### PR TITLE
[Object][DirectX] Fix UB when parsing a DXContainer from a null buffer

### DIFF
--- a/llvm/lib/Object/DXContainer.cpp
+++ b/llvm/lib/Object/DXContainer.cpp
@@ -21,7 +21,7 @@ static Error parseFailed(const Twine &Msg) {
 }
 
 static bool readIsOutOfBounds(StringRef Buffer, const char *Src, size_t Size) {
-  return !Src || Src < Buffer.begin() || Src + Size > Buffer.end();
+  return !Src || Size > static_cast<size_t>(Buffer.end() - Src);
 }
 
 template <typename T>

--- a/llvm/lib/Object/DXContainer.cpp
+++ b/llvm/lib/Object/DXContainer.cpp
@@ -21,7 +21,7 @@ static Error parseFailed(const Twine &Msg) {
 }
 
 static bool readIsOutOfBounds(StringRef Buffer, const char *Src, size_t Size) {
-  return Src < Buffer.begin() || Src + Size > Buffer.end();
+  return !Src || Src < Buffer.begin() || Src + Size > Buffer.end();
 }
 
 template <typename T>

--- a/llvm/unittests/Object/DXContainerTest.cpp
+++ b/llvm/unittests/Object/DXContainerTest.cpp
@@ -50,6 +50,12 @@ TEST(DXCFile, EmptyFile) {
       FailedWithMessage("Reading structure out of file bounds"));
 }
 
+TEST(DXCFile, NullBuffer) {
+  EXPECT_THAT_EXPECTED(
+      DXContainer::create(MemoryBufferRef(StringRef(), "")),
+      FailedWithMessage("Reading structure out of file bounds"));
+}
+
 TEST(DXCFile, ParseHeader) {
   uint8_t Buffer[] = {0x44, 0x58, 0x42, 0x43, 0x00, 0x00, 0x00, 0x00,
                       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,


### PR DESCRIPTION
Adds an additional check that `Src != nullptr` before doing other operations on it, which caused a UB in one test with #200413.