### PR TITLE
[PGO][HIP] Skip ROCm interceptor in profile-only compiler-rt builds

### DIFF
--- a/compiler-rt/lib/profile/CMakeLists.txt
+++ b/compiler-rt/lib/profile/CMakeLists.txt
@@ -164,8 +164,18 @@ if(COMPILER_RT_BUILD_PROFILE_ROCM)
       -DCOMPILER_RT_BUILD_PROFILE_ROCM=1)
 endif()
 
+# The HIP host interceptor in InstrProfilingPlatformROCm.cpp pulls in
+# RTInterception + sanitizer_common object libs. Those targets are only created
+# when COMPILER_RT_BUILD_SANITIZERS / _MEMPROF / _XRAY / _CTX_PROFILE is enabled
+# (see lib/CMakeLists.txt). In a profile-only build the targets do not exist;
+# skip both the object-lib merge and the ROCm source file so the static archive
+# remains self-contained.
 set(PROFILE_OBJECT_LIBS)
-if(COMPILER_RT_HAS_INTERCEPTION AND NOT COMPILER_RT_PROFILE_BAREMETAL)
+set(PROFILE_HAS_HIP_INTERCEPTOR FALSE)
+if(COMPILER_RT_HAS_INTERCEPTION AND NOT COMPILER_RT_PROFILE_BAREMETAL
+   AND TARGET RTInterception.${COMPILER_RT_DEFAULT_TARGET_ARCH}
+   AND TARGET RTSanitizerCommon.${COMPILER_RT_DEFAULT_TARGET_ARCH}
+   AND TARGET RTSanitizerCommonLibc.${COMPILER_RT_DEFAULT_TARGET_ARCH})
   # RTInterception references __sanitizer_internal_{memcpy,memset,memmove} and other
   # sanitizer_common symbols; merge the same object libs as clang_rt.cfi (without
   # coverage/symbolizer) so -fprofile-instr-generate links stay self-contained.
@@ -173,6 +183,11 @@ if(COMPILER_RT_HAS_INTERCEPTION AND NOT COMPILER_RT_PROFILE_BAREMETAL)
     RTInterception
     RTSanitizerCommon
     RTSanitizerCommonLibc)
+  set(PROFILE_HAS_HIP_INTERCEPTOR TRUE)
+endif()
+
+if(NOT PROFILE_HAS_HIP_INTERCEPTOR)
+  list(REMOVE_ITEM PROFILE_SOURCES InstrProfilingPlatformROCm.cpp)
 endif()
 
 if("${COMPILER_RT_DEFAULT_TARGET_ARCH}" MATCHES "amdgcn|nvptx")
@@ -193,7 +208,7 @@ if(MSVC)
   # built with MultiThreadedDLL (/MD) — see interception/CMakeLists.txt and
   # sanitizer_common/CMakeLists.txt. Mixing /MD objects into a /MT libclang_rt.profile
   # yields LNK2019 (__imp__stricmp from interception_win.cpp) and LNK4098 in Profile-*.
-  if(COMPILER_RT_HAS_INTERCEPTION AND NOT COMPILER_RT_PROFILE_BAREMETAL)
+  if(PROFILE_HAS_HIP_INTERCEPTOR)
     set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
   else()
     set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded)


### PR DESCRIPTION
PR #177665 made `libclang_rt.profile.a` merge `RTInterception` and `sanitizer_common` object libs to support the `hipModuleLoad*` host interceptor added in `InstrProfilingPlatformROCm.cpp`. Those object-lib targets are only created when `COMPILER_RT_BUILD_SANITIZERS / _MEMPROF / _XRAY / _CTX_PROFILE` is enabled (see `compiler-rt/lib/CMakeLists.txt`), so a profile-only configuration fails at configure time:

```
CMake Error at cmake/Modules/AddCompilerRT.cmake:365 (add_library):
  Error evaluating generator expression:
    $<TARGET_OBJECTS:RTInterception.x86_64>
  Objects of target "RTInterception.x86_64" referenced but no such target
  exists.
Call Stack (most recent call first):
  lib/profile/CMakeLists.txt:233 (add_compiler_rt_runtime)
```

Fix: gate the object-lib merge on the `RTInterception.<arch>` / `RTSanitizerCommon*.<arch>` targets actually existing, and drop `InstrProfilingPlatformROCm.cpp` from `PROFILE_SOURCES` in that case so the static archive stays self-contained. The host-side hook `__llvm_profile_hip_collect_device_data` is already declared weak in `InstrProfilingFile.c` (PR #200101), so its absence is fine at link time.

Verified:
- Profile-only standalone compiler-rt build (`-DCOMPILER_RT_BUILD_SANITIZERS=OFF -DCOMPILER_RT_BUILD_MEMPROF=OFF -DCOMPILER_RT_BUILD_XRAY=OFF -DCOMPILER_RT_BUILD_CTX_PROFILE=OFF -DCOMPILER_RT_BUILD_PROFILE=ON`) now configures and links cleanly.
- Default runtimes build still merges the object libs and produces the interceptor; `check-profile` 134/134 pass.
