### PR TITLE
`cp -r` replaces symlinks, update to `cp -R`

### DIFF
--- a/clang-tools-extra/clangd/test/background-index.test
+++ b/clang-tools-extra/clangd/test/background-index.test
@@ -1,6 +1,6 @@
 # Use a copy of inputs, as we'll mutate it (as will the background index).
 # RUN: rm -rf %/t
-# RUN: cp -r %/S/Inputs/background-index %/t
+# RUN: cp -R %/S/Inputs/background-index %/t
 # Need to embed the correct temp path in the actual JSON-RPC requests.
 # RUN: sed -e "s|DIRECTORY|%/t|" %/t/definition.jsonrpc.tmpl > %/t/definition.jsonrpc.1
 # RUN: sed -e "s|DIRECTORY|%/t|" %/t/compile_commands.json.tmpl > %/t/compile_commands.json

--- a/clang-tools-extra/clangd/test/include-cleaner-batch-fix.test
+++ b/clang-tools-extra/clangd/test/include-cleaner-batch-fix.test
@@ -4,7 +4,7 @@
 
 # RUN: rm -rf %t
 # RUN: mkdir -p %t/clangd
-# RUN: cp -r %S/Inputs/include-cleaner %t/include
+# RUN: cp -R %S/Inputs/include-cleaner %t/include
 # RUN: echo '-I%t/include' > %t/compile_flags.txt
 # Create a config file enabling include-cleaner features.
 # RUN: echo 'Diagnostics:' > %t/clangd/config.yaml

--- a/clang-tools-extra/clangd/test/path-mappings.test
+++ b/clang-tools-extra/clangd/test/path-mappings.test
@@ -1,6 +1,6 @@
 # Copy over the server file into test workspace
 # RUN: rm -rf %t
-# RUN: cp -r %S/Inputs/path-mappings %t
+# RUN: cp -R %S/Inputs/path-mappings %t
 #
 # RUN: clangd --clang-tidy=false --path-mappings 'C:\client=%t/server' -lit-test < %s | FileCheck -strict-whitespace %s
 {"jsonrpc":"2.0","id":0,"method":"initialize","params":{"processId":123,"rootPath":"clangd","capabilities":{},"trace":"off"}}

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/header-include-cycle.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/header-include-cycle.cpp
@@ -1,8 +1,8 @@
 // RUN: rm -rf %t.dir/misc-header-include-cycle-headers
 // RUN: mkdir -p %t.dir/misc-header-include-cycle-headers
-// RUN: cp -r %S/Inputs/header-include-cycle* %t.dir/misc-header-include-cycle-headers/
+// RUN: cp -R %S/Inputs/header-include-cycle* %t.dir/misc-header-include-cycle-headers/
 // RUN: mkdir %t.dir/misc-header-include-cycle-headers/system
-// RUN: cp -r %S/Inputs/system/header-include-cycle* %t.dir/misc-header-include-cycle-headers/system
+// RUN: cp -R %S/Inputs/system/header-include-cycle* %t.dir/misc-header-include-cycle-headers/system
 // RUN: cp %s %t.dir/header-include-cycle.cpp
 // RUN: clang-tidy %t.dir%{fs-sep}header-include-cycle.cpp -checks='-*,misc-header-include-cycle' -header-filter=.* \
 // RUN: -config="{CheckOptions: {misc-header-include-cycle.IgnoredFilesList: 'header-include-cycle.self-e.hpp'}}" \

--- a/clang-tools-extra/test/clang-tidy/checkers/portability/restrict-system-includes-transitive.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/portability/restrict-system-includes-transitive.cpp
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t.dir/Headers
 // RUN: mkdir -p %t.dir/Headers
-// RUN: cp -r %S/Inputs/restrict-system-includes %t.dir/Headers/portability-restrict-system-includes
+// RUN: cp -R %S/Inputs/restrict-system-includes %t.dir/Headers/portability-restrict-system-includes
 // RUN: %check_clang_tidy -std=c++11 %s portability-restrict-system-includes %t \
 // RUN:   -- -config="{CheckOptions: {portability-restrict-system-includes.Includes: 'transitive.h,s.h'}}" \
 // RUN:   -system-headers -header-filter=.* \

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-symlink.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-symlink.cpp
@@ -4,7 +4,7 @@
 //
 // RUN: rm -rf %t.dir
 // RUN: mkdir -p %t.dir
