### PR TITLE
[AArch64] Add -global-isel runlines to ZCZ tests(NFC)

### DIFF
--- a/llvm/test/CodeGen/AArch64/arm64-zero-cycle-zeroing-fpr.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-zero-cycle-zeroing-fpr.ll
@@ -9,6 +9,9 @@
 ; RUN: llc < %s -mtriple=aarch64-linux-gnu -mcpu=kryo | FileCheck %s --match-full-lines -check-prefixes=ALL,ZCZ-FPR64
 ; RUN: llc < %s -mtriple=aarch64-linux-gnu -mcpu=falkor | FileCheck %s --match-full-lines -check-prefixes=ALL,ZCZ-FPR64
 
+;; Test Global ISel
+; RUN: llc < %s -mtriple=arm64-apple-macosx -mcpu=apple-m5 -global-isel | FileCheck %s --match-full-lines -check-prefixes=ALL,NOZCZ-FPR64-ZCZ-FPR128
+
 define half @tf16() {
 entry:
 ; ALL-LABEL: {{_?}}tf16:{{ *(;|//) *}}@tf16

--- a/llvm/test/CodeGen/AArch64/arm64-zero-cycle-zeroing-gpr.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-zero-cycle-zeroing-gpr.ll
@@ -8,6 +8,9 @@
 ; RUN: llc < %s -mtriple=aarch64-linux-gnu -mcpu=kryo | FileCheck %s --match-full-lines -check-prefixes=ALL,ZCZ-GPR32,ZCZ-GPR64
 ; RUN: llc < %s -mtriple=aarch64-linux-gnu -mcpu=falkor | FileCheck %s --match-full-lines -check-prefixes=ALL,ZCZ-GPR32,ZCZ-GPR64
 
+;; Test Global ISel
+; RUN: llc < %s -mtriple=arm64-apple-macosx -mcpu=apple-m5 -global-isel | FileCheck %s --match-full-lines -check-prefixes=ALL,ZCZ-GPR32,ZCZ-GPR64
+
 define i8 @ti8() {
 entry:
 ; ALL-LABEL: {{_?}}ti8:{{ *(;|//) *}}@ti8


### PR DESCRIPTION
ZCZ lowering relies on ISel (for FPR - pseudo instruction pattern matching, for GPR - canonical form pattern matching). This patch adds a representative -global-isel runlines to catch possible regressions, though these are not very likely because both selectors should share the patterns.