### PR TITLE
[lit] Add type hints

### DIFF
--- a/llvm/utils/lit/lit/BooleanExpression.py
+++ b/llvm/utils/lit/lit/BooleanExpression.py
@@ -1,4 +1,5 @@
 import re
+from typing import Set, Union
 
 
 class BooleanExpression:
@@ -26,7 +27,7 @@ class BooleanExpression:
     # 'true' is true.
     # All other identifiers are false.
     @staticmethod
-    def evaluate(string, variables):
+    def evaluate(string: str, variables: Set[str]) -> bool:
         try:
             parser = BooleanExpression(string, set(variables))
             return parser.parseAll()
@@ -35,7 +36,7 @@ class BooleanExpression:
 
     #####
 
-    def __init__(self, string, variables):
+    def __init__(self, string: str, variables: Set[str]) -> None:
         self.tokens = BooleanExpression.tokenize(string)
         self.variables = variables
         self.variables.add("true")
@@ -71,14 +72,14 @@ class BooleanExpression:
         else:
             return repr(token)
 
-    def accept(self, t):
+    def accept(self, t: str) -> bool:
         if self.token == t:
             self.token = next(self.tokens)
             return True
         else:
             return False
 
-    def expect(self, t):
+    def expect(self, t: Union[object, str]) -> None:
         if self.token == t:
             if self.token != BooleanExpression.END:
                 self.token = next(self.tokens)
@@ -88,7 +89,7 @@ class BooleanExpression:
             )
 
     @staticmethod
