### PR TITLE
[ExpandIRInsts] Avoid redundant dyn_cast after #175864

### DIFF
--- a/llvm/lib/CodeGen/ExpandIRInsts.cpp
+++ b/llvm/lib/CodeGen/ExpandIRInsts.cpp
@@ -694,13 +694,11 @@ static void expandFPToI(Instruction *FPToI, bool IsSaturating, bool IsSigned) {
       ZeroResultCond = Builder.CreateOr(ZeroResultCond, IsNeg);
     }
   }
-  Value *CondBr = Builder.CreateCondBr(
+  Instruction *CondBr = Builder.CreateCondBr(
       ZeroResultCond, End, IsSaturating ? CheckSaturateBB : CheckExpSizeBB);
   // We do not have any information on the value of the exponent, so mark the
   // branch weights as unkown.
-  if (auto *CondBrInstruction = dyn_cast<Instruction>(CondBr))
-    setExplicitlyUnknownBranchWeightsIfProfiled(*CondBrInstruction, DEBUG_TYPE,
-                                                F);
+  setExplicitlyUnknownBranchWeightsIfProfiled(*CondBr, DEBUG_TYPE, F);
 
   Value *Saturated;
   if (IsSaturating) {


### PR DESCRIPTION
CreateCondBr always returns an Instruction, so no need to dyn_cast back
to an instruction after downcasting to a Value.