### PR TITLE
[z/OS][tests] XFAIL using aliases on z/OS

### DIFF
--- a/llvm/test/CodeGen/Generic/2009-03-17-LSR-APInt.ll
+++ b/llvm/test/CodeGen/Generic/2009-03-17-LSR-APInt.ll
@@ -1,8 +1,8 @@
 ; RUN: llc < %s
 ; PR3806
 
-; NVPTX does not support 'alias' yet
-; XFAIL: target=nvptx{{.*}}
+; NVPTX and z/OS do not support 'alias' yet
+; XFAIL: target=nvptx{{.*}}, target={{.*}}-zos{{.*}}
 
 	%struct..0__pthread_mutex_s = type { i32, i32, i32, i32, i32, i32, %struct.__pthread_list_t }
 	%struct.Alignment = type { i32 }

--- a/llvm/test/CodeGen/Generic/available_externally_alias.ll
+++ b/llvm/test/CodeGen/Generic/available_externally_alias.ll
@@ -1,7 +1,7 @@
 ; RUN: llc < %s
 
-; NVPTX does not support 'alias' yet
-; XFAIL: target=nvptx{{.*}}
+; NVPTX and z/OS do not support 'alias' yet
+; XFAIL: target=nvptx{{.*}}, target={{.*}}-zos{{.*}}
 
 @v = available_externally global i32 42, align 4
 @va = available_externally alias i32, ptr @v


### PR DESCRIPTION
This PR XFAIL 2 lit test cases as the following errors are expected:

```
FAIL: LLVM :: CodeGen/Generic/available_externally_alias.ll
# | <unknown>:0: error: Only aliases to functions is supported in GOFF.

FAIL: LLVM :: CodeGen/Generic/2009-03-17-LSR-APInt.ll
# | <unknown>:0: error: Weak alias/reference not supported on z/OS
```