### PR TITLE
[AsmParser] Delete orphaned select/phi when rejecting fast-math-flags

### DIFF
--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -7752,9 +7752,11 @@ int LLParser::parseInstruction(Instruction *&Inst, BasicBlock *BB,
     if (Res != 0)
       return Res;
     if (FMF.any()) {
-      if (!isa<FPMathOperator>(Inst))
+      if (!isa<FPMathOperator>(Inst)) {
+        Inst->deleteValue();
         return error(Loc, "fast-math-flags specified for select without "
                           "floating-point scalar or vector return type");
+      }
       Inst->setFastMathFlags(FMF);
     }
     return 0;
@@ -7773,9 +7775,11 @@ int LLParser::parseInstruction(Instruction *&Inst, BasicBlock *BB,
     if (Res != 0)
       return Res;
     if (FMF.any()) {
-      if (!isa<FPMathOperator>(Inst))
+      if (!isa<FPMathOperator>(Inst)) {
+        Inst->deleteValue();
         return error(Loc, "fast-math-flags specified for phi without "
                           "floating-point scalar or vector return type");
+      }
       Inst->setFastMathFlags(FMF);
     }
     return 0;

--- a/llvm/test/Assembler/invalid-phi-fast-math-flags.ll
+++ b/llvm/test/Assembler/invalid-phi-fast-math-flags.ll
@@ -1,0 +1,10 @@
+; RUN: not llvm-as -disable-output %s 2>&1 | FileCheck %s
+
+; CHECK: error: fast-math-flags specified for phi without floating-point scalar or vector return type
+define i32 @f(i32 %v) {
+entry:
+  br label %b
+b:
+  %p = phi nnan i32 [ %v, %entry ]
+  ret i32 %p
+}

--- a/llvm/test/Assembler/invalid-select-fast-math-flags.ll
+++ b/llvm/test/Assembler/invalid-select-fast-math-flags.ll
@@ -1,0 +1,7 @@
+; RUN: not llvm-as -disable-output %s 2>&1 | FileCheck %s
+
+; CHECK: error: fast-math-flags specified for select without floating-point scalar or vector return type
+define i32 @f(i1 %c, i32 %v) {
+  %s = select nnan i1 %c, i32 %v, i32 0
+  ret i32 %s
+}


### PR DESCRIPTION
parseSelect/parsePHI create the instruction before the caller checks the fast-math-flags. When FMF are rejected on a non-FP select/phi, the error path leaked the instruction, which crashed on teardown with "Uses remain when a value is destroyed!".

Fix by deleting the instruction before returning the error, as is already done for `call`.

Fixes #185111.