### PR TITLE
Remove incorrect gcal link from C/C++ language wg

### DIFF
--- a/llvm/docs/GettingInvolved.rst
+++ b/llvm/docs/GettingInvolved.rst
@@ -194,6 +194,7 @@ what to add to your calendar invite.
      - `Minutes/docs <https://docs.google.com/document/d/1GahxppHJ7o1O_fn1Mbidu1DHEg7V2aOr92LXCtNV1_o/edit?usp=sharing>`__
    * - Clang C and C++ Language Working Group
      - 1st and 3rd Wednesday of the month
+     -
      - `Minutes/docs <https://docs.google.com/document/d/1x5-RbOC6-jnI_NcJ9Dp4pSmGhhNe7lUevuWUIB46TeM/edit?usp=sharing>`__
    * - LLVM SPIR-V Backend Working Group
      - Every week on Monday

--- a/llvm/docs/GettingInvolved.rst
+++ b/llvm/docs/GettingInvolved.rst
@@ -194,7 +194,6 @@ what to add to your calendar invite.
      - `Minutes/docs <https://docs.google.com/document/d/1GahxppHJ7o1O_fn1Mbidu1DHEg7V2aOr92LXCtNV1_o/edit?usp=sharing>`__
    * - Clang C and C++ Language Working Group
      - 1st and 3rd Wednesday of the month
-     - `gcal <https://calendar.google.com/calendar/u/0?cid=cW1lZGg0ZXNpMnIyZDN2aTVydGVrdWF1YzRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ>`__
      - `Minutes/docs <https://docs.google.com/document/d/1x5-RbOC6-jnI_NcJ9Dp4pSmGhhNe7lUevuWUIB46TeM/edit?usp=sharing>`__
    * - LLVM SPIR-V Backend Working Group
      - Every week on Monday


### PR DESCRIPTION
The C and C++ language working group meets on the first and third Wed of the month, but Google Calendar does not support doing this via a single event. Instead, we have one event for recurring on the 1st Wed and a second event for recurring on the 3rd Wed. That means we cannot use a single gcal link for the event. Instead of listing two links, this removes the gcal link entirely because the meeting is also listed on the community calendar itself. This reduces confusion for folks, but it would be nice to get a replacement link at some point.