### PR TITLE
[InstCombine] Remove redundant overflow select before umin clamp

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -1419,6 +1419,45 @@ static Value *canonicalizeSaturatedAdd(ICmpInst *Cmp, Value *TVal, Value *FVal,
   return nullptr;
 }
 
+static Value *foldRedundantUMinOverflowSelect(ICmpInst *Cmp, Value *TVal,
+                                              Value *FVal,
+                                              const SimplifyQuery &SQ) {
+  Value *Sum = Cmp->getOperand(0);
+  Value *X = Cmp->getOperand(1);
+
+  // Match overflow check from unsigned addition: icmp ult %sum, %x
+  if (Cmp->getPredicate() != ICmpInst::ICMP_ULT)
+    return nullptr;
+
+  // TrueVal must be K (the clamp bound). Match FalseVal: umin(sum, K)
+  Value *K = TVal;
+  if (!match(FVal,
+             m_c_Intrinsic<Intrinsic::umin>(m_Specific(Sum), m_Specific(K))))
+    return nullptr;
+
+  // Ensure Sum is an add with NSW before extracting operands.
+  auto *SumInst = dyn_cast<BinaryOperator>(Sum);
+  if (!SumInst || !SumInst->hasNoSignedWrap() ||
+      SumInst->getOpcode() != Instruction::Add)
+    return nullptr;
+
+  // Match the guarded sum commutatively and capture U
+  Value *U;
+  if (!match(Sum, m_c_Add(m_Value(U), m_Specific(X))))
+    return nullptr;
+
+  // Match growth source: %u = umax(x, C)
+  Value *C;
+  if (!match(U, m_c_Intrinsic<Intrinsic::umax>(m_Specific(X), m_Value(C))))
+    return nullptr;
+
+  // Require C <=u signbit and K <=u signbit
+  if (!isKnownNonNegative(C, SQ) || !isKnownNonNegative(K, SQ))
+    return nullptr;
+
+  return FVal;
+}
+
 /// Try to match patterns with select and subtract as absolute difference.
 static Value *foldAbsDiff(ICmpInst *Cmp, Value *TVal, Value *FVal,
                           InstCombiner::BuilderTy &Builder) {
@@ -2464,6 +2503,10 @@ Instruction *InstCombinerImpl::foldSelectInstWithICmp(SelectInst &SI,
     return replaceInstUsesWith(SI, V);
 
   if (Value *V = canonicalizeSaturatedAdd(ICI, TrueVal, FalseVal, Builder))
+    return replaceInstUsesWith(SI, V);
+
+  SimplifyQuery SQ = getSimplifyQuery().getWithInstruction(&SI);
+  if (Value *V = foldRedundantUMinOverflowSelect(ICI, TrueVal, FalseVal, SQ))
     return replaceInstUsesWith(SI, V);
 
   if (Value *V = foldAbsDiff(ICI, TrueVal, FalseVal, Builder))

--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -1409,6 +1409,45 @@ static Value *canonicalizeSaturatedAdd(ICmpInst *Cmp, Value *TVal, Value *FVal,
   return nullptr;
 }
 
+static Value *foldRedundantUMinOverflowSelect(ICmpInst *Cmp, Value *TVal,
+                                              Value *FVal,
+                                              const SimplifyQuery &SQ) {
+  Value *Sum = Cmp->getOperand(0);
+  Value *X = Cmp->getOperand(1);
+
+  // Match overflow check from unsigned addition: icmp ult %sum, %x
+  if (Cmp->getPredicate() != ICmpInst::ICMP_ULT)
+    return nullptr;
+
+  // TrueVal must be K (the clamp bound). Match FalseVal: umin(sum, K)
+  Value *K = TVal;
+  if (!match(FVal,
+             m_c_Intrinsic<Intrinsic::umin>(m_Specific(Sum), m_Specific(K))))
+    return nullptr;
+
+  // Ensure Sum is an add with NSW before extracting operands.
+  auto *SumInst = dyn_cast<BinaryOperator>(Sum);
+  if (!SumInst || !SumInst->hasNoSignedWrap() ||
+      SumInst->getOpcode() != Instruction::Add)
+    return nullptr;
+
+  // Match the guarded sum commutatively and capture U
+  Value *U;
+  if (!match(Sum, m_c_Add(m_Value(U), m_Specific(X))))
+    return nullptr;
+
+  // Match growth source: %u = umax(x, C)
+  Value *C;
+  if (!match(U, m_c_Intrinsic<Intrinsic::umax>(m_Specific(X), m_Value(C))))
+    return nullptr;
+
+  // Require C <=u signbit and K <=u signbit
+  if (!isKnownNonNegative(C, SQ) || !isKnownNonNegative(K, SQ))
+    return nullptr;
+
+  return FVal;
+}
+
 /// Try to match patterns with select and subtract as absolute difference.
 static Value *foldAbsDiff(ICmpInst *Cmp, Value *TVal, Value *FVal,
                           InstCombiner::BuilderTy &Builder) {
@@ -2470,6 +2509,10 @@ Instruction *InstCombinerImpl::foldSelectInstWithICmp(SelectInst &SI,
     return replaceInstUsesWith(SI, V);
 
   if (Value *V = canonicalizeSaturatedAdd(ICI, TrueVal, FalseVal, Builder))
+    return replaceInstUsesWith(SI, V);
+
+  SimplifyQuery SQ = getSimplifyQuery().getWithInstruction(&SI);
+  if (Value *V = foldRedundantUMinOverflowSelect(ICI, TrueVal, FalseVal, SQ))
     return replaceInstUsesWith(SI, V);
 
   if (Value *V = foldAbsDiff(ICI, TrueVal, FalseVal, Builder))

--- a/llvm/test/Transforms/InstCombine/select-min-max.ll
+++ b/llvm/test/Transforms/InstCombine/select-min-max.ll
@@ -364,3 +364,84 @@ define i8 @sel_umin_non_constant(i8 %x, i8 %y) {
   %sel = select i1 %cmp, i8 %umin, i8 %y
   ret i8 %sel
 }
+
+define i8 @redundant_overflow_select_umin(i8 %x) {
+; CHECK-LABEL: @redundant_overflow_select_umin(
+; CHECK-NEXT:    [[U:%.*]] = call i8 @llvm.umax.i8(i8 [[X:%.*]], i8 64)
+; CHECK-NEXT:    [[SUM:%.*]] = add nsw i8 [[U]], [[X]]
+; CHECK-NEXT:    [[CLAMP:%.*]] = call i8 @llvm.umin.i8(i8 [[SUM]], i8 100)
+; CHECK-NEXT:    ret i8 [[CLAMP]]
+;
+  %u = call i8 @llvm.umax.i8(i8 %x, i8 64)
+  %sum = add nsw i8 %u, %x
+  %ov = icmp ult i8 %sum, %x
+  %clamp = call i8 @llvm.umin.i8(i8 %sum, i8 100)
+  %r = select i1 %ov, i8 100, i8 %clamp
+  ret i8 %r
+}
+
+define i8 @redundant_overflow_select_umin_swapped_add(i8 %x) {
+; CHECK-LABEL: @redundant_overflow_select_umin_swapped_add(
+; CHECK-NEXT:    [[U:%.*]] = call i8 @llvm.umax.i8(i8 [[X:%.*]], i8 64)
+; CHECK-NEXT:    [[SUM:%.*]] = add nsw i8 [[X]], [[U]]
+; CHECK-NEXT:    [[CLAMP:%.*]] = call i8 @llvm.umin.i8(i8 [[SUM]], i8 100)
+; CHECK-NEXT:    ret i8 [[CLAMP]]
+;
+  %u = call i8 @llvm.umax.i8(i8 %x, i8 64)
+  %sum = add nsw i8 %x, %u
+  %ov = icmp ult i8 %sum, %x
+  %clamp = call i8 @llvm.umin.i8(i8 %sum, i8 100)
+  %r = select i1 %ov, i8 100, i8 %clamp
+  ret i8 %r
+}
+
+define i8 @redundant_overflow_select_umin_no_nsw(i8 %x) {
+; CHECK-LABEL: @redundant_overflow_select_umin_no_nsw(
+; CHECK-NEXT:    [[U:%.*]] = call i8 @llvm.umax.i8(i8 [[X:%.*]], i8 64)
+; CHECK-NEXT:    [[SUM:%.*]] = add i8 [[U]], [[X]]
+; CHECK-NEXT:    [[OV:%.*]] = icmp ult i8 [[SUM]], [[X]]
+; CHECK-NEXT:    [[CLAMP:%.*]] = call i8 @llvm.umin.i8(i8 [[SUM]], i8 100)
+; CHECK-NEXT:    [[R:%.*]] = select i1 [[OV]], i8 100, i8 [[CLAMP]]
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %u = call i8 @llvm.umax.i8(i8 %x, i8 64)
+  %sum = add i8 %u, %x
+  %ov = icmp ult i8 %sum, %x
+  %clamp = call i8 @llvm.umin.i8(i8 %sum, i8 100)
+  %r = select i1 %ov, i8 100, i8 %clamp
+  ret i8 %r
+}
+
+define i8 @redundant_overflow_select_umin_k_too_large(i8 %x) {
+; CHECK-LABEL: @redundant_overflow_select_umin_k_too_large(
+; CHECK-NEXT:    [[U:%.*]] = call i8 @llvm.umax.i8(i8 [[X:%.*]], i8 64)
+; CHECK-NEXT:    [[SUM:%.*]] = add nsw i8 [[U]], [[X]]
+; CHECK-NEXT:    [[OV:%.*]] = icmp ult i8 [[SUM]], [[X]]
+; CHECK-NEXT:    [[CLAMP:%.*]] = call i8 @llvm.umin.i8(i8 [[SUM]], i8 -56)
+; CHECK-NEXT:    [[R:%.*]] = select i1 [[OV]], i8 -56, i8 [[CLAMP]]
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %u = call i8 @llvm.umax.i8(i8 %x, i8 64)
+  %sum = add nsw i8 %u, %x
+  %ov = icmp ult i8 %sum, %x
+  %clamp = call i8 @llvm.umin.i8(i8 %sum, i8 200)
+  %r = select i1 %ov, i8 200, i8 %clamp
+  ret i8 %r
+}
+
+define i8 @redundant_overflow_select_umin_c_too_large(i8 %x) {
+; CHECK-LABEL: @redundant_overflow_select_umin_c_too_large(
+; CHECK-NEXT:    [[U:%.*]] = call i8 @llvm.umax.i8(i8 [[X:%.*]], i8 -56)
+; CHECK-NEXT:    [[SUM:%.*]] = add nsw i8 [[U]], [[X]]
+; CHECK-NEXT:    [[OV:%.*]] = icmp ult i8 [[SUM]], [[X]]
+; CHECK-NEXT:    [[CLAMP:%.*]] = call i8 @llvm.umin.i8(i8 [[SUM]], i8 100)
+; CHECK-NEXT:    [[R:%.*]] = select i1 [[OV]], i8 100, i8 [[CLAMP]]
+; CHECK-NEXT:    ret i8 [[R]]
+;
+  %u = call i8 @llvm.umax.i8(i8 %x, i8 200)
+  %sum = add nsw i8 %u, %x
+  %ov = icmp ult i8 %sum, %x
+  %clamp = call i8 @llvm.umin.i8(i8 %sum, i8 100)
+  %r = select i1 %ov, i8 100, i8 %clamp
+  ret i8 %r
+}


### PR DESCRIPTION
fix: https://github.com/llvm/llvm-project/issues/199806

Added a foldRedundantUMinOverflowSelect function to handle the fold.
Alive Proof : https://alive2.llvm.org/ce/z/2UEYwP
Compiler-explorer sample & perf : https://compiler-explorer.com/z/3nvj53rcv
RealWorld Usage : https://github.com/dtcxzyw/llvm-opt-benchmark-nightly/pull/379/changes