### PR TITLE
[AArch64] Add an early return and de-indent a long indented block (NFC)

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64LoadStoreOptimizer.cpp
+++ b/llvm/lib/Target/AArch64/AArch64LoadStoreOptimizer.cpp
@@ -2869,52 +2869,52 @@ bool AArch64LoadStoreOpt::tryToPairLdStInst(MachineBasicBlock::iterator &MBBI) {
   LdStPairFlags Flags;
   MachineBasicBlock::iterator Paired =
       findMatchingInsn(MBBI, Flags, LdStLimit, /* FindNarrowMerge = */ false);
-  if (Paired != E) {
-    // Keeping the iterator straight is a pain, so we let the merge routine tell
-    // us what the next instruction is after it's done mucking about.
-    auto Prev = std::prev(MBBI);
 
-    // Fetch the memoperand of the load/store that is a candidate for
-    // combination.
-    MachineMemOperand *MemOp =
-        MI.memoperands_empty() ? nullptr : MI.memoperands().front();
+  if (Paired == E)
+    return false;
 
-    // If a load/store arrives and ldp/stp-aligned-only feature is opted, check
-    // that the alignment of the source pointer is at least double the alignment
-    // of the type.
-    if ((MI.mayLoad() && Subtarget->hasLdpAlignedOnly()) ||
-        (MI.mayStore() && Subtarget->hasStpAlignedOnly())) {
-      // If there is no size/align information, cancel the transformation.
-      if (!MemOp || !MemOp->getMemoryType().isValid()) {
-        NumFailedAlignmentCheck++;
-        return false;
-      }
+  // Keeping the iterator straight is a pain, so we let the merge routine tell
+  // us what the next instruction is after it's done mucking about.
+  auto Prev = std::prev(MBBI);
 
-      // Get the needed alignments to check them if
-      // ldp-aligned-only/stp-aligned-only features are opted.
-      uint64_t MemAlignment = MemOp->getAlign().value();
-      uint64_t TypeAlignment =
-          Align(MemOp->getSize().getValue().getKnownMinValue()).value();
+  // Fetch the memoperand of the load/store that is a candidate for combination.
+  MachineMemOperand *MemOp =
+      MI.memoperands_empty() ? nullptr : MI.memoperands().front();
 
-      if (MemAlignment < 2 * TypeAlignment) {
-        NumFailedAlignmentCheck++;
-        return false;
-      }
+  // If a load/store arrives and ldp/stp-aligned-only feature is opted, check
+  // that the alignment of the source pointer is at least double the alignment
+  // of the type.
+  if ((MI.mayLoad() && Subtarget->hasLdpAlignedOnly()) ||
+      (MI.mayStore() && Subtarget->hasStpAlignedOnly())) {
+    // If there is no size/align information, cancel the transformation.
+    if (!MemOp || !MemOp->getMemoryType().isValid()) {
+      NumFailedAlignmentCheck++;
+      return false;
     }
 
-    ++NumPairCreated;
-    if (TII->hasUnscaledLdStOffset(MI))
-      ++NumUnscaledPairCreated;
+    // Get the needed alignments to check them if
+    // ldp-aligned-only/stp-aligned-only features are opted.
+    uint64_t MemAlignment = MemOp->getAlign().value();
+    uint64_t TypeAlignment =
+        Align(MemOp->getSize().getValue().getKnownMinValue()).value();
 
-    MBBI = mergePairedInsns(MBBI, Paired, Flags);
-    // Collect liveness info for instructions between Prev and the new position
-    // MBBI.
-    for (auto I = std::next(Prev); I != MBBI; I++)
-      updateDefinedRegisters(*I, DefinedInBB, TRI);
-
-    return true;
+    if (MemAlignment < 2 * TypeAlignment) {
+      NumFailedAlignmentCheck++;
+      return false;
+    }
   }
-  return false;
+
+  ++NumPairCreated;
+  if (TII->hasUnscaledLdStOffset(MI))
+    ++NumUnscaledPairCreated;
+
+  MBBI = mergePairedInsns(MBBI, Paired, Flags);
+  // Collect liveness info for instructions between Prev and the new position
+  // MBBI.
+  for (auto I = std::next(Prev); I != MBBI; I++)
+    updateDefinedRegisters(*I, DefinedInBB, TRI);
+
+  return true;
 }
 
 bool AArch64LoadStoreOpt::tryToMergeLdStUpdate


### PR DESCRIPTION
As per LLVM coding standards recommendation in [1].

[1]: https://llvm.org/docs/CodingStandards.html#use-early-exits-and-continue-to-simplify-code