### PR TITLE
[lit] Add type hints to formats

### DIFF
--- a/llvm/utils/lit/lit/formats/base.py
+++ b/llvm/utils/lit/lit/formats/base.py
@@ -1,11 +1,26 @@
+from __future__ import annotations
+
 import os
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
 
 import lit.Test
 import lit.util
 
+# Can't import unconditionally due to circular dependency
+if TYPE_CHECKING:
+    from lit.LitConfig import LitConfig
+    from lit.TestingConfig import TestingConfig
+
 
 class TestFormat:
-    def getTestsForPath(self, testSuite, path_in_suite, litConfig, localConfig):
+    def getTestsForPath(
+        self,
+        testSuite: lit.Test.TestSuite,
+        path_in_suite: tuple[str, ...],
+        litConfig: LitConfig,
+        localConfig: TestingConfig,
+    ) -> Iterator[lit.Test.Test]:
         """
         Given the path to a test in the test suite, generates the Lit tests associated
         to that path. There can be zero, one or more tests. For example, some testing
@@ -17,11 +32,18 @@ class TestFormat:
         """
         yield lit.Test.Test(testSuite, path_in_suite, localConfig)
 
+
 ###
 
 
 class FileBasedTest(TestFormat):
-    def getTestsForPath(self, testSuite, path_in_suite, litConfig, localConfig):
+    def getTestsForPath(
+        self,
+        testSuite: lit.Test.TestSuite,
+        path_in_suite: tuple[str, ...],
+        litConfig: LitConfig,
+        localConfig: TestingConfig,
+    ) -> Iterator[lit.Test.Test]:
         """
         Expand each path in a test suite to a Lit test using that path and assuming
         it is a file containing the test. File extensions excluded by the configuration
@@ -36,20 +58,31 @@ class FileBasedTest(TestFormat):
         if any(filename.endswith(suffix) for suffix in localConfig.suffixes):
             yield lit.Test.Test(testSuite, path_in_suite, localConfig)
 
-    def getTestsInDirectory(self, testSuite, path_in_suite, litConfig, localConfig):
+    def getTestsInDirectory(
+        self,
+        testSuite: lit.Test.TestSuite,
+        path_in_suite: tuple[str, ...],
+        litConfig: LitConfig,
+        localConfig: TestingConfig,
+    ) -> Iterator[lit.Test.Test]:
         source_path = testSuite.getSourcePath(path_in_suite)
         for filename in os.listdir(source_path):
             filepath = os.path.join(source_path, filename)
             if not os.path.isdir(filepath):
-                for t in self.getTestsForPath(testSuite, path_in_suite + (filename,), litConfig, localConfig):
+                for t in self.getTestsForPath(
+                    testSuite, path_in_suite + (filename,), litConfig, localConfig
+                ):
                     yield t
 
 
 ###
 
+
 # Check exit code of a simple executable with no input
 class ExecutableTest(FileBasedTest):
-    def execute(self, test, litConfig):
+    def execute(
+        self, test: lit.Test.Test, litConfig: LitConfig
+    ) -> lit.Test.ResultCode | tuple[lit.Test.ResultCode, str]:
         if test.config.unsupported:
             return lit.Test.UNSUPPORTED
 

--- a/llvm/utils/lit/lit/formats/googletest.py
+++ b/llvm/utils/lit/lit/formats/googletest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import math
 import os
@@ -9,13 +11,26 @@ import lit.Test
 import lit.TestRunner
 import lit.util
 from .base import TestFormat
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
+
+# Can't import unconditionally due to circular dependency
+if TYPE_CHECKING:
+    from lit.LitConfig import LitConfig
+    from lit.TestingConfig import TestingConfig
 
 kIsWindows = sys.platform in ["win32", "cygwin"]
 
 
 class GoogleTest(TestFormat):
-    def __init__(self, test_sub_dirs, test_suffix, run_under=[], test_prefix=None):
-        self.seen_executables = set()
+    def __init__(
+        self,
+        test_sub_dirs: str,
+        test_suffix: str,
+        run_under: str | list[str] = [],
+        test_prefix: str | None = None,
+    ) -> None:
+        self.seen_executables: set[str] = set()
         self.test_sub_dirs = str(test_sub_dirs).split(";")
 
         # On Windows, assume tests will also end in '.exe'.
@@ -28,7 +43,9 @@ class GoogleTest(TestFormat):
         self.test_prefixes = {test_prefix} if test_prefix else None
         self.run_under = run_under
 
-    def get_num_tests(self, path, litConfig, localConfig):
+    def get_num_tests(
+        self, path: str, litConfig: LitConfig, localConfig: TestingConfig
+    ) -> int | None:
         list_test_cmd = self.prepareCmd(
             [path, "--gtest_list_tests", "--gtest_filter=-*DISABLED_*"]
         )
@@ -47,7 +64,13 @@ class GoogleTest(TestFormat):
             )
         )
 
-    def getTestsInDirectory(self, testSuite, path_in_suite, litConfig, localConfig):
+    def getTestsInDirectory(
+        self,
+        testSuite: lit.Test.TestSuite,
+        path_in_suite: tuple[str, ...],
+        litConfig: LitConfig,
+        localConfig: TestingConfig,
+    ) -> Iterator[lit.Test.Test]:
         init_shard_size = 512  # number of tests in a shard
         core_count = lit.util.usable_core_count()
         source_path = testSuite.getSourcePath(path_in_suite)
@@ -141,7 +164,9 @@ class GoogleTest(TestFormat):
                         testSuite, testPath, localConfig, file_path=execpath
                     )
 
-    def execute(self, test, litConfig):
+    def execute(
+        self, test: lit.Test.Test, litConfig: LitConfig
+    ) -> tuple[lit.Test.ResultCode, str]:
         if test.gtest_json_file is None:
             return lit.Test.FAIL, ""
 
@@ -181,7 +206,7 @@ class GoogleTest(TestFormat):
         if litConfig.noExecute:
             return lit.Test.PASS, ""
 
-        def get_shard_header(shard_env):
+        def get_shard_header(shard_env: dict[str, str]) -> str:
             shard_envs = " ".join([k + "=" + v for k, v in shard_env.items()])
             return f"Script(shard):\n--\n%s %s\n--\n" % (shard_envs, " ".join(cmd))
 
@@ -210,8 +235,8 @@ class GoogleTest(TestFormat):
         if exitCode == 0:
             return lit.Test.PASS, ""
 
-        def get_test_stdout(test_name):
-            res = []
+        def get_test_stdout(test_name: str) -> str:
+            res: list[str] = []
             header = f"[ RUN      ] " + test_name
             footer = f"[  FAILED  ] " + test_name
             in_range = False
@@ -263,7 +288,7 @@ class GoogleTest(TestFormat):
 
         return lit.Test.FAIL, output
 
-    def prepareCmd(self, cmd):
+    def prepareCmd(self, cmd: list[str]) -> list[str]:
         """Insert interpreter if needed.
 
         It inserts the python exe into the command if cmd[0] ends in .py or caller
