### PR TITLE
[libc][math] Implement double-precision asinh

### DIFF
--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -538,6 +538,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.acospif
     libc.src.math.asin
     libc.src.math.asinf
+    libc.src.math.asinh
     libc.src.math.asinhf
     libc.src.math.asinpi
     libc.src.math.asinpif

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -158,6 +158,20 @@ add_header_library(
 )
 
 add_header_library(
+  asinh
+  HDRS
+    asinh.h
+  DEPENDS
+    .log
+    .log1p
+    libc.src.__support.FPUtil.fenv_impl
+    libc.src.__support.FPUtil.fp_bits
+    libc.src.__support.FPUtil.sqrt
+    libc.src.__support.macros.config
+    libc.src.__support.macros.optimization
+)
+
+add_header_library(
   asinhf
   HDRS
     asinhf.h

--- a/libc/src/__support/math/asinh.h
+++ b/libc/src/__support/math/asinh.h
@@ -1,0 +1,79 @@
+//===-- Implementation header for asinh -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_ASINH_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_ASINH_H
+
+#include "log.h"
+#include "log1p.h"
+#include "src/__support/FPUtil/FEnvImpl.h"
+#include "src/__support/FPUtil/FPBits.h"
+#include "src/__support/FPUtil/sqrt.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+LIBC_INLINE double asinh(double x) {
+  using FPBits = fputil::FPBits<double>;
+  FPBits xbits(x);
+
+  // Handle NaN.
+  if (LIBC_UNLIKELY(xbits.is_nan())) {
+    if (xbits.is_signaling_nan()) {
+      fputil::raise_except_if_required(FE_INVALID);
+      return FPBits::quiet_nan().get_val();
+    }
+    return x;
+  }
+
+  // Handle +/-inf: asinh(+/-inf) = +/-inf.
+  if (LIBC_UNLIKELY(xbits.is_inf()))
+    return x;
+
+  uint64_t x_abs_u = xbits.abs().uintval();
+  double x_abs = xbits.abs().get_val();
+  bool is_neg = xbits.is_neg();
+
+  // For very small |x| (|x| <= 2^-26), asinh(x) ~ x.
+  // Use FP arithmetic to ensure FTZ/DAZ mode behavior.
+  if (LIBC_UNLIKELY(x_abs_u <= 0x3e50000000000000ULL)) {
+    // asinh(+/-0) = +/-0, preserve sign of zero exactly.
+    if (LIBC_UNLIKELY(x_abs_u == 0))
+      return x;
+    double x2 = x_abs * x_abs;
+    double result = x_abs - x2 * x_abs * (1.0 / 6.0);
+    return is_neg ? -result : result;
+  }
+
+  double result;
+  // For large |x| (|x| >= 2^28): asinh(x) ~ log(2|x|) = log(|x|) + log(2).
+  if (LIBC_UNLIKELY(x_abs_u >= 0x41b0000000000000ULL)) {
+    constexpr double LOG_2 = 0x1.62e42fefa39efp-1;
+    result = math::log(x_abs) + LOG_2;
+  } else if (x_abs_u >= 0x3fe0000000000000ULL) {
+    // |x| >= 0.5: asinh(x) = log(x + sqrt(x^2 + 1)).
+    result = math::log(x_abs + fputil::sqrt<double>(x_abs * x_abs + 1.0));
+  } else {
+    // |x| < 0.5: use log1p for better accuracy near 0.
+    // asinh(x) = log1p(x + x^2 / (1 + sqrt(1 + x^2)))
+    double x2 = x_abs * x_abs;
+    double sqrt1px2 = fputil::sqrt<double>(1.0 + x2);
+    result = math::log1p(x_abs + x2 / (1.0 + sqrt1px2));
+  }
+
+  return is_neg ? -result : result;
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_ASINH_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -3723,6 +3723,16 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  asinh
+  SRCS
+    asinh.cpp
+  HDRS
+    ../asinh.h
+  DEPENDS
+    libc.src.__support.math.asinh
+)
+
+add_entrypoint_object(
   asinhf
   SRCS
     asinhf.cpp

--- a/libc/src/math/generic/asinh.cpp
+++ b/libc/src/math/generic/asinh.cpp
@@ -1,0 +1,16 @@
+//===-- Double-precision asinh implementation -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/math/asinh.h"
+#include "src/__support/math/asinh.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(double, asinh, (double x)) { return math::asinh(x); }
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/test/src/math/CMakeLists.txt
+++ b/libc/test/src/math/CMakeLists.txt
@@ -2442,6 +2442,18 @@ add_fp_unittest(
 )
 
 add_fp_unittest(
+  asinh_test
+  NEED_MPFR
+  SUITE
+    libc-math-unittests
+  SRCS
+    asinh_test.cpp
+  DEPENDS
+    libc.src.math.asinh
+    libc.src.__support.FPUtil.fp_bits
+)
+
+add_fp_unittest(
   asinhf_test
   NEED_MPFR
   SUITE

--- a/libc/test/src/math/asinh_test.cpp
+++ b/libc/test/src/math/asinh_test.cpp
@@ -1,0 +1,99 @@
+//===-- Unittests for asinh -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/__support/FPUtil/FPBits.h"
+#include "src/math/asinh.h"
+#include "test/UnitTest/FPMatcher.h"
+#include "test/UnitTest/Test.h"
+#include "utils/MPFRWrapper/MPFRUtils.h"
+
+using LlvmLibcAsinhTest = LIBC_NAMESPACE::testing::FPTest<double>;
+
+namespace mpfr = LIBC_NAMESPACE::testing::mpfr;
+
+using LIBC_NAMESPACE::testing::tlog;
+
+TEST_F(LlvmLibcAsinhTest, InDoubleRange) {
+  // asinh is odd; test positive range [2^-26, 2^52] and negate for negatives.
+  constexpr uint64_t COUNT = 123'451;
+  uint64_t START = FPBits(0x1.0p-26).uintval();
+  uint64_t STOP = FPBits(0x1.0p52).uintval();
+  uint64_t STEP = (STOP - START) / COUNT;
+
+  auto test = [&](mpfr::RoundingMode rounding_mode) {
+    mpfr::ForceRoundingMode __r(rounding_mode);
+    if (!__r.success)
+      return;
+
+    uint64_t fails = 0;
+    uint64_t count = 0;
+    uint64_t cc = 0;
+    double mx = 0.0, mr = 0.0;
+    double tol = 0.5;
+
+    for (uint64_t i = 0, v = START; i <= COUNT; ++i, v += STEP) {
+      double x = FPBits(v).get_val();
+      if (FPBits(v).is_inf_or_nan())
+        continue;
+
+      // Test positive x.
+      double result = LIBC_NAMESPACE::asinh(x);
+      ++cc;
+      ++count;
+      if (!TEST_MPFR_MATCH_ROUNDING_SILENTLY(mpfr::Operation::Asinh, x, result,
+                                             0.5, rounding_mode)) {
+        ++fails;
+        while (!TEST_MPFR_MATCH_ROUNDING_SILENTLY(mpfr::Operation::Asinh, x,
+                                                  result, tol, rounding_mode)) {
+          mx = x;
+          mr = result;
+          if (tol > 1000.0)
+            break;
+          tol *= 2.0;
+        }
+      }
+
+      // Test negative x (asinh is odd).
+      double neg_x = -x;
+      double neg_result = LIBC_NAMESPACE::asinh(neg_x);
+      ++cc;
+      ++count;
+      if (!TEST_MPFR_MATCH_ROUNDING_SILENTLY(mpfr::Operation::Asinh, neg_x,
+                                             neg_result, 0.5, rounding_mode)) {
+        ++fails;
+        while (!TEST_MPFR_MATCH_ROUNDING_SILENTLY(mpfr::Operation::Asinh,
+                                                  neg_x, neg_result, tol,
+                                                  rounding_mode)) {
+          mx = neg_x;
+          mr = neg_result;
+          if (tol > 1000.0)
+            break;
+          tol *= 2.0;
+        }
+      }
+    }
+    if (fails) {
+      tlog << " Asinh failed: " << fails << "/" << count << "/" << cc
+           << " tests.\n";
+      tlog << "   Max ULPs is at most: " << static_cast<uint64_t>(tol) << ".\n";
+      EXPECT_MPFR_MATCH(mpfr::Operation::Asinh, mx, mr, 0.5, rounding_mode);
+    }
+  };
+
+  tlog << " Test Rounding To Nearest...\n";
+  test(mpfr::RoundingMode::Nearest);
+
+  tlog << " Test Rounding Downward...\n";
+  test(mpfr::RoundingMode::Downward);
+
+  tlog << " Test Rounding Upward...\n";
+  test(mpfr::RoundingMode::Upward);
+
+  tlog << " Test Rounding Toward Zero...\n";
+  test(mpfr::RoundingMode::TowardZero);
+}

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -4735,6 +4735,17 @@ add_fp_unittest(
 )
 
 add_fp_unittest(
+  asinh_test
+  SUITE
+    libc-math-smoke-tests
+  SRCS
+    asinh_test.cpp
+  DEPENDS
+    libc.src.math.asinh
+    libc.src.__support.FPUtil.fp_bits
+)
+
+add_fp_unittest(
   asinhf_test
   SUITE
     libc-math-smoke-tests

--- a/libc/test/src/math/smoke/asinh_test.cpp
+++ b/libc/test/src/math/smoke/asinh_test.cpp
@@ -1,0 +1,57 @@
+//===-- Unittests for asinh -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hdr/math_macros.h"
+#include "src/__support/FPUtil/FPBits.h"
+#include "src/math/asinh.h"
+#include "test/UnitTest/FPMatcher.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcAsinhTest = LIBC_NAMESPACE::testing::FPTest<double>;
+
+TEST_F(LlvmLibcAsinhTest, SpecialNumbers) {
+  EXPECT_FP_EQ_WITH_EXCEPTION(aNaN, LIBC_NAMESPACE::asinh(sNaN), FE_INVALID);
+
+  EXPECT_FP_EQ_ALL_ROUNDING(aNaN, LIBC_NAMESPACE::asinh(aNaN));
+
+  EXPECT_FP_EQ_ALL_ROUNDING(inf, LIBC_NAMESPACE::asinh(inf));
+  EXPECT_FP_EQ_ALL_ROUNDING(neg_inf, LIBC_NAMESPACE::asinh(neg_inf));
+
+  EXPECT_FP_EQ_ALL_ROUNDING(0.0, LIBC_NAMESPACE::asinh(0.0));
+  EXPECT_FP_EQ_ALL_ROUNDING(neg_zero, LIBC_NAMESPACE::asinh(neg_zero));
+}
+
+#ifdef LIBC_TEST_FTZ_DAZ
+
+using namespace LIBC_NAMESPACE::testing;
+
+TEST_F(LlvmLibcAsinhTest, FTZMode) {
+  ModifyMXCSR mxcsr(FTZ);
+
+  const double neg_min_denormal = FPBits::min_subnormal(Sign::NEG).get_val();
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::asinh(min_denormal));
+  EXPECT_FP_EQ(neg_zero, LIBC_NAMESPACE::asinh(neg_min_denormal));
+}
+
+TEST_F(LlvmLibcAsinhTest, DAZMode) {
+  ModifyMXCSR mxcsr(DAZ);
+
+  const double neg_min_denormal = FPBits::min_subnormal(Sign::NEG).get_val();
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::asinh(min_denormal));
+  EXPECT_FP_EQ(neg_zero, LIBC_NAMESPACE::asinh(neg_min_denormal));
+}
+
+TEST_F(LlvmLibcAsinhTest, FTZDAZMode) {
+  ModifyMXCSR mxcsr(FTZ | DAZ);
+
+  const double neg_min_denormal = FPBits::min_subnormal(Sign::NEG).get_val();
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::asinh(min_denormal));
+  EXPECT_FP_EQ(neg_zero, LIBC_NAMESPACE::asinh(neg_min_denormal));
+}
+
+#endif


### PR DESCRIPTION
This PR adds an implementation of the double-precision inverse hyperbolic sine function `asinh` to the `math` library.