### PR TITLE
[LifetimeSafety] Prevent false-negative lifetimebound verification when origin escapes in an unrelated manner

### DIFF
--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -133,7 +133,8 @@ public:
         return;
       if (PVD->hasAttr<LifetimeBoundAttr>()) {
         // Track that this lifetimebound parameter correctly escapes.
-        VerifiedLiftimeboundEscapes.insert(PVD);
+        if (isa<ReturnEscapeFact>(OEF))
+          VerifiedLiftimeboundEscapes.insert(PVD);
       } else {
         // Otherwise, suggest lifetimebound for parameter escaping through
         // return or a field in constructor.
@@ -147,9 +148,10 @@ public:
       // field!
     };
     auto CheckImplicitThis = [&](const CXXMethodDecl *MD) {
-      if (implicitObjectParamIsLifetimeBound(MD))
-        VerifiedLiftimeboundEscapes.insert(MD);
-      else if (auto *ReturnEsc = dyn_cast<ReturnEscapeFact>(OEF))
+      if (implicitObjectParamIsLifetimeBound(MD)) {
+        if (isa<ReturnEscapeFact>(OEF))
+          VerifiedLiftimeboundEscapes.insert(MD);
+      } else if (auto *ReturnEsc = dyn_cast<ReturnEscapeFact>(OEF))
         AnnotationWarningsMap.try_emplace(MD, ReturnEsc->getReturnExpr());
     };
     auto MovedAtEscape = MovedLoans.getMovedLoans(OEF);

--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -148,11 +148,12 @@ public:
       // field!
     };
     auto CheckImplicitThis = [&](const CXXMethodDecl *MD) {
-      if (implicitObjectParamIsLifetimeBound(MD)) {
-        if (isa<ReturnEscapeFact>(OEF))
+      if (auto *ReturnEsc = dyn_cast<ReturnEscapeFact>(OEF)) {
+        if (implicitObjectParamIsLifetimeBound(MD))
           VerifiedLiftimeboundEscapes.insert(MD);
-      } else if (auto *ReturnEsc = dyn_cast<ReturnEscapeFact>(OEF))
-        AnnotationWarningsMap.try_emplace(MD, ReturnEsc->getReturnExpr());
+        else
+          AnnotationWarningsMap.try_emplace(MD, ReturnEsc->getReturnExpr());
+      }
     };
     auto MovedAtEscape = MovedLoans.getMovedLoans(OEF);
     for (LoanID LID : EscapedLoans) {

--- a/clang/test/Sema/warn-lifetime-safety-lifetimebound.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-lifetimebound.cpp
@@ -44,6 +44,24 @@ View return_alias_through_unannotated_passthrough(
   return not_lb(alias);
 }
 
+View global_view;
+
+View assign_param_to_global(
+    const MyObj &obj [[clang::lifetimebound]]) { // expected-warning {{could not verify that the return value can be lifetime bound to 'obj'}}
+  global_view = obj; // Wrong kind of escape.
+  return View(); // Unrelated view.
+}
+
+struct EnclosingState {
+  View member;
+
+  View assign_param_to_field(
+      const MyObj &obj [[clang::lifetimebound]]) { // expected-warning {{could not verify that the return value can be lifetime bound to 'obj'}}
+    member = obj; // Wrong kind of escape.
+    return View(); // Unrelated view.
+  }
+};
+
 View not_lb_view(View v);
 
 View lb_view(View v [[clang::lifetimebound]]);


### PR DESCRIPTION
This PR removes a false-negative `[[lifetimebound]]` verification result that occurs when the annotated attribute escapes via unrelated origin escape kinds (escape through global, escape through field).

Change summary:
- `Checker.cpp` has function `checkAnnotations` which checks if an escaping `Origin` was an annotated parameter. Modified the logic there to only verify `[[lifetimebound]]` in the case that the escape was through a return statement.

Fixes #200412 