### PR TITLE
[clang-format] Configure ASSIGN_OR_RETURN macros for Google style

### DIFF
--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -2101,6 +2101,20 @@ FormatStyle getGoogleStyle(FormatStyle::LanguageKind Language) {
   GoogleStyle.IncludeStyle.IncludeIsMainRegex = "([-_](test|unittest))?$";
   GoogleStyle.IndentCaseLabels = true;
   GoogleStyle.KeepEmptyLines.AtStartOfBlock = false;
+
+  GoogleStyle.Macros.push_back("ASSIGN_OR_RETURN(a, b)=a = (b)");
+  GoogleStyle.Macros.push_back(
+      "ASSIGN_OR_RETURN(a, b, c)=a = (b); if (x) return c");
+  GoogleStyle.Macros.push_back("RETURN_IF_ERROR(expr)=if (x) return expr");
+  GoogleStyle.Macros.push_back(
+      "ASSERT_OK_AND_ASSIGN(lhs, rexpr)=lhs = (rexpr)");
+  GoogleStyle.Macros.push_back("ABSL_ASSIGN_OR_RETURN(a, b)=a = (b)");
+  GoogleStyle.Macros.push_back(
+      "ABSL_ASSIGN_OR_RETURN(a, b, c)=a = (b); if (x) return c");
+  GoogleStyle.Macros.push_back("ABSL_RETURN_IF_ERROR(expr)=if (x) return expr");
+  GoogleStyle.Macros.push_back(
+      "ABSL_ASSERT_OK_AND_ASSIGN(lhs, rexpr)=lhs = (rexpr)");
+
   GoogleStyle.ObjCBinPackProtocolList = FormatStyle::BPS_Never;
   GoogleStyle.ObjCSpaceAfterProperty = false;
   GoogleStyle.ObjCSpaceBeforeProtocolList = true;

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -2102,18 +2102,16 @@ FormatStyle getGoogleStyle(FormatStyle::LanguageKind Language) {
   GoogleStyle.IndentCaseLabels = true;
   GoogleStyle.KeepEmptyLines.AtStartOfBlock = false;
 
-  GoogleStyle.Macros.push_back("ASSIGN_OR_RETURN(a, b)=a = (b)");
-  GoogleStyle.Macros.push_back(
-      "ASSIGN_OR_RETURN(a, b, c)=a = (b); if (x) return c");
-  GoogleStyle.Macros.push_back("RETURN_IF_ERROR(expr)=if (x) return expr");
-  GoogleStyle.Macros.push_back(
-      "ASSERT_OK_AND_ASSIGN(lhs, rexpr)=lhs = (rexpr)");
-  GoogleStyle.Macros.push_back("ABSL_ASSIGN_OR_RETURN(a, b)=a = (b)");
-  GoogleStyle.Macros.push_back(
-      "ABSL_ASSIGN_OR_RETURN(a, b, c)=a = (b); if (x) return c");
-  GoogleStyle.Macros.push_back("ABSL_RETURN_IF_ERROR(expr)=if (x) return expr");
-  GoogleStyle.Macros.push_back(
-      "ABSL_ASSERT_OK_AND_ASSIGN(lhs, rexpr)=lhs = (rexpr)");
+  GoogleStyle.Macros = {
+      "ASSIGN_OR_RETURN(a, b)=a = (b)",
+      "ASSIGN_OR_RETURN(a, b, c)=a = (b); if (x) return c",
+      "RETURN_IF_ERROR(expr)=if (x) return expr",
+      "ASSERT_OK_AND_ASSIGN(lhs, rexpr)=lhs = (rexpr)",
+      "ABSL_ASSIGN_OR_RETURN(a, b)=a = (b)",
+      "ABSL_ASSIGN_OR_RETURN(a, b, c)=a = (b); if (x) return c",
+      "ABSL_RETURN_IF_ERROR(expr)=if (x) return expr",
+      "ABSL_ASSERT_OK_AND_ASSIGN(lhs, rexpr)=lhs = (rexpr)",
+  };
 
   GoogleStyle.ObjCBinPackProtocolList = FormatStyle::BPS_Never;
   GoogleStyle.ObjCSpaceAfterProperty = false;

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -1099,6 +1099,20 @@ TEST(ConfigParseTest, ParsesConfiguration) {
               StatementAttributeLikeMacros,
               std::vector<std::string>({"emit", "Q_EMIT"}));
 
+  Style.Macros.clear();
+  CHECK_PARSE("{Macros: [foo]}", Macros, std::vector<std::string>({"foo"}));
+  std::vector<std::string> GoogleMacros;
+  GoogleMacros.push_back("ASSIGN_OR_RETURN(a, b)=a = (b)");
+  GoogleMacros.push_back("ASSIGN_OR_RETURN(a, b, c)=a = (b); if (x) return c");
+  GoogleMacros.push_back("RETURN_IF_ERROR(expr)=if (x) return expr");
+  GoogleMacros.push_back("ASSERT_OK_AND_ASSIGN(lhs, rexpr)=lhs = (rexpr)");
+  GoogleMacros.push_back("ABSL_ASSIGN_OR_RETURN(a, b)=a = (b)");
+  GoogleMacros.push_back(
+      "ABSL_ASSIGN_OR_RETURN(a, b, c)=a = (b); if (x) return c");
+  GoogleMacros.push_back("ABSL_RETURN_IF_ERROR(expr)=if (x) return expr");
+  GoogleMacros.push_back("ABSL_ASSERT_OK_AND_ASSIGN(lhs, rexpr)=lhs = (rexpr)");
+  CHECK_PARSE("BasedOnStyle: Google", Macros, GoogleMacros);
+
   Style.StatementMacros.clear();
   CHECK_PARSE("StatementMacros: [QUNUSED]", StatementMacros,
               std::vector<std::string>{"QUNUSED"});
@@ -1106,7 +1120,6 @@ TEST(ConfigParseTest, ParsesConfiguration) {
               std::vector<std::string>({"QUNUSED", "QT_REQUIRE_VERSION"}));
 
   CHECK_PARSE_LIST(JavaImportGroups);
-  CHECK_PARSE_LIST(Macros);
   CHECK_PARSE_LIST(MacrosSkippedByRemoveParentheses);
   CHECK_PARSE_LIST(NamespaceMacros);
   CHECK_PARSE_LIST(ObjCPropertyAttributeOrder);

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -1099,20 +1099,6 @@ TEST(ConfigParseTest, ParsesConfiguration) {
               StatementAttributeLikeMacros,
               std::vector<std::string>({"emit", "Q_EMIT"}));
 
-  Style.Macros.clear();
-  CHECK_PARSE("{Macros: [foo]}", Macros, std::vector<std::string>({"foo"}));
-  std::vector<std::string> GoogleMacros;
-  GoogleMacros.push_back("ASSIGN_OR_RETURN(a, b)=a = (b)");
-  GoogleMacros.push_back("ASSIGN_OR_RETURN(a, b, c)=a = (b); if (x) return c");
-  GoogleMacros.push_back("RETURN_IF_ERROR(expr)=if (x) return expr");
-  GoogleMacros.push_back("ASSERT_OK_AND_ASSIGN(lhs, rexpr)=lhs = (rexpr)");
-  GoogleMacros.push_back("ABSL_ASSIGN_OR_RETURN(a, b)=a = (b)");
-  GoogleMacros.push_back(
-      "ABSL_ASSIGN_OR_RETURN(a, b, c)=a = (b); if (x) return c");
-  GoogleMacros.push_back("ABSL_RETURN_IF_ERROR(expr)=if (x) return expr");
-  GoogleMacros.push_back("ABSL_ASSERT_OK_AND_ASSIGN(lhs, rexpr)=lhs = (rexpr)");
-  CHECK_PARSE("BasedOnStyle: Google", Macros, GoogleMacros);
-
   Style.StatementMacros.clear();
   CHECK_PARSE("StatementMacros: [QUNUSED]", StatementMacros,
               std::vector<std::string>{"QUNUSED"});
@@ -1120,6 +1106,10 @@ TEST(ConfigParseTest, ParsesConfiguration) {
               std::vector<std::string>({"QUNUSED", "QT_REQUIRE_VERSION"}));
 
   CHECK_PARSE_LIST(JavaImportGroups);
+  // Clear Macros populated as a side effect of the BasedOnStyle: Google test
+  // for AttributeMacros above.
+  Style.Macros.clear();
+  CHECK_PARSE_LIST(Macros);
   CHECK_PARSE_LIST(MacrosSkippedByRemoveParentheses);
   CHECK_PARSE_LIST(NamespaceMacros);
   CHECK_PARSE_LIST(ObjCPropertyAttributeOrder);

--- a/clang/unittests/Format/FormatTestMacroExpansion.cpp
+++ b/clang/unittests/Format/FormatTestMacroExpansion.cpp
@@ -58,10 +58,18 @@ TEST_F(FormatTestMacroExpansion, UnexpandConfiguredMacros) {
   verifyFormat("ASSIGN_OR_RETURN(MySomewhatLongType *variable,\n"
                "                 MySomewhatLongFunction(SomethingElse()));",
                Style);
-  verifyFormat("ASSIGN_OR_RETURN(MySomewhatLongType *variable,\n"
-               "                 MySomewhatLongFunction(SomethingElse()), "
-               "ReturnMe());",
-               Style);
+  verifyFormat(
+      "ASSIGN_OR_RETURN(MySomewhatLongType *variable,\n"
+      "                 MySomewhatLongFunction(SomethingElse()), RetMe());",
+      Style);
+
+  verifyFormat(
+      "void f() {\n"
+      "  ASSIGN_OR_RETURN(MySomewhatLongType* variable,\n"
+      "                   MySomewhatLongFunction(SomethingElse()));\n"
+      "  ASSIGN_OR_RETURN(MySomewhatLongType* variable,\n"
+      "                   MySomewhatLongFunction(SomethingElse()), RetMe());",
+      getGoogleStyle());
 
   verifyFormat(R"(
 #define MACRO(a, b) ID(a + b)
@@ -300,6 +308,109 @@ TEST_F(FormatTestMacroExpansion, IndentChildrenWithinMacroCall) {
                "}",
                Style);
 }
+
+// clang-format off
+TEST_F(FormatTestMacroExpansion, NestedMacrosInLambdas) {
+  // These are tests for regressions reported in
+  // https://github.com/llvm/llvm-project/pull/169037#issuecomment-4056423543
+  verifyFormat(
+      "void f() {\n"
+      "  RETURN_IF_ERROR(Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(\n"
+      "      a,\n"
+      "      []() {\n"
+      "        if (z()) {\n"
+      "          ASSIGN_OR_RETURN(w, Wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww());\n"
+      "        }\n"
+      "      }));\n"
+      "}",
+      getGoogleStyle());
+
+  verifyFormat(
+      "void g() {\n"
+      "  RETURN_IF_ERROR(q(\n"
+      "      w,\n"
+      "      []() {\n"
+      "        if (z()) {\n"
+      "          ASSIGN_OR_RETURN(w, Wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww());\n"
+      "        }\n"
+      "      }));\n"
+      "}",
+      getGoogleStyle());
+
+  verifyFormat(
+      "void f() {\n"
+      "  ABSL_RETURN_IF_ERROR(\n"
+      "      Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(\n"
+      "          a,\n"
+      "          []() {\n"
+      "            if (z()) {\n"
+      "              ABSL_ASSIGN_OR_RETURN(w, Wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww());\n"
+      "            }\n"
+      "          }));\n"
+      "}",
+      getGoogleStyle());
+
+  verifyFormat(
+      "void g() {\n"
+      "  ABSL_RETURN_IF_ERROR(q(\n"
+      "      w,\n"
+      "      []() {\n"
+      "        if (z()) {\n"
+      "          ABSL_ASSIGN_OR_RETURN(w, Wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww());\n"
+      "        }\n"
+      "      }));\n"
+      "}",
+      getGoogleStyle());
+}
+
+TEST_F(FormatTestMacroExpansion, PredefinedGoogleMacros) {
+  verifyFormat(
+      "void f() {\n"
+      "  ASSIGN_OR_RETURN(MySomewhatLongType* variable,\n"
+      "                   MySomewhatLongFunction(SomethingElse()));\n"
+      "  ASSIGN_OR_RETURN(MySomewhatLongType* variable,\n"
+      "                   MySomewhatLongFunction(SomethingElse()), RetMe());\n"
+      "}",
+      getGoogleStyle());
+
+  verifyFormat(
+      "void f() {\n"
+      "  ABSL_ASSIGN_OR_RETURN(MySomewhatLongType* variable,\n"
+      "                        MySomewhatLongFunction(SomethingElse()));\n"
+      "  ABSL_ASSIGN_OR_RETURN(MySomewhatLongType* variable,\n"
+      "                        MySomewhatLongFunction(SomethingElse()), RetMe());\n"
+      "}",
+      getGoogleStyle());
+
+  verifyFormat(
+      "void f() {\n"
+      "  RETURN_IF_ERROR(\n"
+      "      MySomewhatLongFunction(SomethingElse(WithManyArguments, AndSomeMore)));\n"
+      "}",
+      getGoogleStyle());
+
+  verifyFormat(
+      "void f() {\n"
+      "  ABSL_RETURN_IF_ERROR(\n"
+      "      MySomewhatLongFunction(SomethingElse(WithManyArguments, AndSomeMore)));\n"
+      "}",
+      getGoogleStyle());
+
+  verifyFormat(
+      "void f() {\n"
+      "  ASSERT_OK_AND_ASSIGN(MySomewhatLongType* variable,\n"
+      "                       MySomewhatLongFunction(SomethingElse()));\n"
+      "}",
+      getGoogleStyle());
+
+  verifyFormat(
+      "void f() {\n"
+      "  ABSL_ASSERT_OK_AND_ASSIGN(MySomewhatLongType* variable,\n"
+      "                            MySomewhatLongFunction(SomethingElse()));\n"
+      "}",
+      getGoogleStyle());
+}
+// clang-format on
 
 } // namespace
 } // namespace test

--- a/clang/unittests/Format/FormatTestMacroExpansion.cpp
+++ b/clang/unittests/Format/FormatTestMacroExpansion.cpp
@@ -309,10 +309,10 @@ TEST_F(FormatTestMacroExpansion, IndentChildrenWithinMacroCall) {
                Style);
 }
 
