### PR TITLE
[lit] print shard count of gtests instead of individual tests

### DIFF
--- a/llvm/utils/lit/lit/formats/googletest.py
+++ b/llvm/utils/lit/lit/formats/googletest.py
@@ -286,6 +286,7 @@ class GoogleTest(TestFormat):
         def remove_gtest(tests):
             return [t for t in tests if t.gtest_json_file is None]
 
+        shard_level_tests = list(discovered_tests)
         discovered_tests = remove_gtest(discovered_tests)
         gtests = [t for t in selected_tests if t.gtest_json_file]
         selected_tests = remove_gtest(selected_tests)
@@ -365,4 +366,4 @@ class GoogleTest(TestFormat):
                 selected_tests.append(test)
                 discovered_tests.append(test)
 
-        return selected_tests, discovered_tests
+        return selected_tests, discovered_tests, shard_level_tests

--- a/llvm/utils/lit/lit/main.py
+++ b/llvm/utils/lit/lit/main.py
@@ -133,9 +133,11 @@ def main(builtin_params={}):
     if not opts.skip_test_time_recording:
         record_test_times(selected_tests, lit_config)
 
-    selected_tests, discovered_tests, shard_level_tests = (
-        GoogleTest.post_process_shard_results(selected_tests, discovered_tests)
-    )
+    (
+        selected_tests,
+        discovered_tests,
+        shard_level_tests,
+    ) = GoogleTest.post_process_shard_results(selected_tests, discovered_tests)
 
     if opts.time_tests:
         print_histogram(discovered_tests)

--- a/llvm/utils/lit/lit/main.py
+++ b/llvm/utils/lit/lit/main.py
@@ -133,14 +133,14 @@ def main(builtin_params={}):
     if not opts.skip_test_time_recording:
         record_test_times(selected_tests, lit_config)
 
