### PR TITLE
[RISCV] Skip unrelated COPY during Zdinx/P instruction generation in RISCVMoveMerge

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVMoveMerger.cpp
+++ b/llvm/lib/Target/RISCV/RISCVMoveMerger.cpp
@@ -249,6 +249,17 @@ RISCVMoveMerge::findMatchingInstPair(MachineBasicBlock::iterator &MBBI,
   MachineBasicBlock::iterator E = MBBI->getParent()->end();
   ModifiedRegUnits.clear();
   UsedRegUnits.clear();
+  unsigned RegPairIdx = EvenRegPair ? RISCV::sub_gpr_even : RISCV::sub_gpr_odd;
+  unsigned SecondPairIdx =
+      !EvenRegPair ? RISCV::sub_gpr_even : RISCV::sub_gpr_odd;
+
+  // Get the expected source/destination registers of the matching lane.
+  Register SrcGPRPair = TRI->getMatchingSuperReg(
+      RegPair.Source->getReg(), RegPairIdx, &RISCV::GPRPairRegClass);
+  Register DestGPRPair = TRI->getMatchingSuperReg(
+      RegPair.Destination->getReg(), RegPairIdx, &RISCV::GPRPairRegClass);
+  Register ExpectedSourceReg = TRI->getSubReg(SrcGPRPair, SecondPairIdx);
+  Register ExpectedDestReg = TRI->getSubReg(DestGPRPair, SecondPairIdx);
 
   for (MachineBasicBlock::iterator I = next_nodbg(MBBI, E); I != E;
        I = next_nodbg(I, E)) {
@@ -263,32 +274,19 @@ RISCVMoveMerge::findMatchingInstPair(MachineBasicBlock::iterator &MBBI,
           RegPair.Source->getReg() == SourceReg)
         return E;
 
-      unsigned RegPairIdx =
-          EvenRegPair ? RISCV::sub_gpr_even : RISCV::sub_gpr_odd;
-      unsigned SecondPairIdx =
-          !EvenRegPair ? RISCV::sub_gpr_even : RISCV::sub_gpr_odd;
-
-      // Get the register GPRPair.
-      Register SrcGPRPair = TRI->getMatchingSuperReg(
-          RegPair.Source->getReg(), RegPairIdx, &RISCV::GPRPairRegClass);
-
-      Register DestGPRPair = TRI->getMatchingSuperReg(
-          RegPair.Destination->getReg(), RegPairIdx, &RISCV::GPRPairRegClass);
-
       // Check if the second pair's registers match the other lane of the
       // GPRPairs.
-      if (SourceReg == TRI->getSubReg(SrcGPRPair, SecondPairIdx) &&
-          DestReg == TRI->getSubReg(DestGPRPair, SecondPairIdx)) {
-        if (!ModifiedRegUnits.available(DestReg) ||
-            !UsedRegUnits.available(DestReg) ||
-            !ModifiedRegUnits.available(SourceReg))
-          return E;
-
+      if (SourceReg == ExpectedSourceReg && DestReg == ExpectedDestReg)
         return I;
-      }
     }
     // Update modified / used register units.
     LiveRegUnits::accumulateUsedDefed(MI, ModifiedRegUnits, UsedRegUnits, TRI);
+    // Once expected lane registers are clobbered/read in-between, we can stop
+    // scanning since the pair cannot be legally merged anymore.
+    if (!ModifiedRegUnits.available(ExpectedDestReg) ||
+        !UsedRegUnits.available(ExpectedDestReg) ||
+        !ModifiedRegUnits.available(ExpectedSourceReg))
+      return E;
   }
   return E;
 }

