### PR TITLE
[lldb][Darwin] Correct jGetLoadedDynamicLibrariesInfos typeo & fallback

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -446,7 +446,7 @@ bool DynamicLoaderDarwin::JSONImageInformationIntoImageInfo(
         mh->GetValueForKey("cpusubtype")->GetUnsignedIntegerValue();
     image_infos[i].header.filetype =
         mh->GetValueForKey("filetype")->GetUnsignedIntegerValue();
-    if (mh->HasKey("sizeof_h_and_loadcmds"))
+    if (mh->HasKey("sizeof_mh_and_loadcmds"))
       image_infos[i].mh_and_load_cmd_size =
           mh->GetValueForKey("sizeof_mh_and_loadcmds")
               ->GetUnsignedIntegerValue();

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.h
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.h
@@ -124,9 +124,9 @@ protected:
     /// When we need to read a binary's mach header and load commands
     /// out of memory, this specifies how much to read to get
     /// everything in one read packet, if known.  Increase the
-    /// default 512 bytes to 3192 which is enough to include most
+    /// default 512 bytes to 8192 which is enough to include most
     /// mach header + load commands.
-    uint32_t mh_and_load_cmd_size = 3192;
+    uint32_t mh_and_load_cmd_size = 8192;
 
     ImageInfo() = default;
 
@@ -143,7 +143,7 @@ protected:
       os_type = llvm::Triple::OSType::UnknownOS;
       os_env = llvm::Triple::EnvironmentType::UnknownEnvironment;
       min_version_os_sdk.clear();
-      mh_and_load_cmd_size = 3192;
+      mh_and_load_cmd_size = 8192;
     }
 
     bool operator==(const ImageInfo &rhs) const {


### PR DESCRIPTION
Jonas caught that I had a typeo in checking for the `sizeof_mh_and_loadcmds` key in the `jGetLoadedDynamicLibrariesInfos` response from debugserver in DyanmicLoaderDarwin.  Fix that.

Also I originally picked a fallback value for the mach header + load commands as a guess.  I've sinced looked at a large UI app's binaries and based on the size of their actual mh+load commands, picked a default that will read all the data needed in the majority of cases.

rdar://178283767