### PR TITLE
[CaptureTracking] Remove allocator comparison special case

### DIFF
--- a/llvm/lib/Analysis/CaptureTracking.cpp
+++ b/llvm/lib/Analysis/CaptureTracking.cpp
@@ -372,23 +372,11 @@ UseCaptureInfo llvm::DetermineUseCaptureKind(const Use &U, const Value *Base) {
   case Instruction::ICmp: {
     unsigned Idx = U.getOperandNo();
     unsigned OtherIdx = 1 - Idx;
+    // Check whether this is a comparison of the base pointer against
+    // null.
     if (isa<ConstantPointerNull>(I->getOperand(OtherIdx)) &&
-        cast<ICmpInst>(I)->isEquality()) {
-      // TODO(captures): Remove these special cases once we make use of
-      // captures(address_is_null).
-
-      // Don't count comparisons of a no-alias return value against null as
-      // captures. This allows us to ignore comparisons of malloc results
-      // with null, for example.
-      if (U->getType()->getPointerAddressSpace() == 0)
-        if (isNoAliasCall(U.get()->stripPointerCasts()))
-          return CaptureComponents::None;
-
-      // Check whether this is a comparison of the base pointer against
-      // null.
-      if (U.get() == Base)
-        return CaptureComponents::AddressIsNull;
-    }
+        cast<ICmpInst>(I)->isEquality() && U.get() == Base)
+      return CaptureComponents::AddressIsNull;
 
     // Otherwise, be conservative. There are crazy ways to capture pointers
     // using comparisons. However, only the address is captured, not the


### PR DESCRIPTION
CaptureTracking had a special case that (incorrectly) reported `captures(none)` for comparisons of allocation functions with null. Remove this special case and return the correct `captures(address_is_null)` result instead.

It seems like this doesn't have any practical benefit anymore, as things like AA will ignore address-only captures nowadays.