### PR TITLE
[SLP][REVEC] Skip external-use extract cost for insertelement buildvector roots

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -19580,8 +19580,10 @@ InstructionCost BoUpSLP::getTreeCost(InstructionCost TreeCost,
          isa_and_present<UnreachableInst>(UserParent->getTerminator())))
       continue;
 
-    // No extract cost for vector "scalar" if REVEC is disabled
-    if (!SLPReVec && isa<FixedVectorType>(EU.Scalar->getType()))
+    // No extract cost for vector "scalar" if REVEC is disabled.
+    if (isVectorizedTy(EU.Scalar->getType()) &&
+        (!SLPReVec ||
+         (EU.E.hasState() && EU.E.getOpcode() == Instruction::InsertElement)))
       continue;
 
     // If found user is an insertelement, do not calculate extract cost but try

--- a/llvm/test/Transforms/SLPVectorizer/X86/revec-fma-vectorize.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/revec-fma-vectorize.ll
@@ -4,14 +4,10 @@
 define dso_local <2 x float> @fma_f32(ptr %A, float %B) {
 ; CHECK-LABEL: @fma_f32(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[REAL:%.*]] = load float, ptr [[A:%.*]], align 4
-; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr inbounds nuw i8, ptr [[A]], i64 4
-; CHECK-NEXT:    [[IMAG:%.*]] = load float, ptr [[TMP0]], align 4
-; CHECK-NEXT:    [[MUL_R:%.*]] = fmul reassoc nsz contract float [[REAL]], 2.000000e+00
-; CHECK-NEXT:    [[MUL_I:%.*]] = fmul reassoc nsz contract float [[IMAG]], 2.000000e+00
-; CHECK-NEXT:    [[ADD_R:%.*]] = fadd reassoc nsz contract float [[MUL_R]], [[B:%.*]]
-; CHECK-NEXT:    [[V0:%.*]] = insertelement <2 x float> poison, float [[ADD_R]], i64 0
-; CHECK-NEXT:    [[TMP3:%.*]] = insertelement <2 x float> [[V0]], float [[MUL_I]], i64 1
+; CHECK-NEXT:    [[TMP0:%.*]] = load <2 x float>, ptr [[A:%.*]], align 4
+; CHECK-NEXT:    [[TMP1:%.*]] = fmul reassoc nsz contract <2 x float> [[TMP0]], splat (float 2.000000e+00)
+; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <2 x float> <float poison, float -0.000000e+00>, float [[B:%.*]], i32 0
+; CHECK-NEXT:    [[TMP3:%.*]] = fadd reassoc nsz contract <2 x float> [[TMP1]], [[TMP2]]
 ; CHECK-NEXT:    ret <2 x float> [[TMP3]]
 ;
 entry:


### PR DESCRIPTION
An insertelement buildvector node produces a single vector whose type
equals the scalar type, and its external use is the whole vector, not a
subvector lane. SLP charged it an SK_ExtractSubvector cost, flipping
trees like the complex FMA (2.0f * A) + B from cost -1 to 0 so REVEC
kept them scalar.

Fixes #199715
