### PR TITLE
[DRAFT] [libc++] Optimize std::string find_first_of functions with lookup table for single-byte types

### DIFF
--- a/libcxx/include/__string/char_traits.h
+++ b/libcxx/include/__string/char_traits.h
@@ -462,12 +462,29 @@ __str_rfind(const _CharT* __p, _SizeT __sz, const _CharT* __s, _SizeT __pos, _Si
   return static_cast<_SizeT>(__r - __p);
 }
 
+template <class _CharT>
+_LIBCPP_HIDE_FROM_ABI void __build_char_lookup_table(const _CharT* __s, size_t __n, bool (&__table)[256]) {
+  __builtin_memset(__table, 0, sizeof(__table));
+  for (size_t __i = 0; __i < __n; ++__i)
+    __table[static_cast<unsigned char>(__s[__i])] = true;
+}
+
 // __str_find_first_of
 template <class _CharT, class _SizeT, class _Traits, _SizeT __npos>
 inline _SizeT _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
 __str_find_first_of(const _CharT* __p, _SizeT __sz, const _CharT* __s, _SizeT __pos, _SizeT __n) _NOEXCEPT {
   if (__pos >= __sz || __n == 0)
     return __npos;
+  if _LIBCPP_CONSTEXPR (sizeof(_CharT) == 1) {
+    if (!__libcpp_is_constant_evaluated()) {
+      bool __table[256];
+      std::__build_char_lookup_table(__s, __n, __table);
+      for (_SizeT __i = __pos; __i < __sz; ++__i)
+        if (__table[static_cast<unsigned char>(__p[__i])])
+          return __i;
+      return __npos;
+    }
+  }
   const _CharT* __r = std::__find_first_of_ce(__p + __pos, __p + __sz, __s, __s + __n, _Traits::eq);
   if (__r == __p + __sz)
     return __npos;
@@ -478,16 +495,27 @@ __str_find_first_of(const _CharT* __p, _SizeT __sz, const _CharT* __s, _SizeT __
 template <class _CharT, class _SizeT, class _Traits, _SizeT __npos>
 inline _SizeT _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
 __str_find_last_of(const _CharT* __p, _SizeT __sz, const _CharT* __s, _SizeT __pos, _SizeT __n) _NOEXCEPT {
-  if (__n != 0) {
-    if (__pos < __sz)
-      ++__pos;
-    else
-      __pos = __sz;
-    for (const _CharT* __ps = __p + __pos; __ps != __p;) {
-      const _CharT* __r = _Traits::find(__s, __n, *--__ps);
-      if (__r)
-        return static_cast<_SizeT>(__ps - __p);
+  if (__n == 0)
+    return __npos;
+  if _LIBCPP_CONSTEXPR (sizeof(_CharT) == 1) {
+    if (!__libcpp_is_constant_evaluated()) {
+      bool __table[256];
+      std::__build_char_lookup_table(__s, __n, __table);
+      _SizeT __end = (__pos < __sz) ? __pos + 1 : __sz;
+      for (_SizeT __i = __end; __i > 0; --__i)
+        if (__table[static_cast<unsigned char>(__p[__i - 1])])
+          return __i - 1;
+      return __npos;
     }
+  }
+  if (__pos < __sz)
+    ++__pos;
+  else
+    __pos = __sz;
+  for (const _CharT* __ps = __p + __pos; __ps != __p;) {
+    const _CharT* __r = _Traits::find(__s, __n, *--__ps);
+    if (__r)
+      return static_cast<_SizeT>(__ps - __p);
   }
   return __npos;
 }
@@ -496,12 +524,22 @@ __str_find_last_of(const _CharT* __p, _SizeT __sz, const _CharT* __s, _SizeT __p
 template <class _CharT, class _SizeT, class _Traits, _SizeT __npos>
 inline _SizeT _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
 __str_find_first_not_of(const _CharT* __p, _SizeT __sz, const _CharT* __s, _SizeT __pos, _SizeT __n) _NOEXCEPT {
-  if (__pos < __sz) {
-    const _CharT* __pe = __p + __sz;
-    for (const _CharT* __ps = __p + __pos; __ps != __pe; ++__ps)
-      if (_Traits::find(__s, __n, *__ps) == nullptr)
-        return static_cast<_SizeT>(__ps - __p);
+  if (__pos >= __sz)
+    return __npos;
+  if _LIBCPP_CONSTEXPR (sizeof(_CharT) == 1) {
+    if (!__libcpp_is_constant_evaluated()) {
+      bool __table[256];
+      std::__build_char_lookup_table(__s, __n, __table);
+      for (_SizeT __i = __pos; __i < __sz; ++__i)
+        if (!__table[static_cast<unsigned char>(__p[__i])])
+          return __i;
+      return __npos;
+    }
   }
+  const _CharT* __pe = __p + __sz;
+  for (const _CharT* __ps = __p + __pos; __ps != __pe; ++__ps)
+    if (_Traits::find(__s, __n, *__ps) == nullptr)
+      return static_cast<_SizeT>(__ps - __p);
   return __npos;
 }
 
@@ -521,6 +559,17 @@ __str_find_first_not_of(const _CharT* __p, _SizeT __sz, _CharT __c, _SizeT __pos
 template <class _CharT, class _SizeT, class _Traits, _SizeT __npos>
 inline _SizeT _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
 __str_find_last_not_of(const _CharT* __p, _SizeT __sz, const _CharT* __s, _SizeT __pos, _SizeT __n) _NOEXCEPT {
+  if _LIBCPP_CONSTEXPR (sizeof(_CharT) == 1) {
+    if (!__libcpp_is_constant_evaluated()) {
+      bool __table[256];
+      std::__build_char_lookup_table(__s, __n, __table);
+      _SizeT __end = (__pos < __sz) ? __pos + 1 : __sz;
+      for (_SizeT __i = __end; __i > 0; --__i)
+        if (!__table[static_cast<unsigned char>(__p[__i - 1])])
+          return __i - 1;
+      return __npos;
+    }
+  }
   if (__pos < __sz)
     ++__pos;
   else

--- a/libcxx/test/benchmarks/containers/string_find_first_of.bench.cpp
+++ b/libcxx/test/benchmarks/containers/string_find_first_of.bench.cpp
@@ -1,0 +1,93 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+#include <cstddef>
+#include <string>
+
+#include "benchmark/benchmark.h"
+
+constexpr std::size_t MAX_STRING_LEN = 8 << 14;
+
+// No match found — worst case for find_first_of (must scan entire haystack).
+// Varies haystack size with a fixed needle size.
+static void BM_StringFindFirstOfNoMatch(benchmark::State& state) {
+  std::string haystack(state.range(0), 'a');
+  std::string needle("xyz!@#$%");
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(haystack);
+    benchmark::DoNotOptimize(needle);
+    benchmark::DoNotOptimize(haystack.find_first_of(needle));
+  }
+}
+BENCHMARK(BM_StringFindFirstOfNoMatch)->Range(32, MAX_STRING_LEN);
+
+// No match found — varies needle size with a fixed haystack.
+// Demonstrates O(n*m) vs O(n+m) scaling with needle size.
+static void BM_StringFindFirstOfNoMatchVaryNeedle(benchmark::State& state) {
+  std::string haystack(8192, 'a');
+  std::string needle(state.range(0), 'b');
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(haystack);
+    benchmark::DoNotOptimize(needle);
+    benchmark::DoNotOptimize(haystack.find_first_of(needle));
+  }
+}
+BENCHMARK(BM_StringFindFirstOfNoMatchVaryNeedle)->Arg(2)->Arg(4)->Arg(8)->Arg(16)->Arg(32)->Arg(64)->Arg(128);
+
+// Match at the end — must scan nearly the entire haystack before finding it.
+static void BM_StringFindFirstOfMatchAtEnd(benchmark::State& state) {
+  std::string haystack(state.range(0), 'a');
+  haystack.back() = 'z';
+  std::string needle("xyz!@#$%");
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(haystack);
+    benchmark::DoNotOptimize(needle);
+    benchmark::DoNotOptimize(haystack.find_first_of(needle));
+  }
+}
+BENCHMARK(BM_StringFindFirstOfMatchAtEnd)->Range(32, MAX_STRING_LEN);
+
+// find_last_of — no match, must scan entire haystack backward.
+static void BM_StringFindLastOfNoMatch(benchmark::State& state) {
+  std::string haystack(state.range(0), 'a');
+  std::string needle("xyz!@#$%");
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(haystack);
+    benchmark::DoNotOptimize(needle);
+    benchmark::DoNotOptimize(haystack.find_last_of(needle));
+  }
+}
+BENCHMARK(BM_StringFindLastOfNoMatch)->Range(32, MAX_STRING_LEN);
+
+// find_first_not_of — all characters are in the needle, no "not of" found.
+static void BM_StringFindFirstNotOfNoMatch(benchmark::State& state) {
+  std::string haystack(state.range(0), 'a');
+  std::string needle("abcdefgh");
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(haystack);
+    benchmark::DoNotOptimize(needle);
+    benchmark::DoNotOptimize(haystack.find_first_not_of(needle));
+  }
+}
+BENCHMARK(BM_StringFindFirstNotOfNoMatch)->Range(32, MAX_STRING_LEN);
+
+// find_last_not_of — all characters are in the needle, no "not of" found.
+static void BM_StringFindLastNotOfNoMatch(benchmark::State& state) {
+  std::string haystack(state.range(0), 'a');
+  std::string needle("abcdefgh");
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(haystack);
+    benchmark::DoNotOptimize(needle);
+    benchmark::DoNotOptimize(haystack.find_last_not_of(needle));
+  }
+}
+BENCHMARK(BM_StringFindLastNotOfNoMatch)->Range(32, MAX_STRING_LEN);
+
+BENCHMARK_MAIN();

--- a/libcxx/test/benchmarks/containers/string_find_first_of.bench.cpp
+++ b/libcxx/test/benchmarks/containers/string_find_first_of.bench.cpp
@@ -15,7 +15,7 @@
 
 constexpr std::size_t MAX_STRING_LEN = 8 << 14;
 
-// No match found — worst case for find_first_of (must scan entire haystack).
+// No match found -- worst case for find_first_of (must scan entire haystack).
 // Varies haystack size with a fixed needle size.
 static void BM_StringFindFirstOfNoMatch(benchmark::State& state) {
   std::string haystack(state.range(0), 'a');
@@ -28,7 +28,7 @@ static void BM_StringFindFirstOfNoMatch(benchmark::State& state) {
 }
 BENCHMARK(BM_StringFindFirstOfNoMatch)->Range(32, MAX_STRING_LEN);
 
-// No match found — varies needle size with a fixed haystack.
+// No match found -- varies needle size with a fixed haystack.
 // Demonstrates O(n*m) vs O(n+m) scaling with needle size.
 static void BM_StringFindFirstOfNoMatchVaryNeedle(benchmark::State& state) {
   std::string haystack(8192, 'a');
@@ -41,7 +41,7 @@ static void BM_StringFindFirstOfNoMatchVaryNeedle(benchmark::State& state) {
 }
 BENCHMARK(BM_StringFindFirstOfNoMatchVaryNeedle)->Arg(2)->Arg(4)->Arg(8)->Arg(16)->Arg(32)->Arg(64)->Arg(128);
 
-// Match at the end — must scan nearly the entire haystack before finding it.
+// Match at the end -- must scan nearly the entire haystack before finding it.
 static void BM_StringFindFirstOfMatchAtEnd(benchmark::State& state) {
   std::string haystack(state.range(0), 'a');
   haystack.back() = 'z';
@@ -54,7 +54,7 @@ static void BM_StringFindFirstOfMatchAtEnd(benchmark::State& state) {
 }
 BENCHMARK(BM_StringFindFirstOfMatchAtEnd)->Range(32, MAX_STRING_LEN);
 
-// find_last_of — no match, must scan entire haystack backward.
+// find_last_of -- no match, must scan entire haystack backward.
 static void BM_StringFindLastOfNoMatch(benchmark::State& state) {
   std::string haystack(state.range(0), 'a');
   std::string needle("xyz!@#$%");
@@ -66,7 +66,7 @@ static void BM_StringFindLastOfNoMatch(benchmark::State& state) {
 }
 BENCHMARK(BM_StringFindLastOfNoMatch)->Range(32, MAX_STRING_LEN);
 
-// find_first_not_of — all characters are in the needle, no "not of" found.
+// find_first_not_of -- all characters are in the needle, no "not of" found.
 static void BM_StringFindFirstNotOfNoMatch(benchmark::State& state) {
   std::string haystack(state.range(0), 'a');
   std::string needle("abcdefgh");
@@ -78,7 +78,7 @@ static void BM_StringFindFirstNotOfNoMatch(benchmark::State& state) {
 }
 BENCHMARK(BM_StringFindFirstNotOfNoMatch)->Range(32, MAX_STRING_LEN);
 
-// find_last_not_of — all characters are in the needle, no "not of" found.
+// find_last_not_of -- all characters are in the needle, no "not of" found.
 static void BM_StringFindLastNotOfNoMatch(benchmark::State& state) {
   std::string haystack(state.range(0), 'a');
   std::string needle("abcdefgh");


### PR DESCRIPTION
## Summary

  Add O(n+m) lookup table fast paths to `__str_find_first_of`, `__str_find_last_of`, `__str_find_first_not_of`, and
  `__str_find_last_not_of` in `__string/char_traits.h`.

  The current implementations use O(n*m) algorithms — either a nested loop (`__find_first_of_ce`) or per-character `_Traits::find` (which calls `memchr` for each haystack character against the full needle). For single-byte character types (`char`, `char8_t`), a 256-byte `bool` lookup table reduces this to O(n+m): one pass to populate the table from the needle, one pass to scan the haystack.

  ## Approach

  - Added `__build_char_lookup_table` helper that zero-initializes a `bool[256]` via `__builtin_memset` and populates it from the needle
  - Each `__str_find_*` function gains a fast path gated by:
    - `if _LIBCPP_CONSTEXPR (sizeof(_CharT) == 1)` — compile-time elimination for wide types (zero codegen impact on `wchar_t`, `char16_t`, `char32_t`)
    - `if (!__libcpp_is_constant_evaluated())` — constexpr evaluation falls through to existing algorithms (lookup table uses
  `__builtin_memset` which isn't constexpr; the existing O(n*m) algorithms are fine for compile-time evaluation)

  ## What doesn't change

  - `string` class methods — unchanged, still call through to `__str_find_*`
  - `__find_first_of_ce` generic algorithm — unchanged, still used by `std::find_first_of` with arbitrary iterators
  - `_Traits::find` / `_Traits::eq` — unchanged
  - Single-character overloads — unchanged (already delegate to `find()`/`rfind()`)
  - Behavior for `wchar_t`, `char16_t`, `char32_t` — unchanged
  - Constexpr evaluation — unchanged (falls through to existing code)

  ## Test plan

  - [ ] Existing `string_find.first.of/`, `string_find.last.of/`, `string_find.first.not.of/`, `string_find.last.not.of/` tests pass
  - [ ] Constexpr string tests pass (C++20)
  - [ ] `std::find_first_of` algorithm tests pass (generic algorithm unmodified)
  - [ ] New benchmark (`string_find_first_of.bench.cpp`) confirms O(n+m) scaling — time is nearly constant as needle size varies, vs linear scaling with O(n*m)

  Assisted by: Claude Code