### PR TITLE
[TableGen] Add support for sparse direct-lookup tables

### DIFF
--- a/llvm/docs/TableGen/BackEnds.rst
+++ b/llvm/docs/TableGen/BackEnds.rst
@@ -702,7 +702,7 @@ TableGen produces C++ code to define the table entries and also produces
 the declaration and definition of a function to search the table based on a
 primary key. To define the table, define a record whose parent class is
 ``GenericTable`` and whose name is the name of the global table of entries.
-This class provides six fields.
+This class provides the following fields.
 
 * ``string FilterClass``. The table will have one entry for each record
   that derives from this class.
@@ -734,6 +734,11 @@ This class provides six fields.
   object. This feature proves useful when multiple objects meet the criteria
   specified by the lookup function. Currently, it is supported only for primary
   lookup functions. Refer to the second example below for further details.
+
+* ``bit DisallowSparseTable``. When set to 1 (the default), prevents the
+  emitter from generating a sparse direct-lookup array for this table. Set to 
+  0 to allow the emitter to emit a sparse directly-indexed array when the
+  primary key qualifies (see below).
 
 TableGen attempts to deduce the type of each of the table fields so that it
 can format the C++ initializers in the emitted table. It can deduce ``bit``,
@@ -835,9 +840,24 @@ The table entries in ``ATable`` are sorted in order by ``Val1``, and within
 each of those values, by ``Val2``. This allows a binary search of the table,
 which is performed in the lookup function by ``std::lower_bound``. The
 lookup function returns a reference to the found table entry, or the null
-pointer if no entry is found. If the table has a single primary key field
-which is integral and densely numbered, a direct lookup is generated rather
-than a binary search.
+pointer if no entry is found.
+
+The emitter selects the lookup strategy automatically based on the primary key:
+
+* **Dense direct lookup**: used when the primary key is a single integral field
+  whose values form a contiguous range. A compact array is emitted and the
+  lookup function indexes into it directly.
+
+* **Sparse direct lookup**: used when ``DisallowSparseTable = 0``, the primary
+  key is a single ``bits<N>`` field with N ≤ 12, ``PrimaryKeyReturnRange`` is
+  false, and the table has no secondary search indexes. The emitter allocates a
+  directly-indexed array of ``2^N`` entries. Empty slots are filled with a
+  sentinel value in the key field such that the in-place key comparison in the
+  lookup function returns ``nullptr`` for them. This trades memory for
+  O(1) lookup.
+
+* **Binary search**: the default for all other cases. Entries are sorted by the
+  primary key and ``std::lower_bound`` is used in the lookup function.
 
 This example includes a field whose type TableGen cannot deduce. The ``Kind``
 field uses the enumerated type ``CEnum`` defined above. To inform TableGen
@@ -1067,6 +1087,62 @@ The generated tables are:
     { 0x7 }, // 3
     { 0x9 }, // 4
   };
+
+Here is an example of a sparse direct-lookup table. ``FTable`` uses a 4-bit
+primary key (``bits<4>``), so the emitter allocates an array of
+``2^4 = 16`` entries.
+
+.. code-block:: text
+
+  def FTable : GenericTable {
+    let FilterClass = "FEntry";
+    let Fields = ["Key", "Val"];
+    let PrimaryKey = ["Key"];
+    let PrimaryKeyName = "lookupFTableByKey";
+    let DisallowSparseTable = false;
+  }
+
+Here is the generated C++ code. The declaration of ``lookupFTableByKey`` is
+guarded by ``GET_FTable_DECL``, while the definitions are guarded by
+``GET_FTable_IMPL``.
+
+.. code-block:: text
+
+  #ifdef GET_FTable_DECL
+  const FEntry *lookupFTableByKey(uint8_t Key);
+  #endif
+
+  #ifdef GET_FTable_IMPL
+  constexpr FEntry FTable[] = {
+    { 0xF, 0x0 }, // 0
+    { 0xE, 0x0 }, // 1
+    { 0x2, 0xA }, // 2
+    { 0xC, 0x0 }, // 3
+    { 0xB, 0x0 }, // 4
+    { 0x5, 0x14 }, // 5
+    { 0x9, 0x0 }, // 6
+    { 0x8, 0x0 }, // 7
+    { 0x7, 0x0 }, // 8
+    { 0x6, 0x0 }, // 9
+    { 0x5, 0x0 }, // 10
+    { 0x4, 0x0 }, // 11
+    { 0x3, 0x0 }, // 12
+    { 0xD, 0x1E }, // 13
+    { 0x1, 0x0 }, // 14
+    { 0x0, 0x0 }, // 15
+  };
+
+  const FEntry *lookupFTableByKey(uint8_t Key) {
+    if (Key >= 16)
+      return nullptr;
+    const auto *Entry = &FTable[Key];
+    return Entry->Key == Key ? Entry : nullptr;
+  }
+  #endif
+
+Empty slots are filled with a sentinel value in the ``Key`` field
+(``(15 ^ Idx)``) so that the in-place comparison ``Entry->Key == Key``
+returns ``nullptr`` for them without a separate presence array.
 
 Search Indexes
 ~~~~~~~~~~~~~~

