### PR TITLE
[FileCheck] Add --filter-label to drop CHECKs outside selected CHECK-LABEL sections

### DIFF
--- a/llvm/include/llvm/FileCheck/FileCheck.h
+++ b/llvm/include/llvm/FileCheck/FileCheck.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_FILECHECK_FILECHECK_H
 #define LLVM_FILECHECK_FILECHECK_H
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Compiler.h"
@@ -501,6 +502,10 @@ public:
   /// UNIX-style '\n'.
   LLVM_ABI StringRef CanonicalizeFile(MemoryBuffer &MB,
                                       SmallVectorImpl<char> &OutputBuffer);
+
+  /// Drops CHECKs whose CHECK-LABEL section's literal text doesn't match any
+  /// of \p Names. CHECKs before the first label are dropped. Nop if empty.
+  LLVM_ABI void filterByLabel(ArrayRef<StringRef> Names);
 
   /// Checks the input to FileCheck provided in the \p Buffer against the
   /// expected strings read from the check file and record diagnostics emitted

--- a/llvm/lib/FileCheck/FileCheck.cpp
+++ b/llvm/lib/FileCheck/FileCheck.cpp
@@ -2531,6 +2531,30 @@ static bool ValidatePrefixes(StringRef Kind, StringSet<> &UniquePrefixes,
   return true;
 }
 
+void FileCheck::filterByLabel(ArrayRef<StringRef> Names) {
+  if (Names.empty())
+    return;
+
+  // (name1|name2|...) bracketed by non-chars (or string ends).
+  std::string Alts;
+  for (StringRef Name : Names) {
+    if (!Alts.empty())
+      Alts += '|';
+    Alts += Regex::escape(Name);
+  }
+  Regex Re("(^|[^[:alnum:]_])(" + Alts + ")([^[:alnum:]_]|$)");
+
+  std::vector<FileCheckString> Filtered;
+  bool Keeping = false;
+  for (auto &CS : CheckStrings) {
+    if (CS.Pat.getCheckTy() == Check::CheckLabel)
+      Keeping = Re.match(CS.Pat.getFixedStr());
+    if (Keeping)
+      Filtered.push_back(std::move(CS));
+  }
+  CheckStrings = std::move(Filtered);
+}
+
 bool FileCheck::ValidateCheckPrefixes() {
   StringSet<> UniquePrefixes;
   // Add default prefixes to catch user-supplied duplicates of them below.

--- a/llvm/lib/FileCheck/FileCheckImpl.h
+++ b/llvm/lib/FileCheck/FileCheckImpl.h
@@ -745,6 +745,11 @@ public:
 
   Check::FileCheckType getCheckTy() const { return CheckTy; }
 
+  /// \returns the literal pattern text, or an empty StringRef if the pattern
+  /// requires a regex match. Used by FileCheck::filterByLabel to identify
+  /// CHECK-LABEL sections by their literal text.
+  StringRef getFixedStr() const { return FixedStr; }
+
   int getCount() const { return CheckTy.getCount(); }
 
 private:

--- a/llvm/test/FileCheck/filter-label.txt
+++ b/llvm/test/FileCheck/filter-label.txt
@@ -1,0 +1,51 @@
+; Verify --filter-label drops CHECKs whose CHECK-LABEL section's literal text
+; doesn't match any of the given names.
+
+; RUN: FileCheck --filter-label=foo -input-file %s %s -check-prefix=ALL
+; RUN: FileCheck --filter-label=bar -input-file %s %s -check-prefix=ALL
+; RUN: FileCheck --filter-label=foo,bar -input-file %s %s -check-prefix=ALL
+; RUN: FileCheck --filter-label=bar,foo -input-file %s %s -check-prefix=ALL
+
+; RUN: %ProtectFileCheckOutput \
+; RUN: not FileCheck --filter-label=foobar -input-file %s %s -check-prefix=ALL 2>&1 \
+; RUN: | FileCheck %s -check-prefix=FAIL-ERR
+
+; RUN: %ProtectFileCheckOutput \
+; RUN: not FileCheck -input-file %s %s -check-prefix=ALL 2>&1 \
+; RUN: | FileCheck %s -check-prefix=FAIL-ERR
+
+; RUN: %ProtectFileCheckOutput \
+; RUN: not FileCheck --filter-label=baz -input-file %s %s -check-prefix=BAZ 2>&1 \
+; RUN: | FileCheck %s -check-prefix=FAIL-ERR
+
+
+@foo:
+a
+b
+
+@bar:
+c
+d
+
+@foobar:
+e
+f
+
+@baz:
+g
+h
+
+; ALL-LABEL: @foo:
+; ALL: {{^}}a
+; ALL: {{^}}b
+; ALL-LABEL: @bar:
+; ALL: {{^}}c
+; ALL: {{^}}d
+; ALL-LABEL: @foobar:
+; ALL: {{^}}e
+; ALL: {{^}}MISMATCH
+; BAZ-LABEL: @baz:
+; BAZ: {{^}}g
+; BAZ: {{^}}i
+
+; FAIL-ERR: expected string not found in input

--- a/llvm/utils/FileCheck/FileCheck.cpp
+++ b/llvm/utils/FileCheck/FileCheck.cpp
@@ -143,6 +143,12 @@ enum DumpInputFilterValue {
   DumpInputFilterAll
 };
 
+static cl::list<std::string> FilterLabel(
+    "filter-label", cl::CommaSeparated,
+    cl::desc("Keep only CHECKs in CHECK-LABEL sections whose label\n"
+             "matches one of the given names."),
+    cl::value_desc("name"));
+
 static cl::list<DumpInputFilterValue> DumpInputFilters(
     "dump-input-filter",
     cl::desc("In the dump requested by -dump-input, print only input lines of\n"
@@ -867,6 +873,12 @@ int main(int argc, char **argv) {
   std::pair<unsigned, unsigned> ImpPatBufferIDRange;
   if (FC.readCheckFile(SM, CheckFileText, &ImpPatBufferIDRange))
     return 2;
+
+  if (!FilterLabel.empty()) {
+    SmallVector<StringRef, 4> FilterLabelRefs(FilterLabel.begin(),
+                                              FilterLabel.end());
+    FC.filterByLabel(FilterLabelRefs);
+  }
 
   // Open the file to check and add it to SourceMgr.
   ErrorOr<std::unique_ptr<MemoryBuffer>> InputFileOrErr =


### PR DESCRIPTION
Add --filter-label=NAMES (comma-separated) to drop CHECKs outside selected CHECK-LABEL sections whose NAME does not match the CHECK-line under the CHECK-LABEL.

Stacked above https://github.com/llvm/llvm-project/pull/199147; and below https://github.com/llvm/llvm-project/pull/200350.