### PR TITLE
[CIR][NFC] Remove unused DataLayout in array lowering

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -492,7 +492,6 @@ mlir::Value CIRAttrToValue::visitCirAttr(cir::ConstArrayAttr attr) {
   // Iteratively lower each constant element of the array.
   if (auto arrayAttr = mlir::dyn_cast<mlir::ArrayAttr>(attr.getElts())) {
     for (auto [idx, elt] : llvm::enumerate(arrayAttr)) {
-      mlir::DataLayout dataLayout(parentOp->getParentOfType<mlir::ModuleOp>());
       mlir::Value init = visit(elt);
       result =
           mlir::LLVM::InsertValueOp::create(rewriter, loc, result, init, idx);


### PR DESCRIPTION
The per-element loop in `CIRAttrToValue::visitCirAttr(ConstArrayAttr)` constructed an `mlir::DataLayout` for every element of an `ArrayAttr`-backed constant array and never used it.  Constructing a `DataLayout` walks the parent ops to gather the layout spec, so for an N-element array this was N redundant constructions on the lowering path.  Removing the dead local is NFC — the generated IR is unchanged.

Split out of #198427, where it was flagged as an unrelated drive-by.