--- a/llvm/docs/TableGen/BackEnds.rst
+++ b/llvm/docs/TableGen/BackEnds.rst
@@ -736,7 +736,7 @@ This class provides the following fields.
   lookup functions. Refer to the second example below for further details.
 
 * ``bit DisallowSparseTable``. When set to 1 (the default), prevents the
-  emitter from generating a sparse direct-lookup array for this table. Set to 
+  emitter from generating a sparse direct-lookup array for this table. Set to
   0 to allow the emitter to emit a sparse directly-indexed array when the
   primary key qualifies (see below).
 

--- a/llvm/include/llvm/TableGen/SearchableTable.td
+++ b/llvm/include/llvm/TableGen/SearchableTable.td
@@ -125,6 +125,13 @@ class GenericTable {
   // iterator range of pointers giving the starting and end value of the range.
   // e.g. lookupSysRegByEncoding returns multiple CSRs for same encoding.
   bit PrimaryKeyReturnRange = false;
+
+  // Opt out of emitting the primary table as a direct-lookup sparse array
+  // indexed by the primary key value.
+  // TODO: Eventually this should default to `false`, so it is up to heuristics
+  // in the emitter to pick the best lookup scheme. It will then be used to
+  // override that logic and force an emission of non-sparse array.
+  bit DisallowSparseTable = true;
 }
 
 // Define a record derived from this class to generate an additional search

--- a/llvm/test/TableGen/generic-tables.td
+++ b/llvm/test/TableGen/generic-tables.td
@@ -238,3 +238,84 @@ def EEntryOddTable : GenericTable {
   let PrimaryKey = ["Value"];
   let PrimaryKeyName = "lookupEEntryOddTableByValue";
 }
