### PR TITLE
[bazel][BBAddrMap] add include/llvm/Object/*.def as headers

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -1304,6 +1304,7 @@ cc_library(
         "lib/Object/*.h",
     ]),
     hdrs = glob([
+        "include/llvm/Object/*.def",
         "include/llvm/Object/*.h",
     ]) + [
         "include/llvm-c/Object.h",


### PR DESCRIPTION
This change adapts the bazel build system for the change in: [BBAddrMap] Drive Features and Metadata bits from BBAddrMap.def (#196906) commit 532940bdee66bf5f36a70578698aab66f16919af
The commit had added a .def file, which was not found by the glob for .h in the bazel build file. This change adds a glob for *.def to fix this.