### PR TITLE
[PGO][HIP] Default COMPILER_RT_BUILD_PROFILE_ROCM off on Windows

### DIFF
--- a/compiler-rt/CMakeLists.txt
+++ b/compiler-rt/CMakeLists.txt
@@ -323,7 +323,12 @@ option(COMPILER_RT_USE_ATOMIC_LIBRARY "Use compiler-rt atomic instead of libatom
 option(COMPILER_RT_PROFILE_BAREMETAL "Build minimal baremetal profile library" OFF)
 
 set(DEFAULT_COMPILER_RT_BUILD_PROFILE_ROCM ON)
-if(APPLE)
+if(APPLE OR WIN32)
+  # On Windows the HIP host interceptor (InstrProfilingPlatformROCm.cpp) pulls in
+  # RTInterception + sanitizer_common, which are built /MD and force the whole
+  # profile library to /MD, breaking the default static-CRT (/MT) profile builds.
+  # Device PGO on Windows is not wired up yet, so default this off; users who need
+  # it can opt in explicitly and accept the /MD profile library.
   set(DEFAULT_COMPILER_RT_BUILD_PROFILE_ROCM OFF)
 endif()
 option(COMPILER_RT_BUILD_PROFILE_ROCM

--- a/compiler-rt/lib/profile/CMakeLists.txt
+++ b/compiler-rt/lib/profile/CMakeLists.txt
@@ -161,12 +161,15 @@ endif()
 # The HIP host interceptor in InstrProfilingPlatformROCm.cpp pulls in
 # RTInterception + sanitizer_common object libs. Those targets are only created
 # when COMPILER_RT_BUILD_SANITIZERS / _MEMPROF / _XRAY / _CTX_PROFILE is enabled
-# (see lib/CMakeLists.txt). In a profile-only build the targets do not exist;
-# skip both the object-lib merge and the ROCm source file so the static archive
-# remains self-contained.
+# (see lib/CMakeLists.txt). Only merge them (and keep the ROCm source) when ROCm
+# device PGO is requested and the targets exist; otherwise skip both so the
+# static archive stays self-contained. This also keeps the profile library on
+# the static CRT (/MT) on Windows by default, since the merged sanitizer object
+# libs are built /MD.
 set(PROFILE_OBJECT_LIBS)
 set(PROFILE_HAS_HIP_INTERCEPTOR FALSE)
-if(COMPILER_RT_HAS_INTERCEPTION AND NOT COMPILER_RT_PROFILE_BAREMETAL
+if(COMPILER_RT_BUILD_PROFILE_ROCM
+   AND COMPILER_RT_HAS_INTERCEPTION AND NOT COMPILER_RT_PROFILE_BAREMETAL
    AND TARGET RTInterception.${COMPILER_RT_DEFAULT_TARGET_ARCH}
    AND TARGET RTSanitizerCommon.${COMPILER_RT_DEFAULT_TARGET_ARCH}
    AND TARGET RTSanitizerCommonLibc.${COMPILER_RT_DEFAULT_TARGET_ARCH})

--- a/compiler-rt/test/profile/CMakeLists.txt
+++ b/compiler-rt/test/profile/CMakeLists.txt
@@ -28,8 +28,12 @@ foreach(arch ${PROFILE_TEST_ARCH})
   # with MultiThreadedDLL (/MD), so the .objs reference __imp_* symbols;
   # the test binary defaults to /MT and fails to link (LNK2019 __imp__stricmp
   # from interception_win.cpp, LNK4098 default-lib conflicts). Match the
-  # DLL CRT here so test executables link against the same runtime.
-  if(MSVC AND COMPILER_RT_HAS_INTERCEPTION AND NOT COMPILER_RT_PROFILE_BAREMETAL)
+  # DLL CRT here so test executables link against the same runtime. This must
+  # mirror the archive's interceptor gate in lib/profile/CMakeLists.txt: the
+  # libs are only merged (and the archive only goes /MD) when ROCm device PGO
+  # is enabled, so without it the test binaries stay on the default /MT.
+  if(MSVC AND COMPILER_RT_BUILD_PROFILE_ROCM
+     AND COMPILER_RT_HAS_INTERCEPTION AND NOT COMPILER_RT_PROFILE_BAREMETAL)
     string(APPEND PROFILE_TEST_TARGET_CFLAGS
            " -D_MT -D_DLL -Wl,-nodefaultlib:libcmt,-defaultlib:msvcrt,-defaultlib:oldnames")
   endif()


### PR DESCRIPTION
PR #177665 added the HIP device-profile collection runtime
(`InstrProfilingPlatformROCm.cpp`) to `clang_rt.profile`. That source uses the
sanitizer interceptor infrastructure, so the profile archive now merges the
`RTInterception` + `RTSanitizerCommon` object libraries. Those object libs are
built with `MultiThreadedDLL` (`/MD`), and to avoid mixing CRT models PR #177665
switched the whole profile archive to `/MD` whenever the interceptor was present.

On Windows the profile library has historically used the static CRT (`/MT`), and
most consumers link it that way. Flipping the default archive to `/MD` broke
existing static-CRT users:

```
clang-cl a.c -fprofile-generate
LINK : warning LNK4098: defaultlib 'msvcrt.lib' conflicts with use of other libs
clang_rt.profile-x86_64.lib(InstrProfilingFile.c.obj) : error LNK2019: unresolved external symbol __imp_getpid
clang_rt.profile-x86_64.lib(InstrProfilingFile.c.obj) : error LNK2019: unresolved external symbol __imp_getenv
... 20 unresolved externals
```

Device PGO on Windows is not wired up yet, so there is no reason to pull the HIP
collection runtime into the default Windows profile build. This patch defaults
`COMPILER_RT_BUILD_PROFILE_ROCM` **off on Windows** (it is already off on Apple).
With it off:

- `InstrProfilingPlatformROCm.cpp` and the `RTInterception` / `RTSanitizerCommon`
  object libs are not pulled into `clang_rt.profile`;
- the archive stays on `/MT`, so existing static-CRT profile builds link again.

Users who want the Windows ROCm collection runtime can still opt in with
`-DCOMPILER_RT_BUILD_PROFILE_ROCM=ON` and accept the `/MD` archive.

The interceptor object-lib merge and the matching `/MD` CRT model for the
`Profile-*` test executables are now also gated on `COMPILER_RT_BUILD_PROFILE_ROCM`,
so a Windows build with sanitizers enabled but ROCm off no longer drags the `/MD`
sanitizer libs into the otherwise-`/MT` profile archive (and the test binaries
stay on `/MT` to match).

Reported by @zmodem in https://github.com/llvm/llvm-project/pull/177665#issuecomment-4613485503
