### PR TITLE
[lldb] Update DenseMap lldb formatters

### DIFF
--- a/llvm/utils/lldbDataFormatters.py
+++ b/llvm/utils/lldbDataFormatters.py
@@ -448,14 +448,7 @@ class PointerUnionSynthProvider:
 def DenseMapSummary(valobj: lldb.SBValue, _) -> str:
     raw_value = valobj.GetNonSyntheticValue()
     num_entries = raw_value.GetChildMemberWithName("NumEntries").unsigned
-    num_tombstones = raw_value.GetChildMemberWithName("NumTombstones").unsigned
-
-    summary = f"size={num_entries}"
-    if num_tombstones == 1:
-        # The heuristic to identify valid entries does not handle the case of a
-        # single tombstone. The summary calls attention to this.
-        summary = f"tombstones=1, {summary}"
-    return summary
+    return f"size={num_entries}"
 
 
 class DenseMapSynthetic:
@@ -495,26 +488,17 @@ class DenseMapSynthetic:
         buckets = self.valobj.GetChildMemberWithName("Buckets")
         num_buckets = self.valobj.GetChildMemberWithName("NumBuckets").unsigned
 
-        # Bucket entries contain one of the following:
-        #   1. Valid key-value
-        #   2. Empty key
-        #   3. Tombstone key (a deleted entry)
-        #
-        # NumBuckets is always greater than NumEntries. The empty key, and
-        # potentially the tombstone key, will occur multiple times. A key that
-        # is repeated is either the empty key or the tombstone key.
-
-        # For each key, collect a list of buckets it appears in.
+        # Heuristic: Group buckets by key as a means to identifying the indexes
+        # of populated buckets. The empty key always appears in multiple
+        # buckets, and any key that appears only once must be a valid entry.
         key_buckets: dict[str, list[int]] = collections.defaultdict(list)
         for index in range(num_buckets):
             bucket = buckets.GetValueForExpressionPath(f"[{index}]")
             key = bucket.GetChildAtIndex(0)
             key_buckets[str(key.data)].append(index)
 
-        # Heuristic: This is not a multi-map, any repeated (non-unique) keys are
-        # either the the empty key or the tombstone key. Populate child_buckets
-        # with the indexes of entries containing unique keys.
         for indexes in key_buckets.values():
+            # A key with a single instance is a valid entry.
             if len(indexes) == 1:
                 self.child_buckets.append(indexes[0])
 


### PR DESCRIPTION
DenseMap tombstone keys were removed in #200595.

This change simplifies the DenseMap synthetic formatter. This data formatter uses a heuristic to avoid expression evaluation. Previously, the heuristic could produce an off-by-one count of the number of map entries, which happened if the DenseMap contained exactly one tombstone key. The change to DenseMap eliminates this corner case.
