### PR TITLE
[AArch64][SVE] Enable known bits for predicated shifts

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -4527,11 +4527,6 @@ KnownBits SelectionDAG::computeKnownBits(SDValue Op, const APInt &DemandedElts,
   case ISD::INTRINSIC_WO_CHAIN:
   case ISD::INTRINSIC_W_CHAIN:
   case ISD::INTRINSIC_VOID:
-    // TODO: Probably okay to remove after audit; here to reduce change size
-    // in initial enablement patch for scalable vectors
-    if (Op.getValueType().isScalableVector())
-      break;
-
     // Allow the target to implement this method for its nodes.
     TLI->computeKnownBitsForTargetNode(Op, Known, DemandedElts, *this, Depth);
     break;

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -2952,6 +2952,26 @@ void AArch64TargetLowering::computeKnownBitsForTargetNode(
     }
     break;
   }
+  case AArch64ISD::SHL_PRED:
+  case AArch64ISD::SRL_PRED:
+  case AArch64ISD::SRA_PRED: {
+    SDValue Pg = Op->getOperand(0);
+    if (!isAllActivePredicate(DAG, Pg))
+      break;
+
+    KnownBits KnownVal =
+        DAG.computeKnownBits(Op->getOperand(1), DemandedElts, Depth + 1);
+    KnownBits KnownAmt =
+        DAG.computeKnownBits(Op->getOperand(2), DemandedElts, Depth + 1);
+
+    if (Op.getOpcode() == AArch64ISD::SHL_PRED)
+      Known = KnownBits::shl(KnownVal, KnownAmt);
+    else if (Op.getOpcode() == AArch64ISD::SRL_PRED)
+      Known = KnownBits::lshr(KnownVal, KnownAmt);
+    else
+      Known = KnownBits::ashr(KnownVal, KnownAmt);
+    break;
+  }
   case ISD::INTRINSIC_WO_CHAIN:
   case ISD::INTRINSIC_VOID: {
     unsigned IntNo = Op.getConstantOperandVal(0);
@@ -15961,7 +15981,7 @@ static bool isAllInactivePredicate(SDValue N) {
   return ISD::isConstantSplatVectorAllZeros(N.getNode());
 }
 
-static bool isAllActivePredicate(SelectionDAG &DAG, SDValue N) {
+static bool isAllActivePredicate(const SelectionDAG &DAG, SDValue N) {
   unsigned NumElts = N.getValueType().getVectorMinNumElements();
 
   // Look through cast.
@@ -33901,7 +33921,7 @@ SDValue AArch64TargetLowering::getSVESafeBitCast(EVT VT, SDValue Op,
   return Op;
 }
 
-bool AArch64TargetLowering::isAllActivePredicate(SelectionDAG &DAG,
+bool AArch64TargetLowering::isAllActivePredicate(const SelectionDAG &DAG,
                                                  SDValue N) const {
   return ::isAllActivePredicate(DAG, N);
 }

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.h
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.h
@@ -545,7 +545,7 @@ public:
     return 128;
   }
 
-  bool isAllActivePredicate(SelectionDAG &DAG, SDValue N) const;
+  bool isAllActivePredicate(const SelectionDAG &DAG, SDValue N) const;
   EVT getPromotedVTForPredicate(EVT VT) const;
 
   EVT getAsmOperandValueType(const DataLayout &DL, Type *Ty,

--- a/llvm/test/CodeGen/AArch64/sve2-sli-sri.ll
+++ b/llvm/test/CodeGen/AArch64/sve2-sli-sri.ll
@@ -118,14 +118,22 @@ define <vscale x 8 x i16> @testRightGood8x16(<vscale x 8 x i16> %src1, <vscale x
 }
 
 define <vscale x 8 x i16> @testRightBad8x16(<vscale x 8 x i16> %src1, <vscale x 8 x i16> %src2) {
-; CHECK-LABEL: testRightBad8x16:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    mov w8, #16500 // =0x4074
-; CHECK-NEXT:    lsr z1.h, z1.h, #14
-; CHECK-NEXT:    mov z2.h, w8
-; CHECK-NEXT:    and z0.d, z0.d, z2.d
-; CHECK-NEXT:    orr z0.d, z0.d, z1.d
-; CHECK-NEXT:    ret
+; SVE-LABEL: testRightBad8x16:
+; SVE:       // %bb.0:
+; SVE-NEXT:    mov w8, #16500 // =0x4074
+; SVE-NEXT:    lsr z1.h, z1.h, #14
+; SVE-NEXT:    mov z2.h, w8
+; SVE-NEXT:    and z0.d, z0.d, z2.d
+; SVE-NEXT:    orr z0.d, z0.d, z1.d
+; SVE-NEXT:    ret
+;
+; SVE2-LABEL: testRightBad8x16:
+; SVE2:       // %bb.0:
+; SVE2-NEXT:    mov w8, #16500 // =0x4074
+; SVE2-NEXT:    mov z2.h, w8
+; SVE2-NEXT:    and z0.d, z0.d, z2.d
+; SVE2-NEXT:    usra z0.h, z1.h, #14
+; SVE2-NEXT:    ret
   %and.i = and <vscale x 8 x i16> %src1, splat(i16 16500)
   %vshl_n = lshr <vscale x 8 x i16> %src2, splat(i16 14)
   %result = or <vscale x 8 x i16> %and.i, %vshl_n

--- a/llvm/test/CodeGen/AArch64/sve2-sra.ll
+++ b/llvm/test/CodeGen/AArch64/sve2-sra.ll
@@ -333,8 +333,7 @@ define <vscale x 16 x i8> @usra_disjoint_shift_or16xi8(<vscale x 16 x i8> %a, <v
 ; CHECK-LABEL: usra_disjoint_shift_or16xi8:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    lsl z0.b, z0.b, #7
-; CHECK-NEXT:    lsr z1.b, z1.b, #1
-; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    usra z0.b, z1.b, #1
 ; CHECK-NEXT:    ret
   %shl = shl <vscale x 16 x i8> %a, splat (i8 7)
   %srl = lshr <vscale x 16 x i8> %b, splat (i8 1)
@@ -346,8 +345,7 @@ define <vscale x 8 x i16> @usra_disjoint_shift_or8xi16(<vscale x 8 x i16> %a, <v
 ; CHECK-LABEL: usra_disjoint_shift_or8xi16:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    lsl z0.h, z0.h, #7
-; CHECK-NEXT:    lsr z1.h, z1.h, #9
-; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    usra z0.h, z1.h, #9
 ; CHECK-NEXT:    ret
   %shl = shl <vscale x 8 x i16> %a, splat (i16 7)
   %srl = lshr <vscale x 8 x i16> %b, splat (i16 9)
@@ -359,8 +357,7 @@ define <vscale x 4 x i32> @usra_disjoint_shift_or4xi32(<vscale x 4 x i32> %a, <v
 ; CHECK-LABEL: usra_disjoint_shift_or4xi32:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    lsl z0.s, z0.s, #7
-; CHECK-NEXT:    lsr z1.s, z1.s, #25
-; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    usra z0.s, z1.s, #25
 ; CHECK-NEXT:    ret
   %shl = shl <vscale x 4 x i32> %a, splat (i32 7)
   %srl = lshr <vscale x 4 x i32> %b, splat (i32 25)
@@ -372,8 +369,7 @@ define <vscale x 2 x i64> @usra_disjoint_shift_or2xi64(<vscale x 2 x i64> %a, <v
 ; CHECK-LABEL: usra_disjoint_shift_or2xi64:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    lsl z0.d, z0.d, #7
-; CHECK-NEXT:    lsr z1.d, z1.d, #57
-; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    usra z0.d, z1.d, #57
 ; CHECK-NEXT:    ret
   %shl = shl <vscale x 2 x i64> %a, splat (i64 7)
   %srl = lshr <vscale x 2 x i64> %b, splat (i64 57)
@@ -386,10 +382,9 @@ define <vscale x 2 x i64> @usra_disjoint_shift_or2xi64(<vscale x 2 x i64> %a, <v
 define <vscale x 16 x i8> @ssra_disjoint_shift_or16xi8(<vscale x 16 x i8> %a, <vscale x 16 x i8> %b) #0 {
 ; CHECK-LABEL: ssra_disjoint_shift_or16xi8:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    lsl z1.b, z1.b, #7
 ; CHECK-NEXT:    lsr z0.b, z0.b, #2
-; CHECK-NEXT:    asr z1.b, z1.b, #1
-; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    lsl z1.b, z1.b, #7
+; CHECK-NEXT:    ssra z0.b, z1.b, #1
 ; CHECK-NEXT:    ret
   %acc = lshr <vscale x 16 x i8> %a, splat (i8 2)
   %sign = shl <vscale x 16 x i8> %b, splat (i8 7)
@@ -401,10 +396,9 @@ define <vscale x 16 x i8> @ssra_disjoint_shift_or16xi8(<vscale x 16 x i8> %a, <v
 define <vscale x 8 x i16> @ssra_disjoint_shift_or8xi16(<vscale x 8 x i16> %a, <vscale x 8 x i16> %b) #0 {
 ; CHECK-LABEL: ssra_disjoint_shift_or8xi16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    lsl z1.h, z1.h, #15
 ; CHECK-NEXT:    lsr z0.h, z0.h, #10
-; CHECK-NEXT:    asr z1.h, z1.h, #9
-; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    lsl z1.h, z1.h, #15
+; CHECK-NEXT:    ssra z0.h, z1.h, #9
 ; CHECK-NEXT:    ret
   %acc = lshr <vscale x 8 x i16> %a, splat (i16 10)
   %sign = shl <vscale x 8 x i16> %b, splat (i16 15)
@@ -416,10 +410,9 @@ define <vscale x 8 x i16> @ssra_disjoint_shift_or8xi16(<vscale x 8 x i16> %a, <v
 define <vscale x 4 x i32> @ssra_disjoint_shift_or4xi32(<vscale x 4 x i32> %a, <vscale x 4 x i32> %b) #0 {
 ; CHECK-LABEL: ssra_disjoint_shift_or4xi32:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    lsl z1.s, z1.s, #31
 ; CHECK-NEXT:    lsr z0.s, z0.s, #26
-; CHECK-NEXT:    asr z1.s, z1.s, #25
-; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    lsl z1.s, z1.s, #31
+; CHECK-NEXT:    ssra z0.s, z1.s, #25
 ; CHECK-NEXT:    ret
   %acc = lshr <vscale x 4 x i32> %a, splat (i32 26)
   %sign = shl <vscale x 4 x i32> %b, splat (i32 31)
@@ -431,10 +424,9 @@ define <vscale x 4 x i32> @ssra_disjoint_shift_or4xi32(<vscale x 4 x i32> %a, <v
 define <vscale x 2 x i64> @ssra_disjoint_shift_or2xi64(<vscale x 2 x i64> %a, <vscale x 2 x i64> %b) #0 {
 ; CHECK-LABEL: ssra_disjoint_shift_or2xi64:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    lsl z1.d, z1.d, #63
 ; CHECK-NEXT:    lsr z0.d, z0.d, #58
-; CHECK-NEXT:    asr z1.d, z1.d, #57
-; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    lsl z1.d, z1.d, #63
+; CHECK-NEXT:    ssra z0.d, z1.d, #57
 ; CHECK-NEXT:    ret
   %acc = lshr <vscale x 2 x i64> %a, splat (i64 58)
   %sign = shl <vscale x 2 x i64> %b, splat (i64 63)
@@ -449,8 +441,7 @@ define <vscale x 16 x i8> @usra_disjoint_shl_lsr_or16xi8(<vscale x 16 x i1> %pg,
 ; CHECK-LABEL: usra_disjoint_shl_lsr_or16xi8:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    lsl z0.b, z0.b, #4
-; CHECK-NEXT:    lsr z1.b, z1.b, #4
-; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    usra z0.b, z1.b, #4
 ; CHECK-NEXT:    ret
   %ptrue = call <vscale x 16 x i1> @llvm.aarch64.sve.ptrue.nxv16i1(i32 31)
   %shl = call <vscale x 16 x i8> @llvm.aarch64.sve.lsl.u.nxv16i8(<vscale x 16 x i1> %ptrue, <vscale x 16 x i8> %a, <vscale x 16 x i8> splat(i8 4))
@@ -463,8 +454,7 @@ define <vscale x 8 x i16> @usra_disjoint_shl_lsr_or8xi16(<vscale x 8 x i1> %pg, 
 ; CHECK-LABEL: usra_disjoint_shl_lsr_or8xi16:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    lsl z0.h, z0.h, #8
-; CHECK-NEXT:    lsr z1.h, z1.h, #8
-; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    usra z0.h, z1.h, #8
 ; CHECK-NEXT:    ret
   %ptrue = call <vscale x 8 x i1> @llvm.aarch64.sve.ptrue.nxv8i1(i32 31)
   %shl = call <vscale x 8 x i16> @llvm.aarch64.sve.lsl.u.nxv8i16(<vscale x 8 x i1> %ptrue, <vscale x 8 x i16> %a, <vscale x 8 x i16> splat(i16 8))
@@ -477,8 +467,7 @@ define <vscale x 4 x i32> @usra_disjoint_shl_lsr_or4xi32(<vscale x 4 x i1> %pg, 
 ; CHECK-LABEL: usra_disjoint_shl_lsr_or4xi32:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    lsl z0.s, z0.s, #16
-; CHECK-NEXT:    lsr z1.s, z1.s, #16
-; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    usra z0.s, z1.s, #16
 ; CHECK-NEXT:    ret
   %ptrue = call <vscale x 4 x i1> @llvm.aarch64.sve.ptrue.nxv4i1(i32 31)
   %shl = call <vscale x 4 x i32> @llvm.aarch64.sve.lsl.u.nxv4i32(<vscale x 4 x i1> %ptrue, <vscale x 4 x i32> %a, <vscale x 4 x i32> splat(i32 16))
@@ -491,8 +480,7 @@ define <vscale x 2 x i64> @usra_disjoint_shl_lsr_or2xi64(<vscale x 2 x i1> %pg, 
 ; CHECK-LABEL: usra_disjoint_shl_lsr_or2xi64:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    lsl z0.d, z0.d, #32
-; CHECK-NEXT:    lsr z1.d, z1.d, #32
-; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    usra z0.d, z1.d, #32
 ; CHECK-NEXT:    ret
   %ptrue = call <vscale x 2 x i1> @llvm.aarch64.sve.ptrue.nxv2i1(i32 31)
   %shl = call <vscale x 2 x i64> @llvm.aarch64.sve.lsl.u.nxv2i64(<vscale x 2 x i1> %ptrue, <vscale x 2 x i64> %a, <vscale x 2 x i64> splat(i64 32))
@@ -506,10 +494,9 @@ define <vscale x 2 x i64> @usra_disjoint_shl_lsr_or2xi64(<vscale x 2 x i1> %pg, 
 define <vscale x 16 x i8> @ssra_disjoint_shift_intr_or16xi8(<vscale x 16 x i8> %a, <vscale x 16 x i8> %b) #0 {
 ; CHECK-LABEL: ssra_disjoint_shift_intr_or16xi8:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    lsl z1.b, z1.b, #7
 ; CHECK-NEXT:    lsr z0.b, z0.b, #2
-; CHECK-NEXT:    asr z1.b, z1.b, #1
-; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    lsl z1.b, z1.b, #7
+; CHECK-NEXT:    ssra z0.b, z1.b, #1
 ; CHECK-NEXT:    ret
   %pg = call <vscale x 16 x i1> @llvm.aarch64.sve.ptrue.nxv16i1(i32 31)
   %acc = call <vscale x 16 x i8> @llvm.aarch64.sve.lsr.u.nxv16i8(<vscale x 16 x i1> %pg, <vscale x 16 x i8> %a, <vscale x 16 x i8> splat(i8 2))
@@ -522,10 +509,9 @@ define <vscale x 16 x i8> @ssra_disjoint_shift_intr_or16xi8(<vscale x 16 x i8> %
 define <vscale x 8 x i16> @ssra_disjoint_shift_intr_or8xi16(<vscale x 8 x i16> %a, <vscale x 8 x i16> %b) #0 {
 ; CHECK-LABEL: ssra_disjoint_shift_intr_or8xi16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    lsl z1.h, z1.h, #15
 ; CHECK-NEXT:    lsr z0.h, z0.h, #10
-; CHECK-NEXT:    asr z1.h, z1.h, #9
-; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    lsl z1.h, z1.h, #15
+; CHECK-NEXT:    ssra z0.h, z1.h, #9
 ; CHECK-NEXT:    ret
   %pg = call <vscale x 8 x i1> @llvm.aarch64.sve.ptrue.nxv8i1(i32 31)
   %acc = call <vscale x 8 x i16> @llvm.aarch64.sve.lsr.u.nxv8i16(<vscale x 8 x i1> %pg, <vscale x 8 x i16> %a, <vscale x 8 x i16> splat(i16 10))
@@ -538,10 +524,9 @@ define <vscale x 8 x i16> @ssra_disjoint_shift_intr_or8xi16(<vscale x 8 x i16> %
 define <vscale x 4 x i32> @ssra_disjoint_shift_intr_or4xi32(<vscale x 4 x i32> %a, <vscale x 4 x i32> %b) #0 {
 ; CHECK-LABEL: ssra_disjoint_shift_intr_or4xi32:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    lsl z1.s, z1.s, #31
 ; CHECK-NEXT:    lsr z0.s, z0.s, #26
-; CHECK-NEXT:    asr z1.s, z1.s, #25
-; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    lsl z1.s, z1.s, #31
+; CHECK-NEXT:    ssra z0.s, z1.s, #25
 ; CHECK-NEXT:    ret
   %pg = call <vscale x 4 x i1> @llvm.aarch64.sve.ptrue.nxv4i1(i32 31)
   %acc = call <vscale x 4 x i32> @llvm.aarch64.sve.lsr.u.nxv4i32(<vscale x 4 x i1> %pg, <vscale x 4 x i32> %a, <vscale x 4 x i32> splat(i32 26))
@@ -554,10 +539,9 @@ define <vscale x 4 x i32> @ssra_disjoint_shift_intr_or4xi32(<vscale x 4 x i32> %
 define <vscale x 2 x i64> @ssra_disjoint_shift_intr_or2xi64(<vscale x 2 x i64> %a, <vscale x 2 x i64> %b) #0 {
 ; CHECK-LABEL: ssra_disjoint_shift_intr_or2xi64:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    lsl z1.d, z1.d, #63
 ; CHECK-NEXT:    lsr z0.d, z0.d, #58
-; CHECK-NEXT:    asr z1.d, z1.d, #57
-; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    lsl z1.d, z1.d, #63
+; CHECK-NEXT:    ssra z0.d, z1.d, #57
 ; CHECK-NEXT:    ret
   %pg = call <vscale x 2 x i1> @llvm.aarch64.sve.ptrue.nxv2i1(i32 31)
   %acc = call <vscale x 2 x i64> @llvm.aarch64.sve.lsr.u.nxv2i64(<vscale x 2 x i1> %pg, <vscale x 2 x i64> %a, <vscale x 2 x i64> splat(i64 58))

--- a/llvm/test/CodeGen/AArch64/sve2-sra.ll
+++ b/llvm/test/CodeGen/AArch64/sve2-sra.ll
@@ -247,6 +247,8 @@ define <vscale x 2 x i64> @ssra_intr_u_i64(<vscale x 2 x i1> %pg, <vscale x 2 x 
   ret <vscale x 2 x i64> %add
 }
 
+; USRA
+
 define <vscale x 16 x i8> @usra_disjoint_or16xi8(<vscale x 16 x i8> %a, <vscale x 16 x i8> %b) #0 {
 ; CHECK-LABEL: usra_disjoint_or16xi8:
 ; CHECK:       // %bb.0:
@@ -327,14 +329,242 @@ define <vscale x 2 x i64> @ssra_disjoint_or2xi64(<vscale x 2 x i64> %a, <vscale 
   ret <vscale x 2 x i64> %add
 }
 
-declare <vscale x 16 x i8> @llvm.aarch64.sve.lsr.u.nxv16i8(<vscale x 16 x i1>, <vscale x 16 x i8>, <vscale x 16 x i8>)
-declare <vscale x 8 x i16> @llvm.aarch64.sve.lsr.u.nxv8i16(<vscale x 8 x i1>, <vscale x 8 x i16>, <vscale x 8 x i16>)
-declare <vscale x 4 x i32> @llvm.aarch64.sve.lsr.u.nxv4i32(<vscale x 4 x i1>, <vscale x 4 x i32>, <vscale x 4 x i32>)
-declare <vscale x 2 x i64> @llvm.aarch64.sve.lsr.u.nxv2i64(<vscale x 2 x i1>, <vscale x 2 x i64>, <vscale x 2 x i64>)
+define <vscale x 16 x i8> @usra_disjoint_shift_or16xi8(<vscale x 16 x i8> %a, <vscale x 16 x i8> %b) #0 {
+; CHECK-LABEL: usra_disjoint_shift_or16xi8:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    lsl z0.b, z0.b, #7
+; CHECK-NEXT:    lsr z1.b, z1.b, #1
+; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    ret
+  %shl = shl <vscale x 16 x i8> %a, splat (i8 7)
+  %srl = lshr <vscale x 16 x i8> %b, splat (i8 1)
+  %r = or <vscale x 16 x i8> %shl, %srl
+  ret <vscale x 16 x i8> %r
+}
 
-declare <vscale x 16 x i8> @llvm.aarch64.sve.asr.u.nxv16i8(<vscale x 16 x i1>, <vscale x 16 x i8>, <vscale x 16 x i8>)
-declare <vscale x 8 x i16> @llvm.aarch64.sve.asr.u.nxv8i16(<vscale x 8 x i1>, <vscale x 8 x i16>, <vscale x 8 x i16>)
-declare <vscale x 4 x i32> @llvm.aarch64.sve.asr.u.nxv4i32(<vscale x 4 x i1>, <vscale x 4 x i32>, <vscale x 4 x i32>)
-declare <vscale x 2 x i64> @llvm.aarch64.sve.asr.u.nxv2i64(<vscale x 2 x i1>, <vscale x 2 x i64>, <vscale x 2 x i64>)
+define <vscale x 8 x i16> @usra_disjoint_shift_or8xi16(<vscale x 8 x i16> %a, <vscale x 8 x i16> %b) #0 {
+; CHECK-LABEL: usra_disjoint_shift_or8xi16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    lsl z0.h, z0.h, #7
+; CHECK-NEXT:    lsr z1.h, z1.h, #9
+; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    ret
+  %shl = shl <vscale x 8 x i16> %a, splat (i16 7)
+  %srl = lshr <vscale x 8 x i16> %b, splat (i16 9)
+  %r = or <vscale x 8 x i16> %shl, %srl
+  ret <vscale x 8 x i16> %r
+}
+
+define <vscale x 4 x i32> @usra_disjoint_shift_or4xi32(<vscale x 4 x i32> %a, <vscale x 4 x i32> %b) #0 {
+; CHECK-LABEL: usra_disjoint_shift_or4xi32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    lsl z0.s, z0.s, #7
+; CHECK-NEXT:    lsr z1.s, z1.s, #25
+; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    ret
+  %shl = shl <vscale x 4 x i32> %a, splat (i32 7)
+  %srl = lshr <vscale x 4 x i32> %b, splat (i32 25)
+  %r = or <vscale x 4 x i32> %shl, %srl
+  ret <vscale x 4 x i32> %r
+}
+
+define <vscale x 2 x i64> @usra_disjoint_shift_or2xi64(<vscale x 2 x i64> %a, <vscale x 2 x i64> %b) #0 {
+; CHECK-LABEL: usra_disjoint_shift_or2xi64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    lsl z0.d, z0.d, #7
+; CHECK-NEXT:    lsr z1.d, z1.d, #57
+; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    ret
+  %shl = shl <vscale x 2 x i64> %a, splat (i64 7)
+  %srl = lshr <vscale x 2 x i64> %b, splat (i64 57)
+  %r = or <vscale x 2 x i64> %shl, %srl
+  ret <vscale x 2 x i64> %r
+}
+
+; SSRA
+
+define <vscale x 16 x i8> @ssra_disjoint_shift_or16xi8(<vscale x 16 x i8> %a, <vscale x 16 x i8> %b) #0 {
+; CHECK-LABEL: ssra_disjoint_shift_or16xi8:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    lsl z1.b, z1.b, #7
+; CHECK-NEXT:    lsr z0.b, z0.b, #2
+; CHECK-NEXT:    asr z1.b, z1.b, #1
+; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    ret
+  %acc = lshr <vscale x 16 x i8> %a, splat (i8 2)
+  %sign = shl <vscale x 16 x i8> %b, splat (i8 7)
+  %sra = ashr <vscale x 16 x i8> %sign, splat (i8 1)
+  %r = or <vscale x 16 x i8> %acc, %sra
+  ret <vscale x 16 x i8> %r
+}
+
+define <vscale x 8 x i16> @ssra_disjoint_shift_or8xi16(<vscale x 8 x i16> %a, <vscale x 8 x i16> %b) #0 {
+; CHECK-LABEL: ssra_disjoint_shift_or8xi16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    lsl z1.h, z1.h, #15
+; CHECK-NEXT:    lsr z0.h, z0.h, #10
+; CHECK-NEXT:    asr z1.h, z1.h, #9
+; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    ret
+  %acc = lshr <vscale x 8 x i16> %a, splat (i16 10)
+  %sign = shl <vscale x 8 x i16> %b, splat (i16 15)
+  %sra = ashr <vscale x 8 x i16> %sign, splat (i16 9)
+  %r = or <vscale x 8 x i16> %acc, %sra
+  ret <vscale x 8 x i16> %r
+}
+
+define <vscale x 4 x i32> @ssra_disjoint_shift_or4xi32(<vscale x 4 x i32> %a, <vscale x 4 x i32> %b) #0 {
+; CHECK-LABEL: ssra_disjoint_shift_or4xi32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    lsl z1.s, z1.s, #31
+; CHECK-NEXT:    lsr z0.s, z0.s, #26
+; CHECK-NEXT:    asr z1.s, z1.s, #25
+; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    ret
+  %acc = lshr <vscale x 4 x i32> %a, splat (i32 26)
+  %sign = shl <vscale x 4 x i32> %b, splat (i32 31)
+  %sra = ashr <vscale x 4 x i32> %sign, splat (i32 25)
+  %r = or <vscale x 4 x i32> %acc, %sra
+  ret <vscale x 4 x i32> %r
+}
+
+define <vscale x 2 x i64> @ssra_disjoint_shift_or2xi64(<vscale x 2 x i64> %a, <vscale x 2 x i64> %b) #0 {
+; CHECK-LABEL: ssra_disjoint_shift_or2xi64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    lsl z1.d, z1.d, #63
+; CHECK-NEXT:    lsr z0.d, z0.d, #58
+; CHECK-NEXT:    asr z1.d, z1.d, #57
+; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    ret
+  %acc = lshr <vscale x 2 x i64> %a, splat (i64 58)
+  %sign = shl <vscale x 2 x i64> %b, splat (i64 63)
+  %sra = ashr <vscale x 2 x i64> %sign, splat (i64 57)
+  %r = or <vscale x 2 x i64> %acc, %sra
+  ret <vscale x 2 x i64> %r
+}
+
+; USRA
+
+define <vscale x 16 x i8> @usra_disjoint_shl_lsr_or16xi8(<vscale x 16 x i1> %pg, <vscale x 16 x i8> %a, <vscale x 16 x i8> %b) #0 {
+; CHECK-LABEL: usra_disjoint_shl_lsr_or16xi8:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    lsl z0.b, z0.b, #4
+; CHECK-NEXT:    lsr z1.b, z1.b, #4
+; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    ret
+  %ptrue = call <vscale x 16 x i1> @llvm.aarch64.sve.ptrue.nxv16i1(i32 31)
+  %shl = call <vscale x 16 x i8> @llvm.aarch64.sve.lsl.u.nxv16i8(<vscale x 16 x i1> %ptrue, <vscale x 16 x i8> %a, <vscale x 16 x i8> splat(i8 4))
+  %srl = call <vscale x 16 x i8> @llvm.aarch64.sve.lsr.u.nxv16i8(<vscale x 16 x i1> %ptrue, <vscale x 16 x i8> %b, <vscale x 16 x i8> splat(i8 4))
+  %r = or <vscale x 16 x i8> %shl, %srl
+  ret <vscale x 16 x i8> %r
+}
+
+define <vscale x 8 x i16> @usra_disjoint_shl_lsr_or8xi16(<vscale x 8 x i1> %pg, <vscale x 8 x i16> %a, <vscale x 8 x i16> %b) #0 {
+; CHECK-LABEL: usra_disjoint_shl_lsr_or8xi16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    lsl z0.h, z0.h, #8
+; CHECK-NEXT:    lsr z1.h, z1.h, #8
+; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    ret
+  %ptrue = call <vscale x 8 x i1> @llvm.aarch64.sve.ptrue.nxv8i1(i32 31)
+  %shl = call <vscale x 8 x i16> @llvm.aarch64.sve.lsl.u.nxv8i16(<vscale x 8 x i1> %ptrue, <vscale x 8 x i16> %a, <vscale x 8 x i16> splat(i16 8))
+  %srl = call <vscale x 8 x i16> @llvm.aarch64.sve.lsr.u.nxv8i16(<vscale x 8 x i1> %ptrue, <vscale x 8 x i16> %b, <vscale x 8 x i16> splat(i16 8))
+  %r = or <vscale x 8 x i16> %shl, %srl
+  ret <vscale x 8 x i16> %r
+}
+
+define <vscale x 4 x i32> @usra_disjoint_shl_lsr_or4xi32(<vscale x 4 x i1> %pg, <vscale x 4 x i32> %a, <vscale x 4 x i32> %b) #0 {
+; CHECK-LABEL: usra_disjoint_shl_lsr_or4xi32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    lsl z0.s, z0.s, #16
+; CHECK-NEXT:    lsr z1.s, z1.s, #16
+; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    ret
+  %ptrue = call <vscale x 4 x i1> @llvm.aarch64.sve.ptrue.nxv4i1(i32 31)
+  %shl = call <vscale x 4 x i32> @llvm.aarch64.sve.lsl.u.nxv4i32(<vscale x 4 x i1> %ptrue, <vscale x 4 x i32> %a, <vscale x 4 x i32> splat(i32 16))
+  %srl = call <vscale x 4 x i32> @llvm.aarch64.sve.lsr.u.nxv4i32(<vscale x 4 x i1> %ptrue, <vscale x 4 x i32> %b, <vscale x 4 x i32> splat(i32 16))
+  %r = or <vscale x 4 x i32> %shl, %srl
+  ret <vscale x 4 x i32> %r
+}
+
+define <vscale x 2 x i64> @usra_disjoint_shl_lsr_or2xi64(<vscale x 2 x i1> %pg, <vscale x 2 x i64> %a, <vscale x 2 x i64> %b) #0 {
+; CHECK-LABEL: usra_disjoint_shl_lsr_or2xi64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    lsl z0.d, z0.d, #32
+; CHECK-NEXT:    lsr z1.d, z1.d, #32
+; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    ret
+  %ptrue = call <vscale x 2 x i1> @llvm.aarch64.sve.ptrue.nxv2i1(i32 31)
+  %shl = call <vscale x 2 x i64> @llvm.aarch64.sve.lsl.u.nxv2i64(<vscale x 2 x i1> %ptrue, <vscale x 2 x i64> %a, <vscale x 2 x i64> splat(i64 32))
+  %srl = call <vscale x 2 x i64> @llvm.aarch64.sve.lsr.u.nxv2i64(<vscale x 2 x i1> %ptrue, <vscale x 2 x i64> %b, <vscale x 2 x i64> splat(i64 32))
+  %r = or <vscale x 2 x i64> %shl, %srl
+  ret <vscale x 2 x i64> %r
+}
+
+; SSRA
+
+define <vscale x 16 x i8> @ssra_disjoint_shift_intr_or16xi8(<vscale x 16 x i8> %a, <vscale x 16 x i8> %b) #0 {
+; CHECK-LABEL: ssra_disjoint_shift_intr_or16xi8:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    lsl z1.b, z1.b, #7
+; CHECK-NEXT:    lsr z0.b, z0.b, #2
+; CHECK-NEXT:    asr z1.b, z1.b, #1
+; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    ret
+  %pg = call <vscale x 16 x i1> @llvm.aarch64.sve.ptrue.nxv16i1(i32 31)
+  %acc = call <vscale x 16 x i8> @llvm.aarch64.sve.lsr.u.nxv16i8(<vscale x 16 x i1> %pg, <vscale x 16 x i8> %a, <vscale x 16 x i8> splat(i8 2))
+  %sign = call <vscale x 16 x i8> @llvm.aarch64.sve.lsl.u.nxv16i8(<vscale x 16 x i1> %pg, <vscale x 16 x i8> %b, <vscale x 16 x i8> splat(i8 7))
+  %sra = call <vscale x 16 x i8> @llvm.aarch64.sve.asr.u.nxv16i8(<vscale x 16 x i1> %pg, <vscale x 16 x i8> %sign, <vscale x 16 x i8> splat(i8 1))
+  %r = or <vscale x 16 x i8> %acc, %sra
+  ret <vscale x 16 x i8> %r
+}
+
+define <vscale x 8 x i16> @ssra_disjoint_shift_intr_or8xi16(<vscale x 8 x i16> %a, <vscale x 8 x i16> %b) #0 {
+; CHECK-LABEL: ssra_disjoint_shift_intr_or8xi16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    lsl z1.h, z1.h, #15
+; CHECK-NEXT:    lsr z0.h, z0.h, #10
+; CHECK-NEXT:    asr z1.h, z1.h, #9
+; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    ret
+  %pg = call <vscale x 8 x i1> @llvm.aarch64.sve.ptrue.nxv8i1(i32 31)
+  %acc = call <vscale x 8 x i16> @llvm.aarch64.sve.lsr.u.nxv8i16(<vscale x 8 x i1> %pg, <vscale x 8 x i16> %a, <vscale x 8 x i16> splat(i16 10))
+  %sign = call <vscale x 8 x i16> @llvm.aarch64.sve.lsl.u.nxv8i16(<vscale x 8 x i1> %pg, <vscale x 8 x i16> %b, <vscale x 8 x i16> splat(i16 15))
+  %sra = call <vscale x 8 x i16> @llvm.aarch64.sve.asr.u.nxv8i16(<vscale x 8 x i1> %pg, <vscale x 8 x i16> %sign, <vscale x 8 x i16> splat(i16 9))
+  %r = or <vscale x 8 x i16> %acc, %sra
+  ret <vscale x 8 x i16> %r
+}
+
+define <vscale x 4 x i32> @ssra_disjoint_shift_intr_or4xi32(<vscale x 4 x i32> %a, <vscale x 4 x i32> %b) #0 {
+; CHECK-LABEL: ssra_disjoint_shift_intr_or4xi32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    lsl z1.s, z1.s, #31
+; CHECK-NEXT:    lsr z0.s, z0.s, #26
+; CHECK-NEXT:    asr z1.s, z1.s, #25
+; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    ret
+  %pg = call <vscale x 4 x i1> @llvm.aarch64.sve.ptrue.nxv4i1(i32 31)
+  %acc = call <vscale x 4 x i32> @llvm.aarch64.sve.lsr.u.nxv4i32(<vscale x 4 x i1> %pg, <vscale x 4 x i32> %a, <vscale x 4 x i32> splat(i32 26))
+  %sign = call <vscale x 4 x i32> @llvm.aarch64.sve.lsl.u.nxv4i32(<vscale x 4 x i1> %pg, <vscale x 4 x i32> %b, <vscale x 4 x i32> splat(i32 31))
+  %sra = call <vscale x 4 x i32> @llvm.aarch64.sve.asr.u.nxv4i32(<vscale x 4 x i1> %pg, <vscale x 4 x i32> %sign, <vscale x 4 x i32> splat(i32 25))
+  %r = or <vscale x 4 x i32> %acc, %sra
+  ret <vscale x 4 x i32> %r
+}
+
+define <vscale x 2 x i64> @ssra_disjoint_shift_intr_or2xi64(<vscale x 2 x i64> %a, <vscale x 2 x i64> %b) #0 {
+; CHECK-LABEL: ssra_disjoint_shift_intr_or2xi64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    lsl z1.d, z1.d, #63
+; CHECK-NEXT:    lsr z0.d, z0.d, #58
+; CHECK-NEXT:    asr z1.d, z1.d, #57
+; CHECK-NEXT:    orr z0.d, z0.d, z1.d
+; CHECK-NEXT:    ret
+  %pg = call <vscale x 2 x i1> @llvm.aarch64.sve.ptrue.nxv2i1(i32 31)
+  %acc = call <vscale x 2 x i64> @llvm.aarch64.sve.lsr.u.nxv2i64(<vscale x 2 x i1> %pg, <vscale x 2 x i64> %a, <vscale x 2 x i64> splat(i64 58))
+  %sign = call <vscale x 2 x i64> @llvm.aarch64.sve.lsl.u.nxv2i64(<vscale x 2 x i1> %pg, <vscale x 2 x i64> %b, <vscale x 2 x i64> splat(i64 63))
+  %sra = call <vscale x 2 x i64> @llvm.aarch64.sve.asr.u.nxv2i64(<vscale x 2 x i1> %pg, <vscale x 2 x i64> %sign, <vscale x 2 x i64> splat(i64 57))
+  %r = or <vscale x 2 x i64> %acc, %sra
+  ret <vscale x 2 x i64> %r
+}
 
 attributes #0 = { "target-features"="+sve,+sve2" }


### PR DESCRIPTION
Allow SelectionDAG to query target known-bits information for scalable vector nodes, and known-bits cases for SVE predicated SHL, SRL and SRA nodes.

This enables DAG combines to prove disjointness for ORs involving scalable vector shifts, enabling USRA/SSRA instruction selection.

Dependency PR: https://github.com/llvm/llvm-project/pull/197657