### PR TITLE
[dsymutil] Make the Parallel DWARF linker the default

### DIFF
--- a/llvm/tools/dsymutil/LinkUtils.h
+++ b/llvm/tools/dsymutil/LinkUtils.h
@@ -65,7 +65,7 @@ struct LinkOptions {
   bool KeepFunctionForStatic = false;
 
   /// Type of DWARFLinker to use.
-  DsymutilDWARFLinkerType DWARFLinkerType = DsymutilDWARFLinkerType::Classic;
+  DsymutilDWARFLinkerType DWARFLinkerType = DsymutilDWARFLinkerType::Parallel;
 
   /// Use a 64-bit header when emitting universal binaries.
   bool Fat64 = false;

--- a/llvm/tools/dsymutil/dsymutil.cpp
+++ b/llvm/tools/dsymutil/dsymutil.cpp
@@ -273,7 +273,7 @@ getDWARFLinkerType(opt::InputArgList &Args) {
                                    inconvertibleErrorCode());
   }
 
-  return DsymutilDWARFLinkerType::Classic;
+  return DsymutilDWARFLinkerType::Parallel;
 }
 
 static Expected<ReproducerMode> getReproducerMode(opt::InputArgList &Args) {


### PR DESCRIPTION
This commit toggles the default linker in dsymutil from the classic linker to the parallel linker. This means that we have parity between the two implementations, at least for everything we have test coverage for in LLVM and LLDB.

I expected we'll continue to uncover more differences in the future. However I don't think that necessitates holding off on toggling the default. By making the parallel linker the default, we get maximum living on upstream, even if that audience is comparatively small.

Fixes #195390