### PR TITLE
[AArch64][SME] Add multi-vector load opcodes to getMemOpInfo

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -4880,6 +4880,18 @@ bool AArch64InstrInfo::getMemOpInfo(unsigned Opcode, TypeSize &Scale,
   case AArch64::ST2H_IMM:
   case AArch64::ST2W_IMM:
   case AArch64::ST2D_IMM:
+  case AArch64::LD1B_2Z_IMM:
+  case AArch64::LD1B_2Z_STRIDED_IMM:
+  case AArch64::LD1H_2Z_IMM:
+  case AArch64::LD1H_2Z_STRIDED_IMM:
+  case AArch64::LD1W_2Z_IMM:
+  case AArch64::LD1W_2Z_STRIDED_IMM:
+  case AArch64::LD1D_2Z_IMM:
+  case AArch64::LD1D_2Z_STRIDED_IMM:
+  case AArch64::LD1B_2Z_IMM_PSEUDO:
+  case AArch64::LD1H_2Z_IMM_PSEUDO:
+  case AArch64::LD1W_2Z_IMM_PSEUDO:
+  case AArch64::LD1D_2Z_IMM_PSEUDO:
     Scale = TypeSize::getScalable(32);
     Width = TypeSize::getScalable(16 * 2);
     MinOffset = -8;
@@ -4906,6 +4918,18 @@ bool AArch64InstrInfo::getMemOpInfo(unsigned Opcode, TypeSize &Scale,
   case AArch64::ST4H_IMM:
   case AArch64::ST4W_IMM:
   case AArch64::ST4D_IMM:
+  case AArch64::LD1B_4Z_IMM:
+  case AArch64::LD1B_4Z_STRIDED_IMM:
+  case AArch64::LD1H_4Z_IMM:
+  case AArch64::LD1H_4Z_STRIDED_IMM:
+  case AArch64::LD1W_4Z_IMM:
+  case AArch64::LD1W_4Z_STRIDED_IMM:
+  case AArch64::LD1D_4Z_IMM:
+  case AArch64::LD1D_4Z_STRIDED_IMM:
+  case AArch64::LD1B_4Z_IMM_PSEUDO:
+  case AArch64::LD1H_4Z_IMM_PSEUDO:
+  case AArch64::LD1W_4Z_IMM_PSEUDO:
+  case AArch64::LD1D_4Z_IMM_PSEUDO:
     Scale = TypeSize::getScalable(64);
     Width = TypeSize::getScalable(16 * 4);
     MinOffset = -8;
@@ -5016,40 +5040,6 @@ bool AArch64InstrInfo::getMemOpInfo(unsigned Opcode, TypeSize &Scale,
     Width = TypeSize::getFixed(8);
     MinOffset = 0;
     MaxOffset = 63;
-    break;
-  case AArch64::LD1B_2Z_IMM:
-  case AArch64::LD1B_2Z_STRIDED_IMM:
-  case AArch64::LD1H_2Z_IMM:
-  case AArch64::LD1H_2Z_STRIDED_IMM:
-  case AArch64::LD1W_2Z_IMM:
-  case AArch64::LD1W_2Z_STRIDED_IMM:
-  case AArch64::LD1D_2Z_IMM:
-  case AArch64::LD1D_2Z_STRIDED_IMM:
-  case AArch64::LD1B_2Z_IMM_PSEUDO:
-  case AArch64::LD1H_2Z_IMM_PSEUDO:
-  case AArch64::LD1W_2Z_IMM_PSEUDO:
-  case AArch64::LD1D_2Z_IMM_PSEUDO:
-    Scale = TypeSize::getScalable(/*Width*/ 16 * /*NVecs*/ 2);
-    Width = TypeSize::getScalable(/*Width*/ 16 * /*NVecs*/ 2);
-    MinOffset = -8;
-    MaxOffset = 7;
-    break;
-  case AArch64::LD1B_4Z_IMM:
-  case AArch64::LD1B_4Z_STRIDED_IMM:
-  case AArch64::LD1H_4Z_IMM:
-  case AArch64::LD1H_4Z_STRIDED_IMM:
-  case AArch64::LD1W_4Z_IMM:
-  case AArch64::LD1W_4Z_STRIDED_IMM:
-  case AArch64::LD1D_4Z_IMM:
-  case AArch64::LD1D_4Z_STRIDED_IMM:
-  case AArch64::LD1B_4Z_IMM_PSEUDO:
-  case AArch64::LD1H_4Z_IMM_PSEUDO:
-  case AArch64::LD1W_4Z_IMM_PSEUDO:
-  case AArch64::LD1D_4Z_IMM_PSEUDO:
-    Scale = TypeSize::getScalable(/*Width*/ 16 * /*NVecs*/ 4);
-    Width = TypeSize::getScalable(/*Width*/ 16 * /*NVecs*/ 4);
-    MinOffset = -8;
-    MaxOffset = 7;
     break;
   }
 

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -3166,6 +3166,30 @@ unsigned AArch64InstrInfo::getLoadStoreImmIdx(unsigned Opc) {
   case AArch64::STRWpre:
   case AArch64::STRXpost:
   case AArch64::STRXpre:
+  case AArch64::LD1B_2Z_IMM:
+  case AArch64::LD1B_2Z_STRIDED_IMM:
+  case AArch64::LD1H_2Z_IMM:
+  case AArch64::LD1H_2Z_STRIDED_IMM:
+  case AArch64::LD1W_2Z_IMM:
+  case AArch64::LD1W_2Z_STRIDED_IMM:
+  case AArch64::LD1D_2Z_IMM:
+  case AArch64::LD1D_2Z_STRIDED_IMM:
+  case AArch64::LD1B_4Z_IMM:
+  case AArch64::LD1B_4Z_STRIDED_IMM:
+  case AArch64::LD1H_4Z_IMM:
+  case AArch64::LD1H_4Z_STRIDED_IMM:
+  case AArch64::LD1W_4Z_IMM:
+  case AArch64::LD1W_4Z_STRIDED_IMM:
+  case AArch64::LD1D_4Z_IMM:
+  case AArch64::LD1D_4Z_STRIDED_IMM:
+  case AArch64::LD1B_2Z_IMM_PSEUDO:
+  case AArch64::LD1H_2Z_IMM_PSEUDO:
+  case AArch64::LD1W_2Z_IMM_PSEUDO:
+  case AArch64::LD1D_2Z_IMM_PSEUDO:
+  case AArch64::LD1B_4Z_IMM_PSEUDO:
+  case AArch64::LD1H_4Z_IMM_PSEUDO:
+  case AArch64::LD1W_4Z_IMM_PSEUDO:
+  case AArch64::LD1D_4Z_IMM_PSEUDO:
     return 3;
   case AArch64::LDPDpost:
   case AArch64::LDPDpre:
@@ -4992,6 +5016,40 @@ bool AArch64InstrInfo::getMemOpInfo(unsigned Opcode, TypeSize &Scale,
     Width = TypeSize::getFixed(8);
     MinOffset = 0;
     MaxOffset = 63;
+    break;
+  case AArch64::LD1B_2Z_IMM:
+  case AArch64::LD1B_2Z_STRIDED_IMM:
+  case AArch64::LD1H_2Z_IMM:
+  case AArch64::LD1H_2Z_STRIDED_IMM:
+  case AArch64::LD1W_2Z_IMM:
+  case AArch64::LD1W_2Z_STRIDED_IMM:
+  case AArch64::LD1D_2Z_IMM:
+  case AArch64::LD1D_2Z_STRIDED_IMM:
+  case AArch64::LD1B_2Z_IMM_PSEUDO:
+  case AArch64::LD1H_2Z_IMM_PSEUDO:
+  case AArch64::LD1W_2Z_IMM_PSEUDO:
+  case AArch64::LD1D_2Z_IMM_PSEUDO:
+    Scale = TypeSize::getScalable(/*Width*/ 16 * /*NVecs*/ 2 * /*ImmScale*/ 2);
+    Width = TypeSize::getScalable(/*Width*/ 16 * /*NVecs*/ 2);
+    MinOffset = -8;
+    MaxOffset = 7;
+    break;
+  case AArch64::LD1B_4Z_IMM:
+  case AArch64::LD1B_4Z_STRIDED_IMM:
+  case AArch64::LD1H_4Z_IMM:
+  case AArch64::LD1H_4Z_STRIDED_IMM:
+  case AArch64::LD1W_4Z_IMM:
+  case AArch64::LD1W_4Z_STRIDED_IMM:
+  case AArch64::LD1D_4Z_IMM:
+  case AArch64::LD1D_4Z_STRIDED_IMM:
+  case AArch64::LD1B_4Z_IMM_PSEUDO:
+  case AArch64::LD1H_4Z_IMM_PSEUDO:
+  case AArch64::LD1W_4Z_IMM_PSEUDO:
+  case AArch64::LD1D_4Z_IMM_PSEUDO:
+    Scale = TypeSize::getScalable(/*Width*/ 16 * /*NVecs*/ 4 * /*ImmScale*/ 4);
+    Width = TypeSize::getScalable(/*Width*/ 16 * /*NVecs*/ 4);
+    MinOffset = -8;
+    MaxOffset = 7;
     break;
   }
 

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -5029,7 +5029,7 @@ bool AArch64InstrInfo::getMemOpInfo(unsigned Opcode, TypeSize &Scale,
   case AArch64::LD1H_2Z_IMM_PSEUDO:
   case AArch64::LD1W_2Z_IMM_PSEUDO:
   case AArch64::LD1D_2Z_IMM_PSEUDO:
-    Scale = TypeSize::getScalable(/*Width*/ 16 * /*NVecs*/ 2 * /*ImmScale*/ 2);
+    Scale = TypeSize::getScalable(/*Width*/ 16 * /*NVecs*/ 2);
     Width = TypeSize::getScalable(/*Width*/ 16 * /*NVecs*/ 2);
     MinOffset = -8;
     MaxOffset = 7;
@@ -5046,7 +5046,7 @@ bool AArch64InstrInfo::getMemOpInfo(unsigned Opcode, TypeSize &Scale,
   case AArch64::LD1H_4Z_IMM_PSEUDO:
   case AArch64::LD1W_4Z_IMM_PSEUDO:
   case AArch64::LD1D_4Z_IMM_PSEUDO:
-    Scale = TypeSize::getScalable(/*Width*/ 16 * /*NVecs*/ 4 * /*ImmScale*/ 4);
+    Scale = TypeSize::getScalable(/*Width*/ 16 * /*NVecs*/ 4);
     Width = TypeSize::getScalable(/*Width*/ 16 * /*NVecs*/ 4);
     MinOffset = -8;
     MaxOffset = 7;

--- a/llvm/test/CodeGen/AArch64/sve-ldst-multi-vec.mir
+++ b/llvm/test/CodeGen/AArch64/sve-ldst-multi-vec.mir
@@ -99,37 +99,37 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: early-clobber $sp = frame-setup STRXpre killed $fp, $sp, -16 :: (store (s64) into %stack.1)
     ; CHECK-NEXT: $sp = frame-setup ADDVL_XXI $sp, -32, implicit $vg
-    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -4, implicit $vg
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -2, implicit $vg
     ; CHECK-NEXT: $z16_z24 = LD1B_2Z_IMM_PSEUDO renamable $pn8, killed $x8, -8
-    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 4, implicit $vg
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 2, implicit $vg
     ; CHECK-NEXT: $z16_z24 = LD1B_2Z_IMM_PSEUDO renamable $pn8, killed $x8, 7
-    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -4, implicit $vg
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -2, implicit $vg
     ; CHECK-NEXT: $z16_z24 = LD1H_2Z_IMM_PSEUDO renamable $pn8, killed $x8, -8
-    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 4, implicit $vg
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 2, implicit $vg
     ; CHECK-NEXT: $z16_z24 = LD1H_2Z_IMM_PSEUDO renamable $pn8, killed $x8, 7
-    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -4, implicit $vg
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -2, implicit $vg
     ; CHECK-NEXT: $z16_z24 = LD1W_2Z_IMM_PSEUDO renamable $pn8, killed $x8, -8
-    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 4, implicit $vg
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 2, implicit $vg
     ; CHECK-NEXT: $z16_z24 = LD1W_2Z_IMM_PSEUDO renamable $pn8, killed $x8, 7
-    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -4, implicit $vg
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -2, implicit $vg
     ; CHECK-NEXT: $z16_z24 = LD1D_2Z_IMM_PSEUDO renamable $pn8, killed $x8, -8
-    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 4, implicit $vg
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 2, implicit $vg
     ; CHECK-NEXT: $z16_z24 = LD1D_2Z_IMM_PSEUDO renamable $pn8, killed $x8, 7
-    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -16, implicit $vg
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -4, implicit $vg
     ; CHECK-NEXT: $z16_z20_z24_z28 = LD1B_4Z_IMM_PSEUDO renamable $pn8, killed $x8, -8
-    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 16, implicit $vg
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 4, implicit $vg
     ; CHECK-NEXT: $z16_z20_z24_z28 = LD1B_4Z_IMM_PSEUDO renamable $pn8, killed $x8, 7
-    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -16, implicit $vg
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -4, implicit $vg
     ; CHECK-NEXT: $z16_z20_z24_z28 = LD1H_4Z_IMM_PSEUDO renamable $pn8, killed $x8, -8
-    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 16, implicit $vg
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 4, implicit $vg
     ; CHECK-NEXT: $z16_z20_z24_z28 = LD1H_4Z_IMM_PSEUDO renamable $pn8, killed $x8, 7
-    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -16, implicit $vg
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -4, implicit $vg
     ; CHECK-NEXT: $z16_z20_z24_z28 = LD1W_4Z_IMM_PSEUDO renamable $pn8, killed $x8, -8
-    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 16, implicit $vg
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 4, implicit $vg
     ; CHECK-NEXT: $z16_z20_z24_z28 = LD1W_4Z_IMM_PSEUDO renamable $pn8, killed $x8, 7
-    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -16, implicit $vg
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -4, implicit $vg
     ; CHECK-NEXT: $z16_z20_z24_z28 = LD1D_4Z_IMM_PSEUDO renamable $pn8, killed $x8, -8
-    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 16, implicit $vg
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 4, implicit $vg
     ; CHECK-NEXT: $z16_z20_z24_z28 = LD1D_4Z_IMM_PSEUDO renamable $pn8, killed $x8, 7
     ; CHECK-NEXT: $sp = frame-destroy ADDVL_XXI $sp, 31, implicit $vg
     ; CHECK-NEXT: $sp = frame-destroy ADDVL_XXI $sp, 1, implicit $vg
@@ -139,37 +139,37 @@ body:             |
     ; CHECK-OFFSET-LABEL: testcase_offset_out_of_range:
     ; CHECK-OFFSET: str	x29, [sp, #-16]!
     ; CHECK-OFFSET-NEXT: addvl	sp, sp, #-32
-    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-4
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-2
     ; CHECK-OFFSET-NEXT: ld1b	{ z16.b, z24.b }, pn8/z, [x8, #-16, mul vl]
-    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #4
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #2
     ; CHECK-OFFSET-NEXT: ld1b	{ z16.b, z24.b }, pn8/z, [x8, #14, mul vl]
-    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-4
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-2
     ; CHECK-OFFSET-NEXT: ld1h	{ z16.h, z24.h }, pn8/z, [x8, #-16, mul vl]
-    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #4
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #2
     ; CHECK-OFFSET-NEXT: ld1h	{ z16.h, z24.h }, pn8/z, [x8, #14, mul vl]
-    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-4
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-2
     ; CHECK-OFFSET-NEXT: ld1w	{ z16.s, z24.s }, pn8/z, [x8, #-16, mul vl]
-    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #4
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #2
     ; CHECK-OFFSET-NEXT: ld1w	{ z16.s, z24.s }, pn8/z, [x8, #14, mul vl]
-    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-4
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-2
     ; CHECK-OFFSET-NEXT: ld1d	{ z16.d, z24.d }, pn8/z, [x8, #-16, mul vl]
-    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #4
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #2
     ; CHECK-OFFSET-NEXT: ld1d	{ z16.d, z24.d }, pn8/z, [x8, #14, mul vl]
-    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-16
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-4
     ; CHECK-OFFSET-NEXT: ld1b	{ z16.b, z20.b, z24.b, z28.b }, pn8/z, [x8, #-32, mul vl]
-    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #16
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #4
     ; CHECK-OFFSET-NEXT: ld1b	{ z16.b, z20.b, z24.b, z28.b }, pn8/z, [x8, #28, mul vl]
-    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-16
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-4
     ; CHECK-OFFSET-NEXT: ld1h	{ z16.h, z20.h, z24.h, z28.h }, pn8/z, [x8, #-32, mul vl]
-    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #16
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #4
     ; CHECK-OFFSET-NEXT: ld1h	{ z16.h, z20.h, z24.h, z28.h }, pn8/z, [x8, #28, mul vl]
-    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-16
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-4
     ; CHECK-OFFSET-NEXT: ld1w	{ z16.s, z20.s, z24.s, z28.s }, pn8/z, [x8, #-32, mul vl]
-    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #16
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #4
     ; CHECK-OFFSET-NEXT: ld1w	{ z16.s, z20.s, z24.s, z28.s }, pn8/z, [x8, #28, mul vl]
-    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-16
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-4
     ; CHECK-OFFSET-NEXT: ld1d	{ z16.d, z20.d, z24.d, z28.d }, pn8/z, [x8, #-32, mul vl]
-    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #16
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #4
     ; CHECK-OFFSET-NEXT: ld1d	{ z16.d, z20.d, z24.d, z28.d }, pn8/z, [x8, #28, mul vl]
     ; CHECK-OFFSET-NEXT: addvl	sp, sp, #31
     ; CHECK-OFFSET-NEXT: addvl	sp, sp, #1

--- a/llvm/test/CodeGen/AArch64/sve-ldst-multi-vec.mir
+++ b/llvm/test/CodeGen/AArch64/sve-ldst-multi-vec.mir
@@ -1,0 +1,198 @@
+# RUN: llc -mtriple=aarch64-linux-gnu -mattr=+sme2 -run-pass=prologepilog -simplify-mir -verify-machineinstrs %s -o - | FileCheck %s
+# RUN: llc -mtriple=aarch64-linux-gnu -mattr=+sme2 -start-before=prologepilog -simplify-mir -verify-machineinstrs %s -o - | FileCheck %s --check-prefix=CHECK-OFFSET
+
+--- |
+  define void @testcase_valid_offset() "aarch64_pstate_sm_enabled" nounwind { entry: unreachable }
+  define void @testcase_offset_out_of_range() "aarch64_pstate_sm_enabled" nounwind { entry: unreachable }
+...
+---
+name:            testcase_valid_offset
+tracksRegLiveness: true
+stack:
+  - { id: 0, name: '', type: default, offset: 0, size: 512, alignment: 16, stack-id: scalable-vector }
+body:             |
+  bb.0:
+    liveins: $pn8, $z16
+
+    ; CHECK-LABEL: name: testcase_valid_offset
+    ; CHECK: liveins: $pn8, $z16, $fp
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: early-clobber $sp = frame-setup STRXpre killed $fp, $sp, -16 :: (store (s64) into %stack.1)
+    ; CHECK-NEXT: $sp = frame-setup ADDVL_XXI $sp, -32, implicit $vg
+    ; CHECK-NEXT: $z16_z24 = LD1B_2Z_IMM_PSEUDO renamable $pn8, $sp, -8
+    ; CHECK-NEXT: $z16_z24 = LD1B_2Z_IMM_PSEUDO renamable $pn8, $sp, 7
+    ; CHECK-NEXT: $z16_z24 = LD1H_2Z_IMM_PSEUDO renamable $pn8, $sp, -8
+    ; CHECK-NEXT: $z16_z24 = LD1H_2Z_IMM_PSEUDO renamable $pn8, $sp, 7
+    ; CHECK-NEXT: $z16_z24 = LD1W_2Z_IMM_PSEUDO renamable $pn8, $sp, -8
+    ; CHECK-NEXT: $z16_z24 = LD1W_2Z_IMM_PSEUDO renamable $pn8, $sp, 7
+    ; CHECK-NEXT: $z16_z24 = LD1D_2Z_IMM_PSEUDO renamable $pn8, $sp, -8
+    ; CHECK-NEXT: $z16_z24 = LD1D_2Z_IMM_PSEUDO renamable $pn8, $sp, 7
+    ; CHECK-NEXT: $z16_z20_z24_z28 = LD1B_4Z_IMM_PSEUDO renamable $pn8, $sp, -8
+    ; CHECK-NEXT: $z16_z20_z24_z28 = LD1B_4Z_IMM_PSEUDO renamable $pn8, $sp, 7
+    ; CHECK-NEXT: $z16_z20_z24_z28 = LD1H_4Z_IMM_PSEUDO renamable $pn8, $sp, -8
+    ; CHECK-NEXT: $z16_z20_z24_z28 = LD1H_4Z_IMM_PSEUDO renamable $pn8, $sp, 7
+    ; CHECK-NEXT: $z16_z20_z24_z28 = LD1W_4Z_IMM_PSEUDO renamable $pn8, $sp, -8
+    ; CHECK-NEXT: $z16_z20_z24_z28 = LD1W_4Z_IMM_PSEUDO renamable $pn8, $sp, 7
+    ; CHECK-NEXT: $z16_z20_z24_z28 = LD1D_4Z_IMM_PSEUDO renamable $pn8, $sp, -8
+    ; CHECK-NEXT: $z16_z20_z24_z28 = LD1D_4Z_IMM_PSEUDO renamable $pn8, $sp, 7
+    ; CHECK-NEXT: $sp = frame-destroy ADDVL_XXI $sp, 31, implicit $vg
+    ; CHECK-NEXT: $sp = frame-destroy ADDVL_XXI $sp, 1, implicit $vg
+    ; CHECK-NEXT: early-clobber $sp, $fp = frame-destroy LDRXpost $sp, 16 :: (load (s64) from %stack.1)
+    ; CHECK-NEXT: RET_ReallyLR
+
+    ; CHECK-OFFSET-LABEL: testcase_valid_offset:
+    ; CHECK-OFFSET:	str	x29, [sp, #-16]!
+    ; CHECK-OFFSET-NEXT: addvl	sp, sp, #-32
+    ; CHECK-OFFSET-NEXT: ld1b	{ z16.b, z24.b }, pn8/z, [sp, #-16, mul vl]
+    ; CHECK-OFFSET-NEXT: ld1b	{ z16.b, z24.b }, pn8/z, [sp, #14, mul vl]
+    ; CHECK-OFFSET-NEXT: ld1h	{ z16.h, z24.h }, pn8/z, [sp, #-16, mul vl]
+    ; CHECK-OFFSET-NEXT: ld1h	{ z16.h, z24.h }, pn8/z, [sp, #14, mul vl]
+    ; CHECK-OFFSET-NEXT: ld1w	{ z16.s, z24.s }, pn8/z, [sp, #-16, mul vl]
+    ; CHECK-OFFSET-NEXT: ld1w	{ z16.s, z24.s }, pn8/z, [sp, #14, mul vl]
+    ; CHECK-OFFSET-NEXT: ld1d	{ z16.d, z24.d }, pn8/z, [sp, #-16, mul vl]
+    ; CHECK-OFFSET-NEXT: ld1d	{ z16.d, z24.d }, pn8/z, [sp, #14, mul vl]
+    ; CHECK-OFFSET-NEXT: ld1b	{ z16.b, z20.b, z24.b, z28.b }, pn8/z, [sp, #-32, mul vl]
+    ; CHECK-OFFSET-NEXT: ld1b	{ z16.b, z20.b, z24.b, z28.b }, pn8/z, [sp, #28, mul vl]
+    ; CHECK-OFFSET-NEXT: ld1h	{ z16.h, z20.h, z24.h, z28.h }, pn8/z, [sp, #-32, mul vl]
+    ; CHECK-OFFSET-NEXT: ld1h	{ z16.h, z20.h, z24.h, z28.h }, pn8/z, [sp, #28, mul vl]
+    ; CHECK-OFFSET-NEXT: ld1w	{ z16.s, z20.s, z24.s, z28.s }, pn8/z, [sp, #-32, mul vl]
+    ; CHECK-OFFSET-NEXT: ld1w	{ z16.s, z20.s, z24.s, z28.s }, pn8/z, [sp, #28, mul vl]
+    ; CHECK-OFFSET-NEXT: ld1d	{ z16.d, z20.d, z24.d, z28.d }, pn8/z, [sp, #-32, mul vl]
+    ; CHECK-OFFSET-NEXT: ld1d	{ z16.d, z20.d, z24.d, z28.d }, pn8/z, [sp, #28, mul vl]
+    ; CHECK-OFFSET-NEXT: addvl	sp, sp, #31
+    ; CHECK-OFFSET-NEXT: addvl	sp, sp, #1
+    ; CHECK-OFFSET-NEXT: ldr	x29, [sp], #16
+    ; CHECK-OFFSET-NEXT: ret
+
+    $z16_z24 = LD1B_2Z_IMM_PSEUDO renamable $pn8, %stack.0, -8
+    $z16_z24 = LD1B_2Z_IMM_PSEUDO renamable $pn8, %stack.0, 7
+    $z16_z24 = LD1H_2Z_IMM_PSEUDO renamable $pn8, %stack.0, -8
+    $z16_z24 = LD1H_2Z_IMM_PSEUDO renamable $pn8, %stack.0, 7
+    $z16_z24 = LD1W_2Z_IMM_PSEUDO renamable $pn8, %stack.0, -8
+    $z16_z24 = LD1W_2Z_IMM_PSEUDO renamable $pn8, %stack.0, 7
+    $z16_z24 = LD1D_2Z_IMM_PSEUDO renamable $pn8, %stack.0, -8
+    $z16_z24 = LD1D_2Z_IMM_PSEUDO renamable $pn8, %stack.0, 7
+
+    $z16_z20_z24_z28 = LD1B_4Z_IMM_PSEUDO renamable $pn8, %stack.0, -8
+    $z16_z20_z24_z28 = LD1B_4Z_IMM_PSEUDO renamable $pn8, %stack.0, 7
+    $z16_z20_z24_z28 = LD1H_4Z_IMM_PSEUDO renamable $pn8, %stack.0, -8
+    $z16_z20_z24_z28 = LD1H_4Z_IMM_PSEUDO renamable $pn8, %stack.0, 7
+    $z16_z20_z24_z28 = LD1W_4Z_IMM_PSEUDO renamable $pn8, %stack.0, -8
+    $z16_z20_z24_z28 = LD1W_4Z_IMM_PSEUDO renamable $pn8, %stack.0, 7
+    $z16_z20_z24_z28 = LD1D_4Z_IMM_PSEUDO renamable $pn8, %stack.0, -8
+    $z16_z20_z24_z28 = LD1D_4Z_IMM_PSEUDO renamable $pn8, %stack.0, 7
+
+
+    RET_ReallyLR
+...
+---
+name:            testcase_offset_out_of_range
+tracksRegLiveness: true
+stack:
+  - { id: 0, name: '', type: default, offset: 0, size: 512, alignment: 16, stack-id: scalable-vector }
+body:             |
+  bb.0:
+    liveins: $pn8, $z16
+
+    ; CHECK-LABEL: name: testcase_offset_out_of_range
+    ; CHECK: liveins: $pn8, $z16, $fp
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: early-clobber $sp = frame-setup STRXpre killed $fp, $sp, -16 :: (store (s64) into %stack.1)
+    ; CHECK-NEXT: $sp = frame-setup ADDVL_XXI $sp, -32, implicit $vg
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -4, implicit $vg
+    ; CHECK-NEXT: $z16_z24 = LD1B_2Z_IMM_PSEUDO renamable $pn8, killed $x8, -8
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 4, implicit $vg
+    ; CHECK-NEXT: $z16_z24 = LD1B_2Z_IMM_PSEUDO renamable $pn8, killed $x8, 7
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -4, implicit $vg
+    ; CHECK-NEXT: $z16_z24 = LD1H_2Z_IMM_PSEUDO renamable $pn8, killed $x8, -8
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 4, implicit $vg
+    ; CHECK-NEXT: $z16_z24 = LD1H_2Z_IMM_PSEUDO renamable $pn8, killed $x8, 7
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -4, implicit $vg
+    ; CHECK-NEXT: $z16_z24 = LD1W_2Z_IMM_PSEUDO renamable $pn8, killed $x8, -8
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 4, implicit $vg
+    ; CHECK-NEXT: $z16_z24 = LD1W_2Z_IMM_PSEUDO renamable $pn8, killed $x8, 7
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -4, implicit $vg
+    ; CHECK-NEXT: $z16_z24 = LD1D_2Z_IMM_PSEUDO renamable $pn8, killed $x8, -8
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 4, implicit $vg
+    ; CHECK-NEXT: $z16_z24 = LD1D_2Z_IMM_PSEUDO renamable $pn8, killed $x8, 7
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -16, implicit $vg
+    ; CHECK-NEXT: $z16_z20_z24_z28 = LD1B_4Z_IMM_PSEUDO renamable $pn8, killed $x8, -8
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 16, implicit $vg
+    ; CHECK-NEXT: $z16_z20_z24_z28 = LD1B_4Z_IMM_PSEUDO renamable $pn8, killed $x8, 7
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -16, implicit $vg
+    ; CHECK-NEXT: $z16_z20_z24_z28 = LD1H_4Z_IMM_PSEUDO renamable $pn8, killed $x8, -8
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 16, implicit $vg
+    ; CHECK-NEXT: $z16_z20_z24_z28 = LD1H_4Z_IMM_PSEUDO renamable $pn8, killed $x8, 7
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -16, implicit $vg
+    ; CHECK-NEXT: $z16_z20_z24_z28 = LD1W_4Z_IMM_PSEUDO renamable $pn8, killed $x8, -8
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 16, implicit $vg
+    ; CHECK-NEXT: $z16_z20_z24_z28 = LD1W_4Z_IMM_PSEUDO renamable $pn8, killed $x8, 7
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, -16, implicit $vg
+    ; CHECK-NEXT: $z16_z20_z24_z28 = LD1D_4Z_IMM_PSEUDO renamable $pn8, killed $x8, -8
+    ; CHECK-NEXT: $x8 = ADDVL_XXI $sp, 16, implicit $vg
+    ; CHECK-NEXT: $z16_z20_z24_z28 = LD1D_4Z_IMM_PSEUDO renamable $pn8, killed $x8, 7
+    ; CHECK-NEXT: $sp = frame-destroy ADDVL_XXI $sp, 31, implicit $vg
+    ; CHECK-NEXT: $sp = frame-destroy ADDVL_XXI $sp, 1, implicit $vg
+    ; CHECK-NEXT: early-clobber $sp, $fp = frame-destroy LDRXpost $sp, 16 :: (load (s64) from %stack.1)
+    ; CHECK-NEXT: RET_ReallyLR
+
+    ; CHECK-OFFSET-LABEL: testcase_offset_out_of_range:
+    ; CHECK-OFFSET: str	x29, [sp, #-16]!
+    ; CHECK-OFFSET-NEXT: addvl	sp, sp, #-32
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-4
+    ; CHECK-OFFSET-NEXT: ld1b	{ z16.b, z24.b }, pn8/z, [x8, #-16, mul vl]
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #4
+    ; CHECK-OFFSET-NEXT: ld1b	{ z16.b, z24.b }, pn8/z, [x8, #14, mul vl]
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-4
+    ; CHECK-OFFSET-NEXT: ld1h	{ z16.h, z24.h }, pn8/z, [x8, #-16, mul vl]
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #4
+    ; CHECK-OFFSET-NEXT: ld1h	{ z16.h, z24.h }, pn8/z, [x8, #14, mul vl]
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-4
+    ; CHECK-OFFSET-NEXT: ld1w	{ z16.s, z24.s }, pn8/z, [x8, #-16, mul vl]
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #4
+    ; CHECK-OFFSET-NEXT: ld1w	{ z16.s, z24.s }, pn8/z, [x8, #14, mul vl]
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-4
+    ; CHECK-OFFSET-NEXT: ld1d	{ z16.d, z24.d }, pn8/z, [x8, #-16, mul vl]
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #4
+    ; CHECK-OFFSET-NEXT: ld1d	{ z16.d, z24.d }, pn8/z, [x8, #14, mul vl]
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-16
+    ; CHECK-OFFSET-NEXT: ld1b	{ z16.b, z20.b, z24.b, z28.b }, pn8/z, [x8, #-32, mul vl]
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #16
+    ; CHECK-OFFSET-NEXT: ld1b	{ z16.b, z20.b, z24.b, z28.b }, pn8/z, [x8, #28, mul vl]
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-16
+    ; CHECK-OFFSET-NEXT: ld1h	{ z16.h, z20.h, z24.h, z28.h }, pn8/z, [x8, #-32, mul vl]
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #16
+    ; CHECK-OFFSET-NEXT: ld1h	{ z16.h, z20.h, z24.h, z28.h }, pn8/z, [x8, #28, mul vl]
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-16
+    ; CHECK-OFFSET-NEXT: ld1w	{ z16.s, z20.s, z24.s, z28.s }, pn8/z, [x8, #-32, mul vl]
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #16
+    ; CHECK-OFFSET-NEXT: ld1w	{ z16.s, z20.s, z24.s, z28.s }, pn8/z, [x8, #28, mul vl]
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #-16
+    ; CHECK-OFFSET-NEXT: ld1d	{ z16.d, z20.d, z24.d, z28.d }, pn8/z, [x8, #-32, mul vl]
+    ; CHECK-OFFSET-NEXT: addvl	x8, sp, #16
+    ; CHECK-OFFSET-NEXT: ld1d	{ z16.d, z20.d, z24.d, z28.d }, pn8/z, [x8, #28, mul vl]
+    ; CHECK-OFFSET-NEXT: addvl	sp, sp, #31
+    ; CHECK-OFFSET-NEXT: addvl	sp, sp, #1
+    ; CHECK-OFFSET-NEXT: ldr	x29, [sp], #16
+    ; CHECK-OFFSET-NEXT: ret
+
+    $z16_z24 = LD1B_2Z_IMM_PSEUDO renamable $pn8, %stack.0, -9
+    $z16_z24 = LD1B_2Z_IMM_PSEUDO renamable $pn8, %stack.0, 8
+    $z16_z24 = LD1H_2Z_IMM_PSEUDO renamable $pn8, %stack.0, -9
+    $z16_z24 = LD1H_2Z_IMM_PSEUDO renamable $pn8, %stack.0, 8
+    $z16_z24 = LD1W_2Z_IMM_PSEUDO renamable $pn8, %stack.0, -9
+    $z16_z24 = LD1W_2Z_IMM_PSEUDO renamable $pn8, %stack.0, 8
+    $z16_z24 = LD1D_2Z_IMM_PSEUDO renamable $pn8, %stack.0, -9
+    $z16_z24 = LD1D_2Z_IMM_PSEUDO renamable $pn8, %stack.0, 8
+
+    $z16_z20_z24_z28 = LD1B_4Z_IMM_PSEUDO renamable $pn8, %stack.0, -9
+    $z16_z20_z24_z28 = LD1B_4Z_IMM_PSEUDO renamable $pn8, %stack.0, 8
+    $z16_z20_z24_z28 = LD1H_4Z_IMM_PSEUDO renamable $pn8, %stack.0, -9
+    $z16_z20_z24_z28 = LD1H_4Z_IMM_PSEUDO renamable $pn8, %stack.0, 8
+    $z16_z20_z24_z28 = LD1W_4Z_IMM_PSEUDO renamable $pn8, %stack.0, -9
+    $z16_z20_z24_z28 = LD1W_4Z_IMM_PSEUDO renamable $pn8, %stack.0, 8
+    $z16_z20_z24_z28 = LD1D_4Z_IMM_PSEUDO renamable $pn8, %stack.0, -9
+    $z16_z20_z24_z28 = LD1D_4Z_IMM_PSEUDO renamable $pn8, %stack.0, 8
+
+    RET_ReallyLR
+...


### PR DESCRIPTION
We recently started emitting these in 84fab943b5740ec273e9f8d238ea8420033320a4, which now means we can hit an unhandled opcode error in AArch64InstrInfo::getMemOpInfo when resolving stack offsets.

Fixes #200034