### PR TITLE
[Mips] Fix Clang crashes when assembling MIPS div/rem with register-name symbol as divisor

### DIFF
--- a/llvm/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
+++ b/llvm/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
@@ -2020,6 +2020,8 @@ bool MipsAsmParser::processInstruction(MCInst &Inst, SMLoc IDLoc,
   case Mips::UDivIMacro:
   case Mips::DSDivIMacro:
   case Mips::DUDivIMacro:
+    if (!Inst.getOperand(2).isImm())
+      return Error(IDLoc, "expected immediate operand kind");
     if (Inst.getOperand(2).getImm() == 0) {
       if (Inst.getOperand(1).getReg() == Mips::ZERO ||
           Inst.getOperand(1).getReg() == Mips::ZERO_64)

--- a/llvm/test/MC/Mips/div-err.s
+++ b/llvm/test/MC/Mips/div-err.s
@@ -1,0 +1,4 @@
+# RUN: not llvm-mc %s -triple=mips -mcpu=mips32 2>&1 | FileCheck %s
+
+# CHECK: error: expected immediate operand kind
+  div $t0, $t1, f0

--- a/llvm/test/MC/Mips/div-err.s
+++ b/llvm/test/MC/Mips/div-err.s
@@ -1,4 +1,0 @@
-# RUN: not llvm-mc %s -triple=mips -mcpu=mips32 2>&1 | FileCheck %s
-
-# CHECK: error: expected immediate operand kind
-  div $t0, $t1, f0

--- a/llvm/test/MC/Mips/macro-ddiv-bad.s
+++ b/llvm/test/MC/Mips/macro-ddiv-bad.s
@@ -4,15 +4,18 @@
 # RUN: FileCheck %s --check-prefix=MIPS32-OR-R6
 # RUN: not llvm-mc %s -triple=mips64 -mcpu=mips64r6 2>&1 | \
 # RUN: FileCheck %s --check-prefix=MIPS32-OR-R6
-# RUN: llvm-mc %s -triple=mips64 -mcpu=mips64r2 2>&1 | \
+# RUN: not llvm-mc %s -triple=mips64 -mcpu=mips64r2 2>&1 | \
 # RUN: FileCheck %s --check-prefix=MIPS64-NOT-R6
 
   .text
-  ddivu $25, $11
+  ddiv $25, $11
   # MIPS32-OR-R6: :[[@LINE-1]]:{{[0-9]+}}: error: instruction requires a CPU feature not currently enabled
 
-  ddivu $25, $0
+  ddiv $25, $0
   # MIPS64-NOT-R6: :[[@LINE-1]]:3: warning: division by zero
 
-  ddivu $0,$0
+  ddiv $0,$0
   # MIPS64-NOT-R6: :[[@LINE-1]]:3: warning: dividing zero by zero
+
+  ddiv $t0, $t1, f0
+  # MIPS64-NOT-R6: :[[@LINE-1]]:3: error: expected immediate operand kind

--- a/llvm/test/MC/Mips/macro-ddivu-bad.s
+++ b/llvm/test/MC/Mips/macro-ddivu-bad.s
@@ -4,7 +4,7 @@
 # RUN: FileCheck %s --check-prefix=MIPS32-OR-R6
 # RUN: not llvm-mc %s -triple=mips64 -mcpu=mips64r6 2>&1 | \
 # RUN: FileCheck %s --check-prefix=MIPS32-OR-R6
-# RUN: llvm-mc %s -triple=mips64 -mcpu=mips64r2 2>&1 | \
+# RUN: not llvm-mc %s -triple=mips64 -mcpu=mips64r2 2>&1 | \
 # RUN: FileCheck %s --check-prefix=MIPS64-NOT-R6
 
   .text
@@ -16,3 +16,6 @@
 
   ddivu $0,$0
   # MIPS64-NOT-R6: :[[@LINE-1]]:3: warning: dividing zero by zero
+
+  ddivu $t0, $t1, f0
+  # MIPS64-NOT-R6: :[[@LINE-1]]:3: error: expected immediate operand kind

--- a/llvm/test/MC/Mips/macro-div-bad.s
+++ b/llvm/test/MC/Mips/macro-div-bad.s
@@ -2,9 +2,9 @@
 # RUN: FileCheck %s --check-prefix=R6
 # RUN: not llvm-mc %s -triple=mips64 -mcpu=mips64r6 2>&1 | \
 # RUN: FileCheck %s --check-prefix=R6
-# RUN: llvm-mc %s -triple=mips -mcpu=mips32r2 2>&1 | \
+# RUN: not llvm-mc %s -triple=mips -mcpu=mips32r2 2>&1 | \
 # RUN: FileCheck %s --check-prefix=NOT-R6
-# RUN: llvm-mc %s -triple=mips64 -mcpu=mips64r2 2>&1 | \
+# RUN: not llvm-mc %s -triple=mips64 -mcpu=mips64r2 2>&1 | \
 # RUN: FileCheck %s --check-prefix=NOT-R6
 
   .text
@@ -16,3 +16,6 @@
 
   div $0,$0
   # NOT-R6: :[[@LINE-1]]:3: warning: dividing zero by zero
+
+  div $t0, $t1, f0
+  # NOT-R6: :[[@LINE-1]]:3: error: expected immediate operand kind

--- a/llvm/test/MC/Mips/macro-divu-bad.s
+++ b/llvm/test/MC/Mips/macro-divu-bad.s
@@ -2,9 +2,9 @@
 # RUN: FileCheck %s --check-prefix=R6
 # RUN: not llvm-mc %s -triple=mips64 -mcpu=mips64r6 2>&1 | \
 # RUN: FileCheck %s --check-prefix=R6
-# RUN: llvm-mc %s -triple=mips -mcpu=mips32r2 2>&1 | \
+# RUN: not llvm-mc %s -triple=mips -mcpu=mips32r2 2>&1 | \
 # RUN: FileCheck %s --check-prefix=NOT-R6
-# RUN: llvm-mc %s -triple=mips64 -mcpu=mips64r2 2>&1 | \
+# RUN: not llvm-mc %s -triple=mips64 -mcpu=mips64r2 2>&1 | \
 # RUN: FileCheck %s --check-prefix=NOT-R6
 
   .text
@@ -16,3 +16,6 @@
 
   divu $0,$0
   # NOT-R6: :[[@LINE-1]]:3: warning: dividing zero by zero
+
+  divu $t0, $t1, f0
+  # NOT-R6: :[[@LINE-1]]:3: error: expected immediate operand kind


### PR DESCRIPTION
Add check before getimm().

Fix #185363.