+
+// Test direct sparse lookup.
+
+// CHECK-LABEL: GET_FTable_DECL
+// CHECK: const FEntry *lookupFTableByKey(uint8_t Key);
+
+// CHECK-LABEL: GET_FTable_IMPL
+// CHECK: constexpr FEntry FTable[] = {
+// CHECK:   { 0x1, {} }, // 0
+// CHECK:   { 0x0, {} }, // 1
+// CHECK:   { 0x2, 0x14 }, // 2
+// CHECK:   { 0x0, {} }, // 3
+// CHECK:   { 0x0, {} }, // 4
+// CHECK:   { 0x5, 0x32 }, // 5
+// CHECK:   { 0x0, {} }, // 6
+// CHECK:   { 0x0, {} }, // 7
+// CHECK:   { 0x0, {} }, // 8
+// CHECK:   { 0x0, {} }, // 9
+// CHECK:   { 0x0, {} }, // 10
+// CHECK:   { 0x0, {} }, // 11
+// CHECK:   { 0x0, {} }, // 12
+// CHECK:   { 0x0, {} }, // 13
+// CHECK:   { 0x0, {} }, // 14
+// CHECK:   { 0x0, {} }, // 15
+// CHECK: };
+
+// CHECK: const FEntry *lookupFTableByKey(uint8_t Key) {
+// CHECK:   if (Key >= 16)
+// CHECK:     return nullptr;
+// CHECK:   const auto *Entry = &FTable[Key];
+// CHECK:   return Entry->Key == Key ? Entry : nullptr;
+// CHECK: }
+
+class FEntry<int key, int val> {
+  bits<4> Key = key;
+  bits<8> Val = val;
+}
+
+def FEntry2 : FEntry<2, 20>;
+def FEntry5 : FEntry<5, 50>;
+
+def FTable : GenericTable {
+  let FilterClass = "FEntry";
+  let Fields = ["Key", "Val"];
+  let PrimaryKey = ["Key"];
+  let PrimaryKeyName = "lookupFTableByKey";
+  let DisallowSparseTable = false;
+}
+
+// Check TableGen fallbacks to binary search when DisallowSparseTable = false
+// and a secondary search index is used.
+
+// CHECK-LABEL: GET_GTable_IMPL
+// CHECK: constexpr GEntry GTable[] = {
+// CHECK:   { 0x2, 0x14 }, // 0
+// CHECK:   { 0x5, 0x32 }, // 1
+// CHECK: };
+
+// CHECK: const GEntry *lookupGTableByKey(uint8_t Key) {
+// CHECK:   auto Idx = std::lower_bound(
+
+class GEntry<int key, int val> {
+  bits<4> Key = key;
+  bits<8> Val = val;
+}
+
+def GEntry2 : GEntry<2, 20>;
+def GEntry5 : GEntry<5, 50>;
+
+def GTable : GenericTable {
+  let FilterClass = "GEntry";
+  let Fields = ["Key", "Val"];
+  let PrimaryKey = ["Key"];
+  let PrimaryKeyName = "lookupGTableByKey";
+  let DisallowSparseTable = false;
+}
+
+def lookupGTableByVal : SearchIndex {
+  let Table = GTable;
+  let Key = ["Val"];
+}

