### PR TITLE
[Clang][test] Fix leading slash

### DIFF
--- a/clang/test/Driver/freebsd.c
+++ b/clang/test/Driver/freebsd.c
@@ -105,25 +105,25 @@
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mips-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPS %s
-// CHECK-MIPS: ld{{[^" ]*}}"
+// CHECK-MIPS: {{[/\\"]}}ld{{[^" ]*}}"
 // CHECK-MIPS: "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
 // CHECK-MIPS-NOT: "--hash-style={{gnu|both}}"
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mipsel-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPSEL %s
-// CHECK-MIPSEL: ld{{[^" ]*}}"
+// CHECK-MIPSEL: {{[/\\"]}}ld{{[^" ]*}}"
 // CHECK-MIPSEL: "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
 // CHECK-MIPSEL-NOT: "--hash-style={{gnu|both}}"
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mips64-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPS64 %s
-// CHECK-MIPS64: ld{{[^" ]*}}"
+// CHECK-MIPS64: {{[/\\"]}}ld{{[^" ]*}}"
 // CHECK-MIPS64: "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
 // CHECK-MIPS64-NOT: "--hash-style={{gnu|both}}"
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mips64el-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPS64EL %s
-// CHECK-MIPS64EL: ld{{[^" ]*}}"
+// CHECK-MIPS64EL: {{[/\\"]}}ld{{[^" ]*}}"
 // CHECK-MIPS64EL: "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
 // CHECK-MIPS64EL-NOT: "--hash-style={{gnu|both}}"
 

--- a/clang/test/Driver/freebsd.c
+++ b/clang/test/Driver/freebsd.c
@@ -105,25 +105,25 @@
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mips-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPS %s
-// CHECK-MIPS: {{[/\\]}}ld{{[^" ]*}}"
+// CHECK-MIPS: ld{{[^" ]*}}"
 // CHECK-MIPS: "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
 // CHECK-MIPS-NOT: "--hash-style={{gnu|both}}"
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mipsel-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPSEL %s
-// CHECK-MIPSEL: {{[/\\]}}ld{{[^" ]*}}"
+// CHECK-MIPSEL: ld{{[^" ]*}}"
 // CHECK-MIPSEL: "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
 // CHECK-MIPSEL-NOT: "--hash-style={{gnu|both}}"
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mips64-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPS64 %s
-// CHECK-MIPS64: {{[/\\]}}ld{{[^" ]*}}"
+// CHECK-MIPS64: ld{{[^" ]*}}"
 // CHECK-MIPS64: "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
 // CHECK-MIPS64-NOT: "--hash-style={{gnu|both}}"
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mips64el-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPS64EL %s
-// CHECK-MIPS64EL: {{[/\\]}}ld{{[^" ]*}}"
+// CHECK-MIPS64EL: ld{{[^" ]*}}"
 // CHECK-MIPS64EL: "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
 // CHECK-MIPS64EL-NOT: "--hash-style={{gnu|both}}"
 


### PR DESCRIPTION
A reviewer in #200012 required checking for a leading (back-)slash to the test despite none of the other tests doing so. Turns out, the slash isn't there if the driver is unable to resolve the full path to the linker. Remove the leading slash from the test.

Fixes reported buildbot failures:
 * [clang-debian-cpp20](https://lab.llvm.org/buildbot/#/builders/108)
 * [clang-s390x-linux-multistage](https://lab.llvm.org/buildbot/#/builders/98)
 * [clang-solaris11-sparcv9](https://lab.llvm.org/buildbot/#/builders/13)
 * [clang-solaris11-amd64](https://lab.llvm.org/staging/#/builders/120)
 