### PR TITLE
[DA] Fix overflow in the Exact test

### DIFF
--- a/llvm/lib/Analysis/DependenceAnalysis.cpp
+++ b/llvm/lib/Analysis/DependenceAnalysis.cpp
@@ -1588,12 +1588,14 @@ bool DependenceInfo::exactTestImpl(const SCEVAddRecExpr *Src,
 
   APInt TU(APInt::getSignedMaxValue(Bits));
   APInt TL(APInt::getSignedMinValue(Bits));
-  APInt TC = CM.sdiv(G);
-  APInt TX = X * TC;
-  APInt TY = Y * TC;
-  LLVM_DEBUG(dbgs() << "\t    TC = " << TC << "\n");
-  LLVM_DEBUG(dbgs() << "\t    TX = " << TX << "\n");
-  LLVM_DEBUG(dbgs() << "\t    TY = " << TY << "\n");
+  OverflowSafeSignedAPInt TC = CM.sdiv(G);
+  OverflowSafeSignedAPInt TX = OverflowSafeSignedAPInt(X) * TC;
+  OverflowSafeSignedAPInt TY = OverflowSafeSignedAPInt(Y) * TC;
+  if (!TC || !TX || !TY)
+    return false;
+  LLVM_DEBUG(dbgs() << "\t    TC = " << *TC << "\n");
+  LLVM_DEBUG(dbgs() << "\t    TX = " << *TX << "\n");
+  LLVM_DEBUG(dbgs() << "\t    TY = " << *TY << "\n");
 
   APInt TB = BM.sdiv(G);
   APInt TA = AM.sdiv(G);

--- a/llvm/test/Analysis/DependenceAnalysis/exact-siv-mul-overflow.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/exact-siv-mul-overflow.ll
@@ -18,15 +18,13 @@ target datalayout = "e-m:e-p:32:32-i64:64-n32-S128"
 ;  A[5*i]            |               | A[750000000]
 ;  A[8*i + 750000000]| A[750000000]  |
 ;
-; FIXME: DependenceAnalysis currently fails to detect this dependency due to
-; mishandling of overflow.
 ;
 define void @exactsiv_mul_overflow(ptr %A) {
 ; CHECK-LABEL: 'exactsiv_mul_overflow'
 ; CHECK-NEXT:  Src: store i8 0, ptr %src.ptr, align 1 --> Dst: store i8 0, ptr %src.ptr, align 1
 ; CHECK-NEXT:    da analyze - none!
 ; CHECK-NEXT:  Src: store i8 0, ptr %src.ptr, align 1 --> Dst: store i8 1, ptr %dst.ptr, align 1
-; CHECK-NEXT:    da analyze - none!
+; CHECK-NEXT:    da analyze - output [*|<]!
 ; CHECK-NEXT:  Src: store i8 1, ptr %dst.ptr, align 1 --> Dst: store i8 1, ptr %dst.ptr, align 1
 ; CHECK-NEXT:    da analyze - none!
 ;


### PR DESCRIPTION
In exactTestImpl, some computations using APInt could overflow, which might lead to incorrect results.
This patch addresses the issue by replacing APInt with OverflowSafeSignedAPInt, a class that is sensitive to overflow and allows us to detect it properly.

Fixes #200766.