### PR TITLE
[WIP][CIR] Rewrite ConstRecordBuilder to be based on layout

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
@@ -834,31 +834,429 @@ mlir::Attribute ConstRecordBuilder::finalize(QualType type) {
   return builder.build(valTy, rd->hasFlexibleArrayMember());
 }
 
+//===----------------------------------------------------------------------===//
+// Layout-driven record initializer emission.
+//
+// Walk the CIR record layout (CIRGenRecordLayout::getCIRType()) directly:
+// for each CIR member, decide what value goes there based on the AST init,
+// then assemble a ConstRecordAttr of that exact CIR record type. This avoids
+// synthesizing an anon storage record whose member list disagrees with the
+// logical record type that other code paths see for the same VarDecl.
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// Pack a bitfield value into a per-storage-member accumulator.
+/// `cirIdx` is the CIR field index of the storage member.
+struct BitfieldAccumulator {
+  llvm::APInt value;
+  mlir::Type storageType;
+};
+
+/// Compute the IntAttr that fills a bitfield storage member.
+static cir::IntAttr packBitfield(CIRGenModule &cgm,
+                                 const CIRGenBitFieldInfo &info,
+                                 llvm::APInt fieldValue,
+                                 cir::IntAttr existing) {
+  llvm::APInt accum(info.storageSize, 0);
+  if (existing)
+    accum = existing.getValue().zextOrTrunc(info.storageSize);
+
+  // Truncate the field value to its bitfield size, then position into the
+  // storage word. Bit ordering follows the target endianness.
+  if (fieldValue.getBitWidth() > info.size)
+    fieldValue = fieldValue.trunc(info.size);
+  fieldValue = fieldValue.zextOrTrunc(info.storageSize);
+
+  unsigned offset = info.offset;
+  if (cgm.getDataLayout().isBigEndian())
+    offset = info.storageSize - info.size - offset;
+  fieldValue = fieldValue.shl(offset);
+
+  // Mask the destination bits to zero (in case allow-overwrite scenarios put
+  // something there) and OR in the new value.
+  llvm::APInt mask(info.storageSize, 0);
+  mask.setBits(offset, offset + info.size);
+  accum &= ~mask;
+  accum |= fieldValue;
+
+  return cir::IntAttr::get(info.storageType, accum);
+}
+
+/// True for AST fields that the CIR record layout doesn't keep as their own
+/// member (empty struct fields, zero-length bitfields, etc). Their init still
+/// has to be evaluated for side effects but contributes nothing to the
+/// const_record's element list.
+static bool astFieldElidedFromCIRLayout(const ASTContext &ctx,
+                                        const CIRGenRecordLayout &layout,
+                                        const FieldDecl *field) {
+  if (field->isUnnamedBitField())
+    return true;
+  if (field->isZeroSize(ctx))
+    return true;
+  if (isEmptyFieldForLayout(ctx, field))
+    return true;
+  // A bitfield may live inside a shared storage member, so it is not elided —
+  // its FieldDecl still maps to a CIR index via getCIRFieldNo.
+  if (field->isBitField())
+    return false;
+  // Non-bitfield FieldDecls that survive show up in fieldIdxMap. Anything not
+  // there must have been elided (e.g. zero-length bitfield not skipped above).
+  return !layout.hasField(field);
+}
+
+/// Emit a ConstRecordAttr whose element list is keyed off the CIR record
+/// layout. Callers supply per-AST-field initializers via `getFieldInit`,
+/// per-base initializers via `getBaseInit`, and optionally a vtable address
+/// via `vtableInit`. Returns null on failure (caller should fall back to
+/// emitNull or NYI).
+template <typename FieldInitFn, typename BaseInitFn>
+static mlir::Attribute
+emitRecordInitializer(ConstantEmitter &emitter, const RecordDecl *rd,
+                      bool asCompleteObject, FieldInitFn getFieldInit,
+                      BaseInitFn getBaseInit, mlir::Attribute vtableInit) {
+  CIRGenModule &cgm = emitter.cgm;
+  const ASTContext &astCtx = cgm.getASTContext();
+  const CIRGenRecordLayout &layout = cgm.getTypes().getCIRGenRecordLayout(rd);
+  cir::RecordType recordTy =
+      asCompleteObject ? layout.getCIRType() : layout.getBaseSubobjectCIRType();
+
+  // Unions are represented in CIR with a multi-member RecordType that
+  // enumerates every union field for type info, but at lowering time only
+  // a single storage member survives. A ConstRecordAttr of the union's CIR
+  // type would have N>=1 elements that don't line up with the lowered LLVM
+  // struct's single element, so we synthesize a single-member anonymous
+  // record for the active union initializer instead. This matches OG's
+  // behavior. Unions don't have nested non-zero offsets, so the type-swap
+  // back-pressure that motivates the layout-driven build for structs doesn't
+  // apply.
+  if (rd->isUnion()) {
+    CIRGenBuilderTy &builder = cgm.getBuilder();
+    // The LLVM lowering of a UnionType picks a single storage member, so the
+    // value we hand back has to match that storage type. If the active C
+    // union field has a different type, bitcast its constant into the storage
+    // type's representation.
+    auto unionTy = mlir::cast<cir::UnionType>(recordTy);
+    mlir::Type storageTy =
+        unionTy.getUnionStorageType(cir::CIRDataLayout(cgm.getModule()).layout);
+    for (const FieldDecl *field : rd->fields()) {
+      const FieldDecl *active = getFieldInit.unionActiveField();
+      if (active && !declaresSameEntity(active->getCanonicalDecl(),
+                                        field->getCanonicalDecl()))
+        continue;
+      if (field->isZeroSize(astCtx))
+        continue;
+      auto initInfo = getFieldInit(/*astIdx=*/0, field);
+      if (initInfo.failed)
+        return {};
+      if (initInfo.skip)
+        continue;
+      mlir::TypedAttr eltAttr = initInfo.attr;
+      if (!eltAttr) {
+        if (active)
+          return {};
+        continue;
+      }
+
+      if (eltAttr.getType() != storageTy) {
+        // The active field's type differs from the union's storage type.
+        // Repack the bits as an integer that matches the storage type's
+        // bit width. Higher bits stay zero (representing the union's
+        // trailing-padding bytes); lowering will widen/bitcast as needed.
+        cir::CIRDataLayout dl(cgm.getModule());
+        uint64_t eltBits = (uint64_t)dl.getTypeSizeInBits(eltAttr.getType());
+        uint64_t storageBits = (uint64_t)dl.getTypeSizeInBits(storageTy);
+        if (eltBits > storageBits)
+          return {};
+        llvm::APInt bits(eltBits ? eltBits : 1, 0);
+        if (auto i = mlir::dyn_cast<cir::IntAttr>(eltAttr))
+          bits = i.getValue();
+        else if (auto f = mlir::dyn_cast<cir::FPAttr>(eltAttr))
+          bits = f.getValue().bitcastToAPInt();
+        else
+          return {};
+        bits = bits.zextOrTrunc(storageBits);
+        if (auto sti = mlir::dyn_cast<cir::IntType>(storageTy))
+          eltAttr = cir::IntAttr::get(storageTy, bits);
+        else if (auto stf = mlir::dyn_cast<cir::FPTypeInterface>(storageTy))
+          eltAttr = cir::FPAttr::get(
+              storageTy, llvm::APFloat(stf.getFloatSemantics(), bits));
+        else
+          return {};
+      }
+
+      return cir::ConstRecordAttr::get(recordTy,
+                                       builder.getArrayAttr({eltAttr}));
+    }
+    // No active union field initialized -> zero of the union type.
+    return cir::ZeroAttr::get(recordTy);
+  }
+
+  unsigned numElements = recordTy.getNumElements();
+  llvm::SmallVector<mlir::Attribute> elements(numElements);
+
+  // Bases first (C++).
+  if (const auto *cxxrd = dyn_cast<CXXRecordDecl>(rd)) {
+    if (asCompleteObject) {
+      for (auto [idx, base] : llvm::enumerate(cxxrd->bases())) {
+        if (base.isVirtual())
+          continue;
+        const auto *baseDecl = base.getType()->castAsCXXRecordDecl();
+        if (isEmptyRecordForLayout(astCtx, base.getType()) ||
+            astCtx.getASTRecordLayout(baseDecl).getNonVirtualSize().isZero())
+          continue;
+        mlir::Attribute baseAttr = getBaseInit(idx, baseDecl);
+        if (!baseAttr)
+          return {};
+        unsigned cirIdx = layout.getNonVirtualBaseCIRFieldNo(baseDecl);
+        elements[cirIdx] = baseAttr;
+      }
+    }
+    if (cxxrd->getNumVBases()) {
+      cgm.errorNYI(cxxrd->getSourceRange(),
+                   "emitRecordInitializer: virtual base");
+      return {};
+    }
+  }
+
+  // Vtable pointer, if any.
+  if (vtableInit) {
+    // Vtable lives at offset 0 of the complete object's CIR layout.
+    elements[0] = vtableInit;
+  }
+
+  // Fields. Bitfields accumulate into their shared storage member.
+  unsigned astFieldIdx = 0;
+  for (const FieldDecl *field : rd->fields()) {
+    unsigned thisAstIdx = astFieldIdx++;
+
+    auto initInfo = getFieldInit(thisAstIdx, field);
+    if (initInfo.failed)
+      return {};
+    if (initInfo.skip)
+      continue;
+
+    if (astFieldElidedFromCIRLayout(astCtx, layout, field)) {
+      // Init has already been evaluated by the accessor for side effects.
+      continue;
+    }
+
+    if (field->isBitField()) {
+      auto intAttr = mlir::dyn_cast_if_present<cir::IntAttr>(initInfo.attr);
+      if (!intAttr)
+        return {};
+      const CIRGenBitFieldInfo &info = layout.getBitFieldInfo(field);
+      unsigned cirIdx = layout.getCIRFieldNo(field);
+      auto existing = mlir::dyn_cast_if_present<cir::IntAttr>(elements[cirIdx]);
+      elements[cirIdx] = packBitfield(cgm, info, intAttr.getValue(), existing);
+    } else {
+      if (!initInfo.attr)
+        return {};
+      unsigned cirIdx = layout.getCIRFieldNo(field);
+      elements[cirIdx] = initInfo.attr;
+    }
+  }
+
+  // Zero-fill any CIR member that wasn't explicitly set (padding members,
+  // unset bases under the complete-object form, etc).
+  CIRGenBuilderTy &builder = cgm.getBuilder();
+  for (unsigned i = 0; i < numElements; ++i) {
+    if (!elements[i])
+      elements[i] = builder.getZeroInitAttr(recordTy.getElementType(i));
+  }
+
+  // Let the helper collapse all-zero records to a single ZeroAttr.
+  return builder.getConstRecordOrZeroAttr(builder.getArrayAttr(elements),
+                                          /*packed=*/recordTy.getPacked(),
+                                          /*padded=*/recordTy.getPadded(),
+                                          recordTy);
+}
+
+/// Per-field result returned by the init accessors used in
+/// emitRecordInitializer.
+struct FieldInitResult {
+  /// The TypedAttr to place into the const_record (null for skip/fail).
+  mlir::TypedAttr attr;
+  /// True if this field has no initializer and shouldn't contribute (e.g.
+  /// NoInitExpr from a designated initializer).
+  bool skip = false;
+  /// True if the accessor encountered an error and emission must abort.
+  bool failed = false;
+};
+
+/// Accessor adapter for InitListExpr.
+struct InitListExprAccessor {
+  ConstantEmitter &emitter;
+  InitListExpr *ile;
+  mlir::Location loc;
+  unsigned elementNo = 0;
+
+  const FieldDecl *unionActiveField() const {
+    return ile->getInitializedFieldInUnion();
+  }
+
+  FieldInitResult operator()(unsigned, const FieldDecl *field) {
+    CIRGenModule &cgm = emitter.cgm;
+    const ASTContext &astCtx = cgm.getASTContext();
+    FieldInitResult r;
+    if (field->isUnnamedBitField())
+      return (r.skip = true, r);
+
+    Expr *init = nullptr;
+    if (elementNo < ile->getNumInits())
+      init = ile->getInit(elementNo++);
+    if (isa_and_nonnull<NoInitExpr>(init))
+      return (r.skip = true, r);
+
+    if (field->isZeroSize(astCtx)) {
+      if (init && init->HasSideEffects(astCtx)) {
+        r.failed = true;
+        return r;
+      }
+      r.skip = true;
+      return r;
+    }
+    if (isEmptyFieldForLayout(astCtx, field)) {
+      r.skip = true;
+      return r;
+    }
+
+    mlir::Attribute attr =
+        init ? emitter.tryEmitPrivateForMemory(init, field->getType())
+             : emitter.emitNullForMemory(loc, field->getType());
+    if (!attr) {
+      r.failed = true;
+      return r;
+    }
+    r.attr = mlir::cast<mlir::TypedAttr>(attr);
+    return r;
+  }
+};
+
+/// Accessor adapter for APValue.
+struct APValueAccessor {
+  ConstantEmitter &emitter;
+  const APValue &val;
+  const RecordDecl *rd;
+  mlir::Location loc;
+
+  const FieldDecl *unionActiveField() const {
+    return rd->isUnion() ? val.getUnionField() : nullptr;
+  }
+
+  FieldInitResult operator()(unsigned astFieldIdx, const FieldDecl *field) {
+    CIRGenModule &cgm = emitter.cgm;
+    const ASTContext &astCtx = cgm.getASTContext();
+    FieldInitResult r;
+    if (field->isUnnamedBitField())
+      return (r.skip = true, r);
+    if (field->isZeroSize(astCtx)) {
+      r.skip = true;
+      return r;
+    }
+    if (isEmptyFieldForLayout(astCtx, field)) {
+      r.skip = true;
+      return r;
+    }
+
+    const APValue &fieldVal =
+        rd->isUnion() ? val.getUnionValue() : val.getStructField(astFieldIdx);
+    mlir::Attribute attr =
+        emitter.tryEmitPrivateForMemory(fieldVal, field->getType());
+    if (!attr) {
+      r.failed = true;
+      return r;
+    }
+    r.attr = mlir::cast<mlir::TypedAttr>(attr);
+    return r;
+  }
+};
+
+} // namespace
+
 mlir::Attribute ConstRecordBuilder::buildRecord(ConstantEmitter &emitter,
                                                 InitListExpr *ile,
                                                 QualType valTy) {
-  ConstantAggregateBuilder constant(emitter.cgm);
-  ConstRecordBuilder builder(emitter, constant, CharUnits::Zero());
+  RecordDecl *rd = ile->getType()->castAsRecordDecl();
+  if (auto *cxxrd = dyn_cast<CXXRecordDecl>(rd))
+    if (cxxrd->getNumBases())
+      return nullptr;
+  mlir::Location loc = emitter.cgm.getLoc(ile->getSourceRange());
+  InitListExprAccessor fieldAcc{emitter, ile, loc};
+  auto baseAcc = [&](unsigned, const CXXRecordDecl *) {
+    return mlir::Attribute{};
+  };
+  return emitRecordInitializer(emitter, rd, /*asCompleteObject=*/true, fieldAcc,
+                               baseAcc, /*vtableInit=*/{});
+}
 
