### PR TITLE
[CIR] Terminate switch scope after case cleanup

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -269,6 +269,18 @@ void CIRGenFunction::LexicalScope::cleanup() {
     forceCleanup();
   }
 
+  // A switch case that declares a variable with a non-trivial destructor
+  // extends that variable's lifetime to the end of the switch body, so its
+  // cleanup is owned by the switch's lexical scope rather than by a nested
+  // case scope.  forceCleanup() pops that cleanup and leaves the insertion
+  // point inside the case region (after the variable's cir.cleanup.scope),
+  // which is a different region from the cir.scope that wraps the switch.
+  // The scope-terminating yield must land in the switch scope's own region,
+  // so bring the insertion point back to the end of that region.
+  if (isSwitch() && builder.getInsertionBlock() &&
+      builder.getInsertionBlock()->getParent() != entryBlock->getParent())
+    builder.setInsertionPointToEnd(&entryBlock->getParent()->back());
+
   mlir::Block *curBlock = builder.getBlock();
   if (isGlobalInit() && !curBlock)
     return;

--- a/clang/test/CIR/CodeGen/switch-case-scope-cleanup.cpp
+++ b/clang/test/CIR/CodeGen/switch-case-scope-cleanup.cpp
@@ -1,0 +1,46 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=LLVM
+
+struct Struk {
+  ~Struk();
+};
+
+void use(int);
+
+int test(int x) {
+  switch (x) {
+  case 0:
+    return 1;
+  case 2:
+    Struk s;
+    use(x);
+    return 2;
+  }
+  return 3;
+}
+
+// CIR: cir.func {{.*}} @_Z4testi
+// CIR:         cir.scope {
+// CIR:           cir.switch
+// CIR:             cir.case(equal, [#cir.int<2> : !s32i]) {
+// CIR:               cir.cleanup.scope {
+// CIR:                 cir.return
+// CIR:               } cleanup normal {
+// CIR:                 cir.call{{.*}}@_ZN5StrukD1Ev
+// CIR:               }
+// CIR:         }
+// CIR:         cir.const #cir.int<3> : !s32i
+// CIR:         cir.return
+
+// LLVM: define dso_local noundef i32 @_Z4testi(i32 noundef %{{.*}})
+// LLVM:   switch i32 %{{.*}}, label %{{.*}} [
+// LLVM:     i32 0, label %{{.*}}
+// LLVM:     i32 2, label %{{.*}}
+// LLVM:   ]
+// LLVM:   call void @_Z3usei(i32 noundef %{{.*}})
+// LLVM:   call void @_ZN5StrukD1Ev(
+// LLVM:   ret i32


### PR DESCRIPTION
A variable declared directly in a `switch` case without enclosing braces
lives until the end of the switch body, so its destructor cleanup is owned by
the switch's lexical scope rather than a per-case scope.
[#197780](https://github.com/llvm/llvm-project/pull/197780) fixed the
general "last block of cir.scope must be terminated" verifier error by
repositioning the builder after `forceCleanup` strands it in a nested region,
but the unbraced-switch-case variant still slips through: `forceCleanup()` ->
`popCleanup()` leaves the insertion point inside the switch *case* region (just
after the variable's `cir.cleanup.scope`), and the scope-terminating `cir.yield`
is then emitted into that case region instead of the `cir.scope` that wraps the
switch.  The wrapping scope is left unterminated and the verifier rejects it with
`'cir.scope' op last block of cir.scope must be terminated`.

```c++
struct Struk { ~Struk(); };
void use(int);
int test(int x) {
  switch (x) {
  case 0:
    return 1;
  case 2:
    Struk s;
    use(x);
    return 2;
  }
  return 3;
}
```

The fix brings the insertion point back to the end of the switch scope's own
region before emitting the terminator, in `LexicalScope::cleanup`.  It is gated
on `isSwitch()`: a switch is the only scope whose cleanups can be buried in a
sibling structured region (its cases are distinct regions), so for regular
scopes and OpenACC recipe scopes the existing behavior of letting
`forceCleanup()` leave the insertion point where it lands is correct — ungating
it regresses the OpenACC recipe tests.
