### PR TITLE
[lldb][docs] Some fixes for lldbgdbremote.md.

### DIFF
--- a/lldb/docs/resources/lldbgdbremote.md
+++ b/lldb/docs/resources/lldbgdbremote.md
@@ -1405,7 +1405,7 @@ Key value pairs are one of:
 * `arch`: a string for the architecture, not needed if "triple" is specified
 * `cputype`: is a number that is the mach-o CPU type that is being debugged (base 10)
 * `cpusubtype`: is a number that is the mach-o CPU subtype type that is being debugged (base 10)
-* `triple`: a hex encoded string for the target triple (for example, hex encoding of `x86_64-apple-macosx`) that can be used to specify arch + vendor + os in one entry
+* `triple`: an ASCII hex encoded string for the target triple (for example, hex encoding of `x86_64-apple-macosx`) that can be used to specify arch + vendor + os in one entry
 * `vendor`: a string for the vendor (apple), not needed if "triple" is specified
 * `ostype`: a string for the OS being debugged (macosx, linux, freebsd, ios, watchos), not needed if "triple" is specified
 * `endian`: is one of "little", "big", or "pdp"

--- a/lldb/docs/resources/lldbgdbremote.md
+++ b/lldb/docs/resources/lldbgdbremote.md
@@ -1709,7 +1709,7 @@ The key value pairs in the response are:
 * `euid` - `integer` - A string value containing the decimal effective user ID
 * `egid` - `integer` - A string value containing the decimal effective group ID
 * `name` - `ascii-hex` - An ASCII hex string that contains the name of the process
-* `triple` - `string` - A hex encoded target triple (for example, hex encodings of `x86_64-apple-macosx`, `armv7-apple-ios`)
+* `triple` - `ascii-hex` - An ASCII hex string that contains the target triple (for example, `x86_64-apple-macosx`, `armv7-apple-ios`)
 
 Sample packet/response:
 ```

--- a/lldb/docs/resources/lldbgdbremote.md
+++ b/lldb/docs/resources/lldbgdbremote.md
@@ -1330,7 +1330,13 @@ send packet: $qsProcessInfo#00
 read packet: $pid:59992;ppid:192;uid:7746;gid:11;euid:7746;egid:11;name:6d64776f726b6572;triple:x86_64-apple-macosx;#00
 send packet: $qsProcessInfo#00
 read packet: $E04#00
+send packet: $qfProcessInfo:name_match:contains;name:616263;all_users:0;triple:arm64-unknown-linux-gnu;#da
+read packet: $E03#a8
 ```
+
+Note that triples in this packet are normal strings, but triples
+received in response are hex encoded strings.  This difference was
+unintentional but cannot be changed at this point.
 
 **Priority To Implement:** Required
 

--- a/lldb/docs/resources/lldbgdbremote.md
+++ b/lldb/docs/resources/lldbgdbremote.md
@@ -1324,10 +1324,10 @@ documentation.
 
 Sample packet/response:
 ```
-send packet: $qfProcessInfo#00
-read packet: $pid:60001;ppid:59948;uid:7746;gid:11;euid:7746;egid:11;name:6c6c6462;triple:x86_64-apple-macosx;#00
-send packet: $qsProcessInfo#00
-read packet: $pid:59992;ppid:192;uid:7746;gid:11;euid:7746;egid:11;name:6d64776f726b6572;triple:x86_64-apple-macosx;#00
+send packet: $qfProcessInfo:name_match:contains;name:656d616373;all_users:0;#21
+read packet: $pid:4086;ppid:2681;uid:1000;gid:1000;euid:1000;egid:1000;name:2f7573722f62696e2f656d6163732d67746b;args:656d616373-2d2d6461656d6f6e;triple:7838365f36342d2d6c696e75782d676e75;#07
+send packet: $qsProcessInfo#4f
+read packet: $pid:146456;ppid:1;uid:1000;gid:1000;euid:1000;egid:1000;name:2f7573722f62696e2f656d6163732d67746b;args:2f7573722f62696e2f656d616373;triple:7838365f36342d2d6c696e75782d676e75;#e2
 send packet: $qsProcessInfo#00
 read packet: $E04#00
 send packet: $qfProcessInfo:name_match:contains;name:616263;all_users:0;triple:arm64-unknown-linux-gnu;#da

--- a/lldb/docs/resources/lldbgdbremote.md
+++ b/lldb/docs/resources/lldbgdbremote.md
@@ -1259,7 +1259,7 @@ already has a thread selected (see the `Hg` packet from the standard
 GDB remote protocol documentation) yet the remote GDB server actually
 has another thread selected.
 
-## qAttachOrWaitSupported
+## qVAttachOrWaitSupported
 
 This is a binary "is it supported" query. Return OK if you support
 `vAttachOrWait`.
@@ -1312,7 +1312,7 @@ some key value pairs. The key value pairs in the command are:
   be listed for all users, not just the user that the
   platform is running as
 * `triple` - `string` -
-  An ASCII triple string (`x86_64`, `x86_64-apple-macosx`, `armv7-apple-ios`)
+  An hex encoded triple string (hex encodings of `x86_64`, `x86_64-apple-macosx`, `armv7-apple-ios`)
 * `args` - `string` -
   A string value containing the process arguments separated by the character `-`,
   where each argument is hex-encoded. It includes `argv[0]`.
@@ -1396,9 +1396,10 @@ read packet: $cputype:16777223;cpusubtype:3;ostype:darwin;vendor:apple;endian:li
 ```
 
 Key value pairs are one of:
+* `arch`: a string for the architecture, not needed if "triple" is specified
 * `cputype`: is a number that is the mach-o CPU type that is being debugged (base 10)
 * `cpusubtype`: is a number that is the mach-o CPU subtype type that is being debugged (base 10)
-* `triple`: a string for the target triple (x86_64-apple-macosx) that can be used to specify arch + vendor + os in one entry
+* `triple`: a hex encoded string for the target triple (x86_64-apple-macosx) that can be used to specify arch + vendor + os in one entry
 * `vendor`: a string for the vendor (apple), not needed if "triple" is specified
 * `ostype`: a string for the OS being debugged (macosx, linux, freebsd, ios, watchos), not needed if "triple" is specified
 * `endian`: is one of "little", "big", or "pdp"
@@ -1702,7 +1703,7 @@ The key value pairs in the response are:
 * `euid` - `integer` - A string value containing the decimal effective user ID
 * `egid` - `integer` - A string value containing the decimal effective group ID
 * `name` - `ascii-hex` - An ASCII hex string that contains the name of the process
-* `triple` - `string` - A target triple (`x86_64-apple-macosx`, `armv7-apple-ios`)
+* `triple` - `string` - A hex encoded target triple (hex encodings of `x86_64-apple-macosx`, `armv7-apple-ios`)
 
 Sample packet/response:
 ```

--- a/lldb/docs/resources/lldbgdbremote.md
+++ b/lldb/docs/resources/lldbgdbremote.md
@@ -1312,7 +1312,7 @@ some key value pairs. The key value pairs in the command are:
   be listed for all users, not just the user that the
   platform is running as
 * `triple` - `string` -
-  An hex encoded triple string (hex encodings of `x86_64`, `x86_64-apple-macosx`, `armv7-apple-ios`)
+  An ASCII triple string (for example `x86_64`, `x86_64-apple-macosx`, `armv7-apple-ios`)
 * `args` - `string` -
   A string value containing the process arguments separated by the character `-`,
   where each argument is hex-encoded. It includes `argv[0]`.
@@ -1399,7 +1399,7 @@ Key value pairs are one of:
 * `arch`: a string for the architecture, not needed if "triple" is specified
 * `cputype`: is a number that is the mach-o CPU type that is being debugged (base 10)
 * `cpusubtype`: is a number that is the mach-o CPU subtype type that is being debugged (base 10)
-* `triple`: a hex encoded string for the target triple (x86_64-apple-macosx) that can be used to specify arch + vendor + os in one entry
+* `triple`: a hex encoded string for the target triple (for example, hex encoding of `x86_64-apple-macosx`) that can be used to specify arch + vendor + os in one entry
 * `vendor`: a string for the vendor (apple), not needed if "triple" is specified
 * `ostype`: a string for the OS being debugged (macosx, linux, freebsd, ios, watchos), not needed if "triple" is specified
 * `endian`: is one of "little", "big", or "pdp"
@@ -1703,7 +1703,7 @@ The key value pairs in the response are:
 * `euid` - `integer` - A string value containing the decimal effective user ID
 * `egid` - `integer` - A string value containing the decimal effective group ID
 * `name` - `ascii-hex` - An ASCII hex string that contains the name of the process
-* `triple` - `string` - A hex encoded target triple (hex encodings of `x86_64-apple-macosx`, `armv7-apple-ios`)
+* `triple` - `string` - A hex encoded target triple (for example, hex encodings of `x86_64-apple-macosx`, `armv7-apple-ios`)
 
 Sample packet/response:
 ```


### PR DESCRIPTION
This has the following fixes:

- fix a typo: `qAttachOrWaitSupported` -> `qVAttachOrWaitSupported`

- document that a response to `qHostInfo` can contain an `arch` key-value pair

- clarify that the value of the `triple` key in some cases is a hex encoded string.