### PR TITLE
[clang-tidy] Avoid evaluating value-dependent static initializers in fuchsia-statically-constructed-objects

### DIFF
--- a/clang-tools-extra/clang-tidy/fuchsia/StaticallyConstructedObjectsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/fuchsia/StaticallyConstructedObjectsCheck.cpp
@@ -13,8 +13,9 @@ using namespace clang::ast_matchers;
 namespace clang::tidy::fuchsia {
 
 namespace {
-AST_MATCHER(Expr, isConstantInitializer) {
-  return Node.isConstantInitializer(Finder->getASTContext(), false);
+AST_MATCHER(Expr, isConstantInitializerOrValueDependent) {
+  return Node.isValueDependent() ||
+         Node.isConstantInitializer(Finder->getASTContext(), false);
 }
 
 AST_MATCHER(VarDecl, isGlobalStatic) {
@@ -35,8 +36,8 @@ void StaticallyConstructedObjectsCheck::registerMatchers(MatchFinder *Finder) {
                    hasDescendant(cxxConstructExpr(unless(allOf(
                        // ... unless it is constexpr ...
                        hasDeclaration(cxxConstructorDecl(isConstexpr())),
-                       // ... and is statically initialized.
-                       isConstantInitializer())))))
+                       // ... and is statically initialized or value-dependent.
+                       isConstantInitializerOrValueDependent())))))
                    .bind("decl")),
       this);
 }

--- a/clang-tools-extra/clang-tidy/fuchsia/StaticallyConstructedObjectsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/fuchsia/StaticallyConstructedObjectsCheck.cpp
@@ -13,9 +13,8 @@ using namespace clang::ast_matchers;
 namespace clang::tidy::fuchsia {
 
 namespace {
-AST_MATCHER(Expr, isConstantOrValueDependentInitializer) {
-  return Node.isValueDependent() ||
-         Node.isConstantInitializer(Finder->getASTContext(), false);
+AST_MATCHER(Expr, isConstantInitializer) {
+  return Node.isConstantInitializer(Finder->getASTContext(), false);
 }
 
 AST_MATCHER(VarDecl, isGlobalStatic) {
@@ -36,8 +35,8 @@ void StaticallyConstructedObjectsCheck::registerMatchers(MatchFinder *Finder) {
                    hasDescendant(cxxConstructExpr(unless(allOf(
                        // ... unless it is constexpr ...
                        hasDeclaration(cxxConstructorDecl(isConstexpr())),
-                       // ... and is a constant or value-dependent initializer.
-                       isConstantOrValueDependentInitializer())))))
+                       // ... and is statically initialized or value-dependent.
+                       anyOf(isValueDependent(), isConstantInitializer()))))))
                    .bind("decl")),
       this);
 }

--- a/clang-tools-extra/clang-tidy/fuchsia/StaticallyConstructedObjectsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/fuchsia/StaticallyConstructedObjectsCheck.cpp
@@ -13,7 +13,7 @@ using namespace clang::ast_matchers;
 namespace clang::tidy::fuchsia {
 
 namespace {
-AST_MATCHER(Expr, isConstantInitializerOrValueDependent) {
+AST_MATCHER(Expr, isConstantOrValueDependentInitializer) {
   return Node.isValueDependent() ||
          Node.isConstantInitializer(Finder->getASTContext(), false);
 }
@@ -36,8 +36,8 @@ void StaticallyConstructedObjectsCheck::registerMatchers(MatchFinder *Finder) {
                    hasDescendant(cxxConstructExpr(unless(allOf(
                        // ... unless it is constexpr ...
                        hasDeclaration(cxxConstructorDecl(isConstexpr())),
-                       // ... and is statically initialized or value-dependent.
-                       isConstantInitializerOrValueDependent())))))
+                       // ... and is a constant or value-dependent initializer.
+                       isConstantOrValueDependentInitializer())))))
                    .bind("decl")),
       this);
 }

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -511,6 +511,10 @@ Changes in existing checks
   `IgnoreMacros` option. When enabled, unscoped ``enum`` declarations within
   macros are ignored.
 
+- Improved :doc:`fuchsia-statically-constructed-objects
+  <clang-tidy/checks/fuchsia/statically-constructed-objects>` check by fixing a
+  crash when checking value-dependent static member initializers in class templates.
+
 - Improved :doc:`llvm-use-ranges
   <clang-tidy/checks/llvm/use-ranges>` check by adding support for the following
   algorithms: ``std::accumulate``, ``std::replace_copy``, and

--- a/clang-tools-extra/test/clang-tidy/checkers/fuchsia/statically-constructed-objects.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/fuchsia/statically-constructed-objects.cpp
@@ -81,6 +81,14 @@ static S s3(get_i());
 // CHECK-MESSAGES: [[@LINE-1]]:1: warning: static objects are disallowed; if possible, use a constexpr constructor instead [fuchsia-statically-constructed-objects]
 // CHECK-MESSAGES-NEXT:  static S s3(get_i());
 
+template <typename T, int Val>
+struct ClassTemplateWithStaticMember {
+  static S StaticMember;
+};
+
+template <typename T, int Val>
+S ClassTemplateWithStaticMember<T, Val>::StaticMember(Val);
+
 void f() {
   // Locally static is fine
   static int i;


### PR DESCRIPTION
Static data member initializers in class templates could crash the check when they used non-type template parameters. This commit skips them during analysis.

Closes https://github.com/llvm/llvm-project/issues/201110