### PR TITLE
[lldb] Add PARTIAL_SOURCES_INTENDED to HostTests to fix build 

### DIFF
--- a/lldb/unittests/Host/CMakeLists.txt
+++ b/lldb/unittests/Host/CMakeLists.txt
@@ -38,6 +38,7 @@ endif()
 
 add_lldb_unittest(HostTests
   ${FILES}
+  PARTIAL_SOURCES_INTENDED
   LINK_LIBS
     lldbHost
     lldbCore


### PR DESCRIPTION
with LLDB_ENABLE_PYTHON=OFF

PythonRuntimeLoaderTest.cpp is only added to the target when Python is enabled, which orphaned the source and broke configuration otherwise

culprit PR: https://github.com/llvm/llvm-project/pull/200524