### PR TITLE
[asan] NFC: clang-format allocator-related files

### DIFF
--- a/compiler-rt/lib/asan/asan_allocator.cpp
+++ b/compiler-rt/lib/asan/asan_allocator.cpp
@@ -52,9 +52,9 @@ static u32 RZSize2Log(u32 rz_size) {
   return res;
 }
 
-static AsanAllocator &get_allocator();
+static AsanAllocator& get_allocator();
 
-static void AtomicContextStore(volatile atomic_uint64_t *atomic_context,
+static void AtomicContextStore(volatile atomic_uint64_t* atomic_context,
                                u32 tid, u32 stack) {
   u64 context = tid;
   context <<= 32;
@@ -62,8 +62,8 @@ static void AtomicContextStore(volatile atomic_uint64_t *atomic_context,
   atomic_store(atomic_context, context, memory_order_relaxed);
 }
 
-static void AtomicContextLoad(const volatile atomic_uint64_t *atomic_context,
-                              u32 &tid, u32 &stack) {
+static void AtomicContextLoad(const volatile atomic_uint64_t* atomic_context,
+                              u32& tid, u32& stack) {
   u64 context = atomic_load(atomic_context, memory_order_relaxed);
   stack = context;
   context >>= 32;
@@ -128,7 +128,7 @@ class ChunkHeader {
     AtomicContextStore(&alloc_context_id, tid, stack);
   }
 
-  void GetAllocContext(u32 &tid, u32 &stack) const {
+  void GetAllocContext(u32& tid, u32& stack) const {
     AtomicContextLoad(&alloc_context_id, tid, stack);
   }
 };
@@ -141,7 +141,7 @@ class ChunkBase : public ChunkHeader {
     AtomicContextStore(&free_context_id, tid, stack);
   }
 
-  void GetFreeContext(u32 &tid, u32 &stack) const {
+  void GetFreeContext(u32& tid, u32& stack) const {
     AtomicContextLoad(&free_context_id, tid, stack);
   }
 };
@@ -174,16 +174,16 @@ class LargeChunkHeader {
   static constexpr uptr kAllocBegMagic =
       FIRST_32_SECOND_64(0xCC6E96B9, 0xCC6E96B9CC6E96B9ULL);
   atomic_uintptr_t magic;
-  AsanChunk *chunk_header;
+  AsanChunk* chunk_header;
 
  public:
-  AsanChunk *Get() const {
+  AsanChunk* Get() const {
     return atomic_load(&magic, memory_order_acquire) == kAllocBegMagic
                ? chunk_header
                : nullptr;
   }
 
-  void Set(AsanChunk *p) {
+  void Set(AsanChunk* p) {
     if (p) {
       chunk_header = p;
       atomic_store(&magic, kAllocBegMagic, memory_order_release);
@@ -198,9 +198,9 @@ class LargeChunkHeader {
   }
 };
 
-static void FillChunk(AsanChunk *m) {
+static void FillChunk(AsanChunk* m) {
   // FIXME: Use ReleaseMemoryPagesToOS.
-  Flags &fl = *flags();
+  Flags& fl = *flags();
 
   if (fl.max_free_fill_size > 0) {
     // We have to skip the chunk header, it contains free_context_id.
@@ -208,26 +208,24 @@ static void FillChunk(AsanChunk *m) {
     if (m->UsedSize() >= kChunkHeader2Size) {  // Skip Header2 in user area.
       uptr size_to_fill = m->UsedSize() - kChunkHeader2Size;
       size_to_fill = Min(size_to_fill, (uptr)fl.max_free_fill_size);
-      REAL(memset)((void *)scribble_start, fl.free_fill_byte, size_to_fill);
+      REAL(memset)((void*)scribble_start, fl.free_fill_byte, size_to_fill);
     }
   }
 }
 
 struct QuarantineCallback {
-  QuarantineCallback(AllocatorCache *cache, BufferedStackTrace *stack)
-      : cache_(cache),
-        stack_(stack) {
-  }
+  QuarantineCallback(AllocatorCache* cache, BufferedStackTrace* stack)
+      : cache_(cache), stack_(stack) {}
 
-  void PreQuarantine(AsanChunk *m) const {
+  void PreQuarantine(AsanChunk* m) const {
     FillChunk(m);
     // Poison the region.
     PoisonShadow(m->Beg(), RoundUpTo(m->UsedSize(), ASAN_SHADOW_GRANULARITY),
                  kAsanHeapFreeMagic);
   }
 
-  void Recycle(AsanChunk *m) const {
-    void *p = get_allocator().GetBlockBegin(m);
+  void Recycle(AsanChunk* m) const {
+    void* p = get_allocator().GetBlockBegin(m);
 
     // The secondary will immediately unpoison and unmap the memory, so this
     // branch is unnecessary.
@@ -235,7 +233,7 @@ struct QuarantineCallback {
       if (p != m) {
         // Clear the magic value, as allocator internals may overwrite the
         // contents of deallocated chunk, confusing GetAsanChunk lookup.
-        reinterpret_cast<LargeChunkHeader *>(p)->Set(nullptr);
+        reinterpret_cast<LargeChunkHeader*>(p)->Set(nullptr);
       }
 
       u8 old_chunk_state = CHUNK_QUARANTINE;
@@ -250,14 +248,14 @@ struct QuarantineCallback {
     }
 
     // Statistics.
-    AsanStats &thread_stats = GetCurrentThreadStats();
+    AsanStats& thread_stats = GetCurrentThreadStats();
     thread_stats.real_frees++;
     thread_stats.really_freed += m->UsedSize();
 
     get_allocator().Deallocate(cache_, p);
   }
 
-  void RecyclePassThrough(AsanChunk *m) const {
+  void RecyclePassThrough(AsanChunk* m) const {
     // Recycle for the secondary will immediately unpoison and unmap the
     // memory, so quarantine preparation is unnecessary.
     if (get_allocator().FromPrimary(m)) {
@@ -267,15 +265,15 @@ struct QuarantineCallback {
     Recycle(m);
   }
 
-  void *Allocate(uptr size) const {
-    void *res = get_allocator().Allocate(cache_, size, 1);
+  void* Allocate(uptr size) const {
+    void* res = get_allocator().Allocate(cache_, size, 1);
     // TODO(alekseys): Consider making quarantine OOM-friendly.
     if (UNLIKELY(!res))
       ReportOutOfMemory(size, stack_);
     return res;
   }
 
-  void Deallocate(void *p) const { get_allocator().Deallocate(cache_, p); }
+  void Deallocate(void* p) const { get_allocator().Deallocate(cache_, p); }
 
  private:
   AllocatorCache* const cache_;
@@ -288,7 +286,7 @@ typedef AsanQuarantine::Cache QuarantineCache;
 void AsanMapUnmapCallback::OnMap(uptr p, uptr size) const {
   PoisonShadow(p, size, kAsanHeapLeftRedzoneMagic);
   // Statistics.
-  AsanStats &thread_stats = GetCurrentThreadStats();
+  AsanStats& thread_stats = GetCurrentThreadStats();
   thread_stats.mmaps++;
   thread_stats.mmaped += size;
 }
@@ -303,7 +301,7 @@ void AsanMapUnmapCallback::OnMapSecondary(uptr p, uptr size, uptr user_begin,
   PoisonShadow(p, user_begin - p, kAsanHeapLeftRedzoneMagic);
   PoisonShadow(user_end, size - (user_end - p), kAsanHeapLeftRedzoneMagic);
   // Statistics.
-  AsanStats &thread_stats = GetCurrentThreadStats();
+  AsanStats& thread_stats = GetCurrentThreadStats();
   thread_stats.mmaps++;
   thread_stats.mmaped += size;
 }
@@ -314,7 +312,7 @@ void AsanMapUnmapCallback::OnUnmap(uptr p, uptr size) const {
   // Mark the corresponding shadow memory as not needed.
   FlushUnneededASanShadowMemory(p, size);
   // Statistics.
-  AsanStats &thread_stats = GetCurrentThreadStats();
+  AsanStats& thread_stats = GetCurrentThreadStats();
   thread_stats.munmaps++;
   thread_stats.munmaped += size;
 }
@@ -322,18 +320,18 @@ void AsanMapUnmapCallback::OnUnmap(uptr p, uptr size) const {
 // We can not use THREADLOCAL because it is not supported on some of the
 // platforms we care about (OSX 10.6, Android).
 // static THREADLOCAL AllocatorCache cache;
-AllocatorCache *GetAllocatorCache(AsanThreadLocalMallocStorage *ms) {
+AllocatorCache* GetAllocatorCache(AsanThreadLocalMallocStorage* ms) {
   CHECK(ms);
   return &ms->allocator_cache;
 }
 
-QuarantineCache *GetQuarantineCache(AsanThreadLocalMallocStorage *ms) {
+QuarantineCache* GetQuarantineCache(AsanThreadLocalMallocStorage* ms) {
   CHECK(ms);
   CHECK_LE(sizeof(QuarantineCache), sizeof(ms->quarantine_cache));
-  return reinterpret_cast<QuarantineCache *>(ms->quarantine_cache);
+  return reinterpret_cast<QuarantineCache*>(ms->quarantine_cache);
 }
 
-void AllocatorOptions::SetFrom(const Flags *f, const CommonFlags *cf) {
+void AllocatorOptions::SetFrom(const Flags* f, const CommonFlags* cf) {
   quarantine_size_mb = f->quarantine_size_mb;
   thread_local_quarantine_size_kb = f->thread_local_quarantine_size_kb;
   min_redzone = f->redzone;
@@ -343,7 +341,7 @@ void AllocatorOptions::SetFrom(const Flags *f, const CommonFlags *cf) {
   release_to_os_interval_ms = cf->allocator_release_to_os_interval_ms;
 }
 
-void AllocatorOptions::CopyTo(Flags *f, CommonFlags *cf) {
+void AllocatorOptions::CopyTo(Flags* f, CommonFlags* cf) {
   f->quarantine_size_mb = quarantine_size_mb;
   f->thread_local_quarantine_size_kb = thread_local_quarantine_size_kb;
   f->redzone = min_redzone;
@@ -375,7 +373,7 @@ struct Allocator {
       : quarantine(LINKER_INITIALIZED),
         fallback_quarantine_cache(LINKER_INITIALIZED) {}
 
-  void CheckOptions(const AllocatorOptions &options) const {
+  void CheckOptions(const AllocatorOptions& options) const {
     CHECK_GE(options.min_redzone, 16);
     CHECK_GE(options.max_redzone, options.min_redzone);
     CHECK_LE(options.max_redzone, 2048);
@@ -383,7 +381,7 @@ struct Allocator {
     CHECK(IsPowerOfTwo(options.max_redzone));
   }
 
-  void SharedInitCode(const AllocatorOptions &options) {
+  void SharedInitCode(const AllocatorOptions& options) {
     CheckOptions(options);
     quarantine.Init((uptr)options.quarantine_size_mb << 20,
                     (uptr)options.thread_local_quarantine_size_kb << 10);
@@ -393,7 +391,7 @@ struct Allocator {
     atomic_store(&max_redzone, options.max_redzone, memory_order_release);
   }
 
-  void InitLinkerInitialized(const AllocatorOptions &options) {
+  void InitLinkerInitialized(const AllocatorOptions& options) {
     SetAllocatorMayReturnNull(options.may_return_null);
     allocator.InitLinkerInitialized(options.release_to_os_interval_ms);
     SharedInitCode(options);
@@ -406,8 +404,8 @@ struct Allocator {
   void RePoisonChunk(uptr chunk) {
     // This could be a user-facing chunk (with redzones), or some internal
     // housekeeping chunk, like TransferBatch. Start by assuming the former.
-    AsanChunk *ac = GetAsanChunk((void *)chunk);
-    uptr allocated_size = allocator.GetActuallyAllocatedSize((void *)chunk);
+    AsanChunk* ac = GetAsanChunk((void*)chunk);
+    uptr allocated_size = allocator.GetActuallyAllocatedSize((void*)chunk);
     if (ac && atomic_load(&ac->chunk_state, memory_order_acquire) ==
                   CHUNK_ALLOCATED) {
       uptr beg = ac->Beg();
@@ -430,28 +428,28 @@ struct Allocator {
   }
 
   // Apply provided AllocatorOptions to an Allocator
-  void ApplyOptions(const AllocatorOptions &options) {
+  void ApplyOptions(const AllocatorOptions& options) {
     SetAllocatorMayReturnNull(options.may_return_null);
     allocator.SetReleaseToOSIntervalMs(options.release_to_os_interval_ms);
     SharedInitCode(options);
   }
 
-  void ReInitialize(const AllocatorOptions &options) {
+  void ReInitialize(const AllocatorOptions& options) {
     ApplyOptions(options);
 
     // Poison all existing allocation's redzones.
     if (CanPoisonMemory()) {
       allocator.ForceLock();
       allocator.ForEachChunk(
-          [](uptr chunk, void *alloc) {
-            ((Allocator *)alloc)->RePoisonChunk(chunk);
+          [](uptr chunk, void* alloc) {
+            ((Allocator*)alloc)->RePoisonChunk(chunk);
           },
           this);
       allocator.ForceUnlock();
     }
   }
 
-  void GetOptions(AllocatorOptions *options) const {
+  void GetOptions(AllocatorOptions* options) const {
     options->quarantine_size_mb = quarantine.GetMaxSize() >> 20;
     options->thread_local_quarantine_size_kb =
         quarantine.GetMaxCacheSize() >> 10;
@@ -494,8 +492,8 @@ struct Allocator {
   }
 
   // We have an address between two chunks, and we want to report just one.
-  AsanChunk *ChooseChunk(uptr addr, AsanChunk *left_chunk,
-                         AsanChunk *right_chunk) {
+  AsanChunk* ChooseChunk(uptr addr, AsanChunk* left_chunk,
+                         AsanChunk* right_chunk) {
     if (!left_chunk)
       return right_chunk;
     if (!right_chunk)
@@ -524,19 +522,21 @@ struct Allocator {
     return right_chunk;
   }
 
-  bool UpdateAllocationStack(uptr addr, BufferedStackTrace *stack) {
-    AsanChunk *m = GetAsanChunkByAddr(addr);
-    if (!m) return false;
+  bool UpdateAllocationStack(uptr addr, BufferedStackTrace* stack) {
+    AsanChunk* m = GetAsanChunkByAddr(addr);
+    if (!m)
+      return false;
     if (atomic_load(&m->chunk_state, memory_order_acquire) != CHUNK_ALLOCATED)
       return false;
-    if (m->Beg() != addr) return false;
-    AsanThread *t = GetCurrentThread();
+    if (m->Beg() != addr)
+      return false;
+    AsanThread* t = GetCurrentThread();
     m->SetAllocContext(t ? t->tid() : kMainTid, StackDepotPut(*stack));
     return true;
   }
 
   // -------------------- Allocation/Deallocation routines ---------------
-  void *Allocate(uptr size, uptr alignment, BufferedStackTrace *stack,
+  void* Allocate(uptr size, uptr alignment, BufferedStackTrace* stack,
                  AllocType alloc_type, bool can_fill) {
     if (UNLIKELY(!AsanInited()))
       AsanInitFromRtl();
@@ -545,7 +545,7 @@ struct Allocator {
         return nullptr;
       ReportRssLimitExceeded(stack);
     }
-    Flags &fl = *flags();
+    Flags& fl = *flags();
     CHECK(stack);
     const uptr min_alignment = ASAN_SHADOW_GRANULARITY;
     const uptr user_requested_alignment_log =
@@ -588,14 +588,14 @@ struct Allocator {
       ReportAllocationSizeTooBig(size, needed_size, malloc_limit, stack);
     }
 
-    AsanThread *t = GetCurrentThread();
-    void *allocated;
+    AsanThread* t = GetCurrentThread();
+    void* allocated;
     if (t) {
-      AllocatorCache *cache = GetAllocatorCache(&t->malloc_storage());
+      AllocatorCache* cache = GetAllocatorCache(&t->malloc_storage());
       allocated = allocator.Allocate(cache, needed_size, 8);
     } else {
       SpinMutexLock l(&fallback_mutex);
-      AllocatorCache *cache = &fallback_allocator_cache;
+      AllocatorCache* cache = &fallback_allocator_cache;
       allocated = allocator.Allocate(cache, needed_size, 8);
     }
     if (UNLIKELY(!allocated)) {
@@ -613,7 +613,7 @@ struct Allocator {
     uptr user_end = user_beg + size;
     CHECK_LE(user_end, alloc_end);
     uptr chunk_beg = user_beg - kChunkHeaderSize;
-    AsanChunk *m = reinterpret_cast<AsanChunk *>(chunk_beg);
+    AsanChunk* m = reinterpret_cast<AsanChunk*>(chunk_beg);
     m->alloc_type = alloc_type;
 #if SANITIZER_WINDOWS
     m->from_zero_alloc = upgraded_from_zero;
@@ -624,7 +624,7 @@ struct Allocator {
 
     m->SetAllocContext(t ? t->tid() : kMainTid, StackDepotPut(*stack));
 
-    if (!from_primary || *(u8 *)MEM_TO_SHADOW((uptr)allocated) == 0) {
+    if (!from_primary || *(u8*)MEM_TO_SHADOW((uptr)allocated) == 0) {
       // The allocator provides an unpoisoned chunk. This is possible for the
       // secondary allocator, or if CanPoisonMemory() was false for some time,
       // for example, due to flags()->start_disabled. Anyway, poison left and
@@ -642,8 +642,8 @@ struct Allocator {
       PoisonShadow(user_beg, size_rounded_down_to_granularity, 0);
     // Deal with the end of the region if size is not aligned to granularity.
     if (size != size_rounded_down_to_granularity && CanPoisonMemory()) {
-      u8 *shadow =
-          (u8 *)MemToShadow(user_beg + size_rounded_down_to_granularity);
+      u8* shadow =
+          (u8*)MemToShadow(user_beg + size_rounded_down_to_granularity);
       *shadow = fl.poison_partial ? (size & (ASAN_SHADOW_GRANULARITY - 1)) : 0;
     }
 
@@ -651,7 +651,7 @@ struct Allocator {
       PoisonShadow(user_beg, ASAN_SHADOW_GRANULARITY,
                    kAsanHeapLeftRedzoneMagic);
 
-    AsanStats &thread_stats = GetCurrentThreadStats();
+    AsanStats& thread_stats = GetCurrentThreadStats();
     thread_stats.mallocs++;
     thread_stats.malloced += size;
     thread_stats.malloced_redzones += needed_size - size;
@@ -660,7 +660,7 @@ struct Allocator {
     else
       thread_stats.malloced_by_size[SizeClassMap::ClassID(needed_size)]++;
 
-    void *res = reinterpret_cast<void *>(user_beg);
+    void* res = reinterpret_cast<void*>(user_beg);
     if (can_fill && fl.max_malloc_fill_size) {
       uptr fill_size = Min(size, (uptr)fl.max_malloc_fill_size);
       REAL(memset)(res, fl.malloc_fill_byte, fill_size);
@@ -673,7 +673,7 @@ struct Allocator {
     atomic_store(&m->chunk_state, CHUNK_ALLOCATED, memory_order_release);
     if (alloc_beg != chunk_beg) {
       CHECK_LE(alloc_beg + sizeof(LargeChunkHeader), chunk_beg);
-      reinterpret_cast<LargeChunkHeader *>(alloc_beg)->Set(m);
+      reinterpret_cast<LargeChunkHeader*>(alloc_beg)->Set(m);
     }
     RunMallocHooks(res, size);
     return res;
@@ -681,8 +681,8 @@ struct Allocator {
 
   // Set quarantine flag if chunk is allocated, issue ASan error report on
   // available and quarantined chunks. Return true on success, false otherwise.
-  bool AtomicallySetQuarantineFlagIfAllocated(AsanChunk *m, void *ptr,
-                                              BufferedStackTrace *stack) {
+  bool AtomicallySetQuarantineFlagIfAllocated(AsanChunk* m, void* ptr,
+                                              BufferedStackTrace* stack) {
     u8 old_chunk_state = CHUNK_ALLOCATED;
     // Flip the chunk_state atomically to avoid race on double-free.
     if (!atomic_compare_exchange_strong(&m->chunk_state, &old_chunk_state,
@@ -700,38 +700,38 @@ struct Allocator {
 
   // Expects the chunk to already be marked as quarantined by using
   // AtomicallySetQuarantineFlagIfAllocated.
-  void QuarantineChunk(AsanChunk *m, void *ptr, BufferedStackTrace *stack) {
+  void QuarantineChunk(AsanChunk* m, void* ptr, BufferedStackTrace* stack) {
     CHECK_EQ(atomic_load(&m->chunk_state, memory_order_relaxed),
              CHUNK_QUARANTINE);
-    AsanThread *t = GetCurrentThread();
+    AsanThread* t = GetCurrentThread();
     m->SetFreeContext(t ? t->tid() : 0, StackDepotPut(*stack));
 
     // Push into quarantine.
     if (t) {
-      AsanThreadLocalMallocStorage *ms = &t->malloc_storage();
-      AllocatorCache *ac = GetAllocatorCache(ms);
+      AsanThreadLocalMallocStorage* ms = &t->malloc_storage();
+      AllocatorCache* ac = GetAllocatorCache(ms);
       quarantine.Put(GetQuarantineCache(ms), QuarantineCallback(ac, stack), m,
                      m->UsedSize());
     } else {
       SpinMutexLock l(&fallback_mutex);
-      AllocatorCache *ac = &fallback_allocator_cache;
+      AllocatorCache* ac = &fallback_allocator_cache;
       quarantine.Put(&fallback_quarantine_cache, QuarantineCallback(ac, stack),
                      m, m->UsedSize());
     }
   }
 
-  void Deallocate(void *ptr, uptr delete_size, uptr delete_alignment,
-                  BufferedStackTrace *stack, AllocType alloc_type) {
+  void Deallocate(void* ptr, uptr delete_size, uptr delete_alignment,
+                  BufferedStackTrace* stack, AllocType alloc_type) {
     uptr p = reinterpret_cast<uptr>(ptr);
-    if (p == 0) return;
+    if (p == 0)
+      return;
 
     uptr chunk_beg = p - kChunkHeaderSize;
-    AsanChunk *m = reinterpret_cast<AsanChunk *>(chunk_beg);
+    AsanChunk* m = reinterpret_cast<AsanChunk*>(chunk_beg);
 
     // On Windows, uninstrumented DLLs may allocate memory before ASan hooks
     // malloc. Don't report an invalid free in this case.
-    if (SANITIZER_WINDOWS &&
-        !get_allocator().PointerIsMine(ptr)) {
+    if (SANITIZER_WINDOWS && !get_allocator().PointerIsMine(ptr)) {
       if (!IsSystemHeapAddress(p))
         ReportFreeNotMalloced(p, stack);
       return;
@@ -749,7 +749,8 @@ struct Allocator {
 
     // Must mark the chunk as quarantined before any changes to its metadata.
     // Do not quarantine given chunk if we failed to set CHUNK_QUARANTINE flag.
-    if (!AtomicallySetQuarantineFlagIfAllocated(m, ptr, stack)) return;
+    if (!AtomicallySetQuarantineFlagIfAllocated(m, ptr, stack))
+      return;
 
     if (m->alloc_type != alloc_type) {
       if (atomic_load(&alloc_dealloc_mismatch, memory_order_acquire) &&
@@ -781,20 +782,20 @@ struct Allocator {
       }
     }
 
-    AsanStats &thread_stats = GetCurrentThreadStats();
+    AsanStats& thread_stats = GetCurrentThreadStats();
     thread_stats.frees++;
     thread_stats.freed += m->UsedSize();
 
     QuarantineChunk(m, ptr, stack);
   }
 
-  void *Reallocate(void *old_ptr, uptr new_size, BufferedStackTrace *stack) {
+  void* Reallocate(void* old_ptr, uptr new_size, BufferedStackTrace* stack) {
     CHECK(old_ptr && new_size);
     uptr p = reinterpret_cast<uptr>(old_ptr);
     uptr chunk_beg = p - kChunkHeaderSize;
-    AsanChunk *m = reinterpret_cast<AsanChunk *>(chunk_beg);
+    AsanChunk* m = reinterpret_cast<AsanChunk*>(chunk_beg);
 
-    AsanStats &thread_stats = GetCurrentThreadStats();
+    AsanStats& thread_stats = GetCurrentThreadStats();
     thread_stats.reallocs++;
     thread_stats.realloced += new_size;
 
@@ -830,15 +831,15 @@ struct Allocator {
     return ptr;
   }
 
-  void ReportInvalidFree(void *ptr, u8 chunk_state, BufferedStackTrace *stack) {
+  void ReportInvalidFree(void* ptr, u8 chunk_state, BufferedStackTrace* stack) {
     if (chunk_state == CHUNK_QUARANTINE)
       ReportDoubleFree((uptr)ptr, stack);
     else
       ReportFreeNotMalloced((uptr)ptr, stack);
   }
 
-  void CommitBack(AsanThreadLocalMallocStorage *ms, BufferedStackTrace *stack) {
-    AllocatorCache *ac = GetAllocatorCache(ms);
+  void CommitBack(AsanThreadLocalMallocStorage* ms, BufferedStackTrace* stack) {
+    AllocatorCache* ac = GetAllocatorCache(ms);
     quarantine.Drain(GetQuarantineCache(ms), QuarantineCallback(ac, stack));
     allocator.SwallowCache(ac);
   }
@@ -849,14 +850,14 @@ struct Allocator {
   // Returns nullptr if AsanChunk is not yet initialized just after
   // get_allocator().Allocate(), or is being destroyed just before
   // get_allocator().Deallocate().
-  AsanChunk *GetAsanChunk(void *alloc_beg) {
+  AsanChunk* GetAsanChunk(void* alloc_beg) {
     if (!alloc_beg)
       return nullptr;
-    AsanChunk *p = reinterpret_cast<LargeChunkHeader *>(alloc_beg)->Get();
+    AsanChunk* p = reinterpret_cast<LargeChunkHeader*>(alloc_beg)->Get();
     if (!p) {
       if (!allocator.FromPrimary(alloc_beg))
         return nullptr;
-      p = reinterpret_cast<AsanChunk *>(alloc_beg);
+      p = reinterpret_cast<AsanChunk*>(alloc_beg);
     }
     u8 state = atomic_load(&p->chunk_state, memory_order_relaxed);
     // It does not guaranty that Chunk is initialized, but it's
@@ -866,24 +867,26 @@ struct Allocator {
     return nullptr;
   }
 
-  AsanChunk *GetAsanChunkByAddr(uptr p) {
-    void *alloc_beg = allocator.GetBlockBegin(reinterpret_cast<void *>(p));
+  AsanChunk* GetAsanChunkByAddr(uptr p) {
+    void* alloc_beg = allocator.GetBlockBegin(reinterpret_cast<void*>(p));
     return GetAsanChunk(alloc_beg);
   }
 
   // Allocator must be locked when this function is called.
-  AsanChunk *GetAsanChunkByAddrFastLocked(uptr p) {
-    void *alloc_beg =
-        allocator.GetBlockBeginFastLocked(reinterpret_cast<void *>(p));
+  AsanChunk* GetAsanChunkByAddrFastLocked(uptr p) {
+    void* alloc_beg =
+        allocator.GetBlockBeginFastLocked(reinterpret_cast<void*>(p));
     return GetAsanChunk(alloc_beg);
   }
 
   uptr AllocationSize(uptr p) {
-    AsanChunk *m = GetAsanChunkByAddr(p);
-    if (!m) return 0;
+    AsanChunk* m = GetAsanChunkByAddr(p);
+    if (!m)
+      return 0;
     if (atomic_load(&m->chunk_state, memory_order_acquire) != CHUNK_ALLOCATED)
       return 0;
-    if (m->Beg() != p) return 0;
+    if (m->Beg() != p)
+      return 0;
     return m->UsedSize();
   }
 
@@ -905,20 +908,21 @@ struct Allocator {
 #endif
 
   uptr AllocationSizeFast(uptr p) {
-    return reinterpret_cast<AsanChunk *>(p - kChunkHeaderSize)->UsedSize();
+    return reinterpret_cast<AsanChunk*>(p - kChunkHeaderSize)->UsedSize();
   }
 
   AsanChunkView FindHeapChunkByAddress(uptr addr) {
-    AsanChunk *m1 = GetAsanChunkByAddr(addr);
+    AsanChunk* m1 = GetAsanChunkByAddr(addr);
     sptr offset = 0;
     if (!m1 || AsanChunkView(m1).AddrIsAtLeft(addr, 1, &offset)) {
       // The address is in the chunk's left redzone, so maybe it is actually
       // a right buffer overflow from the other chunk before.
       // Search a bit before to see if there is another chunk.
-      AsanChunk *m2 = nullptr;
+      AsanChunk* m2 = nullptr;
       for (uptr l = 1; l < GetPageSizeCached(); l++) {
         m2 = GetAsanChunkByAddr(addr - l);
-        if (m2 == m1) continue;  // Still the same chunk.
+        if (m2 == m1)
+          continue;  // Still the same chunk.
         break;
       }
       if (m2 && AsanChunkView(m2).AddrIsAtRight(addr, 1, &offset))
@@ -927,19 +931,19 @@ struct Allocator {
     return AsanChunkView(m1);
   }
 
-  void Purge(BufferedStackTrace *stack) {
-    AsanThread *t = GetCurrentThread();
+  void Purge(BufferedStackTrace* stack) {
+    AsanThread* t = GetCurrentThread();
     if (t) {
-      AsanThreadLocalMallocStorage *ms = &t->malloc_storage();
-      quarantine.DrainAndRecycle(GetQuarantineCache(ms),
-                                 QuarantineCallback(GetAllocatorCache(ms),
-                                                    stack));
+      AsanThreadLocalMallocStorage* ms = &t->malloc_storage();
+      quarantine.DrainAndRecycle(
+          GetQuarantineCache(ms),
+          QuarantineCallback(GetAllocatorCache(ms), stack));
     }
     {
       SpinMutexLock l(&fallback_mutex);
-      quarantine.DrainAndRecycle(&fallback_quarantine_cache,
-                                 QuarantineCallback(&fallback_allocator_cache,
-                                                    stack));
+      quarantine.DrainAndRecycle(
+          &fallback_quarantine_cache,
+          QuarantineCallback(&fallback_allocator_cache, stack));
     }
 
     allocator.ForceReleaseToOS();
@@ -963,9 +967,7 @@ struct Allocator {
 
 static Allocator instance(LINKER_INITIALIZED);
 
-static AsanAllocator &get_allocator() {
-  return instance.allocator;
-}
+static AsanAllocator& get_allocator() { return instance.allocator; }
 
 bool AsanChunkView::IsValid() const {
   return chunk_ && atomic_load(&chunk_->chunk_state, memory_order_relaxed) !=
@@ -1022,20 +1024,20 @@ u32 AsanChunkView::GetFreeStackId() const {
   return stack;
 }
 
-void InitializeAllocator(const AllocatorOptions &options) {
+void InitializeAllocator(const AllocatorOptions& options) {
   instance.InitLinkerInitialized(options);
 }
 
-void ReInitializeAllocator(const AllocatorOptions &options) {
+void ReInitializeAllocator(const AllocatorOptions& options) {
   instance.ReInitialize(options);
 }
 
 // Apply provided AllocatorOptions to an Allocator
-void ApplyAllocatorOptions(const AllocatorOptions &options) {
+void ApplyAllocatorOptions(const AllocatorOptions& options) {
   instance.ApplyOptions(options);
 }
 
-void GetAllocatorOptions(AllocatorOptions *options) {
+void GetAllocatorOptions(AllocatorOptions* options) {
   instance.GetOptions(options);
 }
 
@@ -1051,11 +1053,9 @@ void AsanThreadLocalMallocStorage::CommitBack() {
   instance.CommitBack(this, &stack);
 }
 
-void PrintInternalAllocatorStats() {
-  instance.PrintStats();
-}
+void PrintInternalAllocatorStats() { instance.PrintStats(); }
 
-void asan_free(void *ptr, BufferedStackTrace *stack) {
+void asan_free(void* ptr, BufferedStackTrace* stack) {
   instance.Deallocate(ptr, 0, 0, stack, FROM_MALLOC);
 }
 
@@ -1068,12 +1068,12 @@ void asan_free_aligned_sized(void* ptr, uptr alignment, uptr size,
   instance.Deallocate(ptr, size, alignment, stack, FROM_MALLOC);
 }
 
-void *asan_malloc(uptr size, BufferedStackTrace *stack) {
+void* asan_malloc(uptr size, BufferedStackTrace* stack) {
   return SetErrnoOnNull(instance.Allocate(size, /*alignment=*/8, stack,
                                           FROM_MALLOC, /*can_fill=*/true));
 }
 
-void *asan_calloc(uptr nmemb, uptr size, BufferedStackTrace *stack) {
+void* asan_calloc(uptr nmemb, uptr size, BufferedStackTrace* stack) {
   return SetErrnoOnNull(instance.Calloc(nmemb, size, stack));
 }
 
@@ -1088,8 +1088,8 @@ void* asan_vec_calloc(uptr nmemb, uptr size, BufferedStackTrace* stack) {
 }
 #endif
 
-void *asan_reallocarray(void *p, uptr nmemb, uptr size,
-                        BufferedStackTrace *stack) {
+void* asan_reallocarray(void* p, uptr nmemb, uptr size,
+                        BufferedStackTrace* stack) {
   if (UNLIKELY(CheckForCallocOverflow(size, nmemb))) {
     errno = errno_ENOMEM;
     if (AllocatorMayReturnNull())
@@ -1099,7 +1099,7 @@ void *asan_reallocarray(void *p, uptr nmemb, uptr size,
   return asan_realloc(p, nmemb * size, stack);
 }
 
-void *asan_realloc(void *p, uptr size, BufferedStackTrace *stack) {
+void* asan_realloc(void* p, uptr size, BufferedStackTrace* stack) {
   if (!p)
     return SetErrnoOnNull(instance.Allocate(size, /*alignment=*/8, stack,
                                             FROM_MALLOC, /*can_fill=*/true));
@@ -1114,12 +1114,12 @@ void *asan_realloc(void *p, uptr size, BufferedStackTrace *stack) {
   return SetErrnoOnNull(instance.Reallocate(p, size, stack));
 }
 
-void *asan_valloc(uptr size, BufferedStackTrace *stack) {
+void* asan_valloc(uptr size, BufferedStackTrace* stack) {
   return SetErrnoOnNull(instance.Allocate(size, GetPageSizeCached(), stack,
                                           FROM_MALLOC, /*can_fill=*/true));
 }
 
-void *asan_pvalloc(uptr size, BufferedStackTrace *stack) {
+void* asan_pvalloc(uptr size, BufferedStackTrace* stack) {
   uptr PageSize = GetPageSizeCached();
   if (UNLIKELY(CheckForPvallocOverflow(size, PageSize))) {
     errno = errno_ENOMEM;
@@ -1133,7 +1133,7 @@ void *asan_pvalloc(uptr size, BufferedStackTrace *stack) {
       instance.Allocate(size, PageSize, stack, FROM_MALLOC, /*can_fill=*/true));
 }
 
-void *asan_memalign(uptr alignment, uptr size, BufferedStackTrace *stack) {
+void* asan_memalign(uptr alignment, uptr size, BufferedStackTrace* stack) {
   if (UNLIKELY(!IsPowerOfTwo(alignment))) {
     errno = errno_EINVAL;
     if (AllocatorMayReturnNull())
@@ -1144,7 +1144,7 @@ void *asan_memalign(uptr alignment, uptr size, BufferedStackTrace *stack) {
                                           /*can_fill=*/true));
 }
 
-void *asan_aligned_alloc(uptr alignment, uptr size, BufferedStackTrace *stack) {
+void* asan_aligned_alloc(uptr alignment, uptr size, BufferedStackTrace* stack) {
   if (UNLIKELY(!CheckAlignedAllocAlignmentAndSize(alignment, size))) {
     errno = errno_EINVAL;
     if (AllocatorMayReturnNull())
@@ -1155,8 +1155,8 @@ void *asan_aligned_alloc(uptr alignment, uptr size, BufferedStackTrace *stack) {
                                           /*can_fill=*/true));
 }
 
-int asan_posix_memalign(void **memptr, uptr alignment, uptr size,
-                        BufferedStackTrace *stack) {
+int asan_posix_memalign(void** memptr, uptr alignment, uptr size,
+                        BufferedStackTrace* stack) {
   if (UNLIKELY(!CheckPosixMemalignAlignment(alignment))) {
     if (AllocatorMayReturnNull())
       return errno_EINVAL;
@@ -1172,8 +1172,9 @@ int asan_posix_memalign(void **memptr, uptr alignment, uptr size,
   return 0;
 }
 
-uptr asan_malloc_usable_size(const void *ptr, uptr pc, uptr bp) {
-  if (!ptr) return 0;
+uptr asan_malloc_usable_size(const void* ptr, uptr pc, uptr bp) {
+  if (!ptr)
+    return 0;
   uptr usable_size = instance.AllocationSize(reinterpret_cast<uptr>(ptr));
   if (flags()->check_malloc_usable_size && (usable_size == 0)) {
     GET_STACK_TRACE_FATAL(pc, bp);
@@ -1195,13 +1196,13 @@ uptr asan_malloc_usable_size(const void *ptr, uptr pc, uptr bp) {
 
 namespace {
 
-void *asan_new(uptr size, BufferedStackTrace *stack, bool array) {
+void* asan_new(uptr size, BufferedStackTrace* stack, bool array) {
   return SetErrnoOnNull(instance.Allocate(size, /*alignment=*/0, stack,
                                           array ? FROM_NEW_BR : FROM_NEW,
                                           /*can_fill=*/true));
 }
 
-void *asan_new_aligned(uptr size, uptr alignment, BufferedStackTrace *stack,
+void* asan_new_aligned(uptr size, uptr alignment, BufferedStackTrace* stack,
                        bool array) {
   if (UNLIKELY(alignment == 0 || !IsPowerOfTwo(alignment))) {
     errno = errno_EINVAL;
@@ -1214,77 +1215,77 @@ void *asan_new_aligned(uptr size, uptr alignment, BufferedStackTrace *stack,
                                           /*can_fill=*/true));
 }
 
-void asan_delete(void *ptr, BufferedStackTrace *stack, bool array) {
+void asan_delete(void* ptr, BufferedStackTrace* stack, bool array) {
   instance.Deallocate(ptr, 0, 0, stack, array ? FROM_NEW_BR : FROM_NEW);
 }
 
-void asan_delete_aligned(void *ptr, uptr alignment, BufferedStackTrace *stack,
+void asan_delete_aligned(void* ptr, uptr alignment, BufferedStackTrace* stack,
                          bool array) {
   instance.Deallocate(ptr, 0, alignment, stack, array ? FROM_NEW_BR : FROM_NEW);
 }
 
-void asan_delete_sized(void *ptr, uptr size, BufferedStackTrace *stack,
+void asan_delete_sized(void* ptr, uptr size, BufferedStackTrace* stack,
                        bool array) {
   instance.Deallocate(ptr, size, 0, stack, array ? FROM_NEW_BR : FROM_NEW);
 }
 
-void asan_delete_sized_aligned(void *ptr, uptr size, uptr alignment,
-                               BufferedStackTrace *stack, bool array) {
+void asan_delete_sized_aligned(void* ptr, uptr size, uptr alignment,
+                               BufferedStackTrace* stack, bool array) {
   instance.Deallocate(ptr, size, alignment, stack,
                       array ? FROM_NEW_BR : FROM_NEW);
 }
 
 }  // namespace
 
-void *asan_new(uptr size, BufferedStackTrace *stack) {
+void* asan_new(uptr size, BufferedStackTrace* stack) {
   return asan_new(size, stack, /*array=*/false);
 }
 
-void *asan_new_aligned(uptr size, uptr alignment, BufferedStackTrace *stack) {
+void* asan_new_aligned(uptr size, uptr alignment, BufferedStackTrace* stack) {
   return asan_new_aligned(size, alignment, stack, /*array=*/false);
 }
 
-void *asan_new_array(uptr size, BufferedStackTrace *stack) {
+void* asan_new_array(uptr size, BufferedStackTrace* stack) {
   return asan_new(size, stack, /*array=*/true);
 }
 
-void *asan_new_array_aligned(uptr size, uptr alignment,
-                             BufferedStackTrace *stack) {
+void* asan_new_array_aligned(uptr size, uptr alignment,
+                             BufferedStackTrace* stack) {
   return asan_new_aligned(size, alignment, stack, /*array=*/true);
 }
 
-void asan_delete(void *ptr, BufferedStackTrace *stack) {
+void asan_delete(void* ptr, BufferedStackTrace* stack) {
   asan_delete(ptr, stack, /*array=*/false);
 }
 
-void asan_delete_aligned(void *ptr, uptr alignment, BufferedStackTrace *stack) {
+void asan_delete_aligned(void* ptr, uptr alignment, BufferedStackTrace* stack) {
   asan_delete_aligned(ptr, alignment, stack, /*array=*/false);
 }
 
-void asan_delete_sized(void *ptr, uptr size, BufferedStackTrace *stack) {
+void asan_delete_sized(void* ptr, uptr size, BufferedStackTrace* stack) {
   asan_delete_sized(ptr, size, stack, /*array=*/false);
 }
 
-void asan_delete_sized_aligned(void *ptr, uptr size, uptr alignment,
-                               BufferedStackTrace *stack) {
+void asan_delete_sized_aligned(void* ptr, uptr size, uptr alignment,
+                               BufferedStackTrace* stack) {
   asan_delete_sized_aligned(ptr, size, alignment, stack, /*array=*/false);
 }
 
-void asan_delete_array(void *ptr, BufferedStackTrace *stack) {
+void asan_delete_array(void* ptr, BufferedStackTrace* stack) {
   asan_delete(ptr, stack, /*array=*/true);
 }
 
-void asan_delete_array_aligned(void *ptr, uptr alignment,
-                               BufferedStackTrace *stack) {
+void asan_delete_array_aligned(void* ptr, uptr alignment,
+                               BufferedStackTrace* stack) {
   asan_delete_aligned(ptr, alignment, stack, /*array=*/true);
 }
 
-void asan_delete_array_sized(void *ptr, uptr size, BufferedStackTrace *stack) {
+void asan_delete_array_sized(void* ptr, uptr size, BufferedStackTrace* stack) {
   asan_delete_sized(ptr, size, stack, /*array=*/true);
 }
 
-void asan_delete_array_sized_aligned(void *ptr, uptr size, uptr alignment,
-                                     BufferedStackTrace *stack) {
+void asan_delete_array_sized_aligned(void* ptr, uptr size, uptr alignment,
+                                     BufferedStackTrace* stack) {
   asan_delete_sized_aligned(ptr, size, alignment, stack, /*array=*/true);
 }
 
@@ -1319,22 +1320,18 @@ void asan_mz_force_unlock() SANITIZER_NO_THREAD_SAFETY_ANALYSIS {
 
 // --- Implementation of LSan-specific functions --- {{{1
 namespace __lsan {
-void LockAllocator() {
-  __asan::get_allocator().ForceLock();
-}
+void LockAllocator() { __asan::get_allocator().ForceLock(); }
 
-void UnlockAllocator() {
-  __asan::get_allocator().ForceUnlock();
-}
+void UnlockAllocator() { __asan::get_allocator().ForceUnlock(); }
 
-void GetAllocatorGlobalRange(uptr *begin, uptr *end) {
+void GetAllocatorGlobalRange(uptr* begin, uptr* end) {
   *begin = (uptr)&__asan::get_allocator();
   *end = *begin + sizeof(__asan::get_allocator());
 }
 
-uptr PointsIntoChunk(void *p) {
+uptr PointsIntoChunk(void* p) {
   uptr addr = reinterpret_cast<uptr>(p);
-  __asan::AsanChunk *m = __asan::instance.GetAsanChunkByAddrFastLocked(addr);
+  __asan::AsanChunk* m = __asan::instance.GetAsanChunkByAddrFastLocked(addr);
   if (!m || atomic_load(&m->chunk_state, memory_order_acquire) !=
                 __asan::CHUNK_ALLOCATED)
     return 0;
@@ -1349,57 +1346,55 @@ uptr PointsIntoChunk(void *p) {
 uptr GetUserBegin(uptr chunk) {
   // FIXME: All usecases provide chunk address, GetAsanChunkByAddrFastLocked is
   // not needed.
-  __asan::AsanChunk *m = __asan::instance.GetAsanChunkByAddrFastLocked(chunk);
+  __asan::AsanChunk* m = __asan::instance.GetAsanChunkByAddrFastLocked(chunk);
   return m ? m->Beg() : 0;
 }
 
-uptr GetUserAddr(uptr chunk) {
-  return chunk;
-}
+uptr GetUserAddr(uptr chunk) { return chunk; }
 
 LsanMetadata::LsanMetadata(uptr chunk) {
-  metadata_ = chunk ? reinterpret_cast<void *>(chunk - __asan::kChunkHeaderSize)
+  metadata_ = chunk ? reinterpret_cast<void*>(chunk - __asan::kChunkHeaderSize)
                     : nullptr;
 }
 
 bool LsanMetadata::allocated() const {
   if (!metadata_)
     return false;
-  __asan::AsanChunk *m = reinterpret_cast<__asan::AsanChunk *>(metadata_);
+  __asan::AsanChunk* m = reinterpret_cast<__asan::AsanChunk*>(metadata_);
   return atomic_load(&m->chunk_state, memory_order_relaxed) ==
          __asan::CHUNK_ALLOCATED;
 }
 
 ChunkTag LsanMetadata::tag() const {
-  __asan::AsanChunk *m = reinterpret_cast<__asan::AsanChunk *>(metadata_);
+  __asan::AsanChunk* m = reinterpret_cast<__asan::AsanChunk*>(metadata_);
   return static_cast<ChunkTag>(m->lsan_tag);
 }
 
 void LsanMetadata::set_tag(ChunkTag value) {
-  __asan::AsanChunk *m = reinterpret_cast<__asan::AsanChunk *>(metadata_);
+  __asan::AsanChunk* m = reinterpret_cast<__asan::AsanChunk*>(metadata_);
   m->lsan_tag = value;
 }
 
 uptr LsanMetadata::requested_size() const {
-  __asan::AsanChunk *m = reinterpret_cast<__asan::AsanChunk *>(metadata_);
+  __asan::AsanChunk* m = reinterpret_cast<__asan::AsanChunk*>(metadata_);
   return m->UsedSize();
 }
 
 u32 LsanMetadata::stack_trace_id() const {
-  __asan::AsanChunk *m = reinterpret_cast<__asan::AsanChunk *>(metadata_);
+  __asan::AsanChunk* m = reinterpret_cast<__asan::AsanChunk*>(metadata_);
   u32 tid = 0;
   u32 stack = 0;
   m->GetAllocContext(tid, stack);
   return stack;
 }
 
-void ForEachChunk(ForEachChunkCallback callback, void *arg) {
+void ForEachChunk(ForEachChunkCallback callback, void* arg) {
   __asan::get_allocator().ForEachChunk(callback, arg);
 }
 
-IgnoreObjectResult IgnoreObject(const void *p) {
+IgnoreObjectResult IgnoreObject(const void* p) {
   uptr addr = reinterpret_cast<uptr>(p);
-  __asan::AsanChunk *m = __asan::instance.GetAsanChunkByAddr(addr);
+  __asan::AsanChunk* m = __asan::instance.GetAsanChunkByAddr(addr);
   if (!m ||
       (atomic_load(&m->chunk_state, memory_order_acquire) !=
        __asan::CHUNK_ALLOCATED) ||
@@ -1417,30 +1412,29 @@ IgnoreObjectResult IgnoreObject(const void *p) {
 // ---------------------- Interface ---------------- {{{1
 using namespace __asan;
 
-static const void *AllocationBegin(const void *p) {
-  AsanChunk *m = __asan::instance.GetAsanChunkByAddr((uptr)p);
+static const void* AllocationBegin(const void* p) {
+  AsanChunk* m = __asan::instance.GetAsanChunkByAddr((uptr)p);
   if (!m)
     return nullptr;
   if (atomic_load(&m->chunk_state, memory_order_acquire) != CHUNK_ALLOCATED)
     return nullptr;
   if (m->UsedSize() == 0)
     return nullptr;
-  return (const void *)(m->Beg());
+  return (const void*)(m->Beg());
 }
 
 // ASan allocator doesn't reserve extra bytes, so normally we would
 // just return "size". We don't want to expose our redzone sizes, etc here.
-uptr __sanitizer_get_estimated_allocated_size(uptr size) {
-  return size;
-}
+uptr __sanitizer_get_estimated_allocated_size(uptr size) { return size; }
 
-int __sanitizer_get_ownership(const void *p) {
+int __sanitizer_get_ownership(const void* p) {
   uptr ptr = reinterpret_cast<uptr>(p);
   return instance.AllocationSize(ptr) > 0;
 }
 
-uptr __sanitizer_get_allocated_size(const void *p) {
-  if (!p) return 0;
+uptr __sanitizer_get_allocated_size(const void* p) {
+  if (!p)
+    return 0;
   uptr ptr = reinterpret_cast<uptr>(p);
   uptr allocated_size = instance.AllocationSize(ptr);
   // Die if p is not malloced or if it is already freed.
@@ -1451,14 +1445,14 @@ uptr __sanitizer_get_allocated_size(const void *p) {
   return allocated_size;
 }
 
-uptr __sanitizer_get_allocated_size_fast(const void *p) {
+uptr __sanitizer_get_allocated_size_fast(const void* p) {
   DCHECK_EQ(p, __sanitizer_get_allocated_begin(p));
   uptr ret = instance.AllocationSizeFast(reinterpret_cast<uptr>(p));
   DCHECK_EQ(ret, __sanitizer_get_allocated_size(p));
   return ret;
 }
 
-const void *__sanitizer_get_allocated_begin(const void *p) {
+const void* __sanitizer_get_allocated_begin(const void* p) {
   return AllocationBegin(p);
 }
 

--- a/compiler-rt/lib/asan/asan_allocator.h
+++ b/compiler-rt/lib/asan/asan_allocator.h
@@ -40,18 +40,18 @@ struct AllocatorOptions {
   u8 alloc_dealloc_mismatch;
   s32 release_to_os_interval_ms;
 
-  void SetFrom(const Flags *f, const CommonFlags *cf);
-  void CopyTo(Flags *f, CommonFlags *cf);
+  void SetFrom(const Flags* f, const CommonFlags* cf);
+  void CopyTo(Flags* f, CommonFlags* cf);
 };
 
-void InitializeAllocator(const AllocatorOptions &options);
-void ReInitializeAllocator(const AllocatorOptions &options);
-void GetAllocatorOptions(AllocatorOptions *options);
-void ApplyAllocatorOptions(const AllocatorOptions &options);
+void InitializeAllocator(const AllocatorOptions& options);
+void ReInitializeAllocator(const AllocatorOptions& options);
+void GetAllocatorOptions(AllocatorOptions* options);
+void ApplyAllocatorOptions(const AllocatorOptions& options);
 
 class AsanChunkView {
  public:
-  explicit AsanChunkView(AsanChunk *chunk) : chunk_(chunk) {}
+  explicit AsanChunkView(AsanChunk* chunk) : chunk_(chunk) {}
   bool IsValid() const;        // Checks if AsanChunkView points to a valid
                                // allocated or quarantined chunk.
   bool IsAllocated() const;    // Checks if the memory is currently allocated.
@@ -62,18 +62,18 @@ class AsanChunkView {
   u32 UserRequestedAlignment() const;  // Originally requested alignment.
   uptr AllocTid() const;
   uptr FreeTid() const;
-  bool Eq(const AsanChunkView &c) const { return chunk_ == c.chunk_; }
+  bool Eq(const AsanChunkView& c) const { return chunk_ == c.chunk_; }
   u32 GetAllocStackId() const;
   u32 GetFreeStackId() const;
   AllocType GetAllocType() const;
-  bool AddrIsInside(uptr addr, uptr access_size, sptr *offset) const {
+  bool AddrIsInside(uptr addr, uptr access_size, sptr* offset) const {
     if (addr >= Beg() && (addr + access_size) <= End()) {
       *offset = addr - Beg();
       return true;
     }
     return false;
   }
-  bool AddrIsAtLeft(uptr addr, uptr access_size, sptr *offset) const {
+  bool AddrIsAtLeft(uptr addr, uptr access_size, sptr* offset) const {
     (void)access_size;
     if (addr < Beg()) {
       *offset = Beg() - addr;
@@ -81,7 +81,7 @@ class AsanChunkView {
     }
     return false;
   }
-  bool AddrIsAtRight(uptr addr, uptr access_size, sptr *offset) const {
+  bool AddrIsAtRight(uptr addr, uptr access_size, sptr* offset) const {
     if (addr + access_size > End()) {
       *offset = addr - End();
       return true;
@@ -90,25 +90,26 @@ class AsanChunkView {
   }
 
  private:
-  AsanChunk *const chunk_;
+  AsanChunk* const chunk_;
 };
 
 AsanChunkView FindHeapChunkByAddress(uptr address);
 AsanChunkView FindHeapChunkByAllocBeg(uptr address);
 
 // List of AsanChunks with total size.
-class AsanChunkFifoList: public IntrusiveList<AsanChunk> {
+class AsanChunkFifoList : public IntrusiveList<AsanChunk> {
  public:
-  explicit AsanChunkFifoList(LinkerInitialized) { }
+  explicit AsanChunkFifoList(LinkerInitialized) {}
   AsanChunkFifoList() { clear(); }
-  void Push(AsanChunk *n);
-  void PushList(AsanChunkFifoList *q);
-  AsanChunk *Pop();
+  void Push(AsanChunk* n);
+  void PushList(AsanChunkFifoList* q);
+  AsanChunk* Pop();
   uptr size() { return size_; }
   void clear() {
     IntrusiveList<AsanChunk>::clear();
     size_ = 0;
   }
+
  private:
   uptr size_;
 };
@@ -120,7 +121,7 @@ struct AsanMapUnmapCallback {
 };
 
 #if SANITIZER_CAN_USE_ALLOCATOR64
-# if SANITIZER_FUCHSIA
+#  if SANITIZER_FUCHSIA
 // This is a sentinel indicating we do not want the primary allocator arena to
 // be placed at a fixed address. It will be anonymously mmap'd.
 const uptr kAllocatorSpace = ~(uptr)0;
@@ -201,13 +202,13 @@ const uptr kAllocatorSpace = ~(uptr)0;
 #      if SANITIZER_AIX
 const uptr kAllocatorSize = 1ULL << 38;  // 256G.
 #      else
-const uptr kAllocatorSize  =  0x20000000000ULL;  // 2T.
+const uptr kAllocatorSize = 0x20000000000ULL;  // 2T.
 #      endif
 typedef DefaultSizeClassMap SizeClassMap;
 #    elif defined(__aarch64__) && \
         (SANITIZER_ANDROID || defined(SANITIZER_AARCH64_39BIT_VA))
 // Android needs to support 39, 42 and 48 bit VMA.
-const uptr kAllocatorSize  =  0x2000000000ULL;  // 128G.
+const uptr kAllocatorSize = 0x2000000000ULL;  // 128G.
 typedef VeryCompactSizeClassMap SizeClassMap;
 #    elif SANITIZER_RISCV64
 const uptr kAllocatorSize = 0x2000000000ULL;  // 128G.
@@ -221,10 +222,10 @@ typedef DefaultSizeClassMap SizeClassMap;
 const uptr kAllocatorSize = 0x8000000000ULL;  // 512G.
 typedef DefaultSizeClassMap SizeClassMap;
 #    elif SANITIZER_WINDOWS
-const uptr kAllocatorSize  =  0x8000000000ULL;  // 500G
+const uptr kAllocatorSize = 0x8000000000ULL;  // 500G
 typedef DefaultSizeClassMap SizeClassMap;
 #    elif SANITIZER_APPLE
-const uptr kAllocatorSize  =  0x40000000000ULL;  // 4T.
+const uptr kAllocatorSize = 0x40000000000ULL;  // 4T.
 typedef DefaultSizeClassMap SizeClassMap;
 #    else
 const uptr kAllocatorSize = 0x40000000000ULL;  // 4T.
@@ -259,7 +260,7 @@ struct AP32 {
   static const uptr kFlags = 0;
 };
 template <typename AddressSpaceView>
-using PrimaryAllocatorASVT = SizeClassAllocator32<AP32<AddressSpaceView> >;
+using PrimaryAllocatorASVT = SizeClassAllocator32<AP32<AddressSpaceView>>;
 using PrimaryAllocator = PrimaryAllocatorASVT<LocalAddressSpaceView>;
 #endif  // SANITIZER_CAN_USE_ALLOCATOR64
 
@@ -275,52 +276,53 @@ struct AsanThreadLocalMallocStorage {
   uptr quarantine_cache[16];
   AllocatorCache allocator_cache;
   void CommitBack();
+
  private:
   // These objects are allocated via mmap() and are zero-initialized.
   AsanThreadLocalMallocStorage() {}
 };
 
-void *asan_memalign(uptr alignment, uptr size, BufferedStackTrace *stack);
-void asan_free(void *ptr, BufferedStackTrace *stack);
+void* asan_memalign(uptr alignment, uptr size, BufferedStackTrace* stack);
+void asan_free(void* ptr, BufferedStackTrace* stack);
 void asan_free_sized(void* ptr, uptr size, BufferedStackTrace* stack);
 void asan_free_aligned_sized(void* ptr, uptr alignment, uptr size,
                              BufferedStackTrace* stack);
 
-void *asan_malloc(uptr size, BufferedStackTrace *stack);
-void *asan_calloc(uptr nmemb, uptr size, BufferedStackTrace *stack);
+void* asan_malloc(uptr size, BufferedStackTrace* stack);
+void* asan_calloc(uptr nmemb, uptr size, BufferedStackTrace* stack);
 #if SANITIZER_AIX
 void* asan_vec_malloc(uptr size, BufferedStackTrace* stack);
 void* asan_vec_calloc(uptr nmemb, uptr size, BufferedStackTrace* stack);
 #endif
-void *asan_realloc(void *p, uptr size, BufferedStackTrace *stack);
-void *asan_reallocarray(void *p, uptr nmemb, uptr size,
-                        BufferedStackTrace *stack);
-void *asan_valloc(uptr size, BufferedStackTrace *stack);
-void *asan_pvalloc(uptr size, BufferedStackTrace *stack);
+void* asan_realloc(void* p, uptr size, BufferedStackTrace* stack);
+void* asan_reallocarray(void* p, uptr nmemb, uptr size,
+                        BufferedStackTrace* stack);
+void* asan_valloc(uptr size, BufferedStackTrace* stack);
+void* asan_pvalloc(uptr size, BufferedStackTrace* stack);
 
-void *asan_aligned_alloc(uptr alignment, uptr size, BufferedStackTrace *stack);
-int asan_posix_memalign(void **memptr, uptr alignment, uptr size,
-                        BufferedStackTrace *stack);
-uptr asan_malloc_usable_size(const void *ptr, uptr pc, uptr bp);
+void* asan_aligned_alloc(uptr alignment, uptr size, BufferedStackTrace* stack);
+int asan_posix_memalign(void** memptr, uptr alignment, uptr size,
+                        BufferedStackTrace* stack);
+uptr asan_malloc_usable_size(const void* ptr, uptr pc, uptr bp);
 
-void *asan_new(uptr size, BufferedStackTrace *stack);
-void *asan_new_aligned(uptr size, uptr alignment, BufferedStackTrace *stack);
-void *asan_new_array(uptr size, BufferedStackTrace *stack);
-void *asan_new_array_aligned(uptr size, uptr alignment,
-                             BufferedStackTrace *stack);
-void asan_delete(void *ptr, BufferedStackTrace *stack);
-void asan_delete_aligned(void *ptr, uptr alignment, BufferedStackTrace *stack);
-void asan_delete_sized(void *ptr, uptr size, BufferedStackTrace *stack);
-void asan_delete_sized_aligned(void *ptr, uptr size, uptr alignment,
-                               BufferedStackTrace *stack);
-void asan_delete_array(void *ptr, BufferedStackTrace *stack);
-void asan_delete_array_aligned(void *ptr, uptr alignment,
-                               BufferedStackTrace *stack);
-void asan_delete_array_sized(void *ptr, uptr size, BufferedStackTrace *stack);
-void asan_delete_array_sized_aligned(void *ptr, uptr size, uptr alignment,
-                                     BufferedStackTrace *stack);
+void* asan_new(uptr size, BufferedStackTrace* stack);
+void* asan_new_aligned(uptr size, uptr alignment, BufferedStackTrace* stack);
+void* asan_new_array(uptr size, BufferedStackTrace* stack);
+void* asan_new_array_aligned(uptr size, uptr alignment,
+                             BufferedStackTrace* stack);
+void asan_delete(void* ptr, BufferedStackTrace* stack);
+void asan_delete_aligned(void* ptr, uptr alignment, BufferedStackTrace* stack);
+void asan_delete_sized(void* ptr, uptr size, BufferedStackTrace* stack);
+void asan_delete_sized_aligned(void* ptr, uptr size, uptr alignment,
+                               BufferedStackTrace* stack);
+void asan_delete_array(void* ptr, BufferedStackTrace* stack);
+void asan_delete_array_aligned(void* ptr, uptr alignment,
+                               BufferedStackTrace* stack);
+void asan_delete_array_sized(void* ptr, uptr size, BufferedStackTrace* stack);
+void asan_delete_array_sized_aligned(void* ptr, uptr size, uptr alignment,
+                                     BufferedStackTrace* stack);
 
-uptr asan_mz_size(const void *ptr);
+uptr asan_mz_size(const void* ptr);
 void asan_mz_force_lock();
 void asan_mz_force_unlock();
 

--- a/compiler-rt/lib/asan/asan_malloc_linux.cpp
+++ b/compiler-rt/lib/asan/asan_malloc_linux.cpp
@@ -31,35 +31,35 @@ using namespace __asan;
 
 struct DlsymAlloc : public DlSymAllocator<DlsymAlloc> {
   static bool UseImpl() { return !TryAsanInitFromRtl(); }
-  static void OnAllocate(const void *ptr, uptr size) {
+  static void OnAllocate(const void* ptr, uptr size) {
 #  if CAN_SANITIZE_LEAKS
     // Suppress leaks from dlerror(). Previously dlsym hack on global array was
     // used by leak sanitizer as a root region.
     __lsan_register_root_region(ptr, size);
 #  endif
   }
-  static void OnFree(const void *ptr, uptr size) {
+  static void OnFree(const void* ptr, uptr size) {
 #  if CAN_SANITIZE_LEAKS
     __lsan_unregister_root_region(ptr, size);
 #  endif
   }
 };
 
-INTERCEPTOR(void, free, void *ptr) {
+INTERCEPTOR(void, free, void* ptr) {
   if (DlsymAlloc::PointerIsMine(ptr))
     return DlsymAlloc::Free(ptr);
   GET_STACK_TRACE_FREE;
   asan_free(ptr, &stack);
 }
 
-#if SANITIZER_INTERCEPT_CFREE
-INTERCEPTOR(void, cfree, void *ptr) {
+#  if SANITIZER_INTERCEPT_CFREE
+INTERCEPTOR(void, cfree, void* ptr) {
   if (DlsymAlloc::PointerIsMine(ptr))
     return DlsymAlloc::Free(ptr);
   GET_STACK_TRACE_FREE;
   asan_free(ptr, &stack);
 }
-#endif // SANITIZER_INTERCEPT_CFREE
+#  endif  // SANITIZER_INTERCEPT_CFREE
 
 #  if SANITIZER_INTERCEPT_FREE_SIZED
 INTERCEPTOR(void, free_sized, void* ptr, uptr size) {
@@ -120,22 +120,22 @@ INTERCEPTOR(void*, calloc, uptr nmemb, uptr size) {
 // TODO: AIX needs a method to ensure 16-byte alignment if the incoming
 // pointer was allocated with a 16-byte alignment requirement (or perhaps
 // merely if it happens to have 16-byte alignment).
-INTERCEPTOR(void*, realloc, void *ptr, uptr size) {
+INTERCEPTOR(void*, realloc, void* ptr, uptr size) {
   if (DlsymAlloc::Use() || DlsymAlloc::PointerIsMine(ptr))
     return DlsymAlloc::Realloc(ptr, size);
   GET_STACK_TRACE_MALLOC;
   return asan_realloc(ptr, size, &stack);
 }
 
-#if SANITIZER_INTERCEPT_REALLOCARRAY
-INTERCEPTOR(void*, reallocarray, void *ptr, uptr nmemb, uptr size) {
+#  if SANITIZER_INTERCEPT_REALLOCARRAY
+INTERCEPTOR(void*, reallocarray, void* ptr, uptr nmemb, uptr size) {
   AsanInitFromRtl();
   GET_STACK_TRACE_MALLOC;
   return asan_reallocarray(ptr, nmemb, size, &stack);
 }
-#endif  // SANITIZER_INTERCEPT_REALLOCARRAY
+#  endif  // SANITIZER_INTERCEPT_REALLOCARRAY
 
-#if SANITIZER_INTERCEPT_MEMALIGN
+#  if SANITIZER_INTERCEPT_MEMALIGN
 INTERCEPTOR(void*, memalign, uptr boundary, uptr size) {
   GET_STACK_TRACE_MALLOC;
   return asan_memalign(boundary, size, &stack);
@@ -145,22 +145,22 @@ INTERCEPTOR(void*, __libc_memalign, uptr boundary, uptr size) {
   GET_STACK_TRACE_MALLOC;
   return asan_memalign(boundary, size, &stack);
 }
-#endif // SANITIZER_INTERCEPT_MEMALIGN
+#  endif  // SANITIZER_INTERCEPT_MEMALIGN
 
-#if SANITIZER_INTERCEPT_ALIGNED_ALLOC
+#  if SANITIZER_INTERCEPT_ALIGNED_ALLOC
 INTERCEPTOR(void*, aligned_alloc, uptr boundary, uptr size) {
   GET_STACK_TRACE_MALLOC;
   return asan_aligned_alloc(boundary, size, &stack);
 }
-#endif // SANITIZER_INTERCEPT_ALIGNED_ALLOC
+#  endif  // SANITIZER_INTERCEPT_ALIGNED_ALLOC
 
-INTERCEPTOR(uptr, malloc_usable_size, void *ptr) {
+INTERCEPTOR(uptr, malloc_usable_size, void* ptr) {
   GET_CURRENT_PC_BP_SP;
   (void)sp;
   return asan_malloc_usable_size(ptr, pc, bp);
 }
 
-#if SANITIZER_INTERCEPT_MALLOPT_AND_MALLINFO
+#  if SANITIZER_INTERCEPT_MALLOPT_AND_MALLINFO
 // We avoid including malloc.h for portability reasons.
 // man mallinfo says the fields are "long", but the implementation uses int.
 // It doesn't matter much -- we just need to make sure that the libc's mallinfo
@@ -175,12 +175,10 @@ INTERCEPTOR(struct fake_mallinfo, mallinfo, void) {
   return res;
 }
 
-INTERCEPTOR(int, mallopt, int cmd, int value) {
-  return 0;
-}
-#endif // SANITIZER_INTERCEPT_MALLOPT_AND_MALLINFO
+INTERCEPTOR(int, mallopt, int cmd, int value) { return 0; }
+#  endif  // SANITIZER_INTERCEPT_MALLOPT_AND_MALLINFO
 
-INTERCEPTOR(int, posix_memalign, void **memptr, uptr alignment, uptr size) {
+INTERCEPTOR(int, posix_memalign, void** memptr, uptr alignment, uptr size) {
   GET_STACK_TRACE_MALLOC;
   return asan_posix_memalign(memptr, alignment, size, &stack);
 }
@@ -190,40 +188,38 @@ INTERCEPTOR(void*, valloc, uptr size) {
   return asan_valloc(size, &stack);
 }
 
-#if SANITIZER_INTERCEPT_PVALLOC
+#  if SANITIZER_INTERCEPT_PVALLOC
 INTERCEPTOR(void*, pvalloc, uptr size) {
   GET_STACK_TRACE_MALLOC;
   return asan_pvalloc(size, &stack);
 }
-#endif // SANITIZER_INTERCEPT_PVALLOC
+#  endif  // SANITIZER_INTERCEPT_PVALLOC
 
-INTERCEPTOR(void, malloc_stats, void) {
-  __asan_print_accumulated_stats();
-}
+INTERCEPTOR(void, malloc_stats, void) { __asan_print_accumulated_stats(); }
 
-#if SANITIZER_ANDROID
+#  if SANITIZER_ANDROID
 // Format of __libc_malloc_dispatch has changed in Android L.
 // While we are moving towards a solution that does not depend on bionic
 // internals, here is something to support both K* and L releases.
 struct MallocDebugK {
-  void *(*malloc)(uptr bytes);
-  void (*free)(void *mem);
-  void *(*calloc)(uptr n_elements, uptr elem_size);
-  void *(*realloc)(void *oldMem, uptr bytes);
-  void *(*memalign)(uptr alignment, uptr bytes);
-  uptr (*malloc_usable_size)(void *mem);
+  void* (*malloc)(uptr bytes);
+  void (*free)(void* mem);
+  void* (*calloc)(uptr n_elements, uptr elem_size);
+  void* (*realloc)(void* oldMem, uptr bytes);
+  void* (*memalign)(uptr alignment, uptr bytes);
+  uptr (*malloc_usable_size)(void* mem);
 };
 
 struct MallocDebugL {
-  void *(*calloc)(uptr n_elements, uptr elem_size);
-  void (*free)(void *mem);
+  void* (*calloc)(uptr n_elements, uptr elem_size);
+  void (*free)(void* mem);
   fake_mallinfo (*mallinfo)(void);
-  void *(*malloc)(uptr bytes);
-  uptr (*malloc_usable_size)(void *mem);
-  void *(*memalign)(uptr alignment, uptr bytes);
-  int (*posix_memalign)(void **memptr, uptr alignment, uptr size);
+  void* (*malloc)(uptr bytes);
+  uptr (*malloc_usable_size)(void* mem);
+  void* (*memalign)(uptr alignment, uptr bytes);
+  int (*posix_memalign)(void** memptr, uptr alignment, uptr size);
   void* (*pvalloc)(uptr size);
-  void *(*realloc)(void *oldMem, uptr bytes);
+  void* (*realloc)(void* oldMem, uptr bytes);
   void* (*valloc)(uptr size);
 };
 
@@ -232,34 +228,39 @@ alignas(32) const MallocDebugK asan_malloc_dispatch_k = {
     WRAP(realloc), WRAP(memalign), WRAP(malloc_usable_size)};
 
 alignas(32) const MallocDebugL asan_malloc_dispatch_l = {
-    WRAP(calloc),         WRAP(free),               WRAP(mallinfo),
-    WRAP(malloc),         WRAP(malloc_usable_size), WRAP(memalign),
-    WRAP(posix_memalign), WRAP(pvalloc),            WRAP(realloc),
+    WRAP(calloc),
+    WRAP(free),
+    WRAP(mallinfo),
+    WRAP(malloc),
+    WRAP(malloc_usable_size),
+    WRAP(memalign),
+    WRAP(posix_memalign),
+    WRAP(pvalloc),
+    WRAP(realloc),
     WRAP(valloc)};
 
 namespace __asan {
 void ReplaceSystemMalloc() {
-  void **__libc_malloc_dispatch_p =
-      (void **)AsanDlSymNext("__libc_malloc_dispatch");
+  void** __libc_malloc_dispatch_p =
+      (void**)AsanDlSymNext("__libc_malloc_dispatch");
   if (__libc_malloc_dispatch_p) {
     // Decide on K vs L dispatch format by the presence of
     // __libc_malloc_default_dispatch export in libc.
-    void *default_dispatch_p = AsanDlSymNext("__libc_malloc_default_dispatch");
+    void* default_dispatch_p = AsanDlSymNext("__libc_malloc_default_dispatch");
     if (default_dispatch_p)
-      *__libc_malloc_dispatch_p = (void *)&asan_malloc_dispatch_k;
+      *__libc_malloc_dispatch_p = (void*)&asan_malloc_dispatch_k;
     else
-      *__libc_malloc_dispatch_p = (void *)&asan_malloc_dispatch_l;
+      *__libc_malloc_dispatch_p = (void*)&asan_malloc_dispatch_l;
   }
 }
 }  // namespace __asan
 
-#else  // SANITIZER_ANDROID
+#  else   // SANITIZER_ANDROID
 
 namespace __asan {
-void ReplaceSystemMalloc() {
-}
+void ReplaceSystemMalloc() {}
 }  // namespace __asan
-#endif  // SANITIZER_ANDROID
+#  endif  // SANITIZER_ANDROID
 
 #endif  // SANITIZER_FREEBSD || SANITIZER_FUCHSIA || SANITIZER_LINUX ||
         // SANITIZER_NETBSD || SANITIZER_SOLARIS || SANITIZER_HAIKU

--- a/compiler-rt/lib/asan/asan_malloc_mac.cpp
+++ b/compiler-rt/lib/asan/asan_malloc_mac.cpp
@@ -14,14 +14,14 @@
 #include "sanitizer_common/sanitizer_platform.h"
 #if SANITIZER_APPLE
 
-#include "asan_interceptors.h"
-#include "asan_report.h"
-#include "asan_stack.h"
-#include "asan_stats.h"
-#include "lsan/lsan_common.h"
+#  include "asan_interceptors.h"
+#  include "asan_report.h"
+#  include "asan_stack.h"
+#  include "asan_stats.h"
+#  include "lsan/lsan_common.h"
 
 using namespace __asan;
-#define COMMON_MALLOC_ZONE_NAME "asan"
+#  define COMMON_MALLOC_ZONE_NAME "asan"
 #  define COMMON_MALLOC_ENTER() \
     do {                        \
       AsanInitFromRtl();        \
@@ -31,22 +31,22 @@ using namespace __asan;
 #  define COMMON_MALLOC_FORCE_UNLOCK() asan_mz_force_unlock()
 #  define COMMON_MALLOC_MEMALIGN(alignment, size) \
     GET_STACK_TRACE_MALLOC;                       \
-    void *p = asan_memalign(alignment, size, &stack)
+    void* p = asan_memalign(alignment, size, &stack)
 #  define COMMON_MALLOC_MALLOC(size) \
     GET_STACK_TRACE_MALLOC;          \
-    void *p = asan_malloc(size, &stack)
+    void* p = asan_malloc(size, &stack)
 #  define COMMON_MALLOC_REALLOC(ptr, size) \
     GET_STACK_TRACE_MALLOC;                \
-    void *p = asan_realloc(ptr, size, &stack);
+    void* p = asan_realloc(ptr, size, &stack);
 #  define COMMON_MALLOC_CALLOC(count, size) \
     GET_STACK_TRACE_MALLOC;                 \
-    void *p = asan_calloc(count, size, &stack);
+    void* p = asan_calloc(count, size, &stack);
 #  define COMMON_MALLOC_POSIX_MEMALIGN(memptr, alignment, size) \
     GET_STACK_TRACE_MALLOC;                                     \
     int res = asan_posix_memalign(memptr, alignment, size, &stack);
 #  define COMMON_MALLOC_VALLOC(size) \
     GET_STACK_TRACE_MALLOC;          \
-    void *p = asan_memalign(GetPageSizeCached(), size, &stack);
+    void* p = asan_memalign(GetPageSizeCached(), size, &stack);
 #  define COMMON_MALLOC_FREE(ptr) \
     GET_STACK_TRACE_FREE;         \
     asan_free(ptr, &stack);
@@ -89,7 +89,7 @@ bool HandleDlopenInit() {
 
 namespace {
 
-void mi_extra_init(sanitizer_malloc_introspection_t *mi) {
+void mi_extra_init(sanitizer_malloc_introspection_t* mi) {
   uptr last_byte_plus_one = 0;
   mi->allocator_ptr = 0;
   // Range is [begin_ptr, end_ptr)

--- a/compiler-rt/lib/asan/asan_new_delete.cpp
+++ b/compiler-rt/lib/asan/asan_new_delete.cpp
@@ -24,26 +24,26 @@
 // dllexport would normally do. We need to export them in order to make the
 // VS2015 dynamic CRT (MD) work.
 #if SANITIZER_WINDOWS && defined(_MSC_VER)
-#define CXX_OPERATOR_ATTRIBUTE
-#define COMMENT_EXPORT(sym) __pragma(comment(linker, "/export:" sym))
-#ifdef _WIN64
+#  define CXX_OPERATOR_ATTRIBUTE
+#  define COMMENT_EXPORT(sym) __pragma(comment(linker, "/export:" sym))
+#  ifdef _WIN64
 COMMENT_EXPORT("??2@YAPEAX_K@Z")                     // operator new
 COMMENT_EXPORT("??2@YAPEAX_KAEBUnothrow_t@std@@@Z")  // operator new nothrow
 COMMENT_EXPORT("??3@YAXPEAX@Z")                      // operator delete
 COMMENT_EXPORT("??3@YAXPEAX_K@Z")                    // sized operator delete
 COMMENT_EXPORT("??_U@YAPEAX_K@Z")                    // operator new[]
 COMMENT_EXPORT("??_V@YAXPEAX@Z")                     // operator delete[]
-#else
+#  else
 COMMENT_EXPORT("??2@YAPAXI@Z")                    // operator new
 COMMENT_EXPORT("??2@YAPAXIABUnothrow_t@std@@@Z")  // operator new nothrow
 COMMENT_EXPORT("??3@YAXPAX@Z")                    // operator delete
 COMMENT_EXPORT("??3@YAXPAXI@Z")                   // sized operator delete
 COMMENT_EXPORT("??_U@YAPAXI@Z")                   // operator new[]
 COMMENT_EXPORT("??_V@YAXPAX@Z")                   // operator delete[]
-#endif
-#undef COMMENT_EXPORT
+#  endif
+#  undef COMMENT_EXPORT
 #else
-#define CXX_OPERATOR_ATTRIBUTE INTERCEPTOR_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE
+#  define CXX_OPERATOR_ATTRIBUTE INTERCEPTOR_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE
 #endif
 
 using namespace __asan;
@@ -54,7 +54,7 @@ using namespace __asan;
 // Fake std::nothrow_t and std::align_val_t to avoid including <new>.
 namespace std {
 struct nothrow_t {};
-enum class align_val_t: size_t {};
+enum class align_val_t : size_t {};
 }  // namespace std
 
 // TODO(alekseyshl): throw std::bad_alloc instead of dying on OOM.
@@ -62,7 +62,7 @@ enum class align_val_t: size_t {};
 // allocator behavior.
 #define OPERATOR_NEW_BODY             \
   GET_STACK_TRACE_MALLOC;             \
-  void *res = asan_new(size, &stack); \
+  void* res = asan_new(size, &stack); \
   if (UNLIKELY(!res))                 \
     ReportOutOfMemory(size, &stack);  \
   return res
@@ -71,7 +71,7 @@ enum class align_val_t: size_t {};
   return asan_new(size, &stack)
 #define OPERATOR_NEW_BODY_ARRAY             \
   GET_STACK_TRACE_MALLOC;                   \
-  void *res = asan_new_array(size, &stack); \
+  void* res = asan_new_array(size, &stack); \
   if (UNLIKELY(!res))                       \
     ReportOutOfMemory(size, &stack);        \
   return res
@@ -80,7 +80,7 @@ enum class align_val_t: size_t {};
   return asan_new_array(size, &stack)
 #define OPERATOR_NEW_BODY_ALIGN                                         \
   GET_STACK_TRACE_MALLOC;                                               \
-  void *res = asan_new_aligned(size, static_cast<uptr>(align), &stack); \
+  void* res = asan_new_aligned(size, static_cast<uptr>(align), &stack); \
   if (UNLIKELY(!res))                                                   \
     ReportOutOfMemory(size, &stack);                                    \
   return res
@@ -89,7 +89,7 @@ enum class align_val_t: size_t {};
   return asan_new_aligned(size, static_cast<uptr>(align), &stack)
 #define OPERATOR_NEW_BODY_ALIGN_ARRAY                                         \
   GET_STACK_TRACE_MALLOC;                                                     \
-  void *res = asan_new_array_aligned(size, static_cast<uptr>(align), &stack); \
+  void* res = asan_new_array_aligned(size, static_cast<uptr>(align), &stack); \
   if (UNLIKELY(!res))                                                         \
     ReportOutOfMemory(size, &stack);                                          \
   return res
@@ -106,43 +106,42 @@ enum class align_val_t: size_t {};
 // OS X we need to intercept them using their mangled names.
 #if !SANITIZER_APPLE
 CXX_OPERATOR_ATTRIBUTE
-void *operator new(size_t size) { OPERATOR_NEW_BODY; }
+void* operator new(size_t size) { OPERATOR_NEW_BODY; }
 CXX_OPERATOR_ATTRIBUTE
-void *operator new[](size_t size) { OPERATOR_NEW_BODY_ARRAY; }
+void* operator new[](size_t size) { OPERATOR_NEW_BODY_ARRAY; }
 CXX_OPERATOR_ATTRIBUTE
-void *operator new(size_t size, std::nothrow_t const &) {
+void* operator new(size_t size, std::nothrow_t const&) {
   OPERATOR_NEW_BODY_NOTHROW;
 }
 CXX_OPERATOR_ATTRIBUTE
-void *operator new[](size_t size, std::nothrow_t const &) {
+void* operator new[](size_t size, std::nothrow_t const&) {
   OPERATOR_NEW_BODY_ARRAY_NOTHROW;
 }
 CXX_OPERATOR_ATTRIBUTE
-void *operator new(size_t size, std::align_val_t align) {
+void* operator new(size_t size, std::align_val_t align) {
   OPERATOR_NEW_BODY_ALIGN;
 }
 CXX_OPERATOR_ATTRIBUTE
-void *operator new[](size_t size, std::align_val_t align) {
+void* operator new[](size_t size, std::align_val_t align) {
   OPERATOR_NEW_BODY_ALIGN_ARRAY;
 }
 CXX_OPERATOR_ATTRIBUTE
-void *operator new(size_t size, std::align_val_t align,
-                   std::nothrow_t const &) {
+void* operator new(size_t size, std::align_val_t align, std::nothrow_t const&) {
   OPERATOR_NEW_BODY_ALIGN_NOTHROW;
 }
 CXX_OPERATOR_ATTRIBUTE
-void *operator new[](size_t size, std::align_val_t align,
-                     std::nothrow_t const &) {
+void* operator new[](size_t size, std::align_val_t align,
+                     std::nothrow_t const&) {
   OPERATOR_NEW_BODY_ALIGN_ARRAY_NOTHROW;
 }
 
 #else  // SANITIZER_APPLE
-INTERCEPTOR(void *, _Znwm, size_t size) { OPERATOR_NEW_BODY; }
-INTERCEPTOR(void *, _Znam, size_t size) { OPERATOR_NEW_BODY_ARRAY; }
-INTERCEPTOR(void *, _ZnwmRKSt9nothrow_t, size_t size, std::nothrow_t const&) {
+INTERCEPTOR(void*, _Znwm, size_t size) { OPERATOR_NEW_BODY; }
+INTERCEPTOR(void*, _Znam, size_t size) { OPERATOR_NEW_BODY_ARRAY; }
+INTERCEPTOR(void*, _ZnwmRKSt9nothrow_t, size_t size, std::nothrow_t const&) {
   OPERATOR_NEW_BODY_NOTHROW;
 }
-INTERCEPTOR(void *, _ZnamRKSt9nothrow_t, size_t size, std::nothrow_t const&) {
+INTERCEPTOR(void*, _ZnamRKSt9nothrow_t, size_t size, std::nothrow_t const&) {
   OPERATOR_NEW_BODY_ARRAY_NOTHROW;
 }
 #endif  // !SANITIZER_APPLE
@@ -174,60 +173,57 @@ INTERCEPTOR(void *, _ZnamRKSt9nothrow_t, size_t size, std::nothrow_t const&) {
 
 #if !SANITIZER_APPLE
 CXX_OPERATOR_ATTRIBUTE
-void operator delete(void *ptr) NOEXCEPT { OPERATOR_DELETE_BODY; }
+void operator delete(void* ptr) NOEXCEPT { OPERATOR_DELETE_BODY; }
 CXX_OPERATOR_ATTRIBUTE
-void operator delete[](void *ptr) NOEXCEPT { OPERATOR_DELETE_BODY_ARRAY; }
+void operator delete[](void* ptr) NOEXCEPT { OPERATOR_DELETE_BODY_ARRAY; }
 CXX_OPERATOR_ATTRIBUTE
-void operator delete(void *ptr, std::nothrow_t const &) {
-  OPERATOR_DELETE_BODY;
-}
+void operator delete(void* ptr, std::nothrow_t const&) { OPERATOR_DELETE_BODY; }
 CXX_OPERATOR_ATTRIBUTE
-void operator delete[](void *ptr, std::nothrow_t const &) {
+void operator delete[](void* ptr, std::nothrow_t const&) {
   OPERATOR_DELETE_BODY_ARRAY;
 }
 CXX_OPERATOR_ATTRIBUTE
-void operator delete(void *ptr, size_t size) NOEXCEPT {
+void operator delete(void* ptr, size_t size) NOEXCEPT {
   OPERATOR_DELETE_BODY_SIZE;
 }
 CXX_OPERATOR_ATTRIBUTE
-void operator delete[](void *ptr, size_t size) NOEXCEPT {
+void operator delete[](void* ptr, size_t size) NOEXCEPT {
   OPERATOR_DELETE_BODY_SIZE_ARRAY;
 }
 CXX_OPERATOR_ATTRIBUTE
-void operator delete(void *ptr, std::align_val_t align) NOEXCEPT {
+void operator delete(void* ptr, std::align_val_t align) NOEXCEPT {
   OPERATOR_DELETE_BODY_ALIGN;
 }
 CXX_OPERATOR_ATTRIBUTE
-void operator delete[](void *ptr, std::align_val_t align) NOEXCEPT {
+void operator delete[](void* ptr, std::align_val_t align) NOEXCEPT {
   OPERATOR_DELETE_BODY_ALIGN_ARRAY;
 }
 CXX_OPERATOR_ATTRIBUTE
-void operator delete(void *ptr, std::align_val_t align,
-                     std::nothrow_t const &) {
+void operator delete(void* ptr, std::align_val_t align, std::nothrow_t const&) {
   OPERATOR_DELETE_BODY_ALIGN;
 }
 CXX_OPERATOR_ATTRIBUTE
-void operator delete[](void *ptr, std::align_val_t align,
-                       std::nothrow_t const &) {
+void operator delete[](void* ptr, std::align_val_t align,
+                       std::nothrow_t const&) {
   OPERATOR_DELETE_BODY_ALIGN_ARRAY;
 }
 CXX_OPERATOR_ATTRIBUTE
-void operator delete(void *ptr, size_t size, std::align_val_t align) NOEXCEPT {
+void operator delete(void* ptr, size_t size, std::align_val_t align) NOEXCEPT {
   OPERATOR_DELETE_BODY_SIZE_ALIGN;
 }
 CXX_OPERATOR_ATTRIBUTE
-void operator delete[](void *ptr, size_t size,
+void operator delete[](void* ptr, size_t size,
                        std::align_val_t align) NOEXCEPT {
   OPERATOR_DELETE_BODY_SIZE_ALIGN_ARRAY;
 }
 
-#else  // SANITIZER_APPLE
-INTERCEPTOR(void, _ZdlPv, void *ptr) { OPERATOR_DELETE_BODY; }
-INTERCEPTOR(void, _ZdaPv, void *ptr) { OPERATOR_DELETE_BODY_ARRAY; }
-INTERCEPTOR(void, _ZdlPvRKSt9nothrow_t, void *ptr, std::nothrow_t const &) {
+#else   // SANITIZER_APPLE
+INTERCEPTOR(void, _ZdlPv, void* ptr) { OPERATOR_DELETE_BODY; }
+INTERCEPTOR(void, _ZdaPv, void* ptr) { OPERATOR_DELETE_BODY_ARRAY; }
+INTERCEPTOR(void, _ZdlPvRKSt9nothrow_t, void* ptr, std::nothrow_t const&) {
   OPERATOR_DELETE_BODY;
 }
-INTERCEPTOR(void, _ZdaPvRKSt9nothrow_t, void *ptr, std::nothrow_t const &) {
+INTERCEPTOR(void, _ZdaPvRKSt9nothrow_t, void* ptr, std::nothrow_t const&) {
   OPERATOR_DELETE_BODY_ARRAY;
 }
 #endif  // !SANITIZER_APPLE

--- a/compiler-rt/lib/asan/tests/asan_noinst_test.cpp
+++ b/compiler-rt/lib/asan/tests/asan_noinst_test.cpp
@@ -35,18 +35,14 @@ using namespace __sanitizer;
 
 // Make sure __asan_init is called before any test case is run.
 struct AsanInitCaller {
-  AsanInitCaller() {
-    __asan_init();
-  }
+  AsanInitCaller() { __asan_init(); }
 };
 static AsanInitCaller asan_init_caller;
 
-TEST(AddressSanitizer, InternalSimpleDeathTest) {
-  EXPECT_DEATH(exit(1), "");
-}
+TEST(AddressSanitizer, InternalSimpleDeathTest) { EXPECT_DEATH(exit(1), ""); }
 
-static void *MallocStress(void *NumOfItrPtr) {
-  size_t n = *((size_t *)NumOfItrPtr);
+static void* MallocStress(void* NumOfItrPtr) {
+  size_t n = *((size_t*)NumOfItrPtr);
   u32 seed = my_rand();
   BufferedStackTrace stack1;
   stack1.trace_buffer[0] = 0xa123;
@@ -63,29 +59,36 @@ static void *MallocStress(void *NumOfItrPtr) {
   stack3.trace_buffer[1] = 0xc456;
   stack3.size = 2;
 
-  std::vector<void *> vec;
+  std::vector<void*> vec;
   for (size_t i = 0; i < n; i++) {
     if ((i % 3) == 0) {
-      if (vec.empty()) continue;
+      if (vec.empty())
+        continue;
       size_t idx = my_rand_r(&seed) % vec.size();
-      void *ptr = vec[idx];
+      void* ptr = vec[idx];
       vec[idx] = vec.back();
       vec.pop_back();
       __asan::asan_free(ptr, &stack1);
     } else {
       size_t size = my_rand_r(&seed) % 1000 + 1;
       switch ((my_rand_r(&seed) % 128)) {
-        case 0: size += 1024; break;
-        case 1: size += 2048; break;
-        case 2: size += 4096; break;
+        case 0:
+          size += 1024;
+          break;
+        case 1:
+          size += 2048;
+          break;
+        case 2:
+          size += 4096;
+          break;
       }
       size_t alignment = 1 << (my_rand_r(&seed) % 10 + 1);
-      char *ptr = (char *)__asan::asan_memalign(alignment, size, &stack2);
+      char* ptr = (char*)__asan::asan_memalign(alignment, size, &stack2);
       EXPECT_EQ(size, __asan::asan_malloc_usable_size(ptr, 0, 0));
       vec.push_back(ptr);
       ptr[0] = 0;
-      ptr[size-1] = 0;
-      ptr[size/2] = 0;
+      ptr[size - 1] = 0;
+      ptr[size / 2] = 0;
     }
   }
   for (size_t i = 0; i < vec.size(); i++) __asan::asan_free(vec[i], &stack3);
@@ -94,7 +97,7 @@ static void *MallocStress(void *NumOfItrPtr) {
 
 TEST(AddressSanitizer, NoInstMallocTest) {
   const size_t kNumIterations = (ASAN_LOW_MEMORY) ? 300000 : 1000000;
-  MallocStress((void *)&kNumIterations);
+  MallocStress((void*)&kNumIterations);
 }
 
 TEST(AddressSanitizer, ThreadedMallocStressTest) {
@@ -102,15 +105,15 @@ TEST(AddressSanitizer, ThreadedMallocStressTest) {
   const size_t kNumIterations = (ASAN_LOW_MEMORY) ? 10000 : 100000;
   pthread_t t[kNumThreads];
   for (int i = 0; i < kNumThreads; i++) {
-    PTHREAD_CREATE(&t[i], 0, (void *(*)(void *x))MallocStress,
-                   (void *)&kNumIterations);
+    PTHREAD_CREATE(&t[i], 0, (void* (*)(void* x))MallocStress,
+                   (void*)&kNumIterations);
   }
   for (int i = 0; i < kNumThreads; i++) {
     PTHREAD_JOIN(t[i], 0);
   }
 }
 
-static void PrintShadow(const char *tag, uptr ptr, size_t size) {
+static void PrintShadow(const char* tag, uptr ptr, size_t size) {
   fprintf(stderr, "%s shadow: %lx size % 3ld: ", tag, (long)ptr, (long)size);
   uptr prev_shadow = 0;
   for (sptr i = -32; i < (sptr)size + 32; i++) {
@@ -127,9 +130,9 @@ static void PrintShadow(const char *tag, uptr ptr, size_t size) {
 
 TEST(AddressSanitizer, DISABLED_InternalPrintShadow) {
   for (size_t size = 1; size <= 513; size++) {
-    char *ptr = new char[size];
+    char* ptr = new char[size];
     PrintShadow("m", (uptr)ptr, size);
-    delete [] ptr;
+    delete[] ptr;
     PrintShadow("f", (uptr)ptr, size);
   }
 }
@@ -140,21 +143,22 @@ TEST(AddressSanitizer, QuarantineTest) {
   stack.size = 1;
 
   const int size = 1024;
-  void *p = __asan::asan_malloc(size, &stack);
+  void* p = __asan::asan_malloc(size, &stack);
   __asan::asan_free(p, &stack);
   size_t i;
   size_t max_i = 1 << 30;
   for (i = 0; i < max_i; i++) {
-    void *p1 = __asan::asan_malloc(size, &stack);
+    void* p1 = __asan::asan_malloc(size, &stack);
     __asan::asan_free(p1, &stack);
-    if (p1 == p) break;
+    if (p1 == p)
+      break;
   }
   EXPECT_GE(i, 10000U);
   EXPECT_LT(i, max_i);
 }
 
 #if !defined(__NetBSD__)
-void *ThreadedQuarantineTestWorker(void *unused) {
+void* ThreadedQuarantineTestWorker(void* unused) {
   (void)unused;
   u32 seed = my_rand();
   UNINITIALIZED BufferedStackTrace stack;
@@ -162,7 +166,7 @@ void *ThreadedQuarantineTestWorker(void *unused) {
   stack.size = 1;
 
   for (size_t i = 0; i < 1000; i++) {
-    void *p = __asan::asan_malloc(1 + (my_rand_r(&seed) % 4000), &stack);
+    void* p = __asan::asan_malloc(1 + (my_rand_r(&seed) % 4000), &stack);
     __asan::asan_free(p, &stack);
   }
   return NULL;
@@ -190,14 +194,14 @@ TEST(AddressSanitizer, ThreadedQuarantineTest) {
 }
 #endif
 
-void *ThreadedOneSizeMallocStress(void *unused) {
+void* ThreadedOneSizeMallocStress(void* unused) {
   (void)unused;
   UNINITIALIZED BufferedStackTrace stack;
   stack.trace_buffer[0] = 0x890;
   stack.size = 1;
   const size_t kNumMallocs = 1000;
   for (int iter = 0; iter < 1000; iter++) {
-    void *p[kNumMallocs];
+    void* p[kNumMallocs];
     for (size_t i = 0; i < kNumMallocs; i++) {
       p[i] = __asan::asan_malloc(32, &stack);
     }
@@ -278,7 +282,7 @@ static void TestLoadStoreCallbacks(CB cb[2][5]) {
   stack.size = 1;
 
   for (uptr len = 16; len <= 32; len++) {
-    char *ptr = (char*) __asan::asan_malloc(len, &stack);
+    char* ptr = (char*)__asan::asan_malloc(len, &stack);
     uptr p = reinterpret_cast<uptr>(ptr);
     for (uptr is_write = 0; is_write <= 1; is_write++) {
       for (uptr size_log = 0; size_log <= 4; size_log++) {


### PR DESCRIPTION
Depends on #200615
Groundwork for #196413.

Mechanical cleanup of allocator related files in preparation of
functional changes. clang-format (v21.1.2) applied whole-file to:

  compiler-rt/lib/asan/asan_allocator.cpp
  compiler-rt/lib/asan/asan_allocator.h
  compiler-rt/lib/asan/asan_malloc_linux.cpp
  compiler-rt/lib/asan/asan_malloc_mac.cpp
  compiler-rt/lib/asan/asan_new_delete.cpp
  compiler-rt/lib/asan/tests/asan_noinst_test.cpp

Both compiler-rt/lib/asan/.clang-format and
compiler-rt/lib/sanitizer_common/.clang-format use
"BasedOnStyle: Google", so pointer alignment becomes "Type* name"
throughout.

NFC.

Assisted by: Claude Opus 4.7
