### PR TITLE
[clang][WebAssembly] Fix flat compiler-rt search on WASI preview targets

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -841,6 +841,10 @@ StringRef ToolChain::getOSLibName() const {
     return "aix";
   case llvm::Triple::Serenity:
     return "serenity";
+  case llvm::Triple::WASIp1:
+  case llvm::Triple::WASIp2:
+  case llvm::Triple::WASIp3:
+    return "wasi";
   default:
     return getOS();
   }


### PR DESCRIPTION
# [clang][WebAssembly] Fix flat compiler-rt search on WASI preview targets

This PR fixes issue #200500.

This patch allows clang to find the proper compiler-rt paths when `LLVM_ENABLE_PER_TARGET_RUNTIME_DIR` is disabled for compiler-rt. `ToolChain::getOSLibName()` already has explicit cases for other OS names that don't match their library dir names (FreeBSD, SunOS, etc.); WASI is simply missing from that list.

## Steps to test bug fix

The following steps were done in a fresh Ubuntu 26.04 LTS installation. Steps to reproduce the bug can be found in the [issue](https://github.com/llvm/llvm-project/issues/200500).

First, build my modified toolchain so it is capable of targeting WebAssembly:

```
$ apt update

$ apt install -y build-essential cmake ninja-build python3 git

$ git clone --depth 1 -b fix-flat-builtins-search https://github.com/maxgmr/llvm-project.git

$ cmake -G Ninja llvm-project/llvm \
    -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_INSTALL_PREFIX=/opt/llvm \
    -DLLVM_ENABLE_PROJECTS="clang;lld" \
    -DLLVM_TARGETS_TO_BUILD="WebAssembly" \
    -DLLVM_INCLUDE_TESTS=OFF

$ ninja install
```

Next, build compiler-rt with a wasm target and `LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF`:

```
$ mkdir build-rt && cd build-rt

$ cmake -G Ninja ../llvm-project/compiler-rt \
    -DCMAKE_BUILD_TYPE=Release \
    -DCOMPILER_RT_INSTALL_PATH=$(/opt/llvm/bin/clang --print-resource-dir) \
    -DCMAKE_C_COMPILER=/opt/llvm/bin/clang \
    -DCMAKE_C_COMPILER_TARGET=wasm32-wasip1 \
    -DCMAKE_CXX_COMPILER=/opt/llvm/bin/clang++ \
    -DCMAKE_CXX_COMPILER_TARGET=wasm32-wasip1 \
    -DCMAKE_SYSTEM_NAME=WASI \
    -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY \
    -DCOMPILER_RT_BAREMETAL_BUILD=ON \
    -DCOMPILER_RT_BUILD_BUILTINS=ON \
    -DCOMPILER_RT_BUILD_CRT=OFF \
    -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
    -DCOMPILER_RT_BUILD_XRAY=OFF \
    -DCOMPILER_RT_BUILD_PROFILE=OFF \
    -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
    -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
    -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF

$ ninja install

$ touch test.c
```

Finally, attempt to build a dummy program:

```
$ /opt/llvm/bin/clang --target=wasm32-wasip1 -nostartfiles -nodefaultlibs test.c
$ /opt/llvm/bin/clang --target=wasm32-wasip2 -fuse-ld=/opt/llvm/bin/wasm-ld -nostartfiles -nodefaultlibs test.c
$ /opt/llvm/bin/clang --target=wasm32-wasip3 -fuse-ld=/opt/llvm/bin/wasm-ld -nostartfiles -nodefaultlibs test.c
```

The following error should be absent from the output of the final three commands:

```
wasm-ld: error: cannot open /opt/llvm/lib/clang/23/lib/wasm32-unknown-wasip{1,2,3}/libclang_rt.builtins.a: No such file or directory
```