### PR TITLE
[Mips] Did not put fake_use into delay slot

### DIFF
--- a/llvm/lib/Target/Mips/MipsDelaySlotFiller.cpp
+++ b/llvm/lib/Target/Mips/MipsDelaySlotFiller.cpp
@@ -854,10 +854,17 @@ bool MipsDelaySlotFiller::searchRange(MachineBasicBlock &MBB, IterTy Begin,
     IterTy CurrI = I;
     ++I;
     LLVM_DEBUG(dbgs() << DEBUG_TYPE ": checking instruction: "; CurrI->dump());
-    // Skip debug value.
+
+    if (terminateSearch(*CurrI)) {
+      LLVM_DEBUG(dbgs() << DEBUG_TYPE ": should terminate search: ";
+                 CurrI->dump());
+      break;
+    }
+    // Skip debug and pseudo instructions.
     // Instruction TargetOpcode::JUMP_TABLE_DEBUG_INFO is only used to note
     // jump table debug info.
-    if (CurrI->isDebugInstr() || CurrI->isJumpTableDebugInfo()) {
+    if (CurrI->isDebugInstr() || CurrI->isJumpTableDebugInfo() ||
+        CurrI->isMetaInstruction()) {
       LLVM_DEBUG(dbgs() << DEBUG_TYPE ": ignoring debug instruction: ";
                  CurrI->dump());
       continue;
@@ -869,12 +876,6 @@ bool MipsDelaySlotFiller::searchRange(MachineBasicBlock &MBB, IterTy Begin,
       // However, we still need to update the register def-use information.
       RegDU.update(*CurrI, 0, CurrI->getNumOperands());
       continue;
-    }
-
-    if (terminateSearch(*CurrI)) {
-      LLVM_DEBUG(dbgs() << DEBUG_TYPE ": should terminate search: ";
-                 CurrI->dump());
-      break;
     }
 
     assert((!CurrI->isCall() && !CurrI->isReturn() && !CurrI->isBranch()) &&

--- a/llvm/test/CodeGen/Mips/fake-use.ll
+++ b/llvm/test/CodeGen/Mips/fake-use.ll
@@ -1,0 +1,15 @@
+; RUN: llc -verify-machineinstrs -mtriple=mipsel-linux-gnu -mcpu=mips32r2 %s -o - | FileCheck %s
+
+define void @fake_use(ptr %aaaa) {
+; CHECK-LABEL: fake_use:
+; CHECK:       # %bb.0:    # %entry
+; CHECK-NEXT:              # fake_use: $a0 
+; CHECK-NEXT:    jr $ra 
+; CHECK-NEXT:    nop
+entry:
+  notail call void (...) @llvm.fake.use(ptr %aaaa)
+  ret void
+}
+
+declare void @llvm.fake.use(...)
+


### PR DESCRIPTION
When compiling with -fextend-variable-liveness, the compiler generates FAKE_USE instructions that are not handled by the Mips assembly printer. This causes a fatal error: "Unsupported instruction : <MCInst 44 <MCOperand Reg:22>>" when using clang with -target mipsel-gnu-linux -Og.

The issue occurs because MipsDelaySlotFiller attempts to process FAKE_USE instructions (which are meta instructions) when searching for instructions to fill delay slots, eventually leading to the assembly printer trying to emit an unsupported instruction.

This patch fixes the crash by treating meta instructions (including FAKE_USE) the same way as debug instructions in the delay slot filler's searchRange function. Meta instructions should be skipped during delay slot filling.

Specifically, the fix:
1. Moves the terminateSearch check before debug/meta instruction checks to ensure proper search termination.
2. Adds isMetaInstruction() check alongside existing isDebugInstr() and isJumpTableDebugInfo() checks.

Fix #198835.