### PR TITLE
[RISCV] Support sf_vtmv OFP8 intrinsics

### DIFF
--- a/clang/include/clang/Basic/riscv_sifive_vector.td
+++ b/clang/include/clang/Basic/riscv_sifive_vector.td
@@ -258,6 +258,8 @@ multiclass RVVSFTileMoveBuiltinSet<list<list<string>> suffixes_prototypes,
     let RequiredFeatures = !listconcat(RequiredFeatures,
                                        !cond(!eq(type, "x"): ["zvfhmin"],
                                              !eq(type, "y"): ["zvfbfmin"],
+                                             !eq(type, "a"): ["zvfofp8min"],
+                                             !eq(type, "b"): ["zvfofp8min"],
                                              true:           []<string>)),
         SupportOverloading = false,
         HasMasked = false,
@@ -274,7 +276,7 @@ multiclass RVVSFTileMoveVTBuiltinSet<list<string> RequiredFeatures = []> {
     defm NAME :
         RVVSFTileMoveBuiltinSet<[["v", "vz"], ["Uv", "Uvz"]], [-1], type,
                                 RequiredFeatures>;
-  foreach type = ["x", "y", "f", "d"] in
+  foreach type = ["x", "y", "f", "d", "a", "b"] in
     defm NAME :
         RVVSFTileMoveBuiltinSet<[["v", "vz"]], [-1], type, RequiredFeatures>;
 }
@@ -285,7 +287,7 @@ multiclass RVVSFTileMoveTVBuiltinSet<list<string> RequiredFeatures = []> {
       defm NAME :
           RVVSFTileMoveBuiltinSet<[["v", "0zv"], ["Uv", "0zUv"]], [1], type,
                                   RequiredFeatures>;
-    foreach type = ["x", "y", "f", "d"] in
+    foreach type = ["x", "y", "f", "d", "a", "b"] in
       defm NAME :
           RVVSFTileMoveBuiltinSet<[["v", "0zv"]], [1], type, RequiredFeatures>;
   }

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-sifive/non-policy/non-overloaded/sf_vtmv_t_v.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-sifive/non-policy/non-overloaded/sf_vtmv_t_v.c
@@ -2,7 +2,7 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +xsfmmbase \
 // RUN:   -target-feature +zvfhmin -target-feature +zvfbfmin \
-// RUN:   -target-feature +zve64d \
+// RUN:   -target-feature +experimental-zvfofp8min -target-feature +zve64d \
 // RUN:   -disable-O0-optnone -emit-llvm %s -o - | \
 // RUN:   opt -S -passes=mem2reg | FileCheck --check-prefix=CHECK-RV64 %s
 
