### PR TITLE
[SimplifyCFG] Preserve atomicity when merging atomic conditional stores

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -4324,6 +4324,8 @@ static bool mergeConditionalStoreToAddress(
 
   // Now check the stores are compatible.
   if (!QStore->isUnordered() || !PStore->isUnordered() ||
+      PStore->getOrdering() != QStore->getOrdering() ||
+      PStore->getSyncScopeID() != QStore->getSyncScopeID() ||
       PStore->getValueOperand()->getType() !=
           QStore->getValueOperand()->getType())
     return false;
@@ -4475,6 +4477,9 @@ static bool mergeConditionalStoreToAddress(
   // stores executes.  And we don't know it's safe to take the alignment from a
   // store that doesn't execute.
   SI->setAlignment(std::min(PStore->getAlign(), QStore->getAlign()));
+
+  if (QStore->isAtomic())
+    SI->setAtomic(QStore->getOrdering(), QStore->getSyncScopeID());
 
   QStore->eraseFromParent();
   PStore->eraseFromParent();

--- a/llvm/test/Transforms/SimplifyCFG/merge-cond-stores.ll
+++ b/llvm/test/Transforms/SimplifyCFG/merge-cond-stores.ll
@@ -407,6 +407,42 @@ end:
   ret void
 }
 
+; Unordered atomic stores can be merged, but the merged store must remain
+; atomic with the same ordering/syncscope (it must not be downgraded to a
+; plain store).
+define void @test_atomic_store_merged(i1 %c1, i1 %c2, ptr %p) {
+; CHECK-LABEL: @test_atomic_store_merged(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[TMP0:%.*]] = or i1 [[C1:%.*]], [[C2:%.*]]
+; CHECK-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; CHECK:       1:
+; CHECK-NEXT:    [[SPEC_SELECT:%.*]] = select i1 [[C2]], i32 2, i32 1
+; CHECK-NEXT:    store atomic i32 [[SPEC_SELECT]], ptr [[P:%.*]] unordered, align 4
+; CHECK-NEXT:    br label [[TMP2]]
+; CHECK:       2:
+; CHECK-NEXT:    ret void
+;
+entry:
+  br i1 %c1, label %if.then, label %if.else
+
+if.then:
+  store atomic i32 1, ptr %p unordered, align 4
+  br label %merge
+
+if.else:
+  br label %merge
+
+merge:
+  br i1 %c2, label %if.then2, label %if.end
+
+if.then2:
+  store atomic i32 2, ptr %p unordered, align 4
+  br label %if.end
+
+if.end:
+  ret void
+}
+
 !0 = !{!"branch_weights", i32 7, i32 13}
 !1 = !{!"branch_weights", i32 3, i32 11}
 ;.


### PR DESCRIPTION
mergeConditionalStoreToAddress() merges two stores into one.  It does
this for non-atomic and atomic-unordered stores, but when merging
unordered stores, it would downgrade them to non-atomic!

This bug isn't accessible from C because C doesn't expose unordered
atomics.  But you can access it from e.g. Objective-C with something like

```
// repro.m — clang -fno-objc-arc -O2
__attribute__((objc_root_class))
@interface C { int _value; }
@property(atomic, direct) int value;
@end
@implementation C
@end

void f(C *obj, _Bool c1, _Bool c2, int v1, int v2) {
    if (!obj) __builtin_unreachable();
    if (c1) obj.value = v1;
    if (c2) obj.value = v2;
}
```

LLVM merges these into a single store.  The store is non-atomic without
this change.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
