### PR TITLE
[lldb-dap] Replace SBData::GetAddress with SBValue::GetValueAsAddress

### DIFF
--- a/lldb/tools/lldb-dap/Handler/LocationsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/LocationsRequestHandler.cpp
@@ -39,10 +39,7 @@ LocationsRequestHandler::Run(const protocol::LocationsArguments &args) const {
       return llvm::make_error<DAPError>(
           "Value locations are only available for pointers and references");
 
-    lldb::SBError error;
-    lldb::addr_t raw_addr = variable.GetData().GetAddress(error, 0);
-    if (error.Fail())
-      return ToError(error);
+    lldb::addr_t raw_addr = variable.GetValueAsAddress();
     lldb::SBAddress addr = dap.target.ResolveLoadAddress(raw_addr);
     lldb::SBLineEntry line_entry = GetLineEntryForAddress(dap.target, addr);
 

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -350,8 +350,7 @@ bool ValuePointsToCode(lldb::SBValue v) {
   if (!type.GetPointeeType().IsFunctionType())
     return false;
 
-  lldb::SBError error;
-  lldb::addr_t addr = v.GetData().GetAddress(error, 0);
+  lldb::addr_t addr = v.GetValueAsAddress();
   lldb::SBLineEntry line_entry =
       v.GetTarget().ResolveLoadAddress(addr).GetLineEntry();
 


### PR DESCRIPTION
`SBValue` -> `GetData()` -> `GetAddress()` is not a great way to get the load address of an SBValue. `SBData::GetAddress` extracts an address-sized value from a data extractor. While this works most of the time, this fails on any platform in which pointers have metadata (e.g. arm64e).

`SBValue::GetValueAsAddress` should be used instead because it fixes the address before returning it to you.

This fixes TestDAP_evaluate.py and TestDAP_locations.py on arm64e.

Note: I don't think `SBData::GetAddress` should fix up the address. SBData (the analogue for DataExtractor) should return the exact data it reads without cooking it. Callers should either use something like `SBValue::GetValueAsAddress`, or if that's not possible, the address can be cooked with `SBProcess::FixAddress`.