### PR TITLE
[ADT] Add `_twine` literal for length-aware `Twine`s

### DIFF
--- a/llvm/include/llvm/ADT/Twine.h
+++ b/llvm/include/llvm/ADT/Twine.h
@@ -187,6 +187,8 @@ class Twine {
     assert(isValid() && "Invalid twine!");
   }
 
+  friend Twine operator""_twine(const char *Str, size_t Len);
+
   /// Check for the null twine.
   bool isNull() const { return getLHSKind() == NullKind; }
 
@@ -539,6 +541,15 @@ inline Twine operator+(const char *LHS, StringRef RHS) {
 
 inline Twine operator+(StringRef LHS, const char *RHS) {
   return Twine(LHS, RHS);
+}
+
+/// Construct a Twine from a string literal.
+inline Twine operator""_twine(const char *Str, size_t Len) {
+  Twine::Child LHS, RHS;
+  LHS.ptrAndLength.ptr = Str;
+  LHS.ptrAndLength.length = Len;
+  RHS.twine = nullptr;
+  return Twine(LHS, Twine::StringLiteralKind, RHS, Twine::EmptyKind);
 }
 
 inline raw_ostream &operator<<(raw_ostream &OS, const Twine &RHS) {

--- a/llvm/unittests/ADT/TwineTest.cpp
+++ b/llvm/unittests/ADT/TwineTest.cpp
@@ -26,6 +26,7 @@ std::string repr(const Twine &Value) {
 TEST(TwineTest, Construction) {
   EXPECT_EQ("", Twine().str());
   EXPECT_EQ("hi", Twine("hi").str());
+  EXPECT_EQ("hi", "hi"_twine.str());
   EXPECT_EQ("hi", Twine(std::string("hi")).str());
   EXPECT_EQ("hi", Twine(StringRef("hi")).str());
   EXPECT_EQ("hi", Twine(StringRef(std::string("hi"))).str());
@@ -100,6 +101,9 @@ TEST(TwineTest, toNullTerminatedStringRef) {
   EXPECT_EQ(
       0,
       *Twine(StringLiteral("hello")).toNullTerminatedStringRef(storage).end());
+  StringRef LiteralRef = "hello"_twine.toNullTerminatedStringRef(storage);
+  EXPECT_EQ("hello", LiteralRef);
+  EXPECT_EQ(0, *LiteralRef.end());
   EXPECT_EQ(0, *Twine(SmallString<11>("hello"))
                     .toNullTerminatedStringRef(storage)
                     .end());
@@ -110,8 +114,14 @@ TEST(TwineTest, toNullTerminatedStringRef) {
 
 TEST(TwineTest, isSingleStringLiteral) {
   EXPECT_TRUE(Twine(StringLiteral("hi")).isSingleStringLiteral());
+  EXPECT_TRUE("hi"_twine.isSingleStringLiteral());
   EXPECT_FALSE(Twine("hi").isSingleStringLiteral());
   EXPECT_FALSE(Twine(StringRef("hi")).isSingleStringLiteral());
+}
+
+TEST(TwineTest, UserDefinedLiteral) {
+  EXPECT_EQ("(Twine constexprPtrAndLength:\"hi\" empty)", repr("hi"_twine));
+  EXPECT_EQ(StringRef("a\0b", 3), "a\0b"_twine.getSingleStringRef());
 }
 
 TEST(TwineTest, LazyEvaluation) {


### PR DESCRIPTION
This avoids `strlen`-style length scans for literal `Twine` leaves. The new literal stores the pointer and length directly using `StringLiteralKind`, while the existing `Twine(const char *) `constructor and `CStringKind` behavior remain unchanged.

It also makes literal `Twine`s easier to read:
`"string literal"_twine` instead of `llvm::Twine("string literal")`.