### PR TITLE
[libc] Define _POSIX_THREADS and support _SC_THREADS in sysconf

### DIFF
--- a/libc/include/llvm-libc-macros/linux/unistd-macros.h
+++ b/libc/include/llvm-libc-macros/linux/unistd-macros.h
@@ -1,9 +1,14 @@
-//===-- Definition of macros from unistd.h --------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Linux specific declarations of macros from unistd.h.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_MACROS_LINUX_UNISTD_MACROS_H
@@ -19,6 +24,7 @@
 #define _SC_PAGE_SIZE _SC_PAGESIZE
 #define _SC_NPROCESSORS_CONF 83
 #define _SC_NPROCESSORS_ONLN 84
+#define _SC_THREADS 67
 
 #define _PC_FILESIZEBITS 0
 #define _PC_LINK_MAX 1
@@ -43,6 +49,7 @@
 
 // TODO: Move these limit macros to a separate file
 #define _POSIX_CHOWN_RESTRICTED 1
+#define _POSIX_THREADS 202405L
 #define _POSIX_PIPE_BUF 512
 #define _POSIX_NO_TRUNC 1
 #define _POSIX_VDISABLE '\0'

--- a/libc/include/unistd.yaml
+++ b/libc/include/unistd.yaml
@@ -22,6 +22,10 @@ macros:
     macro_header: unistd-macros.h
   - macro_name: _SC_NPROCESSORS_ONLN
     macro_header: unistd-macros.h
+  - macro_name: _SC_THREADS
+    macro_header: unistd-macros.h
+  - macro_name: _POSIX_THREADS
+    macro_header: unistd-macros.h
 types:
   - type_name: uid_t
   - type_name: gid_t

--- a/libc/src/unistd/linux/sysconf.cpp
+++ b/libc/src/unistd/linux/sysconf.cpp
@@ -36,6 +36,9 @@ LLVM_LIBC_FUNCTION(long, sysconf, (int name)) {
     return static_cast<long>(
         sysinfo::parse_nproc_with_fallback_from(sysinfo::ONLINE_NPROC_PATH));
 
+  if (name == _SC_THREADS)
+    return _POSIX_THREADS;
+
   // TODO: Complete the rest of the sysconf options.
   libc_errno = EINVAL;
   return -1;

--- a/libc/test/include/CMakeLists.txt
+++ b/libc/test/include/CMakeLists.txt
@@ -30,8 +30,6 @@ add_libc_test(
   DEPENDS
     libc.include.llvm-libc-macros.unistd_macros
 )
-
-
 add_libc_test(
   sys_queue_test
   SUITE

--- a/libc/test/include/CMakeLists.txt
+++ b/libc/test/include/CMakeLists.txt
@@ -22,6 +22,17 @@ add_libc_test(
 )
 
 add_libc_test(
+  unistd_macros_test
+  SUITE
+    libc_include_tests
+  SRCS
+    unistd_macros_test.cpp
+  DEPENDS
+    libc.include.llvm-libc-macros.unistd_macros
+)
+
+
+add_libc_test(
   sys_queue_test
   SUITE
     libc_include_tests

--- a/libc/test/include/unistd_macros_test.cpp
+++ b/libc/test/include/unistd_macros_test.cpp
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unit tests for unistd-macros.
+///
+//===----------------------------------------------------------------------===//
+
+#include "include/llvm-libc-macros/unistd-macros.h"
+#include "test/UnitTest/Test.h"
+
+namespace LIBC_NAMESPACE {
+
+TEST(LlvmLibcUnistdMacrosTest, VersionMacros) {
+#ifdef __linux__
+#ifndef _POSIX_THREADS
+#error "_POSIX_THREADS is not defined on Linux"
+#endif
+  EXPECT_EQ(_POSIX_THREADS, 202405L);
+#endif
+}
+
+} // namespace LIBC_NAMESPACE

--- a/libc/test/src/unistd/sysconf_test.cpp
+++ b/libc/test/src/unistd/sysconf_test.cpp
@@ -25,3 +25,8 @@ TEST(LlvmLibcSysconfTest, NprocessorsOnlnTest) {
   long sysconf_count = LIBC_NAMESPACE::sysconf(_SC_NPROCESSORS_ONLN);
   ASSERT_GT(sysconf_count, 0l);
 }
+
+TEST(LlvmLibcSysconfTest, ThreadsTest) {
+  long threads = LIBC_NAMESPACE::sysconf(_SC_THREADS);
+  ASSERT_EQ(threads, _POSIX_THREADS);
+}


### PR DESCRIPTION
Defined the _POSIX_THREADS macro to 202405L in unistd-macros.h for Linux to signal POSIX thread support.

Also implemented runtime support for _SC_THREADS in sysconf, returning _POSIX_THREADS, and added _SC_THREADS and _POSIX_THREADS to the public unistd.yaml specification.

Added compile-time and runtime tests to verify _POSIX_THREADS definition and sysconf(_SC_THREADS) behavior. Standardized header comments in unistd-macros.h to conform to LLVM style.

Assisted-by: Automated tooling, human reviewed.