### PR TITLE
[RISCV][CodeGen] Use vzip.vv for e64 interleave shuffles with Zvzip

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -5220,10 +5220,13 @@ static bool isLegalVTForZvzipOperand(MVT VT, const RISCVSubtarget &Subtarget) {
 static bool isInterleaveShuffle(ArrayRef<int> Mask, MVT VT, int &EvenSrc,
                                 int &OddSrc, const RISCVSubtarget &Subtarget) {
   // We need to be able to widen elements to the next larger integer type or
-  // use the zip2a instruction at e64.
-  if (VT.getScalarSizeInBits() >= Subtarget.getELen() &&
-      !Subtarget.hasVendorXRivosVizip())
-    return false;
+  // use the zip2a/vzip instruction at e64.
+  if (VT.getScalarSizeInBits() >= Subtarget.getELen()) {
+    if (!Subtarget.hasVendorXRivosVizip() && !Subtarget.hasStdExtZvzip())
+      return false;
+    if (Subtarget.hasStdExtZvzip() && !isLegalVTForZvzipOperand(VT, Subtarget))
+      return false;
+  }
 
   int Size = Mask.size();
   int NumElts = VT.getVectorNumElements();

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-shuffle-int-interleave.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-shuffle-int-interleave.ll
@@ -129,15 +129,10 @@ define <4 x i64> @interleave_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ;
 ; ZVZIP-LABEL: interleave_v2i64:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 1, e8, m1, ta, ma
+; ZVZIP-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
 ; ZVZIP-NEXT:    vmv1r.v v10, v9
-; ZVZIP-NEXT:    vmv.v.i v0, 10
-; ZVZIP-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
-; ZVZIP-NEXT:    vslideup.vi v12, v10, 1
-; ZVZIP-NEXT:    vslideup.vi v12, v10, 2
-; ZVZIP-NEXT:    vmv2r.v v10, v8
-; ZVZIP-NEXT:    vslideup.vi v10, v8, 1
-; ZVZIP-NEXT:    vmerge.vvm v8, v10, v12, v0
+; ZVZIP-NEXT:    vmv1r.v v11, v8
+; ZVZIP-NEXT:    vzip.vv v8, v11, v10
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <2 x i64> %x, <2 x i64> %y, <4 x i32> <i32 0, i32 2, i32 1, i32 3>
   ret <4 x i64> %a
@@ -1088,15 +1083,11 @@ define <4 x i64> @unary_interleave_v4i64(<4 x i64> %x) {
 ;
 ; ZVZIP-LABEL: unary_interleave_v4i64:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    lui a0, 12304
-; ZVZIP-NEXT:    addi a0, a0, 512
-; ZVZIP-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
-; ZVZIP-NEXT:    vmv.s.x v10, a0
-; ZVZIP-NEXT:    vsetvli zero, zero, e16, mf2, ta, ma
-; ZVZIP-NEXT:    vsext.vf2 v12, v10
-; ZVZIP-NEXT:    vsetvli zero, zero, e64, m2, ta, ma
-; ZVZIP-NEXT:    vrgatherei16.vv v10, v8, v12
-; ZVZIP-NEXT:    vmv.v.v v8, v10
+; ZVZIP-NEXT:    vsetivli zero, 2, e64, m2, ta, ma
+; ZVZIP-NEXT:    vslidedown.vi v12, v8, 2
+; ZVZIP-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
+; ZVZIP-NEXT:    vzip.vv v10, v8, v12
+; ZVZIP-NEXT:    vmv2r.v v8, v10
 ; ZVZIP-NEXT:    ret
   %a = shufflevector <4 x i64> %x, <4 x i64> poison, <4 x i32> <i32 0, i32 2, i32 1, i32 3>
   ret <4 x i64> %a

--- a/llvm/test/CodeGen/RISCV/rvv/vector-interleave-fixed.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vector-interleave-fixed.ll
@@ -200,17 +200,10 @@ define <4 x i64> @vector_interleave_v4i64_v2i64(<2 x i64> %a, <2 x i64> %b) {
 ;
 ; ZVZIP-LABEL: vector_interleave_v4i64_v2i64:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
+; ZVZIP-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
 ; ZVZIP-NEXT:    vmv1r.v v10, v9
-; ZVZIP-NEXT:    lui a0, 12304
-; ZVZIP-NEXT:    addi a0, a0, 512
-; ZVZIP-NEXT:    vslideup.vi v8, v10, 2
-; ZVZIP-NEXT:    vmv.s.x v10, a0
-; ZVZIP-NEXT:    vsetvli zero, zero, e16, mf2, ta, ma
-; ZVZIP-NEXT:    vsext.vf2 v12, v10
-; ZVZIP-NEXT:    vsetvli zero, zero, e64, m2, ta, ma
-; ZVZIP-NEXT:    vrgatherei16.vv v10, v8, v12
-; ZVZIP-NEXT:    vmv.v.v v8, v10
+; ZVZIP-NEXT:    vmv1r.v v11, v8
+; ZVZIP-NEXT:    vzip.vv v8, v11, v10
 ; ZVZIP-NEXT:    ret
 	   %res = call <4 x i64> @llvm.vector.interleave2.v4i64(<2 x i64> %a, <2 x i64> %b)
 	   ret <4 x i64> %res
@@ -1389,17 +1382,10 @@ define <4 x double> @vector_interleave_v4f64_v2f64(<2 x double> %a, <2 x double>
 ;
 ; ZVZIP-LABEL: vector_interleave_v4f64_v2f64:
 ; ZVZIP:       # %bb.0:
-; ZVZIP-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
+; ZVZIP-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
 ; ZVZIP-NEXT:    vmv1r.v v10, v9
-; ZVZIP-NEXT:    lui a0, 12304
-; ZVZIP-NEXT:    addi a0, a0, 512
-; ZVZIP-NEXT:    vslideup.vi v8, v10, 2
-; ZVZIP-NEXT:    vmv.s.x v10, a0
-; ZVZIP-NEXT:    vsetvli zero, zero, e16, mf2, ta, ma
-; ZVZIP-NEXT:    vsext.vf2 v12, v10
-; ZVZIP-NEXT:    vsetvli zero, zero, e64, m2, ta, ma
-; ZVZIP-NEXT:    vrgatherei16.vv v10, v8, v12
-; ZVZIP-NEXT:    vmv.v.v v8, v10
+; ZVZIP-NEXT:    vmv1r.v v11, v8
+; ZVZIP-NEXT:    vzip.vv v8, v11, v10
 ; ZVZIP-NEXT:    ret
 	   %res = call <4 x double> @llvm.vector.interleave2.v4f64(<2 x double> %a, <2 x double> %b)
 	   ret <4 x double> %res


### PR DESCRIPTION
Allow e64 interleave shuffles to use the standard Zvzip `vzip.vv` lowering when the operand type is legal for Zvzip, just the same as what XrivosVizip already does.