### PR TITLE
[libc] prefer *at syscalls in sys/stat wrappers

### DIFF
--- a/libc/src/__support/File/linux/dir.cpp
+++ b/libc/src/__support/File/linux/dir.cpp
@@ -13,17 +13,17 @@
 #include "src/__support/macros/config.h"
 
 #include "hdr/fcntl_macros.h" // For open flags
-#include <sys/syscall.h> // For syscall numbers
+#include <sys/syscall.h>      // For syscall numbers
 
 namespace LIBC_NAMESPACE_DECL {
 
 ErrorOr<int> platform_opendir(const char *name) {
   int open_flags = O_RDONLY | O_DIRECTORY | O_CLOEXEC;
-#ifdef SYS_open
-  int fd = LIBC_NAMESPACE::syscall_impl<int>(SYS_open, name, open_flags);
-#elif defined(SYS_openat)
+#ifdef SYS_openat
   int fd =
       LIBC_NAMESPACE::syscall_impl<int>(SYS_openat, AT_FDCWD, name, open_flags);
+#elif defined(SYS_open)
+  int fd = LIBC_NAMESPACE::syscall_impl<int>(SYS_open, name, open_flags);
 #else
 #error                                                                         \
     "SYS_open and SYS_openat syscalls not available to perform an open operation."

--- a/libc/src/__support/File/linux/file.cpp
+++ b/libc/src/__support/File/linux/file.cpp
@@ -92,12 +92,12 @@ ErrorOr<File *> openfile(const char *path, const char *mode) {
   constexpr long OPEN_MODE =
       S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
 
-#ifdef SYS_open
-  int fd =
-      LIBC_NAMESPACE::syscall_impl<int>(SYS_open, path, open_flags, OPEN_MODE);
-#elif defined(SYS_openat)
+#ifdef SYS_openat
   int fd = LIBC_NAMESPACE::syscall_impl<int>(SYS_openat, AT_FDCWD, path,
                                              open_flags, OPEN_MODE);
+#elif defined(SYS_open)
+  int fd =
+      LIBC_NAMESPACE::syscall_impl<int>(SYS_open, path, open_flags, OPEN_MODE);
 #else
 #error "open and openat syscalls not available."
 #endif


### PR DESCRIPTION
- These changes flips the #ifdef order to prefer the *at syscalls over normal ones.
- In modern architectures, *at system calls are preferred over normal system calls cuz of safety issues.
- So by checking for ""*at"" system calls first, we ensure better compatibility with modern systems.
- After then normal syscalls moved else or elif for support to older ones.
- From merged pr(#195792) .
- issue(#195620).