### PR TITLE
[Driver] Switch clang++ to default Solaris 11.4 compilation environment

### DIFF
--- a/clang/lib/Basic/Targets/OSTargets.h
+++ b/clang/lib/Basic/Targets/OSTargets.h
@@ -670,7 +670,6 @@ protected:
     DefineStd(Builder, "unix", Opts);
     Builder.defineMacro("__svr4__");
     Builder.defineMacro("__SVR4");
-    Builder.defineMacro("_XOPEN_SOURCE", "600");
     if (Opts.CPlusPlus) {
       Builder.defineMacro("__C99FEATURES__");
       Builder.defineMacro("_FILE_OFFSET_BITS", "64");


### PR DESCRIPTION
`clang++` has long followed `g++`'s lead predefining `_XOPEN_SOURCE=600` on Solaris.  As detailed in [Switch g++ to default Solaris 11.4 compilation environment](https://gcc.gnu.org/pipermail/gcc-patches/2026-May/716990.html), this is no longer necessary in Solaris 11.4.

Tested on `amd64-pc-solaris2.11` and `sparcv9-sun-solaris2.11`.