### PR TITLE
[mlir][Python] Don't attempt to load builtin dialect

### DIFF
--- a/mlir/lib/Bindings/Python/Globals.cpp
+++ b/mlir/lib/Bindings/Python/Globals.cpp
@@ -62,6 +62,9 @@ PyGlobals &PyGlobals::get() {
 }
 
 bool PyGlobals::loadDialectModule(std::string_view dialectNamespace) {
+  if (dialectNamespace == "builtin")
+    return true;
+
   {
     nb::ft_lock_guard lock(mutex);
     std::string dialectNamespaceStr(dialectNamespace);


### PR DESCRIPTION
Builtin dialect is loaded/available by default, right?
I've seen repeated load attempts of builtin, but the module is not found and thus 'false' returned and not cached. But calls to `nb::module_::import_` are expensive.