### PR TITLE
[lld] Remove unused DenseMapInfo::getTombstoneKey

### DIFF
--- a/lld/COFF/Chunks.h
+++ b/lld/COFF/Chunks.h
@@ -724,9 +724,6 @@ struct ChunkAndOffset {
     static ChunkAndOffset getEmptyKey() {
       return {llvm::DenseMapInfo<Chunk *>::getEmptyKey(), 0};
     }
-    static ChunkAndOffset getTombstoneKey() {
-      return {llvm::DenseMapInfo<Chunk *>::getTombstoneKey(), 0};
-    }
     static unsigned getHashValue(const ChunkAndOffset &co) {
       return llvm::DenseMapInfo<std::pair<Chunk *, uint32_t>>::getHashValue(
           {co.inputChunk, co.offset});

--- a/lld/MachO/ConcatOutputSection.h
+++ b/lld/MachO/ConcatOutputSection.h
@@ -147,12 +147,8 @@ struct ThunkKey {
   static ThunkKey getEmptyKey() {
     return {llvm::DenseMapInfo<Symbol *>::getEmptyKey(), 0};
   }
-  static ThunkKey getTombstoneKey() {
-    return {llvm::DenseMapInfo<Symbol *>::getTombstoneKey(), 0};
-  }
   bool isSentinel() const {
-    return sym == llvm::DenseMapInfo<Symbol *>::getEmptyKey() ||
-           sym == llvm::DenseMapInfo<Symbol *>::getTombstoneKey();
+    return sym == llvm::DenseMapInfo<Symbol *>::getEmptyKey();
   }
   bool operator==(const ThunkKey &other) const {
     if (addend != other.addend)
@@ -171,7 +167,6 @@ struct ThunkKey {
 
 struct ThunkMapKeyInfo {
   static ThunkKey getEmptyKey() { return ThunkKey::getEmptyKey(); }
-  static ThunkKey getTombstoneKey() { return ThunkKey::getTombstoneKey(); }
   static unsigned getHashValue(const ThunkKey &k) {
     if (k.isSentinel())
       return llvm::hash_value(k.sym);

--- a/lld/wasm/SyntheticSections.h
+++ b/lld/wasm/SyntheticSections.h
@@ -102,7 +102,7 @@ protected:
  */
 template <typename T> struct ImportKey {
 public:
-  enum class State { Plain, Empty, Tombstone };
+  enum class State { Plain, Empty };
 
 public:
   T type;
@@ -134,11 +134,6 @@ template <typename T> struct DenseMapInfo<lld::wasm::ImportKey<T>> {
   static lld::wasm::ImportKey<T> getEmptyKey() {
     typename lld::wasm::ImportKey<T> key(llvm::DenseMapInfo<T>::getEmptyKey());
     key.state = lld::wasm::ImportKey<T>::State::Empty;
-    return key;
-  }
-  static lld::wasm::ImportKey<T> getTombstoneKey() {
-    typename lld::wasm::ImportKey<T> key(llvm::DenseMapInfo<T>::getEmptyKey());
-    key.state = lld::wasm::ImportKey<T>::State::Tombstone;
     return key;
   }
   static unsigned getHashValue(const lld::wasm::ImportKey<T> &key) {


### PR DESCRIPTION
#200595 changed DenseMap to no longer create tombstone buckets, so
DenseMapInfo<T>::getTombstoneKey() is never called. Remove dead
definitions and dead tombstone branches.
