### PR TITLE
[lldb][test] Don't print LLDB version in every test

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/configuration.py
+++ b/lldb/packages/Python/lldbsuite/test/configuration.py
@@ -154,6 +154,9 @@ mte_enabled = False
 # Whether debugserver is built with arm64e support.
 arm64e_debugserver = False
 
+# Whether to print the lldb version banner during test setup.
+print_lldb_version = False
+
 # the build type of lldb
 # Typical values include Debug, Release, RelWithDebInfo and MinSizeRel
 cmake_build_type = None

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -472,6 +472,9 @@ def parseOptionsAndInitTestdirs():
     if args.arm64e_debugserver:
         configuration.arm64e_debugserver = True
 
+    if args.print_lldb_version:
+        configuration.print_lldb_version = True
+
     # Gather all the dirs passed on the command line.
     if len(args.args) > 0:
         configuration.testdirs = [
@@ -568,7 +571,8 @@ def setupSysPath():
         )
         sys.exit(-1)
 
-    os.system("%s -v" % lldbtest_config.lldbExec)
+    if configuration.print_lldb_version:
+        os.system("%s -v" % lldbtest_config.lldbExec)
 
     lldbDir = os.path.dirname(lldbtest_config.lldbExec)
 

--- a/lldb/packages/Python/lldbsuite/test/dotest_args.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest_args.py
@@ -281,6 +281,12 @@ def create_parser():
         action="store_true",
         help="Indicate that debugserver is built with arm64e support.",
     )
+    group.add_argument(
+        "--print-lldb-version",
+        dest="print_lldb_version",
+        action="store_true",
+        help="Print the lldb version banner during test setup.",
+    )
 
     # Configuration options
     group = parser.add_argument_group("Remote platform options")

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -255,6 +255,18 @@ if is_configured("clang_module_cache"):
 
 if is_configured("lldb_executable"):
     dotest_cmd += ["--executable", config.lldb_executable]
+    try:
+        version_output = subprocess.check_output(
+            [config.lldb_executable, "--version"],
+            stderr=subprocess.STDOUT,
+            text=True,
+        ).strip()
+        for line in version_output.splitlines():
+            lit_config.note(line.strip())
+    except (subprocess.CalledProcessError, OSError) as e:
+        lit_config.warning(
+            "Could not get lldb version from {}: {}".format(config.lldb_executable, e)
+        )
 
 if is_configured("test_compiler"):
     dotest_cmd += ["--compiler", config.test_compiler]


### PR DESCRIPTION
An empty minimal API test currently runs for 330ms on my macOS system. Of these 330ms, we spend 70ms (20%) just to print the lldb version number at the start of each test.

This patch disables this behavior by default and instead prints the LLDB version number once at the start of the LIT test suite. This saves about 2 minutes of CPU time in an LLDB test suite run.