### PR TITLE
[AMDGPU][MIRFormatter] S_WAIT_LOADCNT_DSCNT human-readable mask

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUMIRFormatter.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMIRFormatter.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "AMDGPUMIRFormatter.h"
+#include "AMDGPUWaitcntUtils.h"
 #include "SIMachineFunctionInfo.h"
 #include "llvm/TargetParser/AMDGPUTargetParser.h"
 
@@ -33,6 +34,9 @@ StringLiteral AllOff = "AllOff";
 StringLiteral VmcntName = "Vmcnt";
 StringLiteral ExpcntName = "Expcnt";
 StringLiteral LgkmcntName = "Lgkmcnt";
+
+StringLiteral LoadcntName = "Loadcnt";
+StringLiteral DscntName = "Dscnt";
 
 void AMDGPUMIRFormatter::printSWaitAluImm(uint64_t Imm, raw_ostream &OS) const {
   bool NonePrinted = true;
@@ -86,6 +90,26 @@ void AMDGPUMIRFormatter::printSWaitcntImm(uint64_t Imm, raw_ostream &OS) const {
     OS << AllOff;
 }
 
+void AMDGPUMIRFormatter::printSWaitLoadcntDscntImm(uint64_t Imm,
+                                                   raw_ostream &OS) const {
+  const AMDGPU::IsaVersion &Version = AMDGPU::getIsaVersion(STI.getCPU());
+  bool NonePrinted = true;
+  ListSeparator Delim(SWaitAluDelim);
+  auto PrintFieldIfNotMax = [&](StringRef Descr, uint64_t Num, unsigned Max) {
+    if (Num != Max) {
+      OS << Delim << Descr << SWaitAluDelim << Num;
+      NonePrinted = false;
+    }
+  };
+  OS << SWaitAluImmPrefix;
+  PrintFieldIfNotMax(LoadcntName, AMDGPU::decodeLoadcnt(Version, Imm),
+                     AMDGPU::getLoadcntBitMask(Version));
+  PrintFieldIfNotMax(DscntName, AMDGPU::decodeDscnt(Version, Imm),
+                     AMDGPU::getDscntBitMask(Version));
+  if (NonePrinted)
+    OS << AllOff;
+}
+
 void AMDGPUMIRFormatter::printImm(raw_ostream &OS, const MachineInstr &MI,
                       std::optional<unsigned int> OpIdx, int64_t Imm) const {
 
@@ -93,6 +117,9 @@ void AMDGPUMIRFormatter::printImm(raw_ostream &OS, const MachineInstr &MI,
   case AMDGPU::S_WAITCNT:
   case AMDGPU::S_WAITCNT_soft:
     printSWaitcntImm(Imm, OS);
+    break;
+  case AMDGPU::S_WAIT_LOADCNT_DSCNT:
+    printSWaitLoadcntDscntImm(Imm, OS);
     break;
   case AMDGPU::S_WAITCNT_DEPCTR:
     printSWaitAluImm(Imm, OS);
@@ -119,6 +146,8 @@ bool AMDGPUMIRFormatter::parseImmMnemonic(const unsigned OpCode,
   case AMDGPU::S_WAITCNT:
   case AMDGPU::S_WAITCNT_soft:
     return parseSWaitcntImmMnemonic(OpIdx, Imm, Src, ErrorCallback);
+  case AMDGPU::S_WAIT_LOADCNT_DSCNT:
+    return parseSWaitLoadcntDscntImmMnemonic(OpIdx, Imm, Src, ErrorCallback);
   case AMDGPU::S_WAITCNT_DEPCTR:
     return parseSWaitAluImmMnemonic(OpIdx, Imm, Src, ErrorCallback);
   case AMDGPU::S_DELAY_ALU:
@@ -235,6 +264,68 @@ bool AMDGPUMIRFormatter::parseSWaitcntImmMnemonic(
   }
 
   Imm = AMDGPU::encodeWaitcnt(Version, Vmcnt, Expcnt, Lgkmcnt);
+  return false;
+}
+
+bool AMDGPUMIRFormatter::parseSWaitLoadcntDscntImmMnemonic(
+    const unsigned int OpIdx, int64_t &Imm, StringRef &Src,
+    MIRFormatter::ErrorCallbackType &ErrorCallback) const {
+  const AMDGPU::IsaVersion &Version = AMDGPU::getIsaVersion(STI.getCPU());
+
+  // Accept integer masks for compatibility with old MIR.
+  if (!Src.consumeInteger(10, Imm))
+    return false;
+
+  // Initialize with all counters at max (no wait).
+  unsigned Loadcnt = AMDGPU::getLoadcntBitMask(Version);
+  unsigned Dscnt = AMDGPU::getDscntBitMask(Version);
+
+  // The input is in the form: .Name1_Num1_Name2_Num2
+  // Drop the '.' prefix.
+  if (!Src.consume_front(SWaitAluImmPrefix))
+    return ErrorCallback(Src.begin(), "expected prefix");
+  if (Src.empty())
+    return ErrorCallback(Src.begin(), "expected <CounterName>_<CounterNum>");
+
+  // Special case for all off (all counters at max).
+  if (Src == AllOff) {
+    Imm = AMDGPU::encodeLoadcntDscnt(Version, Loadcnt, Dscnt);
+    return false;
+  }
+
+  // Parse counter name, number pairs.
+  while (!Src.empty()) {
+    size_t DelimIdx = Src.find(SWaitAluDelim);
+    if (DelimIdx == StringRef::npos)
+      return ErrorCallback(Src.begin(), "expected <CounterName>_<CounterNum>");
+    StringRef Name = Src.substr(0, DelimIdx);
+    StringRef::iterator NamePos = Src.begin();
+    Src.consume_front(Name);
+    Src.consume_front(SWaitAluDelim);
+
+    int64_t Num;
+    StringRef::iterator NumPos = Src.begin();
+    if (Src.consumeInteger(10, Num) || Num < 0)
+      return ErrorCallback(NumPos,
+                           "expected non-negative integer counter number");
+
+    unsigned Max;
+    if (Name == LoadcntName) {
+      Max = AMDGPU::getLoadcntBitMask(Version);
+      Loadcnt = Num;
+    } else if (Name == DscntName) {
+      Max = AMDGPU::getDscntBitMask(Version);
+      Dscnt = Num;
+    } else {
+      return ErrorCallback(NamePos, "invalid counter name");
+    }
+    if (Num >= Max)
+      return ErrorCallback(NumPos, "counter value too large");
+
+    Src.consume_front(SWaitAluDelim);
+  }
+
+  Imm = AMDGPU::encodeLoadcntDscnt(Version, Loadcnt, Dscnt);
   return false;
 }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUMIRFormatter.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMIRFormatter.h
@@ -54,6 +54,8 @@ private:
   void printSWaitAluImm(uint64_t Imm, raw_ostream &OS) const;
   /// Prints the string to represent s_waitcnt immediate value.
   void printSWaitcntImm(uint64_t Imm, raw_ostream &OS) const;
+  /// Prints the string to represent s_wait_loadcnt_dscnt immediate value.
+  void printSWaitLoadcntDscntImm(uint64_t Imm, raw_ostream &OS) const;
   /// Print the string to represent s_delay_alu immediate value
   void printSDelayAluImm(int64_t Imm, llvm::raw_ostream &OS) const;
 
@@ -64,6 +66,11 @@ private:
 
   /// Parse the immediate pseudo literal for s_waitcnt
   bool parseSWaitcntImmMnemonic(
+      const unsigned int OpIdx, int64_t &Imm, StringRef &Src,
+      MIRFormatter::ErrorCallbackType &ErrorCallback) const;
+
+  /// Parse the immediate pseudo literal for s_wait_loadcnt_dscnt
+  bool parseSWaitLoadcntDscntImmMnemonic(
       const unsigned int OpIdx, int64_t &Imm, StringRef &Src,
       MIRFormatter::ErrorCallbackType &ErrorCallback) const;
 

--- a/llvm/test/CodeGen/AMDGPU/asyncmark-merge-empty-other.mir
+++ b/llvm/test/CodeGen/AMDGPU/asyncmark-merge-empty-other.mir
@@ -33,7 +33,7 @@ body:             |
   ; CHECK-NEXT:   successors: %bb.2(0x40000000), %bb.1(0x40000000)
   ; CHECK-NEXT:   liveins: $sgpr0, $sgpr1, $vgpr0_vgpr1, $vgpr2
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   S_WAIT_LOADCNT_DSCNT 0
+  ; CHECK-NEXT:   S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
   ; CHECK-NEXT:   S_WAIT_KMCNT 0
   ; CHECK-NEXT:   S_CMP_LG_U32 $sgpr0, $sgpr1, implicit-def $scc
   ; CHECK-NEXT:   S_CBRANCH_SCC1 %bb.2, implicit killed $scc
@@ -92,7 +92,7 @@ body:             |
   ; CHECK-NEXT:   successors: %bb.2(0x40000000), %bb.1(0x40000000)
   ; CHECK-NEXT:   liveins: $sgpr0, $sgpr1, $vgpr0_vgpr1, $vgpr2
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   S_WAIT_LOADCNT_DSCNT 0
+  ; CHECK-NEXT:   S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
   ; CHECK-NEXT:   S_WAIT_KMCNT 0
   ; CHECK-NEXT:   S_CMP_LG_U32 $sgpr0, $sgpr1, implicit-def $scc
   ; CHECK-NEXT:   S_CBRANCH_SCC1 %bb.2, implicit killed $scc

--- a/llvm/test/CodeGen/AMDGPU/expert_scheduling_gfx12.mir
+++ b/llvm/test/CodeGen/AMDGPU/expert_scheduling_gfx12.mir
@@ -12,7 +12,7 @@ body:             |
   bb.0:
     ; GCN-LABEL: name: raw_exp
     ; GCN: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -43,7 +43,7 @@ body:             |
     ; GCN: liveins: $sgpr0, $sgpr1, $sgpr2, $sgpr3, $sgpr4, $sgpr5, $sgpr6, $sgpr7, $vgpr0
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -82,7 +82,7 @@ body:             |
     ; GCN: liveins: $sgpr0, $sgpr1, $sgpr2, $sgpr3, $sgpr4, $sgpr5, $sgpr6, $sgpr7, $vgpr0, $vgpr1
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -90,7 +90,7 @@ body:             |
     ; GCN-NEXT: $vgpr5_vgpr6_vgpr7_vgpr8 = IMAGE_LOAD_V4_V1_gfx12 $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, 15, 0, 0, 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), addrspace 8)
     ; GCN-NEXT: S_WAITCNT_DEPCTR .VmVsrc_0
     ; GCN-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = DS_READ_B128_gfx9 $vgpr1, 0, 0, implicit $exec :: (load (s128), addrspace 3)
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: $vgpr0 = nofpexcept V_ADD_F32_e32 $vgpr5, $vgpr0, implicit $mode, implicit $exec
     ; GCN-NEXT: S_WAITCNT_DEPCTR .VmVsrc_0
     ; GCN-NEXT: $vgpr1 = nofpexcept V_ADD_F32_e32 $vgpr6, $vgpr1, implicit $mode, implicit $exec
@@ -119,7 +119,7 @@ body:             |
     ; GCN: liveins: $sgpr0, $sgpr1, $sgpr2, $sgpr3, $sgpr4, $sgpr5, $sgpr6, $sgpr7, $vgpr0, $vgpr1, $vgpr2
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -132,7 +132,7 @@ body:             |
     ; GCN-NEXT: DS_WRITE_B128_gfx9 $vgpr5, $vgpr0_vgpr1_vgpr2_vgpr3, 0, 0, implicit $exec :: (store (s128), addrspace 3)
     ; GCN-NEXT: S_WAITCNT_DEPCTR .VmVsrc_0
     ; GCN-NEXT: $vgpr0_vgpr1_vgpr2_vgpr3 = IMAGE_LOAD_V4_V1_gfx12 $vgpr4, $sgpr0_sgpr1_sgpr2_sgpr3_sgpr4_sgpr5_sgpr6_sgpr7, 15, 0, 0, 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s128), addrspace 8)
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_SETREG_IMM32_B32 0, 2074, implicit-def $mode, implicit $mode
     ; GCN-NEXT: SI_RETURN_TO_EPILOG $vgpr0, $vgpr1, $vgpr2, $vgpr3
     $vgpr4 = V_MOV_B32_e32 $vgpr0, implicit $exec, implicit $exec
