### PR TITLE
[LLVM][InstSimplify] Ensure scalar sincos constant fold only triggers for scalars.

### DIFF
--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -4635,6 +4635,9 @@ ConstantFoldStructCall(StringRef Name, Intrinsic::ID IntrinsicID,
                                  ConstantVector::get(CosResults));
     }
 
+    if (!Ty->isFloatingPointTy())
+      return nullptr;
+
     auto [SinResult, CosResult] = ConstantFoldScalarSincosCall(Operands[0]);
     if (!SinResult || !CosResult)
       return nullptr;

--- a/llvm/test/Transforms/InstSimplify/sincos.ll
+++ b/llvm/test/Transforms/InstSimplify/sincos.ll
@@ -108,6 +108,15 @@ define { <vscale x 2 x float>, <vscale x 2 x float> } @sincos_zero_scalable_vect
   ret { <vscale x 2 x float>, <vscale x 2 x float> } %ret
 }
 
+define { <vscale x 2 x float>, <vscale x 2 x float> } @sincos_one_scalable_vector() {
+; CHECK-LABEL: define { <vscale x 2 x float>, <vscale x 2 x float> } @sincos_one_scalable_vector() {
+; CHECK-NEXT:    [[RET:%.*]] = call { <vscale x 2 x float>, <vscale x 2 x float> } @llvm.sincos.nxv2f32(<vscale x 2 x float> splat (float 1.000000e+00))
+; CHECK-NEXT:    ret { <vscale x 2 x float>, <vscale x 2 x float> } [[RET]]
+;
+  %ret = call { <vscale x 2 x float>, <vscale x 2 x float> } @llvm.sincos.nxv2f32(<vscale x 2 x float> splat (float 1.0))
+  ret { <vscale x 2 x float>, <vscale x 2 x float> } %ret
+}
+
 define { float, float } @sincos_inf() {
 ; CHECK-LABEL: define { float, float } @sincos_inf() {
 ; CHECK-NEXT:    [[RET:%.*]] = call { float, float } @llvm.sincos.f32(float +inf)


### PR DESCRIPTION
We can fold the scalable vector case but to do that I'd want to refactor the current implementation to remove some of the indirection, so for now I've restricted the change to what's needed to prevent the compiler assert/crash.