### PR TITLE
[MC] Remove PrivateLabelPrefix in favor of InternalSymbolPrefix. NFC

### DIFF
--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -2099,9 +2099,9 @@ void RewriteInstance::adjustFunctionBoundaries(
       // Skip basic block labels. This happens on RISC-V with linker relaxation
       // enabled because every branch needs a relocation and corresponding
       // symbol. We don't want to add such symbols as entry points.
-      const auto PrivateLabelPrefix = BC->AsmInfo->getPrivateLabelPrefix();
-      if (!PrivateLabelPrefix.empty() &&
-          cantFail(Symbol.getName()).starts_with(PrivateLabelPrefix)) {
+      const auto InternalSymbolPrefix = BC->AsmInfo->getInternalSymbolPrefix();
+      if (!InternalSymbolPrefix.empty() &&
+          cantFail(Symbol.getName()).starts_with(InternalSymbolPrefix)) {
         ++NextSymRefI;
         continue;
       }

--- a/llvm/include/llvm/MC/MCAsmInfo.h
+++ b/llvm/include/llvm/MC/MCAsmInfo.h
@@ -158,11 +158,8 @@ protected:
 
   /// For internal use by compiler and assembler, not meant to be visible
   /// externally. They are usually not emitted to the symbol table in the
-  /// object file.
+  /// object file. This is also used for labels for basic blocks.
   StringRef InternalSymbolPrefix = "L";
-
-  /// This prefix is used for labels for basic blocks. Defaults to "L"
-  StringRef PrivateLabelPrefix = "L";
 
   /// This prefix is used for symbols that should be passed through the
   /// assembler but be removed by the linker.  This is 'l' on Darwin, currently
@@ -563,7 +560,6 @@ public:
   bool useAssignmentForEHBegin() const { return UseAssignmentForEHBegin; }
   bool needsLocalForSize() const { return NeedsLocalForSize; }
   StringRef getInternalSymbolPrefix() const { return InternalSymbolPrefix; }
-  StringRef getPrivateLabelPrefix() const { return PrivateLabelPrefix; }
 
   bool hasLinkerPrivateGlobalPrefix() const {
     return !LinkerPrivateGlobalPrefix.empty();

--- a/llvm/include/llvm/MC/MCContext.h
+++ b/llvm/include/llvm/MC/MCContext.h
@@ -457,8 +457,8 @@ public:
 
   /// Get or create a symbol for a basic block. For non-always-emit symbols,
   /// this behaves like createTempSymbol, except that it uses the
-  /// PrivateLabelPrefix instead of the InternalSymbolPrefix. When AlwaysEmit is
-  /// true, behaves like getOrCreateSymbol, prefixed with PrivateLabelPrefix.
+  /// InternalSymbolPrefix. When AlwaysEmit is true, behaves like
+  /// getOrCreateSymbol, prefixed with InternalSymbolPrefix.
   LLVM_ABI MCSymbol *createBlockSymbol(const Twine &Name,
                                        bool AlwaysEmit = false);
 

--- a/llvm/lib/MC/MCAsmInfoELF.cpp
+++ b/llvm/lib/MC/MCAsmInfoELF.cpp
@@ -46,7 +46,6 @@ MCAsmInfoELF::MCAsmInfoELF(const MCTargetOptions &Options)
   HasPreferredAlignment = true;
   WeakRefDirective = "\t.weak\t";
   InternalSymbolPrefix = ".L";
-  PrivateLabelPrefix = ".L";
 }
 
 static void printName(raw_ostream &OS, StringRef Name) {

--- a/llvm/lib/MC/MCAsmInfoGOFF.cpp
+++ b/llvm/lib/MC/MCAsmInfoGOFF.cpp
@@ -26,7 +26,6 @@ MCAsmInfoGOFF::MCAsmInfoGOFF(const MCTargetOptions &Options)
   Data64bitsDirective = "\t.quad\t";
   WeakRefDirective = "WXTRN";
   InternalSymbolPrefix = "L#";
-  PrivateLabelPrefix = "L#";
   ZeroDirective = "\t.space\t";
 }
 

--- a/llvm/lib/MC/MCAsmInfoWasm.cpp
+++ b/llvm/lib/MC/MCAsmInfoWasm.cpp
@@ -24,7 +24,6 @@ MCAsmInfoWasm::MCAsmInfoWasm(const MCTargetOptions &Options)
   HasNoDeadStrip = true;
   WeakRefDirective = "\t.weak\t";
   InternalSymbolPrefix = ".L";
-  PrivateLabelPrefix = ".L";
 }
 
 static void printName(raw_ostream &OS, StringRef Name) {

--- a/llvm/lib/MC/MCAsmInfoXCOFF.cpp
+++ b/llvm/lib/MC/MCAsmInfoXCOFF.cpp
@@ -26,7 +26,6 @@ MCAsmInfoXCOFF::MCAsmInfoXCOFF(const MCTargetOptions &Options)
   IsLittleEndian = false;
 
   InternalSymbolPrefix = "L..";
-  PrivateLabelPrefix = "L..";
   SupportsQuotedNames = false;
   if (UseLEB128Directives == cl::BOU_UNSET)
     HasLEB128Directives = false;

--- a/llvm/lib/MC/MCContext.cpp
+++ b/llvm/lib/MC/MCContext.cpp
@@ -376,12 +376,12 @@ MCSymbol *MCContext::createNamedTempSymbol(const Twine &Name) {
 
 MCSymbol *MCContext::createBlockSymbol(const Twine &Name, bool AlwaysEmit) {
   if (AlwaysEmit)
-    return getOrCreateSymbol(MAI.getPrivateLabelPrefix() + Name);
+    return getOrCreateSymbol(MAI.getInternalSymbolPrefix() + Name);
 
   bool IsTemporary = !SaveTempLabels;
   if (IsTemporary && !UseNamesOnTempLabels)
     return createSymbolImpl(nullptr, IsTemporary);
-  return createRenamableSymbol(MAI.getPrivateLabelPrefix() + Name,
+  return createRenamableSymbol(MAI.getInternalSymbolPrefix() + Name,
                                /*AlwaysAddSuffix=*/false, IsTemporary);
 }
 

--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -6288,7 +6288,7 @@ bool AsmParser::parseMSInlineAsm(
         OS << "]";
       break;
     case AOK_Label:
-      OS << Ctx.getAsmInfo().getPrivateLabelPrefix() << AR.Label;
+      OS << Ctx.getAsmInfo().getInternalSymbolPrefix() << AR.Label;
       break;
     case AOK_Input:
       if (AR.IntelExpRestricted)

--- a/llvm/lib/MC/MCParser/MasmParser.cpp
+++ b/llvm/lib/MC/MCParser/MasmParser.cpp
@@ -6074,7 +6074,7 @@ bool MasmParser::parseMSInlineAsm(
         OS << "]";
       break;
     case AOK_Label:
-      OS << Ctx.getAsmInfo().getPrivateLabelPrefix() << AR.Label;
+      OS << Ctx.getAsmInfo().getInternalSymbolPrefix() << AR.Label;
       break;
     case AOK_Input:
       OS << '$' << InputIdx++;

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCAsmInfo.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCAsmInfo.cpp
@@ -147,7 +147,6 @@ AArch64MCAsmInfoDarwin::AArch64MCAsmInfoDarwin(bool IsILP32,
   AssemblerDialect = AsmWriterVariant == Default ? Apple : AsmWriterVariant;
 
   InternalSymbolPrefix = "L";
-  PrivateLabelPrefix = "L";
   SeparatorString = "%%";
   CommentString = ";";
   CalleeSaveStackSlotSize = 8;
@@ -222,7 +221,6 @@ AArch64MCAsmInfoELF::AArch64MCAsmInfoELF(const Triple &T,
 
   CommentString = "//";
   InternalSymbolPrefix = ".L";
-  PrivateLabelPrefix = ".L";
 
   Data16bitsDirective = "\t.hword\t";
   Data32bitsDirective = "\t.word\t";
@@ -265,7 +263,6 @@ AArch64MCAsmInfoMicrosoftCOFF::AArch64MCAsmInfoMicrosoftCOFF(
     const MCTargetOptions &Options)
     : MCAsmInfoMicrosoft(Options) {
   InternalSymbolPrefix = ".L";
-  PrivateLabelPrefix = ".L";
 
   Data16bitsDirective = "\t.hword\t";
   Data32bitsDirective = "\t.word\t";
@@ -296,7 +293,6 @@ bool AArch64MCAsmInfoMicrosoftCOFF::evaluateAsRelocatableImpl(
 AArch64MCAsmInfoGNUCOFF::AArch64MCAsmInfoGNUCOFF(const MCTargetOptions &Options)
     : MCAsmInfoGNUCOFF(Options) {
   InternalSymbolPrefix = ".L";
-  PrivateLabelPrefix = ".L";
 
   Data16bitsDirective = "\t.hword\t";
   Data32bitsDirective = "\t.word\t";

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMMCAsmInfo.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMMCAsmInfo.cpp
@@ -126,7 +126,6 @@ ARMCOFFMCAsmInfoMicrosoft::ARMCOFFMCAsmInfoMicrosoft(
   ExceptionsType = ExceptionHandling::WinEH;
   WinEHEncodingType = WinEH::EncodingType::Itanium;
   InternalSymbolPrefix = "$M";
-  PrivateLabelPrefix = "$M";
   CommentString = "@";
 
   // Conditional Thumb 4-byte instructions can have an implicit IT.
@@ -144,7 +143,6 @@ ARMCOFFMCAsmInfoGNU::ARMCOFFMCAsmInfoGNU(const MCTargetOptions &Options)
 
   CommentString = "@";
   InternalSymbolPrefix = ".L";
-  PrivateLabelPrefix = ".L";
 
   SupportsDebugInformation = true;
   ExceptionsType = ExceptionHandling::WinEH;

--- a/llvm/lib/Target/BPF/MCTargetDesc/BPFMCAsmInfo.h
+++ b/llvm/lib/Target/BPF/MCTargetDesc/BPFMCAsmInfo.h
@@ -26,7 +26,6 @@ public:
       IsLittleEndian = false;
 
     InternalSymbolPrefix = ".L";
-    PrivateLabelPrefix = ".L";
     WeakRefDirective = "\t.weak\t";
 
     UsesELFSectionDirectiveForBSS = true;

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsMCAsmInfo.cpp
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsMCAsmInfo.cpp
@@ -35,7 +35,6 @@ MipsELFMCAsmInfo::MipsELFMCAsmInfo(const Triple &TheTriple,
     InternalSymbolPrefix = "$";
   else if (ABI.IsN32() || ABI.IsN64())
     InternalSymbolPrefix = ".L";
-  PrivateLabelPrefix = InternalSymbolPrefix;
 
   AlignmentIsInBytes          = false;
   Data16bitsDirective         = "\t.2byte\t";
@@ -59,7 +58,6 @@ MipsCOFFMCAsmInfo::MipsCOFFMCAsmInfo(const MCTargetOptions &Options)
   ExceptionsType = ExceptionHandling::WinEH;
 
   InternalSymbolPrefix = ".L";
-  PrivateLabelPrefix = ".L";
   AllowAtInName = true;
 }
 

--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXMCAsmInfo.cpp
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXMCAsmInfo.cpp
@@ -49,7 +49,6 @@ NVPTXMCAsmInfo::NVPTXMCAsmInfo(const Triple &TheTriple,
   SupportsSignedData = false;
 
   InternalSymbolPrefix = "$L__";
-  PrivateLabelPrefix = InternalSymbolPrefix;
 
   // TODO: Can we just disable this?
   WeakDirective = "\t// .weak\t";

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.cpp
@@ -63,7 +63,6 @@ RISCVMCAsmInfoDarwin::RISCVMCAsmInfoDarwin(const MCTargetOptions &Options)
     : MCAsmInfoDarwin(Options) {
   CodePointerSize = 4;
   InternalSymbolPrefix = "L";
-  PrivateLabelPrefix = "L";
   SeparatorString = "%%";
   CommentString = ";";
   AlignmentIsInBytes = false;

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.cpp
@@ -154,7 +154,6 @@ X86MCAsmInfoMicrosoft::X86MCAsmInfoMicrosoft(const Triple &Triple,
     : MCAsmInfoMicrosoft(Options) {
   if (Triple.isX86_64()) {
     InternalSymbolPrefix = ".L";
-    PrivateLabelPrefix = ".L";
     CodePointerSize = 8;
     WinEHEncodingType = WinEH::EncodingType::Itanium;
   } else {
@@ -224,7 +223,6 @@ X86MCAsmInfoGNUCOFF::X86MCAsmInfoGNUCOFF(const Triple &Triple,
          "Windows and UEFI are the only supported COFF targets");
   if (Triple.isX86_64()) {
     InternalSymbolPrefix = ".L";
-    PrivateLabelPrefix = ".L";
     CodePointerSize = 8;
     WinEHEncodingType = WinEH::EncodingType::Itanium;
     ExceptionsType = ExceptionHandling::WinEH;


### PR DESCRIPTION
Every target sets `PrivateLabelPrefix` equal to `InternalSymbolPrefix`.
BPF was the last target where the two diverged, and it was unified to ".L"
(#185164).

With no remaining target distinguishing the two, drop the redundant
`PrivateLabelPrefix` member and `getPrivateLabelPrefix` accessor and route
the basic-block label callers (MCContext::createBlockSymbol, the inline-asm
label fixups in AsmParser/MasmParser, and BOLT) through
`getInternalSymbolPrefix`.
