### PR TITLE
[analyzer] Normalize sub-array indices in RegionStore initializer res…

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
+++ b/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
@@ -1819,7 +1819,8 @@ getElementRegionOffsetsWithBase(const ElementRegion *ER) {
 ///
 /// \example:
 ///   const int arr[10][20][30] = {}; // ArrayExtents { 10, 20, 30 }
-///   int x1 = arr[4][5][6]; // DstOffsets { 4, 5, 6 }, returns std::nullopt
+///   int x1 = arr[4][5][6]; // SrcOffsets { NonLoc(6), NonLoc(5), NonLoc(4) }
+///                          // DstOffsets { 4, 5, 6 }, returns std::nullopt
 ///   int x2 = arr[0][0][35]; // DstOffsets { 0, 1, 5 }, returns std::nullopt
 ///   int x3 = arr[0][25][-5]; // DstOffsets { 1, 4, 25 }, returns std::nullopt
 ///   int x4 = arr[10][0][0]; // returns UndefinedVal (flat offset >= total)

--- a/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
+++ b/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
@@ -1804,65 +1804,56 @@ getElementRegionOffsetsWithBase(const ElementRegion *ER) {
 
 /// This is a helper function for `getConstantValFromConstArrayInitializer`.
 ///
-/// Convert array of offsets from `SVal` to `uint64_t` in consideration of
-/// respective array extents.
-/// \param SrcOffsets [in]   The array of offsets of type `SVal` in reversed
-///   order (expectedly received from `getElementRegionOffsetsWithBase`).
-/// \param ArrayExtents [in] The array of extents.
-/// \param DstOffsets [out]  The array of offsets of type `uint64_t`.
+/// Flatten per-dimension SVal offsets into a linear index, bounds-check
+/// against the total allocation, and decompose back into per-dimension
+/// uint64_t indices.
+///
+/// \param SrcOffsets [in]   Per-dimension offsets in reversed order
+///   (as received from `getElementRegionOffsetsWithBase`).
+/// \param ArrayExtents [in] Extents per dimension (outer to inner).
+/// \param DstOffsets [out]  Normalized per-dimension indices.
 /// \returns:
-/// - `std::nullopt` for successful convertion.
-/// - `UndefinedVal` or `UnknownVal` otherwise. It's expected that this SVal
-///   will be returned as a suitable value of the access operation.
-///   which should be returned as a correct
+/// - `std::nullopt` on success.
+/// - `UndefinedVal` if the flat offset is out of bounds.
+/// - `UnknownVal` if any index is symbolic.
 ///
 /// \example:
 ///   const int arr[10][20][30] = {}; // ArrayExtents { 10, 20, 30 }
-///   int x1 = arr[4][5][6]; // SrcOffsets { NonLoc(6), NonLoc(5), NonLoc(4) }
-///                          // DstOffsets { 4, 5, 6 }
-///                          // returns std::nullopt
-///   int x2 = arr[42][5][-6]; // returns UndefinedVal
-///   int x3 = arr[4][5][x2];  // returns UnknownVal
+///   int x1 = arr[4][5][6]; // DstOffsets { 4, 5, 6 }, returns std::nullopt
+///   int x2 = arr[0][0][35]; // DstOffsets { 0, 1, 5 }, returns std::nullopt
+///   int x3 = arr[0][25][-5]; // DstOffsets { 1, 4, 25 }, returns std::nullopt
+///   int x4 = arr[10][0][0]; // returns UndefinedVal (flat offset >= total)
+///   int x5 = arr[4][5][x1]; // returns UnknownVal
 static std::optional<SVal>
 convertOffsetsFromSvalToUnsigneds(const SmallVector<SVal, 2> &SrcOffsets,
                                   const SmallVector<uint64_t, 2> ArrayExtents,
                                   SmallVector<uint64_t, 2> &DstOffsets) {
-  // Check offsets for being out of bounds.
-  // C++20 [expr.add] 7.6.6.4 (excerpt):
-  //   If P points to an array element i of an array object x with n
-  //   elements, where i < 0 or i > n, the behavior is undefined.
-  //   Dereferencing is not allowed on the "one past the last
-  //   element", when i == n.
-  // Example:
-  //  const int arr[3][2] = {{1, 2}, {3, 4}};
-  //  arr[0][0];  // 1
-  //  arr[0][1];  // 2
-  //  arr[0][2];  // UB
-  //  arr[1][0];  // 3
-  //  arr[1][1];  // 4
-  //  arr[1][-1]; // UB
-  //  arr[2][0];  // 0
-  //  arr[2][1];  // 0
-  //  arr[-2][0]; // UB
-  DstOffsets.resize(SrcOffsets.size());
+  // Flatten to a linear offset so that both positive overflow and negative
+  // indices across sub-array boundaries resolve to the correct element.
+  int64_t FlatOffset = 0;
   auto ExtentIt = ArrayExtents.begin();
-  auto OffsetIt = DstOffsets.begin();
-  // Reverse `SValOffsets` to make it consistent with `ArrayExtents`.
   for (SVal V : llvm::reverse(SrcOffsets)) {
-    if (auto CI = V.getAs<nonloc::ConcreteInt>()) {
-      // When offset is out of array's bounds, result is UB.
-      const llvm::APSInt &Offset = CI->getValue();
-      if (Offset.isNegative() || Offset.uge(*(ExtentIt++)))
-        return UndefinedVal();
-      // Store index in a reversive order.
-      *(OffsetIt++) = Offset.getZExtValue();
-      continue;
-    }
-    // Symbolic index presented. Return Unknown value.
-    // FIXME: We also need to take ElementRegions with symbolic indexes into
-    // account.
-    return UnknownVal();
+    auto CI = V.getAs<nonloc::ConcreteInt>();
+    if (!CI)
+      return UnknownVal();
+    FlatOffset = FlatOffset * static_cast<int64_t>(*(ExtentIt++)) +
+                 CI->getValue()->getExtValue();
   }
+
+  int64_t TotalSize = 1;
+  for (uint64_t E : ArrayExtents)
+    TotalSize *= static_cast<int64_t>(E);
+
+  if (FlatOffset < 0 || FlatOffset >= TotalSize)
+    return UndefinedVal();
+
+  DstOffsets.resize(ArrayExtents.size());
+  uint64_t Remaining = static_cast<uint64_t>(FlatOffset);
+  for (int I = DstOffsets.size() - 1; I >= 0; --I) {
+    DstOffsets[I] = Remaining % ArrayExtents[I];
+    Remaining /= ArrayExtents[I];
+  }
+
   return std::nullopt;
 }
 

--- a/clang/test/Analysis/bstring_UninitRead.c
+++ b/clang/test/Analysis/bstring_UninitRead.c
@@ -152,3 +152,10 @@ void ff_mov_lang_to_iso639() {
   memcpy(ff_mov_lang_to_iso639_to,
          mov_mdhd_language_map[ff_mov_lang_to_iso639_code], 4);
 }
+
+void memcpy_multidim_crossing_subarray(void *dst) {
+  const long b[4][1200] = {};
+  const long *f = &b[0][0];
+  f = f + 2001; // crosses into b[1][801]
+  memcpy(dst, f, sizeof(long)); // no-warning
+}

--- a/clang/test/Analysis/bstring_UninitRead.c
+++ b/clang/test/Analysis/bstring_UninitRead.c
@@ -159,3 +159,13 @@ void memcpy_multidim_crossing_subarray(void *dst) {
   f = f + 2001; // crosses into b[1][801]
   memcpy(dst, f, sizeof(long)); // no-warning
 }
+
+const long b[1][4][1200][1] = {0};
+extern void *dst[];
+void memcpy_multidim_crossing_multiple_dimensions() {
+  const long *f = &b[0][0][0][0];
+  for (unsigned long i = 0; i < 2; i++) {
+    memcpy(dst[i], f, sizeof(long)); // no-warning
+    f = f + 2001;
+  }
+}

--- a/clang/test/Analysis/initialization.c
+++ b/clang/test/Analysis/initialization.c
@@ -73,10 +73,10 @@ void glob_arr_index3(void) {
 
 void negative_index(void) {
   int x = 2, y = -2;
-  clang_analyzer_eval(glob_arr2[x][y] == 5); // expected-warning{{UNDEFINED}}
+  clang_analyzer_eval(glob_arr2[x][y] == 5); // expected-warning{{TRUE}}
   x = 3;
   y = -3;
-  clang_analyzer_eval(glob_arr2[x][y] == 7); // expected-warning{{UNDEFINED}}
+  clang_analyzer_eval(glob_arr2[x][y] == 7); // expected-warning{{TRUE}}
 }
 
 void glob_invalid_index3(void) {

--- a/clang/test/Analysis/initialization.cpp
+++ b/clang/test/Analysis/initialization.cpp
@@ -87,9 +87,9 @@ void glob_ptr_index2() {
   int const *ptr = glob_arr5[1];
   clang_analyzer_eval(ptr[0] == 3); // expected-warning{{TRUE}}
   clang_analyzer_eval(ptr[1] == 4); // expected-warning{{TRUE}}
-  clang_analyzer_eval(ptr[2] == 5); // expected-warning{{UNDEFINED}}
-  clang_analyzer_eval(ptr[3] == 0); // expected-warning{{UNDEFINED}}
-  clang_analyzer_eval(ptr[4] == 0); // expected-warning{{UNDEFINED}}
+  clang_analyzer_eval(ptr[2] == 5); // expected-warning{{TRUE}}
+  clang_analyzer_eval(ptr[3] == 0); // expected-warning{{TRUE}}
+  clang_analyzer_eval(ptr[4] == 0); // expected-warning{{TRUE}}
 }
 
 void glob_invalid_index5() {
@@ -255,4 +255,87 @@ const E glob[] = {{}};
 void initlistWithinInitlist() {
   // no-crash
   clang_analyzer_dump(glob[0]); // expected-warning-re {{reg_${{[0-9]+}}<enum E Element{glob,0 S64b,enum E}>}}
+}
+
+const int glob_arr_cross[4][3] = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}};
+void glob_array_cross_subarray_boundary() {
+  const int *p = &glob_arr_cross[0][0];
+  clang_analyzer_eval(p[4] == 5);   // expected-warning{{TRUE}}
+  clang_analyzer_eval(p[7] == 8);   // expected-warning{{TRUE}}
+  clang_analyzer_eval(p[11] == 12); // expected-warning{{TRUE}}
+}
+
+const int glob_arr_sparse[4][3] = {{1, 2}, {0, 0, 7}};
+void glob_array_sparse_cross_boundary() {
+  const int *p = &glob_arr_sparse[0][0];
+  clang_analyzer_eval(p[0] == 1); // expected-warning{{TRUE}}
+  clang_analyzer_eval(p[1] == 2); // expected-warning{{TRUE}}
+  clang_analyzer_eval(p[2] == 0); // expected-warning{{TRUE}}
+  clang_analyzer_eval(p[3] == 0); // expected-warning{{TRUE}}
+  clang_analyzer_eval(p[5] == 7); // expected-warning{{TRUE}}
+  clang_analyzer_eval(p[6] == 0); // expected-warning{{TRUE}}
+  clang_analyzer_eval(p[11] == 0); // expected-warning{{TRUE}}
+}
+
+const int glob_arr_3d[2][3][4] = {
+    {{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10, 11, 12}},
+    {{13, 14, 15, 16}, {17, 18, 19, 20}, {21, 22, 23, 24}}};
+void glob_array_3d_cross_boundary() {
+  const int *p = &glob_arr_3d[0][0][0];
+  clang_analyzer_eval(p[0] == 1);   // expected-warning{{TRUE}}
+  clang_analyzer_eval(p[5] == 6);   // expected-warning{{TRUE}}
+  clang_analyzer_eval(p[11] == 12); // expected-warning{{TRUE}}
+  clang_analyzer_eval(p[12] == 13); // expected-warning{{TRUE}}
+  clang_analyzer_eval(p[23] == 24); // expected-warning{{TRUE}}
+}
+
+// Limitation: type-punned access through incompatible pointer type.
+const int glob_arr_pun[2][3] = {{1, 2, 3}, {4, 5, 6}};
+void glob_array_type_pun_unresolved() {
+  const unsigned *p = (const unsigned *)&glob_arr_pun[0][0];
+  clang_analyzer_dump(p[0]); // expected-warning-re{{reg_${{[0-9]+}}<unsigned int Element{glob_arr_pun,0 S64b,unsigned int}>}}
+}
+
+const int glob_arr_recast[4][3] = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}};
+void glob_array_recast_resolves_against_declared_type() {
+  const int (*q)[6] = (const int (*)[6])&glob_arr_recast[0][0];
+  clang_analyzer_eval(q[0][4] == 5); // expected-warning{{TRUE}}
+  clang_analyzer_eval(q[1][0] == 4); // expected-warning{{TRUE}}
+}
+
+void glob_array_write_then_read_cross_boundary() {
+  int arr[4][3];
+  arr[0][0] = 10;
+  arr[1][1] = 42;
+  arr[2][2] = 99;
+  arr[3][2] = 77;
+
+  int *p = &arr[0][0];
+  clang_analyzer_eval(p[0] == 10); // expected-warning{{TRUE}}
+  clang_analyzer_eval(p[4] == 42); // expected-warning{{TRUE}}
+  clang_analyzer_eval(p[8] == 99); // expected-warning{{TRUE}}
+  clang_analyzer_eval(p[11] == 77); // expected-warning{{TRUE}}
+}
+
+void glob_array_write_then_read_before_start() {
+  int arr[4][3];
+  arr[0][0] = 10;
+  int *p = &arr[0][0];
+  int x = p[-1]; // expected-warning{{Assigned value is uninitialized}}
+  (void)x;
+}
+
+// Negative inner index from a non-zero outer base lands within the allocation.
+const int glob_arr_neg[4][3] = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}};
+void glob_array_negative_inner_index() {
+  const int *p = &glob_arr_neg[2][0];
+  clang_analyzer_eval(p[-1] == 6); // expected-warning{{TRUE}}
+}
+
+void glob_array_write_then_read_past_end() {
+  int arr[4][3];
+  arr[3][2] = 77;
+  int *p = &arr[0][0];
+  int x = p[12]; // expected-warning{{Assigned value is uninitialized}}
+  (void)x;
 }


### PR DESCRIPTION
…olution

After #198346, alpha.unix.cstring.UninitializedRead reports a false positive when a pointer into a fully-initialized const multidimensional array is advanced past an inner dimension boundary and used as a source argument to memcpy. The root cause is in `convertOffsetsFromSvalToUnsigneds` in RegionStore, which returned UndefinedVal for any element index exceeding its sub-array extent, conflating pointer arithmetic legality with memory initializedness.

This patch separates the two concerns. The RegionStore now normalizes indices that overflow an inner dimension by carrying into the outer dimension via divmod, the same way `arr[0][5]` in `int arr[4][3]` denotes the same memory as `arr[1][2]`. UndefinedVal is returned only when the computed flat offset exceeds the total array allocation. Whether cross-subobject pointer arithmetic constitutes undefined behavior per C/C++ standards is a separate concern for individual checkers to diagnose. No existing checker flags sub-array boundary crossing as UB, verified both before and after #198346.

Fixes #199271