### PR TITLE
[IR][Analysis] Remove unused DenseMapInfo::getTombstoneKey

### DIFF
--- a/llvm/include/llvm/Analysis/AliasAnalysis.h
+++ b/llvm/include/llvm/Analysis/AliasAnalysis.h
@@ -221,10 +221,6 @@ template <> struct DenseMapInfo<AACacheLoc> {
     return {DenseMapInfo<AACacheLoc::PtrTy>::getEmptyKey(),
             DenseMapInfo<LocationSize>::getEmptyKey()};
   }
-  static inline AACacheLoc getTombstoneKey() {
-    return {DenseMapInfo<AACacheLoc::PtrTy>::getTombstoneKey(),
-            DenseMapInfo<LocationSize>::getTombstoneKey()};
-  }
   static unsigned getHashValue(const AACacheLoc &Val) {
     return DenseMapInfo<AACacheLoc::PtrTy>::getHashValue(Val.Ptr) ^
            DenseMapInfo<LocationSize>::getHashValue(Val.Size);

--- a/llvm/include/llvm/Analysis/AssumeBundleQueries.h
+++ b/llvm/include/llvm/Analysis/AssumeBundleQueries.h
@@ -53,9 +53,6 @@ template<> struct DenseMapInfo<Attribute::AttrKind> {
   static Attribute::AttrKind getEmptyKey() {
     return Attribute::EmptyKey;
   }
-  static Attribute::AttrKind getTombstoneKey() {
-    return Attribute::TombstoneKey;
-  }
   static unsigned getHashValue(Attribute::AttrKind AK) {
     return hash_combine(AK);
   }

--- a/llvm/include/llvm/Analysis/IRSimilarityIdentifier.h
+++ b/llvm/include/llvm/Analysis/IRSimilarityIdentifier.h
@@ -315,9 +315,6 @@ LLVM_ABI bool isClose(const IRInstructionData &A, const IRInstructionData &B);
 
 struct IRInstructionDataTraits : DenseMapInfo<IRInstructionData *> {
   static inline IRInstructionData *getEmptyKey() { return nullptr; }
-  static inline IRInstructionData *getTombstoneKey() {
-    return reinterpret_cast<IRInstructionData *>(-1);
-  }
 
   static unsigned getHashValue(const IRInstructionData *E) {
     using llvm::hash_value;
@@ -327,8 +324,7 @@ struct IRInstructionDataTraits : DenseMapInfo<IRInstructionData *> {
 
   static bool isEqual(const IRInstructionData *LHS,
                       const IRInstructionData *RHS) {
-    if (RHS == getEmptyKey() || RHS == getTombstoneKey() ||
-        LHS == getEmptyKey() || LHS == getTombstoneKey())
+    if (RHS == getEmptyKey() || LHS == getEmptyKey())
       return LHS == RHS;
 
     assert(LHS && RHS && "nullptr should have been caught by getEmptyKey?");
@@ -511,8 +507,6 @@ struct IRInstructionMapper {
     // changed.
     static_assert(DenseMapInfo<unsigned>::getEmptyKey() ==
                   static_cast<unsigned>(-1));
-    static_assert(DenseMapInfo<unsigned>::getTombstoneKey() ==
-                  static_cast<unsigned>(-2));
 
     IDL = new (IDLAllocator->Allocate())
         IRInstructionDataList();

--- a/llvm/include/llvm/Analysis/MemoryLocation.h
+++ b/llvm/include/llvm/Analysis/MemoryLocation.h
@@ -330,9 +330,6 @@ public:
 // Specialize DenseMapInfo.
 template <> struct DenseMapInfo<LocationSize> {
   static inline LocationSize getEmptyKey() { return LocationSize::mapEmpty(); }
-  static inline LocationSize getTombstoneKey() {
-    return LocationSize::mapTombstone();
-  }
   static unsigned getHashValue(const LocationSize &Val) {
     return DenseMapInfo<uint64_t>::getHashValue(Val.toRaw());
   }
@@ -345,10 +342,6 @@ template <> struct DenseMapInfo<MemoryLocation> {
   static inline MemoryLocation getEmptyKey() {
     return MemoryLocation(DenseMapInfo<const Value *>::getEmptyKey(),
                           DenseMapInfo<LocationSize>::getEmptyKey());
-  }
-  static inline MemoryLocation getTombstoneKey() {
-    return MemoryLocation(DenseMapInfo<const Value *>::getTombstoneKey(),
-                          DenseMapInfo<LocationSize>::getTombstoneKey());
   }
   static unsigned getHashValue(const MemoryLocation &Val) {
     return DenseMapInfo<const Value *>::getHashValue(Val.Ptr) ^

--- a/llvm/include/llvm/Analysis/MemorySSA.h
+++ b/llvm/include/llvm/Analysis/MemorySSA.h
@@ -1208,11 +1208,6 @@ template <> struct DenseMapInfo<UpwardDefsElem> {
             DenseMapInfo<MemoryLocation>::getEmptyKey(), false};
   }
 
-  static inline UpwardDefsElem getTombstoneKey() {
-    return {DenseMapInfo<MemoryAccess *>::getTombstoneKey(),
-            DenseMapInfo<MemoryLocation>::getTombstoneKey(), false};
-  }
-
   static unsigned getHashValue(const UpwardDefsElem &Val) {
     return hash_combine(DenseMapInfo<MemoryAccess *>::getHashValue(Val.MA),
                         DenseMapInfo<MemoryLocation>::getHashValue(Val.Loc),

--- a/llvm/include/llvm/Analysis/ScalarEvolution.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolution.h
@@ -206,11 +206,6 @@ template <> struct DenseMapInfo<SCEVUse> {
     return PointerLikeTypeTraits<SCEVUse>::getFromVoidPointer((void *)Val);
   }
 
-  static inline SCEVUse getTombstoneKey() {
-    uintptr_t Val = static_cast<uintptr_t>(-2);
-    return PointerLikeTypeTraits<SCEVUse>::getFromVoidPointer((void *)Val);
-  }
-
   static unsigned getHashValue(SCEVUse U) {
     return hash_value(U.getOpaqueValue());
   }
@@ -2732,10 +2727,6 @@ private:
 template <> struct DenseMapInfo<ScalarEvolution::FoldID> {
   static inline ScalarEvolution::FoldID getEmptyKey() {
     ScalarEvolution::FoldID ID(0);
-    return ID;
-  }
-  static inline ScalarEvolution::FoldID getTombstoneKey() {
-    ScalarEvolution::FoldID ID(1);
     return ID;
   }
 

--- a/llvm/include/llvm/Analysis/VectorUtils.h
+++ b/llvm/include/llvm/Analysis/VectorUtils.h
@@ -554,9 +554,8 @@ public:
       return false;
     int32_t Key = *MaybeKey;
 
-    // Skip if the key is used for either the tombstone or empty special values.
-    if (DenseMapInfo<int32_t>::getTombstoneKey() == Key ||
-        DenseMapInfo<int32_t>::getEmptyKey() == Key)
+    // Skip if the key is used for the empty special value.
+    if (DenseMapInfo<int32_t>::getEmptyKey() == Key)
       return false;
 
     // Skip if there is already a member with the same index.

--- a/llvm/include/llvm/IR/Attributes.h
+++ b/llvm/include/llvm/IR/Attributes.h
@@ -532,12 +532,6 @@ template <> struct DenseMapInfo<AttributeSet, void> {
     return AttributeSet(reinterpret_cast<AttributeSetNode *>(Val));
   }
 
-  static AttributeSet getTombstoneKey() {
-    auto Val = static_cast<uintptr_t>(-2);
-    Val <<= PointerLikeTypeTraits<void *>::NumLowBitsAvailable;
-    return AttributeSet(reinterpret_cast<AttributeSetNode *>(Val));
-  }
-
   static unsigned getHashValue(AttributeSet AS) {
     return (unsigned((uintptr_t)AS.SetNode) >> 4) ^
            (unsigned((uintptr_t)AS.SetNode) >> 9);
@@ -1103,12 +1097,6 @@ public:
 template <> struct DenseMapInfo<AttributeList, void> {
   static AttributeList getEmptyKey() {
     auto Val = static_cast<uintptr_t>(-1);
-    Val <<= PointerLikeTypeTraits<void*>::NumLowBitsAvailable;
-    return AttributeList(reinterpret_cast<AttributeListImpl *>(Val));
-  }
-
-  static AttributeList getTombstoneKey() {
-    auto Val = static_cast<uintptr_t>(-2);
     Val <<= PointerLikeTypeTraits<void*>::NumLowBitsAvailable;
     return AttributeList(reinterpret_cast<AttributeListImpl *>(Val));
   }

--- a/llvm/include/llvm/IR/BasicBlock.h
+++ b/llvm/include/llvm/IR/BasicBlock.h
@@ -771,12 +771,6 @@ template <> struct DenseMapInfo<BasicBlock::iterator> {
     return BasicBlock::iterator(nullptr);
   }
 
-  static inline BasicBlock::iterator getTombstoneKey() {
-    BasicBlock::iterator It(nullptr);
-    It.setHeadBit(true);
-    return It;
-  }
-
   static unsigned getHashValue(const BasicBlock::iterator &It) {
     return DenseMapInfo<void *>::getHashValue(
                reinterpret_cast<void *>(It.getNodePtr())) ^

--- a/llvm/include/llvm/IR/DebugInfo.h
+++ b/llvm/include/llvm/IR/DebugInfo.h
@@ -265,11 +265,6 @@ template <> struct DenseMapInfo<at::VarRecord> {
                          DenseMapInfo<DILocation *>::getEmptyKey());
   }
 
-  static inline at::VarRecord getTombstoneKey() {
-    return at::VarRecord(DenseMapInfo<DILocalVariable *>::getTombstoneKey(),
-                         DenseMapInfo<DILocation *>::getTombstoneKey());
-  }
-
   static unsigned getHashValue(const at::VarRecord &Var) {
     return hash_combine(Var.Var, Var.DL);
   }

--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -3925,8 +3925,6 @@ template <> struct DenseMapInfo<DIExpression::FragmentInfo> {
 
   static inline FragInfo getEmptyKey() { return {MaxVal, MaxVal}; }
 
-  static inline FragInfo getTombstoneKey() { return {MaxVal - 1, MaxVal - 1}; }
-
   static unsigned getHashValue(const FragInfo &Frag) {
     return (Frag.SizeInBits & 0xffff) << 16 | (Frag.OffsetInBits & 0xffff);
   }
@@ -4798,11 +4796,6 @@ template <> struct DenseMapInfo<DebugVariable> {
   /// Empty key: no key should be generated that has no DILocalVariable.
   static inline DebugVariable getEmptyKey() {
     return DebugVariable(nullptr, std::nullopt, nullptr);
-  }
-
-  /// Difference in tombstone is that the Optional is meaningful.
-  static inline DebugVariable getTombstoneKey() {
-    return DebugVariable(nullptr, {{0, 0}}, nullptr);
   }
 
   static unsigned getHashValue(const DebugVariable &D) {

--- a/llvm/include/llvm/IR/Dominators.h
+++ b/llvm/include/llvm/IR/Dominators.h
@@ -123,10 +123,6 @@ template <> struct DenseMapInfo<BasicBlockEdge> {
     return BasicBlockEdge(BBInfo::getEmptyKey(), BBInfo::getEmptyKey());
   }
 
-  static inline BasicBlockEdge getTombstoneKey() {
-    return BasicBlockEdge(BBInfo::getTombstoneKey(), BBInfo::getTombstoneKey());
-  }
-
   static unsigned getHashValue(const BasicBlockEdge &Edge) {
     return hash_combine(BBInfo::getHashValue(Edge.getStart()),
                         BBInfo::getHashValue(Edge.getEnd()));

--- a/llvm/include/llvm/IR/Metadata.h
+++ b/llvm/include/llvm/IR/Metadata.h
@@ -874,11 +874,6 @@ struct DenseMapInfo<AAMDNodes> {
                      nullptr, nullptr);
   }
 
-  static inline AAMDNodes getTombstoneKey() {
-    return AAMDNodes(DenseMapInfo<MDNode *>::getTombstoneKey(), nullptr,
-                     nullptr, nullptr, nullptr);
-  }
-
   static unsigned getHashValue(const AAMDNodes &Val) {
     return DenseMapInfo<MDNode *>::getHashValue(Val.TBAA) ^
            DenseMapInfo<MDNode *>::getHashValue(Val.TBAAStruct) ^

--- a/llvm/include/llvm/IR/ModuleSummaryIndex.h
+++ b/llvm/include/llvm/IR/ModuleSummaryIndex.h
@@ -304,13 +304,7 @@ template <> struct DenseMapInfo<ValueInfo> {
     return ValueInfo(false, (GlobalValueSummaryMapTy::value_type *)-8);
   }
 
-  static inline ValueInfo getTombstoneKey() {
-    return ValueInfo(false, (GlobalValueSummaryMapTy::value_type *)-16);
-  }
-
-  static inline bool isSpecialKey(ValueInfo V) {
-    return V == getTombstoneKey() || V == getEmptyKey();
-  }
+  static inline bool isSpecialKey(ValueInfo V) { return V == getEmptyKey(); }
 
   static bool isEqual(ValueInfo L, ValueInfo R) {
     // We are not supposed to mix ValueInfo(s) with different HaveGVs flag
@@ -1132,10 +1126,6 @@ public:
 template <> struct DenseMapInfo<FunctionSummary::VFuncId> {
   static FunctionSummary::VFuncId getEmptyKey() { return {0, uint64_t(-1)}; }
 
-  static FunctionSummary::VFuncId getTombstoneKey() {
-    return {0, uint64_t(-2)};
-  }
-
   static bool isEqual(FunctionSummary::VFuncId L, FunctionSummary::VFuncId R) {
     return L.GUID == R.GUID && L.Offset == R.Offset;
   }
@@ -1146,10 +1136,6 @@ template <> struct DenseMapInfo<FunctionSummary::VFuncId> {
 template <> struct DenseMapInfo<FunctionSummary::ConstVCall> {
   static FunctionSummary::ConstVCall getEmptyKey() {
     return {{0, uint64_t(-1)}, {}};
-  }
-
-  static FunctionSummary::ConstVCall getTombstoneKey() {
-    return {{0, uint64_t(-2)}, {}};
   }
 
   static bool isEqual(FunctionSummary::ConstVCall L,

--- a/llvm/include/llvm/IR/ValueHandle.h
+++ b/llvm/include/llvm/IR/ValueHandle.h
@@ -130,9 +130,7 @@ protected:
   Value *getValPtr() const { return Val; }
 
   static bool isValid(Value *V) {
-    return V &&
-           V != DenseMapInfo<Value *>::getEmptyKey() &&
-           V != DenseMapInfo<Value *>::getTombstoneKey();
+    return V && V != DenseMapInfo<Value *>::getEmptyKey();
   }
 
   /// Remove this ValueHandle from its current use list.
@@ -210,10 +208,6 @@ template <> struct simplify_type<const WeakVH> {
 template <> struct DenseMapInfo<WeakVH> {
   static inline WeakVH getEmptyKey() {
     return WeakVH(DenseMapInfo<Value *>::getEmptyKey());
-  }
-
-  static inline WeakVH getTombstoneKey() {
-    return WeakVH(DenseMapInfo<Value *>::getTombstoneKey());
   }
 
   static unsigned getHashValue(const WeakVH &Val) {
@@ -585,12 +579,6 @@ template <typename T> struct DenseMapInfo<PoisoningVH<T>> {
   static inline PoisoningVH<T> getEmptyKey() {
     PoisoningVH<T> Res;
     Res.setRawValPtr(DenseMapInfo<Value *>::getEmptyKey());
-    return Res;
-  }
-
-  static inline PoisoningVH<T> getTombstoneKey() {
-    PoisoningVH<T> Res;
-    Res.setRawValPtr(DenseMapInfo<Value *>::getTombstoneKey());
     return Res;
   }
 

--- a/llvm/include/llvm/IR/ValueMap.h
+++ b/llvm/include/llvm/IR/ValueMap.h
@@ -245,7 +245,7 @@ class ValueMapCallbackVH final : public CallbackVH {
       : CallbackVH(const_cast<Value *>(static_cast<const Value *>(Key))),
         Map(Map) {}
 
-  // Private constructor used to create empty/tombstone DenseMap keys.
+  // Private constructor used to create empty DenseMap keys.
   ValueMapCallbackVH(Value *V) : CallbackVH(V), Map(nullptr) {}
 
 public:
@@ -294,10 +294,6 @@ struct DenseMapInfo<ValueMapCallbackVH<KeyT, ValueT, Config>> {
 
   static inline VH getEmptyKey() {
     return VH(DenseMapInfo<Value *>::getEmptyKey());
-  }
-
-  static inline VH getTombstoneKey() {
-    return VH(DenseMapInfo<Value *>::getTombstoneKey());
   }
 
   static unsigned getHashValue(const VH &Val) {

--- a/llvm/lib/Analysis/IRSimilarityIdentifier.cpp
+++ b/llvm/lib/Analysis/IRSimilarityIdentifier.cpp
@@ -360,9 +360,7 @@ unsigned IRInstructionMapper::mapToLegalUnsigned(
          "Instruction mapping overflow!");
 
   assert(LegalInstrNumber != DenseMapInfo<unsigned>::getEmptyKey() &&
-         "Tried to assign DenseMap tombstone or empty key to instruction.");
-  assert(LegalInstrNumber != DenseMapInfo<unsigned>::getTombstoneKey() &&
-         "Tried to assign DenseMap tombstone or empty key to instruction.");
+         "Tried to assign DenseMap empty key to instruction.");
 
   return INumber;
 }
@@ -411,10 +409,7 @@ unsigned IRInstructionMapper::mapToIllegalUnsigned(
          "Instruction mapping overflow!");
 
   assert(IllegalInstrNumber != DenseMapInfo<unsigned>::getEmptyKey() &&
-         "IllegalInstrNumber cannot be DenseMap tombstone or empty key!");
-
-  assert(IllegalInstrNumber != DenseMapInfo<unsigned>::getTombstoneKey() &&
-         "IllegalInstrNumber cannot be DenseMap tombstone or empty key!");
+         "IllegalInstrNumber cannot be DenseMap empty key!");
 
   return INumber;
 }

--- a/llvm/lib/Analysis/MemorySSA.cpp
+++ b/llvm/lib/Analysis/MemorySSA.cpp
@@ -221,10 +221,6 @@ template <> struct DenseMapInfo<MemoryLocOrCall> {
     return MemoryLocOrCall(DenseMapInfo<MemoryLocation>::getEmptyKey());
   }
 
-  static inline MemoryLocOrCall getTombstoneKey() {
-    return MemoryLocOrCall(DenseMapInfo<MemoryLocation>::getTombstoneKey());
-  }
-
   static unsigned getHashValue(const MemoryLocOrCall &MLOC) {
     if (!MLOC.IsCall)
       return hash_combine(

--- a/llvm/lib/IR/ConstantsContext.h
+++ b/llvm/lib/IR/ConstantsContext.h
@@ -569,10 +569,6 @@ private:
       return ConstantClassInfo::getEmptyKey();
     }
 
-    static inline ConstantClass *getTombstoneKey() {
-      return ConstantClassInfo::getTombstoneKey();
-    }
-
     static unsigned getHashValue(const ConstantClass *CP) {
       SmallVector<Constant *, 32> Storage;
       return getHashValue(LookupKey(CP->getType(), ValType(CP, Storage)));
@@ -591,7 +587,7 @@ private:
     }
 
     static bool isEqual(const LookupKey &LHS, const ConstantClass *RHS) {
-      if (RHS == getEmptyKey() || RHS == getTombstoneKey())
+      if (RHS == getEmptyKey())
         return false;
       if (LHS.first != RHS->getType())
         return false;

--- a/llvm/lib/IR/LLVMContextImpl.h
+++ b/llvm/lib/IR/LLVMContextImpl.h
@@ -77,9 +77,6 @@ class ValueHandleBase;
 
 template <> struct DenseMapInfo<APFloat> {
   static inline APFloat getEmptyKey() { return APFloat(APFloat::Bogus(), 1); }
-  static inline APFloat getTombstoneKey() {
-    return APFloat(APFloat::Bogus(), 2);
-  }
 
   static unsigned getHashValue(const APFloat &Key) {
     return static_cast<unsigned>(hash_value(Key));
@@ -114,10 +111,6 @@ struct AnonStructTypeKeyInfo {
     return DenseMapInfo<StructType *>::getEmptyKey();
   }
 
-  static inline StructType *getTombstoneKey() {
-    return DenseMapInfo<StructType *>::getTombstoneKey();
-  }
-
   static unsigned getHashValue(const KeyTy &Key) {
     return hash_combine(hash_combine_range(Key.ETypes), Key.isPacked);
   }
@@ -127,7 +120,7 @@ struct AnonStructTypeKeyInfo {
   }
 
   static bool isEqual(const KeyTy &LHS, const StructType *RHS) {
-    if (RHS == getEmptyKey() || RHS == getTombstoneKey())
+    if (RHS == getEmptyKey())
       return false;
     return LHS == KeyTy(RHS);
   }
@@ -165,10 +158,6 @@ struct FunctionTypeKeyInfo {
     return DenseMapInfo<FunctionType *>::getEmptyKey();
   }
 
-  static inline FunctionType *getTombstoneKey() {
-    return DenseMapInfo<FunctionType *>::getTombstoneKey();
-  }
-
   static unsigned getHashValue(const KeyTy &Key) {
     return hash_combine(Key.ReturnType, hash_combine_range(Key.Params),
                         Key.isVarArg);
@@ -179,7 +168,7 @@ struct FunctionTypeKeyInfo {
   }
 
   static bool isEqual(const KeyTy &LHS, const FunctionType *RHS) {
-    if (RHS == getEmptyKey() || RHS == getTombstoneKey())
+    if (RHS == getEmptyKey())
       return false;
     return LHS == KeyTy(RHS);
   }
@@ -212,10 +201,6 @@ struct TargetExtTypeKeyInfo {
     return DenseMapInfo<TargetExtType *>::getEmptyKey();
   }
 
-  static inline TargetExtType *getTombstoneKey() {
-    return DenseMapInfo<TargetExtType *>::getTombstoneKey();
-  }
-
   static unsigned getHashValue(const KeyTy &Key) {
     return hash_combine(Key.Name, hash_combine_range(Key.TypeParams),
                         hash_combine_range(Key.IntParams));
@@ -226,7 +211,7 @@ struct TargetExtTypeKeyInfo {
   }
 
   static bool isEqual(const KeyTy &LHS, const TargetExtType *RHS) {
-    if (RHS == getEmptyKey() || RHS == getTombstoneKey())
+    if (RHS == getEmptyKey())
       return false;
     return LHS == KeyTy(RHS);
   }
@@ -1527,10 +1512,6 @@ struct DIArgListInfo {
     return DenseMapInfo<DIArgList *>::getEmptyKey();
   }
 
-  static inline DIArgList *getTombstoneKey() {
-    return DenseMapInfo<DIArgList *>::getTombstoneKey();
-  }
-
   static unsigned getHashValue(const KeyTy &Key) { return Key.getHashValue(); }
 
   static unsigned getHashValue(const DIArgList *N) {
@@ -1538,7 +1519,7 @@ struct DIArgListInfo {
   }
 
   static bool isEqual(const KeyTy &LHS, const DIArgList *RHS) {
-    if (RHS == getEmptyKey() || RHS == getTombstoneKey())
+    if (RHS == getEmptyKey())
       return false;
     return LHS.isKeyOf(RHS);
   }
@@ -1557,10 +1538,6 @@ template <class NodeTy> struct MDNodeInfo {
     return DenseMapInfo<NodeTy *>::getEmptyKey();
   }
 
-  static inline NodeTy *getTombstoneKey() {
-    return DenseMapInfo<NodeTy *>::getTombstoneKey();
-  }
-
   static unsigned getHashValue(const KeyTy &Key) { return Key.getHashValue(); }
 
   static unsigned getHashValue(const NodeTy *N) {
@@ -1568,7 +1545,7 @@ template <class NodeTy> struct MDNodeInfo {
   }
 
   static bool isEqual(const KeyTy &LHS, const NodeTy *RHS) {
-    if (RHS == getEmptyKey() || RHS == getTombstoneKey())
+    if (RHS == getEmptyKey())
       return false;
     return SubsetEqualTy::isSubsetEqual(LHS, RHS) || LHS.isKeyOf(RHS);
   }
@@ -1576,7 +1553,7 @@ template <class NodeTy> struct MDNodeInfo {
   static bool isEqual(const NodeTy *LHS, const NodeTy *RHS) {
     if (LHS == RHS)
       return true;
-    if (RHS == getEmptyKey() || RHS == getTombstoneKey())
+    if (RHS == getEmptyKey())
       return false;
     return SubsetEqualTy::isSubsetEqual(LHS, RHS);
   }


### PR DESCRIPTION
#200595 changed DenseMap to no longer create tombstone buckets, so
DenseMapInfo<T>::getTombstoneKey() is never called. Remove dead
definitions and dead tombstone branches.
