### PR TITLE
Patch tryCanonicalizeStructToVector to handle split slice tails

### DIFF
--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -723,7 +723,7 @@ FUNCTION_PASS_WITH_PARAMS(
 FUNCTION_PASS_WITH_PARAMS(
     "sroa", "SROAPass",
     [](SROAOptions PreserveCFG) { return SROAPass(PreserveCFG); },
-    parseSROAOptions, "preserve-cfg;modify-cfg")
+    parseSROAOptions, "preserve-cfg;modify-cfg;aggregate-to-vector")
 FUNCTION_PASS_WITH_PARAMS(
     "structurizecfg", "StructurizeCFG",
     [](bool SkipUniformRegions) {

--- a/llvm/lib/Transforms/Scalar/SROA.cpp
+++ b/llvm/lib/Transforms/Scalar/SROA.cpp
@@ -5131,20 +5131,27 @@ static FixedVectorType *tryCanonicalizeStructToVector(StructType *STy,
   if (StructSize != VectorSize)
     return nullptr;
 
-  for (const Slice &S : P) {
+  auto IsMemIntrinsicOnlySlice = [](const Slice &S) {
     if (S.isDead())
-      continue;
+      return true;
     auto *U = S.getUse();
     if (!U)
-      continue;
+      return true;
 
     User *Usr = U->getUser();
     if (isa<LifetimeIntrinsic>(Usr) || isa<DbgInfoIntrinsic>(Usr))
-      continue;
+      return true;
 
-    if (!isa<MemIntrinsic>(Usr))
+    return isa<MemIntrinsic>(Usr);
+  };
+
+  for (const Slice &S : P)
+    if (!IsMemIntrinsicOnlySlice(S))
       return nullptr;
-  }
+
+  for (const Slice *S : P.splitSliceTails())
+    if (!IsMemIntrinsicOnlySlice(*S))
+      return nullptr;
 
   return VTy;
 }

--- a/llvm/lib/Transforms/Scalar/SROA.cpp
+++ b/llvm/lib/Transforms/Scalar/SROA.cpp
@@ -5094,7 +5094,7 @@ bool SROA::presplitLoadsAndStores(AllocaInst &AI, AllocaSlices &AS) {
 /// packed. This can sometimes eliminate allocas because structs cannot get
 /// promoted to LLVM values, but vectors can.
 ///
-/// We only apply this transformation when all users of the alloca are memory
+/// We only apply this transformation when all users of the partition are memory
 /// intrinsics. Otherwise, if there is a load or store of some other type to the
 /// partition, SROA would select that type.
 ///
@@ -5131,7 +5131,7 @@ static FixedVectorType *tryCanonicalizeStructToVector(StructType *STy,
   if (StructSize != VectorSize)
     return nullptr;
 
-  auto IsMemIntrinsicOnlySlice = [](const Slice &S) {
+  auto IsIgnorableOrMemIntrinsicSlice = [](const Slice &S) {
     if (S.isDead())
       return true;
     auto *U = S.getUse();
@@ -5146,11 +5146,11 @@ static FixedVectorType *tryCanonicalizeStructToVector(StructType *STy,
   };
 
   for (const Slice &S : P)
-    if (!IsMemIntrinsicOnlySlice(S))
+    if (!IsIgnorableOrMemIntrinsicSlice(S))
       return nullptr;
 
   for (const Slice *S : P.splitSliceTails())
-    if (!IsMemIntrinsicOnlySlice(*S))
+    if (!IsIgnorableOrMemIntrinsicSlice(*S))
       return nullptr;
 
   return VTy;

--- a/llvm/test/Transforms/SROA/struct-to-vector-subpartition.ll
+++ b/llvm/test/Transforms/SROA/struct-to-vector-subpartition.ll
@@ -67,3 +67,41 @@ merge:
   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %dst, ptr align 8 %sel, i64 16, i1 false)
   ret void
 }
+
+; SROA sees these slices:
+;   [0,8)   load ptr
+;   [0,32)  store i256, splittable
+;   [8,16)  load i64, splittable
+;   [16,32) memcpy source, splittable
+;
+; These form three partitions:
+;   [0,8)   contains the ptr load and the store i256 slice that starts at 0
+;   [8,16)  contains the i64 load, plus the store i256 split tail
+;   [16,32) contains the memcpy source, plus the store i256 split tail
+;
+; The [16,32) subpartition has type { i64, i64 }, and the only slice that
+; starts in the partition is a memcpy. However, the whole-alloca i256 store is a
+; split tail overlapping the subpartition, so it must block struct-to-vector
+; fallback canonicalization.
+
+; CHECK-LABEL: define void @test_split_tail_store_blocks_subpartition_type(
+; CHECK-NOT: <2 x i64>
+; CHECK: ret void
+define void @test_split_tail_store_blocks_subpartition_type(ptr %dst, i256 %x) {
+entry:
+  %a = alloca { ptr, i64, i64, i64 }, align 8
+  store i256 %x, ptr %a, align 8
+
+  ; Force earlier partition boundaries so [16,32) is selected as a subpartition
+  ; whose type from getTypePartition is { i64, i64 }.
+  %p = load ptr, ptr %a, align 8
+  %puse = ptrtoint ptr %p to i64
+  %gep.a.8 = getelementptr inbounds i8, ptr %a, i64 8
+  %v8 = load i64, ptr %gep.a.8, align 8
+  %use = add i64 %puse, %v8
+  store i64 %use, ptr %dst, align 8
+
+  %gep.a.16 = getelementptr inbounds i8, ptr %a, i64 16
+  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %dst, ptr align 8 %gep.a.16, i64 16, i1 false)
+  ret void
+}

--- a/llvm/test/Transforms/SROA/struct-to-vector-subpartition.ll
+++ b/llvm/test/Transforms/SROA/struct-to-vector-subpartition.ll
@@ -86,6 +86,12 @@ merge:
 
 ; CHECK-LABEL: define void @test_split_tail_store_blocks_subpartition_type(
 ; CHECK-NOT: <2 x i64>
+; CHECK: [[TAIL_SHIFT:%.*]] = lshr i256 %x, 128
+; CHECK-NOT: <2 x i64>
+; CHECK: [[TAIL:%.*]] = trunc i256 [[TAIL_SHIFT]] to i128
+; CHECK-NOT: <2 x i64>
+; CHECK: store i128 [[TAIL]], ptr %dst, align 8
+; CHECK-NOT: <2 x i64>
 ; CHECK: ret void
 define void @test_split_tail_store_blocks_subpartition_type(ptr %dst, i256 %x) {
 entry:


### PR DESCRIPTION
We choose a vector alloca over a struct alloca when all users of the alloca are memory or lifetime intrinsics. But we only accounted for slices that start in the corresponding partition. We have to also check that all split slice tails overlapping the partition are memory or lifetime intrinsics

I also updated the `PassRegistry.def` to include the new pass option because we forgot to add that.