### PR TITLE
[clangd] Optionally Suppress Types in Completions

### DIFF
--- a/clang-tools-extra/clangd/CodeComplete.cpp
+++ b/clang-tools-extra/clangd/CodeComplete.cpp
@@ -482,7 +482,8 @@ struct CodeCompletionBuilder {
           C.SemaResult->CursorKind,
           /*IncludeFunctionArguments=*/C.SemaResult->FunctionCanBeCall ||
               C.SemaResult->DeclaringEntity,
-          /*RequiredQualifiers=*/&Completion.RequiredQualifier);
+          /*RequiredQualifiers=*/&Completion.RequiredQualifier,
+          ArgumentLists == Config::ArgumentListsPolicy::NamePlaceholders);
       S.ReturnType = getReturnType(*SemaCCS);
       if (C.SemaResult->Kind == CodeCompletionResult::RK_Declaration)
         if (const auto *D = C.SemaResult->getDeclaration())
@@ -1237,8 +1238,11 @@ private:
       case CodeCompletionString::CK_VerticalSpace:
         break;
       case CodeCompletionString::CK_CurrentParameter:
-      case CodeCompletionString::CK_Placeholder:
         processParameterChunk(Chunk.Text, Signature);
+        Signal.NumberOfOptionalParameters++;
+        break;
+      case CodeCompletionString::CK_Placeholder:
+        processParameterChunk(Chunk.Placeholder.Full, Signature);
         Signal.NumberOfOptionalParameters++;
         break;
       default:
@@ -1271,8 +1275,11 @@ private:
         ReturnType = Chunk.Text;
         break;
       case CodeCompletionString::CK_CurrentParameter:
-      case CodeCompletionString::CK_Placeholder:
         processParameterChunk(Chunk.Text, Signature);
