### PR TITLE
[lldb-dap] Run the terminate commands only on disconnect

### DIFF
--- a/lldb/test/API/tools/lldb-dap/attach-commands/TestDAP_attachCommands.py
+++ b/lldb/test/API/tools/lldb-dap/attach-commands/TestDAP_attachCommands.py
@@ -58,6 +58,7 @@ class TestDAP_attachCommands(lldbdap_testcase.DAPTestCaseBase):
             exitCommands=exitCommands,
             terminateCommands=terminateCommands,
             postRunCommands=postRunCommands,
+            disconnectAutomatically=False,
         )
         self.dap_server.wait_for_initialized()
         # Get output from the console. This should contain both the
@@ -89,6 +90,7 @@ class TestDAP_attachCommands(lldbdap_testcase.DAPTestCaseBase):
 
         # Continue until the program exits
         self.continue_to_exit()
+        self.dap_server.request_disconnect(terminateDebuggee=True)
         # Get output from the console. This should contain both the
         # "exitCommands" that were run after the second breakpoint was hit
         # and the "terminateCommands" due to the debugging session ending

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_commands.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_commands.py
@@ -42,6 +42,7 @@ class TestDAP_launch_commands(lldbdap_testcase.DAPTestCaseBase):
             stopCommands=stopCommands,
             exitCommands=exitCommands,
             terminateCommands=terminateCommands,
+            disconnectAutomatically=False,
         )
         self.dap_server.wait_for_initialized()
 
@@ -83,6 +84,7 @@ class TestDAP_launch_commands(lldbdap_testcase.DAPTestCaseBase):
 
         # Continue until the program exits
         self.continue_to_exit()
+        self.dap_server.request_disconnect(terminateDebuggee=True)
         # Get output from the console. This should contain both the
         # "exitCommands" that were run after the second breakpoint was hit
         # and the "terminateCommands" due to the debugging session ending

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -891,8 +891,6 @@ bool DAP::HandleObject(const Message &M) {
 void DAP::SendTerminatedEvent() {
   // Prevent races if the process exits while we're being asked to disconnect.
   llvm::call_once(terminated_event_flag, [&] {
-    RunTerminateCommands();
-    // Send a "terminated" event
     llvm::json::Object event(CreateTerminatedEventObject(target));
     SendJSON(llvm::json::Value(std::move(event)));
   });
@@ -924,6 +922,7 @@ llvm::Error DAP::Disconnect(bool terminateDebuggee) {
   }
   }
 
+  RunTerminateCommands();
   SendTerminatedEvent();
   TerminateLoop();
   return ToError(error);


### PR DESCRIPTION
The terminate commands should only run when a debug session ends.

Fixes https://github.com/llvm/llvm-project/issues/194670