### PR TITLE
[Object][OffloadBundle] validate version before calling getHeaderSize

### DIFF
--- a/llvm/lib/Object/OffloadBundle.cpp
+++ b/llvm/lib/Object/OffloadBundle.cpp
@@ -489,6 +489,9 @@ CompressedOffloadBundle::CompressedBundleHeader::tryParse(StringRef Blob) {
   CompressedBundleHeader Normalized;
   Normalized.Version = Header.Common.Version;
 
+  if (Normalized.Version < 1 || Normalized.Version > 3)
+    return createStringError("unknown compressed bundle version");
+
   size_t RequiredSize = getHeaderSize(Normalized.Version);
 
   if (Blob.size() < RequiredSize)


### PR DESCRIPTION
CompressedBundleHeader::tryParse reads Version straight from the blob and
hands it to getHeaderSize, which calls llvm_unreachable for any value
other than 1/2/3. Reachable from extractOffloadBundleFatBinary on any
ELF/COFF section starting with CCOB. Reject the unknown version before
getHeaderSize; the switch below already has the matching default error.