### PR TITLE
test(llvm-symbolizer): fix Wasm layering violation by using YAML

### DIFF
--- a/llvm/test/tools/llvm-symbolizer/Inputs/wasm-basic.yaml
+++ b/llvm/test/tools/llvm-symbolizer/Inputs/wasm-basic.yaml
@@ -1,0 +1,61 @@
+--- !WASM
+FileHeader:
+  Version:         0x1
+Sections:
+  - Type:            TYPE
+    Signatures:
+      - Index:           0
+        ParamTypes:      []
+        ReturnTypes:     []
+      - Index:           1
+        ParamTypes:
+          - I32
+        ReturnTypes:
+          - I32
+  - Type:            FUNCTION
+    FunctionTypes:   [ 0, 1 ]
+  - Type:            MEMORY
+    Memories:
+      - Minimum:         0x1
+  - Type:            EXPORT
+    Exports:
+      - Name:            memory
+        Kind:            MEMORY
+        Index:           0
+      - Name:            foo
+        Kind:            FUNCTION
+        Index:           0
+      - Name:            bar
+        Kind:            FUNCTION
+        Index:           1
+  - Type:            CODE
+    Functions:
+      - Index:           0
+        Locals:          []
+        Body:            010F0B
+      - Index:           1
+        Locals:          []
+        Body:            2000010F0B
+  - Type:            CUSTOM
+    Name:            .debug_info
+    Payload:         C9000000040000000000040100000000000000006C6C766D2D70726F6A6563742F6C6C766D2F746573742F746F6F6C732F6C6C766D2D73796D626F6C697A65722F7761736D2D62617369632E73002F7573722F6C6F63616C2F676F6F676C652F62747266735F6D6F756E742F7761736D2D62617369632F656D722D7761736D2D6261736963006C6C766D2D6D6320286261736564206F6E204C4C564D2032332E302E306769742900018002666F6F00010000000B00000002000000026261720001000000120000000700000000
+  - Type:            CUSTOM
+    Name:            .debug_abbrev
+    Payload:         0111011017551703081B08250813050000020A0003083A063B061101000000
+  - Type:            CUSTOM
+    Name:            .debug_aranges
+    Payload:         '24000000020000000000040000000000020000000400000007000000060000000000000000000000'
+  - Type:            CUSTOM
+    Name:            .debug_ranges
+    Payload:         FFFFFFFF020000000000000004000000FFFFFFFF0700000000000000060000000000000000000000
+  - Type:            CUSTOM
+    Name:            .debug_line
+    Payload:         7A000000040051000000010101FB0E0D0001010101000000010000016C6C766D2D70726F6A6563742F6C6C766D2F746573742F746F6F6C732F6C6C766D2D73796D626F6C697A657200007761736D2D62617369632E73000100000000050202000000030C012F210201000101000502070000000313013D21210201000101
+  - Type:            CUSTOM
+    Name:            name
+    FunctionNames:
+      - Index:           0
+        Name:            foo
+      - Index:           1
+        Name:            bar
+...

--- a/llvm/test/tools/llvm-symbolizer/lit.local.cfg
+++ b/llvm/test/tools/llvm-symbolizer/lit.local.cfg
@@ -1,4 +1,0 @@
-from lit.llvm import llvm_config
-
-if llvm_config.use_lld(required=False):
-    config.available_features.add("lld")

--- a/llvm/test/tools/llvm-symbolizer/wasm-basic.s
+++ b/llvm/test/tools/llvm-symbolizer/wasm-basic.s
@@ -1,11 +1,11 @@
-# REQUIRES: webassembly-registered-target, lld
+# REQUIRES: webassembly-registered-target
 # RUN: llvm-mc -triple=wasm32-unknown-unknown -filetype=obj %s -o %t.o -g
 # RUN: llvm-symbolizer --basenames --output-style=GNU -e %t.o 0 1 2 3 4 5 6 7 8 9 10 11 12 13 16 | FileCheck %s
-
-# This is the same test but on a linked wasm file, using file offsets rather than section offsets.
-# The code section starts at 0x37, so these are equivalent to above (except 3, see below for why).
-# RUN: wasm-ld %t.o -o %t.wasm --no-entry --export=foo --export=bar
-# RUN: llvm-symbolizer --basenames --output-style=GNU -e %t.wasm 3 0x38 0x39 0x3a 0x3b 0x3c 0x3d 0x3e 0x3f 0x40 0x41 0x42 0x43 0x44 0x47 | FileCheck %s
+# This is the same test but on a linked wasm file, using file offsets.
+# wasm-basic.yaml was created by linking this object and converting to YAML.
+# CODE section starts at 0x4b in the yaml2obj-generated file.
+# RUN: yaml2obj %S/Inputs/wasm-basic.yaml -o %t.wasm
+# RUN: llvm-symbolizer --basenames --output-style=GNU -e %t.wasm 3 0x4c 0x4d 0x4e 0x4f 0x50 0x51 0x52 0x53 0x54 0x55 0x56 0x57 0x58 0x5b | FileCheck %s
 
 .globl foo
 foo:


### PR DESCRIPTION
Avoid using wasm-ld in LLVM tests by prebuilding the test binary
as a YAML file and using yaml2obj at test time.

This matches the approach taken in 4bce216e6b550c770f2e536422c3d95333f65ba3.
Because yaml2obj always uses 5-byte LEBs, the CODE section offset
shifted from 0x37 to 0x4b, so the file offsets passed to llvm-symbolizer
were updated accordingly.

Replaces #200046

Assisted-by: Gemini
