### PR TITLE
[HotColdSplit] Consolidate pass pipeline

### DIFF
--- a/llvm/test/Transforms/HotColdSplit/coldentrycount.ll
+++ b/llvm/test/Transforms/HotColdSplit/coldentrycount.ll
@@ -1,5 +1,5 @@
 ; REQUIRES: x86-registered-target
-; RUN: opt -passes=hotcoldsplit -hotcoldsplit-threshold=0 < %s | opt -passes='require<profile-summary>,function(codegenprepare)' -S | FileCheck %s
+; RUN: opt -passes="require<profile-summary>,hotcoldsplit,codegenprepare" -hotcoldsplit-threshold=0 < %s -S | FileCheck %s
 
 ; Test to ensure that split cold function gets 0 entry count profile
 ; metadata when compiling with pgo.


### PR DESCRIPTION
Codegenprepare was added for more of a E2E test in
f0f68c6e6c5e0064c0196e4f1528e910a47766e0. The pipeline was split in
cb5e48d1c2c4774ed9f17ff89412f1291b640172 to allow for the removal of the
HotColdSplit legacy pass. Now that CodeGenPrepare has been ported to the
NewPM in f1ec0d12bb0843f0deab83ef2b5cf1339cbc4f0b (which even touched
this test), we can use a single pass pipeline and simplify the run line
a little bit.