### PR TITLE
[SelectOptimize] Enable in default pipeline for X86 only

### DIFF
--- a/llvm/lib/Target/X86/X86CodeGenPassBuilder.cpp
+++ b/llvm/lib/Target/X86/X86CodeGenPassBuilder.cpp
@@ -21,6 +21,7 @@
 #include "llvm/CodeGen/InterleavedAccess.h"
 #include "llvm/CodeGen/JMCInstrumenter.h"
 #include "llvm/CodeGen/KCFI.h"
+#include "llvm/CodeGen/SelectOptimize.h"
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/Passes/CodeGenPassBuilder.h"
 #include "llvm/Passes/PassBuilder.h"
@@ -30,6 +31,7 @@
 using namespace llvm;
 
 extern cl::opt<bool> X86EnableMachineCombinerPass;
+extern cl::opt<bool> X86EnableSelectOpt;
 
 namespace {
 
@@ -73,6 +75,9 @@ void X86CodeGenPassBuilder::addIRPasses(PassManagerWrapper &PMW) const {
   addFunctionPass(X86LowerAMXTypePass(&TM), PMW);
 
   Base::addIRPasses(PMW);
+
+  if (getOptLevel() != CodeGenOptLevel::None && X86EnableSelectOpt)
+    addFunctionPass(SelectOptimizePass(TM), PMW);
 
   if (getOptLevel() != CodeGenOptLevel::None) {
     addFunctionPass(InterleavedAccessPass(TM), PMW);

--- a/llvm/lib/Target/X86/X86TargetMachine.cpp
+++ b/llvm/lib/Target/X86/X86TargetMachine.cpp
@@ -63,6 +63,11 @@ static cl::opt<bool>
                      cl::desc("Enable the tile register allocation pass"),
                      cl::init(true), cl::Hidden);
 
+cl::opt<bool>
+    X86EnableSelectOpt("x86-select-opt", cl::Hidden,
+                       cl::desc("Enable select to branch optimizations"),
+                       cl::init(true));
+
 extern "C" LLVM_C_ABI void LLVMInitializeX86Target() {
   // Register the target.
   RegisterTargetMachine<X86TargetMachine> X(getTheX86_32Target());
@@ -430,7 +435,11 @@ void X86PassConfig::addIRPasses() {
 
   TargetPassConfig::addIRPasses();
 
-  if (TM->getOptLevel() != CodeGenOptLevel::None) {
+  if (TM->getOptLevel() != CodeGenOptLevel::None && X86EnableSelectOpt) {
+    addPass(createSelectOptimizePass());
+    addPass(createInterleavedAccessPass());
+    addPass(createX86PartialReductionLegacyPass());
+  } else if (TM->getOptLevel() != CodeGenOptLevel::None) {
     addPass(createInterleavedAccessPass());
     addPass(createX86PartialReductionLegacyPass());
   }

--- a/llvm/test/CodeGen/X86/llc-pipeline-npm.ll
+++ b/llvm/test/CodeGen/X86/llc-pipeline-npm.ll
@@ -99,6 +99,7 @@
 ; O2-NEXT: ee-instrument<post-inline>
 ; O2-NEXT: scalarize-masked-mem-intrin
 ; O2-NEXT: expand-reductions
+; O2-NEXT: select-optimize
 ; O2-NEXT: interleaved-access
 ; O2-NEXT: x86-partial-reduction
 ; O2-NEXT: indirectbr-expand
@@ -289,6 +290,7 @@
 ; O3-WINDOWS-NEXT: ee-instrument<post-inline>
 ; O3-WINDOWS-NEXT: scalarize-masked-mem-intrin
 ; O3-WINDOWS-NEXT: expand-reductions
+; O3-WINDOWS-NEXT: select-optimize
 ; O3-WINDOWS-NEXT: interleaved-access
 ; O3-WINDOWS-NEXT: x86-partial-reduction
 ; O3-WINDOWS-NEXT: indirectbr-expand


### PR DESCRIPTION
# Part one of fix for issue #200690

TargetPassConfig.cpp: run SelectOptimize in the default pipeline for X86 optimized builds, while keeping non-X86 targets unchanged.

SelectOptimize was added in D85085 to revert unprofitable select chains back to branches. This change enables it by default for the X86 default pipeline, and updates the X86 llc pipeline test accordingly.