### PR TITLE
CI: ignore errors on HLSL Publish step

### DIFF
--- a/.github/workflows/hlsl-test-all.yaml
+++ b/.github/workflows/hlsl-test-all.yaml
@@ -81,6 +81,7 @@ jobs:
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action/macos@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         if: always() && runner.os == 'macOS'
+        continue-on-error: true
         with:
           comment_mode: off
           files: llvm-project/build/**/testresults.xunit.xml


### PR DESCRIPTION
This step seems to fail consistently on the remote endpoint for large PRs.

Example: https://github.com/llvm/llvm-project/actions/runs/26589632748/job/78344693871?pr=199528