### PR TITLE
[LLVM][CodeGen][SPIRV] Match NULL splat to OpConstantNull.

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -3921,6 +3921,22 @@ bool SPIRVInstructionSelector::selectBuildVector(Register ResVReg,
         I, "There must be at least two constituent operands in a vector");
 
   MRI->setRegClass(ResVReg, GR.getRegClass(ResType));
+
+  bool IsNullVector = IsConst && !STI.isShader();
+  for (unsigned i = I.getNumExplicitDefs();
+       i < I.getNumExplicitOperands() && IsNullVector; ++i) {
+    MachineInstr *Def = getDef(I.getOperand(i), MRI);
+    IsNullVector = Def && isNullOrNullSplat(*Def, *MRI);
+  }
+
+  if (IsNullVector) {
+    BuildMI(*I.getParent(), I, I.getDebugLoc(), TII.get(SPIRV::OpConstantNull))
+        .addDef(ResVReg)
+        .addUse(GR.getSPIRVTypeID(ResType))
+        .constrainAllUses(TII, TRI, RBI);
+    return true;
+  }
+
   auto MIB = BuildMI(*I.getParent(), I, I.getDebugLoc(),
                      TII.get(IsConst ? SPIRV::OpConstantComposite
                                      : SPIRV::OpCompositeConstruct))

