### PR TITLE
[AMDGPU] Fold fneg into select source modifiers

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -5070,13 +5070,19 @@ AMDGPUTargetLowering::foldFreeOpFromSelect(TargetLowering::DAGCombinerInfo &DCI,
   SDValue RHS = N.getOperand(2);
 
   EVT VT = N.getValueType();
-  if ((LHS.getOpcode() == ISD::FABS && RHS.getOpcode() == ISD::FABS) ||
-      (LHS.getOpcode() == ISD::FNEG && RHS.getOpcode() == ISD::FNEG)) {
+  if (LHS.getOpcode() == ISD::FNEG && RHS.getOpcode() == ISD::FNEG) {
+    if (!AMDGPUTargetLowering::allUsesHaveSourceMods(N.getNode(), 0) &&
+        shouldFoldFNegIntoSelect(N, LHS.getOperand(0), RHS.getOperand(0)))
+      return SDValue();
+
+    return distributeOpThroughSelect(DCI, ISD::FNEG, SDLoc(N), Cond, LHS, RHS);
+  }
+
+  if (LHS.getOpcode() == ISD::FABS && RHS.getOpcode() == ISD::FABS) {
     if (!AMDGPUTargetLowering::allUsesHaveSourceMods(N.getNode()))
       return SDValue();
 
-    return distributeOpThroughSelect(DCI, LHS.getOpcode(),
-                                     SDLoc(N), Cond, LHS, RHS);
+    return distributeOpThroughSelect(DCI, ISD::FABS, SDLoc(N), Cond, LHS, RHS);
   }
 
   bool Inv = false;
@@ -5266,6 +5272,21 @@ bool AMDGPUTargetLowering::shouldFoldFNegIntoSrc(SDNode *N, SDValue N0) {
   }
 
   return true;
+}
+
+bool AMDGPUTargetLowering::shouldFoldFNegIntoSelect(SDValue Res, SDValue LHS,
+                                                    SDValue RHS) const {
+  if (!selectSupportsSourceMods(Res.getNode()))
+    return false;
+
+  // If the fneg already folds into all its users for free, leave it there
+  // (only relevant when Res is the fneg, i.e. the push-in).
+  if (Res.getOpcode() == ISD::FNEG && allUsesHaveSourceMods(Res.getNode()))
+    return false;
+
+  // Negating a value is free (a source modifier); decline only for a constant
+  // whose negation is not an inline immediate (e.g. +0.0 -> -0.0).
+  return !isConstantCostlierToNegate(LHS) && !isConstantCostlierToNegate(RHS);
 }
 
 SDValue AMDGPUTargetLowering::performFNegCombine(SDNode *N,
@@ -5468,8 +5489,16 @@ SDValue AMDGPUTargetLowering::performFNegCombine(SDNode *N,
   }
   case ISD::SELECT: {
     // fneg (select c, a, b) -> select c, (fneg a), (fneg b)
-    // TODO: Invert conditions of foldFreeOpFromSelect
-    return SDValue();
+    if (!shouldFoldFNegIntoSelect(SDValue(N, 0), N0.getOperand(1),
+                                  N0.getOperand(2)))
+      return SDValue();
+
+    SDValue NegT =
+        DAG.getNode(ISD::FNEG, SL, VT, N0.getOperand(1), N->getFlags());
+    SDValue NegF =
+        DAG.getNode(ISD::FNEG, SL, VT, N0.getOperand(2), N->getFlags());
+    return DAG.getNode(ISD::SELECT, SL, VT, N0.getOperand(0), NegT, NegF,
+                       N0->getFlags());
   }
   case ISD::BITCAST: {
     SDLoc SL(N);

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.h
@@ -200,6 +200,9 @@ public:
   }
 
   static bool shouldFoldFNegIntoSrc(SDNode *FNeg, SDValue FNegSrc);
+  /// \return true if select(fneg \p LHS, fneg \p RHS) is preferable to
+  /// fneg(select).
+  bool shouldFoldFNegIntoSelect(SDValue Res, SDValue LHS, SDValue RHS) const;
   static bool allUsesHaveSourceMods(const SDNode *N,
                                     unsigned CostThreshold = 4);
   bool isFAbsFree(EVT VT) const override;

--- a/llvm/test/CodeGen/AMDGPU/fneg-combines.ll
+++ b/llvm/test/CodeGen/AMDGPU/fneg-combines.ll
@@ -8171,8 +8171,7 @@ define float @v_fneg_select_f32(i32 %arg0, float %a, float %b, float %c) {
 ; GCN:       ; %bb.0:
 ; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
-; GCN-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
-; GCN-NEXT:    v_xor_b32_e32 v0, 0x80000000, v0
+; GCN-NEXT:    v_cndmask_b32_e64 v0, -v2, -v1, vcc
 ; GCN-NEXT:    s_setpc_b64 s[30:31]
   %cond = icmp eq i32 %arg0, 0
   %select = select i1 %cond, float %a, float %b
@@ -8188,8 +8187,7 @@ define float @v_fneg_select_2_f32(i32 %arg0, float %a, float %b, float %c) {
 ; GCN-NEXT:    v_add_f32_e32 v1, 2.0, v1
 ; GCN-NEXT:    v_add_f32_e32 v2, 4.0, v2
 ; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
-; GCN-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
-; GCN-NEXT:    v_xor_b32_e32 v0, 0x80000000, v0
+; GCN-NEXT:    v_cndmask_b32_e64 v0, -v2, -v1, vcc
 ; GCN-NEXT:    s_setpc_b64 s[30:31]
   %cond = icmp eq i32 %arg0, 0
   %add.0 = fadd float %a, 2.0
@@ -8214,8 +8212,7 @@ define amdgpu_kernel void @v_fneg_posk_select_f32(ptr addrspace(1) %out, ptr add
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, s0, v3
 ; SI-NEXT:    v_addc_u32_e32 v2, vcc, 0, v2, vcc
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
-; SI-NEXT:    v_cndmask_b32_e32 v0, 4.0, v4, vcc
-; SI-NEXT:    v_xor_b32_e32 v0, 0x80000000, v0
+; SI-NEXT:    v_cndmask_b32_e64 v0, -4.0, -v4, vcc
 ; SI-NEXT:    flat_store_dword v[1:2], v0
 ; SI-NEXT:    s_endpgm
 ;
@@ -8233,8 +8230,7 @@ define amdgpu_kernel void @v_fneg_posk_select_f32(ptr addrspace(1) %out, ptr add
 ; VI-NEXT:    v_add_u32_e32 v1, vcc, s0, v3
 ; VI-NEXT:    v_addc_u32_e32 v2, vcc, 0, v2, vcc
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
-; VI-NEXT:    v_cndmask_b32_e32 v0, 4.0, v4, vcc
-; VI-NEXT:    v_xor_b32_e32 v0, 0x80000000, v0
+; VI-NEXT:    v_cndmask_b32_e64 v0, -4.0, -v4, vcc
 ; VI-NEXT:    flat_store_dword v[1:2], v0
 ; VI-NEXT:    s_endpgm
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
@@ -8264,8 +8260,7 @@ define amdgpu_kernel void @v_fneg_negk_select_f32(ptr addrspace(1) %out, ptr add
 ; SI-NEXT:    v_add_i32_e32 v1, vcc, s0, v3
 ; SI-NEXT:    v_addc_u32_e32 v2, vcc, 0, v2, vcc
 ; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
-; SI-NEXT:    v_cndmask_b32_e32 v0, -4.0, v4, vcc
-; SI-NEXT:    v_xor_b32_e32 v0, 0x80000000, v0
+; SI-NEXT:    v_cndmask_b32_e64 v0, 4.0, -v4, vcc
 ; SI-NEXT:    flat_store_dword v[1:2], v0
 ; SI-NEXT:    s_endpgm
 ;
@@ -8283,8 +8278,7 @@ define amdgpu_kernel void @v_fneg_negk_select_f32(ptr addrspace(1) %out, ptr add
 ; VI-NEXT:    v_add_u32_e32 v1, vcc, s0, v3
 ; VI-NEXT:    v_addc_u32_e32 v2, vcc, 0, v2, vcc
 ; VI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
-; VI-NEXT:    v_cndmask_b32_e32 v0, -4.0, v4, vcc
-; VI-NEXT:    v_xor_b32_e32 v0, 0x80000000, v0
+; VI-NEXT:    v_cndmask_b32_e64 v0, 4.0, -v4, vcc
 ; VI-NEXT:    flat_store_dword v[1:2], v0
 ; VI-NEXT:    s_endpgm
   %tid = call i32 @llvm.amdgcn.workitem.id.x()

--- a/llvm/test/CodeGen/AMDGPU/fneg-combines.new.ll
+++ b/llvm/test/CodeGen/AMDGPU/fneg-combines.new.ll
@@ -1559,10 +1559,9 @@ define float @v_fneg_inv2pi_minimum_f32(float %a) #0 {
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-NEXT:    v_min_f32_e32 v1, 0.15915494, v0
-; VI-NEXT:    v_mov_b32_e32 v2, 0x7fc00000
+; VI-NEXT:    v_mov_b32_e32 v2, 0xffc00000
 ; VI-NEXT:    v_cmp_o_f32_e32 vcc, v0, v0
-; VI-NEXT:    v_cndmask_b32_e32 v0, v2, v1, vcc
-; VI-NEXT:    v_xor_b32_e32 v0, 0x80000000, v0
+; VI-NEXT:    v_cndmask_b32_e64 v0, v2, -v1, vcc
 ; VI-NEXT:    s_setpc_b64 s[30:31]
   %min = call float @llvm.minimum.f32(float 0x3FC45F3060000000, float %a)
   %fneg = fneg float %min

--- a/llvm/test/CodeGen/AMDGPU/fneg-modifier-casting.ll
+++ b/llvm/test/CodeGen/AMDGPU/fneg-modifier-casting.ll
@@ -1725,6 +1725,60 @@ bb5:                                              ; preds = %bb, %.entry
 }
 
 
+; f32 select(fneg, fneg): both fnegs fold into the cndmask source modifiers.
+define float @select_fneg_fneg_f32(i1 %cond, float %arg0, float %arg1) {
+; GCN-LABEL: select_fneg_fneg_f32:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GCN-NEXT:    v_and_b32_e32 v0, 1, v0
+; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 1, v0
+; GCN-NEXT:    v_cndmask_b32_e64 v0, -v2, -v1, vcc
+; GCN-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: select_fneg_fneg_f32:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_and_b32_e32 v0, 1, v0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 1, v0
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, -v2, -v1, vcc_lo
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+  %neg0 = fneg float %arg0
+  %neg1 = fneg float %arg1
+  %select = select i1 %cond, float %neg0, float %neg1
+  ret float %select
+}
+
+; f64 select(fneg, fneg): the negate only affects the sign (high half), so it
+; folds into the high-half cndmask modifier (llvm/llvm-project#171724).
+define double @select_fneg_fneg_f64(i1 %cond, double %arg0, double %arg1) {
+; GCN-LABEL: select_fneg_fneg_f64:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GCN-NEXT:    v_and_b32_e32 v0, 1, v0
+; GCN-NEXT:    v_xor_b32_e32 v2, 0x80000000, v2
+; GCN-NEXT:    v_xor_b32_e32 v4, 0x80000000, v4
+; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 1, v0
+; GCN-NEXT:    v_cndmask_b32_e32 v0, v3, v1, vcc
+; GCN-NEXT:    v_cndmask_b32_e32 v1, v4, v2, vcc
+; GCN-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX11-LABEL: select_fneg_fneg_f64:
+; GFX11:       ; %bb.0:
+; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX11-NEXT:    v_xor_b32_e32 v2, 0x80000000, v2
+; GFX11-NEXT:    v_xor_b32_e32 v4, 0x80000000, v4
+; GFX11-NEXT:    v_and_b32_e32 v0, 1, v0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 1, v0
+; GFX11-NEXT:    v_dual_cndmask_b32 v0, v3, v1 :: v_dual_cndmask_b32 v1, v4, v2
+; GFX11-NEXT:    s_setpc_b64 s[30:31]
+  %neg0 = fneg double %arg0
+  %neg1 = fneg double %arg1
+  %select = select i1 %cond, double %neg0, double %neg1
+  ret double %select
+}
+
 declare <2 x i32> @llvm.amdgcn.s.buffer.load.v2i32(<4 x i32>, i32, i32 immarg) #0
 
 attributes #0 = { nocallback nofree nosync nounwind willreturn memory(none) }

--- a/llvm/test/CodeGen/AMDGPU/fneg-modifier-casting.ll
+++ b/llvm/test/CodeGen/AMDGPU/fneg-modifier-casting.ll
@@ -1613,12 +1613,12 @@ define amdgpu_kernel void @multiple_uses_fneg_select_f64(double %x, double %y, i
 ; GFX7-NEXT:    v_mov_b32_e32 v0, s3
 ; GFX7-NEXT:    v_mov_b32_e32 v1, s1
 ; GFX7-NEXT:    s_cselect_b32 s1, s1, s3
-; GFX7-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v0, -v0, -v1, vcc
 ; GFX7-NEXT:    s_cselect_b32 s0, s0, s2
 ; GFX7-NEXT:    v_mov_b32_e32 v1, s1
 ; GFX7-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX7-NEXT:    s_mov_b32 flat_scratch_lo, s13
-; GFX7-NEXT:    v_cndmask_b32_e64 v1, v1, -v0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v1, v0, vcc
 ; GFX7-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX7-NEXT:    v_mov_b32_e32 v3, s5
 ; GFX7-NEXT:    flat_store_dwordx2 v[2:3], v[0:1]
@@ -1637,10 +1637,10 @@ define amdgpu_kernel void @multiple_uses_fneg_select_f64(double %x, double %y, i
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s3
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s1
 ; GFX9-NEXT:    s_cselect_b32 s1, s1, s3
-; GFX9-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
+; GFX9-NEXT:    v_cndmask_b32_e64 v0, -v0, -v1, vcc
 ; GFX9-NEXT:    s_cselect_b32 s0, s0, s2
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s1
-; GFX9-NEXT:    v_cndmask_b32_e64 v1, v1, -v0, vcc
+; GFX9-NEXT:    v_cndmask_b32_e32 v1, v1, v0, vcc
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX9-NEXT:    global_store_dwordx2 v2, v[0:1], s[4:5]
 ; GFX9-NEXT:    s_endpgm
@@ -1651,17 +1651,17 @@ define amdgpu_kernel void @multiple_uses_fneg_select_f64(double %x, double %y, i
 ; GFX11-NEXT:    s_load_b128 s[0:3], s[4:5], 0x0
 ; GFX11-NEXT:    s_load_b32 s6, s[4:5], 0x10
 ; GFX11-NEXT:    s_load_b64 s[4:5], s[4:5], 0x18
-; GFX11-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    v_mov_b32_e32 v0, s1
 ; GFX11-NEXT:    s_bitcmp1_b32 s6, 0
 ; GFX11-NEXT:    s_cselect_b32 vcc_lo, -1, 0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_1)
-; GFX11-NEXT:    v_cndmask_b32_e32 v0, s3, v0, vcc_lo
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX11-NEXT:    v_cndmask_b32_e64 v0, -s3, -v0, vcc_lo
 ; GFX11-NEXT:    s_and_b32 s6, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_cselect_b32 s1, s1, s3
 ; GFX11-NEXT:    s_cselect_b32 s0, s0, s2
-; GFX11-NEXT:    v_cndmask_b32_e64 v1, s1, -v0, vcc_lo
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-NEXT:    v_dual_mov_b32 v2, 0 :: v_dual_cndmask_b32 v1, s1, v0
 ; GFX11-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX11-NEXT:    global_store_b64 v2, v[0:1], s[4:5]
 ; GFX11-NEXT:    s_endpgm
@@ -1756,22 +1756,19 @@ define double @select_fneg_fneg_f64(i1 %cond, double %arg0, double %arg1) {
 ; GCN:       ; %bb.0:
 ; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GCN-NEXT:    v_and_b32_e32 v0, 1, v0
-; GCN-NEXT:    v_xor_b32_e32 v2, 0x80000000, v2
-; GCN-NEXT:    v_xor_b32_e32 v4, 0x80000000, v4
 ; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, 1, v0
 ; GCN-NEXT:    v_cndmask_b32_e32 v0, v3, v1, vcc
-; GCN-NEXT:    v_cndmask_b32_e32 v1, v4, v2, vcc
+; GCN-NEXT:    v_cndmask_b32_e64 v1, -v4, -v2, vcc
 ; GCN-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: select_fneg_fneg_f64:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-NEXT:    v_xor_b32_e32 v2, 0x80000000, v2
-; GFX11-NEXT:    v_xor_b32_e32 v4, 0x80000000, v4
 ; GFX11-NEXT:    v_and_b32_e32 v0, 1, v0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_3)
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 1, v0
-; GFX11-NEXT:    v_dual_cndmask_b32 v0, v3, v1 :: v_dual_cndmask_b32 v1, v4, v2
+; GFX11-NEXT:    v_cndmask_b32_e32 v0, v3, v1, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, -v4, -v2, vcc_lo
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
   %neg0 = fneg double %arg0
   %neg1 = fneg double %arg1


### PR DESCRIPTION
Add shouldFoldFNegIntoSelect to gate the fold between:
```
  fneg(select) <--> select(fneg, fneg)
```
- f32, choose select(fneg, fneg).
- f64, choose fneg(select).

This saves an explicit v_xor by folding the negate into the v_cndmask_b32source modifier.

Resolves llvm/llvm-project#171724.
