### PR TITLE
[NVPTX] Remove support for `sub` in global initializers.

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -1690,7 +1690,7 @@ void NVPTXAsmPrinter::bufferLEByte(const Constant *CPV, int Bytes,
         break;
       }
       // A symbol-relative integer whose offset is applied outside the
-      // ptrtoint, e.g. add/sub(ptrtoint(@g), C). It can't fold to a ConstantInt
+      // ptrtoint, e.g. add(ptrtoint(@g), C). It can't fold to a ConstantInt
       // because it references a symbol; emit it through lowerConstantForGV, the
       // same path scalar symbol-relative integer globals use.
       AggBuffer->addSymbol(Cexpr, Cexpr);
@@ -1991,15 +1991,12 @@ NVPTXAsmPrinter::lowerConstantForGV(const Constant *CV,
 
   // The MC library also has a right-shift operator, but it isn't consistently
   // signed or unsigned between different targets.
-  case Instruction::Add:
-  case Instruction::Sub: {
+  case Instruction::Add: {
     const MCExpr *LHS = lowerConstantForGV(CE->getOperand(0), ProcessingGeneric);
     const MCExpr *RHS = lowerConstantForGV(CE->getOperand(1), ProcessingGeneric);
     switch (CE->getOpcode()) {
     default: llvm_unreachable("Unknown binary operator constant cast expr");
     case Instruction::Add: return MCBinaryExpr::createAdd(LHS, RHS, Ctx);
-    case Instruction::Sub:
-      return MCBinaryExpr::createSub(LHS, RHS, Ctx);
     }
   }
   }

--- a/llvm/test/CodeGen/NVPTX/global-ordering.ll
+++ b/llvm/test/CodeGen/NVPTX/global-ordering.ll
@@ -22,16 +22,9 @@
 @b = addrspace(1) global i8 1
 
 
-; Emit global aggregates with a field computed from the address of another global.
+; Emit a global aggregate with a field computed from the address of another
+; global.
 @g = addrspace(1) global i8 0
-@h = addrspace(1) global i8 0
 
 ; PTX64: .visible .global .align 8 .u64 sadd[2] = {g+4, 7};
 @sadd = addrspace(1) global { i64, i64 } { i64 add (i64 ptrtoint (ptr addrspace(1) @g to i64), i64 4), i64 7 }
-
-; PTX64: .visible .global .align 8 .u64 ssub[2] = {g-4, 7};
-@ssub = addrspace(1) global { i64, i64 } { i64 sub (i64 ptrtoint (ptr addrspace(1) @g to i64), i64 4), i64 7 }
-
-; PTX32: .visible .global .align 8 .u64 sdiff = (g&4294967295)-(h&4294967295);
-; PTX64: .visible .global .align 8 .u64 sdiff = g-h;
-@sdiff = addrspace(1) global i64 sub (i64 ptrtoint (ptr addrspace(1) @g to i64), i64 ptrtoint (ptr addrspace(1) @h to i64))


### PR DESCRIPTION
I added this in https://github.com/llvm/llvm-project/pull/201220 and
assumed it worked because the pre-commit builders passed.  But (a) this
is not attested in the PTX ISA, and (b) it seems that the builders don't
actually run ptxas.

Oops.  Removed support for `sub`.
