### PR TITLE
[lldb-dap] Use SetTarget for launch commands

### DIFF
--- a/lldb/test/API/tools/lldb-dap/attach-commands/TestDAP_attachCommands.py
+++ b/lldb/test/API/tools/lldb-dap/attach-commands/TestDAP_attachCommands.py
@@ -77,6 +77,10 @@ class TestDAP_attachCommands(lldbdap_testcase.DAPTestCaseBase):
         output = self.collect_console(pattern=stopCommands[-1])
         self.verify_commands("stopCommands", output, stopCommands)
 
+        # Check that we got module events from target
+        modules = self.dap_server.wait_for_module_events()
+        self.assertGreater(len(modules), 0)
+
         # Continue after launch and hit the "pause()" call and stop the target.
         # Get output from the console. This should contain both the
         # "stopCommands" that were run after we stop.

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_extra_launch_commands.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_extra_launch_commands.py
@@ -57,8 +57,15 @@ class TestDAP_launch_extra_launch_commands(lldbdap_testcase.DAPTestCaseBase):
         # After execution, program should launch
         self.verify_commands("launchCommands", output, launchCommands)
         self.verify_commands("postRunCommands", output, postRunCommands)
+
+        # Finish configuration and continue target
+        self.verify_configuration_done()
+
+        # Check that we got module events from target
+        modules = self.dap_server.wait_for_module_events()
+        self.assertGreater(len(modules), 0)
+
         # Verify the "stopCommands" here
-        self.continue_to_next_stop()
         output = self.get_console()
         self.verify_commands("stopCommands", output, stopCommands)
 

--- a/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
@@ -103,7 +103,7 @@ Error AttachRequestHandler::Run(const AttachRequestArguments &args) const {
       if (llvm::Error err = dap.RunAttachCommands(args.attachCommands))
         return err;
 
-      dap.target = dap.debugger.GetSelectedTarget();
+      dap.SetTarget(dap.debugger.GetSelectedTarget());
 
       // Validate the attachCommand results.
       if (!dap.target.GetProcess().IsValid())

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
@@ -261,7 +261,7 @@ llvm::Error BaseRequestHandler::LaunchProcess(
 
       // The custom commands might have created a new target so we should use
       // the selected target after these commands are run.
-      dap.target = dap.debugger.GetSelectedTarget();
+      dap.SetTarget(dap.debugger.GetSelectedTarget());
     }
   }
 


### PR DESCRIPTION
Without this patch event listener registration was skipped, as a result `Modules` view in UI was not displayed in case of launching target via `launchCommands`.