### PR TITLE
[IR][NFC] Inline Type::isIntegerTy(n)

### DIFF
--- a/llvm/include/llvm/IR/DerivedTypes.h
+++ b/llvm/include/llvm/IR/DerivedTypes.h
@@ -108,10 +108,6 @@ unsigned Type::getIntegerBitWidth() const {
   return cast<IntegerType>(this)->getBitWidth();
 }
 
-bool Type::isIntegerTy(unsigned Bitwidth) const {
-  return isIntegerTy() && cast<IntegerType>(this)->getBitWidth() == Bitwidth;
-}
-
 /// Class to represent byte types.
 class ByteType : public Type {
   friend class LLVMContextImpl;

--- a/llvm/include/llvm/IR/DerivedTypes.h
+++ b/llvm/include/llvm/IR/DerivedTypes.h
@@ -108,6 +108,10 @@ unsigned Type::getIntegerBitWidth() const {
   return cast<IntegerType>(this)->getBitWidth();
 }
 
+bool Type::isIntegerTy(unsigned Bitwidth) const {
+  return isIntegerTy() && cast<IntegerType>(this)->getBitWidth() == Bitwidth;
+}
+
 /// Class to represent byte types.
 class ByteType : public Type {
   friend class LLVMContextImpl;

--- a/llvm/include/llvm/IR/DerivedTypes.h
+++ b/llvm/include/llvm/IR/DerivedTypes.h
@@ -108,6 +108,14 @@ unsigned Type::getIntegerBitWidth() const {
   return cast<IntegerType>(this)->getBitWidth();
 }
 
+bool Type::isIntegerTy(unsigned BitWidth) const {
+  return isIntegerTy() && getIntegerBitWidth() == BitWidth;
+}
+
+bool Type::isIntOrIntVectorTy(unsigned BitWidth) const {
+  return getScalarType()->isIntegerTy(BitWidth);
+}
+
 /// Class to represent byte types.
 class ByteType : public Type {
   friend class LLVMContextImpl;

--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -257,7 +257,9 @@ public:
   bool isIntegerTy() const { return getTypeID() == IntegerTyID; }
 
   /// Return true if this is an IntegerType of the given width.
-  inline bool isIntegerTy(unsigned Bitwidth) const;
+  bool isIntegerTy(unsigned Bitwidth) const {
+    return isIntegerTy() && getIntegerBitwidth() == Bitwidth;
+  }
 
   /// Return true if this is an integer type or a vector of integer types.
   bool isIntOrIntVectorTy() const { return getScalarType()->isIntegerTy(); }

--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -257,18 +257,14 @@ public:
   bool isIntegerTy() const { return getTypeID() == IntegerTyID; }
 
   /// Return true if this is an IntegerType of the given width.
-  bool isIntegerTy(unsigned Bitwidth) const {
-    return isIntegerTy() && getIntegerBitwidth() == Bitwidth;
-  }
+  LLVM_ABI inline bool isIntegerTy(unsigned BitWidth) const;
 
   /// Return true if this is an integer type or a vector of integer types.
   bool isIntOrIntVectorTy() const { return getScalarType()->isIntegerTy(); }
 
   /// Return true if this is an integer type or a vector of integer types of
   /// the given width.
-  bool isIntOrIntVectorTy(unsigned BitWidth) const {
-    return getScalarType()->isIntegerTy(BitWidth);
-  }
+  LLVM_ABI inline bool isIntOrIntVectorTy(unsigned BitWidth) const;
 
   /// Return true if this is an integer type or a pointer type.
   bool isIntOrPtrTy() const { return isIntegerTy() || isPointerTy(); }

--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -257,7 +257,7 @@ public:
   bool isIntegerTy() const { return getTypeID() == IntegerTyID; }
 
   /// Return true if this is an IntegerType of the given width.
-  LLVM_ABI bool isIntegerTy(unsigned Bitwidth) const;
+  inline bool isIntegerTy(unsigned Bitwidth) const;
 
   /// Return true if this is an integer type or a vector of integer types.
   bool isIntOrIntVectorTy() const { return getScalarType()->isIntegerTy(); }

--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -58,10 +58,6 @@ bool Type::isByteTy(unsigned BitWidth) const {
   return isByteTy() && cast<ByteType>(this)->getBitWidth() == BitWidth;
 }
 
-bool Type::isIntegerTy(unsigned Bitwidth) const {
-  return isIntegerTy() && cast<IntegerType>(this)->getBitWidth() == Bitwidth;
-}
-
 bool Type::isScalableTy(SmallPtrSetImpl<const Type *> &Visited) const {
   if (const auto *ATy = dyn_cast<ArrayType>(this))
     return ATy->getElementType()->isScalableTy(Visited);

--- a/llvm/lib/IR/Use.cpp
+++ b/llvm/lib/IR/Use.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/IR/Use.h"
-#include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/User.h"
 
 using namespace llvm;

--- a/llvm/lib/IR/Use.cpp
+++ b/llvm/lib/IR/Use.cpp
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Use.h"
+#include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/User.h"
 
 using namespace llvm;

--- a/llvm/lib/IR/Use.cpp
+++ b/llvm/lib/IR/Use.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/IR/Use.h"
+#include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/User.h"
 
 using namespace llvm;

--- a/llvm/lib/IR/Use.cpp
+++ b/llvm/lib/IR/Use.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Use.h"
 #include "llvm/IR/User.h"
 


### PR DESCRIPTION
Although this gets inlined in LTO builds, non-LTO builds benefit from
having isIntegerTy(n) defined in a header.

Co-authored-by: Nikita Popov <npopov@redhat.com>
