### PR TITLE
[M68k] Add to LINK_COMPONENTS to fix BUILD_SHARED_LIBS build

### DIFF
--- a/llvm/lib/Target/M68k/AsmParser/CMakeLists.txt
+++ b/llvm/lib/Target/M68k/AsmParser/CMakeLists.txt
@@ -4,6 +4,7 @@ add_llvm_component_library(LLVMM68kAsmParser
   LINK_COMPONENTS
   CodeGenTypes
   M68kCodeGen
+  M68kDesc
   M68kInfo
   MC
   MCParser


### PR DESCRIPTION
Fixes: 6897c5e24ce5 ("[M68k][MC] Add MC support for PCI w/ base displacement addressing mode (#200696)")