### PR TITLE
[libc] Add a placeholder for swprintf function

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -1282,6 +1282,8 @@ if(LLVM_LIBC_ENABLE_EXPERIMENTAL_ENTRYPOINTS)
       libc.src.regex.regexec
       libc.src.regex.regerror
       libc.src.regex.regfree
+      # wchar.h entrypoints
+      libc.src.wchar.swprintf      
     )
   endif()
 endif()

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1506,6 +1506,8 @@ if(LLVM_LIBC_ENABLE_EXPERIMENTAL_ENTRYPOINTS)
       libc.src.regex.regexec
       libc.src.regex.regerror
       libc.src.regex.regfree
+      # wchar.h entrypoints
+      libc.src.wchar.swprintf
     )
   endif()
 endif()

--- a/libc/include/wchar.yaml
+++ b/libc/include/wchar.yaml
@@ -438,4 +438,3 @@ functions:
       - type: size_t
       - type: const wchar_t *__restrict
       - type: '...'
-

--- a/libc/include/wchar.yaml
+++ b/libc/include/wchar.yaml
@@ -429,3 +429,13 @@ functions:
     arguments:
       - type: wint_t
       - type: FILE *
+  - name: swprintf
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: wchar_t *__restrict
+      - type: size_t
+      - type: const wchar_t *__restrict
+      - type: '...'
+

--- a/libc/src/wchar/CMakeLists.txt
+++ b/libc/src/wchar/CMakeLists.txt
@@ -724,3 +724,16 @@ add_entrypoint_object(
     libc.src.__support.macros.config
     libc.src.stdio.stdout
 )
+
+add_entrypoint_object(
+  swprintf
+  SRCS
+    swprintf.cpp
+  HDRS
+    swprintf.h
+  DEPENDS
+    libc.hdr.types.size_t
+    libc.hdr.types.wchar_t
+    libc.src.__support.common
+    libc.src.__support.macros.config
+)

--- a/libc/src/wchar/CMakeLists.txt
+++ b/libc/src/wchar/CMakeLists.txt
@@ -734,6 +734,8 @@ add_entrypoint_object(
   DEPENDS
     libc.hdr.types.size_t
     libc.hdr.types.wchar_t
+    libc.hdr.errno_macros
     libc.src.__support.common
     libc.src.__support.macros.config
+    libc.src.errno.errno
 )

--- a/libc/src/wchar/swprintf.cpp
+++ b/libc/src/wchar/swprintf.cpp
@@ -23,11 +23,9 @@
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, swprintf,
-                   (wchar_t *__restrict buffer, size_t bufsz,
-                    const wchar_t *__restrict format, ...)) {
-  (void)buffer;
-  (void)bufsz;
-  (void)format;
+                   ([[maybe_unused]] wchar_t *__restrict buffer,
+                    [[maybe_unused]] size_t bufsz,
+                    [[maybe_unused]] const wchar_t *__restrict format, ...)) {
   // Always returns -1 for now
   return -1;
 }

--- a/libc/src/wchar/swprintf.cpp
+++ b/libc/src/wchar/swprintf.cpp
@@ -13,9 +13,11 @@
 
 #include "src/wchar/swprintf.h"
 
+#include "hdr/errno_macros.h"
 #include "hdr/types/size_t.h"
 #include "hdr/types/wchar_t.h"
 #include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 
 #include <stdarg.h>
@@ -26,6 +28,7 @@ LLVM_LIBC_FUNCTION(int, swprintf,
                    ([[maybe_unused]] wchar_t *__restrict buffer,
                     [[maybe_unused]] size_t bufsz,
                     [[maybe_unused]] const wchar_t *__restrict format, ...)) {
+  libc_errno = ENOSYS;
   // Always returns -1 for now
   return -1;
 }

