### PR TITLE
[WebAssembly] Fix crash combining complex numbers and multivalue

### DIFF
--- a/clang/lib/CodeGen/Targets/WebAssembly.cpp
+++ b/clang/lib/CodeGen/Targets/WebAssembly.cpp
@@ -115,16 +115,20 @@ ABIArgInfo WebAssemblyABIInfo::classifyArgumentType(QualType Ty) const {
       return ABIArgInfo::getDirect(CGT.ConvertType(QualType(SeltTy, 0)));
     // For the experimental multivalue ABI, fully expand all other aggregates
     if (Kind == WebAssemblyABIKind::ExperimentalMV) {
-      const auto *RD = Ty->castAsRecordDecl();
-      bool HasBitField = false;
-      for (auto *Field : RD->fields()) {
-        if (Field->isBitField()) {
-          HasBitField = true;
-          break;
+      if (Ty->getAs<ComplexType>())
+        return ABIArgInfo::getDirect();
+      const auto *RD = Ty->getAsRecordDecl();
+      if (RD) {
+        bool HasBitField = false;
+        for (auto *Field : RD->fields()) {
+          if (Field->isBitField()) {
+            HasBitField = true;
+            break;
+          }
         }
+        if (!HasBitField)
+          return ABIArgInfo::getExpand();
       }
-      if (!HasBitField)
-        return ABIArgInfo::getExpand();
     }
   }
 

--- a/clang/test/CodeGen/WebAssembly/wasm-arguments.c
+++ b/clang/test/CodeGen/WebAssembly/wasm-arguments.c
@@ -138,3 +138,13 @@ bitfield1 bitfield_ret(void) {
   bitfield1 baz;
   return baz;
 }
+
+// Complex numbers are expanded in parameter position for the multivalue
+// experimental ABI.
+
+// WEBASSEMBLY32: define void @complex_double(ptr
+// WEBASSEMBLY64: define void @complex_double(ptr
+// EXPERIMENTAL-MV: define void @complex_double(double {{.*}}, double {{.*}})
+void complex_double(_Complex double a) {
+  // ..
+}


### PR DESCRIPTION
This fixes a crash in Clang when the `experimental-mv` ABI is used on WebAssembly targets in conjunction with complex numbers as arguments. There's no strict definition for what the multivalue ABI is at this time, so the main goal is to just not crash for now.

Closes #70402
Closes #153567