### PR TITLE
[LV] Add users to header phis in tests (NFC).

### DIFF
--- a/llvm/test/Transforms/LoopVectorize/VPlan/vplan-printing-reductions.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/vplan-printing-reductions.ll
@@ -1429,6 +1429,7 @@ define i64 @print_ext_mul_two_uses(i64 %n, ptr %a, i16 %b, i32 %c) {
 ; CHECK-NEXT:    WIDEN-CAST ir<%load.ext> = sext ir<%load> to i32
 ; CHECK-NEXT:    WIDEN-CAST ir<%load.ext.ext> = sext ir<%load.ext> to i64
 ; CHECK-NEXT:    EMIT vp<[[VP7:%[0-9]+]]> = compute-reduction-result (add, in-loop) vp<[[VP5]]>
+; CHECK-NEXT:    EMIT vp<%vector.recur.extract.for.phi> = extract-penultimate-element ir<%load.ext.ext>
 ; CHECK-NEXT:    EMIT vp<[[VP8:%[0-9]+]]> = extract-last-part ir<%load.ext.ext>
 ; CHECK-NEXT:    EMIT vp<%vector.recur.extract> = extract-last-lane vp<[[VP8]]>
 ; CHECK-NEXT:    EMIT vp<%cmp.n> = icmp eq vp<[[VP2]]>, vp<[[VP1]]>
@@ -1436,7 +1437,9 @@ define i64 @print_ext_mul_two_uses(i64 %n, ptr %a, i16 %b, i32 %c) {
 ; CHECK-NEXT:  Successor(s): ir-bb<exit>, scalar.ph
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  ir-bb<exit>:
+; CHECK-NEXT:    IR   %res1.lcssa = phi i64 [ %res1, %loop ] (extra operand: vp<%vector.recur.extract.for.phi> from middle.block)
 ; CHECK-NEXT:    IR   %add.lcssa = phi i64 [ %add, %loop ] (extra operand: vp<[[VP7]]> from middle.block)
+; CHECK-NEXT:    IR   %res = add i64 %res1.lcssa, %add.lcssa
 ; CHECK-NEXT:  No successors
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  scalar.ph:
@@ -1482,7 +1485,8 @@ loop:
   br i1 %exitcond740.not, label %exit, label %loop
 
 exit:
-  ret i64 %add
+  %res = add i64 %res1, %add
+  ret i64 %res
 }
 
 define i32 @print_umax_reduction_out_of_loop(ptr %y) {

--- a/llvm/test/Transforms/LoopVectorize/iv_outside_user.ll
+++ b/llvm/test/Transforms/LoopVectorize/iv_outside_user.ll
@@ -1194,6 +1194,8 @@ define i32 @iv_ext_used_outside( ptr %dst) {
 ; VEC-NEXT:    br i1 [[EC]], label %[[LOOP]], label %[[EXIT:.*]], {{!llvm.loop ![0-9]+}}
 ; VEC:       [[EXIT]]:
 ; VEC-NEXT:    [[IV_1_EXT_LCSSA:%.*]] = phi i32 [ [[IV_1_EXT]], %[[LOOP]] ]
+; VEC-NEXT:    [[IV_2_LCSSA:%.*]] = phi i32 [ [[IV_2]], %[[LOOP]] ]
+; VEC-NEXT:    [[ADD:%.*]] = add i32 [[IV_1_EXT_LCSSA]], [[IV_2_LCSSA]]
 ; VEC-NEXT:    ret i32 [[IV_1_EXT_LCSSA]]
 ;
 ; INTERLEAVE-LABEL: define i32 @iv_ext_used_outside(
@@ -1228,6 +1230,8 @@ define i32 @iv_ext_used_outside( ptr %dst) {
 ; INTERLEAVE-NEXT:    br i1 [[EC]], label %[[LOOP]], label %[[EXIT:.*]], {{!llvm.loop ![0-9]+}}
 ; INTERLEAVE:       [[EXIT]]:
 ; INTERLEAVE-NEXT:    [[IV_1_EXT_LCSSA:%.*]] = phi i32 [ [[IV_1_EXT]], %[[LOOP]] ]
+; INTERLEAVE-NEXT:    [[IV_2_LCSSA:%.*]] = phi i32 [ [[IV_2]], %[[LOOP]] ]
+; INTERLEAVE-NEXT:    [[ADD:%.*]] = add i32 [[IV_1_EXT_LCSSA]], [[IV_2_LCSSA]]
 ; INTERLEAVE-NEXT:    ret i32 [[IV_1_EXT_LCSSA]]
 ;
 entry:
@@ -1245,6 +1249,8 @@ loop:
 
 exit:
   %iv.1.ext.lcssa = phi i32 [ %iv.1.ext, %loop ]
+  %iv.2.lcssa = phi i32 [ %iv.2, %loop ]
+  %add = add i32 %iv.1.ext.lcssa, %iv.2.lcssa
   ret i32 %iv.1.ext.lcssa
 }
 

--- a/llvm/test/Transforms/LoopVectorize/replace-first-order-recurrence-by-versioned-iv.ll
+++ b/llvm/test/Transforms/LoopVectorize/replace-first-order-recurrence-by-versioned-iv.ll
@@ -159,8 +159,8 @@ for.end:
   ret void
 }
 
-define void @do_not_replace_first_order_recurrence_with_versioned_iv_for_wide_pointer_use(ptr %y, ptr %x, i32 %n) {
-; CHECK-LABEL: define void @do_not_replace_first_order_recurrence_with_versioned_iv_for_wide_pointer_use(
+define i64 @do_not_replace_first_order_recurrence_with_versioned_iv_for_wide_pointer_use(ptr %y, ptr %x, i32 %n) {
+; CHECK-LABEL: define i64 @do_not_replace_first_order_recurrence_with_versioned_iv_for_wide_pointer_use(
 ; CHECK-SAME: ptr [[Y:%.*]], ptr [[X:%.*]], i32 [[N:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*]]:
 ; CHECK-NEXT:    [[X2:%.*]] = ptrtoaddr ptr [[X]] to i64
@@ -196,6 +196,7 @@ define void @do_not_replace_first_order_recurrence_with_versioned_iv_for_wide_po
 ; CHECK-NEXT:    [[TMP12:%.*]] = icmp eq i64 [[INDEX_NEXT]], [[N_VEC]]
 ; CHECK-NEXT:    br i1 [[TMP12]], label %[[MIDDLE_BLOCK:.*]], label %[[VECTOR_BODY]], !llvm.loop [[LOOP6:![0-9]+]]
 ; CHECK:       [[MIDDLE_BLOCK]]:
+; CHECK-NEXT:    [[IND_ESCAPE:%.*]] = sub i64 [[N_VEC]], 1
 ; CHECK-NEXT:    [[CMP_N:%.*]] = icmp eq i64 [[TMP0]], [[N_VEC]]
 ; CHECK-NEXT:    br i1 [[CMP_N]], label %[[FOR_END:.*]], label %[[SCALAR_PH]]
 ; CHECK:       [[SCALAR_PH]]:
@@ -215,7 +216,8 @@ define void @do_not_replace_first_order_recurrence_with_versioned_iv_for_wide_po
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[I32NEXT]], [[N]]
 ; CHECK-NEXT:    br i1 [[CMP]], label %[[FOR_BODY]], label %[[FOR_END]], !llvm.loop [[LOOP7:![0-9]+]]
 ; CHECK:       [[FOR_END]]:
-; CHECK-NEXT:    ret void
+; CHECK-NEXT:    [[PHI64_LCSSA:%.*]] = phi i64 [ [[PHI64]], %[[FOR_BODY]] ], [ [[IND_ESCAPE]], %[[MIDDLE_BLOCK]] ]
+; CHECK-NEXT:    ret i64 [[PHI64_LCSSA]]
 ;
 entry:
   br label %for.body
@@ -234,7 +236,7 @@ for.body:
   br i1 %cmp, label %for.body, label %for.end
 
 for.end:
-  ret void
+  ret i64 %phi64
 }
 
 define void @replace_first_order_recurrence_with_versioned_iv_for_uniform_non_pointer_use(ptr %y, ptr %x, i64 %n) {


### PR DESCRIPTION
Make sure the header phis in various tests are actually used, to make them more robust w.r.t. to future simplification changes. Those dead phis would be cleaned up before LV in the regular pipeline.