### PR TITLE
[X86] combineMaskBitOp - fold vXi1 logicop(truncate(N0),truncate(N1)) -> truncate(logicop(X,Y))

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -52422,6 +52422,41 @@ static SDValue combineAndNotOrIntoAndNotAnd(SDNode *N, const SDLoc &DL,
   return SDValue();
 }
 
+// Fold vXi1 logicop(truncate(N0),truncate(N1)) -> truncate(logicop(X,Y))
+// Generic vector logicops are always quicker than predicate equivalents.
+static SDValue combineMaskBitOp(SDNode *N, const SDLoc &DL, SelectionDAG &DAG) {
+  using namespace SDPatternMatch;
+  unsigned Opc = N->getOpcode();
+  assert(ISD::isBitwiseLogicOp(Opc) && "Unexpected opcode!");
+  EVT VT = N->getValueType(0);
+  const TargetLowering &TLI = DAG.getTargetLoweringInfo();
+
+  if (!VT.isVector() || VT.getScalarType() != MVT::i1 || !TLI.isTypeLegal(VT))
+    return SDValue();
+
+  SDValue Src0, Src1;
+  if (sd_match(
+          N, m_BitwiseLogic(m_Trunc(m_Value(Src0)), m_Trunc(m_Value(Src1))))) {
+    EVT SrcVT = Src0.getValueType();
+    if (SrcVT == Src1.getValueType() && TLI.isOperationLegal(Opc, SrcVT)) {
+      return DAG.getNode(ISD::TRUNCATE, DL, VT,
+                         DAG.getNode(Opc, DL, SrcVT, Src0, Src1));
+    }
+  }
+
+  // Attempt to match expanded ANDNOT pattern (if AND is legal then ANDNP is).
+  if (sd_match(N,
+               m_And(m_Not(m_Trunc(m_Value(Src0))), m_Trunc(m_Value(Src1))))) {
+    EVT SrcVT = Src0.getValueType();
+    if (SrcVT == Src1.getValueType() && TLI.isOperationLegal(ISD::AND, SrcVT)) {
+      return DAG.getNode(ISD::TRUNCATE, DL, VT,
+                         DAG.getNode(X86ISD::ANDNP, DL, SrcVT, Src0, Src1));
+    }
+  }
+
+  return SDValue();
+}
+
 // This function recognizes cases where X86 bzhi instruction can replace and
 // 'and-load' sequence.
 // In case of loading integer value from an array of constants which is defined
