### PR TITLE
[lldb-dap][Windows] skip TestDAP_restart_console

### DIFF
--- a/lldb/test/API/tools/lldb-dap/restart/TestDAP_restart_console.py
+++ b/lldb/test/API/tools/lldb-dap/restart/TestDAP_restart_console.py
@@ -12,7 +12,7 @@ from lldbsuite.test.lldbtest import line_number
 @skipIfBuildType(["debug"])
 class TestDAP_restart_console(lldbdap_testcase.DAPTestCaseBase):
     @skipIfAsan
-    @expectedFailureWindows
+    @skipIfWindows  # https://github.com/llvm/llvm-project/issues/200840
     @skipIf(oslist=["linux"], archs=["arm$"])  # Always times out on buildbot
     def test_basic_functionality(self):
         """
@@ -61,7 +61,7 @@ class TestDAP_restart_console(lldbdap_testcase.DAPTestCaseBase):
         self.continue_to_exit()
 
     @skipIfAsan
-    @expectedFailureWindows
+    @skipIfWindows  # https://github.com/llvm/llvm-project/issues/200840
     @skipIf(oslist=["linux"], archs=["arm$"])  # Always times out on buildbot
     def test_stopOnEntry(self):
         """


### PR DESCRIPTION
`TestDAP_restart_console` is already failing on Windows. It reliably crashes (UNRESOLVED) on some Windows version, including inside Docker containers.

This is preventing us from enabling pre-merge CI testing for lldb on Windows in https://github.com/llvm/llvm-project/pull/198906.

This patch skips the test entirely. See https://github.com/llvm/llvm-project/issues/200840 for more details.