### PR TITLE
[libc][math] Adding constexpr to tests for Double-type math functions 

### DIFF
--- a/libc/test/src/math/acos_test.cpp
+++ b/libc/test/src/math/acos_test.cpp
@@ -26,9 +26,9 @@ using LIBC_NAMESPACE::testing::tlog;
 
 TEST_F(LlvmLibcAcosTest, InDoubleRange) {
   constexpr uint64_t COUNT = 1'231;
-  uint64_t START = FPBits(0x1.0p-60).uintval();
-  uint64_t STOP = FPBits(1.0).uintval();
-  uint64_t STEP = (STOP - START) / COUNT;
+  constexpr uint64_t START = FPBits(0x1.0p-60).uintval();
+  constexpr uint64_t STOP = FPBits(1.0).uintval();
+  constexpr uint64_t STEP = (STOP - START) / COUNT;
 
   auto test = [&](mpfr::RoundingMode rounding_mode) {
     mpfr::ForceRoundingMode __r(rounding_mode);

--- a/libc/test/src/math/asin_test.cpp
+++ b/libc/test/src/math/asin_test.cpp
@@ -26,9 +26,9 @@ using LIBC_NAMESPACE::testing::tlog;
 
 TEST_F(LlvmLibcAsinTest, InDoubleRange) {
   constexpr uint64_t COUNT = 1'231;
-  uint64_t START = FPBits(0x1.0p-60).uintval();
-  uint64_t STOP = FPBits(1.0).uintval();
-  uint64_t STEP = (STOP - START) / COUNT;
+  constexpr uint64_t START = FPBits(0x1.0p-60).uintval();
+  constexpr uint64_t STOP = FPBits(1.0).uintval();
+  constexpr int64_t STEP = (STOP - START) / COUNT;
 
   auto test = [&](mpfr::RoundingMode rounding_mode) {
     mpfr::ForceRoundingMode __r(rounding_mode);

--- a/libc/test/src/math/asin_test.cpp
+++ b/libc/test/src/math/asin_test.cpp
@@ -28,7 +28,7 @@ TEST_F(LlvmLibcAsinTest, InDoubleRange) {
   constexpr uint64_t COUNT = 1'231;
   constexpr uint64_t START = FPBits(0x1.0p-60).uintval();
   constexpr uint64_t STOP = FPBits(1.0).uintval();
-  constexpr int64_t STEP = (STOP - START) / COUNT;
+  constexpr uint64_t STEP = (STOP - START) / COUNT;
 
   auto test = [&](mpfr::RoundingMode rounding_mode) {
     mpfr::ForceRoundingMode __r(rounding_mode);

--- a/libc/test/src/math/atan_test.cpp
+++ b/libc/test/src/math/atan_test.cpp
@@ -20,8 +20,8 @@ using LIBC_NAMESPACE::testing::tlog;
 
 TEST_F(LlvmLibcAtanTest, InDoubleRange) {
   constexpr uint64_t COUNT = 1'231;
-  constexpr uint64_t START = FPBits<double>(0x1.0p-60).uintval();
-  constexpr uint64_t STOP = FPBits<double>(0x1.0p60).uintval();
+  constexpr uint64_t START = FPBits(0x1.0p-60).uintval();
+  constexpr uint64_t STOP = FPBits(0x1.0p60).uintval();
   constexpr uint64_t STEP = (STOP - START) / COUNT;
 
   auto test = [&](mpfr::RoundingMode rounding_mode) {

--- a/libc/test/src/math/atan_test.cpp
+++ b/libc/test/src/math/atan_test.cpp
@@ -20,9 +20,9 @@ using LIBC_NAMESPACE::testing::tlog;
 
 TEST_F(LlvmLibcAtanTest, InDoubleRange) {
   constexpr uint64_t COUNT = 1'231;
-  uint64_t START = LIBC_NAMESPACE::fputil::FPBits<double>(0x1.0p-60).uintval();
-  uint64_t STOP = LIBC_NAMESPACE::fputil::FPBits<double>(0x1.0p60).uintval();
-  uint64_t STEP = (STOP - START) / COUNT;
+  constexpr uint64_t START = FPBits<double>(0x1.0p-60).uintval();
+  constexpr uint64_t STOP = FPBits<double>(0x1.0p60).uintval();
+  constexpr uint64_t STEP = (STOP - START) / COUNT;
 
   auto test = [&](mpfr::RoundingMode rounding_mode) {
     mpfr::ForceRoundingMode __r(rounding_mode);

--- a/libc/test/src/math/cbrt_test.cpp
+++ b/libc/test/src/math/cbrt_test.cpp
@@ -28,9 +28,9 @@ using LIBC_NAMESPACE::testing::tlog;
 
 TEST_F(LlvmLibcCbrtTest, InDoubleRange) {
   constexpr uint64_t COUNT = 1'231;
-  uint64_t START = FPBits(1.0).uintval();
-  uint64_t STOP = FPBits(8.0).uintval();
-  uint64_t STEP = (STOP - START) / COUNT;
+  constexpr uint64_t START = FPBits(1.0).uintval();
+  constexpr uint64_t STOP = FPBits(8.0).uintval();
+  constexpr uint64_t STEP = (STOP - START) / COUNT;
 
   auto test = [&](mpfr::RoundingMode rounding_mode) {
     mpfr::ForceRoundingMode force_rounding(rounding_mode);

--- a/libc/test/src/math/exp10_test.cpp
+++ b/libc/test/src/math/exp10_test.cpp
@@ -91,8 +91,8 @@ TEST_F(LlvmLibcExp10Test, TrickyInputs) {
 
 TEST_F(LlvmLibcExp10Test, InDoubleRange) {
   constexpr uint64_t COUNT = 1'231;
-  constexpr uint64_t START = FPBits<double>(0.25).uintval();
-  constexpr uint64_t STOP = FPBits<double>(4.0).uintval();
+  constexpr uint64_t START = FPBits(0.25).uintval();
+  constexpr uint64_t STOP = FPBits(4.0).uintval();
   constexpr uint64_t STEP = (STOP - START) / COUNT;
 
   auto test = [&](mpfr::RoundingMode rounding_mode) {

--- a/libc/test/src/math/exp10_test.cpp
+++ b/libc/test/src/math/exp10_test.cpp
@@ -91,9 +91,9 @@ TEST_F(LlvmLibcExp10Test, TrickyInputs) {
 
 TEST_F(LlvmLibcExp10Test, InDoubleRange) {
   constexpr uint64_t COUNT = 1'231;
-  uint64_t START = LIBC_NAMESPACE::fputil::FPBits<double>(0.25).uintval();
-  uint64_t STOP = LIBC_NAMESPACE::fputil::FPBits<double>(4.0).uintval();
-  uint64_t STEP = (STOP - START) / COUNT;
+  constexpr uint64_t START = FPBits<double>(0.25).uintval();
+  constexpr uint64_t STOP = FPBits<double>(4.0).uintval();
+  constexpr uint64_t STEP = (STOP - START) / COUNT;
 
   auto test = [&](mpfr::RoundingMode rounding_mode) {
     mpfr::ForceRoundingMode __r(rounding_mode);

--- a/libc/test/src/math/exp2_test.cpp
+++ b/libc/test/src/math/exp2_test.cpp
@@ -60,8 +60,8 @@ TEST_F(LlvmLibcExp2Test, TrickyInputs) {
 
 TEST_F(LlvmLibcExp2Test, InDoubleRange) {
   constexpr uint64_t COUNT = 1'231;
-  constexpr uint64_t START = LIBC_NAMESPACE::fputil::FPBits<double>(0.25).uintval();
-  constexpr uint64_t STOP = LIBC_NAMESPACE::fputil::FPBits<double>(4.0).uintval();
+  constexpr uint64_t START = FPBits(0.25).uintval();
+  constexpr uint64_t STOP = FPBits(4.0).uintval();
   constexpr uint64_t STEP = (STOP - START) / COUNT;
 
   auto test = [&](mpfr::RoundingMode rounding_mode) {

--- a/libc/test/src/math/exp2_test.cpp
+++ b/libc/test/src/math/exp2_test.cpp
@@ -60,9 +60,9 @@ TEST_F(LlvmLibcExp2Test, TrickyInputs) {
 
 TEST_F(LlvmLibcExp2Test, InDoubleRange) {
   constexpr uint64_t COUNT = 1'231;
-  uint64_t START = LIBC_NAMESPACE::fputil::FPBits<double>(0.25).uintval();
-  uint64_t STOP = LIBC_NAMESPACE::fputil::FPBits<double>(4.0).uintval();
-  uint64_t STEP = (STOP - START) / COUNT;
+  constexpr uint64_t START = LIBC_NAMESPACE::fputil::FPBits<double>(0.25).uintval();
+  constexpr uint64_t STOP = LIBC_NAMESPACE::fputil::FPBits<double>(4.0).uintval();
+  constexpr uint64_t STEP = (STOP - START) / COUNT;
 
   auto test = [&](mpfr::RoundingMode rounding_mode) {
     mpfr::ForceRoundingMode __r(rounding_mode);

--- a/libc/test/src/math/exp_test.cpp
+++ b/libc/test/src/math/exp_test.cpp
@@ -64,8 +64,8 @@ TEST_F(LlvmLibcExpTest, TrickyInputs) {
 
 TEST_F(LlvmLibcExpTest, InDoubleRange) {
   constexpr uint64_t COUNT = 1'231;
-  constexpr uint64_t START = LIBC_NAMESPACE::fputil::FPBits<double>(0.25).uintval();
-  constexpr uint64_t STOP = LIBC_NAMESPACE::fputil::FPBits<double>(4.0).uintval();
+  constexpr uint64_t START = FPBits(0.25).uintval();
+  constexpr uint64_t STOP = FPBits(4.0).uintval();
   constexpr uint64_t STEP = (STOP - START) / COUNT;
 
   auto test = [&](mpfr::RoundingMode rounding_mode) {

--- a/libc/test/src/math/exp_test.cpp
+++ b/libc/test/src/math/exp_test.cpp
@@ -64,9 +64,9 @@ TEST_F(LlvmLibcExpTest, TrickyInputs) {
 
 TEST_F(LlvmLibcExpTest, InDoubleRange) {
   constexpr uint64_t COUNT = 1'231;
-  uint64_t START = LIBC_NAMESPACE::fputil::FPBits<double>(0.25).uintval();
-  uint64_t STOP = LIBC_NAMESPACE::fputil::FPBits<double>(4.0).uintval();
-  uint64_t STEP = (STOP - START) / COUNT;
+  constexpr uint64_t START = LIBC_NAMESPACE::fputil::FPBits<double>(0.25).uintval();
+  constexpr uint64_t STOP = LIBC_NAMESPACE::fputil::FPBits<double>(4.0).uintval();
+  constexpr uint64_t STEP = (STOP - START) / COUNT;
 
   auto test = [&](mpfr::RoundingMode rounding_mode) {
     mpfr::ForceRoundingMode __r(rounding_mode);

--- a/libc/test/src/math/expm1_test.cpp
+++ b/libc/test/src/math/expm1_test.cpp
@@ -50,8 +50,8 @@ TEST_F(LlvmLibcExpm1Test, TrickyInputs) {
 
 TEST_F(LlvmLibcExpm1Test, InDoubleRange) {
   constexpr uint64_t COUNT = 1'231;
-  constexpr uint64_t START = LIBC_NAMESPACE::fputil::FPBits<double>(0.25).uintval();
-  constexpr uint64_t STOP = LIBC_NAMESPACE::fputil::FPBits<double>(4.0).uintval();
+  constexpr uint64_t START = FPBits(0.25).uintval();
+  constexpr uint64_t STOP = FPBits(4.0).uintval();
   constexpr uint64_t STEP = (STOP - START) / COUNT;
 
   auto test = [&](mpfr::RoundingMode rounding_mode) {

--- a/libc/test/src/math/expm1_test.cpp
+++ b/libc/test/src/math/expm1_test.cpp
@@ -50,9 +50,9 @@ TEST_F(LlvmLibcExpm1Test, TrickyInputs) {
 
 TEST_F(LlvmLibcExpm1Test, InDoubleRange) {
   constexpr uint64_t COUNT = 1'231;
-  uint64_t START = LIBC_NAMESPACE::fputil::FPBits<double>(0.25).uintval();
-  uint64_t STOP = LIBC_NAMESPACE::fputil::FPBits<double>(4.0).uintval();
-  uint64_t STEP = (STOP - START) / COUNT;
+  constexpr uint64_t START = LIBC_NAMESPACE::fputil::FPBits<double>(0.25).uintval();
+  constexpr uint64_t STOP = LIBC_NAMESPACE::fputil::FPBits<double>(4.0).uintval();
+  constexpr uint64_t STEP = (STOP - START) / COUNT;
 
   auto test = [&](mpfr::RoundingMode rounding_mode) {
     mpfr::ForceRoundingMode __r(rounding_mode);

--- a/libc/test/src/math/sin_test.cpp
+++ b/libc/test/src/math/sin_test.cpp
@@ -59,8 +59,8 @@ TEST_F(LlvmLibcSinTest, TrickyInputs) {
 
 TEST_F(LlvmLibcSinTest, InDoubleRange) {
   constexpr uint64_t COUNT = 1'231;
-  constexpr uint64_t START = LIBC_NAMESPACE::fputil::FPBits<double>(0x1.0p-50).uintval();
-  constexpr uint64_t STOP = LIBC_NAMESPACE::fputil::FPBits<double>(0x1.0p200).uintval();
+  constexpr uint64_t START = FPBits(0x1.0p-50).uintval();
+  constexpr uint64_t STOP = FPBits(0x1.0p200).uintval();
   constexpr uint64_t STEP = (STOP - START) / COUNT;
 
   auto test = [&](mpfr::RoundingMode rounding_mode) {

--- a/libc/test/src/math/sin_test.cpp
+++ b/libc/test/src/math/sin_test.cpp
@@ -59,9 +59,9 @@ TEST_F(LlvmLibcSinTest, TrickyInputs) {
 
 TEST_F(LlvmLibcSinTest, InDoubleRange) {
   constexpr uint64_t COUNT = 1'231;
-  uint64_t START = LIBC_NAMESPACE::fputil::FPBits<double>(0x1.0p-50).uintval();
-  uint64_t STOP = LIBC_NAMESPACE::fputil::FPBits<double>(0x1.0p200).uintval();
-  uint64_t STEP = (STOP - START) / COUNT;
+  constexpr uint64_t START = LIBC_NAMESPACE::fputil::FPBits<double>(0x1.0p-50).uintval();
+  constexpr uint64_t STOP = LIBC_NAMESPACE::fputil::FPBits<double>(0x1.0p200).uintval();
+  constexpr uint64_t STEP = (STOP - START) / COUNT;
 
   auto test = [&](mpfr::RoundingMode rounding_mode) {
     mpfr::ForceRoundingMode __r(rounding_mode);

--- a/libc/test/src/math/sincos_test.cpp
+++ b/libc/test/src/math/sincos_test.cpp
@@ -111,8 +111,8 @@ TEST_F(LlvmLibcSincosTest, TrickyInputs) {
 
 TEST_F(LlvmLibcSincosTest, InDoubleRange) {
   constexpr uint64_t COUNT = 1'231;
-  constexpr uint64_t START = FPBits<double>(0x1.0p-50).uintval();
-  constexpr uint64_t STOP = FPBits<double>(0x1.0p200).uintval();
+  constexpr uint64_t START = FPBits(0x1.0p-50).uintval();
+  constexpr uint64_t STOP = FPBits(0x1.0p200).uintval();
   constexpr uint64_t STEP = (STOP - START) / COUNT;
 
   for (uint64_t i = 0, v = START; i <= COUNT; ++i, v += STEP) {

--- a/libc/test/src/math/sincos_test.cpp
+++ b/libc/test/src/math/sincos_test.cpp
@@ -111,9 +111,9 @@ TEST_F(LlvmLibcSincosTest, TrickyInputs) {
 
 TEST_F(LlvmLibcSincosTest, InDoubleRange) {
   constexpr uint64_t COUNT = 1'231;
-  uint64_t START = LIBC_NAMESPACE::fputil::FPBits<double>(0x1.0p-50).uintval();
-  uint64_t STOP = LIBC_NAMESPACE::fputil::FPBits<double>(0x1.0p200).uintval();
-  uint64_t STEP = (STOP - START) / COUNT;
+  constexpr uint64_t START = FPBits<double>(0x1.0p-50).uintval();
+  constexpr uint64_t STOP = FPBits<double>(0x1.0p200).uintval();
+  constexpr uint64_t STEP = (STOP - START) / COUNT;
 
   for (uint64_t i = 0, v = START; i <= COUNT; ++i, v += STEP) {
     double x = FPBits(v).get_val();


### PR DESCRIPTION
Similar to 
```CPP
  constexpr uint64_t X_COUNT = 123;
  constexpr uint64_t X_START = FPBits(0.25).uintval();
  constexpr uint64_t X_STOP = FPBits(4.0).uintval();
  constexpr uint64_t X_STEP = (X_STOP - X_START) / X_COUNT;

  constexpr uint64_t Y_COUNT = 137;
  constexpr uint64_t Y_START = FPBits(0.25).uintval();
  constexpr uint64_t Y_STOP = FPBits(4.0).uintval();
  constexpr uint64_t Y_STEP = (Y_STOP - Y_START) / Y_COUNT;
  ```
  in [atan2_test.cpp](https://github.com/llvm/llvm-project/blob/main/libc/test/src/math/atan2_test.cpp)
  This PR tends to add constexpr to all double function tests-only
  
  Additonally, replacing 
  ``` CPP
  LIBC_NAMESPACE::fputil::FPBits<double>(x).uintval();
   ```
to 
```CPP
FPBits(x).uintval();
```
  Assisted using Copilot.