### PR TITLE
[RISCV] Enable GP relaxation for Linux

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -812,6 +812,7 @@ RISC-V Support
 - Tenstorrent Ascalon D8 was renamed to Ascalon X. Use `tt-ascalon-x` with `-mcpu` or `-mtune`.
 - Intrinsics were added for the 'Zvabd` (RISC-V Integer Vector Absolute Difference) extension.
 - Intrinsics were added for the 'Zvzip` (Reordering Structured Data in Vector Registers) extension.
+- GP relaxation was enabled by default on Linux.
 
 CUDA/HIP Language Changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -343,6 +343,16 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back("--no-relax");
   }
 
+  // Default-enable LLD's --relax-gp for RISC-V on Linux when LLD is used and
+  // linker relaxation is not disabled by -mno-relax.
+  if (Triple.isRISCV() && Triple.isOSLinux()) {
+    bool IsLLD = false;
+    ToolChain.GetLinkerPath(&IsLLD);
+    if (IsLLD &&
+        Args.hasFlag(options::OPT_mrelax, options::OPT_mno_relax, true))
+      CmdArgs.push_back("--relax-gp");
+  }
+
   const bool IsShared = Args.hasArg(options::OPT_shared);
   if (IsShared)
     CmdArgs.push_back("-shared");

--- a/clang/test/Driver/riscv32-toolchain.c
+++ b/clang/test/Driver/riscv32-toolchain.c
@@ -247,6 +247,31 @@
 // RUN:   | FileCheck -check-prefix=CHECK-RV32-GNU-RELAX %s
 // CHECK-RV32-GNU-RELAX-NOT: "--no-relax"
 
+/// Check that "--relax-gp" is forwarded to LLD for RISC-V on Linux by default.
+// RUN: %clang -### %s -fuse-ld=lld -B%S/Inputs/lld -no-pie \
+// RUN:   --target=riscv32-unknown-linux-gnu --rtlib=platform --unwindlib=platform -mabi=ilp32 \
+// RUN:   --gcc-toolchain=%S/Inputs/multilib_riscv_linux_sdk \
+// RUN:   --sysroot=%S/Inputs/multilib_riscv_linux_sdk/sysroot 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-RV32-LLD-RELAXGP %s
+// CHECK-RV32-LLD-RELAXGP: "--relax-gp"
+
+/// Check that "--relax-gp" is NOT forwarded to GNU ld for RISC-V on Linux.
+// RUN: env "PATH=" %clang -### %s -fuse-ld=ld -no-pie \
+// RUN:   --target=riscv32-unknown-linux-gnu --rtlib=platform --unwindlib=platform -mabi=ilp32 \
+// RUN:   --gcc-toolchain=%S/Inputs/multilib_riscv_linux_sdk \
+// RUN:   --sysroot=%S/Inputs/multilib_riscv_linux_sdk/sysroot 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-RV32-GNU-NO-RELAXGP %s
+// CHECK-RV32-GNU-NO-RELAXGP-NOT: "--relax-gp"
+
+/// Check that "--relax-gp" is NOT forwarded to LLD when -mno-relax is set.
+// RUN: %clang -### %s -fuse-ld=lld -B%S/Inputs/lld -no-pie -mno-relax \
+// RUN:   --target=riscv32-unknown-linux-gnu --rtlib=platform --unwindlib=platform -mabi=ilp32 \
+// RUN:   --gcc-toolchain=%S/Inputs/multilib_riscv_linux_sdk \
+// RUN:   --sysroot=%S/Inputs/multilib_riscv_linux_sdk/sysroot 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-RV32-LLD-NORELAX-NOGP %s
+// CHECK-RV32-LLD-NORELAX-NOGP: "--no-relax"
+// CHECK-RV32-LLD-NORELAX-NOGP-NOT: "--relax-gp"
+
 /// Check that "-static -pie" is forwarded to linker when "-static-pie" is used
 // RUN: %clang -static-pie -### %s -fuse-ld= \
 // RUN:   --target=riscv32-unknown-elf -rtlib=platform --unwindlib=platform \

--- a/clang/test/Driver/riscv64-toolchain.c
+++ b/clang/test/Driver/riscv64-toolchain.c
@@ -203,6 +203,31 @@
 // RUN:   | FileCheck -check-prefix=CHECK-RV64-GNU-RELAX %s
 // CHECK-RV64-GNU-RELAX-NOT: "--no-relax"
 
+/// Check that "--relax-gp" is forwarded to LLD for RISC-V on Linux by default.
+// RUN: %clang -### %s -fuse-ld=lld -B%S/Inputs/lld -no-pie \
+// RUN:   --target=riscv64-unknown-linux-gnu --rtlib=platform --unwindlib=platform -mabi=lp64 \
+// RUN:   --gcc-toolchain=%S/Inputs/multilib_riscv_linux_sdk \
+// RUN:   --sysroot=%S/Inputs/multilib_riscv_linux_sdk/sysroot 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-RV64-LLD-RELAXGP %s
+// CHECK-RV64-LLD-RELAXGP: "--relax-gp"
+
+/// Check that "--relax-gp" is NOT forwarded to GNU ld for RISC-V on Linux.
+// RUN: env "PATH=" %clang -### %s -fuse-ld=ld -no-pie \
+// RUN:   --target=riscv64-unknown-linux-gnu --rtlib=platform --unwindlib=platform -mabi=lp64 \
+// RUN:   --gcc-toolchain=%S/Inputs/multilib_riscv_linux_sdk \
+// RUN:   --sysroot=%S/Inputs/multilib_riscv_linux_sdk/sysroot 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-RV64-GNU-NO-RELAXGP %s
+// CHECK-RV64-GNU-NO-RELAXGP-NOT: "--relax-gp"
+
+/// Check that "--relax-gp" is NOT forwarded to LLD when -mno-relax is set.
+// RUN: %clang -### %s -fuse-ld=lld -B%S/Inputs/lld -no-pie -mno-relax \
+// RUN:   --target=riscv64-unknown-linux-gnu --rtlib=platform --unwindlib=platform -mabi=lp64 \
+// RUN:   --gcc-toolchain=%S/Inputs/multilib_riscv_linux_sdk \
+// RUN:   --sysroot=%S/Inputs/multilib_riscv_linux_sdk/sysroot 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK-RV64-LLD-NORELAX-NOGP %s
+// CHECK-RV64-LLD-NORELAX-NOGP: "--no-relax"
+// CHECK-RV64-LLD-NORELAX-NOGP-NOT: "--relax-gp"
+
 /// Check that "-static -pie" is forwarded to linker when "-static-pie" is used
 // RUN: %clang -static-pie -### %s -fuse-ld= \
 // RUN:   --target=riscv64-unknown-elf -rtlib=platform --unwindlib=platform \


### PR DESCRIPTION
We have supported GP relaxation in https://reviews.llvm.org/D143673
for a long time, but we made it disabled by default.

This PR enables it in Clang driver when targeting Linux.

(Please remind me if I missed the context why we disabled it on Linux).
