### PR TITLE
[VectorCombine] Don't scalarize atomic loads

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -2017,6 +2017,11 @@ bool VectorCombine::scalarizeLoad(Instruction &I) {
   if (LI->isVolatile() || !DL->typeSizeEqualsStoreSize(VecTy->getScalarType()))
     return false;
 
+  // Cowardly refuse to handle atomics.  We could handle unordered atomics if
+  // we wanted, but this transformation is illegal on other atomic orderings.
+  if (LI->isAtomic())
+    return false;
+
   bool AllExtracts = true;
   bool AllBitcasts = true;
   Instruction *LastCheckedInst = LI;

--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -2014,12 +2014,10 @@ bool VectorCombine::scalarizeLoad(Instruction &I) {
 
   auto *LI = cast<LoadInst>(&I);
   auto *VecTy = cast<VectorType>(LI->getType());
-  if (LI->isVolatile() || !DL->typeSizeEqualsStoreSize(VecTy->getScalarType()))
-    return false;
 
-  // Cowardly refuse to handle atomics.  We could handle unordered atomics if
-  // we wanted, but this transformation is illegal on other atomic orderings.
-  if (LI->isAtomic())
+  // The isSimple() check could be isUnordered(), but for now we cowardly
+  // refuse to handle even unordered atomics.
+  if (!LI->isSimple() || !DL->typeSizeEqualsStoreSize(VecTy->getScalarType()))
     return false;
 
   bool AllExtracts = true;

--- a/llvm/test/Transforms/VectorCombine/X86/load-extractelement-scalarization.ll
+++ b/llvm/test/Transforms/VectorCombine/X86/load-extractelement-scalarization.ll
@@ -37,3 +37,26 @@ define void @unused_extract(ptr %p) {
   %extract = extractelement <4 x float> %load, i64 1
   ret void
 }
+
+; Atomic loads must not be scalarized.
+define i32 @dont_scalarize_atomic_extract(ptr %p) {
+; CHECK-LABEL: @dont_scalarize_atomic_extract(
+; CHECK-NEXT:    [[LOAD:%.*]] = load atomic <2 x i32>, ptr [[P:%.*]] seq_cst, align 8
+; CHECK-NEXT:    [[EXTRACT:%.*]] = extractelement <2 x i32> [[LOAD]], i64 0
+; CHECK-NEXT:    ret i32 [[EXTRACT]]
+;
+  %load = load atomic <2 x i32>, ptr %p seq_cst, align 8
+  %extract = extractelement <2 x i32> %load, i64 0
+  ret i32 %extract
+}
+
+define i64 @dont_scalarize_atomic_bitcast(ptr %p) {
+; CHECK-LABEL: @dont_scalarize_atomic_bitcast(
+; CHECK-NEXT:    [[LOAD:%.*]] = load atomic <2 x i32>, ptr [[P:%.*]] seq_cst, align 8
+; CHECK-NEXT:    [[BITCAST:%.*]] = bitcast <2 x i32> [[LOAD]] to i64
+; CHECK-NEXT:    ret i64 [[BITCAST]]
+;
+  %load = load atomic <2 x i32>, ptr %p seq_cst, align 8
+  %bitcast = bitcast <2 x i32> %load to i64
+  ret i64 %bitcast
+}


### PR DESCRIPTION
scalarizeLoad tries to convert e.g.

      %a = load <2 x i32> %ptr
      %b = extractelement %a, 1

into a scalar load. Before this patch it would do this even when the
load is atomic, but in doing so it accidentally dropped the atomicity of
the load!

Although it is correct to apply this transformation to unordered
atomics, for now we simply don't apply this pass to atomics at all.

This bug was found by a large run of Opus 4.7 looking for bugs in LLVM.