--- a/llvm/lib/Target/RISCV/RISCVMoveMerger.cpp
+++ b/llvm/lib/Target/RISCV/RISCVMoveMerger.cpp
@@ -277,16 +277,15 @@ RISCVMoveMerge::findMatchingInstPair(MachineBasicBlock::iterator &MBBI,
 
       // Check if the second pair's registers match the other lane of the
       // GPRPairs.
-      if (SourceReg != TRI->getSubReg(SrcGPRPair, SecondPairIdx) ||
-          DestReg != TRI->getSubReg(DestGPRPair, SecondPairIdx))
-        return E;
+      if (SourceReg == TRI->getSubReg(SrcGPRPair, SecondPairIdx) &&
+          DestReg == TRI->getSubReg(DestGPRPair, SecondPairIdx)) {
+        if (!ModifiedRegUnits.available(DestReg) ||
+            !UsedRegUnits.available(DestReg) ||
+            !ModifiedRegUnits.available(SourceReg))
+          return E;
 
-      if (!ModifiedRegUnits.available(DestReg) ||
-          !UsedRegUnits.available(DestReg) ||
-          !ModifiedRegUnits.available(SourceReg))
-        return E;
-
-      return I;
+        return I;
+      }
     }
     // Update modified / used register units.
     LiveRegUnits::accumulateUsedDefed(MI, ModifiedRegUnits, UsedRegUnits, TRI);

--- a/llvm/test/CodeGen/RISCV/rv32-merge-non-arg-reg.mir
+++ b/llvm/test/CodeGen/RISCV/rv32-merge-non-arg-reg.mir
@@ -24,3 +24,29 @@ body:             |
     $x7 = COPY $x29
     PseudoRET implicit $x6
 ...
+---
+name:            merge_copy_non_arg_reg_with_intervening_unrelated_copy
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $x12, $x28, $x29
+    ; ZDINX-LABEL: name: merge_copy_non_arg_reg_with_intervening_unrelated_copy
+    ; ZDINX: liveins: $x12, $x28, $x29
+    ; ZDINX-NEXT: {{  $}}
+    ; ZDINX-NEXT: $x6 = ADDI $x28, 0
+    ; ZDINX-NEXT: $x18 = ADDI $x12, 0
+    ; ZDINX-NEXT: $x7 = ADDI $x29, 0
+    ; ZDINX-NEXT: PseudoRET implicit $x6
+    ;
+    ; P-EXT-LABEL: name: merge_copy_non_arg_reg_with_intervening_unrelated_copy
+    ; P-EXT: liveins: $x12, $x28, $x29
+    ; P-EXT-NEXT: {{  $}}
+    ; P-EXT-NEXT: $x6 = ADDI $x28, 0
+    ; P-EXT-NEXT: $x18 = ADDI $x12, 0
+    ; P-EXT-NEXT: $x7 = ADDI $x29, 0
+    ; P-EXT-NEXT: PseudoRET implicit $x6
+    $x6 = COPY $x28
+    $x18 = COPY $x12
+    $x7 = COPY $x29
+    PseudoRET implicit $x6
+...

--- a/llvm/test/CodeGen/RISCV/rv32-merge-non-arg-reg.mir
+++ b/llvm/test/CodeGen/RISCV/rv32-merge-non-arg-reg.mir
@@ -33,17 +33,15 @@ body:             |
     ; ZDINX-LABEL: name: merge_copy_non_arg_reg_with_intervening_unrelated_copy
     ; ZDINX: liveins: $x12, $x28, $x29
     ; ZDINX-NEXT: {{  $}}
-    ; ZDINX-NEXT: $x6 = ADDI $x28, 0
+    ; ZDINX-NEXT: $x6_x7 = FSGNJ_D_IN32X $x28_x29, $x28_x29
     ; ZDINX-NEXT: $x18 = ADDI $x12, 0
-    ; ZDINX-NEXT: $x7 = ADDI $x29, 0
     ; ZDINX-NEXT: PseudoRET implicit $x6
     ;
     ; P-EXT-LABEL: name: merge_copy_non_arg_reg_with_intervening_unrelated_copy
     ; P-EXT: liveins: $x12, $x28, $x29
     ; P-EXT-NEXT: {{  $}}
-    ; P-EXT-NEXT: $x6 = ADDI $x28, 0
+    ; P-EXT-NEXT: $x6_x7 = PADD_DW $x28_x29, $x0_pair
     ; P-EXT-NEXT: $x18 = ADDI $x12, 0
-    ; P-EXT-NEXT: $x7 = ADDI $x29, 0
     ; P-EXT-NEXT: PseudoRET implicit $x6
     $x6 = COPY $x28
     $x18 = COPY $x12


### PR DESCRIPTION
`findMatchingInstPair` returned early on the first non-matching `COPY`, which could miss a valid later `COPY` pair. 

Update the scan to continue past non-matching `COPY` instructions and only apply existing dependency checks when a lane match is found.