### PR TITLE
[alpha.webkit.NoDeleteChecker] Treat a r-value smart pointer return value as no-delete.

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -713,9 +713,8 @@ public:
   }
 
   bool VisitReturnStmt(const ReturnStmt *RS) {
-    // A return statement is allowed as long as the return value is trivial.
     if (auto *RV = RS->getRetValue())
-      return Visit(RV);
+      return VisitIgnoringTempWithoutDestruction(RV);
     return true;
   }
 
@@ -895,15 +894,35 @@ public:
 
   bool checkArguments(const CallExpr *CE) {
     for (const Expr *Arg : CE->arguments()) {
-      if (Arg && !Visit(Arg))
+      if (Arg && !VisitIgnoringTempWithoutDestruction(Arg))
         return false;
     }
     return true;
   }
 
+  bool VisitIgnoringTempWithoutDestruction(const Expr *Arg) {
+    QualType OriginalQT = Arg->getType();
+    auto *Type = OriginalQT.getTypePtrOrNull();
+    if (!Type)
+      return Visit(Arg);
+    auto *CXXRD = Type->getAsCXXRecordDecl();
+    if (!CXXRD || !isSmartPtrClass(safeGetName(CXXRD)))
+      return Visit(Arg);
+    Arg = Arg->IgnoreParenCasts();
+    if (!Arg->isPRValue())
+      return Visit(Arg);
+    if (auto *ExprWithClean = dyn_cast<ExprWithCleanups>(Arg))
+      Arg = ExprWithClean->getSubExpr()->IgnoreParenCasts();
+    if (auto *BTE = dyn_cast<CXXBindTemporaryExpr>(Arg)) {
+      if (OriginalQT == BTE->getType())
+        return Visit(BTE->getSubExpr());
+    }
+    return Visit(Arg);
+  }
+
   bool VisitCXXConstructExpr(const CXXConstructExpr *CE) {
     for (const Expr *Arg : CE->arguments()) {
-      if (Arg && !Visit(Arg))
+      if (Arg && !VisitIgnoringTempWithoutDestruction(Arg))
         return false;
     }
 

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -713,8 +713,12 @@ public:
   }
 
   bool VisitReturnStmt(const ReturnStmt *RS) {
+    // A return statement is allowed as long as the return value is trivial. A
+    // returned smart-pointer prvalue is special: under guaranteed copy elision
+    // the temporary *is* the function's return slot, so it is destructed by the
+    // caller, not here. Hence we may ignore that temporary's destructor.
     if (auto *RV = RS->getRetValue())
-      return VisitIgnoringTempWithoutDestruction(RV);
+      return visitReturnValueElidingTemp(RV);
     return true;
   }
 
@@ -894,13 +898,25 @@ public:
 
   bool checkArguments(const CallExpr *CE) {
     for (const Expr *Arg : CE->arguments()) {
-      if (Arg && !VisitIgnoringTempWithoutDestruction(Arg))
+      if (Arg && !Visit(Arg))
         return false;
     }
     return true;
   }
 
