### PR TITLE
[mlir] Fix StridedMemRefRankOf to check isStrided() 

### DIFF
--- a/mlir/include/mlir/IR/CommonTypeConstraints.td
+++ b/mlir/include/mlir/IR/CommonTypeConstraints.td
@@ -930,7 +930,7 @@ class AnyStridedMemRefOfRank<int rank> :
        AnyStridedMemRef.summary # " of rank " # rank>;
 
 class StridedMemRefRankOf<list<Type> allowedTypes, list<int> ranks> :
-    ConfinedType<MemRefOf<allowedTypes>, [HasAnyRankOfPred<ranks>],
+    ConfinedType<MemRefOf<allowedTypes>, [HasAnyRankOfPred<ranks>, HasStridesPred],
          !interleave(!foreach(rank, ranks, rank # "D"), "/") # " " #
          MemRefOf<allowedTypes>.summary>;
 

--- a/mlir/include/mlir/IR/CommonTypeConstraints.td
+++ b/mlir/include/mlir/IR/CommonTypeConstraints.td
@@ -931,7 +931,7 @@ class AnyStridedMemRefOfRank<int rank> :
 
 class StridedMemRefRankOf<list<Type> allowedTypes, list<int> ranks> :
     ConfinedType<MemRefOf<allowedTypes>, [HasAnyRankOfPred<ranks>, HasStridesPred],
-         !interleave(!foreach(rank, ranks, rank # "D"), "/") # " " #
+         !interleave(!foreach(rank, ranks, rank # "D"), "/") # " strided " #
          MemRefOf<allowedTypes>.summary>;
 
 // This represents a generic tuple without any constraints on element type.

--- a/mlir/test/Dialect/SparseTensor/invalid.mlir
+++ b/mlir/test/Dialect/SparseTensor/invalid.mlir
@@ -308,7 +308,7 @@ func.func @sparse_push_back_n(%arg0: index, %arg1: memref<?xf32>, %arg2: f32) ->
 // -----
 
 func.func @sparse_push_back_non_strided(%arg0: index, %arg1: memref<?xf64, affine_map<(d0) -> (d0 mod 2)>>, %arg2: f64) {
-  // expected-error@+1 {{'sparse_tensor.push_back' op operand #1 must be 1D memref of any type values, but got 'memref<?xf64, affine_map<(d0) -> (d0 mod 2)>>'}}
+  // expected-error@+1 {{operand #1 must be 1D strided memref of any non-token type values, but got 'memref<?xf64, affine_map<(d0) -> (d0 mod 2)>>}}
   %0:2 = sparse_tensor.push_back %arg0, %arg1, %arg2 : index, memref<?xf64, affine_map<(d0) -> (d0 mod 2)>>, f64
   return
 }
@@ -851,7 +851,7 @@ func.func @sparse_tensor_foreach(%arg0: tensor<2x4xf64, #DCSR>, %arg1: f32) -> (
 #MAP = affine_map<(i,j) -> (i,j)>
 
 func.func @sparse_sort_coo_x_type( %arg0: index, %arg1: memref<?xf32>) {
-  // expected-error@+1 {{operand #1 must be 1D memref of integer or index values}}
+  // expected-error@+1 {{operand #1 must be 1D strided memref of integer or index values}}
   sparse_tensor.sort insertion_sort_stable %arg0, %arg1 {perm_map = #MAP} : memref<?xf32>
   return
 }

--- a/mlir/test/Dialect/SparseTensor/invalid.mlir
+++ b/mlir/test/Dialect/SparseTensor/invalid.mlir
@@ -307,6 +307,14 @@ func.func @sparse_push_back_n(%arg0: index, %arg1: memref<?xf32>, %arg2: f32) ->
 
 // -----
 
+func.func @sparse_push_back_non_strided(%arg0: index, %arg1: memref<?xf64, affine_map<(d0) -> (d0 mod 2)>>, %arg2: f64) {
+  // expected-error@+1 {{'sparse_tensor.push_back' op operand #1 must be 1D memref of any type values, but got 'memref<?xf64, affine_map<(d0) -> (d0 mod 2)>>'}}
+  %0:2 = sparse_tensor.push_back %arg0, %arg1, %arg2 : index, memref<?xf64, affine_map<(d0) -> (d0 mod 2)>>, f64
+  return
+}
+
+// -----
+
 func.func @sparse_unannotated_expansion(%arg0: tensor<128xf64>) {
   // expected-error@+1 {{'sparse_tensor.expand' op operand #0 must be sparse tensor of any non-token type values, but got 'tensor<128xf64>'}}
   %values, %filled, %added, %count = sparse_tensor.expand %arg0


### PR DESCRIPTION
StridedMemRefRankOf was equivalent to MemRefRankOf: it only applied HasAnyRankOfPred and never HasStridesPred, so non-strided memref layouts (e.g. multi-result affine maps) incorrectly passed ODS verification on ops using this constraint (e.g. sparse_tensor.push_back).

The inBuffer of push_back uses StridedMemRefRankOf, which requires a strided memref layout (HasStridesPred). A non-strided layout must be rejected.