### PR TITLE
[NVPTX] Handle symbol-relative integer initializers in aggregates

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -1689,6 +1689,13 @@ void NVPTXAsmPrinter::bufferLEByte(const Constant *CPV, int Bytes,
         AggBuffer->addZeros(AllocSize);
         break;
       }
+      // A symbol-relative integer whose offset is applied outside the
+      // ptrtoint, e.g. add/sub(ptrtoint(@g), C). It can't fold to a ConstantInt
+      // because it references a symbol; emit it through lowerConstantForGV, the
+      // same path scalar symbol-relative integer globals use.
+      AggBuffer->addSymbol(Cexpr, Cexpr);
+      AggBuffer->addZeros(AllocSize);
+      break;
     }
     llvm_unreachable("unsupported integer const type");
     break;
@@ -1976,12 +1983,15 @@ NVPTXAsmPrinter::lowerConstantForGV(const Constant *CV,
 
   // The MC library also has a right-shift operator, but it isn't consistently
   // signed or unsigned between different targets.
-  case Instruction::Add: {
+  case Instruction::Add:
+  case Instruction::Sub: {
     const MCExpr *LHS = lowerConstantForGV(CE->getOperand(0), ProcessingGeneric);
     const MCExpr *RHS = lowerConstantForGV(CE->getOperand(1), ProcessingGeneric);
     switch (CE->getOpcode()) {
     default: llvm_unreachable("Unknown binary operator constant cast expr");
     case Instruction::Add: return MCBinaryExpr::createAdd(LHS, RHS, Ctx);
+    case Instruction::Sub:
+      return MCBinaryExpr::createSub(LHS, RHS, Ctx);
     }
   }
   }

--- a/llvm/test/CodeGen/NVPTX/global-ordering.ll
+++ b/llvm/test/CodeGen/NVPTX/global-ordering.ll
@@ -20,3 +20,18 @@
 ; PTX64-NEXT: .visible .global .align 8 .u64 b2[2] = {b, b};
 @b2 = addrspace(1) global [2 x ptr addrspace(1)] [ptr addrspace(1) @b, ptr addrspace(1) @b]
 @b = addrspace(1) global i8 1
+
+
+; Emit global aggregates with a field computed from the address of another global.
+@g = addrspace(1) global i8 0
+@h = addrspace(1) global i8 0
+
+; PTX64: .visible .global .align 8 .u64 sadd[2] = {g+4, 7};
+@sadd = addrspace(1) global { i64, i64 } { i64 add (i64 ptrtoint (ptr addrspace(1) @g to i64), i64 4), i64 7 }
+
+; PTX64: .visible .global .align 8 .u64 ssub[2] = {g-4, 7};
+@ssub = addrspace(1) global { i64, i64 } { i64 sub (i64 ptrtoint (ptr addrspace(1) @g to i64), i64 4), i64 7 }
+
+; PTX32: .visible .global .align 8 .u64 sdiff = (g&4294967295)-(h&4294967295);
+; PTX64: .visible .global .align 8 .u64 sdiff = g-h;
+@sdiff = addrspace(1) global i64 sub (i64 ptrtoint (ptr addrspace(1) @g to i64), i64 ptrtoint (ptr addrspace(1) @h to i64))


### PR DESCRIPTION
A symbol-relative integer applies an offset outside the ptrtoint, e.g.

    @g = addrspace(1) global i8 0
    @s = addrspace(1) global { i64, i64 }
           { i64 add (i64 ptrtoint (ptr addrspace(1) @g to i64), i64 4),
             i64 7 }

I'm not sure this is an important feature, but it's explicitly
implemented and works for scalars; the bug is that it hits
llvm_unreachable if you use it inside an aggregate.

While we're here, we also add support for Sub in addition to Add.
