### PR TITLE
[MemProf] Improve post cloning remark

### DIFF
--- a/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
+++ b/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
@@ -3377,7 +3377,8 @@ void CallsiteContextGraph<DerivedCCG, FuncTy, CallTy>::printTotalSizes(
         // This is only emitted if the context size info is not present.
         std::string Msg =
             "MemProf hinting: " + getAllocTypeString((uint8_t)TypeI->second) +
-            " is " + getAllocTypeString(Node->AllocTypes) + " after cloning";
+            " context is " + getAllocTypeString(Node->AllocTypes) +
+            " after cloning";
         if (allocTypeToUse(Node->AllocTypes) != AllocTypeFromCall)
           Msg += " marked " + getAllocTypeString((uint8_t)AllocTypeFromCall) +
                  " due to cold byte percent";

--- a/llvm/test/ThinLTO/X86/remark-missing-info.ll
+++ b/llvm/test/ThinLTO/X86/remark-missing-info.ll
@@ -9,8 +9,8 @@
 ; RUN:	-o %t.out 2>&1
 ; RUN: FileCheck %s < %t.remarks.yaml
 
-; CHECK: MemProf hinting: NotCold is NotCold after cloning (internal context id 1)
-; CHECK: MemProf hinting: Cold is Cold after cloning (internal context id 2)
+; CHECK: MemProf hinting: NotCold context is NotCold after cloning (internal context id 1)
+; CHECK: MemProf hinting: Cold context is Cold after cloning (internal context id 2)
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"

--- a/llvm/test/Transforms/MemProfContextDisambiguation/remark-missing-info.ll
+++ b/llvm/test/Transforms/MemProfContextDisambiguation/remark-missing-info.ll
@@ -4,8 +4,8 @@
 ; RUN:	-memprof-report-hinted-sizes \
 ; RUN:	%s -S 2>&1 | FileCheck %s
 
-; CHECK: MemProf hinting: NotCold is NotCold after cloning (internal context id 1)
-; CHECK: MemProf hinting: Cold is Cold after cloning (internal context id 2)
+; CHECK: MemProf hinting: NotCold context is NotCold after cloning (internal context id 1)
+; CHECK: MemProf hinting: Cold context is Cold after cloning (internal context id 2)
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"


### PR DESCRIPTION
This makes the remark when we don't have context size info more
consistent with the one when we do, and clarifies that the first
coldness tag is for the context.
