### PR TITLE
[C23] Combine two proposals on C status tracking page

### DIFF
--- a/clang/www/c_status.html
+++ b/clang/www/c_status.html
@@ -831,11 +831,6 @@ conformance.</p>
       <td class="full" align="center">Clang 15</td>
     </tr>
     <tr>
-      <td>Remove default argument promotions for _FloatN types</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2844.pdf">N2844</a></td>
-      <td class="none" align="center">No</td>
-    </tr>
-    <tr>
       <td>Revised Suggestions of Change for Numerically Equal/Equivalent</td>
       <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2847.pdf">N2847</a></td>
       <td class="full" align="center">Yes</td>
@@ -893,11 +888,17 @@ conformance.</p>
       <td class="full" align="center">Yes</td>
     </tr>
     <!-- May 2022 Papers -->
-    <tr>
-      <td>Annex X (replacing Annex H) for IEC 60559 interchange</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2601.pdf">N2601</a></td>
-      <td class="none" align="center">No</td>
+    <tr id="annex-h">
+      <td rowspan="3">Annex H (interchange and extended types)</td>
     </tr>
+      <tr>
+        <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2601.pdf">N2601</a></td>
+        <td class="none" align="center">No</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2844.pdf">N2844</a></td>
+        <td class="none" align="center">No</td>
+      </tr>
     <tr>
       <td>Indeterminate Values and Trap Representations</td>
       <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2861.pdf">N2861</a></td>


### PR DESCRIPTION
N2601 is what added Annex H for the interchange and extended floating point types.

N2844 removed default argument promotions for the types in Annex H.

So these two proposals really do go together.