### PR TITLE
[AMDGPU] Use direct lookup table for VOPD eligibility

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.td
@@ -3543,7 +3543,7 @@ def FP4FP8DstByteSelTable : GenericTable {
 def VOPDComponentTable : GenericTable {
   let FilterClass = "VOPD_Component";
   let CppTypeName = "VOPDComponentInfo";
-  let Fields = ["BaseVOP", "VOPDOp", "CanBeVOPDX"];
+  let Fields = ["BaseVOP", "VOPDOp"];
   let PrimaryKey = ["BaseVOP"];
   let PrimaryKeyName = "getVOPDComponentHelper";
 }
@@ -3573,24 +3573,21 @@ def hi16_to_vgpr32 : OutPatFrag<(ops node:$op),
   (REG_SEQUENCE VGPR_32, (i16 (IMPLICIT_DEF)), lo16, $op, hi16)>;
 
 // Instructions eligible to be the first (X) instruction in Dual Issue VALU
-// (VOPD) encoding. This only includes VOPD3 opcodes that are subtarget dependent.
-// Non-VOPD3 opcodes should be checked with CanBeVOPDX from VOPDComponentTable.
+// (VOPD) encoding. Consumed by buildVOPDXYLookup() to build a direct lookup
+// table; no helper is generated.
 def VOPDXTable : GenericTable {
   let FilterClass = "VOPDX";
   let CppTypeName = "VOPDXYInfo";
   let Fields = ["VOPDOp", "Subtarget", "VOPD3"];
-  let PrimaryKey = ["VOPDOp", "Subtarget", "VOPD3"];
-  let PrimaryKeyName = "canBeVOPDX";
 }
 
 // Instructions eligible to be the second (Y) instruction in Dual Issue VALU
-// (VOPD) encoding.
+// (VOPD) encoding. Consumed by buildVOPDXYLookup() to build a direct lookup
+// table; no helper is generated.
 def VOPDYTable : GenericTable {
   let FilterClass = "VOPDY";
   let CppTypeName = "VOPDXYInfo";
   let Fields = ["VOPDOp", "Subtarget", "VOPD3"];
-  let PrimaryKey = ["VOPDOp", "Subtarget", "VOPD3"];
-  let PrimaryKeyName = "canBeVOPDY";
 }
 
 include "SIInstructions.td"

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -404,7 +404,6 @@ struct VOP3CDPPAsmOnlyInfo {
 struct VOPDComponentInfo {
   uint16_t BaseVOP;
   uint16_t VOPDOp;
-  bool CanBeVOPDX;
 };
 
 struct VOPDInfo {
@@ -663,6 +662,28 @@ unsigned getVOPDEncodingFamily(const MCSubtargetInfo &ST) {
   llvm_unreachable("Subtarget generation does not support VOPD!");
 }
 
+static constexpr unsigned getVOPDXYKey(unsigned VOPDOp, unsigned Subtarget,
+                                       bool VOPD3) {
+  return (VOPDOp << 5) | (Subtarget << 1) | (VOPD3 ? 1u : 0u);
+}
+
+// TODO: Ideally, the table should be emitted by the TableGen backend, however
+// this is currently not supported, so the direct lookup table is generated
+// manually here.
+constexpr unsigned VOPDXYKeyBits = 11;
+static constexpr std::array<CanBeVOPD, 1 << VOPDXYKeyBits> buildVOPDXYLookup() {
+  std::array<CanBeVOPD, 1 << VOPDXYKeyBits> Table{};
+  for (auto &E : Table)
+    E = {false, false};
+  for (const auto &E : VOPDXTable)
+    Table[getVOPDXYKey(E.VOPDOp, E.Subtarget, E.VOPD3)].X = true;
+  for (const auto &E : VOPDYTable)
+    Table[getVOPDXYKey(E.VOPDOp, E.Subtarget, E.VOPD3)].Y = true;
+  return Table;
+}
+
+constexpr auto VOPDXYLookup = buildVOPDXYLookup();
+
 CanBeVOPD getCanBeVOPD(unsigned Opc, unsigned EncodingFamily, bool VOPD3) {
   bool IsConvertibleToBitOp = VOPD3 ? getBitOp2(Opc) : 0;
   Opc = IsConvertibleToBitOp ? (unsigned)AMDGPU::V_BITOP3_B32_e64 : Opc;
@@ -671,14 +692,7 @@ CanBeVOPD getCanBeVOPD(unsigned Opc, unsigned EncodingFamily, bool VOPD3) {
   const VOPDComponentInfo *Info = getVOPDComponentHelper(Opc);
   if (!Info)
     return {false, false};
-  if (VOPD3) {
-    return {canBeVOPDX(Info->VOPDOp, EncodingFamily, true) != nullptr,
-            canBeVOPDY(Info->VOPDOp, EncodingFamily, true) != nullptr};
-  }
-  // VOPDX eligibility is encoding-family-independent for non-VOPD3, so re-use
-  // information in Info.
-  return {Info->CanBeVOPDX,
-          canBeVOPDY(Info->VOPDOp, EncodingFamily, false) != nullptr};
+  return VOPDXYLookup[getVOPDXYKey(Info->VOPDOp, EncodingFamily, VOPD3)];
 }
 
 unsigned getVOPDOpcode(unsigned Opc, bool VOPD3) {

--- a/llvm/lib/Target/AMDGPU/VOPDInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOPDInstructions.td
@@ -300,6 +300,9 @@ class VOPDX<bits<6> Op, int Sub, bit IsVOPD3> : VOPDXY<Op, Sub, IsVOPD3>;
 class VOPDY<bits<6> Op, int Sub, bit IsVOPD3> : VOPDXY<Op, Sub, IsVOPD3>;
 
 foreach Gen = [GFX11GenD, GFX1170GenD, GFX12GenD, GFX1250GenD, GFX13GenD] in {
+  foreach p = Gen.VOPDXPseudos in
+    def "VOPDX_" # p # Gen.Suffix :
+        VOPDX<!cast<VOPD_Component>(p).VOPDOp, Gen.Subtarget, 0>;
   foreach p = Gen.VOPDYPseudos in
     def "VOPDY_" # p # Gen.Suffix :
         VOPDY<!cast<VOPD_Component>(p).VOPDOp, Gen.Subtarget, 0>;

--- a/llvm/lib/Target/AMDGPU/VOPInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOPInstructions.td
@@ -42,7 +42,6 @@ class VOPD_Component<bits<6> OpIn, string vOPDName> {
   Instruction BaseVOP = !cast<Instruction>(NAME);
   string VOPDName = "v_dual_" # !substr(vOPDName, 2);
   bits<6> VOPDOp = OpIn;
-  bit CanBeVOPDX = !le(VOPDOp, VOPDX_Max_Index);
   bit CanBeVOPD3X = !and(!le(VOPDOp, VOPD3X_Max_Index),
                          !and(!ne(vOPDName, "v_bitop2_b32"),
                               !and(!ne(vOPDName, "v_max_i32"),


### PR DESCRIPTION
This further improves lookup by using a packed key that returns both X and Y eligibility via a direct lookup, removing the need for a binary search on the VOPDX and VOPDY tables.

Due to TableGen limitations the direct lookup table is generated manually from the VOPDX and VOPDY tables. Doing it automatically is future work.

After this patch, `getCanBeVOPD` is reduced to one O(log n) binary search and one O(1) direct lookup. We could replace the whole function with a direct lookup using Opc as a key, but the new table would be an order of magnitude larger. As such, a two-step lookup is the preferred approach unless we can show that the benefit of a single lookup outweighs the significant increase in table size — especially since n in the initial O(log n) lookup is only ~50.

With this patch I'm seeing a decrease from ~2.5% to ~1.75% in perf report for `getCanBeVOPD`. The baseline has both #199072 and #200184 applied.

Assisted-By: Claude Code