@@ -154,7 +154,7 @@ body:             |
     ; GCN: liveins: $sgpr0, $sgpr1, $sgpr2, $sgpr3, $sgpr4, $sgpr5, $sgpr6, $sgpr7, $vgpr0
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -192,7 +192,7 @@ body:             |
     ; GCN: liveins: $sgpr0, $sgpr1, $sgpr2, $sgpr3, $sgpr4, $sgpr5, $sgpr6, $sgpr7, $vgpr0
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -231,7 +231,7 @@ body:             |
     ; GCN: liveins: $sgpr0, $sgpr1, $sgpr2, $sgpr3, $sgpr4, $sgpr5, $sgpr6, $sgpr7, $vgpr0
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -264,7 +264,7 @@ body: |
   bb.0:
     ; GCN-LABEL: name: raw_valu_scratch
     ; GCN: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -287,7 +287,7 @@ body: |
   bb.0:
     ; GCN-LABEL: name: valu_depctr_valu
     ; GCN: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -309,7 +309,7 @@ body: |
     ; GCN: liveins: $sgpr0, $sgpr1, $sgpr2, $sgpr3, $sgpr4, $sgpr5, $sgpr6, $sgpr7, $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr4, $vgpr5, $vgpr6, $vgpr7, $vgpr10, $vgpr11, $vgpr12, $vgpr13, $vgpr14, $vgpr15, $vgpr16, $vgpr17, $vgpr18
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -333,7 +333,7 @@ body: |
     ; GCN: liveins: $sgpr0, $sgpr1, $sgpr2, $sgpr3, $sgpr4, $sgpr5, $sgpr6, $sgpr7, $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr11, $vgpr18
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -357,7 +357,7 @@ body: |
     ; GCN: liveins: $sgpr0, $sgpr1, $sgpr2, $sgpr3, $sgpr4, $sgpr5, $sgpr6, $sgpr7, $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr11, $vgpr18
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -381,7 +381,7 @@ body: |
     ; GCN: liveins: $sgpr0, $sgpr1, $sgpr2, $sgpr3, $sgpr4, $sgpr5, $sgpr6, $sgpr7, $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr11, $vgpr18
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -405,7 +405,7 @@ body: |
     ; GCN: liveins: $sgpr0, $sgpr1, $sgpr2, $sgpr3, $sgpr4, $sgpr5, $sgpr6, $sgpr7, $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr18
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -429,7 +429,7 @@ body: |
     ; GCN: liveins: $sgpr0, $sgpr1, $sgpr2, $sgpr3, $sgpr4, $sgpr5, $sgpr6, $sgpr7, $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr11, $vgpr18
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -453,7 +453,7 @@ body: |
     ; GCN: liveins: $sgpr0, $sgpr1, $sgpr2, $sgpr3, $sgpr4, $sgpr5, $sgpr6, $sgpr7, $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vgpr4, $vgpr5, $vgpr6, $vgpr7, $vgpr10, $vgpr11, $vgpr12, $vgpr13, $vgpr14, $vgpr15, $vgpr16, $vgpr17, $vgpr18, $vgpr19, $vgpr20, $vgpr21, $vgpr22, $vgpr23, $vgpr24, $vgpr25, $vgpr26
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -477,7 +477,7 @@ body: |
     ; GCN: liveins: $sgpr0, $sgpr1, $sgpr2, $sgpr3, $sgpr4, $sgpr5, $sgpr6, $sgpr7, $vgpr0, $vgpr1
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -510,7 +510,7 @@ body: |
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -521,7 +521,7 @@ body: |
     ; GCN-NEXT: $vgpr0 = nofpexcept V_ADD_F32_e32 $vgpr0, $vgpr1, implicit $mode, implicit $exec
     ; GCN-NEXT: S_WAITCNT_DEPCTR .VmVsrc_0
     ; GCN-NEXT: $vgpr2 = nofpexcept V_ADD_F32_e32 $vgpr2, $vgpr3, implicit $mode, implicit $exec
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAITCNT_DEPCTR .VaVdst_0
     ; GCN-NEXT: S_SETREG_IMM32_B32 0, 2074, implicit-def $mode, implicit $mode
     ; GCN-NEXT: SI_RETURN_TO_EPILOG $vgpr6, $vgpr7
