### PR TITLE
workflows/ci-post-commit-analyzer: Pin container image

### DIFF
--- a/.github/workflows/ci-post-commit-analyzer.yml
+++ b/.github/workflows/ci-post-commit-analyzer.yml
@@ -36,7 +36,7 @@ jobs:
       github.event.action != 'closed'
     runs-on: ubuntu-24.04
     container:
-      image: 'ghcr.io/llvm/ci-ubuntu-24.04:latest'
+      image: 'ghcr.io/llvm/ci-ubuntu-24.04:latest@sha256:571cfd8a5ec38a9f241b421c56aa821139c0fd9dcbde5f6161210884befb5ec4'
     env:
       LLVM_VERSION: 18
     steps:


### PR DESCRIPTION
This is pinned to the image that was used in the last successful run of this job.

https://github.com/llvm/llvm-project/security/code-scanning/1596