### PR TITLE
[mlir][presburger] Avoid redundant zero-initialization in insertColumns

### DIFF
--- a/mlir/lib/Analysis/Presburger/Matrix.cpp
+++ b/mlir/lib/Analysis/Presburger/Matrix.cpp
@@ -160,17 +160,17 @@ void Matrix<T>::insertColumns(unsigned pos, unsigned count) {
   }
   nColumns += count;
 
+  int colStart = nColumns - 1;
+  if (oldNReservedColumns != nReservedColumns)
+    colStart = nReservedColumns - 1;
   for (int ri = nRows - 1; ri >= 0; --ri) {
-    for (int ci = nReservedColumns - 1; ci >= 0; --ci) {
+    for (int ci = colStart; ci >= 0; --ci) {
       unsigned r = ri;
       unsigned c = ci;
       T &dest = data[r * nReservedColumns + c];
       if (c >= nColumns) { // NOLINT
         // Out of bounds columns are zero-initialized. NOLINT because clang-tidy
         // complains about this branch being the same as the c >= pos one.
-        //
-        // TODO: this case can be skipped if the number of reserved columns
-        // didn't change.
         dest = 0;
       } else if (c >= pos + count) {
         // Shift the data occuring after the inserted columns.


### PR DESCRIPTION
When insertColumns does not trigger a physical reallocation, the inner loop needlessly loops up to nReservedColumns - 1. This causes massive redundant zero-writes on trailing columns that are already zero. This patch truncates the inner loop start boundary to nColumns - 1, when the reserved capacity is unchanged, optimizing the non-realloc path from O(nRows * nReservedColumns) to O(nRows * nColumns).