### PR TITLE
[NVPTX] Print the full value of e.g. an i65 global.

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -1735,8 +1735,11 @@ void NVPTXAsmPrinter::bufferAggregateConstant(const Constant *CPV,
   const DataLayout &DL = getDataLayout();
 
   auto ExtendBuffer = [](APInt Val, AggBuffer *Buffer) {
-    for (unsigned I : llvm::seq(Val.getBitWidth() / 8))
-      Buffer->addByte(Val.extractBitsAsZExtValue(8, I * 8));
+    unsigned NumBytes = divideCeil(Val.getBitWidth(), 8);
+    for (unsigned I : llvm::seq(NumBytes)) {
+      unsigned NumBits = std::min(8u, Val.getBitWidth() - I * 8);
+      Buffer->addByte(Val.extractBitsAsZExtValue(NumBits, I * 8));
+    }
   };
 
   // Integer or floating point vector splats.

--- a/llvm/test/CodeGen/NVPTX/globals_init.ll
+++ b/llvm/test/CodeGen/NVPTX/globals_init.ll
@@ -36,3 +36,11 @@
 
 ; CHECK-DAG: .b8 Gblv4f32[16] = {0, 0, 128, 63, 0, 0, 128, 63, 0, 0, 128, 63, 0, 0, 128, 63};
 @Gblv4f32 = global <4 x float> splat(float 1.0)
+
+; Large-integer globals whose bit width is not a multiple of 8 must emit
+; their full ceil(bitWidth/8) bytes, including the top partial byte.
+; CHECK-DAG: .b8 globalint_Gbli65[9] = {255, 255, 255, 255, 255, 255, 255, 255, 1};
+@globalint_Gbli65 = global i65 u0x1FFFFFFFFFFFFFFFF
+
+; CHECK-DAG: .b8 globalint_Gbli100[13] = {186, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 15};
+@globalint_Gbli100 = global i100 u0xF000000000000000000000ABA


### PR DESCRIPTION
If you have an integer global whose width is 64 and not a multiple of 8,
the NVPTX asm printer used to drop the top bits!
