### PR TITLE
[libc][math] Implement double-precision cosh

### DIFF
--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -560,6 +560,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.copysignl
     libc.src.math.cos
     libc.src.math.cosf
+    libc.src.math.cosh
     libc.src.math.coshf
     libc.src.math.cospif
     libc.src.math.dfmal

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -2798,6 +2798,19 @@ add_header_library(
 )
 
 add_header_library(
+  cosh
+  HDRS
+    cosh.h
+  DEPENDS
+    .exp
+    libc.src.__support.FPUtil.fenv_impl
+    libc.src.__support.FPUtil.fp_bits
+    libc.src.__support.FPUtil.rounding_mode
+    libc.src.__support.macros.config
+    libc.src.__support.macros.optimization
+)
+
+add_header_library(
   coshf
   HDRS
     coshf.h

--- a/libc/src/__support/math/cosh.h
+++ b/libc/src/__support/math/cosh.h
@@ -1,0 +1,67 @@
+//===-- Implementation header for cosh --------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_COSH_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_COSH_H
+
+#include "exp.h"
+#include "src/__support/FPUtil/FEnvImpl.h"
+#include "src/__support/FPUtil/FPBits.h"
+#include "src/__support/FPUtil/rounding_mode.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+LIBC_INLINE double cosh(double x) {
+  using FPBits = fputil::FPBits<double>;
+  FPBits xbits(x);
+  // cosh is even, work with |x|.
+  xbits.set_sign(Sign::POS);
+  double x_abs = xbits.get_val();
+  uint64_t x_abs_u = xbits.uintval();
+
+  // Handle NaN: cosh(NaN) = NaN.
+  if (LIBC_UNLIKELY(xbits.is_nan())) {
+    if (xbits.is_signaling_nan()) {
+      fputil::raise_except_if_required(FE_INVALID);
+      return FPBits::quiet_nan().get_val();
+    }
+    return x;
+  }
+
+  // cosh(+/-inf) = +inf.
+  if (LIBC_UNLIKELY(xbits.is_inf()))
+    return FPBits::inf(Sign::POS).get_val();
+
+  // For very small |x| (|x| <= 2^-27), cosh(x) ~ 1.
+  if (LIBC_UNLIKELY(x_abs_u <= 0x3e40000000000000ULL))
+    return 1.0;
+
+  // For |x| >= 710, overflow.
+  if (LIBC_UNLIKELY(x_abs_u >= 0x4086340000000000ULL)) {
+    int rounding = fputil::quick_get_round();
+    if (rounding == FE_DOWNWARD || rounding == FE_TOWARDZERO)
+      return FPBits::max_normal().get_val();
+    fputil::set_errno_if_required(ERANGE);
+    fputil::raise_except_if_required(FE_OVERFLOW);
+    return FPBits::inf(Sign::POS).get_val();
+  }
+
+  // General case: cosh(x) = (exp(x) + exp(-x)) / 2.
+  double ex = math::exp(x_abs);
+  return (ex + 1.0 / ex) * 0.5;
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_COSH_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -3632,6 +3632,16 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  cosh
+  SRCS
+    cosh.cpp
+  HDRS
+    ../cosh.h
+  DEPENDS
+    libc.src.__support.math.cosh
+)
+
+add_entrypoint_object(
   coshf
   SRCS
     coshf.cpp

--- a/libc/src/math/generic/cosh.cpp
+++ b/libc/src/math/generic/cosh.cpp
@@ -1,0 +1,16 @@
+//===-- Double-precision cosh implementation ------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/math/cosh.h"
+#include "src/__support/math/cosh.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(double, cosh, (double x)) { return math::cosh(x); }
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/test/src/math/CMakeLists.txt
+++ b/libc/test/src/math/CMakeLists.txt
@@ -2300,6 +2300,19 @@ add_fp_unittest(
 )
 
 add_fp_unittest(
+  cosh_test
+  NEED_MPFR
+  SUITE
+    libc-math-unittests
+  SRCS
+    cosh_test.cpp
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.src.math.cosh
+    libc.src.__support.FPUtil.fp_bits
+)
+
+add_fp_unittest(
   coshf_test
   NEED_MPFR
   SUITE

--- a/libc/test/src/math/cosh_test.cpp
+++ b/libc/test/src/math/cosh_test.cpp
@@ -1,0 +1,83 @@
+//===-- Unittests for cosh ------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/__support/FPUtil/FPBits.h"
+#include "src/math/cosh.h"
+#include "test/UnitTest/FPMatcher.h"
+#include "test/UnitTest/Test.h"
+#include "utils/MPFRWrapper/MPFRUtils.h"
+
+using LlvmLibcCoshTest = LIBC_NAMESPACE::testing::FPTest<double>;
+
+namespace mpfr = LIBC_NAMESPACE::testing::mpfr;
+
+using LIBC_NAMESPACE::testing::tlog;
+
+TEST_F(LlvmLibcCoshTest, InDoubleRange) {
+  // cosh is even; test [0, 710) — values >= 710 overflow to inf.
+  constexpr uint64_t COUNT = 123'451;
+  uint64_t START = FPBits(0x1.0p-27).uintval();
+  uint64_t STOP = FPBits(710.0).uintval();
+  uint64_t STEP = (STOP - START) / COUNT;
+
+  auto test = [&](mpfr::RoundingMode rounding_mode) {
+    mpfr::ForceRoundingMode __r(rounding_mode);
+    if (!__r.success)
+      return;
+
+    uint64_t fails = 0;
+    uint64_t count = 0;
+    uint64_t cc = 0;
+    double mx = 0.0, mr = 0.0;
+    double tol = 0.5;
+
+    for (uint64_t i = 0, v = START; i <= COUNT; ++i, v += STEP) {
+      double x = FPBits(v).get_val();
+      if (FPBits(v).is_inf_or_nan())
+        continue;
+
+      double result = LIBC_NAMESPACE::cosh(x);
+      ++cc;
+      if (FPBits(result).is_inf_or_nan())
+        continue;
+
+      ++count;
+
+      if (!TEST_MPFR_MATCH_ROUNDING_SILENTLY(mpfr::Operation::Cosh, x, result,
+                                             0.5, rounding_mode)) {
+        ++fails;
+        while (!TEST_MPFR_MATCH_ROUNDING_SILENTLY(mpfr::Operation::Cosh, x,
+                                                  result, tol, rounding_mode)) {
+          mx = x;
+          mr = result;
+          if (tol > 1000.0)
+            break;
+          tol *= 2.0;
+        }
+      }
+    }
+    if (fails) {
+      tlog << " Cosh failed: " << fails << "/" << count << "/" << cc
+           << " tests.\n";
+      tlog << "   Max ULPs is at most: " << static_cast<uint64_t>(tol) << ".\n";
+      EXPECT_MPFR_MATCH(mpfr::Operation::Cosh, mx, mr, 0.5, rounding_mode);
+    }
+  };
+
+  tlog << " Test Rounding To Nearest...\n";
+  test(mpfr::RoundingMode::Nearest);
+
+  tlog << " Test Rounding Downward...\n";
+  test(mpfr::RoundingMode::Downward);
+
+  tlog << " Test Rounding Upward...\n";
+  test(mpfr::RoundingMode::Upward);
+
+  tlog << " Test Rounding Toward Zero...\n";
+  test(mpfr::RoundingMode::TowardZero);
+}

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -4623,6 +4623,18 @@ add_fp_unittest(
 )
 
 add_fp_unittest(
+  cosh_test
+  SUITE
+    libc-math-smoke-tests
+  SRCS
+    cosh_test.cpp
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.src.math.cosh
+    libc.src.__support.FPUtil.fp_bits
+)
+
+add_fp_unittest(
   coshf_test
   SUITE
     libc-math-smoke-tests

--- a/libc/test/src/math/smoke/cosh_test.cpp
+++ b/libc/test/src/math/smoke/cosh_test.cpp
@@ -1,0 +1,72 @@
+//===-- Unittests for cosh ------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hdr/errno_macros.h"
+#include "hdr/math_macros.h"
+#include "src/__support/FPUtil/FPBits.h"
+#include "src/math/cosh.h"
+#include "test/UnitTest/FPMatcher.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcCoshTest = LIBC_NAMESPACE::testing::FPTest<double>;
+
+TEST_F(LlvmLibcCoshTest, SpecialNumbers) {
+  EXPECT_FP_EQ_WITH_EXCEPTION(aNaN, LIBC_NAMESPACE::cosh(sNaN), FE_INVALID);
+  EXPECT_MATH_ERRNO(0);
+
+  EXPECT_FP_EQ_ALL_ROUNDING(aNaN, LIBC_NAMESPACE::cosh(aNaN));
+  EXPECT_MATH_ERRNO(0);
+
+  EXPECT_FP_EQ_ALL_ROUNDING(inf, LIBC_NAMESPACE::cosh(inf));
+  EXPECT_MATH_ERRNO(0);
+
+  EXPECT_FP_EQ_ALL_ROUNDING(inf, LIBC_NAMESPACE::cosh(neg_inf));
+  EXPECT_MATH_ERRNO(0);
+
+  EXPECT_FP_EQ_ALL_ROUNDING(1.0, LIBC_NAMESPACE::cosh(0.0));
+  EXPECT_MATH_ERRNO(0);
+
+  EXPECT_FP_EQ_ALL_ROUNDING(1.0, LIBC_NAMESPACE::cosh(-0.0));
+  EXPECT_MATH_ERRNO(0);
+}
+
+TEST_F(LlvmLibcCoshTest, Overflow) {
+  EXPECT_FP_EQ_WITH_EXCEPTION(inf, LIBC_NAMESPACE::cosh(0x1.0p10), FE_OVERFLOW);
+  EXPECT_MATH_ERRNO(ERANGE);
+
+  EXPECT_FP_EQ_WITH_EXCEPTION(inf, LIBC_NAMESPACE::cosh(-0x1.0p10),
+                              FE_OVERFLOW);
+  EXPECT_MATH_ERRNO(ERANGE);
+}
+
+#ifdef LIBC_TEST_FTZ_DAZ
+
+using namespace LIBC_NAMESPACE::testing;
+
+TEST_F(LlvmLibcCoshTest, FTZMode) {
+  ModifyMXCSR mxcsr(FTZ);
+
+  EXPECT_FP_EQ(1.0, LIBC_NAMESPACE::cosh(min_denormal));
+  EXPECT_FP_EQ(1.0, LIBC_NAMESPACE::cosh(max_denormal));
+}
+
+TEST_F(LlvmLibcCoshTest, DAZMode) {
+  ModifyMXCSR mxcsr(DAZ);
+
+  EXPECT_FP_EQ(1.0, LIBC_NAMESPACE::cosh(min_denormal));
+  EXPECT_FP_EQ(1.0, LIBC_NAMESPACE::cosh(max_denormal));
+}
+
+TEST_F(LlvmLibcCoshTest, FTZDAZMode) {
+  ModifyMXCSR mxcsr(FTZ | DAZ);
+
+  EXPECT_FP_EQ(1.0, LIBC_NAMESPACE::cosh(min_denormal));
+  EXPECT_FP_EQ(1.0, LIBC_NAMESPACE::cosh(max_denormal));
+}
+
+#endif


### PR DESCRIPTION
This PR adds an implementation of the double-precision hyperbolic cosine function `cosh` to the `math` library.