### PR TITLE
[MC][NVPTX] Add target capability for .addrsig directive and disable it for NVPTX

### DIFF
--- a/llvm/include/llvm/MC/MCAsmInfo.h
+++ b/llvm/include/llvm/MC/MCAsmInfo.h
@@ -218,6 +218,9 @@ protected:
   /// True if full register names are printed.
   bool PPCUseFullRegisterNames = false;
 
+  /// True if the target supports the .addrsig directive.
+  bool HasAddrsigDirective = true;
+
   //===--- Data Emission Directives -------------------------------------===//
 
   /// This should be set to the directive used to get some number of zero (and
@@ -604,6 +607,8 @@ public:
 
   bool useFullRegisterNames() const { return PPCUseFullRegisterNames; }
   void setFullRegisterNames(bool V) { PPCUseFullRegisterNames = V; }
+
+  bool hasAddrsigDirective() const { return HasAddrsigDirective; }
 
   const char *getZeroDirective() const { return ZeroDirective; }
   const char *getAsciiDirective() const { return AsciiDirective; }

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -3111,7 +3111,7 @@ bool AsmPrinter::doFinalization(Module &M) {
   if (S)
     OutStreamer->switchSection(S);
 
-  if (TM.Options.EmitAddrsig) {
+  if (TM.Options.EmitAddrsig && MAI.hasAddrsigDirective()) {
     // Emit address-significance attributes for all globals.
     OutStreamer->emitAddrsig();
     for (const GlobalValue &GV : M.global_values()) {

--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXMCAsmInfo.cpp
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXMCAsmInfo.cpp
@@ -60,4 +60,7 @@ NVPTXMCAsmInfo::NVPTXMCAsmInfo(const Triple &TheTriple,
   // ptxas does not support DWARF `.file fileno directory filename'
   // syntax as of v11.X.
   EnableDwarfFileDirectoryDefault = false;
+
+  // ptx does not support the .addrsig directive
+  HasAddrsigDirective = false;
 }

--- a/llvm/test/CodeGen/NVPTX/no-addrsig.ll
+++ b/llvm/test/CodeGen/NVPTX/no-addrsig.ll
@@ -1,0 +1,12 @@
+; RUN: llc -mtriple=nvptx64-nvidia-cuda -mattr=+ptx70 -addrsig < %s | FileCheck %s
+
+; CHECK-NOT: .addrsig
+; CHECK-NOT: .addrsig_sym
+; CHECK: .visible .func foo
+
+@p = addrspace(1) global ptr @foo
+
+define void @foo() {
+entry:
+  ret void
+}


### PR DESCRIPTION
When compiling for NVPTX with the Rust compiler, it currently emits LLVM bitcode for each codegen unit. To link these together and produce a final artefact, Rust uses a self-contained linker, which essentially comprises an llvm-link -> opt -> llc pipeline. This self-contained linker is only necessary for NVPTX, so we would like to phase it out and replace it with lld's LTO pipeline.

Only some minor changes to lld are necessary for this to work (#200679). To produce PTX `--lto-emit-asm` can be used. However, the final codegen invocation of lld always sets EmitAddrsig to true. This produces invalid PTX: ptxas cannot handle the resulting `.addrsig` section.

To handle this, this patch introduces a target capability in `MCAsmInfo` to indicate support for `.addrsig` directives and use it in `AsmPrinter` to suppress emission on targets that do not support the directive. It also disables .addrsig directives for NVPTX and add a regression test to verify that NVPTX assembly does not contain `.addrsig`.

I considered handling this in lld, but thought that doing so in the backend might be better. The reason for this is that I could simply invoke llc with -addrsig and produce invalid PTX too.