-// RUN: cp -r %S/Inputs/identifier-naming/symlink %t.dir/symlink
+// RUN: cp -R %S/Inputs/identifier-naming/symlink %t.dir/symlink
 // RUN: mkdir -p %t.dir/symlink/build
 // RUN: ln -s %t.dir/symlink/include/test.h %t.dir/symlink/build/test.h
 // RUN: %check_clang_tidy -std=c++20 %s readability-identifier-naming %t.dir -- --header-filter="test.h" --config-file=%S/Inputs/identifier-naming/symlink/include/.clang-tidy -- -I %t.dir/symlink/build

--- a/clang-tools-extra/test/clang-tidy/infrastructure/clang-tidy-mac-libcxx.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/clang-tidy-mac-libcxx.cpp
@@ -5,7 +5,7 @@
 // RUN: mkdir %t
 //
 // Install the mock libc++ (simulates the libc++ directory structure).
-// RUN: cp -r %S/Inputs/mock-libcxx %t/
+// RUN: cp -R %S/Inputs/mock-libcxx %t/
 //
 // Pretend clang is installed beside the mock library that we provided.
 // RUN: echo '[{"directory":"%t","command":"%t/mock-libcxx/bin/clang++ -stdlib=libc++ -std=c++11 -target x86_64-apple-darwin -c test.cpp","file":"test.cpp"}]' | sed -e 's/\\/\//g' > %t/compile_commands.json

--- a/clang-tools-extra/test/clang-tidy/infrastructure/remarks.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/remarks.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t
-// RUN: cp -r %S/Inputs/remarks %t
+// RUN: cp -R %S/Inputs/remarks %t
 // RUN: cp %s %t/t.cpp
 
 // RUN: clang-tidy -checks='-*,modernize-use-override,clang-diagnostic-module-import' %t/t.cpp -- \

--- a/clang/test/APINotes/module-cache.m
+++ b/clang/test/APINotes/module-cache.m
@@ -4,7 +4,7 @@
 // RUN: mkdir -p %t/APINotes
 // RUN: cp %S/Inputs/APINotes/SomeOtherKit.apinotes %t/APINotes/SomeOtherKit.apinotes
 // RUN: mkdir -p %t/Frameworks
-// RUN: cp -r %S/Inputs/Frameworks/SomeOtherKit.framework %t/Frameworks
+// RUN: cp -R %S/Inputs/Frameworks/SomeOtherKit.framework %t/Frameworks
 
 // First build: check that 'methodB' is unavailable but 'methodA' is available.
 // RUN: not %clang_cc1 -fmodules -fimplicit-module-maps -Rmodule-build -fmodules-cache-path=%t/ModulesCache -iapinotes-modules %t/APINotes  -F %t/Frameworks %s > %t/before.log 2>&1

--- a/clang/test/ClangScanDeps/build-session-validation-relocated-modules.c
+++ b/clang/test/ClangScanDeps/build-session-validation-relocated-modules.c
@@ -20,7 +20,7 @@
 // This can occur on an incremental build where dependency relationships are updated.
 // RUN: sleep 1
 // RUN: mkdir %t/preferred_frameworks/
-// RUN: cp -r %t/fallback_frameworks/MovedDep.framework %t/preferred_frameworks/
+// RUN: cp -R %t/fallback_frameworks/MovedDep.framework %t/preferred_frameworks/
 // RUN: touch %t/fallback_frameworks/InvalidatedDep.framework/Modules/module.modulemap
 
 // RUN: clang-scan-deps -format experimental-full -j 1 \

