### PR TITLE
[lldb][Windows] Suspend new threads when stopped

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.cpp
@@ -633,6 +633,18 @@ void NativeProcessWindows::OnCreateThread(const HostThread &new_thread) {
                           wp.m_hardware);
   }
 
+  if (StateType state = GetState();
+      state == eStateStopped || state == eStateCrashed) {
+    if (Status error = thread->DoStop(); error.Fail()) {
+      Log *log = GetLog(WindowsLog::Thread);
+      LLDB_LOG(log, "failed to suspend newly-created thread {0}: {1}",
+               thread->GetID(), error);
+    }
+    ThreadStopInfo stop_info;
+    stop_info.reason = lldb::eStopReasonNone;
+    thread->SetStopReason(stop_info, "");
+  }
+
   m_threads.push_back(std::move(thread));
 }
 


### PR DESCRIPTION
`OnCreateThread` runs from the `DebuggerThread` loop after a `CREATE_THREAD_DEBUG_EVENT`. Each iteration of that loop ends with a `ContinueDebugEvent`, which on Windows resumes every thread in the debuggee that *isn't* individually suspended with `SuspendThread`.

If a thread is created while the debuggee is stopped, all the existing threads are suspended expect the new one. After the next ContinueDebugEvent it just runs, while lldb's StateType still reads eStateStopped.

This patch suspends the new thread when the debuggee is stopped.

This fixes `TestTwoHitsOneActual.py` and `TestBreakOnLambdaCapture.py` when running the test suite with `LLDB_USE_LLDB_SERVER=1`.

rdar://178718627