### PR TITLE
[lldb][windows] Fix Python library link for LLDB_ENABLE_PYTHON_LIMITED_API

### DIFF
--- a/lldb/bindings/python/CMakeLists.txt
+++ b/lldb/bindings/python/CMakeLists.txt
@@ -181,6 +181,9 @@ function(finish_swig_python swig_target lldb_python_bindings_dir lldb_python_tar
   endif()
 
   add_dependencies(${swig_target} swig_wrapper_python liblldb lldb-argdumper)
+  if (LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS)
+    add_dependencies(${swig_target} lldbPluginScriptInterpreterPython)
+  endif()
   set_target_properties(${swig_target} swig_wrapper_python PROPERTIES FOLDER "lldb misc")
 
   # Ensure we do the python post-build step when building lldb.

--- a/lldb/source/Plugins/ScriptInterpreter/Python/CMakeLists.txt
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/CMakeLists.txt
@@ -116,12 +116,5 @@ else()
   target_link_directories(lldbPluginScriptInterpreterPython PUBLIC ${PYTHON_SABI_LIBRARY_DIRS})
 endif()
 
-if (WIN32 AND LLDB_ENABLE_PYTHON_LIMITED_API)
-  # Define Py_LIMITED_API directly so pyconfig.h emits #pragma comment(lib,
-  # "python3.lib") instead of the version-specific library.
-  target_compile_definitions(lldbPluginScriptInterpreterPython PUBLIC
-    "Py_LIMITED_API=0x03080000")
-endif()
-
 target_include_directories(lldbPluginScriptInterpreterPython
   PUBLIC ${Python3_INCLUDE_DIRS})

--- a/lldb/source/Plugins/ScriptInterpreter/Python/CMakeLists.txt
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/CMakeLists.txt
@@ -95,7 +95,10 @@ if (LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS)
 
   target_link_directories(lldbStaticScriptInterpreterPython PUBLIC ${PYTHON_SABI_LIBRARY_DIRS})
 else()
-  if (NOT LLDB_ENABLE_PYTHON_LIMITED_API)
+  # On Windows with the limited API, the Python import library is selected via
+  # #pragma comment(lib, ...) in pyconfig.h based on Py_LIMITED_API.
+  # On all other platforms, always link Python3_LIBRARIES explicitly.
+  if (NOT (WIN32 AND LLDB_ENABLE_PYTHON_LIMITED_API))
     set(python_link_libs ${Python3_LIBRARIES})
   endif()
   add_lldb_library(lldbPluginScriptInterpreterPython PLUGIN

--- a/lldb/source/Plugins/ScriptInterpreter/Python/CMakeLists.txt
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/CMakeLists.txt
@@ -62,9 +62,12 @@ if (LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS)
     target_link_options(lldbPluginScriptInterpreterPython PRIVATE
       "LINKER:--unresolved-symbols=ignore-all")
   else()
-    # Windows continues to use delay-load + import lib.
-    target_link_libraries(lldbPluginScriptInterpreterPython PRIVATE
-      ${Python3_LIBRARIES})
+    # For the limited API, rely on #pragma comment(lib, "python3.lib")
+    # emitted by SWIG. For the full API, link the version-specific import lib.
+    if (NOT LLDB_ENABLE_PYTHON_LIMITED_API)
+      target_link_libraries(lldbPluginScriptInterpreterPython PRIVATE
+        ${Python3_LIBRARIES})
+    endif()
     target_link_directories(lldbPluginScriptInterpreterPython PRIVATE
       ${PYTHON_SABI_LIBRARY_DIRS})
   endif()
@@ -92,6 +95,9 @@ if (LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS)
 
   target_link_directories(lldbStaticScriptInterpreterPython PUBLIC ${PYTHON_SABI_LIBRARY_DIRS})
 else()
+  if (NOT LLDB_ENABLE_PYTHON_LIMITED_API)
+    set(python_link_libs ${Python3_LIBRARIES})
+  endif()
   add_lldb_library(lldbPluginScriptInterpreterPython PLUGIN
     ${python_plugin_sources}
     LINK_COMPONENTS
@@ -104,10 +110,17 @@ else()
       lldbInterpreter
       lldbTarget
       lldbValueObject
-      ${Python3_LIBRARIES}
+      ${python_link_libs}
       ${LLDB_LIBEDIT_LIBS}
   )
   target_link_directories(lldbPluginScriptInterpreterPython PUBLIC ${PYTHON_SABI_LIBRARY_DIRS})
+endif()
+
+if (WIN32 AND LLDB_ENABLE_PYTHON_LIMITED_API)
+  # Define Py_LIMITED_API directly so pyconfig.h emits #pragma comment(lib,
+  # "python3.lib") instead of the version-specific library.
+  target_compile_definitions(lldbPluginScriptInterpreterPython PUBLIC
+    "Py_LIMITED_API=0x03080000")
 endif()
 
 target_include_directories(lldbPluginScriptInterpreterPython

--- a/lldb/source/Plugins/ScriptInterpreter/Python/lldb-python.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/lldb-python.h
@@ -34,8 +34,9 @@ static llvm::Expected<bool> *g_fcxx_modules_workaround [[maybe_unused]];
 
 #define LLDB_MINIMUM_PYTHON_VERSION 0x03080000
 
-// Config.h must be included before Python.h so that LLDB_ENABLE_PYTHON_LIMITED_API
-// is defined when pyconfig.h selects the Windows import library via #pragma comment.
+// Config.h must be included before Python.h so that
+// LLDB_ENABLE_PYTHON_LIMITED_API is defined when pyconfig.h selects the Windows
+// import library via #pragma comment.
 #include "lldb/Host/Config.h"
 
 #if LLDB_ENABLE_PYTHON_LIMITED_API

--- a/lldb/source/Plugins/ScriptInterpreter/Python/lldb-python.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/lldb-python.h
@@ -34,6 +34,10 @@ static llvm::Expected<bool> *g_fcxx_modules_workaround [[maybe_unused]];
 
 #define LLDB_MINIMUM_PYTHON_VERSION 0x03080000
 
+// Config.h must be included before Python.h so that LLDB_ENABLE_PYTHON_LIMITED_API
+// is defined when pyconfig.h selects the Windows import library via #pragma comment.
+#include "lldb/Host/Config.h"
+
 #if LLDB_ENABLE_PYTHON_LIMITED_API
 // If defined, LLDB will be ABI-compatible with all Python 3 releases from the
 // specified one onward, and can use Limited API introduced up to that version.


### PR DESCRIPTION
When `LLDB_ENABLE_PYTHON_LIMITED_API` is `ON`, `liblldb` should link against `python3.dll` (stable ABI) rather than the `python310.dll`.

Previously, two issues prevented this on Windows:

1. The `ScriptInterpreter` plugin explicitly linked `${Python3_LIBRARIES}` regardless of whether the limited API was enabled.

2. Python's `pyconfig.h` emits a `#pragma` to select the import library at link time, choosing `python3.lib` or `python310.lib` depending on whether `Py_LIMITED_API` is defined. However, `LLDB_ENABLE_PYTHON_LIMITED_API` was only surfaced through Config.h, which is not included early enough in the compilation chain to affect pyconfig.h in all translation units.

This patch fixes both issues.

This is needed for https://github.com/llvm/llvm-project/pull/200533.