### PR TITLE
[Sema] Fix assertion crash on section conflict with a non-identifier decl

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -666,6 +666,9 @@ Bug Fixes to Attribute Support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Fixed a behavioral discrepancy between deleted functions and private members when checking the ``enable_if`` attribute. (#GH175895)
 - Fixed ``init_priority`` attribute by delaying type checks until after the type is deduced.
+- Fixed a crash when a ``section`` attribute or ``#pragma clang section`` caused a
+  section type conflict with a declaration whose name is not a simple identifier,
+  such as a lambda's call operator. (#GH192264)
 
 Bug Fixes to C++ Support
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaAttr.cpp
+++ b/clang/lib/Sema/SemaAttr.cpp
@@ -853,8 +853,7 @@ bool Sema::UnifySection(StringRef SectionName, int SectionFlags,
     return false;
   Diag(Decl->getLocation(), diag::err_section_conflict) << Decl << Section;
   if (Section.Decl)
-    Diag(Section.Decl->getLocation(), diag::note_declared_at)
-        << Section.Decl->getName();
+    Diag(Section.Decl->getLocation(), diag::note_declared_at);
   if (PragmaLocation.isValid())
     Diag(PragmaLocation, diag::note_pragma_entered_here);
   if (Section.PragmaSectionLocation.isValid())
@@ -874,8 +873,7 @@ bool Sema::UnifySection(StringRef SectionName,
       Diag(PragmaSectionLocation, diag::err_section_conflict)
           << "this" << Section;
       if (Section.Decl)
-        Diag(Section.Decl->getLocation(), diag::note_declared_at)
-            << Section.Decl->getName();
+        Diag(Section.Decl->getLocation(), diag::note_declared_at);
       if (Section.PragmaSectionLocation.isValid())
         Diag(Section.PragmaSectionLocation, diag::note_pragma_entered_here);
       return true;

--- a/clang/test/SemaCXX/attr-section.cpp
+++ b/clang/test/SemaCXX/attr-section.cpp
@@ -72,7 +72,7 @@ __attribute__((section("non_trivial_ctor"))) const t1 v2{3}; // expected-error {
 
 // Check that a section conflict with a decl whose name is not a simple
 // identifier (here, a lambda's call operator) is diagnosed without crashing.
-namespace lambda_call_operator {
+namespace GH192264 {
 auto lambda = [](int val) __attribute__((section("lambda_op"))) { return val; }; // expected-note {{declared here}}
 __attribute__((section("lambda_op"))) int i{}; // expected-error {{'i' causes a section type conflict with 'operator()'}}
 } // namespace lambda_call_operator

--- a/clang/test/SemaCXX/attr-section.cpp
+++ b/clang/test/SemaCXX/attr-section.cpp
@@ -69,3 +69,18 @@ __attribute__((section("non_trivial_ctor"))) const t1 v1; // expected-note {{dec
 extern const t1 v2;
 __attribute__((section("non_trivial_ctor"))) const t1 v2{3}; // expected-error {{'v2' causes a section type conflict with 'v1'}}
 } // namespace non_trivial_ctor
+
+// Check that a section conflict with a decl whose name is not a simple
+// identifier (here, a lambda's call operator) is diagnosed without crashing.
+namespace lambda_call_operator {
+auto lambda = [](int val) __attribute__((section("lambda_op"))) { return val; }; // expected-note {{declared here}}
+__attribute__((section("lambda_op"))) int i{}; // expected-error {{'i' causes a section type conflict with 'operator()'}}
+} // namespace lambda_call_operator
+
+// Check that a section conflict with a decl whose name is not a simple
+// identifier (here, a lambda's call operator) is diagnosed without crashing.
+namespace lambda_call_operator_pragma {
+auto lambda = [](int val) __attribute__((section("lambda_op_pragma"))) { return val; }; // expected-note {{declared here}}
+#pragma clang section bss="lambda_op_pragma" // expected-error {{this causes a section type conflict with 'operator()'}}
+#pragma clang section bss=""
+} // namespace lambda_call_operator_pragma

--- a/clang/test/SemaCXX/attr-section.cpp
+++ b/clang/test/SemaCXX/attr-section.cpp
@@ -75,7 +75,7 @@ __attribute__((section("non_trivial_ctor"))) const t1 v2{3}; // expected-error {
 namespace GH192264 {
 auto lambda = [](int val) __attribute__((section("lambda_op"))) { return val; }; // expected-note {{declared here}}
 __attribute__((section("lambda_op"))) int i{}; // expected-error {{'i' causes a section type conflict with 'operator()'}}
-} // namespace lambda_call_operator
+} // namespace GH192264
 
 // Check that a section conflict with a decl whose name is not a simple
 // identifier (here, a lambda's call operator) is diagnosed without crashing.


### PR DESCRIPTION
NamedDecl::getName() asserts the name is a simple identifier, so UnifySection crashed when the conflicting section decl had a special name such as a lambda's call operator.

Drop the argument: `note_declared_at` has no format placeholder, so it was dead code. The error already prints the section decl.

Fixes https://github.com/llvm/llvm-project/issues/192264