### PR TITLE
[mlir][Arith][EmitC] Add tests for bail-out on arith.constant conversion

### DIFF
--- a/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
+++ b/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
@@ -62,6 +62,9 @@ public:
     Type newTy = this->getTypeConverter()->convertType(arithConst.getType());
     if (!newTy)
       return rewriter.notifyMatchFailure(arithConst, "type conversion failed");
+    if (isa<MemRefType>(arithConst.getType()))
+      return rewriter.notifyMatchFailure(arithConst,
+                                         "memref constants are not supported");
     rewriter.replaceOpWithNewOp<emitc::ConstantOp>(arithConst, newTy,
                                                    adaptor.getValue());
     return success();

--- a/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
+++ b/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
@@ -62,9 +62,6 @@ public:
     Type newTy = this->getTypeConverter()->convertType(arithConst.getType());
     if (!newTy)
       return rewriter.notifyMatchFailure(arithConst, "type conversion failed");
-    if (isa<MemRefType>(arithConst.getType()))
-      return rewriter.notifyMatchFailure(arithConst,
-                                         "memref constants are not supported");
     rewriter.replaceOpWithNewOp<emitc::ConstantOp>(arithConst, newTy,
                                                    adaptor.getValue());
     return success();

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc-failed.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc-failed.mlir
@@ -21,3 +21,27 @@ func.func @unsuppoted_emitc_type(%arg0: i4, %arg1: i4) {
   %0 = arith.addi %arg0, %arg1 : i4
   return
 }
+
+// -----
+
+func.func private @rank0_constant() -> memref<i64> {
+  // expected-error@+1 {{failed to legalize operation 'arith.constant'}}
+  %0 = arith.constant dense<-1> : memref<i64>
+  return %0 : memref<i64>
+}
+
+// -----
+
+func.func private @rank1_constant() -> memref<1xi64> {
+  // expected-error@+1 {{failed to legalize operation 'arith.constant'}}
+  %0 = arith.constant dense<[-1]> : memref<1xi64>
+  return %0 : memref<1xi64>
+}
+
+// -----
+
+func.func private @return_rank2_constant() -> memref<1x1xi64> {
+  // expected-error@+1 {{failed to legalize operation 'arith.constant'}}
+  %0 = arith.constant dense<[[-1]]> : memref<1x1xi64>
+  return %0 : memref<1x1xi64>
+}

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc-failed.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc-failed.mlir
@@ -40,7 +40,7 @@ func.func private @rank1_constant() -> memref<1xi64> {
 
 // -----
 
-func.func private @return_rank2_constant() -> memref<1x1xi64> {
+func.func private @rank2_constant() -> memref<1x1xi64> {
   // expected-error@+1 {{failed to legalize operation 'arith.constant'}}
   %0 = arith.constant dense<[[-1]]> : memref<1x1xi64>
   return %0 : memref<1x1xi64>


### PR DESCRIPTION
ArithToEmitC avoids rewriting memref constants to `emitc.constant`, since the type conversion changes the result type but the attribute cannot be converted into a valid EmitC initializer.

This patch does not add support for converting these memrefs. It only makes the existing limitation explicit at the conversion boundary by adding tests for the standalone conversion pass. This pass marks its source ops illegal, so when a pattern bails-out the pass reports a legalization failure. This is the expected behavior and tests document the unsupported cases directly.

Assisted-by: Codex (refine description). I reviewed all text before submission.