### PR TITLE
[AArch64][llvm] Restrict STSHH decoding to valid policy encodings

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -1883,10 +1883,11 @@ def phint_op : Operand<i32> {
 class STSHHI
     : SimpleSystemI<0, (ins phint_op:$policy), "stshh", "\t$policy", []>,
       Sched<[WriteHint]> {
-  bits<3> policy;
+  bits<1> policy;
   let Inst{20-12} = 0b000110010;
   let Inst{11-8} = 0b0110;
-  let Inst{7-5} = policy;
+  let Inst{7-6} = 0b00;
+  let Inst{5} = policy;
 }
 
 // System instructions taking a single literal operand which encodes into


### PR DESCRIPTION
`STSHH` only uses the `op2 == 00x` encodings, where bit 5 selects the
keep/strm policy. The TableGen definition was modeling the whole `op2`
field as a 3-bit policy operand, which made the disassembler also match
`op2 == 110` and `op2 == 111`.

Constrain STSHH to `op2 == 00x` by making the policy operand one bit
wide and fixing bits 7:6 to zero. This will avoid decode clashes in
future if these bits are set.