### PR TITLE
[TBAA] Remove handling for old TBAA format

### DIFF
--- a/llvm/lib/Analysis/TypeBasedAliasAnalysis.cpp
+++ b/llvm/lib/Analysis/TypeBasedAliasAnalysis.cpp
@@ -15,13 +15,7 @@
 // typical C/C++ TBAA, but it can also be used to implement custom alias
 // analysis behavior for other languages.
 //
-// We now support two types of metadata format: scalar TBAA and struct-path
-// aware TBAA. After all testing cases are upgraded to use struct-path aware
-// TBAA and we can auto-upgrade existing bc files, the support for scalar TBAA
-// can be dropped.
-//
-// The scalar TBAA metadata format is very simple. TBAA MDNodes have up to
-// three fields, e.g.:
+// Scalar type nodes have up to three fields, e.g.:
 //   !0 = !{ !"an example type tree" }
 //   !1 = !{ !"int", !0 }
 //   !2 = !{ !"float", !0 }
@@ -44,8 +38,8 @@
 // should return true; see
 // http://llvm.org/docs/AliasAnalysis.html#OtherItfs).
 //
-// With struct-path aware TBAA, the MDNodes attached to an instruction using
-// "!tbaa" are called path tag nodes.
+// The MDNodes attached to an instruction using "!tbaa" are not plain type
+// nodes, but path tag nodes.
 //
 // The path tag node has 4 fields with the last field being optional.
 //
@@ -364,15 +358,6 @@ public:
 
 } // end anonymous namespace
 
-/// Check the first operand of the tbaa tag node, if it is a MDNode, we treat
-/// it as struct-path aware TBAA format, otherwise, we treat it as scalar TBAA
-/// format.
-static bool isStructPathTBAA(const MDNode *MD) {
-  // Anonymous TBAA root starts with a MDNode and dragonegg uses it as
-  // a TBAA tag.
-  return isa<MDNode>(MD->getOperand(0)) && MD->getNumOperands() >= 3;
-}
-
 AliasResult TypeBasedAAResult::alias(const MemoryLocation &LocA,
                                      const MemoryLocation &LocB,
                                      AAQueryInfo &AAQI, const Instruction *) {
@@ -417,8 +402,7 @@ ModRefInfo TypeBasedAAResult::getModRefInfoMask(const MemoryLocation &Loc,
 
   // If this is an "immutable" type, we can assume the pointer is pointing
   // to constant memory.
-  if ((!isStructPathTBAA(M) && TBAANode(M).isTypeImmutable()) ||
-      (isStructPathTBAA(M) && TBAAStructTagNode(M).isTypeImmutable()))
+  if (TBAAStructTagNode(M).isTypeImmutable())
     return ModRefInfo::NoModRef;
 
   return ModRefInfo::ModRef;
@@ -431,8 +415,7 @@ MemoryEffects TypeBasedAAResult::getMemoryEffects(const CallBase *Call,
 
   // If this is an "immutable" type, the access is not observable.
   if (const MDNode *M = Call->getMetadata(LLVMContext::MD_tbaa))
-    if ((!isStructPathTBAA(M) && TBAANode(M).isTypeImmutable()) ||
-        (isStructPathTBAA(M) && TBAAStructTagNode(M).isTypeImmutable()))
+    if (TBAAStructTagNode(M).isTypeImmutable())
       return MemoryEffects::none();
 
   return MemoryEffects::unknown();
@@ -472,16 +455,6 @@ ModRefInfo TypeBasedAAResult::getModRefInfo(const CallBase *Call1,
 }
 
 bool MDNode::isTBAAVtableAccess() const {
-  if (!isStructPathTBAA(this)) {
-    if (getNumOperands() < 1)
-      return false;
-    if (MDString *Tag1 = dyn_cast<MDString>(getOperand(0))) {
-      if (Tag1->getString() == "vtable pointer")
-        return true;
-    }
-    return false;
-  }
-
   // For struct-path aware TBAA, we use the access type of the tag.
   TBAAStructTagNode Tag(this);
   TBAAStructTypeNode AccessType(Tag.getAccessType());
@@ -691,11 +664,6 @@ static bool matchAccessTags(const MDNode *A, const MDNode *B,
     return true;
   }
 
-  // Verify that both input nodes are struct-path aware.  Auto-upgrade should
-  // have taken care of this.
-  assert(isStructPathTBAA(A) && "Access A is not struct-path aware!");
-  assert(isStructPathTBAA(B) && "Access B is not struct-path aware!");
-
   TBAAStructTagNode TagA(A), TagB(B);
   const MDNode *CommonType = getLeastCommonType(TagA.getAccessType(),
                                                 TagB.getAccessType());
@@ -767,9 +735,6 @@ MDNode *AAMDNodes::shiftTBAA(MDNode *MD, size_t Offset) {
   // Fast path if there's no offset
   if (Offset == 0)
     return MD;
-  // Fast path if there's no path tbaa node (and thus scalar)
-  if (!isStructPathTBAA(MD))
-    return MD;
 
   // The correct behavior here is to add the offset into the TBAA
   // struct node offset. The base type, however may not have defined
@@ -816,11 +781,6 @@ MDNode *AAMDNodes::extendToTBAA(MDNode *MD, ssize_t Len) {
   // Fast path if 0-length
   if (Len == 0)
     return nullptr;
-
-  // Regular TBAA is invariant of length, so we only need to consider
-  // struct-path TBAA.
-  if (!isStructPathTBAA(MD))
-    return MD;
 
   TBAAStructTagNode Tag(MD);
 


### PR DESCRIPTION
Nowadays only struct-path TBAA is supported, and the verifier enforced this.