-    def isMatchExpression(token):
+    def isMatchExpression(token: str) -> bool:
         if (
             token is BooleanExpression.END
             or token == "&&"
@@ -100,7 +101,7 @@ class BooleanExpression:
             return False
         return True
 
-    def parseMATCH(self):
+    def parseMATCH(self) -> None:
         regex = ""
         for part in filter(None, re.split(r"(\{\{.+?\}\})", self.token)):
             if part.startswith("{{"):
@@ -112,7 +113,7 @@ class BooleanExpression:
         self.value = any(regex.fullmatch(var) for var in self.variables)
         self.token = next(self.tokens)
 
-    def parseNOT(self):
+    def parseNOT(self) -> None:
         if self.accept("!"):
             self.parseNOT()
             self.value = not self.value
@@ -127,7 +128,7 @@ class BooleanExpression:
         else:
             self.parseMATCH()
 
-    def parseAND(self):
+    def parseAND(self) -> None:
         self.parseNOT()
         while self.accept("&&"):
             left = self.value
@@ -137,7 +138,7 @@ class BooleanExpression:
             # doesn't matter for this limited expression grammar
             self.value = left and right
 
-    def parseOR(self):
+    def parseOR(self) -> None:
         self.parseAND()
         while self.accept("||"):
             left = self.value
@@ -147,7 +148,7 @@ class BooleanExpression:
             # doesn't matter for this limited expression grammar
             self.value = left or right
 
-    def parseAll(self):
+    def parseAll(self) -> bool:
         self.token = next(self.tokens)
         self.parseOR()
         self.expect(BooleanExpression.END)

--- a/llvm/utils/lit/lit/DiffUpdater.py
+++ b/llvm/utils/lit/lit/DiffUpdater.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
 import shutil
 import os
 import shlex
 import pathlib
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+
+if TYPE_CHECKING:
+    from lit.ShellEnvironment import ShellCommandResult
+    from lit.Test import Test
 
 """
 This file provides the `diff_test_updater` function, which is invoked on failed RUN lines when lit is executed with --update-tests.
@@ -23,24 +30,30 @@ Possible improvements:
 
 
 class NormalFileTarget:
-    def __init__(self, target):
+    def __init__(self, target: str) -> None:
         self.target = target
 
-    def copyFrom(self, source):
+    def copyFrom(self, source: str) -> None:
         shutil.copy(source, self.target)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.target
 
 
 class SplitFileTarget:
-    def __init__(self, slice_start_idx, test_path, lines, filename):
+    def __init__(
+        self,
+        slice_start_idx: int,
+        test_path: pathlib.Path,
+        lines: List[str],
+        filename: str,
+    ) -> None:
         self.slice_start_idx = slice_start_idx
         self.test_path = test_path
         self.lines = lines
         self.filename = filename
 
-    def copyFrom(self, source):
+    def copyFrom(self, source: str) -> None:
         lines_before = self.lines[: self.slice_start_idx + 1]
         self.lines = self.lines[self.slice_start_idx + 1 :]
         slice_end_idx = None
@@ -58,11 +71,11 @@ class SplitFileTarget:
             for l in new_lines:
                 f.write(l)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"slice {self.filename} in {self.test_path}"
 
     @staticmethod
-    def get_target_dir(commands, test_path):
+    def get_target_dir(commands: List[str], test_path: pathlib.Path) -> Optional[str]:
         # posix=True breaks Windows paths because \ is treated as an escaping character
         for cmd in commands:
             split = shlex.split(cmd, posix=False)
@@ -79,7 +92,9 @@ class SplitFileTarget:
         return None
 
     @staticmethod
-    def create(path, commands, test_path, target_dir):
+    def create(
+        path: str, commands: List[str], test_path: pathlib.Path, target_dir: str
+    ) -> Optional[SplitFileTarget]:
         path = pathlib.Path(path)
         with open(test_path, "r") as f:
             lines = f.readlines()
@@ -93,7 +108,7 @@ class SplitFileTarget:
         return SplitFileTarget(idx, test_path, lines, p)
 
     @staticmethod
-    def _get_split_line_path(l):
+    def _get_split_line_path(l: str) -> Optional[str]:
         if len(l) < 6:
             return None
         if l.startswith("//"):
@@ -107,19 +122,21 @@ class SplitFileTarget:
         return l.rstrip()
 
 
-def unquote(s):
+def unquote(s: str) -> str:
     if len(s) > 1 and s[0] == s[-1] and (s[0] == '"' or s[0] == "'"):
         return s[1:-1]
     return s
 
 
-def get_source_and_target(a, b, test_path, commands):
+def get_source_and_target(
+    a: str, b: str, test_path: pathlib.Path, commands: List[str]
+) -> Optional[Tuple[str, Union[NormalFileTarget, SplitFileTarget]]]:
     """
     Try to figure out which file is the test output and which is the reference.
     """
     split_target_dir = SplitFileTarget.get_target_dir(commands, test_path)
-    a_target = None
-    b_target = None
+    a_target: Optional[Union[NormalFileTarget, SplitFileTarget]] = None
+    b_target: Optional[Union[NormalFileTarget, SplitFileTarget]] = None
     if split_target_dir:
         a_target = SplitFileTarget.create(a, commands, test_path, split_target_dir)
         b_target = SplitFileTarget.create(b, commands, test_path, split_target_dir)
@@ -148,11 +165,13 @@ def get_source_and_target(a, b, test_path, commands):
     return None
 
 
-def filter_flags(args):
+def filter_flags(args: List[str]) -> List[str]:
     return [arg for arg in args if not arg.startswith("-")]
 
 
-def diff_test_updater(result, test, commands):
+def diff_test_updater(
+    result: ShellCommandResult, test: Test, commands: List[str]
+) -> Optional[str]:
     args = filter_flags(result.command.args)
     if len(args) != 3:
         return None

--- a/llvm/utils/lit/lit/InprocBuiltins.py
+++ b/llvm/utils/lit/lit/InprocBuiltins.py
@@ -9,6 +9,7 @@ from io import StringIO
 
 import lit.util
 from lit.ShellEnvironment import (
+    ShellEnvironment,
     InternalShellError,
     ShellCommandResult,
     expand_glob_expressions,
@@ -16,9 +17,10 @@ from lit.ShellEnvironment import (
     processRedirects,
     updateEnv,
 )
+from lit.ShCommands import Command
 
 
-def executeBuiltinCd(cmd, shenv):
+def executeBuiltinCd(cmd: Command, shenv: ShellEnvironment) -> ShellCommandResult:
     """executeBuiltinCd - Change the current directory."""
     if len(cmd.args) != 2:
         raise InternalShellError(cmd, "'cd' supports only one argument")
@@ -29,7 +31,7 @@ def executeBuiltinCd(cmd, shenv):
     return ShellCommandResult(cmd, "", "", 0, False)
 
 
-def executeBuiltinPushd(cmd, shenv):
+def executeBuiltinPushd(cmd: Command, shenv: ShellEnvironment) -> ShellCommandResult:
     """executeBuiltinPushd - Change the current dir and save the old."""
     if len(cmd.args) != 2:
         raise InternalShellError(cmd, "'pushd' supports only one argument")
@@ -38,7 +40,7 @@ def executeBuiltinPushd(cmd, shenv):
     return ShellCommandResult(cmd, "", "", 0, False)
 
 
-def executeBuiltinPopd(cmd, shenv):
+def executeBuiltinPopd(cmd: Command, shenv: ShellEnvironment) -> ShellCommandResult:
     """executeBuiltinPopd - Restore a previously saved working directory."""
     if len(cmd.args) != 1:
         raise InternalShellError(cmd, "'popd' does not support arguments")
@@ -48,7 +50,7 @@ def executeBuiltinPopd(cmd, shenv):
     return ShellCommandResult(cmd, "", "", 0, False)
 
 
-def executeBuiltinExport(cmd, shenv):
+def executeBuiltinExport(cmd: Command, shenv: ShellEnvironment) -> ShellCommandResult:
     """executeBuiltinExport - Set an environment variable."""
     if len(cmd.args) != 2:
         raise InternalShellError(cmd, "'export' supports only one argument")
@@ -56,7 +58,7 @@ def executeBuiltinExport(cmd, shenv):
     return ShellCommandResult(cmd, "", "", 0, False)
 
 
-def executeBuiltinEcho(cmd, shenv):
+def executeBuiltinEcho(cmd: Command, shenv: ShellEnvironment) -> ShellCommandResult:
     """Interpret a redirected echo or @echo command"""
     opened_files = []
     stdin, stdout, stderr = processRedirects(cmd, subprocess.PIPE, shenv, opened_files)
@@ -113,7 +115,9 @@ def executeBuiltinEcho(cmd, shenv):
     return ShellCommandResult(cmd, output, "", 0, False)
 
 
-def executeBuiltinMkdir(cmd, cmd_shenv):
+def executeBuiltinMkdir(
+    cmd: Command, cmd_shenv: ShellEnvironment
+) -> ShellCommandResult:
     """executeBuiltinMkdir - Create new directories."""
     args = expand_glob_expressions(cmd.args, cmd_shenv.cwd)[1:]
     try:
@@ -149,7 +153,7 @@ def executeBuiltinMkdir(cmd, cmd_shenv):
     return ShellCommandResult(cmd, "", stderr.getvalue(), exitCode, False)
 
 
-def executeBuiltinRm(cmd, cmd_shenv):
+def executeBuiltinRm(cmd: Command, cmd_shenv: ShellEnvironment) -> ShellCommandResult:
     """executeBuiltinRm - Removes (deletes) files or directories."""
     args = expand_glob_expressions(cmd.args, cmd_shenv.cwd)[1:]
     try:
@@ -310,6 +314,8 @@ def executeBuiltinUlimit(cmd, shenv):
     return ShellCommandResult(cmd, "", "", 0, False)
 
 
-def executeBuiltinColon(cmd, cmd_shenv):
+def executeBuiltinColon(
+    cmd: Command, cmd_shenv: ShellEnvironment
+) -> ShellCommandResult:
     """executeBuiltinColon - Discard arguments and exit with status 0."""
     return ShellCommandResult(cmd, "", "", 0, False)

--- a/llvm/utils/lit/lit/LitConfig.py
+++ b/llvm/utils/lit/lit/LitConfig.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 import os
 import enum
@@ -9,6 +11,11 @@ import lit.formats
 import lit.TestingConfig
 import lit.util
 from lit.DiffUpdater import diff_test_updater
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from lit.cl_arguments import TestOrder
+
 
 # LitConfig must be a new style class for properties to work
 class LitConfig:
@@ -23,25 +30,25 @@ class LitConfig:
 
     def __init__(
         self,
-        progname,
-        path,
-        diagnostic_level,
-        useValgrind,
-        valgrindLeakCheck,
-        valgrindArgs,
-        noExecute,
-        debug,
-        isWindows,
-        order,
-        params,
-        config_prefix=None,
-        maxIndividualTestTime=None,
-        maxRetriesPerTest=None,
-        parallelism_groups={},
-        per_test_coverage=False,
-        gtest_sharding=True,
-        update_tests=False,
-    ):
+        progname: str,
+        path: List[str],
+        diagnostic_level: str,
+        useValgrind: bool,
+        valgrindLeakCheck: bool,
+        valgrindArgs: List[str],
+        noExecute: bool,
+        debug: bool,
+        isWindows: bool,
+        order: TestOrder,
+        params: Dict[str, Any],
+        config_prefix: Optional[str] = None,
+        maxIndividualTestTime: Optional[int] = None,
+        maxRetriesPerTest: Optional[int] = None,
+        parallelism_groups: Dict[Any, Any] = {},
+        per_test_coverage: bool = False,
+        gtest_sharding: bool = True,
+        update_tests: bool = False,
+    ) -> None:
         # The name of the test runner.
         self.progname = progname
         # The items to add to the PATH environment variable.
@@ -215,7 +222,7 @@ class LitConfig:
 
         return dir
 
-    def _write_message(self, kind, message):
+    def _write_message(self, kind: str, message: str) -> None:
         if not self.diagnostic_level_enabled(kind):
             return
         # Get the file/line where this message was generated.
@@ -245,14 +252,14 @@ class LitConfig:
                 "unable to find %r parameter, use '--param=%s=VALUE'" % (key, key)
             )
 
-    def diagnostic_level_enabled(self, kind):
+    def diagnostic_level_enabled(self, kind: str) -> bool:
         if kind == "debug":
             return self.debug
         return DiagnosticLevel.create(self.diagnostic_level) >= DiagnosticLevel.create(
             kind
         )
 
-    def dbg(self, message):
+    def dbg(self, message: str) -> None:
         self._write_message("debug", message)
 
     def note(self, message):

--- a/llvm/utils/lit/lit/LitTestCase.py
+++ b/llvm/utils/lit/lit/LitTestCase.py
@@ -1,8 +1,15 @@
+from __future__ import annotations
+
 import unittest
 
 import lit.discovery
 import lit.LitConfig
 import lit.worker
+from typing import TYPE_CHECKING, List
+
+if TYPE_CHECKING:
+    from lit.Test import Test
+    from unittest.suite import TestSuite
 
 """
 TestCase adaptor for providing a Python 'unittest' compatible interface to 'lit'
@@ -15,18 +22,18 @@ class UnresolvedError(RuntimeError):
 
 
 class LitTestCase(unittest.TestCase):
-    def __init__(self, test, lit_config):
+    def __init__(self, test: Test, lit_config: lit.LitConfig.LitConfig) -> None:
         unittest.TestCase.__init__(self)
         self._test = test
         self._lit_config = lit_config
 
-    def id(self):
+    def id(self) -> str:
         return self._test.getFullName()
 
-    def shortDescription(self):
+    def shortDescription(self) -> str:
         return self._test.getFullName()
 
-    def runTest(self):
+    def runTest(self) -> None:
         # Run the test.
         result = lit.worker._execute(self._test, self._lit_config)
 
@@ -37,7 +44,7 @@ class LitTestCase(unittest.TestCase):
             self.fail(result.output)
 
 
-def load_test_suite(inputs):
+def load_test_suite(inputs: List[str]) -> TestSuite:
     import platform
 
     windows = platform.system() == "Windows"

--- a/llvm/utils/lit/lit/ProgressBar.py
+++ b/llvm/utils/lit/lit/ProgressBar.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import annotations
 
 # Source: http://code.activestate.com/recipes/475116/, with
 # modifications by Daniel Dunbar.
@@ -7,6 +8,8 @@ import os
 import re
 import sys
 import time
+from io import TextIOWrapper
+from typing import Type
 
 
 def to_bytes(str):
@@ -86,7 +89,9 @@ class TerminalController:
 
     _ANSICOLORS = "BLACK RED GREEN YELLOW BLUE MAGENTA CYAN WHITE".split()
 
-    def __new__(cls, term_stream=sys.stdout):
+    def __new__(
+        cls: Type[TerminalController], term_stream: TextIOWrapper = sys.stdout
+    ) -> "_PosixTerminalController":
         if cls is TerminalController:
             if sys.platform == "win32":
                 return super().__new__(_WindowsTerminalController)
@@ -117,7 +122,7 @@ class _PosixTerminalController(TerminalController):
     HIDE_CURSOR=cinvis SHOW_CURSOR=cnorm""".split()
     _COLORS = """BLACK BLUE GREEN CYAN RED MAGENTA YELLOW WHITE""".split()
 
-    def __init__(self, term_stream=sys.stdout):
+    def __init__(self, term_stream: TextIOWrapper = sys.stdout) -> None:
         try:
             import curses
         except:
@@ -249,11 +254,11 @@ class SimpleProgressBar:
       'Header:  0.. 10.. 20.. ...'
     """
 
-    def __init__(self, header):
+    def __init__(self, header: str) -> None:
         self.header = header
         self.atIndex = None
 
-    def update(self, percent, message):
+    def update(self, percent: float, message: str) -> None:
         if self.atIndex is None:
             sys.stdout.write(self.header)
             self.atIndex = 0
@@ -275,7 +280,7 @@ class SimpleProgressBar:
         sys.stdout.flush()
         self.atIndex = next
 
-    def clear(self, interrupted):
+    def clear(self, interrupted: bool) -> None:
         if self.atIndex is not None and not interrupted:
             sys.stdout.write("\n")
             sys.stdout.flush()
@@ -297,7 +302,13 @@ class ProgressBar:
     BAR = "%s${%s}[${BOLD}%s%s${NORMAL}${%s}]${NORMAL}%s"
     HEADER = "${BOLD}${CYAN}%s${NORMAL}\n\n"
 
-    def __init__(self, term, header, minOutputInterval, useETA=True):
+    def __init__(
+        self,
+        term: _PosixTerminalController,
+        header: str,
+        minOutputInterval: float,
+        useETA: bool = True,
+    ):
         self.term = term
         if not (self.term.CLEAR_EOL and self.term.UP and self.term.BOL):
             raise ValueError(

--- a/llvm/utils/lit/lit/ShCommands.py
+++ b/llvm/utils/lit/lit/ShCommands.py
@@ -1,12 +1,21 @@
+from __future__ import annotations
+
+from typing import Any, List, Tuple, Union
+
+
 class Command:
-    def __init__(self, args, redirects):
+    def __init__(
+        self,
+        args: List[Union[str, GlobItem]],
+        redirects: List[Union[Tuple[Tuple[str], str], Any]],
+    ) -> None:
         self.args = list(args)
         self.redirects = list(redirects)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Command(%r, %r)" % (self.args, self.redirects)
 
-    def __eq__(self, other):
+    def __eq__(self, other: "Command") -> bool:
         if not isinstance(other, Command):
             return False
 
@@ -37,7 +46,7 @@ class Command:
 
 
 class GlobItem:
-    def __init__(self, pattern):
+    def __init__(self, pattern: str) -> None:
         self.pattern = pattern
 
     def __repr__(self):
@@ -62,15 +71,17 @@ class GlobItem:
 
 
 class Pipeline:
-    def __init__(self, commands, negate=False, pipe_err=False):
+    def __init__(
+        self, commands: List[Command], negate: bool = False, pipe_err: bool = False
+    ) -> None:
         self.commands = commands
         self.negate = negate
         self.pipe_err = pipe_err
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Pipeline(%r, %r, %r)" % (self.commands, self.negate, self.pipe_err)
 
-    def __eq__(self, other):
+    def __eq__(self, other: "Pipeline") -> bool:
         if not isinstance(other, Pipeline):
             return False
 
@@ -92,13 +103,13 @@ class Pipeline:
 
 
 class Seq:
-    def __init__(self, lhs, op, rhs):
+    def __init__(self, lhs: Pipeline, op: str, rhs: Pipeline) -> None:
         assert op in (";", "&", "||", "&&")
         self.op = op
         self.lhs = lhs
         self.rhs = rhs
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Seq(%r, %r, %r)" % (self.lhs, self.op, self.rhs)
 
     def __eq__(self, other):

--- a/llvm/utils/lit/lit/ShUtil.py
+++ b/llvm/utils/lit/lit/ShUtil.py
@@ -2,24 +2,25 @@ import itertools
 
 import lit.util
 from lit.ShCommands import Command, GlobItem, Pipeline, Seq
+from typing import Iterator, Optional, Tuple, Union
 
 
 class ShLexer:
-    def __init__(self, data, win32Escapes=False):
+    def __init__(self, data: str, win32Escapes: bool = False) -> None:
         self.data = data
         self.pos = 0
         self.end = len(data)
         self.win32Escapes = win32Escapes
 
-    def eat(self):
+    def eat(self) -> str:
         c = self.data[self.pos]
         self.pos += 1
         return c
 
-    def look(self):
+    def look(self) -> str:
         return self.data[self.pos]
 
-    def maybe_eat(self, c):
+    def maybe_eat(self, c: str) -> bool:
         """
         maybe_eat(c) - Consume the character c if it is the next character,
         returning True if a character was consumed."""
@@ -28,7 +29,7 @@ class ShLexer:
             return True
         return False
 
-    def lex_arg_fast(self, c):
+    def lex_arg_fast(self, c: str) -> Optional[Union[GlobItem, str]]:
         # Get the leading whitespace free section.
         chunk = self.data[self.pos - 1 :].split(None, 1)[0]
 
@@ -48,7 +49,7 @@ class ShLexer:
         self.pos = self.pos - 1 + len(chunk)
         return GlobItem(chunk) if "*" in chunk or "?" in chunk else chunk
 
-    def lex_arg_slow(self, c):
+    def lex_arg_slow(self, c: str) -> str:
         if c in "'\"":
             parts = [self.lex_arg_quoted(c)]
         else:
@@ -110,7 +111,7 @@ class ShLexer:
         token = "".join(parts)
         return GlobItem(token) if unquoted_glob_char else token
 
-    def lex_arg_quoted(self, delim):
+    def lex_arg_quoted(self, delim: str) -> str:
         parts = []
         while self.pos != self.end:
             c = self.eat()
@@ -155,10 +156,10 @@ class ShLexer:
                 raise ValueError("Fast path failure: %r != %r" % (self.pos, end))
         return reference
 
-    def lex_arg(self, c):
+    def lex_arg(self, c: str) -> Union[GlobItem, str]:
         return self.lex_arg_fast(c) or self.lex_arg_slow(c)
 
-    def lex_one_token(self):
+    def lex_one_token(self) -> Union[GlobItem, Tuple[str], str]:
         """
         lex_one_token - Lex a single 'sh' token."""
 
@@ -190,7 +191,7 @@ class ShLexer:
 
         return self.lex_arg(c)
 
-    def lex(self):
+    def lex(self) -> Iterator[Union[str, GlobItem, Tuple[str]]]:
         while self.pos != self.end:
             if self.look().isspace():
                 self.eat()
@@ -202,23 +203,25 @@ class ShLexer:
 
 
 class ShParser:
-    def __init__(self, data, win32Escapes=False, pipefail=False):
+    def __init__(
+        self, data: str, win32Escapes: bool = False, pipefail: bool = False
+    ) -> None:
         self.data = data
         self.pipefail = pipefail
         self.tokens = ShLexer(data, win32Escapes=win32Escapes).lex()
 
-    def lex(self):
+    def lex(self) -> Optional[Union[GlobItem, str, Tuple[str]]]:
         for item in self.tokens:
             return item
         return None
 
-    def look(self):
+    def look(self) -> Optional[Union[GlobItem, Tuple[str], str]]:
         token = self.lex()
         if token is not None:
             self.tokens = itertools.chain([token], self.tokens)
         return token
 
-    def parse_command(self):
+    def parse_command(self) -> Command:
         tok = self.lex()
         if not tok:
             raise ValueError("empty command!")
@@ -253,7 +256,7 @@ class ShParser:
 
         return Command(args, redirects)
 
-    def parse_pipeline(self):
+    def parse_pipeline(self) -> Pipeline:
         negate = False
 
         commands = [self.parse_command()]
@@ -262,7 +265,7 @@ class ShParser:
             commands.append(self.parse_command())
         return Pipeline(commands, negate, self.pipefail)
 
-    def parse(self):
+    def parse(self) -> Union[Seq, Pipeline]:
         lhs = self.parse_pipeline()
 
         while self.look():

--- a/llvm/utils/lit/lit/ShellEnvironment.py
+++ b/llvm/utils/lit/lit/ShellEnvironment.py
@@ -4,7 +4,8 @@ import subprocess
 import tempfile
 
 import lit.util
-from lit.ShCommands import GlobItem
+from lit.ShCommands import Command, GlobItem
+from typing import Any, Dict, List, Optional, Union
 
 kIsWindows = platform.system() == "Windows"
 
@@ -32,8 +33,14 @@ class ShellCommandResult:
     )
 
     def __init__(
-        self, command, stdout, stderr, exitCode, timeoutReached, outputFiles=[]
-    ):
+        self,
+        command: Command,
+        stdout: str,
+        stderr: str,
+        exitCode: int,
+        timeoutReached: bool,
+        outputFiles: List[Any] = [],
+    ) -> None:
         self.command = command
         self.stdout = stdout
         self.stderr = stderr
