### PR TITLE
[lldb] Fix Symbol static_assert for 32 bit Windows

### DIFF
--- a/lldb/include/lldb/Symbol/Symbol.h
+++ b/lldb/include/lldb/Symbol/Symbol.h
@@ -364,7 +364,7 @@ protected:
 static_assert(
     sizeof(lldb_private::Symbol) == 80,
     "Symbol is a high volume data type, size must be increased with care");
-#elif __SIZEOF_POINTER__ == 4
+#elif __SIZEOF_POINTER__ == 4 && !defined(_WIN32)
 static_assert(
     sizeof(lldb_private::Symbol) == 52,
     "Symbol is a high volume data type, size must be increased with care");


### PR DESCRIPTION
Follow up to https://github.com/llvm/llvm-project/pull/200919#issuecomment-4600914496