### PR TITLE
[lldb][test] Make TestInterruptThreadNames not depend on debug info

### DIFF
--- a/lldb/test/API/macosx/thread-names/TestInterruptThreadNames.py
+++ b/lldb/test/API/macosx/thread-names/TestInterruptThreadNames.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestInterruptThreadNames(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
     @skipUnlessDarwin
     @add_test_categories(["pyapi"])
     def test_with_python_api(self):


### PR DESCRIPTION
This test only reads the pthread names, which don't depend on any debug info.

This halves the runtime of this very long test from 22s to 11s.