### PR TITLE
[OFFLOAD][L0] Move dataFence logic to L0Queue

### DIFF
--- a/offload/plugins-nextgen/level_zero/include/L0CmdListManager.h
+++ b/offload/plugins-nextgen/level_zero/include/L0CmdListManager.h
@@ -126,6 +126,15 @@ public:
                       NumWaitEvents, WaitEvents);
     return Plugin::success();
   }
+
+  Error appendBarrier(ze_event_handle_t SignalEvent = nullptr,
+                      uint32_t NumWaitEvents = 0,
+                      ze_event_handle_t *WaitEvents = nullptr) {
+    std::lock_guard<std::mutex> Lock(Mtx);
+    CALL_ZE_RET_ERROR(zeCommandListAppendBarrier, CmdList, SignalEvent,
+                      NumWaitEvents, WaitEvents);
+    return Plugin::success();
+  }
 };
 
 } // namespace llvm::omp::target::plugin

--- a/offload/plugins-nextgen/level_zero/include/L0CmdListManager.h
+++ b/offload/plugins-nextgen/level_zero/include/L0CmdListManager.h
@@ -127,9 +127,8 @@ public:
     return Plugin::success();
   }
 
-  Error appendBarrier(ze_event_handle_t SignalEvent = nullptr,
-                      uint32_t NumWaitEvents = 0,
-                      ze_event_handle_t *WaitEvents = nullptr) {
+  Error appendBarrier(ze_event_handle_t SignalEvent, uint32_t NumWaitEvents,
+                      ze_event_handle_t *WaitEvents) {
     std::lock_guard<std::mutex> Lock(Mtx);
     CALL_ZE_RET_ERROR(zeCommandListAppendBarrier, CmdList, SignalEvent,
                       NumWaitEvents, WaitEvents);

--- a/offload/plugins-nextgen/level_zero/include/L0Queue.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Queue.h
@@ -46,8 +46,6 @@ public:
   /// Clear data.
   void reset() { resetImpl(); }
 
-  ze_command_list_handle_t getCmdList() const { return CmdList->getCmdList(); }
-
   Error init();
   Error deinit();
   Error synchronize() { return synchronizeImpl(); }
@@ -83,6 +81,8 @@ public:
     return launchKernelImpl(Kernel, KEnv);
   }
 
+  Error dataFence() { return dataFenceImpl(); }
+
   virtual Error initImpl() { return Plugin::success(); }
   virtual Error deinitImpl() { return Plugin::success(); }
   virtual void resetImpl() {}
@@ -104,6 +104,7 @@ public:
                                size_t PatternSize, size_t Size) {
     return CmdList->appendMemoryFill(Ptr, Pattern, PatternSize, Size);
   }
+  virtual Error dataFenceImpl() = 0;
 };
 
 class L0AsyncQueueTy : public L0QueueTy {
@@ -150,6 +151,7 @@ public:
                          L0LaunchEnvTy &KEnv) override;
   Error memoryFillImpl(void *Ptr, const void *Pattern, size_t PatternSize,
                        size_t Size) override;
