### PR TITLE
[clangd][Mangler] Drop unknown compile options

### DIFF
--- a/clang-tools-extra/clangd/CompileCommands.cpp
+++ b/clang-tools-extra/clangd/CompileCommands.cpp
@@ -273,6 +273,19 @@ void CommandMangler::operator()(tooling::CompileCommand &Command,
       SawInput(Cmd[I]);
     Cmd.resize(DashDashIndex);
   }
+
+  llvm::SmallVector<const char *, 16> UnknownArgs;
+
+  for (auto *UnknownArg : ArgList.filtered(options::OPT_UNKNOWN)) {
+    UnknownArgs.push_back(UnknownArg->getValue());
+    IndicesToDrop.push_back(UnknownArg->getIndex());
+  }
+
+  if (!UnknownArgs.empty()) {
+    log("Warning: detected unsupported options '{0}'",
+        llvm::join(UnknownArgs, ", "));
+  }
+
   llvm::sort(IndicesToDrop);
   for (unsigned Idx : llvm::reverse(IndicesToDrop))
     // +1 to account for the executable name in Cmd[0] that

--- a/clang-tools-extra/clangd/unittests/CompileCommandsTests.cpp
+++ b/clang-tools-extra/clangd/unittests/CompileCommandsTests.cpp
@@ -525,6 +525,17 @@ TEST(CommandMangler, RespectsOriginalSysroot) {
                 Not(HasSubstr(testPath("fake/sysroot"))));
   }
 }
+TEST(CommandMangler, ClangUnknownArgs) {
+  // Check that clang++ will drop unknown flags
+  const auto Mangler = CommandMangler::forTests();
+  tooling::CompileCommand Cmd;
+  Cmd.CommandLine = {"clang++", "-std=c++23", "--unknown-flag",
+                     "--unknown-option=abcd"};
+  Mangler(Cmd, "foo.cc");
+  EXPECT_THAT(Cmd.CommandLine, Not(Contains("--unknown-flag")));
+  EXPECT_THAT(Cmd.CommandLine, Not(Contains("--unknown-option=abcd")));
+  EXPECT_THAT(Cmd.CommandLine, Contains("-std=c++23"));
+}
 
 TEST(CommandMangler, StdLatestFlag) {
   const auto Mangler = CommandMangler::forTests();


### PR DESCRIPTION
this pr remove the options that not work for clang, which will make compile failed for clang++, and this will make modules completions of clangd work. And we will also log the unsupported options