### PR TITLE
[PowerPC] Add patterns for atomic load with immediates

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -13154,7 +13154,8 @@ MachineBasicBlock *PPCTargetLowering::EmitAtomicBinary(MachineInstr &MI,
   Register dest = MI.getOperand(0).getReg();
   Register ptrA = MI.getOperand(1).getReg();
   Register ptrB = MI.getOperand(2).getReg();
-  Register incr = MI.getOperand(4).isReg() ? MI.getOperand(4).getReg() : PPC::ZERO;
+  Register incr =
+      MI.getOperand(4).isReg() ? MI.getOperand(4).getReg() : PPC::ZERO;
   int64_t imm = MI.getOperand(4).isImm() ? MI.getOperand(4).getImm() : 0;
   DebugLoc dl = MI.getDebugLoc();
 
@@ -13188,9 +13189,10 @@ MachineBasicBlock *PPCTargetLowering::EmitAtomicBinary(MachineInstr &MI,
   exitMBB->transferSuccessorsAndUpdatePHIs(BB);
 
   MachineRegisterInfo &RegInfo = F->getRegInfo();
-  Register TmpReg = (!BinOpcode) ? incr :
-    RegInfo.createVirtualRegister( AtomicSizeLog == 3 ? &PPC::G8RCRegClass
-                                           : &PPC::GPRCRegClass);
+  Register TmpReg = (!BinOpcode) ? incr
+                                 : RegInfo.createVirtualRegister(
+                                       AtomicSizeLog == 3 ? &PPC::G8RCRegClass
+                                                          : &PPC::GPRCRegClass);
 
   //  thisMBB:
   //   ...
@@ -13215,8 +13217,7 @@ MachineBasicBlock *PPCTargetLowering::EmitAtomicBinary(MachineInstr &MI,
   //   fallthrough --> exitMBB
 
   BB = loopMBB;
-  BuildMI(BB, dl, TII->get(LoadMnemonic), dest)
-    .addReg(ptrA).addReg(ptrB);
+  BuildMI(BB, dl, TII->get(LoadMnemonic), dest).addReg(ptrA).addReg(ptrB);
   if (BinOpcode) {
     if (imm)
       BuildMI(BB, dl, TII->get(BinOpcode), TmpReg).addReg(dest).addImm(imm);
@@ -13229,7 +13230,8 @@ MachineBasicBlock *PPCTargetLowering::EmitAtomicBinary(MachineInstr &MI,
     if (CmpOpcode == PPC::CMPW && AtomicSizeLog < 2) {
       Register ExtReg = RegInfo.createVirtualRegister(&PPC::GPRCRegClass);
       BuildMI(BB, dl, TII->get(AtomicSizeLog == 0 ? PPC::EXTSB : PPC::EXTSH),
-              ExtReg).addReg(dest);
+              ExtReg)
+          .addReg(dest);
       BuildMI(BB, dl, TII->get(CmpOpcode), CrReg).addReg(ExtReg).addReg(incr);
     } else
       BuildMI(BB, dl, TII->get(CmpOpcode), CrReg).addReg(dest).addReg(incr);

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -13132,45 +13132,48 @@ MachineBasicBlock *PPCTargetLowering::EmitAtomicBinary(MachineInstr &MI,
   // CmpOpcode != 0: Handles atomic load with MIN/MAX etc.
   // BinOpcode == 0 && CmpOpcode == 0: Handles ATOMIC_SWAP.
   const PPCInstrInfo *TII = Subtarget.getInstrInfo();
-  unsigned AtomicSize = MI.getOperand(3).getImm();
+  // Log2 of the byte size.
+  unsigned AtomicSizeLog = MI.getOperand(3).getImm();
+  assert(AtomicSizeLog < 4 && "log2 of byte size too large");
 
-  auto LoadMnemonic = PPC::LDARX;
-  auto StoreMnemonic = PPC::STDCX;
-  switch (AtomicSize) {
-  default:
-    llvm_unreachable("Unexpected size of atomic entity");
-  case 1:
-    LoadMnemonic = PPC::LBARX;
-    StoreMnemonic = PPC::STBCX;
-    assert(Subtarget.hasPartwordAtomics() && "Call this only with size >=4");
-    break;
-  case 2:
-    LoadMnemonic = PPC::LHARX;
-    StoreMnemonic = PPC::STHCX;
-    assert(Subtarget.hasPartwordAtomics() && "Call this only with size >=4");
-    break;
-  case 4:
-    LoadMnemonic = PPC::LWARX;
-    StoreMnemonic = PPC::STWCX;
-    break;
-  case 8:
-    LoadMnemonic = PPC::LDARX;
-    StoreMnemonic = PPC::STDCX;
-    break;
-  }
+  static const unsigned LoadOpc[] = {PPC::LBARX, PPC::LHARX, PPC::LWARX,
+                                     PPC::LDARX};
+  static const unsigned StoreOpc[] = {PPC::STBCX, PPC::STHCX, PPC::STWCX,
+                                      PPC::STDCX};
+
+  auto LoadMnemonic = LoadOpc[AtomicSizeLog];
+  auto StoreMnemonic = StoreOpc[AtomicSizeLog];
 
   const BasicBlock *LLVM_BB = BB->getBasicBlock();
   MachineFunction *F = BB->getParent();
   MachineFunction::iterator It = ++BB->getIterator();
 
-  if (CmpOpcode == PPC::CMPW && (AtomicSize == 1 || AtomicSize == 2))
-    signExtendOperandIfUnknown(MI, BB, 4, /*IsByte=*/AtomicSize == 1, TII);
+  if (CmpOpcode == PPC::CMPW && AtomicSizeLog < 2)
+    signExtendOperandIfUnknown(MI, BB, 4, /*IsByte=*/AtomicSizeLog == 0, TII);
 
   Register dest = MI.getOperand(0).getReg();
   Register ptrA = MI.getOperand(1).getReg();
   Register ptrB = MI.getOperand(2).getReg();
-  Register incr = MI.getOperand(4).getReg();
+  Register incr = MI.getOperand(4).isReg() ? MI.getOperand(4).getReg() : PPC::ZERO;
+  int64_t imm = MI.getOperand(4).isImm() ? MI.getOperand(4).getImm() : 0;
   DebugLoc dl = MI.getDebugLoc();
+
+  // Change opcode if there is an immediate.
+  if (imm) {
+    switch (BinOpcode) {
+    case PPC::AND:
+      BinOpcode = PPC::ANDI_rec;
+      break;
+    case PPC::OR:
+      BinOpcode = PPC::ORI;
+      break;
+    case PPC::XOR:
+      BinOpcode = PPC::XORI;
+      break;
+    default:
+      llvm_unreachable("Unexpected opcode with imm");
+    }
+  }
 
   MachineBasicBlock *loopMBB = F->CreateMachineBasicBlock(LLVM_BB);
   MachineBasicBlock *loop2MBB =
@@ -13186,7 +13189,7 @@ MachineBasicBlock *PPCTargetLowering::EmitAtomicBinary(MachineInstr &MI,
 
   MachineRegisterInfo &RegInfo = F->getRegInfo();
   Register TmpReg = (!BinOpcode) ? incr :
-    RegInfo.createVirtualRegister( AtomicSize == 8 ? &PPC::G8RCRegClass
+    RegInfo.createVirtualRegister( AtomicSizeLog == 3 ? &PPC::G8RCRegClass
                                            : &PPC::GPRCRegClass);
 
   //  thisMBB:
@@ -13214,14 +13217,18 @@ MachineBasicBlock *PPCTargetLowering::EmitAtomicBinary(MachineInstr &MI,
   BB = loopMBB;
   BuildMI(BB, dl, TII->get(LoadMnemonic), dest)
     .addReg(ptrA).addReg(ptrB);
-  if (BinOpcode)
-    BuildMI(BB, dl, TII->get(BinOpcode), TmpReg).addReg(incr).addReg(dest);
+  if (BinOpcode) {
+    if (imm)
+      BuildMI(BB, dl, TII->get(BinOpcode), TmpReg).addReg(dest).addImm(imm);
+    else
+      BuildMI(BB, dl, TII->get(BinOpcode), TmpReg).addReg(incr).addReg(dest);
+  }
   if (CmpOpcode) {
     Register CrReg = RegInfo.createVirtualRegister(&PPC::CRRCRegClass);
     // Signed comparisons of byte or halfword values must be sign-extended.
-    if (CmpOpcode == PPC::CMPW && AtomicSize < 4) {
+    if (CmpOpcode == PPC::CMPW && AtomicSizeLog < 2) {
       Register ExtReg = RegInfo.createVirtualRegister(&PPC::GPRCRegClass);
-      BuildMI(BB, dl, TII->get(AtomicSize == 1 ? PPC::EXTSB : PPC::EXTSH),
+      BuildMI(BB, dl, TII->get(AtomicSizeLog == 0 ? PPC::EXTSB : PPC::EXTSH),
               ExtReg).addReg(dest);
       BuildMI(BB, dl, TII->get(CmpOpcode), CrReg).addReg(ExtReg).addReg(incr);
     } else
@@ -13342,7 +13349,7 @@ MachineBasicBlock *PPCTargetLowering::EmitPartwordAtomicBinary(
   DebugLoc dl = MI.getDebugLoc();
   MachineFunction *F = BB->getParent();
   MachineRegisterInfo &RegInfo = F->getRegInfo();
-  const bool is8bit = MI.getOperand(3).getImm() == 1;
+  const bool is8bit = MI.getOperand(3).getImm() == 0;
   if (CmpOpcode == PPC::CMPW)
     signExtendOperandIfUnknown(MI, BB, 4, is8bit, TII);
   Register incr = MI.getOperand(4).getReg();
@@ -14513,6 +14520,7 @@ PPCTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
     BB = EmitPartwordAtomicBinary(MI, BB, PPC::AND);
     break;
   case PPC::ATOMIC_LOAD_AND:
+  case PPC::ATOMIC_LOAD_AND_IMM:
     BB = EmitAtomicBinary(MI, BB, PPC::AND);
     break;
   case PPC::ATOMIC_LOAD_AND_I64:
@@ -14522,6 +14530,7 @@ PPCTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
     BB = EmitPartwordAtomicBinary(MI, BB, PPC::OR);
     break;
   case PPC::ATOMIC_LOAD_OR:
+  case PPC::ATOMIC_LOAD_OR_IMM:
     BB = EmitAtomicBinary(MI, BB, PPC::OR);
     break;
   case PPC::ATOMIC_LOAD_OR_I64:
@@ -14531,6 +14540,7 @@ PPCTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
     BB = EmitPartwordAtomicBinary(MI, BB, PPC::XOR);
     break;
   case PPC::ATOMIC_LOAD_XOR:
+  case PPC::ATOMIC_LOAD_XOR_IMM:
     BB = EmitAtomicBinary(MI, BB, PPC::XOR);
     break;
   case PPC::ATOMIC_LOAD_XOR_I64:

--- a/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
+++ b/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
@@ -303,7 +303,7 @@ foreach op = ["load_add", "load_sub", "load_and", "load_or", "load_xor",
         (outs g8rc:$dst), (ins memrr:$ptr, i32imm:$sz, g8rc:$incr),
         "#" # NAME, []>;
   def : Pat<(i64 (pat ForceXForm:$ptr, g8rc:$incr)),
-          (!cast<Instruction>(pseudo) memrr:$ptr, 8, g8rc:$incr)>;
+          (!cast<Instruction>(pseudo) memrr:$ptr, 3, g8rc:$incr)>;
 }
 
 let Defs = [CR0] in

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.td
@@ -2073,14 +2073,30 @@ foreach op = ["load_add", "load_sub", "load_and", "load_or", "load_xor",
   foreach bitsz = [8, 16] in {
     defvar pat = !cast<PatFrag>(!tolower(atomic_load)#"_i"#bitsz);
     def : Pat<(i32 (pat ForceXForm:$ptr, gprc:$incr)),
-            (!cast<Instruction>(atomic_load) memrr:$ptr, !div(bitsz, 8), gprc:$incr)>,
+            (!cast<Instruction>(atomic_load) memrr:$ptr, !logtwo(!div(bitsz, 8)), gprc:$incr)>,
             Requires<[HasPartwordAtomics]>;
     def : Pat<(i32 (pat ForceXForm:$ptr, gprc:$incr)),
-            (!cast<Instruction>(atomic_load_nowp) memrr:$ptr, !div(bitsz, 8), gprc:$incr)>;
+            (!cast<Instruction>(atomic_load_nowp) memrr:$ptr, !logtwo(!div(bitsz, 8)), gprc:$incr)>;
   }
   defvar pat = !cast<PatFrag>(!tolower(atomic_load)#"_i32");
   def : Pat<(i32 (pat ForceXForm:$ptr, gprc:$incr)),
-          (!cast<Instruction>(atomic_load) memrr:$ptr, 4, gprc:$incr)>;
+          (!cast<Instruction>(atomic_load) memrr:$ptr, 2, gprc:$incr)>;
+}
+
+// Match (some) atomic load operations with immediates.
+foreach op = ["load_and", "load_or", "load_xor"] in {
+  defvar atomic_load = "ATOMIC_"#!toupper(op)#"_IMM";
+  def atomic_load : PPCCustomInserterPseudo<
+      (outs gprc:$dst), (ins memrr:$ptr, i32imm:$sz, u16imm:$incr), "",[]>;
+  foreach bitsz = [8, 16] in {
+    defvar pat = !cast<PatFrag>("atomic_"#op#"_i"#bitsz);
+    def : Pat<(i32 (pat ForceXForm:$ptr, u16imm_pat:$incr)),
+            (!cast<Instruction>(atomic_load) memrr:$ptr, !logtwo(!div(bitsz, 8)), immZExt16:$incr)>,
+            Requires<[HasPartwordAtomics]>;
+  }
+  defvar pat = !cast<PatFrag>("atomic_"#op#"_i32");
+  def : Pat<(i32 (pat ForceXForm:$ptr, u16imm_pat:$incr)),
+            (!cast<Instruction>(atomic_load) memrr:$ptr, 2, immZExt16:$incr)>;
 }
 
 foreach bitsz = [8, 16, 32] in {

--- a/llvm/test/CodeGen/PowerPC/all-atomics.ll
+++ b/llvm/test/CodeGen/PowerPC/all-atomics.ll
@@ -22,311 +22,311 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    addis 3, 2, sc@toc@ha
 ; CHECK-NEXT:    std 26, -48(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    std 27, -40(1) # 8-byte Folded Spill
-; CHECK-NEXT:    addi 4, 3, sc@toc@l
+; CHECK-NEXT:    li 12, 1
 ; CHECK-NEXT:    std 28, -32(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    std 29, -24(1) # 8-byte Folded Spill
+; CHECK-NEXT:    addi 3, 3, sc@toc@l
 ; CHECK-NEXT:    std 30, -16(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    sync
-; CHECK-NEXT:    li 3, 1
 ; CHECK-NEXT:  .LBB0_1: # %entry
+; CHECK-NEXT:    #
+; CHECK-NEXT:    lbarx 4, 0, 3
+; CHECK-NEXT:    addi 4, 4, 1
+; CHECK-NEXT:    stbcx. 4, 0, 3
+; CHECK-NEXT:    bne- 0, .LBB0_1
+; CHECK-NEXT:  # %bb.2: # %entry
+; CHECK-NEXT:    addis 4, 2, uc@toc@ha
+; CHECK-NEXT:    lwsync
+; CHECK-NEXT:    sync
+; CHECK-NEXT:    addi 4, 4, uc@toc@l
+; CHECK-NEXT:  .LBB0_3: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    lbarx 5, 0, 4
 ; CHECK-NEXT:    addi 5, 5, 1
 ; CHECK-NEXT:    stbcx. 5, 0, 4
-; CHECK-NEXT:    bne- 0, .LBB0_1
-; CHECK-NEXT:  # %bb.2: # %entry
-; CHECK-NEXT:    addis 5, 2, uc@toc@ha
-; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    sync
-; CHECK-NEXT:    addi 5, 5, uc@toc@l
-; CHECK-NEXT:  .LBB0_3: # %entry
-; CHECK-NEXT:    #
-; CHECK-NEXT:    lbarx 6, 0, 5
-; CHECK-NEXT:    addi 6, 6, 1
-; CHECK-NEXT:    stbcx. 6, 0, 5
 ; CHECK-NEXT:    bne- 0, .LBB0_3
 ; CHECK-NEXT:  # %bb.4: # %entry
-; CHECK-NEXT:    addis 6, 2, ss@toc@ha
+; CHECK-NEXT:    addis 5, 2, ss@toc@ha
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
-; CHECK-NEXT:    addi 6, 6, ss@toc@l
+; CHECK-NEXT:    addi 5, 5, ss@toc@l
 ; CHECK-NEXT:  .LBB0_5: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 7, 0, 6
-; CHECK-NEXT:    addi 7, 7, 1
-; CHECK-NEXT:    sthcx. 7, 0, 6
+; CHECK-NEXT:    lharx 6, 0, 5
+; CHECK-NEXT:    addi 6, 6, 1
+; CHECK-NEXT:    sthcx. 6, 0, 5
 ; CHECK-NEXT:    bne- 0, .LBB0_5
 ; CHECK-NEXT:  # %bb.6: # %entry
-; CHECK-NEXT:    addis 7, 2, us@toc@ha
+; CHECK-NEXT:    addis 6, 2, us@toc@ha
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
-; CHECK-NEXT:    addi 8, 7, us@toc@l
+; CHECK-NEXT:    addi 7, 6, us@toc@l
 ; CHECK-NEXT:  .LBB0_7: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 7, 0, 8
-; CHECK-NEXT:    addi 7, 7, 1
-; CHECK-NEXT:    sthcx. 7, 0, 8
+; CHECK-NEXT:    lharx 6, 0, 7
+; CHECK-NEXT:    addi 6, 6, 1
+; CHECK-NEXT:    sthcx. 6, 0, 7
 ; CHECK-NEXT:    bne- 0, .LBB0_7
 ; CHECK-NEXT:  # %bb.8: # %entry
-; CHECK-NEXT:    addis 7, 2, si@toc@ha
+; CHECK-NEXT:    addis 6, 2, si@toc@ha
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
-; CHECK-NEXT:    addi 9, 7, si@toc@l
+; CHECK-NEXT:    addi 8, 6, si@toc@l
 ; CHECK-NEXT:  .LBB0_9: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 7, 0, 9
-; CHECK-NEXT:    addi 7, 7, 1
-; CHECK-NEXT:    stwcx. 7, 0, 9
+; CHECK-NEXT:    lwarx 6, 0, 8
+; CHECK-NEXT:    addi 6, 6, 1
+; CHECK-NEXT:    stwcx. 6, 0, 8
 ; CHECK-NEXT:    bne- 0, .LBB0_9
 ; CHECK-NEXT:  # %bb.10: # %entry
-; CHECK-NEXT:    addis 7, 2, ui@toc@ha
+; CHECK-NEXT:    addis 6, 2, ui@toc@ha
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
-; CHECK-NEXT:    addi 10, 7, ui@toc@l
+; CHECK-NEXT:    addi 9, 6, ui@toc@l
 ; CHECK-NEXT:  .LBB0_11: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 7, 0, 10
-; CHECK-NEXT:    addi 7, 7, 1
-; CHECK-NEXT:    stwcx. 7, 0, 10
+; CHECK-NEXT:    lwarx 6, 0, 9
+; CHECK-NEXT:    addi 6, 6, 1
+; CHECK-NEXT:    stwcx. 6, 0, 9
 ; CHECK-NEXT:    bne- 0, .LBB0_11
 ; CHECK-NEXT:  # %bb.12: # %entry
-; CHECK-NEXT:    addis 7, 2, sll@toc@ha
+; CHECK-NEXT:    addis 6, 2, sll@toc@ha
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
-; CHECK-NEXT:    addi 11, 7, sll@toc@l
-; CHECK-NEXT:    li 7, 1
+; CHECK-NEXT:    addi 10, 6, sll@toc@l
+; CHECK-NEXT:    li 6, 1
 ; CHECK-NEXT:  .LBB0_13: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 12, 0, 11
-; CHECK-NEXT:    addi 12, 12, 1
-; CHECK-NEXT:    stdcx. 12, 0, 11
+; CHECK-NEXT:    ldarx 11, 0, 10
+; CHECK-NEXT:    addi 11, 11, 1
+; CHECK-NEXT:    stdcx. 11, 0, 10
 ; CHECK-NEXT:    bne- 0, .LBB0_13
 ; CHECK-NEXT:  # %bb.14: # %entry
-; CHECK-NEXT:    addis 12, 2, ull@toc@ha
+; CHECK-NEXT:    addis 11, 2, ull@toc@ha
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
-; CHECK-NEXT:    addi 12, 12, ull@toc@l
+; CHECK-NEXT:    addi 11, 11, ull@toc@l
 ; CHECK-NEXT:  .LBB0_15: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 30, 0, 12
+; CHECK-NEXT:    ldarx 30, 0, 11
 ; CHECK-NEXT:    addi 0, 30, 1
-; CHECK-NEXT:    stdcx. 0, 0, 12
+; CHECK-NEXT:    stdcx. 0, 0, 11
 ; CHECK-NEXT:    bne- 0, .LBB0_15
 ; CHECK-NEXT:  # %bb.16: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_17: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lbarx 0, 0, 4
-; CHECK-NEXT:    sub 0, 0, 3
-; CHECK-NEXT:    stbcx. 0, 0, 4
+; CHECK-NEXT:    lbarx 0, 0, 3
+; CHECK-NEXT:    sub 0, 0, 12
+; CHECK-NEXT:    stbcx. 0, 0, 3
 ; CHECK-NEXT:    bne- 0, .LBB0_17
 ; CHECK-NEXT:  # %bb.18: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_19: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lbarx 0, 0, 5
-; CHECK-NEXT:    sub 0, 0, 3
-; CHECK-NEXT:    stbcx. 0, 0, 5
+; CHECK-NEXT:    lbarx 0, 0, 4
+; CHECK-NEXT:    sub 0, 0, 12
+; CHECK-NEXT:    stbcx. 0, 0, 4
 ; CHECK-NEXT:    bne- 0, .LBB0_19
 ; CHECK-NEXT:  # %bb.20: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_21: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 0, 0, 6
-; CHECK-NEXT:    sub 0, 0, 3
-; CHECK-NEXT:    sthcx. 0, 0, 6
+; CHECK-NEXT:    lharx 0, 0, 5
+; CHECK-NEXT:    sub 0, 0, 12
+; CHECK-NEXT:    sthcx. 0, 0, 5
 ; CHECK-NEXT:    bne- 0, .LBB0_21
 ; CHECK-NEXT:  # %bb.22: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_23: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 0, 0, 8
-; CHECK-NEXT:    sub 0, 0, 3
-; CHECK-NEXT:    sthcx. 0, 0, 8
+; CHECK-NEXT:    lharx 0, 0, 7
+; CHECK-NEXT:    sub 0, 0, 12
+; CHECK-NEXT:    sthcx. 0, 0, 7
 ; CHECK-NEXT:    bne- 0, .LBB0_23
 ; CHECK-NEXT:  # %bb.24: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_25: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 0, 0, 9
-; CHECK-NEXT:    sub 0, 0, 3
-; CHECK-NEXT:    stwcx. 0, 0, 9
+; CHECK-NEXT:    lwarx 0, 0, 8
+; CHECK-NEXT:    sub 0, 0, 12
+; CHECK-NEXT:    stwcx. 0, 0, 8
 ; CHECK-NEXT:    bne- 0, .LBB0_25
 ; CHECK-NEXT:  # %bb.26: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_27: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 0, 0, 10
-; CHECK-NEXT:    sub 0, 0, 3
-; CHECK-NEXT:    stwcx. 0, 0, 10
+; CHECK-NEXT:    lwarx 0, 0, 9
+; CHECK-NEXT:    sub 0, 0, 12
+; CHECK-NEXT:    stwcx. 0, 0, 9
 ; CHECK-NEXT:    bne- 0, .LBB0_27
 ; CHECK-NEXT:  # %bb.28: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_29: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 0, 0, 11
-; CHECK-NEXT:    sub 0, 0, 7
-; CHECK-NEXT:    stdcx. 0, 0, 11
+; CHECK-NEXT:    ldarx 0, 0, 10
+; CHECK-NEXT:    sub 0, 0, 6
+; CHECK-NEXT:    stdcx. 0, 0, 10
 ; CHECK-NEXT:    bne- 0, .LBB0_29
 ; CHECK-NEXT:  # %bb.30: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_31: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 0, 0, 12
-; CHECK-NEXT:    sub 0, 0, 7
-; CHECK-NEXT:    stdcx. 0, 0, 12
+; CHECK-NEXT:    ldarx 0, 0, 11
+; CHECK-NEXT:    sub 0, 0, 6
+; CHECK-NEXT:    stdcx. 0, 0, 11
 ; CHECK-NEXT:    bne- 0, .LBB0_31
 ; CHECK-NEXT:  # %bb.32: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_33: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lbarx 0, 0, 4
+; CHECK-NEXT:    lbarx 0, 0, 3
 ; CHECK-NEXT:    ori 0, 0, 1
-; CHECK-NEXT:    stbcx. 0, 0, 4
+; CHECK-NEXT:    stbcx. 0, 0, 3
 ; CHECK-NEXT:    bne- 0, .LBB0_33
 ; CHECK-NEXT:  # %bb.34: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_35: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lbarx 0, 0, 5
+; CHECK-NEXT:    lbarx 0, 0, 4
 ; CHECK-NEXT:    ori 0, 0, 1
-; CHECK-NEXT:    stbcx. 0, 0, 5
+; CHECK-NEXT:    stbcx. 0, 0, 4
 ; CHECK-NEXT:    bne- 0, .LBB0_35
 ; CHECK-NEXT:  # %bb.36: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_37: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 0, 0, 6
+; CHECK-NEXT:    lharx 0, 0, 5
 ; CHECK-NEXT:    ori 0, 0, 1
-; CHECK-NEXT:    sthcx. 0, 0, 6
+; CHECK-NEXT:    sthcx. 0, 0, 5
 ; CHECK-NEXT:    bne- 0, .LBB0_37
 ; CHECK-NEXT:  # %bb.38: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_39: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 0, 0, 8
+; CHECK-NEXT:    lharx 0, 0, 7
 ; CHECK-NEXT:    ori 0, 0, 1
-; CHECK-NEXT:    sthcx. 0, 0, 8
+; CHECK-NEXT:    sthcx. 0, 0, 7
 ; CHECK-NEXT:    bne- 0, .LBB0_39
 ; CHECK-NEXT:  # %bb.40: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_41: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 0, 0, 9
+; CHECK-NEXT:    lwarx 0, 0, 8
 ; CHECK-NEXT:    ori 0, 0, 1
-; CHECK-NEXT:    stwcx. 0, 0, 9
+; CHECK-NEXT:    stwcx. 0, 0, 8
 ; CHECK-NEXT:    bne- 0, .LBB0_41
 ; CHECK-NEXT:  # %bb.42: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_43: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 0, 0, 10
+; CHECK-NEXT:    lwarx 0, 0, 9
 ; CHECK-NEXT:    ori 0, 0, 1
-; CHECK-NEXT:    stwcx. 0, 0, 10
+; CHECK-NEXT:    stwcx. 0, 0, 9
 ; CHECK-NEXT:    bne- 0, .LBB0_43
 ; CHECK-NEXT:  # %bb.44: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_45: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 0, 0, 11
+; CHECK-NEXT:    ldarx 0, 0, 10
 ; CHECK-NEXT:    ori 0, 0, 1
-; CHECK-NEXT:    stdcx. 0, 0, 11
+; CHECK-NEXT:    stdcx. 0, 0, 10
 ; CHECK-NEXT:    bne- 0, .LBB0_45
 ; CHECK-NEXT:  # %bb.46: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_47: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 0, 0, 12
+; CHECK-NEXT:    ldarx 0, 0, 11
 ; CHECK-NEXT:    ori 0, 0, 1
-; CHECK-NEXT:    stdcx. 0, 0, 12
+; CHECK-NEXT:    stdcx. 0, 0, 11
 ; CHECK-NEXT:    bne- 0, .LBB0_47
 ; CHECK-NEXT:  # %bb.48: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_49: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lbarx 0, 0, 4
+; CHECK-NEXT:    lbarx 0, 0, 3
 ; CHECK-NEXT:    xori 0, 0, 1
-; CHECK-NEXT:    stbcx. 0, 0, 4
+; CHECK-NEXT:    stbcx. 0, 0, 3
 ; CHECK-NEXT:    bne- 0, .LBB0_49
 ; CHECK-NEXT:  # %bb.50: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_51: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lbarx 0, 0, 5
+; CHECK-NEXT:    lbarx 0, 0, 4
 ; CHECK-NEXT:    xori 0, 0, 1
-; CHECK-NEXT:    stbcx. 0, 0, 5
+; CHECK-NEXT:    stbcx. 0, 0, 4
 ; CHECK-NEXT:    bne- 0, .LBB0_51
 ; CHECK-NEXT:  # %bb.52: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_53: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 0, 0, 6
+; CHECK-NEXT:    lharx 0, 0, 5
 ; CHECK-NEXT:    xori 0, 0, 1
-; CHECK-NEXT:    sthcx. 0, 0, 6
+; CHECK-NEXT:    sthcx. 0, 0, 5
 ; CHECK-NEXT:    bne- 0, .LBB0_53
 ; CHECK-NEXT:  # %bb.54: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_55: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 0, 0, 8
+; CHECK-NEXT:    lharx 0, 0, 7
 ; CHECK-NEXT:    xori 0, 0, 1
-; CHECK-NEXT:    sthcx. 0, 0, 8
+; CHECK-NEXT:    sthcx. 0, 0, 7
 ; CHECK-NEXT:    bne- 0, .LBB0_55
 ; CHECK-NEXT:  # %bb.56: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_57: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 0, 0, 9
+; CHECK-NEXT:    lwarx 0, 0, 8
 ; CHECK-NEXT:    xori 0, 0, 1
-; CHECK-NEXT:    stwcx. 0, 0, 9
+; CHECK-NEXT:    stwcx. 0, 0, 8
 ; CHECK-NEXT:    bne- 0, .LBB0_57
 ; CHECK-NEXT:  # %bb.58: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_59: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 0, 0, 10
+; CHECK-NEXT:    lwarx 0, 0, 9
 ; CHECK-NEXT:    xori 0, 0, 1
-; CHECK-NEXT:    stwcx. 0, 0, 10
+; CHECK-NEXT:    stwcx. 0, 0, 9
 ; CHECK-NEXT:    bne- 0, .LBB0_59
 ; CHECK-NEXT:  # %bb.60: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_61: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 0, 0, 11
+; CHECK-NEXT:    ldarx 0, 0, 10
 ; CHECK-NEXT:    xori 0, 0, 1
-; CHECK-NEXT:    stdcx. 0, 0, 11
+; CHECK-NEXT:    stdcx. 0, 0, 10
 ; CHECK-NEXT:    bne- 0, .LBB0_61
 ; CHECK-NEXT:  # %bb.62: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_63: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 0, 0, 12
+; CHECK-NEXT:    ldarx 0, 0, 11
 ; CHECK-NEXT:    xori 0, 0, 1
-; CHECK-NEXT:    stdcx. 0, 0, 12
+; CHECK-NEXT:    stdcx. 0, 0, 11
 ; CHECK-NEXT:    bne- 0, .LBB0_63
 ; CHECK-NEXT:  # %bb.64: # %entry
 ; CHECK-NEXT:    addis 30, 2, u128@toc@ha
@@ -337,7 +337,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:  .LBB0_65: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    lqarx 28, 0, 0
-; CHECK-NEXT:    xor 27, 7, 29
+; CHECK-NEXT:    xor 27, 6, 29
 ; CHECK-NEXT:    xor 26, 30, 28
 ; CHECK-NEXT:    stqcx. 26, 0, 0
 ; CHECK-NEXT:    bne 0, .LBB0_65
@@ -349,7 +349,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:  .LBB0_67: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    lqarx 28, 0, 0
-; CHECK-NEXT:    xor 27, 7, 29
+; CHECK-NEXT:    xor 27, 6, 29
 ; CHECK-NEXT:    xor 26, 30, 28
 ; CHECK-NEXT:    stqcx. 26, 0, 0
 ; CHECK-NEXT:    bne 0, .LBB0_67
@@ -358,144 +358,144 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_69: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lbarx 0, 0, 4
-; CHECK-NEXT:    nand 0, 3, 0
-; CHECK-NEXT:    stbcx. 0, 0, 4
+; CHECK-NEXT:    lbarx 0, 0, 3
+; CHECK-NEXT:    nand 0, 12, 0
+; CHECK-NEXT:    stbcx. 0, 0, 3
 ; CHECK-NEXT:    bne- 0, .LBB0_69
 ; CHECK-NEXT:  # %bb.70: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_71: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lbarx 0, 0, 5
-; CHECK-NEXT:    nand 0, 3, 0
-; CHECK-NEXT:    stbcx. 0, 0, 5
+; CHECK-NEXT:    lbarx 0, 0, 4
+; CHECK-NEXT:    nand 0, 12, 0
+; CHECK-NEXT:    stbcx. 0, 0, 4
 ; CHECK-NEXT:    bne- 0, .LBB0_71
 ; CHECK-NEXT:  # %bb.72: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_73: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 0, 0, 6
-; CHECK-NEXT:    nand 0, 3, 0
-; CHECK-NEXT:    sthcx. 0, 0, 6
+; CHECK-NEXT:    lharx 0, 0, 5
+; CHECK-NEXT:    nand 0, 12, 0
+; CHECK-NEXT:    sthcx. 0, 0, 5
 ; CHECK-NEXT:    bne- 0, .LBB0_73
 ; CHECK-NEXT:  # %bb.74: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_75: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 0, 0, 8
-; CHECK-NEXT:    nand 0, 3, 0
-; CHECK-NEXT:    sthcx. 0, 0, 8
+; CHECK-NEXT:    lharx 0, 0, 7
+; CHECK-NEXT:    nand 0, 12, 0
+; CHECK-NEXT:    sthcx. 0, 0, 7
 ; CHECK-NEXT:    bne- 0, .LBB0_75
 ; CHECK-NEXT:  # %bb.76: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_77: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 0, 0, 9
-; CHECK-NEXT:    nand 0, 3, 0
-; CHECK-NEXT:    stwcx. 0, 0, 9
+; CHECK-NEXT:    lwarx 0, 0, 8
+; CHECK-NEXT:    nand 0, 12, 0
+; CHECK-NEXT:    stwcx. 0, 0, 8
 ; CHECK-NEXT:    bne- 0, .LBB0_77
 ; CHECK-NEXT:  # %bb.78: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_79: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 0, 0, 10
-; CHECK-NEXT:    nand 0, 3, 0
-; CHECK-NEXT:    stwcx. 0, 0, 10
+; CHECK-NEXT:    lwarx 0, 0, 9
+; CHECK-NEXT:    nand 0, 12, 0
+; CHECK-NEXT:    stwcx. 0, 0, 9
 ; CHECK-NEXT:    bne- 0, .LBB0_79
 ; CHECK-NEXT:  # %bb.80: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_81: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 0, 0, 11
-; CHECK-NEXT:    nand 0, 7, 0
-; CHECK-NEXT:    stdcx. 0, 0, 11
+; CHECK-NEXT:    ldarx 12, 0, 10
+; CHECK-NEXT:    nand 12, 6, 12
+; CHECK-NEXT:    stdcx. 12, 0, 10
 ; CHECK-NEXT:    bne- 0, .LBB0_81
 ; CHECK-NEXT:  # %bb.82: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_83: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 0, 0, 12
-; CHECK-NEXT:    nand 0, 7, 0
-; CHECK-NEXT:    stdcx. 0, 0, 12
+; CHECK-NEXT:    ldarx 12, 0, 11
+; CHECK-NEXT:    nand 12, 6, 12
+; CHECK-NEXT:    stdcx. 12, 0, 11
 ; CHECK-NEXT:    bne- 0, .LBB0_83
 ; CHECK-NEXT:  # %bb.84: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_85: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lbarx 0, 0, 4
-; CHECK-NEXT:    and 0, 3, 0
-; CHECK-NEXT:    stbcx. 0, 0, 4
+; CHECK-NEXT:    lbarx 12, 0, 3
+; CHECK-NEXT:    andi. 12, 12, 1
+; CHECK-NEXT:    stbcx. 12, 0, 3
 ; CHECK-NEXT:    bne- 0, .LBB0_85
 ; CHECK-NEXT:  # %bb.86: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_87: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lbarx 4, 0, 5
-; CHECK-NEXT:    and 4, 3, 4
-; CHECK-NEXT:    stbcx. 4, 0, 5
+; CHECK-NEXT:    lbarx 3, 0, 4
+; CHECK-NEXT:    andi. 3, 3, 1
+; CHECK-NEXT:    stbcx. 3, 0, 4
 ; CHECK-NEXT:    bne- 0, .LBB0_87
 ; CHECK-NEXT:  # %bb.88: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_89: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 4, 0, 6
-; CHECK-NEXT:    and 4, 3, 4
-; CHECK-NEXT:    sthcx. 4, 0, 6
+; CHECK-NEXT:    lharx 3, 0, 5
+; CHECK-NEXT:    andi. 3, 3, 1
+; CHECK-NEXT:    sthcx. 3, 0, 5
 ; CHECK-NEXT:    bne- 0, .LBB0_89
 ; CHECK-NEXT:  # %bb.90: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_91: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 4, 0, 8
-; CHECK-NEXT:    and 4, 3, 4
-; CHECK-NEXT:    sthcx. 4, 0, 8
+; CHECK-NEXT:    lharx 3, 0, 7
+; CHECK-NEXT:    andi. 3, 3, 1
+; CHECK-NEXT:    sthcx. 3, 0, 7
 ; CHECK-NEXT:    bne- 0, .LBB0_91
 ; CHECK-NEXT:  # %bb.92: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_93: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 4, 0, 9
-; CHECK-NEXT:    and 4, 3, 4
-; CHECK-NEXT:    stwcx. 4, 0, 9
+; CHECK-NEXT:    lwarx 3, 0, 8
+; CHECK-NEXT:    andi. 3, 3, 1
+; CHECK-NEXT:    stwcx. 3, 0, 8
 ; CHECK-NEXT:    bne- 0, .LBB0_93
 ; CHECK-NEXT:  # %bb.94: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_95: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 4, 0, 10
-; CHECK-NEXT:    and 4, 3, 4
-; CHECK-NEXT:    stwcx. 4, 0, 10
+; CHECK-NEXT:    lwarx 3, 0, 9
+; CHECK-NEXT:    andi. 3, 3, 1
+; CHECK-NEXT:    stwcx. 3, 0, 9
 ; CHECK-NEXT:    bne- 0, .LBB0_95
 ; CHECK-NEXT:  # %bb.96: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_97: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 3, 0, 11
-; CHECK-NEXT:    and 3, 7, 3
-; CHECK-NEXT:    stdcx. 3, 0, 11
+; CHECK-NEXT:    ldarx 3, 0, 10
+; CHECK-NEXT:    and 3, 6, 3
+; CHECK-NEXT:    stdcx. 3, 0, 10
 ; CHECK-NEXT:    bne- 0, .LBB0_97
 ; CHECK-NEXT:  # %bb.98: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB0_99: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 3, 0, 12
-; CHECK-NEXT:    and 3, 7, 3
-; CHECK-NEXT:    stdcx. 3, 0, 12
+; CHECK-NEXT:    ldarx 3, 0, 11
+; CHECK-NEXT:    and 3, 6, 3
+; CHECK-NEXT:    stdcx. 3, 0, 11
 ; CHECK-NEXT:    bne- 0, .LBB0_99
 ; CHECK-NEXT:  # %bb.100: # %entry
 ; CHECK-NEXT:    lwsync
@@ -985,84 +985,84 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    cmplwi 3, 0
 ; AIX32-NEXT:    beq 0, L..BB0_51
 ; AIX32-NEXT:  # %bb.52: # %atomicrmw.end
-; AIX32-NEXT:    li 29, 1
-; AIX32-NEXT:    li 3, 255
+; AIX32-NEXT:    li 3, 1
+; AIX32-NEXT:    li 4, 255
 ; AIX32-NEXT:    sync
-; AIX32-NEXT:    slw 18, 29, 26
-; AIX32-NEXT:    slw 3, 3, 26
+; AIX32-NEXT:    slw 29, 3, 26
+; AIX32-NEXT:    slw 4, 4, 26
 ; AIX32-NEXT:  L..BB0_53: # %atomicrmw.end
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 28
-; AIX32-NEXT:    nand 5, 18, 4
-; AIX32-NEXT:    andc 4, 4, 3
-; AIX32-NEXT:    and 5, 5, 3
-; AIX32-NEXT:    or 4, 5, 4
-; AIX32-NEXT:    stwcx. 4, 0, 28
+; AIX32-NEXT:    lwarx 5, 0, 28
+; AIX32-NEXT:    nand 6, 29, 5
+; AIX32-NEXT:    andc 5, 5, 4
+; AIX32-NEXT:    and 6, 6, 4
+; AIX32-NEXT:    or 5, 6, 5
+; AIX32-NEXT:    stwcx. 5, 0, 28
 ; AIX32-NEXT:    bne- 0, L..BB0_53
 ; AIX32-NEXT:  # %bb.54: # %atomicrmw.end
-; AIX32-NEXT:    li 3, 255
+; AIX32-NEXT:    li 4, 255
 ; AIX32-NEXT:    lwsync
-; AIX32-NEXT:    slw 17, 29, 24
+; AIX32-NEXT:    slw 18, 3, 24
 ; AIX32-NEXT:    sync
-; AIX32-NEXT:    slw 3, 3, 24
+; AIX32-NEXT:    slw 4, 4, 24
 ; AIX32-NEXT:  L..BB0_55: # %atomicrmw.end
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 27
-; AIX32-NEXT:    nand 5, 17, 4
-; AIX32-NEXT:    andc 4, 4, 3
-; AIX32-NEXT:    and 5, 5, 3
-; AIX32-NEXT:    or 4, 5, 4
-; AIX32-NEXT:    stwcx. 4, 0, 27
+; AIX32-NEXT:    lwarx 5, 0, 27
+; AIX32-NEXT:    nand 6, 18, 5
+; AIX32-NEXT:    andc 5, 5, 4
+; AIX32-NEXT:    and 6, 6, 4
+; AIX32-NEXT:    or 5, 6, 5
+; AIX32-NEXT:    stwcx. 5, 0, 27
 ; AIX32-NEXT:    bne- 0, L..BB0_55
 ; AIX32-NEXT:  # %bb.56: # %atomicrmw.end
-; AIX32-NEXT:    li 3, 0
+; AIX32-NEXT:    li 4, 0
 ; AIX32-NEXT:    lwsync
-; AIX32-NEXT:    slw 16, 29, 22
+; AIX32-NEXT:    slw 17, 3, 22
 ; AIX32-NEXT:    sync
-; AIX32-NEXT:    ori 3, 3, 65535
-; AIX32-NEXT:    slw 3, 3, 22
+; AIX32-NEXT:    ori 4, 4, 65535
+; AIX32-NEXT:    slw 4, 4, 22
 ; AIX32-NEXT:  L..BB0_57: # %atomicrmw.end
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 25
-; AIX32-NEXT:    nand 5, 16, 4
-; AIX32-NEXT:    andc 4, 4, 3
-; AIX32-NEXT:    and 5, 5, 3
-; AIX32-NEXT:    or 4, 5, 4
-; AIX32-NEXT:    stwcx. 4, 0, 25
+; AIX32-NEXT:    lwarx 5, 0, 25
+; AIX32-NEXT:    nand 6, 17, 5
+; AIX32-NEXT:    andc 5, 5, 4
+; AIX32-NEXT:    and 6, 6, 4
+; AIX32-NEXT:    or 5, 6, 5
+; AIX32-NEXT:    stwcx. 5, 0, 25
 ; AIX32-NEXT:    bne- 0, L..BB0_57
 ; AIX32-NEXT:  # %bb.58: # %atomicrmw.end
-; AIX32-NEXT:    li 3, 0
+; AIX32-NEXT:    li 4, 0
 ; AIX32-NEXT:    lwsync
-; AIX32-NEXT:    slw 15, 29, 21
+; AIX32-NEXT:    slw 16, 3, 21
 ; AIX32-NEXT:    sync
-; AIX32-NEXT:    ori 3, 3, 65535
-; AIX32-NEXT:    slw 3, 3, 21
+; AIX32-NEXT:    ori 4, 4, 65535
+; AIX32-NEXT:    slw 4, 4, 21
 ; AIX32-NEXT:  L..BB0_59: # %atomicrmw.end
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 23
-; AIX32-NEXT:    nand 5, 15, 4
-; AIX32-NEXT:    andc 4, 4, 3
-; AIX32-NEXT:    and 5, 5, 3
-; AIX32-NEXT:    or 4, 5, 4
-; AIX32-NEXT:    stwcx. 4, 0, 23
+; AIX32-NEXT:    lwarx 5, 0, 23
+; AIX32-NEXT:    nand 6, 16, 5
+; AIX32-NEXT:    andc 5, 5, 4
+; AIX32-NEXT:    and 6, 6, 4
+; AIX32-NEXT:    or 5, 6, 5
+; AIX32-NEXT:    stwcx. 5, 0, 23
 ; AIX32-NEXT:    bne- 0, L..BB0_59
 ; AIX32-NEXT:  # %bb.60: # %atomicrmw.end
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    sync
 ; AIX32-NEXT:  L..BB0_61: # %atomicrmw.end
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 3, 0, 20
-; AIX32-NEXT:    nand 3, 29, 3
-; AIX32-NEXT:    stwcx. 3, 0, 20
+; AIX32-NEXT:    lwarx 4, 0, 20
+; AIX32-NEXT:    nand 4, 3, 4
+; AIX32-NEXT:    stwcx. 4, 0, 20
 ; AIX32-NEXT:    bne- 0, L..BB0_61
 ; AIX32-NEXT:  # %bb.62: # %atomicrmw.end
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    sync
 ; AIX32-NEXT:  L..BB0_63: # %atomicrmw.end
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 3, 0, 19
-; AIX32-NEXT:    nand 3, 29, 3
-; AIX32-NEXT:    stwcx. 3, 0, 19
+; AIX32-NEXT:    lwarx 4, 0, 19
+; AIX32-NEXT:    nand 4, 3, 4
+; AIX32-NEXT:    stwcx. 4, 0, 19
 ; AIX32-NEXT:    bne- 0, L..BB0_63
 ; AIX32-NEXT:  # %bb.64: # %atomicrmw.end
 ; AIX32-NEXT:    lwz 31, L..C6(2) # @sll
@@ -1086,7 +1086,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:  L..BB0_65: # %atomicrmw.end
 ; AIX32-NEXT:    #
 ; AIX32-NEXT:    lwarx 4, 0, 28
-; AIX32-NEXT:    and 5, 18, 4
+; AIX32-NEXT:    and 5, 29, 4
 ; AIX32-NEXT:    andc 4, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
@@ -1100,7 +1100,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:  L..BB0_67: # %atomicrmw.end
 ; AIX32-NEXT:    #
 ; AIX32-NEXT:    lwarx 4, 0, 27
-; AIX32-NEXT:    and 5, 17, 4
+; AIX32-NEXT:    and 5, 18, 4
 ; AIX32-NEXT:    andc 4, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
@@ -1115,7 +1115,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:  L..BB0_69: # %atomicrmw.end
 ; AIX32-NEXT:    #
 ; AIX32-NEXT:    lwarx 4, 0, 25
-; AIX32-NEXT:    and 5, 16, 4
+; AIX32-NEXT:    and 5, 17, 4
 ; AIX32-NEXT:    andc 4, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
@@ -1130,7 +1130,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:  L..BB0_71: # %atomicrmw.end
 ; AIX32-NEXT:    #
 ; AIX32-NEXT:    lwarx 4, 0, 23
-; AIX32-NEXT:    and 5, 15, 4
+; AIX32-NEXT:    and 5, 16, 4
 ; AIX32-NEXT:    andc 4, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
@@ -1142,7 +1142,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:  L..BB0_73: # %atomicrmw.end
 ; AIX32-NEXT:    #
 ; AIX32-NEXT:    lwarx 3, 0, 20
-; AIX32-NEXT:    and 3, 29, 3
+; AIX32-NEXT:    andi. 3, 3, 1
 ; AIX32-NEXT:    stwcx. 3, 0, 20
 ; AIX32-NEXT:    bne- 0, L..BB0_73
 ; AIX32-NEXT:  # %bb.74: # %atomicrmw.end
@@ -1151,7 +1151,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:  L..BB0_75: # %atomicrmw.end
 ; AIX32-NEXT:    #
 ; AIX32-NEXT:    lwarx 3, 0, 19
-; AIX32-NEXT:    and 3, 29, 3
+; AIX32-NEXT:    andi. 3, 3, 1
 ; AIX32-NEXT:    stwcx. 3, 0, 19
 ; AIX32-NEXT:    bne- 0, L..BB0_75
 ; AIX32-NEXT:  # %bb.76: # %atomicrmw.end
@@ -1246,169 +1246,169 @@ entry:
 define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-LABEL: test_fetch_and_op:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    addis 4, 2, sc@toc@ha
+; CHECK-NEXT:    addis 3, 2, sc@toc@ha
 ; CHECK-NEXT:    std 22, -80(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    std 23, -72(1) # 8-byte Folded Spill
-; CHECK-NEXT:    li 3, 11
+; CHECK-NEXT:    addi 5, 3, sc@toc@l
 ; CHECK-NEXT:    std 24, -64(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    std 25, -56(1) # 8-byte Folded Spill
-; CHECK-NEXT:    addi 6, 4, sc@toc@l
 ; CHECK-NEXT:    std 26, -48(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    std 27, -40(1) # 8-byte Folded Spill
+; CHECK-NEXT:    li 24, 11
 ; CHECK-NEXT:    std 28, -32(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    std 29, -24(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    std 30, -16(1) # 8-byte Folded Spill
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_1: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lbarx 5, 0, 6
-; CHECK-NEXT:    addi 7, 5, 11
-; CHECK-NEXT:    stbcx. 7, 0, 6
+; CHECK-NEXT:    lbarx 4, 0, 5
+; CHECK-NEXT:    addi 6, 4, 11
+; CHECK-NEXT:    stbcx. 6, 0, 5
 ; CHECK-NEXT:    bne- 0, .LBB1_1
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    stb 5, sc@toc@l(4)
-; CHECK-NEXT:    addis 5, 2, uc@toc@ha
+; CHECK-NEXT:    stb 4, sc@toc@l(3)
+; CHECK-NEXT:    addis 4, 2, uc@toc@ha
 ; CHECK-NEXT:    sync
-; CHECK-NEXT:    addi 8, 5, uc@toc@l
+; CHECK-NEXT:    addi 7, 4, uc@toc@l
 ; CHECK-NEXT:  .LBB1_3: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lbarx 7, 0, 8
-; CHECK-NEXT:    addi 9, 7, 11
-; CHECK-NEXT:    stbcx. 9, 0, 8
+; CHECK-NEXT:    lbarx 6, 0, 7
+; CHECK-NEXT:    addi 8, 6, 11
+; CHECK-NEXT:    stbcx. 8, 0, 7
 ; CHECK-NEXT:    bne- 0, .LBB1_3
 ; CHECK-NEXT:  # %bb.4: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    stb 7, uc@toc@l(5)
-; CHECK-NEXT:    addis 7, 2, ss@toc@ha
+; CHECK-NEXT:    stb 6, uc@toc@l(4)
+; CHECK-NEXT:    addis 6, 2, ss@toc@ha
 ; CHECK-NEXT:    sync
-; CHECK-NEXT:    addi 10, 7, ss@toc@l
+; CHECK-NEXT:    addi 9, 6, ss@toc@l
 ; CHECK-NEXT:  .LBB1_5: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 9, 0, 10
-; CHECK-NEXT:    addi 11, 9, 11
-; CHECK-NEXT:    sthcx. 11, 0, 10
+; CHECK-NEXT:    lharx 8, 0, 9
+; CHECK-NEXT:    addi 10, 8, 11
+; CHECK-NEXT:    sthcx. 10, 0, 9
 ; CHECK-NEXT:    bne- 0, .LBB1_5
 ; CHECK-NEXT:  # %bb.6: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    sth 9, ss@toc@l(7)
-; CHECK-NEXT:    addis 9, 2, us@toc@ha
+; CHECK-NEXT:    sth 8, ss@toc@l(6)
+; CHECK-NEXT:    addis 8, 2, us@toc@ha
 ; CHECK-NEXT:    sync
-; CHECK-NEXT:    addi 0, 9, us@toc@l
+; CHECK-NEXT:    addi 12, 8, us@toc@l
 ; CHECK-NEXT:  .LBB1_7: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 11, 0, 0
-; CHECK-NEXT:    addi 12, 11, 11
-; CHECK-NEXT:    sthcx. 12, 0, 0
+; CHECK-NEXT:    lharx 10, 0, 12
+; CHECK-NEXT:    addi 11, 10, 11
+; CHECK-NEXT:    sthcx. 11, 0, 12
 ; CHECK-NEXT:    bne- 0, .LBB1_7
 ; CHECK-NEXT:  # %bb.8: # %entry
-; CHECK-NEXT:    addis 12, 2, si@toc@ha
+; CHECK-NEXT:    addis 11, 2, si@toc@ha
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    sth 11, us@toc@l(9)
+; CHECK-NEXT:    sth 10, us@toc@l(8)
 ; CHECK-NEXT:    sync
-; CHECK-NEXT:    addi 29, 12, si@toc@l
+; CHECK-NEXT:    addi 0, 11, si@toc@l
 ; CHECK-NEXT:  .LBB1_9: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 11, 0, 29
-; CHECK-NEXT:    addi 30, 11, 11
-; CHECK-NEXT:    stwcx. 30, 0, 29
+; CHECK-NEXT:    lwarx 10, 0, 0
+; CHECK-NEXT:    addi 30, 10, 11
+; CHECK-NEXT:    stwcx. 30, 0, 0
 ; CHECK-NEXT:    bne- 0, .LBB1_9
 ; CHECK-NEXT:  # %bb.10: # %entry
 ; CHECK-NEXT:    addis 30, 2, ui@toc@ha
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    stw 11, si@toc@l(12)
+; CHECK-NEXT:    stw 10, si@toc@l(11)
 ; CHECK-NEXT:    sync
-; CHECK-NEXT:    addi 27, 30, ui@toc@l
+; CHECK-NEXT:    addi 28, 30, ui@toc@l
 ; CHECK-NEXT:  .LBB1_11: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 11, 0, 27
-; CHECK-NEXT:    addi 28, 11, 11
-; CHECK-NEXT:    stwcx. 28, 0, 27
+; CHECK-NEXT:    lwarx 10, 0, 28
+; CHECK-NEXT:    addi 29, 10, 11
+; CHECK-NEXT:    stwcx. 29, 0, 28
 ; CHECK-NEXT:    bne- 0, .LBB1_11
 ; CHECK-NEXT:  # %bb.12: # %entry
-; CHECK-NEXT:    addis 28, 2, sll@toc@ha
+; CHECK-NEXT:    addis 29, 2, sll@toc@ha
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    stw 11, ui@toc@l(30)
-; CHECK-NEXT:    li 11, 11
+; CHECK-NEXT:    stw 10, ui@toc@l(30)
+; CHECK-NEXT:    li 10, 11
 ; CHECK-NEXT:    sync
-; CHECK-NEXT:    addi 25, 28, sll@toc@l
+; CHECK-NEXT:    addi 26, 29, sll@toc@l
 ; CHECK-NEXT:  .LBB1_13: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 26, 0, 25
-; CHECK-NEXT:    addi 24, 26, 11
-; CHECK-NEXT:    stdcx. 24, 0, 25
+; CHECK-NEXT:    ldarx 27, 0, 26
+; CHECK-NEXT:    addi 25, 27, 11
+; CHECK-NEXT:    stdcx. 25, 0, 26
 ; CHECK-NEXT:    bne- 0, .LBB1_13
 ; CHECK-NEXT:  # %bb.14: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    std 26, sll@toc@l(28)
-; CHECK-NEXT:    addis 26, 2, ull@toc@ha
+; CHECK-NEXT:    std 27, sll@toc@l(29)
+; CHECK-NEXT:    addis 27, 2, ull@toc@ha
 ; CHECK-NEXT:    sync
-; CHECK-NEXT:    addi 24, 26, ull@toc@l
+; CHECK-NEXT:    addi 25, 27, ull@toc@l
 ; CHECK-NEXT:  .LBB1_15: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 23, 0, 24
+; CHECK-NEXT:    ldarx 23, 0, 25
 ; CHECK-NEXT:    addi 22, 23, 11
-; CHECK-NEXT:    stdcx. 22, 0, 24
+; CHECK-NEXT:    stdcx. 22, 0, 25
 ; CHECK-NEXT:    bne- 0, .LBB1_15
 ; CHECK-NEXT:  # %bb.16: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    std 23, ull@toc@l(26)
+; CHECK-NEXT:    std 23, ull@toc@l(27)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_17: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lbarx 23, 0, 6
-; CHECK-NEXT:    sub 22, 23, 3
-; CHECK-NEXT:    stbcx. 22, 0, 6
+; CHECK-NEXT:    lbarx 23, 0, 5
+; CHECK-NEXT:    sub 22, 23, 24
+; CHECK-NEXT:    stbcx. 22, 0, 5
 ; CHECK-NEXT:    bne- 0, .LBB1_17
 ; CHECK-NEXT:  # %bb.18: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    stb 23, sc@toc@l(4)
+; CHECK-NEXT:    stb 23, sc@toc@l(3)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_19: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lbarx 23, 0, 8
-; CHECK-NEXT:    sub 22, 23, 3
-; CHECK-NEXT:    stbcx. 22, 0, 8
+; CHECK-NEXT:    lbarx 23, 0, 7
+; CHECK-NEXT:    sub 22, 23, 24
+; CHECK-NEXT:    stbcx. 22, 0, 7
 ; CHECK-NEXT:    bne- 0, .LBB1_19
 ; CHECK-NEXT:  # %bb.20: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    stb 23, uc@toc@l(5)
+; CHECK-NEXT:    stb 23, uc@toc@l(4)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_21: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 23, 0, 10
-; CHECK-NEXT:    sub 22, 23, 3
-; CHECK-NEXT:    sthcx. 22, 0, 10
+; CHECK-NEXT:    lharx 23, 0, 9
+; CHECK-NEXT:    sub 22, 23, 24
+; CHECK-NEXT:    sthcx. 22, 0, 9
 ; CHECK-NEXT:    bne- 0, .LBB1_21
 ; CHECK-NEXT:  # %bb.22: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    sth 23, ss@toc@l(7)
+; CHECK-NEXT:    sth 23, ss@toc@l(6)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_23: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 23, 0, 0
-; CHECK-NEXT:    sub 22, 23, 3
-; CHECK-NEXT:    sthcx. 22, 0, 0
+; CHECK-NEXT:    lharx 23, 0, 12
+; CHECK-NEXT:    sub 22, 23, 24
+; CHECK-NEXT:    sthcx. 22, 0, 12
 ; CHECK-NEXT:    bne- 0, .LBB1_23
 ; CHECK-NEXT:  # %bb.24: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    sth 23, us@toc@l(9)
+; CHECK-NEXT:    sth 23, us@toc@l(8)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_25: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 23, 0, 29
-; CHECK-NEXT:    sub 22, 23, 3
-; CHECK-NEXT:    stwcx. 22, 0, 29
+; CHECK-NEXT:    lwarx 23, 0, 0
+; CHECK-NEXT:    sub 22, 23, 24
+; CHECK-NEXT:    stwcx. 22, 0, 0
 ; CHECK-NEXT:    bne- 0, .LBB1_25
 ; CHECK-NEXT:  # %bb.26: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    stw 23, si@toc@l(12)
+; CHECK-NEXT:    stw 23, si@toc@l(11)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_27: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 23, 0, 27
-; CHECK-NEXT:    sub 22, 23, 3
-; CHECK-NEXT:    stwcx. 22, 0, 27
+; CHECK-NEXT:    lwarx 23, 0, 28
+; CHECK-NEXT:    sub 22, 23, 24
+; CHECK-NEXT:    stwcx. 22, 0, 28
 ; CHECK-NEXT:    bne- 0, .LBB1_27
 ; CHECK-NEXT:  # %bb.28: # %entry
 ; CHECK-NEXT:    lwsync
@@ -1416,79 +1416,79 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_29: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 23, 0, 25
-; CHECK-NEXT:    sub 22, 23, 11
-; CHECK-NEXT:    stdcx. 22, 0, 25
+; CHECK-NEXT:    ldarx 23, 0, 26
+; CHECK-NEXT:    sub 22, 23, 10
+; CHECK-NEXT:    stdcx. 22, 0, 26
 ; CHECK-NEXT:    bne- 0, .LBB1_29
 ; CHECK-NEXT:  # %bb.30: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    std 23, sll@toc@l(28)
+; CHECK-NEXT:    std 23, sll@toc@l(29)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_31: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 23, 0, 24
-; CHECK-NEXT:    sub 22, 23, 11
-; CHECK-NEXT:    stdcx. 22, 0, 24
+; CHECK-NEXT:    ldarx 23, 0, 25
+; CHECK-NEXT:    sub 22, 23, 10
+; CHECK-NEXT:    stdcx. 22, 0, 25
 ; CHECK-NEXT:    bne- 0, .LBB1_31
 ; CHECK-NEXT:  # %bb.32: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    std 23, ull@toc@l(26)
+; CHECK-NEXT:    std 23, ull@toc@l(27)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_33: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lbarx 23, 0, 6
+; CHECK-NEXT:    lbarx 23, 0, 5
 ; CHECK-NEXT:    ori 22, 23, 11
-; CHECK-NEXT:    stbcx. 22, 0, 6
+; CHECK-NEXT:    stbcx. 22, 0, 5
 ; CHECK-NEXT:    bne- 0, .LBB1_33
 ; CHECK-NEXT:  # %bb.34: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    stb 23, sc@toc@l(4)
+; CHECK-NEXT:    stb 23, sc@toc@l(3)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_35: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lbarx 23, 0, 8
+; CHECK-NEXT:    lbarx 23, 0, 7
 ; CHECK-NEXT:    ori 22, 23, 11
-; CHECK-NEXT:    stbcx. 22, 0, 8
+; CHECK-NEXT:    stbcx. 22, 0, 7
 ; CHECK-NEXT:    bne- 0, .LBB1_35
 ; CHECK-NEXT:  # %bb.36: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    stb 23, uc@toc@l(5)
+; CHECK-NEXT:    stb 23, uc@toc@l(4)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_37: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 23, 0, 10
+; CHECK-NEXT:    lharx 23, 0, 9
 ; CHECK-NEXT:    ori 22, 23, 11
-; CHECK-NEXT:    sthcx. 22, 0, 10
+; CHECK-NEXT:    sthcx. 22, 0, 9
 ; CHECK-NEXT:    bne- 0, .LBB1_37
 ; CHECK-NEXT:  # %bb.38: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    sth 23, ss@toc@l(7)
+; CHECK-NEXT:    sth 23, ss@toc@l(6)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_39: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 23, 0, 0
+; CHECK-NEXT:    lharx 23, 0, 12
 ; CHECK-NEXT:    ori 22, 23, 11
-; CHECK-NEXT:    sthcx. 22, 0, 0
+; CHECK-NEXT:    sthcx. 22, 0, 12
 ; CHECK-NEXT:    bne- 0, .LBB1_39
 ; CHECK-NEXT:  # %bb.40: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    sth 23, us@toc@l(9)
+; CHECK-NEXT:    sth 23, us@toc@l(8)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_41: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 23, 0, 29
+; CHECK-NEXT:    lwarx 23, 0, 0
 ; CHECK-NEXT:    ori 22, 23, 11
-; CHECK-NEXT:    stwcx. 22, 0, 29
+; CHECK-NEXT:    stwcx. 22, 0, 0
 ; CHECK-NEXT:    bne- 0, .LBB1_41
 ; CHECK-NEXT:  # %bb.42: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    stw 23, si@toc@l(12)
+; CHECK-NEXT:    stw 23, si@toc@l(11)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_43: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 23, 0, 27
+; CHECK-NEXT:    lwarx 23, 0, 28
 ; CHECK-NEXT:    ori 22, 23, 11
-; CHECK-NEXT:    stwcx. 22, 0, 27
+; CHECK-NEXT:    stwcx. 22, 0, 28
 ; CHECK-NEXT:    bne- 0, .LBB1_43
 ; CHECK-NEXT:  # %bb.44: # %entry
 ; CHECK-NEXT:    lwsync
@@ -1496,79 +1496,79 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_45: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 23, 0, 25
+; CHECK-NEXT:    ldarx 23, 0, 26
 ; CHECK-NEXT:    ori 22, 23, 11
-; CHECK-NEXT:    stdcx. 22, 0, 25
+; CHECK-NEXT:    stdcx. 22, 0, 26
 ; CHECK-NEXT:    bne- 0, .LBB1_45
 ; CHECK-NEXT:  # %bb.46: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    std 23, sll@toc@l(28)
+; CHECK-NEXT:    std 23, sll@toc@l(29)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_47: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 23, 0, 24
+; CHECK-NEXT:    ldarx 23, 0, 25
 ; CHECK-NEXT:    ori 22, 23, 11
-; CHECK-NEXT:    stdcx. 22, 0, 24
+; CHECK-NEXT:    stdcx. 22, 0, 25
 ; CHECK-NEXT:    bne- 0, .LBB1_47
 ; CHECK-NEXT:  # %bb.48: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    std 23, ull@toc@l(26)
+; CHECK-NEXT:    std 23, ull@toc@l(27)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_49: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lbarx 23, 0, 6
+; CHECK-NEXT:    lbarx 23, 0, 5
 ; CHECK-NEXT:    xori 22, 23, 11
-; CHECK-NEXT:    stbcx. 22, 0, 6
+; CHECK-NEXT:    stbcx. 22, 0, 5
 ; CHECK-NEXT:    bne- 0, .LBB1_49
 ; CHECK-NEXT:  # %bb.50: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    stb 23, sc@toc@l(4)
+; CHECK-NEXT:    stb 23, sc@toc@l(3)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_51: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lbarx 23, 0, 8
+; CHECK-NEXT:    lbarx 23, 0, 7
 ; CHECK-NEXT:    xori 22, 23, 11
-; CHECK-NEXT:    stbcx. 22, 0, 8
+; CHECK-NEXT:    stbcx. 22, 0, 7
 ; CHECK-NEXT:    bne- 0, .LBB1_51
 ; CHECK-NEXT:  # %bb.52: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    stb 23, uc@toc@l(5)
+; CHECK-NEXT:    stb 23, uc@toc@l(4)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_53: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 23, 0, 10
+; CHECK-NEXT:    lharx 23, 0, 9
 ; CHECK-NEXT:    xori 22, 23, 11
-; CHECK-NEXT:    sthcx. 22, 0, 10
+; CHECK-NEXT:    sthcx. 22, 0, 9
 ; CHECK-NEXT:    bne- 0, .LBB1_53
 ; CHECK-NEXT:  # %bb.54: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    sth 23, ss@toc@l(7)
+; CHECK-NEXT:    sth 23, ss@toc@l(6)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_55: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 23, 0, 0
+; CHECK-NEXT:    lharx 23, 0, 12
 ; CHECK-NEXT:    xori 22, 23, 11
-; CHECK-NEXT:    sthcx. 22, 0, 0
+; CHECK-NEXT:    sthcx. 22, 0, 12
 ; CHECK-NEXT:    bne- 0, .LBB1_55
 ; CHECK-NEXT:  # %bb.56: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    sth 23, us@toc@l(9)
+; CHECK-NEXT:    sth 23, us@toc@l(8)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_57: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 23, 0, 29
+; CHECK-NEXT:    lwarx 23, 0, 0
 ; CHECK-NEXT:    xori 22, 23, 11
-; CHECK-NEXT:    stwcx. 22, 0, 29
+; CHECK-NEXT:    stwcx. 22, 0, 0
 ; CHECK-NEXT:    bne- 0, .LBB1_57
 ; CHECK-NEXT:  # %bb.58: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    stw 23, si@toc@l(12)
+; CHECK-NEXT:    stw 23, si@toc@l(11)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_59: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 23, 0, 27
+; CHECK-NEXT:    lwarx 23, 0, 28
 ; CHECK-NEXT:    xori 22, 23, 11
-; CHECK-NEXT:    stwcx. 22, 0, 27
+; CHECK-NEXT:    stwcx. 22, 0, 28
 ; CHECK-NEXT:    bne- 0, .LBB1_59
 ; CHECK-NEXT:  # %bb.60: # %entry
 ; CHECK-NEXT:    lwsync
@@ -1576,79 +1576,79 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_61: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 23, 0, 25
+; CHECK-NEXT:    ldarx 23, 0, 26
 ; CHECK-NEXT:    xori 22, 23, 11
-; CHECK-NEXT:    stdcx. 22, 0, 25
+; CHECK-NEXT:    stdcx. 22, 0, 26
 ; CHECK-NEXT:    bne- 0, .LBB1_61
 ; CHECK-NEXT:  # %bb.62: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    std 23, sll@toc@l(28)
+; CHECK-NEXT:    std 23, sll@toc@l(29)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_63: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 23, 0, 24
+; CHECK-NEXT:    ldarx 23, 0, 25
 ; CHECK-NEXT:    xori 22, 23, 11
-; CHECK-NEXT:    stdcx. 22, 0, 24
+; CHECK-NEXT:    stdcx. 22, 0, 25
 ; CHECK-NEXT:    bne- 0, .LBB1_63
 ; CHECK-NEXT:  # %bb.64: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    std 23, ull@toc@l(26)
+; CHECK-NEXT:    std 23, ull@toc@l(27)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_65: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lbarx 23, 0, 6
-; CHECK-NEXT:    nand 22, 3, 23
-; CHECK-NEXT:    stbcx. 22, 0, 6
+; CHECK-NEXT:    lbarx 23, 0, 5
+; CHECK-NEXT:    nand 22, 24, 23
+; CHECK-NEXT:    stbcx. 22, 0, 5
 ; CHECK-NEXT:    bne- 0, .LBB1_65
 ; CHECK-NEXT:  # %bb.66: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    stb 23, sc@toc@l(4)
+; CHECK-NEXT:    stb 23, sc@toc@l(3)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_67: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lbarx 23, 0, 8
-; CHECK-NEXT:    nand 22, 3, 23
-; CHECK-NEXT:    stbcx. 22, 0, 8
+; CHECK-NEXT:    lbarx 23, 0, 7
+; CHECK-NEXT:    nand 22, 24, 23
+; CHECK-NEXT:    stbcx. 22, 0, 7
 ; CHECK-NEXT:    bne- 0, .LBB1_67
 ; CHECK-NEXT:  # %bb.68: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    stb 23, uc@toc@l(5)
+; CHECK-NEXT:    stb 23, uc@toc@l(4)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_69: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 23, 0, 10
-; CHECK-NEXT:    nand 22, 3, 23
-; CHECK-NEXT:    sthcx. 22, 0, 10
+; CHECK-NEXT:    lharx 23, 0, 9
+; CHECK-NEXT:    nand 22, 24, 23
+; CHECK-NEXT:    sthcx. 22, 0, 9
 ; CHECK-NEXT:    bne- 0, .LBB1_69
 ; CHECK-NEXT:  # %bb.70: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    sth 23, ss@toc@l(7)
+; CHECK-NEXT:    sth 23, ss@toc@l(6)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_71: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 23, 0, 0
-; CHECK-NEXT:    nand 22, 3, 23
-; CHECK-NEXT:    sthcx. 22, 0, 0
+; CHECK-NEXT:    lharx 23, 0, 12
+; CHECK-NEXT:    nand 22, 24, 23
+; CHECK-NEXT:    sthcx. 22, 0, 12
 ; CHECK-NEXT:    bne- 0, .LBB1_71
 ; CHECK-NEXT:  # %bb.72: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    sth 23, us@toc@l(9)
+; CHECK-NEXT:    sth 23, us@toc@l(8)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_73: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 23, 0, 29
-; CHECK-NEXT:    nand 22, 3, 23
-; CHECK-NEXT:    stwcx. 22, 0, 29
+; CHECK-NEXT:    lwarx 23, 0, 0
+; CHECK-NEXT:    nand 22, 24, 23
+; CHECK-NEXT:    stwcx. 22, 0, 0
 ; CHECK-NEXT:    bne- 0, .LBB1_73
 ; CHECK-NEXT:  # %bb.74: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    stw 23, si@toc@l(12)
+; CHECK-NEXT:    stw 23, si@toc@l(11)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_75: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 23, 0, 27
-; CHECK-NEXT:    nand 22, 3, 23
-; CHECK-NEXT:    stwcx. 22, 0, 27
+; CHECK-NEXT:    lwarx 23, 0, 28
+; CHECK-NEXT:    nand 22, 24, 23
+; CHECK-NEXT:    stwcx. 22, 0, 28
 ; CHECK-NEXT:    bne- 0, .LBB1_75
 ; CHECK-NEXT:  # %bb.76: # %entry
 ; CHECK-NEXT:    lwsync
@@ -1656,103 +1656,103 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_77: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 23, 0, 25
-; CHECK-NEXT:    nand 22, 11, 23
-; CHECK-NEXT:    stdcx. 22, 0, 25
+; CHECK-NEXT:    ldarx 24, 0, 26
+; CHECK-NEXT:    nand 23, 10, 24
+; CHECK-NEXT:    stdcx. 23, 0, 26
 ; CHECK-NEXT:    bne- 0, .LBB1_77
 ; CHECK-NEXT:  # %bb.78: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    std 23, sll@toc@l(28)
+; CHECK-NEXT:    std 24, sll@toc@l(29)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_79: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 23, 0, 24
-; CHECK-NEXT:    nand 22, 11, 23
-; CHECK-NEXT:    stdcx. 22, 0, 24
+; CHECK-NEXT:    ldarx 24, 0, 25
+; CHECK-NEXT:    nand 23, 10, 24
+; CHECK-NEXT:    stdcx. 23, 0, 25
 ; CHECK-NEXT:    bne- 0, .LBB1_79
 ; CHECK-NEXT:  # %bb.80: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    std 23, ull@toc@l(26)
+; CHECK-NEXT:    std 24, ull@toc@l(27)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_81: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lbarx 23, 0, 6
-; CHECK-NEXT:    and 22, 3, 23
-; CHECK-NEXT:    stbcx. 22, 0, 6
+; CHECK-NEXT:    lbarx 24, 0, 5
+; CHECK-NEXT:    andi. 23, 24, 11
+; CHECK-NEXT:    stbcx. 23, 0, 5
 ; CHECK-NEXT:    bne- 0, .LBB1_81
 ; CHECK-NEXT:  # %bb.82: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    stb 23, sc@toc@l(4)
+; CHECK-NEXT:    stb 24, sc@toc@l(3)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_83: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lbarx 4, 0, 8
-; CHECK-NEXT:    and 6, 3, 4
-; CHECK-NEXT:    stbcx. 6, 0, 8
+; CHECK-NEXT:    lbarx 3, 0, 7
+; CHECK-NEXT:    andi. 5, 3, 11
+; CHECK-NEXT:    stbcx. 5, 0, 7
 ; CHECK-NEXT:    bne- 0, .LBB1_83
 ; CHECK-NEXT:  # %bb.84: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    stb 4, uc@toc@l(5)
+; CHECK-NEXT:    stb 3, uc@toc@l(4)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_85: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 4, 0, 10
-; CHECK-NEXT:    and 5, 3, 4
-; CHECK-NEXT:    sthcx. 5, 0, 10
+; CHECK-NEXT:    lharx 3, 0, 9
+; CHECK-NEXT:    andi. 4, 3, 11
+; CHECK-NEXT:    sthcx. 4, 0, 9
 ; CHECK-NEXT:    bne- 0, .LBB1_85
 ; CHECK-NEXT:  # %bb.86: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    sth 4, ss@toc@l(7)
+; CHECK-NEXT:    sth 3, ss@toc@l(6)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_87: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lharx 4, 0, 0
-; CHECK-NEXT:    and 5, 3, 4
-; CHECK-NEXT:    sthcx. 5, 0, 0
+; CHECK-NEXT:    lharx 3, 0, 12
+; CHECK-NEXT:    andi. 4, 3, 11
+; CHECK-NEXT:    sthcx. 4, 0, 12
 ; CHECK-NEXT:    bne- 0, .LBB1_87
 ; CHECK-NEXT:  # %bb.88: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    sth 4, us@toc@l(9)
+; CHECK-NEXT:    sth 3, us@toc@l(8)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_89: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 4, 0, 29
-; CHECK-NEXT:    and 5, 3, 4
-; CHECK-NEXT:    stwcx. 5, 0, 29
+; CHECK-NEXT:    lwarx 3, 0, 0
+; CHECK-NEXT:    andi. 4, 3, 11
+; CHECK-NEXT:    stwcx. 4, 0, 0
 ; CHECK-NEXT:    bne- 0, .LBB1_89
 ; CHECK-NEXT:  # %bb.90: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    stw 4, si@toc@l(12)
+; CHECK-NEXT:    stw 3, si@toc@l(11)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_91: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    lwarx 4, 0, 27
-; CHECK-NEXT:    and 5, 3, 4
-; CHECK-NEXT:    stwcx. 5, 0, 27
+; CHECK-NEXT:    lwarx 3, 0, 28
+; CHECK-NEXT:    andi. 4, 3, 11
+; CHECK-NEXT:    stwcx. 4, 0, 28
 ; CHECK-NEXT:    bne- 0, .LBB1_91
 ; CHECK-NEXT:  # %bb.92: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    stw 4, ui@toc@l(30)
+; CHECK-NEXT:    stw 3, ui@toc@l(30)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_93: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 3, 0, 25
-; CHECK-NEXT:    and 4, 11, 3
-; CHECK-NEXT:    stdcx. 4, 0, 25
+; CHECK-NEXT:    ldarx 3, 0, 26
+; CHECK-NEXT:    and 4, 10, 3
+; CHECK-NEXT:    stdcx. 4, 0, 26
 ; CHECK-NEXT:    bne- 0, .LBB1_93
 ; CHECK-NEXT:  # %bb.94: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    std 3, sll@toc@l(28)
+; CHECK-NEXT:    std 3, sll@toc@l(29)
 ; CHECK-NEXT:    sync
 ; CHECK-NEXT:  .LBB1_95: # %entry
 ; CHECK-NEXT:    #
-; CHECK-NEXT:    ldarx 3, 0, 24
-; CHECK-NEXT:    and 4, 11, 3
-; CHECK-NEXT:    stdcx. 4, 0, 24
+; CHECK-NEXT:    ldarx 3, 0, 25
+; CHECK-NEXT:    and 4, 10, 3
+; CHECK-NEXT:    stdcx. 4, 0, 25
 ; CHECK-NEXT:    bne- 0, .LBB1_95
 ; CHECK-NEXT:  # %bb.96: # %entry
 ; CHECK-NEXT:    lwsync
-; CHECK-NEXT:    std 3, ull@toc@l(26)
+; CHECK-NEXT:    std 3, ull@toc@l(27)
 ; CHECK-NEXT:    ld 30, -16(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    ld 29, -24(1) # 8-byte Folded Reload
 ; CHECK-NEXT:    ld 28, -32(1) # 8-byte Folded Reload
@@ -1771,7 +1771,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwz 4, L..C0(2) # @sc
 ; AIX32-NEXT:    stw 0, 152(1)
 ; AIX32-NEXT:    li 7, 11
-; AIX32-NEXT:    stw 26, 120(1) # 4-byte Folded Spill
+; AIX32-NEXT:    stw 27, 124(1) # 4-byte Folded Spill
 ; AIX32-NEXT:    stw 13, 68(1) # 4-byte Folded Spill
 ; AIX32-NEXT:    stw 14, 72(1) # 4-byte Folded Spill
 ; AIX32-NEXT:    stw 15, 76(1) # 4-byte Folded Spill
@@ -1779,9 +1779,9 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    stw 16, 80(1) # 4-byte Folded Spill
 ; AIX32-NEXT:    stw 17, 84(1) # 4-byte Folded Spill
 ; AIX32-NEXT:    stw 18, 88(1) # 4-byte Folded Spill
-; AIX32-NEXT:    xori 26, 3, 24
+; AIX32-NEXT:    xori 27, 3, 24
 ; AIX32-NEXT:    li 3, 255
-; AIX32-NEXT:    slw 3, 3, 26
+; AIX32-NEXT:    slw 3, 3, 27
 ; AIX32-NEXT:    stw 19, 92(1) # 4-byte Folded Spill
 ; AIX32-NEXT:    stw 20, 96(1) # 4-byte Folded Spill
 ; AIX32-NEXT:    stw 21, 100(1) # 4-byte Folded Spill
@@ -1789,116 +1789,116 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    stw 23, 108(1) # 4-byte Folded Spill
 ; AIX32-NEXT:    stw 24, 112(1) # 4-byte Folded Spill
 ; AIX32-NEXT:    stw 25, 116(1) # 4-byte Folded Spill
-; AIX32-NEXT:    stw 27, 124(1) # 4-byte Folded Spill
+; AIX32-NEXT:    stw 26, 120(1) # 4-byte Folded Spill
 ; AIX32-NEXT:    stw 28, 128(1) # 4-byte Folded Spill
 ; AIX32-NEXT:    stw 29, 132(1) # 4-byte Folded Spill
 ; AIX32-NEXT:    stw 30, 136(1) # 4-byte Folded Spill
 ; AIX32-NEXT:    stw 31, 140(1) # 4-byte Folded Spill
 ; AIX32-NEXT:    sync
-; AIX32-NEXT:    rlwinm 25, 4, 0, 0, 29
-; AIX32-NEXT:    slw 24, 7, 26
+; AIX32-NEXT:    rlwinm 26, 4, 0, 0, 29
+; AIX32-NEXT:    slw 25, 7, 27
 ; AIX32-NEXT:    stw 4, 64(1) # 4-byte Folded Spill
 ; AIX32-NEXT:  L..BB1_1: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 25
-; AIX32-NEXT:    add 5, 24, 4
+; AIX32-NEXT:    lwarx 4, 0, 26
+; AIX32-NEXT:    add 5, 25, 4
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 25
+; AIX32-NEXT:    stwcx. 5, 0, 26
 ; AIX32-NEXT:    bne- 0, L..BB1_1
 ; AIX32-NEXT:  # %bb.2: # %entry
-; AIX32-NEXT:    srw 3, 4, 26
+; AIX32-NEXT:    srw 3, 4, 27
 ; AIX32-NEXT:    lwsync
-; AIX32-NEXT:    lwz 27, L..C1(2) # @uc
+; AIX32-NEXT:    lwz 28, L..C1(2) # @uc
 ; AIX32-NEXT:    lwz 4, 64(1) # 4-byte Folded Reload
 ; AIX32-NEXT:    clrlwi 3, 3, 24
-; AIX32-NEXT:    rlwinm 21, 27, 0, 0, 29
+; AIX32-NEXT:    rlwinm 22, 28, 0, 0, 29
 ; AIX32-NEXT:    stb 3, 0(4)
-; AIX32-NEXT:    rlwinm 3, 27, 3, 27, 28
+; AIX32-NEXT:    rlwinm 3, 28, 3, 27, 28
 ; AIX32-NEXT:    sync
-; AIX32-NEXT:    xori 22, 3, 24
+; AIX32-NEXT:    xori 23, 3, 24
 ; AIX32-NEXT:    li 3, 255
-; AIX32-NEXT:    slw 20, 7, 22
-; AIX32-NEXT:    slw 3, 3, 22
+; AIX32-NEXT:    slw 21, 7, 23
+; AIX32-NEXT:    slw 3, 3, 23
 ; AIX32-NEXT:  L..BB1_3: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 21
-; AIX32-NEXT:    add 5, 20, 4
+; AIX32-NEXT:    lwarx 4, 0, 22
+; AIX32-NEXT:    add 5, 21, 4
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 21
+; AIX32-NEXT:    stwcx. 5, 0, 22
 ; AIX32-NEXT:    bne- 0, L..BB1_3
 ; AIX32-NEXT:  # %bb.4: # %entry
-; AIX32-NEXT:    srw 3, 4, 22
-; AIX32-NEXT:    lwz 23, L..C2(2) # @ss
+; AIX32-NEXT:    srw 3, 4, 23
+; AIX32-NEXT:    lwz 24, L..C2(2) # @ss
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    clrlwi 3, 3, 24
-; AIX32-NEXT:    rlwinm 17, 23, 0, 0, 29
-; AIX32-NEXT:    stb 3, 0(27)
+; AIX32-NEXT:    rlwinm 18, 24, 0, 0, 29
+; AIX32-NEXT:    stb 3, 0(28)
 ; AIX32-NEXT:    sync
-; AIX32-NEXT:    rlwinm 3, 23, 3, 27, 27
-; AIX32-NEXT:    xori 18, 3, 16
+; AIX32-NEXT:    rlwinm 3, 24, 3, 27, 27
+; AIX32-NEXT:    xori 19, 3, 16
 ; AIX32-NEXT:    li 3, 0
 ; AIX32-NEXT:    ori 3, 3, 65535
-; AIX32-NEXT:    slw 16, 7, 18
-; AIX32-NEXT:    slw 3, 3, 18
+; AIX32-NEXT:    slw 17, 7, 19
+; AIX32-NEXT:    slw 3, 3, 19
 ; AIX32-NEXT:  L..BB1_5: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 17
-; AIX32-NEXT:    add 5, 16, 4
+; AIX32-NEXT:    lwarx 4, 0, 18
+; AIX32-NEXT:    add 5, 17, 4
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 17
+; AIX32-NEXT:    stwcx. 5, 0, 18
 ; AIX32-NEXT:    bne- 0, L..BB1_5
 ; AIX32-NEXT:  # %bb.6: # %entry
-; AIX32-NEXT:    srw 3, 4, 18
-; AIX32-NEXT:    lwz 19, L..C3(2) # @us
+; AIX32-NEXT:    srw 3, 4, 19
+; AIX32-NEXT:    lwz 20, L..C3(2) # @us
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    clrlwi 3, 3, 16
-; AIX32-NEXT:    rlwinm 14, 19, 0, 0, 29
-; AIX32-NEXT:    sth 3, 0(23)
+; AIX32-NEXT:    rlwinm 15, 20, 0, 0, 29
+; AIX32-NEXT:    sth 3, 0(24)
 ; AIX32-NEXT:    sync
-; AIX32-NEXT:    rlwinm 3, 19, 3, 27, 27
-; AIX32-NEXT:    xori 15, 3, 16
+; AIX32-NEXT:    rlwinm 3, 20, 3, 27, 27
+; AIX32-NEXT:    xori 16, 3, 16
 ; AIX32-NEXT:    li 3, 0
 ; AIX32-NEXT:    ori 3, 3, 65535
-; AIX32-NEXT:    slw 13, 7, 15
-; AIX32-NEXT:    slw 3, 3, 15
+; AIX32-NEXT:    slw 14, 7, 16
+; AIX32-NEXT:    slw 3, 3, 16
 ; AIX32-NEXT:  L..BB1_7: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 14
-; AIX32-NEXT:    add 5, 13, 4
+; AIX32-NEXT:    lwarx 4, 0, 15
+; AIX32-NEXT:    add 5, 14, 4
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 14
+; AIX32-NEXT:    stwcx. 5, 0, 15
 ; AIX32-NEXT:    bne- 0, L..BB1_7
 ; AIX32-NEXT:  # %bb.8: # %entry
-; AIX32-NEXT:    srw 3, 4, 15
+; AIX32-NEXT:    srw 3, 4, 16
 ; AIX32-NEXT:    lwsync
-; AIX32-NEXT:    lwz 29, L..C4(2) # @si
+; AIX32-NEXT:    lwz 13, L..C4(2) # @si
 ; AIX32-NEXT:    clrlwi 3, 3, 16
-; AIX32-NEXT:    sth 3, 0(19)
+; AIX32-NEXT:    sth 3, 0(20)
 ; AIX32-NEXT:    sync
 ; AIX32-NEXT:  L..BB1_9: # %entry
+; AIX32-NEXT:    #
+; AIX32-NEXT:    lwarx 3, 0, 13
+; AIX32-NEXT:    addi 4, 3, 11
+; AIX32-NEXT:    stwcx. 4, 0, 13
+; AIX32-NEXT:    bne- 0, L..BB1_9
+; AIX32-NEXT:  # %bb.10: # %entry
+; AIX32-NEXT:    lwsync
+; AIX32-NEXT:    stw 3, 0(13)
+; AIX32-NEXT:    lwz 29, L..C5(2) # @ui
+; AIX32-NEXT:    sync
+; AIX32-NEXT:  L..BB1_11: # %entry
 ; AIX32-NEXT:    #
 ; AIX32-NEXT:    lwarx 3, 0, 29
 ; AIX32-NEXT:    addi 4, 3, 11
 ; AIX32-NEXT:    stwcx. 4, 0, 29
-; AIX32-NEXT:    bne- 0, L..BB1_9
-; AIX32-NEXT:  # %bb.10: # %entry
-; AIX32-NEXT:    lwsync
-; AIX32-NEXT:    stw 3, 0(29)
-; AIX32-NEXT:    lwz 28, L..C5(2) # @ui
-; AIX32-NEXT:    sync
-; AIX32-NEXT:  L..BB1_11: # %entry
-; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 3, 0, 28
-; AIX32-NEXT:    addi 4, 3, 11
-; AIX32-NEXT:    stwcx. 4, 0, 28
 ; AIX32-NEXT:    bne- 0, L..BB1_11
 ; AIX32-NEXT:  # %bb.12: # %entry
 ; AIX32-NEXT:    lwz 31, L..C6(2) # @sll
@@ -1906,7 +1906,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    li 4, 0
 ; AIX32-NEXT:    li 5, 11
 ; AIX32-NEXT:    li 6, 5
-; AIX32-NEXT:    stw 3, 0(28)
+; AIX32-NEXT:    stw 3, 0(29)
 ; AIX32-NEXT:    mr 3, 31
 ; AIX32-NEXT:    bl .__atomic_fetch_add_8[PR]
 ; AIX32-NEXT:    nop
@@ -1923,99 +1923,99 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    li 3, 255
 ; AIX32-NEXT:    stw 4, 4(30)
 ; AIX32-NEXT:    sync
-; AIX32-NEXT:    slw 3, 3, 26
+; AIX32-NEXT:    slw 3, 3, 27
 ; AIX32-NEXT:  L..BB1_13: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 25
-; AIX32-NEXT:    sub 5, 4, 24
+; AIX32-NEXT:    lwarx 4, 0, 26
+; AIX32-NEXT:    sub 5, 4, 25
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 25
+; AIX32-NEXT:    stwcx. 5, 0, 26
 ; AIX32-NEXT:    bne- 0, L..BB1_13
 ; AIX32-NEXT:  # %bb.14: # %entry
-; AIX32-NEXT:    srw 3, 4, 26
+; AIX32-NEXT:    srw 3, 4, 27
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    lwz 4, 64(1) # 4-byte Folded Reload
 ; AIX32-NEXT:    clrlwi 3, 3, 24
 ; AIX32-NEXT:    stb 3, 0(4)
 ; AIX32-NEXT:    li 3, 255
 ; AIX32-NEXT:    sync
-; AIX32-NEXT:    slw 3, 3, 22
+; AIX32-NEXT:    slw 3, 3, 23
 ; AIX32-NEXT:  L..BB1_15: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 21
-; AIX32-NEXT:    sub 5, 4, 20
+; AIX32-NEXT:    lwarx 4, 0, 22
+; AIX32-NEXT:    sub 5, 4, 21
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 21
+; AIX32-NEXT:    stwcx. 5, 0, 22
 ; AIX32-NEXT:    bne- 0, L..BB1_15
 ; AIX32-NEXT:  # %bb.16: # %entry
-; AIX32-NEXT:    srw 3, 4, 22
+; AIX32-NEXT:    srw 3, 4, 23
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    li 7, 11
 ; AIX32-NEXT:    clrlwi 3, 3, 24
-; AIX32-NEXT:    stb 3, 0(27)
+; AIX32-NEXT:    stb 3, 0(28)
 ; AIX32-NEXT:    sync
 ; AIX32-NEXT:    li 3, 0
 ; AIX32-NEXT:    ori 3, 3, 65535
-; AIX32-NEXT:    slw 3, 3, 18
+; AIX32-NEXT:    slw 3, 3, 19
 ; AIX32-NEXT:  L..BB1_17: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 17
-; AIX32-NEXT:    sub 5, 4, 16
+; AIX32-NEXT:    lwarx 4, 0, 18
+; AIX32-NEXT:    sub 5, 4, 17
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 17
+; AIX32-NEXT:    stwcx. 5, 0, 18
 ; AIX32-NEXT:    bne- 0, L..BB1_17
 ; AIX32-NEXT:  # %bb.18: # %entry
-; AIX32-NEXT:    srw 3, 4, 18
+; AIX32-NEXT:    srw 3, 4, 19
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    clrlwi 3, 3, 16
-; AIX32-NEXT:    sth 3, 0(23)
+; AIX32-NEXT:    sth 3, 0(24)
 ; AIX32-NEXT:    li 3, 0
 ; AIX32-NEXT:    sync
 ; AIX32-NEXT:    ori 3, 3, 65535
-; AIX32-NEXT:    slw 3, 3, 15
+; AIX32-NEXT:    slw 3, 3, 16
 ; AIX32-NEXT:  L..BB1_19: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 14
-; AIX32-NEXT:    sub 5, 4, 13
+; AIX32-NEXT:    lwarx 4, 0, 15
+; AIX32-NEXT:    sub 5, 4, 14
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 14
+; AIX32-NEXT:    stwcx. 5, 0, 15
 ; AIX32-NEXT:    bne- 0, L..BB1_19
 ; AIX32-NEXT:  # %bb.20: # %entry
-; AIX32-NEXT:    srw 3, 4, 15
+; AIX32-NEXT:    srw 3, 4, 16
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    clrlwi 3, 3, 16
-; AIX32-NEXT:    sth 3, 0(19)
+; AIX32-NEXT:    sth 3, 0(20)
 ; AIX32-NEXT:    sync
 ; AIX32-NEXT:  L..BB1_21: # %entry
+; AIX32-NEXT:    #
+; AIX32-NEXT:    lwarx 3, 0, 13
+; AIX32-NEXT:    sub 4, 3, 7
+; AIX32-NEXT:    stwcx. 4, 0, 13
+; AIX32-NEXT:    bne- 0, L..BB1_21
+; AIX32-NEXT:  # %bb.22: # %entry
+; AIX32-NEXT:    lwsync
+; AIX32-NEXT:    stw 3, 0(13)
+; AIX32-NEXT:    sync
+; AIX32-NEXT:  L..BB1_23: # %entry
 ; AIX32-NEXT:    #
 ; AIX32-NEXT:    lwarx 3, 0, 29
 ; AIX32-NEXT:    sub 4, 3, 7
 ; AIX32-NEXT:    stwcx. 4, 0, 29
-; AIX32-NEXT:    bne- 0, L..BB1_21
-; AIX32-NEXT:  # %bb.22: # %entry
-; AIX32-NEXT:    lwsync
-; AIX32-NEXT:    stw 3, 0(29)
-; AIX32-NEXT:    sync
-; AIX32-NEXT:  L..BB1_23: # %entry
-; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 3, 0, 28
-; AIX32-NEXT:    sub 4, 3, 7
-; AIX32-NEXT:    stwcx. 4, 0, 28
 ; AIX32-NEXT:    bne- 0, L..BB1_23
 ; AIX32-NEXT:  # %bb.24: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    li 4, 0
 ; AIX32-NEXT:    li 5, 11
 ; AIX32-NEXT:    li 6, 5
-; AIX32-NEXT:    stw 3, 0(28)
+; AIX32-NEXT:    stw 3, 0(29)
 ; AIX32-NEXT:    mr 3, 31
 ; AIX32-NEXT:    bl .__atomic_fetch_sub_8[PR]
 ; AIX32-NEXT:    nop
@@ -2031,98 +2031,98 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    li 3, 255
 ; AIX32-NEXT:    stw 4, 4(30)
 ; AIX32-NEXT:    sync
-; AIX32-NEXT:    slw 3, 3, 26
+; AIX32-NEXT:    slw 3, 3, 27
 ; AIX32-NEXT:  L..BB1_25: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 25
-; AIX32-NEXT:    or 5, 24, 4
+; AIX32-NEXT:    lwarx 4, 0, 26
+; AIX32-NEXT:    or 5, 25, 4
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 25
+; AIX32-NEXT:    stwcx. 5, 0, 26
 ; AIX32-NEXT:    bne- 0, L..BB1_25
 ; AIX32-NEXT:  # %bb.26: # %entry
-; AIX32-NEXT:    srw 3, 4, 26
+; AIX32-NEXT:    srw 3, 4, 27
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    lwz 4, 64(1) # 4-byte Folded Reload
 ; AIX32-NEXT:    clrlwi 3, 3, 24
 ; AIX32-NEXT:    stb 3, 0(4)
 ; AIX32-NEXT:    li 3, 255
 ; AIX32-NEXT:    sync
-; AIX32-NEXT:    slw 3, 3, 22
+; AIX32-NEXT:    slw 3, 3, 23
 ; AIX32-NEXT:  L..BB1_27: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 21
-; AIX32-NEXT:    or 5, 20, 4
+; AIX32-NEXT:    lwarx 4, 0, 22
+; AIX32-NEXT:    or 5, 21, 4
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 21
+; AIX32-NEXT:    stwcx. 5, 0, 22
 ; AIX32-NEXT:    bne- 0, L..BB1_27
 ; AIX32-NEXT:  # %bb.28: # %entry
-; AIX32-NEXT:    srw 3, 4, 22
+; AIX32-NEXT:    srw 3, 4, 23
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    clrlwi 3, 3, 24
-; AIX32-NEXT:    stb 3, 0(27)
+; AIX32-NEXT:    stb 3, 0(28)
 ; AIX32-NEXT:    li 3, 0
 ; AIX32-NEXT:    sync
 ; AIX32-NEXT:    ori 3, 3, 65535
-; AIX32-NEXT:    slw 3, 3, 18
+; AIX32-NEXT:    slw 3, 3, 19
 ; AIX32-NEXT:  L..BB1_29: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 17
-; AIX32-NEXT:    or 5, 16, 4
+; AIX32-NEXT:    lwarx 4, 0, 18
+; AIX32-NEXT:    or 5, 17, 4
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 17
+; AIX32-NEXT:    stwcx. 5, 0, 18
 ; AIX32-NEXT:    bne- 0, L..BB1_29
 ; AIX32-NEXT:  # %bb.30: # %entry
-; AIX32-NEXT:    srw 3, 4, 18
+; AIX32-NEXT:    srw 3, 4, 19
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    clrlwi 3, 3, 16
-; AIX32-NEXT:    sth 3, 0(23)
+; AIX32-NEXT:    sth 3, 0(24)
 ; AIX32-NEXT:    li 3, 0
 ; AIX32-NEXT:    sync
 ; AIX32-NEXT:    ori 3, 3, 65535
-; AIX32-NEXT:    slw 3, 3, 15
+; AIX32-NEXT:    slw 3, 3, 16
 ; AIX32-NEXT:  L..BB1_31: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 14
-; AIX32-NEXT:    or 5, 13, 4
+; AIX32-NEXT:    lwarx 4, 0, 15
+; AIX32-NEXT:    or 5, 14, 4
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 14
+; AIX32-NEXT:    stwcx. 5, 0, 15
 ; AIX32-NEXT:    bne- 0, L..BB1_31
 ; AIX32-NEXT:  # %bb.32: # %entry
-; AIX32-NEXT:    srw 3, 4, 15
+; AIX32-NEXT:    srw 3, 4, 16
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    clrlwi 3, 3, 16
-; AIX32-NEXT:    sth 3, 0(19)
+; AIX32-NEXT:    sth 3, 0(20)
 ; AIX32-NEXT:    sync
 ; AIX32-NEXT:  L..BB1_33: # %entry
+; AIX32-NEXT:    #
+; AIX32-NEXT:    lwarx 3, 0, 13
+; AIX32-NEXT:    ori 4, 3, 11
+; AIX32-NEXT:    stwcx. 4, 0, 13
+; AIX32-NEXT:    bne- 0, L..BB1_33
+; AIX32-NEXT:  # %bb.34: # %entry
+; AIX32-NEXT:    lwsync
+; AIX32-NEXT:    stw 3, 0(13)
+; AIX32-NEXT:    sync
+; AIX32-NEXT:  L..BB1_35: # %entry
 ; AIX32-NEXT:    #
 ; AIX32-NEXT:    lwarx 3, 0, 29
 ; AIX32-NEXT:    ori 4, 3, 11
 ; AIX32-NEXT:    stwcx. 4, 0, 29
-; AIX32-NEXT:    bne- 0, L..BB1_33
-; AIX32-NEXT:  # %bb.34: # %entry
-; AIX32-NEXT:    lwsync
-; AIX32-NEXT:    stw 3, 0(29)
-; AIX32-NEXT:    sync
-; AIX32-NEXT:  L..BB1_35: # %entry
-; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 3, 0, 28
-; AIX32-NEXT:    ori 4, 3, 11
-; AIX32-NEXT:    stwcx. 4, 0, 28
 ; AIX32-NEXT:    bne- 0, L..BB1_35
 ; AIX32-NEXT:  # %bb.36: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    li 4, 0
 ; AIX32-NEXT:    li 5, 11
 ; AIX32-NEXT:    li 6, 5
-; AIX32-NEXT:    stw 3, 0(28)
+; AIX32-NEXT:    stw 3, 0(29)
 ; AIX32-NEXT:    mr 3, 31
 ; AIX32-NEXT:    bl .__atomic_fetch_or_8[PR]
 ; AIX32-NEXT:    nop
@@ -2138,98 +2138,98 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    li 3, 255
 ; AIX32-NEXT:    stw 4, 4(30)
 ; AIX32-NEXT:    sync
-; AIX32-NEXT:    slw 3, 3, 26
+; AIX32-NEXT:    slw 3, 3, 27
 ; AIX32-NEXT:  L..BB1_37: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 25
-; AIX32-NEXT:    xor 5, 24, 4
+; AIX32-NEXT:    lwarx 4, 0, 26
+; AIX32-NEXT:    xor 5, 25, 4
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 25
+; AIX32-NEXT:    stwcx. 5, 0, 26
 ; AIX32-NEXT:    bne- 0, L..BB1_37
 ; AIX32-NEXT:  # %bb.38: # %entry
-; AIX32-NEXT:    srw 3, 4, 26
+; AIX32-NEXT:    srw 3, 4, 27
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    lwz 4, 64(1) # 4-byte Folded Reload
 ; AIX32-NEXT:    clrlwi 3, 3, 24
 ; AIX32-NEXT:    stb 3, 0(4)
 ; AIX32-NEXT:    li 3, 255
 ; AIX32-NEXT:    sync
-; AIX32-NEXT:    slw 3, 3, 22
+; AIX32-NEXT:    slw 3, 3, 23
 ; AIX32-NEXT:  L..BB1_39: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 21
-; AIX32-NEXT:    xor 5, 20, 4
+; AIX32-NEXT:    lwarx 4, 0, 22
+; AIX32-NEXT:    xor 5, 21, 4
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 21
+; AIX32-NEXT:    stwcx. 5, 0, 22
 ; AIX32-NEXT:    bne- 0, L..BB1_39
 ; AIX32-NEXT:  # %bb.40: # %entry
-; AIX32-NEXT:    srw 3, 4, 22
+; AIX32-NEXT:    srw 3, 4, 23
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    clrlwi 3, 3, 24
-; AIX32-NEXT:    stb 3, 0(27)
+; AIX32-NEXT:    stb 3, 0(28)
 ; AIX32-NEXT:    li 3, 0
 ; AIX32-NEXT:    sync
 ; AIX32-NEXT:    ori 3, 3, 65535
-; AIX32-NEXT:    slw 3, 3, 18
+; AIX32-NEXT:    slw 3, 3, 19
 ; AIX32-NEXT:  L..BB1_41: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 17
-; AIX32-NEXT:    xor 5, 16, 4
+; AIX32-NEXT:    lwarx 4, 0, 18
+; AIX32-NEXT:    xor 5, 17, 4
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 17
+; AIX32-NEXT:    stwcx. 5, 0, 18
 ; AIX32-NEXT:    bne- 0, L..BB1_41
 ; AIX32-NEXT:  # %bb.42: # %entry
-; AIX32-NEXT:    srw 3, 4, 18
+; AIX32-NEXT:    srw 3, 4, 19
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    clrlwi 3, 3, 16
-; AIX32-NEXT:    sth 3, 0(23)
+; AIX32-NEXT:    sth 3, 0(24)
 ; AIX32-NEXT:    li 3, 0
 ; AIX32-NEXT:    sync
 ; AIX32-NEXT:    ori 3, 3, 65535
-; AIX32-NEXT:    slw 3, 3, 15
+; AIX32-NEXT:    slw 3, 3, 16
 ; AIX32-NEXT:  L..BB1_43: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 14
-; AIX32-NEXT:    xor 5, 13, 4
+; AIX32-NEXT:    lwarx 4, 0, 15
+; AIX32-NEXT:    xor 5, 14, 4
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 14
+; AIX32-NEXT:    stwcx. 5, 0, 15
 ; AIX32-NEXT:    bne- 0, L..BB1_43
 ; AIX32-NEXT:  # %bb.44: # %entry
-; AIX32-NEXT:    srw 3, 4, 15
+; AIX32-NEXT:    srw 3, 4, 16
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    clrlwi 3, 3, 16
-; AIX32-NEXT:    sth 3, 0(19)
+; AIX32-NEXT:    sth 3, 0(20)
 ; AIX32-NEXT:    sync
 ; AIX32-NEXT:  L..BB1_45: # %entry
+; AIX32-NEXT:    #
+; AIX32-NEXT:    lwarx 3, 0, 13
+; AIX32-NEXT:    xori 4, 3, 11
+; AIX32-NEXT:    stwcx. 4, 0, 13
+; AIX32-NEXT:    bne- 0, L..BB1_45
+; AIX32-NEXT:  # %bb.46: # %entry
+; AIX32-NEXT:    lwsync
+; AIX32-NEXT:    stw 3, 0(13)
+; AIX32-NEXT:    sync
+; AIX32-NEXT:  L..BB1_47: # %entry
 ; AIX32-NEXT:    #
 ; AIX32-NEXT:    lwarx 3, 0, 29
 ; AIX32-NEXT:    xori 4, 3, 11
 ; AIX32-NEXT:    stwcx. 4, 0, 29
-; AIX32-NEXT:    bne- 0, L..BB1_45
-; AIX32-NEXT:  # %bb.46: # %entry
-; AIX32-NEXT:    lwsync
-; AIX32-NEXT:    stw 3, 0(29)
-; AIX32-NEXT:    sync
-; AIX32-NEXT:  L..BB1_47: # %entry
-; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 3, 0, 28
-; AIX32-NEXT:    xori 4, 3, 11
-; AIX32-NEXT:    stwcx. 4, 0, 28
 ; AIX32-NEXT:    bne- 0, L..BB1_47
 ; AIX32-NEXT:  # %bb.48: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    li 4, 0
 ; AIX32-NEXT:    li 5, 11
 ; AIX32-NEXT:    li 6, 5
-; AIX32-NEXT:    stw 3, 0(28)
+; AIX32-NEXT:    stw 3, 0(29)
 ; AIX32-NEXT:    mr 3, 31
 ; AIX32-NEXT:    bl .__atomic_fetch_xor_8[PR]
 ; AIX32-NEXT:    nop
@@ -2245,18 +2245,18 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    li 3, 255
 ; AIX32-NEXT:    stw 4, 4(30)
 ; AIX32-NEXT:    sync
-; AIX32-NEXT:    slw 3, 3, 26
+; AIX32-NEXT:    slw 3, 3, 27
 ; AIX32-NEXT:  L..BB1_49: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 25
-; AIX32-NEXT:    nand 5, 24, 4
+; AIX32-NEXT:    lwarx 4, 0, 26
+; AIX32-NEXT:    nand 5, 25, 4
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 25
+; AIX32-NEXT:    stwcx. 5, 0, 26
 ; AIX32-NEXT:    bne- 0, L..BB1_49
 ; AIX32-NEXT:  # %bb.50: # %entry
-; AIX32-NEXT:    srw 3, 4, 26
+; AIX32-NEXT:    srw 3, 4, 27
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    li 7, 11
 ; AIX32-NEXT:    lwz 4, 64(1) # 4-byte Folded Reload
@@ -2264,80 +2264,80 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    stb 3, 0(4)
 ; AIX32-NEXT:    sync
 ; AIX32-NEXT:    li 3, 255
-; AIX32-NEXT:    slw 3, 3, 22
+; AIX32-NEXT:    slw 3, 3, 23
 ; AIX32-NEXT:  L..BB1_51: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 21
-; AIX32-NEXT:    nand 5, 20, 4
+; AIX32-NEXT:    lwarx 4, 0, 22
+; AIX32-NEXT:    nand 5, 21, 4
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 21
+; AIX32-NEXT:    stwcx. 5, 0, 22
 ; AIX32-NEXT:    bne- 0, L..BB1_51
 ; AIX32-NEXT:  # %bb.52: # %entry
-; AIX32-NEXT:    srw 3, 4, 22
+; AIX32-NEXT:    srw 3, 4, 23
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    clrlwi 3, 3, 24
-; AIX32-NEXT:    stb 3, 0(27)
+; AIX32-NEXT:    stb 3, 0(28)
 ; AIX32-NEXT:    li 3, 0
 ; AIX32-NEXT:    sync
 ; AIX32-NEXT:    ori 3, 3, 65535
-; AIX32-NEXT:    slw 3, 3, 18
+; AIX32-NEXT:    slw 3, 3, 19
 ; AIX32-NEXT:  L..BB1_53: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 17
-; AIX32-NEXT:    nand 5, 16, 4
+; AIX32-NEXT:    lwarx 4, 0, 18
+; AIX32-NEXT:    nand 5, 17, 4
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 17
+; AIX32-NEXT:    stwcx. 5, 0, 18
 ; AIX32-NEXT:    bne- 0, L..BB1_53
 ; AIX32-NEXT:  # %bb.54: # %entry
-; AIX32-NEXT:    srw 3, 4, 18
+; AIX32-NEXT:    srw 3, 4, 19
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    clrlwi 3, 3, 16
-; AIX32-NEXT:    sth 3, 0(23)
+; AIX32-NEXT:    sth 3, 0(24)
 ; AIX32-NEXT:    li 3, 0
 ; AIX32-NEXT:    sync
 ; AIX32-NEXT:    ori 3, 3, 65535
-; AIX32-NEXT:    slw 3, 3, 15
+; AIX32-NEXT:    slw 3, 3, 16
 ; AIX32-NEXT:  L..BB1_55: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 14
-; AIX32-NEXT:    nand 5, 13, 4
+; AIX32-NEXT:    lwarx 4, 0, 15
+; AIX32-NEXT:    nand 5, 14, 4
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 14
+; AIX32-NEXT:    stwcx. 5, 0, 15
 ; AIX32-NEXT:    bne- 0, L..BB1_55
 ; AIX32-NEXT:  # %bb.56: # %entry
-; AIX32-NEXT:    srw 3, 4, 15
+; AIX32-NEXT:    srw 3, 4, 16
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    clrlwi 3, 3, 16
-; AIX32-NEXT:    sth 3, 0(19)
+; AIX32-NEXT:    sth 3, 0(20)
 ; AIX32-NEXT:    sync
 ; AIX32-NEXT:  L..BB1_57: # %entry
+; AIX32-NEXT:    #
+; AIX32-NEXT:    lwarx 3, 0, 13
+; AIX32-NEXT:    nand 4, 7, 3
+; AIX32-NEXT:    stwcx. 4, 0, 13
+; AIX32-NEXT:    bne- 0, L..BB1_57
+; AIX32-NEXT:  # %bb.58: # %entry
+; AIX32-NEXT:    lwsync
+; AIX32-NEXT:    stw 3, 0(13)
+; AIX32-NEXT:    sync
+; AIX32-NEXT:  L..BB1_59: # %entry
 ; AIX32-NEXT:    #
 ; AIX32-NEXT:    lwarx 3, 0, 29
 ; AIX32-NEXT:    nand 4, 7, 3
 ; AIX32-NEXT:    stwcx. 4, 0, 29
-; AIX32-NEXT:    bne- 0, L..BB1_57
-; AIX32-NEXT:  # %bb.58: # %entry
-; AIX32-NEXT:    lwsync
-; AIX32-NEXT:    stw 3, 0(29)
-; AIX32-NEXT:    sync
-; AIX32-NEXT:  L..BB1_59: # %entry
-; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 3, 0, 28
-; AIX32-NEXT:    nand 4, 7, 3
-; AIX32-NEXT:    stwcx. 4, 0, 28
 ; AIX32-NEXT:    bne- 0, L..BB1_59
 ; AIX32-NEXT:  # %bb.60: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    li 4, 0
 ; AIX32-NEXT:    li 5, 11
 ; AIX32-NEXT:    li 6, 5
-; AIX32-NEXT:    stw 3, 0(28)
+; AIX32-NEXT:    stw 3, 0(29)
 ; AIX32-NEXT:    mr 3, 31
 ; AIX32-NEXT:    bl .__atomic_fetch_nand_8[PR]
 ; AIX32-NEXT:    nop
@@ -2353,99 +2353,98 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    li 3, 255
 ; AIX32-NEXT:    stw 4, 4(30)
 ; AIX32-NEXT:    sync
-; AIX32-NEXT:    slw 3, 3, 26
+; AIX32-NEXT:    slw 3, 3, 27
 ; AIX32-NEXT:  L..BB1_61: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 25
-; AIX32-NEXT:    and 5, 24, 4
+; AIX32-NEXT:    lwarx 4, 0, 26
+; AIX32-NEXT:    and 5, 25, 4
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 25
+; AIX32-NEXT:    stwcx. 5, 0, 26
 ; AIX32-NEXT:    bne- 0, L..BB1_61
 ; AIX32-NEXT:  # %bb.62: # %entry
-; AIX32-NEXT:    srw 3, 4, 26
+; AIX32-NEXT:    srw 3, 4, 27
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    lwz 4, 64(1) # 4-byte Folded Reload
 ; AIX32-NEXT:    clrlwi 3, 3, 24
 ; AIX32-NEXT:    stb 3, 0(4)
 ; AIX32-NEXT:    li 3, 255
 ; AIX32-NEXT:    sync
-; AIX32-NEXT:    slw 3, 3, 22
+; AIX32-NEXT:    slw 3, 3, 23
 ; AIX32-NEXT:  L..BB1_63: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 21
-; AIX32-NEXT:    and 5, 20, 4
+; AIX32-NEXT:    lwarx 4, 0, 22
+; AIX32-NEXT:    and 5, 21, 4
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 21
+; AIX32-NEXT:    stwcx. 5, 0, 22
 ; AIX32-NEXT:    bne- 0, L..BB1_63
 ; AIX32-NEXT:  # %bb.64: # %entry
-; AIX32-NEXT:    srw 3, 4, 22
+; AIX32-NEXT:    srw 3, 4, 23
 ; AIX32-NEXT:    lwsync
-; AIX32-NEXT:    li 7, 11
 ; AIX32-NEXT:    clrlwi 3, 3, 24
-; AIX32-NEXT:    stb 3, 0(27)
-; AIX32-NEXT:    sync
+; AIX32-NEXT:    stb 3, 0(28)
 ; AIX32-NEXT:    li 3, 0
+; AIX32-NEXT:    sync
 ; AIX32-NEXT:    ori 3, 3, 65535
-; AIX32-NEXT:    slw 3, 3, 18
+; AIX32-NEXT:    slw 3, 3, 19
 ; AIX32-NEXT:  L..BB1_65: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 17
-; AIX32-NEXT:    and 5, 16, 4
+; AIX32-NEXT:    lwarx 4, 0, 18
+; AIX32-NEXT:    and 5, 17, 4
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 17
+; AIX32-NEXT:    stwcx. 5, 0, 18
 ; AIX32-NEXT:    bne- 0, L..BB1_65
 ; AIX32-NEXT:  # %bb.66: # %entry
-; AIX32-NEXT:    srw 3, 4, 18
+; AIX32-NEXT:    srw 3, 4, 19
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    clrlwi 3, 3, 16
-; AIX32-NEXT:    sth 3, 0(23)
+; AIX32-NEXT:    sth 3, 0(24)
 ; AIX32-NEXT:    li 3, 0
 ; AIX32-NEXT:    sync
 ; AIX32-NEXT:    ori 3, 3, 65535
-; AIX32-NEXT:    slw 3, 3, 15
+; AIX32-NEXT:    slw 3, 3, 16
 ; AIX32-NEXT:  L..BB1_67: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 4, 0, 14
-; AIX32-NEXT:    and 5, 13, 4
+; AIX32-NEXT:    lwarx 4, 0, 15
+; AIX32-NEXT:    and 5, 14, 4
 ; AIX32-NEXT:    andc 6, 4, 3
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
-; AIX32-NEXT:    stwcx. 5, 0, 14
+; AIX32-NEXT:    stwcx. 5, 0, 15
 ; AIX32-NEXT:    bne- 0, L..BB1_67
 ; AIX32-NEXT:  # %bb.68: # %entry
-; AIX32-NEXT:    srw 3, 4, 15
+; AIX32-NEXT:    srw 3, 4, 16
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    clrlwi 3, 3, 16
-; AIX32-NEXT:    sth 3, 0(19)
+; AIX32-NEXT:    sth 3, 0(20)
 ; AIX32-NEXT:    sync
 ; AIX32-NEXT:  L..BB1_69: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 3, 0, 29
-; AIX32-NEXT:    and 4, 7, 3
-; AIX32-NEXT:    stwcx. 4, 0, 29
+; AIX32-NEXT:    lwarx 3, 0, 13
+; AIX32-NEXT:    andi. 4, 3, 11
+; AIX32-NEXT:    stwcx. 4, 0, 13
 ; AIX32-NEXT:    bne- 0, L..BB1_69
 ; AIX32-NEXT:  # %bb.70: # %entry
 ; AIX32-NEXT:    lwsync
-; AIX32-NEXT:    stw 3, 0(29)
+; AIX32-NEXT:    stw 3, 0(13)
 ; AIX32-NEXT:    sync
 ; AIX32-NEXT:  L..BB1_71: # %entry
 ; AIX32-NEXT:    #
-; AIX32-NEXT:    lwarx 3, 0, 28
-; AIX32-NEXT:    and 4, 7, 3
-; AIX32-NEXT:    stwcx. 4, 0, 28
+; AIX32-NEXT:    lwarx 3, 0, 29
+; AIX32-NEXT:    andi. 4, 3, 11
+; AIX32-NEXT:    stwcx. 4, 0, 29
 ; AIX32-NEXT:    bne- 0, L..BB1_71
 ; AIX32-NEXT:  # %bb.72: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    li 4, 0
 ; AIX32-NEXT:    li 5, 11
 ; AIX32-NEXT:    li 6, 5
-; AIX32-NEXT:    stw 3, 0(28)
+; AIX32-NEXT:    stw 3, 0(29)
 ; AIX32-NEXT:    mr 3, 31
 ; AIX32-NEXT:    bl .__atomic_fetch_and_8[PR]
 ; AIX32-NEXT:    nop


### PR DESCRIPTION
Adds pattern to use the immediate form of and, or, and xor for atomic loads. The matching is limited to 16-bit immediates, which seems to be the most used ones.