### PR TITLE
[alpha.webkit.UncountedCallArgsChecker] Protect the const member getter's this argument

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
@@ -267,8 +267,12 @@ public:
             return true;
           if (isASafeCallArg(ArgOrigin))
             return true;
-          if (EFA.isACallToEnsureFn(ArgOrigin))
-            return true;
+          if (EFA.isACallToEnsureFn(ArgOrigin)) {
+            auto *MCE = dyn_cast<CXXMemberCallExpr>(ArgOrigin);
+            assert(MCE);
+            if (isPtrOriginSafe(MCE->getImplicitObjectArgument()))
+              return true;
+          }
           if (isSafeExpr(ArgOrigin))
             return true;
           return false;

--- a/clang/test/Analysis/Checkers/WebKit/call-args.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args.cpp
@@ -535,10 +535,21 @@ namespace call_on_member {
 
     void work();
 
+    RefCountable& constObj() const { return *m_constObj; }
+
   private:
     RefPtr<RefCountable> m_obj;
     const RefPtr<RefCountable> m_constObj;
   };
+
+  SomeObj* provide();
+
+  void foo() {
+    provide()->constObj().method();
+    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    Ref { provide()->constObj() }->method();
+    RefPtr { provide() }->constObj().method();
+  }
 
 }
 


### PR DESCRIPTION
This PR fixes a bug that when a const member variable getter is detected, we don't check if its object argument is kept alive for the duration of the function call.