### PR TITLE
[SYCL] Fix -nolibsycl and spurious spirv-link flags for SYCL offloading

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9664,10 +9664,11 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       // SPIR-V linker. `spirv-link` isn't called in LTO mode so restrict these
       // flags to normal compilation.
       // SPIR-V for AMD doesn't use spirv-link and therefore doesn't need these
-      // flags.
+      // flags. SYCL uses clang-sycl-linker instead of spirv-link, so skip it.
       if (TC->getTriple().isSPIRV() &&
           TC->getTriple().getVendor() != llvm::Triple::VendorType::AMD &&
-          !C.getDriver().isUsingLTO() && !C.getDriver().isUsingOffloadLTO()) {
+          Kind != Action::OFK_SYCL && !C.getDriver().isUsingLTO() &&
+          !C.getDriver().isUsingOffloadLTO()) {
         // For SPIR-V some functions will be defined by the runtime so allow
         // unresolved symbols in `spirv-link`.
         LinkerArgs.emplace_back("--allow-partial-linkage");

--- a/clang/lib/Driver/ToolChains/Linux.cpp
+++ b/clang/lib/Driver/ToolChains/Linux.cpp
@@ -880,7 +880,8 @@ void Linux::addOffloadRTLibs(unsigned ActiveKinds, const ArgList &Args,
   llvm::SmallVector<std::pair<StringRef, StringRef>> Libraries;
   if (ActiveKinds & Action::OFK_HIP)
     Libraries.emplace_back(RocmInstallation->getLibPath(), "libamdhip64.so");
-  else if (ActiveKinds & Action::OFK_SYCL)
+  else if ((ActiveKinds & Action::OFK_SYCL) &&
+           !Args.hasArg(options::OPT_nolibsycl))
     Libraries.emplace_back(SYCLInstallation->getSYCLRTLibPath(),
                            "libLLVMSYCL.so");
 

--- a/clang/test/Driver/sycl-offload-jit-unix.cpp
+++ b/clang/test/Driver/sycl-offload-jit-unix.cpp
@@ -23,3 +23,11 @@
 // RUN: %t/bin/clang -### -no-canonical-prefixes --target=x86_64-unknown-linux-gnu -fsycl %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-LSYCL-FLAT %s
 // CHECK-LSYCL-FLAT: clang-linker-wrapper{{.*}} "{{.*}}bin{{[/\\]+}}..{{[/\\]+}}lib{{[/\\]+}}libLLVMSYCL.so"
+
+// Check that -nolibsycl suppresses libLLVMSYCL.so from the linker invocation.
+// RUN: rm -rf %t && mkdir -p %t/bin %t/lib/x86_64-unknown-linux-gnu
+// RUN: touch %t/lib/x86_64-unknown-linux-gnu/libLLVMSYCL.so
+// RUN: ln -s %clang %t/bin/clang
+// RUN: %t/bin/clang -### -no-canonical-prefixes --target=x86_64-unknown-linux-gnu -fsycl -nolibsycl %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-NOLIBSYCL %s
+// CHECK-NOLIBSYCL-NOT: libLLVMSYCL.so

--- a/clang/test/Driver/sycl-offload-jit.cpp
+++ b/clang/test/Driver/sycl-offload-jit.cpp
@@ -47,6 +47,13 @@
 // CHK-FSYCL-IS-DEVICE: "-cc1"{{.*}} "-fsycl-is-device" {{.*}} "-emit-llvm-bc"
 // CHK-FSYCL-IS-HOST: "-cc1"{{.*}} "-fsycl-is-host"
 
+// Check that --allow-partial-linkage and --create-library are not passed to
+// clang-linker-wrapper for SYCL (they are spirv-link flags, not clang-sycl-linker flags).
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fsycl %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-NO-SPIRVLINK-FLAGS %s
+// CHECK-NO-SPIRVLINK-FLAGS-NOT: --device-linker=spirv64-unknown-unknown=--allow-partial-linkage
+// CHECK-NO-SPIRVLINK-FLAGS-NOT: --device-linker=spirv64-unknown-unknown=--create-library
+
 /// Check for option incompatibility with -fsycl
 // RUN: not %clang -### -fsycl -ffreestanding %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-INCOMPATIBILITY %s -DINCOMPATOPT=-ffreestanding

--- a/clang/test/Driver/sycl-windows.cpp
+++ b/clang/test/Driver/sycl-windows.cpp
@@ -106,3 +106,8 @@
 // RUN:   | FileCheck -check-prefix=CHECK-SEP-LINK %s
 // CHECK-SEP-LINK: "-libpath:{{.*}}{{[/\\]+}}lib"
 // CHECK-SEP-LINK: "-defaultlib:LLVMSYCL"
+
+/// Test 17: clang (non-clang-cl) with -nolibsycl suppresses -defaultlib:LLVMSYCL
+// RUN: %clang -### -fsycl -nolibsycl -fms-runtime-lib=dll --target=x86_64-pc-windows-msvc -- %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-CLANG-NOLIBSYCL %s
+// CHECK-CLANG-NOLIBSYCL-NOT: "-defaultlib:LLVMSYCL"


### PR DESCRIPTION
Two related driver fixes for SYCL offloading on Linux:

1. Honor -nolibsycl during linking: the SYCL runtime library (libLLVMSYCL.so) was unconditionally added to the link line even when -nolibsycl was passed. The flag was recognized but silently ignored at the point where the library path is emitted.

2. Do not forward spirv-link flags to clang-sycl-linker: the driver was passing --allow-partial-linkage and --create-library to clang-sycl-linker for all SPIR-V offload targets, but these flags are only meaningful to the out-of-tree spirv-link tool used by OpenMP. SYCL uses clang-sycl-linker which does not accept them, causing a link failure. The flags are now restricted to non-SYCL SPIR-V offload kinds.