### PR TITLE
[Clang][CodeGen] Avoid emitting poison immargs for __builtin_prefetch

### DIFF
--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -4305,11 +4305,13 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   }
   case Builtin::BI__builtin_prefetch: {
     Value *Locality, *RW, *Address = EmitScalarExpr(E->getArg(0));
+    unsigned ICEArguments = (1 << 1) | (1 << 2);
     // FIXME: Technically these constants should of type 'int', yes?
-    RW = (E->getNumArgs() > 1) ? EmitScalarExpr(E->getArg(1)) :
-      llvm::ConstantInt::get(Int32Ty, 0);
-    Locality = (E->getNumArgs() > 2) ? EmitScalarExpr(E->getArg(2)) :
-      llvm::ConstantInt::get(Int32Ty, 3);
+    RW = (E->getNumArgs() > 1) ? EmitScalarOrConstFoldImmArg(ICEArguments, 1, E)
+                               : llvm::ConstantInt::get(Int32Ty, 0);
+    Locality = (E->getNumArgs() > 2)
+                   ? EmitScalarOrConstFoldImmArg(ICEArguments, 2, E)
+                   : llvm::ConstantInt::get(Int32Ty, 3);
     Value *Data = llvm::ConstantInt::get(Int32Ty, 1);
     Function *F = CGM.getIntrinsic(Intrinsic::prefetch, Address->getType());
     Builder.CreateCall(F, {Address, RW, Locality, Data});

--- a/clang/test/CodeGen/prefetch-poison-arg.c
+++ b/clang/test/CodeGen/prefetch-poison-arg.c
@@ -1,0 +1,6 @@
+// RUN: %clang_cc1 -triple x86_64-pc-linux -emit-llvm %s -o - | FileCheck %s
+
+void test_poison_rw(void) {
+  __builtin_prefetch(0, 2 >> 32, 2 >> 32);
+  // CHECK: call void @llvm.prefetch.p0(ptr null, i32 {{-?[0-9]+}}, i32 {{-?[0-9]+}}, i32 1)
+}


### PR DESCRIPTION
Fixes #201448

This PR fixes invalid clang CodeGen when lowering `__builtin_prefetch` that is called with a constant expression that produces a poison value.

The code currently assumes that the immediate operands are `ConstantInt`s. This is not always true as poison values may come from UB expressions (e.g., `__builtin_prefetch(0, 2 >> 32)`) due to the use of `EmitScalarExpr`. This would cause the subsequent downcast `cast<ConstantInt>` in `SelectionDAGBuilder` to fail.

This PR replaces `EmitScalarExpr` with `EmitScalarOrConstFoldImmArg` to obtain an integer constant instead of emitting a poison value for the corresponding arguments of `llvm.prefetch`.

A regression test is also added to cover the poison immediate argument case.

I used GPT-5.5 while working on this PR for understanding the issue and drafting the PR description / test plan. The actual code changes and tests are written by me, and I have noted the AI tool usage in the PR description.