### PR TITLE
[SandboxVec][DAG] Implement UnscheduledPreds API

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h
@@ -144,6 +144,7 @@ protected:
   /// The number of unscheduled successors. Optional represents whether the
   /// value is meaningless, e.g., after a node gets scheduled.
   std::optional<unsigned> UnscheduledSuccs = 0;
+  std::optional<unsigned> UnscheduledPreds = 0;
   /// This is true if this node has been scheduled.
   bool Scheduled = false;
   /// The scheduler bundle that this node belongs to.
@@ -168,9 +169,16 @@ public:
     assert((bool)UnscheduledSuccs && "Invalid UnscheduledSuccs!");
     return *UnscheduledSuccs;
   }
+  /// \Returns the number of unscheduled predecessors.
+  unsigned getNumUnscheduledPreds() const {
+    assert((bool)UnscheduledPreds && "Invalid UnscheduledPreds!");
+    return *UnscheduledPreds;
+  }
 #ifndef NDEBUG
   /// \returns true unscheduled successors contains valid data (for testing).
   bool validUnscheduledSuccs() const { return (bool)UnscheduledSuccs; }
+  /// \returns true unscheduled predecessors contains valid data (for testing).
+  bool validUnscheduledPreds() const { return (bool)UnscheduledPreds; }
 #endif
   // TODO: Make this private?
   void decrUnscheduledSuccs() {
@@ -178,18 +186,28 @@ public:
     --*UnscheduledSuccs;
   }
   void incrUnscheduledSuccs() { ++*UnscheduledSuccs; }
+  void decrUnscheduledPreds() {
+    assert(*UnscheduledPreds > 0 && "Counting error!");
+    --*UnscheduledPreds;
+  }
+  void incrUnscheduledPreds() { ++*UnscheduledPreds; }
+
   void resetScheduleState() {
     UnscheduledSuccs = 0;
+    UnscheduledPreds = 0;
     Scheduled = false;
   }
-  /// \Returns true if all dependent successors have been scheduled.
-  bool ready() const { return UnscheduledSuccs == 0; }
+  /// \Returns true if all dependent successors (or predecessors during top-down
+  /// scheduling) have been scheduled.
+  bool readyBottomUp() const { return UnscheduledSuccs == 0; }
+  bool readyTopDown() const { return UnscheduledPreds == 0; }
   /// \Returns true if this node has been scheduled.
   bool scheduled() const { return Scheduled; }
   void setScheduled() {
     Scheduled = true;
     // UnscheduledSuccs is meaningless from this point on, so prohibit its use.
     UnscheduledSuccs = std::nullopt;
+    UnscheduledPreds = std::nullopt;
   }
   /// \Returns the scheduling bundle that this node belongs to, or nullptr.
   SchedBundle *getSchedBundle() const { return SB; }
@@ -367,8 +385,10 @@ public:
     assert(PredN != this && "Trying to add a dependency to self!");
     PredN->MemSuccs.insert(this);
     if (!Scheduled) {
-      if (!PredN->Scheduled)
+      if (!PredN->Scheduled) {
         PredN->incrUnscheduledSuccs();
+        incrUnscheduledPreds();
+      }
     }
   }
   /// Removes the memory dependency PredN->this. This also updates the
