### PR TITLE
[libc++][mdspan][test] Correct `mapping::operator()` constraint tests

### DIFF
--- a/libcxx/test/std/containers/views/mdspan/layout_left/index_operator.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/index_operator.pass.cpp
@@ -27,7 +27,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <mdspan>
-#include <type_traits>
+#include <concepts>
 
 #include "test_macros.h"
 
@@ -35,7 +35,7 @@
 
 template <class Mapping, class... Indices>
 concept operator_constraints = requires(Mapping m, Indices... idxs) {
-  { std::is_same_v<decltype(m(idxs...)), typename Mapping::index_type> };
+  { m(idxs...) } noexcept -> std::same_as<typename Mapping::index_type>;
 };
 
 template <class Mapping, class... Indices>

--- a/libcxx/test/std/containers/views/mdspan/layout_right/index_operator.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_right/index_operator.pass.cpp
@@ -27,7 +27,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <mdspan>
-#include <type_traits>
+#include <concepts>
 
 #include "test_macros.h"
 
@@ -35,7 +35,7 @@
 
 template <class Mapping, class... Indices>
 concept operator_constraints = requires(Mapping m, Indices... idxs) {
-  { std::is_same_v<decltype(m(idxs...)), typename Mapping::index_type> };
+  { m(idxs...) } noexcept -> std::same_as<typename Mapping::index_type>;
 };
 
 template <class Mapping, class... Indices>

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/index_operator.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/index_operator.pass.cpp
@@ -27,7 +27,7 @@
 #include <array>
 #include <cassert>
 #include <cstdint>
-#include <type_traits>
+#include <concepts>
 
 #include "test_macros.h"
 
@@ -35,7 +35,7 @@
 
 template <class Mapping, class... Indices>
 concept operator_constraints = requires(Mapping m, Indices... idxs) {
-  { std::is_same_v<decltype(m(idxs...)), typename Mapping::index_type> };
+  { m(idxs...) } noexcept -> std::same_as<typename Mapping::index_type>;
 };
 
 template <class Mapping, class... Indices>


### PR DESCRIPTION
The previous requires-expression only checked that `std::is_same_v<...>` was a well-formed expression, so the test would pass even when the result was false.