### PR TITLE
[flang][docs] Documented IS_CONTIGUOUS() extension for constant arrays

### DIFF
--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -353,10 +353,9 @@ end
   containing only the selected elements, and that fresh array is trivially
   contiguous.  When `-pedantic` is enabled, Flang emits the
   `-Wconstant-is-contiguous` warning at each such call.  For example:
-```fortran
-integer, parameter :: a(5) = [1,2,3,4,5]
-print *, is_contiguous(a(::2))                   ! prints T in Flang
-```
+  ```fortran
+  integer, parameter :: a(5) = [1,2,3,4,5]
+  print *, is_contiguous(a(::2))                   ! prints T in Flang
   Other compilers may report `a(::2)` as non-contiguous.
 * We support some combinations of specific procedures in generic
   interfaces that a strict reading of the standard would preclude

--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -356,6 +356,7 @@ end
   ```fortran
   integer, parameter :: a(5) = [1,2,3,4,5]
   print *, is_contiguous(a(::2))                   ! prints T in Flang
+  ```
   Other compilers may report `a(::2)` as non-contiguous.
 * We support some combinations of specific procedures in generic
   interfaces that a strict reading of the standard would preclude

--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -357,7 +357,7 @@ end
 integer, parameter :: a(5) = [1,2,3,4,5]
 print *, is_contiguous(a(::2))                   ! prints T in Flang
 ```
-  The other compilers may report `a(::2)` as non-contiguous in this case.
+  Other compilers may report `a(::2)` as non-contiguous.
 * We support some combinations of specific procedures in generic
   interfaces that a strict reading of the standard would preclude
   when their calls must nonetheless be distinguishable.

--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -353,10 +353,10 @@ end
   containing only the selected elements, and that fresh array is trivially
   contiguous.  When `-pedantic` is enabled, Flang emits the
   `-Wconstant-is-contiguous` warning at each such call.  For example:
-  ```fortran
-  integer, parameter :: a(5) = [1,2,3,4,5]
-  print *, is_contiguous(a(::2))                   ! prints T in Flang
-  ```
+```fortran
+integer, parameter :: a(5) = [1,2,3,4,5]
+print *, is_contiguous(a(::2))                   ! prints T in Flang
+```
   Other compilers may report `a(::2)` as non-contiguous.
 * We support some combinations of specific procedures in generic
   interfaces that a strict reading of the standard would preclude

--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -345,6 +345,19 @@ end
   with bounds remapping.
 * The `CONTIGUOUS` attribute can be redundantly applied to simply
   contiguous objects, including scalars, with a portability warning.
+* `IS_CONTIGUOUS` is always true when its argument is a named constant
+  (`PARAMETER`) or a subobject of a named constant, even when the standard's
+  rules in F2023 8.5.7 would otherwise classify the subobject as non-contiguous
+  (for example, a strided section like `a(::2)`).  This happens because Flang
+  constant-folds an array section of a named constant into a fresh constant array
+  containing only the selected elements, and that fresh array is trivially
+  contiguous.  When `-pedantic` is enabled, Flang emits the
+  `-Wconstant-is-contiguous` warningat each such call.  For example:
+```fortran
+integer, parameter :: a(5) = [1,2,3,4,5]
+print *, is_contiguous(a(::2))                   ! prints T in Flang
+```
+  The other compilers may report `a(::2)` as non-contiguous in this case.
 * We support some combinations of specific procedures in generic
   interfaces that a strict reading of the standard would preclude
   when their calls must nonetheless be distinguishable.

--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -352,7 +352,7 @@ end
   constant-folds an array section of a named constant into a fresh constant array
   containing only the selected elements, and that fresh array is trivially
   contiguous.  When `-pedantic` is enabled, Flang emits the
-  `-Wconstant-is-contiguous` warningat each such call.  For example:
+  `-Wconstant-is-contiguous` warning at each such call.  For example:
 ```fortran
 integer, parameter :: a(5) = [1,2,3,4,5]
 print *, is_contiguous(a(::2))                   ! prints T in Flang


### PR DESCRIPTION
Flang considers constant objects or subobjects of constant objects as contiguous even in cases, where the other compilers may consider them non-contiguous. Documented the extension.

Fixes #199878