### PR TITLE
[DWARFLinker] Emit .debug_names entries for type-unit DIEs in parallel linker

### DIFF
--- a/llvm/lib/DWARFLinker/Parallel/AcceleratorRecordsSaver.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/AcceleratorRecordsSaver.cpp
@@ -140,15 +140,16 @@ void AcceleratorRecordsSaver::save(const DWARFDebugInfoEntry *InputDieEntry,
     // Nothing to do.
   } break;
   default:
-    if (TypeEntry)
-      // Do not store this kind of accelerator entries for type entries.
-      return;
+    // HasLiveAddress / HasRanges below decides whether a DIE carries enough
+    // information of its own to warrant a name record; the output unit is
+    // incidental and routed by the helpers.
 
     if (AttrInfo.HasLiveAddress || AttrInfo.HasRanges) {
       if (AttrInfo.Name)
         saveNameRecord(
             InputDieEntry, AttrInfo.Name, OutDIE, InputDieEntry->getTag(),
-            InputDieEntry->getTag() == dwarf::DW_TAG_inlined_subroutine);
+            InputDieEntry->getTag() == dwarf::DW_TAG_inlined_subroutine,
+            TypeEntry);
 
       // Look for mangled name recursively if mangled name is not known yet.
       if (!AttrInfo.MangledName)
@@ -160,7 +161,8 @@ void AcceleratorRecordsSaver::save(const DWARFDebugInfoEntry *InputDieEntry,
         saveNameRecord(InputDieEntry, AttrInfo.MangledName, OutDIE,
                        InputDieEntry->getTag(),
                        InputDieEntry->getTag() ==
-                           dwarf::DW_TAG_inlined_subroutine);
+                           dwarf::DW_TAG_inlined_subroutine,
+                       TypeEntry);
 
       // Strip template parameters from the short name.
       if (AttrInfo.Name && AttrInfo.MangledName != AttrInfo.Name &&
@@ -171,19 +173,20 @@ void AcceleratorRecordsSaver::save(const DWARFDebugInfoEntry *InputDieEntry,
               GlobalData.getStringPool().insert(*Name).first;
 
           saveNameRecord(InputDieEntry, NameWithoutTemplateParams, OutDIE,
-                         InputDieEntry->getTag(), true);
+                         InputDieEntry->getTag(), true, TypeEntry);
         }
       }
 
       if (AttrInfo.Name)
-        saveObjC(InputDieEntry, OutDIE, AttrInfo);
+        saveObjC(InputDieEntry, OutDIE, AttrInfo, TypeEntry);
     }
     break;
   }
 }
 
 void AcceleratorRecordsSaver::saveObjC(const DWARFDebugInfoEntry *InputDieEntry,
-                                       DIE *OutDIE, AttributesInfo &AttrInfo) {
+                                       DIE *OutDIE, AttributesInfo &AttrInfo,
+                                       TypeEntry *TypeEntry) {
   std::optional<ObjCSelectorNames> Names =
       getObjCNamesIfSelector(AttrInfo.Name->getKey());
   if (!Names)
@@ -191,22 +194,23 @@ void AcceleratorRecordsSaver::saveObjC(const DWARFDebugInfoEntry *InputDieEntry,
 
   StringEntry *Selector =
       GlobalData.getStringPool().insert(Names->Selector).first;
-  saveNameRecord(InputDieEntry, Selector, OutDIE, InputDieEntry->getTag(),
-                 true);
+  saveNameRecord(InputDieEntry, Selector, OutDIE, InputDieEntry->getTag(), true,
+                 TypeEntry);
   StringEntry *ClassName =
       GlobalData.getStringPool().insert(Names->ClassName).first;
-  saveObjCNameRecord(InputDieEntry, ClassName, OutDIE, InputDieEntry->getTag());
+  saveObjCNameRecord(InputDieEntry, ClassName, OutDIE, InputDieEntry->getTag(),
+                     TypeEntry);
   if (Names->ClassNameNoCategory) {
     StringEntry *ClassNameNoCategory =
         GlobalData.getStringPool().insert(*Names->ClassNameNoCategory).first;
     saveObjCNameRecord(InputDieEntry, ClassNameNoCategory, OutDIE,
-                       InputDieEntry->getTag());
+                       InputDieEntry->getTag(), TypeEntry);
   }
   if (Names->MethodNameNoCategory) {
     StringEntry *MethodNameNoCategory =
         GlobalData.getStringPool().insert(*Names->MethodNameNoCategory).first;
     saveNameRecord(InputDieEntry, MethodNameNoCategory, OutDIE,
-                   InputDieEntry->getTag(), true);
+                   InputDieEntry->getTag(), true, TypeEntry);
   }
 }
 
