### PR TITLE
validate arc destination block number in GCOVFile::readGCNO

### DIFF
--- a/llvm/lib/ProfileData/GCOV.cpp
+++ b/llvm/lib/ProfileData/GCOV.cpp
@@ -165,6 +165,11 @@ bool GCOVFile::readGCNO(GCOVBuffer &buf) {
           version >= GCOV::V1200 ? (length / 4 - 1) / 2 : (length - 1) / 2;
       for (uint32_t i = 0; i != e; ++i) {
         uint32_t dstNo = buf.getWord(), flags = buf.getWord();
+        if (dstNo >= fn->blocks.size()) {
+          errs() << "unexpected block number: " << dstNo << " (in "
+                 << fn->blocks.size() << ")\n";
+          return false;
+        }
         GCOVBlock *dst = fn->blocks[dstNo].get();
         auto arc = std::make_unique<GCOVArc>(*src, *dst, flags);
         src->addDstEdge(arc.get());


### PR DESCRIPTION
readGCNO checks the arc source block number srcNo against fn->blocks.size() but not the destination dstNo, which is read from the same untrusted .gcno word. A crafted GCOV_TAG_ARCS record with an out-of-range dstNo indexes fn->blocks out of bounds (GCOV.cpp:168) when running llvm-cov gcov. Mirror the existing srcNo guard.