### PR TITLE
[clang-doc] Add standalone Markdown parsing library

### DIFF
--- a/clang-tools-extra/clang-doc/CMakeLists.txt
+++ b/clang-tools-extra/clang-doc/CMakeLists.txt
@@ -12,7 +12,6 @@ add_clang_library(clangDoc STATIC
   Generators.cpp
   HTMLGenerator.cpp
   Mapper.cpp
-  Markdown.cpp
   MDGenerator.cpp
   Representation.cpp
   Serialize.cpp

--- a/clang-tools-extra/clang-doc/CMakeLists.txt
+++ b/clang-tools-extra/clang-doc/CMakeLists.txt
@@ -12,6 +12,7 @@ add_clang_library(clangDoc STATIC
   Generators.cpp
   HTMLGenerator.cpp
   Mapper.cpp
+  Markdown.cpp
   MDGenerator.cpp
   Representation.cpp
   Serialize.cpp

--- a/clang-tools-extra/clang-doc/Markdown.cpp
+++ b/clang-tools-extra/clang-doc/Markdown.cpp
@@ -1,0 +1,133 @@
+//===-- Markdown.cpp - Markdown Parser --------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Markdown.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Allocator.h"
+
+namespace clang {
+namespace doc {
+namespace markdown {
+
+static MDNode makeText(llvm::StringRef S) {
+  return {NodeKind::Text, S, {}};
+}
+
+// A line is a table separator if it only contains |, -, :, and spaces,
+// and has at least one -.
+static bool isSepRow(llvm::StringRef Line) {
+  return llvm::all_of(Line, [](char C) {
+    return C == '|' || C == '-' || C == ':' || C == ' ';
+  }) && Line.contains('-');
+}
+
+static llvm::ArrayRef<MDNode>
+allocateNodes(llvm::SmallVectorImpl<MDNode> &Nodes,
+              llvm::BumpPtrAllocator &Arena) {
+  if (Nodes.empty())
+    return {};
+  MDNode *Allocated = Arena.Allocate<MDNode>(Nodes.size());
+  std::uninitialized_copy(Nodes.begin(), Nodes.end(), Allocated);
+  return llvm::ArrayRef<MDNode>(Allocated, Nodes.size());
+}
+
+llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
+                                     llvm::BumpPtrAllocator &Arena) {
+  if (ParagraphText.trim().empty())
+    return {};
+
+  llvm::SmallVector<llvm::StringRef, 16> Lines;
+  ParagraphText.split(Lines, '\n');
+
+  llvm::SmallVector<MDNode, 8> Nodes;
+  unsigned I = 0;
+
+  while (I < Lines.size()) {
+    llvm::StringRef Line = Lines[I].trim();
+
+    if (Line.empty()) {
+      ++I;
+      continue;
+    }
+
+    // Fenced code block: ``` or ~~~
+    if (Line.starts_with("```") || Line.starts_with("~~~")) {
+      char Fence = Line[0];
+      llvm::StringRef Lang = Line.drop_front(3).trim();
+      llvm::SmallVector<MDNode, 4> CodeLines;
+      ++I;
+      while (I < Lines.size()) {
+        llvm::StringRef CodeLine = Lines[I].trim();
+        if (CodeLine.size() >= 3 &&
+            llvm::all_of(CodeLine.take_front(3),
+                         [Fence](char C) { return C == Fence; }))
+          break;
+        CodeLines.push_back(makeText(Lines[I]));
+        ++I;
+      }
+      ++I; // skip closing fence
+      MDNode Code;
+      Code.Kind = NodeKind::FencedCode;
+      Code.Content = Lang;
+      Code.Children = allocateNodes(CodeLines, Arena);
+      Nodes.push_back(Code);
+      continue;
+    }
+
+    // Pipe table: current line has | and next line is a separator row
+    if (Line.contains('|') && I + 1 < Lines.size() &&
+        isSepRow(Lines[I + 1].trim())) {
+      llvm::SmallVector<MDNode, 4> Rows;
+      while (I < Lines.size() && Lines[I].trim().contains('|')) {
+        Rows.push_back(makeText(Lines[I].trim()));
+        ++I;
+      }
+      MDNode Table;
+      Table.Kind = NodeKind::Table;
+      Table.Content = {};
+      Table.Children = allocateNodes(Rows, Arena);
+      Nodes.push_back(Table);
+      continue;
+    }
+
+    // Unordered list item
+    if (Line.starts_with("- ") || Line.starts_with("* ") ||
+        Line.starts_with("+ ")) {
+      llvm::SmallVector<MDNode, 4> Items;
+      while (I < Lines.size()) {
+        llvm::StringRef L = Lines[I].trim();
+        if (!L.starts_with("- ") && !L.starts_with("* ") &&
+            !L.starts_with("+ "))
+          break;
+        MDNode Item;
+        Item.Kind = NodeKind::ListItem;
+        Item.Content = L.drop_front(2).trim();
+        Item.Children = {};
+        Items.push_back(Item);
+        ++I;
+      }
+      MDNode List;
+      List.Kind = NodeKind::UnorderedList;
+      List.Content = {};
+      List.Children = allocateNodes(Items, Arena);
+      Nodes.push_back(List);
+      continue;
+    }
+
+    // Plain text fallback
+    Nodes.push_back(makeText(Line));
+    ++I;
+  }
+
+  return allocateNodes(Nodes, Arena);
+}
+
+} // namespace markdown
+} // namespace doc
+} // namespace clang

--- a/clang-tools-extra/clang-doc/Markdown.cpp
+++ b/clang-tools-extra/clang-doc/Markdown.cpp
@@ -22,9 +22,11 @@ static MDNode makeText(llvm::StringRef S) {
 // A line is a table separator if it only contains |, -, :, and spaces,
 // and has at least one -.
 static bool isSepRow(llvm::StringRef Line) {
-  return llvm::all_of(Line, [](char C) {
-    return C == '|' || C == '-' || C == ':' || C == ' ';
-  }) && Line.contains('-');
+  return llvm::all_of(Line,
+                      [](char C) {
+                        return C == '|' || C == '-' || C == ':' || C == ' ';
+                      }) &&
+         Line.contains('-');
 }
 
 static llvm::ArrayRef<MDNode>

--- a/clang-tools-extra/clang-doc/Markdown.cpp
+++ b/clang-tools-extra/clang-doc/Markdown.cpp
@@ -15,9 +15,7 @@ namespace clang {
 namespace doc {
 namespace markdown {
 
-static MDNode makeText(llvm::StringRef S) {
-  return {NodeKind::Text, S, {}};
-}
+static MDNode makeText(llvm::StringRef S) { return {NodeKind::Text, S, {}}; }
 
 // A line is a table separator if it only contains |, -, :, and spaces,
 // and has at least one -.

--- a/clang-tools-extra/clang-doc/Markdown.h
+++ b/clang-tools-extra/clang-doc/Markdown.h
@@ -1,0 +1,59 @@
+//===-- Markdown.h - Markdown Parser ----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines a standalone Markdown parsing library for the LLVM
+// ecosystem. The parser takes plain text and returns a tree of typed nodes
+// with no knowledge of comments, Doxygen, or Clang-Doc internals.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_MARKDOWN_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_MARKDOWN_H
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Allocator.h"
+
+namespace clang {
+namespace doc {
+namespace markdown {
+
+enum class NodeKind : uint8_t {
+  // Block nodes
+  Paragraph,
+  FencedCode,
+  Table,
+  UnorderedList,
+  OrderedList,
+  ListItem,
+  ThematicBreak,
+  // Inline nodes
+  Text,
+  InlineCode,
+  Emphasis,
+  Strong,
+  SoftBreak,
+};
+
+struct MDNode {
+  NodeKind Kind;
+  llvm::StringRef Content;       // lang tag for FencedCode, leaf text for Text
+  llvm::ArrayRef<MDNode> Children; // arena allocated
+};
+
+// Parses Markdown from a single comment paragraph's text.
+// Returns an empty ArrayRef if no Markdown constructs are found,
+// so generators can fall back to plain-text rendering at zero cost.
+llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
+                                     llvm::BumpPtrAllocator &Arena);
+
+} // namespace markdown
+} // namespace doc
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_MARKDOWN_H

--- a/clang-tools-extra/clang-doc/Markdown.h
+++ b/clang-tools-extra/clang-doc/Markdown.h
@@ -42,7 +42,7 @@ enum class NodeKind : uint8_t {
 
 struct MDNode {
   NodeKind Kind;
-  llvm::StringRef Content;       // lang tag for FencedCode, leaf text for Text
+  llvm::StringRef Content; // lang tag for FencedCode, leaf text for Text
   llvm::ArrayRef<MDNode> Children; // arena allocated
 };
 

--- a/clang-tools-extra/clang-doc/support/CMakeLists.txt
+++ b/clang-tools-extra/clang-doc/support/CMakeLists.txt
@@ -6,5 +6,6 @@ set(LLVM_LINK_COMPONENTS
 
 add_clang_library(clangDocSupport STATIC
   File.cpp
+  Markdown.cpp
   Utils.cpp
   )

--- a/clang-tools-extra/clang-doc/support/Markdown.cpp
+++ b/clang-tools-extra/clang-doc/support/Markdown.cpp
@@ -1,0 +1,133 @@
+//===-- Markdown.cpp - Markdown Parser --------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Markdown.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Allocator.h"
+
+namespace clang {
+namespace doc {
+namespace markdown {
+
+static MDNode makeText(llvm::StringRef S) { return {NodeKind::Text, S, {}}; }
+
+// A line is a table separator if it only contains |, -, :, and spaces,
+// and has at least one -.
+static bool isSepRow(llvm::StringRef Line) {
+  return llvm::all_of(Line,
+                      [](char C) {
+                        return C == '|' || C == '-' || C == ':' || C == ' ';
+                      }) &&
+         Line.contains('-');
+}
+
+static llvm::ArrayRef<MDNode>
+allocateNodes(llvm::SmallVectorImpl<MDNode> &Nodes,
+              llvm::BumpPtrAllocator &Arena) {
+  if (Nodes.empty())
+    return {};
+  MDNode *Allocated = Arena.Allocate<MDNode>(Nodes.size());
+  std::uninitialized_copy(Nodes.begin(), Nodes.end(), Allocated);
+  return llvm::ArrayRef<MDNode>(Allocated, Nodes.size());
+}
+
+llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
+                                     llvm::BumpPtrAllocator &Arena) {
+  if (ParagraphText.trim().empty())
+    return {};
+
+  llvm::SmallVector<llvm::StringRef, 16> Lines;
+  ParagraphText.split(Lines, '\n');
+
+  llvm::SmallVector<MDNode, 8> Nodes;
+  unsigned I = 0;
+
+  while (I < Lines.size()) {
+    llvm::StringRef Line = Lines[I].trim();
+
+    if (Line.empty()) {
+      ++I;
+      continue;
+    }
+
+    // Fenced code block: ``` or ~~~
+    if (Line.starts_with("```") || Line.starts_with("~~~")) {
+      char Fence = Line[0];
+      llvm::StringRef Lang = Line.drop_front(3).trim();
+      llvm::SmallVector<MDNode, 4> CodeLines;
+      ++I;
+      while (I < Lines.size()) {
+        llvm::StringRef CodeLine = Lines[I].trim();
+        if (CodeLine.size() >= 3 &&
+            llvm::all_of(CodeLine.take_front(3),
+                         [Fence](char C) { return C == Fence; }))
+          break;
+        CodeLines.push_back(makeText(Lines[I]));
+        ++I;
+      }
+      ++I; // skip closing fence
+      MDNode Code;
+      Code.Kind = NodeKind::FencedCode;
+      Code.Content = Lang;
+      Code.Children = allocateNodes(CodeLines, Arena);
+      Nodes.push_back(Code);
+      continue;
+    }
+
+    // Pipe table: current line has | and next line is a separator row
+    if (Line.contains('|') && I + 1 < Lines.size() &&
+        isSepRow(Lines[I + 1].trim())) {
+      llvm::SmallVector<MDNode, 4> Rows;
+      while (I < Lines.size() && Lines[I].trim().contains('|')) {
+        Rows.push_back(makeText(Lines[I].trim()));
+        ++I;
+      }
+      MDNode Table;
+      Table.Kind = NodeKind::Table;
+      Table.Content = {};
+      Table.Children = allocateNodes(Rows, Arena);
+      Nodes.push_back(Table);
+      continue;
+    }
+
+    // Unordered list item
+    if (Line.starts_with("- ") || Line.starts_with("* ") ||
+        Line.starts_with("+ ")) {
+      llvm::SmallVector<MDNode, 4> Items;
+      while (I < Lines.size()) {
+        llvm::StringRef L = Lines[I].trim();
+        if (!L.starts_with("- ") && !L.starts_with("* ") &&
+            !L.starts_with("+ "))
+          break;
+        MDNode Item;
+        Item.Kind = NodeKind::ListItem;
+        Item.Content = L.drop_front(2).trim();
+        Item.Children = {};
+        Items.push_back(Item);
+        ++I;
+      }
+      MDNode List;
+      List.Kind = NodeKind::UnorderedList;
+      List.Content = {};
+      List.Children = allocateNodes(Items, Arena);
+      Nodes.push_back(List);
+      continue;
+    }
+
+    // Plain text fallback
+    Nodes.push_back(makeText(Line));
+    ++I;
+  }
+
+  return allocateNodes(Nodes, Arena);
+}
+
+} // namespace markdown
+} // namespace doc
+} // namespace clang

--- a/clang-tools-extra/clang-doc/support/Markdown.cpp
+++ b/clang-tools-extra/clang-doc/support/Markdown.cpp
@@ -10,6 +10,10 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+
+#define DEBUG_TYPE "clang-doc-markdown"
 
 namespace clang {
 namespace doc {
@@ -38,11 +42,16 @@ allocateNodes(llvm::SmallVectorImpl<MDNode> &Nodes,
 
 llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
                                      llvm::BumpPtrAllocator &Arena) {
-  if (ParagraphText.trim().empty())
+  if (ParagraphText.trim().empty()) {
+    LLVM_DEBUG(llvm::dbgs() << "[md] empty input, returning nothing\n");
     return {};
+  }
 
   llvm::SmallVector<llvm::StringRef, 16> Lines;
   ParagraphText.split(Lines, '\n');
+
+  LLVM_DEBUG(llvm::dbgs() << "[md] parsing " << Lines.size()
+                           << " line(s)\n");
 
   llvm::SmallVector<MDNode, 8> Nodes;
   unsigned I = 0;
@@ -59,14 +68,19 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
     if (Line.starts_with("```") || Line.starts_with("~~~")) {
       char Fence = Line[0];
       llvm::StringRef Lang = Line.drop_front(3).trim();
+      LLVM_DEBUG(llvm::dbgs() << "[md] fenced code block, lang='"
+                               << Lang << "'\n");
       llvm::SmallVector<MDNode, 4> CodeLines;
       ++I;
       while (I < Lines.size()) {
         llvm::StringRef CodeLine = Lines[I].trim();
         if (CodeLine.size() >= 3 &&
             llvm::all_of(CodeLine.take_front(3),
-                         [Fence](char C) { return C == Fence; }))
+                         [Fence](char C) { return C == Fence; })) {
+          LLVM_DEBUG(llvm::dbgs() << "[md] closing fence found at line "
+                                   << I << "\n");
           break;
+        }
         CodeLines.push_back(makeText(Lines[I]));
         ++I;
       }
@@ -75,6 +89,8 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
       Code.Kind = NodeKind::NK_FencedCode;
       Code.Content = Lang;
       Code.Children = allocateNodes(CodeLines, Arena);
+      LLVM_DEBUG(llvm::dbgs() << "[md] emitting NK_FencedCode with "
+                               << CodeLines.size() << " line(s)\n");
       Nodes.push_back(Code);
       continue;
     }
@@ -82,6 +98,8 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
     // Pipe table: current line has | and next line is a separator row
     if (Line.contains('|') && I + 1 < Lines.size() &&
         isSepRow(Lines[I + 1].trim())) {
+      LLVM_DEBUG(llvm::dbgs() << "[md] pipe table detected at line "
+                               << I << "\n");
       llvm::SmallVector<MDNode, 4> Rows;
       while (I < Lines.size() && Lines[I].trim().contains('|')) {
         Rows.push_back(makeText(Lines[I].trim()));
@@ -91,6 +109,8 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
       Table.Kind = NodeKind::NK_Table;
       Table.Content = {};
       Table.Children = allocateNodes(Rows, Arena);
+      LLVM_DEBUG(llvm::dbgs() << "[md] emitting NK_Table with "
+                               << Rows.size() << " row(s)\n");
       Nodes.push_back(Table);
       continue;
     }
@@ -98,6 +118,8 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
     // Unordered list item
     if (Line.starts_with("- ") || Line.starts_with("* ") ||
         Line.starts_with("+ ")) {
+      LLVM_DEBUG(llvm::dbgs() << "[md] unordered list at line " << I
+                               << "\n");
       llvm::SmallVector<MDNode, 4> Items;
       while (I < Lines.size()) {
         llvm::StringRef L = Lines[I].trim();
@@ -115,15 +137,20 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
       List.Kind = NodeKind::NK_UnorderedList;
       List.Content = {};
       List.Children = allocateNodes(Items, Arena);
+      LLVM_DEBUG(llvm::dbgs() << "[md] emitting NK_UnorderedList with "
+                               << Items.size() << " item(s)\n");
       Nodes.push_back(List);
       continue;
     }
 
     // Plain text fallback
+    LLVM_DEBUG(llvm::dbgs() << "[md] plain text: '" << Line << "'\n");
     Nodes.push_back(makeText(Line));
     ++I;
   }
 
+  LLVM_DEBUG(llvm::dbgs() << "[md] done, " << Nodes.size()
+                           << " top-level node(s)\n");
   return allocateNodes(Nodes, Arena);
 }
 

--- a/clang-tools-extra/clang-doc/support/Markdown.cpp
+++ b/clang-tools-extra/clang-doc/support/Markdown.cpp
@@ -1,4 +1,4 @@
-//===-- Markdown.cpp - Markdown Parser --------------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -15,16 +15,15 @@ namespace clang {
 namespace doc {
 namespace markdown {
 
-static MDNode makeText(llvm::StringRef S) { return {NodeKind::Text, S, {}}; }
+static MDNode makeText(llvm::StringRef S) {
+  return {NodeKind::NK_Text, S, {}};
+}
 
 // A line is a table separator if it only contains |, -, :, and spaces,
 // and has at least one -.
 static bool isSepRow(llvm::StringRef Line) {
-  return llvm::all_of(Line,
-                      [](char C) {
-                        return C == '|' || C == '-' || C == ':' || C == ' ';
-                      }) &&
-         Line.contains('-');
+  return Line.contains('-') &&
+         Line.find_first_not_of("|-: ") == llvm::StringRef::npos;
 }
 
 static llvm::ArrayRef<MDNode>
@@ -73,7 +72,7 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
       }
       ++I; // skip closing fence
       MDNode Code;
-      Code.Kind = NodeKind::FencedCode;
+      Code.Kind = NodeKind::NK_FencedCode;
       Code.Content = Lang;
       Code.Children = allocateNodes(CodeLines, Arena);
       Nodes.push_back(Code);
@@ -89,7 +88,7 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
         ++I;
       }
       MDNode Table;
-      Table.Kind = NodeKind::Table;
+      Table.Kind = NodeKind::NK_Table;
       Table.Content = {};
       Table.Children = allocateNodes(Rows, Arena);
       Nodes.push_back(Table);
@@ -106,14 +105,14 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
             !L.starts_with("+ "))
           break;
         MDNode Item;
-        Item.Kind = NodeKind::ListItem;
+        Item.Kind = NodeKind::NK_ListItem;
         Item.Content = L.drop_front(2).trim();
         Item.Children = {};
         Items.push_back(Item);
         ++I;
       }
       MDNode List;
-      List.Kind = NodeKind::UnorderedList;
+      List.Kind = NodeKind::NK_UnorderedList;
       List.Content = {};
       List.Children = allocateNodes(Items, Arena);
       Nodes.push_back(List);

--- a/clang-tools-extra/clang-doc/support/Markdown.cpp
+++ b/clang-tools-extra/clang-doc/support/Markdown.cpp
@@ -50,8 +50,7 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
   llvm::SmallVector<llvm::StringRef, 16> Lines;
   ParagraphText.split(Lines, '\n');
 
-  LLVM_DEBUG(llvm::dbgs() << "[md] parsing " << Lines.size()
-                           << " line(s)\n");
+  LLVM_DEBUG(llvm::dbgs() << "[md] parsing " << Lines.size() << " line(s)\n");
 
   llvm::SmallVector<MDNode, 8> Nodes;
   unsigned I = 0;
@@ -68,8 +67,8 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
     if (Line.starts_with("```") || Line.starts_with("~~~")) {
       char Fence = Line[0];
       llvm::StringRef Lang = Line.drop_front(3).trim();
-      LLVM_DEBUG(llvm::dbgs() << "[md] fenced code block, lang='"
-                               << Lang << "'\n");
+      LLVM_DEBUG(llvm::dbgs()
+                 << "[md] fenced code block, lang='" << Lang << "'\n");
       llvm::SmallVector<MDNode, 4> CodeLines;
       ++I;
       while (I < Lines.size()) {
@@ -77,8 +76,8 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
         if (CodeLine.size() >= 3 &&
             llvm::all_of(CodeLine.take_front(3),
                          [Fence](char C) { return C == Fence; })) {
-          LLVM_DEBUG(llvm::dbgs() << "[md] closing fence found at line "
-                                   << I << "\n");
+          LLVM_DEBUG(llvm::dbgs()
+                     << "[md] closing fence found at line " << I << "\n");
           break;
         }
         CodeLines.push_back(makeText(Lines[I]));
@@ -90,7 +89,7 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
       Code.Content = Lang;
       Code.Children = allocateNodes(CodeLines, Arena);
       LLVM_DEBUG(llvm::dbgs() << "[md] emitting NK_FencedCode with "
-                               << CodeLines.size() << " line(s)\n");
+                              << CodeLines.size() << " line(s)\n");
       Nodes.push_back(Code);
       continue;
     }
@@ -98,8 +97,8 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
     // Pipe table: current line has | and next line is a separator row
     if (Line.contains('|') && I + 1 < Lines.size() &&
         isSepRow(Lines[I + 1].trim())) {
-      LLVM_DEBUG(llvm::dbgs() << "[md] pipe table detected at line "
-                               << I << "\n");
+      LLVM_DEBUG(llvm::dbgs()
+                 << "[md] pipe table detected at line " << I << "\n");
       llvm::SmallVector<MDNode, 4> Rows;
       while (I < Lines.size() && Lines[I].trim().contains('|')) {
         Rows.push_back(makeText(Lines[I].trim()));
@@ -109,8 +108,8 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
       Table.Kind = NodeKind::NK_Table;
       Table.Content = {};
       Table.Children = allocateNodes(Rows, Arena);
-      LLVM_DEBUG(llvm::dbgs() << "[md] emitting NK_Table with "
-                               << Rows.size() << " row(s)\n");
+      LLVM_DEBUG(llvm::dbgs() << "[md] emitting NK_Table with " << Rows.size()
+                              << " row(s)\n");
       Nodes.push_back(Table);
       continue;
     }
@@ -118,8 +117,7 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
     // Unordered list item
     if (Line.starts_with("- ") || Line.starts_with("* ") ||
         Line.starts_with("+ ")) {
-      LLVM_DEBUG(llvm::dbgs() << "[md] unordered list at line " << I
-                               << "\n");
+      LLVM_DEBUG(llvm::dbgs() << "[md] unordered list at line " << I << "\n");
       llvm::SmallVector<MDNode, 4> Items;
       while (I < Lines.size()) {
         llvm::StringRef L = Lines[I].trim();
@@ -138,7 +136,7 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
       List.Content = {};
       List.Children = allocateNodes(Items, Arena);
       LLVM_DEBUG(llvm::dbgs() << "[md] emitting NK_UnorderedList with "
-                               << Items.size() << " item(s)\n");
+                              << Items.size() << " item(s)\n");
       Nodes.push_back(List);
       continue;
     }
@@ -150,7 +148,7 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
   }
 
   LLVM_DEBUG(llvm::dbgs() << "[md] done, " << Nodes.size()
-                           << " top-level node(s)\n");
+                          << " top-level node(s)\n");
   return allocateNodes(Nodes, Arena);
 }
 

--- a/clang-tools-extra/clang-doc/support/Markdown.cpp
+++ b/clang-tools-extra/clang-doc/support/Markdown.cpp
@@ -14,69 +14,72 @@
 
 #define DEBUG_TYPE "clang-doc-markdown"
 
-namespace clang {
-namespace doc {
-namespace markdown {
+using namespace llvm;
 
-static MDNode makeText(llvm::StringRef S) {
+namespace clang::doc::markdown {
+
+static MDNode makeText(StringRef S) {
   return {NodeKind::NK_Text, S, {}};
 }
 
 // A line is a table separator if it only contains |, -, :, and spaces,
 // and has at least one -.
-static bool isSepRow(llvm::StringRef Line) {
+static bool isSepRow(StringRef Line) {
   return Line.contains('-') &&
-         Line.find_first_not_of("|-: ") == llvm::StringRef::npos;
+         Line.find_first_not_of("|-: ") == StringRef::npos;
 }
 
-static llvm::ArrayRef<MDNode>
-allocateNodes(llvm::SmallVectorImpl<MDNode> &Nodes,
-              llvm::BumpPtrAllocator &Arena) {
+// Returns true if Line begins with a bullet list marker (-, *, or +)
+// followed by a space.
+static bool isListItem(StringRef Line) {
+  return Line.starts_with("- ") || Line.starts_with("* ") ||
+         Line.starts_with("+ ");
+}
+
+static ArrayRef<MDNode> allocateNodes(const SmallVectorImpl<MDNode> &Nodes,
+                                      BumpPtrAllocator &Arena) {
   if (Nodes.empty())
     return {};
   MDNode *Allocated = Arena.Allocate<MDNode>(Nodes.size());
   std::uninitialized_copy(Nodes.begin(), Nodes.end(), Allocated);
-  return llvm::ArrayRef<MDNode>(Allocated, Nodes.size());
+  return ArrayRef<MDNode>(Allocated, Nodes.size());
 }
 
-llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
-                                     llvm::BumpPtrAllocator &Arena) {
-  if (ParagraphText.trim().empty()) {
-    LDBG() << "empty input, returning nothing";
+ArrayRef<MDNode> parseMarkdown(StringRef ParagraphText,
+                               BumpPtrAllocator &Arena) {
+  if (ParagraphText.trim().empty())
     return {};
-  }
 
-  llvm::SmallVector<llvm::StringRef, 16> Lines;
+  SmallVector<StringRef, 16> Lines;
   ParagraphText.split(Lines, '\n');
 
-  LDBG() << "parsing " << Lines.size() << " line(s)";
+  SmallVector<MDNode> Nodes;
+  size_t I = 0, E = Lines.size();
 
-  llvm::SmallVector<MDNode, 8> Nodes;
-  unsigned I = 0;
-
-  while (I < Lines.size()) {
-    llvm::StringRef Line = Lines[I].trim();
+  while (I < E) {
+    StringRef Line = Lines[I].trim();
 
     if (Line.empty()) {
       ++I;
       continue;
     }
 
-    // Fenced code block: ``` or ~~~
+    // TODO: Follow CommonMark spec §4.5 more closely -- opening fences may be
+    // indented up to 3 spaces, the closing fence must use the same character
+    // and be at least as long as the opening fence, and the closing fence may
+    // only be followed by spaces. Doxygen specifics should be handled on a
+    // case-by-case basis.
     if (Line.starts_with("```") || Line.starts_with("~~~")) {
       char Fence = Line[0];
-      llvm::StringRef Lang = Line.drop_front(3).trim();
-      LDBG() << "fenced code block, lang='" << Lang << "'";
-      llvm::SmallVector<MDNode, 4> CodeLines;
+      StringRef Lang = Line.drop_front(3).trim();
+      SmallVector<MDNode> CodeLines;
       ++I;
-      while (I < Lines.size()) {
-        llvm::StringRef CodeLine = Lines[I].trim();
+      while (I < E) {
+        StringRef CodeLine = Lines[I].trim();
         if (CodeLine.size() >= 3 &&
-            llvm::all_of(CodeLine.take_front(3),
-                         [Fence](char C) { return C == Fence; })) {
-          LDBG() << "closing fence found at line " << I;
+            all_of(CodeLine.take_front(3),
+                   [Fence](char C) { return C == Fence; }))
           break;
-        }
         CodeLines.push_back(makeText(Lines[I]));
         ++I;
       }
@@ -85,18 +88,16 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
       Code.Kind = NodeKind::NK_FencedCode;
       Code.Content = Lang;
       Code.Children = allocateNodes(CodeLines, Arena);
-      LDBG() << "emitting NK_FencedCode with " << CodeLines.size()
-             << " line(s)";
+      LDBG() << "emitting NK_FencedCode lang='" << Lang
+             << "' lines=" << CodeLines.size();
       Nodes.push_back(Code);
       continue;
     }
 
-    // Pipe table: current line has | and next line is a separator row
-    if (Line.contains('|') && I + 1 < Lines.size() &&
-        isSepRow(Lines[I + 1].trim())) {
-      LDBG() << "pipe table detected at line " << I;
-      llvm::SmallVector<MDNode, 4> Rows;
-      while (I < Lines.size() && Lines[I].trim().contains('|')) {
+    // Pipe table: current line has | and next line is a separator row.
+    if (Line.contains('|') && I + 1 < E && isSepRow(Lines[I + 1].trim())) {
+      SmallVector<MDNode> Rows;
+      while (I < E && Lines[I].trim().contains('|')) {
         Rows.push_back(makeText(Lines[I].trim()));
         ++I;
       }
@@ -104,20 +105,17 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
       Table.Kind = NodeKind::NK_Table;
       Table.Content = {};
       Table.Children = allocateNodes(Rows, Arena);
-      LDBG() << "emitting NK_Table with " << Rows.size() << " row(s)";
+      LDBG() << "emitting NK_Table rows=" << Rows.size();
       Nodes.push_back(Table);
       continue;
     }
 
-    // Unordered list item
-    if (Line.starts_with("- ") || Line.starts_with("* ") ||
-        Line.starts_with("+ ")) {
-      LDBG() << "unordered list at line " << I;
-      llvm::SmallVector<MDNode, 4> Items;
-      while (I < Lines.size()) {
-        llvm::StringRef L = Lines[I].trim();
-        if (!L.starts_with("- ") && !L.starts_with("* ") &&
-            !L.starts_with("+ "))
+    // Unordered list item.
+    if (isListItem(Line)) {
+      SmallVector<MDNode> Items;
+      while (I < E) {
+        StringRef L = Lines[I].trim();
+        if (!isListItem(L))
           break;
         MDNode Item;
         Item.Kind = NodeKind::NK_ListItem;
@@ -130,21 +128,18 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
       List.Kind = NodeKind::NK_UnorderedList;
       List.Content = {};
       List.Children = allocateNodes(Items, Arena);
-      LDBG() << "emitting NK_UnorderedList with " << Items.size() << " item(s)";
+      LDBG() << "emitting NK_UnorderedList items=" << Items.size();
       Nodes.push_back(List);
       continue;
     }
 
-    // Plain text fallback
-    LDBG() << "plain text: '" << Line << "'";
+    // Plain text fallback.
     Nodes.push_back(makeText(Line));
     ++I;
   }
 
-  LDBG() << "done, " << Nodes.size() << " top-level node(s)";
+  LDBG() << "parseMarkdown done nodes=" << Nodes.size();
   return allocateNodes(Nodes, Arena);
 }
 
-} // namespace markdown
-} // namespace doc
-} // namespace clang
+} // namespace clang::doc::markdown

--- a/clang-tools-extra/clang-doc/support/Markdown.cpp
+++ b/clang-tools-extra/clang-doc/support/Markdown.cpp
@@ -10,8 +10,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Allocator.h"
-#include "llvm/Support/Debug.h"
-#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/DebugLog.h"
 
 #define DEBUG_TYPE "clang-doc-markdown"
 
@@ -43,14 +42,14 @@ allocateNodes(llvm::SmallVectorImpl<MDNode> &Nodes,
 llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
                                      llvm::BumpPtrAllocator &Arena) {
   if (ParagraphText.trim().empty()) {
-    LLVM_DEBUG(llvm::dbgs() << "[md] empty input, returning nothing\n");
+    LDBG() << "empty input, returning nothing";
     return {};
   }
 
   llvm::SmallVector<llvm::StringRef, 16> Lines;
   ParagraphText.split(Lines, '\n');
 
-  LLVM_DEBUG(llvm::dbgs() << "[md] parsing " << Lines.size() << " line(s)\n");
+  LDBG() << "parsing " << Lines.size() << " line(s)";
 
   llvm::SmallVector<MDNode, 8> Nodes;
   unsigned I = 0;
@@ -67,8 +66,7 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
     if (Line.starts_with("```") || Line.starts_with("~~~")) {
       char Fence = Line[0];
       llvm::StringRef Lang = Line.drop_front(3).trim();
-      LLVM_DEBUG(llvm::dbgs()
-                 << "[md] fenced code block, lang='" << Lang << "'\n");
+      LDBG() << "fenced code block, lang='" << Lang << "'";
       llvm::SmallVector<MDNode, 4> CodeLines;
       ++I;
       while (I < Lines.size()) {
@@ -76,8 +74,7 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
         if (CodeLine.size() >= 3 &&
             llvm::all_of(CodeLine.take_front(3),
                          [Fence](char C) { return C == Fence; })) {
-          LLVM_DEBUG(llvm::dbgs()
-                     << "[md] closing fence found at line " << I << "\n");
+          LDBG() << "closing fence found at line " << I;
           break;
         }
         CodeLines.push_back(makeText(Lines[I]));
@@ -88,8 +85,8 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
       Code.Kind = NodeKind::NK_FencedCode;
       Code.Content = Lang;
       Code.Children = allocateNodes(CodeLines, Arena);
-      LLVM_DEBUG(llvm::dbgs() << "[md] emitting NK_FencedCode with "
-                              << CodeLines.size() << " line(s)\n");
+      LDBG() << "emitting NK_FencedCode with " << CodeLines.size()
+             << " line(s)";
       Nodes.push_back(Code);
       continue;
     }
@@ -97,8 +94,7 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
     // Pipe table: current line has | and next line is a separator row
     if (Line.contains('|') && I + 1 < Lines.size() &&
         isSepRow(Lines[I + 1].trim())) {
-      LLVM_DEBUG(llvm::dbgs()
-                 << "[md] pipe table detected at line " << I << "\n");
+      LDBG() << "pipe table detected at line " << I;
       llvm::SmallVector<MDNode, 4> Rows;
       while (I < Lines.size() && Lines[I].trim().contains('|')) {
         Rows.push_back(makeText(Lines[I].trim()));
@@ -108,8 +104,7 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
       Table.Kind = NodeKind::NK_Table;
       Table.Content = {};
       Table.Children = allocateNodes(Rows, Arena);
-      LLVM_DEBUG(llvm::dbgs() << "[md] emitting NK_Table with " << Rows.size()
-                              << " row(s)\n");
+      LDBG() << "emitting NK_Table with " << Rows.size() << " row(s)";
       Nodes.push_back(Table);
       continue;
     }
@@ -117,7 +112,7 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
     // Unordered list item
     if (Line.starts_with("- ") || Line.starts_with("* ") ||
         Line.starts_with("+ ")) {
-      LLVM_DEBUG(llvm::dbgs() << "[md] unordered list at line " << I << "\n");
+      LDBG() << "unordered list at line " << I;
       llvm::SmallVector<MDNode, 4> Items;
       while (I < Lines.size()) {
         llvm::StringRef L = Lines[I].trim();
@@ -135,20 +130,18 @@ llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
       List.Kind = NodeKind::NK_UnorderedList;
       List.Content = {};
       List.Children = allocateNodes(Items, Arena);
-      LLVM_DEBUG(llvm::dbgs() << "[md] emitting NK_UnorderedList with "
-                              << Items.size() << " item(s)\n");
+      LDBG() << "emitting NK_UnorderedList with " << Items.size() << " item(s)";
       Nodes.push_back(List);
       continue;
     }
 
     // Plain text fallback
-    LLVM_DEBUG(llvm::dbgs() << "[md] plain text: '" << Line << "'\n");
+    LDBG() << "plain text: '" << Line << "'";
     Nodes.push_back(makeText(Line));
     ++I;
   }
 
-  LLVM_DEBUG(llvm::dbgs() << "[md] done, " << Nodes.size()
-                          << " top-level node(s)\n");
+  LDBG() << "done, " << Nodes.size() << " top-level node(s)";
   return allocateNodes(Nodes, Arena);
 }
 

--- a/clang-tools-extra/clang-doc/support/Markdown.h
+++ b/clang-tools-extra/clang-doc/support/Markdown.h
@@ -11,6 +11,22 @@
 /// ecosystem. The parser takes plain text and returns a tree of typed nodes
 /// with no knowledge of comments, Doxygen, or Clang-Doc internals.
 ///
+/// This is a simple Markdown parser for use inside Clang-Doc's comment
+/// pipeline. You give it a paragraph of text and an arena allocator, and it
+/// gives back a list of typed nodes describing the Markdown structure it found.
+///
+/// The main entry point is parseMarkdown(). If the text has no Markdown in it,
+/// you get back an empty list and can fall back to plain-text output. If it
+/// does, you get a tree of MDNode structs where each node has a kind, optional
+/// content (like the language tag on a code fence), and optional children.
+///
+/// All nodes are allocated in the arena you pass in. You own the arena and are
+/// responsible for keeping it alive as long as you use the nodes.
+///
+/// The parser handles fenced code blocks, pipe tables, and unordered lists.
+/// Anything it does not recognize comes back as a plain text node. It will
+/// never crash on bad input.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_MARKDOWN_H

--- a/clang-tools-extra/clang-doc/support/Markdown.h
+++ b/clang-tools-extra/clang-doc/support/Markdown.h
@@ -1,0 +1,59 @@
+//===-- Markdown.h - Markdown Parser ----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines a standalone Markdown parsing library for the LLVM
+// ecosystem. The parser takes plain text and returns a tree of typed nodes
+// with no knowledge of comments, Doxygen, or Clang-Doc internals.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_MARKDOWN_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_MARKDOWN_H
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Allocator.h"
+
+namespace clang {
+namespace doc {
+namespace markdown {
+
+enum class NodeKind : uint8_t {
+  // Block nodes
+  Paragraph,
+  FencedCode,
+  Table,
+  UnorderedList,
+  OrderedList,
+  ListItem,
+  ThematicBreak,
+  // Inline nodes
+  Text,
+  InlineCode,
+  Emphasis,
+  Strong,
+  SoftBreak,
+};
+
+struct MDNode {
+  NodeKind Kind;
+  llvm::StringRef Content; // lang tag for FencedCode, leaf text for Text
+  llvm::ArrayRef<MDNode> Children; // arena allocated
+};
+
+// Parses Markdown from a single comment paragraph's text.
+// Returns an empty ArrayRef if no Markdown constructs are found,
+// so generators can fall back to plain-text rendering at zero cost.
+llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
+                                     llvm::BumpPtrAllocator &Arena);
+
+} // namespace markdown
+} // namespace doc
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_MARKDOWN_H

--- a/clang-tools-extra/clang-doc/support/Markdown.h
+++ b/clang-tools-extra/clang-doc/support/Markdown.h
@@ -36,9 +36,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Allocator.h"
 
-namespace clang {
-namespace doc {
-namespace markdown {
+namespace clang::doc::markdown {
 
 enum class NodeKind {
   // Block nodes
@@ -69,8 +67,6 @@ struct MDNode {
 llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
                                      llvm::BumpPtrAllocator &Arena);
 
-} // namespace markdown
-} // namespace doc
-} // namespace clang
+} // namespace clang::doc::markdown
 
 #endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_MARKDOWN_H

--- a/clang-tools-extra/clang-doc/support/Markdown.h
+++ b/clang-tools-extra/clang-doc/support/Markdown.h
@@ -1,15 +1,16 @@
-//===-- Markdown.h - Markdown Parser ----------------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
-// This file defines a standalone Markdown parsing library for the LLVM
-// ecosystem. The parser takes plain text and returns a tree of typed nodes
-// with no knowledge of comments, Doxygen, or Clang-Doc internals.
-//
+///
+/// \file
+/// This file defines a standalone Markdown parsing library for the LLVM
+/// ecosystem. The parser takes plain text and returns a tree of typed nodes
+/// with no knowledge of comments, Doxygen, or Clang-Doc internals.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_MARKDOWN_H
@@ -23,21 +24,21 @@ namespace clang {
 namespace doc {
 namespace markdown {
 
-enum class NodeKind : uint8_t {
+enum class NodeKind {
   // Block nodes
-  Paragraph,
-  FencedCode,
-  Table,
-  UnorderedList,
-  OrderedList,
-  ListItem,
-  ThematicBreak,
+  NK_Paragraph,
+  NK_FencedCode,
+  NK_Table,
+  NK_UnorderedList,
+  NK_OrderedList,
+  NK_ListItem,
+  NK_ThematicBreak,
   // Inline nodes
-  Text,
-  InlineCode,
-  Emphasis,
-  Strong,
-  SoftBreak,
+  NK_Text,
+  NK_InlineCode,
+  NK_Emphasis,
+  NK_Strong,
+  NK_SoftBreak,
 };
 
 struct MDNode {
@@ -46,9 +47,9 @@ struct MDNode {
   llvm::ArrayRef<MDNode> Children; // arena allocated
 };
 
-// Parses Markdown from a single comment paragraph's text.
-// Returns an empty ArrayRef if no Markdown constructs are found,
-// so generators can fall back to plain-text rendering at zero cost.
+/// Parses Markdown from a single comment paragraph's text.
+/// Returns an empty ArrayRef if no Markdown constructs are found,
+/// so generators can fall back to plain-text rendering at zero cost.
 llvm::ArrayRef<MDNode> parseMarkdown(llvm::StringRef ParagraphText,
                                      llvm::BumpPtrAllocator &Arena);
 

--- a/clang-tools-extra/unittests/clang-doc/CMakeLists.txt
+++ b/clang-tools-extra/unittests/clang-doc/CMakeLists.txt
@@ -26,6 +26,7 @@ add_extra_unittest(ClangDocTests
   ClangDocTest.cpp
   GeneratorTest.cpp
   HTMLGeneratorTest.cpp
+  MarkdownParserTest.cpp
   MDGeneratorTest.cpp
   MergeTest.cpp
   SerializeTest.cpp
@@ -49,5 +50,6 @@ clang_target_link_libraries(ClangDocTests
 target_link_libraries(ClangDocTests
   PRIVATE
   clangDoc
+  clangDocSupport
   LLVMTestingSupport
   )

--- a/clang-tools-extra/unittests/clang-doc/MarkdownParserTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/MarkdownParserTest.cpp
@@ -1,0 +1,94 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "support/Markdown.h"
+#include "llvm/Support/Allocator.h"
+#include "gtest/gtest.h"
+
+using namespace clang::doc::markdown;
+
+namespace {
+
+TEST(MarkdownParserTest, EmptyInput) {
+  llvm::BumpPtrAllocator Arena;
+  auto Nodes = parseMarkdown("", Arena);
+  EXPECT_TRUE(Nodes.empty());
+}
+
+TEST(MarkdownParserTest, WhitespaceOnlyInput) {
+  llvm::BumpPtrAllocator Arena;
+  auto Nodes = parseMarkdown("   \n  \n", Arena);
+  EXPECT_TRUE(Nodes.empty());
+}
+
+TEST(MarkdownParserTest, PlainText) {
+  llvm::BumpPtrAllocator Arena;
+  auto Nodes = parseMarkdown("hello world", Arena);
+  ASSERT_EQ(Nodes.size(), 1u);
+  EXPECT_EQ(Nodes[0].Kind, NodeKind::NK_Text);
+  EXPECT_EQ(Nodes[0].Content, "hello world");
+}
+
+TEST(MarkdownParserTest, FencedCodeBlock) {
+  llvm::BumpPtrAllocator Arena;
+  auto Nodes = parseMarkdown("```cpp\nint x = 0;\n```", Arena);
+  ASSERT_EQ(Nodes.size(), 1u);
+  EXPECT_EQ(Nodes[0].Kind, NodeKind::NK_FencedCode);
+  EXPECT_EQ(Nodes[0].Content, "cpp");
+  ASSERT_EQ(Nodes[0].Children.size(), 1u);
+}
+
+TEST(MarkdownParserTest, FencedCodeBlockNoLang) {
+  llvm::BumpPtrAllocator Arena;
+  auto Nodes = parseMarkdown("```\nsome code\n```", Arena);
+  ASSERT_EQ(Nodes.size(), 1u);
+  EXPECT_EQ(Nodes[0].Kind, NodeKind::NK_FencedCode);
+  EXPECT_TRUE(Nodes[0].Content.empty());
+}
+
+TEST(MarkdownParserTest, UnterminatedFenceReturnsEmpty) {
+  llvm::BumpPtrAllocator Arena;
+  auto Nodes = parseMarkdown("```cpp\nint x = 0;", Arena);
+  // Unterminated fence should not crash and should produce a code node
+  // with whatever lines were found.
+  EXPECT_FALSE(Nodes.empty());
+}
+
+TEST(MarkdownParserTest, PipeTable) {
+  llvm::BumpPtrAllocator Arena;
+  auto Nodes = parseMarkdown("| A | B |\n|---|---|\n| 1 | 2 |", Arena);
+  ASSERT_EQ(Nodes.size(), 1u);
+  EXPECT_EQ(Nodes[0].Kind, NodeKind::NK_Table);
+}
+
+TEST(MarkdownParserTest, PipeCharacterWithoutSepRowIsPlainText) {
+  llvm::BumpPtrAllocator Arena;
+  auto Nodes = parseMarkdown("a | b\nc | d", Arena);
+  // No separator row so should not be parsed as a table
+  for (const auto &Node : Nodes)
+    EXPECT_NE(Node.Kind, NodeKind::NK_Table);
+}
+
+TEST(MarkdownParserTest, UnorderedList) {
+  llvm::BumpPtrAllocator Arena;
+  auto Nodes = parseMarkdown("- foo\n- bar\n- baz", Arena);
+  ASSERT_EQ(Nodes.size(), 1u);
+  EXPECT_EQ(Nodes[0].Kind, NodeKind::NK_UnorderedList);
+  ASSERT_EQ(Nodes[0].Children.size(), 3u);
+  EXPECT_EQ(Nodes[0].Children[0].Content, "foo");
+  EXPECT_EQ(Nodes[0].Children[1].Content, "bar");
+  EXPECT_EQ(Nodes[0].Children[2].Content, "baz");
+}
+
+TEST(MarkdownParserTest, MixedContent) {
+  llvm::BumpPtrAllocator Arena;
+  auto Nodes = parseMarkdown("some text\n```\ncode\n```\n- item", Arena);
+  EXPECT_EQ(Nodes.size(), 3u);
+}
+
+} // namespace


### PR DESCRIPTION
Draft PR for GSoC 2026 Clang-Doc Markdown parsing library. Adds a standalone Markdown parser that takes paragraph text and returns a typed node tree. No knowledge of Doxygen or Clang-Doc internals. Currently handles fenced code blocks, pipe tables, unordered lists, and plain text fallback. Integration into the generator is next. Assisted-by: Claude

cc @ilovepi  @petrhosek  @evelez7 