### PR TITLE
[flang][OpenACC] Re-declare cached array sections with lower bounds only

### DIFF
--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -4606,9 +4606,28 @@ genACC(Fortran::lower::AbstractConverter &converter,
             converter.getSymbolMap().lookupSymbol(symbol)) {
       // For simple variables, rebind the symbol directly.
       fir::ExtendedValue hostExv = converter.getSymbolExtendedValue(symbol);
-      fir::ExtendedValue cacheExv =
-          fir::substBase(hostExv, cacheOp.getAccVar());
-      converter.bindSymbol(symbol, cacheExv);
+      mlir::Value accVar = cacheOp.getAccVar();
+      if (mlir::isa<fir::BaseBoxType>(accVar.getType())) {
+        // acc.cache produces the cache descriptor; its eventual extents and
+        // strides are decided later by cache materialization, which may stage
+        // the section into packed or unpacked storage depending on the bounds
+        // and access pattern. We therefore cannot know the cached shape/strides
+        // here and must not re-impose the host array's shape on the descriptor.
+        // Re-declare with the original lower bounds only (lowered to a
+        // fir.shift, no extents): the resulting fir.rebox then preserves
+        // whatever extents and strides the materialized descriptor carries,
+        // rather than reshaping it back to the host's contiguous layout.
+        llvm::SmallVector<mlir::Value> lbounds =
+            fir::factory::getNonDefaultLowerBounds(builder, operandLocation,
+                                                   hostExv);
+        converter.bindSymbol(symbol, fir::BoxValue(accVar, lbounds,
+                                                   /*explicitParams=*/{},
+                                                   /*explicitExtents=*/{}));
+      } else {
+        // Raw reference (e.g. a contiguous, default-lower-bound array): the
+        // cached reads use the constant-stride path, so keep the host shape.
+        converter.bindSymbol(symbol, fir::substBase(hostExv, accVar));
+      }
     } else {
       // Derived type component reference.
       assert(designator && "expected designator for non-symbol cache operand");

--- a/flang/test/Lower/OpenACC/acc-cache.f90
+++ b/flang/test/Lower/OpenACC/acc-cache.f90
@@ -783,3 +783,61 @@ end subroutine
 
 ! CHECK-LABEL: func.func @_QPfull_array_cache()
 ! CHECK: acc.cache var(%{{.*}}) bounds(%{{.*}})
+
+! Caching a section of an array with a non-unit lower bound produces a
+! box-typed acc.cache. The cache descriptor's extents and strides are decided
+! later by cache materialization, so the cached symbol must be re-declared with
+! the ORIGINAL lower bound ONLY -- a fir.shift, never a fir.shape_shift. A
+! fir.shape_shift would re-impose the host array's extents on the descriptor and
+! defeat the materialized (possibly packed) layout.
+subroutine test_cache_nonunit_lb_box()
+  integer :: arr(10:20)
+  integer :: i
+
+  !$acc loop
+  do i = 10, 20
+    !$acc cache(arr(12:18))
+    arr(i) = i
+  end do
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_cache_nonunit_lb_box()
+! The host array is declared with its full shape: lower bound 10, extent 11.
+! CHECK: %[[LB:.*]] = arith.constant 10 : index
+! CHECK: %[[EXT:.*]] = arith.constant 11 : index
+! CHECK: %[[SHAPE:.*]] = fir.shape_shift %[[LB]], %[[EXT]] : (index, index) -> !fir.shapeshift<1>
+! CHECK: %[[ARR:.*]]:2 = hlfir.declare %{{.*}}(%[[SHAPE]]) {uniq_name = "_QFtest_cache_nonunit_lb_boxEarr"} : (!fir.ref<!fir.array<11xi32>>, !fir.shapeshift<1>) -> (!fir.box<!fir.array<11xi32>>, !fir.ref<!fir.array<11xi32>>)
+! CHECK: %[[CACHE:.*]] = acc.cache var(%[[ARR]]#0 : !fir.box<!fir.array<11xi32>>) bounds(%{{.*}}) -> !fir.box<!fir.array<11xi32>> {name = "arr(12:18)"
+! The cached re-declaration reuses the SAME lower bound (10) with NO extent: a
+! fir.shift on %[[LB]], never a fir.shape_shift.
+! CHECK-NOT: fir.shape_shift
+! CHECK: %[[SHIFT:.*]] = fir.shift %[[LB]] : (index) -> !fir.shift<1>
+! CHECK: hlfir.declare %[[CACHE]](%[[SHIFT]]) {uniq_name = "_QFtest_cache_nonunit_lb_boxEarr"} : (!fir.box<!fir.array<11xi32>>, !fir.shift<1>) -> (!fir.box<!fir.array<11xi32>>, !fir.box<!fir.array<11xi32>>)
+
+! Same property for an assumed-shape array (runtime descriptor): the cached
+! re-declaration uses a multi-dimensional fir.shift (lower bounds only), so the
+! rebox preserves the descriptor's extents/strides instead of reshaping them.
+subroutine test_cache_assumed_shape_box(arr)
+  real(8) :: arr(0:, 0:)
+  integer :: i
+
+  !$acc loop
+  do i = 1, 10
+    !$acc cache(arr(3:8, 0:4))
+    arr(i, 0) = arr(i, 1)
+  end do
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_cache_assumed_shape_box(
+! Both declared lower bounds are 0 (arr(0:,0:)):
+! CHECK: %[[C0A:.*]] = arith.constant 0 : i64
+! CHECK: %[[LB0:.*]] = fir.convert %[[C0A]] : (i64) -> index
+! CHECK: %[[C0B:.*]] = arith.constant 0 : i64
+! CHECK: %[[LB1:.*]] = fir.convert %[[C0B]] : (i64) -> index
+! CHECK: %[[ARR:.*]]:2 = hlfir.declare %arg0(%{{.*}}) dummy_scope %{{.*}} {{.*}}uniq_name = "_QFtest_cache_assumed_shape_boxEarr"}
+! CHECK: %[[CACHE:.*]] = acc.cache var(%[[ARR]]#0 : !fir.box<!fir.array<?x?xf64>>) bounds(%{{.*}}, %{{.*}}) -> !fir.box<!fir.array<?x?xf64>> {name = "arr(3:8,0:4)"
+! The cached re-declaration reuses the SAME two lower bounds (0, 0) with no
+! extents: a fir.shift on %[[LB0]], %[[LB1]], never a fir.shape_shift.
+! CHECK-NOT: fir.shape_shift
+! CHECK: %[[SHIFT:.*]] = fir.shift %[[LB0]], %[[LB1]] : (index, index) -> !fir.shift<2>
+! CHECK: hlfir.declare %[[CACHE]](%[[SHIFT]]) {uniq_name = "_QFtest_cache_assumed_shape_boxEarr"} : (!fir.box<!fir.array<?x?xf64>>, !fir.shift<2>) -> (!fir.box<!fir.array<?x?xf64>>, !fir.box<!fir.array<?x?xf64>>)


### PR DESCRIPTION
When acc.cache yields a box, rebind the symbol with a fir.shift (lower
bounds, no extents) instead of a fir.shape_shift, so the rebox preserves
the materialized descriptor's extents and strides. Add lowering tests.

Assisted by Claude