### PR TITLE
[lit] Handle config loading safely

### DIFF
--- a/llvm/utils/lit/lit/TestingConfig.py
+++ b/llvm/utils/lit/lit/TestingConfig.py
@@ -138,10 +138,10 @@ class TestingConfig:
 
         # Load the config script data.
         data = None
-        f = open(path)
         try:
-            data = f.read()
-        except:
+            with open(path) as f:
+                data = f.read()
+        except OSError:
             litConfig.fatal("unable to load config file: %r" % (path,))
         f.close()
 


### PR DESCRIPTION
Currently, the config file is opened outside the `try` block without explicit encoding and handled with a bare `except`. 
We can move to putting a `with open()` context manager inside the `try` block and catching OSError.