### PR TITLE
[OFFLOAD][L0][NFC] Remove Device TLS table

### DIFF
--- a/offload/plugins-nextgen/level_zero/include/L0Device.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Device.h
@@ -74,26 +74,6 @@ struct L0DeviceIdTy {
       : zeId(Device), RootId(RootId), SubId(SubId), CCSId(CCSId) {}
 };
 
-class L0DeviceTLSTy {
-public:
-  L0DeviceTLSTy() = default;
-  ~L0DeviceTLSTy() {}
-  L0DeviceTLSTy(const L0DeviceTLSTy &) = delete;
-  L0DeviceTLSTy &operator=(const L0DeviceTLSTy &) = delete;
-  L0DeviceTLSTy &operator=(L0DeviceTLSTy &&) = delete;
-  L0DeviceTLSTy(L0DeviceTLSTy &&Other) {}
-
-  Error deinit() { return Plugin::success(); }
-};
-
-struct L0DeviceTLSTableTy
-    : public PerThreadContainer<std::vector<L0DeviceTLSTy>, 8> {
-  Error deinit() {
-    return PerThreadTable::deinit(
-        [](L0DeviceTLSTy &Entry) { return Entry.deinit(); });
-  }
-};
-
 class L0DeviceTy final : public GenericDeviceTy {
   // Level Zero Context for this Device.
   L0ContextTy &l0Context;
@@ -187,8 +167,6 @@ public:
   LevelZeroPluginTy &getPlugin() {
     return reinterpret_cast<LevelZeroPluginTy &>(Plugin);
   }
-
-  L0DeviceTLSTy &getTLS();
 
   Error setContext() override { return Plugin::success(); }
   Error initImpl(GenericPluginTy &Plugin) override;

--- a/offload/plugins-nextgen/level_zero/include/L0Plugin.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Plugin.h
@@ -34,8 +34,6 @@ private:
   /// Context (and Driver) specific data.
   std::list<L0ContextTy> ContextList;
 
-  // Table containing per-thread information for each device using TLS.
-  L0DeviceTLSTableTy DeviceTLSTable;
   // Table containing per-thread information for each Context using TLS.
   L0ContextTLSTableTy ContextTLSTable;
 
@@ -50,9 +48,6 @@ public:
   LevelZeroPluginTy() : GenericPluginTy(getTripleArch()) {}
   virtual ~LevelZeroPluginTy() = default;
 
-  L0DeviceTLSTy &getDeviceTLS(int32_t DeviceId) {
-    return DeviceTLSTable.get(DeviceId);
-  }
   L0ContextTLSTy &getContextTLS(ze_context_handle_t Context) {
     return ContextTLSTable.get(Context);
   }

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -24,10 +24,6 @@
 
 namespace llvm::omp::target::plugin {
 
-L0DeviceTLSTy &L0DeviceTy::getTLS() {
-  return getPlugin().getDeviceTLS(getDeviceId());
-}
-
 // clang-format off
 /// Mapping from device arch to GPU runtime's device identifiers.
 static struct {

--- a/offload/plugins-nextgen/level_zero/src/L0Plugin.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Plugin.cpp
@@ -123,8 +123,6 @@ Error LevelZeroPluginTy::deinitImpl() {
   ODBG(OLDT_Deinit) << "Deinit Level0 plugin!";
   if (auto Err = ContextTLSTable.deinit())
     return Err;
-  if (auto Err = DeviceTLSTable.deinit())
-    return Err;
   for (auto &Context : ContextList)
     if (auto Err = Context.deinit())
       return Err;


### PR DESCRIPTION
After #200650 the Device TLS table is not used anymore so it can be removed.