### PR TITLE
[AArch64][CodeLayoutOpt] Add page-cross alignment for large nested-loop functions

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64CodeLayoutOpt.cpp
+++ b/llvm/lib/Target/AArch64/AArch64CodeLayoutOpt.cpp
@@ -25,6 +25,7 @@
 #include "llvm/ADT/Statistic.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineLoopInfo.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -39,14 +40,17 @@ using namespace llvm;
 enum CodeLayoutOpt {
   CmpCsel,   // Align CMP/CMN-CSEL pairs
   FcmpFcsel, // Align FCMP-FCSEL pairs
+  PageCross, // Align page-cross functions
 };
 
 static cl::bits<CodeLayoutOpt> EnableCodeAlignment(
     "aarch64-code-layout-opt-enable", cl::Hidden, cl::CommaSeparated,
     cl::desc("Enable code alignment optimization for instruction pairs"),
-    cl::values(
-        clEnumValN(CmpCsel, "cmp-csel", "CMP/CMN-CSEL pair alignment (32-bit)"),
-        clEnumValN(FcmpFcsel, "fcmp-fcsel", "FCMP-FCSEL pair alignment")));
+    cl::values(clEnumValN(CmpCsel, "cmp-csel",
+                          "CMP/CMN-CSEL pair alignment (32-bit)"),
+               clEnumValN(FcmpFcsel, "fcmp-fcsel", "FCMP-FCSEL pair alignment"),
+               clEnumValN(PageCross, "page-cross",
+                          "Page-cross alignment of large functions")));
 
 static cl::opt<unsigned> FunctionAlignBytes(
     "aarch64-code-layout-opt-align-functions", cl::Hidden,
@@ -58,12 +62,54 @@ static cl::opt<unsigned> FunctionAlignBytes(
             "aarch64-code-layout-opt-align must be a power of 2");
     }));
 
+namespace {
+/// Inclusive-exclusive instruction count range: a function qualifies iff its
+/// instruction count is in (Min, Max).
+struct InsnsRange {
+  unsigned Min;
+  unsigned Max;
+};
+} // namespace
+
+static constexpr InsnsRange DefaultPageCrossInsnsRange{350, 1100};
+
+static cl::list<unsigned> PageCrossInsnsRangeFlag(
+    "aarch64-code-layout-opt-page-cross-insns-range", cl::Hidden,
+    cl::CommaSeparated,
+    cl::desc("Instruction count range (exclusive) for page-cross alignment; "
+             "defaults to 350,1100"),
+    cl::value_desc("min,max"));
+
+/// Read and validate the page-cross instruction-count range. Errors fatally on
+/// malformed input so the message points at the user's mistake, not a later
+/// crash.
+static InsnsRange getPageCrossInsnsRange() {
+  size_t N = PageCrossInsnsRangeFlag.size();
+  if (N == 0)
+    return DefaultPageCrossInsnsRange;
+  if (N != 2)
+    report_fatal_error("aarch64-code-layout-opt-page-cross-insns-range "
+                       "expects exactly two values: 'min,max'");
+  unsigned Lo = PageCrossInsnsRangeFlag[0];
+  unsigned Hi = PageCrossInsnsRangeFlag[1];
+  if (Lo >= Hi)
+    report_fatal_error("aarch64-code-layout-opt-page-cross-insns-range "
+                       "must be 'min,max' with min < max");
+  return {Lo, Hi};
+}
+
+static cl::opt<unsigned> PageCrossMinLoopDepth(
+    "aarch64-code-layout-opt-page-cross-min-loop-depth", cl::Hidden,
+    cl::desc("Minimum loop nest depth for page-cross alignment"), cl::init(2));
+
 STATISTIC(NumFunctionsAligned,
           "Number of functions with aligned (to 64-bytes by default)");
 STATISTIC(NumCmpCselPairsDetected,
           "Number of CMP/CMN-CSEL pairs detected for alignment");
 STATISTIC(NumFcmpFcselPairsDetected,
           "Number of FCMP-FCSEL pairs detected for alignment");