@@ -234,17 +238,36 @@ std::optional<uint64_t> AcceleratorRecordsSaver::getDefiningParentOutOffset(
 
 void AcceleratorRecordsSaver::saveNameRecord(
     const DWARFDebugInfoEntry *InputDieEntry, StringEntry *Name, DIE *OutDIE,
-    dwarf::Tag Tag, bool AvoidForPubSections) {
-  DwarfUnit::AccelInfo Info;
+    dwarf::Tag Tag, bool AvoidForPubSections, TypeEntry *TypeEntry) {
+  if (OutUnit.isCompileUnit()) {
+    assert(TypeEntry == nullptr);
+    DwarfUnit::AccelInfo Info;
 
+    Info.Type = DwarfUnit::AccelType::Name;
+    Info.String = Name;
+    Info.OutOffset = OutDIE->getOffset();
+    Info.ParentOffset = getDefiningParentOutOffset(InputDieEntry);
+    Info.Tag = Tag;
+    Info.AvoidForPubSections = AvoidForPubSections;
+
+    OutUnit.getAsCompileUnit()->saveAcceleratorInfo(Info);
+    return;
+  }
+
+  // TODO: compute DW_IDX_parent for entries emitted into the artificial type
+  // unit (see saveNamespaceRecord).
+
+  assert(TypeEntry != nullptr);
+  TypeUnit::TypeUnitAccelInfo Info;
   Info.Type = DwarfUnit::AccelType::Name;
   Info.String = Name;
-  Info.OutOffset = OutDIE->getOffset();
-  Info.ParentOffset = getDefiningParentOutOffset(InputDieEntry);
+  Info.OutOffset = 0xbaddef;
   Info.Tag = Tag;
   Info.AvoidForPubSections = AvoidForPubSections;
+  Info.OutDIE = OutDIE;
+  Info.TypeEntryBodyPtr = TypeEntry->getValue().load();
 
-  OutUnit.getAsCompileUnit()->saveAcceleratorInfo(Info);
+  OutUnit.getAsTypeUnit()->saveAcceleratorInfo(Info);
 }
 void AcceleratorRecordsSaver::saveNamespaceRecord(
     const DWARFDebugInfoEntry *InputDieEntry, StringEntry *Name, DIE *OutDIE,
@@ -281,17 +304,36 @@ void AcceleratorRecordsSaver::saveNamespaceRecord(
 
 void AcceleratorRecordsSaver::saveObjCNameRecord(
     const DWARFDebugInfoEntry *InputDieEntry, StringEntry *Name, DIE *OutDIE,
-    dwarf::Tag Tag) {
-  DwarfUnit::AccelInfo Info;
+    dwarf::Tag Tag, TypeEntry *TypeEntry) {
+  if (OutUnit.isCompileUnit()) {
+    assert(TypeEntry == nullptr);
+    DwarfUnit::AccelInfo Info;
 
+    Info.Type = DwarfUnit::AccelType::ObjC;
+    Info.String = Name;
+    Info.OutOffset = OutDIE->getOffset();
+    Info.ParentOffset = getDefiningParentOutOffset(InputDieEntry);
+    Info.Tag = Tag;
+    Info.AvoidForPubSections = true;
+
+    OutUnit.getAsCompileUnit()->saveAcceleratorInfo(Info);
+    return;
+  }
+
+  // TODO: compute DW_IDX_parent for entries emitted into the artificial type
+  // unit (see saveNamespaceRecord).
+
+  assert(TypeEntry != nullptr);
+  TypeUnit::TypeUnitAccelInfo Info;
   Info.Type = DwarfUnit::AccelType::ObjC;
   Info.String = Name;
-  Info.OutOffset = OutDIE->getOffset();
-  Info.ParentOffset = getDefiningParentOutOffset(InputDieEntry);
+  Info.OutOffset = 0xbaddef;
   Info.Tag = Tag;
   Info.AvoidForPubSections = true;
+  Info.OutDIE = OutDIE;
+  Info.TypeEntryBodyPtr = TypeEntry->getValue().load();
 
-  OutUnit.getAsCompileUnit()->saveAcceleratorInfo(Info);
+  OutUnit.getAsTypeUnit()->saveAcceleratorInfo(Info);
 }
 
 void AcceleratorRecordsSaver::saveTypeRecord(

--- a/llvm/lib/DWARFLinker/Parallel/AcceleratorRecordsSaver.h
+++ b/llvm/lib/DWARFLinker/Parallel/AcceleratorRecordsSaver.h
@@ -44,16 +44,17 @@ protected:
       : GlobalData(GlobalData), InUnit(InUnit), OutUnit(OutUnit) {}
 
   void saveObjC(const DWARFDebugInfoEntry *InputDieEntry, DIE *OutDIE,
-                AttributesInfo &AttrInfo);
+                AttributesInfo &AttrInfo, TypeEntry *TypeEntry);
 
   void saveNameRecord(const DWARFDebugInfoEntry *InputDieEntry,
                       StringEntry *Name, DIE *OutDIE, dwarf::Tag Tag,
-                      bool AvoidForPubSections);
+                      bool AvoidForPubSections, TypeEntry *TypeEntry);
   void saveNamespaceRecord(const DWARFDebugInfoEntry *InputDieEntry,
                            StringEntry *Name, DIE *OutDIE, dwarf::Tag Tag,
                            TypeEntry *TypeEntry);
   void saveObjCNameRecord(const DWARFDebugInfoEntry *InputDieEntry,
-                          StringEntry *Name, DIE *OutDIE, dwarf::Tag Tag);
+                          StringEntry *Name, DIE *OutDIE, dwarf::Tag Tag,
+                          TypeEntry *TypeEntry);
   void saveTypeRecord(const DWARFDebugInfoEntry *InputDieEntry,
                       StringEntry *Name, DIE *OutDIE, dwarf::Tag Tag,
                       uint32_t QualifiedNameHash, bool ObjcClassImplementation,

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/debug-names-static-member-decl.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/debug-names-static-member-decl.test
@@ -1,0 +1,47 @@
+## DIEs cloned into the artificial type unit must still produce .debug_names
+## entries when they carry enough information to be addressable on their own
+## (e.g. via DW_AT_const_value).
+##
+## Inputs are shared with odr-static-member-decl.test:
+##   struct S { const static int x = 42; int y; };
+##   a.cpp uses S; b.cpp also defines `const int S::x;` out-of-class.
+
+# RUN: dsymutil --linker=parallel -accelerator=Dwarf -f -o %t.parallel.out \
+# RUN:   -oso-prepend-path=%p/../../Inputs -y %s
+# RUN: llvm-dwarfdump --debug-names %t.parallel.out | \
+# RUN:   FileCheck %s --check-prefix=PARALLEL
+
+# RUN: dsymutil --linker=classic -accelerator=Dwarf -f -o %t.classic.out \
+# RUN:   -oso-prepend-path=%p/../../Inputs -y %s
+# RUN: llvm-dwarfdump --debug-names %t.classic.out | \
+# RUN:   FileCheck %s --check-prefix=CLASSIC
+
+---
+triple: 'x86_64-apple-darwin'
+objects:
+  - filename: 'odr-static-member-decl/a.o'
+    timestamp: 0
+    symbols:
+      - { sym: __Z4useAP1S, objAddr: 0x0, binAddr: 0x100000000, size: 0x20 }
+  - filename: 'odr-static-member-decl/b.o'
+    timestamp: 0
+    symbols:
+      - { sym: __Z4useBP1S, objAddr: 0x0, binAddr: 0x100000100, size: 0x20 }
+      - { sym: __ZN1S1xE,   objAddr: 0x14, binAddr: 0x100000200, size: 0x4 }
+...
+
+## Both regular-CU and type-unit emissions for "x" must appear.
+# PARALLEL:      String: {{.*}} "x"
+# PARALLEL-NEXT: Entry
+# PARALLEL:        Tag: DW_TAG_variable
+# PARALLEL-NOT:    DW_IDX_compile_unit: 0x00
+# PARALLEL:      Entry
+# PARALLEL:        Tag: DW_TAG_variable
+# PARALLEL:        DW_IDX_compile_unit: 0x00
+
+## Classic regression check; layout differs but coverage matches.
+# CLASSIC:      String: {{.*}} "x"
+# CLASSIC-NEXT: Entry
+# CLASSIC:        Tag: DW_TAG_variable
+# CLASSIC:      Entry
+# CLASSIC:        Tag: DW_TAG_variable


### PR DESCRIPTION
The default tag arm of AcceleratorRecordsSaver::save returned early when a DIE was cloned into the artificial type unit, so class-static const data members (DW_AT_const_value, no out-of-class definition) never got an accelerator entry. As a result `target var A::int_val` in LLDB then found nothing.

The HasLiveAddress / HasRanges guard already decides whether a DIE carries enough information of its own to warrant a name record; the output unit is just doing the routing. Drop the early return and thread the TypeEntry through saveNameRecord / saveObjCNameRecord / saveObjC so they emit into the type-unit accel storage when appropriate, the same way saveTypeRecord and saveNamespaceRecord already do.