### PR TITLE
[Flang-RT][test] Add flang-rt-mod dependency

### DIFF
--- a/flang-rt/test/CMakeLists.txt
+++ b/flang-rt/test/CMakeLists.txt
@@ -44,6 +44,7 @@ add_custom_target(flang-rt-test-depends)
 set_target_properties(flang-rt-test-depends PROPERTIES FOLDER "Flang-RT/Meta")
 add_dependencies(flang-rt-test-depends
     flang_rt.runtime
+    flang-rt-mod
   )
 if (TARGET flang_rt.quadmath)
   add_dependencies(flang-rt-test-depends


### PR DESCRIPTION
Flang-RT's tests require the modules since #198793. #171515 did not account for this additional dependency.

Fixes #201254