### PR TITLE
[CIR] Lower bitwise vector reduce builtins

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1701,29 +1701,26 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
   case Builtin::BI__builtin_masked_compress_store:
   case Builtin::BI__builtin_masked_scatter:
     return errorBuiltinNYI(*this, e, builtinID);
-  case Builtin::BI__builtin_reduce_xor:
-  case Builtin::BI__builtin_reduce_or:
+  case Builtin::BI__builtin_reduce_xor: {
+    mlir::Value arg = emitScalarExpr(e->getArg(0));
+    cir::VectorType vecTy = cast<cir::VectorType>(arg.getType());
+    return RValue::get(builder.emitIntrinsicCallOp(
+        getLoc(e->getExprLoc()), "vector.reduce.xor", vecTy.getElementType(),
+        mlir::ValueRange{arg}));
+  }
+  case Builtin::BI__builtin_reduce_or: {
+    mlir::Value arg = emitScalarExpr(e->getArg(0));
+    cir::VectorType vecTy = cast<cir::VectorType>(arg.getType());
+    return RValue::get(builder.emitIntrinsicCallOp(
+        getLoc(e->getExprLoc()), "vector.reduce.or", vecTy.getElementType(),
+        mlir::ValueRange{arg}));
+  }
   case Builtin::BI__builtin_reduce_and: {
     mlir::Value arg = emitScalarExpr(e->getArg(0));
     cir::VectorType vecTy = cast<cir::VectorType>(arg.getType());
-    llvm::StringRef intrinsicName;
-    switch (builtinID) {
-    default:
-      llvm_unreachable("unexpected vector reduce bitwise builtin");
-    case Builtin::BI__builtin_reduce_xor:
-      intrinsicName = "vector.reduce.xor";
-      break;
-    case Builtin::BI__builtin_reduce_or:
-      intrinsicName = "vector.reduce.or";
-      break;
-    case Builtin::BI__builtin_reduce_and:
-      intrinsicName = "vector.reduce.and";
-      break;
-    }
-    mlir::Value result = builder.emitIntrinsicCallOp(
-        getLoc(e->getExprLoc()), intrinsicName, vecTy.getElementType(),
-        mlir::ValueRange{arg});
-    return RValue::get(result);
+    return RValue::get(builder.emitIntrinsicCallOp(
+        getLoc(e->getExprLoc()), "vector.reduce.and", vecTy.getElementType(),
+        mlir::ValueRange{arg}));
   }
   case Builtin::BI__builtin_isinf_sign: {
     CIRGenFunction::CIRGenFPOptionsRAII FPOptsRAII(*this, e);

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1687,9 +1687,6 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
   case Builtin::BI__builtin_reduce_min:
   case Builtin::BI__builtin_reduce_add:
   case Builtin::BI__builtin_reduce_mul:
-  case Builtin::BI__builtin_reduce_xor:
-  case Builtin::BI__builtin_reduce_or:
-  case Builtin::BI__builtin_reduce_and:
   case Builtin::BI__builtin_reduce_assoc_fadd:
   case Builtin::BI__builtin_reduce_in_order_fadd:
   case Builtin::BI__builtin_reduce_maximum:
@@ -1704,6 +1701,30 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
   case Builtin::BI__builtin_masked_compress_store:
   case Builtin::BI__builtin_masked_scatter:
     return errorBuiltinNYI(*this, e, builtinID);
+  case Builtin::BI__builtin_reduce_xor:
+  case Builtin::BI__builtin_reduce_or:
+  case Builtin::BI__builtin_reduce_and: {
+    mlir::Value arg = emitScalarExpr(e->getArg(0));
+    cir::VectorType vecTy = cast<cir::VectorType>(arg.getType());
+    llvm::StringRef intrinsicName;
+    switch (builtinID) {
+    default:
+      llvm_unreachable("unexpected vector reduce bitwise builtin");
+    case Builtin::BI__builtin_reduce_xor:
+      intrinsicName = "vector.reduce.xor";
+      break;
+    case Builtin::BI__builtin_reduce_or:
+      intrinsicName = "vector.reduce.or";
+      break;
+    case Builtin::BI__builtin_reduce_and:
+      intrinsicName = "vector.reduce.and";
+      break;
+    }
+    mlir::Value result = builder.emitIntrinsicCallOp(
+        getLoc(e->getExprLoc()), intrinsicName, vecTy.getElementType(),
+        mlir::ValueRange{arg});
+    return RValue::get(result);
+  }
   case Builtin::BI__builtin_isinf_sign: {
     CIRGenFunction::CIRGenFPOptionsRAII FPOptsRAII(*this, e);
     mlir::Location loc = getLoc(e->getBeginLoc());

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1687,19 +1687,6 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
   case Builtin::BI__builtin_reduce_min:
   case Builtin::BI__builtin_reduce_add:
   case Builtin::BI__builtin_reduce_mul:
-  case Builtin::BI__builtin_reduce_assoc_fadd:
-  case Builtin::BI__builtin_reduce_in_order_fadd:
-  case Builtin::BI__builtin_reduce_maximum:
-  case Builtin::BI__builtin_reduce_minimum:
-  case Builtin::BI__builtin_matrix_transpose:
-  case Builtin::BI__builtin_matrix_column_major_load:
-  case Builtin::BI__builtin_matrix_column_major_store:
-  case Builtin::BI__builtin_masked_load:
-  case Builtin::BI__builtin_masked_expand_load:
-  case Builtin::BI__builtin_masked_gather:
-  case Builtin::BI__builtin_masked_store:
-  case Builtin::BI__builtin_masked_compress_store:
-  case Builtin::BI__builtin_masked_scatter:
     return errorBuiltinNYI(*this, e, builtinID);
   case Builtin::BI__builtin_reduce_xor: {
     mlir::Value arg = emitScalarExpr(e->getArg(0));
@@ -1722,6 +1709,20 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
         getLoc(e->getExprLoc()), "vector.reduce.and", vecTy.getElementType(),
         mlir::ValueRange{arg}));
   }
