### PR TITLE
[SandboxVec][VecUtils][NFC] Improve VecUtils::areConsecutive() template

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/VecUtils.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/VecUtils.h
@@ -65,8 +65,8 @@ public:
     return *Diff == ElmBytes;
   }
 
-  template <typename LoadOrStoreT, typename ValT>
-  static bool areConsecutive(ArrayRef<ValT *> Bndl, ScalarEvolution &SE,
+  template <typename LoadOrStoreT, typename RangeT>
+  static bool areConsecutive(const RangeT &Bndl, ScalarEvolution &SE,
                              const DataLayout &DL) {
     static_assert(std::is_same<LoadOrStoreT, LoadInst>::value ||
                       std::is_same<LoadOrStoreT, StoreInst>::value,

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/LoadStoreVec.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/LoadStoreVec.cpp
@@ -72,8 +72,7 @@ bool LoadStoreVec::runOnRegion(Region &Rgn, const Analyses &A) {
   DL = &F.getParent()->getDataLayout();
   auto &Ctx = F.getContext();
   Scheduler Sched(A.getAA(), Ctx);
-  if (!VecUtils::areConsecutive<StoreInst, Instruction>(
-          Bndl, A.getScalarEvolution(), *DL))
+  if (!VecUtils::areConsecutive<StoreInst>(Bndl, A.getScalarEvolution(), *DL))
     return false;
   if (!canVectorize(Bndl, Sched))
     return false;
@@ -119,8 +118,8 @@ bool LoadStoreVec::runOnRegion(Region &Rgn, const Analyses &A) {
     for (Value *Op : Operands)
       Loads.push_back(cast<Instruction>(Op));
 
-    bool Consecutive = VecUtils::areConsecutive<LoadInst, Instruction>(
-        Loads, A.getScalarEvolution(), *DL);
+    bool Consecutive =
+        VecUtils::areConsecutive<LoadInst>(Loads, A.getScalarEvolution(), *DL);
     if (!Consecutive) {
       Ctx.accept();
       return false;


### PR DESCRIPTION
This helps drop the second template argument.