### PR TITLE
[bazel] Fix compiler-rt:interception

### DIFF
--- a/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
@@ -60,10 +60,11 @@ cc_library(
     name = "interception",
     srcs = glob(["lib/interception/*.cpp"]),
     hdrs = glob(["lib/interception/*.h"]),
-    includes = ["lib"],
     copts = [
+        "-fomit-frame-pointer",
         "-fvisibility=hidden",
     ],
+    includes = ["lib"],
     linkstatic = True,
     deps = [
         ":sanitizer_common_headers",

--- a/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
@@ -15,6 +15,7 @@ cc_library(
     name = "config",
     defines = select({
         "@platforms//os:linux": [
+            "COMPILER_RT_BUILD_PROFILE_ROCM=1",
             "COMPILER_RT_HAS_ATOMICS=1",
             "COMPILER_RT_HAS_FCNTL_LCK=1",
             "COMPILER_RT_HAS_UNAME=1",
@@ -46,7 +47,6 @@ cc_library(
     srcs = glob(
         [
             "lib/sanitizer_common/*.cpp",
-            "lib/sanitizer_common/*.S",
         ],
     ),
     linkstatic = True,
@@ -60,7 +60,10 @@ cc_library(
     name = "interception",
     srcs = glob(["lib/interception/*.cpp"]),
     hdrs = glob(["lib/interception/*.h"]),
-    includes = [":lib"],
+    includes = ["lib"],
+    copts = [
+        "-fvisibility=hidden",
+    ],
     linkstatic = True,
     deps = [
         ":sanitizer_common_headers",


### PR DESCRIPTION
- Add `-DCOMPILER_RT_BUILD_PROFILE_ROCM=1`
- Prune `"lib/sanitizer_common/*.S"`, it means `*.inc.S`
- Add `-fvisibility=hidden`

Bazel doesn't add `-gline-tables-only` by default. Add flags to CMake side to align the build to Bazel.

- `-DCOMPILER_RT_HAS_G_FLAG=OFF`
- `-DCOMPILER_RT_HAS_GLINE_TABLES_ONLY_FLAG=OFF`