### PR TITLE
[Clang][Hexagon]  Predefine _GNU_SOURCE for C++ compilations

### DIFF
--- a/clang/lib/Basic/Targets/Hexagon.cpp
+++ b/clang/lib/Basic/Targets/Hexagon.cpp
@@ -116,6 +116,9 @@ void HexagonTargetInfo::getTargetDefines(const LangOptions &Opts,
   Builder.defineMacro("__GCC_HAVE_SYNC_COMPARE_AND_SWAP_2");
   Builder.defineMacro("__GCC_HAVE_SYNC_COMPARE_AND_SWAP_4");
   Builder.defineMacro("__GCC_HAVE_SYNC_COMPARE_AND_SWAP_8");
+
+  if (Opts.CPlusPlus && getTriple().getOS() == llvm::Triple::UnknownOS)
+    Builder.defineMacro("_GNU_SOURCE");
 }
 
 bool HexagonTargetInfo::initFeatureMap(

--- a/clang/lib/Basic/Targets/OSTargets.h
+++ b/clang/lib/Basic/Targets/OSTargets.h
@@ -1092,6 +1092,8 @@ protected:
   void getOSDefines(const LangOptions &Opts, const llvm::Triple &Triple,
                     MacroBuilder &Builder) const override {
     Builder.defineMacro("__qurt__");
+    if (Opts.CPlusPlus)
+      Builder.defineMacro("_GNU_SOURCE");
   }
 
 public:
@@ -1105,6 +1107,8 @@ protected:
   void getOSDefines(const LangOptions &Opts, const llvm::Triple &Triple,
                     MacroBuilder &Builder) const override {
     Builder.defineMacro("__h2__");
+    if (Opts.CPlusPlus)
+      Builder.defineMacro("_GNU_SOURCE");
   }
 
 public:

--- a/clang/test/Preprocessor/hexagon-predefines.c
+++ b/clang/test/Preprocessor/hexagon-predefines.c
@@ -261,3 +261,19 @@
 // CHECK-H2: #define __h2__ 1
 // CHECK-H2: #define __hexagon__ 1
 // CHECK-H2-NOT: #define __linux__
+
+// RUN: %clang_cc1 -E -dM -triple hexagon-unknown-elf -x c++ %s | FileCheck \
+// RUN: %s -check-prefix CHECK-CXX-GNU
+// CHECK-CXX-GNU: #define _GNU_SOURCE 1
+
+// RUN: %clang_cc1 -E -dM -triple hexagon-unknown-h2 -x c++ %s | FileCheck \
+// RUN: %s -check-prefix CHECK-H2-CXX-GNU
+// CHECK-H2-CXX-GNU: #define _GNU_SOURCE 1
+
+// RUN: %clang_cc1 -E -dM -triple hexagon-unknown-qurt -x c++ %s | FileCheck \
+// RUN: %s -check-prefix CHECK-QURT-CXX-GNU
+// CHECK-QURT-CXX-GNU: #define _GNU_SOURCE 1
+
+// RUN: %clang_cc1 -E -dM -triple hexagon-unknown-elf %s | FileCheck \
+// RUN: %s -check-prefix CHECK-C-GNU
+// CHECK-C-GNU-NOT: #define _GNU_SOURCE


### PR DESCRIPTION
Predefine _GNU_SOURCE in C++ mode for H2, QuRT, and baremetal
Hexagon targets.