### PR TITLE
[OpenMP] Fix RPC register segfaulting without PM initialized

### DIFF
--- a/offload/libomptarget/interface.cpp
+++ b/offload/libomptarget/interface.cpp
@@ -646,6 +646,9 @@ EXTERN void __tgt_target_nowait_query(void **AsyncHandle) {
 
 EXTERN void __tgt_register_rpc_callback(unsigned (*Callback)(void *,
                                                              unsigned)) {
+  if (!PM)
+    return;
+
   for (auto &Plugin : PM->plugins())
     if (Plugin.is_initialized())
       Plugin.getRPCServer().registerCallback(Callback);


### PR DESCRIPTION
Summary:
This happens in practice if you link libomptarget without initializing
it in the Flang RPC IO handling.
