### PR TITLE
[lldb][test] Make delayed-definition-die-searching CU-layout agnostic

### DIFF
--- a/lldb/test/Shell/SymbolFile/DWARF/delayed-definition-die-searching.test
+++ b/lldb/test/Shell/SymbolFile/DWARF/delayed-definition-die-searching.test
@@ -12,8 +12,8 @@
 # CHECK: DW_TAG_structure_type (DW_TAG_structure_type) 't2<t1>' resolving forward declaration...
 # CHECK: (t2<t1>)  {}
 # CHECK: (lldb) p v2
-# CHECK: DWARFASTParserClang::ParseTypeFromDWARF{{.*}}DW_TAG_structure_type (DW_TAG_structure_type) name = 't1'
 # CHECK: DW_TAG_structure_type (DW_TAG_structure_type) 't1' resolving forward declaration...
+# CHECK: (t1)  (x = 0)
 
 #--- lldb.cmd
 log enable dwarf comp


### PR DESCRIPTION
The second `ParseTypeFromDWARF` for t1 (after `p v2`) only fires when t1's definition lives in a separate CU from its forward declaration: LLDB parses the forward-decl DIE during `p v1` and a distinct definition DIE during `p v2`. dsymutil's parallel linker collapses both into a single DIE in the artificial type unit, so t1 is parsed once during `p v1` and only re-resolved during `p v2`.

Drop the second-parse CHECK so the test no longer presumes a per-CU type layout. The remaining `'t1' resolving forward declaration...` CHECK after `p v2` still verifies what the test was designed to catch: t1's complete-type resolution is deferred until v2 is evaluated. If LLDB regressed to eager resolution during `p v1`, that log line would move and the test would fail. Add a `(t1) (x = 0)` CHECK at the end to cover the end-to-end value.