### PR TITLE
[lldb][Windows] Move `processthreadsapi.h` include

### DIFF
--- a/lldb/test/API/windows/thread/main.c
+++ b/lldb/test/API/windows/thread/main.c
@@ -1,6 +1,9 @@
-#include <processthreadsapi.h>
 #include <stdio.h>
+
+// clang-format off
 #include <windows.h>
+#include <processthreadsapi.h>
+// clang-format on
 
 int main() {
   // break here


### PR DESCRIPTION
`processthreadsapi.h` needs to be included after `windows.h`. clang-format needs to be disabled here to avoid sorting the includes.

Fixes the test failure from https://github.com/llvm/llvm-project/pull/199983#issuecomment-4567633271.