### PR TITLE
[clangd] Handle dependent call to function with explicit object parameter in InlayHintVisitor

### DIFF
--- a/clang-tools-extra/clangd/InlayHints.cpp
+++ b/clang-tools-extra/clangd/InlayHints.cpp
@@ -492,7 +492,8 @@ public:
     // either.
     if (const CXXMethodDecl *Method =
             dyn_cast_or_null<CXXMethodDecl>(Callee.Decl))
-      if (IsFunctor || Method->hasCXXExplicitFunctionObjectParameter())
+      if (IsFunctor || (!E->isTypeDependent() &&
+                        Method->hasCXXExplicitFunctionObjectParameter()))
         Args = Args.drop_front(1);
     processCall(Callee, E->getRParenLoc(), Args);
     return true;

--- a/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
+++ b/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
@@ -890,6 +890,21 @@ TEST(ParameterHints, DeducingThis) {
                        ExpectedHint{"Param: ", "3"}, ExpectedHint{"C: ", "4"});
 }
 
+TEST(ParameterHints, DependentDeducingThis) {
+  assertParameterHints(R"cpp(
+   template <typename T>
+   struct S {
+      void f1(this S& obj);
+      void f2(this S& obj, int x, int y);
+      void g(S s) {
+        s.f1();  // no crash
+        s.f2($x[[42]], $y[[43]]);
+      }
+    };
+  )cpp",
+                       ExpectedHint{"x: ", "x"}, ExpectedHint{"y: ", "y"});
+}
+
 TEST(ParameterHints, Macros) {
   // Handling of macros depends on where the call's argument list comes from.
 


### PR DESCRIPTION
Dependent calls do not yet have the implicit object argument preprended to the CallExpr's argument list, so the first argument should not be expected to be present and dropped in this case.

Fixes https://github.com/llvm/llvm-project/issues/198588