### PR TITLE
[Support] Add EmitKeyValuePair to OnDiskChainedHashTableGenerator

### DIFF
--- a/llvm/include/llvm/Support/OnDiskHashTable.h
+++ b/llvm/include/llvm/Support/OnDiskHashTable.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_SUPPORT_ONDISKHASHTABLE_H
 #define LLVM_SUPPORT_ONDISKHASHTABLE_H
 
+#include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/Support/Alignment.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/DataTypes.h"
@@ -56,6 +57,40 @@ namespace llvm {
 /// };
 /// \endcode
 template <typename Info> class OnDiskChainedHashTableGenerator {
+  template <typename T>
+  using emit_key_value_pair_t = decltype(std::declval<T>().EmitKeyValuePair(
+      std::declval<raw_ostream &>(), std::declval<typename T::key_type_ref>(),
+      std::declval<typename T::data_type_ref>()));
+
+  template <typename T>
+  using emit_key_data_length_t = decltype(std::declval<T>().EmitKeyDataLength(
+      std::declval<raw_ostream &>(), std::declval<typename T::key_type_ref>(),
+      std::declval<typename T::data_type_ref>()));
+
+  template <typename T>
+  using emit_key_t = decltype(std::declval<T>().EmitKey(
+      std::declval<raw_ostream &>(), std::declval<typename T::key_type_ref>(),
+      std::declval<typename T::offset_type>()));
+
+  template <typename T>
+  using emit_data_t = decltype(std::declval<T>().EmitData(
+      std::declval<raw_ostream &>(), std::declval<typename T::key_type_ref>(),
+      std::declval<typename T::data_type_ref>(),
+      std::declval<typename T::offset_type>()));
+
+  static_assert(
+      (llvm::is_detected<emit_key_value_pair_t, Info>::value &&
+       !llvm::is_detected<emit_key_data_length_t, Info>::value &&
+       !llvm::is_detected<emit_key_t, Info>::value &&
+       !llvm::is_detected<emit_data_t, Info>::value) ||
+          (!llvm::is_detected<emit_key_value_pair_t, Info>::value &&
+           llvm::is_detected<emit_key_data_length_t, Info>::value &&
+           llvm::is_detected<emit_key_t, Info>::value &&
+           llvm::is_detected<emit_data_t, Info>::value),
+      "Info trait class must implement either EmitKeyValuePair (and not mix it "
+      "with split emission methods) OR all of (EmitKeyDataLength, EmitKey, "
+      "EmitData).");
+
   /// A single item in the hash table.
   class Item {
   public:
@@ -108,6 +143,31 @@ private:
     free(Buckets);
     NumBuckets = NewSize;
     Buckets = NewBuckets;
+  }
+
+  void EmitKeyValuePair(raw_ostream &Out, Info &InfoObj,
+                        typename Info::key_type_ref Key,
+                        typename Info::data_type_ref Data) {
+    if constexpr (llvm::is_detected<emit_key_value_pair_t, Info>::value) {
+      InfoObj.EmitKeyValuePair(Out, Key, Data);
+    } else {
+      const std::pair<offset_type, offset_type> &Len =
+          InfoObj.EmitKeyDataLength(Out, Key, Data);
+#ifdef NDEBUG
+      InfoObj.EmitKey(Out, Key, Len.first);
+      InfoObj.EmitData(Out, Key, Data, Len.second);
+#else
+      uint64_t KeyStart = Out.tell();
+      InfoObj.EmitKey(Out, Key, Len.first);
+      uint64_t DataStart = Out.tell();
+      InfoObj.EmitData(Out, Key, Data, Len.second);
+      uint64_t End = Out.tell();
+      assert(offset_type(DataStart - KeyStart) == Len.first &&
+             "key length does not match bytes written");
+      assert(offset_type(End - DataStart) == Len.second &&
+             "data length does not match bytes written");
+#endif
+    }
   }
 
 public:
@@ -184,24 +244,7 @@ public:
       // Write out the entries in the bucket.
       for (Item *I = B.Head; I; I = I->Next) {
         LE.write<typename Info::hash_value_type>(I->Hash);
-        const std::pair<offset_type, offset_type> &Len =
-            InfoObj.EmitKeyDataLength(Out, I->Key, I->Data);
-#ifdef NDEBUG
-        InfoObj.EmitKey(Out, I->Key, Len.first);
-        InfoObj.EmitData(Out, I->Key, I->Data, Len.second);
-#else
-        // In asserts mode, check that the users length matches the data they
-        // wrote.
-        uint64_t KeyStart = Out.tell();
-        InfoObj.EmitKey(Out, I->Key, Len.first);
-        uint64_t DataStart = Out.tell();
-        InfoObj.EmitData(Out, I->Key, I->Data, Len.second);
-        uint64_t End = Out.tell();
-        assert(offset_type(DataStart - KeyStart) == Len.first &&
-               "key length does not match bytes written");
-        assert(offset_type(End - DataStart) == Len.second &&
-               "data length does not match bytes written");
-#endif
+        EmitKeyValuePair(Out, InfoObj, I->Key, I->Data);
       }
     }
 

--- a/llvm/unittests/Support/CMakeLists.txt
+++ b/llvm/unittests/Support/CMakeLists.txt
@@ -69,6 +69,7 @@ add_llvm_unittest(SupportTests
   MustacheTest.cpp
   ModRefTest.cpp
   NativeFormatTests.cpp
+  OnDiskHashTableTest.cpp
   OptimizedStructLayoutTest.cpp
   ParallelTest.cpp
   Path.cpp

--- a/llvm/unittests/Support/OnDiskHashTableTest.cpp
+++ b/llvm/unittests/Support/OnDiskHashTableTest.cpp
@@ -1,0 +1,186 @@
+//===- unittests/Support/OnDiskHashTableTest.cpp --------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/OnDiskHashTable.h"
+#include "llvm/Support/raw_ostream.h"
+#include "gtest/gtest.h"
+#include <type_traits>
+
+using namespace llvm;
+
+namespace {
+
+// Common types used in the tests.
+using KeyType = std::string;
+using ValueType = std::string;
+
+// Shared reader trait for verifying the written tables.
+struct TestLookupTrait {
+  using data_type = ValueType;
+  using internal_key_type = KeyType;
+  using external_key_type = KeyType;
+  using hash_value_type = uint32_t;
+  using offset_type = uint32_t;
+
+  static bool EqualKey(const internal_key_type &A, const internal_key_type &B) {
+    return A == B;
+  }
+  static const internal_key_type &GetInternalKey(const external_key_type &K) {
+    return K;
+  }
+  static const external_key_type &GetExternalKey(const internal_key_type &K) {
+    return K;
+  }
+
+  static hash_value_type ComputeHash(const internal_key_type &K) {
+    // Simple hash function for testing.
+    hash_value_type Hash = 0;
+    for (char C : K)
+      Hash = Hash * 33 + C;
+    return Hash;
+  }
+
+  static std::pair<offset_type, offset_type>
+  ReadKeyDataLength(const unsigned char *&D) {
+    using namespace llvm::support;
+    offset_type KeyLen =
+        endian::readNext<offset_type, llvm::endianness::little, unaligned>(D);
+    offset_type DataLen =
+        endian::readNext<offset_type, llvm::endianness::little, unaligned>(D);
+    return {KeyLen, DataLen};
+  }
+
+  internal_key_type ReadKey(const unsigned char *D, offset_type KeyLen) {
+    return std::string(reinterpret_cast<const char *>(D), KeyLen);
+  }
+
+  data_type ReadData(const internal_key_type &, const unsigned char *D,
+                     offset_type DataLen) {
+    return std::string(reinterpret_cast<const char *>(D), DataLen);
+  }
+};
+
+// Unified/Split Templated Writer Trait.
+template <bool IsUnified> struct TestWriterTrait : public TestLookupTrait {
+  using key_type = KeyType;
+  using key_type_ref = const KeyType &;
+  using data_type = ValueType;
+  using data_type_ref = const ValueType &;
+
+  // Split (3-step) emission. Enabled only when IsUnified is false.
+  template <bool B = IsUnified, std::enable_if_t<!B, int> = 0>
+  static std::pair<offset_type, offset_type>
+  EmitKeyDataLength(raw_ostream &Out, key_type_ref K, data_type_ref V) {
+    using namespace llvm::support;
+    endian::Writer LE(Out, llvm::endianness::little);
+    offset_type KeyLen = K.size();
+    offset_type DataLen = V.size();
+    LE.write<offset_type>(KeyLen);
+    LE.write<offset_type>(DataLen);
+    return {KeyLen, DataLen};
+  }
+
+  template <bool B = IsUnified, std::enable_if_t<!B, int> = 0>
+  static void EmitKey(raw_ostream &Out, key_type_ref K, offset_type) {
+    Out << K;
+  }
+
+  template <bool B = IsUnified, std::enable_if_t<!B, int> = 0>
+  static void EmitData(raw_ostream &Out, key_type_ref, data_type_ref V,
+                       offset_type) {
+    Out << V;
+  }
+
+  // Unified (KeyValuePair) emission. Enabled only when IsUnified is true.
+  template <bool B = IsUnified, std::enable_if_t<B, int> = 0>
+  static void EmitKeyValuePair(raw_ostream &Out, key_type_ref K,
+                               data_type_ref V) {
+    using namespace llvm::support;
+    endian::Writer LE(Out, llvm::endianness::little);
+    offset_type KeyLen = K.size();
+    offset_type DataLen = V.size();
+    LE.write<offset_type>(KeyLen);
+    LE.write<offset_type>(DataLen);
+    Out << K;
+    Out << V;
+  }
+};
+
+template <typename Trait>
+static SmallVector<char, 1024>
+WriteTable(const std::vector<std::pair<KeyType, ValueType>> &Data) {
+  SmallVector<char, 1024> Buf;
+  raw_svector_ostream OS(Buf);
+  OS << "PAD"; // Pad with some bytes because Emit requires non-zero offset.
+  OnDiskChainedHashTableGenerator<Trait> Generator;
+  for (const auto &[Key, Value] : Data)
+    Generator.insert(Key, Value);
+  uint32_t TableOffset = Generator.Emit(OS);
+
+  using namespace llvm::support;
+  endian::Writer LE(OS, llvm::endianness::little);
+  LE.write<uint32_t>(TableOffset);
+  return Buf;
+}
+
+TEST(OnDiskHashTableTest, SplitVsUnified) {
+  // Mock data to write.
+  std::vector<std::pair<KeyType, ValueType>> Data = {{"apple", "red"},
+                                                     {"banana", "yellow"},
+                                                     {"grape", "purple"},
+                                                     {"orange", "orange"}};
+
+  // Write using Split Trait (IsUnified = false).
+  SmallVector<char, 1024> SplitBuf = WriteTable<TestWriterTrait<false>>(Data);
+
+  // Write using Unified Trait (IsUnified = true).
+  SmallVector<char, 1024> UnifiedBuf = WriteTable<TestWriterTrait<true>>(Data);
+
+  // Assert that the generated binary data is identical.
+  ASSERT_EQ(SplitBuf, UnifiedBuf);
+
+  // Verify the table layout (verifying SplitBuf is sufficient since they are
+  // identical).
+  const unsigned char *Base =
+      reinterpret_cast<const unsigned char *>(SplitBuf.data());
+  const unsigned char *Ptr = Base + SplitBuf.size() - sizeof(uint32_t);
+  using namespace llvm::support;
+  uint32_t TableOffset =
+      endian::readNext<uint32_t, llvm::endianness::little, unaligned>(Ptr);
+
+  const unsigned char *Buckets = Base + TableOffset;
+
+  std::unique_ptr<OnDiskChainedHashTable<TestLookupTrait>> Table(
+      OnDiskChainedHashTable<TestLookupTrait>::Create(Buckets, Base));
+
+  // Verify lookups.
+  {
+    auto It = Table->find("apple");
+    ASSERT_NE(It, Table->end());
+    EXPECT_EQ(*It, "red");
+  }
+  {
+    auto It = Table->find("banana");
+    ASSERT_NE(It, Table->end());
+    EXPECT_EQ(*It, "yellow");
+  }
+  {
+    auto It = Table->find("grape");
+    ASSERT_NE(It, Table->end());
+    EXPECT_EQ(*It, "purple");
+  }
+  {
+    auto It = Table->find("orange");
+    ASSERT_NE(It, Table->end());
+    EXPECT_EQ(*It, "orange");
+  }
+
+  EXPECT_EQ(Table->find("pear"), Table->end());
+}
+
+} // namespace


### PR DESCRIPTION
This patch introduces EmitKeyValuePair to
OnDiskChainedHashTableGenerator, allowing trait classes to serialize
key-value pairs in a single step rather than the three-step emission
(EmitKeyDataLength -> EmitKey -> EmitData).

This is particularly useful when the serialized size of a value is not
known until after it is emitted, avoiding double-serialization or
complex state buffering within the trait class.

This patch also adds static assertions to prevent mixing the split
style with the new unified style, and adds a comprehensive unit test
to verify that both styles produce identical binary hash tables.
