### PR TITLE
[clang][CUDA] Avoid ambiguity in host/device template specializations

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -598,9 +598,9 @@ Improvements to Clang's diagnostics
 - Clang now rejects inline asm constraints and clobbers that contain an
   embedded null character, instead of silently truncating them. (#GH173900)
 
-- Fixed false positive for host-device ambiguities when retrieving the address
-  of specializations of templated functions that have overloads for both host
-  and device. (#GH199299)
+- Fixed false positive for host-device ambiguities in CUDA/HIP when retrieving
+  the address of specializations of templated functions that have overloads for
+  both host and device. (#GH199299)
 
 Improvements to Clang's time-trace
 ----------------------------------

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -600,7 +600,7 @@ Improvements to Clang's diagnostics
 
 - Fixed false positive for host-device ambiguities when retrieving the address
   of specializations of templated functions that have overloads for both host
-  and device.
+  and device. (#GH199299)
 
 Improvements to Clang's time-trace
 ----------------------------------

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -598,6 +598,10 @@ Improvements to Clang's diagnostics
 - Clang now rejects inline asm constraints and clobbers that contain an
   embedded null character, instead of silently truncating them. (#GH173900)
 
+- Fixed false positive for host-device ambiguities when retrieving the address
+  of specializations of templated functions that have overloads for both host
+  and device.
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -598,10 +598,6 @@ Improvements to Clang's diagnostics
 - Clang now rejects inline asm constraints and clobbers that contain an
   embedded null character, instead of silently truncating them. (#GH173900)
 
-- Fixed false positive for host-device ambiguities in CUDA/HIP when retrieving
-  the address of specializations of templated functions that have overloads for
-  both host and device. (#GH199299)
-
 Improvements to Clang's time-trace
 ----------------------------------
 
@@ -820,6 +816,10 @@ CUDA/HIP Language Changes
 
 CUDA Support
 ^^^^^^^^^^^^
+
+- Fixed a bug where host-device ambiguities in CUDA/HIP when retrieving the
+  address of specializations of templated functions that have overloads for both
+  host and device. (#GH199299)
 
 AIX Support
 ^^^^^^^^^^^

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -13742,6 +13742,9 @@ public:
       OvlExpr->copyTemplateArgumentsInto(OvlExplicitTemplateArgs);
 
     if (FindAllFunctionsThatMatchTargetTypeExactly()) {
+      if (Matches.size() > 1 && S.getLangOpts().CUDA)
+        EliminateSuboptimalCudaMatches();
+
       // C++ [over.over]p4:
       //   If more than one function is selected, [...]
       if (Matches.size() > 1 && !eliminiateSuboptimalOverloadCandidates()) {
@@ -13752,9 +13755,6 @@ public:
           EliminateAllExceptMostSpecializedTemplate();
       }
     }
-
-    if (S.getLangOpts().CUDA && Matches.size() > 1)
-      EliminateSuboptimalCudaMatches();
   }
 
   bool hasComplained() const { return HasComplained; }

--- a/clang/test/SemaCUDA/addr-of-overloaded-template-fn.cu
+++ b/clang/test/SemaCUDA/addr-of-overloaded-template-fn.cu
@@ -5,22 +5,24 @@
 // RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -fsyntax-only -fcuda-is-device -verify %s
 // RUN: %clang_cc1 -triple spirv64-amd-amdhsa -fsyntax-only -fcuda-is-device -verify %s
 
+// Tests that no ambiguities are diagnosed when resolving addresses of
+// specialized template functions with the same overloads on host and device.
+
 #include "Inputs/cuda.h"
 
-__host__ void overload() {}
-__device__ void overload() {}
+template <typename T> __host__ void overload(T) {}
+template <typename T> __device__ void overload(T) {}
 
 __host__ __device__ void test_hd() {
-  // This should not be ambiguous -- we choose the host or the device overload
-  // depending on whether or not we're compiling for host or device.
-  void (*x)() = overload;
+  void (*x)(int) = overload<int>;
+  void (*y)(float) = overload<float>;
 }
 
-// These also shouldn't be ambiguous, but they're an easier test than the HD
-// function above.
 __host__ void test_host() {
-  void (*x)() = overload;
+  void (*x)(int) = overload<int>;
+  void (*y)(float) = overload<float>;
 }
 __device__ void test_device() {
-  void (*x)() = overload;
+  void (*x)(int) = overload<int>;
+  void (*y)(float) = overload<float>;
 }


### PR DESCRIPTION
This commit changes SemaOverload to resolve an otherwise diagnosed ambiguity between addresses of template specializations of functions that are overloaded for both device and host. Similar to how it works for non-templated function overloads, these changes prioritizes the specializations that corresponds to the target of the owning function, i.e. if compiling for host, the address of the host specialization takes precedence over the device specialization and vice versa.

Fixes https://github.com/llvm/llvm-project/issues/199299