### PR TITLE
[AIX][libc++] Mark offset_range test UNSUPPORTED on 32-bit AIX due to 32-bit off_t

### DIFF
--- a/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/offset_range.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/offset_range.pass.cpp
@@ -19,7 +19,7 @@
 // XFAIL: target={{i686|arm.*}}-{{.+}}-android{{.*}}
 
 // By default, off_t is typically a 32-bit integer on ARMv7 Linux systems and
-// 32-bit AIX meaning it can represent file sizes up to 2GB (2^31 bytes) only.
+// 32-bit AIX, meaning it can represent file sizes up to 2GB (2^31 bytes) only.
 //
 // UNSUPPORTED: target=armv7-unknown-linux-gnueabihf, target=powerpc-{{.+}}-aix{{.*}}
 

--- a/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/offset_range.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/offset_range.pass.cpp
@@ -18,14 +18,10 @@
 //
 // XFAIL: target={{i686|arm.*}}-{{.+}}-android{{.*}}
 
-// Writing the >4 GB test file fails on 32 bit AIX.
+// By default, off_t is typically a 32-bit integer on ARMv7 Linux systems and
+// 32-bit AIX meaning it can represent file sizes up to 2GB (2^31 bytes) only.
 //
-// XFAIL: target=powerpc-{{.+}}-aix{{.*}}
-
-// By default, off_t is typically a 32-bit integer on ARMv7 Linux systems,
-// meaning it can represent file sizes up to 2GB (2^31 bytes) only.
-//
-// UNSUPPORTED: target=armv7-unknown-linux-gnueabihf
+// UNSUPPORTED: target=armv7-unknown-linux-gnueabihf, target=powerpc-{{.+}}-aix{{.*}}
 
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
Marking the test as UNSUPPORTED and combined the comment since both platforms have the same fundamental limitation with `32-bit off_t`.