### PR TITLE
[Docs] Update coding standard for TD files

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,3 @@
+# Do not attempt to format .td files; we have too many formatting needs across
+# the various files to allow automatic formatting.
+**/*.td

--- a/clang/.clang-format-ignore
+++ b/clang/.clang-format-ignore
@@ -1,3 +1,0 @@
-# Do not attempt to format .td files; we have too many formatting needs across
-# the various files to allow automatic formatting.
-**/*.td

--- a/llvm/docs/CodingStandards.rst
+++ b/llvm/docs/CodingStandards.rst
@@ -463,7 +463,7 @@ for it (vs something else, like 90 columns).
 However, documentation files are not source code files, and instead of fitting into 80 columns, they must be formatted to one sentence per line.
 This way a change in the middle of a paragraph doesn't cause unnecessary changes in subsequent lines, making it easier for reviewers to see what has changed when documentation is updated.
 
-Another exception are TableGen files (*.td).
+Another exception are TableGen files (.td).
 There are no tools that can parse, verify and edit them to match our coding style, including clang-format, so they are excluded from this limit.
 It is still good practice to try to fit them into 80 columns, but it is not a requirement.
 As with other changes, if you patch a TD file, do not reformat the entire file, but only the lines you are changing.

--- a/llvm/docs/CodingStandards.rst
+++ b/llvm/docs/CodingStandards.rst
@@ -463,8 +463,8 @@ for it (vs something else, like 90 columns).
 However, documentation files are not source code files, and instead of fitting into 80 columns, they must be formatted to one sentence per line.
 This way a change in the middle of a paragraph doesn't cause unnecessary changes in subsequent lines, making it easier for reviewers to see what has changed when documentation is updated.
 
-Another exception are table gen files.
-There are no tools that can parse, verify and edit them to match our coding style, so they are excluded from this limit.
+Another exception are TableGen files (*.td).
+There are no tools that can parse, verify and edit them to match our coding style, including clang-format, so they are excluded from this limit.
 It is still good practice to try to fit them into 80 columns, but it is not a requirement.
 As with other changes, if you patch a TD file, do not reformat the entire file, but only the lines you are changing.
 

--- a/llvm/docs/CodingStandards.rst
+++ b/llvm/docs/CodingStandards.rst
@@ -463,6 +463,15 @@ for it (vs something else, like 90 columns).
 However, documentation files are not source code files, and instead of fitting into 80 columns, they must be formatted to one sentence per line.
 This way a change in the middle of a paragraph doesn't cause unnecessary changes in subsequent lines, making it easier for reviewers to see what has changed when documentation is updated.
 
+Another exception are table gen files.
+There are no tools that can parse, verify and edit them to match our coding style, so they are excluded from this limit.
+It is still good practice to try to fit them into 80 columns, but it is not a requirement.
+As with other changes, if you patch a TD file, do not reformat the entire file, but only the lines you are changing.
+
+If your reformatting is causing unnecessary changes in subsequent lines, please just follow the existing formatting.
+Unecessary changes in TD files cause unnecessary churn in the file history and force recompilation of many unnecessary files.
+It also causes unnecessary changes in forks working on the same TD files, which makes it harder to rebase and merge later.
+
 Whitespace
 ^^^^^^^^^^
 


### PR DESCRIPTION
This PR proposes an update to the coding standards document to make explicit that we do not want unnecessary formatting changes to TD files.

This is in response to this merged PR (#199346), which lead to this RFC (https://discourse.llvm.org/t/80-column-limit-for-td-files/90950/).