### PR TITLE
[llvm-objdump] Create PDB context for symbolizer

### DIFF
--- a/llvm/include/llvm/DebugInfo/Symbolize/Symbolize.h
+++ b/llvm/include/llvm/DebugInfo/Symbolize/Symbolize.h
@@ -212,6 +212,8 @@ private:
                                                       StringRef ArchName,
                                                       StringRef FullPath);
 
+  Expected<DIContext *> createPDBContext(const ObjectFile &Obj);
+
   /// Update the LRU cache order when a binary is accessed.
   void recordAccess(CachedBinary &Bin);
 

--- a/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
+++ b/llvm/lib/DebugInfo/Symbolize/Symbolize.cpp
@@ -740,6 +740,39 @@ LLVMSymbolizer::createModuleInfo(const ObjectFile *Obj,
   return InsertResult.first->second.get();
 }
 
+Expected<DIContext *> LLVMSymbolizer::createPDBContext(const ObjectFile &Obj) {
+  auto *CoffObject = dyn_cast<COFFObjectFile>(&Obj);
+  if (!CoffObject)
+    return nullptr;
+
+  StringRef PDBFileName = Opts.PDBName;
+  if (PDBFileName.empty()) {
+    const codeview::DebugInfo *DebugInfo;
+    auto EC = CoffObject->getDebugPDBInfo(DebugInfo, PDBFileName);
+    // Use DWARF if there're DWARF sections and we weren't asked for PDB.
+    bool HasDwarf =
+        llvm::any_of(Obj.sections(), [](SectionRef Section) -> bool {
+          if (Expected<StringRef> SectionName = Section.getName())
+            return SectionName.get() == ".debug_info";
+          return false;
+        });
+
+    if (EC || HasDwarf || !DebugInfo || PDBFileName.empty())
+      return nullptr;
+  }
+
+  using namespace pdb;
+  std::unique_ptr<IPDBSession> Session;
+
+  PDB_ReaderType ReaderType =
+      Opts.UseDIA ? PDB_ReaderType::DIA : PDB_ReaderType::Native;
+  if (auto Err = loadDataForEXE(ReaderType, Obj.getFileName(), Session)) {
+    // Return along the PDB filename to provide more context
+    return createFileError(PDBFileName, std::move(Err));
+  }
+  return new PDBContext(*CoffObject, std::move(Session));
+}
+
 Expected<SymbolizableModule *>
 LLVMSymbolizer::getOrCreateModuleInfo(StringRef ModuleName) {
   StringRef BinaryName = ModuleName;
@@ -770,29 +803,16 @@ LLVMSymbolizer::getOrCreateModuleInfo(StringRef ModuleName) {
   ObjectPair Objects = ObjectsOrErr.get();
 
   std::unique_ptr<DIContext> Context;
-  pdb::PDB_ReaderType ReaderType =
-      Opts.UseDIA ? pdb::PDB_ReaderType::DIA : pdb::PDB_ReaderType::Native;
-  const auto *CoffObject = dyn_cast<COFFObjectFile>(Objects.first);
+  // We try the following in order
+  // - GSYM (if no PDB was given on the command line)
+  // - PDB
+  // - DWARF
 
-  // First, if the user specified a pdb file on the command line, use that.
-  if (CoffObject && !Opts.PDBName.empty()) {
-    using namespace pdb;
-    std::unique_ptr<IPDBSession> Session;
-    if (auto Err = loadDataForPDB(ReaderType, Opts.PDBName, Session)) {
-      Modules.emplace(ModuleName, std::unique_ptr<SymbolizableModule>());
-      return createFileError(Opts.PDBName, std::move(Err));
-    }
-    Context.reset(new PDBContext(*CoffObject, std::move(Session)));
-  }
+  // PDB was explicitly requested, use it.
+  bool PreferCoffPDB =
+      isa<COFFObjectFile>(Objects.first) && !Opts.PDBName.empty();
 
-  if (!Context) {
-    // If this is a COFF object containing PDB info and not containing DWARF
-    // section, use a PDBContext to symbolize. Otherwise, use DWARF.
-    // Create a DIContext to symbolize as follows:
-    // - If there is a GSYM file, create a GsymContext.
-    // - Otherwise, if this is a COFF object containing PDB info, create a
-    // PDBContext.
-    // - Otherwise, create a DWARFContext.
+  if (!PreferCoffPDB) {
     const auto GsymFile = lookUpGsymFile(BinaryName.str());
     if (!GsymFile.empty()) {
       auto ReaderOrErr = gsym::GsymReader::openFile(GsymFile);
@@ -802,34 +822,20 @@ LLVMSymbolizer::getOrCreateModuleInfo(StringRef ModuleName) {
     }
   }
 
-  if (!Context && CoffObject) {
-    const codeview::DebugInfo *DebugInfo;
-    StringRef PDBFileName;
-    auto EC = CoffObject->getDebugPDBInfo(DebugInfo, PDBFileName);
-    // Use DWARF if there're DWARF sections.
-    bool HasDwarf =
-        llvm::any_of(Objects.first->sections(), [](SectionRef Section) -> bool {
-          if (Expected<StringRef> SectionName = Section.getName())
-            return SectionName.get() == ".debug_info";
-          return false;
-        });
-    if (!EC && !HasDwarf && DebugInfo != nullptr && !PDBFileName.empty()) {
-      using namespace pdb;
-      std::unique_ptr<IPDBSession> Session;
-
-      if (auto Err = loadDataForEXE(ReaderType, Objects.first->getFileName(),
-                                    Session)) {
-        Modules.emplace(ModuleName, std::unique_ptr<SymbolizableModule>());
-        // Return along the PDB filename to provide more context
-        return createFileError(PDBFileName, std::move(Err));
-      }
-      Context.reset(new PDBContext(*CoffObject, std::move(Session)));
+  if (!Context) {
+    Expected<DIContext *> PDBContextOrErr = createPDBContext(*Objects.first);
+    if (!PDBContextOrErr) {
+      Modules.emplace(ModuleName, std::unique_ptr<SymbolizableModule>());
+      return PDBContextOrErr.takeError();
     }
+
+    Context.reset(*PDBContextOrErr);
   }
   if (!Context)
     Context = DWARFContext::create(
         *Objects.second, DWARFContext::ProcessDebugRelocations::Process,
         nullptr, Opts.DWPName);
+
   auto ModuleOrErr =
       createModuleInfo(Objects.first, std::move(Context), ModuleName);
   if (ModuleOrErr) {
@@ -858,9 +864,18 @@ LLVMSymbolizer::getOrCreateModuleInfo(const ObjectFile &Obj) {
   std::unique_ptr<DIContext> Context;
   if (useBTFContext(Obj))
     Context = BTFContext::create(Obj);
-  else
-    Context = DWARFContext::create(Obj);
-  // FIXME: handle COFF object with PDB info to use PDBContext
+  else {
+    Expected<DIContext *> PDBContextOrErr = createPDBContext(Obj);
+    if (!PDBContextOrErr) {
+      Modules.emplace(ObjName, std::unique_ptr<SymbolizableModule>());
+      return PDBContextOrErr.takeError();
+    }
+
+    if (*PDBContextOrErr)
+      Context.reset(*PDBContextOrErr);
+    else
+      Context = DWARFContext::create(Obj);
+  }
   return createModuleInfo(&Obj, std::move(Context), ObjName);
 }
 

--- a/llvm/test/tools/llvm-objdump/COFF/pdb-lines.yaml
+++ b/llvm/test/tools/llvm-objdump/COFF/pdb-lines.yaml
@@ -1,0 +1,507 @@
+## This test checks that llvm-objdump can show line info from PDB files.
+# RUN: rm -rf %t.dir
+# RUN: mkdir %t.dir
+# RUN: yaml2obj %s --docnum=1 -o %t.dir/test-pdb.exe
+# RUN: llvm-pdbutil yaml2pdb %s --docnum=2 --pdb %t.dir/test-pdb.pdb
+# RUN: llvm-objdump -l -C %t.dir/test-pdb.exe | FileCheck %s
+
+# CHECK:      0000000140001000 <.text>:
+# CHECK-NEXT: ; square():
+# CHECK-NEXT: ; F:\Dev\llvm-project\llvm\test\tools\llvm-objdump\COFF\Inputs\test-pdb.c:8
+# CHECK-NEXT: 140001000: 50                           pushq   %rax
+# CHECK-NEXT: 140001001: 89 4c 24 04                  movl    %ecx, 0x4(%rsp)
+# CHECK-NEXT: ; F:\Dev\llvm-project\llvm\test\tools\llvm-objdump\COFF\Inputs\test-pdb.c:9
+# CHECK-NEXT: 140001005: 8b 44 24 04                  movl    0x4(%rsp), %eax
+# CHECK-NEXT: 140001009: 0f af 44 24 04               imull   0x4(%rsp), %eax
+# CHECK-NEXT: 14000100e: 59                           popq    %rcx
+# CHECK-NEXT: 14000100f: c3                           retq
+# CHECK-NEXT: ; main():
+# CHECK-NEXT: ; F:\Dev\llvm-project\llvm\test\tools\llvm-objdump\COFF\Inputs\test-pdb.c:12
+# CHECK-NEXT: 140001010: 48 83 ec 28                  subq    $0x28, %rsp
+# CHECK-NEXT: 140001014: c7 44 24 24 00 00 00 00      movl    $0x0, 0x24(%rsp)
+# CHECK-NEXT: ; F:\Dev\llvm-project\llvm\test\tools\llvm-objdump\COFF\Inputs\test-pdb.c:13
+# CHECK-NEXT: 14000101c: b9 04 00 00 00               movl    $0x4, %ecx
+# CHECK-NEXT: 140001021: e8 da ff ff ff               callq   0x140001000 <.text>
+# CHECK-NEXT: 140001026: 90                           nop
+# CHECK-NEXT: 140001027: 48 83 c4 28                  addq    $0x28, %rsp
+# CHECK-NEXT: 14000102b: c3                           retq
+
+## The files were generated from test-pdb.c:
+##
+## int square(int num) {
+##     return num * num;
+## }
+## 
+## int main() {
+##     return square(4);
+## }
+##
+## clang-cl test-pdb.c -fuse-ld=lld-link /Z7 /link /nodefaultlib /entry:main
+## llvm-pdbutil pdb2yaml test-pdb.pdb --all > test-pdb.pdb.yaml
+## obj2yaml test-pdb.exe -o test-pdb.exe.yaml
+## rm test-pdb.exe && rm test-pdb.pdb
+
+## The COFF executable.
+
+--- !COFF
+OptionalHeader:
+  AddressOfEntryPoint: 4112
+  ImageBase:       5368709120
+  SectionAlignment: 4096
+  FileAlignment:   512
+  MajorOperatingSystemVersion: 6
+  MinorOperatingSystemVersion: 0
+  MajorImageVersion: 0
+  MinorImageVersion: 0
+  MajorSubsystemVersion: 6
+  MinorSubsystemVersion: 0
+  Subsystem:       IMAGE_SUBSYSTEM_WINDOWS_CUI
+  DLLCharacteristics: [ IMAGE_DLL_CHARACTERISTICS_HIGH_ENTROPY_VA, IMAGE_DLL_CHARACTERISTICS_DYNAMIC_BASE, IMAGE_DLL_CHARACTERISTICS_NX_COMPAT, IMAGE_DLL_CHARACTERISTICS_TERMINAL_SERVER_AWARE ]
+  SizeOfStackReserve: 1048576
+  SizeOfStackCommit: 4096
+  SizeOfHeapReserve: 1048576
+  SizeOfHeapCommit: 4096
+  ExportTable:
+    RelativeVirtualAddress: 0
+    Size:            0
+  ImportTable:
+    RelativeVirtualAddress: 0
+    Size:            0
+  ResourceTable:
+    RelativeVirtualAddress: 0
+    Size:            0
+  ExceptionTable:
+    RelativeVirtualAddress: 12288
+    Size:            24
+  CertificateTable:
+    RelativeVirtualAddress: 0
+    Size:            0
+  BaseRelocationTable:
+    RelativeVirtualAddress: 0
+    Size:            0
+  Debug:
+    RelativeVirtualAddress: 8192
+    Size:            28
+  Architecture:
+    RelativeVirtualAddress: 0
+    Size:            0
+  GlobalPtr:
+    RelativeVirtualAddress: 0
+    Size:            0
+  TlsTable:
+    RelativeVirtualAddress: 0
+    Size:            0
+  LoadConfigTable:
+    RelativeVirtualAddress: 0
+    Size:            0
+  BoundImport:
+    RelativeVirtualAddress: 0
+    Size:            0
+  IAT:
+    RelativeVirtualAddress: 0
+    Size:            0
+  DelayImportDescriptor:
+    RelativeVirtualAddress: 0
+    Size:            0
+  ClrRuntimeHeader:
+    RelativeVirtualAddress: 0
+    Size:            0
+header:
+  Machine:         IMAGE_FILE_MACHINE_AMD64
+  Characteristics: [ IMAGE_FILE_EXECUTABLE_IMAGE, IMAGE_FILE_LARGE_ADDRESS_AWARE ]
+sections:
+  - Name:            .text
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    VirtualAddress:  4096
+    VirtualSize:     44
+    SectionData:     50894C24048B4424040FAF44240459C34883EC28C744242400000000B904000000E8DAFFFFFF904883C428C3
+    SizeOfRawData:   512
+  - Name:            .rdata
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_READ ]
+    VirtualAddress:  8192
+    VirtualSize:     144
+    SectionData:     000000004456456A0000000002000000620000001C2000001C060000525344539EF0FB1ACCD05EFF4C4C44205044422E01000000463A5C4465765C6C6C766D2D70726F6A6563745C6C6C766D5C746573745C746F6F6C735C6C6C766D2D6F626A64756D705C434F46465C496E707574735C746573742D7064622E70646200000001010100010200000104010004420000
+    SizeOfRawData:   512
+  - Name:            .pdata
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_READ ]
+    VirtualAddress:  12288
+    VirtualSize:     24
+    SectionData:     001000001010000080200000101000002C10000088200000
+    SizeOfRawData:   512
+symbols:         []
+...
+
+## The PDB file.
+
+---
+StringTable:
+  - 'F:\Dev\llvm-project\llvm\test\tools\llvm-objdump\COFF\Inputs\test-pdb.c'
+PdbStream:
+  Age:             1
+  Guid:            '{1AFBF09E-D0CC-FF5E-4C4C-44205044422E}'
+  Signature:       452718750
+  Features:        [ VC140 ]
+  Version:         VC70
+DbiStream:
+  VerHeader:       V70
+  Age:             1
+  BuildNumber:     36363
+  PdbDllVersion:   0
+  PdbDllRbld:      0
+  Flags:           0
+  MachineType:     Amd64
+  Modules:
+    - Module:          'C:\Users\johannes\AppData\Local\Temp\test-pdb-39ef50.obj'
+      ObjFile:         'C:\Users\johannes\AppData\Local\Temp\test-pdb-39ef50.obj'
+      SourceFiles:
+        - 'F:\Dev\llvm-project\llvm\test\tools\llvm-objdump\COFF\Inputs\test-pdb.c'
+      Subsections:
+        - !Lines
+          CodeSize:        16
+          Flags:           [  ]
+          RelocOffset:     0
+          RelocSegment:    1
+          Blocks:
+            - FileName:        'F:\Dev\llvm-project\llvm\test\tools\llvm-objdump\COFF\Inputs\test-pdb.c'
+              Lines:
+                - Offset:          0
+                  LineStart:       8
+                  IsStatement:     false
+                  EndDelta:        0
+                - Offset:          5
+                  LineStart:       9
+                  IsStatement:     false
+                  EndDelta:        0
+              Columns:         []
+        - !Lines
+          CodeSize:        28
+          Flags:           [  ]
+          RelocOffset:     16
+          RelocSegment:    1
+          Blocks:
+            - FileName:        'F:\Dev\llvm-project\llvm\test\tools\llvm-objdump\COFF\Inputs\test-pdb.c'
+              Lines:
+                - Offset:          0
+                  LineStart:       12
+                  IsStatement:     false
+                  EndDelta:        0
+                - Offset:          12
+                  LineStart:       13
+                  IsStatement:     false
+                  EndDelta:        0
+              Columns:         []
+        - !FileChecksums
+          Checksums:
+            - FileName:        'F:\Dev\llvm-project\llvm\test\tools\llvm-objdump\COFF\Inputs\test-pdb.c'
+              Kind:            MD5
+              Checksum:        315F8C23981DC54CD31EAF857C6779A1
+      Modi:
+        Signature:       4
+        Records:
+          - Kind:            S_OBJNAME
+            ObjNameSym:
+              Signature:       0
+              ObjectName:      'C:\Users\johannes\AppData\Local\Temp\test-pdb-39ef50.obj'
+          - Kind:            S_COMPILE3
+            Compile3Sym:
+              Flags:           [  ]
+              Machine:         X64
+              FrontendMajor:   22
+              FrontendMinor:   1
+              FrontendBuild:   4
+              FrontendQFE:     0
+              BackendMajor:    22014
+              BackendMinor:    0
+              BackendBuild:    0
+              BackendQFE:      0
+              Version:         'clang version 22.1.4 (https://github.com/llvm/llvm-project 35990504507d79e0b9deb809c8ee5e1b34ceef20)'
+          - Kind:            S_GPROC32
+            ProcSym:
+              PtrParent:       0
+              PtrEnd:          312
+              PtrNext:         0
+              CodeSize:        16
+              DbgStart:        0
+              DbgEnd:          0
+              FunctionType:    4097
+              Offset:          0
+              Segment:         1
+              Flags:           [ IsNoInline, HasOptimizedDebugInfo ]
+              DisplayName:     square
+          - Kind:            S_FRAMEPROC
+            FrameProcSym:
+              TotalFrameBytes: 8
+              PaddingFrameBytes: 0
+              OffsetToPadding: 0
+              BytesOfCalleeSavedRegisters: 0
+              OffsetOfExceptionHandler: 0
+              SectionIdOfExceptionHandler: 0
+              Flags:           [  ]
+          - Kind:            S_LOCAL
+            LocalSym:
+              Type:            116
+              Flags:           [ IsParameter ]
+              VarName:         num
+          - Kind:            S_DEFRANGE_FRAMEPOINTER_REL
+            DefRangeFramePointerRelSym:
+              Offset:          4
+              Range:
+                OffsetStart:     5
+                ISectStart:      1
+                Range:           11
+              Gaps:            []
+          - Kind:            S_END
+            ScopeEndSym:     {}
+          - Kind:            S_GPROC32
+            ProcSym:
+              PtrParent:       0
+              PtrEnd:          392
+              PtrNext:         0
+              CodeSize:        28
+              DbgStart:        0
+              DbgEnd:          0
+              FunctionType:    4099
+              Offset:          16
+              Segment:         1
+              Flags:           [ IsNoInline, HasOptimizedDebugInfo ]
+              DisplayName:     main
+          - Kind:            S_FRAMEPROC
+            FrameProcSym:
+              TotalFrameBytes: 40
+              PaddingFrameBytes: 0
+              OffsetToPadding: 0
+              BytesOfCalleeSavedRegisters: 0
+              OffsetOfExceptionHandler: 0
+              SectionIdOfExceptionHandler: 0
+              Flags:           [  ]
+          - Kind:            S_END
+            ScopeEndSym:     {}
+          - Kind:            S_BUILDINFO
+            BuildInfoSym:
+              BuildId:         4103
+    - Module:          '* Linker *'
+      ObjFile:         ''
+      Modi:
+        Signature:       4
+        Records:
+          - Kind:            S_OBJNAME
+            ObjNameSym:
+              Signature:       0
+              ObjectName:      '* Linker *'
+          - Kind:            S_COMPILE3
+            Compile3Sym:
+              Flags:           [  ]
+              Machine:         X64
+              FrontendMajor:   0
+              FrontendMinor:   0
+              FrontendBuild:   0
+              FrontendQFE:     0
+              BackendMajor:    14
+              BackendMinor:    10
+              BackendBuild:    25019
+              BackendQFE:      0
+              Version:         LLVM Linker
+          - Kind:            S_ENVBLOCK
+            EnvBlockSym:
+              Entries:
+                - cwd
+                - 'F:\Dev\llvm-project\llvm\test\tools\llvm-objdump\COFF\Inputs'
+                - exe
+                - 'C:\Users\johannes\scoop\apps\llvm\22.1.4\bin\lld-link.exe'
+                - pdb
+                - 'F:\Dev\llvm-project\llvm\test\tools\llvm-objdump\COFF\Inputs\test-pdb.pdb'
+                - cmd
+                - '-out:test-pdb.exe -libpath:F:\VisualStudio2026\VC\Tools\MSVC\14.51.36231\lib\x64 -libpath:F:\VisualStudio2026\VC\Tools\MSVC\14.51.36231\atlmfc\lib\x64 "-libpath:C:\Program Files (x86)\Windows Kits\10\Lib\10.0.28000.0\ucrt\x64" "-libpath:C:\Program Files (x86)\Windows Kits\10\Lib\10.0.28000.0\um\x64" -libpath:C:\Users\johannes\scoop\apps\llvm\22.1.4\lib\clang\22\lib\x86_64-pc-windows-msvc -libpath:C:\Users\johannes\scoop\apps\llvm\22.1.4\lib\clang\22\lib\windows -nologo -debug /nodefaultlib /entry:main'
+          - Kind:            S_SECTION
+            SectionSym:
+              SectionNumber:   1
+              Alignment:       12
+              Rva:             4096
+              Length:          44
+              Characteristics: 1610612768
+              Name:            .text
+          - Kind:            S_COFFGROUP
+            CoffGroupSym:
+              Size:            44
+              Characteristics: 1610612768
+              Offset:          0
+              Segment:         1
+              Name:            .text
+          - Kind:            S_SECTION
+            SectionSym:
+              SectionNumber:   2
+              Alignment:       12
+              Rva:             8192
+              Length:          144
+              Characteristics: 1073741888
+              Name:            .rdata
+          - Kind:            S_COFFGROUP
+            CoffGroupSym:
+              Size:            16
+              Characteristics: 1073741888
+              Offset:          128
+              Segment:         2
+              Name:            .xdata
+          - Kind:            S_SECTION
+            SectionSym:
+              SectionNumber:   3
+              Alignment:       12
+              Rva:             12288
+              Length:          24
+              Characteristics: 1073741888
+              Name:            .pdata
+          - Kind:            S_COFFGROUP
+            CoffGroupSym:
+              Size:            24
+              Characteristics: 1073741888
+              Offset:          0
+              Segment:         3
+              Name:            .pdata
+  SectionHeaders:
+    - Name:            .text
+      VirtualSize:     44
+      VirtualAddress:  4096
+      SizeOfRawData:   512
+      PointerToRawData: 1024
+      PointerToRelocations: 0
+      PointerToLinenumbers: 0
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      Characteristics: 1610612768
+    - Name:            .rdata
+      VirtualSize:     144
+      VirtualAddress:  8192
+      SizeOfRawData:   512
+      PointerToRawData: 1536
+      PointerToRelocations: 0
+      PointerToLinenumbers: 0
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      Characteristics: 1073741888
+    - Name:            .pdata
+      VirtualSize:     24
+      VirtualAddress:  12288
+      SizeOfRawData:   512
+      PointerToRawData: 2048
+      PointerToRelocations: 0
+      PointerToLinenumbers: 0
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      Characteristics: 1073741888
+  SectionContribs:
+    Version:         Ver60
+    Items:
+      - ISect:           1
+        Offset:          0
+        Size:            44
+        Characteristics: 1615855648
+        Imod:            0
+        DataCrc:         3884831978
+        RelocCrc:        0
+        ISectCoff:       0
+      - ISect:           2
+        Offset:          0
+        Size:            28
+        Characteristics: 1073741888
+        Imod:            1
+        DataCrc:         0
+        RelocCrc:        0
+        ISectCoff:       0
+      - ISect:           2
+        Offset:          28
+        Size:            98
+        Characteristics: 1073741888
+        Imod:            1
+        DataCrc:         0
+        RelocCrc:        0
+        ISectCoff:       0
+      - ISect:           2
+        Offset:          128
+        Size:            16
+        Characteristics: 1076887616
+        Imod:            0
+        DataCrc:         1183868784
+        RelocCrc:        0
+        ISectCoff:       0
+      - ISect:           3
+        Offset:          0
+        Size:            24
+        Characteristics: 1076887616
+        Imod:            0
+        DataCrc:         2276661551
+        RelocCrc:        0
+        ISectCoff:       0
+TpiStream:
+  Version:         VC80
+  Records:
+    - Kind:            LF_ARGLIST
+      ArgList:
+        ArgIndices:      [ 116 ]
+    - Kind:            LF_PROCEDURE
+      Procedure:
+        ReturnType:      116
+        CallConv:        NearC
+        Options:         [ None ]
+        ParameterCount:  1
+        ArgumentList:    4096
+    - Kind:            LF_ARGLIST
+      ArgList:
+        ArgIndices:      [  ]
+    - Kind:            LF_PROCEDURE
+      Procedure:
+        ReturnType:      116
+        CallConv:        NearC
+        Options:         [ None ]
+        ParameterCount:  0
+        ArgumentList:    4098
+IpiStream:
+  Version:         VC80
+  Records:
+    - Kind:            LF_FUNC_ID
+      FuncId:
+        ParentScope:     0
+        FunctionType:    4097
+        Name:            square
+    - Kind:            LF_FUNC_ID
+      FuncId:
+        ParentScope:     0
+        FunctionType:    4099
+        Name:            main
+    - Kind:            LF_STRING_ID
+      StringId:
+        Id:              0
+        String:          'F:\Dev\llvm-project\llvm\test\tools\llvm-objdump\COFF\Inputs'
+    - Kind:            LF_STRING_ID
+      StringId:
+        Id:              0
+        String:          test-pdb.c
+    - Kind:            LF_STRING_ID
+      StringId:
+        Id:              0
+        String:          ''
+    - Kind:            LF_STRING_ID
+      StringId:
+        Id:              0
+        String:          'C:\Users\johannes\scoop\apps\llvm\22.1.4\bin\clang-cl.exe'
+    - Kind:            LF_STRING_ID
+      StringId:
+        Id:              0
+        String:          '"-cc1" "-triple" "x86_64-pc-windows-msvc19.51.36246" "-emit-obj" "-mincremental-linker-compatible" "-dumpdir" "a-" "-disable-free" "-clear-ast-before-backend" "-disable-llvm-verifier" "-discard-value-names" "-mrelocation-model" "pic" "-pic-level" "2" "-mframe-pointer=none" "-relaxed-aliasing" "-fmath-errno" "-ffp-contract=on" "-fno-rounding-math" "-mconstructor-aliases" "-fms-volatile" "-funwind-tables=2" "-target-cpu" "x86-64" "-mllvm" "-x86-asm-syntax=intel" "-tune-cpu" "generic" "-D_MT" "-flto-visibility-public-std" "--dependent-lib=libcmt" "--dependent-lib=oldnames" "-stack-protector" "2" "-fdiagnostics-format" "msvc" "-gno-column-info" "-gcodeview" "-debug-info-kind=constructor" "-fdebug-compilation-dir=F:\\Dev\\llvm-project\\llvm\\test\\tools\\llvm-objdump\\COFF\\Inputs" "-fcoverage-compilation-dir=F:\\Dev\\llvm-project\\llvm\\test\\tools\\llvm-objdump\\COFF\\Inputs" "-resource-dir" "C:\\Users\\johannes\\scoop\\apps\\llvm\\22.1.4\\lib\\clang\\22" "-internal-isystem" "C:\\Users\\johannes\\scoop\\apps\\llvm\\22.1.4\\lib\\clang\\22\\include" "-internal-isystem" "F:\\VisualStudio2026\\VC\\Tools\\MSVC\\14.51.36231\\include" "-internal-isystem" "F:\\VisualStudio2026\\VC\\Tools\\MSVC\\14.51.36231\\atlmfc\\include" "-internal-isystem" "C:\\Program Files (x86)\\Windows Kits\\10\\Include\\10.0.28000.0\\ucrt" "-internal-isystem" "C:\\Program Files (x86)\\Windows Kits\\10\\Include\\10.0.28000.0\\shared" "-internal-isystem" "C:\\Program Files (x86)\\Windows Kits\\10\\Include\\10.0.28000.0\\um" "-internal-isystem" "C:\\Program Files (x86)\\Windows Kits\\10\\Include\\10.0.28000.0\\winrt" "-internal-isystem" "C:\\Program Files (x86)\\Windows Kits\\10\\Include\\10.0.28000.0\\cppwinrt" "-ferror-limit" "19" "-fno-use-cxa-atexit" "-fms-extensions" "-fms-compatibility" "-fms-compatibility-version=19.51.36246" "-fskip-odr-check-in-gmf" "-fdelayed-template-parsing" "-fcolor-diagnostics" "-faddrsig" "-x" "c"'
+    - Kind:            LF_BUILDINFO
+      BuildInfo:
+        ArgIndices:      [ 4098, 4101, 4099, 4100, 4102 ]
+PublicsStream:
+  Records:
+    - Kind:            S_PUB32
+      PublicSym32:
+        Flags:           [ Function ]
+        Offset:          16
+        Segment:         1
+        Name:            main
+    - Kind:            S_PUB32
+      PublicSym32:
+        Flags:           [ Function ]
+        Offset:          0
+        Segment:         1
+        Name:            square
+...


### PR DESCRIPTION
When dumping and disassembling COFF executables, llvm-objdump wouldn't show function names and line info, even if there was a PDB available. With this PR, the associated PDB file is loaded and used.

The symbolizer already created a context when asked for a filename. However, when asked for the DI context for an object file, it wouldn't create a PDB one. llvm-objdump's `SourcePrinter` passes an object file when symbolizing code [here](https://github.com/llvm/llvm-project/blob/d8f56af5fecb3d431efa801b80a87a6547638fd8/llvm/tools/llvm-objdump/SourcePrinter.cpp#L747-L748).

I moved the PDB creation out into a new function to reuse it across the two `getOrCreateModuleInfo` overloads.