### PR TITLE
[AArch64][GlobalISel] Add handling for scalar sqneg intrinsic

### DIFF
--- a/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.cpp
@@ -650,6 +650,7 @@ static bool isFPIntrinsic(const MachineRegisterInfo &MRI,
   case Intrinsic::aarch64_neon_sqrshrun:
   case Intrinsic::aarch64_neon_uqshrn:
   case Intrinsic::aarch64_neon_uqrshrn:
+  case Intrinsic::aarch64_neon_sqneg:
   case Intrinsic::aarch64_crypto_sha1h:
   case Intrinsic::aarch64_crypto_sha1c:
   case Intrinsic::aarch64_crypto_sha1p:

--- a/llvm/test/CodeGen/AArch64/arm64-int-neon.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-int-neon.ll
@@ -5,8 +5,6 @@
 ; CHECK-GI:    warning: Instruction selection used fallback path for test_sqdmulh_scalar
 ; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_sqabs_s32
 ; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_sqabs_s64
-; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_sqneg_s32
-; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_sqneg_s64
 
 define void @test_sqrshl_s32(float noundef %a, ptr %dst){
 ; CHECK-LABEL: test_sqrshl_s32:


### PR DESCRIPTION
Scalar versions of the intrinsic must be performed on FPR banks. To ensure this happens, coerce the source and destination registers to be on FPR.