### PR TITLE
[mlir][spirv][tosa] Extend TOSA to SPIR-V TOSA op conversion

### DIFF
--- a/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaOps.cpp
+++ b/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaOps.cpp
@@ -26,6 +26,19 @@ spirv::TosaExtNaNPropagationModeType getNanMode(OpAdaptor adaptor) {
       adaptor.getNanMode());
 }
 
+template <typename OpAdaptor>
+spirv::TosaExtResizeModeType getResizeMode(OpAdaptor adaptor) {
+  return static_cast<spirv::TosaExtResizeModeType>(adaptor.getMode());
+}
+
+DenseIntElementsAttr getI32TensorArmAttr(ArrayRef<int32_t> values,
+                                         ConversionPatternRewriter &rewriter) {
+  return DenseIntElementsAttr::get(
+      spirv::TensorArmType::get(static_cast<int64_t>(values.size()),
+                                IntegerType::get(rewriter.getContext(), 32)),
+      values);
+}
+
 template <typename SourceOp, typename Replacer>
 struct TosaOpConvert final : public OpConversionPattern<SourceOp> {
   using OpConversionPattern<SourceOp>::OpConversionPattern;
@@ -83,15 +96,193 @@ struct BinaryNanModeElementwiseReplace {
   }
 };
 
+template <typename TargetOp>
+struct ReductionReplace {
+  template <typename SourceOp>
+  static LogicalResult replace(SourceOp op, typename SourceOp::Adaptor adaptor,
+                               Type type, ConversionPatternRewriter &rewriter) {
+    rewriter.replaceOpWithNewOp<TargetOp>(op, type, adaptor.getAxis(),
+                                          adaptor.getInput());
+    return success();
+  }
+};
+
+template <typename TargetOp>
+struct NanModeReductionReplace {
+  template <typename SourceOp>
+  static LogicalResult replace(SourceOp op, typename SourceOp::Adaptor adaptor,
+                               Type type, ConversionPatternRewriter &rewriter) {
+    rewriter.replaceOpWithNewOp<TargetOp>(
+        op, type, adaptor.getAxis(), getNanMode(adaptor), adaptor.getInput());
+    return success();
+  }
+};
+
+struct ClampReplace {
+  static LogicalResult replace(tosa::ClampOp op, tosa::ClampOpAdaptor adaptor,
+                               Type type, ConversionPatternRewriter &rewriter) {
+    rewriter.replaceOpWithNewOp<spirv::TosaClampOp>(
+        op, type, adaptor.getMinVal(), adaptor.getMaxVal(), getNanMode(adaptor),
+        adaptor.getInput());
+    return success();
+  }
+};
+
+struct ArithmeticRightShiftReplace {
+  static LogicalResult replace(tosa::ArithmeticRightShiftOp op,
+                               tosa::ArithmeticRightShiftOpAdaptor adaptor,
+                               Type type, ConversionPatternRewriter &rewriter) {
+    rewriter.replaceOpWithNewOp<spirv::TosaArithmeticRightShiftOp>(
+        op, type, adaptor.getRound(), adaptor.getInput1(), adaptor.getInput2());
+    return success();
+  }
+};
+
+struct MulReplace {
+  static LogicalResult replace(tosa::MulOp op, tosa::MulOpAdaptor adaptor,
+                               Type type, ConversionPatternRewriter &rewriter) {
+    rewriter.replaceOpWithNewOp<spirv::TosaMulOp>(
+        op, type, adaptor.getInput1(), adaptor.getInput2(), adaptor.getShift());
+    return success();
+  }
+};
+
+struct TableReplace {
+  static LogicalResult replace(tosa::TableOp op, tosa::TableOpAdaptor adaptor,
+                               Type type, ConversionPatternRewriter &rewriter) {
+    rewriter.replaceOpWithNewOp<spirv::TosaTableOp>(
+        op, type, adaptor.getInput1(), adaptor.getTable());
+    return success();
+  }
+};
+
+struct NegateReplace {
+  static LogicalResult replace(tosa::NegateOp op, tosa::NegateOpAdaptor adaptor,
+                               Type type, ConversionPatternRewriter &rewriter) {
+    rewriter.replaceOpWithNewOp<spirv::TosaNegateOp>(
+        op, type, adaptor.getInput1(), adaptor.getInput1Zp(),
+        adaptor.getOutputZp());
+    return success();
+  }
+};
+
+struct SelectReplace {
+  static LogicalResult replace(tosa::SelectOp op, tosa::SelectOpAdaptor adaptor,
+                               Type type, ConversionPatternRewriter &rewriter) {
+    rewriter.replaceOpWithNewOp<spirv::TosaSelectOp>(
+        op, type, adaptor.getInput1(), adaptor.getInput2(),
+        adaptor.getInput3());
+    return success();
+  }
+};
+
+struct ReshapeReplace {
+  static LogicalResult replace(tosa::ReshapeOp op,
+                               tosa::ReshapeOpAdaptor adaptor, Type type,
+                               ConversionPatternRewriter &rewriter) {
+    rewriter.replaceOpWithNewOp<spirv::TosaReshapeOp>(
+        op, type, adaptor.getInput1(), adaptor.getShape());
+    return success();
+  }
+};
+
+struct ReverseReplace {
+  static LogicalResult replace(tosa::ReverseOp op,
+                               tosa::ReverseOpAdaptor adaptor, Type type,
+                               ConversionPatternRewriter &rewriter) {
+    rewriter.replaceOpWithNewOp<spirv::TosaReverseOp>(
+        op, type, adaptor.getAxis(), adaptor.getInput1());
+    return success();
+  }
+};
+
+struct SliceReplace {
+  static LogicalResult replace(tosa::SliceOp op, tosa::SliceOpAdaptor adaptor,
+                               Type type, ConversionPatternRewriter &rewriter) {
+    rewriter.replaceOpWithNewOp<spirv::TosaSliceOp>(
+        op, type, adaptor.getInput1(), adaptor.getStart(), adaptor.getSize());
+    return success();
+  }
+};
+
+struct TileReplace {
+  static LogicalResult replace(tosa::TileOp op, tosa::TileOpAdaptor adaptor,
+                               Type type, ConversionPatternRewriter &rewriter) {
+    rewriter.replaceOpWithNewOp<spirv::TosaTileOp>(
+        op, type, adaptor.getInput1(), adaptor.getMultiples());
+    return success();
+  }
+};
+
+struct TransposeReplace {
+  static LogicalResult replace(tosa::TransposeOp op,
+                               tosa::TransposeOpAdaptor adaptor, Type type,
+                               ConversionPatternRewriter &rewriter) {
+    DenseIntElementsAttr perms =
+        getI32TensorArmAttr(adaptor.getPerms(), rewriter);
+    rewriter.replaceOpWithNewOp<spirv::TosaTransposeOp>(op, type, perms,
+                                                        adaptor.getInput1());
+    return success();
+  }
+};
+
+struct GatherReplace {
+  static LogicalResult replace(tosa::GatherOp op, tosa::GatherOpAdaptor adaptor,
+                               Type type, ConversionPatternRewriter &rewriter) {
+    rewriter.replaceOpWithNewOp<spirv::TosaGatherOp>(
+        op, type, adaptor.getValues(), adaptor.getIndices());
+    return success();
+  }
+};
+
+struct ScatterReplace {
+  static LogicalResult replace(tosa::ScatterOp op,
+                               tosa::ScatterOpAdaptor adaptor, Type type,
+                               ConversionPatternRewriter &rewriter) {
+    rewriter.replaceOpWithNewOp<spirv::TosaScatterOp>(
+        op, type, adaptor.getValuesIn(), adaptor.getIndices(),
+        adaptor.getInput());
+    return success();
+  }
+};
+
+struct ResizeReplace {
+  static LogicalResult replace(tosa::ResizeOp op, tosa::ResizeOpAdaptor adaptor,
+                               Type type, ConversionPatternRewriter &rewriter) {
+    rewriter.replaceOpWithNewOp<spirv::TosaResizeOp>(
+        op, type, getResizeMode(adaptor), adaptor.getInput(),
+        adaptor.getScale(), adaptor.getOffset(), adaptor.getBorder());
+    return success();
+  }
+};
+
+struct ConstShapeReplace {
+  static LogicalResult replace(tosa::ConstShapeOp op,
+                               tosa::ConstShapeOpAdaptor adaptor, Type type,
+                               ConversionPatternRewriter &rewriter) {
+    SmallVector<int32_t> values;
+    for (const APInt &value : adaptor.getValues().getValues<APInt>())
+      values.push_back(value.getSExtValue());
+
+    rewriter.replaceOpWithNewOp<spirv::ConstantOp>(
+        op, type, getI32TensorArmAttr(values, rewriter));
+    return success();
+  }
+};
+
 } // namespace
 
 void populateTosaToSPIRVTosaOpsConversionPatterns(
     SPIRVTypeConverter &typeConverter, RewritePatternSet &patterns) {
   patterns.add<
+      TosaOpConvert<tosa::ArgMaxOp,
+                    NanModeReductionReplace<spirv::TosaArgMaxOp>>,
+      TosaOpConvert<tosa::ClampOp, ClampReplace>,
       TosaOpConvert<tosa::ErfOp, UnaryInputReplace<spirv::TosaErfOp>>,
       TosaOpConvert<tosa::SigmoidOp, UnaryInputReplace<spirv::TosaSigmoidOp>>,
       TosaOpConvert<tosa::TanhOp, UnaryInputReplace<spirv::TosaTanhOp>>,
       TosaOpConvert<tosa::AddOp, BinaryElementwiseReplace<spirv::TosaAddOp>>,
+      TosaOpConvert<tosa::ArithmeticRightShiftOp, ArithmeticRightShiftReplace>,
       TosaOpConvert<tosa::BitwiseAndOp,
                     BinaryElementwiseReplace<spirv::TosaBitwiseAndOp>>,
       TosaOpConvert<tosa::BitwiseOrOp,
@@ -114,8 +305,10 @@ void populateTosaToSPIRVTosaOpsConversionPatterns(
                     BinaryNanModeElementwiseReplace<spirv::TosaMaximumOp>>,
       TosaOpConvert<tosa::MinimumOp,
                     BinaryNanModeElementwiseReplace<spirv::TosaMinimumOp>>,
+      TosaOpConvert<tosa::MulOp, MulReplace>,
       TosaOpConvert<tosa::PowOp, BinaryElementwiseReplace<spirv::TosaPowOp>>,
       TosaOpConvert<tosa::SubOp, BinaryElementwiseReplace<spirv::TosaSubOp>>,
+      TosaOpConvert<tosa::TableOp, TableReplace>,
       TosaOpConvert<tosa::AbsOp, UnaryInput1Replace<spirv::TosaAbsOp>>,
       TosaOpConvert<tosa::BitwiseNotOp,
                     UnaryInput1Replace<spirv::TosaBitwiseNotOp>>,
@@ -127,16 +320,40 @@ void populateTosaToSPIRVTosaOpsConversionPatterns(
       TosaOpConvert<tosa::LogOp, UnaryInput1Replace<spirv::TosaLogOp>>,
       TosaOpConvert<tosa::LogicalNotOp,
                     UnaryInput1Replace<spirv::TosaLogicalNotOp>>,
+      TosaOpConvert<tosa::NegateOp, NegateReplace>,
       TosaOpConvert<tosa::ReciprocalOp,
                     UnaryInput1Replace<spirv::TosaReciprocalOp>>,
       TosaOpConvert<tosa::RsqrtOp, UnaryInput1Replace<spirv::TosaRsqrtOp>>,
       TosaOpConvert<tosa::SinOp, UnaryInput1Replace<spirv::TosaSinOp>>,
+      TosaOpConvert<tosa::SelectOp, SelectReplace>,
       TosaOpConvert<tosa::EqualOp,
                     BinaryElementwiseReplace<spirv::TosaEqualOp>>,
       TosaOpConvert<tosa::GreaterOp,
                     BinaryElementwiseReplace<spirv::TosaGreaterOp>>,
       TosaOpConvert<tosa::GreaterEqualOp,
-                    BinaryElementwiseReplace<spirv::TosaGreaterEqualOp>>>(
+                    BinaryElementwiseReplace<spirv::TosaGreaterEqualOp>>,
+      TosaOpConvert<tosa::ReduceAllOp,
+                    ReductionReplace<spirv::TosaReduceAllOp>>,
+      TosaOpConvert<tosa::ReduceAnyOp,
+                    ReductionReplace<spirv::TosaReduceAnyOp>>,
+      TosaOpConvert<tosa::ReduceMaxOp,
+                    NanModeReductionReplace<spirv::TosaReduceMaxOp>>,
+      TosaOpConvert<tosa::ReduceMinOp,
+                    NanModeReductionReplace<spirv::TosaReduceMinOp>>,
+      TosaOpConvert<tosa::ReduceProductOp,
+                    ReductionReplace<spirv::TosaReduceProductOp>>,
+      TosaOpConvert<tosa::ReduceSumOp,
+                    ReductionReplace<spirv::TosaReduceSumOp>>,
+      TosaOpConvert<tosa::ReshapeOp, ReshapeReplace>,
+      TosaOpConvert<tosa::ReverseOp, ReverseReplace>,
+      TosaOpConvert<tosa::SliceOp, SliceReplace>,
+      TosaOpConvert<tosa::TileOp, TileReplace>,
+      TosaOpConvert<tosa::TransposeOp, TransposeReplace>,
+      TosaOpConvert<tosa::GatherOp, GatherReplace>,
+      TosaOpConvert<tosa::ScatterOp, ScatterReplace>,
+      TosaOpConvert<tosa::ResizeOp, ResizeReplace>,
+      TosaOpConvert<tosa::CastOp, UnaryInputReplace<spirv::TosaCastOp>>,
+      TosaOpConvert<tosa::ConstShapeOp, ConstShapeReplace>>(
       typeConverter, patterns.getContext());
 }
 

--- a/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaOps.cpp
+++ b/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaOps.cpp
@@ -21,18 +21,13 @@ namespace mlir::tosa {
 namespace {
 
 template <typename OpAdaptor>
-Value getInput1(OpAdaptor adaptor) {
-  return adaptor.getInput1();
+spirv::TosaExtNaNPropagationModeType getNanMode(OpAdaptor adaptor) {
+  return static_cast<spirv::TosaExtNaNPropagationModeType>(
+      adaptor.getNanMode());
 }
 
-Value getInput1(tosa::ErfOpAdaptor adaptor) { return adaptor.getInput(); }
-
-Value getInput1(tosa::SigmoidOpAdaptor adaptor) { return adaptor.getInput(); }
-
-Value getInput1(tosa::TanhOpAdaptor adaptor) { return adaptor.getInput(); }
-
-template <typename SourceOp, typename TargetOp>
-struct UnaryElementwiseOpConvert final : public OpConversionPattern<SourceOp> {
+template <typename SourceOp, typename Replacer>
+struct TosaOpConvert final : public OpConversionPattern<SourceOp> {
   using OpConversionPattern<SourceOp>::OpConversionPattern;
 
   LogicalResult
@@ -41,42 +36,49 @@ struct UnaryElementwiseOpConvert final : public OpConversionPattern<SourceOp> {
     Type type = this->getTypeConverter()->convertType(op.getType());
     if (!type)
       return rewriter.notifyMatchFailure(op, "type conversion failed");
-    rewriter.replaceOpWithNewOp<TargetOp>(op, type, getInput1(adaptor));
+    return Replacer::replace(op, adaptor, type, rewriter);
+  }
+};
+
+template <typename TargetOp>
+struct UnaryInput1Replace {
+  template <typename SourceOp>
+  static LogicalResult replace(SourceOp op, typename SourceOp::Adaptor adaptor,
+                               Type type, ConversionPatternRewriter &rewriter) {
+    rewriter.replaceOpWithNewOp<TargetOp>(op, type, adaptor.getInput1());
     return success();
   }
 };
 
-template <typename SourceOp, typename TargetOp>
-struct BinaryElementwiseOpConvert final : public OpConversionPattern<SourceOp> {
-  using OpConversionPattern<SourceOp>::OpConversionPattern;
+template <typename TargetOp>
+struct UnaryInputReplace {
+  template <typename SourceOp>
+  static LogicalResult replace(SourceOp op, typename SourceOp::Adaptor adaptor,
+                               Type type, ConversionPatternRewriter &rewriter) {
+    rewriter.replaceOpWithNewOp<TargetOp>(op, type, adaptor.getInput());
+    return success();
+  }
+};
 
-  LogicalResult
-  matchAndRewrite(SourceOp op, typename SourceOp::Adaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    Type type = this->getTypeConverter()->convertType(op.getType());
-    if (!type)
-      return rewriter.notifyMatchFailure(op, "type conversion failed");
+template <typename TargetOp>
+struct BinaryElementwiseReplace {
+  template <typename SourceOp>
+  static LogicalResult replace(SourceOp op, typename SourceOp::Adaptor adaptor,
+                               Type type, ConversionPatternRewriter &rewriter) {
     rewriter.replaceOpWithNewOp<TargetOp>(op, type, adaptor.getInput1(),
                                           adaptor.getInput2());
     return success();
   }
 };
 
-template <typename SourceOp, typename TargetOp>
-struct BinaryNanModeElementwiseOpConvert final
-    : public OpConversionPattern<SourceOp> {
-  using OpConversionPattern<SourceOp>::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(SourceOp op, typename SourceOp::Adaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    auto nanMode =
-        static_cast<spirv::TosaExtNaNPropagationModeType>(adaptor.getNanMode());
-    Type type = this->getTypeConverter()->convertType(op.getType());
-    if (!type)
-      return rewriter.notifyMatchFailure(op, "type conversion failed");
-    rewriter.replaceOpWithNewOp<TargetOp>(
-        op, type, nanMode, adaptor.getInput1(), adaptor.getInput2());
+template <typename TargetOp>
+struct BinaryNanModeElementwiseReplace {
+  template <typename SourceOp>
+  static LogicalResult replace(SourceOp op, typename SourceOp::Adaptor adaptor,
+                               Type type, ConversionPatternRewriter &rewriter) {
+    rewriter.replaceOpWithNewOp<TargetOp>(op, type, getNanMode(adaptor),
+                                          adaptor.getInput1(),
+                                          adaptor.getInput2());
     return success();
   }
 };
@@ -86,41 +88,55 @@ struct BinaryNanModeElementwiseOpConvert final
 void populateTosaToSPIRVTosaOpsConversionPatterns(
     SPIRVTypeConverter &typeConverter, RewritePatternSet &patterns) {
   patterns.add<
-      UnaryElementwiseOpConvert<tosa::ErfOp, spirv::TosaErfOp>,
-      UnaryElementwiseOpConvert<tosa::SigmoidOp, spirv::TosaSigmoidOp>,
-      UnaryElementwiseOpConvert<tosa::TanhOp, spirv::TosaTanhOp>,
-      BinaryElementwiseOpConvert<tosa::AddOp, spirv::TosaAddOp>,
-      BinaryElementwiseOpConvert<tosa::BitwiseAndOp, spirv::TosaBitwiseAndOp>,
-      BinaryElementwiseOpConvert<tosa::BitwiseOrOp, spirv::TosaBitwiseOrOp>,
-      BinaryElementwiseOpConvert<tosa::BitwiseXorOp, spirv::TosaBitwiseXorOp>,
-      BinaryElementwiseOpConvert<tosa::IntDivOp, spirv::TosaIntDivOp>,
-      BinaryElementwiseOpConvert<tosa::LogicalAndOp, spirv::TosaLogicalAndOp>,
-      BinaryElementwiseOpConvert<tosa::LogicalLeftShiftOp,
-                                 spirv::TosaLogicalLeftShiftOp>,
-      BinaryElementwiseOpConvert<tosa::LogicalRightShiftOp,
-                                 spirv::TosaLogicalRightShiftOp>,
-      BinaryElementwiseOpConvert<tosa::LogicalOrOp, spirv::TosaLogicalOrOp>,
-      BinaryElementwiseOpConvert<tosa::LogicalXorOp, spirv::TosaLogicalXorOp>,
-      BinaryNanModeElementwiseOpConvert<tosa::MaximumOp, spirv::TosaMaximumOp>,
-      BinaryNanModeElementwiseOpConvert<tosa::MinimumOp, spirv::TosaMinimumOp>,
-      BinaryElementwiseOpConvert<tosa::PowOp, spirv::TosaPowOp>,
-      BinaryElementwiseOpConvert<tosa::SubOp, spirv::TosaSubOp>,
-      UnaryElementwiseOpConvert<tosa::AbsOp, spirv::TosaAbsOp>,
-      UnaryElementwiseOpConvert<tosa::BitwiseNotOp, spirv::TosaBitwiseNotOp>,
-      UnaryElementwiseOpConvert<tosa::CeilOp, spirv::TosaCeilOp>,
-      UnaryElementwiseOpConvert<tosa::ClzOp, spirv::TosaClzOp>,
-      UnaryElementwiseOpConvert<tosa::CosOp, spirv::TosaCosOp>,
-      UnaryElementwiseOpConvert<tosa::ExpOp, spirv::TosaExpOp>,
-      UnaryElementwiseOpConvert<tosa::FloorOp, spirv::TosaFloorOp>,
-      UnaryElementwiseOpConvert<tosa::LogOp, spirv::TosaLogOp>,
-      UnaryElementwiseOpConvert<tosa::LogicalNotOp, spirv::TosaLogicalNotOp>,
-      UnaryElementwiseOpConvert<tosa::ReciprocalOp, spirv::TosaReciprocalOp>,
-      UnaryElementwiseOpConvert<tosa::RsqrtOp, spirv::TosaRsqrtOp>,
-      UnaryElementwiseOpConvert<tosa::SinOp, spirv::TosaSinOp>,
-      BinaryElementwiseOpConvert<tosa::EqualOp, spirv::TosaEqualOp>,
-      BinaryElementwiseOpConvert<tosa::GreaterOp, spirv::TosaGreaterOp>,
-      BinaryElementwiseOpConvert<tosa::GreaterEqualOp,
-                                 spirv::TosaGreaterEqualOp>>(
+      TosaOpConvert<tosa::ErfOp, UnaryInputReplace<spirv::TosaErfOp>>,
+      TosaOpConvert<tosa::SigmoidOp, UnaryInputReplace<spirv::TosaSigmoidOp>>,
+      TosaOpConvert<tosa::TanhOp, UnaryInputReplace<spirv::TosaTanhOp>>,
+      TosaOpConvert<tosa::AddOp, BinaryElementwiseReplace<spirv::TosaAddOp>>,
+      TosaOpConvert<tosa::BitwiseAndOp,
+                    BinaryElementwiseReplace<spirv::TosaBitwiseAndOp>>,
+      TosaOpConvert<tosa::BitwiseOrOp,
+                    BinaryElementwiseReplace<spirv::TosaBitwiseOrOp>>,
+      TosaOpConvert<tosa::BitwiseXorOp,
+                    BinaryElementwiseReplace<spirv::TosaBitwiseXorOp>>,
+      TosaOpConvert<tosa::IntDivOp,
+                    BinaryElementwiseReplace<spirv::TosaIntDivOp>>,
+      TosaOpConvert<tosa::LogicalAndOp,
+                    BinaryElementwiseReplace<spirv::TosaLogicalAndOp>>,
+      TosaOpConvert<tosa::LogicalLeftShiftOp,
+                    BinaryElementwiseReplace<spirv::TosaLogicalLeftShiftOp>>,
+      TosaOpConvert<tosa::LogicalRightShiftOp,
+                    BinaryElementwiseReplace<spirv::TosaLogicalRightShiftOp>>,
+      TosaOpConvert<tosa::LogicalOrOp,
+                    BinaryElementwiseReplace<spirv::TosaLogicalOrOp>>,
+      TosaOpConvert<tosa::LogicalXorOp,
+                    BinaryElementwiseReplace<spirv::TosaLogicalXorOp>>,
+      TosaOpConvert<tosa::MaximumOp,
+                    BinaryNanModeElementwiseReplace<spirv::TosaMaximumOp>>,
+      TosaOpConvert<tosa::MinimumOp,
+                    BinaryNanModeElementwiseReplace<spirv::TosaMinimumOp>>,
+      TosaOpConvert<tosa::PowOp, BinaryElementwiseReplace<spirv::TosaPowOp>>,
+      TosaOpConvert<tosa::SubOp, BinaryElementwiseReplace<spirv::TosaSubOp>>,
+      TosaOpConvert<tosa::AbsOp, UnaryInput1Replace<spirv::TosaAbsOp>>,
+      TosaOpConvert<tosa::BitwiseNotOp,
+                    UnaryInput1Replace<spirv::TosaBitwiseNotOp>>,
+      TosaOpConvert<tosa::CeilOp, UnaryInput1Replace<spirv::TosaCeilOp>>,
+      TosaOpConvert<tosa::ClzOp, UnaryInput1Replace<spirv::TosaClzOp>>,
+      TosaOpConvert<tosa::CosOp, UnaryInput1Replace<spirv::TosaCosOp>>,
+      TosaOpConvert<tosa::ExpOp, UnaryInput1Replace<spirv::TosaExpOp>>,
+      TosaOpConvert<tosa::FloorOp, UnaryInput1Replace<spirv::TosaFloorOp>>,
+      TosaOpConvert<tosa::LogOp, UnaryInput1Replace<spirv::TosaLogOp>>,
+      TosaOpConvert<tosa::LogicalNotOp,
+                    UnaryInput1Replace<spirv::TosaLogicalNotOp>>,
+      TosaOpConvert<tosa::ReciprocalOp,
+                    UnaryInput1Replace<spirv::TosaReciprocalOp>>,
+      TosaOpConvert<tosa::RsqrtOp, UnaryInput1Replace<spirv::TosaRsqrtOp>>,
+      TosaOpConvert<tosa::SinOp, UnaryInput1Replace<spirv::TosaSinOp>>,
+      TosaOpConvert<tosa::EqualOp,
+                    BinaryElementwiseReplace<spirv::TosaEqualOp>>,
+      TosaOpConvert<tosa::GreaterOp,
+                    BinaryElementwiseReplace<spirv::TosaGreaterOp>>,
+      TosaOpConvert<tosa::GreaterEqualOp,
+                    BinaryElementwiseReplace<spirv::TosaGreaterEqualOp>>>(
       typeConverter, patterns.getContext());
 }
 

--- a/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaOps.cpp
+++ b/mlir/lib/Conversion/TosaToSPIRVTosa/TosaToSPIRVTosaOps.cpp
@@ -39,7 +39,7 @@ DenseIntElementsAttr getI32TensorArmAttr(ArrayRef<int32_t> values,
       values);
 }
 
-template <typename SourceOp, typename Replacer>
+template <typename SourceOp, auto Replace>
 struct TosaOpConvert final : public OpConversionPattern<SourceOp> {
   using OpConversionPattern<SourceOp>::OpConversionPattern;
 
@@ -49,311 +49,302 @@ struct TosaOpConvert final : public OpConversionPattern<SourceOp> {
     Type type = this->getTypeConverter()->convertType(op.getType());
     if (!type)
       return rewriter.notifyMatchFailure(op, "type conversion failed");
-    return Replacer::replace(op, adaptor, type, rewriter);
+    return Replace(op, adaptor, type, rewriter);
   }
 };
 
-template <typename TargetOp>
-struct UnaryInput1Replace {
-  template <typename SourceOp>
-  static LogicalResult replace(SourceOp op, typename SourceOp::Adaptor adaptor,
+template <typename SourceOp, typename TargetOp>
+LogicalResult replaceUnaryInput1(SourceOp op,
+                                 typename SourceOp::Adaptor adaptor, Type type,
+                                 ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOpWithNewOp<TargetOp>(op, type, adaptor.getInput1());
+  return success();
+}
+
+template <typename SourceOp, typename TargetOp>
+LogicalResult replaceUnaryInput(SourceOp op, typename SourceOp::Adaptor adaptor,
+                                Type type,
+                                ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOpWithNewOp<TargetOp>(op, type, adaptor.getInput());
+  return success();
+}
+
+template <typename SourceOp, typename TargetOp>
+LogicalResult
+replaceBinaryElementwise(SourceOp op, typename SourceOp::Adaptor adaptor,
+                         Type type, ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOpWithNewOp<TargetOp>(op, type, adaptor.getInput1(),
+                                        adaptor.getInput2());
+  return success();
+}
+
+template <typename SourceOp, typename TargetOp>
+LogicalResult
+replaceBinaryNanModeElementwise(SourceOp op, typename SourceOp::Adaptor adaptor,
+                                Type type,
+                                ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOpWithNewOp<TargetOp>(
+      op, type, getNanMode(adaptor), adaptor.getInput1(), adaptor.getInput2());
+  return success();
+}
+
+template <typename SourceOp, typename TargetOp>
+LogicalResult replaceReduction(SourceOp op, typename SourceOp::Adaptor adaptor,
                                Type type, ConversionPatternRewriter &rewriter) {
-    rewriter.replaceOpWithNewOp<TargetOp>(op, type, adaptor.getInput1());
-    return success();
-  }
-};
+  rewriter.replaceOpWithNewOp<TargetOp>(op, type, adaptor.getAxis(),
+                                        adaptor.getInput());
+  return success();
+}
 
-template <typename TargetOp>
-struct UnaryInputReplace {
-  template <typename SourceOp>
-  static LogicalResult replace(SourceOp op, typename SourceOp::Adaptor adaptor,
-                               Type type, ConversionPatternRewriter &rewriter) {
-    rewriter.replaceOpWithNewOp<TargetOp>(op, type, adaptor.getInput());
-    return success();
-  }
-};
+template <typename SourceOp, typename TargetOp>
+LogicalResult
+replaceNanModeReduction(SourceOp op, typename SourceOp::Adaptor adaptor,
+                        Type type, ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOpWithNewOp<TargetOp>(
+      op, type, adaptor.getAxis(), getNanMode(adaptor), adaptor.getInput());
+  return success();
+}
 
-template <typename TargetOp>
-struct BinaryElementwiseReplace {
-  template <typename SourceOp>
-  static LogicalResult replace(SourceOp op, typename SourceOp::Adaptor adaptor,
-                               Type type, ConversionPatternRewriter &rewriter) {
-    rewriter.replaceOpWithNewOp<TargetOp>(op, type, adaptor.getInput1(),
-                                          adaptor.getInput2());
-    return success();
-  }
-};
+LogicalResult replaceClamp(tosa::ClampOp op, tosa::ClampOpAdaptor adaptor,
+                           Type type, ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOpWithNewOp<spirv::TosaClampOp>(
+      op, type, adaptor.getMinVal(), adaptor.getMaxVal(), getNanMode(adaptor),
+      adaptor.getInput());
+  return success();
+}
 
-template <typename TargetOp>
-struct BinaryNanModeElementwiseReplace {
-  template <typename SourceOp>
-  static LogicalResult replace(SourceOp op, typename SourceOp::Adaptor adaptor,
-                               Type type, ConversionPatternRewriter &rewriter) {
-    rewriter.replaceOpWithNewOp<TargetOp>(op, type, getNanMode(adaptor),
-                                          adaptor.getInput1(),
-                                          adaptor.getInput2());
-    return success();
-  }
-};
+LogicalResult
+replaceArithmeticRightShift(tosa::ArithmeticRightShiftOp op,
+                            tosa::ArithmeticRightShiftOpAdaptor adaptor,
+                            Type type, ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOpWithNewOp<spirv::TosaArithmeticRightShiftOp>(
+      op, type, adaptor.getRound(), adaptor.getInput1(), adaptor.getInput2());
+  return success();
+}
 
-template <typename TargetOp>
-struct ReductionReplace {
-  template <typename SourceOp>
-  static LogicalResult replace(SourceOp op, typename SourceOp::Adaptor adaptor,
-                               Type type, ConversionPatternRewriter &rewriter) {
-    rewriter.replaceOpWithNewOp<TargetOp>(op, type, adaptor.getAxis(),
-                                          adaptor.getInput());
-    return success();
-  }
-};
+LogicalResult replaceMul(tosa::MulOp op, tosa::MulOpAdaptor adaptor, Type type,
+                         ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOpWithNewOp<spirv::TosaMulOp>(
+      op, type, adaptor.getInput1(), adaptor.getInput2(), adaptor.getShift());
+  return success();
+}
 
-template <typename TargetOp>
-struct NanModeReductionReplace {
-  template <typename SourceOp>
-  static LogicalResult replace(SourceOp op, typename SourceOp::Adaptor adaptor,
-                               Type type, ConversionPatternRewriter &rewriter) {
-    rewriter.replaceOpWithNewOp<TargetOp>(
-        op, type, adaptor.getAxis(), getNanMode(adaptor), adaptor.getInput());
-    return success();
-  }
-};
+LogicalResult replaceTable(tosa::TableOp op, tosa::TableOpAdaptor adaptor,
+                           Type type, ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOpWithNewOp<spirv::TosaTableOp>(op, type, adaptor.getInput1(),
+                                                  adaptor.getTable());
+  return success();
+}
 
-struct ClampReplace {
-  static LogicalResult replace(tosa::ClampOp op, tosa::ClampOpAdaptor adaptor,
-                               Type type, ConversionPatternRewriter &rewriter) {
-    rewriter.replaceOpWithNewOp<spirv::TosaClampOp>(
-        op, type, adaptor.getMinVal(), adaptor.getMaxVal(), getNanMode(adaptor),
-        adaptor.getInput());
-    return success();
-  }
-};
+LogicalResult replaceNegate(tosa::NegateOp op, tosa::NegateOpAdaptor adaptor,
+                            Type type, ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOpWithNewOp<spirv::TosaNegateOp>(
+      op, type, adaptor.getInput1(), adaptor.getInput1Zp(),
+      adaptor.getOutputZp());
+  return success();
+}
 
-struct ArithmeticRightShiftReplace {
-  static LogicalResult replace(tosa::ArithmeticRightShiftOp op,
-                               tosa::ArithmeticRightShiftOpAdaptor adaptor,
-                               Type type, ConversionPatternRewriter &rewriter) {
-    rewriter.replaceOpWithNewOp<spirv::TosaArithmeticRightShiftOp>(
-        op, type, adaptor.getRound(), adaptor.getInput1(), adaptor.getInput2());
-    return success();
-  }
-};
+LogicalResult replaceSelect(tosa::SelectOp op, tosa::SelectOpAdaptor adaptor,
+                            Type type, ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOpWithNewOp<spirv::TosaSelectOp>(
+      op, type, adaptor.getInput1(), adaptor.getInput2(), adaptor.getInput3());
+  return success();
+}
 
-struct MulReplace {
-  static LogicalResult replace(tosa::MulOp op, tosa::MulOpAdaptor adaptor,
-                               Type type, ConversionPatternRewriter &rewriter) {
-    rewriter.replaceOpWithNewOp<spirv::TosaMulOp>(
-        op, type, adaptor.getInput1(), adaptor.getInput2(), adaptor.getShift());
-    return success();
-  }
-};
+LogicalResult replaceReshape(tosa::ReshapeOp op, tosa::ReshapeOpAdaptor adaptor,
+                             Type type, ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOpWithNewOp<spirv::TosaReshapeOp>(
+      op, type, adaptor.getInput1(), adaptor.getShape());
+  return success();
+}
 
-struct TableReplace {
-  static LogicalResult replace(tosa::TableOp op, tosa::TableOpAdaptor adaptor,
-                               Type type, ConversionPatternRewriter &rewriter) {
-    rewriter.replaceOpWithNewOp<spirv::TosaTableOp>(
-        op, type, adaptor.getInput1(), adaptor.getTable());
-    return success();
-  }
-};
+LogicalResult replaceReverse(tosa::ReverseOp op, tosa::ReverseOpAdaptor adaptor,
+                             Type type, ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOpWithNewOp<spirv::TosaReverseOp>(op, type, adaptor.getAxis(),
+                                                    adaptor.getInput1());
+  return success();
+}
 
-struct NegateReplace {
-  static LogicalResult replace(tosa::NegateOp op, tosa::NegateOpAdaptor adaptor,
-                               Type type, ConversionPatternRewriter &rewriter) {
-    rewriter.replaceOpWithNewOp<spirv::TosaNegateOp>(
-        op, type, adaptor.getInput1(), adaptor.getInput1Zp(),
-        adaptor.getOutputZp());
-    return success();
-  }
-};
+LogicalResult replaceSlice(tosa::SliceOp op, tosa::SliceOpAdaptor adaptor,
+                           Type type, ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOpWithNewOp<spirv::TosaSliceOp>(
+      op, type, adaptor.getInput1(), adaptor.getStart(), adaptor.getSize());
+  return success();
+}
 
-struct SelectReplace {
-  static LogicalResult replace(tosa::SelectOp op, tosa::SelectOpAdaptor adaptor,
-                               Type type, ConversionPatternRewriter &rewriter) {
-    rewriter.replaceOpWithNewOp<spirv::TosaSelectOp>(
-        op, type, adaptor.getInput1(), adaptor.getInput2(),
-        adaptor.getInput3());
-    return success();
-  }
-};
+LogicalResult replaceTile(tosa::TileOp op, tosa::TileOpAdaptor adaptor,
+                          Type type, ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOpWithNewOp<spirv::TosaTileOp>(op, type, adaptor.getInput1(),
+                                                 adaptor.getMultiples());
+  return success();
+}
 
-struct ReshapeReplace {
-  static LogicalResult replace(tosa::ReshapeOp op,
-                               tosa::ReshapeOpAdaptor adaptor, Type type,
-                               ConversionPatternRewriter &rewriter) {
-    rewriter.replaceOpWithNewOp<spirv::TosaReshapeOp>(
-        op, type, adaptor.getInput1(), adaptor.getShape());
-    return success();
-  }
-};
-
-struct ReverseReplace {
-  static LogicalResult replace(tosa::ReverseOp op,
-                               tosa::ReverseOpAdaptor adaptor, Type type,
-                               ConversionPatternRewriter &rewriter) {
-    rewriter.replaceOpWithNewOp<spirv::TosaReverseOp>(
-        op, type, adaptor.getAxis(), adaptor.getInput1());
-    return success();
-  }
-};
-
-struct SliceReplace {
-  static LogicalResult replace(tosa::SliceOp op, tosa::SliceOpAdaptor adaptor,
-                               Type type, ConversionPatternRewriter &rewriter) {
-    rewriter.replaceOpWithNewOp<spirv::TosaSliceOp>(
-        op, type, adaptor.getInput1(), adaptor.getStart(), adaptor.getSize());
-    return success();
-  }
-};
-
-struct TileReplace {
-  static LogicalResult replace(tosa::TileOp op, tosa::TileOpAdaptor adaptor,
-                               Type type, ConversionPatternRewriter &rewriter) {
-    rewriter.replaceOpWithNewOp<spirv::TosaTileOp>(
-        op, type, adaptor.getInput1(), adaptor.getMultiples());
-    return success();
-  }
-};
-
-struct TransposeReplace {
-  static LogicalResult replace(tosa::TransposeOp op,
+LogicalResult replaceTranspose(tosa::TransposeOp op,
                                tosa::TransposeOpAdaptor adaptor, Type type,
                                ConversionPatternRewriter &rewriter) {
-    DenseIntElementsAttr perms =
-        getI32TensorArmAttr(adaptor.getPerms(), rewriter);
-    rewriter.replaceOpWithNewOp<spirv::TosaTransposeOp>(op, type, perms,
-                                                        adaptor.getInput1());
-    return success();
-  }
-};
+  DenseIntElementsAttr perms =
+      getI32TensorArmAttr(adaptor.getPerms(), rewriter);
+  rewriter.replaceOpWithNewOp<spirv::TosaTransposeOp>(op, type, perms,
+                                                      adaptor.getInput1());
+  return success();
+}
 
-struct GatherReplace {
-  static LogicalResult replace(tosa::GatherOp op, tosa::GatherOpAdaptor adaptor,
-                               Type type, ConversionPatternRewriter &rewriter) {
-    rewriter.replaceOpWithNewOp<spirv::TosaGatherOp>(
-        op, type, adaptor.getValues(), adaptor.getIndices());
-    return success();
-  }
-};
+LogicalResult replaceGather(tosa::GatherOp op, tosa::GatherOpAdaptor adaptor,
+                            Type type, ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOpWithNewOp<spirv::TosaGatherOp>(
+      op, type, adaptor.getValues(), adaptor.getIndices());
+  return success();
+}
 
-struct ScatterReplace {
-  static LogicalResult replace(tosa::ScatterOp op,
-                               tosa::ScatterOpAdaptor adaptor, Type type,
-                               ConversionPatternRewriter &rewriter) {
-    rewriter.replaceOpWithNewOp<spirv::TosaScatterOp>(
-        op, type, adaptor.getValuesIn(), adaptor.getIndices(),
-        adaptor.getInput());
-    return success();
-  }
-};
+LogicalResult replaceScatter(tosa::ScatterOp op, tosa::ScatterOpAdaptor adaptor,
+                             Type type, ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOpWithNewOp<spirv::TosaScatterOp>(
+      op, type, adaptor.getValuesIn(), adaptor.getIndices(),
+      adaptor.getInput());
+  return success();
+}
 
-struct ResizeReplace {
-  static LogicalResult replace(tosa::ResizeOp op, tosa::ResizeOpAdaptor adaptor,
-                               Type type, ConversionPatternRewriter &rewriter) {
-    rewriter.replaceOpWithNewOp<spirv::TosaResizeOp>(
-        op, type, getResizeMode(adaptor), adaptor.getInput(),
-        adaptor.getScale(), adaptor.getOffset(), adaptor.getBorder());
-    return success();
-  }
-};
+LogicalResult replaceResize(tosa::ResizeOp op, tosa::ResizeOpAdaptor adaptor,
+                            Type type, ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOpWithNewOp<spirv::TosaResizeOp>(
+      op, type, getResizeMode(adaptor), adaptor.getInput(), adaptor.getScale(),
+      adaptor.getOffset(), adaptor.getBorder());
+  return success();
+}
 
-struct ConstShapeReplace {
-  static LogicalResult replace(tosa::ConstShapeOp op,
-                               tosa::ConstShapeOpAdaptor adaptor, Type type,
-                               ConversionPatternRewriter &rewriter) {
-    SmallVector<int32_t> values;
-    for (const APInt &value : adaptor.getValues().getValues<APInt>())
-      values.push_back(value.getSExtValue());
+LogicalResult replaceConstShape(tosa::ConstShapeOp op,
+                                tosa::ConstShapeOpAdaptor adaptor, Type type,
+                                ConversionPatternRewriter &rewriter) {
+  SmallVector<int32_t> values;
+  for (const APInt &value : adaptor.getValues().getValues<APInt>())
+    values.push_back(value.getSExtValue());
 
-    rewriter.replaceOpWithNewOp<spirv::ConstantOp>(
-        op, type, getI32TensorArmAttr(values, rewriter));
-    return success();
-  }
-};
+  rewriter.replaceOpWithNewOp<spirv::ConstantOp>(
+      op, type, getI32TensorArmAttr(values, rewriter));
+  return success();
+}
 
 } // namespace
 
 void populateTosaToSPIRVTosaOpsConversionPatterns(
     SPIRVTypeConverter &typeConverter, RewritePatternSet &patterns) {
   patterns.add<
-      TosaOpConvert<tosa::ArgMaxOp,
-                    NanModeReductionReplace<spirv::TosaArgMaxOp>>,
-      TosaOpConvert<tosa::ClampOp, ClampReplace>,
-      TosaOpConvert<tosa::ErfOp, UnaryInputReplace<spirv::TosaErfOp>>,
-      TosaOpConvert<tosa::SigmoidOp, UnaryInputReplace<spirv::TosaSigmoidOp>>,
-      TosaOpConvert<tosa::TanhOp, UnaryInputReplace<spirv::TosaTanhOp>>,
-      TosaOpConvert<tosa::AddOp, BinaryElementwiseReplace<spirv::TosaAddOp>>,
-      TosaOpConvert<tosa::ArithmeticRightShiftOp, ArithmeticRightShiftReplace>,
+      TosaOpConvert<tosa::ArgMaxOp, replaceNanModeReduction<
+                                        tosa::ArgMaxOp, spirv::TosaArgMaxOp>>,
+      TosaOpConvert<tosa::ClampOp, replaceClamp>,
+      TosaOpConvert<tosa::ErfOp,
+                    replaceUnaryInput<tosa::ErfOp, spirv::TosaErfOp>>,
+      TosaOpConvert<tosa::SigmoidOp,
+                    replaceUnaryInput<tosa::SigmoidOp, spirv::TosaSigmoidOp>>,
+      TosaOpConvert<tosa::TanhOp,
+                    replaceUnaryInput<tosa::TanhOp, spirv::TosaTanhOp>>,
+      TosaOpConvert<tosa::AddOp,
+                    replaceBinaryElementwise<tosa::AddOp, spirv::TosaAddOp>>,
+      TosaOpConvert<tosa::ArithmeticRightShiftOp, replaceArithmeticRightShift>,
       TosaOpConvert<tosa::BitwiseAndOp,
-                    BinaryElementwiseReplace<spirv::TosaBitwiseAndOp>>,
-      TosaOpConvert<tosa::BitwiseOrOp,
-                    BinaryElementwiseReplace<spirv::TosaBitwiseOrOp>>,
+                    replaceBinaryElementwise<tosa::BitwiseAndOp,
+                                             spirv::TosaBitwiseAndOp>>,
+      TosaOpConvert<
+          tosa::BitwiseOrOp,
+          replaceBinaryElementwise<tosa::BitwiseOrOp, spirv::TosaBitwiseOrOp>>,
       TosaOpConvert<tosa::BitwiseXorOp,
-                    BinaryElementwiseReplace<spirv::TosaBitwiseXorOp>>,
-      TosaOpConvert<tosa::IntDivOp,
-                    BinaryElementwiseReplace<spirv::TosaIntDivOp>>,
+                    replaceBinaryElementwise<tosa::BitwiseXorOp,
+                                             spirv::TosaBitwiseXorOp>>,
+      TosaOpConvert<tosa::IntDivOp, replaceBinaryElementwise<
+                                        tosa::IntDivOp, spirv::TosaIntDivOp>>,
       TosaOpConvert<tosa::LogicalAndOp,
-                    BinaryElementwiseReplace<spirv::TosaLogicalAndOp>>,
+                    replaceBinaryElementwise<tosa::LogicalAndOp,
+                                             spirv::TosaLogicalAndOp>>,
       TosaOpConvert<tosa::LogicalLeftShiftOp,
-                    BinaryElementwiseReplace<spirv::TosaLogicalLeftShiftOp>>,
+                    replaceBinaryElementwise<tosa::LogicalLeftShiftOp,
+                                             spirv::TosaLogicalLeftShiftOp>>,
       TosaOpConvert<tosa::LogicalRightShiftOp,
-                    BinaryElementwiseReplace<spirv::TosaLogicalRightShiftOp>>,
-      TosaOpConvert<tosa::LogicalOrOp,
-                    BinaryElementwiseReplace<spirv::TosaLogicalOrOp>>,
+                    replaceBinaryElementwise<tosa::LogicalRightShiftOp,
+                                             spirv::TosaLogicalRightShiftOp>>,
+      TosaOpConvert<
+          tosa::LogicalOrOp,
+          replaceBinaryElementwise<tosa::LogicalOrOp, spirv::TosaLogicalOrOp>>,
       TosaOpConvert<tosa::LogicalXorOp,
-                    BinaryElementwiseReplace<spirv::TosaLogicalXorOp>>,
+                    replaceBinaryElementwise<tosa::LogicalXorOp,
+                                             spirv::TosaLogicalXorOp>>,
       TosaOpConvert<tosa::MaximumOp,
-                    BinaryNanModeElementwiseReplace<spirv::TosaMaximumOp>>,
+                    replaceBinaryNanModeElementwise<tosa::MaximumOp,
+                                                    spirv::TosaMaximumOp>>,
       TosaOpConvert<tosa::MinimumOp,
-                    BinaryNanModeElementwiseReplace<spirv::TosaMinimumOp>>,
-      TosaOpConvert<tosa::MulOp, MulReplace>,
-      TosaOpConvert<tosa::PowOp, BinaryElementwiseReplace<spirv::TosaPowOp>>,
-      TosaOpConvert<tosa::SubOp, BinaryElementwiseReplace<spirv::TosaSubOp>>,
-      TosaOpConvert<tosa::TableOp, TableReplace>,
-      TosaOpConvert<tosa::AbsOp, UnaryInput1Replace<spirv::TosaAbsOp>>,
-      TosaOpConvert<tosa::BitwiseNotOp,
-                    UnaryInput1Replace<spirv::TosaBitwiseNotOp>>,
-      TosaOpConvert<tosa::CeilOp, UnaryInput1Replace<spirv::TosaCeilOp>>,
-      TosaOpConvert<tosa::ClzOp, UnaryInput1Replace<spirv::TosaClzOp>>,
-      TosaOpConvert<tosa::CosOp, UnaryInput1Replace<spirv::TosaCosOp>>,
-      TosaOpConvert<tosa::ExpOp, UnaryInput1Replace<spirv::TosaExpOp>>,
-      TosaOpConvert<tosa::FloorOp, UnaryInput1Replace<spirv::TosaFloorOp>>,
-      TosaOpConvert<tosa::LogOp, UnaryInput1Replace<spirv::TosaLogOp>>,
-      TosaOpConvert<tosa::LogicalNotOp,
-                    UnaryInput1Replace<spirv::TosaLogicalNotOp>>,
-      TosaOpConvert<tosa::NegateOp, NegateReplace>,
-      TosaOpConvert<tosa::ReciprocalOp,
-                    UnaryInput1Replace<spirv::TosaReciprocalOp>>,
-      TosaOpConvert<tosa::RsqrtOp, UnaryInput1Replace<spirv::TosaRsqrtOp>>,
-      TosaOpConvert<tosa::SinOp, UnaryInput1Replace<spirv::TosaSinOp>>,
-      TosaOpConvert<tosa::SelectOp, SelectReplace>,
-      TosaOpConvert<tosa::EqualOp,
-                    BinaryElementwiseReplace<spirv::TosaEqualOp>>,
-      TosaOpConvert<tosa::GreaterOp,
-                    BinaryElementwiseReplace<spirv::TosaGreaterOp>>,
+                    replaceBinaryNanModeElementwise<tosa::MinimumOp,
+                                                    spirv::TosaMinimumOp>>,
+      TosaOpConvert<tosa::MulOp, replaceMul>,
+      TosaOpConvert<tosa::PowOp,
+                    replaceBinaryElementwise<tosa::PowOp, spirv::TosaPowOp>>,
+      TosaOpConvert<tosa::SubOp,
+                    replaceBinaryElementwise<tosa::SubOp, spirv::TosaSubOp>>,
+      TosaOpConvert<tosa::TableOp, replaceTable>,
+      TosaOpConvert<tosa::AbsOp,
+                    replaceUnaryInput1<tosa::AbsOp, spirv::TosaAbsOp>>,
+      TosaOpConvert<
+          tosa::BitwiseNotOp,
+          replaceUnaryInput1<tosa::BitwiseNotOp, spirv::TosaBitwiseNotOp>>,
+      TosaOpConvert<tosa::CeilOp,
+                    replaceUnaryInput1<tosa::CeilOp, spirv::TosaCeilOp>>,
+      TosaOpConvert<tosa::ClzOp,
+                    replaceUnaryInput1<tosa::ClzOp, spirv::TosaClzOp>>,
+      TosaOpConvert<tosa::CosOp,
+                    replaceUnaryInput1<tosa::CosOp, spirv::TosaCosOp>>,
+      TosaOpConvert<tosa::ExpOp,
+                    replaceUnaryInput1<tosa::ExpOp, spirv::TosaExpOp>>,
+      TosaOpConvert<tosa::FloorOp,
+                    replaceUnaryInput1<tosa::FloorOp, spirv::TosaFloorOp>>,
+      TosaOpConvert<tosa::LogOp,
+                    replaceUnaryInput1<tosa::LogOp, spirv::TosaLogOp>>,
+      TosaOpConvert<
+          tosa::LogicalNotOp,
+          replaceUnaryInput1<tosa::LogicalNotOp, spirv::TosaLogicalNotOp>>,
+      TosaOpConvert<tosa::NegateOp, replaceNegate>,
+      TosaOpConvert<
+          tosa::ReciprocalOp,
+          replaceUnaryInput1<tosa::ReciprocalOp, spirv::TosaReciprocalOp>>,
+      TosaOpConvert<tosa::RsqrtOp,
+                    replaceUnaryInput1<tosa::RsqrtOp, spirv::TosaRsqrtOp>>,
+      TosaOpConvert<tosa::SinOp,
+                    replaceUnaryInput1<tosa::SinOp, spirv::TosaSinOp>>,
+      TosaOpConvert<tosa::SelectOp, replaceSelect>,
+      TosaOpConvert<tosa::EqualOp, replaceBinaryElementwise<
+                                       tosa::EqualOp, spirv::TosaEqualOp>>,
+      TosaOpConvert<
+          tosa::GreaterOp,
+          replaceBinaryElementwise<tosa::GreaterOp, spirv::TosaGreaterOp>>,
       TosaOpConvert<tosa::GreaterEqualOp,
-                    BinaryElementwiseReplace<spirv::TosaGreaterEqualOp>>,
-      TosaOpConvert<tosa::ReduceAllOp,
-                    ReductionReplace<spirv::TosaReduceAllOp>>,
-      TosaOpConvert<tosa::ReduceAnyOp,
-                    ReductionReplace<spirv::TosaReduceAnyOp>>,
-      TosaOpConvert<tosa::ReduceMaxOp,
-                    NanModeReductionReplace<spirv::TosaReduceMaxOp>>,
-      TosaOpConvert<tosa::ReduceMinOp,
-                    NanModeReductionReplace<spirv::TosaReduceMinOp>>,
-      TosaOpConvert<tosa::ReduceProductOp,
-                    ReductionReplace<spirv::TosaReduceProductOp>>,
-      TosaOpConvert<tosa::ReduceSumOp,
-                    ReductionReplace<spirv::TosaReduceSumOp>>,
-      TosaOpConvert<tosa::ReshapeOp, ReshapeReplace>,
-      TosaOpConvert<tosa::ReverseOp, ReverseReplace>,
-      TosaOpConvert<tosa::SliceOp, SliceReplace>,
-      TosaOpConvert<tosa::TileOp, TileReplace>,
-      TosaOpConvert<tosa::TransposeOp, TransposeReplace>,
-      TosaOpConvert<tosa::GatherOp, GatherReplace>,
-      TosaOpConvert<tosa::ScatterOp, ScatterReplace>,
-      TosaOpConvert<tosa::ResizeOp, ResizeReplace>,
-      TosaOpConvert<tosa::CastOp, UnaryInputReplace<spirv::TosaCastOp>>,
-      TosaOpConvert<tosa::ConstShapeOp, ConstShapeReplace>>(
+                    replaceBinaryElementwise<tosa::GreaterEqualOp,
+                                             spirv::TosaGreaterEqualOp>>,
+      TosaOpConvert<
+          tosa::ReduceAllOp,
+          replaceReduction<tosa::ReduceAllOp, spirv::TosaReduceAllOp>>,
+      TosaOpConvert<
+          tosa::ReduceAnyOp,
+          replaceReduction<tosa::ReduceAnyOp, spirv::TosaReduceAnyOp>>,
+      TosaOpConvert<
+          tosa::ReduceMaxOp,
+          replaceNanModeReduction<tosa::ReduceMaxOp, spirv::TosaReduceMaxOp>>,
+      TosaOpConvert<
+          tosa::ReduceMinOp,
+          replaceNanModeReduction<tosa::ReduceMinOp, spirv::TosaReduceMinOp>>,
+      TosaOpConvert<
+          tosa::ReduceProductOp,
+          replaceReduction<tosa::ReduceProductOp, spirv::TosaReduceProductOp>>,
+      TosaOpConvert<
+          tosa::ReduceSumOp,
+          replaceReduction<tosa::ReduceSumOp, spirv::TosaReduceSumOp>>,
+      TosaOpConvert<tosa::ReshapeOp, replaceReshape>,
+      TosaOpConvert<tosa::ReverseOp, replaceReverse>,
+      TosaOpConvert<tosa::SliceOp, replaceSlice>,
+      TosaOpConvert<tosa::TileOp, replaceTile>,
+      TosaOpConvert<tosa::TransposeOp, replaceTranspose>,
+      TosaOpConvert<tosa::GatherOp, replaceGather>,
+      TosaOpConvert<tosa::ScatterOp, replaceScatter>,
+      TosaOpConvert<tosa::ResizeOp, replaceResize>,
+      TosaOpConvert<tosa::CastOp,
+                    replaceUnaryInput<tosa::CastOp, spirv::TosaCastOp>>,
+      TosaOpConvert<tosa::ConstShapeOp, replaceConstShape>>(
       typeConverter, patterns.getContext());
 }
 

--- a/mlir/test/Conversion/TosaToSPIRVTosa/tosa-to-spirv.mlir
+++ b/mlir/test/Conversion/TosaToSPIRVTosa/tosa-to-spirv.mlir
@@ -1,6 +1,32 @@
 // RUN: mlir-opt --split-input-file --tosa-to-spirv-tosa %s | FileCheck %s
 
 //===----------------------------------------------------------------------===//
+// spirv.TOSA.ArgMax
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: spirv.ARM.Graph @argmax_int
+func.func @argmax_int(%arg0: tensor<2x3x4xi8>) -> tensor<2x4xi32> {
+  // CHECK: %[[ARGMAX:.*]] = spirv.Tosa.ArgMax axis = 1, nan_mode = <Propagate>, %arg0 : !spirv.arm.tensor<2x3x4xi8> -> !spirv.arm.tensor<2x4xi32>
+  %res = tosa.argmax %arg0 {axis = 1 : i32, nan_mode = PROPAGATE} : (tensor<2x3x4xi8>) -> tensor<2x4xi32>
+  return %res : tensor<2x4xi32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Clamp
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: spirv.ARM.Graph @clamp_int
+func.func @clamp_int(%arg0: tensor<4x8xi8>) -> tensor<4x8xi8> {
+  // CHECK: %[[CLAMP:.*]] = spirv.Tosa.Clamp min_val = -2 : i8, max_val = 3 : i8, nan_mode = <Propagate>, %arg0 : !spirv.arm.tensor<4x8xi8> -> !spirv.arm.tensor<4x8xi8>
+  %res = tosa.clamp %arg0 {min_val = -2 : i8, max_val = 3 : i8, nan_mode = PROPAGATE} : (tensor<4x8xi8>) -> tensor<4x8xi8>
+  return %res : tensor<4x8xi8>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
 // spirv.TOSA.Erf
 //===----------------------------------------------------------------------===//
 
@@ -48,6 +74,19 @@ func.func @add_int(%arg0: tensor<4x7x3x10xi32>, %arg1: tensor<4x7x3x1xi32>) -> t
   // CHECK: %[[ADD:.*]] = spirv.Tosa.Add  %arg0, %arg1 : !spirv.arm.tensor<4x7x3x10xi32>, !spirv.arm.tensor<4x7x3x1xi32> -> !spirv.arm.tensor<4x7x3x10xi32>
   %res = tosa.add %arg0, %arg1  : (tensor<4x7x3x10xi32>, tensor<4x7x3x1xi32>) -> tensor<4x7x3x10xi32>
   return %res : tensor<4x7x3x10xi32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.ArithmeticRightShift
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: spirv.ARM.Graph @arithmetic_right_shift_int
+func.func @arithmetic_right_shift_int(%arg0: tensor<1x4xi16>, %arg1: tensor<3x4xi16>) -> tensor<3x4xi16> {
+  // CHECK: %[[SHIFT:.*]] = spirv.Tosa.ArithmeticRightShift round = true, %arg0, %arg1 : !spirv.arm.tensor<1x4xi16>, !spirv.arm.tensor<3x4xi16> -> !spirv.arm.tensor<3x4xi16>
+  %res = tosa.arithmetic_right_shift %arg0, %arg1 {round = true} : (tensor<1x4xi16>, tensor<3x4xi16>) -> tensor<3x4xi16>
+  return %res : tensor<3x4xi16>
 }
 
 // -----
@@ -196,6 +235,19 @@ func.func @minimum_int(%arg0: tensor<15x2x10x11xi32>, %arg1: tensor<15x1x10x11xi
 // -----
 
 //===----------------------------------------------------------------------===//
+// spirv.TOSA.Mul
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: spirv.ARM.Graph @mul_int
+func.func @mul_int(%arg0: tensor<2x4xi32>, %arg1: tensor<2x1xi32>, %arg2: tensor<1xi8>) -> tensor<2x4xi32> {
+  // CHECK: %[[MUL:.*]] = spirv.Tosa.Mul  %arg0, %arg1, %arg2 : !spirv.arm.tensor<2x4xi32>, !spirv.arm.tensor<2x1xi32>, !spirv.arm.tensor<1xi8> -> !spirv.arm.tensor<2x4xi32>
+  %res = tosa.mul %arg0, %arg1, %arg2 : (tensor<2x4xi32>, tensor<2x1xi32>, tensor<1xi8>) -> tensor<2x4xi32>
+  return %res : tensor<2x4xi32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
 // spirv.TOSA.Pow
 //===----------------------------------------------------------------------===//
 
@@ -217,6 +269,19 @@ func.func @sub_int(%arg0: tensor<6x10x6x6xi32>, %arg1: tensor<1x10x6x6xi32>) -> 
   // CHECK: %[[SUB:.*]] = spirv.Tosa.Sub  %arg0, %arg1 : !spirv.arm.tensor<6x10x6x6xi32>, !spirv.arm.tensor<1x10x6x6xi32> -> !spirv.arm.tensor<6x10x6x6xi32>
   %res = tosa.sub %arg0, %arg1  : (tensor<6x10x6x6xi32>, tensor<1x10x6x6xi32>) -> tensor<6x10x6x6xi32>
   return %res : tensor<6x10x6x6xi32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Table
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: spirv.ARM.Graph @table_int
+func.func @table_int(%arg0: tensor<3x2xi8>, %arg1: tensor<256xi8>) -> tensor<3x2xi8> {
+  // CHECK: %[[TABLE:.*]] = spirv.Tosa.Table  %arg0, %arg1 : !spirv.arm.tensor<3x2xi8>, !spirv.arm.tensor<256xi8> -> !spirv.arm.tensor<3x2xi8>
+  %res = tosa.table %arg0, %arg1 : (tensor<3x2xi8>, tensor<256xi8>) -> tensor<3x2xi8>
+  return %res : tensor<3x2xi8>
 }
 
 // -----
@@ -339,6 +404,19 @@ func.func @logicalnot_any(%arg0: tensor<54x26x10xi1>) -> tensor<54x26x10xi1> {
 // -----
 
 //===----------------------------------------------------------------------===//
+// spirv.TOSA.Negate
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: spirv.ARM.Graph @negate_int
+func.func @negate_int(%arg0: tensor<2x3xi8>, %arg1: tensor<1xi8>, %arg2: tensor<1xi8>) -> tensor<2x3xi8> {
+  // CHECK: %[[NEGATE:.*]] = spirv.Tosa.Negate  %arg0, %arg1, %arg2 : !spirv.arm.tensor<2x3xi8>, !spirv.arm.tensor<1xi8>, !spirv.arm.tensor<1xi8> -> !spirv.arm.tensor<2x3xi8>
+  %res = tosa.negate %arg0, %arg1, %arg2 : (tensor<2x3xi8>, tensor<1xi8>, tensor<1xi8>) -> tensor<2x3xi8>
+  return %res : tensor<2x3xi8>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
 // spirv.TOSA.Reciprocal
 //===----------------------------------------------------------------------===//
 
@@ -373,6 +451,19 @@ func.func @sin_fp(%arg0: tensor<49x38x58xf16>) -> tensor<49x38x58xf16> {
   // CHECK: %[[SIN:.*]] = spirv.Tosa.Sin  %arg0 : !spirv.arm.tensor<49x38x58xf16> -> !spirv.arm.tensor<49x38x58xf16>
   %res = tosa.sin %arg0  : (tensor<49x38x58xf16>) -> tensor<49x38x58xf16>
   return %res : tensor<49x38x58xf16>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Select
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: spirv.ARM.Graph @select_int
+func.func @select_int(%arg0: tensor<2x1xi1>, %arg1: tensor<2x4xi8>, %arg2: tensor<2x4xi8>) -> tensor<2x4xi8> {
+  // CHECK: %[[SELECT:.*]] = spirv.Tosa.Select  %arg0, %arg1, %arg2 : !spirv.arm.tensor<2x1xi1>, !spirv.arm.tensor<2x4xi8>, !spirv.arm.tensor<2x4xi8> -> !spirv.arm.tensor<2x4xi8>
+  %res = tosa.select %arg0, %arg1, %arg2 : (tensor<2x1xi1>, tensor<2x4xi8>, tensor<2x4xi8>) -> tensor<2x4xi8>
+  return %res : tensor<2x4xi8>
 }
 
 // -----
@@ -414,3 +505,211 @@ func.func @greaterequal_int(%arg0: tensor<10x17x7x1xi32>, %arg1: tensor<10x17x7x
   return %res : tensor<10x17x7x16xi1>
 }
 
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.ReduceAll
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: spirv.ARM.Graph @reduce_all
+func.func @reduce_all(%arg0: tensor<2x3x4xi1>) -> tensor<2x1x4xi1> {
+  // CHECK: %[[REDUCE:.*]] = spirv.Tosa.ReduceAll axis = 1, %arg0 : !spirv.arm.tensor<2x3x4xi1> -> !spirv.arm.tensor<2x1x4xi1>
+  %res = tosa.reduce_all %arg0 {axis = 1 : i32} : (tensor<2x3x4xi1>) -> tensor<2x1x4xi1>
+  return %res : tensor<2x1x4xi1>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.ReduceAny
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: spirv.ARM.Graph @reduce_any
+func.func @reduce_any(%arg0: tensor<2x3x4xi1>) -> tensor<2x1x4xi1> {
+  // CHECK: %[[REDUCE:.*]] = spirv.Tosa.ReduceAny axis = 1, %arg0 : !spirv.arm.tensor<2x3x4xi1> -> !spirv.arm.tensor<2x1x4xi1>
+  %res = tosa.reduce_any %arg0 {axis = 1 : i32} : (tensor<2x3x4xi1>) -> tensor<2x1x4xi1>
+  return %res : tensor<2x1x4xi1>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.ReduceMax
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: spirv.ARM.Graph @reduce_max_int
+func.func @reduce_max_int(%arg0: tensor<2x3x4xi8>) -> tensor<2x1x4xi8> {
+  // CHECK: %[[REDUCE:.*]] = spirv.Tosa.ReduceMax axis = 1, nan_mode = <Propagate>, %arg0 : !spirv.arm.tensor<2x3x4xi8> -> !spirv.arm.tensor<2x1x4xi8>
+  %res = tosa.reduce_max %arg0 {axis = 1 : i32, nan_mode = PROPAGATE} : (tensor<2x3x4xi8>) -> tensor<2x1x4xi8>
+  return %res : tensor<2x1x4xi8>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.ReduceMin
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: spirv.ARM.Graph @reduce_min_int
+func.func @reduce_min_int(%arg0: tensor<2x3x4xi8>) -> tensor<2x1x4xi8> {
+  // CHECK: %[[REDUCE:.*]] = spirv.Tosa.ReduceMin axis = 1, nan_mode = <Propagate>, %arg0 : !spirv.arm.tensor<2x3x4xi8> -> !spirv.arm.tensor<2x1x4xi8>
+  %res = tosa.reduce_min %arg0 {axis = 1 : i32, nan_mode = PROPAGATE} : (tensor<2x3x4xi8>) -> tensor<2x1x4xi8>
+  return %res : tensor<2x1x4xi8>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.ReduceProduct
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: spirv.ARM.Graph @reduce_product_fp
+func.func @reduce_product_fp(%arg0: tensor<2x3x4xf32>) -> tensor<2x1x4xf32> {
+  // CHECK: %[[REDUCE:.*]] = spirv.Tosa.ReduceProduct axis = 1, %arg0 : !spirv.arm.tensor<2x3x4xf32> -> !spirv.arm.tensor<2x1x4xf32>
+  %res = tosa.reduce_product %arg0 {axis = 1 : i32} : (tensor<2x3x4xf32>) -> tensor<2x1x4xf32>
+  return %res : tensor<2x1x4xf32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.ReduceSum
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: spirv.ARM.Graph @reduce_sum_int
+func.func @reduce_sum_int(%arg0: tensor<2x3x4xi32>) -> tensor<2x1x4xi32> {
+  // CHECK: %[[REDUCE:.*]] = spirv.Tosa.ReduceSum axis = 1, %arg0 : !spirv.arm.tensor<2x3x4xi32> -> !spirv.arm.tensor<2x1x4xi32>
+  %res = tosa.reduce_sum %arg0 {axis = 1 : i32} : (tensor<2x3x4xi32>) -> tensor<2x1x4xi32>
+  return %res : tensor<2x1x4xi32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Reshape
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: spirv.ARM.Graph @reshape_int
+func.func @reshape_int(%arg0: tensor<25x6x29x35xi16>) -> tensor<125x6x7x29xi16> {
+  %shape = "tosa.const_shape"() <{values = dense<[125, 6, 7, 29]> : tensor<4xindex>}> : () -> !tosa.shape<4>
+  // CHECK: %[[SHAPE:.*]] = spirv.Constant dense<[125, 6, 7, 29]> : !spirv.arm.tensor<4xi32>
+  // CHECK: %[[RESHAPE:.*]] = spirv.Tosa.Reshape  %arg0, %[[SHAPE]] : !spirv.arm.tensor<25x6x29x35xi16>, !spirv.arm.tensor<4xi32> -> !spirv.arm.tensor<125x6x7x29xi16>
+  %res = tosa.reshape %arg0, %shape : (tensor<25x6x29x35xi16>, !tosa.shape<4>) -> tensor<125x6x7x29xi16>
+  return %res : tensor<125x6x7x29xi16>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Reverse
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: spirv.ARM.Graph @reverse_int
+func.func @reverse_int(%arg0: tensor<20x5x28x31xi32>) -> tensor<20x5x28x31xi32> {
+  // CHECK: %[[REVERSE:.*]] = spirv.Tosa.Reverse axis = 2, %arg0 : !spirv.arm.tensor<20x5x28x31xi32> -> !spirv.arm.tensor<20x5x28x31xi32>
+  %res = tosa.reverse %arg0 {axis = 2 : i32} : (tensor<20x5x28x31xi32>) -> tensor<20x5x28x31xi32>
+  return %res : tensor<20x5x28x31xi32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Slice
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: spirv.ARM.Graph @slice_int
+func.func @slice_int(%arg0: tensor<32x19x41xi8>) -> tensor<21x5x2xi8> {
+  %start = "tosa.const_shape"() <{values = dense<[8, 11, 39]> : tensor<3xindex>}> : () -> !tosa.shape<3>
+  %size = "tosa.const_shape"() <{values = dense<[21, 5, 2]> : tensor<3xindex>}> : () -> !tosa.shape<3>
+  // CHECK: %[[START:.*]] = spirv.Constant dense<[8, 11, 39]> : !spirv.arm.tensor<3xi32>
+  // CHECK: %[[SIZE:.*]] = spirv.Constant dense<[21, 5, 2]> : !spirv.arm.tensor<3xi32>
+  // CHECK: %[[SLICE:.*]] = spirv.Tosa.Slice  %arg0, %[[START]], %[[SIZE]] : !spirv.arm.tensor<32x19x41xi8>, !spirv.arm.tensor<3xi32>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<21x5x2xi8>
+  %res = tosa.slice %arg0, %start, %size : (tensor<32x19x41xi8>, !tosa.shape<3>, !tosa.shape<3>) -> tensor<21x5x2xi8>
+  return %res : tensor<21x5x2xi8>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Tile
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: spirv.ARM.Graph @tile_int
+func.func @tile_int(%arg0: tensor<10x28x21xi16>) -> tensor<10x28x63xi16> {
+  %multiples = "tosa.const_shape"() <{values = dense<[1, 1, 3]> : tensor<3xindex>}> : () -> !tosa.shape<3>
+  // CHECK: %[[MULTIPLES:.*]] = spirv.Constant dense<[1, 1, 3]> : !spirv.arm.tensor<3xi32>
+  // CHECK: %[[TILE:.*]] = spirv.Tosa.Tile  %arg0, %[[MULTIPLES]] : !spirv.arm.tensor<10x28x21xi16>, !spirv.arm.tensor<3xi32> -> !spirv.arm.tensor<10x28x63xi16>
+  %res = tosa.tile %arg0, %multiples : (tensor<10x28x21xi16>, !tosa.shape<3>) -> tensor<10x28x63xi16>
+  return %res : tensor<10x28x63xi16>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Transpose
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: spirv.ARM.Graph @transpose_int
+func.func @transpose_int(%arg0: tensor<14x28x1x61xi16>) -> tensor<1x14x28x61xi16> {
+  // CHECK: %[[TRANSPOSE:.*]] = spirv.Tosa.Transpose perms = [2, 0, 1, 3], %arg0 : !spirv.arm.tensor<14x28x1x61xi16> -> !spirv.arm.tensor<1x14x28x61xi16>
+  %res = tosa.transpose %arg0 {perms = array<i32: 2, 0, 1, 3>} : (tensor<14x28x1x61xi16>) -> tensor<1x14x28x61xi16>
+  return %res : tensor<1x14x28x61xi16>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Gather
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: spirv.ARM.Graph @gather_int
+func.func @gather_int(%arg0: tensor<31x11x45xi32>, %arg1: tensor<31x15xi32>) -> tensor<31x15x45xi32> {
+  // CHECK: %[[GATHER:.*]] = spirv.Tosa.Gather  %arg0, %arg1 : !spirv.arm.tensor<31x11x45xi32>, !spirv.arm.tensor<31x15xi32> -> !spirv.arm.tensor<31x15x45xi32>
+  %res = tosa.gather %arg0, %arg1 : (tensor<31x11x45xi32>, tensor<31x15xi32>) -> tensor<31x15x45xi32>
+  return %res : tensor<31x15x45xi32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Scatter
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: spirv.ARM.Graph @scatter_int
+func.func @scatter_int(%arg0: tensor<34x28x54xi32>, %arg1: tensor<34x18xi32>, %arg2: tensor<34x18x54xi32>) -> tensor<34x28x54xi32> {
+  // CHECK: %[[SCATTER:.*]] = spirv.Tosa.Scatter  %arg0, %arg1, %arg2 : !spirv.arm.tensor<34x28x54xi32>, !spirv.arm.tensor<34x18xi32>, !spirv.arm.tensor<34x18x54xi32> -> !spirv.arm.tensor<34x28x54xi32>
+  %res = tosa.scatter %arg0, %arg1, %arg2 : (tensor<34x28x54xi32>, tensor<34x18xi32>, tensor<34x18x54xi32>) -> tensor<34x28x54xi32>
+  return %res : tensor<34x28x54xi32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Resize
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: spirv.ARM.Graph @resize_int
+func.func @resize_int(%arg0: tensor<1x1x31x55xi8>) -> tensor<1x1x278x55xi8> {
+  %scale = "tosa.const_shape"() <{values = dense<[16, 1, 9, 1]> : tensor<4xindex>}> : () -> !tosa.shape<4>
+  %offset = "tosa.const_shape"() <{values = dense<0> : tensor<2xindex>}> : () -> !tosa.shape<2>
+  %border = "tosa.const_shape"() <{values = dense<[0, 7]> : tensor<2xindex>}> : () -> !tosa.shape<2>
+  // CHECK: %[[SCALE:.*]] = spirv.Constant dense<[16, 1, 9, 1]> : !spirv.arm.tensor<4xi32>
+  // CHECK: %[[OFFSET:.*]] = spirv.Constant dense<0> : !spirv.arm.tensor<2xi32>
+  // CHECK: %[[BORDER:.*]] = spirv.Constant dense<[0, 7]> : !spirv.arm.tensor<2xi32>
+  // CHECK: %[[RESIZE:.*]] = spirv.Tosa.Resize mode = <NearestNeighbor>, %arg0, %[[SCALE]], %[[OFFSET]], %[[BORDER]] : !spirv.arm.tensor<1x1x31x55xi8>, !spirv.arm.tensor<4xi32>, !spirv.arm.tensor<2xi32>, !spirv.arm.tensor<2xi32> -> !spirv.arm.tensor<1x1x278x55xi8>
+  %res = tosa.resize %arg0, %scale, %offset, %border {mode = NEAREST_NEIGHBOR} : (tensor<1x1x31x55xi8>, !tosa.shape<4>, !tosa.shape<2>, !tosa.shape<2>) -> tensor<1x1x278x55xi8>
+  return %res : tensor<1x1x278x55xi8>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.TOSA.Cast
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: spirv.ARM.Graph @cast_int
+func.func @cast_int(%arg0: tensor<2x3xi8>) -> tensor<2x3xi32> {
+  // CHECK: %[[CAST:.*]] = spirv.Tosa.Cast  %arg0 : !spirv.arm.tensor<2x3xi8> -> !spirv.arm.tensor<2x3xi32>
+  %res = tosa.cast %arg0 : (tensor<2x3xi8>) -> tensor<2x3xi32>
+  return %res : tensor<2x3xi32>
+}


### PR DESCRIPTION
Add conversion patterns for additional TOSA 1.0 operations targeting
the SPIR-V TOSA extended instruction set.

Introduce a common TosaOpConvert pattern with small replacer classes
to share result type conversion while keeping op-specific replacement
logic explicit.

The newly covered operations include:
* elementwise ops such as clamp, arithmetic_right_shift, mul, table,
  negate, and select
* reductions and argmax
* gather, scatter, resize
* reshape, reverse, slice, tile, transpose
* cast and const_shape

Also add conversion tests.