### PR TITLE
[Clang] Accept `-flto=none` similar to `-fno-lto`

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -1347,6 +1347,7 @@ static LTOKind parseLTOMode(const llvm::opt::ArgList &Args,
   return llvm::StringSwitch<LTOKind>(LTOName)
       .Case("full", LTOK_Full)
       .Case("thin", LTOK_Thin)
+      .Case("none", LTOK_None)
       .Default(LTOK_Unknown);
 }
 

--- a/clang/test/Driver/lto.c
+++ b/clang/test/Driver/lto.c
@@ -46,6 +46,8 @@
 // RUN:   -fuse-ld=lld -flto -### 2>&1 | FileCheck --check-prefix=NO-LLVMGOLD %s
 // RUN: %clang --target=x86_64-unknown-linux-gnu --sysroot=%S/Inputs/basic_cross_linux_tree %s \
 // RUN:   -fuse-ld=gold -flto -fno-lto -### 2>&1 | FileCheck --check-prefix=NO-LLVMGOLD %s
+// RUN: %clang --target=x86_64-unknown-linux-gnu --sysroot=%S/Inputs/basic_cross_linux_tree %s \
+// RUN:   -fuse-ld=gold -flto -flto=none -### 2>&1 | FileCheck --check-prefix=NO-LLVMGOLD %s
 // NO-LLVMGOLD-NOT: "-plugin" "{{.*}}{{[/\\]}}LLVMgold.{{dll|dylib|so}}"
 
 // RUN: %clang --target=x86_64-unknown-linux-gnu --sysroot=%S/Inputs/basic_cross_linux_tree %s \


### PR DESCRIPTION
Summary:
Personal preference, but I would like to be able to set all the LTO
kinds from the string, and it feels a little odd to need to use
`-fno-lto` to override the mode.
