### PR TITLE
[Clang][OpenMP] Fixed an assertion on omp taskloop transparent

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -349,6 +349,7 @@ features cannot lower the translation-unit ABI level;
 - Fixed an assertion failure when passing a wide string literal to `__builtin_nan`. (#GH212108)
 - Fixed a constraint comparison bug in partial ordering. (#GH182671)
 - Fixed a rejected-valid case that used an explicit object parameter in an out-of-line definition of a nested class member. (#GH136472)
+- Fixed an assertion on omp taskloop transparent (#GH197162)
 - Fixed a bug where `__func__`, `__PRETTY_FUNCTION__` and `__FUNCTION__` were not resolving to the proper function when inside a lambda return type (#GH211811)
 - Fixed USR generation for declarations whose signature mentions a class-type
   non-type template parameter. (#GH212351)

--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -3289,8 +3289,9 @@ OMPClause *Parser::ParseOpenMPClause(OpenMPDirectiveKind DKind,
     if (CKind == OMPC_transparent && PP.LookAhead(0).isNot(tok::l_paren)) {
       SourceLocation Loc = ConsumeToken();
       SourceLocation LLoc = Tok.getLocation();
-      Clause = Actions.OpenMP().ActOnOpenMPTransparentClause(nullptr, LLoc,
-                                                             LLoc, Loc);
+      if (!WrongDirective)
+        Clause = Actions.OpenMP().ActOnOpenMPTransparentClause(nullptr, LLoc,
+                                                               LLoc, Loc);
       break;
     }
     if ((CKind == OMPC_ordered || CKind == OMPC_partial) &&

--- a/clang/test/SemaOpenMP/gh197162.c
+++ b/clang/test/SemaOpenMP/gh197162.c
@@ -1,0 +1,6 @@
+// RUN: %clang_cc1 -fopenmp -fsyntax-only -verify %s
+
+void foo() {
+#pragma omp taskloop transparent // expected-error {{unexpected OpenMP clause 'transparent' in directive '#pragma omp taskloop'}}
+    for(int i = 0; i < 2; i++);
+}


### PR DESCRIPTION
In https://github.com/llvm/llvm-project/blob/15bb4a97a798ed43b3966c99d37585651b965e5e/clang/lib/Parse/ParseOpenMP.cpp#L3289-L3295
We missed a check for `WrongDirective` before calling `ActOnOpenMPTransparentClause`.

This patch adds the missing check.
fix #197162 