### PR TITLE
Ignore `!guid` metadata when merging globals or constants

### DIFF
--- a/llvm/include/llvm/IR/GlobalObject.h
+++ b/llvm/include/llvm/IR/GlobalObject.h
@@ -181,7 +181,7 @@ public:
                             SmallVectorImpl<MDNode *> &MDs) const;
   /// @}
 
-  LLVM_ABI bool hasMetadataOtherThanDebugLoc() const;
+  LLVM_ABI bool hasMetadataOtherThanDebugLocAndGuid() const;
 
   /// Copy metadata from Src, adjusting offsets by Offset.
   LLVM_ABI void copyMetadata(const GlobalObject *Src, unsigned Offset);

--- a/llvm/include/llvm/Transforms/Utils/AssignGUID.h
+++ b/llvm/include/llvm/Transforms/Utils/AssignGUID.h
@@ -17,6 +17,8 @@
 #ifndef LLVM_TRANSFORMS_UTILS_ASSIGNGUID_H
 #define LLVM_TRANSFORMS_UTILS_ASSIGNGUID_H
 
+#include "llvm/IR/GlobalVariable.h"
+#include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Support/Debug.h"
@@ -35,6 +37,11 @@ public:
   }
 
   static bool isRequired() { return true; }
+
+  // Let GlobalMerge assign a GUID for merged GVs, instead of needing to
+  // traverse all the module; or instead of making GlobalValue::assignGUID
+  // public.
+  static void assignGUIDForMergedGV(GlobalVariable &GV);
 };
 
 } // end namespace llvm

--- a/llvm/lib/CodeGen/GlobalMerge.cpp
+++ b/llvm/lib/CodeGen/GlobalMerge.cpp
@@ -729,13 +729,14 @@ bool GlobalMergeImpl::run(Module &M) {
     if (GV.isTagged())
       continue;
 
-    // Don't merge globals with metadata other than !dbg, as this is essentially
-    // equivalent to adding metadata to an existing global, which is not
-    // necessarily a correct transformation depending on the specific metadata's
-    // semantics. We will later use copyMetadata() to copy metadata from
-    // component globals to the combined global, which only knows how to do this
-    // correctly for !dbg (and !type, but by this point LowerTypeTests will have
-    // already run).
+    // Don't merge globals with metadata other than !dbg or !guid, as this is
+    // essentially equivalent to adding metadata to an existing global, which is
+    // not necessarily a correct transformation depending on the specific
+    // metadata's semantics. We will later use copyMetadata() to copy metadata
+    // from component globals to the combined global, which only knows how to do
+    // this correctly for !dbg (and !type, but by this point LowerTypeTests will
+    // have already run).
+    // Note that a new !guid will be created as part of doMerge
     if (GV.hasMetadataOtherThanDebugLocAndGuid())
       continue;
 

--- a/llvm/lib/CodeGen/GlobalMerge.cpp
+++ b/llvm/lib/CodeGen/GlobalMerge.cpp
@@ -80,6 +80,7 @@
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/Instruction.h"
 #include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Type.h"
 #include "llvm/IR/Use.h"
@@ -94,6 +95,7 @@
 #include "llvm/Target/TargetLoweringObjectFile.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/TargetParser/Triple.h"
+#include "llvm/Transforms/Utils/AssignGUID.h"
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
@@ -605,6 +607,7 @@ bool GlobalMergeImpl::doMerge(const SmallVectorImpl<GlobalVariable *> &Globals,
 
       NumMerged++;
     }
+    AssignGUIDPass::assignGUIDForMergedGV(*MergedGV);
     Changed = true;
     i = j;
   }
