### PR TITLE
[Clang] Fixed an assertion failure in constant evaluation/AST parsing when encountering malformed struct and enum declarations with missing closing braces

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -352,6 +352,7 @@ features cannot lower the translation-unit ABI level;
 - Fixed a bug where `__func__`, `__PRETTY_FUNCTION__` and `__FUNCTION__` were not resolving to the proper function when inside a lambda return type (#GH211811)
 - Fixed USR generation for declarations whose signature mentions a class-type
   non-type template parameter. (#GH212351)
+- Fixed an assertion failure in constant evaluation/AST parsing when encountering malformed struct and enum declarations with missing closing braces. (#GH118061)
 
 #### Bug Fixes to Compiler Builtins
 

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -18903,6 +18903,10 @@ CreateNewDecl:
     } else
       New = RecordDecl::Create(Context, Kind, SearchDC, KWLoc, Loc, Name,
                                cast_or_null<RecordDecl>(PrevDecl));
+
+    // Impossible to decl struct/union/class in enum
+    if (isa<EnumDecl>(SearchDC))
+      Invalid = true;
   }
 
   // Only C23 and later allow defining new types in 'offsetof()'.

--- a/clang/test/Sema/gh118061.cpp
+++ b/clang/test/Sema/gh118061.cpp
@@ -1,0 +1,48 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+// expected-warning@+3 {{declaration does not declare anything}}
+// expected-note@+2 {{to match this '{'}}
+// expected-error@+1 {{anonymous structs and classes must be class members}}
+struct {
+    // expected-error@+1 {{types cannot be declared in an anonymous struct}}
+    enum a1 {
+        b1 = (struct c1
+    // expected-error@-1 {{expected ';' after struct}}
+    // expected-note@-2 {{to match this '('}}
+};
+// expected-error@-1 {{expected ')'}}
+
+// expected-error@+1 {{types cannot be declared in an anonymous struct}}
+struct c1 {
+};
+
+// expected-note@+1 {{to match this '{'}}
+union {
+    enum a2 {
+        b2 = (union c2
+    // expected-error@-1 {{expected ';' after union}}
+    // expected-note@-2 {{to match this '('}}
+};
+// expected-error@-1 {{expected ')'}}
+
+union c2 {
+};
+
+// expected-note@+2 {{to match this '{'}}
+// expected-warning@+1 {{declaration does not declare anything}}
+class {
+    // expected-error@+1 {{types cannot be declared in an anonymous struct}}
+    enum a3 {
+        b3 = (class c3
+    // expected-error@-1 {{expected ';' after class}}
+    // expected-note@-2 {{to match this '('}}
+    // expected-note@-3 {{previously declared 'public' here}}
+};
+// expected-error@-1 {{expected ')'}}
+
+// expected-error@+2 {{types cannot be declared in an anonymous struct}}
+// expected-error@+1 {{'c3' redeclared with 'private' access}}
+class c3 {
+};
+// expected-error@-1 {{expected ';' after class}}
+// expected-error {{expected ';' after struct}} \ expected-error {{expected ';' after union}} \ expected-error 3 {{expected '}'}}


### PR DESCRIPTION
Declaring a `struct` within an unclosed `enum` succeeds without being flagged as invalid; however, since the `struct` (e.g., `struct d`) lacks an access specifier in this context, a subsequent redefinition triggers an assertion failure when the redefinition error message attempts to call `getAccessName`.

This PR change marks all `struct`, `union`, and `class` declarations within an enum context as invalid, thereby avoiding assertion failures.

Noted that `union` and `class` exhibit the same behavior, so tests for them were also added.
 
fix #118061 