### PR TITLE
[lldb] Use the right MinGW name for the Python DLLs

### DIFF
--- a/lldb/CMakeLists.txt
+++ b/lldb/CMakeLists.txt
@@ -100,8 +100,13 @@ if (LLDB_ENABLE_PYTHON)
   if(WIN32)
     # On Windows, FindPython3 doesn't reliably expose the runtime DLL path,
     # only the import library. CPython's DLL naming is standard.
-    set(LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME
-        "python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}.dll")
+    if(MINGW)
+      set(LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME
+          "libpython${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}.dll")
+    else()
+      set(LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME
+          "python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}.dll")
+    endif()
     message(STATUS "LLDB Python runtime DLL: ${LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME} "
                    "(Python3_VERSION=${Python3_VERSION}, "
                    "limited_api=${LLDB_ENABLE_PYTHON_LIMITED_API})")

--- a/lldb/source/Host/common/PythonRuntimeLoader.cpp
+++ b/lldb/source/Host/common/PythonRuntimeLoader.cpp
@@ -133,12 +133,16 @@ private:
         if (m_path.empty())
           return;
 #if defined(_WIN32)
-        // liblldb.dll may link against python3.dll (stable ABI). Ensure it is
-        // loaded from the same directory as the version-specific runtime so
-        // the delay-load resolver can find it.
+        // liblldb.dll may link against (lib)python3.dll (stable ABI). Ensure
+        // it is loaded from the same directory as the version-specific runtime
+        // so the delay-load resolver can find it.
         llvm::SmallString<256> stable_abi_path(m_path);
         llvm::sys::path::remove_filename(stable_abi_path);
+#if defined(__MINGW32__)
+        llvm::sys::path::append(stable_abi_path, "libpython3.dll");
+#else
         llvm::sys::path::append(stable_abi_path, "python3.dll");
+#endif
         std::string err;
         llvm::sys::DynamicLibrary::getPermanentLibrary(stable_abi_path.c_str(),
                                                        &err);


### PR DESCRIPTION
In MinGW mode, the Python DLLs have different names than they have in MSVC mode; they are named `libpython<major>.<minor>.dll` (a "lib" prefix and a dot between major and minor) and `libpython3.dll`.

This avoids a warning on startup after
142ad481b6254104a51da7d636ad9e3f30518a32 and total failures to start up after 3eb13f8db39ed42827122489c830c414cb6660e3.