@@ -543,7 +543,7 @@ body: |
     ; GCN: liveins: $vgpr0, $vgpr1
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -576,7 +576,7 @@ body: |
     ; GCN: liveins: $sgpr0, $sgpr1, $sgpr2, $sgpr3, $sgpr4, $sgpr5, $sgpr6, $sgpr7, $vgpr0, $vgpr1
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -586,7 +586,7 @@ body: |
     ; GCN-NEXT: S_WAITCNT_DEPCTR .VmVsrc_0
     ; GCN-NEXT: $vgpr0 = nofpexcept V_ADD_F32_e32 $vgpr0, $vgpr0, implicit $mode, implicit $exec
     ; GCN-NEXT: $vgpr1 = nofpexcept V_ADD_F32_e32 $vgpr1, $vgpr1, implicit $mode, implicit $exec
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAITCNT_DEPCTR .VaVdst_0
     ; GCN-NEXT: S_SETREG_IMM32_B32 0, 2074, implicit-def $mode, implicit $mode
     ; GCN-NEXT: SI_RETURN_TO_EPILOG $vgpr0, $vgpr1
@@ -608,7 +608,7 @@ body: |
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -618,7 +618,7 @@ body: |
     ; GCN-NEXT: S_WAITCNT_DEPCTR .VmVsrc_0
     ; GCN-NEXT: $vgpr1 = nofpexcept V_ADD_F32_e32 $vgpr1, $vgpr1, implicit $mode, implicit $exec
     ; GCN-NEXT: $vgpr2 = nofpexcept V_ADD_F32_e32 $vgpr2, $vgpr2, implicit $mode, implicit $exec
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAITCNT_DEPCTR .VaVdst_0
     ; GCN-NEXT: S_SETREG_IMM32_B32 0, 2074, implicit-def $mode, implicit $mode
     ; GCN-NEXT: SI_RETURN_TO_EPILOG $vgpr1, $vgpr2
@@ -640,7 +640,7 @@ body: |
     ; GCN: liveins: $sgpr0, $sgpr1, $sgpr2, $sgpr3, $sgpr4, $sgpr5, $sgpr6, $sgpr7, $vgpr0, $vgpr1, $vgpr2
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -650,7 +650,7 @@ body: |
     ; GCN-NEXT: S_WAITCNT_DEPCTR .VmVsrc_0
     ; GCN-NEXT: $vgpr1 = nofpexcept V_ADD_F32_e32 $vgpr1, $vgpr1, implicit $mode, implicit $exec
     ; GCN-NEXT: $vgpr2 = nofpexcept V_ADD_F32_e32 $vgpr2, $vgpr2, implicit $mode, implicit $exec
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAITCNT_DEPCTR .VaVdst_0
     ; GCN-NEXT: S_SETREG_IMM32_B32 0, 2074, implicit-def $mode, implicit $mode
     ; GCN-NEXT: SI_RETURN_TO_EPILOG $vgpr1, $vgpr2
@@ -670,7 +670,7 @@ body: |
   bb.0:
     ; GCN-LABEL: name: test_war_completed_vmem
     ; GCN: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0

--- a/llvm/test/CodeGen/AMDGPU/expert_scheduling_gfx1250.mir
+++ b/llvm/test/CodeGen/AMDGPU/expert_scheduling_gfx1250.mir
@@ -7,7 +7,7 @@ body: |
   bb.0:
     ; CHECK-LABEL: name: wmma_scale
     ; CHECK: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; CHECK-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; CHECK-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; CHECK-NEXT: S_WAIT_KMCNT 0
     ; CHECK-NEXT: early-clobber $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15 = V_WMMA_F32_16X16X64_FP8_FP8_w32_twoaddr $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, 8, $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15, 0, 0, 0, 0, implicit $exec
     ; CHECK-NEXT: early-clobber $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23 = V_WMMA_SCALE_F32_16X16X128_F8F6F4_f8_f8_w32_threeaddr $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23_vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31, $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23_vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31, 0, $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23, $vgpr16, $vgpr16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, implicit $exec

