### PR TITLE
[flang][OpenMP] Rename check-omp-metadirective.cpp (NFC).

### DIFF
--- a/flang/lib/Semantics/CMakeLists.txt
+++ b/flang/lib/Semantics/CMakeLists.txt
@@ -22,7 +22,7 @@ add_flang_library(FortranSemantics
   check-nullify.cpp
   check-omp-atomic.cpp
   check-omp-loop.cpp
-  check-omp-metadirective.cpp
+  check-omp-variant.cpp
   check-omp-structure.cpp
   check-purity.cpp
   check-return.cpp

--- a/flang/lib/Semantics/check-omp-structure.h
+++ b/flang/lib/Semantics/check-omp-structure.h
@@ -258,7 +258,7 @@ private:
   void CheckScanModifier(const parser::OmpClause::Reduction &x);
   void CheckDistLinear(const parser::OpenMPLoopConstruct &x);
 
-  // check-omp-metadirective.cpp
+  // check-omp-variant.cpp
   void CheckOmpDeclareVariantDirective(
       const parser::OmpDeclareVariantDirective &);
   void CheckDeclareVariantUserConditions(const parser::OmpContextSelector &);

--- a/flang/lib/Semantics/check-omp-variant.cpp
+++ b/flang/lib/Semantics/check-omp-variant.cpp
@@ -1,4 +1,4 @@
-//===-- lib/Semantics/check-omp-metadirective.cpp -------------------------===//
+//===-- lib/Semantics/check-omp-variant.cpp --------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/flang/lib/Semantics/check-omp-variant.cpp
+++ b/flang/lib/Semantics/check-omp-variant.cpp
@@ -1,4 +1,4 @@
-//===-- lib/Semantics/check-omp-variant.cpp --------------------------------===//
+//===-- lib/Semantics/check-omp-variant.cpp -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.


### PR DESCRIPTION
Both METADIRECTIVE and DECLARE VARIANT fall into the "variant directives" category, so check-omp-variant.cpp is a more accurate name for the file that hosts their semantic checks.

Suggested in https://github.com/llvm/llvm-project/pull/198799#issuecomment-4576970335