### PR TITLE
[Xtensa] Fix literal section emit for ConstantPool entries.

### DIFF
--- a/llvm/lib/Target/Xtensa/MCTargetDesc/XtensaTargetStreamer.cpp
+++ b/llvm/lib/Target/Xtensa/MCTargetDesc/XtensaTargetStreamer.cpp
@@ -112,6 +112,8 @@ void XtensaTargetELFStreamer::startLiteralSection(MCSection *BaseSection) {
       SectionName, ELF::SHT_PROGBITS, ELF::SHF_EXECINSTR | ELF::SHF_ALLOC);
 
   ConstSection->setAlignment(Align(4));
+  MCStreamer &OutStreamer = getStreamer();
+  OutStreamer.switchSection(ConstSection);
 }
 
 MCELFStreamer &XtensaTargetELFStreamer::getStreamer() {

--- a/llvm/test/CodeGen/Xtensa/literal.ll
+++ b/llvm/test/CodeGen/Xtensa/literal.ll
@@ -1,0 +1,34 @@
+; RUN: llc -mtriple=xtensa -function-sections --mcpu=esp32 --filetype=obj < %s\
+; RUN: | llvm-objdump -r -s --triple=xtensa --mcpu=esp32 -\
+; RUN: | FileCheck -check-prefix=CHECK %s
+
+; CHECK-LABEL: RELOCATION RECORDS FOR [.literal.func_b]:
+; CHECK:       OFFSET   TYPE                     VALUE
+; CHECK-NEXT:  00000000 R_XTENSA_32              func_a
+
+; CHECK-LABEL: Contents of section .literal.func_b:
+; CHECK:       0000 00000000                             ....
+
+define i32 @func_a(i32 %x) #0 {
+  %1 = alloca i32, align 4
+  store i32 %x, ptr %1, align 4
+  %2 = load i32, ptr %1, align 4
+  %3 = icmp sgt i32 %2, 0
+  br i1 %3, label %then, label %else
+then:
+  %4 = load i32, ptr %1, align 4
+  %5 = add i32 %4, 1
+  ret i32 %5
+else:
+  %6 = load i32, ptr %1, align 4
+  %7 = sub i32 %6, 1
+  ret i32 %7
+}
+
+define i32 @func_b() #0 {
+  %fp = alloca ptr, align 4
+  store ptr @func_a, ptr %fp, align 4
+  %1 = load ptr, ptr %fp, align 4
+  %2 = call i32 %1(i32 42)
+  ret i32 %2
+}

--- a/llvm/test/CodeGen/Xtensa/literal.ll
+++ b/llvm/test/CodeGen/Xtensa/literal.ll
@@ -1,6 +1,6 @@
 ; RUN: llc -mtriple=xtensa -function-sections --mcpu=esp32 --filetype=obj < %s\
 ; RUN: | llvm-objdump -r -s --triple=xtensa --mcpu=esp32 -\
-; RUN: | FileCheck -check-prefix=CHECK %s
+; RUN: | FileCheck %s
 
 ; CHECK-LABEL: RELOCATION RECORDS FOR [.literal.func_b]:
 ; CHECK:       OFFSET   TYPE                     VALUE
@@ -9,26 +9,12 @@
 ; CHECK-LABEL: Contents of section .literal.func_b:
 ; CHECK:       0000 00000000                             ....
 
-define i32 @func_a(i32 %x) #0 {
-  %1 = alloca i32, align 4
-  store i32 %x, ptr %1, align 4
-  %2 = load i32, ptr %1, align 4
-  %3 = icmp sgt i32 %2, 0
-  br i1 %3, label %then, label %else
-then:
-  %4 = load i32, ptr %1, align 4
-  %5 = add i32 %4, 1
-  ret i32 %5
-else:
-  %6 = load i32, ptr %1, align 4
-  %7 = sub i32 %6, 1
-  ret i32 %7
-}
-
 define i32 @func_b() #0 {
   %fp = alloca ptr, align 4
   store ptr @func_a, ptr %fp, align 4
-  %1 = load ptr, ptr %fp, align 4
-  %2 = call i32 %1(i32 42)
-  ret i32 %2
+  %func_a_ptr = load ptr, ptr %fp, align 4
+  %res = call i32 %func_a_ptr(i32 42)
+  ret i32 %res
 }
+
+declare dso_local i32 @func_a(i32 %x)

--- a/llvm/test/CodeGen/Xtensa/literal.ll
+++ b/llvm/test/CodeGen/Xtensa/literal.ll
@@ -4,6 +4,6 @@
 ; CHECK-LABEL: Contents of section .literal.func:
 ; CHECK:       0000 88130000                             ....
 
-define i32 @func() #0 {
+define i32 @func() {
   ret i32 5000
 }

--- a/llvm/test/CodeGen/Xtensa/literal.ll
+++ b/llvm/test/CodeGen/Xtensa/literal.ll
@@ -1,20 +1,9 @@
 ; RUN: llc -mtriple=xtensa -function-sections --mcpu=esp32 --filetype=obj < %s\
-; RUN: | llvm-objdump -r -s --triple=xtensa --mcpu=esp32 -\
-; RUN: | FileCheck %s
+; RUN: | llvm-objdump -r -s --triple=xtensa --mcpu=esp32 - | FileCheck %s
 
-; CHECK-LABEL: RELOCATION RECORDS FOR [.literal.func_b]:
-; CHECK:       OFFSET   TYPE                     VALUE
-; CHECK-NEXT:  00000000 R_XTENSA_32              func_a
+; CHECK-LABEL: Contents of section .literal.func:
+; CHECK:       0000 88130000                             ....
 
-; CHECK-LABEL: Contents of section .literal.func_b:
-; CHECK:       0000 00000000                             ....
-
-define i32 @func_b() #0 {
-  %fp = alloca ptr, align 4
-  store ptr @func_a, ptr %fp, align 4
-  %func_a_ptr = load ptr, ptr %fp, align 4
-  %res = call i32 %func_a_ptr(i32 42)
-  ret i32 %res
+define i32 @func() #0 {
+  ret i32 5000
 }
-
-declare dso_local i32 @func_a(i32 %x)


### PR DESCRIPTION
Fix literal section switching in XtensaTargetStreamer.
 https://github.com/llvm/llvm-project/issues/190204