-// clang-format off
 TEST_F(FormatTestMacroExpansion, NestedMacrosInLambdas) {
   // These are tests for regressions reported in
   // https://github.com/llvm/llvm-project/pull/169037#issuecomment-4056423543
+  // clang-format off
   verifyFormat(
       "void f() {\n"
       "  RETURN_IF_ERROR(Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(\n"
@@ -361,9 +361,11 @@ TEST_F(FormatTestMacroExpansion, NestedMacrosInLambdas) {
       "      }));\n"
       "}",
       getGoogleStyle());
+  // clang-format on
 }
 
 TEST_F(FormatTestMacroExpansion, PredefinedGoogleMacros) {
+  // clang-format off
   verifyFormat(
       "void f() {\n"
       "  ASSIGN_OR_RETURN(MySomewhatLongType* variable,\n"
@@ -409,8 +411,8 @@ TEST_F(FormatTestMacroExpansion, PredefinedGoogleMacros) {
       "                            MySomewhatLongFunction(SomethingElse()));\n"
       "}",
       getGoogleStyle());
+  // clang-format on
 }
-// clang-format on
 
 } // namespace
 } // namespace test

--- a/clang/unittests/Format/FormatTestMacroExpansion.cpp
+++ b/clang/unittests/Format/FormatTestMacroExpansion.cpp
@@ -364,54 +364,31 @@ TEST_F(FormatTestMacroExpansion, NestedMacrosInLambdas) {
   // clang-format on
 }
 