--- a/libc/src/wchar/swprintf.cpp
+++ b/libc/src/wchar/swprintf.cpp
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the implementation of the swprintf function.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/wchar/swprintf.h"
+
+#include "hdr/types/size_t.h"
+#include "hdr/types/wchar_t.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+#include <stdarg.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, swprintf,
+                   (wchar_t *__restrict buffer, size_t bufsz,
+                    const wchar_t *__restrict format, ...)) {
+  (void)buffer;
+  (void)bufsz;
+  (void)format;
+  // Always returns -1 for now
+  return -1;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wchar/swprintf.h
+++ b/libc/src/wchar/swprintf.h
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the prototype for the swprintf function.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCHAR_SWPRINTF_H
+#define LLVM_LIBC_SRC_WCHAR_SWPRINTF_H
+
+#include "hdr/types/size_t.h"
+#include "hdr/types/wchar_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int swprintf(wchar_t *__restrict buffer, size_t bufsz,
+             const wchar_t *__restrict format, ...);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCHAR_SWPRINTF_H

--- a/libc/test/src/wchar/CMakeLists.txt
+++ b/libc/test/src/wchar/CMakeLists.txt
@@ -720,3 +720,15 @@ add_libc_test(
     libc.src.wchar.putwchar
     libc.test.UnitTest.ErrnoCheckingTest
 )
+
+add_libc_test(
+  swprintf_test
+  SUITE
+    libc_wchar_unittests
+  SRCS
+    swprintf_test.cpp
+  DEPENDS
+    libc.hdr.types.size_t
+    libc.hdr.types.wchar_t
+    libc.src.wchar.swprintf
+)

--- a/libc/test/src/wchar/CMakeLists.txt
+++ b/libc/test/src/wchar/CMakeLists.txt
@@ -728,7 +728,9 @@ add_libc_test(
   SRCS
     swprintf_test.cpp
   DEPENDS
+    libc.hdr.errno_macros
     libc.hdr.types.size_t
     libc.hdr.types.wchar_t
     libc.src.wchar.swprintf
+    libc.test.UnitTest.ErrnoCheckingTest
 )

--- a/libc/test/src/wchar/swprintf_test.cpp
+++ b/libc/test/src/wchar/swprintf_test.cpp
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for swprintf.
+///
+//===----------------------------------------------------------------------===//
+
+#include "hdr/types/size_t.h"
+#include "hdr/types/wchar_t.h"
+#include "src/wchar/swprintf.h"
+#include "test/UnitTest/Test.h"
+
+TEST(LlvmLibcSwprintfTest, StubReturnsMinusOne) {
+  wchar_t buf[10];
+  int result = LIBC_NAMESPACE::swprintf(buf, 10, L"test");
+  ASSERT_EQ(result, -1);
+}

--- a/libc/test/src/wchar/swprintf_test.cpp
+++ b/libc/test/src/wchar/swprintf_test.cpp
@@ -11,13 +11,18 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "hdr/errno_macros.h"
 #include "hdr/types/size_t.h"
 #include "hdr/types/wchar_t.h"
 #include "src/wchar/swprintf.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/Test.h"
 
-TEST(LlvmLibcSwprintfTest, StubReturnsMinusOne) {
+using LlvmLibcSwprintfTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcSwprintfTest, StubReturnsMinusOne) {
   wchar_t buf[10];
   int result = LIBC_NAMESPACE::swprintf(buf, 10, L"test");
   ASSERT_EQ(result, -1);
+  ASSERT_ERRNO_EQ(ENOSYS);
 }


### PR DESCRIPTION
Add a declaration and stub implementation for the `swprintf` function. Only enable it when `LLVM_LIBC_ENABLE_EXPERIMENTAL_ENTRYPOINTS` is specified to clarify that the implementation is not ready yet.

We're singling out `swprintf` among the other wide-character formatting functions because it's used in libc++ to implement `std::to_wstring` for floating point values (https://github.com/llvm/llvm-project/blob/2a2e45257b8277ae6dbd3bce1627a9b07d1a301d/libcxx/src/string.cpp#L366), and is the last remaining piece of functionality preventing us from turning on wide character support in libc++ built against llvm-libc.  Adding the stub function would allow us to test the compilation with `_LIBCPP_HAS_WIDE_CHARACTERS` enabled, and start keeping track of what tests from libc++ test suite are working / not working yet.