### PR TITLE
[AMDGPU][libclc] Enable cl_khr_subgroup_non_uniform_arithmetic and use in libclc

### DIFF
--- a/clang/lib/Basic/Targets/AMDGPU.h
+++ b/clang/lib/Basic/Targets/AMDGPU.h
@@ -324,6 +324,7 @@ public:
       Opts["cl_khr_mipmap_image"] = true;
       Opts["cl_khr_mipmap_image_writes"] = true;
       Opts["cl_khr_subgroups"] = true;
+      Opts["cl_khr_subgroup_non_uniform_arithmetic"] = true;
       Opts["cl_amd_media_ops"] = true;
       Opts["cl_amd_media_ops2"] = true;
 

--- a/clang/lib/Basic/Targets/AMDGPU.h
+++ b/clang/lib/Basic/Targets/AMDGPU.h
@@ -324,7 +324,6 @@ public:
       Opts["cl_khr_mipmap_image"] = true;
       Opts["cl_khr_mipmap_image_writes"] = true;
       Opts["cl_khr_subgroups"] = true;
-      Opts["cl_khr_subgroup_non_uniform_arithmetic"] = true;
       Opts["cl_amd_media_ops"] = true;
       Opts["cl_amd_media_ops2"] = true;
 
@@ -348,6 +347,7 @@ public:
 
       if (getTriple().getEnvironment() == llvm::Triple::LLVM) {
         Opts["cl_khr_subgroup_extended_types"] = true;
+        Opts["cl_khr_subgroup_non_uniform_arithmetic"] = true;
       }
     }
   }

--- a/clang/test/Misc/amdgcn.languageOptsOpenCL.cl
+++ b/clang/test/Misc/amdgcn.languageOptsOpenCL.cl
@@ -158,8 +158,10 @@
 #endif
 #pragma OPENCL EXTENSION cl_khr_subgroups: enable
 
-#ifndef cl_khr_subgroup_non_uniform_arithmetic
-#error "Missing cl_khr_subgroup_non_uniform_arithmetic define"
+#ifdef LLVM_ENV_EXTENSIONS
+  #ifndef cl_khr_subgroup_non_uniform_arithmetic
+    #error "Missing cl_khr_subgroup_non_uniform_arithmetic define"
+  #endif
 #endif
 
 #ifndef cl_amd_media_ops

--- a/clang/test/Misc/amdgcn.languageOptsOpenCL.cl
+++ b/clang/test/Misc/amdgcn.languageOptsOpenCL.cl
@@ -158,6 +158,10 @@
 #endif
 #pragma OPENCL EXTENSION cl_khr_subgroups: enable
 
+#ifndef cl_khr_subgroup_non_uniform_arithmetic
+#error "Missing cl_khr_subgroup_non_uniform_arithmetic define"
+#endif
+
 #ifndef cl_amd_media_ops
 #error "Missing cl_amd_media_ops define"
 #endif

--- a/libclc/opencl/lib/generic/subgroup/sub_group_non_uniform_reduce.cl
+++ b/libclc/opencl/lib/generic/subgroup/sub_group_non_uniform_reduce.cl
@@ -8,6 +8,8 @@
 
 #include "clc/subgroup/clc_sub_group_non_uniform_reduce.h"
 
+#ifdef cl_khr_subgroup_non_uniform_arithmetic
+
 #define __CLC_BODY "sub_group_non_uniform_reduce.inc"
 #include "clc/integer/gentype.inc"
 
@@ -28,3 +30,5 @@ _CLC_DEF _CLC_OVERLOAD int
 sub_group_non_uniform_reduce_logical_xor(int predicate) {
   return __clc_sub_group_non_uniform_reduce_logical_xor(predicate);
 }
+
+#endif // cl_khr_subgroup_non_uniform_arithmetic


### PR DESCRIPTION
Per OpenCL spec, sub_group_non_uniform_reduce_* functions requires support for the cl_khr_subgroup_non_uniform_arithmetic extension.