### PR TITLE
[libc] Convert environ and getopt variables to use LLVM_LIBC_VARIABLE

### DIFF
--- a/libc/src/unistd/CMakeLists.txt
+++ b/libc/src/unistd/CMakeLists.txt
@@ -362,6 +362,9 @@ add_entrypoint_object(
     environ.cpp
   HDRS
     environ.h
+  DEPENDS
+    libc.src.__support.common
+    libc.src.__support.macros.config
 )
 
 add_entrypoint_object(
@@ -372,6 +375,10 @@ add_entrypoint_object(
     getopt.h
   DEPENDS
     libc.include.unistd
+    libc.hdr.unistd_macros
+    libc.hdr.types.FILE
+    libc.src.__support.common
+    libc.src.__support.macros.config
     libc.src.__support.CPP.optional
     libc.src.__support.CPP.string_view
     libc.src.__support.File.file

--- a/libc/src/unistd/environ.cpp
+++ b/libc/src/unistd/environ.cpp
@@ -6,13 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "src/unistd/environ.h"
+#include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-// This is initialized to the correct value by the statup code.
-extern "C" {
-char **environ = nullptr;
-}
+// This is initialized to the correct value by the startup code.
+LLVM_LIBC_VARIABLE(char **, environ) = nullptr;
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/unistd/environ.h
+++ b/libc/src/unistd/environ.h
@@ -13,7 +13,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-extern "C" char **environ;
+extern char **environ;
 
 } // namespace LIBC_NAMESPACE_DECL
 

--- a/libc/src/unistd/getopt.cpp
+++ b/libc/src/unistd/getopt.cpp
@@ -23,6 +23,11 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
+LLVM_LIBC_VARIABLE(char *, optarg) = nullptr;
+LLVM_LIBC_VARIABLE(int, optind) = 1;
+LLVM_LIBC_VARIABLE(int, optopt) = 0;
+LLVM_LIBC_VARIABLE(int, opterr) = 0;
+
 template <typename T> struct RefWrapper {
   RefWrapper() = delete;
   constexpr RefWrapper(T *p) : ptr{p} {}
@@ -177,17 +182,10 @@ int getopt_r(int argc, char *const argv[], const char *optstring,
 
 namespace impl {
 
-extern "C" {
-char *optarg = nullptr;
-int optind = 1;
-int optopt = 0;
-int opterr = 0;
-}
-
 static unsigned optpos;
 
-static GetoptContext ctx{&impl::optarg, &impl::optind, &impl::optopt,
-                         &optpos,       &impl::opterr, /*errstream=*/nullptr};
+static GetoptContext ctx{&optarg, &optind, &optopt,
+                         &optpos, &opterr, /*errstream=*/nullptr};
 
 #ifndef LIBC_COPT_PUBLIC_PACKAGING
 // This is used exclusively in tests.

--- a/libc/src/unistd/getopt.h
+++ b/libc/src/unistd/getopt.h
@@ -15,6 +15,11 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
+extern char *optarg;
+extern int optind;
+extern int optopt;
+extern int opterr;
+
 namespace impl {
 void set_getopt_state(char **, int *, int *, unsigned *, int *, FILE *);
 }


### PR DESCRIPTION
This brings them in line with how other standard global variables like stdin/stdout/stderr are managed.

Assisted by Gemini.