### PR TITLE
[AArch64] Set the default cache line size to 64 bytes.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
@@ -137,7 +137,6 @@ void AArch64Subtarget::initializeProperties(bool HasMinSize) {
       AvoidLDAPUR = true;
     break;
   case Carmel:
-    CacheLineSize = 64;
     break;
   case CortexA35:
   case CortexA53:
@@ -221,7 +220,6 @@ void AArch64Subtarget::initializeProperties(bool HasMinSize) {
   case AppleA17:
   case AppleM4:
   case AppleM5:
-    CacheLineSize = 64;
     PrefetchDistance = 280;
     MinPrefetchStride = 2048;
     MaxPrefetchIterationsAhead = 3;
@@ -258,7 +256,6 @@ void AArch64Subtarget::initializeProperties(bool HasMinSize) {
     break;
   case NeoverseV2:
   case NeoverseV3:
-    CacheLineSize = 64;
     EpilogueVectorizationMinVF = 8;
     ScatterOverhead = 13;
     [[fallthrough]];
@@ -285,7 +282,6 @@ void AArch64Subtarget::initializeProperties(bool HasMinSize) {
     MinVectorRegisterBitWidth = 128;
     break;
   case ThunderX2T99:
-    CacheLineSize = 64;
     PrefFunctionAlignment = Align(8);
     PrefLoopAlignment = Align(4);
     PrefetchDistance = 128;
@@ -305,12 +301,10 @@ void AArch64Subtarget::initializeProperties(bool HasMinSize) {
     MinVectorRegisterBitWidth = 128;
     break;
   case TSV110:
-    CacheLineSize = 64;
     PrefFunctionAlignment = Align(16);
     PrefLoopAlignment = Align(4);
     break;
   case ThunderX3T110:
-    CacheLineSize = 64;
     PrefFunctionAlignment = Align(16);
     PrefLoopAlignment = Align(4);
     PrefetchDistance = 128;
@@ -323,18 +317,15 @@ void AArch64Subtarget::initializeProperties(bool HasMinSize) {
   case Ampere1A:
   case Ampere1B:
   case Ampere1C:
-    CacheLineSize = 64;
     PrefFunctionAlignment = Align(64);
     PrefLoopAlignment = Align(64);
     break;
   case Oryon:
-    CacheLineSize = 64;
     PrefFunctionAlignment = Align(16);
     PrefetchDistance = 128;
     MinPrefetchStride = 1024;
     break;
   case Olympus:
-    CacheLineSize = 64;
     EpilogueVectorizationMinVF = 8;
     ScatterOverhead = 13;
     PrefFunctionAlignment = Align(16);

--- a/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
@@ -334,6 +334,7 @@ void AArch64Subtarget::initializeProperties(bool HasMinSize) {
     MinPrefetchStride = 1024;
     break;
   case Olympus:
+    CacheLineSize = 64;
     EpilogueVectorizationMinVF = 8;
     ScatterOverhead = 13;
     PrefFunctionAlignment = Align(16);

--- a/llvm/lib/Target/AArch64/AArch64Subtarget.h
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.h
@@ -59,7 +59,7 @@ protected:
   unsigned EpilogueVectorizationMinVF = 16;
   uint8_t MaxInterleaveFactor = 2;
   uint8_t VectorInsertExtractBaseCost = 2;
-  uint16_t CacheLineSize = 0;
+  uint16_t CacheLineSize = 64;
   // Default scatter/gather overhead.
   unsigned ScatterOverhead = 10;
   unsigned GatherOverhead = 10;

--- a/llvm/unittests/Target/AArch64/AArch64CacheLineSizeTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64CacheLineSizeTest.cpp
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "AArch64Subtarget.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Target/TargetMachine.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+
+namespace {
+
+class AArch64CacheLineSizeTest : public testing::Test {
+protected:
+  static void SetUpTestSuite() {
+    LLVMInitializeAArch64TargetInfo();
+    LLVMInitializeAArch64Target();
+    LLVMInitializeAArch64TargetMC();
+  }
+
+  unsigned getCacheLineSizeForCPU(StringRef CPU) {
+    std::string Error;
+    Triple TT("aarch64--");
+    const Target *T = TargetRegistry::lookupTarget(TT, Error);
+    std::unique_ptr<TargetMachine> TM(
+        T->createTargetMachine(TT, CPU, "", TargetOptions(), std::nullopt));
+    AArch64Subtarget ST(TT, CPU, CPU, TM->getTargetFeatureString(), *TM, true);
+    return ST.getCacheLineSize();
+  }
+};
+
+TEST_F(AArch64CacheLineSizeTest, IsCorrect) {
+  EXPECT_EQ(getCacheLineSizeForCPU("generic"), 0u);
+  EXPECT_EQ(getCacheLineSizeForCPU("a64fx"), 256u);
+  EXPECT_EQ(getCacheLineSizeForCPU("ampere1"), 64u);
+  EXPECT_EQ(getCacheLineSizeForCPU("apple-m5"), 64u);
+  EXPECT_EQ(getCacheLineSizeForCPU("carmel"), 64u);
+  EXPECT_EQ(getCacheLineSizeForCPU("cortex-a57"), 0u);
+  EXPECT_EQ(getCacheLineSizeForCPU("cortex-a725"), 0u);
+  EXPECT_EQ(getCacheLineSizeForCPU("cortex-x4"), 0u);
+  EXPECT_EQ(getCacheLineSizeForCPU("cortex-x925"), 0u);
+  EXPECT_EQ(getCacheLineSizeForCPU("falkor"), 128u);
+  EXPECT_EQ(getCacheLineSizeForCPU("grace"), 64u);
+  EXPECT_EQ(getCacheLineSizeForCPU("kryo"), 128u);
+  EXPECT_EQ(getCacheLineSizeForCPU("neoverse-v1"), 0u);
+  EXPECT_EQ(getCacheLineSizeForCPU("neoverse-v3"), 64u);
+  EXPECT_EQ(getCacheLineSizeForCPU("olympus"), 64u);
+  EXPECT_EQ(getCacheLineSizeForCPU("oryon-1"), 64u);
+  EXPECT_EQ(getCacheLineSizeForCPU("thunderx"), 128u);
+  EXPECT_EQ(getCacheLineSizeForCPU("thunderx2t99"), 64u);
+  EXPECT_EQ(getCacheLineSizeForCPU("thunderx3t110"), 64u);
+  EXPECT_EQ(getCacheLineSizeForCPU("tsv110"), 64u);
+}
+
+} // namespace

--- a/llvm/unittests/Target/AArch64/AArch64CacheLineSizeTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64CacheLineSizeTest.cpp
@@ -36,19 +36,19 @@ protected:
 };
 
 TEST_F(AArch64CacheLineSizeTest, IsCorrect) {
-  EXPECT_EQ(getCacheLineSizeForCPU("generic"), 0u);
+  EXPECT_EQ(getCacheLineSizeForCPU("generic"), 64u);
   EXPECT_EQ(getCacheLineSizeForCPU("a64fx"), 256u);
   EXPECT_EQ(getCacheLineSizeForCPU("ampere1"), 64u);
   EXPECT_EQ(getCacheLineSizeForCPU("apple-m5"), 64u);
   EXPECT_EQ(getCacheLineSizeForCPU("carmel"), 64u);
-  EXPECT_EQ(getCacheLineSizeForCPU("cortex-a57"), 0u);
-  EXPECT_EQ(getCacheLineSizeForCPU("cortex-a725"), 0u);
-  EXPECT_EQ(getCacheLineSizeForCPU("cortex-x4"), 0u);
-  EXPECT_EQ(getCacheLineSizeForCPU("cortex-x925"), 0u);
+  EXPECT_EQ(getCacheLineSizeForCPU("cortex-a57"), 64u);
+  EXPECT_EQ(getCacheLineSizeForCPU("cortex-a725"), 64u);
+  EXPECT_EQ(getCacheLineSizeForCPU("cortex-x4"), 64u);
+  EXPECT_EQ(getCacheLineSizeForCPU("cortex-x925"), 64u);
   EXPECT_EQ(getCacheLineSizeForCPU("falkor"), 128u);
   EXPECT_EQ(getCacheLineSizeForCPU("grace"), 64u);
   EXPECT_EQ(getCacheLineSizeForCPU("kryo"), 128u);
-  EXPECT_EQ(getCacheLineSizeForCPU("neoverse-v1"), 0u);
+  EXPECT_EQ(getCacheLineSizeForCPU("neoverse-v1"), 64u);
   EXPECT_EQ(getCacheLineSizeForCPU("neoverse-v3"), 64u);
   EXPECT_EQ(getCacheLineSizeForCPU("olympus"), 64u);
   EXPECT_EQ(getCacheLineSizeForCPU("oryon-1"), 64u);

--- a/llvm/unittests/Target/AArch64/CMakeLists.txt
+++ b/llvm/unittests/Target/AArch64/CMakeLists.txt
@@ -30,6 +30,7 @@ add_llvm_target_unittest(AArch64Tests
   InstSizes.cpp
   MatrixRegisterAliasing.cpp
   SMEAttributesTest.cpp
+  AArch64CacheLineSizeTest.cpp
   AArch64RegisterInfoTest.cpp
   AArch64SVESchedPseudoTest.cpp
   AArch64SelectionDAGTest.cpp


### PR DESCRIPTION
This should be set to enable more precise interchange in the future, for instance.