### PR TITLE
[analysis/lint] fulfilled the todo for linting unusual sizes in alloca

### DIFF
--- a/llvm/lib/Analysis/Lint.cpp
+++ b/llvm/lib/Analysis/Lint.cpp
@@ -593,12 +593,16 @@ void Lint::visitURem(BinaryOperator &I) {
 }
 
 void Lint::visitAllocaInst(AllocaInst &I) {
-  if (isa<ConstantInt>(I.getArraySize()))
+  if (isa<ConstantInt>(I.getArraySize())) {
     // This isn't undefined behavior, it's just an obvious pessimization.
     Check(&I.getParent()->getParent()->getEntryBlock() == I.getParent(),
           "Pessimization: Static alloca outside of entry block", &I);
-
-  // TODO: Check for an unusual size (MSB set?)
+    
+    // Check for unusual sizes in alloca
+    auto* value = dyn_cast<ConstantInt>(I.getArraySize());
+    Check(value->getSExtValue() >= 0, 
+          "Undefined behavior: Static alloca used with a negative number", &I);
+  }
 }
 
 void Lint::visitVAArgInst(VAArgInst &I) {

--- a/llvm/test/Analysis/Lint/alloca-negative-size.ll
+++ b/llvm/test/Analysis/Lint/alloca-negative-size.ll
@@ -1,0 +1,9 @@
+; RUN: opt < %s -passes=lint -disable-output 2>&1 | FileCheck %s
+
+define void @test() {
+entry:
+    %tmp = alloca i32, i32 -5
+    ret void
+}
+
+; CHECK: Undefined behavior: Static alloca used with a negative number


### PR DESCRIPTION
The to-do in the `visitAllocaInst` function requested to lint for unusual sizes, such as MSB being set. 
My fix fulfils this request by carrying out a simple negativity check on the alloca instance - since `Check` will report on a false value; the check condition is `>= 0`.

Additionally, a lit test was added to `llvm/test/Analysis/Lint/alloca-negative-size.ll` to ensure the functionality of lint works as intended.

https://github.com/llvm/llvm-project/blob/86350249871598fe76318ebd21af468879b9e87e/llvm/lib/Analysis/Lint.cpp#L595

*Note: I used an LLM to understand LLVM's casting API; such as the usage of `dyn_cast`*