### PR TITLE
[mlir][SCF] Allow breaking exit from `scf.execute_region`

### DIFF
--- a/mlir/docs/LangRef.md
+++ b/mlir/docs/LangRef.md
@@ -515,13 +515,16 @@ However, when control flow enters a region, it always begins in the first block
 of the region, called the *entry* block. Terminator operations ending each block
 represent control flow by explicitly specifying the successor blocks of the
 block. Control flow can only pass to one of the specified successor blocks as in
-a `branch` operation, or back to the containing operation as in a `return`
+a `branch` operation, or back to an enclosing operation as in a `return`
 operation. Terminator operations without successors can only pass control back
-to the containing operation. Within these restrictions, the particular semantics
-of terminator operations is determined by the specific dialect operations
-involved. Blocks (other than the entry block) that are not listed as a successor
-of a terminator operation are defined to be unreachable and can be removed
-without affecting the semantics of the containing operation.
+to an enclosing operation. By default, control returns to the *immediately*
+containing operation, but a terminator may also pass control further out by
+referring to an outer enclosing operation; see the [region-breaking
+terminator](#region-breaking-terminators) section. Within these restrictions,
+the particular semantics of terminator operations is determined by the specific
+dialect operations involved. Blocks (other than the entry block) that are not
+listed as a successor of a terminator operation are defined to be unreachable
+and can be removed without affecting the semantics of the containing operation.
 
 Although control flow always enters a region through the entry block, control
 flow may exit a region through any block with an appropriate terminator. The
@@ -557,6 +560,18 @@ func.func @accelerator_compute(i64, i1) -> i64 { // An SSACFG region
   ...
 }
 ```
+
+#### Region-Breaking Terminators
+
+A region-breaking terminator is a terminator that passes control back to an
+enclosing operation other than its immediately containing one. It typically
+identifie its destination through a [token](#token-type) operand, where the
+token is an entry block argument of the enclosing operation that the terminator
+transfers control to.
+
+Any operation on the path from a region-breaking terminator to the operation it
+transfers control to (excluding the target operation itself) must carry the
+`PropagateControlFlowBreak` trait.
 
 #### Operations with Multiple Regions
 

--- a/mlir/include/mlir/Analysis/DataFlow/DeadCodeAnalysis.h
+++ b/mlir/include/mlir/Analysis/DataFlow/DeadCodeAnalysis.h
@@ -203,8 +203,10 @@ private:
 
   /// Visit region branch edges from `predecessorOp` to a list of successors.
   /// For each edge, mark the successor program point as executable, and record
-  /// the predecessor information in its `PredecessorState`.
-  void visitRegionBranchEdges(RegionBranchOpInterface regionBranchOp,
+  /// the predecessor information in its `PredecessorState`. Region and "parent"
+  /// successors belong to `defaultBranchOp`; an early-exit successor names its
+  /// own (ancestor) owning op.
+  void visitRegionBranchEdges(Operation *defaultBranchOp,
                               Operation *predecessorOp,
                               const SmallVector<RegionSuccessor> &successors);
 
@@ -216,7 +218,7 @@ private:
   /// Visit the given terminator operation that exits a region under an
   /// operation with control-flow semantics. These are terminators with no CFG
   /// successors.
-  void visitRegionTerminator(Operation *op, RegionBranchOpInterface branch);
+  void visitRegionTerminator(RegionBranchTerminatorOpInterface terminator);
 
   /// Visit the given terminator operation that exits a callable region. These
   /// are terminators with no CFG successors.

--- a/mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h
+++ b/mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h
@@ -484,12 +484,12 @@ private:
                              ArrayRef<AbstractSparseLattice *> operands);
 
   /// Visit a `RegionBranchTerminatorOpInterface` to compute the lattice values
-  /// of its operands, given its parent op `branch`. The lattice value of an
-  /// operand is determined based on the corresponding arguments in
-  /// `terminator`'s region successor(s).
+  /// of its operands. The lattice value of an operand is determined based on
+  /// the corresponding successor inputs in `terminator`'s region successor(s);
+  /// the owning op of each successor is the terminator's enclosing op, or (for
+  /// an early-exit successor) the ancestor it names.
   void visitRegionSuccessorsFromTerminator(
-      RegionBranchTerminatorOpInterface terminator,
-      RegionBranchOpInterface branch);
+      RegionBranchTerminatorOpInterface terminator);
 
   /// Get the lattice element for a value, and also set up
   /// dependencies so that the analysis on the given ProgramPoint is re-invoked

--- a/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
+++ b/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
@@ -78,21 +78,36 @@ def ConditionOp : SCF_Op<"condition", [
 //===----------------------------------------------------------------------===//
 
 def ExecuteRegionOp : SCF_Op<"execute_region", [
-    DeclareOpInterfaceMethods<RegionBranchOpInterface, ["getSuccessorInputs"]>,
+    DeclareOpInterfaceMethods<RegionBranchOpInterface,
+        ["getSuccessorInputs", "getRegionBranchPointTerminators"]>,
     DeclareOpInterfaceMethods<PromotableRegionOpInterface>,
-    RecursiveMemoryEffects]> {
+    PropagateControlFlowBreak,
+    RecursiveMemoryEffects,
+    TokenProducerTrait]> {
   let summary = "operation that executes its region exactly once";
   let description = [{
     The `scf.execute_region` operation is used to allow multiple blocks within SCF
     and other operations which can hold only one block.  The `scf.execute_region`
     operation executes the region held exactly once and cannot have any operands.
-    As such, its region has no arguments. All SSA values that dominate the op can
-    be accessed inside the op. The op's region can have multiple blocks and the
-    blocks can have multiple distinct terminators. Values returned from this op's
-    region define the op's results.
+    All SSA values that dominate the op can be accessed inside the op. The op's
+    region can have multiple blocks and the blocks can have multiple distinct
+    terminators. Values returned from this op's region define the op's results.
+
+    The entry block of the region may optionally have a single block argument
+    of `token` type, which identifies this `scf.execute_region` op. This token
+    can be used by `scf.break` ops nested in the region (possibly through other
+    operations that carry the `PropagateControlFlowBreak` trait) to perform an
+    early exit, transferring control directly back to this `scf.execute_region`
+    and providing its result values.
+
     The optional 'no_inline' flag can be set to request the ExecuteRegionOp to be
     preserved as much as possible and not being inlined in the parent block until
     an explicit lowering step.
+
+    Control returns to this operation either via an `scf.yield` terminator of
+    one of its own blocks, or by an early exit via an `scf.break` that targets
+    this op. In both cases, the terminator's operand types must match this
+    operation's result types.
 
     Example:
 
@@ -130,6 +145,17 @@ def ExecuteRegionOp : SCF_Op<"execute_region", [
       }
       "bar"(%v) : (i64) -> ()
     }
+
+    // Early exit using the entry block token.
+    %a = scf.execute_region -> f32 {
+    ^bb0(%tok: token):
+      %0 = "some.compute"() : () -> (i1)
+      scf.if %0 {
+        scf.break %tok, %val1 : f32
+      }
+      %1 = "some.compute"() : () -> (f32)
+      scf.yield %1 : f32
+    }
     ```
   }];
 
