### PR TITLE
[BOLT] Remove unused DenseMapInfo::getTombstoneKey

### DIFF
--- a/bolt/include/bolt/Passes/DataflowAnalysis.h
+++ b/bolt/include/bolt/Passes/DataflowAnalysis.h
@@ -570,11 +570,6 @@ template <> struct DenseMapInfo<bolt::ProgramPoint> {
     Val <<= PointerLikeTypeTraits<MCInst *>::NumLowBitsAvailable;
     return bolt::ProgramPoint(reinterpret_cast<MCInst *>(Val));
   }
-  static inline bolt::ProgramPoint getTombstoneKey() {
-    uintptr_t Val = static_cast<uintptr_t>(-2);
-    Val <<= PointerLikeTypeTraits<MCInst *>::NumLowBitsAvailable;
-    return bolt::ProgramPoint(reinterpret_cast<MCInst *>(Val));
-  }
   static unsigned getHashValue(const bolt::ProgramPoint &PP) {
     return (unsigned((uintptr_t)PP.Data.BB) >> 4) ^
            (unsigned((uintptr_t)PP.Data.BB) >> 9);

--- a/bolt/include/bolt/Passes/SplitFunctions.h
+++ b/bolt/include/bolt/Passes/SplitFunctions.h
@@ -43,9 +43,6 @@ private:
         : SourceFN(SourceFN), Target(Target) {}
 
     static inline TrampolineKey getEmptyKey() { return TrampolineKey(); };
-    static inline TrampolineKey getTombstoneKey() {
-      return TrampolineKey(FragmentNum(UINT_MAX), nullptr);
-    };
     static unsigned getHashValue(const TrampolineKey &Val) {
       return llvm::hash_combine(Val.SourceFN.get(), Val.Target);
     }

--- a/bolt/include/bolt/Profile/DataReader.h
+++ b/bolt/include/bolt/Profile/DataReader.h
@@ -491,10 +491,6 @@ template <> struct DenseMapInfo<bolt::Location> {
   static inline bolt::Location getEmptyKey() {
     return bolt::Location(true, StringRef(), static_cast<uint64_t>(-1LL));
   }
-  static inline bolt::Location getTombstoneKey() {
-    return bolt::Location(true, StringRef(), static_cast<uint64_t>(-2LL));
-    ;
-  }
   static unsigned getHashValue(const bolt::Location &L) {
     return (unsigned(DenseMapInfo<StringRef>::getHashValue(L.Name)) >> 4) ^
            (unsigned(L.Offset));


### PR DESCRIPTION
#200595 changed DenseMap to no longer create tombstone buckets, so
DenseMapInfo<T>::getTombstoneKey() is never called. Remove dead
definitions and dead tombstone branches.
