### PR TITLE
[RISCV][P-ext] Add missing let Inst{31} = 0b0 to RVPPairShift_rr.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -408,6 +408,7 @@ class RVPPairShift_rr<bits<3> f, bits<2> w, string opcodestr,
                   "$rd, $rs1, $rs2", DefVXSAT> {
   bits<5> rs2;
 
+  let Inst{31}    = 0b0;
   let Inst{26-25} = w;
   let Inst{24-20} = rs2;
 }


### PR DESCRIPTION
This bit was accidentally left unset. I think this means we might have treated this bit as a don't care for the disassembler could disassemble some invalid encodings to these instructions. I didn't check the opcode map closely enough to confirm this.