### PR TITLE
[clang-tidy] Fix crash in readability-non-const-parameter with redecls

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/NonConstParameterCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/NonConstParameterCheck.cpp
@@ -14,6 +14,15 @@ using namespace clang::ast_matchers;
 
 namespace clang::tidy::readability {
 
+namespace {
+AST_MATCHER_P(VarDecl, hasOwnInitializer, ast_matchers::internal::Matcher<Expr>,
+              InnerMatcher) {
+  const Expr *Initializer = Node.getInit();
+  return Initializer != nullptr &&
+         InnerMatcher.matches(*Initializer, Finder, Builder);
+}
+} // namespace
+
 void NonConstParameterCheck::registerMatchers(MatchFinder *Finder) {
   // Add parameters to Parameters.
   Finder->addMatcher(parmVarDecl().bind("Parm"), this);
@@ -32,7 +41,7 @@ void NonConstParameterCheck::registerMatchers(MatchFinder *Finder) {
                  cxxUnresolvedConstructExpr()))
           .bind("Mark"),
       this);
-  Finder->addMatcher(varDecl(hasInitializer(anything())).bind("Mark"), this);
+  Finder->addMatcher(varDecl(hasOwnInitializer(anything())).bind("Mark"), this);
 }
 
 void NonConstParameterCheck::check(const MatchFinder::MatchResult &Result) {
@@ -104,12 +113,7 @@ void NonConstParameterCheck::check(const MatchFinder::MatchResult &Result) {
   } else if (const auto *VD = Result.Nodes.getNodeAs<VarDecl>("Mark")) {
     const QualType T = VD->getType();
     if (T->isDependentType()) {
-      // Initializer matched by hasInitializer() may be attached to a different
-      // redeclaration.
-      const Expr *Init = VD->getInit();
-      if (!Init)
-        return;
-      Init = Init->IgnoreParenCasts();
+      const Expr *Init = VD->getInit()->IgnoreParenCasts();
       if (const auto *U = dyn_cast<UnaryOperator>(Init);
           U && U->getOpcode() == UO_Deref) {
         markCanNotBeConst(U->getSubExpr(), true);

--- a/clang-tools-extra/clang-tidy/readability/NonConstParameterCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/NonConstParameterCheck.cpp
@@ -104,7 +104,12 @@ void NonConstParameterCheck::check(const MatchFinder::MatchResult &Result) {
   } else if (const auto *VD = Result.Nodes.getNodeAs<VarDecl>("Mark")) {
     const QualType T = VD->getType();
     if (T->isDependentType()) {
-      const Expr *Init = VD->getInit()->IgnoreParenCasts();
+      // Initializer matched by hasInitializer() may be attached to a different
+      // redeclaration.
+      const Expr *Init = VD->getInit();
+      if (!Init)
+        return;
+      Init = Init->IgnoreParenCasts();
       if (const auto *U = dyn_cast<UnaryOperator>(Init);
           U && U->getOpcode() == UO_Deref) {
         markCanNotBeConst(U->getSubExpr(), true);

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -715,6 +715,9 @@ Changes in existing checks
   - Fixed a false positive in array subscript expressions where the types are
     not yet resolved.
 
+  - Fixed a crash when analyzing a redeclaration whose initializer is attached
+    to another declaration.
+
 - Improved :doc:`readability-redundant-casting
   <clang-tidy/checks/readability/redundant-casting>` check by adding the
   `IgnoreImplicitCasts` option (default `false`) to flag casts as redundant

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
@@ -433,3 +433,11 @@ void dependentInitInGenericLambdaMultiArg() {
     DependentCtor2<T> s(p, p);
   };
 }
+
+template <class T>
+struct StaticMemberWithDependentType {
+  static const T X = 0;
+};
+
+template <class T>
+const T StaticMemberWithDependentType<T>::X;

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
@@ -435,9 +435,17 @@ void dependentInitInGenericLambdaMultiArg() {
 }
 
 template <class T>
-struct StaticMemberWithDependentType {
+struct StaticDepInClassInit {
   static const T X = 0;
 };
 
 template <class T>
-const T StaticMemberWithDependentType<T>::X;
+const T StaticDepInClassInit<T>::X;
+
+template <class T>
+struct StaticDepOutOfClassInit {
+  static const T X;
+};
+
+template <class T>
+const T StaticDepOutOfClassInit<T>::X = 0;


### PR DESCRIPTION
The check matches `VarDecls` with `hasInitializer()`, which uses `getAnyInitializer()` and may therefore match a redeclaration whose initializer is attached to another declaration. So calling `IgnoreParenCasts()` on `VD->getInit()` directly would crash when that redeclaration had no initializer of its own.

This commit fixes the problem by using a new matcher that only matches VarDecls with an initializer on the current declaration.

Closes https://github.com/llvm/llvm-project/issues/199197