### PR TITLE
[libc++] Fix constraint recursion in std::expected's operator==

### DIFF
--- a/libcxx/include/__expected/expected.h
+++ b/libcxx/include/__expected/expected.h
@@ -1161,8 +1161,11 @@ public:
     }
   }
 
-  template <class _T2>
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const expected& __x, const _T2& __v)
+  // The unusual signature avoids constraint recursion via ADL through
+  // std::expected, see https://github.com/llvm/llvm-project/issues/160431.
+  template <class _T2, class _Tp2>
+    requires _IsSame<_Tp2, _Tp>::value
+  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const expected<_Tp2, _Err>& __x, const _T2& __v)
 #  if _LIBCPP_STD_VER >= 26
     requires(!__is_std_expected<_T2>::value) && requires {
       { *__x == __v } -> __core_convertible_to<bool>;

--- a/libcxx/include/__expected/expected.h
+++ b/libcxx/include/__expected/expected.h
@@ -10,6 +10,7 @@
 #define _LIBCPP___EXPECTED_EXPECTED_H
 
 #include <__assert>
+#include <__concepts/same_as.h>
 #include <__config>
 #include <__expected/bad_expected_access.h>
 #include <__expected/unexpect.h>
@@ -1162,9 +1163,9 @@ public:
   }
 
   // The unusual signature avoids constraint recursion via ADL through
-  // std::expected, see https://github.com/llvm/llvm-project/issues/160431.
-  template <class _T2, class _Tp2>
-    requires _IsSame<_Tp2, _Tp>::value
+  // std::expected, see https://llvm.org/PR160431. Note that this only
+  // triggers with compilers that implement https://wg21.link/CWG2369.
+  template <class _T2, same_as<_Tp> _Tp2>
   _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const expected<_Tp2, _Err>& __x, const _T2& __v)
 #  if _LIBCPP_STD_VER >= 26
     requires(!__is_std_expected<_T2>::value) && requires {

--- a/libcxx/test/std/utilities/expected/expected.expected/equality/equality.T2.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/equality/equality.T2.pass.cpp
@@ -45,6 +45,17 @@ constexpr bool test() {
     assert(e1 != i3);
   }
 
+#if TEST_STD_VER >= 26
+  // Regression test for https://github.com/llvm/llvm-project/issues/160431:
+  // the constraint of this overload would recurse when ADL on the comparison
+  // found the same hidden friend through a type whose associated namespaces
+  // reach std::expected.
+  {
+    std::pair<int, std::expected<int, int>> p1, p2;
+    assert(p1 == p2);
+  }
+#endif
+
   return true;
 }
 

--- a/libcxx/test/std/utilities/expected/expected.expected/equality/equality.T2.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/equality/equality.T2.pass.cpp
@@ -46,10 +46,9 @@ constexpr bool test() {
   }
 
 #if TEST_STD_VER >= 26
-  // Regression test for https://github.com/llvm/llvm-project/issues/160431:
-  // the constraint of this overload would recurse when ADL on the comparison
-  // found the same hidden friend through a type whose associated namespaces
-  // reach std::expected.
+  // Regression test for https://llvm.org/PR160431: the constraint of this overload
+  // would recurse when ADL on the comparison found the same hidden friend through a
+  // type whose associated namespaces reach std::expected.
   {
     std::pair<int, std::expected<int, int>> p1, p2;
     assert(p1 == p2);


### PR DESCRIPTION
The C++26 constraint added to operator==(const expected& x, const T2& v) by P3379R0 evaluates *x == v as part of constraint satisfaction. When ADL on a comparison reaches this hidden friend through a type whose associated namespaces include std::expected -- for example std::pair<T, std::expected<U, V>> -- the constraint check ends up considering the same overload again with the original type as T2, producing a "satisfaction of constraint depends on itself" error.

Parameterize the expected operand with an extra template parameter constrained to be the same type as the enclosing expected's value type. This is observationally equivalent but makes template argument deduction fail for non-expected operands before the constraint is evaluated, so the recursion never starts.

Fixes #160431
Fixes #204919

rdar://178226313

Assisted-by: Claude