### PR TITLE
[lldb][test] Speed up ProcessAttach test

### DIFF
--- a/lldb/test/API/commands/process/attach/TestProcessAttach.py
+++ b/lldb/test/API/commands/process/attach/TestProcessAttach.py
@@ -49,13 +49,36 @@ class ProcessAttachTestCase(TestBase):
         # Spawn a new process
         popen = self.spawnSubprocess(exe)
 
+        # Don't wait for the continue to finish.
+        self.setAsync(True)
         self.runCmd("process attach -c -p " + str(popen.pid))
 
         target = self.dbg.GetSelectedTarget()
 
+        # Start listening to process events.
         process = target.GetProcess()
         self.assertTrue(process, PROCESS_IS_VALID)
-        self.assertTrue(process.GetState(), lldb.eStateRunning)
+        broadcaster = process.GetBroadcaster()
+        listener = self.dbg.GetListener()
+        state = process.GetState()
+        self.assertEqual(
+            state, lldb.eStateStopped, "The attach stopped before continuing"
+        )
+
+        # Listen for events until we see the process continue.
+        event = lldb.SBEvent()
+        got_running = False
+        got_event = False
+        timeout = 180
+        while listener.WaitForEventForBroadcaster(timeout, broadcaster, event):
+            state = process.GetState()
+            got_event = True
+            if state == lldb.eStateRunning:
+                got_running = True
+                break
+
+        self.assertTrue(got_event, "Didn't receive any events after attaching")
+        self.assertTrue(got_running, "Process didn't auto-continue")
 
     @skipIfWindows  # This is flakey on Windows AND when it fails, it hangs: llvm.org/pr48806
     def test_attach_to_process_from_different_dir_by_id(self):


### PR DESCRIPTION
ProcessAttach is our slowest test and runs for about 70s. We spend 60s in the autocontinue test waiting for the target program to terminate.

The reason we wait for the program is that our autocontinue test is not running its command in async mode, and we wait after the attach for the next breakpoint or the program terminates.

This patch makes the attach and autocontinue run in async mode so we don't wait for the program to finish. This reduces the test time from 70s to about 10s.

This also raises the question how this test passes as we seem to wait for the program to finish, but then later still (successfully) check that the program is still running. I think this is either an API quirk or a bug, but that's out of scope for this patch.