### PR TITLE
[LLVM][ComplexDeinterleaving] Update identifyDeinterleave to support all forms of zero.

### DIFF
--- a/llvm/lib/CodeGen/ComplexDeinterleavingPass.cpp
+++ b/llvm/lib/CodeGen/ComplexDeinterleavingPass.cpp
@@ -2070,12 +2070,12 @@ ComplexDeinterleavingGraph::identifyDeinterleave(ComplexValues &Vals) {
   }
 
   Value *RealOp1 = RealShuffle->getOperand(1);
-  if (!isa<UndefValue>(RealOp1) && !isa<ConstantAggregateZero>(RealOp1)) {
+  if (!isa<UndefValue>(RealOp1) && !match(RealOp1, m_Zero())) {
     LLVM_DEBUG(dbgs() << " - RealOp1 is not undef or zero.\n");
     return nullptr;
   }
   Value *ImagOp1 = ImagShuffle->getOperand(1);
-  if (!isa<UndefValue>(ImagOp1) && !isa<ConstantAggregateZero>(ImagOp1)) {
+  if (!isa<UndefValue>(ImagOp1) && !match(ImagOp1, m_Zero())) {
     LLVM_DEBUG(dbgs() << " - ImagOp1 is not undef or zero.\n");
     return nullptr;
   }

--- a/llvm/test/CodeGen/AArch64/complex-deinterleaving-f32-add.ll
+++ b/llvm/test/CodeGen/AArch64/complex-deinterleaving-f32-add.ll
@@ -80,13 +80,7 @@ entry:
 define <2 x float> @complex_add_v2f32_no_CAZ(<2 x float> %a, <2 x float> %b) {
 ; CHECK-LABEL: complex_add_v2f32_no_CAZ:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    // kill: def $d1 killed $d1 def $q1
-; CHECK-NEXT:    // kill: def $d0 killed $d0 def $q0
-; CHECK-NEXT:    dup v2.2s, v0.s[1]
-; CHECK-NEXT:    dup v3.2s, v1.s[1]
-; CHECK-NEXT:    fsub v1.2s, v1.2s, v2.2s
-; CHECK-NEXT:    fadd v0.2s, v3.2s, v0.2s
-; CHECK-NEXT:    zip1 v0.2s, v1.2s, v0.2s
+; CHECK-NEXT:    fcadd v0.2s, v1.2s, v0.2s, #90
 ; CHECK-NEXT:    ret
 entry:
   %a.real = shufflevector <2 x float> %a, <2 x float> splat (float +0.0), <1 x i32> <i32 0>

--- a/llvm/test/CodeGen/AArch64/complex-deinterleaving-f32-add.ll
+++ b/llvm/test/CodeGen/AArch64/complex-deinterleaving-f32-add.ll
@@ -75,3 +75,26 @@ entry:
   %interleaved.vec = shufflevector <8 x float> %0, <8 x float> %1, <16 x i32> <i32 0, i32 8, i32 1, i32 9, i32 2, i32 10, i32 3, i32 11, i32 4, i32 12, i32 5, i32 13, i32 6, i32 14, i32 7, i32 15>
   ret <16 x float> %interleaved.vec
 }
+
+; A variant of complex_add_v2f32 that uses ConstantFP(0.0) rather than ConstantAggregateZero.
+define <2 x float> @complex_add_v2f32_no_CAZ(<2 x float> %a, <2 x float> %b) {
+; CHECK-LABEL: complex_add_v2f32_no_CAZ:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    // kill: def $d1 killed $d1 def $q1
+; CHECK-NEXT:    // kill: def $d0 killed $d0 def $q0
+; CHECK-NEXT:    dup v2.2s, v0.s[1]
+; CHECK-NEXT:    dup v3.2s, v1.s[1]
+; CHECK-NEXT:    fsub v1.2s, v1.2s, v2.2s
+; CHECK-NEXT:    fadd v0.2s, v3.2s, v0.2s
+; CHECK-NEXT:    zip1 v0.2s, v1.2s, v0.2s
+; CHECK-NEXT:    ret
+entry:
+  %a.real = shufflevector <2 x float> %a, <2 x float> splat (float +0.0), <1 x i32> <i32 0>
+  %a.imag = shufflevector <2 x float> %a, <2 x float> splat (float +0.0), <1 x i32> <i32 1>
+  %b.real = shufflevector <2 x float> %b, <2 x float> splat (float +0.0), <1 x i32> <i32 0>
+  %b.imag = shufflevector <2 x float> %b, <2 x float> splat (float +0.0), <1 x i32> <i32 1>
+  %0 = fsub fast <1 x float> %b.real, %a.imag
+  %1 = fadd fast <1 x float> %b.imag, %a.real
+  %interleaved.vec = shufflevector <1 x float> %0, <1 x float> %1, <2 x i32> <i32 0, i32 1>
+  ret <2 x float> %interleaved.vec
+}


### PR DESCRIPTION
The original code misses ConstantFP based zeros.