### PR TITLE
[OFFLOAD] Update L0 olMemFill unit tests known failures

### DIFF
--- a/offload/unittests/OffloadAPI/memory/olMemFill.cpp
+++ b/offload/unittests/OffloadAPI/memory/olMemFill.cpp
@@ -13,12 +13,16 @@
 struct olMemFillTest : OffloadQueueTest {
   void SetUp() override {
     RETURN_ON_FATAL_FAILURE(OffloadQueueTest::SetUp());
-    SKIP_KNOWN_FAILURE(LevelZero{"unsupported feature"});
   }
 
   template <typename PatternTy, PatternTy PatternVal, size_t Size,
             bool Block = false>
   void test_body() {
+    if constexpr (Block) {
+      // Only tests relying on olLaunchHostFunction are failing.
+      SKIP_KNOWN_FAILURE(LevelZero{"unsupported feature"});
+    }
+
     ManuallyTriggeredTask Manual;
 
     // Block/enqueue tests ensure that the test has been enqueued to a queue
@@ -101,6 +105,7 @@ TEST_P(olMemFillTest, SuccessLarge) {
 }
 
 TEST_P(olMemFillTest, SuccessLargeEnqueue) {
+  SKIP_KNOWN_FAILURE(LevelZero{"unsupported feature"});
   constexpr size_t Size = 1024;
   void *Alloc;
   ManuallyTriggeredTask Manual;
@@ -155,6 +160,7 @@ TEST_P(olMemFillTest, SuccessLargeByteAligned) {
 }
 
 TEST_P(olMemFillTest, SuccessLargeByteAlignedEnqueue) {
+  SKIP_KNOWN_FAILURE(LevelZero{"unsupported feature"});
   constexpr size_t Size = 17 * 64;
   void *Alloc;
   ManuallyTriggeredTask Manual;

--- a/offload/unittests/OffloadAPI/memory/olMemFill.cpp
+++ b/offload/unittests/OffloadAPI/memory/olMemFill.cpp
@@ -11,9 +11,7 @@
 #include <gtest/gtest.h>
 
 struct olMemFillTest : OffloadQueueTest {
-  void SetUp() override {
-    RETURN_ON_FATAL_FAILURE(OffloadQueueTest::SetUp());
-  }
+  void SetUp() override { RETURN_ON_FATAL_FAILURE(OffloadQueueTest::SetUp()); }
 
   template <typename PatternTy, PatternTy PatternVal, size_t Size,
             bool Block = false>


### PR DESCRIPTION
With the latest L0 changes most MemFill tests are passing. Only those that rely on olLaunchHostFunction should be skipped.