### PR TITLE
[CodeGen][MIR] Delete llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err3.mir (NFC)

### DIFF
--- a/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err3.mir
+++ b/llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err3.mir
@@ -1,9 +1,0 @@
-# RUN: not llc -run-pass none -o - %s 2>&1 | FileCheck %s
----
-name: err_after_vscalex0
-body: |
-  bb.0:
-    %0:_(<vscale x) = IMPLICIT_DEF
-...
-
-# CHECK: expected <vscale x M x tN> for vector type, where t = {'s', 'i', 'f', 'bf', 'p'}


### PR DESCRIPTION
It's bit-identical to
llvm/test/CodeGen/MIR/Generic/scalable-vector-type-err2.mir. Not sure what the original intention was.