### PR TITLE
[CI] Add 'lld' to LLVM projects in build script for lldb windows bot

### DIFF
--- a/.ci/green-dragon/lldb-windows.groovy
+++ b/.ci/green-dragon/lldb-windows.groovy
@@ -57,7 +57,7 @@ cmake -G Ninja ^
     -DCMAKE_BUILD_TYPE=%BUILD_TYPE% ^
     -DCMAKE_INSTALL_PREFIX=..\\llvm-install\\base ^
     -DCMAKE_TOOLCHAIN_FILE=C:\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake ^
-    -DLLVM_ENABLE_PROJECTS="clang;lldb" ^
+    -DLLVM_ENABLE_PROJECTS="clang;lld;lldb" ^
     -DLLVM_ENABLE_ASSERTIONS=ON ^
     -DLLVM_ENABLE_LIBEDIT=OFF ^
     -DLLVM_OPTIMIZED_TABLEGEN=ON ^


### PR DESCRIPTION
Multiple LLDB tests are failing on green dragon. 

```
[2026-05-28T14:37:53.700Z] Traceback (most recent call last):

[2026-05-28T14:37:53.700Z]   File "C:\workspace\llvm-project\lldb\test\API\dotest.py", line 8, in <module>

[2026-05-28T14:37:53.700Z]     lldbsuite.test.run_suite()

[2026-05-28T14:37:53.700Z]     ~~~~~~~~~~~~~~~~~~~~~~~~^^

[2026-05-28T14:37:53.700Z]   File "C:\workspace\llvm-project\lldb\packages\Python\lldbsuite\test\dotest.py", line 1042, in run_suite

[2026-05-28T14:37:53.700Z]     import lldb

[2026-05-28T14:37:53.700Z]   File "C:\workspace\llvm-build\Lib\site-packages\lldb\__init__.py", line 47, in <module>

[2026-05-28T14:37:53.700Z]     from .native import _lldb

[2026-05-28T14:37:53.700Z] ImportError: DLL load failed while importing _lldb: The specified module could not be found.
```