### PR TITLE
[lldb] Enable MyST colon_fence and deflist extensions (NFC)

### DIFF
--- a/lldb/docs/conf.py
+++ b/lldb/docs/conf.py
@@ -71,7 +71,7 @@ except ImportError:
 # Automatic anchors for markdown titles
 myst_heading_anchors = 6
 myst_heading_slug_func = "llvm_slug.make_slug"
-myst_enable_extensions = ["fieldlist"]
+myst_enable_extensions = ["fieldlist", "colon_fence", "deflist"]
 
 autodoc_default_options = {"special-members": True}
 


### PR DESCRIPTION
Enable the colon_fence and deflist MyST parser extensions in the LLDB docs configuration. This is a preparatory step for converting the remaining reStructuredText documentation pages to Markdown, where these two extensions are needed to translate RST admonition directives (:::{note}) and definition lists.

Context: https://discourse.llvm.org/t/rfc-make-myst-markdown-the-llvm-docs-format-rip-rest/