### PR TITLE
[lldb][windows] bound ReadProcessMemory

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
@@ -614,6 +614,65 @@ static std::optional<std::string> GetFileNameByLoadAddress(HANDLE hProcess,
   return dos_path;
 }
 
+// Determine how many bytes can be read at `addr` in `hProcess` before crossing
+// out of the committed memory region containing it. Returns 0 if the address is
+// not within a committed region.
+static SIZE_T BytesReadableAt(HANDLE hProcess, LPCVOID addr) {
+  MEMORY_BASIC_INFORMATION mbi{};
+  if (!::VirtualQueryEx(hProcess, addr, &mbi, sizeof(mbi)))
+    return 0;
+  if (mbi.State != MEM_COMMIT)
+    return 0;
+  uintptr_t region_end =
+      reinterpret_cast<uintptr_t>(mbi.BaseAddress) + mbi.RegionSize;
+  uintptr_t a = reinterpret_cast<uintptr_t>(addr);
+  if (a >= region_end)
+    return 0;
+  return region_end - a;
+}
+
+static std::optional<std::string> ReadRemoteStringW(HANDLE hProcess,
+                                                    LPCVOID addr) {
+  SIZE_T to_read = std::min<SIZE_T>((MAX_PATH + 1) * sizeof(wchar_t),
+                                    BytesReadableAt(hProcess, addr));
+  to_read &= ~SIZE_T(1); // round down to a wchar_t boundary
+  if (to_read < sizeof(wchar_t))
+    return std::nullopt;
+
+  std::array<wchar_t, MAX_PATH + 1> buf{};
+  SIZE_T bytes_read = 0;
+  if (!::ReadProcessMemory(hProcess, addr, buf.data(), to_read, &bytes_read))
+    return std::nullopt;
+
+  size_t max_chars = bytes_read / sizeof(wchar_t);
+  size_t len = ::wcsnlen(buf.data(), max_chars);
+  if (len == 0 || len == max_chars) // no null terminator found
+    return std::nullopt;
+
+  std::string result;
+  llvm::convertWideToUTF8(std::wstring(buf.data(), len), result);
+  return result;
+}
+
+static std::optional<std::string> ReadRemoteStringA(HANDLE hProcess,
+                                                    LPCVOID addr) {
+  SIZE_T to_read =
+      std::min<SIZE_T>(MAX_PATH + 1, BytesReadableAt(hProcess, addr));
+  if (to_read == 0)
+    return std::nullopt;
+
+  std::array<char, MAX_PATH + 1> buf{};
+  SIZE_T bytes_read = 0;
+  if (!::ReadProcessMemory(hProcess, addr, buf.data(), to_read, &bytes_read))
+    return std::nullopt;
+
+  size_t len = ::strnlen(buf.data(), bytes_read);
+  if (len == 0 || len == bytes_read) // no null terminator found
+    return std::nullopt;
+
+  return std::string(buf.data(), len);
+}
+
 // Resolve the LOAD_DLL_DEBUG_INFO::lpImageName field.
 static std::optional<std::string>
 GetFileNameFromImageNameField(HANDLE hProcess,
@@ -621,37 +680,16 @@ GetFileNameFromImageNameField(HANDLE hProcess,
   if (info.lpImageName == nullptr)
     return std::nullopt;
 
-  LPVOID name_addr = nullptr;
+  LPVOID string_addr = nullptr;
   SIZE_T bytes_read = 0;
-  if (!::ReadProcessMemory(hProcess, info.lpImageName, &name_addr,
-                           sizeof(name_addr), &bytes_read) ||
-      bytes_read != sizeof(name_addr) || name_addr == nullptr)
+  if (!::ReadProcessMemory(hProcess, info.lpImageName, &string_addr,
+                           sizeof(string_addr), &bytes_read) ||
+      bytes_read != sizeof(string_addr))
     return std::nullopt;
 
-  if (info.fUnicode) {
-    std::array<wchar_t, MAX_PATH + 1> wbuf{};
-    if (!::ReadProcessMemory(hProcess, name_addr, wbuf.data(),
-                             wbuf.size() * sizeof(wchar_t), &bytes_read))
-      return std::nullopt;
-    if (wbuf[MAX_PATH] != L'\0')
-      return std::nullopt;
-    std::string path_utf8;
-    llvm::convertWideToUTF8(wbuf.data(), path_utf8);
-    if (path_utf8.empty())
-      return std::nullopt;
-    return path_utf8;
-  }
-
-  std::array<char, MAX_PATH + 1> abuf{};
-  if (!::ReadProcessMemory(hProcess, name_addr, abuf.data(), abuf.size(),
-                           &bytes_read))
-    return std::nullopt;
-  if (abuf[MAX_PATH] != '\0')
-    return std::nullopt;
-  std::string path(abuf.data());
-  if (path.empty())
-    return std::nullopt;
-  return path;
+  if (info.fUnicode)
+    return ReadRemoteStringW(hProcess, string_addr);
+  return ReadRemoteStringA(hProcess, string_addr);
 }
 
 DWORD

--- a/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
@@ -626,13 +626,12 @@ static SIZE_T BytesReadableAt(HANDLE hProcess, LPCVOID addr) {
   uintptr_t region_end =
       reinterpret_cast<uintptr_t>(mbi.BaseAddress) + mbi.RegionSize;
   uintptr_t a = reinterpret_cast<uintptr_t>(addr);
-  if (a >= region_end)
-    return 0;
+  assert(a < region_end);
   return region_end - a;
 }
 
-static std::optional<std::string> ReadRemoteStringW(HANDLE hProcess,
-                                                    LPCVOID addr) {
+static std::optional<std::string> ReadRemotePathStringW(HANDLE hProcess,
+                                                        LPCVOID addr) {
   SIZE_T to_read = std::min<SIZE_T>((MAX_PATH + 1) * sizeof(wchar_t),
                                     BytesReadableAt(hProcess, addr));
   to_read &= ~SIZE_T(1); // round down to a wchar_t boundary
@@ -646,7 +645,9 @@ static std::optional<std::string> ReadRemoteStringW(HANDLE hProcess,
 
   size_t max_chars = bytes_read / sizeof(wchar_t);
   size_t len = ::wcsnlen(buf.data(), max_chars);
-  if (len == 0 || len == max_chars) // no null terminator found
+  if (len == max_chars) // no null terminator found
+    return std::nullopt;
+  if (len == 0) // empty string
     return std::nullopt;
 
   std::string result;
@@ -654,8 +655,8 @@ static std::optional<std::string> ReadRemoteStringW(HANDLE hProcess,
   return result;
 }
 
-static std::optional<std::string> ReadRemoteStringA(HANDLE hProcess,
-                                                    LPCVOID addr) {
+static std::optional<std::string> ReadRemotePathStringA(HANDLE hProcess,
+                                                        LPCVOID addr) {
   SIZE_T to_read =
       std::min<SIZE_T>(MAX_PATH + 1, BytesReadableAt(hProcess, addr));
   if (to_read == 0)
@@ -667,7 +668,9 @@ static std::optional<std::string> ReadRemoteStringA(HANDLE hProcess,
     return std::nullopt;
 
   size_t len = ::strnlen(buf.data(), bytes_read);
-  if (len == 0 || len == bytes_read) // no null terminator found
+  if (len == bytes_read) // no null terminator found
+    return std::nullopt;
+  if (len == 0) // empty string
     return std::nullopt;
 
   return std::string(buf.data(), len);
@@ -688,8 +691,8 @@ GetFileNameFromImageNameField(HANDLE hProcess,
     return std::nullopt;
 
   if (info.fUnicode)
-    return ReadRemoteStringW(hProcess, string_addr);
-  return ReadRemoteStringA(hProcess, string_addr);
+    return ReadRemotePathStringW(hProcess, string_addr);
+  return ReadRemotePathStringA(hProcess, string_addr);
 }
 
 DWORD


### PR DESCRIPTION
Bound `ReadProcessMemory` by the size of the committed region at `name_addr` to avoid an `ERROR_PARTIAL_COPY` error when the path is short. Replace the strict `wbuf[MAX_PATH] != L'\\0' / abuf[MAX_PATH] != '\\0'` check with `wcsnlen / strnlen` so we don't reject valid short paths whose buffer suffix happens to be non-zero from inferior heap reuse.

The current implementation reads a fixed `MAX_PATH + 1` buffer unconditionally, which could cause `ReadProcessMemory` to fail. It also validated the result by checking for a null terminator at exactly `MAX_PATH`, which rejects any path shorter than `MAX_PATH` characters.

This patch does the following:

- Adds `BytesReadableAt`, which uses `VirtualQueryEx` to clamp each read to the committed region containing the address.
- Switches null-terminator detection to `wcsnlen`/`strnlen` over the actual bytes read.
- Extracts `ReadRemoteStringW`, and `ReadRemoteStringA` so that `GetFileNameFromImageNameField` is reduced to its core logic.

This is needed for https://github.com/llvm/llvm-project/pull/198906.