### PR TITLE
[compiler-rt] [ARM] Restore Windows specific names for fp->int functions

### DIFF
--- a/compiler-rt/lib/builtins/arm/fixdfdi.S
+++ b/compiler-rt/lib/builtins/arm/fixdfdi.S
@@ -208,4 +208,8 @@ LOCAL_LABEL(nan):
 
 END_COMPILERRT_FUNCTION(__aeabi_d2lz)
 
+#if defined(__MINGW32__)
+DEFINE_COMPILERRT_FUNCTION_ALIAS(__dtoi64, __fixdfdi)
+#endif
+
 NO_EXEC_STACK_DIRECTIVE

--- a/compiler-rt/lib/builtins/arm/fixsfdi.S
+++ b/compiler-rt/lib/builtins/arm/fixsfdi.S
@@ -135,4 +135,8 @@ LOCAL_LABEL(return_zero):
 
 END_COMPILERRT_FUNCTION(__aeabi_f2lz)
 
+#if defined(__MINGW32__)
+DEFINE_COMPILERRT_FUNCTION_ALIAS(__stoi64, __fixsfdi)
+#endif
+
 NO_EXEC_STACK_DIRECTIVE

--- a/compiler-rt/lib/builtins/arm/fixunsdfdi.S
+++ b/compiler-rt/lib/builtins/arm/fixunsdfdi.S
@@ -156,4 +156,8 @@ LOCAL_LABEL(positive_invalid):
 
 END_COMPILERRT_FUNCTION(__aeabi_d2ulz)
 
+#if defined(__MINGW32__)
+DEFINE_COMPILERRT_FUNCTION_ALIAS(__dtou64, __fixunsdfdi)
+#endif
+
 NO_EXEC_STACK_DIRECTIVE

--- a/compiler-rt/lib/builtins/arm/fixunssfdi.S
+++ b/compiler-rt/lib/builtins/arm/fixunssfdi.S
@@ -100,4 +100,8 @@ LOCAL_LABEL(positive_invalid):
 
 END_COMPILERRT_FUNCTION(__aeabi_f2ulz)
 
+#if defined(__MINGW32__)
+DEFINE_COMPILERRT_FUNCTION_ALIAS(__stou64, __fixunssfdi)
+#endif
+
 NO_EXEC_STACK_DIRECTIVE


### PR DESCRIPTION
These Windows specific names were added in
8c59680ac26cf3d772f51aa5ebd64be8e59ed384 (and refactored later in e6407356ba008e474322d52b7d031f65fa4913fc).

When ARM specific implementations of them were added in 174eb79572b3433aa338ede31815fa8fa6a13b29, the ARM specific files replace the generic ones - while the ARM specific file lacked the Windows/ARM renaming of the functions.

Restore the Windows naming of these functions.