### PR TITLE
[X86] Use kmovw, not kmovq, for VK16 copies without BWI

### DIFF
--- a/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -4364,7 +4364,7 @@ void X86InstrInfo::copyPhysReg(MachineBasicBlock &MBB,
   // anyone.
   else if (X86::VK16RegClass.contains(DestReg, SrcReg))
     Opc = Subtarget.hasBWI() ? (HasEGPR ? X86::KMOVQkk_EVEX : X86::KMOVQkk)
-                             : (HasEGPR ? X86::KMOVQkk_EVEX : X86::KMOVWkk);
+                             : (HasEGPR ? X86::KMOVWkk_EVEX : X86::KMOVWkk);
 
   if (!Opc)
     Opc = CopyToFromAsymmetricReg(DestReg, SrcReg, Subtarget);

--- a/llvm/test/CodeGen/X86/apx/kmov-kk.ll
+++ b/llvm/test/CodeGen/X86/apx/kmov-kk.ll
@@ -1,7 +1,8 @@
 ; RUN: llc < %s -mtriple=x86_64-unknown -mattr=+avx512f,+egpr -show-mc-encoding | FileCheck --check-prefix=EGPR %s
 
 define <16 x i32> @kmovkk(ptr %base, <16 x i32> %ind, i16 %mask) {
-; EGPR: kmovq   %k1, %k2                        # EVEX TO VEX Compression encoding: [0xc4,0xe1,0xf8,0x90,0xd1]
+; A 16-bit mask copy on avx512f-without-bwi must use kmovw; kmovq requires BWI.
+; EGPR: kmovw   %k1, %k2                        # EVEX TO VEX Compression encoding: [0xc5,0xf8,0x90,0xd1]
   %broadcast.splatinsert = insertelement <16 x ptr> undef, ptr %base, i32 0
   %broadcast.splat = shufflevector <16 x ptr> %broadcast.splatinsert, <16 x ptr> undef, <16 x i32> zeroinitializer
   %gep.random = getelementptr i32, <16 x ptr> %broadcast.splat, <16 x i32> %ind


### PR DESCRIPTION
`copyPhysReg` selected `KMOVQkk_EVEX` for a `$k -> $k` VK16 copy on a `+egpr` (APX) subtarget even without BWI, but `KMOVQ` requires BWI.  Use `KMOVW` instead.

This bug was found by a large run of Opus 4.7 looking for bugs in LLVM.