### PR TITLE
[BOLT] Fix fdata parsing warning

### DIFF
--- a/bolt/lib/Profile/DataReader.cpp
+++ b/bolt/lib/Profile/DataReader.cpp
@@ -338,8 +338,9 @@ std::error_code DataReader::parseInput() {
   if (std::error_code EC = parse())
     return EC;
 
-  Diag << "WARNING: invalid profile data detected at line " << Line
-       << ". Possibly corrupted profile.\n";
+  if (!ParsingBuf.empty())
+    Diag << "WARNING: invalid profile data detected at line " << Line
+         << ". Possibly corrupted profile.\n";
 
   buildLTONameMaps();
 

--- a/bolt/test/X86/nolbr.s
+++ b/bolt/test/X86/nolbr.s
@@ -12,6 +12,11 @@
 # RUN: %clang %cflags %t.o -o %t.exe -Wl,-q -nostdlib
 # RUN: llvm-bolt %t.exe -o %t.out --data %t.fdata --dyno-stats -ba \
 # RUN:    --print-only=_start 2>&1 | FileCheck %s --check-prefix=CHECK-BOLT
+## Check that invalid fdata is detected.
+# RUN: cp %t.fdata %t.invalid.fdata
+# RUN: echo "invalid" >> %t.invalid.fdata
+# RUN: llvm-bolt %t.exe -o %t.invalid.out --data %t.invalid.fdata \
+# RUN:    2>&1 | FileCheck %s --check-prefix=CHECK-WARN
 
 # CHECK-FDATA:      no_lbr
 # CHECK-FDATA-NEXT: 1 _start [[#]] 1
@@ -19,6 +24,9 @@
 # CHECK-BOLT: BOLT-INFO: pre-processing profile using branch profile reader
 # CHECK-BOLT: BOLT-INFO: operating with basic samples profiling data (no brstack).
 # CHECK-BOLT: BOLT-INFO: 1 out of 1 functions in the binary (100.0%) have non-empty execution profile
+# CHECK-BOLT-NOT: WARNING: invalid profile data detected
+
+# CHECK-WARN: WARNING: invalid profile data detected at line {{[0-9]+}}. Possibly corrupted profile.
 
   .globl _start
   .type _start, %function


### PR DESCRIPTION
Put invalid profile warning back under the condition of non-empty
fdata buffer post-parsing.

Test Plan: updated X86/nolbr.s
