### PR TITLE
[SelectionDAG] Remove redundant asserts in WidenVecRes_ATOMIC_LOAD

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorTypes.cpp
@@ -6621,11 +6621,6 @@ SDValue DAGTypeLegalizer::WidenVecRes_ATOMIC_LOAD(AtomicSDNode *LD) {
       TLI.getTypeToTransformTo(*DAG.getContext(), LD->getValueType(0));
   EVT LdVT = LD->getMemoryVT();
   SDLoc dl(LD);
-  assert(LdVT.isVector() && WidenVT.isVector() && "Expected vectors");
-  assert(LdVT.isScalableVector() == WidenVT.isScalableVector() &&
-         "Must be scalable");
-  assert(LdVT.getVectorElementType() == WidenVT.getVectorElementType() &&
-         "Expected equivalent element types");
 
   // Load information
   SDValue Chain = LD->getChain();


### PR DESCRIPTION
These asserts duplicate guarantees already provided elsewhere:
- `isVector()` checks are redundant because `findMemType()` calls
  `WidenVT.getVectorElementType()` and `WidenVT.isScalableVector()`
  internally, and `WidenVecRes_ATOMIC_LOAD` is only reached from the
  `ATOMIC_LOAD` case in `WidenVectorResult`, which is the vector path.
- The element-type and scalability consistency between `LdVT` and
  `WidenVT` is a property of `GetWidenedVector` / `getTypeToTransformTo`.

Follow-up to feedback on #197618.