### PR TITLE
[clang] Add missing BuiltinAnchorSources.def to module map

### DIFF
--- a/clang/include/module.modulemap
+++ b/clang/include/module.modulemap
@@ -150,6 +150,7 @@ module Clang_ScalableStaticAnalysisFramework {
   requires cplusplus
   umbrella "clang/ScalableStaticAnalysisFramework"
 
+  textual header "clang/ScalableStaticAnalysisFramework/BuiltinAnchorSources.def"
   textual header "clang/ScalableStaticAnalysisFramework/Core/Model/PrivateFieldNames.def"
 
   module * { export * }


### PR DESCRIPTION
Started with 5db13643f4b7038db0ca304d9f8900122502935c.