### PR TITLE
[lldb] Add missing quit to TestClangREPL.py

### DIFF
--- a/lldb/test/API/repl/clang/TestClangREPL.py
+++ b/lldb/test/API/repl/clang/TestClangREPL.py
@@ -68,3 +68,5 @@ class TestCase(PExpectTest):
         self.child.send("   ")
         self.child.send("\t")
         self.expect_repl("3 + 3", substrs=["(int) $0 = 6"])
+
+        self.quit()


### PR DESCRIPTION
Without the explicit quit, the test runs until the pexpect instance times out after 1 minute.

This patch reduces the time of this test from >1m to about 10s.