### PR TITLE
[lldb][Windows] Register MSVCRTCFrameRecognizer from DynamicLoaderWindowsDYLD

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/Windows-DYLD/CMakeLists.txt
+++ b/lldb/source/Plugins/DynamicLoader/Windows-DYLD/CMakeLists.txt
@@ -1,10 +1,13 @@
 add_lldb_library(lldbPluginDynamicLoaderWindowsDYLD PLUGIN
   DynamicLoaderWindowsDYLD.cpp
+  MSVCRTCFrameRecognizer.cpp
 
   LINK_COMPONENTS
     Support
     TargetParser
   LINK_LIBS
     lldbCore
+    lldbSymbol
     lldbTarget
+    lldbValueObject
   )

--- a/lldb/source/Plugins/DynamicLoader/Windows-DYLD/DynamicLoaderWindowsDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/Windows-DYLD/DynamicLoaderWindowsDYLD.cpp
@@ -8,6 +8,7 @@
 
 #include "DynamicLoaderWindowsDYLD.h"
 
+#include "MSVCRTCFrameRecognizer.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Target/ExecutionContext.h"
@@ -137,6 +138,8 @@ void DynamicLoaderWindowsDYLD::DidAttach() {
   Log *log = GetLog(LLDBLog::DynamicLoader);
   LLDB_LOGF(log, "DynamicLoaderWindowsDYLD::%s()", __FUNCTION__);
 
+  RegisterMSVCRTCFrameRecognizer(m_process->GetTarget());
+
   ModuleSP executable = GetTargetExecutable();
 
   if (!executable)
@@ -166,6 +169,8 @@ void DynamicLoaderWindowsDYLD::DidAttach() {
 void DynamicLoaderWindowsDYLD::DidLaunch() {
   Log *log = GetLog(LLDBLog::DynamicLoader);
   LLDB_LOGF(log, "DynamicLoaderWindowsDYLD::%s()", __FUNCTION__);
+
+  RegisterMSVCRTCFrameRecognizer(m_process->GetTarget());
 
   ModuleSP executable = GetTargetExecutable();
   if (!executable)

--- a/lldb/source/Plugins/DynamicLoader/Windows-DYLD/MSVCRTCFrameRecognizer.cpp
+++ b/lldb/source/Plugins/DynamicLoader/Windows-DYLD/MSVCRTCFrameRecognizer.cpp
@@ -21,8 +21,8 @@ using namespace lldb_private;
 
 namespace lldb_private {
 
-void RegisterMSVCRTCFrameRecognizer(ProcessWindows &process) {
-  process.GetTarget().GetFrameRecognizerManager().AddRecognizer(
+void RegisterMSVCRTCFrameRecognizer(Target &target) {
+  target.GetFrameRecognizerManager().AddRecognizer(
       std::make_shared<MSVCRTCFrameRecognizer>(), ConstString(""),
       {ConstString("failwithmessage")}, Mangled::ePreferDemangled,
       /*first_instruction_only=*/false);
@@ -32,13 +32,6 @@ lldb::RecognizedStackFrameSP
 MSVCRTCFrameRecognizer::RecognizeFrame(lldb::StackFrameSP frame_sp) {
   // failwithmessage calls __debugbreak() which lands at frame 0.
   if (frame_sp->GetFrameIndex() != 0)
-    return RecognizedStackFrameSP();
-  // Only fire on EXCEPTION_BREAKPOINT (0x80000003), not on other exceptions
-  // that might incidentally have failwithmessage somewhere in the call stack.
-  auto *pw =
-      static_cast<ProcessWindows *>(frame_sp->GetThread()->GetProcess().get());
-  auto exc_code = pw->GetActiveExceptionCode();
-  if (!exc_code || *exc_code != EXCEPTION_BREAKPOINT)
     return RecognizedStackFrameSP();
 
   const char *fn_name = frame_sp->GetFunctionName();

--- a/lldb/source/Plugins/DynamicLoader/Windows-DYLD/MSVCRTCFrameRecognizer.h
+++ b/lldb/source/Plugins/DynamicLoader/Windows-DYLD/MSVCRTCFrameRecognizer.h
@@ -6,16 +6,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLDB_PLUGINS_PROCESS_WINDOWS_MSVCRTCFRAMERECOGNIZER_H
-#define LLDB_PLUGINS_PROCESS_WINDOWS_MSVCRTCFRAMERECOGNIZER_H
+#ifndef LLDB_PLUGINS_DYNAMICLOADER_WINDOWS_MSVCRTCFRAMERECOGNIZER_H
+#define LLDB_PLUGINS_DYNAMICLOADER_WINDOWS_MSVCRTCFRAMERECOGNIZER_H
 
-#include "ProcessWindows.h"
 #include "lldb/Target/StackFrameRecognizer.h"
 
 namespace lldb_private {
 
+class Target;
+
 /// Registers the MSVC run-time check failure frame recognizer with the target.
-void RegisterMSVCRTCFrameRecognizer(ProcessWindows &process);
+void RegisterMSVCRTCFrameRecognizer(Target &target);
 
 /// Recognized stack frame for an MSVC _RTC failure. Carries the human-readable
 /// stop description extracted from failwithmessage's \c msg parameter.
@@ -38,4 +39,4 @@ public:
 
 } // namespace lldb_private
 
-#endif // LLDB_PLUGINS_PROCESS_WINDOWS_MSVCRTCFRAMERECOGNIZER_H
+#endif // LLDB_PLUGINS_DYNAMICLOADER_WINDOWS_MSVCRTCFRAMERECOGNIZER_H

--- a/lldb/source/Plugins/Process/Windows/Common/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/Windows/Common/CMakeLists.txt
@@ -2,7 +2,6 @@
 add_lldb_library(lldbPluginProcessWindowsCommon PLUGIN
   DebuggerThread.cpp
   LocalDebugDelegate.cpp
-  MSVCRTCFrameRecognizer.cpp
   NativeProcessWindows.cpp
   NativeRegisterContextWindows.cpp
   NativeRegisterContextWindows_arm.cpp

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -44,7 +44,6 @@
 #include "ExceptionRecord.h"
 #include "ForwardDecl.h"
 #include "LocalDebugDelegate.h"
-#include "MSVCRTCFrameRecognizer.h"
 #include "ProcessWindowsLog.h"
 #include "TargetThreadWindows.h"
 
@@ -303,8 +302,6 @@ void ProcessWindows::DidLaunch() {
 
 void ProcessWindows::DidAttach(ArchSpec &arch_spec) {
   llvm::sys::ScopedLock lock(m_mutex);
-
-  RegisterMSVCRTCFrameRecognizer(*this);
 
   // The initial stop won't broadcast the state change event, so account for
   // that here.


### PR DESCRIPTION
This patch moves `MSVCRTCFrameRecognizer` to `Plugins/DynamicLoader/Windows-DYLD` and register it from `DynamicLoaderWindowsDYLD::DidLaunch / DidAttach`.

The Windows DYLD plugin runs for every Windows target regardless of process plugin. This patch enables it to work with `lldb-server.exe`. This fixes `TestMSVCRTCException` with `LLDB_USE_LLDB_SERVER=1`.

This patch also removes the exception-code gate (`exc_code != EXCEPTION_BREAKPOINT`) from `RecognizeFrame`. It did not translate to `ProcessGDBRemote`.

rdar://178520529