### PR TITLE
Reland [LLVM] Add flags to crash the opt/codegen pipeline

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/TriggerCrashPass.h
+++ b/llvm/include/llvm/Transforms/Utils/TriggerCrashPass.h
@@ -24,14 +24,12 @@ class TriggerCrashModulePass
     : public OptionalPassInfoMixin<TriggerCrashModulePass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
-  static StringRef name() { return "TriggerCrashModulePass"; }
 };
 
 class TriggerCrashFunctionPass
     : public OptionalPassInfoMixin<TriggerCrashFunctionPass> {
 public:
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
-  static StringRef name() { return "TriggerCrashFunctionPass"; }
 };
 
 FunctionPass *createTriggerCrashFunctionPass();

--- a/llvm/include/llvm/Transforms/Utils/TriggerCrashPass.h
+++ b/llvm/include/llvm/Transforms/Utils/TriggerCrashPass.h
@@ -1,0 +1,39 @@
+//===- TriggerCrashPass.h - Trigger Crash Passes ----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM Exceptions
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides passes that trigger crashes for testing purposes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_TRANSFORMS_UTILS_TRIGGERCRASHPASS_H
+#define LLVM_TRANSFORMS_UTILS_TRIGGERCRASHPASS_H
+
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/Pass.h"
+
+namespace llvm {
+
+class TriggerCrashModulePass
+    : public OptionalPassInfoMixin<TriggerCrashModulePass> {
+public:
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+};
+
+class TriggerCrashFunctionPass
+    : public OptionalPassInfoMixin<TriggerCrashFunctionPass> {
+public:
+  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+};
+
+FunctionPass *createTriggerCrashFunctionPass();
+
+} // namespace llvm
+
+#endif // LLVM_TRANSFORMS_UTILS_TRIGGERCRASHPASS_H

--- a/llvm/include/llvm/Transforms/Utils/TriggerCrashPass.h
+++ b/llvm/include/llvm/Transforms/Utils/TriggerCrashPass.h
@@ -1,4 +1,4 @@
-//===- TriggerCrashPass.h - Trigger Crash Passes ----------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -24,12 +24,14 @@ class TriggerCrashModulePass
     : public OptionalPassInfoMixin<TriggerCrashModulePass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  static StringRef name() { return "TriggerCrashModulePass"; }
 };
 
 class TriggerCrashFunctionPass
     : public OptionalPassInfoMixin<TriggerCrashFunctionPass> {
 public:
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  static StringRef name() { return "TriggerCrashFunctionPass"; }
 };
 
 FunctionPass *createTriggerCrashFunctionPass();

--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -50,6 +50,7 @@
 #include "llvm/Transforms/ObjCARC.h"
 #include "llvm/Transforms/Scalar.h"
 #include "llvm/Transforms/Utils.h"
+#include "llvm/Transforms/Utils/TriggerCrashPass.h"
 #include <cassert>
 #include <optional>
 #include <string>
@@ -99,6 +100,11 @@ static cl::opt<bool> DisableConstantHoisting("disable-constant-hoisting",
     cl::Hidden, cl::desc("Disable ConstantHoisting"));
 static cl::opt<bool> DisableCGP("disable-cgp", cl::Hidden,
     cl::desc("Disable Codegen Prepare"));
