### PR TITLE
[lldb][gdb-remote] Mark thread as stopped in RefreshStateAfterStop

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/TargetThreadWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/TargetThreadWindows.cpp
@@ -39,7 +39,6 @@ TargetThreadWindows::~TargetThreadWindows() { DestroyThread(); }
 
 void TargetThreadWindows::RefreshStateAfterStop() {
   ::SuspendThread(m_host_thread.GetNativeThread().GetSystemHandle());
-  SetState(eStateStopped);
   GetRegisterContext()->InvalidateIfNeeded(false);
 }
 

--- a/lldb/source/Plugins/Process/gdb-remote/ThreadGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ThreadGDBRemote.cpp
@@ -271,6 +271,9 @@ void ThreadGDBRemote::WillResume(StateType resume_state) {
 }
 
 void ThreadGDBRemote::RefreshStateAfterStop() {
+  // Mark this thread as stopped. ThreadList::DidStop only transitions
+  // threads from a running state to stopped.
+  SetState(eStateStopped);
   // Invalidate all registers in our register context. We don't set "force" to
   // true because the stop reply packet might have had some register values
   // that were expedited and these will already be copied into the register

--- a/lldb/source/Plugins/Process/gdb-remote/ThreadGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ThreadGDBRemote.cpp
@@ -271,9 +271,6 @@ void ThreadGDBRemote::WillResume(StateType resume_state) {
 }
 
 void ThreadGDBRemote::RefreshStateAfterStop() {
-  // Mark this thread as stopped. ThreadList::DidStop only transitions
-  // threads from a running state to stopped.
-  SetState(eStateStopped);
   // Invalidate all registers in our register context. We don't set "force" to
   // true because the stop reply packet might have had some register values
   // that were expedited and these will already be copied into the register

--- a/lldb/source/Target/ThreadList.cpp
+++ b/lldb/source/Target/ThreadList.cpp
@@ -482,8 +482,10 @@ void ThreadList::RefreshStateAfterStop() {
       "a thread.");
 
   collection::iterator pos, end = m_threads.end();
-  for (pos = m_threads.begin(); pos != end; ++pos)
+  for (pos = m_threads.begin(); pos != end; ++pos) {
+    (*pos)->SetState(eStateStopped);
     (*pos)->RefreshStateAfterStop();
+  }
 }
 
 void ThreadList::DiscardThreadPlans() {

--- a/lldb/test/API/functionalities/thread/break_after_join/TestBreakAfterJoin.py
+++ b/lldb/test/API/functionalities/thread/break_after_join/TestBreakAfterJoin.py
@@ -17,19 +17,6 @@ class BreakpointAfterJoinTestCase(TestBase):
         # Find the line number for our breakpoint.
         self.breakpoint = line_number("main.cpp", "// Set breakpoint here")
 
-    @expectedFailureAll(
-        oslist=["linux"],
-        bugnumber="llvm.org/pr15824 thread states not properly maintained",
-    )
-    @expectedFailureAll(
-        oslist=lldbplatformutil.getDarwinOSTriples(),
-        bugnumber="llvm.org/pr15824 thread states not properly maintained and <rdar://problem/28557237>",
-    )
-    @expectedFailureAll(
-        oslist=["freebsd"],
-        bugnumber="llvm.org/pr18190 thread states not properly maintained",
-    )
-    @expectedFailureNetBSD
     def test(self):
         """Test breakpoint handling after a thread join."""
         self.build()

--- a/lldb/test/API/functionalities/thread/multi_break/TestMultipleBreakpoints.py
+++ b/lldb/test/API/functionalities/thread/multi_break/TestMultipleBreakpoints.py
@@ -17,20 +17,7 @@ class MultipleBreakpointTestCase(TestBase):
         # Find the line number for our breakpoint.
         self.breakpoint = line_number("main.cpp", "// Set breakpoint here")
 
-    @expectedFailureAll(
-        oslist=["linux"],
-        bugnumber="llvm.org/pr15824 thread states not properly maintained",
-    )
-    @expectedFailureAll(
-        oslist=lldbplatformutil.getDarwinOSTriples(),
-        bugnumber="llvm.org/pr15824 thread states not properly maintained and <rdar://problem/28557237>",
-    )
-    @expectedFailureAll(
-        oslist=["freebsd"],
-        bugnumber="llvm.org/pr18190 thread states not properly maintained",
-    )
     @skipIfWindows  # This is flakey on Windows: llvm.org/pr24668, llvm.org/pr38373
-    @expectedFailureNetBSD
     def test(self):
         """Test simultaneous breakpoints in multiple threads."""
         self.build()

--- a/lldb/test/API/functionalities/thread/state/TestThreadStates.py
+++ b/lldb/test/API/functionalities/thread/state/TestThreadStates.py
@@ -37,6 +37,10 @@ class ThreadStateTestCase(TestBase):
 
     @skipIfDarwin  # rdar://28557237
     @expectedFailureAll(
+        oslist=["linux"],
+        bugnumber="llvm.org/pr15824 process interrupt stop reason is trace instead of signal",
+    )
+    @expectedFailureAll(
         oslist=["windows"],
         bugnumber="llvm.org/pr24668: Breakpoints not resolved correctly",
     )

--- a/lldb/test/API/functionalities/thread/state/TestThreadStates.py
+++ b/lldb/test/API/functionalities/thread/state/TestThreadStates.py
@@ -36,10 +36,7 @@ class ThreadStateTestCase(TestBase):
         self.thread_state_after_expression_test()
 
     @skipIfDarwin  # rdar://28557237
-    @expectedFailureAll(
-        oslist=["linux"],
-        bugnumber="llvm.org/pr15824 process interrupt stop reason is trace instead of signal",
-    )
+    @skipIfLinux  # llvm.org/pr15824 process interrupt stop reason is trace instead of signal sometimes
     @expectedFailureAll(
         oslist=["windows"],
         bugnumber="llvm.org/pr24668: Breakpoints not resolved correctly",

--- a/lldb/test/API/functionalities/thread/state/TestThreadStates.py
+++ b/lldb/test/API/functionalities/thread/state/TestThreadStates.py
@@ -11,16 +11,6 @@ from lldbsuite.test import lldbutil
 
 
 class ThreadStateTestCase(TestBase):
-    @expectedFailureAll(
-        oslist=["linux"],
-        bugnumber="llvm.org/pr15824 thread states not properly maintained",
-    )
-    @skipIfDarwin  # llvm.org/pr15824 thread states not properly maintained and <rdar://problem/28557237>
-    @expectedFailureAll(
-        oslist=["freebsd"],
-        bugnumber="llvm.org/pr18190 thread states not properly maintained",
-    )
-    @expectedFailureNetBSD
     def test_state_after_breakpoint(self):
         """Test thread state after breakpoint."""
         self.build()
@@ -48,13 +38,10 @@ class ThreadStateTestCase(TestBase):
         self.build()
         self.thread_state_after_expression_test()
 
-    # thread states not properly maintained
-    @unittest.expectedFailure  # llvm.org/pr15824 and <rdar://problem/28557237>
     @expectedFailureAll(
         oslist=["windows"],
         bugnumber="llvm.org/pr24668: Breakpoints not resolved correctly",
     )
-    @skipIfDarwin  # llvm.org/pr15824 thread states not properly maintained and <rdar://problem/28557237>
     @expectedFailureNetBSD
     def test_process_state(self):
         """Test thread states (comprehensive)."""
@@ -190,7 +177,6 @@ class ThreadStateTestCase(TestBase):
         oslist=["windows"],
         bugnumber="llvm.org/pr24668: Breakpoints not resolved correctly",
     )
-    @skipIfDarwin  # llvm.org/pr15824 thread states not properly maintained and <rdar://problem/28557237>
     @no_debug_info_test
     def test_process_interrupt(self):
         """Test process interrupt and continue."""

--- a/lldb/test/API/functionalities/thread/state/TestThreadStates.py
+++ b/lldb/test/API/functionalities/thread/state/TestThreadStates.py
@@ -27,17 +27,15 @@ class ThreadStateTestCase(TestBase):
 
     @skipIfDarwin  # 'llvm.org/pr23669', cause Python crash randomly
     @expectedFailureDarwin("llvm.org/pr23669")
-    @expectedFailureNetBSD
     # This actually passes on Windows on Arm but it's hard to describe that
     # and xfail it everywhere else.
     @skipIfWindows
-    # thread states not properly maintained
-    @unittest.expectedFailure  # llvm.org/pr16712
     def test_state_after_expression(self):
         """Test thread state after expression."""
         self.build()
         self.thread_state_after_expression_test()
 
+    @skipIfDarwin  # rdar://28557237
     @expectedFailureAll(
         oslist=["windows"],
         bugnumber="llvm.org/pr24668: Breakpoints not resolved correctly",
@@ -274,7 +272,7 @@ class ThreadStateTestCase(TestBase):
         # Stop the process
         self.runCmd("process interrupt")
 
-        self.assertStopReason(thread.GetState(), lldb.eStopReasonSignal)
+        self.assertStopReason(thread.GetStopReason(), lldb.eStopReasonSignal)
 
         # Check the thread state
         self.assertTrue(
@@ -297,12 +295,12 @@ class ThreadStateTestCase(TestBase):
             "Thread state is 'suspended' after expression evaluation.",
         )
 
-        self.assertStopReason(thread.GetState(), lldb.eStopReasonSignal)
+        self.assertStopReason(thread.GetStopReason(), lldb.eStopReasonSignal)
 
         # Run to breakpoint 2
         self.runCmd("continue")
 
-        self.assertStopReason(thread.GetState(), lldb.eStopReasonBreakpoint)
+        self.assertStopReason(thread.GetStopReason(), lldb.eStopReasonBreakpoint)
 
         # Make sure both threads are stopped
         self.assertTrue(


### PR DESCRIPTION
Currently, the default state of a thread is `eStateUnloaded`. However, `ThreadList::DidStop` only converts threads that were`eStateRunning` to `eStateStopped`. Because of this, new threads stay `eStateUnloaded` forever, and `SBThread::IsStopped()` returns false.

On Windows, `TargetThreadWindows::RefreshStateAfterStop` calls `SetState(eStateStopped)`. When using `LLDB_USE_LLDB_SERVER=1`, lldb uses the gdb-remote code path, which does not have that fix, causing `TestThreadStates::test_state_after_breakpoint` and `TestBreakAfterJoin` to fail.

This patch ports the fix to `ThreadGDBRemote`. When running with `LLDB_USE_LLDB_SERVER=1`, it fixes:
- `TestThreadStates::test_state_after_breakpoint`
- `TestBreakAfterJoin`

This could help fix llvm.org/pr15824 on POSIX.

rdar://178727939