### PR TITLE
[clang-tidy] Change AllowCastToVoid default to true in bugprone-unused-return-value

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/UnusedReturnValueCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/UnusedReturnValueCheck.cpp
@@ -145,7 +145,7 @@ UnusedReturnValueCheck::UnusedReturnValueCheck(StringRef Name,
                                             "^::std::errc$;"
                                             "^::std::expected$;"
                                             "^::boost::system::error_code$"))),
-      AllowCastToVoid(Options.get("AllowCastToVoid", false)) {}
+      AllowCastToVoid(Options.get("AllowCastToVoid", true)) {}
 
 UnusedReturnValueCheck::UnusedReturnValueCheck(
     StringRef Name, ClangTidyContext *Context,

--- a/clang-tools-extra/clang-tidy/cert/CERTTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/cert/CERTTidyModule.cpp
@@ -353,7 +353,6 @@ public:
     Opts["cert-arr39-c.WarnOnSizeOfPointerToAggregate"] = "false";
     Opts["cert-dcl16-c.NewSuffixes"] = "L;LL;LU;LLU";
     Opts["cert-err33-c.CheckedFunctions"] = CertErr33CCheckedFunctions;
-    Opts["cert-err33-c.AllowCastToVoid"] = "true";
     Opts["cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField"] = "false";
     Opts["cert-str34-c.DiagnoseSignedUnsignedCharComparisons"] = "false";
     return Options;

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -423,6 +423,10 @@ Changes in existing checks
   ``std::get_temporary_buffer`` to the default list of unsafe functions. (This
   function is unsafe, useless, deprecated in C++17 and removed in C++20).
 
+- Improved :doc:`bugprone-unused-return-value
+  <clang-tidy/checks/bugprone/unused-return-value>` check by changing the
+  default of the ``AllowCastToVoid`` option from `false` to `true`.
+
 - Improved :doc:`bugprone-use-after-move
   <clang-tidy/checks/bugprone/use-after-move>` check:
 

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/unused-return-value.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/unused-return-value.rst
@@ -63,7 +63,7 @@ Options
 
 .. option:: AllowCastToVoid
 
-   Controls whether casting return values to ``void`` is permitted. Default: `false`.
+   Controls whether casting return values to ``void`` is permitted. Default: `true`.
 
 :doc:`cert-err33-c <../cert/err33-c>` is an alias of this check that checks a
 fixed and large set of standard library functions.

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/unused-return-value-custom.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/unused-return-value-custom.cpp
@@ -53,7 +53,6 @@ void warning() {
   // CHECK-MESSAGES: [[@LINE-1]]:4: warning: the value returned by this function should not be disregarded; neglecting it may lead to errors
 
   (void)fun();
-  // CHECK-MESSAGES: [[@LINE-1]]:9: warning: the value returned by this function should not be disregarded; neglecting it may lead to errors
 
   ns::Outer::Inner ObjA1;
   ObjA1.memFun();

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/unused-return-value-remove.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/unused-return-value-remove.cpp
@@ -1,5 +1,5 @@
 // RUN: %check_clang_tidy %s bugprone-unused-return-value %t -- \
-// RUN:   -config='{CheckOptions: {bugprone-unused-return-value.CheckedFunctions: "^::std::remove$;^::std::remove_if$;^::std::unique$", bugprone-unused-return-value.CheckedReturnTypes: "", bugprone-unused-return-value.AllowCastToVoid: true}}'
+// RUN:   -config='{CheckOptions: {bugprone-unused-return-value.CheckedFunctions: "^::std::remove$;^::std::remove_if$;^::std::unique$", bugprone-unused-return-value.CheckedReturnTypes: ""}}'
 // RUN: %check_clang_tidy -check-suffixes=NOCAST %s bugprone-unused-return-value %t -- \
 // RUN:   -config='{CheckOptions: {bugprone-unused-return-value.CheckedFunctions: "^::std::remove$;^::std::remove_if$;^::std::unique$", bugprone-unused-return-value.CheckedReturnTypes: "", bugprone-unused-return-value.AllowCastToVoid: false}}'
 

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/unused-return-value.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/unused-return-value.cpp
@@ -1,5 +1,4 @@
-// RUN: %check_clang_tidy %s bugprone-unused-return-value %t -- \
-// RUN:   --config="{CheckOptions: {bugprone-unused-return-value.AllowCastToVoid: true}}" -- -fexceptions
+// RUN: %check_clang_tidy %s bugprone-unused-return-value %t -- -- -fexceptions
 #include <vector>
 #include <memory>
 


### PR DESCRIPTION
Casting to (void) is the standard C/C++ idiom for intentionally discarding a return value. The check should respect this by default rather than requiring users to opt in.

Both coding standard aliases that used this check (cert-err33-c and the now-removed hicpp-ignored-remove-result) overrode AllowCastToVoid to true, confirming that (void) casts are a legitimate suppression mechanism.