### PR TITLE
[CMake][Release] Use llvm-bitcode-strip on Darwin for build with -ffat-lto-objects

### DIFF
--- a/clang/cmake/caches/release_cpack_pre_build_strip_lto.cmake
+++ b/clang/cmake/caches/release_cpack_pre_build_strip_lto.cmake
@@ -1,5 +1,14 @@
 file(GLOB files ${CPACK_TEMPORARY_INSTALL_DIRECTORY}/lib/*.a)
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  set(strip_command
+    ${CPACK_TEMPORARY_INSTALL_DIRECTORY}/bin/llvm-bitcode-strip)
+  set(strip_args -r)
+else()
+  set(strip_command ${CPACK_TEMPORARY_INSTALL_DIRECTORY}/bin/llvm-strip)
+  set(strip_args --no-strip-all -R .llvm.lto)
+endif()
+
 foreach(file ${files})
-  execute_process(COMMAND ${CPACK_TEMPORARY_INSTALL_DIRECTORY}/bin/llvm-strip --no-strip-all -R .llvm.lto ${file})
+  execute_process(COMMAND ${strip_command} ${strip_args} ${file} -o ${file})
 endforeach()


### PR DESCRIPTION
Building with --fat-lto-objects was added in #140381 (cff9ae7a15a5). On macOS the tests are failing when building release binaries with many "The file was not recognized as a valid object file" errors, e.g.:

  2026-01-16T12:54:26.0928880Z
  /Users/runner/work/llvm-project/llvm-project/build/tools/clang/stage2-instrumented-bins/tools/clang/stage2-bins/_CPack_Packages/Darwin/TXZ/LLVM-22.1.0-rc1-macOS-ARM64/bin/llvm-strip:
  error:
  '/Users/runner/work/llvm-project/llvm-project/build/tools/clang/stage2-instrumented-bins/tools/clang/stage2-bins/_CPack_Packages/Darwin/TXZ/LLVM-22.1.0-rc1-macOS-ARM64/lib/libLLVMAArch64AsmParser.a(AArch64AsmParser.cpp.o)':
  The file was not recognized as a valid object file

It's assuming bitcode is embedded in section .llvm.lto (llvm/lib/Object/ObjectFile.cpp:80) but on MachO it's in __LLVM,__bitcode (llvm/lib/Object/MachOObjectFile.cpp:2184)

llvm-bitcode-strip is a driver for the MachO bitcode_strip utility which handles this. Use this instead.

Fixes #176398.

Assisted-by: codex