### PR TITLE
[lldb] Remove unused DenseMapInfo::getTombstoneKey

### DIFF
--- a/lldb/include/lldb/Core/Highlighter.h
+++ b/lldb/include/lldb/Core/Highlighter.h
@@ -159,9 +159,6 @@ template <> struct DenseMapInfo<lldb::LanguageType> {
   static inline lldb::LanguageType getEmptyKey() {
     return lldb::eNumLanguageTypes;
   }
-  static inline lldb::LanguageType getTombstoneKey() {
-    return lldb::eNumLanguageTypes;
-  }
   static unsigned getHashValue(lldb::LanguageType language_type) {
     return static_cast<unsigned>(language_type);
   }

--- a/lldb/include/lldb/Host/HostThread.h
+++ b/lldb/include/lldb/Host/HostThread.h
@@ -58,10 +58,6 @@ template <> struct DenseMapInfo<lldb_private::HostThread> {
     return lldb_private::HostThread(
         DenseMapInfo<lldb::thread_t>::getEmptyKey());
   }
-  static inline lldb_private::HostThread getTombstoneKey() {
-    return lldb_private::HostThread(
-        DenseMapInfo<lldb::thread_t>::getTombstoneKey());
-  }
   static unsigned getHashValue(const lldb_private::HostThread &val);
   static bool isEqual(const lldb_private::HostThread &lhs,
                       const lldb_private::HostThread &rhs);

--- a/lldb/include/lldb/Symbol/SymbolContext.h
+++ b/lldb/include/lldb/Symbol/SymbolContext.h
@@ -523,12 +523,6 @@ template <> struct DenseMapInfo<lldb_private::SymbolContext> {
     return sc;
   }
 
-  static inline lldb_private::SymbolContext getTombstoneKey() {
-    lldb_private::SymbolContext sc;
-    sc.function = DenseMapInfo<lldb_private::Function *>::getTombstoneKey();
-    return sc;
-  }
-
   static unsigned getHashValue(const lldb_private::SymbolContext &sc) {
     // Hash all fields EXCEPT symbol, since
     // CompareConsideringPossiblyNullSymbol ignores it.
@@ -547,15 +541,11 @@ template <> struct DenseMapInfo<lldb_private::SymbolContext> {
 
   static bool isEqual(const lldb_private::SymbolContext &lhs,
                       const lldb_private::SymbolContext &rhs) {
-    // Check for empty/tombstone keys first, since these are invalid pointers we
+    // Check for empty keys first, since these are invalid pointers we
     // don't want to accidentally dereference them in
     // CompareConsideringPossiblyNullSymbol.
     if (lhs.function == DenseMapInfo<lldb_private::Function *>::getEmptyKey() ||
-        rhs.function == DenseMapInfo<lldb_private::Function *>::getEmptyKey() ||
-        lhs.function ==
-            DenseMapInfo<lldb_private::Function *>::getTombstoneKey() ||
-        rhs.function ==
-            DenseMapInfo<lldb_private::Function *>::getTombstoneKey())
+        rhs.function == DenseMapInfo<lldb_private::Function *>::getEmptyKey())
       return lhs.function == rhs.function;
 
     return lldb_private::SymbolContext::CompareConsideringPossiblyNullSymbol(

--- a/lldb/include/lldb/Utility/ConstString.h
+++ b/lldb/include/lldb/Utility/ConstString.h
@@ -431,10 +431,6 @@ template <> struct DenseMapInfo<lldb_private::ConstString> {
     return lldb_private::ConstString::FromStringPoolPointer(
         DenseMapInfo<const char *>::getEmptyKey());
   }
-  static inline lldb_private::ConstString getTombstoneKey() {
-    return lldb_private::ConstString::FromStringPoolPointer(
-        DenseMapInfo<const char *>::getTombstoneKey());
-  }
   static unsigned getHashValue(lldb_private::ConstString val) {
     return DenseMapInfo<const char *>::getHashValue(val.m_string);
   }

--- a/lldb/include/lldb/Utility/FileSpec.h
+++ b/lldb/include/lldb/Utility/FileSpec.h
@@ -473,9 +473,6 @@ template <> struct DenseMapInfo<lldb_private::FileSpec> {
   static inline lldb_private::FileSpec getEmptyKey() {
     return lldb_private::FileSpec();
   }
-  static inline lldb_private::FileSpec getTombstoneKey() {
-    return lldb_private::FileSpec();
-  }
   static unsigned getHashValue(lldb_private::FileSpec file_spec) {
     return llvm::hash_combine(
         DenseMapInfo<lldb_private::ConstString>::getHashValue(

--- a/lldb/include/lldb/Utility/UUID.h
+++ b/lldb/include/lldb/Utility/UUID.h
@@ -124,11 +124,6 @@ template <> struct DenseMapInfo<lldb_private::UUID> {
   static inline lldb_private::UUID getEmptyKey() {
     return lldb_private::UUID();
   }
-  static inline lldb_private::UUID getTombstoneKey() {
-    lldb_private::UUID key;
-    key.m_bytes = {0xFF};
-    return key;
-  }
   static unsigned getHashValue(lldb_private::UUID uuid) {
     return DenseMapInfo<llvm::ArrayRef<uint8_t>>::getHashValue(uuid.GetBytes());
   }

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
@@ -426,7 +426,6 @@ private:
   /// Keys are already djbHash values, so use identity as the hash function.
   struct IdentityHashKeyInfo {
     static constexpr uint32_t getEmptyKey() { return ~0U; }
-    static constexpr uint32_t getTombstoneKey() { return ~0U - 1; }
     static unsigned getHashValue(uint32_t Val) { return Val; }
     static bool isEqual(uint32_t LHS, uint32_t RHS) { return LHS == RHS; }
   };

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -2225,10 +2225,10 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
   llvm::DenseSet<addr_t> symbols_added;
 
   // We are using a llvm::DenseSet for "symbols_added" so we must be sure we
-  // do not add the tombstone or empty keys to the set.
+  // do not add the empty key to the set.
   auto add_symbol_addr = [&symbols_added](lldb::addr_t file_addr) {
-    // Don't add the tombstone or empty keys.
-    if (file_addr == UINT64_MAX || file_addr == UINT64_MAX - 1)
+    // Don't add the empty key.
+    if (file_addr == UINT64_MAX)
       return;
     symbols_added.insert(file_addr);
   };

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
@@ -494,13 +494,10 @@ private:
   // The invariant is that all real keys will have the file and architecture
   // set.
   // The empty key has an empty file and an empty arch.
-  // The tombstone key has an invalid arch and an empty file.
   // The comparison and hash functions take the file name and architecture
   // triple into account.
   struct ModuleCacheInfo {
     static ModuleCacheKey getEmptyKey() { return ModuleCacheKey(); }
-
-    static ModuleCacheKey getTombstoneKey() { return ModuleCacheKey("", "T"); }
 
     static unsigned getHashValue(const ModuleCacheKey &key) {
       return llvm::hash_combine(key.first, key.second);

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -1125,8 +1125,7 @@ SymbolFileDWARF::GetTypeUnitSupportFiles(DWARFTypeUnit &tu) {
 
   dw_offset_t offset = tu.GetLineTableOffset();
   if (offset == DW_INVALID_OFFSET ||
-      offset == llvm::DenseMapInfo<dw_offset_t>::getEmptyKey() ||
-      offset == llvm::DenseMapInfo<dw_offset_t>::getTombstoneKey())
+      offset == llvm::DenseMapInfo<dw_offset_t>::getEmptyKey())
     return nullptr;
 
   // Many type units can share a line table, so parse the support file list


### PR DESCRIPTION
#200595 changed DenseMap to no longer create tombstone buckets, so
DenseMapInfo<T>::getTombstoneKey() is never called. Remove dead
definitions and dead tombstone branches.
