### PR TITLE
[Dexter] Add support for nested state nodes

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DebuggerControllers/ScriptDebuggerController.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DebuggerControllers/ScriptDebuggerController.py
@@ -8,16 +8,18 @@
 recording debugger output."""
 
 
+from collections import defaultdict
+from dataclasses import dataclass
 from enum import Enum
 import time
-from typing import Optional
+from typing import Dict, List, Optional
 
 from dex.debugger.DebuggerControllers.DebuggerControllerBase import (
     DebuggerControllerBase,
 )
 from dex.debugger.DebuggerBase import DebuggerBase
 from dex.debugger.DAP import DAP
-from dex.evaluation.StateMatch import get_active_where_expects
+from dex.evaluation.StateMatch import get_active_where_matches
 from dex.test_script.Nodes import Where
 from dex.test_script.Script import DexterScript, Scope
 from dex.tools import Context
@@ -30,7 +32,6 @@ class DebuggerAction(Enum):
     STEP_OUT = 1
     CONTINUE = 2
     EXIT = 3
-
 
 class ScriptDebuggerController(DebuggerControllerBase):
     """Uses a Dexter Script to drive a debugger session, using "where" nodes to make breakpoint/stepping decisions, and
@@ -49,9 +50,12 @@ class ScriptDebuggerController(DebuggerControllerBase):
         # and will be set back to None after we finish running the debugger.
         self.debugger: DebuggerBase = None  # type: ignore
 
+        # Breakpoint IDs currently set for each !where node.
+        self._where_bps: Dict[Where, List[int]] = defaultdict(list)
+
     def add_where_entry_bp(self, where: Where, default_file: Optional[str] = None):
         """Adds a breakpoint to catch when we enter the given !where node."""
