### PR TITLE
[AIX][libc++] Fix redefinition of wchar_t overloads on AIX

### DIFF
--- a/libcxx/include/wchar.h
+++ b/libcxx/include/wchar.h
@@ -139,7 +139,7 @@ size_t wcsrtombs(char* restrict dst, const wchar_t** restrict src, size_t len,
 
 #    if _LIBCPP_HAS_WIDE_CHARACTERS
 #      if defined(__cplusplus) && !defined(_LIBCPP_WCHAR_H_HAS_CONST_OVERLOADS) && defined(_LIBCPP_PREFERRED_OVERLOAD)
-#        if defined(_AIX) && !defined(_LIBCPP_WCHAR_H_OVERLOADS)
+#        ifndef _LIBCPP_WCHAR_H_OVERLOADS
 #          define _LIBCPP_WCHAR_H_OVERLOADS
 extern "C++" {
 inline _LIBCPP_HIDE_FROM_ABI wchar_t* __libcpp_wcschr(const wchar_t* __s, wchar_t __c) {

--- a/libcxx/include/wchar.h
+++ b/libcxx/include/wchar.h
@@ -140,6 +140,7 @@ size_t wcsrtombs(char* restrict dst, const wchar_t** restrict src, size_t len,
 #    if _LIBCPP_HAS_WIDE_CHARACTERS
 #      if defined(__cplusplus) && !defined(_LIBCPP_WCHAR_H_HAS_CONST_OVERLOADS) && defined(_LIBCPP_PREFERRED_OVERLOAD)
 #        if defined(_AIX) && !defined(_LIBCPP_WCHAR_H_OVERLOADS)
+#          define _LIBCPP_WCHAR_H_OVERLOADS
 extern "C++" {
 inline _LIBCPP_HIDE_FROM_ABI wchar_t* __libcpp_wcschr(const wchar_t* __s, wchar_t __c) {
   return (wchar_t*)wcschr(__s, __c);
@@ -194,16 +195,16 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_PREFERRED_OVERLOAD wchar_t* wmemchr(wchar_t
   return __libcpp_wmemchr(__s, __c, __n);
 }
 }
-#        endif
+#        endif // _LIBCPP_WCHAR_H_OVERLOADS
+#      endif
 
-#        if defined(__cplusplus) && (defined(_LIBCPP_MSVCRT_LIKE) || defined(__MVS__))
+#      if defined(__cplusplus) && (defined(_LIBCPP_MSVCRT_LIKE) || defined(__MVS__))
 extern "C" {
 size_t mbsnrtowcs(
     wchar_t* __restrict __dst, const char** __restrict __src, size_t __nmc, size_t __len, mbstate_t* __restrict __ps);
 size_t wcsnrtombs(
     char* __restrict __dst, const wchar_t** __restrict __src, size_t __nwc, size_t __len, mbstate_t* __restrict __ps);
 } // extern "C"
-#        endif // _LIBCPP_WCHAR_H_OVERLOADS
 #      endif // __cplusplus && (_LIBCPP_MSVCRT || __MVS__)
 #    endif   // _LIBCPP_HAS_WIDE_CHARACTERS
 #  endif     // _LIBCPP_WCHAR_H

--- a/libcxx/include/wchar.h
+++ b/libcxx/include/wchar.h
@@ -139,6 +139,7 @@ size_t wcsrtombs(char* restrict dst, const wchar_t** restrict src, size_t len,
 
 #    if _LIBCPP_HAS_WIDE_CHARACTERS
 #      if defined(__cplusplus) && !defined(_LIBCPP_WCHAR_H_HAS_CONST_OVERLOADS) && defined(_LIBCPP_PREFERRED_OVERLOAD)
+#        if defined(_AIX) && !defined(_LIBCPP_WCHAR_H_OVERLOADS)
 extern "C++" {
 inline _LIBCPP_HIDE_FROM_ABI wchar_t* __libcpp_wcschr(const wchar_t* __s, wchar_t __c) {
   return (wchar_t*)wcschr(__s, __c);
@@ -193,15 +194,16 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_PREFERRED_OVERLOAD wchar_t* wmemchr(wchar_t
   return __libcpp_wmemchr(__s, __c, __n);
 }
 }
-#      endif
+#        endif
 
-#      if defined(__cplusplus) && (defined(_LIBCPP_MSVCRT_LIKE) || defined(__MVS__))
+#        if defined(__cplusplus) && (defined(_LIBCPP_MSVCRT_LIKE) || defined(__MVS__))
 extern "C" {
 size_t mbsnrtowcs(
     wchar_t* __restrict __dst, const char** __restrict __src, size_t __nmc, size_t __len, mbstate_t* __restrict __ps);
 size_t wcsnrtombs(
     char* __restrict __dst, const wchar_t** __restrict __src, size_t __nwc, size_t __len, mbstate_t* __restrict __ps);
 } // extern "C"
+#        endif // _LIBCPP_WCHAR_H_OVERLOADS
 #      endif // __cplusplus && (_LIBCPP_MSVCRT || __MVS__)
 #    endif   // _LIBCPP_HAS_WIDE_CHARACTERS
 #  endif     // _LIBCPP_WCHAR_H

--- a/libcxx/test/extensions/clang/clang_modules_include.gen.py
+++ b/libcxx/test/extensions/clang/clang_modules_include.gen.py
@@ -30,8 +30,6 @@
 # TODO: Investigate why this doesn't work on Picolibc once the locale base API is refactored
 # UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
 
-# TODO: Fix seemingly circular inclusion or <wchar.h> on AIX
-# UNSUPPORTED: LIBCXX-AIX-FIXME
 
 # UNSUPPORTED: FROZEN-CXX03-HEADERS-FIXME
 


### PR DESCRIPTION
On AIX, the system headers have a circular dependency: `wctype.h → wchar.h → wctype.h` which causes wchar.h to be processed multiple times. 

The existing `_LIBCPP_WCHAR_H` include guard does not protect because wchar.h is a textual header and they get their own pre-processing per module compilation. 