### PR TITLE
[DAG] isGuaranteedNotToBeUndefOrPoison - add ISD::CONCAT_VECTORS handling

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -5665,6 +5665,29 @@ bool SelectionDAG::isGuaranteedNotToBeUndefOrPoison(SDValue Op,
     }
     return true;
 
+  case ISD::CONCAT_VECTORS: {
+    EVT VT = Op.getValueType();
+    if (!VT.isFixedLengthVector())
+      return all_of(Op->ops(), [&](SDValue V) {
+        return isGuaranteedNotToBeUndefOrPoison(V, Kind, Depth + 1);
+      });
+
+    assert(DemandedElts.getBitWidth() == VT.getVectorNumElements() &&
+           "Unexpected demanded element mask width");
+
+    EVT SubVT = Op.getOperand(0).getValueType();
+    unsigned NumSubElts = SubVT.getVectorNumElements();
+    for (unsigned i = 0, e = Op.getNumOperands(); i != e; ++i) {
+      APInt DemandedSubElts =
+          DemandedElts.extractBits(NumSubElts, i * NumSubElts);
+      if (!!DemandedSubElts &&
+          !isGuaranteedNotToBeUndefOrPoison(Op.getOperand(i), DemandedSubElts,
+                                            Kind, Depth + 1))
+        return false;
+    }
+    return true;
+  }
+
   case ISD::EXTRACT_SUBVECTOR: {
     SDValue Src = Op.getOperand(0);
     if (Src.getValueType().isScalableVector())

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -5668,20 +5668,15 @@ bool SelectionDAG::isGuaranteedNotToBeUndefOrPoison(SDValue Op,
   case ISD::CONCAT_VECTORS: {
     EVT VT = Op.getValueType();
     if (!VT.isFixedLengthVector())
-      return all_of(Op->ops(), [&](SDValue V) {
-        return isGuaranteedNotToBeUndefOrPoison(V, Kind, Depth + 1);
-      });
-
-    assert(DemandedElts.getBitWidth() == VT.getVectorNumElements() &&
-           "Unexpected demanded element mask width");
+      break;
 
     EVT SubVT = Op.getOperand(0).getValueType();
     unsigned NumSubElts = SubVT.getVectorNumElements();
-    for (unsigned i = 0, e = Op.getNumOperands(); i != e; ++i) {
+    for (unsigned I = 0, E = Op.getNumOperands(); I != E; ++I) {
       APInt DemandedSubElts =
-          DemandedElts.extractBits(NumSubElts, i * NumSubElts);
+          DemandedElts.extractBits(NumSubElts, I * NumSubElts);
       if (!!DemandedSubElts &&
-          !isGuaranteedNotToBeUndefOrPoison(Op.getOperand(i), DemandedSubElts,
+          !isGuaranteedNotToBeUndefOrPoison(Op.getOperand(I), DemandedSubElts,
                                             Kind, Depth + 1))
         return false;
     }

--- a/llvm/test/CodeGen/X86/freeze-vector.ll
+++ b/llvm/test/CodeGen/X86/freeze-vector.ll
@@ -767,18 +767,10 @@ define void @freeze_buildvector_not_simple_type(ptr %dst) nounwind {
 }
 
 define <4 x i32> @freeze_lshr_extract_concat_high_demanded(<4 x i32> %a, <4 x i32> %b) {
-; X86-LABEL: freeze_lshr_extract_concat_high_demanded:
-; X86:       # %bb.0:
-; X86-NEXT:    vpsrld $1, %xmm1, %xmm0
-; X86-NEXT:    retl
-;
-; X64-LABEL: freeze_lshr_extract_concat_high_demanded:
-; X64:       # %bb.0:
-; X64-NEXT:    vinserti128 $1, %xmm1, %ymm0, %ymm0
-; X64-NEXT:    vpsrld $1, %ymm0, %ymm0
-; X64-NEXT:    vextracti128 $1, %ymm0, %xmm0
-; X64-NEXT:    vzeroupper
-; X64-NEXT:    retq
+; CHECK-LABEL: freeze_lshr_extract_concat_high_demanded:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpsrld $1, %xmm1, %xmm0
+; CHECK-NEXT:    ret{{[l|q]}}
   %poisonable = add nsw <4 x i32> %a, <i32 2147483647, i32 2147483647, i32 2147483647, i32 2147483647>
   %wide = shufflevector <4 x i32> %poisonable, <4 x i32> %b, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   %shifted = lshr <8 x i32> %wide, <i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1>


### PR DESCRIPTION
Teach isGuaranteedNotToBeUndefOrPoison to distribute fixed-length
demanded element masks across CONCAT_VECTORS operands. This is part of
the series of fixes needed to resolve a SelectionDAG hang by making it
possible to prove certain values don't need to be frozen.

AI note: an LLM generated the code and the test, I've read them

Co-Authored-By: OpenAI Codex <codex@openai.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>