### PR TITLE
[CI] Add precommit CIs to test compiler-rt + LLVM libc integration.

### DIFF
--- a/.github/workflows/compiler-rt-libc-builtins-tests.yml
+++ b/.github/workflows/compiler-rt-libc-builtins-tests.yml
@@ -1,0 +1,58 @@
+# Pre-commit CI for the compiler-rt + LLVM-libc builtins integration.
+name: compiler-rt + libc Builtins Tests
+permissions:
+  contents: read
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "compiler-rt/lib/builtins/**"
+      - "compiler-rt/test/builtins/**"
+      - "libc/shared/builtins.h"
+      - "libc/shared/builtins/**"
+      - "libc/src/__support/builtins/**"
+      - "libc/src/__support/FPUtil/**"
+      - ".github/workflows/compiler-rt-libc-builtins-tests.yml"
+
+jobs:
+  build:
+    name: builtins (${{ matrix.os }})
+    if: github.repository_owner == 'llvm'
+    runs-on: ${{ matrix.os }}
+    container:
+      image: ${{ (startsWith(matrix.os, 'ubuntu-24.04-arm') && 'ghcr.io/llvm/arm64v8/libc-ubuntu-24.04') || 'ghcr.io/llvm/libc-ubuntu-24.04' }}
+      options: >-
+        --privileged
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Configure CMake
+        shell: bash
+        run: |
+          cmake \
+            -B build \
+            -S llvm \
+            -G Ninja \
+            -DCMAKE_C_COMPILER=clang-23 \
+            -DCMAKE_CXX_COMPILER=clang++-23 \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLLVM_ENABLE_ASSERTIONS=ON \
+            -DLLVM_ENABLE_PROJECTS=clang \
+            -DLLVM_ENABLE_RUNTIMES="compiler-rt" \
+            -DCOMPILER_RT_USE_LIBC_MATH=ON \
+            -DCOMPILER_RT_INCLUDE_TESTS=ON
+
+      - name: Test compiler-rt builtins
+        shell: bash
+        run: |
+          cmake \
+            --build build \
+            --parallel \
+            --target check-builtins

--- a/.github/workflows/compiler-rt-libc-builtins-tests.yml
+++ b/.github/workflows/compiler-rt-libc-builtins-tests.yml
@@ -4,7 +4,6 @@ permissions:
   contents: read
 on:
   pull_request:
-    branches: ["main"]
     paths:
       - "compiler-rt/lib/builtins/**"
       - "compiler-rt/test/builtins/**"

--- a/.github/workflows/compiler-rt-libc-builtins-tests.yml
+++ b/.github/workflows/compiler-rt-libc-builtins-tests.yml
@@ -34,13 +34,14 @@ jobs:
         run: |
           cmake \
             -B build \
-            -S compiler-rt \
+            -S llvm \
             -G Ninja \
             -DCMAKE_C_COMPILER=clang-23 \
             -DCMAKE_CXX_COMPILER=clang++-23 \
             -DCMAKE_BUILD_TYPE=Release \
             -DLLVM_ENABLE_ASSERTIONS=ON \
             -DCOMPILER_RT_STANDALONE_BUILD=ON \
+            -DLLVM_ENABLE_PROJECTS="compiler-rt" \
             -DCOMPILER_RT_USE_LIBC_MATH=ON \
             -DCOMPILER_RT_INCLUDE_TESTS=ON
 

--- a/.github/workflows/compiler-rt-libc-builtins-tests.yml
+++ b/.github/workflows/compiler-rt-libc-builtins-tests.yml
@@ -34,14 +34,13 @@ jobs:
         run: |
           cmake \
             -B build \
-            -S llvm \
+            -S compiler-rt \
             -G Ninja \
             -DCMAKE_C_COMPILER=clang-23 \
             -DCMAKE_CXX_COMPILER=clang++-23 \
             -DCMAKE_BUILD_TYPE=Release \
             -DLLVM_ENABLE_ASSERTIONS=ON \
-            -DCOMPILER_RT_STANDALONE_BUILD=On \
-            -DLLVM_ENABLE_RUNTIMES="compiler-rt" \
+            -DCOMPILER_RT_STANDALONE_BUILD=ON \
             -DCOMPILER_RT_USE_LIBC_MATH=ON \
             -DCOMPILER_RT_INCLUDE_TESTS=ON
 

