### PR TITLE
[flang][CUDA] Keep host literals from using unified-memory generic distance

### DIFF
--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -2872,9 +2872,11 @@ static int GetMatchingDistance(const common::LanguageFeatureControl &features,
   CHECK(!(isCudaUnified && isCudaManaged) && "expect only one enabled.");
 
   std::optional<common::CUDADataAttr> actualDataAttr, dummyDataAttr;
+  bool actualCanUseCudaMemoryMode{false};
   if (actual) {
     if (auto *expr{actual->UnwrapExpr()}) {
       if (evaluate::IsVariable(*expr)) {
+        actualCanUseCudaMemoryMode = true;
         // Match check-call.cpp: walk the whole designator so e.g. b%a picks up
         // ATTRIBUTES(DEVICE) from the base b when the component a has no CUDA
         // attribute (OpenACC use_device(b) + doit(b%a)), not only from the
@@ -2888,6 +2890,7 @@ static int GetMatchingDistance(const common::LanguageFeatureControl &features,
           }
         }
       } else if (const auto *actualLastSymbol{evaluate::GetLastSymbol(*expr)}) {
+        actualCanUseCudaMemoryMode = true;
         const Symbol &resolved{
             semantics::ResolveAssociations(*actualLastSymbol)};
         if (const auto *actualObject{
@@ -2925,7 +2928,7 @@ static int GetMatchingDistance(const common::LanguageFeatureControl &features,
 
   if (!dummyDataAttr) {
     if (!actualDataAttr) {
-      if (isCudaUnified || isCudaManaged) {
+      if ((isCudaUnified || isCudaManaged) && actualCanUseCudaMemoryMode) {
         return 3;
       }
       return 0;
@@ -2937,7 +2940,7 @@ static int GetMatchingDistance(const common::LanguageFeatureControl &features,
     }
   } else if (*dummyDataAttr == common::CUDADataAttr::Device) {
     if (!actualDataAttr) {
-      if (isCudaUnified || isCudaManaged) {
+      if ((isCudaUnified || isCudaManaged) && actualCanUseCudaMemoryMode) {
         return 2;
       }
       return cudaInfMatchingValue;
@@ -2949,6 +2952,9 @@ static int GetMatchingDistance(const common::LanguageFeatureControl &features,
     }
   } else if (*dummyDataAttr == common::CUDADataAttr::Managed) {
     if (!actualDataAttr) {
+      if (!actualCanUseCudaMemoryMode) {
+        return cudaInfMatchingValue;
+      }
       return isCudaUnified ? 1 : isCudaManaged ? 0 : cudaInfMatchingValue;
     }
     if (actualIsDeviceMemory()) {
@@ -2960,6 +2966,9 @@ static int GetMatchingDistance(const common::LanguageFeatureControl &features,
     }
   } else if (*dummyDataAttr == common::CUDADataAttr::Unified) {
     if (!actualDataAttr) {
+      if (!actualCanUseCudaMemoryMode) {
+        return cudaInfMatchingValue;
+      }
       return isCudaUnified ? 0 : isCudaManaged ? 1 : cudaInfMatchingValue;
     }
     if (actualIsDeviceMemory()) {

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -2872,11 +2872,13 @@ static int GetMatchingDistance(const common::LanguageFeatureControl &features,
   CHECK(!(isCudaUnified && isCudaManaged) && "expect only one enabled.");
 
   std::optional<common::CUDADataAttr> actualDataAttr, dummyDataAttr;
-  bool actualCanUseCudaMemoryMode{false};
+  // True when an unattributed actual may use the implicit CUDA memory mode
+  // matching enabled by -gpu=mem:unified or -gpu=mem:managed.
+  bool actualCanUseImplicitCudaMemoryMode{false};
   if (actual) {
     if (auto *expr{actual->UnwrapExpr()}) {
       if (evaluate::IsVariable(*expr)) {
-        actualCanUseCudaMemoryMode = true;
+        actualCanUseImplicitCudaMemoryMode = true;
         // Match check-call.cpp: walk the whole designator so e.g. b%a picks up
         // ATTRIBUTES(DEVICE) from the base b when the component a has no CUDA
         // attribute (OpenACC use_device(b) + doit(b%a)), not only from the
@@ -2890,7 +2892,7 @@ static int GetMatchingDistance(const common::LanguageFeatureControl &features,
           }
         }
       } else if (const auto *actualLastSymbol{evaluate::GetLastSymbol(*expr)}) {
-        actualCanUseCudaMemoryMode = true;
+        actualCanUseImplicitCudaMemoryMode = true;
         const Symbol &resolved{
             semantics::ResolveAssociations(*actualLastSymbol)};
         if (const auto *actualObject{
@@ -2928,7 +2930,8 @@ static int GetMatchingDistance(const common::LanguageFeatureControl &features,
 
   if (!dummyDataAttr) {
     if (!actualDataAttr) {
-      if ((isCudaUnified || isCudaManaged) && actualCanUseCudaMemoryMode) {
+      if ((isCudaUnified || isCudaManaged) &&
+          actualCanUseImplicitCudaMemoryMode) {
         return 3;
       }
       return 0;
@@ -2940,7 +2943,8 @@ static int GetMatchingDistance(const common::LanguageFeatureControl &features,
     }
   } else if (*dummyDataAttr == common::CUDADataAttr::Device) {
     if (!actualDataAttr) {
-      if ((isCudaUnified || isCudaManaged) && actualCanUseCudaMemoryMode) {
+      if ((isCudaUnified || isCudaManaged) &&
+          actualCanUseImplicitCudaMemoryMode) {
         return 2;
       }
       return cudaInfMatchingValue;
@@ -2952,7 +2956,7 @@ static int GetMatchingDistance(const common::LanguageFeatureControl &features,
     }
   } else if (*dummyDataAttr == common::CUDADataAttr::Managed) {
     if (!actualDataAttr) {
-      if (!actualCanUseCudaMemoryMode) {
+      if (!actualCanUseImplicitCudaMemoryMode) {
         return cudaInfMatchingValue;
       }
       return isCudaUnified ? 1 : isCudaManaged ? 0 : cudaInfMatchingValue;
@@ -2966,7 +2970,7 @@ static int GetMatchingDistance(const common::LanguageFeatureControl &features,
     }
   } else if (*dummyDataAttr == common::CUDADataAttr::Unified) {
     if (!actualDataAttr) {
-      if (!actualCanUseCudaMemoryMode) {
+      if (!actualCanUseImplicitCudaMemoryMode) {
         return cudaInfMatchingValue;
       }
       return isCudaUnified ? 0 : isCudaManaged ? 1 : cudaInfMatchingValue;

--- a/flang/test/Semantics/cuf-generic-literal-host.cuf
+++ b/flang/test/Semantics/cuf-generic-literal-host.cuf
@@ -1,0 +1,34 @@
+! RUN: %flang_fc1 -emit-hlfir -fcuda -fopenacc -gpu=unified %s -o - | FileCheck %s
+
+! Literal scalar actuals are host temporaries even under -gpu=mem:unified.
+! They must not make a device-scalar pointer-mode specific win when the
+! remaining actuals are device addresses from host_data use_device.
+
+module fake_pointer_mode
+  interface gemm_like
+    subroutine selected_dpm(alpha, a, beta, c) bind(C, name='selected_dpm')
+      !dir$ ignore_tkr (tr) a, (tr) c
+      real(8), device :: alpha, beta
+      real(8), device :: a(*), c(*)
+    end subroutine
+
+    subroutine selected_hpm(alpha, a, beta, c) bind(C, name='selected_hpm')
+      !dir$ ignore_tkr (tr) a, (tr) c
+      real(8) :: alpha, beta
+      real(8), device :: a(*), c(*)
+    end subroutine
+  end interface
+end module
+
+subroutine caller(a, c)
+  use fake_pointer_mode
+  real(8) :: a(*), c(*)
+
+  !$acc host_data use_device(a, c)
+  call gemm_like(1.d0, a, 0.d0, c)
+  !$acc end host_data
+end subroutine
+
+! CHECK-LABEL: func.func @_QPcaller
+! CHECK: fir.call @selected_hpm
+! CHECK-NOT: fir.call @selected_dpm

--- a/flang/test/Semantics/cuf-generic-literal-host.cuf
+++ b/flang/test/Semantics/cuf-generic-literal-host.cuf
@@ -1,4 +1,4 @@
-! RUN: %flang_fc1 -emit-hlfir -fcuda -fopenacc -gpu=unified %s -o - | FileCheck %s
+! RUN: bbc -emit-hlfir -fcuda -fopenacc -gpu=unified %s -o - | FileCheck %s
 
 ! Literal scalar actuals are host temporaries even under -gpu=mem:unified.
 ! They must not make a device-scalar pointer-mode specific win when the

--- a/flang/test/Semantics/cuf28.cuf
+++ b/flang/test/Semantics/cuf28.cuf
@@ -1,0 +1,37 @@
+! RUN: bbc -emit-hlfir -fcuda -gpu=unified %s -o - | FileCheck %s
+
+! Under -gpu=mem:unified, an unattributed host scalar is still an exact match
+! for an unattributed dummy. A device dummy remains compatible as a fallback,
+! but it must not beat the host-specific overload during generic resolution.
+module matching_host_scalar_unified
+  interface pick
+    module procedure host_scalar
+    module procedure device_scalar
+  end interface
+  interface device_fallback
+    module procedure device_scalar
+  end interface
+contains
+  subroutine host_scalar(a, x)
+    real(8), device :: a(:)
+    real(4) :: x
+  end
+
+  subroutine device_scalar(a, x)
+    real(8), device :: a(:)
+    real(4), device :: x
+  end
+end module
+
+program test
+  use matching_host_scalar_unified
+  real(8), device :: a(1)
+  real(4) :: x
+
+  call pick(a, 1.0)
+  call device_fallback(a, x)
+end
+
+! CHECK-LABEL: func.func @_QQmain()
+! CHECK: fir.call @_QMmatching_host_scalar_unifiedPhost_scalar
+! CHECK: fir.call @_QMmatching_host_scalar_unifiedPdevice_scalar


### PR DESCRIPTION
Fix CUDA generic resolution under `-gpu=mem:unified` so unattributed literals and expression temporaries are not treated as unified-memory actuals.

Previously, a host scalar literal such as `1.0` could score as compatible with a `DEVICE` dummy and incorrectly select the device-scalar overload. This could pass a host stack address to a device helper and fail at runtime. The fix applies the unified/managed memory distance columns only to symbol-backed actuals.