### PR TITLE
[IR] Preserve !invariant.group in copyMetadataForLoad

### DIFF
--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -3157,6 +3157,7 @@ void llvm::copyMetadataForLoad(LoadInst &Dest, const LoadInst &Source) {
     case LLVMContext::MD_access_group:
     case LLVMContext::MD_noundef:
     case LLVMContext::MD_noalias_addrspace:
+    case LLVMContext::MD_invariant_group:
       // All of these directly apply.
       Dest.setMetadata(ID, N);
       break;

--- a/llvm/test/Transforms/InstCombine/invariant.group.ll
+++ b/llvm/test/Transforms/InstCombine/invariant.group.ll
@@ -216,9 +216,21 @@ define i1 @icmp_null_launder_bitcasts(ptr %a) {
   ret i1 %r
 }
 
+define i32 @retype_keeps_invariant_group(ptr %p) {
+; CHECK-LABEL: @retype_keeps_invariant_group(
+; CHECK-NEXT:    [[V1:%.*]] = load i32, ptr [[P:%.*]], align 4, !invariant.group [[META0:![0-9]+]]
+; CHECK-NEXT:    ret i32 [[V1]]
+;
+  %v = load float, ptr %p, !invariant.group !1
+  %i = bitcast float %v to i32
+  ret i32 %i
+}
+
 declare ptr @llvm.launder.invariant.group.p0(ptr)
 declare ptr addrspace(42) @llvm.launder.invariant.group.p42(ptr addrspace(42))
 declare ptr @llvm.strip.invariant.group.p0(ptr)
 declare ptr addrspace(42) @llvm.strip.invariant.group.p42(ptr addrspace(42))
 
 attributes #0 = { null_pointer_is_valid }
+
+!1 = !{}


### PR DESCRIPTION
This bug was found by a large run of Opus 4.7 looking for bugs in LLVM.
