### PR TITLE
[HIP] Remove explicit compiler-rt from bot recipe

### DIFF
--- a/offload/ci/hip-tpl.py
+++ b/offload/ci/hip-tpl.py
@@ -86,7 +86,6 @@ with worker.run(
                 f"-S{w.in_llvmsrc('llvm')}",
                 f"-B{llvmbuilddir}",
                 f"-C{w.cachefile}",
-                f"-DLLVM_ENABLE_RUNTIMES=compiler-rt",
             ]
         )
 


### PR DESCRIPTION
The same change was done to the AnnotatedBuilder script recently. Let's keep them in sync.
https://github.com/llvm/llvm-zorg/pull/861