### PR TITLE
Reapply "DebugInfo: Shrink-to-fit some containers to reduce peak memory usage" (#199145)

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugAbbrev.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugAbbrev.cpp
@@ -62,6 +62,7 @@ Error DWARFAbbreviationDeclarationSet::extract(DataExtractor Data,
     PrevAbbrCode = AbbrDecl.getCode();
     Decls.push_back(std::move(AbbrDecl));
   }
+  Decls.shrink_to_fit();
   return Error::success();
 }
 

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
@@ -1269,6 +1269,9 @@ Error DWARFDebugLine::LineTable::parse(
         " is not terminated",
         DebugLineOffset));
 
+  Rows.shrink_to_fit();
+  Sequences.shrink_to_fit();
+
   // Sort all sequences so that address lookup will work faster.
   if (!Sequences.empty()) {
     llvm::stable_sort(Sequences, Sequence::orderByHighPC);

--- a/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
@@ -496,6 +496,7 @@ void DWARFUnit::extractDIEsToVector(
 
     // Stop when compile unit die is removed from the parents stack.
   } while (Parents.size() > 1);
+  Dies.shrink_to_fit();
 }
 
 void DWARFUnit::extractDIEsIfNeeded(bool CUDieOnly) {

--- a/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
+++ b/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
@@ -653,10 +653,9 @@ void DwarfTransformer::parseCallSiteInfoFromDwarf(CUInfo &CUI, DWARFDie Die,
 Error DwarfTransformer::convert(uint32_t NumThreads, OutputAggregator &Out) {
   size_t NumBefore = Gsym.getNumFunctionInfos();
   auto getDie = [&](DWARFUnit &DwarfUnit) -> DWARFDie {
-    DWARFDie ReturnDie = DwarfUnit.getUnitDIE(false);
     // Apple uses DW_AT_GNU_dwo_id for things other than split DWARF.
     if (IsMachO)
-      return ReturnDie;
+      return DwarfUnit.getUnitDIE(false);
 
     if (DwarfUnit.getDWOId()) {
       DWARFUnit *DWOCU = DwarfUnit.getNonSkeletonUnitDIE(false).getDwarfUnit();
@@ -673,10 +672,10 @@ Error DwarfTransformer::convert(uint32_t NumThreads, OutputAggregator &Out) {
                  << DWOName << "\n";
             });
       else {
-        ReturnDie = DWOCU->getUnitDIE(false);
+        return DWOCU->getUnitDIE(false);
       }
     }
-    return ReturnDie;
+    return DwarfUnit.getUnitDIE(false);
   };
   if (NumThreads == 1) {
     // Parse all DWARF data from this thread, use the same string/file table


### PR DESCRIPTION
Starting with posting this as a draft PR to run presubmit checks to
understand what failed.

This reverts commit #199145,
effectively reapplying #198935.
