### PR TITLE
[clang][bytecode] Remove unknown-size-array special handling

### DIFF
--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -214,10 +214,6 @@ APValue Pointer::toAPValue(const ASTContext &ASTCtx) const {
   } else
     llvm_unreachable("Invalid allocation type");
 
-  if (isUnknownSizeArray())
-    return APValue(Base, CharUnits::Zero(), Path,
-                   /*IsOnePastEnd=*/isOnePastEnd(), /*IsNullPtr=*/false);
-
   CharUnits Offset = CharUnits::Zero();
 
   auto getFieldOffset = [&](const FieldDecl *FD) -> CharUnits {

--- a/clang/test/SemaCXX/constant-expression-p2280r4.cpp
+++ b/clang/test/SemaCXX/constant-expression-p2280r4.cpp
@@ -285,11 +285,9 @@ namespace unsized_array {
   void f(int (&a)[], int (&b)[], int (&c)[4]) {
     constexpr int t1 = a - a;
     constexpr int t2 = a - b; // expected-error {{constexpr variable 't2' must be initialized by a constant expression}} \
-                              // nointerpreter-note {{arithmetic involving unrelated objects '&a[0]' and '&b[0]' has unspecified value}} \
-                              // interpreter-note {{arithmetic involving unrelated objects '&a' and '&b' has unspecified value}}
+                              // expected-note {{arithmetic involving unrelated objects '&a[0]' and '&b[0]' has unspecified value}}
     constexpr int t3 = a - &c[2];  // expected-error {{constexpr variable 't3' must be initialized by a constant expression}} \
-                                   // nointerpreter-note {{arithmetic involving unrelated objects '&a[0]' and '&c[2]' has unspecified value}} \
-                                   // interpreter-note {{arithmetic involving unrelated objects '&a' and '&c[2]' has unspecified value}}
+                                   // expected-note {{arithmetic involving unrelated objects '&a[0]' and '&c[2]' has unspecified value}}
   }
 }
 


### PR DESCRIPTION
from `Pointer::toAPValue()`.