### PR TITLE
[lldb][windows] return false in default branch of RegisterContextWindows_*::WriteRegister

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/arm/RegisterContextWindows_arm.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/arm/RegisterContextWindows_arm.cpp
@@ -14,6 +14,7 @@
 #include "lldb/Utility/Status.h"
 #include "lldb/lldb-private-types.h"
 
+#include "ProcessWindowsLog.h"
 #include "RegisterContextWindows_arm.h"
 #include "TargetThreadWindows.h"
 

--- a/lldb/source/Plugins/Process/Windows/Common/arm/RegisterContextWindows_arm.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/arm/RegisterContextWindows_arm.cpp
@@ -274,6 +274,7 @@ bool RegisterContextWindows_arm::WriteRegister(const RegisterInfo *reg_info,
 
   const uint32_t reg = reg_info->kinds[eRegisterKindLLDB];
 
+  Log *log = GetLog(WindowsLog::Registers);
   switch (reg) {
   case gpr_r0:
     m_context.R0 = reg_value.GetAsUInt32();
@@ -421,6 +422,8 @@ bool RegisterContextWindows_arm::WriteRegister(const RegisterInfo *reg_info,
     break;
 
   default:
+    LLDB_LOG(log, "Write value {0:x} to unknown register {1}",
+             reg_value.GetAsUInt32(), reg);
     return false;
   }
 

--- a/lldb/source/Plugins/Process/Windows/Common/x64/RegisterContextWindows_x64.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/x64/RegisterContextWindows_x64.cpp
@@ -494,6 +494,7 @@ bool RegisterContextWindows_x64::WriteRegister(const RegisterInfo *reg_info,
   if (!CacheAllRegisterValues())
     return false;
 
+  Log *log = GetLog(WindowsLog::Registers);
   switch (reg_info->kinds[eRegisterKindLLDB]) {
   case lldb_rax_x86_64:
     m_context.Rax = reg_value.GetAsUInt64();
@@ -597,6 +598,10 @@ bool RegisterContextWindows_x64::WriteRegister(const RegisterInfo *reg_info,
   case lldb_xmm15_x86_64:
     memcpy(&m_context.Xmm15, reg_value.GetBytes(), 16);
     break;
+  default:
+    LLDB_LOG(log, "Write value {0:x} to unknown register {1}",
+             reg_value.GetAsUInt32(), reg);
+    return false;
   }
 
   // Physically update the registers in the target process.

--- a/lldb/source/Plugins/Process/Windows/Common/x64/RegisterContextWindows_x64.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/x64/RegisterContextWindows_x64.cpp
@@ -14,10 +14,11 @@
 #include "lldb/Utility/Status.h"
 #include "lldb/lldb-private-types.h"
 
-#include "RegisterContextWindows_x64.h"
 #include "Plugins/Process/Utility/RegisterContext_x86.h"
-#include "TargetThreadWindows.h"
 #include "Plugins/Process/Utility/lldb-x86-register-enums.h"
+#include "ProcessWindowsLog.h"
+#include "RegisterContextWindows_x64.h"
+#include "TargetThreadWindows.h"
 
 #include "llvm/ADT/STLExtras.h"
 
@@ -494,8 +495,10 @@ bool RegisterContextWindows_x64::WriteRegister(const RegisterInfo *reg_info,
   if (!CacheAllRegisterValues())
     return false;
 
+  const uint32_t reg = reg_info->kinds[eRegisterKindLLDB];
+
   Log *log = GetLog(WindowsLog::Registers);
-  switch (reg_info->kinds[eRegisterKindLLDB]) {
+  switch (reg) {
   case lldb_rax_x86_64:
     m_context.Rax = reg_value.GetAsUInt64();
     break;

--- a/lldb/source/Plugins/Process/Windows/Common/x86/RegisterContextWindows_x86.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/x86/RegisterContextWindows_x86.cpp
@@ -258,6 +258,7 @@ bool RegisterContextWindows_x86::WriteRegister(const RegisterInfo *reg_info,
   default:
     LLDB_LOG(log, "Write value {0:x} to unknown register {1}",
              reg_value.GetAsUInt32(), reg);
+    return false;
   }
 
   // Physically update the registers in the target process.


### PR DESCRIPTION
Other implementations return `false` if something went wrong. The default branch just logs an error and continues. This patch converts it to return `false` instead.