### PR TITLE
[clang-tools-extra][docs] Convert maintainers file to Markdown

### DIFF
--- a/clang-tools-extra/Maintainers.md
+++ b/clang-tools-extra/Maintainers.md
@@ -1,84 +1,82 @@
-=============================
-Clang Tools Extra Maintainers
-=============================
+# Clang Tools Extra Maintainers
 
-This file is a list of the 
-`maintainers <https://llvm.org/docs/DeveloperPolicy.html#maintainers>`_
-for `Extra Clang Tools <https://clang.llvm.org/extra/index.html>`_ project.
+This file is a list of the
+[maintainers](https://llvm.org/docs/DeveloperPolicy.html#maintainers)
+for the [Extra Clang Tools](https://clang.llvm.org/extra/index.html) project.
 
-.. contents::
-   :depth: 2
-   :local:
+```{contents} Table of Contents
+:depth: 2
+```
 
-Active Maintainers
-==================
+# Active Maintainers
+
 The following people are the active maintainers for the project. Please reach
 out to them for code reviews, questions about their area of expertise, or other
 assistance.
 
-Lead Maintainer
----------------
-| Aaron Ballman
-| aaron@aaronballman.com (email), aaron.ballman (Phabricator), AaronBallman (GitHub), AaronBallman (Discourse), aaronballman (Discord)
+## Lead Maintainer
+
+Aaron Ballman \
+aaron@aaronballman.com (email), aaron.ballman (Phabricator), [AaronBallman](https://github.com/AaronBallman) (GitHub), AaronBallman (Discourse), aaronballman (Discord)
 
 
-clang-tidy
-----------
-| Julian Schmidt
-| git.julian.schmidt@gmail.com (email), 5chmidti (GitHub), 5chmidti (Discourse), 5chmidti (Discord)
+## clang-tidy
 
-| Victor Baranov
-| bar.victor.2002@gmail.com (email), vbvictor (GitHub), vbvictor (Discourse), vbvictor  (Discord)
+Julian Schmidt \
+git.julian.schmidt@gmail.com (email), [5chmidti](https://github.com/5chmidti) (GitHub), 5chmidti (Discourse), 5chmidti (Discord)
 
-| Victor Chernyakin
-| chernyakin.victor.j@outlook.com (email), localspook (GitHub), LocalSpook (Discourse), localspook (Discord)
+Victor Baranov \
+bar.victor.2002@gmail.com (email), [vbvictor](https://github.com/vbvictor) (GitHub), vbvictor (Discourse), vbvictor  (Discord)
 
-| Zeyi Xu
-| zeyi2@nekoarch.cc (email), zeyi2 (Github), zeyi2 (Discourse), zeyi1 (Discord)
+Victor Chernyakin \
+chernyakin.victor.j@outlook.com (email), [localspook](https://github.com/localspook) (GitHub), LocalSpook (Discourse), localspook (Discord)
 
-
-clang-query
------------
-| Aaron Ballman
-| aaron@aaronballman.com (email), aaron.ballman (Phabricator), AaronBallman (GitHub), AaronBallman (Discourse), aaronballman (Discord)
+Zeyi Xu \
+zeyi2@nekoarch.cc (email), [zeyi2](https://github.com/zeyi2) (Github), zeyi2 (Discourse), zeyi1 (Discord)
 
 
-clang-doc
----------
-| Paul Kirth
-| paulkirth@google.com (email), ilovepi (GitHub), ilovepi (Discourse)
+## clang-query
 
-| Erick Velez
-| erickvelez7@gmail.com (email), evelez7 (GitHub), evelez (Discourse), erick.velez (Discord)
+Aaron Ballman \
+aaron@aaronballman.com (email), aaron.ballman (Phabricator), [AaronBallman](https://github.com/AaronBallman) (GitHub), AaronBallman (Discourse), aaronballman (Discord)
 
 
-clangd
-------
-| Nathan Ridge
-| zeratul976@hotmail.com (email), HighCommander4 (GitHub), HighCommander4 (Discourse), nridge (Discord)
+## clang-doc
 
-| Aleksandr Platonov
-| arcsinx45@gmail.com (email), ArcsinX (GitHub), ArcsinX (Discourse)
+Paul Kirth \
+paulkirth@google.com (email), [ilovepi](https://github.com/ilovepi) (GitHub), ilovepi (Discourse)
+
+Erick Velez \
+erickvelez7@gmail.com (email), [evelez7](https://github.com/evelez7) (GitHub), evelez (Discourse), erick.velez (Discord)
 
 
-Inactive Maintainers
-====================
+## clangd
+
+Nathan Ridge \
+zeratul976@hotmail.com (email), [HighCommander4](https://github.com/HighCommander4) (GitHub), HighCommander4 (Discourse), nridge (Discord)
+
+Aleksandr Platonov \
+arcsinx45@gmail.com (email), [ArcsinX](https://github.com/ArcsinX) (GitHub), ArcsinX (Discourse)
+
+
+# Inactive Maintainers
+
 The following people have graciously spent time performing maintainership
 responsibilities but are no longer active in that role. Thank you for all your
 help with the success of the project!
 
-Emeritus Lead Maintainers
--------------------------
-| Manuel Klimek (klimek@google.com (email), r4nt (GitHub))
+## Emeritus Lead Maintainers
+
+Manuel Klimek (klimek@google.com (email), [r4nt](https://github.com/r4nt) (GitHub))
 
 
-Inactive component maintainers
-------------------------------
-| Nathan James (n.james93@hotmail.co.uk) -- clang-tidy
-| Julie Hockett (juliehockett@google.com) -- clang-doc
-| Sam McCall (sammccall@google.com (email), sam-mccall (GitHub, Discourse, Discord)) -- clangd
-| Peter Chou (peterchou411@gmail.com (email), PeterChou1 (GitHub, Discourse), .peterchou (Discord)) -- clang-doc
-| Piotr Zegar (me@piotrzegar.pl (email), PiotrZSL (GitHub), PiotrZSL (Discourse), PiotrZSL (Discord)) -- clang-tidy
-| Kadir Çetinkaya (kadircet@google.com (email), kadircet (GitHub) kadircet (Discourse), kadircet (Discord)) -- clangd
-| Chris Bieneman (chris.bieneman@gmail.com (email), llvm-beanz (GitHub), beanz (Discord), beanz (Discourse)) -- clangd
-| Congcong Cai (congcongcai0907@163.com (email), HerrCai0907 (GitHub), HerrCai0907 (Discourse)) -- clang-tidy
+## Inactive component maintainers
+
+Nathan James (n.james93@hotmail.co.uk) \-- clang-tidy \
+Julie Hockett (juliehockett@google.com) \-- clang-doc \
+Sam McCall (sammccall@google.com (email), sam-mccall (GitHub, Discourse, Discord)) \-- clangd \
+Peter Chou (peterchou411@gmail.com (email), PeterChou1 (GitHub, Discourse), .peterchou (Discord)) \-- clang-doc \
+Piotr Zegar (me@piotrzegar.pl (email), [PiotrZSL](https://github.com/PiotrZSL) (GitHub), PiotrZSL (Discourse), PiotrZSL (Discord)) \-- clang-tidy \
+Kadir Çetinkaya (kadircet@google.com (email), [kadircet](https://github.com/kadircet) (GitHub) kadircet (Discourse), kadircet (Discord)) \-- clangd \
+Chris Bieneman (chris.bieneman@gmail.com (email), [llvm-beanz](https://github.com/llvm-beanz) (GitHub), beanz (Discord), beanz (Discourse)) \-- clangd \
+Congcong Cai (congcongcai0907@163.com (email), [HerrCai0907](https://github.com/HerrCai0907) (GitHub), HerrCai0907 (Discourse)) \-- clang-tidy

--- a/clang-tools-extra/docs/Maintainers.md
+++ b/clang-tools-extra/docs/Maintainers.md
@@ -1,1 +1,2 @@
-.. include:: ../Maintainers.rst
+```{include} ../Maintainers.md
+```

--- a/clang-tools-extra/docs/conf.py
+++ b/clang-tools-extra/docs/conf.py
@@ -13,6 +13,7 @@
 
 import sys, os
 from datetime import date
+import myst_parser
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -26,13 +27,13 @@ from datetime import date
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ["sphinx.ext.todo", "sphinx.ext.mathjax"]
+extensions = ["sphinx.ext.todo", "sphinx.ext.mathjax", "myst_parser"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 
 # The suffix of source filenames.
-source_suffix = ".rst"
+source_suffix = [".rst", ".md"]
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'

--- a/llvm/Maintainers.md
+++ b/llvm/Maintainers.md
@@ -510,7 +510,7 @@ Some subprojects maintain their own list of per-component maintainers.
 
 [Clang maintainers](https://github.com/llvm/llvm-project/blob/main/clang/Maintainers.md)
 
-[Clang-tools-extra maintainers](https://github.com/llvm/llvm-project/blob/main/clang-tools-extra/Maintainers.rst)
+[Clang-tools-extra maintainers](https://github.com/llvm/llvm-project/blob/main/clang-tools-extra/Maintainers.md)
 
 [Compiler-rt maintainers](https://github.com/llvm/llvm-project/blob/main/compiler-rt/Maintainers.md)
 


### PR DESCRIPTION
Following the way clang does it.

* Moved files to .md (done in #200769).
* Reformatted into Markdown.
* Changed the stub file docs/Maintainers.rst into docs/Maintainers.md and used a myst directive for the include.
* In the config file, added myst parser and ".md" as a recognised file extension.

After this change, all maintainers files in llvm-project will be in Markdown format.