### PR TITLE
[AMDGPU][NFC] Add CuModeOnly feature

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPU.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.td
@@ -236,6 +236,13 @@ def FeatureCuMode : SubtargetFeature<"cumode",
   "Enable CU wavefront execution mode"
 >;
 
+defm CuModeOnly : AMDGPUSubtargetFeature<"cumode-only",
+  "Target supports only CU mode",
+  /*GenPredicate=*/1,
+  /*GenAssemblerPredicate=*/1,
+  [FeatureCuMode]
+>;
+
 def FeaturePreciseMemory
     : SubtargetFeature<"precise-memory", "EnablePreciseMemory",
                        "true", "Enable precise memory mode">;
@@ -2094,7 +2101,7 @@ def FeatureISAVersion12_50_Common : FeatureSet<
    FeatureGFX1250Insts,
    FeatureBackOffBarrier,
    FeatureRequiresAlignedVGPRs,
-   FeatureCuMode,
+   FeatureCuModeOnly,
    Feature1024AddressableVGPRs,
    Feature64BitLiterals,
    FeatureLDSBankCount32,

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -1246,7 +1246,7 @@ unsigned getEUsPerCU(const MCSubtargetInfo &STI) {
   // workgroup must share".
 
   // GFX12.5 only supports CU mode, which contains four SIMDs.
-  if (isGFX1250(STI)) {
+  if (STI.getFeatureBits().test(FeatureCuModeOnly)) {
     assert(STI.getFeatureBits().test(FeatureCuMode));
     return 4;
   }


### PR DESCRIPTION
Introduce a dedicated subtarget feature for targets that only support CU mode. Use it instead of isGFX1250.

GFX13 can support both CU and WGP modes while still exposing GFX1250 instructions, so checking isGFX1250 is not specific enough for CU-mode-only behavior.