### PR TITLE
[libc++] Only push/pop diagnostics for ABI annotations pragmas if not in a system header

### DIFF
--- a/libcxx/include/__configuration/namespace.h
+++ b/libcxx/include/__configuration/namespace.h
@@ -35,19 +35,24 @@
     _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++20-extensions")                                                               \
     _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++23-extensions")
 #  define _LIBCPP_POP_EXTENSION_DIAGNOSTICS _LIBCPP_DIAGNOSTIC_POP
+#  define _LIBCPP_PUSH_ABI_PRAGMA_DIAGNOSTICS                                                                          \
+    _LIBCPP_DIAGNOSTIC_PUSH _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wpragma-clang-attribute")                               \
+        _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wignored-attributes")
+#  define _LIBCPP_POP_ABI_PRAGMA_DIAGNOSTICS _LIBCPP_DIAGNOSTIC_POP
 #else
 #  define _LIBCPP_PUSH_EXTENSION_DIAGNOSTICS
 #  define _LIBCPP_POP_EXTENSION_DIAGNOSTICS
+#  define _LIBCPP_PUSH_ABI_PRAGMA_DIAGNOSTICS
+#  define _LIBCPP_POP_ABI_PRAGMA_DIAGNOSTICS
 #endif
 
 #define _LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS                                                                           \
-  _LIBCPP_DIAGNOSTIC_PUSH _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wpragma-clang-attribute")                                 \
-      _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wignored-attributes")                                                         \
-          _Pragma(_LIBCPP_TOSTRING(clang attribute _LibcxxExplicitABIAnnotations.push(                                 \
-              __attribute__((__exclude_from_explicit_instantiation__,                                                  \
-                             __visibility__("hidden"),                                                                 \
-                             __abi_tag__(_LIBCPP_TOSTRING(_LIBCPP_ODR_SIGNATURE)))),                                   \
-              apply_to = function))) _LIBCPP_DIAGNOSTIC_POP
+  _LIBCPP_PUSH_ABI_PRAGMA_DIAGNOSTICS                                                                                  \
+  _Pragma(_LIBCPP_TOSTRING(clang attribute _LibcxxExplicitABIAnnotations.push(                                         \
+      __attribute__((__exclude_from_explicit_instantiation__,                                                          \
+                     __visibility__("hidden"),                                                                         \
+                     __abi_tag__(_LIBCPP_TOSTRING(_LIBCPP_ODR_SIGNATURE)))),                                           \
+      apply_to = function))) _LIBCPP_POP_ABI_PRAGMA_DIAGNOSTICS
 
 #define _LIBCPP_BEGIN_EXPLICIT_ABI_ANNOTATIONS _Pragma("clang attribute _LibcxxExplicitABIAnnotations.pop")
 


### PR DESCRIPTION
This should significantly reduce the compile time hit for Clang modules with the new explicit and implicit ABI annotations.
