### PR TITLE
[PGO][HIP] Fix profile-only Windows link by gating ROCm interceptor macro

### DIFF
--- a/compiler-rt/lib/profile/CMakeLists.txt
+++ b/compiler-rt/lib/profile/CMakeLists.txt
@@ -158,12 +158,6 @@ if(COMPILER_RT_PROFILE_BAREMETAL)
      -DCOMPILER_RT_PROFILE_BAREMETAL=1)
 endif()
 
-if(COMPILER_RT_BUILD_PROFILE_ROCM)
-  set(EXTRA_FLAGS
-      ${EXTRA_FLAGS}
-      -DCOMPILER_RT_BUILD_PROFILE_ROCM=1)
-endif()
-
 # The HIP host interceptor in InstrProfilingPlatformROCm.cpp pulls in
 # RTInterception + sanitizer_common object libs. Those targets are only created
 # when COMPILER_RT_BUILD_SANITIZERS / _MEMPROF / _XRAY / _CTX_PROFILE is enabled
@@ -188,6 +182,17 @@ endif()
 
 if(NOT PROFILE_HAS_HIP_INTERCEPTOR)
   list(REMOVE_ITEM PROFILE_SOURCES InstrProfilingPlatformROCm.cpp)
+endif()
+
+# Only advertise the ROCm interceptor to InstrProfilingFile.c when its
+# definition (InstrProfilingPlatformROCm.cpp) is actually compiled into the
+# archive. Otherwise InstrProfilingFile.c references
+# __llvm_profile_hip_collect_device_data with no definition; on COFF/Windows
+# there is no weak-undefined fallback, so the link fails (see PR #200111).
+if(COMPILER_RT_BUILD_PROFILE_ROCM AND PROFILE_HAS_HIP_INTERCEPTOR)
+  set(EXTRA_FLAGS
+      ${EXTRA_FLAGS}
+      -DCOMPILER_RT_BUILD_PROFILE_ROCM=1)
 endif()
 
 if("${COMPILER_RT_DEFAULT_TARGET_ARCH}" MATCHES "amdgcn|nvptx")


### PR DESCRIPTION
PR #200111 stops compiling InstrProfilingPlatformROCm.cpp (which defines the
HIP GPU helper __llvm_profile_hip_collect_device_data) in profile-only builds.
But the compile define -DCOMPILER_RT_BUILD_PROFILE_ROCM=1 was still added
whenever the COMPILER_RT_BUILD_PROFILE_ROCM option was on (the default), so
InstrProfilingFile.c still referenced the helper from __llvm_profile_write_file
even though it was never built.

On ELF the declaration is weak, so the undefined symbol folds to null and the
address-guarded call is skipped. COFF/Windows has no such fallback:

  error LNK2019: unresolved external symbol
  __llvm_profile_hip_collect_device_data referenced in function
  __llvm_profile_write_file

Add the define only when PROFILE_HAS_HIP_INTERCEPTOR is true, i.e. the same
condition that keeps InstrProfilingPlatformROCm.cpp in the archive, so the
macro is defined iff the helper is actually compiled in.

Reported by zmodem:
https://github.com/llvm/llvm-project/pull/200111#issuecomment-4593893230