+STATISTIC(NumPageCrossAligned,
+          "Number of functions aligned to avoid page crossing");
 
 namespace {
 
@@ -79,6 +125,7 @@ public:
 
 private:
   const AArch64InstrInfo *TII = nullptr;
+  MachineLoopInfo *MLI = nullptr;
 
   /// Align each fusible CMP/CMN-CSEL or FCMP-FCSEL pair in \p MBB by emitting
   /// .p2align before the lead instruction (splitting the block if needed).
@@ -88,6 +135,9 @@ private:
   /// Emit .p2align before MI. Splits the block if MI is not at its start.
   void emitP2Align(MachineInstr &MI, Align DesiredAlign,
                    unsigned MaxSkipBytes = 4);
+
+  /// Returns the page-cross alignment in bytes, or 0 if criteria not met.
+  unsigned getPageCrossAlignment(MachineFunction &MF);
 
   bool optimizeForCodeLayout(MachineFunction &MF);
 };
@@ -101,6 +151,7 @@ INITIALIZE_PASS(AArch64CodeLayoutOpt, "aarch64-code-layout-opt",
 
 void AArch64CodeLayoutOpt::getAnalysisUsage(AnalysisUsage &AU) const {
   AU.setPreservesAll();
+  AU.addRequired<MachineLoopInfoWrapperPass>();
   MachineFunctionPass::getAnalysisUsage(AU);
 }
 
@@ -168,17 +219,26 @@ bool AArch64CodeLayoutOpt::runOnMachineFunction(MachineFunction &MF) {
 
   const auto *Subtarget = &MF.getSubtarget<AArch64Subtarget>();
   TII = Subtarget->getInstrInfo();
+  MLI = &getAnalysis<MachineLoopInfoWrapperPass>().getLI();
 
-  // Default: enable when the subtarget opts in via FeatureAlignCmpCSelPairs.
-  if (!EnableCodeAlignment.getBits() && Subtarget->hasAlignCmpCSelPairs()) {
-    if (Subtarget->hasFuseCmpCSel())
-      EnableCodeAlignment.addValue(CmpCsel);
-    if (Subtarget->hasFuseFCmpFCSel())
-      EnableCodeAlignment.addValue(FcmpFcsel);
+  // Default: enable subtarget-opted-in alignments when no flag was set.
+  if (!EnableCodeAlignment.getBits()) {
+    if (Subtarget->hasAlignCmpCSelPairs()) {
+      if (Subtarget->hasFuseCmpCSel())
+        EnableCodeAlignment.addValue(CmpCsel);
+      if (Subtarget->hasFuseFCmpFCSel())
+        EnableCodeAlignment.addValue(FcmpFcsel);
+    }
+    if (Subtarget->hasAlignPageCrossFuncs())
+      EnableCodeAlignment.addValue(PageCross);
   }
 
-  if (!(EnableCodeAlignment.isSet(CmpCsel) && Subtarget->hasFuseCmpCSel()) &&
-      !(EnableCodeAlignment.isSet(FcmpFcsel) && Subtarget->hasFuseFCmpFCSel()))
+  bool HasPairOpt =
+      (EnableCodeAlignment.isSet(CmpCsel) && Subtarget->hasFuseCmpCSel()) ||
+      (EnableCodeAlignment.isSet(FcmpFcsel) && Subtarget->hasFuseFCmpFCSel());
+  bool HasPageCross = EnableCodeAlignment.isSet(PageCross);
+
+  if (!HasPairOpt && !HasPageCross)
     return false;
 
   return optimizeForCodeLayout(MF);
@@ -240,8 +300,60 @@ bool AArch64CodeLayoutOpt::alignLayoutSensitivePatterns(
   return !Pairs.empty();
 }
 
+/// Returns the maximum loop nest depth across all loops in the function.
+static unsigned getMaxLoopDepth(MachineLoopInfo *MLI) {
+  unsigned MaxDepth = 0;
+  for (MachineLoop *L : *MLI)
+    for (MachineLoop *Sub : L->getLoopsInPreorder())
+      MaxDepth = std::max(MaxDepth, Sub->getLoopDepth());
+  return MaxDepth;
+}
+
+unsigned AArch64CodeLayoutOpt::getPageCrossAlignment(MachineFunction &MF) {
+  unsigned InsnCount = 0;
+  unsigned SizeInBytes = 0;
+  for (auto &MBB : MF)
+    for (auto &MI : instructionsWithoutDebug(MBB.begin(), MBB.end())) {
+      ++InsnCount;
+      SizeInBytes += TII->getInstSizeInBytes(MI);
+    }
+
+  InsnsRange Range = getPageCrossInsnsRange();
+  if (InsnCount <= Range.Min || InsnCount >= Range.Max) {
+    DBG("page-cross: " << MF.getName() << " instruction count " << InsnCount
+                       << " outside range (" << Range.Min << ", " << Range.Max
+                       << ")\n");
+    return 0;
+  }
+
+  unsigned MaxDepth = getMaxLoopDepth(MLI);
+  if (MaxDepth < PageCrossMinLoopDepth) {
+    DBG("page-cross: " << MF.getName() << " max loop depth " << MaxDepth
+                       << " < " << PageCrossMinLoopDepth << "\n");
+    return 0;
+  }
+
+  unsigned AlignBytes = NextPowerOf2(SizeInBytes - 1);
+  DBG("page-cross: " << MF.getName() << " qualifies (insns=" << InsnCount
+                     << ", size=" << SizeInBytes << ", depth=" << MaxDepth
+                     << ", align=" << AlignBytes << ")\n");
+  return AlignBytes;
+}
+
 bool AArch64CodeLayoutOpt::optimizeForCodeLayout(MachineFunction &MF) {
   DBG("optimizeForCodeLayout: " << MF.getName() << "\n");
+
+  // Check page-cross alignment first (higher alignment takes precedence).
+  if (EnableCodeAlignment.isSet(PageCross)) {
+    unsigned AlignBytes = getPageCrossAlignment(MF);
+    if (AlignBytes && MF.getAlignment() < Align(AlignBytes)) {
+      MF.setAlignment(Align(AlignBytes));
+      ++NumPageCrossAligned;
+      DBG("Set " << AlignBytes << "-byte alignment for function "
+                 << MF.getName() << "\n");
+      return true;
+    }
+  }
 
   bool Changed = false;
   for (auto &MBB : MF)

--- a/llvm/lib/Target/AArch64/AArch64Features.td
+++ b/llvm/lib/Target/AArch64/AArch64Features.td
@@ -797,6 +797,10 @@ def FeatureAlignCmpCSelPairs : SubtargetFeature<
     "align-cmp-csel-pairs", "HasAlignCmpCSelPairs", "true",
     "Align certain CMP/FCMP and CSEL/FCSEL instruction pairs">;
 
+def FeatureAlignPageCrossFuncs : SubtargetFeature<
+    "align-page-cross-funcs", "HasAlignPageCrossFuncs", "true",
+    "Page-cross alignment for large nested-loop functions">;
+
 def FeatureFuseCryptoEOR : SubtargetFeature<
     "fuse-crypto-eor", "HasFuseCryptoEOR", "true",
     "CPU fuses AES/PMULL and EOR operations">;

--- a/llvm/lib/Target/AArch64/AArch64Processors.td
+++ b/llvm/lib/Target/AArch64/AArch64Processors.td
@@ -423,6 +423,7 @@ def TuneAppleA14 : SubtargetFeature<"apple-a14", "ARMProcFamily", "AppleA14",
                                     !listconcat(TuneAppleA13.Implies, [
                                     FeatureAggressiveFMA,
                                     FeatureAlignCmpCSelPairs,
+                                    FeatureAlignPageCrossFuncs,
                                     FeatureFastLD1Single,
                                     FeatureFuseAddress,
                                     FeatureFuseArithmeticLogic,

--- a/llvm/test/CodeGen/AArch64/code-layout-opt.ll
+++ b/llvm/test/CodeGen/AArch64/code-layout-opt.ll
@@ -3,6 +3,9 @@
 ; RUN: llc < %s -verify-machineinstrs -mtriple=aarch64-apple-darwin -mcpu=apple-m4 -aarch64-code-layout-opt-enable=fcmp-fcsel,cmp-csel | FileCheck %s
 ; Default for -mcpu=apple-m4 enables both fcmp-fcsel and cmp-csel; expect identical output.
 ; RUN: llc < %s -verify-machineinstrs -mtriple=aarch64-apple-darwin -mcpu=apple-m4 | FileCheck %s
+; Default for -mcpu=apple-m4 also enables page-cross; the insns-range knob is relaxed only because the test functions are tiny.
+; RUN: llc < %s -verify-machineinstrs -mtriple=aarch64-apple-darwin -mcpu=apple-m4 \
+; RUN:   -aarch64-code-layout-opt-page-cross-insns-range=5,1100 | FileCheck %s --check-prefix=PAGECROSS
 
 ; Test coverage for optimizeForCodeLayout function:
 ; * Basic FCMP-FCSEL instruction pair detection and function alignment (single/double precision)
@@ -261,4 +264,63 @@ entry:
   %cmp = icmp eq i32 %a, %b
   %result = zext i1 %cmp to i32
   ret i32 %result
+}
+
+;------------------------------------------------------------------------------
+; Page-cross alignment tests (page-cross flag of -aarch64-code-layout-opt-enable)
+;------------------------------------------------------------------------------
+
+; * Positive - function with nested loop (depth 2) and enough instructions.
+; PAGECROSS: .globl _test_page_cross_positive
+; PAGECROSS-NEXT: .p2align
+; PAGECROSS-NOT: .p2align 2
+; PAGECROSS-LABEL: _test_page_cross_positive:
+define void @test_page_cross_positive(ptr %p, i32 %n, i32 %m) {
+entry:
+  br label %outer.header
+
+outer.header:
+  %i = phi i32 [ 0, %entry ], [ %i.next, %outer.latch ]
+  br label %inner.header
+
+inner.header:
+  %j = phi i32 [ 0, %outer.header ], [ %j.next, %inner.header ]
+  %idx = add i32 %i, %j
+  %ptr = getelementptr i32, ptr %p, i32 %idx
+  %val = load i32, ptr %ptr
+  %inc = add i32 %val, 1
+  store i32 %inc, ptr %ptr
+  %j.next = add i32 %j, 1
+  %inner.cond = icmp slt i32 %j.next, %m
+  br i1 %inner.cond, label %inner.header, label %outer.latch
+
+outer.latch:
+  %i.next = add i32 %i, 1
+  %outer.cond = icmp slt i32 %i.next, %n
+  br i1 %outer.cond, label %outer.header, label %exit
+
+exit:
+  ret void
+}
+
+; * Negative - single (non-nested) loop, depth 1 below threshold of 2.
+; PAGECROSS: .globl _test_page_cross_negative_shallow
+; PAGECROSS-NEXT: .p2align 2
+; PAGECROSS-LABEL: _test_page_cross_negative_shallow:
+define void @test_page_cross_negative_shallow(ptr %p, i32 %n) {
+entry:
+  br label %loop
+
+loop:
+  %i = phi i32 [ 0, %entry ], [ %i.next, %loop ]
+  %ptr = getelementptr i32, ptr %p, i32 %i
+  %val = load i32, ptr %ptr
+  %inc = add i32 %val, 1
+  store i32 %inc, ptr %ptr
+  %i.next = add i32 %i, 1
+  %cond = icmp slt i32 %i.next, %n
+  br i1 %cond, label %loop, label %exit
+
+exit:
+  ret void
 }


### PR DESCRIPTION
Extends the recently added `aarch64-code-layout-opt` pass with a third case targeting whole-function alignment:
  III. PageCross — page-cross alignment of large nested-loop functions

Hot functions whose body straddles a 4K-page boundary pay extra (fetch related) costs, especially when loops are involved. When a function is large enough to be expensive but small enough that the whole body fits in a single
  power-of-two-sized region, aligning the function entry to that power of two guarantees the body lives within one such region — eliminating the page crossing. Beyond the per-function speedup, this stabilizes measured performance the same way
  the pair cases do: a hot nested-loop function that previously crossed a page boundary only because of upstream codegen drift won't silently regress when an unrelated change shifts its address.

Concretely, the pass computes per-function alignment as NextPowerOf2(SizeInBytes - 1) and applies it when these heuristics are met: the instruction count falls inside a range, and the maximum loop nest depth in the function is ≥ 2. Enabled by default on processors with the new FeatureAlignPageCrossFuncs subtarget feature, which is added to TuneAppleA14 (and inherited by every later Apple core). It can also be forced via the existing bit-mask: `-aarch64-code-layout-opt-enable=page-cross`. Two debug-only knobs allow tuning the heuristic without a rebuild:
  - `-aarch64-code-layout-opt-page-cross-insns-range=min,max` — the open instruction-count range, defaulting to (350, 1100);
  - `-aarch64-code-layout-opt-page-cross-min-loop-depth=N` — the minimum nest depth (default 2).
  
  A new statistic `NumPageCrossAligned` reports how often the heuristic fires.