### PR TITLE
instruction selection pattern for `cond_br`

### DIFF
--- a/cond_br.asm
+++ b/cond_br.asm
@@ -8,12 +8,27 @@
 cond_br_demo:                           # @cond_br_demo
 	.cfi_startproc
 # %bb.0:
-	andi	a2, a2, 1
-	beqz	a2, .LBB0_2
-# %bb.1:
+	addi	sp, sp, -16
+	.cfi_def_cfa_offset 16
+	.cfi_remember_state
+	mv	a3, a2
+	mv	a2, a1
+	mv	a1, a0
+	andi	a0, a3, 1
+	sd	a2, 0(sp)                       # 8-byte Folded Spill
+	sd	a1, 8(sp)                       # 8-byte Folded Spill
+	beqz	a0, .LBB0_2
+	j	.LBB0_1
+.LBB0_1:
+	ld	a0, 8(sp)                       # 8-byte Folded Reload
+	addi	sp, sp, 16
+	.cfi_def_cfa_offset 0
 	ret
 .LBB0_2:
-	mv	a0, a1
+	.cfi_restore_state
+	ld	a0, 0(sp)                       # 8-byte Folded Reload
+	addi	sp, sp, 16
+	.cfi_def_cfa_offset 0
 	ret
 .Lfunc_end0:
 	.size	cond_br_demo, .Lfunc_end0-cond_br_demo

--- a/cond_br.asm
+++ b/cond_br.asm
@@ -1,0 +1,22 @@
+	.attribute	4, 16
+	.attribute	5, "rv64i2p1_m2p0_b1p0_zmmul1p0_zba1p0_zbb1p0_zbs1p0"
+	.file	"LLVMDialectModule"
+	.text
+	.globl	cond_br_demo                    # -- Begin function cond_br_demo
+	.p2align	2
+	.type	cond_br_demo,@function
+cond_br_demo:                           # @cond_br_demo
+	.cfi_startproc
+# %bb.0:
+	andi	a2, a2, 1
+	beqz	a2, .LBB0_2
+# %bb.1:
+	ret
+.LBB0_2:
+	mv	a0, a1
+	ret
+.Lfunc_end0:
+	.size	cond_br_demo, .Lfunc_end0-cond_br_demo
+	.cfi_endproc
+                                        # -- End function
+	.section	".note.GNU-stack","",@progbits

--- a/cond_br.ll
+++ b/cond_br.ll
@@ -1,0 +1,16 @@
+; ModuleID = 'LLVMDialectModule'
+source_filename = "LLVMDialectModule"
+
+define i32 @cond_br_demo(i32 %0, i32 %1, i1 %2) {
+  br i1 %2, label %4, label %5
+
+4:                                                ; preds = %3
+  ret i32 %0
+
+5:                                                ; preds = %3
+  ret i32 %1
+}
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}

--- a/cond_br.mlir
+++ b/cond_br.mlir
@@ -1,0 +1,9 @@
+llvm.func @cond_br_demo(%arg0: i32, %arg1: i32, %cond: i1) -> i32 {
+  llvm.cond_br %cond, ^true_bb, ^false_bb
+
+^true_bb:
+  llvm.return %arg0 : i32
+
+^false_bb:
+  llvm.return %arg1 : i32
+}

--- a/cond_br_diamond.asm
+++ b/cond_br_diamond.asm
@@ -1,0 +1,38 @@
+	.attribute	4, 16
+	.attribute	5, "rv64i2p1_m2p0_b1p0_zmmul1p0_zba1p0_zbb1p0_zbs1p0"
+	.file	"LLVMDialectModule"
+	.text
+	.globl	diamond_cond_br                 # -- Begin function diamond_cond_br
+	.p2align	2
+	.type	diamond_cond_br,@function
+diamond_cond_br:                        # @diamond_cond_br
+	.cfi_startproc
+# %bb.0:
+	addi	sp, sp, -32
+	.cfi_def_cfa_offset 32
+	mv	a3, a2
+	mv	a2, a1
+	sext.w	a1, a0
+	sd	a3, 16(sp)                      # 8-byte Folded Spill
+	sd	a2, 24(sp)                      # 8-byte Folded Spill
+	li	a0, 0
+	bge	a0, a1, .LBB0_2
+	j	.LBB0_1
+.LBB0_1:
+	ld	a0, 24(sp)                      # 8-byte Folded Reload
+	sd	a0, 8(sp)                       # 8-byte Folded Spill
+	j	.LBB0_3
+.LBB0_2:
+	ld	a0, 16(sp)                      # 8-byte Folded Reload
+	sd	a0, 8(sp)                       # 8-byte Folded Spill
+	j	.LBB0_3
+.LBB0_3:
+	ld	a0, 8(sp)                       # 8-byte Folded Reload
+	addi	sp, sp, 32
+	.cfi_def_cfa_offset 0
+	ret
+.Lfunc_end0:
+	.size	diamond_cond_br, .Lfunc_end0-diamond_cond_br
+	.cfi_endproc
+                                        # -- End function
+	.section	".note.GNU-stack","",@progbits