-        added_ids = []
+        added_ids: List[int] = []
         if where.function:
             if where.lines:
                 raise NotImplementedError(
@@ -66,6 +70,7 @@ class ScriptDebuggerController(DebuggerControllerBase):
             # If this Where covers a range of lines, we breakpoint each of them to ensure that we don't miss any lines.
             for line in where.get_lines():
                 added_ids.append(self.debugger.add_breakpoint(file, line))
+        self._where_bps[where] = added_ids
         for id in added_ids:
             self.context.logger.note(f"Added Entry BP {id} for {where}")
 
@@ -115,12 +120,12 @@ class ScriptDebuggerController(DebuggerControllerBase):
             ## Fetch frame information and breakpoint information from the debugger.
             step_info: StepIR = self.debugger.get_stack_frames(self._step_index)
 
-            active_where_expects = get_active_where_expects(script, step_info)
+            active_where_matches = get_active_where_matches(script, step_info)
 
             watches = [
                 watch
-                for frame_idx, expects in active_where_expects.values()
-                for expect in expects
+                for where_match in active_where_matches.values()
+                for expect in where_match.active_expects
                 if (watch := expect.get_watched_expr())
             ]
             self.debugger.collect_watches(step_info, watches)
@@ -130,13 +135,34 @@ class ScriptDebuggerController(DebuggerControllerBase):
             # - Otherwise, if any !where matches any non-current stack frame, we step out.
             # - Otherwise, we continue.
             if any(
-                frame_idx == 0 for frame_idx, expects in active_where_expects.values()
+                where_match.frame_idx == 0
+                for where_match in active_where_matches.values()
             ):
                 next_action = DebuggerAction.STEP_OVER
-            elif active_where_expects:
+            elif active_where_matches:
                 next_action = DebuggerAction.STEP_OUT
             else:
                 next_action = DebuggerAction.CONTINUE
+
+            # Update breakpoints: first remove unneeded breakpoints, then set newly desired breakpoints.
+            bp_to_delete = []
+            pending_wheres = set(
+                where
+                for where_match in active_where_matches.values()
+                for where in where_match.pending_wheres
+            )
+            for where, bp_ids in self._where_bps.items():
+                if (
+                    bp_ids
+                    and where not in script.root_wheres
+                    and where not in pending_wheres
+                ):
+                    bp_to_delete.extend(bp_ids)
+                    bp_ids.clear()
+            self.debugger.delete_breakpoints(bp_to_delete)
+            for where in pending_wheres:
+                if not self._where_bps[where]:
+                    self.add_where_entry_bp(where)
 
             if step_info.current_frame:
                 self._step_index += 1
@@ -147,7 +173,7 @@ class ScriptDebuggerController(DebuggerControllerBase):
 
             # If we have --trace enabled, report a short overview of this step.
             self.context.logger.note(
-                f"Stopped at {step_info.current_function} {step_info.current_location.short_str()}, {len(active_where_expects)} !wheres on the stack, next_action={next_action}"
+                f"Stopped at {step_info.current_function} {step_info.current_location.short_str()}, {len(active_where_matches)} !wheres on the stack, next_action={next_action}"
             )
 
             if next_action == DebuggerAction.EXIT:

--- a/cross-project-tests/debuginfo-tests/dexter/dex/dextIR/StepIR.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/dextIR/StepIR.py
@@ -64,6 +64,7 @@ class StepIR:
         if watches is None:
             watches = {}
         self.watches = watches
+        self.hit_fn_bps: List[str] = []
 
     def __str__(self):
         try:

--- a/cross-project-tests/debuginfo-tests/dexter/dex/evaluation/RunMatch.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/evaluation/RunMatch.py
@@ -20,7 +20,7 @@ from dex.evaluation.Metrics import (
     get_variable_metrics,
     serialize_metric_to_json,
 )
-from dex.evaluation.StateMatch import get_active_where_expects
+from dex.evaluation.StateMatch import get_active_where_matches
 from dex.test_script import DexterScript, Scope
 from dex.test_script.Nodes import Expect, Value
 
@@ -33,11 +33,11 @@ class DebuggerStepMatch:
     def __init__(self, step: StepIR, script: DexterScript):
         self.step = step
         self.script = script
-        self.state_match = get_active_where_expects(script, step)
+        self.state_match = get_active_where_matches(script, step)
         expects_to_match = {
             expect
-            for frame_idx, expects in self.state_match.values()
-            for expect in expects
+            for where_match in self.state_match.values()
+            for expect in where_match.active_expects
         }
         self.expect_matches: Dict[Expect, DebuggerExpectMatch] = {}
 
@@ -111,8 +111,8 @@ class DebuggerRunMatch(object):
             result += f"Step {step_match.step.step_index}:\n"
             result += f"  {step_match.step.current_location}\n"
             frame_active_wheres = defaultdict(list)
-            for where, (frame_idx, expects) in step_match.state_match.items():
-                frame_active_wheres[frame_idx].append(str(where))
+            for where, where_match in step_match.state_match.items():
+                frame_active_wheres[where_match.frame_idx].append(str(where))
             if not frame_active_wheres:
                 result += f"  No active !where nodes.\n"
                 continue

--- a/cross-project-tests/debuginfo-tests/dexter/dex/evaluation/StateMatch.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/evaluation/StateMatch.py
@@ -7,6 +7,7 @@
 """Utilities for matching debugger state, such as the call stack, conditions, or historical state (e.g. breakpoint
 hitcounts) to descriptions of expected state in a DexterScript."""
 
+from dataclasses import dataclass, field
 import os
 from typing import Dict, List, Tuple
 
@@ -51,20 +52,50 @@ def match_where_to_frame(
     return True
 
 
-def get_active_where_expects(
+class StepMatchResult:
+    """Represents the result of matching the given DexterScript against the given StepIR, used both for running a
+    debugger session and for evaluating the result of a test.
+    """
+
+
+@dataclass
+class WhereMatchResult:
+    """Class storing the result of a single !where matched against a stack frame. The primary information stored is just
+    the frame index that the !where matched against; for convenience, the children of the !where are also included.
+    """
+
+    frame_idx: int
+    active_expects: List[Value] = field(default_factory=list)
+    pending_wheres: List[Where] = field(default_factory=list)
+
+
+def get_active_where_matches(
     script: DexterScript, step_info: StepIR
-) -> Dict[Where, Tuple[int, List[Value]]]:
+) -> Dict[Where, WhereMatchResult]:
     """Match the script against the step_info, producing a dict that maps each !where that matches a stack frame to the
     index of the (rootmost) stack frame that it matches, and if the frame that it matches is the current stack frame
     (i.e. the frame index is 0), also includes a list of every direct child !expect node for that !where.
     """
-    active_where_expects: Dict[Where, Tuple[int, List[Value]]] = {}
+    active_where_expects: Dict[Where, WhereMatchResult] = {}
 
     def get_active_wheres(where: Where, scope: Scope):
+        # For nested !wheres, we must match a specific frame relative to the parent !where.
         if scope.where:
-            raise NotImplementedError(
-                "Support for nested !where nodes currently unimplemented."
+            if scope.where not in active_where_expects:
+                # If the parent !where doesn't match any frame, then this !where cannot match any either.
+                return
+            parent_frame_idx = active_where_expects[scope.where].frame_idx
+            # !and must match the same frame as its parent; !where must match the next leafmost frame.
+            target_frame_idx = (
+                parent_frame_idx if where.is_and else parent_frame_idx - 1
             )
+            if target_frame_idx < 0:
+                # If the target frame is -1, we can't match the !where yet, but we should prepare to step into it.
+                active_where_expects[scope.where].pending_wheres.append(where)
+                return
+            if match_where_to_frame(where, step_info.frames[target_frame_idx]):
+                active_where_expects[where] = WhereMatchResult(target_frame_idx)
+            return
         # For this !where, search for the rootmost stack frame that matches it.
         matching_frame_idx = next(
             (
@@ -75,7 +106,7 @@ def get_active_where_expects(
             None,
         )
         if matching_frame_idx is not None:
-            active_where_expects[where] = (matching_frame_idx, [])
+            active_where_expects[where] = WhereMatchResult(matching_frame_idx)
 
     # As we visit the script nodes in pre-order traversal, we can always assume that an expect's parent !where
     # has already been visited, and thus should have an entry in active_where_expects if it is active.
@@ -85,9 +116,9 @@ def get_active_where_expects(
         ), "Values should be the only type of expect possible!"
         if (
             scope.where in active_where_expects
-            and active_where_expects[scope.where][0] == 0
+            and active_where_expects[scope.where].frame_idx == 0
         ):
-            active_where_expects[scope.where][1].append(expect)
+            active_where_expects[scope.where].active_expects.append(expect)
 
     script.visit_script(visit_where=get_active_wheres, visit_expect=get_active_expects)
 

--- a/cross-project-tests/debuginfo-tests/dexter/dex/evaluation/StateMatch.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/evaluation/StateMatch.py
@@ -52,12 +52,6 @@ def match_where_to_frame(
     return True
 
 
-class StepMatchResult:
-    """Represents the result of matching the given DexterScript against the given StepIR, used both for running a
-    debugger session and for evaluating the result of a test.
-    """
-
-
 @dataclass
 class WhereMatchResult:
     """Class storing the result of a single !where matched against a stack frame. The primary information stored is just

--- a/cross-project-tests/debuginfo-tests/dexter/dex/test_script/Nodes.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/test_script/Nodes.py
@@ -49,13 +49,14 @@ class Where:
     within scope of a "Where" will only be evaluated for the steps where the Where applies.
     """
 
-    def __init__(self, attributes: dict):
+    def __init__(self, attributes: dict, is_and: bool):
         self.file: Optional[str] = attributes.pop("file", None)
         self.function: Union[list[str], str, None] = attributes.pop("function", None)
         self.lines: Union[int, DexRange, None] = attributes.pop("lines", None)
         self.after_hit_count: Optional[int] = attributes.pop("after_hit_count", None)
         self.for_hit_count: Optional[int] = attributes.pop("for_hit_count", None)
         self.conditions: dict = attributes.pop("conditions", None)
+        self.is_and = is_and
         if attributes:
             raise DexterNodeError(
                 self, f"unexpected attributes {', '.join(attributes)}"
@@ -75,7 +76,8 @@ class Where:
             for name, value in self.get_attrs().items()
             if value is not None
         ]
-        return f"Where(" + ", ".join(elts) + ")"
+        name = "And" if self.is_and else "Where"
+        return f"{name}(" + ", ".join(elts) + ")"
 
     def get_attrs(self) -> Dict[str, Any]:
         return {
@@ -88,19 +90,24 @@ class Where:
         }
 
     @staticmethod
-    def constructor(loader: yaml.Loader, node):
-        return Where(loader.construct_mapping(node))
+    def get_constructor(is_and: bool):
+        def constructor(loader, node):
+            return Where(loader.construct_mapping(node), is_and)
+
+        return constructor
 
     @staticmethod
     def representer(dumper: yaml.Dumper, data: "Where"):
         mapping = {
             name: value for name, value in data.get_attrs().items() if value is not None
         }
-        return dumper.represent_mapping("!where", mapping, flow_style=True)
+        tag = "!and" if data.is_and else "!where"
+        return dumper.represent_mapping(tag, mapping, flow_style=True)
 
     @staticmethod
     def register_yaml(loader):
-        yaml.add_constructor("!where", Where.constructor, loader)
+        yaml.add_constructor("!where", Where.get_constructor(False), loader)
+        yaml.add_constructor("!and", Where.get_constructor(True), loader)
         yaml.add_representer(Where, Where.representer)
 
     def get_lines(self) -> range:

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/nested_wheres.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/nested_wheres.cpp
@@ -1,22 +1,20 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-script --binary %t -- %s \
+// RUN:   | FileCheck %s
 
 /// Test that we correctly interpret nested !where+!and nodes during debugging
 /// and evaluation.
 
 int fib(int n) {
-    if (n <= 1) {
-        return 1;
-    }
-    int first = fib(n - 2);
-    int second = fib(n - 1);
-    return first + second;
+  if (n <= 1) {
+    return 1;
+  }
+  int first = fib(n - 2);
+  int second = fib(n - 1);
+  return first + second;
 }
 
-int main() {
-  return fib(4);
-}
-
+int main() { return fib(4); }
 
 // CHECK: correct_steps: 9
 // CHECK: missing_values: 0

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/nested_wheres.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/nested_wheres.cpp
@@ -1,0 +1,40 @@
+// RUN: %dexter_regression_test_cxx_build %s -o %t
+// RUN: %dexter_regression_test_run --use-script --binary %t -- %s | FileCheck %s
+
+/// Test that we correctly interpret nested !where+!and nodes during debugging
+/// and evaluation.
+
+int fib(int n) {
+    if (n <= 1) {
+        return 1;
+    }
+    int first = fib(n - 2);
+    int second = fib(n - 1);
+    return first + second;
+}
+
+int main() {
+  return fib(4);
+}
+
+
+// CHECK: correct_steps: 9
+// CHECK: missing_values: 0
+
+/*
+---
+!where {function: main}:
+    !where {function: fib}:
+        !and {lines: 8}:
+            !value n: 4
+        !where {function: fib}:
+            !and {lines: 8}:
+                !value n: [2, 3]
+            !where {function: fib}:
+                !and {lines: 8}:
+                    !value n: [0, 1, 1, 2]
+                !where {function: fib}:
+                    !and {lines: 8}:
+                        !value n: [0, 1]
+...
+*/

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/parser/valid-parse.test
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/parser/valid-parse.test
@@ -7,7 +7,9 @@ CHECK-NEXT: : !value 'x': 5
 CHECK-NEXT:   ? !where {file: lib.cpp, lines: !range [10, 20]}
 CHECK-NEXT:   : !value 'y': 10
 CHECK-NEXT: ? !where {lines: 5}
-CHECK-NEXT: : !value 'z': bees
+CHECK-NEXT: : ? !and {lines: 5}
+CHECK-NEXT:   : !value 'y': 7
+CHECK-NEXT:   !value 'z': bees
 
 
 ---
@@ -16,5 +18,7 @@ CHECK-NEXT: : !value 'z': bees
     !where {file: "lib.cpp", lines: !range [10, 20]}:
         !value y: 10
 !where {lines: 5}:
+    !and {lines: 5}:
+        !value y: 7
     !value z: bees
 ...


### PR DESCRIPTION
This patch adds support for nested state nodes, !where and a new !and node. Nested state nodes are evaluated only at a frame relative to the frame that their parent matched to:

- `!where` can only match the frame immediately called from/leafwards from their parent frame.
- `!and` can only match the same frame as their parent frame.