### PR TITLE
[MCP] Early exit if no copies (NFC)

### DIFF
--- a/llvm/lib/CodeGen/MachineCopyPropagation.cpp
+++ b/llvm/lib/CodeGen/MachineCopyPropagation.cpp
@@ -175,6 +175,9 @@ public:
   /// Remove register from copy maps.
   void invalidateRegister(MCRegister Reg, const TargetRegisterInfo &TRI,
                           const TargetInstrInfo &TII, bool UseCopyInstr) {
+    if (Copies.empty())
+      return;
+
     // Since Reg might be a subreg of some registers, only invalidate Reg is not
     // enough. We have to find the COPY defines Reg or registers defined by Reg
     // and invalidate all of them. Similarly, we must invalidate all of the
@@ -262,6 +265,9 @@ public:
   /// Clobber a single register, removing it from the tracker's copy maps.
   void clobberRegister(MCRegister Reg, const TargetRegisterInfo &TRI,
                        const TargetInstrInfo &TII, bool UseCopyInstr) {
+    if (Copies.empty())
+      return;
+
     for (MCRegUnit Unit : TRI.regunits(Reg)) {
       clobberRegUnit(Unit, TRI, TII, UseCopyInstr);
     }

--- a/llvm/lib/CodeGen/MachineCopyPropagation.cpp
+++ b/llvm/lib/CodeGen/MachineCopyPropagation.cpp
@@ -175,6 +175,8 @@ public:
   /// Remove register from copy maps.
   void invalidateRegister(MCRegister Reg, const TargetRegisterInfo &TRI,
                           const TargetInstrInfo &TII, bool UseCopyInstr) {
+    // Early exit if there are no copies, as the function wouldn't do anything
+    // in that case.
     if (Copies.empty())
       return;
 
@@ -265,6 +267,8 @@ public:
   /// Clobber a single register, removing it from the tracker's copy maps.
   void clobberRegister(MCRegister Reg, const TargetRegisterInfo &TRI,
                        const TargetInstrInfo &TII, bool UseCopyInstr) {
+    // Early exit if there are no copies, as the function wouldn't do anything
+    // in that case.
     if (Copies.empty())
       return;
 


### PR DESCRIPTION
These two functions do expensive per-regunit work, but are no-ops if there are no Copies, so short-circuit this case.

This is a small compile-time improvement: https://llvm-compile-time-tracker.com/compare.php?from=4d2a670ba868a75103424ff3203f443391d55b1b&to=156a0df89bcdd0cafbdb264d429c7ca38965906e&stat=instructions%3Au