### PR TITLE
[InstCombine] Fold copysign(floor(fabs(X)), X) to trunc(X)

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3116,6 +3116,12 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
     if (match(Mag, m_FAbs(m_Value(X))) || match(Mag, m_FNeg(m_Value(X))))
       return replaceOperand(*II, 0, X);
 
+    // copysign(floor(fabs(X)), X) --> trunc(X)
+    if (match(Mag, m_Intrinsic<Intrinsic::floor>(m_FAbs(m_Specific(Sign))))) {
+      Value *Trunc = Builder.CreateUnaryIntrinsic(Intrinsic::trunc, Sign, II);
+      return replaceInstUsesWith(*II, Trunc);
+    }
+
     Type *SignEltTy = Sign->getType()->getScalarType();
 
     Value *CastSrc;

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3116,14 +3116,13 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
     if (match(Mag, m_FAbs(m_Value(X))) || match(Mag, m_FNeg(m_Value(X))))
       return replaceOperand(*II, 0, X);
 
-    // copysign(floor(fabs(X)), X) --> trunc(X)
-    // Requires nnan: for NaN X the source returns a NaN with X's sign bit
-    // preserved (via copysign), but trunc(X) may return any NaN, making the
-    // target more undefined.
-    if (II->hasNoNaNs() &&
-        match(Mag, m_Intrinsic<Intrinsic::floor>(m_FAbs(m_Specific(Sign))))) {
+    // copysign(floor(fabs(X)), X) --> copysign(trunc(X), X)
+    // copysign ignores the sign bit of its magnitude argument (implicit fabs),
+    // so replacing floor(fabs(X)) with trunc(X) is correct for all inputs
+    // including NaN without requiring nnan.
+    if (match(Mag, m_Intrinsic<Intrinsic::floor>(m_FAbs(m_Specific(Sign))))) {
       Value *Trunc = Builder.CreateUnaryIntrinsic(Intrinsic::trunc, Sign, II);
-      return replaceInstUsesWith(*II, Trunc);
+      return replaceOperand(*II, 0, Trunc);
     }
 
     Type *SignEltTy = Sign->getType()->getScalarType();

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3117,7 +3117,11 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
       return replaceOperand(*II, 0, X);
 
     // copysign(floor(fabs(X)), X) --> trunc(X)
-    if (match(Mag, m_Intrinsic<Intrinsic::floor>(m_FAbs(m_Specific(Sign))))) {
+    // Requires nnan: for NaN X the source returns a NaN with X's sign bit
+    // preserved (via copysign), but trunc(X) may return any NaN, making the
+    // target more undefined.
+    if (II->hasNoNaNs() &&
+        match(Mag, m_Intrinsic<Intrinsic::floor>(m_FAbs(m_Specific(Sign))))) {
       Value *Trunc = Builder.CreateUnaryIntrinsic(Intrinsic::trunc, Sign, II);
       return replaceInstUsesWith(*II, Trunc);
     }

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3119,12 +3119,11 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
     // copysign(floor(fabs(X)), X) --> copysign(trunc(X), X)
     // copysign ignores the sign bit of its magnitude argument (implicit fabs),
     // so replacing floor(fabs(X)) with trunc(X) is correct for all inputs
-    // including NaN without requiring nnan. The m_FAbs ensures the floor arg
-    // is non-negative; stripSignOnlyFPOps handles sign variants inside fabs
-    // such as fabs(copysign(X,Y)).
+    // including NaN without requiring nnan. The m_FAbs match also ensures
+    // the floor argument is non-negative, so floor == trunc.
     Value *FAbsArg;
     if (match(Mag, m_Intrinsic<Intrinsic::floor>(m_FAbs(m_Value(FAbsArg)))) &&
-        stripSignOnlyFPOps(FAbsArg) == Sign) {
+        FAbsArg == Sign) {
       Value *Trunc = Builder.CreateUnaryIntrinsic(Intrinsic::trunc, Sign, II);
       return replaceOperand(*II, 0, Trunc);
     }

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3119,8 +3119,11 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
     // copysign(floor(fabs(X)), X) --> copysign(trunc(X), X)
     // copysign ignores the sign bit of its magnitude argument (implicit fabs),
     // so replacing floor(fabs(X)) with trunc(X) is correct for all inputs
-    // including NaN without requiring nnan.
-    if (match(Mag, m_Intrinsic<Intrinsic::floor>(m_FAbs(m_Specific(Sign))))) {
+    // including NaN without requiring nnan. Use stripSignOnlyFPOps inside the
+    // fabs to also handle fabs(fneg(X)) and fabs(copysign(X,Y)) patterns.
+    Value *FAbsArg;
+    if (match(Mag, m_Intrinsic<Intrinsic::floor>(m_FAbs(m_Value(FAbsArg)))) &&
+        stripSignOnlyFPOps(FAbsArg) == Sign) {
       Value *Trunc = Builder.CreateUnaryIntrinsic(Intrinsic::trunc, Sign, II);
       return replaceOperand(*II, 0, Trunc);
     }

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3119,8 +3119,9 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
     // copysign(floor(fabs(X)), X) --> copysign(trunc(X), X)
     // copysign ignores the sign bit of its magnitude argument (implicit fabs),
     // so replacing floor(fabs(X)) with trunc(X) is correct for all inputs
-    // including NaN without requiring nnan. Use stripSignOnlyFPOps inside the
-    // fabs to also handle fabs(fneg(X)) and fabs(copysign(X,Y)) patterns.
+    // including NaN without requiring nnan. The m_FAbs ensures the floor arg
+    // is non-negative; stripSignOnlyFPOps handles sign variants inside fabs
+    // such as fabs(copysign(X,Y)).
     Value *FAbsArg;
     if (match(Mag, m_Intrinsic<Intrinsic::floor>(m_FAbs(m_Value(FAbsArg)))) &&
         stripSignOnlyFPOps(FAbsArg) == Sign) {

--- a/llvm/test/Transforms/InstCombine/copysign.ll
+++ b/llvm/test/Transforms/InstCombine/copysign.ll
@@ -348,6 +348,33 @@ define double @copysign_floor_fabs_to_trunc_fmf(double %x) {
   ret double %result
 }
 
+; Fold applies without any FMF -- copysign's implicit fabs handles NaN.
+define double @copysign_floor_fabs_to_trunc_no_fmf(double %x) {
+; CHECK-LABEL: @copysign_floor_fabs_to_trunc_no_fmf(
+; CHECK-NEXT:    [[RESULT:%.*]] = call double @llvm.trunc.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[RESULT1:%.*]] = call double @llvm.copysign.f64(double [[RESULT]], double [[X]])
+; CHECK-NEXT:    ret double [[RESULT1]]
+;
+  %abs = call double @llvm.fabs.f64(double %x)
+  %fl = call double @llvm.floor.f64(double %abs)
+  %result = call double @llvm.copysign.f64(double %fl, double %x)
+  ret double %result
+}
+
+; stripSignOnlyFPOps folds fabs(fneg(X)) inside floor.
+define double @copysign_floor_fabs_fneg_to_trunc(double %x) {
+; CHECK-LABEL: @copysign_floor_fabs_fneg_to_trunc(
+; CHECK-NEXT:    [[RESULT:%.*]] = call double @llvm.trunc.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[RESULT1:%.*]] = call double @llvm.copysign.f64(double [[RESULT]], double [[X]])
+; CHECK-NEXT:    ret double [[RESULT1]]
+;
+  %neg = fneg double %x
+  %abs = call double @llvm.fabs.f64(double %neg)
+  %fl = call double @llvm.floor.f64(double %abs)
+  %result = call double @llvm.copysign.f64(double %fl, double %x)
+  ret double %result
+}
+
 ; Negative test: sign argument differs from fabs argument -- must not fold.
 define double @copysign_floor_fabs_no_fold_different_sign(double %x, double %y) {
 ; CHECK-LABEL: @copysign_floor_fabs_no_fold_different_sign(

--- a/llvm/test/Transforms/InstCombine/copysign.ll
+++ b/llvm/test/Transforms/InstCombine/copysign.ll
@@ -295,38 +295,38 @@ define <2 x bfloat> @copysign_simplify_demanded_bits_sign_bitcast_not_int_vec(<2
   ret <2 x bfloat> %result
 }
 
-; copysign(floor(fabs(X)), X) --> trunc(X)
+; copysign(floor(fabs(X)), X) --> trunc(X)  (requires nnan)
 
 define double @copysign_floor_fabs_to_trunc_f64(double %x) {
 ; CHECK-LABEL: @copysign_floor_fabs_to_trunc_f64(
-; CHECK-NEXT:    [[RESULT:%.*]] = call double @llvm.trunc.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nnan double @llvm.trunc.f64(double [[X:%.*]])
 ; CHECK-NEXT:    ret double [[RESULT]]
 ;
   %abs = call double @llvm.fabs.f64(double %x)
   %fl = call double @llvm.floor.f64(double %abs)
-  %result = call double @llvm.copysign.f64(double %fl, double %x)
+  %result = call nnan double @llvm.copysign.f64(double %fl, double %x)
   ret double %result
 }
 
 define float @copysign_floor_fabs_to_trunc_f32(float %x) {
 ; CHECK-LABEL: @copysign_floor_fabs_to_trunc_f32(
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.trunc.f32(float [[X:%.*]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.trunc.f32(float [[X:%.*]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %abs = call float @llvm.fabs.f32(float %x)
   %fl = call float @llvm.floor.f32(float %abs)
-  %result = call float @llvm.copysign.f32(float %fl, float %x)
+  %result = call nnan float @llvm.copysign.f32(float %fl, float %x)
   ret float %result
 }
 
 define <3 x double> @copysign_floor_fabs_to_trunc_vec(<3 x double> %x) {
 ; CHECK-LABEL: @copysign_floor_fabs_to_trunc_vec(
-; CHECK-NEXT:    [[RESULT:%.*]] = call <3 x double> @llvm.trunc.v3f64(<3 x double> [[X:%.*]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nnan <3 x double> @llvm.trunc.v3f64(<3 x double> [[X:%.*]])
 ; CHECK-NEXT:    ret <3 x double> [[RESULT]]
 ;
   %abs = call <3 x double> @llvm.fabs.v3f64(<3 x double> %x)
   %fl = call <3 x double> @llvm.floor.v3f64(<3 x double> %abs)
-  %result = call <3 x double> @llvm.copysign.v3f64(<3 x double> %fl, <3 x double> %x)
+  %result = call nnan <3 x double> @llvm.copysign.v3f64(<3 x double> %fl, <3 x double> %x)
   ret <3 x double> %result
 }
 
@@ -339,6 +339,20 @@ define double @copysign_floor_fabs_to_trunc_fmf(double %x) {
   %abs = call double @llvm.fabs.f64(double %x)
   %fl = call double @llvm.floor.f64(double %abs)
   %result = call nnan ninf double @llvm.copysign.f64(double %fl, double %x)
+  ret double %result
+}
+
+; Negative test: missing nnan -- NaN inputs would give different sign bits.
+define double @copysign_floor_fabs_no_fold_no_nnan(double %x) {
+; CHECK-LABEL: @copysign_floor_fabs_no_fold_no_nnan(
+; CHECK-NEXT:    [[ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[FL:%.*]] = call double @llvm.floor.f64(double [[ABS]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call double @llvm.copysign.f64(double [[FL]], double [[X:%.*]])
+; CHECK-NEXT:    ret double [[RESULT]]
+;
+  %abs = call double @llvm.fabs.f64(double %x)
+  %fl = call double @llvm.floor.f64(double %abs)
+  %result = call double @llvm.copysign.f64(double %fl, double %x)
   ret double %result
 }
 

--- a/llvm/test/Transforms/InstCombine/copysign.ll
+++ b/llvm/test/Transforms/InstCombine/copysign.ll
@@ -2,9 +2,18 @@
 ; RUN: opt -S -passes=instcombine < %s | FileCheck %s
 
 declare float @llvm.fabs.f32(float)
+declare float @llvm.floor.f32(float)
+declare float @llvm.trunc.f32(float)
 declare float @llvm.copysign.f32(float, float)
 declare float @llvm.maxnum.f32(float, float)
+declare double @llvm.fabs.f64(double)
+declare double @llvm.floor.f64(double)
+declare double @llvm.trunc.f64(double)
+declare double @llvm.copysign.f64(double, double)
 declare <3 x double> @llvm.copysign.v3f64(<3 x double>, <3 x double>)
+declare <3 x double> @llvm.fabs.v3f64(<3 x double>)
+declare <3 x double> @llvm.floor.v3f64(<3 x double>)
+declare <3 x double> @llvm.trunc.v3f64(<3 x double>)
 
 define float @positive_sign_arg(float %x) {
 ; CHECK-LABEL: @positive_sign_arg(
@@ -284,4 +293,65 @@ define <2 x bfloat> @copysign_simplify_demanded_bits_sign_bitcast_not_int_vec(<2
   %cast.sign = bitcast <2 x half> %sign to <2 x bfloat>
   %result = call <2 x bfloat> @llvm.copysign.v2bf16(<2 x bfloat> %mag, <2 x bfloat> %cast.sign)
   ret <2 x bfloat> %result
+}
+
+; copysign(floor(fabs(X)), X) --> trunc(X)
+
+define double @copysign_floor_fabs_to_trunc_f64(double %x) {
+; CHECK-LABEL: @copysign_floor_fabs_to_trunc_f64(
+; CHECK-NEXT:    [[RESULT:%.*]] = call double @llvm.trunc.f64(double [[X:%.*]])
+; CHECK-NEXT:    ret double [[RESULT]]
+;
+  %abs = call double @llvm.fabs.f64(double %x)
+  %fl = call double @llvm.floor.f64(double %abs)
+  %result = call double @llvm.copysign.f64(double %fl, double %x)
+  ret double %result
+}
+
+define float @copysign_floor_fabs_to_trunc_f32(float %x) {
+; CHECK-LABEL: @copysign_floor_fabs_to_trunc_f32(
+; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.trunc.f32(float [[X:%.*]])
+; CHECK-NEXT:    ret float [[RESULT]]
+;
+  %abs = call float @llvm.fabs.f32(float %x)
+  %fl = call float @llvm.floor.f32(float %abs)
+  %result = call float @llvm.copysign.f32(float %fl, float %x)
+  ret float %result
+}
+
+define <3 x double> @copysign_floor_fabs_to_trunc_vec(<3 x double> %x) {
+; CHECK-LABEL: @copysign_floor_fabs_to_trunc_vec(
+; CHECK-NEXT:    [[RESULT:%.*]] = call <3 x double> @llvm.trunc.v3f64(<3 x double> [[X:%.*]])
+; CHECK-NEXT:    ret <3 x double> [[RESULT]]
+;
+  %abs = call <3 x double> @llvm.fabs.v3f64(<3 x double> %x)
+  %fl = call <3 x double> @llvm.floor.v3f64(<3 x double> %abs)
+  %result = call <3 x double> @llvm.copysign.v3f64(<3 x double> %fl, <3 x double> %x)
+  ret <3 x double> %result
+}
+
+; FMF flags from copysign propagate to the resulting trunc.
+define double @copysign_floor_fabs_to_trunc_fmf(double %x) {
+; CHECK-LABEL: @copysign_floor_fabs_to_trunc_fmf(
+; CHECK-NEXT:    [[RESULT:%.*]] = call nnan ninf double @llvm.trunc.f64(double [[X:%.*]])
+; CHECK-NEXT:    ret double [[RESULT]]
+;
+  %abs = call double @llvm.fabs.f64(double %x)
+  %fl = call double @llvm.floor.f64(double %abs)
+  %result = call nnan ninf double @llvm.copysign.f64(double %fl, double %x)
+  ret double %result
+}
+
+; Negative test: sign argument differs from fabs argument -- must not fold.
+define double @copysign_floor_fabs_no_fold_different_sign(double %x, double %y) {
+; CHECK-LABEL: @copysign_floor_fabs_no_fold_different_sign(
+; CHECK-NEXT:    [[ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[FL:%.*]] = call double @llvm.floor.f64(double [[ABS]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call double @llvm.copysign.f64(double [[FL]], double [[Y:%.*]])
+; CHECK-NEXT:    ret double [[RESULT]]
+;
+  %abs = call double @llvm.fabs.f64(double %x)
+  %fl = call double @llvm.floor.f64(double %abs)
+  %result = call double @llvm.copysign.f64(double %fl, double %y)
+  ret double %result
 }

--- a/llvm/test/Transforms/InstCombine/copysign.ll
+++ b/llvm/test/Transforms/InstCombine/copysign.ll
@@ -361,16 +361,32 @@ define double @copysign_floor_fabs_to_trunc_no_fmf(double %x) {
   ret double %result
 }
 
-; stripSignOnlyFPOps folds fabs(fneg(X)) inside floor.
-define double @copysign_floor_fabs_fneg_to_trunc(double %x) {
-; CHECK-LABEL: @copysign_floor_fabs_fneg_to_trunc(
+; Fold applies when fabs wraps a sign-only op: fabs(copysign(X, Y)).
+define double @copysign_floor_fabs_copysign_to_trunc(double %x, double %y) {
+; CHECK-LABEL: @copysign_floor_fabs_copysign_to_trunc(
 ; CHECK-NEXT:    [[RESULT:%.*]] = call double @llvm.trunc.f64(double [[X:%.*]])
 ; CHECK-NEXT:    [[RESULT1:%.*]] = call double @llvm.copysign.f64(double [[RESULT]], double [[X]])
 ; CHECK-NEXT:    ret double [[RESULT1]]
 ;
-  %neg = fneg double %x
-  %abs = call double @llvm.fabs.f64(double %neg)
+  %cs = call double @llvm.copysign.f64(double %x, double %y)
+  %abs = call double @llvm.fabs.f64(double %cs)
   %fl = call double @llvm.floor.f64(double %abs)
+  %result = call double @llvm.copysign.f64(double %fl, double %x)
+  ret double %result
+}
+
+; Negative test: fneg(fabs(X)) is not non-negative so floor differs from trunc.
+define double @copysign_floor_fneg_fabs_no_fold(double %x) {
+; CHECK-LABEL: @copysign_floor_fneg_fabs_no_fold(
+; CHECK-NEXT:    [[ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[FNEG:%.*]] = fneg double [[ABS]]
+; CHECK-NEXT:    [[FL:%.*]] = call double @llvm.floor.f64(double [[FNEG]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call double @llvm.copysign.f64(double [[FL]], double [[X]])
+; CHECK-NEXT:    ret double [[RESULT]]
+;
+  %abs = call double @llvm.fabs.f64(double %x)
+  %fneg = fneg double %abs
+  %fl = call double @llvm.floor.f64(double %fneg)
   %result = call double @llvm.copysign.f64(double %fl, double %x)
   ret double %result
 }

--- a/llvm/test/Transforms/InstCombine/copysign.ll
+++ b/llvm/test/Transforms/InstCombine/copysign.ll
@@ -295,64 +295,56 @@ define <2 x bfloat> @copysign_simplify_demanded_bits_sign_bitcast_not_int_vec(<2
   ret <2 x bfloat> %result
 }
 
-; copysign(floor(fabs(X)), X) --> trunc(X)  (requires nnan)
+; copysign(floor(fabs(X)), X) --> copysign(trunc(X), X)
+; copysign ignores the sign of its magnitude arg, so trunc(X) is equivalent
+; to floor(fabs(X)) for the magnitude. Valid for all inputs including NaN.
 
 define double @copysign_floor_fabs_to_trunc_f64(double %x) {
 ; CHECK-LABEL: @copysign_floor_fabs_to_trunc_f64(
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan double @llvm.trunc.f64(double [[X:%.*]])
-; CHECK-NEXT:    ret double [[RESULT]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call double @llvm.trunc.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[RESULT1:%.*]] = call double @llvm.copysign.f64(double [[RESULT]], double [[X]])
+; CHECK-NEXT:    ret double [[RESULT1]]
 ;
   %abs = call double @llvm.fabs.f64(double %x)
   %fl = call double @llvm.floor.f64(double %abs)
-  %result = call nnan double @llvm.copysign.f64(double %fl, double %x)
+  %result = call double @llvm.copysign.f64(double %fl, double %x)
   ret double %result
 }
 
 define float @copysign_floor_fabs_to_trunc_f32(float %x) {
 ; CHECK-LABEL: @copysign_floor_fabs_to_trunc_f32(
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.trunc.f32(float [[X:%.*]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.trunc.f32(float [[X:%.*]])
+; CHECK-NEXT:    [[RESULT1:%.*]] = call float @llvm.copysign.f32(float [[RESULT]], float [[X]])
+; CHECK-NEXT:    ret float [[RESULT1]]
 ;
   %abs = call float @llvm.fabs.f32(float %x)
   %fl = call float @llvm.floor.f32(float %abs)
-  %result = call nnan float @llvm.copysign.f32(float %fl, float %x)
+  %result = call float @llvm.copysign.f32(float %fl, float %x)
   ret float %result
 }
 
 define <3 x double> @copysign_floor_fabs_to_trunc_vec(<3 x double> %x) {
 ; CHECK-LABEL: @copysign_floor_fabs_to_trunc_vec(
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan <3 x double> @llvm.trunc.v3f64(<3 x double> [[X:%.*]])
-; CHECK-NEXT:    ret <3 x double> [[RESULT]]
+; CHECK-NEXT:    [[RESULT:%.*]] = call <3 x double> @llvm.trunc.v3f64(<3 x double> [[X:%.*]])
+; CHECK-NEXT:    [[RESULT1:%.*]] = call <3 x double> @llvm.copysign.v3f64(<3 x double> [[RESULT]], <3 x double> [[X]])
+; CHECK-NEXT:    ret <3 x double> [[RESULT1]]
 ;
   %abs = call <3 x double> @llvm.fabs.v3f64(<3 x double> %x)
   %fl = call <3 x double> @llvm.floor.v3f64(<3 x double> %abs)
-  %result = call nnan <3 x double> @llvm.copysign.v3f64(<3 x double> %fl, <3 x double> %x)
+  %result = call <3 x double> @llvm.copysign.v3f64(<3 x double> %fl, <3 x double> %x)
   ret <3 x double> %result
 }
 
-; FMF flags from copysign propagate to the resulting trunc.
+; FMF flags from copysign propagate to the resulting instructions.
 define double @copysign_floor_fabs_to_trunc_fmf(double %x) {
 ; CHECK-LABEL: @copysign_floor_fabs_to_trunc_fmf(
 ; CHECK-NEXT:    [[RESULT:%.*]] = call nnan ninf double @llvm.trunc.f64(double [[X:%.*]])
-; CHECK-NEXT:    ret double [[RESULT]]
+; CHECK-NEXT:    [[RESULT1:%.*]] = call nnan ninf double @llvm.copysign.f64(double [[RESULT]], double [[X]])
+; CHECK-NEXT:    ret double [[RESULT1]]
 ;
   %abs = call double @llvm.fabs.f64(double %x)
   %fl = call double @llvm.floor.f64(double %abs)
   %result = call nnan ninf double @llvm.copysign.f64(double %fl, double %x)
-  ret double %result
-}
-
-; Negative test: missing nnan -- NaN inputs would give different sign bits.
-define double @copysign_floor_fabs_no_fold_no_nnan(double %x) {
-; CHECK-LABEL: @copysign_floor_fabs_no_fold_no_nnan(
-; CHECK-NEXT:    [[ABS:%.*]] = call double @llvm.fabs.f64(double [[X:%.*]])
-; CHECK-NEXT:    [[FL:%.*]] = call double @llvm.floor.f64(double [[ABS]])
-; CHECK-NEXT:    [[RESULT:%.*]] = call double @llvm.copysign.f64(double [[FL]], double [[X:%.*]])
-; CHECK-NEXT:    ret double [[RESULT]]
-;
-  %abs = call double @llvm.fabs.f64(double %x)
-  %fl = call double @llvm.floor.f64(double %abs)
-  %result = call double @llvm.copysign.f64(double %fl, double %x)
   ret double %result
 }
 


### PR DESCRIPTION
Fixes #200519.

Adds an InstCombine fold for the pattern `copysign(floor(fabs(X)), X) --> trunc(X)`.