### PR TITLE
[DirectX] Implement lowering of SampleGrad. Refactor sample lowering functions

### DIFF
--- a/llvm/lib/Target/DirectX/DXIL.td
+++ b/llvm/lib/Target/DirectX/DXIL.td
@@ -897,6 +897,23 @@ def SampleBias : DXILOp<61, sampleBias> {
   let attributes = [Attributes<DXIL1_0, [ReadOnly]>];
 }
 
+def SampleGrad : DXILOp<63, sampleGrad> {
+  let Doc = "samples a texture using a gradient to influence the way the sample "
+            "location is calculated";
+  // Handle, Sampler, Coord0, Coord1, Coord2, Coord3,
+  // Offset0, Offset1, Offset2, DDX0, DDX1, DDX2, DDY0, DDY1, DDY2, Clamp
+  let arguments = [HandleTy, HandleTy, FloatTy, FloatTy, FloatTy, FloatTy,
+                   Int32Ty, Int32Ty, Int32Ty, FloatTy, FloatTy, FloatTy,
+                   FloatTy, FloatTy, FloatTy, FloatTy];
+  let result = OverloadTy;
+  let overloads =
+      [Overloads<DXIL1_0, [ResRetHalfTy, ResRetFloatTy]>,
+       Overloads<DXIL1_7,
+                 [ResRetHalfTy, ResRetFloatTy, ResRetInt16Ty, ResRetInt32Ty]>];
+  let stages = [Stages<DXIL1_0, [all_stages]>];
+  let attributes = [Attributes<DXIL1_0, [ReadOnly]>];
+}
+
 def TextureLoad : DXILOp<66, textureLoad> {
   let Doc = "reads from a texture resource";
   // Handle, MipLevelOrSampleCount, Coord0, Coord1, Coord2, Offset0, Offset1, Offset2

--- a/llvm/lib/Target/DirectX/DXILOpLowering.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpLowering.cpp
@@ -655,9 +655,15 @@ public:
     });
   }
 
