### PR TITLE
[X86] combineSelect - fold select(c,trunc(x),y) -> X86ISD::MTRUNC(x,y,c) for non-BWI targets

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -48911,6 +48911,15 @@ static SDValue combineSelect(SDNode *N, SelectionDAG &DAG,
       CondVT.getVectorElementType() == MVT::i1 &&
       (VT.getVectorElementType() == MVT::i8 ||
        VT.getVectorElementType() == MVT::i16)) {
+    // Handle AVX512F masked trunc patterns, which do have vXi8/vXi16 selects.
+    if (LHS.getOpcode() == ISD::TRUNCATE) {
+      SDValue TruncSrc = LHS.getOperand(0);
+      EVT TruncSrcVT = TruncSrc.getValueType();
+      if ((VT == MVT::v8i16 && TruncSrcVT == MVT::v8i64) ||
+          (VT == MVT::v16i8 && TruncSrcVT == MVT::v16i32) ||
+          (VT == MVT::v16i16 && TruncSrcVT == MVT::v16i32))
+        return DAG.getNode(X86ISD::VMTRUNC, DL, VT, TruncSrc, RHS, Cond);
+    }
     Cond = DAG.getNode(ISD::SIGN_EXTEND, DL, VT, Cond);
     return DAG.getNode(N->getOpcode(), DL, VT, Cond, LHS, RHS);
   }

