### PR TITLE
[clang][bytecode] Don't deref() non-dereferencable pointers

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -2599,7 +2599,7 @@ bool SubOffset(InterpState &S, CodePtr OpPC) {
 template <ArithOp Op>
 static inline bool IncDecPtrHelper(InterpState &S, CodePtr OpPC,
                                    const Pointer &Ptr) {
-  if (Ptr.isDummy())
+  if (!Ptr.isDereferencable())
     return false;
 
   using OneT = Char<false>;

--- a/clang/test/AST/ByteCode/invalid.cpp
+++ b/clang/test/AST/ByteCode/invalid.cpp
@@ -198,3 +198,14 @@ namespace InvalidUnaryOperator {
       ;
   }
 }
+
+namespace IncNonDereferencable {
+  struct S {};
+
+  void foo() {
+    S *s = (foo *)malloc(sizeof(*s)); // both-error {{expected expression}}
+    S *&sref = s;
+    for (int i = 0; i < 2; sref++)
+      ;
+  }
+}


### PR DESCRIPTION
That shouldn't happen and the isDummy() check wasn't enough.