--- a/cond_br_diamond.ll
+++ b/cond_br_diamond.ll
@@ -1,0 +1,21 @@
+; ModuleID = 'LLVMDialectModule'
+source_filename = "LLVMDialectModule"
+
+define i32 @diamond_cond_br(i32 %0, i32 %1, i32 %2) {
+  %4 = icmp sgt i32 %0, 0
+  br i1 %4, label %5, label %6
+
+5:                                                ; preds = %3
+  br label %7
+
+6:                                                ; preds = %3
+  br label %7
+
+7:                                                ; preds = %5, %6
+  %8 = phi i32 [ %2, %6 ], [ %1, %5 ]
+  ret i32 %8
+}
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}

--- a/cond_br_diamond.mlir
+++ b/cond_br_diamond.mlir
@@ -1,0 +1,15 @@
+llvm.func @diamond_cond_br(%x: i32, %y: i32, %z: i32) -> i32 {
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %cond = llvm.icmp "sgt" %x, %zero : i32
+
+  llvm.cond_br %cond, ^then_bb, ^else_bb
+
+^then_bb:
+  llvm.br ^join(%y : i32)
+
+^else_bb:
+  llvm.br ^join(%z : i32)
+
+^join(%result : i32):
+  llvm.return %result : i32
+}

--- a/cond_br_loop.asm
+++ b/cond_br_loop.asm
@@ -1,0 +1,47 @@
+	.attribute	4, 16
+	.attribute	5, "rv64i2p1_m2p0_b1p0_zmmul1p0_zba1p0_zbb1p0_zbs1p0"
+	.file	"LLVMDialectModule"
+	.text
+	.globl	loop_cond_br                    # -- Begin function loop_cond_br
+	.p2align	2
+	.type	loop_cond_br,@function
+loop_cond_br:                           # @loop_cond_br
+	.cfi_startproc
+# %bb.0:
+	addi	sp, sp, -48
+	.cfi_def_cfa_offset 48
+	mv	a1, a0
+	li	a0, 0
+	sd	a1, 24(sp)                      # 8-byte Folded Spill
+	mv	a1, a0
+	sd	a1, 32(sp)                      # 8-byte Folded Spill
+	sd	a0, 40(sp)                      # 8-byte Folded Spill
+	j	.LBB0_1
+.LBB0_1:                                # =>This Inner Loop Header: Depth=1
+	ld	a1, 24(sp)                      # 8-byte Folded Reload
+	ld	a0, 32(sp)                      # 8-byte Folded Reload
+	ld	a2, 40(sp)                      # 8-byte Folded Reload
+	sd	a2, 8(sp)                       # 8-byte Folded Spill
+	sd	a0, 16(sp)                      # 8-byte Folded Spill
+	sext.w	a1, a1
+	sext.w	a0, a0
+	bge	a0, a1, .LBB0_3
+	j	.LBB0_2
+.LBB0_2:                                #   in Loop: Header=BB0_1 Depth=1
+	ld	a1, 16(sp)                      # 8-byte Folded Reload
+	ld	a0, 8(sp)                       # 8-byte Folded Reload
+	addw	a0, a0, a1
+	addiw	a1, a1, 1
+	sd	a1, 32(sp)                      # 8-byte Folded Spill
+	sd	a0, 40(sp)                      # 8-byte Folded Spill
+	j	.LBB0_1
+.LBB0_3:
+	ld	a0, 8(sp)                       # 8-byte Folded Reload
+	addi	sp, sp, 48
+	.cfi_def_cfa_offset 0
+	ret
+.Lfunc_end0:
+	.size	loop_cond_br, .Lfunc_end0-loop_cond_br
+	.cfi_endproc
+                                        # -- End function
+	.section	".note.GNU-stack","",@progbits

--- a/cond_br_loop.ll
+++ b/cond_br_loop.ll
@@ -1,0 +1,24 @@
+; ModuleID = 'LLVMDialectModule'
+source_filename = "LLVMDialectModule"
+
+define i32 @loop_cond_br(i32 %0) {
+  br label %2
+
+2:                                                ; preds = %6, %1
+  %3 = phi i32 [ %8, %6 ], [ 0, %1 ]
+  %4 = phi i32 [ %7, %6 ], [ 0, %1 ]
+  %5 = icmp sge i32 %3, %0
+  br i1 %5, label %9, label %6
+
+6:                                                ; preds = %2
+  %7 = add i32 %4, %3
+  %8 = add i32 %3, 1
+  br label %2
+
+9:                                                ; preds = %2
+  ret i32 %4
+}
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}

--- a/cond_br_loop.mlir
+++ b/cond_br_loop.mlir
@@ -1,0 +1,17 @@
+llvm.func @loop_cond_br(%n: i32) -> i32 {
+  %zero = llvm.mlir.constant(0 : i32) : i32
+  %one  = llvm.mlir.constant(1 : i32) : i32
+  llvm.br ^header(%zero, %zero : i32, i32)   // i=0, sum=0
+
+^header(%i: i32, %sum: i32):
+  %done = llvm.icmp "sge" %i, %n : i32       // i >= n ?
+  llvm.cond_br %done, ^exit, ^body
+
+^body:
+  %sum2 = llvm.add %sum, %i : i32
+  %i2   = llvm.add %i,   %one : i32
+  llvm.br ^header(%i2, %sum2 : i32, i32)     // back-edge
+
+^exit:
+  llvm.return %sum : i32
+}


### PR DESCRIPTION
obtained via:
`mlir-translate --mlir-to-llvmir file.mlir -o file.ll`
`llc file.ll -O0 -march=riscv64 -mattr=+m,+b -filetype=asm -o file.asm`