### PR TITLE
Fix EH callsite table in basic-block-sections mode.

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/EHStreamer.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/EHStreamer.cpp
@@ -349,6 +349,22 @@ void EHStreamer::computeCallSiteTable(
         CallSites.push_back(Site);
         SawPotentiallyThrowing = false;
       }
+      // In basic-block-sections mode, we emit one call-site table for each
+      // section of the function. However, they all share the same action
+      // table. Unfortunately, this implies that each of the call-site tables
+      // (except the last) has an invalid "length" field, because the length is
+      // also used as the offset to the (shared) action table. In order to
+      // ensure that the personality function won't iterate off the end of the
+      // callsite table into other data, we need to ensure that there's one
+      // final "marker" entry which covers the end of the basic-block-section
+      // address range.
+      if (&MBB != &Asm->MF->back() &&
+          (CallSites.empty() || CallSites.back().EndLabel !=
+                                    CallSiteRanges.back().FragmentEndLabel)) {
+        CallSites.push_back({CallSiteRanges.back().FragmentEndLabel,
+                             CallSiteRanges.back().FragmentEndLabel, nullptr,
+                             0});
+      }
       CallSiteRanges.back().CallSiteEndIdx = CallSites.size();
     }
   }

--- a/llvm/test/CodeGen/X86/gcc_except_table_bb_sections.ll
+++ b/llvm/test/CodeGen/X86/gcc_except_table_bb_sections.ll
@@ -145,10 +145,14 @@ declare i32 @__gxx_personality_v0(...)
 ; CHECK-NEXT:           .byte	1                       # Call site Encoding = uleb128
 ; CHECK-NEXT:           .uleb128 .Laction_table_base0-.Lcst_begin0
 ; CHECK-NEXT:         .Lcst_begin0:
-; CHECK-NEXT:           .uleb128 .Ltmp0-.Lfunc_begin0   # >> Call Site 1 <<
-; CHECK-NEXT:           .uleb128 .Ltmp1-.Ltmp0          #   Call between .Ltmp0 and .Ltmp1
-; CHECK-NEXT:           .uleb128 .Ltmp2-main.__part.2   #     jumps to .Ltmp2
-; CHECK-NEXT:           .byte	3                       #   On action: 2
+; CHECK-NEXT:           .uleb128 .Ltmp0-.Lfunc_begin0      # >> Call Site 1 <<
+; CHECK-NEXT:           .uleb128 .Ltmp1-.Ltmp0             #   Call between .Ltmp0 and .Ltmp1
+; CHECK-NEXT:           .uleb128 .Ltmp2-main.__part.2      #     jumps to .Ltmp2
+; CHECK-NEXT:           .byte	3                          #   On action: 2
+; CHECK-NEXT:           .uleb128 .Lfunc_end0-.Lfunc_begin0 # >> Call Site 2 <<
+; CHECK-NEXT:           .uleb128 .Lfunc_end0-.Lfunc_end0   # Call between .Lfunc_end0 and .Lfunc_end0
+; CHECK-NEXT:           .byte 0                            # has no landing pad
+; CHECK-NEXT:           .byte 0                            # On action: cleanup
 ; CHECK-NEXT:           .p2align	2
 ; CHECK-NEXT:         .Lexception1:
 
@@ -174,6 +178,11 @@ declare i32 @__gxx_personality_v0(...)
 ; CHECK-NEXT:           .byte	1                       # Call site Encoding = uleb128
 ; CHECK-NEXT:           .uleb128 .Laction_table_base0-.Lcst_begin1
 ; CHECK-NEXT:         .Lcst_begin1:
+; CHECK-NEXT:           .uleb128 .LBB_END0_1-main.__part.1 # >> Call Site 3 <<
+; CHECK-NEXT:           .uleb128 .LBB_END0_1-.LBB_END0_1 # Call between .LBB_END0_1 and .LBB_END0_1
+; CHECK-NEXT:           .byte 0                            # has no landing pad
+; CHECK-NEXT:           .byte 0                            # On action: cleanup
+
 ; CHECK-NEXT:           .p2align 2
 ; CHECK-NEXT:         .Lexception2:
 
@@ -199,7 +208,7 @@ declare i32 @__gxx_personality_v0(...)
 ; CHECK-NEXT:           .byte	1                       # Call site Encoding = uleb128
 ; CHECK-NEXT:           .uleb128 .Laction_table_base0-.Lcst_begin2
 ; CHECK-NEXT:         .Lcst_begin2:
-; CHECK-NEXT:           .uleb128 main.__part.2-main.__part.2          # >> Call Site 2 <<
+; CHECK-NEXT:           .uleb128 main.__part.2-main.__part.2          # >> Call Site 4 <<
 ; CHECK-NEXT:           .uleb128 .LBB_END0_2-main.__part.2     #   Call between main.__part.2 and .LBB_END0_2
 ; CHECK-NEXT:           .byte	0                       #     has no landing pad
 ; CHECK-NEXT:           .byte	0                       #   On action: cleanup

--- a/llvm/test/CodeGen/X86/gcc_except_table_bb_sections_ehpad_groups_with_cold.ll
+++ b/llvm/test/CodeGen/X86/gcc_except_table_bb_sections_ehpad_groups_with_cold.ll
@@ -67,6 +67,10 @@ declare i32 @__gxx_personality_v0(...)
 ; CHECK-NEXT:    .uleb128 .Ltmp1-.Ltmp0         #   Call between .Ltmp0 and .Ltmp1
 ; CHECK-NEXT:    .uleb128 .Ltmp2-main.cold      #     jumps to .Ltmp2
 ; CHECK-NEXT:    .byte	3                       #   On action: 2
