### PR TITLE
[AMDGPU] Use v_rsq_f32 for f16 rsqrt on targets without 16-bit insts

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -17696,8 +17696,7 @@ SDValue SITargetLowering::performFDivCombine(SDNode *N,
   SDLoc SL(N);
   EVT VT = N->getValueType(0);
 
-  // fsqrt legality correlates to rsq availability.
-  if ((VT != MVT::f16 && VT != MVT::bf16) || !isOperationLegal(ISD::FSQRT, VT))
+  if (VT != MVT::f16 && VT != MVT::bf16)
     return SDValue();
 
   SDValue LHS = N->getOperand(0);
@@ -17713,12 +17712,32 @@ SDValue SITargetLowering::performFDivCombine(SDNode *N,
     bool IsNegative = false;
     if (CLHS->isExactlyValue(1.0) ||
         (IsNegative = CLHS->isExactlyValue(-1.0))) {
-      // fdiv contract 1.0, (sqrt contract x) -> rsq for f16
-      // fdiv contract -1.0, (sqrt contract x) -> fneg(rsq) for f16
+      // fdiv contract 1.0, (sqrt contract x) -> rsq
+      // fdiv contract -1.0, (sqrt contract x) -> fneg(rsq)
       if (RHS.getOpcode() == ISD::FSQRT) {
         // TODO: Or in RHS flags, somehow missing from SDNodeFlags
-        SDValue Rsq =
-            DAG.getNode(AMDGPUISD::RSQ, SL, VT, RHS.getOperand(0), Flags);
+        SDValue SqrtOp = RHS.getOperand(0);
+        SDValue Rsq;
+        if (isOperationLegal(ISD::FSQRT, VT)) {
+          // fsqrt legality correlates to rsq availability of the same type.
+          Rsq = DAG.getNode(AMDGPUISD::RSQ, SL, VT, SqrtOp, Flags);
+        } else if (VT == MVT::f16) {
+          // Targets without 16-bit instructions (gfx6/gfx7) have no f16 rsq,
+          // but v_rsq_f32 is more than accurate enough for f16. Unlike bf16,
+          // every f16 value (including denormals) extends to a normal f32, and
+          // an f16 rsq result is never denormal, so the f32 reciprocal square
+          // root needs no denormal handling. Compute it in f32 and round back.
+          SDValue Ext =
+              DAG.getNode(ISD::FP_EXTEND, SL, MVT::f32, SqrtOp, Flags);
+          SDValue F32Rsq =
+              DAG.getNode(AMDGPUISD::RSQ, SL, MVT::f32, Ext, Flags);
+          Rsq = DAG.getNode(ISD::FP_ROUND, SL, VT, F32Rsq,
+                            DAG.getTargetConstant(0, SL, MVT::i32), Flags);
+        } else {
+          // bf16 shares f32's exponent range, so bf16 denormals would extend to
+          // f32 denormals that v_rsq_f32 does not handle. Leave it expanded.
+          return SDValue();
+        }
         return IsNegative ? DAG.getNode(ISD::FNEG, SL, VT, Rsq, Flags) : Rsq;
       }
     }

--- a/llvm/test/CodeGen/AMDGPU/fdiv.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/fdiv.f16.ll
@@ -747,25 +747,9 @@ define amdgpu_kernel void @v_rsq_f16(ptr addrspace(1) %r, ptr addrspace(1) %b) #
 ; SI-NEXT:    s_mov_b64 s[4:5], s[2:3]
 ; SI-NEXT:    buffer_load_ushort v2, v[0:1], s[4:7], 0 addr64 glc
 ; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; SI-NEXT:    v_sqrt_f32_e32 v2, v2
-; SI-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_MODE, 2, 2), 0
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; SI-NEXT:    v_div_scale_f32 v3, s[2:3], v2, v2, 1.0
-; SI-NEXT:    v_rcp_f32_e32 v4, v3
-; SI-NEXT:    v_div_scale_f32 v5, vcc, 1.0, v2, 1.0
-; SI-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_MODE, 4, 2), 3
 ; SI-NEXT:    s_mov_b64 s[2:3], s[6:7]
-; SI-NEXT:    v_fma_f32 v6, -v3, v4, 1.0
-; SI-NEXT:    v_fma_f32 v4, v6, v4, v4
-; SI-NEXT:    v_mul_f32_e32 v6, v5, v4
-; SI-NEXT:    v_fma_f32 v7, -v3, v6, v5
-; SI-NEXT:    v_fma_f32 v6, v7, v4, v6
-; SI-NEXT:    v_fma_f32 v3, -v3, v6, v5
-; SI-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_MODE, 4, 2), 0
-; SI-NEXT:    v_div_fmas_f32 v3, v3, v4, v6
-; SI-NEXT:    v_div_fixup_f32 v2, v3, v2, 1.0
+; SI-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; SI-NEXT:    v_rsq_f32_e32 v2, v2
 ; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
 ; SI-NEXT:    buffer_store_short v2, v[0:1], s[0:3], 0 addr64
 ; SI-NEXT:    s_endpgm
