### PR TITLE
[NFC][AMDGPU] Introduce SIInstrFlags predicates to encapsulate TSFlags access

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUInsertDelayAlu.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInsertDelayAlu.cpp
@@ -35,10 +35,9 @@ public:
   // Return true if MI waits for all outstanding VALU instructions to complete.
   static bool instructionWaitsForVALU(const MachineInstr &MI) {
     // These instruction types wait for VA_VDST==0 before issuing.
-    const uint64_t VA_VDST_0 = SIInstrFlags::DS | SIInstrFlags::EXP |
-                               SIInstrFlags::FLAT | SIInstrFlags::MIMG |
-                               SIInstrFlags::MTBUF | SIInstrFlags::MUBUF;
-    if (MI.getDesc().TSFlags & VA_VDST_0)
+    if (SIInstrFlags::isDS(MI) || SIInstrFlags::isEXP(MI) ||
+        SIInstrFlags::isFLAT(MI) || SIInstrFlags::isMIMG(MI) ||
+        SIInstrFlags::isBuffer(MI))
       return true;
     if (MI.getOpcode() == AMDGPU::S_SENDMSG_RTN_B32 ||
         MI.getOpcode() == AMDGPU::S_SENDMSG_RTN_B64)
@@ -51,11 +50,10 @@ public:
 
   static bool instructionWaitsForSGPRWrites(const MachineInstr &MI) {
     // These instruction types wait for VA_SDST==0 before issuing.
-    uint64_t MIFlags = MI.getDesc().TSFlags;
-    if (MIFlags & SIInstrFlags::SMRD)
+    if (SIInstrFlags::isSMRD(MI))
       return true;
 
-    if (MIFlags & SIInstrFlags::SALU) {
+    if (SIInstrFlags::isSALU(MI)) {
       for (auto &Op : MI.operands()) {
         if (Op.isReg())
           return true;

--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -2388,8 +2388,7 @@ void AMDGPUOperand::addLiteralImmOperand(MCInst &Inst, int64_t Val, bool ApplyMo
   uint8_t OpTy = InstDesc.operands()[OpNum].OperandType;
 
   bool CanUse64BitLiterals =
-      AsmParser->has64BitLiterals() &&
-      !(InstDesc.TSFlags & (SIInstrFlags::VOP3 | SIInstrFlags::VOP3P));
+      AsmParser->has64BitLiterals() && !SIInstrFlags::isVOP3Like(InstDesc);
   LitModifier Lit = getModifiers().Lit;
   MCContext &Ctx = AsmParser->getContext();
 
@@ -3654,12 +3653,10 @@ ParseStatus AMDGPUAsmParser::parseVReg32OrOff(OperandVector &Operands) {
 }
 
 unsigned AMDGPUAsmParser::checkTargetMatchPredicate(MCInst &Inst) {
-  uint64_t TSFlags = MII.get(Inst.getOpcode()).TSFlags;
-
-  if ((getForcedEncodingSize() == 32 && (TSFlags & SIInstrFlags::VOP3)) ||
-      (getForcedEncodingSize() == 64 && !(TSFlags & SIInstrFlags::VOP3)) ||
-      (isForcedDPP() && !(TSFlags & SIInstrFlags::DPP)) ||
-      (isForcedSDWA() && !(TSFlags & SIInstrFlags::SDWA)) )
+  if ((getForcedEncodingSize() == 32 && SIInstrFlags::isVOP3(MII, Inst)) ||
+      (getForcedEncodingSize() == 64 && !SIInstrFlags::isVOP3(MII, Inst)) ||
+      (isForcedDPP() && !SIInstrFlags::isDPP(MII, Inst)) ||
+      (isForcedSDWA() && !SIInstrFlags::isSDWA(MII, Inst)))
     return Match_InvalidOperand;
 
   if (Inst.getOpcode() == AMDGPU::V_MAC_F32_sdwa_vi ||
@@ -3920,10 +3917,9 @@ bool AMDGPUAsmParser::validateConstantBusLimitations(
   unsigned NumLiterals = 0;
   unsigned LiteralSize;
 
-  if (!(Desc.TSFlags &
-        (SIInstrFlags::VOPC | SIInstrFlags::VOP1 | SIInstrFlags::VOP2 |
-         SIInstrFlags::VOP3 | SIInstrFlags::VOP3P | SIInstrFlags::SDWA)) &&
-      !isVOPD(Opcode))
+  if (!SIInstrFlags::isVOPC(Desc) && !SIInstrFlags::isVOP1(Desc) &&
+      !SIInstrFlags::isVOP2(Desc) && !SIInstrFlags::isVOP3Like(Desc) &&
+      !SIInstrFlags::isSDWA(Desc) && !isVOPD(Opcode))
     return true;
 
   if (checkWriteLane(Inst))
@@ -4060,7 +4056,7 @@ bool AMDGPUAsmParser::validateVOPD(const MCInst &Inst,
                                    const OperandVector &Operands) {
 
   unsigned Opcode = Inst.getOpcode();
-  bool AsVOPD3 = MII.get(Opcode).TSFlags & SIInstrFlags::VOPD3;
+  bool AsVOPD3 = SIInstrFlags::isVOPD3(MII, Inst);
 
   if (AsVOPD3) {
     for (const std::unique_ptr<MCParsedAsmOperand> &Operand : Operands) {
@@ -4157,11 +4153,10 @@ bool AMDGPUAsmParser::tryVOPD(const MCInst &Inst) {
 // VOPD3 has more relaxed register constraints than VOPD. We prefer shorter VOPD
 // form but switch to VOPD3 otherwise.
 bool AMDGPUAsmParser::tryAnotherVOPDEncoding(const MCInst &Inst) {
-  const unsigned Opcode = Inst.getOpcode();
-  if (!isGFX1250Plus() || !isVOPD(Opcode))
+  if (!isGFX1250Plus() || !isVOPD(Inst.getOpcode()))
     return false;
 
-  if (MII.get(Opcode).TSFlags & SIInstrFlags::VOPD3)
+  if (SIInstrFlags::isVOPD3(MII, Inst))
     return tryVOPD(Inst);
   return tryVOPD3(Inst);
 }
@@ -4169,9 +4164,8 @@ bool AMDGPUAsmParser::tryAnotherVOPDEncoding(const MCInst &Inst) {
 bool AMDGPUAsmParser::validateIntClampSupported(const MCInst &Inst) {
 
   const unsigned Opc = Inst.getOpcode();
-  const MCInstrDesc &Desc = MII.get(Opc);
 
-  if ((Desc.TSFlags & SIInstrFlags::IntClamp) != 0 && !hasIntClamp()) {
+  if (SIInstrFlags::hasIntClamp(MII, Inst) && !hasIntClamp()) {
     int ClampIdx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::clamp);
     assert(ClampIdx != -1);
     return Inst.getOperand(ClampIdx).getImm() == 0;
@@ -4180,15 +4174,12 @@ bool AMDGPUAsmParser::validateIntClampSupported(const MCInst &Inst) {
   return true;
 }
 
-constexpr uint64_t MIMGFlags =
-    SIInstrFlags::MIMG | SIInstrFlags::VIMAGE | SIInstrFlags::VSAMPLE;
-
 bool AMDGPUAsmParser::validateMIMGDataSize(const MCInst &Inst, SMLoc IDLoc) {
 
   const unsigned Opc = Inst.getOpcode();
   const MCInstrDesc &Desc = MII.get(Opc);
 
-  if ((Desc.TSFlags & MIMGFlags) == 0)
+  if ((SIInstrFlags::isImage(Desc)) == 0)
     return true;
 
   int VDataIdx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::vdata);
@@ -4208,8 +4199,7 @@ bool AMDGPUAsmParser::validateMIMGDataSize(const MCInst &Inst, SMLoc IDLoc) {
     DMask = 1;
 
   bool IsPackedD16 = false;
-  unsigned DataSize =
-      (Desc.TSFlags & SIInstrFlags::Gather4) ? 4 : llvm::popcount(DMask);
+  unsigned DataSize = SIInstrFlags::isGather4(Desc) ? 4 : llvm::popcount(DMask);
   if (hasPackedD16()) {
     int D16Idx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::d16);
     IsPackedD16 = D16Idx >= 0;
@@ -4234,7 +4224,7 @@ bool AMDGPUAsmParser::validateMIMGAddrSize(const MCInst &Inst, SMLoc IDLoc) {
   const unsigned Opc = Inst.getOpcode();
   const MCInstrDesc &Desc = MII.get(Opc);
 
-  if ((Desc.TSFlags & MIMGFlags) == 0 || !isGFX10Plus())
+  if (!SIInstrFlags::isImage(Desc) || !isGFX10Plus())
     return true;
 
   const AMDGPU::MIMGInfo *Info = AMDGPU::getMIMGInfo(Opc);
@@ -4242,9 +4232,8 @@ bool AMDGPUAsmParser::validateMIMGAddrSize(const MCInst &Inst, SMLoc IDLoc) {
   const AMDGPU::MIMGBaseOpcodeInfo *BaseOpcode =
       AMDGPU::getMIMGBaseOpcodeInfo(Info->BaseOpcode);
   int VAddr0Idx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::vaddr0);
-  AMDGPU::OpName RSrcOpName = (Desc.TSFlags & SIInstrFlags::MIMG)
-                                  ? AMDGPU::OpName::srsrc
-                                  : AMDGPU::OpName::rsrc;
+  AMDGPU::OpName RSrcOpName =
+      SIInstrFlags::isMIMG(Desc) ? AMDGPU::OpName::srsrc : AMDGPU::OpName::rsrc;
   int SrsrcIdx = AMDGPU::getNamedOperandIdx(Opc, RSrcOpName);
   int DimIdx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::dim);
   int A16Idx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::a16);
@@ -4272,8 +4261,7 @@ bool AMDGPUAsmParser::validateMIMGAddrSize(const MCInst &Inst, SMLoc IDLoc) {
 
   if (IsNSA) {
     if (hasPartialNSAEncoding() &&
-        ExpectedAddrSize >
-            getNSAMaxSize(Desc.TSFlags & SIInstrFlags::VSAMPLE)) {
+        ExpectedAddrSize > getNSAMaxSize(SIInstrFlags::isVSAMPLE(Desc))) {
       int VAddrLastIdx = SrsrcIdx - 1;
       unsigned VAddrLastSize = getRegOperandSize(Desc, VAddrLastIdx) / 4;
 
@@ -4302,7 +4290,7 @@ bool AMDGPUAsmParser::validateMIMGAtomicDMask(const MCInst &Inst) {
   const unsigned Opc = Inst.getOpcode();
   const MCInstrDesc &Desc = MII.get(Opc);
 
-  if ((Desc.TSFlags & MIMGFlags) == 0)
+  if ((SIInstrFlags::isImage(Desc)) == 0)
     return true;
   if (!Desc.mayLoad() || !Desc.mayStore())
     return true; // Not atomic
@@ -4320,9 +4308,8 @@ bool AMDGPUAsmParser::validateMIMGAtomicDMask(const MCInst &Inst) {
 bool AMDGPUAsmParser::validateMIMGGatherDMask(const MCInst &Inst) {
 
   const unsigned Opc = Inst.getOpcode();
-  const MCInstrDesc &Desc = MII.get(Opc);
 
-  if ((Desc.TSFlags & SIInstrFlags::Gather4) == 0)
+  if (!SIInstrFlags::isGather4(MII, Inst))
     return true;
 
   int DMaskIdx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::dmask);
@@ -4342,9 +4329,8 @@ bool AMDGPUAsmParser::validateMIMGDim(const MCInst &Inst,
     return true;
 
   const unsigned Opc = Inst.getOpcode();
-  const MCInstrDesc &Desc = MII.get(Opc);
 
-  if ((Desc.TSFlags & MIMGFlags) == 0)
+  if ((SIInstrFlags::isImage(MII, Inst)) == 0)
     return true;
 
   // image_bvh_intersect_ray instructions do not have dim
@@ -4361,9 +4347,8 @@ bool AMDGPUAsmParser::validateMIMGDim(const MCInst &Inst,
 
 bool AMDGPUAsmParser::validateMIMGMSAA(const MCInst &Inst) {
   const unsigned Opc = Inst.getOpcode();
-  const MCInstrDesc &Desc = MII.get(Opc);
 
-  if ((Desc.TSFlags & MIMGFlags) == 0)
+  if ((SIInstrFlags::isImage(MII, Inst)) == 0)
     return true;
 
   const AMDGPU::MIMGInfo *Info = AMDGPU::getMIMGInfo(Opc);
@@ -4401,9 +4386,8 @@ bool AMDGPUAsmParser::validateMovrels(const MCInst &Inst,
                                       const OperandVector &Operands) {
 
   const unsigned Opc = Inst.getOpcode();
-  const MCInstrDesc &Desc = MII.get(Opc);
 
-  if ((Desc.TSFlags & SIInstrFlags::SDWA) == 0 || !IsMovrelsSDWAOpcode(Opc))
+  if (!SIInstrFlags::isSDWA(MII, Inst) || !IsMovrelsSDWAOpcode(Opc))
     return true;
 
   const int Src0Idx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::src0);
@@ -4450,9 +4434,8 @@ bool AMDGPUAsmParser::validateMAIAccWrite(const MCInst &Inst,
 bool AMDGPUAsmParser::validateMAISrc2(const MCInst &Inst,
                                       const OperandVector &Operands) {
   unsigned Opcode = Inst.getOpcode();
-  const MCInstrDesc &Desc = MII.get(Opcode);
 
-  if (!(Desc.TSFlags & SIInstrFlags::IsMAI) ||
+  if (!SIInstrFlags::isMAI(MII, Inst) ||
       !getFeatureBits()[FeatureMFMAInlineLiteralBug])
     return true;
 
@@ -4474,7 +4457,7 @@ bool AMDGPUAsmParser::validateMFMA(const MCInst &Inst,
   const unsigned Opc = Inst.getOpcode();
   const MCInstrDesc &Desc = MII.get(Opc);
 
-  if ((Desc.TSFlags & SIInstrFlags::IsMAI) == 0)
+  if (!SIInstrFlags::isMAI(Desc))
     return true;
 
   int BlgpIdx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::blgp);
@@ -4565,9 +4548,8 @@ bool AMDGPUAsmParser::validateDivScale(const MCInst &Inst) {
 bool AMDGPUAsmParser::validateMIMGD16(const MCInst &Inst) {
 
   const unsigned Opc = Inst.getOpcode();
-  const MCInstrDesc &Desc = MII.get(Opc);
 
-  if ((Desc.TSFlags & MIMGFlags) == 0)
+  if ((SIInstrFlags::isImage(MII, Inst)) == 0)
     return true;
 
   int D16Idx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::d16);
@@ -4581,9 +4563,8 @@ bool AMDGPUAsmParser::validateMIMGD16(const MCInst &Inst) {
 
 bool AMDGPUAsmParser::validateTensorR128(const MCInst &Inst) {
   const unsigned Opc = Inst.getOpcode();
-  const MCInstrDesc &Desc = MII.get(Opc);
 
-  if ((Desc.TSFlags & SIInstrFlags::TENSOR_CNT) == 0)
+  if (!SIInstrFlags::usesTENSOR_CNT(MII, Inst))
     return true;
 
   int R128Idx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::r128);
@@ -4722,14 +4703,13 @@ static bool IsRevOpcode(const unsigned Opcode)
 
 bool AMDGPUAsmParser::validateLdsDirect(const MCInst &Inst,
                                         const OperandVector &Operands) {
-  using namespace SIInstrFlags;
   const unsigned Opcode = Inst.getOpcode();
-  const MCInstrDesc &Desc = MII.get(Opcode);
 
   // lds_direct register is defined so that it can be used
   // with 9-bit operands only. Ignore encodings which do not accept these.
-  const auto Enc = VOP1 | VOP2 | VOP3 | VOPC | VOP3P | SIInstrFlags::SDWA;
-  if ((Desc.TSFlags & Enc) == 0)
+  if (!SIInstrFlags::isVOP1(MII, Inst) && !SIInstrFlags::isVOP2(MII, Inst) &&
+      !SIInstrFlags::isVOP3Like(MII, Inst) &&
+      !SIInstrFlags::isVOPC(MII, Inst) && !SIInstrFlags::isSDWA(MII, Inst))
     return true;
 
   for (auto SrcName : {OpName::src0, OpName::src1, OpName::src2}) {
@@ -4745,7 +4725,7 @@ bool AMDGPUAsmParser::validateLdsDirect(const MCInst &Inst,
         return false;
       }
 
-      if (IsRevOpcode(Opcode) || (Desc.TSFlags & SIInstrFlags::SDWA)) {
+      if (IsRevOpcode(Opcode) || SIInstrFlags::isSDWA(MII, Inst)) {
         Error(getOperandLoc(Operands, SrcIdx),
               "lds_direct cannot be used with this instruction");
         return false;
@@ -4778,17 +4758,15 @@ bool AMDGPUAsmParser::validateOffset(const MCInst &Inst,
   if (OpNum == -1)
     return true;
 
-  uint64_t TSFlags = MII.get(Inst.getOpcode()).TSFlags;
-  if ((TSFlags & SIInstrFlags::FLAT))
+  if (SIInstrFlags::isFLAT(MII, Inst))
     return validateFlatOffset(Inst, Operands);
 
-  if ((TSFlags & SIInstrFlags::SMRD))
+  if (SIInstrFlags::isSMRD(MII, Inst))
     return validateSMEMOffset(Inst, Operands);
 
   const auto &Op = Inst.getOperand(OpNum);
   // GFX12+ buffer ops: InstOffset is signed 24, but must not be a negative.
-  if (isGFX12Plus() &&
-      (TSFlags & (SIInstrFlags::MUBUF | SIInstrFlags::MTBUF))) {
+  if (isGFX12Plus() && SIInstrFlags::isBuffer(MII, Inst)) {
     const unsigned OffsetSize = 24;
     if (!isUIntN(OffsetSize - 1, Op.getImm())) {
       Error(getFlatOffsetLoc(Operands),
@@ -4809,8 +4787,7 @@ bool AMDGPUAsmParser::validateOffset(const MCInst &Inst,
 
 bool AMDGPUAsmParser::validateFlatOffset(const MCInst &Inst,
                                          const OperandVector &Operands) {
-  uint64_t TSFlags = MII.get(Inst.getOpcode()).TSFlags;
-  if ((TSFlags & SIInstrFlags::FLAT) == 0)
+  if (!SIInstrFlags::isFLAT(MII, Inst))
     return true;
 
   auto Opcode = Inst.getOpcode();
@@ -4828,8 +4805,7 @@ bool AMDGPUAsmParser::validateFlatOffset(const MCInst &Inst,
   // MSB is ignored and forced to zero.
   unsigned OffsetSize = AMDGPU::getNumFlatOffsetBits(getSTI());
   bool AllowNegative =
-      (TSFlags & (SIInstrFlags::FlatGlobal | SIInstrFlags::FlatScratch)) ||
-      isGFX12Plus();
+      SIInstrFlags::isSegmentSpecificFLAT(MII, Inst) || isGFX12Plus();
   if (!isIntN(OffsetSize, Op.getImm()) || (!AllowNegative && Op.getImm() < 0)) {
     Error(getFlatOffsetLoc(Operands),
           Twine("expected a ") +
@@ -4856,8 +4832,7 @@ bool AMDGPUAsmParser::validateSMEMOffset(const MCInst &Inst,
   if (isCI() || isSI())
     return true;
 
-  uint64_t TSFlags = MII.get(Inst.getOpcode()).TSFlags;
-  if ((TSFlags & SIInstrFlags::SMRD) == 0)
+  if (!SIInstrFlags::isSMRD(MII, Inst))
     return true;
 
   auto Opcode = Inst.getOpcode();
@@ -4889,7 +4864,7 @@ bool AMDGPUAsmParser::validateSOPLiteral(const MCInst &Inst,
                                          const OperandVector &Operands) {
   unsigned Opcode = Inst.getOpcode();
   const MCInstrDesc &Desc = MII.get(Opcode);
-  if (!(Desc.TSFlags & (SIInstrFlags::SOP2 | SIInstrFlags::SOPC)))
+  if (!SIInstrFlags::isSOP2(Desc) && !SIInstrFlags::isSOPC(Desc))
     return true;
 
   const int Src0Idx = AMDGPU::getNamedOperandIdx(Opcode, AMDGPU::OpName::src0);
@@ -4952,9 +4927,7 @@ bool AMDGPUAsmParser::validateOpSel(const MCInst &Inst) {
       return false;
   }
 
-  uint64_t TSFlags = MII.get(Opc).TSFlags;
-
-  if (isGFX940() && (TSFlags & SIInstrFlags::IsDOT)) {
+  if (isGFX940() && SIInstrFlags::isDOT(MII, Inst)) {
     int OpSelIdx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::op_sel);
     if (OpSelIdx != -1) {
       if (Inst.getOperand(OpSelIdx).getImm() != 0)
@@ -4968,8 +4941,8 @@ bool AMDGPUAsmParser::validateOpSel(const MCInst &Inst) {
   }
 
   // op_sel[0:1] must be 0 for v_dot2_bf16_bf16 and v_dot2_f16_f16 (VOP3 Dot).
-  if (isGFX11Plus() && (TSFlags & SIInstrFlags::IsDOT) &&
-      (TSFlags & SIInstrFlags::VOP3) && !(TSFlags & SIInstrFlags::VOP3P)) {
+  if (isGFX11Plus() && SIInstrFlags::isDOT(MII, Inst) &&
+      SIInstrFlags::isVOP3(MII, Inst) && !SIInstrFlags::isVOP3P(MII, Inst)) {
     int OpSelIdx = AMDGPU::getNamedOperandIdx(Opc, AMDGPU::OpName::op_sel);
     unsigned OpSel = Inst.getOperand(OpSelIdx).getImm();
     if (OpSel & 3)
@@ -5053,14 +5026,13 @@ bool AMDGPUAsmParser::validateNeg(const MCInst &Inst, AMDGPU::OpName OpName) {
   assert(OpName == AMDGPU::OpName::neg_lo || OpName == AMDGPU::OpName::neg_hi);
 
   const unsigned Opc = Inst.getOpcode();
-  uint64_t TSFlags = MII.get(Opc).TSFlags;
 
   // v_dot4 fp8/bf8 neg_lo/neg_hi not allowed on src0 and src1 (allowed on src2)
   // v_wmma iu4/iu8 neg_lo not allowed on src2 (allowed on src0, src1)
   // v_swmmac f16/bf16 neg_lo/neg_hi not allowed on src2 (allowed on src0, src1)
   // other wmma/swmmac instructions don't have neg_lo/neg_hi operand.
-  if (!(TSFlags & SIInstrFlags::IsDOT) && !(TSFlags & SIInstrFlags::IsWMMA) &&
-      !(TSFlags & SIInstrFlags::IsSWMMAC))
+  if (!SIInstrFlags::isDOT(MII, Inst) && !SIInstrFlags::isWMMA(MII, Inst) &&
+      !SIInstrFlags::isSWMMAC(MII, Inst))
     return true;
 
   int NegIdx = AMDGPU::getNamedOperandIdx(Opc, OpName);
@@ -5142,8 +5114,8 @@ bool AMDGPUAsmParser::validateVOPLiteral(const MCInst &Inst,
   unsigned Opcode = Inst.getOpcode();
   const MCInstrDesc &Desc = MII.get(Opcode);
   bool HasMandatoryLiteral = getNamedOperandIdx(Opcode, OpName::imm) != -1;
-  if (!(Desc.TSFlags & (SIInstrFlags::VOP3 | SIInstrFlags::VOP3P)) &&
-      !HasMandatoryLiteral && !isVOPD(Opcode))
+  if (!SIInstrFlags::isVOP3Like(Desc) && !HasMandatoryLiteral &&
+      !isVOPD(Opcode))
     return true;
 
   OperandIndices OpIndices = getSrcOperandIndices(Opcode, HasMandatoryLiteral);
@@ -5247,13 +5219,11 @@ static int IsAGPROperand(const MCInst &Inst, AMDGPU::OpName Name,
 }
 
 bool AMDGPUAsmParser::validateAGPRLdSt(const MCInst &Inst) const {
-  uint64_t TSFlags = MII.get(Inst.getOpcode()).TSFlags;
-  if ((TSFlags & (SIInstrFlags::FLAT | SIInstrFlags::MUBUF |
-                  SIInstrFlags::MTBUF | SIInstrFlags::MIMG |
-                  SIInstrFlags::DS)) == 0)
+  if (!SIInstrFlags::isFLAT(MII, Inst) && !SIInstrFlags::isBuffer(MII, Inst) &&
+      !SIInstrFlags::isMIMG(MII, Inst) && !SIInstrFlags::isDS(MII, Inst))
     return true;
 
-  AMDGPU::OpName DataName = (TSFlags & SIInstrFlags::DS)
+  AMDGPU::OpName DataName = SIInstrFlags::isDS(MII, Inst)
                                 ? AMDGPU::OpName::data0
                                 : AMDGPU::OpName::vdata;
 
@@ -5261,7 +5231,7 @@ bool AMDGPUAsmParser::validateAGPRLdSt(const MCInst &Inst) const {
   int DstAreg = IsAGPROperand(Inst, AMDGPU::OpName::vdst, MRI);
   int DataAreg = IsAGPROperand(Inst, DataName, MRI);
 
-  if ((TSFlags & SIInstrFlags::DS) && DataAreg >= 0) {
+  if (SIInstrFlags::isDS(MII, Inst) && DataAreg >= 0) {
     int Data2Areg = IsAGPROperand(Inst, AMDGPU::OpName::data1, MRI);
     if (Data2Areg >= 0 && Data2Areg != DataAreg)
       return false;
@@ -5403,10 +5373,9 @@ bool AMDGPUAsmParser::validateWaitCnt(const MCInst &Inst,
 
 bool AMDGPUAsmParser::validateDS(const MCInst &Inst,
                                  const OperandVector &Operands) {
-  uint64_t TSFlags = MII.get(Inst.getOpcode()).TSFlags;
-  if ((TSFlags & SIInstrFlags::DS) == 0)
+  if (!SIInstrFlags::isDS(MII, Inst))
     return true;
-  if (TSFlags & SIInstrFlags::GWS)
+  if (SIInstrFlags::isGWS(MII, Inst))
     return validateGWS(Inst, Operands);
   // Only validate GDS for non-GWS instructions.
   if (hasGDS())
@@ -5486,8 +5455,7 @@ bool AMDGPUAsmParser::validateCoherencyBits(const MCInst &Inst,
   if (isGFX12Plus())
     return validateTHAndScopeBits(Inst, Operands, CPol);
 
-  uint64_t TSFlags = MII.get(Inst.getOpcode()).TSFlags;
-  if (TSFlags & SIInstrFlags::SMRD) {
+  if (SIInstrFlags::isSMRD(MII, Inst)) {
     if (CPol && (isSI() || isCI())) {
       SMLoc S = getImmLoc(AMDGPUOperand::ImmTyCPol, Operands);
       Error(S, "cache policy is not supported for SMRD instructions");
@@ -5500,10 +5468,7 @@ bool AMDGPUAsmParser::validateCoherencyBits(const MCInst &Inst,
   }
 
   if (isGFX90A() && !isGFX940() && (CPol & CPol::SCC)) {
-    const uint64_t AllowSCCModifier = SIInstrFlags::MUBUF |
-                                      SIInstrFlags::MTBUF | SIInstrFlags::MIMG |
-                                      SIInstrFlags::FLAT;
-    if (!(TSFlags & AllowSCCModifier)) {
+    if (!SIInstrFlags::isVMEM(MII, Inst)) {
       SMLoc S = getImmLoc(AMDGPUOperand::ImmTyCPol, Operands);
       StringRef CStr(S.getPointer());
       S = SMLoc::getFromPointer(&CStr.data()[CStr.find("scc")]);
@@ -5513,11 +5478,11 @@ bool AMDGPUAsmParser::validateCoherencyBits(const MCInst &Inst,
     }
   }
 
-  if (!(TSFlags & (SIInstrFlags::IsAtomicNoRet | SIInstrFlags::IsAtomicRet)))
+  if (!SIInstrFlags::isAtomic(MII, Inst))
     return true;
 
-  if (TSFlags & SIInstrFlags::IsAtomicRet) {
-    if (!(TSFlags & SIInstrFlags::MIMG) && !(CPol & CPol::GLC)) {
+  if (SIInstrFlags::isAtomicRet(MII, Inst)) {
+    if (!SIInstrFlags::isMIMG(MII, Inst) && !(CPol & CPol::GLC)) {
       Error(IDLoc, isGFX940() ? "instruction must use sc0"
                               : "instruction must use glc");
       return false;
@@ -5543,9 +5508,6 @@ bool AMDGPUAsmParser::validateTHAndScopeBits(const MCInst &Inst,
   const unsigned TH = CPol & AMDGPU::CPol::TH;
   const unsigned Scope = CPol & AMDGPU::CPol::SCOPE;
 
-  const unsigned Opcode = Inst.getOpcode();
-  const MCInstrDesc &TID = MII.get(Opcode);
-
   auto PrintError = [&](StringRef Msg) {
     SMLoc S = getImmLoc(AMDGPUOperand::ImmTyCPol, Operands);
     Error(S, Msg);
@@ -5553,18 +5515,18 @@ bool AMDGPUAsmParser::validateTHAndScopeBits(const MCInst &Inst,
   };
 
   if ((TH & AMDGPU::CPol::TH_ATOMIC_RETURN) &&
-      (TID.TSFlags & SIInstrFlags::IsAtomicNoRet))
+      SIInstrFlags::isAtomicNoRet(MII, Inst))
     return PrintError("th:TH_ATOMIC_RETURN requires a destination operand");
 
-  if ((TID.TSFlags & SIInstrFlags::IsAtomicRet) &&
-      (TID.TSFlags & (SIInstrFlags::FLAT | SIInstrFlags::MUBUF)) &&
+  if (SIInstrFlags::isAtomicRet(MII, Inst) &&
+      (SIInstrFlags::isFLAT(MII, Inst) || SIInstrFlags::isMUBUF(MII, Inst)) &&
       (!(TH & AMDGPU::CPol::TH_ATOMIC_RETURN)))
     return PrintError("instruction must use th:TH_ATOMIC_RETURN");
 
   if (TH == 0)
     return true;
 
-  if ((TID.TSFlags & SIInstrFlags::SMRD) &&
+  if (SIInstrFlags::isSMRD(MII, Inst) &&
       ((TH == AMDGPU::CPol::TH_NT_RT) || (TH == AMDGPU::CPol::TH_RT_NT) ||
        (TH == AMDGPU::CPol::TH_NT_HT)))
     return PrintError("invalid th value for SMEM instruction");
@@ -5577,7 +5539,7 @@ bool AMDGPUAsmParser::validateTHAndScopeBits(const MCInst &Inst,
       return PrintError("scope and th combination is not valid");
   }
 
-  unsigned THType = AMDGPU::getTemporalHintType(TID);
+  unsigned THType = AMDGPU::getTemporalHintType(MII.get(Inst.getOpcode()));
   if (THType == AMDGPU::CPol::TH_TYPE_ATOMIC) {
     if (!(CPol & AMDGPU::CPol::TH_TYPE_ATOMIC))
       return PrintError("invalid th value for atomic instructions");
@@ -5595,8 +5557,7 @@ bool AMDGPUAsmParser::validateTHAndScopeBits(const MCInst &Inst,
 bool AMDGPUAsmParser::validateTFE(const MCInst &Inst,
                                   const OperandVector &Operands) {
   const MCInstrDesc &Desc = MII.get(Inst.getOpcode());
-  if (Desc.mayStore() &&
-      (Desc.TSFlags & (SIInstrFlags::MUBUF | SIInstrFlags::MTBUF))) {
+  if (Desc.mayStore() && SIInstrFlags::isBuffer(Desc)) {
     SMLoc Loc = getImmLoc(AMDGPUOperand::ImmTyTFE, Operands);
     if (Loc != getInstLoc(Operands)) {
       Error(Loc, "TFE modifier has no meaning for store instructions");
@@ -9257,8 +9218,7 @@ void AMDGPUAsmParser::cvtMubufImpl(MCInst &Inst,
   bool IsAtomicReturn = false;
 
   if (IsAtomic) {
-    IsAtomicReturn =  MII.get(Inst.getOpcode()).TSFlags &
-                      SIInstrFlags::IsAtomicRet;
+    IsAtomicReturn = SIInstrFlags::isAtomicRet(MII, Inst);
   }
 
   for (unsigned i = FirstOperandIdx, e = Operands.size(); i != e; ++i) {
@@ -9758,9 +9718,8 @@ void AMDGPUAsmParser::cvtVOP3(MCInst &Inst, const OperandVector &Operands) {
 void AMDGPUAsmParser::cvtVOP3P(MCInst &Inst, const OperandVector &Operands,
                                OptionalImmIndexMap &OptIdx) {
   const int Opc = Inst.getOpcode();
-  const MCInstrDesc &Desc = MII.get(Opc);
 
-  const bool IsPacked = (Desc.TSFlags & SIInstrFlags::IsPacked) != 0;
+  const bool IsPacked = SIInstrFlags::isPacked(MII, Inst);
 
   if (Opc == AMDGPU::V_CVT_SCALEF32_PK_FP4_F16_vi ||
       Opc == AMDGPU::V_CVT_SCALEF32_PK_FP4_BF16_vi ||
@@ -10416,9 +10375,9 @@ void AMDGPUAsmParser::cvtVOP3DPP(MCInst &Inst, const OperandVector &Operands,
   if (AMDGPU::hasNamedOperand(Opc, AMDGPU::OpName::omod))
     addOptionalImmOperand(Inst, Operands, OptionalIdx, AMDGPUOperand::ImmTyOModSI);
 
-  if (Desc.TSFlags & SIInstrFlags::VOP3P)
+  if (SIInstrFlags::isVOP3P(Desc))
     cvtVOP3P(Inst, Operands, OptionalIdx);
-  else if (Desc.TSFlags & SIInstrFlags::VOP3)
+  else if (SIInstrFlags::isVOP3(Desc))
     cvtVOP3OpSel(Inst, Operands, OptionalIdx);
   else if (AMDGPU::hasNamedOperand(Opc, AMDGPU::OpName::op_sel)) {
     addOptionalImmOperand(Inst, Operands, OptionalIdx, AMDGPUOperand::ImmTyOpSel);

--- a/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
+++ b/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
@@ -782,20 +782,20 @@ DecodeStatus AMDGPUDisassembler::getInstruction(MCInst &MI, uint64_t &Size,
 
   decodeImmOperands(MI, *MCII);
 
-  if (MCII->get(MI.getOpcode()).TSFlags & SIInstrFlags::DPP) {
+  if (SIInstrFlags::isDPP(*MCII, MI)) {
     if (isMacDPP(MI))
       convertMacDPPInst(MI);
 
-    if (MCII->get(MI.getOpcode()).TSFlags & SIInstrFlags::VOP3P)
+    if (SIInstrFlags::isVOP3P(*MCII, MI))
       convertVOP3PDPPInst(MI);
-    else if (MCII->get(MI.getOpcode()).TSFlags & SIInstrFlags::VOPC)
+    else if (SIInstrFlags::isVOPC(*MCII, MI))
       convertVOPCDPPInst(MI); // Special VOP3 case
     else if (AMDGPU::isVOPC64DPP(MI.getOpcode()))
       convertVOPC64DPPInst(MI); // Special VOP3 case
     else if (AMDGPU::getNamedOperandIdx(MI.getOpcode(), AMDGPU::OpName::dpp8) !=
              -1)
       convertDPP8Inst(MI);
-    else if (MCII->get(MI.getOpcode()).TSFlags & SIInstrFlags::VOP3)
+    else if (SIInstrFlags::isVOP3(*MCII, MI))
       convertVOP3DPPInst(MI); // Regular VOP3 case
   }
 
@@ -814,19 +814,17 @@ DecodeStatus AMDGPUDisassembler::getInstruction(MCInst &MI, uint64_t &Size,
                          AMDGPU::OpName::src2_modifiers);
   }
 
-  if ((MCII->get(MI.getOpcode()).TSFlags & SIInstrFlags::DS) &&
-      !AMDGPU::hasGDS(STI)) {
+  if (SIInstrFlags::isDS(*MCII, MI) && !AMDGPU::hasGDS(STI)) {
     insertNamedMCOperand(MI, MCOperand::createImm(0), AMDGPU::OpName::gds);
   }
 
-  if (MCII->get(MI.getOpcode()).TSFlags &
-      (SIInstrFlags::MUBUF | SIInstrFlags::FLAT | SIInstrFlags::SMRD)) {
+  if (SIInstrFlags::isMUBUF(*MCII, MI) || SIInstrFlags::isFLAT(*MCII, MI) ||
+      SIInstrFlags::isSMRD(*MCII, MI)) {
     int CPolPos = AMDGPU::getNamedOperandIdx(MI.getOpcode(),
                                              AMDGPU::OpName::cpol);
     if (CPolPos != -1) {
       unsigned CPol =
-          (MCII->get(MI.getOpcode()).TSFlags & SIInstrFlags::IsAtomicRet) ?
-              AMDGPU::CPol::GLC : 0;
+          SIInstrFlags::isAtomicRet(*MCII, MI) ? AMDGPU::CPol::GLC : 0;
       if (MI.getNumOperands() <= (unsigned)CPolPos) {
         insertNamedMCOperand(MI, MCOperand::createImm(CPol),
                              AMDGPU::OpName::cpol);
@@ -836,8 +834,7 @@ DecodeStatus AMDGPUDisassembler::getInstruction(MCInst &MI, uint64_t &Size,
     }
   }
 
-  if ((MCII->get(MI.getOpcode()).TSFlags &
-       (SIInstrFlags::MTBUF | SIInstrFlags::MUBUF)) &&
+  if (SIInstrFlags::isBuffer(*MCII, MI) &&
       (STI.hasFeature(AMDGPU::FeatureGFX90AInsts))) {
     // GFX90A lost TFE, its place is occupied by ACC.
     int TFEOpIdx =
@@ -861,8 +858,7 @@ DecodeStatus AMDGPUDisassembler::getInstruction(MCInst &MI, uint64_t &Size,
     }
   }
 
-  if (MCII->get(MI.getOpcode()).TSFlags &
-      (SIInstrFlags::MTBUF | SIInstrFlags::MUBUF)) {
+  if (SIInstrFlags::isBuffer(*MCII, MI)) {
     int SWZOpIdx =
         AMDGPU::getNamedOperandIdx(MI.getOpcode(), AMDGPU::OpName::swz);
     if (SWZOpIdx != -1) {
@@ -873,7 +869,7 @@ DecodeStatus AMDGPUDisassembler::getInstruction(MCInst &MI, uint64_t &Size,
   }
 
   const MCInstrDesc &Desc = MCII->get(MI.getOpcode());
-  if (Desc.TSFlags & SIInstrFlags::MIMG) {
+  if (SIInstrFlags::isMIMG(Desc)) {
     int VAddr0Idx =
         AMDGPU::getNamedOperandIdx(MI.getOpcode(), AMDGPU::OpName::vaddr0);
     int RsrcIdx =
@@ -895,23 +891,22 @@ DecodeStatus AMDGPUDisassembler::getInstruction(MCInst &MI, uint64_t &Size,
     convertMIMGInst(MI);
   }
 
-  if (MCII->get(MI.getOpcode()).TSFlags &
-      (SIInstrFlags::VIMAGE | SIInstrFlags::VSAMPLE))
+  if (SIInstrFlags::isVIMAGE(*MCII, MI) || SIInstrFlags::isVSAMPLE(*MCII, MI))
     convertMIMGInst(MI);
 
-  if (MCII->get(MI.getOpcode()).TSFlags & SIInstrFlags::EXP)
+  if (SIInstrFlags::isEXP(*MCII, MI))
     convertEXPInst(MI);
 
-  if (MCII->get(MI.getOpcode()).TSFlags & SIInstrFlags::VINTERP)
+  if (SIInstrFlags::isVINTERP(*MCII, MI))
     convertVINTERPInst(MI);
 
-  if (MCII->get(MI.getOpcode()).TSFlags & SIInstrFlags::SDWA)
+  if (SIInstrFlags::isSDWA(*MCII, MI))
     convertSDWAInst(MI);
 
-  if (MCII->get(MI.getOpcode()).TSFlags & SIInstrFlags::IsMAI)
+  if (SIInstrFlags::isMAI(*MCII, MI))
     convertMAIInst(MI);
 
-  if (MCII->get(MI.getOpcode()).TSFlags & SIInstrFlags::IsWMMA)
+  if (SIInstrFlags::isWMMA(*MCII, MI))
     convertWMMAInst(MI);
 
   int VDstIn_Idx = AMDGPU::getNamedOperandIdx(MI.getOpcode(),
@@ -930,14 +925,14 @@ DecodeStatus AMDGPUDisassembler::getInstruction(MCInst &MI, uint64_t &Size,
     }
   }
 
-  bool IsSOPK = MCII->get(MI.getOpcode()).TSFlags & SIInstrFlags::SOPK;
+  bool IsSOPK = SIInstrFlags::isSOPK(*MCII, MI);
   if (AMDGPU::hasNamedOperand(MI.getOpcode(), AMDGPU::OpName::imm) && !IsSOPK)
     convertFMAanyK(MI);
 
   // Some VOPC instructions, e.g., v_cmpx_f_f64, use VOP3 encoding and
   // have EXEC as implicit destination. Issue a warning if encoding for
   // vdst is not EXEC.
-  if ((MCII->get(MI.getOpcode()).TSFlags & SIInstrFlags::VOP3) &&
+  if (SIInstrFlags::isVOP3(*MCII, MI) &&
       MCII->get(MI.getOpcode()).getNumDefs() == 0 &&
       MCII->get(MI.getOpcode()).hasImplicitDefOfPhysReg(AMDGPU::EXEC)) {
     auto ExecEncoding = MRI.getEncodingValue(AMDGPU::EXEC_LO);
@@ -1275,8 +1270,6 @@ static MCRegister CheckVGPROverflow(MCRegister Reg, const MCRegisterClass &RC,
 // VADDR size. Consequently, decoded instructions always show address as if it
 // has 1 dword, which could be not really so.
 void AMDGPUDisassembler::convertMIMGInst(MCInst &MI) const {
-  auto TSFlags = MCII->get(MI.getOpcode()).TSFlags;
-
   int VDstIdx = AMDGPU::getNamedOperandIdx(MI.getOpcode(),
                                            AMDGPU::OpName::vdst);
 
@@ -1284,7 +1277,7 @@ void AMDGPUDisassembler::convertMIMGInst(MCInst &MI) const {
                                             AMDGPU::OpName::vdata);
   int VAddr0Idx =
       AMDGPU::getNamedOperandIdx(MI.getOpcode(), AMDGPU::OpName::vaddr0);
-  AMDGPU::OpName RsrcOpName = (TSFlags & SIInstrFlags::MIMG)
+  AMDGPU::OpName RsrcOpName = SIInstrFlags::isMIMG(*MCII, MI)
                                   ? AMDGPU::OpName::srsrc
                                   : AMDGPU::OpName::rsrc;
   int RsrcIdx = AMDGPU::getNamedOperandIdx(MI.getOpcode(), RsrcOpName);
@@ -1308,8 +1301,8 @@ void AMDGPUDisassembler::convertMIMGInst(MCInst &MI) const {
   }
 
   bool IsAtomic = (VDstIdx != -1);
-  bool IsGather4 = TSFlags & SIInstrFlags::Gather4;
-  bool IsVSample = TSFlags & SIInstrFlags::VSAMPLE;
+  bool IsGather4 = SIInstrFlags::isGather4(*MCII, MI);
+  bool IsVSample = SIInstrFlags::isVSAMPLE(*MCII, MI);
   bool IsNSA = false;
   bool IsPartialNSA = false;
   unsigned AddrSize = Info->VAddrDwords;
@@ -2907,14 +2900,13 @@ const MCExpr *AMDGPUDisassembler::createConstantSymbolExpr(StringRef Id,
 }
 
 bool AMDGPUDisassembler::isBufferInstruction(const MCInst &MI) const {
-  const uint64_t TSFlags = MCII->get(MI.getOpcode()).TSFlags;
-
   // Check for MUBUF and MTBUF instructions
-  if (TSFlags & (SIInstrFlags::MTBUF | SIInstrFlags::MUBUF))
+  if (SIInstrFlags::isBuffer(*MCII, MI))
     return true;
 
   // Check for SMEM buffer instructions (S_BUFFER_* instructions)
-  if ((TSFlags & SIInstrFlags::SMRD) && AMDGPU::getSMEMIsBuffer(MI.getOpcode()))
+  if (SIInstrFlags::isSMRD(*MCII, MI) &&
+      AMDGPU::getSMEMIsBuffer(MI.getOpcode()))
     return true;
 
   return false;

--- a/llvm/lib/Target/AMDGPU/MCA/AMDGPUCustomBehaviour.cpp
+++ b/llvm/lib/Target/AMDGPU/MCA/AMDGPUCustomBehaviour.cpp
@@ -249,12 +249,11 @@ void AMDGPUCustomBehaviour::generateWaitCntInfo() {
     unsigned Index = EN.index();
     unsigned Opcode = Inst->getOpcode();
     const MCInstrDesc &MCID = MCII.get(Opcode);
-    if ((MCID.TSFlags & SIInstrFlags::DS) &&
-        (MCID.TSFlags & SIInstrFlags::LGKM_CNT)) {
+    if (SIInstrFlags::isDS(MCID) && SIInstrFlags::usesLGKM_CNT(MCID)) {
       InstrWaitCntInfo[Index].LgkmCnt = true;
       if (isAlwaysGDS(Opcode) || hasModifiersSet(Inst, AMDGPU::OpName::gds))
         InstrWaitCntInfo[Index].ExpCnt = true;
-    } else if (MCID.TSFlags & SIInstrFlags::FLAT) {
+    } else if (SIInstrFlags::isFLAT(MCID)) {
       // We conservatively assume that mayAccessVMEMThroughFlat(Inst)
       // and mayAccessLDSThroughFlat(Inst) would both return true for this
       // instruction. We have to do this because those functions use
@@ -262,16 +261,16 @@ void AMDGPUCustomBehaviour::generateWaitCntInfo() {
       InstrWaitCntInfo[Index].LgkmCnt = true;
       if (!STI.hasFeature(AMDGPU::FeatureVscnt))
         InstrWaitCntInfo[Index].VmCnt = true;
-      else if (MCID.mayLoad() && !(MCID.TSFlags & SIInstrFlags::IsAtomicNoRet))
+      else if (MCID.mayLoad() && !SIInstrFlags::isAtomicNoRet(MCID))
         InstrWaitCntInfo[Index].VmCnt = true;
       else
         InstrWaitCntInfo[Index].VsCnt = true;
-    } else if (isVMEM(MCID) && !AMDGPU::getMUBUFIsBufferInv(Opcode)) {
+    } else if (SIInstrFlags::isVMEM(MCID) &&
+               !AMDGPU::getMUBUFIsBufferInv(Opcode)) {
       if (!STI.hasFeature(AMDGPU::FeatureVscnt))
         InstrWaitCntInfo[Index].VmCnt = true;
-      else if ((MCID.mayLoad() &&
-                !(MCID.TSFlags & SIInstrFlags::IsAtomicNoRet)) ||
-               ((MCID.TSFlags & SIInstrFlags::MIMG) && !MCID.mayLoad() &&
+      else if ((MCID.mayLoad() && !SIInstrFlags::isAtomicNoRet(MCID)) ||
+               (SIInstrFlags::isMIMG(MCID) && !MCID.mayLoad() &&
                 !MCID.mayStore()))
         InstrWaitCntInfo[Index].VmCnt = true;
       else if (MCID.mayStore())
@@ -281,12 +280,11 @@ void AMDGPUCustomBehaviour::generateWaitCntInfo() {
       // GCNTarget.vmemWriteNeedsExpWaitcnt()
       // which is defined as
       // { return getGeneration() < SEA_ISLANDS; }
-      if (IV.Major < 7 &&
-          (MCID.mayStore() || (MCID.TSFlags & SIInstrFlags::IsAtomicRet)))
+      if (IV.Major < 7 && (MCID.mayStore() || SIInstrFlags::isAtomicRet(MCID)))
         InstrWaitCntInfo[Index].ExpCnt = true;
-    } else if (MCID.TSFlags & SIInstrFlags::SMRD) {
+    } else if (SIInstrFlags::isSMRD(MCID)) {
       InstrWaitCntInfo[Index].LgkmCnt = true;
-    } else if (MCID.TSFlags & SIInstrFlags::EXP) {
+    } else if (SIInstrFlags::isEXP(MCID)) {
       InstrWaitCntInfo[Index].ExpCnt = true;
     } else {
       switch (Opcode) {
@@ -299,13 +297,6 @@ void AMDGPUCustomBehaviour::generateWaitCntInfo() {
       }
     }
   }
-}
-
-// taken from SIInstrInfo::isVMEM()
-bool AMDGPUCustomBehaviour::isVMEM(const MCInstrDesc &MCID) {
-  return MCID.TSFlags & SIInstrFlags::MUBUF ||
-         MCID.TSFlags & SIInstrFlags::MTBUF ||
-         MCID.TSFlags & SIInstrFlags::MIMG || MCID.TSFlags & SIInstrFlags::FLAT;
 }
 
 // taken from SIInstrInfo::hasModifiersSet()
@@ -322,17 +313,12 @@ bool AMDGPUCustomBehaviour::hasModifiersSet(
   return true;
 }
 
-// taken from SIInstrInfo::isGWS()
-bool AMDGPUCustomBehaviour::isGWS(uint32_t Opcode) const {
-  const MCInstrDesc &MCID = MCII.get(Opcode);
-  return MCID.TSFlags & SIInstrFlags::GWS;
-}
-
 // taken from SIInstrInfo::isAlwaysGDS()
 bool AMDGPUCustomBehaviour::isAlwaysGDS(uint32_t Opcode) const {
   return Opcode == AMDGPU::DS_ORDERED_COUNT ||
          Opcode == AMDGPU::DS_ADD_GS_REG_RTN ||
-         Opcode == AMDGPU::DS_SUB_GS_REG_RTN || isGWS(Opcode);
+         Opcode == AMDGPU::DS_SUB_GS_REG_RTN ||
+         SIInstrFlags::isGWS(MCII.get(Opcode));
 }
 
 } // namespace llvm::mca

--- a/llvm/lib/Target/AMDGPU/MCA/AMDGPUCustomBehaviour.h
+++ b/llvm/lib/Target/AMDGPU/MCA/AMDGPUCustomBehaviour.h
@@ -67,11 +67,7 @@ class AMDGPUCustomBehaviour : public CustomBehaviour {
   bool hasModifiersSet(const std::unique_ptr<Instruction> &Inst,
                        AMDGPU::OpName OpName) const;
   /// Helper function used in generateWaitCntInfo()
-  bool isGWS(uint32_t Opcode) const;
-  /// Helper function used in generateWaitCntInfo()
   bool isAlwaysGDS(uint32_t Opcode) const;
-  /// Helper function used in generateWaitCntInfo()
-  bool isVMEM(const MCInstrDesc &MCID);
   /// This method gets called from checkCustomHazard when mca is attempting to
   /// dispatch an s_waitcnt instruction (or one of its variants). The method
   /// looks at each of the instructions that are still executing in the pipeline

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUInstPrinter.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUInstPrinter.cpp
@@ -111,8 +111,7 @@ void AMDGPUInstPrinter::printOffset(const MCInst *MI, unsigned OpNo,
     O << " offset:";
 
     // GFX12+ uses a 24-bit signed offset for VBUFFER.
-    const MCInstrDesc &Desc = MII.get(MI->getOpcode());
-    bool IsVBuffer = Desc.TSFlags & (SIInstrFlags::MUBUF | SIInstrFlags::MTBUF);
+    bool IsVBuffer = SIInstrFlags::isBuffer(MII, *MI);
     if (IsVBuffer && AMDGPU::isGFX12Plus(STI))
       O << formatDec(SignExtend32<24>(Imm));
     else
@@ -127,9 +126,7 @@ void AMDGPUInstPrinter::printFlatOffset(const MCInst *MI, unsigned OpNo,
   if (Imm != 0) {
     O << " offset:";
 
-    const MCInstrDesc &Desc = MII.get(MI->getOpcode());
-    bool AllowNegative = (Desc.TSFlags & (SIInstrFlags::FlatGlobal |
-                                          SIInstrFlags::FlatScratch)) ||
+    bool AllowNegative = SIInstrFlags::isSegmentSpecificFLAT(MII, *MI) ||
                          STI.hasFeature(AMDGPU::FeatureFlatSignedOffset);
 
     if (AllowNegative) // Signed offset
@@ -178,8 +175,7 @@ void AMDGPUInstPrinter::printCPol(const MCInst *MI, unsigned OpNo,
   }
 
   if (Imm & CPol::GLC)
-    O << ((AMDGPU::isGFX940(STI) &&
-           !(MII.get(MI->getOpcode()).TSFlags & SIInstrFlags::SMRD)) ? " sc0"
+    O << ((AMDGPU::isGFX940(STI) && !SIInstrFlags::isSMRD(MII, *MI)) ? " sc0"
                                                                      : " glc");
   if (Imm & CPol::SLC)
     O << (AMDGPU::isGFX940(STI) ? " nt" : " slc");
@@ -423,19 +419,18 @@ void AMDGPUInstPrinter::printRegOperand(MCRegister Reg, unsigned Opc,
 void AMDGPUInstPrinter::printVOPDst(const MCInst *MI, unsigned OpNo,
                                     const MCSubtargetInfo &STI, raw_ostream &O) {
   auto Opcode = MI->getOpcode();
-  auto Flags = MII.get(Opcode).TSFlags;
   if (OpNo == 0) {
-    if (Flags & SIInstrFlags::VOP3 && Flags & SIInstrFlags::DPP)
+    if (SIInstrFlags::isVOP3(MII, *MI) && SIInstrFlags::isDPP(MII, *MI))
       O << "_e64_dpp";
-    else if (Flags & SIInstrFlags::VOP3) {
+    else if (SIInstrFlags::isVOP3(MII, *MI)) {
       if (!getVOP3IsSingle(Opcode))
         O << "_e64";
-    } else if (Flags & SIInstrFlags::DPP)
+    } else if (SIInstrFlags::isDPP(MII, *MI))
       O << "_dpp";
-    else if (Flags & SIInstrFlags::SDWA)
+    else if (SIInstrFlags::isSDWA(MII, *MI))
       O << "_sdwa";
-    else if (((Flags & SIInstrFlags::VOP1) && !getVOP1IsSingle(Opcode)) ||
-             ((Flags & SIInstrFlags::VOP2) && !getVOP2IsSingle(Opcode)))
+    else if ((SIInstrFlags::isVOP1(MII, *MI) && !getVOP1IsSingle(Opcode)) ||
+             (SIInstrFlags::isVOP2(MII, *MI) && !getVOP2IsSingle(Opcode)))
       O << "_e32";
     O << " ";
   }
@@ -790,8 +785,7 @@ void AMDGPUInstPrinter::printDefaultVccOperand(bool FirstOperand,
 
 bool AMDGPUInstPrinter::needsImpliedVcc(const MCInstrDesc &Desc,
                                         unsigned OpNo) const {
-  return OpNo == 0 && (Desc.TSFlags & SIInstrFlags::DPP) &&
-         (Desc.TSFlags & SIInstrFlags::VOPC) &&
+  return OpNo == 0 && SIInstrFlags::isDPP(Desc) && SIInstrFlags::isVOPC(Desc) &&
          !isVOPCAsmOnly(Desc.getOpcode()) &&
          (Desc.hasImplicitDefOfPhysReg(AMDGPU::VCC) ||
           Desc.hasImplicitDefOfPhysReg(AMDGPU::VCC_LO));
@@ -807,9 +801,8 @@ void AMDGPUInstPrinter::printOperand(const MCInst *MI, unsigned OpNo,
   // 0, 1 and 2 are the first printed operands in different cases
   // If there are printed modifiers, printOperandAndFPInputMods or
   // printOperandAndIntInputMods will be called instead
-  if ((OpNo == 0 ||
-       (OpNo == 1 && (Desc.TSFlags & SIInstrFlags::DPP) && ModIdx != -1)) &&
-      (Desc.TSFlags & SIInstrFlags::VOPC) && !isVOPCAsmOnly(Desc.getOpcode()) &&
+  if ((OpNo == 0 || (OpNo == 1 && SIInstrFlags::isDPP(Desc) && ModIdx != -1)) &&
+      SIInstrFlags::isVOPC(Desc) && !isVOPCAsmOnly(Desc.getOpcode()) &&
       (Desc.hasImplicitDefOfPhysReg(AMDGPU::VCC) ||
        Desc.hasImplicitDefOfPhysReg(AMDGPU::VCC_LO)))
     printDefaultVccOperand(true, STI, O);
@@ -983,7 +976,7 @@ void AMDGPUInstPrinter::printRegularOperand(const MCInst *MI, unsigned OpNo,
     break;
   }
 
-  if (Desc.TSFlags & SIInstrFlags::MTBUF) {
+  if (SIInstrFlags::isMTBUF(Desc)) {
     int SOffsetIdx =
       AMDGPU::getNamedOperandIdx(MI->getOpcode(), AMDGPU::OpName::soffset);
     assert(SOffsetIdx != -1);
@@ -1369,8 +1362,7 @@ void AMDGPUInstPrinter::printPackedModifier(const MCInst *MI,
 
   // Print three values of neg/opsel for wmma instructions (prints 0 when there
   // is no src_modifier operand instead of not printing anything).
-  if (MII.get(MI->getOpcode()).TSFlags & SIInstrFlags::IsSWMMAC ||
-      MII.get(MI->getOpcode()).TSFlags & SIInstrFlags::IsWMMA) {
+  if (SIInstrFlags::isSWMMAC(MII, *MI) || SIInstrFlags::isWMMA(MII, *MI)) {
     NumOps = 0;
     int DefaultValue = Mod == SISrcMods::OP_SEL_1;
     for (AMDGPU::OpName OpName :
@@ -1384,12 +1376,10 @@ void AMDGPUInstPrinter::printPackedModifier(const MCInst *MI,
     }
   }
 
-  const bool HasDstSel =
-      HasDst && NumOps > 0 && Mod == SISrcMods::OP_SEL_0 &&
-      MII.get(MI->getOpcode()).TSFlags & SIInstrFlags::VOP3_OPSEL;
+  const bool HasDstSel = HasDst && NumOps > 0 && Mod == SISrcMods::OP_SEL_0 &&
+                         SIInstrFlags::hasVOP3OpSel(MII, *MI);
 
-  const bool IsPacked =
-    MII.get(MI->getOpcode()).TSFlags & SIInstrFlags::IsPacked;
+  const bool IsPacked = SIInstrFlags::isPacked(MII, *MI);
 
   if (allOpsDefaultValue(Ops, NumOps, Mod, IsPacked, HasDstSel))
     return;

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCCodeEmitter.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCCodeEmitter.cpp
@@ -262,9 +262,8 @@ static uint32_t getLit64Encoding(const MCInstrDesc &Desc, uint64_t Val,
 
   // The rest part needs to align with AMDGPUInstPrinter::printLiteral64.
 
-  bool CanUse64BitLiterals =
-      STI.hasFeature(AMDGPU::Feature64BitLiterals) &&
-      !(Desc.TSFlags & (SIInstrFlags::VOP3 | SIInstrFlags::VOP3P));
+  bool CanUse64BitLiterals = STI.hasFeature(AMDGPU::Feature64BitLiterals) &&
+                             !SIInstrFlags::isVOP3Like(Desc);
   if (IsFP) {
     return CanUse64BitLiterals && Lo_32(Val) ? 254 : 255;
   }
@@ -402,8 +401,7 @@ void AMDGPUMCCodeEmitter::encodeInstruction(const MCInst &MI,
 
   // Set unused op_sel_hi bits to 1 for VOP3P and MAI instructions.
   // Note that accvgpr_read/write are MAI, have src0, but do not use op_sel.
-  if (((Desc.TSFlags & SIInstrFlags::VOP3P) ||
-       Opcode == AMDGPU::V_ACCVGPR_READ_B32_vi ||
+  if ((SIInstrFlags::isVOP3P(Desc) || Opcode == AMDGPU::V_ACCVGPR_READ_B32_vi ||
        Opcode == AMDGPU::V_ACCVGPR_WRITE_B32_vi) &&
       // Matrix B format operand reuses op_sel_hi.
       !AMDGPU::hasNamedOperand(Opcode, AMDGPU::OpName::matrix_b_fmt) &&
@@ -419,7 +417,7 @@ void AMDGPUMCCodeEmitter::encodeInstruction(const MCInst &MI,
   }
 
   // NSA encoding.
-  if (AMDGPU::isGFX10Plus(STI) && Desc.TSFlags & SIInstrFlags::MIMG) {
+  if (AMDGPU::isGFX10Plus(STI) && SIInstrFlags::isMIMG(Desc)) {
     int vaddr0 = AMDGPU::getNamedOperandIdx(MI.getOpcode(),
                                             AMDGPU::OpName::vaddr0);
     int srsrc = AMDGPU::getNamedOperandIdx(MI.getOpcode(),
@@ -757,9 +755,8 @@ APInt AMDGPUMCCodeEmitter::postEncodeVOPCX(const MCInst &MI, APInt EncodedValue,
   // is ignored by HW. It was decided to define dst as "do not care"
   // in td files to allow disassembler accept any dst value.
   // However, dst is encoded as EXEC for compatibility with SP3.
-  [[maybe_unused]] const MCInstrDesc &Desc = MCII.get(MI.getOpcode());
-  assert((Desc.TSFlags & SIInstrFlags::VOP3) &&
-         Desc.hasImplicitDefOfPhysReg(AMDGPU::EXEC));
+  assert(SIInstrFlags::isVOP3(MCII, MI) &&
+         MCII.get(MI.getOpcode()).hasImplicitDefOfPhysReg(AMDGPU::EXEC));
   EncodedValue |= MRI.getEncodingValue(AMDGPU::EXEC_LO) &
                   AMDGPU::HWEncoding::LO256_REG_IDX_MASK;
   return postEncodeVOP3<true, true, false>(MI, EncodedValue, STI);

--- a/llvm/lib/Target/AMDGPU/SIDefines.h
+++ b/llvm/lib/Target/AMDGPU/SIDefines.h
@@ -10,7 +10,9 @@
 #ifndef LLVM_LIB_TARGET_AMDGPU_SIDEFINES_H
 #define LLVM_LIB_TARGET_AMDGPU_SIDEFINES_H
 
+#include "llvm/MC/MCInst.h"
 #include "llvm/MC/MCInstrDesc.h"
+#include "llvm/MC/MCInstrInfo.h"
 #include "llvm/Support/AMDGPUAddrSpace.h"
 
 namespace llvm {
@@ -53,6 +55,9 @@ enum {
 }
 
 namespace SIInstrFlags {
+// Add namespace to trigger a compile error if these are used raw anywhere
+// outside predicates below.
+namespace DontUseRawFlags {
 // This needs to be kept in sync with the field bits in InstSI.
 enum : uint64_t {
   // Low bits - basic encoding information.
@@ -181,6 +186,237 @@ enum : uint64_t {
   // Is a SWMMAC instruction.
   IsSWMMAC = UINT64_C(1) << 63,
 };
+} // namespace DontUseRawFlags
+
+// Inline predicates for TSFlags — the single place where raw TSFlags bit
+// tests are written. All callers (SIInstrInfo methods, MC-level code) go
+// through these functions to make bit layout changes easier.
+//
+// getTSFlags is a shim to allow extracting the TSFlags value from different
+// types of objects (MCInstrDesc, MCInstrInfo + opcode, or MCInstrInfo + MCInst)
+// without ambiguity. SIInstrInfo.h adds a MachineInstr overload in namespace
+// llvm (found via ADL when predicates are instantiated with MachineInstr).
+
+inline uint64_t getTSFlags(const MCInstrDesc &Desc) { return Desc.TSFlags; }
+inline uint64_t getTSFlags(const MCInstrInfo &MII, unsigned Opcode) {
+  return MII.get(Opcode).TSFlags;
+}
+inline uint64_t getTSFlags(const MCInstrInfo &MII, const MCInst &MI) {
+  return getTSFlags(MII, MI.getOpcode());
+}
+
+// Individual-format predicates.
+template <typename... T> inline bool isSALU(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::SALU;
+}
+template <typename... T> inline bool isVALU(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::VALU;
+}
+template <typename... T> inline bool isSOP1(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::SOP1;
+}
+template <typename... T> inline bool isSOP2(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::SOP2;
+}
+template <typename... T> inline bool isSOPC(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::SOPC;
+}
+template <typename... T> inline bool isSOPK(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::SOPK;
+}
+template <typename... T> inline bool isSOPP(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::SOPP;
+}
+template <typename... T> inline bool isVOP1(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::VOP1;
+}
+template <typename... T> inline bool isVOP2(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::VOP2;
+}
+template <typename... T> inline bool isVOPC(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::VOPC;
+}
+template <typename... T> inline bool isVOP3(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::VOP3;
+}
+template <typename... T> inline bool isVOP3P(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::VOP3P;
+}
+template <typename... T> inline bool isVINTRP(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::VINTRP;
+}
+template <typename... T> inline bool isSDWA(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::SDWA;
+}
+template <typename... T> inline bool isDPP(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::DPP;
+}
+template <typename... T> inline bool isTRANS(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::TRANS;
+}
+template <typename... T> inline bool isMUBUF(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::MUBUF;
+}
+template <typename... T> inline bool isMTBUF(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::MTBUF;
+}
+template <typename... T> inline bool isSMRD(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::SMRD;
+}
+template <typename... T> inline bool isMIMG(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::MIMG;
+}
+template <typename... T> inline bool isVIMAGE(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::VIMAGE;
+}
+template <typename... T> inline bool isVSAMPLE(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::VSAMPLE;
+}
+template <typename... T> inline bool isEXP(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::EXP;
+}
+template <typename... T> inline bool isFLAT(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::FLAT;
+}
+template <typename... T> inline bool isDS(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::DS;
+}
+template <typename... T> inline bool isGWS(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::GWS;
+}
+template <typename... T> inline bool isSpill(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::Spill;
+}
+template <typename... T> inline bool isLDSDIR(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::LDSDIR;
+}
+template <typename... T> inline bool isVINTERP(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::VINTERP;
+}
+template <typename... T> inline bool isVOPD3(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::VOPD3;
+}
+template <typename... T> inline bool isWQM(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::WQM;
+}
+template <typename... T> inline bool isDisableWQM(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::DisableWQM;
+}
+template <typename... T> inline bool isGather4(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::Gather4;
+}
+template <typename... T> inline bool isScalarStore(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::SCALAR_STORE;
+}
+template <typename... T> inline bool isFixedSize(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::FIXED_SIZE;
+}
+template <typename... T> inline bool isPacked(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::IsPacked;
+}
+template <typename... T> inline bool isFlatGlobal(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::FlatGlobal;
+}
+template <typename... T> inline bool isFlatScratch(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::FlatScratch;
+}
+template <typename... T> inline bool usesFPDPRounding(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::FPDPRounding;
+}
+template <typename... T> inline bool isFPAtomic(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::FPAtomic;
+}
+template <typename... T> inline bool isMAI(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::IsMAI;
+}
+template <typename... T> inline bool isDOT(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::IsDOT;
+}
+template <typename... T> inline bool isAtomicNoRet(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::IsAtomicNoRet;
+}
+template <typename... T> inline bool isAtomicRet(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::IsAtomicRet;
+}
+template <typename... T> inline bool isWMMA(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::IsWMMA;
+}
+template <typename... T> inline bool isSWMMAC(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::IsSWMMAC;
+}
+template <typename... T> inline bool isNeverUniform(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::IsNeverUniform;
+}
+template <typename... T> inline bool hasFPClamp(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::FPClamp;
+}
+template <typename... T> inline bool hasIntClamp(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::IntClamp;
+}
+template <typename... T> inline bool usesVM_CNT(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::VM_CNT;
+}
+template <typename... T> inline bool usesLGKM_CNT(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::LGKM_CNT;
+}
+template <typename... T> inline bool usesEXP_CNT(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::EXP_CNT;
+}
+template <typename... T> inline bool usesASYNC_CNT(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::ASYNC_CNT;
+}
+template <typename... T> inline bool usesTENSOR_CNT(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::TENSOR_CNT;
+}
+template <typename... T> inline bool isMaybeAtomic(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::maybeAtomic;
+}
+template <typename... T> inline bool isD16Buf(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::D16Buf;
+}
+template <typename... T> inline bool hasVOP3OpSel(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::VOP3_OPSEL;
+}
+template <typename... T> inline bool hasClampLo(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::ClampLo;
+}
+template <typename... T> inline bool hasClampHi(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::ClampHi;
+}
+template <typename... T> inline bool isTiedSourceNotRead(const T &...O) {
+  return getTSFlags(O...) & DontUseRawFlags::TiedSourceNotRead;
+}
+
+// Compound predicates — named by semantic meaning.
+template <typename... T> inline bool isAtomic(const T &...O) {
+  return isAtomicNoRet(O...) || isAtomicRet(O...);
+}
+
+// Any image-family instruction: pre-gfx11 MIMG, gfx11+ VIMAGE or VSAMPLE.
+// MIMG, VIMAGE and VSAMPLE are mutually exclusive bits.
+template <typename... T> inline bool isImage(const T &...O) {
+  return isMIMG(O...) || isVIMAGE(O...) || isVSAMPLE(O...);
+}
+
+// Any MUBUF or MTBUF buffer instruction.
+template <typename... T> inline bool isBuffer(const T &...O) {
+  return isMUBUF(O...) || isMTBUF(O...);
+}
+
+// Any 3-operand VALU encoding: VOP3 or VOP3P.
+template <typename... T> inline bool isVOP3Like(const T &...O) {
+  return isVOP3(O...) || isVOP3P(O...);
+}
+
+// Vector memory instruction: buffer + image + flat.
+template <typename... T> inline bool isVMEM(const T &...O) {
+  return isBuffer(O...) || isImage(O...) || isFLAT(O...);
+}
+
+// FLAT instruction accessing a specific segment (global_* or scratch_*).
+template <typename... T> inline bool isSegmentSpecificFLAT(const T &...O) {
+  return isFlatGlobal(O...) || isFlatScratch(O...);
+}
 
 // v_cmp_class_* etc. use a 10-bit mask for what operation is checked.
 // The result is true if any of these tests are true.

--- a/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
@@ -450,11 +450,10 @@ FunctionPass *llvm::createSIFoldOperandsLegacyPass() {
 bool SIFoldOperandsImpl::canUseImmWithOpSel(const MachineInstr *MI,
                                             unsigned UseOpNo,
                                             int64_t ImmVal) const {
-  const uint64_t TSFlags = MI->getDesc().TSFlags;
 
-  if (!(TSFlags & SIInstrFlags::IsPacked) || (TSFlags & SIInstrFlags::IsMAI) ||
-      (TSFlags & SIInstrFlags::IsWMMA) || (TSFlags & SIInstrFlags::IsSWMMAC) ||
-      (ST->hasDOTOpSelHazard() && (TSFlags & SIInstrFlags::IsDOT)))
+  if (!SIInstrFlags::isPacked(*MI) || SIInstrFlags::isMAI(*MI) ||
+      SIInstrFlags::isWMMA(*MI) || SIInstrFlags::isSWMMAC(*MI) ||
+      (ST->hasDOTOpSelHazard() && SIInstrFlags::isDOT(*MI)))
     return false;
 
   const MachineOperand &Old = MI->getOperand(UseOpNo);
@@ -474,7 +473,7 @@ bool SIFoldOperandsImpl::canUseImmWithOpSel(const MachineInstr *MI,
   case AMDGPU::OPERAND_REG_INLINE_C_V2INT16:
     // VOP3 packed instructions ignore op_sel source modifiers, we cannot encode
     // two different constants.
-    if ((TSFlags & SIInstrFlags::VOP3) && !(TSFlags & SIInstrFlags::VOP3P) &&
+    if (SIInstrFlags::isVOP3(*MI) && !SIInstrFlags::isVOP3P(*MI) &&
         static_cast<uint16_t>(ImmVal) != static_cast<uint16_t>(ImmVal >> 16))
       return false;
     break;

--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -3490,8 +3490,8 @@ bool SIInsertWaitcnts::removeRedundantSoftXcnts(MachineBasicBlock &Block) {
     if (!IsLDS && (MI.mayLoad() ^ MI.mayStore()))
       LastAtomicWithSoftXcnt = nullptr;
 
-    bool IsAtomicRMW = (MI.getDesc().TSFlags & SIInstrFlags::maybeAtomic) &&
-                       MI.mayLoad() && MI.mayStore();
+    bool IsAtomicRMW =
+        SIInstrFlags::isMaybeAtomic(MI) && MI.mayLoad() && MI.mayStore();
     MachineInstr &PrevMI = *MI.getPrevNode();
     // This is an atomic with a soft xcnt.
     if (PrevMI.getOpcode() == AMDGPU::S_WAIT_XCNT_soft && IsAtomicRMW) {

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -10574,10 +10574,10 @@ int SIInstrInfo::pseudoToMCOpcode(int Opcode) const {
   // Adjust the encoding family to GFX80 for D16 buffer instructions when the
   // subtarget has UnpackedD16VMem feature.
   // TODO: remove this when we discard GFX80 encoding.
-  if (ST.hasUnpackedD16VMem() && (get(Opcode).TSFlags & SIInstrFlags::D16Buf))
+  if (ST.hasUnpackedD16VMem() && SIInstrFlags::isD16Buf(get(Opcode)))
     Gen = SIEncodingFamily::GFX80;
 
-  if (get(Opcode).TSFlags & SIInstrFlags::SDWA) {
+  if (SIInstrFlags::isSDWA(get(Opcode))) {
     switch (ST.getGeneration()) {
     default:
       Gen = SIEncodingFamily::SDWA;

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -98,6 +98,12 @@ private:
   SetVector<MachineInstr *> DeferredList;
 };
 
+// In namespace llvm so ADL finds it when SIInstrFlags predicates are
+// instantiated with MachineInstr (MachineInstr is in namespace llvm).
+inline uint64_t getTSFlags(const MachineInstr &MI) {
+  return MI.getDesc().TSFlags;
+}
+
 class SIInstrInfo final : public AMDGPUGenInstrInfo {
   struct ThreeAddressUpdates;
 
@@ -484,19 +490,19 @@ public:
                             const MachineFunction &MF) const override;
 
   static bool isSALU(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::SALU;
+    return SIInstrFlags::isSALU(MI.getDesc());
   }
 
   bool isSALU(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::SALU;
+    return SIInstrFlags::isSALU(get(Opcode));
   }
 
   static bool isVALU(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::VALU;
+    return SIInstrFlags::isVALU(MI.getDesc());
   }
 
   bool isVALU(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::VALU;
+    return SIInstrFlags::isVALU(get(Opcode));
   }
 
   static bool isImage(const MachineInstr &MI) {
@@ -520,71 +526,71 @@ public:
   static bool isXcntDrain(const MachineInstr &MI);
 
   static bool isSOP1(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::SOP1;
+    return SIInstrFlags::isSOP1(MI.getDesc());
   }
 
   bool isSOP1(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::SOP1;
+    return SIInstrFlags::isSOP1(get(Opcode));
   }
 
   static bool isSOP2(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::SOP2;
+    return SIInstrFlags::isSOP2(MI.getDesc());
   }
 
   bool isSOP2(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::SOP2;
+    return SIInstrFlags::isSOP2(get(Opcode));
   }
 
   static bool isSOPC(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::SOPC;
+    return SIInstrFlags::isSOPC(MI.getDesc());
   }
 
   bool isSOPC(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::SOPC;
+    return SIInstrFlags::isSOPC(get(Opcode));
   }
 
   static bool isSOPK(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::SOPK;
+    return SIInstrFlags::isSOPK(MI.getDesc());
   }
 
   bool isSOPK(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::SOPK;
+    return SIInstrFlags::isSOPK(get(Opcode));
   }
 
   static bool isSOPP(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::SOPP;
+    return SIInstrFlags::isSOPP(MI.getDesc());
   }
 
   bool isSOPP(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::SOPP;
+    return SIInstrFlags::isSOPP(get(Opcode));
   }
 
   static bool isPacked(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::IsPacked;
+    return SIInstrFlags::isPacked(MI.getDesc());
   }
 
   bool isPacked(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::IsPacked;
+    return SIInstrFlags::isPacked(get(Opcode));
   }
 
   static bool isVOP1(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::VOP1;
+    return SIInstrFlags::isVOP1(MI.getDesc());
   }
 
   bool isVOP1(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::VOP1;
+    return SIInstrFlags::isVOP1(get(Opcode));
   }
 
   static bool isVOP2(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::VOP2;
+    return SIInstrFlags::isVOP2(MI.getDesc());
   }
 
   bool isVOP2(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::VOP2;
+    return SIInstrFlags::isVOP2(get(Opcode));
   }
 
   static bool isVOP3(const MCInstrDesc &Desc) {
-    return Desc.TSFlags & SIInstrFlags::VOP3;
+    return SIInstrFlags::isVOP3(Desc);
   }
 
   static bool isVOP3(const MachineInstr &MI) { return isVOP3(MI.getDesc()); }
@@ -592,35 +598,35 @@ public:
   bool isVOP3(uint32_t Opcode) const { return isVOP3(get(Opcode)); }
 
   static bool isSDWA(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::SDWA;
+    return SIInstrFlags::isSDWA(MI.getDesc());
   }
 
   bool isSDWA(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::SDWA;
+    return SIInstrFlags::isSDWA(get(Opcode));
   }
 
   static bool isVOPC(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::VOPC;
+    return SIInstrFlags::isVOPC(MI.getDesc());
   }
 
   bool isVOPC(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::VOPC;
+    return SIInstrFlags::isVOPC(get(Opcode));
   }
 
   static bool isMUBUF(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::MUBUF;
+    return SIInstrFlags::isMUBUF(MI.getDesc());
   }
 
   bool isMUBUF(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::MUBUF;
+    return SIInstrFlags::isMUBUF(get(Opcode));
   }
 
   static bool isMTBUF(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::MTBUF;
+    return SIInstrFlags::isMTBUF(MI.getDesc());
   }
 
   bool isMTBUF(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::MTBUF;
+    return SIInstrFlags::isMTBUF(get(Opcode));
   }
 
   static bool isBUF(const MachineInstr &MI) {
@@ -628,110 +634,104 @@ public:
   }
 
   static bool isSMRD(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::SMRD;
+    return SIInstrFlags::isSMRD(MI.getDesc());
   }
 
   bool isSMRD(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::SMRD;
+    return SIInstrFlags::isSMRD(get(Opcode));
   }
 
   bool isBufferSMRD(const MachineInstr &MI) const;
 
   static bool isDS(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::DS;
+    return SIInstrFlags::isDS(MI.getDesc());
   }
 
-  bool isDS(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::DS;
-  }
+  bool isDS(uint32_t Opcode) const { return SIInstrFlags::isDS(get(Opcode)); }
 
   static bool isLDSDMA(const MachineInstr &MI) {
     return (isVALU(MI) && (isMUBUF(MI) || isFLAT(MI))) ||
-           (MI.getDesc().TSFlags & SIInstrFlags::TENSOR_CNT);
+           (SIInstrFlags::usesTENSOR_CNT(MI.getDesc()));
   }
 
   bool isLDSDMA(uint32_t Opcode) {
     return (isVALU(Opcode) && (isMUBUF(Opcode) || isFLAT(Opcode))) ||
-           (get(Opcode).TSFlags & SIInstrFlags::TENSOR_CNT);
+           (SIInstrFlags::usesTENSOR_CNT(get(Opcode)));
   }
 
   static bool isGWS(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::GWS;
+    return SIInstrFlags::isGWS(MI.getDesc());
   }
 
-  bool isGWS(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::GWS;
-  }
+  bool isGWS(uint32_t Opcode) const { return SIInstrFlags::isGWS(get(Opcode)); }
 
   bool isAlwaysGDS(uint32_t Opcode) const;
 
   static bool isMIMG(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::MIMG;
+    return SIInstrFlags::isMIMG(MI.getDesc());
   }
 
   bool isMIMG(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::MIMG;
+    return SIInstrFlags::isMIMG(get(Opcode));
   }
 
   static bool isVIMAGE(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::VIMAGE;
+    return SIInstrFlags::isVIMAGE(MI.getDesc());
   }
 
   bool isVIMAGE(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::VIMAGE;
+    return SIInstrFlags::isVIMAGE(get(Opcode));
   }
 
   static bool isVSAMPLE(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::VSAMPLE;
+    return SIInstrFlags::isVSAMPLE(MI.getDesc());
   }
 
   bool isVSAMPLE(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::VSAMPLE;
+    return SIInstrFlags::isVSAMPLE(get(Opcode));
   }
 
   static bool isGather4(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::Gather4;
+    return SIInstrFlags::isGather4(MI.getDesc());
   }
 
   bool isGather4(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::Gather4;
+    return SIInstrFlags::isGather4(get(Opcode));
   }
 
   static bool isFLAT(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::FLAT;
+    return SIInstrFlags::isFLAT(MI.getDesc());
   }
 
   // Is a FLAT encoded instruction which accesses a specific segment,
   // i.e. global_* or scratch_*.
   static bool isSegmentSpecificFLAT(const MachineInstr &MI) {
-    auto Flags = MI.getDesc().TSFlags;
-    return Flags & (SIInstrFlags::FlatGlobal | SIInstrFlags::FlatScratch);
+    return SIInstrFlags::isSegmentSpecificFLAT(MI.getDesc());
   }
 
   bool isSegmentSpecificFLAT(uint32_t Opcode) const {
-    auto Flags = get(Opcode).TSFlags;
-    return Flags & (SIInstrFlags::FlatGlobal | SIInstrFlags::FlatScratch);
+    return SIInstrFlags::isSegmentSpecificFLAT(get(Opcode));
   }
 
   static bool isFLATGlobal(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::FlatGlobal;
+    return SIInstrFlags::isFlatGlobal(MI.getDesc());
   }
 
   bool isFLATGlobal(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::FlatGlobal;
+    return SIInstrFlags::isFlatGlobal(get(Opcode));
   }
 
   static bool isFLATScratch(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::FlatScratch;
+    return SIInstrFlags::isFlatScratch(MI.getDesc());
   }
 
   bool isFLATScratch(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::FlatScratch;
+    return SIInstrFlags::isFlatScratch(get(Opcode));
   }
 
   // Any FLAT encoded instruction, including global_* and scratch_*.
   bool isFLAT(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::FLAT;
+    return SIInstrFlags::isFLAT(get(Opcode));
   }
 
   /// \returns true for SCRATCH_ instructions, or FLAT/BUF instructions unless
@@ -808,7 +808,7 @@ public:
   }
 
   static bool isEXP(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::EXP;
+    return SIInstrFlags::isEXP(MI.getDesc());
   }
 
   static bool isDualSourceBlendEXP(const MachineInstr &MI) {
@@ -819,34 +819,30 @@ public:
            Target == AMDGPU::Exp::ET_DUAL_SRC_BLEND1;
   }
 
-  bool isEXP(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::EXP;
-  }
+  bool isEXP(uint32_t Opcode) const { return SIInstrFlags::isEXP(get(Opcode)); }
 
   static bool isAtomicNoRet(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::IsAtomicNoRet;
+    return SIInstrFlags::isAtomicNoRet(MI.getDesc());
   }
 
   bool isAtomicNoRet(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::IsAtomicNoRet;
+    return SIInstrFlags::isAtomicNoRet(get(Opcode));
   }
 
   static bool isAtomicRet(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::IsAtomicRet;
+    return SIInstrFlags::isAtomicRet(MI.getDesc());
   }
 
   bool isAtomicRet(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::IsAtomicRet;
+    return SIInstrFlags::isAtomicRet(get(Opcode));
   }
 
   static bool isAtomic(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & (SIInstrFlags::IsAtomicRet |
-                                   SIInstrFlags::IsAtomicNoRet);
+    return SIInstrFlags::isAtomic(MI.getDesc());
   }
 
   bool isAtomic(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & (SIInstrFlags::IsAtomicRet |
-                                  SIInstrFlags::IsAtomicNoRet);
+    return SIInstrFlags::isAtomic(get(Opcode));
   }
 
   static bool mayWriteLDSThroughDMA(const MachineInstr &MI) {
@@ -870,19 +866,17 @@ public:
   }
 
   static bool isWQM(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::WQM;
+    return SIInstrFlags::isWQM(MI.getDesc());
   }
 
-  bool isWQM(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::WQM;
-  }
+  bool isWQM(uint32_t Opcode) const { return SIInstrFlags::isWQM(get(Opcode)); }
 
   static bool isDisableWQM(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::DisableWQM;
+    return SIInstrFlags::isDisableWQM(MI.getDesc());
   }
 
   bool isDisableWQM(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::DisableWQM;
+    return SIInstrFlags::isDisableWQM(get(Opcode));
   }
 
   // SI_SPILL_S32_TO_VGPR and SI_RESTORE_S32_FROM_VGPR form a special case of
@@ -915,11 +909,11 @@ public:
   }
 
   bool isSpill(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::Spill;
+    return SIInstrFlags::isSpill(get(Opcode));
   }
 
   static bool isSpill(const MCInstrDesc &Desc) {
-    return Desc.TSFlags & SIInstrFlags::Spill;
+    return SIInstrFlags::isSpill(Desc);
   }
 
   static bool isSpill(const MachineInstr &MI) { return isSpill(MI.getDesc()); }
@@ -937,27 +931,25 @@ public:
   }
 
   static bool isDPP(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::DPP;
+    return SIInstrFlags::isDPP(MI.getDesc());
   }
 
-  bool isDPP(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::DPP;
-  }
+  bool isDPP(uint32_t Opcode) const { return SIInstrFlags::isDPP(get(Opcode)); }
 
   static bool isTRANS(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::TRANS;
+    return SIInstrFlags::isTRANS(MI.getDesc());
   }
 
   bool isTRANS(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::TRANS;
+    return SIInstrFlags::isTRANS(get(Opcode));
   }
 
   static bool isVOP3P(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::VOP3P;
+    return SIInstrFlags::isVOP3P(MI.getDesc());
   }
 
   bool isVOP3P(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::VOP3P;
+    return SIInstrFlags::isVOP3P(get(Opcode));
   }
 
   bool isVOP3PMix(const MachineInstr &MI) const {
@@ -979,15 +971,15 @@ public:
   }
 
   static bool isVINTRP(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::VINTRP;
+    return SIInstrFlags::isVINTRP(MI.getDesc());
   }
 
   bool isVINTRP(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::VINTRP;
+    return SIInstrFlags::isVINTRP(get(Opcode));
   }
 
   static bool isMAI(const MCInstrDesc &Desc) {
-    return Desc.TSFlags & SIInstrFlags::IsMAI;
+    return SIInstrFlags::isMAI(Desc);
   }
 
   static bool isMAI(const MachineInstr &MI) { return isMAI(MI.getDesc()); }
@@ -1005,15 +997,15 @@ public:
   }
 
   static bool isDOT(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::IsDOT;
+    return SIInstrFlags::isDOT(MI.getDesc());
   }
 
   static bool isWMMA(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::IsWMMA;
+    return SIInstrFlags::isWMMA(MI.getDesc());
   }
 
   bool isWMMA(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::IsWMMA;
+    return SIInstrFlags::isWMMA(get(Opcode));
   }
 
   static bool isMFMAorWMMA(const MachineInstr &MI) {
@@ -1025,16 +1017,14 @@ public:
   }
 
   static bool isSWMMAC(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::IsSWMMAC;
+    return SIInstrFlags::isSWMMAC(MI.getDesc());
   }
 
   bool isSWMMAC(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::IsSWMMAC;
+    return SIInstrFlags::isSWMMAC(get(Opcode));
   }
 
-  bool isDOT(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::IsDOT;
-  }
+  bool isDOT(uint32_t Opcode) const { return SIInstrFlags::isDOT(get(Opcode)); }
 
   bool isXDLWMMA(const MachineInstr &MI) const;
 
@@ -1043,39 +1033,40 @@ public:
   static bool isDGEMM(unsigned Opcode) { return AMDGPU::getMAIIsDGEMM(Opcode); }
 
   static bool isLDSDIR(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::LDSDIR;
+    return SIInstrFlags::isLDSDIR(MI.getDesc());
   }
 
   bool isLDSDIR(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::LDSDIR;
+    return SIInstrFlags::isLDSDIR(get(Opcode));
   }
 
   static bool isVINTERP(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::VINTERP;
+    return SIInstrFlags::isVINTERP(MI.getDesc());
   }
 
   bool isVINTERP(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::VINTERP;
+    return SIInstrFlags::isVINTERP(get(Opcode));
   }
 
   static bool isScalarUnit(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & (SIInstrFlags::SALU | SIInstrFlags::SMRD);
+    return SIInstrFlags::isSALU(MI.getDesc()) ||
+           SIInstrFlags::isSMRD(MI.getDesc());
   }
 
   static bool usesVM_CNT(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::VM_CNT;
+    return SIInstrFlags::usesVM_CNT(MI.getDesc());
   }
 
   static bool usesLGKM_CNT(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::LGKM_CNT;
+    return SIInstrFlags::usesLGKM_CNT(MI.getDesc());
   }
 
   static bool usesASYNC_CNT(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::ASYNC_CNT;
+    return SIInstrFlags::usesASYNC_CNT(MI.getDesc());
   }
 
   bool usesASYNC_CNT(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::ASYNC_CNT;
+    return SIInstrFlags::usesASYNC_CNT(get(Opcode));
   }
 
   // Most sopk treat the immediate as a signed 16-bit, however some
@@ -1091,57 +1082,59 @@ public:
   /// \returns true if this is an s_store_dword* instruction. This is more
   /// specific than isSMEM && mayStore.
   static bool isScalarStore(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::SCALAR_STORE;
+    return SIInstrFlags::isScalarStore(MI.getDesc());
   }
 
   bool isScalarStore(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::SCALAR_STORE;
+    return SIInstrFlags::isScalarStore(get(Opcode));
   }
 
   static bool isFixedSize(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::FIXED_SIZE;
+    return SIInstrFlags::isFixedSize(MI.getDesc());
   }
 
   bool isFixedSize(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::FIXED_SIZE;
+    return SIInstrFlags::isFixedSize(get(Opcode));
   }
 
   static bool hasFPClamp(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::FPClamp;
+    return SIInstrFlags::hasFPClamp(MI.getDesc());
   }
 
   bool hasFPClamp(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::FPClamp;
+    return SIInstrFlags::hasFPClamp(get(Opcode));
   }
 
   static bool hasIntClamp(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::IntClamp;
+    return SIInstrFlags::hasIntClamp(MI.getDesc());
   }
 
   static bool hasSameClamp(const MachineInstr &A, const MachineInstr &B) {
-    const uint64_t Mask = SIInstrFlags::FPClamp | SIInstrFlags::IntClamp |
-                          SIInstrFlags::ClampLo | SIInstrFlags::ClampHi;
-    return (A.getDesc().TSFlags & Mask) == (B.getDesc().TSFlags & Mask);
+    const MCInstrDesc &DA = A.getDesc(), &DB = B.getDesc();
+    return SIInstrFlags::hasFPClamp(DA) == SIInstrFlags::hasFPClamp(DB) &&
+           SIInstrFlags::hasIntClamp(DA) == SIInstrFlags::hasIntClamp(DB) &&
+           SIInstrFlags::hasClampLo(DA) == SIInstrFlags::hasClampLo(DB) &&
+           SIInstrFlags::hasClampHi(DA) == SIInstrFlags::hasClampHi(DB);
   }
 
   static bool usesFPDPRounding(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::FPDPRounding;
+    return SIInstrFlags::usesFPDPRounding(MI.getDesc());
   }
 
   bool usesFPDPRounding(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::FPDPRounding;
+    return SIInstrFlags::usesFPDPRounding(get(Opcode));
   }
 
   static bool isFPAtomic(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::FPAtomic;
+    return SIInstrFlags::isFPAtomic(MI.getDesc());
   }
 
   bool isFPAtomic(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::FPAtomic;
+    return SIInstrFlags::isFPAtomic(get(Opcode));
   }
 
   static bool isNeverUniform(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::IsNeverUniform;
+    return SIInstrFlags::isNeverUniform(MI.getDesc());
   }
 
   // Check to see if opcode is for a barrier start. Pre gfx12 this is just the
@@ -1178,11 +1171,11 @@ public:
   }
 
   static bool doesNotReadTiedSource(const MachineInstr &MI) {
-    return MI.getDesc().TSFlags & SIInstrFlags::TiedSourceNotRead;
+    return SIInstrFlags::isTiedSourceNotRead(MI.getDesc());
   }
 
   bool doesNotReadTiedSource(uint32_t Opcode) const {
-    return get(Opcode).TSFlags & SIInstrFlags::TiedSourceNotRead;
+    return SIInstrFlags::isTiedSourceNotRead(get(Opcode));
   }
 
   bool isIGLP(unsigned Opcode) const {

--- a/llvm/lib/Target/AMDGPU/SIMemoryLegalizer.cpp
+++ b/llvm/lib/Target/AMDGPU/SIMemoryLegalizer.cpp
@@ -880,7 +880,7 @@ std::optional<SIMemOpInfo> SIMemOpAccess::constructFromMIWithMMO(
 
 std::optional<SIMemOpInfo>
 SIMemOpAccess::getLoadInfo(const MachineBasicBlock::iterator &MI) const {
-  assert(MI->getDesc().TSFlags & SIInstrFlags::maybeAtomic);
+  assert(SIInstrFlags::isMaybeAtomic(*MI));
 
   if (!(MI->mayLoad() && !MI->mayStore()))
     return std::nullopt;
@@ -894,7 +894,7 @@ SIMemOpAccess::getLoadInfo(const MachineBasicBlock::iterator &MI) const {
 
 std::optional<SIMemOpInfo>
 SIMemOpAccess::getStoreInfo(const MachineBasicBlock::iterator &MI) const {
-  assert(MI->getDesc().TSFlags & SIInstrFlags::maybeAtomic);
+  assert(SIInstrFlags::isMaybeAtomic(*MI));
 
   if (!(!MI->mayLoad() && MI->mayStore()))
     return std::nullopt;
@@ -908,7 +908,7 @@ SIMemOpAccess::getStoreInfo(const MachineBasicBlock::iterator &MI) const {
 
 std::optional<SIMemOpInfo>
 SIMemOpAccess::getAtomicFenceInfo(const MachineBasicBlock::iterator &MI) const {
-  assert(MI->getDesc().TSFlags & SIInstrFlags::maybeAtomic);
+  assert(SIInstrFlags::isMaybeAtomic(*MI));
 
   if (MI->getOpcode() != AMDGPU::ATOMIC_FENCE)
     return std::nullopt;
@@ -950,7 +950,7 @@ SIMemOpAccess::getAtomicFenceInfo(const MachineBasicBlock::iterator &MI) const {
 
 std::optional<SIMemOpInfo> SIMemOpAccess::getAtomicCmpxchgOrRmwInfo(
     const MachineBasicBlock::iterator &MI) const {
-  assert(MI->getDesc().TSFlags & SIInstrFlags::maybeAtomic);
+  assert(SIInstrFlags::isMaybeAtomic(*MI));
 
   if (!(MI->mayLoad() && MI->mayStore()))
     return std::nullopt;
@@ -964,7 +964,7 @@ std::optional<SIMemOpInfo> SIMemOpAccess::getAtomicCmpxchgOrRmwInfo(
 
 std::optional<SIMemOpInfo>
 SIMemOpAccess::getLDSDMAInfo(const MachineBasicBlock::iterator &MI) const {
-  assert(MI->getDesc().TSFlags & SIInstrFlags::maybeAtomic);
+  assert(SIInstrFlags::isMaybeAtomic(*MI));
 
   if (!SIInstrInfo::isLDSDMA(*MI))
     return std::nullopt;
@@ -2560,7 +2560,7 @@ bool SIMemoryLegalizer::run(MachineFunction &MF) {
         MI = MI->eraseFromParent();
       }
 
-      if (MI->getDesc().TSFlags & SIInstrFlags::maybeAtomic) {
+      if (SIInstrFlags::isMaybeAtomic(*MI)) {
         if (const auto &MOI = MOA.getLoadInfo(MI))
           Changed |= expandLoad(*MOI, MI);
         else if (const auto &MOI = MOA.getStoreInfo(MI))

--- a/llvm/lib/Target/AMDGPU/SIPostRABundler.cpp
+++ b/llvm/lib/Target/AMDGPU/SIPostRABundler.cpp
@@ -60,11 +60,6 @@ private:
   bool canBundle(const MachineInstr &MI, const MachineInstr &NextMI) const;
 };
 
-constexpr uint64_t MemFlags = SIInstrFlags::MTBUF | SIInstrFlags::MUBUF |
-                              SIInstrFlags::SMRD | SIInstrFlags::DS |
-                              SIInstrFlags::FLAT | SIInstrFlags::MIMG |
-                              SIInstrFlags::VIMAGE | SIInstrFlags::VSAMPLE;
-
 } // End anonymous namespace.
 
 INITIALIZE_PASS(SIPostRABundlerLegacy, DEBUG_TYPE, "SI post-RA bundler", false,
@@ -112,19 +107,34 @@ void SIPostRABundler::collectUsedRegUnits(const MachineInstr &MI,
   }
 }
 
+static bool isMemoryInst(const MachineInstr &MI) {
+  return SIInstrFlags::isMUBUF(MI) || SIInstrFlags::isMTBUF(MI) ||
+         SIInstrFlags::isSMRD(MI) || SIInstrFlags::isDS(MI) ||
+         SIInstrFlags::isFLAT(MI) || SIInstrFlags::isMIMG(MI) ||
+         SIInstrFlags::isVIMAGE(MI) || SIInstrFlags::isVSAMPLE(MI);
+}
+
+static bool hasSameMemFormat(const MachineInstr &A, const MachineInstr &B) {
+  return SIInstrFlags::isMUBUF(A) == SIInstrFlags::isMUBUF(B) &&
+         SIInstrFlags::isMTBUF(A) == SIInstrFlags::isMTBUF(B) &&
+         SIInstrFlags::isSMRD(A) == SIInstrFlags::isSMRD(B) &&
+         SIInstrFlags::isDS(A) == SIInstrFlags::isDS(B) &&
+         SIInstrFlags::isFLAT(A) == SIInstrFlags::isFLAT(B) &&
+         SIInstrFlags::isMIMG(A) == SIInstrFlags::isMIMG(B) &&
+         SIInstrFlags::isVIMAGE(A) == SIInstrFlags::isVIMAGE(B) &&
+         SIInstrFlags::isVSAMPLE(A) == SIInstrFlags::isVSAMPLE(B);
+}
+
 bool SIPostRABundler::isBundleCandidate(const MachineInstr &MI) const {
-  const uint64_t IMemFlags = MI.getDesc().TSFlags & MemFlags;
-  return IMemFlags != 0 && MI.mayLoadOrStore() && !MI.isBundled();
+  return isMemoryInst(MI) && MI.mayLoadOrStore() && !MI.isBundled();
 }
 
 bool SIPostRABundler::canBundle(const MachineInstr &MI,
                                 const MachineInstr &NextMI) const {
-  const uint64_t IMemFlags = MI.getDesc().TSFlags & MemFlags;
-
-  return (IMemFlags != 0 && MI.mayLoadOrStore() && !NextMI.isBundled() &&
-          NextMI.mayLoad() == MI.mayLoad() && NextMI.mayStore() == MI.mayStore() &&
-          ((NextMI.getDesc().TSFlags & MemFlags) == IMemFlags) &&
-          !isDependentLoad(NextMI));
+  return isMemoryInst(MI) && MI.mayLoadOrStore() && !NextMI.isBundled() &&
+         NextMI.mayLoad() == MI.mayLoad() &&
+         NextMI.mayStore() == MI.mayStore() && hasSameMemFormat(MI, NextMI) &&
+         !isDependentLoad(NextMI);
 }
 
 bool SIPostRABundlerLegacy::runOnMachineFunction(MachineFunction &MF) {

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -804,7 +804,7 @@ bool isTensorStore(unsigned Opc) {
 }
 
 unsigned getTemporalHintType(const MCInstrDesc TID) {
-  if (TID.TSFlags & (SIInstrFlags::IsAtomicNoRet | SIInstrFlags::IsAtomicRet))
+  if (SIInstrFlags::isAtomic(TID))
     return CPol::TH_TYPE_ATOMIC;
   unsigned Opc = TID.getOpcode();
   // Async and Tensor store should have the temporal hint type of TH_TYPE_STORE
@@ -902,7 +902,7 @@ ComponentProps::ComponentProps(const MCInstrDesc &OpDesc, bool VOP3Layout) {
   HasSrc2Acc = TiedIdx != -1;
   Opcode = OpDesc.getOpcode();
 
-  IsVOP3 = VOP3Layout || (OpDesc.TSFlags & SIInstrFlags::VOP3);
+  IsVOP3 = VOP3Layout || SIInstrFlags::isVOP3(OpDesc);
   SrcOperandsNum = AMDGPU::hasNamedOperand(Opcode, AMDGPU::OpName::src2)   ? 3
                    : AMDGPU::hasNamedOperand(Opcode, AMDGPU::OpName::imm)  ? 3
                    : AMDGPU::hasNamedOperand(Opcode, AMDGPU::OpName::src1) ? 2
@@ -925,7 +925,7 @@ ComponentProps::ComponentProps(const MCInstrDesc &OpDesc, bool VOP3Layout) {
       --NumVOPD3Mods;
   }
 
-  if (OpDesc.TSFlags & SIInstrFlags::VOP3)
+  if (SIInstrFlags::isVOP3(OpDesc))
     return;
 
   auto OperandsNum = OpDesc.getNumOperands();
@@ -1060,7 +1060,7 @@ VOPD::InstInfo getVOPDInstInfo(unsigned VOPDOpcode,
   auto [OpX, OpY] = getVOPDComponents(VOPDOpcode);
   const auto &OpXDesc = InstrInfo->get(OpX);
   const auto &OpYDesc = InstrInfo->get(OpY);
-  bool VOPD3 = InstrInfo->get(VOPDOpcode).TSFlags & SIInstrFlags::VOPD3;
+  bool VOPD3 = SIInstrFlags::isVOPD3(*InstrInfo, VOPDOpcode);
   VOPD::ComponentInfo OpXInfo(OpXDesc, VOPD::ComponentKind::COMPONENT_X, VOPD3);
   VOPD::ComponentInfo OpYInfo(OpYDesc, OpXInfo, VOPD3);
   return VOPD::InstInfo(OpXInfo, OpYInfo);
@@ -3659,11 +3659,9 @@ getVGPRLoweringOperandTables(const MCInstrDesc &Desc) {
       AMDGPU::OpName::src0Y, AMDGPU::OpName::NUM_OPERAND_NAMES,
       AMDGPU::OpName::vsrc1Y, AMDGPU::OpName::vdstY};
 
-  unsigned TSFlags = Desc.TSFlags;
-
-  if (TSFlags &
-      (SIInstrFlags::VOP1 | SIInstrFlags::VOP2 | SIInstrFlags::VOP3 |
-       SIInstrFlags::VOP3P | SIInstrFlags::VOPC | SIInstrFlags::DPP)) {
+  if (SIInstrFlags::isVOP1(Desc) || SIInstrFlags::isVOP2(Desc) ||
+      SIInstrFlags::isVOP3Like(Desc) || SIInstrFlags::isVOPC(Desc) ||
+      SIInstrFlags::isDPP(Desc)) {
     switch (Desc.getOpcode()) {
     // LD_SCALE operands ignore MSB.
     case AMDGPU::V_WMMA_LD_SCALE_PAIRED_B32:
@@ -3687,16 +3685,16 @@ getVGPRLoweringOperandTables(const MCInstrDesc &Desc) {
     return {VOPOps, nullptr};
   }
 
-  if (TSFlags & SIInstrFlags::DS)
+  if (SIInstrFlags::isDS(Desc))
     return {VDSOps, nullptr};
 
-  if (TSFlags & SIInstrFlags::FLAT)
+  if (SIInstrFlags::isFLAT(Desc))
     return {FLATOps, nullptr};
 
-  if (TSFlags & (SIInstrFlags::MUBUF | SIInstrFlags::MTBUF))
+  if (SIInstrFlags::isBuffer(Desc))
     return {BUFOps, nullptr};
 
-  if (TSFlags & SIInstrFlags::VIMAGE)
+  if (SIInstrFlags::isVIMAGE(Desc))
     return {VIMGOps, nullptr};
 
   if (AMDGPU::isVOPD(Desc.getOpcode())) {
@@ -3705,9 +3703,9 @@ getVGPRLoweringOperandTables(const MCInstrDesc &Desc) {
             (OpY == AMDGPU::V_FMAMK_F32) ? VOPDFMAMKOpsY : VOPDOpsY};
   }
 
-  assert(!(TSFlags & SIInstrFlags::MIMG));
+  assert(!SIInstrFlags::isMIMG(Desc));
 
-  if (TSFlags & (SIInstrFlags::VSAMPLE | SIInstrFlags::EXP))
+  if (SIInstrFlags::isVSAMPLE(Desc) || SIInstrFlags::isEXP(Desc))
     llvm_unreachable("Sample and export VGPR lowering is not implemented and"
                      " these instructions are not expected on gfx1250");
 
@@ -3715,15 +3713,13 @@ getVGPRLoweringOperandTables(const MCInstrDesc &Desc) {
 }
 
 bool supportsScaleOffset(const MCInstrInfo &MII, unsigned Opcode) {
-  uint64_t TSFlags = MII.get(Opcode).TSFlags;
-
-  if (TSFlags & SIInstrFlags::SMRD)
+  if (SIInstrFlags::isSMRD(MII, Opcode))
     return !getSMEMIsBuffer(Opcode);
-  if (!(TSFlags & SIInstrFlags::FLAT))
+  if (!SIInstrFlags::isFLAT(MII, Opcode))
     return false;
 
   // Only SV and SVS modes are supported.
-  if (TSFlags & SIInstrFlags::FlatScratch)
+  if (SIInstrFlags::isFlatScratch(MII, Opcode))
     return hasNamedOperand(Opcode, OpName::vaddr);
 
   // Only GVS mode is supported.


### PR DESCRIPTION
Add a DontUseRawFlags sub-namespace in SIDefines.h that holds the raw TSFlag bit constants, making accidental direct use outside the predicate layer a compile error.

Add inline predicate templates (isSALU, isVOP3, isFLAT, isMaybeAtomic, ...) as the single point where raw TSFlag bits are tested. Compound predicates (isMemory, isBuffer, isImage, ...) are built from the simple ones, not from raw bits. A getTSFlags() shim dispatches over MCInstrDesc, MCInstrInfo+opcode, MCInstrInfo+MCInst, and MachineInstr (the last via ADL in namespace llvm so no forward declaration is needed in SIDefines.h).

Route all SIInstrInfo wrapper bodies through the new predicates instead of reading TSFlags directly. Replace all remaining raw TSFlag accesses in .cpp files (AsmParser, Disassembler, InstPrinter, CodeEmitter, MCA, CodeGen passes) with predicate calls.

After this change, a future TSFlags layout change only requires updating SIDefines.h — no other file needs to change.