### PR TITLE
[SPIR-V] Add s128 to allPtrsScalarsAndVectors in legalizer

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -103,9 +103,9 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
   auto allPtrsScalarsAndVectors = {
       p0,    p1,    p2,    p3,    p4,    p5,     p6,     p7,    p8,
       p9,    p10,   p11,   p12,   p13,   s1,     s8,     s16,   s32,
-      s64,   v2s1,  v2s8,  v2s16, v2s32, v2s64,  v3s1,   v3s8,  v3s16,
-      v3s32, v3s64, v4s1,  v4s8,  v4s16, v4s32,  v4s64,  v8s1,  v8s8,
-      v8s16, v8s32, v8s64, v16s1, v16s8, v16s16, v16s32, v16s64};
+      s64,   s128,  v2s1,  v2s8,  v2s16, v2s32,  v2s64,  v3s1,  v3s8,
+      v3s16, v3s32, v3s64, v4s1,  v4s8,  v4s16,  v4s32,  v4s64, v8s1,
+      v8s8,  v8s16, v8s32, v8s64, v16s1, v16s8,  v16s16, v16s32, v16s64};
 
   auto allVectors = {v2s1,  v2s8,   v2s16,  v2s32, v2s64, v3s1,  v3s8,
                      v3s16, v3s32,  v3s64,  v4s1,  v4s8,  v4s16, v4s32,

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -101,11 +101,11 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
 
   // TODO: remove copy-pasting here by using concatenation in some way.
   auto allPtrsScalarsAndVectors = {
-      p0,    p1,    p2,    p3,    p4,    p5,     p6,     p7,    p8,
-      p9,    p10,   p11,   p12,   p13,   s1,     s8,     s16,   s32,
-      s64,   s128,  v2s1,  v2s8,  v2s16, v2s32,  v2s64,  v3s1,  v3s8,
-      v3s16, v3s32, v3s64, v4s1,  v4s8,  v4s16,  v4s32,  v4s64, v8s1,
-      v8s8,  v8s16, v8s32, v8s64, v16s1, v16s8,  v16s16, v16s32, v16s64};
+      p0,    p1,    p2,    p3,    p4,    p5,    p6,     p7,     p8,
+      p9,    p10,   p11,   p12,   p13,   s1,    s8,     s16,    s32,
+      s64,   s128,  v2s1,  v2s8,  v2s16, v2s32, v2s64,  v3s1,   v3s8,
+      v3s16, v3s32, v3s64, v4s1,  v4s8,  v4s16, v4s32,  v4s64,  v8s1,
+      v8s8,  v8s16, v8s32, v8s64, v16s1, v16s8, v16s16, v16s32, v16s64};
 
   auto allVectors = {v2s1,  v2s8,   v2s16,  v2s32, v2s64, v3s1,  v3s8,
                      v3s16, v3s32,  v3s64,  v4s1,  v4s8,  v4s16, v4s32,

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_ALTERA_arbitrary_precision_integers/i128-icmp.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_ALTERA_arbitrary_precision_integers/i128-icmp.ll
@@ -1,0 +1,32 @@
+; RUN: not llc -O0 -mtriple=spirv64-unknown-unknown %s -o %t.spvt 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
+
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_ALTERA_arbitrary_precision_integers %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_ALTERA_arbitrary_precision_integers %s -o - -filetype=obj | spirv-val %}
+
+; Without the extension, i128 cannot be lowered: the diagnostic must come from
+; OpTypeInt emission, not a legalizer "unable to legalize G_ICMP" failure.
+
+; CHECK-ERROR: LLVM ERROR: OpTypeInt type with a width other than 8, 16, 32 or 64 bits requires the following SPIR-V extension: SPV_ALTERA_arbitrary_precision_integers
+
+; CHECK: OpCapability ArbitraryPrecisionIntegersALTERA
+; CHECK: OpExtension "SPV_ALTERA_arbitrary_precision_integers"
+; CHECK-DAG: %[[#BoolTy:]] = OpTypeBool
+; CHECK-DAG: %[[#Int128Ty:]] = OpTypeInt 128 0
+
+; CHECK: OpFunction
+; CHECK: %{{[0-9]+}} = OpSGreaterThan %[[#BoolTy]]
+; CHECK: %{{[0-9]+}} = OpIEqual %[[#BoolTy]]
+; CHECK: %{{[0-9]+}} = OpULessThan %[[#BoolTy]]
+define spir_func void @test_icmp_i128(i128 %a, i128 %b, ptr %out) {
+entry:
+  %sgt = icmp sgt i128 %a, %b
+  %eq = icmp eq i128 %a, %b
+  %ult = icmp ult i128 %a, %b
+  %t1 = zext i1 %sgt to i32
+  %t2 = zext i1 %eq to i32
+  %t3 = zext i1 %ult to i32
+  store i32 %t1, ptr %out
+  store i32 %t2, ptr %out
+  store i32 %t3, ptr %out
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_ALTERA_arbitrary_precision_integers/i128-icmp.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_ALTERA_arbitrary_precision_integers/i128-icmp.ll
@@ -14,9 +14,9 @@
 ; CHECK-DAG: %[[#Int128Ty:]] = OpTypeInt 128 0
 
 ; CHECK: OpFunction
-; CHECK: %{{[0-9]+}} = OpSGreaterThan %[[#BoolTy]]
-; CHECK: %{{[0-9]+}} = OpIEqual %[[#BoolTy]]
-; CHECK: %{{[0-9]+}} = OpULessThan %[[#BoolTy]]
+; CHECK: [[#]] = OpSGreaterThan %[[#BoolTy]]
+; CHECK: [[#]] = OpIEqual %[[#BoolTy]]
+; CHECK: [[#]] = OpULessThan %[[#BoolTy]]
 define spir_func void @test_icmp_i128(i128 %a, i128 %b, ptr %out) {
 entry:
   %sgt = icmp sgt i128 %a, %b


### PR DESCRIPTION
Without this, i128 G_ICMP fails legalization before OpTypeInt emits the diagnostic