### PR TITLE
[DirectX] Update checks for more precise error messages

### DIFF
--- a/llvm/test/CodeGen/DirectX/firstbitlow_error.ll
+++ b/llvm/test/CodeGen/DirectX/firstbitlow_error.ll
@@ -1,7 +1,7 @@
 ; RUN: not opt -S -dxil-op-lower -mtriple=dxil-pc-shadermodel6.3-library %s 2>&1 | FileCheck %s
 
 ; DXIL operation firstbitshigh does not support double overload type
-; CHECK: intrinsic has incorrect argument type
+; CHECK: error: intrinsic argument 0 type (overload type 0) expected any integer or integer vector, but got double
 
 define noundef double @firstbitlow_double(double noundef %a) {
 entry:

--- a/llvm/test/CodeGen/DirectX/firstbitshigh_error.ll
+++ b/llvm/test/CodeGen/DirectX/firstbitshigh_error.ll
@@ -1,7 +1,7 @@
 ; RUN: not opt -S -dxil-op-lower -mtriple=dxil-pc-shadermodel6.3-library %s 2>&1 | FileCheck %s
 
 ; DXIL operation firstbitshigh does not support double overload type
-; CHECK: intrinsic has incorrect argument type
+; CHECK: error: intrinsic argument 0 type (overload type 0) expected any integer or integer vector, but got double
 
 define noundef double @firstbitshigh_double(double noundef %a) {
 entry:

--- a/llvm/test/CodeGen/DirectX/firstbituhigh_error.ll
+++ b/llvm/test/CodeGen/DirectX/firstbituhigh_error.ll
@@ -1,7 +1,7 @@
 ; RUN: not opt -S -dxil-op-lower -mtriple=dxil-pc-shadermodel6.3-library %s 2>&1 | FileCheck %s
 
 ; DXIL operation firstbituhigh does not support double overload type
-; CHECK: intrinsic has incorrect argument type
+; CHECK: error: intrinsic argument 0 type (overload type 0) expected any integer or integer vector, but got double
 
 define noundef double @firstbituhigh_double(double noundef %a) {
 entry:

--- a/llvm/test/CodeGen/DirectX/saturate_errors.ll
+++ b/llvm/test/CodeGen/DirectX/saturate_errors.ll
@@ -1,7 +1,7 @@
 ; RUN: not opt -S -dxil-op-lower -mtriple=dxil-pc-shadermodel6.3-library %s 2>&1 | FileCheck %s
 
 ; DXIL operation saturate does not support i32 overload
-; CHECK: intrinsic has incorrect return type
+; CHECK: error: intrinsic return type (overload type 0) expected any fp or fp vector, but got i32
 
 define noundef i32 @test_saturate_i32(i32 noundef %p0) #0 {
 entry:


### PR DESCRIPTION
We've improved these error messages in #199217, update the tests for the DirectX backend.