### PR TITLE
[SelectionDAG] isGuaranteedNotToBeUndefOrPoison - add ISD::SELECT handling

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -5746,16 +5746,11 @@ bool SelectionDAG::isGuaranteedNotToBeUndefOrPoison(SDValue Op,
   case ISD::SPLAT_VECTOR:
     return isGuaranteedNotToBeUndefOrPoison(Op.getOperand(0), Kind, Depth + 1);
 
-  case ISD::SELECT:
-  case ISD::VSELECT: {
+  case ISD::SELECT: {
     SDValue Cond = Op.getOperand(0);
-    bool CondIsVector = Cond.getValueType().isVector();
     return !canCreateUndefOrPoison(Op, DemandedElts, Kind,
                                    /*ConsiderFlags*/ true, Depth) &&
-           (CondIsVector
-                ? isGuaranteedNotToBeUndefOrPoison(Cond, DemandedElts, Kind,
-                                                   Depth + 1)
-                : isGuaranteedNotToBeUndefOrPoison(Cond, Kind, Depth + 1)) &&
+           isGuaranteedNotToBeUndefOrPoison(Cond, Kind, Depth + 1) &&
            isGuaranteedNotToBeUndefOrPoison(Op.getOperand(1), DemandedElts,
                                             Kind, Depth + 1) &&
            isGuaranteedNotToBeUndefOrPoison(Op.getOperand(2), DemandedElts,
@@ -5812,7 +5807,8 @@ bool SelectionDAG::isGuaranteedNotToBeUndefOrPoison(SDValue Op,
   case ISD::ZERO_EXTEND:
   case ISD::SIGN_EXTEND:
   case ISD::ANY_EXTEND:
-  case ISD::TRUNCATE: {
+  case ISD::TRUNCATE:
+  case ISD::VSELECT: {
     // If Op can't create undef/poison and none of its operands are undef/poison
     // then Op is never undef/poison. A difference from the more common check
     // below, outside the switch, is that we handle elementwise operations for

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -5747,10 +5747,10 @@ bool SelectionDAG::isGuaranteedNotToBeUndefOrPoison(SDValue Op,
     return isGuaranteedNotToBeUndefOrPoison(Op.getOperand(0), Kind, Depth + 1);
 
   case ISD::SELECT: {
-    SDValue Cond = Op.getOperand(0);
     return !canCreateUndefOrPoison(Op, DemandedElts, Kind,
                                    /*ConsiderFlags*/ true, Depth) &&
-           isGuaranteedNotToBeUndefOrPoison(Cond, Kind, Depth + 1) &&
+           isGuaranteedNotToBeUndefOrPoison(Op.getOperand(0), Kind,
+                                            Depth + 1) &&
            isGuaranteedNotToBeUndefOrPoison(Op.getOperand(1), DemandedElts,
                                             Kind, Depth + 1) &&
            isGuaranteedNotToBeUndefOrPoison(Op.getOperand(2), DemandedElts,

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -5746,6 +5746,22 @@ bool SelectionDAG::isGuaranteedNotToBeUndefOrPoison(SDValue Op,
   case ISD::SPLAT_VECTOR:
     return isGuaranteedNotToBeUndefOrPoison(Op.getOperand(0), Kind, Depth + 1);
 
+  case ISD::SELECT:
+  case ISD::VSELECT: {
+    SDValue Cond = Op.getOperand(0);
+    bool CondIsVector = Cond.getValueType().isVector();
+    return !canCreateUndefOrPoison(Op, DemandedElts, Kind,
+                                   /*ConsiderFlags*/ true, Depth) &&
+           (CondIsVector
+                ? isGuaranteedNotToBeUndefOrPoison(Cond, DemandedElts, Kind,
+                                                   Depth + 1)
+                : isGuaranteedNotToBeUndefOrPoison(Cond, Kind, Depth + 1)) &&
+           isGuaranteedNotToBeUndefOrPoison(Op.getOperand(1), DemandedElts,
+                                            Kind, Depth + 1) &&
+           isGuaranteedNotToBeUndefOrPoison(Op.getOperand(2), DemandedElts,
+                                            Kind, Depth + 1);
+  }
+
   case ISD::VECTOR_SHUFFLE: {
     APInt DemandedLHS, DemandedRHS;
     auto *SVN = cast<ShuffleVectorSDNode>(Op);
@@ -5796,8 +5812,7 @@ bool SelectionDAG::isGuaranteedNotToBeUndefOrPoison(SDValue Op,
   case ISD::ZERO_EXTEND:
   case ISD::SIGN_EXTEND:
   case ISD::ANY_EXTEND:
-  case ISD::TRUNCATE:
-  case ISD::VSELECT: {
+  case ISD::TRUNCATE: {
     // If Op can't create undef/poison and none of its operands are undef/poison
     // then Op is never undef/poison. A difference from the more common check
     // below, outside the switch, is that we handle elementwise operations for

--- a/llvm/test/CodeGen/X86/freeze-vector.ll
+++ b/llvm/test/CodeGen/X86/freeze-vector.ll
@@ -804,17 +804,6 @@ define i32 @freeze_select_scalar_demanded(i1 %c, <2 x i32> %a, <2 x i32> %b, <2 
 ;
 ; X64-LABEL: freeze_select_scalar_demanded:
 ; X64:       # %bb.0:
-; X64-NEXT:    testb $1, %dil
-; X64-NEXT:    jne .LBB27_1
-; X64-NEXT:  # %bb.2:
-; X64-NEXT:    vpbroadcastd {{.*#+}} xmm1 = [2147483648,2147483648,2147483648,2147483648]
-; X64-NEXT:    vpsubd %xmm1, %xmm2, %xmm1
-; X64-NEXT:    jmp .LBB27_3
-; X64-NEXT:  .LBB27_1:
-; X64-NEXT:    vpbroadcastd {{.*#+}} xmm2 = [2147483647,2147483647,2147483647,2147483647]
-; X64-NEXT:    vpaddd %xmm2, %xmm1, %xmm1
-; X64-NEXT:  .LBB27_3:
-; X64-NEXT:    vpunpcklqdq {{.*#+}} xmm0 = xmm0[0],xmm1[0]
 ; X64-NEXT:    vmovd %xmm0, %eax
 ; X64-NEXT:    retq
   %poisonable.b = add nsw <2 x i32> %b, <i32 2147483647, i32 2147483647>


### PR DESCRIPTION
Propagate demanded elements through to the two arms of a select, and
check the condition with or without demanded elements depending on if
it's a vector or not.

AI note: an LLM generated the code and the test, I've read them

Co-Authored-By: OpenAI Codex <codex@openai.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>