### PR TITLE
[ORC] Replace ExecutorSymbolDef with ExecutorAddr in remote lookup.

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
@@ -85,7 +85,7 @@ using SPSSimpleExecutorDylibManagerOpenSignature =
                                                  shared::SPSString, uint64_t);
 
 using SPSSimpleExecutorDylibManagerResolveSignature = shared::SPSExpected<
-    shared::SPSSequence<shared::SPSOptional<shared::SPSExecutorSymbolDef>>>(
+    shared::SPSSequence<shared::SPSOptional<shared::SPSExecutorAddr>>>(
     shared::SPSExecutorAddr, shared::SPSExecutorAddr,
     shared::SPSRemoteSymbolLookupSet);
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/TargetProcessControlTypes.h
@@ -118,7 +118,7 @@ using DylibHandle = ExecutorAddr;
 ///  dylib in the target process.
 using ResolverHandle = ExecutorAddr;
 
-using LookupResult = std::vector<std::optional<ExecutorSymbolDef>>;
+using LookupResult = std::vector<std::optional<ExecutorAddr>>;
 
 } // end namespace tpctypes
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/ExecutorResolver.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/ExecutorResolver.h
@@ -23,7 +23,7 @@ namespace llvm::orc {
 
 class ExecutorResolver {
 public:
-  using ResolveResult = Expected<std::vector<std::optional<ExecutorSymbolDef>>>;
+  using ResolveResult = Expected<std::vector<std::optional<ExecutorAddr>>>;
   using YieldResolveResultFn = unique_function<void(ResolveResult)>;
 
   virtual ~ExecutorResolver() = default;

--- a/llvm/lib/ExecutionEngine/Orc/EPCDynamicLibrarySearchGenerator.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/EPCDynamicLibrarySearchGenerator.cpp
@@ -81,8 +81,8 @@ Error EPCDynamicLibrarySearchGenerator::tryToGenerate(
         SymbolMap NewSymbols;
         for (auto &[Name, Flags] : LookupSymbols) {
           const auto &Sym = *SymsIt++;
-          if (Sym && Sym->getAddress())
-            NewSymbols[Name] = *Sym;
+          if (Sym && *Sym)
+            NewSymbols[Name] = {*Sym, JITSymbolFlags::Exported};
           else if (LLVM_UNLIKELY(!Sym &&
                                  Flags == SymbolLookupFlags::RequiredSymbol))
             MissingSymbols.insert(Name);

--- a/llvm/lib/ExecutionEngine/Orc/EPCGenericDylibManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/EPCGenericDylibManager.cpp
@@ -70,8 +70,7 @@ void EPCGenericDylibManager::lookupAsync(tpctypes::DylibHandle H,
       SAs.Resolve,
       [Complete = std::move(Complete)](
           Error SerializationErr,
-          Expected<std::vector<std::optional<ExecutorSymbolDef>>>
-              Result) mutable {
+          Expected<std::vector<std::optional<ExecutorAddr>>> Result) mutable {
         if (SerializationErr) {
           cantFail(Result.takeError());
           Complete(std::move(SerializationErr));
@@ -89,8 +88,7 @@ void EPCGenericDylibManager::lookupAsync(tpctypes::DylibHandle H,
       SAs.Resolve,
       [Complete = std::move(Complete)](
           Error SerializationErr,
-          Expected<std::vector<std::optional<ExecutorSymbolDef>>>
-              Result) mutable {
+          Expected<std::vector<std::optional<ExecutorAddr>>> Result) mutable {
         if (SerializationErr) {
           cantFail(Result.takeError());
           Complete(std::move(SerializationErr));

--- a/llvm/lib/ExecutionEngine/Orc/ExecutorResolutionGenerator.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/ExecutorResolutionGenerator.cpp
@@ -66,8 +66,8 @@ Error ExecutorResolutionGenerator::tryToGenerate(
         SymbolMap NewSyms;
         for (auto &[Name, Flags] : LookupSymbols) {
           const auto &Sym = *Syms++;
-          if (Sym && Sym->getAddress())
-            NewSyms[Name] = *Sym;
+          if (Sym && *Sym)
+            NewSyms[Name] = {*Sym, JITSymbolFlags::Exported};
           else if (LLVM_UNLIKELY(!Sym &&
                                  Flags == SymbolLookupFlags::RequiredSymbol))
             MissingSymbols.insert(Name);

--- a/llvm/lib/ExecutionEngine/Orc/SelfExecutorProcessControl.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/SelfExecutorProcessControl.cpp
@@ -178,8 +178,7 @@ void SelfExecutorProcessControl::InProcessDylibManager::lookupSymbolsAsync(
     if (!Addr && KV.second == SymbolLookupFlags::RequiredSymbol)
       R.emplace_back();
     else
-      R.emplace_back(ExecutorSymbolDef(ExecutorAddr::fromPtr(Addr),
-                                       JITSymbolFlags::Exported));
+      R.emplace_back(ExecutorAddr::fromPtr(Addr));
   }
   Complete(std::move(R));
 }

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/ExecutorResolver.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/ExecutorResolver.cpp
@@ -9,7 +9,7 @@ namespace llvm::orc {
 void DylibSymbolResolver::resolveAsync(
     const RemoteSymbolLookupSet &L,
     ExecutorResolver::YieldResolveResultFn &&OnResolve) {
-  std::vector<std::optional<ExecutorSymbolDef>> Result;
+  std::vector<std::optional<ExecutorAddr>> Result;
   auto DL = sys::DynamicLibrary(Handle.toPtr<void *>());
 
   for (const auto &E : L) {
@@ -35,9 +35,7 @@ void DylibSymbolResolver::resolveAsync(
       if (!Addr && E.Required)
         Result.emplace_back();
       else
-        // FIXME: determine accurate JITSymbolFlags.
-        Result.emplace_back(ExecutorSymbolDef(ExecutorAddr::fromPtr(Addr),
-                                              JITSymbolFlags::Exported));
+        Result.emplace_back(ExecutorAddr::fromPtr(Addr));
     }
   }
 

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.cpp
@@ -47,8 +47,7 @@ SimpleExecutorDylibManager::open(const std::string &Path, uint64_t Mode) {
 ExecutorResolver::ResolveResult
 SimpleExecutorDylibManager::resolve(ExecutorAddr Resolver,
                                     RemoteSymbolLookupSet Lookup) {
-  using TmpResult =
-      MSVCPExpected<std::vector<std::optional<ExecutorSymbolDef>>>;
+  using TmpResult = MSVCPExpected<std::vector<std::optional<ExecutorAddr>>>;
   std::promise<TmpResult> P;
   auto F = P.get_future();
   Resolver.toPtr<ExecutorResolver *>()->resolveAsync(

--- a/llvm/tools/lli/ForwardingMemoryManager.h
+++ b/llvm/tools/lli/ForwardingMemoryManager.h
@@ -112,8 +112,7 @@ public:
       if (!Syms->front())
         return make_error<StringError>("Expected valid address",
                                        inconvertibleErrorCode());
-      return JITSymbol(Syms->front()->getAddress().getValue(),
-                       Syms->front()->getFlags());
+      return JITSymbol(Syms->front()->getValue(), JITSymbolFlags::Exported);
     } else
       return Syms.takeError();
   }

--- a/llvm/unittests/ExecutionEngine/Orc/ObjectLinkingLayerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/ObjectLinkingLayerTest.cpp
@@ -303,13 +303,10 @@ TEST(ObjectLinkingLayerSearchGeneratorTest, AbsoluteSymbolsObjectLayer) {
       tpctypes::LookupResult Result;
       EXPECT_EQ(Symbols.size(), 1u);
       for (auto &Sym : Symbols) {
-        if (*Sym.first == "_testFunc") {
-          ExecutorSymbolDef Def{ExecutorAddr::fromPtr((void *)0x1000),
-                                JITSymbolFlags::Exported};
-          Result.emplace_back(Def);
-        } else {
+        if (*Sym.first == "_testFunc")
+          Result.emplace_back(ExecutorAddr::fromPtr((void *)0x1000));
+        else
           ADD_FAILURE() << "unexpected symbol request " << *Sym.first;
-        }
       }
       Complete(std::move(Result));
     }


### PR DESCRIPTION
Update DylibManager and associated interfaces to return ExecutorAddrs for remote symbols, rather than ExecutorSymbolDefs. No clients were using the flags component of ExecutorSymbolDef, and this brings the SimpleExecutorDylibManager implementation in OrcTargetProcess into closer alignment with the NativeDylibManager implementation in the new ORC runtime.