+
+static cl::opt<bool>
+    TriggerCrash("codegen-pipeline-trigger-crash", cl::init(false), cl::Hidden,
+                 cl::desc("Trigger crash in codegen pipeline"));
+
 static cl::opt<bool> DisableCopyProp("disable-copyprop", cl::Hidden,
     cl::desc("Disable Copy Propagation pass"));
 static cl::opt<bool> DisablePartialLibcallInlining("disable-partial-libcall-inlining",
@@ -1086,6 +1092,10 @@ bool TargetPassConfig::addISelPasses() {
   addPass(createPreISelIntrinsicLoweringPass());
   addPass(createExpandIRInstsPass(getOptLevel()));
   addIRPasses();
+
+  if (TriggerCrash)
+    addPass(createTriggerCrashFunctionPass());
+
   addCodeGenPrepare();
   addPassesToHandleExceptions();
   addISelPrepare();

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -386,6 +386,7 @@
 #include "llvm/Transforms/Utils/StripGCRelocates.h"
 #include "llvm/Transforms/Utils/StripNonLineTableDebugInfo.h"
 #include "llvm/Transforms/Utils/SymbolRewriter.h"
+#include "llvm/Transforms/Utils/TriggerCrashPass.h"
 #include "llvm/Transforms/Utils/UnifyFunctionExitNodes.h"
 #include "llvm/Transforms/Utils/UnifyLoopExits.h"
 #include "llvm/Transforms/Vectorize/LoadStoreVectorizer.h"
@@ -422,28 +423,6 @@ bool applyMIRDebugify(DIBuilder &DIB, Function &F, ModuleAnalysisManager &AM) {
         return MFA ? &MFA->getMF() : nullptr;
       });
 }
-
-// Passes for testing crashes.
-// DO NOT USE THIS EXCEPT FOR TESTING!
-class TriggerCrashModulePass
-    : public OptionalPassInfoMixin<TriggerCrashModulePass> {
-public:
-  PreservedAnalyses run(Module &, ModuleAnalysisManager &) {
-    abort();
-    return PreservedAnalyses::all();
-  }
-  static StringRef name() { return "TriggerCrashModulePass"; }
-};
-
-class TriggerCrashFunctionPass
-    : public OptionalPassInfoMixin<TriggerCrashFunctionPass> {
-public:
-  PreservedAnalyses run(Function &, FunctionAnalysisManager &) {
-    abort();
-    return PreservedAnalyses::all();
-  }
-  static StringRef name() { return "TriggerCrashFunctionPass"; }
-};
 
 // A pass for testing message reporting of -verify-each failures.
 // DO NOT USE THIS EXCEPT FOR TESTING!

--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -151,6 +151,7 @@
 #include "llvm/Transforms/Utils/NameAnonGlobals.h"
 #include "llvm/Transforms/Utils/RelLookupTableConverter.h"
 #include "llvm/Transforms/Utils/SimplifyCFGOptions.h"
+#include "llvm/Transforms/Utils/TriggerCrashPass.h"
 #include "llvm/Transforms/Vectorize/LoopVectorize.h"
 #include "llvm/Transforms/Vectorize/SLPVectorizer.h"
 #include "llvm/Transforms/Vectorize/VectorCombine.h"
