### PR TITLE
[MLIR][ODS] Do not emit code when printing empty lists in Type/Attr assembly printer (NFC)

### DIFF
--- a/mlir/tools/mlir-tblgen/AttrOrTypeFormatGen.cpp
+++ b/mlir/tools/mlir-tblgen/AttrOrTypeFormatGen.cpp
@@ -897,29 +897,31 @@ void DefFormat::genCommaSeparatedPrinter(
   }
 
   // The first printed element does not need to emit a comma.
-  os << "{\n";
-  os.indent() << "bool _firstPrinted = true;\n";
-  for (FormatElement *arg : args) {
-    ParameterElement *param = getEncapsulatedParameterElement(arg);
-    if (param->isOptional()) {
-      param->genPrintGuard(ctx, os << "if (") << ") {\n";
-      os.indent();
+  if (!args.empty()) {
+    os << "{\n";
+    os.indent() << "bool _firstPrinted = true;\n";
+    for (FormatElement *arg : args) {
+      ParameterElement *param = getEncapsulatedParameterElement(arg);
+      if (param->isOptional()) {
+        param->genPrintGuard(ctx, os << "if (") << ") {\n";
+        os.indent();
+      }
+      os << tgfmt("if (!_firstPrinted) $_printer << \", \";\n", &ctx);
+      os << "_firstPrinted = false;\n";
+      extra(arg);
+      shouldEmitSpace = false;
+      lastWasPunctuation = true;
+      if (auto *realParam = dyn_cast<ParameterElement>(arg))
+        genVariablePrinter(realParam, ctx, os);
+      else if (auto *custom = dyn_cast<CustomDirective>(arg))
+        genCustomPrinter(custom, ctx, os);
+      if (extraPost)
+        extraPost(arg);
+      if (param->isOptional())
+        os.unindent() << "}\n";
     }
-    os << tgfmt("if (!_firstPrinted) $_printer << \", \";\n", &ctx);
-    os << "_firstPrinted = false;\n";
-    extra(arg);
-    shouldEmitSpace = false;
-    lastWasPunctuation = true;
-    if (auto *realParam = dyn_cast<ParameterElement>(arg))
-      genVariablePrinter(realParam, ctx, os);
-    else if (auto *custom = dyn_cast<CustomDirective>(arg))
-      genCustomPrinter(custom, ctx, os);
-    if (extraPost)
-      extraPost(arg);
-    if (param->isOptional())
-      os.unindent() << "}\n";
+    os.unindent() << "}\n";
   }
-  os.unindent() << "}\n";
 }
 
 void DefFormat::genParamsPrinter(ParamsDirective *el, FmtContext &ctx,


### PR DESCRIPTION
In TableGen's code generator, `DefFormat::genCommaSeparatedPrinter` can emit code like
```
void FooType::print(::mlir::AsmPrinter &odsPrinter) const {
  ::mlir::Builder odsBuilder(getContext());
  odsPrinter << "<";
  {
    bool _firstPrinted = true;
  }
  odsPrinter << ">";
}
```

This results in unused variable warnings for `_firstPrinted` when compiling the table-gen'd code:
```
warning: unused variable '_firstPrinted' [-Wunused-variable]
  158 |     bool _firstPrinted = true;
```

The solution to this is to not emit the `{ bool _firstPrinted = true; }` block when list being printed is empty. This PR adds a guard around the code that emits the  `{ bool _firstPrinted = true; }`: it is now only emitted if there are arguments to print. In this case, additional code is emitted which uses `_firstPrinted`.
  