### PR TITLE
[Bazel] Add inl files to nanobind textual headers

### DIFF
--- a/utils/bazel/third_party_build/nanobind.BUILD
+++ b/utils/bazel/third_party_build/nanobind.BUILD
@@ -26,6 +26,7 @@ cc_library(
     textual_hdrs = glob(
         [
             "include/**/*.h",
+            "include/**/*.inl",
             "src/*.h",
         ],
     ),


### PR DESCRIPTION
When using this overlay to build some bindings I noticed that counter.inl was not available in the sandbox and the build failed. This line adds it to the sandbox.