@@ -49,7 +56,6 @@ class InternalShellError(Exception):
 
 
 class ShellEnvironment:
-
     """Mutable shell environment containing things like CWD and env vars.
 
     Environment variables are not implemented, but cwd tracking is. In addition,
@@ -61,7 +67,14 @@ class ShellEnvironment:
     # https://github.com/llvm/llvm-project/issues/200531
     __slots__ = ("cwd", "env", "umask", "dirStack", "ulimit", "normalize_slashes")
 
-    def __init__(self, cwd, env, umask=-1, ulimit=None, normalize_slashes=False):
+    def __init__(
+        self,
+        cwd: str,
+        env: Dict[str, str],
+        umask: int = -1,
+        ulimit: Optional[Dict[str, Any]] = None,
+        normalize_slashes: bool = False,
+    ) -> None:
         self.cwd = cwd
         self.env = dict(env)
         self.umask = umask
@@ -69,7 +82,7 @@ class ShellEnvironment:
         self.ulimit = ulimit if ulimit else {}
         self.normalize_slashes = normalize_slashes
 
-    def change_dir(self, newdir):
+    def change_dir(self, newdir: str) -> None:
         if os.path.isabs(newdir):
             self.cwd = newdir
         else:
@@ -80,7 +93,7 @@ class ShellEnvironment:
 # Skips the command, and parses its arguments.
 # Modifies env accordingly.
 # Returns copy of args without the command or its arguments.
-def updateEnv(env, args):
+def updateEnv(env: ShellEnvironment, args: List[str]) -> List[Union[Any, str]]:
     arg_idx_next = len(args)
     unset_next_env_var = False
     for arg_idx, arg in enumerate(args[1:]):
@@ -110,7 +123,12 @@ def updateEnv(env, args):
     return args[arg_idx_next:]
 
 
-def processRedirects(cmd, stdin_source, cmd_shenv, opened_files):
+def processRedirects(
+    cmd: Command,
+    stdin_source: int,
+    cmd_shenv: ShellEnvironment,
+    opened_files: List[Any],
+) -> List[int]:
     """Return the standard fds for cmd after applying redirects
 
     Returns the three standard file descriptors for the new child process.  Each
@@ -205,20 +223,20 @@ def processRedirects(cmd, stdin_source, cmd_shenv, opened_files):
     return std_fds
 
 
-def expand_glob(arg, cwd):
+def expand_glob(arg: str, cwd: str) -> List[str]:
     if isinstance(arg, GlobItem):
         return sorted(arg.resolve(cwd))
     return [arg]
 
 
-def expand_glob_expressions(args, cwd):
+def expand_glob_expressions(args: List[str], cwd: str) -> List[str]:
     result = [args[0]]
     for arg in args[1:]:
         result.extend(expand_glob(arg, cwd))
     return result
 
 
