### PR TITLE
[ARM] Reject invalid BF encoding when target is next instruction

### DIFF
--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
@@ -262,7 +262,7 @@ const char *ARMAsmBackend::reasonForFixupRelaxation(const MCFixup &Fixup,
     break;
   }
   case ARM::fixup_bf_branch:
-    return checkPCRelOffset(Value, 0, 30);
+    return checkPCRelOffset(Value, 2, 30);
   case ARM::fixup_bf_target:
     return checkPCRelOffset(Value, -0x10000, +0xfffe);
   case ARM::fixup_bfl_target:

--- a/llvm/test/MC/ARM/bf-invalid-target.s
+++ b/llvm/test/MC/ARM/bf-invalid-target.s
@@ -1,0 +1,14 @@
+@ RUN: not llvm-mc -triple arm-none-eabi -mcpu=cortex-m55 -filetype=obj %s -o /dev/null 2>&1 | FileCheck %s
+
+.text
+bf label, __myfunc
+label:
+  b __myfunc
+
+.section .text.foo, "ax", %progbits
+.type __myfunc, %function
+.global __myfunc
+__myfunc:
+  nop
+
+@ CHECK: error: out of range pc-relative fixup value


### PR DESCRIPTION
When the BF instruction targets the immediately following label, the encoded branch offset becomes zero, causing LLVM to emit invalid machine code.

Add validation in the fixup_bf_branch path to reject this case and emit an error instead.

Add MC regression test to cover new validation.

Assisted by ChatGPT. Human-verified, debugged, tested and validating by author.