### PR TITLE
Add Apple M5 host detection

### DIFF
--- a/llvm/lib/TargetParser/Host.cpp
+++ b/llvm/lib/TargetParser/Host.cpp
@@ -1820,10 +1820,10 @@ StringRef sys::getHostCPUName() {
   case CPUFAMILY_ARM_TAHITI: // A18 Pro
   case CPUFAMILY_ARM_TUPAI:  // A18
     return "apple-m4";
-  case CPUFAMILY_ARM_HIDRA:  // M5
-  case CPUFAMILY_ARM_SOTRA:  // M5 Pro/Max
-  case CPUFAMILY_ARM_THERA:  // A19 Pro
-  case CPUFAMILY_ARM_TILOS:  // A19
+  case CPUFAMILY_ARM_HIDRA: // M5
+  case CPUFAMILY_ARM_SOTRA: // M5 Pro/Max
+  case CPUFAMILY_ARM_THERA: // A19 Pro
+  case CPUFAMILY_ARM_TILOS: // A19
     return "apple-m5";
   default:
     // Default to the newest CPU we know about.

--- a/llvm/lib/TargetParser/Host.cpp
+++ b/llvm/lib/TargetParser/Host.cpp
@@ -1752,6 +1752,10 @@ StringRef sys::getHostCPUName() {
 #define CPUFAMILY_ARM_BRAVA 0x17d5b93a
 #define CPUFAMILY_ARM_TAHITI 0x75d4acb9
 #define CPUFAMILY_ARM_TUPAI 0x204526d0
+#define CPUFAMILY_ARM_HIDRA 0x1d5a87e8
+#define CPUFAMILY_ARM_SOTRA 0xf76c5b1a
+#define CPUFAMILY_ARM_THERA 0xab345f09
+#define CPUFAMILY_ARM_TILOS 0x01d7a72b
 
 StringRef sys::getHostCPUName() {
   uint32_t Family;
@@ -1812,13 +1816,18 @@ StringRef sys::getHostCPUName() {
   case CPUFAMILY_ARM_COLL: // A17 Pro
     return "apple-a17";
   case CPUFAMILY_ARM_DONAN:  // M4
-  case CPUFAMILY_ARM_BRAVA:  // M4 Max
+  case CPUFAMILY_ARM_BRAVA:  // M4 Pro/Max
   case CPUFAMILY_ARM_TAHITI: // A18 Pro
   case CPUFAMILY_ARM_TUPAI:  // A18
     return "apple-m4";
+  case CPUFAMILY_ARM_HIDRA:  // M5
+  case CPUFAMILY_ARM_SOTRA:  // M5 Pro/Max
+  case CPUFAMILY_ARM_THERA:  // A19 Pro
+  case CPUFAMILY_ARM_TILOS:  // A19
+    return "apple-m5";
   default:
     // Default to the newest CPU we know about.
-    return "apple-m4";
+    return "apple-m5";
   }
 }
 #elif defined(_AIX)


### PR DESCRIPTION
The values have been taken from `mach/machine.h` in the Xcode 26.5 SDK.

Nomenclature of the A19 pro and A19 (Thera and Tilos) have been obtained from [this site](https://hubweb.cn).
<img width="393" height="221" alt="image" src="https://github.com/user-attachments/assets/26c68e6a-2983-4f77-a712-683ac5a8fa97" />

M5 base CPU family matches Hidra
<img width="1130" height="131" alt="image" src="https://github.com/user-attachments/assets/19fd50f4-a64b-4766-beff-57119589058e" />

M5 Pro and Max match Sotra
<img width="1050" height="173" alt="image" src="https://github.com/user-attachments/assets/8aebedc1-ab43-46d7-868b-77b54fad7e65" />
<img width="1150" height="196" alt="image" src="https://github.com/user-attachments/assets/fa9ee05d-5005-48c9-b091-4721a2960af4" />


These screenshots have been taken from https://github.com/devMEremenko/XcodeBenchmark/pull/642, https://github.com/devMEremenko/XcodeBenchmark/issues/668 and https://github.com/devMEremenko/XcodeBenchmark/issues/656

CC @jroelofs