### PR TITLE
[ExpandIRInsts] Fix e.g. fptoui.sat.f32.i256's handling of inf

### DIFF
--- a/llvm/lib/CodeGen/ExpandIRInsts.cpp
+++ b/llvm/lib/CodeGen/ExpandIRInsts.cpp
@@ -704,10 +704,16 @@ static void expandFPToI(Instruction *FPToI, bool IsSaturating, bool IsSigned) {
   if (IsSaturating) {
     // check.saturate:
     Builder.SetInsertPoint(CheckSaturateBB);
+    uint64_t SaturatingBiasedExp =
+        static_cast<uint64_t>(ExponentBias) + BitWidth - IsSigned;
+    // Clamp to the all-ones (inf/NaN) exponent. Without this, when the integer
+    // is wide enough to hold every finite float the threshold exceeds any
+    // possible biased exponent, so +/-inf would never saturate.
+    uint64_t MaxBiasedExp = (1ULL << ExponentWidth) - 1;
+    if (SaturatingBiasedExp > MaxBiasedExp)
+      SaturatingBiasedExp = MaxBiasedExp;
     Value *Cmp3 = Builder.CreateICmpUGE(
-        BiasedExp, ConstantInt::getSigned(
-                       FloatIntTy, static_cast<int64_t>(ExponentBias +
-                                                        BitWidth - IsSigned)));
+        BiasedExp, ConstantInt::get(FloatIntTy, SaturatingBiasedExp));
     Value *CondBrSat = Builder.CreateCondBr(Cmp3, SaturateBB, CheckExpSizeBB);
     // Saturation is considered an unlikely event.
     applyProfMetadataIfEnabled(CondBrSat, [&](Instruction *Inst) {

--- a/llvm/test/CodeGen/AArch64/fcvt-i256.ll
+++ b/llvm/test/CodeGen/AArch64/fcvt-i256.ll
@@ -1292,7 +1292,7 @@ define i256 @f32_to_s256_sat(float %val) {
 ; CHECK-SD-NEXT:    mov x3, x0
 ; CHECK-SD-NEXT:    b.vs .LBB8_7
 ; CHECK-SD-NEXT:  // %bb.2: // %fp-to-i-if-check.saturate
-; CHECK-SD-NEXT:    cmp w10, #382
+; CHECK-SD-NEXT:    cmp w10, #255
 ; CHECK-SD-NEXT:    b.hs .LBB8_8
 ; CHECK-SD-NEXT:  // %bb.3: // %fp-to-i-if-check.exp.size
 ; CHECK-SD-NEXT:    sbfx x9, x8, #31, #1
@@ -1405,8 +1405,8 @@ define i256 @f32_to_s256_sat(float %val) {
 ; CHECK-GI-NEXT:    fcmp s0, s0
 ; CHECK-GI-NEXT:    b.vs .LBB8_5
 ; CHECK-GI-NEXT:  // %bb.2: // %fp-to-i-if-check.saturate
-; CHECK-GI-NEXT:    mov w10, #1 // =0x1
-; CHECK-GI-NEXT:    tbz w10, #0, .LBB8_7
+; CHECK-GI-NEXT:    cmp w11, #255
+; CHECK-GI-NEXT:    b.hs .LBB8_7
 ; CHECK-GI-NEXT:  // %bb.3: // %fp-to-i-if-check.exp.size
 ; CHECK-GI-NEXT:    sbfx x10, x9, #0, #1
 ; CHECK-GI-NEXT:    and w12, w8, #0x7fffff
@@ -1572,7 +1572,7 @@ define i256 @f32_to_u256_sat(float %val) {
 ; CHECK-SD-NEXT:    mov x3, x0
 ; CHECK-SD-NEXT:    tbnz w9, #31, .LBB9_8
 ; CHECK-SD-NEXT:  // %bb.3: // %fp-to-i-if-check.saturate
-; CHECK-SD-NEXT:    cmp w8, #382
+; CHECK-SD-NEXT:    cmp w8, #254
 ; CHECK-SD-NEXT:    b.hi .LBB9_9
 ; CHECK-SD-NEXT:  // %bb.4: // %fp-to-i-if-check.exp.size
 ; CHECK-SD-NEXT:    mov w10, #8388608 // =0x800000
@@ -1641,21 +1641,24 @@ define i256 @f32_to_u256_sat(float %val) {
 ; CHECK-GI-NEXT:    mov x0, xzr
 ; CHECK-GI-NEXT:    ubfx w9, w8, #23, #8
 ; CHECK-GI-NEXT:    cmp w9, #127
-; CHECK-GI-NEXT:    b.lo .LBB9_7
+; CHECK-GI-NEXT:    b.lo .LBB9_6
 ; CHECK-GI-NEXT:  // %bb.1: // %fp-to-i-entry
 ; CHECK-GI-NEXT:    fcmp s0, s0
-; CHECK-GI-NEXT:    b.vs .LBB9_7
+; CHECK-GI-NEXT:    b.vs .LBB9_6
 ; CHECK-GI-NEXT:  // %bb.2: // %fp-to-i-entry
 ; CHECK-GI-NEXT:    mov x1, x0
 ; CHECK-GI-NEXT:    mov x2, x0
 ; CHECK-GI-NEXT:    mov x3, x0
-; CHECK-GI-NEXT:    tbnz w8, #31, .LBB9_6
-; CHECK-GI-NEXT:  // %bb.3: // %fp-to-i-if-check.exp.size
+; CHECK-GI-NEXT:    tbnz w8, #31, .LBB9_8
+; CHECK-GI-NEXT:  // %bb.3: // %fp-to-i-if-check.saturate
+; CHECK-GI-NEXT:    cmp w9, #255
+; CHECK-GI-NEXT:    b.hs .LBB9_9
+; CHECK-GI-NEXT:  // %bb.4: // %fp-to-i-if-check.exp.size
 ; CHECK-GI-NEXT:    and w8, w8, #0x7fffff
 ; CHECK-GI-NEXT:    cmp w9, #150
 ; CHECK-GI-NEXT:    orr w8, w8, #0x800000
-; CHECK-GI-NEXT:    b.hs .LBB9_5
-; CHECK-GI-NEXT:  // %bb.4: // %fp-to-i-if-exp.small
+; CHECK-GI-NEXT:    b.hs .LBB9_7
+; CHECK-GI-NEXT:  // %bb.5: // %fp-to-i-if-exp.small
 ; CHECK-GI-NEXT:    mov w10, #150 // =0x96
 ; CHECK-GI-NEXT:    mov x1, xzr
 ; CHECK-GI-NEXT:    mov x2, xzr
@@ -1663,7 +1666,12 @@ define i256 @f32_to_u256_sat(float %val) {
 ; CHECK-GI-NEXT:    mov x3, xzr
 ; CHECK-GI-NEXT:    lsr w0, w8, w9
 ; CHECK-GI-NEXT:    ret
-; CHECK-GI-NEXT:  .LBB9_5: // %fp-to-i-if-exp.large
+; CHECK-GI-NEXT:  .LBB9_6:
+; CHECK-GI-NEXT:    mov x1, x0
+; CHECK-GI-NEXT:    mov x2, x0
+; CHECK-GI-NEXT:    mov x3, x0
+; CHECK-GI-NEXT:    ret
+; CHECK-GI-NEXT:  .LBB9_7: // %fp-to-i-if-exp.large
 ; CHECK-GI-NEXT:    sub w9, w9, #150
 ; CHECK-GI-NEXT:    mov w11, #64 // =0x40
 ; CHECK-GI-NEXT:    mov w10, #128 // =0x80
@@ -1702,12 +1710,13 @@ define i256 @f32_to_u256_sat(float %val) {
 ; CHECK-GI-NEXT:    cmp x9, #0
 ; CHECK-GI-NEXT:    csel x2, xzr, x8, eq
 ; CHECK-GI-NEXT:    csel x3, xzr, x10, eq
-; CHECK-GI-NEXT:  .LBB9_6: // %fp-to-i-cleanup
+; CHECK-GI-NEXT:  .LBB9_8: // %fp-to-i-cleanup
 ; CHECK-GI-NEXT:    ret
-; CHECK-GI-NEXT:  .LBB9_7:
-; CHECK-GI-NEXT:    mov x1, x0
-; CHECK-GI-NEXT:    mov x2, x0
-; CHECK-GI-NEXT:    mov x3, x0
+; CHECK-GI-NEXT:  .LBB9_9:
+; CHECK-GI-NEXT:    mov x0, #-1 // =0xffffffffffffffff
+; CHECK-GI-NEXT:    mov x1, #-1 // =0xffffffffffffffff
+; CHECK-GI-NEXT:    mov x2, #-1 // =0xffffffffffffffff
+; CHECK-GI-NEXT:    mov x3, #-1 // =0xffffffffffffffff
 ; CHECK-GI-NEXT:    ret
   %result = call i256 @llvm.fptoui.sat(float %val)
   ret i256 %result

--- a/llvm/test/Transforms/ExpandIRInsts/X86/expand-large-fp-convert-fpto-sat-vector.ll
+++ b/llvm/test/Transforms/ExpandIRInsts/X86/expand-large-fp-convert-fpto-sat-vector.ll
@@ -23,7 +23,7 @@ define <2 x i256> @fptoui_sat_v2i256(<2 x float> %x) {
 ; CHECK-NEXT:    [[TMP7:%.*]] = or i1 [[TMP5]], [[TMP6]]
 ; CHECK-NEXT:    br i1 [[TMP7]], label [[FP_TO_I_CLEANUP1:%.*]], label [[FP_TO_I_IF_CHECK_SATURATE2:%.*]]
 ; CHECK:       fp-to-i-if-check.saturate2:
-; CHECK-NEXT:    [[TMP8:%.*]] = icmp uge i32 [[BIASED_EXP7]], 383
+; CHECK-NEXT:    [[TMP8:%.*]] = icmp uge i32 [[BIASED_EXP7]], 255
 ; CHECK-NEXT:    br i1 [[TMP8]], label [[FP_TO_I_IF_SATURATE3:%.*]], label [[FP_TO_I_IF_CHECK_EXP_SIZE4:%.*]]
 ; CHECK:       fp-to-i-if-saturate3:
 ; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP1]]
@@ -58,7 +58,7 @@ define <2 x i256> @fptoui_sat_v2i256(<2 x float> %x) {
 ; CHECK-NEXT:    [[TMP25:%.*]] = or i1 [[TMP23]], [[TMP24]]
 ; CHECK-NEXT:    br i1 [[TMP25]], label [[FP_TO_I_CLEANUP:%.*]], label [[FP_TO_I_IF_CHECK_SATURATE:%.*]]
 ; CHECK:       fp-to-i-if-check.saturate:
-; CHECK-NEXT:    [[TMP26:%.*]] = icmp uge i32 [[BIASED_EXP]], 383
+; CHECK-NEXT:    [[TMP26:%.*]] = icmp uge i32 [[BIASED_EXP]], 255
 ; CHECK-NEXT:    br i1 [[TMP26]], label [[FP_TO_I_IF_SATURATE:%.*]], label [[FP_TO_I_IF_CHECK_EXP_SIZE:%.*]]
 ; CHECK:       fp-to-i-if-saturate:
 ; CHECK-NEXT:    br label [[FP_TO_I_CLEANUP]]
@@ -102,7 +102,7 @@ define <2 x i256> @fptosi_sat_v2i256(<2 x float> %x) {
 ; CHECK-NEXT:    [[TMP6:%.*]] = or i1 [[EXP_IS_NEGATIVE10]], [[IS_NAN11]]
 ; CHECK-NEXT:    br i1 [[TMP6]], label [[FP_TO_I_CLEANUP1:%.*]], label [[FP_TO_I_IF_CHECK_SATURATE2:%.*]]
 ; CHECK:       fp-to-i-if-check.saturate2:
-; CHECK-NEXT:    [[TMP7:%.*]] = icmp uge i32 [[BIASED_EXP8]], 382
+; CHECK-NEXT:    [[TMP7:%.*]] = icmp uge i32 [[BIASED_EXP8]], 255
 ; CHECK-NEXT:    br i1 [[TMP7]], label [[FP_TO_I_IF_SATURATE3:%.*]], label [[FP_TO_I_IF_CHECK_EXP_SIZE4:%.*]]
 ; CHECK:       fp-to-i-if-saturate3:
 ; CHECK-NEXT:    [[SATURATED12:%.*]] = select i1 [[TMP3]], i256 57896044618658097711785492504343953926634992332820282019728792003956564819967, i256 -57896044618658097711785492504343953926634992332820282019728792003956564819968
@@ -140,7 +140,7 @@ define <2 x i256> @fptosi_sat_v2i256(<2 x float> %x) {
 ; CHECK-NEXT:    [[TMP25:%.*]] = or i1 [[EXP_IS_NEGATIVE]], [[IS_NAN]]
 ; CHECK-NEXT:    br i1 [[TMP25]], label [[FP_TO_I_CLEANUP:%.*]], label [[FP_TO_I_IF_CHECK_SATURATE:%.*]]
 ; CHECK:       fp-to-i-if-check.saturate:
-; CHECK-NEXT:    [[TMP26:%.*]] = icmp uge i32 [[BIASED_EXP]], 382
+; CHECK-NEXT:    [[TMP26:%.*]] = icmp uge i32 [[BIASED_EXP]], 255
 ; CHECK-NEXT:    br i1 [[TMP26]], label [[FP_TO_I_IF_SATURATE:%.*]], label [[FP_TO_I_IF_CHECK_EXP_SIZE:%.*]]
 ; CHECK:       fp-to-i-if-saturate:
 ; CHECK-NEXT:    [[SATURATED:%.*]] = select i1 [[TMP22]], i256 57896044618658097711785492504343953926634992332820282019728792003956564819967, i256 -57896044618658097711785492504343953926634992332820282019728792003956564819968


### PR DESCRIPTION
When expanding fptoui.sat/fptosi.sat, we saturate when the biased
exponent is at least ExponentBias + BitWidth - IsSigned, the point where
the value no longer fits in the target integer.

We should *also* always saturate when the floating-point value is
+/-inf.  Usually this doesn't require any special handling; for example
for a float32 -> int32 conversion, inf has a biased exponent of 255 >
ExponentBias + BitWidth - IsSigned = 127 + 32 - 1.

But for integer types which are large enough to contain all source
floating-point values, this doesn't work. For example, if you're
converting float32 to int256, you'd compute a threshold of 383, which is
greater than 255.  Therefore float32(inf) would not correctly saturate
to INT256_MAX.

Fix this by clamping the threshold to the all-ones biased exponent.

This bug was found by a large run of Opus 4.7 looking for bugs in LLVM.
