### PR TITLE
[obj2yaml] Add Obj2Yaml ability to dump GOFF header records

### DIFF
--- a/llvm/include/llvm/Object/GOFFObjectFile.h
+++ b/llvm/include/llvm/Object/GOFFObjectFile.h
@@ -16,14 +16,18 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/IndexedMap.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/BinaryFormat/GOFF.h"
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/ConvertEBCDIC.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/SubtargetFeature.h"
 #include "llvm/TargetParser/Triple.h"
+#include <utility>
 
 namespace llvm {
 
@@ -44,7 +48,27 @@ class LLVM_ABI GOFFObjectFile : public ObjectFile {
   SmallVector<SectionEntryImpl, 256> SectionList;
   mutable DenseMap<uint32_t, SmallVector<uint8_t>> SectionDataCache;
 
+  // Flattened data for all logical records (record type + continuous data
+  // without headers).
+  SmallVector<std::pair<GOFF::RecordType, SmallVector<uint8_t>>> FlattenedData;
+
+  // Populate FlattenedData with all logical records.
+  void createFlattenedData();
+
+  // Helper to get continuous data from a logical record (includes prefix +
+  // continuations) Returns the number of physical records consumed (including
+  // the initial record)
+  Expected<unsigned> getContinuousData(SmallVectorImpl<uint8_t> &CompleteData,
+                                       int DataIndex, uint16_t DataLength,
+                                       const uint8_t *Record) const;
+
 public:
+  // Get the flattened data structure
+  const SmallVector<std::pair<GOFF::RecordType, SmallVector<uint8_t>>> &
+  getFlattenedData() const {
+    return FlattenedData;
+  }
+
   Expected<StringRef> getSymbolName(SymbolRef Symbol) const;
 
   GOFFObjectFile(MemoryBufferRef Object, Error &Err);

--- a/llvm/include/llvm/ObjectYAML/GOFFYAML.h
+++ b/llvm/include/llvm/ObjectYAML/GOFFYAML.h
@@ -28,8 +28,8 @@ struct FileHeader {
   uint32_t TargetEnvironment = 0;
   uint32_t TargetOperatingSystem = 0;
   uint16_t CCSID = 0;
-  StringRef CharacterSetName;
-  StringRef LanguageProductIdentifier;
+  std::string CharacterSetName;
+  std::string LanguageProductIdentifier;
   uint32_t ArchitectureLevel = 0;
   std::optional<uint16_t> InternalCCSID;
   std::optional<uint8_t> TargetSoftwareEnvironment;

--- a/llvm/lib/Object/GOFFObjectFile.cpp
+++ b/llvm/lib/Object/GOFFObjectFile.cpp
@@ -13,9 +13,11 @@
 #include "llvm/Object/GOFFObjectFile.h"
 #include "llvm/BinaryFormat/GOFF.h"
 #include "llvm/Object/GOFF.h"
+#include "llvm/Support/DataExtractor.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/raw_ostream.h"
+#include <cstddef>
 
 #ifndef DEBUG_TYPE
 #define DEBUG_TYPE "goff"
@@ -23,6 +25,141 @@
 
 using namespace llvm::object;
 using namespace llvm;
+
+// Return the type of the record.
+static GOFF::RecordType getRecordType(const uint8_t *PhysicalRecord) {
+  return GOFF::RecordType((PhysicalRecord[1] & 0xF0) >> 4);
+}
+
+// Return true if the record is a continuation record.
+static bool isContinuation(const uint8_t *PhysicalRecord) {
+  return PhysicalRecord[1] & 0x02;
+}
+
+// Return true if the record has a continuation.
+static bool isContinued(const uint8_t *PhysicalRecord) {
+  return PhysicalRecord[1] & 0x01;
+}
+
+// Helper function to get continuous data from a logical record
+// Includes PTV header + everything from first record + continuation payloads
+// Returns the number of physical records consumed (including the initial
+// record)
+Expected<unsigned>
+GOFFObjectFile::getContinuousData(SmallVectorImpl<uint8_t> &CompleteData,
+                                  int DataIndex, uint16_t DataLength,
+                                  const uint8_t *Record) const {
+
+  CompleteData.reserve(DataLength + GOFF::RecordLength - DataIndex);
+
+  // First record - include PTV header (bytes 0-2)
+  CompleteData.append(Record, Record + GOFF::RecordPrefixLength);
+  // Append everything from the first record before the start of the data.
+  CompleteData.append(Record + GOFF::RecordPrefixLength, Record + DataIndex);
+  // Append the data.
+  const uint8_t *Ptr = Record + DataIndex;
+  size_t SliceLength =
+      std::min(DataLength, (uint16_t)(GOFF::RecordLength - DataIndex));
+  CompleteData.append(Ptr, Ptr + SliceLength);
+  DataLength -= SliceLength;
+  Ptr += SliceLength;
+
+  unsigned BlocksConsumed = 1; // Count the initial record
+  // Continuation records.
+  while (DataLength > 0) {
+    // Ptr now points to the start of the next physical record.
+    // Check that this block is a Continuation.
+    assert(isContinuation(Ptr) && "Continuation bit must be set");
+    // Check that the last Continuation is terminated correctly.
+    if (DataLength <= GOFF::PayloadLength && isContinued(Ptr))
+      return createStringError(object_error::parse_failed,
+                               "continued bit should not be set");
+
+    SliceLength = std::min(DataLength, (uint16_t)GOFF::PayloadLength);
+    Ptr += GOFF::RecordPrefixLength; // Skip the 3-byte prefix
+    CompleteData.append(Ptr, Ptr + SliceLength);
+    DataLength -= SliceLength;
+    // Advance to the start of the next record
+    Ptr += (GOFF::RecordLength - GOFF::RecordPrefixLength);
+    BlocksConsumed++;
+  }
+  return BlocksConsumed;
+}
+
+// Walk over the object file and populate FlattenedData.
+void GOFFObjectFile::createFlattenedData() {
+  const uint8_t *It = base();
+  const uint8_t *End = base() + getData().size();
+  while (It < End) {
+    // Skip continuation records - only process first physical record of each
+    // logical record
+    if (isContinuation(It)) {
+      It += GOFF::RecordLength;
+      continue;
+    }
+
+    GOFF::RecordType RecordType = ::getRecordType(It);
+    // Call get continuous data based on record type.
+    int DataIndex = 0;
+    uint16_t DataLength = 0;
+    ArrayRef<uint8_t> Slice(It, GOFF::RecordLength);
+    DataExtractor DE(Slice, false);
+
+    switch (RecordType) {
+    case GOFF::RT_ESD: {
+      DataIndex = 72;
+      uint64_t Offset = 70;
+      DataLength = DE.getU16(&Offset);
+      break;
+    }
+    case GOFF::RT_TXT: {
+      DataIndex = 24;
+      uint64_t Offset = 22;
+      DataLength = DE.getU16(&Offset);
+      break;
+    }
+    case GOFF::RT_RLD: {
+      DataIndex = 6;
+      uint64_t Offset = 4;
+      DataLength = DE.getU16(&Offset);
+      break;
+    }
+    case GOFF::RT_LEN: {
+      DataIndex = 8;
+      uint64_t Offset = 6;
+      DataLength = DE.getU16(&Offset);
+      break;
+    }
+    case GOFF::RT_END: {
+      DataIndex = 26;
+      uint64_t Offset = 24;
+      DataLength = DE.getU16(&Offset);
+      break;
+    }
+    case GOFF::RT_HDR: {
+      DataIndex = 60;
+      uint64_t Offset = 52;
+      DataLength = DE.getU16(&Offset);
+      break;
+    }
+    }
+    // Get the flattened data for this logical record (including continuations)
+    SmallVector<uint8_t> CompleteData;
+    Expected<unsigned> BlocksConsumed =
+        getContinuousData(CompleteData, DataIndex, DataLength, It);
+    if (!BlocksConsumed) {
+      llvm::handleAllErrors(
+          BlocksConsumed.takeError(), [](const llvm::ErrorInfoBase &EIB) {
+            llvm::errs() << "ERROR: " << EIB.message() << "\n";
+          });
+      return;
+    }
+    FlattenedData.push_back({RecordType, std::move(CompleteData)});
+
+    // Move to next logical record using the number of blocks consumed
+    It += (*BlocksConsumed) * GOFF::RecordLength;
+  }
+}
 
 Expected<std::unique_ptr<ObjectFile>>
 ObjectFile::createGOFFObjectFile(MemoryBufferRef Object) {
@@ -61,56 +198,13 @@ GOFFObjectFile::GOFFObjectFile(MemoryBufferRef Object, Error &Err)
     }
   }
 
+  createFlattenedData();
+
   SectionEntryImpl DummySection;
   SectionList.emplace_back(DummySection); // Dummy entry at index 0.
 
-  uint8_t PrevRecordType = 0;
-  uint8_t PrevContinuationBits = 0;
-  const uint8_t *End = reinterpret_cast<const uint8_t *>(Data.getBufferEnd());
-  for (const uint8_t *I = base(); I < End; I += GOFF::RecordLength) {
-    uint8_t RecordType = (I[1] & 0xF0) >> 4;
-    bool IsContinuation = I[1] & 0x02;
-    bool PrevWasContinued = PrevContinuationBits & 0x01;
-    size_t RecordNum = (I - base()) / GOFF::RecordLength;
-
-    // If the previous record was continued, the current record should be a
-    // continuation.
-    if (PrevWasContinued && !IsContinuation) {
-      if (PrevRecordType == RecordType) {
-        Err = createStringError(object_error::parse_failed,
-                                "record " + std::to_string(RecordNum) +
-                                    " is not a continuation record but the "
-                                    "preceding record is continued");
-        return;
-      }
-    }
-    // Don't parse continuations records, only parse initial record.
-    if (IsContinuation) {
-      if (RecordType != PrevRecordType) {
-        Err = createStringError(object_error::parse_failed,
-                                "record " + std::to_string(RecordNum) +
-                                    " is a continuation record that does not "
-                                    "match the type of the previous record");
-        return;
-      }
-      if (!PrevWasContinued) {
-        Err = createStringError(object_error::parse_failed,
-                                "record " + std::to_string(RecordNum) +
-                                    " is a continuation record that is not "
-                                    "preceded by a continued record");
-        return;
-      }
-      PrevRecordType = RecordType;
-      PrevContinuationBits = I[1] & 0x03;
-      continue;
-    }
-    LLVM_DEBUG(for (size_t J = 0; J < GOFF::RecordLength; ++J) {
-      const uint8_t *P = I + J;
-      if (J % 8 == 0)
-        dbgs() << "  ";
-      dbgs() << format("%02hhX", *P);
-    });
-
+  for (const auto &[RecordType, Data] : FlattenedData) {
+    const uint8_t *I = Data.data();
     switch (RecordType) {
     case GOFF::RT_ESD: {
       // Save ESD record.
@@ -170,6 +264,12 @@ GOFFObjectFile::GOFFObjectFile(MemoryBufferRef Object, Error &Err)
       TextPtrs.emplace_back(I);
       LLVM_DEBUG(dbgs() << "  --  TXT\n");
       break;
+    case GOFF::RT_RLD:
+      LLVM_DEBUG(dbgs() << "  --  RLD (GOFF record type) unhandled\n");
+      break;
+    case GOFF::RT_LEN:
+      LLVM_DEBUG(dbgs() << "  --  LEN (GOFF record type) unhandled\n");
+      break;
     case GOFF::RT_END:
       LLVM_DEBUG(dbgs() << "  --  END (GOFF record type) unhandled\n");
       break;
@@ -179,8 +279,6 @@ GOFFObjectFile::GOFFObjectFile(MemoryBufferRef Object, Error &Err)
     default:
       llvm_unreachable("Unknown record type");
     }
-    PrevRecordType = RecordType;
-    PrevContinuationBits = I[1] & 0x03;
   }
 }
 
@@ -195,9 +293,18 @@ Expected<StringRef> GOFFObjectFile::getSymbolName(DataRefImpl Symb) const {
     return StringRef(StrPtr.second.get(), StrPtr.first);
   }
 
+  // Get the ESD record pointer from EsdPtrs (points to FlattenedData)
+  const uint8_t *EsdRecord = getSymbolEsdRecord(Symb);
+  // Extract name from the flattened ESD record
+  // Name length is at byte 70-71, name data starts at byte 72
+  uint16_t NameLength = ESDRecord::getNameLength(EsdRecord);
   SmallString<256> SymbolName;
-  if (auto Err = ESDRecord::getData(getSymbolEsdRecord(Symb), SymbolName))
-    return std::move(Err);
+  if (NameLength > 0) {
+    // Name starts at byte 72 in the record (already flattened, no
+    // continuations)
+    const uint8_t *NameStart = EsdRecord + 72;
+    SymbolName.append(NameStart, NameStart + NameLength);
+  }
 
   SmallString<256> SymbolNameConverted;
   ConverterEBCDIC::convertToUTF8(SymbolName, SymbolNameConverted);
@@ -477,8 +584,7 @@ GOFFObjectFile::getSectionContents(DataRefImpl Sec) const {
   SmallVector<uint8_t> Data(SectionSize, FillByte);
 
   // Replace section with content from text records.
-  for (const uint8_t *TxtRecordInt : TextPtrs) {
-    const uint8_t *TxtRecordPtr = TxtRecordInt;
+  for (const uint8_t *TxtRecordPtr : TextPtrs) {
     uint32_t TxtEsdId;
     TXTRecord::getElementEsdId(TxtRecordPtr, TxtEsdId);
     LLVM_DEBUG(dbgs() << "Got txt EsdId: " << TxtEsdId << '\n');
@@ -495,13 +601,12 @@ GOFFObjectFile::getSectionContents(DataRefImpl Sec) const {
     LLVM_DEBUG(dbgs() << "Record offset " << TxtDataOffset << ", data size "
                       << TxtDataSize << "\n");
 
-    SmallString<256> CompleteData;
-    CompleteData.reserve(TxtDataSize);
-    if (Error Err = TXTRecord::getData(TxtRecordPtr, CompleteData))
-      return std::move(Err);
-    assert(CompleteData.size() == TxtDataSize && "Wrong length of data");
-    std::copy(CompleteData.data(), CompleteData.data() + TxtDataSize,
-              Data.begin() + TxtDataOffset);
+    // Text data starts at byte 24 in the flattened record (already processed
+    // continuations)
+    const uint8_t *TxtData = TxtRecordPtr + 24;
+    assert(TxtDataSize <= Data.size() - TxtDataOffset &&
+           "Text data exceeds section size");
+    std::copy(TxtData, TxtData + TxtDataSize, Data.begin() + TxtDataOffset);
   }
   auto &Cache = SectionDataCache[Sec.d.a];
   Cache = std::move(Data);
@@ -591,57 +696,4 @@ basic_symbol_iterator GOFFObjectFile::symbol_begin() const {
 basic_symbol_iterator GOFFObjectFile::symbol_end() const {
   DataRefImpl Symb;
   return basic_symbol_iterator(SymbolRef(Symb, this));
-}
-
-Error Record::getContinuousData(const uint8_t *Record, uint16_t DataLength,
-                                int DataIndex, SmallString<256> &CompleteData) {
-  // First record.
-  const uint8_t *Slice = Record + DataIndex;
-  size_t SliceLength =
-      std::min(DataLength, (uint16_t)(GOFF::RecordLength - DataIndex));
-  CompleteData.append(Slice, Slice + SliceLength);
-  DataLength -= SliceLength;
-  Slice += SliceLength;
-
-  // Continuation records.
-  for (; DataLength > 0;
-       DataLength -= SliceLength, Slice += GOFF::PayloadLength) {
-    // Slice points to the start of the new record.
-    // Check that this block is a Continuation.
-    assert(Record::isContinuation(Slice) && "Continuation bit must be set");
-    // Check that the last Continuation is terminated correctly.
-    if (DataLength <= 77 && Record::isContinued(Slice))
-      return createStringError(object_error::parse_failed,
-                               "continued bit should not be set");
-
-    SliceLength = std::min(DataLength, (uint16_t)GOFF::PayloadLength);
-    Slice += GOFF::RecordPrefixLength;
-    CompleteData.append(Slice, Slice + SliceLength);
-  }
-  return Error::success();
-}
-
-Error HDRRecord::getData(const uint8_t *Record,
-                         SmallString<256> &CompleteData) {
-  uint16_t Length = getPropertyModuleLength(Record);
-  return getContinuousData(Record, Length, 60, CompleteData);
-}
-
-Error ESDRecord::getData(const uint8_t *Record,
-                         SmallString<256> &CompleteData) {
-  uint16_t DataSize = getNameLength(Record);
-  return getContinuousData(Record, DataSize, 72, CompleteData);
-}
-
-Error TXTRecord::getData(const uint8_t *Record,
-                         SmallString<256> &CompleteData) {
-  uint16_t Length;
-  getDataLength(Record, Length);
-  return getContinuousData(Record, Length, 24, CompleteData);
-}
-
-Error ENDRecord::getData(const uint8_t *Record,
-                         SmallString<256> &CompleteData) {
-  uint16_t Length = getNameLength(Record);
-  return getContinuousData(Record, Length, 26, CompleteData);
 }

--- a/llvm/lib/Object/ObjectFile.cpp
+++ b/llvm/lib/Object/ObjectFile.cpp
@@ -163,7 +163,6 @@ ObjectFile::createObjectFile(MemoryBufferRef Object, file_magic Type,
   case file_magic::windows_resource:
   case file_magic::pdb:
   case file_magic::minidump:
-  case file_magic::goff_object:
   case file_magic::cuda_fatbinary:
   case file_magic::offload_binary:
   case file_magic::offload_bundle:
@@ -178,6 +177,8 @@ ObjectFile::createObjectFile(MemoryBufferRef Object, file_magic Type,
   case file_magic::elf_shared_object:
   case file_magic::elf_core:
     return createELFObjectFile(Object, InitContent);
+  case file_magic::goff_object:
+    return createGOFFObjectFile(Object);
   case file_magic::macho_object:
   case file_magic::macho_executable:
   case file_magic::macho_fixed_virtual_memory_shared_lib:

--- a/llvm/lib/ObjectYAML/GOFFEmitter.cpp
+++ b/llvm/lib/ObjectYAML/GOFFEmitter.cpp
@@ -218,7 +218,8 @@ void GOFFState::writeHeader(GOFFYAML::FileHeader &FileHdr) {
   }
 
   GW.makeNewRecord(GOFF::RT_HDR, GOFF::PayloadLength);
-  GW << binaryBe(FileHdr.TargetEnvironment)     // TargetEnvironment
+  GW << zeros(1)                                // Reserved
+     << binaryBe(FileHdr.TargetEnvironment)     // TargetEnvironment
      << binaryBe(FileHdr.TargetOperatingSystem) // TargetOperatingSystem
      << zeros(2)                                // Reserved
      << binaryBe(FileHdr.CCSID)                 // CCSID

--- a/llvm/test/tools/obj2yaml/GOFF/header-default.test
+++ b/llvm/test/tools/obj2yaml/GOFF/header-default.test
@@ -1,0 +1,11 @@
+; REQUIRES: systemz-registered-target
+; RUN: llc -mtriple=s390x-ibm-zos -filetype=obj %s -o %t
+; RUN: obj2yaml %t | FileCheck %s
+
+; CHECK:      --- !GOFF
+; CHECK-NEXT: FileHeader: {}
+
+define i32 @f() {
+entry:
+  ret i32 42
+}

--- a/llvm/tools/obj2yaml/CMakeLists.txt
+++ b/llvm/tools/obj2yaml/CMakeLists.txt
@@ -15,6 +15,7 @@ add_llvm_utility(obj2yaml
   dwarf2yaml.cpp
   dxcontainer2yaml.cpp
   elf2yaml.cpp
+  goff2yaml.cpp
   macho2yaml.cpp
   minidump2yaml.cpp
   offload2yaml.cpp

--- a/llvm/tools/obj2yaml/goff2yaml.cpp
+++ b/llvm/tools/obj2yaml/goff2yaml.cpp
@@ -1,0 +1,156 @@
+//===------ goff2yaml.cpp - obj2yaml conversion tool ------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "obj2yaml.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/Object/GOFF.h"
+#include "llvm/Object/GOFFObjectFile.h"
+#include "llvm/ObjectYAML/ObjectYAML.h"
+#include "llvm/Support/ConvertEBCDIC.h"
+#include "llvm/Support/DataExtractor.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/Format.h"
+
+using namespace llvm;
+
+static std::string getFixedLengthEBCDICString(DataExtractor &Data,
+                                              DataExtractor::Cursor &C,
+                                              uint64_t Length,
+                                              StringRef TrimChars = {"\0", 1}) {
+  StringRef FixedLenStr = Data.getBytes(C, Length);
+  SmallString<16> Str;
+  ConverterEBCDIC::convertToUTF8(FixedLenStr, Str);
+  return Str.str().trim(TrimChars).str();
+}
+
+class GOFFDumper {
+  const object::GOFFObjectFile &Obj;
+  GOFFYAML::Object YAMLObj;
+
+  Error dumpHeader(ArrayRef<uint8_t> Data);
+  Error dumpExternalSymbol(ArrayRef<uint8_t> Data);
+  Error dumpText(ArrayRef<uint8_t> Data);
+  Error dumpRelocationDirectory(ArrayRef<uint8_t> Data);
+  Error dumpDeferredLength(ArrayRef<uint8_t> Data);
+  Error dumpEnd(ArrayRef<uint8_t> Data);
+
+public:
+  GOFFDumper(const object::GOFFObjectFile &Obj);
+  Error dump();
+  GOFFYAML::Object &getYAMLObj();
+};
+
+GOFFDumper::GOFFDumper(const object::GOFFObjectFile &Obj) : Obj(Obj) {}
+
+Error GOFFDumper::dumpHeader(ArrayRef<uint8_t> Data) {
+  DataExtractor DE(Data, false, 0);
+  DataExtractor::Cursor C(0);
+
+  // Flattened data contains: PTV header (bytes 0-2) + bytes 3-60 (prefix) + data from byte 60 onwards
+  // HDR data starts at byte 4 in the original record
+  C.seek(4); // Skip PTV header and record type
+  YAMLObj.Header.TargetEnvironment = DE.getU32(C);
+  YAMLObj.Header.TargetOperatingSystem = DE.getU32(C);
+  DE.skip(C, 2);
+  YAMLObj.Header.CCSID = DE.getU16(C);
+  YAMLObj.Header.CharacterSetName = getFixedLengthEBCDICString(DE, C, 16);
+  YAMLObj.Header.LanguageProductIdentifier =
+      getFixedLengthEBCDICString(DE, C, 16);
+  YAMLObj.Header.ArchitectureLevel = DE.getU32(C);
+  uint16_t PropertiesLength = DE.getU16(C);
+  DE.skip(C, 6);
+  if (PropertiesLength) {
+    YAMLObj.Header.InternalCCSID = DE.getU16(C);
+    PropertiesLength -= 2;
+  }
+  if (PropertiesLength) {
+    YAMLObj.Header.TargetSoftwareEnvironment = DE.getU8(C);
+    PropertiesLength -= 1;
+  }
+  if (!C)
+    return C.takeError();
+  return Error::success();
+}
+
+Error GOFFDumper::dumpExternalSymbol(ArrayRef<uint8_t> Data) {
+  // TODO: Implement dumping ESD records
+  return Error::success();
+}
+
+Error GOFFDumper::dumpText(ArrayRef<uint8_t> Data) {
+  // TODO: Implement dumping TXT records
+  return Error::success();
+}
+
+Error GOFFDumper::dumpRelocationDirectory(ArrayRef<uint8_t> Data) {
+  // TODO: Implement dumping RLD records
+  return Error::success();
+}
+
+Error GOFFDumper::dumpDeferredLength(ArrayRef<uint8_t> Records) {
+  // TODO: Implement if/when GOFF LEN records are emitted by current producers
+  // or covered by handcrafted-object tests.
+  return Error::success();
+}
+
+Error GOFFDumper::dumpEnd(ArrayRef<uint8_t> Records) {
+  // TODO: implement dumping END records
+  return Error::success();
+}
+
+Error GOFFDumper::dump() {
+  Error Err = Error::success();
+
+  // Use the pre-flattened data structure instead of iterating through records
+  const auto& FlattenedData = Obj.getFlattenedData();
+
+  for (const auto& [RecordType, Data] : FlattenedData) {
+    switch (RecordType) {
+    case GOFF::RT_HDR:
+      if (auto Err = dumpHeader(Data))
+        return Err;
+      break;
+    case GOFF::RT_ESD:
+      if (auto Err = dumpExternalSymbol(Data))
+        return Err;
+      break;
+    case GOFF::RT_TXT:
+      if (auto Err = dumpText(Data))
+        return Err;
+      break;
+    case GOFF::RT_RLD:
+      if (auto Err = dumpRelocationDirectory(Data))
+        return Err;
+      break;
+    case GOFF::RT_LEN:
+      if (auto Err = dumpDeferredLength(Data))
+        return Err;
+      break;
+    case GOFF::RT_END:
+      if (auto Err = dumpEnd(Data))
+        return Err;
+      break;
+    }
+  }
+  return Err;
+}
+
+GOFFYAML::Object &GOFFDumper::getYAMLObj() { return YAMLObj; }
+
+Error goff2yaml(raw_ostream &Out, const llvm::object::GOFFObjectFile &Obj) {
+  GOFFDumper Dumper(Obj);
+
+  if (auto Err = Dumper.dump())
+    return Err;
+
+  yaml::Output Yout(Out);
+  Yout << Dumper.getYAMLObj();
+
+  return Error::success();
+}

--- a/llvm/tools/obj2yaml/obj2yaml.cpp
+++ b/llvm/tools/obj2yaml/obj2yaml.cpp
@@ -45,6 +45,9 @@ static Error dumpObject(const ObjectFile &Obj, raw_ostream &OS) {
   if (Obj.isELF())
     return elf2yaml(OS, Obj);
 
+  if (Obj.isGOFF())
+    return goff2yaml(OS, cast<GOFFObjectFile>(Obj));
+
   if (Obj.isWasm())
     return errorCodeToError(wasm2yaml(OS, cast<WasmObjectFile>(Obj)));
 

--- a/llvm/tools/obj2yaml/obj2yaml.h
+++ b/llvm/tools/obj2yaml/obj2yaml.h
@@ -13,6 +13,7 @@
 #define LLVM_TOOLS_OBJ2YAML_OBJ2YAML_H
 
 #include "llvm/Object/COFF.h"
+#include "llvm/Object/GOFFObjectFile.h"
 #include "llvm/Object/Minidump.h"
 #include "llvm/Object/Wasm.h"
 #include "llvm/Object/XCOFFObjectFile.h"
@@ -25,6 +26,8 @@ std::error_code coff2yaml(llvm::raw_ostream &Out,
                           const llvm::object::COFFObjectFile &Obj);
 llvm::Error elf2yaml(llvm::raw_ostream &Out,
                      const llvm::object::ObjectFile &Obj);
+llvm::Error goff2yaml(llvm::raw_ostream &Out,
+                      const llvm::object::GOFFObjectFile &Obj);
 llvm::Error macho2yaml(llvm::raw_ostream &Out, const llvm::object::Binary &Obj,
                        unsigned RawSegments);
 llvm::Error minidump2yaml(llvm::raw_ostream &Out,


### PR DESCRIPTION
Add obj2yaml support for the GOFF file format, beginning with dumping header records.
The GOFF file format consists of 80 btye records with data that can be continued in the next records. A new data structure is added to preprocess the GOFF object file to flatten the data.