### PR TITLE
[libc] Remove redundant file(COPY) for x86_64 types

### DIFF
--- a/libc/include/llvm-libc-types/CMakeLists.txt
+++ b/libc/include/llvm-libc-types/CMakeLists.txt
@@ -133,7 +133,6 @@ set(mcontext_deps)
 set(ucontext_deps .sigset_t .stack_t)
 
 if(LIBC_TARGET_ARCHITECTURE STREQUAL "x86_64")
-  file(COPY x86_64 DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
   add_header(
     mcontext_t_arch
     HDR


### PR DESCRIPTION
Removed the redundant file(COPY) command from the x86_64 architecture check in libc/include/llvm-libc-types/CMakeLists.txt.

This command eagerly copies the x86_64 directory to the binary directory, which is redundant because individual headers are already copied by their respective add_header targets. It also preserved read-only depot permissions from the source tree, making the build directory read-only and causing rm -rf to fail.

Assisted-by: Automated tooling, human reviewed.