### PR TITLE
[RDA] Slightly optimize enterBasicBlock() (NFC)

### DIFF
--- a/llvm/lib/CodeGen/ReachingDefAnalysis.cpp
+++ b/llvm/lib/CodeGen/ReachingDefAnalysis.cpp
@@ -115,18 +115,15 @@ void ReachingDefInfo::enterBasicBlock(MachineBasicBlock *MBB) {
   unsigned MBBNumber = MBB->getNumber();
   assert(MBBNumber < MBBReachingDefs.numBlockIDs() &&
          "Unexpected basic block number.");
+  assert(LiveRegs.empty() && "LiveRegs should be empty on BB entry");
   MBBReachingDefs.startBasicBlock(MBBNumber, NumRegUnits);
 
   // Reset instruction counter in each basic block.
   CurInstr = 0;
 
-  // Set up LiveRegs to represent registers entering MBB.
-  // Default values are 'nothing happened a long time ago'.
-  if (LiveRegs.empty())
-    LiveRegs.assign(NumRegUnits, ReachingDefDefaultVal);
-
   // This is the entry block.
   if (MBB == &MBB->getParent()->front()) {
+    LiveRegs.assign(NumRegUnits, ReachingDefDefaultVal);
     for (const auto &LI : MBB->liveins()) {
       for (MCRegUnit Unit : TRI->regunits(LI.PhysReg)) {
         // Treat function live-ins as if they were defined just before the first
@@ -143,6 +140,7 @@ void ReachingDefInfo::enterBasicBlock(MachineBasicBlock *MBB) {
   }
 
   // Try to coalesce live-out registers from predecessors.
+  bool Initialized = false;
   for (MachineBasicBlock *pred : MBB->predecessors()) {
     assert(unsigned(pred->getNumber()) < MBBOutRegsInfos.size() &&
            "Should have pre-allocated MBBInfos for all MBBs");
@@ -152,10 +150,20 @@ void ReachingDefInfo::enterBasicBlock(MachineBasicBlock *MBB) {
     if (Incoming.empty())
       continue;
 
+    // Directly copy over the reg infos for the first predecessor.
+    if (!Initialized) {
+      LiveRegs = Incoming;
+      Initialized = true;
+      continue;
+    }
+
     // Find the most recent reaching definition from a predecessor.
     for (unsigned Unit = 0; Unit != NumRegUnits; ++Unit)
       LiveRegs[Unit] = std::max(LiveRegs[Unit], Incoming[Unit]);
   }
+
+  if (!Initialized)
+    LiveRegs.assign(NumRegUnits, ReachingDefDefaultVal);
 
   // Insert the most recent reaching definition we found.
   for (unsigned Unit = 0; Unit != NumRegUnits; ++Unit)


### PR DESCRIPTION
Instead of initializing LiveRegs and doing an elementwise std::max with the first incoming predecessor, directly copy the data for the first predecessor.

This is a small compile-time improvement: https://llvm-compile-time-tracker.com/compare.php?from=4d2a670ba868a75103424ff3203f443391d55b1b&to=481b79aea35769c357a9db93554ea216f958c58e&stat=instructions%3Au