### PR TITLE
[lldb] Tighten TestObjcMethods test case for arm64e

### DIFF
--- a/lldb/test/API/lang/objc/foundation/TestObjCMethods.py
+++ b/lldb/test/API/lang/objc/foundation/TestObjCMethods.py
@@ -5,6 +5,7 @@ Also lookup objective-c data types and evaluate expressions.
 
 import os
 import os.path
+import re
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -331,11 +332,17 @@ class FoundationTestCase(TestBase):
         self.addTearDownHook(cleanup)
 
         if os.path.exists(logfile):
+            # The goal is to avoid looking up any symbol with `$__lldb` in the name.
+            lookup_pattern = re.compile(r'name\s*=\s*"(.+)"')
             f = open(logfile)
             lines = f.readlines()
             num_errors = 0
             for line in lines:
-                if "$__lldb" in line:
+                m = lookup_pattern.match(line)
+                if not m:
+                    continue
+
+                if "$__lldb" in m.group(1):
                     if num_errors == 0:
                         print(
                             "error: found spurious name lookups when evaluating an expression:"


### PR DESCRIPTION
This test explicitly checks for spurious DWARF lookups by looking for the string `$__lldb` in the dwarf lookup logs. The intent here is to validate that any calls to `FindFunctions` or `FindTypes` won't have `$__lldb` in its lookup target. On arm64, this is trivial because `expr self` goes through the IRInterpreter.

However, on arm64e, `expr self` is JIT compiled and executed in the inferior process. LLDB installs some utility functions to check invariants and those functions are usually prefixed with `$__lldb`. When those utility functions appear in the logs, the test incorrectly fails.