### PR TITLE
[clang][PowerPC] Enable IEEE-128 long double on FreeBSD/powerpc64le

### DIFF
--- a/clang/lib/Basic/Targets/PPC.cpp
+++ b/clang/lib/Basic/Targets/PPC.cpp
@@ -835,6 +835,14 @@ void PPCTargetInfo::adjust(DiagnosticsEngine &Diags, LangOptions &Opts,
   if (HasAltivec)
     Opts.AltiVec = 1;
   TargetInfo::adjust(Diags, Opts, Aux);
+  // FreeBSD >= 16 on ppc64le defaults to IEEE-128 long double and has no IBM
+  // double-double support, so enable it here unconditionally; this also drives
+  // the __LONG_DOUBLE_IEEE128__ predefine via getTargetDefines().
+  if (getTriple().isOSFreeBSD() &&
+      getTriple().getArch() == llvm::Triple::ppc64le &&
+      (getTriple().getOSMajorVersion() >= 16 ||
+       getTriple().getOSVersion().empty()))
+    Opts.PPCIEEELongDouble = true;
   if (LongDoubleFormat != &llvm::APFloat::IEEEdouble())
     LongDoubleFormat = Opts.PPCIEEELongDouble
                            ? &llvm::APFloat::IEEEquad()

--- a/clang/lib/Basic/Targets/PPC.h
+++ b/clang/lib/Basic/Targets/PPC.h
@@ -459,7 +459,14 @@ public:
       ABI = "elfv1";
     }
 
