### PR TITLE
[Support][ScopedPrinter] Emit valid JSON in printHex<ulittle16_t>

### DIFF
--- a/llvm/include/llvm/Support/ScopedPrinter.h
+++ b/llvm/include/llvm/Support/ScopedPrinter.h
@@ -549,7 +549,7 @@ template <>
 inline void
 ScopedPrinter::printHex<support::ulittle16_t>(StringRef Label,
                                               support::ulittle16_t Value) {
-  startLine() << Label << ": " << hex(Value) << "\n";
+  printHexImpl(Label, hex(static_cast<uint16_t>(Value)));
 }
 
 struct DelimitedScope {

--- a/llvm/include/llvm/Support/ScopedPrinter.h
+++ b/llvm/include/llvm/Support/ScopedPrinter.h
@@ -545,13 +545,6 @@ private:
   ScopedPrinterKind Kind;
 };
 
-template <>
-inline void
-ScopedPrinter::printHex<support::ulittle16_t>(StringRef Label,
-                                              support::ulittle16_t Value) {
-  printHexImpl(Label, hex(static_cast<uint16_t>(Value)));
-}
-
 struct DelimitedScope {
   DelimitedScope(ScopedPrinter &W) : W(&W) {}
   DelimitedScope() : W(nullptr) {}

--- a/llvm/test/tools/llvm-readobj/ELF/file-headers.test
+++ b/llvm/test/tools/llvm-readobj/ELF/file-headers.test
@@ -233,3 +233,20 @@ Sections:
 # RUN:  | FileCheck %s -DFILE=%t.invalid2 -DSECHDRCOUNT="<?>" -DSECHDRSTRTABINDEX="<?>" --check-prefix=INVALID-LLVM
 # RUN: not llvm-readelf --file-headers %t.invalid2 2>&1 \
 # RUN:  | FileCheck %s -DFILE=%t.invalid2 -DSECHDRCOUNT="<?>" -DSECHDRSTRTABINDEX="<?>" --check-prefix=INVALID-GNU
+
+## --elf-output-style=JSON must emit well-formed JSON when e_machine is not
+## in any known enum table (regression: raw "Machine: 0x..." inside JSON).
+# RUN: yaml2obj %s --docnum=5 -o %t.unknown-machine
+# RUN: llvm-readobj --elf-output-style=JSON --pretty-print --file-header \
+# RUN:   %t.unknown-machine | FileCheck %s --check-prefix=JSON-UNKNOWN-MACHINE
+
+# JSON-UNKNOWN-MACHINE:      "Type": "SharedObject (0x3)",
+# JSON-UNKNOWN-MACHINE-NEXT: "Machine": 36902,
+# JSON-UNKNOWN-MACHINE-NEXT: "Version": 1,
+
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_DYN
+  Machine: 0x9026

--- a/llvm/test/tools/llvm-readobj/ELF/file-headers.test
+++ b/llvm/test/tools/llvm-readobj/ELF/file-headers.test
@@ -238,7 +238,9 @@ Sections:
 ## in any known enum table.
 # RUN: yaml2obj %s --docnum=5 -o %t.unknown-machine
 # RUN: llvm-readobj --elf-output-style=JSON --pretty-print --file-header \
-# RUN:   %t.unknown-machine | FileCheck %s --check-prefix=JSON-UNKNOWN-MACHINE
+# RUN:   %t.unknown-machine > %t.unknown-machine.json
+# RUN: FileCheck %s --check-prefix=JSON-UNKNOWN-MACHINE < %t.unknown-machine.json
+# RUN: %python -c 'import json, sys; json.load(sys.stdin)' < %t.unknown-machine.json
 
 # JSON-UNKNOWN-MACHINE:      "Type": "SharedObject (0x3)",
 # JSON-UNKNOWN-MACHINE-NEXT: "Machine": 36902,

--- a/llvm/test/tools/llvm-readobj/ELF/file-headers.test
+++ b/llvm/test/tools/llvm-readobj/ELF/file-headers.test
@@ -235,7 +235,7 @@ Sections:
 # RUN:  | FileCheck %s -DFILE=%t.invalid2 -DSECHDRCOUNT="<?>" -DSECHDRSTRTABINDEX="<?>" --check-prefix=INVALID-GNU
 
 ## --elf-output-style=JSON must emit well-formed JSON when e_machine is not
-## in any known enum table (regression: raw "Machine: 0x..." inside JSON).
+## in any known enum table.
 # RUN: yaml2obj %s --docnum=5 -o %t.unknown-machine
 # RUN: llvm-readobj --elf-output-style=JSON --pretty-print --file-header \
 # RUN:   %t.unknown-machine | FileCheck %s --check-prefix=JSON-UNKNOWN-MACHINE


### PR DESCRIPTION
Previously, `llvm-readobj` generated invalid JSON with unknown Machine:

```
 yaml2obj llvm/test/tools/llvm-readobj/ELF/file-headers.test --docnum=5 \
   | llvm-readobj --elf-output-style=JSON --pretty-print --file-header - \
   | grep Machine
```

```
      "Type": "SharedObject (0x3)"Machine: 0x9026
```

<details>
<summary>Full output</summary>
<pre><code>
[
  {
    "FileSummary": {
      "File": "<stdin>",
      "Format": "elf64-unknown",
      "Arch": "unknown",
      "AddressSize": "64bit",
      "LoadName": "<Not found>"
    },
    "ElfHeader": {
      "Ident": {
        "Magic": {
          "Offset": 0,
          "Bytes": [
            127,
            69,
            76,
            70
          ]
        },
        "Class": {
          "Name": "64-bit",
          "Value": 2
        },
        "DataEncoding": {
          "Name": "LittleEndian",
          "Value": 1
        },
        "FileVersion": 1,
        "OS/ABI": {
          "Name": "SystemV",
          "Value": 0
        },
        "ABIVersion": 0,
        "Unused": {
          "Offset": 0,
          "Bytes": [
            0,
            0,
            0,
            0,
            0,
            0,
            0
          ]
        }
      },
      "Type": "SharedObject (0x3)"Machine: 0x9026
,
      "Version": 1,
      "Entry": 0,
      "ProgramHeaderOffset": 0,
      "SectionHeaderOffset": 88,
      "Flags": {
        "Value": 0,
        "Flags": []
      },
      "HeaderSize": 64,
      "ProgramHeaderEntrySize": 0,
      "ProgramHeaderCount": 0,
      "SectionHeaderEntrySize": 64,
      "SectionHeaderCount": "3",
      "StringTableSectionIndex": "2"
    }
  }
]
</code></pre>
</details>