### PR TITLE
[Dexter][NFC] Mark script tests unsupported for non-lldb debuggers

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/lit.local.cfg
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/lit.local.cfg
@@ -1,0 +1,3 @@
+# Structured scripts require DAP-based debugging, which is currently only supported through LLDB.
+if "lldb" not in config.available_features:
+    config.unsupported = True


### PR DESCRIPTION
The recently-added structured script feature currently relies on DAP-based debuggers, of which the only one currently supported by Dexter is LLDB. In order to prevent the tests that depend on this feature from running for other debuggers, we require LLDB for the script test directory.