@@ -141,8 +167,69 @@ def ExecuteRegionOp : SCF_Op<"execute_region", [
 
   let regions = (region AnyRegion:$region);
 
+  let extraClassDeclaration = [{
+    /// Returns the token entry block argument that identifies this op for
+    /// region-breaking terminators, or a null Value if the entry block has no
+    /// token argument.
+    ::mlir::Value getToken();
+  }];
+
   let hasCanonicalizer = 1;
   let hasCustomAssemblyFormat = 1;
+
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// BreakOp
+//===----------------------------------------------------------------------===//
+
+def BreakOp : SCF_Op<"break", [
+    Terminator, TokenConsumerTrait,
+    DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface,
+        ["getMutableSuccessorOperands", "getSuccessorRegions"]>
+  ]> {
+  let summary = "early exit from a region-bearing op identified by a token";
+  let description = [{
+    The `scf.break` operation is a region-breaking terminator that terminates
+    the enclosing op identified by its `token` operand. The operands become
+    the target op's result values; their types must match the result types of
+    the target op.
+
+    `scf.break` may appear as the terminator of any block nested inside the
+    target op, as long as every operation on the path between this `scf.break`
+    and the target op carries the `PropagateControlFlowBreak` op trait.
+
+    Example:
+
+    ```mlir
+    %a = scf.execute_region -> f32 {
+    ^bb0(%tok: token):
+      %0 = "some.compute"() : () -> (i1)
+      scf.if %0 {
+        scf.break %tok, %val1 : f32
+      }
+      %1 = "some.compute"() : () -> (f32)
+      scf.yield %1 : f32
+    }
+    ```
+  }];
+
+  let arguments = (ins Token:$token, Variadic<AnyType>:$values);
+  let builders = [OpBuilder<(ins "::mlir::Value":$token), [{
+      $_state.addOperands(token);
+    }]>];
+
+  let assemblyFormat = [{
+    $token (`,` $values^ `:` type($values))? attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    /// Returns the `scf.execute_region` op that this `scf.break` transfers
+    /// control to (the op that owns the entry block argument used as the token
+    /// operand).
+    ::mlir::Operation *getTarget();
+  }];
 
   let hasVerifier = 1;
 }
@@ -706,7 +793,7 @@ def IfOp : SCF_Op<"if", [DeclareOpInterfaceMethods<RegionBranchOpInterface, [
     "getNumRegionInvocations", "getRegionInvocationBounds",
     "getEntrySuccessorRegions", "getSuccessorInputs"]>,
     DeclareOpInterfaceMethods<PromotableRegionOpInterface>,
-    InferTypeOpAdaptor, SingleBlockImplicitTerminator<"scf::YieldOp">,
+    PropagateControlFlowBreak, SingleBlock,
     RecursiveMemoryEffects, RecursivelySpeculatable, NoRegionArguments]> {
   let summary = "if-then-else operation";
   let description = [{
@@ -743,9 +830,16 @@ def IfOp : SCF_Op<"if", [DeclareOpInterfaceMethods<RegionBranchOpInterface, [
     block. In case the `scf.if` produces results, the "else" region must also
     have exactly 1 block.
 
-    The blocks are always terminated with `scf.yield`. If `scf.if` defines no
+    The blocks are normally terminated with `scf.yield`. If `scf.if` defines no
     values, the `scf.yield` can be left out, and will be inserted implicitly.
-    Otherwise, it must be explicit.
+    Otherwise, it must be explicit. The types of the yielded values must match
+    the result types of the `scf.if`.
+
+    A region of an `scf.if` can also be terminated with an `scf.break`. In that
+    case, it transfers the control flow to the targeted enclosing op (e.g.,
+    an `scf.execute_region`). Mixing yield and break terminators across the two
+    regions is allowed, but if `scf.if` produces results, the region that
+    reaches the join (i.e., does not break out) must yield matching values.
 
     Example:
 
@@ -754,9 +848,6 @@ def IfOp : SCF_Op<"if", [DeclareOpInterfaceMethods<RegionBranchOpInterface, [
       ...
     }
     ```
-
-    The types of the yielded values must match the result types of the
-    `scf.if`.
   }];
   let arguments = (ins I1:$condition);
   let results = (outs Variadic<AnyType>:$results);

--- a/mlir/include/mlir/Dialect/SCF/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/SCF/Transforms/Passes.h
@@ -64,6 +64,10 @@ std::unique_ptr<Pass> createParallelForToNestedForsPass();
 // Creates a pass which lowers for loops into while loops.
 std::unique_ptr<Pass> createForToWhileLoopPass();
 
+/// Creates a pass that lowers away region-breaking terminators (`scf.break`),
+/// producing an SCF program that uses only `scf.yield` terminators.
+std::unique_ptr<Pass> createSCFLowerEarlyExitPass();
+
 //===----------------------------------------------------------------------===//
 // Registration
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Dialect/SCF/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/SCF/Transforms/Passes.td
@@ -134,6 +134,23 @@ def SCFParallelForToNestedFors : Pass<"scf-parallel-for-to-nested-fors"> {
   }];
 }
 
+def SCFLowerEarlyExit : Pass<"scf-lower-early-exit"> {
+  let summary = "Lower `scf.break` region-breaking terminators";
+  let description = [{
+    Rewrites `scf.break` ops away so that the resulting IR uses only
+    `scf.yield` terminators. The transformation operates on SCF and produces
+    SCF: it threads the broken-out values (and a flag) through any
+    intermediate `scf.execute_region` / `scf.if` ops, replacing the break by
+    an equivalent dataflow that yields the same values to the target.
+
+    The pass leaves the IR in a form that contains no `scf.break` and no
+    token-bearing `scf.execute_region`. It does not change the externally
+    observable semantics of any op.
+  }];
+  let constructor = "mlir::createSCFLowerEarlyExitPass()";
+  let dependentDialects = ["arith::ArithDialect", "ub::UBDialect"];
+}
+
 def SCFForToWhileLoop : Pass<"scf-for-to-while"> {
   let summary = "Convert SCF for loops to SCF while loops";
   let constructor = "mlir::createForToWhileLoopPass()";

--- a/mlir/include/mlir/IR/OpBase.td
+++ b/mlir/include/mlir/IR/OpBase.td
@@ -102,6 +102,8 @@ def Terminator : NativeOpTrait<"IsTerminator">;
 def TokenProducerTrait : NativeOpTrait<"TokenProducerTrait">;
 // Op consumes builtin token values.
 def TokenConsumerTrait : NativeOpTrait<"TokenConsumerTrait">;
+// Op is transparent to region-breaking terminators.
+def PropagateControlFlowBreak : NativeOpTrait<"PropagateControlFlowBreak">;
 // Op can be safely normalized in the presence of MemRefs with
 // non-identity maps.
 def MemRefsNormalizable : NativeOpTrait<"MemRefsNormalizable">;

--- a/mlir/include/mlir/IR/OpDefinition.h
+++ b/mlir/include/mlir/IR/OpDefinition.h
@@ -790,6 +790,14 @@ template <typename ConcreteType>
 class TokenConsumerTrait : public TraitBase<ConcreteType, TokenConsumerTrait> {
 };
 
+/// This trait marks operations that are transparent to region-breaking
+/// terminators: a region-breaking terminator (i.e., a terminator that passes
+/// control to an enclosing operation) may appear as a terminator of any block
+/// within this op.
+template <typename ConcreteType>
+class PropagateControlFlowBreak
+    : public TraitBase<ConcreteType, PropagateControlFlowBreak> {};
+
 /// This class provides verification for ops that are known to have zero
 /// successors.
 template <typename ConcreteType>

--- a/mlir/include/mlir/Interfaces/ControlFlowInterfaces.h
+++ b/mlir/include/mlir/Interfaces/ControlFlowInterfaces.h
@@ -192,10 +192,18 @@ using RegionBranchSuccessorMapping = DenseMap<OpOperand *, SmallVector<Value>>;
 using RegionBranchInverseSuccessorMapping =
     DenseMap<Value, SmallVector<OpOperand *>>;
 
-/// This class represents a successor of a region. A region successor can either
-/// be another region, or the parent operation (i.e., the operation that
-/// implements the `RegionBranchOpInterface`). In the latter case, the control
-/// flow branches after/out of the region branch operation.
+/// This class represents a successor of a region. A region successor can be:
+///   1. Another region of the parent operation.
+///   2. The parent operation (i.e., the operation that implements the
+///      `RegionBranchOpInterface`). In this case, the control flow branches
+///      after/out of the region branch operation.
+///   3. An "early exit" to a non-immediate `RegionBranchOpInterface` ancestor.
+///      In this case, control leaves one or more enclosing operations and
+///      resumes after that ancestor, whose results receive the successor
+///      operands. This models region-breaking terminators (e.g. `scf.break`)
+///      that target an enclosing op which is not their immediate parent.
+/// TODO: "Parent" and "early exit" should be unified into a single API. Because
+/// that's a larger API change, we're going to do that in a separate commit.
 class RegionSuccessor {
 public:
   /// Initialize a successor that branches to a region of the parent operation.
@@ -206,18 +214,40 @@ public:
   /// Initialize a successor that branches after/out of the parent operation.
   static RegionSuccessor parent() { return RegionSuccessor(); }
 
-  /// Return the given region successor. Returns nullptr if the successor is the
-  /// parent operation.
-  Region *getSuccessor() const { return successor; }
-
-  /// Return true if the successor is the parent operation.
-  bool isParent() const { return successor == nullptr; }
-
-  bool operator==(RegionSuccessor rhs) const {
-    return successor == rhs.successor;
+  /// Initialize an "early exit" successor: control leaves one or more enclosing
+  /// operations and resumes after `exitTarget`, whose results receive the
+  /// successor operands. `exitTarget` is a `RegionBranchOpInterface` ancestor
+  /// that is not necessarily the immediate parent of the branch point.
+  static RegionSuccessor exitingTo(Operation *exitTarget) {
+    assert(exitTarget && "exit target must not be null");
+    RegionSuccessor successor;
+    successor.exitTarget = exitTarget;
+    return successor;
   }
 
-  bool operator==(const Region *region) const { return successor == region; }
+  /// Return the given region successor. Returns nullptr if the successor is the
+  /// parent operation or an early exit.
+  Region *getSuccessor() const { return successor; }
+
+  /// Return the ancestor operation that control exits to for an early-exit
+  /// successor. Returns nullptr otherwise.
+  Operation *getSuccessorOp() const { return exitTarget; }
+
+  /// Return true if the successor is the (immediate) parent operation.
+  bool isParent() const {
+    return successor == nullptr && exitTarget == nullptr;
+  }
+
+  /// Return true if the successor is an early exit to a non-immediate ancestor.
+  bool isEarlyExit() const { return exitTarget != nullptr; }
+
+  bool operator==(RegionSuccessor rhs) const {
+    return successor == rhs.successor && exitTarget == rhs.exitTarget;
+  }
+
+  bool operator==(const Region *region) const {
+    return successor == region && exitTarget == nullptr;
+  }
 
   friend bool operator!=(RegionSuccessor lhs, RegionSuccessor rhs) {
     return !(lhs == rhs);
@@ -227,15 +257,22 @@ private:
   /// Private constructor to encourage the use of `RegionSuccessor::parent`.
   RegionSuccessor() : successor(nullptr) {}
 
+  /// The successor region, or null for "parent"/early-exit successors.
   Region *successor = nullptr;
+  /// For early-exit successors: the ancestor op control resumes after. Null
+  /// otherwise.
+  Operation *exitTarget = nullptr;
 };
 
 /// This class represents a point being branched from in the methods of the
 /// `RegionBranchOpInterface`.
 /// One can branch from one of two kinds of places:
 /// * The parent operation (aka the `RegionBranchOpInterface` implementation)
-/// * A RegionBranchTerminatorOpInterface inside a region within the parent
-//    operation.
+/// * A RegionBranchTerminatorOpInterface nested within the parent operation.
+///   This terminator is usually an immediately nested block terminator, but for
+///   region-breaking terminators (early exit) it may be nested deeper, with
+///   transparent ops (carrying the `PropagateControlFlowBreak` trait) in
+///   between.
 class RegionBranchPoint {
 public:
   /// Returns an instance of `RegionBranchPoint` representing the parent
@@ -425,6 +462,11 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                                      RegionSuccessor successor) {
   if (successor.isParent())
     return os << "<to parent>";
+  if (successor.isEarlyExit())
+    return os << "<early exit to "
+              << OpWithFlags(successor.getSuccessorOp(),
+                             OpPrintingFlags().skipRegions())
+              << ">";
   return os << "<to region #" << successor.getSuccessor()->getRegionNumber()
             << ">";
 }

--- a/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
+++ b/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
@@ -127,8 +127,10 @@ def RegionBranchOpInterface : OpInterface<"RegionBranchOpInterface"> {
 
     A "region branch point" indicates a point from which a branch originates. It
     can indicate:
-    1. A `RegionBranchTerminatorOpInterface` terminator in any of the
-       immediately nested regions of this op.
+    1. A `RegionBranchTerminatorOpInterface` terminator, nested within a region
+       of this op, that transfers control to this op. (Region branch terminators
+       that transfer control to another op are not region branch points of this
+       op.)
     2. `RegionBranchPoint::parent()`: the branch originates from outside of the
        op, i.e., when first executing this op.
 
@@ -150,13 +152,13 @@ def RegionBranchOpInterface : OpInterface<"RegionBranchOpInterface"> {
 
 
     Note: This interface works in conjunction with
-    `RegionBranchTerminatorOpInterface`. All immediately nested block
-    terminators that model branching between regions must implement the
-    `RegionBranchTerminatorOpInterface`. Otherwise, analyses/transformations
-    may miss control flow edges and produce incorrect results. Not every block
-    terminator is necessarily a region branch terminator: e.g., in the presence
-    of unstructured control flow, a block terminator could indicate a branch to
-    a different block within the same region.
+    `RegionBranchTerminatorOpInterface`. All terminators that model branching
+    between regions must implement the `RegionBranchTerminatorOpInterface`.
+    Otherwise, analyses/transformations may miss control flow edges and produce
+    incorrect results. Not every block terminator is necessarily a region branch
+    terminator: e.g., in the presence of unstructured control flow, a block
+    terminator could indicate a branch to a different block within the same
+    region.
 
     Example:
 
@@ -231,8 +233,16 @@ def RegionBranchOpInterface : OpInterface<"RegionBranchOpInterface"> {
 
         When `point = RegionBranchPoint::parent()`, this method returns the
         region successors when entering the operation. Otherwise, this method
-        returns the successor regions when branching from the region indicated
-        by `point`.
+        returns the successor regions when branching from the terminator
+        indicated by `point`.
+
+        A non-parent `point` is always a terminator that transfers control back
+        to this op (one returned by `getRegionBranchPointTerminators`); this
+        method enumerates only the edges this op owns. A region-breaking
+        terminator nested within this op but targeting a *further-enclosing* op
+        is not a branch point of this op and is enumerated by that ancestor
+        instead; it must not be reported here (otherwise the edge would be
+        counted twice).
 
         Example: In the above example, this method returns the region of the
         `scf.for` and `parent` for either region branch point. An implementation
@@ -245,6 +255,31 @@ def RegionBranchOpInterface : OpInterface<"RegionBranchOpInterface"> {
            "::llvm::SmallVectorImpl<::mlir::RegionSuccessor> &":$regions)
     >,
     InterfaceMethod<[{
+        Populate `terminators` with the `RegionBranchTerminatorOpInterface`
+        terminators in `region` that transfer control to this op, i.e. this op's
+        non-parent region branch points originating from `region`.
+
+        The default implementation returns the terminator of each (non-empty)
+        block in `region`. Operations that can be the target of region-breaking
+        terminators (early exit) nested deeper than `region`'s blocks should
+        override this to also include those terminators (e.g. by inspecting the
+        users of an identifying token).
+      }],
+      "void", "getRegionBranchPointTerminators",
+      (ins "::mlir::Region &":$region,
+           "::llvm::SmallVectorImpl<::mlir::RegionBranchTerminatorOpInterface> &"
+             :$terminators),
+      [{}],
+      /*defaultImplementation=*/[{
+        for (::mlir::Block &block : region) {
+          if (block.empty())
+            continue;
+          if (auto terminator =
+                  dyn_cast<RegionBranchTerminatorOpInterface>(block.back()))
+            terminators.push_back(terminator);
+        }
+      }]>,
+    InterfaceMethod<[{
         Returns the potential region successors when branching from any
         terminator in `region`.
       }],
@@ -253,14 +288,14 @@ def RegionBranchOpInterface : OpInterface<"RegionBranchOpInterface"> {
            "::llvm::SmallVectorImpl<::mlir::RegionSuccessor> &":$regions),
       [{}],
       /*defaultImplementation=*/[{
-        for (::mlir::Block &block : region) {
-          if (block.empty())
-            continue;
-          if (auto terminator =
-                  dyn_cast<RegionBranchTerminatorOpInterface>(block.back()))
-            $_op.getSuccessorRegions(RegionBranchPoint(terminator),
-                                     regions);
-        }
+        // Dispatch to the per-branch-point overload for each region branch
+        // point terminator originating from `region`.
+        ::llvm::SmallVector<::mlir::RegionBranchTerminatorOpInterface>
+            terminators;
+        $_op.getRegionBranchPointTerminators(region, terminators);
+        for (::mlir::RegionBranchTerminatorOpInterface terminator : terminators)
+          $_op.getSuccessorRegions(::mlir::RegionBranchPoint(terminator),
+                                   regions);
       }]>,
     InterfaceMethod<[{
         Return all successor inputs for the given region successor. If the
@@ -289,8 +324,7 @@ def RegionBranchOpInterface : OpInterface<"RegionBranchOpInterface"> {
           ::llvm::SmallVector<::mlir::RegionSuccessor> successors;
           op.getSuccessorRegions(point, successors);
           bool isPred = llvm::any_of(successors, [&] (const auto &succ) {
-            return succ.getSuccessor() == successor.getSuccessor() ||
-                   (succ.isParent() && successor.isParent());
+            return succ == successor;
             });
           if (isPred)
             predecessors.push_back(point);
@@ -417,6 +451,15 @@ def RegionBranchTerminatorOpInterface :
     in the presence of a parent `RegionBranchOpInterface` implementation. It
     acts as a marker for valid region branch points and specifies which
     operands are passed to which region successor.
+
+    `getSuccessorRegions` fully describes where control may transfer: each
+    `RegionSuccessor` is a region, the immediately enclosing op ("parent"), or
+    (for region-breaking terminators / early exit) a non-immediate
+    `RegionBranchOpInterface` ancestor whose results receive the successor
+    operands. A single terminator may have several such successors, possibly
+    targeting different ancestors. Every operation on the path from a
+    region-breaking terminator up to a targeted ancestor must be transparent to
+    region-breaking control flow (carry the `PropagateControlFlowBreak` trait).
 
     Note: If an operation does not implement the
     `RegionBranchTerminatorOpInterface`, then that op has no region successors.

--- a/mlir/lib/Analysis/DataFlow/DeadCodeAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/DeadCodeAnalysis.cpp
@@ -374,11 +374,15 @@ LogicalResult DeadCodeAnalysis::visit(ProgramPoint *point) {
   }
 
   if (isRegionOrCallableReturn(op)) {
-    if (auto branch = dyn_cast<RegionBranchOpInterface>(op->getParentOp())) {
+    auto terminator = dyn_cast<RegionBranchTerminatorOpInterface>(op);
+    if (terminator && isa<RegionBranchOpInterface>(op->getParentOp())) {
       LDBG() << "Visiting region terminator: "
              << OpWithFlags(op, OpPrintingFlags().skipRegions());
-      // Visit the exiting terminator of a region.
-      visitRegionTerminator(op, branch);
+      // Visit the exiting terminator of a region. The owning op of each edge is
+      // derived per region successor (it may be a non-immediate ancestor for an
+      // early-exit terminator). A region terminator that does not implement the
+      // interface has no region successors and is skipped.
+      visitRegionTerminator(terminator);
     } else if (auto callable =
                    dyn_cast<CallableOpInterface>(op->getParentOp())) {
       LDBG() << "Visiting callable terminator: "
@@ -499,48 +503,54 @@ void DeadCodeAnalysis::visitRegionBranchOperation(
   SmallVector<RegionSuccessor> successors;
   branch.getEntrySuccessorRegions(*operands, successors);
 
-  visitRegionBranchEdges(branch, branch.getOperation(), successors);
+  // When entering the op, regions/parent successors all belong to `branch`.
+  visitRegionBranchEdges(branch.getOperation(), branch.getOperation(),
+                         successors);
 }
 
-void DeadCodeAnalysis::visitRegionTerminator(Operation *op,
-                                             RegionBranchOpInterface branch) {
-  LDBG() << "visitRegionTerminator: " << *op;
-  std::optional<SmallVector<Attribute>> operands = getOperandValues(op);
+void DeadCodeAnalysis::visitRegionTerminator(
+    RegionBranchTerminatorOpInterface terminator) {
+  LDBG() << "visitRegionTerminator: " << *terminator;
+  std::optional<SmallVector<Attribute>> operands = getOperandValues(terminator);
   if (!operands)
     return;
 
   SmallVector<RegionSuccessor> successors;
-  auto terminator = dyn_cast<RegionBranchTerminatorOpInterface>(op);
-  if (!terminator)
-    return;
   terminator.getSuccessorRegions(*operands, successors);
-  visitRegionBranchEdges(branch, op, successors);
+  // Region/parent successors belong to the terminator's immediately enclosing
+  // op; early-exit successors carry their own (ancestor) target.
+  visitRegionBranchEdges(terminator->getParentOp(), terminator, successors);
 }
 
 void DeadCodeAnalysis::visitRegionBranchEdges(
-    RegionBranchOpInterface regionBranchOp, Operation *predecessorOp,
+    Operation *defaultBranchOp, Operation *predecessorOp,
     const SmallVector<RegionSuccessor> &successors) {
   for (const RegionSuccessor &successor : successors) {
-    // The successor can be either an entry block or the parent operation.
+    // Determine the op that owns this edge: an early-exit successor names a
+    // (possibly non-immediate) ancestor; every other successor (a region or
+    // "parent") belongs to `defaultBranchOp`. Control "leaving the op" resumes
+    // after that owning op.
+    Operation *ownerOp =
+        successor.isEarlyExit() ? successor.getSuccessorOp() : defaultBranchOp;
+    bool leavesOp = successor.isParent() || successor.isEarlyExit();
     // Skip empty regions — they have no entry block to mark executable.
-    if (!successor.isParent() && successor.getSuccessor()->empty())
+    if (!leavesOp && successor.getSuccessor()->empty())
       continue;
     ProgramPoint *point =
-        successor.isParent()
-            ? getProgramPointAfter(regionBranchOp)
-            : getProgramPointBefore(&successor.getSuccessor()->front());
+        leavesOp ? getProgramPointAfter(ownerOp)
+                 : getProgramPointBefore(&successor.getSuccessor()->front());
 
     // Mark the entry block as executable.
     auto *state = getOrCreate<Executable>(point);
     propagateIfChanged(state, state->setToLive());
     LDBG() << "Marked region successor live: " << *point;
 
-    // Add the parent op as a predecessor.
+    // Add the predecessor, forwarding the owning op's successor inputs.
+    auto branch = cast<RegionBranchOpInterface>(ownerOp);
     auto *predecessors = getOrCreate<PredecessorState>(point);
     propagateIfChanged(
-        predecessors,
-        predecessors->join(predecessorOp,
-                           regionBranchOp.getSuccessorInputs(successor)));
+        predecessors, predecessors->join(predecessorOp,
+                                         branch.getSuccessorInputs(successor)));
     LDBG() << "Added region branch as predecessor for successor: " << *point;
   }
 }

--- a/mlir/lib/Analysis/DataFlow/DenseAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/DenseAnalysis.cpp
@@ -318,9 +318,17 @@ void AbstractDenseForwardDataFlowAnalysis::visitRegionBranchOperation(
     //   before the parent.
     // In the latter case, just perform the join as it isn't the control flow
     // affected by the region.
-    std::optional<unsigned> regionFrom =
-        op == branch ? std::optional<unsigned>()
-                     : op->getBlock()->getParent()->getRegionNumber();
+    // Determine the region of `branch` that (transitively, in the case of an
+    // early exit) contains `op`. This is `std::nullopt` if `op` is the branch
+    // op itself or is not nested in any region of `branch`.
+    std::optional<unsigned> regionFrom;
+    if (op != branch.getOperation()) {
+      Region *region = op->getParentRegion();
+      while (region && region->getParentOp() != branch.getOperation())
+        region = region->getParentOp()->getParentRegion();
+      if (region)
+        regionFrom = region->getRegionNumber();
+    }
     LDBG() << "      regionFrom: "
            << (regionFrom ? std::to_string(*regionFrom) : "parent");
 
@@ -336,9 +344,10 @@ void AbstractDenseForwardDataFlowAnalysis::visitRegionBranchOperation(
              "expected to be visiting the branch itself");
       LDBG() << "      Point is not block start, checking if predecessor is "
                 "region or op itself";
-      // Only need to call the arc transfer when the predecessor is the region
-      // or the op itself, not the previous op.
-      if (op->getParentOp() == branch || op == branch) {
+      // Only need to call the arc transfer when the predecessor is one of the
+      // branch op's region terminators (possibly via an early exit) or the op
+      // itself, not the previous op.
+      if (regionFrom.has_value() || op == branch.getOperation()) {
         LDBG() << "      Predecessor is region or op itself, calling "
                   "visitRegionBranchControlFlowTransfer";
         visitRegionBranchControlFlowTransfer(
@@ -586,13 +595,19 @@ void AbstractDenseBackwardDataFlowAnalysis::visitBlock(Block *block) {
     }
 
     // If this block is exiting from an operation with region-based control
-    // flow, propagate the lattice back along the control flow edge.
-    if (auto branch = dyn_cast<RegionBranchOpInterface>(block->getParentOp())) {
-      LDBG() << "    Exit block of region branch operation";
-      auto terminator =
-          cast<RegionBranchTerminatorOpInterface>(block->getTerminator());
-      visitRegionBranchOperation(point, branch, terminator, before);
-      return;
+    // flow, propagate the lattice back along the control flow edge. The
+    // terminator's successors (including any early-exit ancestors) are derived
+    // per successor inside `visitRegionBranchOperation`; the immediately
+    // enclosing op is passed as the default branch op.
+    if (auto terminator =
+            dyn_cast_if_present<RegionBranchTerminatorOpInterface>(
+                block->empty() ? nullptr : &block->back())) {
+      if (auto branch = dyn_cast_or_null<RegionBranchOpInterface>(
+              terminator->getParentOp())) {
+        LDBG() << "    Exit block of region branch operation";
+        visitRegionBranchOperation(point, branch, terminator, before);
+        return;
+      }
     }
 
     // Cannot reason about successors of an exit block, set the pessimistic
@@ -629,17 +644,30 @@ void AbstractDenseBackwardDataFlowAnalysis::visitRegionBranchOperation(
   LDBG() << "  branchPoint: " << (branchPoint.isParent() ? "parent" : "region");
   LDBG() << "  before state: " << *before;
 
-  // The successors of the operation may be either the first operation of the
-  // entry block of each possible successor region, or the next operation when
-  // the branch is a successor of itself.
+  // Gather successors. When branching from a terminator, take them from the
+  // terminator itself so early-exit (and multi-target) successors are included;
+  // when entering the op, take them from the op. `branch` is the default owning
+  // op for region/"parent" successors.
   SmallVector<RegionSuccessor> successors;
-  branch.getSuccessorRegions(branchPoint, successors);
+  if (RegionBranchTerminatorOpInterface terminator =
+          branchPoint.getTerminatorPredecessorOrNull()) {
+    SmallVector<Attribute> constants(terminator->getNumOperands(), nullptr);
+    terminator.getSuccessorRegions(constants, successors);
+  } else {
+    branch.getSuccessorRegions(branchPoint, successors);
+  }
   LDBG() << "  Processing " << successors.size() << " successor regions";
   for (const RegionSuccessor &successor : successors) {
+    // The owning op of an early-exit successor is the (possibly non-immediate)
+    // ancestor it names; any other successor belongs to `branch`.
+    auto owner = successor.isEarlyExit()
+                     ? cast<RegionBranchOpInterface>(successor.getSuccessorOp())
+                     : branch;
     const AbstractDenseLattice *after;
-    if (successor.isParent() || successor.getSuccessor()->empty()) {
-      LDBG() << "    Successor is parent or empty region";
-      after = getLatticeFor(point, getProgramPointAfter(branch));
+    if (successor.isParent() || successor.isEarlyExit() ||
+        successor.getSuccessor()->empty()) {
+      LDBG() << "    Successor is parent, early exit, or empty region";
+      after = getLatticeFor(point, getProgramPointAfter(owner));
     } else {
       Region *successorRegion = successor.getSuccessor();
       assert(!successorRegion->empty() && "unexpected empty successor region");
@@ -658,7 +686,7 @@ void AbstractDenseBackwardDataFlowAnalysis::visitRegionBranchOperation(
     }
     LDBG() << "    After state: " << *after;
 
-    visitRegionBranchControlFlowTransfer(branch, branchPoint, successor, *after,
+    visitRegionBranchControlFlowTransfer(owner, branchPoint, successor, *after,
                                          before);
   }
 }

--- a/mlir/lib/Analysis/DataFlow/LivenessAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/LivenessAnalysis.cpp
@@ -140,7 +140,10 @@ void LivenessAnalysis::visitBranchOperand(OpOperand &operand) {
   // check).
   // 3. RegionBranchOpTerminatorInterface, the operand is live if the
   // surrounding RegionBranchOp is live, so we call visitOperation on the
-  // surrounding op, but with the operand that we are looking at.
+  // surrounding op, but with the operand that we are looking at. (This is a
+  // non-forwarded operand, e.g. a token; forwarded operands are handled by
+  // visitRegionSuccessorsFromTerminator, which resolves early-exit targets per
+  // successor.)
   auto *visitOp =
       isa<RegionBranchTerminatorOpInterface>(op) ? op->getParentOp() : op;
   Liveness *operandLiveness[] = {getLatticeElement(operand.get())};

--- a/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
@@ -557,8 +557,11 @@ AbstractSparseBackwardDataFlowAnalysis::visitOperation(Operation *op) {
   // this op.
   if (auto terminator = dyn_cast<RegionBranchTerminatorOpInterface>(op)) {
     LDBG() << "Processing RegionBranchTerminatorOpInterface operation";
-    if (auto branch = dyn_cast<RegionBranchOpInterface>(op->getParentOp())) {
-      visitRegionSuccessorsFromTerminator(terminator, branch);
+    // This is a region branch terminator if its parent is a region branch op.
+    // (Its successors -- including any early-exit ancestors -- come from the
+    // terminator's own `getSuccessorRegions`.)
+    if (isa<RegionBranchOpInterface>(op->getParentOp())) {
+      visitRegionSuccessorsFromTerminator(terminator);
       return success();
     }
   }
@@ -638,23 +641,30 @@ void AbstractSparseBackwardDataFlowAnalysis::visitRegionSuccessors(
 
 void AbstractSparseBackwardDataFlowAnalysis::
     visitRegionSuccessorsFromTerminator(
-        RegionBranchTerminatorOpInterface terminator,
-        RegionBranchOpInterface branch) {
-  assert(terminator->getParentOp() == branch.getOperation() &&
-         "expected `branch` to be the parent op of `terminator`");
-
+        RegionBranchTerminatorOpInterface terminator) {
   // Not all operands are forwarded to a successor. This set can be
   // non-contiguous in the presence of multiple successors.
   BitVector unaccounted(terminator->getNumOperands(), true);
 
-  RegionBranchSuccessorMapping mapping;
-  branch.getSuccessorOperandInputMapping(mapping,
-                                         RegionBranchPoint(terminator));
-  for (const auto &[operand, inputs] : mapping) {
-    for (Value input : inputs) {
-      meet(getLatticeElement(operand->get()),
+  SmallVector<RegionSuccessor> successors;
+  SmallVector<Attribute> constantOperands(terminator->getNumOperands(),
+                                          nullptr);
+  terminator.getSuccessorRegions(constantOperands, successors);
+  for (const RegionSuccessor &successor : successors) {
+    // The op whose successor inputs the operands are forwarded to: an
+    // early-exit successor names its (possibly non-immediate) ancestor target;
+    // any other successor belongs to the terminator's immediately enclosing op.
+    Operation *ownerOp = successor.isEarlyExit() ? successor.getSuccessorOp()
+                                                 : terminator->getParentOp();
+    auto branch = cast<RegionBranchOpInterface>(ownerOp);
+    OperandRange operands = terminator.getSuccessorOperands(successor);
+    ValueRange inputs = branch.getSuccessorInputs(successor);
+    assert(operands.size() == inputs.size() &&
+           "expected the same number of successor operands and inputs");
+    for (auto [index, input] : llvm::enumerate(inputs)) {
+      meet(getLatticeElement(operands[index]),
            *getLatticeElementFor(getProgramPointAfter(terminator), input));
-      unaccounted.reset(operand->getOperandNumber());
+      unaccounted.reset(operands.getBeginOperandIndex() + index);
     }
   }
 

--- a/mlir/lib/Conversion/SCFToControlFlow/SCFToControlFlow.cpp
+++ b/mlir/lib/Conversion/SCFToControlFlow/SCFToControlFlow.cpp
@@ -402,6 +402,18 @@ LogicalResult IfLowering::matchAndRewrite(IfOp ifOp,
                                           PatternRewriter &rewriter) const {
   auto loc = ifOp.getLoc();
 
+  // Only `scf.if` ops whose regions terminate with `scf.yield` are supported.
+  // Region-breaking terminators (`scf.break`) are not yet handled by this
+  // lowering.
+  auto isYieldTerminated = [](Region &region) {
+    return region.empty() || isa<scf::YieldOp>(region.front().back());
+  };
+  if (!isYieldTerminated(ifOp.getThenRegion()) ||
+      !isYieldTerminated(ifOp.getElseRegion()))
+    return rewriter.notifyMatchFailure(
+        ifOp, "lowering of 'scf.if' with a non-'scf.yield' terminator is "
+              "not implemented yet");
+
   // Start by splitting the block containing the 'scf.if' into two parts.
   // The part before will contain the condition, the part after will be the
   // continuation point.
@@ -458,6 +470,14 @@ LogicalResult
 ExecuteRegionLowering::matchAndRewrite(ExecuteRegionOp op,
                                        PatternRewriter &rewriter) const {
   auto loc = op.getLoc();
+
+  // An `scf.execute_region` op with a token entry block argument may be the
+  // target of an `scf.break`. This lowering does not yet handle the resulting
+  // early exits; bail out so the conversion fails cleanly.
+  if (!op.getRegion().empty() && op.getRegion().front().getNumArguments() != 0)
+    return rewriter.notifyMatchFailure(
+        op, "lowering of 'scf.execute_region' with a token block argument "
+            "is not implemented yet");
 
   auto *condBlock = rewriter.getInsertionBlock();
   auto opPosition = rewriter.getInsertionPoint();

--- a/mlir/lib/Dialect/SCF/IR/SCF.cpp
+++ b/mlir/lib/Dialect/SCF/IR/SCF.cpp
@@ -143,6 +143,14 @@ std::optional<llvm::APSInt> mlir::scf::computeUbMinusLb(Value lb, Value ub,
 ///     return %idx : i32
 ///   }
 ///
+///   // Variant with a token entry block argument used to identify this op
+///   // for early exits via `scf.break`.
+///   scf.execute_region -> i32 {
+///   ^bb0(%tok: token):
+///     ...
+///     scf.yield %v : i32
+///   }
+///
 ParseResult ExecuteRegionOp::parse(OpAsmParser &parser,
                                    OperationState &result) {
   if (parser.parseOptionalArrowTypeList(result.types))
@@ -151,7 +159,8 @@ ParseResult ExecuteRegionOp::parse(OpAsmParser &parser,
   if (succeeded(parser.parseOptionalKeyword("no_inline")))
     result.addAttribute("no_inline", parser.getBuilder().getUnitAttr());
 
-  // Introduce the body region and parse it.
+  // Introduce the body region and parse it. The region's entry block may
+  // optionally have a single `token`-typed block argument.
   Region *body = result.addRegion();
   if (parser.parseRegion(*body, /*arguments=*/{}, /*argTypes=*/{}) ||
       parser.parseOptionalAttrDict(result.attributes))
@@ -165,8 +174,12 @@ void ExecuteRegionOp::print(OpAsmPrinter &p) {
   p << ' ';
   if (getNoInline())
     p << "no_inline ";
+  // If the entry block has a token argument, print entry block arguments so
+  // the operation round-trips.
+  bool printEntryBlockArgs =
+      !getRegion().empty() && getRegion().front().getNumArguments() != 0;
   p.printRegion(getRegion(),
-                /*printEntryBlockArgs=*/false,
+                /*printEntryBlockArgs=*/printEntryBlockArgs,
                 /*printBlockTerminators=*/true);
   p.printOptionalAttrDict((*this)->getAttrs(), /*elidedAttrs=*/{"no_inline"});
 }
@@ -174,9 +187,24 @@ void ExecuteRegionOp::print(OpAsmPrinter &p) {
 LogicalResult ExecuteRegionOp::verify() {
   if (getRegion().empty())
     return emitOpError("region needs to have at least one block");
-  if (getRegion().front().getNumArguments() > 0)
-    return emitOpError("region cannot have any arguments");
+  Block &entryBlock = getRegion().front();
+  // The entry block is allowed to have zero arguments, or exactly one `token`
+  // block argument that identifies this op for region-breaking terminators.
+  unsigned numArgs = entryBlock.getNumArguments();
+  if (numArgs > 1)
+    return emitOpError("entry block may only have zero or one block argument");
+  if (numArgs == 1 && !isa<TokenType>(entryBlock.getArgument(0).getType()))
+    return emitOpError("entry block argument must be of `token` type");
   return success();
+}
+
+Value ExecuteRegionOp::getToken() {
+  if (getRegion().empty())
+    return {};
+  Block &entry = getRegion().front();
+  if (entry.getNumArguments() == 0)
+    return {};
+  return entry.getArgument(0);
 }
 
 // Inline an ExecuteRegionOp if its parent can contain multiple blocks.
@@ -225,6 +253,10 @@ struct MultiBlockExecuteInliner : public OpRewritePattern<ExecuteRegionOp> {
       return failure();
     if (!isa<FunctionOpInterface, ExecuteRegionOp>(op->getParentOp()))
       return failure();
+    // An op with a token entry block argument may be the target of an
+    // `scf.break` and cannot simply be inlined.
+    if (op.getToken())
+      return failure();
 
     Block *prevBlock = op->getBlock();
     Block *postBlock = rewriter.splitBlock(prevBlock, op->getIterator());
@@ -257,11 +289,18 @@ void ExecuteRegionOp::getCanonicalizationPatterns(RewritePatternSet &results,
   results.add<MultiBlockExecuteInliner>(context);
   populateRegionBranchOpInterfaceCanonicalizationPatterns(
       results, ExecuteRegionOp::getOperationName());
-  // Inline ops with a single block that are not marked as "no_inline".
+  // Inline ops with a single block that are not marked as "no_inline" and
+  // that do not have a token entry block argument (which would be the target
+  // of an `scf.break`).
   populateRegionBranchOpInterfaceInliningPattern(
       results, ExecuteRegionOp::getOperationName(),
       mlir::detail::defaultReplBuilderFn, [](Operation *op) {
-        return failure(cast<ExecuteRegionOp>(op).getNoInline());
+        auto exec = cast<ExecuteRegionOp>(op);
+        if (exec.getNoInline())
+          return failure();
+        if (exec.getToken())
+          return failure();
+        return success();
       });
 }
 
@@ -273,13 +312,124 @@ void ExecuteRegionOp::getSuccessorRegions(
     return;
   }
 
-  // Otherwise, the region branches back to the parent operation.
-  regions.push_back(RegionSuccessor::parent());
+  RegionBranchTerminatorOpInterface terminator =
+      point.getTerminatorPredecessorOrNull();
+  if (!terminator)
+    return;
+  Operation *termOp = terminator.getOperation();
+
+  // Control returns to this op only from terminators it owns: a `scf.yield`
+  // directly in its region, or an `scf.break` that targets it (i.e. a user of
+  // its token, at any nesting depth). Terminators that pass *through* this op
+  // to a further-enclosing target (foreign breaks) are that ancestor's branch
+  // points, not this op's, so they are not enumerated here.
+  bool returnsHere =
+      isa<YieldOp>(termOp) && termOp->getParentOp() == getOperation();
+  if (Value token = getToken())
+    returnsHere |= llvm::is_contained(token.getUsers(), termOp);
+  if (returnsHere)
+    regions.push_back(RegionSuccessor::parent());
 }
 
 ValueRange ExecuteRegionOp::getSuccessorInputs(RegionSuccessor successor) {
-  return successor.isParent() ? ValueRange(getOperation()->getResults())
-                              : ValueRange();
+  // Branching into a region forwards no successor inputs (the token block
+  // argument is not a successor input).
+  if (successor.getSuccessor())
+    return ValueRange();
+  // The only other successors of this op are control leaving it: the normal
+  // exit ("parent") or an early exit back to this op. In both cases the
+  // operands become this op's results.
+  assert(
+      (successor.isParent() || successor.getSuccessorOp() == getOperation()) &&
+      "expected the successor to be this op or one of its regions");
+  return getOperation()->getResults();
+}
+
+void ExecuteRegionOp::getRegionBranchPointTerminators(
+    Region &region,
+    SmallVectorImpl<RegionBranchTerminatorOpInterface> &terminators) {
+  // Normal returns: `scf.yield` terminators directly in this op's blocks.
+  for (Block &block : region) {
+    if (block.empty())
+      continue;
+    Operation *terminator = &block.back();
+    if (isa<YieldOp>(terminator))
+      terminators.push_back(
+          cast<RegionBranchTerminatorOpInterface>(terminator));
+  }
+  // Early exits: the `scf.break` ops that target this op are exactly the users
+  // of its token, at any nesting depth. (A break directly in one of this op's
+  // blocks is a token user too, so it is collected here rather than above.)
+  if (Value token = getToken())
+    for (Operation *user : token.getUsers())
+      if (isa<BreakOp>(user))
+        terminators.push_back(cast<RegionBranchTerminatorOpInterface>(user));
+}
+
+//===----------------------------------------------------------------------===//
+// BreakOp
+//===----------------------------------------------------------------------===//
+
+// `scf.break` is a region-breaking terminator: it transfers control to the
+// `scf.execute_region` identified by its token operand (a possibly
+// non-immediate ancestor), forwarding its value operands as that op's results.
+Operation *BreakOp::getTarget() {
+  // The verifier guarantees the token operand is the entry block argument of an
+  // enclosing `scf.execute_region`, so these casts always succeed.
+  auto blockArg = cast<BlockArgument>(getToken());
+  auto targetOp = cast<ExecuteRegionOp>(blockArg.getOwner()->getParentOp());
+  assert(targetOp.getToken() == blockArg &&
+         "expected the token to be the execute_region's entry block argument");
+  return targetOp;
+}
+
+MutableOperandRange
+BreakOp::getMutableSuccessorOperands(RegionSuccessor point) {
+  // Only the value operands are forwarded to the target's results; the token
+  // operand is structural and is not a successor operand.
+  return getValuesMutable();
+}
+
+void BreakOp::getSuccessorRegions(ArrayRef<Attribute> operands,
+                                  SmallVectorImpl<RegionSuccessor> &regions) {
+  regions.push_back(RegionSuccessor::exitingTo(getTarget()));
+}
+
+LogicalResult BreakOp::verify() {
+  // The token must be an entry block argument of an enclosing
+  // `scf.execute_region` op.
+  auto blockArg = dyn_cast<BlockArgument>(getToken());
+  if (!blockArg)
+    return emitOpError()
+           << "expects the token operand to be the entry block argument of "
+              "an enclosing 'scf.execute_region'";
+  auto targetOp =
+      dyn_cast_or_null<ExecuteRegionOp>(blockArg.getOwner()->getParentOp());
+  if (!targetOp || targetOp.getToken() != blockArg)
+    return emitOpError()
+           << "expects the token operand to be the entry block argument of "
+              "an enclosing 'scf.execute_region'";
+
+  // Note: The number and types of the value operands are checked against the
+  // target op's result types generically by the `RegionBranchOpInterface`
+  // verifier of the target `scf.execute_region` (the break is one of its region
+  // branch points), so they are not re-checked here.
+
+  // Every op on the path from this terminator up to the target op must be
+  // transparent to region-breaking terminators, i.e., it must implement the
+  // `PropagateControlFlowBreak` trait.
+  Operation *cursor = (*this)->getParentOp();
+  while (cursor && cursor != targetOp.getOperation()) {
+    if (!cursor->mightHaveTrait<OpTrait::PropagateControlFlowBreak>())
+      return emitOpError()
+             << "cannot break through '" << cursor->getName()
+             << "': op does not implement the 'PropagateControlFlowBreak' "
+                "trait";
+    cursor = cursor->getParentOp();
+  }
+  if (cursor != targetOp.getOperation())
+    return emitOpError("target 'scf.execute_region' is not an ancestor");
+  return success();
 }
 
 //===----------------------------------------------------------------------===//
@@ -1931,24 +2081,17 @@ bool mlir::scf::insideMutuallyExclusiveBranches(Operation *a, Operation *b) {
   return false;
 }
 
-LogicalResult
-IfOp::inferReturnTypes(MLIRContext *ctx, std::optional<Location> loc,
-                       IfOp::Adaptor adaptor,
-                       SmallVectorImpl<Type> &inferredReturnTypes) {
-  if (adaptor.getRegions().empty())
-    return failure();
-  Region *r = &adaptor.getThenRegion();
-  if (r->empty())
-    return failure();
-  Block &b = r->front();
-  if (b.empty())
-    return failure();
-  auto yieldOp = llvm::dyn_cast<YieldOp>(b.back());
-  if (!yieldOp)
-    return failure();
-  TypeRange types = yieldOp.getOperandTypes();
-  llvm::append_range(inferredReturnTypes, types);
-  return success();
+/// Ensure that `region`, which belongs to an `scf.if`, terminates with an
+/// `scf.yield` if it does not already have a terminator.
+template <typename BuilderTy>
+static void ensureIfYieldTerminator(Region &region, BuilderTy &builder,
+                                    Location loc) {
+  ::mlir::impl::ensureRegionTerminator(
+      region, builder, loc, [](OpBuilder &b, Location l) -> Operation * {
+        OperationState state(l, scf::YieldOp::getOperationName());
+        scf::YieldOp::build(b, state);
+        return Operation::create(state);
+      });
 }
 
 void IfOp::build(OpBuilder &builder, OperationState &result,
@@ -1990,14 +2133,14 @@ void IfOp::build(OpBuilder &builder, OperationState &result,
   Region *thenRegion = result.addRegion();
   builder.createBlock(thenRegion);
   if (resultTypes.empty())
-    IfOp::ensureTerminator(*thenRegion, builder, result.location);
+    ensureIfYieldTerminator(*thenRegion, builder, result.location);
 
   // Build else region.
   Region *elseRegion = result.addRegion();
   if (withElseRegion) {
     builder.createBlock(elseRegion);
     if (resultTypes.empty())
-      IfOp::ensureTerminator(*elseRegion, builder, result.location);
+      ensureIfYieldTerminator(*elseRegion, builder, result.location);
   }
 }
 
@@ -2020,20 +2163,55 @@ void IfOp::build(OpBuilder &builder, OperationState &result, Value cond,
     elseBuilder(builder, result.location);
   }
 
-  // Infer result types.
-  SmallVector<Type> inferredReturnTypes;
-  MLIRContext *ctx = builder.getContext();
-  auto attrDict = DictionaryAttr::get(ctx, result.attributes);
-  if (succeeded(inferReturnTypes(ctx, std::nullopt, result.operands, attrDict,
-                                 /*properties=*/PropertyRef{}, result.regions,
-                                 inferredReturnTypes))) {
-    result.addTypes(inferredReturnTypes);
-  }
+  // Infer result types from the first region whose fall-through terminator is
+  // `scf.yield`. Regions terminated by `scf.break` do not contribute.
+  auto tryRegion = [&](Region *r) -> std::optional<TypeRange> {
+    if (!r || r->empty())
+      return std::nullopt;
+    Block &b = r->front();
+    if (b.empty())
+      return std::nullopt;
+    if (auto y = dyn_cast<YieldOp>(b.back()))
+      return TypeRange(y.getOperandTypes());
+    return std::nullopt;
+  };
+  if (auto ts = tryRegion(thenRegion))
+    result.addTypes(*ts);
+  else if (auto ts = tryRegion(elseRegion))
+    result.addTypes(*ts);
 }
 
 LogicalResult IfOp::verify() {
   if (getNumResults() != 0 && getElseRegion().empty())
     return emitOpError("must have an else block if defining values");
+
+  // The terminator of each region must be either `scf.yield` (the regular
+  // case) or a region-breaking terminator (`scf.break`) that transfers
+  // control to an enclosing target op. The validity of region-breaking
+  // terminators is checked by their own verifiers; here we only enforce that
+  // nothing else terminates an `scf.if` region.
+  auto verifyRegionTerminator = [&](Region &region,
+                                    StringRef name) -> LogicalResult {
+    if (region.empty())
+      return success();
+    Operation &terminator = region.front().back();
+    if (isa<YieldOp, BreakOp>(terminator))
+      return success();
+    return emitOpError() << "expects '" << name
+                         << "' region to be terminated by 'scf.yield' or "
+                            "'scf.break', found '"
+                         << terminator.getName() << "'";
+  };
+  if (failed(verifyRegionTerminator(getThenRegion(), "then")))
+    return failure();
+  if (failed(verifyRegionTerminator(getElseRegion(), "else")))
+    return failure();
+
+  // Note: when a branch terminates with `scf.yield`, the per-yield-operand
+  // type matching against this op's result types is enforced by the
+  // `RegionBranchOpInterface` verifier. Branches that terminate with
+  // `scf.break` transfer control out without yielding values, so the
+  // break's own verifier handles type compatibility there.
   return success();
 }
 
@@ -2055,13 +2233,13 @@ ParseResult IfOp::parse(OpAsmParser &parser, OperationState &result) {
   // Parse the 'then' region.
   if (parser.parseRegion(*thenRegion, /*arguments=*/{}, /*argTypes=*/{}))
     return failure();
-  IfOp::ensureTerminator(*thenRegion, parser.getBuilder(), result.location);
+  ensureIfYieldTerminator(*thenRegion, parser.getBuilder(), result.location);
 
   // If we find an 'else' keyword then parse the 'else' region.
   if (!parser.parseOptionalKeyword("else")) {
     if (parser.parseRegion(*elseRegion, /*arguments=*/{}, /*argTypes=*/{}))
       return failure();
-    IfOp::ensureTerminator(*elseRegion, parser.getBuilder(), result.location);
+    ensureIfYieldTerminator(*elseRegion, parser.getBuilder(), result.location);
   }
 
   // Parse the optional attribute list.
@@ -2071,18 +2249,28 @@ ParseResult IfOp::parse(OpAsmParser &parser, OperationState &result) {
 }
 
 void IfOp::print(OpAsmPrinter &p) {
-  bool printBlockTerminators = false;
+  bool hasResults = !getResults().empty();
 
   p << " " << getCondition();
-  if (!getResults().empty()) {
+  if (hasResults)
     p << " -> (" << getResultTypes() << ")";
-    // Print yield explicitly if the op defines values.
-    printBlockTerminators = true;
-  }
+
+  // We must print the terminator whenever the op produces results, or when
+  // the terminator is not a plain `scf.yield` (so that region-breaking
+  // terminators round-trip).
+  auto needsExplicitTerminator = [&](Region &region) {
+    if (region.empty())
+      return false;
+    if (hasResults)
+      return true;
+    return !isa<YieldOp>(region.front().back());
+  };
+
   p << ' ';
   p.printRegion(getThenRegion(),
                 /*printEntryBlockArgs=*/false,
-                /*printBlockTerminators=*/printBlockTerminators);
+                /*printBlockTerminators=*/
+                needsExplicitTerminator(getThenRegion()));
 
   // Print the 'else' regions if it exists and has a block.
   auto &elseRegion = getElseRegion();
@@ -2090,7 +2278,8 @@ void IfOp::print(OpAsmPrinter &p) {
     p << " else ";
     p.printRegion(elseRegion,
                   /*printEntryBlockArgs=*/false,
-                  /*printBlockTerminators=*/printBlockTerminators);
+                  /*printBlockTerminators=*/
+                  needsExplicitTerminator(elseRegion));
   }
 
   p.printOptionalAttrDict((*this)->getAttrs());
@@ -2098,10 +2287,14 @@ void IfOp::print(OpAsmPrinter &p) {
 
 void IfOp::getSuccessorRegions(RegionBranchPoint point,
                                SmallVectorImpl<RegionSuccessor> &regions) {
-  // The `then` and the `else` region branch back to the parent operation or one
-  // of the recursive parent operations (early exit case).
   if (!point.isParent()) {
-    regions.push_back(RegionSuccessor::parent());
+    Operation *terminator = point.getTerminatorPredecessorOrNull();
+    // A `scf.yield` branches back to this op. The only other valid terminator
+    // is `scf.break` and it branches back to an enclosing op. Therefore, it is
+    // not enumerated by this implementation. The owning ancestor reports that
+    // early-exit edge instead
+    if (isa<YieldOp>(terminator))
+      regions.push_back(RegionSuccessor::parent());
     return;
   }
 
@@ -2183,6 +2376,11 @@ struct ConvertTrivialIfToSelect : public OpRewritePattern<IfOp> {
   LogicalResult matchAndRewrite(IfOp op,
                                 PatternRewriter &rewriter) const override {
     if (op->getNumResults() == 0)
+      return failure();
+    // This pattern requires both regions to fall through with `scf.yield`.
+    if (!isa<YieldOp>(op.getThenRegion().back().getTerminator()) ||
+        op.getElseRegion().empty() ||
+        !isa<YieldOp>(op.getElseRegion().back().getTerminator()))
       return failure();
 
     auto cond = op.getCondition();
@@ -2385,6 +2583,11 @@ struct ReplaceIfYieldWithConditionOrValue : public OpRewritePattern<IfOp> {
     // Early exit if there are no results that could be replaced.
     if (op.getNumResults() == 0)
       return failure();
+    // This pattern requires both regions to fall through with `scf.yield`.
+    if (!isa<YieldOp>(op.getThenRegion().back().getTerminator()) ||
+        op.getElseRegion().empty() ||
+        !isa<YieldOp>(op.getElseRegion().back().getTerminator()))
+      return failure();
 
     auto trueYield =
         cast<scf::YieldOp>(op.getThenRegion().back().getTerminator());
@@ -2470,6 +2673,17 @@ struct CombineIfs : public OpRewritePattern<IfOp> {
 
     auto prevIf = dyn_cast<IfOp>(nextIf->getPrevNode());
     if (!prevIf)
+      return failure();
+
+    // This pattern requires both if ops' regions to fall through with
+    // `scf.yield`.
+    auto isYieldTerminated = [](Region &region) {
+      return region.empty() || isa<YieldOp>(region.back().getTerminator());
+    };
+    if (!isYieldTerminated(prevIf.getThenRegion()) ||
+        !isYieldTerminated(prevIf.getElseRegion()) ||
+        !isYieldTerminated(nextIf.getThenRegion()) ||
+        !isYieldTerminated(nextIf.getElseRegion()))
       return failure();
 
     // Determine the logical then/else blocks when prevIf's
@@ -2631,6 +2845,14 @@ struct CombineNestedIfs : public OpRewritePattern<IfOp> {
 
   LogicalResult matchAndRewrite(IfOp op,
                                 PatternRewriter &rewriter) const override {
+    // This pattern requires the outer if's regions to fall through with
+    // `scf.yield`.
+    if (!isa<YieldOp>(op.getThenRegion().back().getTerminator()))
+      return failure();
+    if (!op.getElseRegion().empty() &&
+        !isa<YieldOp>(op.getElseRegion().back().getTerminator()))
+      return failure();
+
     auto nestedOps = op.thenBlock()->without_terminator();
     // Nested `if` must be the only op in block.
     if (!llvm::hasSingleElement(nestedOps))
@@ -2645,6 +2867,12 @@ struct CombineNestedIfs : public OpRewritePattern<IfOp> {
       return failure();
 
     if (nestedIf.elseBlock() && !llvm::hasSingleElement(*nestedIf.elseBlock()))
+      return failure();
+    // The nested if's regions must also fall through with `scf.yield`.
+    if (!isa<YieldOp>(nestedIf.getThenRegion().back().getTerminator()))
+      return failure();
+    if (!nestedIf.getElseRegion().empty() &&
+        !isa<YieldOp>(nestedIf.getElseRegion().back().getTerminator()))
       return failure();
 
     SmallVector<Value> thenYield(op.thenYield().getOperands());
@@ -3453,6 +3681,14 @@ struct WhileMoveIfDown : public OpRewritePattern<scf::WhileOp> {
     // TODO: support else blocks with content.
     if (!ifOp || ifOp.getCondition() != conditionOp.getCondition() ||
         (ifOp.elseBlock() && !ifOp.elseBlock()->without_terminator().empty()))
+      return failure();
+
+    // This pattern requires both regions of the ifOp to fall through with
+    // `scf.yield`.
+    if (!isa<scf::YieldOp>(ifOp.getThenRegion().back().getTerminator()))
+      return failure();
+    if (!ifOp.getElseRegion().empty() &&
+        !isa<scf::YieldOp>(ifOp.getElseRegion().back().getTerminator()))
       return failure();
 
     assert((ifOp->use_empty() || (llvm::all_equal(ifOp->getUsers()) &&

--- a/mlir/lib/Dialect/SCF/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/SCF/Transforms/CMakeLists.txt
@@ -5,6 +5,7 @@ add_mlir_dialect_library(MLIRSCFTransforms
   ForallToParallel.cpp
   ForToWhile.cpp
   LoopCanonicalization.cpp
+  LowerEarlyExit.cpp
   LoopPipelining.cpp
   LoopRangeFolding.cpp
   LoopSpecialization.cpp
@@ -39,6 +40,7 @@ add_mlir_dialect_library(MLIRSCFTransforms
   MLIRSCFDialect
   MLIRSCFUtils
   MLIRSideEffectInterfaces
+  MLIRUBDialect
   MLIRSupport
   MLIRTensorTransforms
   MLIRTransforms

--- a/mlir/lib/Dialect/SCF/Transforms/LowerEarlyExit.cpp
+++ b/mlir/lib/Dialect/SCF/Transforms/LowerEarlyExit.cpp
@@ -1,0 +1,487 @@
+//===- LowerEarlyExit.cpp - Lower `scf.break` to yield-only SCF -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass removes all early-exit control flow from SCF: after the pass runs,
+// the IR contains no `scf.break` ops and no `token`-typed block arguments on
+// `scf.execute_region` ops.
+//
+// The lowering is intentionally split into a handful of small, local rewrite
+// rules that can each be understood in isolation. Their fixed-point combination
+// (run by the greedy pattern driver) eliminates arbitrary early-exit nests:
+//
+//   * BreakToYield        -- a break that targets the closest enclosing
+//                            `scf.execute_region` and is already in "tail
+//                            position" becomes a plain `scf.yield`.
+//   * SinkContinuationIntoIf
+//                         -- an `scf.if` that may break out is rewritten so the
+//                            code following it is sunk into the fall-through
+//                            branch(es) and the `scf.if` forwards the target's
+//                            results. This drives breaks into tail position.
+//   * HoistBreakThroughExecuteRegion
+//                         -- a break that targets a *non-closest* enclosing
+//                            `scf.execute_region` is hoisted out of the closest
+//                            one by threading an (i1 flag, values...) suffix
+//                            through it and re-breaking (guarded by the flag)
+//                            in the parent region. Applied repeatedly, this
+//                            moves a break up one `scf.execute_region` at a
+//                            time.
+//
+// Once the greedy rewrite reaches a fixed point, the pass removes every
+// remaining token block argument from `scf.execute_region` ops. At that point
+// all such tokens are expected to be unused.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/SCF/Transforms/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+#define GEN_PASS_DEF_SCFLOWEREARLYEXIT
+#include "mlir/Dialect/SCF/Transforms/Passes.h.inc"
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::scf;
+
+//===----------------------------------------------------------------------===//
+// Helpers
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// Returns the closest enclosing token-bearing `scf.execute_region` of `op`, or
+/// null if there is none.
+///
+/// Example: for the `scf.break` below, this returns the *inner* execute_region
+/// (`%tok1`), regardless of which region the break ultimately targets.
+///
+///   scf.execute_region {            // <- not the closest
+///   ^bb0(%tok0: token):
+///     scf.execute_region {          // <- returned (closest)
+///     ^bb1(%tok1: token):
+///       scf.break %tok0             // op = this break
+///     }
+///   }
+static ExecuteRegionOp getClosestTokenExecuteRegion(Operation *op) {
+  for (Operation *p = op->getParentOp(); p; p = p->getParentOp())
+    if (auto er = dyn_cast<ExecuteRegionOp>(p))
+      if (er.getToken())
+        return er;
+  return nullptr;
+}
+
+/// Returns true if yielding `op`'s results (in order) from its enclosing block
+/// would make them flow unchanged into `target`'s results, i.e. `op` is in
+/// "tail position" with respect to `target`. This is the case when `op` is
+/// immediately followed by an `scf.yield` that forwards exactly `op`'s results,
+/// and (recursively) the op owning that block is either `target` itself or an
+/// `scf.if` that is also in tail position.
+///
+/// Example: `%inner` is in tail position w.r.t. the execute_region, because its
+/// result is forwarded unchanged up to the target through forwarding yields:
+///
+///   %r = scf.execute_region -> f32 {          // target
+///     %outer = scf.if %c -> f32 {
+///       %inner = scf.if %d -> f32 { ... }      // op (tail position)
+///       scf.yield %inner : f32                 // forwards %inner
+///     } else { ... }
+///     scf.yield %outer : f32                   // forwards %outer
+///   }
+static bool isTailToTarget(Operation *op, ExecuteRegionOp target) {
+  Block *block = op->getBlock();
+  Operation *term = block->getTerminator();
+  if (op->getNextNode() != term)
+    return false;
+  auto yield = dyn_cast<YieldOp>(term);
+  if (!yield || !llvm::equal(yield.getOperands(), op->getResults()))
+    return false;
+
+  Operation *parent = block->getParentOp();
+  if (parent == target.getOperation())
+    return true;
+  if (auto parentIf = dyn_cast<IfOp>(parent))
+    return isTailToTarget(parentIf, target);
+  return false;
+}
+
+/// Returns true if `ifOp` transitively contains an `scf.break`.
+static bool hasBreak(IfOp ifOp) {
+  return ifOp.walk([](BreakOp) { return WalkResult::interrupt(); })
+      .wasInterrupted();
+}
+
+/// Materializes `count` poison values for the given `types`.
+static void appendPoison(RewriterBase &rewriter, Location loc, TypeRange types,
+                         SmallVectorImpl<Value> &out) {
+  for (Type t : types)
+    out.push_back(ub::PoisonOp::create(rewriter, loc, t));
+}
+
+/// Materializes an `i1` constant.
+static Value makeBool(RewriterBase &rewriter, Location loc, bool value) {
+  return arith::ConstantOp::create(rewriter, loc, rewriter.getBoolAttr(value));
+}
+
+//===----------------------------------------------------------------------===//
+// BreakToYield
+//===----------------------------------------------------------------------===//
+
+/// Replaces a `scf.break` with a `scf.yield` when the break already reaches its
+/// target by simple fall-through. This is the terminal rule: it is the only one
+/// that actually removes a break.
+///
+/// It fires when either:
+///   (a) the break is a terminator of a block directly inside its target
+///       `scf.execute_region` (so yielding returns the same values), or
+///   (b) the break terminates a branch of an `scf.if` that is in tail position
+///       with respect to the target (so the values are forwarded unchanged).
+///
+/// Case (a), break directly in the target:
+///
+///   scf.execute_region -> f32 {            scf.execute_region -> f32 {
+///   ^bb0(%tok: token):              ==>     ^bb0(%tok: token):
+///     scf.break %tok, %v : f32                scf.yield %v : f32
+///   }                                       }
+///
+/// Case (b), break in a tail-position `scf.if`:
+///
+///   %r = scf.if %c -> f32 {                 %r = scf.if %c -> f32 {
+///     scf.break %tok, %v : f32      ==>        scf.yield %v : f32
+///   } else {                                } else {
+///     scf.yield %w : f32                       scf.yield %w : f32
+///   }                                       }
+///   scf.yield %r : f32                      scf.yield %r : f32
+struct BreakToYield : OpRewritePattern<BreakOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(BreakOp breakOp,
+                                PatternRewriter &rewriter) const override {
+    auto target = dyn_cast_or_null<ExecuteRegionOp>(breakOp.getTarget());
+    if (!target)
+      return failure();
+
+    Operation *parent = breakOp->getParentOp();
+    bool resolved = false;
+    if (parent == target.getOperation()) {
+      resolved = true; // case (a)
+    } else if (auto parentIf = dyn_cast<IfOp>(parent)) {
+      resolved = isTailToTarget(parentIf, target); // case (b)
+    }
+    if (!resolved)
+      return failure();
+
+    rewriter.replaceOpWithNewOp<YieldOp>(breakOp, breakOp.getValues());
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// SinkContinuationIntoIf
+//===----------------------------------------------------------------------===//
+
+/// Rewrites an `scf.if` that may break out to its closest enclosing target so
+/// that the code following it (its "continuation") is sunk into the
+/// fall-through branch(es), and the `scf.if` itself forwards the values that
+/// the continuation would have produced. This drives breaks toward tail
+/// position.
+///
+/// Before:
+///   scf.if %c { ...; scf.break %tok, %v } // (a fall-through branch may exist)
+///   <continuation ops...>
+///   scf.yield %ys
+///
+/// After:
+///   %r... = scf.if %c -> (types(%ys)) {
+///     ...; scf.break %tok, %v             // breaking branch unchanged
+///   } else {
+///     <continuation ops...>; scf.yield %ys
+///   }
+///   scf.yield %r...
+///
+/// A branch that itself breaks out is left untouched (its continuation is
+/// unreachable). A branch that falls through (terminates with `scf.yield`, or
+/// is an absent `else`) receives a copy of the continuation, with the old
+/// `scf.if` results remapped to that branch's yielded values.
+///
+/// When *both* branches fall through (the break is nested deeper, so neither
+/// branch terminator is a break), the continuation is cloned into *both* of
+/// them -- it is tail-duplicated:
+///
+/// Before:
+///   scf.if %c {
+///     scf.if %d { scf.break %tok, %v }   // break nested; %c falls through
+///   }
+///   <continuation ops...>
+///   scf.yield %ys
+///
+/// After (continuation duplicated into the then and else branches of %c):
+///   %r... = scf.if %c -> (types(%ys)) {
+///     scf.if %d { scf.break %tok, %v }
+///     <continuation ops...>; scf.yield %ys
+///   } else {
+///     <continuation ops...>; scf.yield %ys
+///   }
+///   scf.yield %r...
+struct SinkContinuationIntoIf : OpRewritePattern<IfOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(IfOp ifOp,
+                                PatternRewriter &rewriter) const override {
+    // Progress gate: only fire on ifs that may actually early-exit.
+    if (!hasBreak(ifOp))
+      return failure();
+
+    Block *block = ifOp->getBlock();
+    Operation *term = block->getTerminator();
+    auto yield = dyn_cast<YieldOp>(term);
+    if (!yield)
+      return failure();
+
+    // If the if is already in canonical tail form, there is nothing to sink;
+    // BreakToYield will finish the job.
+    bool alreadyTail = ifOp->getNextNode() == term &&
+                       llvm::equal(yield.getOperands(), ifOp->getResults());
+    if (alreadyTail)
+      return failure();
+
+    SmallVector<Type> newResultTypes(yield.getOperandTypes());
+
+    // Carve the continuation -- everything after the if, up to and including
+    // the terminating yield -- into its own block. It serves as a template:
+    // each fall-through branch receives a copy, and the copied yield becomes
+    // that branch's new terminator.
+    Block *contBlock =
+        rewriter.splitBlock(block, std::next(ifOp->getIterator()));
+
+    // Build the replacement `scf.if` with the continuation's result types and
+    // move the existing regions into it.
+    rewriter.setInsertionPoint(ifOp);
+    auto newIf = IfOp::create(rewriter, ifOp.getLoc(), newResultTypes,
+                              ifOp.getCondition(), /*addThenBlock=*/false,
+                              /*addElseBlock=*/false);
+    newIf.getThenRegion().takeBody(ifOp.getThenRegion());
+    newIf.getElseRegion().takeBody(ifOp.getElseRegion());
+    if (newIf.getElseRegion().empty())
+      rewriter.createBlock(&newIf.getElseRegion());
+
+    for (Region *region : {&newIf.getThenRegion(), &newIf.getElseRegion()}) {
+      Block *body = &region->front();
+      Operation *branchTerm = body->empty() ? nullptr : &body->back();
+
+      // Leave breaking branches alone: their continuation is unreachable.
+      if (branchTerm && isa<BreakOp>(branchTerm))
+        continue;
+
+      // Map the old if results to the values this branch yields, drop the
+      // branch's yield, then append a copy of the continuation (whose own
+      // yield becomes the new branch terminator).
+      IRMapping mapping;
+      if (auto branchYield = dyn_cast_or_null<YieldOp>(branchTerm)) {
+        mapping.map(ifOp.getResults(), branchYield.getOperands());
+        rewriter.eraseOp(branchYield);
+      }
+
+      rewriter.setInsertionPointToEnd(body);
+      for (Operation &op : *contBlock)
+        rewriter.clone(op, mapping);
+    }
+
+    // The continuation now lives in the fall-through branches; drop the
+    // template block and forward the new if's results.
+    rewriter.eraseBlock(contBlock);
+    rewriter.setInsertionPointToEnd(block);
+    YieldOp::create(rewriter, ifOp.getLoc(), newIf.getResults());
+
+    rewriter.eraseOp(ifOp);
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// HoistBreakThroughExecuteRegion
+//===----------------------------------------------------------------------===//
+
+/// Hoists breaks that target a *non-closest* enclosing `scf.execute_region` out
+/// of the closest one. The closest region `E` is augmented with a suffix of
+/// results `(i1 didBreak, <target results...>)`; breaks to the outer target are
+/// re-pointed at `E` (driving the flag to true and forwarding the broken-out
+/// values), all of `E`'s ordinary exits are extended with `(false, poison...)`,
+/// and a flag-guarded re-break to the outer target is inserted right after `E`.
+///
+/// Applied repeatedly, this moves a break up one `scf.execute_region` at a time
+/// until its target becomes the closest one, at which point the other rules
+/// finish the lowering.
+///
+/// Before (the inner break targets the *outer* `%tok`):
+///
+///   %a = scf.execute_region -> f32 {
+///   ^bb0(%tok: token):
+///     %b = scf.execute_region -> f32 {
+///     ^bb1(%tok1: token):
+///       scf.break %tok, %v : f32
+///     }
+///     <continuation using %b...>
+///   }
+///
+/// After (the break now targets the inner `%tok1`, threading out a flag and the
+/// broken-out value; a flag-guarded re-break to `%tok` follows the region):
+///
+///   %a = scf.execute_region -> f32 {
+///   ^bb0(%tok: token):
+///     %b, %broke, %bv = scf.execute_region -> (f32, i1, f32) {
+///     ^bb1(%tok1: token):
+///       %p = ub.poison : f32
+///       %t = arith.constant true
+///       scf.break %tok1, %p, %t, %v : f32, i1, f32
+///     }
+///     scf.if %broke {
+///       scf.break %tok, %bv : f32
+///     }
+///     <continuation using %b...>
+///   }
+struct HoistBreakThroughExecuteRegion : OpRewritePattern<BreakOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(BreakOp breakToHoist,
+                                PatternRewriter &rewriter) const override {
+    auto target = dyn_cast_or_null<ExecuteRegionOp>(breakToHoist.getTarget());
+    if (!target)
+      return failure();
+
+    ExecuteRegionOp region = getClosestTokenExecuteRegion(breakToHoist);
+    if (!region || target == region)
+      return failure();
+
+    Value token = region.getToken();
+    if (!token)
+      return failure();
+
+    TypeRange oldResultTypes = region.getResultTypes();
+    TypeRange targetTypes = target.getResultTypes();
+    unsigned numOld = oldResultTypes.size();
+    Location loc = region.getLoc();
+
+    SmallVector<Type> newResultTypes(oldResultTypes);
+    newResultTypes.push_back(rewriter.getI1Type());
+    newResultTypes.append(targetTypes.begin(), targetTypes.end());
+
+    // Collect ordinary exits of `region` (its own yields and self-targeted
+    // breaks); they are extended with the inactive suffix.
+    SmallVector<Operation *> extended;
+    for (Block &block : region.getRegion()) {
+      if (auto yield = dyn_cast<YieldOp>(block.getTerminator()))
+        extended.push_back(yield);
+    }
+    for (Operation *user : token.getUsers()) {
+      if (auto b = dyn_cast<BreakOp>(user)) {
+        extended.push_back(b);
+      }
+    }
+
+    // Extend ordinary exits with `(false, poison...)`.
+    for (Operation *op : extended) {
+      rewriter.setInsertionPoint(op);
+      SmallVector<Value> operands(op->getOperands());
+      operands.push_back(makeBool(rewriter, loc, false));
+      appendPoison(rewriter, loc, targetTypes, operands);
+      rewriter.modifyOpInPlace(op, [&]() { op->setOperands(operands); });
+    }
+
+    // Redirect the selected outer-target break to `region`, driving the flag
+    // and forwarding the broken-out values; the original-result slots become
+    // poison.
+    rewriter.setInsertionPoint(breakToHoist);
+    SmallVector<Value> operands;
+    operands.push_back(token);
+    appendPoison(rewriter, loc, oldResultTypes, operands);
+    operands.push_back(makeBool(rewriter, loc, true));
+    operands.append(breakToHoist.getValues().begin(),
+                    breakToHoist.getValues().end());
+    rewriter.modifyOpInPlace(breakToHoist,
+                             [&]() { breakToHoist->setOperands(operands); });
+
+    // Build the widened execute_region and move the body over.
+    rewriter.setInsertionPoint(region);
+    auto newRegion = ExecuteRegionOp::create(rewriter, loc, newResultTypes);
+    newRegion.getRegion().takeBody(region.getRegion());
+
+    // Insert the guarded re-break to the outer target right after the region.
+    rewriter.setInsertionPointAfter(newRegion);
+    Value flag = newRegion.getResult(numOld);
+    SmallVector<Value> targetVals(
+        newRegion.getResults().slice(numOld + 1, targetTypes.size()));
+    auto guard = IfOp::create(rewriter, loc, TypeRange{}, flag,
+                              /*addThenBlock=*/true, /*addElseBlock=*/false);
+    rewriter.setInsertionPointToStart(&guard.getThenRegion().front());
+    BreakOp::create(rewriter, loc, target.getToken(), targetVals);
+
+    // Replace the original results with the leading slots of the new region.
+    rewriter.replaceOp(region,
+                       newRegion.getResults().take_front(numOld));
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Pass
+//===----------------------------------------------------------------------===//
+
+struct SCFLowerEarlyExitPass
+    : public impl::SCFLowerEarlyExitBase<SCFLowerEarlyExitPass> {
+  void runOnOperation() override {
+    WalkResult unsupportedTerminator =
+        getOperation()->walk([](ExecuteRegionOp region) {
+          for (Block &block : region.getRegion()) {
+            Operation *term = block.getTerminator();
+            if (isa<YieldOp, BreakOp>(term))
+              continue;
+            region.emitOpError()
+                << "contains unsupported terminator '" << term->getName()
+                << "'; expected 'scf.yield' or 'scf.break'";
+            return WalkResult::interrupt();
+          }
+          return WalkResult::advance();
+        });
+    if (unsupportedTerminator.wasInterrupted()) {
+      signalPassFailure();
+      return;
+    }
+
+    MLIRContext *ctx = &getContext();
+    RewritePatternSet patterns(ctx);
+    patterns.add<BreakToYield, SinkContinuationIntoIf,
+                 HoistBreakThroughExecuteRegion>(ctx);
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+      signalPassFailure();
+      return;
+    }
+
+    getOperation()->walk([](ExecuteRegionOp region) {
+      Value token = region.getToken();
+      if (!token)
+        return;
+      assert(token.use_empty() &&
+             "expected all scf.execute_region tokens to be unused after "
+             "lowering early exits");
+      region.getRegion().front().eraseArgument(0);
+    });
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::createSCFLowerEarlyExitPass() {
+  return std::make_unique<SCFLowerEarlyExitPass>();
+}

--- a/mlir/lib/Interfaces/ControlFlowInterfaces.cpp
+++ b/mlir/lib/Interfaces/ControlFlowInterfaces.cpp
@@ -260,14 +260,15 @@ static bool traverseRegionGraph(Region *begin,
       LDBG() << "Found " << successors.size()
              << " successors from terminator in block";
       for (RegionSuccessor successor : successors) {
-        if (!successor.isParent()) {
-          worklist.push_back(successor.getSuccessor());
-          LDBG() << "Added region #"
-                 << successor.getSuccessor()->getRegionNumber()
-                 << " to worklist";
-        } else {
-          LDBG() << "Skipping parent successor";
+        // Both "parent" and "early exit" successors leave this op; they have no
+        // region to enqueue.
+        if (successor.isParent() || successor.isEarlyExit()) {
+          LDBG() << "Skipping parent/early-exit successor";
+          continue;
         }
+        worklist.push_back(successor.getSuccessor());
+        LDBG() << "Added region #"
+               << successor.getSuccessor()->getRegionNumber() << " to worklist";
       }
     }
   };
@@ -446,10 +447,16 @@ RegionBranchOpInterface::getSuccessorOperands(RegionBranchPoint src,
 
 SmallVector<Value>
 RegionBranchOpInterface::getNonSuccessorInputs(RegionSuccessor successor) {
-  SmallVector<Value> results = llvm::to_vector(
-      successor.isParent()
-          ? ValueRange(getOperation()->getResults())
-          : ValueRange(successor.getSuccessor()->getArguments()));
+  // For an early exit, the relevant values are the results of the targeted
+  // ancestor op; for "parent", the results of this op; otherwise the block
+  // arguments of the successor region.
+  ValueRange allValues =
+      successor.isEarlyExit()
+          ? ValueRange(successor.getSuccessorOp()->getResults())
+          : (successor.isParent()
+                 ? ValueRange(getOperation()->getResults())
+                 : ValueRange(successor.getSuccessor()->getArguments()));
+  SmallVector<Value> results = llvm::to_vector(allValues);
   ValueRange successorInputs = getSuccessorInputs(successor);
   if (!successorInputs.empty()) {
     unsigned inputBegin =
@@ -515,15 +522,15 @@ SmallVector<RegionBranchPoint>
 RegionBranchOpInterface::getAllRegionBranchPoints() {
   SmallVector<RegionBranchPoint> branchPoints;
   branchPoints.push_back(RegionBranchPoint::parent());
-  for (Region &region : getOperation()->getRegions()) {
-    for (Block &block : region) {
-      if (block.empty())
-        continue;
-      if (auto terminator =
-              dyn_cast<RegionBranchTerminatorOpInterface>(block.back()))
-        branchPoints.push_back(RegionBranchPoint(terminator));
-    }
-  }
+  // Collect all terminators that branch back to this op. The per-op
+  // `getRegionBranchPointTerminators` implementation decides which terminators
+  // these are (e.g. `scf.execute_region` also includes early-exit `scf.break`s
+  // that target it).
+  SmallVector<RegionBranchTerminatorOpInterface> terminators;
+  for (Region &region : getOperation()->getRegions())
+    getRegionBranchPointTerminators(region, terminators);
+  for (RegionBranchTerminatorOpInterface terminator : terminators)
+    branchPoints.push_back(RegionBranchPoint(terminator));
   return branchPoints;
 }
 

--- a/mlir/test/Analysis/DataFlow/test-early-exit.mlir
+++ b/mlir/test/Analysis/DataFlow/test-early-exit.mlir
@@ -1,0 +1,86 @@
+// RUN: mlir-opt -test-dead-code-analysis 2>&1 %s | FileCheck %s
+
+// An `scf.break` nested in an `scf.if` is a region-branch predecessor of the
+// enclosing `scf.execute_region` (an early exit), alongside the normal
+// `scf.yield`. This exercises the early-exit generalization of
+// RegionBranchOpInterface: the break targets a non-immediate ancestor.
+
+// CHECK-LABEL: test_early_exit:
+// CHECK: op_preds: (all) predecessors:
+// CHECK-DAG:   scf.yield %{{.*}} : i32
+// CHECK-DAG:   scf.break %{{.*}}, %{{.*}} : i32
+func.func @test_early_exit(%cond: i1, %a: i32, %b: i32) -> i32 {
+  %0 = scf.execute_region -> i32 {
+  ^bb0(%tok: token):
+    scf.if %cond {
+      scf.break %tok, %a : i32
+    }
+    scf.yield %b : i32
+  } {tag = "test_early_exit"}
+  return %0 : i32
+}
+
+// An `scf.break` that is the immediate terminator of the `scf.execute_region`
+// is a (sole) region-branch predecessor of that op.
+
+// CHECK-LABEL: test_immediate_break:
+// CHECK: op_preds: (all) predecessors:
+// CHECK-NEXT:   scf.break %{{.*}}, %{{.*}} : i32
+func.func @test_immediate_break(%a: i32) -> i32 {
+  %0 = scf.execute_region -> i32 {
+  ^bb0(%tok: token):
+    scf.break %tok, %a : i32
+  } {tag = "test_immediate_break"}
+  return %0 : i32
+}
+
+// When *all* terminators of an `scf.execute_region` break to a further
+// enclosing op, the inner op's result is never produced: it has no op
+// predecessors at all (only its body is entered). The break is attributed to
+// the outer op instead.
+
+// CHECK-LABEL: test_all_break_outer_inner:
+// CHECK: region_preds: (all) predecessors:
+// CHECK-NOT: op_preds
+// CHECK-LABEL: test_all_break_outer:
+// CHECK: op_preds: (all) predecessors:
+// CHECK-DAG:   scf.yield %{{.*}} : i32
+// CHECK-DAG:   scf.break %{{.*}}, %{{.*}} : i32
+func.func @test_all_break_outer(%a: i32) -> i32 {
+  %0 = scf.execute_region -> i32 {
+  ^bb0(%tok_outer: token):
+    %1 = scf.execute_region -> i32 {
+    ^bb1(%tok_inner: token):
+      scf.break %tok_outer, %a : i32
+    } {tag = "test_all_break_outer_inner"}
+    scf.yield %1 : i32
+  } {tag = "test_all_break_outer"}
+  return %0 : i32
+}
+
+// A break that targets the *outer* `scf.execute_region` passes through (and
+// skips) the inner one. It is therefore a predecessor of the outer op, but
+// *not* of the inner op (whose only exit is its own yield).
+
+// CHECK-LABEL: test_inner:
+// CHECK: op_preds: (all) predecessors:
+// CHECK-NEXT:   scf.yield %{{.*}} : i32
+// CHECK-NOT:   scf.break
+// CHECK-LABEL: test_outer:
+// CHECK: op_preds: (all) predecessors:
+// CHECK-DAG:   scf.yield %{{.*}} : i32
+// CHECK-DAG:   scf.break %{{.*}}, %{{.*}} : i32
+func.func @test_outer_early_exit(%cond: i1, %a: i32, %b: i32, %c: i32) -> i32 {
+  %0 = scf.execute_region -> i32 {
+  ^bb0(%tok_outer: token):
+    %1 = scf.execute_region -> i32 {
+    ^bb1(%tok_inner: token):
+      scf.if %cond {
+        scf.break %tok_outer, %a : i32
+      }
+      scf.yield %b : i32
+    } {tag = "test_inner"}
+    scf.yield %c : i32
+  } {tag = "test_outer"}
+  return %0 : i32
+}

--- a/mlir/test/Analysis/DataFlow/test-liveness-analysis.mlir
+++ b/mlir/test/Analysis/DataFlow/test-liveness-analysis.mlir
@@ -400,3 +400,43 @@ func.func @unstructured_cf(%val: f32, %c: i1) -> f32 attributes {tag = "func"} {
 ^bb1(%arg1: f32):
   return %arg1: f32
 }
+
+// -----
+
+// Liveness is threaded across an early-exit (`scf.break`) edge: the broken-out
+// value becomes the `scf.execute_region` result, so it is live when that result
+// is live. Here the result is stored, hence the broken-out value is live.
+// CHECK-LABEL: test_tag: live_break_val:
+// CHECK-NEXT:  result #0: live
+func.func @early_exit_live(%arg0: memref<i32>, %cond: i1) {
+  %live = arith.constant {tag = "live_break_val"} 1 : i32
+  %0 = scf.execute_region -> i32 {
+  ^bb0(%tok: token):
+    scf.if %cond {
+      scf.break %tok, %live : i32
+    }
+    %c0 = arith.constant 0 : i32
+    scf.yield %c0 : i32
+  }
+  memref.store %0, %arg0[] : memref<i32>
+  return
+}
+
+// -----
+
+// Conversely, when the `scf.execute_region` result is unused, the broken-out
+// value is dead.
+// CHECK-LABEL: test_tag: dead_break_val:
+// CHECK-NEXT:  result #0: not live
+func.func @early_exit_dead(%cond: i1) {
+  %dead = arith.constant {tag = "dead_break_val"} 1 : i32
+  %0 = scf.execute_region -> i32 {
+  ^bb0(%tok: token):
+    scf.if %cond {
+      scf.break %tok, %dead : i32
+    }
+    %c0 = arith.constant 0 : i32
+    scf.yield %c0 : i32
+  }
+  return
+}

--- a/mlir/test/Conversion/SCFToControlFlow/convert-to-cfg-unsupported.mlir
+++ b/mlir/test/Conversion/SCFToControlFlow/convert-to-cfg-unsupported.mlir
@@ -1,0 +1,27 @@
+// RUN: mlir-opt -allow-unregistered-dialect -convert-scf-to-cf -split-input-file -verify-diagnostics %s
+
+// CHECK: scf.execute_region
+func.func @execute_region_with_token(%cond: i1, %val: f32) -> f32 {
+  // expected-error @below {{failed to legalize operation 'scf.execute_region'}}
+  %res = scf.execute_region -> f32 {
+  ^bb0(%t: token):
+    scf.yield %val : f32
+  }
+  return %res : f32
+}
+
+// -----
+
+// `scf.if` with a region-breaking terminator (`scf.break`) cannot be lowered
+// by SCFToControlFlow yet.
+func.func @if_with_break(%cond: i1, %val: f32) -> f32 {
+  // expected-error @below {{failed to legalize operation 'scf.execute_region'}}
+  %res = scf.execute_region -> f32 {
+  ^bb0(%t: token):
+    scf.if %cond {
+      scf.break %t, %val : f32
+    }
+    scf.yield %val : f32
+  }
+  return %res : f32
+}

--- a/mlir/test/Dialect/Arith/int-range-early-exit.mlir
+++ b/mlir/test/Dialect/Arith/int-range-early-exit.mlir
@@ -1,0 +1,143 @@
+// RUN: mlir-opt --int-range-optimizations %s | FileCheck %s
+
+// Verify that `IntegerRangeAnalysis` threads integer bounds across early-exit
+// edges (`scf.break`) modeled by the `RegionBranchOpInterface`. The result of
+// the `scf.execute_region` is the union of the bounds along the early-exit
+// (`scf.break`) path and the fall-through (`scf.yield`) path.
+
+// The result is either 0 (break) or 10 (yield), i.e. in [0, 10]. If the
+// early-exit edge were not modeled, only the yield (10) would be seen.
+
+// CHECK-LABEL: func @early_exit_range
+// CHECK: test.reflect_bounds {smax = 10 : si32, smin = 0 : si32, umax = 10 : ui32, umin = 0 : ui32}
+func.func @early_exit_range(%cond: i1) -> i32 {
+  %0 = scf.execute_region -> i32 {
+  ^bb0(%tok: token):
+    %c0 = arith.constant 0 : i32
+    %c10 = arith.constant 10 : i32
+    scf.if %cond {
+      scf.break %tok, %c0 : i32
+    }
+    scf.yield %c10 : i32
+  }
+  %r = test.reflect_bounds %0 : i32
+  return %r : i32
+}
+
+// -----
+
+// Because the result is provably in [0, 5], the comparison `%0 < 100` folds to
+// `true`. This is the dead-code-elimination scenario enabled by early exit:
+// without the early-exit edge the analysis would still see only the yield, but
+// the point here is that the break value participates in the bound.
+
+// CHECK-LABEL: func @early_exit_dead_code
+// CHECK: %[[TRUE:.*]] = arith.constant true
+// CHECK: return %[[TRUE]] : i1
+func.func @early_exit_dead_code(%cond: i1) -> i1 {
+  %0 = scf.execute_region -> i32 {
+  ^bb0(%tok: token):
+    %c0 = arith.constant 0 : i32
+    %c5 = arith.constant 5 : i32
+    scf.if %cond {
+      scf.break %tok, %c0 : i32
+    }
+    scf.yield %c5 : i32
+  }
+  %c100 = arith.constant 100 : i32
+  %cmp = arith.cmpi slt, %0, %c100 : i32
+  return %cmp : i1
+}
+
+// -----
+
+// A break that targets the *outer* `scf.execute_region` skips the inner one.
+// The outer result is either 1 (break) or 7 (inner yield forwarded by the
+// outer yield), i.e. in [1, 7].
+
+// CHECK-LABEL: func @outer_early_exit_range
+// CHECK: test.reflect_bounds {smax = 7 : si32, smin = 1 : si32, umax = 7 : ui32, umin = 1 : ui32}
+func.func @outer_early_exit_range(%cond: i1) -> i32 {
+  %0 = scf.execute_region -> i32 {
+  ^bb0(%tok_outer: token):
+    %c1 = arith.constant 1 : i32
+    %1 = scf.execute_region -> i32 {
+    ^bb1(%tok_inner: token):
+      %c7 = arith.constant 7 : i32
+      scf.if %cond {
+        scf.break %tok_outer, %c1 : i32
+      }
+      scf.yield %c7 : i32
+    }
+    scf.yield %1 : i32
+  }
+  %r = test.reflect_bounds %0 : i32
+  return %r : i32
+}
+
+// -----
+
+// The immediate (and only) terminator of the `scf.execute_region` is an
+// `scf.break`. The result is exactly the broken-out value, so it is in [3, 3].
+
+// CHECK-LABEL: func @immediate_break
+// CHECK: test.reflect_bounds {smax = 3 : si32, smin = 3 : si32, umax = 3 : ui32, umin = 3 : ui32}
+func.func @immediate_break(%cond: i1) -> i32 {
+  %0 = scf.execute_region -> i32 {
+  ^bb0(%tok: token):
+    %c3 = arith.constant 3 : i32
+    scf.break %tok, %c3 : i32
+  }
+  %r = test.reflect_bounds %0 : i32
+  return %r : i32
+}
+
+// -----
+
+// All terminators of the inner `scf.execute_region` break to the outer one, so
+// the inner result is never produced and the analysis infers no bounds for it
+// (the `test.reflect_bounds` on it stays unannotated). The outer result is
+// exactly the break value 4.
+
+// CHECK-LABEL: func @range_all_break_outer
+// The inner (never-produced) result has no inferred bounds:
+// CHECK: test.reflect_bounds %{{[a-z0-9_]+}} : i32
+// The outer result is the break value, in [4, 4]:
+// CHECK: test.reflect_bounds {smax = 4 : si32, smin = 4 : si32, umax = 4 : ui32, umin = 4 : ui32}
+func.func @range_all_break_outer(%cond: i1) -> i32 {
+  %0 = scf.execute_region -> i32 {
+  ^bb0(%tok_outer: token):
+    %c4 = arith.constant 4 : i32
+    %1 = scf.execute_region -> i32 {
+    ^bb1(%tok_inner: token):
+      scf.break %tok_outer, %c4 : i32
+    }
+    %r1 = test.reflect_bounds %1 : i32
+    scf.yield %r1 : i32
+  }
+  %r = test.reflect_bounds %0 : i32
+  return %r : i32
+}
+
+// -----
+
+// Both exits are breaks to the same `scf.execute_region`: a nested one (early
+// exit through the `scf.if`) and the block's immediate terminator. The result
+// is either 2 or 8, i.e. in [2, 8]. This covers both the "early exit through a
+// transparent op" and the "immediate-terminator break" edges for one op.
+
+// CHECK-LABEL: func @nested_and_immediate_break
+// CHECK: test.reflect_bounds {smax = 8 : si32, smin = 2 : si32, umax = 8 : ui32, umin = 2 : ui32}
+func.func @nested_and_immediate_break(%cond: i1) -> i32 {
+  %0 = scf.execute_region -> i32 {
+  ^bb0(%tok: token):
+    %c2 = arith.constant 2 : i32
+    %c8 = arith.constant 8 : i32
+    scf.if %cond {
+      scf.break %tok, %c2 : i32
+    }
+    scf.break %tok, %c8 : i32
+  }
+  %r = test.reflect_bounds %0 : i32
+  return %r : i32
+}

--- a/mlir/test/Dialect/SCF/invalid.mlir
+++ b/mlir/test/Dialect/SCF/invalid.mlir
@@ -645,7 +645,7 @@ func.func @while_bad_terminator() {
 // -----
 
 func.func @execute_region() {
-  // expected-error @+1 {{region cannot have any arguments}}
+  // expected-error @+1 {{entry block argument must be of `token` type}}
   "scf.execute_region"() ({
   ^bb0(%i : i32):
     scf.yield
@@ -851,4 +851,68 @@ func.func @for_missing_induction_var(%arg0: index, %arg1: index) {
     "scf.yield"() : () -> ()
   }) : (index, index, index) -> ()
   return
+}
+
+// -----
+
+func.func @execute_region_too_many_args(%val: f32) -> f32 {
+  // expected-error @below {{'scf.execute_region' op entry block may only have zero or one block argument}}
+  %res = scf.execute_region -> f32 {
+  ^bb0(%t: token, %x: f32):
+    scf.yield %x : f32
+  }
+  return %res : f32
+}
+
+// -----
+
+func.func @execute_region_nontoken_arg(%val: f32) -> f32 {
+  // expected-error @below {{'scf.execute_region' op entry block argument must be of `token` type}}
+  %res = scf.execute_region -> f32 {
+  ^bb0(%x: f32):
+    scf.yield %x : f32
+  }
+  return %res : f32
+}
+
+// -----
+
+func.func @break_wrong_result_count(%val: f32) -> f32 {
+  // expected-error @below {{'scf.execute_region' op along control flow edge from Operation scf.break to parent: region branch point has 0 operands, but region successor needs 1 inputs}}
+  %res = scf.execute_region -> f32 {
+  ^bb0(%t: token):
+    // expected-note @below {{region branch point}}
+    scf.break %t
+  }
+  return %res : f32
+}
+
+// -----
+
+func.func @break_wrong_result_type(%val: i32) -> f32 {
+  // expected-error @below {{'scf.execute_region' op along control flow edge from Operation scf.break to parent: successor operand type #0 'i32' should match successor input type #0 'f32'}}
+  %res = scf.execute_region -> f32 {
+  ^bb0(%t: token):
+    // expected-note @below {{region branch point}}
+    scf.break %t, %val : i32
+  }
+  return %res : f32
+}
+
+// -----
+
+// A `scf.break` may only pass through ops that are transparent to
+// region-breaking control flow (the `PropagateControlFlowBreak` trait). Here
+// the break targets the `scf.execute_region` but is nested under a
+// `test.one_region_op`, which does not carry that trait.
+func.func @break_through_non_transparent(%val: f32) -> f32 {
+  %res = scf.execute_region -> f32 {
+  ^bb0(%tok: token):
+    "test.one_region_op"() ({
+      // expected-error @below {{'scf.break' op cannot break through 'test.one_region_op': op does not implement the 'PropagateControlFlowBreak' trait}}
+      scf.break %tok, %val : f32
+    }) : () -> ()
+    scf.yield %val : f32
+  }
+  return %res : f32
 }

--- a/mlir/test/Dialect/SCF/lower-early-exit-invalid.mlir
+++ b/mlir/test/Dialect/SCF/lower-early-exit-invalid.mlir
@@ -1,0 +1,27 @@
+// RUN: mlir-opt %s -pass-pipeline='builtin.module(func.func(scf-lower-early-exit))' -split-input-file -verify-diagnostics
+
+func.func @reject_cf_br(%v: f32) -> f32 {
+  // expected-error @below {{'scf.execute_region' op contains unsupported terminator 'cf.br'; expected 'scf.yield' or 'scf.break'}}
+  %0 = scf.execute_region -> f32 {
+  ^bb0(%tok: token):
+    cf.br ^bb1
+  ^bb1:
+    scf.yield %v : f32
+  }
+  return %0 : f32
+}
+
+// -----
+
+func.func @reject_cf_cond_br(%c: i1, %v: f32) -> f32 {
+  // expected-error @below {{'scf.execute_region' op contains unsupported terminator 'cf.cond_br'; expected 'scf.yield' or 'scf.break'}}
+  %0 = scf.execute_region -> f32 {
+  ^bb0(%tok: token):
+    cf.cond_br %c, ^bb1, ^bb2
+  ^bb1:
+    scf.yield %v : f32
+  ^bb2:
+    scf.yield %v : f32
+  }
+  return %0 : f32
+}

--- a/mlir/test/Dialect/SCF/lower-early-exit.mlir
+++ b/mlir/test/Dialect/SCF/lower-early-exit.mlir
@@ -1,0 +1,702 @@
+// RUN: mlir-opt %s -pass-pipeline='builtin.module(func.func(scf-lower-early-exit))' -split-input-file | FileCheck %s
+
+// Scenario 1: `scf.break` directly in the target's entry block becomes
+// `scf.yield`.
+
+// CHECK-LABEL:   func.func @break_in_entry(
+// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9_]*]]: f32) -> f32 {
+// CHECK:           %[[EXECUTE_REGION_0:.*]] = scf.execute_region -> f32 {
+// CHECK:             scf.yield %[[ARG0]] : f32
+// CHECK:           }
+// CHECK:           return %[[EXECUTE_REGION_0]] : f32
+// CHECK:         }
+func.func @break_in_entry(%v: f32) -> f32 {
+  %0 = scf.execute_region -> f32 {
+  ^bb0(%tok: token):
+    scf.break %tok, %v : f32
+  }
+  return %0 : f32
+}
+
+// -----
+
+// Scenario 2: `scf.break` inside an `scf.if`, with trailing ops after the if.
+// After lowering, no break remains, the if has both branches yielding f32,
+// and the trailing ops live in the else branch.
+
+// CHECK-LABEL:   func.func @break_in_if(
+// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9_]*]]: i1,
+// CHECK-SAME:      %[[ARG1:[a-zA-Z0-9_]*]]: f32,
+// CHECK-SAME:      %[[ARG2:[a-zA-Z0-9_]*]]: f32) -> f32 {
+// CHECK:           %[[EXECUTE_REGION_0:.*]] = scf.execute_region -> f32 {
+// CHECK:             %[[IF_0:.*]] = scf.if %[[ARG0]] -> (f32) {
+// CHECK:               scf.yield %[[ARG1]] : f32
+// CHECK:             } else {
+// CHECK:               %[[ADDF_0:.*]] = arith.addf %[[ARG2]], %[[ARG2]] : f32
+// CHECK:               scf.yield %[[ADDF_0]] : f32
+// CHECK:             }
+// CHECK:             scf.yield %[[IF_0]] : f32
+// CHECK:           }
+// CHECK:           return %[[EXECUTE_REGION_0]] : f32
+// CHECK:         }
+func.func @break_in_if(%cond: i1, %v1: f32, %v2: f32) -> f32 {
+  %0 = scf.execute_region -> f32 {
+  ^bb0(%tok: token):
+    scf.if %cond {
+      scf.break %tok, %v1 : f32
+    }
+    %1 = arith.addf %v2, %v2 : f32
+    scf.yield %1 : f32
+  }
+  return %0 : f32
+}
+
+// -----
+
+// Scenario 3: `scf.break` inside an inner `scf.execute_region` targeting the
+// outer one. The inner execute_region is augmented with extra results to
+// thread the broken-out value and a flag, and a guarded re-break is inserted
+// in the outer body.
+
+// CHECK-LABEL:   func.func @break_through_execute_region(
+// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9_]*]]: i1,
+// CHECK-SAME:      %[[ARG1:[a-zA-Z0-9_]*]]: f32,
+// CHECK-SAME:      %[[ARG2:[a-zA-Z0-9_]*]]: f32) -> f32 {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant false
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant true
+// CHECK:           %[[POISON_0:.*]] = ub.poison : f32
+// CHECK:           %[[EXECUTE_REGION_0:.*]] = scf.execute_region -> f32 {
+// CHECK:             %[[EXECUTE_REGION_1:.*]]:3 = scf.execute_region -> (f32, i1, f32) {
+// CHECK:               %[[IF_0:.*]]:3 = scf.if %[[ARG0]] -> (f32, i1, f32) {
+// CHECK:                 scf.yield %[[POISON_0]], %[[CONSTANT_1]], %[[ARG1]] : f32, i1, f32
+// CHECK:               } else {
+// CHECK:                 "test.some_compute"() : () -> ()
+// CHECK:                 scf.yield %[[ARG2]], %[[CONSTANT_0]], %[[POISON_0]] : f32, i1, f32
+// CHECK:               }
+// CHECK:               scf.yield %[[VAL_0:.*]]#0, %[[VAL_0]]#1, %[[VAL_0]]#2 : f32, i1, f32
+// CHECK:             }
+// CHECK:             %[[IF_1:.*]] = scf.if %[[VAL_1:.*]]#1 -> (f32) {
+// CHECK:               scf.yield %[[VAL_1]]#2 : f32
+// CHECK:             } else {
+// CHECK:               %[[VAL_2:.*]] = "test.use"(%[[VAL_3:.*]]#0) : (f32) -> f32
+// CHECK:               scf.yield %[[VAL_2]] : f32
+// CHECK:             }
+// CHECK:             scf.yield %[[IF_1]] : f32
+// CHECK:           }
+// CHECK:           return %[[EXECUTE_REGION_0]] : f32
+// CHECK:         }
+func.func @break_through_execute_region(%c1: i1, %v1: f32, %v2: f32) -> f32 {
+  %0 = scf.execute_region -> f32 {
+  ^bb0(%tok: token):
+    %b = scf.execute_region -> f32 {
+    ^bb0(%tok2: token):
+      scf.if %c1 {
+        scf.break %tok, %v1 : f32
+      }
+      "test.some_compute"() : () -> ()
+      scf.yield %v2 : f32
+    }
+    %u = "test.use"(%b) : (f32) -> f32
+    scf.yield %u : f32
+  }
+  return %0 : f32
+}
+
+// -----
+
+// A pre-existing token-bearing execute_region with no break inside is left
+// structurally similar (the body's yield remains the only terminator).
+
+// CHECK-LABEL:   func.func @no_break_inside(
+// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9_]*]]: f32) -> f32 {
+// CHECK:           %[[EXECUTE_REGION_0:.*]] = scf.execute_region -> f32 {
+// CHECK:             scf.yield %[[ARG0]] : f32
+// CHECK:           }
+// CHECK:           return %[[EXECUTE_REGION_0]] : f32
+// CHECK:         }
+func.func @no_break_inside(%v: f32) -> f32 {
+  %0 = scf.execute_region -> f32 {
+  ^bb0(%tok: token):
+    scf.yield %v : f32
+  }
+  return %0 : f32
+}
+
+// -----
+
+// A break nested inside two `scf.if` ops (both forwarding through the target's
+// yield) should be replaced with a yield after sinking trailing ops into the
+// fall-through branches.
+
+// CHECK-LABEL:   func.func @break_in_nested_if(
+// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9_]*]]: i1,
+// CHECK-SAME:      %[[ARG1:[a-zA-Z0-9_]*]]: i1,
+// CHECK-SAME:      %[[ARG2:[a-zA-Z0-9_]*]]: f32,
+// CHECK-SAME:      %[[ARG3:[a-zA-Z0-9_]*]]: f32) -> f32 {
+// CHECK:           %[[EXECUTE_REGION_0:.*]] = scf.execute_region -> f32 {
+// CHECK:             %[[IF_0:.*]] = scf.if %[[ARG0]] -> (f32) {
+// CHECK:               %[[IF_1:.*]] = scf.if %[[ARG1]] -> (f32) {
+// CHECK:                 scf.yield %[[ARG2]] : f32
+// CHECK:               } else {
+// CHECK:                 scf.yield %[[ARG3]] : f32
+// CHECK:               }
+// CHECK:               scf.yield %[[IF_1]] : f32
+// CHECK:             } else {
+// CHECK:               scf.yield %[[ARG3]] : f32
+// CHECK:             }
+// CHECK:             scf.yield %[[IF_0]] : f32
+// CHECK:           }
+// CHECK:           return %[[EXECUTE_REGION_0]] : f32
+// CHECK:         }
+func.func @break_in_nested_if(%c1: i1, %c2: i1, %v1: f32, %v2: f32) -> f32 {
+  %0 = scf.execute_region -> f32 {
+  ^bb0(%tok: token):
+    scf.if %c1 {
+      scf.if %c2 {
+        scf.break %tok, %v1 : f32
+      }
+    }
+    scf.yield %v2 : f32
+  }
+  return %0 : f32
+}
+
+// -----
+
+// `scf.break` in the else-branch should be handled symmetrically to the
+// then-branch case.
+
+// CHECK-LABEL:   func.func @break_in_else(
+// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9_]*]]: i1,
+// CHECK-SAME:      %[[ARG1:[a-zA-Z0-9_]*]]: f32,
+// CHECK-SAME:      %[[ARG2:[a-zA-Z0-9_]*]]: f32) -> f32 {
+// CHECK:           %[[EXECUTE_REGION_0:.*]] = scf.execute_region -> f32 {
+// CHECK:             %[[IF_0:.*]] = scf.if %[[ARG0]] -> (f32) {
+// CHECK:               %[[ADDF_0:.*]] = arith.addf %[[ARG2]], %[[ARG2]] : f32
+// CHECK:               scf.yield %[[ADDF_0]] : f32
+// CHECK:             } else {
+// CHECK:               scf.yield %[[ARG1]] : f32
+// CHECK:             }
+// CHECK:             scf.yield %[[IF_0]] : f32
+// CHECK:           }
+// CHECK:           return %[[EXECUTE_REGION_0]] : f32
+// CHECK:         }
+func.func @break_in_else(%cond: i1, %v1: f32, %v2: f32) -> f32 {
+  %0 = scf.execute_region -> f32 {
+  ^bb0(%tok: token):
+    scf.if %cond {
+    } else {
+      scf.break %tok, %v1 : f32
+    }
+    %r = arith.addf %v2, %v2 : f32
+    scf.yield %r : f32
+  }
+  return %0 : f32
+}
+
+// -----
+
+// `scf.execute_region` ops with no result and no break inside are left
+// untouched (other than the token block argument, which we keep around -- it
+// can be eliminated by canonicalization).
+
+// CHECK-LABEL:   func.func @nontoken_execute_region() {
+// CHECK:           scf.execute_region {
+// CHECK:             "test.foo"() : () -> ()
+// CHECK:             scf.yield
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+func.func @nontoken_execute_region() {
+  scf.execute_region {
+    "test.foo"() : () -> ()
+    scf.yield
+  }
+  return
+}
+
+// -----
+
+// Both branches of an `scf.if` break to the same target. Lowering converts
+// each break into the corresponding "true / break-val" yield, and the if
+// becomes effectively unconditional (the parent yield still forwards).
+
+// CHECK-LABEL:   func.func @break_in_both_branches_same_target(
+// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9_]*]]: i1,
+// CHECK-SAME:      %[[ARG1:[a-zA-Z0-9_]*]]: f32,
+// CHECK-SAME:      %[[ARG2:[a-zA-Z0-9_]*]]: f32) -> f32 {
+// CHECK:           %[[EXECUTE_REGION_0:.*]] = scf.execute_region -> f32 {
+// CHECK:             %[[IF_0:.*]] = scf.if %[[ARG0]] -> (f32) {
+// CHECK:               scf.yield %[[ARG1]] : f32
+// CHECK:             } else {
+// CHECK:               scf.yield %[[ARG2]] : f32
+// CHECK:             }
+// CHECK:             scf.yield %[[IF_0]] : f32
+// CHECK:           }
+// CHECK:           return %[[EXECUTE_REGION_0]] : f32
+// CHECK:         }
+func.func @break_in_both_branches_same_target(%cond: i1, %v1: f32, %v2: f32)
+    -> f32 {
+  %0 = scf.execute_region -> f32 {
+  ^bb0(%tok: token):
+    scf.if %cond {
+      scf.break %tok, %v1 : f32
+    } else {
+      scf.break %tok, %v2 : f32
+    }
+    // Unreachable trailing op (both branches break) — still legal IR.
+    %unused = arith.constant 0.0 : f32
+    scf.yield %unused : f32
+  }
+  return %0 : f32
+}
+
+// -----
+
+// One branch breaks, the other yields. After lowering the if has both
+// branches yielding the same f32 (one from the break value, one from the
+// fall-through path).
+
+// CHECK-LABEL:   func.func @break_then_yield_else(
+// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9_]*]]: i1,
+// CHECK-SAME:      %[[ARG1:[a-zA-Z0-9_]*]]: f32,
+// CHECK-SAME:      %[[ARG2:[a-zA-Z0-9_]*]]: f32) -> f32 {
+// CHECK:           %[[EXECUTE_REGION_0:.*]] = scf.execute_region -> f32 {
+// CHECK:             %[[IF_0:.*]] = scf.if %[[ARG0]] -> (f32) {
+// CHECK:               scf.yield %[[ARG1]] : f32
+// CHECK:             } else {
+// CHECK:               scf.yield %[[ARG2]] : f32
+// CHECK:             }
+// CHECK:             scf.yield %[[IF_0]] : f32
+// CHECK:           }
+// CHECK:           return %[[EXECUTE_REGION_0]] : f32
+// CHECK:         }
+func.func @break_then_yield_else(%cond: i1, %v1: f32, %v2: f32) -> f32 {
+  %0 = scf.execute_region -> f32 {
+  ^bb0(%tok: token):
+    %y = scf.if %cond -> f32 {
+      scf.break %tok, %v1 : f32
+    } else {
+      scf.yield %v2 : f32
+    }
+    scf.yield %y : f32
+  }
+  return %0 : f32
+}
+
+// -----
+
+// The "then" branch breaks to the outer execute_region and the "else" branch
+// breaks to the inner (self) one. The inner execute_region grows by an
+// (i1, f32) pair for the outer target; the self-break populates the original
+// f32 slot directly.
+
+// A single guarded re-break to the outer target, immediately re-lowered by
+// the outer pass into a yielding `scf.if`.
+// CHECK-LABEL:   func.func @break_two_branches_two_targets(
+// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9_]*]]: i1,
+// CHECK-SAME:      %[[ARG1:[a-zA-Z0-9_]*]]: f32,
+// CHECK-SAME:      %[[ARG2:[a-zA-Z0-9_]*]]: f32) -> f32 {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant false
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant true
+// CHECK:           %[[POISON_0:.*]] = ub.poison : f32
+// CHECK:           %[[EXECUTE_REGION_0:.*]] = scf.execute_region -> f32 {
+// CHECK:             %[[EXECUTE_REGION_1:.*]]:3 = scf.execute_region -> (f32, i1, f32) {
+// CHECK:               %[[IF_0:.*]]:3 = scf.if %[[ARG0]] -> (f32, i1, f32) {
+// CHECK:                 scf.yield %[[POISON_0]], %[[CONSTANT_1]], %[[ARG1]] : f32, i1, f32
+// CHECK:               } else {
+// CHECK:                 scf.yield %[[ARG2]], %[[CONSTANT_0]], %[[POISON_0]] : f32, i1, f32
+// CHECK:               }
+// CHECK:               scf.yield %[[VAL_0:.*]]#0, %[[VAL_0]]#1, %[[VAL_0]]#2 : f32, i1, f32
+// CHECK:             }
+// CHECK:             %[[IF_1:.*]] = scf.if %[[VAL_1:.*]]#1 -> (f32) {
+// CHECK:               scf.yield %[[VAL_1]]#2 : f32
+// CHECK:             } else {
+// CHECK:               scf.yield %[[VAL_2:.*]]#0 : f32
+// CHECK:             }
+// CHECK:             scf.yield %[[IF_1]] : f32
+// CHECK:           }
+// CHECK:           return %[[EXECUTE_REGION_0]] : f32
+// CHECK:         }
+func.func @break_two_branches_two_targets(%c: i1, %v1: f32, %v2: f32) -> f32 {
+  %0 = scf.execute_region -> f32 {
+  ^bb0(%tok_outer: token):
+    %r = scf.execute_region -> f32 {
+    ^bb0(%tok_inner: token):
+      %x = scf.if %c -> f32 {
+        scf.break %tok_outer, %v1 : f32
+      } else {
+        scf.break %tok_inner, %v2 : f32
+      }
+      scf.yield %x : f32
+    }
+    scf.yield %r : f32
+  }
+  return %0 : f32
+}
+
+// -----
+
+// Multiple distinct outer break targets: an inner execute_region contains two
+// `scf.if` ops, each of which breaks to a different ancestor execute_region.
+// The inner execute_region's result list grows by (1 + |target.results|)
+// slots per outer target -- here, 1 + 1 (f32) + 1 + 1 (i32) = 4 extra results.
+// All breaks are eliminated; each outer target is handled by the post-region
+// guarded `scf.if { scf.break }` it generates (which is then re-lowered by
+// the outer pass).
+
+// The lowering augments the middle execute_region (original i32) with one
+// `(i1, f32)` pair for the outermost target, and the innermost
+// execute_region (original f32) with both an `(i1, i32)` pair for the
+// middle target and an `(i1, f32)` pair for the outermost target. The
+// exact order in which slot pairs are appended is an implementation
+// detail of the lowering pass; what matters here is that both targets
+// are threaded out cleanly and turn into guarded re-breaks that
+// themselves get resolved into forwarding `scf.if`s.
+
+//
+// Middle execute_region: original i32 result + (i1, f32) for the
+// outermost target.
+//
+// Innermost execute_region: original f32 result + (i1, i32) for the
+// middle target + (i1, f32) for the outermost target.
+//
+// The chain `scf.if`s inside the innermost body all carry the same
+// (f32, i1, i32, i1, f32) shape. Both original breaks have become
+// augmented yields (with poison for the slots the branch doesn't drive).
+//
+// First post-region guard (in the middle ER's body): re-break for the
+// outermost target, already turned into a forwarding `scf.if -> i32` by
+// the resolve step.
+//
+// Second post-region guard (in the outermost ER's body): re-break for
+// the outermost target, resolved into a forwarding `scf.if -> f32`.
+// CHECK-LABEL:   func.func @break_to_two_outer_targets(
+// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9_]*]]: i1,
+// CHECK-SAME:      %[[ARG1:[a-zA-Z0-9_]*]]: i1,
+// CHECK-SAME:      %[[ARG2:[a-zA-Z0-9_]*]]: f32,
+// CHECK-SAME:      %[[ARG3:[a-zA-Z0-9_]*]]: i32,
+// CHECK-SAME:      %[[ARG4:[a-zA-Z0-9_]*]]: f32) -> f32 {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant false
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant true
+// CHECK:           %[[POISON_I32:.*]] = ub.poison : i32
+// CHECK:           %[[POISON_I1:.*]] = ub.poison : i1
+// CHECK:           %[[POISON_F32:.*]] = ub.poison : f32
+// CHECK:           %[[EXECUTE_REGION_0:.*]] = scf.execute_region -> f32 {
+// CHECK:             %[[EXECUTE_REGION_1:.*]]:3 = scf.execute_region -> (i32, i1, f32) {
+// CHECK:               %[[EXECUTE_REGION_2:.*]]:5 = scf.execute_region -> (f32, i1, i32, i1, f32) {
+// CHECK:                 %[[IF_0:.*]]:5 = scf.if %[[ARG0]] -> (f32, i1, i32, i1, f32) {
+// CHECK:                   scf.yield %[[POISON_F32]], %[[POISON_I1]], %[[POISON_I32]], %[[CONSTANT_1]], %[[ARG2]] : f32, i1, i32, i1, f32
+// CHECK:                 } else {
+// CHECK:                   %[[IF_1:.*]]:3 = scf.if %[[ARG1]] -> (f32, i1, i32) {
+// CHECK:                     scf.yield %[[POISON_F32]], %[[CONSTANT_1]], %[[ARG3]] : f32, i1, i32
+// CHECK:                   } else {
+// CHECK:                     scf.yield %[[ARG4]], %[[CONSTANT_0]], %[[POISON_I32]] : f32, i1, i32
+// CHECK:                   }
+// CHECK:                   scf.yield %[[IF_1]]#0, %[[IF_1]]#1, %[[IF_1]]#2, %[[CONSTANT_0]], %[[POISON_F32]] : f32, i1, i32, i1, f32
+// CHECK:                 }
+// CHECK:                 scf.yield %[[IF_0]]#0, %[[IF_0]]#1, %[[IF_0]]#2, %[[IF_0]]#3, %[[IF_0]]#4 : f32, i1, i32, i1, f32
+// CHECK:               }
+// CHECK:               %[[IF_2:.*]]:3 = scf.if %[[EXECUTE_REGION_2]]#3 -> (i32, i1, f32) {
+// CHECK:                 scf.yield %[[POISON_I32]], %[[CONSTANT_1]], %[[EXECUTE_REGION_2]]#4 : i32, i1, f32
+// CHECK:               } else {
+// CHECK:                 %[[IF_3:.*]] = scf.if %[[EXECUTE_REGION_2]]#1 -> (i32) {
+// CHECK:                   scf.yield %[[EXECUTE_REGION_2]]#2 : i32
+// CHECK:                 } else {
+// CHECK:                   "test.use_f32"(%[[EXECUTE_REGION_2]]#0) : (f32) -> ()
+// CHECK:                   scf.yield %[[ARG3]] : i32
+// CHECK:                 }
+// CHECK:                 scf.yield %[[IF_3]], %[[CONSTANT_0]], %[[POISON_F32]] : i32, i1, f32
+// CHECK:               }
+// CHECK:               scf.yield %[[IF_2]]#0, %[[IF_2]]#1, %[[IF_2]]#2 : i32, i1, f32
+// CHECK:             }
+// CHECK:             %[[IF_4:.*]] = scf.if %[[EXECUTE_REGION_1]]#1 -> (f32) {
+// CHECK:               scf.yield %[[EXECUTE_REGION_1]]#2 : f32
+// CHECK:             } else {
+// CHECK:               "test.use_i32"(%[[EXECUTE_REGION_1]]#0) : (i32) -> ()
+// CHECK:               scf.yield %[[ARG2]] : f32
+// CHECK:             }
+// CHECK:             scf.yield %[[IF_4]] : f32
+// CHECK:           }
+// CHECK:           return %[[EXECUTE_REGION_0]] : f32
+// CHECK:         }
+func.func @break_to_two_outer_targets(%c1: i1, %c2: i1, %v1: f32, %v2: i32,
+                                       %v3: f32) -> f32 {
+  %0 = scf.execute_region -> f32 {
+  ^bb0(%tok1: token):
+    %r = scf.execute_region -> i32 {
+    ^bb0(%tok2: token):
+      %s = scf.execute_region -> f32 {
+      ^bb0(%tok3: token):
+        scf.if %c1 {
+          scf.break %tok1, %v1 : f32
+        }
+        scf.if %c2 {
+          scf.break %tok2, %v2 : i32
+        }
+        scf.yield %v3 : f32
+      }
+      "test.use_f32"(%s) : (f32) -> ()
+      scf.yield %v2 : i32
+    }
+    "test.use_i32"(%r) : (i32) -> ()
+    scf.yield %v1 : f32
+  }
+  return %0 : f32
+}
+
+// -----
+
+// A self-break inside a then-branch and another self-break inside the else-
+// branch of the SAME if both target the inner execute_region. No outer
+// targets are involved, so no augmentation suffix is added; both breaks
+// become plain `scf.yield`s.
+
+// CHECK-LABEL:   func.func @both_branches_self_break(
+// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9_]*]]: i1,
+// CHECK-SAME:      %[[ARG1:[a-zA-Z0-9_]*]]: f32,
+// CHECK-SAME:      %[[ARG2:[a-zA-Z0-9_]*]]: f32) -> f32 {
+// CHECK:           %[[EXECUTE_REGION_0:.*]] = scf.execute_region -> f32 {
+// CHECK:             %[[IF_0:.*]] = scf.if %[[ARG0]] -> (f32) {
+// CHECK:               scf.yield %[[ARG1]] : f32
+// CHECK:             } else {
+// CHECK:               scf.yield %[[ARG2]] : f32
+// CHECK:             }
+// CHECK:             scf.yield %[[IF_0]] : f32
+// CHECK:           }
+// CHECK:           return %[[EXECUTE_REGION_0]] : f32
+// CHECK:         }
+func.func @both_branches_self_break(%c: i1, %v1: f32, %v2: f32) -> f32 {
+  %0 = scf.execute_region -> f32 {
+  ^bb0(%tok: token):
+    scf.if %c {
+      scf.break %tok, %v1 : f32
+    } else {
+      scf.break %tok, %v2 : f32
+    }
+    scf.yield %v1 : f32
+  }
+  return %0 : f32
+}
+
+// -----
+
+// A `scf.break` carrying multiple result values.
+
+// CHECK-LABEL:   func.func @break_multi_result(
+// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9_]*]]: i1,
+// CHECK-SAME:      %[[ARG1:[a-zA-Z0-9_]*]]: f32,
+// CHECK-SAME:      %[[ARG2:[a-zA-Z0-9_]*]]: i32,
+// CHECK-SAME:      %[[ARG3:[a-zA-Z0-9_]*]]: f32,
+// CHECK-SAME:      %[[ARG4:[a-zA-Z0-9_]*]]: i32) -> (f32, i32) {
+// CHECK:           %[[EXECUTE_REGION_0:.*]]:2 = scf.execute_region -> (f32, i32) {
+// CHECK:             %[[IF_0:.*]]:2 = scf.if %[[ARG0]] -> (f32, i32) {
+// CHECK:               scf.yield %[[ARG1]], %[[ARG2]] : f32, i32
+// CHECK:             } else {
+// CHECK:               scf.yield %[[ARG3]], %[[ARG4]] : f32, i32
+// CHECK:             }
+// CHECK:             scf.yield %[[VAL_0:.*]]#0, %[[VAL_0]]#1 : f32, i32
+// CHECK:           }
+// CHECK:           return %[[VAL_1:.*]]#0, %[[VAL_1]]#1 : f32, i32
+// CHECK:         }
+func.func @break_multi_result(%c: i1, %a: f32, %b: i32, %x: f32, %y: i32)
+    -> (f32, i32) {
+  %0:2 = scf.execute_region -> (f32, i32) {
+  ^bb0(%tok: token):
+    scf.if %c {
+      scf.break %tok, %a, %b : f32, i32
+    }
+    scf.yield %x, %y : f32, i32
+  }
+  return %0#0, %0#1 : f32, i32
+}
+
+// -----
+
+// A zero-result early exit (a `scf.break` with no values).
+
+// CHECK-LABEL:   func.func @break_zero_result(
+// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9_]*]]: i1) {
+// CHECK:           scf.execute_region {
+// CHECK:             scf.if %[[ARG0]] {
+// CHECK:             } else {
+// CHECK:               "test.body"() : () -> ()
+// CHECK:             }
+// CHECK:             scf.yield
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+func.func @break_zero_result(%c: i1) {
+  scf.execute_region {
+  ^bb0(%tok: token):
+    scf.if %c {
+      scf.break %tok
+    }
+    "test.body"() : () -> ()
+    scf.yield
+  }
+  return
+}
+
+// -----
+
+// A break nested in two `scf.if`s that targets the *outer* execute_region
+// (combines flag-based hoisting with if-sinking/tail-duplication).
+
+// CHECK-LABEL:   func.func @break_outer_through_nested_if(
+// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9_]*]]: i1,
+// CHECK-SAME:      %[[ARG1:[a-zA-Z0-9_]*]]: i1,
+// CHECK-SAME:      %[[ARG2:[a-zA-Z0-9_]*]]: f32,
+// CHECK-SAME:      %[[ARG3:[a-zA-Z0-9_]*]]: f32) -> f32 {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant false
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant true
+// CHECK:           %[[POISON_0:.*]] = ub.poison : f32
+// CHECK:           %[[EXECUTE_REGION_0:.*]] = scf.execute_region -> f32 {
+// CHECK:             %[[EXECUTE_REGION_1:.*]]:3 = scf.execute_region -> (f32, i1, f32) {
+// CHECK:               %[[IF_0:.*]]:3 = scf.if %[[ARG0]] -> (f32, i1, f32) {
+// CHECK:                 %[[IF_1:.*]]:3 = scf.if %[[ARG1]] -> (f32, i1, f32) {
+// CHECK:                   scf.yield %[[POISON_0]], %[[CONSTANT_1]], %[[ARG2]] : f32, i1, f32
+// CHECK:                 } else {
+// CHECK:                   scf.yield %[[ARG3]], %[[CONSTANT_0]], %[[POISON_0]] : f32, i1, f32
+// CHECK:                 }
+// CHECK:                 scf.yield %[[VAL_0:.*]]#0, %[[VAL_0]]#1, %[[VAL_0]]#2 : f32, i1, f32
+// CHECK:               } else {
+// CHECK:                 scf.yield %[[ARG3]], %[[CONSTANT_0]], %[[POISON_0]] : f32, i1, f32
+// CHECK:               }
+// CHECK:               scf.yield %[[VAL_1:.*]]#0, %[[VAL_1]]#1, %[[VAL_1]]#2 : f32, i1, f32
+// CHECK:             }
+// CHECK:             %[[IF_2:.*]] = scf.if %[[VAL_2:.*]]#1 -> (f32) {
+// CHECK:               scf.yield %[[VAL_2]]#2 : f32
+// CHECK:             } else {
+// CHECK:               %[[VAL_3:.*]] = "test.use"(%[[VAL_4:.*]]#0) : (f32) -> f32
+// CHECK:               scf.yield %[[VAL_3]] : f32
+// CHECK:             }
+// CHECK:             scf.yield %[[IF_2]] : f32
+// CHECK:           }
+// CHECK:           return %[[EXECUTE_REGION_0]] : f32
+// CHECK:         }
+func.func @break_outer_through_nested_if(%c1: i1, %c2: i1, %v1: f32, %v2: f32)
+    -> f32 {
+  %0 = scf.execute_region -> f32 {
+  ^bb0(%tok: token):
+    %r = scf.execute_region -> f32 {
+    ^bb1(%tok1: token):
+      scf.if %c1 {
+        scf.if %c2 {
+          scf.break %tok, %v1 : f32
+        }
+      }
+      scf.yield %v2 : f32
+    }
+    %u = "test.use"(%r) : (f32) -> f32
+    scf.yield %u : f32
+  }
+  return %0 : f32
+}
+
+// -----
+
+// The continuation after a breaking `scf.if` has side effects and consumes the
+// if's result; sinking must remap the result to the fall-through value.
+
+// CHECK-LABEL:   func.func @break_sink_with_use(
+// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9_]*]]: i1,
+// CHECK-SAME:      %[[ARG1:[a-zA-Z0-9_]*]]: f32,
+// CHECK-SAME:      %[[ARG2:[a-zA-Z0-9_]*]]: f32) -> f32 {
+// CHECK:           %[[EXECUTE_REGION_0:.*]] = scf.execute_region -> f32 {
+// CHECK:             %[[IF_0:.*]] = scf.if %[[ARG0]] -> (f32) {
+// CHECK:               scf.yield %[[ARG1]] : f32
+// CHECK:             } else {
+// CHECK:               %[[ADDF_0:.*]] = arith.addf %[[ARG2]], %[[ARG2]] : f32
+// CHECK:               "test.sink"(%[[ADDF_0]]) : (f32) -> ()
+// CHECK:               scf.yield %[[ADDF_0]] : f32
+// CHECK:             }
+// CHECK:             scf.yield %[[IF_0]] : f32
+// CHECK:           }
+// CHECK:           return %[[EXECUTE_REGION_0]] : f32
+// CHECK:         }
+func.func @break_sink_with_use(%c: i1, %v1: f32, %v2: f32) -> f32 {
+  %0 = scf.execute_region -> f32 {
+  ^bb0(%tok: token):
+    %y = scf.if %c -> f32 {
+      scf.break %tok, %v1 : f32
+    } else {
+      scf.yield %v2 : f32
+    }
+    %z = arith.addf %y, %y : f32
+    "test.sink"(%z) : (f32) -> ()
+    scf.yield %z : f32
+  }
+  return %0 : f32
+}
+
+// -----
+
+// When an execute_region is widened, every break targeting its token must be
+// extended, including breaks nested under another token-bearing execute_region.
+// Otherwise the nested break would still have the old operand list for the
+// widened target.
+
+// CHECK-LABEL:   func.func @extend_nested_break_to_widened_region(
+// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9_]*]]: i1,
+// CHECK-SAME:      %[[ARG1:[a-zA-Z0-9_]*]]: i1,
+// CHECK-SAME:      %[[ARG2:[a-zA-Z0-9_]*]]: f32,
+// CHECK-SAME:      %[[ARG3:[a-zA-Z0-9_]*]]: f32,
+// CHECK-SAME:      %[[ARG4:[a-zA-Z0-9_]*]]: f32) -> f32 {
+// CHECK:           %[[FALSE:.*]] = arith.constant false
+// CHECK:           %[[TRUE:.*]] = arith.constant true
+// CHECK:           %[[POISON:.*]] = ub.poison : f32
+// CHECK:           %[[OUTER:.*]] = scf.execute_region -> f32 {
+// CHECK:             %[[INNER:.*]]:3 = scf.execute_region -> (f32, i1, f32) {
+// CHECK:               %[[IF_OUTER:.*]]:3 = scf.if %[[ARG0]] -> (f32, i1, f32) {
+// CHECK:                 scf.yield %[[POISON]], %[[TRUE]], %[[ARG2]] : f32, i1, f32
+// CHECK:               } else {
+// CHECK:                 %[[DEEP:.*]]:3 = scf.execute_region -> (f32, i1, f32) {
+// CHECK:                   %[[IF_DEEP:.*]]:3 = scf.if %[[ARG1]] -> (f32, i1, f32) {
+// CHECK:                     scf.yield %[[POISON]], %[[TRUE]], %[[ARG3]] : f32, i1, f32
+// CHECK:                   } else {
+// CHECK:                     scf.yield %[[ARG4]], %[[FALSE]], %[[POISON]] : f32, i1, f32
+// CHECK:                   }
+// CHECK:                   scf.yield %[[IF_DEEP]]#0, %[[IF_DEEP]]#1, %[[IF_DEEP]]#2 : f32, i1, f32
+// CHECK:                 }
+// CHECK:                 %[[IF_INNER_REBREAK:.*]] = scf.if %[[DEEP]]#1 -> (f32) {
+// CHECK:                   scf.yield %[[DEEP]]#2 : f32
+// CHECK:                 } else {
+// CHECK:                   scf.yield %[[DEEP]]#0 : f32
+// CHECK:                 }
+// CHECK:                 scf.yield %[[IF_INNER_REBREAK]], %[[FALSE]], %[[POISON]] : f32, i1, f32
+// CHECK:               }
+// CHECK:               scf.yield %[[IF_OUTER]]#0, %[[IF_OUTER]]#1, %[[IF_OUTER]]#2 : f32, i1, f32
+// CHECK:             }
+// CHECK:             %[[IF_OUTER_REBREAK:.*]] = scf.if %[[INNER]]#1 -> (f32) {
+// CHECK:               scf.yield %[[INNER]]#2 : f32
+// CHECK:             } else {
+// CHECK:               scf.yield %[[INNER]]#0 : f32
+// CHECK:             }
+// CHECK:             scf.yield %[[IF_OUTER_REBREAK]] : f32
+// CHECK:           }
+// CHECK:           return %[[OUTER]] : f32
+// CHECK:         }
+func.func @extend_nested_break_to_widened_region(%c1: i1, %c2: i1, %v1: f32,
+                                                 %v2: f32, %v3: f32) -> f32 {
+  %0 = scf.execute_region -> f32 {
+  ^bb0(%tok_outer: token):
+    %inner = scf.execute_region -> f32 {
+    ^bb0(%tok_inner: token):
+      scf.if %c1 {
+        scf.break %tok_outer, %v1 : f32
+      }
+      %deep = scf.execute_region -> f32 {
+      ^bb0(%tok_deep: token):
+        scf.if %c2 {
+          scf.break %tok_inner, %v2 : f32
+        }
+        scf.yield %v3 : f32
+      }
+      scf.yield %deep : f32
+    }
+    scf.yield %inner : f32
+  }
+  return %0 : f32
+}
+

--- a/mlir/test/Dialect/SCF/ops.mlir
+++ b/mlir/test/Dialect/SCF/ops.mlir
@@ -332,6 +332,85 @@ func.func @execute_region() -> i64 {
   return %res : i64
 }
 
+// CHECK-LABEL: func @execute_region_token
+func.func @execute_region_token(%cond: i1, %val: f32) -> f32 {
+  // CHECK: scf.execute_region -> f32 {
+  // CHECK-NEXT: ^bb0(%[[TOK:.*]]: token):
+  // CHECK-NEXT:   scf.if
+  // CHECK-NEXT:     scf.break %[[TOK]], %{{.*}} : f32
+  // CHECK-NEXT:   }
+  // CHECK-NEXT:   scf.yield %{{.*}} : f32
+  // CHECK-NEXT: }
+  %res = scf.execute_region -> f32 {
+  ^bb0(%tok: token):
+    scf.if %cond {
+      scf.break %tok, %val : f32
+    }
+    scf.yield %val : f32
+  }
+  return %res : f32
+}
+
+// CHECK-LABEL: func @execute_region_token_no_results
+func.func @execute_region_token_no_results(%cond: i1) {
+  // CHECK: scf.execute_region {
+  // CHECK-NEXT: ^bb0(%[[TOK:.*]]: token):
+  // CHECK-NEXT:   scf.if
+  // CHECK-NEXT:     scf.break %[[TOK]]
+  scf.execute_region {
+  ^bb0(%tok: token):
+    scf.if %cond {
+      scf.break %tok
+    }
+    scf.yield
+  }
+  return
+}
+
+// Early exit through a nested `scf.execute_region`. The inner break targets
+// the outer op via the outer's token.
+// CHECK-LABEL: func @execute_region_token_nested
+func.func @execute_region_token_nested(%cond: i1, %val: f32) -> f32 {
+  // CHECK: %[[OUTER:.*]] = scf.execute_region -> f32 {
+  // CHECK-NEXT: ^bb0(%[[T1:.*]]: token):
+  %res = scf.execute_region -> f32 {
+  ^bb0(%t1: token):
+    // CHECK: scf.execute_region {
+    // CHECK-NEXT: ^bb0(%{{.*}}: token):
+    // CHECK: scf.break %[[T1]], %{{.*}} : f32
+    scf.execute_region {
+    ^bb0(%t2: token):
+      scf.if %cond {
+        scf.break %t1, %val : f32
+      }
+      scf.yield
+    }
+    scf.yield %val : f32
+  }
+  return %res : f32
+}
+
+// All terminators of the inner `scf.execute_region` break to the outer one, so
+// the inner op declares a result (of a type that need not match the outer's)
+// that is never produced. The break carries the outer op's result type. This is
+// valid IR.
+// CHECK-LABEL: func @execute_region_all_break_outer
+func.func @execute_region_all_break_outer(%val: f32) -> f32 {
+  // CHECK: scf.execute_region -> f32 {
+  // CHECK-NEXT: ^bb0(%[[TOK:.*]]: token):
+  %res = scf.execute_region -> f32 {
+  ^bb0(%tok_outer: token):
+    // CHECK: scf.execute_region -> i32 {
+    // CHECK: scf.break %[[TOK]], %{{.*}} : f32
+    %inner = scf.execute_region -> i32 {
+    ^bb1(%tok_inner: token):
+      scf.break %tok_outer, %val : f32
+    }
+    scf.yield %val : f32
+  }
+  return %res : f32
+}
+
 // CHECK-LABEL: func.func @normalized_forall
 func.func @normalized_forall(%in: tensor<100xf32>, %out: tensor<100xf32>) {
   %c1 = arith.constant 1 : index

--- a/mlir/test/Transforms/sccp-structured.mlir
+++ b/mlir/test/Transforms/sccp-structured.mlir
@@ -229,3 +229,72 @@ func.func @while_loop_false_condition(%arg0 : index) -> index {
   // CHECK: return %[[C0]]
   func.return %1 : index
 }
+
+// -----
+
+// Both the early-exit (`scf.break`) path and the fall-through (`scf.yield`)
+// path produce the same constant, so the `scf.execute_region` result is a
+// constant. This requires sparse constant propagation to thread a value along
+// the early-exit edge modeled by RegionBranchOpInterface.
+
+// CHECK-LABEL: func @early_exit_constant(
+//       CHECK:   %[[C5:.*]] = arith.constant 5 : i32
+//       CHECK:   return %[[C5]] : i32
+func.func @early_exit_constant(%cond: i1) -> i32 {
+  %0 = scf.execute_region -> i32 {
+  ^bb0(%tok: token):
+    %c5 = arith.constant 5 : i32
+    scf.if %cond {
+      scf.break %tok, %c5 : i32
+    }
+    scf.yield %c5 : i32
+  }
+  return %0 : i32
+}
+
+// -----
+
+// The early-exit path produces 5 while the fall-through path produces 6, so
+// the result is *not* a constant. If the early-exit edge were not modeled,
+// constant propagation would only see the `scf.yield` and would incorrectly
+// fold the result to 6.
+
+// CHECK-LABEL: func @early_exit_not_constant(
+//       CHECK:   %[[R:.*]] = scf.execute_region
+//       CHECK:   return %[[R]] : i32
+func.func @early_exit_not_constant(%cond: i1) -> i32 {
+  %0 = scf.execute_region -> i32 {
+  ^bb0(%tok: token):
+    %c5 = arith.constant 5 : i32
+    %c6 = arith.constant 6 : i32
+    scf.if %cond {
+      scf.break %tok, %c5 : i32
+    }
+    scf.yield %c6 : i32
+  }
+  return %0 : i32
+}
+
+// -----
+
+// All terminators of the inner `scf.execute_region` break to the outer one, so
+// the inner result (and the outer `scf.yield` that forwards it) is on an
+// unreachable path. The outer result is therefore exactly the break's constant
+// (4): the never-produced inner result stays uninitialized and does not
+// pollute the meet.
+
+// CHECK-LABEL: func @early_exit_all_break_outer
+//       CHECK:   %[[C4:.*]] = arith.constant 4 : i32
+//       CHECK:   return %[[C4]] : i32
+func.func @early_exit_all_break_outer(%cond: i1) -> i32 {
+  %0 = scf.execute_region -> i32 {
+  ^bb0(%tok_outer: token):
+    %c4 = arith.constant 4 : i32
+    %1 = scf.execute_region -> i32 {
+    ^bb1(%tok_inner: token):
+      scf.break %tok_outer, %c4 : i32
+    }
+    scf.yield %1 : i32
+  }
+  return %0 : i32
+}


### PR DESCRIPTION
Allow breaking exit from `scf.execute_region` via `scf.if`.

* Add a new optional token entry block argument to `scf.execute_region`. Loop operations can follow the same design in the future.
* Add a new `scf.break` terminator that can target `scf.execute_region` ops. For now, only `scf.execute_region` ops can be targeted.
* Operations on the ancestor-path between a region terminator and the targeted operation must implement the `PropagateControlFlowBreak` trait. `scf.if` implements that trait.
* Extend the `RegionBranchOpInterface` to handle breaking exit.
* Extend the data flow analysis framework to support breaking exit.
* Add a new `LowerEarlyExit` pass that rewrites SCF IR with breaking exit to SCF IR without early exit.

Details on the `RegionBranchOpInterface`:
* A region successor can now target the parent, another region or an enclosing op. (Parent / enclosing op can be merged in a follow-up commit. To keep the diff smaller, this is not done in this commit.)
* Interface methods support only those region branch points that target this op.
* Add a new `...` interface method that enumerates all region branch points that target this operation. Token-based ops can enumerate those by collecting all users of the token.

Partly extracted from: https://github.com/llvm/llvm-project/pull/166688.
Co-authored-by: Mehdi Amini [joker.eph@gmail.com](mailto:joker.eph@gmail.com)
Assisted-by: Opus 4.7

