### PR TITLE
[libc] Add sys/param.h header

### DIFF
--- a/libc/config/linux/aarch64/headers.txt
+++ b/libc/config/linux/aarch64/headers.txt
@@ -40,6 +40,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_epoll
     libc.include.sys_ioctl
     libc.include.sys_mman
+    libc.include.sys_param
     libc.include.sys_personality
     libc.include.sys_prctl
     libc.include.sys_queue

--- a/libc/config/linux/arm/headers.txt
+++ b/libc/config/linux/arm/headers.txt
@@ -20,6 +20,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.wchar
     libc.include.wctype
 
+    libc.include.sys_param
     libc.include.sys_personality
 
     # Disabled due to epoll_wait syscalls not being available on this platform.

--- a/libc/config/linux/riscv/headers.txt
+++ b/libc/config/linux/riscv/headers.txt
@@ -40,6 +40,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_epoll
     libc.include.sys_ioctl
     libc.include.sys_mman
+    libc.include.sys_param
     libc.include.sys_personality
     libc.include.sys_prctl
     libc.include.sys_queue

--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -42,6 +42,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_ioctl
     libc.include.sys_ipc
     libc.include.sys_mman
+    libc.include.sys_param
     libc.include.sys_personality
     libc.include.sys_prctl
     libc.include.sys_queue

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -669,6 +669,15 @@ add_header_macro(
 )
 
 add_header_macro(
+  sys_param
+  ../libc/include/sys/param.yaml
+  sys/param.h
+  DEPENDS
+    .llvm_libc_common_h
+    .llvm-libc-macros.sys_param_macros
+)
+
+add_header_macro(
   sys_personality
   ../libc/include/sys/personality.yaml
   sys/personality.h

--- a/libc/include/llvm-libc-macros/CMakeLists.txt
+++ b/libc/include/llvm-libc-macros/CMakeLists.txt
@@ -268,6 +268,14 @@ add_macro_header(
 )
 
 add_macro_header(
+  sys_param_macros
+  HDR
+    sys-param-macros.h
+  DEPENDS
+    .limits_macros
+)
+
+add_macro_header(
   sys_queue_macros
   HDR
     sys-queue-macros.h

--- a/libc/include/llvm-libc-macros/sys-param-macros.h
+++ b/libc/include/llvm-libc-macros/sys-param-macros.h
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Definition of macros from sys/param.h.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_MACROS_SYS_PARAM_MACROS_H
+#define LLVM_LIBC_MACROS_SYS_PARAM_MACROS_H
+
+#include "limits-macros.h"
+
+// Number Bits per BYte
+#ifndef NBBY
+#ifdef __CHAR_BIT__
+#define NBBY __CHAR_BIT__
+#else
+#define NBBY 8
+#endif
+#endif
+
+#ifndef MIN
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+
+#ifndef MAX
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+
+#ifndef howmany
+#define howmany(n, d) (((n) + ((d) - 1)) / (d))
+#endif
+
+#ifndef roundup
+#define roundup(n, d) (howmany(n, d) * (d))
+#endif
+
+#ifndef powerof2
+#define powerof2(n) !(((n) - 1) & (n))
+#endif
+
+#ifndef MAXPATHLEN
+#ifdef PATH_MAX
+#define MAXPATHLEN PATH_MAX
+#else
+#define MAXPATHLEN 4096
+#endif
+#endif
+
+#endif // LLVM_LIBC_MACROS_SYS_PARAM_MACROS_H

--- a/libc/include/sys/param.yaml
+++ b/libc/include/sys/param.yaml
@@ -1,0 +1,22 @@
+header: sys/param.h
+standards:
+  - bsd
+macros:
+  - macro_name: NBBY
+    macro_header: sys-param-macros.h
+  - macro_name: MIN
+    macro_header: sys-param-macros.h
+  - macro_name: MAX
+    macro_header: sys-param-macros.h
+  - macro_name: howmany
+    macro_header: sys-param-macros.h
+  - macro_name: roundup
+    macro_header: sys-param-macros.h
+  - macro_name: powerof2
+    macro_header: sys-param-macros.h
+  - macro_name: MAXPATHLEN
+    macro_header: sys-param-macros.h
+types: []
+enums: []
+objects: []
+functions: []


### PR DESCRIPTION
Added the sys/param.h header containing standard BSD macros:

* NBBY
* MIN and MAX
* howmany, roundup, and powerof2
* MAXPATHLEN

The macros are defined in llvm-libc-macros/sys-param-macros.h with guards to prevent redefinition conflicts.

Enabled the header for x86_64, aarch64, riscv, and arm Linux targets.

Assisted-by: Automated tooling, human reviewed.