### PR TITLE
[libc] Add sys/uio.h to Linux public header target lists

### DIFF
--- a/libc/config/linux/aarch64/headers.txt
+++ b/libc/config/linux/aarch64/headers.txt
@@ -54,6 +54,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_syscall
     libc.include.sys_time
     libc.include.sys_types
+    libc.include.sys_uio
     libc.include.sys_un
     libc.include.sys_utsname
     libc.include.sys_wait

--- a/libc/config/linux/riscv/headers.txt
+++ b/libc/config/linux/riscv/headers.txt
@@ -54,6 +54,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_syscall
     libc.include.sys_time
     libc.include.sys_types
+    libc.include.sys_uio
     libc.include.sys_utsname
     libc.include.sys_wait
     libc.include.syscall

--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -58,6 +58,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_time
     libc.include.sys_types
     libc.include.sys_ucontext
+    libc.include.sys_uio
     libc.include.sys_un
     libc.include.sys_utsname
     libc.include.sys_wait


### PR DESCRIPTION
The headers don't get installed without this.

Assisted by Gemini.