### PR TITLE
[IR][NFC] Expose structural hash details

### DIFF
--- a/llvm/include/llvm/IR/StructuralHash.h
+++ b/llvm/include/llvm/IR/StructuralHash.h
@@ -15,6 +15,7 @@
 #define LLVM_IR_STRUCTURALHASH_H
 
 #include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StableHashing.h"
 #include "llvm/IR/Instruction.h"
 #include "llvm/Support/Compiler.h"
@@ -22,8 +23,19 @@
 
 namespace llvm {
 
+class BasicBlock;
 class Function;
 class Module;
+
+struct BasicBlockStructuralHashInfo {
+  const BasicBlock *BB = nullptr;
+  stable_hash BlockHash = 0;
+};
+
+struct FunctionStructuralHashInfo {
+  stable_hash FunctionHash = 0;
+  SmallVector<BasicBlockStructuralHashInfo, 0> Blocks;
+};
 
 /// Returns a hash of the function \p F.
 /// \param F The function to hash.
@@ -32,6 +44,11 @@ class Module;
 /// to true includes instruction and operand type information.
 LLVM_ABI stable_hash StructuralHash(const Function &F,
                                     bool DetailedHash = false);
+
+/// Returns structural hash details for \p F, including the function hash and
+/// block hashes computed while building it.
+LLVM_ABI FunctionStructuralHashInfo
+StructuralHashWithDetails(const Function &F, bool DetailedHash = false);
 
 /// Returns a hash of the global variable \p G.
 LLVM_ABI stable_hash StructuralHash(const GlobalVariable &G);

--- a/llvm/lib/IR/StructuralHash.cpp
+++ b/llvm/lib/IR/StructuralHash.cpp
@@ -26,6 +26,7 @@ class StructuralHashImpl {
   stable_hash Hash = 4;
 
   bool DetailedHash;
+  bool CollectDetails;
 
   // This random value acts as a block header, as otherwise the partition of
   // opcodes into BBs wouldn't affect the hash, only the order of the opcodes.
@@ -42,6 +43,7 @@ class StructuralHashImpl {
   /// A mapping from pairs of instruction indices and operand indices
   /// to the hashes of the operands.
   std::unique_ptr<IndexOperandHashMapType> IndexOperandHashMap = nullptr;
+  FunctionStructuralHashInfo Details;
 
   /// Assign a unique ID to each Value in the order they are first seen.
   DenseMap<const Value *, int> ValueToId;
@@ -57,8 +59,10 @@ class StructuralHashImpl {
 public:
   StructuralHashImpl() = delete;
   explicit StructuralHashImpl(bool DetailedHash,
-                              IgnoreOperandFunc IgnoreOp = nullptr)
-      : DetailedHash(DetailedHash), IgnoreOp(IgnoreOp) {
+                              IgnoreOperandFunc IgnoreOp = nullptr,
+                              bool CollectDetails = false)
+      : DetailedHash(DetailedHash), CollectDetails(CollectDetails),
+        IgnoreOp(IgnoreOp) {
     if (IgnoreOp) {
       IndexInstruction = std::make_unique<IndexInstrMap>();
       IndexOperandHashMap = std::make_unique<IndexOperandHashMapType>();
@@ -257,8 +261,11 @@ public:
   // selectively.
   void update(const Function &F) {
     // Declarations don't affect analyses.
-    if (F.isDeclaration())
+    if (F.isDeclaration()) {
+      if (CollectDetails)
+        Details.FunctionHash = Hash;
       return;
+    }
 
     SmallVector<stable_hash> Hashes;
     Hashes.emplace_back(Hash);
@@ -279,8 +286,18 @@ public:
       const BasicBlock *BB = BBs.pop_back_val();
 
       Hashes.emplace_back(BlockHeaderHash);
-      for (auto &Inst : *BB)
-        Hashes.emplace_back(hashInstruction(Inst));
+      SmallVector<stable_hash> BlockHashes;
+      if (CollectDetails)
+        BlockHashes.emplace_back(BlockHeaderHash);
+
+      for (auto &Inst : *BB) {
+        stable_hash InstHash = hashInstruction(Inst);
+        Hashes.emplace_back(InstHash);
+        if (CollectDetails)
+          BlockHashes.emplace_back(InstHash);
+      }
+      if (CollectDetails)
+        Details.Blocks.push_back({BB, stable_hash_combine(BlockHashes)});
 
       for (const BasicBlock *Succ : successors(BB))
         if (VisitedBBs.insert(Succ).second)
@@ -289,6 +306,8 @@ public:
 
     // Update the combined hash in place.
     Hash = stable_hash_combine(Hashes);
+    if (CollectDetails)
+      Details.FunctionHash = Hash;
   }
 
   void update(const GlobalVariable &GV) {
@@ -315,6 +334,8 @@ public:
 
   uint64_t getHash() const { return Hash; }
 
+  FunctionStructuralHashInfo getDetails() { return std::move(Details); }
+
   std::unique_ptr<IndexInstrMap> getIndexInstrMap() {
     return std::move(IndexInstruction);
   }
@@ -330,6 +351,14 @@ stable_hash llvm::StructuralHash(const Function &F, bool DetailedHash) {
   StructuralHashImpl H(DetailedHash);
   H.update(F);
   return H.getHash();
+}
+
+FunctionStructuralHashInfo llvm::StructuralHashWithDetails(const Function &F,
+                                                           bool DetailedHash) {
+  StructuralHashImpl H(DetailedHash, /*IgnoreOp=*/nullptr,
+                       /*CollectDetails=*/true);
+  H.update(F);
+  return H.getDetails();
 }
 
 stable_hash llvm::StructuralHash(const GlobalVariable &GVar) {

--- a/llvm/unittests/IR/StructuralHashTest.cpp
+++ b/llvm/unittests/IR/StructuralHashTest.cpp
@@ -70,6 +70,33 @@ TEST(StructuralHashTest, BasicFunction) {
             StructuralHash(*M->getFunction("h")));
 }
 
+TEST(StructuralHashTest, FunctionHashDetails) {
+  LLVMContext Ctx;
+  std::unique_ptr<Module> M = parseIR(Ctx, "define i32 @f(i32 %x) {\n"
+                                           "entry:\n"
+                                           "  %a = add i32 %x, 1\n"
+                                           "  ret i32 %a\n"
+                                           "}\n");
+  Function &F = *M->getFunction("f");
+
+  FunctionStructuralHashInfo Info =
+      StructuralHashWithDetails(F, /*DetailedHash=*/true);
+  EXPECT_EQ(StructuralHash(F, /*DetailedHash=*/true), Info.FunctionHash);
+  ASSERT_THAT(Info.Blocks, SizeIs(1));
+  EXPECT_EQ(&F.getEntryBlock(), Info.Blocks[0].BB);
+  EXPECT_NE(0u, Info.Blocks[0].BlockHash);
+}
+
+TEST(StructuralHashTest, FunctionHashDetailsForDeclaration) {
+  LLVMContext Ctx;
+  std::unique_ptr<Module> M = parseIR(Ctx, "declare void @f()\n");
+  Function &F = *M->getFunction("f");
+
+  FunctionStructuralHashInfo Info = StructuralHashWithDetails(F);
+  EXPECT_EQ(StructuralHash(F), Info.FunctionHash);
+  EXPECT_THAT(Info.Blocks, SizeIs(0));
+}
+
 TEST(StructuralHashTest, Declaration) {
   LLVMContext Ctx;
   std::unique_ptr<Module> M0 = parseIR(Ctx, "");


### PR DESCRIPTION
StructuralHash already computes block and function hashes while walking a function. Expose those pieces so other users can reuse the same change-detection logic instead of rebuilding a parallel hash walk.

This is NFC for existing users. The existing StructuralHash entry points keep returning the same hashes.

This is intended for tools such as `-print-changed`, which need the function hash for a quick skip check and block hashes to decide which blocks changed.