### PR TITLE
[lldb][windows] fix scope_exit warning

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
@@ -497,7 +497,7 @@ ConvertNtDevicePathToDosPath(llvm::ArrayRef<wchar_t> nt_path) {
              ::GetLastError());
     return std::nullopt;
   }
-  auto close_iter = llvm::make_scope_exit([&] { ::FindVolumeClose(vol_iter); });
+  llvm::scope_exit close_iter([&] { ::FindVolumeClose(vol_iter); });
 
   do {
     // FindFirstVolumeW yields "\\?\Volume{GUID}\".


### PR DESCRIPTION
Using the constructor rather than `make_scope_exit` is preferred.