### PR TITLE
[GlobalISel] Legalize pointer vector icmp through equating them with integer vectors

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/GIMatchTableExecutorImpl.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/GIMatchTableExecutorImpl.h
@@ -38,6 +38,25 @@
 
 namespace llvm {
 
+/// Imported SelectionDAG patterns describe pointer operands with integer MVTs
+/// (e.g. i64, v2i64). GlobalISel may keep distinct pointer LLTs (e.g. p0,
+/// v2p0). For \p GIM_CheckType, accept the match when the actual operand is a
+/// pointer or pointer vector and equals the expected integer type after
+/// normalizing with \p LLT::changeElementType.
+///
+/// This is a one-way bridge (pointer actual, integer expected). When the
+/// pattern already knows the operand is a pointer, \p GIM_CheckPointerToAny
+/// is used instead.
+static inline bool isLLTIntegerCompatibleWithPointer(const LLT &Actual,
+                                                     const LLT &Expected) {
+  if (Actual == Expected)
+    return true;
+  if (!Actual.isPointerOrPointerVector() || Expected.isPointerOrPointerVector())
+    return false;
+  return Actual.changeElementType(LLT::integer(Actual.getScalarSizeInBits())) ==
+         Expected;
+}
+
 template <class TgtExecutor, class PredicateBitset, class ComplexMatcherMemFn,
           class CustomRendererFn>
 bool GIMatchTableExecutor::executeMatchTable(
@@ -752,7 +771,9 @@ bool GIMatchTableExecutor::executeMatchTable(
                              << "), TypeID=" << TypeID << ")\n");
       assert(State.MIs[InsnID] != nullptr && "Used insn before defined");
       MachineOperand &MO = State.MIs[InsnID]->getOperand(OpIdx);
-      if (!MO.isReg() || MRI.getType(MO.getReg()) != getTypeFromIdx(TypeID)) {
+      if (!MO.isReg() ||
+          !isLLTIntegerCompatibleWithPointer(MRI.getType(MO.getReg()),
+                                             getTypeFromIdx(TypeID))) {
         if (handleReject() == RejectAndGiveUp)
           return false;
       }
@@ -781,7 +802,8 @@ bool GIMatchTableExecutor::executeMatchTable(
       assert(SizeInBits != 0 && "Pointer size must be known");
 
       if (MO.isReg()) {
-        if (!Ty.isPointer() || Ty.getSizeInBits() != SizeInBits)
+        if (!Ty.isPointerOrPointerVector() ||
+            Ty.getScalarSizeInBits() != SizeInBits)
           if (handleReject() == RejectAndGiveUp)
             return false;
       } else if (handleReject() == RejectAndGiveUp)

--- a/llvm/test/CodeGen/AArch64/icmp.ll
+++ b/llvm/test/CodeGen/AArch64/icmp.ll
@@ -2,12 +2,6 @@
 ; RUN: llc -mtriple=aarch64 -verify-machineinstrs %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-SD
 ; RUN: llc -mtriple=aarch64 -global-isel -global-isel-abort=2 -verify-machineinstrs %s -o - 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-GI
 
-; CHECK-GI:       warning: Instruction selection used fallback path for v2p0_p0
-; CHECK-GI-NEXT:  warning: Instruction selection used fallback path for v3p0_p0
-; CHECK-GI-NEXT:  warning: Instruction selection used fallback path for v4p0_p0
-; CHECK-GI-NEXT:  warning: Instruction selection used fallback path for icmp_eq_v2p0_Zero_RHS
-; CHECK-GI-NEXT:  warning: Instruction selection used fallback path for icmp_eq_v2p0_Zero_LHS
-
 define i64 @i64_i64(i64 %a, i64 %b, i64 %d, i64 %e) {
 ; CHECK-LABEL: i64_i64:
 ; CHECK:       // %bb.0: // %entry
@@ -1428,11 +1422,18 @@ entry:
 }
 
 define <2 x ptr> @v2p0_p0(<2 x ptr> %a, <2 x ptr> %b, <2 x ptr> %d, <2 x ptr> %e) {
-; CHECK-LABEL: v2p0_p0:
-; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    cmeq v0.2d, v0.2d, v1.2d
-; CHECK-NEXT:    bsl v0.16b, v3.16b, v2.16b
-; CHECK-NEXT:    ret
+; CHECK-SD-LABEL: v2p0_p0:
+; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    cmeq v0.2d, v0.2d, v1.2d
+; CHECK-SD-NEXT:    bsl v0.16b, v3.16b, v2.16b
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: v2p0_p0:
+; CHECK-GI:       // %bb.0: // %entry
+; CHECK-GI-NEXT:    cmeq v0.2d, v0.2d, v1.2d
+; CHECK-GI-NEXT:    mvn v0.16b, v0.16b
+; CHECK-GI-NEXT:    bsl v0.16b, v2.16b, v3.16b
+; CHECK-GI-NEXT:    ret
 entry:
   %c = icmp ne <2 x ptr> %a, %b
   %s = select <2 x i1> %c, <2 x ptr> %d, <2 x ptr> %e
@@ -1440,32 +1441,62 @@ entry:
 }
 
 define <3 x ptr> @v3p0_p0(<3 x ptr> %a, <3 x ptr> %b, <3 x ptr> %d, <3 x ptr> %e) {
-; CHECK-LABEL: v3p0_p0:
-; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    // kill: def $d4 killed $d4 def $q4
-; CHECK-NEXT:    // kill: def $d3 killed $d3 def $q3
-; CHECK-NEXT:    // kill: def $d1 killed $d1 def $q1
-; CHECK-NEXT:    // kill: def $d0 killed $d0 def $q0
-; CHECK-NEXT:    // kill: def $d6 killed $d6 def $q6
-; CHECK-NEXT:    // kill: def $d7 killed $d7 def $q7
-; CHECK-NEXT:    // kill: def $d5 killed $d5 def $q5
-; CHECK-NEXT:    // kill: def $d2 killed $d2 def $q2
-; CHECK-NEXT:    ldr d16, [sp, #24]
-; CHECK-NEXT:    ldr d17, [sp]
-; CHECK-NEXT:    mov v3.d[1], v4.d[0]
-; CHECK-NEXT:    mov v0.d[1], v1.d[0]
-; CHECK-NEXT:    mov v6.d[1], v7.d[0]
-; CHECK-NEXT:    ldp d1, d4, [sp, #8]
-; CHECK-NEXT:    mov v1.d[1], v4.d[0]
-; CHECK-NEXT:    cmgt v0.2d, v3.2d, v0.2d
-; CHECK-NEXT:    bsl v0.16b, v6.16b, v1.16b
-; CHECK-NEXT:    cmgt v1.2d, v5.2d, v2.2d
-; CHECK-NEXT:    mov v2.16b, v1.16b
-; CHECK-NEXT:    mov d1, v0.d[1]
-; CHECK-NEXT:    // kill: def $d0 killed $d0 killed $q0
-; CHECK-NEXT:    bsl v2.16b, v17.16b, v16.16b
-; CHECK-NEXT:    // kill: def $d2 killed $d2 killed $q2
-; CHECK-NEXT:    ret
+; CHECK-SD-LABEL: v3p0_p0:
+; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    // kill: def $d4 killed $d4 def $q4
+; CHECK-SD-NEXT:    // kill: def $d3 killed $d3 def $q3
+; CHECK-SD-NEXT:    // kill: def $d1 killed $d1 def $q1
+; CHECK-SD-NEXT:    // kill: def $d0 killed $d0 def $q0
+; CHECK-SD-NEXT:    // kill: def $d6 killed $d6 def $q6
+; CHECK-SD-NEXT:    // kill: def $d7 killed $d7 def $q7
+; CHECK-SD-NEXT:    // kill: def $d5 killed $d5 def $q5
+; CHECK-SD-NEXT:    // kill: def $d2 killed $d2 def $q2
+; CHECK-SD-NEXT:    ldr d16, [sp, #24]
+; CHECK-SD-NEXT:    ldr d17, [sp]
+; CHECK-SD-NEXT:    mov v3.d[1], v4.d[0]
+; CHECK-SD-NEXT:    mov v0.d[1], v1.d[0]
+; CHECK-SD-NEXT:    mov v6.d[1], v7.d[0]
+; CHECK-SD-NEXT:    ldp d1, d4, [sp, #8]
+; CHECK-SD-NEXT:    mov v1.d[1], v4.d[0]
+; CHECK-SD-NEXT:    cmgt v0.2d, v3.2d, v0.2d
+; CHECK-SD-NEXT:    bsl v0.16b, v6.16b, v1.16b
+; CHECK-SD-NEXT:    cmgt v1.2d, v5.2d, v2.2d
+; CHECK-SD-NEXT:    mov v2.16b, v1.16b
+; CHECK-SD-NEXT:    mov d1, v0.d[1]
+; CHECK-SD-NEXT:    // kill: def $d0 killed $d0 killed $q0
+; CHECK-SD-NEXT:    bsl v2.16b, v17.16b, v16.16b
+; CHECK-SD-NEXT:    // kill: def $d2 killed $d2 killed $q2
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: v3p0_p0:
+; CHECK-GI:       // %bb.0: // %entry
+; CHECK-GI-NEXT:    fmov x8, d1
+; CHECK-GI-NEXT:    fmov x9, d4
+; CHECK-GI-NEXT:    // kill: def $d0 killed $d0 def $q0
+; CHECK-GI-NEXT:    // kill: def $d3 killed $d3 def $q3
+; CHECK-GI-NEXT:    // kill: def $d2 killed $d2 def $q2
+; CHECK-GI-NEXT:    // kill: def $d6 killed $d6 def $q6
+; CHECK-GI-NEXT:    // kill: def $d5 killed $d5 def $q5
+; CHECK-GI-NEXT:    ldr x10, [sp, #24]
+; CHECK-GI-NEXT:    ldp d4, d1, [sp, #8]
+; CHECK-GI-NEXT:    mov v0.d[1], x8
+; CHECK-GI-NEXT:    mov v3.d[1], x9
+; CHECK-GI-NEXT:    fmov x8, d7
+; CHECK-GI-NEXT:    fmov x9, d1
+; CHECK-GI-NEXT:    cmgt v1.2d, v5.2d, v2.2d
+; CHECK-GI-NEXT:    mov v6.d[1], x8
+; CHECK-GI-NEXT:    mov v4.d[1], x9
+; CHECK-GI-NEXT:    cmgt v0.2d, v3.2d, v0.2d
+; CHECK-GI-NEXT:    fmov x8, d1
+; CHECK-GI-NEXT:    ldr x9, [sp]
+; CHECK-GI-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-GI-NEXT:    bsl v0.16b, v6.16b, v4.16b
+; CHECK-GI-NEXT:    and x9, x9, x8
+; CHECK-GI-NEXT:    bic x8, x10, x8
+; CHECK-GI-NEXT:    orr x8, x9, x8
+; CHECK-GI-NEXT:    fmov d2, x8
+; CHECK-GI-NEXT:    mov d1, v0.d[1]
+; CHECK-GI-NEXT:    ret
 entry:
   %c = icmp slt <3 x ptr> %a, %b
   %s = select <3 x i1> %c, <3 x ptr> %d, <3 x ptr> %e
@@ -1473,13 +1504,21 @@ entry:
 }
 
 define <4 x ptr> @v4p0_p0(<4 x ptr> %a, <4 x ptr> %b, <4 x ptr> %d, <4 x ptr> %e) {
-; CHECK-LABEL: v4p0_p0:
-; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    cmgt v1.2d, v3.2d, v1.2d
-; CHECK-NEXT:    cmgt v0.2d, v2.2d, v0.2d
-; CHECK-NEXT:    bsl v1.16b, v5.16b, v7.16b
-; CHECK-NEXT:    bsl v0.16b, v4.16b, v6.16b
-; CHECK-NEXT:    ret
+; CHECK-SD-LABEL: v4p0_p0:
+; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    cmgt v1.2d, v3.2d, v1.2d
+; CHECK-SD-NEXT:    cmgt v0.2d, v2.2d, v0.2d
+; CHECK-SD-NEXT:    bsl v1.16b, v5.16b, v7.16b
+; CHECK-SD-NEXT:    bsl v0.16b, v4.16b, v6.16b
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: v4p0_p0:
+; CHECK-GI:       // %bb.0: // %entry
+; CHECK-GI-NEXT:    cmgt v0.2d, v2.2d, v0.2d
+; CHECK-GI-NEXT:    cmgt v1.2d, v3.2d, v1.2d
+; CHECK-GI-NEXT:    bsl v0.16b, v4.16b, v6.16b
+; CHECK-GI-NEXT:    bsl v1.16b, v5.16b, v7.16b
+; CHECK-GI-NEXT:    ret
 entry:
   %c = icmp slt <4 x ptr> %a, %b
   %s = select <4 x i1> %c, <4 x ptr> %d, <4 x ptr> %e

--- a/llvm/test/CodeGen/RISCV/GlobalISel/instruction-select/icmp-rv32.mir
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/instruction-select/icmp-rv32.mir
@@ -742,9 +742,8 @@ body:             |
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
-    ; CHECK-NEXT: [[ADDI:%[0-9]+]]:gpr = ADDI $x0, 10
-    ; CHECK-NEXT: [[SLTU:%[0-9]+]]:gpr = SLTU [[COPY]], [[ADDI]]
-    ; CHECK-NEXT: $x10 = COPY [[SLTU]]
+    ; CHECK-NEXT: [[SLTIU:%[0-9]+]]:gpr = SLTIU [[COPY]], 10
+    ; CHECK-NEXT: $x10 = COPY [[SLTIU]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:gprb(p0) = COPY $x10
     %1:gprb(p0) = G_CONSTANT i32 10
@@ -766,9 +765,8 @@ body:             |
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
-    ; CHECK-NEXT: [[ADDI:%[0-9]+]]:gpr = ADDI $x0, -10
-    ; CHECK-NEXT: [[SLT:%[0-9]+]]:gpr = SLT [[COPY]], [[ADDI]]
-    ; CHECK-NEXT: $x10 = COPY [[SLT]]
+    ; CHECK-NEXT: [[SLTI:%[0-9]+]]:gpr = SLTI [[COPY]], -10
+    ; CHECK-NEXT: $x10 = COPY [[SLTI]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:gprb(p0) = COPY $x10
     %1:gprb(p0) = G_CONSTANT i32 -10
@@ -790,9 +788,9 @@ body:             |
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
-    ; CHECK-NEXT: [[ADDI:%[0-9]+]]:gpr = ADDI $x0, 10
-    ; CHECK-NEXT: [[SLTU:%[0-9]+]]:gpr = SLTU [[ADDI]], [[COPY]]
-    ; CHECK-NEXT: $x10 = COPY [[SLTU]]
+    ; CHECK-NEXT: [[SLTIU:%[0-9]+]]:gpr = SLTIU [[COPY]], 11
+    ; CHECK-NEXT: [[XORI:%[0-9]+]]:gpr = XORI [[SLTIU]], 1
+    ; CHECK-NEXT: $x10 = COPY [[XORI]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:gprb(p0) = COPY $x10
     %1:gprb(p0) = G_CONSTANT i32 10
@@ -814,9 +812,9 @@ body:             |
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
-    ; CHECK-NEXT: [[ADDI:%[0-9]+]]:gpr = ADDI $x0, -10
-    ; CHECK-NEXT: [[SLT:%[0-9]+]]:gpr = SLT [[ADDI]], [[COPY]]
-    ; CHECK-NEXT: $x10 = COPY [[SLT]]
+    ; CHECK-NEXT: [[SLTI:%[0-9]+]]:gpr = SLTI [[COPY]], -9
+    ; CHECK-NEXT: [[XORI:%[0-9]+]]:gpr = XORI [[SLTI]], 1
+    ; CHECK-NEXT: $x10 = COPY [[XORI]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:gprb(p0) = COPY $x10
     %1:gprb(p0) = G_CONSTANT i32 -10
@@ -838,9 +836,8 @@ body:             |
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
-    ; CHECK-NEXT: [[ADDI:%[0-9]+]]:gpr = ADDI $x0, 10
-    ; CHECK-NEXT: [[XOR:%[0-9]+]]:gpr = XOR [[COPY]], [[ADDI]]
-    ; CHECK-NEXT: [[SLTIU:%[0-9]+]]:gpr = SLTIU [[XOR]], 1
+    ; CHECK-NEXT: [[ADDI:%[0-9]+]]:gpr = ADDI [[COPY]], -10
+    ; CHECK-NEXT: [[SLTIU:%[0-9]+]]:gpr = SLTIU [[ADDI]], 1
     ; CHECK-NEXT: $x10 = COPY [[SLTIU]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:gprb(p0) = COPY $x10
@@ -863,9 +860,8 @@ body:             |
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
-    ; CHECK-NEXT: [[ADDI:%[0-9]+]]:gpr = ADDI $x0, -10
-    ; CHECK-NEXT: [[XOR:%[0-9]+]]:gpr = XOR [[COPY]], [[ADDI]]
-    ; CHECK-NEXT: [[SLTU:%[0-9]+]]:gpr = SLTU $x0, [[XOR]]
+    ; CHECK-NEXT: [[ADDI:%[0-9]+]]:gpr = ADDI [[COPY]], 10
+    ; CHECK-NEXT: [[SLTU:%[0-9]+]]:gpr = SLTU $x0, [[ADDI]]
     ; CHECK-NEXT: $x10 = COPY [[SLTU]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:gprb(p0) = COPY $x10
@@ -888,10 +884,8 @@ body:             |
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
-    ; CHECK-NEXT: [[ADDI:%[0-9]+]]:gpr = ADDI $x0, 10
-    ; CHECK-NEXT: [[SLTU:%[0-9]+]]:gpr = SLTU [[ADDI]], [[COPY]]
-    ; CHECK-NEXT: [[XORI:%[0-9]+]]:gpr = XORI [[SLTU]], 1
-    ; CHECK-NEXT: $x10 = COPY [[XORI]]
+    ; CHECK-NEXT: [[SLTIU:%[0-9]+]]:gpr = SLTIU [[COPY]], 11
+    ; CHECK-NEXT: $x10 = COPY [[SLTIU]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:gprb(p0) = COPY $x10
     %1:gprb(p0) = G_CONSTANT i32 10
@@ -913,10 +907,8 @@ body:             |
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
-    ; CHECK-NEXT: [[ADDI:%[0-9]+]]:gpr = ADDI $x0, -10
-    ; CHECK-NEXT: [[SLT:%[0-9]+]]:gpr = SLT [[ADDI]], [[COPY]]
-    ; CHECK-NEXT: [[XORI:%[0-9]+]]:gpr = XORI [[SLT]], 1
-    ; CHECK-NEXT: $x10 = COPY [[XORI]]
+    ; CHECK-NEXT: [[SLTI:%[0-9]+]]:gpr = SLTI [[COPY]], -9
+    ; CHECK-NEXT: $x10 = COPY [[SLTI]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:gprb(p0) = COPY $x10
     %1:gprb(p0) = G_CONSTANT i32 -10
@@ -963,9 +955,8 @@ body:             |
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
-    ; CHECK-NEXT: [[ADDI:%[0-9]+]]:gpr = ADDI $x0, -10
-    ; CHECK-NEXT: [[SLT:%[0-9]+]]:gpr = SLT [[COPY]], [[ADDI]]
-    ; CHECK-NEXT: [[XORI:%[0-9]+]]:gpr = XORI [[SLT]], 1
+    ; CHECK-NEXT: [[SLTI:%[0-9]+]]:gpr = SLTI [[COPY]], -10
+    ; CHECK-NEXT: [[XORI:%[0-9]+]]:gpr = XORI [[SLTI]], 1
     ; CHECK-NEXT: $x10 = COPY [[XORI]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:gprb(p0) = COPY $x10

--- a/llvm/test/CodeGen/RISCV/GlobalISel/instruction-select/icmp-rv64.mir
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/instruction-select/icmp-rv64.mir
@@ -742,9 +742,8 @@ body:             |
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
-    ; CHECK-NEXT: [[ADDI:%[0-9]+]]:gpr = ADDI $x0, 10
-    ; CHECK-NEXT: [[SLTU:%[0-9]+]]:gpr = SLTU [[COPY]], [[ADDI]]
-    ; CHECK-NEXT: $x10 = COPY [[SLTU]]
+    ; CHECK-NEXT: [[SLTIU:%[0-9]+]]:gpr = SLTIU [[COPY]], 10
+    ; CHECK-NEXT: $x10 = COPY [[SLTIU]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:gprb(p0) = COPY $x10
     %1:gprb(p0) = G_CONSTANT i64 10
@@ -766,9 +765,8 @@ body:             |
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
-    ; CHECK-NEXT: [[ADDI:%[0-9]+]]:gpr = ADDI $x0, -10
-    ; CHECK-NEXT: [[SLT:%[0-9]+]]:gpr = SLT [[COPY]], [[ADDI]]
-    ; CHECK-NEXT: $x10 = COPY [[SLT]]
+    ; CHECK-NEXT: [[SLTI:%[0-9]+]]:gpr = SLTI [[COPY]], -10
+    ; CHECK-NEXT: $x10 = COPY [[SLTI]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:gprb(p0) = COPY $x10
     %1:gprb(p0) = G_CONSTANT i64 -10
@@ -790,9 +788,9 @@ body:             |
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
-    ; CHECK-NEXT: [[ADDI:%[0-9]+]]:gpr = ADDI $x0, 10
-    ; CHECK-NEXT: [[SLTU:%[0-9]+]]:gpr = SLTU [[ADDI]], [[COPY]]
-    ; CHECK-NEXT: $x10 = COPY [[SLTU]]
+    ; CHECK-NEXT: [[SLTIU:%[0-9]+]]:gpr = SLTIU [[COPY]], 11
+    ; CHECK-NEXT: [[XORI:%[0-9]+]]:gpr = XORI [[SLTIU]], 1
+    ; CHECK-NEXT: $x10 = COPY [[XORI]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:gprb(p0) = COPY $x10
     %1:gprb(p0) = G_CONSTANT i64 10
@@ -814,9 +812,9 @@ body:             |
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
-    ; CHECK-NEXT: [[ADDI:%[0-9]+]]:gpr = ADDI $x0, -10
-    ; CHECK-NEXT: [[SLT:%[0-9]+]]:gpr = SLT [[ADDI]], [[COPY]]
-    ; CHECK-NEXT: $x10 = COPY [[SLT]]
+    ; CHECK-NEXT: [[SLTI:%[0-9]+]]:gpr = SLTI [[COPY]], -9
+    ; CHECK-NEXT: [[XORI:%[0-9]+]]:gpr = XORI [[SLTI]], 1
+    ; CHECK-NEXT: $x10 = COPY [[XORI]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:gprb(p0) = COPY $x10
     %1:gprb(p0) = G_CONSTANT i64 -10
@@ -838,9 +836,8 @@ body:             |
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
-    ; CHECK-NEXT: [[ADDI:%[0-9]+]]:gpr = ADDI $x0, 10
-    ; CHECK-NEXT: [[XOR:%[0-9]+]]:gpr = XOR [[COPY]], [[ADDI]]
-    ; CHECK-NEXT: [[SLTIU:%[0-9]+]]:gpr = SLTIU [[XOR]], 1
+    ; CHECK-NEXT: [[ADDI:%[0-9]+]]:gpr = ADDI [[COPY]], -10
+    ; CHECK-NEXT: [[SLTIU:%[0-9]+]]:gpr = SLTIU [[ADDI]], 1
     ; CHECK-NEXT: $x10 = COPY [[SLTIU]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:gprb(p0) = COPY $x10
@@ -863,9 +860,8 @@ body:             |
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
-    ; CHECK-NEXT: [[ADDI:%[0-9]+]]:gpr = ADDI $x0, -10
-    ; CHECK-NEXT: [[XOR:%[0-9]+]]:gpr = XOR [[COPY]], [[ADDI]]
-    ; CHECK-NEXT: [[SLTU:%[0-9]+]]:gpr = SLTU $x0, [[XOR]]
+    ; CHECK-NEXT: [[ADDI:%[0-9]+]]:gpr = ADDI [[COPY]], 10
+    ; CHECK-NEXT: [[SLTU:%[0-9]+]]:gpr = SLTU $x0, [[ADDI]]
     ; CHECK-NEXT: $x10 = COPY [[SLTU]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:gprb(p0) = COPY $x10
@@ -888,10 +884,8 @@ body:             |
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
-    ; CHECK-NEXT: [[ADDI:%[0-9]+]]:gpr = ADDI $x0, 10
-    ; CHECK-NEXT: [[SLTU:%[0-9]+]]:gpr = SLTU [[ADDI]], [[COPY]]
-    ; CHECK-NEXT: [[XORI:%[0-9]+]]:gpr = XORI [[SLTU]], 1
-    ; CHECK-NEXT: $x10 = COPY [[XORI]]
+    ; CHECK-NEXT: [[SLTIU:%[0-9]+]]:gpr = SLTIU [[COPY]], 11
+    ; CHECK-NEXT: $x10 = COPY [[SLTIU]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:gprb(p0) = COPY $x10
     %1:gprb(p0) = G_CONSTANT i64 10
@@ -913,10 +907,8 @@ body:             |
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
-    ; CHECK-NEXT: [[ADDI:%[0-9]+]]:gpr = ADDI $x0, -10
-    ; CHECK-NEXT: [[SLT:%[0-9]+]]:gpr = SLT [[ADDI]], [[COPY]]
-    ; CHECK-NEXT: [[XORI:%[0-9]+]]:gpr = XORI [[SLT]], 1
-    ; CHECK-NEXT: $x10 = COPY [[XORI]]
+    ; CHECK-NEXT: [[SLTI:%[0-9]+]]:gpr = SLTI [[COPY]], -9
+    ; CHECK-NEXT: $x10 = COPY [[SLTI]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:gprb(p0) = COPY $x10
     %1:gprb(p0) = G_CONSTANT i64 -10
@@ -963,9 +955,8 @@ body:             |
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
-    ; CHECK-NEXT: [[ADDI:%[0-9]+]]:gpr = ADDI $x0, -10
-    ; CHECK-NEXT: [[SLT:%[0-9]+]]:gpr = SLT [[COPY]], [[ADDI]]
-    ; CHECK-NEXT: [[XORI:%[0-9]+]]:gpr = XORI [[SLT]], 1
+    ; CHECK-NEXT: [[SLTI:%[0-9]+]]:gpr = SLTI [[COPY]], -10
+    ; CHECK-NEXT: [[XORI:%[0-9]+]]:gpr = XORI [[SLTI]], 1
     ; CHECK-NEXT: $x10 = COPY [[XORI]]
     ; CHECK-NEXT: PseudoRET implicit $x10
     %0:gprb(p0) = COPY $x10

--- a/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.h
+++ b/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.h
@@ -1060,14 +1060,16 @@ public:
 
 /// Generates code to check that an operand is a pointer to any address space.
 ///
-/// In SelectionDAG, the types did not describe pointers or address spaces. As a
-/// result, iN is used to describe a pointer of N bits to any address space and
+/// Used when the imported pattern marks an operand as a pointer (iPTR or
+/// IsPointer). SelectionDAG did not distinguish pointer from integer types, so
 /// PatFrag predicates are typically used to constrain the address space.
-/// There's no reliable means to derive the missing type information from the
-/// pattern so imported rules must test the components of a pointer separately.
 ///
-/// If SizeInBits is zero, then the pointer size will be obtained from the
-/// subtarget.
+/// Scalar and pointer-vector operands are accepted when the scalar element
+/// size matches \p SizeInBits. When the pattern instead expected an integer
+/// MVT, \p GIM_CheckType uses isLLTIntegerCompatibleWithPointer().
+///
+/// If SizeInBits is zero, the pointer size is obtained from the data layout
+/// for the operand's address space.
 class PointerToAnyOperandMatcher : public OperandPredicateMatcher {
 protected:
   unsigned SizeInBits;


### PR DESCRIPTION
Do what SelectionDAG does and equate pointer vectors with integer types.