### PR TITLE
[NFC][AMDGPU] Replace getClampMask with hasSameClamp in SIInstrInfo

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
@@ -2184,7 +2184,7 @@ bool SIFoldOperandsImpl::tryFoldClamp(MachineInstr &MI) {
       MRI->getVRegDef(DefSrcReg.isVirtual() ? DefSrcReg : ClampSrc->getReg());
 
   // The type of clamp must be compatible.
-  if (TII->getClampMask(*Def) != TII->getClampMask(MI))
+  if (!SIInstrInfo::hasSameClamp(*Def, MI))
     return false;
 
   if (Def->mayRaiseFPException())

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -1118,12 +1118,10 @@ public:
     return MI.getDesc().TSFlags & SIInstrFlags::IntClamp;
   }
 
-  uint64_t getClampMask(const MachineInstr &MI) const {
-    const uint64_t ClampFlags = SIInstrFlags::FPClamp |
-                                SIInstrFlags::IntClamp |
-                                SIInstrFlags::ClampLo |
-                                SIInstrFlags::ClampHi;
-      return MI.getDesc().TSFlags & ClampFlags;
+  static bool hasSameClamp(const MachineInstr &A, const MachineInstr &B) {
+    const uint64_t Mask = SIInstrFlags::FPClamp | SIInstrFlags::IntClamp |
+                          SIInstrFlags::ClampLo | SIInstrFlags::ClampHi;
+    return (A.getDesc().TSFlags & Mask) == (B.getDesc().TSFlags & Mask);
   }
 
   static bool usesFPDPRounding(const MachineInstr &MI) {


### PR DESCRIPTION
getClampMask had a single call site that used the result only for equality comparison. Replace it with hasSameClamp(A, B) which directly expresses the intent and removes the need to expose raw TSFlags bit values through the return type.