### PR TITLE
[LLDB] Serve unknown type symbols through `qSymbol` for non-MachO targets

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -15,6 +15,7 @@
 #include <optional>
 #include <sstream>
 
+#include "lldb/Core/Module.h"
 #include "lldb/Core/ModuleSpec.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Host/SafeMachO.h"
@@ -42,6 +43,7 @@
 #include "llvm/Config/llvm-config.h" // for LLVM_ENABLE_ZLIB
 #include "llvm/Support/ErrorExtras.h"
 #include "llvm/Support/JSON.h"
+#include "llvm/TargetParser/Triple.h"
 
 #if HAVE_LIBCOMPRESSION
 #include <compression.h>
@@ -4279,6 +4281,19 @@ void GDBRemoteCommunicationClient::ServeSymbolLookups(
                   case eSymbolTypeCompiler:
                   case eSymbolTypeInstrumentation:
                   case eSymbolTypeTrampoline:
+                    if (sc.module_sp->GetArchitecture()
+                            .GetTriple()
+                            .getObjectFormat() !=
+                        llvm::Triple::ObjectFormatType::MachO) {
+                      // GDB does return symbols even when they are of unknown
+                      // type, following this behavior on non Mach-O
+                      // architectures.
+                      symbol_load_addr =
+                          sc.symbol->GetLoadAddress(&process->GetTarget());
+                      if (symbol_load_addr == LLDB_INVALID_ADDRESS) {
+                        symbol_load_addr = sc.symbol->GetRawValue();
+                      }
+                    }
                     break;
 
                   case eSymbolTypeCode:

--- a/lldb/test/API/functionalities/gdb_remote_client/TestQSymbol.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestQSymbol.py
@@ -74,10 +74,8 @@ class TestQSymbol(GDBRemoteTestBase):
             [
                 ("main", 0x1000),
                 ("local_address", 0x1004),
-                # FIXME: Should return a value.
-                ("global_value", None),
-                # FIXME: Should return a value.
-                ("local_value", None),
+                ("global_value", 0x1234),
+                ("local_value", 0xABCD),
                 ("not_a_symbol", None),
             ]
         )


### PR DESCRIPTION
I am working with a binary where some symbols are generated from linker scripts. They end up identified as `eSymbolInvalid` when loaded in LLDB. OpenOCD can try to fetch them.
Some might even be hard-coded data, not going through an address in the binary (explaining the presence of the [check and raw value return](https://github.com/llvm/llvm-project/pull/200134/changes/BASE..a8dcabf9cad6b64cf35cb06f902e0ecc6108c76a#diff-82cb38d9af6d5239660a958e92a0dbe5d953a5f371b4b7dc8b2002a6264ab558R4207-R4209)). Testing it showed that **GDB returns them despite them not being proper addresses**.
These can also be generated by C++ static constexpr, such values could be accessed by a qSymbol query.

358cf1ea302eb introduced a divergence between GDB and LLDB where LLDB does not serve symbols of unknown type through GDB protocol command `qSymbol`. Per commit description, this is an expected behavior on MachO-based platforms, but it is not on ELF-based platforms, where LLDB should follow GDB. The changes introduced by said commit are now gated behind an architecture check.