### PR TITLE
[SandboxVec][LoadStoreVec][AMDGPU] Remove early reject of mixed types

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/LoadStoreVec.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/LoadStoreVec.cpp
@@ -9,13 +9,21 @@
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/Passes/LoadStoreVec.h"
 #include "llvm/SandboxIR/Module.h"
 #include "llvm/SandboxIR/Region.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/InstructionCost.h"
+#include "llvm/Transforms/Vectorize/SandboxVectorizer/Debug.h"
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/Legality.h"
+#include "llvm/Transforms/Vectorize/SandboxVectorizer/RegionWithScore.h"
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h"
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/VecUtils.h"
 
 namespace llvm {
 
+extern cl::opt<int> CostThreshold; // Defined in TransactionAcceptOrRevert.cpp
+
 namespace sandboxir {
+
+#define DEBUG_PREFIX_LOCAL DEBUG_PREFIX "LoadStoreVec: "
 
 std::optional<Type *> LoadStoreVec::canVectorize(ArrayRef<Instruction *> Bndl,
                                                  Scheduler &Sched) {
@@ -25,19 +33,6 @@ std::optional<Type *> LoadStoreVec::canVectorize(ArrayRef<Instruction *> Bndl,
 
   // Check if instructions repeat.
   if (!LegalityAnalysis::areUnique(Bndl))
-    return std::nullopt;
-
-  // TODO: This is target-dependent.
-  // Don't mix integer with floating point.
-  bool IsFloat = false;
-  bool IsInteger = false;
-  for ([[maybe_unused]] auto *I : Bndl) {
-    if (Utils::getExpectedType(I)->getScalarType()->isFloatingPointTy())
-      IsFloat = true;
-    else
-      IsInteger = true;
-  }
-  if (IsFloat && IsInteger)
     return std::nullopt;
 
   // Check scheduling.
@@ -83,6 +78,9 @@ bool LoadStoreVec::runOnRegion(Region &Rgn, const Analyses &A) {
   if (!canVectorize(Bndl, Sched))
     return false;
 
+  const auto &SB = cast<RegionWithScore>(Rgn).getScoreboard();
+  InstructionCost CostBefore = SB.getAfterCost() - SB.getBeforeCost();
+
   SmallVector<Value *, 4> Operands;
   Operands.reserve(Bndl.size());
   for (auto *I : Bndl) {
@@ -109,6 +107,10 @@ bool LoadStoreVec::runOnRegion(Region &Rgn, const Analyses &A) {
   if (!AllLoads && !AllConstants)
     return false;
 
+  // Vectorizing mixed floats and integers with external uses may not be
+  // profitable on some targets, so save state here.
+  Ctx.save();
+
   Value *VecOp = nullptr;
   if (AllLoads) {
     // TODO: Try to avoid the extra copy to an instruction vector.
@@ -119,10 +121,14 @@ bool LoadStoreVec::runOnRegion(Region &Rgn, const Analyses &A) {
 
     bool Consecutive = VecUtils::areConsecutive<LoadInst, Instruction>(
         Loads, A.getScalarEvolution(), *DL);
-    if (!Consecutive)
+    if (!Consecutive) {
+      Ctx.accept();
       return false;
-    if (!canVectorize(Loads, Sched))
+    }
+    if (!canVectorize(Loads, Sched)) {
+      Ctx.accept();
       return false;
+    }
 
     // Generate vector load.
     Type *Ty = VecUtils::getCombinedVectorTypeFor(Bndl, *DL);
@@ -163,6 +169,20 @@ bool LoadStoreVec::runOnRegion(Region &Rgn, const Analyses &A) {
   StoreInst::create(VecOp, StPtr, StAlign, StWhereIt, Ctx);
 
   tryEraseDeadInstrs(Bndl, Operands);
+
+  // Check the cost.
+  InstructionCost CostAfter = SB.getAfterCost() - SB.getBeforeCost();
+  InstructionCost CostGain = CostAfter - CostBefore;
+  LLVM_DEBUG(dbgs() << DEBUG_PREFIX_LOCAL << "CostGain=" << CostGain
+                    << " (After=" << CostAfter << " Before=" << CostBefore
+                    << ")\n");
+  if (CostGain > CostThreshold) {
+    LLVM_DEBUG(dbgs() << DEBUG_PREFIX_LOCAL << "Not profitable, reverting.\n");
+    Ctx.revert();
+    return false;
+  }
+  LLVM_DEBUG(dbgs() << DEBUG_PREFIX_LOCAL << "Profitable accepting.\n");
+  Ctx.accept();
   return true;
 }
 

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/TransactionAcceptOrRevert.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/TransactionAcceptOrRevert.cpp
@@ -14,9 +14,8 @@
 
 namespace llvm {
 
-static cl::opt<int> CostThreshold("sbvec-cost-threshold", cl::init(0),
-                                  cl::Hidden,
-                                  cl::desc("Vectorization cost threshold."));
+cl::opt<int> CostThreshold("sbvec-cost-threshold", cl::init(0), cl::Hidden,
+                           cl::desc("Vectorization cost threshold."));
 
 namespace sandboxir {
 

--- a/llvm/test/Transforms/SandboxVectorizer/load_store_vec.ll
+++ b/llvm/test/Transforms/SandboxVectorizer/load_store_vec.ll
@@ -139,11 +139,8 @@ define void @load_store_vec_mixed_int_float(ptr %ptr) {
 ; CHECK-LABEL: define void @load_store_vec_mixed_int_float(
 ; CHECK-SAME: ptr [[PTR:%.*]]) {
 ; CHECK-NEXT:    [[PTR0:%.*]] = getelementptr i32, ptr [[PTR]], i32 0
-; CHECK-NEXT:    [[PTR1:%.*]] = getelementptr i32, ptr [[PTR]], i32 1
-; CHECK-NEXT:    [[LD0:%.*]] = load i32, ptr [[PTR0]], align 4
-; CHECK-NEXT:    [[LD1:%.*]] = load float, ptr [[PTR1]], align 4
-; CHECK-NEXT:    store i32 [[LD0]], ptr [[PTR0]], align 4, !sandboxvec [[META7:![0-9]+]]
-; CHECK-NEXT:    store float [[LD1]], ptr [[PTR1]], align 4, !sandboxvec [[META7]]
+; CHECK-NEXT:    [[VECIINITL:%.*]] = load <2 x i32>, ptr [[PTR0]], align 1, !sandboxvec [[META7:![0-9]+]]
+; CHECK-NEXT:    store <2 x i32> [[VECIINITL]], ptr [[PTR0]], align 1, !sandboxvec [[META7]]
 ; CHECK-NEXT:    ret void
 ;
   %ptr0 = getelementptr i32, ptr %ptr, i32 0
@@ -159,11 +156,8 @@ define void @load_store_vec_mixed_int_float_vectors(ptr %ptr) {
 ; CHECK-LABEL: define void @load_store_vec_mixed_int_float_vectors(
 ; CHECK-SAME: ptr [[PTR:%.*]]) {
 ; CHECK-NEXT:    [[PTR0:%.*]] = getelementptr i32, ptr [[PTR]], i32 0
-; CHECK-NEXT:    [[PTR1:%.*]] = getelementptr i32, ptr [[PTR]], i32 1
-; CHECK-NEXT:    [[LD0:%.*]] = load i32, ptr [[PTR0]], align 4
-; CHECK-NEXT:    [[LD1:%.*]] = load <2 x float>, ptr [[PTR1]], align 8
-; CHECK-NEXT:    store i32 [[LD0]], ptr [[PTR0]], align 4, !sandboxvec [[META8:![0-9]+]]
-; CHECK-NEXT:    store <2 x float> [[LD1]], ptr [[PTR1]], align 8, !sandboxvec [[META8]]
+; CHECK-NEXT:    [[VECIINITL:%.*]] = load <3 x i32>, ptr [[PTR0]], align 1, !sandboxvec [[META8:![0-9]+]]
+; CHECK-NEXT:    store <3 x i32> [[VECIINITL]], ptr [[PTR0]], align 1, !sandboxvec [[META8]]
 ; CHECK-NEXT:    ret void
 ;
   %ptr0 = getelementptr i32, ptr %ptr, i32 0

--- a/llvm/test/Transforms/SandboxVectorizer/load_store_vec_mixed_types.ll
+++ b/llvm/test/Transforms/SandboxVectorizer/load_store_vec_mixed_types.ll
@@ -5,11 +5,8 @@
 define void @mixed_int_float(ptr %ptr0) {
 ; CHECK-LABEL: define void @mixed_int_float(
 ; CHECK-SAME: ptr [[PTR0:%.*]]) {
-; CHECK-NEXT:    [[PTR1:%.*]] = getelementptr inbounds i8, ptr [[PTR0]], i64 4
-; CHECK-NEXT:    [[LD0:%.*]] = load i32, ptr [[PTR0]], align 4
-; CHECK-NEXT:    [[LD1:%.*]] = load float, ptr [[PTR1]], align 4
-; CHECK-NEXT:    store i32 [[LD0]], ptr [[PTR0]], align 4, !sandboxvec [[META0:![0-9]+]]
-; CHECK-NEXT:    store float [[LD1]], ptr [[PTR1]], align 4, !sandboxvec [[META0]]
+; CHECK-NEXT:    [[VECIINITL:%.*]] = load <2 x i32>, ptr [[PTR0]], align 1, !sandboxvec [[META0:![0-9]+]]
+; CHECK-NEXT:    store <2 x i32> [[VECIINITL]], ptr [[PTR0]], align 1, !sandboxvec [[META0]]
 ; CHECK-NEXT:    ret void
 ;
   %ptr1 = getelementptr inbounds i8, ptr %ptr0, i64 4
@@ -26,11 +23,8 @@ define void @mixed_int_float(ptr %ptr0) {
 define void @mixed_int_vector_float(ptr %ptr) {
 ; CHECK-LABEL: define void @mixed_int_vector_float(
 ; CHECK-SAME: ptr [[PTR:%.*]]) {
-; CHECK-NEXT:    [[PTR_4:%.*]] = getelementptr inbounds i8, ptr [[PTR]], i64 4
-; CHECK-NEXT:    [[LD_0_3:%.*]] = load i32, ptr [[PTR]], align 4
-; CHECK-NEXT:    [[LD_4_LOAD:%.*]] = load <2 x half>, ptr [[PTR_4]], align 4
-; CHECK-NEXT:    store i32 [[LD_0_3]], ptr [[PTR]], align 4, !sandboxvec [[META1:![0-9]+]]
-; CHECK-NEXT:    store <2 x half> [[LD_4_LOAD]], ptr [[PTR_4]], align 4, !sandboxvec [[META1]]
+; CHECK-NEXT:    [[VECIINITL:%.*]] = load <4 x half>, ptr [[PTR]], align 1, !sandboxvec [[META1:![0-9]+]]
+; CHECK-NEXT:    store <4 x half> [[VECIINITL]], ptr [[PTR]], align 1, !sandboxvec [[META1]]
 ; CHECK-NEXT:    ret void
 ;
   %ptr_4 = getelementptr inbounds i8, ptr %ptr, i64 4
@@ -65,11 +59,8 @@ define void @mixed_int_pointer(ptr %ptr) {
 define void @mixed_dboule_pointer(ptr %ptr) {
 ; CHECK-LABEL: define void @mixed_dboule_pointer(
 ; CHECK-SAME: ptr [[PTR:%.*]]) {
-; CHECK-NEXT:    [[PTR_8:%.*]] = getelementptr inbounds i8, ptr [[PTR]], i64 8
-; CHECK-NEXT:    [[LD_0_7:%.*]] = load double, ptr [[PTR]], align 8
-; CHECK-NEXT:    [[LD_8_15:%.*]] = load ptr, ptr [[PTR_8]], align 8
-; CHECK-NEXT:    store double [[LD_0_7]], ptr [[PTR]], align 8, !sandboxvec [[META3:![0-9]+]]
-; CHECK-NEXT:    store ptr [[LD_8_15]], ptr [[PTR_8]], align 8, !sandboxvec [[META3]]
+; CHECK-NEXT:    [[VECIINITL:%.*]] = load <2 x double>, ptr [[PTR]], align 1, !sandboxvec [[META3:![0-9]+]]
+; CHECK-NEXT:    store <2 x double> [[VECIINITL]], ptr [[PTR]], align 1, !sandboxvec [[META3]]
 ; CHECK-NEXT:    ret void
 ;
   %ptr_8 = getelementptr inbounds i8, ptr %ptr, i64 8


### PR DESCRIPTION
Up until now mixing floats and non-floats was disabled in the legality checks. This patch changes this. We are now eagerly vectorizing mixed types, but we are also checking the cost model to make sure we don't regress on targets where this is expensive.