### PR TITLE
[Hexagon] Fix arch attribute mapping in ELFObjectFile

### DIFF
--- a/llvm/lib/Object/ELFObjectFile.cpp
+++ b/llvm/lib/Object/ELFObjectFile.cpp
@@ -287,37 +287,8 @@ SubtargetFeatures ELFObjectFileBase::getARMFeatures() const {
   return Features;
 }
 
-static std::optional<std::string> hexagonAttrToFeatureString(unsigned Attr) {
-  switch (Attr) {
-  case 5:
-    return "v5";
-  case 55:
-    return "v55";
-  case 60:
-    return "v60";
-  case 62:
-    return "v62";
-  case 65:
-    return "v65";
-  case 67:
-    return "v67";
-  case 68:
-    return "v68";
-  case 69:
-    return "v69";
-  case 71:
-    return "v71";
-  case 73:
-    return "v73";
-  case 75:
-    return "v75";
-  case 79:
-    return "v79";
-  case 81:
-    return "v81";
-  default:
-    return {};
-  }
+static std::string hexagonAttrToFeatureString(unsigned Attr) {
+  return "v" + utostr(Attr);
 }
 
 SubtargetFeatures ELFObjectFileBase::getHexagonFeatures() const {
@@ -331,19 +302,11 @@ SubtargetFeatures ELFObjectFileBase::getHexagonFeatures() const {
   }
   std::optional<unsigned> Attr;
 
-  if ((Attr = Parser.getAttributeValue(HexagonAttrs::ARCH))) {
-    if (std::optional<std::string> FeatureString =
-            hexagonAttrToFeatureString(*Attr))
-      Features.AddFeature(*FeatureString);
-  }
+  if ((Attr = Parser.getAttributeValue(HexagonAttrs::ARCH)))
+    Features.AddFeature(hexagonAttrToFeatureString(*Attr));
 
-  if ((Attr = Parser.getAttributeValue(HexagonAttrs::HVXARCH))) {
-    std::optional<std::string> FeatureString =
-        hexagonAttrToFeatureString(*Attr);
-    // There is no corresponding hvx arch for v5 and v55.
-    if (FeatureString && *Attr >= 60)
-      Features.AddFeature("hvx" + *FeatureString);
-  }
+  if ((Attr = Parser.getAttributeValue(HexagonAttrs::HVXARCH)))
+    Features.AddFeature("hvx" + hexagonAttrToFeatureString(*Attr));
 
   if ((Attr = Parser.getAttributeValue(HexagonAttrs::HVXIEEEFP)))
     if (*Attr)

--- a/llvm/test/MC/Hexagon/hexagon_attribues_arch.s
+++ b/llvm/test/MC/Hexagon/hexagon_attribues_arch.s
@@ -1,0 +1,52 @@
+// Regression test for hexagonAttrToFeatureString in
+/// llvm/lib/Object/ELFObjectFile.cpp.
+///
+
+r0 = add(r1,r2)
+
+// RUN: llvm-mc -triple=hexagon --mcpu=hexagonv5 %s \
+// RUN:   -filetype=obj --hexagon-add-build-attributes -o %t.v5.o
+// RUN: llvm-readelf -A %t.v5.o | FileCheck %s --check-prefix=V5
+// RUN: llvm-objdump -d %t.v5.o | FileCheck %s --check-prefix=DIS
+
+// RUN: llvm-mc -triple=hexagon --mcpu=hexagonv55 %s \
+// RUN:   -filetype=obj --hexagon-add-build-attributes -o %t.v55.o
+// RUN: llvm-readelf -A %t.v55.o | FileCheck %s --check-prefix=V55
+// RUN: llvm-objdump -d %t.v55.o | FileCheck %s --check-prefix=DIS
+
+// RUN: llvm-mc -triple=hexagon --mcpu=hexagonv68 %s \
+// RUN:   -filetype=obj --hexagon-add-build-attributes -o %t.v68.o
+// RUN: llvm-readelf -A %t.v68.o | FileCheck %s --check-prefix=V68
+// RUN: llvm-objdump -d %t.v68.o | FileCheck %s --check-prefix=DIS
+
+// RUN: llvm-mc -triple=hexagon --mcpu=hexagonv75 %s \
+// RUN:   -filetype=obj --hexagon-add-build-attributes -o %t.v75.o
+// RUN: llvm-readelf -A %t.v75.o | FileCheck %s --check-prefix=V75
+// RUN: llvm-objdump -d %t.v75.o | FileCheck %s --check-prefix=DIS
+
+/// Test HVX arch attribute mapping. llvm-objdump should pick up hvx features
+/// from build attributes and disassemble HVX instructions correctly.
+// RUN: llvm-mc -triple=hexagon --mcpu=hexagonv68 -mhvx %s \
+// RUN:   -filetype=obj --hexagon-add-build-attributes -o %t.v68.hvx.o
+// RUN: llvm-readelf -A %t.v68.hvx.o | FileCheck %s --check-prefix=HVX68
+// RUN: llvm-objdump -d %t.v68.hvx.o | FileCheck %s --check-prefix=DIS
+
+/// Each readelf invocation should record the matching arch tag value.
+// V5: TagName: arch
+// V5-NEXT: Value: 5
+// V55: TagName: arch
+// V55-NEXT: Value: 55
+// V68: TagName: arch
+// V68-NEXT: Value: 68
+// V75: TagName: arch
+// V75-NEXT: Value: 75
+
+/// HVX arch attribute should be recorded when -mhvx is used.
+// HVX68: TagName: hvx_arch
+// HVX68-NEXT: Value: 68
+
+/// llvm-objdump should disassemble the instruction correctly for every
+/// arch version, with no <unknown> fallback.
+// DIS:      <.text>:
+// DIS-NEXT: r0 = add(r1,r2)
+// DIS-NOT:  <unknown>


### PR DESCRIPTION
hexagonAttrToFeatureString in ELFObjectFile.cpp used a hardcoded switch listing each supported Hexagon arch version. The switch was not kept in sync, so .hexagon.attributes entries for newer versions returned std::nullopt and were silently dropped. The disassembler then ran without v68 enabled and valid instructions were rendered as <unknown> in llvm-objdump output.

Replace the switch with `"v" + utostr(Attr)` so any current or future arch version recorded in build attributes is translated to a subtarget feature string automatically.

Fixes #201594 