### PR TITLE
[lit] Remove redundant f.close() in TestingConfig

### DIFF
--- a/llvm/utils/lit/lit/TestingConfig.py
+++ b/llvm/utils/lit/lit/TestingConfig.py
@@ -143,7 +143,6 @@ class TestingConfig:
                 data = f.read()
         except OSError:
             litConfig.fatal("unable to load config file: %r" % (path,))
-        f.close()
 
         # Execute the config script to initialize the object.
         cfg_globals = dict(globals())


### PR DESCRIPTION
[This commit](https://github.com/llvm/llvm-project/commit/5536348d060066e875c9bf9e056447ece59c783d) moved the config file `open()` into a `with` context manager but left the trailing `f.close()` call behind. Since the context manager already closes the file, the call is redundant. It is also outside the `with` block, so `f` is unbound on the `except OSError` path. This removes it. No change in behavior.