### PR TITLE
[Flang][Driver] Remove compatibility module search paths

### DIFF
--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -1183,29 +1183,6 @@ void Flang::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back(Args.MakeArgString(*IntrModPath));
   }
 
-  // Ideally, every target triple has its own set of builtin modules since they
-  // are compiled with platform-dependent conditionals such as `#if __x86_64__`.
-  // However, getting the builtin modules for offload targets requires building
-  // the flang-rt and openmp for those targets as well:
-  // -DLLVM_RUNTIME_TARGETS=default;amdgcn-amd-amdhsa;nvptx64-nvidia-cuda.
-  // To reduce friction when build systems have not yet been updated, we also
-  // add the host's builtin module to the search path (with lower priority), in
-  // case a module file has not been found for the offload targets itself.
-  // FIXME: This workaround may mix module files targeting different triples and
-  //        should eventually be removed.
-  auto &&HostTCs =
-      C.getOffloadToolChains<clang::driver::OffloadAction ::OFK_Host>();
-  for (auto [OKind, HostTC] : llvm::make_range(HostTCs.first, HostTCs.second)) {
-    if (HostTC == &TC)
-      continue;
-
-    if (std::optional<std::string> IntrModPath =
-            HostTC->getDefaultIntrinsicModuleDir()) {
-      CmdArgs.push_back("-fintrinsic-modules-path");
-      CmdArgs.push_back(Args.MakeArgString(*IntrModPath));
-    }
-  }
-
   // Offloading related options
   addOffloadOptions(C, Inputs, JA, Args, CmdArgs);
 

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -919,16 +919,6 @@ static bool parseFrontendArgs(FrontendOptions &opts, llvm::opt::ArgList &args,
   return !diags.hasUncompilableErrorOccurred();
 }
 
-// Generate the path to look for intrinsic modules
-static std::string getIntrinsicDir(const char *argv) {
-  // TODO: Find a system independent API
-  llvm::SmallString<128> driverPath;
-  driverPath.assign(llvm::sys::fs::getMainExecutable(argv, nullptr));
-  llvm::sys::path::remove_filename(driverPath);
-  driverPath.append("/../include/flang/");
-  return std::string(driverPath);
-}
-
 // Generate the path to look for OpenMP headers
 static std::string getOpenMPHeadersDir(const char *argv) {
   llvm::SmallString<128> includePath;
@@ -1915,10 +1905,6 @@ void CompilerInvocation::setFortranOpts() {
       fortranOptions.intrinsicModuleDirectories.end(),
       preprocessorOptions.searchDirectoriesFromIntrModPath.begin(),
       preprocessorOptions.searchDirectoriesFromIntrModPath.end());
-
-  //  Add the default intrinsic module directory
-  fortranOptions.intrinsicModuleDirectories.emplace_back(
-      getIntrinsicDir(getArgv0()));
 
   // Add the directory supplied through -J/-module-dir to the list of search
   // directories


### PR DESCRIPTION
#196558 added target-dependent paths to the default intrinsic module path list. With #171515 the modules now are now emitted to the new search path location and the old search path in `<PREFIX>/include/flang` should not be needed anymore.

Also remove the fallback to the host's omp_lib.mod for device-side compilation. The device should have its own `omp_lib.mod`.