### PR TITLE
[clang] Fix null buffer dereference in InitializeFileRemapping

### DIFF
--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -413,6 +413,13 @@ static void InitializeFileRemapping(DiagnosticsEngine &Diags,
                                     const PreprocessorOptions &InitOpts) {
   // Remap files in the source manager (with buffers).
   for (const auto &RB : InitOpts.RemappedFileBuffers) {
+    // Skip entries with a null buffer — this can occur when a module
+    // compilation fails partway through, leaving an uninitialized entry
+    // in RemappedFileBuffers. Treat it as a missing file and continue.
+    if (!RB.second) {
+      Diags.Report(diag::err_fe_remap_missing_to_file) << RB.first << "(null buffer)";
+      continue;
+    }
     // Create the file entry for the file that we're mapping from.
     FileEntryRef FromFile =
         FileMgr.getVirtualFileRef(RB.first, RB.second->getBufferSize(), 0);

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -417,7 +417,8 @@ static void InitializeFileRemapping(DiagnosticsEngine &Diags,
     // compilation fails partway through, leaving an uninitialized entry
     // in RemappedFileBuffers. Treat it as a missing file and continue.
     if (!RB.second) {
-      Diags.Report(diag::err_fe_remap_missing_to_file) << RB.first << "(null buffer)";
+      Diags.Report(diag::err_fe_remap_missing_to_file)
+          << RB.first << "(null buffer)";
       continue;
     }
     // Create the file entry for the file that we're mapping from.


### PR DESCRIPTION
When a module compilation fails partway through, a null buffer entry
can be left in `PreprocessorOptions::RemappedFileBuffers`. The existing
code in `InitializeFileRemapping` unconditionally dereferences `RB.second`
via `getBufferSize()` and `getMemBufferRef()`, causing a crash.

Add a null check consistent with the existing pattern in the
`RemappedFiles` loop below, which already checks for missing files
before use.

The crash was discovered by a fuzzer and reported with a clear stacktrace
showing the crash at `InitializeFileRemapping` line 424.

Fixes: https://github.com/llvm/llvm-project/issues/201188