### PR TITLE
[TBAA] Assume struct member TBAA does not alias errno

### DIFF
--- a/llvm/lib/Analysis/TypeBasedAliasAnalysis.cpp
+++ b/llvm/lib/Analysis/TypeBasedAliasAnalysis.cpp
@@ -395,6 +395,11 @@ AliasResult TypeBasedAAResult::aliasErrno(const MemoryLocation &Loc,
   if (!N)
     return AliasResult::MayAlias;
 
+  // Assume that struct member accesses never alias errno, even if the member
+  // is an integer.
+  if (N->getOperand(0) != N->getOperand(1))
+    return AliasResult::NoAlias;
+
   // There cannot be any alias with errno if TBAA proves the given memory
   // location does not alias errno.
   const auto *ErrnoTBAAMD = M->getNamedMetadata("llvm.errno.tbaa");

--- a/llvm/test/Transforms/InstCombine/may-alias-errno.ll
+++ b/llvm/test/Transforms/InstCombine/may-alias-errno.ll
@@ -3,8 +3,8 @@
 
 ; sinf clobbering errno, but %p cannot alias errno per C/C++ strict aliasing rules via TBAA.
 ; Can do constant store-to-load forwarding.
-define float @does_not_alias_errno(ptr %p, float %f) {
-; CHECK-LABEL: define float @does_not_alias_errno(
+define float @does_not_alias_errno_float_tbaa(ptr %p, float %f) {
+; CHECK-LABEL: define float @does_not_alias_errno_float_tbaa(
 ; CHECK-SAME: ptr [[P:%.*]], float [[F:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    store float 0.000000e+00, ptr [[P]], align 4, !tbaa [[TBAA4:![0-9]+]]
@@ -16,6 +16,21 @@ entry:
   %call = call float @sinf(float %f)
   %0 = load float, ptr %p, align 4, !tbaa !4
   ret float %0
+}
+
+define i32 @does_not_alias_errno_struct_tbaa(ptr %p, float %f) {
+; CHECK-LABEL: define i32 @does_not_alias_errno_struct_tbaa(
+; CHECK-SAME: ptr [[P:%.*]], float [[F:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    store i32 0, ptr [[P]], align 4, !tbaa [[TBAA6:![0-9]+]]
+; CHECK-NEXT:    [[CALL:%.*]] = call float @sinf(float [[F]])
+; CHECK-NEXT:    ret i32 0
+;
+entry:
+  store i32 0, ptr %p, align 4, !tbaa !6
+  %call = call float @sinf(float %f)
+  %val = load i32, ptr %p, align 4, !tbaa !6
+  ret i32 %val
 }
 
 ; sinf clobbering errno, but %p is alloca memory, wich can never aliases errno.
@@ -161,6 +176,8 @@ declare void @escape(ptr %p)
 !3 = !{!"Simple C/C++ TBAA"}
 !4 = !{!5, !5, i64 0}
 !5 = !{!"float", !2, i64 0}
+!6 = !{!7, !1, i64 0}
+!7 = !{!"my_struct", !1, i64 0}
 ;.
 ; CHECK: [[TBAA0]] = !{[[META1:![0-9]+]], [[META1]], i64 0}
 ; CHECK: [[META1]] = !{!"int", [[META2:![0-9]+]], i64 0}
@@ -168,4 +185,6 @@ declare void @escape(ptr %p)
 ; CHECK: [[META3]] = !{!"Simple C/C++ TBAA"}
 ; CHECK: [[TBAA4]] = !{[[META5:![0-9]+]], [[META5]], i64 0}
 ; CHECK: [[META5]] = !{!"float", [[META2]], i64 0}
+; CHECK: [[TBAA6]] = !{[[META7:![0-9]+]], [[META1]], i64 0}
+; CHECK: [[META7]] = !{!"my_struct", [[META1]], i64 0}
 ;.


### PR DESCRIPTION
Assume that TBAA that refers to a struct member access, assume it does not alias errno even if the member is compatible with int.

This is subject to the usual libc LTO issue where the heuristic might not be strictly correct if the errno implementation is visible (as errno may be part of a struct).

In particular, this is important to make sure that things like string length/capacity are not considered clobbered by allocation calls that may write to errno. See #197199 for where this came up.