### PR TITLE
[flang][OpenACC] Add minus operator to reduction clause

### DIFF
--- a/flang/docs/OpenACC-extensions.md
+++ b/flang/docs/OpenACC-extensions.md
@@ -41,6 +41,8 @@ These extensions require no flag.
 * The OpenACC specification disallows a variable from appearing multiple times
   in clauses of `!$acc declare` directives for a function, subroutine, program,
   or module, but Flang permits it with a warning when the same clause is used.
+* The REDUCTION clause accepts a MINUS "-" operator which is not permitted in
+  the OpenACC specification. A warning is issued for this use. 
 
 ## Extensions enabled by flag
 

--- a/flang/include/flang/Parser/parse-tree.h
+++ b/flang/include/flang/Parser/parse-tree.h
@@ -2254,11 +2254,11 @@ struct ConcurrentHeader {
 // F'2023 R1131 reduce-operation -> reduction-operator
 // CUF reduction-op -> reduction-operator
 // OpenACC 3.3 2.5.15 reduction-operator ->
-//                      + | * | .AND. | .OR. | .EQV. | .NEQV. |
+//                      + | - | * | .AND. | .OR. | .EQV. | .NEQV. |
 //                      MAX | MIN | IAND | IOR | IEOR
 struct ReductionOperator {
-  ENUM_CLASS(
-      Operator, Plus, Multiply, Max, Min, Iand, Ior, Ieor, And, Or, Eqv, Neqv)
+  ENUM_CLASS(Operator, Plus, Minus, Multiply, Max, Min, Iand, Ior, Ieor, And,
+      Or, Eqv, Neqv)
   WRAPPER_CLASS_BOILERPLATE(ReductionOperator, Operator);
   CharBlock source;
 };

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -2247,6 +2247,11 @@ private:
     switch (rOpr.v) {
     case Fortran::parser::ReductionOperator::Operator::Plus:
       return fir::ReduceOperationEnum::Add;
+    case Fortran::parser::ReductionOperator::Operator::Minus:
+      // '-' is not a valid reduction operator for DO CONCURRENT REDUCE or
+      // !$CUF KERNEL DO REDUCE; both are rejected during semantic checking
+      // before lowering is reached, so it is never lowered here.
+      llvm_unreachable("minus is not a valid reduction operator");
     case Fortran::parser::ReductionOperator::Operator::Multiply:
       return fir::ReduceOperationEnum::Multiply;
     case Fortran::parser::ReductionOperator::Operator::And:

--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -1070,6 +1070,7 @@ getReductionOperator(const Fortran::parser::ReductionOperator &op,
       converter.getLoweringOptions().getFPMaxminBehavior();
   switch (op.v) {
   case Fortran::parser::ReductionOperator::Operator::Plus:
+  case Fortran::parser::ReductionOperator::Operator::Minus:
     return mlir::acc::ReductionOperator::AccAdd;
   case Fortran::parser::ReductionOperator::Operator::Multiply:
     return mlir::acc::ReductionOperator::AccMul;

--- a/flang/lib/Parser/openacc-parsers.cpp
+++ b/flang/lib/Parser/openacc-parsers.cpp
@@ -103,6 +103,7 @@ TYPE_PARSER(construct<AccCollapseArg>(
 // Operator for reduction
 TYPE_PARSER(construct<ReductionOperator>(
     first("+" >> pure(ReductionOperator::Operator::Plus),
+        "-" >> pure(ReductionOperator::Operator::Minus),
         "*" >> pure(ReductionOperator::Operator::Multiply),
         "MAX" >> pure(ReductionOperator::Operator::Max),
         "MIN" >> pure(ReductionOperator::Operator::Min),

--- a/flang/lib/Parser/unparse.cpp
+++ b/flang/lib/Parser/unparse.cpp
@@ -2895,6 +2895,9 @@ public:
     case ReductionOperator::Operator::Plus:
       Word("+");
       break;
+    case ReductionOperator::Operator::Minus:
+      Word("-");
+      break;
     case ReductionOperator::Operator::Multiply:
       Word("*");
       break;

--- a/flang/lib/Semantics/check-acc-structure.cpp
+++ b/flang/lib/Semantics/check-acc-structure.cpp
@@ -36,6 +36,7 @@ using ReductionOpsSet =
 
 static ReductionOpsSet reductionIntegerSet{
     Fortran::parser::ReductionOperator::Operator::Plus,
+    Fortran::parser::ReductionOperator::Operator::Minus,
     Fortran::parser::ReductionOperator::Operator::Multiply,
     Fortran::parser::ReductionOperator::Operator::Max,
     Fortran::parser::ReductionOperator::Operator::Min,
@@ -45,12 +46,14 @@ static ReductionOpsSet reductionIntegerSet{
 
 static ReductionOpsSet reductionRealSet{
     Fortran::parser::ReductionOperator::Operator::Plus,
+    Fortran::parser::ReductionOperator::Operator::Minus,
     Fortran::parser::ReductionOperator::Operator::Multiply,
     Fortran::parser::ReductionOperator::Operator::Max,
     Fortran::parser::ReductionOperator::Operator::Min};
 
 static ReductionOpsSet reductionComplexSet{
     Fortran::parser::ReductionOperator::Operator::Plus,
+    Fortran::parser::ReductionOperator::Operator::Minus,
     Fortran::parser::ReductionOperator::Operator::Multiply};
 
 static ReductionOpsSet reductionLogicalSet{
@@ -1083,6 +1086,11 @@ void AccStructureChecker::Enter(const parser::AccClause::Reduction &reduction) {
   const parser::AccObjectListWithReduction &list{reduction.v};
   const auto &op{std::get<parser::ReductionOperator>(list.t)};
   const auto &objects{std::get<parser::AccObjectList>(list.t)};
+
+  if (op.v == parser::ReductionOperator::Operator::Minus) {
+    context_.Warn(common::UsageWarning::OpenAccUsage, GetContext().clauseSource,
+        "The minus '-' reduction operator is non-standard and is treated as '+'"_warn_en_US);
+  }
 
   for (const auto &object : objects.v) {
     common::visit(

--- a/flang/lib/Semantics/check-cuda.cpp
+++ b/flang/lib/Semantics/check-cuda.cpp
@@ -664,6 +664,10 @@ static void CheckReduce(
         auto cat{type->category()};
         bool isOk{false};
         switch (op) {
+        case parser::ReductionOperator::Operator::Minus:
+          context.Say(var.thing.GetSource(),
+              "'-' is not a supported !$CUF KERNEL DO REDUCE operator"_err_en_US);
+          continue;
         case parser::ReductionOperator::Operator::Plus:
         case parser::ReductionOperator::Operator::Multiply:
         case parser::ReductionOperator::Operator::Max:

--- a/flang/lib/Semantics/check-do-forall.cpp
+++ b/flang/lib/Semantics/check-do-forall.cpp
@@ -709,6 +709,10 @@ private:
         }};
         supportedIdentifier = true;
         switch (reductionOperator.v) {
+        case parser::ReductionOperator::Operator::Minus:
+          context_.Say(currentStatementSourcePosition_,
+              "'-' is not a supported reduction operator in a DO CONCURRENT REDUCE locality specifier"_err_en_US);
+          break;
         case parser::ReductionOperator::Operator::Plus:
         case parser::ReductionOperator::Operator::Multiply:
           if (!(type->IsNumeric(TypeCategory::Complex) ||

--- a/flang/test/Lower/OpenACC/acc-reduction.f90
+++ b/flang/test/Lower/OpenACC/acc-reduction.f90
@@ -1342,6 +1342,24 @@ end subroutine
 ! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<i32>) recipe(@reduction_add_ref_i32) -> !fir.ref<i32> {name = "b"}
 ! CHECK:       acc.loop {{.*}} reduction(%[[RED_B]] : !fir.ref<i32>)
 
+! The non-standard '-' reduction operator is treated as '+', so it reuses the
+! add recipe.
+subroutine acc_reduction_minus_int(a, b)
+  integer :: a(100)
+  integer :: i, b
+
+  !$acc loop reduction(-:b)
+  do i = 1, 100
+    b = b - a(i)
+  end do
+end subroutine
+
+! CHECK-LABEL: func.func @_QPacc_reduction_minus_int(
+! CHECK-SAME:  %{{.*}}: !fir.ref<!fir.array<100xi32>> {fir.bindc_name = "a"}, %[[B:.*]]: !fir.ref<i32> {fir.bindc_name = "b"})
+! CHECK:       %[[DECLB:.*]]:2 = hlfir.declare %[[B]]
+! CHECK:       %[[RED_B:.*]] = acc.reduction varPtr(%[[DECLB]]#0 : !fir.ref<i32>) recipe(@reduction_add_ref_i32) -> !fir.ref<i32> {name = "b"}
+! CHECK:       acc.loop {{.*}} reduction(%[[RED_B]] : !fir.ref<i32>)
+
 subroutine acc_reduction_add_int_array_1d(a, b)
   integer :: a(100)
   integer :: i, b(100)

--- a/flang/test/Semantics/OpenACC/acc-reduction-validity.f90
+++ b/flang/test/Semantics/OpenACC/acc-reduction-validity.f90
@@ -13,6 +13,10 @@ program openacc_reduction_validity
   !$acc parallel reduction(+:i)
   !$acc end parallel
 
+  !WARNING: The minus '-' reduction operator is non-standard and is treated as '+' [-Wopenacc-usage]
+  !$acc parallel reduction(-:i)
+  !$acc end parallel
+
   !$acc parallel reduction(*:i)
   !$acc end parallel
 
@@ -48,6 +52,10 @@ program openacc_reduction_validity
   !$acc end parallel
 
   !$acc parallel reduction(+:r)
+  !$acc end parallel
+
+  !WARNING: The minus '-' reduction operator is non-standard and is treated as '+' [-Wopenacc-usage]
+  !$acc parallel reduction(-:r)
   !$acc end parallel
 
   !$acc parallel reduction(*:r)
@@ -88,6 +96,10 @@ program openacc_reduction_validity
   !$acc end parallel
 
   !$acc parallel reduction(+:c)
+  !$acc end parallel
+
+  !WARNING: The minus '-' reduction operator is non-standard and is treated as '+' [-Wopenacc-usage]
+  !$acc parallel reduction(-:c)
   !$acc end parallel
 
   !$acc parallel reduction(*:c)
@@ -143,6 +155,11 @@ program openacc_reduction_validity
 
   !ERROR: reduction operator not supported for logical type
   !$acc parallel reduction(+:l)
+  !$acc end parallel
+
+  !WARNING: The minus '-' reduction operator is non-standard and is treated as '+' [-Wopenacc-usage]
+  !ERROR: reduction operator not supported for logical type
+  !$acc parallel reduction(-:l)
   !$acc end parallel
 
   !ERROR: reduction operator not supported for logical type

--- a/flang/test/Semantics/reduce.cuf
+++ b/flang/test/Semantics/reduce.cuf
@@ -73,4 +73,11 @@ subroutine s(n,m,a,l,c)
   do j=1,n; end do
 !$cuf kernel do <<<*,*>>> reduce (+:cr) ! ok complex type
   do j=1,n; cr = cr + c(j); end do
+! '-' is not a supported CUF reduction operator, regardless of variable type
+!ERROR: '-' is not a supported !$CUF KERNEL DO REDUCE operator
+!$cuf kernel do <<<*,*>>> reduce (-:mr)
+  do j=1,n; end do
+!ERROR: '-' is not a supported !$CUF KERNEL DO REDUCE operator
+!$cuf kernel do <<<*,*>>> reduce (-:ar)
+  do j=1,n; end do
 end

--- a/flang/test/Semantics/resolve124.f90
+++ b/flang/test/Semantics/resolve124.f90
@@ -87,3 +87,20 @@ subroutine s6()
   do concurrent(i=1:5) reduce(+:ch)
   end do
 end subroutine s6
+
+subroutine s7()
+! The '-' reduction operator is not supported for a DO CONCURRENT REDUCE
+! locality-spec, regardless of the reduction variable's type.
+  integer :: i1
+  real :: r1
+  complex :: c1
+!ERROR: '-' is not a supported reduction operator in a DO CONCURRENT REDUCE locality specifier
+  do concurrent(i=1:5) reduce(-:i1)
+  end do
+!ERROR: '-' is not a supported reduction operator in a DO CONCURRENT REDUCE locality specifier
+  do concurrent(i=1:5) reduce(-:r1)
+  end do
+!ERROR: '-' is not a supported reduction operator in a DO CONCURRENT REDUCE locality specifier
+  do concurrent(i=1:5) reduce(-:c1)
+  end do
+end subroutine s7


### PR DESCRIPTION
Adds '-' as a recognized reduction operator alongside '+'. The new ReductionOperator::Operator::Minus is parsed from the '-' token, accepted on integer/real/complex reduction variables, and lowered the same as Plus (mlir::acc::ReductionOperator::AccAdd in OpenACC, and fir::ReduceOperationEnum::Add in DO CONCURRENT). The unparser emits it as '-'.