### PR TITLE
[AMDGPU] Fix SuperReg to MCRegister conversion

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIFrameLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFrameLowering.cpp
@@ -448,7 +448,7 @@ class PrologEpilogSGPRSpillBuilder {
 
     for (unsigned I = 0, DwordOff = 0; I < NumSubRegs; ++I) {
       MCRegister SubReg = NumSubRegs == 1
-                              ? MCRegister(SuperReg)
+                              ? SuperReg.asMCReg()
                               : TRI.getSubReg(SuperReg, SplitParts[I]);
 
       buildEpilogRestore(ST, TRI, *FuncInfo, LiveUnits, MF, MBB, MI, DL,
@@ -469,7 +469,7 @@ class PrologEpilogSGPRSpillBuilder {
 
     for (unsigned I = 0; I < NumSubRegs; ++I) {
       MCRegister SubReg = NumSubRegs == 1
-                              ? MCRegister(SuperReg)
+                              ? SuperReg.asMCReg()
                               : TRI.getSubReg(SuperReg, SplitParts[I]);
       BuildMI(MBB, MI, DL, TII->get(AMDGPU::SI_RESTORE_S32_FROM_VGPR), SubReg)
           .addReg(Spill[I].VGPR)


### PR DESCRIPTION
This is a fix for "[AMDGPU] Implement CFI for non-kernel functions (#183153)" f78a233ac89dc0f9f0f26dfe051874013ae6e242 to use "SuperReg.asMCReg()" instead of "MCRegister(SuperReg)", which leads to "ambiguous call" when using the MSVC compiler.