### PR TITLE
[RISCV] Make amocas.q require Ziccamoc

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -111,6 +111,9 @@ def FeatureStdExtZiccamoa
 
 def FeatureStdExtZiccamoc
     : RISCVExtension<1, 0, "Main Memory Supports Atomics in Zacas">;
+def HasStdExtZiccamoc : Predicate<"Subtarget->hasStdExtZiccamoc()">,
+                        AssemblerPredicate<(all_of FeatureStdExtZiccamoc),
+                            "Main Memory Supports All Atomics in A">;
 
 def FeatureStdExtZiccif
     : RISCVExtension<1, 0,

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZa.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZa.td
@@ -65,6 +65,7 @@ defm AMOCAS_D_RV32 : AMO_cas_aq_rl<0b00101, 0b011, "amocas.d", GPRPairRV32>;
 
 let Predicates = [HasStdExtZacas, IsRV64] in {
 defm AMOCAS_D_RV64 : AMO_cas_aq_rl<0b00101, 0b011, "amocas.d", GPR>;
+let append Predicates = [HasStdExtZiccamoc] in
 defm AMOCAS_Q : AMO_cas_aq_rl<0b00101, 0b100, "amocas.q", GPRPairRV64>;
 } // Predicates = [HasStdExtZacas, IsRV64]
 

--- a/llvm/test/MC/RISCV/rv32zacas-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zacas-invalid.s
@@ -15,4 +15,4 @@ amocas.d.aqrl a1, a2, (a1) # CHECK: :[[@LINE]]:15: error: register must be even
 amocas.d.aqrl a0, a1, (a1) # CHECK: :[[@LINE]]:19: error: register must be even
 
 # amocas.q is not supported for RV32.
-amocas.q a0, a0, (a1) # CHECK: :[[@LINE]]:1: error: instruction requires the following: RV64I Base Instruction Set{{$}}
+amocas.q a0, a0, (a1) # CHECK: :[[@LINE]]:1: error: instruction requires the following: Main Memory Supports All Atomics in A, RV64I Base Instruction Set{{$}}

--- a/llvm/test/MC/RISCV/rv64zacas-valid.s
+++ b/llvm/test/MC/RISCV/rv64zacas-valid.s
@@ -1,7 +1,7 @@
-# RUN: llvm-mc %s -triple=riscv64 -mattr=+a,+zacas -M no-aliases -show-encoding \
+# RUN: llvm-mc %s -triple=riscv64 -mattr=+a,+zacas,+ziccamoc -M no-aliases -show-encoding \
 # RUN:     | FileCheck -check-prefixes=CHECK-ASM,CHECK-ASM-AND-OBJ %s
-# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+a,+zacas < %s \
-# RUN:     | llvm-objdump --mattr=+a,+zacas -M no-aliases -d -r - \
+# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+a,+zacas,+ziccamoc < %s \
+# RUN:     | llvm-objdump --mattr=+a,+zacas,+ziccamoc -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 # RUN: not llvm-mc -triple=riscv64 -mattr=+a -show-encoding %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
@@ -27,25 +27,25 @@ amocas.d.aqrl a1, a3, (a5)
 
 # CHECK-ASM-AND-OBJ: amocas.q a0, a2, (a1)
 # CHECK-ASM: encoding: [0x2f,0xc5,0xc5,0x28]
-# CHECK-ERROR: instruction requires the following: 'Zacas' (Atomic Compare-And-Swap Instructions){{$}}
+# CHECK-ERROR: instruction requires the following: 'Zacas' (Atomic Compare-And-Swap Instructions), Main Memory Supports All Atomics in A{{$}}
 amocas.q a0, a2, (a1)
 # CHECK-ASM-AND-OBJ: amocas.q a0, a2, (a1)
 # CHECK-ASM: encoding: [0x2f,0xc5,0xc5,0x28]
-# CHECK-ERROR: instruction requires the following: 'Zacas' (Atomic Compare-And-Swap Instructions){{$}}
+# CHECK-ERROR: instruction requires the following: 'Zacas' (Atomic Compare-And-Swap Instructions), Main Memory Supports All Atomics in A{{$}}
 amocas.q a0, a2, 0(a1)
 # CHECK-ASM-AND-OBJ: amocas.q zero, zero, (a1)
 # CHECK-ASM: encoding: [0x2f,0xc0,0x05,0x28]
-# CHECK-ERROR: instruction requires the following: 'Zacas' (Atomic Compare-And-Swap Instructions){{$}}
+# CHECK-ERROR: instruction requires the following: 'Zacas' (Atomic Compare-And-Swap Instructions), Main Memory Supports All Atomics in A{{$}}
 amocas.q zero, zero, (a1)
 # CHECK-ASM-AND-OBJ: amocas.q.aq zero, zero, (a1)
 # CHECK-ASM: encoding: [0x2f,0xc0,0x05,0x2c]
-# CHECK-ERROR: instruction requires the following: 'Zacas' (Atomic Compare-And-Swap Instructions){{$}}
+# CHECK-ERROR: instruction requires the following: 'Zacas' (Atomic Compare-And-Swap Instructions), Main Memory Supports All Atomics in A{{$}}
 amocas.q.aq zero, zero, (a1)
 # CHECK-ASM-AND-OBJ: amocas.q.rl zero, zero, (a1)
 # CHECK-ASM: encoding: [0x2f,0xc0,0x05,0x2a]
-# CHECK-ERROR: instruction requires the following: 'Zacas' (Atomic Compare-And-Swap Instructions){{$}}
+# CHECK-ERROR: instruction requires the following: 'Zacas' (Atomic Compare-And-Swap Instructions), Main Memory Supports All Atomics in A{{$}}
 amocas.q.rl zero, zero, (a1)
 # CHECK-ASM-AND-OBJ: amocas.q.aqrl zero, zero, (a1)
 # CHECK-ASM: encoding: [0x2f,0xc0,0x05,0x2e]
-# CHECK-ERROR: instruction requires the following: 'Zacas' (Atomic Compare-And-Swap Instructions){{$}}
+# CHECK-ERROR: instruction requires the following: 'Zacas' (Atomic Compare-And-Swap Instructions), Main Memory Supports All Atomics in A{{$}}
 amocas.q.aqrl zero, zero, (a1)


### PR DESCRIPTION
`amocas.q` requires `AMOCASQ` level PMA and `Ziccamoc` mandates it.

This is a PoC for https://github.com/riscv-non-isa/riscv-toolchain-conventions/issues/173.