-TEST_F(FormatTestMacroExpansion, PredefinedGoogleMacros) {
-  // clang-format off
-  verifyFormat(
-      "void f() {\n"
-      "  ASSIGN_OR_RETURN(MySomewhatLongType* variable,\n"
-      "                   MySomewhatLongFunction(SomethingElse()));\n"
-      "  ASSIGN_OR_RETURN(MySomewhatLongType* variable,\n"
-      "                   MySomewhatLongFunction(SomethingElse()), RetMe());\n"
-      "}",
-      getGoogleStyle());
+// Verify that the predefined Google macros cause `*` to be treated as a
+// pointer declaration rather than multiplication.
+TEST_F(FormatTestMacroExpansion, GoogleMacrosFormatsAsPtrDecl) {
+  verifyFormat("void f() { ASSIGN_OR_RETURN(Type* x, F()); }",
+               getGoogleStyle());
+  verifyFormat("void f() { ABSL_ASSIGN_OR_RETURN(Type* x, F()); }",
+               getGoogleStyle());
+  verifyFormat("void f() { ASSERT_OK_AND_ASSIGN(Type* x, F()); }",
+               getGoogleStyle());
+  verifyFormat("void f() { ABSL_ASSERT_OK_AND_ASSIGN(Type* x, F()); }",
+               getGoogleStyle());
+}
 
-  verifyFormat(
-      "void f() {\n"
-      "  ABSL_ASSIGN_OR_RETURN(MySomewhatLongType* variable,\n"
-      "                        MySomewhatLongFunction(SomethingElse()));\n"
-      "  ABSL_ASSIGN_OR_RETURN(MySomewhatLongType* variable,\n"
-      "                        MySomewhatLongFunction(SomethingElse()), RetMe());\n"
-      "}",
-      getGoogleStyle());
-
-  verifyFormat(
-      "void f() {\n"
-      "  RETURN_IF_ERROR(\n"
-      "      MySomewhatLongFunction(SomethingElse(WithManyArguments, AndSomeMore)));\n"
-      "}",
-      getGoogleStyle());
-
-  verifyFormat(
-      "void f() {\n"
-      "  ABSL_RETURN_IF_ERROR(\n"
-      "      MySomewhatLongFunction(SomethingElse(WithManyArguments, AndSomeMore)));\n"
-      "}",
-      getGoogleStyle());
-
-  verifyFormat(
-      "void f() {\n"
-      "  ASSERT_OK_AND_ASSIGN(MySomewhatLongType* variable,\n"
-      "                       MySomewhatLongFunction(SomethingElse()));\n"
-      "}",
-      getGoogleStyle());
-
-  verifyFormat(
-      "void f() {\n"
-      "  ABSL_ASSERT_OK_AND_ASSIGN(MySomewhatLongType* variable,\n"
-      "                            MySomewhatLongFunction(SomethingElse()));\n"
-      "}",
-      getGoogleStyle());
-  // clang-format on
+// Macros whose expansion contains multiple statements or control flow (e.g.,
+// `if`) prevent short function merging but don't force `{` to a new line,
+// resulting in `{ code\n}` instead of `{ code }` or `{\n  code\n}`.
+TEST_F(FormatTestMacroExpansion, GoogleMacrosShortFunctionFormattingIsBroken) {
+  // RETURN_IF_ERROR expands to `if (x) return expr`.
+  verifyFormat("void f() { RETURN_IF_ERROR(F());\n}", getGoogleStyle());
+  verifyFormat("void f() { ABSL_RETURN_IF_ERROR(F());\n}", getGoogleStyle());
+  // 3-arg ASSIGN_OR_RETURN expands to `a = (b); if (x) return c`.
+  verifyFormat("void f() { ASSIGN_OR_RETURN(auto x, F(), R());\n}",
+               getGoogleStyle());
+  verifyFormat("void f() { ABSL_ASSIGN_OR_RETURN(auto x, F(), R());\n}",
+               getGoogleStyle());
 }
 
 } // namespace


### PR DESCRIPTION
Add macros that wrap assignment to GoogleStyle.
* ASSIGN_OR_RETURN/ABSL_ASSIGN_OR_RETURN
* RETURN_IF_ERROR/ABSL_RETURN_IF_ERROR
* ASSERT_OK_AND_ASSIGN/ABSL_ASSERT_OK_AND_ASSIGN

`ASSIGN_OR_RETURN(T* p, f())` will be formatted as a multiplication without these macros definitions.

This is a resubmission of https://github.com/llvm/llvm-project/pull/169037 with fixes for the reported regressions caused by not having RETURN_IF_ERROR Macros defined.

https://github.com/llvm/llvm-project/pull/169037#issuecomment-4056423543

Reverts 7e51783 (Revert "[Format] Configure ASSIGN_OR_RETURN macros for Google style" (#186445)).