### PR TITLE
[SPIR-V] Avoid typed pointers for global variables

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -818,6 +818,8 @@ Register SPIRVGlobalRegistry::buildGlobalVariable(
     GVar = M->getGlobalVariable(Name);
     if (GVar == nullptr) {
       const Type *Ty = getTypeForSPIRVType(BaseType); // TODO: check type.
+      if (auto *TPTy = dyn_cast<TypedPointerType>(Ty))
+        Ty = PointerType::get(M->getContext(), TPTy->getAddressSpace());
       // Module takes ownership of the global var.
       GVar = new GlobalVariable(*M, const_cast<Type *>(Ty), false,
                                 GlobalValue::ExternalLinkage, nullptr,

--- a/llvm/test/CodeGen/SPIRV/pointers/global-vars-untyped.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/global-vars-untyped.ll
@@ -1,0 +1,14 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -stop-after=irtranslator -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK: @__spirv_BuiltInLocalInvocationId = external addrspace(1) global ptr addrspace
+; CHECK: define spir_kernel void @func
+; CHECK-SAME: ptr addrspace(1) %{{.*}}
+
+define spir_kernel void @func(ptr addrspace(1) %arg) {
+entry:
+  %x = call spir_func i64 @_Z12get_local_idj(i32 0)
+  ret void
+}
+
+declare spir_func i64 @_Z12get_local_idj(i32)


### PR DESCRIPTION
This PR replaces typed pointers with opaque pointers for global variable types. Since typed pointers are legal in SPIR-V, the type retrieved when creating a global variable may be a typed pointer, causing it to leak into the module. This will break the bitcode parsing of the serialized module. 