### PR TITLE
[X86] matchShuffleAsVSHLD - fix incorrect shift factor

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -12923,7 +12923,7 @@ static int matchShuffleAsVSHLD(MVT &ShiftVT, SDValue &V1, SDValue &V2,
       if (isShuffleEquivalent(Mask, FunnelMask)) {
         MVT ShiftSVT = MVT::getIntegerVT(ScalarSizeInBits * Scale);
         ShiftVT = MVT::getVectorVT(ShiftSVT, Size / Scale);
-        return Shift * 8;
+        return Shift * ScalarSizeInBits;
       }
       ShuffleVectorSDNode::commuteMask(FunnelMask);
       if (isShuffleEquivalent(Mask, FunnelMask)) {

--- a/llvm/test/CodeGen/X86/vector-shuffle-combining-avx512vbmi2.ll
+++ b/llvm/test/CodeGen/X86/vector-shuffle-combining-avx512vbmi2.ll
@@ -52,6 +52,23 @@ define <16 x i8> @combine_vpshrd_vpshufb(<16 x i8> %x, <16 x i8> %y) {
   ret <16 x i8> %r
 }
 
+define <16 x i16> @combine_vpshldq_v16i16_shuffle(<16 x i16> %a, <16 x i16> %b) {
+; VLX-LABEL: combine_vpshldq_v16i16_shuffle:
+; VLX:       # %bb.0:
+; VLX-NEXT:    vpshldq $16, %ymm1, %ymm0, %ymm0
+; VLX-NEXT:    ret{{[l|q]}}
+;
+; NOVLX-LABEL: combine_vpshldq_v16i16_shuffle:
+; NOVLX:       # %bb.0:
+; NOVLX-NEXT:    # kill: def $ymm1 killed $ymm1 def $zmm1
+; NOVLX-NEXT:    # kill: def $ymm0 killed $ymm0 def $zmm0
+; NOVLX-NEXT:    vpshldq $16, %zmm1, %zmm0, %zmm0
+; NOVLX-NEXT:    # kill: def $ymm0 killed $ymm0 killed $zmm0
+; NOVLX-NEXT:    ret{{[l|q]}}
+  %r = shufflevector <16 x i16> %a, <16 x i16> %b, <16 x i32> <i32 19, i32 0, i32 1, i32 2, i32 23, i32 4, i32 5, i32 6, i32 27, i32 8, i32 9, i32 10, i32 31, i32 12, i32 13, i32 14>
+  ret <16 x i16> %r
+}
+
 define <8 x i32> @combine_vpshld_v8i32_shuffle(<8 x i32> %a, <8 x i32> %b) {
 ; VLX-LABEL: combine_vpshld_v8i32_shuffle:
 ; VLX:       # %bb.0:


### PR DESCRIPTION
#200604 left the non-commuted case to still scale by 8bits instead of the src scalar bit size