### PR TITLE
[clang][bytecode] Fix a crash with covariant return types

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -2000,6 +2000,12 @@ bool CallVirt(InterpState &S, CodePtr OpPC, const Function *Func,
         Overrider->getReturnType()->getPointeeType();
     QualType InitialPointeeType =
         InitialFunction->getReturnType()->getPointeeType();
+
+    // Nothing to do if the types already match.
+    if (S.getASTContext().hasSimilarType(InitialPointeeType,
+                                         OverriderPointeeType))
+      return true;
+
     // We've called Overrider above, but calling code expects us to return what
     // InitialFunction returned. According to the rules for covariant return
     // types, what InitialFunction returns needs to be a base class of what

--- a/clang/lib/AST/ByteCode/Pointer.h
+++ b/clang/lib/AST/ByteCode/Pointer.h
@@ -931,6 +931,8 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const Pointer &P) {
     OS << " dummy";
   if (!P.isLive())
     OS << " dead";
+  if (P.isBaseClass())
+    OS << " base-class";
   return OS;
 }
 

--- a/clang/test/AST/ByteCode/cxx20.cpp
+++ b/clang/test/AST/ByteCode/cxx20.cpp
@@ -1365,5 +1365,20 @@ namespace IndirectFieldInitializer {
     constexpr A() {}
   };
   static_assert(A().x == 3, "");
+}
 
+namespace Covariant {
+  struct A {
+    int a;
+    constexpr virtual const A* getA() const = 0;
+  };
+  struct B { int b; };
+
+  struct C: A, B {
+    constexpr const C* getA() const override {
+      return this;
+    }
+  };
+  constexpr  C c{};
+  static_assert(c.getA() == &c);
 }


### PR DESCRIPTION
`Context::collectBaseOffset()` will assert if the passed-in classes are the same.