### PR TITLE
[clang] Respect `CLANG_USE_EXPERIMENTAL_CONST_INTERP`

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -2162,10 +2162,10 @@ def fconstexpr_steps_EQ : Joined<["-"], "fconstexpr-steps=">, Group<f_Group>,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Set the maximum number of steps in constexpr function evaluation (0 = no limit)">,
   MarshallingInfoInt<LangOpts<"ConstexprStepLimit">, "1048576">;
-def fexperimental_new_constant_interpreter : Flag<["-"], "fexperimental-new-constant-interpreter">, Group<f_Group>,
-  HelpText<"Enable the experimental new constant interpreter">,
-  Visibility<[ClangOption, CC1Option]>,
-  MarshallingInfoFlag<LangOpts<"EnableNewConstInterp">>;
+defm experimental_new_constant_interpreter : BoolFOption<"experimental-new-constant-interpreter",
+  LangOpts<"EnableNewConstInterp">, Default<"CLANG_USE_EXPERIMENTAL_CONST_INTERP">,
+  PosFlag<SetTrue, [], [ClangOption, CC1Option]>,
+  NegFlag<SetFalse, [], [ClangOption, CC1Option]>>;
 def fconstexpr_backtrace_limit_EQ : Joined<["-"], "fconstexpr-backtrace-limit=">, Group<f_Group>,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Set the maximum number of entries to print in a constexpr evaluation backtrace (0 = no limit)">,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6673,8 +6673,15 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   Args.AddLastArg(CmdArgs, options::OPT_fexperimental_library);
 
-  if (Args.hasArg(options::OPT_fexperimental_new_constant_interpreter))
-    CmdArgs.push_back("-fexperimental-new-constant-interpreter");
+  if (CLANG_USE_EXPERIMENTAL_CONST_INTERP) {
+    Args.ClaimAllArgs(options::OPT_fexperimental_new_constant_interpreter);
+    Args.AddLastArg(CmdArgs,
+                    options::OPT_fno_experimental_new_constant_interpreter);
+  } else {
+    Args.ClaimAllArgs(options::OPT_fno_experimental_new_constant_interpreter);
+    Args.AddLastArg(CmdArgs,
+                    options::OPT_fexperimental_new_constant_interpreter);
+  }
 
   if (Arg *A = Args.getLastArg(options::OPT_fbracket_depth_EQ)) {
     CmdArgs.push_back("-fbracket-depth");

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6673,7 +6673,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   Args.AddLastArg(CmdArgs, options::OPT_fexperimental_library);
 
-  if (Args.hasArg(options::OPT_fexperimental_new_constant_interpreter))
+  if (Args.hasArg(options::OPT_fexperimental_new_constant_interpreter) ||
+      CLANG_USE_EXPERIMENTAL_CONST_INTERP)
     CmdArgs.push_back("-fexperimental-new-constant-interpreter");
 
   if (Arg *A = Args.getLastArg(options::OPT_fbracket_depth_EQ)) {

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6673,8 +6673,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   Args.AddLastArg(CmdArgs, options::OPT_fexperimental_library);
 
-  if (Args.hasArg(options::OPT_fexperimental_new_constant_interpreter) ||
-      CLANG_USE_EXPERIMENTAL_CONST_INTERP)
+  if (Args.hasArg(options::OPT_fexperimental_new_constant_interpreter))
     CmdArgs.push_back("-fexperimental-new-constant-interpreter");
 
   if (Arg *A = Args.getLastArg(options::OPT_fbracket_depth_EQ)) {

--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -184,9 +184,6 @@ CreateFrontendAction(CompilerInstance &CI) {
 
   const FrontendOptions &FEOpts = CI.getFrontendOpts();
 
-  if (CLANG_USE_EXPERIMENTAL_CONST_INTERP)
-    CI.getLangOpts().EnableNewConstInterp = true;
-
   if (CI.getLangOpts().HLSL)
     Act = std::make_unique<HLSLFrontendAction>(std::move(Act));
 

--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -184,6 +184,9 @@ CreateFrontendAction(CompilerInstance &CI) {
 
   const FrontendOptions &FEOpts = CI.getFrontendOpts();
 
+  if (CLANG_USE_EXPERIMENTAL_CONST_INTERP)
+    CI.getLangOpts().EnableNewConstInterp = true;
+
   if (CI.getLangOpts().HLSL)
     Act = std::make_unique<HLSLFrontendAction>(std::move(Act));
 

--- a/clang/test/AST/ByteCode/command-line-options.cpp
+++ b/clang/test/AST/ByteCode/command-line-options.cpp
@@ -1,0 +1,28 @@
+/// This tests that the bytecode interpreter is in use if -fexperimental-new-constant-interpreter is passed.
+/// This should be the case regardless of whether CLANG_USE_EXPERIMENTAL_CONST_INTERP is enabled or not.
+///
+/// Similarly, it should _not_ be used if -fno-experimental-new-constant-interpreter is passed.
+///
+/// All this should be true if the driver is used or -cc1.
+
+
+// RUN: %clang -c   -fexperimental-new-constant-interpreter %s -Xclang -verify=bc
+// RUN: %clang -cc1 -fexperimental-new-constant-interpreter %s         -verify=bc
+
+// RUN: %clang -c   -fno-experimental-new-constant-interpreter %s -Xclang -verify=nobc
+// RUN: %clang -cc1 -fno-experimental-new-constant-interpreter %s         -verify=nobc
+
+
+/// Note that we're not testing the behavior without those command line options since that
+/// depends on the value of CLANG_USE_EXPERIMENTAL_CONST_INTERP, which we can't test for.
+
+
+// bc-no-diagnostics
+
+
+/// We test for the bytecode interperter by trying to bitcast a bitfield.
+struct S {
+  unsigned a : 10;
+};
+constexpr S s = __builtin_bit_cast(S, 12); // nobc-error {{must be initialized by a constant expression}} \
+                                           // nobc-note {{constexpr bit_cast involving bit-field is not yet supported}}


### PR DESCRIPTION
Seems like https://github.com/llvm/llvm-project/pull/199396 had no effect at all, even though the patch itself seems pretty obvious.


Change the semantics of the command-line option to support `-fno-experimental-constant-interpreter` as well. This way, the cmake option can be used to set the default and the `-f`/`-fno-` command-line options can be used to override the default behavior.