### PR TITLE
[lldb][debugserver] Arguments to kill(2) are reversed

### DIFF
--- a/lldb/tools/debugserver/source/DNB.cpp
+++ b/lldb/tools/debugserver/source/DNB.cpp
@@ -379,7 +379,7 @@ nub_process_t DNBProcessLaunch(
         // point and get reparented to someone else and never go away.
         DNBLog("Could not get task port for process, sending SIGKILL and "
                "exiting.");
-        kill(SIGKILL, pid);
+        kill(pid, SIGKILL);
 
         if (err_str && err_len > 0) {
           if (launch_err.AsString()) {


### PR DESCRIPTION
This codepath is only executed as an attempt to clean up during a failed launch, so the reversed arguments were rarely actually used.

rdar://175507620