### PR TITLE
[TySan] Remove incorrect memcpy shadow memory tracking

### DIFF
--- a/compiler-rt/lib/tysan/tysan.cpp
+++ b/compiler-rt/lib/tysan/tysan.cpp
@@ -331,8 +331,6 @@ __tysan_instrument_mem_inst(char *dest, char *src, uint64_t size,
 
   if (needsMemMove) {
     internal_memmove((char *)destShadowDataPtr, srcShadow, size << PtrShift());
-  } else {
-    internal_memcpy((char *)destShadowDataPtr, srcShadow, size << PtrShift());
   }
 }
 

--- a/compiler-rt/lib/tysan/tysan_interceptors.cpp
+++ b/compiler-rt/lib/tysan/tysan_interceptors.cpp
@@ -53,18 +53,6 @@ INTERCEPTOR(void *, memmove, void *dst, const void *src, uptr size) {
   return res;
 }
 
-INTERCEPTOR(void *, memcpy, void *dst, const void *src, uptr size) {
-  if (!tysan_inited && REAL(memcpy) == nullptr) {
-    // memmove is used here because on some platforms this will also
-    // intercept the memmove implementation.
-    return internal_memmove(dst, src, size);
-  }
-
-  void *res = REAL(memcpy)(dst, src, size);
-  tysan_copy_types(dst, src, size);
-  return res;
-}
-
 INTERCEPTOR(void *, mmap, void *addr, SIZE_T length, int prot, int flags,
             int fd, OFF_T offset) {
   void *res = REAL(mmap)(addr, length, prot, flags, fd, offset);
@@ -238,7 +226,6 @@ void InitializeInterceptors() {
 
   INTERCEPT_FUNCTION(memset);
   INTERCEPT_FUNCTION(memmove);
-  INTERCEPT_FUNCTION(memcpy);
 
   inited = 1;
 }

--- a/compiler-rt/test/tysan/global.c
+++ b/compiler-rt/test/tysan/global.c
@@ -12,20 +12,12 @@ int main() {
   // CHECK: WRITE of size 4 at {{.*}} with type int accesses an existing object of type float
   // CHECK: {{#0 0x.* in main .*global.c:}}[[@LINE-3]]
 
-  void *mem = malloc(sizeof(long));
-  *(int *)mem = 6;
-  memcpy(mem, &L, sizeof(L));
-  *(int *)mem = 8;
+  P = *(((float *)&L) + 1);
   // CHECK: ERROR: TypeSanitizer: type-aliasing-violation
-  // CHECK: WRITE of size 4 at {{.*}} with type int accesses an existing object of type long
+  // CHECK: READ of size 4 at {{.*}} with type float accesses part of an existing object of type long that starts at offset -4
   // CHECK: {{#0 0x.* in main .*global.c:}}[[@LINE-3]]
-  int r = *(((int *)mem) + 1);
-  // CHECK: ERROR: TypeSanitizer: type-aliasing-violation
-  // CHECK: READ of size 4 at {{.*}} with type int accesses part of an existing object of type long that starts at offset -4
-  // CHECK: {{#0 0x.* in main .*global.c:}}[[@LINE-3]]
-  free(mem);
 
-  return r;
+  return 0;
 }
 
 // CHECK-NOT: ERROR: TypeSanitizer: type-aliasing-violation

--- a/compiler-rt/test/tysan/memcpy_doesnt_change_shadow.c
+++ b/compiler-rt/test/tysan/memcpy_doesnt_change_shadow.c
@@ -1,0 +1,25 @@
+// RUN: %clang_tysan -O0 %s -o %t && %run %t >%t.out 2>&1
+// RUN: FileCheck %s < %t.out
+
+#include <stdio.h>
+#include <string.h>
+
+int main() {
+
+  int i = 0;
+  float f = 5.0f;
+
+  *(float *)&i = 3.0f;
+  *(int *)&f = 2;
+  // CHECK: WRITE of size 4 at 0x{{.*}} with type float accesses an existing object of type int
+  // CHECK: WRITE of size 4 at 0x{{.*}} with type int accesses an existing object of type float
+
+  memcpy(&i, &f, sizeof(int));
+
+  *(float *)&i = 3.0f;
+  *(int *)&f = 2;
+  // CHECK: WRITE of size 4 at 0x{{.*}} with type int accesses an existing object of type float
+  // CHECK: WRITE of size 4 at 0x{{.*}} with type float accesses an existing object of type int
+
+  return 0;
+}

--- a/compiler-rt/test/tysan/memcpy_doesnt_change_shadow.c
+++ b/compiler-rt/test/tysan/memcpy_doesnt_change_shadow.c
@@ -18,8 +18,8 @@ int main() {
 
   *(float *)&i = 3.0f;
   *(int *)&f = 2;
-  // CHECK: WRITE of size 4 at 0x{{.*}} with type int accesses an existing object of type float
   // CHECK: WRITE of size 4 at 0x{{.*}} with type float accesses an existing object of type int
+  // CHECK: WRITE of size 4 at 0x{{.*}} with type int accesses an existing object of type float
 
   return 0;
 }


### PR DESCRIPTION
Fixes the false positive in https://github.com/llvm/llvm-project/issues/122934

memcpy is allowed to bypass strict aliasing rules (see https://en.cppreference.com/c/string/byte/memcpy) so we shouldn't alter shadow memory when it is used