--- a/clang/test/ClangScanDeps/header-search-pruning.cpp
+++ b/clang/test/ClangScanDeps/header-search-pruning.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: cp -r %S/Inputs/header-search-pruning/* %t
+// RUN: cp -R %S/Inputs/header-search-pruning/* %t
 // RUN: cp %S/header-search-pruning.cpp %t/header-search-pruning.cpp
 // RUN: sed -e "s|DIR|%/t|g" -e "s|DEFINES|-DINCLUDE_A|g"             %S/Inputs/header-search-pruning/cdb.json > %t/cdb_a.json
 // RUN: sed -e "s|DIR|%/t|g" -e "s|DEFINES|-DINCLUDE_B|g"             %S/Inputs/header-search-pruning/cdb.json > %t/cdb_b.json

--- a/clang/test/ClangScanDeps/modules-context-hash.c
+++ b/clang/test/ClangScanDeps/modules-context-hash.c
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir %t
-// RUN: cp -r %S/Inputs/modules-context-hash/* %t
+// RUN: cp -R %S/Inputs/modules-context-hash/* %t
 
 // Check that the scanner reports the same module as distinct dependencies when
 // a single translation unit gets compiled with multiple command-lines that

--- a/clang/test/ClangScanDeps/modules-relocated-mm-macro.c
+++ b/clang/test/ClangScanDeps/modules-relocated-mm-macro.c
@@ -11,7 +11,7 @@
 // RUN:   -F %t/frameworks1 -F %t/frameworks2 \
 // RUN:   -c %t/tu1.m -o %t/tu1.o
 
-// RUN: cp -r %t/frameworks2/A.framework %t/frameworks1
+// RUN: cp -R %t/frameworks2/A.framework %t/frameworks1
 
 // RUN: clang-scan-deps -format experimental-full -o %t/deps2.json 2>&1 -- \
 // RUN:   %clang -fmodules -fmodules-cache-path=%t/cache \

--- a/clang/test/Driver/hip-runtime-libs-linux.hip
+++ b/clang/test/Driver/hip-runtime-libs-linux.hip
@@ -27,8 +27,8 @@
 
 // Test detecting latest /opt/rocm-{release} directory.
 // RUN: rm -rf %t && mkdir -p %t/opt
-// RUN: cp -r %S/Inputs/rocm %t/opt/rocm-3.9.0-1234
-// RUN: cp -r %S/Inputs/rocm %t/opt/rocm-3.10.0
+// RUN: cp -R %S/Inputs/rocm %t/opt/rocm-3.9.0-1234
+// RUN: cp -R %S/Inputs/rocm %t/opt/rocm-3.10.0
 // RUN: %clang -### --hip-link --target=x86_64-linux-gnu \
 // RUN:   --sysroot=%t %t.o 2>&1 \
 // RUN:   | FileCheck -check-prefixes=ROCM-REL %s

--- a/clang/test/Driver/hip-version.hip
+++ b/clang/test/Driver/hip-version.hip
@@ -20,7 +20,7 @@
 
 // RUN: rm -rf %t/Inputs
 // RUN: mkdir -p %t/Inputs
-// RUN: cp -r %S/Inputs/rocm %t/Inputs
+// RUN: cp -R %S/Inputs/rocm %t/Inputs
 // RUN: mkdir -p %t/Inputs/rocm/share/hip
 // RUN: mkdir -p %t/Inputs/rocm/hip
 // RUN: mv %t/Inputs/rocm/bin/.hipVersion %t/Inputs/rocm/share/hip/version

--- a/clang/test/Driver/rocm-detect-lib-llvm.hip
+++ b/clang/test/Driver/rocm-detect-lib-llvm.hip
@@ -14,7 +14,7 @@
 // Set up a fake ROCm installation rooted at /opt/rocm in the synthetic sysroot
 // so that the device libraries and HIP runtime can be found.
 // RUN: mkdir -p %t/sysroot/opt/rocm
-// RUN: cp -r %S/Inputs/rocm/* %t/sysroot/opt/rocm
+// RUN: cp -R %S/Inputs/rocm/* %t/sysroot/opt/rocm
 // Copy the built clang binary so that its InstalledDir and the real path used
 // by the driver both reside under /opt/rocm/lib/llvm/bin, which is what the
 // detection logic inspects.

--- a/clang/test/Driver/rocm-detect.hip
+++ b/clang/test/Driver/rocm-detect.hip
@@ -29,7 +29,7 @@
 
 // RUN: rm -rf %t/myhip
 // RUN: mkdir -p %t/myhip
-// RUN: cp -r %S/Inputs/rocm/bin %t/myhip
+// RUN: cp -R %S/Inputs/rocm/bin %t/myhip
 
 // Test HIP_PATH overrides ROCM_PATH.
 // RUN: env ROCM_PATH=%S/Inputs/rocm HIP_PATH=%t/myhip \
@@ -68,8 +68,8 @@
 // RUN: rm -rf %t/myhip_nouse
 // RUN: mkdir -p %t/myhip
 // RUN: mkdir -p %t/myhip_nouse
-// RUN: cp -r %S/Inputs/rocm/bin %t/myhip
-// RUN: cp -r %S/Inputs/rocm/bin %t/myhip_nouse
+// RUN: cp -R %S/Inputs/rocm/bin %t/myhip
+// RUN: cp -R %S/Inputs/rocm/bin %t/myhip_nouse
 // RUN: env ROCM_PATH=%S/Inputs/rocm HIP_PATH=%t/myhip_nouse \
 // RUN:   %clang -### -target x86_64-linux-gnu --offload-arch=gfx1010 --hip-link \
 // RUN:   --hip-path=%t/myhip --print-rocm-search-dirs %s 2>&1 \
@@ -77,7 +77,7 @@
 
 // Test detecting /usr directory.
 // RUN: rm -rf %t/*
-// RUN: cp -r %S/Inputs/rocm %t/usr
+// RUN: cp -R %S/Inputs/rocm %t/usr
 // RUN: mkdir -p %t/usr/share/hip
 // RUN: mv %t/usr/bin/.hipVersion %t/usr/share/hip/version
 // RUN: mkdir -p %t/usr/local
@@ -88,8 +88,8 @@
 // Test detecting latest /opt/rocm-{release} directory.
 // RUN: rm -rf %t/*
 // RUN: mkdir -p %t/opt
-// RUN: cp -r %S/Inputs/rocm %t/opt/rocm-3.9.0-1234
-// RUN: cp -r %S/Inputs/rocm %t/opt/rocm-3.10.0
+// RUN: cp -R %S/Inputs/rocm %t/opt/rocm-3.9.0-1234
+// RUN: cp -R %S/Inputs/rocm %t/opt/rocm-3.10.0
 // RUN: %clang -### --target=x86_64-linux-gnu --offload-arch=gfx1010 --sysroot=%t \
 // RUN:   --print-rocm-search-dirs %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=ROCM-REL %s

--- a/clang/test/InstallAPI/binary-attributes.test
+++ b/clang/test/InstallAPI/binary-attributes.test
@@ -1,7 +1,7 @@
 ; RUN: rm -rf %t 
 ; RUN: split-file %s %t
 ; RUN: mkdir -p %t/System/Library/Frameworks 
-; RUN: cp -r %S/Inputs/Simple/Simple.framework %t/System/Library/Frameworks/
+; RUN: cp -R %S/Inputs/Simple/Simple.framework %t/System/Library/Frameworks/
 ; RUN: yaml2obj %S/Inputs/Simple/Simple.yaml -o %t/Simple 
 
 ; RUN: not clang-installapi -target x86_64h-apple-macos10.12 \

--- a/clang/test/InstallAPI/diagnostics-zippered.test
+++ b/clang/test/InstallAPI/diagnostics-zippered.test
@@ -1,6 +1,6 @@
 ; RUN: rm -rf %t
 ; RUN: split-file %s %t
-; RUN: cp -r %S/Inputs/Foundation/Foundation.framework %t/System/Library/Frameworks/
+; RUN: cp -R %S/Inputs/Foundation/Foundation.framework %t/System/Library/Frameworks/
 ; RUN: sed -e "s|DSTROOT|%/t|g" %t/inputs.json.in > %t/inputs.json
 ; RUN: yaml2obj %t/Mismatch.yaml -o %t/System/Library/Frameworks/Mismatch.framework/Mismatch
 

--- a/clang/test/InstallAPI/directory-scanning-dylib.test
+++ b/clang/test/InstallAPI/directory-scanning-dylib.test
@@ -1,7 +1,7 @@
 ; RUN: rm -rf %t
 ; RUN: split-file %s %t
 ; RUN: mkdir -p %t/DstRoot/
-; RUN: cp -r %S/Inputs/LibFoo/* %t/DstRoot/
+; RUN: cp -R %S/Inputs/LibFoo/* %t/DstRoot/
 
 ; RUN: clang-installapi \
 ; RUN: -target arm64-apple-macos12 -install_name @rpath/libfoo.dylib \

--- a/clang/test/InstallAPI/directory-scanning-frameworks.test
+++ b/clang/test/InstallAPI/directory-scanning-frameworks.test
@@ -1,8 +1,8 @@
 ; RUN: rm -rf %t
 ; RUN: split-file %s %t
 ; RUN: mkdir -p %t/SDKRoot/System/Library/Frameworks 
-; RUN: cp -r %S/Inputs/Simple/* %t/SDKRoot/System/Library/Frameworks/
-; RUN: cp -r %S/Inputs/Foundation/* %t/SDKRoot/System/Library/Frameworks/
+; RUN: cp -R %S/Inputs/Simple/* %t/SDKRoot/System/Library/Frameworks/
+; RUN: cp -R %S/Inputs/Foundation/* %t/SDKRoot/System/Library/Frameworks/
 # Skip over header that produces warnings.
 ; RUN: rm %t/SDKRoot/System/Library/Frameworks/Simple.framework/Headers/Simple.h
 

--- a/clang/test/InstallAPI/directory-scanning-subdirectories.test
+++ b/clang/test/InstallAPI/directory-scanning-subdirectories.test
@@ -1,7 +1,7 @@
 ; RUN: rm -rf %t
 ; RUN: split-file %s %t
 ; RUN: mkdir -p %t/DstRoot/
-; RUN: cp -r %S/Inputs/LibFoo/* %t/DstRoot/
+; RUN: cp -R %S/Inputs/LibFoo/* %t/DstRoot/
 
 ; RUN: clang-installapi \
 ; RUN: -target arm64-apple-macos12 -install_name @rpath/libfoo.dylib \

--- a/clang/test/InstallAPI/exclusive-passes-zippered.test
+++ b/clang/test/InstallAPI/exclusive-passes-zippered.test
@@ -1,7 +1,7 @@
 ; RUN: rm -rf %t
 ; RUN: split-file %s %t
 ; RUN: mkdir -p %t/Frameworks/
-; RUN: cp -r %S/Inputs/Zippered/Zippered.framework %t/Frameworks/
+; RUN: cp -R %S/Inputs/Zippered/Zippered.framework %t/Frameworks/
 ; RUN: sed -e "s|DSTROOT|%/t|g" %t/inputs.json.in > %t/inputs.json
 ; RUN: yaml2obj %S/Inputs/Zippered/Zippered.yaml -o %t/Frameworks/Zippered.framework/Zippered
 

--- a/clang/test/InstallAPI/extra-exclude-headers.test
+++ b/clang/test/InstallAPI/extra-exclude-headers.test
@@ -1,8 +1,8 @@
 ; RUN: rm -rf %t 
 ; RUN: split-file %s %t
 ; RUN: mkdir -p %t/System/Library/Frameworks 
-; RUN: cp -r %S/Inputs/Simple/Simple.framework %t/System/Library/Frameworks/
-; RUN: cp -r %S/Inputs/Foundation/Foundation.framework %t/System/Library/Frameworks/
+; RUN: cp -R %S/Inputs/Simple/Simple.framework %t/System/Library/Frameworks/
+; RUN: cp -R %S/Inputs/Foundation/Foundation.framework %t/System/Library/Frameworks/
 ; RUN: sed -e "s|DSTROOT|%/t|g" %t/inputs.json.in > %t/inputs.json
 ; RUN: yaml2obj %S/Inputs/Simple/Simple.yaml -o %t/Simple 
 

--- a/clang/test/InstallAPI/forwarded-search-paths.test
+++ b/clang/test/InstallAPI/forwarded-search-paths.test
@@ -3,8 +3,8 @@
 ; RUN: sed -e "s|DSTROOT|%/t|g" %t/input.json.in > %t/input.json
 
 ; RUN: mkdir -p %t/System/Library/Frameworks 
-; RUN: cp -r %S/Inputs/Foundation/Foundation.framework %t/System/Library/Frameworks/
-; RUN: cp -r %S/Inputs/Simple/Simple.framework %t/System/Library/Frameworks/
+; RUN: cp -R %S/Inputs/Foundation/Foundation.framework %t/System/Library/Frameworks/
+; RUN: cp -R %S/Inputs/Simple/Simple.framework %t/System/Library/Frameworks/
 ; RUN: yaml2obj %S/Inputs/Simple/Simple.yaml -o %t/Simple 
 ; RUN: mkdir -p %t/usr/include/after
 

--- a/clang/test/InstallAPI/umbrella-headers-unix.test
+++ b/clang/test/InstallAPI/umbrella-headers-unix.test
@@ -4,7 +4,7 @@
 ; RUN: split-file %s %t
 ; RUN: sed -e "s|DSTROOT|%/t|g" %t/inputs.json.in > %t/inputs.json
 ; RUN: mkdir %t/Frameworks/
-; RUN: cp -r %S/Inputs/Umbrella/Umbrella.framework %t/Frameworks/
+; RUN: cp -R %S/Inputs/Umbrella/Umbrella.framework %t/Frameworks/
 
 // Only validate path based input that rely on regex matching on unix based file systems.
 ; RUN: clang-installapi --target=arm64-apple-macosx13 \

--- a/clang/test/InstallAPI/umbrella-headers.test
+++ b/clang/test/InstallAPI/umbrella-headers.test
@@ -1,7 +1,7 @@
 ; RUN: rm -rf %t
 ; RUN: split-file %s %t
 ; RUN: sed -e "s|DSTROOT|%/t|g" %t/inputs.json.in > %t/inputs.json
-; RUN: cp -r %S/Inputs/Umbrella/Umbrella.framework %t/Frameworks/
+; RUN: cp -R %S/Inputs/Umbrella/Umbrella.framework %t/Frameworks/
 
 // Check base filename matches.
 ; RUN: clang-installapi --target=arm64-apple-macosx13 \

--- a/clang/test/Modules/add-remove-private.m
+++ b/clang/test/Modules/add-remove-private.m
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: rm -rf %t.mcp
 // RUN: mkdir -p %t
-// RUN: cp -r %S/Inputs/AddRemovePrivate.framework %t/AddRemovePrivate.framework
+// RUN: cp -R %S/Inputs/AddRemovePrivate.framework %t/AddRemovePrivate.framework
 
 // Build with module.private.modulemap
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t.mcp -fdisable-module-hash -F %t %s -verify -DP -Wno-private-module

--- a/clang/test/Modules/build-session-validation-relocated-modules.c
+++ b/clang/test/Modules/build-session-validation-relocated-modules.c
@@ -10,7 +10,7 @@
 // NO_RELOC-NOT: checking if module {{.*}} has relocated
 
 // RUN: mkdir %t/preferred_frameworks/
-// RUN: cp -r %t/fallback_frameworks/IndirectDep.framework %t/preferred_frameworks/
+// RUN: cp -R %t/fallback_frameworks/IndirectDep.framework %t/preferred_frameworks/
 
 // Verify no relocation checks happen because pcms are newer than timestamp.
 // RUN: %clang -fmodules -fimplicit-module-maps  -fsyntax-only %t/tu1.c \

--- a/clang/test/Modules/dependent-module-different-location.m
+++ b/clang/test/Modules/dependent-module-different-location.m
@@ -7,7 +7,7 @@
 //
 // Now add Movable.framework to JustBuilt.
 // RUN: mkdir %t/JustBuilt
-// RUN: cp -r %t/StableFrameworks/Movable.framework %t/JustBuilt/Movable.framework
+// RUN: cp -R %t/StableFrameworks/Movable.framework %t/JustBuilt/Movable.framework
 //
 // Load Movable.pcm at first for JustBuilt location and then in the same TU try to load transitively for StableFrameworks location.
 // RUN: %clang_cc1 -fsyntax-only -F %t/JustBuilt -F %t/StableFrameworks %t/trigger-error.m \

--- a/clang/test/Modules/implicit-invalidate-common.c
+++ b/clang/test/Modules/implicit-invalidate-common.c
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t
 // RUN: mkdir -p %t/implicit-invalidate-common
-// RUN: cp -r %S/Inputs/implicit-invalidate-common %t/
+// RUN: cp -R %S/Inputs/implicit-invalidate-common %t/
 // RUN: echo '#include "A.h"' > %t/A.c
 // RUN: echo '#include "B.h"' > %t/B.c
 

--- a/clang/test/Modules/include-relative.c
+++ b/clang/test/Modules/include-relative.c
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
-// RUN: cp -r %S/Inputs/include-relative %t/include-relative
+// RUN: cp -R %S/Inputs/include-relative %t/include-relative
 // RUN: cd %t
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps -x c -verify -fmodules-cache-path=%t -I include-relative %s
 

--- a/clang/test/Modules/relative-import-path.c
+++ b/clang/test/Modules/relative-import-path.c
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t
-// RUN: cp -r %S/Inputs/relative-import-path %t
+// RUN: cp -R %S/Inputs/relative-import-path %t
 // RUN: cp %s %t/t.c
 
 // Use FileCheck, which is more flexible.

--- a/clang/test/Tooling/clang-check-mac-libcxx-abspath.cpp
+++ b/clang/test/Tooling/clang-check-mac-libcxx-abspath.cpp
@@ -5,7 +5,7 @@
 // RUN: mkdir %t
 //
 // Install the mock libc++ (simulates the libc++ directory structure).
-// RUN: cp -r %S/Inputs/mock-libcxx %t/
+// RUN: cp -R %S/Inputs/mock-libcxx %t/
 //
 // Pretend clang is installed beside the mock library that we provided.
 // RUN: echo '[{"directory":"%t","command":"%t/mock-libcxx/bin/clang++ -stdlib=libc++ -target x86_64-apple-darwin -c test.cpp","file":"test.cpp"}]' | sed -e 's/\\/\//g' > %t/compile_commands.json

--- a/clang/test/Tooling/clang-check-mac-libcxx-fixed-compilation-db.cpp
+++ b/clang/test/Tooling/clang-check-mac-libcxx-fixed-compilation-db.cpp
@@ -6,7 +6,7 @@
 // RUN: mkdir %t
 //
 // Install the mock libc++ (simulates the libc++ directory structure).
-// RUN: cp -r %S/Inputs/mock-libcxx %t/
+// RUN: cp -R %S/Inputs/mock-libcxx %t/
 //
 // RUN: cp clang-check %t/mock-libcxx/bin/
 // RUN: cp %s %t/test.cpp

--- a/clang/test/Tooling/clang-check-mac-libcxx-relpath.cpp
+++ b/clang/test/Tooling/clang-check-mac-libcxx-relpath.cpp
@@ -5,7 +5,7 @@
 // RUN: mkdir %t
 //
 // Install the mock libc++ (simulates the libc++ directory structure).
-// RUN: cp -r %S/Inputs/mock-libcxx %t/
+// RUN: cp -R %S/Inputs/mock-libcxx %t/
 //
 // Pretend clang is installed beside the mock library that we provided.
 // RUN: echo '[{"directory":"%t","command":"mock-libcxx/bin/clang++ -stdlib=libc++ -target x86_64-apple-darwin -c test.cpp","file":"test.cpp"}]' | sed -e 's/\\/\//g' > %t/compile_commands.json

--- a/llvm/test/tools/llvm-cov/coverage-prefix-map.test
+++ b/llvm/test/tools/llvm-cov/coverage-prefix-map.test
@@ -18,7 +18,7 @@
 
 Instructions for regenerating the test:
 # cd %S/Inputs/coverage_prefix_map
-cp -r . /tmp/coverage_prefix_map
+cp -R . /tmp/coverage_prefix_map
 
 clang -fprofile-instr-generate -mllvm -enable-name-compression=false -fcoverage-mapping -fcoverage-prefix-map=$PWD=. main.cc -o main
 LLVM_PROFILE_FILE="main.raw" ./main

--- a/llvm/test/tools/llvm-cov/directory_coverage.test
+++ b/llvm/test/tools/llvm-cov/directory_coverage.test
@@ -42,7 +42,7 @@
 
 # The input of this test is generated on Linux.
 # For regenerating the test:
-# cp -r %S/Inputs/directory_coverage /tmp
+# cp -R %S/Inputs/directory_coverage /tmp
 # cd /tmp/directory_coverage
 # clang -fprofile-instr-generate -fcoverage-mapping -mllvm -enable-name-compression=false \
 #   -o main main.cc a0/a1/a2.cc b0/b1_1.cc b0/b1_2.cc c0/c1/c2_1.cc c0/c1/c2_2.cc

--- a/llvm/test/tools/llvm-cov/multithreaded-report.test
+++ b/llvm/test/tools/llvm-cov/multithreaded-report.test
@@ -82,7 +82,7 @@ Instructions for regenerating the test:
 
 # cd %S/Inputs/multithreaded_report
 
-cp -r . /tmp/multithreaded_report
+cp -R . /tmp/multithreaded_report
 
 clang++ -std=c++11 -mllvm -enable-name-compression=false \
     -fprofile-instr-generate -fcoverage-mapping \

--- a/llvm/test/tools/llvm-cov/sources-specified.test
+++ b/llvm/test/tools/llvm-cov/sources-specified.test
@@ -51,7 +51,7 @@ EXPORT-DAG: {{"filename":"(/|\\\\)tmp(/|\\\\)sources_specified(/|\\\\)extra(/|\\
 Instructions for regenerating the test:
 
 # cd %S/Inputs/sources_specified
-cp -r . /tmp/sources_specified
+cp -R . /tmp/sources_specified
 
 clang -mllvm -enable-name-compression=false -fprofile-instr-generate \
     -fcoverage-mapping /tmp/sources_specified/main.cc -o main

--- a/llvm/utils/docker/build_docker_image.sh
+++ b/llvm/utils/docker/build_docker_image.sh
@@ -170,8 +170,8 @@ BUILD_DIR=$(mktemp -d)
 trap "rm -rf $BUILD_DIR" EXIT
 echo "Using a temporary directory for the build: $BUILD_DIR"
 
-cp -r "$SOURCE_DIR/$IMAGE_SOURCE" "$BUILD_DIR/$IMAGE_SOURCE"
-cp -r "$SOURCE_DIR/scripts" "$BUILD_DIR/scripts"
+cp -R "$SOURCE_DIR/$IMAGE_SOURCE" "$BUILD_DIR/$IMAGE_SOURCE"
+cp -R "$SOURCE_DIR/scripts" "$BUILD_DIR/scripts"
 
 mkdir "$BUILD_DIR/checksums"
 if [ "$CHECKSUMS_FILE" != "" ]; then

--- a/llvm/utils/lit/tests/filter-failed-delete.py
+++ b/llvm/utils/lit/tests/filter-failed-delete.py
@@ -2,7 +2,7 @@
 # before running with --filter-failed.
 
 # RUN: rm -rf %t
-# RUN: cp -rL %{inputs}%{fs-sep}filter-failed %t
+# RUN: cp -RL %{inputs}%{fs-sep}filter-failed %t
 #
 # RUN: not %{lit} %t | FileCheck %s --check-prefix=CHECK-FIRST
 #

--- a/llvm/utils/lit/tests/filter-failed-rerun.py
+++ b/llvm/utils/lit/tests/filter-failed-rerun.py
@@ -2,7 +2,7 @@
 # since the last time --filter-failed was run.
 
 # RUN: rm -rf %t
-# RUN: cp -rL %{inputs}%{fs-sep}filter-failed %t
+# RUN: cp -RL %{inputs}%{fs-sep}filter-failed %t
 #
 # RUN: not %{lit} %t | FileCheck %s --check-prefix=CHECK-FIRST
 #

--- a/llvm/utils/lit/tests/filter-failed.py
+++ b/llvm/utils/lit/tests/filter-failed.py
@@ -1,7 +1,7 @@
 # Checks that --filter-failed only runs tests that previously failed.
 
 # RUN: rm -rf %t
-# RUN: cp -rL %{inputs}%{fs-sep}filter-failed %t
+# RUN: cp -RL %{inputs}%{fs-sep}filter-failed %t
 #
 # RUN: not %{lit} %t
 #

--- a/llvm/utils/vscode/llvm/README.md
+++ b/llvm/utils/vscode/llvm/README.md
@@ -20,7 +20,7 @@ sudo npm install -g typescript npx vsce
 ### Install From Source
 ```sh
 cd <extensions-installation-folder>
-cp -r llvm/utils/vscode/llvm .
+cp -R llvm/utils/vscode/llvm .
 cd llvm
 npm install
 npm run vscode:prepublish


### PR DESCRIPTION
`cp -r` translates to `cp -RL` on at least FreeBSD and macOS. `-L` replaces symlinks with flat directories which effectively breaks Apple style bundles like frameworks. Switch to `-R` so that the symlinks don't get broken.