### PR TITLE
[OpenMP][OMPT] Map `ompt_get_num_devices` to runtime function

### DIFF
--- a/offload/test/ompt/get_num_devices.c
+++ b/offload/test/ompt/get_num_devices.c
@@ -1,0 +1,57 @@
+// clang-format off
+// RUN: %libomptarget-compile-run-and-check-generic
+// REQUIRES: ompt
+// REQUIRES: gpu
+// clang-format on
+
+/*
+ * Test to ensure that a tool receives the same number of devices
+ * via the OMPT entry point that an application receives via the
+ * omp_get_num_devices runtime function.
+ *
+ * Note, that the get_num_devices() entry point will _not_ provide
+ * the correct amount of devices before the PluginManager has been
+ * fully initialized, i.e. until after `ompt_initialize`.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+
+#include <omp-tools.h>
+#include <omp.h>
+
+// OMPT entry point handles
+static ompt_get_num_devices_t ompt_get_num_devices = 0;
+
+// Init functions
+int ompt_initialize(ompt_function_lookup_t lookup, int initial_device_num,
+                    ompt_data_t *tool_data) {
+  ompt_get_num_devices = (ompt_get_num_devices_t)lookup("ompt_get_num_devices");
+
+  if (!ompt_get_num_devices)
+    return 0; // failed
+
+  return 1; // success
+}
+
+void ompt_finalize(ompt_data_t *tool_data) {}
+
+ompt_start_tool_result_t *ompt_start_tool(unsigned int omp_version,
+                                          const char *runtime_version) {
+  static ompt_start_tool_result_t ompt_start_tool_result = {&ompt_initialize,
+                                                            &ompt_finalize, 0};
+  return &ompt_start_tool_result;
+}
+
+int main(void) {
+  const int NumDevices = omp_get_num_devices();
+  assert(ompt_get_num_devices != NULL &&
+         "ompt_get_num_devices() should not be NULL\n");
+  const int NumDevicesOmpt = ompt_get_num_devices();
+
+  printf("Num Devices: %d\n", NumDevices);
+  printf("Num Devices via OMPT: %d\n", NumDevicesOmpt);
+}
+
+/// CHECK: Num Devices: [[NUM:[0-9]+]]
+/// CHECK: Num Devices via OMPT: [[NUM]]

--- a/openmp/runtime/src/ompt-general.cpp
+++ b/openmp/runtime/src/ompt-general.cpp
@@ -864,8 +864,10 @@ OMPT_API_ROUTINE int ompt_get_target_info(uint64_t *device_num,
   return 0; // thread is not in a target region
 }
 
+extern "C" int omp_get_num_devices(void);
+
 OMPT_API_ROUTINE int ompt_get_num_devices(void) {
-  return 1; // only one device (the current device) is available
+  return omp_get_num_devices();
 }
 
 /*****************************************************************************


### PR DESCRIPTION
Since 82e94a593433f36734e2d34898d353a2ecb65b8b, `ompt_get_num_devices` was hard coded to always provide a return value of `1`, regardless of the actual number of devices. Tools relying on this return value were henced forced to use other approaches to estimate the number of available devices.

To improve the situtation, map the returned value to the one provided by `omp_get_num_devices()`. This does not resolve the issue completely though. When OMPT is initialized through `libomptarget.so`, the PluginManager, providing the number of devices, is not initialized until after OMPT has been fully set up. This means that tools, trying to retrieve the number of devices during the _initialize_ callback, will still receive the incorrect number of devices.

Still, this is a significant improvement compared to the prior state which provided an incorrect result for most of the program runtime.

Closes #196829