### PR TITLE
[compiler-rt][profile] Add COMPILER_RT_BUILD_PROFILE_ROCM option

### DIFF
--- a/compiler-rt/CMakeLists.txt
+++ b/compiler-rt/CMakeLists.txt
@@ -322,6 +322,15 @@ option(COMPILER_RT_USE_ATOMIC_LIBRARY "Use compiler-rt atomic instead of libatom
 
 option(COMPILER_RT_PROFILE_BAREMETAL "Build minimal baremetal profile library" OFF)
 
+set(DEFAULT_COMPILER_RT_BUILD_PROFILE_ROCM ON)
+if(APPLE)
+  set(DEFAULT_COMPILER_RT_BUILD_PROFILE_ROCM OFF)
+endif()
+option(COMPILER_RT_BUILD_PROFILE_ROCM
+  "Build the host-side ROCm/HIP device profile collection runtime"
+  ${DEFAULT_COMPILER_RT_BUILD_PROFILE_ROCM})
+mark_as_advanced(COMPILER_RT_BUILD_PROFILE_ROCM)
+
 include(config-ix)
 
 #================================

--- a/compiler-rt/lib/profile/CMakeLists.txt
+++ b/compiler-rt/lib/profile/CMakeLists.txt
@@ -89,11 +89,13 @@ if (NOT COMPILER_RT_PROFILE_BAREMETAL)
   list(APPEND PROFILE_SOURCES
     GCDAProfiling.c
     InstrProfilingFile.c
-    InstrProfilingPlatformROCm.cpp
     InstrProfilingRuntime.cpp
     InstrProfilingUtil.c
     InstrProfilingValue.c
     )
+  if(COMPILER_RT_BUILD_PROFILE_ROCM)
+    list(APPEND PROFILE_SOURCES InstrProfilingPlatformROCm.cpp)
+  endif()
 endif()
 
 set(PROFILE_HEADERS
@@ -154,6 +156,12 @@ if(COMPILER_RT_PROFILE_BAREMETAL)
  set(EXTRA_FLAGS
      ${EXTRA_FLAGS}
      -DCOMPILER_RT_PROFILE_BAREMETAL=1)
+endif()
+
+if(COMPILER_RT_BUILD_PROFILE_ROCM)
+  set(EXTRA_FLAGS
+      ${EXTRA_FLAGS}
+      -DCOMPILER_RT_BUILD_PROFILE_ROCM=1)
 endif()
 
 set(PROFILE_OBJECT_LIBS)

--- a/compiler-rt/lib/profile/InstrProfilingFile.c
+++ b/compiler-rt/lib/profile/InstrProfilingFile.c
@@ -50,10 +50,12 @@
  * and the address test at the call site would fold to true.
  * Windows: __declspec(selectany) is data-only, and the ROCm interceptor path
  * is not used there, so keep the original strong extern. */
+#if COMPILER_RT_BUILD_PROFILE_ROCM
 #if defined(_WIN32)
 extern int __llvm_profile_hip_collect_device_data(void);
 #else
 __attribute__((weak)) int __llvm_profile_hip_collect_device_data(void);
+#endif
 #endif
 
 /* From where is profile name specified.
@@ -1217,11 +1219,13 @@ int __llvm_profile_write_file(void) {
    * InstrProfilingPlatformROCm.o is in the link, which happens when the program
    * references other ROCm-runtime symbols (HIP-with-PGO). Warning on failure is
    * handled inside the callee. */
+#if COMPILER_RT_BUILD_PROFILE_ROCM
 #if defined(_WIN32)
   (void)__llvm_profile_hip_collect_device_data();
 #else
   if (&__llvm_profile_hip_collect_device_data)
     (void)__llvm_profile_hip_collect_device_data();
+#endif
 #endif
 
   // Restore SIGKILL.


### PR DESCRIPTION
InstrProfilingPlatformROCm.cpp (added in 5db13643f4b7 or https://github.com/llvm/llvm-project/pull/177665) is currently built into every non-baremetal libclang_rt.profile, but not all hosts support it (e.g. it fails to link on Darwin, where __llvm_write_custom_profile is unavailable).

Add a COMPILER_RT_BUILD_PROFILE_ROCM CMake option (defaulting off on Apple, on elsewhere) to allow that host to opt out.