### PR TITLE
[IR] Fix !invariant.group in combineMetadataForCSE when K moves

### DIFF
--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -3008,21 +3008,16 @@ static void combineMetadata(Instruction *K, const Instruction *J,
           K->setMetadata(Kind, MDNode::getMostGenericFPMath(JMD, KMD));
         break;
       case LLVMContext::MD_invariant_load:
-        // If K moves, only set the !invariant.load if it is present in both
-        // instructions.
+      case LLVMContext::MD_invariant_group:
+	// If K moves, only keep the invariant metadata if it is present on
+	// both instructions; otherwise the invariant would be asserted on a
+	// path (J's) that never promised it. If K does not move, K stays on
+	// its original path, so its existing metadata remains valid.
         if (DoesKMove)
           K->setMetadata(Kind, JMD);
         break;
       case LLVMContext::MD_nonnull:
         if (!AAOnly && (DoesKMove || !K->hasMetadata(LLVMContext::MD_noundef)))
-          K->setMetadata(Kind, JMD);
-        break;
-      case LLVMContext::MD_invariant_group:
-        // If K moves, only keep !invariant.group if it is present on both
-        // instructions; otherwise the invariant would be asserted on a path
-        // (J's) that never promised it. If K does not move, K stays on its
-        // original path, so its metadata remains valid.
-        if (DoesKMove)
           K->setMetadata(Kind, JMD);
         break;
       // Keep empty cases for prof, mmra, memprof, and callsite to prevent them
@@ -3087,15 +3082,6 @@ static void combineMetadata(Instruction *K, const Instruction *J,
         break;
       }
   }
-  // Set !invariant.group from J if J has it. If both instructions have it
-  // then we will just pick it from J - even when they are different.
-  // Also make sure that K is load or store - f.e. combining bitcast with load
-  // could produce bitcast with invariant.group metadata, which is invalid.
-  // FIXME: we should try to preserve both invariant.group md if they are
-  // different, but right now instruction can only have one invariant.group.
-  if (auto *JMD = J->getMetadata(LLVMContext::MD_invariant_group))
-    if (isa<LoadInst>(K) || isa<StoreInst>(K))
-      K->setMetadata(LLVMContext::MD_invariant_group, JMD);
 
   // Merge MMRAs.
   // This is handled separately because we also want to handle cases where K

