### PR TITLE
[SelectionDAG] Promote FPOWI/FLDEXP exponents where possible, and raise an error otherwise

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
@@ -2826,8 +2826,11 @@ SDValue DAGTypeLegalizer::PromoteIntOp_ExpOp(SDNode *N) {
   // sign-extended to int by the makeLibCall below.
   if (N->getOperand(1 + OpOffset).getScalarValueSizeInBits() >
       DAG.getLibInfo().getIntSize()) {
-    DAG.getContext()->emitError(
-        "powi/ldexp exponent does not match sizeof(int)");
+    const Function &Fn = DAG.getMachineFunction().getFunction();
+    Fn.getContext().diagnose(DiagnosticInfoLegalizationFailure(
+        Twine(IsPowI ? "powi" : "ldexp") +
+            " exponent does not match sizeof(int)",
+        Fn, N->getDebugLoc()));
     if (IsStrict)
       ReplaceValueWith(SDValue(N, 1), Chain);
     ReplaceValueWith(SDValue(N, 0), DAG.getPOISON(N->getValueType(0)));

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
@@ -2821,10 +2821,19 @@ SDValue DAGTypeLegalizer::PromoteIntOp_ExpOp(SDNode *N) {
   // we rewrite to a libcall here directly, letting makeLibCall handle promotion
   // if the target accepts it according to shouldSignExtendTypeInLibCall.
 
-  // The exponent should fit in a sizeof(int) type for the libcall to be valid.
-  assert(DAG.getLibInfo().getIntSize() ==
-             N->getOperand(1 + OpOffset).getValueType().getSizeInBits() &&
-         "POWI exponent should match with sizeof(int) when doing the libcall.");
+  // A wider-than-int exponent can't be passed in an int (there's no wider
+  // libcall), so bail like the soften/expand paths. A narrower one is
+  // sign-extended to int by the makeLibCall below.
+  if (N->getOperand(1 + OpOffset).getScalarValueSizeInBits() >
+      DAG.getLibInfo().getIntSize()) {
+    DAG.getContext()->emitError(
+        "powi/ldexp exponent does not match sizeof(int)");
+    if (IsStrict)
+      ReplaceValueWith(SDValue(N, 1), Chain);
+    ReplaceValueWith(SDValue(N, 0), DAG.getPOISON(N->getValueType(0)));
+    return SDValue();
+  }
+
   TargetLowering::MakeLibCallOptions CallOptions;
   CallOptions.setIsSigned(true);
   SDValue Ops[2] = {N->getOperand(0 + OpOffset), N->getOperand(1 + OpOffset)};

--- a/llvm/test/CodeGen/AArch64/ldexp.ll
+++ b/llvm/test/CodeGen/AArch64/ldexp.ll
@@ -56,6 +56,65 @@ entry:
   ret double %call
 }
 
+; A sub-int exponent must be sign-extended to int on the libcall path;
+; PromoteIntOp_ExpOp must not crash on it.
+define double @testExpIntrinsic_i16(double %val, i16 %a) {
+; SVELINUX-LABEL: testExpIntrinsic_i16:
+; SVELINUX:       // %bb.0: // %entry
+; SVELINUX-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
+; SVELINUX-NEXT:    .cfi_def_cfa_offset 16
+; SVELINUX-NEXT:    .cfi_offset w30, -16
+; SVELINUX-NEXT:    sxth w0, w0
+; SVELINUX-NEXT:    bl ldexp
+; SVELINUX-NEXT:    ldr x30, [sp], #16 // 8-byte Folded Reload
+; SVELINUX-NEXT:    ret
+;
+; GISEL-LABEL: testExpIntrinsic_i16:
+; GISEL:       // %bb.0: // %entry
+; GISEL-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
+; GISEL-NEXT:    .cfi_def_cfa_offset 16
+; GISEL-NEXT:    .cfi_offset w30, -16
+; GISEL-NEXT:    sxth w0, w0
+; GISEL-NEXT:    bl ldexp
+; GISEL-NEXT:    ldr x30, [sp], #16 // 8-byte Folded Reload
+; GISEL-NEXT:    ret
+;
+; SVEWINDOWS-LABEL: testExpIntrinsic_i16:
+; SVEWINDOWS:       .seh_proc testExpIntrinsic_i16
+; SVEWINDOWS-NEXT:  // %bb.0: // %entry
+; SVEWINDOWS-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
+; SVEWINDOWS-NEXT:    .seh_save_reg_x x30, 16
+; SVEWINDOWS-NEXT:    .seh_endprologue
+; SVEWINDOWS-NEXT:    sxth w0, w0
+; SVEWINDOWS-NEXT:    bl ldexp
+; SVEWINDOWS-NEXT:    .seh_startepilogue
+; SVEWINDOWS-NEXT:    ldr x30, [sp], #16 // 8-byte Folded Reload
+; SVEWINDOWS-NEXT:    .seh_save_reg_x x30, 16
+; SVEWINDOWS-NEXT:    .seh_endepilogue
+; SVEWINDOWS-NEXT:    ret
+; SVEWINDOWS-NEXT:    .seh_endfunclet
+; SVEWINDOWS-NEXT:    .seh_endproc
+;
+; WINDOWS-LABEL: testExpIntrinsic_i16:
+; WINDOWS:       .seh_proc testExpIntrinsic_i16
+; WINDOWS-NEXT:  // %bb.0: // %entry
+; WINDOWS-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
+; WINDOWS-NEXT:    .seh_save_reg_x x30, 16
+; WINDOWS-NEXT:    .seh_endprologue
+; WINDOWS-NEXT:    sxth w0, w0
+; WINDOWS-NEXT:    bl ldexp
+; WINDOWS-NEXT:    .seh_startepilogue
+; WINDOWS-NEXT:    ldr x30, [sp], #16 // 8-byte Folded Reload
+; WINDOWS-NEXT:    .seh_save_reg_x x30, 16
+; WINDOWS-NEXT:    .seh_endepilogue
+; WINDOWS-NEXT:    ret
+; WINDOWS-NEXT:    .seh_endfunclet
+; WINDOWS-NEXT:    .seh_endproc
+entry:
+  %call = tail call fast double @llvm.ldexp.f64.i16(double %val, i16 %a)
+  ret double %call
+}
+
 define float @testExpf(float %val, i32 %a) {
 ; SVELINUX-LABEL: testExpf:
 ; SVELINUX:       // %bb.0: // %entry

--- a/llvm/test/CodeGen/AArch64/ldexp.ll
+++ b/llvm/test/CodeGen/AArch64/ldexp.ll
@@ -58,58 +58,30 @@ entry:
 
 ; A sub-int exponent must be sign-extended to int on the libcall path;
 ; PromoteIntOp_ExpOp must not crash on it.
-define double @testExpIntrinsic_i16(double %val, i16 %a) {
-; SVELINUX-LABEL: testExpIntrinsic_i16:
-; SVELINUX:       // %bb.0: // %entry
-; SVELINUX-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
-; SVELINUX-NEXT:    .cfi_def_cfa_offset 16
-; SVELINUX-NEXT:    .cfi_offset w30, -16
-; SVELINUX-NEXT:    sxth w0, w0
-; SVELINUX-NEXT:    bl ldexp
-; SVELINUX-NEXT:    ldr x30, [sp], #16 // 8-byte Folded Reload
-; SVELINUX-NEXT:    ret
+define double @testExpIntrinsic_i16(double %val, i16 %a) nounwind {
+; SVE-LABEL: testExpIntrinsic_i16:
+; SVE:       // %bb.0: // %entry
+; SVE-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
+; SVE-NEXT:    sxth w0, w0
+; SVE-NEXT:    bl ldexp
+; SVE-NEXT:    ldr x30, [sp], #16 // 8-byte Folded Reload
+; SVE-NEXT:    ret
 ;
 ; GISEL-LABEL: testExpIntrinsic_i16:
 ; GISEL:       // %bb.0: // %entry
 ; GISEL-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
-; GISEL-NEXT:    .cfi_def_cfa_offset 16
-; GISEL-NEXT:    .cfi_offset w30, -16
 ; GISEL-NEXT:    sxth w0, w0
 ; GISEL-NEXT:    bl ldexp
 ; GISEL-NEXT:    ldr x30, [sp], #16 // 8-byte Folded Reload
 ; GISEL-NEXT:    ret
 ;
-; SVEWINDOWS-LABEL: testExpIntrinsic_i16:
-; SVEWINDOWS:       .seh_proc testExpIntrinsic_i16
-; SVEWINDOWS-NEXT:  // %bb.0: // %entry
-; SVEWINDOWS-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
-; SVEWINDOWS-NEXT:    .seh_save_reg_x x30, 16
-; SVEWINDOWS-NEXT:    .seh_endprologue
-; SVEWINDOWS-NEXT:    sxth w0, w0
-; SVEWINDOWS-NEXT:    bl ldexp
-; SVEWINDOWS-NEXT:    .seh_startepilogue
-; SVEWINDOWS-NEXT:    ldr x30, [sp], #16 // 8-byte Folded Reload
-; SVEWINDOWS-NEXT:    .seh_save_reg_x x30, 16
-; SVEWINDOWS-NEXT:    .seh_endepilogue
-; SVEWINDOWS-NEXT:    ret
-; SVEWINDOWS-NEXT:    .seh_endfunclet
-; SVEWINDOWS-NEXT:    .seh_endproc
-;
 ; WINDOWS-LABEL: testExpIntrinsic_i16:
-; WINDOWS:       .seh_proc testExpIntrinsic_i16
-; WINDOWS-NEXT:  // %bb.0: // %entry
+; WINDOWS:       // %bb.0: // %entry
 ; WINDOWS-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
-; WINDOWS-NEXT:    .seh_save_reg_x x30, 16
-; WINDOWS-NEXT:    .seh_endprologue
 ; WINDOWS-NEXT:    sxth w0, w0
 ; WINDOWS-NEXT:    bl ldexp
-; WINDOWS-NEXT:    .seh_startepilogue
 ; WINDOWS-NEXT:    ldr x30, [sp], #16 // 8-byte Folded Reload
-; WINDOWS-NEXT:    .seh_save_reg_x x30, 16
-; WINDOWS-NEXT:    .seh_endepilogue
 ; WINDOWS-NEXT:    ret
-; WINDOWS-NEXT:    .seh_endfunclet
-; WINDOWS-NEXT:    .seh_endproc
 entry:
   %call = tail call fast double @llvm.ldexp.f64.i16(double %val, i16 %a)
   ret double %call

--- a/llvm/test/CodeGen/AArch64/powi-ldexp-promote-libcall-error.ll
+++ b/llvm/test/CodeGen/AArch64/powi-ldexp-promote-libcall-error.ll
@@ -1,0 +1,24 @@
+; RUN: not llc -mtriple=aarch64-linux-gnu -filetype=null %s 2>&1 | FileCheck %s
+
+; A powi/ldexp exponent wider than sizeof(int) can't be passed to the libcall,
+; so PromoteIntOp_ExpOp must emit a clean error rather than crash (assertions)
+; or silently truncate. i48 is illegal and promoted through that path here; i64
+; would be legal and i128 expanded, so neither would reach it.
+
+; CHECK: error: powi/ldexp exponent does not match sizeof(int)
+define double @ldexp_f64_i48(double %val, i48 %a) {
+  %call = call double @llvm.ldexp.f64.i48(double %val, i48 %a)
+  ret double %call
+}
+
+; CHECK: error: powi/ldexp exponent does not match sizeof(int)
+define double @powi_f64_i48(double %val, i48 %a) {
+  %call = call double @llvm.powi.f64.i48(double %val, i48 %a)
+  ret double %call
+}
+
+; CHECK: error: powi/ldexp exponent does not match sizeof(int)
+define double @ldexp_f64_i48_strictfp(double %val, i48 %a) strictfp {
+  %call = call double @llvm.experimental.constrained.ldexp.f64.i48(double %val, i48 %a, metadata !"round.tonearest", metadata !"fpexcept.strict")
+  ret double %call
+}

--- a/llvm/test/CodeGen/AArch64/powi-ldexp-promote-libcall-error.ll
+++ b/llvm/test/CodeGen/AArch64/powi-ldexp-promote-libcall-error.ll
@@ -1,23 +1,23 @@
-; RUN: not llc -mtriple=aarch64-linux-gnu -filetype=null %s 2>&1 | FileCheck %s
+; RUN: not llc -mtriple=aarch64 -filetype=null %s 2>&1 | FileCheck %s
 
 ; A powi/ldexp exponent wider than sizeof(int) can't be passed to the libcall,
 ; so PromoteIntOp_ExpOp must emit a clean error rather than crash (assertions)
 ; or silently truncate. i48 is illegal and promoted through that path here; i64
 ; would be legal and i128 expanded, so neither would reach it.
 
-; CHECK: error: powi/ldexp exponent does not match sizeof(int)
+; CHECK: error: {{.*}}ldexp exponent does not match sizeof(int)
 define double @ldexp_f64_i48(double %val, i48 %a) {
   %call = call double @llvm.ldexp.f64.i48(double %val, i48 %a)
   ret double %call
 }
 
-; CHECK: error: powi/ldexp exponent does not match sizeof(int)
+; CHECK: error: {{.*}}powi exponent does not match sizeof(int)
 define double @powi_f64_i48(double %val, i48 %a) {
   %call = call double @llvm.powi.f64.i48(double %val, i48 %a)
   ret double %call
 }
 
-; CHECK: error: powi/ldexp exponent does not match sizeof(int)
+; CHECK: error: {{.*}}ldexp exponent does not match sizeof(int)
 define double @ldexp_f64_i48_strictfp(double %val, i48 %a) strictfp {
   %call = call double @llvm.experimental.constrained.ldexp.f64.i48(double %val, i48 %a, metadata !"round.tonearest", metadata !"fpexcept.strict")
   ret double %call


### PR DESCRIPTION
PromoteIntOp_ExpOp is reached when the exponent type is illegal.

- When the exponent type was smaller than int, we'd hit an assertion.  In builds where asserts were disabled, we actually ended up doing the right thing; makeLibCall would sign-extend the value to int.

- When the exponent type was too large, we'd also hit an assertion.  In builds were asserts were disabled, we would *not* do the right thing; we'd end up silently truncating the value.  Now we explicitly raise an error.