### PR TITLE
[ELF] Support NVPTX bitcode in LTO output modes

### DIFF
--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -399,6 +399,11 @@ static void checkOptions(Ctx &ctx) {
       ctx.arg.zCetReport != ReportPolicy::None)
     ErrAlways(ctx) << "-z cet-report only supported on X86 and X86_64";
 
+  if (ctx.arg.emachine == EM_CUDA && !ctx.arg.ltoEmitAsm && !ctx.arg.emitLLVM) {
+    ErrAlways(ctx) << "CUDA bitcode inputs are only supported with "
+                      "--lto-emit-asm or --lto-emit-llvm";
+  }
+
   if (ctx.arg.pie && ctx.arg.shared)
     ErrAlways(ctx) << "-shared and -pie may not be used together";
 

--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -1783,6 +1783,9 @@ static uint16_t getBitcodeMachineKind(Ctx &ctx, StringRef path,
     return t.isOSIAMCU() ? EM_IAMCU : EM_386;
   case Triple::x86_64:
     return EM_X86_64;
+  case Triple::nvptx:
+  case Triple::nvptx64:
+    return EM_CUDA;
   default:
     ErrAlways(ctx) << path
                    << ": could not infer e_machine from bitcode target triple "

--- a/lld/test/ELF/lto/nvptx-bitcode.ll
+++ b/lld/test/ELF/lto/nvptx-bitcode.ll
@@ -1,0 +1,23 @@
+; REQUIRES: nvptx
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: ld.lld --lto-emit-asm --plugin-opt=-mcpu=sm_70 --plugin-opt=-mattr=+ptx70 %t.bc -o %t
+;
+; lld writes assembly output produced by LTO to a .lto.s side file.
+; RUN: FileCheck %s --check-prefix=PTX < %t.lto.s
+
+; RUN: ld.lld --lto-emit-llvm %t.bc -o %t.lto.bc
+; RUN: llvm-dis %t.lto.bc -o - | FileCheck %s --check-prefix=LLVM
+
+; RUN: not ld.lld %t.bc -o %t.out 2>&1 | FileCheck %s --check-prefix=ERR
+
+target datalayout = "e-i64:64-v16:16-v32:32-n16:32:64"
+target triple = "nvptx64-nvidia-cuda"
+
+; PTX: .version 7.0
+; PTX: .target sm_70
+; PTX: .address_size 64
+
+; LLVM: target triple = "nvptx64-nvidia-cuda"
+
+; ERR: error: CUDA bitcode inputs are only supported with --lto-emit-asm or --lto-emit-llvm

--- a/lld/test/lit.cfg.py
+++ b/lld/test/lit.cfg.py
@@ -93,6 +93,7 @@ llvm_config.feature_config(
                 "LoongArch": "loongarch",
                 "Mips": "mips",
                 "MSP430": "msp430",
+                "NVPTX": "nvptx",
                 "PowerPC": "ppc",
                 "RISCV": "riscv",
                 "Sparc": "sparc",


### PR DESCRIPTION
When compiling for NVPTX with the Rust compiler, it currently emits LLVM bitcode for each codegen unit. To link these together and produce a final artefact, Rust uses a self-contained linker, which essentially comprises an llvm-link -> opt -> llc pipeline. This self-contained linker is only necessary for NVPTX, so we would like to phase it out and replace it with lld's LTO pipeline. Please see the corresponding [Rust issue](https://github.com/rust-lang/rust/issues/156921).

To make this work, this patch maps nvptx and nvptx64 bitcode modules to `EM_CUDA` so that they can participate in lld's LTO pipeline. This allows lld to perform LTO over NVPTX LLVM bitcode and emit the resulting assembly or LLVM IR using the existing `--lto-emit-asm` and `--lto-emit-llvm` modes. 

Since NVPTX does not support normal ELF output, this patch also restricts `EM_CUDA` inputs to LTO output modes and emit an error unless `--lto-emit-asm` or `--lto-emit-llvm` is specified.

`EM_CUDA` is used only as an identifier for the LTO pipeline; this change does not add support for producing CUDA ELF files.

Generating valid PTX additionally requires suppressing unsupported .addrsig directives; see also: #200678