### PR TITLE
[lldb][windows] explicitly load python3.dll in PythonRuntimeLoader

### DIFF
--- a/lldb/CMakeLists.txt
+++ b/lldb/CMakeLists.txt
@@ -99,14 +99,9 @@ if (LLDB_ENABLE_PYTHON)
   endif()
   if(WIN32)
     # On Windows, FindPython3 doesn't reliably expose the runtime DLL path,
-    # only the import library. CPython's DLL naming is standard, though:
-    # python3.dll for the limited API, otherwise python<MAJOR><MINOR>.dll.
-    if(LLDB_ENABLE_PYTHON_LIMITED_API)
-      set(LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME "python${Python3_VERSION_MAJOR}.dll")
-    else()
-      set(LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME
-          "python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}.dll")
-    endif()
+    # only the import library. CPython's DLL naming is standard.
+    set(LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME
+        "python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}.dll")
     message(STATUS "LLDB Python runtime DLL: ${LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME} "
                    "(Python3_VERSION=${Python3_VERSION}, "
                    "limited_api=${LLDB_ENABLE_PYTHON_LIMITED_API})")

--- a/lldb/source/Host/common/PythonRuntimeLoader.cpp
+++ b/lldb/source/Host/common/PythonRuntimeLoader.cpp
@@ -12,8 +12,10 @@
 #include "PythonRuntimeLoaderInternal.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/Support/DynamicLibrary.h"
 #include "llvm/Support/ErrorExtras.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/Threading.h"
 
 #include <cstdlib>
@@ -128,6 +130,19 @@ private:
     llvm::call_once(m_once, [this] {
       if (llvm::Expected<std::string> result = LoadPythonRuntime()) {
         m_path = std::move(*result);
+        if (m_path.empty())
+          return;
+#if defined(_WIN32)
+        // liblldb.dll may link against python3.dll (stable ABI). Ensure it is
+        // loaded from the same directory as the version-specific runtime so
+        // the delay-load resolver can find it.
+        llvm::SmallString<256> stable_abi_path(m_path);
+        llvm::sys::path::remove_filename(stable_abi_path);
+        llvm::sys::path::append(stable_abi_path, "python3.dll");
+        std::string err;
+        llvm::sys::DynamicLibrary::getPermanentLibrary(stable_abi_path.c_str(),
+                                                       &err);
+#endif
       } else {
         m_error_message = llvm::toString(result.takeError());
         LLDB_LOG(GetLog(LLDBLog::Host), "Python runtime load failed: {0}",


### PR DESCRIPTION
When building with the Python stable API, `liblldb.dll`'s delay-load crashes because it needs `python3.dll` and it can't find it 
Loading `python310.dll` via `LoadLibrary` with a full path doesn't add Python's directory to the DLL search path for subsequent loads.
This patch also explicitly loads `python3.dll` from the same directory in `PythonRuntimeLoader` to fix the issue.

This is needed for https://github.com/llvm/llvm-project/pull/200533.