### PR TITLE
[Demangle] Fix compilation on MSVC

### DIFF
--- a/llvm/lib/Demangle/MicrosoftDemangle.cpp
+++ b/llvm/lib/Demangle/MicrosoftDemangle.cpp
@@ -2544,7 +2544,7 @@ char *llvm::microsoftDemangle(std::string_view MangledName, size_t *NMangled,
     OF = OutputFlags(OF | OF_NoVariableType);
 
   int InternalStatus = demangle_success;
-  char *Buf;
+  char *Buf = nullptr;
   if (D.Error)
     InternalStatus = demangle_invalid_mangled_name;
   else {


### PR DESCRIPTION
Fix uninitialized variable compilation error when using the MSVC v145 compiler on Visual Studio 2026