### PR TITLE
[Docs] Note change to Maintainers.md in DeveloperPolicy

### DIFF
--- a/llvm/docs/DeveloperPolicy.rst
+++ b/llvm/docs/DeveloperPolicy.rst
@@ -141,7 +141,8 @@ products.
 Maintainers are those volunteers; they are regular contributors who volunteer
 to take on additional community responsibilities beyond code contributions.
 Community members can find active and inactive maintainers for a project in the
-``Maintainers.rst`` file at the root directory of the individual project.
+``Maintainers.md`` or ``Maintainers.rst`` file at the root directory of the
+individual project.
 
 Maintainers are volunteering to take on the following shared responsibilities
 within an area of a project:
@@ -191,25 +192,26 @@ the same project vouches for their ability to perform the responsibilities and
 there are no explicit objections raised by the community.
 
 *To step down as a maintainer*, you can move your name to the "inactive
-maintainers" section of the ``Maintainers.rst`` file for the project, or remove
-your name entirely; no PR review is necessary. Additionally, any maintainer who
-has not been actively performing their responsibilities over an extended period
-of time can be moved to the "inactive maintainers" section by another active
-maintainer within that project with agreement from one other active maintainer
-within that project. If there is only one active maintainer for a project,
-please post on Discourse to solicit wider community feedback about the removal
-and future direction for the project. However, please discuss the situation
-with the inactive maintainer before such removal to avoid accidental
-miscommunications. If the inactive maintainer is unreachable, no discussion
-with them is required. Stepping down or being removed as a maintainer is normal
-and does not prevent someone from resuming their activities as a maintainer in
-the future.
+maintainers" section of the ``Maintainers.md`` or ``Maintainers.rst`` file for
+the project, or remove your name entirely; no PR review is necessary.
+Additionally, any maintainer who has not been actively performing their
+responsibilities over an extended period of time can be moved to the "inactive
+maintainers" section by another active maintainer within that project with
+agreement from one other active maintainer within that project. If there is
+only one active maintainer for a project, please post on Discourse to solicit
+wider community feedback about the removal and future direction for the project.
+However, please discuss the situation with the inactive maintainer before such
+removal to avoid accidental miscommunications. If the inactive maintainer is
+unreachable, no discussion with them is required. Stepping down or being removed
+as a maintainer is normal and does not prevent someone from resuming their
+activities as a maintainer in the future.
 
 *To resume activities as a maintainer*, you can post a PR moving your name from
-the "inactive maintainers" section of the ``Maintainers.rst`` file to the
-active maintainers list. Because the volunteer was already previously accepted,
-they will be re-accepted so long as at least one maintainer in the same project
-approves the PR and there are no explicit objections raised by the community.
+the "inactive maintainers" section of the ``Maintainers.md`` or
+``Maintainers.rst``file to the active maintainers list. Because the volunteer
+was already previously accepted, they will be re-accepted so long as at least
+one maintainer in the same project approves the PR and there are no explicit
+objections raised by the community.
 
 .. _include a testcase:
 
@@ -956,7 +958,7 @@ The differences between both classes are:
 The basic rules for a back-end to be upstreamed in **experimental** mode are:
 
 * Every target must have at least one :ref:`maintainer<maintainers>`. The
-  `Maintainers.rst` file has to be updated as part of the first merge. These
+  `Maintainers.md` file has to be updated as part of the first merge. These
   maintainers make sure that changes to the target get reviewed and steers the
   overall effort.
 


### PR DESCRIPTION
This was brought up in a Discord discussion around adding a new target.
Update the documentation to mention Maintainers.md everywhere and remove
references to Maintainers.rst where the former is exclusive.

The only remaining usage of Maintainers.rst is in clang-tools-extra and
we should probably just rewrite it in Markdown especially given it seems
like there is conesnsus to move away from ReST entirely, but we can do
that later.