### PR TITLE
[X86] Emit ENDBR at WinEH funclet entries under CET-IBT

### DIFF
--- a/llvm/lib/Target/X86/X86IndirectBranchTracking.cpp
+++ b/llvm/lib/Target/X86/X86IndirectBranchTracking.cpp
@@ -171,7 +171,13 @@ static bool runIndirectBranchTracking(MachineFunction &MF) {
           break;
         }
       }
-    } else if (MBB.isEHPad()){
+    } else if (MBB.isEHFuncletEntry()) {
+      // WinEH catch/cleanup funclet entries are indirect call targets of the
+      // EH runtime's dispatcher. They carry no EH_LABEL, so the isEHPad()
+      // handling below would miss them; emit ENDBR at the funclet entry so a
+      // CET-IBT-enforcing CPU does not #CP-fault when an exception is thrown.
+      Changed |= addENDBR(MBB, MBB.begin());
+    } else if (MBB.isEHPad()) {
       for (MachineBasicBlock::iterator I = MBB.begin(); I != MBB.end(); ++I) {
         if (!I->isEHLabel())
           continue;

--- a/llvm/test/CodeGen/X86/indirect-branch-tracking-wineh.ll
+++ b/llvm/test/CodeGen/X86/indirect-branch-tracking-wineh.ll
@@ -1,0 +1,30 @@
+; RUN: llc -mtriple=x86_64-pc-windows-msvc < %s | FileCheck %s
+
+; Under CET-IBT (-fcf-protection=branch), WinEH catch/cleanup funclet entries
+; are indirect call targets of the C++ EH runtime dispatcher and must begin
+; with endbr64, otherwise throwing an exception #CP-faults on an IBT-enforcing
+; CPU.
+
+declare i32 @__CxxFrameHandler3(...)
+declare void @throws()
+
+define void @f() personality ptr @__CxxFrameHandler3 {
+; CHECK-LABEL: f:
+; CHECK: endbr64
+entry:
+  invoke void @throws() to label %cont unwind label %cd
+cont:
+  ret void
+cd:
+  %cs = catchswitch within none [label %c] unwind to caller
+c:
+  %cp = catchpad within %cs [ptr null, i32 64, ptr null]
+  catchret from %cp to label %cont
+}
+
+; The catch funclet entry must also carry endbr64.
+; CHECK: "?catch${{[^"]*}}":
+; CHECK: endbr64
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 8, !"cf-protection-branch", i32 1}


### PR DESCRIPTION
X86IndirectBranchTracking only marks landing pads reached via an EH_LABEL. WinEH catch/cleanup funclet entries are also indirect targets of the EH runtime but carry no EH_LABEL, so under `-fcf-protection=branch` a thrown exception lands on a funclet whose first instruction is not `endbr64` and an IBT-enforcing CPU raises #CP.

This bug was found by a large run of Opus 4.7 looking for bugs in LLVM.