--- a/.github/workflows/compiler-rt-libc-builtins-tests.yml
+++ b/.github/workflows/compiler-rt-libc-builtins-tests.yml
@@ -20,8 +20,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     container:
       image: ${{ (startsWith(matrix.os, 'ubuntu-24.04-arm') && 'ghcr.io/llvm/arm64v8/libc-ubuntu-24.04') || 'ghcr.io/llvm/libc-ubuntu-24.04' }}
-      options: >-
-        --privileged
     strategy:
       fail-fast: false
       matrix:
@@ -33,7 +31,6 @@ jobs:
           persist-credentials: false
 
       - name: Configure CMake
-        shell: bash
         run: |
           cmake \
             -B build \
@@ -43,13 +40,12 @@ jobs:
             -DCMAKE_CXX_COMPILER=clang++-23 \
             -DCMAKE_BUILD_TYPE=Release \
             -DLLVM_ENABLE_ASSERTIONS=ON \
-            -DLLVM_ENABLE_PROJECTS=clang \
+            -DCOMPILER_RT_STANDALONE_BUILD=On \
             -DLLVM_ENABLE_RUNTIMES="compiler-rt" \
             -DCOMPILER_RT_USE_LIBC_MATH=ON \
             -DCOMPILER_RT_INCLUDE_TESTS=ON
 
       - name: Test compiler-rt builtins
-        shell: bash
         run: |
           cmake \
             --build build \

--- a/.github/workflows/compiler-rt-libc-builtins-tests.yml
+++ b/.github/workflows/compiler-rt-libc-builtins-tests.yml
@@ -34,7 +34,8 @@ jobs:
         run: |
           cmake \
             -B build \
-            -S compiler-rt \
+            -S runtimes \
+            -DLLVM_ENABLE_RUNTIMES=compiler-rt \
             -G Ninja \
             -DCMAKE_C_COMPILER=clang-23 \
             -DCMAKE_CXX_COMPILER=clang++-23 \

--- a/.github/workflows/compiler-rt-libc-builtins-tests.yml
+++ b/.github/workflows/compiler-rt-libc-builtins-tests.yml
@@ -43,6 +43,7 @@ jobs:
             -DLLVM_ENABLE_ASSERTIONS=ON \
             -DCOMPILER_RT_STANDALONE_BUILD=ON \
             -DCOMPILER_RT_USE_LIBC_MATH=ON \
+            -DLIT_EXECUTABLE=$(which lit-23) \
             -DCOMPILER_RT_INCLUDE_TESTS=ON
 
       - name: Test compiler-rt builtins

--- a/.github/workflows/compiler-rt-libc-builtins-tests.yml
+++ b/.github/workflows/compiler-rt-libc-builtins-tests.yml
@@ -43,7 +43,7 @@ jobs:
             -DLLVM_ENABLE_ASSERTIONS=ON \
             -DCOMPILER_RT_STANDALONE_BUILD=ON \
             -DCOMPILER_RT_USE_LIBC_MATH=ON \
-            -DLIT_EXECUTABLE=$(which lit-23) \
+            -DLLVM_EXTERNAL_LIT=$(which lit-23) \
             -DCOMPILER_RT_INCLUDE_TESTS=ON
 
       - name: Test compiler-rt builtins

--- a/.github/workflows/compiler-rt-libc-builtins-tests.yml
+++ b/.github/workflows/compiler-rt-libc-builtins-tests.yml
@@ -34,14 +34,13 @@ jobs:
         run: |
           cmake \
             -B build \
-            -S llvm \
+            -S compiler-rt \
             -G Ninja \
             -DCMAKE_C_COMPILER=clang-23 \
             -DCMAKE_CXX_COMPILER=clang++-23 \
             -DCMAKE_BUILD_TYPE=Release \
             -DLLVM_ENABLE_ASSERTIONS=ON \
             -DCOMPILER_RT_STANDALONE_BUILD=ON \
-            -DLLVM_ENABLE_PROJECTS="compiler-rt" \
             -DCOMPILER_RT_USE_LIBC_MATH=ON \
             -DCOMPILER_RT_INCLUDE_TESTS=ON
 


### PR DESCRIPTION
Add Pre-commit CI to test compiler-rt builtins with libc to check it works without issues

Split from #197950

Part of #197824