### PR TITLE
llvm: Fix most LLVM_C_ABI annotations

### DIFF
--- a/llvm/include/llvm-c/Remarks.h
+++ b/llvm/include/llvm-c/Remarks.h
@@ -343,7 +343,7 @@ LLVM_C_ABI extern void LLVMRemarkParserDispose(LLVMRemarkParserRef Parser);
  *
  * \since REMARKS_API_VERSION=0
  */
-extern uint32_t LLVMRemarkVersion(void);
+LLVM_C_ABI extern uint32_t LLVMRemarkVersion(void);
 
 /**
  * @} // endgoup LLVMCREMARKS

--- a/llvm/include/llvm-c/lto.h
+++ b/llvm/include/llvm-c/lto.h
@@ -17,6 +17,7 @@
 #define LLVM_C_LTO_H
 
 #include "llvm-c/ExternC.h"
+#include "llvm-c/Visibility.h"
 
 #ifdef __cplusplus
 #include <cstddef>
@@ -107,33 +108,30 @@ LLVM_C_EXTERN_C_BEGIN
  *
  * \since prior to LTO_API_VERSION=3
  */
-extern const char*
-lto_get_version(void);
+LLVM_C_ABI extern const char *lto_get_version(void);
 
 /**
  * Returns the last error string or NULL if last operation was successful.
  *
  * \since prior to LTO_API_VERSION=3
  */
-extern const char*
-lto_get_error_message(void);
+LLVM_C_ABI extern const char *lto_get_error_message(void);
 
 /**
  * Checks if a file is a loadable object file.
  *
  * \since prior to LTO_API_VERSION=3
  */
-extern lto_bool_t
-lto_module_is_object_file(const char* path);
+LLVM_C_ABI extern lto_bool_t lto_module_is_object_file(const char *path);
 
 /**
  * Checks if a file is a loadable object compiled for requested target.
  *
  * \since prior to LTO_API_VERSION=3
  */
-extern lto_bool_t
-lto_module_is_object_file_for_target(const char* path,
-                                     const char* target_triple_prefix);
+LLVM_C_ABI extern lto_bool_t
+lto_module_is_object_file_for_target(const char *path,
+                                     const char *target_triple_prefix);
 
 /**
  * Return true if \p Buffer contains a bitcode file with ObjC code (category
@@ -141,25 +139,24 @@ lto_module_is_object_file_for_target(const char* path,
  *
  * \since LTO_API_VERSION=20
  */
-extern lto_bool_t
-lto_module_has_objc_category(const void *mem, size_t length);
+LLVM_C_ABI extern lto_bool_t lto_module_has_objc_category(const void *mem,
+                                                          size_t length);
 
 /**
  * Checks if a buffer is a loadable object file.
  *
  * \since prior to LTO_API_VERSION=3
  */
-extern lto_bool_t lto_module_is_object_file_in_memory(const void *mem,
-                                                      size_t length);
+LLVM_C_ABI extern lto_bool_t
+lto_module_is_object_file_in_memory(const void *mem, size_t length);
 
 /**
  * Checks if a buffer is a loadable object compiled for requested target.
  *
  * \since prior to LTO_API_VERSION=3
  */
-extern lto_bool_t
-lto_module_is_object_file_in_memory_for_target(const void* mem, size_t length,
-                                              const char* target_triple_prefix);
+LLVM_C_ABI extern lto_bool_t lto_module_is_object_file_in_memory_for_target(
+    const void *mem, size_t length, const char *target_triple_prefix);
 
 /**
  * Loads an object file from disk.
@@ -167,8 +164,7 @@ lto_module_is_object_file_in_memory_for_target(const void* mem, size_t length,
  *
  * \since prior to LTO_API_VERSION=3
  */
-extern lto_module_t
-lto_module_create(const char* path);
+LLVM_C_ABI extern lto_module_t lto_module_create(const char *path);
 
 /**
  * Loads an object file from memory.
@@ -176,8 +172,8 @@ lto_module_create(const char* path);
  *
  * \since prior to LTO_API_VERSION=3
  */
-extern lto_module_t
-lto_module_create_from_memory(const void* mem, size_t length);
+LLVM_C_ABI extern lto_module_t lto_module_create_from_memory(const void *mem,
+                                                             size_t length);
 
 /**
  * Loads an object file from memory with an extra path argument.
@@ -185,8 +181,8 @@ lto_module_create_from_memory(const void* mem, size_t length);
  *
  * \since LTO_API_VERSION=9
  */
