### PR TITLE
docs/ParallelMultiImageFortranRuntime: Update link to latest PRIF Specification

### DIFF
--- a/flang/docs/ParallelMultiImageFortranRuntime.md
+++ b/flang/docs/ParallelMultiImageFortranRuntime.md
@@ -14,7 +14,7 @@ interface designed for LLVM Flang to target implementations of
 Fortran's multi-image parallel features.
 
 The current revision of the PRIF specification is here:
-<https://doi.org/10.25344/S46S3W>
+<https://doi.org/10.25344/S4Z88F>
 
 Library implementations of PRIF include:
 


### PR DESCRIPTION

The PRIF Committee is pleased to announce the publication of the Parallel Runtime Interface for Fortran (PRIF) Specification, Revision 0.8. The latest iteration of this specification represents the efforts of a collaborative design process involving multiple individuals across several institutions.

The document is available here: https://doi.org/10.25344/S4Z88F

The PRIF specification is governed by a formal PRIF Committee. For more details, see: https://go.lbl.gov/prif-governance

The Committee vote to approve the technical content in this revision began on 2026-04-30 and concluded successfully on 2026-05-18.

The 7-day committee comment period for cosmetic feedback began on 2026-05-21 and concluded on 2026-05-28 with no comments, and only minor editorial changes by the Editor.

See the Change Log in Section 1 of the document for the list of changes relative to the prior revision.