### PR TITLE
[scudo] Return nullptr if a remap fails on linux.

### DIFF
--- a/compiler-rt/lib/scudo/standalone/mem_map_linux.cpp
+++ b/compiler-rt/lib/scudo/standalone/mem_map_linux.cpp
@@ -68,6 +68,10 @@ static void *mmapWrapper(uptr Addr, uptr Size, const char *Name, uptr Flags) {
       reportMapError(errno == ENOMEM ? Size : 0);
     return nullptr;
   }
+
+  if (Addr && reinterpret_cast<uptr>(P) != Addr)
+    reportMapFixedError(reinterpret_cast<uptr>(P), Addr);
+
 #if SCUDO_ANDROID
   if (Name)
     prctl(ANDROID_PR_SET_VMA, ANDROID_PR_SET_VMA_ANON_NAME, P, Size, Name);
@@ -108,9 +112,7 @@ void MemMapLinux::unmapImpl(uptr Addr, uptr Size) {
 bool MemMapLinux::remapImpl(uptr Addr, uptr Size, const char *Name,
                             uptr Flags) {
   void *P = mmapWrapper(Addr, Size, Name, Flags);
-  if (reinterpret_cast<uptr>(P) != Addr)
-    reportMapError();
-  return true;
+  return reinterpret_cast<uptr>(P) == Addr;
 }
 
 void MemMapLinux::setMemoryPermissionImpl(uptr Addr, uptr Size, uptr Flags) {

--- a/compiler-rt/lib/scudo/standalone/report_linux.cpp
+++ b/compiler-rt/lib/scudo/standalone/report_linux.cpp
@@ -33,6 +33,14 @@ void NORETURN reportMapError(uptr SizeIfOOM) {
   reportRawError(Error.data());
 }
 
+void NORETURN reportMapFixedError(uptr ExpectedAddr, uptr RequestedAddr) {
+  ScopedString Error;
+  Error.append("Scudo ERROR: internal map failure using fixed address "
+               "(expected: 0x%zx requested: 0x%zx)\n",
+               ExpectedAddr, RequestedAddr);
+  reportRawError(Error.data());
+}
+
 void NORETURN reportUnmapError(uptr Addr, uptr Size) {
   ScopedString Error;
   Error.append("Scudo ERROR: internal unmap failure (error desc=%s) Addr 0x%zx "

--- a/compiler-rt/lib/scudo/standalone/report_linux.h
+++ b/compiler-rt/lib/scudo/standalone/report_linux.h
@@ -21,6 +21,10 @@ namespace scudo {
 // hold the requested size on an out-of-memory error, 0 otherwise.
 void NORETURN reportMapError(uptr SizeIfOOM = 0);
 
+// Report a fatal error when a map call using a fixed address doesn't
+// return the requested address.
+void NORETURN reportMapFixedError(uptr ExpectedAddr, uptr RequestedAddr);
+
 // Report a fatal error when an unmap call fails.
 void NORETURN reportUnmapError(uptr Addr, uptr Size);
 

--- a/compiler-rt/lib/scudo/standalone/secondary.h
+++ b/compiler-rt/lib/scudo/standalone/secondary.h
@@ -306,8 +306,13 @@ public:
         // Fuchsia does not support replacing mappings by creating a new mapping
         // on top so we just do the two syscalls there.
         Entry.Time = 0;
-        mapSecondary<Config>(Options, Entry.CommitBase, Entry.CommitSize,
-                             Entry.CommitBase, MAP_NOACCESS, Entry.MemMap);
+        if (!mapSecondary<Config>(Options, Entry.CommitBase, Entry.CommitSize,
+                                  Entry.CommitBase, MAP_NOACCESS,
+                                  Entry.MemMap)) {
+          // A mmap failed, unmap and return.
+          unmapCallBack(Entry.MemMap);
+          return;
+        }
       } else {
         Entry.MemMap.setMemoryPermission(Entry.CommitBase, Entry.CommitSize,
                                          MAP_NOACCESS);

--- a/compiler-rt/lib/scudo/standalone/tests/report_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/report_test.cpp
@@ -105,6 +105,9 @@ TEST(ScudoReportDeathTest, Linux) {
   EXPECT_DEATH(scudo::reportMapError(1024U),
                "Scudo ERROR:.*internal map failure \\(error desc=.*\\) "
                "requesting 1KB");
+  EXPECT_DEATH(scudo::reportMapFixedError(0x1000U, 0x2000U),
+               "Scudo ERROR:.*internal map failure using fixed address "
+               "\\(expected: 0x1000 requested: 0x2000\\)");
   errno = ENOMEM;
   EXPECT_DEATH(scudo::reportUnmapError(0x1000U, 100U),
                "Scudo ERROR:.*internal unmap failure \\(error desc=.*\\) Addr "


### PR DESCRIPTION
Add a check if a fixed address mmap doesn't return the expected address.

Allow a remap call to fail if the mmap fails and returns a nullptr to the caller.

Fix a place where if remap fails in the secondary, it didn't do anything. Now it will unmap the original entry on failure.