-def quote_windows_command(seq):
+def quote_windows_command(seq: List[str]) -> str:
     r"""
     Reimplement Python's private subprocess.list2cmdline for MSys compatibility
 

--- a/llvm/utils/lit/lit/Test.py
+++ b/llvm/utils/lit/lit/Test.py
@@ -166,9 +166,9 @@ class Result:
         self,
         code: ResultCode,
         output: str = "",
-        elapsed: None = None,
+        elapsed: Optional[float] = None,
         attempts: int = 1,
-        max_allowed_attempts: None = None,
+        max_allowed_attempts: Optional[int] = None,
         test_updater_outputs: List[Any] = [],
     ) -> None:
         # The result code.
@@ -177,8 +177,8 @@ class Result:
         self.output = output
         # The wall timing to execute the test, if timing.
         self.elapsed = elapsed
-        self.start = None
-        self.pid = None
+        self.start: Optional[float] = None
+        self.pid: Optional[int] = None
         # The metrics reported by this test.
         self.metrics = {}
         # The micro-test results reported by this test.
@@ -261,10 +261,10 @@ class Test:
     def __init__(
         self,
         suite: TestSuite,
-        path_in_suite: Union[Tuple[str], Tuple[str, str]],
+        path_in_suite: Tuple[str, ...],
         config: TestingConfig,
-        file_path: None = None,
-        gtest_json_file: None = None,
+        file_path: Optional[str] = None,
+        gtest_json_file: Optional[str] = None,
     ) -> None:
         self.suite = suite
         self.path_in_suite = path_in_suite

--- a/llvm/utils/lit/lit/Test.py
+++ b/llvm/utils/lit/lit/Test.py
@@ -1,10 +1,17 @@
+from __future__ import annotations
 import abc
+
 import itertools
 import os
 from json import JSONEncoder
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Type, Union
 
 from lit.BooleanExpression import BooleanExpression
 from lit.TestTimes import read_test_times
+
+if TYPE_CHECKING:
+    from lit.LitConfig import LitConfig
+    from lit.TestingConfig import TestingConfig
 
 # Test result codes.
 
@@ -16,14 +23,16 @@ class ResultCode:
     _all_codes = []
 
     @staticmethod
-    def all_codes():
+    def all_codes() -> List[ResultCode]:
         return ResultCode._all_codes
 
     # We override __new__ and __getnewargs__ to ensure that pickling still
     # provides unique ResultCode objects in any particular instance.
     _instances = {}
 
-    def __new__(cls, name, label, isFailure):
+    def __new__(
+        cls: Type[ResultCode], name: str, label: str, isFailure: bool
+    ) -> "ResultCode":
         res = cls._instances.get(name)
         if res is None:
             cls._instances[name] = res = super().__new__(cls)
@@ -32,7 +41,7 @@ class ResultCode:
     def __getnewargs__(self):
         return (self.name, self.label, self.isFailure)
 
-    def __init__(self, name, label, isFailure):
+    def __init__(self, name: str, label: str, isFailure: bool) -> None:
         self.name = name
         self.label = label
         self.isFailure = isFailure
@@ -155,13 +164,13 @@ class Result:
 
     def __init__(
         self,
-        code,
-        output="",
-        elapsed=None,
-        attempts=1,
-        max_allowed_attempts=None,
-        test_updater_outputs=[],
-    ):
+        code: ResultCode,
+        output: str = "",
+        elapsed: None = None,
+        attempts: int = 1,
+        max_allowed_attempts: None = None,
+        test_updater_outputs: List[Any] = [],
+    ) -> None:
         # The result code.
         self.code = code
         # The test output.
@@ -223,7 +232,14 @@ class TestSuite:
     A test suite groups together a set of logically related tests.
     """
 
-    def __init__(self, name, source_root, exec_root, config, lit_config=None):
+    def __init__(
+        self,
+        name: str,
+        source_root: str,
+        exec_root: str,
+        config: TestingConfig,
+        lit_config: Optional[LitConfig] = None,
+    ) -> None:
         self.name = name
         self.source_root = source_root
         self.exec_root = exec_root
@@ -232,10 +248,10 @@ class TestSuite:
 
         self.test_times = read_test_times(self, lit_config)
 
-    def getSourcePath(self, components):
+    def getSourcePath(self, components: Union[Tuple[str], Tuple[()]]) -> str:
         return os.path.join(self.source_root, *components)
 
-    def getExecPath(self, components):
+    def getExecPath(self, components: Tuple[str]) -> str:
         return os.path.join(self.exec_root, *components)
 
 
@@ -243,8 +259,13 @@ class Test:
     """Test - Information on a single test instance."""
 
     def __init__(
-        self, suite, path_in_suite, config, file_path=None, gtest_json_file=None
-    ):
+        self,
+        suite: TestSuite,
+        path_in_suite: Union[Tuple[str], Tuple[str, str]],
+        config: TestingConfig,
+        file_path: None = None,
+        gtest_json_file: None = None,
+    ) -> None:
         self.suite = suite
         self.path_in_suite = path_in_suite
         self.config = config
@@ -313,14 +334,14 @@ class Test:
                     result.code = XFAIL
         self.result = result
 
-    def isFailure(self):
+    def isFailure(self) -> bool:
         assert self.result
         return self.result.code.isFailure
 
-    def getFullName(self):
+    def getFullName(self) -> str:
         return self.suite.config.name + " :: " + "/".join(self.path_in_suite)
 
-    def getSummaryName(self, printPathRelativeCWD):
+    def getSummaryName(self, printPathRelativeCWD: bool) -> str:
         if printPathRelativeCWD:
             return os.path.relpath(self.getFilePath())
         return self.getFullName()

--- a/llvm/utils/lit/lit/TestTimes.py
+++ b/llvm/utils/lit/lit/TestTimes.py
@@ -1,14 +1,23 @@
+from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from lit.LitConfig import LitConfig
+    from lit.Test import Test, TestSuite
 
 
-def _get_test_times_path(suite):
+def _get_test_times_path(suite: TestSuite) -> str:
     test_times_file = os.path.join(suite.exec_root, ".lit_test_times.txt")
     if not os.path.exists(test_times_file):
         test_times_file = os.path.join(suite.source_root, ".lit_test_times.txt")
     return test_times_file
 
 
-def read_test_times(suite, lit_config=None):
+def read_test_times(
+    suite: TestSuite, lit_config: Optional[LitConfig] = None
+) -> Dict[Any, Any]:
     test_times = {}
     test_times_file = _get_test_times_path(suite)
     if os.path.exists(test_times_file):
@@ -33,7 +42,7 @@ def read_test_times(suite, lit_config=None):
     return test_times
 
 
-def record_test_times(tests, lit_config):
+def record_test_times(tests: List[Test], lit_config: LitConfig) -> None:
     times_by_suite = {}
     for t in tests:
         assert t.suite.test_times is None

--- a/llvm/utils/lit/lit/TestingConfig.py
+++ b/llvm/utils/lit/lit/TestingConfig.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import os
 import sys
-from typing import TYPE_CHECKING, Any, Dict, List, Set
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Union
 
 if TYPE_CHECKING:
     from lit.LitConfig import LitConfig
+    from lit.formats.base import TestFormat
 
 
 class TestingConfig:
@@ -175,23 +176,23 @@ class TestingConfig:
 
     def __init__(
         self,
-        parent: None,
+        parent: Optional["TestingConfig"],
         name: str,
         suffixes: Set[Any],
-        test_format: None,
+        test_format: Optional["TestFormat"],
         environment: Dict[str, str],
         substitutions: List[Any],
         unsupported: bool,
-        test_exec_root: None,
-        test_source_root: None,
+        test_exec_root: Optional[str],
+        test_source_root: Optional[str],
         excludes: List[Any],
         available_features: List[Any],
         pipefail: bool,
         limit_to_features: List[Any] = [],
         is_early: bool = False,
-        parallelism_group: None = None,
+        parallelism_group: Optional[Union[str, Callable]] = None,
         standalone_tests: bool = False,
-        maxIndividualTestTime: None = 0,
+        maxIndividualTestTime: Optional[int] = 0,
     ) -> None:
         self.parent = parent
         self.name = str(name)

--- a/llvm/utils/lit/lit/TestingConfig.py
+++ b/llvm/utils/lit/lit/TestingConfig.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
 import os
 import sys
+from typing import TYPE_CHECKING, Any, Dict, List, Set
+
+if TYPE_CHECKING:
+    from lit.LitConfig import LitConfig
 
 
 class TestingConfig:
@@ -8,7 +14,7 @@ class TestingConfig:
     """
 
     @staticmethod
-    def fromdefaults(litConfig):
+    def fromdefaults(litConfig: LitConfig) -> "TestingConfig":
         """
         fromdefaults(litConfig) -> TestingConfig
 
@@ -128,7 +134,7 @@ class TestingConfig:
             maxIndividualTestTime=litConfig.maxIndividualTestTime,
         )
 