--- a/llvm/test/CodeGen/AMDGPU/insert-skips-gfx12.mir
+++ b/llvm/test/CodeGen/AMDGPU/insert-skips-gfx12.mir
@@ -44,7 +44,7 @@ body: |
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   V_NOP_e32 implicit $exec
-  ; CHECK-NEXT:   S_WAIT_LOADCNT_DSCNT 0
+  ; CHECK-NEXT:   S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2:
   ; CHECK-NEXT:   S_ENDPGM 0
@@ -55,7 +55,7 @@ body: |
   bb.1:
     successors: %bb.2
     V_NOP_e32 implicit $exec
-    S_WAIT_LOADCNT_DSCNT 0
+    S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
 
   bb.2:
     S_ENDPGM 0

--- a/llvm/test/CodeGen/AMDGPU/insert-waitcnts-gfx12-wbinv.mir
+++ b/llvm/test/CodeGen/AMDGPU/insert-waitcnts-gfx12-wbinv.mir
@@ -12,7 +12,7 @@ body:             |
   ; CHECK: bb.0:
   ; CHECK-NEXT:   successors: %bb.2(0x40000000), %bb.1(0x40000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   S_WAIT_LOADCNT_DSCNT 0
+  ; CHECK-NEXT:   S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
   ; CHECK-NEXT:   S_WAIT_EXPCNT 0
   ; CHECK-NEXT:   S_WAIT_SAMPLECNT 0
   ; CHECK-NEXT:   S_WAIT_BVHCNT 0
@@ -54,7 +54,7 @@ body:             |
   ; CHECK: bb.0:
   ; CHECK-NEXT:   successors: %bb.2(0x40000000), %bb.1(0x40000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   S_WAIT_LOADCNT_DSCNT 0
+  ; CHECK-NEXT:   S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
   ; CHECK-NEXT:   S_WAIT_EXPCNT 0
   ; CHECK-NEXT:   S_WAIT_SAMPLECNT 0
   ; CHECK-NEXT:   S_WAIT_BVHCNT 0
@@ -96,7 +96,7 @@ body:             |
   ; CHECK: bb.0:
   ; CHECK-NEXT:   successors: %bb.2(0x40000000), %bb.1(0x40000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   S_WAIT_LOADCNT_DSCNT 0
+  ; CHECK-NEXT:   S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
   ; CHECK-NEXT:   S_WAIT_EXPCNT 0
   ; CHECK-NEXT:   S_WAIT_SAMPLECNT 0
   ; CHECK-NEXT:   S_WAIT_BVHCNT 0

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.s.barrier.signal.isfirst.mir
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.s.barrier.signal.isfirst.mir
@@ -6,7 +6,7 @@ name: signal_isfirst_imm_same_barrier_wait
 body: |
   bb.0:
     ; GCN-LABEL: name: signal_isfirst_imm_same_barrier_wait
-    ; GCN: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -30,7 +30,7 @@ name: signal_isfirst_imm_different_barrier_wait
 body: |
   bb.0:
     ; GCN-LABEL: name: signal_isfirst_imm_different_barrier_wait
-    ; GCN: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -55,7 +55,7 @@ name: signal_isfirst_m0_same_barrier_wait
 body: |
   bb.0:
     ; GCN-LABEL: name: signal_isfirst_m0_same_barrier_wait
-    ; GCN: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0
@@ -82,7 +82,7 @@ name: signal_isfirst_m0_different_barrier_wait
 body: |
   bb.0:
     ; GCN-LABEL: name: signal_isfirst_m0_different_barrier_wait
-    ; GCN: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_EXPCNT 0
     ; GCN-NEXT: S_WAIT_SAMPLECNT 0
     ; GCN-NEXT: S_WAIT_BVHCNT 0

--- a/llvm/test/CodeGen/AMDGPU/spill-wait.mir
+++ b/llvm/test/CodeGen/AMDGPU/spill-wait.mir
@@ -23,7 +23,7 @@ body: |
     ; GFX12-LABEL: name: spill_vgpr_tuple
     ; GFX12: liveins: $vgpr0_vgpr1, $sgpr76_sgpr77_sgpr78_sgpr79
     ; GFX12-NEXT: {{  $}}
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
@@ -59,7 +59,7 @@ body: |
     ; GFX12-LABEL: name: load_vcc_wait
     ; GFX12: liveins: $vgpr0, $sgpr10_sgpr11
     ; GFX12-NEXT: {{  $}}
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
@@ -94,7 +94,7 @@ body: |
     ; GFX12-LABEL: name: load_flat_scr_lo_flat_load_wait
     ; GFX12: liveins: $sgpr10_sgpr11, $vgpr0_vgpr1
     ; GFX12-NEXT: {{  $}}
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
@@ -127,7 +127,7 @@ body: |
     ; GFX12-LABEL: name: load_flat_scr_lo_scratch_store_wait
     ; GFX12: liveins: $sgpr10_sgpr11, $vgpr0, $sgpr32
     ; GFX12-NEXT: {{  $}}
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
@@ -171,7 +171,7 @@ body: |
     ; GFX12-LABEL: name: spill_load_store
     ; GFX12: liveins: $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr32
     ; GFX12-NEXT: {{  $}}
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
@@ -219,7 +219,7 @@ body:             |
     ; GFX12-LABEL: name: scratch_load_waw
     ; GFX12: liveins: $vgpr0, $sgpr0
     ; GFX12-NEXT: {{  $}}
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0

--- a/llvm/test/CodeGen/AMDGPU/wait-xcnt-drain.mir
+++ b/llvm/test/CodeGen/AMDGPU/wait-xcnt-drain.mir
@@ -54,7 +54,7 @@ body: |
     ; GCN-LABEL: name: drain_call
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2, $sgpr0_sgpr1
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_KMCNT 0
     ; GCN-NEXT: GLOBAL_STORE_DWORD killed $vgpr0_vgpr1, $vgpr2, 0, 0, implicit $exec
     ; GCN-NEXT: $sgpr30_sgpr31 = SI_CALL killed $sgpr0_sgpr1, 0, csr_amdgpu

--- a/llvm/test/CodeGen/AMDGPU/wait-xcnt.mir
+++ b/llvm/test/CodeGen/AMDGPU/wait-xcnt.mir
@@ -141,7 +141,7 @@ body: |
     ; GCN-LABEL: name: vmem_buffer_store
     ; GCN: liveins: $vgpr0, $vgpr1
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_KMCNT 0
     ; GCN-NEXT: BUFFER_STORE_DWORD_OFFSET killed $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr32, 0, 0, 0, implicit $exec
     ; GCN-NEXT: S_WAIT_XCNT 0
@@ -161,7 +161,7 @@ body: |
     ; GCN-LABEL: name: vmem_scratch_store
     ; GCN: liveins: $vgpr0, $vgpr1, $vgpr2
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_KMCNT 0
     ; GCN-NEXT: SCRATCH_STORE_DWORDX2_SADDR killed $vgpr0_vgpr1, $sgpr32, 0, 0, implicit $exec, implicit $flat_scr
     ; GCN-NEXT: S_WAIT_XCNT 0

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-func-global-inv.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-func-global-inv.mir
@@ -21,7 +21,7 @@ body: |
     ; GFX12-LABEL: name: func_global_inv_only
     ; GFX12: liveins: $sgpr30_sgpr31
     ; GFX12-NEXT: {{  $}}
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
@@ -45,7 +45,7 @@ body: |
     ; GFX12-LABEL: name: func_global_inv_with_vgpr_load
     ; GFX12: liveins: $vgpr0, $sgpr0_sgpr1, $sgpr30_sgpr31
     ; GFX12-NEXT: {{  $}}
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
@@ -71,7 +71,7 @@ body: |
     ; GFX12-LABEL: name: func_vgpr_load_no_global_inv
     ; GFX12: liveins: $vgpr0, $sgpr0_sgpr1, $sgpr30_sgpr31
     ; GFX12-NEXT: {{  $}}
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
@@ -96,7 +96,7 @@ body: |
     ; GFX12-LABEL: name: func_global_inv_load_already_waited
     ; GFX12: liveins: $vgpr0, $sgpr0_sgpr1, $sgpr30_sgpr31
     ; GFX12-NEXT: {{  $}}
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-gfx1250.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-gfx1250.mir
@@ -6,7 +6,7 @@ name: no_wait_between_low_and_high_vgpr
 body: |
   bb.0:
     ; GCN-LABEL: name: no_wait_between_low_and_high_vgpr
-    ; GCN: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_KMCNT 0
     ; GCN-NEXT: $vgpr0 = FLAT_LOAD_DWORD undef $vgpr2_vgpr3, 0, 0, implicit $exec, implicit $flat_scr
     ; GCN-NEXT: FLAT_STORE_DWORD undef $vgpr4_vgpr5, $vgpr256, 0, 0, implicit $exec, implicit $flat_scr
@@ -21,10 +21,10 @@ name: wait_between_high_and_high_vgpr
 body: |
   bb.0:
     ; GCN-LABEL: name: wait_between_high_and_high_vgpr
-    ; GCN: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_KMCNT 0
     ; GCN-NEXT: $vgpr511 = FLAT_LOAD_DWORD undef $vgpr2_vgpr3, 0, 0, implicit $exec, implicit $flat_scr
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: FLAT_STORE_DWORD undef $vgpr4_vgpr5, $vgpr511, 0, 0, implicit $exec, implicit $flat_scr
     ; GCN-NEXT: S_ENDPGM 0
     $vgpr511 = FLAT_LOAD_DWORD undef $vgpr2_vgpr3, 0, 0, implicit $exec, implicit $flat_scr
@@ -37,7 +37,7 @@ name: no_wait_between_low_and_high_vgpr_512
 body: |
   bb.0:
     ; GCN-LABEL: name: no_wait_between_low_and_high_vgpr_512
-    ; GCN: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_KMCNT 0
     ; GCN-NEXT: $vgpr0 = FLAT_LOAD_DWORD undef $vgpr2_vgpr3, 0, 0, implicit $exec, implicit $flat_scr
     ; GCN-NEXT: FLAT_STORE_DWORD undef $vgpr4_vgpr5, $vgpr512, 0, 0, implicit $exec, implicit $flat_scr
@@ -52,10 +52,10 @@ name: wait_between_high_and_high_vgpr_512
 body: |
   bb.0:
     ; GCN-LABEL: name: wait_between_high_and_high_vgpr_512
-    ; GCN: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_KMCNT 0
     ; GCN-NEXT: $vgpr512 = FLAT_LOAD_DWORD undef $vgpr2_vgpr3, 0, 0, implicit $exec, implicit $flat_scr
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: FLAT_STORE_DWORD undef $vgpr4_vgpr5, $vgpr512, 0, 0, implicit $exec, implicit $flat_scr
     ; GCN-NEXT: S_ENDPGM 0
     $vgpr512 = FLAT_LOAD_DWORD undef $vgpr2_vgpr3, 0, 0, implicit $exec, implicit $flat_scr
@@ -68,7 +68,7 @@ name: no_wait_between_high_vgpr_768_and_high_vgpr_512
 body: |
   bb.0:
     ; GCN-LABEL: name: no_wait_between_high_vgpr_768_and_high_vgpr_512
-    ; GCN: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_KMCNT 0
     ; GCN-NEXT: $vgpr768 = FLAT_LOAD_DWORD undef $vgpr2_vgpr3, 0, 0, implicit $exec, implicit $flat_scr
     ; GCN-NEXT: FLAT_STORE_DWORD undef $vgpr4_vgpr5, $vgpr512, 0, 0, implicit $exec, implicit $flat_scr
@@ -83,10 +83,10 @@ name: wait_between_high_and_high_vgpr_768
 body: |
   bb.0:
     ; GCN-LABEL: name: wait_between_high_and_high_vgpr_768
-    ; GCN: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: S_WAIT_KMCNT 0
     ; GCN-NEXT: $vgpr768 = FLAT_LOAD_DWORD undef $vgpr2_vgpr3, 0, 0, implicit $exec, implicit $flat_scr
-    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GCN-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GCN-NEXT: FLAT_STORE_DWORD undef $vgpr4_vgpr5, $vgpr768, 0, 0, implicit $exec, implicit $flat_scr
     ; GCN-NEXT: S_ENDPGM 0
     $vgpr768 = FLAT_LOAD_DWORD undef $vgpr2_vgpr3, 0, 0, implicit $exec, implicit $flat_scr

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-kmcnt-scc-different-block.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-kmcnt-scc-different-block.mir
@@ -8,7 +8,7 @@ body: |
   ; GFX12: bb.0:
   ; GFX12-NEXT:   successors: %bb.2(0x40000000), %bb.1(0x40000000)
   ; GFX12-NEXT: {{  $}}
-  ; GFX12-NEXT:   S_WAIT_LOADCNT_DSCNT 0
+  ; GFX12-NEXT:   S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
   ; GFX12-NEXT:   S_WAIT_EXPCNT 0
   ; GFX12-NEXT:   S_WAIT_SAMPLECNT 0
   ; GFX12-NEXT:   S_WAIT_BVHCNT 0
@@ -56,7 +56,7 @@ body: |
   ; GFX12: bb.0:
   ; GFX12-NEXT:   successors: %bb.2(0x40000000), %bb.1(0x40000000)
   ; GFX12-NEXT: {{  $}}
-  ; GFX12-NEXT:   S_WAIT_LOADCNT_DSCNT 0
+  ; GFX12-NEXT:   S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
   ; GFX12-NEXT:   S_WAIT_EXPCNT 0
   ; GFX12-NEXT:   S_WAIT_SAMPLECNT 0
   ; GFX12-NEXT:   S_WAIT_BVHCNT 0
@@ -105,7 +105,7 @@ body: |
   ; GFX12: bb.0:
   ; GFX12-NEXT:   successors: %bb.4(0x40000000), %bb.1(0x40000000)
   ; GFX12-NEXT: {{  $}}
-  ; GFX12-NEXT:   S_WAIT_LOADCNT_DSCNT 0
+  ; GFX12-NEXT:   S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
   ; GFX12-NEXT:   S_WAIT_EXPCNT 0
   ; GFX12-NEXT:   S_WAIT_SAMPLECNT 0
   ; GFX12-NEXT:   S_WAIT_BVHCNT 0

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-overflow.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-overflow.mir
@@ -117,7 +117,7 @@ body:             |
     ; GFX12-LABEL: name: max-counter-lgkmcnt
     ; GFX12: liveins: $vgpr99
     ; GFX12-NEXT: {{  $}}
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
@@ -417,7 +417,7 @@ body:             |
     ; GFX12-LABEL: name: max-counter-vmcnt
     ; GFX12: liveins: $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4
     ; GFX12-NEXT: {{  $}}
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
@@ -623,7 +623,7 @@ body:             |
     ; GFX12-LABEL: name: max-counter-expcnt
     ; GFX12: liveins: $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, $vgpr0, $vgpr1
     ; GFX12-NEXT: {{  $}}
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
@@ -800,7 +800,7 @@ body: |
     ; GFX12-LABEL: name: max-counter-dscnt
     ; GFX12: liveins: $vgpr99
     ; GFX12-NEXT: {{  $}}
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-preexisting.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-preexisting.mir
@@ -28,7 +28,7 @@ body:             |
     ; GFX12-LABEL: name: test_waitcnt_preexisting_lgkmcnt_unmodified
     ; GFX12: liveins: $vgpr0
     ; GFX12-NEXT: {{  $}}
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
@@ -37,7 +37,7 @@ body:             |
     ; GFX12-NEXT: S_WAITCNT .Vmcnt_48_Lgkmcnt_7
     ; GFX12-NEXT: S_WAIT_DSCNT 0
     ; GFX12-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX12-NEXT: S_ENDPGM 0
     $vgpr0_vgpr1 = DS_READ2_B32 $vgpr0, 0, 1, 0, implicit $m0, implicit $exec
@@ -67,7 +67,7 @@ body:             |
     ; GFX12-LABEL: name: test_waitcnt_preexisting_vmcnt_unmodified
     ; GFX12: liveins: $vgpr0_vgpr1
     ; GFX12-NEXT: {{  $}}
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
@@ -76,7 +76,7 @@ body:             |
     ; GFX12-NEXT: S_WAITCNT .Vmcnt_3_Expcnt_0_Lgkmcnt_55
     ; GFX12-NEXT: S_WAIT_LOADCNT 0
     ; GFX12-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX12-NEXT: S_ENDPGM 0
     $vgpr0_vgpr1 = GLOBAL_LOAD_DWORDX2 $vgpr0_vgpr1, 0, 0, implicit $exec
@@ -108,7 +108,7 @@ body:             |
     ; GFX12-LABEL: name: test_waitcnt_preexisting_vmcnt_needs_lgkmcnt
     ; GFX12: liveins: $vgpr0
     ; GFX12-NEXT: {{  $}}
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
@@ -117,7 +117,7 @@ body:             |
     ; GFX12-NEXT: S_WAITCNT .Vmcnt_3_Expcnt_0_Lgkmcnt_55
     ; GFX12-NEXT: S_WAIT_DSCNT 0
     ; GFX12-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX12-NEXT: S_ENDPGM 0
     $vgpr0_vgpr1 = DS_READ2_B32 $vgpr0, 0, 1, 0, implicit $m0, implicit $exec
@@ -147,7 +147,7 @@ body:             |
     ; GFX12-LABEL: name: test_waitcnt_preexisting_lgkmcnt_needs_vmcnt
     ; GFX12: liveins: $vgpr0_vgpr1
     ; GFX12-NEXT: {{  $}}
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
@@ -156,7 +156,7 @@ body:             |
     ; GFX12-NEXT: S_WAITCNT .Vmcnt_48_Lgkmcnt_7
     ; GFX12-NEXT: S_WAIT_LOADCNT 0
     ; GFX12-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX12-NEXT: S_ENDPGM 0
     $vgpr0_vgpr1 = GLOBAL_LOAD_DWORDX2 $vgpr0_vgpr1, 0, 0, implicit $exec
@@ -190,7 +190,7 @@ body:             |
     ; GFX12-LABEL: name: test_waitcnt_preexisting_apply_all_counters
     ; GFX12: liveins: $vgpr0_vgpr1, $vgpr2
     ; GFX12-NEXT: {{  $}}
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
@@ -202,7 +202,7 @@ body:             |
     ; GFX12-NEXT: $vgpr6 = V_OR_B32_e32 1, killed $vgpr6, implicit $exec
     ; GFX12-NEXT: S_WAIT_LOADCNT 0
     ; GFX12-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr4_vgpr5, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     $vgpr4_vgpr5 = GLOBAL_LOAD_DWORDX2 $vgpr0_vgpr1, 0, 0, implicit $exec
     $vgpr6_vgpr7 = DS_READ2_B32 $vgpr2, 0, 1, 0, implicit $m0, implicit $exec
@@ -229,7 +229,7 @@ body:             |
     ; GFX12-LABEL: name: test_waitcnt_preexisting_combine_waitcnt
     ; GFX12: liveins: $vgpr0_vgpr1
     ; GFX12-NEXT: {{  $}}
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
@@ -241,7 +241,7 @@ body:             |
     ; GFX12-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX12-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GFX12-NEXT: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
     S_WAITCNT 0
@@ -270,7 +270,7 @@ body:             |
     ; GFX12-LABEL: name: test_waitcnt_preexisting_combine_waitcnt_diff_counters
     ; GFX12: liveins: $vgpr0_vgpr1
     ; GFX12-NEXT: {{  $}}
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
@@ -278,7 +278,7 @@ body:             |
     ; GFX12-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX12-NEXT: S_WAITCNT .Vmcnt_48_Lgkmcnt_7
     ; GFX12-NEXT: S_WAITCNT .Vmcnt_3_Expcnt_0_Lgkmcnt_55
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
     S_WAITCNT 49279
@@ -310,7 +310,7 @@ body:             |
     ; GFX12-LABEL: name: test_waitcnt_preexisting_early_wait
     ; GFX12: liveins: $vgpr0_vgpr1
     ; GFX12-NEXT: {{  $}}
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
@@ -320,7 +320,7 @@ body:             |
     ; GFX12-NEXT: S_NOP 0
     ; GFX12-NEXT: S_NOP 0
     ; GFX12-NEXT: S_NOP 0
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX12-NEXT: S_ENDPGM 0
     $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
@@ -349,7 +349,7 @@ body:             |
     ; GFX12-LABEL: name: test_waitcnt_preexisting_ignore_kill
     ; GFX12: liveins: $vgpr0_vgpr1
     ; GFX12-NEXT: {{  $}}
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
@@ -373,7 +373,7 @@ body:             |
     ; GFX9-NEXT: S_ENDPGM 0
     ;
     ; GFX12-LABEL: name: test_waitcnt_preexisting_func_start
-    ; GFX12: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
@@ -402,7 +402,7 @@ body:             |
     ; GFX9-NEXT: S_ENDPGM 0
     ;
     ; GFX12-LABEL: name: test_waitcnt_preexisting_buffer_inv
-    ; GFX12: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: S_WAIT_EXPCNT 0
     ; GFX12-NEXT: S_WAIT_SAMPLECNT 0
     ; GFX12-NEXT: S_WAIT_BVHCNT 0
@@ -413,7 +413,7 @@ body:             |
     ; GFX12-NEXT: S_WAIT_LOADCNT 0
     ; GFX12-NEXT: BUFFER_WBINVL1_VOL implicit $exec
     ; GFX12-NEXT: $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; GFX12-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; GFX12-NEXT: FLAT_STORE_DWORD $vgpr0_vgpr1, $vgpr0, 0, 0, implicit $exec, implicit $flat_scr
     ; GFX12-NEXT: S_ENDPGM 0
     $vgpr0_vgpr1 = GLOBAL_LOAD_DWORDX2 $vgpr0_vgpr1, 0, 0, implicit $exec

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-vmcnt-loop.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-vmcnt-loop.mir
@@ -790,9 +790,9 @@ body:             |
 # GFX12-LABEL: waitcnt_vm_loop_flat_mem
 # GFX12-LABEL: bb.0:
 # GFX12: FLAT_LOAD_DWORD
-# GFX12-NOT: S_WAIT_LOADCNT_DSCNT 0
+# GFX12-NOT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
 # GFX12-LABEL: bb.1:
-# GFX12: S_WAIT_LOADCNT_DSCNT 0
+# GFX12: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
 # GFX12-LABEL: bb.2:
 name:            waitcnt_vm_loop_flat_mem
 body:             |

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-wcg-attributes.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-wcg-attributes.mir
@@ -27,7 +27,7 @@ name:            test-wcg-attributes-noexpert
 body:             |
   bb.0:
     ; CHECK-LABEL: name: test-wcg-attributes-noexpert
-    ; CHECK: S_WAIT_LOADCNT_DSCNT 0
+    ; CHECK: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; CHECK-NEXT: S_WAIT_EXPCNT 0
     ; CHECK-NEXT: S_WAIT_SAMPLECNT 0
     ; CHECK-NEXT: S_WAIT_BVHCNT 0
@@ -46,7 +46,7 @@ body:             |
   bb.0:
     ; CHECK-LABEL: name: test-wcg-attributes-expert
     ; CHECK: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
-    ; CHECK-NEXT: S_WAIT_LOADCNT_DSCNT 0
+    ; CHECK-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; CHECK-NEXT: S_WAIT_EXPCNT 0
     ; CHECK-NEXT: S_WAIT_SAMPLECNT 0
     ; CHECK-NEXT: S_WAIT_BVHCNT 0
@@ -79,7 +79,7 @@ name:            test-wcg-attributes-gfx1200
 body:             |
   bb.0:
     ; CHECK-LABEL: name: test-wcg-attributes-gfx1200
-    ; CHECK: S_WAIT_LOADCNT_DSCNT 0
+    ; CHECK: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
     ; CHECK-NEXT: S_WAIT_EXPCNT 0
     ; CHECK-NEXT: S_WAIT_SAMPLECNT 0
     ; CHECK-NEXT: S_WAIT_BVHCNT 0

--- a/llvm/test/CodeGen/MIR/AMDGPU/s_wait_loadcnt_dscnt-errors.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/s_wait_loadcnt_dscnt-errors.mir
@@ -1,0 +1,143 @@
+# RUN: split-file %s %t
+
+;--- bad-expression.mir
+# RUN: not llc %t/bad-expression.mir -mtriple=amdgcn -mcpu=gfx1200 -run-pass=none -filetype=null 2>&1 | FileCheck %t/bad-expression.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} expected <CounterName>_<CounterNum>
+# CHECK-NEXT:    S_WAIT_LOADCNT_DSCNT .BadExpression
+# CHECK-NEXT:                          ^
+name: BadExpression
+body: |
+  bb.0:
+    S_WAIT_LOADCNT_DSCNT .BadExpression
+...
+
+;--- loadcnt-too-large.mir
+# RUN: not llc %t/loadcnt-too-large.mir -mtriple=amdgcn -mcpu=gfx1200 -run-pass=none -filetype=null 2>&1 | FileCheck %t/loadcnt-too-large.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} counter value too large
+# CHECK-NEXT:    S_WAIT_LOADCNT_DSCNT .Loadcnt_99999
+# CHECK-NEXT:                                  ^
+name: LoadcntTooLarge
+body: |
+  bb.0:
+    S_WAIT_LOADCNT_DSCNT .Loadcnt_99999
+...
+
+;--- dscnt-too-large.mir
+# RUN: not llc %t/dscnt-too-large.mir -mtriple=amdgcn -mcpu=gfx1200 -run-pass=none -filetype=null 2>&1 | FileCheck %t/dscnt-too-large.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} counter value too large
+# CHECK-NEXT:    S_WAIT_LOADCNT_DSCNT .Dscnt_99999
+# CHECK-NEXT:                                ^
+name: DscntTooLarge
+body: |
+  bb.0:
+    S_WAIT_LOADCNT_DSCNT .Dscnt_99999
+...
+
+;--- expected-prefix.mir
+# RUN: not llc %t/expected-prefix.mir -mtriple=amdgcn -mcpu=gfx1200 -run-pass=none -filetype=null 2>&1 | FileCheck %t/expected-prefix.mir
+---
+# CHECK: error: {{.*}}
+name: MissingDotPrefix
+body: |
+  bb.0:
+    S_WAIT_LOADCNT_DSCNT MissingDotPrefix
+...
+
+;--- invalid-counter-name.mir
+# RUN: not llc %t/invalid-counter-name.mir -mtriple=amdgcn -mcpu=gfx1200 -run-pass=none -filetype=null 2>&1 | FileCheck %t/invalid-counter-name.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} invalid counter name
+# CHECK-NEXT:    S_WAIT_LOADCNT_DSCNT .InvalidCounterName_1
+# CHECK-NEXT:                          ^
+name: InvalidCounterName
+body: |
+  bb.0:
+    S_WAIT_LOADCNT_DSCNT .InvalidCounterName_1
+...
+
+;--- loadcnt-non-integer.mir
+# RUN: not llc %t/loadcnt-non-integer.mir -mtriple=amdgcn -mcpu=gfx1200 -run-pass=none -filetype=null 2>&1 | FileCheck %t/loadcnt-non-integer.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} expected non-negative integer counter number
+# CHECK-NEXT:    S_WAIT_LOADCNT_DSCNT .Loadcnt_BadCnt
+# CHECK-NEXT:                                  ^
+name: LoadcntNonInteger
+body: |
+  bb.0:
+    S_WAIT_LOADCNT_DSCNT .Loadcnt_BadCnt
+...
+
+;--- dscnt-non-integer.mir
+# RUN: not llc %t/dscnt-non-integer.mir -mtriple=amdgcn -mcpu=gfx1200 -run-pass=none -filetype=null 2>&1 | FileCheck %t/dscnt-non-integer.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} expected non-negative integer counter number
+# CHECK-NEXT:    S_WAIT_LOADCNT_DSCNT .Dscnt_BadCnt
+# CHECK-NEXT:                                ^
+name: DscntNonInteger
+body: |
+  bb.0:
+    S_WAIT_LOADCNT_DSCNT .Dscnt_BadCnt
+...
+
+;--- loadcnt-negative.mir
+# RUN: not llc %t/loadcnt-negative.mir -mtriple=amdgcn -mcpu=gfx1200 -run-pass=none -filetype=null 2>&1 | FileCheck %t/loadcnt-negative.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} expected non-negative integer counter number
+# CHECK-NEXT:    S_WAIT_LOADCNT_DSCNT .Loadcnt_-1
+# CHECK-NEXT:                                  ^
+name: LoadcntNegative
+body: |
+  bb.0:
+    S_WAIT_LOADCNT_DSCNT .Loadcnt_-1
+...
+
+;--- dscnt-negative.mir
+# RUN: not llc %t/dscnt-negative.mir -mtriple=amdgcn -mcpu=gfx1200 -run-pass=none -filetype=null 2>&1 | FileCheck %t/dscnt-negative.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} expected non-negative integer counter number
+# CHECK-NEXT:    S_WAIT_LOADCNT_DSCNT .Dscnt_-1
+# CHECK-NEXT:                                ^
+name: DscntNegative
+body: |
+  bb.0:
+    S_WAIT_LOADCNT_DSCNT .Dscnt_-1
+...
+
+;--- valid-loadcnt-invalid-dscnt.mir
+# RUN: not llc %t/valid-loadcnt-invalid-dscnt.mir -mtriple=amdgcn -mcpu=gfx1200 -run-pass=none -filetype=null 2>&1 | FileCheck %t/valid-loadcnt-invalid-dscnt.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} counter value too large
+# CHECK-NEXT:    S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_99999
+# CHECK-NEXT:                                          ^
+name: ValidLoadcntInvalidDscnt
+body: |
+  bb.0:
+    S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_99999
+...
+
+;--- valid-loadcnt-invalid-name.mir
+# RUN: not llc %t/valid-loadcnt-invalid-name.mir -mtriple=amdgcn -mcpu=gfx1200 -run-pass=none -filetype=null 2>&1 | FileCheck %t/valid-loadcnt-invalid-name.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} invalid counter name
+# CHECK-NEXT:    S_WAIT_LOADCNT_DSCNT .Loadcnt_0_BadName_1
+# CHECK-NEXT:                                    ^
+name: ValidLoadcntInvalidName
+body: |
+  bb.0:
+    S_WAIT_LOADCNT_DSCNT .Loadcnt_0_BadName_1
+...
+
+;--- valid-loadcnt-non-integer-dscnt.mir
+# RUN: not llc %t/valid-loadcnt-non-integer-dscnt.mir -mtriple=amdgcn -mcpu=gfx1200 -run-pass=none -filetype=null 2>&1 | FileCheck %t/valid-loadcnt-non-integer-dscnt.mir --strict-whitespace --match-full-lines
+---
+# CHECK:error: {{.*}} expected non-negative integer counter number
+# CHECK-NEXT:    S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_abc
+# CHECK-NEXT:                                          ^
+name: ValidLoadcntNonIntegerDscnt
+body: |
+  bb.0:
+    S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_abc
+...

--- a/llvm/test/CodeGen/MIR/AMDGPU/s_wait_loadcnt_dscnt.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/s_wait_loadcnt_dscnt.mir
@@ -1,0 +1,90 @@
+# RUN: llc -mtriple=amdgcn -mcpu=gfx1200 -run-pass=none %s -o - | FileCheck %s
+---
+name: loadcnt_0
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: loadcnt_0
+    ; CHECK: S_WAIT_LOADCNT_DSCNT .Loadcnt_0
+    S_WAIT_LOADCNT_DSCNT .Loadcnt_0
+...
+---
+name: loadcnt_1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: loadcnt_1
+    ; CHECK: S_WAIT_LOADCNT_DSCNT .Loadcnt_1
+    S_WAIT_LOADCNT_DSCNT .Loadcnt_1
+...
+---
+name: loadcnt_max-1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: loadcnt_max-1
+    ; CHECK: S_WAIT_LOADCNT_DSCNT .Loadcnt_62
+    S_WAIT_LOADCNT_DSCNT .Loadcnt_62
+...
+---
+name: dscnt_0
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: dscnt_0
+    ; CHECK: S_WAIT_LOADCNT_DSCNT .Dscnt_0
+    S_WAIT_LOADCNT_DSCNT .Dscnt_0
+...
+---
+name: dscnt_1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: dscnt_1
+    ; CHECK: S_WAIT_LOADCNT_DSCNT .Dscnt_1
+    S_WAIT_LOADCNT_DSCNT .Dscnt_1
+...
+---
+name: dscnt_max-1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: dscnt_max-1
+    ; CHECK: S_WAIT_LOADCNT_DSCNT .Dscnt_62
+    S_WAIT_LOADCNT_DSCNT .Dscnt_62
+...
+---
+name: loadcnt_dscnt
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: loadcnt_dscnt
+    ; CHECK: S_WAIT_LOADCNT_DSCNT .Loadcnt_3_Dscnt_5
+    S_WAIT_LOADCNT_DSCNT .Loadcnt_3_Dscnt_5
+...
+---
+name: all-zero
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: all-zero
+    ; CHECK: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
+    S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
+...
+---
+name: all-off
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: all-off
+    ; CHECK: S_WAIT_LOADCNT_DSCNT .AllOff
+    S_WAIT_LOADCNT_DSCNT .AllOff
+...
+---
+name: zero-number
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: zero-number
+    ; CHECK: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
+    S_WAIT_LOADCNT_DSCNT 0
+...
+---
+name: all-off-number
+body: |
+  bb.0:
+    ; dscnt[5:0]=63, loadcnt[13:8]=63 -> 0x3F3F = 16191
+    ; CHECK-LABEL: name: all-off-number
+    ; CHECK: S_WAIT_LOADCNT_DSCNT .AllOff
+    S_WAIT_LOADCNT_DSCNT 16191
+...


### PR DESCRIPTION
This patch implements a printer and parser for the S_WAIT_LOADCNT_DSCNT mask. It prints the mask in a human-readable format, showing the counter values like: `Loadcnt_<NUM>_Dscnt_<NUM>`.

The format matches the printing style of S_WAITCNT_DEPCTR. For example:
```
  S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dsccnt_0
  S_WAIT_LOADCNT_DSCNT .Dsccnt_2
  S_WAIT_LOADCNT_DSCNT .AllOff
```
Counters at their maximum value (meaning "don't wait") are omitted. When all counters are at max, `.AllOff` is printed.