-    if (Triple.isOSFreeBSD() || Triple.isOSOpenBSD() || Triple.isMusl()) {
+    // FreeBSD >= 16 on ppc64le uses IEEE-128 long double (enabled in adjust());
+    // it never supported IBM double-double.  Older FreeBSD, OpenBSD and musl
+    // use a 64-bit long double.
+    bool IsPPC64LEFreeBSDIEEELongDouble =
+        Triple.isOSFreeBSD() && Triple.getArch() == llvm::Triple::ppc64le &&
+        (Triple.getOSMajorVersion() >= 16 || Triple.getOSVersion().empty());
+    if ((Triple.isOSFreeBSD() && !IsPPC64LEFreeBSDIEEELongDouble) ||
+        Triple.isOSOpenBSD() || Triple.isMusl()) {
       LongDoubleWidth = LongDoubleAlign = 64;
       LongDoubleFormat = &llvm::APFloat::IEEEdouble();
     }

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -234,7 +234,10 @@ llvm::Constant *CodeGenModule::getBuiltinLibFunction(const FunctionDecl *FD,
   else {
     // TODO: This mutation should also be applied to other targets other than
     // PPC, after backend supports IEEE 128-bit style libcalls.
-    if (getTriple().isPPC64() &&
+    // FreeBSD's powerpc64le has a single IEEE-128 long double format and uses
+    // the unsuffixed libm names, so skip the IEEE-128 libcall redirection
+    // there; other PPC64 IEEE-128 targets keep it.
+    if (getTriple().isPPC64() && !getTriple().isOSFreeBSD() &&
         &getTarget().getLongDoubleFormat() == &llvm::APFloat::IEEEquad() &&
         F128Builtins.contains(BuiltinID))
       Name = F128Builtins.lookup(BuiltinID);
@@ -2962,6 +2965,7 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   // TODO: This mutation should also be applied to other targets other than PPC,
   // after backend supports IEEE 128-bit style libcalls.
   if (getTarget().getTriple().isPPC64() &&
+      !getTarget().getTriple().isOSFreeBSD() &&
       &getTarget().getLongDoubleFormat() == &llvm::APFloat::IEEEquad())
     BuiltinID = mutateLongDoubleBuiltin(BuiltinID);
 

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -264,6 +264,11 @@ bool ToolChain::useRelaxRelocations() const {
 }
 
 bool ToolChain::defaultToIEEELongDouble() const {
+  if (getTriple().isOSFreeBSD() &&
+      getTriple().getArch() == llvm::Triple::ppc64le &&
+      (getTriple().getOSMajorVersion() >= 16 ||
+       getTriple().getOSVersion().empty()))
+    return true;
   return PPC_LINUX_DEFAULT_IEEELONGDOUBLE && getTriple().isOSLinux();
 }
 

--- a/clang/test/CodeGen/math-builtins-long.c
+++ b/clang/test/CodeGen/math-builtins-long.c
@@ -6,6 +6,8 @@
 // RUN:   -o - -emit-llvm %s -fmath-errno | FileCheck %s -check-prefix=X86F128
 // RUN: %clang_cc1 -triple ppc64le-unknown-unknown -mabi=ieeelongdouble -w \
 // RUN:   -o - -emit-llvm %s -fmath-errno | FileCheck %s -check-prefix=PPCF128
+// RUN: %clang_cc1 -triple powerpc64le-unknown-freebsd16 -mabi=ieeelongdouble -w \
+// RUN:   -o - -emit-llvm %s -fmath-errno | FileCheck %s -check-prefix=PPCFBSD
 
 void bar(long double);
 
@@ -14,359 +16,419 @@ void foo(long double f, long double *l, int *i, const char *c) {
   // PPC: call ppc_fp128 @fmodl(ppc_fp128 noundef %{{.+}}, ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @fmodl(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
   // PPCF128: call fp128 @fmodf128(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @fmodl(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
   __builtin_fmodl(f,f);
 
   // F80: call x86_fp80 @atan2l(x86_fp80 noundef %{{.+}}, x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @atan2l(ppc_fp128 noundef %{{.+}}, ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @atan2l(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
   // PPCF128: call fp128 @atan2f128(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @atan2l(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
   __builtin_atan2l(f,f);
 
   // F80: call x86_fp80 @llvm.copysign.f80(x86_fp80 %{{.+}}, x86_fp80 %{{.+}})
   // PPC: call ppc_fp128 @llvm.copysign.ppcf128(ppc_fp128 %{{.+}}, ppc_fp128 %{{.+}})
   // X86F128: call fp128 @llvm.copysign.f128(fp128 %{{.+}}, fp128 %{{.+}})
   // PPCF128: call fp128 @llvm.copysign.f128(fp128 %{{.+}}, fp128 %{{.+}})
+  // PPCFBSD: call fp128 @llvm.copysign.f128(fp128 %{{.+}}, fp128 %{{.+}})
   __builtin_copysignl(f,f);
 
   // F80: call x86_fp80 @llvm.fabs.f80(x86_fp80 %{{.+}})
   // PPC: call ppc_fp128 @llvm.fabs.ppcf128(ppc_fp128 %{{.+}})
   // X86F128: call fp128 @llvm.fabs.f128(fp128 %{{.+}})
   // PPCF128: call fp128 @llvm.fabs.f128(fp128 %{{.+}})
+  // PPCFBSD: call fp128 @llvm.fabs.f128(fp128 %{{.+}})
   __builtin_fabsl(f);
 
   // F80: call { x86_fp80, i32 } @llvm.frexp.f80.i32(x86_fp80 %{{.+}})
   // PPC: call ppc_fp128 @frexpl(ppc_fp128 noundef %{{.+}}, ptr noundef %{{.+}})
   // X86F128: call { fp128, i32 } @llvm.frexp.f128.i32(fp128 %{{.+}})
   // PPCF128: call { fp128, i32 } @llvm.frexp.f128.i32(fp128 %{{.+}})
+  // PPCFBSD: call { fp128, i32 } @llvm.frexp.f128.i32(fp128 %{{.+}})
   __builtin_frexpl(f,i);
 
   // F80: store x86_fp80 +inf, ptr
   // PPC: store ppc_fp128 +inf, ptr
   // X86F128: store fp128 +inf, ptr
   // PPCF128: store fp128 +inf, ptr
+  // PPCFBSD: store fp128 +inf, ptr
   *l = __builtin_huge_vall();
 
   // F80: store x86_fp80 +inf, ptr
   // PPC: store ppc_fp128 +inf, ptr
   // X86F128: store fp128 +inf, ptr
   // PPCF128: store fp128 +inf, ptr
+  // PPCFBSD: store fp128 +inf, ptr
   *l = __builtin_infl();
 
   // F80: call x86_fp80 @ldexpl(x86_fp80 noundef %{{.+}}, i32 noundef %{{.+}})
   // PPC: call ppc_fp128 @ldexpl(ppc_fp128 noundef %{{.+}}, {{(signext)?.+}})
   // X86F128: call fp128 @ldexpl(fp128 noundef %{{.+}}, {{(signext)?.+}})
   // PPCF128: call fp128 @ldexpf128(fp128 noundef %{{.+}}, {{(signext)?.+}})
+  // PPCFBSD: call fp128 @ldexpl(fp128 noundef %{{.+}}, {{(signext)?.+}})
   __builtin_ldexpl(f,f);
 
   // F80: call { x86_fp80, x86_fp80 } @llvm.modf.f80(x86_fp80 %{{.+}})
   // PPC: call { ppc_fp128, ppc_fp128 } @llvm.modf.ppcf128(ppc_fp128 %{{.+}})
   // X86F128: call { fp128, fp128 } @llvm.modf.f128(fp128 %{{.+}})
   // PPCF128: call fp128 @modff128(fp128 noundef %{{.+}}, ptr noundef %{{.+}})
+  // PPCFBSD: call { fp128, fp128 } @llvm.modf.f128(fp128 %{{.+}})
   __builtin_modfl(f,l);
 
   // F80: call x86_fp80 @nanl(ptr noundef %{{.+}})
   // PPC: call ppc_fp128 @nanl(ptr noundef %{{.+}})
   // X86F128: call fp128 @nanl(ptr noundef %{{.+}})
   // PPCF128: call fp128 @nanf128(ptr noundef %{{.+}})
+  // PPCFBSD: call fp128 @nanl(ptr noundef %{{.+}})
   __builtin_nanl(c);
 
   // F80: call x86_fp80 @nansl(ptr noundef %{{.+}})
   // PPC: call ppc_fp128 @nansl(ptr noundef %{{.+}})
   // X86F128: call fp128 @nansl(ptr noundef %{{.+}})
   // PPCF128: call fp128 @nansf128(ptr noundef %{{.+}})
+  // PPCFBSD: call fp128 @nansl(ptr noundef %{{.+}})
   __builtin_nansl(c);
 
   // F80: call x86_fp80 @powl(x86_fp80 noundef %{{.+}}, x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @powl(ppc_fp128 noundef %{{.+}}, ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @powl(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
   // PPCF128: call fp128 @powf128(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @powl(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
   __builtin_powl(f,f);
 
   // F80: call x86_fp80 @acosl(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @acosl(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @acosl(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @acosf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @acosl(fp128 noundef %{{.+}})
   __builtin_acosl(f);
 
   // F80: call x86_fp80 @acoshl(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @acoshl(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @acoshl(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @acoshf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @acoshl(fp128 noundef %{{.+}})
   __builtin_acoshl(f);
 
   // F80: call x86_fp80 @asinl(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @asinl(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @asinl(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @asinf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @asinl(fp128 noundef %{{.+}})
   __builtin_asinl(f);
 
   // F80: call x86_fp80 @asinhl(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @asinhl(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @asinhl(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @asinhf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @asinhl(fp128 noundef %{{.+}})
   __builtin_asinhl(f);
 
   // F80: call x86_fp80 @atanl(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @atanl(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @atanl(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @atanf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @atanl(fp128 noundef %{{.+}})
   __builtin_atanl(f);
 
   // F80: call x86_fp80 @atanhl(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @atanhl(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @atanhl(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @atanhf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @atanhl(fp128 noundef %{{.+}})
   __builtin_atanhl(f);
 
   // F80: call x86_fp80 @cbrtl(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @cbrtl(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @cbrtl(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @cbrtf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @cbrtl(fp128 noundef %{{.+}})
   __builtin_cbrtl(f);
 
   // F80: call x86_fp80 @llvm.ceil.f80(x86_fp80 %{{.+}})
   // PPC: call ppc_fp128 @llvm.ceil.ppcf128(ppc_fp128 %{{.+}})
   // X86F128: call fp128 @llvm.ceil.f128(fp128 %{{.+}})
   // PPCF128: call fp128 @llvm.ceil.f128(fp128 %{{.+}})
+  // PPCFBSD: call fp128 @llvm.ceil.f128(fp128 %{{.+}})
   __builtin_ceill(f);
 
   // F80: call x86_fp80 @cosl(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @cosl(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @cosl(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @cosf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @cosl(fp128 noundef %{{.+}})
   __builtin_cosl(f);
 
   // F80: call x86_fp80 @coshl(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @coshl(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @coshl(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @coshf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @coshl(fp128 noundef %{{.+}})
   __builtin_coshl(f);
 
   // F80: call x86_fp80 @llvm.floor.f80(x86_fp80 %{{.+}})
   // PPC: call ppc_fp128 @llvm.floor.ppcf128(ppc_fp128 %{{.+}})
   // X86F128: call fp128 @llvm.floor.f128(fp128 %{{.+}})
   // PPCF128: call fp128 @llvm.floor.f128(fp128 %{{.+}})
+  // PPCFBSD: call fp128 @llvm.floor.f128(fp128 %{{.+}})
   __builtin_floorl(f);
 
   // F80: call nsz x86_fp80 @llvm.maxnum.f80(x86_fp80 %{{.+}}, x86_fp80 %{{.+}})
   // PPC: call nsz ppc_fp128 @llvm.maxnum.ppcf128(ppc_fp128 %{{.+}}, ppc_fp128 %{{.+}})
   // X86F128: call nsz fp128 @llvm.maxnum.f128(fp128 %{{.+}}, fp128 %{{.+}})
   // PPCF128: call nsz fp128 @llvm.maxnum.f128(fp128 %{{.+}}, fp128 %{{.+}})
+  // PPCFBSD: call nsz fp128 @llvm.maxnum.f128(fp128 %{{.+}}, fp128 %{{.+}})
   __builtin_fmaxl(f,f);
 
   // F80: call nsz x86_fp80 @llvm.minnum.f80(x86_fp80 %{{.+}}, x86_fp80 %{{.+}})
   // PPC: call nsz ppc_fp128 @llvm.minnum.ppcf128(ppc_fp128 %{{.+}}, ppc_fp128 %{{.+}})
   // X86F128: call nsz fp128 @llvm.minnum.f128(fp128 %{{.+}}, fp128 %{{.+}})
   // PPCF128: call nsz fp128 @llvm.minnum.f128(fp128 %{{.+}}, fp128 %{{.+}})
+  // PPCFBSD: call nsz fp128 @llvm.minnum.f128(fp128 %{{.+}}, fp128 %{{.+}})
   __builtin_fminl(f,f);
 
   // F80: call x86_fp80 @llvm.nearbyint.f80(x86_fp80 %{{.+}})
   // PPC: call ppc_fp128 @llvm.nearbyint.ppcf128(ppc_fp128 %{{.+}})
   // X86F128: call fp128 @llvm.nearbyint.f128(fp128 %{{.+}})
   // PPCF128: call fp128 @llvm.nearbyint.f128(fp128 %{{.+}})
+  // PPCFBSD: call fp128 @llvm.nearbyint.f128(fp128 %{{.+}})
   __builtin_nearbyintl(f);
 
   // F80: call x86_fp80 @llvm.trunc.f80(x86_fp80 %{{.+}})
   // PPC: call ppc_fp128 @llvm.trunc.ppcf128(ppc_fp128  %{{.+}})
   // X86F128: call fp128 @llvm.trunc.f128(fp128 %{{.+}})
   // PPCF128: call fp128 @llvm.trunc.f128(fp128 %{{.+}})
+  // PPCFBSD: call fp128 @llvm.trunc.f128(fp128 %{{.+}})
   __builtin_truncl(f);
 
   // F80: call x86_fp80 @llvm.rint.f80(x86_fp80 %{{.+}})
   // PPC: call ppc_fp128 @llvm.rint.ppcf128(ppc_fp128 %{{.+}})
   // X86F128: call fp128 @llvm.rint.f128(fp128 %{{.+}})
   // PPCF128: call fp128 @llvm.rint.f128(fp128 %{{.+}})
+  // PPCFBSD: call fp128 @llvm.rint.f128(fp128 %{{.+}})
   __builtin_rintl(f);
 
   // F80: call x86_fp80 @llvm.round.f80(x86_fp80 %{{.+}})
   // PPC: call ppc_fp128 @llvm.round.ppcf128(ppc_fp128 %{{.+}})
   // X86F128: call fp128 @llvm.round.f128(fp128 %{{.+}})
   // PPCF128: call fp128 @llvm.round.f128(fp128 %{{.+}})
+  // PPCFBSD: call fp128 @llvm.round.f128(fp128 %{{.+}})
   __builtin_roundl(f);
 
   // F80: call x86_fp80 @erfl(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @erfl(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @erfl(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @erff128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @erfl(fp128 noundef %{{.+}})
   __builtin_erfl(f);
 
   // F80: call x86_fp80 @erfcl(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @erfcl(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @erfcl(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @erfcf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @erfcl(fp128 noundef %{{.+}})
   __builtin_erfcl(f);
 
   // F80: call x86_fp80 @expl(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @expl(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @expl(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @expf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @expl(fp128 noundef %{{.+}})
   __builtin_expl(f);
 
   // F80: call x86_fp80 @exp2l(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @exp2l(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @exp2l(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @exp2f128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @exp2l(fp128 noundef %{{.+}})
   __builtin_exp2l(f);
 
   // F80: call x86_fp80 @expm1l(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @expm1l(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @expm1l(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @expm1f128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @expm1l(fp128 noundef %{{.+}})
   __builtin_expm1l(f);
 
   // F80: call x86_fp80 @fdiml(x86_fp80 noundef %{{.+}}, x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @fdiml(ppc_fp128 noundef %{{.+}}, ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @fdiml(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
   // PPCF128: call fp128 @fdimf128(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @fdiml(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
   __builtin_fdiml(f,f);
 
   // F80: call x86_fp80 @fmal(x86_fp80 noundef %{{.+}}, x86_fp80 noundef %{{.+}}, x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @fmal(ppc_fp128 noundef %{{.+}}, ppc_fp128 noundef %{{.+}}, ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @fmal(fp128 noundef %{{.+}}, fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
   // PPCF128: call fp128 @fmaf128(fp128 noundef %{{.+}}, fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @fmal(fp128 noundef %{{.+}}, fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
   __builtin_fmal(f,f,f);
 
   // F80: call x86_fp80 @hypotl(x86_fp80 noundef %{{.+}}, x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @hypotl(ppc_fp128 noundef %{{.+}}, ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @hypotl(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
   // PPCF128: call fp128 @hypotf128(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @hypotl(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
   __builtin_hypotl(f,f);
 
   // F80: call i32 @ilogbl(x86_fp80 noundef %{{.+}})
   // PPC: call {{(i32)|(signext i32)}} @ilogbl(ppc_fp128 noundef %{{.+}})
   // X86F128: call {{(i32)|(signext i32)}} @ilogbl(fp128 noundef %{{.+}})
   // PPCF128: call {{(i32)|(signext i32)}} @ilogbf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call {{(i32)|(signext i32)}} @ilogbl(fp128 noundef %{{.+}})
   __builtin_ilogbl(f);
 
   // F80: call x86_fp80 @lgammal(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @lgammal(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @lgammal(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @lgammaf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @lgammal(fp128 noundef %{{.+}})
   __builtin_lgammal(f);
 
   // F80: call i64 @llrintl(x86_fp80 noundef %{{.+}})
   // PPC: call i64 @llrintl(ppc_fp128 noundef %{{.+}})
   // X86F128: call i64 @llrintl(fp128 noundef %{{.+}})
   // PPCF128: call i64 @llrintf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call i64 @llrintl(fp128 noundef %{{.+}})
   __builtin_llrintl(f);
 
   // F80: call i64 @llroundl(x86_fp80 noundef %{{.+}})
   // PPC: call i64 @llroundl(ppc_fp128 noundef %{{.+}})
   // X86F128: call i64 @llroundl(fp128 noundef %{{.+}})
   // PPCF128: call i64 @llroundf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call i64 @llroundl(fp128 noundef %{{.+}})
   __builtin_llroundl(f);
 
   // F80: call x86_fp80 @logl(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @logl(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @logl(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @logf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @logl(fp128 noundef %{{.+}})
   __builtin_logl(f);
 
   // F80: call x86_fp80 @log10l(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @log10l(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @log10l(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @log10f128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @log10l(fp128 noundef %{{.+}})
   __builtin_log10l(f);
 
   // F80: call x86_fp80 @log1pl(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @log1pl(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @log1pl(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @log1pf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @log1pl(fp128 noundef %{{.+}})
   __builtin_log1pl(f);
 
   // F80: call x86_fp80 @log2l(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @log2l(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @log2l(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @log2f128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @log2l(fp128 noundef %{{.+}})
   __builtin_log2l(f);
 
   // F80: call x86_fp80 @logbl(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @logbl(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @logbl(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @logbf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @logbl(fp128 noundef %{{.+}})
   __builtin_logbl(f);
 
   // F80: call i64 @lrintl(x86_fp80 noundef %{{.+}})
   // PPC: call i64 @lrintl(ppc_fp128 noundef %{{.+}})
   // X86F128: call i64 @lrintl(fp128 noundef %{{.+}})
   // PPCF128: call i64 @lrintf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call i64 @lrintl(fp128 noundef %{{.+}})
   __builtin_lrintl(f);
 
   // F80: call i64 @lroundl(x86_fp80 noundef %{{.+}})
   // PPC: call i64 @lroundl(ppc_fp128 noundef %{{.+}})
   // X86F128: call i64 @lroundl(fp128 noundef %{{.+}})
   // PPCF128: call i64 @lroundf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call i64 @lroundl(fp128 noundef %{{.+}})
   __builtin_lroundl(f);
 
   // F80: call x86_fp80 @nextafterl(x86_fp80 noundef %{{.+}}, x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @nextafterl(ppc_fp128 noundef %{{.+}}, ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @nextafterl(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
   // PPCF128: call fp128 @nextafterf128(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @nextafterl(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
   __builtin_nextafterl(f,f);
 
   // F80: call x86_fp80 @nexttowardl(x86_fp80 noundef %{{.+}}, x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @nexttowardl(ppc_fp128 noundef %{{.+}}, ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @nexttowardl(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
   // PPCF128: call fp128 @__nexttowardieee128(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @nexttowardl(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
   __builtin_nexttowardl(f,f);
 
   // F80: call x86_fp80 @remainderl(x86_fp80 noundef %{{.+}}, x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @remainderl(ppc_fp128 noundef %{{.+}}, ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @remainderl(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
   // PPCF128: call fp128 @remainderf128(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @remainderl(fp128 noundef %{{.+}}, fp128 noundef %{{.+}})
   __builtin_remainderl(f,f);
 
   // F80: call x86_fp80 @remquol(x86_fp80 noundef %{{.+}}, x86_fp80 noundef %{{.+}}, ptr noundef %{{.+}})
   // PPC: call ppc_fp128 @remquol(ppc_fp128 noundef %{{.+}}, ppc_fp128 noundef %{{.+}}, ptr noundef %{{.+}})
   // X86F128: call fp128 @remquol(fp128 noundef %{{.+}}, fp128 noundef %{{.+}}, ptr noundef %{{.+}})
   // PPCF128: call fp128 @remquof128(fp128 noundef %{{.+}}, fp128 noundef %{{.+}}, ptr noundef %{{.+}})
+  // PPCFBSD: call fp128 @remquol(fp128 noundef %{{.+}}, fp128 noundef %{{.+}}, ptr noundef %{{.+}})
   __builtin_remquol(f,f,i);
 
   // F80: call x86_fp80 @scalblnl(x86_fp80 noundef %{{.+}}, i64 noundef %{{.+}})
   // PPC: call ppc_fp128 @scalblnl(ppc_fp128 noundef %{{.+}}, i64 noundef %{{.+}})
   // X86F128: call fp128 @scalblnl(fp128 noundef %{{.+}}, i64 noundef %{{.+}})
   // PPCF128: call fp128 @scalblnf128(fp128 noundef %{{.+}}, i64 noundef %{{.+}})
+  // PPCFBSD: call fp128 @scalblnl(fp128 noundef %{{.+}}, i64 noundef %{{.+}})
   __builtin_scalblnl(f,f);
 
   // F80: call x86_fp80 @scalbnl(x86_fp80 noundef %{{.+}}, i32 noundef %{{.+}})
   // PPC: call ppc_fp128 @scalbnl(ppc_fp128 noundef %{{.+}}, {{(signext)?.+}})
   // X86F128: call fp128 @scalbnl(fp128 noundef %{{.+}}, {{(signext)?.+}})
   // PPCF128: call fp128 @scalbnf128(fp128 noundef %{{.+}}, {{(signext)?.+}})
+  // PPCFBSD: call fp128 @scalbnl(fp128 noundef %{{.+}}, {{(signext)?.+}})
   __builtin_scalbnl(f,f);
 
   // F80: call x86_fp80 @sinl(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @sinl(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @sinl(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @sinf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @sinl(fp128 noundef %{{.+}})
   __builtin_sinl(f);
 
   // F80: call x86_fp80 @sinhl(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @sinhl(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @sinhl(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @sinhf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @sinhl(fp128 noundef %{{.+}})
   __builtin_sinhl(f);
 
   // F80: call x86_fp80 @sqrtl(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @sqrtl(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @sqrtl(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @sqrtf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @sqrtl(fp128 noundef %{{.+}})
   __builtin_sqrtl(f);
 
   // F80: call x86_fp80 @tanl(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @tanl(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @tanl(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @tanf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @tanl(fp128 noundef %{{.+}})
   __builtin_tanl(f);
 
   // F80: call x86_fp80 @tanhl(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @tanhl(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @tanhl(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @tanhf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @tanhl(fp128 noundef %{{.+}})
   __builtin_tanhl(f);
 
   // F80: call x86_fp80 @tgammal(x86_fp80 noundef %{{.+}})
   // PPC: call ppc_fp128 @tgammal(ppc_fp128 noundef %{{.+}})
   // X86F128: call fp128 @tgammal(fp128 noundef %{{.+}})
   // PPCF128: call fp128 @tgammaf128(fp128 noundef %{{.+}})
+  // PPCFBSD: call fp128 @tgammal(fp128 noundef %{{.+}})
   __builtin_tgammal(f);
 }

--- a/clang/test/Preprocessor/init-ppc64.c
+++ b/clang/test/Preprocessor/init-ppc64.c
@@ -1148,8 +1148,11 @@
 // PPC64LE-LINUX:#define _CALL_LINUX 1
 
 // RUN: %clang_cc1 -E -dM -ffreestanding -triple=powerpc64-unknown-freebsd < /dev/null | FileCheck -match-full-lines -check-prefix PPC64-FREEBSD %s
-// RUN: %clang_cc1 -E -dM -ffreestanding -triple=powerpc64le-unknown-freebsd < /dev/null | FileCheck -match-full-lines -check-prefix PPC64-FREEBSD %s
+// RUN: %clang_cc1 -E -dM -ffreestanding -triple=powerpc64le-unknown-freebsd < /dev/null | FileCheck -match-full-lines -check-prefix PPC64LE-FREEBSD %s
 // PPC64-FREEBSD-NOT: #define __LONG_DOUBLE_128__ 1
+// PPC64LE-FREEBSD: #define __LDBL_MANT_DIG__ 113
+// PPC64LE-FREEBSD: #define __LONG_DOUBLE_128__ 1
+// PPC64LE-FREEBSD: #define __LONG_DOUBLE_IEEE128__ 1
 
 // RUN: %clang_cc1 -E -dM -ffreestanding -triple=powerpc64-none-none < /dev/null | FileCheck -match-full-lines -check-prefix PPC64PWR4-RSQRT %s
 //


### PR DESCRIPTION
Starting with FreeBSD 16, powerpc64le switches its long double type from
64-bit double to IEEE 754 binary128, matching the GCC powerpc64le ABI and
the IEEE-128 long double already used on aarch64 and riscv.

For the FreeBSD powerpc64le triple with an OS major version >= 16:
  - In PPC64TargetInfo, set the long double width and alignment to 128 and
    the format to IEEEquad, instead of falling into the 64-bit double case
    shared with OpenBSD and musl.
  - ToolChain::defaultToIEEELongDouble() returns true, so the driver selects
    IEEE-128 long double independently of the Linux-only
    PPC_LINUX_DEFAULT_IEEELONGDOUBLE setting.

Also restrict the F128Builtins redirection (printf/scanf/*_chk -> __*ieee128)
to GNU environments. The *ieee128-suffixed names are glibc's mechanism for
coexisting IBM double-double and IEEE-128 long double in a single library;
targets with a single IEEE-128 long double format, such as FreeBSD, use the
unsuffixed libm names, which is what the backend already emits.
