### PR TITLE
[libc] Move fixed buffer GPU test to an integration test

### DIFF
--- a/libc/test/integration/src/__support/GPU/CMakeLists.txt
+++ b/libc/test/integration/src/__support/GPU/CMakeLists.txt
@@ -28,7 +28,7 @@ add_integration_test(
     --threads 64
 )
 
-add_libc_test(
+add_integration_test(
   fixedbuffer_test
   SUITE
     libc-support-gpu-tests


### PR DESCRIPTION
Move the `fixedbuffer` GPU test to an integration test.

libc tests are intended to be GTest style tests written with the normal `TEST(Suite, Test)` GTest macros. Example [here](https://github.com/llvm/llvm-project/blob/main/libc/test/include/SignbitTest.h#L32). 

This test has its own `main` which ends up causing a `main multiple definitions` linker error when compiling for SPIR-V (work in progress).  I'm not sure why this error doesn't occur for AMDGPU, probably the fact we have to compile with a ton less compile/linker flags for SPIR-V and one of them hides the issue.

Specifically the fix is that we don't link against `libc/test/UnitTest/CMakeFiles/LibcTest.hermetic.dir/LibcTestMain.cpp.o` which has its own main which conflicts with the one defined in the test.

All other tests in this directory are integration tests too.

A quick check of other uses of the `TEST_MAIN` macro also showed them using `add_integration_test` and not `add_libc_test`.