### PR TITLE
[lit] Make MetricValue a proper abstract base class

### DIFF
--- a/llvm/utils/lit/lit/Test.py
+++ b/llvm/utils/lit/lit/Test.py
@@ -1,3 +1,4 @@
+import abc
 import itertools
 import os
 from json import JSONEncoder
@@ -59,7 +60,8 @@ XPASS = ResultCode("XPASS", "Unexpectedly Passed", True)
 # Test metric values.
 
 
-class MetricValue:
+class MetricValue(abc.ABC):
+    @abc.abstractmethod
     def format(self):
         """
         format() -> str
@@ -67,8 +69,8 @@ class MetricValue:
         Convert this metric to a string suitable for displaying as part of the
         console output.
         """
-        raise RuntimeError("abstract method")
 
+    @abc.abstractmethod
     def todata(self):
         """
         todata() -> json-serializable data
@@ -76,7 +78,6 @@ class MetricValue:
         Convert this metric to content suitable for serializing in the JSON test
         output.
         """
-        raise RuntimeError("abstract method")
 
 
 class IntMetricValue(MetricValue):


### PR DESCRIPTION
Currently, `MetricValue` signals abstract methods by raising `RuntimeError("abstract method")` at runtime. This means a subclass that forgets to implement `format()` or `todata()` is only caught when the method is actually called.
This change makes `MetricValue` inherit from `abc.ABC` and decorates `format` and `todata` with `@abc.abstractmethod`. All three existing subclasses (`IntMetricValue`, `RealMetricValue`, `JSONMetricValue`) already implement both methods. No change in behavior.