### PR TITLE
[llvm] Remove unused DenseMapInfo::getTombstoneKey

### DIFF
--- a/llvm/include/llvm/ADT/APFixedPoint.h
+++ b/llvm/include/llvm/ADT/APFixedPoint.h
@@ -143,10 +143,6 @@ template <> struct DenseMapInfo<FixedPointSemantics> {
     return FixedPointSemantics(0, 0, false, false, false);
   }
 
-  static inline FixedPointSemantics getTombstoneKey() {
-    return FixedPointSemantics(0, 1, false, false, false);
-  }
-
   static unsigned getHashValue(const FixedPointSemantics &Val) {
     return hash_value(Val);
   }
@@ -321,10 +317,6 @@ inline hash_code hash_value(const APFixedPoint &Val) {
 template <> struct DenseMapInfo<APFixedPoint> {
   static inline APFixedPoint getEmptyKey() {
     return APFixedPoint(DenseMapInfo<FixedPointSemantics>::getEmptyKey());
-  }
-
-  static inline APFixedPoint getTombstoneKey() {
-    return APFixedPoint(DenseMapInfo<FixedPointSemantics>::getTombstoneKey());
   }
 
   static unsigned getHashValue(const APFixedPoint &Val) {

--- a/llvm/include/llvm/ADT/APInt.h
+++ b/llvm/include/llvm/ADT/APInt.h
@@ -2533,12 +2533,6 @@ template <> struct DenseMapInfo<APInt, void> {
     return V;
   }
 
-  static inline APInt getTombstoneKey() {
-    APInt V(nullptr, 0);
-    V.U.VAL = ~1ULL;
-    return V;
-  }
-
   LLVM_ABI static unsigned getHashValue(const APInt &Key);
 
   static bool isEqual(const APInt &LHS, const APInt &RHS) {

--- a/llvm/include/llvm/ADT/APSInt.h
+++ b/llvm/include/llvm/ADT/APSInt.h
@@ -371,10 +371,6 @@ template <> struct DenseMapInfo<APSInt, void> {
     return APSInt(DenseMapInfo<APInt, void>::getEmptyKey());
   }
 
-  static inline APSInt getTombstoneKey() {
-    return APSInt(DenseMapInfo<APInt, void>::getTombstoneKey());
-  }
-
   static unsigned getHashValue(const APSInt &Key) {
     return DenseMapInfo<APInt, void>::getHashValue(Key);
   }

--- a/llvm/include/llvm/ADT/ArrayRef.h
+++ b/llvm/include/llvm/ADT/ArrayRef.h
@@ -569,23 +569,14 @@ template <typename T> struct DenseMapInfo<ArrayRef<T>, void> {
                        size_t(0));
   }
 
-  static inline ArrayRef<T> getTombstoneKey() {
-    return ArrayRef<T>(reinterpret_cast<const T *>(~static_cast<uintptr_t>(1)),
-                       size_t(0));
-  }
-
   static unsigned getHashValue(ArrayRef<T> Val) {
     assert(Val.data() != getEmptyKey().data() && "Cannot hash the empty key!");
-    assert(Val.data() != getTombstoneKey().data() &&
-           "Cannot hash the tombstone key!");
     return (unsigned)(hash_value(Val));
   }
 
   static bool isEqual(ArrayRef<T> LHS, ArrayRef<T> RHS) {
     if (RHS.data() == getEmptyKey().data())
       return LHS.data() == getEmptyKey().data();
-    if (RHS.data() == getTombstoneKey().data())
-      return LHS.data() == getTombstoneKey().data();
     return LHS == RHS;
   }
 };

--- a/llvm/include/llvm/ADT/BitVector.h
+++ b/llvm/include/llvm/ADT/BitVector.h
@@ -854,11 +854,6 @@ inline BitVector::size_type capacity_in_bytes(const BitVector &X) {
 
 template <> struct DenseMapInfo<BitVector> {
   static inline BitVector getEmptyKey() { return {}; }
-  static inline BitVector getTombstoneKey() {
-    BitVector V;
-    V.invalid();
-    return V;
-  }
   static unsigned getHashValue(const BitVector &V) {
     return DenseMapInfo<std::pair<BitVector::size_type, ArrayRef<uintptr_t>>>::
         getHashValue(std::make_pair(V.size(), V.getData()));

--- a/llvm/include/llvm/ADT/CachedHashString.h
+++ b/llvm/include/llvm/ADT/CachedHashString.h
@@ -12,8 +12,8 @@
 /// their string data.
 ///
 /// Unlike std::string, CachedHashString can be used in DenseSet/DenseMap
-/// (because, unlike std::string, CachedHashString lets us have empty and
-/// tombstone values).
+/// (because, unlike std::string, CachedHashString lets us have an empty
+/// value).
 ///
 //===----------------------------------------------------------------------===//
 
@@ -51,12 +51,8 @@ template <> struct DenseMapInfo<CachedHashStringRef> {
   static CachedHashStringRef getEmptyKey() {
     return CachedHashStringRef(DenseMapInfo<StringRef>::getEmptyKey(), 0);
   }
-  static CachedHashStringRef getTombstoneKey() {
-    return CachedHashStringRef(DenseMapInfo<StringRef>::getTombstoneKey(), 1);
-  }
   static unsigned getHashValue(const CachedHashStringRef &S) {
     assert(!isEqual(S, getEmptyKey()) && "Cannot hash the empty key!");
-    assert(!isEqual(S, getTombstoneKey()) && "Cannot hash the tombstone key!");
     return S.hash();
   }
   static bool isEqual(const CachedHashStringRef &LHS,
@@ -77,19 +73,14 @@ class CachedHashString {
   uint32_t Hash;
 
   static char *getEmptyKeyPtr() { return DenseMapInfo<char *>::getEmptyKey(); }
-  static char *getTombstoneKeyPtr() {
-    return DenseMapInfo<char *>::getTombstoneKey();
-  }
 
-  bool isEmptyOrTombstone() const {
-    return P == getEmptyKeyPtr() || P == getTombstoneKeyPtr();
-  }
+  bool isEmpty() const { return P == getEmptyKeyPtr(); }
 
-  struct ConstructEmptyOrTombstoneTy {};
+  struct ConstructEmptyTy {};
 
-  CachedHashString(ConstructEmptyOrTombstoneTy, char *EmptyOrTombstonePtr)
-      : P(EmptyOrTombstonePtr), Size(0), Hash(0) {
-    assert(isEmptyOrTombstone());
+  CachedHashString(ConstructEmptyTy, char *EmptyKeyPtr)
+      : P(EmptyKeyPtr), Size(0), Hash(0) {
+    assert(isEmpty());
   }
 
   // TODO: Use small-string optimization to avoid allocating.
@@ -110,7 +101,7 @@ public:
   // keys, and we want this to be usable there.
   CachedHashString(const CachedHashString &Other)
       : Size(Other.Size), Hash(Other.Hash) {
-    if (Other.isEmptyOrTombstone()) {
+    if (Other.isEmpty()) {
       P = Other.P;
     } else {
       P = new char[Size];
@@ -129,7 +120,7 @@ public:
   }
 
   ~CachedHashString() {
-    if (!isEmptyOrTombstone())
+    if (!isEmpty())
       delete[] P;
   }
 
@@ -152,16 +143,11 @@ public:
 
 template <> struct DenseMapInfo<CachedHashString> {
   static CachedHashString getEmptyKey() {
-    return CachedHashString(CachedHashString::ConstructEmptyOrTombstoneTy(),
+    return CachedHashString(CachedHashString::ConstructEmptyTy(),
                             CachedHashString::getEmptyKeyPtr());
-  }
-  static CachedHashString getTombstoneKey() {
-    return CachedHashString(CachedHashString::ConstructEmptyOrTombstoneTy(),
-                            CachedHashString::getTombstoneKeyPtr());
   }
   static unsigned getHashValue(const CachedHashString &S) {
     assert(!isEqual(S, getEmptyKey()) && "Cannot hash the empty key!");
-    assert(!isEqual(S, getTombstoneKey()) && "Cannot hash the tombstone key!");
     return S.hash();
   }
   static bool isEqual(const CachedHashString &LHS,
@@ -170,11 +156,9 @@ template <> struct DenseMapInfo<CachedHashString> {
       return false;
     if (LHS.P == CachedHashString::getEmptyKeyPtr())
       return RHS.P == CachedHashString::getEmptyKeyPtr();
-    if (LHS.P == CachedHashString::getTombstoneKeyPtr())
-      return RHS.P == CachedHashString::getTombstoneKeyPtr();
 
-    // This is safe because if RHS.P is the empty or tombstone key, it will have
-    // length 0, so we'll never dereference its pointer.
+    // This is safe because if RHS.P is the empty key, it will have length 0, so
+    // we'll never dereference its pointer.
     return LHS.val() == RHS.val();
   }
 };

--- a/llvm/include/llvm/ADT/DenseMapInfo.h
+++ b/llvm/include/llvm/ADT/DenseMapInfo.h
@@ -53,7 +53,6 @@ inline unsigned combineHashValue(unsigned a, unsigned b) {
 template<typename T, typename Enable = void>
 struct DenseMapInfo {
   // static constexpr T getEmptyKey();
-  // static constexpr T getTombstoneKey();
   // static unsigned getHashValue(const T &Val);
   // static bool isEqual(const T &LHS, const T &RHS);
 };
@@ -77,12 +76,6 @@ struct DenseMapInfo<T*> {
     return reinterpret_cast<T*>(Val);
   }
 
-  static constexpr T *getTombstoneKey() {
-    uintptr_t Val = static_cast<uintptr_t>(-2);
-    Val <<= Log2MaxAlign;
-    return reinterpret_cast<T*>(Val);
-  }
-
   static unsigned getHashValue(const T *PtrVal) {
     return densemap::detail::mix(reinterpret_cast<uintptr_t>(PtrVal));
   }
@@ -93,7 +86,6 @@ struct DenseMapInfo<T*> {
 // Provide DenseMapInfo for chars.
 template<> struct DenseMapInfo<char> {
   static constexpr char getEmptyKey() { return ~0; }
-  static constexpr char getTombstoneKey() { return ~0 - 1; }
   static unsigned getHashValue(const char& Val) { return Val * 37U; }
 
   static bool isEqual(const char &LHS, const char &RHS) {
@@ -111,13 +103,6 @@ template <typename T>
 struct DenseMapInfo<
     T, std::enable_if_t<std::is_integral_v<T> && !std::is_same_v<T, char>>> {
   static constexpr T getEmptyKey() { return std::numeric_limits<T>::max(); }
-
-  static constexpr T getTombstoneKey() {
-    if constexpr (std::is_unsigned_v<T> || std::is_same_v<T, long>)
-      return std::numeric_limits<T>::max() - 1;
-    else
-      return std::numeric_limits<T>::min();
-  }
 
   static unsigned getHashValue(const T &Val) {
     if constexpr (std::is_unsigned_v<T> && sizeof(T) > sizeof(unsigned))
@@ -139,10 +124,6 @@ struct DenseMapInfo<std::pair<T, U>> {
 
   static constexpr Pair getEmptyKey() {
     return {FirstInfo::getEmptyKey(), SecondInfo::getEmptyKey()};
-  }
-
-  static constexpr Pair getTombstoneKey() {
-    return {FirstInfo::getTombstoneKey(), SecondInfo::getTombstoneKey()};
   }
 
   static unsigned getHashValue(const Pair& PairVal) {
@@ -170,10 +151,6 @@ template <typename... Ts> struct DenseMapInfo<std::tuple<Ts...>> {
 
   static constexpr Tuple getEmptyKey() {
     return Tuple(DenseMapInfo<Ts>::getEmptyKey()...);
-  }
-
-  static constexpr Tuple getTombstoneKey() {
-    return Tuple(DenseMapInfo<Ts>::getTombstoneKey()...);
   }
 
   template <unsigned I> static unsigned getHashValueImpl(const Tuple &values) {
@@ -223,11 +200,6 @@ struct DenseMapInfo<Enum, std::enable_if_t<std::is_enum_v<Enum>>> {
     return V;
   }
 
-  static constexpr Enum getTombstoneKey() {
-    constexpr Enum V = static_cast<Enum>(Info::getTombstoneKey());
-    return V;
-  }
-
   static unsigned getHashValue(const Enum &Val) {
     return Info::getHashValue(static_cast<UnderlyingType>(Val));
   }
@@ -240,10 +212,6 @@ template <typename T> struct DenseMapInfo<std::optional<T>> {
   using Info = DenseMapInfo<T>;
 
   static constexpr Optional getEmptyKey() { return {Info::getEmptyKey()}; }
-
-  static constexpr Optional getTombstoneKey() {
-    return {Info::getTombstoneKey()};
-  }
 
   static unsigned getHashValue(const Optional &OptionalVal) {
     return detail::combineHashValue(

--- a/llvm/include/llvm/ADT/DenseMapInfoVariant.h
+++ b/llvm/include/llvm/ADT/DenseMapInfoVariant.h
@@ -29,11 +29,6 @@ template <typename... Ts> struct DenseMapInfo<std::variant<Ts...>> {
     return Variant(std::in_place_index<0>, DenseMapInfo<FirstT>::getEmptyKey());
   }
 
-  static inline Variant getTombstoneKey() {
-    return Variant(std::in_place_index<0>,
-                   DenseMapInfo<FirstT>::getTombstoneKey());
-  }
-
   static unsigned getHashValue(const Variant &Val) {
     return std::visit(
         [&Val](auto &&Alternative) {

--- a/llvm/include/llvm/ADT/Hashing.h
+++ b/llvm/include/llvm/ADT/Hashing.h
@@ -392,7 +392,6 @@ template <typename T> hash_code hash_value(const std::optional<T> &arg) {
 
 template <> struct DenseMapInfo<hash_code, void> {
   static constexpr hash_code getEmptyKey() { return hash_code(-1); }
-  static constexpr hash_code getTombstoneKey() { return hash_code(-2); }
   static constexpr unsigned getHashValue(hash_code val) {
     return static_cast<unsigned>(size_t(val));
   }

--- a/llvm/include/llvm/ADT/ImmutableList.h
+++ b/llvm/include/llvm/ADT/ImmutableList.h
@@ -224,10 +224,6 @@ template <typename T> struct DenseMapInfo<ImmutableList<T>, void> {
     return reinterpret_cast<ImmutableListImpl<T>*>(-1);
   }
 
-  static inline ImmutableList<T> getTombstoneKey() {
-    return reinterpret_cast<ImmutableListImpl<T>*>(-2);
-  }
-
   static unsigned getHashValue(ImmutableList<T> X) {
     uintptr_t PtrVal = reinterpret_cast<uintptr_t>(X.getInternalPointer());
     return (unsigned((uintptr_t)PtrVal) >> 4) ^

--- a/llvm/include/llvm/ADT/PointerEmbeddedInt.h
+++ b/llvm/include/llvm/ADT/PointerEmbeddedInt.h
@@ -102,7 +102,6 @@ struct DenseMapInfo<PointerEmbeddedInt<IntT, Bits>> {
   using IntInfo = DenseMapInfo<IntT>;
 
   static inline T getEmptyKey() { return IntInfo::getEmptyKey(); }
-  static inline T getTombstoneKey() { return IntInfo::getTombstoneKey(); }
 
   static unsigned getHashValue(const T &Arg) {
     return IntInfo::getHashValue(Arg);

--- a/llvm/include/llvm/ADT/PointerIntPair.h
+++ b/llvm/include/llvm/ADT/PointerIntPair.h
@@ -223,12 +223,6 @@ struct DenseMapInfo<PointerIntPair<PointerTy, IntBits, IntType>, void> {
     return Ty::getFromOpaqueValue(reinterpret_cast<void *>(Val));
   }
 
-  static Ty getTombstoneKey() {
-    uintptr_t Val = static_cast<uintptr_t>(-2);
-    Val <<= PointerLikeTypeTraits<PointerTy>::NumLowBitsAvailable;
-    return Ty::getFromOpaqueValue(reinterpret_cast<void *>(Val));
-  }
-
   static unsigned getHashValue(Ty V) {
     uintptr_t IV = reinterpret_cast<uintptr_t>(V.getOpaqueValue());
     return unsigned(IV) ^ unsigned(IV >> 9);

--- a/llvm/include/llvm/ADT/PointerSumType.h
+++ b/llvm/include/llvm/ADT/PointerSumType.h
@@ -259,11 +259,6 @@ struct DenseMapInfo<PointerSumType<TagT, MemberTs...>> {
     return SumType::template create<SomeTag>(SomePointerInfo::getEmptyKey());
   }
 
-  static inline SumType getTombstoneKey() {
-    return SumType::template create<SomeTag>(
-        SomePointerInfo::getTombstoneKey());
-  }
-
   static unsigned getHashValue(const SumType &Arg) {
     uintptr_t OpaqueValue = Arg.getOpaqueValue();
     return DenseMapInfo<uintptr_t>::getHashValue(OpaqueValue);

--- a/llvm/include/llvm/ADT/PointerUnion.h
+++ b/llvm/include/llvm/ADT/PointerUnion.h
@@ -428,10 +428,6 @@ template <typename... PTs> struct DenseMapInfo<PointerUnion<PTs...>> {
 
   static inline Union getEmptyKey() { return Union(FirstInfo::getEmptyKey()); }
 
-  static inline Union getTombstoneKey() {
-    return Union(FirstInfo::getTombstoneKey());
-  }
-
   static unsigned getHashValue(const Union &UnionVal) {
     auto Key = reinterpret_cast<uintptr_t>(UnionVal.getOpaqueValue());
     return DenseMapInfo<uintptr_t>::getHashValue(Key);

--- a/llvm/include/llvm/ADT/SmallBitVector.h
+++ b/llvm/include/llvm/ADT/SmallBitVector.h
@@ -735,11 +735,6 @@ operator^(const SmallBitVector &LHS, const SmallBitVector &RHS) {
 
 template <> struct DenseMapInfo<SmallBitVector> {
   static inline SmallBitVector getEmptyKey() { return SmallBitVector(); }
-  static inline SmallBitVector getTombstoneKey() {
-    SmallBitVector V;
-    V.invalid();
-    return V;
-  }
   static unsigned getHashValue(const SmallBitVector &V) {
     uintptr_t Store;
     return DenseMapInfo<

--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -1353,10 +1353,6 @@ template <typename T, unsigned N> struct DenseMapInfo<llvm::SmallVector<T, N>> {
     return {DenseMapInfo<T>::getEmptyKey()};
   }
 
-  static SmallVector<T, N> getTombstoneKey() {
-    return {DenseMapInfo<T>::getTombstoneKey()};
-  }
-
   static unsigned getHashValue(const SmallVector<T, N> &V) {
     return static_cast<unsigned>(hash_combine_range(V));
   }

--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -956,18 +956,11 @@ template <> struct DenseMapInfo<StringRef, void> {
                      0);
   }
 
-  static inline StringRef getTombstoneKey() {
-    return StringRef(reinterpret_cast<const char *>(~static_cast<uintptr_t>(1)),
-                     0);
-  }
-
   LLVM_ABI static unsigned getHashValue(StringRef Val);
 
   static bool isEqual(StringRef LHS, StringRef RHS) {
     if (RHS.data() == getEmptyKey().data())
       return LHS.data() == getEmptyKey().data();
-    if (RHS.data() == getTombstoneKey().data())
-      return LHS.data() == getTombstoneKey().data();
     return LHS == RHS;
   }
 };

--- a/llvm/include/llvm/Analysis/AliasAnalysis.h
+++ b/llvm/include/llvm/Analysis/AliasAnalysis.h
@@ -221,10 +221,6 @@ template <> struct DenseMapInfo<AACacheLoc> {
     return {DenseMapInfo<AACacheLoc::PtrTy>::getEmptyKey(),
             DenseMapInfo<LocationSize>::getEmptyKey()};
   }
-  static inline AACacheLoc getTombstoneKey() {
-    return {DenseMapInfo<AACacheLoc::PtrTy>::getTombstoneKey(),
-            DenseMapInfo<LocationSize>::getTombstoneKey()};
-  }
   static unsigned getHashValue(const AACacheLoc &Val) {
     return DenseMapInfo<AACacheLoc::PtrTy>::getHashValue(Val.Ptr) ^
            DenseMapInfo<LocationSize>::getHashValue(Val.Size);

--- a/llvm/include/llvm/Analysis/AssumeBundleQueries.h
+++ b/llvm/include/llvm/Analysis/AssumeBundleQueries.h
@@ -53,9 +53,6 @@ template<> struct DenseMapInfo<Attribute::AttrKind> {
   static Attribute::AttrKind getEmptyKey() {
     return Attribute::EmptyKey;
   }
-  static Attribute::AttrKind getTombstoneKey() {
-    return Attribute::TombstoneKey;
-  }
   static unsigned getHashValue(Attribute::AttrKind AK) {
     return hash_combine(AK);
   }

--- a/llvm/include/llvm/Analysis/IRSimilarityIdentifier.h
+++ b/llvm/include/llvm/Analysis/IRSimilarityIdentifier.h
@@ -315,9 +315,6 @@ LLVM_ABI bool isClose(const IRInstructionData &A, const IRInstructionData &B);
 
 struct IRInstructionDataTraits : DenseMapInfo<IRInstructionData *> {
   static inline IRInstructionData *getEmptyKey() { return nullptr; }
-  static inline IRInstructionData *getTombstoneKey() {
-    return reinterpret_cast<IRInstructionData *>(-1);
-  }
 
   static unsigned getHashValue(const IRInstructionData *E) {
     using llvm::hash_value;
@@ -327,8 +324,7 @@ struct IRInstructionDataTraits : DenseMapInfo<IRInstructionData *> {
 
   static bool isEqual(const IRInstructionData *LHS,
                       const IRInstructionData *RHS) {
-    if (RHS == getEmptyKey() || RHS == getTombstoneKey() ||
-        LHS == getEmptyKey() || LHS == getTombstoneKey())
+    if (RHS == getEmptyKey() || LHS == getEmptyKey())
       return LHS == RHS;
 
     assert(LHS && RHS && "nullptr should have been caught by getEmptyKey?");
@@ -511,8 +507,6 @@ struct IRInstructionMapper {
     // changed.
     static_assert(DenseMapInfo<unsigned>::getEmptyKey() ==
                   static_cast<unsigned>(-1));
-    static_assert(DenseMapInfo<unsigned>::getTombstoneKey() ==
-                  static_cast<unsigned>(-2));
 
     IDL = new (IDLAllocator->Allocate())
         IRInstructionDataList();

--- a/llvm/include/llvm/Analysis/MemoryLocation.h
+++ b/llvm/include/llvm/Analysis/MemoryLocation.h
@@ -330,9 +330,6 @@ public:
 // Specialize DenseMapInfo.
 template <> struct DenseMapInfo<LocationSize> {
   static inline LocationSize getEmptyKey() { return LocationSize::mapEmpty(); }
-  static inline LocationSize getTombstoneKey() {
-    return LocationSize::mapTombstone();
-  }
   static unsigned getHashValue(const LocationSize &Val) {
     return DenseMapInfo<uint64_t>::getHashValue(Val.toRaw());
   }
@@ -345,10 +342,6 @@ template <> struct DenseMapInfo<MemoryLocation> {
   static inline MemoryLocation getEmptyKey() {
     return MemoryLocation(DenseMapInfo<const Value *>::getEmptyKey(),
                           DenseMapInfo<LocationSize>::getEmptyKey());
-  }
-  static inline MemoryLocation getTombstoneKey() {
-    return MemoryLocation(DenseMapInfo<const Value *>::getTombstoneKey(),
-                          DenseMapInfo<LocationSize>::getTombstoneKey());
   }
   static unsigned getHashValue(const MemoryLocation &Val) {
     return DenseMapInfo<const Value *>::getHashValue(Val.Ptr) ^

--- a/llvm/include/llvm/Analysis/MemorySSA.h
+++ b/llvm/include/llvm/Analysis/MemorySSA.h
@@ -1208,11 +1208,6 @@ template <> struct DenseMapInfo<UpwardDefsElem> {
             DenseMapInfo<MemoryLocation>::getEmptyKey(), false};
   }
 
-  static inline UpwardDefsElem getTombstoneKey() {
-    return {DenseMapInfo<MemoryAccess *>::getTombstoneKey(),
-            DenseMapInfo<MemoryLocation>::getTombstoneKey(), false};
-  }
-
   static unsigned getHashValue(const UpwardDefsElem &Val) {
     return hash_combine(DenseMapInfo<MemoryAccess *>::getHashValue(Val.MA),
                         DenseMapInfo<MemoryLocation>::getHashValue(Val.Loc),

--- a/llvm/include/llvm/Analysis/ScalarEvolution.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolution.h
@@ -206,11 +206,6 @@ template <> struct DenseMapInfo<SCEVUse> {
     return PointerLikeTypeTraits<SCEVUse>::getFromVoidPointer((void *)Val);
   }
 
-  static inline SCEVUse getTombstoneKey() {
-    uintptr_t Val = static_cast<uintptr_t>(-2);
-    return PointerLikeTypeTraits<SCEVUse>::getFromVoidPointer((void *)Val);
-  }
-
   static unsigned getHashValue(SCEVUse U) {
     return hash_value(U.getOpaqueValue());
   }
@@ -2732,10 +2727,6 @@ private:
 template <> struct DenseMapInfo<ScalarEvolution::FoldID> {
   static inline ScalarEvolution::FoldID getEmptyKey() {
     ScalarEvolution::FoldID ID(0);
-    return ID;
-  }
-  static inline ScalarEvolution::FoldID getTombstoneKey() {
-    ScalarEvolution::FoldID ID(1);
     return ID;
   }
 

--- a/llvm/include/llvm/Analysis/VectorUtils.h
+++ b/llvm/include/llvm/Analysis/VectorUtils.h
@@ -554,9 +554,8 @@ public:
       return false;
     int32_t Key = *MaybeKey;
 
-    // Skip if the key is used for either the tombstone or empty special values.
-    if (DenseMapInfo<int32_t>::getTombstoneKey() == Key ||
-        DenseMapInfo<int32_t>::getEmptyKey() == Key)
+    // Skip if the key is used for the empty special value.
+    if (DenseMapInfo<int32_t>::getEmptyKey() == Key)
       return false;
 
     // Skip if there is already a member with the same index.

--- a/llvm/include/llvm/BinaryFormat/Minidump.h
+++ b/llvm/include/llvm/BinaryFormat/Minidump.h
@@ -272,10 +272,6 @@ static_assert(sizeof(ExceptionStream) == 168);
 template <> struct DenseMapInfo<minidump::StreamType> {
   static minidump::StreamType getEmptyKey() { return minidump::StreamType(-1); }
 
-  static minidump::StreamType getTombstoneKey() {
-    return minidump::StreamType(-2);
-  }
-
   static unsigned getHashValue(minidump::StreamType Val) {
     return DenseMapInfo<uint32_t>::getHashValue(static_cast<uint32_t>(Val));
   }

--- a/llvm/include/llvm/BinaryFormat/Wasm.h
+++ b/llvm/include/llvm/BinaryFormat/Wasm.h
@@ -519,8 +519,8 @@ struct WasmSignature {
   // but does not actually model them. Instead a placeholder signature is
   // created in the Object's signature list.
   enum { Function, Tag, Placeholder } Kind = Function;
-  // Support empty and tombstone instances, needed by DenseMap.
-  enum { Plain, Empty, Tombstone } State = Plain;
+  // Support empty instances, needed by DenseMap.
+  enum { Plain, Empty } State = Plain;
 
   WasmSignature(SmallVector<ValType, 1> &&InReturns,
                 SmallVector<ValType, 4> &&InParams)

--- a/llvm/include/llvm/BinaryFormat/WasmTraits.h
+++ b/llvm/include/llvm/BinaryFormat/WasmTraits.h
@@ -25,11 +25,6 @@ template <> struct DenseMapInfo<wasm::WasmSignature, void> {
     Sig.State = wasm::WasmSignature::Empty;
     return Sig;
   }
-  static wasm::WasmSignature getTombstoneKey() {
-    wasm::WasmSignature Sig;
-    Sig.State = wasm::WasmSignature::Tombstone;
-    return Sig;
-  }
   static unsigned getHashValue(const wasm::WasmSignature &Sig) {
     uintptr_t H = hash_value(Sig.State);
     for (auto Ret : Sig.Returns)
@@ -49,9 +44,6 @@ template <> struct DenseMapInfo<wasm::WasmGlobalType, void> {
   static wasm::WasmGlobalType getEmptyKey() {
     return wasm::WasmGlobalType{1, true};
   }
-  static wasm::WasmGlobalType getTombstoneKey() {
-    return wasm::WasmGlobalType{2, true};
-  }
   static unsigned getHashValue(const wasm::WasmGlobalType &GlobalType) {
     return hash_combine(GlobalType.Type, GlobalType.Mutable);
   }
@@ -65,9 +57,6 @@ template <> struct DenseMapInfo<wasm::WasmGlobalType, void> {
 template <> struct DenseMapInfo<wasm::WasmLimits, void> {
   static wasm::WasmLimits getEmptyKey() {
     return wasm::WasmLimits{0xff, 0xff, 0xff, 0xff};
-  }
-  static wasm::WasmLimits getTombstoneKey() {
-    return wasm::WasmLimits{0xee, 0xee, 0xee, 0xee};
   }
   static unsigned getHashValue(const wasm::WasmLimits &Limits) {
     unsigned Hash = hash_value(Limits.Flags);
@@ -88,11 +77,6 @@ template <> struct DenseMapInfo<wasm::WasmTableType, void> {
   static wasm::WasmTableType getEmptyKey() {
     return wasm::WasmTableType{
         wasm::ValType(0), DenseMapInfo<wasm::WasmLimits, void>::getEmptyKey()};
-  }
-  static wasm::WasmTableType getTombstoneKey() {
-    return wasm::WasmTableType{
-        wasm::ValType(1),
-        DenseMapInfo<wasm::WasmLimits, void>::getTombstoneKey()};
   }
   static unsigned getHashValue(const wasm::WasmTableType &TableType) {
     return hash_combine(

--- a/llvm/include/llvm/CAS/CASID.h
+++ b/llvm/include/llvm/CAS/CASID.h
@@ -107,7 +107,11 @@ public:
     return CASID(nullptr, DenseMapInfo<StringRef>::getEmptyKey());
   }
   static CASID getDenseMapTombstoneKey() {
-    return CASID(nullptr, DenseMapInfo<StringRef>::getTombstoneKey());
+    // A reserved StringRef value distinct from the empty key, used only as a
+    // DenseMap sentinel for CASID.
+    return CASID(nullptr, StringRef(reinterpret_cast<const char *>(
+                                        ~static_cast<uintptr_t>(1)),
+                                    0));
   }
 
   CASID() = delete;
@@ -129,10 +133,6 @@ private:
 
 template <> struct DenseMapInfo<cas::CASID> {
   static cas::CASID getEmptyKey() { return cas::CASID::getDenseMapEmptyKey(); }
-
-  static cas::CASID getTombstoneKey() {
-    return cas::CASID::getDenseMapTombstoneKey();
-  }
 
   static unsigned getHashValue(cas::CASID ID) {
     return (unsigned)hash_value(ID);

--- a/llvm/include/llvm/CAS/CASReference.h
+++ b/llvm/include/llvm/CAS/CASReference.h
@@ -177,10 +177,6 @@ template <> struct DenseMapInfo<cas::ObjectRef> {
     return cas::ObjectRef::getDenseMapEmptyKey();
   }
 
-  static cas::ObjectRef getTombstoneKey() {
-    return cas::ObjectRef::getDenseMapTombstoneKey();
-  }
-
   static unsigned getHashValue(cas::ObjectRef Ref) {
     return Ref.getDenseMapHash();
   }

--- a/llvm/include/llvm/CodeGen/AccelTable.h
+++ b/llvm/include/llvm/CodeGen/AccelTable.h
@@ -274,9 +274,6 @@ template <> struct DenseMapInfo<OffsetAndUnitID> {
   static inline OffsetAndUnitID getEmptyKey() {
     return OffsetAndUnitID(-1, -1, false);
   }
-  static inline OffsetAndUnitID getTombstoneKey() {
-    return OffsetAndUnitID(-2, -2, false);
-  }
   static unsigned getHashValue(const OffsetAndUnitID &Val) {
     return (unsigned)llvm::hash_combine(Val.offset(), Val.unitID(), Val.IsTU);
   }

--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -88,9 +88,6 @@ template <> struct DenseMapInfo<MBBSectionID> {
   static inline MBBSectionID getEmptyKey() {
     return MBBSectionID(NumberInfo::getEmptyKey());
   }
-  static inline MBBSectionID getTombstoneKey() {
-    return MBBSectionID(NumberInfo::getTombstoneKey());
-  }
   static unsigned getHashValue(const MBBSectionID &SecID) {
     return detail::combineHashValue(TypeInfo::getHashValue(SecID.Type),
                                     NumberInfo::getHashValue(SecID.Number));

--- a/llvm/include/llvm/CodeGen/MachineInstr.h
+++ b/llvm/include/llvm/CodeGen/MachineInstr.h
@@ -2133,16 +2133,11 @@ struct MachineInstrExpressionTrait : DenseMapInfo<MachineInstr*> {
     return nullptr;
   }
 
-  static inline MachineInstr *getTombstoneKey() {
-    return reinterpret_cast<MachineInstr*>(-1);
-  }
-
   LLVM_ABI static unsigned getHashValue(const MachineInstr *const &MI);
 
   static bool isEqual(const MachineInstr* const &LHS,
                       const MachineInstr* const &RHS) {
-    if (RHS == getEmptyKey() || RHS == getTombstoneKey() ||
-        LHS == getEmptyKey() || LHS == getTombstoneKey())
+    if (RHS == getEmptyKey() || LHS == getEmptyKey())
       return LHS == RHS;
     return LHS->isIdenticalTo(*RHS, MachineInstr::IgnoreVRegDefs);
   }

--- a/llvm/include/llvm/CodeGen/MachineOperand.h
+++ b/llvm/include/llvm/CodeGen/MachineOperand.h
@@ -1018,7 +1018,6 @@ private:
   /// Artificial kinds for DenseMap usage.
   enum : unsigned char {
     MO_Empty = MO_Last + 1,
-    MO_Tombstone,
   };
 
   friend struct DenseMapInfo<MachineOperand>;
@@ -1041,18 +1040,12 @@ template <> struct DenseMapInfo<MachineOperand> {
     return MachineOperand(static_cast<MachineOperand::MachineOperandType>(
         MachineOperand::MO_Empty));
   }
-  static MachineOperand getTombstoneKey() {
-    return MachineOperand(static_cast<MachineOperand::MachineOperandType>(
-        MachineOperand::MO_Tombstone));
-  }
   static unsigned getHashValue(const MachineOperand &MO) {
     return hash_value(MO);
   }
   static bool isEqual(const MachineOperand &LHS, const MachineOperand &RHS) {
     if (LHS.getType() == static_cast<MachineOperand::MachineOperandType>(
-                             MachineOperand::MO_Empty) ||
-        LHS.getType() == static_cast<MachineOperand::MachineOperandType>(
-                             MachineOperand::MO_Tombstone))
+                             MachineOperand::MO_Empty))
       return LHS.getType() == RHS.getType();
     return LHS.isIdenticalTo(RHS);
   }

--- a/llvm/include/llvm/CodeGen/PBQP/CostAllocator.h
+++ b/llvm/include/llvm/CodeGen/PBQP/CostAllocator.h
@@ -49,10 +49,6 @@ private:
   public:
     static inline PoolEntry *getEmptyKey() { return nullptr; }
 
-    static inline PoolEntry *getTombstoneKey() {
-      return reinterpret_cast<PoolEntry *>(static_cast<uintptr_t>(1));
-    }
-
     template <typename ValueKeyT>
     static unsigned getHashValue(const ValueKeyT &C) {
       return hash_value(C);
@@ -73,13 +69,13 @@ private:
 
     template <typename ValueKeyT>
     static bool isEqual(const ValueKeyT &C, PoolEntry *P) {
-      if (P == getEmptyKey() || P == getTombstoneKey())
+      if (P == getEmptyKey())
         return false;
       return isEqual(C, P->getValue());
     }
 
     static bool isEqual(PoolEntry *P1, PoolEntry *P2) {
-      if (P1 == getEmptyKey() || P1 == getTombstoneKey())
+      if (P1 == getEmptyKey())
         return P1 == P2;
       return isEqual(P1->getValue(), P2);
     }

--- a/llvm/include/llvm/CodeGen/Register.h
+++ b/llvm/include/llvm/CodeGen/Register.h
@@ -166,9 +166,6 @@ template <> struct DenseMapInfo<Register> {
   static inline Register getEmptyKey() {
     return DenseMapInfo<unsigned>::getEmptyKey();
   }
-  static inline Register getTombstoneKey() {
-    return DenseMapInfo<unsigned>::getTombstoneKey();
-  }
   static unsigned getHashValue(const Register &Val) {
     return DenseMapInfo<unsigned>::getHashValue(Val.id());
   }

--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -245,12 +245,6 @@ template<> struct DenseMapInfo<SDValue> {
     return V;
   }
 
-  static inline SDValue getTombstoneKey() {
-    SDValue V;
-    V.ResNo = -2U;
-    return V;
-  }
-
   static unsigned getHashValue(const SDValue &Val) {
     return ((unsigned)((uintptr_t)Val.getNode() >> 4) ^
             (unsigned)((uintptr_t)Val.getNode() >> 9)) + Val.getResNo();

--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -2422,11 +2422,6 @@ template <> struct DenseMapInfo<TargetInstrInfo::RegSubRegPair> {
                                           SubRegInfo::getEmptyKey());
   }
 
-  static inline TargetInstrInfo::RegSubRegPair getTombstoneKey() {
-    return TargetInstrInfo::RegSubRegPair(RegInfo::getTombstoneKey(),
-                                          SubRegInfo::getTombstoneKey());
-  }
-
   /// Reuse getHashValue implementation from
   /// std::pair<unsigned, unsigned>.
   static unsigned getHashValue(const TargetInstrInfo::RegSubRegPair &Val) {

--- a/llvm/include/llvm/CodeGenTypes/LowLevelType.h
+++ b/llvm/include/llvm/CodeGenTypes/LowLevelType.h
@@ -722,11 +722,6 @@ template <> struct DenseMapInfo<LLT> {
     Invalid.Info = LLT::Kind::POINTER;
     return Invalid;
   }
-  static inline LLT getTombstoneKey() {
-    LLT Invalid;
-    Invalid.Info = LLT::Kind::VECTOR_ANY;
-    return Invalid;
-  }
   static inline unsigned getHashValue(const LLT &Ty) {
     uint64_t Val = Ty.getUniqueRAWLLTData();
     return DenseMapInfo<uint64_t>::getHashValue(Val);

--- a/llvm/include/llvm/DWARFLinker/Classic/DWARFLinkerDeclContext.h
+++ b/llvm/include/llvm/DWARFLinker/Classic/DWARFLinkerDeclContext.h
@@ -173,14 +173,13 @@ private:
 /// Info type for the DenseMap storing the DeclContext pointers.
 struct DeclMapInfo : private DenseMapInfo<DeclContext *> {
   using DenseMapInfo<DeclContext *>::getEmptyKey;
-  using DenseMapInfo<DeclContext *>::getTombstoneKey;
 
   static unsigned getHashValue(const DeclContext *Ctxt) {
     return Ctxt->QualifiedNameHash;
   }
 
   static bool isEqual(const DeclContext *LHS, const DeclContext *RHS) {
-    if (RHS == getEmptyKey() || RHS == getTombstoneKey())
+    if (RHS == getEmptyKey())
       return RHS == LHS;
     return LHS->QualifiedNameHash == RHS->QualifiedNameHash &&
            LHS->Line == RHS->Line && LHS->ByteSize == RHS->ByteSize &&

--- a/llvm/include/llvm/DebugInfo/CodeView/TypeHashing.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/TypeHashing.h
@@ -184,11 +184,8 @@ static_assert(std::is_trivially_copyable<GloballyHashedType>::value,
 
 template <> struct DenseMapInfo<codeview::LocallyHashedType> {
   LLVM_ABI static codeview::LocallyHashedType Empty;
-  LLVM_ABI static codeview::LocallyHashedType Tombstone;
 
   static codeview::LocallyHashedType getEmptyKey() { return Empty; }
-
-  static codeview::LocallyHashedType getTombstoneKey() { return Tombstone; }
 
   static unsigned getHashValue(codeview::LocallyHashedType Val) {
     return Val.Hash;
@@ -204,11 +201,8 @@ template <> struct DenseMapInfo<codeview::LocallyHashedType> {
 
 template <> struct DenseMapInfo<codeview::GloballyHashedType> {
   LLVM_ABI static codeview::GloballyHashedType Empty;
-  LLVM_ABI static codeview::GloballyHashedType Tombstone;
 
   static codeview::GloballyHashedType getEmptyKey() { return Empty; }
-
-  static codeview::GloballyHashedType getTombstoneKey() { return Tombstone; }
 
   static unsigned getHashValue(codeview::GloballyHashedType Val) {
     return *reinterpret_cast<const unsigned *>(Val.Hash.data());

--- a/llvm/include/llvm/DebugInfo/CodeView/TypeIndex.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/TypeIndex.h
@@ -293,9 +293,6 @@ template <> struct DenseMapInfo<codeview::TypeIndex> {
   static inline codeview::TypeIndex getEmptyKey() {
     return codeview::TypeIndex{DenseMapInfo<uint32_t>::getEmptyKey()};
   }
-  static inline codeview::TypeIndex getTombstoneKey() {
-    return codeview::TypeIndex{DenseMapInfo<uint32_t>::getTombstoneKey()};
-  }
   static unsigned getHashValue(const codeview::TypeIndex &TI) {
     return DenseMapInfo<uint32_t>::getHashValue(TI.getIndex());
   }

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
@@ -536,7 +536,6 @@ private:
   /// DenseMapInfo for struct Abbrev.
   struct AbbrevMapInfo {
     LLVM_ABI static Abbrev getEmptyKey();
-    LLVM_ABI static Abbrev getTombstoneKey();
     static unsigned getHashValue(uint32_t Code) {
       return DenseMapInfo<uint32_t>::getHashValue(Code);
     }

--- a/llvm/include/llvm/DebugInfo/GSYM/FileEntry.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/FileEntry.h
@@ -56,10 +56,6 @@ template <> struct DenseMapInfo<gsym::FileEntry> {
     gsym::gsym_strp_t key = DenseMapInfo<gsym::gsym_strp_t>::getEmptyKey();
     return gsym::FileEntry(key, key);
   }
-  static inline gsym::FileEntry getTombstoneKey() {
-    gsym::gsym_strp_t key = DenseMapInfo<gsym::gsym_strp_t>::getTombstoneKey();
-    return gsym::FileEntry(key, key);
-  }
   static unsigned getHashValue(const gsym::FileEntry &Val) {
     return llvm::hash_combine(
         DenseMapInfo<gsym::gsym_strp_t>::getHashValue(Val.Dir),

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h
@@ -347,9 +347,6 @@ template <> struct DenseMapInfo<orc::ExecutorAddr> {
   static inline orc::ExecutorAddr getEmptyKey() {
     return orc::ExecutorAddr(DenseMapInfo<uint64_t>::getEmptyKey());
   }
-  static inline orc::ExecutorAddr getTombstoneKey() {
-    return orc::ExecutorAddr(DenseMapInfo<uint64_t>::getTombstoneKey());
-  }
 
   static unsigned getHashValue(const orc::ExecutorAddr &Addr) {
     return DenseMapInfo<uint64_t>::getHashValue(Addr.getValue());

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/MemoryFlags.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/MemoryFlags.h
@@ -210,9 +210,6 @@ inline raw_ostream &operator<<(raw_ostream &OS, AllocGroup AG) {
 
 template <> struct DenseMapInfo<orc::MemProt> {
   static inline orc::MemProt getEmptyKey() { return orc::MemProt(~uint8_t(0)); }
-  static inline orc::MemProt getTombstoneKey() {
-    return orc::MemProt(~uint8_t(0) - 1);
-  }
   static unsigned getHashValue(const orc::MemProt &Val) {
     using UT = std::underlying_type_t<orc::MemProt>;
     return DenseMapInfo<UT>::getHashValue(static_cast<UT>(Val));
@@ -225,9 +222,6 @@ template <> struct DenseMapInfo<orc::MemProt> {
 template <> struct DenseMapInfo<orc::AllocGroup> {
   static inline orc::AllocGroup getEmptyKey() {
     return orc::AllocGroup(~uint8_t(0));
-  }
-  static inline orc::AllocGroup getTombstoneKey() {
-    return orc::AllocGroup(~uint8_t(0) - 1);
   }
   static unsigned getHashValue(const orc::AllocGroup &Val) {
     return DenseMapInfo<orc::AllocGroup::underlying_type>::getHashValue(Val.Id);

--- a/llvm/include/llvm/ExecutionEngine/Orc/SymbolStringPool.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/SymbolStringPool.h
@@ -333,10 +333,6 @@ struct DenseMapInfo<orc::SymbolStringPtr> {
     return orc::SymbolStringPtr::getEmptyVal();
   }
 
-  static orc::SymbolStringPtr getTombstoneKey() {
-    return orc::SymbolStringPtr::getTombstoneVal();
-  }
-
   static unsigned getHashValue(const orc::SymbolStringPtrBase &V) {
     return DenseMapInfo<orc::SymbolStringPtr::PoolEntryPtr>::getHashValue(V.S);
   }
@@ -351,10 +347,6 @@ template <> struct DenseMapInfo<orc::NonOwningSymbolStringPtr> {
 
   static orc::NonOwningSymbolStringPtr getEmptyKey() {
     return orc::NonOwningSymbolStringPtr::getEmptyVal();
-  }
-
-  static orc::NonOwningSymbolStringPtr getTombstoneKey() {
-    return orc::NonOwningSymbolStringPtr::getTombstoneVal();
   }
 
   static unsigned getHashValue(const orc::SymbolStringPtrBase &V) {

--- a/llvm/include/llvm/Frontend/OpenMP/OMPContext.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPContext.h
@@ -205,9 +205,6 @@ template <> struct DenseMapInfo<omp::TraitProperty> {
   static inline omp::TraitProperty getEmptyKey() {
     return omp::TraitProperty(-1);
   }
-  static inline omp::TraitProperty getTombstoneKey() {
-    return omp::TraitProperty(-2);
-  }
   static unsigned getHashValue(omp::TraitProperty val) {
     return std::hash<unsigned>{}(unsigned(val));
   }

--- a/llvm/include/llvm/IR/Attributes.h
+++ b/llvm/include/llvm/IR/Attributes.h
@@ -532,12 +532,6 @@ template <> struct DenseMapInfo<AttributeSet, void> {
     return AttributeSet(reinterpret_cast<AttributeSetNode *>(Val));
   }
 
-  static AttributeSet getTombstoneKey() {
-    auto Val = static_cast<uintptr_t>(-2);
-    Val <<= PointerLikeTypeTraits<void *>::NumLowBitsAvailable;
-    return AttributeSet(reinterpret_cast<AttributeSetNode *>(Val));
-  }
-
   static unsigned getHashValue(AttributeSet AS) {
     return (unsigned((uintptr_t)AS.SetNode) >> 4) ^
            (unsigned((uintptr_t)AS.SetNode) >> 9);
@@ -1103,12 +1097,6 @@ public:
 template <> struct DenseMapInfo<AttributeList, void> {
   static AttributeList getEmptyKey() {
     auto Val = static_cast<uintptr_t>(-1);
-    Val <<= PointerLikeTypeTraits<void*>::NumLowBitsAvailable;
-    return AttributeList(reinterpret_cast<AttributeListImpl *>(Val));
-  }
-
-  static AttributeList getTombstoneKey() {
-    auto Val = static_cast<uintptr_t>(-2);
     Val <<= PointerLikeTypeTraits<void*>::NumLowBitsAvailable;
     return AttributeList(reinterpret_cast<AttributeListImpl *>(Val));
   }

--- a/llvm/include/llvm/IR/BasicBlock.h
+++ b/llvm/include/llvm/IR/BasicBlock.h
@@ -771,12 +771,6 @@ template <> struct DenseMapInfo<BasicBlock::iterator> {
     return BasicBlock::iterator(nullptr);
   }
 
-  static inline BasicBlock::iterator getTombstoneKey() {
-    BasicBlock::iterator It(nullptr);
-    It.setHeadBit(true);
-    return It;
-  }
-
   static unsigned getHashValue(const BasicBlock::iterator &It) {
     return DenseMapInfo<void *>::getHashValue(
                reinterpret_cast<void *>(It.getNodePtr())) ^

--- a/llvm/include/llvm/IR/DebugInfo.h
+++ b/llvm/include/llvm/IR/DebugInfo.h
@@ -265,11 +265,6 @@ template <> struct DenseMapInfo<at::VarRecord> {
                          DenseMapInfo<DILocation *>::getEmptyKey());
   }
 
-  static inline at::VarRecord getTombstoneKey() {
-    return at::VarRecord(DenseMapInfo<DILocalVariable *>::getTombstoneKey(),
-                         DenseMapInfo<DILocation *>::getTombstoneKey());
-  }
-
   static unsigned getHashValue(const at::VarRecord &Var) {
     return hash_combine(Var.Var, Var.DL);
   }

--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -3925,8 +3925,6 @@ template <> struct DenseMapInfo<DIExpression::FragmentInfo> {
 
   static inline FragInfo getEmptyKey() { return {MaxVal, MaxVal}; }
 
-  static inline FragInfo getTombstoneKey() { return {MaxVal - 1, MaxVal - 1}; }
-
   static unsigned getHashValue(const FragInfo &Frag) {
     return (Frag.SizeInBits & 0xffff) << 16 | (Frag.OffsetInBits & 0xffff);
   }
@@ -4798,11 +4796,6 @@ template <> struct DenseMapInfo<DebugVariable> {
   /// Empty key: no key should be generated that has no DILocalVariable.
   static inline DebugVariable getEmptyKey() {
     return DebugVariable(nullptr, std::nullopt, nullptr);
-  }
-
-  /// Difference in tombstone is that the Optional is meaningful.
-  static inline DebugVariable getTombstoneKey() {
-    return DebugVariable(nullptr, {{0, 0}}, nullptr);
   }
 
   static unsigned getHashValue(const DebugVariable &D) {

--- a/llvm/include/llvm/IR/Dominators.h
+++ b/llvm/include/llvm/IR/Dominators.h
@@ -123,10 +123,6 @@ template <> struct DenseMapInfo<BasicBlockEdge> {
     return BasicBlockEdge(BBInfo::getEmptyKey(), BBInfo::getEmptyKey());
   }
 
-  static inline BasicBlockEdge getTombstoneKey() {
-    return BasicBlockEdge(BBInfo::getTombstoneKey(), BBInfo::getTombstoneKey());
-  }
-
   static unsigned getHashValue(const BasicBlockEdge &Edge) {
     return hash_combine(BBInfo::getHashValue(Edge.getStart()),
                         BBInfo::getHashValue(Edge.getEnd()));

--- a/llvm/include/llvm/IR/Metadata.h
+++ b/llvm/include/llvm/IR/Metadata.h
@@ -874,11 +874,6 @@ struct DenseMapInfo<AAMDNodes> {
                      nullptr, nullptr);
   }
 
-  static inline AAMDNodes getTombstoneKey() {
-    return AAMDNodes(DenseMapInfo<MDNode *>::getTombstoneKey(), nullptr,
-                     nullptr, nullptr, nullptr);
-  }
-
   static unsigned getHashValue(const AAMDNodes &Val) {
     return DenseMapInfo<MDNode *>::getHashValue(Val.TBAA) ^
            DenseMapInfo<MDNode *>::getHashValue(Val.TBAAStruct) ^

--- a/llvm/include/llvm/IR/ModuleSummaryIndex.h
+++ b/llvm/include/llvm/IR/ModuleSummaryIndex.h
@@ -304,13 +304,7 @@ template <> struct DenseMapInfo<ValueInfo> {
     return ValueInfo(false, (GlobalValueSummaryMapTy::value_type *)-8);
   }
 
-  static inline ValueInfo getTombstoneKey() {
-    return ValueInfo(false, (GlobalValueSummaryMapTy::value_type *)-16);
-  }
-
-  static inline bool isSpecialKey(ValueInfo V) {
-    return V == getTombstoneKey() || V == getEmptyKey();
-  }
+  static inline bool isSpecialKey(ValueInfo V) { return V == getEmptyKey(); }
 
   static bool isEqual(ValueInfo L, ValueInfo R) {
     // We are not supposed to mix ValueInfo(s) with different HaveGVs flag
@@ -1132,10 +1126,6 @@ public:
 template <> struct DenseMapInfo<FunctionSummary::VFuncId> {
   static FunctionSummary::VFuncId getEmptyKey() { return {0, uint64_t(-1)}; }
 
-  static FunctionSummary::VFuncId getTombstoneKey() {
-    return {0, uint64_t(-2)};
-  }
-
   static bool isEqual(FunctionSummary::VFuncId L, FunctionSummary::VFuncId R) {
     return L.GUID == R.GUID && L.Offset == R.Offset;
   }
@@ -1146,10 +1136,6 @@ template <> struct DenseMapInfo<FunctionSummary::VFuncId> {
 template <> struct DenseMapInfo<FunctionSummary::ConstVCall> {
   static FunctionSummary::ConstVCall getEmptyKey() {
     return {{0, uint64_t(-1)}, {}};
-  }
-
-  static FunctionSummary::ConstVCall getTombstoneKey() {
-    return {{0, uint64_t(-2)}, {}};
   }
 
   static bool isEqual(FunctionSummary::ConstVCall L,

--- a/llvm/include/llvm/IR/ValueHandle.h
+++ b/llvm/include/llvm/IR/ValueHandle.h
@@ -130,9 +130,7 @@ protected:
   Value *getValPtr() const { return Val; }
 
   static bool isValid(Value *V) {
-    return V &&
-           V != DenseMapInfo<Value *>::getEmptyKey() &&
-           V != DenseMapInfo<Value *>::getTombstoneKey();
+    return V && V != DenseMapInfo<Value *>::getEmptyKey();
   }
 
   /// Remove this ValueHandle from its current use list.
@@ -210,10 +208,6 @@ template <> struct simplify_type<const WeakVH> {
 template <> struct DenseMapInfo<WeakVH> {
   static inline WeakVH getEmptyKey() {
     return WeakVH(DenseMapInfo<Value *>::getEmptyKey());
-  }
-
-  static inline WeakVH getTombstoneKey() {
-    return WeakVH(DenseMapInfo<Value *>::getTombstoneKey());
   }
 
   static unsigned getHashValue(const WeakVH &Val) {
@@ -585,12 +579,6 @@ template <typename T> struct DenseMapInfo<PoisoningVH<T>> {
   static inline PoisoningVH<T> getEmptyKey() {
     PoisoningVH<T> Res;
     Res.setRawValPtr(DenseMapInfo<Value *>::getEmptyKey());
-    return Res;
-  }
-
-  static inline PoisoningVH<T> getTombstoneKey() {
-    PoisoningVH<T> Res;
-    Res.setRawValPtr(DenseMapInfo<Value *>::getTombstoneKey());
     return Res;
   }
 

--- a/llvm/include/llvm/IR/ValueMap.h
+++ b/llvm/include/llvm/IR/ValueMap.h
@@ -245,7 +245,7 @@ class ValueMapCallbackVH final : public CallbackVH {
       : CallbackVH(const_cast<Value *>(static_cast<const Value *>(Key))),
         Map(Map) {}
 
-  // Private constructor used to create empty/tombstone DenseMap keys.
+  // Private constructor used to create empty DenseMap keys.
   ValueMapCallbackVH(Value *V) : CallbackVH(V), Map(nullptr) {}
 
 public:
@@ -294,10 +294,6 @@ struct DenseMapInfo<ValueMapCallbackVH<KeyT, ValueT, Config>> {
 
   static inline VH getEmptyKey() {
     return VH(DenseMapInfo<Value *>::getEmptyKey());
-  }
-
-  static inline VH getTombstoneKey() {
-    return VH(DenseMapInfo<Value *>::getTombstoneKey());
   }
 
   static unsigned getHashValue(const VH &Val) {

--- a/llvm/include/llvm/Linker/IRMover.h
+++ b/llvm/include/llvm/Linker/IRMover.h
@@ -39,7 +39,6 @@ class IRMover {
       LLVM_ABI bool operator!=(const KeyTy &that) const;
     };
     LLVM_ABI static StructType *getEmptyKey();
-    LLVM_ABI static StructType *getTombstoneKey();
     LLVM_ABI static unsigned getHashValue(const KeyTy &Key);
     LLVM_ABI static unsigned getHashValue(const StructType *ST);
     LLVM_ABI static bool isEqual(const KeyTy &LHS, const StructType *RHS);

--- a/llvm/include/llvm/MC/MCRegister.h
+++ b/llvm/include/llvm/MC/MCRegister.h
@@ -112,9 +112,6 @@ template <> struct DenseMapInfo<MCRegister> {
   static inline MCRegister getEmptyKey() {
     return DenseMapInfo<unsigned>::getEmptyKey();
   }
-  static inline MCRegister getTombstoneKey() {
-    return DenseMapInfo<unsigned>::getTombstoneKey();
-  }
   static unsigned getHashValue(const MCRegister &Val) {
     return DenseMapInfo<unsigned>::getHashValue(Val.id());
   }

--- a/llvm/include/llvm/Object/ObjectFile.h
+++ b/llvm/include/llvm/Object/ObjectFile.h
@@ -656,11 +656,6 @@ template <> struct DenseMapInfo<object::SectionRef> {
   static object::SectionRef getEmptyKey() {
     return object::SectionRef({}, nullptr);
   }
-  static object::SectionRef getTombstoneKey() {
-    object::DataRefImpl TS;
-    TS.p = (uintptr_t)-1;
-    return object::SectionRef(TS, nullptr);
-  }
   static unsigned getHashValue(const object::SectionRef &Sec) {
     object::DataRefImpl Raw = Sec.getRawDataRefImpl();
     return hash_combine(Raw.p, Raw.d.a, Raw.d.b);

--- a/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
+++ b/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
@@ -1534,14 +1534,6 @@ template<> struct DenseMapInfo<coverage::CounterExpression> {
                              Counter::getCounter(~0U));
   }
 
-  static inline coverage::CounterExpression getTombstoneKey() {
-    using namespace coverage;
-
-    return CounterExpression(CounterExpression::ExprKind::Add,
-                             Counter::getCounter(~0U),
-                             Counter::getCounter(~0U));
-  }
-
   static unsigned getHashValue(const coverage::CounterExpression &V) {
     return static_cast<unsigned>(
         hash_combine(V.Kind, V.LHS.getKind(), V.LHS.getCounterID(),

--- a/llvm/include/llvm/ProfileData/FunctionId.h
+++ b/llvm/include/llvm/ProfileData/FunctionId.h
@@ -182,10 +182,6 @@ template <> struct DenseMapInfo<sampleprof::FunctionId, void> {
     return sampleprof::FunctionId(~0ULL);
   }
 
-  static inline sampleprof::FunctionId getTombstoneKey() {
-    return sampleprof::FunctionId(~1ULL);
-  }
-
   static unsigned getHashValue(const sampleprof::FunctionId &Val) {
     return Val.getHashCode();
   }

--- a/llvm/include/llvm/ProfileData/SampleProf.h
+++ b/llvm/include/llvm/ProfileData/SampleProf.h
@@ -1706,10 +1706,6 @@ using namespace sampleprof;
 template <> struct DenseMapInfo<SampleContext> {
   static inline SampleContext getEmptyKey() { return SampleContext(); }
 
-  static inline SampleContext getTombstoneKey() {
-    return SampleContext(FunctionId(~1ULL));
-  }
-
   static unsigned getHashValue(const SampleContext &Val) {
     return Val.getHashCode();
   }

--- a/llvm/include/llvm/SandboxIR/Context.h
+++ b/llvm/include/llvm/SandboxIR/Context.h
@@ -321,9 +321,6 @@ template <> struct DenseMapInfo<sandboxir::Context::CallbackID> {
   static CallbackID getEmptyKey() {
     return CallbackID{ReprInfo::getEmptyKey()};
   }
-  static CallbackID getTombstoneKey() {
-    return CallbackID{ReprInfo::getTombstoneKey()};
-  }
   static unsigned getHashValue(const CallbackID &ID) {
     return ReprInfo::getHashValue(ID.Val);
   }

--- a/llvm/include/llvm/Support/FileSystem/UniqueID.h
+++ b/llvm/include/llvm/Support/FileSystem/UniqueID.h
@@ -58,12 +58,6 @@ template <> struct DenseMapInfo<llvm::sys::fs::UniqueID> {
     return {EmptyKey.first, EmptyKey.second};
   }
 
-  static inline llvm::sys::fs::UniqueID getTombstoneKey() {
-    auto TombstoneKey =
-        DenseMapInfo<std::pair<uint64_t, uint64_t>>::getTombstoneKey();
-    return {TombstoneKey.first, TombstoneKey.second};
-  }
-
   static hash_code getHashValue(const llvm::sys::fs::UniqueID &Tag) {
     return hash_value(std::make_pair(Tag.getDevice(), Tag.getFile()));
   }

--- a/llvm/include/llvm/Support/TypeSize.h
+++ b/llvm/include/llvm/Support/TypeSize.h
@@ -434,9 +434,6 @@ template <> struct DenseMapInfo<ElementCount, void> {
   static inline ElementCount getEmptyKey() {
     return ElementCount::getScalable(~0U);
   }
-  static inline ElementCount getTombstoneKey() {
-    return ElementCount::getFixed(~0U - 1);
-  }
   static unsigned getHashValue(const ElementCount &EltCnt) {
     unsigned HashVal = EltCnt.getKnownMinValue() * 37U;
     if (EltCnt.isScalable())

--- a/llvm/include/llvm/Support/UniqueBBID.h
+++ b/llvm/include/llvm/Support/UniqueBBID.h
@@ -49,11 +49,6 @@ template <> struct DenseMapInfo<UniqueBBID> {
     return UniqueBBID{EmptyKey, EmptyKey};
   }
 
-  static inline UniqueBBID getTombstoneKey() {
-    unsigned TombstoneKey = DenseMapInfo<unsigned>::getTombstoneKey();
-    return UniqueBBID{TombstoneKey, TombstoneKey};
-  }
-
   static unsigned getHashValue(const UniqueBBID &Val) {
     return DenseMapInfo<unsigned>::getHashValue(Val.BaseID) ^
            DenseMapInfo<unsigned>::getHashValue(Val.CloneID);

--- a/llvm/include/llvm/Support/VersionTuple.h
+++ b/llvm/include/llvm/Support/VersionTuple.h
@@ -216,9 +216,6 @@ LLVM_ABI raw_ostream &operator<<(raw_ostream &Out, const VersionTuple &V);
 // Provide DenseMapInfo for version tuples.
 template <> struct DenseMapInfo<VersionTuple> {
   static inline VersionTuple getEmptyKey() { return VersionTuple(0x7FFFFFFF); }
-  static inline VersionTuple getTombstoneKey() {
-    return VersionTuple(0x7FFFFFFE);
-  }
   static unsigned getHashValue(const VersionTuple &Value) {
     unsigned Result = Value.getMajor();
     if (auto Minor = Value.getMinor())

--- a/llvm/include/llvm/TextAPI/SymbolSet.h
+++ b/llvm/include/llvm/TextAPI/SymbolSet.h
@@ -35,11 +35,6 @@ template <> struct DenseMapInfo<SymbolsMapKey> {
     return SymbolsMapKey(MachO::EncodeKind::GlobalSymbol, StringRef{});
   }
 
-  static inline SymbolsMapKey getTombstoneKey() {
-    return SymbolsMapKey(MachO::EncodeKind::ObjectiveCInstanceVariable,
-                         StringRef{});
-  }
-
   static unsigned getHashValue(const SymbolsMapKey &Key) {
     return hash_combine(hash_value(Key.Kind), hash_value(Key.Name));
   }

--- a/llvm/include/llvm/Transforms/IPO/Attributor.h
+++ b/llvm/include/llvm/Transforms/IPO/Attributor.h
@@ -325,7 +325,7 @@ struct RangeTy {
   /// Constants used to represent special offsets or sizes.
   /// - We cannot assume that Offsets and Size are non-negative.
   /// - The constants should not clash with DenseMapInfo, such as EmptyKey
-  ///   (INT64_MAX) and TombstoneKey (INT64_MIN).
+  ///   (INT64_MAX).
   /// We use values "in the middle" of the 64 bit range to represent these
   /// special cases.
   static constexpr int64_t Unassigned = std::numeric_limits<int32_t>::min();
@@ -434,9 +434,6 @@ struct DenseMapInfo<AA::ValueAndContext>
   static inline AA::ValueAndContext getEmptyKey() {
     return Base::getEmptyKey();
   }
-  static inline AA::ValueAndContext getTombstoneKey() {
-    return Base::getTombstoneKey();
-  }
   static unsigned getHashValue(const AA::ValueAndContext &VAC) {
     return Base::getHashValue(VAC);
   }
@@ -452,9 +449,6 @@ struct DenseMapInfo<AA::ValueScope> : public DenseMapInfo<unsigned char> {
   using Base = DenseMapInfo<unsigned char>;
   static inline AA::ValueScope getEmptyKey() {
     return AA::ValueScope(Base::getEmptyKey());
-  }
-  static inline AA::ValueScope getTombstoneKey() {
-    return AA::ValueScope(Base::getTombstoneKey());
   }
   static unsigned getHashValue(const AA::ValueScope &S) {
     return Base::getHashValue(S);
@@ -472,10 +466,6 @@ struct DenseMapInfo<const AA::InstExclusionSetTy *>
   static inline const AA::InstExclusionSetTy *getEmptyKey() {
     return static_cast<const AA::InstExclusionSetTy *>(super::getEmptyKey());
   }
-  static inline const AA::InstExclusionSetTy *getTombstoneKey() {
-    return static_cast<const AA::InstExclusionSetTy *>(
-        super::getTombstoneKey());
-  }
   static unsigned getHashValue(const AA::InstExclusionSetTy *BES) {
     unsigned H = 0;
     if (BES)
@@ -487,8 +477,7 @@ struct DenseMapInfo<const AA::InstExclusionSetTy *>
                       const AA::InstExclusionSetTy *RHS) {
     if (LHS == RHS)
       return true;
-    if (LHS == getEmptyKey() || RHS == getEmptyKey() ||
-        LHS == getTombstoneKey() || RHS == getTombstoneKey())
+    if (LHS == getEmptyKey() || RHS == getEmptyKey())
       return false;
     auto SizeLHS = LHS ? LHS->size() : 0;
     auto SizeRHS = RHS ? RHS->size() : 0;
@@ -957,7 +946,6 @@ struct IRPosition {
   ///
   ///{
   LLVM_ABI static const IRPosition EmptyKey;
-  LLVM_ABI static const IRPosition TombstoneKey;
   ///}
 
   /// Conversion into a void * to allow reuse of pointer hashing.
@@ -1095,9 +1083,6 @@ private:
 /// Helper that allows IRPosition as a key in a DenseMap.
 template <> struct DenseMapInfo<IRPosition> {
   static inline IRPosition getEmptyKey() { return IRPosition::EmptyKey; }
-  static inline IRPosition getTombstoneKey() {
-    return IRPosition::TombstoneKey;
-  }
   static unsigned getHashValue(const IRPosition &IRP) {
     return (DenseMapInfo<void *>::getHashValue(IRP) << 4) ^
            (DenseMapInfo<Value *>::getHashValue(IRP.getCallBaseContext()));

--- a/llvm/include/llvm/Transforms/IPO/FunctionSpecialization.h
+++ b/llvm/include/llvm/Transforms/IPO/FunctionSpecialization.h
@@ -108,8 +108,7 @@ using ConstMap = DenseMap<Value *, Constant *>;
 // Specialization signature, used to uniquely designate a specialization within
 // a function.
 struct SpecSig {
-  // Hashing support, used to distinguish between ordinary, empty, or tombstone
-  // keys.
+  // Hashing support, used to distinguish between ordinary and empty keys.
   unsigned Key = 0;
   SmallVector<ArgInfo, 4> Args;
 

--- a/llvm/include/llvm/Transforms/IPO/IROutliner.h
+++ b/llvm/include/llvm/Transforms/IPO/IROutliner.h
@@ -207,8 +207,6 @@ public:
     // Check that the DenseMap implementation has not changed.
     static_assert(DenseMapInfo<unsigned>::getEmptyKey() ==
                   static_cast<unsigned>(-1));
-    static_assert(DenseMapInfo<unsigned>::getTombstoneKey() ==
-                  static_cast<unsigned>(-2));
   }
   LLVM_ABI bool run(Module &M);
 

--- a/llvm/include/llvm/Transforms/Scalar/GVNExpression.h
+++ b/llvm/include/llvm/Transforms/Scalar/GVNExpression.h
@@ -71,13 +71,12 @@ public:
   virtual ~Expression();
 
   static unsigned getEmptyKey() { return ~0U; }
-  static unsigned getTombstoneKey() { return ~1U; }
 
   bool operator!=(const Expression &Other) const { return !(*this == Other); }
   bool operator==(const Expression &Other) const {
     if (getOpcode() != Other.getOpcode())
       return false;
-    if (getOpcode() == getEmptyKey() || getOpcode() == getTombstoneKey())
+    if (getOpcode() == getEmptyKey())
       return true;
     // Compare the expression type for anything but load and store.
     // For load and store we set the opcode to zero to make them equal.

--- a/llvm/include/llvm/Transforms/Utils/BypassSlowDivision.h
+++ b/llvm/include/llvm/Transforms/Utils/BypassSlowDivision.h
@@ -50,10 +50,6 @@ template <> struct DenseMapInfo<DivRemMapKey> {
     return DivRemMapKey(false, nullptr, nullptr);
   }
 
-  static DivRemMapKey getTombstoneKey() {
-    return DivRemMapKey(true, nullptr, nullptr);
-  }
-
   static unsigned getHashValue(const DivRemMapKey &Val) {
     return (unsigned)(reinterpret_cast<uintptr_t>(
                           static_cast<Value *>(Val.Dividend)) ^

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/VecUtils.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/VecUtils.h
@@ -25,9 +25,6 @@ template <> struct DenseMapInfo<SmallVector<sandboxir::Value *>> {
   static inline SmallVector<sandboxir::Value *> getEmptyKey() {
     return SmallVector<sandboxir::Value *>({(sandboxir::Value *)-1});
   }
-  static inline SmallVector<sandboxir::Value *> getTombstoneKey() {
-    return SmallVector<sandboxir::Value *>({(sandboxir::Value *)-2});
-  }
   static unsigned getHashValue(const SmallVector<sandboxir::Value *> &Vec) {
     return hash_combine_range(Vec);
   }

--- a/llvm/lib/Analysis/IRSimilarityIdentifier.cpp
+++ b/llvm/lib/Analysis/IRSimilarityIdentifier.cpp
@@ -360,9 +360,7 @@ unsigned IRInstructionMapper::mapToLegalUnsigned(
          "Instruction mapping overflow!");
 
   assert(LegalInstrNumber != DenseMapInfo<unsigned>::getEmptyKey() &&
-         "Tried to assign DenseMap tombstone or empty key to instruction.");
-  assert(LegalInstrNumber != DenseMapInfo<unsigned>::getTombstoneKey() &&
-         "Tried to assign DenseMap tombstone or empty key to instruction.");
+         "Tried to assign DenseMap empty key to instruction.");
 
   return INumber;
 }
@@ -411,10 +409,7 @@ unsigned IRInstructionMapper::mapToIllegalUnsigned(
          "Instruction mapping overflow!");
 
   assert(IllegalInstrNumber != DenseMapInfo<unsigned>::getEmptyKey() &&
-         "IllegalInstrNumber cannot be DenseMap tombstone or empty key!");
-
-  assert(IllegalInstrNumber != DenseMapInfo<unsigned>::getTombstoneKey() &&
-         "IllegalInstrNumber cannot be DenseMap tombstone or empty key!");
+         "IllegalInstrNumber cannot be DenseMap empty key!");
 
   return INumber;
 }

--- a/llvm/lib/Analysis/MemorySSA.cpp
+++ b/llvm/lib/Analysis/MemorySSA.cpp
@@ -221,10 +221,6 @@ template <> struct DenseMapInfo<MemoryLocOrCall> {
     return MemoryLocOrCall(DenseMapInfo<MemoryLocation>::getEmptyKey());
   }
 
-  static inline MemoryLocOrCall getTombstoneKey() {
-    return MemoryLocOrCall(DenseMapInfo<MemoryLocation>::getTombstoneKey());
-  }
-
   static unsigned getHashValue(const MemoryLocOrCall &MLOC) {
     if (!MLOC.IsCall)
       return hash_combine(

--- a/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.h
+++ b/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.h
@@ -85,13 +85,6 @@ public:
       return V;
     }
 
-    static LocalVarDef tombstoneValue() {
-      LocalVarDef V;
-      std::memset(&V, 0xff, sizeof(LocalVarDef));
-      V.InMemory = 0;
-      return V;
-    }
-
     unsigned hashValue() const {
       uint64_t H = 0;
       std::memcpy(&H, this, sizeof(uint64_t));
@@ -557,10 +550,6 @@ template <> struct DenseMapInfo<CodeViewDebug::LocalVarDef> {
 
   static inline CodeViewDebug::LocalVarDef getEmptyKey() {
     return CodeViewDebug::LocalVarDef::emptyValue();
-  }
-
-  static inline CodeViewDebug::LocalVarDef getTombstoneKey() {
-    return CodeViewDebug::LocalVarDef::tombstoneValue();
   }
 
   static unsigned getHashValue(const CodeViewDebug::LocalVarDef &DR) {

--- a/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
+++ b/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
@@ -73,9 +73,6 @@ template <> struct llvm::DenseMapInfo<VariableID> {
   static inline VariableID getEmptyKey() {
     return static_cast<VariableID>(Wrapped::getEmptyKey());
   }
-  static inline VariableID getTombstoneKey() {
-    return static_cast<VariableID>(Wrapped::getTombstoneKey());
-  }
   static unsigned getHashValue(const VariableID &Val) {
     return Wrapped::getHashValue(static_cast<unsigned>(Val));
   }

--- a/llvm/lib/CodeGen/ComplexDeinterleavingPass.cpp
+++ b/llvm/lib/CodeGen/ComplexDeinterleavingPass.cpp
@@ -131,10 +131,6 @@ template <> struct llvm::DenseMapInfo<ComplexValue> {
     return {DenseMapInfo<Value *>::getEmptyKey(),
             DenseMapInfo<Value *>::getEmptyKey()};
   }
-  static inline ComplexValue getTombstoneKey() {
-    return {DenseMapInfo<Value *>::getTombstoneKey(),
-            DenseMapInfo<Value *>::getTombstoneKey()};
-  }
   static unsigned getHashValue(const ComplexValue &Val) {
     return hash_combine(DenseMapInfo<Value *>::getHashValue(Val.Real),
                         DenseMapInfo<Value *>::getHashValue(Val.Imag));

--- a/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.cpp
+++ b/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.cpp
@@ -983,7 +983,6 @@ public:
 //===----------------------------------------------------------------------===//
 
 ValueIDNum ValueIDNum::EmptyValue = {UINT_MAX, UINT_MAX, UINT_MAX};
-ValueIDNum ValueIDNum::TombstoneValue = {UINT_MAX, UINT_MAX, UINT_MAX - 1};
 
 #ifndef NDEBUG
 void ResolvedDbgOp::dump(const MLocTracker *MTrack) const {

--- a/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.h
+++ b/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.h
@@ -93,11 +93,6 @@ public:
   }
 
   static LocIdx MakeIllegalLoc() { return LocIdx(); }
-  static LocIdx MakeTombstoneLoc() {
-    LocIdx L = LocIdx();
-    --L.Location;
-    return L;
-  }
 
   bool isIllegal() const { return Location == UINT_MAX; }
 
@@ -206,7 +201,6 @@ public:
   }
 
   LLVM_ABI_FOR_TEST static ValueIDNum EmptyValue;
-  LLVM_ABI_FOR_TEST static ValueIDNum TombstoneValue;
 };
 
 } // End namespace LiveDebugValues
@@ -216,7 +210,6 @@ using namespace LiveDebugValues;
 
 template <> struct DenseMapInfo<LocIdx> {
   static inline LocIdx getEmptyKey() { return LocIdx::MakeIllegalLoc(); }
-  static inline LocIdx getTombstoneKey() { return LocIdx::MakeTombstoneLoc(); }
 
   static unsigned getHashValue(const LocIdx &Loc) { return Loc.asU64(); }
 
@@ -225,9 +218,6 @@ template <> struct DenseMapInfo<LocIdx> {
 
 template <> struct DenseMapInfo<ValueIDNum> {
   static inline ValueIDNum getEmptyKey() { return ValueIDNum::EmptyValue; }
-  static inline ValueIDNum getTombstoneKey() {
-    return ValueIDNum::TombstoneValue;
-  }
 
   static unsigned getHashValue(const ValueIDNum &Val) {
     return hash_value(Val.asU64());

--- a/llvm/lib/CodeGen/MachineOutliner.cpp
+++ b/llvm/lib/CodeGen/MachineOutliner.cpp
@@ -245,9 +245,7 @@ struct InstructionMapper {
       report_fatal_error("Instruction mapping overflow!");
 
     assert(LegalInstrNumber != DenseMapInfo<unsigned>::getEmptyKey() &&
-           "Tried to assign DenseMap tombstone or empty key to instruction.");
-    assert(LegalInstrNumber != DenseMapInfo<unsigned>::getTombstoneKey() &&
-           "Tried to assign DenseMap tombstone or empty key to instruction.");
+           "Tried to assign DenseMap empty key to instruction.");
 
     // Statistics.
     ++NumLegalInUnsignedVec;
@@ -285,10 +283,7 @@ struct InstructionMapper {
            "Instruction mapping overflow!");
 
     assert(IllegalInstrNumber != DenseMapInfo<unsigned>::getEmptyKey() &&
-           "IllegalInstrNumber cannot be DenseMap tombstone or empty key!");
-
-    assert(IllegalInstrNumber != DenseMapInfo<unsigned>::getTombstoneKey() &&
-           "IllegalInstrNumber cannot be DenseMap tombstone or empty key!");
+           "IllegalInstrNumber cannot be DenseMap empty key!");
 
     return MINumber;
   }
@@ -423,8 +418,6 @@ struct InstructionMapper {
     // changed.
     static_assert(DenseMapInfo<unsigned>::getEmptyKey() ==
                   static_cast<unsigned>(-1));
-    static_assert(DenseMapInfo<unsigned>::getTombstoneKey() ==
-                  static_cast<unsigned>(-2));
   }
 };
 

--- a/llvm/lib/CodeGen/StackMaps.cpp
+++ b/llvm/lib/CodeGen/StackMaps.cpp
@@ -242,13 +242,11 @@ StackMaps::parseOperand(MachineInstr::const_mop_iterator MOI,
       } else {
         // ConstPool is intentionally a MapVector of 'uint64_t's (as
         // opposed to 'int64_t's).  We should never be in a situation
-        // where we have to insert either the tombstone or the empty
-        // keys into a map, and for a DenseMap<uint64_t, T> these are
-        // (uint64_t)0 and (uint64_t)-1.  They can be and are
+        // where we have to insert the empty key into a map, and for a
+        // DenseMap<uint64_t, T> this is (uint64_t)-1.  It can be and is
         // represented using 32 bit integers.
         assert((uint64_t)Imm != DenseMapInfo<uint64_t>::getEmptyKey() &&
-               (uint64_t)Imm != DenseMapInfo<uint64_t>::getTombstoneKey() &&
-               "empty and tombstone keys should fit in 32 bits!");
+               "empty key should fit in 32 bits!");
         auto Result = ConstPool.insert(std::make_pair(Imm, Imm));
         Locs.emplace_back(Location::ConstantIndex, sizeof(int64_t), 0,
                           Result.first - ConstPool.begin());

--- a/llvm/lib/DebugInfo/CodeView/TypeHashing.cpp
+++ b/llvm/lib/DebugInfo/CodeView/TypeHashing.cpp
@@ -15,15 +15,11 @@ using namespace llvm;
 using namespace llvm::codeview;
 
 LocallyHashedType DenseMapInfo<LocallyHashedType>::Empty{0, {}};
-LocallyHashedType DenseMapInfo<LocallyHashedType>::Tombstone{hash_code(-1), {}};
 
 static std::array<uint8_t, 8> EmptyHash = {
     {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-static std::array<uint8_t, 8> TombstoneHash = {
-    {0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
 GloballyHashedType DenseMapInfo<GloballyHashedType>::Empty{EmptyHash};
-GloballyHashedType DenseMapInfo<GloballyHashedType>::Tombstone{TombstoneHash};
 
 LocallyHashedType LocallyHashedType::hashType(ArrayRef<uint8_t> RecordData) {
   return {llvm::hash_value(RecordData), RecordData};

--- a/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
@@ -516,10 +516,6 @@ DWARFDebugNames::Abbrev DWARFDebugNames::AbbrevMapInfo::getEmptyKey() {
   return sentinelAbbrev();
 }
 
-DWARFDebugNames::Abbrev DWARFDebugNames::AbbrevMapInfo::getTombstoneKey() {
-  return DWARFDebugNames::Abbrev(~0, dwarf::Tag(0), 0, {});
-}
-
 Expected<DWARFDebugNames::AttributeEncoding>
 DWARFDebugNames::NameIndex::extractAttributeEncoding(uint64_t *Offset) {
   if (*Offset >= Offsets.EntriesBase) {

--- a/llvm/lib/DebugInfo/PDB/Native/GSIStreamBuilder.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/GSIStreamBuilder.cpp
@@ -72,11 +72,6 @@ struct llvm::pdb::SymbolDenseMapInfo {
     static CVSymbol Empty;
     return Empty;
   }
-  static inline CVSymbol getTombstoneKey() {
-    static CVSymbol Tombstone(
-        DenseMapInfo<ArrayRef<uint8_t>>::getTombstoneKey());
-    return Tombstone;
-  }
   static unsigned getHashValue(const CVSymbol &Val) {
     return xxh3_64bits(Val.RecordData);
   }

--- a/llvm/lib/IR/ConstantsContext.h
+++ b/llvm/lib/IR/ConstantsContext.h
@@ -567,10 +567,6 @@ private:
       return ConstantClassInfo::getEmptyKey();
     }
 
-    static inline ConstantClass *getTombstoneKey() {
-      return ConstantClassInfo::getTombstoneKey();
-    }
-
     static unsigned getHashValue(const ConstantClass *CP) {
       SmallVector<Constant *, 32> Storage;
       return getHashValue(LookupKey(CP->getType(), ValType(CP, Storage)));
@@ -589,7 +585,7 @@ private:
     }
 
     static bool isEqual(const LookupKey &LHS, const ConstantClass *RHS) {
-      if (RHS == getEmptyKey() || RHS == getTombstoneKey())
+      if (RHS == getEmptyKey())
         return false;
       if (LHS.first != RHS->getType())
         return false;

--- a/llvm/lib/IR/LLVMContextImpl.h
+++ b/llvm/lib/IR/LLVMContextImpl.h
@@ -77,9 +77,6 @@ class ValueHandleBase;
 
 template <> struct DenseMapInfo<APFloat> {
   static inline APFloat getEmptyKey() { return APFloat(APFloat::Bogus(), 1); }
-  static inline APFloat getTombstoneKey() {
-    return APFloat(APFloat::Bogus(), 2);
-  }
 
   static unsigned getHashValue(const APFloat &Key) {
     return static_cast<unsigned>(hash_value(Key));
@@ -114,10 +111,6 @@ struct AnonStructTypeKeyInfo {
     return DenseMapInfo<StructType *>::getEmptyKey();
   }
 
-  static inline StructType *getTombstoneKey() {
-    return DenseMapInfo<StructType *>::getTombstoneKey();
-  }
-
   static unsigned getHashValue(const KeyTy &Key) {
     return hash_combine(hash_combine_range(Key.ETypes), Key.isPacked);
   }
@@ -127,7 +120,7 @@ struct AnonStructTypeKeyInfo {
   }
 
   static bool isEqual(const KeyTy &LHS, const StructType *RHS) {
-    if (RHS == getEmptyKey() || RHS == getTombstoneKey())
+    if (RHS == getEmptyKey())
       return false;
     return LHS == KeyTy(RHS);
   }
@@ -165,10 +158,6 @@ struct FunctionTypeKeyInfo {
     return DenseMapInfo<FunctionType *>::getEmptyKey();
   }
 
-  static inline FunctionType *getTombstoneKey() {
-    return DenseMapInfo<FunctionType *>::getTombstoneKey();
-  }
-
   static unsigned getHashValue(const KeyTy &Key) {
     return hash_combine(Key.ReturnType, hash_combine_range(Key.Params),
                         Key.isVarArg);
@@ -179,7 +168,7 @@ struct FunctionTypeKeyInfo {
   }
 
   static bool isEqual(const KeyTy &LHS, const FunctionType *RHS) {
-    if (RHS == getEmptyKey() || RHS == getTombstoneKey())
+    if (RHS == getEmptyKey())
       return false;
     return LHS == KeyTy(RHS);
   }
@@ -212,10 +201,6 @@ struct TargetExtTypeKeyInfo {
     return DenseMapInfo<TargetExtType *>::getEmptyKey();
   }
 
-  static inline TargetExtType *getTombstoneKey() {
-    return DenseMapInfo<TargetExtType *>::getTombstoneKey();
-  }
-
   static unsigned getHashValue(const KeyTy &Key) {
     return hash_combine(Key.Name, hash_combine_range(Key.TypeParams),
                         hash_combine_range(Key.IntParams));
@@ -226,7 +211,7 @@ struct TargetExtTypeKeyInfo {
   }
 
   static bool isEqual(const KeyTy &LHS, const TargetExtType *RHS) {
-    if (RHS == getEmptyKey() || RHS == getTombstoneKey())
+    if (RHS == getEmptyKey())
       return false;
     return LHS == KeyTy(RHS);
   }
@@ -1527,10 +1512,6 @@ struct DIArgListInfo {
     return DenseMapInfo<DIArgList *>::getEmptyKey();
   }
 
-  static inline DIArgList *getTombstoneKey() {
-    return DenseMapInfo<DIArgList *>::getTombstoneKey();
-  }
-
   static unsigned getHashValue(const KeyTy &Key) { return Key.getHashValue(); }
 
   static unsigned getHashValue(const DIArgList *N) {
@@ -1538,7 +1519,7 @@ struct DIArgListInfo {
   }
 
   static bool isEqual(const KeyTy &LHS, const DIArgList *RHS) {
-    if (RHS == getEmptyKey() || RHS == getTombstoneKey())
+    if (RHS == getEmptyKey())
       return false;
     return LHS.isKeyOf(RHS);
   }
@@ -1557,10 +1538,6 @@ template <class NodeTy> struct MDNodeInfo {
     return DenseMapInfo<NodeTy *>::getEmptyKey();
   }
 
-  static inline NodeTy *getTombstoneKey() {
-    return DenseMapInfo<NodeTy *>::getTombstoneKey();
-  }
-
   static unsigned getHashValue(const KeyTy &Key) { return Key.getHashValue(); }
 
   static unsigned getHashValue(const NodeTy *N) {
@@ -1568,7 +1545,7 @@ template <class NodeTy> struct MDNodeInfo {
   }
 
   static bool isEqual(const KeyTy &LHS, const NodeTy *RHS) {
-    if (RHS == getEmptyKey() || RHS == getTombstoneKey())
+    if (RHS == getEmptyKey())
       return false;
     return SubsetEqualTy::isSubsetEqual(LHS, RHS) || LHS.isKeyOf(RHS);
   }
@@ -1576,7 +1553,7 @@ template <class NodeTy> struct MDNodeInfo {
   static bool isEqual(const NodeTy *LHS, const NodeTy *RHS) {
     if (LHS == RHS)
       return true;
-    if (RHS == getEmptyKey() || RHS == getTombstoneKey())
+    if (RHS == getEmptyKey())
       return false;
     return SubsetEqualTy::isSubsetEqual(LHS, RHS);
   }

--- a/llvm/lib/Linker/IRMover.cpp
+++ b/llvm/lib/Linker/IRMover.cpp
@@ -1617,10 +1617,6 @@ StructType *IRMover::StructTypeKeyInfo::getEmptyKey() {
   return DenseMapInfo<StructType *>::getEmptyKey();
 }
 
-StructType *IRMover::StructTypeKeyInfo::getTombstoneKey() {
-  return DenseMapInfo<StructType *>::getTombstoneKey();
-}
-
 unsigned IRMover::StructTypeKeyInfo::getHashValue(const KeyTy &Key) {
   return hash_combine(hash_combine_range(Key.ETypes), Key.IsPacked);
 }
@@ -1631,14 +1627,14 @@ unsigned IRMover::StructTypeKeyInfo::getHashValue(const StructType *ST) {
 
 bool IRMover::StructTypeKeyInfo::isEqual(const KeyTy &LHS,
                                          const StructType *RHS) {
-  if (RHS == getEmptyKey() || RHS == getTombstoneKey())
+  if (RHS == getEmptyKey())
     return false;
   return LHS == KeyTy(RHS);
 }
 
 bool IRMover::StructTypeKeyInfo::isEqual(const StructType *LHS,
                                          const StructType *RHS) {
-  if (RHS == getEmptyKey() || RHS == getTombstoneKey())
+  if (RHS == getEmptyKey())
     return LHS == RHS;
   return KeyTy(LHS) == KeyTy(RHS);
 }

--- a/llvm/lib/Object/Minidump.cpp
+++ b/llvm/lib/Object/Minidump.cpp
@@ -129,8 +129,7 @@ MinidumpFile::create(MemoryBufferRef Source) {
       continue;
     }
 
-    if (Type == DenseMapInfo<StreamType>::getEmptyKey() ||
-        Type == DenseMapInfo<StreamType>::getTombstoneKey())
+    if (Type == DenseMapInfo<StreamType>::getEmptyKey())
       return createError("Cannot handle one of the minidump streams");
 
     // Update the directory map, checking for duplicate stream types.

--- a/llvm/lib/Support/StringRef.cpp
+++ b/llvm/lib/Support/StringRef.cpp
@@ -610,9 +610,6 @@ bool StringRef::getAsDouble(double &Result, bool AllowInexact) const {
 hash_code llvm::hash_value(StringRef S) { return hash_combine_range(S); }
 
 unsigned DenseMapInfo<StringRef, void>::getHashValue(StringRef Val) {
-  assert(Val.data() != getEmptyKey().data() &&
-         "Cannot hash the empty key!");
-  assert(Val.data() != getTombstoneKey().data() &&
-         "Cannot hash the tombstone key!");
+  assert(Val.data() != getEmptyKey().data() && "Cannot hash the empty key!");
   return (unsigned)(hash_value(Val));
 }

--- a/llvm/lib/Target/AArch64/AArch64StackTaggingPreRA.cpp
+++ b/llvm/lib/Target/AArch64/AArch64StackTaggingPreRA.cpp
@@ -232,7 +232,6 @@ struct SlotWithTag {
 namespace llvm {
 template <> struct DenseMapInfo<SlotWithTag> {
   static inline SlotWithTag getEmptyKey() { return {-2, -2}; }
-  static inline SlotWithTag getTombstoneKey() { return {-3, -3}; }
   static unsigned getHashValue(const SlotWithTag &V) {
     return hash_combine(DenseMapInfo<int>::getHashValue(V.FI),
                         DenseMapInfo<int>::getHashValue(V.Tag));

--- a/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
@@ -484,11 +484,6 @@ hasHazard(StateT InitialState,
                   DenseMapInfo<void *>::getEmptyKey()),
               DenseMapInfo<unsigned>::getEmptyKey()};
     }
-    static inline StateMapKey getTombstoneKey() {
-      return {static_cast<SmallVectorImpl<StateT> *>(
-                  DenseMapInfo<void *>::getTombstoneKey()),
-              DenseMapInfo<unsigned>::getTombstoneKey()};
-    }
     static unsigned getHashValue(const StateMapKey &Key) {
       return StateT::getHashValue((*Key.States)[Key.Idx]);
     }
@@ -497,15 +492,12 @@ hasHazard(StateT InitialState,
     }
     static bool isEqual(const StateMapKey &LHS, const StateMapKey &RHS) {
       const auto EKey = getEmptyKey();
-      const auto TKey = getTombstoneKey();
-      if (StateMapKey::isEqual(LHS, EKey) || StateMapKey::isEqual(RHS, EKey) ||
-          StateMapKey::isEqual(LHS, TKey) || StateMapKey::isEqual(RHS, TKey))
+      if (StateMapKey::isEqual(LHS, EKey) || StateMapKey::isEqual(RHS, EKey))
         return StateMapKey::isEqual(LHS, RHS);
       return StateT::isEqual((*LHS.States)[LHS.Idx], (*RHS.States)[RHS.Idx]);
     }
     static bool isEqual(const StateT &LHS, const StateMapKey &RHS) {
-      if (StateMapKey::isEqual(RHS, getEmptyKey()) ||
-          StateMapKey::isEqual(RHS, getTombstoneKey()))
+      if (StateMapKey::isEqual(RHS, getEmptyKey()))
         return false;
       return StateT::isEqual(LHS, (*RHS.States)[RHS.Idx]);
     }

--- a/llvm/lib/Target/CSKY/MCTargetDesc/CSKYTargetStreamer.h
+++ b/llvm/lib/Target/CSKY/MCTargetDesc/CSKYTargetStreamer.h
@@ -78,9 +78,6 @@ template <> struct DenseMapInfo<CSKYTargetStreamer::SymbolIndex> {
   static inline CSKYTargetStreamer::SymbolIndex getEmptyKey() {
     return {nullptr, CSKY::S_Invalid};
   }
-  static inline CSKYTargetStreamer::SymbolIndex getTombstoneKey() {
-    return {nullptr, CSKY::S_Invalid};
-  }
   static unsigned getHashValue(const CSKYTargetStreamer::SymbolIndex &V) {
     return hash_combine(DenseMapInfo<const MCSymbol *>::getHashValue(V.sym),
                         DenseMapInfo<int>::getHashValue(V.kind));

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -125,9 +125,6 @@ struct DenseMapInfo<std::pair<const MCSymbol *, PPCMCExpr::Specifier>> {
   using TOCKey = std::pair<const MCSymbol *, PPCMCExpr::Specifier>;
 
   static inline TOCKey getEmptyKey() { return {nullptr, PPC::S_None}; }
-  static inline TOCKey getTombstoneKey() {
-    return {(const MCSymbol *)1, PPC::S_None};
-  }
   static unsigned getHashValue(const TOCKey &PairVal) {
     return detail::combineHashValue(
         DenseMapInfo<const MCSymbol *>::getHashValue(PairVal.first),

--- a/llvm/lib/Target/SPIRV/SPIRVTypeInst.h
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeInst.h
@@ -64,9 +64,6 @@ template <> struct DenseMapInfo<SPIRVTypeInst> {
   static SPIRVTypeInst getEmptyKey() {
     return {MIInfo::getEmptyKey(), SPIRVTypeInst::UncheckedConstructor()};
   }
-  static SPIRVTypeInst getTombstoneKey() {
-    return {MIInfo::getTombstoneKey(), SPIRVTypeInst::UncheckedConstructor()};
-  }
   static unsigned getHashValue(SPIRVTypeInst Ty) {
     return MIInfo::getHashValue(Ty.MI);
   }

--- a/llvm/lib/Target/X86/X86OptimizeLEAs.cpp
+++ b/llvm/lib/Target/X86/X86OptimizeLEAs.cpp
@@ -124,18 +124,10 @@ template <> struct DenseMapInfo<MemOpKey> {
                     PtrInfo::getEmptyKey());
   }
 
-  static inline MemOpKey getTombstoneKey() {
-    return MemOpKey(PtrInfo::getTombstoneKey(), PtrInfo::getTombstoneKey(),
-                    PtrInfo::getTombstoneKey(), PtrInfo::getTombstoneKey(),
-                    PtrInfo::getTombstoneKey());
-  }
-
   static unsigned getHashValue(const MemOpKey &Val) {
     // Checking any field of MemOpKey is enough to determine if the key is
-    // empty or tombstone.
+    // empty.
     assert(Val.Disp != PtrInfo::getEmptyKey() && "Cannot hash the empty key");
-    assert(Val.Disp != PtrInfo::getTombstoneKey() &&
-           "Cannot hash the tombstone key");
 
     hash_code Hash = hash_combine(*Val.Operands[0], *Val.Operands[1],
                                   *Val.Operands[2], *Val.Operands[3]);
@@ -175,11 +167,9 @@ template <> struct DenseMapInfo<MemOpKey> {
 
   static bool isEqual(const MemOpKey &LHS, const MemOpKey &RHS) {
     // Checking any field of MemOpKey is enough to determine if the key is
-    // empty or tombstone.
+    // empty.
     if (RHS.Disp == PtrInfo::getEmptyKey())
       return LHS.Disp == PtrInfo::getEmptyKey();
-    if (RHS.Disp == PtrInfo::getTombstoneKey())
-      return LHS.Disp == PtrInfo::getTombstoneKey();
     return LHS == RHS;
   }
 };

--- a/llvm/lib/Transforms/IPO/Attributor.cpp
+++ b/llvm/lib/Transforms/IPO/Attributor.cpp
@@ -1333,8 +1333,6 @@ ChangeStatus Attributor::manifestAttrs(const IRPosition &IRP,
 }
 
 const IRPosition IRPosition::EmptyKey(DenseMapInfo<void *>::getEmptyKey());
-const IRPosition
-    IRPosition::TombstoneKey(DenseMapInfo<void *>::getTombstoneKey());
 
 SubsumingPositionIterator::SubsumingPositionIterator(const IRPosition &IRP) {
   IRPositions.emplace_back(IRP);

--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -746,7 +746,6 @@ template <>
 struct DenseMapInfo<AAPointerInfo::Access> : DenseMapInfo<Instruction *> {
   using Access = AAPointerInfo::Access;
   static inline Access getEmptyKey();
-  static inline Access getTombstoneKey();
   static unsigned getHashValue(const Access &A);
   static bool isEqual(const Access &LHS, const Access &RHS);
 };
@@ -756,11 +755,6 @@ template <> struct DenseMapInfo<AA::RangeTy> {
   static inline AA::RangeTy getEmptyKey() {
     auto EmptyKey = DenseMapInfo<int64_t>::getEmptyKey();
     return AA::RangeTy{EmptyKey, EmptyKey};
-  }
-
-  static inline AA::RangeTy getTombstoneKey() {
-    auto TombstoneKey = DenseMapInfo<int64_t>::getTombstoneKey();
-    return AA::RangeTy{TombstoneKey, TombstoneKey};
   }
 
   static unsigned getHashValue(const AA::RangeTy &Range) {
@@ -780,7 +774,6 @@ struct AccessAsInstructionInfo : DenseMapInfo<Instruction *> {
   using Base = DenseMapInfo<Instruction *>;
   using Access = AAPointerInfo::Access;
   static inline Access getEmptyKey();
-  static inline Access getTombstoneKey();
   static unsigned getHashValue(const Access &A);
   static bool isEqual(const Access &LHS, const Access &RHS);
 };
@@ -3477,12 +3470,8 @@ template <typename ToTy> struct DenseMapInfo<ReachabilityQueryInfo<ToTy> *> {
   using PairDMI = DenseMapInfo<std::pair<const Instruction *, const ToTy *>>;
 
   static ReachabilityQueryInfo<ToTy> EmptyKey;
-  static ReachabilityQueryInfo<ToTy> TombstoneKey;
 
   static inline ReachabilityQueryInfo<ToTy> *getEmptyKey() { return &EmptyKey; }
-  static inline ReachabilityQueryInfo<ToTy> *getTombstoneKey() {
-    return &TombstoneKey;
-  }
   static unsigned getHashValue(const ReachabilityQueryInfo<ToTy> *RQI) {
     return RQI->Hash ? RQI->Hash : RQI->computeHashValue();
   }
@@ -3500,13 +3489,7 @@ template <typename ToTy> struct DenseMapInfo<ReachabilityQueryInfo<ToTy> *> {
       DenseMapInfo<ReachabilityQueryInfo<ToTy> *>::EmptyKey =                  \
           ReachabilityQueryInfo<ToTy>(                                         \
               DenseMapInfo<const Instruction *>::getEmptyKey(),                \
-              DenseMapInfo<const ToTy *>::getEmptyKey());                      \
-  template <>                                                                  \
-  ReachabilityQueryInfo<ToTy>                                                  \
-      DenseMapInfo<ReachabilityQueryInfo<ToTy> *>::TombstoneKey =              \
-          ReachabilityQueryInfo<ToTy>(                                         \
-              DenseMapInfo<const Instruction *>::getTombstoneKey(),            \
-              DenseMapInfo<const ToTy *>::getTombstoneKey());
+              DenseMapInfo<const ToTy *>::getEmptyKey());
 
 DefineKeys(Instruction) DefineKeys(Function)
 #undef DefineKeys

--- a/llvm/lib/Transforms/IPO/FunctionSpecialization.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionSpecialization.cpp
@@ -632,11 +632,8 @@ void FunctionSpecializer::cleanUpSSA() {
     removeSSACopy(*F);
 }
 
-
 template <> struct llvm::DenseMapInfo<SpecSig> {
   static inline SpecSig getEmptyKey() { return {~0U, {}}; }
-
-  static inline SpecSig getTombstoneKey() { return {~1U, {}}; }
 
   static unsigned getHashValue(const SpecSig &S) {
     return static_cast<unsigned>(hash_value(S));

--- a/llvm/lib/Transforms/IPO/WholeProgramDevirt.cpp
+++ b/llvm/lib/Transforms/IPO/WholeProgramDevirt.cpp
@@ -387,10 +387,6 @@ template <> struct llvm::DenseMapInfo<VTableSlot> {
     return {DenseMapInfo<Metadata *>::getEmptyKey(),
             DenseMapInfo<uint64_t>::getEmptyKey()};
   }
-  static VTableSlot getTombstoneKey() {
-    return {DenseMapInfo<Metadata *>::getTombstoneKey(),
-            DenseMapInfo<uint64_t>::getTombstoneKey()};
-  }
   static unsigned getHashValue(const VTableSlot &I) {
     return DenseMapInfo<Metadata *>::getHashValue(I.TypeID) ^
            DenseMapInfo<uint64_t>::getHashValue(I.ByteOffset);
@@ -405,10 +401,6 @@ template <> struct llvm::DenseMapInfo<VTableSlotSummary> {
   static VTableSlotSummary getEmptyKey() {
     return {DenseMapInfo<StringRef>::getEmptyKey(),
             DenseMapInfo<uint64_t>::getEmptyKey()};
-  }
-  static VTableSlotSummary getTombstoneKey() {
-    return {DenseMapInfo<StringRef>::getTombstoneKey(),
-            DenseMapInfo<uint64_t>::getTombstoneKey()};
   }
   static unsigned getHashValue(const VTableSlotSummary &I) {
     return DenseMapInfo<StringRef>::getHashValue(I.TypeID) ^

--- a/llvm/lib/Transforms/InstCombine/InstCombinePHI.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombinePHI.cpp
@@ -1051,9 +1051,6 @@ template <> struct llvm::DenseMapInfo<LoweredPHIRecord> {
   static inline LoweredPHIRecord getEmptyKey() {
     return LoweredPHIRecord(nullptr, 0);
   }
-  static inline LoweredPHIRecord getTombstoneKey() {
-    return LoweredPHIRecord(nullptr, 1);
-  }
   static unsigned getHashValue(const LoweredPHIRecord &Val) {
     return DenseMapInfo<PHINode *>::getHashValue(Val.PN) ^ (Val.Shift >> 3) ^
            (Val.Width >> 3);

--- a/llvm/lib/Transforms/Scalar/EarlyCSE.cpp
+++ b/llvm/lib/Transforms/Scalar/EarlyCSE.cpp
@@ -98,8 +98,7 @@ struct SimpleValue {
   }
 
   bool isSentinel() const {
-    return Inst == DenseMapInfo<Instruction *>::getEmptyKey() ||
-           Inst == DenseMapInfo<Instruction *>::getTombstoneKey();
+    return Inst == DenseMapInfo<Instruction *>::getEmptyKey();
   }
 
   static bool canHandle(Instruction *Inst) {
@@ -157,10 +156,6 @@ struct SimpleValue {
 template <> struct llvm::DenseMapInfo<SimpleValue> {
   static inline SimpleValue getEmptyKey() {
     return DenseMapInfo<Instruction *>::getEmptyKey();
-  }
-
-  static inline SimpleValue getTombstoneKey() {
-    return DenseMapInfo<Instruction *>::getTombstoneKey();
   }
 
   static unsigned getHashValue(SimpleValue Val);
@@ -483,8 +478,7 @@ struct CallValue {
   }
 
   bool isSentinel() const {
-    return Inst == DenseMapInfo<Instruction *>::getEmptyKey() ||
-           Inst == DenseMapInfo<Instruction *>::getTombstoneKey();
+    return Inst == DenseMapInfo<Instruction *>::getEmptyKey();
   }
 
   static bool canHandle(Instruction *Inst) {
@@ -508,10 +502,6 @@ struct CallValue {
 template <> struct llvm::DenseMapInfo<CallValue> {
   static inline CallValue getEmptyKey() {
     return DenseMapInfo<Instruction *>::getEmptyKey();
-  }
-
-  static inline CallValue getTombstoneKey() {
-    return DenseMapInfo<Instruction *>::getTombstoneKey();
   }
 
   static unsigned getHashValue(CallValue Val);
@@ -561,8 +551,7 @@ struct GEPValue {
   }
 
   bool isSentinel() const {
-    return Inst == DenseMapInfo<Instruction *>::getEmptyKey() ||
-           Inst == DenseMapInfo<Instruction *>::getTombstoneKey();
+    return Inst == DenseMapInfo<Instruction *>::getEmptyKey();
   }
 
   static bool canHandle(Instruction *Inst) {
@@ -575,10 +564,6 @@ struct GEPValue {
 template <> struct llvm::DenseMapInfo<GEPValue> {
   static inline GEPValue getEmptyKey() {
     return DenseMapInfo<Instruction *>::getEmptyKey();
-  }
-
-  static inline GEPValue getTombstoneKey() {
-    return DenseMapInfo<Instruction *>::getTombstoneKey();
   }
 
   static unsigned getHashValue(const GEPValue &Val);

--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -173,7 +173,6 @@ struct llvm::GVNPass::Expression {
 
 template <> struct llvm::DenseMapInfo<GVNPass::Expression> {
   static inline GVNPass::Expression getEmptyKey() { return ~0U; }
-  static inline GVNPass::Expression getTombstoneKey() { return ~1U; }
 
   static unsigned getHashValue(const GVNPass::Expression &E) {
     using llvm::hash_value;

--- a/llvm/lib/Transforms/Scalar/GVNSink.cpp
+++ b/llvm/lib/Transforms/Scalar/GVNSink.cpp
@@ -260,11 +260,6 @@ template <> struct llvm::DenseMapInfo<ModelledPHI> {
     return Dummy;
   }
 
-  static inline ModelledPHI &getTombstoneKey() {
-    static ModelledPHI Dummy = ModelledPHI::createDummy(1);
-    return Dummy;
-  }
-
   static unsigned getHashValue(const ModelledPHI &V) { return V.hash(); }
 
   static bool isEqual(const ModelledPHI &LHS, const ModelledPHI &RHS) {

--- a/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
@@ -307,10 +307,6 @@ struct UnrolledInstStateKeyInfo {
     return {PtrInfo::getEmptyKey(), 0, 0, 0};
   }
 
-  static inline UnrolledInstState getTombstoneKey() {
-    return {PtrInfo::getTombstoneKey(), 0, 0, 0};
-  }
-
   static inline unsigned getHashValue(const UnrolledInstState &S) {
     return PairInfo::getHashValue({S.I, S.Iteration});
   }

--- a/llvm/lib/Transforms/Scalar/NewGVN.cpp
+++ b/llvm/lib/Transforms/Scalar/NewGVN.cpp
@@ -448,12 +448,6 @@ template <> struct llvm::DenseMapInfo<const Expression *> {
     return reinterpret_cast<const Expression *>(Val);
   }
 
-  static const Expression *getTombstoneKey() {
-    auto Val = static_cast<uintptr_t>(~1U);
-    Val <<= PointerLikeTypeTraits<const Expression *>::NumLowBitsAvailable;
-    return reinterpret_cast<const Expression *>(Val);
-  }
-
   static unsigned getHashValue(const Expression *E) {
     return E->getComputedHash();
   }
@@ -463,7 +457,7 @@ template <> struct llvm::DenseMapInfo<const Expression *> {
   }
 
   static bool isEqual(const ExactEqualsExpression &LHS, const Expression *RHS) {
-    if (RHS == getTombstoneKey() || RHS == getEmptyKey())
+    if (RHS == getEmptyKey())
       return false;
     return LHS == *RHS;
   }
@@ -471,8 +465,7 @@ template <> struct llvm::DenseMapInfo<const Expression *> {
   static bool isEqual(const Expression *LHS, const Expression *RHS) {
     if (LHS == RHS)
       return true;
-    if (LHS == getTombstoneKey() || RHS == getTombstoneKey() ||
-        LHS == getEmptyKey() || RHS == getEmptyKey())
+    if (LHS == getEmptyKey() || RHS == getEmptyKey())
       return false;
     // Compare hashes before equality.  This is *not* what the hashtable does,
     // since it is computing it modulo the number of buckets, whereas we are

--- a/llvm/lib/Transforms/Utils/CanonicalizeFreezeInLoops.cpp
+++ b/llvm/lib/Transforms/Utils/CanonicalizeFreezeInLoops.cpp
@@ -107,11 +107,6 @@ template <> struct llvm::DenseMapInfo<FrozenIndPHIInfo> {
                             DenseMapInfo<BinaryOperator *>::getEmptyKey());
   }
 
-  static inline FrozenIndPHIInfo getTombstoneKey() {
-    return FrozenIndPHIInfo(DenseMapInfo<PHINode *>::getTombstoneKey(),
-                            DenseMapInfo<BinaryOperator *>::getTombstoneKey());
-  }
-
   static unsigned getHashValue(const FrozenIndPHIInfo &Val) {
     return DenseMapInfo<FreezeInst *>::getHashValue(Val.FI);
   };

--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -1436,13 +1436,7 @@ EliminateDuplicatePHINodesSetBasedImpl(BasicBlock *BB,
       return DenseMapInfo<PHINode *>::getEmptyKey();
     }
 
-    static PHINode *getTombstoneKey() {
-      return DenseMapInfo<PHINode *>::getTombstoneKey();
-    }
-
-    static bool isSentinel(PHINode *PN) {
-      return PN == getEmptyKey() || PN == getTombstoneKey();
-    }
+    static bool isSentinel(PHINode *PN) { return PN == getEmptyKey(); }
 
     // WARNING: this logic must be kept in sync with
     //          Instruction::isIdenticalToWhenDefined()!
@@ -2827,18 +2821,13 @@ static bool markAliveBlocks(Function &F, SmallVectorImpl<bool> &Reachable,
           return DenseMapInfo<CatchPadInst *>::getEmptyKey();
         }
 
-        static CatchPadInst *getTombstoneKey() {
-          return DenseMapInfo<CatchPadInst *>::getTombstoneKey();
-        }
-
         static unsigned getHashValue(CatchPadInst *CatchPad) {
           return static_cast<unsigned>(hash_combine_range(
               CatchPad->value_op_begin(), CatchPad->value_op_end()));
         }
 
         static bool isEqual(CatchPadInst *LHS, CatchPadInst *RHS) {
-          if (LHS == getEmptyKey() || LHS == getTombstoneKey() ||
-              RHS == getEmptyKey() || RHS == getTombstoneKey())
+          if (LHS == getEmptyKey() || RHS == getEmptyKey())
             return LHS == RHS;
           return LHS->isIdenticalTo(RHS);
         }

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -8055,10 +8055,6 @@ template <> struct llvm::DenseMapInfo<const EqualBBWrapper *> {
   static const EqualBBWrapper *getEmptyKey() {
     return static_cast<EqualBBWrapper *>(DenseMapInfo<void *>::getEmptyKey());
   }
-  static const EqualBBWrapper *getTombstoneKey() {
-    return static_cast<EqualBBWrapper *>(
-        DenseMapInfo<void *>::getTombstoneKey());
-  }
   static unsigned getHashValue(const EqualBBWrapper *EBW) {
     BasicBlock *BB = EBW->BB;
     UncondBrInst *BI = cast<UncondBrInst>(BB->getTerminator());
@@ -8079,8 +8075,7 @@ template <> struct llvm::DenseMapInfo<const EqualBBWrapper *> {
   }
   static bool isEqual(const EqualBBWrapper *LHS, const EqualBBWrapper *RHS) {
     auto *EKey = DenseMapInfo<EqualBBWrapper *>::getEmptyKey();
-    auto *TKey = DenseMapInfo<EqualBBWrapper *>::getTombstoneKey();
-    if (LHS == EKey || RHS == EKey || LHS == TKey || RHS == TKey)
+    if (LHS == EKey || RHS == EKey)
       return LHS == RHS;
 
     BasicBlock *A = LHS->BB;

--- a/llvm/lib/Transforms/Vectorize/LoadStoreVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoadStoreVectorizer.cpp
@@ -1820,17 +1820,12 @@ std::vector<Chain> Vectorizer::gatherChains(ArrayRef<Instruction *> Instrs) {
     using PtrInfo = DenseMapInfo<InstrListElem *>;
     using IInfo = DenseMapInfo<Instruction *>;
     static InstrListElem *getEmptyKey() { return PtrInfo::getEmptyKey(); }
-    static InstrListElem *getTombstoneKey() {
-      return PtrInfo::getTombstoneKey();
-    }
     static unsigned getHashValue(const InstrListElem *E) {
       return IInfo::getHashValue(E->first);
     }
     static bool isEqual(const InstrListElem *A, const InstrListElem *B) {
       if (A == getEmptyKey() || B == getEmptyKey())
         return A == getEmptyKey() && B == getEmptyKey();
-      if (A == getTombstoneKey() || B == getTombstoneKey())
-        return A == getTombstoneKey() && B == getTombstoneKey();
       return IInfo::isEqual(A->first, B->first);
     }
   };

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -2076,10 +2076,6 @@ struct CSEDenseMapInfo {
     return DenseMapInfo<Instruction *>::getEmptyKey();
   }
 
-  static inline Instruction *getTombstoneKey() {
-    return DenseMapInfo<Instruction *>::getTombstoneKey();
-  }
-
   static unsigned getHashValue(const Instruction *I) {
     assert(canHandle(I) && "Unknown instruction!");
     return hash_combine(I->getOpcode(),
@@ -2087,8 +2083,7 @@ struct CSEDenseMapInfo {
   }
 
   static bool isEqual(const Instruction *LHS, const Instruction *RHS) {
-    if (LHS == getEmptyKey() || RHS == getEmptyKey() ||
-        LHS == getTombstoneKey() || RHS == getTombstoneKey())
+    if (LHS == getEmptyKey() || RHS == getEmptyKey())
       return LHS == RHS;
     return LHS->isIdenticalTo(RHS);
   }

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -6426,12 +6426,6 @@ private:
       return V;
     }
 
-    static OrdersType getTombstoneKey() {
-      OrdersType V;
-      V.push_back(~2U);
-      return V;
-    }
-
     static unsigned getHashValue(const OrdersType &V) {
       return static_cast<unsigned>(hash_combine_range(V));
     }
@@ -6489,11 +6483,6 @@ template <> struct llvm::DenseMapInfo<BoUpSLP::EdgeInfo> {
   static BoUpSLP::EdgeInfo getEmptyKey() {
     return BoUpSLP::EdgeInfo(FirstInfo::getEmptyKey(),
                              SecondInfo::getEmptyKey());
-  }
-
-  static BoUpSLP::EdgeInfo getTombstoneKey() {
-    return BoUpSLP::EdgeInfo(FirstInfo::getTombstoneKey(),
-                             SecondInfo::getTombstoneKey());
   }
 
   static unsigned getHashValue(const BoUpSLP::EdgeInfo &Val) {

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -2396,7 +2396,7 @@ void VPlanTransforms::clearReductionWrapFlags(VPlan &Plan) {
 namespace {
 struct VPCSEDenseMapInfo : public DenseMapInfo<VPSingleDefRecipe *> {
   static bool isSentinel(const VPSingleDefRecipe *Def) {
-    return Def == getEmptyKey() || Def == getTombstoneKey();
+    return Def == getEmptyKey();
   }
 
   /// If recipe \p R will lower to a GEP with a non-i8 source element type,

--- a/llvm/tools/dsymutil/BinaryHolder.h
+++ b/llvm/tools/dsymutil/BinaryHolder.h
@@ -161,10 +161,6 @@ template <> struct DenseMapInfo<dsymutil::BinaryHolder::ArchiveEntry::KeyTy> {
     return dsymutil::BinaryHolder::ArchiveEntry::KeyTy();
   }
 
-  static inline dsymutil::BinaryHolder::ArchiveEntry::KeyTy getTombstoneKey() {
-    return dsymutil::BinaryHolder::ArchiveEntry::KeyTy("/", {});
-  }
-
   static unsigned
   getHashValue(const dsymutil::BinaryHolder::ArchiveEntry::KeyTy &K) {
     return hash_combine(DenseMapInfo<StringRef>::getHashValue(K.Filename),

--- a/llvm/tools/llvm-c-test/echo.cpp
+++ b/llvm/tools/llvm-c-test/echo.cpp
@@ -42,10 +42,6 @@ struct CAPIDenseMap<T*> {
       uintptr_t Val = static_cast<uintptr_t>(-1);
       return reinterpret_cast<T*>(Val);
     }
-    static inline T* getTombstoneKey() {
-      uintptr_t Val = static_cast<uintptr_t>(-2);
-      return reinterpret_cast<T*>(Val);
-    }
     static unsigned getHashValue(const T *PtrVal) {
       return hash_value(PtrVal);
     }

--- a/llvm/tools/llvm-reduce/deltas/Delta.h
+++ b/llvm/tools/llvm-reduce/deltas/Delta.h
@@ -62,11 +62,6 @@ struct DenseMapInfo<Chunk> {
             DenseMapInfo<int>::getEmptyKey()};
   }
 
-  static inline Chunk getTombstoneKey() {
-    return {DenseMapInfo<int>::getTombstoneKey(),
-            DenseMapInfo<int>::getTombstoneKey()};
-  }
-
   static unsigned getHashValue(const Chunk Val) {
     std::pair<int, int> PairVal = std::make_pair(Val.Begin, Val.End);
     return DenseMapInfo<std::pair<int, int>>::getHashValue(PairVal);

--- a/llvm/tools/llvm-split/llvm-split.cpp
+++ b/llvm/tools/llvm-split/llvm-split.cpp
@@ -191,8 +191,6 @@ private:
   struct KeyInfo {
     static SmallString<0> getEmptyKey() { return SmallString<0>(""); }
 
-    static SmallString<0> getTombstoneKey() { return SmallString<0>("-"); }
-
     static bool isEqual(const SmallString<0> &LHS, const SmallString<0> &RHS) {
       return LHS == RHS;
     }

--- a/llvm/unittests/ADT/DenseMapTest.cpp
+++ b/llvm/unittests/ADT/DenseMapTest.cpp
@@ -86,7 +86,6 @@ std::set<CtorTester *> CtorTester::Constructed;
 
 struct CtorTesterMapInfo {
   static inline CtorTester getEmptyKey() { return CtorTester(-1); }
-  static inline CtorTester getTombstoneKey() { return CtorTester(-2); }
   static unsigned getHashValue(const CtorTester &Val) {
     return Val.getValue() * 37u;
   }
@@ -733,7 +732,6 @@ TEST(DenseMapCustomTest, LookupOrConstness) {
 // In the latter case, "a" == 0, "b" == 1 and so on.
 struct TestDenseMapInfo {
   static inline unsigned getEmptyKey() { return ~0; }
-  static inline unsigned getTombstoneKey() { return ~0U - 1; }
   static unsigned getHashValue(const unsigned& Val) { return Val * 37U; }
   static unsigned getHashValue(const char* Val) {
     return (unsigned)(Val[0] - 'a') * 37U;
@@ -790,7 +788,6 @@ TEST(DenseMapCustomTest, SmallDenseMapInitializerList) {
 
 struct ContiguousDenseMapInfo {
   static inline unsigned getEmptyKey() { return ~0; }
-  static inline unsigned getTombstoneKey() { return ~0U - 1; }
   static unsigned getHashValue(const unsigned& Val) { return Val; }
   static bool isEqual(const unsigned& LHS, const unsigned& RHS) {
     return LHS == RHS;
@@ -916,7 +913,6 @@ namespace llvm {
 template <typename T>
 struct DenseMapInfo<T, std::enable_if_t<std::is_base_of_v<A, T>>> {
   static inline T getEmptyKey() { return {static_cast<int>(~0)}; }
-  static inline T getTombstoneKey() { return {static_cast<int>(~0U - 1)}; }
   static unsigned getHashValue(const T &Val) { return Val.value; }
   static bool isEqual(const T &LHS, const T &RHS) {
     return LHS.value == RHS.value;
@@ -926,7 +922,6 @@ struct DenseMapInfo<T, std::enable_if_t<std::is_base_of_v<A, T>>> {
 template <> struct DenseMapInfo<AlwaysEqType> {
   using T = AlwaysEqType;
   static inline T getEmptyKey() { return {}; }
-  static inline T getTombstoneKey() { return {}; }
   static unsigned getHashValue(const T &Val) { return 0; }
   static bool isEqual(const T &LHS, const T &RHS) {
     return false;

--- a/llvm/unittests/ADT/DenseSetTest.cpp
+++ b/llvm/unittests/ADT/DenseSetTest.cpp
@@ -83,7 +83,6 @@ TEST(DenseSetTest, RemoveIf) {
 
 struct TestDenseSetInfo {
   static inline unsigned getEmptyKey() { return ~0; }
-  static inline unsigned getTombstoneKey() { return ~0U - 1; }
   static unsigned getHashValue(const unsigned& Val) { return Val * 37U; }
   static unsigned getHashValue(const char* Val) {
     return (unsigned)(Val[0] - 'a') * 37U;
@@ -231,9 +230,6 @@ namespace llvm {
 // Specialization required to insert a CountCopyAndMove into a DenseSet.
 template <> struct DenseMapInfo<CountCopyAndMove> {
   static inline CountCopyAndMove getEmptyKey() { return CountCopyAndMove(-1); };
-  static inline CountCopyAndMove getTombstoneKey() {
-    return CountCopyAndMove(-2);
-  };
   static unsigned getHashValue(const CountCopyAndMove &Val) {
     return Val.Value;
   }

--- a/llvm/unittests/ADT/MapVectorTest.cpp
+++ b/llvm/unittests/ADT/MapVectorTest.cpp
@@ -36,7 +36,6 @@ struct A : CountCopyAndMove {
 namespace llvm {
 template <> struct DenseMapInfo<A> {
   static inline A getEmptyKey() { return 0x7fffffff; }
-  static inline A getTombstoneKey() { return -0x7fffffff - 1; }
   static unsigned getHashValue(const A &Val) { return (unsigned)(Val.v * 37U); }
   static bool isEqual(const A &LHS, const A &RHS) { return LHS.v == RHS.v; }
 };

--- a/llvm/unittests/Support/ReverseIterationTest.cpp
+++ b/llvm/unittests/Support/ReverseIterationTest.cpp
@@ -66,11 +66,6 @@ template<> struct DenseMapInfo<PtrLikeInt *> {
     return &EmptyKey;
   }
 
-  static PtrLikeInt *getTombstoneKey() {
-    static PtrLikeInt TombstoneKey;
-    return &TombstoneKey;
-  }
-
   static int getHashValue(const PtrLikeInt *P) {
     return P->value;
   }

--- a/llvm/utils/TableGen/Basic/RuntimeLibcallsEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/RuntimeLibcallsEmitter.cpp
@@ -52,11 +52,6 @@ template <> struct DenseMapInfo<PredicateWithCC, void> {
         std::pair<const Record *, const Record *>>::getEmptyKey();
   }
 
-  static inline PredicateWithCC getTombstoneKey() {
-    return DenseMapInfo<
-        std::pair<const Record *, const Record *>>::getTombstoneKey();
-  }
-
   static unsigned getHashValue(const PredicateWithCC Val) {
     auto Pair = std::make_pair(Val.Predicate, Val.CallingConv);
     return DenseMapInfo<

--- a/llvm/utils/gdb-scripts/prettyprinters.py
+++ b/llvm/utils/gdb-scripts/prettyprinters.py
@@ -163,7 +163,6 @@ class DenseMapPrinter:
             n = self.key_info_t.name
             is_equal = gdb.parse_and_eval(n + "::isEqual")
             empty = gdb.parse_and_eval(n + "::getEmptyKey()")
-            tombstone = gdb.parse_and_eval(n + "::getTombstoneKey()")
             # the following is invalid, GDB fails with:
             #   Python Exception <class 'gdb.error'> Attempt to take address of value
             #   not located in memory.
@@ -173,10 +172,8 @@ class DenseMapPrinter:
             # member function, not the 'first' member variable, but I've yet to figure
             # out how to find/call member functions (especially (const) overloaded
             # ones) on a gdb.Value.
-            while self.cur != self.end and (
-                is_equal(self.cur.dereference()["first"], empty)
-                or is_equal(self.cur.dereference()["first"], tombstone)
-            ):
+            while self.cur != self.end and
+                is_equal(self.cur.dereference()["first"], empty):
                 self.cur = self.cur + 1
 
         def __next__(self):

--- a/polly/include/polly/Support/VirtualInstruction.h
+++ b/polly/include/polly/Support/VirtualInstruction.h
@@ -322,13 +322,6 @@ public:
                                                 RHS.getInstruction());
   }
 
-  static polly::VirtualInstruction getTombstoneKey() {
-    polly::VirtualInstruction TombstoneKey;
-    TombstoneKey.Stmt = DenseMapInfo<polly::ScopStmt *>::getTombstoneKey();
-    TombstoneKey.Inst = DenseMapInfo<Instruction *>::getTombstoneKey();
-    return TombstoneKey;
-  }
-
   static polly::VirtualInstruction getEmptyKey() {
     polly::VirtualInstruction EmptyKey;
     EmptyKey.Stmt = DenseMapInfo<polly::ScopStmt *>::getEmptyKey();


### PR DESCRIPTION
PR #200595 changed DenseMap to no longer create tombstone buckets, so
DenseMapInfo<T>::getTombstoneKey() is never called. Remove dead
definitions and dead tombstone branches.