### PR TITLE
[Object] Add missing BBAddrMap.def to module map

### DIFF
--- a/llvm/include/module.modulemap
+++ b/llvm/include/module.modulemap
@@ -313,6 +313,8 @@ module LLVM_Object {
   requires cplusplus
   umbrella "llvm/Object"
   module * { export * }
+
+  textual header "llvm/Object/BBAddrMap.def"
 }
 
 module LLVM_Option {


### PR DESCRIPTION
Added in 532940bdee66bf5f36a70578698aab66f16919af.