### PR TITLE
[SLP] Scale extract cost of external uses with nullptr user

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -19960,14 +19960,26 @@ InstructionCost BoUpSLP::getTreeCost(InstructionCost TreeCost,
     // scalar instruction executes at its definition site's frequency.
     if (!ExternalUsesAsOriginalScalar.contains(EU.Scalar)) {
       if (ExtraCost.isValid() && ExtraCost != 0) {
-        BasicBlock *ExtractBB = ScalarToExtractBlock.lookup(EU.Scalar);
-        if (const Loop *L = ExtractBB ? LI->getLoopFor(ExtractBB) : nullptr) {
-          uint64_t Scale = getLoopNestScale(
-              findInnermostNonInvariantLoop(L, ArrayRef<Value *>(EU.Scalar)));
-          LLVM_DEBUG(dbgs()
-                     << "SLP: Extract scale " << Scale << " (NCD block) for "
-                     << EU.Scalar->getNameOrAsOperand() << "\n");
-          ExtraCost *= Scale;
+        if (!EU.User) {
+          // No external user instruction is recorded (User == nullptr): the
+          // scalar stays live in vectorized instructions or is used as an
+          // extra arg, and is not present in ScalarToExtractBlock (the
+          // pre-pass only records sites of real users). vectorizeTree() then
+          // places the extractelement right after the vectorized instruction
+          // (in the entry's block) and replaces the scalar uses with it, so
+          // scale by the entry block's execution frequency to match that
+          // placement.
+          ExtraCost = ScaleCost(ExtraCost, *Entry, EU.Scalar, /*U=*/nullptr);
+        } else {
+          BasicBlock *ExtractBB = ScalarToExtractBlock.lookup(EU.Scalar);
+          if (const Loop *L = ExtractBB ? LI->getLoopFor(ExtractBB) : nullptr) {
+            uint64_t Scale = getLoopNestScale(
+                findInnermostNonInvariantLoop(L, ArrayRef<Value *>(EU.Scalar)));
+            LLVM_DEBUG(dbgs()
+                       << "SLP: Extract scale " << Scale << " (NCD block) for "
+                       << EU.Scalar->getNameOrAsOperand() << "\n");
+            ExtraCost *= Scale;
+          }
         }
       }
     } else {

--- a/llvm/test/Transforms/SLPVectorizer/ARM/extract-cost-scale-nullptr-user.ll
+++ b/llvm/test/Transforms/SLPVectorizer/ARM/extract-cost-scale-nullptr-user.ll
@@ -7,9 +7,11 @@ define void @test(ptr %p) {
 ; CHECK-NEXT:  [[ENTRY:.*]]:
 ; CHECK-NEXT:    br label %[[LOOP:.*]]
 ; CHECK:       [[LOOP]]:
+; CHECK-NEXT:    [[I0:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[N0:%.*]], %[[LOOP]] ]
+; CHECK-NEXT:    [[TMP1:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[N1:%.*]], %[[LOOP]] ]
+; CHECK-NEXT:    [[I2:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[N2:%.*]], %[[LOOP]] ]
+; CHECK-NEXT:    [[I3:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[N3:%.*]], %[[LOOP]] ]
 ; CHECK-NEXT:    [[IV:%.*]] = phi i32 [ 0, %[[ENTRY]] ], [ [[NIV:%.*]], %[[LOOP]] ]
-; CHECK-NEXT:    [[TMP0:%.*]] = phi <4 x i32> [ zeroinitializer, %[[ENTRY]] ], [ [[TMP2:%.*]], %[[LOOP]] ]
-; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <4 x i32> [[TMP0]], i32 3
 ; CHECK-NEXT:    [[A0:%.*]] = getelementptr i8, ptr [[P]], i32 [[TMP1]]
 ; CHECK-NEXT:    store i8 0, ptr [[A0]], align 1
 ; CHECK-NEXT:    [[A1:%.*]] = getelementptr i8, ptr [[P]], i32 [[TMP1]]
@@ -26,7 +28,10 @@ define void @test(ptr %p) {
 ; CHECK-NEXT:    store i8 6, ptr [[A6]], align 1
 ; CHECK-NEXT:    [[A7:%.*]] = getelementptr i8, ptr [[P]], i32 [[TMP1]]
 ; CHECK-NEXT:    store i8 7, ptr [[A7]], align 1
-; CHECK-NEXT:    [[TMP2]] = add nuw nsw <4 x i32> [[TMP0]], <i32 32, i32 32, i32 32, i32 16>
+; CHECK-NEXT:    [[N0]] = add nuw nsw i32 [[I0]], 32
+; CHECK-NEXT:    [[N1]] = add nuw nsw i32 [[TMP1]], 16
+; CHECK-NEXT:    [[N2]] = add nuw nsw i32 [[I2]], 32
+; CHECK-NEXT:    [[N3]] = add nuw nsw i32 [[I3]], 32
 ; CHECK-NEXT:    [[NIV]] = add nuw nsw i32 [[IV]], 16
 ; CHECK-NEXT:    [[C:%.*]] = icmp eq i32 [[NIV]], 512
 ; CHECK-NEXT:    br i1 [[C]], label %[[EXIT:.*]], label %[[LOOP]]


### PR DESCRIPTION
The NCD pre-pass from #199962 only records extract blocks for external
uses that have a real user, so uses with a nullptr user were left
unscaled, making the loop in the report look profitable and get wrongly
vectorized. For a nullptr user vectorizeTree() places the extract right
after the vectorized instruction (entry block) and RAUWs the scalar, so
scale those extracts by the entry block frequency, restoring the
pre-#199962 behavior for that case.
