### PR TITLE
[flang] Remove unused DenseMapInfo::getTombstoneKey

### DIFF
--- a/flang/include/flang/Lower/IterationSpace.h
+++ b/flang/include/flang/Lower/IterationSpace.h
@@ -297,9 +297,6 @@ struct DenseMapInfo<Fortran::lower::ExplicitSpaceArrayBases> {
   static inline Fortran::lower::ExplicitSpaceArrayBases getEmptyKey() {
     return reinterpret_cast<Fortran::lower::FrontEndSymbol>(~0);
   }
-  static inline Fortran::lower::ExplicitSpaceArrayBases getTombstoneKey() {
-    return reinterpret_cast<Fortran::lower::FrontEndSymbol>(~0 - 1);
-  }
   static unsigned
   getHashValue(const Fortran::lower::ExplicitSpaceArrayBases &v) {
     return Fortran::lower::getHashValue(v);

--- a/flang/include/flang/Lower/Support/Utils.h
+++ b/flang/include/flang/Lower/Support/Utils.h
@@ -131,9 +131,6 @@ struct DenseMapInfo<const Fortran::lower::SomeExpr *> {
   static inline const Fortran::lower::SomeExpr *getEmptyKey() {
     return reinterpret_cast<Fortran::lower::SomeExpr *>(~0);
   }
-  static inline const Fortran::lower::SomeExpr *getTombstoneKey() {
-    return reinterpret_cast<Fortran::lower::SomeExpr *>(~0 - 1);
-  }
   static unsigned getHashValue(const Fortran::lower::SomeExpr *v) {
     return Fortran::lower::getHashValue(v);
   }
@@ -148,9 +145,6 @@ template <>
 struct DenseMapInfo<const Fortran::evaluate::Component *> {
   static inline const Fortran::evaluate::Component *getEmptyKey() {
     return reinterpret_cast<Fortran::evaluate::Component *>(~0);
-  }
-  static inline const Fortran::evaluate::Component *getTombstoneKey() {
-    return reinterpret_cast<Fortran::evaluate::Component *>(~0 - 1);
   }
   static unsigned getHashValue(const Fortran::evaluate::Component *v) {
     return Fortran::lower::getHashValue(v);

--- a/flang/include/flang/Semantics/symbol.h
+++ b/flang/include/flang/Semantics/symbol.h
@@ -1239,12 +1239,6 @@ template <> struct DenseMapInfo<Fortran::semantics::SymbolRef> {
     return *reinterpret_cast<Fortran::semantics::SymbolRef *>(&ptr);
   }
 
-  static inline Fortran::semantics::SymbolRef getTombstoneKey() {
-    auto ptr =
-        DenseMapInfo<const Fortran::semantics::Symbol *>::getTombstoneKey();
-    return *reinterpret_cast<Fortran::semantics::SymbolRef *>(&ptr);
-  }
-
   static unsigned getHashValue(const Fortran::semantics::SymbolRef &sym) {
     return DenseMapInfo<const Fortran::semantics::Symbol *>::getHashValue(
         &sym.get());

--- a/flang/lib/Lower/Support/Utils.cpp
+++ b/flang/lib/Lower/Support/Utils.cpp
@@ -632,9 +632,7 @@ bool isEqual(const Fortran::lower::SomeExpr *x,
              const Fortran::lower::SomeExpr *y) {
   const auto *empty =
       llvm::DenseMapInfo<const Fortran::lower::SomeExpr *>::getEmptyKey();
-  const auto *tombstone =
-      llvm::DenseMapInfo<const Fortran::lower::SomeExpr *>::getTombstoneKey();
-  if (x == empty || y == empty || x == tombstone || y == tombstone)
+  if (x == empty || y == empty)
     return x == y;
   return x == y || IsEqualEvaluateExpr::isEqual(*x, *y);
 }
@@ -663,9 +661,7 @@ bool isEqual(const Fortran::evaluate::Component *x,
              const Fortran::evaluate::Component *y) {
   const auto *empty =
       llvm::DenseMapInfo<const Fortran::evaluate::Component *>::getEmptyKey();
-  const auto *tombstone = llvm::DenseMapInfo<
-      const Fortran::evaluate::Component *>::getTombstoneKey();
-  if (x == empty || y == empty || x == tombstone || y == tombstone)
+  if (x == empty || y == empty)
     return x == y;
   return x == y || IsEqualEvaluateExpr::isEqual(*x, *y);
 }


### PR DESCRIPTION
#200595 changed DenseMap to no longer create tombstone buckets, so
DenseMapInfo<T>::getTombstoneKey() is never called. Remove dead
definitions and dead tombstone branches.