--- a/llvm/test/CodeGen/SPIRV/FCmpFalse_Vec.ll
+++ b/llvm/test/CodeGen/SPIRV/FCmpFalse_Vec.ll
@@ -3,9 +3,8 @@
 
 ; CHECK: %[[#BoolTy:]] = OpTypeBool
 ; CHECK: %[[#VecTy:]] = OpTypeVector %[[#BoolTy]] 4
-; CHECK: %[[#False:]] = OpConstantFalse %[[#BoolTy]]
-; CHECK: %[[#Composite:]] = OpConstantComposite %[[#VecTy]] %[[#False]] %[[#False]] %[[#False]] %[[#False]]
-; CHECK: OpReturnValue %[[#Composite]]
+; CHECK: %[[#NullVec:]] = OpConstantNull %[[#VecTy]]
+; CHECK: OpReturnValue %[[#NullVec]]
 
 define spir_func <4 x i1> @test(<4 x float> %a) {
  %compare = fcmp false <4 x float> %a, %a

--- a/llvm/test/CodeGen/SPIRV/constant/local-zero-constants.ll
+++ b/llvm/test/CodeGen/SPIRV/constant/local-zero-constants.ll
@@ -1,0 +1,62 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan %s -o - | FileCheck %s --check-prefix=CHECK-HLSL
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-OCL
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val %}
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+define i32 @getNullIntConstant() {
+  ret i32 0
+}
+
+define float @getNullFloatConstant() {
+  ret float +0.0
+}
+
+define <4 x i32> @getNullIntVectorConstant() {
+  ret <4 x i32> splat (i32 0)
+}
+
+define <4 x float> @getNullFloatVectorConstant() {
+  ret <4 x float> splat (float +0.0)
+}
+
+define [2 x <4 x i32>] @getNullIntArrayOfVectorConstant() {
+  ret [2 x <4 x i32>] [ <4 x i32> splat (i32 0), <4 x i32> splat (i32 0) ]
+}
+
+define [2 x <4 x float>] @getNullFloatArrayOfVectorConstant() {
+  ret [2 x <4 x float>] [ <4 x float> splat (float +0.0), <4 x float> splat (float +0.0) ]
+}
+
+%null.struct = type { i32, float, <4 x i32>, <4 x float> }
+define %null.struct @getNullStructConstant() {
+  ret %null.struct { i32 0, float +0.0, <4 x i32> splat (i32 0), <4 x float> splat (float +0.0) }
+}
+
+; CHECK-HLSL-DAG: [[I32:%.+]] = OpTypeInt 32 0
+; CHECK-HLSL-DAG: [[F32:%.+]] = OpTypeFloat 32
+; CHECK-HLSL-DAG: [[INT_VECTOR:%.+]] = OpTypeVector [[I32]]
+; CHECK-HLSL-DAG: [[FLOAT_VECTOR:%.+]] = OpTypeVector [[F32]]
+; CHECK-HLSL-DAG: [[INT_VECTOR_ARRAY:%.+]] = OpTypeArray [[INT_VECTOR]]
+; CHECK-HLSL-DAG: [[FLOAT_VECTOR_ARRAY:%.+]] = OpTypeArray [[FLOAT_VECTOR]]
+; CHECK-HLSL-DAG: [[NULL_STRUCT:%.+]] = OpTypeStruct [[I32]] [[F32]] [[INT_VECTOR]] [[FLOAT_VECTOR]]
+; CHECK-HLSL-DAG: [[NULL_F32:%.+]] = OpConstant [[F32]] 0
+; CHECK-HLSL-DAG: [[NULL_INT_VECTOR:%.+]] = OpConstantNull [[INT_VECTOR]]
+; CHECK-HLSL-DAG: [[NULL_FLOAT_VECTOR:%.+]] = OpConstantComposite [[FLOAT_VECTOR]] [[NULL_F32]] [[NULL_F32]] [[NULL_F32]] [[NULL_F32]]
+; CHECK-HLSL-DAG: [[NULL_INT_VECTOR_ARRAY:%.+]] = OpConstantNull [[INT_VECTOR_ARRAY]]
+; CHECK-HLSL-DAG: [[NULL_FLOAT_VECTOR_ARRAY:%.+]] = OpConstantNull [[FLOAT_VECTOR_ARRAY]]
+; CHECK-HLSL-DAG: [[NULL_STRUCT_CONST:%.+]] = OpConstantNull [[NULL_STRUCT]]
+
+; CHECK-OCL-DAG: [[I32:%.+]] = OpTypeInt 32
+; CHECK-OCL-DAG: [[F32:%.+]] = OpTypeFloat 32
+; CHECK-OCL-DAG: [[INT_VECTOR:%.+]] = OpTypeVector [[I32]]
+; CHECK-OCL-DAG: [[FLOAT_VECTOR:%.+]] = OpTypeVector [[F32]]
+; CHECK-OCL-DAG: [[INT_VECTOR_ARRAY:%.+]] = OpTypeArray [[INT_VECTOR]]
+; CHECK-OCL-DAG: [[FLOAT_VECTOR_ARRAY:%.+]] = OpTypeArray [[FLOAT_VECTOR]]
+; CHECK-OCL-DAG: [[NULL_STRUCT:%.+]] = OpTypeStruct [[I32]] [[F32]] [[INT_VECTOR]] [[FLOAT_VECTOR]]
+; CHECK-OCL-DAG: [[NULL_I32:%.+]] = OpConstantNull [[I32]]
+; CHECK-OCL-DAG: [[NULL_F32:%.+]] = OpConstantNull [[F32]]
+; CHECK-OCL-DAG: [[NULL_INT_VECTOR:%.+]] = OpConstantNull [[INT_VECTOR]]
+; CHECK-OCL-DAG: [[NULL_FLOAT_VECTOR:%.+]] = OpConstantComposite [[FLOAT_VECTOR]] [[NULL_F32]] [[NULL_F32]] [[NULL_F32]] [[NULL_F32]]
+; CHECK-OCL-DAG: [[NULL_INT_VECTOR_ARRAY:%.+]] = OpConstantNull [[INT_VECTOR_ARRAY]]
+; CHECK-OCL-DAG: [[NULL_FLOAT_VECTOR_ARRAY:%.+]] = OpConstantNull [[FLOAT_VECTOR_ARRAY]]
+; CHECK-OCL-DAG: [[NULL_STRUCT_CONST:%.+]] = OpConstantNull [[NULL_STRUCT]]

--- a/llvm/test/CodeGen/SPIRV/constant/local-zero-constants.ll
+++ b/llvm/test/CodeGen/SPIRV/constant/local-zero-constants.ll
@@ -56,7 +56,7 @@ define %null.struct @getNullStructConstant() {
 ; CHECK-OCL-DAG: [[NULL_I32:%.+]] = OpConstantNull [[I32]]
 ; CHECK-OCL-DAG: [[NULL_F32:%.+]] = OpConstantNull [[F32]]
 ; CHECK-OCL-DAG: [[NULL_INT_VECTOR:%.+]] = OpConstantNull [[INT_VECTOR]]
-; CHECK-OCL-DAG: [[NULL_FLOAT_VECTOR:%.+]] = OpConstantComposite [[FLOAT_VECTOR]] [[NULL_F32]] [[NULL_F32]] [[NULL_F32]] [[NULL_F32]]
+; CHECK-OCL-DAG: [[NULL_FLOAT_VECTOR:%.+]] = OpConstantNull [[FLOAT_VECTOR]]
 ; CHECK-OCL-DAG: [[NULL_INT_VECTOR_ARRAY:%.+]] = OpConstantNull [[INT_VECTOR_ARRAY]]
 ; CHECK-OCL-DAG: [[NULL_FLOAT_VECTOR_ARRAY:%.+]] = OpConstantNull [[FLOAT_VECTOR_ARRAY]]
 ; CHECK-OCL-DAG: [[NULL_STRUCT_CONST:%.+]] = OpConstantNull [[NULL_STRUCT]]

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/is_fpclass.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/is_fpclass.ll
@@ -33,7 +33,7 @@
 ; CHECK-DAG: %[[#InfFP64:]] = OpConstant %[[#I64Ty]] 9218868437227405312
 ; CHECK-DAG: %[[#NegInfFP64:]] = OpConstant %[[#I64Ty]] 18442240474082181120
 
-; CHECK-DAG: %[[#FalseV4:]] = OpConstantComposite %[[#V4BoolTy]] %[[#False]] %[[#False]] %[[#False]] %[[#False]]
+; CHECK-DAG: %[[#FalseV4:]] = OpConstantNull %[[#V4BoolTy]]
 ; CHECK-DAG: %[[#ValueMaskV4:]] = OpConstantComposite %[[#V4I32Ty]] %[[#ValueMask]] %[[#ValueMask]] %[[#ValueMask]] %[[#ValueMask]]
 ; CHECK-DAG: %[[#InfV4:]] = OpConstantComposite %[[#V4I32Ty]] %[[#Inf]] %[[#Inf]] %[[#Inf]] %[[#Inf]]
 ; CHECK-DAG: %[[#InfWithQnanBitV4:]] = OpConstantComposite %[[#V4I32Ty]] %[[#InfWithQnanBit]] %[[#InfWithQnanBit]] %[[#InfWithQnanBit]] %[[#InfWithQnanBit]]

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/signed_arithmetic_overflow.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/signed_arithmetic_overflow.ll
@@ -8,7 +8,7 @@
 ; CHECK-DAG: %[[#NullInt:]] = OpConstantNull %[[#Int]]
 ; CHECK-DAG: %[[#V2Int:]] = OpTypeVector %[[#Int]] 2
 ; CHECK-DAG: %[[#V2Bool:]] = OpTypeVector %[[#Bool]] 2
-; CHECK-DAG: %[[#NullV2Int:]] = OpConstantComposite %[[#V2Int]]
+; CHECK-DAG: %[[#NullV2Int:]] = OpConstantNull %[[#V2Int]]
 
 ; CHECK: OpFunction
 ; CHECK: %[[#A:]] = OpFunctionParameter %[[#Int]]


### PR DESCRIPTION
I'm hoping the transformation stands on its own, but the rational for the change is https://github.com/llvm/llvm-project/pull/200465, where I'm changing the canonical form of NULL floating point vectors.