### PR TITLE
[CI] install packaging before running lldb tests on Windows

### DIFF
--- a/.ci/green-dragon/lldb-windows.groovy
+++ b/.ci/green-dragon/lldb-windows.groovy
@@ -51,6 +51,8 @@ pipeline {
                         writeFile file: 'build.bat', text: '''@echo off
 call "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Auxiliary\\Build\\vcvars64.bat" || exit /b 1
 
+"C:\\Program Files\\Python313\\python.exe" -m pip install packaging || exit /b 1
+
 cmake -G Ninja ^
     -S llvm ^
     -B ..\\llvm-build\\ ^


### PR DESCRIPTION
https://ci-external.swift.org/job/lldb-windows/job/main/ is failing because lldb API tests require the `packaging` module.

This patch installs it before running the `check-lldb` target.