### PR TITLE
[SimplifyCFG] Look at all uses when checking phi incoming for UB

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -8756,8 +8756,8 @@ static bool passingValueIsAlwaysUndefined(Value *V, Instruction *I, bool PtrValu
     return false;
 
   if (C->isNullValue() || isa<UndefValue>(C)) {
-    // Only look at the first use we can handle, avoid hurting compile time with
-    // long uselists
+    // Find the first same-block use with a UB-triggering opcode, skipping
+    // cross-block or before-I uses.
     auto FindUse = llvm::find_if(I->uses(), [I](auto &U) {
       auto *Use = cast<Instruction>(U.getUser());
       // Only same-block uses after I can witness UB at I's program point.

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -8758,8 +8758,12 @@ static bool passingValueIsAlwaysUndefined(Value *V, Instruction *I, bool PtrValu
   if (C->isNullValue() || isa<UndefValue>(C)) {
     // Only look at the first use we can handle, avoid hurting compile time with
     // long uselists
-    auto FindUse = llvm::find_if(I->uses(), [](auto &U) {
+    auto FindUse = llvm::find_if(I->uses(), [I](auto &U) {
       auto *Use = cast<Instruction>(U.getUser());
+      // Only same-block uses after I can witness UB at I's program point.
+      // Self-uses and before-I uses can occur when I is a PHI node.
+      if (Use->getParent() != I->getParent() || Use == I || Use->comesBefore(I))
+        return false;
       // Change this list when we want to add new instructions.
       switch (Use->getOpcode()) {
       default:
@@ -8786,12 +8790,6 @@ static bool passingValueIsAlwaysUndefined(Value *V, Instruction *I, bool PtrValu
       return false;
     auto &Use = *FindUse;
     auto *User = cast<Instruction>(Use.getUser());
-    // Bail out if User is not in the same BB as I or User == I or User comes
-    // before I in the block. The latter two can be the case if User is a
-    // PHI node.
-    if (User->getParent() != I->getParent() || User == I ||
-        User->comesBefore(I))
-      return false;
 
     // Now make sure that there are no instructions in between that can alter
     // control flow (eg. calls)

--- a/llvm/test/Transforms/SimplifyCFG/phi-undef-loadstore.ll
+++ b/llvm/test/Transforms/SimplifyCFG/phi-undef-loadstore.ll
@@ -351,7 +351,7 @@ if.end7:                                          ; preds = %if.else, %if.then4,
 
 define i64 @test5_several_uses(i1 %c, i1 %branch, ptr %p) {
 ; CHECK-LABEL: define i64 @test5_several_uses
-; CHECK-SAME: (i1 [[C:%.*]], i1 [[BRANCH:%.*]], ptr [[P:%.*]]) #[[ATTR0]] {
+; CHECK-SAME: (i1 [[C:%.*]], i1 [[BRANCH:%.*]], ptr [[P:%.*]]) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[C]])
 ; CHECK-NEXT:    [[G_IN_BLOCK:%.*]] = getelementptr i8, ptr [[P]], i64 48

--- a/llvm/test/Transforms/SimplifyCFG/phi-undef-loadstore.ll
+++ b/llvm/test/Transforms/SimplifyCFG/phi-undef-loadstore.ll
@@ -349,19 +349,19 @@ if.end7:                                          ; preds = %if.else, %if.then4,
   ret i32 %tmp9
 }
 
-define i64 @test5_several_uses(i1 %c, i1 %branch, ptr %p) nounwind #0 {
+define i64 @test5_several_uses(i1 %c, i1 %branch, ptr %p) nounwind {
 ; CHECK-LABEL: define i64 @test5_several_uses
-; CHECK-SAME: (i1 [[C:%.*]], i1 [[BRANCH:%.*]], ptr [[P:%.*]]) #[[ATTR1]] {
+; CHECK-SAME: (i1 [[C:%.*]], i1 [[BRANCH:%.*]], ptr [[P:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[SPEC_SELECT:%.*]] = select i1 [[C]], ptr [[P]], ptr null
-; CHECK-NEXT:    [[G_IN_BLOCK:%.*]] = getelementptr i8, ptr [[SPEC_SELECT]], i64 48
+; CHECK-NEXT:    call void @llvm.assume(i1 [[C]])
+; CHECK-NEXT:    [[G_IN_BLOCK:%.*]] = getelementptr i8, ptr [[P]], i64 48
 ; CHECK-NEXT:    [[V:%.*]] = load i64, ptr [[G_IN_BLOCK]], align 8
 ; CHECK-NEXT:    br i1 [[BRANCH]], label [[COMMON_RET:%.*]], label [[USE:%.*]]
 ; CHECK:       common.ret:
 ; CHECK-NEXT:    [[COMMON_RET_OP:%.*]] = phi i64 [ [[SUM:%.*]], [[USE]] ], [ [[V]], [[ENTRY:%.*]] ]
 ; CHECK-NEXT:    ret i64 [[COMMON_RET_OP]]
 ; CHECK:       use:
-; CHECK-NEXT:    [[G_CROSS:%.*]] = getelementptr i8, ptr [[SPEC_SELECT]], i64 16
+; CHECK-NEXT:    [[G_CROSS:%.*]] = getelementptr i8, ptr [[P]], i64 16
 ; CHECK-NEXT:    [[X:%.*]] = load i64, ptr [[G_CROSS]], align 8
 ; CHECK-NEXT:    [[SUM]] = add i64 [[V]], [[X]]
 ; CHECK-NEXT:    br label [[COMMON_RET]]

--- a/llvm/test/Transforms/SimplifyCFG/phi-undef-loadstore.ll
+++ b/llvm/test/Transforms/SimplifyCFG/phi-undef-loadstore.ll
@@ -349,4 +349,43 @@ if.end7:                                          ; preds = %if.else, %if.then4,
   ret i32 %tmp9
 }
 
+define i64 @test5_several_uses(i1 %c, i1 %branch, ptr %p) nounwind #0 {
+; CHECK-LABEL: define i64 @test5_several_uses
+; CHECK-SAME: (i1 [[C:%.*]], i1 [[BRANCH:%.*]], ptr [[P:%.*]]) #[[ATTR1]] {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[SPEC_SELECT:%.*]] = select i1 [[C]], ptr [[P]], ptr null
+; CHECK-NEXT:    [[G_IN_BLOCK:%.*]] = getelementptr i8, ptr [[SPEC_SELECT]], i64 48
+; CHECK-NEXT:    [[V:%.*]] = load i64, ptr [[G_IN_BLOCK]], align 8
+; CHECK-NEXT:    br i1 [[BRANCH]], label [[COMMON_RET:%.*]], label [[USE:%.*]]
+; CHECK:       common.ret:
+; CHECK-NEXT:    [[COMMON_RET_OP:%.*]] = phi i64 [ [[SUM:%.*]], [[USE]] ], [ [[V]], [[ENTRY:%.*]] ]
+; CHECK-NEXT:    ret i64 [[COMMON_RET_OP]]
+; CHECK:       use:
+; CHECK-NEXT:    [[G_CROSS:%.*]] = getelementptr i8, ptr [[SPEC_SELECT]], i64 16
+; CHECK-NEXT:    [[X:%.*]] = load i64, ptr [[G_CROSS]], align 8
+; CHECK-NEXT:    [[SUM]] = add i64 [[V]], [[X]]
+; CHECK-NEXT:    br label [[COMMON_RET]]
+;
+entry:
+  br i1 %c, label %acquire, label %join
+
+acquire:
+  br label %join
+
+join:
+  %obj = phi ptr [ null, %entry ], [ %p, %acquire ]
+  %g_in_block = getelementptr i8, ptr %obj, i64 48
+  %v = load i64, ptr %g_in_block, align 8
+  br i1 %branch, label %ret_direct, label %use
+
+ret_direct:
+  ret i64 %v
+
+use:
+  %g_cross = getelementptr i8, ptr %obj, i64 16
+  %x = load i64, ptr %g_cross, align 8
+  %sum = add i64 %v, %x
+  ret i64 %sum
+}
+
 attributes #0 = { null_pointer_is_valid }

--- a/llvm/test/Transforms/SimplifyCFG/phi-undef-loadstore.ll
+++ b/llvm/test/Transforms/SimplifyCFG/phi-undef-loadstore.ll
@@ -349,7 +349,7 @@ if.end7:                                          ; preds = %if.else, %if.then4,
   ret i32 %tmp9
 }
 
-define i64 @test5_several_uses(i1 %c, i1 %branch, ptr %p) nounwind {
+define i64 @test5_several_uses(i1 %c, i1 %branch, ptr %p) {
 ; CHECK-LABEL: define i64 @test5_several_uses
 ; CHECK-SAME: (i1 [[C:%.*]], i1 [[BRANCH:%.*]], ptr [[P:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:  entry:


### PR DESCRIPTION
passingValueIsAlwaysUndefined only looks at the first use of the phi that has a UB-candidate opcode. If that use is in a different block, the function gives up, even when another use in the same block would prove UB. Use-list order is not guaranteed, so this happens in practice.

Move the same-block check into the find_if lambda so the scan keeps going past cross-block uses.