### PR TITLE
[flang] Define array named constants from the iso_fortran_env intrins…

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -6526,7 +6526,8 @@ private:
       return;
     for (const auto &scope : intrinsicModuleScope->children()) {
       llvm::StringRef modName = toStringRef(scope.symbol()->name());
-      if (modName != "__fortran_ieee_exceptions")
+      if (modName != "__fortran_ieee_exceptions" &&
+          modName != "iso_fortran_env")
         continue;
       for (auto &var : Fortran::lower::pft::getScopeVariableList(scope)) {
         const Fortran::semantics::Symbol &sym = var.getSymbol();

--- a/flang/test/Lower/intrinsic-module-array-constant.f90
+++ b/flang/test/Lower/intrinsic-module-array-constant.f90
@@ -1,0 +1,19 @@
+! Regression test: array named constants declared directly in the intrinsic
+! iso_fortran_env module (e.g. character_kinds) must be emitted as a DEFINITION
+! with an initializer, not as a bodyless external declaration. Otherwise the
+! reference is undefined at link time.
+! See createIntrinsicModuleDefinitions in lib/Lower/Bridge.cpp.
+
+! RUN: bbc -emit-hlfir -o - %s | FileCheck %s
+
+subroutine test_character_kinds(i, r)
+  use iso_fortran_env, only: character_kinds
+  integer :: i, r
+  r = character_kinds(i)
+end subroutine
+
+! The global must be DEFINED (linkonce_odr linkage + a parenthesized
+! initializer), not a bodyless "fir.global @_QM...character_kinds ... constant"
+! external declaration.
+! CHECK:     fir.global linkonce_odr @_QMiso_fortran_envECcharacter_kinds({{.*}}) {{.*}}constant : !fir.array<{{[0-9]+}}xi32>
+! CHECK-NOT: fir.global @_QMiso_fortran_envECcharacter_kinds {{.*}}constant


### PR DESCRIPTION
…ic module

createIntrinsicModuleDefinitions() only emitted definitions for array named constants belonging to the __fortran_ieee_exceptions intrinsic module. Array constants declared directly in the iso_fortran_env intrinsic module -- in practice character_kinds -- were therefore only lowered as bodyless `fir.global` external declarations at their use site and never defined anywhere, producing an undefined reference at link time.

This is usually hidden because scalar iso_fortran_env parameters fold to immediates and constant-shape array accesses are folded away, so the dangling external symbol is DCE'd before linking. It surfaces when the address of the array genuinely escapes to runtime, e.g.:
```
    use iso_fortran_env
    integer :: i, x(1)
    do i = 1, size(character_kinds)
      x = findloc(character_kinds, character_kinds(i))
    end do
```
which fails with:

    undefined reference to `_QMiso_fortran_envECcharacter_kinds'

Fix by also processing the iso_fortran_env scope in createIntrinsicModuleDefinitions(), so its array constants are emitted as linkonce_odr definitions with initializers.

Note that integer_kinds/real_kinds/logical_kinds are unaffected: they are renamed from iso_fortran_env_impl, a non-intrinsic module that is compiled into the runtime, so their definitions already exist there.

Assisted-by: AI