### PR TITLE
[clang][scan-deps] Add option to disable caching stat failures

### DIFF
--- a/clang/include/clang/DependencyScanning/DependencyScanningFilesystem.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningFilesystem.h
@@ -23,6 +23,8 @@
 namespace clang {
 namespace dependencies {
 
+class DependencyScanningService;
+
 using DependencyDirectivesTy =
     SmallVector<dependency_directives_scan::Directive, 20>;
 
@@ -370,7 +372,7 @@ public:
   static const char ID;
 
   DependencyScanningWorkerFilesystem(
-      DependencyScanningFilesystemSharedCache &SharedCache,
+      DependencyScanningService &Service,
       IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS);
 
   llvm::ErrorOr<llvm::vfs::Status> status(const Twine &Path) override;
@@ -450,10 +452,7 @@ private:
   /// Returns entry associated with the unique ID in the shared cache or nullptr
   /// if none is found.
   const CachedFileSystemEntry *
-  findSharedEntryByUID(llvm::vfs::Status Stat) const {
-    return SharedCache.getShardForUID(Stat.getUniqueID())
-        .findEntryByUID(Stat.getUniqueID());
-  }
+  findSharedEntryByUID(llvm::vfs::Status Stat) const;
 
   /// Associates the given entry with the filename in the local cache and
   /// returns it.
@@ -467,20 +466,14 @@ private:
   /// some. Otherwise, constructs new one with the given error code, associates
   /// it with the filename and returns the result.
   const CachedFileSystemEntry &
-  getOrEmplaceSharedEntryForFilename(StringRef Filename, std::error_code EC) {
-    return SharedCache.getShardForFilename(Filename)
-        .getOrEmplaceEntryForFilename(Filename, EC);
-  }
+  getOrEmplaceSharedEntryForFilename(StringRef Filename, std::error_code EC);
 
   /// Returns entry associated with the filename in the shared cache if there is
   /// some. Otherwise, associates the given entry with the filename and returns
   /// it.
   const CachedFileSystemEntry &
   getOrInsertSharedEntryForFilename(StringRef Filename,
-                                    const CachedFileSystemEntry &Entry) {
-    return SharedCache.getShardForFilename(Filename)
-        .getOrInsertEntryForFilename(Filename, Entry);
-  }
+                                    const CachedFileSystemEntry &Entry);
 
   void printImpl(raw_ostream &OS, PrintType Type,
                  unsigned IndentLevel) const override {
@@ -489,8 +482,8 @@ private:
     getUnderlyingFS().print(OS, Type, IndentLevel + 1);
   }
 
-  /// The global cache shared between worker threads.
-  DependencyScanningFilesystemSharedCache &SharedCache;
+  /// The service associated with this VFS.
+  DependencyScanningService &Service;
   /// The local cache is used by the worker thread to cache file system queries
   /// locally instead of querying the global cache every time.
   DependencyScanningFilesystemLocalCache LocalCache;

--- a/clang/include/clang/DependencyScanning/DependencyScanningService.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningService.h
@@ -60,6 +60,12 @@ enum class ScanningOptimizations {
 
 #undef DSS_LAST_BITMASK_ENUM
 
+bool shouldCacheNegativeStatsDefault();
+
+/// \return true if failed stats for files with this name should be cached,
+///         false otherwise.
+bool shouldCacheNegativeStatsForPath(StringRef Path);
+
 /// The configuration knobs for the dependency scanning service.
 struct DependencyScanningServiceOptions {
   DependencyScanningServiceOptions();
@@ -90,6 +96,8 @@ struct DependencyScanningServiceOptions {
   /// Whether to automatically flush the module cache from memory to disk at the
   /// end of the service lifetime.
   bool FlushModuleCache = true;
+  /// Whether the caching VFS should cache missing filesystem entries.
+  bool CacheNegativeStats = shouldCacheNegativeStatsDefault();
 };
 
 /// The dependency scanning service contains shared configuration and state that

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -624,7 +624,7 @@ struct AsyncModuleCompile : PPCallbacks {
     // We should build the PCM.
     IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS =
         llvm::makeIntrusiveRefCnt<DependencyScanningWorkerFilesystem>(
-            Service.getSharedCache(), Service.getOpts().MakeVFS());
+            Service, Service.getOpts().MakeVFS());
     VFS = createVFSFromCompilerInvocation(CI.getInvocation(),
                                           CI.getDiagnostics(), std::move(VFS));
     auto DC = std::make_unique<DiagnosticConsumer>();

--- a/clang/lib/DependencyScanning/DependencyScanningFilesystem.cpp
+++ b/clang/lib/DependencyScanning/DependencyScanningFilesystem.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/DependencyScanning/DependencyScanningFilesystem.h"
+#include "clang/DependencyScanning/DependencyScanningService.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Threading.h"
 #include <optional>
@@ -244,19 +245,19 @@ const CachedRealPath &DependencyScanningFilesystemSharedCache::CacheShard::
 }
 
 DependencyScanningWorkerFilesystem::DependencyScanningWorkerFilesystem(
-    DependencyScanningFilesystemSharedCache &SharedCache,
+    DependencyScanningService &Service,
     IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS)
     : llvm::RTTIExtends<DependencyScanningWorkerFilesystem,
                         llvm::vfs::ProxyFileSystem>(std::move(FS)),
-      SharedCache(SharedCache),
-      WorkingDirForCacheLookup(llvm::errc::invalid_argument) {
+      Service(Service), WorkingDirForCacheLookup(llvm::errc::invalid_argument) {
   updateWorkingDirForCacheLookup();
 }
 
 const CachedFileSystemEntry &
 DependencyScanningWorkerFilesystem::getOrEmplaceSharedEntryForUID(
     TentativeEntry TEntry) {
-  auto &Shard = SharedCache.getShardForUID(TEntry.Status.getUniqueID());
+  auto &Shard =
+      Service.getSharedCache().getShardForUID(TEntry.Status.getUniqueID());
   return Shard.getOrEmplaceEntryForUID(TEntry.Status.getUniqueID(),
                                        std::move(TEntry.Status),
                                        std::move(TEntry.Contents));
@@ -267,10 +268,34 @@ DependencyScanningWorkerFilesystem::findEntryByFilenameWithWriteThrough(
     StringRef Filename) {
   if (const auto *Entry = LocalCache.findEntryByFilename(Filename))
     return Entry;
-  auto &Shard = SharedCache.getShardForFilename(Filename);
+  auto &Shard = Service.getSharedCache().getShardForFilename(Filename);
   if (const auto *Entry = Shard.findEntryByFilename(Filename))
     return &LocalCache.insertEntryForFilename(Filename, *Entry);
   return nullptr;
+}
+
+const CachedFileSystemEntry *
+DependencyScanningWorkerFilesystem::findSharedEntryByUID(
+    llvm::vfs::Status Stat) const {
+  return Service.getSharedCache()
+      .getShardForUID(Stat.getUniqueID())
+      .findEntryByUID(Stat.getUniqueID());
+}
+
+const CachedFileSystemEntry &
+DependencyScanningWorkerFilesystem::getOrEmplaceSharedEntryForFilename(
+    StringRef Filename, std::error_code EC) {
+  return Service.getSharedCache()
+      .getShardForFilename(Filename)
+      .getOrEmplaceEntryForFilename(Filename, EC);
+}
+
+const CachedFileSystemEntry &
+DependencyScanningWorkerFilesystem::getOrInsertSharedEntryForFilename(
+    StringRef Filename, const CachedFileSystemEntry &Entry) {
+  return Service.getSharedCache()
+      .getShardForFilename(Filename)
+      .getOrInsertEntryForFilename(Filename, Entry);
 }
 
 llvm::ErrorOr<const CachedFileSystemEntry &>
@@ -279,6 +304,10 @@ DependencyScanningWorkerFilesystem::computeAndStoreResult(
   llvm::ErrorOr<llvm::vfs::Status> Stat =
       getUnderlyingFS().status(OriginalFilename);
   if (!Stat) {
+    if (!Service.getOpts().CacheNegativeStats ||
+        !shouldCacheNegativeStatsForPath(OriginalFilename))
+      return Stat.getError();
+
     const auto &Entry =
         getOrEmplaceSharedEntryForFilename(FilenameForLookup, Stat.getError());
     return insertLocalEntryForFilename(FilenameForLookup, Entry);
@@ -424,7 +453,8 @@ DependencyScanningWorkerFilesystem::getRealPath(const Twine &Path,
     return HandleCachedRealPath(*RealPath);
 
   // If we have the result in the shared cache, cache it locally.
-  auto &Shard = SharedCache.getShardForFilename(*FilenameForLookup);
+  auto &Shard =
+      Service.getSharedCache().getShardForFilename(*FilenameForLookup);
   if (const auto *ShardRealPath =
           Shard.findRealPathByFilename(*FilenameForLookup)) {
     const auto &RealPath = LocalCache.insertRealPathForFilename(

--- a/clang/lib/DependencyScanning/DependencyScanningService.cpp
+++ b/clang/lib/DependencyScanning/DependencyScanningService.cpp
@@ -9,9 +9,34 @@
 #include "clang/DependencyScanning/DependencyScanningService.h"
 
 #include "llvm/Support/Chrono.h"
+#include "llvm/Support/Process.h"
 
 using namespace clang;
 using namespace dependencies;
+
+bool dependencies::shouldCacheNegativeStatsDefault() {
+  if (std::optional<std::string> MaybeNegStats =
+          llvm::sys::Process::GetEnv("CLANG_SCAN_CACHE_NEGATIVE_STATS")) {
+    if (MaybeNegStats->empty())
+      return true;
+    return llvm::StringSwitch<bool>(*MaybeNegStats)
+        .Case("1", true)
+        .Case("0", false)
+        .Default(false);
+  }
+  return false;
+}
+
+// Negative caching directories can cause build failures due to incorrectly
+// configured projects.
+bool dependencies::shouldCacheNegativeStatsForPath(StringRef Path) {
+  StringRef Ext = llvm::sys::path::extension(Path);
+  if (Ext.empty())
+    return false;
+  if (Ext == ".framework")
+    return false;
+  return true;
+}
 
 DependencyScanningServiceOptions::DependencyScanningServiceOptions()
     : MakeVFS([] { return llvm::vfs::createPhysicalFileSystem(); }),

--- a/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
@@ -37,7 +37,7 @@ DependencyScanningWorker::DependencyScanningWorker(
   }
 
   DepFS = llvm::makeIntrusiveRefCnt<DependencyScanningWorkerFilesystem>(
-      Service.getSharedCache(), std::move(BaseFS));
+      Service, std::move(BaseFS));
 }
 
 DependencyScanningWorker::~DependencyScanningWorker() = default;

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -103,6 +103,7 @@ static ScanningOutputFormat Format = ScanningOutputFormat::Make;
 static ScanningOptimizations OptimizeArgs;
 static std::string ModuleFilesDir;
 static bool EagerLoadModules;
+static bool CacheNegativeStats;
 static unsigned NumThreads = 0;
 static std::string CompilationDB;
 static std::optional<std::string> ModuleNames;
@@ -211,6 +212,8 @@ static void ParseArgs(int argc, char **argv) {
     OutputFileName = A->getValue();
 
   EagerLoadModules = Args.hasArg(OPT_eager_load_pcm);
+
+  CacheNegativeStats = Args.hasArg(OPT_cache_negative_stats);
 
   if (const llvm::opt::Arg *A = Args.getLastArg(OPT_j)) {
     StringRef S{A->getValue()};
@@ -1184,6 +1187,7 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
   Opts.TraceVFS = Verbose;
   Opts.AsyncScanModules = AsyncScanModules;
   Opts.FlushModuleCache = !NoFlushModuleCache;
+  Opts.CacheNegativeStats = CacheNegativeStats;
 
   llvm::Timer T;
   T.startTimer();

--- a/clang/tools/clang-scan-deps/Opts.td
+++ b/clang/tools/clang-scan-deps/Opts.td
@@ -22,6 +22,7 @@ defm module_files_dir : Eq<"module-files-dir",
 
 def optimize_args_EQ : CommaJoined<["-", "--"], "optimize-args=">, HelpText<"Which command-line arguments of modules to optimize">;
 def eager_load_pcm : F<"eager-load-pcm", "Load PCM files eagerly (instead of lazily on import)">;
+def cache_negative_stats : F<"cache-negative-stats", "Cache stat failures">;
 
 def j : Arg<"j", "Number of worker threads to use (default: use all concurrent threads)">;
 

--- a/clang/unittests/DependencyScanning/DependencyScanningFilesystemTest.cpp
+++ b/clang/unittests/DependencyScanning/DependencyScanningFilesystemTest.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/DependencyScanning/DependencyScanningFilesystem.h"
+#include "clang/DependencyScanning/DependencyScanningService.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "gtest/gtest.h"
@@ -18,8 +19,8 @@ TEST(DependencyScanningFilesystem, OpenFileAndGetBufferRepeatedly) {
   InMemoryFS->setCurrentWorkingDirectory("/");
   InMemoryFS->addFile("/foo", 0, llvm::MemoryBuffer::getMemBuffer("content"));
 
-  DependencyScanningFilesystemSharedCache SharedCache;
-  DependencyScanningWorkerFilesystem DepFS(SharedCache, InMemoryFS);
+  DependencyScanningService Service({});
+  DependencyScanningWorkerFilesystem DepFS(Service, InMemoryFS);
 
   auto FileOrErr1 = DepFS.openFileForRead("foo");
   auto FileOrErr2 = DepFS.openFileForRead("foo");
@@ -52,9 +53,11 @@ TEST(DependencyScanningWorkerFilesystem, CacheStatusFailures) {
   auto InstrumentingFS =
       llvm::makeIntrusiveRefCnt<llvm::vfs::TracingFileSystem>(InMemoryFS);
 
-  DependencyScanningFilesystemSharedCache SharedCache;
-  DependencyScanningWorkerFilesystem DepFS(SharedCache, InstrumentingFS);
-  DependencyScanningWorkerFilesystem DepFS2(SharedCache, InstrumentingFS);
+  DependencyScanningServiceOptions Opts;
+  Opts.CacheNegativeStats = true;
+  DependencyScanningService Service(std::move(Opts));
+  DependencyScanningWorkerFilesystem DepFS(Service, InstrumentingFS);
+  DependencyScanningWorkerFilesystem DepFS2(Service, InstrumentingFS);
 
   DepFS.status("/foo.c");
   EXPECT_EQ(InstrumentingFS->NumStatusCalls, 1u);
@@ -78,9 +81,9 @@ TEST(DependencyScanningFilesystem, CacheGetRealPath) {
   auto InstrumentingFS =
       llvm::makeIntrusiveRefCnt<llvm::vfs::TracingFileSystem>(InMemoryFS);
 
-  DependencyScanningFilesystemSharedCache SharedCache;
-  DependencyScanningWorkerFilesystem DepFS(SharedCache, InstrumentingFS);
-  DependencyScanningWorkerFilesystem DepFS2(SharedCache, InstrumentingFS);
+  DependencyScanningService Service({});
+  DependencyScanningWorkerFilesystem DepFS(Service, InstrumentingFS);
+  DependencyScanningWorkerFilesystem DepFS2(Service, InstrumentingFS);
 
   {
     llvm::SmallString<128> Result;
@@ -113,8 +116,8 @@ TEST(DependencyScanningFilesystem, RealPathAndStatusInvariants) {
   InMemoryFS->addFile("/foo.c", 0, llvm::MemoryBuffer::getMemBuffer(""));
   InMemoryFS->addFile("/bar.c", 0, llvm::MemoryBuffer::getMemBuffer(""));
 
-  DependencyScanningFilesystemSharedCache SharedCache;
-  DependencyScanningWorkerFilesystem DepFS(SharedCache, InMemoryFS);
+  DependencyScanningService Service({});
+  DependencyScanningWorkerFilesystem DepFS(Service, InMemoryFS);
 
   // Success.
   {
@@ -166,8 +169,8 @@ TEST(DependencyScanningFilesystem, CacheStatOnExists) {
   InMemoryFS->setCurrentWorkingDirectory("/");
   InMemoryFS->addFile("/foo", 0, llvm::MemoryBuffer::getMemBuffer(""));
   InMemoryFS->addFile("/bar", 0, llvm::MemoryBuffer::getMemBuffer(""));
-  DependencyScanningFilesystemSharedCache SharedCache;
-  DependencyScanningWorkerFilesystem DepFS(SharedCache, InstrumentingFS);
+  DependencyScanningService Service({});
+  DependencyScanningWorkerFilesystem DepFS(Service, InstrumentingFS);
 
   DepFS.status("/foo");
   DepFS.status("/foo");
@@ -183,30 +186,71 @@ TEST(DependencyScanningFilesystem, CacheStatOnExists) {
 TEST(DependencyScanningFilesystem, CacheStatFailures) {
   auto InMemoryFS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
   InMemoryFS->setCurrentWorkingDirectory("/");
-  InMemoryFS->addFile("/dir/vector", 0, llvm::MemoryBuffer::getMemBuffer(""));
-  InMemoryFS->addFile("/cache/a.pcm", 0, llvm::MemoryBuffer::getMemBuffer(""));
+  InMemoryFS->addFile("/dir/present.h", 0,
+                      llvm::MemoryBuffer::getMemBuffer(""));
 
   auto InstrumentingFS =
       llvm::makeIntrusiveRefCnt<llvm::vfs::TracingFileSystem>(InMemoryFS);
 
-  DependencyScanningFilesystemSharedCache SharedCache;
-  DependencyScanningWorkerFilesystem DepFS(SharedCache, InstrumentingFS);
+  DependencyScanningServiceOptions Opts;
+  Opts.CacheNegativeStats = true;
+  DependencyScanningService Service(std::move(Opts));
+  DependencyScanningWorkerFilesystem DepFS(Service, InstrumentingFS);
 
   DepFS.status("/dir");
+  EXPECT_EQ(InstrumentingFS->NumStatusCalls, 1u);
   DepFS.status("/dir");
   EXPECT_EQ(InstrumentingFS->NumStatusCalls, 1u);
 
-  DepFS.status("/dir/vector");
-  DepFS.status("/dir/vector");
+  DepFS.status("/dir/present.h");
   EXPECT_EQ(InstrumentingFS->NumStatusCalls, 2u);
+  DepFS.status("/dir/present.h");
+  EXPECT_EQ(InstrumentingFS->NumStatusCalls, 2u);
+
+  DepFS.status("/dir/missing.h");
+  EXPECT_EQ(InstrumentingFS->NumStatusCalls, 3u);
+  DepFS.status("/dir/missing.h");
+  EXPECT_EQ(InstrumentingFS->NumStatusCalls, 3u);
+}
+
+TEST(DependencyScanningFilesystem, NoNegativeCache) {
+  auto InMemoryFS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
+  InMemoryFS->setCurrentWorkingDirectory("/");
+  InMemoryFS->addFile("/dir/present.h", 0,
+                      llvm::MemoryBuffer::getMemBuffer(""));
+
+  auto InstrumentingFS =
+      llvm::makeIntrusiveRefCnt<llvm::vfs::TracingFileSystem>(InMemoryFS);
+
+  DependencyScanningServiceOptions Opts;
+  Opts.CacheNegativeStats = false;
+  DependencyScanningService Service(std::move(Opts));
+  DependencyScanningWorkerFilesystem DepFS(Service, InstrumentingFS);
+
+  DepFS.status("/dir");
+  EXPECT_EQ(InstrumentingFS->NumStatusCalls, 1u);
+  DepFS.status("/dir");
+  EXPECT_EQ(InstrumentingFS->NumStatusCalls, 1u);
+
+  DepFS.status("/dir/present.h");
+  EXPECT_EQ(InstrumentingFS->NumStatusCalls, 2u);
+  DepFS.status("/dir/present.h");
+  EXPECT_EQ(InstrumentingFS->NumStatusCalls, 2u);
+
+  DepFS.status("/dir/missing.h");
+  EXPECT_EQ(InstrumentingFS->NumStatusCalls, 3u);
+  DepFS.status("/dir/missing.h");
+  EXPECT_EQ(InstrumentingFS->NumStatusCalls, 4u);
 }
 
 TEST(DependencyScanningFilesystem, DiagnoseStaleStatFailures) {
   auto InMemoryFS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
   InMemoryFS->setCurrentWorkingDirectory("/");
 
-  DependencyScanningFilesystemSharedCache SharedCache;
-  DependencyScanningWorkerFilesystem DepFS(SharedCache, InMemoryFS);
+  DependencyScanningServiceOptions Opts;
+  Opts.CacheNegativeStats = true;
+  DependencyScanningService Service(std::move(Opts));
+  DependencyScanningWorkerFilesystem DepFS(Service, InMemoryFS);
 
   bool Path1Exists = DepFS.exists("/path1.suffix");
   ASSERT_EQ(Path1Exists, false);
@@ -218,7 +262,8 @@ TEST(DependencyScanningFilesystem, DiagnoseStaleStatFailures) {
   // DepFS's eyes.
   ASSERT_EQ(Path1Exists, false);
 
-  auto InvalidEntries = SharedCache.getOutOfDateEntries(*InMemoryFS);
+  auto InvalidEntries =
+      Service.getSharedCache().getOutOfDateEntries(*InMemoryFS);
 
   EXPECT_EQ(InvalidEntries.size(), 1u);
   ASSERT_STREQ("/path1.suffix", InvalidEntries[0].Path);
@@ -230,8 +275,10 @@ TEST(DependencyScanningFilesystem, DiagnoseCachedFileSizeChange) {
   InMemoryFS1->setCurrentWorkingDirectory("/");
   InMemoryFS2->setCurrentWorkingDirectory("/");
 
-  DependencyScanningFilesystemSharedCache SharedCache;
-  DependencyScanningWorkerFilesystem DepFS(SharedCache, InMemoryFS1);
+  DependencyScanningServiceOptions Opts;
+  Opts.CacheNegativeStats = true;
+  DependencyScanningService Service(std::move(Opts));
+  DependencyScanningWorkerFilesystem DepFS(Service, InMemoryFS1);
 
   InMemoryFS1->addFile("/path1.suffix", 0,
                        llvm::MemoryBuffer::getMemBuffer(""));
@@ -244,7 +291,8 @@ TEST(DependencyScanningFilesystem, DiagnoseCachedFileSizeChange) {
 
   // Check against the new file system. InMemoryFS2 could be the underlying
   // physical system in the real world.
-  auto InvalidEntries = SharedCache.getOutOfDateEntries(*InMemoryFS2);
+  auto InvalidEntries =
+      Service.getSharedCache().getOutOfDateEntries(*InMemoryFS2);
 
   ASSERT_EQ(InvalidEntries.size(), 1u);
   ASSERT_STREQ("/path1.suffix", InvalidEntries[0].Path);
@@ -263,8 +311,8 @@ TEST(DependencyScanningFilesystem, DoNotDiagnoseDirSizeChange) {
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS =
       llvm::vfs::createPhysicalFileSystem();
 
-  DependencyScanningFilesystemSharedCache SharedCache;
-  DependencyScanningWorkerFilesystem DepFS(SharedCache, FS);
+  DependencyScanningService Service({});
+  DependencyScanningWorkerFilesystem DepFS(Service, FS);
 
   // Trigger the file system cache.
   ASSERT_EQ(DepFS.exists(Dir), true);
@@ -283,6 +331,6 @@ TEST(DependencyScanningFilesystem, DoNotDiagnoseDirSizeChange) {
   }
 
   // We do not report directory size changes.
-  auto InvalidEntries = SharedCache.getOutOfDateEntries(*FS);
+  auto InvalidEntries = Service.getSharedCache().getOutOfDateEntries(*FS);
   EXPECT_EQ(InvalidEntries.size(), 0u);
 }


### PR DESCRIPTION
While the source code isn't supposed to change during a build, in some environments it does. This adds an option that disables caching of stat failures, meaning that source files can be added to the build during scanning.

This adds a `-no-cache-negative-stats` option to clang-scan-deps to enable this behavior. There are no tests for clang-scan-deps as there's no reliable way to do so from it. A unit test has been added that modifies the filesystem between scans to test it.