### PR TITLE
[compiler-rt][builtins] Enable i386 long double to float128 conversions

### DIFF
--- a/compiler-rt/lib/builtins/extendxftf2.c
+++ b/compiler-rt/lib/builtins/extendxftf2.c
@@ -12,7 +12,7 @@
 #define QUAD_PRECISION
 #include "fp_lib.h"
 
-#if defined(CRT_HAS_TF_MODE) && __LDBL_MANT_DIG__ == 64 && defined(__x86_64__)
+#if defined(CRT_HAS_TF_MODE) && __LDBL_MANT_DIG__ == 64 && HAS_80_BIT_LONG_DOUBLE
 #define SRC_80
 #define DST_QUAD
 #include "fp_extend_impl.inc"

--- a/compiler-rt/lib/builtins/trunctfxf2.c
+++ b/compiler-rt/lib/builtins/trunctfxf2.c
@@ -12,7 +12,7 @@
 #define QUAD_PRECISION
 #include "fp_lib.h"
 
-#if defined(CRT_HAS_TF_MODE) && __LDBL_MANT_DIG__ == 64 && defined(__x86_64__)
+#if defined(CRT_HAS_TF_MODE) && __LDBL_MANT_DIG__ == 64 && HAS_80_BIT_LONG_DOUBLE
 
 #define SRC_QUAD
 #define DST_80

--- a/compiler-rt/test/builtins/Unit/extendxftf2_test.c
+++ b/compiler-rt/test/builtins/Unit/extendxftf2_test.c
@@ -1,11 +1,10 @@
-// RUN: %clang_builtins %s %librt -o %t && %run %t
+// RUN: %clang_builtins %s %librt -fforce-enable-int128 -o %t && %run %t
 // REQUIRES: librt_has_extendxftf2
 
 #include "int_lib.h"
 #include <stdio.h>
 
-#if __LDBL_MANT_DIG__ == 64 && defined(__x86_64__) &&                          \
-    (defined(__FLOAT128__) || defined(__SIZEOF_FLOAT128__))
+#if defined(CRT_HAS_TF_MODE) && HAS_80_BIT_LONG_DOUBLE
 
 #include "fp_test.h"
 
@@ -28,8 +27,7 @@ char assumption_1[sizeof(long double) * CHAR_BIT == 128] = {0};
 #endif
 
 int main() {
-#if __LDBL_MANT_DIG__ == 64 && defined(__x86_64__) &&                          \
-    (defined(__FLOAT128__) || defined(__SIZEOF_FLOAT128__))
+#if defined(CRT_HAS_TF_MODE) && HAS_80_BIT_LONG_DOUBLE
   // qNaN
   if (test__extendxftf2(makeQNaN80(), UINT64_C(0x7fff800000000000),
                         UINT64_C(0x0)))

--- a/compiler-rt/test/builtins/Unit/trunctfxf2_test.c
+++ b/compiler-rt/test/builtins/Unit/trunctfxf2_test.c
@@ -1,11 +1,10 @@
-// RUN: %clang_builtins %s %librt -o %t && %run %t
+// RUN: %clang_builtins %s %librt -fforce-enable-int128 -o %t && %run %t
 // REQUIRES: librt_has_trunctfxf2
 
 #include "int_lib.h"
 #include <stdio.h>
 
-#if __LDBL_MANT_DIG__ == 64 && defined(__x86_64__) &&                          \
-    (defined(__FLOAT128__) || defined(__SIZEOF_FLOAT128__))
+#if defined(CRT_HAS_TF_MODE) && HAS_80_BIT_LONG_DOUBLE
 
 #include "fp_test.h"
 
@@ -28,8 +27,7 @@ char assumption_1[sizeof(long double) * CHAR_BIT == 128] = {0};
 #endif
 
 int main() {
-#if __LDBL_MANT_DIG__ == 64 && defined(__x86_64__) &&                          \
-    (defined(__FLOAT128__) || defined(__SIZEOF_FLOAT128__))
+#if defined(CRT_HAS_TF_MODE) && HAS_80_BIT_LONG_DOUBLE
   // qNaN
   if (test__trunctfxf2(makeQNaN128(), UINT64_C(0x7FFF),
                        UINT64_C(0xC000000000000000)))


### PR DESCRIPTION
__extendxftf2 (80-bit long double -> 128-bit __float128) and __trunctfxf2 (the reverse) were already compiled for i386 via x86_80_BIT_SOURCES, but their bodies were gated on defined(__x86_64__) and so produced empty objects on i386.

Switch the guard from defined(__x86_64__) to HAS_80_BIT_LONG_DOUBLE so the routines are emitted on i386, and correctly excluded on environments without FP80 such as MSVC and Android.

Update the unit tests to match, passing -fforce-enable-int128 on the RUN line unconditionally. This is safe because %clang_builtins always invokes clang (never GCC) and the flag is a no-op where __int128 is already native, so no lit substitution is needed.

Fixes: #121757
Based on https://github.com/llvm/llvm-project/pull/122658