### PR TITLE
[CIR] Implement 'coroutine' exception handling lowering

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -125,7 +125,6 @@ struct MissingFeatures {
 
   // Coroutines
   static bool coroOutsideFrameMD() { return false; }
-  static bool coroutineExceptions() { return false; };
 
   // Various handling of deferred processing in CIRGenModule.
   static bool cgmRelease() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
@@ -43,6 +43,12 @@ struct clang::CIRGen::CGCoroData {
   // Stores the last emitted coro.free for the deallocate expressions, we use it
   // to wrap dealloc code with if(auto mem = coro.free) dealloc(mem).
   cir::CallOp lastCoroFree = nullptr;
+
+  // A temporary bool alloca that stores whether 'await_resume' threw an
+  // exception. If it did, 'true' is stored in this variable, and the coroutine
+  // body must be skipped. If the promise type does not define an exception
+  // handler, this is null.
+  Address resumeEHVar = Address::invalid();
 };
 
 // Defining these here allows to keep CGCoroData private to this file.
@@ -313,6 +319,28 @@ cir::CallOp CIRGenFunction::emitCoroFreeBuiltin(const CallExpr *e) {
   return coroFree;
 }
 
+static mlir::LogicalResult
+coroutineBodyExceptionHelper(CIRGenFunction &cgf, const CoroutineBodyStmt &s) {
+
+  CXXCatchStmt catchStmt(s.getBeginLoc(), /*exDecl=*/nullptr,
+                         cgf.curCoro.data->exceptionHandler);
+  auto *tryStmt = CXXTryStmt::Create(cgf.getContext(), s.getBeginLoc(),
+                                     s.getBody(), &catchStmt);
+  struct handlerEmitter final : CIRGenFunction::cxxTryBodyEmitter {
+    const CoroutineBodyStmt &s;
+
+    handlerEmitter(const CoroutineBodyStmt &s) : s(s) /*, scope(scope)*/ {}
+    mlir::LogicalResult operator()(CIRGenFunction &cgf) override {
+      return emitBodyAndFallthrough(cgf, s, s.getBody(), cgf.curLexScope);
+    }
+    ~handlerEmitter() override = default;
+  } emitter{s};
+  ;
+  mlir::LogicalResult res = cgf.emitCXXTryStmt(*tryStmt, emitter);
+
+  return res;
+}
+
 mlir::LogicalResult
 CIRGenFunction::emitCoroutineBody(const CoroutineBodyStmt &s) {
   mlir::Location openCurlyLoc = getLoc(s.getBeginLoc());
@@ -401,6 +429,8 @@ CIRGenFunction::emitCoroutineBody(const CoroutineBodyStmt &s) {
     assert(!cir::MissingFeatures::ehCleanupScope());
 
     curCoro.data->currentAwaitKind = cir::AwaitKind::Init;
+    curCoro.data->exceptionHandler = s.getExceptionHandler();
+
     if (emitStmt(s.getInitSuspendStmt(), /*useCurrentScope=*/true).failed())
       return mlir::failure();
 
@@ -415,12 +445,41 @@ CIRGenFunction::emitCoroutineBody(const CoroutineBodyStmt &s) {
     {
       mlir::OpBuilder::InsertionGuard guard(builder);
       builder.restoreInsertionPoint(userBody);
-      // FIXME(cir): wrap emitBodyAndFallthrough with try/catch bits.
-      if (s.getExceptionHandler()) {
-        assert(!cir::MissingFeatures::coroutineExceptions());
-        cgm.errorNYI("exceptions in coroutines are not yet supported in CIR");
-      }
-      if (emitBodyAndFallthrough(*this, s, s.getBody(), curLexScope).failed()) {
+      if (curCoro.data->exceptionHandler) {
+        // This bit of code is supposed to do:
+        //
+        // if (await-resume-didnt-throw-exception) {
+        //   try {
+        //     coroutine-body
+        //   } catch (...) {
+        //     unhandled_exception();
+        //   }
+        // }
+        //
+        // IF resume couldn't have thrown an exception(await_resume is
+        // noexcept), we skip the 'if'.
+        //
+        // Note that we've reversed the condition of the 'if' from classic
+        // codegen so that we don't need an 'else' block.
+        if (curCoro.data->resumeEHVar.isValid()) {
+          mlir::Value shouldSkip = builder.createFlagLoad(
+              openCurlyLoc, curCoro.data->resumeEHVar.getPointer());
+          mlir::LogicalResult res = mlir::success();
+          cir::IfOp::create(builder, openCurlyLoc, shouldSkip,
+                            /*withElseRegion=*/false,
+                            [&](mlir::OpBuilder &b, mlir::Location loc) {
+                              res = coroutineBodyExceptionHelper(*this, s);
+                              builder.createYield(openCurlyLoc);
+                            });
+
+          if (res.failed())
+            return mlir::failure();
+
+        } else if (coroutineBodyExceptionHelper(*this, s).failed()) {
+          return mlir::failure();
+        }
+      } else if (emitBodyAndFallthrough(*this, s, s.getBody(), curLexScope)
+                     .failed()) {
         return mlir::failure();
       }
     }
@@ -543,14 +602,61 @@ emitSuspendExpression(CIRGenFunction &cgf, CGCoroData &coro,
         // Exception handling requires additional IR. If the 'await_resume'
         // function is marked as 'noexcept', we avoid generating this additional
         // IR.
-        CXXTryStmt *tryStmt = nullptr;
         if (coro.exceptionHandler && kind == cir::AwaitKind::Init &&
-            memberCallExpressionCanThrow(s.getResumeExpr()))
-          cgf.cgm.errorNYI("Coro resume Exception");
+            memberCallExpressionCanThrow(s.getResumeExpr())) {
+          // we are basically just emitting:
+          // resumeEh = false;
+          // try {
+          //   resumeExpr();
+          //   resumeEh = true;
+          // } catch(...) {
+          //   exceptionHandler();
+          // }
+          // Note the values of resumeEh are reversed from classic codegen,
+          // simply so we can use an 'IfOp' without a 'else' later.
+          ASTContext &ctx = cgf.getContext();
+          SourceLocation resumeLoc = s.getResumeExpr()->getExprLoc();
+          mlir::Location mlirLoc = cgf.getLoc(resumeLoc);
+          coro.resumeEHVar = cgf.createTempAlloca(
+              builder.getBoolTy(), ctx.getTypeAlignInChars(ctx.BoolTy), mlirLoc,
+              "resume.eh");
+          builder.createFlagStore(mlirLoc, false,
+                                  coro.resumeEHVar.getPointer());
 
-        // FIXME(cir): the alloca for the resume expr should be placed in the
-        // enclosing cir.scope instead.
-        if (forLValue) {
+          CXXCatchStmt catchStmt(resumeLoc,
+                                 /*exDecl=*/nullptr, coro.exceptionHandler);
+          auto *tryBody =
+              CompoundStmt::Create(ctx, s.getResumeExpr(), FPOptionsOverride(),
+                                   resumeLoc, resumeLoc);
+          CXXTryStmt *tryStmt =
+              CXXTryStmt::Create(ctx, resumeLoc, tryBody, &catchStmt);
+
+          struct resumeEmitter final : CIRGenFunction::cxxTryBodyEmitter {
+            const CXXTryStmt &tryStmt;
+            mlir::Location loc;
+            mlir::Value resumeEHVar;
+            resumeEmitter(const CXXTryStmt &tryStmt, mlir::Location loc,
+                          Address resumeEHVar)
+                : tryStmt(tryStmt), loc(loc),
+                  resumeEHVar(resumeEHVar.getPointer()) {}
+
+            mlir::LogicalResult operator()(CIRGenFunction &cgf) override {
+              mlir::LogicalResult res =
+                  cgf.emitStmt(tryStmt.getTryBlock(), /*useCurrentScope=*/true);
+              cgf.getBuilder().createFlagStore(loc, true, resumeEHVar);
+              return res;
+            }
+
+            ~resumeEmitter() override = default;
+          } emitter{*tryStmt, mlirLoc, coro.resumeEHVar};
+
+          awaitBuild = cgf.emitCXXTryStmt(*tryStmt, emitter);
+          // We are not supposed to obtain the value from init suspend
+          // await_resume().
+          awaitRes.rv = RValue::getIgnored();
+        } else if (forLValue) {
+          // FIXME(cir): the alloca for the resume expr should be placed in the
+          // enclosing cir.scope instead.
           awaitRes.lv = cgf.emitLValue(s.getResumeExpr());
         } else {
           awaitRes.rv =
@@ -577,9 +683,6 @@ emitSuspendExpression(CIRGenFunction &cgf, CGCoroData &coro,
                                                   tmpResumeRValAddr);
           }
         }
-
-        if (tryStmt)
-          cgf.cgm.errorNYI("Coro tryStmt");
 
         // Returns control back to parent.
         cir::YieldOp::create(builder, loc);

--- a/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCoroutine.cpp
@@ -335,7 +335,7 @@ coroutineBodyExceptionHelper(CIRGenFunction &cgf, const CoroutineBodyStmt &s) {
     }
     ~handlerEmitter() override = default;
   } emitter{s};
-  ;
+
   mlir::LogicalResult res = cgf.emitCXXTryStmt(*tryStmt, emitter);
 
   return res;

--- a/clang/lib/CIR/CodeGen/CIRGenException.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenException.cpp
@@ -539,7 +539,9 @@ CIRGenFunction::emitCXXTryStmt(const CXXTryStmt &s,
         if (bodyCallback(*this).failed())
           tryRes = mlir::failure();
         tryBodyCleanups.forceCleanup();
-        cir::YieldOp::create(builder, loc);
+        if (!builder.getBlock()->mightHaveTerminator() ||
+            !builder.getBlock()->getTerminator())
+          cir::YieldOp::create(builder, loc);
       },
       /*handlersBuilder=*/
       [&](mlir::OpBuilder &b, mlir::Location loc,

--- a/clang/test/CIR/CodeGen/coro-exceptions.cpp
+++ b/clang/test/CIR/CodeGen/coro-exceptions.cpp
@@ -1,0 +1,138 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fcxx-exceptions -fexceptions -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+
+// FIXME: we currently don't have flatten-cfg for coroutines or lower to LLVM-IR
+// implemented correctly, so this tests only the CIR output.
+
+namespace std {
+template <class Ret, typename... T>
+struct coroutine_traits { using promise_type = typename Ret::promise_type; };
+
+template <class Promise = void> struct coroutine_handle {
+  static coroutine_handle from_address(void *) noexcept;
+};
+template <> struct coroutine_handle<void> {
+  template <class P> coroutine_handle(coroutine_handle<P>) noexcept;
+  static coroutine_handle from_address(void *);
+};
+
+// Awaitable whose await_resume CAN throw.
+struct suspend_maybe_throw {
+  bool await_ready() noexcept;
+  void await_suspend(coroutine_handle<>) noexcept;
+  void await_resume(); // not noexcept
+};
+
+// Awaitable whose await_resume is noexcept.
+struct suspend_nothrow {
+  bool await_ready() noexcept;
+  void await_suspend(coroutine_handle<>) noexcept;
+  void await_resume() noexcept;
+};
+} // namespace std
+
+struct TaskWithEH {
+  struct promise_type {
+    TaskWithEH get_return_object();
+    std::suspend_nothrow initial_suspend() noexcept;
+    std::suspend_nothrow final_suspend() noexcept;
+    void return_void();
+    void unhandled_exception();
+  };
+};
+
+TaskWithEH simple_eh_body() {
+  co_return;
+}
+
+// CIR-LABEL: cir.func{{.*}} @_Z14simple_eh_bodyv
+// CIR: }, resume : {
+// Note no 'try'/'catch' here.
+// CIR-NEXT: cir.call @_ZNSt15suspend_nothrow12await_resumeEv
+// CIR-NEXT: cir.yield
+// CIR-NEXT: }
+
+// CIR: cir.coro.body {
+// CIR-NOT: cir.if
+// CIR:   cir.scope {
+// CIR:     cir.try {
+// CIR:       cir.call @_ZN10TaskWithEH12promise_type11return_voidEv
+// CIR:       cir.co_return
+// CIR:     } catch all {{.*}} {
+// CIR:       cir.cleanup.scope {
+// CIR:         cir.call @_ZN10TaskWithEH12promise_type19unhandled_exceptionEv
+// CIR:         cir.yield
+// CIR:       } cleanup all {
+// CIR:         cir.end_catch
+// CIR:         cir.yield
+// CIR:       }
+// CIR:       cir.yield
+// CIR:     }
+// CIR:   }
+// CIR:   cir.yield
+// CIR: }
+// Make sure that 'final' is outside of the above try/catch/etc.
+// CIR: cir.call @_ZN10TaskWithEH12promise_type13final_suspendEv
+
+struct TaskThrowingInit {
+  struct promise_type {
+    TaskThrowingInit get_return_object();
+    std::suspend_maybe_throw initial_suspend() noexcept;   // resume CAN throw
+    std::suspend_nothrow final_suspend() noexcept;
+    void return_void();
+    void unhandled_exception();
+  };
+};
+
+TaskThrowingInit throwing_init_suspend() {
+  co_return;
+}
+
+// CIR-LABEL: cir.func{{.*}} @_Z21throwing_init_suspendv
+// CIR: %[[RESUME_FLAG:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["resume.eh"] {alignment = 1 : i64}
+// CIR: }, resume : {
+// CIR:    %[[FALSE:.*]] = cir.const #false
+// CIR:    cir.store %[[FALSE]], %[[RESUME_FLAG]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:    cir.scope {
+// CIR:      cir.try {
+// CIR:        cir.call @_ZNSt19suspend_maybe_throw12await_resumeEv
+// CIR:        %[[TRUE:.*]] = cir.const #true
+// CIR:        cir.store %[[TRUE]], %[[RESUME_FLAG]] : !cir.bool, !cir.ptr<!cir.bool>
+// CIR:        cir.yield
+// CIR:      } catch all {{.*}} {
+// CIR:        cir.begin_catch
+// CIR:        cir.cleanup.scope {
+// CIR:          cir.call @_ZN16TaskThrowingInit12promise_type19unhandled_exceptionEv
+// CIR:          cir.yield
+// CIR:        } cleanup all {
+// CIR:          cir.end_catch
+// CIR:          cir.yield
+// CIR:        }
+// CIR:        cir.yield
+// CIR:      }
+// CIR:    }
+// CIR:    cir.yield
+// CIR: }
+
+// CIR: cir.coro.body {
+// CIR:   %[[LOAD_RESUME_FLAG:.*]] = cir.load align(1) %[[RESUME_FLAG]] : !cir.ptr<!cir.bool>, !cir.bool
+// CIR:   cir.if %[[LOAD_RESUME_FLAG]] {
+// CIR:     cir.scope {
+// CIR:       cir.try {
+// CIR:         cir.call @_ZN16TaskThrowingInit12promise_type11return_voidEv
+// CIR:         cir.co_return
+// CIR:       } catch all {{.*}} {
+// CIR:         cir.cleanup.scope {
+// CIR:           cir.call @_ZN16TaskThrowingInit12promise_type19unhandled_exceptionEv
+// CIR:           cir.yield
+// CIR:         } cleanup all {
+// CIR:           cir.end_catch
+// CIR:           cir.yield
+// CIR:         }
+// CIR:         cir.yield
+// CIR:       }
+// CIR:     }
+// CIR:   }
+// CIR:   cir.yield
+// CIR: }
+// CIR: cir.call @_ZN16TaskThrowingInit12promise_type13final_suspendEv


### PR DESCRIPTION
This patch implements the lowering to CIR for exception handling. Unfortunately the missing components of Flatten-CFG don't work here, so we only test that we get successfully to CIR, not to LLVM-IR.

This patch runs the 'await-resume' in a try/catch, and only if that succeeds, does it run the coroutine body (also in a try/catch if there is an exception handler).

This is nearly identical to the implementation in classic-codegen, except we invert the resume-eh variable's value, so we can just use a simple `if` op for the branch.