### PR TITLE
[Github] Add github-automation container

### DIFF
--- a/.github/workflows/build-ci-container-tooling.yml
+++ b/.github/workflows/build-ci-container-tooling.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - .github/workflows/build-ci-container-tooling.yml
       - '.github/workflows/containers/github-action-ci-tooling/**'
+      - llvm/utils/git/github-automation.py
       - llvm/utils/git/requirements_formatting.txt
       - llvm/utils/git/requirements_linting.txt
       - '.github/actions/build-container/**'
@@ -18,6 +19,7 @@ on:
     paths:
       - .github/workflows/build-ci-container-tooling.yml
       - '.github/workflows/containers/github-action-ci-tooling/**'
+      - llvm/utils/git/github-automation.py
       - llvm/utils/git/requirements_formatting.txt
       - llvm/utils/git/requirements_linting.txt
       - '.github/actions/build-container/**'
@@ -39,6 +41,10 @@ jobs:
           - container-name: abi-tests
             test-command: 'cd $HOME && abi-compliance-checker --help'
             target: abi-tests
+          - container-name: github-automation
+            test-command: 'true'
+            target: github-automation
+
     steps:
       - name: Checkout LLVM
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/build-ci-container-tooling.yml
+++ b/.github/workflows/build-ci-container-tooling.yml
@@ -66,6 +66,7 @@ jobs:
           dockerfile: .github/workflows/containers/github-action-ci-tooling/Dockerfile
           target: ci-container-${{ matrix.target || format('code-{0}', matrix.container-name) }}
           test-command: ${{ matrix.test-command }}
+          context: ${{ matrix.context }}
 
   push-ci-container:
     if: github.event_name == 'push'

--- a/.github/workflows/build-ci-container-tooling.yml
+++ b/.github/workflows/build-ci-container-tooling.yml
@@ -44,6 +44,7 @@ jobs:
           - container-name: github-automation
             test-command: 'true'
             target: github-automation
+            context: llvm/utils/git/
 
     steps:
       - name: Checkout LLVM
@@ -54,6 +55,7 @@ jobs:
             .github/workflows/containers/github-action-ci-tooling/
             llvm/utils/git/requirements_formatting.txt
             llvm/utils/git/requirements_linting.txt
+            llvm/utils/git/github-automation.py
             clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
             .github/actions/build-container
 

--- a/.github/workflows/containers/github-action-ci-tooling/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-tooling/Dockerfile
@@ -115,9 +115,6 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 FROM base as ci-container-github-automation
-ARG LLVM_GIT_CHECKOUT=/home/gha/llvm-project
-ARG LLVM_GITHUB_AUTOMATION_DIR=llvm/utils/git
-ENV PATH=${LLVM_GIT_CHECKOUT}/${LLVM_GITHUB_AUTOMATION_DIR}:${PATH}
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -127,8 +124,5 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 USER gha
-RUN git clone https://github.com/llvm/llvm-project --depth=1 -b main --no-checkout ${LLVM_GIT_CHECKOUT} && \
-    git -C ${LLVM_GIT_CHECKOUT} sparse-checkout init --cone && \
-    git -C ${LLVM_GIT_CHECKOUT} sparse-checkout set ${LLVM_GITHUB_AUTOMATION_DIR} && \
-    git -C ${LLVM_GIT_CHECKOUT} checkout && \
-    rm -Rf ${LLVM_GIT_CHECKOUT}/.git
+
+ADD github-automation.py /usr/local/bin/

--- a/.github/workflows/containers/github-action-ci-tooling/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-tooling/Dockerfile
@@ -113,3 +113,22 @@ RUN apt-get update && \
     universal-ctags && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+FROM base as ci-container-github-automation
+ARG LLVM_GIT_CHECKOUT=/home/gha/llvm-project
+ARG LLVM_GITHUB_AUTOMATION_DIR=llvm/utils/git
+ENV PATH=${LLVM_GIT_CHECKOUT}/${LLVM_GITHUB_AUTOMATION_DIR}:${PATH}
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    python3-git \
+    python3-github && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+USER gha
+RUN git clone https://github.com/llvm/llvm-project --depth=1 -b main --no-checkout ${LLVM_GIT_CHECKOUT} && \
+    git -C ${LLVM_GIT_CHECKOUT} sparse-checkout init --cone && \
+    git -C ${LLVM_GIT_CHECKOUT} sparse-checkout set ${LLVM_GITHUB_AUTOMATION_DIR} && \
+    git -C ${LLVM_GIT_CHECKOUT} checkout && \
+    rm -Rf ${LLVM_GIT_CHECKOUT}/.git


### PR DESCRIPTION
There are several jobs that use the pattern:
1. Checkout github-automation.py script.
2. Install dependencies for github-automation.py script.
3. Run the github-automation.py script.

We can consolidate a lot of this logic into the container and simplify the workflows.  This may also speed them up the workflow jobs slightly, but most of them are already pretty fast, so it may not make a big difference.