### PR TITLE
[clang] Fix assertion crash in alloc_size structural equivalence check (#199407)

### DIFF
--- a/clang/lib/AST/AttrImpl.cpp
+++ b/clang/lib/AST/AttrImpl.cpp
@@ -306,16 +306,17 @@ equalAttrArgs(T A1, T A2, StructuralEquivalenceContext &Context) {
   return A1 == A2;
 }
 
-// ParamIdx has an explicit specialization because it can be invalid (when
-// representing an optional parameter that was not specified).  Two invalid
-// ParamIdx values compare equal; an invalid value is not equal to any valid
-// one.  ParamIdx::operator== asserts both sides are valid, so we must guard
-// against the invalid case here before delegating to operator==.
 template <>
 bool equalAttrArgs<ParamIdx>(ParamIdx P1, ParamIdx P2,
                              StructuralEquivalenceContext &) {
-  if (!P1.isValid() || !P2.isValid())
-    return P1.isValid() == P2.isValid();
+  // ParamIdx can be invalid when representing an optional parameter that was
+  // not specified (e.g. the second argument of alloc_size(N)).
+  // ParamIdx::operator== asserts both sides are valid, so guard against the
+  // invalid case before delegating to it.
+  if (P1.isValid() != P2.isValid())
+    return false;
+  if (!P1.isValid())
+    return true;
   return P1 == P2;
 }
 

--- a/clang/lib/AST/AttrImpl.cpp
+++ b/clang/lib/AST/AttrImpl.cpp
@@ -291,8 +291,8 @@ namespace {
 //  - VariadicOMPInteropInfoArgument
 #define USE_DEFAULT_EQUALITY                                                   \
   (std::is_same_v<T, StringRef> || std::is_same_v<T, VersionTuple> ||          \
-   std::is_same_v<T, IdentifierInfo *> || std::is_same_v<T, ParamIdx> ||       \
-   std::is_same_v<T, char *> || std::is_enum_v<T> || std::is_integral_v<T>)
+   std::is_same_v<T, IdentifierInfo *> || std::is_same_v<T, char *> ||         \
+   std::is_enum_v<T> || std::is_integral_v<T>)
 
 template <class T>
 typename std::enable_if_t<!USE_DEFAULT_EQUALITY, bool>
@@ -304,6 +304,19 @@ template <class T>
 typename std::enable_if_t<USE_DEFAULT_EQUALITY, bool>
 equalAttrArgs(T A1, T A2, StructuralEquivalenceContext &Context) {
   return A1 == A2;
+}
+
+// ParamIdx has an explicit specialization because it can be invalid (when
+// representing an optional parameter that was not specified).  Two invalid
+// ParamIdx values compare equal; an invalid value is not equal to any valid
+// one.  ParamIdx::operator== asserts both sides are valid, so we must guard
+// against the invalid case here before delegating to operator==.
+template <>
+bool equalAttrArgs<ParamIdx>(ParamIdx P1, ParamIdx P2,
+                             StructuralEquivalenceContext &) {
+  if (!P1.isValid() || !P2.isValid())
+    return P1.isValid() == P2.isValid();
+  return P1 == P2;
 }
 
 template <class T>

--- a/clang/test/Sema/alloc-size.c
+++ b/clang/test/Sema/alloc-size.c
@@ -58,3 +58,11 @@ int main() {
   my_malloc_fn_pointer_type f3 = fn2;
   my_other_malloc_fn_pointer_type f4 = fn2;
 }
+
+// Regression test for GH199407: structural equivalence of alloc_size attrs
+// with an unset optional ParamIdx must not crash.
+#define GH199407(Ty, Name) _Alignas(Ty) char Name[sizeof(Ty)]
+GH199407(struct GH199407S { float *f(long) __attribute__((alloc_size(1))); }, gbuf);  // expected-error 2{{field 'f' declared as a function}} expected-error{{redefinition of 'GH199407S'}} expected-note{{previous definition is here}}
+// nonnull uses a VariadicParamIdx whose elements are always valid; verify no
+// regression for the valid-ParamIdx path in equalAttrArgs<ParamIdx>.
+GH199407(struct GH199407T { void *g(void *p) __attribute__((nonnull(1))); }, gbuf2); // expected-error 2{{field 'g' declared as a function}} expected-error{{redefinition of 'GH199407T'}} expected-note{{previous definition is here}}

--- a/clang/test/Sema/alloc-size.c
+++ b/clang/test/Sema/alloc-size.c
@@ -63,6 +63,3 @@ int main() {
 // with an unset optional ParamIdx must not crash.
 #define GH199407(Ty, Name) _Alignas(Ty) char Name[sizeof(Ty)]
 GH199407(struct GH199407S { float *f(long) __attribute__((alloc_size(1))); }, gbuf);  // expected-error 2{{field 'f' declared as a function}} expected-error{{redefinition of 'GH199407S'}} expected-note{{previous definition is here}}
-// nonnull uses a VariadicParamIdx whose elements are always valid; verify no
-// regression for the valid-ParamIdx path in equalAttrArgs<ParamIdx>.
-GH199407(struct GH199407T { void *g(void *p) __attribute__((nonnull(1))); }, gbuf2); // expected-error 2{{field 'g' declared as a function}} expected-error{{redefinition of 'GH199407T'}} expected-note{{previous definition is here}}

--- a/clang/test/Sema/attr-nonnull.c
+++ b/clang/test/Sema/attr-nonnull.c
@@ -6,3 +6,8 @@ void f1(int *a1, int *a2, int *a3, int *a4, int *a5, int *a6, int *a7,
         int *a15, int *a16) __attribute__((nonnull(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)));
 
 void f2(void) __attribute__((nonnull())); // expected-warning {{'nonnull' attribute applied to function with no pointer arguments}}
+
+// Regression test for GH199407: verify no crash when structural equivalence
+// checks nonnull attrs with VariadicParamIdx (always-valid) elements.
+#define GH199407(Ty, Name) _Alignas(Ty) char Name[sizeof(Ty)]
+GH199407(struct GH199407T { void *g(void *p) __attribute__((nonnull(1))); }, gbuf); // expected-error 2{{field 'g' declared as a function}} expected-error{{redefinition of 'GH199407T'}} expected-note{{previous definition is here}}

--- a/clang/test/Sema/gh199407.c
+++ b/clang/test/Sema/gh199407.c
@@ -1,7 +1,0 @@
-// RUN: %clang_cc1 -std=c23 -fsyntax-only -verify %s
-
-// Regression test for https://github.com/llvm/llvm-project/issues/199407
-
-#define FOO(Ty, Name) alignas(Ty) char Name[sizeof(Ty)]
-
-FOO(struct S { float *malloc(long) __attribute__((alloc_size(1))); }, buffer); // expected-error 2{{field 'malloc' declared as a function}}

--- a/clang/test/Sema/gh199407.c
+++ b/clang/test/Sema/gh199407.c
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -std=c23 -fsyntax-only -verify %s
+
+// Regression test for https://github.com/llvm/llvm-project/issues/199407
+
+#define FOO(Ty, Name) alignas(Ty) char Name[sizeof(Ty)]
+
+FOO(struct S { float *malloc(long) __attribute__((alloc_size(1))); }, buffer); // expected-error 2{{field 'malloc' declared as a function}}


### PR DESCRIPTION
Fixes #199407

Remove ParamIdx from the `USE_DEFAULT_EQUALITY` default-comparison path and add an explicit `equalAttrArgs<ParamIdx>` specialization that safely handles invalid (unset) values.
