### PR TITLE
[IR] SubclassOptionalData is only optional for Instruction

### DIFF
--- a/llvm/include/llvm/IR/FMF.h
+++ b/llvm/include/llvm/IR/FMF.h
@@ -27,10 +27,7 @@ private:
   unsigned Flags = 0;
 
 public:
-  // This is how the bits are used in Value::SubclassOptionalData so they
-  // should fit there too.
-  // WARNING: We're out of space. SubclassOptionalData only has 7 bits. New
-  // functionality will require a change in how this information is stored.
+  /// Flag bits.
   enum {
     AllowReassoc    = (1 << 0),
     NoNaNs          = (1 << 1),

--- a/llvm/include/llvm/IR/Instruction.h
+++ b/llvm/include/llvm/IR/Instruction.h
@@ -550,9 +550,7 @@ public:
   LLVM_ABI const DebugLoc &getStableDebugLoc() const;
 
   /// Clear the optional flags contained in this instruction.
-  void clearSubclassOptionalData() {
-    SubclassOptionalData = 0;
-  }
+  void clearSubclassOptionalData() { SubclassOptionalData = 0; }
 
   /// Set or clear the nuw flag on this instruction, which must be an operator
   /// which supports this flag. See LangRef.html for the meaning of this flag.

--- a/llvm/include/llvm/IR/Instruction.h
+++ b/llvm/include/llvm/IR/Instruction.h
@@ -549,6 +549,11 @@ public:
   /// in which case fetch the debug location of the next non-debug node.
   LLVM_ABI const DebugLoc &getStableDebugLoc() const;
 
+  /// Clear the optional flags contained in this instruction.
+  void clearSubclassOptionalData() {
+    SubclassOptionalData = 0;
+  }
+
   /// Set or clear the nuw flag on this instruction, which must be an operator
   /// which supports this flag. See LangRef.html for the meaning of this flag.
   LLVM_ABI void setHasNoUnsignedWrap(bool b = true);

--- a/llvm/include/llvm/IR/Instruction.h
+++ b/llvm/include/llvm/IR/Instruction.h
@@ -549,9 +549,6 @@ public:
   /// in which case fetch the debug location of the next non-debug node.
   LLVM_ABI const DebugLoc &getStableDebugLoc() const;
 
-  /// Clear the optional flags contained in this instruction.
-  void clearSubclassOptionalData() { SubclassOptionalData = 0; }
-
   /// Set or clear the nuw flag on this instruction, which must be an operator
   /// which supports this flag. See LangRef.html for the meaning of this flag.
   LLVM_ABI void setHasNoUnsignedWrap(bool b = true);

--- a/llvm/include/llvm/IR/Operator.h
+++ b/llvm/include/llvm/IR/Operator.h
@@ -88,10 +88,12 @@ private:
   friend class ConstantExpr;
 
   void setHasNoUnsignedWrap(bool B) {
+    assert(isa<Instruction>(this) && "cannot modify ConstantExpr");
     SubclassOptionalData =
       (SubclassOptionalData & ~NoUnsignedWrap) | (B * NoUnsignedWrap);
   }
   void setHasNoSignedWrap(bool B) {
+    assert(isa<Instruction>(this) && "cannot modify ConstantExpr");
     SubclassOptionalData =
       (SubclassOptionalData & ~NoSignedWrap) | (B * NoSignedWrap);
   }

--- a/llvm/include/llvm/IR/Value.h
+++ b/llvm/include/llvm/IR/Value.h
@@ -77,11 +77,11 @@ class Value {
   unsigned char HasValueHandle : 1; // Has a ValueHandle pointing to this?
 
 protected:
-  /// Hold subclass data that can be dropped.
+  /// Hold arbitary subclass data.
   ///
-  /// This member is similar to SubclassData, however it is for holding
-  /// information which may be used to aid optimization, but which may be
-  /// cleared to zero without affecting conservative interpretation.
+  /// This member is similar to SubclassData, however it is often used for
+  /// holding information which may be used to aid optimization, but which may
+  /// be cleared to zero without affecting conservative interpretation.
   unsigned char SubclassOptionalData : 7;
 
 private:
@@ -549,16 +549,6 @@ public:
   /// This should only be used when testing two Values for equivalence.
   unsigned getRawSubclassOptionalData() const {
     return SubclassOptionalData;
-  }
-
-  /// Clear the optional flags contained in this value.
-  void clearSubclassOptionalData() {
-    SubclassOptionalData = 0;
-  }
-
-  /// Check the optional flags for equality.
-  bool hasSameSubclassOptionalData(const Value *V) const {
-    return SubclassOptionalData == V->SubclassOptionalData;
   }
 
   /// Return true if there is a value handle associated with this value.

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -398,21 +398,6 @@ static bool hasNoSignedWrap(BinaryOperator &I) {
   return OBO && OBO->hasNoSignedWrap();
 }
 
-/// Conservatively clears subclassOptionalData after a reassociation or
-/// commutation. We preserve fast-math flags when applicable as they can be
-/// preserved.
-static void ClearSubclassDataAfterReassociation(BinaryOperator &I) {
-  FPMathOperator *FPMO = dyn_cast<FPMathOperator>(&I);
-  if (!FPMO) {
-    I.clearSubclassOptionalData();
-    return;
-  }
-
-  FastMathFlags FMF = I.getFastMathFlags();
-  I.clearSubclassOptionalData();
-  I.setFastMathFlags(FMF);
-}
-
 /// Combine constant operands of associative operations either before or after a
 /// cast to eliminate one of the associative operations:
 /// (op (cast (op X, C2)), C1) --> (cast (op X, op (C1, C2)))
@@ -543,15 +528,15 @@ bool InstCombinerImpl::SimplifyAssociativeOrCommutative(BinaryOperator &I) {
           // Conservatively clear all optional flags since they may not be
           // preserved by the reassociation. Reset nsw/nuw based on the above
           // analysis.
-          ClearSubclassDataAfterReassociation(I);
+          if (auto *PDI = dyn_cast<PossiblyDisjointInst>(&I))
+            PDI->setIsDisjoint(false);
 
           // Note: this is only valid because SimplifyBinOp doesn't look at
           // the operands to Op0.
-          if (IsNUW)
-            I.setHasNoUnsignedWrap(true);
-
-          if (IsNSW)
-            I.setHasNoSignedWrap(true);
+          if (isa<OverflowingBinaryOperator>(I)) {
+            I.setHasNoUnsignedWrap(IsNUW);
+            I.setHasNoSignedWrap(IsNSW);
+          }
 
           Changed = true;
           ++NumReassoc;
@@ -572,7 +557,8 @@ bool InstCombinerImpl::SimplifyAssociativeOrCommutative(BinaryOperator &I) {
           replaceOperand(I, 1, C);
           // Conservatively clear the optional flags, since they may not be
           // preserved by the reassociation.
-          ClearSubclassDataAfterReassociation(I);
+          if (!isa<FPMathOperator>(I))
+            I.dropPoisonGeneratingFlags();
           Changed = true;
           ++NumReassoc;
           continue;
@@ -600,7 +586,8 @@ bool InstCombinerImpl::SimplifyAssociativeOrCommutative(BinaryOperator &I) {
           replaceOperand(I, 1, B);
           // Conservatively clear the optional flags, since they may not be
           // preserved by the reassociation.
-          ClearSubclassDataAfterReassociation(I);
+          if (!isa<FPMathOperator>(I))
+            I.dropPoisonGeneratingFlags();
           Changed = true;
           ++NumReassoc;
           continue;
@@ -620,7 +607,8 @@ bool InstCombinerImpl::SimplifyAssociativeOrCommutative(BinaryOperator &I) {
           replaceOperand(I, 1, V);
           // Conservatively clear the optional flags, since they may not be
           // preserved by the reassociation.
-          ClearSubclassDataAfterReassociation(I);
+          if (!isa<FPMathOperator>(I))
+            I.dropPoisonGeneratingFlags();
           Changed = true;
           ++NumReassoc;
           continue;
@@ -655,7 +643,8 @@ bool InstCombinerImpl::SimplifyAssociativeOrCommutative(BinaryOperator &I) {
         replaceOperand(I, 1, CRes);
         // Conservatively clear the optional flags, since they may not be
         // preserved by the reassociation.
-        ClearSubclassDataAfterReassociation(I);
+        if (!isa<FPMathOperator>(I))
+          I.dropPoisonGeneratingFlags();
         if (IsNUW)
           I.setHasNoUnsignedWrap(true);
 

--- a/llvm/lib/Transforms/Scalar/Reassociate.cpp
+++ b/llvm/lib/Transforms/Scalar/Reassociate.cpp
@@ -731,9 +731,7 @@ void ReassociatePass::RewriteExprTree(BinaryOperator *I,
       // Preserve flags.
       if (ClearFlags) {
         if (isa<FPMathOperator>(I)) {
-          FastMathFlags Flags = I->getFastMathFlags();
-          ExpressionChangedStart->clearSubclassOptionalData();
-          ExpressionChangedStart->setFastMathFlags(Flags);
+          ExpressionChangedStart->copyFastMathFlags(I->getFastMathFlags());
         } else {
           Flags.applyFlags(*ExpressionChangedStart);
         }

--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -4087,7 +4087,7 @@ void OverflowTracking::mergeFlags(Instruction &I) {
 }
 
 void OverflowTracking::applyFlags(Instruction &I) {
-  I.clearSubclassOptionalData();
+  I.dropPoisonGeneratingFlags();
   if (I.getOpcode() == Instruction::Add ||
       (I.getOpcode() == Instruction::Mul && AllKnownNonZero)) {
     if (HasNUW)


### PR DESCRIPTION
BasicBlock currently uses this for HasAddressTaken. ConstantExpr uses
this for flags and it should not be possible to modify constant
expressions after they have been created.

Therefore, update the documentation accordingly and remove the unsafe
clearSubclassOptionalData.

Remove hasSameSubclassOptionalData, as it is unused.
