### PR TITLE
[flang] Fix -E -dM macro dumping for stdin and .f90 inputs

### DIFF
--- a/flang/lib/Frontend/FrontendAction.cpp
+++ b/flang/lib/Frontend/FrontendAction.cpp
@@ -81,6 +81,7 @@ bool FrontendAction::beginSourceFile(CompilerInstance &ci,
   //  * the file extension (if the user didn't express any preference)
   // to decide whether to include them or not.
   if ((invoc.getPreprocessorOpts().macrosFlag == PPMacrosFlag::Include) ||
+      (invoc.getPreprocessorOpts().showMacros) ||
       (invoc.getPreprocessorOpts().macrosFlag == PPMacrosFlag::Unknown &&
        getCurrentInput().getMustBePreprocessed())) {
     invoc.setDefaultPredefinitions();

--- a/flang/test/Preprocessing/show-macros-stdin.f90
+++ b/flang/test/Preprocessing/show-macros-stdin.f90
@@ -1,0 +1,10 @@
+! RUN: %flang -E -dM - < /dev/null | FileCheck %s
+
+! Check that dumping macros from stdin still emits default definitions.
+
+! CHECK: #define __DATE__
+! CHECK: #define __TIME__
+! CHECK: #define __flang__
+! CHECK: #define __flang_major__
+! CHECK: #define __flang_minor__
+! CHECK: #define __flang_patchlevel__


### PR DESCRIPTION
Issue:
flang -E -dM does not consistently print predefined macros for stdin and .f90 inputs, unlike expected behavior.

Root cause:
Flang only initialized predefined macros when preprocessing was implied by -cpp or suffix-based inference (mustBePreprocessed), but not when -dM alone requested macro dumping.

Fix:
Treat -dM as an explicit trigger to initialize macro predefinitions in, and add a stdin regression test for flang -E -dM - < /dev/null.

Fixes #198234