### PR TITLE
[alpha.webkit.NoDeleteChecker] Returning or passing an argument with copy elision should be considered no-delete.

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -892,7 +892,7 @@ public:
     return true;
   }
 
-  bool VisitIgnoringTempGivenToRValue(const Expr* Arg) {
+  bool VisitIgnoringTempGivenToRValue(const Expr *Arg) {
     Arg = Arg->IgnoreParenCasts();
     if (!Arg->isPRValue())
       return Visit(Arg);

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -705,21 +705,8 @@ public:
   }
 
   bool VisitReturnStmt(const ReturnStmt *RS) {
-    // A return statement is allowed as long as the return value is trivial.
-    if (auto *RV = RS->getRetValue()) {
-      if (auto *ExprWithClean = dyn_cast<ExprWithCleanups>(RV)) {
-        if (ExprWithClean->isPRValue())
-          RV = ExprWithClean->getSubExpr();
-      }
-      if (auto *SubE = RV->IgnoreParenCasts()) {
-        if (auto *BTE = dyn_cast<CXXBindTemporaryExpr>(SubE)) {
-          // Ignore the destructor of BTE if copy elision is in effect.
-          if (RV->getType() == BTE->getType())
-            return Visit(BTE->getSubExpr());
-        }
-      }
-      return Visit(RV);
-    }
+    if (auto *RV = RS->getRetValue())
+      return VisitIgnoringTempGivenToRValue(RV);
     return true;
   }
 
@@ -899,15 +886,28 @@ public:
 
   bool checkArguments(const CallExpr *CE) {
     for (const Expr *Arg : CE->arguments()) {
-      if (Arg && !Visit(Arg))
+      if (Arg && !VisitIgnoringTempGivenToRValue(Arg))
         return false;
     }
     return true;
   }
 
+  bool VisitIgnoringTempGivenToRValue(const Expr* Arg) {
+    Arg = Arg->IgnoreParenCasts();
+    if (!Arg->isPRValue())
+      return Visit(Arg);
+    if (auto *ExprWithClean = dyn_cast<ExprWithCleanups>(Arg))
+      Arg = ExprWithClean->getSubExpr()->IgnoreParenCasts();
+    if (auto *BTE = dyn_cast<CXXBindTemporaryExpr>(Arg)) {
+      if (Arg->getType() == BTE->getType())
+        return Visit(BTE->getSubExpr());
+    }
+    return Visit(Arg);
+  }
+
   bool VisitCXXConstructExpr(const CXXConstructExpr *CE) {
     for (const Expr *Arg : CE->arguments()) {
-      if (Arg && !Visit(Arg))
+      if (Arg && !VisitIgnoringTempGivenToRValue(Arg))
         return false;
     }
 

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -706,8 +706,20 @@ public:
 
   bool VisitReturnStmt(const ReturnStmt *RS) {
     // A return statement is allowed as long as the return value is trivial.
-    if (auto *RV = RS->getRetValue())
+    if (auto *RV = RS->getRetValue()) {
+      if (auto *ExprWithClean = dyn_cast<ExprWithCleanups>(RV)) {
+        if (ExprWithClean->isPRValue())
+          RV = ExprWithClean->getSubExpr();
+      }
+      if (auto *SubE = RV->IgnoreParenCasts()) {
+        if (auto *BTE = dyn_cast<CXXBindTemporaryExpr>(SubE)) {
+          // Ignore the destructor of BTE if copy elision is in effect.
+          if (RV->getType() == BTE->getType())
+            return Visit(BTE->getSubExpr());
+        }
+      }
       return Visit(RV);
+    }
     return true;
   }
 

--- a/clang/test/Analysis/Checkers/WebKit/call-args.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args.cpp
@@ -557,4 +557,21 @@ namespace call_with_weak_ptr {
     weakPtr->method();
     // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
   }
+
+  struct Provider {
+    RefCountableWithWeakPtr* provide();
+  };
+  int intValue();
+
+  struct Container {
+    Container(Provider& provider)
+      : m_weakPtr(provider.provide())
+      , m_value(intValue())
+    { }
+
+  private:
+    WeakPtr<RefCountableWithWeakPtr> m_weakPtr;
+    int m_value;
+  };
+
 }

--- a/clang/test/Analysis/Checkers/WebKit/mock-types.h
+++ b/clang/test/Analysis/Checkers/WebKit/mock-types.h
@@ -202,6 +202,7 @@ template <typename T> struct RefPtr {
     t = o.t;
     o.t = tmp;
   }
+  operator T*() { return t; }
   T *get() const { return t; }
   T *operator->() const { return t; }
   T &operator*() const { return *t; }

--- a/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
@@ -316,8 +316,17 @@ public:
 };
 
 struct Data {
-  static Ref<Data> create() {
+  static Ref<Data> [[clang::annotate_type("webkit.nodelete")]] create() {
     return adoptRef(*new Data);
+  }
+
+  static Ref<Data> [[clang::annotate_type("webkit.nodelete")]] create(double) {
+    return adoptRef(*new Data(RefCountable::create()->next()));
+    // expected-warning@-1{{A function 'create' has [[clang::annotate_type("webkit.nodelete")]] but it contains code that could destruct an object}}
+  }
+
+  static Data* [[clang::annotate_type("webkit.nodelete")]] create(int) {
+    return adoptRef(new Data); // expected-warning{{A function 'create' has [[clang::annotate_type("webkit.nodelete")]] but it contains code that could destruct an object}}
   }
 
   void ref() {
@@ -338,6 +347,7 @@ struct Data {
   
 protected:
   Data() = default;
+  Data(RefCountable*) { }
 
 private:
   unsigned refCount { 0 };

--- a/clang/test/Analysis/Checkers/WebKit/nodelete-lazy-initialize.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/nodelete-lazy-initialize.cpp
@@ -1,0 +1,36 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.NoDeleteChecker -verify %s
+
+#include "mock-types.h"
+
+void crash();
+
+template<typename T, typename U>
+[[clang::suppress]] inline void [[clang::annotate_type("webkit.nodelete")]] lazyInitialize(const RefPtr<T>& ptr, Ref<U>&& obj)
+{
+    if (ptr)
+        crash();
+    const_cast<RefPtr<T>&>(ptr) = WTF::move(obj);
+}
+
+struct RefObj {
+  static Ref<RefObj> [[clang::annotate_type("webkit.nodelete")]] create(int = 0);
+  void ref() const;
+  void deref() const;
+  int value() const;
+};
+
+struct Container {
+
+  void [[clang::annotate_type("webkit.nodelete")]] foo() {
+    if (!m_bar)
+      lazyInitialize(m_bar, RefObj::create());
+  }
+
+  void [[clang::annotate_type("webkit.nodelete")]] bar() {
+    if (!m_bar)
+      lazyInitialize(m_bar, RefObj::create(RefObj::create()->value()));
+      // expected-warning@-1{{A function 'bar' has [[clang::annotate_type("webkit.nodelete")]] but it contains code that could destruct an object}}
+  }
+
+  const RefPtr<RefObj> m_bar;
+};


### PR DESCRIPTION
Ignore the destructor of `CXXBindTemporaryExpr` when returning a value or passing an argument with copy elision.