### PR TITLE
[LifetimeSafety] Remove FactMgr parameter from buildOriginFlowChain

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LoanPropagation.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LoanPropagation.h
@@ -45,10 +45,12 @@ public:
   /// sequence of origins through which the loan flowed, ending at the origin
   /// where the loan was originally issued.
   llvm::SmallVector<OriginID>
-  buildOriginFlowChain(const FactManager &FactMgr, ProgramPoint StartPoint,
-                       const OriginID StartOID, const LoanID TargetLoan) const;
+  buildOriginFlowChain(ProgramPoint StartPoint, const OriginID StartOID,
+                       const LoanID TargetLoan) const;
 
 private:
+  FactManager &getFactManager() const;
+
   class Impl;
   std::unique_ptr<Impl> PImpl;
 };

--- a/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
@@ -198,6 +198,8 @@ public:
     return getLoans(getState(P), OID);
   }
 
+  FactManager &getFactManager() const { return FactMgr; }
+
 private:
   /// Returns true if the origin is persistent (referenced in multiple blocks).
   bool isPersistent(OriginID OID) const {
@@ -248,15 +250,21 @@ LoanSet LoanPropagationAnalysis::getLoans(OriginID OID, ProgramPoint P) const {
   return PImpl->getLoans(OID, P);
 }
 
-llvm::SmallVector<OriginID> LoanPropagationAnalysis::buildOriginFlowChain(
-    const FactManager &FactMgr, ProgramPoint StartPoint,
-    const OriginID StartOID, const LoanID TargetLoan) const {
+FactManager &LoanPropagationAnalysis::getFactManager() const {
+  return PImpl->getFactManager();
+}
+
+llvm::SmallVector<OriginID>
+LoanPropagationAnalysis::buildOriginFlowChain(ProgramPoint StartPoint,
+                                              const OriginID StartOID,
+                                              const LoanID TargetLoan) const {
   assert(getLoans(StartOID, StartPoint).contains(TargetLoan) &&
          "TargetLoan must be present in the StartOID at the StartPoint");
 
   OriginID CurrOID = StartOID;
   llvm::SmallVector<OriginID> OriginFlowChain;
-  llvm::ArrayRef<const Fact *> Facts = FactMgr.getBlockContaining(StartPoint);
+  llvm::ArrayRef<const Fact *> Facts =
+      getFactManager().getBlockContaining(StartPoint);
   const auto *StartIt = llvm::find(Facts, StartPoint);
   assert(StartIt != Facts.end());
 

--- a/clang/unittests/Analysis/LifetimeSafetyTest.cpp
+++ b/clang/unittests/Analysis/LifetimeSafetyTest.cpp
@@ -215,7 +215,6 @@ public:
     for (LoanID LID : EndLoanIDs) {
       const llvm::SmallVector<OriginID> OriginFlowChain =
           Runner.getAnalysis().getLoanPropagation().buildOriginFlowChain(
-              Runner.getAnalysis().getFactManager(),
               getProgramPoint(Annotation), *StartOriginID, LID);
       if (!OriginFlowChain.empty())
         return OriginFlowChain;


### PR DESCRIPTION
`LoanPropagationAnalysis` already takes `FactMgr` during construction since it is required by the dataflow analysis itself. Expose an accessor instead of requiring callers to provide the same object explicitly.
