### PR TITLE
[lldb-server] Add breakpoint support to accelerator plugin protocol

### DIFF
--- a/lldb/docs/resources/lldbgdbremote.md
+++ b/lldb/docs/resources/lldbgdbremote.md
@@ -174,8 +174,7 @@ support. Not needed for non-hardware-accelerator debugging.
 ## jAcceleratorPluginBreakpointHit
 
 Sent by the client when a breakpoint requested by an accelerator plugin
-is hit in the native process. Breakpoints can originate from any response
-that contains `AcceleratorActions`. This packet requires the
+is hit in the native process. This packet requires the
 `accelerator-plugins+` feature from `qSupported`.
 
 ```
@@ -197,7 +196,7 @@ The response JSON has the following fields:
 |----------------------|------|-------------|
 | `disable_bp`         | bool   | If true, the client should disable this breakpoint. |
 | `auto_resume_native` | bool   | If true, the native process should automatically resume after handling the hit. |
-| `actions`            | object | Optional `AcceleratorActions` containing new breakpoints to set and other actions to perform. |
+| `actions`            | object | Optional `AcceleratorActions` for the client to perform. |
 
 Example:
 ```

--- a/lldb/docs/resources/lldbgdbremote.md
+++ b/lldb/docs/resources/lldbgdbremote.md
@@ -168,14 +168,15 @@ In future patches, each `accelerator_action` will include additional fields
 such as connection info for secondary debug sessions and synchronization
 options.
 
-**Priority To Implement:** Low. Only needed for hardware accelerator
-debugging support.
+**Priority To Implement:** Required for hardware accelerator debugging
+support. Not needed for non-hardware-accelerator debugging.
 
 ## jAcceleratorPluginBreakpointHit
 
 Sent by the client when a breakpoint requested by an accelerator plugin
-(via `jAcceleratorPluginInitialize`) is hit in the native process. This
-packet requires the `accelerator-plugins+` feature from `qSupported`.
+is hit in the native process. Breakpoints can originate from any response
+that contains `AcceleratorActions`. This packet requires the
+`accelerator-plugins+` feature from `qSupported`.
 
 ```
 LLDB SENDS:    jAcceleratorPluginBreakpointHit:<json>
@@ -194,17 +195,18 @@ The response JSON has the following fields:
 
 | Key                  | Type | Description |
 |----------------------|------|-------------|
-| `disable_bp`         | bool | If true, the client should disable this breakpoint. |
-| `auto_resume_native` | bool | If true, the native process should automatically resume after handling the hit. |
+| `disable_bp`         | bool   | If true, the client should disable this breakpoint. |
+| `auto_resume_native` | bool   | If true, the native process should automatically resume after handling the hit. |
+| `actions`            | object | Optional `AcceleratorActions` containing new breakpoints to set and other actions to perform. |
 
 Example:
 ```
 LLDB SENDS:    jAcceleratorPluginBreakpointHit:{"plugin_name":"mock","breakpoint":{"identifier":1,"symbol_names":[]},"symbol_values":[]}
-STUB REPLIES:  {"disable_bp":true,"auto_resume_native":false}
+STUB REPLIES:  {"disable_bp":true,"auto_resume_native":false,"actions":{"plugin_name":"mock","session_name":"","identifier":2,"breakpoints":[{"identifier":2,"by_name":{"function_name":"exit"},"symbol_names":[]}]}}
 ```
 
-**Priority To Implement:** Low. Only needed for hardware accelerator
-debugging support.
+**Priority To Implement:** Required for hardware accelerator debugging
+support. Not needed for non-hardware-accelerator debugging.
 
 ## jGetDyldProcessState
 

--- a/lldb/docs/resources/lldbgdbremote.md
+++ b/lldb/docs/resources/lldbgdbremote.md
@@ -159,9 +159,49 @@ STUB REPLIES:  [{"plugin_name":"amdgpu","session_name":"AMD GPU Session","identi
 If no accelerator plugins are installed, the server does not advertise the
 `accelerator-plugins+` feature and this packet should not be sent.
 
+Each `accelerator_action` may include a `breakpoints` array requesting
+breakpoints to be set in the native process. See
+`jAcceleratorPluginBreakpointHit` for the callback when those breakpoints
+are hit.
+
 In future patches, each `accelerator_action` will include additional fields
-such as breakpoints to set in the native process, connection info for
-secondary debug sessions, and synchronization options.
+such as connection info for secondary debug sessions and synchronization
+options.
+
+**Priority To Implement:** Low. Only needed for hardware accelerator
+debugging support.
+
+## jAcceleratorPluginBreakpointHit
+
+Sent by the client when a breakpoint requested by an accelerator plugin
+(via `jAcceleratorPluginInitialize`) is hit in the native process. This
+packet requires the `accelerator-plugins+` feature from `qSupported`.
+
+```
+LLDB SENDS:    jAcceleratorPluginBreakpointHit:<json>
+STUB REPLIES:  <json_response>
+```
+
+The request JSON has the following fields:
+
+| Key             | Type   | Description |
+|-----------------|--------|-------------|
+| `plugin_name`   | string | Name of the plugin that requested the breakpoint. |
+| `breakpoint`    | object | The `AcceleratorBreakpointInfo` that was hit, including its `identifier`. |
+| `symbol_values` | array  | Array of `{"name": "<name>", "value": <addr>}` for each symbol requested in the breakpoint's `symbol_names`. |
+
+The response JSON has the following fields:
+
+| Key                  | Type | Description |
+|----------------------|------|-------------|
+| `disable_bp`         | bool | If true, the client should disable this breakpoint. |
+| `auto_resume_native` | bool | If true, the native process should automatically resume after handling the hit. |
+
+Example:
+```
+LLDB SENDS:    jAcceleratorPluginBreakpointHit:{"plugin_name":"mock","breakpoint":{"identifier":1,"symbol_names":[]},"symbol_values":[]}
+STUB REPLIES:  {"disable_bp":true,"auto_resume_native":false}
+```
 
 **Priority To Implement:** Low. Only needed for hardware accelerator
 debugging support.

--- a/lldb/docs/resources/lldbgdbremote.md
+++ b/lldb/docs/resources/lldbgdbremote.md
@@ -120,93 +120,6 @@ In any case, if we want the normal detach behavior we will just send:
 D
 ```
 
