### PR TITLE
[Webkit Checkers][SaferCpp] Detect base-to-derived downcasts laundered through void* in MemoryUnsafeCastChecker

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
@@ -123,10 +123,15 @@ void MemoryUnsafeCastChecker::checkASTCodeBody(const Decl *D,
             unless(anyOf(hasSourceExpression(hasDescendant(cxxThisExpr())),
                          hasType(templateTypeParmDecl()))));
   auto MatchExprPtrVoidCast = cxxStaticCastExpr(
-      hasSourceExpression(cxxStaticCastExpr(
-          hasType(pointerType(pointee(voidType()))),
-          hasSourceExpression(ignoringImpCasts(
-              hasTypePointingTo(cxxRecordDecl().bind(BaseNode)))))),
+      anyOf(
+          hasSourceExpression(cxxStaticCastExpr(
+              hasType(pointerType(pointee(voidType()))),
+              hasSourceExpression(ignoringImpCasts(
+                  hasTypePointingTo(cxxRecordDecl().bind(BaseNode)))))),
+          hasSourceExpression(callExpr(
+              hasType(pointerType(pointee(voidType()))),
+              hasAnyArgument(ignoringImpCasts(
+                  hasTypePointingTo(cxxRecordDecl().bind(BaseNode))))))),
       hasTypePointingTo(cxxRecordDecl(isDerivedFrom(equalsBoundNode(BaseNode)))
                             .bind(DerivedNode)));
 
@@ -139,6 +144,22 @@ void MemoryUnsafeCastChecker::checkASTCodeBody(const Decl *D,
   auto Matches =
       match(stmt(forEachDescendant(Cast)), *D->getBody(), AM.getASTContext());
   for (BoundNodes Match : Matches)
+    emitDiagnostics(Match, BR, ADC, this, BT);
+
+  // Match calls returning derived type where an argument is static_cast<void*>(Base*)
+  auto MatchCallPtrVoidArgCast = callExpr(
+      hasAnyArgument(
+          cxxStaticCastExpr(
+              hasType(pointerType(pointee(voidType()))),
+              hasSourceExpression(ignoringImpCasts(
+                  hasTypePointingTo(cxxRecordDecl().bind(BaseNode)))))
+              .bind(WarnRecordDecl)),
+      hasTypePointingTo(
+          cxxRecordDecl(isDerivedFrom(equalsBoundNode(BaseNode))).bind(DerivedNode)));
+  auto CallArgCast = stmt(MatchCallPtrVoidArgCast);
+  auto MatchesCallArgCast =
+      match(stmt(forEachDescendant(CallArgCast)), *D->getBody(), AM.getASTContext());
+  for (BoundNodes Match : MatchesCallArgCast)
     emitDiagnostics(Match, BR, ADC, this, BT);
 
   // Match casts between unrelated types and warn

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
@@ -127,12 +127,12 @@ void MemoryUnsafeCastChecker::checkASTCodeBody(const Decl *D,
           hasType(pointerType(pointee(voidType()))),
           hasSourceExpression(ignoringImpCasts(
               hasTypePointingTo(cxxRecordDecl().bind(BaseNode)))))),
-      hasTypePointingTo(
-          cxxRecordDecl(isDerivedFrom(equalsBoundNode(BaseNode))).bind(DerivedNode)));
+      hasTypePointingTo(cxxRecordDecl(isDerivedFrom(equalsBoundNode(BaseNode)))
+                            .bind(DerivedNode)));
 
   auto ExplicitCast =
-      explicitCastExpr(anyOf(MatchExprPtr, MatchExprRefTypeDef, MatchExprPtrObjC,
-                             MatchExprPtrVoidCast))
+        explicitCastExpr(anyOf(MatchExprPtr, MatchExprRefTypeDef,
+                             MatchExprPtrObjC, MatchExprPtrVoidCast))
           .bind(WarnRecordDecl);
   auto Cast = stmt(ExplicitCast);
 

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
@@ -122,9 +122,9 @@ void MemoryUnsafeCastChecker::checkASTCodeBody(const Decl *D,
                          .bind(DerivedNode)))))),
             unless(anyOf(hasSourceExpression(hasDescendant(cxxThisExpr())),
                          hasType(templateTypeParmDecl()))));