@@ -126,5 +126,25 @@ void test_sf_vtmv_t_v_u32m8(size_t tss, vuint32m8_t src, size_t vl) {
 //
 void test_sf_vtmv_t_v_u64m8(size_t tss, vuint64m8_t src, size_t vl) {
   return __riscv_sf_vtmv_t_v_u64m8(tss, src, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_sf_vtmv_t_v_f8e4m3m8(
+// CHECK-RV64-SAME: i64 noundef [[TSS:%.*]], <vscale x 64 x i8> [[SRC:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.sf.vtmv.t.v.nxv64i8.i64(i64 [[TSS]], <vscale x 64 x i8> [[SRC]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_sf_vtmv_t_v_f8e4m3m8(size_t tss, vfloat8e4m3m8_t src, size_t vl) {
+  return __riscv_sf_vtmv_t_v_f8e4m3m8(tss, src, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_sf_vtmv_t_v_f8e5m2m8(
+// CHECK-RV64-SAME: i64 noundef [[TSS:%.*]], <vscale x 64 x i8> [[SRC:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.sf.vtmv.t.v.nxv64i8.i64(i64 [[TSS]], <vscale x 64 x i8> [[SRC]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_sf_vtmv_t_v_f8e5m2m8(size_t tss, vfloat8e5m2m8_t src, size_t vl) {
+  return __riscv_sf_vtmv_t_v_f8e5m2m8(tss, src, vl);
 }
 

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-sifive/non-policy/non-overloaded/sf_vtmv_v_t.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-sifive/non-policy/non-overloaded/sf_vtmv_v_t.c
@@ -2,7 +2,7 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +xsfmmbase \
 // RUN:   -target-feature +zvfhmin -target-feature +zvfbfmin \
-// RUN:   -target-feature +zve64d \
+// RUN:   -target-feature +experimental-zvfofp8min -target-feature +zve64d \
 // RUN:   -disable-O0-optnone -emit-llvm %s -o - | \
 // RUN:   opt -S -passes=mem2reg | FileCheck --check-prefix=CHECK-RV64 %s
 
@@ -126,5 +126,25 @@ vuint32m8_t test_sf_vtmv_v_t_u32m8(size_t tss, size_t vl) {
 //
 vuint64m8_t test_sf_vtmv_v_t_u64m8(size_t tss, size_t vl) {
   return __riscv_sf_vtmv_v_t_u64m8(tss, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 64 x i8> @test_sf_vtmv_v_t_f8e4m3m8(
+// CHECK-RV64-SAME: i64 noundef [[TSS:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 64 x i8> @llvm.riscv.sf.vtmv.v.t.nxv64i8.i64(i64 [[TSS]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 64 x i8> [[TMP0]]
+//
+vfloat8e4m3m8_t test_sf_vtmv_v_t_f8e4m3m8(size_t tss, size_t vl) {
+  return __riscv_sf_vtmv_v_t_f8e4m3m8(tss, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local <vscale x 64 x i8> @test_sf_vtmv_v_t_f8e5m2m8(
+// CHECK-RV64-SAME: i64 noundef [[TSS:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = call <vscale x 64 x i8> @llvm.riscv.sf.vtmv.v.t.nxv64i8.i64(i64 [[TSS]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret <vscale x 64 x i8> [[TMP0]]
+//
+vfloat8e5m2m8_t test_sf_vtmv_v_t_f8e5m2m8(size_t tss, size_t vl) {
+  return __riscv_sf_vtmv_v_t_f8e5m2m8(tss, vl);
 }
 

--- a/clang/test/CodeGen/RISCV/rvv-intrinsics-sifive/non-policy/overloaded/sf_vtmv_t_v.c
+++ b/clang/test/CodeGen/RISCV/rvv-intrinsics-sifive/non-policy/overloaded/sf_vtmv_t_v.c
@@ -2,7 +2,7 @@
 // REQUIRES: riscv-registered-target
 // RUN: %clang_cc1 -triple riscv64 -target-feature +xsfmmbase \
 // RUN:   -target-feature +zvfhmin -target-feature +zvfbfmin \
-// RUN:   -target-feature +zve64d \
+// RUN:   -target-feature +experimental-zvfofp8min -target-feature +zve64d \
 // RUN:   -disable-O0-optnone -emit-llvm %s -o - | \
 // RUN:   opt -S -passes=mem2reg | FileCheck --check-prefix=CHECK-RV64 %s
 
@@ -125,6 +125,26 @@ void test_sf_vtmv_t_v_u32m8(size_t tss, vuint32m8_t src, size_t vl) {
 // CHECK-RV64-NEXT:    ret void
 //
 void test_sf_vtmv_t_v_u64m8(size_t tss, vuint64m8_t src, size_t vl) {
+  return __riscv_sf_vtmv_t_v(tss, src, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_sf_vtmv_t_v_f8e4m3m8(
+// CHECK-RV64-SAME: i64 noundef [[TSS:%.*]], <vscale x 64 x i8> [[SRC:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.sf.vtmv.t.v.nxv64i8.i64(i64 [[TSS]], <vscale x 64 x i8> [[SRC]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_sf_vtmv_t_v_f8e4m3m8(size_t tss, vfloat8e4m3m8_t src, size_t vl) {
+  return __riscv_sf_vtmv_t_v(tss, src, vl);
+}
+
+// CHECK-RV64-LABEL: define dso_local void @test_sf_vtmv_t_v_f8e5m2m8(
+// CHECK-RV64-SAME: i64 noundef [[TSS:%.*]], <vscale x 64 x i8> [[SRC:%.*]], i64 noundef [[VL:%.*]]) #[[ATTR0]] {
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    call void @llvm.riscv.sf.vtmv.t.v.nxv64i8.i64(i64 [[TSS]], <vscale x 64 x i8> [[SRC]], i64 [[VL]])
+// CHECK-RV64-NEXT:    ret void
+//
+void test_sf_vtmv_t_v_f8e5m2m8(size_t tss, vfloat8e5m2m8_t src, size_t vl) {
   return __riscv_sf_vtmv_t_v(tss, src, vl);
 }
 


### PR DESCRIPTION
This patch supports OFP8 type vtmv_v_t and vtmv_t_v intrinsics which were missing back then since there's no OFP8 vector types.