### PR TITLE
[flang][AA] Relax TARGET handling in getCallModRef for local variables

### DIFF
--- a/flang/include/flang/Optimizer/Analysis/AliasAnalysis.h
+++ b/flang/include/flang/Optimizer/Analysis/AliasAnalysis.h
@@ -295,6 +295,31 @@ struct AliasAnalysis {
   /// POINTER object or a raw fir::PointerType.
   static bool isPointerReference(mlir::Type ty);
 
+  /// Flow-sensitive escape check: return true if the address of the variable
+  /// declared by `declareOp` (a `fir.declare` / `hlfir.declare`) may have been
+  /// bound to a Fortran POINTER -- or otherwise published into opaque storage
+  /// reachable from a procedure call -- on any path that reaches `op`.
+  ///
+  /// The walk is intra-procedural and "best effort": uses textually after
+  /// `op`'s outermost ancestor in the same block are skipped (they cannot run
+  /// before `op`); any use elsewhere is treated as if it could run before
+  /// `op`. Recognised user ops:
+  ///   - aliasing views (`[hl]fir.declare`, `hlfir.designate`, `fir.array_coor`,
+  ///     `fir.coordinate_of`, plain-box `fir.embox`) propagate the walk to
+  ///     their results,
+  ///   - `fir.load`, `hlfir.assign`, and `fir.store` of a value at the address
+  ///     are benign,
+  ///   - explicit OpenACC / OpenMP data-clause ops are benign,
+  ///   - `fir.embox` into a `fir.box<fir.ptr<...>>` / `fir.box<fir.heap<...>>`
+  ///     (i.e. a pointer assignment per F2023 10.2.2 / 19.5.2), a store of the
+  ///     address as the stored value, or any other use (including a different
+  ///     `fir.call` taking the address by reference) is treated as a capture.
+  ///
+  /// Returns `true` conservatively when `declareOp` or `op` is null, when `op`
+  /// has no enclosing function, or when an unrecognised use is encountered.
+  static bool mayBeCapturedBefore(mlir::Operation *declareOp,
+                                  mlir::Operation *op);
+
 private:
   /// Return true, if `ty` is a reference type to an object of derived type
   /// that contains a component with POINTER attribute.

--- a/flang/include/flang/Optimizer/Analysis/AliasAnalysis.h
+++ b/flang/include/flang/Optimizer/Analysis/AliasAnalysis.h
@@ -295,28 +295,11 @@ struct AliasAnalysis {
   /// POINTER object or a raw fir::PointerType.
   static bool isPointerReference(mlir::Type ty);
 
-  /// Flow-sensitive escape check: return true if the address of the variable
-  /// declared by `declareOp` (a `fir.declare` / `hlfir.declare`) may have been
-  /// bound to a Fortran POINTER -- or otherwise published into opaque storage
-  /// reachable from a procedure call -- on any path that reaches `op`.
-  ///
-  /// The walk is intra-procedural and "best effort": uses textually after
-  /// `op`'s outermost ancestor in the same block are skipped (they cannot run
-  /// before `op`); any use elsewhere is treated as if it could run before
-  /// `op`. Recognised user ops:
-  ///   - aliasing views (`[hl]fir.declare`, `hlfir.designate`, `fir.array_coor`,
-  ///     `fir.coordinate_of`, plain-box `fir.embox`) propagate the walk to
-  ///     their results,
-  ///   - `fir.load`, `hlfir.assign`, and `fir.store` of a value at the address
-  ///     are benign,
-  ///   - explicit OpenACC / OpenMP data-clause ops are benign,
-  ///   - `fir.embox` into a `fir.box<fir.ptr<...>>` / `fir.box<fir.heap<...>>`
-  ///     (i.e. a pointer assignment per F2023 10.2.2 / 19.5.2), a store of the
-  ///     address as the stored value, or any other use (including a different
-  ///     `fir.call` taking the address by reference) is treated as a capture.
-  ///
-  /// Returns `true` conservatively when `declareOp` or `op` is null, when `op`
-  /// has no enclosing function, or when an unrecognised use is encountered.
+  /// Return true if the address of the variable declared by `declareOp` may
+  /// have been bound to a Fortran POINTER -- or otherwise published into
+  /// opaque storage reachable from a call -- on any path that reaches `op`.
+  /// The walk follows `fir::FortranObjectViewOpInterface` views (same as
+  /// getSource()) and is conservative on unknown uses.
   static bool mayBeCapturedBefore(mlir::Operation *declareOp,
                                   mlir::Operation *op);
 

--- a/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
+++ b/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
@@ -813,6 +813,12 @@ bool AliasAnalysis::mayBeCapturedBefore(mlir::Operation *declareOp,
   auto funcOp = op->getParentOfType<mlir::FunctionOpInterface>();
   if (!funcOp)
     return true;
+  // The same-block "after callAnchor" skip below is unsound when funcOp has
+  // CFG back-edges; gate it on a single-block body.
+  bool topLevelIsAcyclic = false;
+  if (mlir::Region *body = funcOp.getCallableRegion())
+    topLevelIsAcyclic = body->hasOneBlock();
+
   mlir::Operation *callAnchor = op;
   while (callAnchor->getParentOp() && callAnchor->getParentOp() != funcOp)
     callAnchor = callAnchor->getParentOp();
@@ -829,7 +835,7 @@ bool AliasAnalysis::mayBeCapturedBefore(mlir::Operation *declareOp,
       mlir::Operation *userOp = use.getOwner();
       if (userOp == op || userOp == callAnchor)
         continue;
-      if (userOp->getBlock() == callAnchor->getBlock() &&
+      if (topLevelIsAcyclic && userOp->getBlock() == callAnchor->getBlock() &&
           callAnchor->isBeforeInBlock(userOp))
         continue;
       // OpenACC / OpenMP data-clause ops only describe device staging of the

--- a/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
+++ b/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
@@ -807,7 +807,7 @@ static bool isSavedLocal(const fir::AliasAnalysis::Source &src) {
 }
 
 bool AliasAnalysis::mayBeCapturedBefore(mlir::Operation *declareOp,
-                                       mlir::Operation *op) {
+                                        mlir::Operation *op) {
   if (!declareOp || !op)
     return true;
   auto funcOp = op->getParentOfType<mlir::FunctionOpInterface>();
@@ -832,11 +832,32 @@ bool AliasAnalysis::mayBeCapturedBefore(mlir::Operation *declareOp,
       if (userOp->getBlock() == callAnchor->getBlock() &&
           callAnchor->isBeforeInBlock(userOp))
         continue;
-      if (mlir::isa<fir::DeclareOp, hlfir::DeclareOp, hlfir::DesignateOp,
-                    fir::ArrayCoorOp, fir::CoordinateOp>(userOp)) {
-        for (mlir::Value r : userOp->getResults())
+      // OpenACC / OpenMP data-clause ops only describe device staging of the
+      // host variable; they do not bind the host address into Fortran-visible
+      // pointer state.  Check before the generic view-propagation path because
+      // some acc data-clause ops also implement FortranObjectViewOpInterface
+      // (their device-pointer result is not a host address-aliasing view).
+      if (mlir::isa<ACC_DATA_CLAUSE_OPS, mlir::acc::ReductionInitOp,
+                    mlir::omp::MapInfoOp>(userOp))
+        continue;
+      // Address-aliasing view ops (declare, designate, coordinate_of,
+      // array_coor, embox, rebox, box_addr, convert, volatile_cast) implement
+      // fir::FortranObjectViewOpInterface, which is the same abstraction
+      // getSource() uses to walk address-view chains. Propagate to each result
+      // whose view-source operand is the current value -- except an embox into
+      // a POINTER / HEAP descriptor, which materialises a pointer-association
+      // descriptor and counts as a capture.
+      if (auto view =
+              mlir::dyn_cast<fir::FortranObjectViewOpInterface>(userOp)) {
+        for (mlir::OpResult r : userOp->getResults()) {
+          if (view.getViewSource(r) != v)
+            continue;
+          if (auto boxT = mlir::dyn_cast<fir::BoxType>(r.getType()))
+            if (mlir::isa<fir::PointerType, fir::HeapType>(boxT.getEleTy()))
+              return true;
           if (seen.insert(r).second)
             worklist.push_back(r);
+        }
         continue;
       }
       if (mlir::isa<fir::LoadOp, hlfir::AssignOp>(userOp))
@@ -846,20 +867,6 @@ bool AliasAnalysis::mayBeCapturedBefore(mlir::Operation *declareOp,
           return true;
         continue;
       }
-      if (auto embox = mlir::dyn_cast<fir::EmboxOp>(userOp)) {
-        if (auto boxT =
-                mlir::dyn_cast<fir::BoxType>(embox.getResult().getType())) {
-          if (mlir::isa<fir::PointerType, fir::HeapType>(boxT.getEleTy()))
-            return true;
-          for (mlir::Value r : userOp->getResults())
-            if (seen.insert(r).second)
-              worklist.push_back(r);
-          continue;
-        }
-      }
-      if (mlir::isa<ACC_DATA_CLAUSE_OPS, mlir::acc::ReductionInitOp,
-                    mlir::omp::MapInfoOp>(userOp))
-        continue;
       return true;
     }
   }

--- a/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
+++ b/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
@@ -806,6 +806,69 @@ static bool isSavedLocal(const fir::AliasAnalysis::Source &src) {
   return false;
 }
 
+/// Return true if `declareOp`'s address may have been bound to a Fortran
+/// POINTER before `callOp`. Uses textually after the call in the same block
+/// are skipped; anything else is conservative.
+static bool mayBeCapturedByPointer(mlir::Operation *declareOp,
+                                   mlir::Operation *callOp) {
+  if (!declareOp || !callOp)
+    return true;
+  auto funcOp = callOp->getParentOfType<mlir::FunctionOpInterface>();
+  if (!funcOp)
+    return true;
+  mlir::Operation *callAnchor = callOp;
+  while (callAnchor->getParentOp() && callAnchor->getParentOp() != funcOp)
+    callAnchor = callAnchor->getParentOp();
+
+  llvm::SmallVector<mlir::Value, 8> worklist;
+  llvm::SmallPtrSet<mlir::Value, 8> seen;
+  for (mlir::Value res : declareOp->getResults())
+    if (seen.insert(res).second)
+      worklist.push_back(res);
+
+  while (!worklist.empty()) {
+    mlir::Value v = worklist.pop_back_val();
+    for (mlir::OpOperand &use : v.getUses()) {
+      mlir::Operation *userOp = use.getOwner();
+      if (userOp == callOp || userOp == callAnchor)
+        continue;
+      if (userOp->getBlock() == callAnchor->getBlock() &&
+          callAnchor->isBeforeInBlock(userOp))
+        continue;
+      if (mlir::isa<fir::DeclareOp, hlfir::DeclareOp, hlfir::DesignateOp,
+                    fir::ArrayCoorOp, fir::CoordinateOp>(userOp)) {
+        for (mlir::Value r : userOp->getResults())
+          if (seen.insert(r).second)
+            worklist.push_back(r);
+        continue;
+      }
+      if (mlir::isa<fir::LoadOp, hlfir::AssignOp>(userOp))
+        continue;
+      if (auto store = mlir::dyn_cast<fir::StoreOp>(userOp)) {
+        if (store.getValue() == v)
+          return true;
+        continue;
+      }
+      if (auto embox = mlir::dyn_cast<fir::EmboxOp>(userOp)) {
+        if (auto boxT =
+                mlir::dyn_cast<fir::BoxType>(embox.getResult().getType())) {
+          if (mlir::isa<fir::PointerType, fir::HeapType>(boxT.getEleTy()))
+            return true;
+          for (mlir::Value r : userOp->getResults())
+            if (seen.insert(r).second)
+              worklist.push_back(r);
+          continue;
+        }
+      }
+      if (mlir::isa<ACC_DATA_CLAUSE_OPS, mlir::acc::ReductionInitOp,
+                    mlir::omp::MapInfoOp>(userOp))
+        continue;
+      return true;
+    }
+  }
+  return false;
+}
+
 bool AliasAnalysis::isCallToFortranUserProcedure(Operation *op) {
   fir::CallOp call = dyn_cast<fir::CallOp>(op);
   if (!call)
@@ -859,9 +922,15 @@ ModRefResult AliasAnalysis::getCallModRef(Operation *op, Value var) {
   // attribute, which would lead this analysis to believe it cannot escape.
   if (!varSrc.isFortranUserVariable() || !isCallToFortranUserProcedure(call))
     return ModRefResult::getModAndRef();
-  // Pointer and target may have been captured.
-  if (varSrc.isTargetOrPointer())
+  // Pointer or non-local TARGET: may have been bound to a POINTER outside
+  // this procedure. Local TARGET: check for an intraprocedural binding.
+  if (varSrc.isPointer())
     return ModRefResult::getModAndRef();
+  if (varSrc.isTarget()) {
+    if (varSrc.kind != fir::AliasAnalysis::SourceKind::Allocate ||
+        mayBeCapturedByPointer(varSrc.origin.instantiationPoint, call))
+      return ModRefResult::getModAndRef();
+  }
   // Host associated variables may be addressed indirectly via an internal
   // function call, whether the call is in the parent or an internal procedure.
   // Note that the host associated/internal procedure may be referenced

--- a/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
+++ b/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
@@ -806,17 +806,14 @@ static bool isSavedLocal(const fir::AliasAnalysis::Source &src) {
   return false;
 }
 
-/// Return true if `declareOp`'s address may have been bound to a Fortran
-/// POINTER before `callOp`. Uses textually after the call in the same block
-/// are skipped; anything else is conservative.
-static bool mayBeCapturedByPointer(mlir::Operation *declareOp,
-                                   mlir::Operation *callOp) {
-  if (!declareOp || !callOp)
+bool AliasAnalysis::mayBeCapturedBefore(mlir::Operation *declareOp,
+                                       mlir::Operation *op) {
+  if (!declareOp || !op)
     return true;
-  auto funcOp = callOp->getParentOfType<mlir::FunctionOpInterface>();
+  auto funcOp = op->getParentOfType<mlir::FunctionOpInterface>();
   if (!funcOp)
     return true;
-  mlir::Operation *callAnchor = callOp;
+  mlir::Operation *callAnchor = op;
   while (callAnchor->getParentOp() && callAnchor->getParentOp() != funcOp)
     callAnchor = callAnchor->getParentOp();
 
@@ -830,7 +827,7 @@ static bool mayBeCapturedByPointer(mlir::Operation *declareOp,
     mlir::Value v = worklist.pop_back_val();
     for (mlir::OpOperand &use : v.getUses()) {
       mlir::Operation *userOp = use.getOwner();
-      if (userOp == callOp || userOp == callAnchor)
+      if (userOp == op || userOp == callAnchor)
         continue;
       if (userOp->getBlock() == callAnchor->getBlock() &&
           callAnchor->isBeforeInBlock(userOp))
@@ -928,7 +925,7 @@ ModRefResult AliasAnalysis::getCallModRef(Operation *op, Value var) {
     return ModRefResult::getModAndRef();
   if (varSrc.isTarget()) {
     if (varSrc.kind != fir::AliasAnalysis::SourceKind::Allocate ||
-        mayBeCapturedByPointer(varSrc.origin.instantiationPoint, call))
+        mayBeCapturedBefore(varSrc.origin.instantiationPoint, call))
       return ModRefResult::getModAndRef();
   }
   // Host associated variables may be addressed indirectly via an internal

--- a/flang/test/HLFIR/opt-bufferization-eval_in_mem.fir
+++ b/flang/test/HLFIR/opt-bufferization-eval_in_mem.fir
@@ -146,3 +146,34 @@ func.func @_QPnegative_test_target_local_captured_before(
 // CHECK:         %[[TMP:.*]] = fir.alloca !fir.array<10xf32>
 // CHECK:         hlfir.as_expr
 // CHECK:         return
+
+
+// A multi-block (post-CFG) function: the capturing fir.embox is in a later
+// block than `call`. The "use textually after op in the same block" skip rule
+// is unsound here because the cf.br could form a back-edge, so the temporary
+// must be preserved.
+func.func @_QPnegative_test_target_local_multi_block(
+    %arg_ptr: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) {
+  %c10 = arith.constant 10 : index
+  %0 = fir.alloca !fir.array<10xf32> {bindc_name = "x", fir.target, uniq_name = "_QFnegative_test_target_local_multi_blockEx"}
+  %1 = fir.shape %c10 : (index) -> !fir.shape<1>
+  %2:2 = hlfir.declare %0(%1) {fortran_attrs = #fir.var_attrs<target>, uniq_name = "_QFnegative_test_target_local_multi_blockEx"} : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>)
+  %3 = hlfir.eval_in_mem shape %1 : (!fir.shape<1>) -> !hlfir.expr<10xf32> {
+  ^bb0(%arg1: !fir.ref<!fir.array<10xf32>>):
+    %4 = fir.call @_QPfoo() fastmath<contract> : () -> !fir.array<10xf32>
+    fir.save_result %4 to %arg1(%1) : !fir.array<10xf32>, !fir.ref<!fir.array<10xf32>>, !fir.shape<1>
+  }
+  hlfir.assign %3 to %2#0 : !hlfir.expr<10xf32>, !fir.ref<!fir.array<10xf32>>
+  hlfir.destroy %3 : !hlfir.expr<10xf32>
+  cf.br ^bb1
+^bb1:
+  %5 = fir.convert %2#0 : (!fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  %6 = fir.embox %5(%1) : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  fir.store %6 to %arg_ptr : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  return
+}
+// CHECK-LABEL: func.func @_QPnegative_test_target_local_multi_block(
+// CHECK:         fir.alloca !fir.array<10xf32>
+// CHECK:         %[[TMP:.*]] = fir.alloca !fir.array<10xf32>
+// CHECK:         hlfir.as_expr
+// CHECK:         fir.embox

--- a/flang/test/HLFIR/opt-bufferization-eval_in_mem.fir
+++ b/flang/test/HLFIR/opt-bufferization-eval_in_mem.fir
@@ -60,3 +60,89 @@ func.func @_QPnegative_test_is_target(%arg0: !fir.ref<!fir.array<10xf32>> {fir.b
 // CHECK:         hlfir.destroy %[[VAL_10]] : !hlfir.expr<10xf32>
 // CHECK:         return
 // CHECK:       }
+
+
+// A local (Allocate) TARGET variable whose address is not bound to a Fortran
+// POINTER anywhere in the surrounding procedure can be evaluated in place:
+// _QPfoo cannot reach it indirectly, matching classic nvfortran's behaviour
+// for `lhs = func()` with a procedure-local TARGET LHS.
+func.func @_QPpositive_test_target_local_no_capture() {
+  %c10 = arith.constant 10 : index
+  %0 = fir.alloca !fir.array<10xf32> {bindc_name = "x", fir.target, uniq_name = "_QFpositive_test_target_local_no_captureEx"}
+  %1 = fir.shape %c10 : (index) -> !fir.shape<1>
+  %2:2 = hlfir.declare %0(%1) {fortran_attrs = #fir.var_attrs<target>, uniq_name = "_QFpositive_test_target_local_no_captureEx"} : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>)
+  %3 = hlfir.eval_in_mem shape %1 : (!fir.shape<1>) -> !hlfir.expr<10xf32> {
+  ^bb0(%arg1: !fir.ref<!fir.array<10xf32>>):
+    %4 = fir.call @_QPfoo() fastmath<contract> : () -> !fir.array<10xf32>
+    fir.save_result %4 to %arg1(%1) : !fir.array<10xf32>, !fir.ref<!fir.array<10xf32>>, !fir.shape<1>
+  }
+  hlfir.assign %3 to %2#0 : !hlfir.expr<10xf32>, !fir.ref<!fir.array<10xf32>>
+  hlfir.destroy %3 : !hlfir.expr<10xf32>
+  return
+}
+// CHECK-LABEL: func.func @_QPpositive_test_target_local_no_capture(
+// CHECK:         %[[VAL_X:.*]] = fir.alloca !fir.array<10xf32>
+// CHECK:         %[[VAL_DECL:.*]]:2 = hlfir.declare %[[VAL_X]]{{.*}}
+// CHECK:         %[[VAL_CALL:.*]] = fir.call @_QPfoo() fastmath<contract> : () -> !fir.array<10xf32>
+// CHECK:         fir.save_result %[[VAL_CALL]] to %[[VAL_DECL]]#0{{.*}}
+// CHECK-NOT:     hlfir.as_expr
+// CHECK:         return
+
+
+// Mirrors the RRTMGP `col_dry_arr` pattern: a local TARGET LHS bound to a
+// POINTER *after* the call. The pointer binding cannot have been observed by
+// the call, so the temporary can still be elided.
+func.func @_QPpositive_test_target_local_captured_after(
+    %arg_ptr: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) {
+  %c10 = arith.constant 10 : index
+  %0 = fir.alloca !fir.array<10xf32> {bindc_name = "x", fir.target, uniq_name = "_QFpositive_test_target_local_captured_afterEx"}
+  %1 = fir.shape %c10 : (index) -> !fir.shape<1>
+  %2:2 = hlfir.declare %0(%1) {fortran_attrs = #fir.var_attrs<target>, uniq_name = "_QFpositive_test_target_local_captured_afterEx"} : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>)
+  %3 = hlfir.eval_in_mem shape %1 : (!fir.shape<1>) -> !hlfir.expr<10xf32> {
+  ^bb0(%arg1: !fir.ref<!fir.array<10xf32>>):
+    %4 = fir.call @_QPfoo() fastmath<contract> : () -> !fir.array<10xf32>
+    fir.save_result %4 to %arg1(%1) : !fir.array<10xf32>, !fir.ref<!fir.array<10xf32>>, !fir.shape<1>
+  }
+  hlfir.assign %3 to %2#0 : !hlfir.expr<10xf32>, !fir.ref<!fir.array<10xf32>>
+  hlfir.destroy %3 : !hlfir.expr<10xf32>
+  %5 = fir.convert %2#0 : (!fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  %6 = fir.embox %5(%1) : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  fir.store %6 to %arg_ptr : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  return
+}
+// CHECK-LABEL: func.func @_QPpositive_test_target_local_captured_after(
+// CHECK:         %[[VAL_X:.*]] = fir.alloca !fir.array<10xf32>
+// CHECK:         %[[VAL_DECL:.*]]:2 = hlfir.declare %[[VAL_X]]{{.*}}
+// CHECK:         %[[VAL_CALL:.*]] = fir.call @_QPfoo() fastmath<contract> : () -> !fir.array<10xf32>
+// CHECK:         fir.save_result %[[VAL_CALL]] to %[[VAL_DECL]]#0{{.*}}
+// CHECK-NOT:     hlfir.as_expr
+// CHECK:         fir.embox
+// CHECK:         return
+
+
+// A local TARGET variable whose address is bound to a Fortran POINTER *before*
+// the call. The temporary must be preserved because _QPfoo could observe the
+// LHS through that pointer.
+func.func @_QPnegative_test_target_local_captured_before(
+    %arg_ptr: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>) {
+  %c10 = arith.constant 10 : index
+  %0 = fir.alloca !fir.array<10xf32> {bindc_name = "x", fir.target, uniq_name = "_QFnegative_test_target_local_captured_beforeEx"}
+  %1 = fir.shape %c10 : (index) -> !fir.shape<1>
+  %2:2 = hlfir.declare %0(%1) {fortran_attrs = #fir.var_attrs<target>, uniq_name = "_QFnegative_test_target_local_captured_beforeEx"} : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<10xf32>>, !fir.ref<!fir.array<10xf32>>)
+  %5 = fir.convert %2#0 : (!fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<?xf32>>
+  %6 = fir.embox %5(%1) : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+  fir.store %6 to %arg_ptr : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+  %3 = hlfir.eval_in_mem shape %1 : (!fir.shape<1>) -> !hlfir.expr<10xf32> {
+  ^bb0(%arg1: !fir.ref<!fir.array<10xf32>>):
+    %4 = fir.call @_QPfoo() fastmath<contract> : () -> !fir.array<10xf32>
+    fir.save_result %4 to %arg1(%1) : !fir.array<10xf32>, !fir.ref<!fir.array<10xf32>>, !fir.shape<1>
+  }
+  hlfir.assign %3 to %2#0 : !hlfir.expr<10xf32>, !fir.ref<!fir.array<10xf32>>
+  hlfir.destroy %3 : !hlfir.expr<10xf32>
+  return
+}
+// CHECK-LABEL: func.func @_QPnegative_test_target_local_captured_before(
+// CHECK:         fir.alloca !fir.array<10xf32>
+// CHECK:         %[[TMP:.*]] = fir.alloca !fir.array<10xf32>
+// CHECK:         hlfir.as_expr
+// CHECK:         return


### PR DESCRIPTION
Example:
```fortran
program p
  real, target :: arr(8)
  integer :: i
  !$acc enter data create(arr)
  arr = compute()
  !$acc parallel loop present(arr)
  do i = 1, 8
    arr(i) = arr(i) * 2.0
  end do
  !$acc exit data copyout(arr)
  print *, arr  ! expected: 2.0, 4.0, ..., 16.0
contains
  function compute() result(out)
    real :: out(8)
    integer :: j
    !$acc parallel loop copyout(out)
    do j = 1, 8
      out(j) = real(j)
    end do
  end function
end program
```

In this code, `arr` is a procedure-local TARGET whose address is published into the OpenACC device map before `compute()` is called. Inside the procedure, `arr` is not pointer-assigned to any Fortran POINTER and is not passed to another procedure that could bind it to one (F2023 §19.5.2.3 enumerates all events that cause pointer association), so the assignment may write `compute()`'s result directly into `arr`'s storage. `fir::AliasAnalysis::getCallModRef` was conservatively reporting `ModAndRef` for this case, blocking the in-place evaluation.

Fix: in `getCallModRef`, treat a procedure-local TARGET allocation as not mod/ref'd by a Fortran user-procedure call when a flow-sensitive forward walk from its `[hl]fir.declare` (new helper `AliasAnalysis::mayBeCapturedBefore`) sees no pre-call pointer-association event — i.e. no `fir.embox` into a `POINTER`/`HEAP` descriptor (§19.5.2.3 item (2)) and no other unrecognised use. OpenACC / OpenMP data-clause ops are skipped *before* the view-propagation step, since some (e.g. `acc.create`) implement `FortranObjectViewOpInterface` but their device-pointer result is not a host address-aliasing view.