### PR TITLE
[docs] Remove all references to Maintainers.rst

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 #
 # This is independent of LLVM's own "maintainer" concept.
 # See https://llvm.org/docs/DeveloperPolicy.html#maintainers as well as the
-# Maintainers.* files in the the respective subproject directories.
+# Maintainers.md files in the the respective subproject directories.
 
 /libc/ @llvm/reviewers-libc
 /libcxx/ @llvm/reviewers-libcxx

--- a/libc/docs/porting.rst
+++ b/libc/docs/porting.rst
@@ -95,7 +95,7 @@ people are the maintainers, and they are responsible for keeping their target in
 good shape. This means fixing their target when it breaks, reviewing patches
 related to their target, and keeping the target's CI running.
 
-Maintainers are listed in libc/maintainers.rst and must follow
+Maintainers are listed in libc/maintainers.md and must follow
 `LLVM's maintainer policy <https://llvm.org/docs/DeveloperPolicy.html#maintainers>`_.
 
 CI builders

--- a/llvm/docs/Contributing.rst
+++ b/llvm/docs/Contributing.rst
@@ -116,9 +116,9 @@ and add them to your patch when requesting a review.
 
 Suitable reviewers are the maintainers of the project you are modifying, and
 anyone else working in the area your patch touches. To find maintainers, look for
-the ``Maintainers.md`` or ``Maintainers.rst`` file in the root of the project's
+the ``Maintainers.md`` file in the root of the project's
 sub-directory. For example, LLVM's is ``llvm/Maintainers.md`` and
-clang-tools-extra's is ``clang-tools-extra/Maintainers.rst``.
+clang-tools-extra's is ``clang-tools-extra/Maintainers.md``.
 
 If you are a new contributor, you will not be able to select reviewers in such a
 way, in which case you can still get the attention of potential reviewers by CC'ing

--- a/llvm/docs/DeveloperPolicy.rst
+++ b/llvm/docs/DeveloperPolicy.rst
@@ -141,8 +141,7 @@ products.
 Maintainers are those volunteers; they are regular contributors who volunteer
 to take on additional community responsibilities beyond code contributions.
 Community members can find active and inactive maintainers for a project in the
-``Maintainers.md`` or ``Maintainers.rst`` file at the root directory of the
-individual project.
+``Maintainers.md`` file at the root directory of the individual project.
 
 Maintainers are volunteering to take on the following shared responsibilities
 within an area of a project:
@@ -192,7 +191,7 @@ the same project vouches for their ability to perform the responsibilities and
 there are no explicit objections raised by the community.
 
 *To step down as a maintainer*, you can move your name to the "inactive
-maintainers" section of the ``Maintainers.md`` or ``Maintainers.rst`` file for
+maintainers" section of the ``Maintainers.md`` file for
 the project, or remove your name entirely; no PR review is necessary.
 Additionally, any maintainer who has not been actively performing their
 responsibilities over an extended period of time can be moved to the "inactive
@@ -207,8 +206,8 @@ as a maintainer is normal and does not prevent someone from resuming their
 activities as a maintainer in the future.
 
 *To resume activities as a maintainer*, you can post a PR moving your name from
-the "inactive maintainers" section of the ``Maintainers.md`` or
-``Maintainers.rst`` file to the active maintainers list. Because the volunteer
+the "inactive maintainers" section of the ``Maintainers.md``
+file to the active maintainers list. Because the volunteer
 was already previously accepted, they will be re-accepted so long as at least
 one maintainer in the same project approves the PR and there are no explicit
 objections raised by the community.


### PR DESCRIPTION
All projects are using Maintainers.md files as of #200365.