### PR TITLE
[AArch64][llvm] Deprecate FEAT_MPAMv2_VID

### DIFF
--- a/clang/test/Driver/aarch64-v97a.c
+++ b/clang/test/Driver/aarch64-v97a.c
@@ -46,10 +46,6 @@
 // RUN: %clang -target aarch64 -march=armv9.7-a+tlbid -### -c %s 2>&1 | FileCheck -check-prefix=V97A-TLBID %s
 // V97A-TLBID: "-cc1"{{.*}} "-triple" "aarch64{{.*}}" "-target-cpu" "generic" "-target-feature" "+v9.7a"{{.*}} "-target-feature" "+tlbid"
 
-// RUN: %clang -target aarch64 -march=armv9.7a+mpamv2 -### -c %s 2>&1 | FileCheck -check-prefix=V97A-MPAMv2 %s
-// RUN: %clang -target aarch64 -march=armv9.7-a+mpamv2 -### -c %s 2>&1 | FileCheck -check-prefix=V97A-MPAMv2 %s
-// V97A-MPAMv2: "-cc1"{{.*}} "-triple" "aarch64{{.*}}" "-target-cpu" "generic" "-target-feature" "+v9.7a"{{.*}} "-target-feature" "+mpamv2"
-
 // RUN: %clang -target aarch64 -march=armv9.7a+mtetc -### -c %s 2>&1 | FileCheck -check-prefix=V97A-MTETC %s
 // RUN: %clang -target aarch64 -march=armv9.7-a+mtetc -### -c %s 2>&1 | FileCheck -check-prefix=V97A-MTETC %s
 // V97A-MTETC: "-cc1"{{.*}} "-triple" "aarch64{{.*}}" "-target-cpu" "generic" "-target-feature" "+v9.7a"{{.*}} "-target-feature" "+mtetc"

--- a/clang/test/Driver/print-supported-extensions-aarch64.c
+++ b/clang/test/Driver/print-supported-extensions-aarch64.c
@@ -51,7 +51,7 @@
 // CHECK-NEXT:     lut                 FEAT_LUT                                               Enable Lookup Table instructions
 // CHECK-NEXT:     mops                FEAT_MOPS                                              Enable Armv8.8-A memcpy and memset acceleration instructions
 // CHECK-NEXT:     mops-go             FEAT_MOPS_GO                                           Enable memset acceleration granule only
-// CHECK-NEXT:     mpamv2              FEAT_MPAMv2                                            Enable Armv9.7-A MPAMv2 Lookaside Buffer Invalidate instructions
+// CHECK-NEXT:     mpamv2-deprecated   FEAT_MPAMv2                                            (Deprecated) MPAMv2 Lookaside Buffer Invalidate instructions
 // CHECK-NEXT:     memtag              FEAT_MTE, FEAT_MTE2                                    Enable Memory Tagging Extension
 // CHECK-NEXT:     mtetc               FEAT_MTETC                                             Enable Virtual Memory Tagging Extension
 // CHECK-NEXT:     simd                FEAT_AdvSIMD                                           Enable Advanced SIMD instructions

--- a/llvm/lib/Target/AArch64/AArch64Features.td
+++ b/llvm/lib/Target/AArch64/AArch64Features.td
@@ -595,8 +595,8 @@ def FeatureLSCP : ExtensionWithMArch<"lscp", "LSCP", "FEAT_LSCP",
 def FeatureTLBID: ExtensionWithMArch<"tlbid", "TLBID", "FEAT_TLBID",
   "Enable Armv9.7-A TLBI Domains extension">;
 
-def FeatureMPAMv2: ExtensionWithMArch<"mpamv2", "MPAMv2", "FEAT_MPAMv2",
-  "Enable Armv9.7-A MPAMv2 Lookaside Buffer Invalidate instructions">;
+def FeatureMPAMv2: ExtensionWithMArch<"mpamv2-deprecated", "MPAMv2", "FEAT_MPAMv2",
+  "(Deprecated) MPAMv2 Lookaside Buffer Invalidate instructions">;
 
 def FeatureMTETC: ExtensionWithMArch<"mtetc", "MTETC", "FEAT_MTETC",
   "Enable Virtual Memory Tagging Extension", [FeatureMTE]>;

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -400,7 +400,7 @@ def HasCPA           : Predicate<"Subtarget->hasCPA()">,
 def HasTLBID         : Predicate<"Subtarget->hasTLBID()">,
                                  AssemblerPredicateWithAll<(all_of FeatureTLBID), "tlbid">;
 def HasMPAMv2        : Predicate<"Subtarget->hasMPAMv2()">,
