### PR TITLE
[ORC] Make SimpleExecutorDylibManager::resolve an instance method.

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
@@ -86,7 +86,8 @@ using SPSSimpleExecutorDylibManagerOpenSignature =
 
 using SPSSimpleExecutorDylibManagerResolveSignature = shared::SPSExpected<
     shared::SPSSequence<shared::SPSOptional<shared::SPSExecutorSymbolDef>>>(
-    shared::SPSExecutorAddr, shared::SPSRemoteSymbolLookupSet);
+    shared::SPSExecutorAddr, shared::SPSExecutorAddr,
+    shared::SPSRemoteSymbolLookupSet);
 
 using SPSSimpleExecutorMemoryManagerReserveSignature =
     shared::SPSExpected<shared::SPSExecutorAddr>(shared::SPSExecutorAddr,

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.h
@@ -41,6 +41,9 @@ public:
 
   Expected<tpctypes::DylibHandle> open(const std::string &Path, uint64_t Mode);
 
+  ExecutorResolver::ResolveResult resolve(ExecutorAddr Resolver,
+                                          RemoteSymbolLookupSet Lookup);
+
   Error shutdown() override;
   void addBootstrapSymbols(StringMap<ExecutorAddr> &M) override;
 

--- a/llvm/lib/ExecutionEngine/Orc/EPCGenericDylibManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/EPCGenericDylibManager.cpp
@@ -79,7 +79,7 @@ void EPCGenericDylibManager::lookupAsync(tpctypes::DylibHandle H,
         }
         Complete(std::move(Result));
       },
-      H, Lookup);
+      SAs.Instance, H, Lookup);
 }
 
 void EPCGenericDylibManager::lookupAsync(tpctypes::DylibHandle H,
@@ -98,7 +98,7 @@ void EPCGenericDylibManager::lookupAsync(tpctypes::DylibHandle H,
         }
         Complete(std::move(Result));
       },
-      H, Lookup);
+      SAs.Instance, H, Lookup);
 }
 
 Expected<tpctypes::DylibHandle>

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.cpp
@@ -44,6 +44,18 @@ SimpleExecutorDylibManager::open(const std::string &Path, uint64_t Mode) {
   return ExecutorAddr::fromPtr(Resolvers.back().get());
 }
 
+ExecutorResolver::ResolveResult
+SimpleExecutorDylibManager::resolve(ExecutorAddr Resolver,
+                                    RemoteSymbolLookupSet Lookup) {
+  using TmpResult =
+      MSVCPExpected<std::vector<std::optional<ExecutorSymbolDef>>>;
+  std::promise<TmpResult> P;
+  auto F = P.get_future();
+  Resolver.toPtr<ExecutorResolver *>()->resolveAsync(
+      std::move(Lookup), [&](TmpResult R) { P.set_value(std::move(R)); });
+  return F.get();
+}
+
 Error SimpleExecutorDylibManager::shutdown() {
 
   DylibSet DS;
@@ -78,20 +90,11 @@ SimpleExecutorDylibManager::openWrapper(const char *ArgData, size_t ArgSize) {
 llvm::orc::shared::CWrapperFunctionBuffer
 SimpleExecutorDylibManager::resolveWrapper(const char *ArgData,
                                            size_t ArgSize) {
-  using ResolveResult = ExecutorResolver::ResolveResult;
   return shared::WrapperFunction<
              rt::SPSSimpleExecutorDylibManagerResolveSignature>::
       handle(ArgData, ArgSize,
-             [](ExecutorAddr Obj, RemoteSymbolLookupSet L) -> ResolveResult {
-               using TmpResult =
-                   MSVCPExpected<std::vector<std::optional<ExecutorSymbolDef>>>;
-               std::promise<TmpResult> P;
-               auto F = P.get_future();
-               Obj.toPtr<ExecutorResolver *>()->resolveAsync(
-                   std::move(L),
-                   [&](TmpResult R) { P.set_value(std::move(R)); });
-               return F.get();
-             })
+             shared::makeMethodWrapperHandler(
+                 &SimpleExecutorDylibManager::resolve))
           .release();
 }
 


### PR DESCRIPTION
Promote the lambdas inside resolveWrapper to a public method on SimpleExecutorDylibManager. This brings SimpleExecutorDylibManager into better alignment with the NativeDylibManager implementation in the new ORC runtime, and is a step towards allowing NativeDylibManager to be used as a drop-in replacement for SimpleExecutorDylibManager.