### PR TITLE
[CIR] Fix ordering of lifetime-extended cleanups

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCleanup.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCleanup.cpp
@@ -198,9 +198,10 @@ void CIRGenFunction::FullExprCleanupScope::exit(
     cgf.builder.createStore(val.getLoc(), val, temp);
   }
 
-  // Pop any EH and lifetime-extended cleanups that were pushed during
-  // the expression (e.g. temporary destructors).
-  cleanups.forceCleanup();
+  // Pop any EH cleanups that were pushed during the expression but leave
+  // any lifetime-extended cleanups so that they can be promoted to the EH
+  // stack after we've finished emitting any deferred cleanups.
+  cleanups.forceCleanupExceptLifetimeExtended();
 
   // Make sure the cleanup scope body region has a terminator.
   {
@@ -264,6 +265,12 @@ void CIRGenFunction::FullExprCleanupScope::exit(
 
   cgf.deferredConditionalCleanupStack.truncate(oldSize);
   cgf.builder.setInsertionPointAfter(scope);
+
+  // Promote any lifetime-extended cleanups onto the EH scope stack. The new
+  // cir.cleanup.scope ops created here will wrap any code in the enclosing
+  // scope, including reloads of any spilled values below, so the
+  // lifetime-extended destructors run at the correct point.
+  cleanups.forceLifetimeExtendedCleanups();
 
   // Reload spilled values now that the builder is after the closed scope.
   for (auto [addr, valPtr] : llvm::zip(tempAllocas, valuesToReload)) {

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1205,6 +1205,29 @@ public:
       cgf.currentCleanupStackDepth = oldCleanupStackDepth;
     }
 
+    /// Force the emission of EH cleanups now, but defer promoting any
+    /// lifetime-extended cleanup entries onto the EH scope stack. The caller
+    /// must subsequently call forceLifetimeExtendedCleanups() to finalize the
+    /// scope.
+    void forceCleanupExceptLifetimeExtended() {
+      assert(performCleanup && "Already forced cleanup");
+      cgf.didCallStackSave = oldDidCallStackSave;
+      deactivateCleanups.forceDeactivate();
+      cgf.popCleanupBlocks(cleanupStackDepth);
+    }
+
+    /// Promote any pending lifetime-extended cleanup entries onto the EH scope
+    /// stack at the current insertion point and finalize this scope. This must
+    /// be paired with a prior call to forceCleanupExceptLifetimeExtended().
+    void forceLifetimeExtendedCleanups() {
+      assert(performCleanup && "Already forced cleanup");
+      assert(deactivateCleanups.deactivated &&
+             "forceCleanupExceptLifetimeExtended() must be called first");
+      cgf.popCleanupBlocks(cleanupStackDepth, lifetimeExtendedCleanupStackSize);
+      performCleanup = false;
+      cgf.currentCleanupStackDepth = oldCleanupStackDepth;
+    }
+
     /// Whether there are any pending cleanups that have been pushed since
     /// this scope was entered.
     bool hasPendingCleanups() const {

--- a/clang/test/CIR/CodeGen/cleanup-conditional.cpp
+++ b/clang/test/CIR/CodeGen/cleanup-conditional.cpp
@@ -874,3 +874,161 @@ _Complex float test_complex_cond_cleanup(bool b, _Complex float x) {
 // OGCG:       [[DTOR]]:
 // OGCG:         call void @_ZN5CplxDD1Ev(ptr {{.*}} %[[TMP]])
 // OGCG:         br label %[[DONE]]
+
+struct LE {
+  LE(int);
+  ~LE();
+};
+
+void test_lifetime_ext_cond_ref(bool c) {
+  const LE &r = c ? LE(1) : LE(2);
+}
+// CIR-LABEL: @_Z26test_lifetime_ext_cond_refb
+// CIR:   %[[TMP:.*]] = cir.alloca !rec_LE, !cir.ptr<!rec_LE>, ["ref.tmp0"]
+// CIR:   %[[R:.*]] = cir.alloca !cir.ptr<!rec_LE>, !cir.ptr<!cir.ptr<!rec_LE>>, ["r", init, const]
+// CIR:   %[[SPILL:.*]] = cir.alloca !cir.ptr<!rec_LE>, !cir.ptr<!cir.ptr<!rec_LE>>, ["tmp.exprcleanup"]
+// CIR:   cir.if %{{.*}} {
+// CIR:     cir.call @_ZN2LEC1Ei(%[[TMP]], %{{.*}})
+// CIR:   } else {
+// CIR:     cir.call @_ZN2LEC1Ei(%[[TMP]], %{{.*}})
+// CIR:   }
+// CIR:   cir.store {{.*}} %[[TMP]], %[[SPILL]]
+// CIR:   cir.cleanup.scope {
+// CIR:     %[[RELOAD:.*]] = cir.load {{.*}} %[[SPILL]] : !cir.ptr<!cir.ptr<!rec_LE>>, !cir.ptr<!rec_LE>
+// CIR:     cir.store {{.*}} %[[RELOAD]], %[[R]]
+// CIR:     cir.yield
+// CIR:   } cleanup normal {
+// CIR:     cir.call @_ZN2LED1Ev(%[[TMP]]) nothrow
+// CIR:     cir.yield
+// CIR:   }
+// CIR:   cir.return
+
+// LLVM-LABEL: define dso_local void @_Z26test_lifetime_ext_cond_refb(
+// LLVM:   %[[TMP:.*]] = alloca %struct.LE
+// LLVM:   %[[R:.*]] = alloca ptr
+// LLVM:   %[[SPILL:.*]] = alloca ptr
+// LLVM:   br i1 %{{.*}}, label %[[TRUE:.*]], label %[[FALSE:.*]]
+// LLVM: [[TRUE]]:
+// LLVM:   call void @_ZN2LEC1Ei(ptr {{.*}} %[[TMP]], i32 {{.*}} 1)
+// LLVM: [[FALSE]]:
+// LLVM:   call void @_ZN2LEC1Ei(ptr {{.*}} %[[TMP]], i32 {{.*}} 2)
+// LLVM:   store ptr %[[TMP]], ptr %[[SPILL]]
+// LLVM:   %[[RELOAD:.*]] = load ptr, ptr %[[SPILL]]
+// LLVM:   store ptr %[[RELOAD]], ptr %[[R]]
+// LLVM:   call void @_ZN2LED1Ev(ptr {{.*}} %[[TMP]])
+// LLVM:   ret void
+
+// OGCG-LABEL: define dso_local void @_Z26test_lifetime_ext_cond_refb(
+// OGCG:   %[[R:.*]] = alloca ptr
+// OGCG:   %[[TMP:.*]] = alloca %struct.LE
+// OGCG:   br i1 %{{.*}}, label %[[TRUE:.*]], label %[[FALSE:.*]]
+// OGCG: [[TRUE]]:
+// OGCG:   call void @_ZN2LEC1Ei(ptr {{.*}} %[[TMP]], i32 {{.*}} 1)
+// OGCG: [[FALSE]]:
+// OGCG:   call void @_ZN2LEC1Ei(ptr {{.*}} %[[TMP]], i32 {{.*}} 2)
+// OGCG:   store ptr %[[TMP]], ptr %[[R]]
+// OGCG:   call void @_ZN2LED1Ev(ptr {{.*}} %[[TMP]])
+// OGCG:   ret void
+
+void test_combined_cleanups(bool c) {
+  const LE &r = LE((S().get(), c ? B().get() : 0));
+}
+// CIR-LABEL: @_Z22test_combined_cleanupsb
+// CIR:   %[[TMP_LE:.*]] = cir.alloca !rec_LE, !cir.ptr<!rec_LE>, ["ref.tmp0"]
+// CIR:   %[[R:.*]] = cir.alloca !cir.ptr<!rec_LE>, !cir.ptr<!cir.ptr<!rec_LE>>, ["r", init, const]
+// CIR:   %[[TMP_S:.*]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["ref.tmp1"]
+// CIR:   %[[TMP_B:.*]] = cir.alloca !rec_B, !cir.ptr<!rec_B>, ["ref.tmp2"]
+// CIR:   %[[ACT_B:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.cond"]
+// CIR:   %[[SPILL:.*]] = cir.alloca !cir.ptr<!rec_LE>, !cir.ptr<!cir.ptr<!rec_LE>>, ["tmp.exprcleanup"]
+// CIR:   cir.cleanup.scope {
+// CIR:     cir.call @_ZN1SC1Ev(%[[TMP_S]])
+// CIR:     cir.cleanup.scope {
+// CIR:       cir.call @_ZN1S3getEv(%[[TMP_S]])
+// CIR:       cir.store {{.*}}, %[[ACT_B]]
+// CIR:       %{{.*}} = cir.ternary({{.*}}, true {
+// CIR:         cir.call @_ZN1BC1Ev(%[[TMP_B]])
+// CIR:         cir.store {{.*}}, %[[ACT_B]]
+// CIR:         cir.call @_ZN1B3getEv(%[[TMP_B]])
+// CIR:       }, false {
+// CIR:       })
+// CIR:       cir.call @_ZN2LEC1Ei(%[[TMP_LE]], %{{.*}})
+// CIR:       cir.store {{.*}} %[[TMP_LE]], %[[SPILL]]
+// CIR:       cir.yield
+// CIR:     } cleanup normal {
+// CIR:       cir.call @_ZN1SD1Ev(%[[TMP_S]]) nothrow
+// CIR:       cir.yield
+// CIR:     }
+// CIR:     cir.yield
+// CIR:   } cleanup normal {
+// CIR:     %[[FLAG:.*]] = cir.load {{.*}} %[[ACT_B]]
+// CIR:     cir.if %[[FLAG]] {
+// CIR:       cir.call @_ZN1BD1Ev(%[[TMP_B]]) nothrow
+// CIR:     }
+// CIR:     cir.yield
+// CIR:   }
+// CIR:   cir.cleanup.scope {
+// CIR:     %[[RELOAD:.*]] = cir.load {{.*}} %[[SPILL]]
+// CIR:     cir.store {{.*}} %[[RELOAD]], %[[R]]
+// CIR:     cir.yield
+// CIR:   } cleanup normal {
+// CIR:     cir.call @_ZN2LED1Ev(%[[TMP_LE]]) nothrow
+// CIR:     cir.yield
+// CIR:   }
+// CIR:   cir.return
+
+// LLVM-LABEL: define dso_local void @_Z22test_combined_cleanupsb(
+// LLVM:   %[[TMP_LE:.*]] = alloca %struct.LE
+// LLVM:   %[[R:.*]] = alloca ptr
+// LLVM:   %[[TMP_S:.*]] = alloca %struct.S
+// LLVM:   %[[TMP_B:.*]] = alloca %struct.B
+// LLVM:   %[[ACT_B:.*]] = alloca i8
+// LLVM:   %[[SPILL:.*]] = alloca ptr
+// LLVM:   call void @_ZN1SC1Ev(ptr {{.*}} %[[TMP_S]])
+// LLVM:   call {{.*}} i32 @_ZN1S3getEv(ptr {{.*}} %[[TMP_S]])
+// LLVM:   store i8 0, ptr %[[ACT_B]]
+// LLVM:   br i1 %{{.*}}, label %[[T:.*]], label %[[F:.*]]
+// LLVM: [[T]]:
+// LLVM:   call void @_ZN1BC1Ev(ptr {{.*}} %[[TMP_B]])
+// LLVM:   store i8 1, ptr %[[ACT_B]]
+// LLVM:   call {{.*}} i32 @_ZN1B3getEv(ptr {{.*}} %[[TMP_B]])
+// LLVM: [[F]]:
+// LLVM:   phi i32 [ 0, %[[F]] ], [ %{{.*}}, %[[T]] ]
+// LLVM:   call void @_ZN2LEC1Ei(ptr {{.*}} %[[TMP_LE]], i32 {{.*}})
+// LLVM:   store ptr %[[TMP_LE]], ptr %[[SPILL]]
+// LLVM:   call void @_ZN1SD1Ev(ptr {{.*}} %[[TMP_S]])
+// LLVM:   %[[FLAG_BYTE:.*]] = load i8, ptr %[[ACT_B]]
+// LLVM:   %[[FLAG:.*]] = trunc i8 %[[FLAG_BYTE]] to i1
+// LLVM:   br i1 %[[FLAG]], label %[[B_DTOR:.*]], label %[[B_DONE:.*]]
+// LLVM: [[B_DTOR]]:
+// LLVM:   call void @_ZN1BD1Ev(ptr {{.*}} %[[TMP_B]])
+// LLVM: [[B_DONE]]:
+// LLVM:   %[[RELOAD:.*]] = load ptr, ptr %[[SPILL]]
+// LLVM:   store ptr %[[RELOAD]], ptr %[[R]]
+// LLVM:   call void @_ZN2LED1Ev(ptr {{.*}} %[[TMP_LE]])
+// LLVM:   ret void
+
+// OGCG-LABEL: define dso_local void @_Z22test_combined_cleanupsb(
+// OGCG:   %[[R:.*]] = alloca ptr
+// OGCG:   %[[TMP_LE:.*]] = alloca %struct.LE
+// OGCG:   %[[TMP_S:.*]] = alloca %struct.S
+// OGCG:   %[[TMP_B:.*]] = alloca %struct.B
+// OGCG:   %[[ACT_B:.*]] = alloca i1
+// OGCG:   call void @_ZN1SC1Ev(ptr {{.*}} %[[TMP_S]])
+// OGCG:   call {{.*}} i32 @_ZN1S3getEv(ptr {{.*}} %[[TMP_S]])
+// OGCG:   store i1 false, ptr %[[ACT_B]]
+// OGCG:   br i1 %{{.*}}, label %[[T:.*]], label %[[F:.*]]
+// OGCG: [[T]]:
+// OGCG:   call void @_ZN1BC1Ev(ptr {{.*}} %[[TMP_B]])
+// OGCG:   store i1 true, ptr %[[ACT_B]]
+// OGCG:   call {{.*}} i32 @_ZN1B3getEv(ptr {{.*}} %[[TMP_B]])
+// OGCG: [[F]]:
+// OGCG:   phi i32
+// OGCG:   call void @_ZN2LEC1Ei(ptr {{.*}} %[[TMP_LE]], i32 {{.*}})
+// OGCG:   br i1 %{{.*}}, label %[[B_DTOR:.*]], label %[[B_DONE:.*]]
+// OGCG: [[B_DTOR]]:
+// OGCG:   call void @_ZN1BD1Ev(ptr {{.*}} %[[TMP_B]])
+// OGCG: [[B_DONE]]:
+// OGCG:   call void @_ZN1SD1Ev(ptr {{.*}} %[[TMP_S]])
+// OGCG:   store ptr %[[TMP_LE]], ptr %[[R]]
+// OGCG:   call void @_ZN2LED1Ev(ptr {{.*}} %[[TMP_LE]])
+// OGCG:   ret void

--- a/clang/test/CIR/CodeGen/loop-cond-cleanup.cpp
+++ b/clang/test/CIR/CodeGen/loop-cond-cleanup.cpp
@@ -279,9 +279,9 @@ void while_body_temp_ref() {
 // LLVM: [[FALSE]]:
 // LLVM:   call void @_ZN1SC1Ev(ptr {{.*}} %[[REF_TMP]])
 // LLVM:   store ptr %[[REF_TMP]], ptr %[[SPILL]]
-// LLVM:   call void @_ZN1SD1Ev(ptr {{.*}} %[[REF_TMP]])
 // LLVM:   %[[RELOAD:.*]] = load ptr, ptr %[[SPILL]]
 // LLVM:   store ptr %[[RELOAD]], ptr %[[OP]]
+// LLVM:   call void @_ZN1SD1Ev(ptr {{.*}} %[[REF_TMP]])
 // LLVM:   br label %[[LOOP_COND]]
 // LLVM: [[AFTER]]:
 // LLVM:   ret void
@@ -346,9 +346,9 @@ void for_body_temp_ref() {
 // LLVM: [[FALSE]]:
 // LLVM:   call void @_ZN1SC1Ev(ptr {{.*}} %[[REF_TMP]])
 // LLVM:   store ptr %[[REF_TMP]], ptr %[[SPILL]]
-// LLVM:   call void @_ZN1SD1Ev(ptr {{.*}} %[[REF_TMP]])
 // LLVM:   %[[RELOAD:.*]] = load ptr, ptr %[[SPILL]]
 // LLVM:   store ptr %[[RELOAD]], ptr %[[OP]]
+// LLVM:   call void @_ZN1SD1Ev(ptr {{.*}} %[[REF_TMP]])
 // LLVM:   %[[OLDI:.*]] = load i32, ptr %[[I]]
 // LLVM:   %[[NEWI:.*]] = add nsw i32 %[[OLDI]], 1
 // LLVM:   store i32 %[[NEWI]], ptr %[[I]]
@@ -421,9 +421,9 @@ void do_body_temp_ref() {
 // LLVM: [[FALSE]]:
 // LLVM:   call void @_ZN1SC1Ev(ptr {{.*}} %[[REF_TMP]])
 // LLVM:   store ptr %[[REF_TMP]], ptr %[[SPILL]]
-// LLVM:   call void @_ZN1SD1Ev(ptr {{.*}} %[[REF_TMP]])
 // LLVM:   %[[RELOAD:.*]] = load ptr, ptr %[[SPILL]]
 // LLVM:   store ptr %[[RELOAD]], ptr %[[OP]]
+// LLVM:   call void @_ZN1SD1Ev(ptr {{.*}} %[[REF_TMP]])
 // LLVM:   br label %[[LOOP_COND]]
 // LLVM: [[AFTER]]:
 // LLVM:   ret void


### PR DESCRIPTION
We had a bug that was causing any lifetime-extended cleanups that occurred within a full-expression cleanup scope to be emitted prematurely when the expression also required deferred conditional cleanups. This was, in some cases, causing a dangling reference to temporaries that had already been destructed. Luckily, it was also causing us to not emit a return at the end of the function in one case, leading the verifier to draw attention to this problem.

This change introduces new functions in RunCleanupsScope to allow "ordinary" EH stack cleanups to be force-emitted separately from lifetime-extended cleanups. Classic codegen doesn't need this capability because it handles deferred conditional cleanups very differently than CIR due to its flat/branching approach.

The testing for this fix did uncover a significant issue wherein CIR is calling destructors in the wrong order even after the fix in this PR. However, that's a pre-existing issue that will require changes beyond the scope of this fix, so I'll handle it in a follow-up.

Assisted-by: Cursor / claude-opus-4.7