### PR TITLE
[NVPTX] Pad non-power-of-2 vectors in structs properly.

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -1715,9 +1715,14 @@ void NVPTXAsmPrinter::bufferLEByte(const Constant *CPV, int Bytes,
   case Type::FixedVectorTyID:
   case Type::StructTyID: {
     if (isa<ConstantAggregate>(CPV) || isa<ConstantDataSequential>(CPV)) {
+      // bufferAggregateConstant doesn't emit tail-padding, i.e. it writes
+      // `store_size` bytes, not `alloc_size` bytes.  Do it ourselves here.
+      unsigned StartPos = AggBuffer->getCurpos();
       bufferAggregateConstant(CPV, AggBuffer);
-      if (Bytes > AllocSize)
-        AggBuffer->addZeros(Bytes - AllocSize);
+      unsigned Written = AggBuffer->getCurpos() - StartPos;
+      unsigned SlotSize = std::max<int>(Bytes, AllocSize);
+      if (SlotSize > Written)
+        AggBuffer->addZeros(SlotSize - Written);
     } else if (isa<ConstantAggregateZero>(CPV))
       AggBuffer->addZeros(Bytes);
     else

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.h
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.h
@@ -112,6 +112,9 @@ class LLVM_LIBRARY_VISIBILITY NVPTXAsmPrinter : public AsmPrinter {
 
     unsigned getBufferSize() const { return Size; }
 
+    // Number of bytes written so far.
+    unsigned getCurpos() const { return curpos; }
+
     // Copy Num bytes from Ptr.
     // if Bytes > Num, zero fill up to Bytes.
     void addBytes(const unsigned char *Ptr, unsigned Num, unsigned Bytes) {

--- a/llvm/test/CodeGen/NVPTX/globals_init.ll
+++ b/llvm/test/CodeGen/NVPTX/globals_init.ll
@@ -44,3 +44,12 @@
 
 ; CHECK-DAG: .b8 globalint_Gbli100[13] = {186, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 15};
 @globalint_Gbli100 = global i100 u0xF000000000000000000000ABA
+
+; Non-power-of-2 vector (<3 x i32> store=12 alloc=16) in the middle of the
+; struct must keep its tail padding.
+; CHECK-DAG: .b8 nonpow2vec_field_pad[32] = {1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 254, 255, 255, 255};
+%struct.nonpow2vec_pad = type { <3 x i32>, i32 }
+@nonpow2vec_field_pad = global %struct.nonpow2vec_pad { <3 x i32> <i32 1, i32 2, i32 3>, i32 -2 }
+
+; CHECK-DAG: .b8 nonpow2vec_arr_pad[32] = {1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 0, 6};
+@nonpow2vec_arr_pad = global [2 x <3 x i32>] [<3 x i32> <i32 1, i32 2, i32 3>, <3 x i32> <i32 4, i32 5, i32 6>]


### PR DESCRIPTION
A non-power-of-2 vector inside of a struct is padded up to its alloc
size.

But when the NVPTX asm printer emits bytes for such a struct, it
currently skips this tail padding, thus emitting an incorrect struct.
