### PR TITLE
[llvm] Remove unused DenseMapInfo::getTombstoneKey

### DIFF
--- a/llvm/include/llvm/BinaryFormat/Minidump.h
+++ b/llvm/include/llvm/BinaryFormat/Minidump.h
@@ -272,10 +272,6 @@ static_assert(sizeof(ExceptionStream) == 168);
 template <> struct DenseMapInfo<minidump::StreamType> {
   static minidump::StreamType getEmptyKey() { return minidump::StreamType(-1); }
 
-  static minidump::StreamType getTombstoneKey() {
-    return minidump::StreamType(-2);
-  }
-
   static unsigned getHashValue(minidump::StreamType Val) {
     return DenseMapInfo<uint32_t>::getHashValue(static_cast<uint32_t>(Val));
   }

--- a/llvm/include/llvm/BinaryFormat/Wasm.h
+++ b/llvm/include/llvm/BinaryFormat/Wasm.h
@@ -519,8 +519,8 @@ struct WasmSignature {
   // but does not actually model them. Instead a placeholder signature is
   // created in the Object's signature list.
   enum { Function, Tag, Placeholder } Kind = Function;
-  // Support empty and tombstone instances, needed by DenseMap.
-  enum { Plain, Empty, Tombstone } State = Plain;
+  // Support empty instances, needed by DenseMap.
+  enum { Plain, Empty } State = Plain;
 
   WasmSignature(SmallVector<ValType, 1> &&InReturns,
                 SmallVector<ValType, 4> &&InParams)

--- a/llvm/include/llvm/BinaryFormat/WasmTraits.h
+++ b/llvm/include/llvm/BinaryFormat/WasmTraits.h
@@ -25,11 +25,6 @@ template <> struct DenseMapInfo<wasm::WasmSignature, void> {
     Sig.State = wasm::WasmSignature::Empty;
     return Sig;
   }
-  static wasm::WasmSignature getTombstoneKey() {
-    wasm::WasmSignature Sig;
-    Sig.State = wasm::WasmSignature::Tombstone;
-    return Sig;
-  }
   static unsigned getHashValue(const wasm::WasmSignature &Sig) {
     uintptr_t H = hash_value(Sig.State);
     for (auto Ret : Sig.Returns)
@@ -49,9 +44,6 @@ template <> struct DenseMapInfo<wasm::WasmGlobalType, void> {
   static wasm::WasmGlobalType getEmptyKey() {
     return wasm::WasmGlobalType{1, true};
   }
-  static wasm::WasmGlobalType getTombstoneKey() {
-    return wasm::WasmGlobalType{2, true};
-  }
   static unsigned getHashValue(const wasm::WasmGlobalType &GlobalType) {
     return hash_combine(GlobalType.Type, GlobalType.Mutable);
   }
@@ -65,9 +57,6 @@ template <> struct DenseMapInfo<wasm::WasmGlobalType, void> {
 template <> struct DenseMapInfo<wasm::WasmLimits, void> {
   static wasm::WasmLimits getEmptyKey() {
     return wasm::WasmLimits{0xff, 0xff, 0xff, 0xff};
-  }
-  static wasm::WasmLimits getTombstoneKey() {
-    return wasm::WasmLimits{0xee, 0xee, 0xee, 0xee};
   }
   static unsigned getHashValue(const wasm::WasmLimits &Limits) {
     unsigned Hash = hash_value(Limits.Flags);
@@ -88,11 +77,6 @@ template <> struct DenseMapInfo<wasm::WasmTableType, void> {
   static wasm::WasmTableType getEmptyKey() {
     return wasm::WasmTableType{
         wasm::ValType(0), DenseMapInfo<wasm::WasmLimits, void>::getEmptyKey()};
-  }
-  static wasm::WasmTableType getTombstoneKey() {
-    return wasm::WasmTableType{
-        wasm::ValType(1),
-        DenseMapInfo<wasm::WasmLimits, void>::getTombstoneKey()};
   }
   static unsigned getHashValue(const wasm::WasmTableType &TableType) {
     return hash_combine(

--- a/llvm/include/llvm/CAS/CASID.h
+++ b/llvm/include/llvm/CAS/CASID.h
@@ -107,7 +107,11 @@ public:
     return CASID(nullptr, DenseMapInfo<StringRef>::getEmptyKey());
   }
   static CASID getDenseMapTombstoneKey() {
-    return CASID(nullptr, DenseMapInfo<StringRef>::getTombstoneKey());
+    // A reserved StringRef value distinct from the empty key, used only as a
+    // DenseMap sentinel for CASID.
+    return CASID(nullptr, StringRef(reinterpret_cast<const char *>(
+                                        ~static_cast<uintptr_t>(1)),
+                                    0));
   }
 
   CASID() = delete;
@@ -129,10 +133,6 @@ private:
 
 template <> struct DenseMapInfo<cas::CASID> {
   static cas::CASID getEmptyKey() { return cas::CASID::getDenseMapEmptyKey(); }
-
-  static cas::CASID getTombstoneKey() {
-    return cas::CASID::getDenseMapTombstoneKey();
-  }
 
   static unsigned getHashValue(cas::CASID ID) {
     return (unsigned)hash_value(ID);

--- a/llvm/include/llvm/CAS/CASReference.h
+++ b/llvm/include/llvm/CAS/CASReference.h
@@ -27,7 +27,6 @@ class ObjectRef;
 class ReferenceBase {
 protected:
   struct DenseMapEmptyTag {};
-  struct DenseMapTombstoneTag {};
   static constexpr uint64_t getDenseMapEmptyRef() { return -1ULL; }
   static constexpr uint64_t getDenseMapTombstoneRef() { return -2ULL; }
 
@@ -78,8 +77,6 @@ protected:
   }
   explicit ReferenceBase(DenseMapEmptyTag)
       : InternalRef(getDenseMapEmptyRef()) {}
-  explicit ReferenceBase(DenseMapTombstoneTag)
-      : InternalRef(getDenseMapTombstoneRef()) {}
 
 private:
   uint64_t InternalRef;
@@ -119,9 +116,6 @@ public:
   static ObjectRef getDenseMapEmptyKey() {
     return ObjectRef(DenseMapEmptyTag{});
   }
-  static ObjectRef getDenseMapTombstoneKey() {
-    return ObjectRef(DenseMapTombstoneTag{});
-  }
 
   /// Print internal ref and/or CASID. Only suitable for debugging.
   void print(raw_ostream &OS) const { return ReferenceBase::print(OS, *this); }
@@ -138,7 +132,6 @@ private:
     assert(InternalRef != -2ULL && "Reserved for DenseMapInfo");
   }
   explicit ObjectRef(DenseMapEmptyTag T) : ReferenceBase(T) {}
-  explicit ObjectRef(DenseMapTombstoneTag T) : ReferenceBase(T) {}
   explicit ObjectRef(ReferenceBase) = delete;
 };
 
@@ -175,10 +168,6 @@ private:
 template <> struct DenseMapInfo<cas::ObjectRef> {
   static cas::ObjectRef getEmptyKey() {
     return cas::ObjectRef::getDenseMapEmptyKey();
-  }
-
-  static cas::ObjectRef getTombstoneKey() {
-    return cas::ObjectRef::getDenseMapTombstoneKey();
   }
 
   static unsigned getHashValue(cas::ObjectRef Ref) {

--- a/llvm/include/llvm/CodeGenTypes/LowLevelType.h
+++ b/llvm/include/llvm/CodeGenTypes/LowLevelType.h
@@ -722,11 +722,6 @@ template <> struct DenseMapInfo<LLT> {
     Invalid.Info = LLT::Kind::POINTER;
     return Invalid;
   }
-  static inline LLT getTombstoneKey() {
-    LLT Invalid;
-    Invalid.Info = LLT::Kind::VECTOR_ANY;
-    return Invalid;
-  }
   static inline unsigned getHashValue(const LLT &Ty) {
     uint64_t Val = Ty.getUniqueRAWLLTData();
     return DenseMapInfo<uint64_t>::getHashValue(Val);

--- a/llvm/include/llvm/DWARFLinker/Classic/DWARFLinkerDeclContext.h
+++ b/llvm/include/llvm/DWARFLinker/Classic/DWARFLinkerDeclContext.h
@@ -173,14 +173,13 @@ private:
 /// Info type for the DenseMap storing the DeclContext pointers.
 struct DeclMapInfo : private DenseMapInfo<DeclContext *> {
   using DenseMapInfo<DeclContext *>::getEmptyKey;
-  using DenseMapInfo<DeclContext *>::getTombstoneKey;
 
   static unsigned getHashValue(const DeclContext *Ctxt) {
     return Ctxt->QualifiedNameHash;
   }
 
   static bool isEqual(const DeclContext *LHS, const DeclContext *RHS) {
-    if (RHS == getEmptyKey() || RHS == getTombstoneKey())
+    if (RHS == getEmptyKey())
       return RHS == LHS;
     return LHS->QualifiedNameHash == RHS->QualifiedNameHash &&
            LHS->Line == RHS->Line && LHS->ByteSize == RHS->ByteSize &&

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h
@@ -347,9 +347,6 @@ template <> struct DenseMapInfo<orc::ExecutorAddr> {
   static inline orc::ExecutorAddr getEmptyKey() {
     return orc::ExecutorAddr(DenseMapInfo<uint64_t>::getEmptyKey());
   }
-  static inline orc::ExecutorAddr getTombstoneKey() {
-    return orc::ExecutorAddr(DenseMapInfo<uint64_t>::getTombstoneKey());
-  }
 
   static unsigned getHashValue(const orc::ExecutorAddr &Addr) {
     return DenseMapInfo<uint64_t>::getHashValue(Addr.getValue());

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/MemoryFlags.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/MemoryFlags.h
@@ -210,9 +210,6 @@ inline raw_ostream &operator<<(raw_ostream &OS, AllocGroup AG) {
 
 template <> struct DenseMapInfo<orc::MemProt> {
   static inline orc::MemProt getEmptyKey() { return orc::MemProt(~uint8_t(0)); }
-  static inline orc::MemProt getTombstoneKey() {
-    return orc::MemProt(~uint8_t(0) - 1);
-  }
   static unsigned getHashValue(const orc::MemProt &Val) {
     using UT = std::underlying_type_t<orc::MemProt>;
     return DenseMapInfo<UT>::getHashValue(static_cast<UT>(Val));
@@ -225,9 +222,6 @@ template <> struct DenseMapInfo<orc::MemProt> {
 template <> struct DenseMapInfo<orc::AllocGroup> {
   static inline orc::AllocGroup getEmptyKey() {
     return orc::AllocGroup(~uint8_t(0));
-  }
-  static inline orc::AllocGroup getTombstoneKey() {
-    return orc::AllocGroup(~uint8_t(0) - 1);
   }
   static unsigned getHashValue(const orc::AllocGroup &Val) {
     return DenseMapInfo<orc::AllocGroup::underlying_type>::getHashValue(Val.Id);

--- a/llvm/include/llvm/ExecutionEngine/Orc/SymbolStringPool.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/SymbolStringPool.h
@@ -333,10 +333,6 @@ struct DenseMapInfo<orc::SymbolStringPtr> {
     return orc::SymbolStringPtr::getEmptyVal();
   }
 
-  static orc::SymbolStringPtr getTombstoneKey() {
-    return orc::SymbolStringPtr::getTombstoneVal();
-  }
-
   static unsigned getHashValue(const orc::SymbolStringPtrBase &V) {
     return DenseMapInfo<orc::SymbolStringPtr::PoolEntryPtr>::getHashValue(V.S);
   }
@@ -351,10 +347,6 @@ template <> struct DenseMapInfo<orc::NonOwningSymbolStringPtr> {
 
   static orc::NonOwningSymbolStringPtr getEmptyKey() {
     return orc::NonOwningSymbolStringPtr::getEmptyVal();
-  }
-
-  static orc::NonOwningSymbolStringPtr getTombstoneKey() {
-    return orc::NonOwningSymbolStringPtr::getTombstoneVal();
   }
 
   static unsigned getHashValue(const orc::SymbolStringPtrBase &V) {

--- a/llvm/include/llvm/Frontend/OpenMP/OMPContext.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPContext.h
@@ -205,9 +205,6 @@ template <> struct DenseMapInfo<omp::TraitProperty> {
   static inline omp::TraitProperty getEmptyKey() {
     return omp::TraitProperty(-1);
   }
-  static inline omp::TraitProperty getTombstoneKey() {
-    return omp::TraitProperty(-2);
-  }
   static unsigned getHashValue(omp::TraitProperty val) {
     return std::hash<unsigned>{}(unsigned(val));
   }

--- a/llvm/include/llvm/Linker/IRMover.h
+++ b/llvm/include/llvm/Linker/IRMover.h
@@ -39,7 +39,6 @@ class IRMover {
       LLVM_ABI bool operator!=(const KeyTy &that) const;
     };
     LLVM_ABI static StructType *getEmptyKey();
-    LLVM_ABI static StructType *getTombstoneKey();
     LLVM_ABI static unsigned getHashValue(const KeyTy &Key);
     LLVM_ABI static unsigned getHashValue(const StructType *ST);
     LLVM_ABI static bool isEqual(const KeyTy &LHS, const StructType *RHS);

--- a/llvm/include/llvm/MC/MCRegister.h
+++ b/llvm/include/llvm/MC/MCRegister.h
@@ -112,9 +112,6 @@ template <> struct DenseMapInfo<MCRegister> {
   static inline MCRegister getEmptyKey() {
     return DenseMapInfo<unsigned>::getEmptyKey();
   }
-  static inline MCRegister getTombstoneKey() {
-    return DenseMapInfo<unsigned>::getTombstoneKey();
-  }
   static unsigned getHashValue(const MCRegister &Val) {
     return DenseMapInfo<unsigned>::getHashValue(Val.id());
   }

--- a/llvm/include/llvm/Object/ObjectFile.h
+++ b/llvm/include/llvm/Object/ObjectFile.h
@@ -656,11 +656,6 @@ template <> struct DenseMapInfo<object::SectionRef> {
   static object::SectionRef getEmptyKey() {
     return object::SectionRef({}, nullptr);
   }
-  static object::SectionRef getTombstoneKey() {
-    object::DataRefImpl TS;
-    TS.p = (uintptr_t)-1;
-    return object::SectionRef(TS, nullptr);
-  }
   static unsigned getHashValue(const object::SectionRef &Sec) {
     object::DataRefImpl Raw = Sec.getRawDataRefImpl();
     return hash_combine(Raw.p, Raw.d.a, Raw.d.b);

--- a/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
+++ b/llvm/include/llvm/ProfileData/Coverage/CoverageMapping.h
@@ -1534,14 +1534,6 @@ template<> struct DenseMapInfo<coverage::CounterExpression> {
                              Counter::getCounter(~0U));
   }
 
-  static inline coverage::CounterExpression getTombstoneKey() {
-    using namespace coverage;
-
-    return CounterExpression(CounterExpression::ExprKind::Add,
-                             Counter::getCounter(~0U),
-                             Counter::getCounter(~0U));
-  }
-
   static unsigned getHashValue(const coverage::CounterExpression &V) {
     return static_cast<unsigned>(
         hash_combine(V.Kind, V.LHS.getKind(), V.LHS.getCounterID(),

--- a/llvm/include/llvm/ProfileData/FunctionId.h
+++ b/llvm/include/llvm/ProfileData/FunctionId.h
@@ -182,10 +182,6 @@ template <> struct DenseMapInfo<sampleprof::FunctionId, void> {
     return sampleprof::FunctionId(~0ULL);
   }
 
-  static inline sampleprof::FunctionId getTombstoneKey() {
-    return sampleprof::FunctionId(~1ULL);
-  }
-
   static unsigned getHashValue(const sampleprof::FunctionId &Val) {
     return Val.getHashCode();
   }

--- a/llvm/include/llvm/ProfileData/SampleProf.h
+++ b/llvm/include/llvm/ProfileData/SampleProf.h
@@ -1706,10 +1706,6 @@ using namespace sampleprof;
 template <> struct DenseMapInfo<SampleContext> {
   static inline SampleContext getEmptyKey() { return SampleContext(); }
 
-  static inline SampleContext getTombstoneKey() {
-    return SampleContext(FunctionId(~1ULL));
-  }
-
   static unsigned getHashValue(const SampleContext &Val) {
     return Val.getHashCode();
   }

--- a/llvm/include/llvm/SandboxIR/Context.h
+++ b/llvm/include/llvm/SandboxIR/Context.h
@@ -321,9 +321,6 @@ template <> struct DenseMapInfo<sandboxir::Context::CallbackID> {
   static CallbackID getEmptyKey() {
     return CallbackID{ReprInfo::getEmptyKey()};
   }
-  static CallbackID getTombstoneKey() {
-    return CallbackID{ReprInfo::getTombstoneKey()};
-  }
   static unsigned getHashValue(const CallbackID &ID) {
     return ReprInfo::getHashValue(ID.Val);
   }

--- a/llvm/include/llvm/TextAPI/SymbolSet.h
+++ b/llvm/include/llvm/TextAPI/SymbolSet.h
@@ -35,11 +35,6 @@ template <> struct DenseMapInfo<SymbolsMapKey> {
     return SymbolsMapKey(MachO::EncodeKind::GlobalSymbol, StringRef{});
   }
 
-  static inline SymbolsMapKey getTombstoneKey() {
-    return SymbolsMapKey(MachO::EncodeKind::ObjectiveCInstanceVariable,
-                         StringRef{});
-  }
-
   static unsigned getHashValue(const SymbolsMapKey &Key) {
     return hash_combine(hash_value(Key.Kind), hash_value(Key.Name));
   }

--- a/llvm/lib/Linker/IRMover.cpp
+++ b/llvm/lib/Linker/IRMover.cpp
@@ -1617,10 +1617,6 @@ StructType *IRMover::StructTypeKeyInfo::getEmptyKey() {
   return DenseMapInfo<StructType *>::getEmptyKey();
 }
 
-StructType *IRMover::StructTypeKeyInfo::getTombstoneKey() {
-  return DenseMapInfo<StructType *>::getTombstoneKey();
-}
-
 unsigned IRMover::StructTypeKeyInfo::getHashValue(const KeyTy &Key) {
   return hash_combine(hash_combine_range(Key.ETypes), Key.IsPacked);
 }
@@ -1631,14 +1627,14 @@ unsigned IRMover::StructTypeKeyInfo::getHashValue(const StructType *ST) {
 
 bool IRMover::StructTypeKeyInfo::isEqual(const KeyTy &LHS,
                                          const StructType *RHS) {
-  if (RHS == getEmptyKey() || RHS == getTombstoneKey())
+  if (RHS == getEmptyKey())
     return false;
   return LHS == KeyTy(RHS);
 }
 
 bool IRMover::StructTypeKeyInfo::isEqual(const StructType *LHS,
                                          const StructType *RHS) {
-  if (RHS == getEmptyKey() || RHS == getTombstoneKey())
+  if (RHS == getEmptyKey())
     return LHS == RHS;
   return KeyTy(LHS) == KeyTy(RHS);
 }

--- a/llvm/lib/Object/Minidump.cpp
+++ b/llvm/lib/Object/Minidump.cpp
@@ -129,8 +129,7 @@ MinidumpFile::create(MemoryBufferRef Source) {
       continue;
     }
 
-    if (Type == DenseMapInfo<StreamType>::getEmptyKey() ||
-        Type == DenseMapInfo<StreamType>::getTombstoneKey())
+    if (Type == DenseMapInfo<StreamType>::getEmptyKey())
       return createError("Cannot handle one of the minidump streams");
 
     // Update the directory map, checking for duplicate stream types.

--- a/llvm/tools/dsymutil/BinaryHolder.h
+++ b/llvm/tools/dsymutil/BinaryHolder.h
@@ -161,10 +161,6 @@ template <> struct DenseMapInfo<dsymutil::BinaryHolder::ArchiveEntry::KeyTy> {
     return dsymutil::BinaryHolder::ArchiveEntry::KeyTy();
   }
 
-  static inline dsymutil::BinaryHolder::ArchiveEntry::KeyTy getTombstoneKey() {
-    return dsymutil::BinaryHolder::ArchiveEntry::KeyTy("/", {});
-  }
-
   static unsigned
   getHashValue(const dsymutil::BinaryHolder::ArchiveEntry::KeyTy &K) {
     return hash_combine(DenseMapInfo<StringRef>::getHashValue(K.Filename),

--- a/llvm/tools/llvm-c-test/echo.cpp
+++ b/llvm/tools/llvm-c-test/echo.cpp
@@ -42,10 +42,6 @@ struct CAPIDenseMap<T*> {
       uintptr_t Val = static_cast<uintptr_t>(-1);
       return reinterpret_cast<T*>(Val);
     }
-    static inline T* getTombstoneKey() {
-      uintptr_t Val = static_cast<uintptr_t>(-2);
-      return reinterpret_cast<T*>(Val);
-    }
     static unsigned getHashValue(const T *PtrVal) {
       return hash_value(PtrVal);
     }

--- a/llvm/tools/llvm-reduce/deltas/Delta.h
+++ b/llvm/tools/llvm-reduce/deltas/Delta.h
@@ -62,11 +62,6 @@ struct DenseMapInfo<Chunk> {
             DenseMapInfo<int>::getEmptyKey()};
   }
 
-  static inline Chunk getTombstoneKey() {
-    return {DenseMapInfo<int>::getTombstoneKey(),
-            DenseMapInfo<int>::getTombstoneKey()};
-  }
-
   static unsigned getHashValue(const Chunk Val) {
     std::pair<int, int> PairVal = std::make_pair(Val.Begin, Val.End);
     return DenseMapInfo<std::pair<int, int>>::getHashValue(PairVal);

--- a/llvm/tools/llvm-split/llvm-split.cpp
+++ b/llvm/tools/llvm-split/llvm-split.cpp
@@ -191,8 +191,6 @@ private:
   struct KeyInfo {
     static SmallString<0> getEmptyKey() { return SmallString<0>(""); }
 
-    static SmallString<0> getTombstoneKey() { return SmallString<0>("-"); }
-
     static bool isEqual(const SmallString<0> &LHS, const SmallString<0> &RHS) {
       return LHS == RHS;
     }

--- a/llvm/utils/TableGen/Basic/RuntimeLibcallsEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/RuntimeLibcallsEmitter.cpp
@@ -52,11 +52,6 @@ template <> struct DenseMapInfo<PredicateWithCC, void> {
         std::pair<const Record *, const Record *>>::getEmptyKey();
   }
 
-  static inline PredicateWithCC getTombstoneKey() {
-    return DenseMapInfo<
-        std::pair<const Record *, const Record *>>::getTombstoneKey();
-  }
-
   static unsigned getHashValue(const PredicateWithCC Val) {
     auto Pair = std::make_pair(Val.Predicate, Val.CallingConv);
     return DenseMapInfo<

--- a/llvm/utils/gdb-scripts/prettyprinters.py
+++ b/llvm/utils/gdb-scripts/prettyprinters.py
@@ -163,7 +163,6 @@ class DenseMapPrinter:
             n = self.key_info_t.name
             is_equal = gdb.parse_and_eval(n + "::isEqual")
             empty = gdb.parse_and_eval(n + "::getEmptyKey()")
-            tombstone = gdb.parse_and_eval(n + "::getTombstoneKey()")
             # the following is invalid, GDB fails with:
             #   Python Exception <class 'gdb.error'> Attempt to take address of value
             #   not located in memory.
@@ -173,10 +172,8 @@ class DenseMapPrinter:
             # member function, not the 'first' member variable, but I've yet to figure
             # out how to find/call member functions (especially (const) overloaded
             # ones) on a gdb.Value.
-            while self.cur != self.end and (
-                is_equal(self.cur.dereference()["first"], empty)
-                or is_equal(self.cur.dereference()["first"], tombstone)
-            ):
+            while self.cur != self.end and
+                is_equal(self.cur.dereference()["first"], empty):
                 self.cur = self.cur + 1
 
         def __next__(self):

--- a/polly/include/polly/Support/VirtualInstruction.h
+++ b/polly/include/polly/Support/VirtualInstruction.h
@@ -322,13 +322,6 @@ public:
                                                 RHS.getInstruction());
   }
 
-  static polly::VirtualInstruction getTombstoneKey() {
-    polly::VirtualInstruction TombstoneKey;
-    TombstoneKey.Stmt = DenseMapInfo<polly::ScopStmt *>::getTombstoneKey();
-    TombstoneKey.Inst = DenseMapInfo<Instruction *>::getTombstoneKey();
-    return TombstoneKey;
-  }
-
   static polly::VirtualInstruction getEmptyKey() {
     polly::VirtualInstruction EmptyKey;
     EmptyKey.Stmt = DenseMapInfo<polly::ScopStmt *>::getEmptyKey();

--- a/polly/include/polly/Support/VirtualInstruction.h
+++ b/polly/include/polly/Support/VirtualInstruction.h
@@ -322,6 +322,13 @@ public:
                                                 RHS.getInstruction());
   }
 
+  static polly::VirtualInstruction getTombstoneKey() {
+    polly::VirtualInstruction TombstoneKey;
+    TombstoneKey.Stmt = DenseMapInfo<polly::ScopStmt *>::getTombstoneKey();
+    TombstoneKey.Inst = DenseMapInfo<Instruction *>::getTombstoneKey();
+    return TombstoneKey;
+  }
+
   static polly::VirtualInstruction getEmptyKey() {
     polly::VirtualInstruction EmptyKey;
     EmptyKey.Stmt = DenseMapInfo<polly::ScopStmt *>::getEmptyKey();


### PR DESCRIPTION
#200595 changed DenseMap to no longer create tombstone buckets, so
DenseMapInfo<T>::getTombstoneKey() is never called. Remove dead
definitions and dead tombstone branches.
