### PR TITLE
Revert "[X86] matchBinaryPermuteShuffle - match to X86ISD::SHLD funnel shift patterns"

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -12902,42 +12902,6 @@ static SDValue lowerShuffleAsShift(const SDLoc &DL, MVT VT, SDValue V1,
   return DAG.getBitcast(VT, V);
 }
 
-/// Try to match a vector shuffle as a X86ISD::VSHLD funnel shift.
-static int matchShuffleAsVSHLD(MVT &ShiftVT, SDValue &V1, SDValue &V2,
-                               unsigned ScalarSizeInBits, ArrayRef<int> Mask) {
-  assert(isPowerOf2_32(ScalarSizeInBits) && ScalarSizeInBits >= 8 &&
-         "Unexpected element size");
-  int Size = Mask.size();
-  if (llvm::is_contained(Mask, SM_SentinelZero))
-    return -1;
-
-  SmallVector<int, 32> FunnelMask(Size);
-  for (int Scale = 2; (Scale * ScalarSizeInBits) <= 64; Scale *= 2) {
-    for (int Shift = 1; Shift != Scale; ++Shift) {
-      for (int Elt = 0; Elt != Size; Elt += Scale) {
-        std::iota(FunnelMask.begin() + Elt, FunnelMask.begin() + Elt + Shift,
-                  Elt + Size + (Scale - Shift));
-        std::iota(FunnelMask.begin() + Elt + Shift,
-                  FunnelMask.begin() + Elt + Scale, Elt);
-      }
-      if (isShuffleEquivalent(Mask, FunnelMask)) {
-        MVT ShiftSVT = MVT::getIntegerVT(ScalarSizeInBits * Scale);
-        ShiftVT = MVT::getVectorVT(ShiftSVT, Size / Scale);
-        return Shift * 8;
-      }
-      ShuffleVectorSDNode::commuteMask(FunnelMask);
-      if (isShuffleEquivalent(Mask, FunnelMask)) {
-        MVT ShiftSVT = MVT::getIntegerVT(ScalarSizeInBits * Scale);
-        ShiftVT = MVT::getVectorVT(ShiftSVT, Size / Scale);
-        std::swap(V1, V2);
-        return Shift * 8;
-      }
-    }
-  }
-
-  return -1;
-}
-
 // EXTRQ: Extract Len elements from lower half of source, starting at Idx.
 // Remainder of lower half result is zero and upper half is all undef.
 static bool matchShuffleAsEXTRQ(MVT VT, SDValue &V1, SDValue &V2,
@@ -40718,16 +40682,6 @@ static bool matchBinaryPermuteShuffle(
       Shuffle = X86ISD::PALIGNR;
       ShuffleVT = MVT::getVectorVT(MVT::i8, MaskVT.getSizeInBits() / 8);
       PermuteImm = ByteRotation;
-      return true;
-    }
-  }
-
-  // Attempt to match against VSHLD funnel shift.
-  if (AllowIntDomain && Subtarget.hasVBMI2()) {
-    int ShiftAmt = matchShuffleAsVSHLD(ShuffleVT, V1, V2, EltSizeInBits, Mask);
-    if (0 < ShiftAmt) {
-      Shuffle = X86ISD::VSHLD;
-      PermuteImm = (unsigned)ShiftAmt;
       return true;
     }
   }

