### PR TITLE
[clang] Fix VFS creation crash with missing `DiagnosticConsumer`

### DIFF
--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -287,9 +287,15 @@ static void collectVFSEntries(CompilerInstance &CI,
 
 void CompilerInstance::createVirtualFileSystem(
     IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS, DiagnosticConsumer *DC) {
+  bool ShouldOwnClient = false;
+  if (!DC) {
+    DC = new DiagnosticConsumer;
+    ShouldOwnClient = true;
+  }
+
   DiagnosticOptions DiagOpts;
   DiagnosticsEngine Diags(DiagnosticIDs::create(), DiagOpts, DC,
-                          /*ShouldOwnClient=*/false);
+                          ShouldOwnClient);
 
   VFS = createVFSFromCompilerInvocation(getInvocation(), Diags,
                                         std::move(BaseFS));

--- a/clang/unittests/Frontend/CompilerInstanceTest.cpp
+++ b/clang/unittests/Frontend/CompilerInstanceTest.cpp
@@ -82,6 +82,17 @@ TEST(CompilerInstance, DefaultVFSOverlayFromInvocation) {
   ASSERT_TRUE(Instance.getFileManager().getOptionalFileRef("vfs-virtual.file"));
 }
 
+TEST(CompilerInstance, CreateVFSWithoutDiagnosticConsumer) {
+  auto Invocation = std::make_shared<CompilerInvocation>();
+  Invocation->getHeaderSearchOpts().VFSOverlayFiles.push_back("/missing.yaml");
+  auto BaseFS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
+  CompilerInstance Instance(std::move(Invocation));
+  // Check that omitting the DiagnosticConsumer doesn't crash (e.g. by
+  // dereferencing the null pointer).
+  ASSERT_NO_FATAL_FAILURE(
+      Instance.createVirtualFileSystem(std::move(BaseFS), /*DC=*/nullptr));
+}
+
 TEST(CompilerInstance, AllowDiagnosticLogWithUnownedDiagnosticConsumer) {
   DiagnosticOptions DiagOpts;
   // Tell the diagnostics engine to emit the diagnostic log to STDERR. This


### PR DESCRIPTION
For convenience, the `CompilerInstance::createVirtualFileSystem()` API allows omitting the diagnostic consumer for clients that don't care about missing overlay files and other VFS creation errors. However, even in that case, the temporary `DiagnosticsEngine` created internally within the function does need a consumer. This PR sets it up.

rdar://176754115