-                                 AssemblerPredicateWithAll<(all_of FeatureMPAMv2), "mpamv2">;
+                                 AssemblerPredicateWithAll<(all_of FeatureMPAMv2), "mpamv2-deprecated">;
 def HasMTETC         : Predicate<"Subtarget->hasMTETC()">,
                                  AssemblerPredicateWithAll<(all_of FeatureMTETC), "mtetc">;
 def HasGCIE          : Predicate<"Subtarget->hasGCIE()">,

--- a/llvm/lib/Target/AArch64/AArch64SystemOperands.td
+++ b/llvm/lib/Target/AArch64/AArch64SystemOperands.td
@@ -2367,9 +2367,9 @@ def : RWSysReg<"MPAMCTL_EL1",   0b11, 0b000, 0b1010, 0b0101, 0b010>;
 def : RWSysReg<"MPAMCTL_EL12",  0b11, 0b101, 0b1010, 0b0101, 0b010>;
 def : RWSysReg<"MPAMCTL_EL2",   0b11, 0b100, 0b1010, 0b0101, 0b010>;
 def : RWSysReg<"MPAMCTL_EL3",   0b11, 0b110, 0b1010, 0b0101, 0b010>;
-def : RWSysReg<"MPAMVIDCR_EL2", 0b11, 0b100, 0b1010, 0b0111, 0b000>;
-def : RWSysReg<"MPAMVIDSR_EL2", 0b11, 0b100, 0b1010, 0b0111, 0b001>;
-def : RWSysReg<"MPAMVIDSR_EL3", 0b11, 0b110, 0b1010, 0b0111, 0b001>;
+def : RWSysReg<"MPAM_DEPRECATED_VIDCR_EL2", 0b11, 0b100, 0b1010, 0b0111, 0b000>;
+def : RWSysReg<"MPAM_DEPRECATED_VIDSR_EL2", 0b11, 0b100, 0b1010, 0b0111, 0b001>;
+def : RWSysReg<"MPAM_DEPRECATED_VIDSR_EL3", 0b11, 0b110, 0b1010, 0b0111, 0b001>;
 
 //===----------------------------------------------------------------------===//
 // FEAT_SRMASK v9.6a registers

