### PR TITLE
[libc++][type_traits] Applied `[[nodiscard]]`

### DIFF
--- a/libcxx/include/__type_traits/integral_constant.h
+++ b/libcxx/include/__type_traits/integral_constant.h
@@ -24,7 +24,7 @@ struct _LIBCPP_NO_SPECIALIZATIONS integral_constant {
   typedef integral_constant type;
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR operator value_type() const _NOEXCEPT { return value; }
 #if _LIBCPP_STD_VER >= 14
-  _LIBCPP_HIDE_FROM_ABI constexpr value_type operator()() const _NOEXCEPT { return value; }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI constexpr value_type operator()() const _NOEXCEPT { return value; }
 #endif
 };
 

--- a/libcxx/include/__type_traits/is_constant_evaluated.h
+++ b/libcxx/include/__type_traits/is_constant_evaluated.h
@@ -18,7 +18,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if _LIBCPP_STD_VER >= 20
-_LIBCPP_HIDE_FROM_ABI inline constexpr bool is_constant_evaluated() noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool is_constant_evaluated() noexcept {
   return __builtin_is_constant_evaluated();
 }
 #endif

--- a/libcxx/include/__type_traits/is_within_lifetime.h
+++ b/libcxx/include/__type_traits/is_within_lifetime.h
@@ -19,7 +19,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if _LIBCPP_STD_VER >= 26 && __has_builtin(__builtin_is_within_lifetime)
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI consteval bool is_within_lifetime(const _Tp* __p) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI consteval bool is_within_lifetime(const _Tp* __p) noexcept {
   return __builtin_is_within_lifetime(__p);
 }
 #endif

--- a/libcxx/test/libcxx/type_traits/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/type_traits/nodiscard.verify.cpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: std-at-least-c++14
+
+// Check that functions are marked [[nodiscard]]
+
+#include <type_traits>
+
+#include "test_macros.h"
+
+void test() {
+  std::true_type tag;
+  tag(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+
+#if TEST_STD_VER >= 20
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::is_constant_evaluated();
+#endif
+}
+
+#if TEST_STD_VER >= 26 && defined(__cpp_lib_is_within_lifetime)
+consteval void test_consteval() {
+  [[maybe_unused]] int n = 0;
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::is_within_lifetime(&n);
+}
+#endif

--- a/libcxx/test/std/utilities/meta/meta.const.eval/is_within_lifetime.compile.pass.cpp
+++ b/libcxx/test/std/utilities/meta/meta.const.eval/is_within_lifetime.compile.pass.cpp
@@ -134,7 +134,7 @@ static_assert(f());
 // (i.e., taking the address of below will fail because it will be an immediate function)
 template <typename T>
 constexpr void does_escalate(T p) {
-  std::is_within_lifetime(p);
+  (void)std::is_within_lifetime(p);
 }
 template <typename T, void (*)(T) = &does_escalate<T>>
 constexpr bool check_escalated(int) {


### PR DESCRIPTION
`[[nodiscard]]` should be applied to functions where discarding the return value is most likely a correctness issue.

- https://libcxx.llvm.org/CodingGuidelines.html
- https://wg21.link/type.traits