@@ -377,8 +397,10 @@ public:
     MemPreds.erase(PredN);
     PredN->MemSuccs.erase(this);
     if (!Scheduled) {
-      if (!PredN->Scheduled)
+      if (!PredN->Scheduled) {
         PredN->decrUnscheduledSuccs();
+        decrUnscheduledPreds();
+      }
     }
   }
   /// \Returns true if there is a memory dependency N->this.

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
@@ -151,7 +151,7 @@ public:
   LLVM_ABI void cluster(BasicBlock::iterator Where);
   /// \Returns true if all nodes in the bundle are ready.
   bool ready() const {
-    return all_of(Nodes, [](const auto *N) { return N->ready(); });
+    return all_of(Nodes, [](const auto *N) { return N->readyBottomUp(); });
   }
 #ifndef NDEBUG
   void dump(raw_ostream &OS) const;

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.cpp
@@ -142,7 +142,8 @@ DGNode::~DGNode() {
 
 #ifndef NDEBUG
 void DGNode::print(raw_ostream &OS, bool PrintDeps) const {
-  OS << *I << " USuccs:" << UnscheduledSuccs << " Sched:" << Scheduled << "\n";
+  OS << *I << " USuccs:" << UnscheduledSuccs << " UPreds:" << UnscheduledPreds
+     << " Sched:" << Scheduled << "\n";
 }
 void DGNode::dump() const { print(dbgs()); }
 void MemDGNode::print(raw_ostream &OS, bool PrintDeps) const {
@@ -305,6 +306,7 @@ void DependencyGraph::setDefUseUnscheduledSuccs(
   // +---+
   // Set the intra-interval counters in NewInterval.
   for (Instruction &I : NewInterval) {
+    unsigned CntUnschedPreds = 0;
     for (Value *Op : I.operands()) {
       auto *OpI = dyn_cast<Instruction>(Op);
       if (OpI == nullptr)
@@ -318,7 +320,10 @@ void DependencyGraph::setDefUseUnscheduledSuccs(
       if (OpN == nullptr)
         continue;
       OpN->incrUnscheduledSuccs();
+      if (!OpN->scheduled())
+        ++CntUnschedPreds;
     }
+    getNode(&I)->UnscheduledPreds = CntUnschedPreds;
   }
 
   // Now handle the cross-interval edges.
@@ -340,6 +345,7 @@ void DependencyGraph::setDefUseUnscheduledSuccs(
     // Skip scheduled nodes.
     if (BotN->scheduled())
       continue;
+    unsigned CntUnscheduledPreds = 0;
     for (Value *Op : BotI.operands()) {
       auto *OpI = dyn_cast<Instruction>(Op);
       if (OpI == nullptr)
@@ -350,7 +356,10 @@ void DependencyGraph::setDefUseUnscheduledSuccs(
       if (!TopInterval.contains(OpI))
         continue;
       OpN->incrUnscheduledSuccs();
+      if (!OpN->scheduled())
+        ++CntUnscheduledPreds;
     }
+    *BotN->UnscheduledPreds += CntUnscheduledPreds;
   }
 }
 
@@ -571,9 +580,12 @@ void DependencyGraph::notifyEraseInstr(Instruction *I) {
     // NOTE: The unscheduled succs for MemNodes get updated be setMemPred().
   } else {
     // If this is a non-mem node we only need to update UnscheduledSuccs.
-    if (!N->scheduled())
+    if (!N->scheduled()) {
       for (auto *PredN : N->preds(*this))
         PredN->decrUnscheduledSuccs();
+      for (auto *SuccN : N->succs(*this))
+        SuccN->decrUnscheduledPreds();
+    }
   }
   // Finally erase the Node.
   InstrToNodeMap.erase(I);
@@ -602,15 +614,19 @@ void DependencyGraph::notifySetUse(const Use &U, Value *NewSrc) {
   if (auto *CurrSrcI = dyn_cast<Instruction>(U.get())) {
     if (auto *CurrSrcN = getNode(CurrSrcI)) {
       // If CurrSrcN is scheduled there is no point in updating UnscheduleSuccs.
-      if (!CurrSrcN->scheduled())
+      if (!CurrSrcN->scheduled()) {
         CurrSrcN->decrUnscheduledSuccs();
+        UserN->decrUnscheduledPreds();
+      }
     }
   }
   if (auto *NewSrcI = dyn_cast<Instruction>(NewSrc)) {
     if (auto *NewSrcN = getNode(NewSrcI)) {
       // If CurrSrcN is scheduled there is no point in updating UnscheduleSuccs.
-      if (!NewSrcN->scheduled())
+      if (!NewSrcN->scheduled()) {
         NewSrcN->incrUnscheduledSuccs();
+        UserN->incrUnscheduledPreds();
+      }
     }
   }
 }

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Scheduler.cpp
@@ -79,7 +79,7 @@ void Scheduler::scheduleAndUpdateReadyList(SchedBundle &Bndl) {
   for (DGNode *N : Bndl) {
     for (auto *DepN : N->preds(DAG)) {
       DepN->decrUnscheduledSuccs();
-      if (DepN->ready() && !DepN->scheduled())
+      if (DepN->readyBottomUp() && !DepN->scheduled())
         ReadyList.insert(DepN);
     }
     N->setScheduled();
@@ -282,7 +282,7 @@ void Scheduler::trimSchedule(ArrayRef<Instruction *> Instrs) {
   Interval<Instruction> RefillIntvl(DAG.getInterval().top(), LowestI);
   for (Instruction &I : RefillIntvl) {
     auto *N = DAG.getNode(&I);
-    if (N->ready())
+    if (N->readyBottomUp())
       ReadyList.insert(N);
   }
 }
@@ -333,7 +333,7 @@ bool Scheduler::trySchedule(ArrayRef<Instruction *> Instrs) {
     // Add nodes to ready list.
     for (auto &I : Extension) {
       auto *N = DAG.getNode(&I);
-      if (N->ready())
+      if (N->readyBottomUp())
         ReadyList.insert(N);
     }
     // Try schedule all nodes until we can schedule Instrs back-to-back.

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/DependencyGraphTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/DependencyGraphTest.cpp
@@ -871,6 +871,8 @@ define void @foo(ptr %ptr, i8 %v1, i8 %v2, i8 %v3, i8 %v4, i8 %v5) {
     [[maybe_unused]] auto *S3N = cast<sandboxir::MemDGNode>(DAG.getNode(S3));
     // Check UnscheduledSuccs.
     EXPECT_EQ(S3N->getNumUnscheduledSuccs(), 0u);
+    // Check UnscheduledPreds.
+    EXPECT_EQ(S3N->getNumUnscheduledPreds(), 0u);
   }
   {
     // Scenario 2: Extend below
@@ -886,6 +888,10 @@ define void @foo(ptr %ptr, i8 %v1, i8 %v2, i8 %v3, i8 %v4, i8 %v5) {
     EXPECT_EQ(S3N->getNumUnscheduledSuccs(), 2u); // S4N, S5N
     EXPECT_EQ(S4N->getNumUnscheduledSuccs(), 1u); // S5N
     EXPECT_EQ(S5N->getNumUnscheduledSuccs(), 0u);
+    // Check UnscheduledPreds.
+    EXPECT_EQ(S3N->getNumUnscheduledPreds(), 0u);
+    EXPECT_EQ(S4N->getNumUnscheduledPreds(), 1u); // S3N
+    EXPECT_EQ(S5N->getNumUnscheduledPreds(), 2u); // S3N, S4N
   }
   {
     // Scenario 3: Extend above
@@ -917,6 +923,12 @@ define void @foo(ptr %ptr, i8 %v1, i8 %v2, i8 %v3, i8 %v4, i8 %v5) {
     EXPECT_EQ(S3N->getNumUnscheduledSuccs(), 2u); // S4N, S5N
     EXPECT_EQ(S4N->getNumUnscheduledSuccs(), 1u); // S5N
     EXPECT_EQ(S5N->getNumUnscheduledSuccs(), 0u);
+    // Check UnscheduledPreds.
+    EXPECT_EQ(S1N->getNumUnscheduledPreds(), 0u);
+    EXPECT_EQ(S2N->getNumUnscheduledPreds(), 1u); // S1N
+    EXPECT_EQ(S3N->getNumUnscheduledPreds(), 2u); // S1N, S2N
+    EXPECT_EQ(S4N->getNumUnscheduledPreds(), 3u); // S1N, S2N, S3N
+    EXPECT_EQ(S5N->getNumUnscheduledPreds(), 4u); // S1N, S2N, S3N, S4N
   }
 
   {
@@ -928,7 +940,18 @@ define void @foo(ptr %ptr, i8 %v1, i8 %v2, i8 %v3, i8 %v4, i8 %v5) {
 
     DAG.extend({S1, S1});
     auto *S1N = cast<sandboxir::MemDGNode>(DAG.getNode(S1));
-    EXPECT_EQ(S1N->getNumUnscheduledSuccs(), 0u); // S1 is scheduled
+    EXPECT_EQ(S1N->getNumUnscheduledSuccs(), 0u); // S2 is scheduled
+  }
+  {
+    // Check UnscheduledPreds when a node is scheduled
+    sandboxir::DependencyGraph DAG(getAA(*LLVMF), Ctx);
+    DAG.extend({S1, S1});
+    auto *S1N = cast<sandboxir::MemDGNode>(DAG.getNode(S1));
+    S1N->setScheduled();
+
+    DAG.extend({S2, S2});
+    auto *S2N = cast<sandboxir::MemDGNode>(DAG.getNode(S2));
+    EXPECT_EQ(S2N->getNumUnscheduledPreds(), 0u); // S1 is scheduled
   }
 }
 
@@ -1029,6 +1052,9 @@ define void @foo(ptr %ptr, i8 %v1, i8 %v2, i8 %v3, i8 %v4, i8 %arg) {
   EXPECT_EQ(S1MemN->getNumUnscheduledSuccs(), 2u);
   EXPECT_EQ(S2MemN->getNumUnscheduledSuccs(), 1u);
   EXPECT_EQ(S3MemN->getNumUnscheduledSuccs(), 0u);
+  EXPECT_EQ(S1MemN->getNumUnscheduledPreds(), 0u);
+  EXPECT_EQ(S2MemN->getNumUnscheduledPreds(), 1u);
+  EXPECT_EQ(S3MemN->getNumUnscheduledPreds(), 2u);
   S2->eraseFromParent();
   // Check that the DAG Node for S2 no longer exists.
   auto *DeletedN = DAG.getNode(S2);
@@ -1038,6 +1064,8 @@ define void @foo(ptr %ptr, i8 %v1, i8 %v2, i8 %v3, i8 %v4, i8 %arg) {
   EXPECT_THAT(S1MemN->succs(DAG), testing::UnorderedElementsAre(S3MemN));
   // Also check that UnscheduledSuccs was updated for S1.
   EXPECT_EQ(S1MemN->getNumUnscheduledSuccs(), 1u);
+  // Also check that UnscheduledPreds was updated for S3.
+  EXPECT_EQ(S3MemN->getNumUnscheduledPreds(), 1u);
 
   // Check the MemDGNode chain.
   EXPECT_EQ(S1MemN->getNextNode(), S3MemN);
@@ -1051,12 +1079,14 @@ define void @foo(ptr %ptr, i8 %v1, i8 %v2, i8 %v3, i8 %v4, i8 %arg) {
   S4NotInDAG->eraseFromParent();
 }
 
-// Same but check that we don't update UnscheduledSuccs when Node is scheduled.
+// Same but check that we don't update UnscheduledSuccs and UnscheduledPreds
+// when Node is scheduled.
 TEST_F(DependencyGraphTest, EraseInstrCallbackScheduled) {
   parseIR(C, R"IR(
-define void @foo(ptr %ptr, i8 %v1, i8 %v2, i8 %v3, i8 %v4, i8 %arg) {
+define void @foo(ptr %ptr, i8 %v1, i8 %v2, i8 %v3) {
   store i8 %v1, ptr %ptr
   store i8 %v2, ptr %ptr
+  store i8 %v3, ptr %ptr
   ret void
 }
 )IR");
@@ -1067,19 +1097,27 @@ define void @foo(ptr %ptr, i8 %v1, i8 %v2, i8 %v3, i8 %v4, i8 %arg) {
   auto It = BB->begin();
   auto *S1 = cast<sandboxir::StoreInst>(&*It++);
   auto *S2 = cast<sandboxir::StoreInst>(&*It++);
+  auto *S3 = cast<sandboxir::StoreInst>(&*It++);
 
   sandboxir::DependencyGraph DAG(getAA(*LLVMF), Ctx);
-  DAG.extend({S1, S2});
+  DAG.extend({S1, S3});
   auto *S1MemN = cast<sandboxir::MemDGNode>(DAG.getNode(S1));
   auto *S2MemN = cast<sandboxir::MemDGNode>(DAG.getNode(S2));
-  EXPECT_EQ(S1MemN->getNumUnscheduledSuccs(), 1u);
-  EXPECT_EQ(S2MemN->getNumUnscheduledSuccs(), 0u);
+  auto *S3MemN = cast<sandboxir::MemDGNode>(DAG.getNode(S3));
+  EXPECT_EQ(S1MemN->getNumUnscheduledSuccs(), 2u);
+  EXPECT_EQ(S2MemN->getNumUnscheduledSuccs(), 1u);
+  EXPECT_EQ(S3MemN->getNumUnscheduledSuccs(), 0u);
+  EXPECT_EQ(S1MemN->getNumUnscheduledPreds(), 0u);
+  EXPECT_EQ(S2MemN->getNumUnscheduledPreds(), 1u);
+  EXPECT_EQ(S3MemN->getNumUnscheduledPreds(), 2u);
   // Mark S2 as scheduled and erase it.
   S2MemN->setScheduled();
   S2->eraseFromParent();
   EXPECT_EQ(DAG.getNode(S2), nullptr);
   // Check that we did not update S1's UnscheduledSuccs
-  EXPECT_EQ(S1MemN->getNumUnscheduledSuccs(), 1u);
+  EXPECT_EQ(S1MemN->getNumUnscheduledSuccs(), 2u);
+  // Check that we did not update S3's UnscheduledPreds
+  EXPECT_EQ(S3MemN->getNumUnscheduledPreds(), 2u);
 }
 
 TEST_F(DependencyGraphTest, MoveInstrCallback) {
@@ -1198,7 +1236,8 @@ define void @foo(ptr %ptr, i8 %v, i8 %v0, i8 %v1, i8 %v2, i8 %v3) {
 }
 
 // Setting a Use with a setOperand(), RUW, RAUW etc. can add/remove use-def
-// edges. This needs to maintain the UnscheduledSuccs counter.
+// edges. This needs to maintain the UnscheduledSuccs and UnscheduledPreds
+// counters.
 TEST_F(DependencyGraphTest, MaintainUnscheduledSuccsOnUseSet) {
   parseIR(C, R"IR(
 define void @foo(i8 %v0, i8 %v1) {
@@ -1218,35 +1257,45 @@ define void @foo(i8 %v0, i8 %v1) {
   sandboxir::DependencyGraph DAG(getAA(*LLVMF), Ctx);
   DAG.extend({Add0, Add1});
   auto *N0 = DAG.getNode(Add0);
+  auto *N1 = DAG.getNode(Add1);
 
   EXPECT_EQ(N0->getNumUnscheduledSuccs(), 1u);
+  EXPECT_EQ(N1->getNumUnscheduledPreds(), 1u);
   // Now change %add1 operand to not use %add0.
   Add1->setOperand(0, Arg0);
   EXPECT_EQ(N0->getNumUnscheduledSuccs(), 0u);
+  EXPECT_EQ(N1->getNumUnscheduledPreds(), 0u);
   // Restore it: %add0 is now used by %add1.
   Add1->setOperand(0, Add0);
   EXPECT_EQ(N0->getNumUnscheduledSuccs(), 1u);
+  EXPECT_EQ(N1->getNumUnscheduledPreds(), 1u);
 
   // RAUW
   Add0->replaceAllUsesWith(Arg0);
   EXPECT_EQ(N0->getNumUnscheduledSuccs(), 0u);
+  EXPECT_EQ(N1->getNumUnscheduledPreds(), 0u);
   // Restore it: %add0 is now used by %add1.
   Add1->setOperand(0, Add0);
   EXPECT_EQ(N0->getNumUnscheduledSuccs(), 1u);
+  EXPECT_EQ(N1->getNumUnscheduledPreds(), 1u);
 
   // RUWIf
   Add0->replaceUsesWithIf(Arg0, [](const auto &U) { return true; });
   EXPECT_EQ(N0->getNumUnscheduledSuccs(), 0u);
+  EXPECT_EQ(N1->getNumUnscheduledPreds(), 0u);
   // Restore it: %add0 is now used by %add1.
   Add1->setOperand(0, Add0);
   EXPECT_EQ(N0->getNumUnscheduledSuccs(), 1u);
+  EXPECT_EQ(N1->getNumUnscheduledPreds(), 1u);
 
   // RUOW
   Add1->replaceUsesOfWith(Add0, Arg0);
   EXPECT_EQ(N0->getNumUnscheduledSuccs(), 0u);
+  EXPECT_EQ(N1->getNumUnscheduledPreds(), 0u);
   // Restore it: %add0 is now used by %add1.
   Add1->setOperand(0, Add0);
   EXPECT_EQ(N0->getNumUnscheduledSuccs(), 1u);
+  EXPECT_EQ(N1->getNumUnscheduledPreds(), 1u);
 }
 
 // Make sure we maintain the unscheduled succs when the use-def edges cross the
@@ -1290,7 +1339,48 @@ define void @foo(i8 %v0, i8 %v1) {
   EXPECT_EQ(Add0N->getNumUnscheduledSuccs(), 1u);
 }
 
-// Don't udpate the unscheduled succs if nodes have already been scheduled.
+// Make sure we don't change the unscheduled preds when the use-def edges cross
+// the DAG boundaries, i.e., when have an external operand.
+TEST_F(DependencyGraphTest, MaintainUnscheduledPredsExtOperand) {
+  parseIR(C, R"IR(
+define void @foo(i8 %v0, i8 %v1) {
+  %extOp = add i8 %v0, 0   ; This is not in the DAG
+  %add0 = add i8 %v0, %v1
+  ret void
+}
+)IR");
+  llvm::Function *LLVMF = &*M->getFunction("foo");
+  sandboxir::Context Ctx(C);
+  auto *F = Ctx.createFunction(LLVMF);
+  auto *Arg0 = F->getArg(0);
+  auto *Arg1 = F->getArg(1);
+  auto *BB = &*F->begin();
+  auto It = BB->begin();
+  auto *ExtOp = cast<sandboxir::BinaryOperator>(&*It++);
+  auto *Add0 = cast<sandboxir::BinaryOperator>(&*It++);
+  // DAG does not contain ExtOp
+  sandboxir::DependencyGraph DAG(getAA(*LLVMF), Ctx);
+  DAG.extend({Add0});
+  auto *Add0N = DAG.getNode(Add0);
+  EXPECT_EQ(DAG.getNode(ExtOp), nullptr);
+  EXPECT_EQ(Add0N->getNumUnscheduledPreds(), 0u);
+
+  // Adding def-use ExtOp->Add0 shouldn't change Add0's unscheduled preds.
+  Add0->setOperand(1, ExtOp);
+  EXPECT_EQ(Add0N->getNumUnscheduledPreds(), 0u);
+  Add0->setOperand(0, Arg0);
+  EXPECT_EQ(Add0N->getNumUnscheduledPreds(), 0u);
+
+  // Same with RUOW.
+  Add0->replaceUsesOfWith(Arg1, ExtOp);
+  EXPECT_EQ(Add0->getOperand(1), ExtOp);
+  EXPECT_EQ(Add0N->getNumUnscheduledPreds(), 0u);
+  Add0->setOperand(1, Arg1);
+  EXPECT_EQ(Add0N->getNumUnscheduledPreds(), 0u);
+}
+
+// Don't udpate the unscheduled succs and preds if nodes have already been
+// scheduled.
 TEST_F(DependencyGraphTest, MaintainUnscheduledSuccsWhenScheduled) {
   parseIR(C, R"IR(
 define void @foo(i8 %v0) {
@@ -1316,20 +1406,26 @@ define void @foo(i8 %v0) {
   // Mark Add0N and Add1N as scheduled.
 #ifndef NDEBUG
   EXPECT_TRUE(Add0N->validUnscheduledSuccs());
+  EXPECT_TRUE(Add0N->validUnscheduledPreds());
 #endif
   Add0N->setScheduled();
 #ifndef NDEBUG
   EXPECT_FALSE(Add0N->validUnscheduledSuccs());
   EXPECT_DEATH(Add0N->getNumUnscheduledSuccs(), ".*");
+  EXPECT_FALSE(Add0N->validUnscheduledPreds());
+  EXPECT_DEATH(Add0N->getNumUnscheduledPreds(), ".*");
 #endif
 
 #ifndef NDEBUG
   EXPECT_TRUE(Add1N->validUnscheduledSuccs());
+  EXPECT_TRUE(Add1N->validUnscheduledPreds());
 #endif
   Add1N->setScheduled();
 #ifndef NDEBUG
   EXPECT_FALSE(Add1N->validUnscheduledSuccs());
   EXPECT_DEATH(Add1N->getNumUnscheduledSuccs(), ".*");
+  EXPECT_FALSE(Add1N->validUnscheduledPreds());
+  EXPECT_DEATH(Add1N->getNumUnscheduledPreds(), ".*");
 #endif
 
   // Change Modify's operand and make sure we won't update Add0N's or Add1N's
@@ -1340,6 +1436,16 @@ define void @foo(i8 %v0) {
   EXPECT_DEATH(Add0N->getNumUnscheduledSuccs(), ".*");
   EXPECT_FALSE(Add1N->validUnscheduledSuccs());
   EXPECT_DEATH(Add1N->getNumUnscheduledSuccs(), ".*");
+#endif
+
+  // Create a def-use edge Add0->Add1 and make sure Add0N's and Add1N's
+  // unscheduled preds are still invalid.
+  Add1->setOperand(1, Add0);
+#ifndef NDEBUG
+  EXPECT_FALSE(Add0N->validUnscheduledPreds());
+  EXPECT_DEATH(Add0N->getNumUnscheduledPreds(), ".*");
+  EXPECT_FALSE(Add1N->validUnscheduledPreds());
+  EXPECT_DEATH(Add1N->getNumUnscheduledPreds(), ".*");
 #endif
 }
 
@@ -1379,4 +1485,34 @@ define void @foo(i8 %v0) {
   Modify->setOperand(0, Add1);
   EXPECT_EQ(Add0N->getNumUnscheduledSuccs(), 0u);
   EXPECT_EQ(Add1N->getNumUnscheduledSuccs(), 0u);
+}
+
+// Don't udpate the unscheduled preds if the operand is scheduled.
+TEST_F(DependencyGraphTest, MaintainUnscheduledPredsWhenOperandScheduled) {
+  parseIR(C, R"IR(
+define void @foo(i8 %v0) {
+  %sched = add i8 %add0, 1
+  %add0 = add i8 %v0, 0
+  ret void
+}
+)IR");
+  llvm::Function *LLVMF = &*M->getFunction("foo");
+  sandboxir::Context Ctx(C);
+  auto *F = Ctx.createFunction(LLVMF);
+  auto *BB = &*F->begin();
+  auto It = BB->begin();
+  auto *Sched = cast<sandboxir::BinaryOperator>(&*It++);
+  auto *Add0 = cast<sandboxir::BinaryOperator>(&*It++);
+  sandboxir::DependencyGraph DAG(getAA(*LLVMF), Ctx);
+  DAG.extend({Sched, Add0});
+  auto *SchedN = DAG.getNode(Sched);
+  auto *Add0N = DAG.getNode(Add0);
+  EXPECT_EQ(Add0N->getNumUnscheduledPreds(), 0u);
+  // Mark SchedN as scheduled
+  SchedN->setScheduled();
+
+  // Change Add0's operand and make sure that this won't update Add0N's
+  // unscheduled preds because SchedN is "scheduled".
+  Add0->setOperand(0, Sched);
+  EXPECT_EQ(Add0N->getNumUnscheduledPreds(), 0u);
 }

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
@@ -730,6 +730,7 @@ define void @foo(ptr noalias %ptr, ptr noalias %ptr1, ptr noalias %ptr2) {
   DAG.extend({L0});
   auto *L0N = DAG.getNode(L0);
   EXPECT_EQ(L0N->getNumUnscheduledSuccs(), 0u);
+  EXPECT_EQ(L0N->getNumUnscheduledPreds(), 0u);
   // We should have DAG nodes for all instructions at this point
 
   // Now create a new instruction below S0.
@@ -739,6 +740,11 @@ define void @foo(ptr noalias %ptr, ptr noalias %ptr1, ptr noalias %ptr2) {
   // Check that it is marked as "scheduled".
   auto *NewS1N = DAG.getNode(NewS1);
   EXPECT_TRUE(NewS1N->scheduled());
+#ifndef NDEBUG
+  // NewS1N is scheduled so unscheduled preds/succs are irrelevant.
+  EXPECT_FALSE(NewS1N->validUnscheduledPreds());
+  EXPECT_FALSE(NewS1N->validUnscheduledSuccs());
+#endif
   // Check that L0's UnscheduledSuccs are still == 0 since NewS1 is "scheduled".
   EXPECT_EQ(L0N->getNumUnscheduledSuccs(), 0u);
 
@@ -751,6 +757,7 @@ define void @foo(ptr noalias %ptr, ptr noalias %ptr1, ptr noalias %ptr2) {
   EXPECT_FALSE(NewS2N->scheduled());
   // Check that L0's UnscheduledSuccs got updated because of NewS2.
   EXPECT_EQ(L0N->getNumUnscheduledSuccs(), 1u);
+  EXPECT_EQ(NewS2N->getNumUnscheduledPreds(), 0u);
 
   sandboxir::ReadyListContainer ReadyList;
   // Check empty().


### PR DESCRIPTION
Mirroring UnscheduledSuccs, this patch adds an UnscheduledPreds DAG node counter that counts how many predecessors are not scheduled yet.

It also renames the existing ready() to readyBottomUp() to help us differentiate between the two variants that are now available.