### PR TITLE
[os_log] Fix a CodeGen crash for non-trivial C++ arguments

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -9563,6 +9563,10 @@ bool CheckPrintfHandler::checkFormatExpr(
     // was deferred until now, we emit a warning for non-POD
     // arguments here.
     bool EmitTypeMismatch = false;
+    // Record and complex type arguments cannot be code generated for os_log
+    // and would crash CodeGen, so they are rejected with a hard error emitted
+    // after the switch below.
+    bool EmitOSLogError = false;
     switch (S.isValidVarArgType(ExprTy)) {
     case VarArgKind::Valid:
     case VarArgKind::ValidInCXX11: {
@@ -9582,22 +9586,26 @@ bool CheckPrintfHandler::checkFormatExpr(
         Diag = diag::warn_format_conversion_argument_type_mismatch_confusion;
         break;
       case ArgType::NoMatch:
-        Diag = isInvalidOSLogArgTypeForCodeGen(FSType, ExprTy)
-                   ? diag::err_format_conversion_argument_type_mismatch
-                   : diag::warn_format_conversion_argument_type_mismatch;
+        EmitOSLogError = isInvalidOSLogArgTypeForCodeGen(FSType, ExprTy);
+        Diag = diag::warn_format_conversion_argument_type_mismatch;
         break;
       }
 
-      EmitFormatDiagnostic(
-          S.PDiag(Diag) << AT.getRepresentativeTypeName(S.Context) << ExprTy
-                        << IsEnum << CSR << E->getSourceRange(),
-          E->getBeginLoc(), /*IsStringLocation*/ false, CSR);
+      if (!EmitOSLogError)
+        EmitFormatDiagnostic(
+            S.PDiag(Diag) << AT.getRepresentativeTypeName(S.Context) << ExprTy
+                          << IsEnum << CSR << E->getSourceRange(),
+            E->getBeginLoc(), /*IsStringLocation*/ false, CSR);
       break;
     }
     case VarArgKind::Undefined:
     case VarArgKind::MSVCUndefined:
       if (CallType == VariadicCallType::DoesNotApply) {
         EmitTypeMismatch = true;
+      } else if (isInvalidOSLogArgTypeForCodeGen(FSType, ExprTy)) {
+        // Emit a hard error rather than the -Wnon-pod-varargs warning, which
+        // does not stop compilation.
+        EmitOSLogError = true;
       } else {
         EmitFormatDiagnostic(
             S.PDiag(diag::warn_non_pod_vararg_with_format_string)
@@ -9627,6 +9635,13 @@ bool CheckPrintfHandler::checkFormatExpr(
             << AT.getRepresentativeTypeName(S.Context) << E->getSourceRange();
       break;
     }
+
+    if (EmitOSLogError)
+      EmitFormatDiagnostic(
+          S.PDiag(diag::err_format_conversion_argument_type_mismatch)
+              << AT.getRepresentativeTypeName(S.Context) << ExprTy << IsEnum
+              << CSR << E->getSourceRange(),
+          E->getBeginLoc(), /*IsStringLocation*/ false, CSR);
 
     if (EmitTypeMismatch) {
       // The function is not variadic, so we do not generate warnings about

--- a/clang/test/SemaCXX/os_log.cpp
+++ b/clang/test/SemaCXX/os_log.cpp
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++20 %s
+
+// Passing a non-trivial C++ class type (non-trivial copy/move ctor or dtor) to
+// os_log used to crash CodeGen: such arguments take the VarArgKind::Undefined
+// path in checkFormatExpr, which only emitted the -Wnon-pod-varargs warning and
+// let compilation proceed into CodeGen, where the argument's size has no
+// corresponding integer type. Emit a hard error instead.
+
+struct NonTrivial {
+  char a, b, c;
+  ~NonTrivial();
+};
+
+void test(void *buf, NonTrivial nt) {
+  __builtin_os_log_format(buf, "%s", nt); // expected-error {{format specifies type 'char *' but the argument has type 'NonTrivial'}}
+}


### PR DESCRIPTION
The earlier fix in commit 8a0d145d90df (#158744) only emitted a hard error for os_log arguments of record or complex type that took the VarArgKind::Valid / ValidInCXX11 path in checkFormatExpr. Arguments of non-trivial C++ class type (non-trivial copy/move ctor or dtor) instead take the VarArgKind::Undefined path, which only emitted the -Wnon-pod-varargs warning and let compilation proceed into CodeGen.

There, emitBuiltinOSLogFormat passes the argument expression to EmitScalarExpr, which requires a scalar type. A non-trivial class argument is not a scalar, so CodeGen crashes (asserting in hasScalarEvaluationKind in assertions builds).

Emit the hard error err_format_conversion_argument_type_mismatch on the Undefined path too, so compilation stops before CodeGen.

rdar://174747930