### PR TITLE
[lldb][Windows] Default-initialize PseudoConsole Kernel32 members

### DIFF
--- a/lldb/source/Host/windows/PseudoConsole.cpp
+++ b/lldb/source/Host/windows/PseudoConsole.cpp
@@ -57,10 +57,10 @@ struct Kernel32 {
   bool IsConPTYAvailable() { return isAvailable; }
 
 private:
-  HMODULE hModule;
-  CreatePseudoConsole_t CreatePseudoConsole_;
-  ClosePseudoConsole_t ClosePseudoConsole_;
-  bool isAvailable;
+  HMODULE hModule = nullptr;
+  CreatePseudoConsole_t CreatePseudoConsole_ = nullptr;
+  ClosePseudoConsole_t ClosePseudoConsole_ = nullptr;
+  bool isAvailable = false;
 };
 
 static Kernel32 kernel32;


### PR DESCRIPTION
If `LoadLibraryW(L\"kernel32.dll\")` fails, none of the class members are written to. Subsequent reads will read unitialized variables.

This is highly unlikely to happen as `LoadLibraryW(L\"kernel32.dll\")` is unlikely.