### PR TITLE
[lldb] Skip simulator platform tests on arm64e

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -563,6 +563,9 @@ def apple_simulator_test(platform):
         if lldbplatformutil.getHostPlatform() not in ["darwin", "macosx"]:
             return "simulator tests are run only on darwin hosts."
 
+        if lldbplatformutil.getArchitecture() == "arm64e":
+            return "simulators do not support arm64e."
+
         # Make sure we recognize the platform.
         mapping = {
             "iphone": "ios",

--- a/lldb/test/API/macosx/simulator/TestSimulatorPlatform.py
+++ b/lldb/test/API/macosx/simulator/TestSimulatorPlatform.py
@@ -119,6 +119,7 @@ class TestSimulatorPlatformLaunching(TestBase):
     @skipUnlessDarwin
     @skipIfDarwinEmbedded
     @apple_simulator_test("iphone")
+    @skipIf(archs=["arm64e"])  # Simulators do not support arm64e
     def test_ios(self):
         """Test running an iOS simulator binary"""
         self.run_with(
@@ -134,6 +135,7 @@ class TestSimulatorPlatformLaunching(TestBase):
     @skipUnlessDarwin
     @skipIfDarwinEmbedded
     @apple_simulator_test("appletv")
+    @skipIf(archs=["arm64e"])  # Simulators do not support arm64e
     def test_tvos(self):
         """Test running an tvOS simulator binary"""
         self.run_with(
@@ -166,6 +168,7 @@ class TestSimulatorPlatformLaunching(TestBase):
     @apple_simulator_test("watch")
     @skipIfDarwin  # rdar://problem/64552748
     @skipIf(archs=["i386", "x86_64"])
+    @skipIf(archs=["arm64e"])  # Simulators do not support arm64e
     def test_watchos_armv7k(self):
         """Test running a 32-bit watchOS simulator binary"""
         self.run_with(
@@ -235,6 +238,7 @@ class TestSimulatorPlatformLaunching(TestBase):
     @skipIfDarwinEmbedded
     @apple_simulator_test("iphone")
     @skipIf(archs=["i386", "x86_64"])
+    @skipIf(archs=["arm64e"])  # Simulators do not support arm64e
     def test_ios_backdeploy_apple_silicon(self):
         """Test running a back-deploying iOS simulator binary"""
         self.run_with(
@@ -266,6 +270,7 @@ class TestSimulatorPlatformLaunching(TestBase):
     @skipIfDarwinEmbedded
     @apple_simulator_test("appletv")
     @skipIf(archs=["i386", "x86_64"])
+    @skipIf(archs=["arm64e"])  # Simulators do not support arm64e
     def test_tvos_backdeploy_apple_silicon(self):
         """Test running a back-deploying tvOS simulator binary"""
         self.run_with(

--- a/lldb/test/API/macosx/simulator/TestSimulatorPlatform.py
+++ b/lldb/test/API/macosx/simulator/TestSimulatorPlatform.py
@@ -119,7 +119,6 @@ class TestSimulatorPlatformLaunching(TestBase):
     @skipUnlessDarwin
     @skipIfDarwinEmbedded
     @apple_simulator_test("iphone")
-    @skipIf(archs=["arm64e"])  # Simulators do not support arm64e
     def test_ios(self):
         """Test running an iOS simulator binary"""
         self.run_with(
@@ -135,7 +134,6 @@ class TestSimulatorPlatformLaunching(TestBase):
     @skipUnlessDarwin
     @skipIfDarwinEmbedded
     @apple_simulator_test("appletv")
-    @skipIf(archs=["arm64e"])  # Simulators do not support arm64e
     def test_tvos(self):
         """Test running an tvOS simulator binary"""
         self.run_with(
@@ -168,7 +166,6 @@ class TestSimulatorPlatformLaunching(TestBase):
     @apple_simulator_test("watch")
     @skipIfDarwin  # rdar://problem/64552748
     @skipIf(archs=["i386", "x86_64"])
-    @skipIf(archs=["arm64e"])  # Simulators do not support arm64e
     def test_watchos_armv7k(self):
         """Test running a 32-bit watchOS simulator binary"""
         self.run_with(
@@ -238,7 +235,6 @@ class TestSimulatorPlatformLaunching(TestBase):
     @skipIfDarwinEmbedded
     @apple_simulator_test("iphone")
     @skipIf(archs=["i386", "x86_64"])
-    @skipIf(archs=["arm64e"])  # Simulators do not support arm64e
     def test_ios_backdeploy_apple_silicon(self):
         """Test running a back-deploying iOS simulator binary"""
         self.run_with(
@@ -270,7 +266,6 @@ class TestSimulatorPlatformLaunching(TestBase):
     @skipIfDarwinEmbedded
     @apple_simulator_test("appletv")
     @skipIf(archs=["i386", "x86_64"])
-    @skipIf(archs=["arm64e"])  # Simulators do not support arm64e
     def test_tvos_backdeploy_apple_silicon(self):
         """Test running a back-deploying tvOS simulator binary"""
         self.run_with(


### PR DESCRIPTION
Simulators do not support arm64e.