--- a/llvm/utils/TableGen/SearchableTableEmitter.cpp
+++ b/llvm/utils/TableGen/SearchableTableEmitter.cpp
@@ -96,6 +96,8 @@ struct GenericTable {
   std::unique_ptr<SearchIndex> PrimaryKey;
   SmallVector<std::unique_ptr<SearchIndex>, 2> Indices;
 
+  bool AllowSparseTable;
+
   const GenericField *getFieldByName(StringRef Name) const {
     for (const auto &Field : Fields) {
       if (Name == Field.Name)
@@ -610,25 +612,57 @@ void SearchableTableEmitter::emitGenericTable(const GenericTable &Table,
 
   StringToOffsetTable StrTab;
 
+  SmallVector<const Record *, 0> SparseEntries;
+  ArrayRef<const Record *> Entries;
+  unsigned DirectLookupSlots = 0;
+  if (Table.AllowSparseTable) {
+    const auto *KeyBits = cast<BitsRecTy>(Table.PrimaryKey->Fields[0].RecType);
+    DirectLookupSlots = 1u << KeyBits->getNumBits();
+    SparseEntries.resize(DirectLookupSlots);
+    StringRef KeyFieldName = Table.PrimaryKey->Fields[0].Name;
+    for (const Record *Entry : Table.Entries) {
+      uint64_t Key = static_cast<uint64_t>(getInt(Entry, KeyFieldName));
+      assert(Key < DirectLookupSlots && "key exceeds table size");
+      if (SparseEntries[Key])
+        PrintFatalError(Entry, Twine("In table '") + Table.Name +
+                                   "', duplicate primary key value " +
+                                   Twine(Key));
+      SparseEntries[Key] = Entry;
+    }
+    Entries = SparseEntries;
+  } else {
+    Entries = Table.Entries;
+  }
+
   // The primary data table contains all the fields defined for this map.
   OS << "constexpr " << Table.CppTypeName << " " << Table.Name << "[] = {\n";
-  for (const auto &[Idx, Entry] : enumerate(Table.Entries)) {
+  for (const auto &[Idx, Entry] : enumerate(Entries)) {
     OS << "  { ";
-
     ListSeparator LS;
-    for (const auto &Field : Table.Fields) {
-      OS << LS;
-      const Init *Value = Entry->getValueInit(Field.Name);
-      if (const auto *SI = dyn_cast<StringInit>(Value);
-          SI && !Field.IsCode && !SI->hasCodeFormat()) {
-        OS << StrTab.GetOrAddStringOffset(Value->getAsUnquotedString())
-           << " /* " << primaryRepresentation(Table.Locs[0], Field, Value)
-           << " */";
-      } else {
-        OS << primaryRepresentation(Table.Locs[0], Field, Value);
+    if (Entry) {
+      for (const auto &Field : Table.Fields) {
+        OS << LS;
+        const Init *Value = Entry->getValueInit(Field.Name);
+        if (const auto *SI = dyn_cast<StringInit>(Value);
+            SI && !Field.IsCode && !SI->hasCodeFormat()) {
+          OS << StrTab.GetOrAddStringOffset(Value->getAsUnquotedString())
+             << " /* " << primaryRepresentation(Table.Locs[0], Field, Value)
+             << " */";
+        } else {
+          OS << primaryRepresentation(Table.Locs[0], Field, Value);
+        }
+      }
+    } else if (Table.AllowSparseTable) {
+      // For empty rows emit a sentinel value as a key, so we can return null
+      // during lookup. Value is constructed such that LookupKey != KeyField.
+      for (const auto &Field : Table.Fields) {
+        OS << LS;
+        if (Field.Name == Table.PrimaryKey->Fields[0].Name)
+          OS << "0x" << (Idx == 0 ? 1 : 0);
+        else
+          OS << "{}";
       }
     }
-
     OS << " }, // " << Idx << "\n";
   }
   OS << " };\n";
@@ -637,11 +671,24 @@ void SearchableTableEmitter::emitGenericTable(const GenericTable &Table,
   // The lookup function might add more strings.
   std::string LookupFunction;
   raw_string_ostream LFOS(LookupFunction);
-  // Indexes are sorted "{ Thing, PrimaryIdx }" arrays, so that a binary
-  // search can be performed by "Thing".
-  if (Table.PrimaryKey)
+  if (Table.AllowSparseTable) {
+    LFOS << "\n";
+    emitLookupDeclaration(Table, *Table.PrimaryKey, LFOS);
+    LFOS << " {\n";
+    const GenericField &Field = Table.PrimaryKey->Fields[0];
+    LFOS << "  if (" << Field.Name << " >= " << DirectLookupSlots << ")\n";
+    LFOS << "    return nullptr;\n";
+    LFOS << "  const auto *Entry = &" << Table.Name << "[" << Field.Name
+         << "];\n";
+    LFOS << "  return Entry->" << Field.Name << " == " << Field.Name
+         << " ? Entry : nullptr;\n";
+    LFOS << "}\n";
+  } else if (Table.PrimaryKey) {
+    // Indexes are sorted "{ Thing, PrimaryIdx }" arrays, so that a binary
+    // search can be performed by "Thing".
     emitLookupFunction(Table, *Table.PrimaryKey, /*IsPrimary=*/true, StrTab,
                        LFOS);
+  }
   for (const auto &Index : Table.Indices)
     emitLookupFunction(Table, *Index, /*IsPrimary=*/false, StrTab, LFOS);
 
@@ -794,6 +841,34 @@ void SearchableTableEmitter::collectTableEntries(
   });
 }
 
+static bool canUseSparseTable(const Record *TableRec,
+                              const std::unique_ptr<GenericTable> &Table) {
+  if (TableRec->getValueAsBit("DisallowSparseTable"))
+    return false;
+
+  // Sparse tables are only supported with a single primary key.
+  if (Table->PrimaryKey->Fields.size() != 1)
+    return false;
+
+  const auto *KeyBits =
+      dyn_cast<BitsRecTy>(Table->PrimaryKey->Fields[0].RecType);
+
+  // Sparse tables only support `bits` key.
+  if (!KeyBits)
+    return false;
+
+  // Sparse tables are not compatible with PrimaryKeyReturnRange.
+  if (TableRec->getValueAsBit("PrimaryKeyReturnRange"))
+    return false;
+
+  // Only support tables up to 4k in size.
+  constexpr unsigned MaxKeyBits = 12;
+  if (KeyBits->getNumBits() > MaxKeyBits)
+    return false;
+
+  return true;
+}
+
 void SearchableTableEmitter::run(raw_ostream &OS) {
   // Emit tables in a deterministic order to avoid needless rebuilds.
   SmallVector<std::unique_ptr<GenericTable>, 4> Tables;
@@ -897,6 +972,8 @@ void SearchableTableEmitter::run(raw_ostream &OS) {
                         [&](const Record *LHS, const Record *RHS) {
                           return compareBy(LHS, RHS, *Table->PrimaryKey);
                         });
+
+      Table->AllowSparseTable = canUseSparseTable(TableRec, Table);
     }
 
     TableMap.try_emplace(TableRec, Table.get());
@@ -918,6 +995,9 @@ void SearchableTableEmitter::run(raw_ostream &OS) {
         Table, IndexRec->getValue("Key"), IndexRec->getName(),
         IndexRec->getValueAsListOfStrings("Key"),
         IndexRec->getValueAsBit("EarlyOut"), /*ReturnRange*/ false));
+
+    // Sparse tables with secondary search indices are not supported.
+    Table.AllowSparseTable = false;
   }
 
   // Translate legacy tables.


### PR DESCRIPTION
This change is motivated by the recent AMDGPU patch (#200241) where a sparse direct-lookup table is generated manually to improve VOPD eligibility lookup. The `GenericTable` only generates a direct lookup for continuous tables, defaulting to binary search for non-continuous spaces. This patch extends the  `GenericTable` to support sparse tables. Currently it is implemented as an opt-in feature, however the long-term vision is to heuristically decide the best lookup scheme. Setting `DisallowSparseTable = false` opts a table in: TableGen will emit a sparse array as long as certain conditions are met (key space <= 4K entries, single primary `bits<>` key, no secondary search indices, etc.). For example:

```
def VOPDXYTable : GenericTable {
  let FilterClass = "VOPDXY";
  let CppTypeName = "VOPDXYInfo";
  let Fields = ["VOPDXYKey", "IsX", "IsY"];
  let PrimaryKey = ["VOPDXYKey"];
  let PrimaryKeyName = "getVOPDXYInfo";
  let DisallowSparseTable = false;
}
```

Generates following C++ code:

```c++
#ifdef GET_VOPDXYTable_DECL
const VOPDXYInfo *getVOPDXYInfo(uint16_t VOPDXYKey);
#endif

#ifdef GET_VOPDXYTable_IMPL
constexpr VOPDXYInfo VOPDXYTable[] = {
  { 0x1, {}, {} }, // 0
  { 0x0, {}, {} }, // 1
  { 0x0, {}, {} }, // 2
  { 0x0, {}, {} }, // 3
  { 0x0, {}, {} }, // 4
  { 0x0, {}, {} }, // 5
  { 0x0, {}, {} }, // 6
  { 0x0, {}, {} }, // 7
  { 0x0, {}, {} }, // 8
  { 0x0, {}, {} }, // 9
  { 0x0, {}, {} }, // 10
  { 0x0, {}, {} }, // 11
  { 0x0, {}, {} }, // 12
  { 0x0, {}, {} }, // 13
  { 0x0, {}, {} }, // 14
  { 0x0, {}, {} }, // 15
  { 0x0, {}, {} }, // 16
  { 0x0, {}, {} }, // 17
  { 0x0, {}, {} }, // 18
  { 0x0, {}, {} }, // 19
  { 0x14, true, true }, // 20
  { 0x0, {}, {} }, // 21
  { 0x16, true, true }, // 22
  { 0x0, {}, {} }, // 23
  { 0x18, true, true }, // 24
  { 0x0, {}, {} }, // 25
  { 0x1A, true, true }, // 26
  { 0x1B, true, true }, // 27
  { 0x1C, true, true }, // 28
  { 0x1D, true, true }, // 29
  { 0x0, {}, {} }, // 30
  { 0x0, {}, {} }, // 31
  { 0x0, {}, {} }, // 32
  ...
  { 0x0, {}, {} }, // 2046
  { 0x0, {}, {} }, // 2047
 };

const VOPDXYInfo *getVOPDXYInfo(uint16_t VOPDXYKey) {
  if (VOPDXYKey >= 2048)
    return nullptr;
  const auto *Entry = &VOPDXYTable[VOPDXYKey];
  return Entry->VOPDXYKey == VOPDXYKey ? Entry : nullptr;
}
#endif
```

Assisted-by: Claude Code