### PR TITLE
[clang-tidy] Fix cert-err33-c inheriting CheckedReturnTypes from bugp…

### DIFF
--- a/clang-tools-extra/clang-tidy/cert/CERTTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/cert/CERTTidyModule.cpp
@@ -353,6 +353,7 @@ public:
     Opts["cert-arr39-c.WarnOnSizeOfPointerToAggregate"] = "false";
     Opts["cert-dcl16-c.NewSuffixes"] = "L;LL;LU;LLU";
     Opts["cert-err33-c.CheckedFunctions"] = CertErr33CCheckedFunctions;
+    Opts["cert-err33-c.CheckedReturnTypes"] = "";
     Opts["cert-err33-c.AllowCastToVoid"] = "true";
     Opts["cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField"] = "false";
     Opts["cert-str34-c.DiagnoseSignedUnsignedCharComparisons"] = "false";

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -441,6 +441,12 @@ Changes in existing checks
   - Avoid false positives when moving object is reinitialized via the base
     class's ``operator=``.
 
+- Improved :doc:`cert-err33-c
+  <clang-tidy/checks/cert/err33-c>` check by not inheriting
+  ``CheckedReturnTypes`` from :doc:`bugprone-unused-return-value
+  <clang-tidy/checks/bugprone/unused-return-value>`, which caused false
+  positives on functions returning ``std::error_code`` or similar types.
+
 - Improved :doc:`cppcoreguidelines-avoid-capturing-lambda-coroutines
   <clang-tidy/checks/cppcoreguidelines/avoid-capturing-lambda-coroutines>`
   check by adding the `AllowExplicitObjectParameters` option. When enabled,

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -443,7 +443,7 @@ Changes in existing checks
 
 - Improved :doc:`cert-err33-c
   <clang-tidy/checks/cert/err33-c>` check by not inheriting
-  ``CheckedReturnTypes`` from :doc:`bugprone-unused-return-value
+  `CheckedReturnTypes` option from :doc:`bugprone-unused-return-value
   <clang-tidy/checks/bugprone/unused-return-value>`, which caused false
   positives on functions returning ``std::error_code`` or similar types.
 

--- a/clang-tools-extra/test/clang-tidy/checkers/cert/err33-c.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cert/err33-c.cpp
@@ -1,0 +1,26 @@
+// RUN: %check_clang_tidy %s cert-err33-c %t
+
+namespace std {
+class error_code {
+  int val_;
+public:
+  error_code() : val_(0) {}
+  error_code(int v) : val_(v) {}
+  int value() const { return val_; }
+};
+} // namespace std
+
+std::error_code doSomething(int x);
+
+void negativeReturnType() {
+  doSomething(42);
+}
+
+typedef struct FILE FILE;
+extern "C" int fclose(FILE *);
+
+void positiveCheckedFunction() {
+  fclose(nullptr);
+  // CHECK-MESSAGES: [[@LINE-1]]:3: warning: the value returned by this function should not be disregarded; neglecting it may lead to errors
+  // CHECK-MESSAGES: [[@LINE-2]]:3: note: cast the expression to void to silence this warning
+}


### PR DESCRIPTION
…rone-unused-return-value

The cert-err33-c alias did not override CheckedReturnTypes, causing it to inherit the default from bugprone-unused-return-value. This made it flag any function returning std::error_code, std::expected, etc. That is outside the scope of CERT ERR33-C (a fixed list of C standard library functions).
Set CheckedReturnTypes to empty so the alias only checks its intended function list.