### PR TITLE
[lit] Replace zip(range(len(x)), x) with enumerate(x) in ProgressBar

### DIFF
--- a/llvm/utils/lit/lit/ProgressBar.py
+++ b/llvm/utils/lit/lit/ProgressBar.py
@@ -147,19 +147,19 @@ class _PosixTerminalController(TerminalController):
         # Colors
         set_fg = self._tigetstr("setf")
         if set_fg:
-            for i, color in zip(range(len(self._COLORS)), self._COLORS):
+            for i, color in enumerate(self._COLORS):
                 setattr(self, color, self._tparm(set_fg, i))
         set_fg_ansi = self._tigetstr("setaf")
         if set_fg_ansi:
-            for i, color in zip(range(len(self._ANSICOLORS)), self._ANSICOLORS):
+            for i, color in enumerate(self._ANSICOLORS):
                 setattr(self, color, self._tparm(set_fg_ansi, i))
         set_bg = self._tigetstr("setb")
         if set_bg:
-            for i, color in zip(range(len(self._COLORS)), self._COLORS):
+            for i, color in enumerate(self._COLORS):
                 setattr(self, "BG_" + color, self._tparm(set_bg, i))
         set_bg_ansi = self._tigetstr("setab")
         if set_bg_ansi:
-            for i, color in zip(range(len(self._ANSICOLORS)), self._ANSICOLORS):
+            for i, color in enumerate(self._ANSICOLORS):
                 setattr(self, "BG_" + color, self._tparm(set_bg_ansi, i))
 
     def _tparm(self, arg, index):


### PR DESCRIPTION
Updated `ProgressBar.py` to replace four instances of `zip(range(len(x)), x)` with `enumerate(x)`. The former is a legacy Python 2 pattern, while `enumerate()` is the modern and efficient Python 3 idiom. This is a clean-up refactor that results in no behavioral changes to the code.

This PR is part of the "GSoC 2026: Improving lit" project.