### PR TITLE
[lldb][windows] copy vcpkg runtime dlls

### DIFF
--- a/lldb/bindings/python/CMakeLists.txt
+++ b/lldb/bindings/python/CMakeLists.txt
@@ -157,6 +157,8 @@ function(finish_swig_python swig_target lldb_python_bindings_dir lldb_python_tar
   create_relative_symlink(${swig_target} ${LIBLLDB_SYMLINK_DEST}
                           ${lldb_python_target_dir}/native/ ${LIBLLDB_SYMLINK_OUTPUT_FILE})
 
+  # On Windows, DLLs must reside alongside the .pyd extension so the loader finds them.
+  # Without this, importing _lldb fails at runtime when vcpkg-provided DLLs are not on PATH.
   if(WIN32 AND DEFINED VCPKG_INSTALLED_DIR AND DEFINED VCPKG_TARGET_TRIPLET)
     file(GLOB _lldb_vcpkg_runtime_dlls
       "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/*.dll")

--- a/lldb/bindings/python/CMakeLists.txt
+++ b/lldb/bindings/python/CMakeLists.txt
@@ -157,6 +157,16 @@ function(finish_swig_python swig_target lldb_python_bindings_dir lldb_python_tar
   create_relative_symlink(${swig_target} ${LIBLLDB_SYMLINK_DEST}
                           ${lldb_python_target_dir}/native/ ${LIBLLDB_SYMLINK_OUTPUT_FILE})
 
+  if(WIN32 AND DEFINED VCPKG_INSTALLED_DIR AND DEFINED VCPKG_TARGET_TRIPLET)
+    file(GLOB _lldb_vcpkg_runtime_dlls
+      "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/*.dll")
+    if(_lldb_vcpkg_runtime_dlls)
+      add_custom_command(TARGET ${swig_target} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+          ${_lldb_vcpkg_runtime_dlls} "${lldb_python_target_dir}/native/"
+        COMMENT "Staging vcpkg runtime DLLs next to _lldb.pyd")
+    endif()
+  endif()
 
   if (NOT WIN32)
   add_dependencies(${swig_target} lldb-python-wrapper)


### PR DESCRIPTION
When liblldb is built against vcpkg supplied libraries `(libxml2 and zlib)` on Windows, importing `_lldb` fails with "DLL load failed" because Python 3.8+ loads extensions with `LOAD_LIBRARY_SEARCH_DEFAULT_DIRS`, which excludes `PATH`. 

This patch copies the vcpkg runtime DLLs next to `_lldb.pyd` so the loader finds them.

 This is currently causing https://ci-external.swift.org/job/lldb-windows/job/main/ to fail.

This error can be reproduced at desk with the following CMake flags:
`-DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake" -DLLDB_ENABLE_LIBXML2=ON`

rdar://178245824