### PR TITLE
[SystemZ] Handle pointer size correctly in getVectorBitmaskConversionCost().

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZTargetTransformInfo.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZTargetTransformInfo.cpp
@@ -815,8 +815,8 @@ SystemZTTIImpl::getShuffleCost(TTI::ShuffleKind Kind, VectorType *DstTy,
 
 // Return the log2 difference of the element sizes of the two vector types.
 static unsigned getElSizeLog2Diff(Type *Ty0, Type *Ty1) {
-  unsigned Bits0 = Ty0->getScalarSizeInBits();
-  unsigned Bits1 = Ty1->getScalarSizeInBits();
+  unsigned Bits0 = getScalarSizeInBits(Ty0);
+  unsigned Bits1 = getScalarSizeInBits(Ty1);
 
   if (Bits1 >  Bits0)
     return (Log2_32(Bits1) - Log2_32(Bits0));
@@ -827,8 +827,7 @@ static unsigned getElSizeLog2Diff(Type *Ty0, Type *Ty1) {
 // Return the number of instructions needed to truncate SrcTy to DstTy.
 unsigned SystemZTTIImpl::getVectorTruncCost(Type *SrcTy, Type *DstTy) const {
   assert (SrcTy->isVectorTy() && DstTy->isVectorTy());
-  assert(SrcTy->getPrimitiveSizeInBits().getFixedValue() >
-             DstTy->getPrimitiveSizeInBits().getFixedValue() &&
+  assert(getScalarSizeInBits(SrcTy) > getScalarSizeInBits(DstTy) &&
          "Packing must reduce size of vector type.");
   assert(cast<FixedVectorType>(SrcTy)->getNumElements() ==
              cast<FixedVectorType>(DstTy)->getNumElements() &&
@@ -872,8 +871,8 @@ unsigned SystemZTTIImpl::getVectorBitmaskConversionCost(Type *SrcTy,
           "Should only be called with vector types.");
 
   unsigned PackCost = 0;
-  unsigned SrcScalarBits = SrcTy->getScalarSizeInBits();
-  unsigned DstScalarBits = DstTy->getScalarSizeInBits();
+  unsigned SrcScalarBits = getScalarSizeInBits(SrcTy);
+  unsigned DstScalarBits = getScalarSizeInBits(DstTy);
   unsigned Log2Diff = getElSizeLog2Diff(SrcTy, DstTy);
   if (SrcScalarBits > DstScalarBits)
     // The bitmask will be truncated.

--- a/llvm/test/Analysis/CostModel/SystemZ/cmp-ext-01.ll
+++ b/llvm/test/Analysis/CostModel/SystemZ/cmp-ext-01.ll
@@ -2401,3 +2401,42 @@ define <16 x i64> @fun239(<16 x double> %val1, <16 x double> %val2) {
 ; CHECK: cost of 8 for instruction:   %v = zext <16 x i1> %cmp to <16 x i64>
 }
 
+define <16 x i8> @fun240(<16 x ptr> %val1, <16 x ptr> %val2) {
+  %cmp = icmp eq <16 x ptr> %val1, %val2
+  %v = zext <16 x i1> %cmp to <16 x i8>
+  ret <16 x i8> %v
+
+; CHECK: fun240
+; CHECK: cost of 8 for instruction:   %cmp = icmp eq <16 x ptr> %val1, %val2
+; CHECK: cost of 8 for instruction:   %v = zext <16 x i1> %cmp to <16 x i8>
+}
+
+define <16 x i16> @fun241(<16 x ptr> %val1, <16 x ptr> %val2) {
+  %cmp = icmp eq <16 x ptr> %val1, %val2
+  %v = zext <16 x i1> %cmp to <16 x i16>
+  ret <16 x i16> %v
+
+; CHECK: fun241
+; CHECK: cost of 8 for instruction:   %cmp = icmp eq <16 x ptr> %val1, %val2
+; CHECK: cost of 8 for instruction:   %v = zext <16 x i1> %cmp to <16 x i16>
+}
+
+define <16 x i32> @fun242(<16 x ptr> %val1, <16 x ptr> %val2) {
+  %cmp = icmp eq <16 x ptr> %val1, %val2
+  %v = zext <16 x i1> %cmp to <16 x i32>
+  ret <16 x i32> %v
+
+; CHECK: fun242
+; CHECK: cost of 8 for instruction:   %cmp = icmp eq <16 x ptr> %val1, %val2
+; CHECK: cost of 8 for instruction:   %v = zext <16 x i1> %cmp to <16 x i32>
+}
+
+define <16 x i64> @fun243(<16 x ptr> %val1, <16 x ptr> %val2) {
+  %cmp = icmp eq <16 x ptr> %val1, %val2
+  %v = zext <16 x i1> %cmp to <16 x i64>
+  ret <16 x i64> %v
+
+; CHECK: fun243
+; CHECK: cost of 8 for instruction:   %cmp = icmp eq <16 x ptr> %val1, %val2
+; CHECK: cost of 8 for instruction:   %v = zext <16 x i1> %cmp to <16 x i64>
+}


### PR DESCRIPTION
Unfortunately, getScalarSizeInBits() returns 0 for PointerTy, which means that the loop vectorizer got way too high costs for sext i1 after a compare(ptr, 0).

There is already a version of getScalarSizeInBits() in SystemZTargetTransformInfo.cpp that handles this, so this is fixed by using this in the needed places.

As a result, a few more loops are vectorized, and perl improves ~1%.