--- a/llvm/test/CodeGen/X86/avg-mask.ll
+++ b/llvm/test/CodeGen/X86/avg-mask.ll
@@ -274,10 +274,10 @@ define <16 x i16> @avg_v16i16_mask(<16 x i16> %a, <16 x i16> %b, <16 x i16> %src
 ; AVX512F-LABEL: avg_v16i16_mask:
 ; AVX512F:       # %bb.0:
 ; AVX512F-NEXT:    vpavgw %ymm1, %ymm0, %ymm0
+; AVX512F-NEXT:    vpmovzxwd {{.*#+}} zmm0 = ymm0[0],zero,ymm0[1],zero,ymm0[2],zero,ymm0[3],zero,ymm0[4],zero,ymm0[5],zero,ymm0[6],zero,ymm0[7],zero,ymm0[8],zero,ymm0[9],zero,ymm0[10],zero,ymm0[11],zero,ymm0[12],zero,ymm0[13],zero,ymm0[14],zero,ymm0[15],zero
 ; AVX512F-NEXT:    kmovw %edi, %k1
-; AVX512F-NEXT:    vpternlogd {{.*#+}} zmm1 {%k1} {z} = -1
-; AVX512F-NEXT:    vpmovdw %zmm1, %ymm1
-; AVX512F-NEXT:    vpblendvb %ymm1, %ymm0, %ymm2, %ymm0
+; AVX512F-NEXT:    vpmovdw %zmm0, %ymm2 {%k1}
+; AVX512F-NEXT:    vmovdqa %ymm2, %ymm0
 ; AVX512F-NEXT:    retq
 ;
 ; AVX512BWVL-LABEL: avg_v16i16_mask:
@@ -301,10 +301,9 @@ define <16 x i16> @avg_v16i16_maskz(<16 x i16> %a, <16 x i16> %b, i16 %mask) nou
 ; AVX512F-LABEL: avg_v16i16_maskz:
 ; AVX512F:       # %bb.0:
 ; AVX512F-NEXT:    vpavgw %ymm1, %ymm0, %ymm0
+; AVX512F-NEXT:    vpmovzxwd {{.*#+}} zmm0 = ymm0[0],zero,ymm0[1],zero,ymm0[2],zero,ymm0[3],zero,ymm0[4],zero,ymm0[5],zero,ymm0[6],zero,ymm0[7],zero,ymm0[8],zero,ymm0[9],zero,ymm0[10],zero,ymm0[11],zero,ymm0[12],zero,ymm0[13],zero,ymm0[14],zero,ymm0[15],zero
 ; AVX512F-NEXT:    kmovw %edi, %k1
-; AVX512F-NEXT:    vpternlogd {{.*#+}} zmm1 {%k1} {z} = -1
-; AVX512F-NEXT:    vpmovdw %zmm1, %ymm1
-; AVX512F-NEXT:    vpand %ymm0, %ymm1, %ymm0
+; AVX512F-NEXT:    vpmovdw %zmm0, %ymm0 {%k1} {z}
 ; AVX512F-NEXT:    retq
 ;
 ; AVX512BWVL-LABEL: avg_v16i16_maskz:

--- a/llvm/test/CodeGen/X86/avx512-trunc.ll
+++ b/llvm/test/CodeGen/X86/avx512-trunc.ll
@@ -182,11 +182,8 @@ define <8 x i16> @trunc_qw_512(<8 x i64> %i) #0 {
 define <8 x i16> @trunc_qw_512_maskz(<8 x i64> %i, i8 %m) #0 {
 ; KNL-LABEL: trunc_qw_512_maskz:
 ; KNL:       ## %bb.0:
-; KNL-NEXT:    vpmovqw %zmm0, %xmm0
 ; KNL-NEXT:    kmovw %edi, %k1
-; KNL-NEXT:    vpternlogd {{.*#+}} zmm1 {%k1} {z} = -1
-; KNL-NEXT:    vpmovdw %zmm1, %ymm1
-; KNL-NEXT:    vpand %xmm0, %xmm1, %xmm0
+; KNL-NEXT:    vpmovqw %zmm0, %xmm0 {%k1} {z}
 ; KNL-NEXT:    vzeroupper
 ; KNL-NEXT:    retq
 ;
@@ -205,11 +202,9 @@ define <8 x i16> @trunc_qw_512_maskz(<8 x i64> %i, i8 %m) #0 {
 define <8 x i16> @trunc_qw_512_mask(<8 x i64> %i, <8 x i16> %p, i8 %m) #0 {
 ; KNL-LABEL: trunc_qw_512_mask:
 ; KNL:       ## %bb.0:
-; KNL-NEXT:    vpmovqw %zmm0, %xmm0
 ; KNL-NEXT:    kmovw %edi, %k1
-; KNL-NEXT:    vpternlogd {{.*#+}} zmm2 {%k1} {z} = -1
-; KNL-NEXT:    vpmovdw %zmm2, %ymm2
-; KNL-NEXT:    vpblendvb %xmm2, %xmm0, %xmm1, %xmm0
+; KNL-NEXT:    vpmovqw %zmm0, %xmm1 {%k1}
+; KNL-NEXT:    vmovdqa %xmm1, %xmm0
 ; KNL-NEXT:    vzeroupper
 ; KNL-NEXT:    retq
 ;
@@ -439,8 +434,7 @@ define <16 x i8> @trunc_db_512_maskz(<16 x i32> %i, i16 %m) #0 {
 ; KNL-LABEL: trunc_db_512_maskz:
 ; KNL:       ## %bb.0:
 ; KNL-NEXT:    kmovw %edi, %k1
-; KNL-NEXT:    vmovdqa32 %zmm0, %zmm0 {%k1} {z}
-; KNL-NEXT:    vpmovdb %zmm0, %xmm0
+; KNL-NEXT:    vpmovdb %zmm0, %xmm0 {%k1} {z}
 ; KNL-NEXT:    vzeroupper
 ; KNL-NEXT:    retq
 ;
@@ -459,11 +453,9 @@ define <16 x i8> @trunc_db_512_maskz(<16 x i32> %i, i16 %m) #0 {
 define <16 x i8> @trunc_db_512_mask(<16 x i32> %i, <16 x i8> %p, i16 %m) #0 {
 ; KNL-LABEL: trunc_db_512_mask:
 ; KNL:       ## %bb.0:
-; KNL-NEXT:    vpmovdb %zmm0, %xmm0
 ; KNL-NEXT:    kmovw %edi, %k1
-; KNL-NEXT:    vpternlogd {{.*#+}} zmm2 {%k1} {z} = -1
-; KNL-NEXT:    vpmovdb %zmm2, %xmm2
-; KNL-NEXT:    vpblendvb %xmm2, %xmm0, %xmm1, %xmm0
+; KNL-NEXT:    vpmovdb %zmm0, %xmm1 {%k1}
+; KNL-NEXT:    vmovdqa %xmm1, %xmm0
 ; KNL-NEXT:    vzeroupper
 ; KNL-NEXT:    retq
 ;
@@ -570,8 +562,7 @@ define <16 x i16> @trunc_dw_512_maskz(<16 x i32> %i, i16 %m) #0 {
 ; KNL-LABEL: trunc_dw_512_maskz:
 ; KNL:       ## %bb.0:
 ; KNL-NEXT:    kmovw %edi, %k1
-; KNL-NEXT:    vmovdqa32 %zmm0, %zmm0 {%k1} {z}
-; KNL-NEXT:    vpmovdw %zmm0, %ymm0
+; KNL-NEXT:    vpmovdw %zmm0, %ymm0 {%k1} {z}
 ; KNL-NEXT:    retq
 ;
 ; SKX-LABEL: trunc_dw_512_maskz:
@@ -588,11 +579,9 @@ define <16 x i16> @trunc_dw_512_maskz(<16 x i32> %i, i16 %m) #0 {
 define <16 x i16> @trunc_dw_512_mask(<16 x i32> %i, <16 x i16> %p, i16 %m) #0 {
 ; KNL-LABEL: trunc_dw_512_mask:
 ; KNL:       ## %bb.0:
-; KNL-NEXT:    vpmovdw %zmm0, %ymm0
 ; KNL-NEXT:    kmovw %edi, %k1
-; KNL-NEXT:    vpternlogd {{.*#+}} zmm2 {%k1} {z} = -1
-; KNL-NEXT:    vpmovdw %zmm2, %ymm2
-; KNL-NEXT:    vpblendvb %ymm2, %ymm0, %ymm1, %ymm0
+; KNL-NEXT:    vpmovdw %zmm0, %ymm1 {%k1}
+; KNL-NEXT:    vmovdqa %ymm1, %ymm0
 ; KNL-NEXT:    retq
 ;
 ; SKX-LABEL: trunc_dw_512_mask:


### PR DESCRIPTION
Fixes #200617