### PR TITLE
[AMDGPU] Verify data size of load-to-LDS intrinsics

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -7241,6 +7241,26 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
         "llvm.amdgcn.s.prefetch.data only supports global or constant memory");
     break;
   }
+  case Intrinsic::amdgcn_load_to_lds:
+  case Intrinsic::amdgcn_load_async_to_lds:
+  case Intrinsic::amdgcn_global_load_lds:
+  case Intrinsic::amdgcn_global_load_async_lds:
+  case Intrinsic::amdgcn_raw_buffer_load_lds:
+  case Intrinsic::amdgcn_raw_buffer_load_async_lds:
+  case Intrinsic::amdgcn_raw_ptr_buffer_load_lds:
+  case Intrinsic::amdgcn_raw_ptr_buffer_load_async_lds:
+  case Intrinsic::amdgcn_struct_buffer_load_lds:
+  case Intrinsic::amdgcn_struct_buffer_load_async_lds:
+  case Intrinsic::amdgcn_struct_ptr_buffer_load_lds:
+  case Intrinsic::amdgcn_struct_ptr_buffer_load_async_lds: {
+    // The data byte size immarg is operand 2 for every load-to-LDS intrinsic.
+    uint64_t Size = cast<ConstantInt>(Call.getArgOperand(2))->getZExtValue();
+    Check(Size == 1 || Size == 2 || Size == 4 || Size == 12 || Size == 16,
+          "invalid data size for load-to-LDS intrinsic; must be 1, 2, 4, 12, "
+          "or 16",
+          &Call);
+    break;
+  }
   case Intrinsic::amdgcn_mfma_scale_f32_16x16x128_f8f6f4:
   case Intrinsic::amdgcn_mfma_scale_f32_32x32x64_f8f6f4: {
     Value *Src0 = Call.getArgOperand(0);

--- a/llvm/test/Verifier/AMDGPU/intrinsic-load-to-lds.ll
+++ b/llvm/test/Verifier/AMDGPU/intrinsic-load-to-lds.ll
@@ -1,18 +1,5 @@
 ; RUN: not llvm-as %s -disable-output 2>&1 | FileCheck %s
 
-declare void @llvm.amdgcn.load.to.lds.p1(ptr addrspace(1), ptr addrspace(3), i32, i32, i32)
-declare void @llvm.amdgcn.load.async.to.lds.p1(ptr addrspace(1), ptr addrspace(3), i32, i32, i32)
-declare void @llvm.amdgcn.global.load.lds(ptr addrspace(1), ptr addrspace(3), i32, i32, i32)
-declare void @llvm.amdgcn.global.load.async.lds(ptr addrspace(1), ptr addrspace(3), i32, i32, i32)
-declare void @llvm.amdgcn.raw.buffer.load.lds(<4 x i32>, ptr addrspace(3), i32, i32, i32, i32, i32)
-declare void @llvm.amdgcn.raw.buffer.load.async.lds(<4 x i32>, ptr addrspace(3), i32, i32, i32, i32, i32)
-declare void @llvm.amdgcn.raw.ptr.buffer.load.lds(ptr addrspace(8), ptr addrspace(3), i32, i32, i32, i32, i32)
-declare void @llvm.amdgcn.raw.ptr.buffer.load.async.lds(ptr addrspace(8), ptr addrspace(3), i32, i32, i32, i32, i32)
-declare void @llvm.amdgcn.struct.buffer.load.lds(<4 x i32>, ptr addrspace(3), i32, i32, i32, i32, i32, i32)
-declare void @llvm.amdgcn.struct.buffer.load.async.lds(<4 x i32>, ptr addrspace(3), i32, i32, i32, i32, i32, i32)
-declare void @llvm.amdgcn.struct.ptr.buffer.load.lds(ptr addrspace(8), ptr addrspace(3), i32, i32, i32, i32, i32, i32)
-declare void @llvm.amdgcn.struct.ptr.buffer.load.async.lds(ptr addrspace(8), ptr addrspace(3), i32, i32, i32, i32, i32, i32)
-
 define void @load_to_lds(ptr addrspace(1) %gptr, ptr addrspace(3) %lptr) {
   ; CHECK: invalid data size for load-to-LDS intrinsic; must be 1, 2, 4, 12, or 16
   call void @llvm.amdgcn.load.to.lds.p1(ptr addrspace(1) %gptr, ptr addrspace(3) %lptr, i32 0, i32 0, i32 0)

--- a/llvm/test/Verifier/AMDGPU/intrinsic-load-to-lds.ll
+++ b/llvm/test/Verifier/AMDGPU/intrinsic-load-to-lds.ll
@@ -1,23 +1,58 @@
 ; RUN: not llvm-as %s -disable-output 2>&1 | FileCheck %s
 
+declare void @llvm.amdgcn.load.to.lds.p1(ptr addrspace(1), ptr addrspace(3), i32, i32, i32)
+declare void @llvm.amdgcn.load.async.to.lds.p1(ptr addrspace(1), ptr addrspace(3), i32, i32, i32)
 declare void @llvm.amdgcn.global.load.lds(ptr addrspace(1), ptr addrspace(3), i32, i32, i32)
-declare void @llvm.amdgcn.load.to.lds(ptr addrspace(1), ptr addrspace(3), i32, i32, i32)
+declare void @llvm.amdgcn.global.load.async.lds(ptr addrspace(1), ptr addrspace(3), i32, i32, i32)
+declare void @llvm.amdgcn.raw.buffer.load.lds(<4 x i32>, ptr addrspace(3), i32, i32, i32, i32, i32)
+declare void @llvm.amdgcn.raw.buffer.load.async.lds(<4 x i32>, ptr addrspace(3), i32, i32, i32, i32, i32)
 declare void @llvm.amdgcn.raw.ptr.buffer.load.lds(ptr addrspace(8), ptr addrspace(3), i32, i32, i32, i32, i32)
+declare void @llvm.amdgcn.raw.ptr.buffer.load.async.lds(ptr addrspace(8), ptr addrspace(3), i32, i32, i32, i32, i32)
+declare void @llvm.amdgcn.struct.buffer.load.lds(<4 x i32>, ptr addrspace(3), i32, i32, i32, i32, i32, i32)
+declare void @llvm.amdgcn.struct.buffer.load.async.lds(<4 x i32>, ptr addrspace(3), i32, i32, i32, i32, i32, i32)
+declare void @llvm.amdgcn.struct.ptr.buffer.load.lds(ptr addrspace(8), ptr addrspace(3), i32, i32, i32, i32, i32, i32)
+declare void @llvm.amdgcn.struct.ptr.buffer.load.async.lds(ptr addrspace(8), ptr addrspace(3), i32, i32, i32, i32, i32, i32)
 
-define void @global_load_lds_size_zero(ptr addrspace(1) %gptr, ptr addrspace(3) %lptr) {
+define void @load_to_lds(ptr addrspace(1) %gptr, ptr addrspace(3) %lptr) {
   ; CHECK: invalid data size for load-to-LDS intrinsic; must be 1, 2, 4, 12, or 16
-  call void @llvm.amdgcn.global.load.lds(ptr addrspace(1) %gptr, ptr addrspace(3) %lptr, i32 0, i32 0, i32 0)
+  call void @llvm.amdgcn.load.to.lds.p1(ptr addrspace(1) %gptr, ptr addrspace(3) %lptr, i32 0, i32 0, i32 0)
+  ; CHECK: invalid data size for load-to-LDS intrinsic; must be 1, 2, 4, 12, or 16
+  call void @llvm.amdgcn.load.async.to.lds.p1(ptr addrspace(1) %gptr, ptr addrspace(3) %lptr, i32 3, i32 0, i32 0)
+  ; CHECK: invalid data size for load-to-LDS intrinsic; must be 1, 2, 4, 12, or 16
+  call void @llvm.amdgcn.global.load.lds(ptr addrspace(1) %gptr, ptr addrspace(3) %lptr, i32 5, i32 0, i32 0)
+  ; CHECK: invalid data size for load-to-LDS intrinsic; must be 1, 2, 4, 12, or 16
+  call void @llvm.amdgcn.global.load.async.lds(ptr addrspace(1) %gptr, ptr addrspace(3) %lptr, i32 8, i32 0, i32 0)
   ret void
 }
 
-define void @load_to_lds_size_three(ptr addrspace(1) %gptr, ptr addrspace(3) %lptr) {
+define void @raw_buffer_load_lds(<4 x i32> %rsrc, ptr addrspace(3) %lptr) {
   ; CHECK: invalid data size for load-to-LDS intrinsic; must be 1, 2, 4, 12, or 16
-  call void @llvm.amdgcn.load.to.lds(ptr addrspace(1) %gptr, ptr addrspace(3) %lptr, i32 3, i32 0, i32 0)
+  call void @llvm.amdgcn.raw.buffer.load.lds(<4 x i32> %rsrc, ptr addrspace(3) %lptr, i32 0, i32 0, i32 0, i32 0, i32 0)
+  ; CHECK: invalid data size for load-to-LDS intrinsic; must be 1, 2, 4, 12, or 16
+  call void @llvm.amdgcn.raw.buffer.load.async.lds(<4 x i32> %rsrc, ptr addrspace(3) %lptr, i32 3, i32 0, i32 0, i32 0, i32 0)
   ret void
 }
 
-define void @raw_ptr_buffer_load_lds_size_eight(ptr addrspace(8) inreg %rsrc, ptr addrspace(3) inreg %lds) {
+define void @raw_ptr_buffer_load_lds(ptr addrspace(8) %rsrc, ptr addrspace(3) %lptr) {
   ; CHECK: invalid data size for load-to-LDS intrinsic; must be 1, 2, 4, 12, or 16
-  call void @llvm.amdgcn.raw.ptr.buffer.load.lds(ptr addrspace(8) %rsrc, ptr addrspace(3) %lds, i32 8, i32 0, i32 0, i32 0, i32 0)
+  call void @llvm.amdgcn.raw.ptr.buffer.load.lds(ptr addrspace(8) %rsrc, ptr addrspace(3) %lptr, i32 5, i32 0, i32 0, i32 0, i32 0)
+  ; CHECK: invalid data size for load-to-LDS intrinsic; must be 1, 2, 4, 12, or 16
+  call void @llvm.amdgcn.raw.ptr.buffer.load.async.lds(ptr addrspace(8) %rsrc, ptr addrspace(3) %lptr, i32 8, i32 0, i32 0, i32 0, i32 0)
+  ret void
+}
+
+define void @struct_buffer_load_lds(<4 x i32> %rsrc, ptr addrspace(3) %lptr) {
+  ; CHECK: invalid data size for load-to-LDS intrinsic; must be 1, 2, 4, 12, or 16
+  call void @llvm.amdgcn.struct.buffer.load.lds(<4 x i32> %rsrc, ptr addrspace(3) %lptr, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  ; CHECK: invalid data size for load-to-LDS intrinsic; must be 1, 2, 4, 12, or 16
+  call void @llvm.amdgcn.struct.buffer.load.async.lds(<4 x i32> %rsrc, ptr addrspace(3) %lptr, i32 3, i32 0, i32 0, i32 0, i32 0, i32 0)
+  ret void
+}
+
+define void @struct_ptr_buffer_load_lds(ptr addrspace(8) %rsrc, ptr addrspace(3) %lptr) {
+  ; CHECK: invalid data size for load-to-LDS intrinsic; must be 1, 2, 4, 12, or 16
+  call void @llvm.amdgcn.struct.ptr.buffer.load.lds(ptr addrspace(8) %rsrc, ptr addrspace(3) %lptr, i32 5, i32 0, i32 0, i32 0, i32 0, i32 0)
+  ; CHECK: invalid data size for load-to-LDS intrinsic; must be 1, 2, 4, 12, or 16
+  call void @llvm.amdgcn.struct.ptr.buffer.load.async.lds(ptr addrspace(8) %rsrc, ptr addrspace(3) %lptr, i32 8, i32 0, i32 0, i32 0, i32 0, i32 0)
   ret void
 }

--- a/llvm/test/Verifier/AMDGPU/intrinsic-load-to-lds.ll
+++ b/llvm/test/Verifier/AMDGPU/intrinsic-load-to-lds.ll
@@ -1,0 +1,23 @@
+; RUN: not llvm-as %s -disable-output 2>&1 | FileCheck %s
+
+declare void @llvm.amdgcn.global.load.lds(ptr addrspace(1), ptr addrspace(3), i32, i32, i32)
+declare void @llvm.amdgcn.load.to.lds(ptr addrspace(1), ptr addrspace(3), i32, i32, i32)
+declare void @llvm.amdgcn.raw.ptr.buffer.load.lds(ptr addrspace(8), ptr addrspace(3), i32, i32, i32, i32, i32)
+
+define void @global_load_lds_size_zero(ptr addrspace(1) %gptr, ptr addrspace(3) %lptr) {
+  ; CHECK: invalid data size for load-to-LDS intrinsic; must be 1, 2, 4, 12, or 16
+  call void @llvm.amdgcn.global.load.lds(ptr addrspace(1) %gptr, ptr addrspace(3) %lptr, i32 0, i32 0, i32 0)
+  ret void
+}
+
+define void @load_to_lds_size_three(ptr addrspace(1) %gptr, ptr addrspace(3) %lptr) {
+  ; CHECK: invalid data size for load-to-LDS intrinsic; must be 1, 2, 4, 12, or 16
+  call void @llvm.amdgcn.load.to.lds(ptr addrspace(1) %gptr, ptr addrspace(3) %lptr, i32 3, i32 0, i32 0)
+  ret void
+}
+
+define void @raw_ptr_buffer_load_lds_size_eight(ptr addrspace(8) inreg %rsrc, ptr addrspace(3) inreg %lds) {
+  ; CHECK: invalid data size for load-to-LDS intrinsic; must be 1, 2, 4, 12, or 16
+  call void @llvm.amdgcn.raw.ptr.buffer.load.lds(ptr addrspace(8) %rsrc, ptr addrspace(3) %lds, i32 8, i32 0, i32 0, i32 0, i32 0)
+  ret void
+}


### PR DESCRIPTION
An out-of-range size immarg (e.g. 0) produced an illegal i0 memory type during SelectionDAG building and crashed the backend instead of being rejected up front