### PR TITLE
[Clang][Sema] Move err_seh_object_unwinding diagnostic from CodeGen to Sema

### DIFF
--- a/clang/include/clang/Sema/ScopeInfo.h
+++ b/clang/include/clang/Sema/ScopeInfo.h
@@ -238,6 +238,11 @@ public:
   /// prior to being emitted.
   SmallVector<PossiblyUnreachableDiag, 4> PossiblyUnreachableDiags;
 
+  /// Source locations of declarations or expressions that require object
+  /// unwinding (non-trivial destruction or throwing new-expressions).
+  /// Checked against SEH __try usage at function end.
+  SmallVector<SourceLocation, 4> ObjUnwindingLocs;
+
   /// A list of parameters which have the nonnull attribute and are
   /// modified in the function.
   llvm::SmallPtrSet<const ParmVarDecl *, 8> ModifiedNonNullParams;

--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -2228,13 +2228,8 @@ void CodeGenFunction::EmitAutoVarCleanups(const AutoVarEmission &emission) {
   const VarDecl &D = *emission.Variable;
 
   // Check the type for a cleanup.
-  if (QualType::DestructionKind dtorKind = D.needsDestruction(getContext())) {
-    // Check if we're in a SEH block with /EH, prevent it
-    if (getLangOpts().CXXExceptions && currentFunctionUsesSEHTry())
-      getContext().getDiagnostics().Report(D.getLocation(),
-                                           diag::err_seh_object_unwinding);
+  if (QualType::DestructionKind dtorKind = D.needsDestruction(getContext()))
     emitAutoVarTypeCleanup(emission, dtorKind);
-  }
 
   // In GC mode, honor objc_precise_lifetime.
   if (getLangOpts().getGC() != LangOptions::NonGC &&

--- a/clang/lib/CodeGen/CGException.cpp
+++ b/clang/lib/CodeGen/CGException.cpp
@@ -2247,17 +2247,6 @@ void CodeGenFunction::ExitSEHTryStmt(const SEHTryStmt &S) {
   // TODO: Model unwind edges from instructions, either with iload / istore or
   // a try body function.
   if (!CatchScope.hasEHBranches()) {
-    // Even though we skip emitting the __except body, diagnose variables
-    // with non-trivial destructors that would normally be caught by
-    // EmitAutoVarCleanups.
-    if (getLangOpts().CXXExceptions && currentFunctionUsesSEHTry())
-      for (const Stmt *S : Except->getBlock()->body())
-        if (const auto *DS = dyn_cast<DeclStmt>(S))
-          for (const Decl *D : DS->decls())
-            if (const auto *VD = dyn_cast<VarDecl>(D))
-              if (VD->needsDestruction(getContext()))
-                getContext().getDiagnostics().Report(
-                    VD->getLocation(), diag::err_seh_object_unwinding);
     CatchScope.clearHandlerBlocks();
     EHStack.popCatch();
     SEHCodeSlotStack.pop_back();

--- a/clang/lib/CodeGen/CGExprCXX.cpp
+++ b/clang/lib/CodeGen/CGExprCXX.cpp
@@ -1720,18 +1720,6 @@ llvm::Value *CodeGenFunction::EmitCXXNewExpr(const CXXNewExpr *E) {
   llvm::Instruction *cleanupDominator = nullptr;
   if (E->getOperatorDelete() &&
       !E->getOperatorDelete()->isReservedGlobalPlacementOperator()) {
-    // A potentially-throwing constructor inside __try requires C++ object
-    // unwinding, which is incompatible with SEH.
-    if (getLangOpts().CXXExceptions && currentFunctionUsesSEHTry()) {
-      if (const auto *ConstructExpr = E->getConstructExpr()) {
-        const auto *FPT = ConstructExpr->getConstructor()
-                              ->getType()
-                              ->castAs<FunctionProtoType>();
-        if (!FPT->isNothrow())
-          getContext().getDiagnostics().Report(E->getBeginLoc(),
-                                               diag::err_seh_object_unwinding);
-      }
-    }
     EnterNewDeleteCleanup(*this, E, TypeIdentityArg, allocation, allocSize,
                           allocAlign, allocatorArgs);
     operatorDeleteCleanup = EHStack.stable_begin();

--- a/clang/lib/CodeGen/CGExprCXX.cpp
+++ b/clang/lib/CodeGen/CGExprCXX.cpp
@@ -1731,18 +1731,6 @@ llvm::Value *CodeGenFunction::EmitCXXNewExpr(const CXXNewExpr *E) {
   llvm::Instruction *cleanupDominator = nullptr;
   if (E->getOperatorDelete() &&
       !E->getOperatorDelete()->isReservedGlobalPlacementOperator()) {
-    // A potentially-throwing constructor inside __try requires C++ object
-    // unwinding, which is incompatible with SEH.
-    if (getLangOpts().CXXExceptions && currentFunctionUsesSEHTry()) {
-      if (const auto *ConstructExpr = E->getConstructExpr()) {
-        const auto *FPT = ConstructExpr->getConstructor()
-                              ->getType()
-                              ->castAs<FunctionProtoType>();
-        if (!FPT->isNothrow())
-          getContext().getDiagnostics().Report(E->getBeginLoc(),
-                                               diag::err_seh_object_unwinding);
-      }
-    }
     EnterNewDeleteCleanup(*this, E, TypeIdentityArg, allocation, allocSize,
                           allocAlign, allocatorArgs);
     operatorDeleteCleanup = EHStack.stable_begin();

--- a/clang/lib/Sema/ScopeInfo.cpp
+++ b/clang/lib/Sema/ScopeInfo.cpp
@@ -54,6 +54,7 @@ void FunctionScopeInfo::Clear() {
   ErrorTrap.reset();
   PossiblyUnreachableDiags.clear();
   WeakObjectUses.clear();
+  ObjUnwindingLocs.clear();
   ModifiedNonNullParams.clear();
   Blocks.clear();
   ByrefBlockVars.clear();

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -14931,6 +14931,9 @@ void Sema::CheckCompleteVariableDeclaration(VarDecl *var) {
       var->getType().isDestructedType() == QualType::DK_nontrivial_c_struct)
     setFunctionHasBranchProtectedScope();
 
+  if (var->hasLocalStorage() && var->needsDestruction(Context))
+    getCurFunction()->ObjUnwindingLocs.push_back(var->getLocation());
+
   // Warn about externally-visible variables being defined without a
   // prior declaration.  We only want to do this for global
   // declarations, but we also specifically need to avoid doing it for
@@ -16669,6 +16672,10 @@ Decl *Sema::ActOnFinishFunctionBody(Decl *dcl, Stmt *Body, bool IsInstantiation,
   sema::AnalysisBasedWarnings::Policy WP =
       AnalysisWarnings.getPolicyInEffectAt(AnalysisLoc);
   sema::AnalysisBasedWarnings::Policy *ActivePolicy = nullptr;
+
+  if (getLangOpts().CXXExceptions && FD && FD->usesSEHTry())
+    for (SourceLocation Loc : FSI->ObjUnwindingLocs)
+      Diag(Loc, diag::err_seh_object_unwinding);
 
   // If we skip function body, we can't tell if a function is a coroutine.
   if (getLangOpts().Coroutines && FD && !FD->hasSkippedBody()) {

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -2671,6 +2671,18 @@ ExprResult Sema::BuildCXXNew(SourceRange Range, bool UseGlobal,
     }
   }
 
+  if (FunctionScopeInfo *FSI = getCurFunction()) {
+    if (OperatorDelete &&
+        !OperatorDelete->isReservedGlobalPlacementOperator()) {
+      if (const auto *CCE = dyn_cast_or_null<CXXConstructExpr>(Initializer)) {
+        const auto *FPT =
+            CCE->getConstructor()->getType()->castAs<FunctionProtoType>();
+        if (!FPT->isNothrow())
+          FSI->ObjUnwindingLocs.push_back(StartLoc);
+      }
+    }
+  }
+
   return CXXNewExpr::Create(Context, UseGlobal, OperatorNew, OperatorDelete,
                             IAP, UsualArrayDeleteWantsSize, PlacementArgs,
                             TypeIdParens, ArraySize, InitStyle, Initializer,


### PR DESCRIPTION
Track local variables needing destruction and throwing new-expressions in FunctionScopeInfo::ObjUnwindingLocs during declaration processing,then check against usesSEHTry() at function end