### PR TITLE
[alpha.webkit.UncountedLocalVarsChecker] Check uninitialized raw pointer.

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -566,11 +566,13 @@ class TrivialFunctionAnalysisVisitor
     if (Ty->isPointerOrReferenceType())
       return true;
 
-    // T* is safe even in Objective-C with ARC since [[retain x] autorelease]
-    // will not dealloc.
     // FIXME: Handle a case when there is a local autorelease pool.
-    if (Ty->isObjCObjectPointerType())
-      return true;
+    if (Ty->isObjCObjectPointerType()) {
+      auto Type = Ty.isDestructedType();
+      if (Type == QualType::DK_objc_weak_lifetime || Type == QualType::DK_none)
+        return true;
+      // strong lifetime in ARC could dealloc an object.
+    }
 
     // Fundamental types (integral, nullptr_t, etc...) don't have destructors.
     if (Ty->isFundamentalType() || Ty->isIntegralOrEnumerationType())

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -566,6 +566,11 @@ class TrivialFunctionAnalysisVisitor
     if (Ty->isPointerOrReferenceType())
       return true;
 
+    // T* is safe even in ARC-enabled Objective-C since [[retain x] autorelease] will not dealloc.
+    // FIXME: Handle a case when there is a local autorelease pool.
+    if (Ty->isObjCObjectPointerType())
+      return true;
+
     // Fundamental types (integral, nullptr_t, etc...) don't have destructors.
     if (Ty->isFundamentalType() || Ty->isIntegralOrEnumerationType())
       return true;

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -566,7 +566,8 @@ class TrivialFunctionAnalysisVisitor
     if (Ty->isPointerOrReferenceType())
       return true;
 
-    // T* is safe even in ARC-enabled Objective-C since [[retain x] autorelease] will not dealloc.
+    // T* is safe even in Objective-C with ARC since [[retain x] autorelease]
+    // will not dealloc.
     // FIXME: Handle a case when there is a local autorelease pool.
     if (Ty->isObjCObjectPointerType())
       return true;

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
@@ -244,7 +244,7 @@ public:
 
       bool VisitVarDecl(VarDecl *V) override {
         auto *Init = V->getInit();
-        if (Init && V->isLocalVarDecl())
+        if (V->isLocalVarDecl())
           Checker->visitVarDecl(V, Init, DeclWithIssue);
         return true;
       }
@@ -329,7 +329,7 @@ public:
 
     std::optional<bool> IsUncountedPtr = isUnsafePtr(V->getType());
     if (IsUncountedPtr && *IsUncountedPtr) {
-      if (isPtrOriginSafe(V, Value, DeclWithIssue))
+      if (Value && isPtrOriginSafe(V, Value, DeclWithIssue))
         return;
       reportBug(V, Value, nullptr, DeclWithIssue);
     }

--- a/clang/test/Analysis/Checkers/WebKit/unchecked-local-vars.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/unchecked-local-vars.cpp
@@ -7,11 +7,16 @@ void someFunction();
 
 namespace raw_ptr {
 void foo() {
-  CheckedObj *bar;
-  // FIXME: later on we might warn on uninitialized vars too
+  CheckedObj *bar; // A local variable in a trivial context is ignored.
 }
 
 void bar(CheckedObj *) {}
+
+void baz() {
+  CheckedObj *bar;
+  // expected-warning@-1{{Local variable 'bar' is unchecked and unsafe [alpha.webkit.UncheckedLocalVarsChecker]}}
+  someFunction();
+}
 } // namespace raw_ptr
 
 namespace reference {

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
@@ -7,11 +7,16 @@ void someFunction();
 
 namespace raw_ptr {
 void foo() {
-  RefCountable *bar;
-  // FIXME: later on we might warn on uninitialized vars too
+  RefCountable *bar; // A local variable in a trivial context is ignored.
 }
 
 void bar(RefCountable *) {}
+
+void baz() {
+  RefCountable *bar;
+  // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+  someFunction();
+}
 } // namespace raw_ptr
 
 namespace reference {

--- a/clang/test/Analysis/Checkers/WebKit/unretained-local-vars-arc.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-local-vars-arc.mm
@@ -17,6 +17,10 @@ void foo2() {
   [bar doWork];
 }
 
+void foo3() {
+  SomeObj *bar = provide();
+}
+
 void bar() {
   CFMutableArrayRef array = CFArrayCreateMutable(kCFAllocatorDefault, 10);
   // expected-warning@-1{{Local variable 'array' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}

--- a/clang/test/Analysis/Checkers/WebKit/unretained-local-vars-arc.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-local-vars-arc.mm
@@ -1,4 +1,4 @@
-// RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.UnretainedLocalVarsChecker -fobjc-arc -verify %s
+// RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.UnretainedLocalVarsChecker -fobjc-runtime-has-weak -fobjc-weak -fobjc-arc -verify %s
 
 #import "objc-mock-types.h"
 
@@ -19,6 +19,12 @@ void foo2() {
 
 void foo3() {
   SomeObj *bar = provide();
+  IOSurfaceRef surface;
+  // expected-warning@-1{{Local variable 'surface' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+}
+
+void foo4() {
+  __weak SomeObj *bar = provide();
 }
 
 void bar() {


### PR DESCRIPTION
Emit a warning for a uninitialized local pointer variable.