### PR TITLE
[lldb] Skip minidump case in TestDynamicValue.py for arm64e

### DIFF
--- a/lldb/test/API/lang/cpp/dynamic-value/TestDynamicValue.py
+++ b/lldb/test/API/lang/cpp/dynamic-value/TestDynamicValue.py
@@ -283,6 +283,7 @@ class DynamicValueTestCase(TestBase):
     @no_debug_info_test
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24663")
     @expectedFailureAll(archs=["arm$"]) # Minidump saving not implemented
+    @skipIf(archs=["arm64e"]) # arm64e incompatible with minidump
     def test_from_core_file(self):
         """Test fetching C++ dynamic values from core files. Specifically, test
         that we can determine the dynamic type of the value if the core file

--- a/lldb/test/API/lang/cpp/dynamic-value/TestDynamicValue.py
+++ b/lldb/test/API/lang/cpp/dynamic-value/TestDynamicValue.py
@@ -282,8 +282,8 @@ class DynamicValueTestCase(TestBase):
 
     @no_debug_info_test
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24663")
-    @expectedFailureAll(archs=["arm$"]) # Minidump saving not implemented
-    @skipIf(archs=["arm64e"]) # arm64e incompatible with minidump
+    @expectedFailureAll(archs=["arm$"])  # Minidump saving not implemented
+    @skipIf(archs=["arm64e"])  # arm64e incompatible with minidump
     def test_from_core_file(self):
         """Test fetching C++ dynamic values from core files. Specifically, test
         that we can determine the dynamic type of the value if the core file


### PR DESCRIPTION
The minidump format does not currently have a way to distinguish arm64e from arm64.