### PR TITLE
[clang][doc][SYCL] Expand SYCL driver release notes

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -959,7 +959,7 @@ SYCL Support
   device compilations.
 
 - SYCL runtime library linking is now supported on Windows. When ``-fsycl`` is
-  specified, the driver automatically adds ``/MD`` if no explicit CRT flag is
+  specified, Clang automatically adds ``/MD`` if no explicit CRT flag is
   present, links the appropriate debug (``LLVMSYCLd.lib``) or release
   (``LLVMSYCL.lib``) library, and rejects static CRT flags (``/MT``,
   ``/MTd``) with a diagnostic. Use ``-nolibsycl`` to suppress automatic

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -953,9 +953,8 @@ SYCL Support
   (#GH167358)
 
 - The SYCL runtime shared library has been renamed from ``libsycl.so`` to
-  ``libLLVMSYCL.so`` (``LLVMSYCL.lib`` / ``LLVMSYCLd.lib`` on Windows) to
-  align with LLVM naming conventions. SYCL header include paths are now added
-  automatically for both host and device compilations.
+  ``libLLVMSYCL.so`` to align with LLVM naming conventions. SYCL header include
+  paths are now added automatically for both host and device compilations.
 
 - SYCL runtime library linking is now supported on Windows. When ``-fsycl`` is
   specified, the driver automatically adds ``/MD`` if no explicit CRT flag is

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -945,15 +945,8 @@ OpenMP Support
 
 SYCL Support
 ------------
-- Initial SYCL offload compilation support has been added to Clang. The
-  new ``-fsycl`` flag enables SYCL offloading, producing a SPIR-V device image
-  packaged into the host object. ``-fsycl-device-only`` and
-  ``-fsycl-host-only`` restrict compilation to the device or host side
-  respectively. (#GH117268)
-
 - SYCL compilations now default to ``-std=c++17`` when no explicit language
   standard is specified. Standards below C++17 are rejected with a diagnostic.
-  (#GH194014)
 
 - Clang now assumes default target for SYCL device compilation is 64-bit SPIR-V
   and it now diagnoses if a non-supporting target is specified via command line.
@@ -962,18 +955,18 @@ SYCL Support
 - The SYCL runtime shared library has been renamed from ``libsycl.so`` to
   ``libLLVMSYCL.so`` (``LLVMSYCL.lib`` / ``LLVMSYCLd.lib`` on Windows) to
   align with LLVM naming conventions. SYCL header include paths are now added
-  automatically for both host and device compilations. (#GH188770, #GH174877)
+  automatically for both host and device compilations.
 
 - SYCL runtime library linking is now supported on Windows. When ``-fsycl`` is
   specified, the driver automatically adds ``/MD`` if no explicit CRT flag is
   present, links the appropriate debug (``LLVMSYCLd.lib``) or release
   (``LLVMSYCL.lib``) library, and rejects static CRT flags (``/MT``,
   ``/MTd``) with a diagnostic. Use ``-nolibsycl`` to suppress automatic
-  library linking. (#GH194744)
+  library linking.
 
 - Fixed ``-nolibsycl`` being silently ignored on Linux: the SYCL runtime
   library was unconditionally added to the link line even when the flag was
-  passed. (#GH200252)
+  passed.
 
 Improvements
 ^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -953,8 +953,10 @@ SYCL Support
   (#GH167358)
 
 - The SYCL runtime shared library has been renamed from ``libsycl.so`` to
-  ``libLLVMSYCL.so`` to align with LLVM naming conventions. SYCL header include
-  paths are now added automatically for both host and device compilations.
+  ``libLLVMSYCL.so`` to align with LLVM naming conventions.
+
+- SYCL header include paths are now added automatically for both host and
+  device compilations.
 
 - SYCL runtime library linking is now supported on Windows. When ``-fsycl`` is
   specified, the driver automatically adds ``/MD`` if no explicit CRT flag is

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -945,7 +945,7 @@ OpenMP Support
 
 SYCL Support
 ------------
-- Initial SYCL offload compilation support has been added to the driver. The
+- Initial SYCL offload compilation support has been added to Clang. The
   new ``-fsycl`` flag enables SYCL offloading, producing a SPIR-V device image
   packaged into the host object. ``-fsycl-device-only`` and
   ``-fsycl-host-only`` restrict compilation to the device or host side

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -945,9 +945,38 @@ OpenMP Support
 
 SYCL Support
 ------------
+- Initial SYCL offload compilation support has been added to the driver. The
+  new ``-fsycl`` flag enables SYCL offloading, producing a SPIR-V device image
+  packaged into the host object. ``-fsycl-device-only`` and
+  ``-fsycl-host-only`` restrict compilation to the device or host side
+  respectively. (#GH117268)
+
+- SYCL compilations now default to ``-std=c++17`` when no explicit language
+  standard is specified. Standards below C++17 are rejected with a diagnostic.
+  (#GH194014)
+
 - Clang now assumes default target for SYCL device compilation is 64-bit SPIR-V
   and it now diagnoses if a non-supporting target is specified via command line.
   (#GH167358)
+
+- The SYCL runtime shared library has been renamed from ``libsycl.so`` to
+  ``libLLVMSYCL.so`` (``LLVMSYCL.lib`` / ``LLVMSYCLd.lib`` on Windows) to
+  align with LLVM naming conventions. The driver now passes the runtime library
+  path to ``clang-linker-wrapper`` and adds SYCL header include paths
+  automatically for both host and device compilations. (#GH188770, #GH174877)
+
+- SYCL runtime library linking is now supported on Windows. When ``-fsycl`` is
+  specified, the driver automatically adds ``/MD`` if no explicit CRT flag is
+  present, links the appropriate debug (``LLVMSYCLd.lib``) or release
+  (``LLVMSYCL.lib``) library, and rejects static CRT flags (``/MT``,
+  ``/MTd``) with a diagnostic. Use ``-nolibsycl`` to suppress automatic
+  library linking. (#GH194744)
+
+- Fixed ``-nolibsycl`` being silently ignored on Linux: the SYCL runtime
+  library was unconditionally added to the link line even when the flag was
+  passed. Fixed ``--allow-partial-linkage`` and ``--create-library`` flags
+  being incorrectly forwarded to ``clang-sycl-linker`` for SYCL offload
+  targets, causing link failures. (#GH200252)
 
 Improvements
 ^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -961,8 +961,7 @@ SYCL Support
 
 - The SYCL runtime shared library has been renamed from ``libsycl.so`` to
   ``libLLVMSYCL.so`` (``LLVMSYCL.lib`` / ``LLVMSYCLd.lib`` on Windows) to
-  align with LLVM naming conventions. The driver now passes the runtime library
-  path to ``clang-linker-wrapper`` and adds SYCL header include paths
+  align with LLVM naming conventions. SYCL header include paths are now added
   automatically for both host and device compilations. (#GH188770, #GH174877)
 
 - SYCL runtime library linking is now supported on Windows. When ``-fsycl`` is
@@ -974,9 +973,7 @@ SYCL Support
 
 - Fixed ``-nolibsycl`` being silently ignored on Linux: the SYCL runtime
   library was unconditionally added to the link line even when the flag was
-  passed. Fixed ``--allow-partial-linkage`` and ``--create-library`` flags
-  being incorrectly forwarded to ``clang-sycl-linker`` for SYCL offload
-  targets, causing link failures. (#GH200252)
+  passed. (#GH200252)
 
 Improvements
 ^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

The SYCL Support section in the release notes previously had a single
entry for the default SPIR-V target change. This PR adds driver-level
entries covering all notable SYCL changes landed upstream:

- `-fsycl`, `-fsycl-device-only`, `-fsycl-host-only` flag introduction (#GH117268)
- C++17 default enforcement and sub-C++17 rejection (#GH194014)
- Runtime library rename from `libsycl.so` to `libLLVMSYCL.so` and
  automatic runtime path / header include injection (#GH188770, #GH174877)
- Windows SYCL runtime library linking support with CRT management (#GH194744)
- Fix for `-nolibsycl` being silently ignored and spurious spirv-link
  flags forwarded to `clang-sycl-linker` (#GH200252)

Addresses the review comment on #200200 requesting that notable SYCL
driver and offload tool changes be documented alongside the front-end
changes. This PR covers only the Clang Driver changes.
