### PR TITLE
[mlir] Remove unused DenseMapInfo::getTombstoneKey

### DIFF
--- a/mlir/docs/DefiningDialects/Operations.md
+++ b/mlir/docs/DefiningDialects/Operations.md
@@ -1571,10 +1571,6 @@ template<> struct DenseMapInfo<Outer::Inner::MyIntEnum> {
     return static_cast<Outer::Inner::MyIntEnum>(StorageInfo::getEmptyKey());
   }
 
-  static inline Outer::Inner::MyIntEnum getTombstoneKey() {
-    return static_cast<Outer::Inner::MyIntEnum>(StorageInfo::getTombstoneKey());
-  }
-
   static unsigned getHashValue(const Outer::Inner::MyIntEnum &val) {
     return StorageInfo::getHashValue(static_cast<uint32_t>(val));
   }
@@ -1699,10 +1695,6 @@ template<> struct DenseMapInfo<::MyBitEnum> {
 
   static inline ::MyBitEnum getEmptyKey() {
     return static_cast<::MyBitEnum>(StorageInfo::getEmptyKey());
-  }
-
-  static inline ::MyBitEnum getTombstoneKey() {
-    return static_cast<::MyBitEnum>(StorageInfo::getTombstoneKey());
   }
 
   static unsigned getHashValue(const ::MyBitEnum &val) {

--- a/mlir/include/mlir/Analysis/CallGraph.h
+++ b/mlir/include/mlir/Analysis/CallGraph.h
@@ -121,7 +121,6 @@ private:
         DenseMapInfo<llvm::PointerIntPair<CallGraphNode *, 2, Edge::Kind>>;
 
     static Edge getEmptyKey() { return Edge(BaseInfo::getEmptyKey()); }
-    static Edge getTombstoneKey() { return Edge(BaseInfo::getTombstoneKey()); }
     static unsigned getHashValue(const Edge &edge) {
       return BaseInfo::getHashValue(edge.targetAndKind);
     }

--- a/mlir/include/mlir/Analysis/DataFlowFramework.h
+++ b/mlir/include/mlir/Analysis/DataFlowFramework.h
@@ -817,12 +817,6 @@ struct DenseMapInfo<mlir::ProgramPoint> {
         (mlir::Block *)pointer,
         mlir::Block::iterator((mlir::Operation *)pointer));
   }
-  static mlir::ProgramPoint getTombstoneKey() {
-    void *pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
-    return mlir::ProgramPoint(
-        (mlir::Block *)pointer,
-        mlir::Block::iterator((mlir::Operation *)pointer));
-  }
   static unsigned getHashValue(mlir::ProgramPoint pp) {
     return hash_combine(pp.getBlock(), pp.getPoint().getNodePtr());
   }

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrs.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrs.h
@@ -79,7 +79,7 @@ public:
   /// Support LLVM type casting.
   static bool classof(Attribute attr);
 
-  /// Required by DenseMapInfo to create empty and tombstone key.
+  /// Required by DenseMapInfo to create the empty key.
   static TBAANodeAttr getFromOpaquePointer(const void *pointer) {
     return TBAANodeAttr(reinterpret_cast<const ImplType *>(pointer));
   }

--- a/mlir/include/mlir/IR/AffineExpr.h
+++ b/mlir/include/mlir/IR/AffineExpr.h
@@ -358,10 +358,6 @@ struct DenseMapInfo<mlir::AffineExpr> {
     auto *pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
     return mlir::AffineExpr(static_cast<mlir::AffineExpr::ImplType *>(pointer));
   }
-  static mlir::AffineExpr getTombstoneKey() {
-    auto *pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
-    return mlir::AffineExpr(static_cast<mlir::AffineExpr::ImplType *>(pointer));
-  }
   static unsigned getHashValue(mlir::AffineExpr val) {
     return mlir::hash_value(val);
   }

--- a/mlir/include/mlir/IR/AffineMap.h
+++ b/mlir/include/mlir/IR/AffineMap.h
@@ -719,10 +719,6 @@ struct DenseMapInfo<mlir::AffineMap> {
     auto *pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
     return mlir::AffineMap(static_cast<mlir::AffineMap::ImplType *>(pointer));
   }
-  static mlir::AffineMap getTombstoneKey() {
-    auto *pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
-    return mlir::AffineMap(static_cast<mlir::AffineMap::ImplType *>(pointer));
-  }
   static unsigned getHashValue(mlir::AffineMap val) {
     return mlir::hash_value(val);
   }

--- a/mlir/include/mlir/IR/Attributes.h
+++ b/mlir/include/mlir/IR/Attributes.h
@@ -306,10 +306,6 @@ struct DenseMapInfo<mlir::Attribute> {
     auto *pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
     return mlir::Attribute(static_cast<mlir::Attribute::ImplType *>(pointer));
   }
-  static mlir::Attribute getTombstoneKey() {
-    auto *pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
-    return mlir::Attribute(static_cast<mlir::Attribute::ImplType *>(pointer));
-  }
   static unsigned getHashValue(mlir::Attribute val) {
     return mlir::hash_value(val);
   }
@@ -324,10 +320,6 @@ struct DenseMapInfo<
     : public DenseMapInfo<mlir::Attribute> {
   static T getEmptyKey() {
     const void *pointer = llvm::DenseMapInfo<const void *>::getEmptyKey();
-    return T::getFromOpaquePointer(pointer);
-  }
-  static T getTombstoneKey() {
-    const void *pointer = llvm::DenseMapInfo<const void *>::getTombstoneKey();
     return T::getFromOpaquePointer(pointer);
   }
 };
@@ -350,10 +342,6 @@ struct DenseMapInfo<mlir::NamedAttribute> {
   static mlir::NamedAttribute getEmptyKey() {
     auto emptyAttr = llvm::DenseMapInfo<mlir::Attribute>::getEmptyKey();
     return mlir::NamedAttribute(emptyAttr, emptyAttr);
-  }
-  static mlir::NamedAttribute getTombstoneKey() {
-    auto tombAttr = llvm::DenseMapInfo<mlir::Attribute>::getTombstoneKey();
-    return mlir::NamedAttribute(tombAttr, tombAttr);
   }
   static unsigned getHashValue(mlir::NamedAttribute val) {
     return mlir::hash_value(val);

--- a/mlir/include/mlir/IR/Block.h
+++ b/mlir/include/mlir/IR/Block.h
@@ -444,10 +444,6 @@ struct DenseMapInfo<mlir::Block::iterator> {
     void *pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
     return mlir::Block::iterator((mlir::Operation *)pointer);
   }
-  static mlir::Block::iterator getTombstoneKey() {
-    void *pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
-    return mlir::Block::iterator((mlir::Operation *)pointer);
-  }
   static unsigned getHashValue(mlir::Block::iterator iter) {
     return hash_value(iter.getNodePtr());
   }

--- a/mlir/include/mlir/IR/BlockSupport.h
+++ b/mlir/include/mlir/IR/BlockSupport.h
@@ -180,18 +180,12 @@ struct DenseMapInfo<mlir::SuccessorRange> {
     auto *pointer = llvm::DenseMapInfo<mlir::BlockOperand *>::getEmptyKey();
     return mlir::SuccessorRange(pointer, 0);
   }
-  static mlir::SuccessorRange getTombstoneKey() {
-    auto *pointer = llvm::DenseMapInfo<mlir::BlockOperand *>::getTombstoneKey();
-    return mlir::SuccessorRange(pointer, 0);
-  }
   static unsigned getHashValue(mlir::SuccessorRange value) {
     return llvm::hash_combine_range(value);
   }
   static bool isEqual(mlir::SuccessorRange lhs, mlir::SuccessorRange rhs) {
     if (rhs.getBase() == getEmptyKey().getBase())
       return lhs.getBase() == getEmptyKey().getBase();
-    if (rhs.getBase() == getTombstoneKey().getBase())
-      return lhs.getBase() == getTombstoneKey().getBase();
     return lhs == rhs;
   }
 };

--- a/mlir/include/mlir/IR/BuiltinAttributes.h
+++ b/mlir/include/mlir/IR/BuiltinAttributes.h
@@ -1108,10 +1108,6 @@ struct DenseMapInfo<mlir::StringAttr> : public DenseMapInfo<mlir::Attribute> {
     const void *pointer = llvm::DenseMapInfo<const void *>::getEmptyKey();
     return mlir::StringAttr::getFromOpaquePointer(pointer);
   }
-  static mlir::StringAttr getTombstoneKey() {
-    const void *pointer = llvm::DenseMapInfo<const void *>::getTombstoneKey();
-    return mlir::StringAttr::getFromOpaquePointer(pointer);
-  }
 };
 template <>
 struct PointerLikeTypeTraits<mlir::StringAttr>

--- a/mlir/include/mlir/IR/DialectInterface.h
+++ b/mlir/include/mlir/IR/DialectInterface.h
@@ -87,7 +87,7 @@ class DialectInterfaceCollectionBase {
     }
 
     static bool isEqual(Dialect *lhs, const DialectInterface *rhs) {
-      if (rhs == getEmptyKey() || rhs == getTombstoneKey())
+      if (rhs == getEmptyKey())
         return false;
       return lhs == rhs->getDialect();
     }

--- a/mlir/include/mlir/IR/IntegerSet.h
+++ b/mlir/include/mlir/IR/IntegerSet.h
@@ -135,10 +135,6 @@ struct DenseMapInfo<mlir::IntegerSet> {
     auto *pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
     return mlir::IntegerSet(static_cast<mlir::IntegerSet::ImplType *>(pointer));
   }
-  static mlir::IntegerSet getTombstoneKey() {
-    auto *pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
-    return mlir::IntegerSet(static_cast<mlir::IntegerSet::ImplType *>(pointer));
-  }
   static unsigned getHashValue(mlir::IntegerSet val) {
     return mlir::hash_value(val);
   }

--- a/mlir/include/mlir/IR/Location.h
+++ b/mlir/include/mlir/IR/Location.h
@@ -232,10 +232,6 @@ struct DenseMapInfo<mlir::Location> {
     auto *pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
     return mlir::Location::getFromOpaquePointer(pointer);
   }
-  static mlir::Location getTombstoneKey() {
-    auto *pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
-    return mlir::Location::getFromOpaquePointer(pointer);
-  }
   static unsigned getHashValue(mlir::Location val) {
     return mlir::hash_value(val);
   }

--- a/mlir/include/mlir/IR/OpDefinition.h
+++ b/mlir/include/mlir/IR/OpDefinition.h
@@ -2168,10 +2168,6 @@ struct DenseMapInfo<T,
     auto *pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
     return T::getFromOpaquePointer(pointer);
   }
