### PR TITLE
[lldb] xfail tests for arm64e caused by compiler bugs

### DIFF
--- a/lldb/test/API/commands/expression/call-throws/TestCallThatThrows.py
+++ b/lldb/test/API/commands/expression/call-throws/TestCallThatThrows.py
@@ -18,6 +18,7 @@ class ExprCommandWithThrowTestCase(TestBase):
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
     @add_test_categories(["objc"])
+    @expectedFailureAll(archs=["arm64e"])
     def test(self):
         """Test calling a function that throws and ObjC exception."""
         self.build()

--- a/lldb/test/API/functionalities/step-avoids-no-debug/TestStepNoDebug.py
+++ b/lldb/test/API/functionalities/step-avoids-no-debug/TestStepNoDebug.py
@@ -32,6 +32,7 @@ class StepAvoidsNoDebugTestCase(TestBase):
     @expectedFailureAll(
         archs=["aarch64"], oslist=["windows"], bugnumber="llvm.org/pr56292"
     )
+    @expectedFailureAll(archs=["arm64e"])
     def test_step_over_with_python(self):
         """Test stepping over using avoid-no-debug with dwarf."""
         self.build()
@@ -50,6 +51,7 @@ class StepAvoidsNoDebugTestCase(TestBase):
     @expectedFailureAll(
         archs=["aarch64"], oslist=["windows"], bugnumber="llvm.org/pr56292"
     )
+    @expectedFailureAll(archs=["arm64e"])
     def test_step_in_with_python(self):
         """Test stepping in using avoid-no-debug with dwarf."""
         self.build()

--- a/lldb/test/API/lang/cpp/exceptions/TestCPPExceptionBreakpoints.py
+++ b/lldb/test/API/lang/cpp/exceptions/TestCPPExceptionBreakpoints.py
@@ -22,6 +22,7 @@ class CPPBreakpointTestCase(TestBase):
         oslist=["windows"],
         bugnumber="llvm.org/pr24538, clang-cl does not support throw or catch",
     )
+    @expectedFailureAll(archs=["arm64e"])
     def test(self):
         """Test lldb exception breakpoint command for CPP."""
         self.build()

--- a/lldb/test/API/lang/objc/exceptions/TestObjCExceptions.py
+++ b/lldb/test/API/lang/objc/exceptions/TestObjCExceptions.py
@@ -12,6 +12,7 @@ from lldbsuite.test import lldbutil
 
 class ObjCExceptionsTestCase(TestBase):
     @skipIf(compiler="clang", compiler_version=["<", "13.0"])
+    @expectedFailureAll(archs=["arm64e"])
     def test_objc_exceptions_at_throw(self):
         self.build()
 
@@ -167,6 +168,7 @@ class ObjCExceptionsTestCase(TestBase):
             )
 
     @skipIf(compiler="clang", compiler_version=["<", "13.0"])
+    @expectedFailureAll(archs=["arm64e"])
     def test_objc_exceptions_at_abort(self):
         self.build()
 

--- a/lldb/test/API/python_api/unnamed_symbol_lookup/TestUnnamedSymbolLookup.py
+++ b/lldb/test/API/python_api/unnamed_symbol_lookup/TestUnnamedSymbolLookup.py
@@ -13,6 +13,7 @@ from lldbsuite.test import lldbutil
 # Unnamed symbols don't get into the .eh_frame section on ARM, so LLDB can't find them.
 @skipIf(archs=["arm$"])
 class TestUnnamedSymbolLookup(TestBase):
+    @expectedFailureAll(archs=["arm64e"])
     def test_unnamed_symbol_lookup(self):
         """Test looking up unnamed symbol synthetic name"""
         self.build()


### PR DESCRIPTION
These tests are caused by bugs in clang where arm64e support is not yet complete.