### PR TITLE
[InstCombine] Fix miscompilation when folding cttz with non-powers-of-2

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -42,6 +42,7 @@
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/KnownBits.h"
+#include "llvm/Support/MathExtras.h"
 #include "llvm/Transforms/InstCombine/InstCombiner.h"
 #include <cassert>
 #include <optional>
@@ -1506,7 +1507,8 @@ static Instruction *foldSelectCtlzToCttz(ICmpInst *ICI, Value *TrueVal,
                                          Value *FalseVal,
                                          InstCombiner::BuilderTy &Builder) {
   unsigned BitWidth = TrueVal->getType()->getScalarSizeInBits();
-  if (!ICI->isEquality() || !match(ICI->getOperand(1), m_Zero()))
+  if (!isPowerOf2_64(BitWidth) || !ICI->isEquality() ||
+      !match(ICI->getOperand(1), m_Zero()))
     return nullptr;
 
   if (ICI->getPredicate() == ICmpInst::ICMP_NE)

--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -1507,7 +1507,7 @@ static Instruction *foldSelectCtlzToCttz(ICmpInst *ICI, Value *TrueVal,
                                          Value *FalseVal,
                                          InstCombiner::BuilderTy &Builder) {
   unsigned BitWidth = TrueVal->getType()->getScalarSizeInBits();
-  if (!isPowerOf2_64(BitWidth) || !ICI->isEquality() ||
+  if (!isPowerOf2_32(BitWidth) || !ICI->isEquality() ||
       !match(ICI->getOperand(1), m_Zero()))
     return nullptr;
 

--- a/llvm/test/Transforms/InstCombine/select-ctlz-to-cttz.ll
+++ b/llvm/test/Transforms/InstCombine/select-ctlz-to-cttz.ll
@@ -2,8 +2,6 @@
 ; RUN: opt -passes=instcombine -S < %s | FileCheck %s
 
 declare i3 @llvm.cttz.i3(i3, i1)
-declare i33 @llvm.cttz.i33(i33, i1)
-declare i33 @llvm.ctlz.i33(i33, i1)
 declare i32 @llvm.cttz.i32(i32, i1 immarg)
 declare i32 @llvm.ctlz.i32(i32, i1 immarg)
 declare i64 @llvm.cttz.i64(i64, i1 immarg)

--- a/llvm/test/Transforms/InstCombine/select-ctlz-to-cttz.ll
+++ b/llvm/test/Transforms/InstCombine/select-ctlz-to-cttz.ll
@@ -2,6 +2,8 @@
 ; RUN: opt -passes=instcombine -S < %s | FileCheck %s
 
 declare i3 @llvm.cttz.i3(i3, i1)
+declare i33 @llvm.cttz.i33(i33, i1)
+declare i33 @llvm.ctlz.i33(i33, i1)
 declare i32 @llvm.cttz.i32(i32, i1 immarg)
 declare i32 @llvm.ctlz.i32(i32, i1 immarg)
 declare i64 @llvm.cttz.i64(i64, i1 immarg)
@@ -129,6 +131,27 @@ define i64 @select_clz_to_ctz_i64(i64 %a) {
   %sub1 = xor i64 %lz, 63
   %cond = select i1 %tobool, i64 %lz, i64 %sub1
   ret i64 %cond
+}
+
+; Negative test: xor with (bitwidth - 1) is not (bitwidth - 1) - ctlz when
+; bitwidth is not a power of two (here i33: 31 xor 32 = 63, not cttz(2) = 1).
+define i33 @select_clz_to_ctz_xor_non_pot(i33 %a) {
+; CHECK-LABEL: @select_clz_to_ctz_xor_non_pot(
+; CHECK-NEXT:    [[SUB:%.*]] = sub i33 0, [[A:%.*]]
+; CHECK-NEXT:    [[AND:%.*]] = and i33 [[A]], [[SUB]]
+; CHECK-NEXT:    [[LZ:%.*]] = tail call range(i33 0, 34) i33 @llvm.ctlz.i33(i33 [[AND]], i1 false)
+; CHECK-NEXT:    [[TOBOOL:%.*]] = icmp eq i33 [[A]], 0
+; CHECK-NEXT:    [[SUB1:%.*]] = xor i33 [[LZ]], 32
+; CHECK-NEXT:    [[COND:%.*]] = select i1 [[TOBOOL]], i33 33, i33 [[SUB1]]
+; CHECK-NEXT:    ret i33 [[COND]]
+;
+  %sub = sub i33 0, %a
+  %and = and i33 %sub, %a
+  %lz = tail call i33 @llvm.ctlz.i33(i33 %and, i1 false)
+  %tobool = icmp eq i33 %a, 0
+  %sub1 = xor i33 %lz, 32
+  %cond = select i1 %tobool, i33 33, i33 %sub1
+  ret i33 %cond
 }
 
 ; Negative tests


### PR DESCRIPTION
Does not fold correctly: https://alive2.llvm.org/ce/z/uhHnBd