### PR TITLE
[Clang] Fix leftover use of old LTO path

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9713,6 +9713,17 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
           }
         }
       }
+
+      if (JA.getType() == types::TY_HIP_FATBIN && Kind == Action::OFK_HIP) {
+        // Non-RDC HIP uses the conventional non-LTO pipeline unless the user
+        // opts into offload LTO.
+        bool UsesProfileGenerate = Args.hasArg(
+            options::OPT_fprofile_generate, options::OPT_fprofile_generate_EQ,
+            options::OPT_fprofile_instr_generate,
+            options::OPT_fprofile_instr_generate_EQ);
+        if (TC->getLTOMode(Args, Kind) == LTOK_None && !UsesProfileGenerate)
+          CmdArgs.push_back("--no-lto");
+      }
     }
   }
 
@@ -9820,23 +9831,13 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
          JA.getType() == types::TY_Image);
   if (JA.getType() == types::TY_HIP_FATBIN) {
     CmdArgs.push_back("--emit-fatbin-only");
-    // Non-RDC HIP uses the conventional non-LTO pipeline unless the user opts
-    // into offload LTO. The device backend then runs in the linker wrapper's
-    // parallel device-link step rather than being deferred to the LTO link.
-    // Profile generation still needs LTO so the device profile runtime is
-    // linked and optimized together with the device code.
-    bool UsesProfileGenerate = Args.hasArg(
-        options::OPT_fprofile_generate, options::OPT_fprofile_generate_EQ,
-        options::OPT_fprofile_instr_generate,
-        options::OPT_fprofile_instr_generate_EQ);
-    if (C.getDriver().getOffloadLTOMode() == LTOK_None && !UsesProfileGenerate)
-      CmdArgs.push_back("--no-lto");
     CmdArgs.append({"-o", Output.getFilename()});
     for (auto Input : Inputs)
       CmdArgs.push_back(Input.getFilename());
-  } else
+  } else {
     for (const char *LinkArg : LinkCommand->getArguments())
       CmdArgs.push_back(LinkArg);
+  }
 
   addOffloadCompressArgs(Args, CmdArgs);
 


### PR DESCRIPTION
Summary:
This was accidentally missed when I merged the refactor because it
showed up after I made the PR and didn't have any merge conflicts I
noticed.
