### PR TITLE
[SelectionDAG] Preserve IR alignment on atomicrmw/cmpxchg MMOs

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -5208,10 +5208,10 @@ void SelectionDAGBuilder::visitAtomicCmpXchg(const AtomicCmpXchgInst &I) {
   auto Flags = TLI.getAtomicMemOperandFlags(I, DAG.getDataLayout());
 
   MachineFunction &MF = DAG.getMachineFunction();
-  MachineMemOperand *MMO = MF.getMachineMemOperand(
-      MachinePointerInfo(I.getPointerOperand()), Flags, MemVT.getStoreSize(),
-      DAG.getEVTAlign(MemVT), AAMDNodes(), nullptr, SSID, SuccessOrdering,
-      FailureOrdering);
+  MachineMemOperand *MMO =
+      MF.getMachineMemOperand(MachinePointerInfo(I.getPointerOperand()), Flags,
+                              MemVT.getStoreSize(), I.getAlign(), AAMDNodes(),
+                              nullptr, SSID, SuccessOrdering, FailureOrdering);
 
   SDValue L = DAG.getAtomicCmpSwap(ISD::ATOMIC_CMP_SWAP_WITH_SUCCESS,
                                    dl, MemVT, VTs, InChain,
@@ -5282,7 +5282,7 @@ void SelectionDAGBuilder::visitAtomicRMW(const AtomicRMWInst &I) {
   MachineFunction &MF = DAG.getMachineFunction();
   MachineMemOperand *MMO = MF.getMachineMemOperand(
       MachinePointerInfo(I.getPointerOperand()), Flags, MemVT.getStoreSize(),
-      DAG.getEVTAlign(MemVT), AAMDNodes(), nullptr, SSID, Ordering);
+      I.getAlign(), AAMDNodes(), nullptr, SSID, Ordering);
 
   SDValue L =
     DAG.getAtomic(NT, dl, MemVT, InChain,

--- a/llvm/test/CodeGen/X86/atomic-mmo-align.ll
+++ b/llvm/test/CodeGen/X86/atomic-mmo-align.ll
@@ -1,0 +1,22 @@
+; RUN: llc -mtriple=x86_64-unknown-linux-gnu -stop-after=finalize-isel < %s | FileCheck %s
+
+; The IR-specified alignment on atomicrmw / cmpxchg must be carried into the
+; MachineMemOperand, matching the atomic load/store paths in
+; SelectionDAGBuilder (which use I.getAlign()).  Previously visitAtomicRMW and
+; visitAtomicCmpXchg used getEVTAlign(MemVT) (the natural type alignment),
+; silently discarding an over-aligned `align N`.
+
+define i32 @rmw_align(ptr %p) {
+  ; CHECK-LABEL: name: rmw_align
+  ; CHECK: LXADD32 {{.*}} :: (load store seq_cst (s32) on %ir.p, align 32)
+  %r = atomicrmw add ptr %p, i32 1 seq_cst, align 32
+  ret i32 %r
+}
+
+define i32 @cas_align(ptr %p, i32 %c, i32 %n) {
+  ; CHECK-LABEL: name: cas_align
+  ; CHECK: LCMPXCHG32 {{.*}} :: (load store seq_cst seq_cst (s32) on %ir.p, align 32)
+  %r = cmpxchg ptr %p, i32 %c, i32 %n seq_cst seq_cst, align 32
+  %v = extractvalue { i32, i1 } %r, 0
+  ret i32 %v
+}


### PR DESCRIPTION
Previously SelectionDAG used the natural alignment of the value type,
even if the instruction specified a different alignment.

This bug was found by a large run of Opus 4.7 looking for bugs in LLVM.