### PR TITLE
[OFFLOAD][L0] Return symbol size in getGlobalMetadataFromDevice

### DIFF
--- a/offload/plugins-nextgen/level_zero/include/L0Program.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Program.h
@@ -105,8 +105,10 @@ public:
   /// specified global variable name.
   Error writeGlobalVariable(const char *Name, size_t Size, const void *HostPtr);
 
-  /// Looks up a device global symbol with the given \p Name in the device.
-  Expected<void *> getSymbolDeviceAddr(const char *Name) const;
+  /// Looks up a device global symbol with the given \p Name in the device and
+  /// returns its address and size in \p Addr and \p SizePtr respectively.
+  Error getSymbolMetadata(const char *Name, void **AddrPtr,
+                          size_t *SizePtr) const;
 
   /// Returns the handle of a module that contains a given Kernel name.
   ze_module_handle_t findModuleFromKernelName(const char *KernelName) const {

--- a/offload/plugins-nextgen/level_zero/src/L0Program.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Program.cpp
@@ -29,14 +29,17 @@ Error L0GlobalHandlerTy::getGlobalMetadataFromDevice(GenericDeviceTy &Device,
                                                      DeviceImageTy &Image,
                                                      GlobalTy &DeviceGlobal) {
   const char *GlobalName = DeviceGlobal.getName().data();
+  size_t SymbolSize = 0;
+  void *SymbolAddr = nullptr;
 
   L0ProgramTy &Program = L0ProgramTy::makeL0Program(Image);
-  auto AddrOrErr = Program.getSymbolDeviceAddr(GlobalName);
-  if (!AddrOrErr)
-    return AddrOrErr.takeError();
+  if (auto Err =
+          Program.getSymbolMetadata(GlobalName, &SymbolAddr, &SymbolSize))
+    return Err;
 
   // Save the pointer to the symbol allowing nullptr.
-  DeviceGlobal.setPtr(*AddrOrErr);
+  DeviceGlobal.setPtr(SymbolAddr);
+  DeviceGlobal.setSize(SymbolSize);
 
   return Plugin::success();
 }
@@ -537,27 +540,28 @@ Expected<std::unique_ptr<MemoryBuffer>> L0ProgramBuilderTy::getELF() {
       /*BufferName=*/"L0Program ELF");
 }
 
-Expected<void *> L0ProgramTy::getSymbolDeviceAddr(const char *CName) const {
-  ODBG(OLDT_Module) << "Looking up OpenMP global variable '" << CName << "'.";
-
-  if (!GlobalModule || !CName)
+Error L0ProgramTy::getSymbolMetadata(const char *Name, void **AddrPtr,
+                                     size_t *SizePtr) const {
+  if (!Name)
     return Plugin::error(ErrorCode::INVALID_ARGUMENT,
                          "Invalid arguments to getSymbolDeviceAddr");
 
-  size_t SizeDummy = 0;
-  void *DevicePtr = nullptr;
+  size_t SymbolSize = 0;
+  void *SymbolAddr = nullptr;
   ze_result_t RC;
   for (auto Module : Modules) {
-    CALL_ZE(RC, zeModuleGetGlobalPointer, Module, CName, &SizeDummy,
-            &DevicePtr);
-    if (RC == ZE_RESULT_SUCCESS && DevicePtr)
-      return DevicePtr;
-    CALL_ZE(RC, zeModuleGetFunctionPointer, Module, CName, &DevicePtr);
-    if (RC == ZE_RESULT_SUCCESS && DevicePtr)
-      return DevicePtr;
+    CALL_ZE(RC, zeModuleGetGlobalPointer, Module, Name, &SymbolSize,
+            &SymbolAddr);
+    if (RC == ZE_RESULT_SUCCESS && SymbolAddr) {
+      if (AddrPtr)
+        *AddrPtr = SymbolAddr;
+      if (SizePtr)
+        *SizePtr = SymbolSize;
+      return Plugin::success();
+    }
   }
   return Plugin::error(ErrorCode::NOT_FOUND, "symbol '%s' not found on device",
-                       CName);
+                       Name);
 }
 
 Error L0ProgramTy::readGlobalVariable(const char *Name, size_t Size,

--- a/offload/unittests/OffloadAPI/symbol/olGetSymbolInfo.cpp
+++ b/offload/unittests/OffloadAPI/symbol/olGetSymbolInfo.cpp
@@ -52,8 +52,6 @@ TEST_P(olGetSymbolInfoKernelTest, InvalidSize) {
 }
 
 TEST_P(olGetSymbolInfoGlobalTest, SuccessSize) {
-  SKIP_KNOWN_FAILURE(LevelZero{"unsupported feature"});
-
   size_t RetrievedSize = 0;
   ASSERT_SUCCESS(olGetSymbolInfo(Global, OL_SYMBOL_INFO_GLOBAL_VARIABLE_SIZE,
                                  sizeof(RetrievedSize), &RetrievedSize));


### PR DESCRIPTION
Return not just the address but also the size of the symbols in getGlobalMetadataFromDevice.
Fixes olGetSymbolInfoSizeGlobalTest.SuccessSize unitt test failure with L0 plugin.