### PR TITLE
[orc-rt] Remove NativeDylibManager unload operation.

### DIFF
--- a/orc-rt/include/orc-rt/NativeDylibManager.h
+++ b/orc-rt/include/orc-rt/NativeDylibManager.h
@@ -17,17 +17,15 @@
 #include "orc-rt/Service.h"
 #include "orc-rt/sps-ci/NativeDylibManagerSPSCI.h"
 
-#include <mutex>
-#include <unordered_map>
-
 namespace orc_rt {
 
 class Session;
 
-/// Dylib loading / unloading / symbol lookup service.
+/// Dylib loading / symbol lookup service.
 ///
-/// Any dynamic libraries loaded through this service that are not manually
-/// unloaded will be automatically unloaded at shutdown time in LIFO order.
+/// Libraries loaded through this service are automatically unloaded in LIFO
+/// order at session shutdown via Session::addOnShutdown callbacks registered
+/// from load().
 class NativeDylibManager : public Service {
 public:
   /// Create a NativeDylibManager, adding associated symbols to the given
@@ -53,15 +51,10 @@ public:
 
   /// Load the given library.
   ///
-  /// Returns an Expected handle.
+  /// Returns an Expected handle. On success, registers a Session shutdown
+  /// callback to unload the library.
   using OnLoadCompleteFn = move_only_function<void(Expected<void *>)>;
   void load(OnLoadCompleteFn &&OnComplete, std::string Path);
-
-  /// Unload the given library handle.
-  ///
-  /// Returns an error on failure.
-  using OnUnloadCompleteFn = move_only_function<void(Error)>;
-  void unload(OnUnloadCompleteFn &&OnComplete, void *Handle);
 
   /// Lookup addresses of the given symbols.
   ///
@@ -79,14 +72,6 @@ private:
   NativeDylibManager(Session &S) : S(S) {}
 
   Session &S;
-
-  struct LoadInfo {
-    size_t Ordinal = 0;
-    size_t RefCount = 0;
-  };
-
-  std::mutex M;
-  std::unordered_map<void *, LoadInfo> LoadInfos;
 };
 
 } // namespace orc_rt

--- a/orc-rt/lib/executor/NativeDylibManager.cpp
+++ b/orc-rt/lib/executor/NativeDylibManager.cpp
@@ -13,8 +13,7 @@
 #include "orc-rt/NativeDylibManager.h"
 #include "orc-rt/Session.h"
 
-#include <algorithm>
-#include <sstream>
+#include <sstream> // For NativeDylibAPIs.inc.
 
 #if defined(__APPLE__) || defined(__linux__)
 #include "Unix/NativeDylibAPIs.inc"
