### PR TITLE
[libc] implement wcstoimax/wcstoumax

### DIFF
--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -118,6 +118,8 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.inttypes.imaxdiv
     libc.src.inttypes.strtoimax
     libc.src.inttypes.strtoumax
+    libc.src.inttypes.wcstoimax
+    libc.src.inttypes.wcstoumax
 
     # stdbit.h entrypoints
     libc.src.stdbit.stdc_bit_ceil_uc

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -117,6 +117,7 @@ add_header_macro(
   DEPENDS
     .llvm_libc_common_h
     .llvm-libc-types.imaxdiv_t
+    .llvm-libc-types.wchar_t
     .llvm-libc-macros.inttypes_macros
     .stdint
 )

--- a/libc/include/inttypes.yaml
+++ b/libc/include/inttypes.yaml
@@ -313,6 +313,7 @@ macros:
     macro_header: inttypes-macros.h
 types:
   - type_name: imaxdiv_t
+  - type_name: wchar_t
 enums: []
 objects: []
 functions:
@@ -344,4 +345,20 @@ functions:
     arguments:
       - type: const char *__restrict
       - type: char * *__restrict
+      - type: int
+  - name: wcstoimax
+    standards:
+      - stdc
+    return_type: intmax_t
+    arguments:
+      - type: const wchar_t *__restrict
+      - type: wchar_t * *__restrict
+      - type: int
+  - name: wcstoumax
+    standards:
+      - stdc
+    return_type: uintmax_t
+    arguments:
+      - type: const wchar_t *__restrict
+      - type: wchar_t * *__restrict
       - type: int

--- a/libc/include/inttypes.yaml
+++ b/libc/include/inttypes.yaml
@@ -313,7 +313,6 @@ macros:
     macro_header: inttypes-macros.h
 types:
   - type_name: imaxdiv_t
-  - type_name: wchar_t
 enums: []
 objects: []
 functions:

--- a/libc/src/inttypes/CMakeLists.txt
+++ b/libc/src/inttypes/CMakeLists.txt
@@ -43,3 +43,30 @@ add_entrypoint_object(
     libc.include.inttypes
     libc.src.__support.integer_operations
 )
+
+add_entrypoint_object(
+  wcstoimax
+  SRCS
+    wcstoimax.cpp
+  HDRS
+    wcstoimax.h
+  DEPENDS
+    libc.hdr.types.wchar_t
+    libc.hdr.stdint_proxy
+    libc.src.__support.str_to_integer
+    libc.src.errno.errno
+)
+
+add_entrypoint_object(
+  wcstoumax
+  SRCS
+    wcstoumax.cpp
+  HDRS
+    wcstoumax.h
+  DEPENDS
+    libc.hdr.types.wchar_t
+    libc.hdr.stdint_proxy
+    libc.src.__support.str_to_integer
+    libc.src.errno.errno
+)
+

--- a/libc/src/inttypes/wcstoimax.cpp
+++ b/libc/src/inttypes/wcstoimax.cpp
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation of wcstoimax.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/inttypes/wcstoimax.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/str_to_integer.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(intmax_t, wcstoimax,
+                   (const wchar_t *__restrict str, wchar_t **__restrict str_end,
+                    int base)) {
+  auto result = internal::strtointeger<intmax_t>(str, base);
+  if (result.has_error())
+    libc_errno = result.error;
+
+  if (str_end != nullptr && result.error != EINVAL)
+    *str_end = const_cast<wchar_t *>(str + result.parsed_len);
+
+  return result;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/inttypes/wcstoimax.h
+++ b/libc/src/inttypes/wcstoimax.h
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for wcstoimax.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_INTTYPES_WCSTOIMAX_H
+#define LLVM_LIBC_SRC_INTTYPES_WCSTOIMAX_H
+
+#include "hdr/stdint_proxy.h"
+#include "hdr/types/wchar_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+intmax_t wcstoimax(const wchar_t *__restrict str, wchar_t **__restrict str_end,
+                   int base);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_INTTYPES_WCSTOIMAX_H

--- a/libc/src/inttypes/wcstoumax.cpp
+++ b/libc/src/inttypes/wcstoumax.cpp
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation of wcstoumax.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/inttypes/wcstoumax.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/str_to_integer.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(uintmax_t, wcstoumax,
+                   (const wchar_t *__restrict str, wchar_t **__restrict str_end,
+                    int base)) {
+  auto result = internal::strtointeger<uintmax_t>(str, base);
+  if (result.has_error())
+    libc_errno = result.error;
+
+  if (str_end != nullptr && result.error != EINVAL)
+    *str_end = const_cast<wchar_t *>(str + result.parsed_len);
+
+  return result;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/inttypes/wcstoumax.h
+++ b/libc/src/inttypes/wcstoumax.h
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for wcstoumax.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_INTTYPES_WCSTOUMAX_H
+#define LLVM_LIBC_SRC_INTTYPES_WCSTOUMAX_H
+
+#include "hdr/stdint_proxy.h"
+#include "hdr/types/wchar_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+uintmax_t wcstoumax(const wchar_t *__restrict str, wchar_t **__restrict str_end,
+                    int base);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_INTTYPES_WCSTOUMAX_H

--- a/libc/test/src/inttypes/CMakeLists.txt
+++ b/libc/test/src/inttypes/CMakeLists.txt
@@ -48,3 +48,24 @@ add_libc_test(
     libc.src.inttypes.imaxabs
 )
 
+add_libc_test(
+  wcstoimax_test
+  SUITE
+    libc_inttypes_tests
+  SRCS
+    wcstoimax_test.cpp
+  DEPENDS
+    libc.src.inttypes.wcstoimax
+    libc.test.src.wchar.wcstol_test_support
+)
+
+add_libc_test(
+  wcstoumax_test
+  SUITE
+    libc_inttypes_tests
+  SRCS
+    wcstoumax_test.cpp
+  DEPENDS
+    libc.src.inttypes.wcstoumax
+    libc.test.src.wchar.wcstol_test_support
+)

--- a/libc/test/src/inttypes/wcstoimax_test.cpp
+++ b/libc/test/src/inttypes/wcstoimax_test.cpp
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unit tests for wcstoimax.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/inttypes/wcstoimax.h"
+
+#include "test/UnitTest/Test.h"
+
+#include "test/src/wchar/WcstolTest.h"
+
+WCSTOL_TEST(Wcstoimax, LIBC_NAMESPACE::wcstoimax)

--- a/libc/test/src/inttypes/wcstoumax_test.cpp
+++ b/libc/test/src/inttypes/wcstoumax_test.cpp
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unit tests for wcstoumax.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/inttypes/wcstoumax.h"
+
+#include "test/UnitTest/Test.h"
+
+#include "test/src/wchar/WcstolTest.h"
+
+WCSTOL_TEST(Wcstoumax, LIBC_NAMESPACE::wcstoumax)


### PR DESCRIPTION
Adds the implementation and tests for wide character to intmax_t and
uintmax_t.

Assisted-by: Automated tooling, human reviewed.
