### PR TITLE
[libc] Define SSIZE_MAX in limits-macros.h

### DIFF
--- a/libc/include/limits.yaml
+++ b/libc/include/limits.yaml
@@ -84,6 +84,8 @@ macros:
     macro_header: limits-macros.h
   - macro_name: PTHREAD_DESTRUCTOR_ITERATIONS
     macro_header: limits-macros.h
+  - macro_name: SSIZE_MAX
+    macro_header: limits-macros.h
 types: []
 enums: []
 objects: []

--- a/libc/include/llvm-libc-macros/limits-macros.h
+++ b/libc/include/llvm-libc-macros/limits-macros.h
@@ -261,4 +261,11 @@
 #define IOV_MAX 1024
 #endif // IOV_MAX
 
+#ifndef SSIZE_MAX
+#ifdef __PTRDIFF_MAX__
+/// The maximum value that can be stored in an object of type ssize_t.
+#define SSIZE_MAX __PTRDIFF_MAX__
+#endif
+#endif
+
 #endif // LLVM_LIBC_MACROS_LIMITS_MACROS_H

--- a/libc/test/src/__support/CPP/limits_test.cpp
+++ b/libc/test/src/__support/CPP/limits_test.cpp
@@ -31,6 +31,14 @@ TEST(LlvmLibcLimitsTest, LimitsFollowSpec) {
   ASSERT_EQ(cpp::numeric_limits<long long>::min(), LLONG_MIN);
 
   ASSERT_EQ(cpp::numeric_limits<unsigned long long>::max(), ULLONG_MAX);
+
+#ifdef SSIZE_MAX
+  ASSERT_EQ(cpp::numeric_limits<__PTRDIFF_TYPE__>::max(), SSIZE_MAX);
+#else
+#ifdef LIBC_FULL_BUILD
+#error "SSIZE_MAX is not defined in full build mode"
+#endif
+#endif
 }
 
 TEST(LlvmLibcLimitsTest, UInt128Limits) {


### PR DESCRIPTION
Defined SSIZE_MAX in limits-macros.h to support POSIX compliance. Applications compiling against LLVM libc require SSIZE_MAX to be defined in limits.h.

SSIZE_MAX is defined strictly in terms of __PTRDIFF_MAX__, matching ssize_t defined as __PTRDIFF_TYPE__, ensuring they are always structurally aligned and compile-time safe.

Added Doxygen comments for SSIZE_MAX.
Added SSIZE_MAX to limits.yaml and added a unit test in limits_test.cpp to verify the definition.

Assisted-by: Automated tooling, human reviewed.