### PR TITLE
[IR][NFC] Fast path for Constant::isNullValue

### DIFF
--- a/llvm/include/llvm/IR/Constant.h
+++ b/llvm/include/llvm/IR/Constant.h
@@ -42,6 +42,15 @@ class APInt;
 /// LLVM Constant Representation
 class Constant : public User {
 protected:
+  /// SubclassOptionalData bits. Low bits are used by ConstantExpr.
+  enum {
+    IsNullValue = (1 << 6),
+  };
+
+  /// Bits reserveed in SubclassOptionalData, not to be used for ConstantExpr
+  /// flags.
+  static constexpr unsigned ConstantSubclassBits = IsNullValue;
+
   Constant(Type *ty, ValueTy vty, AllocInfo AllocInfo)
       : User(ty, vty, AllocInfo) {}
 
@@ -52,7 +61,7 @@ public:
   Constant(const Constant &) = delete;
 
   /// Return true if this is the value that would be returned by getNullValue.
-  LLVM_ABI bool isNullValue() const;
+  bool isNullValue() const { return SubclassOptionalData & IsNullValue; }
 
   /// Returns true if the value is one.
   LLVM_ABI bool isOneValue() const;

--- a/llvm/include/llvm/IR/Constant.h
+++ b/llvm/include/llvm/IR/Constant.h
@@ -47,7 +47,7 @@ protected:
     IsNullValue = (1 << 6),
   };
 
-  /// Bits reserveed in SubclassOptionalData, not to be used for ConstantExpr
+  /// Bits reserved in SubclassOptionalData, not to be used for ConstantExpr
   /// flags.
   static constexpr unsigned ConstantSubclassBits = IsNullValue;
 

--- a/llvm/include/llvm/IR/Constants.h
+++ b/llvm/include/llvm/IR/Constants.h
@@ -216,7 +216,7 @@ public:
   /// This is just a convenience method to make client code smaller for a
   /// common code. It also correctly performs the comparison without the
   /// potential for an assertion from getZExtValue().
-  bool isZero() const { return Val.isZero(); }
+  bool isZero() const { return isNullValue(); }
 
   /// This is just a convenience method to make client code smaller for a
   /// common case. It also correctly performs the comparison without the
