### PR TITLE
[AMDGPU] Document that only naturally aligned atomics of up to 64 bits are supported by the AMDGPU backend

### DIFF
--- a/llvm/docs/AMDGPUUsage.rst
+++ b/llvm/docs/AMDGPUUsage.rst
@@ -2133,6 +2133,18 @@ Example:
 
   !0 = !{ !"agent" }
 
+.. _amdgpu_unsupported_constructs:
+
+Unsupported IR Constructs
+-------------------------
+
+The following LLVM IR constructs are not supported by the AMDGPU backend:
+
+* atomic accesses with less than natural alignment or an access size of
+  more than 64 bits
+
+This list is not exhaustive.
+
 .. _amdgpu_metadata:
 
 LLVM IR Metadata


### PR DESCRIPTION
We get an error from AtomicExpandPass if those constraints are not satisfied.
The 64-bit limit is set [here, in AMDGPUISelLowering.cpp](https://github.com/llvm/llvm-project/blob/5cac2751fb9cf3112d16717b278e40d07dd6cfdc/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp#L645).

This patch also introduces a new "Unsupported IR Constructs" section to the AMDGPUUsage doc, where we can document more such cases.