-  static inline T getTombstoneKey() {
-    auto *pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
-    return T::getFromOpaquePointer(pointer);
-  }
   static unsigned getHashValue(T val) {
     return hash_value(val.getAsOpaquePointer());
   }

--- a/mlir/include/mlir/IR/OpImplementation.h
+++ b/mlir/include/mlir/IR/OpImplementation.h
@@ -1848,10 +1848,6 @@ struct DenseMapInfo<mlir::AsmDialectResourceHandle> {
     return {DenseMapInfo<void *>::getEmptyKey(),
             DenseMapInfo<mlir::TypeID>::getEmptyKey(), nullptr};
   }
-  static inline mlir::AsmDialectResourceHandle getTombstoneKey() {
-    return {DenseMapInfo<void *>::getTombstoneKey(),
-            DenseMapInfo<mlir::TypeID>::getTombstoneKey(), nullptr};
-  }
   static unsigned getHashValue(const mlir::AsmDialectResourceHandle &handle) {
     return DenseMapInfo<void *>::getHashValue(handle.getResource());
   }

--- a/mlir/include/mlir/IR/OperationSupport.h
+++ b/mlir/include/mlir/IR/OperationSupport.h
@@ -1455,10 +1455,6 @@ struct DenseMapInfo<mlir::OperationName> {
     void *pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
     return mlir::OperationName::getFromOpaquePointer(pointer);
   }
