### PR TITLE
[CIR] DataMemberAttr: replace flat index with GEP-style path

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -578,8 +578,9 @@ def CIR_DataMemberAttr : CIR_ValueLikeAttr<"DataMember", "data_member"> {
 
   let genVerifyDecl = 1;
 
-  // Printing and parsing available in CIRAttrs.cpp
-  let hasCustomAssemblyFormat = 1;
+  let assemblyFormat = [{
+    `<` custom<DataMemberPath>($member_path) `>`
+  }];
 
   let extraClassDeclaration = [{
     bool isNullPtr() const { return !getMemberPath(); }

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -538,45 +538,54 @@ def CIR_DataMemberAttr : CIR_ValueLikeAttr<"DataMember", "data_member"> {
   let parameters = (ins AttributeSelfTypeParameter<
                             "", "cir::DataMemberType">:$type,
                         OptionalParameter<
-                            "std::optional<unsigned>">:$member_index);
+                            "mlir::DenseI32ArrayAttr">:$member_path);
   let description = [{
     A data member attribute is a literal attribute that represents a constant
     pointer-to-data-member value.
 
-    The `member_index` parameter represents the index of the pointed-to member
-    within its containing record. It is an optional parameter; lack of this
-    parameter indicates a null pointer-to-data-member value.
+    The `member_path` parameter is a GEP-like sequence of field indices
+    navigating from `classTy` down to the pointed-to member.  An absent
+    `member_path` represents a null pointer-to-data-member.
 
-    Example:
+    Examples:
     ```
-    #ptr = #cir.data_member<1> : !cir.data_member<!s32i in !rec_22Point22>
+    // int Point::*p = &Point::z  (z is field 2)
+    #cir.data_member<[2]> : !cir.data_member<!s32i in !rec_Point>
 
-    #null = #cir.data_member<null> : !cir.data_member<!s32i in !rec_22Point22>
+    // int Derived::*p = &Derived::x  (Base subobject at [0], x at [0])
+    #cir.data_member<[0, 0]> : !cir.data_member<!s32i in !rec_Derived>
+
+    // null
+    #cir.data_member<null> : !cir.data_member<!s32i in !rec_Point>
     ```
   }];
 
   let builders = [
+    // Null pointer-to-data-member.
     AttrBuilderWithInferredContext<(ins "cir::DataMemberType":$type), [{
-      return $_get(type.getContext(), type, std::nullopt);
+      return $_get(type.getContext(), type, mlir::DenseI32ArrayAttr{});
     }]>,
+    // Non-null pointer-to-data-member with an explicit field-index path.
     AttrBuilderWithInferredContext<(ins "cir::DataMemberType":$type,
-                                        "unsigned":$member_index), [{
-      return $_get(type.getContext(), type, member_index);
+                                       "llvm::ArrayRef<int32_t>":$path), [{
+      return $_get(type.getContext(), type,
+                   mlir::DenseI32ArrayAttr::get(type.getContext(), path));
     }]>,
   ];
 
-  // This attribute gets lowered during CXXABILowering
+  // This attribute gets lowered during CXXABILowering.
   let hasAttrToValueLowering = 0;
 
   let genVerifyDecl = 1;
 
-  let assemblyFormat = [{
-    `<` ($member_index^):(`null`)? `>`
-  }];
+  // Printing and parsing available in CIRAttrs.cpp
+  let hasCustomAssemblyFormat = 1;
 
   let extraClassDeclaration = [{
-    bool isNullPtr() const {
-      return !getMemberIndex().has_value();
+    bool isNullPtr() const { return !getMemberPath(); }
+    llvm::ArrayRef<int32_t> getPath() const {
+      assert(!isNullPtr() && "getPath() called on null data member pointer");
+      return getMemberPath().asArrayRef();
     }
   }];
 }

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -264,8 +264,8 @@ public:
   // ---------------------------
 
   cir::DataMemberAttr getDataMemberAttr(cir::DataMemberType ty,
-                                        unsigned memberIndex) {
-    return cir::DataMemberAttr::get(ty, memberIndex);
+                                        llvm::ArrayRef<int32_t> path) {
+    return cir::DataMemberAttr::get(ty, path);
   }
 
   cir::DataMemberAttr getNullDataMemberAttr(cir::DataMemberType ty) {

--- a/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
@@ -934,9 +934,14 @@ public:
     case CK_ToUnion:
     case CK_AddressSpaceConversion:
     case CK_ReinterpretMemberPointer:
+      cgm.errorNYI(e->getBeginLoc(), "ConstExprEmitter::VisitCastExpr");
+      return {};
+
     case CK_DerivedToBaseMemberPointer:
     case CK_BaseToDerivedMemberPointer:
-      cgm.errorNYI(e->getBeginLoc(), "ConstExprEmitter::VisitCastExpr");
+      // Return {} to let the APValue evaluator handle member pointer type
+      // conversions.  The APValue::MemberPointer case in tryEmitPrivate
+      // already builds the correct GEP path for cross-class member pointers.
       return {};
 
     case CK_LValueToRValue:
@@ -1951,12 +1956,6 @@ mlir::Attribute ConstantEmitter::tryEmitPrivate(const APValue &value,
     if (!memberDecl)
       return builder.getZeroInitAttr(cgm.convertType(destType));
 
-    if (value.isMemberPointerToDerivedMember()) {
-      cgm.errorNYI(
-          "ConstExprEmitter::tryEmitPrivate member pointer to derived member");
-      return {};
-    }
-
     if (auto const *cxxDecl = dyn_cast<CXXMethodDecl>(memberDecl)) {
       auto ty = mlir::cast<cir::MethodType>(cgm.convertType(destType));
       if (cxxDecl->isVirtual())
@@ -1968,9 +1967,14 @@ mlir::Attribute ConstantEmitter::tryEmitPrivate(const APValue &value,
     }
 
     auto cirTy = mlir::cast<cir::DataMemberType>(cgm.convertType(destType));
-
     const auto *fieldDecl = cast<FieldDecl>(memberDecl);
-    return builder.getDataMemberAttr(cirTy, fieldDecl->getFieldIndex());
+    const auto *mpt = destType->castAs<MemberPointerType>();
+    const auto *destClass = mpt->getMostRecentCXXRecordDecl();
+    std::optional<llvm::SmallVector<int32_t>> path =
+        cgm.buildMemberPath(destClass, fieldDecl);
+    if (!path)
+      return {};
+    return builder.getDataMemberAttr(cirTy, *path);
   }
   case APValue::LValue:
     return ConstantLValueEmitter(*this, value, destType).tryEmit();

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2277,8 +2277,82 @@ mlir::Value CIRGenModule::emitMemberPointerConstant(const UnaryOperator *e) {
   // Otherwise, a member data pointer.
   auto ty = mlir::cast<cir::DataMemberType>(convertType(e->getType()));
   const auto *fieldDecl = cast<FieldDecl>(decl);
-  return cir::ConstantOp::create(
-      builder, loc, builder.getDataMemberAttr(ty, fieldDecl->getFieldIndex()));
+  const auto *mpt = e->getType()->castAs<MemberPointerType>();
+  const auto *destClass = mpt->getMostRecentCXXRecordDecl();
+  std::optional<llvm::SmallVector<int32_t>> path =
+      buildMemberPath(destClass, fieldDecl);
+  if (!path)
+    return {};
+  return cir::ConstantOp::create(builder, loc,
+                                 builder.getDataMemberAttr(ty, *path));
+}
+
+std::optional<llvm::SmallVector<int32_t>>
+CIRGenModule::buildMemberPath(const CXXRecordDecl *destClass,
+                              const FieldDecl *field) {
+  const auto *fieldParent = cast<CXXRecordDecl>(field->getParent());
+
+  const CIRGenRecordLayout &layout =
+      getTypes().getCIRGenRecordLayout(fieldParent);
+  int32_t fieldIdx;
+  if (fieldParent->isUnion()) {
+    // For unions, getCIRFieldNo always returns 0 for every union member (all
+    // members share offset 0 in the CIR record).  Use the declaration-order
+    // index to distinguish members with the same type at the same offset.
+    if (!layout.isZeroInitializable()) {
+      errorNYI(field->getLocation(),
+               "data member pointer for non-zero-initializable union");
+      return std::nullopt;
+    }
+    fieldIdx = static_cast<int32_t>(field->getFieldIndex());
+  } else {
+    fieldIdx = static_cast<int32_t>(layout.getCIRFieldNo(field));
+  }
+
+  llvm::SmallVector<int32_t> path;
+  if (fieldParent == destClass) {
+    path.push_back(fieldIdx);
+    return path;
+  }
+
+  // Field is declared in a base class — find the subobject chain.
+  // findBaseSubobjectPath accumulates in leaf-to-root order; reverse before
+  // appending fieldIdx to produce the root-to-leaf path.
+  if (!findBaseSubobjectPath(destClass, fieldParent, path))
+    return std::nullopt;
+  std::reverse(path.begin(), path.end());
+  path.push_back(fieldIdx);
+  return path;
+}
+
+bool CIRGenModule::findBaseSubobjectPath(const CXXRecordDecl *currentClass,
+                                         const CXXRecordDecl *targetClass,
+                                         llvm::SmallVectorImpl<int32_t> &path) {
+  const CIRGenRecordLayout &layout =
+      getTypes().getCIRGenRecordLayout(currentClass);
+
+  for (const CXXBaseSpecifier &base : currentClass->bases()) {
+    if (base.isVirtual()) {
+      errorNYI(base.getBeginLoc(), "data member pointer through virtual base");
+      return false;
+    }
+
+    const auto *baseDecl =
+        cast<CXXRecordDecl>(base.getType()->getAsRecordDecl());
+    auto baseFieldIdx =
+        static_cast<int32_t>(layout.getNonVirtualBaseCIRFieldNo(baseDecl));
+
+    if (baseDecl == targetClass) {
+      path.push_back(baseFieldIdx);
+      return true;
+    }
+
+    if (findBaseSubobjectPath(baseDecl, targetClass, path)) {
+      path.push_back(baseFieldIdx);
+      return true;
+    }
+  }
+  return false;
 }
 
 void CIRGenModule::emitDeclContext(const DeclContext *dc) {

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2303,8 +2303,6 @@ bool CIRGenModule::findFieldMemberPath(const CXXRecordDecl *currentClass,
       getTypes().getCIRGenRecordLayout(currentClass);
 
   for (const FieldDecl *fd : currentClass->fields()) {
-    if (fd->isBitField())
-      continue;
     if (fd != field)
       continue;
 

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2302,10 +2302,8 @@ bool CIRGenModule::findFieldMemberPath(const CXXRecordDecl *currentClass,
   const CIRGenRecordLayout &layout =
       getTypes().getCIRGenRecordLayout(currentClass);
 
-  for (const FieldDecl *fd : currentClass->fields()) {
-    if (fd != field)
-      continue;
-
+  // The field is declared directly in this class.
+  if (field->getParent() == currentClass) {
     int32_t fieldIdx;
     if (currentClass->isUnion()) {
       // For unions, getCIRFieldNo always returns 0 for every union member (all
@@ -2324,14 +2322,28 @@ bool CIRGenModule::findFieldMemberPath(const CXXRecordDecl *currentClass,
     return true;
   }
 
+  // Otherwise search the base subobjects.  A virtual base only blocks lowering
+  // when the field actually lives within it; a virtual base elsewhere in the
+  // hierarchy must not stop us from reaching a member through a non-virtual
+  // path.
   for (const CXXBaseSpecifier &base : currentClass->bases()) {
-    if (base.isVirtual()) {
-      errorNYI(base.getBeginLoc(), "data member pointer through virtual base");
-      return false;
-    }
-
     const auto *baseDecl =
         cast<CXXRecordDecl>(base.getType()->getAsRecordDecl());
+
+    if (base.isVirtual()) {
+      // A pointer to a data member that traverses a virtual base is ill-formed,
+      // so this guard only fires defensively if the member is reached through
+      // the virtual base.  An unrelated virtual base is skipped so it does not
+      // block members reached through a non-virtual path.
+      llvm::SmallVector<int32_t> discardedPath;
+      if (findFieldMemberPath(baseDecl, field, discardedPath)) {
+        errorNYI(field->getLocation(),
+                 "data member pointer through virtual base");
+        return false;
+      }
+      continue;
+    }
+
     auto baseFieldIdx =
         static_cast<int32_t>(layout.getNonVirtualBaseCIRFieldNo(baseDecl));
     path.push_back(baseFieldIdx);

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2290,46 +2290,41 @@ mlir::Value CIRGenModule::emitMemberPointerConstant(const UnaryOperator *e) {
 std::optional<llvm::SmallVector<int32_t>>
 CIRGenModule::buildMemberPath(const CXXRecordDecl *destClass,
                               const FieldDecl *field) {
-  const auto *fieldParent = cast<CXXRecordDecl>(field->getParent());
-
-  const CIRGenRecordLayout &layout =
-      getTypes().getCIRGenRecordLayout(fieldParent);
-  int32_t fieldIdx;
-  if (fieldParent->isUnion()) {
-    // For unions, getCIRFieldNo always returns 0 for every union member (all
-    // members share offset 0 in the CIR record).  Use the declaration-order
-    // index to distinguish members with the same type at the same offset.
-    if (!layout.isZeroInitializable()) {
-      errorNYI(field->getLocation(),
-               "data member pointer for non-zero-initializable union");
-      return std::nullopt;
-    }
-    fieldIdx = static_cast<int32_t>(field->getFieldIndex());
-  } else {
-    fieldIdx = static_cast<int32_t>(layout.getCIRFieldNo(field));
-  }
-
   llvm::SmallVector<int32_t> path;
-  if (fieldParent == destClass) {
-    path.push_back(fieldIdx);
-    return path;
-  }
-
-  // Field is declared in a base class — find the subobject chain.
-  // findBaseSubobjectPath accumulates in leaf-to-root order; reverse before
-  // appending fieldIdx to produce the root-to-leaf path.
-  if (!findBaseSubobjectPath(destClass, fieldParent, path))
+  if (!findFieldMemberPath(destClass, field, path))
     return std::nullopt;
-  std::reverse(path.begin(), path.end());
-  path.push_back(fieldIdx);
   return path;
 }
 
-bool CIRGenModule::findBaseSubobjectPath(const CXXRecordDecl *currentClass,
-                                         const CXXRecordDecl *targetClass,
-                                         llvm::SmallVectorImpl<int32_t> &path) {
+bool CIRGenModule::findFieldMemberPath(const CXXRecordDecl *currentClass,
+                                       const FieldDecl *field,
+                                       llvm::SmallVectorImpl<int32_t> &path) {
   const CIRGenRecordLayout &layout =
       getTypes().getCIRGenRecordLayout(currentClass);
+
+  for (const FieldDecl *fd : currentClass->fields()) {
+    if (fd->isBitField())
+      continue;
+    if (fd != field)
+      continue;
+
+    int32_t fieldIdx;
+    if (currentClass->isUnion()) {
+      // For unions, getCIRFieldNo always returns 0 for every union member (all
+      // members share offset 0 in the CIR record).  Use the declaration-order
+      // index to distinguish members with the same type at the same offset.
+      if (!layout.isZeroInitializable()) {
+        errorNYI(field->getLocation(),
+                 "data member pointer for non-zero-initializable union");
+        return false;
+      }
+      fieldIdx = static_cast<int32_t>(field->getFieldIndex());
+    } else {
+      fieldIdx = static_cast<int32_t>(layout.getCIRFieldNo(field));
+    }
+    path.push_back(fieldIdx);
+    return true;
+  }
 
   for (const CXXBaseSpecifier &base : currentClass->bases()) {
     if (base.isVirtual()) {
@@ -2341,16 +2336,10 @@ bool CIRGenModule::findBaseSubobjectPath(const CXXRecordDecl *currentClass,
         cast<CXXRecordDecl>(base.getType()->getAsRecordDecl());
     auto baseFieldIdx =
         static_cast<int32_t>(layout.getNonVirtualBaseCIRFieldNo(baseDecl));
-
-    if (baseDecl == targetClass) {
-      path.push_back(baseFieldIdx);
+    path.push_back(baseFieldIdx);
+    if (findFieldMemberPath(baseDecl, field, path))
       return true;
-    }
-
-    if (findBaseSubobjectPath(baseDecl, targetClass, path)) {
-      path.push_back(baseFieldIdx);
-      return true;
-    }
+    path.pop_back();
   }
   return false;
 }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -935,12 +935,11 @@ public:
   void addGlobalAnnotations(const clang::ValueDecl *d, mlir::Operation *gv);
 
 private:
-  /// Recursively find the chain of non-virtual base subobject field indices
-  /// from \p currentClass to \p targetClass.  Appends indices in leaf-to-root
-  /// order; the caller must reverse before use.
-  bool findBaseSubobjectPath(const CXXRecordDecl *currentClass,
-                             const CXXRecordDecl *targetClass,
-                             llvm::SmallVectorImpl<int32_t> &path);
+  /// Search \p currentClass and its non-virtual base subobjects for \p field,
+  /// appending CIR field indices along the path from \p currentClass.
+  bool findFieldMemberPath(const CXXRecordDecl *currentClass,
+                           const FieldDecl *field,
+                           llvm::SmallVectorImpl<int32_t> &path);
 
   // An ordered map of canonical GlobalDecls to their mangled names.
   llvm::MapVector<clang::GlobalDecl, llvm::StringRef> mangledDeclNames;

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -722,6 +722,11 @@ public:
   /// member, depending on the type of mpt.
   mlir::TypedAttr emitNullMemberAttr(QualType t, const MemberPointerType *mpt);
 
+  /// Build a GEP-style field-index path from \p destClass to \p field.
+  /// Returns std::nullopt and emits errorNYI for virtual-base paths.
+  std::optional<llvm::SmallVector<int32_t>>
+  buildMemberPath(const CXXRecordDecl *destClass, const FieldDecl *field);
+
   llvm::StringRef getMangledName(clang::GlobalDecl gd);
   // This function is to support the OpenACC 'bind' clause, which names an
   // alternate name for the function to be called by. This function mangles
@@ -930,6 +935,13 @@ public:
   void addGlobalAnnotations(const clang::ValueDecl *d, mlir::Operation *gv);
 
 private:
+  /// Recursively find the chain of non-virtual base subobject field indices
+  /// from \p currentClass to \p targetClass.  Appends indices in leaf-to-root
+  /// order; the caller must reverse before use.
+  bool findBaseSubobjectPath(const CXXRecordDecl *currentClass,
+                             const CXXRecordDecl *targetClass,
+                             llvm::SmallVectorImpl<int32_t> &path);
+
   // An ordered map of canonical GlobalDecls to their mangled names.
   llvm::MapVector<clang::GlobalDecl, llvm::StringRef> mangledDeclNames;
   llvm::StringMap<clang::GlobalDecl, llvm::BumpPtrAllocator> manglings;

--- a/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
@@ -70,6 +70,13 @@ static mlir::ParseResult parseConstPtr(mlir::AsmParser &parser,
 
 static void printConstPtr(mlir::AsmPrinter &p, mlir::IntegerAttr value);
 
+static mlir::ParseResult
+parseDataMemberPath(mlir::AsmParser &parser,
+                    mlir::DenseI32ArrayAttr &memberPath);
+
+static void printDataMemberPath(mlir::AsmPrinter &p,
+                                mlir::DenseI32ArrayAttr memberPath);
+
 #define GET_ATTRDEF_CLASSES
 #include "clang/CIR/Dialect/IR/CIROpsAttributes.cpp.inc"
 
@@ -260,6 +267,26 @@ static void printConstPtr(AsmPrinter &p, mlir::IntegerAttr value) {
     p << "null";
   else
     p << value;
+}
+
+static ParseResult parseDataMemberPath(AsmParser &parser,
+                                       mlir::DenseI32ArrayAttr &memberPath) {
+  if (parser.parseOptionalKeyword("null").succeeded())
+    return success();
+
+  auto parsed = mlir::FieldParser<mlir::DenseI32ArrayAttr>::parse(parser);
+  if (mlir::failed(parsed))
+    return failure();
+  memberPath = *parsed;
+  return success();
+}
+
+static void printDataMemberPath(AsmPrinter &p,
+                                mlir::DenseI32ArrayAttr memberPath) {
+  if (!memberPath)
+    p << "null";
+  else
+    p.printStrippedAttrOrType(memberPath);
 }
 
 //===----------------------------------------------------------------------===//
@@ -539,54 +566,6 @@ DataMemberAttr::verify(function_ref<InFlightDiagnostic()> emitError,
               "the attribute type";
 
   return success();
-}
-
-mlir::Attribute DataMemberAttr::parse(mlir::AsmParser &parser,
-                                      mlir::Type type) {
-  auto mdt = mlir::cast<cir::DataMemberType>(type);
-  if (parser.parseLess())
-    return {};
-
-  auto emitError = [&]() {
-    return parser.emitError(parser.getCurrentLocation());
-  };
-
-  // null pointer-to-data-member.
-  if (succeeded(parser.parseOptionalKeyword("null"))) {
-    if (parser.parseGreater())
-      return {};
-    return getChecked(emitError, parser.getContext(), mdt,
-                      mlir::DenseI32ArrayAttr{});
-  }
-
-  // Non-null: parse a dense int32 array, e.g. [2] or [0, 1].
-  mlir::MLIRContext *ctx = parser.getContext();
-  llvm::SmallVector<int32_t> path;
-  if (parser.parseCommaSeparatedList(mlir::AsmParser::Delimiter::Square,
-                                     [&]() -> mlir::ParseResult {
-                                       int32_t idx;
-                                       if (parser.parseInteger(idx))
-                                         return mlir::failure();
-                                       path.push_back(idx);
-                                       return mlir::success();
-                                     }))
-    return {};
-  if (parser.parseGreater())
-    return {};
-  auto pathAttr = mlir::DenseI32ArrayAttr::get(ctx, path);
-  return getChecked(emitError, ctx, mdt, pathAttr);
-}
-
-void DataMemberAttr::print(mlir::AsmPrinter &p) const {
-  p << "<";
-  if (isNullPtr()) {
-    p << "null";
-  } else {
-    p << "[";
-    llvm::interleaveComma(getPath(), p);
-    p << "]";
-  }
-  p << ">";
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
@@ -509,29 +509,84 @@ Attribute CUDAVarRegistrationInfoAttr::parse(AsmParser &parser, Type odsType) {
 LogicalResult
 DataMemberAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                        cir::DataMemberType ty,
-                       std::optional<unsigned> memberIndex) {
-  // DataMemberAttr without a given index represents a null value.
-  if (!memberIndex.has_value())
-    return success();
+                       mlir::DenseI32ArrayAttr memberPath) {
+  if (!memberPath)
+    return success(); // null pointer — always valid
 
-  cir::RecordType recTy = ty.getClassTy();
-  if (recTy.isIncomplete())
-    return emitError()
-           << "incomplete 'cir.record' cannot be used to build a non-null "
-              "data member pointer";
+  if (memberPath.empty())
+    return emitError() << "#cir.data_member path must not be empty";
 
-  unsigned memberIndexValue = memberIndex.value();
-  if (memberIndexValue >= recTy.getNumElements())
-    return emitError()
-           << "member index of a #cir.data_member attribute is out of range";
+  mlir::Type currentTy = ty.getClassTy();
+  for (auto [step, idx] : llvm::enumerate(memberPath.asArrayRef())) {
+    auto recTy = mlir::dyn_cast<cir::RecordType>(currentTy);
+    if (!recTy)
+      return emitError() << "#cir.data_member path step " << step
+                         << " reaches a non-record type";
 
-  mlir::Type memberTy = recTy.getMembers()[memberIndexValue];
-  if (memberTy != ty.getMemberTy())
+    if (recTy.isIncomplete())
+      return success(); // cannot validate further; trust the builder
+
+    if (idx < 0 || static_cast<unsigned>(idx) >= recTy.getNumElements())
+      return emitError() << "#cir.data_member path index " << idx << " at step "
+                         << step << " is out of range";
+
+    currentTy = recTy.getMembers()[idx];
+  }
+
+  if (currentTy != ty.getMemberTy())
     return emitError()
-           << "member type of a #cir.data_member attribute must match the "
-              "attribute type";
+           << "member type of a #cir.data_member attribute must match "
+              "the attribute type";
 
   return success();
+}
+
+mlir::Attribute DataMemberAttr::parse(mlir::AsmParser &parser,
+                                      mlir::Type type) {
+  auto mdt = mlir::cast<cir::DataMemberType>(type);
+  if (parser.parseLess())
+    return {};
+
+  auto emitError = [&]() {
+    return parser.emitError(parser.getCurrentLocation());
+  };
+
+  // null pointer-to-data-member.
+  if (succeeded(parser.parseOptionalKeyword("null"))) {
+    if (parser.parseGreater())
+      return {};
+    return getChecked(emitError, parser.getContext(), mdt,
+                      mlir::DenseI32ArrayAttr{});
+  }
+
+  // Non-null: parse a dense int32 array, e.g. [2] or [0, 1].
+  mlir::MLIRContext *ctx = parser.getContext();
+  llvm::SmallVector<int32_t> path;
+  if (parser.parseCommaSeparatedList(mlir::AsmParser::Delimiter::Square,
+                                     [&]() -> mlir::ParseResult {
+                                       int32_t idx;
+                                       if (parser.parseInteger(idx))
+                                         return mlir::failure();
+                                       path.push_back(idx);
+                                       return mlir::success();
+                                     }))
+    return {};
+  if (parser.parseGreater())
+    return {};
+  auto pathAttr = mlir::DenseI32ArrayAttr::get(ctx, path);
+  return getChecked(emitError, ctx, mdt, pathAttr);
+}
+
+void DataMemberAttr::print(mlir::AsmPrinter &p) const {
+  p << "<";
+  if (isNullPtr()) {
+    p << "null";
+  } else {
+    p << "[";
+    llvm::interleaveComma(getPath(), p);
+    p << "]";
+  }
+  p << ">";
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
@@ -202,10 +202,15 @@ mlir::TypedAttr LowerItaniumCXXABI::lowerDataMemberConstant(
   } else {
     // Itanium C++ ABI 2.3:
     //   A pointer to data member is an offset from the base address of
-    //   the class object containing it, represented as a ptrdiff_t
-    unsigned memberIndex = attr.getMemberIndex().value();
-    memberOffset =
-        attr.getType().getClassTy().getElementOffset(layout, memberIndex);
+    //   the class object containing it, represented as a ptrdiff_t.
+    // Walk the GEP-style path, accumulating the byte offset at each step.
+    memberOffset = 0;
+    mlir::Type currentTy = attr.getType().getClassTy();
+    for (int32_t idx : attr.getPath()) {
+      auto recTy = mlir::cast<cir::RecordType>(currentTy);
+      memberOffset += static_cast<int64_t>(recTy.getElementOffset(layout, idx));
+      currentTy = recTy.getMembers()[idx];
+    }
   }
 
   mlir::Type abiTy = lowerDataMemberType(attr.getType(), typeConverter);

--- a/clang/test/CIR/CodeGen/nonzeroinit-struct.cpp
+++ b/clang/test/CIR/CodeGen/nonzeroinit-struct.cpp
@@ -55,7 +55,7 @@ Trivial t;
 // LLVM-DAG: @t = global %struct.Trivial { i32 0, double 0.000000e+00, i64 -1 }, align 8
 
 Trivial t_init{1,2.2, &Other::x};
-// CIR-BEFORE-DAG: cir.global external @t_init = #cir.const_record<{#cir.int<1> : !s32i, #cir.fp<2.200000e+00> : !cir.double, #cir.data_member<0> : !cir.data_member<!s32i in !rec_Other>}> : !rec_Trivial {alignment = 8 : i64}
+// CIR-BEFORE-DAG: cir.global external @t_init = #cir.const_record<{#cir.int<1> : !s32i, #cir.fp<2.200000e+00> : !cir.double, #cir.data_member<[0]> : !cir.data_member<!s32i in !rec_Other>}> : !rec_Trivial {alignment = 8 : i64}
 // CIR-AFTER-DAG: cir.global external @t_init = #cir.const_record<{#cir.int<1> : !s32i, #cir.fp<2.200000e+00> : !cir.double, #cir.int<0> : !s64i}> : !rec_Trivial {alignment = 8 : i64}
 // LLVM-DAG: @t_init = global %struct.Trivial { i32 1, double 2.200000e+00, i64 0 }, align 8
 
@@ -84,7 +84,7 @@ extern "C" void local() {
   // LLVM: call void @llvm.memcpy.p0.p0.i64(ptr {{.*}}%[[MPT_INIT]], ptr {{.*}}@__const.local.localMpt_init, i64 32, i1 false)
 
   Trivial localT_init{1,2.2, &Other::x};
-  // CIR-BEFORE: %[[T_INIT_VAL:.*]] = cir.const #cir.const_record<{#cir.int<1> : !s32i, #cir.fp<2.200000e+00> : !cir.double, #cir.data_member<0> : !cir.data_member<!s32i in !rec_Other>}> : !rec_Trivial
+  // CIR-BEFORE: %[[T_INIT_VAL:.*]] = cir.const #cir.const_record<{#cir.int<1> : !s32i, #cir.fp<2.200000e+00> : !cir.double, #cir.data_member<[0]> : !cir.data_member<!s32i in !rec_Other>}> : !rec_Trivial
   // CIR-BEFORE: cir.store align(8) %[[T_INIT_VAL]], %[[T_INIT]] : !rec_Trivial, !cir.ptr<!rec_Trivial>
 
   // CIR-AFTER: %[[T_INIT_VAL:.*]] = cir.get_global @__const.local.localT_init : !cir.ptr<!rec_Trivial>

--- a/clang/test/CIR/CodeGen/pointer-to-data-member.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-data-member.cpp
@@ -44,11 +44,15 @@ int Point::*pt_member_nested_region = test1();
 // CIR-AFTER: cir.global external @p_inherit_single = #cir.int<0> : !s64i
 // CIR-AFTER: cir.global external @p_multi_inherit = #cir.int<8> : !s64i
 // CIR-AFTER: cir.global external @p_depth3 = #cir.int<8> : !s64i
+// CIR-AFTER: cir.global external @p_vbase_sibling_nv = #cir.int<8> : !s64i
+// CIR-AFTER: cir.global external @p_vbase_sibling_direct = #cir.int<12> : !s64i
 
 // LLVM: @pt_member_nested_region = global i64 -1, align 8
 // LLVM: @p_inherit_single = global i64 0, align 8
 // LLVM: @p_multi_inherit = global i64 8, align 8
 // LLVM: @p_depth3 = global i64 8, align 8
+// LLVM: @p_vbase_sibling_nv = global i64 8, align 8
+// LLVM: @p_vbase_sibling_direct = global i64 12, align 8
 // LLVM: define internal void @__cxx_global_var_init()
 // LLVM:   %[[MEMBER_PTR:.*]] = call i64 @_Z5test1v()
 // LLVM:   store i64 %[[MEMBER_PTR]], ptr @pt_member_nested_region, align 8
@@ -57,6 +61,8 @@ int Point::*pt_member_nested_region = test1();
 // OGCG: @p_inherit_single = global i64 0, align 8
 // OGCG: @p_multi_inherit = global i64 8, align 8
 // OGCG: @p_depth3 = global i64 8, align 8
+// OGCG: @p_vbase_sibling_nv = global i64 8, align 8
+// OGCG: @p_vbase_sibling_direct = global i64 12, align 8
 // OGCG emits __cxx_global_var_init between test1() and test2(). See checks below.
 
 struct InheritBase {
@@ -89,6 +95,19 @@ struct DepthC : DepthB { float z; };
 
 int DepthC::*p_depth3 = &DepthC::x;
 // CIR-BEFORE: cir.global external @p_depth3 = #cir.data_member<[0, 0, 1]> : !cir.data_member<!s32i in !rec_DepthC>
+
+struct VBaseField { int v; };
+struct NVBaseField { int x; };
+struct Diamond : virtual VBaseField, NVBaseField { int d; };
+
+// A virtual base elsewhere in the hierarchy must not block a member reached
+// through a non-virtual base.
+int Diamond::*p_vbase_sibling_nv = &NVBaseField::x;
+// CIR-BEFORE: cir.global external @p_vbase_sibling_nv = #cir.data_member<[1, 0]> : !cir.data_member<!s32i in !rec_Diamond>
+
+// A direct member of a class with a virtual base still resolves.
+int Diamond::*p_vbase_sibling_direct = &Diamond::d;
+// CIR-BEFORE: cir.global external @p_vbase_sibling_direct = #cir.data_member<[2]> : !cir.data_member<!s32i in !rec_Diamond>
 
 // Checks for test1()
 

--- a/clang/test/CIR/CodeGen/pointer-to-data-member.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-data-member.cpp
@@ -19,7 +19,7 @@ int Point::*ptr_none = nullptr;
 // OGCG: @ptr_none = global i64 -1
 
 int Point::*pt_member = &Point::z;
-// CIR-BEFORE: cir.global external @pt_member = #cir.data_member<2> : !cir.data_member<!s32i in !rec_Point>
+// CIR-BEFORE: cir.global external @pt_member = #cir.data_member<[2]> : !cir.data_member<!s32i in !rec_Point>
 // CIR-AFTER: cir.global external @pt_member = #cir.int<8> : !s64i
 // LLVM: @pt_member = global i64 8
 // OGCG: @pt_member = global i64 8
@@ -41,20 +41,60 @@ int Point::*pt_member_nested_region = test1();
 // CIR-AFTER:   %[[MEMBER_PTR_ADDR:.*]] = cir.get_global @pt_member_nested_region : !cir.ptr<!s64i>
 // CIR-AFTER:   %[[MEMBER_PTR:.*]] = cir.call @_Z5test1v() : () -> !s64i
 // CIR-AFTER:   cir.store align(8) %[[MEMBER_PTR]], %[[MEMBER_PTR_ADDR]] : !s64i, !cir.ptr<!s64i>
+// CIR-AFTER: cir.global external @p_inherit_single = #cir.int<0> : !s64i
+// CIR-AFTER: cir.global external @p_multi_inherit = #cir.int<8> : !s64i
+// CIR-AFTER: cir.global external @p_depth3 = #cir.int<8> : !s64i
 
 // LLVM: @pt_member_nested_region = global i64 -1, align 8
+// LLVM: @p_inherit_single = global i64 0, align 8
+// LLVM: @p_multi_inherit = global i64 8, align 8
+// LLVM: @p_depth3 = global i64 8, align 8
 // LLVM: define internal void @__cxx_global_var_init()
 // LLVM:   %[[MEMBER_PTR:.*]] = call i64 @_Z5test1v()
 // LLVM:   store i64 %[[MEMBER_PTR]], ptr @pt_member_nested_region, align 8
 
 // OGCG: @pt_member_nested_region = global i64 -1, align 8
+// OGCG: @p_inherit_single = global i64 0, align 8
+// OGCG: @p_multi_inherit = global i64 8, align 8
+// OGCG: @p_depth3 = global i64 8, align 8
 // OGCG emits __cxx_global_var_init between test1() and test2(). See checks below.
+
+struct InheritBase {
+  int x;
+};
+
+struct InheritDerived : InheritBase {
+  double y;
+};
+
+int InheritDerived::*p_inherit_single = &InheritDerived::x;
+// CIR-BEFORE: cir.global external @p_inherit_single = #cir.data_member<[0, 0]> : !cir.data_member<!s32i in !rec_InheritDerived>
+
+struct MultiA {
+  double a;
+};
+
+struct MultiB {
+  int b;
+};
+
+struct MultiM : MultiA, MultiB {};
+
+int MultiM::*p_multi_inherit = &MultiM::b;
+// CIR-BEFORE: cir.global external @p_multi_inherit = #cir.data_member<[1, 0]> : !cir.data_member<!s32i in !rec_MultiM>
+
+struct DepthA { double a; int x; };
+struct DepthB : DepthA { double y; };
+struct DepthC : DepthB { float z; };
+
+int DepthC::*p_depth3 = &DepthC::x;
+// CIR-BEFORE: cir.global external @p_depth3 = #cir.data_member<[0, 0, 1]> : !cir.data_member<!s32i in !rec_DepthC>
 
 // Checks for test1()
 
 // CIR-BEFORE: cir.func {{.*}} @_Z5test1v() -> !cir.data_member<!s32i in !rec_Point> attributes {{{.*}}nothrow} {
 // CIR-BEFORE:   %[[RETVAL:.*]] = cir.alloca "__retval" {{.*}} : !cir.ptr<!cir.data_member<!s32i in !rec_Point>>
-// CIR-BEFORE:   %[[MEMBER:.*]] = cir.const #cir.data_member<1> : !cir.data_member<!s32i in !rec_Point>
+// CIR-BEFORE:   %[[MEMBER:.*]] = cir.const #cir.data_member<[1]> : !cir.data_member<!s32i in !rec_Point>
 // CIR-BEFORE:   cir.store %[[MEMBER]], %[[RETVAL]] : !cir.data_member<!s32i in !rec_Point>, !cir.ptr<!cir.data_member<!s32i in !rec_Point>>
 // CIR-BEFORE:   %[[RET:.*]] = cir.load %[[RETVAL]] : !cir.ptr<!cir.data_member<!s32i in !rec_Point>>, !cir.data_member<!s32i in !rec_Point>
 // CIR-BEFORE:   cir.return %[[RET]] : !cir.data_member<!s32i in !rec_Point>

--- a/clang/test/CIR/IR/invalid-data-member.cir
+++ b/clang/test/CIR/IR/invalid-data-member.cir
@@ -7,15 +7,7 @@
 !struct1 = !cir.struct<"Struct1" {!u16i, !u32i}>
 
 // expected-error@+1 {{member type of a #cir.data_member attribute must match the attribute type}}
-#invalid_member_ty = #cir.data_member<0> : !cir.data_member<!u32i in !struct1>
-
-// -----
-
-!u16i = !cir.int<u, 16>
-!incomplete_struct = !cir.struct<"Incomplete" incomplete>
-
-// expected-error@+1 {{incomplete 'cir.record' cannot be used to build a non-null data member pointer}}
-#incomplete_cls_member = #cir.data_member<0> : !cir.data_member<!u16i in !incomplete_struct>
+#invalid_member_ty = #cir.data_member<[0]> : !cir.data_member<!u32i in !struct1>
 
 // -----
 
@@ -23,8 +15,17 @@
 !u32i = !cir.int<u, 32>
 !struct1 = !cir.struct<"Struct1" {!u16i, !u32i}>
 
-// expected-error@+1 {{member index of a #cir.data_member attribute is out of range}}
-#invalid_member_ty = #cir.data_member<2> : !cir.data_member<!u32i in !struct1>
+// expected-error@+1 {{#cir.data_member path index 2 at step 0 is out of range}}
+#invalid_member_ty = #cir.data_member<[2]> : !cir.data_member<!u32i in !struct1>
+
+// -----
+
+!u16i = !cir.int<u, 16>
+!u32i = !cir.int<u, 32>
+!struct1 = !cir.struct<"Struct1" {!u16i, !u32i}>
+
+// expected-error@+1 {{#cir.data_member path must not be empty}}
+#empty_path = #cir.data_member<[]> : !cir.data_member<!u32i in !struct1>
 
 // -----
 


### PR DESCRIPTION
`DataMemberAttr` stored a single field index relative to the immediately containing class, which broke when the member is inherited: `int Derived::*p = &Derived::x` with `x` in Base produced a spurious `errorNYI` because Derived's CIR record doesn't directly hold `x`.

The attribute now stores a GEP-style `member_path` — a sequence of CIR field indices stepping from the pointer's class type down to the member, one level per inheritance hop. `lowerDataMemberConstant` walks the path accumulating element offsets to produce the Itanium ABI byte value.

`buildMemberPath` searches the `destClass` record tree for the target field (`findFieldMemberPath`). `CK_BaseToDerivedMemberPointer` and `CK_DerivedToBaseMemberPointer` return `{}` in ConstExprEmitter, delegating to the APValue path which builds the correct path via `buildMemberPath`. Virtual bases are not yet handled.

`CK_ReinterpretMemberPointer` remains `errorNYI` on this branch; a follow-up PR will add that separately.