### PR TITLE
[CIR] Compute union base subobject for tail-padding reuse

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
@@ -705,18 +705,13 @@ CIRGenTypes::computeRecordLayout(const RecordDecl *rd, cir::RecordType *ty) {
   if (llvm::isa<CXXRecordDecl>(rd)) {
     baseTy = *ty;
     // A record needs a distinct base-subobject type when its tail padding can
-    // be reused by an enclosing [[no_unique_address]] field.  For a
-    // struct/class that happens when the non-virtual size differs from the
-    // complete size; for a union it happens when the data size differs from
-    // the complete size (a union has reusable tail padding when one of its
-    // members is a [[no_unique_address]] field with tail padding of its own).
-    CharUnits baseSize = rd->isUnion()
-                             ? lowering.astRecordLayout.getDataSize()
-                             : lowering.astRecordLayout.getNonVirtualSize();
-    // A union whose data size is zero consists entirely of
-    // [[no_unique_address]] empty members.  There is no actual data to expose
-    // via a base subobject, so leave baseTy pointing at the complete type.
-    if (!baseSize.isZero() && baseSize != lowering.astRecordLayout.getSize()) {
+    // be reused by an enclosing [[no_unique_address]] field, i.e. when the
+    // non-virtual size differs from the complete size.  This matches classic
+    // CodeGen and covers unions too: a union's non-virtual size already tracks
+    // its reusable tail padding (and stays at the minimum union size when the
+    // union is empty, so a zero-data union does not spuriously qualify).
+    if (lowering.astRecordLayout.getNonVirtualSize() !=
+        lowering.astRecordLayout.getSize()) {
       CIRRecordLowering baseLowering(*this, rd, /*Packed=*/lowering.packed);
       baseLowering.lower(/*nonVirtualBaseType=*/true);
       std::string baseIdentifier = getRecordTypeName(rd, ".base");
@@ -726,9 +721,11 @@ CIRGenTypes::computeRecordLayout(const RecordDecl *rd, cir::RecordType *ty) {
       // TODO(cir): add something like addRecordTypeName
 
       // BaseTy and Ty must agree on their packedness for getCIRFieldNo to work
-      // on both of them with the same index.  Unions are exempt: every union
-      // field maps to index 0, and a union's data-size base layout may need to
-      // be packed even when its complete layout is not (and vice versa).
+      // on both of them with the same index.  Unions are exempt: CIR derives a
+      // union's packedness from its layout size, which is the data size for the
+      // base subobject but the full size for the complete object, so the two
+      // can legitimately disagree.  (Classic CodeGen derives both from the data
+      // size and so needs no such exemption.)
       assert((rd->isUnion() || lowering.packed == baseLowering.packed) &&
              "Non-virtual and complete types must agree on packedness");
     }
@@ -885,7 +882,7 @@ void CIRRecordLowering::lowerUnion(bool nonVirtualBaseType) {
       fieldTypes.push_back(fieldType);
   }
 
-  if (!storageType || layoutSize.isZero()) {
+  if (!storageType) {
     appendPaddingBytes(layoutSize);
     return;
   }

--- a/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
@@ -713,7 +713,10 @@ CIRGenTypes::computeRecordLayout(const RecordDecl *rd, cir::RecordType *ty) {
     CharUnits baseSize = rd->isUnion()
                              ? lowering.astRecordLayout.getDataSize()
                              : lowering.astRecordLayout.getNonVirtualSize();
-    if (baseSize != lowering.astRecordLayout.getSize()) {
+    // A union whose data size is zero consists entirely of
+    // [[no_unique_address]] empty members.  There is no actual data to expose
+    // via a base subobject, so leave baseTy pointing at the complete type.
+    if (!baseSize.isZero() && baseSize != lowering.astRecordLayout.getSize()) {
       CIRRecordLowering baseLowering(*this, rd, /*Packed=*/lowering.packed);
       baseLowering.lower(/*nonVirtualBaseType=*/true);
       std::string baseIdentifier = getRecordTypeName(rd, ".base");
@@ -882,7 +885,7 @@ void CIRRecordLowering::lowerUnion(bool nonVirtualBaseType) {
       fieldTypes.push_back(fieldType);
   }
 
-  if (!storageType) {
+  if (!storageType || layoutSize.isZero()) {
     appendPaddingBytes(layoutSize);
     return;
   }

--- a/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
@@ -72,7 +72,7 @@ struct CIRRecordLowering final {
                        mlir::Type storageType);
 
   void lower(bool NonVirtualBaseType);
-  void lowerUnion();
+  void lowerUnion(bool nonVirtualBaseType);
 
   /// Determines if we need a packed llvm struct.
   void determinePacked(bool nvBaseType);
@@ -280,7 +280,7 @@ void CIRRecordLowering::setBitFieldInfo(const FieldDecl *fd,
 
 void CIRRecordLowering::lower(bool nonVirtualBaseType) {
   if (recordDecl->isUnion()) {
-    lowerUnion();
+    lowerUnion(nonVirtualBaseType);
     computeVolatileBitfields();
     return;
   }
@@ -692,21 +692,28 @@ CIRGenTypes::computeRecordLayout(const RecordDecl *rd, cir::RecordType *ty) {
   assert(ty->isIncomplete() && "recomputing record layout?");
   lowering.lower(/*nonVirtualBaseType=*/false);
 
-  // If we're in C++, compute the base subobject type. For C++ records the base
-  // subobject type is always set (matching classic CodeGen). For unions and
-  // final classes the base subobject and complete object types are identical
-  // (no tail padding can be reused), so baseTy points at the same record as
-  // ty. We must still populate baseTy in those cases because callers such as
-  // getStorageType(const CXXRecordDecl *) used to lay out potentially-
-  // overlapping ([[no_unique_address]]) fields read it unconditionally; a
-  // null baseTy would otherwise propagate as a null mlir::Type into the
-  // members vector and trip the !empty() assertion in fillOutputFields.
+  // If we're in C++, compute the base subobject type. For C++ records baseTy
+  // defaults to the complete object type and is replaced by a distinct,
+  // smaller record only when the record has tail padding an enclosing
+  // [[no_unique_address]] field can reuse. We must populate baseTy even when
+  // it equals ty because callers such as getStorageType(const CXXRecordDecl *)
+  // read it unconditionally when laying out potentially-overlapping
+  // ([[no_unique_address]]) fields; a null baseTy would otherwise propagate as
+  // a null mlir::Type into the members vector and trip the !empty() assertion
+  // in fillOutputFields.
   cir::RecordType baseTy;
   if (llvm::isa<CXXRecordDecl>(rd)) {
     baseTy = *ty;
-    if (!rd->isUnion() && !rd->hasAttr<FinalAttr>() &&
-        lowering.astRecordLayout.getNonVirtualSize() !=
-            lowering.astRecordLayout.getSize()) {
+    // A record needs a distinct base-subobject type when its tail padding can
+    // be reused by an enclosing [[no_unique_address]] field.  For a
+    // struct/class that happens when the non-virtual size differs from the
+    // complete size; for a union it happens when the data size differs from
+    // the complete size (a union has reusable tail padding when one of its
+    // members is a [[no_unique_address]] field with tail padding of its own).
+    CharUnits baseSize = rd->isUnion()
+                             ? lowering.astRecordLayout.getDataSize()
+                             : lowering.astRecordLayout.getNonVirtualSize();
+    if (baseSize != lowering.astRecordLayout.getSize()) {
       CIRRecordLowering baseLowering(*this, rd, /*Packed=*/lowering.packed);
       baseLowering.lower(/*NonVirtualBaseType=*/true);
       std::string baseIdentifier = getRecordTypeName(rd, ".base");
@@ -716,8 +723,10 @@ CIRGenTypes::computeRecordLayout(const RecordDecl *rd, cir::RecordType *ty) {
       // TODO(cir): add something like addRecordTypeName
 
       // BaseTy and Ty must agree on their packedness for getCIRFieldNo to work
-      // on both of them with the same index.
-      assert(lowering.packed == baseLowering.packed &&
+      // on both of them with the same index.  Unions are exempt: every union
+      // field maps to index 0, and a union's data-size base layout may need to
+      // be packed even when its complete layout is not (and vice versa).
+      assert((rd->isUnion() || lowering.packed == baseLowering.packed) &&
              "Non-virtual and complete types must agree on packedness");
     }
   }
@@ -809,8 +818,13 @@ void CIRGenRecordLayout::dump() const { print(llvm::errs()); }
 
 void CIRGenBitFieldInfo::dump() const { print(llvm::errs()); }
 
-void CIRRecordLowering::lowerUnion() {
-  CharUnits layoutSize = astRecordLayout.getSize();
+void CIRRecordLowering::lowerUnion(bool nonVirtualBaseType) {
+  // The base-subobject layout of a union is sized to its data size rather than
+  // its full size.  A union can have reusable tail padding when one of its
+  // members is a [[no_unique_address]] field that itself has tail padding, so
+  // an enclosing [[no_unique_address]] union field must use this smaller type.
+  CharUnits layoutSize = nonVirtualBaseType ? astRecordLayout.getDataSize()
+                                            : astRecordLayout.getSize();
   mlir::Type storageType = nullptr;
   bool seenNamedMember = false;
 
@@ -860,7 +874,11 @@ void CIRRecordLowering::lowerUnion() {
 
     // NOTE(cir): Track all union member's types, not just the largest one. It
     // allows for proper type-checking and retain more info for analisys.
-    fieldTypes.push_back(fieldType);
+    // The base-subobject type instead uses a single (possibly clipped) storage
+    // type, mirroring classic CodeGen, so that it exposes the union's reusable
+    // tail padding.
+    if (!nonVirtualBaseType)
+      fieldTypes.push_back(fieldType);
   }
 
   if (!storageType) {
@@ -870,8 +888,20 @@ void CIRRecordLowering::lowerUnion() {
 
   if (layoutSize < getSize(storageType))
     storageType = getByteArrayType(layoutSize);
-  else
+
+  if (nonVirtualBaseType) {
+    // The base-subobject record is built as a struct from fieldTypes, so add
+    // the storage type and any trailing padding as ordinary fields rather than
+    // routing padding through the union's single tail-padding slot.
+    fieldTypes.push_back(storageType);
+    CharUnits padding = layoutSize - getSize(storageType);
+    if (!padding.isZero()) {
+      fieldTypes.push_back(getByteArrayType(padding));
+      padded = true;
+    }
+  } else {
     appendPaddingBytes(layoutSize - getSize(storageType));
+  }
 
   // Set packed if we need it.
   if (!layoutSize.isMultipleOf(getAlignment(storageType)))

--- a/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
@@ -71,7 +71,7 @@ struct CIRRecordLowering final {
   void setBitFieldInfo(const FieldDecl *fd, CharUnits startOffset,
                        mlir::Type storageType);
 
-  void lower(bool NonVirtualBaseType);
+  void lower(bool nonVirtualBaseType);
   void lowerUnion(bool nonVirtualBaseType);
 
   /// Determines if we need a packed llvm struct.
@@ -715,7 +715,7 @@ CIRGenTypes::computeRecordLayout(const RecordDecl *rd, cir::RecordType *ty) {
                              : lowering.astRecordLayout.getNonVirtualSize();
     if (baseSize != lowering.astRecordLayout.getSize()) {
       CIRRecordLowering baseLowering(*this, rd, /*Packed=*/lowering.packed);
-      baseLowering.lower(/*NonVirtualBaseType=*/true);
+      baseLowering.lower(/*nonVirtualBaseType=*/true);
       std::string baseIdentifier = getRecordTypeName(rd, ".base");
       baseTy = builder.getCompleteNamedRecordType(
           baseLowering.fieldTypes, baseLowering.packed, baseLowering.padded,
@@ -874,6 +874,7 @@ void CIRRecordLowering::lowerUnion(bool nonVirtualBaseType) {
 
     // NOTE(cir): Track all union member's types, not just the largest one. It
     // allows for proper type-checking and retain more info for analisys.
+    //
     // The base-subobject type instead uses a single (possibly clipped) storage
     // type, mirroring classic CodeGen, so that it exposes the union's reusable
     // tail padding.

--- a/clang/test/CIR/CodeGen/no-unique-address.cpp
+++ b/clang/test/CIR/CodeGen/no-unique-address.cpp
@@ -54,6 +54,9 @@ struct Outer {
 // LLVM-DAG: @of = {{(dso_local )?}}global %struct.OuterFinal zeroinitializer, align 4
 // LLVM-DAG: @oup = {{(dso_local )?}}global %struct.OuterUnionPad zeroinitializer, align 2
 // LLVM-DAG: @ofup = {{(dso_local )?}}global %struct.OuterFinalUnionPad zeroinitializer, align 2
+// LLVM-DAG: %struct.OuterZeroData = type { %union.UnionZeroDataSize, i8 }
+// LLVM-DAG: %union.UnionZeroDataSize = type { i32 }
+// LLVM-DAG: @ozd = {{(dso_local )?}}global %struct.OuterZeroData zeroinitializer, align 4
 // OGCG-DAG: %struct.OuterUnion = type { %union.UnionForNUA, i32 }
 // OGCG-DAG: %union.UnionForNUA = type { i64 }
 // OGCG-DAG: %struct.OuterFinal = type { %struct.FinalForNUA, i8 }
@@ -66,6 +69,9 @@ struct Outer {
 // OGCG-DAG: @of = {{(dso_local )?}}global %struct.OuterFinal zeroinitializer, align 4
 // OGCG-DAG: @oup = {{(dso_local )?}}global %struct.OuterUnionPad zeroinitializer, align 2
 // OGCG-DAG: @ofup = {{(dso_local )?}}global %struct.OuterFinalUnionPad zeroinitializer, align 2
+// OGCG-DAG: %struct.OuterZeroData = type { %union.UnionZeroDataSize, i8 }
+// OGCG-DAG: %union.UnionZeroDataSize = type { i32 }
+// OGCG-DAG: @ozd = {{(dso_local )?}}global %struct.OuterZeroData zeroinitializer, align 4
 
 // LLVM-LABEL: define {{.*}} void @_ZN5OuterC2ERK6Middlec(
 // LLVM:         %[[GEP:.*]] = getelementptr inbounds nuw %struct.Outer, ptr %{{.+}}, i32 0, i32 0
@@ -158,3 +164,20 @@ OuterFinalUnionPad ofup;
 // CIR-NUA-DAG: cir.global external @oup = #cir.zero : !rec_OuterUnionPad
 // CIR-NUA-DAG: cir.global external @ofup = #cir.zero : !rec_OuterFinalUnionPad
 
+struct EmptyForNUA {};
+
+union UnionZeroDataSize {
+  [[no_unique_address]] EmptyForNUA e;
+  [[no_unique_address]] int i;
+};
+
+struct OuterZeroData {
+  [[no_unique_address]] UnionZeroDataSize u;
+  bool flag;
+};
+
+OuterZeroData ozd;
+
+// CIR-NUA-DAG: !rec_UnionZeroDataSize = !cir.union<"UnionZeroDataSize" {!rec_EmptyForNUA, !s32i}>
+// CIR-NUA-DAG: !rec_OuterZeroData = !cir.struct<"OuterZeroData" {!rec_UnionZeroDataSize, !cir.bool}>
+// CIR-NUA-DAG: cir.global external @ozd = #cir.zero : !rec_OuterZeroData

--- a/clang/test/CIR/CodeGen/no-unique-address.cpp
+++ b/clang/test/CIR/CodeGen/no-unique-address.cpp
@@ -46,14 +46,26 @@ struct Outer {
 // LLVM-DAG: %union.UnionForNUA = type { i64 }
 // LLVM-DAG: %struct.OuterFinal = type { %struct.FinalForNUA, i8 }
 // LLVM-DAG: %struct.FinalForNUA = type { i32, i8 }
+// LLVM-DAG: %struct.OuterUnionPad = type { %struct.UnionWithPadding.base, i8 }
+// LLVM-DAG: %struct.UnionWithPadding.base = type { i8 }
+// LLVM-DAG: %struct.OuterFinalUnionPad = type { %struct.FinalUnionWithPadding.base, i8 }
+// LLVM-DAG: %struct.FinalUnionWithPadding.base = type { i8 }
 // LLVM-DAG: @ou = {{(dso_local )?}}global %struct.OuterUnion zeroinitializer, align 8
 // LLVM-DAG: @of = {{(dso_local )?}}global %struct.OuterFinal zeroinitializer, align 4
+// LLVM-DAG: @oup = {{(dso_local )?}}global %struct.OuterUnionPad zeroinitializer, align 2
+// LLVM-DAG: @ofup = {{(dso_local )?}}global %struct.OuterFinalUnionPad zeroinitializer, align 2
 // OGCG-DAG: %struct.OuterUnion = type { %union.UnionForNUA, i32 }
 // OGCG-DAG: %union.UnionForNUA = type { i64 }
 // OGCG-DAG: %struct.OuterFinal = type { %struct.FinalForNUA, i8 }
 // OGCG-DAG: %struct.FinalForNUA = type { i32, i8 }
+// OGCG-DAG: %struct.OuterUnionPad = type { %union.UnionWithPadding.base, i8 }
+// OGCG-DAG: %union.UnionWithPadding.base = type { i8 }
+// OGCG-DAG: %struct.OuterFinalUnionPad = type { %union.FinalUnionWithPadding.base, i8 }
+// OGCG-DAG: %union.FinalUnionWithPadding.base = type { i8 }
 // OGCG-DAG: @ou = {{(dso_local )?}}global %struct.OuterUnion zeroinitializer, align 8
 // OGCG-DAG: @of = {{(dso_local )?}}global %struct.OuterFinal zeroinitializer, align 4
+// OGCG-DAG: @oup = {{(dso_local )?}}global %struct.OuterUnionPad zeroinitializer, align 2
+// OGCG-DAG: @ofup = {{(dso_local )?}}global %struct.OuterFinalUnionPad zeroinitializer, align 2
 
 // LLVM-LABEL: define {{.*}} void @_ZN5OuterC2ERK6Middlec(
 // LLVM:         %[[GEP:.*]] = getelementptr inbounds nuw %struct.Outer, ptr %{{.+}}, i32 0, i32 0
@@ -98,10 +110,51 @@ struct OuterFinal {
 
 OuterFinal of;
 
+// A [[no_unique_address]] union field whose union has reusable tail padding.
+struct Padded {
+  Padded();
+
+private:
+  alignas(2) bool b;
+};
+
+union UnionWithPadding {
+  UnionWithPadding();
+  [[no_unique_address]] Padded p;
+  bool flag;
+};
+
+struct OuterUnionPad {
+  [[no_unique_address]] UnionWithPadding u;
+  bool tail;
+};
+
+OuterUnionPad oup;
+
+// A final union also gets a base-subobject type for tail-padding reuse.
+union FinalUnionWithPadding final {
+  FinalUnionWithPadding();
+  [[no_unique_address]] Padded p;
+  bool flag;
+};
+
+struct OuterFinalUnionPad {
+  [[no_unique_address]] FinalUnionWithPadding u;
+  bool tail;
+};
+
+OuterFinalUnionPad ofup;
+
 // CIR-NUA-DAG: !rec_FinalForNUA = !cir.struct<"FinalForNUA" {!s32i, !s8i}>
 // CIR-NUA-DAG: !rec_UnionForNUA = !cir.union<"UnionForNUA" {!s32i, !s64i}>
 // CIR-NUA-DAG: !rec_OuterFinal = !cir.struct<"OuterFinal" {!rec_FinalForNUA, !s8i}>
 // CIR-NUA-DAG: !rec_OuterUnion = !cir.struct<"OuterUnion" {!rec_UnionForNUA, !s32i}>
+// CIR-NUA-DAG: !rec_UnionWithPadding2Ebase = !cir.struct<"UnionWithPadding.base" {!u8i}>
+// CIR-NUA-DAG: !rec_OuterUnionPad = !cir.struct<"OuterUnionPad" {!rec_UnionWithPadding2Ebase, !cir.bool}>
+// CIR-NUA-DAG: !rec_FinalUnionWithPadding2Ebase = !cir.struct<"FinalUnionWithPadding.base" {!u8i}>
+// CIR-NUA-DAG: !rec_OuterFinalUnionPad = !cir.struct<"OuterFinalUnionPad" {!rec_FinalUnionWithPadding2Ebase, !cir.bool}>
 // CIR-NUA-DAG: cir.global external @ou = #cir.zero : !rec_OuterUnion
 // CIR-NUA-DAG: cir.global external @of = #cir.zero : !rec_OuterFinal
+// CIR-NUA-DAG: cir.global external @oup = #cir.zero : !rec_OuterUnionPad
+// CIR-NUA-DAG: cir.global external @ofup = #cir.zero : !rec_OuterFinalUnionPad
 

--- a/clang/test/CIR/CodeGen/no-unique-address.cpp
+++ b/clang/test/CIR/CodeGen/no-unique-address.cpp
@@ -57,6 +57,8 @@ struct Outer {
 // LLVM-DAG: %struct.OuterZeroData = type { %union.UnionZeroDataSize, i8 }
 // LLVM-DAG: %union.UnionZeroDataSize = type { i32 }
 // LLVM-DAG: @ozd = {{(dso_local )?}}global %struct.OuterZeroData zeroinitializer, align 4
+// LLVM-DAG: %struct.OuterAllEmpty = type { i8 }
+// LLVM-DAG: @oae = {{(dso_local )?}}global %struct.OuterAllEmpty zeroinitializer, align 1
 // OGCG-DAG: %struct.OuterUnion = type { %union.UnionForNUA, i32 }
 // OGCG-DAG: %union.UnionForNUA = type { i64 }
 // OGCG-DAG: %struct.OuterFinal = type { %struct.FinalForNUA, i8 }
@@ -72,6 +74,8 @@ struct Outer {
 // OGCG-DAG: %struct.OuterZeroData = type { %union.UnionZeroDataSize, i8 }
 // OGCG-DAG: %union.UnionZeroDataSize = type { i32 }
 // OGCG-DAG: @ozd = {{(dso_local )?}}global %struct.OuterZeroData zeroinitializer, align 4
+// OGCG-DAG: %struct.OuterAllEmpty = type { i8 }
+// OGCG-DAG: @oae = {{(dso_local )?}}global %struct.OuterAllEmpty zeroinitializer, align 1
 
 // LLVM-LABEL: define {{.*}} void @_ZN5OuterC2ERK6Middlec(
 // LLVM:         %[[GEP:.*]] = getelementptr inbounds nuw %struct.Outer, ptr %{{.+}}, i32 0, i32 0
@@ -177,6 +181,27 @@ struct OuterZeroData {
 };
 
 OuterZeroData ozd;
+
+// A union whose members are all [[no_unique_address]] empty types has data
+// size 0, but its non-virtual size stays at the 1-byte minimum, so the gate
+// does not fire and it needs no distinct base-subobject type.
+struct EmptyA {};
+struct EmptyB {};
+
+union UnionAllEmpty {
+  [[no_unique_address]] EmptyA a;
+  [[no_unique_address]] EmptyB b;
+};
+
+struct OuterAllEmpty {
+  [[no_unique_address]] UnionAllEmpty u;
+  bool flag;
+};
+
+OuterAllEmpty oae;
+
+// CIR-NUA-DAG: !rec_OuterAllEmpty = !cir.struct<"OuterAllEmpty" {!cir.bool}>
+// CIR-NUA-DAG: cir.global external @oae = #cir.zero : !rec_OuterAllEmpty
 
 // CIR-NUA-DAG: !rec_UnionZeroDataSize = !cir.union<"UnionZeroDataSize" {!rec_EmptyForNUA, !s32i}>
 // CIR-NUA-DAG: !rec_OuterZeroData = !cir.struct<"OuterZeroData" {!rec_UnionZeroDataSize, !cir.bool}>


### PR DESCRIPTION
A `[[no_unique_address]]` field whose type is a union with reusable tail
padding made CIRGen trip the `insertPadding` "offset >= size" assertion in
`CIRGenRecordLayoutBuilder`. CIR sized the union member at its full size, so a
following field that the ABI places in the union's tail padding overlapped the
union and `insertPadding` asserted.

CIR already computed a distinct, smaller base subobject type for structs and
classes whose tail padding can be reused, but not for unions. A union has
reusable tail padding when one of its members is itself a `[[no_unique_address]]`
field with tail padding, which makes the union's data size smaller than its
size.

`computeRecordLayout` now builds that base type for unions too, sized from
`getDataSize()`, and `lowerUnion` emits the storage type plus trailing padding
as ordinary struct fields so the reusable padding is exposed, mirroring classic
CodeGen. The base-type gate also no longer skips records marked `final`, which
classic CodeGen never skipped and which otherwise hit the same assertion for a
`final` union with reusable tail padding.

This unblocks libcxx's `std::expected` tests, which lean on
`[[no_unique_address]]` over unions.