-  static mlir::OperationName getTombstoneKey() {
-    void *pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
-    return mlir::OperationName::getFromOpaquePointer(pointer);
-  }
   static unsigned getHashValue(mlir::OperationName val) {
     return DenseMapInfo<void *>::getHashValue(val.getAsOpaquePointer());
   }
@@ -1471,10 +1467,6 @@ struct DenseMapInfo<mlir::RegisteredOperationName>
     : public DenseMapInfo<mlir::OperationName> {
   static mlir::RegisteredOperationName getEmptyKey() {
     void *pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
-    return mlir::RegisteredOperationName::getFromOpaquePointer(pointer);
-  }
-  static mlir::RegisteredOperationName getTombstoneKey() {
-    void *pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
     return mlir::RegisteredOperationName::getFromOpaquePointer(pointer);
   }
 };

--- a/mlir/include/mlir/IR/Remarks.h
+++ b/mlir/include/mlir/IR/Remarks.h
@@ -750,7 +750,6 @@ namespace llvm {
 template <>
 struct DenseMapInfo<mlir::remark::detail::Remark> {
   static constexpr StringRef kEmptyKey = "<EMPTY_KEY>";
-  static constexpr StringRef kTombstoneKey = "<TOMBSTONE_KEY>";
 
   /// Helper to provide a static dummy context for sentinel keys.
   static mlir::MLIRContext *getStaticDummyContext() {
@@ -766,14 +765,6 @@ struct DenseMapInfo<mlir::remark::detail::Remark> {
         mlir::remark::RemarkOpts::name(kEmptyKey));
   }
 
-  /// Create a dead remark
-  static inline mlir::remark::detail::Remark getTombstoneKey() {
-    return mlir::remark::detail::Remark(
-        mlir::remark::RemarkKind::RemarkUnknown, mlir::DiagnosticSeverity::Note,
-        mlir::UnknownLoc::get(getStaticDummyContext()),
-        mlir::remark::RemarkOpts::name(kTombstoneKey));
-  }
-
   /// Compute the hash value of the remark
   static unsigned getHashValue(const mlir::remark::detail::Remark &remark) {
     return llvm::hash_combine(
@@ -785,11 +776,8 @@ struct DenseMapInfo<mlir::remark::detail::Remark> {
 
   static bool isEqual(const mlir::remark::detail::Remark &lhs,
                       const mlir::remark::detail::Remark &rhs) {
-    // Check for empty/tombstone keys first
-    if (lhs.getRemarkName() == kEmptyKey ||
-        lhs.getRemarkName() == kTombstoneKey ||
-        rhs.getRemarkName() == kEmptyKey ||
-        rhs.getRemarkName() == kTombstoneKey) {
+    // Check for empty keys first.
+    if (lhs.getRemarkName() == kEmptyKey || rhs.getRemarkName() == kEmptyKey) {
       return lhs.getRemarkName() == rhs.getRemarkName();
     }
 

--- a/mlir/include/mlir/IR/TypeRange.h
+++ b/mlir/include/mlir/IR/TypeRange.h
@@ -209,17 +209,11 @@ struct DenseMapInfo<mlir::TypeRange> {
     return mlir::TypeRange(getEmptyKeyPointer(), 0);
   }
 
-  static mlir::TypeRange getTombstoneKey() {
-    return mlir::TypeRange(getTombstoneKeyPointer(), 0);
-  }
-
   static unsigned getHashValue(mlir::TypeRange val) { return hash_value(val); }
 
   static bool isEqual(mlir::TypeRange lhs, mlir::TypeRange rhs) {
     if (isEmptyKey(rhs))
       return isEmptyKey(lhs);
-    if (isTombstoneKey(rhs))
-      return isTombstoneKey(lhs);
     return lhs == rhs;
   }
 
@@ -228,21 +222,10 @@ private:
     return DenseMapInfo<mlir::Type *>::getEmptyKey();
   }
 
-  static const mlir::Type *getTombstoneKeyPointer() {
-    return DenseMapInfo<mlir::Type *>::getTombstoneKey();
-  }
-
   static bool isEmptyKey(mlir::TypeRange range) {
     if (const auto *type =
             llvm::dyn_cast_if_present<const mlir::Type *>(range.getBase()))
       return type == getEmptyKeyPointer();
-    return false;
-  }
-
-  static bool isTombstoneKey(mlir::TypeRange range) {
-    if (const auto *type =
-            llvm::dyn_cast_if_present<const mlir::Type *>(range.getBase()))
-      return type == getTombstoneKeyPointer();
     return false;
   }
 };

--- a/mlir/include/mlir/IR/Types.h
+++ b/mlir/include/mlir/IR/Types.h
@@ -317,10 +317,6 @@ struct DenseMapInfo<mlir::Type> {
     auto *pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
     return mlir::Type(static_cast<mlir::Type::ImplType *>(pointer));
   }
-  static mlir::Type getTombstoneKey() {
-    auto *pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
-    return mlir::Type(static_cast<mlir::Type::ImplType *>(pointer));
-  }
   static unsigned getHashValue(mlir::Type val) { return mlir::hash_value(val); }
   static bool isEqual(mlir::Type LHS, mlir::Type RHS) { return LHS == RHS; }
 };
@@ -330,10 +326,6 @@ struct DenseMapInfo<T, std::enable_if_t<std::is_base_of<mlir::Type, T>::value &&
     : public DenseMapInfo<mlir::Type> {
   static T getEmptyKey() {
     const void *pointer = llvm::DenseMapInfo<const void *>::getEmptyKey();
-    return T::getFromOpaquePointer(pointer);
-  }
-  static T getTombstoneKey() {
-    const void *pointer = llvm::DenseMapInfo<const void *>::getTombstoneKey();
     return T::getFromOpaquePointer(pointer);
   }
 };

--- a/mlir/include/mlir/IR/Value.h
+++ b/mlir/include/mlir/IR/Value.h
@@ -504,10 +504,6 @@ struct DenseMapInfo<mlir::Value> {
     void *pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
     return mlir::Value::getFromOpaquePointer(pointer);
   }
-  static mlir::Value getTombstoneKey() {
-    void *pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
-    return mlir::Value::getFromOpaquePointer(pointer);
-  }
   static unsigned getHashValue(mlir::Value val) {
     return mlir::hash_value(val);
   }
@@ -519,19 +515,11 @@ struct DenseMapInfo<mlir::BlockArgument> : public DenseMapInfo<mlir::Value> {
     void *pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
     return reinterpret_cast<mlir::detail::BlockArgumentImpl *>(pointer);
   }
-  static mlir::BlockArgument getTombstoneKey() {
-    void *pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
-    return reinterpret_cast<mlir::detail::BlockArgumentImpl *>(pointer);
-  }
 };
 template <>
 struct DenseMapInfo<mlir::OpResult> : public DenseMapInfo<mlir::Value> {
   static mlir::OpResult getEmptyKey() {
     void *pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
-    return reinterpret_cast<mlir::detail::OpResultImpl *>(pointer);
-  }
-  static mlir::OpResult getTombstoneKey() {
-    void *pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
     return reinterpret_cast<mlir::detail::OpResultImpl *>(pointer);
   }
 };
@@ -540,10 +528,6 @@ struct DenseMapInfo<mlir::detail::TypedValue<T>>
     : public DenseMapInfo<mlir::Value> {
   static mlir::detail::TypedValue<T> getEmptyKey() {
     void *pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
-    return reinterpret_cast<mlir::detail::ValueImpl *>(pointer);
-  }
-  static mlir::detail::TypedValue<T> getTombstoneKey() {
-    void *pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
     return reinterpret_cast<mlir::detail::ValueImpl *>(pointer);
   }
 };

--- a/mlir/include/mlir/Pass/PassInstrumentation.h
+++ b/mlir/include/mlir/Pass/PassInstrumentation.h
@@ -139,10 +139,6 @@ struct DenseMapInfo<mlir::PassInstrumentation::PipelineParentInfo> {
     auto pair = PairInfo::getEmptyKey();
     return {pair.first, reinterpret_cast<mlir::Pass *>(pair.second)};
   }
-  static T getTombstoneKey() {
-    auto pair = PairInfo::getTombstoneKey();
-    return {pair.first, reinterpret_cast<mlir::Pass *>(pair.second)};
-  }
   static unsigned getHashValue(T val) {
     return PairInfo::getHashValue({val.parentThreadID, val.parentPass});
   }

--- a/mlir/include/mlir/Pass/PassManager.h
+++ b/mlir/include/mlir/Pass/PassManager.h
@@ -488,9 +488,9 @@ private:
 
   /// Hash keys used to detect when reinitialization is necessary.
   llvm::hash_code initializationKey =
-      DenseMapInfo<llvm::hash_code>::getTombstoneKey();
+      DenseMapInfo<llvm::hash_code>::getEmptyKey();
   llvm::hash_code pipelineInitializationKey =
-      DenseMapInfo<llvm::hash_code>::getTombstoneKey();
+      DenseMapInfo<llvm::hash_code>::getEmptyKey();
 
   /// Flag that specifies if pass timing is enabled.
   bool passTiming : 1;

--- a/mlir/include/mlir/Support/InterfaceSupport.h
+++ b/mlir/include/mlir/Support/InterfaceSupport.h
@@ -116,7 +116,7 @@ public:
     assert(!t || ConcreteType::getInterfaceFor(t) == conceptImpl);
   }
 
-  /// Constructor for DenseMapInfo's empty key and tombstone key.
+  /// Constructor for DenseMapInfo's empty key.
   Interface(ValueT t, std::nullptr_t) : BaseType(t), conceptImpl(nullptr) {}
 
   /// Support 'classof' by checking if the given object defines the concrete
@@ -299,10 +299,6 @@ struct DenseMapInfo<T, std::enable_if_t<mlir::detail::IsInterface<T>::value>> {
   using ValueTypeInfo = llvm::DenseMapInfo<typename T::ValueType>;
 
   static T getEmptyKey() { return T(ValueTypeInfo::getEmptyKey(), nullptr); }
-
-  static T getTombstoneKey() {
-    return T(ValueTypeInfo::getTombstoneKey(), nullptr);
-  }
 
   static unsigned getHashValue(T val) {
     return ValueTypeInfo::getHashValue(val);

--- a/mlir/include/mlir/Support/TypeID.h
+++ b/mlir/include/mlir/Support/TypeID.h
@@ -398,10 +398,6 @@ struct DenseMapInfo<mlir::TypeID> {
     void *pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
     return mlir::TypeID::getFromOpaquePointer(pointer);
   }
-  static inline mlir::TypeID getTombstoneKey() {
-    void *pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
-    return mlir::TypeID::getFromOpaquePointer(pointer);
-  }
   static unsigned getHashValue(mlir::TypeID val) {
     return mlir::hash_value(val);
   }

--- a/mlir/include/mlir/TableGen/Constraint.h
+++ b/mlir/include/mlir/TableGen/Constraint.h
@@ -122,7 +122,6 @@ struct DenseMapInfo<mlir::tblgen::Constraint> {
   using RecordDenseMapInfo = llvm::DenseMapInfo<const llvm::Record *>;
 
   static mlir::tblgen::Constraint getEmptyKey();
-  static mlir::tblgen::Constraint getTombstoneKey();
   static unsigned getHashValue(mlir::tblgen::Constraint constraint);
   static bool isEqual(mlir::tblgen::Constraint lhs,
                       mlir::tblgen::Constraint rhs);

--- a/mlir/include/mlir/TableGen/Format.h
+++ b/mlir/include/mlir/TableGen/Format.h
@@ -71,9 +71,6 @@ private:
     static inline PHKind getEmptyKey() {
       return static_cast<PHKind>(CharInfo::getEmptyKey());
     }
-    static inline PHKind getTombstoneKey() {
-      return static_cast<PHKind>(CharInfo::getTombstoneKey());
-    }
     static unsigned getHashValue(const PHKind &val) {
       return CharInfo::getHashValue(static_cast<char>(val));
     }

--- a/mlir/include/mlir/TableGen/Pattern.h
+++ b/mlir/include/mlir/TableGen/Pattern.h
@@ -676,10 +676,6 @@ struct DenseMapInfo<mlir::tblgen::DagNode> {
     return mlir::tblgen::DagNode(
         llvm::DenseMapInfo<llvm::DagInit *>::getEmptyKey());
   }
-  static mlir::tblgen::DagNode getTombstoneKey() {
-    return mlir::tblgen::DagNode(
-        llvm::DenseMapInfo<llvm::DagInit *>::getTombstoneKey());
-  }
   static unsigned getHashValue(mlir::tblgen::DagNode node) {
     return llvm::hash_value(node.getAsOpaquePointer());
   }
@@ -693,10 +689,6 @@ struct DenseMapInfo<mlir::tblgen::DagLeaf> {
   static mlir::tblgen::DagLeaf getEmptyKey() {
     return mlir::tblgen::DagLeaf(
         llvm::DenseMapInfo<llvm::Init *>::getEmptyKey());
-  }
-  static mlir::tblgen::DagLeaf getTombstoneKey() {
-    return mlir::tblgen::DagLeaf(
-        llvm::DenseMapInfo<llvm::Init *>::getTombstoneKey());
   }
   static unsigned getHashValue(mlir::tblgen::DagLeaf leaf) {
     return llvm::hash_value(leaf.getAsOpaquePointer());

--- a/mlir/include/mlir/Tools/PDLL/AST/Types.h
+++ b/mlir/include/mlir/Tools/PDLL/AST/Types.h
@@ -399,11 +399,6 @@ struct DenseMapInfo<mlir::pdll::ast::Type> {
     return mlir::pdll::ast::Type(
         static_cast<mlir::pdll::ast::Type::Storage *>(pointer));
   }
-  static mlir::pdll::ast::Type getTombstoneKey() {
-    void *pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
-    return mlir::pdll::ast::Type(
-        static_cast<mlir::pdll::ast::Type::Storage *>(pointer));
-  }
   static unsigned getHashValue(mlir::pdll::ast::Type val) {
     return llvm::hash_value(val.getImpl());
   }

--- a/mlir/lib/Conversion/PDLToPDLInterp/PredicateTree.cpp
+++ b/mlir/lib/Conversion/PDLToPDLInterp/PredicateTree.cpp
@@ -768,7 +768,6 @@ struct OrderedPredicateDenseInfo {
   using Base = DenseMapInfo<std::pair<Position *, Qualifier *>>;
 
   static OrderedPredicate getEmptyKey() { return Base::getEmptyKey(); }
-  static OrderedPredicate getTombstoneKey() { return Base::getTombstoneKey(); }
   static bool isEqual(const OrderedPredicate &lhs,
                       const OrderedPredicate &rhs) {
     return lhs.position == rhs.position && lhs.question == rhs.question;

--- a/mlir/lib/Dialect/Func/Transforms/DuplicateFunctionElimination.cpp
+++ b/mlir/lib/Dialect/Func/Transforms/DuplicateFunctionElimination.cpp
@@ -53,8 +53,7 @@ struct DuplicateFuncOpEquivalenceInfo
   static bool isEqual(func::FuncOp lhs, func::FuncOp rhs) {
     if (lhs == rhs)
       return true;
-    if (lhs == getTombstoneKey() || lhs == getEmptyKey() ||
-        rhs == getTombstoneKey() || rhs == getEmptyKey())
+    if (lhs == getEmptyKey() || rhs == getEmptyKey())
       return false;
 
     if (lhs.isDeclaration() || rhs.isDeclaration())

--- a/mlir/lib/Dialect/Vector/Transforms/VectorUnroll.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorUnroll.cpp
@@ -263,8 +263,6 @@ private:
 struct OffsetMapInfo {
   static SmallVector<int64_t> getEmptyKey() { return {int64_t(-1)}; }
 
-  static SmallVector<int64_t> getTombstoneKey() { return {int64_t(-2)}; }
-
   static unsigned getHashValue(const SmallVector<int64_t> &v) {
     return static_cast<unsigned>(llvm::hash_combine_range(v));
   }

--- a/mlir/lib/Support/StorageUniquer.cpp
+++ b/mlir/lib/Support/StorageUniquer.cpp
@@ -51,9 +51,6 @@ private:
     static inline HashedStorage getEmptyKey() {
       return HashedStorage(0, DenseMapInfo<BaseStorage *>::getEmptyKey());
     }
-    static inline HashedStorage getTombstoneKey() {
-      return HashedStorage(0, DenseMapInfo<BaseStorage *>::getTombstoneKey());
-    }
 
     static inline unsigned getHashValue(const HashedStorage &key) {
       return key.hashValue;
@@ -67,7 +64,7 @@ private:
       return lhs.storage == rhs.storage;
     }
     static inline bool isEqual(const LookupKey &lhs, const HashedStorage &rhs) {
-      if (isEqual(rhs, getEmptyKey()) || isEqual(rhs, getTombstoneKey()))
+      if (isEqual(rhs, getEmptyKey()))
         return false;
       // Invoke the equality function on the lookup key.
       return lhs.isEqual(rhs.storage);

--- a/mlir/lib/TableGen/Constraint.cpp
+++ b/mlir/lib/TableGen/Constraint.cpp
@@ -130,27 +130,18 @@ Constraint DenseMapInfo<Constraint>::getEmptyKey() {
                     Constraint::CK_Uncategorized);
 }
 
-Constraint DenseMapInfo<Constraint>::getTombstoneKey() {
-  return Constraint(RecordDenseMapInfo::getTombstoneKey(),
-                    Constraint::CK_Uncategorized);
-}
-
 unsigned DenseMapInfo<Constraint>::getHashValue(Constraint constraint) {
   if (constraint == getEmptyKey())
     return RecordDenseMapInfo::getHashValue(RecordDenseMapInfo::getEmptyKey());
-  if (constraint == getTombstoneKey()) {
-    return RecordDenseMapInfo::getHashValue(
-        RecordDenseMapInfo::getTombstoneKey());
-  }
   return llvm::hash_combine(constraint.getPredicate(), constraint.getSummary());
 }
 
 bool DenseMapInfo<Constraint>::isEqual(Constraint lhs, Constraint rhs) {
   if (lhs == rhs)
     return true;
-  if (lhs == getEmptyKey() || lhs == getTombstoneKey())
+  if (lhs == getEmptyKey())
     return false;
-  if (rhs == getEmptyKey() || rhs == getTombstoneKey())
+  if (rhs == getEmptyKey())
     return false;
   return lhs.getPredicate() == rhs.getPredicate() &&
          lhs.getSummary() == rhs.getSummary();

--- a/mlir/lib/Transforms/Utils/CFGToSCF.cpp
+++ b/mlir/lib/Transforms/Utils/CFGToSCF.cpp
@@ -404,8 +404,7 @@ struct ReturnLikeOpEquivalence : public llvm::DenseMapInfo<Operation *> {
   static bool isEqual(const Operation *lhs, const Operation *rhs) {
     if (lhs == rhs)
       return true;
-    if (lhs == getTombstoneKey() || lhs == getEmptyKey() ||
-        rhs == getTombstoneKey() || rhs == getEmptyKey())
+    if (lhs == getEmptyKey() || rhs == getEmptyKey())
       return false;
     return OperationEquivalence::isEquivalentTo(
         const_cast<Operation *>(lhs), const_cast<Operation *>(rhs),

--- a/mlir/lib/Transforms/Utils/CSE.cpp
+++ b/mlir/lib/Transforms/Utils/CSE.cpp
@@ -38,8 +38,7 @@ struct SimpleOperationInfo : public llvm::DenseMapInfo<Operation *> {
     auto *rhs = const_cast<Operation *>(rhsC);
     if (lhs == rhs)
       return true;
-    if (lhs == getTombstoneKey() || lhs == getEmptyKey() ||
-        rhs == getTombstoneKey() || rhs == getEmptyKey())
+    if (lhs == getEmptyKey() || rhs == getEmptyKey())
       return false;
     return OperationEquivalence::isEquivalentTo(
         const_cast<Operation *>(lhsC), const_cast<Operation *>(rhsC),

--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -124,7 +124,6 @@ namespace {
 /// Helper class to make it possible to use `ValueVector` as a key in DenseMap.
 struct ValueVectorMapInfo {
   static ValueVector getEmptyKey() { return ValueVector{Value()}; }
-  static ValueVector getTombstoneKey() { return ValueVector{Value(), Value()}; }
   static ::llvm::hash_code getHashValue(const ValueVector &val) {
     return ::llvm::hash_combine_range(val);
   }

--- a/mlir/tools/mlir-tblgen/EnumsGen.cpp
+++ b/mlir/tools/mlir-tblgen/EnumsGen.cpp
@@ -317,10 +317,6 @@ template<> struct DenseMapInfo<{0}> {{
     return static_cast<{0}>(StorageInfo::getEmptyKey());
   }
 
-  static inline {0} getTombstoneKey() {{
-    return static_cast<{0}>(StorageInfo::getTombstoneKey());
-  }
-
   static unsigned getHashValue(const {0} &val) {{
     return StorageInfo::getHashValue(static_cast<{1}>(val));
   }


### PR DESCRIPTION
#200595 changed DenseMap to no longer create tombstone buckets, so
DenseMapInfo<T>::getTombstoneKey() is never called. Remove dead
definitions and dead tombstone branches.
