### PR TITLE
[libsycl] Fix _LIBSYCL_EXPORT placement

### DIFF
--- a/libsycl/src/detail/program_manager.cpp
+++ b/libsycl/src/detail/program_manager.cpp
@@ -18,7 +18,7 @@
 _LIBSYCL_BEGIN_NAMESPACE_SYCL
 namespace detail {
 
-DeviceKernelInfo &_LIBSYCL_EXPORT
+_LIBSYCL_EXPORT DeviceKernelInfo &
 getDeviceKernelInfo(std::string_view KernelName) {
   return ProgramAndKernelManager::getInstance().getDeviceKernelInfo(KernelName);
 }


### PR DESCRIPTION
Fixes another instance of _LIBSYCL_EXPORT causing compiilation errors on Windows.