@@ -858,26 +842,10 @@ define amdgpu_kernel void @v_rsq_f16_neg(ptr addrspace(1) %r, ptr addrspace(1) %
 ; SI-NEXT:    s_mov_b64 s[4:5], s[2:3]
 ; SI-NEXT:    buffer_load_ushort v2, v[0:1], s[4:7], 0 addr64 glc
 ; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; SI-NEXT:    v_sqrt_f32_e32 v2, v2
-; SI-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_MODE, 2, 2), 0
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
-; SI-NEXT:    v_cvt_f32_f16_e32 v2, v2
-; SI-NEXT:    v_div_scale_f32 v3, s[2:3], v2, v2, -1.0
-; SI-NEXT:    v_rcp_f32_e32 v4, v3
-; SI-NEXT:    v_div_scale_f32 v5, vcc, -1.0, v2, -1.0
-; SI-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_MODE, 4, 2), 3
 ; SI-NEXT:    s_mov_b64 s[2:3], s[6:7]
-; SI-NEXT:    v_fma_f32 v6, -v3, v4, 1.0
-; SI-NEXT:    v_fma_f32 v4, v6, v4, v4
-; SI-NEXT:    v_mul_f32_e32 v6, v5, v4
-; SI-NEXT:    v_fma_f32 v7, -v3, v6, v5
-; SI-NEXT:    v_fma_f32 v6, v7, v4, v6
-; SI-NEXT:    v_fma_f32 v3, -v3, v6, v5
-; SI-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_MODE, 4, 2), 0
-; SI-NEXT:    v_div_fmas_f32 v3, v3, v4, v6
-; SI-NEXT:    v_div_fixup_f32 v2, v3, v2, -1.0
-; SI-NEXT:    v_cvt_f16_f32_e32 v2, v2
+; SI-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; SI-NEXT:    v_rsq_f32_e32 v2, v2
+; SI-NEXT:    v_cvt_f16_f32_e64 v2, -v2
 ; SI-NEXT:    buffer_store_short v2, v[0:1], s[0:3], 0 addr64
 ; SI-NEXT:    s_endpgm
 ;
@@ -976,25 +944,9 @@ define amdgpu_kernel void @v_rsq_f16_multi_use(ptr addrspace(1) %r, ptr addrspac
 ; SI-NEXT:    s_mov_b64 s[4:5], s[2:3]
 ; SI-NEXT:    buffer_load_ushort v2, v[0:1], s[4:7], 0 addr64 glc
 ; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, v2
-; SI-NEXT:    v_sqrt_f32_e32 v3, v3
-; SI-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_MODE, 2, 2), 0
-; SI-NEXT:    v_cvt_f16_f32_e32 v3, v3
-; SI-NEXT:    v_cvt_f32_f16_e32 v3, v3
-; SI-NEXT:    v_div_scale_f32 v4, s[2:3], v3, v3, 1.0
-; SI-NEXT:    v_rcp_f32_e32 v5, v4
-; SI-NEXT:    v_div_scale_f32 v6, vcc, 1.0, v3, 1.0
-; SI-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_MODE, 4, 2), 3
 ; SI-NEXT:    s_mov_b64 s[2:3], s[6:7]
-; SI-NEXT:    v_fma_f32 v7, -v4, v5, 1.0
-; SI-NEXT:    v_fma_f32 v5, v7, v5, v5
-; SI-NEXT:    v_mul_f32_e32 v7, v6, v5
-; SI-NEXT:    v_fma_f32 v8, -v4, v7, v6
-; SI-NEXT:    v_fma_f32 v7, v8, v5, v7
-; SI-NEXT:    v_fma_f32 v4, -v4, v7, v6
-; SI-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_MODE, 4, 2), 0
-; SI-NEXT:    v_div_fmas_f32 v4, v4, v5, v7
-; SI-NEXT:    v_div_fixup_f32 v3, v4, v3, 1.0
+; SI-NEXT:    v_cvt_f32_f16_e32 v3, v2
+; SI-NEXT:    v_rsq_f32_e32 v3, v3
 ; SI-NEXT:    v_cvt_f16_f32_e32 v3, v3
 ; SI-NEXT:    buffer_store_short v2, v[0:1], s[0:3], 0 addr64
 ; SI-NEXT:    s_waitcnt vmcnt(0)


### PR DESCRIPTION
On gfx6/gfx7 the f16 1.0/sqrt(x) pattern was not folded to a reciprocal square root because performFDivCombine bailed out whenever f16 fsqrt was not a legal operation. f16 fsqrt is Custom (promoted) on these targets, so the combine never fired and the full f32 fdiv expansion was emitted.

Split the legality check: when same-type fsqrt is legal (gfx8+), keep emitting the native rsq. For f16 without a legal fsqrt, compute the reciprocal square root in f32 with v_rsq_f32 and round back. This is accurate enough for f16, and needs no denormal scaling because every f16 value extends to a normal f32 and an f16 rsq result is never denormal.

bf16 is intentionally left expanded: it shares f32's exponent range, so bf16 denormals would extend to f32 denormals that v_rsq_f32 does not handle.

Fixes #76948