### PR TITLE
[libc] Add compound assignment operator overloads for BFloat16

### DIFF
--- a/libc/src/__support/FPUtil/bfloat16.h
+++ b/libc/src/__support/FPUtil/bfloat16.h
@@ -68,27 +68,27 @@ struct BFloat16 {
     return static_cast<T>(static_cast<float>(*this));
   }
 
-  LIBC_INLINE constexpr bool operator==(BFloat16 other) const {
+  LIBC_INLINE constexpr bool operator==(const BFloat16 &other) const {
     return fputil::equals(*this, other);
   }
 
-  LIBC_INLINE constexpr bool operator!=(BFloat16 other) const {
+  LIBC_INLINE constexpr bool operator!=(const BFloat16 &other) const {
     return !fputil::equals(*this, other);
   }
 
-  LIBC_INLINE constexpr bool operator<(BFloat16 other) const {
+  LIBC_INLINE constexpr bool operator<(const BFloat16 &other) const {
     return fputil::less_than(*this, other);
   }
 
-  LIBC_INLINE constexpr bool operator<=(BFloat16 other) const {
+  LIBC_INLINE constexpr bool operator<=(const BFloat16 &other) const {
     return fputil::less_than_or_equals(*this, other);
   }
 
-  LIBC_INLINE constexpr bool operator>(BFloat16 other) const {
+  LIBC_INLINE constexpr bool operator>(const BFloat16 &other) const {
     return fputil::greater_than(*this, other);
   }
 
-  LIBC_INLINE constexpr bool operator>=(BFloat16 other) const {
+  LIBC_INLINE constexpr bool operator>=(const BFloat16 &other) const {
     return fputil::greater_than_or_equals(*this, other);
   }
 
@@ -98,24 +98,36 @@ struct BFloat16 {
     return result.get_val();
   }
 
-  LIBC_INLINE constexpr BFloat16 operator+(BFloat16 other) const {
+  LIBC_INLINE constexpr BFloat16 operator+(const BFloat16 &other) const {
     return fputil::generic::add<BFloat16>(*this, other);
   }
 
-  LIBC_INLINE constexpr BFloat16 operator-(BFloat16 other) const {
+  LIBC_INLINE constexpr BFloat16 operator-(const BFloat16 &other) const {
     return fputil::generic::sub<BFloat16>(*this, other);
   }
 
-  LIBC_INLINE constexpr BFloat16 operator*(BFloat16 other) const {
+  LIBC_INLINE constexpr BFloat16 operator*(const BFloat16 &other) const {
     return fputil::generic::mul<bfloat16>(*this, other);
   }
 
-  LIBC_INLINE constexpr BFloat16 operator/(BFloat16 other) const {
+  LIBC_INLINE constexpr BFloat16 operator/(const BFloat16 &other) const {
     return fputil::generic::div<bfloat16>(*this, other);
   }
 
   LIBC_INLINE constexpr BFloat16 &operator*=(const BFloat16 &other) {
     *this = *this * other;
+    return *this;
+  }
+  LIBC_INLINE constexpr BFloat16 &operator+=(const BFloat16 &other) {
+    *this = *this + other;
+    return *this;
+  }
+  LIBC_INLINE constexpr BFloat16 &operator-=(const BFloat16 &other) {
+    *this = *this - other;
+    return *this;
+  }
+  LIBC_INLINE constexpr BFloat16 &operator/=(const BFloat16 &other) {
+    *this = *this / other;
     return *this;
   }
 }; // struct BFloat16

--- a/libc/src/__support/FPUtil/bfloat16.h
+++ b/libc/src/__support/FPUtil/bfloat16.h
@@ -68,27 +68,27 @@ struct BFloat16 {
     return static_cast<T>(static_cast<float>(*this));
   }
 
-  LIBC_INLINE constexpr bool operator==(Bfloat16 other) const {
+  LIBC_INLINE constexpr bool operator==(BFloat16 other) const {
     return fputil::equals(*this, other);
   }
 
-  LIBC_INLINE constexpr bool operator!=(Bfloat16 other) const {
+  LIBC_INLINE constexpr bool operator!=(BFloat16 other) const {
     return !fputil::equals(*this, other);
   }
 
-  LIBC_INLINE constexpr bool operator<(Bfloat16 other) const {
+  LIBC_INLINE constexpr bool operator<(BFloat16 other) const {
     return fputil::less_than(*this, other);
   }
 
-  LIBC_INLINE constexpr bool operator<=(Bfloat16 other) const {
+  LIBC_INLINE constexpr bool operator<=(BFloat16 other) const {
     return fputil::less_than_or_equals(*this, other);
   }
 
-  LIBC_INLINE constexpr bool operator>(Bfloat16 other) const {
+  LIBC_INLINE constexpr bool operator>(BFloat16 other) const {
     return fputil::greater_than(*this, other);
   }
 
-  LIBC_INLINE constexpr bool operator>=(Bfloat16 other) const {
+  LIBC_INLINE constexpr bool operator>=(BFloat16 other) const {
     return fputil::greater_than_or_equals(*this, other);
   }
 
@@ -98,35 +98,35 @@ struct BFloat16 {
     return result.get_val();
   }
 
-  LIBC_INLINE constexpr BFloat16 operator+(Bfloat16 other) const {
+  LIBC_INLINE constexpr BFloat16 operator+(BFloat16 other) const {
     return fputil::generic::add<BFloat16>(*this, other);
   }
 
-  LIBC_INLINE constexpr BFloat16 operator-(Bfloat16 other) const {
+  LIBC_INLINE constexpr BFloat16 operator-(BFloat16 other) const {
     return fputil::generic::sub<BFloat16>(*this, other);
   }
 
-  LIBC_INLINE constexpr BFloat16 operator*(Bfloat16 other) const {
+  LIBC_INLINE constexpr BFloat16 operator*(BFloat16 other) const {
     return fputil::generic::mul<bfloat16>(*this, other);
   }
 
-  LIBC_INLINE constexpr BFloat16 operator/(Bfloat16 other) const {
+  LIBC_INLINE constexpr BFloat16 operator/(BFloat16 other) const {
     return fputil::generic::div<bfloat16>(*this, other);
   }
 
-  LIBC_INLINE constexpr BFloat16 &operator*=(Bfloat16 other) {
+  LIBC_INLINE constexpr BFloat16 &operator*=(BFloat16 other) {
     *this = *this * other;
     return *this;
   }
-  LIBC_INLINE constexpr BFloat16 &operator+=(Bfloat16 other) {
+  LIBC_INLINE constexpr BFloat16 &operator+=(BFloat16 other) {
     *this = *this + other;
     return *this;
   }
-  LIBC_INLINE constexpr BFloat16 &operator-=(Bfloat16 other) {
+  LIBC_INLINE constexpr BFloat16 &operator-=(BFloat16 other) {
     *this = *this - other;
     return *this;
   }
-  LIBC_INLINE constexpr BFloat16 &operator/=(Bfloat16 other) {
+  LIBC_INLINE constexpr BFloat16 &operator/=(BFloat16 other) {
     *this = *this / other;
     return *this;
   }

--- a/libc/src/__support/FPUtil/bfloat16.h
+++ b/libc/src/__support/FPUtil/bfloat16.h
@@ -68,27 +68,27 @@ struct BFloat16 {
     return static_cast<T>(static_cast<float>(*this));
   }
 
-  LIBC_INLINE constexpr bool operator==(const BFloat16 &other) const {
+  LIBC_INLINE constexpr bool operator==(Bfloat16 other) const {
     return fputil::equals(*this, other);
   }
 
-  LIBC_INLINE constexpr bool operator!=(const BFloat16 &other) const {
+  LIBC_INLINE constexpr bool operator!=(Bfloat16 other) const {
     return !fputil::equals(*this, other);
   }
 
-  LIBC_INLINE constexpr bool operator<(const BFloat16 &other) const {
+  LIBC_INLINE constexpr bool operator<(Bfloat16 other) const {
     return fputil::less_than(*this, other);
   }
 
-  LIBC_INLINE constexpr bool operator<=(const BFloat16 &other) const {
+  LIBC_INLINE constexpr bool operator<=(Bfloat16 other) const {
     return fputil::less_than_or_equals(*this, other);
   }
 
-  LIBC_INLINE constexpr bool operator>(const BFloat16 &other) const {
+  LIBC_INLINE constexpr bool operator>(Bfloat16 other) const {
     return fputil::greater_than(*this, other);
   }
 
-  LIBC_INLINE constexpr bool operator>=(const BFloat16 &other) const {
+  LIBC_INLINE constexpr bool operator>=(Bfloat16 other) const {
     return fputil::greater_than_or_equals(*this, other);
   }
 
@@ -98,35 +98,35 @@ struct BFloat16 {
     return result.get_val();
   }
 
-  LIBC_INLINE constexpr BFloat16 operator+(const BFloat16 &other) const {
+  LIBC_INLINE constexpr BFloat16 operator+(Bfloat16 other) const {
     return fputil::generic::add<BFloat16>(*this, other);
   }
 
-  LIBC_INLINE constexpr BFloat16 operator-(const BFloat16 &other) const {
+  LIBC_INLINE constexpr BFloat16 operator-(Bfloat16 other) const {
     return fputil::generic::sub<BFloat16>(*this, other);
   }
 
-  LIBC_INLINE constexpr BFloat16 operator*(const BFloat16 &other) const {
+  LIBC_INLINE constexpr BFloat16 operator*(Bfloat16 other) const {
     return fputil::generic::mul<bfloat16>(*this, other);
   }
 
-  LIBC_INLINE constexpr BFloat16 operator/(const BFloat16 &other) const {
+  LIBC_INLINE constexpr BFloat16 operator/(Bfloat16 other) const {
     return fputil::generic::div<bfloat16>(*this, other);
   }
 
-  LIBC_INLINE constexpr BFloat16 &operator*=(const BFloat16 &other) {
+  LIBC_INLINE constexpr BFloat16 &operator*=(Bfloat16 other) {
     *this = *this * other;
     return *this;
   }
-  LIBC_INLINE constexpr BFloat16 &operator+=(const BFloat16 &other) {
+  LIBC_INLINE constexpr BFloat16 &operator+=(Bfloat16 other) {
     *this = *this + other;
     return *this;
   }
-  LIBC_INLINE constexpr BFloat16 &operator-=(const BFloat16 &other) {
+  LIBC_INLINE constexpr BFloat16 &operator-=(Bfloat16 other) {
     *this = *this - other;
     return *this;
   }
-  LIBC_INLINE constexpr BFloat16 &operator/=(const BFloat16 &other) {
+  LIBC_INLINE constexpr BFloat16 &operator/=(Bfloat16 other) {
     *this = *this / other;
     return *this;
   }

--- a/libc/test/src/__support/FPUtil/bfloat16_test.cpp
+++ b/libc/test/src/__support/FPUtil/bfloat16_test.cpp
@@ -68,7 +68,7 @@ TEST_F(LlvmLibcBfloat16ConversionTest, FromInteger) {
   }
 }
 
-TEST_F(LlvmLibcBfloat16ConversionTest, shortHandOperators) {
+TEST_F(LlvmLibcBfloat16ConversionTest, compoundAssignmentOperators) {
 
   constexpr BFloat16 VAL[] = {zero,           neg_zero,        inf,
                               neg_inf,        min_normal,      max_normal,

--- a/libc/test/src/__support/FPUtil/bfloat16_test.cpp
+++ b/libc/test/src/__support/FPUtil/bfloat16_test.cpp
@@ -68,12 +68,13 @@ TEST_F(LlvmLibcBfloat16ConversionTest, FromInteger) {
   }
 }
 
-TEST_F(LlvmLibcBfloat16ConversionTest, MultiplyAssign) {
+TEST_F(LlvmLibcBfloat16ConversionTest, shortHandOperators) {
 
   constexpr BFloat16 VAL[] = {zero,           neg_zero,        inf,
                               neg_inf,        min_normal,      max_normal,
                               bfloat16(1.0f), bfloat16(-1.0f), bfloat16(2.0f),
                               bfloat16(3.0f)};
+  // *=
   for (const bfloat16 &x : VAL) {
     for (const bfloat16 &y : VAL) {
       BFloat16 a = x, b = y;
@@ -81,6 +82,42 @@ TEST_F(LlvmLibcBfloat16ConversionTest, MultiplyAssign) {
       MPFRNumber mpfr_c = mpfr_a.mul(mpfr_b);
       BFloat16 mpfr_bfloat = mpfr_c.as<BFloat16>();
       a *= b;
+      BFloat16 libc_bfloat = a;
+      EXPECT_FP_EQ_ALL_ROUNDING(mpfr_bfloat, libc_bfloat);
+    }
+  }
+  // /=
+  for (const bfloat16 &x : VAL) {
+    for (const bfloat16 &y : VAL) {
+      BFloat16 a = x, b = y;
+      MPFRNumber mpfr_a{a}, mpfr_b{b};
+      MPFRNumber mpfr_c = mpfr_a.div(mpfr_b);
+      BFloat16 mpfr_bfloat = mpfr_c.as<BFloat16>();
+      a /= b;
+      BFloat16 libc_bfloat = a;
+      EXPECT_FP_EQ_ALL_ROUNDING(mpfr_bfloat, libc_bfloat);
+    }
+  }
+  // +=
+  for (const bfloat16 &x : VAL) {
+    for (const bfloat16 &y : VAL) {
+      BFloat16 a = x, b = y;
+      MPFRNumber mpfr_a{a}, mpfr_b{b};
+      MPFRNumber mpfr_c = mpfr_a.add(mpfr_b);
+      BFloat16 mpfr_bfloat = mpfr_c.as<BFloat16>();
+      a += b;
+      BFloat16 libc_bfloat = a;
+      EXPECT_FP_EQ_ALL_ROUNDING(mpfr_bfloat, libc_bfloat);
+    }
+  }
+  // -=
+  for (const bfloat16 &x : VAL) {
+    for (const bfloat16 &y : VAL) {
+      BFloat16 a = x, b = y;
+      MPFRNumber mpfr_a{a}, mpfr_b{b};
+      MPFRNumber mpfr_c = mpfr_a.sub(mpfr_b);
+      BFloat16 mpfr_bfloat = mpfr_c.as<BFloat16>();
+      a -= b;
       BFloat16 libc_bfloat = a;
       EXPECT_FP_EQ_ALL_ROUNDING(mpfr_bfloat, libc_bfloat);
     }


### PR DESCRIPTION
The current Bfloat16 has normal operator overloads `+` , `-` , `=`, `!=`, `*`, & `/`. 
Later during a function failure `*=` was added in https://github.com/llvm/llvm-project/pull/182882
For completeness the rest of the operators: `/=`, `+=`, `-=` are added 
These are added along with some smoke test .