### PR TITLE
Add NVPTX DW_AT_LLVM_language_dialect emission.

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -1119,6 +1119,9 @@ void DwarfDebug::finishUnitAttributes(const DICompileUnit *DIUnit,
   }
 
   NewCU.addString(Die, dwarf::DW_AT_name, FN);
+
+  finishTargetUnitAttributes(*DIUnit, NewCU);
+
   StringRef SysRoot = DIUnit->getSysRoot();
   if (!SysRoot.empty())
     NewCU.addString(Die, dwarf::DW_AT_LLVM_sysroot, SysRoot);

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.h
@@ -734,6 +734,10 @@ protected:
   /// Target-specific source line recording.
   virtual void recordTargetSourceLine(const DebugLoc &DL, unsigned Flags);
 
+  /// Target-specific compile unit attribute finalization.
+  virtual void finishTargetUnitAttributes(const DICompileUnit &DIUnit,
+                                          DwarfCompileUnit &NewCU) {}
+
   const SmallVectorImpl<std::unique_ptr<DwarfCompileUnit>> &getUnits() {
     return InfoHolder.getUnits();
   }

--- a/llvm/lib/Target/NVPTX/NVPTXDwarfDebug.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXDwarfDebug.cpp
@@ -17,6 +17,7 @@
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineInstr.h"
 #include "llvm/IR/DebugInfoMetadata.h"
+#include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/MC/MCAsmInfo.h"
@@ -27,6 +28,9 @@
 #include "llvm/Target/TargetMachine.h"
 
 using namespace llvm;
+
+static constexpr uint16_t SimtDialect = dwarf::DW_LLVM_LANG_DIALECT_simt;
+static constexpr uint16_t TileDialect = dwarf::DW_LLVM_LANG_DIALECT_tile;
 
 // Command line option to control inlined_at enhancement to lineinfo support.
 // Valid only when debuginfo emissionkind is DebugDirectivesOnly or
@@ -278,4 +282,36 @@ void NVPTXDwarfDebug::addTargetVariableAttributes(
 
   CU.addUInt(Die, dwarf::DW_AT_address_class, dwarf::DW_FORM_data1,
              TargetAddrSpace.value_or(DefaultAddrSpace));
+}
+
+void NVPTXDwarfDebug::finishTargetUnitAttributes(const DICompileUnit &DIUnit,
+                                                 DwarfCompileUnit &NewCU) {
+  uint16_t Dialect = DIUnit.getSourceLanguage().getDialect();
+  // A zero dialect means "no dialect specified"; nothing to emit.
+  if (Dialect == 0)
+    return;
+
+  const bool IsKnownDialect = Dialect == SimtDialect || Dialect == TileDialect;
+  if (!IsKnownDialect) {
+    // WarnedDialectCUs only dedups the diagnostic per CU; it does not gate
+    // policy (we always suppress emission of unknown dialects below).
+    if (WarnedDialectCUs.insert(&DIUnit).second) {
+      StringRef DialectName = dwarf::LanguageDialectString(Dialect);
+      std::string DialectString =
+          DialectName.empty() ? Twine(Dialect).str() : DialectName.str();
+      DIUnit.getContext().diagnose(DiagnosticInfoGeneric(
+          Twine("unknown NVPTX language dialect '") + DialectString +
+              "' on DICompileUnit; expected '" +
+              dwarf::LanguageDialectString(SimtDialect) + "' or '" +
+              dwarf::LanguageDialectString(TileDialect) + "'",
+          DS_Warning));
+    }
+    // Do not emit DW_AT_LLVM_language_dialect for unknown dialect values.
+    // This also avoids DW_FORM_data1 truncation when a value happens to
+    // exceed one byte.
+    return;
+  }
+
+  NewCU.addUInt(NewCU.getUnitDie(), dwarf::DW_AT_LLVM_language_dialect,
+                dwarf::DW_FORM_data1, Dialect);
 }

