### PR TITLE
[flang][OpenMP] Fix crash on standalone ordered with depend(source|sink:)

### DIFF
--- a/flang/lib/Lower/OpenMP/Clauses.cpp
+++ b/flang/lib/Lower/OpenMP/Clauses.cpp
@@ -730,7 +730,22 @@ Depend makeDepend(const parser::OmpDependClause::TaskDep &inp,
       m0 ? makeIterator(*m0, semaCtx) : std::optional<Iterator>{};
   return Depend{{/*DependenceType=*/makeDepType(*m1),
                  /*Iterator=*/std::move(maybeIter),
+                 /*Vector=*/std::nullopt,
                  /*LocatorList=*/makeObjects(t1, semaCtx)}};
+}
+
+// depend(source) / depend(sink: vec) on ordered (4.5..5.1 spelling, deprecated
+// in 5.2 in favor of the dedicated doacross clause). Internally modelled as a
+// Depend with the optional iteration Vector populated and an empty
+// LocatorList, mirroring the shape of Doacross.
+Depend makeDependDoacross(const parser::OmpDoacross &doa,
+                          semantics::SemanticsContext &semaCtx) {
+  Doacross doacross = makeDoacross(doa, semaCtx);
+  return Depend{
+      {/*DependenceType=*/std::get<Doacross::DependenceType>(doacross.t),
+       /*Iterator=*/std::nullopt,
+       /*Vector=*/std::get<Doacross::Vector>(std::move(doacross.t)),
+       /*LocatorList=*/{}}};
 }
 
 // Depobj: empty
@@ -1733,8 +1748,14 @@ Clause makeClause(const parser::OmpClause &cls,
               return makeClause(llvm::omp::Clause::OMPC_depend,
                                 clause::makeDepend(*dep, semaCtx), cls.source);
             } else if (auto *doa = std::get_if<parser::OmpDoacross>(&s.v.u)) {
-              return makeClause(llvm::omp::Clause::OMPC_doacross,
-                                clause::makeDoacross(*doa, semaCtx),
+              // depend(source) / depend(sink:) on ordered is the
+              // 4.5 - 5.1 spelling of what 5.2 renamed to the doacross
+              // clause. Represent it as OMPC_depend (the surface clause is
+              // depend) rather than rewriting to OMPC_doacross, otherwise
+              // construct decomposition rejects the clause at OpenMP < 5.2
+              // even though the construct itself is valid since 4.5.
+              return makeClause(llvm::omp::Clause::OMPC_depend,
+                                clause::makeDependDoacross(*doa, semaCtx),
                                 cls.source);
             } else {
               llvm_unreachable("Unexpected alternative");

--- a/flang/test/Lower/OpenMP/Todo/ordered-depend.f90
+++ b/flang/test/Lower/OpenMP/Todo/ordered-depend.f90
@@ -1,0 +1,20 @@
+!RUN: %not_todo_cmd %flang_fc1 -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck %s
+
+! Issue #198972: a standalone ordered construct using the (pre-5.2)
+! depend(source) / depend(sink:) spelling must reach the "not yet
+! implemented" path instead of crashing during construct decomposition. The
+! depend(source|sink:) spelling is represented internally as a doacross
+! clause, which decomposition only accepts from OpenMP 5.2, while the construct
+! itself is valid (using this spelling) since OpenMP 4.5.
+
+!CHECK: not yet implemented: OMPD_ordered
+subroutine f00
+  integer :: i
+  !$omp do ordered(1)
+  do i = 1, 10
+    !$omp ordered depend(source)
+    !$omp ordered depend(sink: i - 1)
+  end do
+  !$omp end do
+end
+

--- a/llvm/include/llvm/Frontend/OpenMP/ClauseT.h
+++ b/llvm/include/llvm/Frontend/OpenMP/ClauseT.h
@@ -533,10 +533,16 @@ struct DependT {
   using Iterator = type::IteratorT<T, I, E>;
   using LocatorList = ObjectListT<I, E>;
   using DependenceType = tomp::type::DependenceType;
+  // For the (pre-5.2) doacross spelling of the depend clause on the
+  // ordered directive: depend(source) / depend(sink: vec). Empty Vector
+  // means omp_cur_iteration, matching DoacrossT::Vector. When Vector has a
+  // value, LocatorList must be empty and the dependence type must be Source or
+  // Sink.
+  using Vector = ListT<type::LoopIterationT<I, E>>;
 
   using TupleTrait = std::true_type;
   // Empty LocatorList means "omp_all_memory".
-  std::tuple<DependenceType, OPT(Iterator), LocatorList> t;
+  std::tuple<DependenceType, OPT(Iterator), OPT(Vector), LocatorList> t;
 };
 
 // [tr14:212-213]


### PR DESCRIPTION
A standalone ordered construct using the pre-OpenMP 5.2 depend(source) / depend(sink:) spelling crashed flang with an assertion failure in buildConstructQueue ("Construct decomposition failed"), or emitted a TODO when assertions were disabled.

These dependence types are valid on ordered since OpenMP 4.5, but flang represents them internally as a doacross clause, which construct decomposition only accepts from OpenMP 5.2. As a result, decomposition produced an empty output and tripped the assertion at every OpenMP version below 5.2 (including the default 3.1).

Lowering of the standalone ordered directive is not implemented yet (genOrderedOp only emits a "not yet implemented" message and ignores the construct queue). Build the construct queue only for the block-associated variant and emit the TODO directly for the standalone directive, so the decomposition that would otherwise assert is no longer reached.

Note: at versions below 4.5 the construct is technically invalid, but flang's semantics accepts it silently. Making semantics emit a "requires OpenMP 4.5" error/warning is probably a good idea.

Fixes #198972