### PR TITLE
[mlir][acc] Add operation for private handle to memref

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/OpenACC.h
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACC.h
@@ -32,6 +32,7 @@
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
 #include <variant>
 
 #define GET_TYPEDEF_CLASSES

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
@@ -17,6 +17,7 @@
 #define OPENACC_CG_OPS
 
 include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/Interfaces/ViewLikeInterface.td"
 
 // This file is intended to be included from OpenACCOps.td, which provides
 // the necessary includes and definitions. The operations defined here use
@@ -251,6 +252,28 @@ def OpenACC_PrivatizeOp : OpenACC_Op<"privatize", []> {
       $_state.addOperands(dynamicSizes);
     }]>
   ];
+}
+
+//===----------------------------------------------------------------------===//
+// acc.unwrap_private
+//===----------------------------------------------------------------------===//
+
+def OpenACC_UnwrapPrivateOp
+    : OpenACC_Op<"unwrap_private",
+                 [NoMemoryEffect, AlwaysSpeculatable, ViewLikeOpInterface]> {
+  let summary = "Unwrap acc.private_type handle to pointer-like storage";
+  let description = [{
+    Converts a privatization handle (`acc.private_type<T>`) to a pointer-like
+    view of the underlying private storage.
+  }];
+  let arguments = (ins OpenACC_PrivateType:$handle);
+  let results = (outs OpenACC_PointerLikeType:$result);
+  let assemblyFormat = [{
+    $handle attr-dict `:` qualified(type($handle)) `to` type($result)
+  }];
+  let extraClassDeclaration = [{
+    ::mlir::Value getViewSource() { return getHandle(); }
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
@@ -346,6 +346,23 @@ struct LLVMPointerPointerLikeModel
   }
 };
 
+struct PrivateTypePointerLikeModel
+    : public PointerLikeType::ExternalModel<PrivateTypePointerLikeModel,
+                                            PrivateType> {
+  Type getElementType(Type type) const {
+    return cast<PrivateType>(type).getBaseTy();
+  }
+
+  Value genCast(Type, OpBuilder &builder, Location loc, Value value,
+                Type resultType) const {
+    if (value.getType() == resultType)
+      return value;
+    if (!isa<PointerLikeType>(resultType))
+      return {};
+    return UnwrapPrivateOp::create(builder, loc, resultType, value).getResult();
+  }
+};
+
 struct MemrefAddressOfGlobalModel
     : public AddressOfGlobalOpInterface::ExternalModel<
           MemrefAddressOfGlobalModel, memref::GetGlobalOp> {
@@ -474,6 +491,7 @@ void OpenACCDialect::initialize() {
       MemRefPointerLikeModel<UnrankedMemRefType>>(*getContext());
   LLVM::LLVMPointerType::attachInterface<LLVMPointerPointerLikeModel>(
       *getContext());
+  PrivateType::attachInterface<PrivateTypePointerLikeModel>(*getContext());
 
   // Attach operation interfaces
   memref::GetGlobalOp::attachInterface<MemrefAddressOfGlobalModel>(

--- a/mlir/test/Dialect/OpenACC/ops-cg-privatization.mlir
+++ b/mlir/test/Dialect/OpenACC/ops-cg-privatization.mlir
@@ -1,5 +1,7 @@
 // RUN: mlir-opt -split-input-file %s | FileCheck %s --check-prefixes=CHECK
+// Verify the printed output can be parsed.
 // RUN: mlir-opt -split-input-file %s | mlir-opt -split-input-file | FileCheck %s --check-prefixes=CHECK
+// Verify the generic form can be parsed.
 // RUN: mlir-opt -split-input-file -mlir-print-op-generic %s | mlir-opt -split-input-file | FileCheck %s --check-prefixes=CHECK
 
 // -----
@@ -114,3 +116,28 @@ func.func @privatize_inside_compute_region(%data : memref<64xf32>) {
 // CHECK: acc.private_local
 // CHECK: memref.load %{{.*}}[%{{.*}}] : memref<64xf32>
 // CHECK: } {origin = "acc.parallel"}
+
+// -----
+
+// CHECK-LABEL: func @unwrap_private_to_memref
+func.func @unwrap_private_to_memref() {
+  %h = acc.privatize : () -> !acc.private_type<memref<i32>>
+  %m = acc.unwrap_private %h : !acc.private_type<memref<i32>> to memref<i32>
+  %z = arith.constant 0 : i32
+  memref.store %z, %m[] : memref<i32>
+  return
+}
+// CHECK-DAG: %[[H:.*]] = acc.privatize
+// CHECK-SAME: () -> !acc.private_type<memref<i32>>
+// CHECK: %{{.*}} = acc.unwrap_private %[[H]]
+// CHECK-SAME: !acc.private_type<memref<i32>> to memref<i32>
+
+// -----
+
+// CHECK-LABEL: func @unwrap_private_to_byte_memref
+func.func @unwrap_private_to_byte_memref() {
+  %h = acc.privatize : () -> !acc.private_type<memref<f64>>
+  %storage = acc.unwrap_private %h : !acc.private_type<memref<f64>> to memref<?xi8>
+  return
+}
+// CHECK: acc.unwrap_private %{{.*}} : !acc.private_type<memref<f64>> to memref<?xi8>

--- a/mlir/unittests/Dialect/OpenACC/OpenACCTypeInterfacesTest.cpp
+++ b/mlir/unittests/Dialect/OpenACC/OpenACCTypeInterfacesTest.cpp
@@ -256,3 +256,24 @@ TEST_F(OpenACCTypeInterfacesTest, PointerLikeGenCastLLVMIntToPtrFromIndex) {
   ASSERT_TRUE(intToPtr);
   EXPECT_TRUE(isa<arith::IndexCastUIOp>(intToPtr.getArg().getDefiningOp()));
 }
+
+TEST_F(OpenACCTypeInterfacesTest, PointerLikeGenCastPrivateTypeToMemref) {
+  Location loc = UnknownLoc::get(&context);
+  OwningOpRef<ModuleOp> module = ModuleOp::create(loc);
+  OpBuilder builder(module->getBodyRegion());
+  func::FuncOp fn = func::FuncOp::create(
+      builder, loc, "cast_private_to_memref", builder.getFunctionType({}, {}));
+  Block *block = fn.addEntryBlock();
+  builder.setInsertionPointToStart(block);
+
+  Type privateTy = PrivateType::get(&context, builder.getI8Type());
+  Type memrefTy = MemRefType::get({ShapedType::kDynamic}, builder.getI8Type());
+  Value handle = UndefOp::create(builder, loc, privateTy);
+  auto ptrLike = cast<PointerLikeType>(privateTy);
+  Value out = ptrLike.genCast(builder, loc, handle, memrefTy);
+  ASSERT_TRUE(out);
+  EXPECT_EQ(out.getType(), memrefTy);
+  auto unwrap = dyn_cast<UnwrapPrivateOp>(out.getDefiningOp());
+  ASSERT_TRUE(unwrap);
+  EXPECT_EQ(unwrap.getHandle(), handle);
+}

--- a/mlir/unittests/Dialect/OpenACC/OpenACCTypeInterfacesTest.cpp
+++ b/mlir/unittests/Dialect/OpenACC/OpenACCTypeInterfacesTest.cpp
@@ -261,8 +261,8 @@ TEST_F(OpenACCTypeInterfacesTest, PointerLikeGenCastPrivateTypeToMemref) {
   Location loc = UnknownLoc::get(&context);
   OwningOpRef<ModuleOp> module = ModuleOp::create(loc);
   OpBuilder builder(module->getBodyRegion());
-  func::FuncOp fn = func::FuncOp::create(
-      builder, loc, "cast_private_to_memref", builder.getFunctionType({}, {}));
+  func::FuncOp fn = func::FuncOp::create(builder, loc, "cast_private_to_memref",
+                                         builder.getFunctionType({}, {}));
   Block *block = fn.addEntryBlock();
   builder.setInsertionPointToStart(block);
 


### PR DESCRIPTION
This MR introduces a new operation `acc.unwrap_private` for creating a pointer-like view of the `acc.private_type` handle. This operation will be used when materializing `acc.private_local` into the memory view needed to access the allocated private memory. This new operation is just a simple cast and thus it gets ViewLikeOpInterface attached to it.

Additionally, `acc.private_type` is now treated as a pointer-like type to ease conversions to other pointer-like types via PointerLikeType::genCast.