### PR TITLE
[flang][OpenMP] Fix declare reduction lookup for USE...ONLY imports

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -38,6 +38,7 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Frontend/OpenMP/OMP.h"
@@ -3745,6 +3746,131 @@ void OmpStructureChecker::Enter(const parser::OmpClause::TaskReduction &x) {
   CheckReductionObjects(objects, llvm::omp::Clause::OMPC_task_reduction);
 }
 
+// Compute the mangled reduction name to look up in a reduction's source module.
+// If the operator was renamed on import (e.g. USE m, ONLY: operator(.local.) =>
+// operator(.remote.)), the local mangled name will not match in the source
+// module; re-derive the lookup name from the source operator's ultimate name.
+// Only defined operators can be renamed (intrinsic operators and named
+// reductions cannot), so a detected rename always has a ".op." source name.
+// For non-renamed lookups the original mangled name is returned unchanged.
+static std::string SourceReductionName(const parser::CharBlock &mangledName,
+    const parser::CharBlock &localName, const parser::CharBlock &sourceName) {
+  if (sourceName != localName && sourceName.size() >= 3 &&
+      sourceName.front() == '.' && sourceName.back() == '.') {
+    return MangleDefinedOperator(sourceName);
+  }
+  return mangledName.ToString();
+}
+
+// Return the reduction details of `symbol` if it is a user reduction that
+// supports `type` (any type when `type` is null).
+static const UserReductionDetails *AcceptReduction(
+    const Symbol &symbol, const DeclTypeSpec *type) {
+  const auto *details{symbol.GetUltimate().detailsIf<UserReductionDetails>()};
+  if (details && (!type || details->SupportsType(*type))) {
+    return details;
+  }
+  return nullptr;
+}
+
+// A reduction symbol is locally declared (authoritative) when it is not reached
+// through any USE association, even via host association. Such a reduction
+// shadows reductions imported or reachable through its operator.
+static bool IsLocalReduction(const Symbol &symbol) {
+  const Symbol *s{&symbol};
+  while (const auto *host{s->detailsIf<HostAssocDetails>()}) {
+    s = &host->symbol();
+  }
+  return !s->detailsIf<UseDetails>();
+}
+
+// Search for a user reduction supporting `type` by following the operator/
+// procedure symbol `opSym` through its USE associations and merged generic
+// sources. Each module the operator passes through is checked for a (possibly
+// renamed) reduction; `localName` is the operator name written at the use site,
+// used to detect renames. A locally declared reduction in a module is
+// authoritative: it is returned if it supports the type, otherwise it shadows
+// reductions reachable further along that branch.
+static const UserReductionDetails *SearchOperatorReduction(const Symbol &opSym,
+    const parser::CharBlock &mangledName, const parser::CharBlock &localName,
+    const DeclTypeSpec *type, llvm::SmallPtrSetImpl<const Symbol *> &visited) {
+  if (!visited.insert(&opSym).second) {
+    return nullptr;
+  }
+  const Scope &scope{opSym.owner()};
+  if (scope.kind() == Scope::Kind::Module) {
+    std::string lookupName{
+        SourceReductionName(mangledName, localName, opSym.name())};
+    auto it{scope.find(parser::CharBlock{lookupName})};
+    if (it != scope.end()) {
+      const Symbol &reductionSym{*it->second};
+      const Symbol &reductionUltimate{reductionSym.GetUltimate()};
+      if (!reductionUltimate.attrs().test(Attr::PRIVATE)) {
+        if (const auto *details{AcceptReduction(reductionUltimate, type)}) {
+          return details;
+        }
+        // A locally declared reduction here shadows reductions reachable
+        // further along this branch.
+        if (reductionUltimate.detailsIf<UserReductionDetails>() &&
+            IsLocalReduction(reductionSym)) {
+          return nullptr;
+        }
+      }
+    }
+  }
+  // Follow a USE-associated operator to the module it was imported from.
+  if (const auto *use{opSym.detailsIf<UseDetails>()}) {
+    return SearchOperatorReduction(
+        use->symbol(), mangledName, localName, type, visited);
+  }
+  // Search each module merged into a generic operator (recursing through
+  // re-exporting facade modules).
+  if (const auto *generic{opSym.detailsIf<GenericDetails>()}) {
+    for (const Symbol &useSym : generic->uses()) {
+      if (const auto *details{SearchOperatorReduction(
+              useSym, mangledName, localName, type, visited)}) {
+        return details;
+      }
+    }
+  }
+  return nullptr;
+}
+
+// Find user reduction details for a mangled name, following USE associations
+// when the reduction is not directly visible in the scope. A type may be
+// supplied to disambiguate an operator that carries reductions for several
+// types (e.g. a generic merged from multiple modules); a candidate is accepted
+// only if it supports that type. A locally declared reduction is authoritative
+// for its operator in its scope and shadows USE-associated reductions.
+static const UserReductionDetails *FindUserReduction(const Scope &scope,
+    const parser::CharBlock &mangledName, const DeclTypeSpec *type = nullptr) {
+  // Direct lookup: a reduction directly visible via bare USE or a local
+  // declaration.
+  const Symbol *directSymbol{scope.FindSymbol(mangledName)};
+  if (directSymbol) {
+    if (const auto *details{AcceptReduction(*directSymbol, type)}) {
+      return details;
+    }
+    // A locally declared reduction that does not support the requested type is
+    // authoritative: it shadows USE-associated reductions (ProcessReduction-
+    // Specifier erases the latter), so do not resurrect them via the operator.
+    if (directSymbol->GetUltimate().detailsIf<UserReductionDetails>() &&
+        IsLocalReduction(*directSymbol)) {
+      return nullptr;
+    }
+  }
+  // Trace the operator/procedure to the modules that declare its reduction.
+  std::string fortranName{GetReductionFortranId(mangledName)};
+  const Symbol *opSymbol{
+      fortranName.empty() ? nullptr : scope.FindSymbol(fortranName)};
+  if (!opSymbol) {
+    return nullptr;
+  }
+  llvm::SmallPtrSet<const Symbol *, 8> visited;
+  return SearchOperatorReduction(
+      *opSymbol, mangledName, opSymbol->name(), type, visited);
+}
+
 bool OmpStructureChecker::CheckReductionOperator(
     const parser::OmpReductionIdentifier &ident, parser::CharBlock source,
     llvm::omp::Clause clauseId) {
@@ -3775,10 +3901,8 @@ bool OmpStructureChecker::CheckReductionOperator(
     if (const auto *definedOp{std::get_if<parser::DefinedOpName>(&dOpr.u)}) {
       std::string mangled{MangleDefinedOperator(definedOp->v.symbol->name())};
       const Scope &scope{definedOp->v.symbol->owner()};
-      if (const Symbol *symbol{scope.FindSymbol(mangled)}) {
-        if (symbol->GetUltimate().detailsIf<UserReductionDetails>()) {
-          return true;
-        }
+      if (FindUserReduction(scope, mangled)) {
+        return true;
       }
     }
     context_.Say(source, "Invalid reduction operator in %s clause."_err_en_US,
@@ -3865,32 +3989,9 @@ void OmpStructureChecker::CheckReductionObjects(
 
 static bool CheckSymbolSupportsType(const Scope &scope,
     const parser::CharBlock &name, const DeclTypeSpec &type) {
-  if (const auto *symbol{scope.FindSymbol(name)}) {
-    const auto &ultimate{symbol->GetUltimate()};
-    if (const auto *reductionDetails{
-            ultimate.detailsIf<UserReductionDetails>()}) {
-      return reductionDetails->SupportsType(type);
-    }
-  }
-  // Look through module scopes in the global scope.
-  // This covers reductions declared in a module and used via USE association.
-  const SemanticsContext &semCtx{scope.context()};
-  Scope &global = const_cast<SemanticsContext &>(semCtx).globalScope();
-  for (const Scope &child : global.children()) {
-    if (child.kind() == Scope::Kind::Module) {
-      if (const auto *symbol{child.FindSymbol(name)}) {
-        // Skip PRIVATE reductions that aren't visible in the current scope.
-        if (symbol->attrs().test(Attr::PRIVATE)) {
-          continue;
-        }
-        if (const auto *reductionDetails{
-                symbol->detailsIf<UserReductionDetails>()}) {
-          return reductionDetails->SupportsType(type);
-        }
-      }
-    }
-  }
-  return false;
+  // FindUserReduction only returns a reduction that supports the requested
+  // type.
+  return FindUserReduction(scope, name, &type) != nullptr;
 }
 
 static bool IsReductionAllowedForType(

--- a/flang/lib/Semantics/mod-file.cpp
+++ b/flang/lib/Semantics/mod-file.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "mod-file.h"
+#include "resolve-names-utils.h"
 #include "resolve-names.h"
 #include "flang/Common/restorer.h"
 #include "flang/Evaluate/tools.h"
@@ -1143,33 +1144,6 @@ void ModFileWriter::PutTypeParam(llvm::raw_ostream &os, const Symbol &symbol) {
       symbol.attrs());
   PutInit(os, details.init());
   os << '\n';
-}
-
-// Map a mangled reduction name to a valid Fortran accessibility identifier
-// for module file serialization (e.g., op.+ → operator(+), op.max → max).
-// Non-mangled names (procedure designators) are returned as-is.
-static std::string GetReductionFortranId(const SourceName &mangledName) {
-  llvm::StringRef name{mangledName.begin(), mangledName.size()};
-  if (!name.starts_with("op.")) {
-    return name.str();
-  }
-  llvm::StringRef suffix{name.drop_front(3)};
-  if (suffix == "+" || suffix == "-" || suffix == "*") {
-    return ("operator(" + suffix + ")").str();
-  }
-  llvm::StringRef logicalOp{llvm::StringSwitch<llvm::StringRef>(suffix)
-          .Case("AND", ".and.")
-          .Case("OR", ".or.")
-          .Case("EQV", ".eqv.")
-          .Case("NEQV", ".neqv.")
-          .Default("")};
-  if (!logicalOp.empty()) {
-    return ("operator(" + logicalOp + ")").str();
-  }
-  if (suffix.size() > 2 && suffix.front() == '.' && suffix.back() == '.') {
-    return ("operator(" + suffix + ")").str();
-  }
-  return suffix.str();
 }
 
 void ModFileWriter::PutUserReduction(

--- a/flang/lib/Semantics/resolve-names-utils.cpp
+++ b/flang/lib/Semantics/resolve-names-utils.cpp
@@ -20,6 +20,7 @@
 #include "flang/Semantics/tools.h"
 #include "flang/Support/Fortran-features.h"
 #include "flang/Support/Fortran.h"
+#include "llvm/ADT/StringRef.h"
 #include <initializer_list>
 #include <variant>
 
@@ -950,6 +951,40 @@ void MapSubprogramToNewSymbols(const Symbol &oldSymbol, Symbol &newSymbol,
     mapper.MapSymbolExprs(*ref);
   }
   newScope.InstantiateDerivedTypes();
+}
+
+std::string GetReductionFortranId(const parser::CharBlock &mangledName) {
+  llvm::StringRef name{mangledName.begin(), mangledName.size()};
+  if (!name.starts_with("op.")) {
+    return name.str();
+  }
+  llvm::StringRef suffix{name.drop_front(3)};
+  // Intrinsic arithmetic operators: op.+ -> operator(+)
+  if (suffix == "+" || suffix == "-" || suffix == "*") {
+    return ("operator(" + suffix + ")").str();
+  }
+  // Intrinsic logical operators (mangled uppercase, scope uses lowercase)
+  if (suffix == "AND") {
+    return "operator(.and.)";
+  }
+  if (suffix == "OR") {
+    return "operator(.or.)";
+  }
+  if (suffix == "EQV") {
+    return "operator(.eqv.)";
+  }
+  if (suffix == "NEQV") {
+    return "operator(.neqv.)";
+  }
+  // Defined operators: op.combine. -> .combine.
+  // MangleDefinedOperator prepends "op" to the operator name (e.g.,
+  // ".combine.") so after stripping "op.", the suffix ends with '.' for defined
+  // operators.
+  if (!suffix.empty() && suffix.back() == '.') {
+    return ("." + suffix).str();
+  }
+  // Named functions: op.max -> max
+  return suffix.str();
 }
 
 } // namespace Fortran::semantics

--- a/flang/lib/Semantics/resolve-names-utils.h
+++ b/flang/lib/Semantics/resolve-names-utils.h
@@ -152,5 +152,11 @@ parser::CharBlock MakeNameFromOperator(
 parser::CharBlock MangleSpecialFunctions(const parser::CharBlock &name);
 std::string MangleDefinedOperator(const parser::CharBlock &name);
 
+// Map a mangled declare reduction name (e.g., "op.+", "op.combine.",
+// "op.max") back to the Fortran identifier used as the scope key for the
+// corresponding operator or procedure (e.g., "operator(+)", ".combine.",
+// "max"). Non-mangled names (procedure designators) are returned as-is.
+std::string GetReductionFortranId(const parser::CharBlock &mangledName);
+
 } // namespace Fortran::semantics
 #endif // FORTRAN_SEMANTICS_RESOLVE_NAMES_H_

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -4543,38 +4543,6 @@ Scope *ModuleVisitor::FindModule(const parser::Name &name,
   return scope;
 }
 
-// Map a mangled declare reduction name (e.g., op.+, op.max, op..myop.) back
-// to the Fortran identifier that controls its accessibility in a module scope.
-// Intrinsic operators map to "operator(+)" etc., named functions to "max" etc.,
-// and defined operators to "operator(.myop.)" etc.
-static std::string GetReductionIdentifierName(const SourceName &mangledName) {
-  llvm::StringRef name{mangledName.begin(), mangledName.size()};
-  if (!name.starts_with("op.")) {
-    return {};
-  }
-  llvm::StringRef suffix{name.drop_front(3)};
-  // Intrinsic arithmetic operators: op.+ → operator(+)
-  if (suffix == "+" || suffix == "-" || suffix == "*") {
-    return ("operator(" + suffix + ")").str();
-  }
-  // Intrinsic logical operators (mangled uppercase, scope uses lowercase)
-  llvm::StringRef logicalOp{llvm::StringSwitch<llvm::StringRef>(suffix)
-          .Case("AND", ".and.")
-          .Case("OR", ".or.")
-          .Case("EQV", ".eqv.")
-          .Case("NEQV", ".neqv.")
-          .Default("")};
-  if (!logicalOp.empty()) {
-    return ("operator(" + logicalOp + ")").str();
-  }
-  // Defined operators: op..myop. → operator(.myop.)
-  if (suffix.size() > 2 && suffix.front() == '.' && suffix.back() == '.') {
-    return ("operator(" + suffix + ")").str();
-  }
-  // Named functions: op.max → max
-  return suffix.str();
-}
-
 void ModuleVisitor::ApplyDefaultAccess() {
   const auto *moduleDetails{
       DEREF(currScope().symbol()).detailsIf<ModuleDetails>()};
@@ -4601,7 +4569,7 @@ void ModuleVisitor::ApplyDefaultAccess() {
         // a module has accessibility as if it were declared as a module entity.
         // If the corresponding operator/procedure has explicit accessibility,
         // the reduction inherits it.
-        std::string opName{GetReductionIdentifierName(symbol.name())};
+        std::string opName{GetReductionFortranId(symbol.name())};
         if (!opName.empty()) {
           if (auto *opSym{FindInScope(currScope(), SourceName{opName})}) {
             if (opSym->attrs().test(Attr::PUBLIC)) {

--- a/flang/test/Semantics/OpenMP/declare-reduction-overbroad-lookup.f90
+++ b/flang/test/Semantics/OpenMP/declare-reduction-overbroad-lookup.f90
@@ -1,0 +1,32 @@
+! RUN: not %flang_fc1 -fopenmp -fopenmp-version=52 %s 2>&1 | FileCheck %s
+
+! Test that a declare reduction from a module that was not USE'd (or only
+! partially USE'd) is not incorrectly found during type checking.
+! Related: https://github.com/llvm/llvm-project/issues/200300
+
+module m_with_reduction
+  type :: t
+    integer :: val = 0
+  end type
+  !$omp declare reduction(+:t:omp_out%val=omp_out%val+omp_in%val) &
+  !$omp   initializer(omp_priv=t(0))
+end module
+
+! proxy re-exports only the type, not the reduction
+module m_proxy
+  use m_with_reduction, only: t
+end module
+
+program test_overbroad_lookup
+  use m_proxy
+  type(t) :: x
+  integer :: i
+  x = t(0)
+  !CHECK: error: The type of 'x' is incompatible with the reduction operator.
+  !$omp parallel do reduction(+:x)
+  do i = 1, 10
+    x%val = x%val + 1
+  end do
+  !$omp end parallel do
+  print *, x%val
+end program

--- a/flang/test/Semantics/OpenMP/declare-reduction-use-mixed-merged.f90
+++ b/flang/test/Semantics/OpenMP/declare-reduction-use-mixed-merged.f90
@@ -1,0 +1,61 @@
+! RUN: %flang_fc1 -fopenmp -fopenmp-version=52 -fsyntax-only %s
+
+! Test that declare reduction resolves the type-correct reduction when an
+! operator carries reductions for different types and one module is imported
+! with a bare USE (making its reduction directly visible) while another is
+! imported with USE...ONLY. The directly visible reduction must not shadow the
+! reduction for the other type.
+
+module m_int
+  type :: t_int
+    integer :: val = 0
+  end type
+  interface operator(.shared.)
+    module procedure add_int
+  end interface
+  !$omp declare reduction(.shared.:t_int:omp_out%val=omp_out%val+omp_in%val) &
+  !$omp   initializer(omp_priv=t_int(0))
+contains
+  type(t_int) function add_int(a, b)
+    type(t_int), intent(in) :: a, b
+    add_int%val = a%val + b%val
+  end function
+end module
+
+module m_real
+  type :: t_real
+    real :: val = 0.0
+  end type
+  interface operator(.shared.)
+    module procedure add_real
+  end interface
+  !$omp declare reduction(.shared.:t_real:omp_out%val=omp_out%val+omp_in%val) &
+  !$omp   initializer(omp_priv=t_real(0.0))
+contains
+  type(t_real) function add_real(a, b)
+    type(t_real), intent(in) :: a, b
+    add_real%val = a%val + b%val
+  end function
+end module
+
+program test_mixed_merged_reduction
+  use m_int                                     ! bare USE: t_int reduction directly visible
+  use m_real, only: t_real, operator(.shared.)  ! USE...ONLY: operator merged in
+  type(t_int) :: x
+  type(t_real) :: y
+  integer :: i
+  x = t_int(0)
+  y = t_real(0.0)
+  !$omp parallel do reduction(.shared.:x)
+  do i = 1, 10
+    x%val = x%val + 1
+  end do
+  !$omp end parallel do
+  ! The t_int reduction from m_int is directly visible, but resolving t_real
+  ! must still find m_real's reduction rather than stopping at t_int.
+  !$omp parallel do reduction(.shared.:y)
+  do i = 1, 10
+    y%val = y%val + 1.0
+  end do
+  !$omp end parallel do
+end program

--- a/flang/test/Semantics/OpenMP/declare-reduction-use-only-defined-op.f90
+++ b/flang/test/Semantics/OpenMP/declare-reduction-use-only-defined-op.f90
@@ -1,0 +1,33 @@
+! RUN: %flang_fc1 -fopenmp -fopenmp-version=52 -fsyntax-only %s
+
+! Test that declare reduction for a defined operator works correctly with
+! USE...ONLY when only the operator interface is imported.
+
+module m_defined_op_reduction
+  type :: dt2
+    real :: x = 0.0
+  end type
+  interface operator(.combine.)
+    module procedure combine_fn
+  end interface
+  !$omp declare reduction(.combine.:dt2:omp_out%x=omp_out%x+omp_in%x) &
+  !$omp   initializer(omp_priv=dt2(0.0))
+contains
+  type(dt2) function combine_fn(a, b)
+    type(dt2), intent(in) :: a, b
+    combine_fn%x = a%x + b%x
+  end function
+end module
+
+subroutine test_defined_op_use_only()
+  use m_defined_op_reduction, only: dt2, operator(.combine.)
+  type(dt2) :: y
+  integer :: i
+  y = dt2(0.0)
+  ! Should compile without error: reduction is accessible via operator(.combine.)
+  !$omp parallel do reduction(.combine.:y)
+  do i = 1, 10
+    y%x = y%x + 1.0
+  end do
+  !$omp end parallel do
+end subroutine

--- a/flang/test/Semantics/OpenMP/declare-reduction-use-only-merged.f90
+++ b/flang/test/Semantics/OpenMP/declare-reduction-use-only-merged.f90
@@ -1,0 +1,60 @@
+! RUN: %flang_fc1 -fopenmp -fopenmp-version=52 -fsyntax-only %s
+
+! Test that declare reduction resolves correctly when the same operator is
+! imported (and renamed) from several modules, each declaring a reduction for a
+! different type. The merged generic must resolve to the reduction matching the
+! requested type, not just the first module's reduction.
+
+module m_int
+  type :: t_int
+    integer :: val = 0
+  end type
+  interface operator(.remote.)
+    module procedure add_int
+  end interface
+  !$omp declare reduction(.remote.:t_int:omp_out%val=omp_out%val+omp_in%val) &
+  !$omp   initializer(omp_priv=t_int(0))
+contains
+  type(t_int) function add_int(a, b)
+    type(t_int), intent(in) :: a, b
+    add_int%val = a%val + b%val
+  end function
+end module
+
+module m_real
+  type :: t_real
+    real :: val = 0.0
+  end type
+  interface operator(.remote.)
+    module procedure add_real
+  end interface
+  !$omp declare reduction(.remote.:t_real:omp_out%val=omp_out%val+omp_in%val) &
+  !$omp   initializer(omp_priv=t_real(0.0))
+contains
+  type(t_real) function add_real(a, b)
+    type(t_real), intent(in) :: a, b
+    add_real%val = a%val + b%val
+  end function
+end module
+
+program test_merged_use_only_reduction
+  use m_int, only: t_int, operator(.local.) => operator(.remote.)
+  use m_real, only: t_real, operator(.local.) => operator(.remote.)
+  type(t_int) :: x
+  type(t_real) :: y
+  integer :: i
+  x = t_int(0)
+  y = t_real(0.0)
+  ! The reduction for the first module (t_int) appears first in the merged
+  ! generic. Resolving the second type (t_real) must still succeed.
+  !$omp parallel do reduction(.local.:x)
+  do i = 1, 10
+    x%val = x%val + 1
+  end do
+  !$omp end parallel do
+  !$omp parallel do reduction(.local.:y)
+  do i = 1, 10
+    y%val = y%val + 1.0
+  end do
+  !$omp end parallel do
+end program

--- a/flang/test/Semantics/OpenMP/declare-reduction-use-only-renamed.f90
+++ b/flang/test/Semantics/OpenMP/declare-reduction-use-only-renamed.f90
@@ -1,0 +1,36 @@
+! RUN: %flang_fc1 -fopenmp -fopenmp-version=52 -fsyntax-only %s
+! RUN: %flang_fc1 -fopenmp -fopenmp-version=52 -fdebug-dump-symbols %s | FileCheck %s
+
+! Test that declare reduction works correctly with USE...ONLY when
+! the operator is renamed during import.
+
+module m_remote_reduction
+  type :: t
+    integer :: val = 0
+  end type
+  interface operator(.remote.)
+    module procedure add_t
+  end interface
+  !$omp declare reduction(.remote.:t:omp_out%val=omp_out%val+omp_in%val) &
+  !$omp   initializer(omp_priv=t(0))
+! CHECK: op.remote., PUBLIC: UserReductionDetails TYPE(t)
+contains
+  type(t) function add_t(a, b)
+    type(t), intent(in) :: a, b
+    add_t%val = a%val + b%val
+  end function
+end module
+
+program test_renamed_use_only_reduction
+  use m_remote_reduction, only: t, operator(.local.) => operator(.remote.)
+! CHECK: .local. (Function): Use from .remote. in m_remote_reduction
+  type(t) :: x
+  integer :: i
+  x = t(0)
+  ! Should compile without error: reduction is accessible via renamed operator
+  !$omp parallel do reduction(.local.:x)
+  do i = 1, 10
+    x%val = x%val + 1
+  end do
+  !$omp end parallel do
+end program

--- a/flang/test/Semantics/OpenMP/declare-reduction-use-only.f90
+++ b/flang/test/Semantics/OpenMP/declare-reduction-use-only.f90
@@ -1,0 +1,35 @@
+! RUN: %flang_fc1 -fopenmp -fopenmp-version=52 -fsyntax-only %s
+
+! Test that declare reduction works correctly with USE...ONLY when
+! only the operator (not the internal reduction symbol) is imported.
+
+module m_with_reduction
+  type :: dt
+    integer :: val = 0
+  end type
+  interface operator(+)
+    module procedure add_dt
+  end interface
+  !$omp declare reduction(+:dt:omp_out%val=omp_out%val+omp_in%val) &
+  !$omp   initializer(omp_priv=dt(0))
+contains
+  type(dt) function add_dt(a, b)
+    type(dt), intent(in) :: a, b
+    add_dt%val = a%val + b%val
+  end function
+end module
+
+! USE...ONLY imports operator(+) but not the internal op.+ symbol
+program test_use_only
+  use m_with_reduction, only: dt, operator(+)
+  type(dt) :: x
+  integer :: i
+  x = dt(0)
+  ! Should compile without error: reduction is accessible via operator(+)
+  !$omp parallel do reduction(+:x)
+  do i = 1, 10
+    x%val = x%val + 1
+  end do
+  !$omp end parallel do
+  print *, x%val
+end program

--- a/flang/test/Semantics/OpenMP/declare-reduction-use-reexport-merged.f90
+++ b/flang/test/Semantics/OpenMP/declare-reduction-use-reexport-merged.f90
@@ -1,0 +1,63 @@
+! RUN: %flang_fc1 -fopenmp -fopenmp-version=52 -fsyntax-only %s
+
+! Test that declare reduction resolves through a re-exporting (facade) module.
+! The intermediate module merges the same operator from two modules (each with
+! a reduction for a different type) and re-exports it. A program that imports
+! the facade must resolve the reduction for both types via the merged generic's
+! USE associations, not only the operator directly in the facade.
+
+module m_int
+  type :: t_int
+    integer :: val = 0
+  end type
+  interface operator(.shared.)
+    module procedure add_int
+  end interface
+  !$omp declare reduction(.shared.:t_int:omp_out%val=omp_out%val+omp_in%val) &
+  !$omp   initializer(omp_priv=t_int(0))
+contains
+  type(t_int) function add_int(a, b)
+    type(t_int), intent(in) :: a, b
+    add_int%val = a%val + b%val
+  end function
+end module
+
+module m_real
+  type :: t_real
+    real :: val = 0.0
+  end type
+  interface operator(.shared.)
+    module procedure add_real
+  end interface
+  !$omp declare reduction(.shared.:t_real:omp_out%val=omp_out%val+omp_in%val) &
+  !$omp   initializer(omp_priv=t_real(0.0))
+contains
+  type(t_real) function add_real(a, b)
+    type(t_real), intent(in) :: a, b
+    add_real%val = a%val + b%val
+  end function
+end module
+
+module m_facade
+  use m_int, only: t_int, operator(.shared.)
+  use m_real, only: t_real, operator(.shared.)
+end module
+
+program test_reexport_merged_reduction
+  use m_facade
+  type(t_int) :: x
+  type(t_real) :: y
+  integer :: i
+  x = t_int(0)
+  y = t_real(0.0)
+  !$omp parallel do reduction(.shared.:x)
+  do i = 1, 10
+    x%val = x%val + 1
+  end do
+  !$omp end parallel do
+  !$omp parallel do reduction(.shared.:y)
+  do i = 1, 10
+    y%val = y%val + 1.0
+  end do
+  !$omp end parallel do
+end program

--- a/flang/test/Semantics/OpenMP/declare-reduction-use-reexport-remerge.f90
+++ b/flang/test/Semantics/OpenMP/declare-reduction-use-reexport-remerge.f90
@@ -1,0 +1,93 @@
+! RUN: %flang_fc1 -fopenmp -fopenmp-version=52 -fsyntax-only %s
+
+! Test that declare reduction resolves through a facade module that re-merges an
+! already-merged operator with a further module's operator. This requires
+! recursively traversing the merged generic's USE associations: the reductions
+! for the first two types live in modules reached only through the inner facade.
+
+module m_int
+  type :: t_int
+    integer :: val = 0
+  end type
+  interface operator(.shared.)
+    module procedure add_int
+  end interface
+  !$omp declare reduction(.shared.:t_int:omp_out%val=omp_out%val+omp_in%val) &
+  !$omp   initializer(omp_priv=t_int(0))
+contains
+  type(t_int) function add_int(a, b)
+    type(t_int), intent(in) :: a, b
+    add_int%val = a%val + b%val
+  end function
+end module
+
+module m_real
+  type :: t_real
+    real :: val = 0.0
+  end type
+  interface operator(.shared.)
+    module procedure add_real
+  end interface
+  !$omp declare reduction(.shared.:t_real:omp_out%val=omp_out%val+omp_in%val) &
+  !$omp   initializer(omp_priv=t_real(0.0))
+contains
+  type(t_real) function add_real(a, b)
+    type(t_real), intent(in) :: a, b
+    add_real%val = a%val + b%val
+  end function
+end module
+
+module m_cplx
+  type :: t_cplx
+    complex :: val = (0.0, 0.0)
+  end type
+  interface operator(.shared.)
+    module procedure add_cplx
+  end interface
+  !$omp declare reduction(.shared.:t_cplx:omp_out%val=omp_out%val+omp_in%val) &
+  !$omp   initializer(omp_priv=t_cplx((0.0, 0.0)))
+contains
+  type(t_cplx) function add_cplx(a, b)
+    type(t_cplx), intent(in) :: a, b
+    add_cplx%val = a%val + b%val
+  end function
+end module
+
+! Inner facade merges .shared. from m_int and m_real.
+module m_facade_inner
+  use m_int, only: t_int, operator(.shared.)
+  use m_real, only: t_real, operator(.shared.)
+end module
+
+! Outer facade re-merges the inner (already-merged) operator with m_cplx.
+module m_facade_outer
+  use m_facade_inner, only: t_int, t_real, operator(.shared.)
+  use m_cplx, only: t_cplx, operator(.shared.)
+end module
+
+program test_reexport_remerge_reduction
+  use m_facade_outer
+  type(t_int) :: x
+  type(t_real) :: y
+  type(t_cplx) :: z
+  integer :: i
+  x = t_int(0)
+  y = t_real(0.0)
+  z = t_cplx((0.0, 0.0))
+  ! t_int and t_real reach only through the inner facade (recursive traversal).
+  !$omp parallel do reduction(.shared.:x)
+  do i = 1, 10
+    x%val = x%val + 1
+  end do
+  !$omp end parallel do
+  !$omp parallel do reduction(.shared.:y)
+  do i = 1, 10
+    y%val = y%val + 1.0
+  end do
+  !$omp end parallel do
+  !$omp parallel do reduction(.shared.:z)
+  do i = 1, 10
+    z%val = z%val + (1.0, 0.0)
+  end do
+  !$omp end parallel do
+end program

--- a/flang/test/Semantics/OpenMP/declare-reduction-use-shadow-merged.f90
+++ b/flang/test/Semantics/OpenMP/declare-reduction-use-shadow-merged.f90
@@ -1,0 +1,59 @@
+! RUN: not %flang_fc1 -fopenmp -fopenmp-version=52 %s 2>&1 | FileCheck %s
+
+! A local DECLARE REDUCTION for an operator is treated as authoritative for that
+! operator in its scope: it shadows reductions that are otherwise reachable
+! through the (merged) operator for other types. Here module `host` declares its
+! own `.shared.` reduction for `t_loc` and also merges in m_int's `.shared.`
+! reduction for `t_int` via USE...ONLY of the operator. Using `.shared.` on a
+! `t_int` object is rejected, because the local declaration is authoritative.
+!
+! This is a deliberate, conservative choice. The precise OpenMP semantics for a
+! local declaration coexisting with a merged-in reduction for a different type
+! are not clearly specified, so the lookup never accepts a reduction that a
+! local declaration might be intended to shadow (it never over-accepts). A
+! future refinement could instead keep merged-in reductions for other types
+! reachable; this test documents the current behavior so a change is deliberate.
+
+module m_int
+  type :: t_int
+    integer :: val = 0
+  end type
+  interface operator(.shared.)
+    module procedure add_int
+  end interface
+  !$omp declare reduction(.shared.:t_int:omp_out%val=omp_out%val+omp_in%val) &
+  !$omp   initializer(omp_priv=t_int(0))
+contains
+  type(t_int) function add_int(a, b)
+    type(t_int), intent(in) :: a, b
+    add_int%val = a%val + b%val
+  end function
+end module
+
+module host
+  use m_int, only: t_int, operator(.shared.)   ! merge in the t_int reduction
+  type :: t_loc
+    real :: val = 0.0
+  end type
+  interface operator(.shared.)
+    module procedure add_loc
+  end interface
+  !$omp declare reduction(.shared.:t_loc:omp_out%val=omp_out%val+omp_in%val) &
+  !$omp   initializer(omp_priv=t_loc(0.0))
+contains
+  type(t_loc) function add_loc(a, b)
+    type(t_loc), intent(in) :: a, b
+    add_loc%val = a%val + b%val
+  end function
+  subroutine s()
+    type(t_int) :: x
+    integer :: i
+    x = t_int(0)
+    !CHECK: error: The type of 'x' is incompatible with the reduction operator.
+    !$omp parallel do reduction(.shared.:x)
+    do i = 1, 10
+      x%val = x%val + 1
+    end do
+    !$omp end parallel do
+  end subroutine
+end module

--- a/flang/test/Semantics/OpenMP/declare-reduction-use-shadow.f90
+++ b/flang/test/Semantics/OpenMP/declare-reduction-use-shadow.f90
@@ -1,0 +1,41 @@
+! RUN: not %flang_fc1 -fopenmp -fopenmp-version=52 %s 2>&1 | FileCheck %s
+
+! A local DECLARE REDUCTION shadows a USE-associated reduction
+! (ProcessReductionSpecifier erases the USE-associated symbol). The shadowed
+! type must not be resurrected through the operator's source module: the local
+! reduction is authoritative because the operator is not merged.
+
+module m_real_shadow
+  type :: t_real
+    real :: val = 0.0
+  end type
+  interface operator(.shared.)
+    module procedure add_real
+  end interface
+  !$omp declare reduction(.shared.:t_real:omp_out%val=omp_out%val+omp_in%val) &
+  !$omp   initializer(omp_priv=t_real(0.0))
+contains
+  type(t_real) function add_real(a, b)
+    type(t_real), intent(in) :: a, b
+    add_real%val = a%val + b%val
+  end function
+end module
+
+program test_shadowed_reduction
+  use m_real_shadow   ! imports operator(.shared.) and the t_real reduction
+  type :: t_int
+    integer :: val = 0
+  end type
+  type(t_real) :: y
+  integer :: i
+  ! Local declaration shadows the USE-associated reduction (now only t_int).
+  !$omp declare reduction(.shared.:t_int:omp_out%val=omp_out%val+omp_in%val) &
+  !$omp   initializer(omp_priv=t_int(0))
+  y = t_real(0.0)
+  !CHECK: error: The type of 'y' is incompatible with the reduction operator.
+  !$omp parallel do reduction(.shared.:y)
+  do i = 1, 10
+    y%val = y%val + 1.0
+  end do
+  !$omp end parallel do
+end program


### PR DESCRIPTION
`CheckSymbolSupportsType` walked every module in the global scope to find
declare-reduction declarations. That accepted reductions from modules that
were never `USE`'d, or were excluded via `USE...ONLY`, and it still rejected
some valid imports such as a renamed operator.

Replace the global scan with `FindUserReduction`, which resolves the
reduction the way name resolution resolves the operator. It checks a
directly visible reduction first, then follows the operator's USE
associations and merged-generic sources to the declaring modules,
re-deriving the source module's mangled name for renamed operators. The
search recurses through re-exporting (facade) modules and is type-aware, so
an operator that carries reductions for several types resolves to the one
supporting the requested type. A locally declared reduction is authoritative
and shadows reductions reachable through the operator.

Also consolidate the duplicated `GetReductionFortranId` (formerly static in
both resolve-names.cpp and mod-file.cpp) into a shared utility, fixing a
latent bug where defined operators were not correctly reverse-mapped.

This corrects the semantic check only. The local lowering ICE for a
user-defined operator declare reduction was fixed separately in
https://github.com/llvm/llvm-project/issues/204299. The cross-module cases
this change additionally accepts (USE-associated, renamed, or merged
operators) now emit a clean "not yet implemented" diagnostic in lowering.
Completing their lowering is a follow-up.

Fixes https://github.com/llvm/llvm-project/issues/200300.

Assisted-by: Claude Opus 4.8.