-extern lto_module_t
-lto_module_create_from_memory_with_path(const void* mem, size_t length,
+LLVM_C_ABI extern lto_module_t
+lto_module_create_from_memory_with_path(const void *mem, size_t length,
                                         const char *path);
 
 /**
@@ -200,7 +196,7 @@ lto_module_create_from_memory_with_path(const void* mem, size_t length,
  *
  * \since LTO_API_VERSION=11
  */
-extern lto_module_t
+LLVM_C_ABI extern lto_module_t
 lto_module_create_in_local_context(const void *mem, size_t length,
                                    const char *path);
 
@@ -214,7 +210,7 @@ lto_module_create_in_local_context(const void *mem, size_t length,
  *
  * \since LTO_API_VERSION=11
  */
-extern lto_module_t
+LLVM_C_ABI extern lto_module_t
 lto_module_create_in_codegen_context(const void *mem, size_t length,
                                      const char *path, lto_code_gen_t cg);
 
@@ -224,7 +220,7 @@ lto_module_create_in_codegen_context(const void *mem, size_t length,
  *
  * \since LTO_API_VERSION=5
  */
-extern lto_module_t
+LLVM_C_ABI extern lto_module_t
 lto_module_create_from_fd(int fd, const char *path, size_t file_size);
 
 /**
@@ -233,7 +229,7 @@ lto_module_create_from_fd(int fd, const char *path, size_t file_size);
  *
  * \since LTO_API_VERSION=5
  */
-extern lto_module_t
+LLVM_C_ABI extern lto_module_t
 lto_module_create_from_fd_at_offset(int fd, const char *path, size_t file_size,
                                     size_t map_size, off_t offset);
 
@@ -243,47 +239,44 @@ lto_module_create_from_fd_at_offset(int fd, const char *path, size_t file_size,
  *
  * \since prior to LTO_API_VERSION=3
  */
-extern void
-lto_module_dispose(lto_module_t mod);
+LLVM_C_ABI extern void lto_module_dispose(lto_module_t mod);
 
 /**
  * Returns triple string which the object module was compiled under.
  *
  * \since prior to LTO_API_VERSION=3
  */
-extern const char*
-lto_module_get_target_triple(lto_module_t mod);
+LLVM_C_ABI extern const char *lto_module_get_target_triple(lto_module_t mod);
 
 /**
  * Sets triple string with which the object will be codegened.
  *
  * \since LTO_API_VERSION=4
  */
-extern void
-lto_module_set_target_triple(lto_module_t mod, const char *triple);
+LLVM_C_ABI extern void lto_module_set_target_triple(lto_module_t mod,
+                                                    const char *triple);
 
 /**
  * Returns the number of symbols in the object module.
  *
  * \since prior to LTO_API_VERSION=3
  */
-extern unsigned int
-lto_module_get_num_symbols(lto_module_t mod);
+LLVM_C_ABI extern unsigned int lto_module_get_num_symbols(lto_module_t mod);
 
 /**
  * Returns the name of the ith symbol in the object module.
  *
  * \since prior to LTO_API_VERSION=3
  */
-extern const char*
-lto_module_get_symbol_name(lto_module_t mod, unsigned int index);
+LLVM_C_ABI extern const char *lto_module_get_symbol_name(lto_module_t mod,
+                                                         unsigned int index);
 
 /**
  * Returns the attributes of the ith symbol in the object module.
  *
  * \since prior to LTO_API_VERSION=3
  */
-extern lto_symbol_attributes
+LLVM_C_ABI extern lto_symbol_attributes
 lto_module_get_symbol_attribute(lto_module_t mod, unsigned int index);
 
 /**
@@ -291,15 +284,16 @@ lto_module_get_symbol_attribute(lto_module_t mod, unsigned int index);
  *
  * \since prior to LTO_API_VERSION=30
  */
-extern unsigned int lto_module_get_num_asm_undef_symbols(lto_module_t mod);
+LLVM_C_ABI extern unsigned int
+lto_module_get_num_asm_undef_symbols(lto_module_t mod);
 
 /**
  * Returns the name of the ith asm undefined symbol in the object module.
  *
  * \since prior to LTO_API_VERSION=30
  */
-extern const char *lto_module_get_asm_undef_symbol_name(lto_module_t mod,
-                                                        unsigned int index);
+LLVM_C_ABI extern const char *
+lto_module_get_asm_undef_symbol_name(lto_module_t mod, unsigned int index);
 
 /**
  * Returns the module's linker options.
@@ -309,8 +303,7 @@ extern const char *lto_module_get_asm_undef_symbol_name(lto_module_t mod,
  *
  * \since LTO_API_VERSION=16
  */
-extern const char*
-lto_module_get_linkeropts(lto_module_t mod);
+LLVM_C_ABI extern const char *lto_module_get_linkeropts(lto_module_t mod);
 
 /**
  * If targeting mach-o on darwin, this function gets the CPU type and subtype
@@ -323,9 +316,9 @@ lto_module_get_linkeropts(lto_module_t mod);
  *
  * \since LTO_API_VERSION=27
  */
-extern lto_bool_t lto_module_get_macho_cputype(lto_module_t mod,
-                                               unsigned int *out_cputype,
-                                               unsigned int *out_cpusubtype);
+LLVM_C_ABI extern lto_bool_t
+lto_module_get_macho_cputype(lto_module_t mod, unsigned int *out_cputype,
+                             unsigned int *out_cpusubtype);
 
 /**
  * This function can be used by the linker to check if a given module has
@@ -336,7 +329,7 @@ extern lto_bool_t lto_module_get_macho_cputype(lto_module_t mod,
  *
  * \since LTO_API_VERSION=29
  */
-extern lto_bool_t lto_module_has_ctor_dtor(lto_module_t mod);
+LLVM_C_ABI extern lto_bool_t lto_module_has_ctor_dtor(lto_module_t mod);
 /**
  * Diagnostic severity.
  *
@@ -368,9 +361,9 @@ typedef void (*lto_diagnostic_handler_t)(
  *
  * \since LTO_API_VERSION=7
  */
-extern void lto_codegen_set_diagnostic_handler(lto_code_gen_t,
-                                               lto_diagnostic_handler_t,
-                                               void *);
+LLVM_C_ABI extern void
+lto_codegen_set_diagnostic_handler(lto_code_gen_t, lto_diagnostic_handler_t,
+                                   void *);
 
 /**
  * Instantiates a code generator.
@@ -381,8 +374,7 @@ extern void lto_codegen_set_diagnostic_handler(lto_code_gen_t,
  *
  * \since prior to LTO_API_VERSION=3
  */
-extern lto_code_gen_t
-lto_codegen_create(void);
+LLVM_C_ABI extern lto_code_gen_t lto_codegen_create(void);
 
 /**
  * Instantiate a code generator in its own context.
@@ -393,8 +385,7 @@ lto_codegen_create(void);
  *
  * \since LTO_API_VERSION=11
  */
-extern lto_code_gen_t
-lto_codegen_create_in_local_context(void);
+LLVM_C_ABI extern lto_code_gen_t lto_codegen_create_in_local_context(void);
 
 /**
  * Frees all code generator and all memory it internally allocated.
@@ -402,8 +393,7 @@ lto_codegen_create_in_local_context(void);
  *
  * \since prior to LTO_API_VERSION=3
  */
-extern void
-lto_codegen_dispose(lto_code_gen_t);
+LLVM_C_ABI extern void lto_codegen_dispose(lto_code_gen_t);
 
 /**
  * Add an object module to the set of modules for which code will be generated.
@@ -415,8 +405,8 @@ lto_codegen_dispose(lto_code_gen_t);
  *
  * \since prior to LTO_API_VERSION=3
  */
-extern lto_bool_t
-lto_codegen_add_module(lto_code_gen_t cg, lto_module_t mod);
+LLVM_C_ABI extern lto_bool_t lto_codegen_add_module(lto_code_gen_t cg,
+                                                    lto_module_t mod);
 
 /**
  * Sets the object module for code generation. This will transfer the ownership
@@ -426,8 +416,8 @@ lto_codegen_add_module(lto_code_gen_t cg, lto_module_t mod);
  *
  * \since LTO_API_VERSION=13
  */
-extern void
-lto_codegen_set_module(lto_code_gen_t cg, lto_module_t mod);
+LLVM_C_ABI extern void lto_codegen_set_module(lto_code_gen_t cg,
+                                              lto_module_t mod);
 
 /**
  * Sets if debug info should be generated.
@@ -435,8 +425,8 @@ lto_codegen_set_module(lto_code_gen_t cg, lto_module_t mod);
  *
  * \since prior to LTO_API_VERSION=3
  */
-extern lto_bool_t
-lto_codegen_set_debug_model(lto_code_gen_t cg, lto_debug_model);
+LLVM_C_ABI extern lto_bool_t lto_codegen_set_debug_model(lto_code_gen_t cg,
+                                                         lto_debug_model);
 
 /**
  * Sets which PIC code model to generated.
@@ -444,16 +434,15 @@ lto_codegen_set_debug_model(lto_code_gen_t cg, lto_debug_model);
  *
  * \since prior to LTO_API_VERSION=3
  */
-extern lto_bool_t
-lto_codegen_set_pic_model(lto_code_gen_t cg, lto_codegen_model);
+LLVM_C_ABI extern lto_bool_t lto_codegen_set_pic_model(lto_code_gen_t cg,
+                                                       lto_codegen_model);
 
 /**
  * Sets the cpu to generate code for.
  *
  * \since LTO_API_VERSION=4
  */
-extern void
-lto_codegen_set_cpu(lto_code_gen_t cg, const char *cpu);
+LLVM_C_ABI extern void lto_codegen_set_cpu(lto_code_gen_t cg, const char *cpu);
 
 /**
  * Sets the location of the assembler tool to run. If not set, libLTO
@@ -461,17 +450,16 @@ lto_codegen_set_cpu(lto_code_gen_t cg, const char *cpu);
  *
  * \since LTO_API_VERSION=3
  */
-extern void
-lto_codegen_set_assembler_path(lto_code_gen_t cg, const char* path);
+LLVM_C_ABI extern void lto_codegen_set_assembler_path(lto_code_gen_t cg,
+                                                      const char *path);
 
 /**
  * Sets extra arguments that libLTO should pass to the assembler.
  *
  * \since LTO_API_VERSION=4
  */
-extern void
-lto_codegen_set_assembler_args(lto_code_gen_t cg, const char **args,
-                               int nargs);
+LLVM_C_ABI extern void
+lto_codegen_set_assembler_args(lto_code_gen_t cg, const char **args, int nargs);
 
 /**
  * Adds to a list of all global symbols that must exist in the final generated
@@ -480,8 +468,8 @@ lto_codegen_set_assembler_args(lto_code_gen_t cg, const char **args,
  *
  * \since prior to LTO_API_VERSION=3
  */
-extern void
-lto_codegen_add_must_preserve_symbol(lto_code_gen_t cg, const char* symbol);
+LLVM_C_ABI extern void lto_codegen_add_must_preserve_symbol(lto_code_gen_t cg,
+                                                            const char *symbol);
 
 /**
  * Writes a new object file at the specified path that contains the
@@ -490,8 +478,8 @@ lto_codegen_add_must_preserve_symbol(lto_code_gen_t cg, const char* symbol);
  *
  * \since LTO_API_VERSION=5
  */
-extern lto_bool_t
-lto_codegen_write_merged_modules(lto_code_gen_t cg, const char* path);
+LLVM_C_ABI extern lto_bool_t lto_codegen_write_merged_modules(lto_code_gen_t cg,
+                                                              const char *path);
 
 /**
  * Generates code for all added modules into one native object file.
@@ -505,8 +493,8 @@ lto_codegen_write_merged_modules(lto_code_gen_t cg, const char* path);
  *
  * \since prior to LTO_API_VERSION=3
  */
-extern const void*
-lto_codegen_compile(lto_code_gen_t cg, size_t* length);
+LLVM_C_ABI extern const void *lto_codegen_compile(lto_code_gen_t cg,
+                                                  size_t *length);
 
 /**
  * Generates code for all added modules into one native object file.
@@ -517,16 +505,15 @@ lto_codegen_compile(lto_code_gen_t cg, size_t* length);
  *
  * \since LTO_API_VERSION=5
  */
-extern lto_bool_t
-lto_codegen_compile_to_file(lto_code_gen_t cg, const char** name);
+LLVM_C_ABI extern lto_bool_t lto_codegen_compile_to_file(lto_code_gen_t cg,
+                                                         const char **name);
 
 /**
  * Runs optimization for the merged module. Returns true on error.
  *
  * \since LTO_API_VERSION=12
  */
-extern lto_bool_t
-lto_codegen_optimize(lto_code_gen_t cg);
+LLVM_C_ABI extern lto_bool_t lto_codegen_optimize(lto_code_gen_t cg);
 
 /**
  * Generates code for the optimized merged module into one native object file.
@@ -540,16 +527,15 @@ lto_codegen_optimize(lto_code_gen_t cg);
  *
  * \since LTO_API_VERSION=12
  */
-extern const void*
-lto_codegen_compile_optimized(lto_code_gen_t cg, size_t* length);
+LLVM_C_ABI extern const void *lto_codegen_compile_optimized(lto_code_gen_t cg,
+                                                            size_t *length);
 
 /**
  * Returns the runtime API version.
  *
  * \since LTO_API_VERSION=12
  */
-extern unsigned int
-lto_api_version(void);
+LLVM_C_ABI extern unsigned int lto_api_version(void);
 
 /**
  * Parses options immediately, making them available as early as possible. For
@@ -563,7 +549,8 @@ lto_api_version(void);
  *
  * \since LTO_API_VERSION=28
  */
-extern void lto_set_debug_options(const char *const *options, int number);
+LLVM_C_ABI extern void lto_set_debug_options(const char *const *options,
+                                             int number);
 
 /**
  * Sets options to help debug codegen bugs. Since parsing shud only happen once,
@@ -576,8 +563,8 @@ extern void lto_set_debug_options(const char *const *options, int number);
  *
  * \since prior to LTO_API_VERSION=3
  */
-extern void
-lto_codegen_debug_options(lto_code_gen_t cg, const char *);
+LLVM_C_ABI extern void lto_codegen_debug_options(lto_code_gen_t cg,
+                                                 const char *);
 
 /**
  * Same as the previous function, but takes every option separately through an
@@ -585,8 +572,9 @@ lto_codegen_debug_options(lto_code_gen_t cg, const char *);
  *
  * \since prior to LTO_API_VERSION=26
  */
-extern void lto_codegen_debug_options_array(lto_code_gen_t cg,
-                                            const char *const *, int number);
+LLVM_C_ABI extern void lto_codegen_debug_options_array(lto_code_gen_t cg,
+                                                       const char *const *,
+                                                       int number);
 
 /**
  * Initializes LLVM disassemblers.
@@ -594,8 +582,7 @@ extern void lto_codegen_debug_options_array(lto_code_gen_t cg,
  *
  * \since LTO_API_VERSION=5
  */
-extern void
-lto_initialize_disassembler(void);
+LLVM_C_ABI extern void lto_initialize_disassembler(void);
 
 /**
  * Sets if we should run internalize pass during optimization and code
@@ -603,7 +590,7 @@ lto_initialize_disassembler(void);
  *
  * \since LTO_API_VERSION=14
  */
-extern void
+LLVM_C_ABI extern void
 lto_codegen_set_should_internalize(lto_code_gen_t cg,
                                    lto_bool_t ShouldInternalize);
 
@@ -615,7 +602,7 @@ lto_codegen_set_should_internalize(lto_code_gen_t cg,
  *
  * \since LTO_API_VERSION=15
  */
-extern void
+LLVM_C_ABI extern void
 lto_codegen_set_should_embed_uselists(lto_code_gen_t cg,
                                       lto_bool_t ShouldEmbedUselists);
 
@@ -630,9 +617,8 @@ typedef struct LLVMOpaqueLTOInput *lto_input_t;
   *
   * \since LTO_API_VERSION=24
   */
-extern lto_input_t lto_input_create(const void *buffer,
-                                    size_t buffer_size,
-                                    const char *path);
+LLVM_C_ABI extern lto_input_t
+lto_input_create(const void *buffer, size_t buffer_size, const char *path);
 
 /**
   * Frees all memory internally allocated by the LTO input file.
@@ -640,7 +626,7 @@ extern lto_input_t lto_input_create(const void *buffer,
   *
   * \since LTO_API_VERSION=24
   */
-extern void lto_input_dispose(lto_input_t input);
+LLVM_C_ABI extern void lto_input_dispose(lto_input_t input);
 
 /**
   * Returns the number of dependent library specifiers
@@ -648,7 +634,8 @@ extern void lto_input_dispose(lto_input_t input);
   *
   * \since LTO_API_VERSION=24
   */
-extern unsigned lto_input_get_num_dependent_libraries(lto_input_t input);
+LLVM_C_ABI extern unsigned
+lto_input_get_num_dependent_libraries(lto_input_t input);
 
 /**
   * Returns the ith dependent library specifier
@@ -657,9 +644,8 @@ extern unsigned lto_input_get_num_dependent_libraries(lto_input_t input);
   *
   * \since LTO_API_VERSION=24
   */
-extern const char * lto_input_get_dependent_library(lto_input_t input,
-                                                    size_t index,
-                                                    size_t *size);
+LLVM_C_ABI extern const char *
+lto_input_get_dependent_library(lto_input_t input, size_t index, size_t *size);
 
 /**
  * Returns the list of libcall symbols that can be generated by LTO
@@ -667,7 +653,7 @@ extern const char * lto_input_get_dependent_library(lto_input_t input,
  *
  * \since prior to LTO_API_VERSION=25
  */
-extern const char *const *lto_runtime_lib_symbols_list(size_t *size);
+LLVM_C_ABI extern const char *const *lto_runtime_lib_symbols_list(size_t *size);
 
 /**
  * @} // endgoup LLVMCLTO
@@ -699,7 +685,7 @@ typedef struct {
  *
  * \since LTO_API_VERSION=18
  */
-extern thinlto_code_gen_t thinlto_create_codegen(void);
+LLVM_C_ABI extern thinlto_code_gen_t thinlto_create_codegen(void);
 
 /**
  * Frees the generator and all memory it internally allocated.
@@ -707,7 +693,7 @@ extern thinlto_code_gen_t thinlto_create_codegen(void);
  *
  * \since LTO_API_VERSION=18
  */
-extern void thinlto_codegen_dispose(thinlto_code_gen_t cg);
+LLVM_C_ABI extern void thinlto_codegen_dispose(thinlto_code_gen_t cg);
 
 /**
  * Add a module to a ThinLTO code generator. Identifier has to be unique among
@@ -720,9 +706,9 @@ extern void thinlto_codegen_dispose(thinlto_code_gen_t cg);
  *
  * \since LTO_API_VERSION=18
  */
-extern void thinlto_codegen_add_module(thinlto_code_gen_t cg,
-                                       const char *identifier, const char *data,
-                                       int length);
+LLVM_C_ABI extern void thinlto_codegen_add_module(thinlto_code_gen_t cg,
+                                                  const char *identifier,
+                                                  const char *data, int length);
 
 /**
  * Optimize and codegen all the modules added to the codegenerator using
@@ -730,7 +716,7 @@ extern void thinlto_codegen_add_module(thinlto_code_gen_t cg,
  *
  * \since LTO_API_VERSION=18
  */
-extern void thinlto_codegen_process(thinlto_code_gen_t cg);
+LLVM_C_ABI extern void thinlto_codegen_process(thinlto_code_gen_t cg);
 
 /**
  * Returns the number of object files produced by the ThinLTO CodeGenerator.
@@ -741,7 +727,8 @@ extern void thinlto_codegen_process(thinlto_code_gen_t cg);
  *
  * \since LTO_API_VERSION=18
  */
-extern unsigned int thinlto_module_get_num_objects(thinlto_code_gen_t cg);
+LLVM_C_ABI extern unsigned int
+thinlto_module_get_num_objects(thinlto_code_gen_t cg);
 
 /**
  * Returns a reference to the ith object file produced by the ThinLTO
@@ -752,8 +739,8 @@ extern unsigned int thinlto_module_get_num_objects(thinlto_code_gen_t cg);
  *
  * \since LTO_API_VERSION=18
  */
-extern LTOObjectBuffer thinlto_module_get_object(thinlto_code_gen_t cg,
-                                                 unsigned int index);
+LLVM_C_ABI extern LTOObjectBuffer
+thinlto_module_get_object(thinlto_code_gen_t cg, unsigned int index);
 
 /**
  * Returns the number of object files produced by the ThinLTO CodeGenerator.
@@ -764,7 +751,8 @@ extern LTOObjectBuffer thinlto_module_get_object(thinlto_code_gen_t cg,
  *
  * \since LTO_API_VERSION=21
  */
-unsigned int thinlto_module_get_num_object_files(thinlto_code_gen_t cg);
+LLVM_C_ABI unsigned int
+thinlto_module_get_num_object_files(thinlto_code_gen_t cg);
 
 /**
  * Returns the path to the ith object file produced by the ThinLTO
@@ -775,8 +763,8 @@ unsigned int thinlto_module_get_num_object_files(thinlto_code_gen_t cg);
  *
  * \since LTO_API_VERSION=21
  */
-const char *thinlto_module_get_object_file(thinlto_code_gen_t cg,
-                                           unsigned int index);
+LLVM_C_ABI const char *thinlto_module_get_object_file(thinlto_code_gen_t cg,
+                                                      unsigned int index);
 
 /**
  * Sets which PIC code model to generate.
@@ -784,8 +772,8 @@ const char *thinlto_module_get_object_file(thinlto_code_gen_t cg,
  *
  * \since LTO_API_VERSION=18
  */
-extern lto_bool_t thinlto_codegen_set_pic_model(thinlto_code_gen_t cg,
-                                                lto_codegen_model);
+LLVM_C_ABI extern lto_bool_t
+thinlto_codegen_set_pic_model(thinlto_code_gen_t cg, lto_codegen_model);
 
 /**
  * Sets the path to a directory to use as a storage for temporary bitcode files.
@@ -794,8 +782,9 @@ extern lto_bool_t thinlto_codegen_set_pic_model(thinlto_code_gen_t cg,
  *
  * \since LTO_API_VERSION=18
  */
-extern void thinlto_codegen_set_savetemps_dir(thinlto_code_gen_t cg,
-                                              const char *save_temps_dir);
+LLVM_C_ABI extern void
+thinlto_codegen_set_savetemps_dir(thinlto_code_gen_t cg,
+                                  const char *save_temps_dir);
 
 /**
  * Set the path to a directory where to save generated object files. This
@@ -805,15 +794,16 @@ extern void thinlto_codegen_set_savetemps_dir(thinlto_code_gen_t cg,
  *
  * \since LTO_API_VERSION=21
  */
-void thinlto_set_generated_objects_dir(thinlto_code_gen_t cg,
-                                       const char *save_temps_dir);
+LLVM_C_ABI void thinlto_set_generated_objects_dir(thinlto_code_gen_t cg,
+                                                  const char *save_temps_dir);
 
 /**
  * Sets the cpu to generate code for.
  *
  * \since LTO_API_VERSION=18
  */
-extern void thinlto_codegen_set_cpu(thinlto_code_gen_t cg, const char *cpu);
+LLVM_C_ABI extern void thinlto_codegen_set_cpu(thinlto_code_gen_t cg,
+                                               const char *cpu);
 
 /**
  * Disable CodeGen, only run the stages till codegen and stop. The output will
@@ -821,30 +811,32 @@ extern void thinlto_codegen_set_cpu(thinlto_code_gen_t cg, const char *cpu);
  *
  * \since LTO_API_VERSION=19
  */
-extern void thinlto_codegen_disable_codegen(thinlto_code_gen_t cg,
-                                            lto_bool_t disable);
+LLVM_C_ABI extern void thinlto_codegen_disable_codegen(thinlto_code_gen_t cg,
+                                                       lto_bool_t disable);
 
 /**
  * Perform CodeGen only: disable all other stages.
  *
  * \since LTO_API_VERSION=19
  */
-extern void thinlto_codegen_set_codegen_only(thinlto_code_gen_t cg,
-                                             lto_bool_t codegen_only);
+LLVM_C_ABI extern void
+thinlto_codegen_set_codegen_only(thinlto_code_gen_t cg,
+                                 lto_bool_t codegen_only);
 
 /**
  * Parse -mllvm style debug options.
  *
  * \since LTO_API_VERSION=18
  */
-extern void thinlto_debug_options(const char *const *options, int number);
+LLVM_C_ABI extern void thinlto_debug_options(const char *const *options,
+                                             int number);
 
 /**
  * Test if a module has support for ThinLTO linking.
  *
  * \since LTO_API_VERSION=18
  */
-extern lto_bool_t lto_module_is_thinlto(lto_module_t mod);
+LLVM_C_ABI extern lto_bool_t lto_module_is_thinlto(lto_module_t mod);
 
 /**
  * Adds a symbol to the list of global symbols that must exist in the final
@@ -854,9 +846,9 @@ extern lto_bool_t lto_module_is_thinlto(lto_module_t mod);
  *
  * \since LTO_API_VERSION=18
  */
-extern void thinlto_codegen_add_must_preserve_symbol(thinlto_code_gen_t cg,
-                                                     const char *name,
-                                                     int length);
+LLVM_C_ABI extern void
+thinlto_codegen_add_must_preserve_symbol(thinlto_code_gen_t cg,
+                                         const char *name, int length);
 
 /**
  * Adds a symbol to the list of global symbols that are cross-referenced between
@@ -866,9 +858,9 @@ extern void thinlto_codegen_add_must_preserve_symbol(thinlto_code_gen_t cg,
  *
  * \since LTO_API_VERSION=18
  */
-extern void thinlto_codegen_add_cross_referenced_symbol(thinlto_code_gen_t cg,
-                                                        const char *name,
-                                                        int length);
+LLVM_C_ABI extern void
+thinlto_codegen_add_cross_referenced_symbol(thinlto_code_gen_t cg,
+                                            const char *name, int length);
 
 /**
  * @} // endgoup LLVMCTLTO
@@ -897,8 +889,8 @@ extern void thinlto_codegen_add_cross_referenced_symbol(thinlto_code_gen_t cg,
  *
  * \since LTO_API_VERSION=18
  */
-extern void thinlto_codegen_set_cache_dir(thinlto_code_gen_t cg,
-                                          const char *cache_dir);
+LLVM_C_ABI extern void thinlto_codegen_set_cache_dir(thinlto_code_gen_t cg,
+                                                     const char *cache_dir);
 
 /**
  * Sets the cache pruning interval (in seconds). A negative value disables the
@@ -907,8 +899,8 @@ extern void thinlto_codegen_set_cache_dir(thinlto_code_gen_t cg,
  *
  * \since LTO_API_VERSION=18
  */
-extern void thinlto_codegen_set_cache_pruning_interval(thinlto_code_gen_t cg,
-                                                       int interval);
+LLVM_C_ABI extern void
+thinlto_codegen_set_cache_pruning_interval(thinlto_code_gen_t cg, int interval);
 
 /**
  * Sets the maximum cache size that can be persistent across build, in terms of
@@ -923,7 +915,8 @@ extern void thinlto_codegen_set_cache_pruning_interval(thinlto_code_gen_t cg,
  *
  * \since LTO_API_VERSION=18
  */
-extern void thinlto_codegen_set_final_cache_size_relative_to_available_space(
+LLVM_C_ABI extern void
+thinlto_codegen_set_final_cache_size_relative_to_available_space(
     thinlto_code_gen_t cg, unsigned percentage);
 
 /**
@@ -932,8 +925,9 @@ extern void thinlto_codegen_set_final_cache_size_relative_to_available_space(
  *
  * \since LTO_API_VERSION=18
  */
-extern void thinlto_codegen_set_cache_entry_expiration(thinlto_code_gen_t cg,
-                                                       unsigned expiration);
+LLVM_C_ABI extern void
+thinlto_codegen_set_cache_entry_expiration(thinlto_code_gen_t cg,
+                                           unsigned expiration);
 
 /**
  * Sets the maximum size of the cache directory (in bytes). A value over the
@@ -943,8 +937,9 @@ extern void thinlto_codegen_set_cache_entry_expiration(thinlto_code_gen_t cg,
  *
  * \since LTO_API_VERSION=22
  */
-extern void thinlto_codegen_set_cache_size_bytes(thinlto_code_gen_t cg,
-                                                 unsigned max_size_bytes);
+LLVM_C_ABI extern void
+thinlto_codegen_set_cache_size_bytes(thinlto_code_gen_t cg,
+                                     unsigned max_size_bytes);
 
 /**
  * Same as thinlto_codegen_set_cache_size_bytes, except the maximum size is in
@@ -952,7 +947,7 @@ extern void thinlto_codegen_set_cache_size_bytes(thinlto_code_gen_t cg,
  *
  * \since LTO_API_VERSION=23
  */
-extern void
+LLVM_C_ABI extern void
 thinlto_codegen_set_cache_size_megabytes(thinlto_code_gen_t cg,
                                          unsigned max_size_megabytes);
 
@@ -962,8 +957,9 @@ thinlto_codegen_set_cache_size_megabytes(thinlto_code_gen_t cg,
  *
  * \since LTO_API_VERSION=22
  */
-extern void thinlto_codegen_set_cache_size_files(thinlto_code_gen_t cg,
-                                                 unsigned max_size_files);
+LLVM_C_ABI extern void
+thinlto_codegen_set_cache_size_files(thinlto_code_gen_t cg,
+                                     unsigned max_size_files);
 
 /**
  * @} // endgroup LLVMCTLTO_CACHING


### PR DESCRIPTION
This updates most LLVM_C_ABI annotations in the llvm-c headers to match expected usage:
* All public APIs should be properly annotated.
* Inlined functions should not be annotated.

These changes were done by a script fixing annotations on LLVM public headers and manually checked.

This effort is tracked in #109483.