### PR TITLE
[flang-rt] Fix weak RPC stub on Mac-OS

### DIFF
--- a/flang-rt/lib/runtime/io-api-server.cpp
+++ b/flang-rt/lib/runtime/io-api-server.cpp
@@ -323,20 +323,19 @@ static std::uint32_t HandleRPCOpcodes(void *raw, std::uint32_t numLanes) {
 }
 
 #if defined(__ELF__)
-extern "C" void __tgt_register_rpc_callback(RPCCallbackTy)
-    __attribute__((weak));
+extern "C" [[gnu::weak]] void __tgt_register_rpc_callback(RPCCallbackTy);
 #elif defined(__APPLE__)
-extern "C" void __tgt_register_rpc_callback(RPCCallbackTy)
-    __attribute__((weak_import));
+extern "C" [[gnu::weak]]
+void __tgt_register_rpc_callback(RPCCallbackTy) {}
 #else
 extern "C" void __tgt_register_rpc_callback(RPCCallbackTy);
 #endif
 
 void RegisterRPCHandlers() {
-#if defined(__ELF__) || defined(__APPLE__)
+#if defined(__ELF__)
   if (__tgt_register_rpc_callback)
     __tgt_register_rpc_callback(HandleRPCOpcodes);
-#elif defined(_MSC_VER)
+#elif defined(__APPLE__) || defined(_MSC_VER)
   __tgt_register_rpc_callback(HandleRPCOpcodes);
 #endif
 }


### PR DESCRIPTION
Summary:
This does not work like the ELF extern weak. Attempt to just provide a
weak function that will get overridden if it is linked in.