-    def load_from_path(self, path, litConfig):
+    def load_from_path(self, path: str, litConfig: LitConfig) -> None:
         """
         load_from_path(path, litConfig)
 
@@ -169,24 +175,24 @@ class TestingConfig:
 
     def __init__(
         self,
-        parent,
-        name,
-        suffixes,
-        test_format,
-        environment,
-        substitutions,
-        unsupported,
-        test_exec_root,
-        test_source_root,
-        excludes,
-        available_features,
-        pipefail,
-        limit_to_features=[],
-        is_early=False,
-        parallelism_group=None,
-        standalone_tests=False,
-        maxIndividualTestTime=0,
-    ):
+        parent: None,
+        name: str,
+        suffixes: Set[Any],
+        test_format: None,
+        environment: Dict[str, str],
+        substitutions: List[Any],
+        unsupported: bool,
+        test_exec_root: None,
+        test_source_root: None,
+        excludes: List[Any],
+        available_features: List[Any],
+        pipefail: bool,
+        limit_to_features: List[Any] = [],
+        is_early: bool = False,
+        parallelism_group: None = None,
+        standalone_tests: bool = False,
+        maxIndividualTestTime: None = 0,
+    ) -> None:
         self.parent = parent
         self.name = str(name)
         self.suffixes = set(suffixes)
@@ -228,7 +234,7 @@ class TestingConfig:
             )
         self._recursiveExpansionLimit = value
 
-    def finish(self, litConfig):
+    def finish(self, litConfig: LitConfig) -> None:
         """finish() - Finish this config object, after loading is complete."""
 
         self.name = str(self.name)

--- a/llvm/utils/lit/lit/builtin_commands/_launch_with_limit.py
+++ b/llvm/utils/lit/lit/builtin_commands/_launch_with_limit.py
@@ -2,11 +2,12 @@ import sys
 import subprocess
 import resource
 import os
+from typing import List
 
 ULIMIT_ENV_VAR_PREFIX = "LIT_INTERNAL_ULIMIT_"
 
 
-def main(argv):
+def main(argv: List[str]):
     command_args = argv[1:]
     for env_var in os.environ:
         if env_var.startswith(ULIMIT_ENV_VAR_PREFIX):

--- a/llvm/utils/lit/lit/builtin_commands/cat.py
+++ b/llvm/utils/lit/lit/builtin_commands/cat.py
@@ -1,9 +1,10 @@
 import getopt
 import sys
 from io import StringIO
+from typing import List, Union
 
 
-def convertToCaretAndMNotation(data):
+def convertToCaretAndMNotation(data: Union[str, bytes]) -> bytes:
     newdata = StringIO()
     if isinstance(data, str):
         data = bytearray(data.encode())
@@ -26,7 +27,7 @@ def convertToCaretAndMNotation(data):
     return newdata.getvalue().encode()
 
 
-def main(argv):
+def main(argv: List[str]) -> None:
     arguments = argv[1:]
     short_options = "v"
     long_options = ["show-nonprinting"]

--- a/llvm/utils/lit/lit/builtin_commands/diff.py
+++ b/llvm/utils/lit/lit/builtin_commands/diff.py
@@ -8,6 +8,11 @@ import re
 import sys
 
 import util
+from typing import List, Optional, Tuple
+
+# A directory tree node: (dirname, child_trees).
+# child_trees is None for a file, [] for an empty dir, or a list of nodes.
+DirTree = Tuple[str, Optional[List["DirTree"]]]
 
 
 class DiffFlags:
@@ -25,7 +30,7 @@ class DiffFlags:
         "strip_trailing_cr",
     )
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.ignore_all_space = False
         self.ignore_space_change = False
         self.ignore_matching_lines = False
@@ -36,7 +41,7 @@ class DiffFlags:
         self.strip_trailing_cr = False
 
 
-def getDirTree(path, basedir=""):
+def getDirTree(path: str, basedir: str = "") -> DirTree:
     # Tree is a tuple of form (dirname, child_trees).
     # An empty dir has child_trees = [], a file has child_trees = None.
     child_trees = []
@@ -48,7 +53,7 @@ def getDirTree(path, basedir=""):
         return path, sorted(child_trees)
 
 
-def compareTwoFiles(flags, filepaths):
+def compareTwoFiles(flags: DiffFlags, filepaths: List[str]) -> int:
     filelines = []
     for file in filepaths:
         if file == "-":
@@ -70,7 +75,9 @@ def compareTwoFiles(flags, filepaths):
             return compareTwoBinaryFiles(flags, filepaths, filelines)
 
 
-def compareTwoBinaryFiles(flags, filepaths, filelines):
+def compareTwoBinaryFiles(
+    flags: DiffFlags, filepaths: List[str], filelines: List[List[bytes]]
+) -> int:
     exitCode = 0
     diffs = difflib.diff_bytes(
         difflib.unified_diff,
@@ -87,7 +94,12 @@ def compareTwoBinaryFiles(flags, filepaths, filelines):
     return exitCode
 
 
-def compareTwoTextFiles(flags, filepaths, filelines_bin, encoding):
+def compareTwoTextFiles(
+    flags: DiffFlags,
+    filepaths: List[str],
+    filelines_bin: List[List[bytes]],
+    encoding: str,
+) -> int:
     filelines = []
     for lines_bin in filelines_bin:
         lines = []
@@ -134,7 +146,7 @@ def compareTwoTextFiles(flags, filepaths, filelines_bin, encoding):
     return exitCode
 
 
-def printDirVsFile(dir_path, file_path):
+def printDirVsFile(dir_path: str, file_path: str) -> None:
     if os.path.getsize(file_path):
         msg = "File %s is a directory while file %s is a regular file"
     else:
@@ -142,7 +154,7 @@ def printDirVsFile(dir_path, file_path):
     sys.stdout.write(msg % (dir_path, file_path) + "\n")
 
 
-def printFileVsDir(file_path, dir_path):
+def printFileVsDir(file_path: str, dir_path: str) -> None:
     if os.path.getsize(file_path):
         msg = "File %s is a regular file while file %s is a directory"
     else:
@@ -150,11 +162,15 @@ def printFileVsDir(file_path, dir_path):
     sys.stdout.write(msg % (file_path, dir_path) + "\n")
 
 
-def printOnlyIn(basedir, path, name):
+def printOnlyIn(basedir: str, path: str, name: str) -> None:
     sys.stdout.write("Only in %s: %s\n" % (os.path.join(basedir, path), name))
 
 
-def compareDirTrees(flags, dir_trees, base_paths=["", ""]):
+def compareDirTrees(
+    flags: DiffFlags,
+    dir_trees: List[DirTree],
+    base_paths: List[str] = ["", ""],
+) -> int:
     # Dirnames of the trees are not checked, it's caller's responsibility,
     # as top-level dirnames are always different. Base paths are important
     # for doing os.walk, but we don't put it into tree's dirname in order
@@ -225,7 +241,7 @@ def compareDirTrees(flags, dir_trees, base_paths=["", ""]):
     return exitCode
 
 
-def main(argv):
+def main(argv: List[str]):
     if sys.platform == "win32":
         sys.stdout = io.TextIOWrapper(sys.stdout.buffer, newline="\n")
 

--- a/llvm/utils/lit/lit/cl_arguments.py
+++ b/llvm/utils/lit/lit/cl_arguments.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
+
 import argparse
 import enum
 import os
+import re
 import shlex
 import sys
 
 import lit.reports
 import lit.util
+from typing import Any, Callable, List, Optional, Union
 
 
 @enum.unique
@@ -23,7 +27,7 @@ class TestOutputLevel(enum.IntEnum):
     ALL = 3
 
     @classmethod
-    def create(cls, value):
+    def create(cls, value: str) -> "TestOutputLevel":
         if value == "off":
             return cls.OFF
         if value == "failed":
@@ -36,14 +40,16 @@ class TestOutputLevel(enum.IntEnum):
 
 
 class TestOutputAction(argparse.Action):
-    def __init__(self, option_strings, dest, **kwargs):
+    def __init__(self, option_strings: List[str], dest: str, **kwargs) -> None:
         super().__init__(option_strings, dest, nargs=None, **kwargs)
 
     def __call__(self, parser, namespace, value, option_string=None):
         TestOutputAction.setOutputLevel(namespace, self.dest, value)
 
     @classmethod
-    def setOutputLevel(cls, namespace, dest, value):
+    def setOutputLevel(
+        cls, namespace: argparse.Namespace, dest: str, value: str
+    ) -> None:
         setattr(namespace, dest, value)
         if dest == "test_output" and TestOutputLevel.create(
             namespace.print_result_after
@@ -56,13 +62,25 @@ class TestOutputAction(argparse.Action):
 
 
 class AliasAction(argparse.Action):
-    def __init__(self, option_strings, dest, nargs=None, **kwargs):
+    def __init__(
+        self,
+        option_strings: List[str],
+        dest: str,
+        nargs: Optional[Union[int, str]] = None,
+        **kwargs,
+    ) -> None:
         self.expansion = kwargs.pop("alias", None)
         if not self.expansion:
             raise ValueError("no aliases expansion provided")
         super().__init__(option_strings, dest, nargs=0, **kwargs)
 
-    def __call__(self, parser, namespace, value, option_string=None):
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        value: Any,
+        option_string: Optional[str] = None,
+    ) -> None:
         for e in self.expansion:
             if callable(e):
                 e(namespace)
@@ -71,7 +89,7 @@ class AliasAction(argparse.Action):
                 setattr(namespace, dest, val)
 
 
-def parse_args():
+def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog="lit", fromfile_prefix_chars="@")
     parser.add_argument(
         "test_paths",
@@ -551,7 +569,7 @@ def parse_args():
     return opts
 
 
-def _positive_int(arg):
+def _positive_int(arg: str) -> int:
     return _int(arg, "positive", lambda i: i > 0)
 
 
@@ -559,7 +577,7 @@ def _non_negative_int(arg):
     return _int(arg, "non-negative", lambda i: i >= 0)
 
 
-def _int(arg, kind, pred):
+def _int(arg: str, kind: str, pred: Callable) -> int:
     desc = "requires {} integer, but found '{}'"
     try:
         i = int(arg)
@@ -588,16 +606,14 @@ def _float(arg, kind, pred):
     return f
 
 
-def _case_insensitive_regex(arg):
-    import re
-
+def _case_insensitive_regex(arg: str) -> re.Pattern:
     try:
         return re.compile(arg, re.IGNORECASE)
     except re.error as reason:
         raise _error("invalid regular expression: '{}', {}", arg, reason)
 
 
-def _semicolon_list(arg):
+def _semicolon_list(arg: str) -> List[str]:
     return arg.split(";")
 
 

--- a/llvm/utils/lit/lit/discovery.py
+++ b/llvm/utils/lit/lit/discovery.py
@@ -8,9 +8,12 @@ import sys
 
 from lit.TestingConfig import TestingConfig
 from lit import LitConfig, Test, util
+import lit.LitConfig
+import lit.Test
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 
-def chooseConfigFileFromDir(dir, config_names):
+def chooseConfigFileFromDir(dir: str, config_names: List[str]) -> Optional[str]:
     for name in config_names:
         p = os.path.join(dir, name)
         if os.path.exists(p):
@@ -18,14 +21,20 @@ def chooseConfigFileFromDir(dir, config_names):
     return None
 
 
-def dirContainsTestSuite(path, lit_config):
+def dirContainsTestSuite(
+    path: str, lit_config: lit.LitConfig.LitConfig
+) -> Optional[str]:
     cfgpath = chooseConfigFileFromDir(path, lit_config.site_config_names)
     if not cfgpath:
         cfgpath = chooseConfigFileFromDir(path, lit_config.config_names)
     return cfgpath
 
 
-def getTestSuite(item, litConfig, cache):
+def getTestSuite(
+    item: str,
+    litConfig: lit.LitConfig.LitConfig,
+    cache: Dict[str, Tuple[lit.Test.TestSuite, Tuple[()]]],
+) -> Tuple[lit.Test.TestSuite, Tuple[()]]:
     """getTestSuite(item, litConfig, cache) -> (suite, relative_path)
 
     Find the test suite containing @arg item.
