### PR TITLE
Fix a warning and an uninitialized variable in benchmark

### DIFF
--- a/third-party/benchmark/src/sysinfo.cc
+++ b/third-party/benchmark/src/sysinfo.cc
@@ -370,6 +370,7 @@ std::vector<CPUInfo::CacheInfo> GetCacheSizesWindows() {
     C.num_sharing = static_cast<int>(b.count());
     C.level = cache.Level;
     C.size = static_cast<int>(cache.Size);
+    C.type = "Unknown";
     switch (cache.Type) {
 // Windows SDK version >= 10.0.26100.0
 #ifdef NTDDI_WIN11_GE
@@ -387,9 +388,6 @@ std::vector<CPUInfo::CacheInfo> GetCacheSizesWindows() {
         break;
       case CacheTrace:
         C.type = "Trace";
-        break;
-      default:
-        C.type = "Unknown";
         break;
     }
     res.push_back(C);


### PR DESCRIPTION
After #198964 I see a -Wcovered-switch-default warning in sysinfo.cc, but it looks like it's uncovering something a bit worse.

Back in #147357 and #149159 it looks like we tried to fix an MSVC warning for an uncovered `CacheUnknown` case in this switch, and removed the initialization of the variable before the switch. The update to Google Benchmark v1.9.5 has a different fix for this - it's handling that specific case guarded by some MSVC version macros, but this depends on the initialization we removed!

Add the initialization back and remove the default case, effectively reverting #149159 and #147357.