+  case Builtin::BI__builtin_reduce_assoc_fadd:
+  case Builtin::BI__builtin_reduce_in_order_fadd:
+  case Builtin::BI__builtin_reduce_maximum:
+  case Builtin::BI__builtin_reduce_minimum:
+  case Builtin::BI__builtin_matrix_transpose:
+  case Builtin::BI__builtin_matrix_column_major_load:
+  case Builtin::BI__builtin_matrix_column_major_store:
+  case Builtin::BI__builtin_masked_load:
+  case Builtin::BI__builtin_masked_expand_load:
+  case Builtin::BI__builtin_masked_gather:
+  case Builtin::BI__builtin_masked_store:
+  case Builtin::BI__builtin_masked_compress_store:
+  case Builtin::BI__builtin_masked_scatter:
+    return errorBuiltinNYI(*this, e, builtinID);
   case Builtin::BI__builtin_isinf_sign: {
     CIRGenFunction::CIRGenFPOptionsRAII FPOptsRAII(*this, e);
     mlir::Location loc = getLoc(e->getBeginLoc());

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1688,27 +1688,21 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
   case Builtin::BI__builtin_reduce_add:
   case Builtin::BI__builtin_reduce_mul:
     return errorBuiltinNYI(*this, e, builtinID);
-  case Builtin::BI__builtin_reduce_xor: {
-    mlir::Value arg = emitScalarExpr(e->getArg(0));
-    cir::VectorType vecTy = cast<cir::VectorType>(arg.getType());
-    return RValue::get(builder.emitIntrinsicCallOp(
-        getLoc(e->getExprLoc()), "vector.reduce.xor", vecTy.getElementType(),
-        mlir::ValueRange{arg}));
-  }
-  case Builtin::BI__builtin_reduce_or: {
-    mlir::Value arg = emitScalarExpr(e->getArg(0));
-    cir::VectorType vecTy = cast<cir::VectorType>(arg.getType());
-    return RValue::get(builder.emitIntrinsicCallOp(
-        getLoc(e->getExprLoc()), "vector.reduce.or", vecTy.getElementType(),
-        mlir::ValueRange{arg}));
-  }
-  case Builtin::BI__builtin_reduce_and: {
-    mlir::Value arg = emitScalarExpr(e->getArg(0));
-    cir::VectorType vecTy = cast<cir::VectorType>(arg.getType());
-    return RValue::get(builder.emitIntrinsicCallOp(
-        getLoc(e->getExprLoc()), "vector.reduce.and", vecTy.getElementType(),
-        mlir::ValueRange{arg}));
-  }
+  case Builtin::BI__builtin_reduce_xor:
+    return emitBuiltinWithOneOverloadedType<1>(
+        e, "vector.reduce.xor",
+        cast<cir::VectorType>(convertType(e->getArg(0)->getType()))
+            .getElementType());
+  case Builtin::BI__builtin_reduce_or:
+    return emitBuiltinWithOneOverloadedType<1>(
+        e, "vector.reduce.or",
+        cast<cir::VectorType>(convertType(e->getArg(0)->getType()))
+            .getElementType());
+  case Builtin::BI__builtin_reduce_and:
+    return emitBuiltinWithOneOverloadedType<1>(
+        e, "vector.reduce.and",
+        cast<cir::VectorType>(convertType(e->getArg(0)->getType()))
+            .getElementType());
   case Builtin::BI__builtin_reduce_assoc_fadd:
   case Builtin::BI__builtin_reduce_in_order_fadd:
   case Builtin::BI__builtin_reduce_maximum:

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1705,16 +1705,21 @@ public:
 
   void instantiateIndirectGotoBlock();
 
-  /// Emit a simple LLVM intrinsic that takes N scalar arguments and whose
-  /// return type matches the type of the first argument. The intrinsic name is
-  /// used verbatim; any overload mangling (e.g. `.f32`, `.p1`) must be baked
-  /// into \p intrinName by the caller.
+  /// Emit a simple LLVM intrinsic that takes N scalar arguments.  The intrinsic
+  /// name is used verbatim; any overload mangling (e.g. `.f32`, `.p1`) must be
+  /// baked into \p intrinName by the caller.  The result type defaults to the
+  /// type of the first argument; pass \p resultType for intrinsics whose result
+  /// differs from the operand, such as a vector reduction that returns the
+  /// element type.  Unlike classic CodeGen, CIR has no intrinsic registry to
+  /// derive the result type from the operand, so it must be supplied here.
   template <unsigned N>
   [[maybe_unused]] RValue
   emitBuiltinWithOneOverloadedType(const CallExpr *e,
-                                   llvm::StringRef intrinName) {
+                                   llvm::StringRef intrinName,
+                                   mlir::Type resultType = {}) {
     static_assert(N, "expect non-empty argument");
-    mlir::Type cirTy = convertType(e->getArg(0)->getType());
+    mlir::Type cirTy =
+        resultType ? resultType : convertType(e->getArg(0)->getType());
     SmallVector<mlir::Value, N> args;
     for (unsigned i = 0; i < N; ++i)
       args.push_back(emitScalarExpr(e->getArg(i)));

--- a/clang/test/CIR/CodeGenBuiltins/builtin-reduce-bitwise.c
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-reduce-bitwise.c
@@ -1,0 +1,49 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+typedef int v4si __attribute__((vector_size(16)));
+typedef unsigned int v4su __attribute__((vector_size(16)));
+
+int test_reduce_or(v4si x) {
+  // CIR-LABEL: @test_reduce_or
+  // CIR: cir.call_llvm_intrinsic "vector.reduce.or"
+  // CIR: cir.return
+  // LLVM-LABEL: @test_reduce_or
+  // LLVM: call i32 @llvm.vector.reduce.or.v4i32(<4 x i32>
+  // LLVM: ret i32
+  return __builtin_reduce_or(x);
+}
+
+int test_reduce_and(v4si x) {
+  // CIR-LABEL: @test_reduce_and
+  // CIR: cir.call_llvm_intrinsic "vector.reduce.and"
+  // CIR: cir.return
+  // LLVM-LABEL: @test_reduce_and
+  // LLVM: call i32 @llvm.vector.reduce.and.v4i32(<4 x i32>
+  // LLVM: ret i32
+  return __builtin_reduce_and(x);
+}
+
+int test_reduce_xor(v4si x) {
+  // CIR-LABEL: @test_reduce_xor
+  // CIR: cir.call_llvm_intrinsic "vector.reduce.xor"
+  // CIR: cir.return
+  // LLVM-LABEL: @test_reduce_xor
+  // LLVM: call i32 @llvm.vector.reduce.xor.v4i32(<4 x i32>
+  // LLVM: ret i32
+  return __builtin_reduce_xor(x);
+}
+
+unsigned test_reduce_or_unsigned(v4su x) {
+  // CIR-LABEL: @test_reduce_or_unsigned
+  // CIR: cir.call_llvm_intrinsic "vector.reduce.or"
+  // CIR: cir.return
+  // LLVM-LABEL: @test_reduce_or_unsigned
+  // LLVM: call i32 @llvm.vector.reduce.or.v4i32(<4 x i32>
+  // LLVM: ret i32
+  return __builtin_reduce_or(x);
+}

--- a/clang/test/CIR/CodeGenBuiltins/builtin-undef-rvalue.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-undef-rvalue.cpp
@@ -5,15 +5,15 @@
 
 typedef int v4si __attribute__((vector_size(16)));
 
-int test_builtin_reduce_or_undef_rvalue(v4si x) {
-  // expected-error@+1 {{unimplemented X86 builtin call: __builtin_reduce_or}}
-  return __builtin_reduce_or(x);
+int test_builtin_reduce_add_undef_rvalue(v4si x) {
+  // expected-error@+1 {{unimplemented X86 builtin call: __builtin_reduce_add}}
+  return __builtin_reduce_add(x);
 }
 
-// CIR-LABEL: @_Z35test_builtin_reduce_or_undef_rvalueDv4_i
+// CIR-LABEL: @_Z36test_builtin_reduce_add_undef_rvalueDv4_i
 // CIR:         cir.const #cir.undef : !s32i
 // CIR:         cir.return
 
-// LLVM-LABEL: @_Z35test_builtin_reduce_or_undef_rvalueDv4_i
+// LLVM-LABEL: @_Z36test_builtin_reduce_add_undef_rvalueDv4_i
 // LLVM:         store i32 undef, ptr %{{.+}}, align 4
 // LLVM:         ret i32 %{{.+}}


### PR DESCRIPTION
`__builtin_reduce_or`, `__builtin_reduce_and`, and `__builtin_reduce_xor` were caught by the batch `errorBuiltinNYI` switch in CIRGen and rejected with an NYI diagnostic.  They now lower to the matching `llvm.vector.reduce.{or,and,xor}` intrinsics on the vector element type, mirroring classic CodeGen in `CGBuiltin.cpp`.

The emission follows the existing X86 `vector.reduce.fmax`/`fmin` convention in `CIRGenBuiltinX86.cpp` — the intrinsic name is passed without the `llvm.` prefix, which `LowerToLLVM` prepends, producing LLVM output byte-identical to OGCG.

The `builtin-undef-rvalue` regression test previously pinned `reduce_or` as NYI; it is retargeted to `reduce_add`, which is still NYI, so the undef-rvalue path stays covered.
