### PR TITLE
[mlir][spirv] Remove unnecessary assertion

### DIFF
--- a/mlir/lib/Target/SPIRV/Deserialization/DeserializeOps.cpp
+++ b/mlir/lib/Target/SPIRV/Deserialization/DeserializeOps.cpp
@@ -417,9 +417,6 @@ spirv::Deserializer::processDebugInfoExtInst(ArrayRef<uint32_t> operands,
                      "<id>, result <id>, set <id> and instruction opcode");
   }
 
-  StringRef &extensionSetName = extendedInstSets[operands[2]];
-  assert(extensionSetName == extDebugInfo);
-
   Type resultType = getType(operands[0]);
   if (!resultType || !isVoidType(resultType))
     return emitError(unknownLoc,


### PR DESCRIPTION
The use of the variable in the assertion was causing a build failure when compiling with assertion off and hence the variable becomes unused.