### PR TITLE
[orc-rt] Make NativeDylibManager::lookup return optional addresses.

### DIFF
--- a/orc-rt/include/orc-rt/NativeDylibManager.h
+++ b/orc-rt/include/orc-rt/NativeDylibManager.h
@@ -62,11 +62,13 @@ public:
   /// Lookup addresses of the given symbols in the given library.
   ///
   /// Each entry in Symbols pairs a name with a flag indicating whether the
-  /// symbol is required or weakly referenced. A missing required symbol
-  /// causes lookup to fail with an error. A missing weakly-referenced symbol
-  /// is returned as a zero address.
+  /// symbol is required or weakly referenced. A missing required symbol is
+  /// reported as an empty optional in the result vector; a missing
+  /// weakly-referenced symbol is reported as a present optional with a zero
+  /// (nullptr) address. This matches the resolve semantics of
+  /// llvm::orc::rt_bootstrap::SimpleExecutorDylibManager.
   using OnLookupCompleteFn =
-      move_only_function<void(Expected<std::vector<void *>>)>;
+      move_only_function<void(Expected<std::vector<std::optional<void *>>>)>;
   void lookup(OnLookupCompleteFn &&OnLookupComplete, void *Handle,
               SymbolLookupSet Symbols);
 

--- a/orc-rt/lib/executor/NativeDylibManager.cpp
+++ b/orc-rt/lib/executor/NativeDylibManager.cpp
@@ -67,22 +67,14 @@ void NativeDylibManager::lookup(OnLookupCompleteFn &&OnLookupComplete,
 
   auto Addrs = hostOSLibraryLookup(Handle, Names);
 
-  bool HasMissing = false;
-  std::ostringstream ErrMsg;
-  for (size_t I = 0, E = Symbols.size(); I != E; ++I) {
-    if (Addrs[I] == nullptr && Symbols[I].second == RequiredSymbol) {
-      if (!HasMissing) {
-        ErrMsg << "Required symbols {";
-        HasMissing = true;
-      }
-      ErrMsg << " \"" << Names[I] << "\"";
-    }
-  }
-  if (HasMissing) {
-    ErrMsg << " } not found";
-    OnLookupComplete(make_error<StringError>(ErrMsg.str()));
-    return;
-  }
+  // Convert weak-missing entries (empty optional from hostOSLibraryLookup)
+  // to a present zero address. This matches the resolve semantics of
+  // llvm::orc::rt_bootstrap::SimpleExecutorDylibManager: an empty optional
+  // in the result signals a missing required symbol, while a missing
+  // weakly-referenced symbol is reported as a zero address.
+  for (size_t I = 0, E = Symbols.size(); I != E; ++I)
+    if (!Addrs[I] && Symbols[I].second == WeaklyReferencedSymbol)
+      Addrs[I] = nullptr;
 
   OnLookupComplete(std::move(Addrs));
 }

--- a/orc-rt/lib/executor/Unix/NativeDylibAPIs.inc
+++ b/orc-rt/lib/executor/Unix/NativeDylibAPIs.inc
@@ -41,12 +41,22 @@ orc_rt::Error hostOSUnloadLibrary(void *Handle) {
   return orc_rt::Error::success();
 }
 
