### PR TITLE
[Hexagon] Skip CRT start files for relocatable (-r) links on musl

### DIFF
--- a/clang/lib/Driver/ToolChains/Hexagon.cpp
+++ b/clang/lib/Driver/ToolChains/Hexagon.cpp
@@ -336,14 +336,15 @@ constructHexagonLinkArgs(Compilation &C, const JobAction &JA,
   CmdArgs.push_back(Output.getFilename());
 
   if (HTC.getTriple().isMusl()) {
-    if (!Args.hasArg(options::OPT_shared, options::OPT_static))
+    if (!Args.hasArg(options::OPT_shared, options::OPT_static, options::OPT_r))
       CmdArgs.push_back("-dynamic-linker=/lib/ld-musl-hexagon.so.1");
 
     if (!Args.hasArg(options::OPT_shared, options::OPT_nostartfiles,
-                     options::OPT_nostdlib))
+                     options::OPT_nostdlib, options::OPT_r))
       CmdArgs.push_back(Args.MakeArgString(D.SysRoot + "/usr/lib/crt1.o"));
     else if (Args.hasArg(options::OPT_shared) &&
-             !Args.hasArg(options::OPT_nostartfiles, options::OPT_nostdlib))
+             !Args.hasArg(options::OPT_nostartfiles, options::OPT_nostdlib,
+                          options::OPT_r))
       CmdArgs.push_back(Args.MakeArgString(D.SysRoot + "/usr/lib/crti.o"));
 
     if (!HTC.getSelectedMultilibs().empty() &&

--- a/clang/test/Driver/hexagon-toolchain-linux.c
+++ b/clang/test/Driver/hexagon-toolchain-linux.c
@@ -182,6 +182,25 @@
 // CHECK-PIE-RELOCATABLE-NOT:  "-pie"
 
 // -----------------------------------------------------------------------------
+// Relocatable (-r) links: no CRT start files, no dynamic linker
+// Partial links must not include crt1.o/crti.o — they define _start which
+// would conflict when the relocatable output is later linked into an executable.
+// -----------------------------------------------------------------------------
+// RUN: %clang -### --target=hexagon-unknown-linux-musl \
+// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree -r %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-RELOC %s
+// CHECK-RELOC-NOT: "-dynamic-linker={{/|\\\\}}lib{{/|\\\\}}ld-musl-hexagon.so.1"
+// CHECK-RELOC-NOT: "{{.*}}crt1.o"
+// CHECK-RELOC-NOT: "{{.*}}crti.o"
+
+// Verify that a normal (non-relocatable) link still gets the CRT files.
+// RUN: %clang -### --target=hexagon-unknown-linux-musl \
+// RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-RELOC-NORMAL %s
+// CHECK-RELOC-NORMAL: "-dynamic-linker={{/|\\\\}}lib{{/|\\\\}}ld-musl-hexagon.so.1"
+// CHECK-RELOC-NORMAL: "{{.*}}crt1.o"
+
+// -----------------------------------------------------------------------------
 // Sanitizer library paths: -fsanitize=memory
 // -----------------------------------------------------------------------------
 // RUN: %clang -### --target=hexagon-unknown-linux-musl \


### PR DESCRIPTION
Guard the dynamic-linker, crt1.o, and crti.o additions with OPT_r, consistent with Gnu.cpp and the existing -pie suppression in this file. CRT start files must not appear in partial links (-r) as they define _start, causing duplicate-symbol errors when the output is later linked into an executable.