### PR TITLE
[IR] Don't use TrackingMDNodeRef for DebugLoc

### DIFF
--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -1796,7 +1796,7 @@ public:
 
 class DeclAsInlineDebugLocation {
   CGDebugInfo *DI;
-  llvm::MDNode *InlinedAt;
+  llvm::DILocation *InlinedAt;
   std::optional<ApplyDebugLocation> Location;
 
 public:

--- a/clang/lib/CodeGen/CGDebugInfo.h
+++ b/clang/lib/CodeGen/CGDebugInfo.h
@@ -72,7 +72,7 @@ class CGDebugInfo {
   llvm::DIFile *CurLocFile = nullptr;
   unsigned CurLocLine = 0;
   unsigned CurLocColumn = 0;
-  llvm::MDNode *CurInlinedAt = nullptr;
+  llvm::DILocation *CurInlinedAt = nullptr;
   llvm::DIType *VTablePtrType = nullptr;
   llvm::DIType *ClassTy = nullptr;
   llvm::DICompositeType *ObjTy = nullptr;
@@ -477,10 +477,10 @@ public:
 
   /// Update the current inline scope. All subsequent calls to \p EmitLocation
   /// will create a location with this inlinedAt field.
-  void setInlinedAt(llvm::MDNode *InlinedAt) { CurInlinedAt = InlinedAt; }
+  void setInlinedAt(llvm::DILocation *InlinedAt) { CurInlinedAt = InlinedAt; }
 
   /// \return the current inline scope.
-  llvm::MDNode *getInlinedAt() const { return CurInlinedAt; }
+  llvm::DILocation *getInlinedAt() const { return CurInlinedAt; }
 
   // Converts a SourceLocation to a DebugLoc
   llvm::DebugLoc SourceLocToDebugLoc(SourceLocation Loc);

--- a/llvm/include/llvm/AsmParser/LLParser.h
+++ b/llvm/include/llvm/AsmParser/LLParser.h
@@ -185,6 +185,11 @@ namespace llvm {
     /// scoped local types.
     SmallVector<DISubprogram *> NewDistinctSPs;
 
+    SmallVector<std::tuple<LocTy, DbgRecord *, TrackingMDNodeRef>>
+        PendingDbgRecords;
+    SmallVector<std::tuple<LocTy, Instruction *, TrackingMDNodeRef>>
+        PendingDbgInsts;
+
     /// Only the llvm-as tool may set this to false to bypass
     /// UpgradeDebuginfo so it can generate broken bitcode.
     bool UpgradeDebugInfo;

--- a/llvm/include/llvm/CodeGen/MachineInstr.h
+++ b/llvm/include/llvm/CodeGen/MachineInstr.h
@@ -1921,10 +1921,7 @@ public:
 
   /// Replace current source information with new such.
   /// Avoid using this, the constructor argument is preferable.
-  void setDebugLoc(DebugLoc DL) {
-    DbgLoc = std::move(DL);
-    assert(DbgLoc.hasTrivialDestructor() && "Expected trivial destructor");
-  }
+  void setDebugLoc(DebugLoc DL) { DbgLoc = std::move(DL); }
 
   /// Erase an operand from an instruction, leaving it with one
   /// fewer operand than it started with.

--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -1232,7 +1232,6 @@ protected:
       : NodeType(Opc), ValueList(VTs.VTs), NumValues(VTs.NumVTs),
         IROrder(Order), debugLoc(std::move(dl)) {
     memset(&RawSDNodeBits, 0, sizeof(RawSDNodeBits));
-    assert(debugLoc.hasTrivialDestructor() && "Expected trivial destructor");
     assert(NumValues == VTs.NumVTs &&
            "NumValues wasn't wide enough for its operands!");
   }

--- a/llvm/include/llvm/IR/DebugLoc.h
+++ b/llvm/include/llvm/IR/DebugLoc.h
@@ -108,35 +108,24 @@ template <> struct simplify_type<const DILocAndCoverageTracking> {
   }
 };
 
-using DebugLocTrackingRef = DILocAndCoverageTracking;
+using DebugLocRef = DILocAndCoverageTracking;
 #else
-using DebugLocTrackingRef = TrackingMDNodeRef;
+using DebugLocRef = DILocation *;
 #endif // LLVM_ENABLE_DEBUGLOC_TRACKING_COVERAGE
 
 /// A debug info location.
 ///
-/// This class is a wrapper around a tracking reference to an \a DILocation
+/// This class is a wrapper around an \a DILocation
 /// pointer.
 ///
 /// To avoid extra includes, \a DebugLoc doubles the \a DILocation API with a
 /// one based on relatively opaque \a MDNode pointers.
 class DebugLoc {
-
-  DebugLocTrackingRef Loc;
+  DebugLocRef Loc = {};
 
 public:
-  DebugLoc() = default;
-
   /// Construct from an \a DILocation.
-  LLVM_ABI DebugLoc(const DILocation *L);
-
-  /// Construct from an \a MDNode.
-  ///
-  /// Note: if \c N is not an \a DILocation, a verifier check will fail, and
-  /// accessors will crash.  However, construction from other nodes is
-  /// supported in order to handle forward references when reading textual
-  /// IR.
-  LLVM_ABI explicit DebugLoc(const MDNode *N);
+  DebugLoc(const DILocation *L = nullptr) : Loc(const_cast<DILocation *>(L)) {}
 
 #if LLVM_ENABLE_DEBUGLOC_TRACKING_COVERAGE
   DebugLoc(DebugLocKind Kind) : Loc(Kind) {}
@@ -225,7 +214,7 @@ public:
   ///
   /// \pre !*this or \c isa<DILocation>(getAsMDNode()).
   /// @{
-  LLVM_ABI DILocation *get() const;
+  DILocation *get() const { return Loc; }
   operator DILocation *() const { return get(); }
   DILocation *operator->() const { return get(); }
   DILocation &operator*() const { return *get(); }
@@ -240,7 +229,7 @@ public:
   explicit operator bool() const { return Loc; }
 
   /// Check whether this has a trivial destructor.
-  bool hasTrivialDestructor() const { return Loc.hasTrivialDestructor(); }
+  bool hasTrivialDestructor() const { return true; }
 
   enum { ReplaceLastInlinedAt = true };
   /// Rebuild the entire inlined-at chain for this instruction so that the top
@@ -287,7 +276,7 @@ public:
   LLVM_ABI DebugLoc getFnDebugLoc() const;
 
   /// Return \c this as a bar \a MDNode.
-  MDNode *getAsMDNode() const { return Loc; }
+  LLVM_ABI MDNode *getAsMDNode() const;
 
   /// Check if the DebugLoc corresponds to an implicit code.
   LLVM_ABI bool isImplicitCode() const;

--- a/llvm/include/llvm/IR/DebugLoc.h
+++ b/llvm/include/llvm/IR/DebugLoc.h
@@ -228,9 +228,6 @@ public:
   /// \a Instruction::hasMetadata().
   explicit operator bool() const { return Loc; }
 
-  /// Check whether this has a trivial destructor.
-  bool hasTrivialDestructor() const { return true; }
-
   enum { ReplaceLastInlinedAt = true };
   /// Rebuild the entire inlined-at chain for this instruction so that the top
   /// of the chain now is inlined-at the new call site.

--- a/llvm/include/llvm/IR/DebugLoc.h
+++ b/llvm/include/llvm/IR/DebugLoc.h
@@ -70,41 +70,42 @@ enum class DebugLocKind : uint8_t {
   Temporary
 };
 
-// Extends TrackingMDNodeRef to also store a DebugLocKind and Origin,
+// Extends a DILocation pointer to also store a DebugLocKind and Origin,
 // allowing Debugify to ignore intentionally-empty DebugLocs and display the
 // code responsible for generating unintentionally-empty DebugLocs.
 // Currently we only need to track the Origin of this DILoc when using a
 // DebugLoc that is not annotated (i.e. has DebugLocKind::Normal) and has a
 // null DILocation, so only collect the origin stacktrace in those cases.
-class DILocAndCoverageTracking : public TrackingMDNodeRef, public DbgLocOrigin {
+class DILocAndCoverageTracking : public DbgLocOrigin {
+  DILocation *Loc;
+
 public:
   DebugLocKind Kind;
   // Default constructor for empty DebugLocs.
   DILocAndCoverageTracking()
-      : TrackingMDNodeRef(nullptr), DbgLocOrigin(true),
+      : DbgLocOrigin(true), Loc(nullptr), Kind(DebugLocKind::Normal) {}
+  // Valid or nullptr DILocation*, no annotative DebugLocKind.
+  DILocAndCoverageTracking(const DILocation *Loc)
+      : DbgLocOrigin(!Loc), Loc(const_cast<DILocation *>(Loc)),
         Kind(DebugLocKind::Normal) {}
-  // Valid or nullptr MDNode*, no annotative DebugLocKind.
-  DILocAndCoverageTracking(const MDNode *Loc)
-      : TrackingMDNodeRef(const_cast<MDNode *>(Loc)), DbgLocOrigin(!Loc),
-        Kind(DebugLocKind::Normal) {}
-  LLVM_ABI DILocAndCoverageTracking(const DILocation *Loc);
-  // Explicit DebugLocKind, which always means a nullptr MDNode*.
+  // Explicit DebugLocKind, which always means a nullptr DILocation*.
   DILocAndCoverageTracking(DebugLocKind Kind)
-      : TrackingMDNodeRef(nullptr), DbgLocOrigin(Kind == DebugLocKind::Normal),
-        Kind(Kind) {}
+      : DbgLocOrigin(Kind == DebugLocKind::Normal), Loc(nullptr), Kind(Kind) {}
+
+  operator DILocation *() const { return Loc; }
 };
 template <> struct simplify_type<DILocAndCoverageTracking> {
-  using SimpleType = MDNode *;
+  using SimpleType = DILocation *;
 
-  static MDNode *getSimplifiedValue(DILocAndCoverageTracking &MD) {
-    return MD.get();
+  static DILocation *getSimplifiedValue(DILocAndCoverageTracking &MD) {
+    return MD;
   }
 };
 template <> struct simplify_type<const DILocAndCoverageTracking> {
-  using SimpleType = MDNode *;
+  using SimpleType = DILocation *;
 
-  static MDNode *getSimplifiedValue(const DILocAndCoverageTracking &MD) {
-    return MD.get();
+  static DILocation *getSimplifiedValue(const DILocAndCoverageTracking &MD) {
+    return MD;
   }
 };
 

--- a/llvm/include/llvm/IR/DebugProgramInstruction.h
+++ b/llvm/include/llvm/IR/DebugProgramInstruction.h
@@ -240,7 +240,7 @@ class DbgLabelRecord : public DbgRecord {
   /// This constructor intentionally left private, so that it is only called via
   /// "createUnresolvedDbgLabelRecord", which clearly expresses that it is for
   /// parsing only.
-  DbgLabelRecord(MDNode *Label, MDNode *DL);
+  DbgLabelRecord(MDNode *Label);
 
 public:
   LLVM_ABI DbgLabelRecord(DILabel *Label, DebugLoc DL);
@@ -249,8 +249,7 @@ public:
   /// MDNodes. Trying to access the resulting DbgLabelRecord's fields before
   /// they are resolved, or if they resolve to the wrong type, will result in a
   /// crash.
-  LLVM_ABI static DbgLabelRecord *createUnresolvedDbgLabelRecord(MDNode *Label,
-                                                                 MDNode *DL);
+  LLVM_ABI static DbgLabelRecord *createUnresolvedDbgLabelRecord(MDNode *Label);
 
   LLVM_ABI DbgLabelRecord *clone() const;
   LLVM_ABI void print(raw_ostream &O, bool IsForDebug = false) const;
@@ -323,7 +322,7 @@ private:
   /// depending on which Type is passed.
   DbgVariableRecord(LocationType Type, Metadata *Val, MDNode *Variable,
                     MDNode *Expression, MDNode *AssignID, Metadata *Address,
-                    MDNode *AddressExpression, MDNode *DI);
+                    MDNode *AddressExpression);
 
 public:
   /// Used to create DbgVariableRecords during parsing, where some metadata
@@ -333,11 +332,9 @@ public:
   /// for all types of DbgVariableRecords for simplicity while parsing, but
   /// asserts if any necessary fields are empty or unused fields are not empty,
   /// i.e. if the #dbg_assign fields are used for a non-dbg-assign type.
-  LLVM_ABI static DbgVariableRecord *
-  createUnresolvedDbgVariableRecord(LocationType Type, Metadata *Val,
-                                    MDNode *Variable, MDNode *Expression,
-                                    MDNode *AssignID, Metadata *Address,
-                                    MDNode *AddressExpression, MDNode *DI);
+  LLVM_ABI static DbgVariableRecord *createUnresolvedDbgVariableRecord(
+      LocationType Type, Metadata *Val, MDNode *Variable, MDNode *Expression,
+      MDNode *AssignID, Metadata *Address, MDNode *AddressExpression);
 
   LLVM_ABI static DbgVariableRecord *
   createDVRAssign(Value *Val, DILocalVariable *Variable,

--- a/llvm/include/llvm/IR/TrackingMDRef.h
+++ b/llvm/include/llvm/IR/TrackingMDRef.h
@@ -69,13 +69,6 @@ public:
     track();
   }
 
-  /// Check whether this has a trivial destructor.
-  ///
-  /// If \c MD isn't replaceable, the destructor will be a no-op.
-  bool hasTrivialDestructor() const {
-    return !MD || !MetadataTracking::isReplaceable(*MD);
-  }
-
   bool operator==(const TrackingMDRef &X) const { return MD == X.MD; }
   bool operator!=(const TrackingMDRef &X) const { return MD != X.MD; }
 
@@ -130,9 +123,6 @@ public:
 
   void reset() { Ref.reset(); }
   void reset(T *MD) { Ref.reset(static_cast<Metadata *>(MD)); }
-
-  /// Check whether this has a trivial destructor.
-  bool hasTrivialDestructor() const { return Ref.hasTrivialDestructor(); }
 };
 
 using TrackingMDNodeRef = TypedTrackingMDRef<MDNode>;

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -188,6 +188,11 @@ void LLParser::dropUnknownMetadataReferences() {
   for (GlobalVariable &GV : M->globals())
     GV.eraseMetadataIf(Pred);
 
+  llvm::erase_if(PendingDbgRecords,
+                 [](const auto &E) { return std::get<2>(E)->isTemporary(); });
+  llvm::erase_if(PendingDbgInsts,
+                 [](const auto &E) { return std::get<2>(E)->isTemporary(); });
+
   for (const auto &[ID, Info] : make_early_inc_range(ForwardRefMDNodes)) {
     // Check whether there is only a single use left, which would be in our
     // own NumberedMetadata.
@@ -424,6 +429,20 @@ bool LLParser::validateEndOfModule(bool UpgradeDebugInfo) {
     return error(ForwardRefMDNodes.begin()->second.second,
                  "use of undefined metadata '!" +
                      Twine(ForwardRefMDNodes.begin()->first) + "'");
+
+  // Set debug locations.
+  for (auto [Loc, DR, MD] : PendingDbgRecords) {
+    if (auto *DI = dyn_cast<DILocation>(MD))
+      DR->setDebugLoc(DebugLoc(DI));
+    else
+      return error(Loc, "invalid debug location");
+  }
+  for (auto [Loc, I, MD] : PendingDbgInsts) {
+    if (auto *DI = dyn_cast<DILocation>(MD))
+      I->setDebugLoc(DebugLoc(DI));
+    else
+      return error(Loc, "invalid !dbg metadata");
+  }
 
   // Resolve metadata cycles.
   for (auto &N : NumberedMetadata) {
@@ -2407,11 +2426,14 @@ bool LLParser::parseInstructionMetadata(Instruction &Inst) {
 
     unsigned MDK;
     MDNode *N;
+    auto Loc = Lex.getLoc();
     if (parseMetadataAttachment(MDK, N))
       return true;
 
     if (MDK == LLVMContext::MD_DIAssignID)
       TempDIAssignIDAttachments[N].push_back(&Inst);
+    else if (MDK == LLVMContext::MD_dbg)
+      PendingDbgInsts.emplace_back(Loc, &Inst, N);
     else
       Inst.setMetadata(MDK, N);
 
@@ -7479,7 +7501,8 @@ bool LLParser::parseDebugRecord(DbgRecord *&DR, PerFunctionState &PFS) {
       return true;
     if (parseToken(lltok::rparen, "Expected ')' here"))
       return true;
-    DR = DbgLabelRecord::createUnresolvedDbgLabelRecord(Label, DbgLoc);
+    DR = DbgLabelRecord::createUnresolvedDbgLabelRecord(Label);
+    PendingDbgRecords.emplace_back(DVRLoc, DR, DbgLoc);
     return false;
   }
 
@@ -7547,7 +7570,8 @@ bool LLParser::parseDebugRecord(DbgRecord *&DR, PerFunctionState &PFS) {
     return true;
   DR = DbgVariableRecord::createUnresolvedDbgVariableRecord(
       ValueType, ValLocMD, Variable, Expression, AssignID, AddressLocation,
-      AddressExpression, DebugLoc);
+      AddressExpression);
+  PendingDbgRecords.emplace_back(DVRLoc, DR, DebugLoc);
   return false;
 }
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -1196,9 +1196,9 @@ bool MIParser::parse(MachineInstr *&MI) {
     } else {
       return error("expected a metadata node after 'debug-location'");
     }
-    if (!isa<DILocation>(Node))
+    DebugLocation = DebugLoc(dyn_cast<DILocation>(Node));
+    if (!DebugLocation)
       return error("referenced metadata is not a DILocation");
-    DebugLocation = DebugLoc(cast<DILocation>(Node));
   }
 
   // Parse the machine memory operands.

--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -1198,7 +1198,7 @@ bool MIParser::parse(MachineInstr *&MI) {
     }
     if (!isa<DILocation>(Node))
       return error("referenced metadata is not a DILocation");
-    DebugLocation = DebugLoc(Node);
+    DebugLocation = DebugLoc(cast<DILocation>(Node));
   }
 
   // Parse the machine memory operands.

--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -101,8 +101,6 @@ MachineInstr::MachineInstr(MachineFunction &MF, const MCInstrDesc &TID,
                            DebugLoc DL, bool NoImp)
     : MCID(&TID), NumOperands(0), Flags(0), AsmPrinterFlags(0),
       Opcode(TID.Opcode), DebugInstrNum(0), DbgLoc(std::move(DL)) {
-  assert(DbgLoc.hasTrivialDestructor() && "Expected trivial destructor");
-
   // Reserve space for the expected number of operands.
   if (unsigned NumOps = MCID->getNumOperands() + MCID->implicit_defs().size() +
                         MCID->implicit_uses().size()) {
@@ -121,8 +119,6 @@ MachineInstr::MachineInstr(MachineFunction &MF, const MachineInstr &MI)
     : MCID(&MI.getDesc()), NumOperands(0), Flags(0), AsmPrinterFlags(0),
       Opcode(MI.getOpcode()), DebugInstrNum(0), Info(MI.Info),
       DbgLoc(MI.getDebugLoc()) {
-  assert(DbgLoc.hasTrivialDestructor() && "Expected trivial destructor");
-
   CapOperands = OperandCapacity::get(MI.getNumOperands());
   Operands = MF.allocateOperandArray(CapOperands);
 

--- a/llvm/lib/CodeGen/SelectionDAG/InstrEmitter.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/InstrEmitter.cpp
@@ -706,12 +706,10 @@ void InstrEmitter::EmitRegSequence(SDNode *Node, VRBaseMapType &VRBaseMap,
 
 /// EmitDbgValue - Generate machine instruction for a dbg_value node.
 ///
-MachineInstr *
-InstrEmitter::EmitDbgValue(SDDbgValue *SD,
-                           VRBaseMapType &VRBaseMap) {
-  DebugLoc DL = SD->getDebugLoc();
+MachineInstr *InstrEmitter::EmitDbgValue(SDDbgValue *SD,
+                                         VRBaseMapType &VRBaseMap) {
   assert(cast<DILocalVariable>(SD->getVariable())
-             ->isValidLocationForIntrinsic(DL) &&
+             ->isValidLocationForIntrinsic(SD->getDebugLoc()) &&
          "Expected inlined-at fields to agree");
 
   SD->setIsEmitted();

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -2392,9 +2392,9 @@ OpenMPIRBuilder::InsertPointOrErrorTy OpenMPIRBuilder::createTaskloop(
   Value *TaskDupFn = *TaskDupFnOrErr;
 
   OI->PostOutlineCB = [this, Ident, LBVal, UBVal, StepVal, Untied,
-                       TaskloopAllocaBB, CLI, Loc, TaskDupFn, ToBeDeleted,
-                       IfCond, GrainSize, NoGroup, Sched, FakeLB, FakeUB,
-                       FakeStep, FakeSharedsTy, Final, Mergeable, Priority,
+                       TaskloopAllocaBB, CLI, TaskDupFn, ToBeDeleted, IfCond,
+                       GrainSize, NoGroup, Sched, FakeLB, FakeUB, FakeStep,
+                       FakeSharedsTy, Final, Mergeable, Priority,
                        NumOfCollapseLoops](Function &OutlinedFn) mutable {
     // Replace the Stale CI by appropriate RTL function call.
     assert(OutlinedFn.hasOneUse() &&

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -4894,32 +4894,24 @@ static Metadata *unwrapMAVMetadataOp(CallBase *CI, unsigned Op) {
   return nullptr;
 }
 
-static MDNode *getDebugLocSafe(const Instruction *I) {
-  // The MDNode attached to this instruction might not be the correct type,
-  // as the verifier has not yet be run. Fetch it as a bare MDNode.
-  return I->getDebugLoc().getAsMDNode();
-}
-
 /// Convert debug intrinsic calls to non-instruction debug records.
 /// \p Name - Final part of the intrinsic name, e.g. 'value' in llvm.dbg.value.
 /// \p CI - The debug intrinsic call.
 static void upgradeDbgIntrinsicToDbgRecord(StringRef Name, CallBase *CI) {
   DbgRecord *DR = nullptr;
   if (Name == "label") {
-    DR = DbgLabelRecord::createUnresolvedDbgLabelRecord(unwrapMAVOp(CI, 0),
-                                                        CI->getDebugLoc());
+    DR = DbgLabelRecord::createUnresolvedDbgLabelRecord(unwrapMAVOp(CI, 0));
   } else if (Name == "assign") {
     DR = DbgVariableRecord::createUnresolvedDbgVariableRecord(
         DbgVariableRecord::LocationType::Assign, unwrapMAVMetadataOp(CI, 0),
         unwrapMAVOp(CI, 1), unwrapMAVOp(CI, 2), unwrapMAVOp(CI, 3),
         unwrapMAVMetadataOp(CI, 4),
         /*The address is a Value ref, it will be stored as a Metadata */
-        unwrapMAVOp(CI, 5), getDebugLocSafe(CI));
+        unwrapMAVOp(CI, 5));
   } else if (Name == "declare") {
     DR = DbgVariableRecord::createUnresolvedDbgVariableRecord(
         DbgVariableRecord::LocationType::Declare, unwrapMAVMetadataOp(CI, 0),
-        unwrapMAVOp(CI, 1), unwrapMAVOp(CI, 2), nullptr, nullptr, nullptr,
-        getDebugLocSafe(CI));
+        unwrapMAVOp(CI, 1), unwrapMAVOp(CI, 2), nullptr, nullptr, nullptr);
   } else if (Name == "addr") {
     // Upgrade dbg.addr to dbg.value with DW_OP_deref.
     MDNode *ExprNode = unwrapMAVOp(CI, 2);
@@ -4930,8 +4922,7 @@ static void upgradeDbgIntrinsicToDbgRecord(StringRef Name, CallBase *CI) {
     }
     DR = DbgVariableRecord::createUnresolvedDbgVariableRecord(
         DbgVariableRecord::LocationType::Value, unwrapMAVMetadataOp(CI, 0),
-        unwrapMAVOp(CI, 1), ExprNode, nullptr, nullptr, nullptr,
-        getDebugLocSafe(CI));
+        unwrapMAVOp(CI, 1), ExprNode, nullptr, nullptr, nullptr);
   } else if (Name == "value") {
     // An old version of dbg.value had an extra offset argument.
     unsigned VarOp = 1;
@@ -4947,8 +4938,9 @@ static void upgradeDbgIntrinsicToDbgRecord(StringRef Name, CallBase *CI) {
     DR = DbgVariableRecord::createUnresolvedDbgVariableRecord(
         DbgVariableRecord::LocationType::Value, unwrapMAVMetadataOp(CI, 0),
         unwrapMAVOp(CI, VarOp), unwrapMAVOp(CI, ExprOp), nullptr, nullptr,
-        nullptr, getDebugLocSafe(CI));
+        nullptr);
   }
+  DR->setDebugLoc(CI->getDebugLoc());
   assert(DR && "Unhandled intrinsic kind in upgrade to DbgRecord");
   CI->getParent()->insertDbgRecordBefore(DR, CI->getIterator());
 }

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -3486,14 +3486,14 @@ LLVMMetadataRef LLVMGetCurrentDebugLocation2(LLVMBuilderRef Builder) {
 
 void LLVMSetCurrentDebugLocation2(LLVMBuilderRef Builder, LLVMMetadataRef Loc) {
   if (Loc)
-    unwrap(Builder)->SetCurrentDebugLocation(DebugLoc(unwrap<MDNode>(Loc)));
+    unwrap(Builder)->SetCurrentDebugLocation(DebugLoc(unwrap<DILocation>(Loc)));
   else
     unwrap(Builder)->SetCurrentDebugLocation(DebugLoc());
 }
 
 void LLVMSetCurrentDebugLocation(LLVMBuilderRef Builder, LLVMValueRef L) {
-  MDNode *Loc =
-      L ? cast<MDNode>(unwrap<MetadataAsValue>(L)->getMetadata()) : nullptr;
+  DILocation *Loc =
+      L ? cast<DILocation>(unwrap<MetadataAsValue>(L)->getMetadata()) : nullptr;
   unwrap(Builder)->SetCurrentDebugLocation(DebugLoc(Loc));
 }
 

--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -1990,7 +1990,7 @@ LLVMMetadataRef LLVMInstructionGetDebugLoc(LLVMValueRef Inst) {
 
 void LLVMInstructionSetDebugLoc(LLVMValueRef Inst, LLVMMetadataRef Loc) {
   if (Loc)
-    unwrap<Instruction>(Inst)->setDebugLoc(DebugLoc(unwrap<MDNode>(Loc)));
+    unwrap<Instruction>(Inst)->setDebugLoc(DebugLoc(unwrap<DILocation>(Loc)));
   else
     unwrap<Instruction>(Inst)->setDebugLoc(DebugLoc());
 }

--- a/llvm/lib/IR/DebugLoc.cpp
+++ b/llvm/lib/IR/DebugLoc.cpp
@@ -42,12 +42,6 @@ DILocAndCoverageTracking::DILocAndCoverageTracking(const DILocation *L)
 //===----------------------------------------------------------------------===//
 // DebugLoc Implementation
 //===----------------------------------------------------------------------===//
-DebugLoc::DebugLoc(const DILocation *L) : Loc(const_cast<DILocation *>(L)) {}
-DebugLoc::DebugLoc(const MDNode *L) : Loc(const_cast<MDNode *>(L)) {}
-
-DILocation *DebugLoc::get() const {
-  return cast_or_null<DILocation>(Loc.get());
-}
 
 unsigned DebugLoc::getLine() const {
   assert(get() && "Expected valid DebugLoc");
@@ -81,6 +75,8 @@ DebugLoc DebugLoc::getFnDebugLoc() const {
 
   return DebugLoc();
 }
+
+MDNode *DebugLoc::getAsMDNode() const { return Loc; }
 
 bool DebugLoc::isImplicitCode() const {
   if (DILocation *Loc = get())

--- a/llvm/lib/IR/DebugLoc.cpp
+++ b/llvm/lib/IR/DebugLoc.cpp
@@ -33,12 +33,6 @@ void DbgLocOrigin::addTrace() {
 }
 #endif // LLVM_ENABLE_DEBUGLOC_TRACKING_ORIGIN
 
-#if LLVM_ENABLE_DEBUGLOC_TRACKING_COVERAGE
-DILocAndCoverageTracking::DILocAndCoverageTracking(const DILocation *L)
-    : TrackingMDNodeRef(const_cast<DILocation *>(L)), DbgLocOrigin(!L),
-      Kind(DebugLocKind::Normal) {}
-#endif // LLVM_ENABLE_DEBUGLOC_TRACKING_COVERAGE
-
 //===----------------------------------------------------------------------===//
 // DebugLoc Implementation
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/IR/DebugProgramInstruction.cpp
+++ b/llvm/lib/IR/DebugProgramInstruction.cpp
@@ -145,8 +145,8 @@ DbgRecord::createDebugIntrinsic(Module *M, Instruction *InsertBefore) const {
   llvm_unreachable("unsupported DbgRecord kind");
 }
 
-DbgLabelRecord::DbgLabelRecord(MDNode *Label, MDNode *DL)
-    : DbgRecord(LabelKind, DebugLoc(DL)), Label(Label) {
+DbgLabelRecord::DbgLabelRecord(MDNode *Label)
+    : DbgRecord(LabelKind, DebugLoc()), Label(Label) {
   assert(Label && "Unexpected nullptr");
   assert((isa<DILabel>(Label) || Label->isTemporary()) &&
          "Label type must be or resolve to a DILabel");
@@ -156,26 +156,25 @@ DbgLabelRecord::DbgLabelRecord(DILabel *Label, DebugLoc DL)
   assert(Label && "Unexpected nullptr");
 }
 
-DbgLabelRecord *DbgLabelRecord::createUnresolvedDbgLabelRecord(MDNode *Label,
-                                                               MDNode *DL) {
-  return new DbgLabelRecord(Label, DL);
+DbgLabelRecord *DbgLabelRecord::createUnresolvedDbgLabelRecord(MDNode *Label) {
+  return new DbgLabelRecord(Label);
 }
 
 DbgVariableRecord::DbgVariableRecord(DbgVariableRecord::LocationType Type,
                                      Metadata *Val, MDNode *Variable,
                                      MDNode *Expression, MDNode *AssignID,
                                      Metadata *Address,
-                                     MDNode *AddressExpression, MDNode *DI)
-    : DbgRecord(ValueKind, DebugLoc(DI)),
+                                     MDNode *AddressExpression)
+    : DbgRecord(ValueKind, DebugLoc()),
       DebugValueUser({Val, Address, AssignID}), Type(Type), Variable(Variable),
       Expression(Expression), AddressExpression(AddressExpression) {}
 
 DbgVariableRecord *DbgVariableRecord::createUnresolvedDbgVariableRecord(
     DbgVariableRecord::LocationType Type, Metadata *Val, MDNode *Variable,
     MDNode *Expression, MDNode *AssignID, Metadata *Address,
-    MDNode *AddressExpression, MDNode *DI) {
+    MDNode *AddressExpression) {
   return new DbgVariableRecord(Type, Val, Variable, Expression, AssignID,
-                               Address, AddressExpression, DI);
+                               Address, AddressExpression);
 }
 
 DbgVariableRecord *

--- a/llvm/lib/IR/Metadata.cpp
+++ b/llvm/lib/IR/Metadata.cpp
@@ -1754,7 +1754,7 @@ void Instruction::setMetadata(unsigned KindID, MDNode *Node) {
 
   // Handle 'dbg' as a special case since it is not stored in the hash table.
   if (KindID == LLVMContext::MD_dbg) {
-    DbgLoc = DebugLoc(Node);
+    DbgLoc = DebugLoc(cast_or_null<DILocation>(Node));
     return;
   }
 

--- a/llvm/test/Assembler/dbg-declare-invalid-debug-loc.ll
+++ b/llvm/test/Assembler/dbg-declare-invalid-debug-loc.ll
@@ -1,14 +1,10 @@
-; RUN: opt %s -o /dev/null -S 2>&1 | FileCheck %s
+; RUN: not opt %s -o /dev/null -S 2>&1 | FileCheck %s
 ;
 ; The last dbg.declare intrinsic in this file has an illegal DILocation -- this
 ; needs to pass through the autoupgrade to #dbg_declare process and then get
-; caught by the verifier.
+; caught at the end of the parser.
 ;
-; CHECK:      invalid #dbg record DILocation
-; CHECK-NEXT: #dbg_declare(ptr %1, ![[VAR:[0-9]+]], !DIExpression(), ![[PROG:[0-9]+]])
-; CHECK-NEXT: ![[PROG]] = distinct !DISubprogram(name: "IgnoreIntrinsicTest",
-; CHECK-NEXT: label %0
-; CHECK-NEXT: ptr @IgnoreIntrinsicTest
+; CHECK: invalid !dbg metadata
 
 declare void @llvm.dbg.declare(metadata, metadata, metadata)
 

--- a/llvm/test/Assembler/dbg.ll
+++ b/llvm/test/Assembler/dbg.ll
@@ -1,0 +1,12 @@
+; RUN: not llvm-as -disable-output <%s 2>&1 | FileCheck %s
+
+define void @foo() {
+  ret void, !dbg !{}
+; CHECK: invalid !dbg metadata
+}
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = distinct !DISubprogram(type: !3)
+!2 = !{null}
+!3 = !DISubroutineType(types: !2)

--- a/llvm/test/CodeGen/X86/stack-protector-dbginfo.ll
+++ b/llvm/test/CodeGen/X86/stack-protector-dbginfo.ll
@@ -21,7 +21,7 @@ entry:
 define i32 @IgnoreIntrinsicTest() #1 {
 ; IGNORE_INTRIN: IgnoreIntrinsicTest:
   %1 = alloca i32, align 4
-  call void @llvm.dbg.declare(metadata ptr %1, metadata !73, metadata !DIExpression()), !dbg !74
+  call void @llvm.dbg.declare(metadata ptr %1, metadata !73, metadata !DIExpression()), !dbg !75
   store volatile i32 1, ptr %1, align 4
   %2 = load volatile i32, ptr %1, align 4
   %3 = mul nsw i32 %2, 42

--- a/llvm/test/DebugInfo/Generic/2009-10-16-Phi.ll
+++ b/llvm/test/DebugInfo/Generic/2009-10-16-Phi.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -disable-output
+; RUN: not llvm-as %s -disable-output 2>&1 | FileCheck %s
 
 define i32 @foo() {
 E:
@@ -6,6 +6,7 @@ E:
 B1:
    br label %B2
 B2:
+; CHECK: error: invalid !dbg metadata
    %0 = phi i32 [ 0, %E ], [ 1, %B1 ], !dbg !0
    ret i32 %0
 }

--- a/llvm/test/DebugInfo/Generic/location-verifier.ll
+++ b/llvm/test/DebugInfo/Generic/location-verifier.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as -disable-output -o - < %s 2>&1 | FileCheck %s
+; RUN: not llvm-as -disable-output -o - < %s 2>&1 | FileCheck %s
 ; ModuleID = 'test.c'
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-apple-macosx10.10.0"
@@ -27,7 +27,6 @@ attributes #0 = { nounwind ssp uwtable }
 !10 = !{i32 2, !"Debug Info Version", i32 3}
 !11 = !{i32 1, !"PIC Level", i32 2}
 !12 = !{!"clang version 3.7.0 "}
-; An old-style DILocation should not pass verify.
-; CHECK: invalid !dbg metadata attachment
+; An old-style DILocation should not parse.
+; CHECK: invalid !dbg metadata
 !13 = !{i32 2, i32 2, !4, null}
-; CHECK: warning: ignoring invalid debug info

--- a/llvm/test/DebugInfo/MIR/X86/regcoalescer.mir
+++ b/llvm/test/DebugInfo/MIR/X86/regcoalescer.mir
@@ -6,7 +6,7 @@
 
   define i32 @main() local_unnamed_addr !dbg !14 {
   entry:
-    %shl = shl i32 undef, undef, !dbg !19
+    %shl = shl i32 undef, undef, !dbg !20
     tail call void @llvm.dbg.value(metadata i32 %shl, metadata !18, metadata !DIExpression()), !dbg !20
     ret i32 %shl, !dbg !21
   }

--- a/llvm/test/Transforms/MergeFunc/mergefunc-preserve-nonnull.ll
+++ b/llvm/test/Transforms/MergeFunc/mergefunc-preserve-nonnull.ll
@@ -55,7 +55,7 @@ define void @noundef_dbg(ptr %0, ptr %1) {
 ; CHECK-NEXT:    tail call void @noundef(ptr [[TMP0:%.*]], ptr [[TMP1:%.*]])
 ; CHECK-NEXT:    ret void
 ;
-  %3 = load ptr, ptr %1, align 8, !noundef !0, !dbg !1
+  %3 = load ptr, ptr %1, align 8, !noundef !0, !dbg !8
   store ptr %3, ptr %0, align 8
   ret void
 }
@@ -79,3 +79,4 @@ define void @noalias_2(ptr %0, ptr %1) {
 !5 = !{!5}
 !6 = !{!6, !5}
 !7 = !{!6}
+!8 = !DILocation(line: 1, column: 1, scope: !{})

--- a/llvm/test/Verifier/RemoveDI/llvm.dbg.intrinsic-dbg-attachment.ll
+++ b/llvm/test/Verifier/RemoveDI/llvm.dbg.intrinsic-dbg-attachment.ll
@@ -5,22 +5,6 @@ entry:
       ptr undef,
       !DILocalVariable(scope: !1),
       !DIExpression(),
-      !{})
-; CHECK-LABEL: invalid #dbg record DILocation
-; CHECK-NEXT: #dbg_value({{.*}})
-
-    #dbg_declare(
-      ptr undef,
-      !DILocalVariable(scope: !1),
-      !DIExpression(),
-      !{})
-; CHECK-LABEL: invalid #dbg record DILocation
-; CHECK-NEXT: #dbg_declare({{.*}})
-
-    #dbg_value(
-      ptr undef,
-      !DILocalVariable(scope: !1),
-      !DIExpression(),
       !DILocation(scope: !2))
 ; CHECK-LABEL: mismatched subprogram between #dbg record variable and DILocation
 ; CHECK-NEXT: #dbg_value({{[^,]+}}, ![[VAR:[0-9]+]], {{[^,]+}}, ![[LOC:[0-9]+]]

--- a/llvm/test/Verifier/dbg.ll
+++ b/llvm/test/Verifier/dbg.ll
@@ -8,10 +8,7 @@ entry:
 ; CHECK-NEXT: ![[IA]] = !{}
 
 exit:
-  ret void, !dbg !{}
-; CHECK: invalid !dbg metadata attachment
-; CHECK-NEXT: ret void, !dbg ![[LOC:[0-9]+]]
-; CHECK-NEXT: ![[LOC]] = !{}
+  ret void
 }
 
 ; CHECK: warning: ignoring invalid debug info

--- a/llvm/test/tools/llvm-reduce/remove-metadata.ll
+++ b/llvm/test/tools/llvm-reduce/remove-metadata.ll
@@ -7,10 +7,10 @@
 ; RUN: llvm-reduce -abort-on-invalid-reduction --test %python --test-arg %p/Inputs/remove-metadata.py %s -o %t
 ; RUN: FileCheck --implicit-check-not=! %s < %t
 
-@global = global i32 0, !dbg !0
+@global = global i32 0, !foo !0
 
-define void @main() !dbg !0 {
-   ret void, !dbg !0
+define void @main() !foo !0 {
+   ret void, !foo !0
 }
 
 !uninteresting = !{!0}

--- a/llvm/unittests/Analysis/IRSimilarityIdentifierTest.cpp
+++ b/llvm/unittests/Analysis/IRSimilarityIdentifierTest.cpp
@@ -1318,12 +1318,13 @@ TEST(IRInstructionMapper, DebugInfoInvisible) {
                           define i32 @f(i32 %a, i32 %b) {
                           then:
                             %0 = add i32 %a, %b
-                              #dbg_value(i32 0, !0, !0, !0)
+                              #dbg_value(i32 0, !0, !0, !1)
                             %1 = add i32 %a, %b
                             ret i32 0
                           }
 
-                          !0 = distinct !{!"test\00", i32 10})";
+                          !0 = distinct !{!"test\00", i32 10}
+                          !1 = !DILocation(line: 1, column: 1, scope: !{}))";
   LLVMContext Context;
   std::unique_ptr<Module> M = makeLLVMModule(Context, ModuleString);
 
@@ -1925,12 +1926,12 @@ TEST(IRSimilarityCandidate, IdenticalWithDebug) {
                           define i32 @f(i32 %a, i32 %b) {
                           bb0:
                              %0 = add i32 %a, %b
-                               #dbg_value(i32 0, !0, !0, !0)
+                               #dbg_value(i32 0, !0, !0, !2)
                              %1 = add i32 %b, %a
                              ret i32 0
                           bb1:
                              %2 = add i32 %a, %b
-                               #dbg_value(i32 1, !1, !1, !1)
+                               #dbg_value(i32 1, !1, !1, !2)
                              %3 = add i32 %b, %a
                              ret i32 0
                           bb2:
@@ -1940,7 +1941,8 @@ TEST(IRSimilarityCandidate, IdenticalWithDebug) {
                           }
 
                           !0 = distinct !{!"test\00", i32 10}
-                          !1 = distinct !{!"test\00", i32 11})";
+                          !1 = distinct !{!"test\00", i32 11}
+                          !2 = !DILocation(line: 1, column: 1, scope: !{}))";
   LLVMContext Context;
   std::unique_ptr<Module> M = makeLLVMModule(Context, ModuleString);
 

--- a/llvm/unittests/CodeGen/MachineInstrTest.cpp
+++ b/llvm/unittests/CodeGen/MachineInstrTest.cpp
@@ -512,8 +512,12 @@ MATCHER_P(HasMIMetadata, MIMD, "") {
 TEST(MachineInstrBuilder, BuildMI) {
   LLVMContext Ctx;
   MDNode *PCS = MDNode::getDistinct(Ctx, {});
-  MDNode *DI = MDNode::getDistinct(Ctx, {});
-  DebugLoc DL(DI);
+  DIFile *DIF = DIFile::getDistinct(Ctx, "filename", "");
+  DISubprogram *DIS = DISubprogram::getDistinct(
+      Ctx, nullptr, "", "", DIF, 0, nullptr, 0, nullptr, 0, 0, DINode::FlagZero,
+      DISubprogram::SPFlagZero, nullptr);
+  DILocation *DIL = DILocation::get(Ctx, 1, 5, DIS);
+  DebugLoc DL(DIL);
   MIMetadata MIMD(DL, PCS);
   EXPECT_EQ(MIMD.getDL(), DL);
   EXPECT_EQ(MIMD.getPCSections(), PCS);

--- a/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
+++ b/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
@@ -2878,8 +2878,6 @@ TEST_F(OpenMPIRBuilderTest, MasterDirective) {
   F->setName("func");
   IRBuilder<> Builder(BB);
 
-  OpenMPIRBuilder::LocationDescription Loc({Builder.saveIP(), DL});
-
   AllocaInst *PrivAI = nullptr;
 
   BasicBlock *EntryBB = nullptr;
@@ -2959,8 +2957,6 @@ TEST_F(OpenMPIRBuilderTest, MaskedDirective) {
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
-
-  OpenMPIRBuilder::LocationDescription Loc({Builder.saveIP(), DL});
 
   AllocaInst *PrivAI = nullptr;
 
@@ -3042,8 +3038,6 @@ TEST_F(OpenMPIRBuilderTest, CriticalDirective) {
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
-
-  OpenMPIRBuilder::LocationDescription Loc({Builder.saveIP(), DL});
 
   Type *PrivType = F->arg_begin()->getType();
   AllocaInst *PrivAI = Builder.CreateAlloca(PrivType);
@@ -3128,8 +3122,6 @@ TEST_F(OpenMPIRBuilderTest, OrderedDirectiveDependSource) {
   IRBuilder<> Builder(BB);
   LLVMContext &Ctx = M->getContext();
 
-  OpenMPIRBuilder::LocationDescription Loc({Builder.saveIP(), DL});
-
   InsertPointTy AllocaIP(&F->getEntryBlock(),
                          F->getEntryBlock().getFirstInsertionPt());
 
@@ -3213,8 +3205,6 @@ TEST_F(OpenMPIRBuilderTest, OrderedDirectiveDependSink) {
   IRBuilder<> Builder(BB);
   LLVMContext &Ctx = M->getContext();
 
-  OpenMPIRBuilder::LocationDescription Loc({Builder.saveIP(), DL});
-
   InsertPointTy AllocaIP(&F->getEntryBlock(),
                          F->getEntryBlock().getFirstInsertionPt());
 
@@ -3297,8 +3287,6 @@ TEST_F(OpenMPIRBuilderTest, OrderedDirectiveThreads) {
   F->setName("func");
   IRBuilder<> Builder(BB);
 
-  OpenMPIRBuilder::LocationDescription Loc({Builder.saveIP(), DL});
-
   Type *PrivType = F->arg_begin()->getType();
   AllocaInst *PrivAI = Builder.CreateAlloca(PrivType, nullptr, "priv.inst");
 
@@ -3374,8 +3362,6 @@ TEST_F(OpenMPIRBuilderTest, OrderedDirectiveSimd) {
   F->setName("func");
   IRBuilder<> Builder(BB);
 
-  OpenMPIRBuilder::LocationDescription Loc({Builder.saveIP(), DL});
-
   Type *PrivType = F->arg_begin()->getType();
   AllocaInst *PrivAI = Builder.CreateAlloca(PrivType, nullptr, "priv.inst");
 
@@ -3441,8 +3427,6 @@ TEST_F(OpenMPIRBuilderTest, CopyinBlocks) {
   F->setName("func");
   IRBuilder<> Builder(BB);
 
-  OpenMPIRBuilder::LocationDescription Loc({Builder.saveIP(), DL});
-
   IntegerType *Int32 = Type::getInt32Ty(M->getContext());
   AllocaInst *MasterAddress = Builder.CreateAlloca(Builder.getPtrTy());
   AllocaInst *PrivAddress = Builder.CreateAlloca(Builder.getPtrTy());
@@ -3476,8 +3460,6 @@ TEST_F(OpenMPIRBuilderTest, SingleDirective) {
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
-
-  OpenMPIRBuilder::LocationDescription Loc({Builder.saveIP(), DL});
 
   AllocaInst *PrivAI = nullptr;
 
@@ -3570,8 +3552,6 @@ TEST_F(OpenMPIRBuilderTest, SingleDirectiveNowait) {
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
-
-  OpenMPIRBuilder::LocationDescription Loc({Builder.saveIP(), DL});
 
   AllocaInst *PrivAI = nullptr;
 
@@ -3684,8 +3664,6 @@ TEST_F(OpenMPIRBuilderTest, SingleDirectiveCopyPrivate) {
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
-
-  OpenMPIRBuilder::LocationDescription Loc({Builder.saveIP(), DL});
 
   AllocaInst *PrivAI = nullptr;
 
@@ -3989,8 +3967,6 @@ TEST_F(OpenMPIRBuilderTest, OMPAtomicUpdate) {
   F->setName("func");
   IRBuilder<> Builder(BB);
 
-  OpenMPIRBuilder::LocationDescription Loc({Builder.saveIP(), DL});
-
   IntegerType *Int32 = Type::getInt32Ty(M->getContext());
   AllocaInst *XVal = Builder.CreateAlloca(Int32);
   XVal->setName("AtomicVar");
@@ -4058,8 +4034,6 @@ TEST_F(OpenMPIRBuilderTest, OMPAtomicUpdateFloat) {
   F->setName("func");
   IRBuilder<> Builder(BB);
 
-  OpenMPIRBuilder::LocationDescription Loc({Builder.saveIP(), DL});
-
   Type *FloatTy = Type::getFloatTy(M->getContext());
   AllocaInst *XVal = Builder.CreateAlloca(FloatTy);
   XVal->setName("AtomicVar");
@@ -4125,8 +4099,6 @@ TEST_F(OpenMPIRBuilderTest, OMPAtomicUpdateIntr) {
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
-
-  OpenMPIRBuilder::LocationDescription Loc({Builder.saveIP(), DL});
 
   Type *IntTy = Type::getInt32Ty(M->getContext());
   AllocaInst *XVal = Builder.CreateAlloca(IntTy);
@@ -4195,8 +4167,6 @@ TEST_F(OpenMPIRBuilderTest, OMPAtomicCapture) {
   F->setName("func");
   IRBuilder<> Builder(BB);
 
-  OpenMPIRBuilder::LocationDescription Loc({Builder.saveIP(), DL});
-
   LLVMContext &Ctx = M->getContext();
   IntegerType *Int32 = Type::getInt32Ty(Ctx);
   AllocaInst *XVal = Builder.CreateAlloca(Int32);
@@ -4246,8 +4216,6 @@ TEST_F(OpenMPIRBuilderTest, OMPAtomicCompare) {
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
-
-  OpenMPIRBuilder::LocationDescription Loc({Builder.saveIP(), DL});
 
   LLVMContext &Ctx = M->getContext();
   IntegerType *Int32 = Type::getInt32Ty(Ctx);
@@ -4306,8 +4274,6 @@ TEST_F(OpenMPIRBuilderTest, OMPAtomicCompareCapture) {
   OMPBuilder.initialize();
   F->setName("func");
   IRBuilder<> Builder(BB);
-
-  OpenMPIRBuilder::LocationDescription Loc({Builder.saveIP(), DL});
 
   LLVMContext &Ctx = M->getContext();
   IntegerType *Int32 = Type::getInt32Ty(Ctx);
@@ -4661,7 +4627,6 @@ TEST_F(OpenMPIRBuilderTest, CreateTeams) {
     return Error::success();
   };
 
-  OpenMPIRBuilder::LocationDescription Loc({Builder.saveIP(), DL});
   ASSERT_EXPECTED_INIT(
       OpenMPIRBuilder::InsertPointTy, AfterIP,
       OMPBuilder.createTeams(Builder, BodyGenCB, /*NumTeamsLower=*/nullptr,
@@ -4913,7 +4878,6 @@ TEST_F(OpenMPIRBuilderTest, CreateTeamsWithNumTeamsAndThreadLimit) {
     return Error::success();
   };
 
-  OpenMPIRBuilder::LocationDescription Loc({Builder.saveIP(), DL});
   ASSERT_EXPECTED_INIT(OpenMPIRBuilder::InsertPointTy, AfterIP,
                        OMPBuilder.createTeams(Builder, BodyGenCB, NumTeamsLower,
                                               NumTeamsUpper, ThreadLimit,

--- a/llvm/unittests/IR/InstructionsTest.cpp
+++ b/llvm/unittests/IR/InstructionsTest.cpp
@@ -768,7 +768,7 @@ TEST(InstructionsTest, AlterCallBundles) {
   AttrBuilder AB(C);
   AB.addAttribute(Attribute::Cold);
   Call->setAttributes(AttributeList::get(C, AttributeList::FunctionIndex, AB));
-  Call->setDebugLoc(DebugLoc(MDNode::get(C, {})));
+  Call->setDebugLoc(DebugLoc(DILocation::get(C, 1, 1, MDNode::get(C, {}))));
 
   OperandBundleDef NewBundle("after", ConstantInt::get(Int32Ty, 7));
   std::unique_ptr<CallInst> Clone(CallInst::Create(Call.get(), NewBundle));
@@ -798,7 +798,7 @@ TEST(InstructionsTest, AlterInvokeBundles) {
   AB.addAttribute(Attribute::Cold);
   Invoke->setAttributes(
       AttributeList::get(C, AttributeList::FunctionIndex, AB));
-  Invoke->setDebugLoc(DebugLoc(MDNode::get(C, {})));
+  Invoke->setDebugLoc(DebugLoc(DILocation::get(C, 1, 1, MDNode::get(C, {}))));
 
   OperandBundleDef NewBundle("after", ConstantInt::get(Int32Ty, 7));
   std::unique_ptr<InvokeInst> Clone(

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -2010,7 +2010,7 @@ bb1:
   ret void, !tbaa !2
 }
 
-!1 = !{}
+!1 = !DILocation(line: 12, column: 1, scope: !{})
 !2 = !{}
 )IR");
   llvm::Function *LLVMF = &*M->getFunction("foo");


### PR DESCRIPTION
TrackingMDNodeRef is expensive and the tracking functionality is only
used when parsing textual LLVM IR. Therefore, store a plain DILocation
pointer in DebugLoc and update the debug locs explicitly when parsing
finishes.

Invalid debug metadata now fails directly at parsing and not (just)
later when verifying. A consequence is that old-style DILocations cannot
be parsed from textual IR anymore.

As related cleanup, remove the now-unused hasTrivialDestructor() on
TrackingMDRef.

While work on changing DILocation to no longer be metadata is on the
way, it is going to take a while to finish, we can get this immediate
performance and max-rss improvement earlier.