--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -3941,7 +3941,7 @@ static const struct Extension {
     {"cmh", {AArch64::FeatureCMH}},
     {"lscp", {AArch64::FeatureLSCP}},
     {"tlbid", {AArch64::FeatureTLBID}},
-    {"mpamv2", {AArch64::FeatureMPAMv2}},
+    {"mpamv2-deprecated", {AArch64::FeatureMPAMv2}},
     {"mtetc", {AArch64::FeatureMTETC}},
     {"gcie", {AArch64::FeatureGCIE}},
     {"sme2p3", {AArch64::FeatureSME2p3}},

--- a/llvm/test/MC/AArch64/armv9.7a-mpamv2-diagnostics.s
+++ b/llvm/test/MC/AArch64/armv9.7a-mpamv2-diagnostics.s
@@ -1,4 +1,4 @@
-// RUN: not llvm-mc -triple=aarch64 -mattr=+mpamv2 -show-encoding < %s 2>&1 \
+// RUN: not llvm-mc -triple=aarch64 -mattr=+mpamv2-deprecated -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 
 //------------------------------------------------------------------------------

--- a/llvm/test/MC/AArch64/armv9.7a-mpamv2.s
+++ b/llvm/test/MC/AArch64/armv9.7a-mpamv2.s
@@ -1,15 +1,15 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+mpamv2 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+mpamv2-deprecated < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+mpamv2 < %s \
-// RUN:        | llvm-objdump -d --mattr=+mpamv2 --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+mpamv2 < %s \
-// RUN:        | llvm-objdump -d --mattr=-mpamv2 --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+mpamv2-deprecated < %s \
+// RUN:        | llvm-objdump -d --mattr=+mpamv2-deprecated --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+mpamv2-deprecated < %s \
+// RUN:        | llvm-objdump -d --mattr=-mpamv2-deprecated --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+mpamv2 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+mpamv2-deprecated < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+mpamv2 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+mpamv2-deprecated -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 //------------------------------------------------------------------------------
@@ -36,18 +36,18 @@ msr MPAMCTL_EL3, x0
 // CHECK-ENCODING: [0x40,0xa5,0x1e,0xd5]
 // CHECK-UNKNOWN: d51ea540
 
-msr MPAMVIDCR_EL2, x0
-// CHECK-INST:    msr     MPAMVIDCR_EL2, x0
+msr MPAM_DEPRECATED_VIDCR_EL2, x0
+// CHECK-INST:    msr     MPAM_DEPRECATED_VIDCR_EL2, x0
 // CHECK-ENCODING: [0x00,0xa7,0x1c,0xd5]
 // CHECK-UNKNOWN: d51ca700
 
-msr MPAMVIDSR_EL2, x0
-// CHECK-INST:    msr     MPAMVIDSR_EL2, x0
+msr MPAM_DEPRECATED_VIDSR_EL2, x0
+// CHECK-INST:    msr     MPAM_DEPRECATED_VIDSR_EL2, x0
 // CHECK-ENCODING: [0x20,0xa7,0x1c,0xd5]
 // CHECK-UNKNOWN: d51ca720
 
-msr MPAMVIDSR_EL3, x0
-// CHECK-INST:    msr     MPAMVIDSR_EL3, x0
+msr MPAM_DEPRECATED_VIDSR_EL3, x0
+// CHECK-INST:    msr     MPAM_DEPRECATED_VIDSR_EL3, x0
 // CHECK-ENCODING: [0x20,0xa7,0x1e,0xd5]
 // CHECK-UNKNOWN: d51ea720
 
@@ -72,18 +72,18 @@ mrs x0, MPAMCTL_EL3
 // CHECK-ENCODING: [0x40,0xa5,0x3e,0xd5]
 // CHECK-UNKNOWN: d53ea540
 
-mrs x0, MPAMVIDCR_EL2
-// CHECK-INST:   mrs     x0, MPAMVIDCR_EL2
+mrs x0, MPAM_DEPRECATED_VIDCR_EL2
+// CHECK-INST:   mrs     x0, MPAM_DEPRECATED_VIDCR_EL2
 // CHECK-ENCODING: [0x00,0xa7,0x3c,0xd5]
 // CHECK-UNKNOWN: d53ca700
 
-mrs x0, MPAMVIDSR_EL2
-// CHECK-INST:   mrs     x0, MPAMVIDSR_EL2
+mrs x0, MPAM_DEPRECATED_VIDSR_EL2
+// CHECK-INST:   mrs     x0, MPAM_DEPRECATED_VIDSR_EL2
 // CHECK-ENCODING: [0x20,0xa7,0x3c,0xd5]
 // CHECK-UNKNOWN: d53ca720
 
-mrs x0, MPAMVIDSR_EL3
-// CHECK-INST:   mrs     x0, MPAMVIDSR_EL3
+mrs x0, MPAM_DEPRECATED_VIDSR_EL3
+// CHECK-INST:   mrs     x0, MPAM_DEPRECATED_VIDSR_EL3
 // CHECK-ENCODING: [0x20,0xa7,0x3e,0xd5]
 // CHECK-UNKNOWN: d53ea720
 

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -1574,7 +1574,7 @@ TEST(TargetParserTest, AArch64ExtensionFeatures) {
   EXPECT_TRUE(llvm::is_contained(Features, "+cmh"));
   EXPECT_TRUE(llvm::is_contained(Features, "+lscp"));
   EXPECT_TRUE(llvm::is_contained(Features, "+tlbid"));
-  EXPECT_TRUE(llvm::is_contained(Features, "+mpamv2"));
+  EXPECT_TRUE(llvm::is_contained(Features, "+mpamv2-deprecated"));
   EXPECT_TRUE(llvm::is_contained(Features, "+mtetc"));
   EXPECT_TRUE(llvm::is_contained(Features, "+gcie"));
   EXPECT_TRUE(llvm::is_contained(Features, "+sme2p3"));
@@ -1755,7 +1755,7 @@ TEST(TargetParserTest, AArch64ArchExtFeature) {
       {"cmh", "nocmh", "+cmh", "-cmh"},
       {"lscp", "nolscp", "+lscp", "-lscp"},
       {"tlbid", "notlbid", "+tlbid", "-tlbid"},
-      {"mpamv2", "nompamv2", "+mpamv2", "-mpamv2"},
+      {"mpamv2-deprecated", "nompamv2-deprecated", "+mpamv2-deprecated", "-mpamv2-deprecated"},
       {"mtetc", "nomtetc", "+mtetc", "-mtetc"},
       {"gcie", "nogcie", "+gcie", "-gcie"},
       {"sme2p3", "nosme2p3", "+sme2p3", "-sme2p3"},


### PR DESCRIPTION
`FEAT_MPAMv2_VID` instructions and system registers, as introduced in change d30f18d2c, are being deprecated at this time, as they've been removed from the latest Arm ARM, which doesn't preclude them returning in some form in future.

Other system registers introduced with `FEAT_MPAMv2` are unaffected, and these continue to be ungated. `+mpamv2` gating is now renamed to `+mpamv2-deprecated`, to avoid an ABI break. This makes it obvious that it shouldn't be used.