### PR TITLE
[offload][lit] Disable three more tests on Intel GPU

### DIFF
--- a/offload/test/api/omp_indirect_func_basic.c
+++ b/offload/test/api/omp_indirect_func_basic.c
@@ -1,5 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 // REQUIRES: gpu
 
 #include <assert.h>

--- a/offload/test/offloading/cuda_no_devices.c
+++ b/offload/test/offloading/cuda_no_devices.c
@@ -5,7 +5,7 @@
 // RUN: %libomptarget-compile-generic
 // RUN: env CUDA_VISIBLE_DEVICES= \
 // RUN:   %libomptarget-run-generic 2>&1 | %fcheck-generic
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/offloading/shared_lib_fp_mapping.c
+++ b/offload/test/offloading/shared_lib_fp_mapping.c
@@ -3,7 +3,7 @@
 // RUN: %clang-generic -fPIC -shared %S/../Inputs/declare_indirect_func.c -o %t.testdir/libslfm.so  -fopenmp-version=51
 // RUN: %libomptarget-compile-generic -rpath %t.testdir -L %t.testdir -l slfm -o %t  -fopenmp-version=51
 // RUN: env LIBOMPTARGET_INFO=32 %t 2>&1 | %fcheck-generic
-// XFAIL: intelgpu
+// UNSUPPORTED: intelgpu
 // clang-format on
 
 #include <stdio.h>


### PR DESCRIPTION
Buildbot is still unstable, these tests are causing kernel driver errors so let's disable them.