-  auto MatchExprPtrVoidCast = cxxStaticCastExpr(
+  auto MatchExprPtrVoidCast = allOf(
       anyOf(
-          hasSourceExpression(cxxStaticCastExpr(
+          hasSourceExpression(explicitCastExpr(
               hasType(pointerType(pointee(voidType()))),
               hasSourceExpression(ignoringImpCasts(
                   hasTypePointingTo(cxxRecordDecl().bind(BaseNode)))))),
@@ -146,14 +146,16 @@ void MemoryUnsafeCastChecker::checkASTCodeBody(const Decl *D,
   for (BoundNodes Match : Matches)
     emitDiagnostics(Match, BR, ADC, this, BT);
 
-  // Match calls returning derived type where an argument is static_cast<void*>(Base*)
+  // Match calls returning derived type where an argument is a void pointer
+  auto VoidPtrCast = castExpr(
+      hasType(pointerType(pointee(voidType()))),
+      hasSourceExpression(ignoringImpCasts(
+          hasTypePointingTo(cxxRecordDecl().bind(BaseNode)))))
+      .bind(WarnRecordDecl);
   auto MatchCallPtrVoidArgCast = callExpr(
-      hasAnyArgument(
-          cxxStaticCastExpr(
-              hasType(pointerType(pointee(voidType()))),
-              hasSourceExpression(ignoringImpCasts(
-                  hasTypePointingTo(cxxRecordDecl().bind(BaseNode)))))
-              .bind(WarnRecordDecl)),
+      hasAnyArgument(anyOf(
+          VoidPtrCast,
+          explicitCastExpr(hasSourceExpression(VoidPtrCast)))),
       hasTypePointingTo(
           cxxRecordDecl(isDerivedFrom(equalsBoundNode(BaseNode))).bind(DerivedNode)));
   auto CallArgCast = stmt(MatchCallPtrVoidArgCast);

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
@@ -123,20 +123,19 @@ void MemoryUnsafeCastChecker::checkASTCodeBody(const Decl *D,
             unless(anyOf(hasSourceExpression(hasDescendant(cxxThisExpr())),
                          hasType(templateTypeParmDecl()))));
   auto MatchExprPtrVoidCast = allOf(
-      anyOf(
-          hasSourceExpression(explicitCastExpr(
-              hasType(pointerType(pointee(voidType()))),
-              hasSourceExpression(ignoringImpCasts(
-                  hasTypePointingTo(cxxRecordDecl().bind(BaseNode)))))),
-          hasSourceExpression(callExpr(
-              hasType(pointerType(pointee(voidType()))),
-              hasAnyArgument(ignoringImpCasts(
-                  hasTypePointingTo(cxxRecordDecl().bind(BaseNode))))))),
+      anyOf(hasSourceExpression(explicitCastExpr(
+                hasType(pointerType(pointee(voidType()))),
+                hasSourceExpression(ignoringImpCasts(
+                    hasTypePointingTo(cxxRecordDecl().bind(BaseNode)))))),
+            hasSourceExpression(
+                callExpr(hasType(pointerType(pointee(voidType()))),
+                         hasAnyArgument(ignoringImpCasts(hasTypePointingTo(
+                             cxxRecordDecl().bind(BaseNode))))))),
       hasTypePointingTo(cxxRecordDecl(isDerivedFrom(equalsBoundNode(BaseNode)))
                             .bind(DerivedNode)));
 
   auto ExplicitCast =
-        explicitCastExpr(anyOf(MatchExprPtr, MatchExprRefTypeDef,
+      explicitCastExpr(anyOf(MatchExprPtr, MatchExprRefTypeDef,
                              MatchExprPtrObjC, MatchExprPtrVoidCast))
           .bind(WarnRecordDecl);
   auto Cast = stmt(ExplicitCast);

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
@@ -145,8 +145,7 @@ void MemoryUnsafeCastChecker::checkASTCodeBody(const Decl *D,
   for (BoundNodes Match : Matches)
     emitDiagnostics(Match, BR, ADC, this, BT);
 
-  // Match calls returning derived type where an argument is
-  // a void pointer
+  // Match calls returning derived type where an argument is a void pointer.
   auto VoidPtrCast =
       castExpr(hasType(pointerType(pointee(voidType()))),
                hasSourceExpression(ignoringImpCasts(

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
@@ -146,7 +146,8 @@ void MemoryUnsafeCastChecker::checkASTCodeBody(const Decl *D,
   for (BoundNodes Match : Matches)
     emitDiagnostics(Match, BR, ADC, this, BT);
 
-  // Match calls returning derived type where an argument is a void pointer
+  // Match calls returning derived type where an argument is
+  // a void pointer
   auto VoidPtrCast = castExpr(
       hasType(pointerType(pointee(voidType()))),
       hasSourceExpression(ignoringImpCasts(

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
@@ -148,20 +148,19 @@ void MemoryUnsafeCastChecker::checkASTCodeBody(const Decl *D,
 
   // Match calls returning derived type where an argument is
   // a void pointer
-  auto VoidPtrCast = castExpr(
-      hasType(pointerType(pointee(voidType()))),
-      hasSourceExpression(ignoringImpCasts(
-          hasTypePointingTo(cxxRecordDecl().bind(BaseNode)))))
-      .bind(WarnRecordDecl);
+  auto VoidPtrCast =
+      castExpr(hasType(pointerType(pointee(voidType()))),
+               hasSourceExpression(ignoringImpCasts(
+                   hasTypePointingTo(cxxRecordDecl().bind(BaseNode)))))
+          .bind(WarnRecordDecl);
   auto MatchCallPtrVoidArgCast = callExpr(
-      hasAnyArgument(anyOf(
-          VoidPtrCast,
-          explicitCastExpr(hasSourceExpression(VoidPtrCast)))),
-      hasTypePointingTo(
-          cxxRecordDecl(isDerivedFrom(equalsBoundNode(BaseNode))).bind(DerivedNode)));
+      hasAnyArgument(anyOf(VoidPtrCast,
+                           explicitCastExpr(hasSourceExpression(VoidPtrCast)))),
+      hasTypePointingTo(cxxRecordDecl(isDerivedFrom(equalsBoundNode(BaseNode)))
+                            .bind(DerivedNode)));
   auto CallArgCast = stmt(MatchCallPtrVoidArgCast);
-  auto MatchesCallArgCast =
-      match(stmt(forEachDescendant(CallArgCast)), *D->getBody(), AM.getASTContext());
+  auto MatchesCallArgCast = match(stmt(forEachDescendant(CallArgCast)),
+                                  *D->getBody(), AM.getASTContext());
   for (BoundNodes Match : MatchesCallArgCast)
     emitDiagnostics(Match, BR, ADC, this, BT);
 

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/MemoryUnsafeCastChecker.cpp
@@ -122,10 +122,18 @@ void MemoryUnsafeCastChecker::checkASTCodeBody(const Decl *D,
                          .bind(DerivedNode)))))),
             unless(anyOf(hasSourceExpression(hasDescendant(cxxThisExpr())),
                          hasType(templateTypeParmDecl()))));
+  auto MatchExprPtrVoidCast = cxxStaticCastExpr(
+      hasSourceExpression(cxxStaticCastExpr(
+          hasType(pointerType(pointee(voidType()))),
+          hasSourceExpression(ignoringImpCasts(
+              hasTypePointingTo(cxxRecordDecl().bind(BaseNode)))))),
+      hasTypePointingTo(
+          cxxRecordDecl(isDerivedFrom(equalsBoundNode(BaseNode))).bind(DerivedNode)));
 
-  auto ExplicitCast = explicitCastExpr(anyOf(MatchExprPtr, MatchExprRefTypeDef,
-                                             MatchExprPtrObjC))
-                          .bind(WarnRecordDecl);
+  auto ExplicitCast =
+      explicitCastExpr(anyOf(MatchExprPtr, MatchExprRefTypeDef, MatchExprPtrObjC,
+                             MatchExprPtrVoidCast))
+          .bind(WarnRecordDecl);
   auto Cast = stmt(ExplicitCast);
 
   auto Matches =

--- a/clang/test/Analysis/Checkers/WebKit/memory-unsafe-cast.mm
+++ b/clang/test/Analysis/Checkers/WebKit/memory-unsafe-cast.mm
@@ -1,12 +1,7 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.MemoryUnsafeCastChecker -verify %s
 
-@protocol NSObject
-+alloc;
--init;
-@end
-
-@interface NSObject <NSObject> {}
-@end
+#include "mock-types.h"
+#include "objc-mock-types.h"
 
 @interface BaseClass : NSObject
 @end
@@ -61,4 +56,15 @@ void testUnrelated(Class1 *c1) {
   Class2 *c2 = (Class2*)c1;
   // expected-warning@-1{{Unsafe cast from type 'Class1' to an unrelated type 'Class2'}}
   Class1 *c1_same = reinterpret_cast<Class1*>(c1); // no warning
+}
+
+struct Base : RefCountable { virtual ~Base() {} };
+struct Derived : Base { int extra; };
+
+void fn_cast_01(Base* base) {
+  auto* d1 = static_cast<Derived*>(base);
+  // expected-warning@-1{{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+
+  auto* d2 = static_cast<Derived*>(static_cast<void*>(base));
+  // expected-warning@-1{{Unsafe cast from base type 'Base' to derived type 'Derived'}}
 }

--- a/clang/test/Analysis/Checkers/WebKit/memory-unsafe-cast.mm
+++ b/clang/test/Analysis/Checkers/WebKit/memory-unsafe-cast.mm
@@ -80,4 +80,20 @@ void fn_cast_01(Base* base) {
   // expected-warning@-1{{Unsafe cast from base type 'Base' to derived type 'Derived'}}
   fnArgCast(static_cast<void*>(base));
   // expected-warning@-1{{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+  auto* d5 = (Derived*)(void*)base;
+  // expected-warning@-1{{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+  auto* d6 = static_cast<Derived*>((void*)base);
+  // expected-warning@-1{{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+  auto* d7 = (Derived*)reinterpret_cast<void*>(base);
+  // expected-warning@-1{{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+  auto* d8 = (Derived*)returnCast(base);
+  // expected-warning@-1{{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+  fnArgCast((void*)base);
+  // expected-warning@-1{{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+  fnArgCast(base);
+  // expected-warning@-1{{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+  auto* d9 = reinterpret_cast<Derived*>(static_cast<void*>(base));
+  // expected-warning@-1{{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+  auto* d10 = reinterpret_cast<Derived*>((void*)base);
+  // expected-warning@-1{{Unsafe cast from base type 'Base' to derived type 'Derived'}}
 }

--- a/clang/test/Analysis/Checkers/WebKit/memory-unsafe-cast.mm
+++ b/clang/test/Analysis/Checkers/WebKit/memory-unsafe-cast.mm
@@ -61,10 +61,23 @@ void testUnrelated(Class1 *c1) {
 struct Base : RefCountable { virtual ~Base() {} };
 struct Derived : Base { int extra; };
 
+void* returnCast(Base* base) {
+  return static_cast<void *>(base);
+}
+
+Derived* fnArgCast(void* base) {
+  return static_cast<Derived*>(base);
+}
+
 void fn_cast_01(Base* base) {
   auto* d1 = static_cast<Derived*>(base);
   // expected-warning@-1{{Unsafe cast from base type 'Base' to derived type 'Derived'}}
-
   auto* d2 = static_cast<Derived*>(static_cast<void*>(base));
+  // expected-warning@-1{{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+  auto* d3 = static_cast<Derived*>(returnCast(base));
+  // expected-warning@-1{{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+  auto* d4 = fnArgCast(static_cast<void*>(base));
+  // expected-warning@-1{{Unsafe cast from base type 'Base' to derived type 'Derived'}}
+  fnArgCast(static_cast<void*>(base));
   // expected-warning@-1{{Unsafe cast from base type 'Base' to derived type 'Derived'}}
 }


### PR DESCRIPTION
Adds a matcher for static_cast<Derived*>(static_cast<void*>(base)), which previously evaded detection because the outer cast's immediate source expression is void*, not Base*.

rdar://173770143