### PR TITLE
[compiler-rt][sanitizer_common] Generalize CheckNoDeepBind as OnDlOpen

### DIFF
--- a/compiler-rt/lib/asan/asan_interceptors.cpp
+++ b/compiler-rt/lib/asan/asan_interceptors.cpp
@@ -163,7 +163,7 @@ DECLARE_REAL_AND_INTERCEPTOR(void, free, void*)
     ({                                              \
       if (flags()->strict_init_order)               \
         StopInitOrderChecking();                    \
-      CheckNoDeepBind(filename, flag);              \
+      OnDlOpen(filename, flag);                     \
       REAL(dlopen)(filename, flag);                 \
     })
 #  define COMMON_INTERCEPTOR_ON_EXIT(ctx) OnExit()

--- a/compiler-rt/lib/sanitizer_common/sanitizer_common.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common.h
@@ -1092,7 +1092,9 @@ struct StackDepotStats {
 // indicate that sanitizer allocator should not attempt to release memory to OS.
 const s32 kReleaseToOSIntervalNever = -1;
 
-void CheckNoDeepBind(const char *filename, int flag);
+// Platform hook invoked before dlopen. Performs platform-specific dlopen flag
+// checks (e.g. RTLD_DEEPBIND on Linux).
+void OnDlOpen(const char* filename, int flag);
 
 // Returns the requested amount of random data (up to 256 bytes) that can then
 // be used to seed a PRNG. Defaults to blocking like the underlying syscall.

--- a/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc
@@ -277,8 +277,11 @@ extern const short *_tolower_tab_;
       common_flags()->strict_string_checks ? (internal_strlen(s)) + 1 : (n) )
 
 #ifndef COMMON_INTERCEPTOR_DLOPEN
-#define COMMON_INTERCEPTOR_DLOPEN(filename, flag) \
-  ({ CheckNoDeepBind(filename, flag); REAL(dlopen)(filename, flag); })
+#  define COMMON_INTERCEPTOR_DLOPEN(filename, flag) \
+    ({                                              \
+      OnDlOpen(filename, flag);                     \
+      REAL(dlopen)(filename, flag);                 \
+    })
 #endif
 
 #ifndef COMMON_INTERCEPTOR_GET_TLS_RANGE

--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -2886,7 +2886,7 @@ void CheckMPROTECT() {
 #  endif
 }
 
-void CheckNoDeepBind(const char *filename, int flag) {
+void OnDlOpen(const char* filename, int flag) {
 #  ifdef RTLD_DEEPBIND
   if (flag & RTLD_DEEPBIND) {
     Report(

--- a/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
@@ -1533,7 +1533,7 @@ void DumpProcessMap() {
   Printf("End of module map.\n");
 }
 
-void CheckNoDeepBind(const char *filename, int flag) {
+void OnDlOpen(const char* filename, int flag) {
   // Do nothing.
 }
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_win.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_win.cpp
@@ -1223,7 +1223,7 @@ int WaitForProcess(pid_t pid) { return -1; }
 // FIXME implement on this platform.
 void GetMemoryProfile(fill_profile_f cb, uptr *stats) {}
 
-void CheckNoDeepBind(const char *filename, int flag) {
+void OnDlOpen(const char* filename, int flag) {
   // Do nothing.
 }
 

--- a/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
@@ -2596,9 +2596,9 @@ static void HandleRecvmsg(ThreadState *thr, uptr pc,
 
 #define COMMON_INTERCEPTOR_DLOPEN(filename, flag) \
   ({                                              \
-    CheckNoDeepBind(filename, flag);              \
+    OnDlOpen(filename, flag);                     \
     ThreadIgnoreBegin(thr, 0);                    \
-    void *res = REAL(dlopen)(filename, flag);     \
+    void* res = REAL(dlopen)(filename, flag);     \
     ThreadIgnoreEnd(thr);                         \
     res;                                          \
   })


### PR DESCRIPTION
Rename the dlopen pre-check hook to OnDlOpen so platform-specific dlopen handling can be extended beyond the RTLD_DEEPBIND guard on Linux. Windows and macOS keep no-op implementations. All dlopen interceptors call the shared hook.