### PR TITLE
[lldb][windows] allow longer paths than MAX_PATH in GetFileNameByLoadAddress

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
@@ -555,11 +555,14 @@ static std::optional<std::string> GetFileNameByLoadAddress(HANDLE hProcess,
   }
 
   // Fallback: ask the kernel for the file backing the mapping at this address.
-  std::array<wchar_t, MAX_PATH + 1> mapped_filename;
-  if (!::GetMappedFileNameW(hProcess, base_addr, mapped_filename.data(),
-                            mapped_filename.size()))
+  std::vector<wchar_t> mapped_filename(PATHCCH_MAX_CCH);
+  DWORD mapped_len = ::GetMappedFileNameW(
+      hProcess, base_addr, mapped_filename.data(), mapped_filename.size());
+  if (!mapped_len)
     return std::nullopt;
-  return ConvertNtDevicePathToDosPath(mapped_filename);
+  std::optional<std::string> dos_path = ConvertNtDevicePathToDosPath(
+      llvm::ArrayRef<wchar_t>(mapped_filename.data(), mapped_len + 1));
+  return dos_path;
 }
 
 // Resolve the LOAD_DLL_DEBUG_INFO::lpImageName field.

--- a/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
@@ -558,13 +558,12 @@ static std::optional<std::string> GetFileNameByLoadAddress(HANDLE hProcess,
   // Fallback: ask the kernel for the file backing the mapping at this address.
   std::vector<wchar_t> mapped_filename(MAX_PATH + 1);
   DWORD mapped_len = 0;
-  while (true) {
+  while (mapped_filename.size() <= PATHCCH_MAX_CCH) {
     mapped_len = ::GetMappedFileNameW(
         hProcess, base_addr, mapped_filename.data(), mapped_filename.size());
-    if (mapped_len > 0)
+    if (mapped_len < mapped_filename.size())
       break;
-    if (::GetLastError() != ERROR_INSUFFICIENT_BUFFER ||
-        mapped_filename.size() >= PATHCCH_MAX_CCH)
+    if (::GetLastError() != ERROR_INSUFFICIENT_BUFFER)
       return std::nullopt;
     mapped_filename.resize(mapped_filename.size() * 2);
   }

--- a/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
@@ -561,7 +561,7 @@ static std::optional<std::string> GetFileNameByLoadAddress(HANDLE hProcess,
   while (true) {
     mapped_len = ::GetMappedFileNameW(
         hProcess, base_addr, mapped_filename.data(), mapped_filename.size());
-    if (SUCCESS(mapped_len))
+    if (mapped_len > 0)
       break;
     if (::GetLastError() != ERROR_INSUFFICIENT_BUFFER ||
         mapped_filename.size() >= PATHCCH_MAX_CCH)

--- a/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
@@ -563,7 +563,7 @@ static std::optional<std::string> GetFileNameByLoadAddress(HANDLE hProcess,
         hProcess, base_addr, mapped_filename.data(), mapped_filename.size());
     if (SUCCESS(mapped_len))
       break;
-    if (::GetLastError() != ERROR_MORE_DATA ||
+    if (::GetLastError() != ERROR_INSUFFICIENT_BUFFER ||
         mapped_filename.size() >= PATHCCH_MAX_CCH)
       return std::nullopt;
     mapped_filename.resize(mapped_filename.size() * 2);

--- a/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
@@ -556,11 +556,18 @@ static std::optional<std::string> GetFileNameByLoadAddress(HANDLE hProcess,
   }
 
   // Fallback: ask the kernel for the file backing the mapping at this address.
-  std::vector<wchar_t> mapped_filename(PATHCCH_MAX_CCH);
-  DWORD mapped_len = ::GetMappedFileNameW(
-      hProcess, base_addr, mapped_filename.data(), mapped_filename.size());
-  if (!mapped_len)
-    return std::nullopt;
+  std::vector<wchar_t> mapped_filename(MAX_PATH + 1);
+  DWORD mapped_len = 0;
+  while (true) {
+    mapped_len = ::GetMappedFileNameW(
+        hProcess, base_addr, mapped_filename.data(), mapped_filename.size());
+    if (SUCCESS(mapped_len))
+      break;
+    if (::GetLastError() != ERROR_MORE_DATA ||
+        mapped_filename.size() >= PATHCCH_MAX_CCH)
+      return std::nullopt;
+    mapped_filename.resize(mapped_filename.size() * 2);
+  }
   std::optional<std::string> dos_path = ConvertNtDevicePathToDosPath(
       llvm::ArrayRef<wchar_t>(mapped_filename.data(), mapped_len + 1));
   return dos_path;

--- a/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
@@ -32,6 +32,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include <optional>
+#include <pathcch.h>
 #include <psapi.h>
 
 #ifndef STATUS_WX86_BREAKPOINT


### PR DESCRIPTION
DLLs can be longer than MAX_PATH. This is causing test failures when running `check-lldb` in a Windows Docker container. 

This patch allow long paths when calling `GetFileNameByLoadAddress`.

https://github.com/llvm/llvm-project/pull/198795#discussion_r3276277895 was correct.