### PR TITLE
[Flang] Fix runtime module file dependency on tests

### DIFF
--- a/flang-rt/cmake/modules/AddFlangRT.cmake
+++ b/flang-rt/cmake/modules/AddFlangRT.cmake
@@ -298,10 +298,12 @@ function (add_flangrt_library name)
     if ("${LLVM_DEFAULT_TARGET_TRIPLE}" MATCHES "^amdgcn")
       target_compile_options(${tgtname} PRIVATE
           $<$<COMPILE_LANGUAGE:CXX>:-nogpulib -flto -fvisibility=hidden>
+          $<$<COMPILE_LANGUAGE:Fortran>:-nogpulib -flto>
         )
     elseif ("${LLVM_DEFAULT_TARGET_TRIPLE}" MATCHES "^nvptx")
       target_compile_options(${tgtname} PRIVATE
           $<$<COMPILE_LANGUAGE:CXX>:-nogpulib -flto -fvisibility=hidden -Wno-unknown-cuda-version --cuda-feature=+ptx63>
+          $<$<COMPILE_LANGUAGE:Fortran>:-nogpulib -flto>
         )
     elseif (APPLE)
       # Clang on Darwin enables non-POSIX extensions by default.

--- a/flang/test/CMakeLists.txt
+++ b/flang/test/CMakeLists.txt
@@ -121,13 +121,8 @@ if (LLVM_INCLUDE_EXAMPLES)
 endif ()
 
 if ("flang-rt" IN_LIST LLVM_ENABLE_RUNTIMES AND NOT FLANG_STANDALONE_BUILD)
-  # For intrinsic module files (in flang-rt/)
-  list(APPEND FLANG_TEST_DEPENDS "flang-rt-mod")
-
-  if ("openmp" IN_LIST LLVM_ENABLE_RUNTIMES)
-    # For omplib.mod and omplib_kinds.mod (in openmp/)
-    list(APPEND FLANG_TEST_DEPENDS "libomp-mod")
-  endif ()
+  # Flang tests need runtimes module files (flang-rt-mod, libomp-mod, etc.).
+  set_property(GLOBAL APPEND PROPERTY LLVM_TEST_DEPENDS_ON_RUNTIMES check-flang)
 endif ()
 
 add_custom_target(flang-test-depends DEPENDS ${FLANG_TEST_DEPENDS})

--- a/flang/test/CMakeLists.txt
+++ b/flang/test/CMakeLists.txt
@@ -122,7 +122,8 @@ endif ()
 
 if ("flang-rt" IN_LIST LLVM_ENABLE_RUNTIMES AND NOT FLANG_STANDALONE_BUILD)
   # Flang tests need runtimes module files (flang-rt-mod, libomp-mod, etc.).
-  set_property(GLOBAL APPEND PROPERTY LLVM_TEST_DEPENDS_ON_RUNTIMES check-flang)
+  add_custom_target(flang-rt-test-deps)
+  list(APPEND FLANG_TEST_DEPENDS flang-rt-test-deps)
 endif ()
 
 add_custom_target(flang-test-depends DEPENDS ${FLANG_TEST_DEPENDS})

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1465,14 +1465,6 @@ if( LLVM_INCLUDE_TESTS )
   endif()
   set_target_properties(test-depends PROPERTIES FOLDER "LLVM/Tests")
   add_dependencies(check-all test-depends)
-
-  # Projects that need runtimes for their tests (e.g. flang needs flang-rt).
-  get_property(runtimes_test_consumers GLOBAL PROPERTY LLVM_TEST_DEPENDS_ON_RUNTIMES)
-  foreach(target ${runtimes_test_consumers})
-    if (TARGET ${target})
-      add_dependencies(${target} test-depends)
-    endif()
-  endforeach()
 endif()
 
 if (LLVM_INCLUDE_DOCS)

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1465,6 +1465,14 @@ if( LLVM_INCLUDE_TESTS )
   endif()
   set_target_properties(test-depends PROPERTIES FOLDER "LLVM/Tests")
   add_dependencies(check-all test-depends)
+
+  # Projects that need runtimes for their tests (e.g. flang needs flang-rt).
+  get_property(runtimes_test_consumers GLOBAL PROPERTY LLVM_TEST_DEPENDS_ON_RUNTIMES)
+  foreach(target ${runtimes_test_consumers})
+    if (TARGET ${target})
+      add_dependencies(${target} test-depends)
+    endif()
+  endforeach()
 endif()
 
 if (LLVM_INCLUDE_DOCS)

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -801,6 +801,16 @@ ${_flag_values}\
 
     set_property(GLOBAL APPEND PROPERTY LLVM_ALL_ADDITIONAL_TEST_TARGETS runtimes ${extra_deps})
   endif()
+
+  # Flang tests depend on module files built by the runtimes.
+  if (TARGET flang-rt-test-deps)
+    if (TARGET flang-rt-mod)
+      add_dependencies(flang-rt-test-deps flang-rt-mod)
+    endif ()
+    if (TARGET libomp-mod)
+      add_dependencies(flang-rt-test-deps libomp-mod)
+    endif ()
+  endif ()
 endif()
 
 if(LIBOMP_ENABLE_ARM64X)


### PR DESCRIPTION
Summary:
Ever since https://github.com/llvm/llvm-project/pull/171515 we now build
the moduel files in the runtime step. This is problematic because pretty
much all of the tests depend on them. The current dependency chain
doesn't work correctly because the dependencies are set much later.

This fix just adds a global property so that we can set these
out-of-order and sets that property to depend on all the runtime tests.

Flang now becomes the only test suite who depends on the runtimes like
this, every other project's test suite is hermetic. However, moving
pretty much every flang test to flang-rt isn't ideal. We can investigate
this in depth later but for now this fixes the build.
