### PR TITLE
[compiler-rt][asan] Force RTLD_GLOBAL for HSA/HIP/OpenCL runtime dlopen.

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -2886,25 +2886,7 @@ void CheckMPROTECT() {
 #  endif
 }
 
-#  if SANITIZER_AMDGPU
-void PatchHsaRuntimeDlopenFlag(const char* filename, int& flag) {
-  if (filename &&
-      (internal_strstr(filename, "libamdhip64.so") ||
-       internal_strstr(filename, "libhsa-runtime64.so") ||
-       internal_strstr(filename, "libamdocl64.so")) &&
-      !(flag & RTLD_GLOBAL)) {
-    flag |= RTLD_GLOBAL;
-    if (Verbosity() >= 2) {
-      Printf(
-          "RTLD_GLOBAL flag on dlopen call forced on for %s due to AMDGPU "
-          "device sanitizer runtime requirements.\n",
-          filename);
-    }
-  }
-}
-#  endif
-
-void OnDlOpen(const char *filename, int flag) {
+void OnDlOpen(const char* filename, int flag) {
 #  ifdef RTLD_DEEPBIND
   if (flag & RTLD_DEEPBIND) {
     Report(
@@ -2918,8 +2900,20 @@ void OnDlOpen(const char *filename, int flag) {
   }
 #  endif
 
-#  if SANITIZER_AMDGPU
-  PatchHsaRuntimeDlopenFlag(filename, flag);
+#  if SANITIZER_AMDHSA
+  if (filename &&
+      (internal_strstr(filename, "libamdhip64.so") ||
+       internal_strstr(filename, "libhsa-runtime64.so") ||
+       internal_strstr(filename, "libamdocl64.so")) &&
+      !(flag & RTLD_GLOBAL)) {
+    flag |= RTLD_GLOBAL;
+    if (Verbosity() >= 2) {
+      Printf(
+          "RTLD_GLOBAL flag on dlopen call forced on for %s due to AMDGPU "
+          "device sanitizer runtime requirements.\n",
+          filename);
+    }
+  }
 #  endif
 }
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -2886,7 +2886,25 @@ void CheckMPROTECT() {
 #  endif
 }
 
-void OnDlOpen(const char* filename, int flag) {
+#  if SANITIZER_AMDGPU
+void PatchHsaRuntimeDlopenFlag(const char* filename, int& flag) {
+  if (filename &&
+      (internal_strstr(filename, "libamdhip64.so") ||
+       internal_strstr(filename, "libhsa-runtime64.so") ||
+       internal_strstr(filename, "libamdocl64.so")) &&
+      !(flag & RTLD_GLOBAL)) {
+    flag |= RTLD_GLOBAL;
+    if (Verbosity() >= 2) {
+      Printf(
+          "RTLD_GLOBAL flag on dlopen call forced on for %s due to AMDGPU "
+          "device sanitizer runtime requirements.\n",
+          filename);
+    }
+  }
+}
+#  endif
+
+void OnDlOpen(const char *filename, int flag) {
 #  ifdef RTLD_DEEPBIND
   if (flag & RTLD_DEEPBIND) {
     Report(
@@ -2898,6 +2916,10 @@ void OnDlOpen(const char* filename, int flag) {
         filename, filename);
     Die();
   }
+#  endif
+
+#  if SANITIZER_AMDGPU
+  PatchHsaRuntimeDlopenFlag(filename, flag);
 #  endif
 }
 


### PR DESCRIPTION
- When ASan intercepts dlopen of libamdhip64.so, libhsa-runtime64.so, or
  libamdocl64.so, add RTLD_GLOBAL if it was omitted, so symbols are visible as
  required by the AMDGPU device sanitizer runtime.