### PR TITLE
[libc] Add missing struct_mmsghdr dependency to sys_socket

### DIFF
--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -789,6 +789,7 @@ add_header_macro(
     .llvm-libc-types.struct_cmsghdr
     .llvm-libc-types.struct_iovec
     .llvm-libc-types.struct_linger
+    .llvm-libc-types.struct_mmsghdr
     .llvm-libc-types.struct_msghdr
     .llvm-libc-types.struct_sockaddr
     .llvm-libc-types.struct_sockaddr_storage


### PR DESCRIPTION
Updated libc/include/CMakeLists.txt to add .llvm-libc-types.struct_mmsghdr to the sys_socket dependency list. This ensures that the generated sys/socket.h correctly includes the struct_mmsghdr.h type header.

Assisted-by: Automated tooling, human reviewed.