### PR TITLE
[SampleProfile] Switch getNameTable() to return iterator_range (NFC)

### DIFF
--- a/llvm/include/llvm/ProfileData/SampleProfReader.h
+++ b/llvm/include/llvm/ProfileData/SampleProfReader.h
@@ -343,6 +343,30 @@ private:
 /// The reader supports two file formats: text and binary. The text format
 /// is useful for debugging and testing, while the binary format is more
 /// compact and I/O efficient. They can both be used interchangeably.
+
+/// NameTableIterator is a lightweight, self-contained input iterator designed
+/// to stream FunctionId symbols from an eagerly populated contiguous buffer
+/// of FunctionId objects.
+class NameTableIterator
+    : public llvm::iterator_facade_base<
+          NameTableIterator, std::input_iterator_tag, FunctionId,
+          std::ptrdiff_t, const FunctionId *, FunctionId> {
+  const FunctionId *Ptr = nullptr;
+
+public:
+  NameTableIterator() = default;
+  NameTableIterator(const FunctionId *P) : Ptr(P) {}
+
+  bool operator==(const NameTableIterator &RHS) const { return Ptr == RHS.Ptr; }
+
+  NameTableIterator &operator++() {
+    ++Ptr;
+    return *this;
+  }
+
+  FunctionId operator*() const { return *Ptr; }
+};
+
 class SampleProfileReader {
 public:
   SampleProfileReader(std::unique_ptr<MemoryBuffer> B, LLVMContext &C,
@@ -496,7 +520,9 @@ public:
 
   /// It includes all the names that have samples either in outline instance
   /// or inline instance.
-  virtual std::vector<FunctionId> *getNameTable() { return nullptr; }
+  virtual llvm::iterator_range<NameTableIterator> getNameTable() const {
+    return {NameTableIterator(), NameTableIterator()};
+  }
   virtual bool dumpSectionInfo(raw_ostream &OS = dbgs()) { return false; };
 
   /// Return whether names in the profile are all MD5 numbers.
@@ -650,8 +676,9 @@ public:
 
   /// It includes all the names that have samples either in outline instance
   /// or inline instance.
-  std::vector<FunctionId> *getNameTable() override {
-    return &NameTable;
+  llvm::iterator_range<NameTableIterator> getNameTable() const override {
+    return {NameTableIterator(NameTable.data()),
+            NameTableIterator(NameTable.data() + NameTable.size())};
   }
 
 protected:

--- a/llvm/lib/Transforms/IPO/SampleProfile.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfile.cpp
@@ -1990,14 +1990,13 @@ bool SampleProfileLoader::doInitialization(Module &M,
   if (ProfAccForSymsInList) {
     NamesInProfile.clear();
     GUIDsInProfile.clear();
-    if (auto NameTable = Reader->getNameTable()) {
-      if (FunctionSamples::UseMD5) {
-        for (auto Name : *NameTable)
-          GUIDsInProfile.insert(Name.getHashCode());
-      } else {
-        for (auto Name : *NameTable)
-          NamesInProfile.insert(Name.stringRef());
-      }
+    auto NameTable = Reader->getNameTable();
+    if (FunctionSamples::UseMD5) {
+      for (FunctionId Name : NameTable)
+        GUIDsInProfile.insert(Name.getHashCode());
+    } else {
+      for (FunctionId Name : NameTable)
+        NamesInProfile.insert(Name.stringRef());
     }
     CoverageTracker.setProfAccForSymsInList(true);
   }

--- a/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
@@ -713,10 +713,8 @@ void SampleProfileMatcher::findFunctionsWithoutProfile() {
   if (FunctionSamples::UseMD5)
     return;
   StringSet<> NamesInProfile;
-  if (auto NameTable = Reader.getNameTable()) {
-    for (auto Name : *NameTable)
-      NamesInProfile.insert(Name.stringRef());
-  }
+  for (FunctionId Name : Reader.getNameTable())
+    NamesInProfile.insert(Name.stringRef());
 
   for (auto &F : M) {
     // Skip declarations, as even if the function can be matched, we have
@@ -772,8 +770,8 @@ static std::string getDemangledBaseName(ItaniumPartialDemangler &Demangler,
 void SampleProfileMatcher::matchFunctionsWithoutProfileByBasename() {
   if (FunctionsWithoutProfile.empty() || !LoadFuncProfileforCGMatching)
     return;
-  auto *NameTable = Reader.getNameTable();
-  if (!NameTable)
+  auto NameTable = Reader.getNameTable();
+  if (NameTable.empty())
     return;
 
   ItaniumPartialDemangler Demangler;
@@ -800,7 +798,7 @@ void SampleProfileMatcher::matchFunctionsWithoutProfileByBasename() {
   // Scan the profile NameTable for candidates whose demangled basename matches
   // a unique orphan. Use a map to track exactly one candidate per basename.
   StringMap<FunctionId> CandidateByBaseName;
-  for (auto &ProfileFuncId : *NameTable) {
+  for (FunctionId ProfileFuncId : NameTable) {
     StringRef ProfName = ProfileFuncId.stringRef();
     if (ProfName.empty())
       continue;


### PR DESCRIPTION
This patch teaches SampleProfileReader::getNameTable() to return an
iterator_range instead of a pointer to std::vector<FunctionId>.

This patch is meant to be a preparation patch for the following
speed-up opportunity.  I'm planning to lazy-load SecNameTable in a
subsequent patch for performance reasons.  We have SecNameTable that
takes up about 90MB on disk.  We eager-load this section into
std::vector<FunctionId> on the heap.  This ends up taking about 180MB
on the heap because the element type of the section is 8-byte MD5 hash
value while FunctionId takes up 16 bytes.  This eager loading shows up
on the execution profile -- about 1%.  Since we do have a few places
where we scan the entire NameTable, we should accommodate those places
with iterators that lazy-load SecNameTable.

See the RFC at:

https://discourse.llvm.org/t/rfc-faster-sample-profile-loading/90957
