### PR TITLE
[SPIR-V] Reject module-level inline assembly with a diagnostic

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
@@ -899,8 +899,8 @@ void SPIRVAsmPrinter::outputModuleSections() {
 bool SPIRVAsmPrinter::doInitialization(Module &M) {
   ModuleSectionsEmitted = false;
   if (!M.getModuleInlineAsm().empty())
-    report_fatal_error(
-        "SPIR-V does not support module-level inline assembly", false);
+    report_fatal_error("SPIR-V does not support module-level inline assembly",
+                       false);
 
   // Register the NSDI handler before calling the base class so that
   // AsmPrinter::doInitialization() calls Handler->beginModule(M) for it.

--- a/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
@@ -898,9 +898,11 @@ void SPIRVAsmPrinter::outputModuleSections() {
 
 bool SPIRVAsmPrinter::doInitialization(Module &M) {
   ModuleSectionsEmitted = false;
-  if (!M.getModuleInlineAsm().empty())
-    report_fatal_error("SPIR-V does not support module-level inline assembly",
-                       false);
+  if (!M.getModuleInlineAsm().empty()) {
+    M.getContext().emitError(
+        "SPIR-V does not support module-level inline assembly");
+    M.setModuleInlineAsm("");
+  }
 
   // Register the NSDI handler before calling the base class so that
   // AsmPrinter::doInitialization() calls Handler->beginModule(M) for it.

--- a/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
@@ -898,6 +898,10 @@ void SPIRVAsmPrinter::outputModuleSections() {
 
 bool SPIRVAsmPrinter::doInitialization(Module &M) {
   ModuleSectionsEmitted = false;
+  if (!M.getModuleInlineAsm().empty())
+    report_fatal_error(
+        "SPIR-V does not support module-level inline assembly", false);
+
   // Register the NSDI handler before calling the base class so that
   // AsmPrinter::doInitialization() calls Handler->beginModule(M) for it.
   if (M.getNamedMetadata("llvm.dbg.cu")) {

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_inline_assembly/module_asm_unsupported.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_inline_assembly/module_asm_unsupported.ll
@@ -5,7 +5,7 @@
 ; The backend must reject it with a clean diagnostic
 ; rather than reach the unimplemented MC asm parser path.
 
-; CHECK: LLVM ERROR: SPIR-V does not support module-level inline assembly
+; CHECK: error: SPIR-V does not support module-level inline assembly
 
 module asm "foo"
 

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_inline_assembly/module_asm_unsupported.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_inline_assembly/module_asm_unsupported.ll
@@ -1,0 +1,15 @@
+; RUN: not llc -O0 -mtriple=spirv32-unknown-unknown %s -o /dev/null 2>&1 | FileCheck %s
+; RUN: not llc -O0 -mtriple=spirv64-unknown-unknown %s -o /dev/null 2>&1 | FileCheck %s
+
+; SPIR-V has no binary analog for module-level inline assembly.
+; The backend must reject it with a clean diagnostic
+; rather than reach the unimplemented MC asm parser path.
+
+; CHECK: LLVM ERROR: SPIR-V does not support module-level inline assembly
+
+module asm "foo"
+
+define void @main() {
+entry:
+  ret void
+}


### PR DESCRIPTION
Module level inline asm is unsupported, even with extension