### PR TITLE
[Polly] Remove unused DenseMapInfo::getTombstoneKey

### DIFF
--- a/polly/include/polly/Support/VirtualInstruction.h
+++ b/polly/include/polly/Support/VirtualInstruction.h
@@ -322,13 +322,6 @@ public:
                                                 RHS.getInstruction());
   }
 
-  static polly::VirtualInstruction getTombstoneKey() {
-    polly::VirtualInstruction TombstoneKey;
-    TombstoneKey.Stmt = DenseMapInfo<polly::ScopStmt *>::getTombstoneKey();
-    TombstoneKey.Inst = DenseMapInfo<Instruction *>::getTombstoneKey();
-    return TombstoneKey;
-  }
-
   static polly::VirtualInstruction getEmptyKey() {
     polly::VirtualInstruction EmptyKey;
     EmptyKey.Stmt = DenseMapInfo<polly::ScopStmt *>::getEmptyKey();


### PR DESCRIPTION
#200595 changed DenseMap to no longer create tombstone buckets, so
DenseMapInfo<T>::getTombstoneKey() is never called. Remove dead
definitions and dead tombstone branches.