-  bool VisitIgnoringTempWithoutDestruction(const Expr *Arg) {
+  // Triviality check for a return value that may elide a smart-pointer
+  // temporary's destructor.
+  //
+  // This is only valid for *return values*: a returned class prvalue is
+  // constructed directly into the function's return slot (C++17 guaranteed copy
+  // elision), so the temporary is destructed by the caller rather than here.
+  //
+  // It is deliberately NOT applied to call/constructor arguments. An argument
+  // temporary's lifetime ends at the full-expression *in this function* (the
+  // caller destroys arguments, e.g. per the Itanium C++ ABI), so its destructor
+  // runs here and may invoke delete. Proving otherwise would require
+  // interprocedural ownership analysis, so arguments are checked normally.
+  bool visitReturnValueElidingTemp(const Expr *Arg) {
     QualType OriginalQT = Arg->getType();
     auto *Type = OriginalQT.getTypePtrOrNull();
     if (!Type)
@@ -922,7 +938,7 @@ public:
 
   bool VisitCXXConstructExpr(const CXXConstructExpr *CE) {
     for (const Expr *Arg : CE->arguments()) {
-      if (Arg && !VisitIgnoringTempWithoutDestruction(Arg))
+      if (Arg && !Visit(Arg))
         return false;
     }
 

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -930,7 +930,12 @@ public:
     if (auto *ExprWithClean = dyn_cast<ExprWithCleanups>(Arg))
       Arg = ExprWithClean->getSubExpr()->IgnoreParenCasts();
     if (auto *BTE = dyn_cast<CXXBindTemporaryExpr>(Arg)) {
-      if (OriginalQT == BTE->getType())
+      // Only elide when the temporary *is* the returned object, i.e. it has the
+      // same smart-pointer type as the return value. Compare canonical,
+      // unqualified types rather than relying on exact QualType identity, which
+      // is sensitive to sugar (typedefs/aliases) and cv-qualifiers.
+      if (OriginalQT.getCanonicalType().getUnqualifiedType() ==
+          BTE->getType().getCanonicalType().getUnqualifiedType())
         return Visit(BTE->getSubExpr());
     }
     return Visit(Arg);

--- a/clang/test/Analysis/Checkers/WebKit/call-args.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args.cpp
@@ -557,4 +557,21 @@ namespace call_with_weak_ptr {
     weakPtr->method();
     // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
   }
+
+  struct Provider {
+    RefCountableWithWeakPtr* provide();
+  };
+  int intValue();
+
+  struct Container {
+    Container(Provider& provider)
+      : m_weakPtr(provider.provide())
+      , m_value(intValue())
+    { }
+
+  private:
+    WeakPtr<RefCountableWithWeakPtr> m_weakPtr;
+    int m_value;
+  };
+
 }

--- a/clang/test/Analysis/Checkers/WebKit/mock-types.h
+++ b/clang/test/Analysis/Checkers/WebKit/mock-types.h
@@ -202,6 +202,7 @@ template <typename T> struct RefPtr {
     t = o.t;
     o.t = tmp;
   }
+  operator T*() { return t; }
   T *get() const { return t; }
   T *operator->() const { return t; }
   T &operator*() const { return *t; }

--- a/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
@@ -685,3 +685,19 @@ void [[clang::annotate_type("webkit.nodelete")]] discardedTemporaryIsFlagged() {
 }
 
 } // namespace argument_temporaries_are_not_elided
+
+namespace returned_prvalue_typedef {
+
+// A returned prvalue spelled through a typedef/alias is still the return-slot
+// object and must be elided. The elision relies on a canonical, unqualified
+// type comparison rather than exact QualType identity.
+
+using RefRC = Ref<RefCountable>;
+RefRC [[clang::annotate_type("webkit.nodelete")]] makeAlias();
+
+Ref<RefCountable> [[clang::annotate_type("webkit.nodelete")]] returnTypedefPrvalue() {
+  return makeAlias(); // no warning: the elided temporary is the return slot.
+}
+
+} // namespace returned_prvalue_typedef
+

--- a/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
@@ -316,8 +316,21 @@ public:
 };
 
 struct Data {
-  static Ref<Data> create() {
+  static Ref<Data> [[clang::annotate_type("webkit.nodelete")]] create() {
     return adoptRef(*new Data);
+  }
+
+  static Ref<Data> [[clang::annotate_type("webkit.nodelete")]] create(double) {
+    return adoptRef(*new Data(RefCountable::create()->next()));
+    // expected-warning@-1{{A function 'create' has [[clang::annotate_type("webkit.nodelete")]] but it contains code that could destruct an object}}
+  }
+
+  static Data* [[clang::annotate_type("webkit.nodelete")]] create(int) {
+    return adoptRef(new Data); // expected-warning{{A function 'create' has [[clang::annotate_type("webkit.nodelete")]] but it contains code that could destruct an object}}
+  }
+
+  static Ref<Data> create(const char*) {
+    return std::move(adoptRef(*new Data));
   }
 
   void ref() {
@@ -338,6 +351,7 @@ struct Data {
   
 protected:
   Data() = default;
+  Data(RefCountable*) { }
 
 private:
   unsigned refCount { 0 };
@@ -562,3 +576,69 @@ private:
   RefPtr<SomeObject> m_someObject;
   Vector<Ref<SomeObject>> m_objects;
 };
+
+namespace copy_elision_edge_cases {
+
+// These cases all inhibit NRVO/copy elision (so a real move or copy constructor runs into the return slot),
+// but none of them perform any local destruction:
+//   - Moved-from operands are emptied; their dtors are no-ops at the caller.
+//   - Globals/statics are not destructed here at all.
+//   - The return-slot temporary is destructed by the caller, not by us.
+// All the mock Ref<T> copy/move ctors only manipulate pointers and a
+// refcount, so the trivial-ctor analysis correctly classifies these as
+// safe. The tests below document that the checker accepts each shape.
+
+Ref<RefCountable> [[clang::annotate_type("webkit.nodelete")]] returnStdMoved(Ref<RefCountable>&& obj) {
+  return std::move(obj);
+}
+
+Ref<RefCountable> [[clang::annotate_type("webkit.nodelete")]] returnFromBranches(bool b, Ref<RefCountable>&& a, Ref<RefCountable>&& c) {
+  if (b)
+    return std::move(a);
+  return std::move(c);
+}
+
+Ref<RefCountable> [[clang::annotate_type("webkit.nodelete")]] returnDerefedParam(Ref<RefCountable>* param) {
+  return *param;
+}
+
+// Returning a by-value parameter also requires a real copy/move construction.
+// The function is still flagged here because of unsafe-parameter diagnostic that fires for the parameter declaration.
+Ref<RefCountable> [[clang::annotate_type("webkit.nodelete")]] returnByValueParam(Ref<RefCountable> param) {
+  // expected-warning@-1{{A function 'returnByValueParam' has [[clang::annotate_type("webkit.nodelete")]] but it contains a parameter 'param' which could destruct an object}}
+  return param;
+}
+
+extern Ref<RefCountable> g_ref;
+Ref<RefCountable> [[clang::annotate_type("webkit.nodelete")]] returnGlobal() {
+  return g_ref;
+}
+
+struct StaticHolder {
+  static Ref<RefCountable> s_ref;
+};
+Ref<RefCountable> [[clang::annotate_type("webkit.nodelete")]] returnClassStatic() {
+  return StaticHolder::s_ref;
+}
+
+} // namespace copy_elision_edge_cases
+
+namespace temp_object_typecheck {
+
+struct Tracked {
+  Tracked();
+  ~Tracked();
+};
+
+Tracked [[clang::annotate_type("webkit.nodelete")]] makeTracked();
+
+struct Box {
+  Box(const Tracked&) {}
+};
+
+Box [[clang::annotate_type("webkit.nodelete")]] makeBox() {
+  return Box(makeTracked());
+  // expected-warning@-1{{A function 'makeBox' has [[clang::annotate_type("webkit.nodelete")]] but it contains code that could destruct an object}}
+}
+
+} // namespace temp_object_typecheck

--- a/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/nodelete-annotation.cpp
@@ -642,3 +642,46 @@ Box [[clang::annotate_type("webkit.nodelete")]] makeBox() {
 }
 
 } // namespace temp_object_typecheck
+
+namespace argument_temporaries_are_not_elided {
+
+// Only a *returned* prvalue is elided into the caller's return slot. A
+// smart-pointer temporary passed as a call argument is destructed in this
+// function at the end of the full-expression (the caller destroys arguments),
+// so its destructor -- which may run delete -- is correctly flagged, no matter
+// how the callee binds it (by value, by rvalue reference, or by const
+// reference). The factory and sinks are annotated no-delete so the only
+// possible offender is the argument temporary's destruction.
+
+Ref<RefCountable> [[clang::annotate_type("webkit.nodelete")]] makeRef();
+void [[clang::annotate_type("webkit.nodelete")]] sinkByValue(Ref<RefCountable>);
+void [[clang::annotate_type("webkit.nodelete")]] sinkByRvalueRef(Ref<RefCountable>&&);
+void [[clang::annotate_type("webkit.nodelete")]] observeByConstRef(const Ref<RefCountable>&);
+
+// Returned prvalue: constructed into the caller's return slot -> no local
+// destruction here.
+Ref<RefCountable> [[clang::annotate_type("webkit.nodelete")]] returnedPrvalueIsElided() {
+  return makeRef();
+}
+
+void [[clang::annotate_type("webkit.nodelete")]] passedByValueIsFlagged() {
+  sinkByValue(makeRef());
+  // expected-warning@-1{{A function 'passedByValueIsFlagged' has [[clang::annotate_type("webkit.nodelete")]] but it contains code that could destruct an object}}
+}
+
+void [[clang::annotate_type("webkit.nodelete")]] passedByRvalueRefIsFlagged() {
+  sinkByRvalueRef(makeRef());
+  // expected-warning@-1{{A function 'passedByRvalueRefIsFlagged' has [[clang::annotate_type("webkit.nodelete")]] but it contains code that could destruct an object}}
+}
+
+void [[clang::annotate_type("webkit.nodelete")]] passedByConstRefIsFlagged() {
+  observeByConstRef(makeRef());
+  // expected-warning@-1{{A function 'passedByConstRefIsFlagged' has [[clang::annotate_type("webkit.nodelete")]] but it contains code that could destruct an object}}
+}
+
+void [[clang::annotate_type("webkit.nodelete")]] discardedTemporaryIsFlagged() {
+  makeRef();
+  // expected-warning@-1{{A function 'discardedTemporaryIsFlagged' has [[clang::annotate_type("webkit.nodelete")]] but it contains code that could destruct an object}}
+}
+
+} // namespace argument_temporaries_are_not_elided

--- a/clang/test/Analysis/Checkers/WebKit/nodelete-lazy-initialize.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/nodelete-lazy-initialize.cpp
@@ -1,0 +1,36 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.NoDeleteChecker -verify %s
+
+#include "mock-types.h"
+
+void crash();
+
+template<typename T, typename U>
+[[clang::suppress]] inline void [[clang::annotate_type("webkit.nodelete")]] lazyInitialize(const RefPtr<T>& ptr, Ref<U>&& obj)
+{
+    if (ptr)
+        crash();
+    const_cast<RefPtr<T>&>(ptr) = WTF::move(obj);
+}
+
+struct RefObj {
+  static Ref<RefObj> [[clang::annotate_type("webkit.nodelete")]] create(int = 0);
+  void ref() const;
+  void deref() const;
+  int value() const;
+};
+
+struct Container {
+
+  void [[clang::annotate_type("webkit.nodelete")]] foo() {
+    if (!m_bar)
+      lazyInitialize(m_bar, RefObj::create());
+  }
+
+  void [[clang::annotate_type("webkit.nodelete")]] bar() {
+    if (!m_bar)
+      lazyInitialize(m_bar, RefObj::create(RefObj::create()->value()));
+      // expected-warning@-1{{A function 'bar' has [[clang::annotate_type("webkit.nodelete")]] but it contains code that could destruct an object}}
+  }
+
+  const RefPtr<RefObj> m_bar;
+};

--- a/clang/test/Analysis/Checkers/WebKit/nodelete-lazy-initialize.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/nodelete-lazy-initialize.cpp
@@ -24,6 +24,11 @@ struct Container {
   void [[clang::annotate_type("webkit.nodelete")]] foo() {
     if (!m_bar)
       lazyInitialize(m_bar, RefObj::create());
+      // expected-warning@-1{{A function 'foo' has [[clang::annotate_type("webkit.nodelete")]] but it contains code that could destruct an object}}
+      // The 'RefObj::create()' temporary is passed as an argument, so its
+      // lifetime ends at this full-expression in 'foo' (the caller destroys
+      // arguments) and its destructor may run delete. Only returned prvalues
+      // are elided, so this is correctly flagged.
   }
 
   void [[clang::annotate_type("webkit.nodelete")]] bar() {


### PR DESCRIPTION
Skip the checkin g of the destructor of T in ExprWithCleanups / CXXBindTemporaryExpr when returning a value using r-value reference since such a construct never invokes delete.