### PR TITLE
[WebAssembly] Avoid crash in LateEHPrepare with empty cleanup pads

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyLateEHPrepare.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyLateEHPrepare.cpp
@@ -311,7 +311,8 @@ bool WebAssemblyLateEHPrepare::addCatchRefsAndThrowRefs(MachineFunction &MF) {
   // caught exception is rethrown. And convert RETHROWs to THROW_REFs.
   for (auto &[EHPad, Rethrows] : EHPadToRethrows) {
     auto *Catch = WebAssembly::findCatch(EHPad);
-    auto *InsertPos = Catch->getIterator()->getNextNode();
+    assert(Catch && "CATCH not found in EHPad");
+    auto InsertPos = std::next(Catch->getIterator());
     auto ExnReg = MRI.createVirtualRegister(&WebAssembly::EXNREFRegClass);
     if (Catch->getOpcode() == WebAssembly::CATCH) {
       MachineInstrBuilder MIB = BuildMI(*EHPad, InsertPos, Catch->getDebugLoc(),

--- a/llvm/test/CodeGen/WebAssembly/exception.ll
+++ b/llvm/test/CodeGen/WebAssembly/exception.ll
@@ -672,5 +672,32 @@ attributes #0 = { nounwind }
 attributes #1 = { noreturn }
 attributes #2 = { noreturn nounwind }
 
+; CHECK-LABEL: empty_cleanup_pad:
+; CHECK:     try_table    (catch_all_ref 0)
+; CHECK:     throw_ref
+define void @empty_cleanup_pad(i32 %arg) personality ptr @__gxx_wasm_personality_v0 {
+entry:
+  br label %loop
+
+loop:
+  invoke void @foo()
+          to label %loop unwind label %cleanup
+
+cleanup:
+  %exn = cleanuppad within none []
+  br label %dispatch
+
+dispatch:                                         ; preds = %cleanup, %dispatch
+  %cond = icmp eq i32 %arg, 0
+  br i1 %cond, label %ret, label %dispatch
+
+ret:                                              ; preds = %dispatch
+  cleanupret from %exn unwind label %cleanup2
+
+cleanup2:                                         ; preds = %ret
+  %exn2 = cleanuppad within none []
+  ret void
+}
+
 ;; The exception tag should not be defined locally
 ; CHECK-NOT: __cpp_exception:


### PR DESCRIPTION
WebAssemblyLateEHPrepare::addCatchRefsAndThrowRefs was using
Catch->getIterator()->getNextNode() to find the insertion position
after the CATCH (or CATCH_ALL) instruction in an EH pad.
If the CATCH/CATCH_ALL instruction is the last instruction in the basic
block, getNextNode() returns nullptr, which causees a crash when passed
to BuildMI. This patch fixes it by using std::next(Catch->getIterator())
which returns MBB.end() if the catch is the last instruction, and the
overload of BuildMI that takes an iterator correctly handles BB.end().

Fixes #197077

Assisted-By: Gemini