+        Signal.NumberOfParameters++;
+        break;
+      case CodeCompletionString::CK_Placeholder:
+        processParameterChunk(Chunk.Placeholder.Full, Signature);
         Signal.NumberOfParameters++;
         break;
       case CodeCompletionString::CK_Optional: {

--- a/clang-tools-extra/clangd/CodeCompletionStrings.cpp
+++ b/clang-tools-extra/clangd/CodeCompletionStrings.cpp
@@ -164,7 +164,7 @@ void getSignature(const CodeCompletionString &CCS, std::string *Signature,
                   std::string *Snippet,
                   CodeCompletionResult::ResultKind ResultKind,
                   CXCursorKind CursorKind, bool IncludeFunctionArguments,
-                  std::string *RequiredQualifiers) {
+                  std::string *RequiredQualifiers, bool TersePlaceholder) {
   // Placeholder with this index will be $0 to mark final cursor position.
   // Usually we do not add $0, so the cursor is placed at end of completed text.
   unsigned CursorSnippetArg = std::numeric_limits<unsigned>::max();
@@ -262,7 +262,7 @@ void getSignature(const CodeCompletionString &CCS, std::string *Signature,
       appendOptionalChunk(*Chunk.Optional, Signature);
       break;
     case CodeCompletionString::CK_Placeholder:
-      *Signature += Chunk.Text;
+      *Signature += Chunk.Placeholder.Full;
       ++SnippetArg;
       if (SnippetArg == CursorSnippetArg) {
         // We'd like to make $0 a placeholder too, but vscode does not support
@@ -270,7 +270,13 @@ void getSignature(const CodeCompletionString &CCS, std::string *Signature,
         *Snippet += "$0";
       } else {
         *Snippet += "${" + std::to_string(SnippetArg) + ':';
-        appendEscapeSnippet(Chunk.Text, Snippet);
+        if (TersePlaceholder) {
+          std::string Full(Chunk.Placeholder.Full);
+          appendEscapeSnippet(Full.substr(Chunk.Placeholder.TerseStart,
+                                          Chunk.Placeholder.TerseLen),
+                              Snippet);
+        } else
+          appendEscapeSnippet(Chunk.Placeholder.Full, Snippet);
         *Snippet += '}';
       }
       break;

--- a/clang-tools-extra/clangd/CodeCompletionStrings.h
+++ b/clang-tools-extra/clangd/CodeCompletionStrings.h
@@ -49,11 +49,15 @@ std::string getDeclComment(const ASTContext &Ctx, const NamedDecl &D);
 /// indicating the cursor should stay there.
 /// Note that for certain \p CursorKind like \p CXCursor_Constructor, $0 won't
 /// be emitted in order to avoid overlapping normal parameters.
+///
+/// If \p TersePlaceholder is enabled, then placeholders will only render the
+/// "terse" version of the Chunk. Typically that is the parameters name.
 void getSignature(const CodeCompletionString &CCS, std::string *Signature,
                   std::string *Snippet,
                   CodeCompletionResult::ResultKind ResultKind,
                   CXCursorKind CursorKind, bool IncludeFunctionArguments = true,
-                  std::string *RequiredQualifiers = nullptr);
+                  std::string *RequiredQualifiers = nullptr,
+                  bool TersePlaceholder = false);
 
 /// Assembles formatted documentation for a completion result. This includes
 /// documentation comments and other relevant information like annotations.

--- a/clang-tools-extra/clangd/Config.h
+++ b/clang-tools-extra/clangd/Config.h
@@ -144,6 +144,8 @@ struct Config {
     OpenDelimiter,
     /// empty pair of delimiters "()" or "<>".
     Delimiters,
+    /// only the name of the variable
+    NamePlaceholders,
     /// full name of both type and variable.
     FullPlaceholders,
   };

--- a/clang-tools-extra/clangd/ConfigCompile.cpp
+++ b/clang-tools-extra/clangd/ConfigCompile.cpp
@@ -690,6 +690,8 @@ struct FragmentCompiler {
                   .map("OpenDelimiter",
                        Config::ArgumentListsPolicy::OpenDelimiter)
                   .map("Delimiters", Config::ArgumentListsPolicy::Delimiters)
+                  .map("NamePlaceholders",
+                       Config::ArgumentListsPolicy::NamePlaceholders)
                   .map("FullPlaceholders",
                        Config::ArgumentListsPolicy::FullPlaceholders)
                   .value())

--- a/clang-tools-extra/clangd/ConfigFragment.h
+++ b/clang-tools-extra/clangd/ConfigFragment.h
@@ -339,6 +339,7 @@ struct Fragment {
     ///   None: Nothing at all
     ///   OpenDelimiter: only opening delimiter "(" or "<"
     ///   Delimiters: empty pair of delimiters "()" or "<>"
+    ///   NamePlaceholders: name of the parameters only
     ///   FullPlaceholders: full name of both type and parameter
     std::optional<Located<std::string>> ArgumentLists;
     /// Add #include directives when accepting code completions. Config

--- a/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
+++ b/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
@@ -2991,6 +2991,39 @@ TEST(CompletionTest, ArgumentListsPolicy) {
     EXPECT_THAT(Results.Completions,
                 UnorderedElementsAre(AllOf(named("xfoo"), snippetSuffix("("))));
   }
+  {
+    Opts.ArgumentLists = Config::ArgumentListsPolicy::Delimiters;
+    auto Results = completions(
+        R"cpp(
+      void xfoo(int x, int y);
+      void f() { xfo^ })cpp",
+        {}, Opts);
+    EXPECT_THAT(
+        Results.Completions,
+        UnorderedElementsAre(AllOf(named("xfoo"), snippetSuffix("($0)"))));
+  }
+  {
+    Opts.ArgumentLists = Config::ArgumentListsPolicy::NamePlaceholders;
+    auto Results = completions(
+        R"cpp(
+      void xfoo(int x, int y);
+      void f() { xfo^ })cpp",
+        {}, Opts);
+    EXPECT_THAT(Results.Completions,
+                UnorderedElementsAre(
+                    AllOf(named("xfoo"), snippetSuffix("(${1:x}, ${2:y})"))));
+  }
+  {
+    Opts.ArgumentLists = Config::ArgumentListsPolicy::FullPlaceholders;
+    auto Results = completions(
+        R"cpp(
+      void xfoo(int x, int y);
+      void f() { xfo^ })cpp",
+        {}, Opts);
+    EXPECT_THAT(Results.Completions,
+                UnorderedElementsAre(AllOf(
+                    named("xfoo"), snippetSuffix("(${1:int x}, ${2:int y})"))));
+  }
 }
 
 TEST(CompletionTest, SuggestOverrides) {

--- a/clang/include/clang/Sema/CodeCompleteConsumer.h
+++ b/clang/include/clang/Sema/CodeCompleteConsumer.h
@@ -467,7 +467,8 @@ public:
     CK_Optional,
 
     /// A string that acts as a placeholder for, e.g., a function
-    /// call argument.
+    /// call argument. Tracks a substring in the string representing
+    /// terser version of the content.
     CK_Placeholder,
 
     /// A piece of text that describes something about the result but
@@ -533,8 +534,8 @@ public:
     ChunkKind Kind = CK_Text;
 
     union {
-      /// The text string associated with a CK_Text, CK_Placeholder,
-      /// CK_Informative, or CK_Comma chunk.
+      /// The text string associated with a CK_Text, CK_Informative,
+      /// or CK_Comma chunk.
       /// The string is owned by the chunk and will be deallocated
       /// (with delete[]) when the chunk is destroyed.
       const char *Text;
@@ -543,6 +544,17 @@ public:
       /// The optional code completion string is owned by the chunk, and will
       /// be deallocated (with delete) when the chunk is destroyed.
       CodeCompletionString *Optional;
+
+      /// The text string associated with a CK_Placeholder.
+      /// TerseStart + TerseLen may be used to calculate a potentially
+      /// shorter substring of the placeholder.
+      /// The string is owned by the chunk and will be deallocated
+      /// (with delete[]) when the chunk is destroyed.
+      struct {
+        const char *Full;
+        size_t TerseStart;
+        size_t TerseLen;
+      } Placeholder;
     };
 
     Chunk() : Text(nullptr) {}
@@ -556,7 +568,8 @@ public:
     static Chunk CreateOptional(CodeCompletionString *Optional);
 
     /// Create a new placeholder chunk.
-    static Chunk CreatePlaceholder(const char *Placeholder);
+    static Chunk CreatePlaceholder(const char *Placeholder, size_t TerseStart,
+                                   size_t TerseLen);
 
     /// Create a new informative chunk.
     static Chunk CreateInformative(const char *Informative);
@@ -733,6 +746,10 @@ public:
 
   /// Add a new placeholder chunk.
   void AddPlaceholderChunk(const char *Placeholder);
+
+  /// Add a new placeholder chunk with a terser substring.
+  void AddPlaceholderChunk(const char *Placeholder, size_t TerseStart,
+                           size_t TerseLen);
 
   /// Add a new informative chunk.
   void AddInformativeChunk(const char *Text);

--- a/clang/lib/Sema/CodeCompleteConsumer.cpp
+++ b/clang/lib/Sema/CodeCompleteConsumer.cpp
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
+#include <cstring>
 #include <string>
 
 using namespace clang;
@@ -181,11 +182,16 @@ CodeCompletionString::Chunk::Chunk(ChunkKind Kind, const char *Text)
   switch (Kind) {
   case CK_TypedText:
   case CK_Text:
-  case CK_Placeholder:
   case CK_Informative:
   case CK_ResultType:
   case CK_CurrentParameter:
     this->Text = Text;
+    break;
+
+  case CK_Placeholder:
+    this->Placeholder.Full = Text;
+    this->Placeholder.TerseStart = 0;
+    this->Placeholder.TerseLen = strlen(Text);
     break;
 
   case CK_Optional:
@@ -262,9 +268,14 @@ CodeCompletionString::Chunk::CreateOptional(CodeCompletionString *Optional) {
   return Result;
 }
 
-CodeCompletionString::Chunk
-CodeCompletionString::Chunk::CreatePlaceholder(const char *Placeholder) {
-  return Chunk(CK_Placeholder, Placeholder);
+CodeCompletionString::Chunk CodeCompletionString::Chunk::CreatePlaceholder(
+    const char *Placeholder, size_t TerseStart, size_t TerseLen) {
+  Chunk Result;
+  Result.Kind = CK_Placeholder;
+  Result.Placeholder.Full = Placeholder;
+  Result.Placeholder.TerseStart = TerseStart;
+  Result.Placeholder.TerseLen = TerseLen;
+  return Result;
 }
 
 CodeCompletionString::Chunk
@@ -323,7 +334,8 @@ std::string CodeCompletionString::getAsString() const {
       OS << "{#" << C.Optional->getAsString() << "#}";
       break;
     case CK_Placeholder:
-      OS << "<#" << C.Text << "#>";
+      OS << "<#" << C.Placeholder.Full << "(" << C.Placeholder.TerseStart
+         << ", " << C.Placeholder.TerseLen << ")#>";
       break;
     case CK_Informative:
     case CK_ResultType:
@@ -454,7 +466,15 @@ void CodeCompletionBuilder::AddOptionalChunk(CodeCompletionString *Optional) {
 }
 
 void CodeCompletionBuilder::AddPlaceholderChunk(const char *Placeholder) {
-  Chunks.push_back(Chunk::CreatePlaceholder(Placeholder));
+  Chunks.push_back(
+      Chunk::CreatePlaceholder(Placeholder, 0, strlen(Placeholder)));
+}
+
+void CodeCompletionBuilder::AddPlaceholderChunk(const char *Placeholder,
+                                                size_t TerseStart,
+                                                size_t TerseLen) {
+  assert(TerseStart + TerseLen <= strlen(Placeholder) && "Terse substring OOB");
+  Chunks.push_back(Chunk::CreatePlaceholder(Placeholder, TerseStart, TerseLen));
 }
 
 void CodeCompletionBuilder::AddInformativeChunk(const char *Text) {

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -3129,41 +3129,53 @@ static std::string formatBlockPlaceholder(
     bool SuppressBlockName = false, bool SuppressBlock = false,
     std::optional<ArrayRef<QualType>> ObjCSubsts = std::nullopt);
 
-static std::string FormatFunctionParameter(
+// First return value in the tuple is the fully qualified parameter while the
+// remaining values are offset and lenth into the std::string respectively.
+// They define a substring of the view representing the parameter name.
+static std::tuple<std::string, size_t, size_t> FormatFunctionParameter(
     const PrintingPolicy &Policy, const DeclaratorDecl *Param,
     bool SuppressName = false, bool SuppressBlock = false,
     std::optional<ArrayRef<QualType>> ObjCSubsts = std::nullopt) {
   // Params are unavailable in FunctionTypeLoc if the FunctionType is invalid.
   // It would be better to pass in the param Type, which is usually available.
   // But this case is rare, so just pretend we fell back to int as elsewhere.
-  if (!Param)
-    return "int";
+  if (!Param) {
+    std::string Result = "int";
+    return std::tuple(Result, 3, 0);
+  }
+
   Decl::ObjCDeclQualifier ObjCQual = Decl::OBJC_TQ_None;
   if (const auto *PVD = dyn_cast<ParmVarDecl>(Param))
     ObjCQual = PVD->getObjCDeclQualifier();
   bool ObjCMethodParam = isa<ObjCMethodDecl>(Param->getDeclContext());
+
+  // Format the param placeholder for a dependent or non-block pointer type
   if (Param->getType()->isDependentType() ||
       !Param->getType()->isBlockPointerType()) {
-    // The argument for a dependent or non-block parameter is a placeholder
-    // containing that parameter's type.
+    std::string Name;
+    if (Param->getIdentifier() && !SuppressName) // TODO: remove SuppressName?
+      Name = std::string(Param->getIdentifier()->deuglifiedName());
+
     std::string Result;
-
-    if (Param->getIdentifier() && !ObjCMethodParam && !SuppressName)
-      Result = std::string(Param->getIdentifier()->deuglifiedName());
-
     QualType Type = Param->getType();
-    if (ObjCSubsts)
-      Type = Type.substObjCTypeArgs(Param->getASTContext(), *ObjCSubsts,
-                                    ObjCSubstitutionContext::Parameter);
+
+    // Special case ObjC
     if (ObjCMethodParam) {
+      if (ObjCSubsts)
+        Type = Type.substObjCTypeArgs(Param->getASTContext(), *ObjCSubsts,
+                                      ObjCSubstitutionContext::Parameter);
+
       Result = "(" + formatObjCParamQualifiers(ObjCQual, Type);
       Result += Type.getAsString(Policy) + ")";
-      if (Param->getIdentifier() && !SuppressName)
-        Result += Param->getIdentifier()->deuglifiedName();
-    } else {
-      Type.getAsStringInternal(Result, Policy);
+      size_t NamePos = Result.length();
+      Result += Name;
+      return std::tuple(Result, NamePos, Name.length());
     }
-    return Result;
+
+    Result = Name;
+    Type.getAsStringInternal(Result, Policy);
+    size_t NamePos = Result.find(Name);
+    return std::tuple(Result, NamePos, Name.length());
   }
 
   // The argument for a block pointer parameter is a block literal with
@@ -3185,12 +3197,14 @@ static std::string FormatFunctionParameter(
   if (!Block) {
     // We were unable to find a FunctionProtoTypeLoc with parameter names
     // for the block; just use the parameter type as a placeholder.
-    std::string Result;
-    if (!ObjCMethodParam && Param->getIdentifier())
-      Result = std::string(Param->getIdentifier()->deuglifiedName());
+    std::string Name;
+    if (Param->getIdentifier())
+      Name = std::string(Param->getIdentifier()->deuglifiedName());
 
+    std::string Result;
     QualType Type = Param->getType().getUnqualifiedType();
 
+    // Special case ObjC
     if (ObjCMethodParam) {
       Result = Type.getAsString(Policy);
       std::string Quals = formatObjCParamQualifiers(ObjCQual, Type);
@@ -3198,20 +3212,23 @@ static std::string FormatFunctionParameter(
         Result = "(" + Quals + " " + Result + ")";
       if (Result.back() != ')')
         Result += " ";
-      if (Param->getIdentifier())
-        Result += Param->getIdentifier()->deuglifiedName();
-    } else {
-      Type.getAsStringInternal(Result, Policy);
+      size_t NamePos = Result.length();
+      Result += Name;
+      return std::tuple(Result, NamePos, Name.length());
     }
 
-    return Result;
+    Result = Name;
+    Type.getAsStringInternal(Result, Policy);
+    size_t NamePos = Result.find(Name);
+    return std::tuple(Result, NamePos, Name.length());
   }
 
   // We have the function prototype behind the block pointer type, as it was
   // written in the source.
-  return formatBlockPlaceholder(Policy, Param, Block, BlockProto,
-                                /*SuppressBlockName=*/false, SuppressBlock,
-                                ObjCSubsts);
+  std::string Result = formatBlockPlaceholder(Policy, Param, Block, BlockProto,
+                                              /*SuppressBlockName=*/false,
+                                              SuppressBlock, ObjCSubsts);
+  return std::tuple(Result, 0, Result.size());
 }
 
 /// Returns a placeholder string that corresponds to an Objective-C block
@@ -3249,9 +3266,10 @@ formatBlockPlaceholder(const PrintingPolicy &Policy, const NamedDecl *BlockDecl,
     for (unsigned I = 0, N = Block.getNumParams(); I != N; ++I) {
       if (I)
         Params += ", ";
-      Params += FormatFunctionParameter(Policy, Block.getParam(I),
-                                        /*SuppressName=*/false,
-                                        /*SuppressBlock=*/true, ObjCSubsts);
+      Params += std::get<0>(FormatFunctionParameter(Policy, Block.getParam(I),
+                                                    /*SuppressName=*/false,
+                                                    /*SuppressBlock=*/true,
+                                                    ObjCSubsts));
 
       if (I == N - 1 && BlockProto.getTypePtr()->isVariadic())
         Params += ", ...";
@@ -3353,7 +3371,9 @@ static void AddFunctionParameterChunks(
     InOptional = false;
 
     // Format the placeholder string.
-    std::string PlaceholderStr = FormatFunctionParameter(Policy, Param);
+    std::tuple<std::string, size_t, size_t> ParamPlaceholder =
+        FormatFunctionParameter(Policy, Param);
+    std::string PlaceholderStr = std::get<0>(ParamPlaceholder);
     std::string DefaultValue;
     if (Param->hasDefaultArg()) {
       if (IsInDeclarationContext)
@@ -3364,6 +3384,7 @@ static void AddFunctionParameterChunks(
                                                 PP.getLangOpts());
     }
 
+    // TODO: This should really be its own placeholder chunk
     if (Function->isVariadic() && P == N - 1)
       PlaceholderStr += ", ...";
 
@@ -3378,7 +3399,8 @@ static void AddFunctionParameterChunks(
             Result.getAllocator().CopyString(DefaultValue));
     } else
       Result.AddPlaceholderChunk(
-          Result.getAllocator().CopyString(PlaceholderStr));
+          Result.getAllocator().CopyString(PlaceholderStr),
+          std::get<1>(ParamPlaceholder), std::get<2>(ParamPlaceholder));
   }
 
   if (const auto *Proto = Function->getType()->getAs<FunctionProtoType>())
@@ -4027,7 +4049,7 @@ CodeCompletionString *CodeCompletionResult::createCodeCompletionStringForDecl(
       if (Idx < StartParameter)
         continue;
 
-      std::string Arg;
+      std::tuple<std::string, size_t, size_t> Arg;
       QualType ParamType = (*P)->getType();
       std::optional<ArrayRef<QualType>> ObjCSubsts;
       if (!CCContext.getBaseType().isNull())
@@ -4040,23 +4062,26 @@ CodeCompletionString *CodeCompletionResult::createCodeCompletionStringForDecl(
         if (ObjCSubsts)
           ParamType = ParamType.substObjCTypeArgs(
               Ctx, *ObjCSubsts, ObjCSubstitutionContext::Parameter);
-        Arg = "(" + formatObjCParamQualifiers((*P)->getObjCDeclQualifier(),
-                                              ParamType);
-        Arg += ParamType.getAsString(Policy) + ")";
+        std::string ArgStr = "(" + formatObjCParamQualifiers(
+                                       (*P)->getObjCDeclQualifier(), ParamType);
+        ArgStr += ParamType.getAsString(Policy) + ")";
         if (const IdentifierInfo *II = (*P)->getIdentifier())
           if (DeclaringEntity || AllParametersAreInformative)
-            Arg += II->getName();
+            ArgStr += II->getName();
+        Arg = {ArgStr, 0, ArgStr.length()};
       }
 
+      std::string ArgStr = std::get<0>(Arg);
       if (Method->isVariadic() && (P + 1) == PEnd)
-        Arg += ", ...";
+        ArgStr += ", ...";
 
       if (DeclaringEntity)
-        Result.AddTextChunk(Result.getAllocator().CopyString(Arg));
+        Result.AddTextChunk(Result.getAllocator().CopyString(ArgStr));
       else if (AllParametersAreInformative)
-        Result.AddInformativeChunk(Result.getAllocator().CopyString(Arg));
+        Result.AddInformativeChunk(Result.getAllocator().CopyString(ArgStr));
       else
-        Result.AddPlaceholderChunk(Result.getAllocator().CopyString(Arg));
+        Result.AddPlaceholderChunk(Result.getAllocator().CopyString(ArgStr),
+                                   std::get<1>(Arg), std::get<2>(Arg));
     }
 
     if (Method->isVariadic()) {
@@ -4141,24 +4166,34 @@ static void AddOverloadAggregateChunks(const RecordDecl *RD,
                                        CodeCompletionBuilder &Result,
                                        unsigned CurrentArg) {
   unsigned ChunkIndex = 0;
-  auto AddChunk = [&](llvm::StringRef Placeholder) {
+  auto AddChunkTerse = [&](llvm::StringRef Placeholder, size_t Start,
+                           size_t Len) {
     if (ChunkIndex > 0)
       Result.AddChunk(CodeCompletionString::CK_Comma);
     const char *Copy = Result.getAllocator().CopyString(Placeholder);
     if (ChunkIndex == CurrentArg)
       Result.AddCurrentParameterChunk(Copy);
     else
-      Result.AddPlaceholderChunk(Copy);
+      Result.AddPlaceholderChunk(Copy, Start, Len);
     ++ChunkIndex;
   };
+
+  auto AddChunk = [&](llvm::StringRef Placeholder) {
+    AddChunkTerse(Placeholder, 0, Placeholder.size());
+  };
+
   // Aggregate initialization has all bases followed by all fields.
   // (Bases are not legal in C++11 but in that case we never get here).
   if (auto *CRD = llvm::dyn_cast<CXXRecordDecl>(RD)) {
     for (const auto &Base : CRD->bases())
       AddChunk(Base.getType().getAsString(Policy));
   }
-  for (const auto &Field : RD->fields())
-    AddChunk(FormatFunctionParameter(Policy, Field));
+
+  for (const auto &Field : RD->fields()) {
+    std::tuple<std::string, size_t, size_t> F =
+        FormatFunctionParameter(Policy, Field);
+    AddChunkTerse(std::get<0>(F), std::get<1>(F), std::get<2>(F));
+  }
 }
 
 /// Add function overload parameter chunks to the given code completion
@@ -4210,23 +4245,29 @@ static void AddOverloadParameterChunks(
 
     // Format the placeholder string.
     std::string Placeholder;
+    size_t PlaceholderTerseStart;
+    size_t PlaceholderTerseLen;
     assert(P < Prototype->getNumParams());
     if (Function || PrototypeLoc) {
       const ParmVarDecl *Param =
           Function ? Function->getParamDecl(P) : PrototypeLoc.getParam(P);
-      Placeholder = FormatFunctionParameter(Policy, Param);
+      std::tie(Placeholder, PlaceholderTerseStart, PlaceholderTerseLen) =
+          FormatFunctionParameter(Policy, Param);
       if (Param->hasDefaultArg())
         Placeholder += GetDefaultValueString(Param, Context.getSourceManager(),
                                              Context.getLangOpts());
     } else {
       Placeholder = Prototype->getParamType(P).getAsString(Policy);
+      PlaceholderTerseStart = Placeholder.size();
+      PlaceholderTerseLen = 0;
     }
 
     if (P == CurrentArg)
       Result.AddCurrentParameterChunk(
           Result.getAllocator().CopyString(Placeholder));
     else
-      Result.AddPlaceholderChunk(Result.getAllocator().CopyString(Placeholder));
+      Result.AddPlaceholderChunk(Result.getAllocator().CopyString(Placeholder),
+                                 PlaceholderTerseStart, PlaceholderTerseLen);
   }
 
   if (Prototype && Prototype->isVariadic()) {
@@ -4300,10 +4341,13 @@ static CodeCompletionString *createTemplateSignatureString(
       Current = &OptionalBuilder;
     if (I > 0)
       Current->AddChunk(CodeCompletionString::CK_Comma);
-    Current->AddChunk(I == CurrentArg
-                          ? CodeCompletionString::CK_CurrentParameter
-                          : CodeCompletionString::CK_Placeholder,
-                      Current->getAllocator().CopyString(Placeholder));
+
+    const char *OwnedPlaceholder =
+        Current->getAllocator().CopyString(Placeholder);
+    if (I == CurrentArg)
+      Current->AddCurrentParameterChunk(OwnedPlaceholder);
+    else
+      Current->AddPlaceholderChunk(OwnedPlaceholder);
   }
   // Add the optional chunk to the main string if we ever used it.
   if (Current == &OptionalBuilder)
@@ -5312,8 +5356,9 @@ static void AddObjCBlockCall(ASTContext &Context, const PrintingPolicy &Policy,
         Builder.AddChunk(CodeCompletionString::CK_Comma);
 
       // Format the placeholder string.
-      std::string PlaceholderStr =
+      std::tuple<std::string, size_t, size_t> Placeholder =
           FormatFunctionParameter(Policy, BlockLoc.getParam(I));
+      std::string PlaceholderStr = std::get<0>(Placeholder);
 
       if (I == N - 1 && BlockProtoLoc &&
           BlockProtoLoc.getTypePtr()->isVariadic())
@@ -5321,7 +5366,8 @@ static void AddObjCBlockCall(ASTContext &Context, const PrintingPolicy &Policy,
 
       // Add the placeholder string.
       Builder.AddPlaceholderChunk(
-          Builder.getAllocator().CopyString(PlaceholderStr));
+          Builder.getAllocator().CopyString(PlaceholderStr),
+          std::get<1>(Placeholder), std::get<2>(Placeholder));
     }
   }
 

--- a/clang/tools/libclang/CIndexCodeCompletion.cpp
+++ b/clang/tools/libclang/CIndexCodeCompletion.cpp
@@ -117,7 +117,6 @@ CXString clang_getCompletionChunkText(CXCompletionString completion_string,
   switch ((*CCStr)[chunk_number].Kind) {
   case CodeCompletionString::CK_TypedText:
   case CodeCompletionString::CK_Text:
-  case CodeCompletionString::CK_Placeholder:
   case CodeCompletionString::CK_CurrentParameter:
   case CodeCompletionString::CK_Informative:
   case CodeCompletionString::CK_LeftParen:
@@ -136,7 +135,8 @@ CXString clang_getCompletionChunkText(CXCompletionString completion_string,
   case CodeCompletionString::CK_HorizontalSpace:
   case CodeCompletionString::CK_VerticalSpace:
     return cxstring::createRef((*CCStr)[chunk_number].Text);
-      
+  case CodeCompletionString::CK_Placeholder:
+    return cxstring::createRef((*CCStr)[chunk_number].Placeholder.Full);
   case CodeCompletionString::CK_Optional:
     // Note: treated as an empty text block.
     return cxstring::createEmpty();


### PR DESCRIPTION
Fixes https://github.com/clangd/clangd/issues/1252

Adds new `NamePlaceholders` value to `ArgumentLists` that omits the type of a parameter from the completions