### PR TITLE
[MRI] Avoid walking past all defs in hasOneUse()

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineRegisterInfo.h
@@ -511,7 +511,15 @@ public:
   /// hasOneUse - Return true if there is exactly one instruction using the
   /// specified register.
   bool hasOneUse(Register RegNo) const {
-    return hasSingleElement(use_operands(RegNo));
+    MachineOperand *Head = getRegUseDefListHead(RegNo);
+    if (!Head)
+      return false;
+    MachineOperand *Tail = Head->Contents.Reg.Prev;
+    if (!Tail->isUse())
+      return false;
+    if (Tail == Head)
+      return true;
+    return Tail->Contents.Reg.Prev->isDef();
   }
 
   /// use_nodbg_iterator/use_nodbg_begin/use_nodbg_end - Walk all uses of the

--- a/llvm/include/llvm/CodeGen/MachineRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineRegisterInfo.h
@@ -514,6 +514,7 @@ public:
     MachineOperand *Head = getRegUseDefListHead(RegNo);
     if (!Head)
       return false;
+    // Prev links are circular, and defs always precede uses.
     MachineOperand *Tail = Head->Contents.Reg.Prev;
     if (!Tail->isUse())
       return false;


### PR DESCRIPTION
The use-def list is circular in the Prev direction (Head->Prev == Tail)
and defs always precede uses, see MachineRegisterInfo::addRegOperandToUseList().

We can implement hasOneUse() by checking only the Tail and its Prev, instead of
walking past all defs from the head via use_iterator.