### PR TITLE
[clang][bytecode] Fix a crash with an empty InitListExpr

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -4039,7 +4039,7 @@ bool Compiler<Emitter>::VisitCXXNewExpr(const CXXNewExpr *E) {
         if (const auto *ILE = dyn_cast<InitListExpr>(Init)) {
           if (ILE->hasArrayFiller())
             DynamicInit = ILE->getArrayFiller();
-          else if (isa<StringLiteral>(ILE->getInit(0)))
+          else if (StaticInitElems > 0 && isa<StringLiteral>(ILE->getInit(0)))
             ElemT = classifyPrim(CAT->getElementType());
         }
       }

--- a/clang/test/AST/ByteCode/new-delete.cpp
+++ b/clang/test/AST/ByteCode/new-delete.cpp
@@ -29,6 +29,9 @@ struct S {
 static_assert(((delete[] (new int[true])), true));
 static_assert(((delete[] (new S[true])), true));
 
+static_assert((new int[]{})[0] == 0); // both-error {{not an integral constant expression}} \
+                                      // both-note {{read of dereferenced one-past-the-end pointer}}
+
 constexpr int a() {
   new int(12); // both-note {{allocation performed here was not deallocated}}
   return 1;


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/200295