### PR TITLE
[lldb][bazel] Add Windows cross-compilation support to LLDB Bazel overlay

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
@@ -575,6 +575,11 @@ cc_library(
                 "source/Host/posix/**/*.cpp",
             ],
         ),
+        "@platforms//os:windows": glob([
+            "source/Host/windows/**/*.cpp",
+        ]) + [
+            "source/Host/posix/ConnectionFileDescriptorPosix.cpp",
+        ],
     }) + select({
         ":libedit_enabled": ["source/Host/common/Editline.cpp"],
         "//conditions:default": [],
@@ -596,6 +601,11 @@ cc_library(
             "include/lldb/Host/linux/*.h",
             "include/lldb/Host/posix/*.h",
         ]),
+        "@platforms//os:windows": glob([
+            "include/lldb/Host/posix/*.h",
+            "include/lldb/Host/windows/*.h",
+            "include/lldb/Host/windows/**/*.h",
+        ]),
     }) + select({
         ":libedit_enabled": ["include/lldb/Host/Editline.h"],
         "//conditions:default": [],
@@ -609,6 +619,12 @@ cc_library(
             "-lxml2",
             "-Wl,-framework,CoreServices",
             "-Wl,-framework,Security",
+        ],
+        "@platforms//os:windows": [
+            "rpcrt4.lib",
+            "version.lib",
+            "dbghelp.lib",
+            "pathcch.lib",
         ],
         "//conditions:default": [],
     }) + select({

--- a/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
@@ -110,9 +110,6 @@ expand_template(
     name = "ConfigHeader",
     out = "include/lldb/Host/Config.h",
     substitutions = {
-        "#cmakedefine01 HAVE_PTSNAME_R": "#define HAVE_PTSNAME_R 1",
-        "#cmakedefine01 LLDB_ENABLE_TERMIOS": "#define LLDB_ENABLE_TERMIOS 1",
-
         # TODO: Add LZMA support by including the library in bazel
         "#cmakedefine01 LLDB_ENABLE_LZMA": "#define LLDB_ENABLE_LZMA 0",
 
@@ -143,8 +140,6 @@ expand_template(
         # Would cause tests to run with MTE.
         "#cmakedefine01 LLDB_ENABLE_MTE": "#define LLDB_ENABLE_MTE 0",
 
-        # Defaults that could be configurable if needed
-        "#cmakedefine01 LLDB_ENABLE_POSIX": "#define LLDB_ENABLE_POSIX 1",
         "#cmakedefine01 LLDB_ENABLE_PROTOCOL_SERVERS": "#define LLDB_ENABLE_PROTOCOL_SERVERS 1",
         "#cmakedefine LLDB_GLOBAL_INIT_DIRECTORY R\"(${LLDB_GLOBAL_INIT_DIRECTORY})\"": "#define LLDB_GLOBAL_INIT_DIRECTORY \"\"",
         "${LLDB_INSTALL_LIBDIR_BASENAME}": "lib",
@@ -155,8 +150,11 @@ expand_template(
             "#cmakedefine01 HAVE_NR_PROCESS_VM_READV": "#define HAVE_NR_PROCESS_VM_READV 0",
             "#cmakedefine01 HAVE_PPOLL": "#define HAVE_PPOLL 0",
             "#cmakedefine01 HAVE_PROCESS_VM_READV": "#define HAVE_PROCESS_VM_READV 0",
+            "#cmakedefine01 HAVE_PTSNAME_R": "#define HAVE_PTSNAME_R 1",
             "#cmakedefine01 HAVE_SYS_EVENT_H": "#define HAVE_SYS_EVENT_H 1",
             "#cmakedefine01 LLDB_ENABLE_LIBXML2": "#define LLDB_ENABLE_LIBXML2 1",
+            "#cmakedefine01 LLDB_ENABLE_POSIX": "#define LLDB_ENABLE_POSIX 1",
+            "#cmakedefine01 LLDB_ENABLE_TERMIOS": "#define LLDB_ENABLE_TERMIOS 1",
             "#cmakedefine01 LLDB_HAVE_EL_RFUNC_T": "#define LLDB_HAVE_EL_RFUNC_T 0",
         },
         "@platforms//os:linux": {
@@ -164,9 +162,24 @@ expand_template(
             "#cmakedefine01 HAVE_NR_PROCESS_VM_READV": "#define HAVE_NR_PROCESS_VM_READV 1",
             "#cmakedefine01 HAVE_PPOLL": "#define HAVE_PPOLL 1",
             "#cmakedefine01 HAVE_PROCESS_VM_READV": "#define HAVE_PROCESS_VM_READV 1",
+            "#cmakedefine01 HAVE_PTSNAME_R": "#define HAVE_PTSNAME_R 1",
             "#cmakedefine01 HAVE_SYS_EVENT_H": "#define HAVE_SYS_EVENT_H 0",
             "#cmakedefine01 LLDB_ENABLE_LIBXML2": "#define LLDB_ENABLE_LIBXML2 0",
+            "#cmakedefine01 LLDB_ENABLE_POSIX": "#define LLDB_ENABLE_POSIX 1",
+            "#cmakedefine01 LLDB_ENABLE_TERMIOS": "#define LLDB_ENABLE_TERMIOS 1",
             "#cmakedefine01 LLDB_HAVE_EL_RFUNC_T": "#define LLDB_HAVE_EL_RFUNC_T 1",
+        },
+        "@platforms//os:windows": {
+            "#cmakedefine01 HAVE_LIBCOMPRESSION": "#define HAVE_LIBCOMPRESSION 0",
+            "#cmakedefine01 HAVE_NR_PROCESS_VM_READV": "#define HAVE_NR_PROCESS_VM_READV 0",
+            "#cmakedefine01 HAVE_PPOLL": "#define HAVE_PPOLL 0",
+            "#cmakedefine01 HAVE_PROCESS_VM_READV": "#define HAVE_PROCESS_VM_READV 0",
+            "#cmakedefine01 HAVE_PTSNAME_R": "#define HAVE_PTSNAME_R 0",
+            "#cmakedefine01 HAVE_SYS_EVENT_H": "#define HAVE_SYS_EVENT_H 0",
+            "#cmakedefine01 LLDB_ENABLE_LIBXML2": "#define LLDB_ENABLE_LIBXML2 0",
+            "#cmakedefine01 LLDB_ENABLE_POSIX": "#define LLDB_ENABLE_POSIX 0",
+            "#cmakedefine01 LLDB_ENABLE_TERMIOS": "#define LLDB_ENABLE_TERMIOS 0",
+            "#cmakedefine01 LLDB_HAVE_EL_RFUNC_T": "#define LLDB_HAVE_EL_RFUNC_T 0",
         },
     }) | select({
         ":curses_enabled": {

--- a/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
@@ -9,7 +9,10 @@ load("@build_bazel_apple_support//rules:apple_genrule.bzl", "apple_genrule")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_import", "cc_library", "objc_library")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("//:vars.bzl", "LLVM_VERSION_MAJOR", "LLVM_VERSION_MINOR", "LLVM_VERSION_PATCH", "LLVM_VERSION_SUFFIX", "PACKAGE_VERSION")
-load("//lldb/source/Plugins:plugin_config.bzl", "DEFAULT_PLUGINS", "DEFAULT_SCRIPT_PLUGINS", "OBJCPP_COPTS")
+load("//lldb/source/Plugins:plugin_config.bzl", "DEFAULT_PLUGINS", "DEFAULT_SCRIPT_PLUGINS", "OBJCPP_COPTS", "WINDOWS_EXCLUDED_PLUGINS")
+
+_ALL_PLUGIN_DEPS = ["//lldb/source/Plugins:Plugin{}".format(x) for x in DEFAULT_PLUGINS + DEFAULT_SCRIPT_PLUGINS]
+_WINDOWS_PLUGIN_DEPS = ["//lldb/source/Plugins:Plugin{}".format(x) for x in DEFAULT_PLUGINS + DEFAULT_SCRIPT_PLUGINS if x not in WINDOWS_EXCLUDED_PLUGINS]
 load("//mlir:build_defs.bzl", "cc_headers_only")
 load("//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
 
@@ -242,6 +245,10 @@ cc_library(
         "source/API/**/*.h",
     ]),
     hdrs = glob(["include/lldb/API/**/*.h"]) + [":lldb-sbapi-dwarf-enums"],
+    defines = select({
+        "@platforms//os:windows": ["LLDB_IN_LIBLLDB"],
+        "//conditions:default": [],
+    }),
     includes = ["include"],
     deps = [
         ":Breakpoint",
@@ -267,10 +274,10 @@ cc_library(
         "//llvm:MCJIT",
         "//llvm:Support",
         "//llvm:config",
-    ] + [
-        "//lldb/source/Plugins:Plugin{}".format(x)
-        for x in DEFAULT_PLUGINS + DEFAULT_SCRIPT_PLUGINS
     ] + select({
+        "@platforms//os:windows": _WINDOWS_PLUGIN_DEPS,
+        "//conditions:default": _ALL_PLUGIN_DEPS,
+    }) + select({
         "@platforms//os:macos": [
             "//lldb/source/Plugins:PluginProcessMacOSXKernel",
             "//lldb/source/Plugins:PluginSymbolLocatorDebugSymbols",
@@ -358,9 +365,15 @@ cc_library(
         ":Utility",
         ":Version",
         "//lldb/source/Plugins:PluginProcessGDBRemote",
-        "//lldb/source/Plugins:PluginProcessPOSIX",
         "//llvm:Support",
-    ],
+    ] + select({
+        "@platforms//os:windows": [
+            "//lldb/source/Plugins:PluginProcessWindowsCommon",
+        ],
+        "//conditions:default": [
+            "//lldb/source/Plugins:PluginProcessPOSIX",
+        ],
+    }),
 )
 
 gentbl_cc_library(
@@ -972,7 +985,10 @@ cc_binary(
         ":lldb_options_inc_gen",
         "//llvm:Option",
         "//llvm:Support",
-    ],
+    ] + select({
+        "@platforms//os:windows": [":Host"],
+        "//conditions:default": [],
+    }),
 )
 
 cc_library(

--- a/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/source/Plugins/BUILD.bazel
@@ -4,7 +4,7 @@
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@rules_cc//cc:defs.bzl", "cc_library", "objc_library")
 load("//mlir:tblgen.bzl", "gentbl_cc_library")
-load(":plugin_config.bzl", "DEFAULT_PLUGINS", "DEFAULT_SCRIPT_PLUGINS", "OBJCPP_COPTS")
+load(":plugin_config.bzl", "DEFAULT_PLUGINS", "DEFAULT_SCRIPT_PLUGINS", "OBJCPP_COPTS", "WINDOWS_EXCLUDED_PLUGINS")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -2422,21 +2422,50 @@ cc_library(
 _DEFAULT_LOAD_PLUGINS = "\n".join(["LLDB_PLUGIN({})".format(x) for x in DEFAULT_PLUGINS]) + \
                         "\n" + "\n".join(["LLDB_SCRIPT_PLUGIN({})".format(x) for x in DEFAULT_SCRIPT_PLUGINS])
 
+_WINDOWS_LOAD_PLUGINS = "\n".join(["LLDB_PLUGIN({})".format(x) for x in DEFAULT_PLUGINS if x not in WINDOWS_EXCLUDED_PLUGINS]) + \
+                         "\n" + "\n".join(["LLDB_SCRIPT_PLUGIN({})".format(x) for x in DEFAULT_SCRIPT_PLUGINS if x not in WINDOWS_EXCLUDED_PLUGINS])
+
+cc_library(
+    name = "PluginProcessWindowsCommon",
+    srcs = glob(["Process/Windows/Common/*.cpp"]),
+    hdrs = glob([
+        "Process/Windows/Common/*.h",
+        "Process/Windows/Common/**/*.h",
+    ]),
+    includes = [".."],
+    target_compatible_with = ["@platforms//os:windows"],
+    deps = [
+        ":PluginDynamicLoaderWindowsDYLD",
+        "//lldb:Breakpoint",
+        "//lldb:Core",
+        "//lldb:Headers",
+        "//lldb:Host",
+        "//lldb:Target",
+        "//lldb:Utility",
+        "//llvm:Support",
+    ],
+)
+
 expand_template(
     name = "plugins_config_gen",
     out = "Plugins.def",
     substitutions = {
-        "@LLDB_PROCESS_WINDOWS_PLUGIN@": "",
         "@LLDB_PROCESS_GDB_PLUGIN@": "LLDB_PLUGIN(ProcessGDBRemote)",
     } | select({
         "@platforms//os:macos": {
+            "@LLDB_PROCESS_WINDOWS_PLUGIN@": "",
             "@LLDB_ENUM_PLUGINS@": _DEFAULT_LOAD_PLUGINS + """
 LLDB_PLUGIN(ProcessMacOSXKernel)
 LLDB_PLUGIN(SymbolLocatorDebugSymbols)
 LLDB_PLUGIN(SymbolVendorMacOSX)
 """,
         },
+        "@platforms//os:windows": {
+            "@LLDB_PROCESS_WINDOWS_PLUGIN@": "LLDB_PLUGIN(ProcessWindowsCommon)",
+            "@LLDB_ENUM_PLUGINS@": _WINDOWS_LOAD_PLUGINS,
+        },
         "//conditions:default": {
+            "@LLDB_PROCESS_WINDOWS_PLUGIN@": "",
             "@LLDB_ENUM_PLUGINS@": _DEFAULT_LOAD_PLUGINS,
         },
     }),

--- a/utils/bazel/llvm-project-overlay/lldb/source/Plugins/plugin_config.bzl
+++ b/utils/bazel/llvm-project-overlay/lldb/source/Plugins/plugin_config.bzl
@@ -100,6 +100,13 @@ DEFAULT_SCRIPT_PLUGINS = [
     "ScriptInterpreterNone",
 ]
 
+# Plugins excluded on Windows: GNUstep has source compat issues with
+# the current LLVM version, ScriptedProcess requires Python.
+WINDOWS_EXCLUDED_PLUGINS = [
+    "GNUstepObjCRuntime",
+    "ScriptedProcess",
+]
+
 OBJCPP_COPTS = [
     "-std=c++{}".format(CMAKE_CXX_STANDARD),
     "-fno-objc-exceptions",


### PR DESCRIPTION
  This adds Windows platform support to the LLDB Bazel overlay, enabling LLDB to be cross-compiled for
  Windows. The LLVM Bazel overlay already has Windows support (22 @platforms//os:windows references), but the
  LLDB overlay had essentially none.  Meta uses the bazel overlays as source for BUCK translation to build internally with buck2.  Windows lldb has only ever been built with custom cmake internally, but never with buck2

  All changes mirror what the cmake build already does for Windows — no new functionality, just making the
  Bazel build match cmake's platform handling.

  Summary of changes

  Config header (lldb/BUILD.bazel): Added @platforms//os:windows branch to the ConfigHeader expand_template
  substitutions. Moved HAVE_PTSNAME_R, LLDB_ENABLE_TERMIOS, and LLDB_ENABLE_POSIX from the common section into
  per-platform select() since they're 0 on Windows. All Windows values match cmake output.

  Host target (lldb/BUILD.bazel): Added Windows branches to srcs, hdrs, and linkopts:
  - Sources: source/Host/windows/**/*.cpp + source/Host/posix/ConnectionFileDescriptorPosix.cpp (compiled on
  all platforms per cmake's add_host_subdirectory(posix ...))
  - Headers: include/lldb/Host/windows/*.h, windows/**/*.h, posix/*.h (needed because
  ConnectionFileDescriptor.h unconditionally includes the posix variant)
  - Linkopts: rpcrt4.lib, version.lib, dbghelp.lib, pathcch.lib 

  Plugins (lldb/source/Plugins/):
  - New PluginProcessWindowsCommon target for Process/Windows/Common/*.cpp
  - WINDOWS_EXCLUDED_PLUGINS list in plugin_config.bzl for plugins that can't compile on Windows
  (GNUstepObjCRuntime, ScriptedProcess)
  - Windows-filtered Plugins.def generation with ProcessWindowsCommon registered

  Initialization, API, driver (lldb/BUILD.bazel):
  - Initialization: Platform-aware deps — PluginProcessPOSIX on non-Windows, PluginProcessWindowsCommon on
  Windows
  - API: LLDB_IN_LIBLLDB define on Windows to prevent __declspec(dllimport) annotations when building
  statically
  - Plugin deps: Windows-filtered list excluding incompatible plugins
  - lldb binary: Direct :Host dep on Windows for SetupPythonRuntimeLibrary (not exported from shared liblldb)

  What's not included

  - Python scripting support (disabled on Windows, ScriptInterpreterNone only)
  - No C++ source changes — all changes are in BUILD.bazel and plugin_config.bzl

  Testing

  Cross-compiled from Linux using Meta's Buck2 build system with @mode/opt-win (which uses these same Bazel
  overlay files via a translator). Produces a working lldb.exe (PE32+ x86-64).

Claude greatly helped to work backwards in this case from working BUCK files to the pre-translated bazel files