### PR TITLE
[X86] Don't fold ADDSUB to plain FP ops under strictfp

### DIFF
--- a/llvm/lib/Target/X86/X86InstCombineIntrinsic.cpp
+++ b/llvm/lib/Target/X86/X86InstCombineIntrinsic.cpp
@@ -3387,12 +3387,14 @@ std::optional<Value *> X86TTIImpl::simplifyDemandedVectorEltsIntrinsic(
   case Intrinsic::x86_avx_addsub_pd_256:
   case Intrinsic::x86_avx_addsub_ps_256: {
     // If none of the even or none of the odd lanes are required, turn this
-    // into a generic FP math instruction.
+    // into a generic FP math instruction.  Don't do this under strictfp: the
+    // plain FP op is evaluated in the default FP environment, dropping the
+    // dynamic rounding mode the intrinsic is required to honor.
     APInt SubMask = APInt::getSplat(VWidth, APInt(2, 0x1));
     APInt AddMask = APInt::getSplat(VWidth, APInt(2, 0x2));
     bool IsSubOnly = DemandedElts.isSubsetOf(SubMask);
     bool IsAddOnly = DemandedElts.isSubsetOf(AddMask);
-    if (IsSubOnly || IsAddOnly) {
+    if ((IsSubOnly || IsAddOnly) && !II.isStrictFP()) {
       assert((IsSubOnly ^ IsAddOnly) && "Can't be both add-only and sub-only");
       IRBuilderBase::InsertPointGuard Guard(IC.Builder);
       IC.Builder.SetInsertPoint(&II);

--- a/llvm/test/Transforms/InstCombine/X86/x86-addsub.ll
+++ b/llvm/test/Transforms/InstCombine/X86/x86-addsub.ll
@@ -192,3 +192,39 @@ define double @PR48476_fadd_fsub(<2 x double> %x) {
   %vecext = extractelement <2 x double> %t2, i32 0
   ret double %vecext
 }
+
+; The addsub -> plain FSub/FAdd demanded-elts fold rewrites the intrinsic into a
+; plain FP op evaluated in the default FP environment.  Under strictfp that drops
+; the dynamic rounding mode the intrinsic must honor, so the intrinsic must be
+; preserved.
+define double @elts_addsub_v2f64_sub_strictfp(<2 x double> %0, <2 x double> %1) strictfp {
+; CHECK-LABEL: @elts_addsub_v2f64_sub_strictfp(
+; CHECK-NEXT:    [[TMP3:%.*]] = tail call <2 x double> @llvm.x86.sse3.addsub.pd(<2 x double> [[TMP0:%.*]], <2 x double> [[TMP1:%.*]]) #[[ATTR1:[0-9]+]]
+; CHECK-NEXT:    [[TMP4:%.*]] = extractelement <2 x double> [[TMP3]], i64 0
+; CHECK-NEXT:    ret double [[TMP4]]
+;
+  %3 = shufflevector <2 x double> %0, <2 x double> poison, <2 x i32> <i32 0, i32 0>
+  %4 = shufflevector <2 x double> %1, <2 x double> poison, <2 x i32> <i32 0, i32 0>
+  %5 = tail call <2 x double> @llvm.x86.sse3.addsub.pd(<2 x double> %3, <2 x double> %4) strictfp
+  %6 = extractelement <2 x double> %5, i32 0
+  ret double %6
+}
+
+define float @elts_addsub_v4f32_add_strictfp(<4 x float> %0, <4 x float> %1) strictfp {
+; CHECK-LABEL: @elts_addsub_v4f32_add_strictfp(
+; CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <4 x float> [[TMP0:%.*]], <4 x float> poison, <4 x i32> <i32 poison, i32 1, i32 poison, i32 1>
+; CHECK-NEXT:    [[TMP4:%.*]] = shufflevector <4 x float> [[TMP1:%.*]], <4 x float> poison, <4 x i32> <i32 poison, i32 1, i32 poison, i32 1>
+; CHECK-NEXT:    [[TMP5:%.*]] = tail call <4 x float> @llvm.x86.sse3.addsub.ps(<4 x float> [[TMP3]], <4 x float> [[TMP4]]) #[[ATTR1]]
+; CHECK-NEXT:    [[TMP6:%.*]] = extractelement <4 x float> [[TMP5]], i64 1
+; CHECK-NEXT:    [[TMP7:%.*]] = extractelement <4 x float> [[TMP5]], i64 3
+; CHECK-NEXT:    [[TMP8:%.*]] = fadd float [[TMP6]], [[TMP7]]
+; CHECK-NEXT:    ret float [[TMP8]]
+;
+  %3 = shufflevector <4 x float> %0, <4 x float> poison, <4 x i32> <i32 0, i32 1, i32 0, i32 1>
+  %4 = shufflevector <4 x float> %1, <4 x float> poison, <4 x i32> <i32 0, i32 1, i32 0, i32 1>
+  %5 = tail call <4 x float> @llvm.x86.sse3.addsub.ps(<4 x float> %3, <4 x float> %4) strictfp
+  %6 = extractelement <4 x float> %5, i32 1
+  %7 = extractelement <4 x float> %5, i32 3
+  %8 = fadd float %6, %7
+  ret float %8
+}


### PR DESCRIPTION
The InstCombine demanded-elements fold for `x86_sse3_addsub_{pd,ps}` and
`x86_avx_addsub_{pd,ps}_256` rewrites the intrinsic into a plain, unconstrained
IR `fadd`/`fsub` when only the add lanes or only the sub lanes are demanded.

ADDSUB has no rounding-mode operand, so it honors the current (dynamic) rounding
mode. Unconstrained FP ops are evaluated in the default FP environment
(round-to-nearest), so under strictfp this silently drops the dynamic rounding
mode the intrinsic is required to honor.

Similar to https://github.com/llvm/llvm-project/pull/200610.