### PR TITLE
[SystemZ] Remove unused variable warning

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
@@ -1805,10 +1805,9 @@ void SystemZInstrInfo::expandStackGuardPseudo(MachineInstr &MI,
   unsigned int Offset = 0;
 
   Register AddrReg = MI.getOperand(0).getReg();
-  Register OpReg = MI.getOperand(1).getReg();
 
   assert(
-      AddrReg != OpReg &&
+      AddrReg != MI.getOperand(1).getReg() &&
       "Scratch register for stack guard address blocked by operand register.");
 
   // Emit an appropriate pseudo for the guard type, which loads the address of


### PR DESCRIPTION
This PR removes a variable declaration that was causing issues in builds without assertions and `-Werror` enabled. Instead of declaring a variable that is then only used in an assert, the value assigned to the variable is moved into the assert instead.

This should resolve the build issue caused by #169317 discovered [here](https://lab.llvm.org/buildbot/#/builders/228/builds/377).