### PR TITLE
[libc][baremetal] cache free bit and remove indirections in malloc block

### DIFF
--- a/libc/src/__support/block.h
+++ b/libc/src/__support/block.h
@@ -94,7 +94,8 @@ class Block {
   // Masks for the contents of the next_ field.
   static constexpr size_t PREV_FREE_MASK = 1 << 0;
   static constexpr size_t LAST_MASK = 1 << 1;
-  static constexpr size_t SIZE_MASK = ~(PREV_FREE_MASK | LAST_MASK);
+  static constexpr size_t FREE_MASK = 1 << 2;
+  static constexpr size_t SIZE_MASK = ~(PREV_FREE_MASK | LAST_MASK | FREE_MASK);
 
 public:
   // To ensure block sizes have two lower unused bits, ensure usable space is
@@ -213,17 +214,19 @@ public:
   }
 
   /// @returns Whether the block is unavailable for allocation.
-  LIBC_INLINE bool used() const { return !next() || !next()->prev_free(); }
+  LIBC_INLINE bool used() const { return !(next_ & FREE_MASK); }
 
   /// Marks this block as in use.
   LIBC_INLINE void mark_used() {
     LIBC_ASSERT(next() && "last block is always considered used");
+    next_ &= ~FREE_MASK;
     next()->next_ &= ~PREV_FREE_MASK;
   }
 
   /// Marks this block as free.
   LIBC_INLINE void mark_free() {
     LIBC_ASSERT(next() && "last block is always considered used");
+    next_ |= FREE_MASK;
     next()->next_ |= PREV_FREE_MASK;
     // The next block's prev_ field becomes alive, as it is no longer part of
     // this block's used space.
@@ -239,6 +242,8 @@ public:
                 "usable space must be aligned to a multiple of MIN_ALIGN");
     if (is_last)
       next_ |= LAST_MASK;
+    else
+      next_ |= FREE_MASK;
   }
 
   LIBC_INLINE bool is_usable_space_aligned(size_t alignment) const {


### PR DESCRIPTION
Free block check indirection is reported in contributing 10~50% overhead in tcmalloc replay (which flares up the flamegraph). Adding a free bit cached in local block to remove indirection.

### Throughput Performance Table

| Workload | Baseline (MOps) | Optimized (MOps) | Speedup (%) |
| :--- | :--- | :--- | :--- |
| TCMALLOC_0 | 5.821 | 6.082 | +4.48% |
| TCMALLOC_1 | 6.945 | 8.244 | +18.70% |
| TCMALLOC_2 | 6.888 | 8.972 | +30.26% |
| TCMALLOC_3 | 5.332 | 8.401 | **+57.56%** |
| TCMALLOC_4 | 5.850 | 6.045 | +3.33% |
| TCMALLOC_5 | 6.700 | 7.699 | +14.91% |
| TCMALLOC_6 | 5.663 | 6.366 | +12.41% |
| TCMALLOC_7 | 6.763 | 6.518 | -3.62% |
| TCMALLOC_8 | 4.818 | 4.335 | -10.02% |
| TCMALLOC_9 | 8.279 | 7.466 | -9.82% |
| **Average** | | | **+11.82%** |

Assisted-by: AI tools, manually checked.