### PR TITLE
[LLVM][IR] Make sure that DILabel's line is always printed

### DIFF
--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -2115,7 +2115,7 @@ static void writeDILocation(raw_ostream &Out, const DILocation *DL,
   Out << "!DILocation(";
   MDFieldPrinter Printer(Out, WriterCtx);
   // Always output the line, since 0 is a relevant and important value for it.
-  Printer.printInt("line", DL->getLine(), /*ShouldSkipZero=*/false);
+  Printer.printInt("line", DL->getLine(), /* ShouldSkipZero */ false);
   Printer.printInt("column", DL->getColumn());
   Printer.printMetadata("scope", DL->getRawScope(), /* ShouldSkipNull */ false);
   Printer.printMetadata("inlinedAt", DL->getRawInlinedAt());

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -2115,7 +2115,7 @@ static void writeDILocation(raw_ostream &Out, const DILocation *DL,
   Out << "!DILocation(";
   MDFieldPrinter Printer(Out, WriterCtx);
   // Always output the line, since 0 is a relevant and important value for it.
-  Printer.printInt("line", DL->getLine(), /* ShouldSkipZero */ false);
+  Printer.printInt("line", DL->getLine(), /*ShouldSkipZero=*/false);
   Printer.printInt("column", DL->getColumn());
   Printer.printMetadata("scope", DL->getRawScope(), /* ShouldSkipNull */ false);
   Printer.printMetadata("inlinedAt", DL->getRawInlinedAt());
@@ -2626,7 +2626,7 @@ static void writeDILabel(raw_ostream &Out, const DILabel *N,
   Printer.printMetadata("scope", N->getRawScope(), /* ShouldSkipNull */ false);
   Printer.printString("name", N->getName());
   Printer.printMetadata("file", N->getRawFile());
-  Printer.printInt("line", N->getLine());
+  Printer.printInt("line", N->getLine(), /* ShouldSkipZero */ false);
   Printer.printInt("column", N->getColumn());
   Printer.printBool("isArtificial", N->isArtificial(), false);
   if (N->getCoroSuspendIdx())

--- a/llvm/test/Assembler/dilabel.ll
+++ b/llvm/test/Assembler/dilabel.ll
@@ -1,0 +1,22 @@
+; RUN: llvm-as < %s | llvm-dis | llvm-as | llvm-dis | FileCheck %s
+
+; CHECK: !named = !{!0, ![[FOO:[0-9]+]], ![[BAR:[0-9]+]]}
+!named = !{!0, !1, !2}
+
+!llvm.module.flags = !{!3}
+!llvm.dbg.cu = !{!4}
+
+; CHECK-DAG: ![[FOO]] = !DILabel(scope: !0, name: "foo", file: ![[FILE:[0-9]+]], line: 7)
+; CHECK-DAG: ![[BAR]] = !DILabel(scope: !0, name: "bar", file: ![[FILE]], line: 0)
+!0 = distinct !DISubprogram(unit: !4, type: !5)
+!1 = !DILabel(scope: !0, name: "foo", file: !6, line: 7)
+!2 = !DILabel(scope: !0, name: "bar", file: !6, line: 0)
+
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = distinct !DICompileUnit(language: DW_LANG_C99, producer: "clang",
+                             file: !6,
+                             isOptimized: true, flags: "-O2",
+                             splitDebugFilename: "abc.debug", emissionKind: 2)
+!5 = !DISubroutineType(types: !7)
+!6 = !DIFile(filename: "path/to/file", directory: "/path/to/dir")
+!7 = !{null}


### PR DESCRIPTION
This commit ensures that the textual IR of the DILabel always contains the `line` information. This is required as the absence of a line causes a parsing failure, i.e., this change fixes the print + parse roundtrip.