### PR TITLE
[lldb][test] Always call quit when tearing down pexpect tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbpexpect.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbpexpect.py
@@ -100,9 +100,24 @@ class PExpectTest(TestBase):
                 self.child.expect_exact(s)
         self.expect_prompt()
 
+    def tearDown(self):
+        # Ensure the child is always cleaned up, even if the test didn't call
+        # quit() explicitly or failed before reaching it.
+        if self.child is not None:
+            self.quit()
+        super().tearDown()
+
     def quit(self, gracefully=True):
-        self.child.sendeof()
-        self.child.close(force=not gracefully)
+        if self.child is None:
+            return
+
+        try:
+            self.child.sendeof()
+            self.child.close(force=not gracefully)
+        except OSError:
+            # This can happen if LLDB quit itself because it is running in
+            # batch mode.
+            pass
         self.child = None
 
     def cursor_forward_escape_seq(self, chars_to_move):

--- a/lldb/test/API/commands/apropos/formatting/TestAproposFormatting.py
+++ b/lldb/test/API/commands/apropos/formatting/TestAproposFormatting.py
@@ -32,7 +32,6 @@ class AproposFormattingTest(PExpectTest):
         )
 
         self.expect_prompt()
-        self.quit()
 
     @skipIfAsan
     @skipIfEditlineSupportMissing
@@ -73,7 +72,6 @@ class AproposFormattingTest(PExpectTest):
         # Settings descriptions.
         self.child.expect_exact("'" + ansi_green + "plug" + ansi_reset + "in")
         self.expect_prompt()
-        self.quit()
 
     @skipIfAsan
     @skipIfEditlineSupportMissing
@@ -95,4 +93,3 @@ class AproposFormattingTest(PExpectTest):
         self.child.expect_exact(ansi_green + "will")
         self.child.expect_exact("this" + ansi_reset)
         self.expect_prompt()
-        self.quit()

--- a/lldb/test/API/commands/expression/multiline-completion/TestMultilineCompletion.py
+++ b/lldb/test/API/commands/expression/multiline-completion/TestMultilineCompletion.py
@@ -64,4 +64,3 @@ class MultilineCompletionTest(PExpectTest):
         self.child.expect_exact("only_local ")
         self.exit_expression_editor()
 
-        self.quit()

--- a/lldb/test/API/commands/expression/multiline-navigation/TestMultilineNavigation.py
+++ b/lldb/test/API/commands/expression/multiline-navigation/TestMultilineNavigation.py
@@ -36,7 +36,6 @@ class TestCase(PExpectTest):
         # and not 123 (the one we initially typed).
         self.child.expect_exact("(int) $0 = 124")
 
-        self.quit()
 
     @skipIfAsan
     @skipIfEditlineSupportMissing
@@ -68,7 +67,6 @@ class TestCase(PExpectTest):
         # us back to the second line.
         self.child.expect_exact("(int) $0 = 334")
 
-        self.quit()
 
     @skipIfAsan
     @skipIfEditlineSupportMissing
@@ -101,4 +99,3 @@ class TestCase(PExpectTest):
         self.child.send("\n\n")
         self.expect_prompt()
 
-        self.quit()

--- a/lldb/test/API/commands/gui/basic/TestGuiBasic.py
+++ b/lldb/test/API/commands/gui/basic/TestGuiBasic.py
@@ -51,4 +51,3 @@ class BasicGuiCommandTest(PExpectTest):
         self.child.send(escape_key)
 
         self.expect_prompt()
-        self.quit()

--- a/lldb/test/API/commands/gui/basicdebug/TestGuiBasicDebug.py
+++ b/lldb/test/API/commands/gui/basicdebug/TestGuiBasicDebug.py
@@ -58,4 +58,3 @@ class TestGuiBasicDebugCommandTest(PExpectTest):
         self.child.send(escape_key)
 
         self.expect_prompt()
-        self.quit()

--- a/lldb/test/API/commands/gui/breakpoints/TestGuiBreakpoints.py
+++ b/lldb/test/API/commands/gui/breakpoints/TestGuiBreakpoints.py
@@ -72,4 +72,3 @@ class TestGuiBasicDebugCommandTest(PExpectTest):
         self.child.send(escape_key)
 
         self.expect_prompt()
-        self.quit()

--- a/lldb/test/API/commands/gui/expand-threads-tree/TestGuiExpandThreadsTree.py
+++ b/lldb/test/API/commands/gui/expand-threads-tree/TestGuiExpandThreadsTree.py
@@ -55,4 +55,3 @@ class TestGuiExpandThreadsTree(PExpectTest):
         self.child.send(escape_key)
 
         self.expect_prompt()
-        self.quit()

--- a/lldb/test/API/commands/gui/spawn-threads/TestGuiSpawnThreads.py
+++ b/lldb/test/API/commands/gui/spawn-threads/TestGuiSpawnThreads.py
@@ -48,4 +48,3 @@ class TestGuiSpawnThreadsTest(PExpectTest):
         self.child.send(escape_key)
         self.expect_prompt()
 
-        self.quit()

