### PR TITLE
[AArch64] Generate umaddl and smaddl from disjoint or

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -2858,7 +2858,7 @@ multiclass MulAccum<bit isSub, string asm> {
 }
 
 class WideMulAccum<bit isSub, bits<3> opc, string asm,
-                   SDNode AccNode, SDNode ExtNode>
+                   SDPatternOperator AccNode, SDNode ExtNode>
   : BaseMulAccum<isSub, opc, GPR32, GPR64, asm,
     [(set GPR64:$Rd, (AccNode GPR64:$Ra,
                             (mul (ExtNode GPR32:$Rn), (ExtNode GPR32:$Rm))))]>,

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -2888,9 +2888,9 @@ def : Pat<(i64 (mul (ineg GPR64:$Rn), GPR64:$Rm)),
 } // AddedComplexity = 5
 
 let AddedComplexity = 5 in {
-def SMADDLrrr : WideMulAccum<0, 0b001, "smaddl", add, sext>;
+def SMADDLrrr : WideMulAccum<0, 0b001, "smaddl", add_like, sext>;
 def SMSUBLrrr : WideMulAccum<1, 0b001, "smsubl", sub, sext>;
-def UMADDLrrr : WideMulAccum<0, 0b101, "umaddl", add, zext>;
+def UMADDLrrr : WideMulAccum<0, 0b101, "umaddl", add_like, zext>;
 def UMSUBLrrr : WideMulAccum<1, 0b101, "umsubl", sub, zext>;
 
 def : Pat<(i64 (mul (sext_inreg GPR64:$Rn, i32), (sext_inreg GPR64:$Rm, i32))),
@@ -2927,11 +2927,11 @@ def : Pat<(i64 (ineg (mul (sext_inreg GPR64:$Rn, i32), (s64imm_32bit:$C)))),
           (SMSUBLrrr (i32 (EXTRACT_SUBREG GPR64:$Rn, sub_32)),
                      (MOVi32imm (trunc_imm imm:$C)), XZR)>;
 
-def : Pat<(i64 (add (mul (sext GPR32:$Rn), (s64imm_32bit:$C)), GPR64:$Ra)),
+def : Pat<(i64 (add_like (mul (sext GPR32:$Rn), (s64imm_32bit:$C)), GPR64:$Ra)),
           (SMADDLrrr GPR32:$Rn, (MOVi32imm (trunc_imm imm:$C)), GPR64:$Ra)>;
-def : Pat<(i64 (add (mul (zext GPR32:$Rn), (i64imm_32bit:$C)), GPR64:$Ra)),
+def : Pat<(i64 (add_like (mul (zext GPR32:$Rn), (i64imm_32bit:$C)), GPR64:$Ra)),
           (UMADDLrrr GPR32:$Rn, (MOVi32imm (trunc_imm imm:$C)), GPR64:$Ra)>;
-def : Pat<(i64 (add (mul (sext_inreg GPR64:$Rn, i32), (s64imm_32bit:$C)),
+def : Pat<(i64 (add_like (mul (sext_inreg GPR64:$Rn, i32), (s64imm_32bit:$C)),
                     GPR64:$Ra)),
           (SMADDLrrr (i32 (EXTRACT_SUBREG GPR64:$Rn, sub_32)),
                      (MOVi32imm (trunc_imm imm:$C)), GPR64:$Ra)>;
@@ -2950,9 +2950,9 @@ def : Pat<(i64 (smullwithsignbits GPR64:$Rn, GPR64:$Rm)),
 def : Pat<(i64 (smullwithsignbits GPR64:$Rn, (sext GPR32:$Rm))),
           (SMADDLrrr (EXTRACT_SUBREG GPR64:$Rn, sub_32), $Rm, XZR)>;
 
-def : Pat<(i64 (add (smullwithsignbits GPR64:$Rn, GPR64:$Rm), GPR64:$Ra)),
+def : Pat<(i64 (add_like (smullwithsignbits GPR64:$Rn, GPR64:$Rm), GPR64:$Ra)),
           (SMADDLrrr (EXTRACT_SUBREG GPR64:$Rn, sub_32), (EXTRACT_SUBREG GPR64:$Rm, sub_32), GPR64:$Ra)>;
-def : Pat<(i64 (add (smullwithsignbits GPR64:$Rn, (sext GPR32:$Rm)), GPR64:$Ra)),
+def : Pat<(i64 (add_like (smullwithsignbits GPR64:$Rn, (sext GPR32:$Rm)), GPR64:$Ra)),
           (SMADDLrrr (EXTRACT_SUBREG GPR64:$Rn, sub_32), $Rm, GPR64:$Ra)>;
 
 def : Pat<(i64 (ineg (smullwithsignbits GPR64:$Rn, GPR64:$Rm))),
@@ -2970,9 +2970,9 @@ def : Pat<(i64 (mul top32Zero:$Rn, top32Zero:$Rm)),
 def : Pat<(i64 (mul top32Zero:$Rn, (zext GPR32:$Rm))),
           (UMADDLrrr (EXTRACT_SUBREG GPR64:$Rn, sub_32), $Rm, XZR)>;
 
-def : Pat<(i64 (add (mul top32Zero:$Rn, top32Zero:$Rm), GPR64:$Ra)),
+def : Pat<(i64 (add_like (mul top32Zero:$Rn, top32Zero:$Rm), GPR64:$Ra)),
           (UMADDLrrr (EXTRACT_SUBREG GPR64:$Rn, sub_32), (EXTRACT_SUBREG GPR64:$Rm, sub_32), GPR64:$Ra)>;
-def : Pat<(i64 (add (mul top32Zero:$Rn, (zext GPR32:$Rm)), GPR64:$Ra)),
+def : Pat<(i64 (add_like (mul top32Zero:$Rn, (zext GPR32:$Rm)), GPR64:$Ra)),
           (UMADDLrrr (EXTRACT_SUBREG GPR64:$Rn, sub_32), $Rm, GPR64:$Ra)>;
 
 def : Pat<(i64 (ineg (mul top32Zero:$Rn, top32Zero:$Rm))),

--- a/llvm/test/CodeGen/AArch64/aarch64-mull-masks.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-mull-masks.ll
@@ -1532,8 +1532,7 @@ define i64 @pr137274(ptr %ptr) {
 define i64 @umaddl_or(i32 %a, i32 %b, i64 %c) {
 ; CHECK-LABEL: umaddl_or:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    umull x8, w0, w1
-; CHECK-NEXT:    orr x0, x8, x2
+; CHECK-NEXT:    umaddl x0, w0, w1, x2
 ; CHECK-NEXT:    ret
 entry:
   %ae = zext i32 %a to i64
@@ -1546,8 +1545,7 @@ entry:
 define i64 @smaddl_or(i32 %a, i32 %b, i64 %c) {
 ; CHECK-LABEL: smaddl_or:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    smull x8, w0, w1
-; CHECK-NEXT:    orr x0, x8, x2
+; CHECK-NEXT:    smaddl x0, w0, w1, x2
 ; CHECK-NEXT:    ret
 entry:
   %ae = sext i32 %a to i64
@@ -1561,8 +1559,7 @@ define i64 @umaddl_or_3(i32 %a, i32 %b, i64 %c) {
 ; CHECK-LABEL: umaddl_or_3:
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    mov w8, #23 // =0x17
-; CHECK-NEXT:    umull x8, w0, w8
-; CHECK-NEXT:    orr x0, x8, x2
+; CHECK-NEXT:    umaddl x0, w0, w8, x2
 ; CHECK-NEXT:    ret
 entry:
   %ae = zext i32 %a to i64
@@ -1575,8 +1572,7 @@ define i64 @smaddl_or_inreg3(i64 %a, i32 %b, i64 %c) {
 ; CHECK-LABEL: smaddl_or_inreg3:
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    mov w8, #23 // =0x17
-; CHECK-NEXT:    smull x8, w0, w8
-; CHECK-NEXT:    orr x0, x8, x2
+; CHECK-NEXT:    smaddl x0, w0, w8, x2
 ; CHECK-NEXT:    ret
 entry:
   %at = trunc i64 %a to i32
@@ -1590,8 +1586,7 @@ define i64 @umaddl_ldrb_h_or(ptr %x0, i32 %x1, i64 %x2) {
 ; CHECK-LABEL: umaddl_ldrb_h_or:
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    ldrb w8, [x0]
-; CHECK-NEXT:    umull x8, w8, w1
-; CHECK-NEXT:    orr x0, x8, x2
+; CHECK-NEXT:    umaddl x0, w8, w1, x2
 ; CHECK-NEXT:    ret
 entry:
   %ext64 = load i8, ptr %x0
@@ -1606,8 +1601,7 @@ define i64 @smaddl_ldrb_h_or(ptr %x0, i32 %x1, i64 %x2) {
 ; CHECK-LABEL: smaddl_ldrb_h_or:
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    ldrsb x8, [x0]
-; CHECK-NEXT:    smull x8, w8, w1
-; CHECK-NEXT:    orr x0, x8, x2
+; CHECK-NEXT:    smaddl x0, w8, w1, x2
 ; CHECK-NEXT:    ret
 entry:
   %ext64 = load i8, ptr %x0
@@ -1623,8 +1617,7 @@ define i64 @umaddl_ldrb2_or(ptr %x0, ptr %x1, i64 %x2) {
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    ldrb w8, [x0]
 ; CHECK-NEXT:    ldrb w9, [x1]
-; CHECK-NEXT:    umull x8, w9, w8
-; CHECK-NEXT:    orr x0, x8, x2
+; CHECK-NEXT:    umaddl x0, w9, w8, x2
 ; CHECK-NEXT:    ret
 entry:
   %ext64 = load i8, ptr %x0
@@ -1641,8 +1634,7 @@ define i64 @smaddl_ldrb2_or(ptr %x0, ptr %x1, i64 %x2) {
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    ldrsb x8, [x0]
 ; CHECK-NEXT:    ldrsb x9, [x1]
-; CHECK-NEXT:    smull x8, w9, w8
-; CHECK-NEXT:    orr x0, x8, x2
+; CHECK-NEXT:    smaddl x0, w9, w8, x2
 ; CHECK-NEXT:    ret
 entry:
   %ext64 = load i8, ptr %x0


### PR DESCRIPTION
Similar to other patches recently, this adds add_like handling to the tablegen patterns for smaddl and umaddl, allowing them to match from disjoint or.