### PR TITLE
[SPIR-V] Select int-to-int convert opcode from source signedness

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
@@ -3209,14 +3209,15 @@ static bool generateConvertInst(const StringRef DemangledCall,
   unsigned Opcode = SPIRV::OpNop;
   if (GR->isScalarOrVectorOfType(Call->Arguments[0], SPIRV::OpTypeInt)) {
     // Int -> ...
+    bool IsSourceSigned =
+        DemangledCall[DemangledCall.find_first_of('(') + 1] != 'u';
     if (GR->isScalarOrVectorOfType(Call->ReturnRegister, SPIRV::OpTypeInt)) {
       // Int -> Int
       if (Builtin->IsSaturated)
         Opcode = Builtin->IsDestinationSigned ? SPIRV::OpSatConvertUToS
                                               : SPIRV::OpSatConvertSToU;
       else
-        Opcode = Builtin->IsDestinationSigned ? SPIRV::OpSConvert
-                                              : SPIRV::OpUConvert;
+        Opcode = IsSourceSigned ? SPIRV::OpSConvert : SPIRV::OpUConvert;
     } else if (GR->isScalarOrVectorOfType(Call->ReturnRegister,
                                           SPIRV::OpTypeFloat)) {
       // Int -> Float
@@ -3231,8 +3232,6 @@ static bool generateConvertInst(const StringRef DemangledCall,
             GR->getScalarOrVectorComponentCount(Call->ReturnRegister);
         Opcode = SPIRV::OpConvertBF16ToFINTEL;
       } else {
-        bool IsSourceSigned =
-            DemangledCall[DemangledCall.find_first_of('(') + 1] != 'u';
         Opcode = IsSourceSigned ? SPIRV::OpConvertSToF : SPIRV::OpConvertUToF;
       }
     }

--- a/llvm/test/CodeGen/SPIRV/transcoding/OpenCL/convert_signedness.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/OpenCL/convert_signedness.ll
@@ -1,0 +1,67 @@
+; Check that convert_ builtins pick the signed/unsigned opcode from the source
+; operand signedness.
+
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK-DAG: OpName %[[#StoS:]] "s_to_s"
+; CHECK-DAG: OpName %[[#StoU:]] "s_to_u"
+; CHECK-DAG: OpName %[[#UtoS:]] "u_to_s"
+; CHECK-DAG: OpName %[[#UtoU:]] "u_to_u"
+; CHECK-DAG: OpName %[[#StoF:]] "s_to_f"
+; CHECK-DAG: OpName %[[#UtoF:]] "u_to_f"
+
+; signed source -> signed dest: sign-extend.
+; CHECK: %[[#StoS]] = OpFunction
+; CHECK: OpSConvert
+define spir_func void @s_to_s(i32 noundef %x) {
+  call spir_func i64 @_Z12convert_longi(i32 noundef %x)
+  ret void
+}
+
+; signed source -> unsigned dest: sign-extend.
+; CHECK: %[[#StoU]] = OpFunction
+; CHECK: OpSConvert
+define spir_func void @s_to_u(i32 noundef %x) {
+  call spir_func i64 @_Z13convert_ulongi(i32 noundef %x)
+  ret void
+}
+
+; unsigned source -> signed dest: zero-extend.
+; CHECK: %[[#UtoS]] = OpFunction
+; CHECK: OpUConvert
+define spir_func void @u_to_s(i32 noundef %x) {
+  call spir_func i64 @_Z12convert_longj(i32 noundef %x)
+  ret void
+}
+
+; unsigned source -> unsigned dest: zero-extend.
+; CHECK: %[[#UtoU]] = OpFunction
+; CHECK: OpUConvert
+define spir_func void @u_to_u(i32 noundef %x) {
+  call spir_func i64 @_Z13convert_ulongj(i32 noundef %x)
+  ret void
+}
+
+; signed source -> float.
+; CHECK: %[[#StoF]] = OpFunction
+; CHECK: OpConvertSToF
+define spir_func void @s_to_f(i32 noundef %x) {
+  call spir_func float @_Z13convert_floati(i32 noundef %x)
+  ret void
+}
+
+; unsigned source -> float.
+; CHECK: %[[#UtoF]] = OpFunction
+; CHECK: OpConvertUToF
+define spir_func void @u_to_f(i32 noundef %x) {
+  call spir_func float @_Z13convert_floatj(i32 noundef %x)
+  ret void
+}
+
+declare spir_func i64 @_Z12convert_longi(i32 noundef)
+declare spir_func i64 @_Z13convert_ulongi(i32 noundef)
+declare spir_func i64 @_Z12convert_longj(i32 noundef)
+declare spir_func i64 @_Z13convert_ulongj(i32 noundef)
+declare spir_func float @_Z13convert_floati(i32 noundef)
+declare spir_func float @_Z13convert_floatj(i32 noundef)


### PR DESCRIPTION
OpSConvert/OpUConvert sext/zext is determined by the source operand, not the destination type. Discovered in https://github.com/llvm/llvm-project/pull/200791/changes#r3341230426

Fix a regression caused by #200791