### PR TITLE
[Clang][test] Use canonical linker line check

### DIFF
--- a/clang/test/Driver/freebsd.c
+++ b/clang/test/Driver/freebsd.c
@@ -99,33 +99,23 @@
 // CHECK-LDFLAGS_HASH: --hash-style=both
 // CHECK-LDFLAGS_HASH: --enable-new-dtags
 //
-// Check that we do not pass --hash-style=gnu and --hash-style=both to linker
-// and provide correct path to the dynamic linker for MIPS platforms.
-// Also verify that we tell the assembler to target the right ISA and ABI.
+// Verify that we tell the assembler to target the right ISA and ABI.
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mips-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPS %s
-// CHECK-MIPS: {{[/\\"]}}ld{{[^" ]*}}"
-// CHECK-MIPS: "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
-// CHECK-MIPS-NOT: "--hash-style={{gnu|both}}"
+// CHECK-MIPS: ld{{.*}}" {{.*}} "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mipsel-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPSEL %s
-// CHECK-MIPSEL: {{[/\\"]}}ld{{[^" ]*}}"
-// CHECK-MIPSEL: "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
-// CHECK-MIPSEL-NOT: "--hash-style={{gnu|both}}"
+// CHECK-MIPSEL: ld{{.*}}" {{.*}} "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mips64-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPS64 %s
-// CHECK-MIPS64: {{[/\\"]}}ld{{[^" ]*}}"
-// CHECK-MIPS64: "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
-// CHECK-MIPS64-NOT: "--hash-style={{gnu|both}}"
+// CHECK-MIPS64:ld{{.*}}" {{.*}} "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mips64el-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPS64EL %s
-// CHECK-MIPS64EL: {{[/\\"]}}ld{{[^" ]*}}"
-// CHECK-MIPS64EL: "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
-// CHECK-MIPS64EL-NOT: "--hash-style={{gnu|both}}"
+// CHECK-MIPS64EL: ld{{.*}}" {{.*}} "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
 
 // RUN: %clang --target=x86_64-pc-freebsd -static %s \
 // RUN:   --sysroot=%S/Inputs/multiarch_freebsd64_tree -### 2>&1 \

--- a/clang/test/Driver/freebsd.c
+++ b/clang/test/Driver/freebsd.c
@@ -99,23 +99,41 @@
 // CHECK-LDFLAGS_HASH: --hash-style=both
 // CHECK-LDFLAGS_HASH: --enable-new-dtags
 //
-// Verify that we tell the assembler to target the right ISA and ABI.
+// Check that we do not pass --hash-style=gnu and --hash-style=both to linker
+// and provide correct path to the dynamic linker for MIPS platforms.
+// Also verify that we tell the assembler to target the right ISA and ABI.
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mips-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPS %s
+// RUN: %clang -### %s 2>&1 \
+// RUN:     --target=mips-unknown-freebsd10.0 \
+// RUN:   | FileCheck --check-prefix=CHECK-MIPS_HASHSTYLE %s
 // CHECK-MIPS: ld{{.*}}" {{.*}} "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
+// CHECK-MIPS_HASHSTYLE-NOT: "--hash-style={{gnu|both}}"
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mipsel-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPSEL %s
+// RUN: %clang -### %s 2>&1 \
+// RUN:     --target=mipsel-unknown-freebsd10.0 \
+// RUN:   | FileCheck --check-prefix=CHECK-MIPSEL_HASHSTYLE %s
 // CHECK-MIPSEL: ld{{.*}}" {{.*}} "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
+// CHECK-MIPSEL_HASHSTYLE-NOT: "--hash-style={{gnu|both}}"
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mips64-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPS64 %s
+// RUN: %clang -### %s 2>&1 \
+// RUN:     --target=mips64-unknown-freebsd10.0 \
+// RUN:   | FileCheck --check-prefix=CHECK-MIPS64_HASHSTYLE %s
 // CHECK-MIPS64:ld{{.*}}" {{.*}} "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
+// CHECK-MIPS64_HASHSTYLE-NOT: "--hash-style={{gnu|both}}"
 // RUN: %clang -### %s 2>&1 \
 // RUN:     --target=mips64el-unknown-freebsd10.0 \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPS64EL %s
+// RUN: %clang -### %s 2>&1 \
+// RUN:     --target=mips64el-unknown-freebsd10.0 \
+// RUN:   | FileCheck --check-prefix=CHECK-MIPS64EL_HASHSTYLE %s
 // CHECK-MIPS64EL: ld{{.*}}" {{.*}} "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
+// CHECK-MIPS64EL_HASHSTYLE-NOT: "--hash-style={{gnu|both}}"
 
 // RUN: %clang --target=x86_64-pc-freebsd -static %s \
 // RUN:   --sysroot=%S/Inputs/multiarch_freebsd64_tree -### 2>&1 \


### PR DESCRIPTION
#200549 unfortunately did not fix the freebsd.c test everywhere, in particular [clang-s390x-linux-multistage](https://lab.llvm.org/buildbot/#/builders/98) is now failing.

Further analysis showed that the MIPS test was broken from the start:
```
// CHECK-MIPS: "{{[^" ]*}}ld{{[^" ]*}}"
```
This file match "ld" in "buildbot" occuring in `"/opt/llvm-buildbot/home/solaris11-sparcv9/clang-solaris11-sparcv9/stage1/bin/clang-23" -fc1` (the frontend invocation line) since most buildbots use "buildbot" in their builder directory name. `clang-s390x-linux-multistage` does not, its clang path is `"/home/uweigand/sandbox/buildbot/clang-s390x-linux-multistage/stage2/bin/clang-23"`.

```
// CHECK-MIPS: "-dynamic-linker" "{{.*}}/libexec/ld-elf.so.1"
```
is missing the "-SAME" modifier, so can only match the next line. Because that was the `-fc1` line for most builders, it works there. Except `clang-s390x-linux-multistage`, where it was expected after the linker line.

```
// CHECK-MIPS-NOT: "--hash-style={{gnu|both}}"
```
This would again match something only after the linker line. It never had a chance to match. This is why `-NOT` tests are considered fragile.

Fixing the MIPS test by using the same CHECK pattern as for all the other architectures. Unfortunately `-SAME-NOT` is not supported by FileCheck, so invoking the same command a second time to ensure no --hash-style appears.

Will fix the [clang-s390x-linux-multistage](https://lab.llvm.org/buildbot/#/builders/98) buildbot.