### PR TITLE
[Clang][test] Fix space in ld path

### DIFF
--- a/clang/test/Driver/freebsd.c
+++ b/clang/test/Driver/freebsd.c
@@ -105,25 +105,25 @@
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mips-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPS %s
-// CHECK-MIPS: ld{{[^" ]*}}"
+// CHECK-MIPS: {{[/\\]}}ld{{[^" ]*}}"
 // CHECK-MIPS: "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
 // CHECK-MIPS-NOT: "--hash-style={{gnu|both}}"
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mipsel-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPSEL %s
-// CHECK-MIPSEL: ld{{[^" ]*}}"
+// CHECK-MIPSEL: {{[/\\]}}ld{{[^" ]*}}"
 // CHECK-MIPSEL: "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
 // CHECK-MIPSEL-NOT: "--hash-style={{gnu|both}}"
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mips64-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPS64 %s
-// CHECK-MIPS64: ld{{[^" ]*}}"
+// CHECK-MIPS64: {{[/\\]}}ld{{[^" ]*}}"
 // CHECK-MIPS64: "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
 // CHECK-MIPS64-NOT: "--hash-style={{gnu|both}}"
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mips64el-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPS64EL %s
-// CHECK-MIPS64EL: ld{{[^" ]*}}"
+// CHECK-MIPS64EL: {{[/\\]}}ld{{[^" ]*}}"
 // CHECK-MIPS64EL: "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
 // CHECK-MIPS64EL-NOT: "--hash-style={{gnu|both}}"
 

--- a/clang/test/Driver/freebsd.c
+++ b/clang/test/Driver/freebsd.c
@@ -105,25 +105,25 @@
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mips-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPS %s
-// CHECK-MIPS: "{{[^" ]*}}ld{{[^" ]*}}"
+// CHECK-MIPS: ld{{[^" ]*}}"
 // CHECK-MIPS: "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
 // CHECK-MIPS-NOT: "--hash-style={{gnu|both}}"
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mipsel-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPSEL %s
-// CHECK-MIPSEL: "{{[^" ]*}}ld{{[^" ]*}}"
+// CHECK-MIPSEL: ld{{[^" ]*}}"
 // CHECK-MIPSEL: "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
 // CHECK-MIPSEL-NOT: "--hash-style={{gnu|both}}"
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mips64-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPS64 %s
-// CHECK-MIPS64: "{{[^" ]*}}ld{{[^" ]*}}"
+// CHECK-MIPS64: ld{{[^" ]*}}"
 // CHECK-MIPS64: "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
 // CHECK-MIPS64-NOT: "--hash-style={{gnu|both}}"
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mips64el-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPS64EL %s
-// CHECK-MIPS64EL: "{{[^" ]*}}ld{{[^" ]*}}"
+// CHECK-MIPS64EL: ld{{[^" ]*}}"
 // CHECK-MIPS64EL: "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
 // CHECK-MIPS64EL-NOT: "--hash-style={{gnu|both}}"
 


### PR DESCRIPTION
The driver resolves the path to the linker ("ld") to the absolute path. Microsoft Visual Studio comes with its own instance of `ld.lld` which it installs under

"c:\\program files\\microsoft visual studio\\2022\\community\\vc\\tools\\llvm\\x64\\bin\\ld.lld.exe"

In the developer command prompt, this path is added to PATH where the Clang driver finds it. However, this path does not match regular expression `"{{[^" ]*}}ld{{[^" ]*}}"` used by the MIPS test because the path contains spaces.

Fix the test failure by matching only the the trailing component after `ld`. Matching the prefix of the path is unique to the MIPS test, this is not done with tests for other platforms.