### PR TITLE
[RISCV] Fix build after isLegalVTForZvzipOperand signature change

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -5224,9 +5224,7 @@ static bool isInterleaveShuffle(ArrayRef<int> Mask, MVT VT, int &EvenSrc,
   if (VT.getScalarSizeInBits() >= Subtarget.getELen()) {
     if (!Subtarget.hasVendorXRivosVizip() && !Subtarget.hasStdExtZvzip())
       return false;
-    if (Subtarget.hasStdExtZvzip() &&
-        !isLegalVTForZvzipOperand(VT, Subtarget,
-                                  *Subtarget.getTargetLowering()))
+    if (Subtarget.hasStdExtZvzip() && !isLegalVTForZvzipOperand(VT, Subtarget))
       return false;
   }
 


### PR DESCRIPTION
The call site introduced in #199512 still passed a TargetLowering arg that was removed from the helper by #199629, breaking the build.