-## jAcceleratorPluginInitialize
-
-This packet requests initialization data from all accelerator plugins
-installed in lldb-server. Accelerator plugins allow lldb-server to support
-debugging of hardware accelerators (e.g. GPUs, FPGAs) alongside the native
-host process.
-
-This packet requires the `accelerator-plugins+` feature from `qSupported`.
-It should be sent early in the session, after `qSupported` but before
-launching or attaching to an inferior process. If the hardware accelerator
-is not present, launching or attaching to the accelerator debug session
-will fail.
-
-```
-LLDB SENDS:    jAcceleratorPluginInitialize
-STUB REPLIES:  [<accelerator_action>,...]
-```
-
-Each `accelerator_action` is a JSON object with the following required fields:
-
-| Key            | Type    | Description |
-|----------------|---------|-------------|
-| `plugin_name`  | string  | Unique name identifying the accelerator plugin (e.g. `"mock"`, `"amdgpu"`). Each installed plugin has a globally unique name. |
-| `session_name` | string  | Human-readable label for the accelerator target, stored on the Target object to distinguish it from the CPU target (e.g. `"AMD GPU Session"`). May be empty. |
-| `identifier`   | integer | Identifier for this action, unique within the scope of its `plugin_name`. To refer to a specific action, use the combination of `plugin_name` and `identifier`. |
-
-There can be multiple accelerator plugins installed, each with a globally
-unique `plugin_name`. The response is a JSON array with one entry per
-installed plugin.
-
-Example:
-```
-LLDB SENDS:    jAcceleratorPluginInitialize
-STUB REPLIES:  [{"plugin_name":"amdgpu","session_name":"AMD GPU Session","identifier":0}]
-```
-
-If no accelerator plugins are installed, the server does not advertise the
-`accelerator-plugins+` feature and this packet should not be sent.
-
-Each `accelerator_action` may include a `breakpoints` array requesting
-breakpoints to be set in the native process. See
-`jAcceleratorPluginBreakpointHit` for the callback when those breakpoints
-are hit.
-
-In future patches, each `accelerator_action` will include additional fields
-such as connection info for secondary debug sessions and synchronization
-options.
-
-**Priority To Implement:** Required for hardware accelerator debugging
-support. Not needed for non-hardware-accelerator debugging.
-
-## jAcceleratorPluginBreakpointHit
-
-Sent by the client when a breakpoint requested by an accelerator plugin
-is hit in the native process. This packet requires the
-`accelerator-plugins+` feature from `qSupported`.
-
-```
-LLDB SENDS:    jAcceleratorPluginBreakpointHit:<json>
-STUB REPLIES:  <json_response>
-```
-
-The request JSON has the following fields:
-
-| Key             | Type   | Description |
-|-----------------|--------|-------------|
-| `plugin_name`   | string | Name of the plugin that requested the breakpoint. |
-| `breakpoint`    | object | The `AcceleratorBreakpointInfo` that was hit, including its `identifier`. |
-| `symbol_values` | array  | Array of `{"name": "<name>", "value": <addr>}` for each symbol requested in the breakpoint's `symbol_names`. |
-
-The response JSON has the following fields:
-
-| Key                  | Type | Description |
-|----------------------|------|-------------|
-| `disable_bp`         | bool   | If true, the client should disable this breakpoint. |
-| `auto_resume_native` | bool   | If true, the native process should automatically resume after handling the hit. |
-| `actions`            | object | Optional `AcceleratorActions` for the client to perform. |
-
-Example:
-```
-LLDB SENDS:    jAcceleratorPluginBreakpointHit:{"plugin_name":"mock","breakpoint":{"identifier":1,"symbol_names":[]},"symbol_values":[]}
-STUB REPLIES:  {"disable_bp":true,"auto_resume_native":false,"actions":{"plugin_name":"mock","session_name":"","identifier":2,"breakpoints":[{"identifier":2,"by_name":{"function_name":"exit"},"symbol_names":[]}]}}
-```
-
-**Priority To Implement:** Required for hardware accelerator debugging
-support. Not needed for non-hardware-accelerator debugging.
-
 ## jGetDyldProcessState
 
 This packet fetches the process launch state, as reported by libdyld on
@@ -2786,3 +2699,96 @@ omitting them will work fine; these numbers are always base 16.
 
 The length of the payload is not provided.  A reliable, 8-bit clean,
 transport layer is assumed.
+
+## Accelerator Packets
+
+The packets below support debugging hardware accelerators (e.g. GPUs,
+FPGAs) alongside the native host process via accelerator plugins installed
+in lldb-server.
+
+### jAcceleratorPluginInitialize
+
+This packet requests initialization data from all accelerator plugins
+installed in lldb-server. Accelerator plugins allow lldb-server to support
+debugging of hardware accelerators (e.g. GPUs, FPGAs) alongside the native
+host process.
+
+This packet requires the `accelerator-plugins+` feature from `qSupported`.
+It should be sent early in the session, after `qSupported` but before
+launching or attaching to an inferior process. If the hardware accelerator
+is not present, launching or attaching to the accelerator debug session
+will fail.
+
+```
+LLDB SENDS:    jAcceleratorPluginInitialize
+STUB REPLIES:  [<accelerator_action>,...]
+```
+
+Each `accelerator_action` is a JSON object with the following required fields:
+
+| Key            | Type    | Description |
+|----------------|---------|-------------|
+| `plugin_name`  | string  | Unique name identifying the accelerator plugin (e.g. `"mock"`, `"amdgpu"`). Each installed plugin has a globally unique name. |
+| `session_name` | string  | Human-readable label for the accelerator target, stored on the Target object to distinguish it from the CPU target (e.g. `"AMD GPU Session"`). May be empty. |
+| `identifier`   | integer | Identifier for this action, unique within the scope of its `plugin_name`. To refer to a specific action, use the combination of `plugin_name` and `identifier`. |
+
+There can be multiple accelerator plugins installed, each with a globally
+unique `plugin_name`. The response is a JSON array with one entry per
+installed plugin.
+
+Example:
+```
+LLDB SENDS:    jAcceleratorPluginInitialize
+STUB REPLIES:  [{"plugin_name":"amdgpu","session_name":"AMD GPU Session","identifier":0}]
+```
+
+If no accelerator plugins are installed, the server does not advertise the
+`accelerator-plugins+` feature and this packet should not be sent.
+
+Each `accelerator_action` may include a `breakpoints` array requesting
+breakpoints to be set in the native process. See
+`jAcceleratorPluginBreakpointHit` for the callback when those breakpoints
+are hit.
+
+In future patches, each `accelerator_action` will include additional fields
+such as connection info for secondary debug sessions and synchronization
+options.
+
+**Priority To Implement:** Required for hardware accelerator debugging
+support. Not needed for non-hardware-accelerator debugging.
+
+### jAcceleratorPluginBreakpointHit
+
+Sent by the client when a breakpoint requested by an accelerator plugin
+is hit in the native process. This packet requires the
+`accelerator-plugins+` feature from `qSupported`.
+
+```
+LLDB SENDS:    jAcceleratorPluginBreakpointHit:<json>
+STUB REPLIES:  <json_response>
+```
+
+The request JSON has the following fields:
+
+| Key             | Type   | Description |
+|-----------------|--------|-------------|
+| `plugin_name`   | string | Name of the plugin that requested the breakpoint. |
+| `breakpoint`    | object | The `AcceleratorBreakpointInfo` that was hit, including its `identifier`. |
+| `symbol_values` | array  | Array of `{"name": "<name>", "value": <addr>}` for each symbol requested in the breakpoint's `symbol_names`. |
+
+The response JSON has the following fields:
+
+| Key                  | Type | Description |
+|----------------------|------|-------------|
+| `disable_bp`         | bool   | If true, the client should disable this breakpoint. |
+| `auto_resume_native` | bool   | If true, the native process should automatically resume after handling the hit. |
+| `actions`            | object | Optional `AcceleratorActions` for the client to perform. |
+
+Example:
+```
+LLDB SENDS:    jAcceleratorPluginBreakpointHit:{"plugin_name":"mock","breakpoint":{"identifier":1,"symbol_names":[]},"symbol_values":[]}
+STUB REPLIES:  {"disable_bp":true,"auto_resume_native":false,"actions":{"plugin_name":"mock","session_name":"","identifier":2,"breakpoints":[{"identifier":2,"by_name":{"function_name":"exit"},"symbol_names":[]}]}}
+```
+
+**Priority To Implement:** Required for hardware accelerator debugging
+support. Not needed for non-hardware-accelerator debugging.

