### PR TITLE
[clang][deps] Disable app extensions during scanning

### DIFF
--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -450,6 +450,10 @@ std::shared_ptr<CompilerInvocation> dependencies::createScanCompilerInvocation(
       true;
   ScanInvocation->getHeaderSearchOpts().ModulesForceValidateUserHeaders = false;
 
+  // Application extension only affects the handling of availability attributes,
+  // which cannot change the dependencies.
+  ScanInvocation->getLangOpts().AppExt = false;
+
   // Ensure that the scanner does not create new dependency collectors,
   // and thus won't write out the extra '.d' files to disk.
   ScanInvocation->getDependencyOutputOpts() = {};


### PR DESCRIPTION
Application extension contributes to the context hash, but only affects the availability attribute on declarations. Since it cannot affect dependencies, disable it for the scan to reduce the number of scanning PCM variants.