--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -3018,7 +3018,12 @@ static void combineMetadata(Instruction *K, const Instruction *J,
           K->setMetadata(Kind, JMD);
         break;
       case LLVMContext::MD_invariant_group:
-        // Preserve !invariant.group in K.
+        // If K moves, only keep !invariant.group if it is present on both
+        // instructions; otherwise the invariant would be asserted on a path
+        // (J's) that never promised it. If K does not move, K stays on its
+        // original path, so its metadata remains valid.
+        if (DoesKMove)
+          K->setMetadata(Kind, JMD);
         break;
       // Keep empty cases for prof, mmra, memprof, and callsite to prevent them
       // from being removed as unknown metadata. The actual merging is handled

--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -3009,10 +3009,10 @@ static void combineMetadata(Instruction *K, const Instruction *J,
         break;
       case LLVMContext::MD_invariant_load:
       case LLVMContext::MD_invariant_group:
-	// If K moves, only keep the invariant metadata if it is present on
-	// both instructions; otherwise the invariant would be asserted on a
-	// path (J's) that never promised it. If K does not move, K stays on
-	// its original path, so its existing metadata remains valid.
+        // If K moves, only keep the invariant metadata if it is present on
+        // both instructions; otherwise the invariant would be asserted on a
+        // path (J's) that never promised it. If K does not move, K stays on
+        // its original path, so its existing metadata remains valid.
         if (DoesKMove)
           K->setMetadata(Kind, JMD);
         break;

--- a/llvm/test/Transforms/GVN/invariant.group.ll
+++ b/llvm/test/Transforms/GVN/invariant.group.ll
@@ -213,7 +213,7 @@ define void @loadCombine1() {
 ; CHECK-NEXT:    [[PTR:%.*]] = alloca i8, align 1
 ; CHECK-NEXT:    store i8 42, ptr [[PTR]], align 1
 ; CHECK-NEXT:    call void @foo(ptr [[PTR]])
-; CHECK-NEXT:    [[C:%.*]] = load i8, ptr [[PTR]], align 1, !invariant.group [[META0]]
+; CHECK-NEXT:    [[C:%.*]] = load i8, ptr [[PTR]], align 1
 ; CHECK-NEXT:    call void @bar(i8 [[C]])
 ; CHECK-NEXT:    call void @bar(i8 [[C]])
 ; CHECK-NEXT:    ret void

--- a/llvm/test/Transforms/NewGVN/invariant.group.ll
+++ b/llvm/test/Transforms/NewGVN/invariant.group.ll
@@ -222,7 +222,7 @@ define void @loadCombine1() {
 ; CHECK-NEXT:    [[PTR:%.*]] = alloca i8, align 1
 ; CHECK-NEXT:    store i8 42, ptr [[PTR]], align 1
 ; CHECK-NEXT:    call void @foo(ptr [[PTR]])
-; CHECK-NEXT:    [[C:%.*]] = load i8, ptr [[PTR]], align 1, !invariant.group [[META0]]
+; CHECK-NEXT:    [[C:%.*]] = load i8, ptr [[PTR]], align 1
 ; CHECK-NEXT:    call void @bar(i8 [[C]])
 ; CHECK-NEXT:    call void @bar(i8 [[C]])
 ; CHECK-NEXT:    ret void

--- a/llvm/test/Transforms/SimplifyCFG/merge-cond-stores.ll
+++ b/llvm/test/Transforms/SimplifyCFG/merge-cond-stores.ll
@@ -409,6 +409,66 @@ end:
 
 !0 = !{!"branch_weights", i32 7, i32 13}
 !1 = !{!"branch_weights", i32 3, i32 11}
+
+; When both merged stores carry the same !invariant.group, every path already
+; asserted that its stored value was the group's invariant value, so the merged
+; store may keep !invariant.group.
+define void @merge_keeps_invariant_group_when_both(i1 %c1, i1 %c2, ptr %p, i32 %a, i32 %b) {
+; CHECK-LABEL: @merge_keeps_invariant_group_when_both(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[TMP0:%.*]] = or i1 [[C1:%.*]], [[C2:%.*]]
+; CHECK-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; CHECK:       1:
+; CHECK-NEXT:    [[SPEC_SELECT:%.*]] = select i1 [[C2]], i32 [[B:%.*]], i32 [[A:%.*]]
+; CHECK-NEXT:    store i32 [[SPEC_SELECT]], ptr [[P:%.*]], align 4, !invariant.group [[META1:![0-9]+]]
+; CHECK-NEXT:    br label [[TMP2]]
+; CHECK:       2:
+; CHECK-NEXT:    ret void
+;
+entry:
+  br i1 %c1, label %t1, label %m
+t1:
+  store i32 %a, ptr %p, !invariant.group !2
+  br label %m
+m:
+  br i1 %c2, label %t2, label %e
+t2:
+  store i32 %b, ptr %p, !invariant.group !2
+  br label %e
+e:
+  ret void
+}
+
+; When only one of the merged stores carries !invariant.group, keeping it would
+; assert the invariant on the other store's path, which never promised it. The
+; merged store must drop !invariant.group.
+define void @merge_drops_invariant_group_when_asymmetric(i1 %c1, i1 %c2, ptr %p, i32 %a, i32 %b) {
+; CHECK-LABEL: @merge_drops_invariant_group_when_asymmetric(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[TMP0:%.*]] = or i1 [[C1:%.*]], [[C2:%.*]]
+; CHECK-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; CHECK:       1:
+; CHECK-NEXT:    [[SPEC_SELECT:%.*]] = select i1 [[C2]], i32 [[B:%.*]], i32 [[A:%.*]]
+; CHECK-NEXT:    store i32 [[SPEC_SELECT]], ptr [[P:%.*]], align 4
+; CHECK-NEXT:    br label [[TMP2]]
+; CHECK:       2:
+; CHECK-NEXT:    ret void
+;
+entry:
+  br i1 %c1, label %t1, label %m
+t1:
+  store i32 %a, ptr %p, !invariant.group !2
+  br label %m
+m:
+  br i1 %c2, label %t2, label %e
+t2:
+  store i32 %b, ptr %p
+  br label %e
+e:
+  ret void
+}
+!2 = !{}
 ;.
 ; CHECK: [[PROF0]] = !{!"branch_weights", i32 137, i32 143}
+; CHECK: [[META1]] = !{}
 ;.


### PR DESCRIPTION
SimplifyCFG mergeConditionalStoreToAddress currently transforms

    if (cond)
      store ptr, x !invariant.group;
    else
      store ptr, y;

into

    store ptr, select(cond, x, y) !invariant.group;  // BUG

It's clearly not valid to preserve !invariant.group here.

Fix this inside combineMetadataForCSE.  It can only preserve
!invariant.group if

 1. !DoesKMove, meaning that original instruction ("K") is replaced by
    the combined instruction in place, without moving it,
 2. Both stores have !invariant.group.

This matches the logic for preserving !invariant.load.

This bug was found by a large run of Opus 4.7 looking for bugs in LLVM.