--- a/lldb/test/API/commands/gui/viewlarge/TestGuiViewLarge.py
+++ b/lldb/test/API/commands/gui/viewlarge/TestGuiViewLarge.py
@@ -75,4 +75,3 @@ class GuiViewLargeCommandTest(PExpectTest):
         self.child.send(escape_key)
 
         self.expect_prompt()
-        self.quit()

--- a/lldb/test/API/iohandler/autosuggestion/TestAutosuggestion.py
+++ b/lldb/test/API/iohandler/autosuggestion/TestAutosuggestion.py
@@ -46,7 +46,6 @@ class TestCase(PExpectTest):
             + " "
         )
 
-        self.quit()
 
     @skipIfAsan
     @skipIfEditlineSupportMissing
@@ -132,7 +131,6 @@ class TestCase(PExpectTest):
         self.child.send(ctrl_f + "help breakpoint" + "\n")
         self.child.expect_exact(breakpoint_output_needle)
 
-        self.quit()
 
     @skipIfAsan
     @skipIfEditlineSupportMissing
@@ -156,4 +154,3 @@ class TestCase(PExpectTest):
         self.child.expect_exact(self.ANSI_RED + "ame variable" + self.ANSI_CYAN)
         self.child.send("\n")
 
-        self.quit()

--- a/lldb/test/API/iohandler/completion/TestIOHandlerCompletion.py
+++ b/lldb/test/API/iohandler/completion/TestIOHandlerCompletion.py
@@ -85,4 +85,3 @@ class IOHandlerCompletionTest(PExpectTest):
         self.child.send("regoinvalid\t")
         self.expect_prompt()
 
-        self.quit()

--- a/lldb/test/API/iohandler/resize/TestIOHandlerResize.py
+++ b/lldb/test/API/iohandler/resize/TestIOHandlerResize.py
@@ -33,4 +33,3 @@ class IOHandlerCompletionTest(PExpectTest):
         self.child.expect_exact(
             "(lldb) This is a long sentence missing its first letter."
         )
-        self.quit()

--- a/lldb/test/API/iohandler/sigint/TestIOHandlerPythonREPLSigint.py
+++ b/lldb/test/API/iohandler/sigint/TestIOHandlerPythonREPLSigint.py
@@ -49,7 +49,6 @@ class TestCase(PExpectTest):
         # Send EOF to quit the Python REPL.
         self.child.sendeof()
 
-        self.quit()
 
     # PExpect uses many timeouts internally and doesn't play well
     # under ASAN on a loaded machine..
@@ -71,4 +70,3 @@ class TestCase(PExpectTest):
         # Send EOF to quit the Python REPL.
         self.child.sendeof()
 
-        self.quit()

--- a/lldb/test/API/iohandler/sigint/TestProcessIOHandlerInterrupt.py
+++ b/lldb/test/API/iohandler/sigint/TestProcessIOHandlerInterrupt.py
@@ -42,4 +42,3 @@ class TestCase(PExpectTest):
         self.child.expect("Process .* exited")
         self.expect_prompt()
 
-        self.quit()

--- a/lldb/test/API/iohandler/stdio/TestIOHandlerProcessSTDIO.py
+++ b/lldb/test/API/iohandler/stdio/TestIOHandlerProcessSTDIO.py
@@ -26,4 +26,3 @@ class TestIOHandlerProcessSTDIO(PExpectTest):
         self.child.expect_exact("stdout: baz")
 
         self.child.sendcontrol("d")
-        self.quit()

--- a/lldb/test/API/iohandler/unicode/TestUnicode.py
+++ b/lldb/test/API/iohandler/unicode/TestUnicode.py
@@ -27,4 +27,3 @@ class TestCase(PExpectTest):
             substrs=["error: '\u1234' is not a valid command".encode("utf-8")],
         )
 
-        self.quit()

--- a/lldb/test/API/repl/clang/TestClangREPL.py
+++ b/lldb/test/API/repl/clang/TestClangREPL.py
@@ -54,7 +54,6 @@ class TestCase(PExpectTest):
         # Try using the persistent variable from before.
         self.expect_repl("$persistent + 10", substrs=["(long) $2 = 17"])
 
-        self.quit()
 
     # PExpect uses many timeouts internally and doesn't play well
     # under ASAN on a loaded machine..

--- a/lldb/test/API/terminal/TestDisabledBreakpoints.py
+++ b/lldb/test/API/terminal/TestDisabledBreakpoints.py
@@ -22,4 +22,3 @@ class DisabledBreakpointsTest(PExpectTest):
         self.expect("b main")
         self.expect("br dis")
         self.expect("br l", substrs=[ansi_red_color_code + "1:"])
-        self.quit()

--- a/lldb/test/API/terminal/TestEditline.py
+++ b/lldb/test/API/terminal/TestEditline.py
@@ -42,7 +42,6 @@ class EditlineTest(PExpectTest):
                 substrs=["Syntax: print"],
             )
 
-        self.quit()
 
     @skipIfAsan
     @skipIfEditlineSupportMissing


### PR DESCRIPTION
Right now we manually have to call quit at the end of each pexpect test. This patches makes this call automatic.

This also makes tests that missed the call and where previously waiting for a timeout faster. For example, TestClangREPL.py now only takes about 10 seconds to run instead of 1 minute.