### PR TITLE
[Clang] Fix crash when comparing fixed point type with BitInt

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -559,7 +559,7 @@ Improvements to Coverage Mapping
 Bug Fixes in This Version
 -------------------------
 
-- Fixed a crash when comparing a fixed point type with a ``_BitInt`` type. (#GH196948)
+- Fixed an assertion when comparing a fixed point type with a ``_BitInt`` type. (#GH196948)
 - Fixed atomic boolean compound assignment; the conversion back to atomic bool would be miscompiled. (#GH33210)
 - Correctly handle default template argument when establishing subsumption. (#GH188640)
 - Fixed a failed assertion in the preprocessor when ``__has_embed`` parameters are missing parentheses. (#GH175088)

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -559,6 +559,7 @@ Improvements to Coverage Mapping
 Bug Fixes in This Version
 -------------------------
 
+- Fixed a crash when comparing a fixed point type with a ``_BitInt`` type. (#GH196948)
 - Fixed atomic boolean compound assignment; the conversion back to atomic bool would be miscompiled. (#GH33210)
 - Correctly handle default template argument when establishing subsumption. (#GH188640)
 - Fixed a failed assertion in the preprocessor when ``__has_embed`` parameters are missing parentheses. (#GH175088)

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -1287,7 +1287,6 @@ static QualType handleFloatConversion(Sema &S, ExprResult &LHS,
 /// Helper function of UsualArithmeticConversions().
 static bool unsupportedTypeConversion(const Sema &S, QualType LHSType,
                                       QualType RHSType) {
-
   // No issue if either is not a floating point type.
   if (!LHSType->isFloatingType() || !RHSType->isFloatingType())
     return false;

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -1282,10 +1282,9 @@ static QualType handleFloatConversion(Sema &S, ExprResult &LHS,
                                     /*ConvertInt=*/!IsCompAssign);
 }
 
- /// Returns true if the conversion between LHSType and RHSType is not supported. 
- /// This includes conversions between fixed point types and BitInt types, 
- /// which would otherwise cause an assertion failure later.
- /// Helper function of UsualArithmeticConversions().
+/// Returns true if the conversion between LHSType and RHSType is not supported. 
+/// This includes conversions between fixed point types and BitInt types.
+/// Helper function of UsualArithmeticConversions().
 static bool unsupportedTypeConversion(const Sema &S, QualType LHSType,
                                       QualType RHSType) {
   if ((LHSType->isFixedPointType() && RHSType->isBitIntType()) ||

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -1540,7 +1540,7 @@ static QualType handleFixedPointConversion(Sema &S, QualType LHSTy,
           RHSTy->isFixedPointOrIntegerType()) &&
          "Special fixed point arithmetic operation conversions are only "
          "applied to ints or other fixed point types");
-  
+
   // If one operand has signed fixed-point type and the other operand has
   // unsigned fixed-point type, then the unsigned fixed-point operand is
   // converted to its corresponding signed fixed-point type and the resulting

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -1752,7 +1752,7 @@ QualType Sema::UsualArithmeticConversions(ExprResult &LHS, ExprResult &RHS,
     return Context.getCommonSugaredType(LHSType, RHSType);
 
   // At this point, we have two different arithmetic types.
-  
+
   if ((LHSType->isFixedPointType() && RHSType->isBitIntType()) ||
       (LHSType->isBitIntType() && RHSType->isFixedPointType()))
     return QualType();

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -1282,12 +1282,10 @@ static QualType handleFloatConversion(Sema &S, ExprResult &LHS,
                                     /*ConvertInt=*/!IsCompAssign);
 }
 
-/// Diagnose attempts to convert between __float128, __ibm128 and
-/// long double if there is no support for such conversion.
-/// Helper function of UsualArithmeticConversions().
-/// Returns true if the conversion between LHSType and RHSType is not supported.
-/// This includes conversions between fixed point types and BitInt types,
-/// which would otherwise cause an assertion failure later.
+ /// Returns true if the conversion between LHSType and RHSType is not supported. 
+ /// This includes conversions between fixed point types and BitInt types, 
+ /// which would otherwise cause an assertion failure later.
+ /// Helper function of UsualArithmeticConversions().
 static bool unsupportedTypeConversion(const Sema &S, QualType LHSType,
                                       QualType RHSType) {
   if ((LHSType->isFixedPointType() && RHSType->isBitIntType()) ||

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -1287,9 +1287,6 @@ static QualType handleFloatConversion(Sema &S, ExprResult &LHS,
 /// Helper function of UsualArithmeticConversions().
 static bool unsupportedTypeConversion(const Sema &S, QualType LHSType,
                                       QualType RHSType) {
-  if ((LHSType->isFixedPointType() && RHSType->isBitIntType()) ||
-      (LHSType->isBitIntType() && RHSType->isFixedPointType()))
-    return true;
 
   // No issue if either is not a floating point type.
   if (!LHSType->isFloatingType() || !RHSType->isFloatingType())
@@ -1755,7 +1752,11 @@ QualType Sema::UsualArithmeticConversions(ExprResult &LHS, ExprResult &RHS,
     return Context.getCommonSugaredType(LHSType, RHSType);
 
   // At this point, we have two different arithmetic types.
-
+  
+  if ((LHSType->isFixedPointType() && RHSType->isBitIntType()) ||
+      (LHSType->isBitIntType() && RHSType->isFixedPointType()))
+    return QualType();
+  
   // Diagnose attempts to convert between __ibm128, __float128 and long double
   // where such conversions currently can't be handled.
   if (unsupportedTypeConversion(*this, LHSType, RHSType))

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -1285,6 +1285,9 @@ static QualType handleFloatConversion(Sema &S, ExprResult &LHS,
 /// Diagnose attempts to convert between __float128, __ibm128 and
 /// long double if there is no support for such conversion.
 /// Helper function of UsualArithmeticConversions().
+/// Returns true if the conversion between LHSType and RHSType is not supported.
+/// This includes conversions between fixed point types and BitInt types,
+/// which would otherwise cause an assertion failure later.
 static bool unsupportedTypeConversion(const Sema &S, QualType LHSType,
                                       QualType RHSType) {
   if ((LHSType->isFixedPointType() && RHSType->isBitIntType()) ||

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -1282,8 +1282,8 @@ static QualType handleFloatConversion(Sema &S, ExprResult &LHS,
                                     /*ConvertInt=*/!IsCompAssign);
 }
 
-/// Returns true if the conversion between LHSType and RHSType is not supported. 
-/// This includes conversions between fixed point types and BitInt types.
+/// Diagnose attempts to convert between __float128, __ibm128 and
+/// long double if there is no support for such conversion.
 /// Helper function of UsualArithmeticConversions().
 static bool unsupportedTypeConversion(const Sema &S, QualType LHSType,
                                       QualType RHSType) {

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -1287,6 +1287,10 @@ static QualType handleFloatConversion(Sema &S, ExprResult &LHS,
 /// Helper function of UsualArithmeticConversions().
 static bool unsupportedTypeConversion(const Sema &S, QualType LHSType,
                                       QualType RHSType) {
+  if ((LHSType->isFixedPointType() && RHSType->isBitIntType()) ||
+      (LHSType->isBitIntType() && RHSType->isFixedPointType()))
+    return true;
+
   // No issue if either is not a floating point type.
   if (!LHSType->isFloatingType() || !RHSType->isFloatingType())
     return false;
@@ -1533,7 +1537,6 @@ static QualType handleFixedPointConversion(Sema &S, QualType LHSTy,
           RHSTy->isFixedPointOrIntegerType()) &&
          "Special fixed point arithmetic operation conversions are only "
          "applied to ints or other fixed point types");
-
   // If one operand has signed fixed-point type and the other operand has
   // unsigned fixed-point type, then the unsigned fixed-point operand is
   // converted to its corresponding signed fixed-point type and the resulting

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -1540,6 +1540,7 @@ static QualType handleFixedPointConversion(Sema &S, QualType LHSTy,
           RHSTy->isFixedPointOrIntegerType()) &&
          "Special fixed point arithmetic operation conversions are only "
          "applied to ints or other fixed point types");
+  
   // If one operand has signed fixed-point type and the other operand has
   // unsigned fixed-point type, then the unsigned fixed-point operand is
   // converted to its corresponding signed fixed-point type and the resulting

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -1755,7 +1755,7 @@ QualType Sema::UsualArithmeticConversions(ExprResult &LHS, ExprResult &RHS,
   if ((LHSType->isFixedPointType() && RHSType->isBitIntType()) ||
       (LHSType->isBitIntType() && RHSType->isFixedPointType()))
     return QualType();
-  
+
   // Diagnose attempts to convert between __ibm128, __float128 and long double
   // where such conversions currently can't be handled.
   if (unsupportedTypeConversion(*this, LHSType, RHSType))

--- a/clang/test/Sema/fixed-point-bitint.c
+++ b/clang/test/Sema/fixed-point-bitint.c
@@ -1,0 +1,8 @@
+// RUN: %%clang_cc1 -ffixed-point -fsyntax-only -verify %%s 
+ 
+// Test that comparing fixed point type with BitInt doesn't crash 
+// Fixes issue #196948 
+ 
+constexpr _BitInt(128) i = 42; 
+static_assert(i == 42.0k); 
+// expected-error@-1 {{invalid operands to binary expression}} 

--- a/clang/test/Sema/fixed-point-bitint.c
+++ b/clang/test/Sema/fixed-point-bitint.c
@@ -1,8 +1,5 @@
 // RUN: %%clang_cc1 -ffixed-point -fsyntax-only -verify %%s 
  
-// Test that comparing fixed point type with BitInt doesn't crash 
-// Fixes issue #196948 
- 
 constexpr _BitInt(128) i = 42; 
 static_assert(i == 42.0k); 
 // expected-error@-1 {{invalid operands to binary expression}} 

--- a/clang/test/Sema/fixed-point-bitint.c
+++ b/clang/test/Sema/fixed-point-bitint.c
@@ -1,4 +1,0 @@
-// RUN: %%clang_cc1 -ffixed-point -fsyntax-only -verify %%s 
-
-constexpr _BitInt(128) i = 42; 
-static_assert(i == 42.0k); // expected-error {{invalid operands to binary expression}} 

--- a/clang/test/Sema/fixed-point-bitint.c
+++ b/clang/test/Sema/fixed-point-bitint.c
@@ -1,5 +1,4 @@
 // RUN: %%clang_cc1 -ffixed-point -fsyntax-only -verify %%s 
- 
+
 constexpr _BitInt(128) i = 42; 
-static_assert(i == 42.0k); 
-// expected-error@-1 {{invalid operands to binary expression}} 
+static_assert(i == 42.0k); // expected-error {{invalid operands to binary expression}} 

--- a/clang/test/SemaCXX/ext-int.cpp
+++ b/clang/test/SemaCXX/ext-int.cpp
@@ -319,6 +319,6 @@ void FromPaper2(_BitInt(8) a1, _BitInt(24) a2) {
 
 namespace GH196948{
   constexpr _BitInt(128) i = 42;
-  static_assert(i == 42.0k);// expected-error {{invalid operands to binary expression ('const _Bitint(128)' and '_Accum')}}
+  static_assert(i == 42.0k);// expected-error {{invalid operands to binary expression ('const _Bitint(128)' and '_Accum')}} \
                             // expected-warning {{'static_assert' with no message is a C++17 extension}}
 }

--- a/clang/test/SemaCXX/ext-int.cpp
+++ b/clang/test/SemaCXX/ext-int.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s -Wimplicit-int-conversion -Wno-unused -Wunevaluated-expression -triple aarch64-unknown-unknown
+// RUN: %clang_cc1 -fsyntax-only -ffixed-point -verify %s -Wimplicit-int-conversion -Wno-unused -Wunevaluated-expression -triple aarch64-unknown-unknown
 
 template<int Bounds>
 struct HasExtInt {
@@ -319,6 +319,5 @@ void FromPaper2(_BitInt(8) a1, _BitInt(24) a2) {
 
 namespace GH196948{
   constexpr _BitInt(128) i = 42;
-  static_assert(i == 42.0k);// expected-error {{invalid operands to binary expression ('const _Bitint(128)' and '_Accum')}} \
-                            // expected-warning {{'static_assert' with no message is a C++17 extension}}
+  static_assert(i == 42.0k); // expected-error {{invalid operands to binary expression ('const _BitInt(128)' and '_Accum')}}
 }

--- a/clang/test/SemaCXX/ext-int.cpp
+++ b/clang/test/SemaCXX/ext-int.cpp
@@ -319,5 +319,5 @@ void FromPaper2(_BitInt(8) a1, _BitInt(24) a2) {
 
 namespace GH196948{
   constexpr _BitInt(128) i = 42;
-  static_assert(i == 42.0k);// expected-error {{invalid operands to binary expression}}
+  static_assert(i == 42.0k);// expected-error {{invalid operands to binary expression ('const _Bitint(128)' and '_Accum')}}
 }

--- a/clang/test/SemaCXX/ext-int.cpp
+++ b/clang/test/SemaCXX/ext-int.cpp
@@ -320,4 +320,5 @@ void FromPaper2(_BitInt(8) a1, _BitInt(24) a2) {
 namespace GH196948{
   constexpr _BitInt(128) i = 42;
   static_assert(i == 42.0k);// expected-error {{invalid operands to binary expression ('const _Bitint(128)' and '_Accum')}}
+                            // expected-warning {{'static_assert' with no message is a C++17 extension}}
 }

--- a/clang/test/SemaCXX/ext-int.cpp
+++ b/clang/test/SemaCXX/ext-int.cpp
@@ -316,3 +316,8 @@ void FromPaper1() {
 void FromPaper2(_BitInt(8) a1, _BitInt(24) a2) {
   static_assert(__is_same(decltype(a1 * (_BitInt(32))a2), _BitInt(32)), "");
 }
+
+namespace GH196948{
+  constexpr _BitInt(128) i = 42;
+  static_assert(i == 42.0k);
+}

--- a/clang/test/SemaCXX/ext-int.cpp
+++ b/clang/test/SemaCXX/ext-int.cpp
@@ -319,5 +319,5 @@ void FromPaper2(_BitInt(8) a1, _BitInt(24) a2) {
 
 namespace GH196948{
   constexpr _BitInt(128) i = 42;
-  static_assert(i == 42.0k);
+  static_assert(i == 42.0k);// expected-error {{invalid operands to binary expression}}
 }


### PR DESCRIPTION
Fixes #196948

Added checks in `handleFixedPointConversion`: reject fixed point/BitInt comparisons

Now clang properly emits an error instead of crashing.