@@ -46,72 +45,21 @@ NativeDylibManager::Create(Session &S, SimpleSymbolTable &ST,
 }
 
 void NativeDylibManager::load(OnLoadCompleteFn &&OnComplete, std::string Path) {
+  auto H = hostOSLoadLibrary(Path);
+  if (!H)
+    return OnComplete(H.takeError());
 
-  if (auto H = hostOSLoadLibrary(Path)) {
-    {
-      std::scoped_lock<std::mutex> Lock(M);
-      auto &LI = LoadInfos[*H];
-      if (LI.Ordinal == 0) // new entry.
-        LI.Ordinal = LoadInfos.size();
-      ++LI.RefCount;
-    }
-    OnComplete(std::move(H));
-  } else
-    OnComplete(H.takeError());
-}
-
-void NativeDylibManager::unload(OnUnloadCompleteFn &&OnComplete, void *Handle) {
-  std::unique_lock<std::mutex> Lock(M);
-
-  auto LIItr = LoadInfos.find(Handle);
-  if (LIItr == LoadInfos.end()) {
-    Lock.unlock();
-    std::ostringstream ErrMsg;
-    ErrMsg << "error: attempt to unload unrecognized handle " << Handle;
-    OnComplete(make_error<StringError>(ErrMsg.str()));
-    return;
-  }
-
-  auto &LI = LIItr->second;
-
-  if (LI.RefCount == 0) {
-    Lock.unlock();
-    std::ostringstream ErrMsg;
-    ErrMsg << "error: cannot close handle " << Handle
-           << ", refcount is already zero";
-    OnComplete(make_error<StringError>(ErrMsg.str()));
-    return;
-  }
-
-  --LI.RefCount;
-
-  Lock.unlock();
-  OnComplete(hostOSUnloadLibrary(Handle));
+  // Capture S by reference, rather than this, so that the callback remains
+  // valid even if the NativeDylibManager is destroyed prior to shutdown.
+  S.addOnShutdown([&S = this->S, Handle = *H]() {
+    if (auto Err = hostOSUnloadLibrary(Handle))
+      S.reportError(std::move(Err));
+  });
+  OnComplete(std::move(H));
 }
 
 void NativeDylibManager::lookup(OnLookupCompleteFn &&OnLookupComplete,
                                 void *Handle, std::vector<std::string> Names) {
-  {
-    std::unique_lock<std::mutex> Lock(M);
-    auto LIItr = LoadInfos.find(Handle);
-    if (LIItr == LoadInfos.end()) {
-      Lock.unlock();
-      std::ostringstream ErrMsg;
-      ErrMsg << "error: cannot perform lookup on unrecognized handle "
-             << Handle;
-      OnLookupComplete(make_error<StringError>(ErrMsg.str()));
-      return;
-    }
-
-    if (LIItr->second.RefCount == 0) {
-      Lock.unlock();
-      std::ostringstream ErrMsg;
-      ErrMsg << "error: cannot perform lookup on closed handle " << Handle;
-      OnLookupComplete(make_error<StringError>(ErrMsg.str()));
-      return;
-    }
-  }
-
   OnLookupComplete(hostOSLibraryLookup(Handle, Names));
 }
 
@@ -123,29 +71,7 @@ void NativeDylibManager::onDetach(Service::OnCompleteFn OnComplete,
 }
 
 void NativeDylibManager::onShutdown(Service::OnCompleteFn OnComplete) {
-
-  // Unload in reverse load order (LIFO).
-  std::vector<void *> ToUnload;
-  ToUnload.reserve(LoadInfos.size());
-
-  for (auto &[Handle, Info] : LoadInfos)
-    ToUnload.push_back(Handle);
-
-  std::sort(ToUnload.begin(), ToUnload.end(), [this](void *LHS, void *RHS) {
-    assert(LoadInfos.count(LHS));
-    assert(LoadInfos.count(RHS));
-    return LoadInfos[LHS].Ordinal < LoadInfos[RHS].Ordinal;
-  });
-
-  while (!ToUnload.empty()) {
-    void *H = ToUnload.back();
-    ToUnload.pop_back();
-    size_t UnloadCount = LoadInfos[H].RefCount;
-    for (size_t I = 0; I != UnloadCount; ++I)
-      if (auto Err = hostOSUnloadLibrary(H))
-        S.reportError(std::move(Err));
-  }
-
+  // Unloads happen via Session shutdown callbacks registered in load().
   OnComplete();
 }
 

