### PR TITLE
[CodeGen][Transforms] Remove unused DenseMapInfo::getTombstoneKey

### DIFF
--- a/llvm/include/llvm/CodeGen/AccelTable.h
+++ b/llvm/include/llvm/CodeGen/AccelTable.h
@@ -274,9 +274,6 @@ template <> struct DenseMapInfo<OffsetAndUnitID> {
   static inline OffsetAndUnitID getEmptyKey() {
     return OffsetAndUnitID(-1, -1, false);
   }
-  static inline OffsetAndUnitID getTombstoneKey() {
-    return OffsetAndUnitID(-2, -2, false);
-  }
   static unsigned getHashValue(const OffsetAndUnitID &Val) {
     return (unsigned)llvm::hash_combine(Val.offset(), Val.unitID(), Val.IsTU);
   }

--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -88,9 +88,6 @@ template <> struct DenseMapInfo<MBBSectionID> {
   static inline MBBSectionID getEmptyKey() {
     return MBBSectionID(NumberInfo::getEmptyKey());
   }
-  static inline MBBSectionID getTombstoneKey() {
-    return MBBSectionID(NumberInfo::getTombstoneKey());
-  }
   static unsigned getHashValue(const MBBSectionID &SecID) {
     return detail::combineHashValue(TypeInfo::getHashValue(SecID.Type),
                                     NumberInfo::getHashValue(SecID.Number));

--- a/llvm/include/llvm/CodeGen/MachineInstr.h
+++ b/llvm/include/llvm/CodeGen/MachineInstr.h
@@ -2130,16 +2130,11 @@ struct MachineInstrExpressionTrait : DenseMapInfo<MachineInstr*> {
     return nullptr;
   }
 
-  static inline MachineInstr *getTombstoneKey() {
-    return reinterpret_cast<MachineInstr*>(-1);
-  }
-
   LLVM_ABI static unsigned getHashValue(const MachineInstr *const &MI);
 
   static bool isEqual(const MachineInstr* const &LHS,
                       const MachineInstr* const &RHS) {
-    if (RHS == getEmptyKey() || RHS == getTombstoneKey() ||
-        LHS == getEmptyKey() || LHS == getTombstoneKey())
+    if (RHS == getEmptyKey() || LHS == getEmptyKey())
       return LHS == RHS;
     return LHS->isIdenticalTo(*RHS, MachineInstr::IgnoreVRegDefs);
   }

--- a/llvm/include/llvm/CodeGen/MachineOperand.h
+++ b/llvm/include/llvm/CodeGen/MachineOperand.h
@@ -1018,7 +1018,6 @@ private:
   /// Artificial kinds for DenseMap usage.
   enum : unsigned char {
     MO_Empty = MO_Last + 1,
-    MO_Tombstone,
   };
 
   friend struct DenseMapInfo<MachineOperand>;
@@ -1041,18 +1040,12 @@ template <> struct DenseMapInfo<MachineOperand> {
     return MachineOperand(static_cast<MachineOperand::MachineOperandType>(
         MachineOperand::MO_Empty));
   }
-  static MachineOperand getTombstoneKey() {
-    return MachineOperand(static_cast<MachineOperand::MachineOperandType>(
-        MachineOperand::MO_Tombstone));
-  }
   static unsigned getHashValue(const MachineOperand &MO) {
     return hash_value(MO);
   }
   static bool isEqual(const MachineOperand &LHS, const MachineOperand &RHS) {
     if (LHS.getType() == static_cast<MachineOperand::MachineOperandType>(
-                             MachineOperand::MO_Empty) ||
-        LHS.getType() == static_cast<MachineOperand::MachineOperandType>(
-                             MachineOperand::MO_Tombstone))
+                             MachineOperand::MO_Empty))
       return LHS.getType() == RHS.getType();
     return LHS.isIdenticalTo(RHS);
   }

--- a/llvm/include/llvm/CodeGen/PBQP/CostAllocator.h
+++ b/llvm/include/llvm/CodeGen/PBQP/CostAllocator.h
@@ -49,10 +49,6 @@ private:
   public:
     static inline PoolEntry *getEmptyKey() { return nullptr; }
 
-    static inline PoolEntry *getTombstoneKey() {
-      return reinterpret_cast<PoolEntry *>(static_cast<uintptr_t>(1));
-    }
-
     template <typename ValueKeyT>
     static unsigned getHashValue(const ValueKeyT &C) {
       return hash_value(C);
@@ -73,13 +69,13 @@ private:
 
     template <typename ValueKeyT>
     static bool isEqual(const ValueKeyT &C, PoolEntry *P) {
-      if (P == getEmptyKey() || P == getTombstoneKey())
+      if (P == getEmptyKey())
         return false;
       return isEqual(C, P->getValue());
     }
 
     static bool isEqual(PoolEntry *P1, PoolEntry *P2) {
-      if (P1 == getEmptyKey() || P1 == getTombstoneKey())
+      if (P1 == getEmptyKey())
         return P1 == P2;
       return isEqual(P1->getValue(), P2);
     }

--- a/llvm/include/llvm/CodeGen/Register.h
+++ b/llvm/include/llvm/CodeGen/Register.h
@@ -166,9 +166,6 @@ template <> struct DenseMapInfo<Register> {
   static inline Register getEmptyKey() {
     return DenseMapInfo<unsigned>::getEmptyKey();
   }
-  static inline Register getTombstoneKey() {
-    return DenseMapInfo<unsigned>::getTombstoneKey();
-  }
   static unsigned getHashValue(const Register &Val) {
     return DenseMapInfo<unsigned>::getHashValue(Val.id());
   }

--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -245,12 +245,6 @@ template<> struct DenseMapInfo<SDValue> {
     return V;
   }
 
-  static inline SDValue getTombstoneKey() {
-    SDValue V;
-    V.ResNo = -2U;
-    return V;
-  }
-
   static unsigned getHashValue(const SDValue &Val) {
     return ((unsigned)((uintptr_t)Val.getNode() >> 4) ^
             (unsigned)((uintptr_t)Val.getNode() >> 9)) + Val.getResNo();

--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -2422,11 +2422,6 @@ template <> struct DenseMapInfo<TargetInstrInfo::RegSubRegPair> {
                                           SubRegInfo::getEmptyKey());
   }
 
-  static inline TargetInstrInfo::RegSubRegPair getTombstoneKey() {
-    return TargetInstrInfo::RegSubRegPair(RegInfo::getTombstoneKey(),
-                                          SubRegInfo::getTombstoneKey());
-  }
-
   /// Reuse getHashValue implementation from
   /// std::pair<unsigned, unsigned>.
   static unsigned getHashValue(const TargetInstrInfo::RegSubRegPair &Val) {

--- a/llvm/include/llvm/DebugInfo/CodeView/TypeHashing.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/TypeHashing.h
@@ -184,11 +184,8 @@ static_assert(std::is_trivially_copyable<GloballyHashedType>::value,
 
 template <> struct DenseMapInfo<codeview::LocallyHashedType> {
   LLVM_ABI static codeview::LocallyHashedType Empty;
-  LLVM_ABI static codeview::LocallyHashedType Tombstone;
 
   static codeview::LocallyHashedType getEmptyKey() { return Empty; }
-
-  static codeview::LocallyHashedType getTombstoneKey() { return Tombstone; }
 
   static unsigned getHashValue(codeview::LocallyHashedType Val) {
     return Val.Hash;
@@ -204,11 +201,8 @@ template <> struct DenseMapInfo<codeview::LocallyHashedType> {
 
 template <> struct DenseMapInfo<codeview::GloballyHashedType> {
   LLVM_ABI static codeview::GloballyHashedType Empty;
-  LLVM_ABI static codeview::GloballyHashedType Tombstone;
 
   static codeview::GloballyHashedType getEmptyKey() { return Empty; }
-
-  static codeview::GloballyHashedType getTombstoneKey() { return Tombstone; }
 
   static unsigned getHashValue(codeview::GloballyHashedType Val) {
     return *reinterpret_cast<const unsigned *>(Val.Hash.data());

--- a/llvm/include/llvm/DebugInfo/CodeView/TypeIndex.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/TypeIndex.h
@@ -293,9 +293,6 @@ template <> struct DenseMapInfo<codeview::TypeIndex> {
   static inline codeview::TypeIndex getEmptyKey() {
     return codeview::TypeIndex{DenseMapInfo<uint32_t>::getEmptyKey()};
   }
-  static inline codeview::TypeIndex getTombstoneKey() {
-    return codeview::TypeIndex{DenseMapInfo<uint32_t>::getTombstoneKey()};
-  }
   static unsigned getHashValue(const codeview::TypeIndex &TI) {
     return DenseMapInfo<uint32_t>::getHashValue(TI.getIndex());
   }

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
@@ -536,7 +536,6 @@ private:
   /// DenseMapInfo for struct Abbrev.
   struct AbbrevMapInfo {
     LLVM_ABI static Abbrev getEmptyKey();
-    LLVM_ABI static Abbrev getTombstoneKey();
     static unsigned getHashValue(uint32_t Code) {
       return DenseMapInfo<uint32_t>::getHashValue(Code);
     }

--- a/llvm/include/llvm/DebugInfo/GSYM/FileEntry.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/FileEntry.h
@@ -56,10 +56,6 @@ template <> struct DenseMapInfo<gsym::FileEntry> {
     gsym::gsym_strp_t key = DenseMapInfo<gsym::gsym_strp_t>::getEmptyKey();
     return gsym::FileEntry(key, key);
   }
-  static inline gsym::FileEntry getTombstoneKey() {
-    gsym::gsym_strp_t key = DenseMapInfo<gsym::gsym_strp_t>::getTombstoneKey();
-    return gsym::FileEntry(key, key);
-  }
   static unsigned getHashValue(const gsym::FileEntry &Val) {
     return llvm::hash_combine(
         DenseMapInfo<gsym::gsym_strp_t>::getHashValue(Val.Dir),

--- a/llvm/include/llvm/Transforms/IPO/Attributor.h
+++ b/llvm/include/llvm/Transforms/IPO/Attributor.h
@@ -325,7 +325,7 @@ struct RangeTy {
   /// Constants used to represent special offsets or sizes.
   /// - We cannot assume that Offsets and Size are non-negative.
   /// - The constants should not clash with DenseMapInfo, such as EmptyKey
-  ///   (INT64_MAX) and TombstoneKey (INT64_MIN).
+  ///   (INT64_MAX).
   /// We use values "in the middle" of the 64 bit range to represent these
   /// special cases.
   static constexpr int64_t Unassigned = std::numeric_limits<int32_t>::min();
@@ -434,9 +434,6 @@ struct DenseMapInfo<AA::ValueAndContext>
   static inline AA::ValueAndContext getEmptyKey() {
     return Base::getEmptyKey();
   }
-  static inline AA::ValueAndContext getTombstoneKey() {
-    return Base::getTombstoneKey();
-  }
   static unsigned getHashValue(const AA::ValueAndContext &VAC) {
     return Base::getHashValue(VAC);
   }
@@ -452,9 +449,6 @@ struct DenseMapInfo<AA::ValueScope> : public DenseMapInfo<unsigned char> {
   using Base = DenseMapInfo<unsigned char>;
   static inline AA::ValueScope getEmptyKey() {
     return AA::ValueScope(Base::getEmptyKey());
-  }
-  static inline AA::ValueScope getTombstoneKey() {
-    return AA::ValueScope(Base::getTombstoneKey());
   }
   static unsigned getHashValue(const AA::ValueScope &S) {
     return Base::getHashValue(S);
@@ -472,10 +466,6 @@ struct DenseMapInfo<const AA::InstExclusionSetTy *>
   static inline const AA::InstExclusionSetTy *getEmptyKey() {
     return static_cast<const AA::InstExclusionSetTy *>(super::getEmptyKey());
   }
-  static inline const AA::InstExclusionSetTy *getTombstoneKey() {
-    return static_cast<const AA::InstExclusionSetTy *>(
-        super::getTombstoneKey());
-  }
   static unsigned getHashValue(const AA::InstExclusionSetTy *BES) {
     unsigned H = 0;
     if (BES)
@@ -487,8 +477,7 @@ struct DenseMapInfo<const AA::InstExclusionSetTy *>
                       const AA::InstExclusionSetTy *RHS) {
     if (LHS == RHS)
       return true;
-    if (LHS == getEmptyKey() || RHS == getEmptyKey() ||
-        LHS == getTombstoneKey() || RHS == getTombstoneKey())
+    if (LHS == getEmptyKey() || RHS == getEmptyKey())
       return false;
     auto SizeLHS = LHS ? LHS->size() : 0;
     auto SizeRHS = RHS ? RHS->size() : 0;
@@ -957,7 +946,6 @@ struct IRPosition {
   ///
   ///{
   LLVM_ABI static const IRPosition EmptyKey;
-  LLVM_ABI static const IRPosition TombstoneKey;
   ///}
 
   /// Conversion into a void * to allow reuse of pointer hashing.
@@ -1095,9 +1083,6 @@ private:
 /// Helper that allows IRPosition as a key in a DenseMap.
 template <> struct DenseMapInfo<IRPosition> {
   static inline IRPosition getEmptyKey() { return IRPosition::EmptyKey; }
-  static inline IRPosition getTombstoneKey() {
-    return IRPosition::TombstoneKey;
-  }
   static unsigned getHashValue(const IRPosition &IRP) {
     return (DenseMapInfo<void *>::getHashValue(IRP) << 4) ^
            (DenseMapInfo<Value *>::getHashValue(IRP.getCallBaseContext()));

--- a/llvm/include/llvm/Transforms/IPO/FunctionSpecialization.h
+++ b/llvm/include/llvm/Transforms/IPO/FunctionSpecialization.h
@@ -108,8 +108,7 @@ using ConstMap = DenseMap<Value *, Constant *>;
 // Specialization signature, used to uniquely designate a specialization within
 // a function.
 struct SpecSig {
-  // Hashing support, used to distinguish between ordinary, empty, or tombstone
-  // keys.
+  // Hashing support, used to distinguish between ordinary and empty keys.
   unsigned Key = 0;
   SmallVector<ArgInfo, 4> Args;
 

--- a/llvm/include/llvm/Transforms/IPO/IROutliner.h
+++ b/llvm/include/llvm/Transforms/IPO/IROutliner.h
@@ -207,8 +207,6 @@ public:
     // Check that the DenseMap implementation has not changed.
     static_assert(DenseMapInfo<unsigned>::getEmptyKey() ==
                   static_cast<unsigned>(-1));
-    static_assert(DenseMapInfo<unsigned>::getTombstoneKey() ==
-                  static_cast<unsigned>(-2));
   }
   LLVM_ABI bool run(Module &M);
 

--- a/llvm/include/llvm/Transforms/Scalar/GVNExpression.h
+++ b/llvm/include/llvm/Transforms/Scalar/GVNExpression.h
@@ -71,13 +71,12 @@ public:
   virtual ~Expression();
 
   static unsigned getEmptyKey() { return ~0U; }
-  static unsigned getTombstoneKey() { return ~1U; }
 
   bool operator!=(const Expression &Other) const { return !(*this == Other); }
   bool operator==(const Expression &Other) const {
     if (getOpcode() != Other.getOpcode())
       return false;
-    if (getOpcode() == getEmptyKey() || getOpcode() == getTombstoneKey())
+    if (getOpcode() == getEmptyKey())
       return true;
     // Compare the expression type for anything but load and store.
     // For load and store we set the opcode to zero to make them equal.

--- a/llvm/include/llvm/Transforms/Utils/BypassSlowDivision.h
+++ b/llvm/include/llvm/Transforms/Utils/BypassSlowDivision.h
@@ -50,10 +50,6 @@ template <> struct DenseMapInfo<DivRemMapKey> {
     return DivRemMapKey(false, nullptr, nullptr);
   }
 
-  static DivRemMapKey getTombstoneKey() {
-    return DivRemMapKey(true, nullptr, nullptr);
-  }
-
   static unsigned getHashValue(const DivRemMapKey &Val) {
     return (unsigned)(reinterpret_cast<uintptr_t>(
                           static_cast<Value *>(Val.Dividend)) ^

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/VecUtils.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/VecUtils.h
@@ -25,9 +25,6 @@ template <> struct DenseMapInfo<SmallVector<sandboxir::Value *>> {
   static inline SmallVector<sandboxir::Value *> getEmptyKey() {
     return SmallVector<sandboxir::Value *>({(sandboxir::Value *)-1});
   }
-  static inline SmallVector<sandboxir::Value *> getTombstoneKey() {
-    return SmallVector<sandboxir::Value *>({(sandboxir::Value *)-2});
-  }
   static unsigned getHashValue(const SmallVector<sandboxir::Value *> &Vec) {
     return hash_combine_range(Vec);
   }

--- a/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.h
+++ b/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.h
@@ -85,13 +85,6 @@ public:
       return V;
     }
 
-    static LocalVarDef tombstoneValue() {
-      LocalVarDef V;
-      std::memset(&V, 0xff, sizeof(LocalVarDef));
-      V.InMemory = 0;
-      return V;
-    }
-
     unsigned hashValue() const {
       uint64_t H = 0;
       std::memcpy(&H, this, sizeof(uint64_t));
@@ -557,10 +550,6 @@ template <> struct DenseMapInfo<CodeViewDebug::LocalVarDef> {
 
   static inline CodeViewDebug::LocalVarDef getEmptyKey() {
     return CodeViewDebug::LocalVarDef::emptyValue();
-  }
-
-  static inline CodeViewDebug::LocalVarDef getTombstoneKey() {
-    return CodeViewDebug::LocalVarDef::tombstoneValue();
   }
 
   static unsigned getHashValue(const CodeViewDebug::LocalVarDef &DR) {

--- a/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
+++ b/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
@@ -73,9 +73,6 @@ template <> struct llvm::DenseMapInfo<VariableID> {
   static inline VariableID getEmptyKey() {
     return static_cast<VariableID>(Wrapped::getEmptyKey());
   }
-  static inline VariableID getTombstoneKey() {
-    return static_cast<VariableID>(Wrapped::getTombstoneKey());
-  }
   static unsigned getHashValue(const VariableID &Val) {
     return Wrapped::getHashValue(static_cast<unsigned>(Val));
   }

--- a/llvm/lib/CodeGen/ComplexDeinterleavingPass.cpp
+++ b/llvm/lib/CodeGen/ComplexDeinterleavingPass.cpp
@@ -131,10 +131,6 @@ template <> struct llvm::DenseMapInfo<ComplexValue> {
     return {DenseMapInfo<Value *>::getEmptyKey(),
             DenseMapInfo<Value *>::getEmptyKey()};
   }
-  static inline ComplexValue getTombstoneKey() {
-    return {DenseMapInfo<Value *>::getTombstoneKey(),
-            DenseMapInfo<Value *>::getTombstoneKey()};
-  }
   static unsigned getHashValue(const ComplexValue &Val) {
     return hash_combine(DenseMapInfo<Value *>::getHashValue(Val.Real),
                         DenseMapInfo<Value *>::getHashValue(Val.Imag));

--- a/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.cpp
+++ b/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.cpp
@@ -983,7 +983,6 @@ public:
 //===----------------------------------------------------------------------===//
 
 ValueIDNum ValueIDNum::EmptyValue = {UINT_MAX, UINT_MAX, UINT_MAX};
-ValueIDNum ValueIDNum::TombstoneValue = {UINT_MAX, UINT_MAX, UINT_MAX - 1};
 
 #ifndef NDEBUG
 void ResolvedDbgOp::dump(const MLocTracker *MTrack) const {

--- a/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.h
+++ b/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.h
@@ -93,11 +93,6 @@ public:
   }
 
   static LocIdx MakeIllegalLoc() { return LocIdx(); }
-  static LocIdx MakeTombstoneLoc() {
-    LocIdx L = LocIdx();
-    --L.Location;
-    return L;
-  }
 
   bool isIllegal() const { return Location == UINT_MAX; }
 
@@ -206,7 +201,6 @@ public:
   }
 
   LLVM_ABI_FOR_TEST static ValueIDNum EmptyValue;
-  LLVM_ABI_FOR_TEST static ValueIDNum TombstoneValue;
 };
 
 } // End namespace LiveDebugValues
@@ -216,7 +210,6 @@ using namespace LiveDebugValues;
 
 template <> struct DenseMapInfo<LocIdx> {
   static inline LocIdx getEmptyKey() { return LocIdx::MakeIllegalLoc(); }
-  static inline LocIdx getTombstoneKey() { return LocIdx::MakeTombstoneLoc(); }
 
   static unsigned getHashValue(const LocIdx &Loc) { return Loc.asU64(); }
 
@@ -225,9 +218,6 @@ template <> struct DenseMapInfo<LocIdx> {
 
 template <> struct DenseMapInfo<ValueIDNum> {
   static inline ValueIDNum getEmptyKey() { return ValueIDNum::EmptyValue; }
-  static inline ValueIDNum getTombstoneKey() {
-    return ValueIDNum::TombstoneValue;
-  }
 
   static unsigned getHashValue(const ValueIDNum &Val) {
     return hash_value(Val.asU64());

--- a/llvm/lib/CodeGen/MachineOutliner.cpp
+++ b/llvm/lib/CodeGen/MachineOutliner.cpp
@@ -245,9 +245,7 @@ struct InstructionMapper {
       report_fatal_error("Instruction mapping overflow!");
 
     assert(LegalInstrNumber != DenseMapInfo<unsigned>::getEmptyKey() &&
-           "Tried to assign DenseMap tombstone or empty key to instruction.");
-    assert(LegalInstrNumber != DenseMapInfo<unsigned>::getTombstoneKey() &&
-           "Tried to assign DenseMap tombstone or empty key to instruction.");
+           "Tried to assign DenseMap empty key to instruction.");
 
     // Statistics.
     ++NumLegalInUnsignedVec;
@@ -285,10 +283,7 @@ struct InstructionMapper {
            "Instruction mapping overflow!");
 
     assert(IllegalInstrNumber != DenseMapInfo<unsigned>::getEmptyKey() &&
-           "IllegalInstrNumber cannot be DenseMap tombstone or empty key!");
-
-    assert(IllegalInstrNumber != DenseMapInfo<unsigned>::getTombstoneKey() &&
-           "IllegalInstrNumber cannot be DenseMap tombstone or empty key!");
+           "IllegalInstrNumber cannot be DenseMap empty key!");
 
     return MINumber;
   }
@@ -423,8 +418,6 @@ struct InstructionMapper {
     // changed.
     static_assert(DenseMapInfo<unsigned>::getEmptyKey() ==
                   static_cast<unsigned>(-1));
-    static_assert(DenseMapInfo<unsigned>::getTombstoneKey() ==
-                  static_cast<unsigned>(-2));
   }
 };
 

--- a/llvm/lib/CodeGen/StackMaps.cpp
+++ b/llvm/lib/CodeGen/StackMaps.cpp
@@ -242,13 +242,11 @@ StackMaps::parseOperand(MachineInstr::const_mop_iterator MOI,
       } else {
         // ConstPool is intentionally a MapVector of 'uint64_t's (as
         // opposed to 'int64_t's).  We should never be in a situation
-        // where we have to insert either the tombstone or the empty
-        // keys into a map, and for a DenseMap<uint64_t, T> these are
-        // (uint64_t)0 and (uint64_t)-1.  They can be and are
+        // where we have to insert the empty key into a map, and for a
+        // DenseMap<uint64_t, T> this is (uint64_t)-1.  It can be and is
         // represented using 32 bit integers.
         assert((uint64_t)Imm != DenseMapInfo<uint64_t>::getEmptyKey() &&
-               (uint64_t)Imm != DenseMapInfo<uint64_t>::getTombstoneKey() &&
-               "empty and tombstone keys should fit in 32 bits!");
+               "empty key should fit in 32 bits!");
         auto Result = ConstPool.insert(std::make_pair(Imm, Imm));
         Locs.emplace_back(Location::ConstantIndex, sizeof(int64_t), 0,
                           Result.first - ConstPool.begin());

--- a/llvm/lib/DebugInfo/CodeView/TypeHashing.cpp
+++ b/llvm/lib/DebugInfo/CodeView/TypeHashing.cpp
@@ -15,15 +15,11 @@ using namespace llvm;
 using namespace llvm::codeview;
 
 LocallyHashedType DenseMapInfo<LocallyHashedType>::Empty{0, {}};
-LocallyHashedType DenseMapInfo<LocallyHashedType>::Tombstone{hash_code(-1), {}};
 
 static std::array<uint8_t, 8> EmptyHash = {
     {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
-static std::array<uint8_t, 8> TombstoneHash = {
-    {0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
 GloballyHashedType DenseMapInfo<GloballyHashedType>::Empty{EmptyHash};
-GloballyHashedType DenseMapInfo<GloballyHashedType>::Tombstone{TombstoneHash};
 
 LocallyHashedType LocallyHashedType::hashType(ArrayRef<uint8_t> RecordData) {
   return {llvm::hash_value(RecordData), RecordData};

--- a/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
@@ -516,10 +516,6 @@ DWARFDebugNames::Abbrev DWARFDebugNames::AbbrevMapInfo::getEmptyKey() {
   return sentinelAbbrev();
 }
 
-DWARFDebugNames::Abbrev DWARFDebugNames::AbbrevMapInfo::getTombstoneKey() {
-  return DWARFDebugNames::Abbrev(~0, dwarf::Tag(0), 0, {});
-}
-
 Expected<DWARFDebugNames::AttributeEncoding>
 DWARFDebugNames::NameIndex::extractAttributeEncoding(uint64_t *Offset) {
   if (*Offset >= Offsets.EntriesBase) {

--- a/llvm/lib/DebugInfo/PDB/Native/GSIStreamBuilder.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/GSIStreamBuilder.cpp
@@ -72,11 +72,6 @@ struct llvm::pdb::SymbolDenseMapInfo {
     static CVSymbol Empty;
     return Empty;
   }
-  static inline CVSymbol getTombstoneKey() {
-    static CVSymbol Tombstone(
-        DenseMapInfo<ArrayRef<uint8_t>>::getTombstoneKey());
-    return Tombstone;
-  }
   static unsigned getHashValue(const CVSymbol &Val) {
     return xxh3_64bits(Val.RecordData);
   }

--- a/llvm/lib/Transforms/IPO/Attributor.cpp
+++ b/llvm/lib/Transforms/IPO/Attributor.cpp
@@ -1333,8 +1333,6 @@ ChangeStatus Attributor::manifestAttrs(const IRPosition &IRP,
 }
 
 const IRPosition IRPosition::EmptyKey(DenseMapInfo<void *>::getEmptyKey());
-const IRPosition
-    IRPosition::TombstoneKey(DenseMapInfo<void *>::getTombstoneKey());
 
 SubsumingPositionIterator::SubsumingPositionIterator(const IRPosition &IRP) {
   IRPositions.emplace_back(IRP);

--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -746,7 +746,6 @@ template <>
 struct DenseMapInfo<AAPointerInfo::Access> : DenseMapInfo<Instruction *> {
   using Access = AAPointerInfo::Access;
   static inline Access getEmptyKey();
-  static inline Access getTombstoneKey();
   static unsigned getHashValue(const Access &A);
   static bool isEqual(const Access &LHS, const Access &RHS);
 };
@@ -756,11 +755,6 @@ template <> struct DenseMapInfo<AA::RangeTy> {
   static inline AA::RangeTy getEmptyKey() {
     auto EmptyKey = DenseMapInfo<int64_t>::getEmptyKey();
     return AA::RangeTy{EmptyKey, EmptyKey};
-  }
-
-  static inline AA::RangeTy getTombstoneKey() {
-    auto TombstoneKey = DenseMapInfo<int64_t>::getTombstoneKey();
-    return AA::RangeTy{TombstoneKey, TombstoneKey};
   }
 
   static unsigned getHashValue(const AA::RangeTy &Range) {
@@ -780,7 +774,6 @@ struct AccessAsInstructionInfo : DenseMapInfo<Instruction *> {
   using Base = DenseMapInfo<Instruction *>;
   using Access = AAPointerInfo::Access;
   static inline Access getEmptyKey();
-  static inline Access getTombstoneKey();
   static unsigned getHashValue(const Access &A);
   static bool isEqual(const Access &LHS, const Access &RHS);
 };
@@ -3477,12 +3470,8 @@ template <typename ToTy> struct DenseMapInfo<ReachabilityQueryInfo<ToTy> *> {
   using PairDMI = DenseMapInfo<std::pair<const Instruction *, const ToTy *>>;
 
   static ReachabilityQueryInfo<ToTy> EmptyKey;
-  static ReachabilityQueryInfo<ToTy> TombstoneKey;
 
   static inline ReachabilityQueryInfo<ToTy> *getEmptyKey() { return &EmptyKey; }
-  static inline ReachabilityQueryInfo<ToTy> *getTombstoneKey() {
-    return &TombstoneKey;
-  }
   static unsigned getHashValue(const ReachabilityQueryInfo<ToTy> *RQI) {
     return RQI->Hash ? RQI->Hash : RQI->computeHashValue();
   }
@@ -3500,13 +3489,7 @@ template <typename ToTy> struct DenseMapInfo<ReachabilityQueryInfo<ToTy> *> {
       DenseMapInfo<ReachabilityQueryInfo<ToTy> *>::EmptyKey =                  \
           ReachabilityQueryInfo<ToTy>(                                         \
               DenseMapInfo<const Instruction *>::getEmptyKey(),                \
-              DenseMapInfo<const ToTy *>::getEmptyKey());                      \
-  template <>                                                                  \
-  ReachabilityQueryInfo<ToTy>                                                  \
-      DenseMapInfo<ReachabilityQueryInfo<ToTy> *>::TombstoneKey =              \
-          ReachabilityQueryInfo<ToTy>(                                         \
-              DenseMapInfo<const Instruction *>::getTombstoneKey(),            \
-              DenseMapInfo<const ToTy *>::getTombstoneKey());
+              DenseMapInfo<const ToTy *>::getEmptyKey());
 
 DefineKeys(Instruction) DefineKeys(Function)
 #undef DefineKeys

--- a/llvm/lib/Transforms/IPO/FunctionSpecialization.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionSpecialization.cpp
@@ -632,11 +632,8 @@ void FunctionSpecializer::cleanUpSSA() {
     removeSSACopy(*F);
 }
 
-
 template <> struct llvm::DenseMapInfo<SpecSig> {
   static inline SpecSig getEmptyKey() { return {~0U, {}}; }
-
-  static inline SpecSig getTombstoneKey() { return {~1U, {}}; }
 
   static unsigned getHashValue(const SpecSig &S) {
     return static_cast<unsigned>(hash_value(S));

--- a/llvm/lib/Transforms/IPO/WholeProgramDevirt.cpp
+++ b/llvm/lib/Transforms/IPO/WholeProgramDevirt.cpp
@@ -387,10 +387,6 @@ template <> struct llvm::DenseMapInfo<VTableSlot> {
     return {DenseMapInfo<Metadata *>::getEmptyKey(),
             DenseMapInfo<uint64_t>::getEmptyKey()};
   }
-  static VTableSlot getTombstoneKey() {
-    return {DenseMapInfo<Metadata *>::getTombstoneKey(),
-            DenseMapInfo<uint64_t>::getTombstoneKey()};
-  }
   static unsigned getHashValue(const VTableSlot &I) {
     return DenseMapInfo<Metadata *>::getHashValue(I.TypeID) ^
            DenseMapInfo<uint64_t>::getHashValue(I.ByteOffset);
@@ -405,10 +401,6 @@ template <> struct llvm::DenseMapInfo<VTableSlotSummary> {
   static VTableSlotSummary getEmptyKey() {
     return {DenseMapInfo<StringRef>::getEmptyKey(),
             DenseMapInfo<uint64_t>::getEmptyKey()};
-  }
-  static VTableSlotSummary getTombstoneKey() {
-    return {DenseMapInfo<StringRef>::getTombstoneKey(),
-            DenseMapInfo<uint64_t>::getTombstoneKey()};
   }
   static unsigned getHashValue(const VTableSlotSummary &I) {
     return DenseMapInfo<StringRef>::getHashValue(I.TypeID) ^

--- a/llvm/lib/Transforms/InstCombine/InstCombinePHI.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombinePHI.cpp
@@ -1051,9 +1051,6 @@ template <> struct llvm::DenseMapInfo<LoweredPHIRecord> {
   static inline LoweredPHIRecord getEmptyKey() {
     return LoweredPHIRecord(nullptr, 0);
   }
-  static inline LoweredPHIRecord getTombstoneKey() {
-    return LoweredPHIRecord(nullptr, 1);
-  }
   static unsigned getHashValue(const LoweredPHIRecord &Val) {
     return DenseMapInfo<PHINode *>::getHashValue(Val.PN) ^ (Val.Shift >> 3) ^
            (Val.Width >> 3);

--- a/llvm/lib/Transforms/Scalar/EarlyCSE.cpp
+++ b/llvm/lib/Transforms/Scalar/EarlyCSE.cpp
@@ -98,8 +98,7 @@ struct SimpleValue {
   }
 
   bool isSentinel() const {
-    return Inst == DenseMapInfo<Instruction *>::getEmptyKey() ||
-           Inst == DenseMapInfo<Instruction *>::getTombstoneKey();
+    return Inst == DenseMapInfo<Instruction *>::getEmptyKey();
   }
 
   static bool canHandle(Instruction *Inst) {
@@ -157,10 +156,6 @@ struct SimpleValue {
 template <> struct llvm::DenseMapInfo<SimpleValue> {
   static inline SimpleValue getEmptyKey() {
     return DenseMapInfo<Instruction *>::getEmptyKey();
-  }
-
-  static inline SimpleValue getTombstoneKey() {
-    return DenseMapInfo<Instruction *>::getTombstoneKey();
   }
 
   static unsigned getHashValue(SimpleValue Val);
@@ -483,8 +478,7 @@ struct CallValue {
   }
 
   bool isSentinel() const {
-    return Inst == DenseMapInfo<Instruction *>::getEmptyKey() ||
-           Inst == DenseMapInfo<Instruction *>::getTombstoneKey();
+    return Inst == DenseMapInfo<Instruction *>::getEmptyKey();
   }
 
   static bool canHandle(Instruction *Inst) {
@@ -508,10 +502,6 @@ struct CallValue {
 template <> struct llvm::DenseMapInfo<CallValue> {
   static inline CallValue getEmptyKey() {
     return DenseMapInfo<Instruction *>::getEmptyKey();
-  }
-
-  static inline CallValue getTombstoneKey() {
-    return DenseMapInfo<Instruction *>::getTombstoneKey();
   }
 
   static unsigned getHashValue(CallValue Val);
@@ -561,8 +551,7 @@ struct GEPValue {
   }
 
   bool isSentinel() const {
-    return Inst == DenseMapInfo<Instruction *>::getEmptyKey() ||
-           Inst == DenseMapInfo<Instruction *>::getTombstoneKey();
+    return Inst == DenseMapInfo<Instruction *>::getEmptyKey();
   }
 
   static bool canHandle(Instruction *Inst) {
@@ -575,10 +564,6 @@ struct GEPValue {
 template <> struct llvm::DenseMapInfo<GEPValue> {
   static inline GEPValue getEmptyKey() {
     return DenseMapInfo<Instruction *>::getEmptyKey();
-  }
-
-  static inline GEPValue getTombstoneKey() {
-    return DenseMapInfo<Instruction *>::getTombstoneKey();
   }
 
   static unsigned getHashValue(const GEPValue &Val);

--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -173,7 +173,6 @@ struct llvm::GVNPass::Expression {
 
 template <> struct llvm::DenseMapInfo<GVNPass::Expression> {
   static inline GVNPass::Expression getEmptyKey() { return ~0U; }
-  static inline GVNPass::Expression getTombstoneKey() { return ~1U; }
 
   static unsigned getHashValue(const GVNPass::Expression &E) {
     using llvm::hash_value;

--- a/llvm/lib/Transforms/Scalar/GVNSink.cpp
+++ b/llvm/lib/Transforms/Scalar/GVNSink.cpp
@@ -260,11 +260,6 @@ template <> struct llvm::DenseMapInfo<ModelledPHI> {
     return Dummy;
   }
 
-  static inline ModelledPHI &getTombstoneKey() {
-    static ModelledPHI Dummy = ModelledPHI::createDummy(1);
-    return Dummy;
-  }
-
   static unsigned getHashValue(const ModelledPHI &V) { return V.hash(); }
 
   static bool isEqual(const ModelledPHI &LHS, const ModelledPHI &RHS) {

--- a/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
@@ -307,10 +307,6 @@ struct UnrolledInstStateKeyInfo {
     return {PtrInfo::getEmptyKey(), 0, 0, 0};
   }
 
-  static inline UnrolledInstState getTombstoneKey() {
-    return {PtrInfo::getTombstoneKey(), 0, 0, 0};
-  }
-
   static inline unsigned getHashValue(const UnrolledInstState &S) {
     return PairInfo::getHashValue({S.I, S.Iteration});
   }

--- a/llvm/lib/Transforms/Scalar/NewGVN.cpp
+++ b/llvm/lib/Transforms/Scalar/NewGVN.cpp
@@ -448,12 +448,6 @@ template <> struct llvm::DenseMapInfo<const Expression *> {
     return reinterpret_cast<const Expression *>(Val);
   }
 
-  static const Expression *getTombstoneKey() {
-    auto Val = static_cast<uintptr_t>(~1U);
-    Val <<= PointerLikeTypeTraits<const Expression *>::NumLowBitsAvailable;
-    return reinterpret_cast<const Expression *>(Val);
-  }
-
   static unsigned getHashValue(const Expression *E) {
     return E->getComputedHash();
   }
@@ -463,7 +457,7 @@ template <> struct llvm::DenseMapInfo<const Expression *> {
   }
 
   static bool isEqual(const ExactEqualsExpression &LHS, const Expression *RHS) {
-    if (RHS == getTombstoneKey() || RHS == getEmptyKey())
+    if (RHS == getEmptyKey())
       return false;
     return LHS == *RHS;
   }
@@ -471,8 +465,7 @@ template <> struct llvm::DenseMapInfo<const Expression *> {
   static bool isEqual(const Expression *LHS, const Expression *RHS) {
     if (LHS == RHS)
       return true;
-    if (LHS == getTombstoneKey() || RHS == getTombstoneKey() ||
-        LHS == getEmptyKey() || RHS == getEmptyKey())
+    if (LHS == getEmptyKey() || RHS == getEmptyKey())
       return false;
     // Compare hashes before equality.  This is *not* what the hashtable does,
     // since it is computing it modulo the number of buckets, whereas we are

--- a/llvm/lib/Transforms/Utils/CanonicalizeFreezeInLoops.cpp
+++ b/llvm/lib/Transforms/Utils/CanonicalizeFreezeInLoops.cpp
@@ -107,11 +107,6 @@ template <> struct llvm::DenseMapInfo<FrozenIndPHIInfo> {
                             DenseMapInfo<BinaryOperator *>::getEmptyKey());
   }
 
-  static inline FrozenIndPHIInfo getTombstoneKey() {
-    return FrozenIndPHIInfo(DenseMapInfo<PHINode *>::getTombstoneKey(),
-                            DenseMapInfo<BinaryOperator *>::getTombstoneKey());
-  }
-
   static unsigned getHashValue(const FrozenIndPHIInfo &Val) {
     return DenseMapInfo<FreezeInst *>::getHashValue(Val.FI);
   };

--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -1436,13 +1436,7 @@ EliminateDuplicatePHINodesSetBasedImpl(BasicBlock *BB,
       return DenseMapInfo<PHINode *>::getEmptyKey();
     }
 
-    static PHINode *getTombstoneKey() {
-      return DenseMapInfo<PHINode *>::getTombstoneKey();
-    }
-
-    static bool isSentinel(PHINode *PN) {
-      return PN == getEmptyKey() || PN == getTombstoneKey();
-    }
+    static bool isSentinel(PHINode *PN) { return PN == getEmptyKey(); }
 
     // WARNING: this logic must be kept in sync with
     //          Instruction::isIdenticalToWhenDefined()!
@@ -2827,18 +2821,13 @@ static bool markAliveBlocks(Function &F, SmallVectorImpl<bool> &Reachable,
           return DenseMapInfo<CatchPadInst *>::getEmptyKey();
         }
 
-        static CatchPadInst *getTombstoneKey() {
-          return DenseMapInfo<CatchPadInst *>::getTombstoneKey();
-        }
-
         static unsigned getHashValue(CatchPadInst *CatchPad) {
           return static_cast<unsigned>(hash_combine_range(
               CatchPad->value_op_begin(), CatchPad->value_op_end()));
         }
 
         static bool isEqual(CatchPadInst *LHS, CatchPadInst *RHS) {
-          if (LHS == getEmptyKey() || LHS == getTombstoneKey() ||
-              RHS == getEmptyKey() || RHS == getTombstoneKey())
+          if (LHS == getEmptyKey() || RHS == getEmptyKey())
             return LHS == RHS;
           return LHS->isIdenticalTo(RHS);
         }

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -8059,10 +8059,6 @@ template <> struct llvm::DenseMapInfo<const EqualBBWrapper *> {
   static const EqualBBWrapper *getEmptyKey() {
     return static_cast<EqualBBWrapper *>(DenseMapInfo<void *>::getEmptyKey());
   }
-  static const EqualBBWrapper *getTombstoneKey() {
-    return static_cast<EqualBBWrapper *>(
-        DenseMapInfo<void *>::getTombstoneKey());
-  }
   static unsigned getHashValue(const EqualBBWrapper *EBW) {
     BasicBlock *BB = EBW->BB;
     UncondBrInst *BI = cast<UncondBrInst>(BB->getTerminator());
@@ -8083,8 +8079,7 @@ template <> struct llvm::DenseMapInfo<const EqualBBWrapper *> {
   }
   static bool isEqual(const EqualBBWrapper *LHS, const EqualBBWrapper *RHS) {
     auto *EKey = DenseMapInfo<EqualBBWrapper *>::getEmptyKey();
-    auto *TKey = DenseMapInfo<EqualBBWrapper *>::getTombstoneKey();
-    if (LHS == EKey || RHS == EKey || LHS == TKey || RHS == TKey)
+    if (LHS == EKey || RHS == EKey)
       return LHS == RHS;
 
     BasicBlock *A = LHS->BB;

--- a/llvm/lib/Transforms/Vectorize/LoadStoreVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoadStoreVectorizer.cpp
@@ -1820,17 +1820,12 @@ std::vector<Chain> Vectorizer::gatherChains(ArrayRef<Instruction *> Instrs) {
     using PtrInfo = DenseMapInfo<InstrListElem *>;
     using IInfo = DenseMapInfo<Instruction *>;
     static InstrListElem *getEmptyKey() { return PtrInfo::getEmptyKey(); }
-    static InstrListElem *getTombstoneKey() {
-      return PtrInfo::getTombstoneKey();
-    }
     static unsigned getHashValue(const InstrListElem *E) {
       return IInfo::getHashValue(E->first);
     }
     static bool isEqual(const InstrListElem *A, const InstrListElem *B) {
       if (A == getEmptyKey() || B == getEmptyKey())
         return A == getEmptyKey() && B == getEmptyKey();
-      if (A == getTombstoneKey() || B == getTombstoneKey())
-        return A == getTombstoneKey() && B == getTombstoneKey();
       return IInfo::isEqual(A->first, B->first);
     }
   };

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -2035,10 +2035,6 @@ struct CSEDenseMapInfo {
     return DenseMapInfo<Instruction *>::getEmptyKey();
   }
 
-  static inline Instruction *getTombstoneKey() {
-    return DenseMapInfo<Instruction *>::getTombstoneKey();
-  }
-
   static unsigned getHashValue(const Instruction *I) {
     assert(canHandle(I) && "Unknown instruction!");
     return hash_combine(I->getOpcode(),
@@ -2046,8 +2042,7 @@ struct CSEDenseMapInfo {
   }
 
   static bool isEqual(const Instruction *LHS, const Instruction *RHS) {
-    if (LHS == getEmptyKey() || RHS == getEmptyKey() ||
-        LHS == getTombstoneKey() || RHS == getTombstoneKey())
+    if (LHS == getEmptyKey() || RHS == getEmptyKey())
       return LHS == RHS;
     return LHS->isIdenticalTo(RHS);
   }

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -6426,12 +6426,6 @@ private:
       return V;
     }
 
-    static OrdersType getTombstoneKey() {
-      OrdersType V;
-      V.push_back(~2U);
-      return V;
-    }
-
     static unsigned getHashValue(const OrdersType &V) {
       return static_cast<unsigned>(hash_combine_range(V));
     }
@@ -6489,11 +6483,6 @@ template <> struct llvm::DenseMapInfo<BoUpSLP::EdgeInfo> {
   static BoUpSLP::EdgeInfo getEmptyKey() {
     return BoUpSLP::EdgeInfo(FirstInfo::getEmptyKey(),
                              SecondInfo::getEmptyKey());
-  }
-
-  static BoUpSLP::EdgeInfo getTombstoneKey() {
-    return BoUpSLP::EdgeInfo(FirstInfo::getTombstoneKey(),
-                             SecondInfo::getTombstoneKey());
   }
 
   static unsigned getHashValue(const BoUpSLP::EdgeInfo &Val) {

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -2436,7 +2436,7 @@ void VPlanTransforms::clearReductionWrapFlags(VPlan &Plan) {
 namespace {
 struct VPCSEDenseMapInfo : public DenseMapInfo<VPSingleDefRecipe *> {
   static bool isSentinel(const VPSingleDefRecipe *Def) {
-    return Def == getEmptyKey() || Def == getTombstoneKey();
+    return Def == getEmptyKey();
   }
 
   /// If recipe \p R will lower to a GEP with a non-i8 source element type,


### PR DESCRIPTION
#200595 changed DenseMap to no longer create tombstone buckets, so
DenseMapInfo<T>::getTombstoneKey() is never called. Remove dead
definitions and dead tombstone branches.
