### PR TITLE
workflows/issue-write: Do not read pr number from file for pull_request events

### DIFF
--- a/.github/workflows/issue-write.yml
+++ b/.github/workflows/issue-write.yml
@@ -46,6 +46,8 @@ jobs:
       - name: 'Comment on PR'
         if: steps.download-artifact.outputs.artifact-ids != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          EVENT_TYPE: ${{ github.event.workflow_run.event }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -56,7 +58,10 @@ jobs:
               if (local_file.startsWith("comments")) {
                 comments.push(...JSON.parse(fs.readFileSync(local_file)))
               }
-              if (local_file.startsWith("pr_number")) {
+              // We can't trust a pr_number that comes from a pull_request event,
+              // because the pull_request author has full control over the
+              // triggering workflow and could put any number here.
+              if (process.env.EVENT_TYPE === "issue_comment" && local_file.startsWith("pr_number")) {
                 pr_number = parseInt(fs.readFileSync(local_file), 10)
               }
             }


### PR DESCRIPTION
For pull_request events, the author of the pull request has full control over the workflow job and can potentially write any pull request number
to the file.   This would allow them to modify comments on any pull
request not just their own.

The reading of the pull request number from the file was added in 53ff447b64186ff51181cd6050a9613983ff80be to support issue_comment events so we don't need it for pull_request events anyway.