### PR TITLE
[lldb][Darwin] Read Mach-O binaries out of memory more efficiently

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -177,7 +177,8 @@ ModuleSP DynamicLoaderDarwin::FindTargetModuleForImageInfo(
   // added to the target, don't let it be called for every one.
   if (!module_sp || module_sp->GetObjectFile() == nullptr) {
     llvm::Expected<ModuleSP> module_sp_or_err = m_process->ReadModuleFromMemory(
-        image_info.file_spec, image_info.address, image_info.mh_and_load_cmd_size);
+        image_info.file_spec, image_info.address,
+        image_info.mh_and_load_cmd_size);
     if (auto err = module_sp_or_err.takeError()) {
       LLDB_LOG_ERROR(GetLog(LLDBLog::DynamicLoader), std::move(err),
                      "Failed to load module from memory: {0}");
@@ -445,9 +446,10 @@ bool DynamicLoaderDarwin::JSONImageInformationIntoImageInfo(
         mh->GetValueForKey("cpusubtype")->GetUnsignedIntegerValue();
     image_infos[i].header.filetype =
         mh->GetValueForKey("filetype")->GetUnsignedIntegerValue();
-    if (mh->HasKey("sizeof_mh_and_loadcmds"))
-      image_infos[i].mh_and_load_cmd_size = 
-          mh->GetValueForKey("sizeof_mh_and_loadcmds")->GetUnsignedIntegerValue();
+    if (mh->HasKey("sizeof_h_and_loadcmds"))
+      image_infos[i].mh_and_load_cmd_size =
+          mh->GetValueForKey("sizeof_mh_and_loadcmds")
+              ->GetUnsignedIntegerValue();
 
     if (image->HasKey("min_version_os_name")) {
       std::string os_name =

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -177,7 +177,7 @@ ModuleSP DynamicLoaderDarwin::FindTargetModuleForImageInfo(
   // added to the target, don't let it be called for every one.
   if (!module_sp || module_sp->GetObjectFile() == nullptr) {
     llvm::Expected<ModuleSP> module_sp_or_err = m_process->ReadModuleFromMemory(
-        image_info.file_spec, image_info.address);
+        image_info.file_spec, image_info.address, image_info.mh_and_load_cmd_size);
     if (auto err = module_sp_or_err.takeError()) {
       LLDB_LOG_ERROR(GetLog(LLDBLog::DynamicLoader), std::move(err),
                      "Failed to load module from memory: {0}");
@@ -445,6 +445,9 @@ bool DynamicLoaderDarwin::JSONImageInformationIntoImageInfo(
         mh->GetValueForKey("cpusubtype")->GetUnsignedIntegerValue();
     image_infos[i].header.filetype =
         mh->GetValueForKey("filetype")->GetUnsignedIntegerValue();
+    if (mh->HasKey("sizeof_mh_and_loadcmds"))
+      image_infos[i].mh_and_load_cmd_size = 
+          mh->GetValueForKey("sizeof_mh_and_loadcmds")->GetUnsignedIntegerValue();
 
     if (image->HasKey("min_version_os_name")) {
       std::string os_name =

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.h
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.h
@@ -121,6 +121,12 @@ protected:
         llvm::Triple::EnvironmentType::UnknownEnvironment;
     /// LC_VERSION_MIN_... SDK.
     std::string min_version_os_sdk;
+    /// When we need to read a binary's mach header and load commands
+    /// out of memory, this specifies how much to read to get
+    /// everything in one read packet, if known.  Increase the
+    /// default 512 bytes to 3192 which is enough to include most
+    /// mach header + load commands.
+    uint32_t mh_and_load_cmd_size = 3192;
 
     ImageInfo() = default;
 
@@ -137,6 +143,7 @@ protected:
       os_type = llvm::Triple::OSType::UnknownOS;
       os_env = llvm::Triple::EnvironmentType::UnknownEnvironment;
       min_version_os_sdk.clear();
+      mh_and_load_cmd_size = 3192;
     }
 
     bool operator==(const ImageInfo &rhs) const {
@@ -144,7 +151,8 @@ protected:
              file_spec == rhs.file_spec && uuid == rhs.uuid &&
              memcmp(&header, &rhs.header, sizeof(header)) == 0 &&
              segments == rhs.segments && os_type == rhs.os_type &&
-             os_env == rhs.os_env;
+             os_env == rhs.os_env &&
+             mh_and_load_cmd_size == rhs.mh_and_load_cmd_size;
     }
 
     bool UUIDValid() const { return uuid.IsValid(); }


### PR DESCRIPTION
When lldb needs to read a Mach-O binary out of memory, it first reads 512 bytes to get the mach header, which includes the size of the load commands, and then does a second read to get the mach header and load commands.

I am changing the initial read to get 3192 bytes, which will include the full load commands for most binaries.

In April I changed debugserver to return the correct size of the mach header and load commands in a `sizeof_mh_and_loadcmds` key.  If this number is provided, refine the amount we read to this size.

This reduces the number of memory read packets we issue from 2 to 1 for a memory module, outside of packets that may be needed to get the symbol table.