### PR TITLE
[Clang][Sema]Report error for non-base types in constructor initializers before causing issue in initializer order

### DIFF
--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-type-member-init.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-type-member-init.cpp
@@ -647,7 +647,7 @@ namespace gh192510 {
   };
 
   template<typename T>
-  class X: public Base {
+  class X: public Base, private C<T> {
     using INT = C<T>;
 
     X(INT i) : INT(i) {} // no crash

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -17,6 +17,7 @@
 #include "clang/AST/CXXInheritance.h"
 #include "clang/AST/CharUnits.h"
 #include "clang/AST/ComparisonCategories.h"
+#include "clang/AST/DeclBase.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/DynamicRecursiveASTVisitor.h"
@@ -4819,33 +4820,33 @@ Sema::BuildBaseInitializer(QualType BaseType, TypeSourceInfo *BaseTInfo,
       return true;
   }
 
+  if (!Dependent && declaresSameEntity(ClassDecl, BaseType->getAsCXXRecordDecl()))
+    return BuildDelegatingInitializer(BaseTInfo, Init, ClassDecl);
+
   // Check for direct and virtual base classes.
   const CXXBaseSpecifier *DirectBaseSpec = nullptr;
   const CXXBaseSpecifier *VirtualBaseSpec = nullptr;
-  if (!Dependent) {
-    if (declaresSameEntity(ClassDecl, BaseType->getAsCXXRecordDecl()))
-      return BuildDelegatingInitializer(BaseTInfo, Init, ClassDecl);
 
-    FindBaseInitializer(*this, ClassDecl, BaseType, DirectBaseSpec,
-                        VirtualBaseSpec);
+  FindBaseInitializer(*this, ClassDecl, BaseType, DirectBaseSpec,
+                      VirtualBaseSpec);
 
-    // C++ [base.class.init]p2:
-    // Unless the mem-initializer-id names a nonstatic data member of the
-    // constructor's class or a direct or virtual base of that class, the
-    // mem-initializer is ill-formed.
-    if (!DirectBaseSpec && !VirtualBaseSpec) {
-      // If the class has any dependent bases, then it's possible that
-      // one of those types will resolve to the same type as
-      // BaseType. Therefore, just treat this as a dependent base
-      // class initialization.  FIXME: Should we try to check the
-      // initialization anyway? It seems odd.
-      if (ClassDecl->hasAnyDependentBases())
-        Dependent = true;
-      else
-        return Diag(BaseLoc, diag::err_not_direct_base_or_virtual)
-               << BaseType << Context.getCanonicalTagType(ClassDecl)
-               << BaseTInfo->getTypeLoc().getSourceRange();
-    }
+  // C++ [base.class.init]p2:
+  // Unless the mem-initializer-id names a nonstatic data member of the
+  // constructor's class or a direct or virtual base of that class, the
+  // mem-initializer is ill-formed.
+  if (!DirectBaseSpec && !VirtualBaseSpec) {
+    // If the class has any dependent bases, then it's possible that
+    // one of those types will resolve to the same type as
+    // BaseType. Therefore, just treat this as a dependent base
+    // class initialization.  FIXME: Should we try to check the
+    // initialization anyway? It seems odd.
+    if (ClassDecl->hasAnyDependentBases())
+      Dependent = true;
+    // We may have a delegating initializer
+    else if (!declaresSameEntity(ClassDecl, BaseType->getAsCXXRecordDecl()))
+      return Diag(BaseLoc, diag::err_not_direct_base_or_virtual)
+             << BaseType << Context.getCanonicalTagType(ClassDecl)
+             << BaseTInfo->getTypeLoc().getSourceRange();
   }
 
   if (Dependent) {

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -4842,9 +4842,9 @@ Sema::BuildBaseInitializer(QualType BaseType, TypeSourceInfo *BaseTInfo,
     // FIXME: Should we try to check the initialization anyway? It seems odd.
     if (ClassDecl->hasAnyDependentBases())
       Dependent = true;
-    // We may have a delegating initializer here, since that is also a type,
-    // that isn't a direct or virtual base of the instantiated type. That will
-    // be handled later.
+    // We may have a delegating initializer here but in a dependent context.
+    // Since that is also a type, that isn't a direct or virtual base of the
+    // instantiated type. That will be handled later.
     else if (!declaresSameEntity(ClassDecl, BaseType->getAsCXXRecordDecl()))
       return Diag(BaseLoc, diag::err_not_direct_base_or_virtual)
              << BaseType << Context.getCanonicalTagType(ClassDecl)

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -4820,7 +4820,8 @@ Sema::BuildBaseInitializer(QualType BaseType, TypeSourceInfo *BaseTInfo,
       return true;
   }
 
-  if (!Dependent && declaresSameEntity(ClassDecl, BaseType->getAsCXXRecordDecl()))
+  if (!Dependent &&
+      declaresSameEntity(ClassDecl, BaseType->getAsCXXRecordDecl()))
     return BuildDelegatingInitializer(BaseTInfo, Init, ClassDecl);
 
   // Check for direct and virtual base classes.
@@ -4835,14 +4836,15 @@ Sema::BuildBaseInitializer(QualType BaseType, TypeSourceInfo *BaseTInfo,
   // constructor's class or a direct or virtual base of that class, the
   // mem-initializer is ill-formed.
   if (!DirectBaseSpec && !VirtualBaseSpec) {
-    // If the class has any dependent bases, then it's possible that
-    // one of those types will resolve to the same type as
-    // BaseType. Therefore, just treat this as a dependent base
-    // class initialization.  FIXME: Should we try to check the
-    // initialization anyway? It seems odd.
+    // If the class has any dependent bases, then it's possible that one of
+    // those types will resolve to the same type as BaseType. Therefore, just
+    // treat this as a dependent base class initialization.
+    // FIXME: Should we try to check the initialization anyway? It seems odd.
     if (ClassDecl->hasAnyDependentBases())
       Dependent = true;
-    // We may have a delegating initializer
+    // We may have a delegating initializer here, since that is also a type,
+    // that isn't a direct or virtual base of the instantiated type. That will
+    // be handled later.
     else if (!declaresSameEntity(ClassDecl, BaseType->getAsCXXRecordDecl()))
       return Diag(BaseLoc, diag::err_not_direct_base_or_virtual)
              << BaseType << Context.getCanonicalTagType(ClassDecl)

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -17,7 +17,6 @@
 #include "clang/AST/CXXInheritance.h"
 #include "clang/AST/CharUnits.h"
 #include "clang/AST/ComparisonCategories.h"
-#include "clang/AST/DeclBase.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/DynamicRecursiveASTVisitor.h"

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -4802,6 +4802,7 @@ Sema::BuildBaseInitializer(QualType BaseType, TypeSourceInfo *BaseTInfo,
   bool Dependent = CurContext->isDependentContext() &&
                    (BaseType->isDependentType() || Init->isTypeDependent());
 
+  llvm::errs() << "Dependent? " << Dependent << '\n';
   SourceRange InitRange = Init->getSourceRange();
   if (EllipsisLoc.isValid()) {
     // This is a pack expansion.
@@ -4828,28 +4829,51 @@ Sema::BuildBaseInitializer(QualType BaseType, TypeSourceInfo *BaseTInfo,
   const CXXBaseSpecifier *DirectBaseSpec = nullptr;
   const CXXBaseSpecifier *VirtualBaseSpec = nullptr;
 
-  FindBaseInitializer(*this, ClassDecl, BaseType, DirectBaseSpec,
-                      VirtualBaseSpec);
+    FindBaseInitializer(*this, ClassDecl, BaseType, DirectBaseSpec,
+                        VirtualBaseSpec);
 
-  // C++ [base.class.init]p2:
-  // Unless the mem-initializer-id names a nonstatic data member of the
-  // constructor's class or a direct or virtual base of that class, the
-  // mem-initializer is ill-formed.
-  if (!DirectBaseSpec && !VirtualBaseSpec) {
-    // If the class has any dependent bases, then it's possible that one of
-    // those types will resolve to the same type as BaseType. Therefore, just
-    // treat this as a dependent base class initialization.
-    // FIXME: Should we try to check the initialization anyway? It seems odd.
-    if (ClassDecl->hasAnyDependentBases())
-      Dependent = true;
-    // We may have a delegating initializer here but in a dependent context.
-    // Since that is also a type, that isn't a direct or virtual base of the
-    // instantiated type. That will be handled later.
-    else if (!declaresSameEntity(ClassDecl, BaseType->getAsCXXRecordDecl()))
-      return Diag(BaseLoc, diag::err_not_direct_base_or_virtual)
-             << BaseType << Context.getCanonicalTagType(ClassDecl)
-             << BaseTInfo->getTypeLoc().getSourceRange();
-  }
+    // C++ [base.class.init]p2:
+    // Unless the mem-initializer-id names a nonstatic data member of the
+    // constructor's class or a direct or virtual base of that class, the
+    // mem-initializer is ill-formed.
+    if (!DirectBaseSpec && !VirtualBaseSpec) {
+      // If the class has any dependent bases, then it's possible that one of
+      // those types will resolve to the same type as BaseType. Therefore, just
+      // treat this as a dependent base class initialization.
+      // FIXME: Should we try to check the initialization anyway? It seems odd.
+      if (ClassDecl->hasAnyDependentBases())
+        Dependent = true;
+      // We may have a delegating initializer here but in a dependent context.
+      // Since that is also a type, that isn't a direct or virtual base of the
+      // instantiated type. That will be handled later.
+      //
+      // Another scenario we may get here is when the initialization list contains
+      // a type template parameter. If the class has any bases classes, the program can be valid, but if not, then the program must be invalid.
+      // For example, the following case must be invalid, no matter how we choose the type of the template at initialization:
+      //
+      // struct S0 {
+      //   S0(int) {}
+      //   template <class T>
+      //   S0(T) : T(42), Member(42) {};
+      //   int Member{21};
+      // };
+      // 
+      // This code can be valid, if we choose `SomeBase` as our template argument:
+      //
+      // class SomeBase {};
+      //
+      // struct S0 : SomeBase {
+      //   S0(int) {}
+      //   template <class T>
+      //   S0(T) : Member(42), T(42) {};
+      //   int Member{21};
+      // };
+      else if (!declaresSameEntity(ClassDecl, BaseType->getAsCXXRecordDecl()) &&
+               ClassDecl->bases().empty())
+        return Diag(BaseLoc, diag::err_not_direct_base_or_virtual)
+               << BaseType << Context.getCanonicalTagType(ClassDecl)
+               << BaseTInfo->getTypeLoc().getSourceRange();
+    }
 
   if (Dependent) {
     DiscardCleanupsInEvaluationContext();

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -4801,7 +4801,6 @@ Sema::BuildBaseInitializer(QualType BaseType, TypeSourceInfo *BaseTInfo,
   bool Dependent = CurContext->isDependentContext() &&
                    (BaseType->isDependentType() || Init->isTypeDependent());
 
-  llvm::errs() << "Dependent? " << Dependent << '\n';
   SourceRange InitRange = Init->getSourceRange();
   if (EllipsisLoc.isValid()) {
     // This is a pack expansion.

--- a/clang/test/SemaCXX/constructor-initializer.cpp
+++ b/clang/test/SemaCXX/constructor-initializer.cpp
@@ -323,3 +323,21 @@ A f2(const B &b) {
   return b; // expected-error {{no matching constructor for initialization of 'B'}}
 }
 }
+
+namespace PR7179 {
+struct X
+{
+  struct Y
+  {
+    template <class T> Y(T x) : X(x) { } // expected-error {{type 'X' is not a direct or virtual base of 'PR7179::X::Y'}}
+  };
+};
+}
+
+namespace PR201379 {
+struct S1 {
+  template<typename T>
+  S1(T) : d(), T()  {} // expected-error {{type 'T' is not a direct or virtual base of 'PR201379::S1'}}
+  int d;
+};
+}

--- a/clang/test/SemaCXX/warn-reorder-ctor-initialization.cpp
+++ b/clang/test/SemaCXX/warn-reorder-ctor-initialization.cpp
@@ -120,16 +120,6 @@ namespace test3 {
   };
 }
 
-namespace PR7179 {
-  struct X
-  {
-    struct Y
-    {
-      template <class T> Y(T x) : X(x) { }
-    };
-  };
-}
-
 namespace test3 {
   struct foo {
     struct {


### PR DESCRIPTION
Fixes #201593 .

Clang crashes on the following invalid C++ code (when assertions are enabled):
```cpp
struct S0 {
    S0(int) {}
    template <class T>
    S0(T) : Member(42), T(42) {};
    int Member{21};
};

void InstantiateS0() {
    S0 S0Instance(67);
}
```

```
Assertion `IdealIndex < NumIdealInits && "initializer not found in initializer list"' failed.
```

The reproducer on Compiler Explorer:
https://godbolt.org/z/xaEWMM5b5

The issue is the assertion made by the member initialization order warning reporter. It assumes that no type names get there, that are not the type of the initialized class itself or not type of a direct super class.

The correct behaviour would be accepting the code, and warning for the wrong initialization order.