@@ -95,7 +104,21 @@ def getTestSuite(item, litConfig, cache):
     return ts, tuple(relative + tuple(components))
 
 
-def getLocalConfig(ts, path_in_suite, litConfig, cache):
+def getLocalConfig(
+    ts: lit.Test.TestSuite,
+    path_in_suite: Union[Tuple[()], Tuple[str]],
+    litConfig: lit.LitConfig.LitConfig,
+    cache: Union[
+        Dict[Tuple[lit.Test.TestSuite, Tuple[()]], TestingConfig],
+        Dict[
+            Union[
+                Tuple[lit.Test.TestSuite, Tuple[()]],
+                Tuple[lit.Test.TestSuite, Tuple[str]],
+            ],
+            TestingConfig,
+        ],
+    ],
+) -> TestingConfig:
     def search1(path_in_suite):
         # Get the parent config.
         if not path_in_suite:
@@ -128,7 +151,12 @@ def getLocalConfig(ts, path_in_suite, litConfig, cache):
     return search(path_in_suite)
 
 
-def getTests(path, litConfig, testSuiteCache, localConfigCache):
+def getTests(
+    path: str,
+    litConfig: lit.LitConfig.LitConfig,
+    testSuiteCache: Dict[Any, Any],
+    localConfigCache: Dict[Any, Any],
+) -> Tuple[lit.Test.TestSuite, Iterator[Any]]:
     # Find the test suite for this input and its relative path.
     ts, path_in_suite = getTestSuite(path, litConfig, testSuiteCache)
     if ts is None:
@@ -147,8 +175,21 @@ def getTests(path, litConfig, testSuiteCache, localConfigCache):
 
 
 def getTestsInSuite(
-    ts, path_in_suite, litConfig, testSuiteCache, localConfigCache
-):
+    ts: lit.Test.TestSuite,
+    path_in_suite: Union[Tuple[()], Tuple[str]],
+    litConfig: lit.LitConfig.LitConfig,
+    testSuiteCache: Dict[str, Tuple[lit.Test.TestSuite, Tuple[()]]],
+    localConfigCache: Union[
+        Dict[Tuple[lit.Test.TestSuite, Tuple[()]], TestingConfig],
+        Dict[
+            Union[
+                Tuple[lit.Test.TestSuite, Tuple[()]],
+                Tuple[lit.Test.TestSuite, Tuple[str]],
+            ],
+            TestingConfig,
+        ],
+    ],
+) -> Iterator[lit.Test.Test]:
     # Check that the source path exists (errors here are reported by the
     # caller).
     source_path = ts.getSourcePath(path_in_suite)
@@ -164,8 +205,11 @@ def getTestsInSuite(
         # always "find" the test itself. Otherwise, we might find no tests at
         # all, which is considered an error but isn't an error with standalone
         # tests.
-        tests = [Test.Test(ts, path_in_suite, lc)] if lc.test_format is None or lc.standalone_tests else \
-                lc.test_format.getTestsForPath(ts, path_in_suite, litConfig, lc)
+        tests = (
+            [Test.Test(ts, path_in_suite, lc)]
+            if lc.test_format is None or lc.standalone_tests
+            else lc.test_format.getTestsForPath(ts, path_in_suite, litConfig, lc)
+        )
 
         for test in tests:
             yield test
@@ -247,7 +291,9 @@ def getTestsInSuite(
             litConfig.warning("test suite %r contained no tests" % sub_ts.name)
 
 
-def find_tests_for_inputs(lit_config, inputs):
+def find_tests_for_inputs(
+    lit_config: lit.LitConfig.LitConfig, inputs: List[str]
+) -> List[lit.Test.Test]:
     """
     find_tests_for_inputs(lit_config, inputs) -> [Test]
 

--- a/llvm/utils/lit/lit/display.py
+++ b/llvm/utils/lit/lit/display.py
@@ -3,9 +3,15 @@ import sys
 
 from argparse import Namespace
 from lit.Test import Test
+from typing import TYPE_CHECKING, List, Optional
+
+if TYPE_CHECKING:
+    from lit.ProgressBar import SimpleProgressBar
 
 
-def create_display(opts, tests, total_tests, workers):
+def create_display(
+    opts: Namespace, tests: List[Test], total_tests: int, workers: int
+) -> "Display":
     if opts.print_result_after == "off" and not opts.useProgressBar:
         return NopDisplay()
 
@@ -30,7 +36,7 @@ def create_display(opts, tests, total_tests, workers):
 
 
 class ProgressPredictor:
-    def __init__(self, tests):
+    def __init__(self, tests: List[Test]) -> None:
         self.completed = 0
         self.time_elapsed = 0.0
         self.predictable_tests_remaining = 0
@@ -96,10 +102,10 @@ class Display:
     def __init__(
         self,
         opts: Namespace,
-        tests: list[Test],
-        header: str | None,
-        progress_bar,
-    ):
+        tests: List[Test],
+        header: Optional[str],
+        progress_bar: Optional[SimpleProgressBar],
+    ) -> None:
         self.opts = opts
         self.num_tests = len(tests)
         self.header = header
@@ -107,7 +113,7 @@ class Display:
         self.progress_bar = progress_bar
         self.completed = 0
 
-    def print_header(self):
+    def print_header(self) -> None:
         if self.header:
             print(self.header)
         if self.progress_bar:
@@ -128,7 +134,7 @@ class Display:
             percent = self.progress_predictor.update(test)
             self.progress_bar.update(percent, test.getFullName())
 
-    def clear(self, interrupted):
+    def clear(self, interrupted: bool) -> None:
         if self.progress_bar:
             self.progress_bar.clear(interrupted)
 

--- a/llvm/utils/lit/lit/formats/base.py
+++ b/llvm/utils/lit/lit/formats/base.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING, Iterator, Tuple, Union
 
 import lit.Test
 import lit.util
+
+if TYPE_CHECKING:
+    from lit.LitConfig import LitConfig
+    from lit.TestingConfig import TestingConfig
 
 
 class TestFormat:
@@ -17,11 +24,18 @@ class TestFormat:
         """
         yield lit.Test.Test(testSuite, path_in_suite, localConfig)
 
+
 ###
 
 
 class FileBasedTest(TestFormat):
-    def getTestsForPath(self, testSuite, path_in_suite, litConfig, localConfig):
+    def getTestsForPath(
+        self,
+        testSuite: lit.Test.TestSuite,
+        path_in_suite: Union[Tuple[str], Tuple[str, str]],
+        litConfig: LitConfig,
+        localConfig: TestingConfig,
+    ) -> Iterator[lit.Test.Test]:
         """
         Expand each path in a test suite to a Lit test using that path and assuming
         it is a file containing the test. File extensions excluded by the configuration
@@ -36,16 +50,25 @@ class FileBasedTest(TestFormat):
         if any(filename.endswith(suffix) for suffix in localConfig.suffixes):
             yield lit.Test.Test(testSuite, path_in_suite, localConfig)
 
-    def getTestsInDirectory(self, testSuite, path_in_suite, litConfig, localConfig):
+    def getTestsInDirectory(
+        self,
+        testSuite: lit.Test.TestSuite,
+        path_in_suite: Union[Tuple[()], Tuple[str]],
+        litConfig: LitConfig,
+        localConfig: TestingConfig,
+    ) -> Iterator[lit.Test.Test]:
         source_path = testSuite.getSourcePath(path_in_suite)
         for filename in os.listdir(source_path):
             filepath = os.path.join(source_path, filename)
             if not os.path.isdir(filepath):
-                for t in self.getTestsForPath(testSuite, path_in_suite + (filename,), litConfig, localConfig):
+                for t in self.getTestsForPath(
+                    testSuite, path_in_suite + (filename,), litConfig, localConfig
+                ):
                     yield t
 
 
 ###
+
 
 # Check exit code of a simple executable with no input
 class ExecutableTest(FileBasedTest):

--- a/llvm/utils/lit/lit/formats/googletest.py
+++ b/llvm/utils/lit/lit/formats/googletest.py
@@ -9,6 +9,7 @@ import lit.Test
 import lit.TestRunner
 import lit.util
 from .base import TestFormat
+from typing import List, Tuple
 
 kIsWindows = sys.platform in ["win32", "cygwin"]
 
@@ -282,7 +283,9 @@ class GoogleTest(TestFormat):
         return cmd
 
     @staticmethod
-    def post_process_shard_results(selected_tests, discovered_tests):
+    def post_process_shard_results(
+        selected_tests: List[lit.Test.Test], discovered_tests: List[lit.Test.Test]
+    ) -> Tuple[List[lit.Test.Test], List[lit.Test.Test]]:
         def remove_gtest(tests):
             return [t for t in tests if t.gtest_json_file is None]
 

--- a/llvm/utils/lit/lit/formats/shtest.py
+++ b/llvm/utils/lit/lit/formats/shtest.py
@@ -2,6 +2,7 @@ import lit.TestRunner
 import lit.util
 
 from .base import FileBasedTest
+from typing import Any, List
 
 
 class ShTest(FileBasedTest):
@@ -17,8 +18,11 @@ class ShTest(FileBasedTest):
     """
 
     def __init__(
-        self, execute_external=False, extra_substitutions=[], preamble_commands=[]
-    ):
+        self,
+        execute_external: bool = False,
+        extra_substitutions: List[Any] = [],
+        preamble_commands: List[Any] = [],
+    ) -> None:
         self.execute_external = execute_external
         self.extra_substitutions = extra_substitutions
         self.preamble_commands = preamble_commands

--- a/llvm/utils/lit/lit/main.py
+++ b/llvm/utils/lit/lit/main.py
@@ -20,9 +20,11 @@ import lit.Test
 import lit.util
 from lit.formats.googletest import GoogleTest
 from lit.TestTimes import record_test_times
+from argparse import Namespace
+from typing import Any, Dict, List, Union
 
 
-def main(builtin_params={}):
+def main(builtin_params: Dict[Any, Any] = {}) -> None:
     opts = lit.cl_arguments.parse_args()
     params = create_params(builtin_params, opts.user_params)
     is_windows = platform.system() == "Windows"
@@ -47,9 +49,7 @@ def main(builtin_params={}):
         maxIndividualTestTime=opts.maxIndividualTestTime,
     )
 