-  if (!builder.build(ile, /*allowOverwrite*/ false))
-    return nullptr;
+/// Build the vtable address-point GlobalViewAttr for a class whose CIR layout
+/// reports `hasOwnVFPtr()`. When emitting a base subobject within some larger
+/// derived class, the vtable used is the *derived's* vtable (`vTableClass`),
+/// indexed at the address point for `(rd, offsetInDerived)`. For the
+/// most-derived (top-level) call, vTableClass == cxxrd and offsetInDerived
+/// is zero.
+static mlir::Attribute buildVTableInit(CIRGenModule &cgm,
+                                       const CXXRecordDecl *rd,
+                                       const CXXRecordDecl *vTableClass,
+                                       CharUnits offsetInDerived) {
+  const ASTRecordLayout &astLayout = cgm.getASTContext().getASTRecordLayout(rd);
+  if (!astLayout.hasOwnVFPtr())
+    return {};
+  CIRGenBuilderTy &builder = cgm.getBuilder();
+  cir::GlobalOp vtable =
+      cgm.getCXXABI().getAddrOfVTable(vTableClass, CharUnits());
+  clang::VTableLayout::AddressPointLocation addressPoint =
+      cgm.getItaniumVTableContext()
+          .getVTableLayout(vTableClass)
+          .getAddressPoint(BaseSubobject(rd, offsetInDerived));
+  assert(!cir::MissingFeatures::addressPointerAuthInfo());
+  mlir::ArrayAttr indices = builder.getArrayAttr({
+      builder.getI32IntegerAttr(addressPoint.VTableIndex),
+      builder.getI32IntegerAttr(addressPoint.AddressPointIndex),
+  });
+  auto vptrTy = cir::VPtrType::get(builder.getContext());
+  auto symbol = mlir::FlatSymbolRefAttr::get(vtable.getSymNameAttr());
+  return cir::GlobalViewAttr::get(vptrTy, symbol, indices);
+}
 