+  Error dataFenceImpl() override;
 };
 
 class L0AsyncOrderedQueueTy : public L0AsyncQueueTy {
@@ -165,6 +167,7 @@ public:
   Error synchronizeImpl() override;
   std::tuple<size_t, ze_event_handle_t *> getMemCopyEvents() override;
   std::tuple<size_t, ze_event_handle_t *> getLaunchKernelEvents() override;
+  Error dataFenceImpl() override { return Plugin::success(); }
 };
 
 class L0InorderQueueTy : public L0QueueTy {
@@ -182,6 +185,7 @@ public:
   Error memoryCopyImpl(void *Dst, const void *Src, size_t Size) override;
   Error launchKernelImpl(ze_kernel_handle_t Kernel,
                          L0LaunchEnvTy &KEnv) override;
+  Error dataFenceImpl() override { return Plugin::success(); }
 };
 
 class L0SyncQueueTy : public L0InorderQueueTy {

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -729,23 +729,12 @@ L0DeviceTy::createImmCmdList(uint32_t Ordinal, uint32_t Index, bool InOrder) {
   return CmdList;
 }
 
-// TODO: logic from this function should be moved to L0QueueTy
 Error L0DeviceTy::dataFence(__tgt_async_info *Async) {
-  const bool Ordered =
-      (getPlugin().getOptions().CommandMode == CommandModeTy::AsyncOrdered);
-
-  // Nothing to do if everything is ordered.
-  if (Ordered)
-    return Plugin::success();
-
   auto QueueOrErr = getOrCreateQueue(Async);
   if (!QueueOrErr)
     return QueueOrErr.takeError();
   L0QueueTy *Queue = *QueueOrErr;
-  ze_command_list_handle_t CmdList = Queue->getCmdList();
-  CALL_ZE_RET_ERROR(zeCommandListAppendBarrier, CmdList, nullptr, 0, nullptr);
-
-  return Plugin::success();
+  return Queue->dataFence();
 }
 
 Expected<bool> L0DeviceTy::isAccessiblePtrImpl(const void *Ptr, size_t Size) {

--- a/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
@@ -221,6 +221,10 @@ Error L0AsyncQueueTy::dataSubmitImpl(void *TgtPtr, const void *HstPtr,
   return memoryCopy(TgtPtr, SrcPtr, Size);
 }
 
+Error L0AsyncQueueTy::dataFenceImpl() {
+  return CmdList->appendBarrier();
+}
+
 Error L0AsyncQueueTy::launchKernelImpl(ze_kernel_handle_t Kernel,
                                        L0LaunchEnvTy &KEnv) {
   auto EventOrError = Device.getEvent();

--- a/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
@@ -221,7 +221,9 @@ Error L0AsyncQueueTy::dataSubmitImpl(void *TgtPtr, const void *HstPtr,
   return memoryCopy(TgtPtr, SrcPtr, Size);
 }
 
-Error L0AsyncQueueTy::dataFenceImpl() { return CmdList->appendBarrier(); }
+Error L0AsyncQueueTy::dataFenceImpl() {
+  return CmdList->appendBarrier(nullptr, 0, nullptr);
+}
 
 Error L0AsyncQueueTy::launchKernelImpl(ze_kernel_handle_t Kernel,
                                        L0LaunchEnvTy &KEnv) {

--- a/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
@@ -222,7 +222,8 @@ Error L0AsyncQueueTy::dataSubmitImpl(void *TgtPtr, const void *HstPtr,
 }
 
 Error L0AsyncQueueTy::dataFenceImpl() {
-  return CmdList->appendBarrier(nullptr, 0, nullptr);
+  return CmdList->appendBarrier(/*SignalEvent*/ nullptr, /*NumWaitEvents*/ 0,
+                                /*WaitEvents*/ nullptr);
 }
 
 Error L0AsyncQueueTy::launchKernelImpl(ze_kernel_handle_t Kernel,

--- a/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Queue.cpp
@@ -221,9 +221,7 @@ Error L0AsyncQueueTy::dataSubmitImpl(void *TgtPtr, const void *HstPtr,
   return memoryCopy(TgtPtr, SrcPtr, Size);
 }
 
-Error L0AsyncQueueTy::dataFenceImpl() {
-  return CmdList->appendBarrier();
-}
+Error L0AsyncQueueTy::dataFenceImpl() { return CmdList->appendBarrier(); }
 
 Error L0AsyncQueueTy::launchKernelImpl(ze_kernel_handle_t Kernel,
                                        L0LaunchEnvTy &KEnv) {


### PR DESCRIPTION
The dataFence device operation logic was still on L0Device. With this all the operations working on command lists have their logic consolidated in L0Queue.