### PR TITLE
[libc] Add netinet/tcp.h header

### DIFF
--- a/libc/config/linux/aarch64/headers.txt
+++ b/libc/config/linux/aarch64/headers.txt
@@ -20,6 +20,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.malloc
     libc.include.math
     libc.include.netinet_in
+    libc.include.netinet_tcp
     libc.include.poll
     libc.include.pthread
     libc.include.sched

--- a/libc/config/linux/riscv/headers.txt
+++ b/libc/config/linux/riscv/headers.txt
@@ -20,6 +20,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.malloc
     libc.include.math
     libc.include.netinet_in
+    libc.include.netinet_tcp
     libc.include.poll
     libc.include.pthread
     libc.include.sched

--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -20,6 +20,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.malloc
     libc.include.math
     libc.include.netinet_in
+    libc.include.netinet_tcp
     libc.include.nl_types
     libc.include.poll
     libc.include.pthread

--- a/libc/docs/CMakeLists.txt
+++ b/libc/docs/CMakeLists.txt
@@ -58,6 +58,7 @@ if (SPHINX_FOUND)
       nl_types
       net/if
       netinet/in
+      netinet/tcp
       poll
       pthread
       pwd

--- a/libc/docs/headers/index.rst
+++ b/libc/docs/headers/index.rst
@@ -24,6 +24,7 @@ Implementation Status
    math/index.rst
    net/if
    netinet/in
+   netinet/tcp
    nl_types
    poll
    pwd

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -226,6 +226,14 @@ add_header_macro(
 )
 
 add_header_macro(
+  netinet_tcp
+  ../libc/include/netinet/tcp.yaml
+  netinet/tcp.h
+  DEPENDS
+    .llvm_libc_common_h
+)
+
+add_header_macro(
   assert
   ../libc/include/assert.yaml
   assert.h

--- a/libc/include/netinet/tcp.yaml
+++ b/libc/include/netinet/tcp.yaml
@@ -1,0 +1,10 @@
+header: netinet/tcp.h
+standards:
+  - posix
+macros:
+  - macro_name: TCP_NODELAY
+    macro_value: 1
+types: []
+enums: []
+objects: []
+functions: []

--- a/libc/utils/docgen/netinet/tcp.yaml
+++ b/libc/utils/docgen/netinet/tcp.yaml
@@ -1,0 +1,3 @@
+macros:
+  TCP_NODELAY:
+    in-latest-posix: ''


### PR DESCRIPTION
This patch adds the netinet/tcp.h header definition. For now I'm only adding TCP_NODELAY to it, as that's the only constant specified by POSIX.

I also include the header in the public headers list for linux targets and hook it up to the implementation status docs.

I don't add a test as this is just a constant definition, and it would be very hard to devise (if even possible over a loopback interface) a test to check that the option has the desired effect (in fact, POSIX says that an implementation doesn't even have to let you set the option).

Assisted by Gemini.