### PR TITLE
[Target] Remove unused DenseMapInfo::getTombstoneKey

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64StackTaggingPreRA.cpp
+++ b/llvm/lib/Target/AArch64/AArch64StackTaggingPreRA.cpp
@@ -232,7 +232,6 @@ struct SlotWithTag {
 namespace llvm {
 template <> struct DenseMapInfo<SlotWithTag> {
   static inline SlotWithTag getEmptyKey() { return {-2, -2}; }
-  static inline SlotWithTag getTombstoneKey() { return {-3, -3}; }
   static unsigned getHashValue(const SlotWithTag &V) {
     return hash_combine(DenseMapInfo<int>::getHashValue(V.FI),
                         DenseMapInfo<int>::getHashValue(V.Tag));

--- a/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
@@ -484,11 +484,6 @@ hasHazard(StateT InitialState,
                   DenseMapInfo<void *>::getEmptyKey()),
               DenseMapInfo<unsigned>::getEmptyKey()};
     }
-    static inline StateMapKey getTombstoneKey() {
-      return {static_cast<SmallVectorImpl<StateT> *>(
-                  DenseMapInfo<void *>::getTombstoneKey()),
-              DenseMapInfo<unsigned>::getTombstoneKey()};
-    }
     static unsigned getHashValue(const StateMapKey &Key) {
       return StateT::getHashValue((*Key.States)[Key.Idx]);
     }
@@ -497,15 +492,12 @@ hasHazard(StateT InitialState,
     }
     static bool isEqual(const StateMapKey &LHS, const StateMapKey &RHS) {
       const auto EKey = getEmptyKey();
-      const auto TKey = getTombstoneKey();
-      if (StateMapKey::isEqual(LHS, EKey) || StateMapKey::isEqual(RHS, EKey) ||
-          StateMapKey::isEqual(LHS, TKey) || StateMapKey::isEqual(RHS, TKey))
+      if (StateMapKey::isEqual(LHS, EKey) || StateMapKey::isEqual(RHS, EKey))
         return StateMapKey::isEqual(LHS, RHS);
       return StateT::isEqual((*LHS.States)[LHS.Idx], (*RHS.States)[RHS.Idx]);
     }
     static bool isEqual(const StateT &LHS, const StateMapKey &RHS) {
-      if (StateMapKey::isEqual(RHS, getEmptyKey()) ||
-          StateMapKey::isEqual(RHS, getTombstoneKey()))
+      if (StateMapKey::isEqual(RHS, getEmptyKey()))
         return false;
       return StateT::isEqual(LHS, (*RHS.States)[RHS.Idx]);
     }

--- a/llvm/lib/Target/CSKY/MCTargetDesc/CSKYTargetStreamer.h
+++ b/llvm/lib/Target/CSKY/MCTargetDesc/CSKYTargetStreamer.h
@@ -78,9 +78,6 @@ template <> struct DenseMapInfo<CSKYTargetStreamer::SymbolIndex> {
   static inline CSKYTargetStreamer::SymbolIndex getEmptyKey() {
     return {nullptr, CSKY::S_Invalid};
   }
-  static inline CSKYTargetStreamer::SymbolIndex getTombstoneKey() {
-    return {nullptr, CSKY::S_Invalid};
-  }
   static unsigned getHashValue(const CSKYTargetStreamer::SymbolIndex &V) {
     return hash_combine(DenseMapInfo<const MCSymbol *>::getHashValue(V.sym),
                         DenseMapInfo<int>::getHashValue(V.kind));

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -125,9 +125,6 @@ struct DenseMapInfo<std::pair<const MCSymbol *, PPCMCExpr::Specifier>> {
   using TOCKey = std::pair<const MCSymbol *, PPCMCExpr::Specifier>;
 
   static inline TOCKey getEmptyKey() { return {nullptr, PPC::S_None}; }
-  static inline TOCKey getTombstoneKey() {
-    return {(const MCSymbol *)1, PPC::S_None};
-  }
   static unsigned getHashValue(const TOCKey &PairVal) {
     return detail::combineHashValue(
         DenseMapInfo<const MCSymbol *>::getHashValue(PairVal.first),

--- a/llvm/lib/Target/SPIRV/SPIRVTypeInst.h
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeInst.h
@@ -64,9 +64,6 @@ template <> struct DenseMapInfo<SPIRVTypeInst> {
   static SPIRVTypeInst getEmptyKey() {
     return {MIInfo::getEmptyKey(), SPIRVTypeInst::UncheckedConstructor()};
   }
-  static SPIRVTypeInst getTombstoneKey() {
-    return {MIInfo::getTombstoneKey(), SPIRVTypeInst::UncheckedConstructor()};
-  }
   static unsigned getHashValue(SPIRVTypeInst Ty) {
     return MIInfo::getHashValue(Ty.MI);
   }

--- a/llvm/lib/Target/X86/X86OptimizeLEAs.cpp
+++ b/llvm/lib/Target/X86/X86OptimizeLEAs.cpp
@@ -124,18 +124,10 @@ template <> struct DenseMapInfo<MemOpKey> {
                     PtrInfo::getEmptyKey());
   }
 
-  static inline MemOpKey getTombstoneKey() {
-    return MemOpKey(PtrInfo::getTombstoneKey(), PtrInfo::getTombstoneKey(),
-                    PtrInfo::getTombstoneKey(), PtrInfo::getTombstoneKey(),
-                    PtrInfo::getTombstoneKey());
-  }
-
   static unsigned getHashValue(const MemOpKey &Val) {
     // Checking any field of MemOpKey is enough to determine if the key is
-    // empty or tombstone.
+    // empty.
     assert(Val.Disp != PtrInfo::getEmptyKey() && "Cannot hash the empty key");
-    assert(Val.Disp != PtrInfo::getTombstoneKey() &&
-           "Cannot hash the tombstone key");
 
     hash_code Hash = hash_combine(*Val.Operands[0], *Val.Operands[1],
                                   *Val.Operands[2], *Val.Operands[3]);
@@ -175,11 +167,9 @@ template <> struct DenseMapInfo<MemOpKey> {
 
   static bool isEqual(const MemOpKey &LHS, const MemOpKey &RHS) {
     // Checking any field of MemOpKey is enough to determine if the key is
-    // empty or tombstone.
+    // empty.
     if (RHS.Disp == PtrInfo::getEmptyKey())
       return LHS.Disp == PtrInfo::getEmptyKey();
-    if (RHS.Disp == PtrInfo::getTombstoneKey())
-      return LHS.Disp == PtrInfo::getTombstoneKey();
     return LHS == RHS;
   }
 };


### PR DESCRIPTION
#200595 changed DenseMap to no longer create tombstone buckets, so
DenseMapInfo<T>::getTombstoneKey() is never called. Remove dead
definitions and dead tombstone branches.
