### PR TITLE
[lldb] Have TestRunLocker run both styles of launch

### DIFF
--- a/lldb/test/API/python_api/run_locker/TestRunLocker.py
+++ b/lldb/test/API/python_api/run_locker/TestRunLocker.py
@@ -88,6 +88,12 @@ class TestRunLocker(TestBase):
                 state_type = lldb.SBProcess.GetStateFromEvent(event)
                 self.assertState(state_type, eStateStopped, "Stop at entry stopped")
             process.Continue()
+            event_result = listener.WaitForEvent(10, event)
+            self.assertTrue(event_result, "timed out waiting for launch")
+            state_type = lldb.SBProcess.GetStateFromEvent(event)
+            self.assertState(
+                state_type, lldb.eStateRunning, "Didn't get a running event"
+            )
 
         # Okay, now the process is running, make sure we can't do things
         # you aren't supposed to do while running, and that we get some

--- a/lldb/test/API/python_api/run_locker/TestRunLocker.py
+++ b/lldb/test/API/python_api/run_locker/TestRunLocker.py
@@ -28,7 +28,7 @@ class TestRunLocker(TestBase):
     def test_run_locker_stop_at_entry(self):
         """Test that the run locker is set correctly when we launch"""
         self.build()
-        self.runlocker_test(False)
+        self.runlocker_test(True)
 
     def setUp(self):
         # Call super's setUp().
@@ -43,8 +43,8 @@ class TestRunLocker(TestBase):
 
         launch_info = target.GetLaunchInfo()
         if stop_at_entry:
-            flags = launch_info.GetFlags()
-            launch_info.SetFlags(flags | lldb.eLaunchFlagStopAtEntry)
+            flags = launch_info.GetLaunchFlags()
+            launch_info.SetLaunchFlags(flags | lldb.eLaunchFlagStopAtEntry)
 
         error = lldb.SBError()
         # We are trying to do things when the process is running, so
@@ -69,16 +69,24 @@ class TestRunLocker(TestBase):
             )
             state_type = lldb.SBProcess.GetStateFromEvent(event)
 
-        self.assertState(state_type, lldb.eStateRunning, "Didn't get a running event")
+        # A stop_at_entry launch may have already stopped, it may
+        # not be eStateRunning.
+        if stop_at_entry and state_type != lldb.eStateStopped:
+            self.assertState(
+                state_type, lldb.eStateRunning, "Didn't get a running event"
+            )
 
         # We aren't checking the entry state, but just making sure
         # the running state is set properly if we continue in this state.
 
         if stop_at_entry:
-            event_result = listener.WaitForEvent(10, event)
-            self.assertTrue(event_result, "Timed out waiting for stop at entry stop")
-            state_type = lldb.SBProcess.GetStateFromEvent(event)
-            self.assertState(state_type, eStateStopped, "Stop at entry stopped")
+            if state_type != lldb.eStateStopped:
+                event_result = listener.WaitForEvent(10, event)
+                self.assertTrue(
+                    event_result, "Timed out waiting for stop at entry stop"
+                )
+                state_type = lldb.SBProcess.GetStateFromEvent(event)
+                self.assertState(state_type, eStateStopped, "Stop at entry stopped")
             process.Continue()
 
         # Okay, now the process is running, make sure we can't do things
@@ -90,7 +98,7 @@ class TestRunLocker(TestBase):
         self.assertIn(
             "can't evaluate expressions when the process is running",
             repr(val),
-            "repr works"
+            "repr works",
         )
         error = val.GetError()
         self.assertTrue(error.Fail(), "Failed to run expression")

--- a/lldb/test/API/python_api/run_locker/TestRunLocker.py
+++ b/lldb/test/API/python_api/run_locker/TestRunLocker.py
@@ -71,7 +71,7 @@ class TestRunLocker(TestBase):
 
         # A stop_at_entry launch may have already stopped, it may
         # not be eStateRunning.
-        if stop_at_entry and state_type != lldb.eStateStopped:
+        if not stop_at_entry or state_type != lldb.eStateStopped:
             self.assertState(
                 state_type, lldb.eStateRunning, "Didn't get a running event"
             )
@@ -89,10 +89,12 @@ class TestRunLocker(TestBase):
                 self.assertState(state_type, eStateStopped, "Stop at entry stopped")
             process.Continue()
             event_result = listener.WaitForEvent(10, event)
-            self.assertTrue(event_result, "timed out waiting for launch")
+            self.assertTrue(event_result, "timed out waiting for Continue")
             state_type = lldb.SBProcess.GetStateFromEvent(event)
             self.assertState(
-                state_type, lldb.eStateRunning, "Didn't get a running event"
+                state_type,
+                lldb.eStateRunning,
+                "Didn't get a running event after Continue",
             )
 
         # Okay, now the process is running, make sure we can't do things


### PR DESCRIPTION
While debugging flakey behavior with TestRunLocker, I noticed that is intended to run its test once with a stop at the entry function (and then Continues) and once where we launch to the main() loop.  But we were never exercising the stop-at-entry codepath.

This doesn't fix the flakey behavior, although that only happens with the launch-directly-into-main() codepath; I don't get failures when I stop at the entry point and then continue.