### PR TITLE
[clang] add test verifying DR242 behavior

### DIFF
--- a/clang/test/CXX/drs/cwg2xx.cpp
+++ b/clang/test/CXX/drs/cwg2xx.cpp
@@ -718,6 +718,16 @@ namespace cwg242 { // cwg242: 2.8
     return (B *)(p);
     // expected-error@-1 {{cannot cast 'cwg242::V *' to 'B *' via virtual base 'cwg242::V'}}
   }
+
+  A &ref_upcast(D &r) {
+    return (A &)(r);
+    // expected-error@-1 {{ambiguous conversion from derived class 'cwg242::D' to base class 'cwg242::A'}}
+  }
+
+  int D::*ptm_cast(int A::*p) {
+    return (int D::*)(p);
+    // expected-error@-1 {{ambiguous conversion from pointer to member of base class 'cwg242::A' to pointer to member of derived class 'cwg242::D'}}
+  }
 } // namespace cwg242
 
 namespace cwg243 { // cwg243: 2.8

--- a/clang/test/CXX/drs/cwg2xx.cpp
+++ b/clang/test/CXX/drs/cwg2xx.cpp
@@ -695,6 +695,37 @@ namespace cwg241 { // cwg241: 9
   }
 } // namespace cwg241
 
+namespace cwg242 { // cwg242: yes
+  struct A {};
+  struct I1 : A {};
+  struct I2 : A {};
+  struct D : I1, I2 {};
+
+  A *upcast(D *p) {
+    return (A *)(p);
+    /* expected-error@-1
+    {{ambiguous conversion from derived class 'D' to base class 'A':
+    struct cwg242::D -> I1 -> A
+    struct cwg242::D -> I2 -> A}}*/
+  }
+
+  D *downcast(A *p) {
+    return (D *)(p);
+    /* expected-error@-1
+    {{ambiguous cast from base 'cwg242::A' to derived 'cwg242::D':
+    A -> I1 -> struct cwg242::D
+    A -> I2 -> struct cwg242::D}}*/
+  }
+
+  struct V {};
+  struct B : virtual V {};
+
+  B *virt_downcast(V *p) {
+    return (B *)(p);
+    // expected-error@-1 {{cannot cast 'cwg242::V *' to 'B *' via virtual base 'cwg242::V'}}
+  }
+} // namespace cwg242
+
 namespace cwg243 { // cwg243: 2.8
   struct B;
   struct A {

--- a/clang/test/CXX/drs/cwg2xx.cpp
+++ b/clang/test/CXX/drs/cwg2xx.cpp
@@ -695,7 +695,7 @@ namespace cwg241 { // cwg241: 9
   }
 } // namespace cwg241
 
-namespace cwg242 { // cwg242: yes
+namespace cwg242 { // cwg242: 2.8
   struct A {};
   struct I1 : A {};
   struct I2 : A {};

--- a/clang/test/CXX/drs/cwg2xx.cpp
+++ b/clang/test/CXX/drs/cwg2xx.cpp
@@ -703,18 +703,12 @@ namespace cwg242 { // cwg242: 2.8
 
   A *upcast(D *p) {
     return (A *)(p);
-    /* expected-error@-1
-    {{ambiguous conversion from derived class 'D' to base class 'A':
-    struct cwg242::D -> I1 -> A
-    struct cwg242::D -> I2 -> A}}*/
+    // expected-error@-1 {{error: ambiguous conversion from derived class 'cwg242::D' to base class 'cwg242::A'}}
   }
 
   D *downcast(A *p) {
     return (D *)(p);
-    /* expected-error@-1
-    {{ambiguous cast from base 'cwg242::A' to derived 'cwg242::D':
-    A -> I1 -> struct cwg242::D
-    A -> I2 -> struct cwg242::D}}*/
+    // expected-error@-1 {{ambiguous cast from base 'cwg242::A' to derived 'cwg242::D'}}
   }
 
   struct V {};

--- a/clang/test/CXX/drs/cwg2xx.cpp
+++ b/clang/test/CXX/drs/cwg2xx.cpp
@@ -744,7 +744,7 @@ namespace cwg242 { // cwg242: 3.0
   A *qual_upcast(const D *p) {
     return (A *)(p);
     /* expected-error@-1
-    {{ambiguous conversion from derived class 'D' to base class 'A':
+    {{ambiguous conversion from derived class '(const )?D' to base class 'A':
     struct cwg242::D -> I1 -> A
     struct cwg242::D -> I2 -> A}}*/
   }
@@ -752,7 +752,7 @@ namespace cwg242 { // cwg242: 3.0
   D *qual_downcast(const A *p) {
     return (D *)(p);
     /* expected-error@-1
-    {{ambiguous cast from base 'cwg242::A' to derived 'cwg242::D':
+    {{ambiguous cast from base '(const )?cwg242::A' to derived 'cwg242::D':
     A -> I1 -> struct cwg242::D
     A -> I2 -> struct cwg242::D}}*/
   }

--- a/clang/test/CXX/drs/cwg2xx.cpp
+++ b/clang/test/CXX/drs/cwg2xx.cpp
@@ -695,7 +695,7 @@ namespace cwg241 { // cwg241: 9
   }
 } // namespace cwg241
 
-namespace cwg242 { // cwg242: 2.8
+namespace cwg242 { // cwg242: 3.0
   struct A {};
   struct I1 : A {};
   struct I2 : A {};
@@ -703,12 +703,18 @@ namespace cwg242 { // cwg242: 2.8
 
   A *upcast(D *p) {
     return (A *)(p);
-    // expected-error@-1 {{error: ambiguous conversion from derived class 'cwg242::D' to base class 'cwg242::A'}}
+    /* expected-error@-1
+    {{ambiguous conversion from derived class 'D' to base class 'A':
+    struct cwg242::D -> I1 -> A
+    struct cwg242::D -> I2 -> A}}*/
   }
 
   D *downcast(A *p) {
     return (D *)(p);
-    // expected-error@-1 {{ambiguous cast from base 'cwg242::A' to derived 'cwg242::D'}}
+    /* expected-error@-1
+    {{ambiguous cast from base 'cwg242::A' to derived 'cwg242::D':
+    A -> I1 -> struct cwg242::D
+    A -> I2 -> struct cwg242::D}}*/
   }
 
   struct V {};
@@ -721,17 +727,42 @@ namespace cwg242 { // cwg242: 2.8
 
   A &ref_upcast(D &r) {
     return (A &)(r);
-    // expected-error@-1 {{ambiguous conversion from derived class 'cwg242::D' to base class 'cwg242::A'}}
+    /* expected-error@-1
+    {{ambiguous conversion from derived class 'D' to base class 'A':
+    struct cwg242::D -> I1 -> A
+    struct cwg242::D -> I2 -> A}}*/
   }
 
   D &ref_downcast(A &r) {
     return (D &)(r);
-    // expected-error@-1 {{ambiguous cast from base 'cwg242::A' to derived 'cwg242::D'}}
+    /* expected-error@-1
+    {{ambiguous cast from base 'cwg242::A' to derived 'cwg242::D':
+    A -> I1 -> struct cwg242::D
+    A -> I2 -> struct cwg242::D}}*/
+  }
+
+  A *qual_upcast(const D *p) {
+    return (A *)(p);
+    /* expected-error@-1
+    {{ambiguous conversion from derived class 'D' to base class 'A':
+    struct cwg242::D -> I1 -> A
+    struct cwg242::D -> I2 -> A}}*/
+  }
+
+  D *qual_downcast(const A *p) {
+    return (D *)(p);
+    /* expected-error@-1
+    {{ambiguous cast from base 'cwg242::A' to derived 'cwg242::D':
+    A -> I1 -> struct cwg242::D
+    A -> I2 -> struct cwg242::D}}*/
   }
 
   int D::*ptm_cast(int A::*p) {
     return (int D::*)(p);
-    // expected-error@-1 {{ambiguous conversion from pointer to member of base class 'cwg242::A' to pointer to member of derived class 'cwg242::D'}}
+    /* expected-error@-1
+    {{ambiguous conversion from pointer to member of base class 'A' to pointer to member of derived class 'D':
+    struct cwg242::D -> I1 -> A
+    struct cwg242::D -> I2 -> A}}*/
   }
 } // namespace cwg242
 

--- a/clang/test/CXX/drs/cwg2xx.cpp
+++ b/clang/test/CXX/drs/cwg2xx.cpp
@@ -724,6 +724,11 @@ namespace cwg242 { // cwg242: 2.8
     // expected-error@-1 {{ambiguous conversion from derived class 'cwg242::D' to base class 'cwg242::A'}}
   }
 
+  D &ref_downcast(A &r) {
+    return (D &)(r);
+    // expected-error@-1 {{ambiguous cast from base 'cwg242::A' to derived 'cwg242::D'}}
+  }
+
   int D::*ptm_cast(int A::*p) {
     return (int D::*)(p);
     // expected-error@-1 {{ambiguous conversion from pointer to member of base class 'cwg242::A' to pointer to member of derived class 'cwg242::D'}}

--- a/clang/test/CXX/drs/cwg2xx.cpp
+++ b/clang/test/CXX/drs/cwg2xx.cpp
@@ -744,7 +744,7 @@ namespace cwg242 { // cwg242: 3.0
   A *qual_upcast(const D *p) {
     return (A *)(p);
     /* expected-error@-1
-    {{ambiguous conversion from derived class '(const )?D' to base class 'A':
+    {{ambiguous conversion from derived class 'const D' to base class 'A':
     struct cwg242::D -> I1 -> A
     struct cwg242::D -> I2 -> A}}*/
   }
@@ -752,7 +752,7 @@ namespace cwg242 { // cwg242: 3.0
   D *qual_downcast(const A *p) {
     return (D *)(p);
     /* expected-error@-1
-    {{ambiguous cast from base '(const )?cwg242::A' to derived 'cwg242::D':
+    {{ambiguous cast from base 'cwg242::A' to derived 'cwg242::D':
     A -> I1 -> struct cwg242::D
     A -> I2 -> struct cwg242::D}}*/
   }

--- a/clang/test/CXX/drs/cwg2xx.cpp
+++ b/clang/test/CXX/drs/cwg2xx.cpp
@@ -717,14 +717,6 @@ namespace cwg242 { // cwg242: 3.0
     A -> I2 -> struct cwg242::D}}*/
   }
 
-  struct V {};
-  struct B : virtual V {};
-
-  B *virt_downcast(V *p) {
-    return (B *)(p);
-    // expected-error@-1 {{cannot cast 'cwg242::V *' to 'B *' via virtual base 'cwg242::V'}}
-  }
-
   A &ref_upcast(D &r) {
     return (A &)(r);
     /* expected-error@-1
@@ -763,6 +755,14 @@ namespace cwg242 { // cwg242: 3.0
     {{ambiguous conversion from pointer to member of base class 'A' to pointer to member of derived class 'D':
     struct cwg242::D -> I1 -> A
     struct cwg242::D -> I2 -> A}}*/
+  }
+
+  struct V {};
+  struct DV : virtual V {};
+
+  DV *virt_downcast(V *p) {
+    return (DV *)(p);
+    // expected-error@-1 {{cannot cast 'cwg242::V *' to 'DV *' via virtual base 'cwg242::V'}}
   }
 } // namespace cwg242
 

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -1740,7 +1740,7 @@
     <td>[<a href="https://wg21.link/expr.cast">expr.cast</a>]</td>
     <td>CD4</td>
     <td>Interpretation of old-style casts</td>
-    <td class="full" align="center">Clang 2.8</td>
+    <td class="full" align="center">Clang 3.0</td>
   </tr>
   <tr id="243">
     <td><a href="https://cplusplus.github.io/CWG/issues/243.html">243</a></td>

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -1740,7 +1740,7 @@
     <td>[<a href="https://wg21.link/expr.cast">expr.cast</a>]</td>
     <td>CD4</td>
     <td>Interpretation of old-style casts</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 2.8</td>
   </tr>
   <tr id="243">
     <td><a href="https://cplusplus.github.io/CWG/issues/243.html">243</a></td>


### PR DESCRIPTION
Adding a test to document CD4 resolution of [DR 242](https://cplusplus.github.io/CWG/issues/242.html) (currently the availability in clang is [marked as unknown](https://clang.llvm.org/cxx_dr_status.html)).

DR 242 points out that the standard said that `static_cast` of expression `e` to type `T` "can't apply" if the declaration `T t(e);` was not well-formed (e.g. due to ambiguity). This implied that a C-style cast would fall through to `reinterpret_cast`, which is nonsense. What the standard meant in spirit (and what the revision targets) is to say that a C-style cast should try `static_cast` first, and if the conversion is nonsensical (ambiguous base, inaccessible base, virtual base downcast) then there should be an error. My PR adds tests to verify Clang correctly errors on ambiguous pointer upcasts/downcasts, ambiguous reference upcasts, virtual base downcasts, and ambiguous pointer-to-member conversions.

[As far as I can tell](https://godbolt.org/z/TvqsfK37j), the resolved behavior has been available in clang since at least 2.8.

I checked the [wording in the current standard](https://eel.is/c++draft/expr.static.cast). Compared to the resolution note [here](https://cplusplus.github.io/CWG/issues/242.html), the wording in DR's paragraphs 2, 11, 12 are the same up to paragraph renumbering,. The wording in DR's paragraph 4 has changed, clarifying implicit conversion sequences, but this doesn't affect the three cases this DR addresses (ambiguous upcast, ambiguous downcast, virtual base downcast).

I used Claude Code to understand more about clang/the tests/the repo, but wrote the test code myself.
