### PR TITLE
[SPIRV][NFC] Factor NSDI type collection into a collectType helper

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.cpp
@@ -87,26 +87,32 @@ void SPIRVNonSemanticDebugHandler::beginModule(Module *M) {
     }
   }
 
-  // Collect basic and pointer types referenced by debug variable records.
+  // Collect types referenced by debug variable records.
   for (const auto &F : *M) {
     for (const auto &BB : F) {
       for (const auto &I : BB) {
         for (const DbgVariableRecord &DVR :
              filterDbgVars(I.getDbgRecordRange())) {
-          const DIType *Ty = DVR.getVariable()->getType();
-          if (const auto *BT = dyn_cast<DIBasicType>(Ty)) {
-            BasicTypes.insert(BT);
-          } else if (const auto *DT = dyn_cast<DIDerivedType>(Ty)) {
-            if (DT->getTag() == dwarf::DW_TAG_pointer_type) {
-              PointerTypes.insert(DT);
-              if (const auto *BT =
-                      dyn_cast_or_null<DIBasicType>(DT->getBaseType()))
-                BasicTypes.insert(BT);
-            }
-          }
+          collectType(DVR.getVariable()->getType());
         }
       }
     }
+  }
+}
+
+void SPIRVNonSemanticDebugHandler::collectType(const DIType *Ty) {
+  if (!Ty)
+    return;
+  if (const auto *BT = dyn_cast<DIBasicType>(Ty)) {
+    BasicTypes.insert(BT);
+    return;
+  }
+  if (const auto *DT = dyn_cast<DIDerivedType>(Ty)) {
+    if (DT->getTag() == dwarf::DW_TAG_pointer_type) {
+      PointerTypes.insert(DT);
+      collectType(DT->getBaseType());
+    }
+    return;
   }
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.h
+++ b/llvm/lib/Target/SPIRV/SPIRVNonSemanticDebugHandler.h
@@ -166,6 +166,11 @@ private:
   /// Map a DWARF source language code to a NonSemantic.Shader.DebugInfo.100
   /// source language code.
   static unsigned toNSDISrcLang(unsigned DwarfSrcLang);
+
+  /// Insert Ty into the appropriate type-collection set, recursing into any
+  /// referenced types. Called from beginModule() for every DIType reached
+  /// through a DbgVariableRecord. Idempotent on SetVector duplicates.
+  void collectType(const DIType *Ty);
 };
 
 } // namespace llvm


### PR DESCRIPTION
I will need this for upcoming PRs to add debug type opcodes for NSDI (essentially, all the `DebugType*` opcodes). The current open-coded `if/else if` chain over `DIBasicType` and `DIDerivedType` would require a new branch per type opcode and would not naturally recurse into `getBaseType()`.

This factors the dispatch into a private `collectType(const DIType *)` helper.

NFC. Existing tests pass unchanged.