### PR TITLE
[clang][AST] Fix StmtProfile handling of GCCAsmStmt asm strings and clobbers

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -363,6 +363,11 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/bad-signal-to-kill-thread>` check by fixing false
   negatives when the ``SIGTERM`` macro is obtained from a precompiled header.
 
+- Improved :doc:`bugprone-branch-clone
+  <clang-tidy/checks/bugprone/branch-clone>` check by fixing a false positive
+  where ``if``/``else`` branches containing inline assembly that differed only
+  in the asm string or clobber list were reported as identical.
+
 - Improved :doc:`bugprone-casting-through-void
   <clang-tidy/checks/bugprone/casting-through-void>` check by running only on
   C++ files because suggested ``reinterpret_cast`` is not available in pure C.

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/branch-clone-inline-asm.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/branch-clone-inline-asm.cpp
@@ -3,31 +3,19 @@
 int test_asm1(int argc, char**) {
   if (argc > 1) {
 // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: if with identical then and else branches [bugprone-branch-clone]
-    __asm__ volatile(
-      "addi %0, %0, -1"
-      : "+r" (argc)
-      );
+    __asm__ volatile("" : "+r" (argc));
   } else {
 // CHECK-MESSAGES: :[[@LINE-1]]:5: note: else branch starts here
-    __asm__ volatile(
-      "addi %0, %0, -1"
-      : "+r" (argc)
-      );
+    __asm__ volatile("" : "+r" (argc));
   }
   return argc;
 }
 
 int test_asm2(int argc, char**) {
   if (argc > 1) { // no-warning
-    __asm__ volatile(
-      "addi %0, %0, -1"
-      : "+r" (argc)
-      );
+    __asm__ volatile("foo" : "+r" (argc));
   } else {
-    __asm__ volatile(
-      "addi %0, %0, -2"
-      : "+r" (argc)
-      );
+    __asm__ volatile("bar" : "+r" (argc));
   }
   return argc;
 }
@@ -36,20 +24,10 @@ int test_asm3(int argc, char**) {
   int Test1 = 0;
   if (argc > 1) {
 // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: if with identical then and else branches [bugprone-branch-clone]
-    __asm__ volatile(
-      "add %w0, %w0, -1"
-      : "+r" (argc)
-      : "r" (Test1)
-      : "w0"
-      );
+    __asm__ volatile("" : "+r" (argc) : "r" (Test1) : "memory");
   } else {
 // CHECK-MESSAGES: :[[@LINE-1]]:5: note: else branch starts here
-    __asm__ volatile(
-      "add %w0, %w0, -1"
-      : "+r" (argc)
-      : "r" (Test1)
-      : "w0"
-      );
+    __asm__ volatile("" : "+r" (argc) : "r" (Test1) : "memory");
   }
   return argc;
 }
@@ -57,19 +35,9 @@ int test_asm3(int argc, char**) {
 int test_asm4(int argc, char**) {
   int Test1 = 0;
   if (argc > 1) { // no-warning
-    __asm__ volatile(
-      "add %w0, %w0, -1"
-      : "+r" (argc)
-      : "r" (Test1)
-      : "w0"
-      );
+    __asm__ volatile("" : "+r" (argc) : "r" (Test1) : "memory");
   } else {
-    __asm__ volatile(
-      "add %w0, %w0, -1" 
-      : "+r" (argc)
-      : "r" (Test1)
-      : "w1"
-      );
+    __asm__ volatile("" : "+r" (argc) : "r" (Test1) : "cc");
   }
   return argc;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/branch-clone-inline-asm.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/branch-clone-inline-asm.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s bugprone-branch-clone %t --
+// RUN: %check_clang_tidy %s bugprone-branch-clone %t
 
 int test_asm1(int argc, char**) {
   if (argc > 1) {

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/branch-clone-inline-asm.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/branch-clone-inline-asm.cpp
@@ -1,0 +1,75 @@
+// RUN: %check_clang_tidy %s bugprone-branch-clone %t --
+
+int test_asm1(int argc, char**) {
+  if (argc > 1) {
+// CHECK-MESSAGES: :[[@LINE-1]]:3: warning: if with identical then and else branches [bugprone-branch-clone]
+    __asm__ volatile(
+      "addi %0, %0, -1"
+      : "+r" (argc)
+      );
+  } else {
+// CHECK-MESSAGES: :[[@LINE-1]]:5: note: else branch starts here
+    __asm__ volatile(
+      "addi %0, %0, -1"
+      : "+r" (argc)
+      );
+  }
+  return argc;
+}
+
+int test_asm2(int argc, char**) {
+  if (argc > 1) { // no-warning
+    __asm__ volatile(
+      "addi %0, %0, -1"
+      : "+r" (argc)
+      );
+  } else {
+    __asm__ volatile(
+      "addi %0, %0, -2"
+      : "+r" (argc)
+      );
+  }
+  return argc;
+}
+
+int test_asm3(int argc, char**) {
+  int Test1 = 0;
+  if (argc > 1) {
+// CHECK-MESSAGES: :[[@LINE-1]]:3: warning: if with identical then and else branches [bugprone-branch-clone]
+    __asm__ volatile(
+      "add %w0, %w0, -1"
+      : "+r" (argc)
+      : "r" (Test1)
+      : "w0"
+      );
+  } else {
+// CHECK-MESSAGES: :[[@LINE-1]]:5: note: else branch starts here
+    __asm__ volatile(
+      "add %w0, %w0, -1"
+      : "+r" (argc)
+      : "r" (Test1)
+      : "w0"
+      );
+  }
+  return argc;
+}
+
+int test_asm4(int argc, char**) {
+  int Test1 = 0;
+  if (argc > 1) { // no-warning
+    __asm__ volatile(
+      "add %w0, %w0, -1"
+      : "+r" (argc)
+      : "r" (Test1)
+      : "w0"
+      );
+  } else {
+    __asm__ volatile(
+      "add %w0, %w0, -1" 
+      : "+r" (argc)
+      : "r" (Test1)
+      : "w1"
+      );
+  }
+  return argc;
+}

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -784,7 +784,7 @@ Bug Fixes to AST Handling
 - Fixed the SourceLocation and SourceRange of reversed rewritten CXXOperatorCallExpr. (#GH192467)
 - Fixed a assertion when ``__block`` is used on global variables in C mode. (#GH183974)
 - Added missing AST nodes representing the ``decltype`` specifiers in destructor call to AST.
-- Fixed a missing ODR violation diagnostic when two inline definitions of the same function differ only in the inline assembly string or clobber list. (#GH198616)
+- Fixed a missing ODR violation diagnostic introduced by the inline assembly string or clobber list. (#GH198616)
 
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -784,7 +784,7 @@ Bug Fixes to AST Handling
 - Fixed the SourceLocation and SourceRange of reversed rewritten CXXOperatorCallExpr. (#GH192467)
 - Fixed a assertion when ``__block`` is used on global variables in C mode. (#GH183974)
 - Added missing AST nodes representing the ``decltype`` specifiers in destructor call to AST.
-- Fixed ``GCCAsmStmt`` profiling so that inline asm statements differing only in their asm string or clobber list no longer compare equal in ``Stmt::Profile`` and the ODR hash. (#GH198616)
+- Fixed a missing ODR violation diagnostic when two inline definitions of the same function differ only in the inline assembly string or clobber list. (#GH198616)
 
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -784,6 +784,7 @@ Bug Fixes to AST Handling
 - Fixed the SourceLocation and SourceRange of reversed rewritten CXXOperatorCallExpr. (#GH192467)
 - Fixed a assertion when ``__block`` is used on global variables in C mode. (#GH183974)
 - Added missing AST nodes representing the ``decltype`` specifiers in destructor call to AST.
+- Fixed ``GCCAsmStmt`` profiling so that inline asm statements differing only in their asm string or clobber list no longer compare equal in ``Stmt::Profile`` and the ODR hash. (#GH198616)
 
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/AST/StmtProfile.cpp
+++ b/clang/lib/AST/StmtProfile.cpp
@@ -332,7 +332,7 @@ void StmtProfiler::VisitGCCAsmStmt(const GCCAsmStmt *S) {
   VisitStmt(S);
   ID.AddBoolean(S->isVolatile());
   ID.AddBoolean(S->isSimple());
-  VisitExpr(S->getAsmStringExpr());
+  Visit(S->getAsmStringExpr());
   ID.AddInteger(S->getNumOutputs());
   for (unsigned I = 0, N = S->getNumOutputs(); I != N; ++I) {
     ID.AddString(S->getOutputName(I));
@@ -345,7 +345,7 @@ void StmtProfiler::VisitGCCAsmStmt(const GCCAsmStmt *S) {
   }
   ID.AddInteger(S->getNumClobbers());
   for (unsigned I = 0, N = S->getNumClobbers(); I != N; ++I)
-    VisitExpr(S->getClobberExpr(I));
+    Visit(S->getClobberExpr(I));
   ID.AddInteger(S->getNumLabels());
   for (auto *L : S->labels())
     VisitDecl(L->getLabel());

--- a/clang/test/Modules/asm-stmt-odr.cppm
+++ b/clang/test/Modules/asm-stmt-odr.cppm
@@ -1,0 +1,67 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: split-file %s %t
+//
+// RUN: %clang_cc1 -x c++ -std=c++20 %t/A.cppm -I%t -emit-module-interface -o %t/A.pcm
+// RUN: %clang_cc1 -x c++ -std=c++20 %t/B.cppm -I%t -emit-module-interface -o %t/B.pcm
+// RUN: %clang_cc1 -x c++ -std=c++20 -fprebuilt-module-path=%t %t/use.cpp -verify
+//
+// RUN: rm %t/A.pcm %t/B.pcm
+// RUN: %clang_cc1 -x c++ -std=c++20 %t/A.cppm -I%t -emit-reduced-module-interface -o %t/A.pcm
+// RUN: %clang_cc1 -x c++ -std=c++20 %t/B.cppm -I%t -emit-reduced-module-interface -o %t/B.pcm
+// RUN: %clang_cc1 -x c++ -std=c++20 -fprebuilt-module-path=%t %t/use.cpp -verify
+
+// Regression test for the StmtProfiler::VisitGCCAsmStmt fix in
+// clang/lib/AST/StmtProfile.cpp (using Visit() so StringLiteral bytes are
+// folded into the FoldingSetNodeID, and therefore into the ODR hash).
+// Without the fix, two inline functions whose only difference is the inline
+// asm body produce the same ODR hash, get merged across modules, and no
+// diagnostic is emitted at the use site.
+
+//--- a.h
+inline int asm_string_func() {
+  int x = 0;
+  __asm__("foo" : "+r"(x));
+  return x;
+}
+inline int clobber_func() {
+  int x = 0;
+  __asm__("" : "+r"(x) : : "memory");
+  return x;
+}
+
+//--- a.v1.h
+inline int asm_string_func() {
+  int x = 0;
+  __asm__("bar" : "+r"(x));        // differs from a.h: asm string
+  return x;
+}
+inline int clobber_func() {
+  int x = 0;
+  __asm__("" : "+r"(x) : : "cc");  // differs from a.h: clobber
+  return x;
+}
+
+//--- A.cppm
+module;
+#include "a.h"
+export module A;
+export using ::asm_string_func;
+export using ::clobber_func;
+
+//--- B.cppm
+module;
+#include "a.v1.h"
+export module B;
+export using ::asm_string_func;
+export using ::clobber_func;
+
+//--- use.cpp
+import A;
+import B;
+// expected-error@*:* 1+{{'asm_string_func' has different definitions in different modules}}
+// expected-error@*:* 1+{{'clobber_func' has different definitions in different modules}}
+// expected-note@*:* 1+{{but in 'A.<global>' found a different body}}
+
+int u1 = asm_string_func();
+int u2 = clobber_func();


### PR DESCRIPTION
`VisitGCCAsmStmt` did not profile asm strings and clobbers because they are not child statements. 
As a result, different inline asm statements could produce the same profile.
This fixes a false positive in `bugprone-branch-clone` where branches containing inline asm were incorrectly reported as identical.

I used AI assistance when writing the test code, but I personally reviewed it. 🤖 

Fixes https://github.com/llvm/llvm-project/issues/198616