### PR TITLE
[lldb][test] Use a fake dsymForUUID in tests

### DIFF
--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -221,6 +221,16 @@ if is_configured("llvm_include_dir"):
 if is_configured("llvm_tools_dir"):
     dotest_cmd += ["--env", "LLVM_TOOLS_DIR=" + config.llvm_tools_dir]
 
+# Prevent tests from accidentally invoking the real dsymForUUID, which can
+# make slow network requests. Tests that need a working dsymForUUID mock
+# should override this with their own script.
+if platform.system() == "Darwin":
+    dotest_cmd += [
+        "--env",
+        "LLDB_APPLE_DSYMFORUUID_EXECUTABLE="
+        + os.path.join(config.lldb_src_root, "test", "Utils", "fake-dsymForUUID.sh"),
+    ]
+
 # If we have a just-built libcxx, prefer it over the system one.
 if is_configured("has_libcxx") and config.has_libcxx:
     if platform.system() != "Windows":

--- a/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/lit.local.cfg
+++ b/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/lit.local.cfg
@@ -1,7 +1,5 @@
 if 'system-darwin' not in config.available_features:
   config.unsupported = True
 
-config.environment["LLDB_APPLE_DSYMFORUUID_EXECUTABLE"] = ""
-
 # Temporary parallel image loading deadlock workaround
 config.environment["NO_PARALLEL_IMG_LOADING"] = ""

--- a/lldb/test/Shell/lit.cfg.py
+++ b/lldb/test/Shell/lit.cfg.py
@@ -221,6 +221,13 @@ if platform.system() == "Darwin":
     except:
         pass
 
+    # Prevent tests from accidentally invoking the real dsymForUUID, which can
+    # make slow network requests. Tests that need a working dsymForUUID mock
+    # should override this.
+    config.environment["LLDB_APPLE_DSYMFORUUID_EXECUTABLE"] = os.path.join(
+        os.path.dirname(config.test_source_root), "Utils", "fake-dsymForUUID.sh"
+    )
+
 # Some shell tests dynamically link with python.dll and need to know the
 # location of the Python libraries. This ensures that we use the same
 # version of Python that was used to build lldb to run our tests.

--- a/lldb/test/Utils/fake-dsymForUUID.sh
+++ b/lldb/test/Utils/fake-dsymForUUID.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Dummy dsymForUUID for the LLDB test suite.
+# Returns an empty plist to indicate that no dSYM was found, without making
+# any network requests or slow filesystem searches.
+echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+echo "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">"
+echo "<plist version=\"1.0\">"
+echo "<dict/>"
+echo "</plist>"


### PR DESCRIPTION
Our test should not invoke dsymForUUID as it creates an unnecessary dependency on the OS and is also incredibly slow. For example, all Crashlog tests on my system run for more than 30s and all of this is just spent waiting for dsymForUUID to return "not found".

This patch provides a simple dummy dsymForUUID script we set for all tests. This is automatically picked up by LLDB with the existing dsymForUUID environment variable. As a result, all crashlog tests which previously run in total for about 4 minutes with one job, now run in about 10s.

assisted-by: claude