### PR TITLE
Remove an invalid FIXME in a MemCpyOpt test

### DIFF
--- a/llvm/test/Transforms/MemCpyOpt/memcpy.ll
+++ b/llvm/test/Transforms/MemCpyOpt/memcpy.ll
@@ -19,7 +19,6 @@ declare void @llvm.memcpy.inline.p0.p0.i32(ptr nocapture, ptr nocapture, i32, i1
 declare void @llvm.memset.p0.i64(ptr nocapture, i8, i64, i1) nounwind
 
 ; Check that one of the memcpy's are removed.
-;; FIXME: PR 8643 We should be able to eliminate the last memcpy here.
 define void @test1(ptr sret(%0)  %agg.result, x86_fp80 %z.0, x86_fp80 %z.1) nounwind  {
 ; CHECK-LABEL: @test1(
 ; CHECK-NEXT:  entry:


### PR DESCRIPTION
Call slot optimization explicitly [requires `writable` and `noalias`][0] when the destination is an argument, and `sret` doesn't imply any of these.

So the `memcpy` into the return value pointer cannot be optimized away in this test.

The test for doing this optimization when the `sret` argument is also `writable` and `noalias` is [here][1].

Relevant commits:

- 369c9b791bc3f380e884bcad444287998c32ae16 requires writability in call slot optimization and adds the `writable` attribute in the test linked above, which already has `sret`, so that it optimizes as before. So `sret` does not imply `writable`.

- f445e39ab271d07733f0f45048badd9e58905aec updates `isWritable` used in the commit above to check for `noalias` on arguments before concluding "writable".

The FIXME should probably have been removed with one of these commits.

[0]: https://github.com/llvm/llvm-project/blob/356d7e6bf429a7ff3ae798bb994631ef33891a44/llvm/lib/Analysis/AliasAnalysis.cpp#L1009-L1019

[1]: https://github.com/llvm/llvm-project/blob/356d7e6bf429a7ff3ae798bb994631ef33891a44/llvm/test/Transforms/MemCpyOpt/sret.ll#L9