### PR TITLE
[clang][bytecode] `Pointer::computeOffsetForComparison()` can fail

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -1242,9 +1242,11 @@ inline bool CmpHelper<Pointer>(InterpState &S, CodePtr OpPC, CompareFn Fn) {
     }
   }
 
-  unsigned VL = LHS.computeOffsetForComparison(S.getASTContext());
-  unsigned VR = RHS.computeOffsetForComparison(S.getASTContext());
-  S.Stk.push<BoolT>(BoolT::from(Fn(Compare(VL, VR))));
+  std::optional<size_t> VL = LHS.computeOffsetForComparison(S.getASTContext());
+  std::optional<size_t> VR = RHS.computeOffsetForComparison(S.getASTContext());
+  if (!VL || !VR)
+    return Invalid(S, OpPC);
+  S.Stk.push<BoolT>(BoolT::from(Fn(Compare(*VL, *VR))));
   return true;
 }
 
@@ -1315,10 +1317,12 @@ inline bool CmpHelperEQ<Pointer>(InterpState &S, CodePtr OpPC, CompareFn Fn) {
   }
 
   if (Pointer::hasSameBase(LHS, RHS)) {
-    size_t A = LHS.computeOffsetForComparison(S.getASTContext());
-    size_t B = RHS.computeOffsetForComparison(S.getASTContext());
+    std::optional<size_t> A = LHS.computeOffsetForComparison(S.getASTContext());
+    std::optional<size_t> B = RHS.computeOffsetForComparison(S.getASTContext());
+    if (!A || !B)
+      return Invalid(S, OpPC);
 
-    S.Stk.push<BoolT>(BoolT::from(Fn(Compare(A, B))));
+    S.Stk.push<BoolT>(BoolT::from(Fn(Compare(*A, *B))));
     return true;
   }
 

--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -359,9 +359,13 @@ void Pointer::print(llvm::raw_ostream &OS) const {
 /// with the same base. To get accurate results, we basically _have to_ compute
 /// the lvalue offset using the ASTRecordLayout.
 ///
-/// FIXME: We're still mixing values from the record layout with our internal
-/// offsets, which will inevitably lead to cryptic errors.
-size_t Pointer::computeOffsetForComparison(const ASTContext &ASTCtx) const {
+/// This function will fail if we're trying to get the type size of a forward
+/// declaration.
+///
+// FIXME: We're still mixing values from the record layout with our internal
+// offsets, which will inevitably lead to cryptic errors.
+std::optional<size_t>
+Pointer::computeOffsetForComparison(const ASTContext &ASTCtx) const {
   switch (StorageKind) {
   case Storage::Int:
     return Int.Value + Offset;
@@ -373,6 +377,15 @@ size_t Pointer::computeOffsetForComparison(const ASTContext &ASTCtx) const {
   case Storage::Typeid:
     return reinterpret_cast<uintptr_t>(asTypeidPointer().TypePtr) + Offset;
   }
+
+  auto getTypeSize = [&](QualType T) -> std::optional<size_t> {
+    if (const RecordType *RT = T->getAs<RecordType>()) {
+      // We cannot get the type size of a forward declaration.
+      if (!RT->getDecl()->getDefinition())
+        return std::nullopt;
+    }
+    return ASTCtx.getTypeSizeInChars(T).getQuantity();
+  };
 
   size_t Result = 0;
   Pointer P = *this;
@@ -397,9 +410,12 @@ size_t Pointer::computeOffsetForComparison(const ASTContext &ASTCtx) const {
     }
 
     if (P.isRoot()) {
-      if (P.isOnePastEnd())
-        Result +=
-            ASTCtx.getTypeSizeInChars(P.getDeclDesc()->getType()).getQuantity();
+      if (P.isOnePastEnd()) {
+        if (auto Size = getTypeSize(P.getDeclDesc()->getType()))
+          Result += *Size;
+        else
+          return std::nullopt;
+      }
       break;
     }
 
@@ -413,9 +429,12 @@ size_t Pointer::computeOffsetForComparison(const ASTContext &ASTCtx) const {
                       Layout.getFieldOffset(P.getField()->getFieldIndex()))
                   .getQuantity();
 
-    if (P.isOnePastEnd())
-      Result +=
-          ASTCtx.getTypeSizeInChars(P.getField()->getType()).getQuantity();
+    if (P.isOnePastEnd()) {
+      if (auto Size = getTypeSize(P.getField()->getType()))
+        Result += *Size;
+      else
+        return std::nullopt;
+    }
 
     P = P.getBase();
     if (P.isRoot())

--- a/clang/lib/AST/ByteCode/Pointer.h
+++ b/clang/lib/AST/ByteCode/Pointer.h
@@ -843,7 +843,8 @@ public:
   /// Compute an integer that can be used to compare this pointer to
   /// another one. This is usually NOT the same as the pointer offset
   /// regarding the AST record layout.
-  size_t computeOffsetForComparison(const ASTContext &ASTCtx) const;
+  std::optional<size_t>
+  computeOffsetForComparison(const ASTContext &ASTCtx) const;
 
 private:
   friend class Block;

--- a/clang/test/AST/ByteCode/const-eval.c
+++ b/clang/test/AST/ByteCode/const-eval.c
@@ -189,3 +189,7 @@ _Static_assert(((union ToUnion_U)9).z == 1, "");
 struct S s; // both-error {{tentative definition has type 'struct S' that is never completed}} \
             // both-note {{forward declaration of 'struct S'}}
 int foo[2 * ((long)&s + 42i) == 2]; // both-error {{variable length array declaration not allowed at file scope}}
+
+struct FD fd; // both-error {{tentative definition has type 'struct FD' that is never completed}} \
+              // both-note {{forward declaration of 'struct FD'}}
+EVAL_EXPR(55, &fd < (struct FD *)((int *)&fd + 42)) // both-error {{not an integer constant expression}}


### PR DESCRIPTION
It used to cause an assertion failure inside
`ASTContext::getTypeSizeInChars()` when the reocord decl was not defined.