### PR TITLE
[RISCV][P-ext] Split v4i16/v8i8 INSERT/EXTRACT_VECTOR_ELT on RV32.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -640,6 +640,8 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
       setOperationAction(ISD::SPLAT_VECTOR, P64VecVTs, Legal);
       setOperationAction(ISD::BUILD_VECTOR, MVT::v2i32, Legal);
       setOperationAction(ISD::EXTRACT_VECTOR_ELT, MVT::v2i32, Legal);
+      setOperationAction({ISD::EXTRACT_VECTOR_ELT, ISD::INSERT_VECTOR_ELT},
+                         {MVT::v4i16, MVT::v8i8}, Custom);
       setOperationAction(ISD::CONCAT_VECTORS, {MVT::v4i16, MVT::v8i8}, Legal);
       setOperationAction(ISD::EXTRACT_SUBVECTOR, {MVT::v2i16, MVT::v4i8},
                          Legal);
@@ -10998,6 +11000,22 @@ SDValue RISCVTargetLowering::lowerINSERT_VECTOR_ELT(SDValue Op,
     unsigned IdxVal = IdxC->getZExtValue();
     unsigned NumElts = VecVT.getVectorNumElements();
     MVT EltVT = VecVT.getVectorElementType();
+
+    if (!Subtarget.is64Bit() && (VecVT == MVT::v4i16 || VecVT == MVT::v8i8)) {
+      unsigned HalfNumElts = NumElts / 2;
+      auto [Lo, Hi] = DAG.SplitVector(Vec, DL);
+      MVT HalfVT = Lo.getSimpleValueType();
+      if (IdxVal < HalfNumElts) {
+        SDValue NewLo =
+            DAG.getNode(ISD::INSERT_VECTOR_ELT, DL, HalfVT, Lo, Val, Idx);
+        return DAG.getNode(ISD::CONCAT_VECTORS, DL, VecVT, NewLo, Hi);
+      }
+      SDValue NewHi =
+          DAG.getNode(ISD::INSERT_VECTOR_ELT, DL, HalfVT, Hi, Val,
+                      DAG.getVectorIdxConstant(IdxVal - HalfNumElts, DL));
+      return DAG.getNode(ISD::CONCAT_VECTORS, DL, VecVT, Lo, NewHi);
+    }
+
     Vec = DAG.getBitcast(XLenVT, Vec);
     SDValue ExtVal = DAG.getNode(ISD::ANY_EXTEND, DL, XLenVT, Val);
 
@@ -11268,6 +11286,20 @@ SDValue RISCVTargetLowering::lowerEXTRACT_VECTOR_ELT(SDValue Op,
     if (VecVT != MVT::v4i16 && VecVT != MVT::v2i16 && VecVT != MVT::v8i8 &&
         VecVT != MVT::v4i8 && VecVT != MVT::v2i32)
       return SDValue();
+
+    if (!Subtarget.is64Bit() && (VecVT == MVT::v4i16 || VecVT == MVT::v8i8)) {
+      auto *IdxC = dyn_cast<ConstantSDNode>(Idx);
+      if (!IdxC)
+        return SDValue();
+      unsigned IdxVal = IdxC->getZExtValue();
+      unsigned HalfNumElts = VecVT.getVectorNumElements() / 2;
+      auto [Lo, Hi] = DAG.SplitVector(Vec, DL);
+      if (IdxVal < HalfNumElts)
+        return DAG.getNode(ISD::EXTRACT_VECTOR_ELT, DL, EltVT, Lo, Idx);
+      return DAG.getNode(ISD::EXTRACT_VECTOR_ELT, DL, EltVT, Hi,
+                         DAG.getVectorIdxConstant(IdxVal - HalfNumElts, DL));
+    }
+
     SDValue Extracted = DAG.getBitcast(XLenVT, Vec);
     unsigned ElemWidth = VecVT.getVectorElementType().getSizeInBits();
     SDValue Shamt = DAG.getNode(ISD::MUL, DL, XLenVT, Idx,

--- a/llvm/test/CodeGen/RISCV/rvp-narrowing-shift-trunc.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-narrowing-shift-trunc.ll
@@ -52,19 +52,11 @@ define i32 @trunc_ashr_v2i32_to_v2i16(i64 %a.coerce) {
 define i32 @trunc_lshr_v4i16_to_v4i8(i64 %a.coerce) {
 ; CHECK-RV32-LABEL: trunc_lshr_v4i16_to_v4i8:
 ; CHECK-RV32:       # %bb.0:
-; CHECK-RV32-NEXT:    addi sp, sp, -16
-; CHECK-RV32-NEXT:    .cfi_def_cfa_offset 16
 ; CHECK-RV32-NEXT:    psrli.dh a0, a0, 4
-; CHECK-RV32-NEXT:    sw a0, 8(sp)
-; CHECK-RV32-NEXT:    sw a1, 12(sp)
-; CHECK-RV32-NEXT:    lh a1, 12(sp)
-; CHECK-RV32-NEXT:    lh a3, 14(sp)
-; CHECK-RV32-NEXT:    lh a0, 8(sp)
-; CHECK-RV32-NEXT:    lh a2, 10(sp)
+; CHECK-RV32-NEXT:    srli a3, a1, 16
+; CHECK-RV32-NEXT:    srli a2, a0, 16
 ; CHECK-RV32-NEXT:    ppaire.db a0, a0, a2
 ; CHECK-RV32-NEXT:    pack a0, a0, a1
-; CHECK-RV32-NEXT:    addi sp, sp, 16
-; CHECK-RV32-NEXT:    .cfi_def_cfa_offset 0
 ; CHECK-RV32-NEXT:    ret
 ;
 ; CHECK-RV64-LABEL: trunc_lshr_v4i16_to_v4i8:

--- a/llvm/test/CodeGen/RISCV/rvp-simd-64.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-simd-64.ll
@@ -1021,37 +1021,17 @@ define <2 x i32> @test_allones_v2i32() {
 }
 
 define i16 @test_extract_vector_16(<4 x i16> %a) {
-; RV32-LABEL: test_extract_vector_16:
-; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -16
-; RV32-NEXT:    .cfi_def_cfa_offset 16
-; RV32-NEXT:    sw a0, 8(sp)
-; RV32-NEXT:    lh a0, 8(sp)
-; RV32-NEXT:    addi sp, sp, 16
-; RV32-NEXT:    .cfi_def_cfa_offset 0
-; RV32-NEXT:    ret
-;
-; RV64-LABEL: test_extract_vector_16:
-; RV64:       # %bb.0:
-; RV64-NEXT:    ret
+; CHECK-LABEL: test_extract_vector_16:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    ret
   %extracted = extractelement <4 x i16> %a, i32 0
   ret i16 %extracted
 }
 
 define i8 @test_extract_vector_8(<8 x i8> %a) {
-; RV32-LABEL: test_extract_vector_8:
-; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -16
-; RV32-NEXT:    .cfi_def_cfa_offset 16
-; RV32-NEXT:    sw a0, 8(sp)
-; RV32-NEXT:    lbu a0, 8(sp)
-; RV32-NEXT:    addi sp, sp, 16
-; RV32-NEXT:    .cfi_def_cfa_offset 0
-; RV32-NEXT:    ret
-;
-; RV64-LABEL: test_extract_vector_8:
-; RV64:       # %bb.0:
-; RV64-NEXT:    ret
+; CHECK-LABEL: test_extract_vector_8:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    ret
   %extracted = extractelement <8 x i8> %a, i32 0
   ret i8 %extracted
 }
@@ -1081,23 +1061,8 @@ define i32 @test_extract_vector_32_elem1(<2 x i32> %a) {
 define <4 x i16> @test_insert_vector_16(<4 x i16> %a, i16 %val) {
 ; RV32-LABEL: test_insert_vector_16:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -32
-; RV32-NEXT:    .cfi_def_cfa_offset 32
-; RV32-NEXT:    sh a2, 24(sp)
-; RV32-NEXT:    sw a0, 8(sp)
-; RV32-NEXT:    sw a1, 12(sp)
-; RV32-NEXT:    lw a0, 24(sp)
-; RV32-NEXT:    sw a0, 0(sp)
-; RV32-NEXT:    lw a0, 12(sp)
-; RV32-NEXT:    sw a0, 20(sp)
-; RV32-NEXT:    lh a0, 10(sp)
-; RV32-NEXT:    sh a0, 18(sp)
-; RV32-NEXT:    lh a0, 0(sp)
-; RV32-NEXT:    sh a0, 16(sp)
-; RV32-NEXT:    lw a0, 16(sp)
-; RV32-NEXT:    lw a1, 20(sp)
-; RV32-NEXT:    addi sp, sp, 32
-; RV32-NEXT:    .cfi_def_cfa_offset 0
+; RV32-NEXT:    srli a0, a0, 16
+; RV32-NEXT:    pack a0, a2, a0
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: test_insert_vector_16:
@@ -1113,25 +1078,8 @@ define <4 x i16> @test_insert_vector_16(<4 x i16> %a, i16 %val) {
 define <4 x i16> @test_insert_vector_16_elem2(<4 x i16> %a, i16 %val) {
 ; RV32-LABEL: test_insert_vector_16_elem2:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -32
-; RV32-NEXT:    .cfi_def_cfa_offset 32
-; RV32-NEXT:    sh a2, 24(sp)
-; RV32-NEXT:    sw a1, 12(sp)
-; RV32-NEXT:    lw a1, 24(sp)
-; RV32-NEXT:    sw a1, 0(sp)
-; RV32-NEXT:    lh a1, 14(sp)
-; RV32-NEXT:    sw a0, 8(sp)
-; RV32-NEXT:    sh a1, 22(sp)
-; RV32-NEXT:    lh a0, 0(sp)
-; RV32-NEXT:    sh a0, 20(sp)
-; RV32-NEXT:    lh a0, 10(sp)
-; RV32-NEXT:    sh a0, 18(sp)
-; RV32-NEXT:    lh a0, 8(sp)
-; RV32-NEXT:    sh a0, 16(sp)
-; RV32-NEXT:    lw a0, 16(sp)
-; RV32-NEXT:    lw a1, 20(sp)
-; RV32-NEXT:    addi sp, sp, 32
-; RV32-NEXT:    .cfi_def_cfa_offset 0
+; RV32-NEXT:    srli a1, a1, 16
+; RV32-NEXT:    pack a1, a2, a1
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: test_insert_vector_16_elem2:
@@ -1148,25 +1096,8 @@ define <4 x i16> @test_insert_vector_16_elem2(<4 x i16> %a, i16 %val) {
 define <8 x i8> @test_insert_vector_8(<8 x i8> %a, i8 %val) {
 ; RV32-LABEL: test_insert_vector_8:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -32
-; RV32-NEXT:    .cfi_def_cfa_offset 32
-; RV32-NEXT:    sb a2, 24(sp)
-; RV32-NEXT:    sw a0, 8(sp)
-; RV32-NEXT:    sw a1, 12(sp)
-; RV32-NEXT:    lw a0, 24(sp)
-; RV32-NEXT:    sw a0, 0(sp)
-; RV32-NEXT:    lw a0, 12(sp)
-; RV32-NEXT:    sw a0, 20(sp)
-; RV32-NEXT:    lh a0, 10(sp)
-; RV32-NEXT:    sh a0, 18(sp)
-; RV32-NEXT:    lbu a0, 9(sp)
-; RV32-NEXT:    sb a0, 17(sp)
-; RV32-NEXT:    lbu a0, 0(sp)
-; RV32-NEXT:    sb a0, 16(sp)
-; RV32-NEXT:    lw a0, 16(sp)
-; RV32-NEXT:    lw a1, 20(sp)
-; RV32-NEXT:    addi sp, sp, 32
-; RV32-NEXT:    .cfi_def_cfa_offset 0
+; RV32-NEXT:    li a3, 255
+; RV32-NEXT:    mvm a0, a2, a3
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: test_insert_vector_8:
@@ -1181,27 +1112,9 @@ define <8 x i8> @test_insert_vector_8(<8 x i8> %a, i8 %val) {
 define <8 x i8> @test_insert_vector_8_elem3(<8 x i8> %a, i8 %val) {
 ; RV32-LABEL: test_insert_vector_8_elem3:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -32
-; RV32-NEXT:    .cfi_def_cfa_offset 32
-; RV32-NEXT:    sb a2, 24(sp)
-; RV32-NEXT:    sw a1, 12(sp)
-; RV32-NEXT:    lw a1, 24(sp)
-; RV32-NEXT:    sw a1, 0(sp)
-; RV32-NEXT:    lw a1, 12(sp)
-; RV32-NEXT:    sw a0, 8(sp)
-; RV32-NEXT:    sw a1, 20(sp)
-; RV32-NEXT:    lbu a0, 0(sp)
-; RV32-NEXT:    sb a0, 19(sp)
-; RV32-NEXT:    lbu a0, 10(sp)
-; RV32-NEXT:    sb a0, 18(sp)
-; RV32-NEXT:    lbu a0, 9(sp)
-; RV32-NEXT:    sb a0, 17(sp)
-; RV32-NEXT:    lbu a0, 8(sp)
-; RV32-NEXT:    sb a0, 16(sp)
-; RV32-NEXT:    lw a0, 16(sp)
-; RV32-NEXT:    lw a1, 20(sp)
-; RV32-NEXT:    addi sp, sp, 32
-; RV32-NEXT:    .cfi_def_cfa_offset 0
+; RV32-NEXT:    slli a2, a2, 24
+; RV32-NEXT:    lui a3, 1044480
+; RV32-NEXT:    mvm a0, a2, a3
 ; RV32-NEXT:    ret
 ;
 ; RV64-LABEL: test_insert_vector_8_elem3:
@@ -1844,52 +1757,44 @@ define <2 x i32> @test_pssla_ws(<2 x i32> %a, i32 %shamt) {
 define <4 x i16> @test_pssla_h(<4 x i16> %a, <4 x i16> %b) {
 ; RV32-LABEL: test_pssla_h:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -32
-; RV32-NEXT:    .cfi_def_cfa_offset 32
-; RV32-NEXT:    sw a3, 20(sp)
-; RV32-NEXT:    sw a1, 12(sp)
-; RV32-NEXT:    sw a2, 16(sp)
-; RV32-NEXT:    sw a0, 8(sp)
-; RV32-NEXT:    lhu a2, 22(sp)
-; RV32-NEXT:    lh a3, 14(sp)
-; RV32-NEXT:    sll a3, a3, a2
-; RV32-NEXT:    sext.h a4, a3
-; RV32-NEXT:    sra a2, a4, a2
-; RV32-NEXT:    sh a2, 30(sp)
-; RV32-NEXT:    lhu a2, 20(sp)
-; RV32-NEXT:    lh a4, 12(sp)
-; RV32-NEXT:    sll a4, a4, a2
-; RV32-NEXT:    sext.h a5, a4
-; RV32-NEXT:    sra a2, a5, a2
-; RV32-NEXT:    sh a2, 28(sp)
-; RV32-NEXT:    lhu a2, 18(sp)
-; RV32-NEXT:    lh a5, 10(sp)
-; RV32-NEXT:    sll a5, a5, a2
-; RV32-NEXT:    sext.h a6, a5
-; RV32-NEXT:    sra a2, a6, a2
-; RV32-NEXT:    sh a2, 26(sp)
-; RV32-NEXT:    lhu a2, 16(sp)
-; RV32-NEXT:    lh a6, 8(sp)
-; RV32-NEXT:    sll a6, a6, a2
-; RV32-NEXT:    sext.h a7, a6
-; RV32-NEXT:    sra a2, a7, a2
-; RV32-NEXT:    lw t2, 28(sp)
-; RV32-NEXT:    sh a2, 24(sp)
-; RV32-NEXT:    lw t1, 24(sp)
-; RV32-NEXT:    lui a7, 8
-; RV32-NEXT:    pack a4, a4, a3
-; RV32-NEXT:    plui.h t0, -512
-; RV32-NEXT:    pmseq.dh a2, a0, t1
+; RV32-NEXT:    addi sp, sp, -16
+; RV32-NEXT:    .cfi_def_cfa_offset 16
+; RV32-NEXT:    srli a4, a3, 16
+; RV32-NEXT:    srli a5, a2, 16
+; RV32-NEXT:    sll a6, a1, a3
+; RV32-NEXT:    srli a7, a1, 16
+; RV32-NEXT:    sll t0, a0, a2
+; RV32-NEXT:    srli t1, a0, 16
+; RV32-NEXT:    sext.h t2, a6
+; RV32-NEXT:    sll a7, a7, a4
+; RV32-NEXT:    sra a3, t2, a3
+; RV32-NEXT:    sext.h t2, t0
+; RV32-NEXT:    sll t1, t1, a5
+; RV32-NEXT:    sra a2, t2, a2
+; RV32-NEXT:    sext.h t2, a7
+; RV32-NEXT:    sra a4, t2, a4
+; RV32-NEXT:    sext.h t2, t1
+; RV32-NEXT:    sra a5, t2, a5
+; RV32-NEXT:    sh a2, 8(sp)
+; RV32-NEXT:    sh a5, 10(sp)
+; RV32-NEXT:    sh a3, 12(sp)
+; RV32-NEXT:    sh a4, 14(sp)
+; RV32-NEXT:    lw a3, 12(sp)
+; RV32-NEXT:    lw a2, 8(sp)
+; RV32-NEXT:    lui a4, 8
+; RV32-NEXT:    pack a5, a6, a7
+; RV32-NEXT:    plui.h a6, -512
+; RV32-NEXT:    pmseq.dh a2, a0, a2
 ; RV32-NEXT:    pmsltz.dh a0, a0
-; RV32-NEXT:    addi a7, a7, -1
-; RV32-NEXT:    pmv.hs a7, a7
-; RV32-NEXT:    merge a1, a7, t0
-; RV32-NEXT:    pack a5, a6, a5
-; RV32-NEXT:    merge a3, a1, a4
-; RV32-NEXT:    merge a0, a7, t0
-; RV32-NEXT:    merge a2, a0, a5
+; RV32-NEXT:    addi a4, a4, -1
+; RV32-NEXT:    pmv.hs a4, a4
+; RV32-NEXT:    merge a1, a4, a6
+; RV32-NEXT:    pack a7, t0, t1
+; RV32-NEXT:    merge a3, a1, a5
+; RV32-NEXT:    merge a0, a4, a6
+; RV32-NEXT:    merge a2, a0, a7
 ; RV32-NEXT:    padd.dw a0, a2, zero
-; RV32-NEXT:    addi sp, sp, 32
+; RV32-NEXT:    addi sp, sp, 16
 ; RV32-NEXT:    .cfi_def_cfa_offset 0
 ; RV32-NEXT:    ret
 ;
@@ -2719,31 +2624,27 @@ define <2 x i32> @test_pmul_w(<2 x i32> %a, <2 x i32> %b) {
 define <4 x i16> @test_psdiv_h(<4 x i16> %a, <4 x i16> %b) {
 ; RV32-LABEL: test_psdiv_h:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -32
-; RV32-NEXT:    .cfi_def_cfa_offset 32
-; RV32-NEXT:    sw a3, 20(sp)
-; RV32-NEXT:    sw a1, 12(sp)
-; RV32-NEXT:    sw a2, 16(sp)
-; RV32-NEXT:    sw a0, 8(sp)
-; RV32-NEXT:    lh a0, 22(sp)
-; RV32-NEXT:    lh a1, 14(sp)
-; RV32-NEXT:    div a0, a1, a0
-; RV32-NEXT:    sh a0, 30(sp)
-; RV32-NEXT:    lh a0, 20(sp)
-; RV32-NEXT:    lh a1, 12(sp)
-; RV32-NEXT:    div a0, a1, a0
-; RV32-NEXT:    sh a0, 28(sp)
-; RV32-NEXT:    lh a0, 18(sp)
-; RV32-NEXT:    lh a1, 10(sp)
-; RV32-NEXT:    div a0, a1, a0
-; RV32-NEXT:    sh a0, 26(sp)
-; RV32-NEXT:    lh a0, 16(sp)
-; RV32-NEXT:    lh a1, 8(sp)
-; RV32-NEXT:    div a0, a1, a0
-; RV32-NEXT:    sh a0, 24(sp)
-; RV32-NEXT:    lw a0, 24(sp)
-; RV32-NEXT:    lw a1, 28(sp)
-; RV32-NEXT:    addi sp, sp, 32
+; RV32-NEXT:    addi sp, sp, -16
+; RV32-NEXT:    .cfi_def_cfa_offset 16
+; RV32-NEXT:    srai a4, a2, 16
+; RV32-NEXT:    srai a5, a0, 16
+; RV32-NEXT:    div a4, a5, a4
+; RV32-NEXT:    srai a5, a3, 16
+; RV32-NEXT:    sext.h a2, a2
+; RV32-NEXT:    sext.h a0, a0
+; RV32-NEXT:    div a0, a0, a2
+; RV32-NEXT:    srai a2, a1, 16
+; RV32-NEXT:    sext.h a3, a3
+; RV32-NEXT:    sext.h a1, a1
+; RV32-NEXT:    div a1, a1, a3
+; RV32-NEXT:    div a2, a2, a5
+; RV32-NEXT:    sh a0, 8(sp)
+; RV32-NEXT:    sh a4, 10(sp)
+; RV32-NEXT:    sh a1, 12(sp)
+; RV32-NEXT:    sh a2, 14(sp)
+; RV32-NEXT:    lw a0, 8(sp)
+; RV32-NEXT:    lw a1, 12(sp)
+; RV32-NEXT:    addi sp, sp, 16
 ; RV32-NEXT:    .cfi_def_cfa_offset 0
 ; RV32-NEXT:    ret
 ;
@@ -2776,47 +2677,51 @@ define <4 x i16> @test_psdiv_h(<4 x i16> %a, <4 x i16> %b) {
 define <8 x i8> @test_psdiv_b(<8 x i8> %a, <8 x i8> %b) {
 ; RV32-LABEL: test_psdiv_b:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -32
-; RV32-NEXT:    .cfi_def_cfa_offset 32
-; RV32-NEXT:    sw a3, 20(sp)
-; RV32-NEXT:    sw a1, 12(sp)
-; RV32-NEXT:    sw a2, 16(sp)
-; RV32-NEXT:    sw a0, 8(sp)
-; RV32-NEXT:    lb a0, 23(sp)
-; RV32-NEXT:    lb a1, 15(sp)
-; RV32-NEXT:    div a0, a1, a0
-; RV32-NEXT:    sb a0, 31(sp)
-; RV32-NEXT:    lb a0, 22(sp)
-; RV32-NEXT:    lb a1, 14(sp)
-; RV32-NEXT:    div a0, a1, a0
-; RV32-NEXT:    sb a0, 30(sp)
-; RV32-NEXT:    lb a0, 21(sp)
-; RV32-NEXT:    lb a1, 13(sp)
-; RV32-NEXT:    div a0, a1, a0
-; RV32-NEXT:    sb a0, 29(sp)
-; RV32-NEXT:    lb a0, 20(sp)
-; RV32-NEXT:    lb a1, 12(sp)
-; RV32-NEXT:    div a0, a1, a0
-; RV32-NEXT:    sb a0, 28(sp)
-; RV32-NEXT:    lb a0, 19(sp)
-; RV32-NEXT:    lb a1, 11(sp)
-; RV32-NEXT:    div a0, a1, a0
-; RV32-NEXT:    sb a0, 27(sp)
-; RV32-NEXT:    lb a0, 18(sp)
-; RV32-NEXT:    lb a1, 10(sp)
-; RV32-NEXT:    div a0, a1, a0
-; RV32-NEXT:    sb a0, 26(sp)
-; RV32-NEXT:    lb a0, 17(sp)
-; RV32-NEXT:    lb a1, 9(sp)
-; RV32-NEXT:    div a0, a1, a0
-; RV32-NEXT:    sb a0, 25(sp)
-; RV32-NEXT:    lb a0, 16(sp)
-; RV32-NEXT:    lb a1, 8(sp)
-; RV32-NEXT:    div a0, a1, a0
-; RV32-NEXT:    sb a0, 24(sp)
-; RV32-NEXT:    lw a0, 24(sp)
-; RV32-NEXT:    lw a1, 28(sp)
-; RV32-NEXT:    addi sp, sp, 32
+; RV32-NEXT:    addi sp, sp, -16
+; RV32-NEXT:    .cfi_def_cfa_offset 16
+; RV32-NEXT:    srai a4, a3, 24
+; RV32-NEXT:    srai a5, a1, 24
+; RV32-NEXT:    sext.b a6, a3
+; RV32-NEXT:    sext.b a7, a1
+; RV32-NEXT:    slli t0, a3, 8
+; RV32-NEXT:    slli t1, a1, 8
+; RV32-NEXT:    slli a3, a3, 16
+; RV32-NEXT:    slli a1, a1, 16
+; RV32-NEXT:    div a4, a5, a4
+; RV32-NEXT:    sext.b a5, a2
+; RV32-NEXT:    div a6, a7, a6
+; RV32-NEXT:    sext.b a7, a0
+; RV32-NEXT:    div a5, a7, a5
+; RV32-NEXT:    slli a7, a2, 8
+; RV32-NEXT:    srai t0, t0, 24
+; RV32-NEXT:    srai t1, t1, 24
+; RV32-NEXT:    div t0, t1, t0
+; RV32-NEXT:    slli t1, a0, 8
+; RV32-NEXT:    srai a3, a3, 24
+; RV32-NEXT:    srai a1, a1, 24
+; RV32-NEXT:    div a1, a1, a3
+; RV32-NEXT:    slli a3, a2, 16
+; RV32-NEXT:    srai a7, a7, 24
+; RV32-NEXT:    srai t1, t1, 24
+; RV32-NEXT:    div a7, t1, a7
+; RV32-NEXT:    slli t1, a0, 16
+; RV32-NEXT:    srai a3, a3, 24
+; RV32-NEXT:    srai t1, t1, 24
+; RV32-NEXT:    div a3, t1, a3
+; RV32-NEXT:    srai a2, a2, 24
+; RV32-NEXT:    srai a0, a0, 24
+; RV32-NEXT:    div a0, a0, a2
+; RV32-NEXT:    sb a6, 12(sp)
+; RV32-NEXT:    sb a1, 13(sp)
+; RV32-NEXT:    sb t0, 14(sp)
+; RV32-NEXT:    sb a4, 15(sp)
+; RV32-NEXT:    sb a5, 8(sp)
+; RV32-NEXT:    sb a3, 9(sp)
+; RV32-NEXT:    sb a7, 10(sp)
+; RV32-NEXT:    sb a0, 11(sp)
+; RV32-NEXT:    lw a0, 8(sp)
+; RV32-NEXT:    lw a1, 12(sp)
+; RV32-NEXT:    addi sp, sp, 16
 ; RV32-NEXT:    .cfi_def_cfa_offset 0
 ; RV32-NEXT:    ret
 ;
@@ -2892,31 +2797,27 @@ define <2 x i32> @test_psdiv_w(<2 x i32> %a, <2 x i32> %b) {
 define <4 x i16> @test_pudiv_h(<4 x i16> %a, <4 x i16> %b) {
 ; RV32-LABEL: test_pudiv_h:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -32
-; RV32-NEXT:    .cfi_def_cfa_offset 32
-; RV32-NEXT:    sw a3, 20(sp)
-; RV32-NEXT:    sw a1, 12(sp)
-; RV32-NEXT:    sw a2, 16(sp)
-; RV32-NEXT:    sw a0, 8(sp)
-; RV32-NEXT:    lhu a0, 22(sp)
-; RV32-NEXT:    lhu a1, 14(sp)
-; RV32-NEXT:    divu a0, a1, a0
-; RV32-NEXT:    sh a0, 30(sp)
-; RV32-NEXT:    lhu a0, 20(sp)
-; RV32-NEXT:    lhu a1, 12(sp)
-; RV32-NEXT:    divu a0, a1, a0
-; RV32-NEXT:    sh a0, 28(sp)
-; RV32-NEXT:    lhu a0, 18(sp)
-; RV32-NEXT:    lhu a1, 10(sp)
-; RV32-NEXT:    divu a0, a1, a0
-; RV32-NEXT:    sh a0, 26(sp)
-; RV32-NEXT:    lhu a0, 16(sp)
-; RV32-NEXT:    lhu a1, 8(sp)
-; RV32-NEXT:    divu a0, a1, a0
-; RV32-NEXT:    sh a0, 24(sp)
-; RV32-NEXT:    lw a0, 24(sp)
-; RV32-NEXT:    lw a1, 28(sp)
-; RV32-NEXT:    addi sp, sp, 32
+; RV32-NEXT:    addi sp, sp, -16
+; RV32-NEXT:    .cfi_def_cfa_offset 16
+; RV32-NEXT:    srli a4, a2, 16
+; RV32-NEXT:    srli a5, a0, 16
+; RV32-NEXT:    divu a4, a5, a4
+; RV32-NEXT:    srli a5, a3, 16
+; RV32-NEXT:    zext.h a2, a2
+; RV32-NEXT:    zext.h a0, a0
+; RV32-NEXT:    divu a0, a0, a2
+; RV32-NEXT:    srli a2, a1, 16
+; RV32-NEXT:    zext.h a3, a3
+; RV32-NEXT:    zext.h a1, a1
+; RV32-NEXT:    divu a1, a1, a3
+; RV32-NEXT:    divu a2, a2, a5
+; RV32-NEXT:    sh a0, 8(sp)
+; RV32-NEXT:    sh a4, 10(sp)
+; RV32-NEXT:    sh a1, 12(sp)
+; RV32-NEXT:    sh a2, 14(sp)
+; RV32-NEXT:    lw a0, 8(sp)
+; RV32-NEXT:    lw a1, 12(sp)
+; RV32-NEXT:    addi sp, sp, 16
 ; RV32-NEXT:    .cfi_def_cfa_offset 0
 ; RV32-NEXT:    ret
 ;
@@ -2947,47 +2848,51 @@ define <4 x i16> @test_pudiv_h(<4 x i16> %a, <4 x i16> %b) {
 define <8 x i8> @test_pudiv_b(<8 x i8> %a, <8 x i8> %b) {
 ; RV32-LABEL: test_pudiv_b:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -32
-; RV32-NEXT:    .cfi_def_cfa_offset 32
-; RV32-NEXT:    sw a3, 20(sp)
-; RV32-NEXT:    sw a1, 12(sp)
-; RV32-NEXT:    sw a2, 16(sp)
-; RV32-NEXT:    sw a0, 8(sp)
-; RV32-NEXT:    lbu a0, 23(sp)
-; RV32-NEXT:    lbu a1, 15(sp)
-; RV32-NEXT:    divu a0, a1, a0
-; RV32-NEXT:    sb a0, 31(sp)
-; RV32-NEXT:    lbu a0, 22(sp)
-; RV32-NEXT:    lbu a1, 14(sp)
-; RV32-NEXT:    divu a0, a1, a0
-; RV32-NEXT:    sb a0, 30(sp)
-; RV32-NEXT:    lbu a0, 21(sp)
-; RV32-NEXT:    lbu a1, 13(sp)
-; RV32-NEXT:    divu a0, a1, a0
-; RV32-NEXT:    sb a0, 29(sp)
-; RV32-NEXT:    lbu a0, 20(sp)
-; RV32-NEXT:    lbu a1, 12(sp)
-; RV32-NEXT:    divu a0, a1, a0
-; RV32-NEXT:    sb a0, 28(sp)
-; RV32-NEXT:    lbu a0, 19(sp)
-; RV32-NEXT:    lbu a1, 11(sp)
-; RV32-NEXT:    divu a0, a1, a0
-; RV32-NEXT:    sb a0, 27(sp)
-; RV32-NEXT:    lbu a0, 18(sp)
-; RV32-NEXT:    lbu a1, 10(sp)
-; RV32-NEXT:    divu a0, a1, a0
-; RV32-NEXT:    sb a0, 26(sp)
-; RV32-NEXT:    lbu a0, 17(sp)
-; RV32-NEXT:    lbu a1, 9(sp)
-; RV32-NEXT:    divu a0, a1, a0
-; RV32-NEXT:    sb a0, 25(sp)
-; RV32-NEXT:    lbu a0, 16(sp)
-; RV32-NEXT:    lbu a1, 8(sp)
-; RV32-NEXT:    divu a0, a1, a0
-; RV32-NEXT:    sb a0, 24(sp)
-; RV32-NEXT:    lw a0, 24(sp)
-; RV32-NEXT:    lw a1, 28(sp)
-; RV32-NEXT:    addi sp, sp, 32
+; RV32-NEXT:    addi sp, sp, -16
+; RV32-NEXT:    .cfi_def_cfa_offset 16
+; RV32-NEXT:    srli a4, a3, 24
+; RV32-NEXT:    srli a5, a1, 24
+; RV32-NEXT:    zext.b a6, a3
+; RV32-NEXT:    zext.b a7, a1
+; RV32-NEXT:    slli t0, a3, 8
+; RV32-NEXT:    slli t1, a1, 8
+; RV32-NEXT:    slli a3, a3, 16
+; RV32-NEXT:    slli a1, a1, 16
+; RV32-NEXT:    divu a4, a5, a4
+; RV32-NEXT:    zext.b a5, a2
+; RV32-NEXT:    divu a6, a7, a6
+; RV32-NEXT:    zext.b a7, a0
+; RV32-NEXT:    divu a5, a7, a5
+; RV32-NEXT:    slli a7, a2, 8
+; RV32-NEXT:    srli t0, t0, 24
+; RV32-NEXT:    srli t1, t1, 24
+; RV32-NEXT:    divu t0, t1, t0
+; RV32-NEXT:    slli t1, a0, 8
+; RV32-NEXT:    srli a3, a3, 24
+; RV32-NEXT:    srli a1, a1, 24
+; RV32-NEXT:    divu a1, a1, a3
+; RV32-NEXT:    slli a3, a2, 16
+; RV32-NEXT:    srli a7, a7, 24
+; RV32-NEXT:    srli t1, t1, 24
+; RV32-NEXT:    divu a7, t1, a7
+; RV32-NEXT:    slli t1, a0, 16
+; RV32-NEXT:    srli a3, a3, 24
+; RV32-NEXT:    srli t1, t1, 24
+; RV32-NEXT:    divu a3, t1, a3
+; RV32-NEXT:    srli a2, a2, 24
+; RV32-NEXT:    srli a0, a0, 24
+; RV32-NEXT:    divu a0, a0, a2
+; RV32-NEXT:    sb a6, 12(sp)
+; RV32-NEXT:    sb a1, 13(sp)
+; RV32-NEXT:    sb t0, 14(sp)
+; RV32-NEXT:    sb a4, 15(sp)
+; RV32-NEXT:    sb a5, 8(sp)
+; RV32-NEXT:    sb a3, 9(sp)
+; RV32-NEXT:    sb a7, 10(sp)
+; RV32-NEXT:    sb a0, 11(sp)
+; RV32-NEXT:    lw a0, 8(sp)
+; RV32-NEXT:    lw a1, 12(sp)
+; RV32-NEXT:    addi sp, sp, 16
 ; RV32-NEXT:    .cfi_def_cfa_offset 0
 ; RV32-NEXT:    ret
 ;
@@ -3061,31 +2966,27 @@ define <2 x i32> @test_pudiv_w(<2 x i32> %a, <2 x i32> %b) {
 define <4 x i16> @test_psrem_h(<4 x i16> %a, <4 x i16> %b) {
 ; RV32-LABEL: test_psrem_h:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -32
-; RV32-NEXT:    .cfi_def_cfa_offset 32
-; RV32-NEXT:    sw a3, 20(sp)
-; RV32-NEXT:    sw a1, 12(sp)
-; RV32-NEXT:    sw a2, 16(sp)
-; RV32-NEXT:    sw a0, 8(sp)
-; RV32-NEXT:    lh a0, 22(sp)
-; RV32-NEXT:    lh a1, 14(sp)
-; RV32-NEXT:    rem a0, a1, a0
-; RV32-NEXT:    sh a0, 30(sp)
-; RV32-NEXT:    lh a0, 20(sp)
-; RV32-NEXT:    lh a1, 12(sp)
-; RV32-NEXT:    rem a0, a1, a0
-; RV32-NEXT:    sh a0, 28(sp)
-; RV32-NEXT:    lh a0, 18(sp)
-; RV32-NEXT:    lh a1, 10(sp)
-; RV32-NEXT:    rem a0, a1, a0
-; RV32-NEXT:    sh a0, 26(sp)
-; RV32-NEXT:    lh a0, 16(sp)
-; RV32-NEXT:    lh a1, 8(sp)
-; RV32-NEXT:    rem a0, a1, a0
-; RV32-NEXT:    sh a0, 24(sp)
-; RV32-NEXT:    lw a0, 24(sp)
-; RV32-NEXT:    lw a1, 28(sp)
-; RV32-NEXT:    addi sp, sp, 32
+; RV32-NEXT:    addi sp, sp, -16
+; RV32-NEXT:    .cfi_def_cfa_offset 16
+; RV32-NEXT:    srai a4, a2, 16
+; RV32-NEXT:    srai a5, a0, 16
+; RV32-NEXT:    rem a4, a5, a4
+; RV32-NEXT:    srai a5, a3, 16
+; RV32-NEXT:    sext.h a2, a2
+; RV32-NEXT:    sext.h a0, a0
+; RV32-NEXT:    rem a0, a0, a2
+; RV32-NEXT:    srai a2, a1, 16
+; RV32-NEXT:    sext.h a3, a3
+; RV32-NEXT:    sext.h a1, a1
+; RV32-NEXT:    rem a1, a1, a3
+; RV32-NEXT:    rem a2, a2, a5
+; RV32-NEXT:    sh a0, 8(sp)
+; RV32-NEXT:    sh a4, 10(sp)
+; RV32-NEXT:    sh a1, 12(sp)
+; RV32-NEXT:    sh a2, 14(sp)
+; RV32-NEXT:    lw a0, 8(sp)
+; RV32-NEXT:    lw a1, 12(sp)
+; RV32-NEXT:    addi sp, sp, 16
 ; RV32-NEXT:    .cfi_def_cfa_offset 0
 ; RV32-NEXT:    ret
 ;
@@ -3118,47 +3019,51 @@ define <4 x i16> @test_psrem_h(<4 x i16> %a, <4 x i16> %b) {
 define <8 x i8> @test_psrem_b(<8 x i8> %a, <8 x i8> %b) {
 ; RV32-LABEL: test_psrem_b:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -32
-; RV32-NEXT:    .cfi_def_cfa_offset 32
-; RV32-NEXT:    sw a3, 20(sp)
-; RV32-NEXT:    sw a1, 12(sp)
-; RV32-NEXT:    sw a2, 16(sp)
-; RV32-NEXT:    sw a0, 8(sp)
-; RV32-NEXT:    lb a0, 23(sp)
-; RV32-NEXT:    lb a1, 15(sp)
-; RV32-NEXT:    rem a0, a1, a0
-; RV32-NEXT:    sb a0, 31(sp)
-; RV32-NEXT:    lb a0, 22(sp)
-; RV32-NEXT:    lb a1, 14(sp)
-; RV32-NEXT:    rem a0, a1, a0
-; RV32-NEXT:    sb a0, 30(sp)
-; RV32-NEXT:    lb a0, 21(sp)
-; RV32-NEXT:    lb a1, 13(sp)
-; RV32-NEXT:    rem a0, a1, a0
-; RV32-NEXT:    sb a0, 29(sp)
-; RV32-NEXT:    lb a0, 20(sp)
-; RV32-NEXT:    lb a1, 12(sp)
-; RV32-NEXT:    rem a0, a1, a0
-; RV32-NEXT:    sb a0, 28(sp)
-; RV32-NEXT:    lb a0, 19(sp)
-; RV32-NEXT:    lb a1, 11(sp)
-; RV32-NEXT:    rem a0, a1, a0
-; RV32-NEXT:    sb a0, 27(sp)
-; RV32-NEXT:    lb a0, 18(sp)
-; RV32-NEXT:    lb a1, 10(sp)
-; RV32-NEXT:    rem a0, a1, a0
-; RV32-NEXT:    sb a0, 26(sp)
-; RV32-NEXT:    lb a0, 17(sp)
-; RV32-NEXT:    lb a1, 9(sp)
-; RV32-NEXT:    rem a0, a1, a0
-; RV32-NEXT:    sb a0, 25(sp)
-; RV32-NEXT:    lb a0, 16(sp)
-; RV32-NEXT:    lb a1, 8(sp)
-; RV32-NEXT:    rem a0, a1, a0
-; RV32-NEXT:    sb a0, 24(sp)
-; RV32-NEXT:    lw a0, 24(sp)
-; RV32-NEXT:    lw a1, 28(sp)
-; RV32-NEXT:    addi sp, sp, 32
+; RV32-NEXT:    addi sp, sp, -16
+; RV32-NEXT:    .cfi_def_cfa_offset 16
+; RV32-NEXT:    srai a4, a3, 24
+; RV32-NEXT:    srai a5, a1, 24
+; RV32-NEXT:    sext.b a6, a3
+; RV32-NEXT:    sext.b a7, a1
+; RV32-NEXT:    slli t0, a3, 8
+; RV32-NEXT:    slli t1, a1, 8
+; RV32-NEXT:    slli a3, a3, 16
+; RV32-NEXT:    slli a1, a1, 16
+; RV32-NEXT:    rem a4, a5, a4
+; RV32-NEXT:    sext.b a5, a2
+; RV32-NEXT:    rem a6, a7, a6
+; RV32-NEXT:    sext.b a7, a0
+; RV32-NEXT:    rem a5, a7, a5
+; RV32-NEXT:    slli a7, a2, 8
+; RV32-NEXT:    srai t0, t0, 24
+; RV32-NEXT:    srai t1, t1, 24
+; RV32-NEXT:    rem t0, t1, t0
+; RV32-NEXT:    slli t1, a0, 8
+; RV32-NEXT:    srai a3, a3, 24
+; RV32-NEXT:    srai a1, a1, 24
+; RV32-NEXT:    rem a1, a1, a3
+; RV32-NEXT:    slli a3, a2, 16
+; RV32-NEXT:    srai a7, a7, 24
+; RV32-NEXT:    srai t1, t1, 24
+; RV32-NEXT:    rem a7, t1, a7
+; RV32-NEXT:    slli t1, a0, 16
+; RV32-NEXT:    srai a3, a3, 24
+; RV32-NEXT:    srai t1, t1, 24
+; RV32-NEXT:    rem a3, t1, a3
+; RV32-NEXT:    srai a2, a2, 24
+; RV32-NEXT:    srai a0, a0, 24
+; RV32-NEXT:    rem a0, a0, a2
+; RV32-NEXT:    sb a6, 12(sp)
+; RV32-NEXT:    sb a1, 13(sp)
+; RV32-NEXT:    sb t0, 14(sp)
+; RV32-NEXT:    sb a4, 15(sp)
+; RV32-NEXT:    sb a5, 8(sp)
+; RV32-NEXT:    sb a3, 9(sp)
+; RV32-NEXT:    sb a7, 10(sp)
+; RV32-NEXT:    sb a0, 11(sp)
+; RV32-NEXT:    lw a0, 8(sp)
+; RV32-NEXT:    lw a1, 12(sp)
+; RV32-NEXT:    addi sp, sp, 16
 ; RV32-NEXT:    .cfi_def_cfa_offset 0
 ; RV32-NEXT:    ret
 ;
@@ -3234,31 +3139,27 @@ define <2 x i32> @test_psrem_w(<2 x i32> %a, <2 x i32> %b) {
 define <4 x i16> @test_purem_h(<4 x i16> %a, <4 x i16> %b) {
 ; RV32-LABEL: test_purem_h:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -32
-; RV32-NEXT:    .cfi_def_cfa_offset 32
-; RV32-NEXT:    sw a3, 20(sp)
-; RV32-NEXT:    sw a1, 12(sp)
-; RV32-NEXT:    sw a2, 16(sp)
-; RV32-NEXT:    sw a0, 8(sp)
-; RV32-NEXT:    lhu a0, 22(sp)
-; RV32-NEXT:    lhu a1, 14(sp)
-; RV32-NEXT:    remu a0, a1, a0
-; RV32-NEXT:    sh a0, 30(sp)
-; RV32-NEXT:    lhu a0, 20(sp)
-; RV32-NEXT:    lhu a1, 12(sp)
-; RV32-NEXT:    remu a0, a1, a0
-; RV32-NEXT:    sh a0, 28(sp)
-; RV32-NEXT:    lhu a0, 18(sp)
-; RV32-NEXT:    lhu a1, 10(sp)
-; RV32-NEXT:    remu a0, a1, a0
-; RV32-NEXT:    sh a0, 26(sp)
-; RV32-NEXT:    lhu a0, 16(sp)
-; RV32-NEXT:    lhu a1, 8(sp)
-; RV32-NEXT:    remu a0, a1, a0
-; RV32-NEXT:    sh a0, 24(sp)
-; RV32-NEXT:    lw a0, 24(sp)
-; RV32-NEXT:    lw a1, 28(sp)
-; RV32-NEXT:    addi sp, sp, 32
+; RV32-NEXT:    addi sp, sp, -16
+; RV32-NEXT:    .cfi_def_cfa_offset 16
+; RV32-NEXT:    srli a4, a2, 16
+; RV32-NEXT:    srli a5, a0, 16
+; RV32-NEXT:    remu a4, a5, a4
+; RV32-NEXT:    srli a5, a3, 16
+; RV32-NEXT:    zext.h a2, a2
+; RV32-NEXT:    zext.h a0, a0
+; RV32-NEXT:    remu a0, a0, a2
+; RV32-NEXT:    srli a2, a1, 16
+; RV32-NEXT:    zext.h a3, a3
+; RV32-NEXT:    zext.h a1, a1
+; RV32-NEXT:    remu a1, a1, a3
+; RV32-NEXT:    remu a2, a2, a5
+; RV32-NEXT:    sh a0, 8(sp)
+; RV32-NEXT:    sh a4, 10(sp)
+; RV32-NEXT:    sh a1, 12(sp)
+; RV32-NEXT:    sh a2, 14(sp)
+; RV32-NEXT:    lw a0, 8(sp)
+; RV32-NEXT:    lw a1, 12(sp)
+; RV32-NEXT:    addi sp, sp, 16
 ; RV32-NEXT:    .cfi_def_cfa_offset 0
 ; RV32-NEXT:    ret
 ;
@@ -3289,47 +3190,51 @@ define <4 x i16> @test_purem_h(<4 x i16> %a, <4 x i16> %b) {
 define <8 x i8> @test_purem_b(<8 x i8> %a, <8 x i8> %b) {
 ; RV32-LABEL: test_purem_b:
 ; RV32:       # %bb.0:
-; RV32-NEXT:    addi sp, sp, -32
-; RV32-NEXT:    .cfi_def_cfa_offset 32
-; RV32-NEXT:    sw a3, 20(sp)
-; RV32-NEXT:    sw a1, 12(sp)
-; RV32-NEXT:    sw a2, 16(sp)
-; RV32-NEXT:    sw a0, 8(sp)
-; RV32-NEXT:    lbu a0, 23(sp)
-; RV32-NEXT:    lbu a1, 15(sp)
-; RV32-NEXT:    remu a0, a1, a0
-; RV32-NEXT:    sb a0, 31(sp)
-; RV32-NEXT:    lbu a0, 22(sp)
-; RV32-NEXT:    lbu a1, 14(sp)
-; RV32-NEXT:    remu a0, a1, a0
-; RV32-NEXT:    sb a0, 30(sp)
-; RV32-NEXT:    lbu a0, 21(sp)
-; RV32-NEXT:    lbu a1, 13(sp)
-; RV32-NEXT:    remu a0, a1, a0
-; RV32-NEXT:    sb a0, 29(sp)
-; RV32-NEXT:    lbu a0, 20(sp)
-; RV32-NEXT:    lbu a1, 12(sp)
-; RV32-NEXT:    remu a0, a1, a0
-; RV32-NEXT:    sb a0, 28(sp)
-; RV32-NEXT:    lbu a0, 19(sp)
-; RV32-NEXT:    lbu a1, 11(sp)
-; RV32-NEXT:    remu a0, a1, a0
-; RV32-NEXT:    sb a0, 27(sp)
-; RV32-NEXT:    lbu a0, 18(sp)
-; RV32-NEXT:    lbu a1, 10(sp)
-; RV32-NEXT:    remu a0, a1, a0
-; RV32-NEXT:    sb a0, 26(sp)
-; RV32-NEXT:    lbu a0, 17(sp)
-; RV32-NEXT:    lbu a1, 9(sp)
-; RV32-NEXT:    remu a0, a1, a0
-; RV32-NEXT:    sb a0, 25(sp)
-; RV32-NEXT:    lbu a0, 16(sp)
-; RV32-NEXT:    lbu a1, 8(sp)
-; RV32-NEXT:    remu a0, a1, a0
-; RV32-NEXT:    sb a0, 24(sp)
-; RV32-NEXT:    lw a0, 24(sp)
-; RV32-NEXT:    lw a1, 28(sp)
-; RV32-NEXT:    addi sp, sp, 32
+; RV32-NEXT:    addi sp, sp, -16
+; RV32-NEXT:    .cfi_def_cfa_offset 16
+; RV32-NEXT:    srli a4, a3, 24
+; RV32-NEXT:    srli a5, a1, 24
+; RV32-NEXT:    zext.b a6, a3
+; RV32-NEXT:    zext.b a7, a1
+; RV32-NEXT:    slli t0, a3, 8
+; RV32-NEXT:    slli t1, a1, 8
+; RV32-NEXT:    slli a3, a3, 16
+; RV32-NEXT:    slli a1, a1, 16
+; RV32-NEXT:    remu a4, a5, a4
+; RV32-NEXT:    zext.b a5, a2
+; RV32-NEXT:    remu a6, a7, a6
+; RV32-NEXT:    zext.b a7, a0
+; RV32-NEXT:    remu a5, a7, a5
+; RV32-NEXT:    slli a7, a2, 8
+; RV32-NEXT:    srli t0, t0, 24
+; RV32-NEXT:    srli t1, t1, 24
+; RV32-NEXT:    remu t0, t1, t0
+; RV32-NEXT:    slli t1, a0, 8
+; RV32-NEXT:    srli a3, a3, 24
+; RV32-NEXT:    srli a1, a1, 24
+; RV32-NEXT:    remu a1, a1, a3
+; RV32-NEXT:    slli a3, a2, 16
+; RV32-NEXT:    srli a7, a7, 24
+; RV32-NEXT:    srli t1, t1, 24
+; RV32-NEXT:    remu a7, t1, a7
+; RV32-NEXT:    slli t1, a0, 16
+; RV32-NEXT:    srli a3, a3, 24
+; RV32-NEXT:    srli t1, t1, 24
+; RV32-NEXT:    remu a3, t1, a3
+; RV32-NEXT:    srli a2, a2, 24
+; RV32-NEXT:    srli a0, a0, 24
+; RV32-NEXT:    remu a0, a0, a2
+; RV32-NEXT:    sb a6, 12(sp)
+; RV32-NEXT:    sb a1, 13(sp)
+; RV32-NEXT:    sb t0, 14(sp)
+; RV32-NEXT:    sb a4, 15(sp)
+; RV32-NEXT:    sb a5, 8(sp)
+; RV32-NEXT:    sb a3, 9(sp)
+; RV32-NEXT:    sb a7, 10(sp)
+; RV32-NEXT:    sb a0, 11(sp)
+; RV32-NEXT:    lw a0, 8(sp)
+; RV32-NEXT:    lw a1, 12(sp)
+; RV32-NEXT:    addi sp, sp, 16
 ; RV32-NEXT:    .cfi_def_cfa_offset 0
 ; RV32-NEXT:    ret
 ;


### PR DESCRIPTION
With a constant lane index, split the vector and recurse on the single-GPR half containing Idx (already Custom-lowered).