@@ -733,7 +736,7 @@ bool GlobalMergeImpl::run(Module &M) {
     // component globals to the combined global, which only knows how to do this
     // correctly for !dbg (and !type, but by this point LowerTypeTests will have
     // already run).
-    if (GV.hasMetadataOtherThanDebugLoc())
+    if (GV.hasMetadataOtherThanDebugLocAndGuid())
       continue;
 
     Type *Ty = GV.getValueType();

--- a/llvm/lib/IR/Globals.cpp
+++ b/llvm/lib/IR/Globals.cpp
@@ -452,11 +452,11 @@ bool GlobalObject::canIncreaseAlignment() const {
   return true;
 }
 
-bool GlobalObject::hasMetadataOtherThanDebugLoc() const {
+bool GlobalObject::hasMetadataOtherThanDebugLocAndGuid() const {
   SmallVector<std::pair<unsigned, MDNode *>, 4> MDs;
   getAllMetadata(MDs);
   for (const auto &V : MDs)
-    if (V.first != LLVMContext::MD_dbg)
+    if (V.first != LLVMContext::MD_dbg && V.first != LLVMContext::MD_unique_id)
       return true;
   return false;
 }

--- a/llvm/lib/Transforms/IPO/ConstantMerge.cpp
+++ b/llvm/lib/Transforms/IPO/ConstantMerge.cpp
@@ -98,9 +98,9 @@ enum class CanMerge { No, Yes };
 static CanMerge makeMergeable(GlobalVariable *Old, GlobalVariable *New) {
   if (!Old->hasGlobalUnnamedAddr() && !New->hasGlobalUnnamedAddr())
     return CanMerge::No;
-  if (Old->hasMetadataOtherThanDebugLoc())
+  if (Old->hasMetadataOtherThanDebugLocAndGuid())
     return CanMerge::No;
-  assert(!New->hasMetadataOtherThanDebugLoc());
+  assert(!New->hasMetadataOtherThanDebugLocAndGuid());
 
   // Merging constants with different comdats means one group cannot in general
   // be dropped independently without the other group now having an invalid
@@ -176,7 +176,7 @@ static bool mergeConstants(Module &M) {
         continue;
 
       // Don't touch globals with metadata other then !dbg.
-      if (GV.hasMetadataOtherThanDebugLoc())
+      if (GV.hasMetadataOtherThanDebugLocAndGuid())
         continue;
 
       Constant *Init = GV.getInitializer();

--- a/llvm/lib/Transforms/IPO/ConstantMerge.cpp
+++ b/llvm/lib/Transforms/IPO/ConstantMerge.cpp
@@ -175,7 +175,7 @@ static bool mergeConstants(Module &M) {
       if (GV.isWeakForLinker())
         continue;
 
-      // Don't touch globals with metadata other then !dbg.
+      // Don't touch globals with metadata other than !dbg or !guid.
       if (GV.hasMetadataOtherThanDebugLocAndGuid())
         continue;
 

--- a/llvm/lib/Transforms/Utils/AssignGUID.cpp
+++ b/llvm/lib/Transforms/Utils/AssignGUID.cpp
@@ -30,3 +30,12 @@ void AssignGUIDPass::runOnModule(Module &M) {
     F.assignGUID();
   }
 }
+
+void AssignGUIDPass::assignGUIDForMergedGV(GlobalVariable &GV) {
+  // FIXME: merging adds all the guids of the original GVs. We currently drop
+  // that metadata from GV first, but we may want to remember those later, if
+  // we had a motivation for that. In that case, we need some other metadata
+  // to maintain that association.
+  GV.eraseMetadata(LLVMContext::MD_unique_id);
+  GV.assignGUID();
+}

--- a/llvm/test/Transforms/ConstantMerge/merge-dbg.ll
+++ b/llvm/test/Transforms/ConstantMerge/merge-dbg.ll
@@ -1,4 +1,5 @@
 ; RUN: opt < %s -passes=constmerge -S | FileCheck %s
+; RUN: opt < %s -passes=assign-guid,constmerge -S | FileCheck %s
 
 ; CHECK: = constant i32 1, !dbg [[A:![0-9]+]], !dbg [[B:![0-9]+]]
 @a = internal constant i32 1, !dbg !0

--- a/llvm/test/Transforms/GlobalMerge/guid.ll
+++ b/llvm/test/Transforms/GlobalMerge/guid.ll
@@ -1,0 +1,38 @@
+; We can merge globals with a guid metadata, and the guid of the merged object
+; is different from that of the original objects.
+; RUN: opt -passes='global-merge<max-offset=100>' -S -o - %s | FileCheck %s
+
+target datalayout = "e-p:64:64"
+target triple = "x86_64-unknown-linux-gnu"
+
+; CHECK: @_MergedGlobals = private global <{ i32, i32 }> <{ i32 1, i32 2 }>, align 4, !guid !0
+; CHECK: @_MergedGlobals.1 = private global <{ i32, i32 }> <{ i32 3, i32 4 }>, section "foo", align 4, !guid !1
+
+; CHECK-DAG: @a = internal alias i32, ptr @_MergedGlobals{{$}}
+@a = internal global i32 1, !guid !{i64 1}
+
+; CHECK-DAG: @b = internal alias i32, getelementptr inbounds (<{ i32, i32 }>, ptr @_MergedGlobals, i32 0, i32 1)
+@b = internal global i32 2, !guid !{i64 2}
+
+; CHECK-DAG: @c = internal alias i32, ptr @_MergedGlobals.1{{$}}
+@c = internal global i32 3, section "foo",  !guid !{i64 3}
+
+; CHECK-DAG: @d = internal alias i32, getelementptr inbounds (<{ i32, i32 }>, ptr @_MergedGlobals.1, i32 0, i32 1)
+@d = internal global i32 4, section "foo", !guid !{i64 4}
+
+; CHECK: define void @use() !guid !2
+define void @use() !guid !{i64 5} {
+  ; CHECK: load i32, ptr @_MergedGlobals,
+  %x = load i32, ptr @a
+  ; CHECK: load i32, ptr getelementptr inbounds (<{ i32, i32 }>, ptr @_MergedGlobals, i32 0, i32 1)
+  %y = load i32, ptr @b
+  ; CHECK: load i32, ptr @_MergedGlobals.1
+  %z1 = load i32, ptr @c
+  ; CHECK: load i32, ptr getelementptr inbounds (<{ i32, i32 }>, ptr @_MergedGlobals.1, i32 0, i32 1)
+  %z2 = load i32, ptr @d
+  ret void
+}
+
+; CHECK: !0 = !{i64 {{-?[0-9][0-9]+}}}
+; CHECK: !1 = !{i64 {{-?[0-9][0-9]+}}}
+; CHECK: !2 = !{i64 5}


### PR DESCRIPTION
Follow up from PR #184065. Since globals or constants would now have their GUID pre-calculated and affixed with metadata, we need to tolerate its presence when merging. To that effect, we rename (and change accordingly) `GlobalObject::hasMetadataOtherThanDebugLoc` to `...AndGuid`.

In the case of Constants, they are merged into one of them, which then keeps its guid, while the rest are erased. In the case of GlobalVariables, a new one is created, and we will give it its own guid.