+; CHECK-NEXT:    .uleb128 .Lfunc_end0-.Lfunc_begin0 # >> Call Site 2 <<
+; CHECK-NEXT:    .uleb128 .Lfunc_end0-.Lfunc_end0   # Call between .Lfunc_end0 and .Lfunc_end0
+; CHECK-NEXT:    .byte 0                            # has no landing pad
+; CHECK-NEXT:    .byte 0                            # On action: cleanup
 ; CHECK-NEXT:    .p2align	2
 ; CHECK-NEXT:  .Lexception1:
 ; CHECK-NEXT:    .byte	0                       # @LPStart Encoding = absptr
@@ -77,7 +81,7 @@ declare i32 @__gxx_personality_v0(...)
 ; CHECK-NEXT:    .byte	1                       # Call site Encoding = uleb128
 ; CHECK-NEXT:    .uleb128 .Laction_table_base0-.Lcst_begin1
 ; CHECK-NEXT:  .Lcst_begin1:
-; CHECK-NEXT:    .uleb128 main.cold-main.cold   # >> Call Site 2 <<
+; CHECK-NEXT:    .uleb128 main.cold-main.cold   # >> Call Site 3 <<
 ; CHECK-NEXT:    .uleb128 .LBB_END0_2-main.cold #   Call between main.cold and .LBB_END0_2
 ; CHECK-NEXT:    .byte	0                       #     has no landing pad
 ; CHECK-NEXT:    .byte	0                       #   On action: cleanup

--- a/llvm/test/CodeGen/X86/gcc_except_table_bb_sections_nolpads.ll
+++ b/llvm/test/CodeGen/X86/gcc_except_table_bb_sections_nolpads.ll
@@ -25,19 +25,29 @@ cond.false:                                         ; preds = %entry
 ; CHECK-NEXT:   .byte	1                               # Call site Encoding = uleb128
 ; CHECK-NEXT:   .uleb128 .Laction_table_base0-.Lcst_begin0
 ; CHECK-NEXT: .Lcst_begin0:
+; CHECK-NEXT:   .uleb128 .Lfunc_end0-.Lfunc_begin0 # >> Call Site 1 <<
+; CHECK-NEXT:   .uleb128 .Lfunc_end0-.Lfunc_end0   # Call between .Lfunc_end0 and .Lfunc_end0
+; CHECK-NEXT:   .byte 0                            # has no landing pad
+; CHECK-NEXT:   .byte 0                            # On action: cleanup
+; CHECK-NEXT:   .p2align 2, 0x0
 ; CHECK-NEXT: .Lexception1:
 ; CHECK-NEXT:   .byte	255                             # @LPStart Encoding = omit
 ; CHECK-NEXT:   .byte	255                             # @TType Encoding = omit
 ; CHECK-NEXT:   .byte	1                               # Call site Encoding = uleb128
 ; CHECK-NEXT:   .uleb128 .Laction_table_base0-.Lcst_begin1
 ; CHECK-NEXT: .Lcst_begin1:
+; CHECK-NEXT:   .uleb128 .LBB_END0_1-foo.__part.1  # >> Call Site 2 <<
+; CHECK-NEXT:   .uleb128 .LBB_END0_1-.LBB_END0_1   # Call between .LBB_END0_1 and .LBB_END0_1
+; CHECK-NEXT:   .byte 0                            # has no landing pad
+; CHECK-NEXT:   .byte 0                            # On action: cleanup
+; CHECK-NEXT:   .p2align 2, 0x0
 ; CHECK-NEXT: .Lexception2:
 ; CHECK-NEXT:   .byte	255                             # @LPStart Encoding = omit
 ; CHECK-NEXT:   .byte	255                             # @TType Encoding = omit
 ; CHECK-NEXT:   .byte	1                               # Call site Encoding = uleb128
 ; CHECK-NEXT:   .uleb128 .Laction_table_base0-.Lcst_begin2
 ; CHECK-NEXT: .Lcst_begin2:
-; CHECK-NEXT:   .uleb128 foo.__part.2-foo.__part.2      # >> Call Site 1 <<
+; CHECK-NEXT:   .uleb128 foo.__part.2-foo.__part.2      # >> Call Site 3 <<
 ; CHECK-NEXT:   .uleb128 .LBB_END0_2-foo.__part.2       #   Call between foo.__part.2 and .LBB_END0_2
 ; CHECK-NEXT:   .byte	0                               #     has no landing pad
 ; CHECK-NEXT:   .byte	0                               #   On action: cleanup


### PR DESCRIPTION
When exception support was added for basic-block-sections in 8955950c121c97a686310991203c89ba14c90b82, the commit said:
> The CallSiteTableLength will not actually represent the length of
> the call site table, but rather the reference to the action
> table. Since the only purpose of this field is to locate the action
> table, correctness is guaranteed.

This is not precisely correct: the unwind library will iterate over callsite entries until either the length has been reached, a callsite entry has matched the lookup pointer, or the next entry has a start address greater-or-equal to that pointer.

Thus, if the end of the function is not covered by an entry, and the length is too large, it will iterate past the "real" end, into garbage.

In LLVM, today, addresses not covered by the callsite table may occur only for 'nounwind' calls. As such calls should not unwind, this issue is "mostly harmless" -- it causes failure only when you're doing something bad already. But, if we use gaps to implement 'unwindabort' behavior in the future, this issue becomes more serious.

To address this, while preserving the ability to share the action table, we ensure there is always be an callsite table entry covering the end of the basic-block-section, when an invalid length is used.

Even after this, we _are_ still emitting malformed call-site tables, with invalid lengths, which I'm not totally comfortable with. An alternative solution would be to stop attempting to share the action table. But, that's a more radical change, and this PR should also address the issue.