### PR TITLE
[flang][OpenMP] Restricting Integration test atomic-capture-release.f90 run to x86 and aarch64

### DIFF
--- a/flang/test/Integration/OpenMP/atomic-capture-release.f90
+++ b/flang/test/Integration/OpenMP/atomic-capture-release.f90
@@ -6,7 +6,8 @@
 ! added to this directory and sub-directories.
 !===----------------------------------------------------------------------===!
 
-!RUN: %flang_fc1 -triple x86_64-unknown-linux-gnu -emit-llvm -fopenmp -fopenmp-version=51 %s -o - | FileCheck %s
+!RUN: %if x86-registered-target %{ %flang_fc1 -triple x86_64-unknown-linux-gnu -emit-llvm -fopenmp -fopenmp-version=51 %s -o - | FileCheck %s %}
+!RUN: %if aarch64-registered-target %{ %flang_fc1 -triple aarch64-unknown-linux-gnu -emit-llvm -fopenmp -fopenmp-version=51 %s -o - | FileCheck %s %}
 
 ! Real(4) capture with release ordering: the initial load in the cmpxchg loop
 ! must use monotonic (not release, which is invalid for loads in LLVM IR).


### PR DESCRIPTION
Similar to the the change in `flang/test/Integration/OpenMP/atomic-compare.f90`, restricting the test case `flang/test/Integration/OpenMP/atomic-capture-release.f90` to run on
`x86-registered-target & aarch64-registered-target`

This also Fixes [#200729](https://github.com/llvm/llvm-project/issues/200729)

A comment has been added to the merge in
[[Flang][OpenMP]Handling restrictions of using Memory-Order-Clause with Atomic-Clause](https://github.com/llvm/llvm-project/pull/199636)

>LLVM Buildbot has detected a new failure on builder ppc64le-mlir-rhel-clang running on ppc64le-mlir-rhel-test while building flang,llvm,mlir at step 4 "cmake-configure".
Full details are available at: https://lab.llvm.org/buildbot/#/builders/129/builds/45227

Hence this PR.