### PR TITLE
[lldb] Add size checks for frequently allocated classes

### DIFF
--- a/lldb/include/lldb/Core/Address.h
+++ b/lldb/include/lldb/Core/Address.h
@@ -501,6 +501,8 @@ protected:
   // know if this address used to have a valid section.
   bool SectionWasDeletedPrivate() const;
 };
+static_assert(sizeof(Address) <= sizeof(lldb::addr_t) + sizeof(lldb::SectionWP),
+              "High-volume object, size of object must be increased with care");
 
 // NOTE: Be careful using this operator. It can correctly compare two
 // addresses from the same Module correctly. It can't compare two addresses

--- a/lldb/include/lldb/Core/AddressRange.h
+++ b/lldb/include/lldb/Core/AddressRange.h
@@ -249,6 +249,8 @@ protected:
   Address m_base_addr;      ///< The section offset base address of this range.
   lldb::addr_t m_byte_size = 0; ///< The size in bytes of this address range.
 };
+static_assert(sizeof(AddressRange) <= sizeof(Address) + sizeof(lldb::addr_t),
+              "High-volume object, size of object must be increased with care");
 
 // Forward-declarable wrapper.
 class AddressRanges : public std::vector<lldb_private::AddressRange> {

--- a/lldb/include/lldb/Core/Mangled.h
+++ b/lldb/include/lldb/Core/Mangled.h
@@ -332,6 +332,9 @@ private:
   /// parts of the name (e.g., basename, arguments, etc.) begin and end.
   mutable std::unique_ptr<DemangledNameInfo> m_demangled_info;
 };
+static_assert(sizeof(Mangled) <= 2 * sizeof(ConstString) +
+                                     sizeof(std::unique_ptr<DemangledNameInfo>),
+              "High-volume object, size of object must be increased with care");
 
 Stream &operator<<(Stream &s, const Mangled &obj);
 

--- a/lldb/include/lldb/Symbol/LineTable.h
+++ b/lldb/include/lldb/Symbol/LineTable.h
@@ -286,6 +286,10 @@ public:
     /// is no file information.
     uint16_t file_idx = 0;
   };
+  static_assert(
+      sizeof(Entry) <=
+          sizeof(lldb::addr_t) + sizeof(uint32_t) + 2 * sizeof(uint16_t),
+      "High-volume object, size of object must be increased with care");
 
   class Sequence {
   public:

--- a/lldb/include/lldb/Utility/ConstString.h
+++ b/lldb/include/lldb/Utility/ConstString.h
@@ -412,6 +412,8 @@ protected:
 
   const char *m_string = nullptr;
 };
+static_assert(sizeof(ConstString) <= sizeof(const char *),
+              "High-volume object, size of object must be increased with care");
 
 /// Stream the string value \a str to the stream \a s
 Stream &operator<<(Stream &s, ConstString str);


### PR DESCRIPTION
Given how frequently we allocate these classes (or classes containing these classes) on the heap, we should only grow them intentionally.

See also bd1b3d47462acf4f854f593bdd77b3f127adea46