### PR TITLE
[SystemZ][GOFF] Implement reset() for GOFFObjectWriter

### DIFF
--- a/llvm/include/llvm/MC/MCGOFFObjectWriter.h
+++ b/llvm/include/llvm/MC/MCGOFFObjectWriter.h
@@ -91,6 +91,8 @@ public:
                    raw_pwrite_stream &OS);
   ~GOFFObjectWriter() override;
 
+  void reset() override;
+
   void setRootSD(MCSectionGOFF *RootSD) { this->RootSD = RootSD; }
 
   // Implementation of the MCObjectWriter interface.

--- a/llvm/lib/MC/GOFFObjectWriter.cpp
+++ b/llvm/lib/MC/GOFFObjectWriter.cpp
@@ -15,6 +15,7 @@
 #include "llvm/MC/MCAssembler.h"
 #include "llvm/MC/MCGOFFAttributes.h"
 #include "llvm/MC/MCGOFFObjectWriter.h"
+#include "llvm/MC/MCObjectWriter.h"
 #include "llvm/MC/MCSectionGOFF.h"
 #include "llvm/MC/MCSymbolGOFF.h"
 #include "llvm/MC/MCValue.h"
@@ -687,6 +688,12 @@ GOFFObjectWriter::GOFFObjectWriter(
     : TargetObjectWriter(std::move(MOTW)), OS(OS) {}
 
 GOFFObjectWriter::~GOFFObjectWriter() = default;
+
+void GOFFObjectWriter::reset() {
+  Relocations.clear();
+  RootSD = nullptr;
+  MCObjectWriter::reset();
+}
 
 void GOFFObjectWriter::recordRelocation(const MCFragment &F,
                                         const MCFixup &Fixup, MCValue Target,


### PR DESCRIPTION
The reset() methods is used to free memory before the object is destructed or reused. This change adds this functionality to the GOFF writer.