-    selected_tests, discovered_tests = GoogleTest.post_process_shard_results(
-        selected_tests, discovered_tests
+    selected_tests, discovered_tests, shard_level_tests = (
+        GoogleTest.post_process_shard_results(selected_tests, discovered_tests)
     )
 
     if opts.time_tests:
         print_histogram(discovered_tests)
 
-    print_results(discovered_tests, elapsed, opts)
+    print_results(shard_level_tests, elapsed, opts)
 
     tests_for_report = selected_tests if opts.shard else discovered_tests
     if opts.report_failures_only:

--- a/llvm/utils/lit/tests/googletest-format.py
+++ b/llvm/utils/lit/tests/googletest-format.py
@@ -31,12 +31,6 @@
 # CHECK-NEXT: --
 # CHECK-NEXT: unresolved test result
 # CHECK: ***
-# CHECK: Unresolved Tests (1):
-# CHECK-NEXT:   googletest-format :: [[PATH]][[FILE]]/FirstTest/subTestD
-# CHECK: ***
-# CHECK-NEXT: Failed Tests (1):
-# CHECK-NEXT:   googletest-format :: [[PATH]][[FILE]]/FirstTest/subTestB
-# CHECK: Skipped{{ *}}: 1
-# CHECK: Passed{{ *}}: 3
-# CHECK: Unresolved{{ *}}: 1
+# CHECK: Failed Tests (1):
+# CHECK-NEXT:   googletest-format :: [[PATH]][[FILE]]/0/{{[0-9]+}}
 # CHECK: Failed{{ *}}: 1

--- a/llvm/utils/lit/tests/googletest-no-sharding.py
+++ b/llvm/utils/lit/tests/googletest-no-sharding.py
@@ -30,14 +30,6 @@
 # CHECK-NEXT: [[FILE]] --gtest_filter=FirstTest.subTestD
 # CHECK-NEXT: --
 # CHECK-NEXT: unresolved test result
-# CHECK: ***
-# CHECK: ***
-# CHECK: Unresolved Tests (1):
-# CHECK-NEXT:   googletest-no-sharding :: FirstTest/subTestD
-# CHECK: ***
-# CHECK-NEXT: Failed Tests (1):
-# CHECK-NEXT:   googletest-no-sharding :: FirstTest/subTestB
-# CHECK: Skipped{{ *}}: 1
-# CHECK: Passed{{ *}}: 3
-# CHECK: Unresolved{{ *}}: 1
+# CHECK: Failed Tests (1):
+# CHECK-NEXT:   googletest-no-sharding :: [[PATH]][[FILE]]
 # CHECK: Failed{{ *}}: 1

--- a/llvm/utils/lit/tests/googletest-sanitizer-error.py
+++ b/llvm/utils/lit/tests/googletest-sanitizer-error.py
@@ -1,7 +1,7 @@
 # Check the output is expected when tests pass but sanitizer fails.
-# Note that there is only one shard which has only one sub-test. However, the summary
-# has one pass for the sub-test and one fail for the shard failure due to sanitizer
-# reported errors.
+# Note that there is only one shard which has only one sub-test (subTestA). The shard
+# fails with a non-zero exit code (sanitizer error) even though the sub-test passes.
+# The summary shows only the shard-level result (Failed: 1).
 
 # RUN: not %{lit} -v --order=random %{inputs}/googletest-sanitizer-error > %t.out
 # FIXME: Temporarily dump test output so we can debug failing tests on
@@ -26,6 +26,5 @@
 # CHECK-NEXT: exit: 1
 # CHECK-NEXT: --
 # CHECK:      Failed Tests (1):
-# CHECK-NEXT:   googletest-sanitizer-error :: [[PATH]][[FILE]]/0/1
-# CHECK: Passed{{ *}}: 1
+# CHECK-NEXT:   googletest-sanitizer-error :: [[PATH]][[FILE]]/0/{{[0-9]+}}
 # CHECK: Failed{{ *}}: 1

--- a/llvm/utils/lit/tests/googletest-timeout.py
+++ b/llvm/utils/lit/tests/googletest-timeout.py
@@ -45,7 +45,7 @@
 # RUN: FileCheck --check-prefix=CHECK-QUICK < %t.cmd.out %s
 
 # CHECK-QUICK: PASS: googletest-timeout :: {{[Dd]ummy[Ss]ub[Dd]ir}}/OneTest.py/0/2 {{.*}}
-# CHECK-QUICK: Passed: 1
+# CHECK-QUICK: Passed: 2
 
 # Test per test timeout via a config file and on the command line.
 # The value set on the command line should override the config file.


### PR DESCRIPTION
Lit test results are printed by counting each gtest individually. In the `check-lldb` target, this number dwarfs the number of API and Shell tests. The time histogram on the other hand, keeps shards of gtests to track long running tests.
This patch keeps gtests sharded together in the final tests count.

# Before

```
[build] Slowest Tests:
[build] --------------------------------------------------------------------------
[build] 123.02s: lldb-api :: commands/platform/connect/TestPlatformConnect.py
[build] 99.85s: lldb-api :: functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
[build] 49.40s: lldb-api :: tools/lldb-server/TestLldbGdbServer.py
[build] 34.97s: lldb-api :: commands/statistics/basic/TestStats.py
[build] 32.06s: lldb-api :: functionalities/gdb_remote_client/TestGDBRemoteClient.py
[build] 30.80s: lldb-api :: functionalities/data-formatter/data-formatter-stl/generic/string/TestDataFormatterStdString.py
[build] 22.44s: lldb-api :: functionalities/data-formatter/data-formatter-stl/generic/variant/TestDataFormatterStdVariant.py
[build] 22.34s: lldb-api :: tools/lldb-dap/attach-commands/TestDAP_attachCommands.py
[build] 22.22s: lldb-api :: tools/lldb-server/TestGdbRemote_qThreadStopInfo.py
[build] 21.19s: lldb-api :: functionalities/gdb_remote_client/TestPlatformClient.py
[build] 16.49s: lldb-api :: functionalities/completion/TestCompletion.py
[build] 14.82s: lldb-api :: symstore/TestSymStore.py
[build] 12.91s: lldb-api :: tools/lldb-dap/attach/TestDAP_attach.py
[build] 12.76s: lldb-api :: commands/target/basic/TestTargetCommand.py
[build] 12.74s: lldb-api :: functionalities/data-formatter/data-formatter-stl/generic/span/TestDataFormatterStdSpan.py
[build] 11.14s: lldb-api :: lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
[build] 10.78s: lldb-api :: functionalities/data-formatter/data-formatter-stl/generic/set/TestDataFormatterGenericSet.py
[build] 10.67s: lldb-api :: functionalities/data-formatter/data-formatter-stl/generic/multiset/TestDataFormatterGenericMultiSet.py
[build] 10.65s: lldb-api :: functionalities/data-formatter/data-formatter-stl/generic/deque/TestDataFormatterGenericDeque.py
[build] 10.46s: lldb-api :: tools/lldb-dap/commands/TestDAP_commands.py
[build] 
[build] Tests Times:
[build] --------------------------------------------------------------------------
[build] [   Range   ] :: [               Percentage               ] :: [  Count  ]
[build] --------------------------------------------------------------------------
[build] [120s,130s) :: [                                        ] :: [   1/2464]
[build] [110s,120s) :: [                                        ] :: [   0/2464]
[build] [100s,110s) :: [                                        ] :: [   1/2464]
[build] [ 90s,100s) :: [                                        ] :: [   0/2464]
[build] [ 80s, 90s) :: [                                        ] :: [   0/2464]
[build] [ 70s, 80s) :: [                                        ] :: [   0/2464]
[build] [ 60s, 70s) :: [                                        ] :: [   0/2464]
[build] [ 50s, 60s) :: [                                        ] :: [   1/2464]
[build] [ 40s, 50s) :: [                                        ] :: [   0/2464]
[build] [ 30s, 40s) :: [                                        ] :: [   3/2464]
[build] [ 20s, 30s) :: [                                        ] :: [   4/2464]
[build] [ 10s, 20s) :: [                                        ] :: [  14/2464]
[build] [  0s, 10s) :: [*************************************** ] :: [2440/2464]
[build] --------------------------------------------------------------------------
[build] 
[build] Testing Time: 124.07s
[build] 
[build] Total Discovered Tests: 33877
[build]   Skipped          :    21 (0.06%)
[build]   Unsupported      :   888 (2.62%)
[build]   Passed           : 32867 (97.02%)
[build]   Expectedly Failed:   101 (0.30%)
```

# After

```
[build] Slowest Tests:
[build] --------------------------------------------------------------------------
[build] 122.51s: lldb-api :: commands/platform/connect/TestPlatformConnect.py
[build] 98.00s: lldb-api :: functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
[build] 48.13s: lldb-api :: tools/lldb-server/TestLldbGdbServer.py
[build] 33.62s: lldb-api :: commands/statistics/basic/TestStats.py
[build] 29.63s: lldb-api :: functionalities/data-formatter/data-formatter-stl/generic/string/TestDataFormatterStdString.py
[build] 21.99s: lldb-api :: tools/lldb-dap/attach-commands/TestDAP_attachCommands.py
[build] 21.88s: lldb-api :: functionalities/data-formatter/data-formatter-stl/generic/variant/TestDataFormatterStdVariant.py
[build] 21.85s: lldb-api :: functionalities/gdb_remote_client/TestGDBRemoteClient.py
[build] 21.65s: lldb-api :: tools/lldb-server/TestGdbRemote_qThreadStopInfo.py
[build] 20.82s: lldb-api :: functionalities/gdb_remote_client/TestPlatformClient.py
[build] 15.45s: lldb-api :: functionalities/completion/TestCompletion.py
[build] 14.01s: lldb-api :: symstore/TestSymStore.py
[build] 12.44s: lldb-api :: tools/lldb-dap/attach/TestDAP_attach.py
[build] 12.14s: lldb-api :: commands/target/basic/TestTargetCommand.py
[build] 12.04s: lldb-api :: functionalities/data-formatter/data-formatter-stl/generic/span/TestDataFormatterStdSpan.py
[build] 10.67s: lldb-api :: lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
[build] 10.06s: lldb-api :: functionalities/data-formatter/data-formatter-stl/generic/set/TestDataFormatterGenericSet.py
[build] 10.03s: lldb-api :: functionalities/data-formatter/data-formatter-stl/generic/deque/TestDataFormatterGenericDeque.py
[build] 10.01s: lldb-api :: functionalities/data-formatter/data-formatter-stl/generic/multiset/TestDataFormatterGenericMultiSet.py
[build] 10.00s: lldb-unit :: Process/gdb-remote/./ProcessGdbRemoteTests.exe/GDBRemoteClientBaseTest/InterruptNoResponse
[build] 
[build] Tests Times:
[build] --------------------------------------------------------------------------
[build] [   Range   ] :: [               Percentage               ] :: [  Count  ]
[build] --------------------------------------------------------------------------
[build] [120s,130s) :: [                                        ] :: [   1/2435]
[build] [110s,120s) :: [                                        ] :: [   0/2435]
[build] [100s,110s) :: [                                        ] :: [   1/2435]
[build] [ 90s,100s) :: [                                        ] :: [   0/2435]
[build] [ 80s, 90s) :: [                                        ] :: [   0/2435]
[build] [ 70s, 80s) :: [                                        ] :: [   0/2435]
[build] [ 60s, 70s) :: [                                        ] :: [   0/2435]
[build] [ 50s, 60s) :: [                                        ] :: [   1/2435]
[build] [ 40s, 50s) :: [                                        ] :: [   0/2435]
[build] [ 30s, 40s) :: [                                        ] :: [   2/2435]
[build] [ 20s, 30s) :: [                                        ] :: [   5/2435]
[build] [ 10s, 20s) :: [                                        ] :: [  14/2435]
[build] [  0s, 10s) :: [*************************************** ] :: [2411/2435]
[build] --------------------------------------------------------------------------
[build] 
[build] Testing Time: 123.53s
[build] 
[build] Total Discovered Tests: 3035
[build]   Unsupported      :  888 (29.26%)
[build]   Passed           : 2046 (67.41%)
[build]   Expectedly Failed:  101 (3.33%)
[driver] Build completed: 00:02:18.478
[build] Build finished with exit code 0
```