### PR TITLE
[TableGen] Remove redundant special BitsInit/BitInt resolution(NFC)

### DIFF
--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -2756,10 +2756,6 @@ TGParser::resolveInitTypes(ArrayRef<const Init *> Inits, const Twine &ErrCtx) {
     const RecTy *VTy = nullptr;
     if (const auto *Vt = dyn_cast<TypedInit>(V))
       VTy = Vt->getType();
-    if (const auto *Vbits = dyn_cast<BitsInit>(V))
-      VTy = BitsRecTy::get(Records, Vbits->getNumBits());
-    if (isa<BitInit>(V))
-      VTy = BitRecTy::get(Records);
 
     if (!Type) {
       Type = VTy;


### PR DESCRIPTION
BitsInit and BitInt are subclasses of TypedInit, so the code above will handle them and separate if for them is not necessary. See https://github.com/llvm/llvm-project/pull/199659#discussion_r3319597920

Keeping the test cases in `llvm/test/TableGen/switch.td` to avoid regressions.