@@ -195,6 +196,10 @@ static cl::opt<bool> EnableMergeFunctions(
 static cl::opt<bool> EnablePostPGOLoopRotation(
     "enable-post-pgo-loop-rotation", cl::init(true), cl::Hidden,
     cl::desc("Run the loop rotation transformation after PGO instrumentation"));
+
+static cl::opt<bool>
+    TriggerCrash("opt-pipeline-trigger-crash", cl::init(false), cl::Hidden,
+                 cl::desc("Trigger crash in optimization pipeline"));
 
 static cl::opt<bool> EnableGlobalAnalyses(
     "enable-global-analyses", cl::init(true), cl::Hidden,
@@ -1775,6 +1780,9 @@ PassBuilder::buildPerModuleDefaultPipeline(OptimizationLevel Level,
 
   // Force any function attributes we want the rest of the pipeline to observe.
   MPM.addPass(ForceFunctionAttrsPass());
+
+  if (TriggerCrash)
+    MPM.addPass(createModuleToFunctionPassAdaptor(TriggerCrashFunctionPass()));
 
   if (PGOOpt && PGOOpt->DebugInfoForProfiling)
     MPM.addPass(createModuleToFunctionPassAdaptor(AddDiscriminatorsPass()));

--- a/llvm/lib/Transforms/Utils/CMakeLists.txt
+++ b/llvm/lib/Transforms/Utils/CMakeLists.txt
@@ -91,6 +91,7 @@ add_llvm_component_library(LLVMTransformUtils
   SplitModuleByCategory.cpp
   StripNonLineTableDebugInfo.cpp
   SymbolRewriter.cpp
+  TriggerCrashPass.cpp
   UnifyFunctionExitNodes.cpp
   UnifyLoopExits.cpp
   Utils.cpp

--- a/llvm/lib/Transforms/Utils/TriggerCrashPass.cpp
+++ b/llvm/lib/Transforms/Utils/TriggerCrashPass.cpp
@@ -1,4 +1,4 @@
-//===- TriggerCrashPass.cpp -----------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/llvm/lib/Transforms/Utils/TriggerCrashPass.cpp
+++ b/llvm/lib/Transforms/Utils/TriggerCrashPass.cpp
@@ -1,0 +1,43 @@
+//===- TriggerCrashPass.cpp -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM Exceptions
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Transforms/Utils/TriggerCrashPass.h"
+#include <cstdlib>
+
+using namespace llvm;
+
+PreservedAnalyses TriggerCrashModulePass::run(Module &,
+                                              ModuleAnalysisManager &) {
+  abort();
+  return PreservedAnalyses::all();
+}
+
+PreservedAnalyses TriggerCrashFunctionPass::run(Function &,
+                                                FunctionAnalysisManager &) {
+  abort();
+  return PreservedAnalyses::all();
+}
+
+namespace {
+class TriggerCrashFunctionLegacyPass : public FunctionPass {
+public:
+  static char ID;
+  TriggerCrashFunctionLegacyPass() : FunctionPass(ID) {}
+  bool runOnFunction(Function &F) override {
+    abort();
+    return false;
+  }
+  StringRef getPassName() const override { return "TriggerCrashFunctionPass"; }
+};
+} // namespace
+
+char TriggerCrashFunctionLegacyPass::ID = 0;
+
+FunctionPass *llvm::createTriggerCrashFunctionPass() {
+  return new TriggerCrashFunctionLegacyPass();
+}

--- a/llvm/test/Other/trigger-crash-flags.ll
+++ b/llvm/test/Other/trigger-crash-flags.ll
@@ -1,3 +1,5 @@
+; REQUIRES: backtrace
+
 ; RUN: not --crash opt -O2 -opt-pipeline-trigger-crash %s -disable-output 2>&1 | \
 ; RUN: FileCheck %s --check-prefix=OPT
 ;

--- a/llvm/test/Other/trigger-crash-flags.ll
+++ b/llvm/test/Other/trigger-crash-flags.ll
@@ -1,0 +1,13 @@
+; RUN: not --crash opt -O2 -opt-pipeline-trigger-crash %s -disable-output 2>&1 | \
+; RUN: FileCheck %s --check-prefix=OPT
+;
+; RUN: not --crash llc -codegen-pipeline-trigger-crash %s -o /dev/null 2>&1 | \
+; RUN: FileCheck %s --check-prefix=CODEGEN
+
+; OPT: trigger-crash-function
+
+; CODEGEN: TriggerCrashFunctionPass
+
+define void @foo() {
+  ret void
+}

--- a/llvm/utils/gn/secondary/llvm/lib/Transforms/Utils/BUILD.gn
+++ b/llvm/utils/gn/secondary/llvm/lib/Transforms/Utils/BUILD.gn
@@ -99,6 +99,7 @@ static_library("Utils") {
     "StripGCRelocates.cpp",
     "StripNonLineTableDebugInfo.cpp",
     "SymbolRewriter.cpp",
+    "TriggerCrashPass.cpp",
     "UnifyFunctionExitNodes.cpp",
     "UnifyLoopExits.cpp",
     "Utils.cpp",


### PR DESCRIPTION
Will be used for testing crash reduction.

Reland of #200967. Test needs `REQUIRES: backtrace`.