### PR TITLE
[lld][WebAssembly] Force-extract archive members that contain user custom sections

### DIFF
--- a/lld/test/wasm/no-strip-segment-archive.s
+++ b/lld/test/wasm/no-strip-segment-archive.s
@@ -1,0 +1,29 @@
+# RUN: split-file %s %t
+# RUN: llvm-mc -filetype=obj --triple=wasm32-unknown-unknown -o %t/main.o %t/main.s
+# RUN: llvm-mc -filetype=obj --triple=wasm32-unknown-unknown -o %t/lib.o %t/lib.s
+# RUN: rm -f %t/lib.a
+# RUN: llvm-ar rcs %t/lib.a %t/lib.o
+# RUN: wasm-ld %t/main.o %t/lib.a --no-entry --allow-undefined -o %t/main.wasm
+# RUN: obj2yaml %t/main.wasm | FileCheck %s
+
+# A user-defined wasm custom section inside an archive member should survive
+# linking even when no symbol in that member is referenced. Custom sections
+# (wasm-bindgen / wit-bindgen / coverage metadata, etc.) have no symbol table
+# entries by construction, so symbol-driven archive extraction cannot reach
+# them. Without explicit handling the archive member is never extracted and
+# the custom section is silently dropped.
+
+#--- main.s
+  .globl _start
+_start:
+  .functype _start () -> ()
+  end_function
+
+#--- lib.s
+  .section .custom_section.my_meta,"",@
+  .asciz "CUSTOM_PAYLOAD"
+
+# The custom section should be present in the linked binary.
+# CHECK:        - Type:            CUSTOM
+# CHECK:          Name:            my_meta
+# CHECK:          Payload:         435553544F4D5F5041594C4F414400

--- a/lld/wasm/InputFiles.cpp
+++ b/lld/wasm/InputFiles.cpp
@@ -395,9 +395,41 @@ static bool shouldMerge(const WasmSegment &seg) {
   return true;
 }
 
+// True if `name` is a custom section the linker synthesizes or otherwise owns,
+// rather than user payload that should be propagated to the output.
+// Mirrors the filter in Writer::createCustomSections.
+static bool isLinkerOwnedCustomSection(StringRef name) {
+  return name == "linking" || name == "name" || name == "producers" ||
+         name == "target_features" || name.starts_with("reloc.") ||
+         name == ".llvmbc" || name == ".llvmcmd" ||
+         name.starts_with(".debug_") || name.starts_with("dylink");
+}
+
 void ObjFile::parseLazy() {
   LLVM_DEBUG(dbgs() << "ObjFile::parseLazy: " << toString(this) << " "
                     << wasmObj.get() << "\n");
+
+  // If this object contains any user-defined wasm custom sections (e.g.
+  // wasm-bindgen / wit-bindgen / coverage / sanitizer metadata, or
+  // __llvm_prf_*), force-extract it. Custom sections have no symbol table
+  // entries by construction, so symbol-driven archive extraction cannot reach
+  // them, and the section is silently dropped along with its archive member.
+  // The only place this content can be anchored is the archive member itself,
+  // so we extract eagerly here.
+  for (const SectionRef &secRef : wasmObj->sections()) {
+    const WasmSection &sec = wasmObj->getWasmSection(secRef);
+    if (sec.Type != WASM_SEC_CUSTOM)
+      continue;
+    if (isLinkerOwnedCustomSection(sec.Name))
+      continue;
+    LLVM_DEBUG(dbgs() << "  forcing extract for custom section: " << sec.Name
+                      << "\n");
+    lazy = false;
+    markLive();
+    symtab->addFile(this, /*symName=*/{});
+    return;
+  }
+
   for (const SymbolRef &sym : wasmObj->symbols()) {
     const WasmSymbol &wasmSym = wasmObj->getWasmSymbol(sym.getRawDataRefImpl());
     if (wasmSym.isUndefined() || wasmSym.isBindingLocal())


### PR DESCRIPTION
Fixes #200083.

**Reframed from initial draft.** The earlier framing — "ELF parity for `SHF_GNU_RETAIN`" — was incorrect: testing showed lld-ELF also drops `SHF_GNU_RETAIN` sections from lazy archive members (only `--whole-archive` extracts them). Furthermore, the original `dataSegments()`+`WASM_SEG_FLAG_RETAIN` scan did not actually fix the wasm-bindgen / wit-bindgen failure mode that motivated the PR: those carriers are wasm *custom sections* (top-level `WASM_SEC_CUSTOM`), not data segments, and they have no `R` flag because they have no symbol-table entry at all.

This rewrite targets the actual structural problem.

wasm-ld silently drops user-defined wasm custom sections (wasm-bindgen descriptors, wit-bindgen component metadata, coverage / sanitizer sections, `__llvm_prf_*`, etc.) from archive members that have no externally-referenced symbol. Custom sections have no symbol-table entries by construction, so symbol-driven archive extraction cannot reach them: the archive member stays lazy and the section is silently dropped along with it.

The fix teaches `ObjFile::parseLazy` to scan top-level sections for `WASM_SEC_CUSTOM` entries, ignoring custom sections that the linker synthesizes or owns:

```cpp
static bool isLinkerOwnedCustomSection(StringRef name) {
  return name == "linking" || name == "name" || name == "producers" ||
         name == "target_features" || name.starts_with("reloc.") ||
         name == ".llvmbc" || name == ".llvmcmd" ||
         name.starts_with(".debug_") || name.starts_with("dylink");
}
```

If a user custom section is present in a lazy member, the member is eagerly extracted (`lazy = false; markLive(); addFile(this)`).

This generalizes the case-specific approach in #172023 (which added `WASM_SEG_FLAG_PRF` specifically for `__llvm_prf_*` sections), addressing @sbc100's comment on that PR asking for a less special-cased solution. The PRF special case could later be retired in favor of this general mechanism.

Not gated on `--gc-sections`: the bug is in archive lazy-extraction, not GC. Without `--gc-sections` the section is still dropped because the archive member is never extracted in the first place.

**Tests**

`lld/test/wasm/no-strip-segment-archive.s` is a minimal lit test: an archive member contains only a user custom section (`.custom_section.my_meta`) with no symbols; the section must survive linking. Fails on `main`, passes with this fix. All 231 buildable wasm-ld tests pass.

**End-to-end verification**

The original wasm-bindgen `raytrace-parallel` failure (`error: import of __wbg_get_* doesn't have an adapter listed`) is the real-world motivation. Red/green tested with locally-built wasm-ld against rust nightly-2026-05-27:

| Linker | Result |
|---|---|
| stock rust-lld (RED) | `error: import of __wbg_get_1f8f054ddbaa7db2 doesn't have an adapter listed` |
| this PR (GREEN) | builds successfully, package produced |

Same nightly, same `codegen-units=16`, same `cargo clean`; only the linker differs.

Note: this PR was authored by an LLM (Claude/OpenCode) under my direction, with my review of the diagnosis, implementation, and tests before submission.
