### PR TITLE
[lldb][test] Increase polling frequency in ProcessAttach

### DIFF
--- a/lldb/test/API/commands/process/attach/main.cpp
+++ b/lldb/test/API/commands/process/attach/main.cpp
@@ -1,21 +1,17 @@
 #include "attach.h"
 #include <chrono>
-#include <cstdio>
 #include <thread>
 
 volatile int g_val = 12345;
 
 int main(int argc, char const *argv[]) {
-    int temp;
-    lldb_enable_attach();
+  lldb_enable_attach();
 
-    // Waiting to be attached by the debugger.
-    temp = 0;
+  // This provides a breakpoint we hit every 50ms that the tests can hit.
+  std::chrono::milliseconds poll_time(50);
+  unsigned total_wait_in_sec = 60;
+  unsigned total_wait_time = total_wait_in_sec * (1000 / poll_time.count());
 
-    while (temp < 30) {
-        std::this_thread::sleep_for(std::chrono::seconds(2)); // Waiting to be attached...
-        temp++;
-    }
-
-    printf("Exiting now\n");
+  for (unsigned wait = 0; wait < total_wait_time; wait++)
+    std::this_thread::sleep_for(poll_time); // Waiting to be attached...
 }


### PR DESCRIPTION
The test_attach_to_process_by_id_correct_executable_offset subtest requires us to hit a breakpoint in an attached process. For this we implement a loop that hits the breakpoint location every 2 seconds.

This patch increases the rate at which we hit this breakpoint to 50ms. The reason is that a 2s interval means that this test is waiting on any fast system for nearly 2 seconds on the first breakpoint hit. With a 50ms interval this subtest passed immediately.