-    discovered_tests = lit.discovery.find_tests_for_inputs(
-        lit_config, opts.test_paths
-    )
+    discovered_tests = lit.discovery.find_tests_for_inputs(lit_config, opts.test_paths)
     if not discovered_tests:
         sys.stderr.write("error: did not discover any tests for provided path(s)\n")
         sys.exit(2)
@@ -68,7 +68,6 @@ def main(builtin_params={}):
         )
         print(" ".join(sorted(features)))
         sys.exit(0)
-
 
     determine_order(discovered_tests, opts.order)
 
@@ -157,7 +156,9 @@ def main(builtin_params={}):
             sys.exit(1)
 
 
-def create_params(builtin_params, user_params):
+def create_params(
+    builtin_params: Dict[Any, Any], user_params: List[Any]
+) -> Dict[Any, Any]:
     def parse(p):
         return p.split("=", 1) if "=" in p else (p, "")
 
@@ -190,7 +191,9 @@ def print_discovered(tests, show_suites, show_tests):
             print("  %s" % t.getFullName())
 
 
-def determine_order(tests, order):
+def determine_order(
+    tests: List[lit.Test.Test], order: lit.cl_arguments.TestOrder
+) -> None:
     from lit.cl_arguments import TestOrder
 
     enum_order = TestOrder(order)
@@ -226,7 +229,7 @@ def filter_by_shard(tests, run, shards, lit_config):
     return selected_tests
 
 
-def mark_xfail(selected_tests, opts):
+def mark_xfail(selected_tests: List[lit.Test.Test], opts: Namespace) -> None:
     for t in selected_tests:
         test_file = os.sep.join(t.path_in_suite)
         test_full_name = t.getFullName()
@@ -238,7 +241,7 @@ def mark_xfail(selected_tests, opts):
             t.exclude_xfail = True
 
 
-def mark_unsupported(selected_tests, opts):
+def mark_unsupported(selected_tests: List[lit.Test.Test], opts: Namespace) -> None:
     for t in selected_tests:
         test_file = os.sep.join(t.path_in_suite)
         test_full_name = t.getFullName()
@@ -250,14 +253,21 @@ def mark_unsupported(selected_tests, opts):
             t.unsupported_not = True
 
 
-def mark_excluded(discovered_tests, selected_tests):
+def mark_excluded(
+    discovered_tests: List[lit.Test.Test], selected_tests: List[lit.Test.Test]
+) -> None:
     excluded_tests = set(discovered_tests) - set(selected_tests)
     result = lit.Test.Result(lit.Test.EXCLUDED)
     for t in excluded_tests:
         t.setResult(result)
 
 
-def run_tests(tests, lit_config, opts, discovered_tests):
+def run_tests(
+    tests: List[lit.Test.Test],
+    lit_config: lit.LitConfig.LitConfig,
+    opts: Namespace,
+    discovered_tests: int,
+) -> None:
     workers = min(len(tests), opts.workers)
     display = lit.display.create_display(opts, tests, discovered_tests, workers)
 
@@ -284,7 +294,7 @@ def run_tests(tests, lit_config, opts, discovered_tests):
         sys.stderr.write("%s, skipping remaining tests\n" % error)
 
 
-def execute_in_tmp_dir(run, lit_config):
+def execute_in_tmp_dir(run: lit.run.Run, lit_config: lit.LitConfig.LitConfig) -> None:
     # Create a temp directory inside the normal temp directory so that we can
     # try to avoid temporary test file leaks. The user can avoid this behavior
     # by setting LIT_PRESERVES_TMP in the environment, so they can easily use
@@ -323,7 +333,7 @@ def print_histogram(tests):
         lit.util.printHistogram(test_times, title="Tests")
 
 
-def print_results(tests, elapsed, opts):
+def print_results(tests: List[lit.Test.Test], elapsed: float, opts: Namespace) -> None:
     tests_by_code = {code: [] for code in lit.Test.ResultCode.all_codes()}
     total_tests = len(tests)
     for test in tests:
@@ -340,7 +350,12 @@ def print_results(tests, elapsed, opts):
     print_summary(total_tests, tests_by_code, opts.terse_summary, elapsed)
 
 
-def print_group(tests, code, shown_codes, printPathRelativeCWD):
+def print_group(
+    tests: List[Union[Any, lit.Test.Test]],
+    code: lit.Test.ResultCode,
+    shown_codes: List[Any],
+    printPathRelativeCWD: bool,
+) -> None:
     if not tests:
         return
     if not code.isFailure and code not in shown_codes:
@@ -352,7 +367,12 @@ def print_group(tests, code, shown_codes, printPathRelativeCWD):
     sys.stdout.write("\n")
 
 
-def print_summary(total_tests, tests_by_code, quiet, elapsed):
+def print_summary(
+    total_tests: int,
+    tests_by_code: Dict[lit.Test.ResultCode, List[Union[Any, lit.Test.Test]]],
+    quiet: bool,
+    elapsed: float,
+) -> None:
     if not quiet:
         print("\nTesting Time: %.2fs" % elapsed)
 
@@ -366,7 +386,7 @@ def print_summary(total_tests, tests_by_code, quiet, elapsed):
     max_label_len = max(len(label) for label, _ in groups)
     max_count_len = max(len(str(count)) for _, count in groups)
 
-    for (label, count) in groups:
+    for label, count in groups:
         label = label.ljust(max_label_len)
         count = str(count).rjust(max_count_len)
         print("  %s: %s (%.2f%%)" % (label, count, float(count) / total_tests * 100))

--- a/llvm/utils/lit/lit/reports.py
+++ b/llvm/utils/lit/lit/reports.py
@@ -9,6 +9,8 @@ import tempfile
 from xml.sax.saxutils import quoteattr as quo
 
 import lit.Test
+from io import TextIOWrapper
+from typing import List
 
 
 def by_suite_and_test_path(test):
@@ -18,12 +20,12 @@ def by_suite_and_test_path(test):
 
 
 class Report:
-    def __init__(self, output_file):
+    def __init__(self, output_file: str) -> None:
         self.output_file = output_file
         # Set by the option parser later.
         self.use_unique_output_file_name = False
 
