### PR TITLE
[SimplifyCFG] Permit less dense lookup tables

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -7093,11 +7093,12 @@ bool SwitchReplacement::isLookupTable() { return Kind == LookupTableKind; }
 
 bool SwitchReplacement::isBitMap() { return Kind == BitMapKind; }
 
-static bool isSwitchDense(uint64_t NumCases, uint64_t CaseRange) {
+static bool isSwitchDense(uint64_t NumCases, uint64_t CaseRange, bool OptSize) {
   // 40% is the default density for building a jump table in optsize/minsize
-  // mode. See also TargetLoweringBase::isSuitableForJumpTable(), which this
-  // function was based on.
-  const uint64_t MinDensity = 40;
+  // mode, 10% is the default density for jump tables. See also
+  // TargetLoweringBase::isSuitableForJumpTable(), which this function was based
+  // on.
+  const uint64_t MinDensity = OptSize ? 40 : 10;
 
   if (CaseRange >= UINT64_MAX / 100)
     return false; // Avoid multiplication overflows below.
@@ -7105,13 +7106,13 @@ static bool isSwitchDense(uint64_t NumCases, uint64_t CaseRange) {
   return NumCases * 100 >= CaseRange * MinDensity;
 }
 
-static bool isSwitchDense(ArrayRef<int64_t> Values) {
+static bool isSwitchDense(ArrayRef<int64_t> Values, bool OptSize) {
   uint64_t Diff = (uint64_t)Values.back() - (uint64_t)Values.front();
   uint64_t Range = Diff + 1;
   if (Range < Diff)
     return false; // Overflow.
 
-  return isSwitchDense(Values.size(), Range);
+  return isSwitchDense(Values.size(), Range, OptSize);
 }
 
 /// Determine whether a lookup table should be built for this switch, based on
@@ -7152,7 +7153,8 @@ static bool shouldBuildLookupTable(SwitchInst *SI, uint64_t TableSize,
   if (HasIllegalType)
     return false;
 
-  return isSwitchDense(SI->getNumCases(), TableSize);
+  return isSwitchDense(SI->getNumCases(), TableSize,
+                       SI->getFunction()->hasOptSize());
 }
 
 static bool shouldUseSwitchConditionAsTableIndex(
@@ -7635,7 +7637,7 @@ static bool reduceSwitchRange(SwitchInst *SI, IRBuilder<> &Builder,
   llvm::sort(Values);
 
   // If the switch is already dense, there's nothing useful to do here.
-  if (isSwitchDense(Values))
+  if (isSwitchDense(Values, SI->getFunction()->hasOptSize()))
     return false;
 
   // First, transform the values such that they start at zero and ascend.
@@ -7661,7 +7663,7 @@ static bool reduceSwitchRange(SwitchInst *SI, IRBuilder<> &Builder,
     for (auto &V : Values)
       V = (int64_t)((uint64_t)V >> Shift);
 
-  if (!isSwitchDense(Values))
+  if (!isSwitchDense(Values, SI->getFunction()->hasOptSize()))
     // Transform didn't create a dense switch.
     return false;
 
@@ -7813,8 +7815,10 @@ static bool simplifySwitchOfPowersOfTwo(SwitchInst *SI, IRBuilder<> &Builder,
 
   // isSwichDense requires case values to be sorted.
   llvm::sort(Values);
-  if (!isSwitchDense(Values.size(), llvm::countr_zero(Values.back()) -
-                                        llvm::countr_zero(Values.front()) + 1))
+  if (!isSwitchDense(Values.size(),
+                     llvm::countr_zero(Values.back()) -
+                         llvm::countr_zero(Values.front()) + 1,
+                     SI->getFunction()->hasOptSize()))
     // Transform is unable to generate dense switch.
     return false;
 

--- a/llvm/test/Transforms/SimplifyCFG/RISCV/switch-of-powers-of-two.ll
+++ b/llvm/test/Transforms/SimplifyCFG/RISCV/switch-of-powers-of-two.ll
@@ -180,8 +180,7 @@ define i32 @unable_to_create_dense_switch(i32 %x) {
 ; CHECK-NEXT:    switch i32 [[X:%.*]], label [[DEFAULT_CASE:%.*]] [
 ; CHECK-NEXT:      i32 1, label [[RETURN:%.*]]
 ; CHECK-NEXT:      i32 2, label [[BB3:%.*]]
-; CHECK-NEXT:      i32 4, label [[BB4:%.*]]
-; CHECK-NEXT:      i32 4096, label [[BB5:%.*]]
+; CHECK-NEXT:      i32 1073741824, label [[BB5:%.*]]
 ; CHECK-NEXT:    ]
 ; CHECK:       default_case:
 ; CHECK-NEXT:    unreachable
@@ -189,18 +188,15 @@ define i32 @unable_to_create_dense_switch(i32 %x) {
 ; CHECK-NEXT:    br label [[RETURN]]
 ; CHECK:       bb4:
 ; CHECK-NEXT:    br label [[RETURN]]
-; CHECK:       bb5:
-; CHECK-NEXT:    br label [[RETURN]]
 ; CHECK:       return:
-; CHECK-NEXT:    [[P:%.*]] = phi i32 [ 42, [[BB5]] ], [ 0, [[BB4]] ], [ 1, [[BB3]] ], [ 2, [[ENTRY:%.*]] ]
+; CHECK-NEXT:    [[P:%.*]] = phi i32 [ 42, [[BB5]] ], [ 1, [[BB3]] ], [ 2, [[ENTRY:%.*]] ]
 ; CHECK-NEXT:    ret i32 [[P]]
 ;
 entry:
   switch i32 %x, label %default_case [
   i32 1,  label %bb2
   i32 2, label %bb3
-  i32 4, label %bb4
-  i32 4096, label %bb5
+  i32 1073741824, label %bb4
   ]
 
 
@@ -209,10 +205,9 @@ bb1: br label %return
 bb2: br label %return
 bb3: br label %return
 bb4: br label %return
-bb5: br label %return
 
 return:
-  %p = phi i32 [ 3, %bb1 ], [ 2, %bb2 ], [ 1, %bb3 ], [ 0, %bb4 ], [ 42, %bb5 ]
+  %p = phi i32 [ 3, %bb1 ], [ 2, %bb2 ], [ 1, %bb3 ], [ 42, %bb4 ]
   ret i32 %p
 }
 

--- a/llvm/test/Transforms/SimplifyCFG/rangereduce.ll
+++ b/llvm/test/Transforms/SimplifyCFG/rangereduce.ll
@@ -9,12 +9,12 @@ target datalayout = "e-n32"
 ; CHECK: @switch.table.test3 = private unnamed_addr constant [3 x i32] [i32 11984, i32 1143, i32 99783], align 4
 ; CHECK: @switch.table.test6 = private unnamed_addr constant [4 x i32] [i32 99783, i32 99783, i32 1143, i32 11984], align 4
 ; CHECK: @switch.table.test8 = private unnamed_addr constant [5 x i32] [i32 11984, i32 1143, i32 99783, i32 8867, i32 99783], align 4
-; CHECK: @switch.table.test9 = private unnamed_addr constant [8 x i32] [i32 99783, i32 8867, i32 99783, i32 8867, i32 8867, i32 8867, i32 11984, i32 1143], align 4
+; CHECK: @switch.table.test9 = private unnamed_addr constant [28 x i32] [i32 99783, i32 8867, i32 99783, i32 8867, i32 8867, i32 8867, i32 11984, i32 8867, i32 8867, i32 8867, i32 8867, i32 8867, i32 8867, i32 8867, i32 8867, i32 8867, i32 8867, i32 1143, i32 8867, i32 8867, i32 8867, i32 8867, i32 8867, i32 8867, i32 8867, i32 8867, i32 8867, i32 99783], align 4
 ;.
 define i32 @test1(i32 %a) !prof !0 {
 ; CHECK-LABEL: @test1(
 ; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[A:%.*]], 97
-; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.fshl.i32(i32 [[TMP1]], i32 [[TMP1]], i32 30)
+; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.fshl.i32(i32 [[TMP1]], i32 [[TMP1]], i32 28)
 ; CHECK-NEXT:    [[TMP3:%.*]] = icmp ult i32 [[TMP2]], 4
 ; CHECK-NEXT:    br i1 [[TMP3]], label [[SWITCH_LOOKUP:%.*]], label [[COMMON_RET:%.*]], !prof [[PROF1:![0-9]+]]
 ; CHECK:       switch.lookup:
@@ -28,9 +28,9 @@ define i32 @test1(i32 %a) !prof !0 {
 ;
   switch i32 %a, label %def [
   i32 97, label %one
-  i32 101, label %two
-  i32 105, label %three
-  i32 109, label %three
+  i32 113, label %two
+  i32 129, label %three
+  i32 145, label %three
   ], !prof !1
 
 def:
@@ -49,9 +49,9 @@ define i128 @test2(i128 %a) {
 ; CHECK-LABEL: @test2(
 ; CHECK-NEXT:    switch i128 [[A:%.*]], label [[COMMON_RET:%.*]] [
 ; CHECK-NEXT:      i128 97, label [[ONE:%.*]]
-; CHECK-NEXT:      i128 101, label [[TWO:%.*]]
-; CHECK-NEXT:      i128 105, label [[THREE:%.*]]
-; CHECK-NEXT:      i128 109, label [[THREE]]
+; CHECK-NEXT:      i128 113, label [[TWO:%.*]]
+; CHECK-NEXT:      i128 129, label [[THREE:%.*]]
+; CHECK-NEXT:      i128 145, label [[THREE]]
 ; CHECK-NEXT:    ]
 ; CHECK:       common.ret:
 ; CHECK-NEXT:    [[COMMON_RET_OP:%.*]] = phi i128 [ 99783, [[THREE]] ], [ 11984, [[ONE]] ], [ 1143, [[TWO]] ], [ 8867, [[TMP0:%.*]] ]
@@ -65,9 +65,9 @@ define i128 @test2(i128 %a) {
 ;
   switch i128 %a, label %def [
   i128 97, label %one
-  i128 101, label %two
-  i128 105, label %three
-  i128 109, label %three
+  i128 113, label %two
+  i128 129, label %three
+  i128 145, label %three
   ]
 
 def:
@@ -118,9 +118,9 @@ define i32 @test4(i32 %a) {
 ; CHECK-LABEL: @test4(
 ; CHECK-NEXT:    switch i32 [[A:%.*]], label [[COMMON_RET:%.*]] [
 ; CHECK-NEXT:      i32 97, label [[ONE:%.*]]
-; CHECK-NEXT:      i32 102, label [[TWO:%.*]]
-; CHECK-NEXT:      i32 105, label [[THREE:%.*]]
-; CHECK-NEXT:      i32 109, label [[THREE]]
+; CHECK-NEXT:      i32 114, label [[TWO:%.*]]
+; CHECK-NEXT:      i32 129, label [[THREE:%.*]]
+; CHECK-NEXT:      i32 145, label [[THREE]]
 ; CHECK-NEXT:    ]
 ; CHECK:       common.ret:
 ; CHECK-NEXT:    [[COMMON_RET_OP:%.*]] = phi i32 [ 99783, [[THREE]] ], [ 11984, [[ONE]] ], [ 1143, [[TWO]] ], [ 8867, [[TMP0:%.*]] ]
@@ -134,9 +134,9 @@ define i32 @test4(i32 %a) {
 ;
   switch i32 %a, label %def [
   i32 97, label %one
-  i32 102, label %two
-  i32 105, label %three
-  i32 109, label %three
+  i32 114, label %two
+  i32 129, label %three
+  i32 145, label %three
   ]
 
 def:
@@ -155,9 +155,9 @@ define i32 @test5(i32 %a) {
 ; CHECK-LABEL: @test5(
 ; CHECK-NEXT:    switch i32 [[A:%.*]], label [[COMMON_RET:%.*]] [
 ; CHECK-NEXT:      i32 97, label [[ONE:%.*]]
-; CHECK-NEXT:      i32 102, label [[TWO:%.*]]
-; CHECK-NEXT:      i32 107, label [[THREE:%.*]]
-; CHECK-NEXT:      i32 112, label [[THREE]]
+; CHECK-NEXT:      i32 112, label [[TWO:%.*]]
+; CHECK-NEXT:      i32 127, label [[THREE:%.*]]
+; CHECK-NEXT:      i32 142, label [[THREE]]
 ; CHECK-NEXT:    ]
 ; CHECK:       common.ret:
 ; CHECK-NEXT:    [[COMMON_RET_OP:%.*]] = phi i32 [ 99783, [[THREE]] ], [ 11984, [[ONE]] ], [ 1143, [[TWO]] ], [ 8867, [[TMP0:%.*]] ]
@@ -171,9 +171,9 @@ define i32 @test5(i32 %a) {
 ;
   switch i32 %a, label %def [
   i32 97, label %one
-  i32 102, label %two
-  i32 107, label %three
-  i32 112, label %three
+  i32 112, label %two
+  i32 127, label %three
+  i32 142, label %three
   ]
 
 def:
@@ -288,11 +288,11 @@ define i32 @test9(i32 %a) {
 ; CHECK-LABEL: @test9(
 ; CHECK-NEXT:    [[TMP1:%.*]] = sub i32 [[A:%.*]], 6
 ; CHECK-NEXT:    [[TMP2:%.*]] = call i32 @llvm.fshl.i32(i32 [[TMP1]], i32 [[TMP1]], i32 31)
-; CHECK-NEXT:    [[TMP3:%.*]] = icmp ult i32 [[TMP2]], 8
+; CHECK-NEXT:    [[TMP3:%.*]] = icmp ult i32 [[TMP2]], 28
 ; CHECK-NEXT:    br i1 [[TMP3]], label [[SWITCH_LOOKUP:%.*]], label [[COMMON_RET:%.*]]
 ; CHECK:       switch.lookup:
 ; CHECK-NEXT:    [[TMP4:%.*]] = zext nneg i32 [[TMP2]] to i64
-; CHECK-NEXT:    [[SWITCH_GEP:%.*]] = getelementptr inbounds [8 x i32], ptr @switch.table.test9, i64 0, i64 [[TMP4]]
+; CHECK-NEXT:    [[SWITCH_GEP:%.*]] = getelementptr inbounds [28 x i32], ptr @switch.table.test9, i64 0, i64 [[TMP4]]
 ; CHECK-NEXT:    [[SWITCH_LOAD:%.*]] = load i32, ptr [[SWITCH_GEP]], align 4
 ; CHECK-NEXT:    br label [[COMMON_RET]]
 ; CHECK:       common.ret:
@@ -301,9 +301,10 @@ define i32 @test9(i32 %a) {
 ;
   switch i32 %a, label %def [
   i32 18, label %one
-  i32 20, label %two
+  i32 40, label %two
   i32 6, label %three
   i32 10, label %three
+  i32 60, label %three
   ]
 
 def:


### PR DESCRIPTION
It should be most often beneficial to generate a lookup table instead of
a jump table: the lookup table is rarely larger, but saves on
instructions and an indirect branch. Therefore, adjust the lookup table
threshold to match the jump table threshold.

The motivation is clang::Decl::castToDeclContext, which is a rather hot
function when parsing C++ programs, but the switch density is just 38%.
This improves stage2-O0g by 0.17% (7zip/kimwitu++ >0.5%).
