### PR TITLE
[SelectionDAG] Don't over-claim alignment on vector splice/compress stack MMOs

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -12977,11 +12977,13 @@ SDValue TargetLowering::expandVectorSplice(SDNode *Node,
   auto PtrInfo = MachinePointerInfo::getFixedStack(MF, FrameIndex);
 
   // Store the lo part of CONCAT_VECTORS(V1, V2)
-  SDValue StoreV1 = DAG.getStore(DAG.getEntryNode(), DL, V1, StackPtr, PtrInfo);
+  SDValue StoreV1 =
+      DAG.getStore(DAG.getEntryNode(), DL, V1, StackPtr, PtrInfo, Alignment);
   // Store the hi part of CONCAT_VECTORS(V1, V2)
   SDValue VTBytes = DAG.getTypeSize(DL, PtrVT, VT.getStoreSize());
   SDValue StackPtr2 = DAG.getNode(ISD::ADD, DL, PtrVT, StackPtr, VTBytes);
-  SDValue StoreV2 = DAG.getStore(StoreV1, DL, V2, StackPtr2, PtrInfo);
+  SDValue StoreV2 =
+      DAG.getStore(StoreV1, DL, V2, StackPtr2, PtrInfo, Alignment);
 
   // NOTE: TrailingBytes must be clamped so as not to read outside of V1:V2.
   SDValue EltByteSize =
@@ -12998,7 +13000,7 @@ SDValue TargetLowering::expandVectorSplice(SDNode *Node,
 
   // Load the spliced result
   return DAG.getLoad(VT, DL, StoreV2, StackPtr,
-                     MachinePointerInfo::getUnknownStack(MF));
+                     MachinePointerInfo::getUnknownStack(MF), Alignment);
 }
 
 SDValue TargetLowering::expandVECTOR_COMPRESS(SDNode *Node,
@@ -13017,8 +13019,8 @@ SDValue TargetLowering::expandVECTOR_COMPRESS(SDNode *Node,
   if (VecVT.isScalableVector())
     report_fatal_error("Cannot expand masked_compress for scalable vectors.");
 
-  SDValue StackPtr = DAG.CreateStackTemporary(
-      VecVT.getStoreSize(), DAG.getReducedAlign(VecVT, /*UseABI=*/false));
+  Align Alignment = DAG.getReducedAlign(VecVT, /*UseABI=*/false);
+  SDValue StackPtr = DAG.CreateStackTemporary(VecVT.getStoreSize(), Alignment);
   int FI = cast<FrameIndexSDNode>(StackPtr.getNode())->getIndex();
   MachinePointerInfo PtrInfo =
       MachinePointerInfo::getFixedStack(DAG.getMachineFunction(), FI);
@@ -13033,7 +13035,7 @@ SDValue TargetLowering::expandVECTOR_COMPRESS(SDNode *Node,
   // positions and then re-write the last element that was potentially
   // overwritten even though mask[i] = false.
   if (HasPassthru)
-    Chain = DAG.getStore(Chain, DL, Passthru, StackPtr, PtrInfo);
+    Chain = DAG.getStore(Chain, DL, Passthru, StackPtr, PtrInfo, Alignment);
 
   SDValue LastWriteVal;
   APInt PassthruSplatVal;
@@ -13101,7 +13103,7 @@ SDValue TargetLowering::expandVECTOR_COMPRESS(SDNode *Node,
     }
   }
 
-  return DAG.getLoad(VecVT, DL, Chain, StackPtr, PtrInfo);
+  return DAG.getLoad(VecVT, DL, Chain, StackPtr, PtrInfo, Alignment);
 }
 
 SDValue TargetLowering::expandCttzElts(SDNode *Node, SelectionDAG &DAG) const {

--- a/llvm/test/CodeGen/AArch64/vector-splice-compress-mmo-align.ll
+++ b/llvm/test/CodeGen/AArch64/vector-splice-compress-mmo-align.ll
@@ -1,0 +1,35 @@
+; RUN: llc -mtriple=aarch64-unknown-linux-gnu -stop-after=finalize-isel < %s | FileCheck %s
+
+; Illegal vector ops are expanded through a stack slot allocated with the reduced
+; (non-ABI) alignment: a scalable VECTOR_SPLICE in expandVectorSplice, and a
+; fixed VECTOR_COMPRESS in expandVECTOR_COMPRESS. The spill/reload MMOs must use
+; that slot alignment, not the type's larger natural one. Both slots here are
+; 16-byte aligned, so no MMO may claim align 32 or more.
+;
+; SVE is enabled per-function (not via -mattr) so that the fixed-vector compress
+; routes through the generic expander rather than an SVE-specific lowering.
+
+; Exercises the two stores and the load in expandVectorSplice.
+define <vscale x 32 x i16> @splice_nxv32i16(<vscale x 32 x i16> %a, <vscale x 32 x i16> %b) #0 {
+; CHECK-LABEL: name: splice_nxv32i16
+; CHECK:         stack:
+; CHECK:           alignment: 16
+; CHECK-NOT:     align 32
+; CHECK-NOT:     align 64
+  %res = call <vscale x 32 x i16> @llvm.vector.splice.nxv32i16(<vscale x 32 x i16> %a, <vscale x 32 x i16> %b, i32 -1)
+  ret <vscale x 32 x i16> %res
+}
+
+; Exercises the passthru store and the load in expandVECTOR_COMPRESS. The
+; passthru operand is needed to exercise the store.
+define <8 x i32> @compress_v8i32(<8 x i32> %vec, <8 x i1> %mask, <8 x i32> %passthru) {
+; CHECK-LABEL: name: compress_v8i32
+; CHECK:         stack:
+; CHECK:           alignment: 16
+; CHECK-NOT:     align 32
+; CHECK-NOT:     align 64
+  %out = call <8 x i32> @llvm.experimental.vector.compress(<8 x i32> %vec, <8 x i1> %mask, <8 x i32> %passthru)
+  ret <8 x i32> %out
+}
+
+attributes #0 = { "target-features"="+sve" }


### PR DESCRIPTION
expandVectorSplice and expandVECTOR_COMPRESS allocate their scratch slot
on the stack with getReducedAlign, but the memory accesses they generate
touching this slot use the type's natural alignment, which may be
larger!
