### PR TITLE
[AMDGPU] Remove _dpp variants from VOPD tables

### DIFF
--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -666,7 +666,7 @@ unsigned getVOPDEncodingFamily(const MCSubtargetInfo &ST) {
 CanBeVOPD getCanBeVOPD(unsigned Opc, unsigned EncodingFamily, bool VOPD3) {
   bool IsConvertibleToBitOp = VOPD3 ? getBitOp2(Opc) : 0;
   Opc = IsConvertibleToBitOp ? (unsigned)AMDGPU::V_BITOP3_B32_e64 : Opc;
-  // Normalize through VOPDComponentTable so that e32, e64 and e64_dpp variants
+  // Normalize through VOPDComponentTable so that e32 and e64 variants
   // of the same logical opcode all share a single entry.
   const VOPDComponentInfo *Info = getVOPDComponentHelper(Opc);
   if (!Info)

--- a/llvm/lib/Target/AMDGPU/VOP2Instructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP2Instructions.td
@@ -166,30 +166,41 @@ multiclass
   defm NAME : VOP2Inst_e32<opName, P, node, revOp>,
               VOPD_Component<VOPDOp, VOPDName>;
 }
+
+multiclass VOP2Inst_e64_base<string opName,
+                             VOPProfile P,
+                             SDPatternOperator node = null_frag,
+                             string revOp = opName> {
+    def _e64 : VOP3InstBase <opName, P, node, 1>,
+               Commutable_REV<revOp#"_e64", !eq(revOp, opName)>;
+}
+
+multiclass VOP2Inst_e64_dpp<string opName, VOPProfile P> {
+  if P.HasExtVOP3DPP then
+    def _e64_dpp : VOP3_DPP_Pseudo <opName, P> {
+      let SubtargetPredicate = isGFX11Plus;
+    }
+  else if P.HasExt64BitDPP then
+    def _e64_dpp : VOP3_DPP_Pseudo <opName, P> {
+      let OtherPredicates = [HasDPALU_DPP];
+    }
+}
+
 multiclass VOP2Inst_e64<string opName,
                         VOPProfile P,
                         SDPatternOperator node = null_frag,
-                        string revOp = opName> {
-    def _e64 : VOP3InstBase <opName, P, node, 1>,
-               Commutable_REV<revOp#"_e64", !eq(revOp, opName)>;
-
-    if P.HasExtVOP3DPP then
-      def _e64_dpp  : VOP3_DPP_Pseudo <opName, P> {
-        let SubtargetPredicate = isGFX11Plus;
-      }
-    else if P.HasExt64BitDPP then
-      def _e64_dpp  : VOP3_DPP_Pseudo <opName, P> {
-        let OtherPredicates = [HasDPALU_DPP];
-      }
-}
+                        string revOp = opName> :
+    VOP2Inst_e64_base<opName, P, node, revOp>,
+    VOP2Inst_e64_dpp<opName, P>;
 
 multiclass VOP2Inst_e64_VOPD<string opName,
                              VOPProfile P, bits<6> VOPDOp,
                              string VOPDName,
                              SDPatternOperator node = null_frag,
-                             string revOp = opName> {
-  defm NAME: VOP2Inst_e64<opName, P, node, revOp>,
-             VOPD_Component<VOPDOp, VOPDName>;
+                             string revOp = opName> :
+    VOP2Inst_e64_dpp<opName, P> {
+  defm NAME : VOP2Inst_e64_base<opName, P, node, revOp>,
+              VOPD_Component<VOPDOp, VOPDName>;
 }
 
 multiclass VOP2Inst_sdwa<string opName,

--- a/llvm/lib/Target/AMDGPU/VOP3Instructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP3Instructions.td
@@ -184,7 +184,7 @@ defm V_FMA_LEGACY_F32 : VOP3Inst <"v_fma_legacy_f32",
 
 defm V_MAD_I32_I24 : VOP3Inst <"v_mad_i32_i24", VOP3_Profile<VOP_I32_I32_I32_I32, VOP3_CLAMP>>;
 defm V_MAD_U32_U24 : VOP3Inst <"v_mad_u32_u24", VOP3_Profile<VOP_I32_I32_I32_I32, VOP3_CLAMP>>;
-defm V_FMA_F32 : VOP3Inst <"v_fma_f32", VOP3_Profile<VOP_F32_F32_F32_F32>, any_fma>, VOPD_Component<0x13, "v_fma_f32">;
+defm V_FMA_F32 : VOP3Inst_VOPD <"v_fma_f32", VOP3_Profile<VOP_F32_F32_F32_F32>, 0x13, "v_fma_f32", any_fma>;
 let SubtargetPredicate = HasLerpInst in
   defm V_LERP_U8 : VOP3Inst <"v_lerp_u8", VOP3_Profile<VOP_I32_I32_I32_I32>, int_amdgcn_lerp>;
 
@@ -200,7 +200,7 @@ let SchedRW = [WriteIntMul] in {
 let SchedRW = [WriteDoubleAdd] in {
 let FPDPRounding = 1 in {
 let IsDPMACCInstruction = 1 in
-defm V_FMA_F64 : VOP3Inst <"v_fma_f64", VOP_F64_F64_F64_F64_DPP_PROF, any_fma>, VOPD_Component<0x20, "v_fma_f64">;
+defm V_FMA_F64 : VOP3Inst_VOPD <"v_fma_f64", VOP_F64_F64_F64_F64_DPP_PROF, 0x20, "v_fma_f64", any_fma>;
 let SubtargetPredicate = isNotGFX12Plus in {
 defm V_ADD_F64 : VOP3Inst <"v_add_f64", VOP3_Profile<VOP_F64_F64_F64>, any_fadd>;
 let IsDPMACCInstruction = 1 in
@@ -1648,9 +1648,9 @@ let OtherPredicates = [HasBitOp3Insts] in {
     let SubtargetPredicate = isGFX1250Plus in
       defm V_BITOP3_B16_gfx1250 : VOP3Inst_t16_with_profiles <"v_bitop3_b16_gfx1250", BitOp3_B16_Profile,
                                     BitOp3_B16_t16_Profile, BitOp3_B16_fake16_Profile>;
-    defm V_BITOP3_B32 : VOP3Inst <"v_bitop3_b32",
-                                  VOP3_BITOP3_Profile<VOPProfile <[i32, i32, i32, i32, i32]>, VOP3_REGULAR>>,
-                        VOPD_Component<0x12, "v_bitop2_b32">;
+    defm V_BITOP3_B32 : VOP3Inst_VOPD <"v_bitop3_b32",
+                                       VOP3_BITOP3_Profile<VOPProfile <[i32, i32, i32, i32, i32]>, VOP3_REGULAR>,
+                                       0x12, "v_bitop2_b32">;
   }
 
   def : GCNPat<

--- a/llvm/lib/Target/AMDGPU/VOPInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOPInstructions.td
@@ -1641,9 +1641,8 @@ class VOP3InstBase<string OpName, VOPProfile P, SDPatternOperator node = null_fr
             ""));
 }
 
-multiclass VOP3Inst<string OpName, VOPProfile P, SDPatternOperator node = null_frag,
-                    list<Predicate> predicates = []> {
-  def _e64 : VOP3InstBase<OpName, P, node>;
+multiclass VOP3Inst_dpp<string OpName, VOPProfile P,
+                        list<Predicate> predicates = []> {
   if P.HasExtVOP3DPP then
     def _e64_dpp  : VOP3_DPP_Pseudo <OpName, P> {
       let SubtargetPredicate = isGFX11Plus;
@@ -1652,6 +1651,21 @@ multiclass VOP3Inst<string OpName, VOPProfile P, SDPatternOperator node = null_f
     def _e64_dpp  : VOP3_DPP_Pseudo <OpName, P> {
       let OtherPredicates = !listconcat(predicates, [HasDPALU_DPP]);
     }
+}
+
+multiclass VOP3Inst<string OpName, VOPProfile P, SDPatternOperator node = null_frag,
+                    list<Predicate> predicates = []> :
+    VOP3Inst_dpp<OpName, P, predicates> {
+  def _e64 : VOP3InstBase<OpName, P, node>;
+}
+
+multiclass VOP3Inst_VOPD<string OpName, VOPProfile P, bits<6> VOPDOp,
+                         string VOPDName,
+                         SDPatternOperator node = null_frag,
+                         list<Predicate> predicates = []> :
+    VOP3Inst_dpp<OpName, P, predicates> {
+  def _e64 : VOP3InstBase<OpName, P, node>,
+             VOPD_Component<VOPDOp, VOPDName>;
 }
 
 class UniformUnaryFragOrOp<SDPatternOperator Op> {


### PR DESCRIPTION
DPP instructions are not eligible to pariticpate in VOPD and will be eventually rejected -- `VOPDComponentTable` size is reduced by 33%. This address a comment from #199072.

Assisted-by: Claude Code