--- a/lldb/include/lldb/Utility/AcceleratorGDBRemotePackets.h
+++ b/lldb/include/lldb/Utility/AcceleratorGDBRemotePackets.h
@@ -85,18 +85,22 @@ bool fromJSON(const llvm::json::Value &value,
               AcceleratorBreakpointHitArgs &data, llvm::json::Path path);
 llvm::json::Value toJSON(const AcceleratorBreakpointHitArgs &data);
 
-/// Response from the plugin when a breakpoint is hit.
-struct AcceleratorBreakpointHitResponse {
-  /// Set to true if this breakpoint should be disabled.
-  bool disable_bp = false;
-  /// Set to true if the native process should automatically resume.
-  bool auto_resume_native = true;
-};
-
-bool fromJSON(const llvm::json::Value &value,
-              AcceleratorBreakpointHitResponse &data, llvm::json::Path path);
-llvm::json::Value toJSON(const AcceleratorBreakpointHitResponse &data);
-
+/// Actions to be performed in the native process on behalf of an accelerator
+/// plugin. AcceleratorActions are returned in the following contexts:
+///
+/// - Initialization: in response to the "jAcceleratorPluginInitialize" packet,
+///   each plugin returns an AcceleratorActions describing initial breakpoints
+///   and other setup needed in the native process.
+///
+/// - Breakpoint hits: when a native breakpoint requested by a plugin is hit,
+///   the AcceleratorBreakpointHitResponse contains an AcceleratorActions that
+///   can request additional breakpoints or other actions.
+///
+/// In future patches, AcceleratorActions will also be returned:
+/// - When the native process stops (via NativeProcessIsStopping), allowing
+///   plugins to react to arbitrary stop events.
+/// - Via accelerator stop reply packets, enabling plugins to inject actions
+///   into the native process asynchronously.
 struct AcceleratorActions {
   AcceleratorActions() = default;
   AcceleratorActions(llvm::StringRef plugin_name, int64_t action_id)
@@ -114,8 +118,23 @@ struct AcceleratorActions {
 
 bool fromJSON(const llvm::json::Value &value, AcceleratorActions &data,
               llvm::json::Path path);
-
 llvm::json::Value toJSON(const AcceleratorActions &data);
+
+/// Response from the plugin when a breakpoint is hit.
+struct AcceleratorBreakpointHitResponse {
+  /// Set to true if this breakpoint should be disabled.
+  bool disable_bp = false;
+  /// Set to true if the native process should automatically resume after
+  /// the breakpoint is hit. When false, the native process will stop and
+  /// wait for user interaction.
+  bool auto_resume_native = true;
+  /// Optional new actions to perform (e.g. set additional breakpoints).
+  std::optional<AcceleratorActions> actions;
+};
+
+bool fromJSON(const llvm::json::Value &value,
+              AcceleratorBreakpointHitResponse &data, llvm::json::Path path);
+llvm::json::Value toJSON(const AcceleratorBreakpointHitResponse &data);
 
 } // namespace lldb_private
 

--- a/lldb/include/lldb/Utility/AcceleratorGDBRemotePackets.h
+++ b/lldb/include/lldb/Utility/AcceleratorGDBRemotePackets.h
@@ -112,7 +112,7 @@ struct AcceleratorActions {
   std::string session_name;
   /// Unique identifier for this action within the plugin.
   int64_t identifier = 0;
-  /// Breakpoints to set in the native process.
+  /// New breakpoints to set. Nothing to set if this is empty.
   std::vector<AcceleratorBreakpointInfo> breakpoints;
 };
 

--- a/lldb/include/lldb/Utility/AcceleratorGDBRemotePackets.h
+++ b/lldb/include/lldb/Utility/AcceleratorGDBRemotePackets.h
@@ -11,9 +11,91 @@
 
 #include "llvm/Support/JSON.h"
 #include <cstdint>
+#include <optional>
 #include <string>
+#include <vector>
 
 namespace lldb_private {
+
+struct SymbolValue {
+  /// Symbol name as requested in AcceleratorBreakpointInfo::symbol_names.
+  std::string name;
+  /// Load address of the symbol in the native process, or nullopt if not found.
+  std::optional<uint64_t> value;
+};
+
+bool fromJSON(const llvm::json::Value &value, SymbolValue &data,
+              llvm::json::Path path);
+llvm::json::Value toJSON(const SymbolValue &data);
+
+struct AcceleratorBreakpointByName {
+  /// Optional shared library name to limit the breakpoint scope.
+  std::optional<std::string> shlib;
+  /// Function name to set a breakpoint at.
+  std::string function_name;
+};
+
+bool fromJSON(const llvm::json::Value &value, AcceleratorBreakpointByName &data,
+              llvm::json::Path path);
+llvm::json::Value toJSON(const AcceleratorBreakpointByName &data);
+
+struct AcceleratorBreakpointByAddress {
+  /// Load address in the native debug target.
+  uint64_t load_address = 0;
+};
+
+bool fromJSON(const llvm::json::Value &value,
+              AcceleratorBreakpointByAddress &data, llvm::json::Path path);
+llvm::json::Value toJSON(const AcceleratorBreakpointByAddress &data);
+
+/// A breakpoint definition. Clients fill in either \a by_name or
+/// \a by_address. If the breakpoint callback needs symbol values from
+/// the native process, fill in \a symbol_names — those values will be
+/// delivered in the breakpoint hit callback.
+struct AcceleratorBreakpointInfo {
+  /// Unique breakpoint ID used to identify this breakpoint in the
+  /// BreakpointWasHit callback.
+  int64_t identifier = 0;
+  /// Breakpoint by function name.
+  std::optional<AcceleratorBreakpointByName> by_name;
+  /// Breakpoint by load address.
+  std::optional<AcceleratorBreakpointByAddress> by_address;
+  /// Symbol names whose values should be supplied when the breakpoint is hit.
+  std::vector<std::string> symbol_names;
+};
+
+bool fromJSON(const llvm::json::Value &value, AcceleratorBreakpointInfo &data,
+              llvm::json::Path path);
+llvm::json::Value toJSON(const AcceleratorBreakpointInfo &data);
+
+/// Sent by the client when a plugin-requested breakpoint is hit.
+struct AcceleratorBreakpointHitArgs {
+  AcceleratorBreakpointHitArgs() = default;
+  AcceleratorBreakpointHitArgs(llvm::StringRef plugin_name)
+      : plugin_name(plugin_name) {}
+
+  std::string plugin_name;
+  AcceleratorBreakpointInfo breakpoint;
+  std::vector<SymbolValue> symbol_values;
+
+  std::optional<uint64_t> GetSymbolValue(llvm::StringRef symbol_name) const;
+};
+
+bool fromJSON(const llvm::json::Value &value,
+              AcceleratorBreakpointHitArgs &data, llvm::json::Path path);
+llvm::json::Value toJSON(const AcceleratorBreakpointHitArgs &data);
+
+/// Response from the plugin when a breakpoint is hit.
+struct AcceleratorBreakpointHitResponse {
+  /// Set to true if this breakpoint should be disabled.
+  bool disable_bp = false;
+  /// Set to true if the native process should automatically resume.
+  bool auto_resume_native = true;
+};
+
+bool fromJSON(const llvm::json::Value &value,
+              AcceleratorBreakpointHitResponse &data, llvm::json::Path path);
+llvm::json::Value toJSON(const AcceleratorBreakpointHitResponse &data);
 
 struct AcceleratorActions {
   AcceleratorActions() = default;
@@ -26,6 +108,8 @@ struct AcceleratorActions {
   std::string session_name;
   /// Unique identifier for this action within the plugin.
   int64_t identifier = 0;
+  /// Breakpoints to set in the native process.
+  std::vector<AcceleratorBreakpointInfo> breakpoints;
 };
 
 bool fromJSON(const llvm::json::Value &value, AcceleratorActions &data,

--- a/lldb/include/lldb/Utility/StringExtractorGDBRemote.h
+++ b/lldb/include/lldb/Utility/StringExtractorGDBRemote.h
@@ -174,6 +174,7 @@ public:
     eServerPacketType_jLLDBTraceGetBinaryData,
     eServerPacketType_jMultiBreakpoint,
     eServerPacketType_jAcceleratorPluginInitialize,
+    eServerPacketType_jAcceleratorPluginBreakpointHit,
 
     eServerPacketType_qMemTags, // read memory tags
     eServerPacketType_QMemTags, // write memory tags

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -226,6 +226,11 @@ void GDBRemoteCommunicationServerLLGS::RegisterPacketHandlers() {
   RegisterMemberFunctionHandler(
       StringExtractorGDBRemote::eServerPacketType_jAcceleratorPluginInitialize,
       &GDBRemoteCommunicationServerLLGS::Handle_jAcceleratorPluginInitialize);
+  RegisterMemberFunctionHandler(
+      StringExtractorGDBRemote::
+          eServerPacketType_jAcceleratorPluginBreakpointHit,
+      &GDBRemoteCommunicationServerLLGS::
+          Handle_jAcceleratorPluginBreakpointHit);
 
   RegisterMemberFunctionHandler(StringExtractorGDBRemote::eServerPacketType_g,
                                 &GDBRemoteCommunicationServerLLGS::Handle_g);
@@ -4547,4 +4552,30 @@ GDBRemoteCommunicationServerLLGS::Handle_jAcceleratorPluginInitialize(
   StreamGDBRemote response;
   response.PutAsJSONArray(accelerator_actions, /*hex_ascii=*/false);
   return SendPacketNoLock(response.GetString());
+}
+
+GDBRemoteCommunication::PacketResult
+GDBRemoteCommunicationServerLLGS::Handle_jAcceleratorPluginBreakpointHit(
+    StringExtractorGDBRemote &packet) {
+  packet.ConsumeFront("jAcceleratorPluginBreakpointHit:");
+  llvm::Expected<AcceleratorBreakpointHitArgs> args =
+      llvm::json::parse<AcceleratorBreakpointHitArgs>(
+          packet.Peek(), "AcceleratorBreakpointHitArgs");
+  if (!args)
+    return SendErrorResponse(args.takeError());
+
+  for (auto &plugin_up : m_accelerator_plugins) {
+    if (plugin_up->GetPluginName() == args->plugin_name) {
+      llvm::Expected<AcceleratorBreakpointHitResponse> bp_response =
+          plugin_up->BreakpointWasHit(*args);
+      if (!bp_response)
+        return SendErrorResponse(bp_response.takeError());
+
+      StreamGDBRemote response;
+      response.PutAsJSON(*bp_response, /*hex_ascii=*/false);
+      return SendPacketNoLock(response.GetString());
+    }
+  }
+  return SendErrorResponse(
+      Status::FromErrorString("unknown accelerator plugin name"));
 }

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -4545,7 +4545,8 @@ GDBRemoteCommunication::PacketResult
 GDBRemoteCommunicationServerLLGS::Handle_jAcceleratorPluginInitialize(
     StringExtractorGDBRemote &) {
   std::vector<AcceleratorActions> accelerator_actions;
-  for (auto &plugin_up : m_accelerator_plugins) {
+  for (std::unique_ptr<lldb_server::LLDBServerAcceleratorPlugin> &plugin_up :
+       m_accelerator_plugins) {
     if (auto actions = plugin_up->GetInitializeActions())
       accelerator_actions.push_back(std::move(*actions));
   }
@@ -4564,7 +4565,8 @@ GDBRemoteCommunicationServerLLGS::Handle_jAcceleratorPluginBreakpointHit(
   if (!args)
     return SendErrorResponse(args.takeError());
 
-  for (auto &plugin_up : m_accelerator_plugins) {
+  for (std::unique_ptr<lldb_server::LLDBServerAcceleratorPlugin> &plugin_up :
+       m_accelerator_plugins) {
     if (plugin_up->GetPluginName() == args->plugin_name) {
       llvm::Expected<AcceleratorBreakpointHitResponse> bp_response =
           plugin_up->BreakpointWasHit(*args);

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.h
@@ -287,6 +287,9 @@ protected:
   PacketResult
   Handle_jAcceleratorPluginInitialize(StringExtractorGDBRemote &packet);
 
+  PacketResult
+  Handle_jAcceleratorPluginBreakpointHit(StringExtractorGDBRemote &packet);
+
   void SetCurrentThreadID(lldb::tid_t tid);
 
   lldb::tid_t GetCurrentThreadID() const;

--- a/lldb/source/Plugins/Process/gdb-remote/LLDBServerAcceleratorPlugin.h
+++ b/lldb/source/Plugins/Process/gdb-remote/LLDBServerAcceleratorPlugin.h
@@ -33,6 +33,9 @@ public:
 
   virtual std::optional<AcceleratorActions> GetInitializeActions() = 0;
 
+  virtual llvm::Expected<AcceleratorBreakpointHitResponse>
+  BreakpointWasHit(AcceleratorBreakpointHitArgs &args) = 0;
+
 protected:
   GDBServer &m_gdb_server;
   MainLoop &m_main_loop;

--- a/lldb/source/Utility/AcceleratorGDBRemotePackets.cpp
+++ b/lldb/source/Utility/AcceleratorGDBRemotePackets.cpp
@@ -86,20 +86,6 @@ AcceleratorBreakpointHitArgs::GetSymbolValue(StringRef symbol_name) const {
   return std::nullopt;
 }
 
-bool fromJSON(const Value &value, AcceleratorBreakpointHitResponse &data,
-              Path path) {
-  ObjectMapper o(value, path);
-  return o && o.map("disable_bp", data.disable_bp) &&
-         o.map("auto_resume_native", data.auto_resume_native);
-}
-
-json::Value toJSON(const AcceleratorBreakpointHitResponse &data) {
-  return Object{
-      {"disable_bp", data.disable_bp},
-      {"auto_resume_native", data.auto_resume_native},
-  };
-}
-
 bool fromJSON(const Value &value, AcceleratorActions &data, Path path) {
   ObjectMapper o(value, path);
   return o && o.map("plugin_name", data.plugin_name) &&
@@ -115,6 +101,24 @@ json::Value toJSON(const AcceleratorActions &data) {
       {"identifier", data.identifier},
       {"breakpoints", data.breakpoints},
   };
+}
+
+bool fromJSON(const Value &value, AcceleratorBreakpointHitResponse &data,
+              Path path) {
+  ObjectMapper o(value, path);
+  return o && o.map("disable_bp", data.disable_bp) &&
+         o.map("auto_resume_native", data.auto_resume_native) &&
+         o.mapOptional("actions", data.actions);
+}
+
+json::Value toJSON(const AcceleratorBreakpointHitResponse &data) {
+  Object obj{
+      {"disable_bp", data.disable_bp},
+      {"auto_resume_native", data.auto_resume_native},
+  };
+  if (data.actions)
+    obj["actions"] = *data.actions;
+  return obj;
 }
 
 } // namespace lldb_private

--- a/lldb/source/Utility/AcceleratorGDBRemotePackets.cpp
+++ b/lldb/source/Utility/AcceleratorGDBRemotePackets.cpp
@@ -8,20 +8,113 @@
 
 #include "lldb/Utility/AcceleratorGDBRemotePackets.h"
 
-using namespace lldb_private;
+using namespace llvm;
+using namespace llvm::json;
 
-llvm::json::Value lldb_private::toJSON(const AcceleratorActions &data) {
-  return llvm::json::Object{
-      {"plugin_name", data.plugin_name},
-      {"session_name", data.session_name},
+namespace lldb_private {
+
+bool fromJSON(const Value &value, SymbolValue &data, Path path) {
+  ObjectMapper o(value, path);
+  return o && o.map("name", data.name) && o.map("value", data.value);
+}
+
+json::Value toJSON(const SymbolValue &data) {
+  return Object{{"name", data.name}, {"value", data.value}};
+}
+
+bool fromJSON(const Value &value, AcceleratorBreakpointByName &data,
+              Path path) {
+  ObjectMapper o(value, path);
+  return o && o.mapOptional("shlib", data.shlib) &&
+         o.map("function_name", data.function_name);
+}
+
+json::Value toJSON(const AcceleratorBreakpointByName &data) {
+  return Object{{"shlib", data.shlib}, {"function_name", data.function_name}};
+}
+
+bool fromJSON(const Value &value, AcceleratorBreakpointByAddress &data,
+              Path path) {
+  ObjectMapper o(value, path);
+  return o && o.map("load_address", data.load_address);
+}
+
+json::Value toJSON(const AcceleratorBreakpointByAddress &data) {
+  return Object{{"load_address", static_cast<int64_t>(data.load_address)}};
+}
+
+bool fromJSON(const Value &value, AcceleratorBreakpointInfo &data, Path path) {
+  ObjectMapper o(value, path);
+  return o && o.map("identifier", data.identifier) &&
+         o.mapOptional("by_name", data.by_name) &&
+         o.mapOptional("by_address", data.by_address) &&
+         o.map("symbol_names", data.symbol_names);
+}
+
+json::Value toJSON(const AcceleratorBreakpointInfo &data) {
+  return Object{
       {"identifier", data.identifier},
+      {"by_name", data.by_name},
+      {"by_address", data.by_address},
+      {"symbol_names", data.symbol_names},
   };
 }
 
-bool lldb_private::fromJSON(const llvm::json::Value &value,
-                            AcceleratorActions &data, llvm::json::Path path) {
-  llvm::json::ObjectMapper o(value, path);
+bool fromJSON(const Value &value, AcceleratorBreakpointHitArgs &data,
+              Path path) {
+  ObjectMapper o(value, path);
+  return o && o.map("plugin_name", data.plugin_name) &&
+         o.map("breakpoint", data.breakpoint) &&
+         o.map("symbol_values", data.symbol_values);
+}
+
+json::Value toJSON(const AcceleratorBreakpointHitArgs &data) {
+  return Object{
+      {"plugin_name", data.plugin_name},
+      {"breakpoint", data.breakpoint},
+      {"symbol_values", data.symbol_values},
+  };
+}
+
+std::optional<uint64_t>
+AcceleratorBreakpointHitArgs::GetSymbolValue(StringRef symbol_name) const {
+  auto it = llvm::find_if(symbol_values, [&](const SymbolValue &symbol) {
+    return symbol.name == symbol_name;
+  });
+  if (it != symbol_values.end())
+    return it->value;
+  return std::nullopt;
+}
+
+bool fromJSON(const Value &value, AcceleratorBreakpointHitResponse &data,
+              Path path) {
+  ObjectMapper o(value, path);
+  return o && o.map("disable_bp", data.disable_bp) &&
+         o.map("auto_resume_native", data.auto_resume_native);
+}
+
+json::Value toJSON(const AcceleratorBreakpointHitResponse &data) {
+  return Object{
+      {"disable_bp", data.disable_bp},
+      {"auto_resume_native", data.auto_resume_native},
+  };
+}
+
+bool fromJSON(const Value &value, AcceleratorActions &data, Path path) {
+  ObjectMapper o(value, path);
   return o && o.map("plugin_name", data.plugin_name) &&
          o.map("session_name", data.session_name) &&
-         o.map("identifier", data.identifier);
+         o.map("identifier", data.identifier) &&
+         o.map("breakpoints", data.breakpoints);
 }
+
+json::Value toJSON(const AcceleratorActions &data) {
+  return Object{
+      {"plugin_name", data.plugin_name},
+      {"session_name", data.session_name},
+      {"identifier", data.identifier},
+      {"breakpoints", data.breakpoints},
+  };
+}
+
+} // namespace lldb_private

--- a/lldb/source/Utility/StringExtractorGDBRemote.cpp
+++ b/lldb/source/Utility/StringExtractorGDBRemote.cpp
@@ -334,6 +334,8 @@ StringExtractorGDBRemote::GetServerPacketType() const {
       return eServerPacketType_jMultiBreakpoint;
     if (PACKET_MATCHES("jAcceleratorPluginInitialize"))
       return eServerPacketType_jAcceleratorPluginInitialize;
+    if (PACKET_STARTS_WITH("jAcceleratorPluginBreakpointHit:"))
+      return eServerPacketType_jAcceleratorPluginBreakpointHit;
     break;
 
   case 'v':

--- a/lldb/test/API/accelerator/mock/TestMockAcceleratorPlugin.py
+++ b/lldb/test/API/accelerator/mock/TestMockAcceleratorPlugin.py
@@ -110,3 +110,13 @@ class MockAcceleratorPluginTestCase(gdbremote_testcase.GdbRemoteTestCaseBase):
         self.assertTrue(response["disable_bp"])
         self.assertIn("auto_resume_native", response)
         self.assertFalse(response["auto_resume_native"])
+
+        # Verify that the response includes new actions with a breakpoint.
+        self.assertIn("actions", response)
+        actions = response["actions"]
+        self.assertEqual(actions["plugin_name"], "mock")
+        self.assertIn("breakpoints", actions)
+        new_bps = actions["breakpoints"]
+        self.assertGreater(len(new_bps), 0)
+        self.assertEqual(new_bps[0]["identifier"], 2)
+        self.assertEqual(new_bps[0]["by_name"]["function_name"], "exit")

--- a/lldb/test/API/accelerator/mock/TestMockAcceleratorPlugin.py
+++ b/lldb/test/API/accelerator/mock/TestMockAcceleratorPlugin.py
@@ -1,14 +1,16 @@
 """
 Tests for the lldb-server mock accelerator plugin.
 
-Verifies the accelerator-plugins+ feature in qSupported and
-the jAcceleratorPluginInitialize packet response.
+Verifies the accelerator-plugins+ feature in qSupported,
+the jAcceleratorPluginInitialize packet response, and
+the jAcceleratorPluginBreakpointHit round-trip.
 """
 
 import json
 
 import gdbremote_testcase
 from lldbsuite.test.decorators import *
+from lldbsuite.test.gdbclientutils import escape_binary
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import configuration
 
@@ -26,6 +28,24 @@ class MockAcceleratorPluginTestCase(gdbremote_testcase.GdbRemoteTestCaseBase):
         if "mock-accelerator" not in configuration.enabled_plugins:
             self.skipTest("mock-accelerator plugin is not enabled")
 
+    def send_and_decode_json(self, packet):
+        """Send a packet and return the decoded JSON response."""
+        self.test_sequence.add_log_lines(
+            [
+                "read packet: $%s#00" % packet,
+                {
+                    "direction": "send",
+                    "regex": r"^\$(.+)#[0-9a-fA-F]{2}",
+                    "capture": {1: "response"},
+                },
+            ],
+            True,
+        )
+        context = self.expect_gdbremote_sequence()
+        raw = context.get("response")
+        self.assertIsNotNone(raw)
+        return json.loads(self.decode_gdbremote_binary(raw))
+
     @add_test_categories(["llgs"])
     def test_qSupported_reports_accelerator_plugins(self):
         self.build()
@@ -40,7 +60,7 @@ class MockAcceleratorPluginTestCase(gdbremote_testcase.GdbRemoteTestCaseBase):
         self.assertEqual(features["accelerator-plugins"], "+")
 
     @add_test_categories(["llgs"])
-    def test_jAcceleratorPluginInitialize_returns_mock_actions(self):
+    def test_jAcceleratorPluginInitialize_returns_breakpoints(self):
         self.build()
         self.set_inferior_startup_launch()
         self.prep_debug_monitor_and_inferior()
@@ -48,27 +68,45 @@ class MockAcceleratorPluginTestCase(gdbremote_testcase.GdbRemoteTestCaseBase):
         self.add_qSupported_packets()
         self.expect_gdbremote_sequence()
 
-        self.test_sequence.add_log_lines(
-            [
-                "read packet: $jAcceleratorPluginInitialize#00",
-                {
-                    "direction": "send",
-                    "regex": r"^\$(.+)#[0-9a-fA-F]{2}",
-                    "capture": {1: "accel_init_response"},
-                },
-            ],
-            True,
-        )
-        context = self.expect_gdbremote_sequence()
-
-        raw_response = context.get("accel_init_response")
-        self.assertIsNotNone(raw_response)
-
-        decoded = self.decode_gdbremote_binary(raw_response)
-        actions = json.loads(decoded)
+        actions = self.send_and_decode_json("jAcceleratorPluginInitialize")
         self.assertIsInstance(actions, list)
 
         mock_action = get_accelerator_action(actions, "mock")
         self.assertIsNotNone(mock_action)
-        self.assertIn("session_name", mock_action)
-        self.assertIn("identifier", mock_action)
+        self.assertIn("breakpoints", mock_action)
+
+        breakpoints = mock_action["breakpoints"]
+        self.assertGreater(len(breakpoints), 0)
+
+        bp = breakpoints[0]
+        self.assertIn("identifier", bp)
+        self.assertIn("by_name", bp)
+        self.assertEqual(bp["by_name"]["function_name"], "main")
+
+    @add_test_categories(["llgs"])
+    def test_jAcceleratorPluginBreakpointHit_response(self):
+        self.build()
+        self.set_inferior_startup_launch()
+        self.prep_debug_monitor_and_inferior()
+
+        self.add_qSupported_packets()
+        self.expect_gdbremote_sequence()
+
+        hit_args = {
+            "plugin_name": "mock",
+            "breakpoint": {
+                "identifier": 1,
+                "symbol_names": [],
+            },
+            "symbol_values": [],
+        }
+        hit_json = json.dumps(hit_args, separators=(",", ":"))
+        escaped_json = escape_binary(hit_json)
+        response = self.send_and_decode_json(
+            "jAcceleratorPluginBreakpointHit:" + escaped_json
+        )
+
+        self.assertIn("disable_bp", response)
+        self.assertTrue(response["disable_bp"])
+        self.assertIn("auto_resume_native", response)
+        self.assertFalse(response["auto_resume_native"])

--- a/lldb/tools/lldb-server/Plugins/Accelerator/Mock/LLDBServerMockAcceleratorPlugin.cpp
+++ b/lldb/tools/lldb-server/Plugins/Accelerator/Mock/LLDBServerMockAcceleratorPlugin.cpp
@@ -21,5 +21,23 @@ llvm::StringRef LLDBServerMockAcceleratorPlugin::GetPluginName() {
 
 std::optional<AcceleratorActions>
 LLDBServerMockAcceleratorPlugin::GetInitializeActions() {
-  return AcceleratorActions(GetPluginName(), 0);
+  AcceleratorActions actions(GetPluginName(), 1);
+
+  AcceleratorBreakpointInfo bp;
+  bp.identifier = kBreakpointIDInitialize;
+  bp.by_name = AcceleratorBreakpointByName{std::nullopt, "main"};
+  actions.breakpoints.push_back(std::move(bp));
+
+  return actions;
+}
+
+llvm::Expected<AcceleratorBreakpointHitResponse>
+LLDBServerMockAcceleratorPlugin::BreakpointWasHit(
+    AcceleratorBreakpointHitArgs &args) {
+  AcceleratorBreakpointHitResponse response;
+  if (args.breakpoint.identifier == kBreakpointIDInitialize) {
+    response.disable_bp = true;
+    response.auto_resume_native = false;
+  }
+  return response;
 }

--- a/lldb/tools/lldb-server/Plugins/Accelerator/Mock/LLDBServerMockAcceleratorPlugin.cpp
+++ b/lldb/tools/lldb-server/Plugins/Accelerator/Mock/LLDBServerMockAcceleratorPlugin.cpp
@@ -38,6 +38,13 @@ LLDBServerMockAcceleratorPlugin::BreakpointWasHit(
   if (args.breakpoint.identifier == kBreakpointIDInitialize) {
     response.disable_bp = true;
     response.auto_resume_native = false;
+
+    AcceleratorActions actions(GetPluginName(), kBreakpointIDExit);
+    AcceleratorBreakpointInfo bp;
+    bp.identifier = kBreakpointIDExit;
+    bp.by_name = AcceleratorBreakpointByName{std::nullopt, "exit"};
+    actions.breakpoints.push_back(std::move(bp));
+    response.actions = std::move(actions);
   }
   return response;
 }

--- a/lldb/tools/lldb-server/Plugins/Accelerator/Mock/LLDBServerMockAcceleratorPlugin.h
+++ b/lldb/tools/lldb-server/Plugins/Accelerator/Mock/LLDBServerMockAcceleratorPlugin.h
@@ -20,6 +20,11 @@ public:
 
   llvm::StringRef GetPluginName() override;
   std::optional<AcceleratorActions> GetInitializeActions() override;
+  llvm::Expected<AcceleratorBreakpointHitResponse>
+  BreakpointWasHit(AcceleratorBreakpointHitArgs &args) override;
+
+private:
+  static constexpr int64_t kBreakpointIDInitialize = 1;
 };
 
 } // namespace lldb_server

--- a/lldb/tools/lldb-server/Plugins/Accelerator/Mock/LLDBServerMockAcceleratorPlugin.h
+++ b/lldb/tools/lldb-server/Plugins/Accelerator/Mock/LLDBServerMockAcceleratorPlugin.h
@@ -25,6 +25,7 @@ public:
 
 private:
   static constexpr int64_t kBreakpointIDInitialize = 1;
+  static constexpr int64_t kBreakpointIDExit = 2;
 };
 
 } // namespace lldb_server

--- a/lldb/unittests/Utility/AcceleratorGDBRemotePacketsTest.cpp
+++ b/lldb/unittests/Utility/AcceleratorGDBRemotePacketsTest.cpp
@@ -1,4 +1,4 @@
-//===-- AcceleratorGDBRemotePacketsTest.cpp --------------------------------===//
+//===-- AcceleratorGDBRemotePacketsTest.cpp ---------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lldb/unittests/Utility/AcceleratorGDBRemotePacketsTest.cpp
+++ b/lldb/unittests/Utility/AcceleratorGDBRemotePacketsTest.cpp
@@ -1,0 +1,189 @@
+//===-- AcceleratorGDBRemotePacketsTest.cpp --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Utility/AcceleratorGDBRemotePackets.h"
+#include "TestingSupport/TestUtilities.h"
+#include "llvm/Support/JSON.h"
+#include "llvm/Testing/Support/Error.h"
+#include "gtest/gtest.h"
+
+using namespace lldb_private;
+using namespace llvm;
+
+TEST(AcceleratorGDBRemotePacketsTest, SymbolValue) {
+  SymbolValue sv;
+  sv.name = "my_symbol";
+  sv.value = 0xDEADBEEF;
+
+  Expected<SymbolValue> deserialized = roundtripJSON(sv);
+  ASSERT_THAT_EXPECTED(deserialized, Succeeded());
+  EXPECT_EQ(sv.name, deserialized->name);
+  EXPECT_EQ(sv.value, deserialized->value);
+}
+
+TEST(AcceleratorGDBRemotePacketsTest, SymbolValueNullopt) {
+  SymbolValue sv;
+  sv.name = "missing";
+  sv.value = std::nullopt;
+
+  Expected<SymbolValue> deserialized = roundtripJSON(sv);
+  ASSERT_THAT_EXPECTED(deserialized, Succeeded());
+  EXPECT_EQ(sv.name, deserialized->name);
+  EXPECT_EQ(std::nullopt, deserialized->value);
+}
+
+TEST(AcceleratorGDBRemotePacketsTest, AcceleratorBreakpointByName) {
+  AcceleratorBreakpointByName bp;
+  bp.function_name = "main";
+  bp.shlib = "libfoo.so";
+
+  Expected<AcceleratorBreakpointByName> deserialized = roundtripJSON(bp);
+  ASSERT_THAT_EXPECTED(deserialized, Succeeded());
+  EXPECT_EQ(bp.function_name, deserialized->function_name);
+  EXPECT_EQ(bp.shlib, deserialized->shlib);
+}
+
+TEST(AcceleratorGDBRemotePacketsTest, AcceleratorBreakpointByNameNoShlib) {
+  AcceleratorBreakpointByName bp;
+  bp.function_name = "main";
+
+  Expected<AcceleratorBreakpointByName> deserialized = roundtripJSON(bp);
+  ASSERT_THAT_EXPECTED(deserialized, Succeeded());
+  EXPECT_EQ(bp.function_name, deserialized->function_name);
+  EXPECT_EQ(std::nullopt, deserialized->shlib);
+}
+
+TEST(AcceleratorGDBRemotePacketsTest, AcceleratorBreakpointByAddress) {
+  AcceleratorBreakpointByAddress bp;
+  bp.load_address = 0x400000;
+
+  Expected<AcceleratorBreakpointByAddress> deserialized = roundtripJSON(bp);
+  ASSERT_THAT_EXPECTED(deserialized, Succeeded());
+  EXPECT_EQ(bp.load_address, deserialized->load_address);
+}
+
+TEST(AcceleratorGDBRemotePacketsTest, AcceleratorBreakpointInfoByName) {
+  AcceleratorBreakpointInfo info;
+  info.identifier = 42;
+  info.by_name = AcceleratorBreakpointByName{std::nullopt, "main"};
+  info.symbol_names = {"sym1", "sym2"};
+
+  Expected<AcceleratorBreakpointInfo> deserialized = roundtripJSON(info);
+  ASSERT_THAT_EXPECTED(deserialized, Succeeded());
+  EXPECT_EQ(info.identifier, deserialized->identifier);
+  ASSERT_TRUE(deserialized->by_name.has_value());
+  EXPECT_EQ("main", deserialized->by_name->function_name);
+  EXPECT_EQ(std::nullopt, deserialized->by_address);
+  EXPECT_EQ(info.symbol_names, deserialized->symbol_names);
+}
+
+TEST(AcceleratorGDBRemotePacketsTest, AcceleratorBreakpointInfoByAddress) {
+  AcceleratorBreakpointInfo info;
+  info.identifier = 7;
+  info.by_address = AcceleratorBreakpointByAddress{0x1000};
+
+  Expected<AcceleratorBreakpointInfo> deserialized = roundtripJSON(info);
+  ASSERT_THAT_EXPECTED(deserialized, Succeeded());
+  EXPECT_EQ(info.identifier, deserialized->identifier);
+  EXPECT_EQ(std::nullopt, deserialized->by_name);
+  ASSERT_TRUE(deserialized->by_address.has_value());
+  EXPECT_EQ(0x1000u, deserialized->by_address->load_address);
+}
+
+TEST(AcceleratorGDBRemotePacketsTest, AcceleratorBreakpointHitArgs) {
+  AcceleratorBreakpointHitArgs args("mock");
+  args.breakpoint.identifier = 1;
+  args.breakpoint.by_name = AcceleratorBreakpointByName{std::nullopt, "main"};
+  args.symbol_values = {{"sym1", 0x2000}, {"sym2", std::nullopt}};
+
+  Expected<AcceleratorBreakpointHitArgs> deserialized = roundtripJSON(args);
+  ASSERT_THAT_EXPECTED(deserialized, Succeeded());
+  EXPECT_EQ("mock", deserialized->plugin_name);
+  EXPECT_EQ(1, deserialized->breakpoint.identifier);
+  ASSERT_EQ(2u, deserialized->symbol_values.size());
+  EXPECT_EQ("sym1", deserialized->symbol_values[0].name);
+  EXPECT_EQ(0x2000u, deserialized->symbol_values[0].value);
+  EXPECT_EQ("sym2", deserialized->symbol_values[1].name);
+  EXPECT_EQ(std::nullopt, deserialized->symbol_values[1].value);
+}
+
+TEST(AcceleratorGDBRemotePacketsTest, AcceleratorBreakpointHitArgsGetSymbol) {
+  AcceleratorBreakpointHitArgs args("mock");
+  args.symbol_values = {{"sym1", 0x1000}, {"sym2", 0x2000}};
+
+  EXPECT_EQ(0x1000u, args.GetSymbolValue("sym1"));
+  EXPECT_EQ(0x2000u, args.GetSymbolValue("sym2"));
+  EXPECT_EQ(std::nullopt, args.GetSymbolValue("missing"));
+}
+
+TEST(AcceleratorGDBRemotePacketsTest, AcceleratorActions) {
+  AcceleratorActions actions("mock", 1);
+  actions.session_name = "Mock Session";
+  AcceleratorBreakpointInfo bp;
+  bp.identifier = 1;
+  bp.by_name = AcceleratorBreakpointByName{std::nullopt, "main"};
+  actions.breakpoints.push_back(std::move(bp));
+
+  Expected<AcceleratorActions> deserialized = roundtripJSON(actions);
+  ASSERT_THAT_EXPECTED(deserialized, Succeeded());
+  EXPECT_EQ("mock", deserialized->plugin_name);
+  EXPECT_EQ("Mock Session", deserialized->session_name);
+  EXPECT_EQ(1, deserialized->identifier);
+  ASSERT_EQ(1u, deserialized->breakpoints.size());
+  EXPECT_EQ(1, deserialized->breakpoints[0].identifier);
+  EXPECT_EQ("main", deserialized->breakpoints[0].by_name->function_name);
+}
+
+TEST(AcceleratorGDBRemotePacketsTest, AcceleratorActionsEmpty) {
+  AcceleratorActions actions("test", 0);
+
+  Expected<AcceleratorActions> deserialized = roundtripJSON(actions);
+  ASSERT_THAT_EXPECTED(deserialized, Succeeded());
+  EXPECT_EQ("test", deserialized->plugin_name);
+  EXPECT_TRUE(deserialized->breakpoints.empty());
+}
+
+TEST(AcceleratorGDBRemotePacketsTest,
+     AcceleratorBreakpointHitResponseNoActions) {
+  AcceleratorBreakpointHitResponse response;
+  response.disable_bp = true;
+  response.auto_resume_native = false;
+
+  Expected<AcceleratorBreakpointHitResponse> deserialized =
+      roundtripJSON(response);
+  ASSERT_THAT_EXPECTED(deserialized, Succeeded());
+  EXPECT_TRUE(deserialized->disable_bp);
+  EXPECT_FALSE(deserialized->auto_resume_native);
+  EXPECT_FALSE(deserialized->actions.has_value());
+}
+
+TEST(AcceleratorGDBRemotePacketsTest,
+     AcceleratorBreakpointHitResponseWithActions) {
+  AcceleratorBreakpointHitResponse response;
+  response.disable_bp = true;
+  response.auto_resume_native = false;
+
+  AcceleratorActions actions("mock", 2);
+  AcceleratorBreakpointInfo bp;
+  bp.identifier = 2;
+  bp.by_name = AcceleratorBreakpointByName{std::nullopt, "exit"};
+  actions.breakpoints.push_back(std::move(bp));
+  response.actions = std::move(actions);
+
+  Expected<AcceleratorBreakpointHitResponse> deserialized =
+      roundtripJSON(response);
+  ASSERT_THAT_EXPECTED(deserialized, Succeeded());
+  EXPECT_TRUE(deserialized->disable_bp);
+  EXPECT_FALSE(deserialized->auto_resume_native);
+  ASSERT_TRUE(deserialized->actions.has_value());
+  EXPECT_EQ("mock", deserialized->actions->plugin_name);
+  EXPECT_EQ(2, deserialized->actions->identifier);
+  ASSERT_EQ(1u, deserialized->actions->breakpoints.size());
+  EXPECT_EQ("exit",
+            deserialized->actions->breakpoints[0].by_name->function_name);
+}

--- a/lldb/unittests/Utility/AcceleratorGDBRemotePacketsTest.cpp
+++ b/lldb/unittests/Utility/AcceleratorGDBRemotePacketsTest.cpp
@@ -1,4 +1,4 @@
-//===-- AcceleratorGDBRemotePacketsTest.cpp ---------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lldb/unittests/Utility/CMakeLists.txt
+++ b/lldb/unittests/Utility/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_lldb_unittest(UtilityTests
+  AcceleratorGDBRemotePacketsTest.cpp
   AnsiTerminalTest.cpp
   ArgsTest.cpp
   OptionsWithRawTest.cpp


### PR DESCRIPTION

This is the 2nd PR of many related to https://discourse.llvm.org/t/upstreaming-basic-support-for-accelerators/89827/6
Continuation to https://github.com/llvm/llvm-project/pull/198907

Extend the accelerator plugin infrastructure with breakpoint request and hit handling, allowing plugins to set breakpoints in the native process and respond when those breakpoints are hit.

This patch adds:

- Support for  jAcceleratorPluginBreakpointHit packet handler in GDBRemoteCommunicationServerLLGS that routes hits to the correct plugin by name and returns the plugin's response
- Many related struct for defining request packet and response packet.  New structs: AcceleratorBreakpointByName, AcceleratorBreakpointByAddress, AcceleratorBreakpointInfo, SymbolValue ,AcceleratorBreakpointHitArgs and AcceleratorBreakpointHitResponse structs with JSON encode/decode for the hit round-trip.
- breakpoints field in AcceleratorActions for plugins to request breakpoints during initialization
- Tests verifying breakpoints in initialize response and breakpoint hit round-trip with JSON validation
- Packet documentation in lldbgdbremote.md