### PR TITLE
[libc] Add byteswap.h to Linux public header target lists

### DIFF
--- a/libc/config/linux/aarch64/headers.txt
+++ b/libc/config/linux/aarch64/headers.txt
@@ -1,6 +1,7 @@
 set(TARGET_PUBLIC_HEADERS
     libc.include.arpa_inet
     libc.include.assert
+    libc.include.byteswap
     libc.include.complex
     libc.include.cpio
     libc.include.ctype

--- a/libc/config/linux/riscv/headers.txt
+++ b/libc/config/linux/riscv/headers.txt
@@ -1,6 +1,7 @@
 set(TARGET_PUBLIC_HEADERS
     libc.include.arpa_inet
     libc.include.assert
+    libc.include.byteswap
     libc.include.complex
     libc.include.cpio
     libc.include.ctype

--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -1,6 +1,7 @@
 set(TARGET_PUBLIC_HEADERS
     libc.include.arpa_inet
     libc.include.assert
+    libc.include.byteswap
     libc.include.complex
     libc.include.cpio
     libc.include.ctype


### PR DESCRIPTION
The headers don't get built/installed without this.