### PR TITLE
[NFC][PowerPC] Delete redundant ISD::TRUNCATE from setTargetDAGCombine

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -1456,7 +1456,7 @@ PPCTargetLowering::PPCTargetLowering(const PPCTargetMachine &TM,
   setTargetDAGCombine({ISD::TRUNCATE, ISD::VECTOR_SHUFFLE});
 
   if (Subtarget.useCRBits()) {
-    setTargetDAGCombine({ISD::TRUNCATE, ISD::SETCC, ISD::SELECT_CC});
+    setTargetDAGCombine({ISD::SETCC, ISD::SELECT_CC});
   }
 
   if (Subtarget.hasP8Vector())


### PR DESCRIPTION
there is 

```
setTargetDAGCombine({ISD::TRUNCATE, ISD::VECTOR_SHUFFLE});

  if (Subtarget.useCRBits()) {
    setTargetDAGCombine({ISD::TRUNCATE, ISD::SETCC, ISD::SELECT_CC});  }
```
  
 we do not need to set the (ISD::TRUNCATE again when Subtarget.useCRBits()