### PR TITLE
[GVN] Canonicalize null values in `createConstantExpression`

### DIFF
--- a/llvm/lib/Transforms/Scalar/NewGVN.cpp
+++ b/llvm/lib/Transforms/Scalar/NewGVN.cpp
@@ -1291,6 +1291,10 @@ const Expression *NewGVN::createVariableOrConstant(Value *V) const {
 }
 
 const ConstantExpression *NewGVN::createConstantExpression(Constant *C) const {
+  // Convert vector ConstantFP splat 0.0 to ConstantAggregateZero,
+  // so that they are compared as equal.
+  if (C->isNullValue())
+    C = Constant::getNullValue(C->getType());
   auto *E = new (ExpressionAllocator) ConstantExpression(C);
   E->setOpcode(C->getValueID());
   return E;

--- a/llvm/test/Transforms/NewGVN/crash.ll
+++ b/llvm/test/Transforms/NewGVN/crash.ll
@@ -191,3 +191,22 @@ reachable.bb:
 r1.bb:
   br label %u2.bb
 }
+
+
+; issue 199348
+
+define void @phi_of_vector_fp_zero() {
+; CHECK-LABEL: @phi_of_vector_fp_zero(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    br label [[BB4:%.*]]
+; CHECK:       bb4:
+; CHECK-NEXT:    br label [[BB4]]
+;
+entry:
+  br label %bb4
+
+bb4:
+  %phi = phi <4 x float> [ zeroinitializer, %entry ], [ %add, %bb4 ]
+  %add = fadd <4 x float> %phi, zeroinitializer
+  br label %bb4
+}


### PR DESCRIPTION
Resolves #199348 .

Canonicalize zero values at creation site so they share the same pointer.


`%0 = fadd <4 x float> %part0.0.0261, zeroinitializer` is constant folded to [1] vector ConstantFP splat 0.0, which is compared against [0] `ConstantAggregateZero`. The are not considered equal by `performSymbolicPHIEvaluation`. Therefore [1] keeps getting created and filtered out until reaching the iteration limit.