@@ -509,7 +509,9 @@ class ConstantAggregateZero final : public ConstantData {
   friend class Constant;
 
   explicit ConstantAggregateZero(Type *Ty)
-      : ConstantData(Ty, ConstantAggregateZeroVal) {}
+      : ConstantData(Ty, ConstantAggregateZeroVal) {
+    SubclassOptionalData = IsNullValue;
+  }
 
   void destroyConstantImpl();
 
@@ -709,7 +711,9 @@ class ConstantPointerNull final : public ConstantData {
   friend class Constant;
 
   explicit ConstantPointerNull(Type *T)
-      : ConstantData(T, Value::ConstantPointerNullVal) {}
+      : ConstantData(T, Value::ConstantPointerNullVal) {
+    SubclassOptionalData = IsNullValue;
+  }
 
   void destroyConstantImpl();
 
@@ -1026,7 +1030,9 @@ class ConstantTokenNone final : public ConstantData {
   friend class Constant;
 
   explicit ConstantTokenNone(LLVMContext &Context)
-      : ConstantData(Type::getTokenTy(Context), ConstantTokenNoneVal) {}
+      : ConstantData(Type::getTokenTy(Context), ConstantTokenNoneVal) {
+    SubclassOptionalData = IsNullValue;
+  }
 
   void destroyConstantImpl();
 
@@ -1047,7 +1053,9 @@ class ConstantTargetNone final : public ConstantData {
   friend class Constant;
 
   explicit ConstantTargetNone(TargetExtType *T)
-      : ConstantData(T, Value::ConstantTargetNoneVal) {}
+      : ConstantData(T, Value::ConstantTargetNoneVal) {
+    SubclassOptionalData = IsNullValue;
+  }
 
   void destroyConstantImpl();
 

--- a/llvm/lib/IR/Constants.cpp
+++ b/llvm/lib/IR/Constants.cpp
@@ -1200,7 +1200,9 @@ ConstantFP::ConstantFP(Type *Ty, const APFloat &V)
     : ConstantData(Ty, ConstantFPVal), Val(V) {
   assert(&V.getSemantics() == &Ty->getScalarType()->getFltSemantics() &&
          "FP type Mismatch");
-  if (V.isExactlyValue(+0.0))
+  // ppc_fp128 determine isZero using high order double only
+  // so check the bitwise value to make sure all bits are zero.
+  if (V.bitcastToAPInt().isZero())
     SubclassOptionalData = IsNullValue;
 }
 

--- a/llvm/lib/IR/Constants.cpp
+++ b/llvm/lib/IR/Constants.cpp
@@ -65,26 +65,6 @@ bool Constant::isNegativeZeroValue() const {
   return isNullValue();
 }
 
-bool Constant::isNullValue() const {
-  // 0 is null.
-  if (const ConstantInt *CI = dyn_cast<ConstantInt>(this))
-    return CI->isZero();
-
-  // 0 is null.
-  if (const ConstantByte *CB = dyn_cast<ConstantByte>(this))
-    return CB->isZero();
-
-  if (const ConstantFP *CFP = dyn_cast<ConstantFP>(this))
-    // ppc_fp128 determine isZero using high order double only
-    // so check the bitwise value to make sure all bits are zero.
-    return CFP->getValue().bitcastToAPInt().isZero();
-
-  // constant zero is zero for aggregates, cpnull is null for pointers, none for
-  // tokens.
-  return isa<ConstantAggregateZero>(this) || isa<ConstantPointerNull>(this) ||
-         isa<ConstantTokenNone>(this) || isa<ConstantTargetNone>(this);
-}
-
 bool Constant::isAllOnesValue() const {
   // Check for -1 integers
   if (const ConstantInt *CI = dyn_cast<ConstantInt>(this))
@@ -906,6 +886,8 @@ ConstantInt::ConstantInt(Type *Ty, const APInt &V)
   assert(V.getBitWidth() ==
              cast<IntegerType>(Ty->getScalarType())->getBitWidth() &&
          "Invalid constant for type");
+  if (V.isZero())
+    SubclassOptionalData = IsNullValue;
 }
 
 ConstantInt *ConstantInt::getTrue(LLVMContext &Context) {
@@ -1031,6 +1013,8 @@ ConstantByte::ConstantByte(Type *Ty, const APInt &V)
   assert(V.getBitWidth() ==
              cast<ByteType>(Ty->getScalarType())->getBitWidth() &&
          "Invalid constant for type");
+  if (V.isZero())
+    SubclassOptionalData = IsNullValue;
 }
 
 // Get a ConstantByte from an APInt.
@@ -1216,6 +1200,8 @@ ConstantFP::ConstantFP(Type *Ty, const APFloat &V)
     : ConstantData(Ty, ConstantFPVal), Val(V) {
   assert(&V.getSemantics() == &Ty->getScalarType()->getFltSemantics() &&
          "FP type Mismatch");
+  if (V.isExactlyValue(+0.0))
+    SubclassOptionalData = IsNullValue;
 }
 
 bool ConstantFP::isExactlyValue(const APFloat &V) const {

--- a/llvm/lib/IR/ConstantsContext.h
+++ b/llvm/lib/IR/ConstantsContext.h
@@ -77,6 +77,7 @@ public:
       : ConstantExpr(C1->getType(), Opcode, AllocMarker) {
     Op<0>() = C1;
     Op<1>() = C2;
+    assert((Flags & ConstantSubclassBits) == 0 && "invalid flags");
     SubclassOptionalData = Flags;
   }
 
@@ -213,6 +214,7 @@ public:
     GetElementPtrConstantExpr *Result = new (AllocMarker)
         GetElementPtrConstantExpr(SrcElementTy, C, IdxList, DestTy,
                                   std::move(InRange), AllocMarker);
+    assert((Flags & ConstantSubclassBits) == 0 && "invalid flags");
     Result->SubclassOptionalData = Flags;
     return Result;
   }


### PR DESCRIPTION
Constant::isNullValue is the, by far, most frequently called out-of-line
function of Constant. It also has non-trivial logic and needs to switch
on the class type.

Therefore, compute the "is null" property once on construction and store
it in an unused bit in SubclassOptionalData.

This improves performance of stage2-O3 by 0.15%.
