### PR TITLE
[CI] switch to BuildTools variant of Visual Studio

### DIFF
--- a/.ci/green-dragon/lldb-windows.groovy
+++ b/.ci/green-dragon/lldb-windows.groovy
@@ -49,9 +49,7 @@ pipeline {
                 timeout(240) {
                     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                         writeFile file: 'build.bat', text: '''@echo off
-call "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Auxiliary\\Build\\vcvars64.bat" || exit /b 1
-
-"C:\\Program Files\\Python313\\python.exe" -m pip install packaging || exit /b 1
+call "C:\\Program Files\\Microsoft Visual Studio\\2022\\BuildTools\\VC\\Auxiliary\\Build\\vcvars64.bat" || exit /b 1
 
 cmake -G Ninja ^
     -S llvm ^

--- a/.ci/green-dragon/lldb-windows.groovy
+++ b/.ci/green-dragon/lldb-windows.groovy
@@ -49,7 +49,7 @@ pipeline {
                 timeout(240) {
                     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                         writeFile file: 'build.bat', text: '''@echo off
-call "C:\\Program Files\\Microsoft Visual Studio\\2022\\BuildTools\\VC\\Auxiliary\\Build\\vcvars64.bat" || exit /b 1
+call "C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\VC\\Auxiliary\\Build\\vcvars64.bat" || exit /b 1
 
 cmake -G Ninja ^
     -S llvm ^


### PR DESCRIPTION
Follow up to:
- https://github.com/swiftlang/swift-docker/pull/566
- https://github.com/swiftlang/swift-docker/pull/565

It's no longer necessary to install packaging at runtime and the new image will use `BuildTools`.