### PR TITLE
[lldb] Strip objc superclass pointer in trampoline handler

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTrampolineHandler.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTrampolineHandler.cpp
@@ -142,7 +142,7 @@ __lldb_objc_find_implementation_for_selector (void *object,
     }
 #if defined(__arm64e__)
     return_struct.class_addr =
-      __builtin_ptrauth_strip(return_struct.class_addr, 2);
+      __builtin_ptrauth_strip(return_struct.class_addr, /*ptrauth_key_asda*/ 2);
 #endif
     if (debug)
       printf("*** Super, class addr: %p\n", return_struct.class_addr);

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTrampolineHandler.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTrampolineHandler.cpp
@@ -140,6 +140,10 @@ __lldb_objc_find_implementation_for_selector (void *object,
     } else {
       return_struct.class_addr = ((__lldb_objc_super *) object)->class_ptr;
     }
+#if defined(__arm64e__)
+    return_struct.class_addr =
+      __builtin_ptrauth_strip(return_struct.class_addr, 2);
+#endif
     if (debug)
       printf("*** Super, class addr: %p\n", return_struct.class_addr);
   } else {


### PR DESCRIPTION
The pointer needs to be stripped before being handed off to any objc runtime functions. Otherwise the utility expression will hit a PAC exception and the thread plan will fail to execute correctly.

This fixes TestObjCStepping.py on arm64e.