### PR TITLE
[cir] Refine cir::CastOp semantics for int <-> float casts

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -526,12 +526,22 @@ LogicalResult cir::CastOp::verify() {
                               "address space of the operand";
     }
 
-  if (mlir::isa<cir::VectorType>(srcType) &&
-      mlir::isa<cir::VectorType>(resType)) {
+  auto kind = getKind();
+  auto srcVTy = mlir::dyn_cast<cir::VectorType>(srcType);
+  auto resVTy = mlir::dyn_cast<cir::VectorType>(resType);
+  if (srcVTy && resVTy) {
+    if ((kind == cir::CastKind::int_to_float ||
+         kind == cir::CastKind::float_to_int) &&
+        srcVTy.getSize() != resVTy.getSize()) {
+      return emitOpError()
+             << "vector float-to-int and int-to-float casts require "
+                "source and destination vectors to have the same number of "
+                "elements";
+    }
     // Use the element type of the vector to verify the cast kind. (Except for
     // bitcast, see below.)
-    srcType = mlir::dyn_cast<cir::VectorType>(srcType).getElementType();
-    resType = mlir::dyn_cast<cir::VectorType>(resType).getElementType();
+    srcType = srcVTy.getElementType();
+    resType = resVTy.getElementType();
   }
 
   switch (getKind()) {

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -526,7 +526,7 @@ LogicalResult cir::CastOp::verify() {
                               "address space of the operand";
     }
 
-  auto kind = getKind();
+  cir::CastKind kind = getKind();
   auto srcVTy = mlir::dyn_cast<cir::VectorType>(srcType);
   auto resVTy = mlir::dyn_cast<cir::VectorType>(resType);
   if (srcVTy && resVTy) {

--- a/clang/test/CIR/IR/invalid-cast.cir
+++ b/clang/test/CIR/IR/invalid-cast.cir
@@ -25,3 +25,15 @@ module {
     cir.return %0 : !cir.bool
   }
 }
+
+// -----
+
+!s8i = !cir.int<s, 8>
+
+module {
+  cir.func @int_to_float(%in: !cir.vector<8 x !s8i>) {
+    // expected-error@+1 {{vector float-to-int and int-to-float casts require source and destination vectors to have the same number of elements}}
+    cir.cast int_to_float %in : !cir.vector<8 x !s8i> -> !cir.vector<2 x !cir.float>
+    cir.return
+  }
+}

--- a/clang/test/CIR/Lowering/cast.cir
+++ b/clang/test/CIR/Lowering/cast.cir
@@ -10,7 +10,7 @@
 !u64i = !cir.int<u, 64>
 
 module {
-  cir.func @cStyleCasts(%arg0: !u32i, %arg1: !s32i, %arg2: !cir.float, %arg3: !cir.double, %arg4: !cir.vector<2 x !s32i>) -> !s32i {
+  cir.func @cStyleCasts(%arg0: !u32i, %arg1: !s32i, %arg2: !cir.float, %arg3: !cir.double) -> !s32i {
   // CHECK: llvm.func @cStyleCasts
     %0 = cir.alloca !u32i, !cir.ptr<!u32i>, ["x1", init] {alignment = 4 : i64}
     %1 = cir.alloca !s32i, !cir.ptr<!s32i>, ["x2", init] {alignment = 4 : i64}
@@ -93,9 +93,11 @@ module {
     cir.return
   }
 
-  cir.func @vectorCasts(%arg0:!cir.vector<2 x !s32i>) {
+  cir.func @vectorCasts(%arg0: !cir.vector<2 x !s32i>, %arg1: !cir.vector<4 x !cir.float>) {
     %i_2_f = cir.cast int_to_float %arg0 : !cir.vector<2 x !s32i> -> !cir.vector<2 x !cir.float>
     // CHECK: %{{.+}} = llvm.sitofp %{{.+}} : vector<2xi32> to vector<2xf32>
+    %f_2_1 = cir.cast float_to_int %arg1 : !cir.vector<4 x !cir.float> -> !cir.vector<4 x !s32i>
+    // CHECK: %{{.+}} = llvm.fptosi %{{.+}} : vector<4xf32> to vector<4xi32>
     %bitcast = cir.cast bitcast %arg0 : !cir.vector<2 x !s32i> -> !cir.vector<1 x !cir.double>
     // CHECK: %{{.+}} = llvm.bitcast %{{.+}} : vector<2xi32> to vector<1xf64>
 

--- a/clang/test/CIR/Lowering/cast.cir
+++ b/clang/test/CIR/Lowering/cast.cir
@@ -64,6 +64,8 @@ module {
     // CHECK: %{{.+}} = llvm.sitofp %{{.+}} : i32 to f32
     %251 = cir.cast int_to_float %arg4 : !cir.vector<2 x !s32i> -> !cir.vector<2 x !cir.float>
     // CHECK: %{{.+}} = llvm.sitofp %{{.+}} : vector<2xi32> to vector<2xf32>
+    %252 = cir.cast bitcast %arg4 : !cir.vector<2 x !s32i> -> !cir.vector<1 x !cir.double>
+    // CHECK: %{{.+}} = llvm.bitcast %{{.+}} : vector<2xi32> to vector<1xf64>
     %26 = cir.cast int_to_float %arg0 : !u32i -> !cir.float
     // CHECK: %{{.+}} = llvm.uitofp %{{.+}} : i32 to f32
     %27 = cir.cast float_to_int %arg2 : !cir.float -> !s32i

--- a/clang/test/CIR/Lowering/cast.cir
+++ b/clang/test/CIR/Lowering/cast.cir
@@ -10,7 +10,7 @@
 !u64i = !cir.int<u, 64>
 
 module {
-  cir.func @cStyleCasts(%arg0: !u32i, %arg1: !s32i, %arg2: !cir.float, %arg3: !cir.double) -> !s32i {
+  cir.func @cStyleCasts(%arg0: !u32i, %arg1: !s32i, %arg2: !cir.float, %arg3: !cir.double, %arg4: !cir.vector<2 x !s32i>) -> !s32i {
   // CHECK: llvm.func @cStyleCasts
     %0 = cir.alloca !u32i, !cir.ptr<!u32i>, ["x1", init] {alignment = 4 : i64}
     %1 = cir.alloca !s32i, !cir.ptr<!s32i>, ["x2", init] {alignment = 4 : i64}
@@ -62,6 +62,8 @@ module {
     // Floating point casts.
     %25 = cir.cast int_to_float %arg1 : !s32i -> !cir.float
     // CHECK: %{{.+}} = llvm.sitofp %{{.+}} : i32 to f32
+    %251 = cir.cast int_to_float %arg4 : !cir.vector<2 x !s32i> -> !cir.vector<2 x !cir.float>
+    // CHECK: %{{.+}} = llvm.sitofp %{{.+}} : vector<2xi32> to vector<2xf32>
     %26 = cir.cast int_to_float %arg0 : !u32i -> !cir.float
     // CHECK: %{{.+}} = llvm.uitofp %{{.+}} : i32 to f32
     %27 = cir.cast float_to_int %arg2 : !cir.float -> !s32i

--- a/clang/test/CIR/Lowering/cast.cir
+++ b/clang/test/CIR/Lowering/cast.cir
@@ -62,10 +62,6 @@ module {
     // Floating point casts.
     %25 = cir.cast int_to_float %arg1 : !s32i -> !cir.float
     // CHECK: %{{.+}} = llvm.sitofp %{{.+}} : i32 to f32
-    %251 = cir.cast int_to_float %arg4 : !cir.vector<2 x !s32i> -> !cir.vector<2 x !cir.float>
-    // CHECK: %{{.+}} = llvm.sitofp %{{.+}} : vector<2xi32> to vector<2xf32>
-    %252 = cir.cast bitcast %arg4 : !cir.vector<2 x !s32i> -> !cir.vector<1 x !cir.double>
-    // CHECK: %{{.+}} = llvm.bitcast %{{.+}} : vector<2xi32> to vector<1xf64>
     %26 = cir.cast int_to_float %arg0 : !u32i -> !cir.float
     // CHECK: %{{.+}} = llvm.uitofp %{{.+}} : i32 to f32
     %27 = cir.cast float_to_int %arg2 : !cir.float -> !s32i
@@ -94,6 +90,15 @@ module {
     // CHECK: %[[EXT:.*]] = llvm.zext %[[TRUNC]] : i1 to i8
 
     cir.store %3, %1 : !u8i, !cir.ptr<!u8i>
+    cir.return
+  }
+
+  cir.func @vectorCasts(%arg0:!cir.vector<2 x !s32i>) {
+    %i_2_f = cir.cast int_to_float %arg0 : !cir.vector<2 x !s32i> -> !cir.vector<2 x !cir.float>
+    // CHECK: %{{.+}} = llvm.sitofp %{{.+}} : vector<2xi32> to vector<2xf32>
+    %bitcast = cir.cast bitcast %arg0 : !cir.vector<2 x !s32i> -> !cir.vector<1 x !cir.double>
+    // CHECK: %{{.+}} = llvm.bitcast %{{.+}} : vector<2xi32> to vector<1xf64>
+
     cir.return
   }
 }


### PR DESCRIPTION
Int-to-float and float-to-int casts in cir::CastOp are lowered directly to
their LLVM equivalents. Update the verifier to reflect this semantics and
ensure that, for vector casts, the source and destination vectors have the
same length.

This lets the CIR verifier reject invalid casts earlier, instead of relying
on errors reported later at the LLVM IR level.