@@ -52907,6 +52942,9 @@ static SDValue combineAnd(SDNode *N, SelectionDAG &DAG,
 
   if (SDValue V = combineScalarAndWithMaskSetcc(N, DAG, Subtarget))
     return V;
+
+  if (SDValue R = combineMaskBitOp(N, dl, DAG))
+    return R;
 
   if (SDValue R = combineBitOpWithMOVMSK(N->getOpcode(), dl, N0, N1, DAG))
     return R;
@@ -53682,6 +53720,9 @@ static SDValue combineOr(SDNode *N, SelectionDAG &DAG,
 
   if (SDValue SetCC = combineAndOrForCcmpCtest(N, DAG, DCI, Subtarget))
     return SetCC;
+
+  if (SDValue R = combineMaskBitOp(N, dl, DAG))
+    return R;
 
   if (SDValue R = combineBitOpWithMOVMSK(N->getOpcode(), dl, N0, N1, DAG))
     return R;
@@ -56521,6 +56562,9 @@ static SDValue combineXor(SDNode *N, SelectionDAG &DAG,
 
   if (SDValue Cmp = foldVectorXorShiftIntoCmp(N, DAG, Subtarget))
     return Cmp;
+
+  if (SDValue R = combineMaskBitOp(N, DL, DAG))
+    return R;
 
   if (SDValue R = combineBitOpWithMOVMSK(N->getOpcode(), DL, N0, N1, DAG))
     return R;

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -52445,8 +52445,8 @@ static SDValue combineMaskBitOp(SDNode *N, const SDLoc &DL, SelectionDAG &DAG) {
   }
 
   // Attempt to match expanded ANDNOT pattern (if AND is legal then ANDNP is).
-  if (sd_match(N,
-               m_And(m_Not(m_Trunc(m_Value(Src0))), m_Trunc(m_Value(Src1))))) {
+  if (sd_match(N, m_And(m_OneUse(m_Not(m_Trunc(m_Value(Src0)))),
+                        m_Trunc(m_Value(Src1))))) {
     EVT SrcVT = Src0.getValueType();
     if (SrcVT == Src1.getValueType() && TLI.isOperationLegal(ISD::AND, SrcVT)) {
       return DAG.getNode(ISD::TRUNCATE, DL, VT,

--- a/llvm/test/CodeGen/X86/avx512-mask-op.ll
+++ b/llvm/test/CodeGen/X86/avx512-mask-op.ll
@@ -3282,114 +3282,61 @@ define i8 @test_v8i1_mul(i8 %x, i8 %y) {
 define <16 x i1> @test_v16i1_select_chain(<16 x i1> %a0, <16 x i1> %a1, <16 x i1> %a2) {
 ; KNL-LABEL: test_v16i1_select_chain:
 ; KNL:       ## %bb.0:
-; KNL-NEXT:    vpmovsxbd %xmm0, %zmm0
-; KNL-NEXT:    vpslld $31, %zmm0, %zmm0
-; KNL-NEXT:    vptestmd %zmm0, %zmm0, %k0
-; KNL-NEXT:    vpmovsxbd %xmm1, %zmm0
-; KNL-NEXT:    vpslld $31, %zmm0, %zmm0
-; KNL-NEXT:    vptestmd %zmm0, %zmm0, %k1
-; KNL-NEXT:    vpmovsxbd %xmm2, %zmm0
-; KNL-NEXT:    vpslld $31, %zmm0, %zmm0
-; KNL-NEXT:    vptestmd %zmm0, %zmm0, %k2
-; KNL-NEXT:    kandw %k1, %k2, %k3
-; KNL-NEXT:    kandnw %k0, %k3, %k3
-; KNL-NEXT:    kandw %k0, %k1, %k4
-; KNL-NEXT:    kandw %k1, %k4, %k5
-; KNL-NEXT:    kandw %k5, %k3, %k3
-; KNL-NEXT:    kandw %k0, %k3, %k0
-; KNL-NEXT:    kxorw %k1, %k0, %k0
-; KNL-NEXT:    kandw %k2, %k4, %k1
-; KNL-NEXT:    kandw %k0, %k1, %k1
-; KNL-NEXT:    vpternlogd {{.*#+}} zmm0 {%k1} {z} = -1
-; KNL-NEXT:    vpmovdb %zmm0, %xmm0
-; KNL-NEXT:    vzeroupper
+; KNL-NEXT:    vandps %xmm1, %xmm2, %xmm3
+; KNL-NEXT:    vandnps %xmm0, %xmm3, %xmm3
+; KNL-NEXT:    vandps %xmm0, %xmm1, %xmm4
+; KNL-NEXT:    vandps %xmm1, %xmm4, %xmm5
+; KNL-NEXT:    vandps %xmm5, %xmm3, %xmm3
+; KNL-NEXT:    vandps %xmm0, %xmm3, %xmm0
+; KNL-NEXT:    vxorps %xmm1, %xmm0, %xmm0
+; KNL-NEXT:    vandps %xmm2, %xmm4, %xmm1
+; KNL-NEXT:    vandps %xmm0, %xmm1, %xmm0
 ; KNL-NEXT:    retq
 ;
 ; SKX-LABEL: test_v16i1_select_chain:
 ; SKX:       ## %bb.0:
-; SKX-NEXT:    vpsllw $7, %xmm0, %xmm0
-; SKX-NEXT:    vpmovb2m %xmm0, %k0
-; SKX-NEXT:    vpsllw $7, %xmm1, %xmm0
-; SKX-NEXT:    vpmovb2m %xmm0, %k1
-; SKX-NEXT:    vpsllw $7, %xmm2, %xmm0
-; SKX-NEXT:    vpmovb2m %xmm0, %k2
-; SKX-NEXT:    kandw %k1, %k2, %k3
-; SKX-NEXT:    kandnw %k0, %k3, %k3
-; SKX-NEXT:    kandw %k0, %k1, %k4
-; SKX-NEXT:    kandw %k1, %k4, %k5
-; SKX-NEXT:    kandw %k5, %k3, %k3
-; SKX-NEXT:    kandw %k0, %k3, %k0
-; SKX-NEXT:    kxorw %k1, %k0, %k0
-; SKX-NEXT:    kandw %k2, %k4, %k1
-; SKX-NEXT:    kandw %k0, %k1, %k0
-; SKX-NEXT:    vpmovm2b %k0, %xmm0
+; SKX-NEXT:    vmovdqa %xmm0, %xmm3
+; SKX-NEXT:    vpternlogq {{.*#+}} xmm3 = xmm3 & ~(xmm2 & xmm1)
+; SKX-NEXT:    vpternlogq {{.*#+}} xmm3 = xmm3 & xmm0 & xmm1
+; SKX-NEXT:    vpternlogq {{.*#+}} xmm3 = xmm3 & xmm0 & xmm1
+; SKX-NEXT:    vpternlogq {{.*#+}} xmm3 = xmm1 & (xmm3 ^ xmm1)
+; SKX-NEXT:    vpternlogq {{.*#+}} xmm0 = xmm0 & xmm2 & xmm3
 ; SKX-NEXT:    retq
 ;
 ; AVX512BW-LABEL: test_v16i1_select_chain:
 ; AVX512BW:       ## %bb.0:
-; AVX512BW-NEXT:    vpsllw $7, %xmm0, %xmm0
-; AVX512BW-NEXT:    vpmovb2m %zmm0, %k0
-; AVX512BW-NEXT:    vpsllw $7, %xmm1, %xmm0
-; AVX512BW-NEXT:    vpmovb2m %zmm0, %k1
-; AVX512BW-NEXT:    vpsllw $7, %xmm2, %xmm0
-; AVX512BW-NEXT:    vpmovb2m %zmm0, %k2
-; AVX512BW-NEXT:    kandw %k1, %k2, %k3
-; AVX512BW-NEXT:    kandnw %k0, %k3, %k3
-; AVX512BW-NEXT:    kandw %k0, %k1, %k4
-; AVX512BW-NEXT:    kandw %k1, %k4, %k5
-; AVX512BW-NEXT:    kandw %k5, %k3, %k3
-; AVX512BW-NEXT:    kandw %k0, %k3, %k0
-; AVX512BW-NEXT:    kxorw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k4, %k1
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    vpmovm2b %k0, %zmm0
-; AVX512BW-NEXT:    ## kill: def $xmm0 killed $xmm0 killed $zmm0
-; AVX512BW-NEXT:    vzeroupper
+; AVX512BW-NEXT:    vandps %xmm1, %xmm2, %xmm3
+; AVX512BW-NEXT:    vandnps %xmm0, %xmm3, %xmm3
+; AVX512BW-NEXT:    vandps %xmm0, %xmm1, %xmm4
+; AVX512BW-NEXT:    vandps %xmm1, %xmm4, %xmm5
+; AVX512BW-NEXT:    vandps %xmm5, %xmm3, %xmm3
+; AVX512BW-NEXT:    vandps %xmm0, %xmm3, %xmm0
+; AVX512BW-NEXT:    vxorps %xmm1, %xmm0, %xmm0
+; AVX512BW-NEXT:    vandps %xmm2, %xmm4, %xmm1
+; AVX512BW-NEXT:    vandps %xmm0, %xmm1, %xmm0
 ; AVX512BW-NEXT:    retq
 ;
 ; AVX512DQ-LABEL: test_v16i1_select_chain:
 ; AVX512DQ:       ## %bb.0:
-; AVX512DQ-NEXT:    vpmovsxbd %xmm0, %zmm0
-; AVX512DQ-NEXT:    vpslld $31, %zmm0, %zmm0
-; AVX512DQ-NEXT:    vpmovd2m %zmm0, %k0
-; AVX512DQ-NEXT:    vpmovsxbd %xmm1, %zmm0
-; AVX512DQ-NEXT:    vpslld $31, %zmm0, %zmm0
-; AVX512DQ-NEXT:    vpmovd2m %zmm0, %k1
-; AVX512DQ-NEXT:    vpmovsxbd %xmm2, %zmm0
-; AVX512DQ-NEXT:    vpslld $31, %zmm0, %zmm0
-; AVX512DQ-NEXT:    vpmovd2m %zmm0, %k2
-; AVX512DQ-NEXT:    kandw %k1, %k2, %k3
-; AVX512DQ-NEXT:    kandnw %k0, %k3, %k3
-; AVX512DQ-NEXT:    kandw %k0, %k1, %k4
-; AVX512DQ-NEXT:    kandw %k1, %k4, %k5
-; AVX512DQ-NEXT:    kandw %k5, %k3, %k3
-; AVX512DQ-NEXT:    kandw %k0, %k3, %k0
-; AVX512DQ-NEXT:    kxorw %k1, %k0, %k0
-; AVX512DQ-NEXT:    kandw %k2, %k4, %k1
-; AVX512DQ-NEXT:    kandw %k0, %k1, %k0
-; AVX512DQ-NEXT:    vpmovm2d %k0, %zmm0
-; AVX512DQ-NEXT:    vpmovdb %zmm0, %xmm0
-; AVX512DQ-NEXT:    vzeroupper
+; AVX512DQ-NEXT:    vandps %xmm1, %xmm2, %xmm3
+; AVX512DQ-NEXT:    vandnps %xmm0, %xmm3, %xmm3
+; AVX512DQ-NEXT:    vandps %xmm0, %xmm1, %xmm4
+; AVX512DQ-NEXT:    vandps %xmm1, %xmm4, %xmm5
+; AVX512DQ-NEXT:    vandps %xmm5, %xmm3, %xmm3
+; AVX512DQ-NEXT:    vandps %xmm0, %xmm3, %xmm0
+; AVX512DQ-NEXT:    vxorps %xmm1, %xmm0, %xmm0
+; AVX512DQ-NEXT:    vandps %xmm2, %xmm4, %xmm1
+; AVX512DQ-NEXT:    vandps %xmm0, %xmm1, %xmm0
 ; AVX512DQ-NEXT:    retq
 ;
 ; X86-LABEL: test_v16i1_select_chain:
 ; X86:       ## %bb.0:
-; X86-NEXT:    vpsllw $7, %xmm0, %xmm0
-; X86-NEXT:    vpmovb2m %xmm0, %k0
-; X86-NEXT:    vpsllw $7, %xmm1, %xmm0
-; X86-NEXT:    vpmovb2m %xmm0, %k1
-; X86-NEXT:    vpsllw $7, %xmm2, %xmm0
-; X86-NEXT:    vpmovb2m %xmm0, %k2
-; X86-NEXT:    kandw %k1, %k2, %k3
-; X86-NEXT:    kandnw %k0, %k3, %k3
-; X86-NEXT:    kandw %k0, %k1, %k4
-; X86-NEXT:    kandw %k1, %k4, %k5
-; X86-NEXT:    kandw %k5, %k3, %k3
-; X86-NEXT:    kandw %k0, %k3, %k0
-; X86-NEXT:    kxorw %k1, %k0, %k0
-; X86-NEXT:    kandw %k2, %k4, %k1
-; X86-NEXT:    kandw %k0, %k1, %k0
-; X86-NEXT:    vpmovm2b %k0, %xmm0
+; X86-NEXT:    vmovdqa %xmm0, %xmm3
+; X86-NEXT:    vpternlogq {{.*#+}} xmm3 = xmm3 & ~(xmm2 & xmm1)
+; X86-NEXT:    vpternlogq {{.*#+}} xmm3 = xmm3 & xmm0 & xmm1
+; X86-NEXT:    vpternlogq {{.*#+}} xmm3 = xmm3 & xmm0 & xmm1
+; X86-NEXT:    vpternlogq {{.*#+}} xmm3 = xmm1 & (xmm3 ^ xmm1)
+; X86-NEXT:    vpternlogq {{.*#+}} xmm0 = xmm0 & xmm2 & xmm3
 ; X86-NEXT:    retl
   %i3 = select <16 x i1> %a2, <16 x i1> %a1, <16 x i1> zeroinitializer
   %i4  = xor <16 x i1> %i3, splat (i1 true)

--- a/llvm/test/CodeGen/X86/fold-select.ll
+++ b/llvm/test/CodeGen/X86/fold-select.ll
@@ -57,14 +57,9 @@ define <8 x float> @select_and_v8i1_3(<8 x i16> %m1, <8 x i16> %m2, <8 x i16> %m
 define <8 x float> @select_or_v8i1(<8 x i1> %a, <8 x i1> %b, <8 x i1> %c, <8 x float> %d) {
 ; CHECK-LABEL: select_or_v8i1:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpsllw $15, %xmm2, %xmm2
-; CHECK-NEXT:    vpmovw2m %xmm2, %k0
-; CHECK-NEXT:    vpsllw $15, %xmm1, %xmm1
-; CHECK-NEXT:    vpmovw2m %xmm1, %k1
+; CHECK-NEXT:    vpternlogq {{.*#+}} xmm0 = (xmm1 & ~xmm0) | xmm2
 ; CHECK-NEXT:    vpsllw $15, %xmm0, %xmm0
-; CHECK-NEXT:    vpmovw2m %xmm0, %k2
-; CHECK-NEXT:    kandnb %k1, %k2, %k1
-; CHECK-NEXT:    korb %k1, %k0, %k1
+; CHECK-NEXT:    vpmovw2m %xmm0, %k1
 ; CHECK-NEXT:    vbroadcastss {{.*#+}} ymm0 = [1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0]
 ; CHECK-NEXT:    vmovaps %ymm3, %ymm0 {%k1}
 ; CHECK-NEXT:    retq


### PR DESCRIPTION
Replace costly predicate logic when possible - generic 128/256/512 vector types are always cheaper

Part of #198162