### PR TITLE
[libc][bazel] Add rules for __support/threads tests.

### DIFF
--- a/libc/test/src/__support/threads/linux/raw_mutex_test.cpp
+++ b/libc/test/src/__support/threads/linux/raw_mutex_test.cpp
@@ -10,11 +10,11 @@
 #include "hdr/sys_mman_macros.h"
 #include "include/llvm-libc-macros/linux/time-macros.h"
 #include "src/__support/CPP/atomic.h"
+#include "src/__support/OSUtil/exit.h"
 #include "src/__support/OSUtil/syscall.h"
 #include "src/__support/threads/raw_mutex.h"
 #include "src/__support/threads/sleep.h"
 #include "src/__support/time/clock_gettime.h"
-#include "src/stdlib/exit.h"
 #include "src/sys/mman/mmap.h"
 #include "src/sys/mman/munmap.h"
 #include "test/UnitTest/Test.h"
@@ -79,7 +79,7 @@ TEST(LlvmLibcSupportThreadsRawMutexTest, PSharedLock) {
   shared->finished.fetch_add(1);
   // let the child exit early to avoid output pollution
   if (pid == 0)
-    LIBC_NAMESPACE::exit(0);
+    LIBC_NAMESPACE::internal::exit(0);
   while (shared->finished.load() != 2)
     LIBC_NAMESPACE::sleep_briefly();
   ASSERT_EQ(shared->data, 20000);

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -387,7 +387,6 @@ libc_support_library(
     ],
 )
 
-
 libc_support_library(
     name = "llvm_libc_macros_sys_socket_macros",
     hdrs = [
@@ -571,7 +570,6 @@ libc_support_library(
     name = "hdr_link_macros",
     hdrs = ["hdr/link_macros.h"],
 )
-
 
 ############################ Type Proxy Header Files ###########################
 
@@ -2885,7 +2883,6 @@ libc_support_library(
         ":hdr_errno_macros",
     ],
 )
-
 
 libc_support_library(
     name = "__support_threads_mutex",

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -380,6 +380,15 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "llvm_libc_macros_time_macros",
+    hdrs = [
+        "include/llvm-libc-macros/linux/time-macros.h",
+        "include/llvm-libc-macros/time-macros.h",
+    ],
+)
+
+
+libc_support_library(
     name = "llvm_libc_macros_sys_socket_macros",
     hdrs = [
         "include/llvm-libc-macros/linux/sys-socket-macros.h",
@@ -550,6 +559,19 @@ libc_support_library(
     name = "hdr_sys_auxv_macros",
     hdrs = ["hdr/sys_auxv_macros.h"],
 )
+
+libc_support_library(
+    name = "hdr_elf_proxy",
+    hdrs = ["staging/hdr/elf_proxy.h"],
+    includes = ["staging"],
+    deps = [":hdr_elf_proxy_h"],
+)
+
+libc_support_library(
+    name = "hdr_link_macros",
+    hdrs = ["hdr/link_macros.h"],
+)
+
 
 ############################ Type Proxy Header Files ###########################
 
@@ -2605,6 +2627,7 @@ libc_support_library(
 
 libc_support_library(
     name = "__support_osutil_vdso",
+    srcs = ["src/__support/OSUtil/linux/vdso.cpp"],
     hdrs = [
         "src/__support/OSUtil/linux/vdso.h",
         "src/__support/OSUtil/linux/vdso_sym.h",
@@ -2626,7 +2649,12 @@ libc_support_library(
         ":__support_cpp_string_view",
         ":__support_macros_attributes",
         ":__support_macros_properties_architectures",
+        ":__support_osutil_linux_auxv",
         ":__support_threads_callonce",
+        ":__support_threads_linux_futex_word_type",
+        ":hdr_elf_proxy",
+        ":hdr_link_macros",
+        ":hdr_sys_auxv_macros",
         ":types_clock_t",
         ":types_clockid_t",
         ":types_struct_timespec",
@@ -2836,6 +2864,30 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_threads_raw_rwlock",
+    hdrs = ["src/__support/threads/raw_rwlock.h"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = [
+        ":__support_common",
+        ":__support_cpp_atomic",
+        ":__support_cpp_limits",
+        ":__support_cpp_optional",
+        ":__support_libc_assert",
+        ":__support_macros_attributes",
+        ":__support_macros_config",
+        ":__support_macros_optimization",
+        ":__support_threads_raw_mutex",
+        ":__support_threads_sleep",
+        ":__support_time",
+        ":hdr_errno_macros",
+    ],
+)
+
+
+libc_support_library(
     name = "__support_threads_mutex",
     hdrs = ["src/__support/threads/mutex.h"],
     deps = [
@@ -2896,6 +2948,7 @@ libc_support_library(
 
 libc_support_library(
     name = "__support_time_clock_gettime",
+    srcs = ["src/__support/time/linux/clock_gettime.cpp"],
     hdrs = ["src/__support/time/clock_gettime.h"],
     target_compatible_with = select({
         "@platforms//os:linux": [],
@@ -2904,6 +2957,8 @@ libc_support_library(
     deps = [
         ":__support_common",
         ":__support_error_or",
+        ":__support_macros_config",
+        ":__support_osutil_syscall",
         ":__support_osutil_vdso",
         ":types_clockid_t",
         ":types_struct_timespec",

--- a/utils/bazel/llvm-project-overlay/libc/test/src/__support/threads/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/__support/threads/BUILD.bazel
@@ -1,0 +1,49 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Tests for LLVM libc __support/threads functionality.
+
+load("//libc/test:libc_test_rules.bzl", "libc_test")
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+libc_test(
+    name = "futex_utils_test",
+    srcs = ["futex_utils_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_optional",
+        "//libc:__support_threads_futex_utils",
+        "//libc:hdr_errno_macros",
+    ],
+)
+
+libc_test(
+    name = "raw_mutex_test",
+    srcs = ["linux/raw_mutex_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_atomic",
+        "//libc:__support_osutil_exit",
+        "//libc:__support_osutil_syscall",
+        "//libc:__support_threads_raw_mutex",
+        "//libc:__support_threads_sleep",
+        "//libc:__support_time_clock_gettime",
+        "//libc:hdr_signal_macros",
+        "//libc:hdr_sys_mman_macros",
+        "//libc:llvm_libc_macros_time_macros",
+        "//libc:mmap",
+        "//libc:munmap",
+    ],
+)
+
+libc_test(
+    name = "raw_rwlock_test",
+    srcs = ["linux/raw_rwlock_test.cpp"],
+    deps = [
+        "//libc:__support_threads_raw_rwlock",
+        "//libc:__support_time_clock_gettime",
+        "//libc:hdr_time_macros",
+    ],
+)


### PR DESCRIPTION
* Add Bazel BUILD rules for three `__support/threads` unit tests.
* Fix/expand BUILD rules for the support libraries they depend on (clock_gettime and vdso) that were previously incorrectly missing `.cpp` files with implementations.
* Minor fix to use `internal::exit` in `raw_mutex_test` to avoid adding a dependency on `exit` entrypoint, which doesn't yet exist in Bazel.

Assisted by: Gemini