### PR TITLE
Revert "[OpenCL] Allow mesa3d OS in spirv32 and spirv64 targets"

### DIFF
--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -714,7 +714,7 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
   }
   case llvm::Triple::spirv32: {
     if ((os != llvm::Triple::UnknownOS && os != llvm::Triple::ChipStar &&
-         os != llvm::Triple::Vulkan && os != llvm::Triple::Mesa3D) ||
+         os != llvm::Triple::Vulkan) ||
         Triple.getEnvironment() != llvm::Triple::UnknownEnvironment)
       return nullptr;
     return std::make_unique<SPIRV32TargetInfo>(Triple, Opts);
@@ -723,7 +723,7 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
     if (os == llvm::Triple::OSType::AMDHSA)
       return std::make_unique<SPIRV64AMDGCNTargetInfo>(Triple, Opts);
     if ((os != llvm::Triple::UnknownOS && os != llvm::Triple::ChipStar &&
-         os != llvm::Triple::Vulkan && os != llvm::Triple::Mesa3D) ||
+         os != llvm::Triple::Vulkan) ||
         Triple.getEnvironment() != llvm::Triple::UnknownEnvironment)
       return nullptr;
     if (Triple.getVendor() == llvm::Triple::Intel)

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -351,13 +351,12 @@ public:
     resetDataLayout();
   }
 
-  // When targeting Vulkan, require a fully specified Vulkan environment
-  // (version + valid shader stage). Non-Vulkan OS triples (e.g. mesa3d)
-  // could be used for OpenCL SPIR-V.
+  // SPIR-V targeting requires a fully specified Vulkan environment.
+  // SPIR-V requires the enviornment to be in a valid shader stage as well.
+  // Validate here before CreateTargetInfo() to emit a proper diagnostic.
   bool validateTarget(DiagnosticsEngine &Diags) const override {
-    if (getTriple().getOS() != llvm::Triple::Vulkan)
-      return true;
-    if (getTriple().getVulkanVersion() == llvm::VersionTuple(0)) {
+    if (getTriple().getOS() != llvm::Triple::Vulkan ||
+        getTriple().getVulkanVersion() == llvm::VersionTuple(0)) {
       Diags.Report(diag::err_target_spirv_requires_vulkan);
       return false;
     }
@@ -382,10 +381,8 @@ public:
            "Invalid architecture for 32-bit SPIR-V.");
     assert((getTriple().getOS() == llvm::Triple::UnknownOS ||
             getTriple().getOS() == llvm::Triple::ChipStar ||
-            getTriple().getOS() == llvm::Triple::Vulkan ||
-            getTriple().getOS() == llvm::Triple::Mesa3D) &&
-           "32-bit SPIR-V target must use unknown, chipstar, vulkan, or mesa3d "
-           "OS");
+            getTriple().getOS() == llvm::Triple::Vulkan) &&
+           "32-bit SPIR-V target must use unknown, chipstar, or vulkan OS");
     assert(getTriple().getEnvironment() == llvm::Triple::UnknownEnvironment &&
            "32-bit SPIR-V target must use unknown environment type");
     PointerWidth = PointerAlign = 32;
@@ -409,10 +406,8 @@ public:
            "Invalid architecture for 64-bit SPIR-V.");
     assert((getTriple().getOS() == llvm::Triple::UnknownOS ||
             getTriple().getOS() == llvm::Triple::ChipStar ||
-            getTriple().getOS() == llvm::Triple::Vulkan ||
-            getTriple().getOS() == llvm::Triple::Mesa3D) &&
-           "64-bit SPIR-V target must use unknown, chipstar, vulkan, or mesa3d "
-           "OS");
+            getTriple().getOS() == llvm::Triple::Vulkan) &&
+           "64-bit SPIR-V target must use unknown, chipstar, or vulkan OS");
     assert(getTriple().getEnvironment() == llvm::Triple::UnknownEnvironment &&
            "64-bit SPIR-V target must use unknown environment type");
     PointerWidth = PointerAlign = 64;

--- a/clang/test/CodeGen/target-data.c
+++ b/clang/test/CodeGen/target-data.c
@@ -272,15 +272,3 @@
 // RUN: %clang_cc1 -triple spirv64-unknown-vulkan -o - -emit-llvm %s | \
 // RUN: FileCheck %s -check-prefix=SPIRV64VULKAN
 // SPIRV64VULKAN: target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
-
-// RUN: %clang_cc1 -triple spirv-mesa-mesa3d -o - -emit-llvm %s | \
-// RUN: FileCheck %s -check-prefix=SPIRVMESA3D
-// SPIRVMESA3D: target datalayout = "e-ve-i64:64-n8:16:32:64-G10"
-
-// RUN: %clang_cc1 -triple spirv32-mesa-mesa3d -o - -emit-llvm %s | \
-// RUN: FileCheck %s -check-prefix=SPIRV32MESA3D
-// SPIRV32MESA3D: target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
-
-// RUN: %clang_cc1 -triple spirv64-mesa-mesa3d -o - -emit-llvm %s | \
-// RUN: FileCheck %s -check-prefix=SPIRV64MESA3D
-// SPIRV64MESA3D: target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"

--- a/clang/test/Frontend/spirv-target-validation.c
+++ b/clang/test/Frontend/spirv-target-validation.c
@@ -1,15 +1,7 @@
-// RUN: not %clang_cc1 -triple spirv-unknown-vulkan1.0 %s 2>&1 | FileCheck %s --check-prefix=CHECK-VULKAN
+// RUN: not %clang_cc1 -triple spirv %s 2>&1 | FileCheck %s --check-prefix=CHECK-VULKAN
 // RUN: not %clang_cc1 -triple spirv-vulkan-mlibc %s 2>&1 | FileCheck %s --check-prefix=CHECK-SHADER
-// RUN: %clang_cc1 -triple spirv %s -fsyntax-only 2>&1 | FileCheck %s --allow-empty --check-prefix=CHECK-SPIRV-BARE
-// RUN: %clang_cc1 -triple spirv32-mesa-mesa3d %s -fsyntax-only 2>&1 | FileCheck %s --allow-empty --check-prefix=CHECK-SPIRV32-MESA
-// RUN: %clang_cc1 -triple spirv64-mesa-mesa3d %s -fsyntax-only 2>&1 | FileCheck %s --allow-empty --check-prefix=CHECK-SPIRV64-MESA
-// RUN: %clang_cc1 -triple spirv-mesa-mesa3d %s -fsyntax-only 2>&1 | FileCheck %s --allow-empty --check-prefix=CHECK-SPIRV-MESA
 
 // CHECK-VULKAN: error: SPIR-V target requires a Vulkan environment
 // CHECK-SHADER: error: SPIR-V target requires a valid shader stage or no environment
-// CHECK-SPIRV-BARE-NOT: error: SPIR-V target requires a Vulkan environment
-// CHECK-SPIRV32-MESA-NOT: error: unknown target triple 'spirv32-mesa-mesa3d'
-// CHECK-SPIRV64-MESA-NOT: error: unknown target triple 'spirv64-mesa-mesa3d'
-// CHECK-SPIRV-MESA-NOT: error: SPIR-V target requires a Vulkan environment
 
 int main() { return 0; }


### PR DESCRIPTION
Reverts llvm/llvm-project#197148

libclc will use generic target triple spirv32[64]-unknown-unknown for use in mesa.