### PR TITLE
[flang] Fix POSIX.1/XPG checks in intrinsics-library.cpp

### DIFF
--- a/flang/lib/Evaluate/intrinsics-library.cpp
+++ b/flang/lib/Evaluate/intrinsics-library.cpp
@@ -440,7 +440,8 @@ struct HostRuntimeLibrary<std::complex<double>, LibraryVersion::Libm> {
 //    clang libc++ (ok in GNU libstdc++). Instead, the Posix libm
 //    extensions are used when available below.
 
-#if _POSIX_VERSION >= 200112L || _XOPEN_VERSION >= 600
+#if _POSIX_C_SOURCE >= 200112L || _POSIX_VERSION >= 200112L || \
+    _XOPEN_SOURCE >= 600 || _XOPEN_VERSION >= 600
 /// Define libm extensions
 /// Bessel functions are defined in POSIX.1-2001.
 
@@ -557,7 +558,8 @@ struct HostRuntimeLibrary<long double, LibraryVersion::LibmExtensions> {
   static_assert(map.Verify(), "map must be sorted");
 };
 #endif // HAS_FLOAT80 || HAS_LDBL128
-#endif //_POSIX_VERSION >= 200112L || _XOPEN_VERSION >= 600
+#endif //_POSIX_C_SOURCE >= 200112L || _POSIX_VERSION >= 200112L ||
+       //_XOPEN_VERSION >= 600 || _XOPEN_VERSION >= 600
 
 #ifdef _WIN32
 template <> struct HostRuntimeLibrary<double, LibraryVersion::LibmExtensions> {

--- a/flang/lib/Evaluate/intrinsics-library.cpp
+++ b/flang/lib/Evaluate/intrinsics-library.cpp
@@ -440,7 +440,7 @@ struct HostRuntimeLibrary<std::complex<double>, LibraryVersion::Libm> {
 //    clang libc++ (ok in GNU libstdc++). Instead, the Posix libm
 //    extensions are used when available below.
 
-#if _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600
+#if _POSIX_VERSION >= 200112L || _XOPEN_VERSION >= 600
 /// Define libm extensions
 /// Bessel functions are defined in POSIX.1-2001.
 
@@ -557,7 +557,7 @@ struct HostRuntimeLibrary<long double, LibraryVersion::LibmExtensions> {
   static_assert(map.Verify(), "map must be sorted");
 };
 #endif // HAS_FLOAT80 || HAS_LDBL128
-#endif //_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600
+#endif //_POSIX_VERSION >= 200112L || _XOPEN_VERSION >= 600
 
 #ifdef _WIN32
 template <> struct HostRuntimeLibrary<double, LibraryVersion::LibmExtensions> {

--- a/flang/lib/Evaluate/intrinsics-library.cpp
+++ b/flang/lib/Evaluate/intrinsics-library.cpp
@@ -28,7 +28,9 @@
 #include "flang/Common/float128.h"
 #include "flang/Common/float80.h"
 #include <type_traits>
-#include <unistd.h>
+#ifndef _WIN32
+#include <unistd.h> // _POSIX_VERSION, _XOPEN_VERSION
+#endif
 
 namespace Fortran::evaluate {
 

--- a/flang/lib/Evaluate/intrinsics-library.cpp
+++ b/flang/lib/Evaluate/intrinsics-library.cpp
@@ -28,6 +28,7 @@
 #include "flang/Common/float128.h"
 #include "flang/Common/float80.h"
 #include <type_traits>
+#include <unistd.h>
 
 namespace Fortran::evaluate {
 
@@ -440,8 +441,7 @@ struct HostRuntimeLibrary<std::complex<double>, LibraryVersion::Libm> {
 //    clang libc++ (ok in GNU libstdc++). Instead, the Posix libm
 //    extensions are used when available below.
 
-#if _POSIX_C_SOURCE >= 200112L || _POSIX_VERSION >= 200112L || \
-    _XOPEN_SOURCE >= 600 || _XOPEN_VERSION >= 600
+#if _POSIX_VERSION >= 200112L || _XOPEN_VERSION >= 600
 /// Define libm extensions
 /// Bessel functions are defined in POSIX.1-2001.
 
@@ -461,7 +461,58 @@ template <> struct HostRuntimeLibrary<float, LibraryVersion::LibmExtensions> {
   static constexpr HostRuntimeMap map{table};
   static_assert(map.Verify(), "map must be sorted");
 };
-#endif
+#endif // !_AIX && !__APPLE__
+
+template <> struct HostRuntimeLibrary<double, LibraryVersion::LibmExtensions> {
+  using F = FuncPointer<double, double>;
+  using FN = FuncPointer<double, int, double>;
+  static constexpr HostRuntimeFunction table[]{
+      FolderFactory<F, F{::j0}>::Create("bessel_j0"),
+      FolderFactory<F, F{::j1}>::Create("bessel_j1"),
+      FolderFactory<FN, FN{::jn}>::Create("bessel_jn"),
+      FolderFactory<F, F{::y0}>::Create("bessel_y0"),
+      FolderFactory<F, F{::y1}>::Create("bessel_y1"),
+      FolderFactory<FN, FN{::yn}>::Create("bessel_yn"),
+  };
+  static constexpr HostRuntimeMap map{table};
+  static_assert(map.Verify(), "map must be sorted");
+};
+
+#if defined(__GLIBC__) && (HAS_FLOAT80 || HAS_LDBL128)
+template <>
+struct HostRuntimeLibrary<long double, LibraryVersion::LibmExtensions> {
+  using F = FuncPointer<long double, long double>;
+  using FN = FuncPointer<long double, int, long double>;
+  static constexpr HostRuntimeFunction table[]{
+      FolderFactory<F, F{::j0l}>::Create("bessel_j0"),
+      FolderFactory<F, F{::j1l}>::Create("bessel_j1"),
+      FolderFactory<FN, FN{::jnl}>::Create("bessel_jn"),
+      FolderFactory<F, F{::y0l}>::Create("bessel_y0"),
+      FolderFactory<F, F{::y1l}>::Create("bessel_y1"),
+      FolderFactory<FN, FN{::ynl}>::Create("bessel_yn"),
+  };
+  static constexpr HostRuntimeMap map{table};
+  static_assert(map.Verify(), "map must be sorted");
+};
+#endif // __GLIBC__ && (HAS_FLOAT80 || HAS_LDBL128)
+#endif // _POSIX_VERSION >= 200112L || _XOPEN_VERSION >= 600
+
+#ifdef _WIN32
+template <> struct HostRuntimeLibrary<double, LibraryVersion::LibmExtensions> {
+  using F = FuncPointer<double, double>;
+  using FN = FuncPointer<double, int, double>;
+  static constexpr HostRuntimeFunction table[]{
+      FolderFactory<F, F{::_j0}>::Create("bessel_j0"),
+      FolderFactory<F, F{::_j1}>::Create("bessel_j1"),
+      FolderFactory<FN, FN{::_jn}>::Create("bessel_jn"),
+      FolderFactory<F, F{::_y0}>::Create("bessel_y0"),
+      FolderFactory<F, F{::_y1}>::Create("bessel_y1"),
+      FolderFactory<FN, FN{::_yn}>::Create("bessel_yn"),
+  };
+  static constexpr HostRuntimeMap map{table};
+  static_assert(map.Verify(), "map must be sorted");
+};
+#endif // _WIN32
 
 #if HAS_QUADMATHLIB
 template <> struct HostRuntimeLibrary<__float128, LibraryVersion::Libm> {
@@ -524,59 +575,7 @@ template <> struct HostRuntimeLibrary<__complex128, LibraryVersion::Libm> {
   static constexpr HostRuntimeMap map{table};
   static_assert(map.Verify(), "map must be sorted");
 };
-#endif
-
-template <> struct HostRuntimeLibrary<double, LibraryVersion::LibmExtensions> {
-  using F = FuncPointer<double, double>;
-  using FN = FuncPointer<double, int, double>;
-  static constexpr HostRuntimeFunction table[]{
-      FolderFactory<F, F{::j0}>::Create("bessel_j0"),
-      FolderFactory<F, F{::j1}>::Create("bessel_j1"),
-      FolderFactory<FN, FN{::jn}>::Create("bessel_jn"),
-      FolderFactory<F, F{::y0}>::Create("bessel_y0"),
-      FolderFactory<F, F{::y1}>::Create("bessel_y1"),
-      FolderFactory<FN, FN{::yn}>::Create("bessel_yn"),
-  };
-  static constexpr HostRuntimeMap map{table};
-  static_assert(map.Verify(), "map must be sorted");
-};
-
-#if defined(__GLIBC__) && (HAS_FLOAT80 || HAS_LDBL128)
-template <>
-struct HostRuntimeLibrary<long double, LibraryVersion::LibmExtensions> {
-  using F = FuncPointer<long double, long double>;
-  using FN = FuncPointer<long double, int, long double>;
-  static constexpr HostRuntimeFunction table[]{
-      FolderFactory<F, F{::j0l}>::Create("bessel_j0"),
-      FolderFactory<F, F{::j1l}>::Create("bessel_j1"),
-      FolderFactory<FN, FN{::jnl}>::Create("bessel_jn"),
-      FolderFactory<F, F{::y0l}>::Create("bessel_y0"),
-      FolderFactory<F, F{::y1l}>::Create("bessel_y1"),
-      FolderFactory<FN, FN{::ynl}>::Create("bessel_yn"),
-  };
-  static constexpr HostRuntimeMap map{table};
-  static_assert(map.Verify(), "map must be sorted");
-};
-#endif // HAS_FLOAT80 || HAS_LDBL128
-#endif //_POSIX_C_SOURCE >= 200112L || _POSIX_VERSION >= 200112L ||
-       //_XOPEN_VERSION >= 600 || _XOPEN_VERSION >= 600
-
-#ifdef _WIN32
-template <> struct HostRuntimeLibrary<double, LibraryVersion::LibmExtensions> {
-  using F = FuncPointer<double, double>;
-  using FN = FuncPointer<double, int, double>;
-  static constexpr HostRuntimeFunction table[]{
-      FolderFactory<F, F{::_j0}>::Create("bessel_j0"),
-      FolderFactory<F, F{::_j1}>::Create("bessel_j1"),
-      FolderFactory<FN, FN{::_jn}>::Create("bessel_jn"),
-      FolderFactory<F, F{::_y0}>::Create("bessel_y0"),
-      FolderFactory<F, F{::_y1}>::Create("bessel_y1"),
-      FolderFactory<FN, FN{::_yn}>::Create("bessel_yn"),
-  };
-  static constexpr HostRuntimeMap map{table};
-  static_assert(map.Verify(), "map must be sorted");
-};
-#endif
+#endif // HAS_QUADMATHLIB
 
 /// Define pgmath description
 #if LINK_WITH_LIBPGMATH


### PR DESCRIPTION
PR #201063 breaks the `flang` build on Solaris:

```
flang/lib/Evaluate/intrinsics-library.cpp:225:26: error: address of overloaded function 'acos' does not match required type '__float128 (__float128)'
flang/lib/Evaluate/intrinsics-library.cpp:225:26: error: address of overloaded function 'acos' does not match required type '_Complex __float128 (_Complex __float128)'

```

There are two problems here:
- The `__float128` support in `intrinsics-library.cpp` is guarded by the POSIX.1 >= 2001/XPG >= 6 check, but only depends on `HAVE_QUADMATHLIB`.
- That check is done incorrectly: it tests for `_POSIX_C_SOURCE >= 200112L` or `_XOPEN_SOURCE >= 600`, which are no longer defined on Solaris after the PR above.  This check is due a misunderstanding of those feature test macros: as detailed in [The Open Group Base Specifications Issue 8, 2.2.1 POSIX.1 Symbols](https://pubs.opengroup.org/onlinepubs/9799919799/functions/V2_chap02.html), those macros are expected to be **defined** by the user to ensure that the features introduced by a particular version of POSIX.1 or XPG are enabled, and only be checked by system headers. To test if they actually are supported, the values of `_POSIX_VERSION` or `_XOPEN_VERSION` need to be checked instead, as explained in [2.1.3.1 POSIX System Interfaces](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap02.html).  The feature test macros being defined by the system headers is a non-portable glibc/AIX extension, it seems.
If the XPG6 features required for `flang` are present by default in a compilation environment, `_POSIX_VERSION` or `_XOPEN_VERSION` will be defined to the required values even without defining `_POSIX_C_SOURCE` or `_XOPEN_SOURCE`.

Tested on `amd64-pc-solaris2.11`, `sparcv9-sun-solaris2.11`, and `x86_64-pc-linux-gnu`.