### PR TITLE
[libc] Add missing `dl_iterate_phdr` dependencies to avoid spurious build failures

### DIFF
--- a/libc/src/link/CMakeLists.txt
+++ b/libc/src/link/CMakeLists.txt
@@ -6,6 +6,8 @@ add_entrypoint_object(
     dl_iterate_phdr.h
   DEPENDS
     libc.hdr.stdint_proxy
+    libc.include.elf
+    libc.include.llvm-libc-macros.link_macros
     libc.src.__support.CPP.span
     libc.src.__support.OSUtil.linux.auxv
 )


### PR DESCRIPTION
Example: https://github.com/llvm/llvm-project/actions/runs/26945498241/job/79504837451?pr=201452

"Spurious" means, in this case, that the build may succeed or fail depending on whether the files were generated before the dependent is built.  