### PR TITLE
[AMDGPU] Speedup canBeVOPD()

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.td
@@ -3556,7 +3556,7 @@ def getVOPDBaseFromComponent : SearchIndex {
 def VOPDPairs : GenericTable {
   let FilterClass = "VOPD_Base";
   let CppTypeName = "VOPDInfo";
-  let Fields = ["Opcode", "OpX", "OpY", "SubTgt", "VOPD3"];
+  let Fields = ["Opcode", "OpX", "OpY", "VOPDX", "VOPDY", "SubTgt", "VOPD3"];
   let PrimaryKey = ["Opcode"];
   let PrimaryKeyName = "getVOPDOpcodeHelper";
 }
@@ -3564,6 +3564,16 @@ def VOPDPairs : GenericTable {
 def getVOPDInfoFromComponentOpcodes : SearchIndex {
   let Table = VOPDPairs;
   let Key = ["OpX", "OpY", "SubTgt", "VOPD3"];
+}
+
+def getCanBeVOPDXInfo : SearchIndex {
+  let Table = VOPDPairs;
+  let Key = ["VOPDX", "SubTgt", "VOPD3"];
+}
+
+def getCanBeVOPDYInfo : SearchIndex {
+  let Table = VOPDPairs;
+  let Key = ["VOPDY", "SubTgt", "VOPD3"];
 }
 
 def lo16_to_vgpr32 : OutPatFrag<(ops node:$op),

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -412,7 +412,9 @@ struct VOPDInfo {
   uint32_t Opcode;
   uint16_t OpX;
   uint16_t OpY;
-  uint16_t Subtarget;
+  uint32_t VOPDX;
+  uint32_t VOPDY;
+  uint16_t SubTgt;
   bool VOPD3;
 };
 
@@ -655,30 +657,13 @@ unsigned getVOPDEncodingFamily(const MCSubtargetInfo &ST) {
 }
 
 CanBeVOPD getCanBeVOPD(unsigned Opc, unsigned EncodingFamily, bool VOPD3) {
+  int Opc32 = getVOPe32(Opc);
+  if (Opc32 != -1)
+    Opc = Opc32;
   bool IsConvertibleToBitOp = VOPD3 ? getBitOp2(Opc) : 0;
   Opc = IsConvertibleToBitOp ? (unsigned)AMDGPU::V_BITOP3_B32_e64 : Opc;
-  const VOPDComponentInfo *Info = getVOPDComponentHelper(Opc);
-  if (Info) {
-    // Check that Opc can be used as VOPDY for this encoding. V_MOV_B32 as a
-    // VOPDX is just a placeholder here, it is supported on all encodings.
-    // TODO: This can be optimized by creating tables of supported VOPDY
-    // opcodes per encoding.
-    unsigned VOPDMov = AMDGPU::getVOPDOpcode(AMDGPU::V_MOV_B32_e32, VOPD3);
-    bool CanBeVOPDX;
-    if (VOPD3) {
-      CanBeVOPDX = getVOPDFull(AMDGPU::getVOPDOpcode(Opc, VOPD3), VOPDMov,
-                               EncodingFamily, VOPD3) != -1;
-    } else {
-      // The list of VOPDX opcodes is currently the same in all encoding
-      // families, so we do not need a family-specific check.
-      CanBeVOPDX = Info->CanBeVOPDX;
-    }
-    bool CanBeVOPDY = getVOPDFull(VOPDMov, AMDGPU::getVOPDOpcode(Opc, VOPD3),
-                                  EncodingFamily, VOPD3) != -1;
-    return {CanBeVOPDX, CanBeVOPDY};
-  }
-
-  return {false, false};
+  return {!!getCanBeVOPDXInfo(Opc, EncodingFamily, VOPD3),
+          !!getCanBeVOPDYInfo(Opc, EncodingFamily, VOPD3)};
 }
 
 unsigned getVOPDOpcode(unsigned Opc, bool VOPD3) {

--- a/llvm/lib/Target/AMDGPU/VOPDInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOPDInstructions.td
@@ -115,6 +115,8 @@ class VOPD_Base<dag outs, dag ins, string asm, VOP_Pseudo VDX, VOP_Pseudo VDY,
   bits<6> OpX = XasVC.VOPDOp;
   bits<6> OpY = YasVC.VOPDOp;
   bits<4> SubTgt = Gen.Subtarget;
+  VOP_Pseudo VOPDX = VDX;
+  VOP_Pseudo VOPDY = VDY;
 
   let VALU = 1;
 


### PR DESCRIPTION
Generate static table from tablegen instead of trying to
create a full VOPD opcode just to see if that is possible.

Ideally it shall be single table with info for both X and
Y components and non-VOPD opcode as a primary key, although
I do not think we can genere it now.
