### PR TITLE
[Clang][Sema] Fix crash when calling EvaluateForOverflow for UnaryOpe…

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -648,6 +648,7 @@ Bug Fixes in This Version
   an array via an element-at-a-time copy loop (#GH192026)
 - Fixed an issue where certain designated initializers would be rejected for constexpr variables. (#GH193373)
 - Fixed a crash when ``#embed`` is used with C++ modules (#GH195350)
+- Fixed crash when checking for overflow for unary operator that can't overflow (#GH170072)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -14325,7 +14325,8 @@ void Sema::CheckForIntOverflow (const Expr *E) {
     const Expr *OriginalE = Exprs.pop_back_val();
     const Expr *E = OriginalE->IgnoreParenCasts();
 
-    if (isa<BinaryOperator, UnaryOperator>(E)) {
+    if (isa<BinaryOperator>(E) ||
+        (isa<UnaryOperator>(E) && cast<UnaryOperator>(E)->canOverflow())) {
       E->EvaluateForOverflow(Context);
       continue;
     }

--- a/clang/test/Sema/gh170072.c
+++ b/clang/test/Sema/gh170072.c
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -Wno-unused %s
+
+int a[-1]; // expected-error {{declared as an array with a negative size}}
+
+void f() {
+  extern int a[];
+  *a;
+}


### PR DESCRIPTION
…rator that can not overflow

A while ago I added checking for overflow in unary operators during constant evaluation:

https://reviews.llvm.org/D142867

This created some new bug opportunities. I am now checking if the UnaryOperator can overflow before calling EvaluateForOverflow in Sema::CheckForIntOverflow.

Fixes: https://github.com/llvm/llvm-project/issues/170072