### PR TITLE
Enable generic TF builtins for i386

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -379,6 +379,7 @@ if (NOT MSVC)
   set(i386_SOURCES
     ${GENERIC_SOURCES}
     ${x86_ARCH_SOURCES}
+    ${GENERIC_TF_SOURCES}
     i386/ashldi3.S
     i386/ashrdi3.S
     i386/divdi3.S
@@ -1086,9 +1087,9 @@ else ()
         list(APPEND BUILTIN_CFLAGS_${arch} -fomit-frame-pointer -DCOMPILER_RT_ARMHF_TARGET)
       endif()
 
-      # For RISCV32 and 32-bit SPARC, we must force enable int128 for compiling long
-      # double routines.
-      if (COMPILER_RT_ENABLE_SOFTWARE_INT128 OR ("${arch}" MATCHES "riscv32|sparc$"
+      # For RISCV32, 32-bit SPARC and i386, we must force enable int128 for
+      # compiling long double routines.
+      if (COMPILER_RT_ENABLE_SOFTWARE_INT128 OR ("${arch}" MATCHES "riscv32|sparc$|i386"
         AND NOT CMAKE_COMPILER_IS_GNUCC))
         list(APPEND BUILTIN_CFLAGS_${arch} -fforce-enable-int128)
       endif()


### PR DESCRIPTION
Hello everyone,

I independently hit the missing i386 builtins issue https://github.com/llvm/llvm-project/issues/121757 which got worse after upgrading to GCC 15 to build glibc in ChromiumOS (the rest of the system is built with clang + compiler-rt) and since the previous [PR fix](https://github.com/llvm/llvm-project/pull/122658) stalled for about 1.5 years, I'm posting a fix based on it, addressing pending feedback.

Just one commit in this one, the conunterpart of https://github.com/llvm/llvm-project/pull/201078 which is a separate fix.
