### PR TITLE
[lldb][test] Only calculate LLDB python path once

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/configuration.py
+++ b/lldb/packages/Python/lldbsuite/test/configuration.py
@@ -160,6 +160,11 @@ arm64e_debugserver = False
 # Whether to print the lldb version banner during test setup.
 print_lldb_version = False
 
+# Path to the directory containing the 'lldb' Python module (i.e. the directory
+# that contains 'lldb/__init__.py'). When set, dotest skips the `lldb -P`
+# subprocess used to discover this path.
+lldb_python_dir = None
+
 # the build type of lldb
 # Typical values include Debug, Release, RelWithDebInfo and MinSizeRel
 cmake_build_type = None

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -477,6 +477,9 @@ def parseOptionsAndInitTestdirs():
     if args.print_lldb_version:
         configuration.print_lldb_version = True
 
+    if args.lldb_python_dir:
+        configuration.lldb_python_dir = args.lldb_python_dir
+
     # Gather all the dirs passed on the command line.
     if len(args.args) > 0:
         configuration.testdirs = [
@@ -588,17 +591,32 @@ def setupSysPath():
 
     lldbPythonDir = None  # The directory that contains 'lldb/__init__.py'
 
-    # If our lldb supports the -P option, use it to find the python path:
-    lldb_dash_p_result = subprocess.check_output(
-        [lldbtest_config.lldbExec, "-P"], universal_newlines=True
-    )
-    if lldb_dash_p_result:
-        for line in lldb_dash_p_result.splitlines():
-            if os.path.isdir(line) and os.path.exists(
-                os.path.join(line, "lldb", "__init__.py")
-            ):
-                lldbPythonDir = line
-                break
+    if configuration.lldb_python_dir:
+        # The path was passed in (typically by LIT, which discovers it once for
+        # the whole test run). Trust it without spawning lldb.
+        candidate = configuration.lldb_python_dir
+        if os.path.isdir(candidate) and os.path.exists(
+            os.path.join(candidate, "lldb", "__init__.py")
+        ):
+            lldbPythonDir = candidate
+        else:
+            print(
+                "warning: --lldb-python-dir '%s' does not contain 'lldb/__init__.py'; "
+                "falling back to '%s -P'" % (candidate, lldbtest_config.lldbExec)
+            )
+
+    if not lldbPythonDir:
+        # If our lldb supports the -P option, use it to find the python path:
+        lldb_dash_p_result = subprocess.check_output(
+            [lldbtest_config.lldbExec, "-P"], universal_newlines=True
+        )
+        if lldb_dash_p_result:
+            for line in lldb_dash_p_result.splitlines():
+                if os.path.isdir(line) and os.path.exists(
+                    os.path.join(line, "lldb", "__init__.py")
+                ):
+                    lldbPythonDir = line
+                    break
 
     if not lldbPythonDir:
         print(

--- a/lldb/packages/Python/lldbsuite/test/dotest_args.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest_args.py
@@ -298,6 +298,12 @@ def create_parser():
         action="store_true",
         help="Print the lldb version banner during test setup.",
     )
+    group.add_argument(
+        "--lldb-python-dir",
+        dest="lldb_python_dir",
+        metavar="path",
+        help="Path to the directory that contains the 'lldb' Python module. ",
+    )
 
     # Configuration options
     group = parser.add_argument_group("Remote platform options")

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -272,6 +272,28 @@ if is_configured("lldb_executable"):
             "Could not get lldb version from {}: {}".format(config.lldb_executable, e)
         )
 
+    # Discover the directory that contains the 'lldb' Python module once here,
+    # so each dotest invocation doesn't have to spawn '<lldb> -P' itself.
+    try:
+        lldb_dash_p_output = subprocess.check_output(
+            [config.lldb_executable, "-P"],
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        for line in lldb_dash_p_output.splitlines():
+            line = line.strip()
+            if os.path.isdir(line) and os.path.exists(
+                os.path.join(line, "lldb", "__init__.py")
+            ):
+                dotest_cmd += ["--lldb-python-dir", line]
+                break
+    except (subprocess.CalledProcessError, OSError) as e:
+        lit_config.warning(
+            "Could not discover lldb python path from {}: {}".format(
+                config.lldb_executable, e
+            )
+        )
+
 if is_configured("test_compiler"):
     dotest_cmd += ["--compiler", config.test_compiler]
 


### PR DESCRIPTION
We spend about 70ms each dotest invocation recalculating the path where
the LLDB module is. This patch changes this so that dotest calculates
this path once and passes it to every dotest invocation.

As a fallback, we still support inferring the location from LLDB as
before, but I would propose we drop this support in the future.