### PR TITLE
[SPIR-V] Insert service function when module has only declarations

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVPrepareFunctions.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPrepareFunctions.cpp
@@ -814,8 +814,8 @@ bool SPIRVPrepareFunctionsImpl::runOnModule(Module &M) {
       ->resolveEnvFromModule(M);
 
   bool Changed = false;
-  if (M.functions().empty()) {
-    // If there are no functions, insert a service
+  if (M.getFunctionDefs().empty()) {
+    // If there are no function definitions, insert a service
     // function so that the global/constant tracking intrinsics
     // will be created. Without these intrinsics the generated SPIR-V
     // will be empty. The service function itself is not emitted.

--- a/llvm/test/CodeGen/SPIRV/declarations-only-module.ll
+++ b/llvm/test/CodeGen/SPIRV/declarations-only-module.ll
@@ -1,0 +1,10 @@
+; Declarations-only module must still reach AsmPrinter.
+
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK-DAG: OpCapability Addresses
+; CHECK-DAG: OpCapability Kernel
+; CHECK:     OpMemoryModel Physical64 OpenCL
+
+declare spir_kernel void @fuzz_kernel(ptr addrspace(1), ptr addrspace(1), i32)


### PR DESCRIPTION
A declarations-only module produces no `MachineFunction` at all, `SPIRVModuleAnalysis` is freed before `AsmPrinter::doFinalization` and `outputModuleSections` asserts in `getAnalysis<SPIRVModuleAnalysis>()` which causes a failure