### PR TITLE
[HotColdSplit] Unconditionally mark new functions as cold

### DIFF
--- a/llvm/lib/Transforms/IPO/HotColdSplitting.cpp
+++ b/llvm/lib/Transforms/IPO/HotColdSplitting.cpp
@@ -431,7 +431,7 @@ Function *HotColdSplitting::extractColdRegion(
         OutF->setSection(OrigF->getSection());
     }
 
-    markFunctionCold(*OutF, BFI != nullptr);
+    markFunctionCold(*OutF, true);
 
     LLVM_DEBUG(llvm::dbgs() << "Outlined Region: " << *OutF);
     ORE.emit([&]() {

--- a/llvm/test/Transforms/CodeExtractor/input-value-debug.ll
+++ b/llvm/test/Transforms/CodeExtractor/input-value-debug.ll
@@ -40,7 +40,7 @@ declare void @sink(i32) cold
 !9 = !DILocalVariable(name: "b", scope: !2, file: !3, type: !7)
 !10 = !DILocalVariable(name: "c", scope: !2, file: !3, type: !7)
 
-; CHECK: define {{.*}}@foo.cold.1(ptr %[[ARG0:.*]], i32 %[[ARG1:.*]], ptr %[[ARG2:.*]]){{.*}} !dbg ![[FN:.*]] {
+; CHECK: define {{.*}}@foo.cold.1(ptr %[[ARG0:.*]], i32 %[[ARG1:.*]], ptr %[[ARG2:.*]]){{.*}} !dbg ![[FN:[0-9]+]] {{.*}} {
 ; CHECK-NEXT: newFuncRoot:
 ; CHECK-NEXT: #dbg_declare(ptr %[[ARG0]], ![[V1:[0-9]+]], {{.*}})
 ; CHECK-NEXT: #dbg_value(i32 %[[ARG1]], ![[V2:[0-9]+]], {{.*}})

--- a/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/generated_funcs.ll.generated.globals.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/generated_funcs.ll.generated.globals.expected
@@ -82,3 +82,5 @@ declare void @_Z10sideeffectv()
 ; CHECK: attributes #[[ATTR1:[0-9]+]] = { cold minsize noreturn }
 ; CHECK: attributes #[[ATTR2]] = { noinline }
 ;.
+; CHECK: [[META0:![0-9]+]] = !{!"function_entry_count", i64 0}
+;.

--- a/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/generated_funcs.ll.nogenerated.globals.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/generated_funcs.ll.nogenerated.globals.expected
@@ -63,3 +63,5 @@ declare void @_Z10sideeffectv()
 ; CHECK: attributes #[[ATTR1:[0-9]+]] = { cold minsize noreturn }
 ; CHECK: attributes #[[ATTR2]] = { noinline }
 ;.
+; CHECK: [[META0:![0-9]+]] = !{!"function_entry_count", i64 0}
+;.

--- a/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/generated_funcs_prefix_reuse.ll.generated.globals.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/generated_funcs_prefix_reuse.ll.generated.globals.expected
@@ -83,3 +83,5 @@ declare void @_Z10sideeffectv()
 ; REUSE: attributes #[[ATTR1:[0-9]+]] = { cold minsize noreturn }
 ; REUSE: attributes #[[ATTR2]] = { noinline }
 ;.
+; REUSE: [[META0:![0-9]+]] = !{!"function_entry_count", i64 0}
+;.

--- a/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/generated_funcs_prefix_reuse.ll.nogenerated.globals.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_test_checks/Inputs/generated_funcs_prefix_reuse.ll.nogenerated.globals.expected
@@ -64,3 +64,5 @@ declare void @_Z10sideeffectv()
 ; REUSE: attributes #[[ATTR1:[0-9]+]] = { cold minsize noreturn }
 ; REUSE: attributes #[[ATTR2]] = { noinline }
 ;.
+; REUSE: [[META0:![0-9]+]] = !{!"function_entry_count", i64 0}
+;.

--- a/llvm/utils/profcheck-xfail.txt
+++ b/llvm/utils/profcheck-xfail.txt
@@ -6,7 +6,6 @@ CodeGen/WinEH/wineh-statenumbering-cleanups.ll
 CodeGen/WinEH/wineh-statenumbering.ll
 DebugInfo/AArch64/ir-outliner.ll
 DebugInfo/Generic/block-asan.ll
-DebugInfo/assignment-tracking/X86/hotcoldsplit.ll
 Transforms/AtomicExpand/ARM/atomic-expansion-v7.ll
 Transforms/Coroutines/coro-await-suspend-lower-invoke.ll
 Transforms/Coroutines/coro-await-suspend-lower.ll


### PR DESCRIPTION
Previously, HotColdSplit would only mark functions as cold if there was a profile summary available in the module metadata. This was causing profcheck failures and is inconsistent with how we handle profile metadata in other parts of the compiler.

This behavior has been around since
c36c10ddfb3dc07129b9f3973029d17940f6a45f when the profile annotation was first introduced.