-    def write_results(self, tests, elapsed):
+    def write_results(self, tests: List[lit.Test.Test], elapsed: float) -> None:
         if self.use_unique_output_file_name:
             filename, ext = os.path.splitext(os.path.basename(self.output_file))
             fd, _ = tempfile.mkstemp(
@@ -44,7 +46,9 @@ class Report:
 
 
 class JsonReport(Report):
-    def _write_results_to_file(self, tests, elapsed, file):
+    def _write_results_to_file(
+        self, tests: List[lit.Test.Test], elapsed: float, file: TextIOWrapper
+    ) -> None:
         unexecuted_codes = {lit.Test.EXCLUDED, lit.Test.SKIPPED}
         tests = [t for t in tests if t.result.code not in unexecuted_codes]
         # Construct the data we will write.
@@ -257,12 +261,16 @@ class ResultDBReport(Report):
                     tests_data.append(
                         gen_resultdb_test_entry(
                             test_name=micro_full_name,
-                            start_time=micro_test.start
-                            if micro_test.start
-                            else test.result.start,
-                            elapsed_time=micro_test.elapsed
-                            if micro_test.elapsed
-                            else test.result.elapsed,
+                            start_time=(
+                                micro_test.start
+                                if micro_test.start
+                                else test.result.start
+                            ),
+                            elapsed_time=(
+                                micro_test.elapsed
+                                if micro_test.elapsed
+                                else test.result.elapsed
+                            ),
                             test_output=micro_test.output,
                             result_code=micro_test.code,
                             is_expected=not micro_test.code.isFailure,

--- a/llvm/utils/lit/lit/run.py
+++ b/llvm/utils/lit/lit/run.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import multiprocessing
 import os
 import platform
@@ -6,6 +8,11 @@ import time
 import lit.Test
 import lit.util
 import lit.worker
+from typing import TYPE_CHECKING, Callable, List, Optional
+
+if TYPE_CHECKING:
+    from lit.LitConfig import LitConfig
+    from multiprocessing.pool import ApplyResult
 
 # Windows has a limit of 60 workers per pool.
 # This is defined in the multiprocessing module implementation.
@@ -13,8 +20,9 @@ import lit.worker
 WINDOWS_MAX_WORKERS_PER_POOL = 60
 
 
-def _ceilDiv(a, b):
+def _ceilDiv(a: int, b: int) -> int:
     return (a + b - 1) // b
+
 
 class MaxFailuresError(Exception):
     pass
@@ -28,8 +36,14 @@ class Run:
     """A concrete, configured testing run."""
 
     def __init__(
-        self, tests, lit_config, workers, progress_callback, max_failures, timeout
-    ):
+        self,
+        tests: List[lit.Test.Test],
+        lit_config: LitConfig,
+        workers: int,
+        progress_callback: Callable,
+        max_failures: Optional[int],
+        timeout: Optional[float],
+    ) -> None:
         self.tests = tests
         self.lit_config = lit_config
         self.workers = workers
@@ -38,7 +52,7 @@ class Run:
         self.timeout = timeout
         assert workers > 0
 
-    def execute(self):
+    def execute(self) -> None:
         """
         Execute the tests in the run using up to the specified number of
         parallel tasks, and inform the caller of each individual result. The
@@ -71,7 +85,7 @@ class Run:
                 if test.result is None:
                     test.setResult(skipped)
 
-    def _execute(self, deadline):
+    def _execute(self, deadline: float) -> None:
         self._increase_process_limit()
 
         semaphores = {
@@ -140,7 +154,7 @@ class Run:
             for pool in pools:
                 pool.join()
 
-    def _wait_for(self, async_results, deadline):
+    def _wait_for(self, async_results: List[ApplyResult], deadline: float) -> None:
         timeout = deadline - time.time()
         idx = 0
         while len(async_results) > 0:
@@ -160,7 +174,9 @@ class Run:
     # Update local test object "in place" from remote test object.  This
     # ensures that the original test object which is used for printing test
     # results reflects the changes.
-    def _update_test(self, local_test, remote_test):
+    def _update_test(
+        self, local_test: lit.Test.Test, remote_test: lit.Test.Test
+    ) -> None:
         # Needed for getMissingRequiredFeatures()
         local_test.requires = remote_test.requires
         local_test.result = remote_test.result
@@ -169,7 +185,7 @@ class Run:
     # Some tests use threads internally, and at least on Linux each of these
     # threads counts toward the current process limit. Try to raise the (soft)
     # process limit so that tests don't fail due to resource exhaustion.
-    def _increase_process_limit(self):
+    def _increase_process_limit(self) -> None:
         ncpus = lit.util.usable_core_count()
         desired_limit = self.workers * ncpus * 2  # the 2 is a safety factor
 

--- a/llvm/utils/lit/lit/util.py
+++ b/llvm/utils/lit/lit/util.py
@@ -10,6 +10,8 @@ import signal
 import subprocess
 import sys
 import threading
+from typing import Callable, Optional
+
 
 def pythonize_bool(value):
     if value is None:
@@ -30,7 +32,7 @@ def make_word_regex(word):
     return r"\b" + word + r"\b"
 
 
-def usable_core_count():
+def usable_core_count() -> int:
     """Return the number of cores the current process can use, if supported.
     Otherwise, return the total number of cores (like `os.cpu_count()`).
     Default to 1 if undetermined.
@@ -43,10 +45,9 @@ def usable_core_count():
 
     return n
 
-def abs_path_preserve_drive(path):
-    """Return the absolute path without resolving drive mappings on Windows.
 
-    """
+def abs_path_preserve_drive(path: str) -> str:
+    """Return the absolute path without resolving drive mappings on Windows."""
     if platform.system() == "Windows":
         # Windows has limitations on path length (MAX_PATH) that
         # can be worked around using substitute drives, which map
@@ -112,7 +113,7 @@ def listdir_files(dirname, suffixes=None, exclude_filenames=None, prefixes=None)
         yield filename
 
 
-def which(command, paths=None):
+def which(command: str, paths: Optional[str] = None) -> str:
     """which(command, [paths]) - Look up the given command in the paths string
     (or the PATH environment variable, if unspecified)."""
 
@@ -328,7 +329,7 @@ def addAIXVersion(target_triple):
     """Add the AIX version to the given target triple,
     e.g. powerpc64-ibm-aix7.2.5.6
     """
-    os_cmd = "oslevel -s | awk -F\'-\' \'{printf \"%.1f.%d.%d\", $1/1000, $2, $3}\'"
+    os_cmd = "oslevel -s | awk -F'-' '{printf \"%.1f.%d.%d\", $1/1000, $2, $3}'"
     os_version = subprocess.run(os_cmd, capture_output=True, shell=True).stdout.decode()
     return re.sub("aix", "aix" + os_version, target_triple)
 
@@ -440,7 +441,7 @@ def killProcessAndChildren(pid):
             pass
 
 
-def memoize(f):
+def memoize(f: Callable) -> Callable:
     cache = {}  # Unbounded
 
     def make_key(args, kwargs):

--- a/llvm/utils/lit/lit/worker.py
+++ b/llvm/utils/lit/lit/worker.py
@@ -5,6 +5,9 @@ Exception: in single process mode _execute is called directly.
 For efficiency, we copy all data needed to execute all tests into each worker
 and store it in global variables. This reduces the cost of each task.
 """
+
+from __future__ import annotations
+
 import contextlib
 import os
 import signal
@@ -14,13 +17,17 @@ import traceback
 import lit.Test
 import lit.util
 from lit.TestRunner import TestUpdaterException
+from typing import TYPE_CHECKING, Any, Dict, Iterator
+
+if TYPE_CHECKING:
+    from lit.LitConfig import LitConfig
 
 
 _lit_config = None
 _parallelism_semaphores = None
 
 
-def initialize(lit_config, parallelism_semaphores):
+def initialize(lit_config: LitConfig, parallelism_semaphores: Dict[Any, Any]) -> None:
     """Copy data shared by all test executions into worker processes"""
     global _lit_config
     global _parallelism_semaphores
@@ -33,7 +40,7 @@ def initialize(lit_config, parallelism_semaphores):
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
 
-def execute(test):
+def execute(test: lit.Test.Test) -> lit.Test.Test:
     """Run one test in a multiprocessing.Pool
 
     Side effects in this function and functions it calls are not visible in the
@@ -51,11 +58,13 @@ def execute(test):
 
 # TODO(python3): replace with contextlib.nullcontext
 @contextlib.contextmanager
-def NopSemaphore():
+def NopSemaphore() -> Iterator[None]:
     yield
 
 
-def _get_parallelism_semaphore(test):
+def _get_parallelism_semaphore(
+    test: lit.Test.Test,
+) -> contextlib._GeneratorContextManager:
     pg = test.config.parallelism_group
     if callable(pg):
         pg = pg(test)
@@ -63,7 +72,7 @@ def _get_parallelism_semaphore(test):
 
 
 # Do not inline! Directly used by LitTestCase.py
-def _execute(test, lit_config):
+def _execute(test: lit.Test.Test, lit_config: LitConfig) -> lit.Test.Result:
     start = time.time()
     result = _execute_test_handle_errors(test, lit_config)
     result.elapsed = time.time() - start
@@ -72,7 +81,9 @@ def _execute(test, lit_config):
     return result
 
 
-def _execute_test_handle_errors(test, lit_config):
+def _execute_test_handle_errors(
+    test: lit.Test.Test, lit_config: LitConfig
+) -> lit.Test.Result:
     try:
         result = test.config.test_format.execute(test, lit_config)
         return _adapt_result(result)
@@ -91,7 +102,7 @@ def _execute_test_handle_errors(test, lit_config):
 
 # Support deprecated result from execute() which returned the result
 # code and additional output as a tuple.
-def _adapt_result(result):
+def _adapt_result(result: lit.Test.Result) -> lit.Test.Result:
     if isinstance(result, lit.Test.Result):
         return result
     assert isinstance(result, tuple)


### PR DESCRIPTION
**WIP**
Currently lit modules lack type annotations, making it harder to reason about APIs and catch type-related issues statically.
This change adds type annotations to a subset of lit files. The annotations were generated using [MonkeyType](https://github.com/instagram/monkeytype) and reviewed manually.