-std::vector<void *> hostOSLibraryLookup(void *Handle,
-                                        const std::vector<std::string> &Names) {
-  std::vector<void *> Result;
+std::vector<std::optional<void *>>
+hostOSLibraryLookup(void *Handle, const std::vector<std::string> &Names) {
+  std::vector<std::optional<void *>> Result;
   Result.reserve(Names.size());
-  for (const auto &Name : Names)
-    Result.push_back(dlsym(Handle, Name.c_str()));
+  // Reset dlerror so we can distinguish "dlsym returned null because the
+  // symbol is present at address 0" from "dlsym returned null because the
+  // symbol isn't in the library" via per-iteration dlerror() checks.
+  dlerror();
+  for (const auto &Name : Names) {
+    if (void *Addr = dlsym(Handle, Name.c_str()))
+      Result.push_back(Addr);
+    else if (dlerror() == nullptr)
+      Result.push_back(nullptr);
+    else
+      Result.push_back(std::nullopt);
+  }
   return Result;
 }
 

--- a/orc-rt/lib/executor/sps-ci/NativeDylibManagerSPSCI.cpp
+++ b/orc-rt/lib/executor/sps-ci/NativeDylibManagerSPSCI.cpp
@@ -54,7 +54,7 @@ ORC_RT_SPS_WRAPPER(
 
 ORC_RT_SPS_WRAPPER(
     orc_rt_ci_sps_NativeDylibManager_lookup,
-    SPSExpected<SPSSequence<SPSExecutorAddr>>(
+    SPSExpected<SPSSequence<SPSOptional<SPSExecutorAddr>>>(
         SPSExecutorAddr, SPSExecutorAddr,
         SPSSequence<SPSTuple<SPSString, bool>>),
     WrapperFunction::handleWithAsyncMethod(&NativeDylibManager::lookup))

--- a/orc-rt/unittests/NativeDylibManagerSPSCITest.cpp
+++ b/orc-rt/unittests/NativeDylibManagerSPSCITest.cpp
@@ -87,7 +87,7 @@ protected:
   template <typename OnCompleteFn>
   void spsLookup(OnCompleteFn &&OnComplete, void *Handle,
                  NativeDylibManager::SymbolLookupSet Symbols) {
-    using SPSSig = SPSExpected<SPSSequence<SPSExecutorAddr>>(
+    using SPSSig = SPSExpected<SPSSequence<SPSOptional<SPSExecutorAddr>>>(
         SPSExecutorAddr, SPSExecutorAddr,
         SPSSequence<SPSTuple<SPSString, bool>>);
     SPSWrapperFunction<SPSSig>::call(
@@ -126,14 +126,16 @@ TEST_F(NativeDylibManagerSPSCITest, LookupSingleSymbol) {
   spsLoad(waitFor(LoadResult), NDM_TEST_LIB_PATH);
   void *Handle = cantFail(cantFail(LoadResult.get()));
 
-  std::future<Expected<Expected<std::vector<void *>>>> LookupResult;
+  std::future<Expected<Expected<std::vector<std::optional<void *>>>>>
+      LookupResult;
   spsLookup(waitFor(LookupResult), Handle,
             {{"NativeDylibManagerTestFunc", Req}});
   auto Addrs = cantFail(cantFail(LookupResult.get()));
   ASSERT_EQ(Addrs.size(), 1U);
-  EXPECT_NE(Addrs[0], nullptr);
+  ASSERT_TRUE(Addrs[0].has_value());
+  EXPECT_NE(*Addrs[0], nullptr);
 
-  auto *Func = reinterpret_cast<int (*)()>(Addrs[0]);
+  auto *Func = reinterpret_cast<int (*)()>(*Addrs[0]);
   EXPECT_EQ(Func(), 42);
 }
 
@@ -142,17 +144,20 @@ TEST_F(NativeDylibManagerSPSCITest, LookupMultipleSymbols) {
   spsLoad(waitFor(LoadResult), NDM_TEST_LIB_PATH);
   void *Handle = cantFail(cantFail(LoadResult.get()));
 
-  std::future<Expected<Expected<std::vector<void *>>>> LookupResult;
+  std::future<Expected<Expected<std::vector<std::optional<void *>>>>>
+      LookupResult;
   spsLookup(waitFor(LookupResult), Handle,
             {{"NativeDylibManagerTestFunc", Req},
              {"NativeDylibManagerTestFunc2", Req}});
   auto Addrs = cantFail(cantFail(LookupResult.get()));
   ASSERT_EQ(Addrs.size(), 2U);
-  EXPECT_NE(Addrs[0], nullptr);
-  EXPECT_NE(Addrs[1], nullptr);
+  ASSERT_TRUE(Addrs[0].has_value());
+  ASSERT_TRUE(Addrs[1].has_value());
+  EXPECT_NE(*Addrs[0], nullptr);
+  EXPECT_NE(*Addrs[1], nullptr);
 
-  auto *Func1 = reinterpret_cast<int (*)()>(Addrs[0]);
-  auto *Func2 = reinterpret_cast<int (*)()>(Addrs[1]);
+  auto *Func1 = reinterpret_cast<int (*)()>(*Addrs[0]);
+  auto *Func2 = reinterpret_cast<int (*)()>(*Addrs[1]);
   EXPECT_EQ(Func1(), 42);
   EXPECT_EQ(Func2(), 7);
 }
@@ -162,11 +167,14 @@ TEST_F(NativeDylibManagerSPSCITest, LookupWeakMissingSymbol) {
   spsLoad(waitFor(LoadResult), NDM_TEST_LIB_PATH);
   void *Handle = cantFail(cantFail(LoadResult.get()));
 
-  std::future<Expected<Expected<std::vector<void *>>>> LookupResult;
+  std::future<Expected<Expected<std::vector<std::optional<void *>>>>>
+      LookupResult;
   spsLookup(waitFor(LookupResult), Handle, {{"no_such_symbol", Weak}});
   auto Addrs = cantFail(cantFail(LookupResult.get()));
   ASSERT_EQ(Addrs.size(), 1U);
-  EXPECT_EQ(Addrs[0], nullptr);
+  ASSERT_TRUE(Addrs[0].has_value())
+      << "weak-missing symbol should be reported as a present optional";
+  EXPECT_EQ(*Addrs[0], nullptr);
 }
 
 TEST_F(NativeDylibManagerSPSCITest, LookupRequiredMissingSymbol) {
@@ -174,11 +182,13 @@ TEST_F(NativeDylibManagerSPSCITest, LookupRequiredMissingSymbol) {
   spsLoad(waitFor(LoadResult), NDM_TEST_LIB_PATH);
   void *Handle = cantFail(cantFail(LoadResult.get()));
 
-  std::future<Expected<Expected<std::vector<void *>>>> LookupResult;
+  std::future<Expected<Expected<std::vector<std::optional<void *>>>>>
+      LookupResult;
   spsLookup(waitFor(LookupResult), Handle, {{"no_such_symbol", Req}});
-  auto Addrs = cantFail(LookupResult.get());
-  EXPECT_FALSE(!!Addrs);
-  consumeError(Addrs.takeError());
+  auto Addrs = cantFail(cantFail(LookupResult.get()));
+  ASSERT_EQ(Addrs.size(), 1U);
+  EXPECT_FALSE(Addrs[0].has_value())
+      << "required-missing symbol should be reported as an empty optional";
 }
 
 TEST_F(NativeDylibManagerSPSCITest, LookupMixedRequiredAndWeak) {
@@ -186,11 +196,15 @@ TEST_F(NativeDylibManagerSPSCITest, LookupMixedRequiredAndWeak) {
   spsLoad(waitFor(LoadResult), NDM_TEST_LIB_PATH);
   void *Handle = cantFail(cantFail(LoadResult.get()));
 
-  std::future<Expected<Expected<std::vector<void *>>>> LookupResult;
+  std::future<Expected<Expected<std::vector<std::optional<void *>>>>>
+      LookupResult;
   spsLookup(waitFor(LookupResult), Handle,
             {{"NativeDylibManagerTestFunc", Req}, {"no_such_symbol", Weak}});
   auto Addrs = cantFail(cantFail(LookupResult.get()));
   ASSERT_EQ(Addrs.size(), 2U);
-  EXPECT_NE(Addrs[0], nullptr);
-  EXPECT_EQ(Addrs[1], nullptr);
+  ASSERT_TRUE(Addrs[0].has_value());
+  EXPECT_NE(*Addrs[0], nullptr);
+  ASSERT_TRUE(Addrs[1].has_value())
+      << "weak-missing symbol should be reported as a present optional";
+  EXPECT_EQ(*Addrs[1], nullptr);
 }

--- a/orc-rt/unittests/NativeDylibManagerTest.cpp
+++ b/orc-rt/unittests/NativeDylibManagerTest.cpp
@@ -40,12 +40,15 @@ static Expected<void *> syncLoad(NativeDylibManager &NDM, std::string Path) {
 }
 
 // Helper: synchronously run lookup and return results.
-static Expected<std::vector<void *>>
+static Expected<std::vector<std::optional<void *>>>
 syncLookup(NativeDylibManager &NDM, void *Handle,
            NativeDylibManager::SymbolLookupSet Symbols) {
-  std::optional<Expected<std::vector<void *>>> Result;
-  NDM.lookup([&](Expected<std::vector<void *>> R) { Result = std::move(R); },
-             Handle, std::move(Symbols));
+  std::optional<Expected<std::vector<std::optional<void *>>>> Result;
+  NDM.lookup(
+      [&](Expected<std::vector<std::optional<void *>>> R) {
+        Result = std::move(R);
+      },
+      Handle, std::move(Symbols));
   return std::move(*Result);
 }
 
@@ -90,10 +93,11 @@ TEST(NativeDylibManagerTest, LookupSingleSymbol) {
   auto Result = syncLookup(*NDM, Handle, {{"NativeDylibManagerTestFunc", Req}});
   ASSERT_TRUE(!!Result) << toString(Result.takeError());
   ASSERT_EQ(Result->size(), 1U);
-  EXPECT_NE((*Result)[0], nullptr);
+  ASSERT_TRUE((*Result)[0].has_value());
+  EXPECT_NE(*(*Result)[0], nullptr);
 
   // Verify the symbol points to the right function.
-  auto *Func = reinterpret_cast<int (*)()>((*Result)[0]);
+  auto *Func = reinterpret_cast<int (*)()>(*(*Result)[0]);
   EXPECT_EQ(Func(), 42);
 }
 
@@ -110,11 +114,13 @@ TEST(NativeDylibManagerTest, LookupMultipleSymbols) {
                             {"NativeDylibManagerTestFunc2", Req}});
   ASSERT_TRUE(!!Result) << toString(Result.takeError());
   ASSERT_EQ(Result->size(), 2U);
-  EXPECT_NE((*Result)[0], nullptr);
-  EXPECT_NE((*Result)[1], nullptr);
+  ASSERT_TRUE((*Result)[0].has_value());
+  ASSERT_TRUE((*Result)[1].has_value());
+  EXPECT_NE(*(*Result)[0], nullptr);
+  EXPECT_NE(*(*Result)[1], nullptr);
 
-  auto *Func1 = reinterpret_cast<int (*)()>((*Result)[0]);
-  auto *Func2 = reinterpret_cast<int (*)()>((*Result)[1]);
+  auto *Func1 = reinterpret_cast<int (*)()>(*(*Result)[0]);
+  auto *Func2 = reinterpret_cast<int (*)()>(*(*Result)[1]);
   EXPECT_EQ(Func1(), 42);
   EXPECT_EQ(Func2(), 7);
 }
@@ -130,7 +136,9 @@ TEST(NativeDylibManagerTest, LookupWeakMissingSymbol) {
   auto Result = syncLookup(*NDM, Handle, {{"no_such_symbol", Weak}});
   ASSERT_TRUE(!!Result) << toString(Result.takeError());
   ASSERT_EQ(Result->size(), 1U);
-  EXPECT_EQ((*Result)[0], nullptr);
+  ASSERT_TRUE((*Result)[0].has_value())
+      << "weak-missing symbol should be reported as a present optional";
+  EXPECT_EQ(*(*Result)[0], nullptr);
 }
 
 TEST(NativeDylibManagerTest, LookupRequiredMissingSymbol) {
@@ -142,10 +150,10 @@ TEST(NativeDylibManagerTest, LookupRequiredMissingSymbol) {
   void *Handle = cantFail(syncLoad(*NDM, NDM_TEST_LIB_PATH));
 
   auto Result = syncLookup(*NDM, Handle, {{"no_such_symbol", Req}});
-  EXPECT_FALSE(!!Result);
-  auto Msg = toString(Result.takeError());
-  EXPECT_NE(Msg.find("no_such_symbol"), std::string::npos)
-      << "error message should mention the missing symbol; got: " << Msg;
+  ASSERT_TRUE(!!Result) << toString(Result.takeError());
+  ASSERT_EQ(Result->size(), 1U);
+  EXPECT_FALSE((*Result)[0].has_value())
+      << "required-missing symbol should be reported as an empty optional";
 }
 
 TEST(NativeDylibManagerTest, LookupMixedRequiredAndWeak) {
@@ -161,6 +169,9 @@ TEST(NativeDylibManagerTest, LookupMixedRequiredAndWeak) {
       {{"NativeDylibManagerTestFunc", Req}, {"no_such_symbol", Weak}});
   ASSERT_TRUE(!!Result) << toString(Result.takeError());
   ASSERT_EQ(Result->size(), 2U);
-  EXPECT_NE((*Result)[0], nullptr);
-  EXPECT_EQ((*Result)[1], nullptr);
+  ASSERT_TRUE((*Result)[0].has_value());
+  EXPECT_NE(*(*Result)[0], nullptr);
+  ASSERT_TRUE((*Result)[1].has_value())
+      << "weak-missing symbol should be reported as a present optional";
+  EXPECT_EQ(*(*Result)[1], nullptr);
 }


### PR DESCRIPTION
NativeDylibManager::lookup used to return (asynchronously) a vector of void *s where null represented not-present. This commit updates it to return a vector of std::optional<void *>s where std::nullopt represents not-present and an address of zero indicates that the symbol is present with an address of zero.

This matches the resolve semantics of SimpleExecutorDylibManager, completing the alignment of the two implementations after the earlier additions of the Mode argument to load() and the required/weakly-referenced flag on lookup symbols.