### PR TITLE
[libclc][test] Update math/cos.cl check lines after #199981 revert

### DIFF
--- a/libclc/test/math/cos.cl
+++ b/libclc/test/math/cos.cl
@@ -145,11 +145,11 @@
 // AMDGCN-NEXT:    [[TMP127:%.*]] = shl i32 [[TMP115]], 30
 // AMDGCN-NEXT:    [[TMP128:%.*]] = and i32 [[TMP127]], -2147483648
 // AMDGCN-NEXT:    [[TMP129:%.*]] = fneg contract float [[TMP120]]
-// AMDGCN-NEXT:    [[TMP130:%.*]] = select contract i1 [[TMP126]], float [[TMP124]], float [[TMP129]]
-// AMDGCN-NEXT:    [[TMP131:%.*]] = bitcast float [[TMP130]] to i32
-// AMDGCN-NEXT:    [[TMP132:%.*]] = xor i32 [[TMP128]], [[TMP131]]
-// AMDGCN-NEXT:    [[TMP133:%.*]] = bitcast i32 [[TMP132]] to float
-// AMDGCN-NEXT:    ret float [[TMP133]]
+// AMDGCN-NEXT:    [[DOTV_I_I:%.*]] = select i1 [[TMP126]], float [[TMP124]], float [[TMP129]]
+// AMDGCN-NEXT:    [[TMP130:%.*]] = bitcast float [[DOTV_I_I]] to i32
+// AMDGCN-NEXT:    [[TMP131:%.*]] = xor i32 [[TMP128]], [[TMP130]]
+// AMDGCN-NEXT:    [[TMP132:%.*]] = bitcast i32 [[TMP131]] to float
+// AMDGCN-NEXT:    ret float [[TMP132]]
 //
 float test_float(float x) {
   return cos(x);


### PR DESCRIPTION
The libclc lit test 'math/cos.cl' (introduced by #197151 with auto-generated FileCheck assertions) started failing on the staging buildbot after the revert in #199981 of the AMDGPU ABI coercion change (#185083). The revert restores the older codegen path, which produces a slightly different IR shape for the select instruction inside the cos() implementation:

  - the select's 'contract' fast-math flag is no longer present, and
  - the result is named %.v.i.i instead of a numbered SSA temporary.

Regenerate the AMDGCN CHECK lines with libclc/test/update_libclc_tests.py to reflect the post-revert IR. After this change, all 10 libclc tests in check-libclc-amdgcn-amd-amdhsa-llvm pass.

Note: running update_libclc_tests.py also produces a purely cosmetic diff in math/rsqrt.cl (it renames a few FileCheck capture names like META13 to META12 to match the actual metadata indices); those capture renames are not required for the test to pass and are not included here to keep the change minimal.