--- a/llvm/test/CodeGen/X86/vector-shuffle-combining-avx512vbmi2.ll
+++ b/llvm/test/CodeGen/X86/vector-shuffle-combining-avx512vbmi2.ll
@@ -7,14 +7,16 @@
 define <16 x i8> @combine_vpshld_vpshufb(<16 x i8> %x, <16 x i8> %y) {
 ; VLX-LABEL: combine_vpshld_vpshufb:
 ; VLX:       # %bb.0:
-; VLX-NEXT:    vpshldq $56, %xmm0, %xmm1, %xmm0
+; VLX-NEXT:    vmovdqa {{.*#+}} xmm2 = [1,2,3,4,5,6,7,16,9,10,11,12,13,14,15,24]
+; VLX-NEXT:    vpermt2b %xmm1, %xmm2, %xmm0
 ; VLX-NEXT:    ret{{[l|q]}}
 ;
 ; NOVLX-LABEL: combine_vpshld_vpshufb:
 ; NOVLX:       # %bb.0:
 ; NOVLX-NEXT:    # kill: def $xmm1 killed $xmm1 def $zmm1
 ; NOVLX-NEXT:    # kill: def $xmm0 killed $xmm0 def $zmm0
-; NOVLX-NEXT:    vpshldq $56, %zmm0, %zmm1, %zmm0
+; NOVLX-NEXT:    vmovdqa {{.*#+}} xmm2 = [1,2,3,4,5,6,7,64,9,10,11,12,13,14,15,72]
+; NOVLX-NEXT:    vpermt2b %zmm1, %zmm2, %zmm0
 ; NOVLX-NEXT:    # kill: def $xmm0 killed $xmm0 killed $zmm0
 ; NOVLX-NEXT:    vzeroupper
 ; NOVLX-NEXT:    ret{{[l|q]}}
@@ -31,15 +33,18 @@ define <16 x i8> @combine_vpshld_vpshufb(<16 x i8> %x, <16 x i8> %y) {
 define <16 x i8> @combine_vpshrd_vpshufb(<16 x i8> %x, <16 x i8> %y) {
 ; VLX-LABEL: combine_vpshrd_vpshufb:
 ; VLX:       # %bb.0:
-; VLX-NEXT:    vpshldd $8, %xmm0, %xmm1, %xmm0
+; VLX-NEXT:    vmovdqa {{.*#+}} xmm2 = [19,0,1,2,23,4,5,6,27,8,9,10,31,12,13,14]
+; VLX-NEXT:    vpermi2b %xmm0, %xmm1, %xmm2
+; VLX-NEXT:    vmovdqa %xmm2, %xmm0
 ; VLX-NEXT:    ret{{[l|q]}}
 ;
 ; NOVLX-LABEL: combine_vpshrd_vpshufb:
 ; NOVLX:       # %bb.0:
 ; NOVLX-NEXT:    # kill: def $xmm1 killed $xmm1 def $zmm1
 ; NOVLX-NEXT:    # kill: def $xmm0 killed $xmm0 def $zmm0
-; NOVLX-NEXT:    vpshldd $8, %zmm0, %zmm1, %zmm0
-; NOVLX-NEXT:    # kill: def $xmm0 killed $xmm0 killed $zmm0
+; NOVLX-NEXT:    vmovdqa {{.*#+}} xmm2 = [67,0,1,2,71,4,5,6,75,8,9,10,79,12,13,14]
+; NOVLX-NEXT:    vpermi2b %zmm0, %zmm1, %zmm2
+; NOVLX-NEXT:    vmovdqa %xmm2, %xmm0
 ; NOVLX-NEXT:    vzeroupper
 ; NOVLX-NEXT:    ret{{[l|q]}}
   %rx = call <16 x i8> @llvm.x86.ssse3.pshuf.b.128(<16 x i8> %x, <16 x i8> <i8 15, i8 14, i8 13, i8 12, i8 11, i8 10, i8 9, i8 8, i8 7, i8 6, i8 5, i8 4, i8 3, i8 2, i8 1, i8 0>)
@@ -55,16 +60,14 @@ define <16 x i8> @combine_vpshrd_vpshufb(<16 x i8> %x, <16 x i8> %y) {
 define <8 x i8> @PR145276(<8 x i8> %a0, <8 x i8> %a1) {
 ; VLX-LABEL: PR145276:
 ; VLX:       # %bb.0:
-; VLX-NEXT:    vpshldq $8, %xmm1, %xmm0, %xmm0
+; VLX-NEXT:    vpunpcklbw {{.*#+}} xmm0 = xmm0[0],xmm1[0],xmm0[1],xmm1[1],xmm0[2],xmm1[2],xmm0[3],xmm1[3],xmm0[4],xmm1[4],xmm0[5],xmm1[5],xmm0[6],xmm1[6],xmm0[7],xmm1[7]
+; VLX-NEXT:    vpshufb {{.*#+}} xmm0 = xmm0[15,0,2,4,6,8,10,12,u,u,u,u,u,u,u,u]
 ; VLX-NEXT:    ret{{[l|q]}}
 ;
 ; NOVLX-LABEL: PR145276:
 ; NOVLX:       # %bb.0:
-; NOVLX-NEXT:    # kill: def $xmm1 killed $xmm1 def $zmm1
-; NOVLX-NEXT:    # kill: def $xmm0 killed $xmm0 def $zmm0
-; NOVLX-NEXT:    vpshldq $8, %zmm1, %zmm0, %zmm0
-; NOVLX-NEXT:    # kill: def $xmm0 killed $xmm0 killed $zmm0
-; NOVLX-NEXT:    vzeroupper
+; NOVLX-NEXT:    vpunpcklbw {{.*#+}} xmm0 = xmm0[0],xmm1[0],xmm0[1],xmm1[1],xmm0[2],xmm1[2],xmm0[3],xmm1[3],xmm0[4],xmm1[4],xmm0[5],xmm1[5],xmm0[6],xmm1[6],xmm0[7],xmm1[7]
+; NOVLX-NEXT:    vpshufb {{.*#+}} xmm0 = xmm0[15,0,2,4,6,8,10,12,u,u,u,u,u,u,u,u]
 ; NOVLX-NEXT:    ret{{[l|q]}}
   %r = shufflevector <8 x i8> %a0, <8 x i8> %a1, <8 x i32> <i32 15, i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6>
   ret <8 x i8> %r


### PR DESCRIPTION
Reverts llvm/llvm-project#200136 while I investigate a miscompilation report