### PR TITLE
[llvm-profgen] Fix -Wunused-variable

### DIFF
--- a/llvm/tools/llvm-profgen/ProfiledBinary.cpp
+++ b/llvm/tools/llvm-profgen/ProfiledBinary.cpp
@@ -1242,8 +1242,7 @@ void ProfiledBinary::loadSymbolsFromPseudoProbe() {
           InlineTreeNode = static_cast<MCDecodedPseudoProbeInlineTree *>(
               InlineTreeNode->Parent);
 
-        auto TopLevelProbes = InlineTreeNode->getProbes();
-        assert(llvm::any_of(TopLevelProbes,
+        assert(llvm::any_of(InlineTreeNode->getProbes(),
                             [Start = StartAddr, End = EndAddr](const auto &P) {
                               return P.getAddress() >= Start &&
                                      P.getAddress() < End;


### PR DESCRIPTION
Inline the variable definition into the assertion given the variable
name does not add much and release builds will end up with an unused
variable otherwise.