### PR TITLE
[lldb][test] Increase polling in TestInterruptThreadNames.py

### DIFF
--- a/lldb/test/API/macosx/thread-names/TestInterruptThreadNames.py
+++ b/lldb/test/API/macosx/thread-names/TestInterruptThreadNames.py
@@ -63,16 +63,9 @@ class TestInterruptThreadNames(TestBase):
     # check to see if the global has that value, and continue if it does not.
     def wait_until_program_setup_complete(self, process, listener):
         inferior_set_up = lldb.SBValue()
-        retry = 5
+        retry = 50
         while retry > 0:
-            arch = self.getArchitecture()
-            # when running the testsuite against a remote arm device, it may take
-            # a little longer for the process to start up.  Use a "can't possibly take
-            # longer than this" value.
-            if arch == "arm64" or arch == "armv7":
-                time.sleep(10)
-            else:
-                time.sleep(1)
+            time.sleep(0.1)
             process.SendAsyncInterrupt()
             self.assertTrue(
                 self.wait_for_stop(process, listener), "Check that process is paused"


### PR DESCRIPTION
This test runs for a very long time on my machine (11s per variation), and nearly all of this time is spent on the 10s sleep in this function.

There are two issues here:

1. It uses the (now outdated) logic that arm64 means we have a remote Darwin device. This is no longer true these days as Macs also run on arm64.

2. The polling duration of 1s is still very long, and the test will still spend all its time just waiting for this 1s sleep. A 100ms sleep that we poll in a loop should be slow enough.