### PR TITLE
[clang][SemaCXX] Fix crash caused by unresolved overloaded function type when using `__builtin_bit_cast`

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -619,6 +619,8 @@ Bug Fixes to Compiler Builtins
 - Fixed a crash when calling `__builtin_allow_sanitize_check` with no arguments. (#GH183927)
 - ``__annotation`` is now diagnosed as unsupported on non-Windows/UEFI targets, fixing a
   crash when using it with ``-fms-extensions`` on other platforms. (#GH184318)
+- Fixed a compiler crash due to an unresolved overloaded function type when
+  calling ``__builtin_bit_cast``. (#GH200112)
 
 Bug Fixes to Attribute Support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaCast.cpp
+++ b/clang/lib/Sema/SemaCast.cpp
@@ -439,6 +439,13 @@ ExprResult Sema::ActOnBuiltinBitCastExpr(SourceLocation KWLoc, Declarator &D,
 ExprResult Sema::BuildBuiltinBitCastExpr(SourceLocation KWLoc,
                                          TypeSourceInfo *TSI, Expr *Operand,
                                          SourceLocation RParenLoc) {
+  if (Operand->hasPlaceholderType()) {
+    ExprResult PR = CheckPlaceholderExpr(Operand);
+    if (PR.isInvalid())
+      return ExprError();
+    Operand = PR.get();
+  }
+
   CastOperation Op(*this, TSI->getType(), Operand);
   Op.OpRange = CastOperation::OpRangeType(KWLoc, KWLoc, RParenLoc);
   TypeLoc TL = TSI->getTypeLoc();

--- a/clang/test/SemaCXX/builtin-bit-cast.cpp
+++ b/clang/test/SemaCXX/builtin-bit-cast.cpp
@@ -46,3 +46,13 @@ extern S<int> extern_decl;
 int x = __builtin_bit_cast(int, extern_decl);
 S<char> y = __builtin_bit_cast(S<char>, 0);
 }
+
+template <class To, class From>
+// expected-note@+1{{possible target for call}}
+constexpr To bit_cast(const From &from) {
+  return __builtin_bit_cast(To, bit_cast);
+  // expected-error@-1{{reference to overloaded function could not be resolved; did you mean to call it?}}
+} // expected-note {{control reached end of constexpr function}}
+constexpr __int128_t foo = bit_cast<__int128_t>((long double)0);
+// expected-error@-1{{constexpr variable 'foo' must be initialized by a constant expression}}
+// expected-note@-2{{in call to 'bit_cast<__int128, long double>((long double)0)'}}


### PR DESCRIPTION
Resolves #200112

By early checking for placeholder expressions, crash can be avoided for unreachable builtin type when fetching type info.