--- a/orc-rt/lib/executor/sps-ci/NativeDylibManagerSPSCI.cpp
+++ b/orc-rt/lib/executor/sps-ci/NativeDylibManagerSPSCI.cpp
@@ -22,11 +22,6 @@ ORC_RT_SPS_WRAPPER(
     WrapperFunction::handleWithAsyncMethod(&NativeDylibManager::load))
 
 ORC_RT_SPS_WRAPPER(
-    orc_rt_ci_sps_NativeDylibManager_unload,
-    SPSError(SPSExecutorAddr, SPSExecutorAddr),
-    WrapperFunction::handleWithAsyncMethod(&NativeDylibManager::unload))
-
-ORC_RT_SPS_WRAPPER(
     orc_rt_ci_sps_NativeDylibManager_lookup,
     SPSExpected<SPSSequence<SPSExecutorAddr>>(SPSExecutorAddr, SPSExecutorAddr,
                                               SPSSequence<SPSString>),
@@ -35,7 +30,6 @@ ORC_RT_SPS_WRAPPER(
 static std::pair<const char *, const void *>
     orc_rt_ci_NativeDylibManager_sps_interface[] = {
         ORC_RT_SYMTAB_PAIR(orc_rt_ci_sps_NativeDylibManager_load),
-        ORC_RT_SYMTAB_PAIR(orc_rt_ci_sps_NativeDylibManager_unload),
         ORC_RT_SYMTAB_PAIR(orc_rt_ci_sps_NativeDylibManager_lookup)};
 
 Error addNativeDylibManager(SimpleSymbolTable &ST) {

--- a/orc-rt/unittests/NativeDylibManagerSPSCITest.cpp
+++ b/orc-rt/unittests/NativeDylibManagerSPSCITest.cpp
@@ -34,14 +34,6 @@ protected:
     NDM = cantFail(NativeDylibManager::Create(*S, CI));
   }
 
-  void TearDown() override {
-    if (NDM) {
-      std::future<void> F;
-      NDM->onShutdown(waitFor(F));
-      F.get();
-    }
-  }
-
   DirectCaller caller(const char *Name) {
     return DirectCaller(nullptr, reinterpret_cast<orc_rt_WrapperFunction>(
                                      const_cast<void *>(CI.at(Name))));
@@ -53,14 +45,6 @@ protected:
     SPSWrapperFunction<SPSSig>::call(
         caller("orc_rt_ci_sps_NativeDylibManager_load"),
         std::forward<OnCompleteFn>(OnComplete), NDM.get(), std::move(Path));
-  }
-
-  template <typename OnCompleteFn>
-  void spsUnload(OnCompleteFn &&OnComplete, void *Handle) {
-    using SPSSig = SPSError(SPSExecutorAddr, SPSExecutorAddr);
-    SPSWrapperFunction<SPSSig>::call(
-        caller("orc_rt_ci_sps_NativeDylibManager_unload"),
-        std::forward<OnCompleteFn>(OnComplete), NDM.get(), Handle);
   }
 
   template <typename OnCompleteFn>
@@ -81,19 +65,14 @@ protected:
 
 TEST_F(NativeDylibManagerSPSCITest, Registration) {
   EXPECT_TRUE(CI.count("orc_rt_ci_sps_NativeDylibManager_load"));
-  EXPECT_TRUE(CI.count("orc_rt_ci_sps_NativeDylibManager_unload"));
   EXPECT_TRUE(CI.count("orc_rt_ci_sps_NativeDylibManager_lookup"));
 }
 
-TEST_F(NativeDylibManagerSPSCITest, LoadAndUnload) {
+TEST_F(NativeDylibManagerSPSCITest, Load) {
   std::future<Expected<Expected<void *>>> LoadResult;
   spsLoad(waitFor(LoadResult), NDM_TEST_LIB_PATH);
   void *Handle = cantFail(cantFail(LoadResult.get()));
   EXPECT_NE(Handle, nullptr);
-
-  std::future<Expected<Error>> UnloadResult;
-  spsUnload(waitFor(UnloadResult), Handle);
-  cantFail(cantFail(UnloadResult.get()));
 }
 
 TEST_F(NativeDylibManagerSPSCITest, LoadNonExistent) {
@@ -102,16 +81,6 @@ TEST_F(NativeDylibManagerSPSCITest, LoadNonExistent) {
   auto Handle = cantFail(LoadResult.get());
   EXPECT_FALSE(!!Handle);
   consumeError(Handle.takeError());
-}
-
-TEST_F(NativeDylibManagerSPSCITest, UnloadUnrecognizedHandle) {
-  // Use Session object address as bogus handle.
-  void *BadHandle = reinterpret_cast<void *>(&S);
-  std::future<Expected<Error>> UnloadResult;
-  spsUnload(waitFor(UnloadResult), BadHandle);
-  auto Handle = cantFail(UnloadResult.get());
-  EXPECT_TRUE(!!Handle);
-  consumeError(std::move(Handle));
 }
 
 TEST_F(NativeDylibManagerSPSCITest, LookupSingleSymbol) {
@@ -127,10 +96,6 @@ TEST_F(NativeDylibManagerSPSCITest, LookupSingleSymbol) {
 
   auto *Func = reinterpret_cast<int (*)()>(Addrs[0]);
   EXPECT_EQ(Func(), 42);
-
-  std::future<Expected<Error>> UnloadResult;
-  spsUnload(waitFor(UnloadResult), Handle);
-  cantFail(cantFail(UnloadResult.get()));
 }
 
 TEST_F(NativeDylibManagerSPSCITest, LookupMultipleSymbols) {
@@ -150,10 +115,6 @@ TEST_F(NativeDylibManagerSPSCITest, LookupMultipleSymbols) {
   auto *Func2 = reinterpret_cast<int (*)()>(Addrs[1]);
   EXPECT_EQ(Func1(), 42);
   EXPECT_EQ(Func2(), 7);
-
-  std::future<Expected<Error>> UnloadResult;
-  spsUnload(waitFor(UnloadResult), Handle);
-  cantFail(cantFail(UnloadResult.get()));
 }
 
 TEST_F(NativeDylibManagerSPSCITest, LookupNonExistentSymbol) {
@@ -166,18 +127,4 @@ TEST_F(NativeDylibManagerSPSCITest, LookupNonExistentSymbol) {
   auto Addrs = cantFail(cantFail(LookupResult.get()));
   ASSERT_EQ(Addrs.size(), 1U);
   EXPECT_EQ(Addrs[0], nullptr);
-
-  std::future<Expected<Error>> UnloadResult;
-  spsUnload(waitFor(UnloadResult), Handle);
-  cantFail(cantFail(UnloadResult.get()));
-}
-
-TEST_F(NativeDylibManagerSPSCITest, LookupOnUnrecognizedHandle) {
-  // Use Session object address as bogus handle.
-  void *BadHandle = reinterpret_cast<void *>(&S);
-  std::future<Expected<Expected<std::vector<void *>>>> LookupResult;
-  spsLookup(waitFor(LookupResult), BadHandle, {"NativeDylibManagerTestFunc"});
-  auto Addrs = cantFail(LookupResult.get());
-  EXPECT_FALSE(!!Addrs);
-  consumeError(Addrs.takeError());
 }

--- a/orc-rt/unittests/NativeDylibManagerTest.cpp
+++ b/orc-rt/unittests/NativeDylibManagerTest.cpp
@@ -33,13 +33,6 @@ static Expected<void *> syncLoad(NativeDylibManager &NDM, std::string Path) {
   return std::move(*Result);
 }
 
-// Helper: synchronously run unload and return result.
-static Error syncUnload(NativeDylibManager &NDM, void *Handle) {
-  std::optional<Error> Result;
-  NDM.unload([&](Error R) { Result = std::move(R); }, Handle);
-  return std::move(*Result);
-}
-
 // Helper: synchronously run lookup and return results.
 static Expected<std::vector<void *>>
 syncLookup(NativeDylibManager &NDM, void *Handle,
@@ -58,21 +51,15 @@ TEST(NativeDylibManagerTest, Create) {
   ASSERT_TRUE(!!NDM) << toString(NDM.takeError());
 }
 
-TEST(NativeDylibManagerTest, LoadAndUnload) {
+TEST(NativeDylibManagerTest, Load) {
   Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
             noErrors);
   SimpleSymbolTable ST;
   auto NDM = cantFail(NativeDylibManager::Create(S, ST));
 
-  // Load the test library.
   auto LoadResult = syncLoad(*NDM, NDM_TEST_LIB_PATH);
   ASSERT_TRUE(!!LoadResult) << toString(LoadResult.takeError());
-  void *Handle = *LoadResult;
-  EXPECT_NE(Handle, nullptr);
-
-  // Unload it.
-  auto UnloadResult = syncUnload(*NDM, Handle);
-  EXPECT_FALSE(!!UnloadResult) << toString(std::move(UnloadResult));
+  EXPECT_NE(*LoadResult, nullptr);
 }
 
 TEST(NativeDylibManagerTest, LoadNonExistent) {
@@ -84,43 +71,6 @@ TEST(NativeDylibManagerTest, LoadNonExistent) {
   auto LoadResult = syncLoad(*NDM, "/no/such/library.dylib");
   EXPECT_FALSE(!!LoadResult);
   consumeError(LoadResult.takeError());
-}
-
-TEST(NativeDylibManagerTest, UnloadUnrecognizedHandle) {
-  Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
-            noErrors);
-  SimpleSymbolTable ST;
-  auto NDM = cantFail(NativeDylibManager::Create(S, ST));
-
-  void *Bogus = reinterpret_cast<void *>(0xDEADBEEF);
-  auto UnloadResult = syncUnload(*NDM, Bogus);
-  EXPECT_TRUE(!!UnloadResult);
-  consumeError(std::move(UnloadResult));
-}
-
-TEST(NativeDylibManagerTest, LoadSameLibraryTwice) {
-  // Loading the same library twice should succeed both times and return
-  // the same handle (since dlopen refcounts).
-  Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
-            noErrors);
-  SimpleSymbolTable ST;
-  auto NDM = cantFail(NativeDylibManager::Create(S, ST));
-
-  auto R1 = syncLoad(*NDM, NDM_TEST_LIB_PATH);
-  ASSERT_TRUE(!!R1) << toString(R1.takeError());
-  void *H1 = *R1;
-
-  auto R2 = syncLoad(*NDM, NDM_TEST_LIB_PATH);
-  ASSERT_TRUE(!!R2) << toString(R2.takeError());
-  void *H2 = *R2;
-
-  EXPECT_EQ(H1, H2);
-
-  // Unload both references.
-  auto UR1 = syncUnload(*NDM, H1);
-  EXPECT_FALSE(!!UR1) << toString(std::move(UR1));
-  auto UR2 = syncUnload(*NDM, H2);
-  EXPECT_FALSE(!!UR2) << toString(std::move(UR2));
 }
 
 TEST(NativeDylibManagerTest, LookupSingleSymbol) {
@@ -139,9 +89,6 @@ TEST(NativeDylibManagerTest, LookupSingleSymbol) {
   // Verify the symbol points to the right function.
   auto *Func = reinterpret_cast<int (*)()>((*Result)[0]);
   EXPECT_EQ(Func(), 42);
-
-  auto UR = syncUnload(*NDM, Handle);
-  EXPECT_FALSE(!!UR) << toString(std::move(UR));
 }
 
 TEST(NativeDylibManagerTest, LookupMultipleSymbols) {
@@ -164,9 +111,6 @@ TEST(NativeDylibManagerTest, LookupMultipleSymbols) {
   auto *Func2 = reinterpret_cast<int (*)()>((*Result)[1]);
   EXPECT_EQ(Func1(), 42);
   EXPECT_EQ(Func2(), 7);
-
-  auto UR = syncUnload(*NDM, Handle);
-  EXPECT_FALSE(!!UR) << toString(std::move(UR));
 }
 
 TEST(NativeDylibManagerTest, LookupNonExistentSymbol) {
@@ -181,19 +125,4 @@ TEST(NativeDylibManagerTest, LookupNonExistentSymbol) {
   ASSERT_TRUE(!!Result) << toString(Result.takeError());
   ASSERT_EQ(Result->size(), 1U);
   EXPECT_EQ((*Result)[0], nullptr);
-
-  auto UR = syncUnload(*NDM, Handle);
-  EXPECT_FALSE(!!UR) << toString(std::move(UR));
-}
-
-TEST(NativeDylibManagerTest, LookupOnUnrecognizedHandle) {
-  Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
-            noErrors);
-  SimpleSymbolTable ST;
-  auto NDM = cantFail(NativeDylibManager::Create(S, ST));
-
-  void *Bogus = reinterpret_cast<void *>(0xDEADBEEF);
-  auto Result = syncLookup(*NDM, Bogus, {"NativeDylibManagerTestFunc"});
-  EXPECT_FALSE(!!Result);
-  consumeError(Result.takeError());
 }


### PR DESCRIPTION
NativeDylibManager is intended to act as a backend for llvm::orc::DylibManager, which does not expose an unload operation. This commit removes the explicit unload from both the C++ and SPS interfaces, and unloads dylibs via an on-shutdown callback instead.