### PR TITLE
[lldb][Windows] Clear stale thread stop info on resume

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/NativeThreadWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeThreadWindows.cpp
@@ -81,6 +81,11 @@ Status NativeThreadWindows::DoResume(lldb::StateType resume_state) {
   }
 
   if (resume_state == eStateStepping || resume_state == eStateRunning) {
+    // Clear any stop info left over from a previous stop.
+    m_stop_info = ThreadStopInfo();
+    m_stop_info.reason = lldb::eStopReasonNone;
+    m_stop_description.clear();
+
     DWORD previous_suspend_count = 0;
     HANDLE thread_handle = m_host_thread.GetNativeThread().GetSystemHandle();
     do {


### PR DESCRIPTION
Currently, a thread that didn't participate in the next stop carries its old reason across a continue.

This patch mirrors the `NativeThreadLinux::Resume` implementation by resetting `m_stop` and clearing `m_stop_description`.

When running the test suite with `LLDB_USE_LLDB_SERVER=1`, this fixes:
- `TestThreadSpecificBreakpoint.py`
- `TestIgnoreSuspendedThread.py`
- `TestDAP_threads.py`

rdar://178725507