### PR TITLE
[AArch64] Don't fold SVE FP binops to plain ops/constants under strictfp

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
@@ -1829,6 +1829,12 @@ simplifySVEIntrinsicBinOp(InstCombiner &IC, IntrinsicInst &II,
   const unsigned Opc = IInfo.getMatchingIROpode();
   assert(Instruction::isBinaryOp(Opc) && "Expected a binary operation!");
 
+  // Don't fold FP ops to an unconstrained IR binop or constant under strictfp:
+  // that would drop the dynamic rounding mode and FP exception behavior the
+  // intrinsic must honor.  Mirrors the guard in instCombineSVEVectorBinOp.
+  if (II.isStrictFP() && isa<FPMathOperator>(&II))
+    return std::nullopt;
+
   Value *Pg = II.getOperand(0);
   Value *Op1 = II.getOperand(1);
   Value *Op2 = II.getOperand(2);

--- a/llvm/test/Transforms/InstCombine/AArch64/sve-intrinsic-strictfp.ll
+++ b/llvm/test/Transforms/InstCombine/AArch64/sve-intrinsic-strictfp.ll
@@ -78,7 +78,34 @@ define <vscale x 2 x double> @call_replace_fsub_intrinsic_double_strictfp(<vscal
   ret <vscale x 2 x double> %1
 }
 
+; The SVE binop simplifier constant-folds the operation in the default FP
+; environment, which under strictfp drops the dynamic rounding mode and FP
+; exception behavior.  The intrinsic must be preserved.
+define <vscale x 2 x double> @constant_fold_fdiv_strictfp() #0 {
+; CHECK: Function Attrs: strictfp
+; CHECK-LABEL: @constant_fold_fdiv_strictfp(
+; CHECK-NEXT:    [[TMP1:%.*]] = tail call <vscale x 2 x double> @llvm.aarch64.sve.fdiv.u.nxv2f64(<vscale x 2 x i1> splat (i1 true), <vscale x 2 x double> splat (double 1.000000e+01), <vscale x 2 x double> splat (double 3.000000e+00)) #[[ATTR2]]
+; CHECK-NEXT:    ret <vscale x 2 x double> [[TMP1]]
+;
+  %1 = tail call <vscale x 2 x i1> @llvm.aarch64.sve.ptrue.nxv2i1(i32 31) #1
+  %2 = tail call <vscale x 2 x double> @llvm.aarch64.sve.fdiv.nxv2f64(<vscale x 2 x i1> %1, <vscale x 2 x double> splat (double 1.000000e+01), <vscale x 2 x double> splat (double 3.000000e+00)) #1
+  ret <vscale x 2 x double> %2
+}
+
+; Likewise for an identity simplification (x * 1.0 -> x).
+define <vscale x 2 x double> @identity_fmul_strictfp(<vscale x 2 x double> %a) #0 {
+; CHECK: Function Attrs: strictfp
+; CHECK-LABEL: @identity_fmul_strictfp(
+; CHECK-NEXT:    [[TMP1:%.*]] = tail call <vscale x 2 x double> @llvm.aarch64.sve.fmul.u.nxv2f64(<vscale x 2 x i1> splat (i1 true), <vscale x 2 x double> [[A:%.*]], <vscale x 2 x double> splat (double 1.000000e+00)) #[[ATTR2]]
+; CHECK-NEXT:    ret <vscale x 2 x double> [[TMP1]]
+;
+  %1 = tail call <vscale x 2 x i1> @llvm.aarch64.sve.ptrue.nxv2i1(i32 31) #1
+  %2 = tail call <vscale x 2 x double> @llvm.aarch64.sve.fmul.nxv2f64(<vscale x 2 x i1> %1, <vscale x 2 x double> %a, <vscale x 2 x double> splat (double 1.000000e+00)) #1
+  ret <vscale x 2 x double> %2
+}
+
 declare <vscale x 2 x double> @llvm.aarch64.sve.fadd.nxv2f64(<vscale x 2 x i1>, <vscale x 2 x double>, <vscale x 2 x double>)
+declare <vscale x 2 x double> @llvm.aarch64.sve.fdiv.nxv2f64(<vscale x 2 x i1>, <vscale x 2 x double>, <vscale x 2 x double>)
 declare <vscale x 2 x double> @llvm.aarch64.sve.fmul.nxv2f64(<vscale x 2 x i1>, <vscale x 2 x double>, <vscale x 2 x double>)
 declare <vscale x 2 x double> @llvm.aarch64.sve.fsub.nxv2f64(<vscale x 2 x i1>, <vscale x 2 x double>, <vscale x 2 x double>)
 


### PR DESCRIPTION
`simplifySVEIntrinsicBinOp` folds the SVE `fadd`/`fsub`/`fmul`/`fdiv` intrinsics
(and their `_u` forms) by calling `simplifyBinOp`, which constant-folds and
applies FP identities (e.g. `x * 1.0 -> x`) in the default FP environment. Under
strictfp that silently drops the dynamic rounding mode and FP exception behavior
the intrinsic is required to honor — e.g. `svdiv(10.0, 3.0)` is folded to a
round-to-nearest constant.

Bail when the intrinsic is strictfp and an `FPMathOperator`, mirroring the
existing guard in `instCombineSVEVectorBinOp`.

Similar to https://github.com/llvm/llvm-project/pull/200610.