### PR TITLE
[lldb] Fix TestBranchIslands.py for arm64e

### DIFF
--- a/lldb/test/API/macosx/branch-islands/Makefile
+++ b/lldb/test/API/macosx/branch-islands/Makefile
@@ -7,7 +7,7 @@ a.out: main.o padding1.o padding2.o padding3.o padding4.o foo.o
 	${CC} ${LDFLAGS} foo.o padding1.o padding2.o padding3.o padding4.o main.o -o a.out
 
 %.o: $(SRCDIR)/%.s
-	${CC} -c $<
+	${CC} ${CFLAGS} -c $<
 
 #padding1.o: padding1.s
 #	${CC} -c $(SRCDIR)/padding1.s


### PR DESCRIPTION
Need to pass CFLAGS to clang when building the asm files, otherwise the triple isn't used and they're automatically compiled for the host platform.