### PR TITLE
[cuda][flang] Diagnose missing CUDA intrinsic modules in Flang semantics

### DIFF
--- a/flang/include/flang/Semantics/semantics.h
+++ b/flang/include/flang/Semantics/semantics.h
@@ -295,8 +295,10 @@ public:
   void UseFortranBuiltinsModule();
   const Scope *GetBuiltinsScope() const { return builtinsScope_; }
 
-  const Scope &GetCUDABuiltinsScope();
-  const Scope &GetCUDADeviceScope();
+  // Locate CUDA intrinsic modules on demand. These return null after emitting a
+  // diagnostic when the required module file cannot be read.
+  const Scope *GetCUDABuiltinsScope();
+  const Scope *GetCUDADeviceScope();
 
   void UsePPCBuiltinTypesModule();
   void UsePPCBuiltinsModule();

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -4937,12 +4937,13 @@ bool SubprogramVisitor::Pre(const parser::PrefixSpec::Attributes &attrs) {
         }
         // Implicitly USE the cudadevice module by copying its symbols in the
         // current scope.
-        const Scope &cudaDeviceScope{context().GetCUDADeviceScope()};
-        for (auto sym : cudaDeviceScope.GetSymbols()) {
-          if (!currScope().FindSymbol(sym->name())) {
-            auto &localSymbol{MakeSymbol(
-                sym->name(), Attrs{}, UseDetails{sym->name(), *sym})};
-            localSymbol.flags() = sym->flags();
+        if (const Scope *cudaDeviceScope{context().GetCUDADeviceScope()}) {
+          for (auto sym : cudaDeviceScope->GetSymbols()) {
+            if (!currScope().FindSymbol(sym->name())) {
+              auto &localSymbol{MakeSymbol(
+                  sym->name(), Attrs{}, UseDetails{sym->name(), *sym})};
+              localSymbol.flags() = sym->flags();
+            }
           }
         }
       }
@@ -9921,11 +9922,13 @@ bool ResolveNamesVisitor::Pre(const parser::SpecificationPart &x) {
 
 void ResolveNamesVisitor::UseCUDABuiltinNames() {
   if (FindCUDADeviceContext(&currScope())) {
-    for (const auto &[name, symbol] : context().GetCUDABuiltinsScope()) {
-      if (!FindInScope(name)) {
-        auto &localSymbol{MakeSymbol(name)};
-        localSymbol.set_details(UseDetails{name, *symbol});
-        localSymbol.flags() = symbol->flags();
+    if (const Scope *cudaBuiltinsScope{context().GetCUDABuiltinsScope()}) {
+      for (const auto &[name, symbol] : *cudaBuiltinsScope) {
+        if (!FindInScope(name)) {
+          auto &localSymbol{MakeSymbol(name)};
+          localSymbol.set_details(UseDetails{name, *symbol});
+          localSymbol.flags() = symbol->flags();
+        }
       }
     }
   }

--- a/flang/lib/Semantics/semantics.cpp
+++ b/flang/lib/Semantics/semantics.cpp
@@ -626,20 +626,31 @@ void SemanticsContext::UsePPCBuiltinTypesModule() {
   }
 }
 
-const Scope &SemanticsContext::GetCUDABuiltinsScope() {
-  if (!cudaBuiltinsScope_) {
-    cudaBuiltinsScope_ = GetBuiltinModule("__cuda_builtins");
-    CHECK(cudaBuiltinsScope_.value() != nullptr);
-  }
-  return **cudaBuiltinsScope_;
+static void SayMissingCUDAIntrinsicModule(
+    SemanticsContext &context, const char *moduleName) {
+  context.messages().Say(context.location().value_or(parser::CharBlock{}),
+      "Cannot read required CUDA intrinsic module '%s'; check -fintrinsic-modules-path or rebuild the Fortran intrinsic modules"_err_en_US,
+      moduleName);
 }
 
-const Scope &SemanticsContext::GetCUDADeviceScope() {
+const Scope *SemanticsContext::GetCUDABuiltinsScope() {
+  if (!cudaBuiltinsScope_) {
+    cudaBuiltinsScope_ = GetBuiltinModule("__cuda_builtins");
+    if (cudaBuiltinsScope_.value() == nullptr) {
+      SayMissingCUDAIntrinsicModule(*this, "__cuda_builtins");
+    }
+  }
+  return cudaBuiltinsScope_.value();
+}
+
+const Scope *SemanticsContext::GetCUDADeviceScope() {
   if (!cudaDeviceScope_) {
     cudaDeviceScope_ = GetBuiltinModule("cudadevice");
-    CHECK(cudaDeviceScope_.value() != nullptr);
+    if (cudaDeviceScope_.value() == nullptr) {
+      SayMissingCUDAIntrinsicModule(*this, "cudadevice");
+    }
   }
-  return **cudaDeviceScope_;
+  return cudaDeviceScope_.value();
 }
 
 void SemanticsContext::UsePPCBuiltinsModule() {

--- a/flang/test/Semantics/cuf-missing-intrinsic-modules.cuf
+++ b/flang/test/Semantics/cuf-missing-intrinsic-modules.cuf
@@ -1,0 +1,10 @@
+! RUN: not %flang_fc1 -module-suffix missingmod %s 2>&1 | FileCheck %s
+
+module m
+contains
+  attributes(device) subroutine devsubr()
+  end subroutine
+end module
+
+! CHECK: error: Cannot read required CUDA intrinsic module 'cudadevice'; check -fintrinsic-modules-path or rebuild the Fortran intrinsic modules
+! CHECK: error: Cannot read required CUDA intrinsic module '__cuda_builtins'; check -fintrinsic-modules-path or rebuild the Fortran intrinsic modules


### PR DESCRIPTION
- Replace CUDA intrinsic module `CHECK`s with actionable diagnostics when `cudadevice` or `__cuda_builtins` cannot be read.
- Avoid dereferencing missing CUDA module scopes during implicit CUDA symbol import.
- Add a semantics test covering the missing CUDA intrinsic module diagnostic.