### PR TITLE
[OpenMP][OMPT] Add ompt_set_frame_enter support to libomptarget

### DIFF
--- a/openmp/runtime/src/ompt-general.cpp
+++ b/openmp/runtime/src/ompt-general.cpp
@@ -892,6 +892,10 @@ static ompt_data_t *ompt_get_target_task_data() {
   return __ompt_get_target_task_data();
 }
 
+static int ompt_set_frame_enter(void *addr, int flags, int state) {
+  return __ompt_set_frame_enter_internal(addr, flags, state);
+}
+
 /// Lookup function to query libomp callbacks registered by the tool
 static ompt_interface_fn_t ompt_libomp_target_fn_lookup(const char *s) {
 #define provide_fn(fn)                                                         \
@@ -901,6 +905,7 @@ static ompt_interface_fn_t ompt_libomp_target_fn_lookup(const char *s) {
   provide_fn(ompt_get_callback);
   provide_fn(ompt_get_task_data);
   provide_fn(ompt_get_target_task_data);
+  provide_fn(ompt_set_frame_enter);
 #undef provide_fn
 
 #define ompt_interface_fn(fn, type, code)                                      \

--- a/openmp/runtime/src/ompt-internal.h
+++ b/openmp/runtime/src/ompt-internal.h
@@ -24,6 +24,12 @@
   ((x == fork_context_gnu) ? ompt_parallel_invoker_program                     \
                            : ompt_parallel_invoker_runtime)
 
+#define OMPT_FRAME_SET(frame, which, ptr_value, flags)                         \
+  {                                                                            \
+    frame->which##_frame.ptr = ptr_value;                                      \
+    frame->which##_frame_flags = flags;                                        \
+  }
+
 #define ompt_callback(e) e##_callback
 
 typedef struct ompt_callbacks_internal_s {

--- a/openmp/runtime/src/ompt-specific.cpp
+++ b/openmp/runtime/src/ompt-specific.cpp
@@ -482,6 +482,21 @@ int __ompt_get_task_memory_internal(void **addr, size_t *size, int blocknum) {
 }
 
 //----------------------------------------------------------
+// target region support
+//----------------------------------------------------------
+
+int __ompt_set_frame_enter_internal(void *addr, int flags, int state) {
+  int gtid = __kmp_entry_gtid();
+  kmp_info_t *thr = __kmp_threads[gtid];
+
+  ompt_frame_t *ompt_frame = &OMPT_CUR_TASK_INFO(thr)->frame;
+  OMPT_FRAME_SET(ompt_frame, enter, addr, flags);
+  int old_state = thr->th.ompt_thread_info.state;
+  thr->th.ompt_thread_info.state = ompt_state_work_parallel;
+  return old_state;
+}
+
+//----------------------------------------------------------
 // team support
 //----------------------------------------------------------
 

--- a/openmp/runtime/src/ompt-specific.h
+++ b/openmp/runtime/src/ompt-specific.h
@@ -24,6 +24,8 @@
 /// done already
 void __ompt_force_initialization();
 
+int __ompt_set_frame_enter_internal(void *addr, int flags, int state);
+
 void __ompt_team_assign_id(kmp_team_t *team, ompt_data_t ompt_pid);
 void __ompt_thread_assign_wait_id(void *variable);
 


### PR DESCRIPTION
The first patch to upstream OMPT device tracing for OpenMP offloading. Used to store the host task frame of the offloading context.

Port of the AMD downstream implementation.
AI assisted.