### PR TITLE
[lit] Add lit.llvm.fn_selection: opt-in select-function pass via --param fn-pass

### DIFF
--- a/llvm/utils/lit/lit/llvm/fn_param.py
+++ b/llvm/utils/lit/lit/llvm/fn_param.py
@@ -37,9 +37,9 @@ def install(config, lit_config):
         config, r"(\S*FileCheck)\b", r"\1 --filter-label=" + ",".join(names)
     )
     if lit_config.params.get("fn-pass"):
-        # from lit.llvm import fn_selection
-        # fn_selection.install(config, lit_config)
-        pass
+        from lit.llvm import fn_selection
+
+        fn_selection.install(config, lit_config)
     else:
         from lit.llvm import fn_extract
 

--- a/llvm/utils/lit/lit/llvm/fn_selection.py
+++ b/llvm/utils/lit/lit/llvm/fn_selection.py
@@ -1,0 +1,16 @@
+"""Splice a `select-function<fn=...>` pass at the head of every `-passes=`
+pipeline so only the named functions (and their transitive dependencies) are
+compiled by `opt`. Driven by `--param fn=NAMES`."""
+
+from lit.llvm.fn_param import add_capture_sub, parse_fn_names
+
+
+def install(config, lit_config):
+    names = parse_fn_names(lit_config)
+    if not names:
+        return
+    sel = "select-function<" + ";".join("fn=" + n for n in names) + ">"
+    # -passes='...' / -passes="..." — splice select-function after the quote
+    add_capture_sub(config, r"""-passes=(['"])""", r"-passes=\1" + sel + ",")
+    # -passes=word (unquoted) — wrap to protect angle brackets
+    add_capture_sub(config, r"-passes=([^'\"\s]\S*)", r"-passes='" + sel + r",\1'")

--- a/llvm/utils/lit/tests/Inputs/fn-selection/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/fn-selection/lit.cfg
@@ -1,0 +1,10 @@
+import lit.formats
+from lit.llvm import fn_param
+
+config.name = "fn-selection"
+config.suffixes = [".ll"]
+config.test_format = lit.formats.ShTest()
+config.test_source_root = None
+config.test_exec_root = None
+
+fn_param.install(config, lit_config)

--- a/llvm/utils/lit/tests/Inputs/fn-selection/sample.ll
+++ b/llvm/utils/lit/tests/Inputs/fn-selection/sample.ll
@@ -1,0 +1,2 @@
+; RUN: echo -passes='instcombine,mem2reg'
+; RUN: echo -passes="instcombine,mem2reg"

--- a/llvm/utils/lit/tests/fn-filter-checks.py
+++ b/llvm/utils/lit/tests/fn-filter-checks.py
@@ -8,3 +8,7 @@
 
 # Without --param fn=foo: @bar fails, so the test fails.
 # RUN: not %{lit} %{inputs}/fn-filter-checks/sample.ll
+
+# With --param fn=foo --param fn-pass=1: select-function removes @bar,
+# so the test passes.
+# RUN: %{lit} --param fn=foo --param fn-pass=1 %{inputs}/fn-filter-checks/sample.ll

--- a/llvm/utils/lit/tests/fn-selection.py
+++ b/llvm/utils/lit/tests/fn-selection.py
@@ -1,0 +1,25 @@
+# Verify --param fn=NAMES + --param fn-pass=1 splices select-function into
+# -passes= pipelines via lit.llvm.fn_selection (same dispatch as
+# llvm/test/lit.cfg.py).
+
+# --- --param fn=foo: single function ---
+# RUN: %{lit} -a --param fn=foo --param fn-pass=1 %{inputs}/fn-selection/sample.ll \
+# RUN:   | FileCheck --check-prefix=SINGLE %s
+#
+# SINGLE: -passes='select-function<fn=foo>,instcombine,mem2reg'
+# SINGLE: -passes="select-function<fn=foo>,instcombine,mem2reg"
+
+# --- --param fn=foo,bar: multiple functions ---
+# RUN: %{lit} -a --param fn=foo,bar --param fn-pass=1 %{inputs}/fn-selection/sample.ll \
+# RUN:   | FileCheck --check-prefix=MULTI %s
+#
+# MULTI: -passes='select-function<fn=foo;fn=bar>,instcombine,mem2reg'
+# MULTI: -passes="select-function<fn=foo;fn=bar>,instcombine,mem2reg"
+
+# --- No --param: passes unchanged ---
+# RUN: %{lit} -a %{inputs}/fn-selection/sample.ll \
+# RUN:   | FileCheck --check-prefix=NONE %s
+#
+# NONE-NOT: select-function
+# NONE: -passes='instcombine,mem2reg'
+# NONE: -passes="instcombine,mem2reg"


### PR DESCRIPTION
Translates `llvm-lit --fn=fn0,fn1 --param fn-pass` into `<tool> -passes='select-function<fn=fn0;fn=fn1>,...'`
by rewriting `-passes=` arguments in RUN lines after substitution.

Stacked above https://github.com/llvm/llvm-project/pull/200351.