### PR TITLE
[IR] Remove options for vector of null representation

### DIFF
--- a/llvm/lib/IR/Constants.cpp
+++ b/llvm/lib/IR/Constants.cpp
@@ -42,22 +42,6 @@ static cl::opt<bool> UseConstantIntForFixedLengthSplat(
 static cl::opt<bool> UseConstantIntForScalableSplat(
     "use-constant-int-for-scalable-splat", cl::init(false), cl::Hidden,
     cl::desc("Use ConstantInt's native scalable vector splat support."));
-static cl::opt<bool> UseConstantPtrNullForFixedLengthSplat(
-    "use-constant-ptrnull-for-fixed-length-splat", cl::init(true), cl::Hidden,
-    cl::desc("Use ConstantPointerNull's native fixed-length vector splat "
-             "support."));
-static cl::opt<bool> UseConstantPtrNullForScalableSplat(
-    "use-constant-ptrnull-for-scalable-splat", cl::init(true), cl::Hidden,
-    cl::desc(
-        "Use ConstantPointerNull's native scalable vector splat support."));
-
-static bool shouldUseConstantPointerNullForVector(VectorType *VTy) {
-  if (!VTy->getElementType()->isPointerTy())
-    return false;
-  return VTy->getElementCount().isScalable()
-             ? UseConstantPtrNullForScalableSplat
-             : UseConstantPtrNullForFixedLengthSplat;
-}
 
 //===----------------------------------------------------------------------===//
 //                              Constant Class
@@ -415,7 +399,7 @@ Constant *Constant::getNullValue(Type *Ty) {
     return ConstantPointerNull::get(cast<PointerType>(Ty));
   case Type::FixedVectorTyID:
   case Type::ScalableVectorTyID:
-    if (shouldUseConstantPointerNullForVector(cast<VectorType>(Ty)))
+    if (cast<VectorType>(Ty)->getElementType()->isPointerTy())
       return ConstantPointerNull::get(Ty);
     return ConstantAggregateZero::get(Ty);
   case Type::StructTyID:
@@ -1579,8 +1563,7 @@ Constant *ConstantVector::getImpl(ArrayRef<Constant*> V) {
   bool isSplatFP = isa<ConstantFP>(C);
   bool isSplatInt = UseConstantIntForFixedLengthSplat && isa<ConstantInt>(C);
   bool isSplatByte = isa<ConstantByte>(C);
-  bool isSplatPtrNull =
-      UseConstantPtrNullForFixedLengthSplat && isa<ConstantPointerNull>(C);
+  bool isSplatPtrNull = isa<ConstantPointerNull>(C);
 
   if (isZero || isUndef || isSplatFP || isSplatInt || isSplatByte ||
       isSplatPtrNull) {
@@ -1623,8 +1606,7 @@ Constant *ConstantVector::getImpl(ArrayRef<Constant*> V) {
 Constant *ConstantVector::getSplat(ElementCount EC, Constant *V) {
   if (isa<ConstantPointerNull>(V)) {
     VectorType *VTy = VectorType::get(V->getType(), EC);
-    if (shouldUseConstantPointerNullForVector(VTy))
-      return ConstantPointerNull::get(VTy);
+    return ConstantPointerNull::get(VTy);
   }
 
   if (auto *CB = dyn_cast<ConstantByte>(V))

--- a/llvm/test/Assembler/aggregate-constant-values.ll
+++ b/llvm/test/Assembler/aggregate-constant-values.ll
@@ -1,5 +1,4 @@
 ; RUN: llvm-as < %s | llvm-dis | llvm-as | llvm-dis | FileCheck %s
-; RUN: llvm-as -use-constant-ptrnull-for-fixed-length-splat=false -use-constant-ptrnull-for-scalable-splat=false < %s | llvm-dis -use-constant-ptrnull-for-fixed-length-splat=false -use-constant-ptrnull-for-scalable-splat=false | FileCheck %s --check-prefix=DISABLED
 ; RUN: verify-uselistorder %s
 
 ; CHECK: @foo


### PR DESCRIPTION
This had a bit time to bake in tree, I don't think we need these options anymore.