### PR TITLE
[VectorCombine] Skip foldShuffleOfIntrinsics when operand types differ

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -3292,11 +3292,13 @@ bool VectorCombine::foldShuffleOfIntrinsics(Instruction &I) {
     return false;
 
   for (unsigned I = 0, E = II0->arg_size(); I != E; ++I) {
+    Value *Arg0 = II0->getArgOperand(I);
+    Value *Arg1 = II1->getArgOperand(I);
     if (isVectorIntrinsicWithScalarOpAtArg(IID, I, &TTI)) {
-      if (II0->getArgOperand(I) != II1->getArgOperand(I))
+      // Scalar operands must be identical.
+      if (Arg0 != Arg1)
         return false;
-    } else if (II0->getArgOperand(I)->getType() !=
-               II1->getArgOperand(I)->getType()) {
+    } else if (Arg0->getType() != Arg1->getType()) {
       // The corresponding vector operands are shuffled together, so they must
       // share the same type. For intrinsics overloaded on their operand type
       // (e.g. llvm.fptosi.sat), two calls can produce the same result type

--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -3291,10 +3291,19 @@ bool VectorCombine::foldShuffleOfIntrinsics(Instruction &I) {
   if (!isTriviallyVectorizable(IID))
     return false;
 
-  for (unsigned I = 0, E = II0->arg_size(); I != E; ++I)
-    if (isVectorIntrinsicWithScalarOpAtArg(IID, I, &TTI) &&
-        II0->getArgOperand(I) != II1->getArgOperand(I))
+  for (unsigned I = 0, E = II0->arg_size(); I != E; ++I) {
+    if (isVectorIntrinsicWithScalarOpAtArg(IID, I, &TTI)) {
+      if (II0->getArgOperand(I) != II1->getArgOperand(I))
+        return false;
+    } else if (II0->getArgOperand(I)->getType() !=
+               II1->getArgOperand(I)->getType()) {
+      // The corresponding vector operands are shuffled together, so they must
+      // share the same type. For intrinsics overloaded on their operand type
+      // (e.g. llvm.fptosi.sat), two calls can produce the same result type
+      // from different operand types; shuffling those would be invalid.
       return false;
+    }
+  }
 
   InstructionCost OldCost =
       CostII0 + CostII1 +

--- a/llvm/test/Transforms/VectorCombine/X86/shuffle-of-intrinsics.ll
+++ b/llvm/test/Transforms/VectorCombine/X86/shuffle-of-intrinsics.ll
@@ -233,3 +233,24 @@ entry:
   %r = shufflevector <4 x i32> %a, <4 x i32> %b, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   ret <8 x i32> %r
 }
+
+; Intrinsics overloaded on their operand type (e.g. llvm.fptosi.sat) can share
+; a result type while having different operand types. The corresponding
+; operands cannot be shuffled together, so the fold must not fire.
+define <4 x i32> @test_mismatched_operand_types(<2 x float> %0, <2 x double> %1) {
+; CHECK-LABEL: @test_mismatched_operand_types(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[A:%.*]] = call <2 x i32> @llvm.fptosi.sat.v2i32.v2f32(<2 x float> [[TMP0:%.*]])
+; CHECK-NEXT:    [[B:%.*]] = call <2 x i32> @llvm.fptosi.sat.v2i32.v2f64(<2 x double> [[TMP1:%.*]])
+; CHECK-NEXT:    [[R:%.*]] = shufflevector <2 x i32> [[A]], <2 x i32> [[B]], <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+; CHECK-NEXT:    ret <4 x i32> [[R]]
+;
+entry:
+  %a = call <2 x i32> @llvm.fptosi.sat.v2i32.v2f32(<2 x float> %0)
+  %b = call <2 x i32> @llvm.fptosi.sat.v2i32.v2f64(<2 x double> %1)
+  %r = shufflevector <2 x i32> %a, <2 x i32> %b, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  ret <4 x i32> %r
+}
+
+declare <2 x i32> @llvm.fptosi.sat.v2i32.v2f32(<2 x float>)
+declare <2 x i32> @llvm.fptosi.sat.v2i32.v2f64(<2 x double>)


### PR DESCRIPTION
Example:
```llvm
define <4 x i32> @t(<2 x float> %a, <2 x double> %b) {
  %fa = call <2 x i32> @llvm.fptosi.sat.v2i32.v2f32(<2 x float> %a)
  %fb = call <2 x i32> @llvm.fptosi.sat.v2i32.v2f64(<2 x double> %b)
  %s = shufflevector <2 x i32> %fa, <2 x i32> %fb, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
  ret <4 x i32> %s
}
```

In this code, `foldShuffleOfIntrinsics` folds `shuffle(intrinsic(x), intrinsic(y))` into `intrinsic(shuffle(x, y))`, but only checks the result type, not the operand types. Since `fptosi.sat` is overloaded on its operand type, the two calls share an `<2 x i32>` result but have different operands (`<2 x float>` vs `<2 x double>`), so the new `shufflevector` gets mismatched operands and trips `isValidOperands`.

Fix: bail out when the intrinsics' shuffled operands have different types.