### PR TITLE
[libc] introduce shared compiler-rt builtins

### DIFF
--- a/libc/include/llvm-libc-macros/float-macros.h
+++ b/libc/include/llvm-libc-macros/float-macros.h
@@ -9,6 +9,12 @@
 #ifndef LLVM_LIBC_MACROS_FLOAT_MACROS_H
 #define LLVM_LIBC_MACROS_FLOAT_MACROS_H
 
+// __has_builtin is a Clang extension; GCC < 10 doesn't define it, which
+// turns a bare `#if __has_builtin(...)` into a preprocessor syntax error.
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#endif
+
 #ifndef FLT_RADIX
 #define FLT_RADIX __FLT_RADIX__
 #endif // FLT_RADIX

--- a/libc/shared/builtins.h
+++ b/libc/shared/builtins.h
@@ -1,0 +1,16 @@
+//===-- Compiler-runtime builtin primitives ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SHARED_BUILTINS_H
+#define LLVM_LIBC_SHARED_BUILTINS_H
+
+#include "libc_common.h"
+
+#include "builtins/addtf3.h"
+
+#endif // LLVM_LIBC_SHARED_BUILTINS_H

--- a/libc/shared/builtins.h
+++ b/libc/shared/builtins.h
@@ -1,9 +1,15 @@
-//===-- Compiler-runtime builtin primitives ---------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This header aggregates LLVM-libc's shared compiler-rt builtins so that
+/// they can be reused by compiler-rt's builtins.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SHARED_BUILTINS_H

--- a/libc/shared/builtins/addtf3.h
+++ b/libc/shared/builtins/addtf3.h
@@ -1,0 +1,35 @@
+//===-- Shared __addtf3 function -------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header exposes LLVM-libc's __addtf3 implementation as shared::addtf3
+// so that it can be reused by other LLVM projects, such as compiler-rt's
+// builtins library.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SHARED_BUILTINS_ADDTF3_H
+#define LLVM_LIBC_SHARED_BUILTINS_ADDTF3_H
+
+#include "include/llvm-libc-types/float128.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT128
+
+#include "shared/libc_common.h"
+#include "src/__support/builtins/addtf3.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace shared {
+
+using builtins::addtf3;
+
+} // namespace shared
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT128
+
+#endif // LLVM_LIBC_SHARED_BUILTINS_ADDTF3_H

--- a/libc/shared/builtins/addtf3.h
+++ b/libc/shared/builtins/addtf3.h
@@ -1,15 +1,15 @@
-//===-- Shared __addtf3 function -------------------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
-// This header exposes LLVM-libc's __addtf3 implementation as shared::addtf3
-// so that it can be reused by other LLVM projects, such as compiler-rt's
-// builtins library.
-//
+///
+/// \file
+/// This header exposes LLVM-libc's __addtf3 implementation as shared::addtf3
+/// so that it can be reused by compiler-rt's builtins.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SHARED_BUILTINS_ADDTF3_H

--- a/libc/src/__support/CMakeLists.txt
+++ b/libc/src/__support/CMakeLists.txt
@@ -472,6 +472,7 @@ add_subdirectory(wchar)
 add_subdirectory(wctype)
 
 add_subdirectory(math)
+add_subdirectory(builtins)
 if(LIBC_COMPILER_HAS_EXT_VECTOR_TYPE)
   add_subdirectory(mathvec)
 endif()

--- a/libc/src/__support/FPUtil/dyadic_float.h
+++ b/libc/src/__support/FPUtil/dyadic_float.h
@@ -416,6 +416,9 @@ template <size_t Bits> struct DyadicFloat {
 #if defined(LIBC_TYPES_HAS_FLOAT16) && !defined(__LIBC_USE_FLOAT16_CONVERSION)
                   || cpp::is_same_v<T, float16>
 #endif
+#if defined(LIBC_TYPES_HAS_FLOAT128)
+                  || cpp::is_same_v<T, float128>
+#endif
     )
       return generic_as<T, ShouldSignalExceptions>();
     else

--- a/libc/src/__support/builtins/CMakeLists.txt
+++ b/libc/src/__support/builtins/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_header_library(
+  addtf3
+  HDRS
+    addtf3.h
+  DEPENDS
+    libc.include.llvm-libc-types.float128
+    libc.src.__support.FPUtil.generic.add_sub
+    libc.src.__support.macros.config
+)

--- a/libc/src/__support/builtins/addtf3.h
+++ b/libc/src/__support/builtins/addtf3.h
@@ -1,0 +1,32 @@
+//===-- Implementation header for __addtf3 ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_BUILTINS_ADDTF3_H
+#define LLVM_LIBC_SRC___SUPPORT_BUILTINS_ADDTF3_H
+
+#include "include/llvm-libc-types/float128.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT128
+
+#include "src/__support/FPUtil/generic/add_sub.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace builtins {
+
+// Mirrors the compiler-rt __addtf3 ABI: a + b at float128 precision.
+LIBC_INLINE float128 addtf3(float128 x, float128 y) {
+  return fputil::generic::add<float128>(x, y);
+}
+
+} // namespace builtins
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT128
+
+#endif // LLVM_LIBC_SRC___SUPPORT_BUILTINS_ADDTF3_H

--- a/libc/src/__support/builtins/addtf3.h
+++ b/libc/src/__support/builtins/addtf3.h
@@ -1,9 +1,15 @@
-//===-- Implementation header for __addtf3 ----------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This header exposes LLVM-libc's __addtf3 implementation as
+/// builtins::addtf3 so that it can be reused by compiler-rt's builtins.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SRC___SUPPORT_BUILTINS_ADDTF3_H

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -815,6 +815,16 @@ add_fp_unittest(
 endif() # LIBC_TEST_SKIP_SHARED_MATH_TESTS
 
 add_fp_unittest(
+  shared_builtins_test
+  SUITE
+    libc-shared-tests
+  SRCS
+    shared_builtins_test.cpp
+  DEPENDS
+    libc.src.__support.builtins.addtf3
+)
+
+add_fp_unittest(
   shared_str_to_num_test
   SUITE
     libc-shared-tests

--- a/libc/test/shared/shared_builtins_test.cpp
+++ b/libc/test/shared/shared_builtins_test.cpp
@@ -1,0 +1,29 @@
+//===-- Unittests for shared builtins -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "shared/builtins.h"
+#include "test/UnitTest/FPMatcher.h"
+#include "test/UnitTest/Test.h"
+
+TEST(LlvmLibcSharedBuiltinsTest, AllFloat) {
+  // TODO: assertions for shared::*sf3 builtins.
+}
+
+TEST(LlvmLibcSharedBuiltinsTest, AllDouble) {
+  // TODO: assertions for shared::*df3 builtins.
+}
+
+#ifdef LIBC_TYPES_HAS_FLOAT128
+
+TEST(LlvmLibcSharedBuiltinsTest, AllFloat128) {
+  namespace shared = LIBC_NAMESPACE::shared;
+
+  EXPECT_FP_EQ(float128(3.0), shared::addtf3(float128(1.0), float128(2.0)));
+}
+
+#endif // LIBC_TYPES_HAS_FLOAT128


### PR DESCRIPTION
Introduce shared compiler-rt builtins to libc and addtf3 builtin

Split from #197950

Part of #197824