### PR TITLE
[clang][bytecode] Variadic ctors also start lifetime

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1747,7 +1747,8 @@ bool CallVar(InterpState &S, CodePtr OpPC, const Function *Func,
     if (!(S.Current->getFunction() &&
           S.Current->getFunction()->isLambdaStaticInvoker() &&
           Func->isLambdaCallOperator())) {
-      if (!CheckInvoke(S, OpPC, ThisPtr))
+      if (!CheckInvoke(S, OpPC, ThisPtr,
+                       Func->isConstructor() || Func->isDestructor()))
         return false;
     }
 

--- a/clang/test/AST/ByteCode/records.cpp
+++ b/clang/test/AST/ByteCode/records.cpp
@@ -2031,3 +2031,16 @@ namespace StaticMemberRedecl {
   const int S::m = 10;
   static_assert(getM() == 10, "");
 }
+
+namespace VariadicCtorStartsLifetime {
+  struct S {
+    constexpr S(int, ...) {}
+  };
+  class C {
+  public:
+    S s;
+    constexpr C() : s(1,1) {}
+  };
+  /// Used to not start the lifetime of 's'.
+  constexpr C c;
+}


### PR DESCRIPTION
This is the same thing we do in the non-variadic `Call()`.