### PR TITLE
[z/OS][tests] using aliases on z/OS are not supported

### DIFF
--- a/llvm/test/CodeGen/Generic/2009-03-17-LSR-APInt.ll
+++ b/llvm/test/CodeGen/Generic/2009-03-17-LSR-APInt.ll
@@ -4,6 +4,9 @@
 ; NVPTX does not support 'alias' yet
 ; XFAIL: target=nvptx{{.*}}
 
+; The z/OS does not support 'alias'.
+; UNSUPPORTED: target={{.*}}-zos{{.*}}
+
 	%struct..0__pthread_mutex_s = type { i32, i32, i32, i32, i32, i32, %struct.__pthread_list_t }
 	%struct.Alignment = type { i32 }
 	%struct.QDesignerFormWindowInterface = type { %struct.QWidget }

--- a/llvm/test/CodeGen/Generic/2009-03-17-LSR-APInt.ll
+++ b/llvm/test/CodeGen/Generic/2009-03-17-LSR-APInt.ll
@@ -1,8 +1,8 @@
 ; RUN: llc < %s
 ; PR3806
 
-; NVPTX and z/OS do not support 'alias' yet
-; XFAIL: target=nvptx{{.*}}, target={{.*}}-zos{{.*}}
+; NVPTX does not support 'alias' yet
+; XFAIL: target=nvptx{{.*}}
 
 	%struct..0__pthread_mutex_s = type { i32, i32, i32, i32, i32, i32, %struct.__pthread_list_t }
 	%struct.Alignment = type { i32 }

--- a/llvm/test/CodeGen/Generic/available_externally_alias.ll
+++ b/llvm/test/CodeGen/Generic/available_externally_alias.ll
@@ -1,7 +1,7 @@
 ; RUN: llc < %s
 
-; NVPTX and z/OS do not support 'alias' yet
-; XFAIL: target=nvptx{{.*}}, target={{.*}}-zos{{.*}}
+; NVPTX does not support 'alias' yet
+; XFAIL: target=nvptx{{.*}}
 
 @v = available_externally global i32 42, align 4
 @va = available_externally alias i32, ptr @v

--- a/llvm/test/CodeGen/Generic/available_externally_alias.ll
+++ b/llvm/test/CodeGen/Generic/available_externally_alias.ll
@@ -3,6 +3,9 @@
 ; NVPTX does not support 'alias' yet
 ; XFAIL: target=nvptx{{.*}}
 
+; The z/OS does not support 'alias'.
+; UNSUPPORTED: target={{.*}}-zos{{.*}}
+
 @v = available_externally global i32 42, align 4
 @va = available_externally alias i32, ptr @v
 


### PR DESCRIPTION
This PR follows up on #200176 by replacing XFAIL with UNSUPPORTED for test cases that are not planned for support in the near future.