### PR TITLE
Implement reportsOriginalInstructions GDB remote feature

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -2332,6 +2332,12 @@ public:
 
   Status ClearBreakpointSiteByID(lldb::user_id_t break_id);
 
+  /// Check if this process reports the original opcodes when memory is read
+  /// around a breakpoint site. Some debuggers/stubs can provide the original
+  /// instruction bytes that were replaced by the breakpoint trap. If false,
+  /// LLDB will attempt to perform the opcode substitution itself.
+  virtual bool ReportsOriginalOpcodes() const { return false; }
+
   lldb::break_id_t CreateBreakpointSite(const lldb::BreakpointLocationSP &owner,
                                         bool use_hardware);
 

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -444,6 +444,8 @@ void GDBRemoteCommunicationClient::GetRemoteQSupported() {
         m_supports_multi_mem_read = eLazyBoolYes;
       else if (x == "jMultiBreakpoint+")
         m_supports_multi_breakpoint = eLazyBoolYes;
+      else if (x == "reportsOriginalInstructions+")
+        m_supports_reportingOriginalInsts = eLazyBoolYes;
       // Look for a list of compressions in the features list e.g.
       // qXfer:features:read+;PacketSize=20000;qEcho+;SupportedCompressions=zlib-
       // deflate,lzma
@@ -685,6 +687,13 @@ bool GDBRemoteCommunicationClient::GetMemoryTaggingSupported() {
     GetRemoteQSupported();
   }
   return m_supports_memory_tagging == eLazyBoolYes;
+}
+
+bool GDBRemoteCommunicationClient::GetReportsOriginalInstructions() const {
+  if (m_supports_reportingOriginalInsts == eLazyBoolCalculate) {
+    GetRemoteQSupported();
+  }
+  return m_supports_reportingOriginalInsts == eLazyBoolYes;
 }
 
 DataBufferSP GDBRemoteCommunicationClient::ReadMemoryTags(lldb::addr_t addr,

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.h
@@ -449,6 +449,8 @@ public:
 
   bool GetMemoryTaggingSupported();
 
+  bool GetReportsOriginalInstructions() const;
+
   bool UsesNativeSignals();
 
   lldb::DataBufferSP ReadMemoryTags(lldb::addr_t addr, size_t len,
@@ -582,6 +584,7 @@ protected:
   LazyBool m_supports_reverse_step = eLazyBoolCalculate;
   LazyBool m_supports_multi_mem_read = eLazyBoolCalculate;
   LazyBool m_supports_multi_breakpoint = eLazyBoolCalculate;
+  LazyBool m_supports_reportingOriginalInsts = eLazyBoolNo;
 
   bool m_supports_qProcessInfoPID : 1, m_supports_qfProcessInfo : 1,
       m_supports_qUserName : 1, m_supports_qGroupName : 1,
@@ -591,8 +594,7 @@ protected:
       m_supports_qSymbol : 1, m_qSymbol_requests_done : 1,
       m_supports_qModuleInfo : 1, m_supports_jThreadsInfo : 1,
       m_supports_jModulesInfo : 1, m_supports_vFileSize : 1,
-      m_supports_vFileMode : 1, m_supports_vFileExists : 1,
-      m_supports_vRun : 1;
+      m_supports_vFileMode : 1, m_supports_vFileExists : 1, m_supports_vRun : 1;
 
   /// Current gdb remote protocol process identifier for all other operations
   lldb::pid_t m_curr_pid = LLDB_INVALID_PROCESS_ID;

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerCommon.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerCommon.cpp
@@ -1386,5 +1386,6 @@ std::vector<std::string> GDBRemoteCommunicationServerCommon::HandleFeatures(
       "QStartNoAckMode+",
       "qEcho+",
       "native-signals+",
+      "reportsOriginalInstructions+",
   };
 }

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -2794,6 +2794,10 @@ void ProcessGDBRemote::WillPublicStop() {
   }
 }
 
+bool ProcessGDBRemote::ReportsOriginalOpcodes() const {
+  return m_gdb_comm.GetReportsOriginalInstructions();
+}
+
 // Process Memory
 size_t ProcessGDBRemote::DoReadMemory(addr_t addr, void *buf, size_t size,
                                       Status &error) {

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
@@ -484,6 +484,8 @@ private:
   void HandleStopReply() override;
   void HandleAsyncStructuredDataPacket(llvm::StringRef data) override;
 
+  bool ReportsOriginalOpcodes() const override;
+
   lldb::ThreadSP
   HandleThreadAsyncInterrupt(uint8_t signo,
                              const std::string &description) override;

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1820,7 +1820,9 @@ size_t Process::RemoveBreakpointOpcodesFromBuffer(addr_t bp_addr, size_t size,
                                          bp_sites_in_range)) {
     bp_sites_in_range.ForEach([bp_addr, size,
                                buf](BreakpointSite *bp_site) -> void {
-      if (bp_site->GetType() == BreakpointSite::eSoftware) {
+      if (bp_site->GetType() == BreakpointSite::eSoftware ||
+          (bp_site->GetType() == BreakpointSite::eExternal &&
+           !ReportsOriginalOpcodes())) {
         addr_t intersect_addr;
         size_t intersect_size;
         size_t opcode_offset;

--- a/lldb/tools/debugserver/source/RNBRemote.cpp
+++ b/lldb/tools/debugserver/source/RNBRemote.cpp
@@ -3703,7 +3703,7 @@ rnb_err_t RNBRemote::HandlePacket_qSupported(const char *p) {
   std::stringstream reply;
   reply << "qXfer:features:read+;PacketSize=" << std::hex << max_packet_size
         << ";";
-  reply << "qEcho+;native-signals+;";
+  reply << "qEcho+;native-signals+;reportsOriginalInstructions+;";
 
   bool enable_compression = false;
   (void)enable_compression;

--- a/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
+++ b/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationClientTest.cpp
@@ -751,3 +751,27 @@ TEST_F(GDBRemoteCommunicationClientTest, MultiBreakpointdNotSupported) {
   ASSERT_FALSE(client.GetMultiBreakpointSupported());
   async_result.wait();
 }
+
+TEST_F(GDBRemoteCommunicationClientTest, ReportsOriginalInstructions) {
+  std::future<void> async_result =
+      std::async(std::launch::async, [&] { client.GetRemoteQSupported(); });
+
+  HandlePacket(
+      server, testing::StartsWith("qSupported:"),
+      "reportsOriginalInstructions+;qXfer:memory-map:read+;PacketSize=4000");
+
+  async_result.get();
+  EXPECT_TRUE(client.GetReportsOriginalInstructions());
+}
+
+TEST_F(GDBRemoteCommunicationClientTest,
+       ReportsOriginalInstructionsUnsupported) {
+  std::future<void> async_result =
+      std::async(std::launch::async, [&] { client.GetRemoteQSupported(); });
+
+  HandlePacket(server, testing::StartsWith("qSupported:"),
+               "qXfer:memory-map:read+;PacketSize=4000");
+
+  async_result.get();
+  EXPECT_FALSE(client.GetReportsOriginalInstructions());
+}


### PR DESCRIPTION
Add support for the `reportsOriginalInstructions` GDB remote protocol feature. This allows debuggers to query whether the remote stub/target preserves the original instruction bytes when memory is read around a breakpoint site. Currently, when working with external GDB servers like openOCD LLDB leaves the substitution upto the servers even if the server doesn't do the substitution and we can see breakpoint trap codes in disassembly (https://github.com/llvm/llvm-project/issues/197564).