### PR TITLE
[ExpandIRInsts] Fix profile metadata after #200291

### DIFF
--- a/llvm/lib/CodeGen/ExpandIRInsts.cpp
+++ b/llvm/lib/CodeGen/ExpandIRInsts.cpp
@@ -1186,9 +1186,16 @@ static void expandIToFP(Instruction *IToFP) {
           ConstantFP::getInfinity(IToFP->getType(), /*Negative=*/true);
       Value *IsNeg =
           Builder.CreateICmpSLT(IntVal, ConstantInt::getNullValue(IntTy));
-      Inf = Builder.CreateSelect(IsNeg, NegInf, Inf);
+      Inf = Builder.CreateSelectWithUnknownProfile(IsNeg, NegInf, Inf,
+                                                   DEBUG_TYPE);
     }
     A4 = Builder.CreateSelect(Overflow, Inf, A4);
+    // We consider overflow to be an unlikely case.
+    applyProfMetadataIfEnabled(A4, [&](Instruction *Inst) {
+      Inst->setMetadata(
+          LLVMContext::MD_prof,
+          MDBuilder(Inst->getContext()).createUnlikelyBranchWeights());
+    });
   }
   Builder.CreateBr(End);
 

--- a/llvm/utils/profcheck-xfail.txt
+++ b/llvm/utils/profcheck-xfail.txt
@@ -56,8 +56,6 @@ Transforms/Coroutines/no-suspend.ll
 Transforms/CrossDSOCFI/basic.ll
 Transforms/CrossDSOCFI/cfi_functions.ll
 Transforms/CrossDSOCFI/thumb.ll
-Transforms/ExpandIRInsts/X86/expand-large-fp-convert-si129tofp.ll
-Transforms/ExpandIRInsts/X86/expand-large-fp-convert-ui129tofp.ll
 Transforms/FixIrreducible/basic.ll
 Transforms/FixIrreducible/bug45623.ll
 Transforms/FixIrreducible/callbr.ll


### PR DESCRIPTION
Ensure that we set reasonable profile metadata on the select instructions that get created. Whether or not the value is negative is unknown, but I think it should be reasonable to assume that overflow is unlikely in the general case.