### PR TITLE
[clang][bytecode] Get the right definition before compiling functions

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1725,7 +1725,9 @@ bool CheckBitCast(InterpState &S, CodePtr OpPC, const Type *TargetType,
 }
 
 static void compileFunction(InterpState &S, const Function *Func) {
-  const FunctionDecl *Definition = Func->getDecl()->getDefinition();
+  const FunctionDecl *Definition;
+  if (!Func->getDecl()->getBody(Definition))
+    return;
   if (!Definition)
     return;
 


### PR DESCRIPTION
This broke libc++'s
std/ranges/range.adaptors/range.concat/iterator/arithmetic.pass.cpp.

The (reduced via cvise but not enough) function looks like this:

```c++
  friend constexpr unsigned
  operator-(const __iterator &__x, const __iterator &__y)
    {
      (void)-(__y - __x);
      return 0;
    }
```

When evaluating the binary operator for overflow, we will compile the operator- (_this_ function) to bytecode. At that point, ::isThisDeclarationADefiniton() will return true and ::getDefiniton() returns the function itself. However, all this is happening while the function is being instantiated, which means the function doesn't have a body yet and the bytecode ends up being just a NoRet op. This will of course later fail.

Fix this by querying the body before trying to compile a function.

Unfortunately I wasn't able to create a reproducer of reasonable size.