### PR TITLE
Set hidden visibility for weak prefetch target symbols to avoid relocation error in shared libraries.

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2017,9 +2017,8 @@ void AsmPrinter::emitPrefetchTargetSymbol(const UniqueBBID &BBID,
   // If the function is weak-linkage it may be replaced by a strong
   // version, in which case the prefetch targets should also be replaced.
   bool IsWeak = MF->getFunction().isWeakForLinker();
-  OutStreamer->emitSymbolAttribute(
-      PrefetchTargetSymbol,
-      IsWeak ? MCSA_Weak : MCSA_Global);
+  OutStreamer->emitSymbolAttribute(PrefetchTargetSymbol,
+                                   IsWeak ? MCSA_Weak : MCSA_Global);
   if (IsWeak) {
     // Weak prefetch target symbols must have hidden visibility to avoid
     // relocation error in shared libraries.

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2016,9 +2016,15 @@ void AsmPrinter::emitPrefetchTargetSymbol(const UniqueBBID &BBID,
       getPrefetchTargetSymbolName(FunctionName, BBID, CallsiteIndex));
   // If the function is weak-linkage it may be replaced by a strong
   // version, in which case the prefetch targets should also be replaced.
+  bool IsWeak = MF->getFunction().isWeakForLinker();
   OutStreamer->emitSymbolAttribute(
       PrefetchTargetSymbol,
-      MF->getFunction().isWeakForLinker() ? MCSA_Weak : MCSA_Global);
+      IsWeak ? MCSA_Weak : MCSA_Global);
+  if (IsWeak) {
+    // Weak prefetch target symbols must have hidden visibility to avoid
+    // relocation error in shared libraries.
+    OutStreamer->emitSymbolAttribute(PrefetchTargetSymbol, MCSA_Hidden);
+  }
   OutStreamer->emitLabel(PrefetchTargetSymbol);
 }
 

--- a/llvm/lib/CodeGen/InsertCodePrefetch.cpp
+++ b/llvm/lib/CodeGen/InsertCodePrefetch.cpp
@@ -163,6 +163,7 @@ insertPrefetchHints(MachineFunction &MF,
           // available.
           if (!WeakFallbackSym->isBindingSet()) {
             WeakFallbackSym->setBinding(ELF::STB_WEAK);
+            WeakFallbackSym->setVisibility(ELF::STV_HIDDEN);
             PrefetchInstr->setPostInstrSymbol(MF, WeakFallbackSym);
           }
         }

--- a/llvm/test/CodeGen/X86/basic-block-sections-code-prefetch.ll
+++ b/llvm/test/CodeGen/X86/basic-block-sections-code-prefetch.ll
@@ -67,8 +67,10 @@ define weak i32 @bar() nounwind {
   ret i32 %call
 ; CHECK:      bar:
 ; CHECK-NEXT:   .weak __llvm_prefetch_target_bar_21_1
+; CHECK-NEXT:   .hidden __llvm_prefetch_target_bar_21_1
 ; CHECK-NEXT: __llvm_prefetch_target_bar_21_1:
 ; CHECK-NEXT:   .weak __llvm_prefetch_target_bar_0_0
+; CHECK-NEXT:   .hidden __llvm_prefetch_target_bar_0_0
 ; CHECK-NEXT: __llvm_prefetch_target_bar_0_0:
 ; CHECK:        callq baz@PLT
 ; CHECK-NEXT:   prefetchit1	__llvm_prefetch_target_foo_0_0(%rip)


### PR DESCRIPTION
An unresolved weak prefetch target will cause a linker relocation error for shared libraries since it would need special handling.

So far, we have not expanded to cross-DSO prefetching. So we make the prefetch target hidden to avoid the error.