### PR TITLE
[libc++] Suppress deprecation warning around wstring_convert::to_bytes

### DIFF
--- a/libcxx/include/__locale_dir/wstring_convert.h
+++ b/libcxx/include/__locale_dir/wstring_convert.h
@@ -174,9 +174,11 @@ wstring_convert<_Codecvt, _Elem, _WideAlloc, _ByteAlloc>::from_bytes(const char*
   return __wide_err_string_;
 }
 
+_LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <class _Codecvt, class _Elem, class _WideAlloc, class _ByteAlloc>
 typename wstring_convert<_Codecvt, _Elem, _WideAlloc, _ByteAlloc>::byte_string
 wstring_convert<_Codecvt, _Elem, _WideAlloc, _ByteAlloc>::to_bytes(const _Elem* __frm, const _Elem* __frm_end) {
+  _LIBCPP_SUPPRESS_DEPRECATED_POP
   __cvtcount_ = 0;
   if (__cvtptr_ != nullptr) {
     byte_string __bs(2 * (__frm_end - __frm), char());

--- a/libcxx/test/libcxx/localization/locales/locale.convenience/conversions/conversions.string/pragma_suppress.compile.pass.cpp
+++ b/libcxx/test/libcxx/localization/locales/locale.convenience/conversions/conversions.string/pragma_suppress.compile.pass.cpp
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <locale>
+
+// Ensure that users can suppress the wstring_convert deprecation warning
+// using #pragma clang diagnostic ignored around the usage site.
+
+// ADDITIONAL_COMPILE_FLAGS: -Werror=deprecated-declarations
+
+// REQUIRES: c++17 || c++20 || c++23
+// UNSUPPORTED: no-wide-characters
+
+#include <codecvt>
+#include <locale>
+#include <string>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+void test() {
+    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> converter;
+    (void)converter.to_bytes(std::basic_string<char16_t>(u"hello"));
+    (void)converter.from_bytes(std::string("hello"));
+}
+#pragma clang diagnostic pop

--- a/libcxx/test/libcxx/localization/locales/locale.convenience/conversions/conversions.string/pragma_suppress.compile.pass.cpp
+++ b/libcxx/test/libcxx/localization/locales/locale.convenience/conversions/conversions.string/pragma_suppress.compile.pass.cpp
@@ -23,8 +23,8 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 void test() {
-    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> converter;
-    (void)converter.to_bytes(std::basic_string<char16_t>(u"hello"));
-    (void)converter.from_bytes(std::string("hello"));
+  std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> converter;
+  (void)converter.to_bytes(std::basic_string<char16_t>(u"hello"));
+  (void)converter.from_bytes(std::string("hello"));
 }
 #pragma clang diagnostic pop

--- a/libcxx/test/libcxx/localization/locales/locale.convenience/conversions/conversions.string/pragma_suppress.compile.pass.cpp
+++ b/libcxx/test/libcxx/localization/locales/locale.convenience/conversions/conversions.string/pragma_suppress.compile.pass.cpp
@@ -11,8 +11,6 @@
 // Ensure that users can suppress the wstring_convert deprecation warning
 // using #pragma clang diagnostic ignored around the usage site.
 
-// ADDITIONAL_COMPILE_FLAGS: -Werror=deprecated-declarations
-
 // REQUIRES: c++17 || c++20 || c++23
 // UNSUPPORTED: no-wide-characters
 


### PR DESCRIPTION
The deprecation warning for wstring_convert::to_bytes fires from inside the libc++ header, so users can't suppress it with their own diagnostic pragmas around the call site. Wrap the definition with _LIBCPP_SUPPRESS_DEPRECATED_PUSH/POP, mirroring what's already done for the destructor and from_bytes just above.

Add a regression test under test/libcxx.

rdar://173319468

Assisted-by: Claude