### PR TITLE
[TableGen] Add ArgMem memory location

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -59,6 +59,7 @@ class IntrinsicMemoryLocation;
 
 // TODO: Populate with all IRMemLocation enum values and update
 // getValueAsIRMemLocation accordingly.
+def ArgMem : IntrinsicMemoryLocation;
 def InaccessibleMem : IntrinsicMemoryLocation;
 def TargetMem0 : IntrinsicMemoryLocation;
 def TargetMem1 : IntrinsicMemoryLocation;

--- a/llvm/test/TableGen/target-mem-intrinsic-attrs.td
+++ b/llvm/test/TableGen/target-mem-intrinsic-attrs.td
@@ -14,65 +14,50 @@ def int_aarch64_set_inaccessible_mem   : DefaultAttrsIntrinsic<[], [llvm_i64_ty]
 
 def int_aarch64_set_target_mem0   : DefaultAttrsIntrinsic<[], [llvm_i64_ty], [IntrWriteMem, IntrWrite<[TargetMem0]>]>;
 
-// CHECK:   static AttributeSet getIntrinsicFnAttributeSet(LLVMContext &C, unsigned ID) {
-// CHECK-NEXT:  switch (ID) {
-// CHECK-NEXT:    default: llvm_unreachable("Invalid attribute set number");
-// CHECK-NEXT:  case 0: // llvm.aarch64.get.target.mem0.mem1
-// CHECK-NEXT:    return AttributeSet::get(C, {
-// CHECK-NEXT:      Attribute::get(C, Attribute::NoUnwind),
-// CHECK-NEXT:      Attribute::get(C, Attribute::NoCallback),
-// CHECK-NEXT:      Attribute::get(C, Attribute::NoSync),
-// CHECK-NEXT:      Attribute::get(C, Attribute::NoFree),
-// CHECK-NEXT:      Attribute::get(C, Attribute::WillReturn),
-// CHECK-NEXT:      // ArgMem: NoModRef, InaccessibleMem: NoModRef, ErrnoMem: NoModRef, Other: NoModRef, TargetMem0: Ref, TargetMem1: Ref
-// CHECK-NEXT:      Attribute::getWithMemoryEffects(C, MemoryEffects::createFromIntValue(1280)),
-// CHECK-NEXT:    });
-// CHECK-NEXT:  case 1: // llvm.aarch64.get.target.mem0.set.target.mem1
-// CHECK-NEXT:    return AttributeSet::get(C, {
-// CHECK-NEXT:      Attribute::get(C, Attribute::NoUnwind),
-// CHECK-NEXT:      Attribute::get(C, Attribute::NoCallback),
-// CHECK-NEXT:      Attribute::get(C, Attribute::NoSync),
-// CHECK-NEXT:     Attribute::get(C, Attribute::NoFree),
-// CHECK-NEXT:      Attribute::get(C, Attribute::WillReturn),
-// CHECK-NEXT:      // ArgMem: NoModRef, InaccessibleMem: NoModRef, ErrnoMem: NoModRef, Other: NoModRef, TargetMem0: Ref, TargetMem1: Mod
-// CHECK-NEXT:      Attribute::getWithMemoryEffects(C, MemoryEffects::createFromIntValue(2304)),
-// CHECK-NEXT:    });
-// CHECK-NEXT:  case 2: // llvm.aarch64.get.target.mem1
-// CHECK-NEXT:    return AttributeSet::get(C, {
-// CHECK-NEXT:      Attribute::get(C, Attribute::NoUnwind),
-// CHECK-NEXT:      Attribute::get(C, Attribute::NoCallback),
-// CHECK-NEXT:      Attribute::get(C, Attribute::NoSync),
-// CHECK-NEXT:      Attribute::get(C, Attribute::NoFree),
-// CHECK-NEXT:      Attribute::get(C, Attribute::WillReturn),
-// CHECK-NEXT:      // ArgMem: NoModRef, InaccessibleMem: NoModRef, ErrnoMem: NoModRef, Other: NoModRef, TargetMem0: NoModRef, TargetMem1: Ref
-// CHECK-NEXT:      Attribute::getWithMemoryEffects(C, MemoryEffects::createFromIntValue(1024)),
-// CHECK-NEXT:    });
-// CHECK-NEXT:  case 3: // llvm.aarch64.get.target.mem1.set.target.mem1
-// CHECK-NEXT:    return AttributeSet::get(C, {
-// CHECK-NEXT:      Attribute::get(C, Attribute::NoUnwind),
-// CHECK-NEXT:      Attribute::get(C, Attribute::NoCallback),
-// CHECK-NEXT:      Attribute::get(C, Attribute::NoSync),
-// CHECK-NEXT:      Attribute::get(C, Attribute::NoFree),
-// CHECK-NEXT:      Attribute::get(C, Attribute::WillReturn),
-// CHECK-NEXT:      // ArgMem: NoModRef, InaccessibleMem: NoModRef, ErrnoMem: NoModRef, Other: NoModRef, TargetMem0: NoModRef, TargetMem1: ModRef
-// CHECK-NEXT:      Attribute::getWithMemoryEffects(C, MemoryEffects::createFromIntValue(3072)),
-// CHECK-NEXT:    });
-// CHECK-NEXT:  case 4: // llvm.aarch64.set.inaccessible.mem
-// CHECK-NEXT:    return AttributeSet::get(C, {
-// CHECK-NEXT:      Attribute::get(C, Attribute::NoUnwind),
-// CHECK-NEXT:      Attribute::get(C, Attribute::NoCallback),
-// CHECK-NEXT:      Attribute::get(C, Attribute::NoSync),
-// CHECK-NEXT:      Attribute::get(C, Attribute::NoFree),
-// CHECK-NEXT:      Attribute::get(C, Attribute::WillReturn),
-// CHECK-NEXT:      // ArgMem: NoModRef, InaccessibleMem: Mod, ErrnoMem: NoModRef, Other: NoModRef, TargetMem0: NoModRef, TargetMem1: NoModRef
-// CHECK-NEXT:      Attribute::getWithMemoryEffects(C, MemoryEffects::createFromIntValue(8)),
-// CHECK-NEXT:    });
-// CHECK-NEXT:  case 5: // llvm.aarch64.set.target.mem0
-// CHECK-NEXT:    return AttributeSet::get(C, {
-// CHECK-NEXT:      Attribute::get(C, Attribute::NoUnwind),
-// CHECK-NEXT:      Attribute::get(C, Attribute::NoCallback),
-// CHECK-NEXT:      Attribute::get(C, Attribute::NoSync),
-// CHECK-NEXT:      Attribute::get(C, Attribute::NoFree),
-// CHECK-NEXT:      Attribute::get(C, Attribute::WillReturn),
-// CHECK-NEXT:      // ArgMem: NoModRef, InaccessibleMem: NoModRef, ErrnoMem: NoModRef, Other: NoModRef, TargetMem0: Mod, TargetMem1: NoModRef
-// CHECK-NEXT:      Attribute::getWithMemoryEffects(C, MemoryEffects::createFromIntValue(512)),
+def int_aarch64_argmem_read_target_mem1_write   :  DefaultAttrsIntrinsic<[], [llvm_i64_ty], [IntrRead<[ArgMem]>, IntrWrite<[TargetMem1]>]>;
+
+def int_aarch64_argmem_target_mem1_read_target_mem1_write  : DefaultAttrsIntrinsic<[], [llvm_i64_ty], [IntrRead<[ArgMem, TargetMem1]>, IntrWrite<[TargetMem1]>]>;
+
+def int_aarch64_target_mem1_read_argmem_write   : DefaultAttrsIntrinsic<[], [llvm_i64_ty], [IntrRead<[TargetMem1]>, IntrWrite<[ArgMem]>]>;
+
+def int_aarch64_target_mem0_read_argmem_write   : DefaultAttrsIntrinsic<[], [llvm_i64_ty], [IntrRead<[TargetMem0]>, IntrWrite<[ArgMem]>]>;
+
+// CHECK-LABEL: case 0: // llvm.aarch64.argmem.read.target.mem1.write
+// CHECK: // ArgMem: Ref, InaccessibleMem: NoModRef, ErrnoMem: NoModRef, Other: NoModRef, TargetMem0: NoModRef, TargetMem1: Mod
+// CHECK-NEXT: Attribute::getWithMemoryEffects(C, MemoryEffects::createFromIntValue(2049)),
+
+// CHECK-LABEL: case 1: // llvm.aarch64.argmem.target.mem1.read.target.mem1.write
+// CHECK: // ArgMem: Ref, InaccessibleMem: NoModRef, ErrnoMem: NoModRef, Other: NoModRef, TargetMem0: NoModRef, TargetMem1: ModRef
+// CHECK-NEXT: Attribute::getWithMemoryEffects(C, MemoryEffects::createFromIntValue(3073)),
+
+// CHECK-LABEL: case 2: // llvm.aarch64.get.target.mem0.mem1
+// CHECK: // ArgMem: NoModRef, InaccessibleMem: NoModRef, ErrnoMem: NoModRef, Other: NoModRef, TargetMem0: Ref, TargetMem1: Ref
+// CHECK-NEXT: Attribute::getWithMemoryEffects(C, MemoryEffects::createFromIntValue(1280)),
+
+// CHECK-LABEL: case 3: // llvm.aarch64.get.target.mem0.set.target.mem1
+// CHECK: // ArgMem: NoModRef, InaccessibleMem: NoModRef, ErrnoMem: NoModRef, Other: NoModRef, TargetMem0: Ref, TargetMem1: Mod
+// CHECK-NEXT: Attribute::getWithMemoryEffects(C, MemoryEffects::createFromIntValue(2304)),
+
+// CHECK-LABEL: case 4: // llvm.aarch64.get.target.mem1
+// CHECK: // ArgMem: NoModRef, InaccessibleMem: NoModRef, ErrnoMem: NoModRef, Other: NoModRef, TargetMem0: NoModRef, TargetMem1: Ref
+// CHECK-NEXT: Attribute::getWithMemoryEffects(C, MemoryEffects::createFromIntValue(1024)),
+
+// CHECK-LABEL: case 5: // llvm.aarch64.get.target.mem1.set.target.mem1
+// CHECK: // ArgMem: NoModRef, InaccessibleMem: NoModRef, ErrnoMem: NoModRef, Other: NoModRef, TargetMem0: NoModRef, TargetMem1: ModRef
+// CHECK-NEXT: Attribute::getWithMemoryEffects(C, MemoryEffects::createFromIntValue(3072)),
+
+// CHECK-LABEL: case 6: // llvm.aarch64.set.inaccessible.mem
+// CHECK: // ArgMem: NoModRef, InaccessibleMem: Mod, ErrnoMem: NoModRef, Other: NoModRef, TargetMem0: NoModRef, TargetMem1: NoModRef
+// CHECK-NEXT: Attribute::getWithMemoryEffects(C, MemoryEffects::createFromIntValue(8)),
+
+// CHECK-LABEL: case 7: // llvm.aarch64.set.target.mem0
+// CHECK: // ArgMem: NoModRef, InaccessibleMem: NoModRef, ErrnoMem: NoModRef, Other: NoModRef, TargetMem0: Mod, TargetMem1: NoModRef
+// CHECK-NEXT: Attribute::getWithMemoryEffects(C, MemoryEffects::createFromIntValue(512)),
+
+// CHECK-LABEL: case 8: // llvm.aarch64.target.mem0.read.argmem.write
+// CHECK: // ArgMem: Mod, InaccessibleMem: NoModRef, ErrnoMem: NoModRef, Other: NoModRef, TargetMem0: Ref, TargetMem1: NoModRef
+// CHECK-NEXT: Attribute::getWithMemoryEffects(C, MemoryEffects::createFromIntValue(258)),
+
+// CHECK-LABEL: case 9: // llvm.aarch64.target.mem1.read.argmem.write
+// CHECK: // ArgMem: Mod, InaccessibleMem: NoModRef, ErrnoMem: NoModRef, Other: NoModRef, TargetMem0: NoModRef, TargetMem1: Ref
+// CHECK-NEXT: Attribute::getWithMemoryEffects(C, MemoryEffects::createFromIntValue(1026)),

--- a/llvm/utils/TableGen/Basic/CodeGenIntrinsics.cpp
+++ b/llvm/utils/TableGen/Basic/CodeGenIntrinsics.cpp
@@ -535,6 +535,7 @@ CodeGenIntrinsic::getValueAsIRMemLocation(const Record *R) const {
   StringRef Name = R->getName();
   IRMemLocation Loc =
       StringSwitch<IRMemLocation>(Name)
+          .Case("ArgMem", IRMemLocation::ArgMem)
           .Case("TargetMem0", IRMemLocation::TargetMem0)
           .Case("TargetMem1", IRMemLocation::TargetMem1)
           .Case("InaccessibleMem", IRMemLocation::InaccessibleMem)


### PR DESCRIPTION
This will allow to use IntrRead/IntrWrite with ArgMem. So this:
```
[IntrWriteMem , IntrInaccessibleMemOrArgMemOnly]
```
could become this:
```
[IntrWriteMem, IntrWrite<[ArgMem, InaccessibleMem]>] 
```