### PR TITLE
[clang-format] Don't unconditionally rotate qualifiers past `typeof_unqual`

### DIFF
--- a/clang/lib/Format/QualifierAlignmentFixer.cpp
+++ b/clang/lib/Format/QualifierAlignmentFixer.cpp
@@ -289,9 +289,12 @@ const FormatToken *LeftRightQualifierAlignmentFixer::analyzeRight(
   if (TypeToken->isTypeName(LangOpts)) {
     // The case `const decltype(foo)` -> `const decltype(foo)`
     // The case `const typeof(foo)` -> `const typeof(foo)`
+    // The case `const typeof_unqual(foo)` -> `const typeof_unqual(foo)`
     // The case `const _Atomic(foo)` -> `const _Atomic(foo)`
-    if (TypeToken->isOneOf(tok::kw_decltype, tok::kw_typeof, tok::kw__Atomic))
+    if (TypeToken->isOneOf(tok::kw_decltype, tok::kw_typeof,
+                           tok::kw_typeof_unqual, tok::kw__Atomic)) {
       return Tok;
+    }
 
     const FormatToken *LastSimpleTypeSpecifier = TypeToken;
     while (isQualifierOrType(LastSimpleTypeSpecifier->getNextNonComment(),

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -447,14 +447,16 @@ private:
       if (PrevNonComment->isAttribute()) {
         OpeningParen.setType(TT_AttributeLParen);
       } else if (PrevNonComment->isOneOf(TT_TypenameMacro, tok::kw_decltype,
-                                         tok::kw_typeof,
+                                         tok::kw_typeof, tok::kw_typeof_unqual,
 #define TRANSFORM_TYPE_TRAIT_DEF(_, Trait) tok::kw___##Trait,
 #include "clang/Basic/TransformTypeTraits.def"
                                          tok::kw__Atomic)) {
         OpeningParen.setType(TT_TypeDeclarationParen);
         // decltype() and typeof() usually contain expressions.
-        if (PrevNonComment->isOneOf(tok::kw_decltype, tok::kw_typeof))
+        if (PrevNonComment->isOneOf(tok::kw_decltype, tok::kw_typeof,
+                                    tok::kw_typeof_unqual)) {
           Contexts.back().IsExpression = true;
+        }
       }
     }
 

--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -120,6 +120,7 @@ bool Token::isSimpleTypeSpecifier(const LangOptions &LangOpts) const {
   case tok::kw_char16_t:
   case tok::kw_char32_t:
   case tok::kw_typeof:
+  case tok::kw_typeof_unqual:
   case tok::kw_decltype:
   case tok::kw_char8_t:
     return getIdentifierInfo()->isKeyword(LangOpts);

--- a/clang/unittests/Format/QualifierFixerTest.cpp
+++ b/clang/unittests/Format/QualifierFixerTest.cpp
@@ -847,6 +847,24 @@ TEST_F(QualifierFixerTest, LeftQualifier) {
   verifyFormat("const float (C::*p)(int);", "float const (C::*p)(int);", Style);
 }
 
+TEST_F(QualifierFixerTest, TypeofUnqualC) {
+  FormatStyle Style = getLLVMStyle(FormatStyle::LK_C);
+  Style.QualifierAlignment = FormatStyle::QAS_Right;
+  Style.QualifierOrder = {"type", "const", "volatile"};
+
+  // Don't move past typeof_unqual or its alternate spellings.
+  verifyFormat("const typeof_unqual(foo)", Style);
+  verifyFormat("const __typeof_unqual(foo)", Style);
+  verifyFormat("const __typeof_unqual__(foo)", Style);
+
+  Style.QualifierAlignment = FormatStyle::QAS_Left;
+  Style.QualifierOrder = {"const", "volatile", "type"};
+
+  verifyFormat("typeof_unqual(foo) const", Style);
+  verifyFormat("__typeof_unqual(foo) const", Style);
+  verifyFormat("__typeof_unqual__(foo) const", Style);
+}
+
 TEST_F(QualifierFixerTest, ConstVolatileQualifiersOrder) {
   FormatStyle Style = getLLVMStyle();
   Style.QualifierAlignment = FormatStyle::QAS_Left;


### PR DESCRIPTION
Follow-up to #198948.

`QualifierAlignmentFixer` skipped `const` / `volatile` rotation for
`decltype(...)`, `typeof(...)`, and `_Atomic(...)`, but not for
`typeof_unqual(...)`. In C23 mode this produced invalid code:

```c
const typeof_unqual(foo)  ->  typeof_unqual const(foo)
```

This adds `tok::kw_typeof_unqual` to:

- the skip case in `QualifierAlignmentFixer::analyzeRight`,
- `TT_TypeDeclarationParen` detection (and the `IsExpression` branch) in
  `TokenAnnotator`,
- `Token::isSimpleTypeSpecifier`, so the token is recognised as a type
  by `FormatToken::isTypeName`.

mirroring `typeof` in every spot.

The reachable spelling depends on language mode: `typeof_unqual` is a
C23 keyword, while `__typeof_unqual` / `__typeof_unqual__` are `KEYALL`
alias spellings, so the new test exercises all three in C mode (where
`isKeyword()` now returns true and the qualifier-fixer logic is actually
reached).

Assisted-by: Cursor/Claude Opus