-  return builder.finalize(valTy);
+static mlir::Attribute buildRecordFromAPValue(ConstantEmitter &emitter,
+                                              const APValue &val,
+                                              const RecordDecl *rd,
+                                              const CXXRecordDecl *vTableClass,
+                                              CharUnits offsetInDerived) {
+  const auto *cxxrd = dyn_cast<CXXRecordDecl>(rd);
+  CIRGenModule &cgm = emitter.cgm;
+  mlir::Location loc = cgm.getBuilder().getUnknownLoc();
+
+  mlir::Attribute vtableInit;
+  if (cxxrd && vTableClass)
+    vtableInit = buildVTableInit(cgm, cxxrd, vTableClass, offsetInDerived);
+
+  APValueAccessor fieldAcc{emitter, val, rd, loc};
+  auto baseAcc = [&](unsigned baseIdx,
+                     const CXXRecordDecl *baseDecl) -> mlir::Attribute {
+    const APValue &baseVal = val.getStructBase(baseIdx);
+    // Recurse into the base subobject, keeping vTableClass pinned to the
+    // most-derived class so any vtables emitted inside use its layout.
+    const ASTRecordLayout &derivedLayout =
+        cgm.getASTContext().getASTRecordLayout(rd);
+    CharUnits baseOff =
+        offsetInDerived + derivedLayout.getBaseClassOffset(baseDecl);
+    return buildRecordFromAPValue(emitter, baseVal, baseDecl, vTableClass,
+                                  baseOff);
+  };
+  return emitRecordInitializer(emitter, rd, /*asCompleteObject=*/true, fieldAcc,
+                               baseAcc, vtableInit);
 }
 
 mlir::Attribute ConstRecordBuilder::buildRecord(ConstantEmitter &emitter,
                                                 const APValue &val,
                                                 QualType valTy) {
-  ConstantAggregateBuilder constant(emitter.cgm);
-  ConstRecordBuilder builder(emitter, constant, CharUnits::Zero());
-
   const RecordDecl *rd =
       valTy->castAs<clang::RecordType>()->getDecl()->getDefinitionOrSelf();
-  const CXXRecordDecl *cd = dyn_cast<CXXRecordDecl>(rd);
-  if (!builder.build(val, rd, false, cd, CharUnits::Zero()))
-    return nullptr;
-
-  return builder.finalize(valTy);
+  const auto *cxxrd = dyn_cast<CXXRecordDecl>(rd);
+  return buildRecordFromAPValue(emitter, val, rd, cxxrd, CharUnits::Zero());
 }
 
 bool ConstRecordBuilder::updateRecord(ConstantEmitter &emitter,
@@ -1157,6 +1555,22 @@ emitArrayConstant(CIRGenModule &cgm, mlir::Type desiredType,
     return cir::ZeroAttr::get(desiredType);
 
   const unsigned trailingZeroes = arrayBound - nonzeroLength;
+
+  // If we have a significant block of trailing zeros and a common element
+  // type, prefer a single ConstArrayAttr of the desired array type with a
+  // `trailingZerosNum` hint instead of synthesizing a packed anonymous record
+  // around a `[N x t] zeroinitializer` tail. This keeps the array's type in
+  // agreement with what the enclosing record layout expects.
+  if (trailingZeroes >= 8 && commonElementType) {
+    SmallVector<mlir::Attribute> eles;
+    eles.reserve(nonzeroLength);
+    for (unsigned i = 0; i < nonzeroLength; ++i)
+      eles.push_back(elements[i]);
+    return cir::ConstArrayAttr::get(
+        cir::ArrayType::get(commonElementType, arrayBound),
+        mlir::ArrayAttr::get(builder.getContext(), eles),
+        /*trailingZerosNum=*/trailingZeroes);
+  }
 
   // Add a zeroinitializer array filler if we have lots of trailing zeroes.
   if (trailingZeroes >= 8) {

--- a/clang/lib/CIR/CodeGen/CIRGenRecordLayout.h
+++ b/clang/lib/CIR/CodeGen/CIRGenRecordLayout.h
@@ -184,6 +184,14 @@ public:
     return fieldIdxMap.lookup(fd);
   }
 
+  /// True if this AST FieldDecl has its own slot in the CIR record layout
+  /// (either as a unique CIR member or as a bitfield sharing a storage
+  /// member). Returns false for fields that were elided by the layout builder,
+  /// e.g. empty struct fields or zero-length bitfields.
+  bool hasField(const clang::FieldDecl *fd) const {
+    return fieldIdxMap.count(fd->getCanonicalDecl());
+  }
+
   unsigned getNonVirtualBaseCIRFieldNo(const CXXRecordDecl *rd) const {
     assert(nonVirtualBases.count(rd) && "Invalid non-virtual base!");
     return nonVirtualBases.lookup(rd);

--- a/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
@@ -207,6 +207,21 @@ ConstRecordAttr::verify(function_ref<InFlightDiagnostic()> emitError,
   if (!sTy)
     return emitError() << "expected !cir.struct or !cir.union type";
 
+  // Unions carry every field on the CIR type for type info but lower to a
+  // single LLVM struct element. A ConstRecordAttr that initializes a union
+  // therefore provides exactly one element whose type matches any of the
+  // union's members (the active field).
+  if (sTy.isUnion()) {
+    if (members.size() != 1)
+      return emitError() << "union constant must have exactly one element, got "
+                         << members.size();
+    auto m = mlir::cast<mlir::TypedAttr>(members[0]);
+    if (!llvm::is_contained(sTy.getMembers(), m.getType()))
+      return emitError() << "union element type " << m.getType()
+                         << " is not a member of " << sTy;
+    return success();
+  }
+
   if (sTy.getMembers().size() != members.size())
     return emitError() << "number of elements must match";
 

--- a/clang/test/CIR/CodeGen/agg-init-constexpr.cpp
+++ b/clang/test/CIR/CodeGen/agg-init-constexpr.cpp
@@ -21,13 +21,12 @@ extern "C" void construct() {
 
 // CIR-LABEL: construct()
 // CIR-NEXT: %[[WC_ALLOCA:.*]] = cir.alloca !rec_WithCtor
-// CIR-NEXT: %[[CONST_VAL:.*]] = cir.const #cir.const_record<{#cir.int<4> : !s32i, #cir.int<10> : !s64i, #cir.const_record<{#cir.int<5> : !s32i}> : !rec_HasVal}>
-// CIR-NEXT: %[[BITCAST:.*]] = cir.cast bitcast %[[WC_ALLOCA]]
-// CIR-NEXT: cir.store{{.*}}%[[CONST_VAL]], %[[BITCAST]]
+// CIR-NEXT: %[[CONST_GLOB:.*]] = cir.get_global @__const.construct.c : !cir.ptr<!rec_WithCtor>
+// CIR-NEXT: cir.copy %[[CONST_GLOB]] to %[[WC_ALLOCA]]
 
 // LLVM-LABEL: construct()
 // LLVM-NEXT: %[[WC_ALLOCA:.*]] = alloca %struct.WithCtor
-// LLVM-NEXT: store { i32, i64, %struct.HasVal } { i32 4, i64 10, %struct.HasVal { i32 5 } }, ptr %[[WC_ALLOCA]]
+// LLVM-NEXT: call void @llvm.memcpy{{.*}}(ptr {{.*}}%[[WC_ALLOCA]], ptr {{.*}}@__const.construct.c
 
 // OGCG-LABEL: construct()
 // OGCG: %[[WC_ALLOCA:.*]] = alloca %struct.WithCtor

--- a/clang/test/CIR/CodeGen/anonymous-nested-init.c
+++ b/clang/test/CIR/CodeGen/anonymous-nested-init.c
@@ -1,0 +1,48 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
+
+// Globals whose layout includes anonymous nested aggregates. The constant
+// emitter has to recurse into the anonymous record's CIR layout and produce a
+// nested const_record whose member list matches that anonymous record's CIR
+// type.
+
+// Anonymous struct as a field.
+struct StructWithAnon {
+  struct { int x; int y; } inner;
+  int z;
+};
+struct StructWithAnon g_anon_struct = { {1, 2}, 3 };
+
+// CIR: cir.global external @g_anon_struct
+// CIR-SAME: #cir.int<1> : !s32i, #cir.int<2> : !s32i
+// CIR-SAME: #cir.int<3> : !s32i
+// LLVM: @g_anon_struct ={{.*}}i32 1, i32 2{{.*}}i32 3
+// OGCG: @g_anon_struct ={{.*}}i32 1, i32 2{{.*}}i32 3
+
+// Anonymous union as a field, initialized via designator.  Because CIR's
+// UnionType carries a single storage member at the LLVM level, the active
+// float value is encoded as the bit-equivalent integer (0x3FC00000 = 1.5f).
+struct StructWithAnonUnion {
+  union { int i; float f; } u;
+  int n;
+};
+struct StructWithAnonUnion g_anon_union = { {.f = 1.5f}, 42 };
+
+// LLVM: @g_anon_union ={{.*}}i32 1069547520{{.*}}i32 42
+// OGCG: @g_anon_union ={{.*}}float 1.500000e+00{{.*}}i32 42
+
+// Anonymous struct holding bitfields, surrounded by a regular field.
+struct StructWithAnonBitfields {
+  int leading;
+  struct { unsigned a : 4; unsigned b : 4; } bits;
+  int trailing;
+};
+struct StructWithAnonBitfields g_anon_bits = { 7, {0xA, 0x5}, 9 };
+
+// a=0xA in bits[0..3], b=0x5 in bits[4..7] -> packed = 0x5A = 90.
+// LLVM: @g_anon_bits ={{.*}}i32 7{{.*}}i8 90{{.*}}i32 9
+// OGCG: @g_anon_bits ={{.*}}i32 7{{.*}}i8 90{{.*}}i32 9

--- a/clang/test/CIR/CodeGen/array.cpp
+++ b/clang/test/CIR/CodeGen/array.cpp
@@ -52,9 +52,9 @@ int dd[3][2] = {{1, 2}, {3, 4}, {5, 6}};
 // OGCG: [i32 3, i32 4], [2 x i32] [i32 5, i32 6]]
 
 int e[10] = {1, 2};
-// CIR: cir.global external @e = #cir.const_record<{#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.zero : !cir.array<!s32i x 8>}> : !rec_anon_struct
+// CIR: cir.global external @e = #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i], trailing_zeros> : !cir.array<!s32i x 10>
 
-// LLVM: @e = global <{ i32, i32, [8 x i32] }> <{ i32 1, i32 2, [8 x i32] zeroinitializer }>
+// LLVM: @e = global [10 x i32] [i32 1, i32 2, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0]
 
 // OGCG: @e = global <{ i32, i32, [8 x i32] }> <{ i32 1, i32 2, [8 x i32] zeroinitializer }>
 
@@ -66,21 +66,11 @@ int f[5] = {1, 2};
 // OGCG: @f = global [5 x i32] [i32 1, i32 2, i32 0, i32 0, i32 0]
 
 int g[16] = {1, 2, 3, 4, 5, 6, 7, 8};
-// CIR:      cir.global external @g = #cir.const_record<{
-// CIR-SAME:   #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i,
-// CIR-SAME:                     #cir.int<3> : !s32i, #cir.int<4> : !s32i,
-// CIR-SAME:                     #cir.int<5> : !s32i, #cir.int<6> : !s32i,
-// CIR-SAME:                     #cir.int<7> : !s32i, #cir.int<8> : !s32i]>
-// CIR-SAME:                     : !cir.array<!s32i x 8>,
-// CIR-SAME:   #cir.zero : !cir.array<!s32i x 8>}> : !rec_anon_struct1
+// CIR: cir.global external @g = #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i, #cir.int<4> : !s32i, #cir.int<5> : !s32i, #cir.int<6> : !s32i, #cir.int<7> : !s32i, #cir.int<8> : !s32i], trailing_zeros> : !cir.array<!s32i x 16>
 
-// LLVM:       @g = global <{ [8 x i32], [8 x i32] }> 
-// LLVM-SAME:          <{ [8 x i32]
-// LLVM-SAME:              [i32 1, i32 2, i32 3, i32 4,
-// LLVM-SAME:               i32 5, i32 6, i32 7, i32 8],
-// LLVM-SAME:             [8 x i32] zeroinitializer }>
+// LLVM: @g = global [16 x i32] [i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0]
 
-// OGCG:       @g = global <{ [8 x i32], [8 x i32] }> 
+// OGCG:       @g = global <{ [8 x i32], [8 x i32] }>
 // OGCG-SAME:          <{ [8 x i32]
 // OGCG-SAME:              [i32 1, i32 2, i32 3, i32 4,
 // OGCG-SAME:               i32 5, i32 6, i32 7, i32 8],
@@ -90,19 +80,9 @@ int g[16] = {1, 2, 3, 4, 5, 6, 7, 8};
 // a zero initializer array.
 int h[16] = {1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0};
 
-// CIR:      cir.global external @h = #cir.const_record<{
-// CIR-SAME:   #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i,
-// CIR-SAME:                     #cir.int<3> : !s32i, #cir.int<4> : !s32i,
-// CIR-SAME:                     #cir.int<5> : !s32i, #cir.int<6> : !s32i,
-// CIR-SAME:                     #cir.int<7> : !s32i, #cir.int<8> : !s32i]>
-// CIR-SAME:                     : !cir.array<!s32i x 8>,
-// CIR-SAME:   #cir.zero : !cir.array<!s32i x 8>}> : !rec_anon_struct1
+// CIR: cir.global external @h = #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i, #cir.int<4> : !s32i, #cir.int<5> : !s32i, #cir.int<6> : !s32i, #cir.int<7> : !s32i, #cir.int<8> : !s32i], trailing_zeros> : !cir.array<!s32i x 16>
 
-// LLVM:       @h = global <{ [8 x i32], [8 x i32] }>
-// LLVM-SAME:          <{ [8 x i32]
-// LLVM-SAME:              [i32 1, i32 2, i32 3, i32 4,
-// LLVM-SAME:               i32 5, i32 6, i32 7, i32 8],
-// LLVM-SAME:             [8 x i32] zeroinitializer }>
+// LLVM: @h = global [16 x i32] [i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0]
 
 // OGCG:       @h = global <{ [8 x i32], [8 x i32] }>
 // OGCG-SAME:          <{ [8 x i32]

--- a/clang/test/CIR/CodeGen/bitfield-init-values.c
+++ b/clang/test/CIR/CodeGen/bitfield-init-values.c
@@ -1,0 +1,46 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
+
+// Pin down the packed value of bitfield-bearing globals across the whole
+// emission path. The CIR record layout collapses contiguous bitfields into a
+// single storage member, and the constant initializer must agree on both the
+// packed integer value and the placement of any non-bitfield fields.
+
+// Two unsigned bitfields packed into one byte: a=0b101 in bits[0..2], b=0b01111
+// in bits[3..7]. Packed value = 0b01111101 = 125.
+struct B1 { unsigned int a : 3; unsigned int b : 5; };
+struct B1 b1 = { 0b101, 0b01111 };
+
+// CIR: cir.global external @b1 = #cir.const_record<{#cir.int<125> : !u8i,
+// LLVM: @b1 ={{.*}}i8 125
+// OGCG: @b1 ={{.*}}i8 125
+
+// Byte-aligned bitfields packed into a single 32-bit storage word: a=0xAA in
+// bits[0..7], b=0xBB in bits[8..15], c=0xCCDD in bits[16..31]. Packed value
+// (little-endian) is 0xCCDDBBAA = -857883734 as i32.
+struct B2 { unsigned int a : 8; unsigned int b : 8; unsigned int c : 16; };
+struct B2 b2 = { 0xAA, 0xBB, 0xCCDD };
+
+// LLVM: @b2 ={{.*}}i32 -857883734
+// OGCG: @b2 ={{.*}}i8 -86, i8 -69, i8 -35, i8 -52
+
+// Bitfield storage followed by an alignment gap and a non-bitfield field.
+// a=1 (bits[0..2]), b=2 (bits[3..7]) -> packed = 0b00010001 = 17.
+// Then c=99 at byte offset 4.
+struct BP { unsigned int a : 3; unsigned int b : 5; int c; };
+struct BP bp = { 1, 2, 99 };
+
+// LLVM: @bp ={{.*}}i8 17,{{.*}}i32 99
+// OGCG: @bp ={{.*}}i8 17,{{.*}}i32 99
+
+// Signed bitfields. a = -1 (4 bits) = 0b1111; b = 3 (4 bits) = 0b0011.
+// Packed little-endian into one byte: 0b00111111 = 63.
+struct BS { int a : 4; int b : 4; };
+struct BS bs = { -1, 3 };
+
+// LLVM: @bs ={{.*}}i8 63
+// OGCG: @bs ={{.*}}i8 63

--- a/clang/test/CIR/CodeGen/constant-inits.cpp
+++ b/clang/test/CIR/CodeGen/constant-inits.cpp
@@ -101,15 +101,14 @@ void function() {
     constexpr static mixed_partial_bitfields p_bf3 = {1, 0, 1, 15};
 }
 
-// Anonymous struct type definitions for bitfields
-// CIR-DAG: !rec_anon_struct = !cir.struct<{!u8i, !u8i, !u8i, !u8i}>
-// CIR-DAG: !rec_anon_struct1 = !cir.struct<{!u8i, !u8i, !cir.array<!u8i x 2>}>
+// (No anon-struct type alias needed; const_records use the named record
+// types directly.)
 
 // CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE1e = #cir.zero : !rec_empty
 // CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE1s = #cir.const_record<{#cir.int<0> : !s32i, #cir.int<-1> : !s32i}> : !rec_simple
 // CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE2p1 = #cir.const_record<{#cir.int<10> : !s32i, #cir.int<20> : !s32i, #cir.const_array<[#cir.int<99> : !s8i, #cir.int<88> : !s8i, #cir.int<77> : !s8i]> : !cir.array<!s8i x 3>, #cir.int<40> : !s32i}> : !rec_Point
 // CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE2p2 = #cir.const_record<{#cir.int<123> : !s8i, #cir.int<456> : !s32i}> : !rec_packed
-// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE3paa = #cir.const_record<{#cir.int<1> : !s16i, #cir.int<2> : !s8i, #cir.fp<3.000000e+00> : !cir.float, #cir.zero : !u8i}> : !rec_packed_and_aligned
+// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE3paa = #cir.const_record<{#cir.int<1> : !s16i, #cir.int<2> : !s8i, #cir.fp<3.000000e+00> : !cir.float, #cir.int<0> : !u8i}> : !rec_packed_and_aligned
 
 // CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE5array = #cir.const_array<[
 // CIR-DAG-SAME:   #cir.const_record<{#cir.int<123> : !s32i, #cir.int<456> : !s32i, #cir.const_array<[#cir.int<11> : !s8i, #cir.int<22> : !s8i, #cir.int<33> : !s8i]> : !cir.array<!s8i x 3>, #cir.int<789> : !s32i}> : !rec_Point
@@ -132,32 +131,15 @@ void function() {
 // CIR-DAG-SAME:   #cir.zero : !rec_packed_and_aligned
 // CIR-DAG-SAME: ]> : !cir.array<!rec_packed_and_aligned x 2>
 
-// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE6ba_bf1 = #cir.const_record<{
-// CIR-DAG-SAME:   #cir.int<255> : !u8i,
-// CIR-DAG-SAME:   #cir.int<170> : !u8i,
-// CIR-DAG-SAME:   #cir.int<52> : !u8i,
-// CIR-DAG-SAME:   #cir.int<18> : !u8i
-// CIR-DAG-SAME: }> : !rec_anon_struct
-// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE6ba_bf2 = #cir.const_record<{
-// CIR-DAG-SAME:   #cir.int<255> : !u8i,
-// CIR-DAG-SAME:   #cir.int<127> : !u8i,
-// CIR-DAG-SAME:   #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 2>
-// CIR-DAG-SAME: }> : !rec_anon_struct1
-// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE6ba_bf3 = #cir.const_record<{
-// CIR-DAG-SAME:   #cir.int<42> : !u8i
-// CIR-DAG-SAME: }> : !rec_single_byte_bitfield
-// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE5p_bf1 = #cir.const_record<{
-// CIR-DAG-SAME:   #cir.int<17> : !u8i,
-// CIR-DAG-SAME:   #cir.int<3> : !u8i,
-// CIR-DAG-SAME:   #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 2>
-// CIR-DAG-SAME: }> : !rec_anon_struct1
-// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE5p_bf2 = #cir.const_record<{
-// CIR-DAG-SAME:   #cir.int<127> : !u8i,
-// CIR-DAG-SAME:   #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 3>
-// CIR-DAG-SAME: }> : !rec_signed_partial_bitfields
-// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE5p_bf3 = #cir.const_record<{
-// CIR-DAG-SAME:   #cir.int<125> : !u8i
-// CIR-DAG-SAME: }> : !rec_mixed_partial_bitfields
+// Bitfields are packed into their CIR storage member as a single integer of
+// the storage type, so the const_record holds one IntAttr per storage member
+// plus any explicit trailing padding the layout already had.
+// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE6ba_bf1 = #cir.const_record<{#cir.int<305441535> : !u32i}> : !rec_byte_aligned_bitfields
+// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE6ba_bf2 = #cir.const_record<{#cir.int<32767> : !u16i, #cir.zero : !cir.array<!u8i x 2>}> : !rec_signed_byte_aligned_bitfields
+// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE6ba_bf3 = #cir.const_record<{#cir.int<42> : !u8i}> : !rec_single_byte_bitfield
+// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE5p_bf1 = #cir.const_record<{#cir.int<785> : !u16i, #cir.zero : !cir.array<!u8i x 2>}> : !rec_partial_bitfields
+// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE5p_bf2 = #cir.const_record<{#cir.int<127> : !u8i, #cir.zero : !cir.array<!u8i x 3>}> : !rec_signed_partial_bitfields
+// CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE5p_bf3 = #cir.const_record<{#cir.int<125> : !u8i}> : !rec_mixed_partial_bitfields
 
 // CIR-LABEL: cir.func {{.*}} @_Z8functionv()
 // CIR:   cir.return
@@ -172,10 +154,10 @@ void function() {
 // LLVM-DAG: @_ZZ8functionvE3paa = internal constant %struct.packed_and_aligned <{ i16 1, i8 2, float 3.000000e+00, i8 0 }>
 // LLVM-DAG: @_ZZ8functionvE5array = internal constant [2 x %struct.Point] [%struct.Point { i32 123, i32 456, [3 x i8] c"\0B\16!", i32 789 }, %struct.Point { i32 10, i32 20, [3 x i8] zeroinitializer, i32 40 }]
 // LLVM-DAG: @_ZZ8functionvE9paa_array = internal constant [2 x %struct.packed_and_aligned] [%struct.packed_and_aligned <{ i16 1, i8 2, float 3.000000e+00, i8 0 }>, %struct.packed_and_aligned zeroinitializer]
-// LLVM-DAG: @_ZZ8functionvE6ba_bf1 = internal constant { i8, i8, i8, i8 } { i8 -1, i8 -86, i8 52, i8 18 }
-// LLVM-DAG: @_ZZ8functionvE6ba_bf2 = internal constant { i8, i8, [2 x i8] } { i8 -1, i8 127, [2 x i8] zeroinitializer }
+// LLVM-DAG: @_ZZ8functionvE6ba_bf1 = internal constant %struct.byte_aligned_bitfields { i32 305441535 }
+// LLVM-DAG: @_ZZ8functionvE6ba_bf2 = internal constant %struct.signed_byte_aligned_bitfields { i16 32767, [2 x i8] zeroinitializer }
 // LLVM-DAG: @_ZZ8functionvE6ba_bf3 = internal constant %struct.single_byte_bitfield { i8 42 }
-// LLVM-DAG: @_ZZ8functionvE5p_bf1 = internal constant { i8, i8, [2 x i8] } { i8 17, i8 3, [2 x i8] zeroinitializer }
+// LLVM-DAG: @_ZZ8functionvE5p_bf1 = internal constant %struct.partial_bitfields { i16 785, [2 x i8] zeroinitializer }
 // LLVM-DAG: @_ZZ8functionvE5p_bf2 = internal constant %struct.signed_partial_bitfields { i8 127, [3 x i8] zeroinitializer }
 // LLVM-DAG: @_ZZ8functionvE5p_bf3 = internal constant %struct.mixed_partial_bitfields { i8 125 }
 

--- a/clang/test/CIR/CodeGen/cross-reference-globals.c
+++ b/clang/test/CIR/CodeGen/cross-reference-globals.c
@@ -1,0 +1,75 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
+
+// Globals whose initializer takes the address of *another* global at a
+// non-zero offset. The risk we are guarding against: when the referenced
+// global's symType changes after its initializer is built (e.g. logical CIR
+// record type swapped for an anon storage record), any GlobalViewAttr indices
+// computed against the old type become stale and the resulting GEP lands on
+// the wrong byte.
+
+// Case 1: scalar -> scalar. Smoke test, no struct typing involved.
+extern int b1;
+int *a1 = &b1;
+int b1 = 100;
+
+// CIR-LABEL: cir.global external @a1
+// CIR-SAME: #cir.global_view<@b1> : !cir.ptr<!s32i>
+// LLVM: @a1 ={{.*}}ptr @b1
+// OGCG: @a1 ={{.*}}ptr @b1
+
+// Case 2: pointer into the interior of a later-emitted struct with an empty
+// struct field. Tentative-definition ordering causes this one to "accidentally"
+// work today because b2 gets emitted before a2, so a2 sees b2's final type.
+struct E2 {};
+struct B2 { struct E2 e; int x; int y; };
+extern struct B2 b2;
+int *a2 = &b2.y;
+struct B2 b2 = { {}, 10, 20 };
+
+// LLVM: @a2 ={{.*}}getelementptr {{(inbounds nuw )?}}(i8, ptr @b2, i64 4)
+// OGCG: @a2 ={{.*}}getelementptr {{(inbounds )?}}(i8, ptr @b2, i64 4)
+
+// Case 3: pointer into a struct whose layout has an alignment-induced padding
+// gap. Currently CIR computes the GEP offset against the anon-with-padding
+// type of @b3 and lands on the padding bytes after `inner`, instead of inside
+// `inner`. Reproduces the same type-swap mechanism as the self-reference 714
+// case, applied across two globals.
+struct E3 {};
+struct In3 { int u, v; };
+struct B3 {
+  struct E3 e;
+  int x;
+  struct In3 inner;
+  int *self;             // forces 4 bytes alignment padding before self
+};
+extern struct B3 b3;
+int *a3 = &b3.inner.v;
+struct B3 b3 = { .x = 7, .self = (int *)&b3 };
+
+// LLVM: @a3 ={{.*}}getelementptr {{(inbounds nuw )?}}(i8, ptr @b3, i64 8)
+// OGCG: @a3 ={{.*}}getelementptr {{(inbounds )?}}(i8, ptr @b3, i64 8)
+
+// Case 4: forward reference order — a is fully built before b's init runs, so
+// any indices into b are necessarily captured against b's pre-init logical
+// type. After b's const_record swaps b's symType to an anon storage record,
+// the indices in a are stale.
+struct E4 {};
+struct In4 { int p, q; };
+struct B4 {
+  struct E4 e;
+  int x;
+  struct In4 inner;
+  int *self;
+};
+extern struct B4 b4_fwd;
+struct A4 { int *target; };
+struct A4 a4 = { .target = &b4_fwd.inner.q };
+struct B4 b4_fwd = { .x = 11, .self = (int *)&b4_fwd };
+
+// LLVM: @a4 ={{.*}}getelementptr {{(inbounds nuw )?}}(i8, ptr @b4_fwd, i64 8)
+// OGCG: @a4 ={{.*}}getelementptr {{(inbounds )?}}(i8, ptr @b4_fwd, i64 8)

--- a/clang/test/CIR/CodeGen/global-dtor-union-narrowed.cpp
+++ b/clang/test/CIR/CodeGen/global-dtor-union-narrowed.cpp
@@ -20,21 +20,19 @@ struct S {
 
 S g;
 
-// The dtor region must bitcast `@g`'s narrowed pointer back to `!rec_S`
-// before the dtor call.
+// With the layout-driven const_record path, @g keeps its logical !rec_S
+// type, so no pointer narrowing/bitcast is needed.
 
 // CIR: !rec_S = !cir.struct<"S"
-// CIR: cir.global external @g = #cir.zero : ![[NARROW_TY:rec_anon_struct[0-9]*]] dtor {
-// CIR:   %[[ADDR:.+]] = cir.get_global @g : !cir.ptr<![[NARROW_TY]]>
-// CIR:   %[[CAST:.+]] = cir.cast bitcast %[[ADDR]] : !cir.ptr<![[NARROW_TY]]> -> !cir.ptr<!rec_S>
-// CIR:   cir.call @_ZN1SD2Ev(%[[CAST]]) : (!cir.ptr<!rec_S>) -> ()
+// CIR: cir.global external @g = ctor : !rec_S {
+// CIR:   %[[GET_GLOB:.+]] = cir.get_global @g : !cir.ptr<!rec_S>
+// CIR:   cir.call @_ZN1SC2Ev(%[[GET_GLOB]])
 // CIR: }
 
-// LLVM: @g = global { { { [16 x i8] } } } zeroinitializer
-// LLVM: define internal void @__cxx_global_array_dtor(ptr noundef %[[A0:.*]])
-// LLVM:   call void @_ZN1SD2Ev(ptr %[[A0]])
+// LLVM: @g = global %struct.S zeroinitializer
 // LLVM: define internal void @__cxx_global_var_init()
-// LLVM:   call void @__cxa_atexit(ptr @__cxx_global_array_dtor, ptr @g, ptr @__dso_handle)
+// LLVM:   call void @_ZN1SC2Ev(ptr {{.*}}@g)
+// LLVM:   call void @__cxa_atexit(ptr @_ZN1SD2Ev, ptr @g, ptr @__dso_handle)
 
 // OGCG: @g = global { { { [16 x i8] } } } zeroinitializer
 // OGCG: define internal void @__cxx_global_var_init()

--- a/clang/test/CIR/CodeGen/lambda.cpp
+++ b/clang/test/CIR/CodeGen/lambda.cpp
@@ -13,7 +13,7 @@ void use_global_lambda() {
   global_lambda();
 }
 
-// CIR: cir.global "private" internal dso_local @global_lambda = #cir.undef : ![[REC_LAM_GLOBAL_LAMBDA:.*]] {alignment = 1 : i64}
+// CIR: cir.global "private" internal dso_local @global_lambda = #cir.zero : ![[REC_LAM_GLOBAL_LAMBDA:.*]] {alignment = 1 : i64}
 // CIR: cir.func {{.*}} lambda internal private dso_local @_ZNK3$_0clEv(%[[THIS_ARG:.*]]: !cir.ptr<![[REC_LAM_GLOBAL_LAMBDA]]> {{.*}})
 // CIR:   %[[THIS:.*]] = cir.alloca !cir.ptr<![[REC_LAM_GLOBAL_LAMBDA]]>, !cir.ptr<!cir.ptr<![[REC_LAM_GLOBAL_LAMBDA]]>>, ["this", init]
 // CIR:   cir.store %[[THIS_ARG]], %[[THIS]]
@@ -23,7 +23,7 @@ void use_global_lambda() {
 // CIR:   %[[LAMBDA:.*]] = cir.get_global @global_lambda : !cir.ptr<![[REC_LAM_GLOBAL_LAMBDA]]>
 // CIR:   cir.call @_ZNK3$_0clEv(%[[LAMBDA]]) : (!cir.ptr<![[REC_LAM_GLOBAL_LAMBDA]]> {llvm.align = 1 : i64, llvm.dereferenceable = 1 : i64, llvm.nonnull, llvm.noundef}) -> ()
 
-// LLVM: @global_lambda = internal global %[[REC_LAM_GLOBAL_LAMBDA:.*]] undef, align 1
+// LLVM: @global_lambda = internal global %[[REC_LAM_GLOBAL_LAMBDA:.*]] zeroinitializer, align 1
 // LLVM: define internal void @"_ZNK3$_0clEv"(ptr {{.*}} %[[THIS_ARG:.*]])
 // LLVM:   %[[THIS_ADDR:.*]] = alloca ptr
 // LLVM:   store ptr %[[THIS_ARG]], ptr %[[THIS_ADDR]]

--- a/clang/test/CIR/CodeGen/paren-list-agg-init.cpp
+++ b/clang/test/CIR/CodeGen/paren-list-agg-init.cpp
@@ -133,14 +133,16 @@ constexpr auto a2 = static_cast<A>('c');
 // LLVM-DAG: [[B1:@.*b1.*]] = internal constant [[STRUCT_B]] { [[STRUCT_A]] { i8 99, double 0.000000e+00 }, i32 0 }, align 8
 // CIR-DAG: cir.global "private" constant internal dso_local @_ZL2b1 = #cir.const_record<{#cir.const_record<{#cir.int<99> : !s8i, #cir.fp<0.000000e+00> : !cir.double}> : ![[STRUCT_A]], #cir.int<0> : !s32i}> : ![[STRUCT_B]] {alignment = 8 : i64}
 constexpr B b1(A('c'));
-// LLVM-DAG: [[C1:@.*c1.*]] = internal constant { [[STRUCT_A]], i32, [4 x i8], i8, double, i32 } { [[STRUCT_A]] { i8 99, double 0.000000e+00 }, i32 0, [4 x i8] {{.*}}, i8 3, double 2.000000e+00, i32 0 }, align
-// CIR-DAG: cir.global "private" constant internal dso_local @_ZL2c1 = #cir.const_record<{#cir.const_record<{#cir.int<99> : !s8i, #cir.fp<0.000000e+00> : !cir.double}> : ![[STRUCT_A]], #cir.int<0> : !s32i, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 4>, #cir.int<3> : !s8i, #cir.fp<2.000000e+00> : !cir.double, #cir.int<0> : !s32i}>
+// LLVMCIR-DAG: [[C1:@_ZL2c1]] = internal constant %struct.C <{ %struct.B { %struct.A { i8 99, double 0.000000e+00 }, i32 0 }, %struct.A { i8 3, double 2.000000e+00 }, i32 0, [4 x i8] zeroinitializer }>, align 8
+// OGCG-DAG:    [[C1:@_ZL2c1]] = internal constant { %struct.A, i32, [4 x i8], i8, double, i32 } { %struct.A { i8 99, double 0.000000e+00 }, i32 0, [4 x i8] undef, i8 3, double 2.000000e+00, i32 0 }, align 8
+// CIR-DAG: cir.global "private" constant internal dso_local @_ZL2c1 = #cir.const_record<{#cir.const_record<{#cir.const_record<{#cir.int<99> : !s8i, #cir.fp<0.000000e+00> : !cir.double}> : ![[STRUCT_A]], #cir.int<0> : !s32i}> : ![[STRUCT_B]], #cir.const_record<{#cir.int<3> : !s8i, #cir.fp<2.000000e+00> : !cir.double}> : ![[STRUCT_A]], #cir.int<0> : !s32i, #cir.zero : !cir.array<!u8i x 4>}>
 constexpr C c1(b1, a1);
 // LLVM-DAG: [[U1:@.*]] = internal constant {{.*}} { [[STRUCT_A]] { i8 1, double 1.000000e+00 } }, align 8
 // CIR-DAG: cir.global "private" constant internal dso_local @_ZL2u1 = #cir.const_record<{#cir.const_record<{#cir.int<1> : !s8i, #cir.fp<1.000000e+00> : !cir.double}> : ![[STRUCT_A]]}> : !{{.*}}{alignment = 8 : i64}
 constexpr U u1(A(1, 1));
-// LLVM-DAG: [[D1:@.*d1.*]] = internal constant { [[STRUCT_A]], [[STRUCT_A]], [8 x i8], [[STRUCT_A]] } { [[STRUCT_A]] { i8 2, double 2.000000e+00 }, [[STRUCT_A]] { i8 2, double 2.000000e+00 }, [8 x i8] {{.*}}, [[STRUCT_A]] zeroinitializer }, align 8
-// CIR-DAG: cir.global "private" constant internal dso_local @_ZL2d1 = #cir.const_record<{#cir.const_record<{#cir.int<2> : !s8i, #cir.fp<2.000000e+00> : !cir.double}> : ![[STRUCT_A]], #cir.const_record<{#cir.int<2> : !s8i, #cir.fp<2.000000e+00> : !cir.double}> : ![[STRUCT_A]], #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 8>, #cir.zero : ![[STRUCT_A]]}>
+// LLVMCIR-DAG: [[D1:@_ZL2d1]] = internal constant %struct.D { %struct.A { i8 2, double 2.000000e+00 }, %struct.A { i8 2, double 2.000000e+00 }, i8 0, %struct.A zeroinitializer }, align 8
+// OGCG-DAG:    [[D1:@_ZL2d1]] = internal constant { %struct.A, %struct.A, [8 x i8], %struct.A } { %struct.A { i8 2, double 2.000000e+00 }, %struct.A { i8 2, double 2.000000e+00 }, [8 x i8] undef, %struct.A zeroinitializer }, align 8
+// CIR-DAG: cir.global "private" constant internal dso_local @_ZL2d1 = #cir.const_record<{#cir.const_record<{#cir.int<2> : !s8i, #cir.fp<2.000000e+00> : !cir.double}> : ![[STRUCT_A]], #cir.const_record<{#cir.int<2> : !s8i, #cir.fp<2.000000e+00> : !cir.double}> : ![[STRUCT_A]], #cir.int<0> : !u8i, #cir.zero : ![[STRUCT_A]]}>
 constexpr D d1(A(2, 2));
 // LLVM-DAG: [[ARR1:@.*arr1.*]] = internal constant [3 x i32] [i32 1, i32 2, i32 0], align 4
 // CIR-DAG: cir.global "private" constant internal dso_local @_ZL4arr1 = #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<0> : !s32i]> : !cir.array<!s32i x 3> {alignment = 4 : i64}
@@ -179,9 +181,8 @@ B foo2() {
 // LLVM: call void @llvm.memcpy.p0.p0.i64(ptr {{.*}}, ptr {{.*}}[[C1]], i64 48, i1 false)
 // CIR: cir.func {{.*}}@_Z4foo3v()
 // CIR: %[[C_ALLOCA:.*]] = cir.alloca ![[STRUCT_C]], !cir.ptr<![[STRUCT_C]]>, ["__retval"] {alignment = 8 : i64}
-// CIR: %[[GET_GLOB:.*]] = cir.get_global @_ZL2c1
-// CIR: %[[GLOB_CAST:.*]] = cir.cast bitcast %[[GET_GLOB]] : !cir.ptr<!{{.*}}> -> !cir.ptr<![[STRUCT_C]]>
-// CIR: cir.copy %[[GLOB_CAST]] to %[[C_ALLOCA]] : !cir.ptr<![[STRUCT_C]]>
+// CIR: %[[GET_GLOB:.*]] = cir.get_global @_ZL2c1 : !cir.ptr<![[STRUCT_C]]>
+// CIR: cir.copy %[[GET_GLOB]] to %[[C_ALLOCA]] : !cir.ptr<![[STRUCT_C]]>
 C foo3() {
   return c1;
 }
@@ -244,9 +245,8 @@ void foo4() {
 // LLVM-NEXT: call void @llvm.memcpy.p0.p0.i64(ptr {{.*}}[[RETVAL]], ptr {{.*}}[[U1]], i64 16, i1 false)
 // CIR-LABEL: cir.func no_inline dso_local @_Z4foo5v()
 // CIR:  %[[RET:.*]] = cir.alloca ![[UNION_U]], !cir.ptr<![[UNION_U]]>, ["__retval"] {alignment = 8 : i64}
-// CIR:  %[[GET_GLOB:.*]] = cir.get_global @_ZL2u1 : !cir.ptr<!{{.*}}>
-// CIR:  %[[GLOB_TO_U:.*]] = cir.cast bitcast %[[GET_GLOB]] : !cir.ptr<!{{.*}}> -> !cir.ptr<![[UNION_U]]>
-// CIR:  cir.copy %[[GLOB_TO_U]] to %[[RET]] : !cir.ptr<![[UNION_U]]>
+// CIR:  %[[GET_GLOB:.*]] = cir.get_global @_ZL2u1 : !cir.ptr<![[UNION_U]]>
+// CIR:  cir.copy %[[GET_GLOB]] to %[[RET]] : !cir.ptr<![[UNION_U]]>
 U foo5() {
   return u1;
 }
@@ -315,11 +315,10 @@ void foo7() {
 
 // LLVM: dso_local {{.*}}@{{.*foo8.*}}(
 // LLVM: call void @llvm.memcpy.p0.p0.i64(ptr {{.*}}, ptr {{.*}}[[D1]], i64 56, i1 false)
-// CIR-LABEL: cir.func no_inline dso_local @_Z4foo8v() 
+// CIR-LABEL: cir.func no_inline dso_local @_Z4foo8v()
 // CIR: %[[RET_ALLOCA:.*]] = cir.alloca ![[STRUCT_D]], !cir.ptr<![[STRUCT_D]]>, ["__retval"] {alignment = 8 : i64}
-// CIR: %[[GET_GLOB:.*]] = cir.get_global @_ZL2d1 :
-// CIR: %[[GLOB_CAST:.*]] = cir.cast bitcast %[[GET_GLOB]] : !cir.ptr<!{{.*}}> -> !cir.ptr<![[STRUCT_D]]>
-// CIR: cir.copy %[[GLOB_CAST]] to %[[RET_ALLOCA]] : !cir.ptr<![[STRUCT_D]]>
+// CIR: %[[GET_GLOB:.*]] = cir.get_global @_ZL2d1 : !cir.ptr<![[STRUCT_D]]>
+// CIR: cir.copy %[[GET_GLOB]] to %[[RET_ALLOCA]] : !cir.ptr<![[STRUCT_D]]>
 D foo8() {
   return d1;
 }

--- a/clang/test/CIR/CodeGen/partial-init-zero-fill.c
+++ b/clang/test/CIR/CodeGen/partial-init-zero-fill.c
@@ -1,0 +1,49 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
+
+// Globals where the brace-enclosed initializer covers fewer fields than the
+// record has. Per C semantics the omitted tail / hole is zero-initialized.
+// The constant emitter has to materialize those zeros in the const_record,
+// otherwise the resulting global has undef bytes where the standard requires
+// zero.
+
+// Trailing fields zero-initialized.
+struct PartialA { int a, b, c, d; };
+struct PartialA pa = { 1 };
+
+// CIR: cir.global external @pa
+// CIR-SAME: #cir.int<1> : !s32i
+// CIR-SAME: #cir.int<0> : !s32i
+// CIR-SAME: #cir.int<0> : !s32i
+// CIR-SAME: #cir.int<0> : !s32i
+// LLVM: @pa ={{.*}}i32 1, i32 0, i32 0, i32 0
+// OGCG: @pa ={{.*}}i32 1, i32 0, i32 0, i32 0
+
+// Partial init of a record with array and trailing scalar. Everything past
+// the first init slot must be zero.
+struct PartialB { int a; double arr[4]; char tail; };
+struct PartialB pb = { 7 };
+
+// LLVM: @pb ={{.*}}i32 7
+// LLVM-SAME: [4 x double] zeroinitializer
+// LLVM-SAME: i8 0
+// OGCG: @pb ={{.*}}i32 7
+// OGCG-SAME: [4 x double] zeroinitializer
+// OGCG-SAME: i8 0
+
+// Hole in the middle: designated init skips an interior aggregate field.
+// The skipped struct member must be zero-initialized in the const_record.
+struct InnerC { int x, y; };
+struct PartialC { int a; struct InnerC inner; int b; };
+struct PartialC pc = { .b = 99 };
+
+// LLVM: @pc ={{.*}}i32 0
+// LLVM-SAME: zeroinitializer
+// LLVM-SAME: i32 99
+// OGCG: @pc ={{.*}}i32 0
+// OGCG-SAME: zeroinitializer
+// OGCG-SAME: i32 99

--- a/clang/test/CIR/CodeGen/record-zero-init-padding.c
+++ b/clang/test/CIR/CodeGen/record-zero-init-padding.c
@@ -5,6 +5,11 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
 
+// CIR uses the logical CIR record type for the const_record; alignment-induced
+// padding bytes between fields are implicit (no separate padding member). OG
+// emits an anonymous struct with explicit padding members; the resulting byte
+// content is the same.
+
 struct padding_after_field {
   char c;
   int i;
@@ -34,49 +39,18 @@ void test_zero_init_padding(void) {
   static const struct multiple_padding mp = {5, 10, 100};
 }
 
-// Type definitions for anonymous structs with padding
-// CIR-DAG: !rec_anon_struct = !cir.struct<{!s8i, !u8i, !s16i, !cir.array<!u8i x 4>, !s64i}>
-// CIR-DAG: !rec_anon_struct1 = !cir.struct<{!s32i, !s8i, !cir.array<!u8i x 3>}>
-// CIR-DAG: !rec_anon_struct2 = !cir.struct<{!u8i, !cir.array<!u8i x 3>, !s32i}>
-// CIR-DAG: !rec_anon_struct3 = !cir.struct<{!s8i, !cir.array<!u8i x 3>, !s32i}>
-
-// paf: char + 3 bytes padding + int -> uses !rec_anon_struct3
-// CIR-DAG: cir.global "private" constant internal dso_local @test_zero_init_padding.paf = #cir.const_record<{
-// CIR-DAG-SAME:   #cir.int<1> : !s8i,
-// CIR-DAG-SAME:   #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 3>,
-// CIR-DAG-SAME:   #cir.int<42> : !s32i
-// CIR-DAG-SAME: }> : !rec_anon_struct3
-
-// bfp: unsigned bitfield byte + 3 bytes padding + int -> uses !rec_anon_struct2
-// CIR-DAG: cir.global "private" constant internal dso_local @test_zero_init_padding.bfp = #cir.const_record<{
-// CIR-DAG-SAME:   #cir.int<17> : !u8i,
-// CIR-DAG-SAME:   #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 3>,
-// CIR-DAG-SAME:   #cir.int<99> : !s32i
-// CIR-DAG-SAME: }> : !rec_anon_struct2
-
-// tp: int + char + 3 bytes tail padding -> uses !rec_anon_struct1
-// CIR-DAG: cir.global "private" constant internal dso_local @test_zero_init_padding.tp = #cir.const_record<{
-// CIR-DAG-SAME:   #cir.int<10> : !s32i,
-// CIR-DAG-SAME:   #cir.int<20> : !s8i,
-// CIR-DAG-SAME:   #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 3>
-// CIR-DAG-SAME: }> : !rec_anon_struct1
-
-// mp: char + 1 byte padding + short + 4 bytes padding + long long -> uses !rec_anon_struct
-// CIR-DAG: cir.global "private" constant internal dso_local @test_zero_init_padding.mp = #cir.const_record<{
-// CIR-DAG-SAME:   #cir.int<5> : !s8i,
-// CIR-DAG-SAME:   #cir.zero : !u8i,
-// CIR-DAG-SAME:   #cir.int<10> : !s16i,
-// CIR-DAG-SAME:   #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 4>,
-// CIR-DAG-SAME:   #cir.int<100> : !s64i
-// CIR-DAG-SAME: }> : !rec_anon_struct
+// CIR-DAG: cir.global "private" constant internal dso_local @test_zero_init_padding.paf = #cir.const_record<{#cir.int<1> : !s8i, #cir.int<42> : !s32i}> : !rec_padding_after_field
+// CIR-DAG: cir.global "private" constant internal dso_local @test_zero_init_padding.bfp = #cir.const_record<{#cir.int<17> : !u8i, #cir.int<99> : !s32i}> : !rec_bitfield_with_padding
+// CIR-DAG: cir.global "private" constant internal dso_local @test_zero_init_padding.tp = #cir.const_record<{#cir.int<10> : !s32i, #cir.int<20> : !s8i}> : !rec_tail_padding
+// CIR-DAG: cir.global "private" constant internal dso_local @test_zero_init_padding.mp = #cir.const_record<{#cir.int<5> : !s8i, #cir.int<10> : !s16i, #cir.int<100> : !s64i}> : !rec_multiple_padding
 
 // CIR-LABEL: cir.func {{.*}}@test_zero_init_padding
 // CIR:   cir.return
 
-// LLVM-DAG: @test_zero_init_padding.paf = internal constant { i8, [3 x i8], i32 } { i8 1, [3 x i8] zeroinitializer, i32 42 }
-// LLVM-DAG: @test_zero_init_padding.bfp = internal constant { i8, [3 x i8], i32 } { i8 17, [3 x i8] zeroinitializer, i32 99 }
-// LLVM-DAG: @test_zero_init_padding.tp = internal constant { i32, i8, [3 x i8] } { i32 10, i8 20, [3 x i8] zeroinitializer }
-// LLVM-DAG: @test_zero_init_padding.mp = internal constant { i8, i8, i16, [4 x i8], i64 } { i8 5, i8 0, i16 10, [4 x i8] zeroinitializer, i64 100 }
+// LLVM-DAG: @test_zero_init_padding.paf = internal constant %struct.padding_after_field { i8 1, i32 42 }
+// LLVM-DAG: @test_zero_init_padding.bfp = internal constant %struct.bitfield_with_padding { i8 17, i32 99 }
+// LLVM-DAG: @test_zero_init_padding.tp = internal constant %struct.tail_padding { i32 10, i8 20 }
+// LLVM-DAG: @test_zero_init_padding.mp = internal constant %struct.multiple_padding { i8 5, i16 10, i64 100 }
 
 // LLVM-LABEL: define{{.*}} void @test_zero_init_padding
 // LLVM:   ret void

--- a/clang/test/CIR/CodeGen/replace-global.cpp
+++ b/clang/test/CIR/CodeGen/replace-global.cpp
@@ -40,26 +40,25 @@ S gSMulti = {{0x50, 0x4B, 0x03, 0x04}};
 
 char *get_ptr_to_element() { return ptrToElement; }
 
-// CIR: cir.global {{.*}} @_ZL2gS = #cir.const_record<{#cir.const_record<{#cir.int<80> : !s8i, #cir.int<75> : !s8i, #cir.int<3> : !s8i, #cir.int<4> : !s8i, #cir.zero : !cir.array<!s8i x 24>}> : !rec_anon_struct}> : !rec_anon_struct1
+// CIR: cir.global {{.*}} @_ZL2gS = #cir.const_record<{#cir.const_array<[#cir.int<80> : !s8i, #cir.int<75> : !s8i, #cir.int<3> : !s8i, #cir.int<4> : !s8i], trailing_zeros> : !cir.array<!s8i x 28>}> : !rec_S
 // CIR: cir.global {{.*}} @ptrToS = #cir.global_view<@_ZL2gS> : !cir.ptr<!rec_S>
 
 // CIR: cir.func {{.*}} @_ZN1RC2Ev
-// CIR:   %[[GS_PTR:.*]] = cir.get_global @_ZL2gS : !cir.ptr<!rec_anon_struct1>
-// CIR:   %[[GS_AS_S:.*]] = cir.cast bitcast %[[GS_PTR]] : !cir.ptr<!rec_anon_struct1> -> !cir.ptr<!rec_S>
-// CIR:   %[[GS_AS_VOID:.*]] = cir.cast bitcast %[[GS_AS_S]] : !cir.ptr<!rec_S> -> !cir.ptr<!void>
+// CIR:   %[[GS_PTR:.*]] = cir.get_global @_ZL2gS : !cir.ptr<!rec_S>
+// CIR:   %[[GS_AS_VOID:.*]] = cir.cast bitcast %[[GS_PTR]] : !cir.ptr<!rec_S> -> !cir.ptr<!void>
 // CIR:   cir.call @_Z3usePv(%[[GS_AS_VOID]]) : (!cir.ptr<!void> {{.*}}) -> ()
 
 // Multi-index case: ptrToElement = &gSMulti.arr[5] produces a global_view with
 // multiple indices, exercising createNewGlobalView.
 // CIR: cir.global {{.*}} @gSMulti = #cir.const_record<
-// CIR: cir.global {{.*}} @ptrToElement = #cir.global_view<@gSMulti, [0, 4, 1]> : !cir.ptr<
+// CIR: cir.global {{.*}} @ptrToElement = #cir.global_view<@gSMulti, [0 : i32, 5 : i32]> : !cir.ptr<
 
 // CIR: cir.func {{.*}} @_Z15use_as_constantv()
 // CIR:   %[[PTR_TO_S:.*]] = cir.alloca !cir.ptr<!rec_S>, !cir.ptr<!cir.ptr<!rec_S>>, ["ptrToS", init, const]
 // CIR:   %[[GLOBAL_PTR:.*]] = cir.const #cir.global_view<@_ZL2gS> : !cir.ptr<!rec_S>
 // CIR:   cir.store{{.*}} %[[GLOBAL_PTR]], %[[PTR_TO_S]] : !cir.ptr<!rec_S>, !cir.ptr<!cir.ptr<!rec_S>>
 
-// LLVM: @_ZL2gS = internal global { <{ i8, i8, i8, i8, [24 x i8] }> } { <{ i8, i8, i8, i8, [24 x i8] }> <{ i8 80, i8 75, i8 3, i8 4, [24 x i8] zeroinitializer }> }, align 1
+// LLVM: @_ZL2gS = internal global %struct.S { [28 x i8] c"PK\03\04\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00" }, align 1
 // LLVM: @ptrToS = global ptr @_ZL2gS, align 8
 // LLVM: @gSMulti = global {{.*}} align 1
 // LLVM: @ptrToElement = global ptr getelementptr

--- a/clang/test/CIR/CodeGen/self-ref-temporaries.cpp
+++ b/clang/test/CIR/CodeGen/self-ref-temporaries.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o - | FileCheck %s --check-prefix=CIR
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o - | FileCheck %s --check-prefix=LLVM
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o - | FileCheck %s --check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o - | FileCheck %s --check-prefixes=LLVM,LLVMCIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o - | FileCheck %s --check-prefixes=LLVM,LLVMOG
 
   constexpr const int &normal = 42;
 // CIR: cir.global "private" constant external @_ZGR6normal_ = #cir.int<42> : !s32i
@@ -13,9 +13,10 @@ struct SelfRef {
   int ints[3] = {1, 2, 3};
 };
 constexpr const SelfRef &sr = SelfRef();
-// CIR: cir.global "private" constant external @_ZGR2sr_ = #cir.const_record<{#cir.global_view<@_ZGR2sr_, [1 : i32]> : !cir.ptr<!s32i>, #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i]> : !cir.array<!s32i x 3>}> 
+// CIR: cir.global "private" constant external @_ZGR2sr_ = #cir.const_record<{#cir.global_view<@_ZGR2sr_, [1 : i32]> : !cir.ptr<!s32i>, #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i]> : !cir.array<!s32i x 3>, #cir.zero : !cir.array<!u8i x 4>}>
 // CIR: cir.global constant external @sr = #cir.global_view<@_ZGR2sr_> : !cir.ptr<!rec_SelfRef>
-// LLVM: @_ZGR2sr_ = {{.*}}constant { ptr, [3 x i32] } { ptr getelementptr {{.*}}(i8, ptr @_ZGR2sr_, i64 8), [3 x i32] [i32 1, i32 2, i32 3] }, align 8
+// LLVMCIR: @_ZGR2sr_ = {{.*}}constant %struct.SelfRef <{ ptr getelementptr inbounds nuw (i8, ptr @_ZGR2sr_, i64 8), [3 x i32] [i32 1, i32 2, i32 3], [4 x i8] zeroinitializer }>, align 8
+// LLVMOG: @_ZGR2sr_ = {{.*}}constant { ptr, [3 x i32] } { ptr getelementptr (i8, ptr @_ZGR2sr_, i64 8), [3 x i32] [i32 1, i32 2, i32 3] }, align 8
 // LLVM: @sr = constant ptr @_ZGR2sr_, align 8
 
 struct MultiSelfRef {
@@ -25,8 +26,9 @@ struct MultiSelfRef {
 };
 
 constexpr const MultiSelfRef &msr = MultiSelfRef();
-// CIR: cir.global "private" constant external @_ZGR3msr_ = #cir.const_record<{#cir.global_view<@_ZGR3msr_, [2 : i32]> : !cir.ptr<!s32i>, #cir.global_view<@_ZGR3msr_, [2 : i32]> : !cir.ptr<!s32i>, #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i]> : !cir.array<!s32i x 3>}>
+// CIR: cir.global "private" constant external @_ZGR3msr_ = #cir.const_record<{#cir.global_view<@_ZGR3msr_, [2 : i32]> : !cir.ptr<!s32i>, #cir.global_view<@_ZGR3msr_, [2 : i32]> : !cir.ptr<!s32i>, #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i]> : !cir.array<!s32i x 3>, #cir.zero : !cir.array<!u8i x 4>}>
 // CIR: cir.global constant external @msr = #cir.global_view<@_ZGR3msr_> : !cir.ptr<!rec_MultiSelfRef>
-// LLVM: @_ZGR3msr_ = {{.*}}constant { ptr, ptr, [3 x i32] } { ptr getelementptr {{.*}}(i8, ptr @_ZGR3msr_, i64 16), ptr getelementptr {{.*}}(i8, ptr @_ZGR3msr_, i64 16), [3 x i32] [i32 1, i32 2, i32 3] }, align 8
+// LLVMCIR: @_ZGR3msr_ = {{.*}}constant %struct.MultiSelfRef <{ ptr getelementptr inbounds nuw (i8, ptr @_ZGR3msr_, i64 16), ptr getelementptr inbounds nuw (i8, ptr @_ZGR3msr_, i64 16), [3 x i32] [i32 1, i32 2, i32 3], [4 x i8] zeroinitializer }>, align 8
+// LLVMOG: @_ZGR3msr_ = {{.*}}constant { ptr, ptr, [3 x i32] } { ptr getelementptr (i8, ptr @_ZGR3msr_, i64 16), ptr getelementptr (i8, ptr @_ZGR3msr_, i64 16), [3 x i32] [i32 1, i32 2, i32 3] }, align 8
 // LLVM: @msr = constant ptr @_ZGR3msr_, align 8
 

--- a/clang/test/CIR/CodeGen/self-reference-globals.c
+++ b/clang/test/CIR/CodeGen/self-reference-globals.c
@@ -1,0 +1,83 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
+
+// Globals whose initializer contains the global's own address with a non-zero
+// byte offset. The correctness property under test is that the resulting GEP
+// (or CIR global_view index path) lands on the named byte, no matter how the
+// initializer's record-type representation is shaped.
+
+// Case 1: simple self-reference, no empty fields, no alignment padding.
+struct S1 { int x; int y; int *p; };
+struct S1 s1 = { 1, 2, &s1.y };
+
+// CIR-LABEL: cir.global external @s1
+// CIR-SAME: #cir.global_view<@s1, [1 : i32]> : !cir.ptr<!s32i>
+// LLVM: @s1 ={{.*}}getelementptr {{(inbounds nuw )?}}(i8, ptr @s1, i64 4)
+// OGCG: @s1 ={{.*}}getelementptr {{(inbounds )?}}(i8, ptr @s1, i64 4)
+
+// Case 2: self-reference through a nested struct member.
+struct Inner2 { int a; int b; };
+struct S2 { int x; struct Inner2 inner; int *p; };
+struct S2 s2 = { 10, {20, 30}, &s2.inner.b };
+
+// CIR-LABEL: cir.global external @s2
+// CIR-SAME: #cir.global_view<@s2, [1 : i32, 1 : i32]> : !cir.ptr<!s32i>
+// LLVM: @s2 ={{.*}}getelementptr {{(inbounds nuw )?}}(i8, ptr @s2, i64 8)
+// OGCG: @s2 ={{.*}}getelementptr {{(inbounds )?}}(i8, ptr @s2, i64 8)
+
+// Case 3: self-reference into an array element.
+struct S3 { int header; int arr[4]; int *p; };
+struct S3 s3 = { 100, {11, 22, 33, 44}, &s3.arr[2] };
+
+// CIR-LABEL: cir.global external @s3
+// CIR-SAME: #cir.global_view<@s3, [1 : i32, 2 : i32]> : !cir.ptr<!s32i>
+// LLVM: @s3 ={{.*}}getelementptr {{(inbounds nuw )?}}(i8, ptr @s3, i64 12)
+// OGCG: @s3 ={{.*}}getelementptr {{(inbounds )?}}(i8, ptr @s3, i64 12)
+
+// Case 4: empty struct field precedes the referenced field. The referenced
+// byte is at offset 0 (because the empty struct contributes no bytes).
+struct E4 {};
+struct S4 { struct E4 e; int x; int *p; };
+struct S4 s4 = { {}, 42, &s4.x };
+
+// CIR-LABEL: cir.global external @s4
+// CIR-SAME: #cir.global_view<@s4> : !cir.ptr<!s32i>
+// LLVM: @s4 ={{.*}}ptr @s4
+// OGCG: @s4 ={{.*}}ptr @s4
+
+// Case 5: empty struct field BEFORE the referenced field. Currently silently
+// miscompiles in CIR — the GEP lands on the wrong offset because the empty
+// struct filler shifts the structural indices used by global_view.
+struct E5 {};
+struct Inner5 { int x; };
+struct S5 { struct E5 e; int n; struct Inner5 inner; int *p; };
+struct S5 s5 = { .p = &s5.inner.x };
+
+// CIR-LABEL: cir.global external @s5
+// CIR-SAME: #cir.global_view<@s5, [1 : i32]> : !cir.ptr<!s32i>
+// LLVM: @s5 ={{.*}}getelementptr {{(inbounds nuw )?}}(i8, ptr @s5, i64 4)
+// OGCG: @s5 ={{.*}}getelementptr {{(inbounds )?}}(i8, ptr @s5, i64 4)
+
+// Case 6: empty struct fields PLUS alignment-induced padding. This is the
+// 714 reproducer pattern — currently crashes the CIR-to-LLVM lowering with
+// "type 'i32' cannot be indexed (index #2)".
+struct E6a {};
+struct E6b {};
+struct Inner6 { int a, b; };
+struct S6 {
+  struct E6a ea;
+  int x;
+  struct E6b eb;
+  struct Inner6 inner;
+  int *p;          // forces 4 bytes alignment padding before p
+};
+struct S6 s6 = { .x = 7, .p = &s6.inner.b };
+
+// CIR-LABEL: cir.global external @s6
+// CIR-SAME: #cir.global_view<@s6, [1 : i32, 1 : i32]> : !cir.ptr<!s32i>
+// LLVM: @s6 ={{.*}}getelementptr {{(inbounds nuw )?}}(i8, ptr @s6, i64 8)
+// OGCG: @s6 ={{.*}}getelementptr {{(inbounds )?}}(i8, ptr @s6, i64 8)

--- a/clang/test/CIR/CodeGen/struct-init.cpp
+++ b/clang/test/CIR/CodeGen/struct-init.cpp
@@ -19,8 +19,8 @@ BitfieldStruct overlapping_init = { 3, 2, 1 };
 // This is unintuitive. The bitfields are initialized using a struct of constants
 // that maps to the bitfields but splits the value into bytes.
 
-// CIR: cir.global external @overlapping_init = #cir.const_record<{#cir.int<35> : !u8i, #cir.int<0> : !u8i, #cir.int<4> : !u8i, #cir.int<0> : !u8i}> : !rec_anon_struct
-// LLVM: @overlapping_init = global { i8, i8, i8, i8 } { i8 35, i8 0, i8 4, i8 0 }
+// CIR: cir.global external @overlapping_init = #cir.const_record<{#cir.int<262179> : !u32i}> : !rec_BitfieldStruct
+// LLVM: @overlapping_init = global %struct.BitfieldStruct { i32 262179 }
 // OGCG: @overlapping_init = global { i8, i8, i8, i8 } { i8 35, i8 0, i8 4, i8 0 }
 
 struct S {
@@ -50,14 +50,14 @@ struct StructWithFieldInitFromConst {
 
 StructWithFieldInitFromConst swfifc = {};
 
-// CIR: cir.global external @swfifc = #cir.zero : !rec_anon_struct
-// LLVM: @swfifc = global { i8, i8, i32 } zeroinitializer, align 4
+// CIR: cir.global external @swfifc = #cir.zero : !rec_StructWithFieldInitFromConst
+// LLVM: @swfifc = global %struct.StructWithFieldInitFromConst zeroinitializer, align 4
 // OGCG: @swfifc = global { i8, i8, i32 } zeroinitializer, align 4
 
 StructWithFieldInitFromConst swfifc2 = { 2 };
 
-// CIR: cir.global external @swfifc2 = #cir.const_record<{#cir.int<2> : !u8i, #cir.int<0> : !u8i, #cir.int<2> : !s32i}> : !rec_anon_struct
-// LLVM: @swfifc2 = global { i8, i8, i32 } { i8 2, i8 0, i32 2 }, align 4
+// CIR: cir.global external @swfifc2 = #cir.const_record<{#cir.int<2> : !u16i, #cir.int<2> : !s32i}> : !rec_StructWithFieldInitFromConst
+// LLVM: @swfifc2 = global %struct.StructWithFieldInitFromConst { i16 2, i32 2 }, align 4
 // OGCG: @swfifc2 = global { i8, i8, i32 } { i8 2, i8 0, i32 2 }, align 4
 
 

--- a/clang/test/CIR/CodeGen/union-agg-init.c
+++ b/clang/test/CIR/CodeGen/union-agg-init.c
@@ -54,12 +54,11 @@ struct outer ret_outer() {
 
   // CIR-LABEL: ret_outer
   // CIR: %[[RET_ALLOCA:.*]] = cir.alloca !rec_outer, !cir.ptr<!rec_outer>, ["__retval", init]
-  // CIR: %[[BITCAST:.*]] = cir.cast bitcast %0 : !cir.ptr<!rec_outer> -> !cir.ptr<!{{.*}}>
-  // CIR: %[[RECORD:.*]] = cir.const #cir.const_record<{#cir.zero : !{{.*}}, #cir.int<1> : !s32i, #cir.const_array<[#cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i, #cir.zero : !u8i]> : !cir.array<!u8i x 4>}> 
-  // CIR: cir.store {{.*}}%[[RECORD]], %[[BITCAST]] 
+  // CIR: %[[CONST:.*]] = cir.get_global @__const.ret_outer.__retval : !cir.ptr<!rec_outer>
+  // CIR: cir.copy %[[CONST]] to %[[RET_ALLOCA]]
 
   // LLVM-LABEL: ret_outer
   // LLVM: %[[RET_ALLOCA:.*]] = alloca %struct.outer
-  // LLVMCIR: store { { i32, [4 x i8] }, i32, [4 x i8] } { { i32, [4 x i8] } zeroinitializer, i32 1, [4 x i8] zeroinitializer }, ptr %[[RET_ALLOCA]]
+  // LLVMCIR: call void @llvm.memcpy{{.*}}(ptr {{.*}}%[[RET_ALLOCA]], ptr {{.*}}@__const.ret_outer.__retval
   // OGCG: call void @llvm.memcpy{{.*}}(ptr{{.*}}%[[RET_ALLOCA]], ptr {{.*}}@__const.ret_outer.o, i64 16, i1 false)
 }

--- a/clang/test/CIR/CodeGenCXX/global-refs.cpp
+++ b/clang/test/CIR/CodeGenCXX/global-refs.cpp
@@ -1,8 +1,8 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -mmlir --mlir-print-ir-before=cir-lowering-prepare %s -o %t.cir 2> %t-before.cir
 // RUN: FileCheck %s --input-file=%t-before.cir --check-prefixes=CIR,CIR-BEFORE
 // RUN: FileCheck %s --input-file=%t.cir --check-prefixes=CIR,CIR-AFTER
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o - | FileCheck %s --check-prefixes=LLVM
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o - | FileCheck %s --check-prefixes=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o - | FileCheck %s --check-prefixes=LLVM,LLVMCIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o - | FileCheck %s --check-prefixes=LLVM,LLVMOG
 
 struct DefCtor{};
 struct WithCtor{
@@ -32,17 +32,19 @@ const int &constGlobalIntRef = 5;
 // LLVM: @constGlobalIntRef = constant ptr @_ZGR17constGlobalIntRef_, align 8
 
 DefCtor defCtor{};
-// CIR: cir.global external @defCtor = #cir.undef : !rec_DefCtor {alignment = 1 : i64}
-// LLVM: @defCtor = global %struct.DefCtor undef, align 1
+// CIR: cir.global external @defCtor = #cir.zero : !rec_DefCtor {alignment = 1 : i64}
+// LLVMCIR: @defCtor = global %struct.DefCtor zeroinitializer, align 1
+// LLVMOG: @defCtor = global %struct.DefCtor undef, align 1
 
 DefCtor &defCtorRef = defCtor;
 // CIR: cir.global constant external @defCtorRef = #cir.global_view<@defCtor> : !cir.ptr<!rec_DefCtor> {alignment = 8 : i64}
 // LLVM: @defCtorRef = constant ptr @defCtor, align 8
 
 const DefCtor &constDefCtorRef{};
-// CIR: cir.global "private" constant external @_ZGR15constDefCtorRef_ = #cir.undef : !rec_DefCtor {alignment = 1 : i64}
+// CIR: cir.global "private" constant external @_ZGR15constDefCtorRef_ = #cir.zero : !rec_DefCtor {alignment = 1 : i64}
 // CIR: cir.global constant external @constDefCtorRef = #cir.global_view<@_ZGR15constDefCtorRef_> : !cir.ptr<!rec_DefCtor> {alignment = 8 : i64}
-// LLVM: @_ZGR15constDefCtorRef_ = {{.*}}constant %struct.DefCtor undef, align 1
+// LLVMCIR: @_ZGR15constDefCtorRef_ = {{.*}}constant %struct.DefCtor zeroinitializer, align 1
+// LLVMOG: @_ZGR15constDefCtorRef_ = {{.*}}constant %struct.DefCtor undef, align 1
 // LLVM: @constDefCtorRef = constant ptr @_ZGR15constDefCtorRef_, align 8
 
 WithCtor withCtor{};

--- a/clang/test/CIR/CodeGenCXX/zero_init_bases.cpp
+++ b/clang/test/CIR/CodeGenCXX/zero_init_bases.cpp
@@ -1,8 +1,8 @@
 // RUN: %clang_cc1 %s -triple x86_64-apple-darwin10 -fclangir -emit-cir -fcxx-exceptions -fexceptions -mmlir --mlir-print-ir-before=cir-cxxabi-lowering -o %t.cir 2> %t-before.cir
 // RUN: FileCheck %s --input-file=%t-before.cir --check-prefixes=CIR,CIR-BEFORE
 // RUN: FileCheck %s --input-file=%t.cir --check-prefixes=CIR,CIR-AFTER
-// RUN: %clang_cc1 %s -triple x86_64-apple-darwin10 -fclangir -emit-llvm -fcxx-exceptions -fexceptions -o - | FileCheck %s --check-prefixes=LLVM
-// RUN: %clang_cc1 %s -triple x86_64-apple-darwin10 -emit-llvm -fcxx-exceptions -fexceptions -o - | FileCheck %s --check-prefixes=LLVM
+// RUN: %clang_cc1 %s -triple x86_64-apple-darwin10 -fclangir -emit-llvm -fcxx-exceptions -fexceptions -o - | FileCheck %s --check-prefixes=LLVM,LLVMCIR
+// RUN: %clang_cc1 %s -triple x86_64-apple-darwin10 -emit-llvm -fcxx-exceptions -fexceptions -o - | FileCheck %s --check-prefixes=LLVM,LLVMOG
 
 struct Base1 {
   int i, j, k;
@@ -37,8 +37,9 @@ Inherits I;
 // LLVM: @I = global %struct.Inherits zeroinitializer, align 4
 
 Inherits I2 {{1,2,3},{1.1, 2.2, 3.3}, 4, 5, 6};
-// CIR: cir.global external @I2 = #cir.const_record<{#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i, #cir.fp<1.100000e+00> : !cir.float, #cir.fp<2.200000e+00> : !cir.float, #cir.fp<3.300000e+00> : !cir.float, #cir.int<4> : !s32i, #cir.int<5> : !s32i, #cir.int<6> : !s32i}> : !rec_anon_struct {alignment = 4 : i64}
-// LLVM: @I2 = global { i32, i32, i32, float, float, float, i32, i32, i32 } { i32 1, i32 2, i32 3, float {{.*}}, float {{.*}}, float {{.*}}, i32 4, i32 5, i32 6 }, align 4
+// CIR: cir.global external @I2 = #cir.const_record<{#cir.const_record<{#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i}> : !rec_Base1, #cir.const_record<{#cir.fp<1.100000e+00> : !cir.float, #cir.fp<2.200000e+00> : !cir.float, #cir.fp<3.300000e+00> : !cir.float}> : !rec_Base2, #cir.int<4> : !s32i, #cir.int<5> : !s32i, #cir.int<6> : !s32i}> : !rec_Inherits {alignment = 4 : i64}
+// LLVMCIR: @I2 = global %struct.Inherits { %struct.Base1 { i32 1, i32 2, i32 3 }, %struct.Base2 { float 1.100000e+00, float 2.200000e+00, float 3.300000e+00 }, i32 4, i32 5, i32 6 }, align 4
+// LLVMOG: @I2 = global { i32, i32, i32, float, float, float, i32, i32, i32 } { i32 1, i32 2, i32 3, float 1.100000e+00, float 2.200000e+00, float 3.300000e+00, i32 4, i32 5, i32 6 }, align 4
 
 VirtualInherits VI;
 // CIR-BEFORE: cir.global external @VI = ctor : !rec_VirtualInherits {

--- a/clang/test/CIR/CodeGenOpenACC/compute-reduction-clause-default-ops.c
+++ b/clang/test/CIR/CodeGenOpenACC/compute-reduction-clause-default-ops.c
@@ -24,9 +24,8 @@ void acc_compute() {
 // CHECK: acc.reduction.recipe @reduction_add__ZTS16DefaultOperators : !cir.ptr<!rec_DefaultOperators> reduction_operator <add> init {
 // CHECK-NEXT: ^bb0(%[[ARG:.*]]: !cir.ptr<!rec_DefaultOperators>{{.*}})
 // CHECK-NEXT: %[[ALLOCA:.*]] = cir.alloca !rec_DefaultOperators, !cir.ptr<!rec_DefaultOperators>, ["openacc.reduction.init", init]
-// CHECK-NEXT: %[[BITCAST:.*]] = cir.cast bitcast %[[ALLOCA]] : !cir.ptr<!rec_DefaultOperators> -> !cir.ptr<!rec_anon_struct>
-// CHECK-NEXT: %[[ZERO:.*]] = cir.const #cir.zero : !rec_anon_struct
-// CHECK-NEXT: cir.store{{.*}} %[[ZERO]], %[[BITCAST]] : !rec_anon_struct, !cir.ptr<!rec_anon_struct>
+// CHECK-NEXT: %[[ZERO:.*]] = cir.const #cir.zero : !rec_DefaultOperators
+// CHECK-NEXT: cir.store{{.*}} %[[ZERO]], %[[ALLOCA]] : !rec_DefaultOperators, !cir.ptr<!rec_DefaultOperators>
 // CHECK-NEXT: acc.yield
 //
 // CHECK-NEXT: } combiner {
@@ -71,9 +70,8 @@ void acc_compute() {
 // CHECK-NEXT: acc.reduction.recipe @reduction_mul__ZTS16DefaultOperators : !cir.ptr<!rec_DefaultOperators> reduction_operator <mul> init {
 // CHECK-NEXT: ^bb0(%[[ARG:.*]]: !cir.ptr<!rec_DefaultOperators>{{.*}})
 // CHECK-NEXT: %[[ALLOCA:.*]] = cir.alloca !rec_DefaultOperators, !cir.ptr<!rec_DefaultOperators>, ["openacc.reduction.init", init]
-// CHECK-NEXT: %[[BITCAST:.*]] = cir.cast bitcast %[[ALLOCA]] : !cir.ptr<!rec_DefaultOperators> -> !cir.ptr<!rec_anon_struct>
-// CHECK-NEXT: %[[CONST:.*]] = cir.const #cir.const_record<{#cir.int<1> : !s32i, #cir.int<1> : !u32i, #cir.fp<1{{.*}}> : !cir.float, {{.*}}, #cir.fp<1{{.*}}> : !cir.double, #true, {{.*}}}> : !rec_anon_struct
-// CHECK-NEXT: cir.store{{.*}} %[[CONST]], %[[BITCAST]] : !rec_anon_struct, !cir.ptr<!rec_anon_struct>
+// CHECK-NEXT: %[[CONST:.*]] = cir.const #cir.const_record<{#cir.int<1> : !s32i, #cir.int<1> : !u32i, #cir.fp<1{{.*}}> : !cir.float, #cir.fp<1{{.*}}> : !cir.double, #true}> : !rec_DefaultOperators
+// CHECK-NEXT: cir.store{{.*}} %[[CONST]], %[[ALLOCA]] : !rec_DefaultOperators, !cir.ptr<!rec_DefaultOperators>
 // CHECK-NEXT: acc.yield
 //
 // CHECK-NEXT: } combiner {
@@ -118,9 +116,8 @@ void acc_compute() {
 // CHECK-NEXT: acc.reduction.recipe @reduction_max__ZTS16DefaultOperators : !cir.ptr<!rec_DefaultOperators> reduction_operator <max> init {
 // CHECK-NEXT: ^bb0(%[[ARG:.*]]: !cir.ptr<!rec_DefaultOperators>{{.*}})
 // CHECK-NEXT: %[[ALLOCA:.*]] = cir.alloca !rec_DefaultOperators, !cir.ptr<!rec_DefaultOperators>, ["openacc.reduction.init", init]
-// CHECK-NEXT: %[[BITCAST:.*]] = cir.cast bitcast %[[ALLOCA]] : !cir.ptr<!rec_DefaultOperators> -> !cir.ptr<!rec_anon_struct>
-// CHECK-NEXT: %[[CONST:.*]] = cir.const #cir.const_record<{#cir.int<-2147483648> : !s32i, #cir.int<0> : !u32i, #cir.fp<-3.4{{.*}}E+38> : !cir.float, {{.*}}, #cir.fp<-1.7{{.*}}E+308> : !cir.double, #false, {{.*}}}> : !rec_anon_struct
-// CHECK-NEXT: cir.store{{.*}} %[[CONST]], %[[BITCAST]] : !rec_anon_struct, !cir.ptr<!rec_anon_struct>
+// CHECK-NEXT: %[[CONST:.*]] = cir.const #cir.const_record<{#cir.int<-2147483648> : !s32i, #cir.int<0> : !u32i, #cir.fp<-3.4{{.*}}E+38> : !cir.float, #cir.fp<-1.7{{.*}}E+308> : !cir.double, #false}> : !rec_DefaultOperators
+// CHECK-NEXT: cir.store{{.*}} %[[CONST]], %[[ALLOCA]] : !rec_DefaultOperators, !cir.ptr<!rec_DefaultOperators>
 // CHECK-NEXT: acc.yield
 //
 // CHECK-NEXT: } combiner {
@@ -207,9 +204,8 @@ void acc_compute() {
 // CHECK-NEXT: acc.reduction.recipe @reduction_min__ZTS16DefaultOperators : !cir.ptr<!rec_DefaultOperators> reduction_operator <min> init {
 // CHECK-NEXT: ^bb0(%[[ARG:.*]]: !cir.ptr<!rec_DefaultOperators>{{.*}})
 // CHECK-NEXT: %[[ALLOCA:.*]] = cir.alloca !rec_DefaultOperators, !cir.ptr<!rec_DefaultOperators>, ["openacc.reduction.init", init]
-// CHECK-NEXT: %[[BITCAST:.*]] = cir.cast bitcast %[[ALLOCA]] : !cir.ptr<!rec_DefaultOperators> -> !cir.ptr<!rec_anon_struct>
-// CHECK-NEXT: %[[CONST:.*]] = cir.const #cir.const_record<{#cir.int<2147483647> : !s32i, #cir.int<4294967295> : !u32i, #cir.fp<3.4{{.*}}E+38> : !cir.float, {{.*}}, #cir.fp<1.7{{.*}}E+308> : !cir.double, #true, {{.*}}}> : !rec_anon_struct
-// CHECK-NEXT: cir.store{{.*}} %[[CONST]], %[[BITCAST]] : !rec_anon_struct, !cir.ptr<!rec_anon_struct>
+// CHECK-NEXT: %[[CONST:.*]] = cir.const #cir.const_record<{#cir.int<2147483647> : !s32i, #cir.int<4294967295> : !u32i, #cir.fp<3.4{{.*}}E+38> : !cir.float, #cir.fp<1.7{{.*}}E+308> : !cir.double, #true}> : !rec_DefaultOperators
+// CHECK-NEXT: cir.store{{.*}} %[[CONST]], %[[ALLOCA]] : !rec_DefaultOperators, !cir.ptr<!rec_DefaultOperators>
 // CHECK-NEXT: acc.yield
 //
 // CHECK-NEXT: } combiner {
@@ -296,9 +292,8 @@ void acc_compute() {
 // CHECK-NEXT: acc.reduction.recipe @reduction_iand__ZTS24DefaultOperatorsNoFloats : !cir.ptr<!rec_DefaultOperatorsNoFloats> reduction_operator <iand> init {
 // CHECK-NEXT: ^bb0(%[[ARG:.*]]: !cir.ptr<!rec_DefaultOperatorsNoFloats>{{.*}})
 // CHECK-NEXT: %[[ALLOCA:.*]] = cir.alloca !rec_DefaultOperatorsNoFloats, !cir.ptr<!rec_DefaultOperatorsNoFloats>, ["openacc.reduction.init", init]
-// CHECK-NEXT: %[[BITCAST:.*]] = cir.cast bitcast %[[ALLOCA]] : !cir.ptr<!rec_DefaultOperatorsNoFloats> -> !cir.ptr<!rec_anon_struct1>
-// CHECK-NEXT: %[[CONST:.*]] = cir.const #cir.const_record<{#cir.int<-1> : !s32i, #cir.int<4294967295> : !u32i, #true, {{.*}}}> : !rec_anon_struct1
-// CHECK-NEXT: cir.store{{.*}} %[[CONST]], %[[BITCAST]] : !rec_anon_struct1, !cir.ptr<!rec_anon_struct1>
+// CHECK-NEXT: %[[CONST:.*]] = cir.const #cir.const_record<{#cir.int<-1> : !s32i, #cir.int<4294967295> : !u32i, #true}> : !rec_DefaultOperatorsNoFloats
+// CHECK-NEXT: cir.store{{.*}} %[[CONST]], %[[ALLOCA]] : !rec_DefaultOperatorsNoFloats, !cir.ptr<!rec_DefaultOperatorsNoFloats>
 // CHECK-NEXT: acc.yield
 //
 // CHECK-NEXT: } combiner {
@@ -331,9 +326,8 @@ void acc_compute() {
 // CHECK-NEXT: acc.reduction.recipe @reduction_ior__ZTS24DefaultOperatorsNoFloats : !cir.ptr<!rec_DefaultOperatorsNoFloats> reduction_operator <ior> init {
 // CHECK-NEXT: ^bb0(%[[ARG:.*]]: !cir.ptr<!rec_DefaultOperatorsNoFloats>{{.*}})
 // CHECK-NEXT: %[[ALLOCA:.*]] = cir.alloca !rec_DefaultOperatorsNoFloats, !cir.ptr<!rec_DefaultOperatorsNoFloats>, ["openacc.reduction.init", init]
-// CHECK-NEXT: %[[BITCAST:.*]] = cir.cast bitcast %[[ALLOCA]] : !cir.ptr<!rec_DefaultOperatorsNoFloats> -> !cir.ptr<!rec_anon_struct1>
-// CHECK-NEXT: %[[ZERO:.*]] = cir.const #cir.zero : !rec_anon_struct1
-// CHECK-NEXT: cir.store{{.*}} %[[ZERO]], %[[BITCAST]] : !rec_anon_struct1, !cir.ptr<!rec_anon_struct1>
+// CHECK-NEXT: %[[ZERO:.*]] = cir.const #cir.zero : !rec_DefaultOperatorsNoFloats
+// CHECK-NEXT: cir.store{{.*}} %[[ZERO]], %[[ALLOCA]] : !rec_DefaultOperatorsNoFloats, !cir.ptr<!rec_DefaultOperatorsNoFloats>
 // CHECK-NEXT: acc.yield
 //
 // CHECK-NEXT: } combiner {
@@ -366,9 +360,8 @@ void acc_compute() {
 // CHECK-NEXT: acc.reduction.recipe @reduction_xor__ZTS24DefaultOperatorsNoFloats : !cir.ptr<!rec_DefaultOperatorsNoFloats> reduction_operator <xor> init {
 // CHECK-NEXT: ^bb0(%[[ARG:.*]]: !cir.ptr<!rec_DefaultOperatorsNoFloats>{{.*}})
 // CHECK-NEXT: %[[ALLOCA:.*]] = cir.alloca !rec_DefaultOperatorsNoFloats, !cir.ptr<!rec_DefaultOperatorsNoFloats>, ["openacc.reduction.init", init]
-// CHECK-NEXT: %[[BITCAST:.*]] = cir.cast bitcast %[[ALLOCA]] : !cir.ptr<!rec_DefaultOperatorsNoFloats> -> !cir.ptr<!rec_anon_struct1>
-// CHECK-NEXT: %[[ZERO:.*]] = cir.const #cir.zero : !rec_anon_struct1
-// CHECK-NEXT: cir.store{{.*}} %[[ZERO]], %[[BITCAST]] : !rec_anon_struct1, !cir.ptr<!rec_anon_struct1>
+// CHECK-NEXT: %[[ZERO:.*]] = cir.const #cir.zero : !rec_DefaultOperatorsNoFloats
+// CHECK-NEXT: cir.store{{.*}} %[[ZERO]], %[[ALLOCA]] : !rec_DefaultOperatorsNoFloats, !cir.ptr<!rec_DefaultOperatorsNoFloats>
 // CHECK-NEXT: acc.yield
 //
 // CHECK-NEXT: } combiner {
@@ -401,9 +394,8 @@ void acc_compute() {
 // CHECK-NEXT: acc.reduction.recipe @reduction_land__ZTS16DefaultOperators : !cir.ptr<!rec_DefaultOperators> reduction_operator <land> init {
 // CHECK-NEXT: ^bb0(%[[ARG:.*]]: !cir.ptr<!rec_DefaultOperators>{{.*}})
 // CHECK-NEXT: %[[ALLOCA:.*]] = cir.alloca !rec_DefaultOperators, !cir.ptr<!rec_DefaultOperators>, ["openacc.reduction.init", init]
-// CHECK-NEXT: %[[BITCAST:.*]] = cir.cast bitcast %[[ALLOCA]] : !cir.ptr<!rec_DefaultOperators> -> !cir.ptr<!rec_anon_struct>
-// CHECK-NEXT: %[[CONST:.*]] = cir.const #cir.const_record<{#cir.int<1> : !s32i, #cir.int<1> : !u32i, #cir.fp<1{{.*}}> : !cir.float, {{.*}}, #cir.fp<1{{.*}}> : !cir.double, #true, {{.*}}}> : !rec_anon_struct
-// CHECK-NEXT: cir.store{{.*}} %[[CONST]], %[[BITCAST]] : !rec_anon_struct, !cir.ptr<!rec_anon_struct>
+// CHECK-NEXT: %[[CONST:.*]] = cir.const #cir.const_record<{#cir.int<1> : !s32i, #cir.int<1> : !u32i, #cir.fp<1{{.*}}> : !cir.float, #cir.fp<1{{.*}}> : !cir.double, #true}> : !rec_DefaultOperators
+// CHECK-NEXT: cir.store{{.*}} %[[CONST]], %[[ALLOCA]] : !rec_DefaultOperators, !cir.ptr<!rec_DefaultOperators>
 // CHECK-NEXT: acc.yield
 //
 // CHECK-NEXT: } combiner {
@@ -489,9 +481,8 @@ void acc_compute() {
 // CHECK-NEXT: acc.reduction.recipe @reduction_lor__ZTS16DefaultOperators : !cir.ptr<!rec_DefaultOperators> reduction_operator <lor> init {
 // CHECK-NEXT: ^bb0(%[[ARG:.*]]: !cir.ptr<!rec_DefaultOperators>{{.*}})
 // CHECK-NEXT: %[[ALLOCA:.*]] = cir.alloca !rec_DefaultOperators, !cir.ptr<!rec_DefaultOperators>, ["openacc.reduction.init", init]
-// CHECK-NEXT: %[[BITCAST:.*]] = cir.cast bitcast %[[ALLOCA]] : !cir.ptr<!rec_DefaultOperators> -> !cir.ptr<!rec_anon_struct>
-// CHECK-NEXT: %[[ZERO:.*]] = cir.const #cir.zero : !rec_anon_struct
-// CHECK-NEXT: cir.store{{.*}} %[[ZERO]], %[[BITCAST]] : !rec_anon_struct, !cir.ptr<!rec_anon_struct>
+// CHECK-NEXT: %[[ZERO:.*]] = cir.const #cir.zero : !rec_DefaultOperators
+// CHECK-NEXT: cir.store{{.*}} %[[ZERO]], %[[ALLOCA]] : !rec_DefaultOperators, !cir.ptr<!rec_DefaultOperators>
 // CHECK-NEXT: acc.yield
 //
 // CHECK-NEXT: } combiner {

--- a/clang/test/CIR/Lowering/array.cpp
+++ b/clang/test/CIR/Lowering/array.cpp
@@ -25,7 +25,7 @@ int dd[3][2] = {{1, 2}, {3, 4}, {5, 6}};
 // CHECK: [i32 3, i32 4], [2 x i32] [i32 5, i32 6]]
 
 int e[10] = {1, 2};
-// CHECK: @e = global <{ i32, i32, [8 x i32] }> <{ i32 1, i32 2, [8 x i32] zeroinitializer }>
+// CHECK: @e = global [10 x i32] [i32 1, i32 2, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0]
 
 int f[5] = {1, 2};
 // CHECK: @f = global [5 x i32] [i32 1, i32 2, i32 0, i32 0, i32 0]


### PR DESCRIPTION
I've come across quite a few bugs now that are a result of our 'temporary' structs generated by ConstRecordBuilder being a different format than the actual type it is initializing. This is functional in classic codegen as long as their sizes/alignments 'line up', since it does all its assignments/work at a byte-level.

However, CIR is doing its best to do accesses at the member-level, so when these don't line up, we get odd GEP/GetMember/type failures.

This patch is a Claude-attempt to rewrite the ConstRecordBuilder to instead of attempting a new transformation from the AST to the temporary types, to do so from the CIRRecordLayoutBuilder, so that they are compatible objects.

NOTE: This is being put up for review as a draft for visibility so that others don't try to solve the same problem.  I'm personally away for a little more than 2 weeks for WG21 activities/vacation, so I'll work on writing this myself/heavily reviewing this code before marking this as ready for review when I return.