### PR TITLE
[lldb][test] Assume clang supports -gmodules

### DIFF
--- a/lldb/packages/Python/lldbsuite/support/gmodules.py
+++ b/lldb/packages/Python/lldbsuite/support/gmodules.py
@@ -14,12 +14,7 @@ def is_compiler_clang_with_gmodules(compiler_path):
 
     def _gmodules_supported_internal():
         compiler = os.path.basename(compiler_path)
-        if "clang" not in compiler:
-            return False
-        else:
-            # Check the compiler help for the -gmodules option.
-            clang_help = os.popen("%s --help" % compiler_path).read()
-            return GMODULES_HELP_REGEX.search(clang_help, re.DOTALL) is not None
+        return "clang" in compiler
 
     GMODULES_SUPPORT_MAP[compiler_path] = _gmodules_supported_internal()
     return GMODULES_SUPPORT_MAP[compiler_path]


### PR DESCRIPTION
We currently spend 50ms in most dotest invocations to check if clang supports `-gmodules`. The expensive part of this check is creating the clang process to run `clang --help`.

`-gmodules` was added 11 years ago and is present in any compiler that has even a remote chance in supporting the rest of our test suite. This patch just assumes that our compiler supports -gmodules if it is clang.