### PR TITLE
[compiler-rt] Write ASAN/TSAN reports to a global for crash reporting

### DIFF
--- a/compiler-rt/lib/asan/asan_descriptions.cpp
+++ b/compiler-rt/lib/asan/asan_descriptions.cpp
@@ -444,6 +444,36 @@ void HeapAddressDescription::Print() const {
   DescribeThread(alloc_thread);
 }
 
+#if SANITIZER_APPLE
+void HeapAddressDescription::GetDarwinStacks(
+    InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks) const {
+  asanThreadRegistry().CheckLocked();
+  AsanThreadContext* alloc_thread = GetThreadContextByTidLocked(alloc_tid);
+  StackTrace alloc_stack = GetStackTraceFromId(alloc_stack_id);
+
+  GetDarwinStack(stacks, alloc_thread->unique_id, &alloc_stack,
+                 LLVM_SANITIZER_V1_STACK_TYPE_ALLOCATION, "Allocated");
+
+  if (free_tid != kInvalidTid) {
+    AsanThreadContext* free_thread = GetThreadContextByTidLocked(free_tid);
+    StackTrace free_stack = GetStackTraceFromId(free_stack_id);
+    GetDarwinStack(stacks, free_thread->unique_id, &free_stack,
+                   LLVM_SANITIZER_V1_STACK_TYPE_DEALLOCATION, "Freed");
+  }
+}
+
+void StackAddressDescription::GetDarwinStacks(
+    InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks) const {
+  if (!frame_descr)
+    return;
+  asanThreadRegistry().CheckLocked();
+  AsanThreadContext* stack_thread = GetThreadContextByTidLocked(tid);
+  StackTrace alloca_stack(&frame_pc, 1);
+  GetDarwinStack(stacks, stack_thread->unique_id, &alloca_stack,
+                 LLVM_SANITIZER_V1_STACK_TYPE_ALLOCATION, "Allocated on stack");
+}
+#endif
+
 AddressDescription::AddressDescription(uptr addr, uptr access_size,
                                        bool shouldLockThreadRegistry) {
   if (GetShadowAddressInformation(addr, &data.shadow)) {

--- a/compiler-rt/lib/asan/asan_descriptions.h
+++ b/compiler-rt/lib/asan/asan_descriptions.h
@@ -124,6 +124,13 @@ struct HeapAddressDescription {
   ChunkAccess chunk_access;
 
   void Print() const;
+
+#if SANITIZER_APPLE
+  // Writes up to 2 stack traces in the Darwin sanitizer stack format.
+  // Return value is the number of stacks written
+  void GetDarwinStacks(
+      InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks) const;
+#endif
 };
 
 bool GetHeapAddressInformation(uptr addr, uptr access_size,
@@ -139,6 +146,13 @@ struct StackAddressDescription {
   const char *frame_descr;
 
   void Print() const;
+
+#if SANITIZER_APPLE
+  // Writes a single stack trace in the Darwin sanitizer stack format
+  // describing the frame where the alloca occurred.
+  void GetDarwinStacks(
+      InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks) const;
+#endif
 };
 
 bool GetStackAddressInformation(uptr addr, uptr access_size,
@@ -245,6 +259,24 @@ class AddressDescription {
     }
     UNREACHABLE("AddressInformation kind is invalid");
   }
+
+#if SANITIZER_APPLE
+  void GetDarwinStacks(
+      InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks)
+      const {
+    switch (data.kind) {
+      case kAddressKindHeap:
+        return data.heap.GetDarwinStacks(stacks);
+      case kAddressKindStack:
+        return data.stack.GetDarwinStacks(stacks);
+      case kAddressKindWild:
+      case kAddressKindShadow:
+      case kAddressKindGlobal:
+        return;
+    }
+    UNREACHABLE("AddressInformation kind is invalid");
+  }
+#endif
 
   void StoreTo(AddressDescriptionData *dst) const { *dst = data; }
 

--- a/compiler-rt/lib/asan/asan_errors.cpp
+++ b/compiler-rt/lib/asan/asan_errors.cpp
@@ -60,6 +60,16 @@ void ErrorDoubleFree::Print() {
   ReportErrorSummary(scariness.GetDescription(), &stack);
 }
 
+#if SANITIZER_APPLE
+void ErrorDoubleFree::GetDarwinStacks(
+    InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks) {
+  GetDarwinStack(stacks, GetThreadContextByTidLocked(tid)->unique_id,
+                 second_free_stack, LLVM_SANITIZER_V1_STACK_TYPE_OTHER,
+                 "Second free");
+  addr_description.GetDarwinStacks(stacks);
+}
+#endif
+
 void ErrorNewDeleteTypeMismatch::Print() {
   Decorator d;
   Printf("%s", d.Error());
@@ -99,6 +109,16 @@ void ErrorNewDeleteTypeMismatch::Print() {
       "HINT: if you don't care about these errors you may set "
       "ASAN_OPTIONS=new_delete_type_mismatch=0\n");
 }
+
+#if SANITIZER_APPLE
+void ErrorNewDeleteTypeMismatch::GetDarwinStacks(
+    InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks) {
+  GetDarwinStack(stacks, GetThreadContextByTidLocked(tid)->unique_id,
+                 free_stack, LLVM_SANITIZER_V1_STACK_TYPE_DEALLOCATION,
+                 "Mismatched delete");
+  addr_description.GetDarwinStacks(stacks);
+}
+#endif
 
 void ErrorFreeSizeMismatch::Print() {
   Decorator d;
@@ -141,6 +161,16 @@ void ErrorFreeSizeMismatch::Print() {
       "ASAN_OPTIONS=free_size_mismatch=0\n");
 }
 
+#if SANITIZER_APPLE
+void ErrorFreeSizeMismatch::GetDarwinStacks(
+    InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks) {
+  GetDarwinStack(stacks, GetThreadContextByTidLocked(tid)->unique_id,
+                 free_stack, LLVM_SANITIZER_V1_STACK_TYPE_DEALLOCATION,
+                 isFreeAlignedSized() ? "free_aligned_sized" : "free_sized");
+  addr_description.GetDarwinStacks(stacks);
+}
+#endif
+
 void ErrorFreeNotMalloced::Print() {
   Decorator d;
   Printf("%s", d.Error());
@@ -156,6 +186,15 @@ void ErrorFreeNotMalloced::Print() {
   addr_description.Print();
   ReportErrorSummary(scariness.GetDescription(), &stack);
 }
+
+#if SANITIZER_APPLE
+void ErrorFreeNotMalloced::GetDarwinStacks(
+    InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks) {
+  GetDarwinStack(stacks, GetThreadContextByTidLocked(tid)->unique_id,
+                 free_stack, LLVM_SANITIZER_V1_STACK_TYPE_DEALLOCATION, "Free");
+  addr_description.GetDarwinStacks(stacks);
+}
+#endif
 
 void ErrorAllocTypeMismatch::Print() {
   static const char *alloc_names[] = {"INVALID", "malloc", "operator new",
@@ -180,6 +219,16 @@ void ErrorAllocTypeMismatch::Print() {
       "ASAN_OPTIONS=alloc_dealloc_mismatch=0\n");
 }
 
+#if SANITIZER_APPLE
+void ErrorAllocTypeMismatch::GetDarwinStacks(
+    InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks) {
+  GetDarwinStack(stacks, GetThreadContextByTidLocked(tid)->unique_id,
+                 dealloc_stack, LLVM_SANITIZER_V1_STACK_TYPE_DEALLOCATION,
+                 "Deallocation");
+  addr_description.GetDarwinStacks(stacks);
+}
+#endif
+
 void ErrorMallocUsableSizeNotOwned::Print() {
   Decorator d;
   Printf("%s", d.Error());
@@ -193,6 +242,15 @@ void ErrorMallocUsableSizeNotOwned::Print() {
   ReportErrorSummary(scariness.GetDescription(), stack);
 }
 
+#if SANITIZER_APPLE
+void ErrorMallocUsableSizeNotOwned::GetDarwinStacks(
+    InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks) {
+  GetDarwinStack(stacks, GetThreadContextByTidLocked(tid)->unique_id, stack,
+                 LLVM_SANITIZER_V1_STACK_TYPE_OTHER, "malloc_usable_size");
+  addr_description.GetDarwinStacks(stacks);
+}
+#endif
+
 void ErrorSanitizerGetAllocatedSizeNotOwned::Print() {
   Decorator d;
   Printf("%s", d.Error());
@@ -205,6 +263,16 @@ void ErrorSanitizerGetAllocatedSizeNotOwned::Print() {
   addr_description.Print();
   ReportErrorSummary(scariness.GetDescription(), stack);
 }
+
+#if SANITIZER_APPLE
+void ErrorSanitizerGetAllocatedSizeNotOwned::GetDarwinStacks(
+    InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks) {
+  GetDarwinStack(stacks, GetThreadContextByTidLocked(tid)->unique_id, stack,
+                 LLVM_SANITIZER_V1_STACK_TYPE_OTHER,
+                 "__sanitizer_get_allocated_size");
+  addr_description.GetDarwinStacks(stacks);
+}
+#endif
 
 void ErrorCallocOverflow::Print() {
   Decorator d;
@@ -349,6 +417,16 @@ void ErrorStringFunctionMemoryRangesOverlap::Print() {
   ReportErrorSummary(bug_type, stack);
 }
 
+#if SANITIZER_APPLE
+void ErrorStringFunctionMemoryRangesOverlap::GetDarwinStacks(
+    InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks) {
+  GetDarwinStack(stacks, GetThreadContextByTidLocked(tid)->unique_id, stack,
+                 LLVM_SANITIZER_V1_STACK_TYPE_OTHER, function);
+  addr1_description.GetDarwinStacks(stacks);
+  addr2_description.GetDarwinStacks(stacks);
+}
+#endif
+
 void ErrorStringFunctionSizeOverflow::Print() {
   Decorator d;
   Printf("%s", d.Error());
@@ -360,6 +438,15 @@ void ErrorStringFunctionSizeOverflow::Print() {
   addr_description.Print();
   ReportErrorSummary(scariness.GetDescription(), stack);
 }
+
+#if SANITIZER_APPLE
+void ErrorStringFunctionSizeOverflow::GetDarwinStacks(
+    InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks) {
+  GetDarwinStack(stacks, GetThreadContextByTidLocked(tid)->unique_id, stack,
+                 LLVM_SANITIZER_V1_STACK_TYPE_OTHER, "String function");
+  addr_description.GetDarwinStacks(stacks);
+}
+#endif
 
 void ErrorBadParamsToAnnotateContiguousContainer::Print() {
   Report(
@@ -448,6 +535,14 @@ void ErrorInvalidPointerPair::Print() {
   addr2_description.Print();
   ReportErrorSummary(scariness.GetDescription(), &stack);
 }
+
+#if SANITIZER_APPLE
+void ErrorInvalidPointerPair::GetDarwinStacks(
+    InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks) {
+  addr1_description.GetDarwinStacks(stacks);
+  addr2_description.GetDarwinStacks(stacks);
+}
+#endif
 
 static bool AdjacentShadowValuesAreFullyPoisoned(u8 *s) {
   return s[-1] > 127 && s[1] > 127;
@@ -709,5 +804,12 @@ void ErrorGeneric::Print() {
     CheckPoisonRecords(addr);
   }
 }
+
+#if SANITIZER_APPLE
+void ErrorGeneric::GetDarwinStacks(
+    InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks) {
+  addr_description.GetDarwinStacks(stacks);
+}
+#endif
 
 }  // namespace __asan

--- a/compiler-rt/lib/asan/asan_errors.h
+++ b/compiler-rt/lib/asan/asan_errors.h
@@ -491,8 +491,10 @@ struct ErrorGeneric : ErrorBase {
   ErrorGeneric(u32 tid, uptr pc_, uptr bp_, uptr sp_, uptr addr, bool is_write_,
                uptr access_size_);
   void Print();
+#if SANITIZER_APPLE
   void GetDarwinStacks(
       InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks);
+#endif
 };
 
 // clang-format off

--- a/compiler-rt/lib/asan/asan_errors.h
+++ b/compiler-rt/lib/asan/asan_errors.h
@@ -34,6 +34,11 @@ struct ErrorBase {
     scariness.Clear();
     scariness.Scare(initial_score, reason);
   }
+#if SANITIZER_APPLE
+  // By default, errors do not report any stacks
+  void GetDarwinStacks(
+      InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks) {}
+#endif
 };
 
 struct ErrorDeadlySignal : ErrorBase {
@@ -76,6 +81,11 @@ struct ErrorDoubleFree : ErrorBase {
     GetHeapAddressInformation(addr, 1, &addr_description);
   }
   void Print();
+
+#if SANITIZER_APPLE
+  void GetDarwinStacks(
+      InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks);
+#endif
 };
 
 struct ErrorNewDeleteTypeMismatch : ErrorBase {
@@ -94,6 +104,11 @@ struct ErrorNewDeleteTypeMismatch : ErrorBase {
     GetHeapAddressInformation(addr, 1, &addr_description);
   }
   void Print();
+
+#if SANITIZER_APPLE
+  void GetDarwinStacks(
+      InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks);
+#endif
 };
 
 struct ErrorFreeSizeMismatch : ErrorBase {
@@ -113,6 +128,11 @@ struct ErrorFreeSizeMismatch : ErrorBase {
   }
   void Print();
   bool isFreeAlignedSized() const { return delete_alignment != 0; }
+
+#if SANITIZER_APPLE
+  void GetDarwinStacks(
+      InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks);
+#endif
 };
 
 struct ErrorFreeNotMalloced : ErrorBase {
@@ -125,6 +145,11 @@ struct ErrorFreeNotMalloced : ErrorBase {
         free_stack(stack),
         addr_description(addr, /*shouldLockThreadRegistry=*/false) {}
   void Print();
+
+#if SANITIZER_APPLE
+  void GetDarwinStacks(
+      InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks);
+#endif
 };
 
 struct ErrorAllocTypeMismatch : ErrorBase {
@@ -141,6 +166,11 @@ struct ErrorAllocTypeMismatch : ErrorBase {
         dealloc_type(dealloc_type_),
         addr_description(addr, 1, false) {}
   void Print();
+
+#if SANITIZER_APPLE
+  void GetDarwinStacks(
+      InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks);
+#endif
 };
 
 struct ErrorMallocUsableSizeNotOwned : ErrorBase {
@@ -153,6 +183,11 @@ struct ErrorMallocUsableSizeNotOwned : ErrorBase {
         stack(stack_),
         addr_description(addr, /*shouldLockThreadRegistry=*/false) {}
   void Print();
+
+#if SANITIZER_APPLE
+  void GetDarwinStacks(
+      InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks);
+#endif
 };
 
 struct ErrorSanitizerGetAllocatedSizeNotOwned : ErrorBase {
@@ -166,6 +201,11 @@ struct ErrorSanitizerGetAllocatedSizeNotOwned : ErrorBase {
         stack(stack_),
         addr_description(addr, /*shouldLockThreadRegistry=*/false) {}
   void Print();
+
+#if SANITIZER_APPLE
+  void GetDarwinStacks(
+      InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks);
+#endif
 };
 
 struct ErrorCallocOverflow : ErrorBase {
@@ -314,6 +354,11 @@ struct ErrorStringFunctionMemoryRangesOverlap : ErrorBase {
     scariness.Scare(10, bug_type);
   }
   void Print();
+
+#if SANITIZER_APPLE
+  void GetDarwinStacks(
+      InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks);
+#endif
 };
 
 struct ErrorStringFunctionSizeOverflow : ErrorBase {
@@ -331,6 +376,11 @@ struct ErrorStringFunctionSizeOverflow : ErrorBase {
         size(size),
         is_write(is_write) {}
   void Print();
+
+#if SANITIZER_APPLE
+  void GetDarwinStacks(
+      InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks);
+#endif
 };
 
 struct ErrorBadParamsToAnnotateContiguousContainer : ErrorBase {
@@ -422,6 +472,11 @@ struct ErrorInvalidPointerPair : ErrorBase {
         addr1_description(p1, 1, /*shouldLockThreadRegistry=*/false),
         addr2_description(p2, 1, /*shouldLockThreadRegistry=*/false) {}
   void Print();
+
+#if SANITIZER_APPLE
+  void GetDarwinStacks(
+      InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks);
+#endif
 };
 
 struct ErrorGeneric : ErrorBase {
@@ -436,6 +491,8 @@ struct ErrorGeneric : ErrorBase {
   ErrorGeneric(u32 tid, uptr pc_, uptr bp_, uptr sp_, uptr addr, bool is_write_,
                uptr access_size_);
   void Print();
+  void GetDarwinStacks(
+      InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks);
 };
 
 // clang-format off
@@ -509,7 +566,6 @@ struct ErrorDescription {
   }
 };
 
-#undef ASAN_FOR_EACH_ERROR_KIND
 #undef ASAN_DEFINE_ERROR_KIND
 #undef ASAN_ERROR_DESCRIPTION_MEMBER
 #undef ASAN_ERROR_DESCRIPTION_CONSTRUCTOR

--- a/compiler-rt/lib/asan/asan_report.cpp
+++ b/compiler-rt/lib/asan/asan_report.cpp
@@ -211,6 +211,45 @@ class ScopedInErrorReport {
       SetAbortMessage(buffer_copy.data());
     }
 
+#if SANITIZER_APPLE
+    if (common_flags()->crashreporter_global) {
+      asanThreadRegistry().Lock();
+      InternalMmapVector<llvm_sanitizer_report_payload_stack_v1> stacks;
+      stacks.reserve(4);
+      const char* error_name = "<unknown>";
+
+#  define ASAN_ERROR_DARWIN_STACKS(name)           \
+    case kErrorKind##name:                         \
+      current_error_.name.GetDarwinStacks(stacks); \
+      error_name = "" #name;                       \
+      break;
+
+      switch (current_error_.kind) {
+        ASAN_FOR_EACH_ERROR_KIND(ASAN_ERROR_DARWIN_STACKS)
+        default:
+          break;
+      }
+
+      uptr fault_address = 0;
+      const HeapAddressDescription* heap = NULL;
+      switch (current_error_.kind) {
+        case kErrorKindGeneric: {
+          error_name = current_error_.Generic.bug_descr;
+          fault_address = current_error_.Generic.addr_description.Address();
+          heap = current_error_.Generic.addr_description.AsHeap();
+          break;
+        }
+        default:
+          break;
+      }
+
+      SetCrashReporterGlobalForReport(
+          error_name, fault_address, heap ? heap->chunk_access.chunk_begin : 0,
+          heap ? heap->chunk_access.chunk_size : 0, stacks);
+      asanThreadRegistry().Unlock();
+    }
+#endif
+
     // In halt_on_error = false mode, reset the current error object (before
     // unlocking).
     if (!halt_on_error_)

--- a/compiler-rt/lib/sanitizer_common/sanitizer_flags.inc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_flags.inc
@@ -258,6 +258,11 @@ COMMON_FLAG(
     bool, abort_on_error, (bool)SANITIZER_ANDROID || (bool)SANITIZER_APPLE,
     "If set, the tool calls abort() instead of _exit() after printing the "
     "error report.")
+#if SANITIZER_APPLE
+COMMON_FLAG(bool, crashreporter_global, (bool)SANITIZER_APPLE,
+            "Uses a global to communicate sanitizer report information to the "
+            "Darwin crash reporting system")
+#endif
 COMMON_FLAG(bool, suppress_equal_pcs, true,
             "Deduplicate multiple reports for single source location in "
             "halt_on_error=false mode (asan only).")

--- a/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
@@ -36,6 +36,7 @@
 #  include "sanitizer_platform_limits_posix.h"
 #  include "sanitizer_procmaps.h"
 #  include "sanitizer_ptrauth.h"
+#  include "sanitizer_stacktrace.h"
 
 #  if !SANITIZER_IOS
 #    include <crt_externs.h>  // for _NSGetEnviron
@@ -112,6 +113,8 @@ extern "C" {
 SANITIZER_WEAK_ATTRIBUTE extern void __tsan_set_in_internal_write_call(
     bool value) {}
 #  endif
+
+llvm_sanitizer_report_payload llvm_sanitizer_report_global;
 
 namespace __sanitizer {
 
@@ -1604,6 +1607,50 @@ void InstallPthreadIntrospectionHook(const ThreadEventCallbacks &callbacks) {
   thread_event_callbacks = callbacks;
   prev_pthread_introspection_hook =
       pthread_introspection_hook_install(&sanitizer_pthread_introspection_hook);
+}
+
+void GetDarwinStack(
+    InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks, int tid,
+    const StackTrace* s, uint16_t type, const char* description,
+    bool includeThreadName) {
+  stacks.resize(stacks.size() + 1);
+  llvm_sanitizer_report_payload_stack_v1& res = stacks.back();
+  res.type = type;
+  res.stack.thread_id = tid;
+  res.stack.time = 0;
+  res.stack.num_frames = Min(
+      (size_t)s->size, sizeof(res.stack.frames) / sizeof(res.stack.frames[0]));
+  for (size_t i = 0; i < res.stack.num_frames; i++) {
+    res.stack.frames[i] = s->trace[res.stack.num_frames - i - 1];
+  }
+  if (includeThreadName) {
+    internal_snprintf(res.description, sizeof(res.description),
+                      "%s by thread %d", description, tid);
+  } else {
+    internal_strncpy(res.description, description, sizeof(res.description));
+  }
+}
+
+void SetCrashReporterGlobalForReport(
+    const char* error_name, uptr fault_addr, uptr allocation_addr,
+    uptr allocation_size,
+    const InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks) {
+  llvm_sanitizer_report_global.vers = 1;
+  internal_strncpy(llvm_sanitizer_report_global.v1.category, SanitizerToolName,
+                   LLVM_SANITIZER_V1_CATEGORY_MAXLEN);
+  llvm_sanitizer_report_global.v1.fault_address = fault_addr;
+  llvm_sanitizer_report_global.v1.allocation_address = allocation_addr;
+  llvm_sanitizer_report_global.v1.allocation_size = allocation_size;
+
+  internal_strncpy(llvm_sanitizer_report_global.v1.type, error_name,
+                   LLVM_SANITIZER_V1_TYPE_MAXLEN);
+  llvm_sanitizer_report_global.v1.type[LLVM_SANITIZER_V1_TYPE_MAXLEN - 1] = 0;
+
+  llvm_sanitizer_report_global.v1.nstacks =
+      Min(stacks.size(), (size_t)LLVM_SANITIZER_V1_MAXSTACKS);
+  internal_memcpy(llvm_sanitizer_report_global.v1.stacks, stacks.data(),
+                  llvm_sanitizer_report_global.v1.nstacks *
+                      sizeof(llvm_sanitizer_report_payload_stack_v1));
 }
 
 }  // namespace __sanitizer

--- a/compiler-rt/lib/sanitizer_common/sanitizer_mac.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_mac.h
@@ -15,7 +15,57 @@
 #include "sanitizer_common.h"
 #include "sanitizer_platform.h"
 #if SANITIZER_APPLE
-#include "sanitizer_posix.h"
+#  include <stddef.h>
+#  include <stdint.h>
+
+#  include "sanitizer_posix.h"
+
+// macOS sanitizer report format for Crash Reporting
+
+#  define LLVM_SANITIZER_V1_CATEGORY_MAXLEN 32
+#  define LLVM_SANITIZER_V1_TYPE_MAXLEN 32
+#  define LLVM_SANITIZER_V1_STACK_DESCRIPTION_MAXLEN 128
+#  define LLVM_SANITIZER_V1_MAXSTACKS 4
+
+#  define LLVM_SANITIZER_V1_STACK_TYPE_OTHER 0
+#  define LLVM_SANITIZER_V1_STACK_TYPE_ALLOCATION 1
+#  define LLVM_SANITIZER_V1_STACK_TYPE_DEALLOCATION 2
+
+typedef struct {
+  uint64_t thread_id;
+  uint64_t time;
+  uint32_t num_frames;
+  uintptr_t frames[64];
+} sanitizers_stack_trace_t;
+
+// Structs for the global format shared between the LLVM compiler-rt
+// runtimes, and ReportCrash.
+typedef struct {
+  uint32_t type;
+  char description[LLVM_SANITIZER_V1_STACK_DESCRIPTION_MAXLEN];
+  sanitizers_stack_trace_t stack;
+} llvm_sanitizer_report_payload_stack_v1;
+
+typedef struct {
+  char category[LLVM_SANITIZER_V1_CATEGORY_MAXLEN];
+  char type[LLVM_SANITIZER_V1_TYPE_MAXLEN];
+
+  // These three fields may be NULL for non-heap errors
+  uintptr_t fault_address;
+  uintptr_t allocation_address;
+  size_t allocation_size;
+
+  // Number of backtraces (up to LLVM_SANITIZER_V1_MAXSTACKS) that follow
+  uint16_t nstacks;
+  llvm_sanitizer_report_payload_stack_v1 stacks[LLVM_SANITIZER_V1_MAXSTACKS];
+} llvm_sanitizer_report_payload_v1;
+
+typedef struct __attribute__((packed)) {
+  uint16_t vers;
+  union {
+    llvm_sanitizer_report_payload_v1 v1;
+  };
+} llvm_sanitizer_report_payload;
 
 namespace __sanitizer {
 
@@ -80,6 +130,16 @@ struct ThreadEventCallbacks {
 };
 
 void InstallPthreadIntrospectionHook(const ThreadEventCallbacks &callbacks);
+
+void GetDarwinStack(
+    InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks, int tid,
+    const StackTrace* s, uint16_t type, const char* description,
+    bool includeThreadName = true);
+
+void SetCrashReporterGlobalForReport(
+    const char* error_name, uptr fault_addr, uptr allocation_addr,
+    uptr allocation_size,
+    const InternalMmapVector<llvm_sanitizer_report_payload_stack_v1>& stacks);
 
 }  // namespace __sanitizer
 

--- a/compiler-rt/lib/tsan/rtl/tsan_report.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_report.cpp
@@ -139,71 +139,100 @@ static const char *ExternalMopDesc(bool first, bool write) {
                : (write ? "Previous modifying" : "Previous read-only");
 }
 
-static void PrintMop(const ReportMop *mop, bool first) {
+#  define Output(...)                                            \
+    if (out) {                                                   \
+      int written = internal_snprintf(out, outlen, __VA_ARGS__); \
+      out += written;                                            \
+      outlen -= written;                                         \
+    } else {                                                     \
+      Printf(__VA_ARGS__);                                       \
+    }
+
+static void PrintMop(const ReportMop* mop, bool first, char* out = NULL,
+                     size_t outlen = 0) {
   Decorator d;
   char thrbuf[kThreadBufSize];
-  Printf("%s", d.Access());
+
+  if (!out)
+    Printf("%s", d.Access());
+
   if (mop->external_tag == kExternalTagNone) {
-    Printf("  %s of size %d at %p by %s",
-           MopDesc(first, mop->write, mop->atomic), mop->size,
-           (void *)mop->addr, thread_name(thrbuf, mop->tid));
+    Output("  %s of size %d at %p by %s",
+           MopDesc(first, mop->write, mop->atomic), mop->size, (void*)mop->addr,
+           thread_name(thrbuf, mop->tid));
   } else {
     const char *object_type = GetObjectTypeFromTag(mop->external_tag);
     if (object_type == nullptr)
         object_type = "external object";
-    Printf("  %s access of %s at %p by %s",
-           ExternalMopDesc(first, mop->write), object_type,
-           (void *)mop->addr, thread_name(thrbuf, mop->tid));
+    Output("  %s access of %s at %p by %s", ExternalMopDesc(first, mop->write),
+           object_type, (void*)mop->addr, thread_name(thrbuf, mop->tid));
   }
-  PrintMutexSet(mop->mset);
-  Printf(":\n");
-  Printf("%s", d.Default());
-  PrintStack(mop->stack);
+
+  if (!out) {
+    PrintMutexSet(mop->mset);
+    Printf(":\n");
+    Printf("%s", d.Default());
+    PrintStack(mop->stack);
+  }
 }
 
-static void PrintLocation(const ReportLocation *loc) {
+static bool PrintLocation(const ReportLocation* loc, char* out = NULL,
+                          size_t outlen = 0) {
   Decorator d;
   char thrbuf[kThreadBufSize];
   bool print_stack = false;
-  Printf("%s", d.Location());
+
+  if (!out)
+    Printf("%s", d.Location());
+
   if (loc->type == ReportLocationGlobal) {
     const DataInfo &global = loc->global;
-    if (global.size != 0)
-      Printf("  Location is global '%s' of size %zu at %p (%s+0x%zx)\n\n",
-             global.name, global.size, reinterpret_cast<void *>(global.start),
+    if (global.size != 0) {
+      Output("  Location is global '%s' of size %zu at %p (%s+0x%zx)\n\n",
+             global.name, global.size, reinterpret_cast<void*>(global.start),
              StripModuleName(global.module), global.module_offset);
-    else
-      Printf("  Location is global '%s' at %p (%s+0x%zx)\n\n", global.name,
-             reinterpret_cast<void *>(global.start),
+    } else {
+      Output("  Location is global '%s' at %p (%s+0x%zx)\n\n", global.name,
+             reinterpret_cast<void*>(global.start),
              StripModuleName(global.module), global.module_offset);
+    }
   } else if (loc->type == ReportLocationHeap) {
     char thrbuf[kThreadBufSize];
     const char *object_type = GetObjectTypeFromTag(loc->external_tag);
     if (!object_type) {
-      Printf("  Location is heap block of size %zu at %p allocated by %s:\n",
+      Output("  Location is heap block of size %zu at %p allocated by %s",
              loc->heap_chunk_size,
-             reinterpret_cast<void *>(loc->heap_chunk_start),
+             reinterpret_cast<void*>(loc->heap_chunk_start),
              thread_name(thrbuf, loc->tid));
     } else {
-      Printf("  Location is %s of size %zu at %p allocated by %s:\n",
-             object_type, loc->heap_chunk_size,
-             reinterpret_cast<void *>(loc->heap_chunk_start),
+      Output("  Location is %s of size %zu at %p allocated by %s", object_type,
+             loc->heap_chunk_size,
+             reinterpret_cast<void*>(loc->heap_chunk_start),
              thread_name(thrbuf, loc->tid));
     }
+    if (!out)
+      Printf(":\n");
     print_stack = true;
   } else if (loc->type == ReportLocationStack) {
-    Printf("  Location is stack of %s.\n\n", thread_name(thrbuf, loc->tid));
+    Output("  Location is stack of %s.\n\n", thread_name(thrbuf, loc->tid));
   } else if (loc->type == ReportLocationTLS) {
-    Printf("  Location is TLS of %s.\n\n", thread_name(thrbuf, loc->tid));
+    Output("  Location is TLS of %s.\n\n", thread_name(thrbuf, loc->tid));
   } else if (loc->type == ReportLocationFD) {
-    Printf("  Location is file descriptor %d %s by %s at:\n", loc->fd,
+    Output("  Location is file descriptor %d %s by %s at:", loc->fd,
            loc->fd_closed ? "destroyed" : "created",
            thread_name(thrbuf, loc->tid));
+    if (!out)
+      Printf(":\n");
     print_stack = true;
   }
-  Printf("%s", d.Default());
-  if (print_stack)
-    PrintStack(loc->stack);
+
+  if (!out) {
+    Output("%s", d.Default());
+    if (print_stack)
+      PrintStack(loc->stack);
+  }
+
+  return print_stack;
 }
 
 static void PrintMutexShort(const ReportMutex *rm, const char *after) {
@@ -218,39 +247,53 @@ static void PrintMutexShortWithAddress(const ReportMutex *rm,
          reinterpret_cast<void *>(rm->addr), d.Default(), after);
 }
 
-static void PrintMutex(const ReportMutex *rm) {
+static void PrintMutex(const ReportMutex* rm, char* out = NULL,
+                       size_t outlen = 0) {
   Decorator d;
-  Printf("%s", d.Mutex());
-  Printf("  Mutex M%u (%p) created at:\n", rm->id,
-         reinterpret_cast<void *>(rm->addr));
-  Printf("%s", d.Default());
-  PrintStack(rm->stack);
+  if (!out)
+    Printf("%s", d.Mutex());
+  Output("  Mutex M%u (%p) created at", rm->id,
+         reinterpret_cast<void*>(rm->addr));
+  if (!out) {
+    Printf(":\n");
+    Printf("%s", d.Default());
+    PrintStack(rm->stack);
+  }
 }
 
-static void PrintThread(const ReportThread *rt) {
+// Returns whether the stack is important enough to be printed
+static bool PrintThread(const ReportThread* rt, char* out = NULL,
+                        size_t outlen = 0) {
   Decorator d;
   if (rt->id == kMainTid)  // Little sense in describing the main thread.
-    return;
-  Printf("%s", d.ThreadDescription());
-  Printf("  Thread T%d", rt->id);
-  if (rt->name && rt->name[0] != '\0')
-    Printf(" '%s'", rt->name);
+    return false;
+  if (!out)
+    Printf("%s", d.ThreadDescription());
+  Output("  Thread T%d", rt->id);
+  if (rt->name && rt->name[0] != '\0') {
+    Output(" '%s'", rt->name);
+  }
   char thrbuf[kThreadBufSize];
   const char *thread_status = rt->running ? "running" : "finished";
   if (rt->thread_type == ThreadType::Worker) {
-    Printf(" (tid=%llu, %s) is a GCD worker thread\n", rt->os_id,
-           thread_status);
+    Output(" (tid=%llu, %s) is a GCD worker thread", rt->os_id, thread_status);
+    if (!out) {
+      Printf("\n");
+      Printf("\n");
+      Printf("%s", d.Default());
+    }
+    return false;
+  }
+  Output(" (tid=%llu, %s) created by %s", rt->os_id, thread_status,
+         thread_name(thrbuf, rt->parent_tid));
+  if (!out) {
+    if (rt->stack)
+      Printf(" at:");
     Printf("\n");
     Printf("%s", d.Default());
-    return;
+    PrintStack(rt->stack);
   }
-  Printf(" (tid=%llu, %s) created by %s", rt->os_id, thread_status,
-         thread_name(thrbuf, rt->parent_tid));
-  if (rt->stack)
-    Printf(" at:");
-  Printf("\n");
-  Printf("%s", d.Default());
-  PrintStack(rt->stack);
+  return true;
 }
 
 static void PrintSleep(const ReportStack *s) {
@@ -359,6 +402,60 @@ void PrintReport(const ReportDesc *rep) {
     DumpProcessMap();
 
   Printf("==================\n");
+#  if SANITIZER_APPLE
+  if (common_flags()->crashreporter_global) {
+    InternalMmapVector<llvm_sanitizer_report_payload_stack_v1> stacks;
+    InternalMmapVector<char> descbuf(
+        LLVM_SANITIZER_V1_STACK_DESCRIPTION_MAXLEN);
+    stacks.reserve(4);
+    uptr fault_address = 0, allocation_addr = 0, allocation_size = 0;
+
+    for (uptr i = 0; i < rep->mops.Size(); i++) {
+      auto mop = rep->mops[i];
+      PrintMop(mop, i == 0, descbuf.data(), descbuf.size());
+      GetDarwinStack(stacks, mop->tid, &mop->stack_trace,
+                     LLVM_SANITIZER_V1_STACK_TYPE_OTHER, descbuf.data(),
+                     /* includeThreadName */ false);
+      fault_address = mop->addr;
+    }
+
+    for (uptr i = 0; i < rep->locs.Size(); i++) {
+      auto loc = rep->locs[i];
+      bool print_stack = PrintLocation(loc, descbuf.data(), descbuf.size());
+      if (print_stack && loc->stack)
+        GetDarwinStack(stacks, loc->tid, &loc->stack->raw,
+                       LLVM_SANITIZER_V1_STACK_TYPE_OTHER, descbuf.data(),
+                       /* includeThreadName */ false);
+
+      if (loc->type == ReportLocationHeap) {
+        allocation_addr = loc->heap_chunk_start;
+        allocation_size = loc->heap_chunk_size;
+      }
+    }
+
+    for (uptr i = 0; i < rep->threads.Size(); i++) {
+      ReportThread* rt = rep->threads[i];
+      bool print_stack = PrintThread(rt, descbuf.data(), descbuf.size());
+      if (print_stack && rt->stack)
+        GetDarwinStack(stacks, rt->parent_tid, &rt->stack->raw,
+                       LLVM_SANITIZER_V1_STACK_TYPE_OTHER, descbuf.data(),
+                       /* includeThreadName */ false);
+    }
+
+    for (uptr i = 0; i < rep->mutexes.Size(); i++) {
+      ReportMutex* rm = rep->mutexes[i];
+      if (!rm->stack)
+        continue;
+      PrintMutex(rm, descbuf.data(), descbuf.size());
+      GetDarwinStack(stacks, kInvalidTid, &rm->stack->raw,
+                     LLVM_SANITIZER_V1_STACK_TYPE_OTHER, descbuf.data(),
+                     /* includeThreadName */ false);
+    }
+
+    SetCrashReporterGlobalForReport(rep_typ_str, fault_address, allocation_addr,
+                                    allocation_size, stacks);
+  }
+#  endif /* SANITIZER_APPLE */
 }
 
 #else  // #if !SANITIZER_GO

--- a/compiler-rt/lib/tsan/rtl/tsan_report.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_report.cpp
@@ -148,7 +148,7 @@ static const char *ExternalMopDesc(bool first, bool write) {
       Printf(__VA_ARGS__);                                       \
     }
 
-static void PrintMop(const ReportMop* mop, bool first, char* out = NULL,
+static void PrintMop(const ReportMop* mop, bool first, char* out = nullptr,
                      size_t outlen = 0) {
   Decorator d;
   char thrbuf[kThreadBufSize];
@@ -176,7 +176,7 @@ static void PrintMop(const ReportMop* mop, bool first, char* out = NULL,
   }
 }
 
-static bool PrintLocation(const ReportLocation* loc, char* out = NULL,
+static bool PrintLocation(const ReportLocation* loc, char* out = nullptr,
                           size_t outlen = 0) {
   Decorator d;
   char thrbuf[kThreadBufSize];
@@ -247,7 +247,7 @@ static void PrintMutexShortWithAddress(const ReportMutex *rm,
          reinterpret_cast<void *>(rm->addr), d.Default(), after);
 }
 
-static void PrintMutex(const ReportMutex* rm, char* out = NULL,
+static void PrintMutex(const ReportMutex* rm, char* out = nullptr,
                        size_t outlen = 0) {
   Decorator d;
   if (!out)
@@ -262,7 +262,7 @@ static void PrintMutex(const ReportMutex* rm, char* out = NULL,
 }
 
 // Returns whether the stack is important enough to be printed
-static bool PrintThread(const ReportThread* rt, char* out = NULL,
+static bool PrintThread(const ReportThread* rt, char* out = nullptr,
                         size_t outlen = 0) {
   Decorator d;
   if (rt->id == kMainTid)  // Little sense in describing the main thread.

--- a/compiler-rt/lib/tsan/rtl/tsan_report.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_report.h
@@ -42,6 +42,7 @@ enum ReportType {
 
 struct ReportStack {
   SymbolizedStack *frames = nullptr;
+  StackTrace raw;
   bool suppressable = false;
 };
 

--- a/compiler-rt/lib/tsan/rtl/tsan_rtl_report.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_rtl_report.cpp
@@ -132,6 +132,7 @@ static ReportStack *SymbolizeStack(StackTrace trace) {
 
   auto *stack = New<ReportStack>();
   stack->frames = top;
+  stack->raw = trace;
   return stack;
 }
 


### PR DESCRIPTION
Add a global llvm_sanitizer_report_global that is filled with structured sanitizer report information (including backtraces) when a report is printed to the screen. Crash reporting infrastructure can inspect the process after it aborts to extract the structured sanitizer report (which could be used for automatic triage or out-of-band symbolication).

To achieve this, the report printing code has been repurposed to support extracting short descriptions to display along with backtraces. e.g. PrintMop() now supports a buffer argument, and can write out the string "Previous write of size 4 at 0x1234 by thread T1" to a buffer (without the terminal formatting control characters) instead of printing it to a screen. Not all executions of Print<X> will necessarily print a stack, though, so for example PrintLocation now returns a boolean to indicate whether the stack was important enough to print.

I considered doing this differently: refactoring to separate the strings describing the stacks from the code that prints the surrounding report information, but I don't think there's any way to do this cleanly because we want to record ~exactly the same stacks that appear in the normal sanitizer report (and thus would need to duplicate that logic as well)

Nothing needs to be done to maintain this feature when new ASAN error types are added: if `GetDarwinStacks` is not implemented for a new ASAN error type, it falls back to ErrorBase::GetDarwinStacks which is a no-op. For TSAN types the existing pattern would need to be followed (i.e. where `PrintX` functions take an optional output buffer that is filled with the header information for backtraces).

rdar://176058208