### PR TITLE
[mlir][IR] Allow OpaqueAttr memory space.

### DIFF
--- a/mlir/lib/IR/BuiltinTypes.cpp
+++ b/mlir/lib/IR/BuiltinTypes.cpp
@@ -613,7 +613,8 @@ bool mlir::detail::isSupportedMemorySpace(Attribute memorySpace) {
     return true;
 
   // Supported built-in attributes.
-  if (llvm::isa<IntegerAttr, StringAttr, DictionaryAttr>(memorySpace))
+  if (llvm::isa<IntegerAttr, StringAttr, DictionaryAttr, OpaqueAttr>(
+          memorySpace))
     return true;
 
   // Allow custom dialect attributes.

--- a/mlir/test/IR/parser.mlir
+++ b/mlir/test/IR/parser.mlir
@@ -127,6 +127,12 @@ func.func private @memrefs_nomap_dictspace(memref<5x6x7xf32, {memSpace = "specia
 // CHECK: func private @memrefs_map_dictspace(memref<5x6x7xf32, #map{{[0-9]*}}, {memSpace = "special", subIndex = 3 : i64}>)
 func.func private @memrefs_map_dictspace(memref<5x6x7xf32, #map3, {memSpace = "special", subIndex = 3}>)
 
+// CHECK: func private @memrefs_nomap_opaquespace(memref<5x6x7xf32, #unregistered_dialect.attr<>>)
+func.func private @memrefs_nomap_opaquespace(memref<5x6x7xf32, #unregistered_dialect.attr<>>)
+
+// CHECK: func private @memrefs_map_opaquespace(memref<5x6x7xf32, #map{{[0-9]*}}, #unregistered_dialect.attr<>>)
+func.func private @memrefs_map_opaquespace(memref<5x6x7xf32, #map3, #unregistered_dialect.attr<>>)
+
 // CHECK: func private @complex_types(complex<i1>) -> complex<f32>
 func.func private @complex_types(complex<i1>) -> complex<f32>
 


### PR DESCRIPTION
This PR addresses issue #200150.

The verifier for `memref` accepts all attributes outside the builtin dialect, as well as a limited set of those within. This set does not contain the `OpaqueAttr`. Since, in generic form, MLIR attributes of unregistered dialects are stores as `OpaqueAttr`, this leads to unexpected results.

This commit adds `OpaqueAttr` to the list of allowed attributes, and adds a test.