### PR TITLE
[IR] Reorder checks in isInterposable() (NFC)

### DIFF
--- a/llvm/lib/IR/Globals.cpp
+++ b/llvm/lib/IR/Globals.cpp
@@ -171,8 +171,8 @@ GlobalObject::~GlobalObject() {
 bool GlobalValue::isInterposable() const {
   if (isInterposableLinkage(getLinkage()))
     return true;
-  return getParent() && getParent()->getSemanticInterposition() &&
-         !isDSOLocal();
+  return !isDSOLocal() && getParent() &&
+         getParent()->getSemanticInterposition();
 }
 
 bool GlobalValue::canBenefitFromLocalAlias() const {


### PR DESCRIPTION
The isDSOLocal() check is a lot cheaper than getSemanticInterposition(), so perform it first.

This is a small compile-time improvement: https://llvm-compile-time-tracker.com/compare.php?from=3c95dd29d834fde3a1070655a8a33df8ab3ee8b8&to=42c82c28e0ffb8e64080fc9ae3f2028ec28a3638&stat=instructions:u