### PR TITLE
[Support] Use ASCII ctype helpers in StringExtras case converters

### DIFF
--- a/llvm/lib/Support/StringExtras.cpp
+++ b/llvm/lib/Support/StringExtras.cpp
@@ -13,7 +13,6 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/raw_ostream.h"
-#include <cctype>
 
 using namespace llvm;
 
@@ -85,15 +84,15 @@ std::string llvm::convertToSnakeFromCamelCase(StringRef input) {
 
   std::string snakeCase;
   snakeCase.reserve(input.size());
-  auto check = [&input](size_t j, function_ref<bool(int)> predicate) {
+  auto check = [&input](size_t j, function_ref<bool(char)> predicate) {
     return j < input.size() && predicate(input[j]);
   };
   for (size_t i = 0; i < input.size(); ++i) {
-    snakeCase.push_back(tolower(input[i]));
+    snakeCase.push_back(toLower(input[i]));
     // Handles "runs" of capitals, such as in OPName -> op_name.
-    if (check(i, isupper) && check(i + 1, isupper) && check(i + 2, islower))
+    if (check(i, isUpper) && check(i + 1, isUpper) && check(i + 2, isLower))
       snakeCase.push_back('_');
-    if ((check(i, islower) || check(i, isdigit)) && check(i + 1, isupper))
+    if ((check(i, isLower) || check(i, isDigit)) && check(i + 1, isUpper))
       snakeCase.push_back('_');
   }
   return snakeCase;
@@ -108,14 +107,14 @@ std::string llvm::convertToCamelFromSnakeCase(StringRef input,
   output.reserve(input.size());
 
   // Push the first character, capatilizing if necessary.
-  if (capitalizeFirst && std::islower(input.front()))
+  if (capitalizeFirst && llvm::isLower(input.front()))
     output.push_back(llvm::toUpper(input.front()));
   else
     output.push_back(input.front());
 
   // Walk the input converting any `*_[a-z]` snake case into `*[A-Z]` camelCase.
   for (size_t pos = 1, e = input.size(); pos < e; ++pos) {
-    if (input[pos] == '_' && pos != (e - 1) && std::islower(input[pos + 1]))
+    if (input[pos] == '_' && pos != (e - 1) && llvm::isLower(input[pos + 1]))
       output.push_back(llvm::toUpper(input[++pos]));
     else
       output.push_back(input[pos]);

--- a/llvm/unittests/ADT/StringExtrasTest.cpp
+++ b/llvm/unittests/ADT/StringExtrasTest.cpp
@@ -214,6 +214,12 @@ TEST(StringExtrasTest, ConvertToSnakeFromCamelCase) {
   testConvertToSnakeCase("_op_name", "_op_name");
   testConvertToSnakeCase("__op_name", "__op_name");
   testConvertToSnakeCase("op__name", "op__name");
+
+  // Bytes >= 0x80 are handled deterministically: the llvm:: ctype helpers are
+  // ASCII-only and locale-independent, so such bytes are neither classified as
+  // letters nor case-folded (the C <cctype> functions are locale-dependent and
+  // have undefined behavior on a negative char).
+  testConvertToSnakeCase("a\x80zB", "a\x80z_b");
 }
 
 TEST(StringExtrasTest, ConvertToCamelFromSnakeCase) {
@@ -247,6 +253,11 @@ TEST(StringExtrasTest, ConvertToCamelFromSnakeCase) {
   testConvertToCamelCase(true, "_OpName", "_OpName");
   testConvertToCamelCase(true, "Op_Name", "Op_Name");
   testConvertToCamelCase(true, "opName", "OpName");
+
+  // Bytes >= 0x80 are passed through unchanged: a '_' is only consumed when the
+  // following byte is an ASCII lowercase letter, independent of locale.
+  testConvertToCamelCase(false, "op_\x80me", "op_\x80me");
+  testConvertToCamelCase(true, "\x80name", "\x80name");
 }
 
 constexpr uint64_t MaxUint64 = std::numeric_limits<uint64_t>::max();


### PR DESCRIPTION
convertToSnakeFromCamelCase() and convertToCamelFromSnakeCase() classified and case-folded characters using the C <cctype> functions (tolower, isupper, islower, isdigit). Those are locale-dependent and have undefined behavior when passed a char whose value is negative, which happens for any byte >= 0x80 on the common platforms where char is signed.

Switch them to llvm::toLower / isUpper / isLower / isDigit, the ASCII-only, locale-independent helpers already declared in StringExtras.h and already used by printLowerCase() in the same file. Behavior is unchanged for ASCII input (the only input these functions receive in practice); the conversion is now well-defined and locale-independent for every byte. The now-unused <cctype> include is removed.

Add unit tests covering bytes >= 0x80 to lock in the deterministic behavior.