### PR TITLE
[libc++] Simplify the implementation of conditional a bit

### DIFF
--- a/libcxx/include/__type_traits/conditional.h
+++ b/libcxx/include/__type_traits/conditional.h
@@ -35,20 +35,10 @@ struct _IfImpl<false> {
 template <bool _Cond, class _IfRes, class _ElseRes>
 using _If _LIBCPP_NODEBUG = typename _IfImpl<_Cond>::template _Select<_IfRes, _ElseRes>;
 
-template <bool _Bp, class _If, class _Then>
+template <bool _Bp, class _IfRes, class _ElseRes>
 struct _LIBCPP_NO_SPECIALIZATIONS conditional {
-  using type _LIBCPP_NODEBUG = _If;
+  using type _LIBCPP_NODEBUG = _If<_Bp, _IfRes, _ElseRes>;
 };
-
-_LIBCPP_DIAGNOSTIC_PUSH
-#if __has_warning("-Winvalid-specialization")
-_LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Winvalid-specialization")
-#endif
-template <class _If, class _Then>
-struct conditional<false, _If, _Then> {
-  using type _LIBCPP_NODEBUG = _Then;
-};
-_LIBCPP_DIAGNOSTIC_POP
 
 #if _LIBCPP_STD_VER >= 14
 template <bool _Bp, class _IfRes, class _ElseRes>


### PR DESCRIPTION
We can use our internal `_If` instead of specializing `conditional` for selecting the appropriate type.