@@ -282,8 +307,10 @@ class GoogleTest(TestFormat):
         return cmd
 
     @staticmethod
-    def post_process_shard_results(selected_tests, discovered_tests):
-        def remove_gtest(tests):
+    def post_process_shard_results(
+        selected_tests: list[lit.Test.Test], discovered_tests: list[lit.Test.Test]
+    ) -> tuple[list[lit.Test.Test], list[lit.Test.Test]]:
+        def remove_gtest(tests: list[lit.Test.Test]) -> list[lit.Test.Test]:
             return [t for t in tests if t.gtest_json_file is None]
 
         discovered_tests = remove_gtest(discovered_tests)

--- a/llvm/utils/lit/lit/formats/shtest.py
+++ b/llvm/utils/lit/lit/formats/shtest.py
@@ -1,7 +1,15 @@
+from __future__ import annotations
+
 import lit.TestRunner
 import lit.util
 
 from .base import FileBasedTest
+from typing import TYPE_CHECKING
+
+# Can't import unconditionally due to circular dependency
+if TYPE_CHECKING:
+    from lit.Test import Test, Result
+    from lit.LitConfig import LitConfig
 
 
 class ShTest(FileBasedTest):
@@ -17,13 +25,16 @@ class ShTest(FileBasedTest):
     """
 
     def __init__(
-        self, execute_external=False, extra_substitutions=[], preamble_commands=[]
-    ):
+        self,
+        execute_external: bool = False,
+        extra_substitutions: list[tuple[str, str]] = [],
+        preamble_commands: list[str] = [],
+    ) -> None:
         self.execute_external = execute_external
         self.extra_substitutions = extra_substitutions
         self.preamble_commands = preamble_commands
 
-    def execute(self, test, litConfig):
+    def execute(self, test: Test, litConfig: LitConfig) -> Result:
         return lit.TestRunner.executeShTest(
             test,
             litConfig,


### PR DESCRIPTION
Currently `lit`'s test formats (`formats/base.py`, `formats/shtest.py` and `formats/googletest.py`) didn't have type annotations. This PR adds them.