### PR TITLE
[LowerInvoke] Use createCallMatchingInvoke instead of rolling it ourselves

### DIFF
--- a/llvm/lib/Transforms/Utils/LowerInvoke.cpp
+++ b/llvm/lib/Transforms/Utils/LowerInvoke.cpp
@@ -14,12 +14,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Transforms/Utils/LowerInvoke.h"
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
 #include "llvm/Transforms/Utils.h"
+#include "llvm/Transforms/Utils/Local.h"
 using namespace llvm;
 
 #define DEBUG_TYPE "lower-invoke"
@@ -46,17 +46,9 @@ static bool runImpl(Function &F) {
   bool Changed = false;
   for (BasicBlock &BB : F)
     if (InvokeInst *II = dyn_cast<InvokeInst>(BB.getTerminator())) {
-      SmallVector<Value *, 16> CallArgs(II->args());
-      SmallVector<OperandBundleDef, 1> OpBundles;
-      II->getOperandBundlesAsDefs(OpBundles);
-      // Insert a normal call instruction...
-      CallInst *NewCall =
-          CallInst::Create(II->getFunctionType(), II->getCalledOperand(),
-                           CallArgs, OpBundles, "", II->getIterator());
+      CallInst *NewCall = createCallMatchingInvoke(II);
       NewCall->takeName(II);
-      NewCall->setCallingConv(II->getCallingConv());
-      NewCall->setAttributes(II->getAttributes());
-      NewCall->setDebugLoc(II->getDebugLoc());
+      NewCall->insertBefore(II->getIterator());
       II->replaceAllUsesWith(NewCall);
 
       // Insert an unconditional branch to the normal destination.

--- a/llvm/test/Transforms/LowerInvoke/lowerinvoke.ll
+++ b/llvm/test/Transforms/LowerInvoke/lowerinvoke.ll
@@ -24,3 +24,24 @@ lpad:
 ; CHECK: lpad:
 ; CHECK-NOT: phi
 ; CHECK: landingpad
+
+; The lowered call must carry the invoke's metadata (e.g. !noalias), and the
+; invoke's two-weight !prof is converted to the call's single total weight.
+declare i32 @g()
+declare i32 @__gxx_personality_v0(...)
+define i32 @keep_md() personality ptr @__gxx_personality_v0 {
+; CHECK-LABEL: @keep_md(
+; CHECK: call i32 @g(){{.*}}!prof ![[PROF:[0-9]+]]{{.*}}!noalias
+; CHECK: ![[PROF]] = !{!"branch_weights", i32 101}
+entry:
+  %r = invoke i32 @g() to label %cont unwind label %lpad, !prof !0, !noalias !1
+cont:
+  ret i32 %r
+lpad:
+  %l = landingpad { ptr, i32 } cleanup
+  ret i32 0
+}
+!0 = !{!"branch_weights", i32 100, i32 1}
+!1 = !{!2}
+!2 = distinct !{!2, !3}
+!3 = distinct !{!3}


### PR DESCRIPTION
Using createCallMatchingInvoke ensures we copy metadata from the invoke onto the call.

This bug was found by a large run of Opus 4.7 looking for bugs in LLVM.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
