### PR TITLE
[orc-rt] Add required/weak-ref attribute to NativeDylibManager lookup.

### DIFF
--- a/orc-rt/include/orc-rt/NativeDylibManager.h
+++ b/orc-rt/include/orc-rt/NativeDylibManager.h
@@ -28,6 +28,9 @@ class Session;
 /// from load().
 class NativeDylibManager : public Service {
 public:
+  enum LookupFlags { RequiredSymbol, WeaklyReferencedSymbol };
+  using SymbolLookupSet = std::vector<std::pair<std::string, LookupFlags>>;
+
   /// Create a NativeDylibManager, adding associated symbols to the given
   /// SimpleSymbolTable (typically the BootstrapInfo table).
   static Expected<std::unique_ptr<NativeDylibManager>>
@@ -56,13 +59,16 @@ public:
   using OnLoadCompleteFn = move_only_function<void(Expected<void *>)>;
   void load(OnLoadCompleteFn &&OnComplete, std::string Path);
 
-  /// Lookup addresses of the given symbols.
+  /// Lookup addresses of the given symbols in the given library.
   ///
-  /// Returns a sequence of addresses.
+  /// Each entry in Symbols pairs a name with a flag indicating whether the
+  /// symbol is required or weakly referenced. A missing required symbol
+  /// causes lookup to fail with an error. A missing weakly-referenced symbol
+  /// is returned as a zero address.
   using OnLookupCompleteFn =
       move_only_function<void(Expected<std::vector<void *>>)>;
   void lookup(OnLookupCompleteFn &&OnLookupComplete, void *Handle,
-              std::vector<std::string> Names);
+              SymbolLookupSet Symbols);
 
   void onDetach(Service::OnCompleteFn OnComplete,
                 bool ShutdownRequested) override;

