### PR TITLE
[VPlan] Don't expand SCEVs without uses to VPInstructions (NFC).

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -5285,7 +5285,7 @@ void VPlanTransforms::expandSCEVsToVPInstructions(VPlan &Plan,
   // late expansion.
   for (VPRecipeBase &R : make_early_inc_range(*Entry)) {
     auto *ExpSCEV = dyn_cast<VPExpandSCEVRecipe>(&R);
-    if (!ExpSCEV)
+    if (!ExpSCEV || ExpSCEV->getNumUsers() == 0)
       continue;
     Builder.setInsertPoint(ExpSCEV);
     VPValue *Expanded = Expander.tryToExpand(ExpSCEV->getSCEV());


### PR DESCRIPTION
If a VPExpandSCEVRecipe does not have users, there's no benefit to expand it to VPInstructions, which then have to get cleaned up.

This also prevents DCE from removing VPInstructions pointed to by TripCount after expansion.