### PR TITLE
[flang] Fix WHERE self-updates on allocatable array sections

### DIFF
--- a/flang/lib/Optimizer/Analysis/ArraySectionAnalyzer.cpp
+++ b/flang/lib/Optimizer/Analysis/ArraySectionAnalyzer.cpp
@@ -111,7 +111,9 @@ ArraySectionAnalyzer::analyze(mlir::Value ref1, mlir::Value ref2,
   if (!des1 || !des2)
     return SlicesOverlapKind::Unknown;
 
-  if (des1.getMemref() != des2.getMemref()) {
+  if (des1.getMemref() != des2.getMemref() &&
+      (!areKnownEquivalent ||
+       !areKnownEquivalent(des1.getMemref(), des2.getMemref()))) {
     // If the bases are different, then there is unknown overlap.
     LLVM_DEBUG(llvm::dbgs() << "No identical base for:\n"
                             << des1 << "and:\n"

--- a/flang/test/HLFIR/order_assignments/where-allocatable-base.f90
+++ b/flang/test/HLFIR/order_assignments/where-allocatable-base.f90
@@ -1,0 +1,25 @@
+! Test scheduling of WHERE assignments on allocatable array sections.
+! The LHS and RHS regions load the allocatable descriptor independently, so the
+! section bases are distinct SSA values even though they are the same variable.
+! The scheduler must still recognize identical sections and avoid RHS temps.
+
+! RUN: bbc -o - -pass-pipeline="builtin.module(lower-hlfir-ordered-assignments)" \
+! RUN:   --debug-only=flang-ordered-assignment \
+! RUN:   -flang-dbg-order-assignment-schedule-only %s 2>&1 | FileCheck %s
+! REQUIRES: asserts
+
+subroutine alloc_base(center, kinetic_constant, mpi_is, mpi_ie, omp_js, omp_je)
+  real(8), allocatable :: center(:,:,:,:,:), kinetic_constant(:,:,:,:)
+  integer :: mpi_is, mpi_ie, omp_js, omp_je
+
+  where (kinetic_constant(mpi_is:mpi_ie, omp_js:omp_je, :, 1) .ne. 0.d0)
+    center(mpi_is:mpi_ie, omp_js:omp_je, :, 1, 1) = &
+      center(mpi_is:mpi_ie, omp_js:omp_je, :, 1, 1) + 1.d0
+  end where
+end subroutine
+
+! CHECK-LABEL: ------------ scheduling where in _QPalloc_base ------------
+! CHECK: conflict (aligned):
+! CHECK-NEXT: run 1 evaluate: where/region_assign1
+! CHECK-NOT: save
+! CHECK-NOT: run 2


### PR DESCRIPTION
Teach ArraySectionAnalyzer to use the scheduler's value-equivalence callback
when comparing hlfir.designate base memrefs. This lets HLFIR ordered assignment
lowering recognize allocatable WHERE self-updates as aligned even when the LHS
and RHS use distinct descriptor loads.

This avoids generating full-sized RHS temporaries for these masked
self-updates, preventing device heap exhaustion while preserving parallel
kernel generation. Add a regression test for allocatable WHERE section
scheduling.