--- a/llvm/lib/Target/NVPTX/NVPTXDwarfDebug.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXDwarfDebug.cpp
@@ -286,6 +286,8 @@ void NVPTXDwarfDebug::finishTargetUnitAttributes(const DICompileUnit &DIUnit,
   // A zero dialect means "no dialect specified"; nothing to emit. This field
   // should have already been range-checked by the assembly parser, IR verifier,
   // and bitcode reader.
+  assert(Dialect <= dwarf::DW_LLVM_LANG_DIALECT_max &&
+         "Invalid or unsupported NVPTX language dialect.");
   if (Dialect == 0)
     return;
 

--- a/llvm/lib/Target/NVPTX/NVPTXDwarfDebug.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXDwarfDebug.cpp
@@ -29,9 +29,6 @@
 
 using namespace llvm;
 
-static constexpr uint16_t SimtDialect = dwarf::DW_LLVM_LANG_DIALECT_simt;
-static constexpr uint16_t TileDialect = dwarf::DW_LLVM_LANG_DIALECT_tile;
-
 // Command line option to control inlined_at enhancement to lineinfo support.
 // Valid only when debuginfo emissionkind is DebugDirectivesOnly or
 // LineTablesOnly.
@@ -291,7 +288,8 @@ void NVPTXDwarfDebug::finishTargetUnitAttributes(const DICompileUnit &DIUnit,
   if (Dialect == 0)
     return;
 
-  const bool IsKnownDialect = Dialect == SimtDialect || Dialect == TileDialect;
+  const bool IsKnownDialect = Dialect == dwarf::DW_LLVM_LANG_DIALECT_simt ||
+                              Dialect == dwarf::DW_LLVM_LANG_DIALECT_tile;
   if (!IsKnownDialect) {
     // WarnedDialectCUs only dedups the diagnostic per CU; it does not gate
     // policy (we always suppress emission of unknown dialects below).
@@ -302,8 +300,10 @@ void NVPTXDwarfDebug::finishTargetUnitAttributes(const DICompileUnit &DIUnit,
       DIUnit.getContext().diagnose(DiagnosticInfoGeneric(
           Twine("unknown NVPTX language dialect '") + DialectString +
               "' on DICompileUnit; expected '" +
-              dwarf::LanguageDialectString(SimtDialect) + "' or '" +
-              dwarf::LanguageDialectString(TileDialect) + "'",
+              dwarf::LanguageDialectString(dwarf::DW_LLVM_LANG_DIALECT_simt) +
+              "' or '" +
+              dwarf::LanguageDialectString(dwarf::DW_LLVM_LANG_DIALECT_tile) +
+              "'",
           DS_Warning));
     }
     // Do not emit DW_AT_LLVM_language_dialect for unknown dialect values.

--- a/llvm/lib/Target/NVPTX/NVPTXDwarfDebug.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXDwarfDebug.cpp
@@ -17,7 +17,6 @@
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineInstr.h"
 #include "llvm/IR/DebugInfoMetadata.h"
-#include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/MC/MCAsmInfo.h"
@@ -284,33 +283,11 @@ void NVPTXDwarfDebug::addTargetVariableAttributes(
 void NVPTXDwarfDebug::finishTargetUnitAttributes(const DICompileUnit &DIUnit,
                                                  DwarfCompileUnit &NewCU) {
   uint16_t Dialect = DIUnit.getSourceLanguage().getDialect();
-  // A zero dialect means "no dialect specified"; nothing to emit.
+  // A zero dialect means "no dialect specified"; nothing to emit. This field
+  // should have already been range-checked by the assembly parser, IR verifier,
+  // and bitcode reader.
   if (Dialect == 0)
     return;
-
-  const bool IsKnownDialect = Dialect == dwarf::DW_LLVM_LANG_DIALECT_simt ||
-                              Dialect == dwarf::DW_LLVM_LANG_DIALECT_tile;
-  if (!IsKnownDialect) {
-    // WarnedDialectCUs only dedups the diagnostic per CU; it does not gate
-    // policy (we always suppress emission of unknown dialects below).
-    if (WarnedDialectCUs.insert(&DIUnit).second) {
-      StringRef DialectName = dwarf::LanguageDialectString(Dialect);
-      std::string DialectString =
-          DialectName.empty() ? Twine(Dialect).str() : DialectName.str();
-      DIUnit.getContext().diagnose(DiagnosticInfoGeneric(
-          Twine("unknown NVPTX language dialect '") + DialectString +
-              "' on DICompileUnit; expected '" +
-              dwarf::LanguageDialectString(dwarf::DW_LLVM_LANG_DIALECT_simt) +
-              "' or '" +
-              dwarf::LanguageDialectString(dwarf::DW_LLVM_LANG_DIALECT_tile) +
-              "'",
-          DS_Warning));
-    }
-    // Do not emit DW_AT_LLVM_language_dialect for unknown dialect values.
-    // This also avoids DW_FORM_data1 truncation when a value happens to
-    // exceed one byte.
-    return;
-  }
 
   NewCU.addUInt(NewCU.getUnitDie(), dwarf::DW_AT_LLVM_language_dialect,
                 dwarf::DW_FORM_data1, Dialect);

--- a/llvm/lib/Target/NVPTX/NVPTXDwarfDebug.h
+++ b/llvm/lib/Target/NVPTX/NVPTXDwarfDebug.h
@@ -33,11 +33,6 @@ private:
   /// Used to avoid redundant emission of parent chain .loc directives.
   DenseSet<const DILocation *> EmittedInlinedAtLocs;
 
-  /// Set of compile units that already emitted an unknown dialect warning.
-  /// Used solely to dedup diagnostics; it does not affect emission policy
-  /// (unknown dialects are never emitted as DW_AT_LLVM_language_dialect).
-  DenseSet<const DICompileUnit *> WarnedDialectCUs;
-
 public:
   NVPTXDwarfDebug(AsmPrinter *A);
 

--- a/llvm/lib/Target/NVPTX/NVPTXDwarfDebug.h
+++ b/llvm/lib/Target/NVPTX/NVPTXDwarfDebug.h
@@ -33,6 +33,11 @@ private:
   /// Used to avoid redundant emission of parent chain .loc directives.
   DenseSet<const DILocation *> EmittedInlinedAtLocs;
 
+  /// Set of compile units that already emitted an unknown dialect warning.
+  /// Used solely to dedup diagnostics; it does not affect emission policy
+  /// (unknown dialects are never emitted as DW_AT_LLVM_language_dialect).
+  DenseSet<const DICompileUnit *> WarnedDialectCUs;
+
 public:
   NVPTXDwarfDebug(AsmPrinter *A);
 
@@ -54,6 +59,8 @@ public:
       const GlobalVariable *GV = nullptr) const override;
 
 protected:
+  void finishTargetUnitAttributes(const DICompileUnit &DIUnit,
+                                  DwarfCompileUnit &NewCU) override;
   void initializeTargetDebugInfo(const MachineFunction &MF) override;
   void recordTargetSourceLine(const DebugLoc &DL, unsigned Flags) override;
   bool shouldAttachCompileUnitRanges() const override;

--- a/llvm/test/DebugInfo/NVPTX/language-dialect.ll
+++ b/llvm/test/DebugInfo/NVPTX/language-dialect.ll
@@ -1,0 +1,85 @@
+;; Test DW_AT_LLVM_language_dialect on DW_TAG_compile_unit for NVPTX.
+;;
+;; Three compile units, each with one kernel:
+;;   CU0 (default.cu): default_kernel - no dialect field
+;;   CU1 (simt.cu): simt_kernel - explicit dialect: DW_LLVM_LANG_DIALECT_simt
+;;   CU2 (tile.cu): tile_kernel - explicit dialect: DW_LLVM_LANG_DIALECT_tile
+;;
+;; DW_AT_LLVM_language_dialect is only emitted when
+;; DW_LLVM_LANG_DIALECT_simt or DW_LLVM_LANG_DIALECT_tile is explicitly
+;; specified.
+;;
+;; The "unknown dialect" warning path in
+;; NVPTXDwarfDebug::finishTargetUnitAttributes is not exercised here: a .ll
+;; file cannot reach it because the assembly parser, verifier, and bitcode
+;; reader all reject dialect values outside dwarf::DW_LLVM_LANG_DIALECT_max
+;; before llc ever sees the IR. That warning code is kept as a defensive
+;; safety net for programmatic IR construction and future dialect-enum
+;; expansion. The DWARF RUN line below uses --implicit-check-not to assert
+;; the happy path stays silent.
+
+;; --- IR round-trip ---
+; RUN: llvm-as < %s | llvm-dis | llvm-as | llvm-dis | FileCheck %s --check-prefix=IR
+
+; IR: define void @default_kernel()
+; IR: define void @simt_kernel()
+; IR: define void @tile_kernel()
+; IR: !llvm.dbg.cu = !{!{{[0-9]+}}, !{{[0-9]+}}, !{{[0-9]+}}}
+; IR: !{{[0-9]+}} = distinct !DICompileUnit(
+; IR-NOT: dialect:
+; IR-SAME: )
+; IR: !{{[0-9]+}} = distinct !DICompileUnit({{.*}}dialect: DW_LLVM_LANG_DIALECT_simt{{.*}})
+; IR: !{{[0-9]+}} = distinct !DICompileUnit({{.*}}dialect: DW_LLVM_LANG_DIALECT_tile{{.*}})
+
+; RUN: llc < %s -mtriple=nvptx64-nvidia-cuda 2>&1 | FileCheck %s --check-prefix=DWARF \
+; RUN:     --implicit-check-not "warning: unknown NVPTX language dialect"
+
+;; The default CU has no dialect attribute; only explicit CUs emit it.
+;; NVPTX emits DW_AT_LLVM_language_dialect as enum values.
+; DWARF: .section .debug_info
+; DWARF: DW_TAG_compile_unit
+; DWARF-NOT: DW_AT_LLVM_language_dialect
+; DWARF: DW_TAG_compile_unit
+;; DW_LLVM_LANG_DIALECT_simt = 1
+; DWARF:      .b8 1 // DW_AT_LLVM_language_dialect
+; DWARF: DW_TAG_compile_unit
+;; DW_LLVM_LANG_DIALECT_tile = 2
+; DWARF:      .b8 2 // DW_AT_LLVM_language_dialect
+
+define void @default_kernel() !dbg !5 {
+  ret void, !dbg !10
+}
+
+define void @simt_kernel() !dbg !15 {
+  ret void, !dbg !16
+}
+
+define void @tile_kernel() !dbg !8 {
+  ret void, !dbg !11
+}
+
+!llvm.dbg.cu = !{!0, !1, !2}
+!llvm.module.flags = !{!12, !13}
+
+;; CU for the default case (no dialect).
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !3, producer: "", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+!3 = !DIFile(filename: "default.cu", directory: "/tmp")
+!4 = !{}
+!9 = !DISubroutineType(types: !4)
+!5 = distinct !DISubprogram(name: "default_kernel", scope: !3, file: !3, line: 1, type: !9, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !4)
+!10 = !DILocation(line: 1, column: 1, scope: !5)
+
+;; CU for explicit SIMT.
+!1 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !18, producer: "", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, dialect: DW_LLVM_LANG_DIALECT_simt)
+!18 = !DIFile(filename: "simt.cu", directory: "/tmp")
+!15 = distinct !DISubprogram(name: "simt_kernel", scope: !18, file: !18, line: 1, type: !9, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !1, retainedNodes: !4)
+!16 = !DILocation(line: 1, column: 1, scope: !15)
+
+;; CU for tile.
+!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !6, producer: "", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, dialect: DW_LLVM_LANG_DIALECT_tile)
+!6 = !DIFile(filename: "tile.cu", directory: "/tmp")
+!8 = distinct !DISubprogram(name: "tile_kernel", scope: !6, file: !6, line: 1, type: !9, scopeLine: 1, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !4)
+!11 = !DILocation(line: 1, column: 1, scope: !8)
+
+!12 = !{i32 2, !"Dwarf Version", i32 2}
+!13 = !{i32 2, !"Debug Info Version", i32 3}

--- a/llvm/test/DebugInfo/NVPTX/language-dialect.ll
+++ b/llvm/test/DebugInfo/NVPTX/language-dialect.ll
@@ -8,15 +8,6 @@
 ;; DW_AT_LLVM_language_dialect is only emitted when
 ;; DW_LLVM_LANG_DIALECT_simt or DW_LLVM_LANG_DIALECT_tile is explicitly
 ;; specified.
-;;
-;; The "unknown dialect" warning path in
-;; NVPTXDwarfDebug::finishTargetUnitAttributes is not exercised here: a .ll
-;; file cannot reach it because the assembly parser, verifier, and bitcode
-;; reader all reject dialect values outside dwarf::DW_LLVM_LANG_DIALECT_max
-;; before llc ever sees the IR. That warning code is kept as a defensive
-;; safety net for programmatic IR construction and future dialect-enum
-;; expansion. The DWARF RUN line below uses --implicit-check-not to assert
-;; the happy path stays silent.
 
 ;; --- IR round-trip ---
 ; RUN: llvm-as < %s | llvm-dis | llvm-as | llvm-dis | FileCheck %s --check-prefix=IR
@@ -31,8 +22,7 @@
 ; IR: !{{[0-9]+}} = distinct !DICompileUnit({{.*}}dialect: DW_LLVM_LANG_DIALECT_simt{{.*}})
 ; IR: !{{[0-9]+}} = distinct !DICompileUnit({{.*}}dialect: DW_LLVM_LANG_DIALECT_tile{{.*}})
 
-; RUN: llc < %s -mtriple=nvptx64-nvidia-cuda 2>&1 | FileCheck %s --check-prefix=DWARF \
-; RUN:     --implicit-check-not "warning: unknown NVPTX language dialect"
+; RUN: llc < %s -mtriple=nvptx64-nvidia-cuda | FileCheck %s --check-prefix=DWARF
 
 ;; The default CU has no dialect attribute; only explicit CUs emit it.
 ;; NVPTX emits DW_AT_LLVM_language_dialect as enum values.


### PR DESCRIPTION
This PR makes use of the recently introduced DW_AT_LLVM_language_dialect attribute.  Currently, no other targets emit this compile unit DWARF attribute ; however, this PR changes that.  NVPTX can optionally emit a dialect based on the type of input being compiled (e.g., from a Tile frontend or traditional CUDA (SIMT) frontend).

- DwarfDebug: add finishTargetUnitAttributes virtual hook so backends can finalize per-CU attributes.
- NVPTX: override the hook to emit DW_AT_LLVM_language_dialect (DW_FORM_data1) for the simt and tile dialects, suppressing emission and warning (per-CU deduplicated) for unknown values.

(Co-developed via LLM)