### PR TITLE
[Clang] Respect `-fno-slp-vectorize` for the LTO pipeline

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9605,7 +9605,9 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       OPT_fsanitize_minimal_runtime,
       OPT_fno_sanitize_minimal_runtime,
       OPT_fsanitize_trap_EQ,
-      OPT_fno_sanitize_trap_EQ};
+      OPT_fno_sanitize_trap_EQ,
+      OPT_fslp_vectorize,
+      OPT_fno_slp_vectorize};
   const llvm::DenseSet<unsigned> LinkerOptions{OPT_mllvm, OPT_Zlinker_input};
   auto ToolChainHasRT = [&](const ToolChain &TC, StringRef Name) {
     return TC.getVFS().exists(

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1157,6 +1157,15 @@ void tools::addLTOOptions(const ToolChain &ToolChain, const ArgList &Args,
     CmdArgs.push_back(Args.MakeArgString(Twine(PluginOptPrefix) +
                                          ParallelismOpt + Parallelism));
 
+  // Forward the SLP vectorization preference to the LTO backend by toggling
+  // the existing -vectorize-slp cl::opt, which the pass honors directly. This
+  // avoids minting dedicated linker options for what is only pipeline tuning.
+  if (Arg *A = Args.getLastArg(options::OPT_fslp_vectorize,
+                               options::OPT_fno_slp_vectorize))
+    CmdArgs.push_back(Args.MakeArgString(
+        Twine(PluginOptPrefix) + "-vectorize-slp=" +
+        (A->getOption().matches(options::OPT_fslp_vectorize) ? "1" : "0")));
+
   // Pass down GlobalISel options.
   if (Arg *A = Args.getLastArg(options::OPT_fglobal_isel,
                                options::OPT_fno_global_isel)) {

--- a/clang/test/Driver/lto.c
+++ b/clang/test/Driver/lto.c
@@ -117,6 +117,14 @@
 // CHECK-GISEL:         "-plugin-opt=-global-isel=1"
 // CHECK-DISABLE-GISEL: "-plugin-opt=-global-isel=0"
 
+// RUN: %clang --target=x86_64-unknown-linux-gnu -### %s -flto -fno-slp-vectorize 2> %t
+// RUN: FileCheck --check-prefix=CHECK-NO-SLP < %t %s
+// RUN: %clang --target=x86_64-unknown-linux-gnu -### %s -flto -fslp-vectorize 2> %t
+// RUN: FileCheck --check-prefix=CHECK-SLP < %t %s
+//
+// CHECK-NO-SLP: "-plugin-opt=-vectorize-slp=0"
+// CHECK-SLP:    "-plugin-opt=-vectorize-slp=1"
+
 // -flto passes -time-passes when -ftime-report is passed
 // RUN: %clang --target=x86_64-unknown-linux-gnu -### %s -flto -ftime-report 2> %t
 // RUN: FileCheck --check-prefix=CHECK-TIME-REPORT < %t %s

--- a/clang/test/Driver/lto.c
+++ b/clang/test/Driver/lto.c
@@ -121,7 +121,7 @@
 // RUN: FileCheck --check-prefix=CHECK-NO-SLP < %t %s
 // RUN: %clang --target=x86_64-unknown-linux-gnu -### %s -flto -fslp-vectorize 2> %t
 // RUN: FileCheck --check-prefix=CHECK-SLP < %t %s
-//
+
 // CHECK-NO-SLP: "-plugin-opt=-vectorize-slp=0"
 // CHECK-SLP:    "-plugin-opt=-vectorize-slp=1"
 


### PR DESCRIPTION
Summary:
This is related to reported regressions in the GROMACS suite when
offloading to AMDGCN devices through the RDC / LTO interface. The
application intentionally passes `-fno-slp-vectorize` to disable that
pass, but there's currently no way to do this through the LTO pipline.

This PR causes the driver to emit `plugin-opt=` for the `-mllvm` option.
That means the pass is still enabled but it should be a no-op now.