-  [[nodiscard]] bool lowerSampleBias(Function &F, bool HasClamp) {
+  /// Common helper for lowering sample operations (SampleBias, SampleGrad,
+  /// etc.) that share the same pattern: extract handle/sampler, unpack
+  /// coordinates and offsets, build the DXIL arg list, and replace uses.
+  [[nodiscard]] bool lowerSampleOp(
+      Function &F, OpCode Op, unsigned CoordsIdx, unsigned OffsetsIdx,
+      unsigned ClampIdx,
+      llvm::function_ref<void(IRBuilder<> &, CallInst *,
+                              SmallVectorImpl<Value *> &)> EmitExtraArgs) {
     IRBuilder<> &IRB = OpBuilder.getIRB();
-    Type *Int32Ty = IRB.getInt32Ty();
     Type *FloatTy = IRB.getFloatTy();
 
     return replaceFunction(F, [&](CallInst *CI) -> Error {
@@ -667,27 +673,32 @@ public:
           createTmpHandleCast(CI->getArgOperand(0), OpBuilder.getHandleType());
       Value *Sampler =
           createTmpHandleCast(CI->getArgOperand(1), OpBuilder.getHandleType());
-      Value *Coords = CI->getArgOperand(2);
-      Value *Bias = CI->getArgOperand(3);
-      Value *Offsets = CI->getArgOperand(4);
-      Value *Clamp = HasClamp ? CI->getArgOperand(5) : UndefValue::get(FloatTy);
+      Value *Coords = CI->getArgOperand(CoordsIdx);
+      Value *Offsets = CI->getArgOperand(OffsetsIdx);
+      Value *Clamp = ClampIdx < CI->arg_size() ? CI->getArgOperand(ClampIdx)
+                                               : UndefValue::get(FloatTy);
 
       Type *OldTy = CI->getType();
       Type *NewRetTy = OpBuilder.getResRetType(OldTy->getScalarType());
 
       Value *UndefF = UndefValue::get(FloatTy);
-      Value *UndefI = UndefValue::get(Int32Ty);
-      // Args: Handle, Sampler, Coord0..3, Offset0..2, Bias, Clamp
-      std::array<Value *, 11> Args{Handle, Sampler, UndefF, UndefF,
-                                   UndefF, UndefF,  UndefI, UndefI,
-                                   UndefI, Bias,    Clamp};
+      Value *UndefI = UndefValue::get(IRB.getInt32Ty());
+      // Common prefix: Handle, Sampler, Coord0..3, Offset0..2
+      SmallVector<Value *, 17> Args{Handle, Sampler, UndefF, UndefF, UndefF,
+                                    UndefF, UndefI,  UndefI, UndefI};
 
       // Copy coordinates and offsets into Args.
       extractElementsIntoArgs(IRB, Args, 2, Coords, 4);
       extractNonZeroOffsets(IRB, Args, 6, Offsets, 3);
 
-      Expected<CallInst *> OpCall = OpBuilder.tryCreateOp(
-          OpCode::SampleBias, Args, CI->getName(), NewRetTy);
+      // Emit op-specific arguments (e.g. Bias or DDX/DDY).
+      EmitExtraArgs(IRB, CI, Args);
+
+      // The clamp is always the last argument.
+      Args.push_back(Clamp);
+
+      Expected<CallInst *> OpCall =
+          OpBuilder.tryCreateOp(Op, Args, CI->getName(), NewRetTy);
       if (Error E = OpCall.takeError())
         return E;
       if (Error E = replaceResRetUses(CI, *OpCall, /*HasCheckBit=*/false))
@@ -695,6 +706,36 @@ public:
 
       return Error::success();
     });
+  }
+
+  [[nodiscard]] bool lowerSampleBias(Function &F, bool HasClamp) {
+    return lowerSampleOp(
+        F, OpCode::SampleBias, /*CoordsIdx=*/2, /*OffsetsIdx=*/4,
+        /*ClampIdx=*/HasClamp ? 5 : ~0u,
+        [](IRBuilder<> &, CallInst *CI, SmallVectorImpl<Value *> &Args) {
+          // Bias is operand 3.
+          Args.push_back(CI->getArgOperand(3));
+        });
+  }
+
+  [[nodiscard]] bool lowerSampleGrad(Function &F, bool HasClamp) {
+    return lowerSampleOp(
+        F, OpCode::SampleGrad, /*CoordsIdx=*/2, /*OffsetsIdx=*/5,
+        /*ClampIdx=*/HasClamp ? 6 : ~0u,
+        [](IRBuilder<> &IRB, CallInst *CI, SmallVectorImpl<Value *> &Args) {
+          Value *DDX = CI->getArgOperand(3);
+          Value *DDY = CI->getArgOperand(4);
+          Type *FloatTy = IRB.getFloatTy();
+          Value *UndefF = UndefValue::get(FloatTy);
+          // DDX0..2
+          size_t DDXStart = Args.size();
+          Args.append(3, UndefF);
+          extractElementsIntoArgs(IRB, Args, DDXStart, DDX, 3);
+          // DDY0..2
+          size_t DDYStart = Args.size();
+          Args.append(3, UndefF);
+          extractElementsIntoArgs(IRB, Args, DDYStart, DDY, 3);
+        });
   }
 
   [[nodiscard]] bool lowerRawBufferLoad(Function &F) {
@@ -1119,6 +1160,12 @@ public:
         break;
       case Intrinsic::dx_resource_samplebias_clamp:
         HasErrors |= lowerSampleBias(F, /*HasClamp=*/true);
+        break;
+      case Intrinsic::dx_resource_samplegrad:
+        HasErrors |= lowerSampleGrad(F, /*HasClamp=*/false);
+        break;
+      case Intrinsic::dx_resource_samplegrad_clamp:
+        HasErrors |= lowerSampleGrad(F, /*HasClamp=*/true);
         break;
       case Intrinsic::dx_resource_store_typedbuffer:
         HasErrors |= lowerBufferStore(F, /*IsRaw=*/false);

--- a/llvm/lib/Target/DirectX/DXILOpLowering.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpLowering.cpp
@@ -660,7 +660,6 @@ public:
   /// coordinates and offsets, build the DXIL arg list, and replace uses.
   [[nodiscard]] bool lowerSampleOp(
       Function &F, OpCode Op, unsigned CoordsIdx, unsigned OffsetsIdx,
-      unsigned ClampIdx,
       llvm::function_ref<void(IRBuilder<> &, CallInst *,
                               SmallVectorImpl<Value *> &)> EmitExtraArgs) {
     IRBuilder<> &IRB = OpBuilder.getIRB();
@@ -675,8 +674,6 @@ public:
           createTmpHandleCast(CI->getArgOperand(1), OpBuilder.getHandleType());
       Value *Coords = CI->getArgOperand(CoordsIdx);
       Value *Offsets = CI->getArgOperand(OffsetsIdx);
-      Value *Clamp = ClampIdx < CI->arg_size() ? CI->getArgOperand(ClampIdx)
-                                               : UndefValue::get(FloatTy);
 
       Type *OldTy = CI->getType();
       Type *NewRetTy = OpBuilder.getResRetType(OldTy->getScalarType());
@@ -691,11 +688,8 @@ public:
       extractElementsIntoArgs(IRB, Args, 2, Coords, 4);
       extractNonZeroOffsets(IRB, Args, 6, Offsets, 3);
 
-      // Emit op-specific arguments (e.g. Bias or DDX/DDY).
+      // Emit op-specific trailing arguments (e.g. Bias+Clamp, DDX+DDY+Clamp).
       EmitExtraArgs(IRB, CI, Args);
-
-      // The clamp is always the last argument.
-      Args.push_back(Clamp);
 
       Expected<CallInst *> OpCall =
           OpBuilder.tryCreateOp(Op, Args, CI->getName(), NewRetTy);
@@ -711,18 +705,21 @@ public:
   [[nodiscard]] bool lowerSampleBias(Function &F, bool HasClamp) {
     return lowerSampleOp(
         F, OpCode::SampleBias, /*CoordsIdx=*/2, /*OffsetsIdx=*/4,
-        /*ClampIdx=*/HasClamp ? 5 : ~0u,
-        [](IRBuilder<> &, CallInst *CI, SmallVectorImpl<Value *> &Args) {
+        [HasClamp](IRBuilder<> &IRB, CallInst *CI,
+                   SmallVectorImpl<Value *> &Args) {
           // Bias is operand 3.
           Args.push_back(CI->getArgOperand(3));
+          // Clamp
+          Args.push_back(HasClamp ? CI->getArgOperand(5)
+                                  : UndefValue::get(IRB.getFloatTy()));
         });
   }
 
   [[nodiscard]] bool lowerSampleGrad(Function &F, bool HasClamp) {
     return lowerSampleOp(
         F, OpCode::SampleGrad, /*CoordsIdx=*/2, /*OffsetsIdx=*/5,
-        /*ClampIdx=*/HasClamp ? 6 : ~0u,
-        [](IRBuilder<> &IRB, CallInst *CI, SmallVectorImpl<Value *> &Args) {
+        [HasClamp](IRBuilder<> &IRB, CallInst *CI,
+                   SmallVectorImpl<Value *> &Args) {
           Value *DDX = CI->getArgOperand(3);
           Value *DDY = CI->getArgOperand(4);
           Type *FloatTy = IRB.getFloatTy();
@@ -735,6 +732,8 @@ public:
           size_t DDYStart = Args.size();
           Args.append(3, UndefF);
           extractElementsIntoArgs(IRB, Args, DDYStart, DDY, 3);
+          // Clamp
+          Args.push_back(HasClamp ? CI->getArgOperand(6) : UndefF);
         });
   }
 

--- a/llvm/lib/Target/DirectX/DXILOpLowering.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpLowering.cpp
@@ -663,8 +663,6 @@ public:
       llvm::function_ref<void(IRBuilder<> &, CallInst *,
                               SmallVectorImpl<Value *> &)> EmitExtraArgs) {
     IRBuilder<> &IRB = OpBuilder.getIRB();
-    Type *FloatTy = IRB.getFloatTy();
-
     return replaceFunction(F, [&](CallInst *CI) -> Error {
       IRB.SetInsertPoint(CI);
 
@@ -678,7 +676,7 @@ public:
       Type *OldTy = CI->getType();
       Type *NewRetTy = OpBuilder.getResRetType(OldTy->getScalarType());
 
-      Value *UndefF = UndefValue::get(FloatTy);
+      Value *UndefF = UndefValue::get(IRB.getFloatTy());
       Value *UndefI = UndefValue::get(IRB.getInt32Ty());
       // Common prefix: Handle, Sampler, Coord0..3, Offset0..2
       SmallVector<Value *, 17> Args{Handle, Sampler, UndefF, UndefF, UndefF,
@@ -722,8 +720,7 @@ public:
                    SmallVectorImpl<Value *> &Args) {
           Value *DDX = CI->getArgOperand(3);
           Value *DDY = CI->getArgOperand(4);
-          Type *FloatTy = IRB.getFloatTy();
-          Value *UndefF = UndefValue::get(FloatTy);
+          Value *UndefF = UndefValue::get(IRB.getFloatTy());
           // DDX0..2
           size_t DDXStart = Args.size();
           Args.append(3, UndefF);

--- a/llvm/test/CodeGen/DirectX/SampleGrad.ll
+++ b/llvm/test/CodeGen/DirectX/SampleGrad.ll
@@ -1,0 +1,338 @@
+; RUN: opt -S -dxil-op-lower %s | FileCheck %s
+
+target triple = "dxil-pc-shadermodel6.6-pixel"
+
+declare void @use_float4(<4 x float>)
+declare void @use_float(float)
+declare void @use_half4(<4 x half>)
+
+; Test basic SampleGrad on a Texture2D with float4 result.
+; CHECK-LABEL: define void @samplegrad_texture2d_float4(
+define void @samplegrad_texture2d_float4(<2 x float> %coords, <2 x float> %ddx, <2 x float> %ddy) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_2t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding.tdx.Sampler_0t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <2 x float> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <2 x float> %coords, i64 1
+  ; CHECK: %[[DDX0:.*]] = extractelement <2 x float> %ddx, i64 0
+  ; CHECK: %[[DDX1:.*]] = extractelement <2 x float> %ddx, i64 1
+  ; CHECK: %[[DDY0:.*]] = extractelement <2 x float> %ddy, i64 0
+  ; CHECK: %[[DDY1:.*]] = extractelement <2 x float> %ddy, i64 1
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32
+  ; CHECK-SAME: @dx.op.sampleGrad.f32(i32 63,
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: float %[[COORD0]], float %[[COORD1]], float undef, float undef,
+  ; CHECK-SAME: i32 undef, i32 undef, i32 undef,
+  ; CHECK-SAME: float %[[DDX0]], float %[[DDX1]], float undef,
+  ; CHECK-SAME: float %[[DDY0]], float %[[DDY1]], float undef,
+  ; CHECK-SAME: float undef)
+  %data = call <4 x float>
+      @llvm.dx.resource.samplegrad.v4f32.tdx.Texture_v4f32_0_0_0_2t.tdx.Sampler_0t.v2f32.v2f32.v2f32.v2i32(
+          target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+          target("dx.Sampler", 0) %sampler,
+          <2 x float> %coords, <2 x float> %ddx, <2 x float> %ddy,
+          <2 x i32> zeroinitializer)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[SAMPLE]], 0
+  call void @use_float4(<4 x float> %data)
+  ret void
+}
+
+; Test SampleGrad with clamp on a Texture2D.
+; CHECK-LABEL: define void @samplegrad_texture2d_with_clamp(
+define void @samplegrad_texture2d_with_clamp(<2 x float> %coords, <2 x float> %ddx, <2 x float> %ddy, float %clamp) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_2t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding.tdx.Sampler_0t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <2 x float> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <2 x float> %coords, i64 1
+  ; CHECK: %[[DDX0:.*]] = extractelement <2 x float> %ddx, i64 0
+  ; CHECK: %[[DDX1:.*]] = extractelement <2 x float> %ddx, i64 1
+  ; CHECK: %[[DDY0:.*]] = extractelement <2 x float> %ddy, i64 0
+  ; CHECK: %[[DDY1:.*]] = extractelement <2 x float> %ddy, i64 1
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32
+  ; CHECK-SAME: @dx.op.sampleGrad.f32(i32 63,
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: float %[[COORD0]], float %[[COORD1]], float undef, float undef,
+  ; CHECK-SAME: i32 undef, i32 undef, i32 undef,
+  ; CHECK-SAME: float %[[DDX0]], float %[[DDX1]], float undef,
+  ; CHECK-SAME: float %[[DDY0]], float %[[DDY1]], float undef,
+  ; CHECK-SAME: float %clamp)
+  %data = call <4 x float>
+      @llvm.dx.resource.samplegrad.clamp.v4f32.tdx.Texture_v4f32_0_0_0_2t.tdx.Sampler_0t.v2f32.v2f32.v2f32.v2i32(
+          target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+          target("dx.Sampler", 0) %sampler,
+          <2 x float> %coords, <2 x float> %ddx, <2 x float> %ddy,
+          <2 x i32> zeroinitializer, float %clamp)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[SAMPLE]], 0
+  call void @use_float4(<4 x float> %data)
+  ret void
+}
+
+; Test SampleGrad with constant non-zero offsets on a Texture2D.
+; CHECK-LABEL: define void @samplegrad_texture2d_with_offset(
+define void @samplegrad_texture2d_with_offset(<2 x float> %coords, <2 x float> %ddx, <2 x float> %ddy) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_2t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding.tdx.Sampler_0t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <2 x float> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <2 x float> %coords, i64 1
+  ; CHECK: %[[DDX0:.*]] = extractelement <2 x float> %ddx, i64 0
+  ; CHECK: %[[DDX1:.*]] = extractelement <2 x float> %ddx, i64 1
+  ; CHECK: %[[DDY0:.*]] = extractelement <2 x float> %ddy, i64 0
+  ; CHECK: %[[DDY1:.*]] = extractelement <2 x float> %ddy, i64 1
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32
+  ; CHECK-SAME: @dx.op.sampleGrad.f32(i32 63,
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: float %[[COORD0]], float %[[COORD1]], float undef, float undef,
+  ; CHECK-SAME: i32 1, i32 -2, i32 undef,
+  ; CHECK-SAME: float %[[DDX0]], float %[[DDX1]], float undef,
+  ; CHECK-SAME: float %[[DDY0]], float %[[DDY1]], float undef,
+  ; CHECK-SAME: float undef)
+  %data = call <4 x float>
+      @llvm.dx.resource.samplegrad.v4f32.tdx.Texture_v4f32_0_0_0_2t.tdx.Sampler_0t.v2f32.v2f32.v2f32.v2i32(
+          target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+          target("dx.Sampler", 0) %sampler,
+          <2 x float> %coords, <2 x float> %ddx, <2 x float> %ddy,
+          <2 x i32> <i32 1, i32 -2>)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[SAMPLE]], 0
+  call void @use_float4(<4 x float> %data)
+  ret void
+}
+
+; Test SampleGrad with dynamic (non-constant) offsets on a Texture2D.
+; CHECK-LABEL: define void @samplegrad_texture2d_with_dynamic_offset(
+define void @samplegrad_texture2d_with_dynamic_offset(<2 x float> %coords, <2 x float> %ddx, <2 x float> %ddy, <2 x i32> %offsets) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_2t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding.tdx.Sampler_0t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <2 x float> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <2 x float> %coords, i64 1
+  ; CHECK: %[[OFF0:.*]] = extractelement <2 x i32> %offsets, i64 0
+  ; CHECK: %[[OFF1:.*]] = extractelement <2 x i32> %offsets, i64 1
+  ; CHECK: %[[DDX0:.*]] = extractelement <2 x float> %ddx, i64 0
+  ; CHECK: %[[DDX1:.*]] = extractelement <2 x float> %ddx, i64 1
+  ; CHECK: %[[DDY0:.*]] = extractelement <2 x float> %ddy, i64 0
+  ; CHECK: %[[DDY1:.*]] = extractelement <2 x float> %ddy, i64 1
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32
+  ; CHECK-SAME: @dx.op.sampleGrad.f32(i32 63,
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: float %[[COORD0]], float %[[COORD1]], float undef, float undef,
+  ; CHECK-SAME: i32 %[[OFF0]], i32 %[[OFF1]], i32 undef,
+  ; CHECK-SAME: float %[[DDX0]], float %[[DDX1]], float undef,
+  ; CHECK-SAME: float %[[DDY0]], float %[[DDY1]], float undef,
+  ; CHECK-SAME: float undef)
+  %data = call <4 x float>
+      @llvm.dx.resource.samplegrad.v4f32.tdx.Texture_v4f32_0_0_0_2t.tdx.Sampler_0t.v2f32.v2f32.v2f32.v2i32(
+          target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+          target("dx.Sampler", 0) %sampler,
+          <2 x float> %coords, <2 x float> %ddx, <2 x float> %ddy,
+          <2 x i32> %offsets)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[SAMPLE]], 0
+  call void @use_float4(<4 x float> %data)
+  ret void
+}
+
+; Test SampleGrad with both offset and clamp on a Texture2D.
+; CHECK-LABEL: define void @samplegrad_texture2d_with_offset_and_clamp(
+define void @samplegrad_texture2d_with_offset_and_clamp(<2 x float> %coords, <2 x float> %ddx, <2 x float> %ddy, float %clamp) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_2t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding.tdx.Sampler_0t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <2 x float> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <2 x float> %coords, i64 1
+  ; CHECK: %[[DDX0:.*]] = extractelement <2 x float> %ddx, i64 0
+  ; CHECK: %[[DDX1:.*]] = extractelement <2 x float> %ddx, i64 1
+  ; CHECK: %[[DDY0:.*]] = extractelement <2 x float> %ddy, i64 0
+  ; CHECK: %[[DDY1:.*]] = extractelement <2 x float> %ddy, i64 1
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32
+  ; CHECK-SAME: @dx.op.sampleGrad.f32(i32 63,
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: float %[[COORD0]], float %[[COORD1]], float undef, float undef,
+  ; CHECK-SAME: i32 3, i32 -1, i32 undef,
+  ; CHECK-SAME: float %[[DDX0]], float %[[DDX1]], float undef,
+  ; CHECK-SAME: float %[[DDY0]], float %[[DDY1]], float undef,
+  ; CHECK-SAME: float %clamp)
+  %data = call <4 x float>
+      @llvm.dx.resource.samplegrad.clamp.v4f32.tdx.Texture_v4f32_0_0_0_2t.tdx.Sampler_0t.v2f32.v2f32.v2f32.v2i32(
+          target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+          target("dx.Sampler", 0) %sampler,
+          <2 x float> %coords, <2 x float> %ddx, <2 x float> %ddy,
+          <2 x i32> <i32 3, i32 -1>, float %clamp)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[SAMPLE]], 0
+  call void @use_float4(<4 x float> %data)
+  ret void
+}
+
+; Test SampleGrad on a Texture1D (scalar coordinate/gradient, scalar offset).
+; CHECK-LABEL: define void @samplegrad_texture1d_float4(
+define void @samplegrad_texture1d_float4(float %coord, float %ddx_scalar, float %ddy_scalar) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 1)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_1t(
+          i32 0, i32 3, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding.tdx.Sampler_0t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32
+  ; CHECK-SAME: @dx.op.sampleGrad.f32(i32 63,
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: float %coord, float undef, float undef, float undef,
+  ; CHECK-SAME: i32 undef, i32 undef, i32 undef,
+  ; CHECK-SAME: float %ddx_scalar, float undef, float undef,
+  ; CHECK-SAME: float %ddy_scalar, float undef, float undef,
+  ; CHECK-SAME: float undef)
+  %data = call <4 x float>
+      @llvm.dx.resource.samplegrad.v4f32.tdx.Texture_v4f32_0_0_0_1t.tdx.Sampler_0t.f32.f32.f32.i32(
+          target("dx.Texture", <4 x float>, 0, 0, 0, 1) %texture,
+          target("dx.Sampler", 0) %sampler,
+          float %coord, float %ddx_scalar, float %ddy_scalar, i32 0)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[SAMPLE]], 0
+  call void @use_float4(<4 x float> %data)
+  ret void
+}
+
+; Test SampleGrad on a Texture3D (3-component coordinates/gradients).
+; CHECK-LABEL: define void @samplegrad_texture3d_float4(
+define void @samplegrad_texture3d_float4(<3 x float> %coords, <3 x float> %ddx, <3 x float> %ddy) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 4)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_4t(
+          i32 0, i32 4, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding.tdx.Sampler_0t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <3 x float> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <3 x float> %coords, i64 1
+  ; CHECK: %[[COORD2:.*]] = extractelement <3 x float> %coords, i64 2
+  ; CHECK: %[[DDX0:.*]] = extractelement <3 x float> %ddx, i64 0
+  ; CHECK: %[[DDX1:.*]] = extractelement <3 x float> %ddx, i64 1
+  ; CHECK: %[[DDX2:.*]] = extractelement <3 x float> %ddx, i64 2
+  ; CHECK: %[[DDY0:.*]] = extractelement <3 x float> %ddy, i64 0
+  ; CHECK: %[[DDY1:.*]] = extractelement <3 x float> %ddy, i64 1
+  ; CHECK: %[[DDY2:.*]] = extractelement <3 x float> %ddy, i64 2
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32
+  ; CHECK-SAME: @dx.op.sampleGrad.f32(i32 63,
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: float %[[COORD0]], float %[[COORD1]], float %[[COORD2]], float undef,
+  ; CHECK-SAME: i32 undef, i32 undef, i32 undef,
+  ; CHECK-SAME: float %[[DDX0]], float %[[DDX1]], float %[[DDX2]],
+  ; CHECK-SAME: float %[[DDY0]], float %[[DDY1]], float %[[DDY2]],
+  ; CHECK-SAME: float undef)
+  %data = call <4 x float>
+      @llvm.dx.resource.samplegrad.v4f32.tdx.Texture_v4f32_0_0_0_4t.tdx.Sampler_0t.v3f32.v3f32.v3f32.v3i32(
+          target("dx.Texture", <4 x float>, 0, 0, 0, 4) %texture,
+          target("dx.Sampler", 0) %sampler,
+          <3 x float> %coords, <3 x float> %ddx, <3 x float> %ddy,
+          <3 x i32> zeroinitializer)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[SAMPLE]], 0
+  call void @use_float4(<4 x float> %data)
+  ret void
+}
+
+; Test SampleGrad with a scalar return type on a Texture2D.
+; CHECK-LABEL: define void @samplegrad_texture2d_scalar(
+define void @samplegrad_texture2d_scalar(<2 x float> %coords, <2 x float> %ddx, <2 x float> %ddy) {
+  %texture = call target("dx.Texture", float, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_f32_0_0_0_2t(
+          i32 0, i32 1, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding.tdx.Sampler_0t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <2 x float> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <2 x float> %coords, i64 1
+  ; CHECK: %[[DDX0:.*]] = extractelement <2 x float> %ddx, i64 0
+  ; CHECK: %[[DDX1:.*]] = extractelement <2 x float> %ddx, i64 1
+  ; CHECK: %[[DDY0:.*]] = extractelement <2 x float> %ddy, i64 0
+  ; CHECK: %[[DDY1:.*]] = extractelement <2 x float> %ddy, i64 1
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32
+  ; CHECK-SAME: @dx.op.sampleGrad.f32(i32 63,
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: float %[[COORD0]], float %[[COORD1]], float undef, float undef,
+  ; CHECK-SAME: i32 undef, i32 undef, i32 undef,
+  ; CHECK-SAME: float %[[DDX0]], float %[[DDX1]], float undef,
+  ; CHECK-SAME: float %[[DDY0]], float %[[DDY1]], float undef,
+  ; CHECK-SAME: float undef)
+  %data = call float
+      @llvm.dx.resource.samplegrad.f32.tdx.Texture_f32_0_0_0_2t.tdx.Sampler_0t.v2f32.v2f32.v2f32.v2i32(
+          target("dx.Texture", float, 0, 0, 0, 2) %texture,
+          target("dx.Sampler", 0) %sampler,
+          <2 x float> %coords, <2 x float> %ddx, <2 x float> %ddy,
+          <2 x i32> zeroinitializer)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[SAMPLE]], 0
+  call void @use_float(float %data)
+  ret void
+}
+
+; Test SampleGrad with half-precision result type on a Texture2D.
+; CHECK-LABEL: define void @samplegrad_texture2d_half4(
+define void @samplegrad_texture2d_half4(<2 x float> %coords, <2 x float> %ddx, <2 x float> %ddy) {
+  %texture = call target("dx.Texture", <4 x half>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f16_0_0_0_2t(
+          i32 0, i32 5, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding.tdx.Sampler_0t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <2 x float> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <2 x float> %coords, i64 1
+  ; CHECK: %[[DDX0:.*]] = extractelement <2 x float> %ddx, i64 0
+  ; CHECK: %[[DDX1:.*]] = extractelement <2 x float> %ddx, i64 1
+  ; CHECK: %[[DDY0:.*]] = extractelement <2 x float> %ddy, i64 0
+  ; CHECK: %[[DDY1:.*]] = extractelement <2 x float> %ddy, i64 1
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f16
+  ; CHECK-SAME: @dx.op.sampleGrad.f16(i32 63,
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: float %[[COORD0]], float %[[COORD1]], float undef, float undef,
+  ; CHECK-SAME: i32 undef, i32 undef, i32 undef,
+  ; CHECK-SAME: float %[[DDX0]], float %[[DDX1]], float undef,
+  ; CHECK-SAME: float %[[DDY0]], float %[[DDY1]], float undef,
+  ; CHECK-SAME: float undef)
+  %data = call <4 x half>
+      @llvm.dx.resource.samplegrad.v4f16.tdx.Texture_v4f16_0_0_0_2t.tdx.Sampler_0t.v2f32.v2f32.v2f32.v2i32(
+          target("dx.Texture", <4 x half>, 0, 0, 0, 2) %texture,
+          target("dx.Sampler", 0) %sampler,
+          <2 x float> %coords, <2 x float> %ddx, <2 x float> %ddy,
+          <2 x i32> zeroinitializer)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f16 %[[SAMPLE]], 0
+  call void @use_half4(<4 x half> %data)
+  ret void
+}


### PR DESCRIPTION
Fixes #192549

This PR builds atop #199745 by adding a helper `lowerSampleOp` function to refactor `lowerSampleBias` and implement `lowerSampleGrad`.

The `lowerSampleGrad` implementation is very similar to `lowerSampleBias`, just with ddx and ddy arguments instead of a bias.
Unlike SampleBias, SampleGrad is usable in all shader stages because it has explicit gradient/derivative arguments.

Assisted-by: GitHub Copilot