--- a/orc-rt/lib/executor/NativeDylibManager.cpp
+++ b/orc-rt/lib/executor/NativeDylibManager.cpp
@@ -59,8 +59,32 @@ void NativeDylibManager::load(OnLoadCompleteFn &&OnComplete, std::string Path) {
 }
 
 void NativeDylibManager::lookup(OnLookupCompleteFn &&OnLookupComplete,
-                                void *Handle, std::vector<std::string> Names) {
-  OnLookupComplete(hostOSLibraryLookup(Handle, Names));
+                                void *Handle, SymbolLookupSet Symbols) {
+  std::vector<std::string> Names;
+  Names.reserve(Symbols.size());
+  for (auto &S : Symbols)
+    Names.push_back(std::move(S.first));
+
+  auto Addrs = hostOSLibraryLookup(Handle, Names);
+
+  bool HasMissing = false;
+  std::ostringstream ErrMsg;
+  for (size_t I = 0, E = Symbols.size(); I != E; ++I) {
+    if (Addrs[I] == nullptr && Symbols[I].second == RequiredSymbol) {
+      if (!HasMissing) {
+        ErrMsg << "Required symbols {";
+        HasMissing = true;
+      }
+      ErrMsg << " \"" << Names[I] << "\"";
+    }
+  }
+  if (HasMissing) {
+    ErrMsg << " } not found";
+    OnLookupComplete(make_error<StringError>(ErrMsg.str()));
+    return;
+  }
+
+  OnLookupComplete(std::move(Addrs));
 }
 
 void NativeDylibManager::onDetach(Service::OnCompleteFn OnComplete,

--- a/orc-rt/lib/executor/sps-ci/NativeDylibManagerSPSCI.cpp
+++ b/orc-rt/lib/executor/sps-ci/NativeDylibManagerSPSCI.cpp
@@ -14,6 +14,37 @@
 #include "orc-rt/NativeDylibManager.h"
 #include "orc-rt/SPSWrapperFunction.h"
 
+namespace orc_rt {
+
+/// SPS serialization for NativeDylibManager::LookupFlags as a bool.
+///
+/// RequiredSymbol serializes as true, WeaklyReferencedSymbol as false. This
+/// matches the wire format of llvm::orc::RemoteSymbolLookupSetElement, which
+/// uses a bool 'Required' field.
+template <>
+class SPSSerializationTraits<bool, NativeDylibManager::LookupFlags> {
+public:
+  static size_t size(NativeDylibManager::LookupFlags) { return sizeof(bool); }
+
+  static bool serialize(SPSOutputBuffer &OB,
+                        NativeDylibManager::LookupFlags L) {
+    return SPSSerializationTraits<bool, bool>::serialize(
+        OB, L == NativeDylibManager::RequiredSymbol);
+  }
+
+  static bool deserialize(SPSInputBuffer &IB,
+                          NativeDylibManager::LookupFlags &L) {
+    bool Required;
+    if (!SPSSerializationTraits<bool, bool>::deserialize(IB, Required))
+      return false;
+    L = Required ? NativeDylibManager::RequiredSymbol
+                 : NativeDylibManager::WeaklyReferencedSymbol;
+    return true;
+  }
+};
+
+} // namespace orc_rt
+
 namespace orc_rt::sps_ci {
 
 ORC_RT_SPS_WRAPPER(
@@ -23,8 +54,9 @@ ORC_RT_SPS_WRAPPER(
 
 ORC_RT_SPS_WRAPPER(
     orc_rt_ci_sps_NativeDylibManager_lookup,
-    SPSExpected<SPSSequence<SPSExecutorAddr>>(SPSExecutorAddr, SPSExecutorAddr,
-                                              SPSSequence<SPSString>),
+    SPSExpected<SPSSequence<SPSExecutorAddr>>(
+        SPSExecutorAddr, SPSExecutorAddr,
+        SPSSequence<SPSTuple<SPSString, bool>>),
     WrapperFunction::handleWithAsyncMethod(&NativeDylibManager::lookup))
 
 static std::pair<const char *, const void *>

--- a/orc-rt/unittests/NativeDylibManagerSPSCITest.cpp
+++ b/orc-rt/unittests/NativeDylibManagerSPSCITest.cpp
@@ -21,6 +21,43 @@
 
 using namespace orc_rt;
 
+namespace orc_rt {
+
+/// SPS serialization for NativeDylibManager::LookupFlags as a bool.
+///
+/// Duplicated from NativeDylibManagerSPSCI.cpp so the test can serialize
+/// SymbolLookupSet values when invoking the SPS wrapper via
+/// SPSWrapperFunction<...>::call.
+template <>
+class SPSSerializationTraits<bool, NativeDylibManager::LookupFlags> {
+public:
+  static size_t size(NativeDylibManager::LookupFlags) { return sizeof(bool); }
+
+  static bool serialize(SPSOutputBuffer &OB,
+                        NativeDylibManager::LookupFlags L) {
+    return SPSSerializationTraits<bool, bool>::serialize(
+        OB, L == NativeDylibManager::RequiredSymbol);
+  }
+
+  static bool deserialize(SPSInputBuffer &IB,
+                          NativeDylibManager::LookupFlags &L) {
+    bool Required;
+    if (!SPSSerializationTraits<bool, bool>::deserialize(IB, Required))
+      return false;
+    L = Required ? NativeDylibManager::RequiredSymbol
+                 : NativeDylibManager::WeaklyReferencedSymbol;
+    return true;
+  }
+};
+
+} // namespace orc_rt
+
+namespace {
+// Local aliases for brevity in test bodies.
+constexpr auto Req = NativeDylibManager::RequiredSymbol;
+constexpr auto Weak = NativeDylibManager::WeaklyReferencedSymbol;
+} // namespace
+
 #ifndef NDM_TEST_LIB_PATH
 #error                                                                         \
     "NDM_TEST_LIB_PATH must be defined to the path of the test shared library"
@@ -49,13 +86,14 @@ protected:
 
   template <typename OnCompleteFn>
   void spsLookup(OnCompleteFn &&OnComplete, void *Handle,
-                 std::vector<std::string> Names) {
+                 NativeDylibManager::SymbolLookupSet Symbols) {
     using SPSSig = SPSExpected<SPSSequence<SPSExecutorAddr>>(
-        SPSExecutorAddr, SPSExecutorAddr, SPSSequence<SPSString>);
+        SPSExecutorAddr, SPSExecutorAddr,
+        SPSSequence<SPSTuple<SPSString, bool>>);
     SPSWrapperFunction<SPSSig>::call(
         caller("orc_rt_ci_sps_NativeDylibManager_lookup"),
         std::forward<OnCompleteFn>(OnComplete), NDM.get(), Handle,
-        std::move(Names));
+        std::move(Symbols));
   }
 
   SimpleSymbolTable CI;
@@ -89,7 +127,8 @@ TEST_F(NativeDylibManagerSPSCITest, LookupSingleSymbol) {
   void *Handle = cantFail(cantFail(LoadResult.get()));
 
   std::future<Expected<Expected<std::vector<void *>>>> LookupResult;
-  spsLookup(waitFor(LookupResult), Handle, {"NativeDylibManagerTestFunc"});
+  spsLookup(waitFor(LookupResult), Handle,
+            {{"NativeDylibManagerTestFunc", Req}});
   auto Addrs = cantFail(cantFail(LookupResult.get()));
   ASSERT_EQ(Addrs.size(), 1U);
   EXPECT_NE(Addrs[0], nullptr);
@@ -105,7 +144,8 @@ TEST_F(NativeDylibManagerSPSCITest, LookupMultipleSymbols) {
 
   std::future<Expected<Expected<std::vector<void *>>>> LookupResult;
   spsLookup(waitFor(LookupResult), Handle,
-            {"NativeDylibManagerTestFunc", "NativeDylibManagerTestFunc2"});
+            {{"NativeDylibManagerTestFunc", Req},
+             {"NativeDylibManagerTestFunc2", Req}});
   auto Addrs = cantFail(cantFail(LookupResult.get()));
   ASSERT_EQ(Addrs.size(), 2U);
   EXPECT_NE(Addrs[0], nullptr);
@@ -117,14 +157,40 @@ TEST_F(NativeDylibManagerSPSCITest, LookupMultipleSymbols) {
   EXPECT_EQ(Func2(), 7);
 }
 
-TEST_F(NativeDylibManagerSPSCITest, LookupNonExistentSymbol) {
+TEST_F(NativeDylibManagerSPSCITest, LookupWeakMissingSymbol) {
   std::future<Expected<Expected<void *>>> LoadResult;
   spsLoad(waitFor(LoadResult), NDM_TEST_LIB_PATH);
   void *Handle = cantFail(cantFail(LoadResult.get()));
 
   std::future<Expected<Expected<std::vector<void *>>>> LookupResult;
-  spsLookup(waitFor(LookupResult), Handle, {"no_such_symbol"});
+  spsLookup(waitFor(LookupResult), Handle, {{"no_such_symbol", Weak}});
   auto Addrs = cantFail(cantFail(LookupResult.get()));
   ASSERT_EQ(Addrs.size(), 1U);
   EXPECT_EQ(Addrs[0], nullptr);
+}
+
+TEST_F(NativeDylibManagerSPSCITest, LookupRequiredMissingSymbol) {
+  std::future<Expected<Expected<void *>>> LoadResult;
+  spsLoad(waitFor(LoadResult), NDM_TEST_LIB_PATH);
+  void *Handle = cantFail(cantFail(LoadResult.get()));
+
+  std::future<Expected<Expected<std::vector<void *>>>> LookupResult;
+  spsLookup(waitFor(LookupResult), Handle, {{"no_such_symbol", Req}});
+  auto Addrs = cantFail(LookupResult.get());
+  EXPECT_FALSE(!!Addrs);
+  consumeError(Addrs.takeError());
+}
+
+TEST_F(NativeDylibManagerSPSCITest, LookupMixedRequiredAndWeak) {
+  std::future<Expected<Expected<void *>>> LoadResult;
+  spsLoad(waitFor(LoadResult), NDM_TEST_LIB_PATH);
+  void *Handle = cantFail(cantFail(LoadResult.get()));
+
+  std::future<Expected<Expected<std::vector<void *>>>> LookupResult;
+  spsLookup(waitFor(LookupResult), Handle,
+            {{"NativeDylibManagerTestFunc", Req}, {"no_such_symbol", Weak}});
+  auto Addrs = cantFail(cantFail(LookupResult.get()));
+  ASSERT_EQ(Addrs.size(), 2U);
+  EXPECT_NE(Addrs[0], nullptr);
+  EXPECT_EQ(Addrs[1], nullptr);
 }

--- a/orc-rt/unittests/NativeDylibManagerTest.cpp
+++ b/orc-rt/unittests/NativeDylibManagerTest.cpp
@@ -21,6 +21,12 @@
 
 using namespace orc_rt;
 
+namespace {
+// Local aliases for brevity in test bodies.
+constexpr auto Req = NativeDylibManager::RequiredSymbol;
+constexpr auto Weak = NativeDylibManager::WeaklyReferencedSymbol;
+} // namespace
+
 #ifndef NDM_TEST_LIB_PATH
 #error                                                                         \
     "NDM_TEST_LIB_PATH must be defined to the path of the test shared library"
@@ -36,10 +42,10 @@ static Expected<void *> syncLoad(NativeDylibManager &NDM, std::string Path) {
 // Helper: synchronously run lookup and return results.
 static Expected<std::vector<void *>>
 syncLookup(NativeDylibManager &NDM, void *Handle,
-           std::vector<std::string> Names) {
+           NativeDylibManager::SymbolLookupSet Symbols) {
   std::optional<Expected<std::vector<void *>>> Result;
   NDM.lookup([&](Expected<std::vector<void *>> R) { Result = std::move(R); },
-             Handle, std::move(Names));
+             Handle, std::move(Symbols));
   return std::move(*Result);
 }
 
@@ -81,7 +87,7 @@ TEST(NativeDylibManagerTest, LookupSingleSymbol) {
 
   void *Handle = cantFail(syncLoad(*NDM, NDM_TEST_LIB_PATH));
 
-  auto Result = syncLookup(*NDM, Handle, {"NativeDylibManagerTestFunc"});
+  auto Result = syncLookup(*NDM, Handle, {{"NativeDylibManagerTestFunc", Req}});
   ASSERT_TRUE(!!Result) << toString(Result.takeError());
   ASSERT_EQ(Result->size(), 1U);
   EXPECT_NE((*Result)[0], nullptr);
@@ -99,9 +105,9 @@ TEST(NativeDylibManagerTest, LookupMultipleSymbols) {
 
   void *Handle = cantFail(syncLoad(*NDM, NDM_TEST_LIB_PATH));
 
-  auto Result =
-      syncLookup(*NDM, Handle,
-                 {"NativeDylibManagerTestFunc", "NativeDylibManagerTestFunc2"});
+  auto Result = syncLookup(*NDM, Handle,
+                           {{"NativeDylibManagerTestFunc", Req},
+                            {"NativeDylibManagerTestFunc2", Req}});
   ASSERT_TRUE(!!Result) << toString(Result.takeError());
   ASSERT_EQ(Result->size(), 2U);
   EXPECT_NE((*Result)[0], nullptr);
@@ -113,7 +119,7 @@ TEST(NativeDylibManagerTest, LookupMultipleSymbols) {
   EXPECT_EQ(Func2(), 7);
 }
 
-TEST(NativeDylibManagerTest, LookupNonExistentSymbol) {
+TEST(NativeDylibManagerTest, LookupWeakMissingSymbol) {
   Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
             noErrors);
   SimpleSymbolTable ST;
@@ -121,8 +127,40 @@ TEST(NativeDylibManagerTest, LookupNonExistentSymbol) {
 
   void *Handle = cantFail(syncLoad(*NDM, NDM_TEST_LIB_PATH));
 
-  auto Result = syncLookup(*NDM, Handle, {"no_such_symbol"});
+  auto Result = syncLookup(*NDM, Handle, {{"no_such_symbol", Weak}});
   ASSERT_TRUE(!!Result) << toString(Result.takeError());
   ASSERT_EQ(Result->size(), 1U);
   EXPECT_EQ((*Result)[0], nullptr);
+}
+
+TEST(NativeDylibManagerTest, LookupRequiredMissingSymbol) {
+  Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
+            noErrors);
+  SimpleSymbolTable ST;
+  auto NDM = cantFail(NativeDylibManager::Create(S, ST));
+
+  void *Handle = cantFail(syncLoad(*NDM, NDM_TEST_LIB_PATH));
+
+  auto Result = syncLookup(*NDM, Handle, {{"no_such_symbol", Req}});
+  EXPECT_FALSE(!!Result);
+  auto Msg = toString(Result.takeError());
+  EXPECT_NE(Msg.find("no_such_symbol"), std::string::npos)
+      << "error message should mention the missing symbol; got: " << Msg;
+}
+
+TEST(NativeDylibManagerTest, LookupMixedRequiredAndWeak) {
+  Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
+            noErrors);
+  SimpleSymbolTable ST;
+  auto NDM = cantFail(NativeDylibManager::Create(S, ST));
+
+  void *Handle = cantFail(syncLoad(*NDM, NDM_TEST_LIB_PATH));
+
+  auto Result = syncLookup(
+      *NDM, Handle,
+      {{"NativeDylibManagerTestFunc", Req}, {"no_such_symbol", Weak}});
+  ASSERT_TRUE(!!Result) << toString(Result.takeError());
+  ASSERT_EQ(Result->size(), 2U);
+  EXPECT_NE((*Result)[0], nullptr);
+  EXPECT_EQ((*Result)[1], nullptr);
 }


### PR DESCRIPTION
Replace the std::vector<std::string> argument to lookup() with a SymbolLookupSet (a vector of (name, LookupFlags) pairs, where LookupFlags is RequiredSymbol or WeaklyReferencedSymbol).

This brings NativeDylibManager more closely into alignment with the SimpleExecutorDylibManager implementation in the LLVM OrcTargetProcess library.