### PR TITLE
[OpenMP] Mark critical region lock variables as dso_local

### DIFF
--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -2069,7 +2069,14 @@ Address CGOpenMPRuntime::emitThreadIDAddress(CodeGenFunction &CGF,
 llvm::Value *CGOpenMPRuntime::getCriticalRegionLock(StringRef CriticalName) {
   std::string Prefix = Twine("gomp_critical_user_", CriticalName).str();
   std::string Name = getName({Prefix, "var"});
-  return OMPBuilder.getOrCreateInternalVariable(KmpCriticalNameTy, Name);
+
+  llvm::GlobalVariable *GV =
+      OMPBuilder.getOrCreateInternalVariable(KmpCriticalNameTy, Name);
+
+  if (CGM.getCodeGenOpts().RelocationModel == llvm::Reloc::Static)
+    GV->setDSOLocal(true);
+
+  return GV;
 }
 
 namespace {

--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -2072,9 +2072,7 @@ llvm::Value *CGOpenMPRuntime::getCriticalRegionLock(StringRef CriticalName) {
 
   llvm::GlobalVariable *GV =
       OMPBuilder.getOrCreateInternalVariable(KmpCriticalNameTy, Name);
-
-  if (CGM.getCodeGenOpts().RelocationModel == llvm::Reloc::Static)
-    GV->setDSOLocal(true);
+  CGM.setDSOLocal(GV);
 
   return GV;
 }

--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -2069,11 +2069,9 @@ Address CGOpenMPRuntime::emitThreadIDAddress(CodeGenFunction &CGF,
 llvm::Value *CGOpenMPRuntime::getCriticalRegionLock(StringRef CriticalName) {
   std::string Prefix = Twine("gomp_critical_user_", CriticalName).str();
   std::string Name = getName({Prefix, "var"});
-
   llvm::GlobalVariable *GV =
       OMPBuilder.getOrCreateInternalVariable(KmpCriticalNameTy, Name);
   CGM.setDSOLocal(GV);
-
   return GV;
 }
 

--- a/clang/test/OpenMP/critical-dso-local.cpp
+++ b/clang/test/OpenMP/critical-dso-local.cpp
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu \
+// RUN:   -fopenmp \
+// RUN:   -mrelocation-model static \
+// RUN:   -emit-llvm %s -o - | FileCheck %s --check-prefix=STATIC
+
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu \
+// RUN:   -fopenmp \
+// RUN:   -mrelocation-model pic \
+// RUN:   -emit-llvm %s -o - | FileCheck %s --check-prefix=PIC
+
+// STATIC: @.gomp_critical_user_foo.var = common dso_local global [8 x i32] zeroinitializer
+// PIC: @.gomp_critical_user_foo.var = common global [8 x i32] zeroinitializer
+
+void f() {
+#pragma omp critical(foo)
+  ;
+}

--- a/clang/test/OpenMP/critical-dso-local.cpp
+++ b/clang/test/OpenMP/critical-dso-local.cpp
@@ -1,11 +1,7 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu \
-// RUN:   -fopenmp \
-// RUN:   -mrelocation-model static \
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fopenmp -mrelocation-model static \
 // RUN:   -emit-llvm %s -o - | FileCheck %s --check-prefix=STATIC
 
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu \
-// RUN:   -fopenmp \
-// RUN:   -mrelocation-model pic \
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fopenmp -mrelocation-model pic \
 // RUN:   -emit-llvm %s -o - | FileCheck %s --check-prefix=PIC
 
 // STATIC: @.gomp_critical_user_foo.var = common dso_local global [8 x i32] zeroinitializer

--- a/clang/test/OpenMP/critical_codegen.cpp
+++ b/clang/test/OpenMP/critical_codegen.cpp
@@ -16,9 +16,9 @@
 #define HEADER
 
 // ALL:       [[IDENT_T_TY:%.+]] = type { i32, i32, i32, i32, ptr }
-// ALL:       [[UNNAMED_LOCK:@.+]] = common global [8 x i32] zeroinitializer
-// ALL:       [[THE_NAME_LOCK:@.+]] = common global [8 x i32] zeroinitializer
-// ALL:       [[THE_NAME_LOCK1:@.+]] = common global [8 x i32] zeroinitializer
+// ALL:       [[UNNAMED_LOCK:@.+]] = common {{(dso_local )?}}global [8 x i32] zeroinitializer
+// ALL:       [[THE_NAME_LOCK:@.+]] = common {{(dso_local )?}}global [8 x i32] zeroinitializer
+// ALL:       [[THE_NAME_LOCK1:@.+]] = common {{(dso_local )?}}global [8 x i32] zeroinitializer
 
 // ALL:       define {{.*}}void [[FOO:@.+]]()
 

--- a/clang/test/OpenMP/critical_codegen_attr.cpp
+++ b/clang/test/OpenMP/critical_codegen_attr.cpp
@@ -16,9 +16,9 @@
 #define HEADER
 
 // ALL:       [[IDENT_T_TY:%.+]] = type { i32, i32, i32, i32, ptr }
-// ALL:       [[UNNAMED_LOCK:@.+]] = common global [8 x i32] zeroinitializer
-// ALL:       [[THE_NAME_LOCK:@.+]] = common global [8 x i32] zeroinitializer
-// ALL:       [[THE_NAME_LOCK1:@.+]] = common global [8 x i32] zeroinitializer
+// ALL:       [[UNNAMED_LOCK:@.+]] = common {{(dso_local )?}}global [8 x i32] zeroinitializer
+// ALL:       [[THE_NAME_LOCK:@.+]] = common {{(dso_local )?}}global [8 x i32] zeroinitializer
+// ALL:       [[THE_NAME_LOCK1:@.+]] = common {{(dso_local )?}}global [8 x i32] zeroinitializer
 
 // ALL:       define {{.*}}void [[FOO:@.+]]()
 


### PR DESCRIPTION
OpenMP named critical regions use lock variables of the form .gomp_critical_user_<name>.var, which are created through CGOpenMPRuntime::getCriticalRegionLock().

These variables are created via OpenMPIRBuilder::getOrCreateInternalVariable() and bypass the normal CodeGenModule::setDSOLocal() path used for other Clang-generated globals. As a result, OpenMP critical lock variables do not receive the usual frontend dso_local inference.

Apply CodeGenModule::setDSOLocal() to critical lock variables after creation. This matches the existing frontend
dso_local inference logic.

On ELF targets with a static relocation model, this results in direct accesses to the lock variable instead of GOT-based accesses. For example, x86-64 code generation changes from R_X86_64_REX_GOTPCRELX relocations
to direct relocations for .gomp_critical_user_<name>.var, while PIC code generation remains unchanged.

Rework of #75564.