### PR TITLE
[lldb][Windows] add stdin support to lldb-server

### DIFF
--- a/lldb/include/lldb/Host/common/NativeProcessProtocol.h
+++ b/lldb/include/lldb/Host/common/NativeProcessProtocol.h
@@ -247,8 +247,12 @@ public:
   // Access to inferior stdio
   virtual int GetTerminalFileDescriptor() { return m_terminal_fd; }
 
-  // Stop id interface
+  /// Write up to \p len bytes from \p buf to the inferior's stdin.
+  virtual size_t WriteStdin(const void *buf, size_t len, Status &error) {
+    return 0;
+  }
 
+  // Stop id interface
   uint32_t GetStopID() const;
 
   // Callbacks for low-level process state changes

--- a/lldb/source/Host/windows/ConnectionConPTYWindows.cpp
+++ b/lldb/source/Host/windows/ConnectionConPTYWindows.cpp
@@ -61,5 +61,30 @@ size_t ConnectionConPTY::Read(void *dst, size_t dst_len,
 size_t ConnectionConPTY::Write(const void *src, size_t src_len,
                                lldb::ConnectionStatus &status,
                                Status *error_ptr) {
-  llvm_unreachable("not implemented");
+  if (!m_pty || !m_pty->IsConnected()) {
+    status = eConnectionStatusNoConnection;
+    if (error_ptr)
+      *error_ptr = Status::FromErrorString("ConPTY not connected");
+    return 0;
+  }
+  HANDLE stdin_handle = m_pty->GetSTDINHandle();
+  if (stdin_handle == INVALID_HANDLE_VALUE || stdin_handle == nullptr) {
+    status = eConnectionStatusNoConnection;
+    if (error_ptr)
+      *error_ptr = Status::FromErrorString("ConPTY STDIN handle is invalid");
+    return 0;
+  }
+  DWORD written = 0;
+  if (!::WriteFile(stdin_handle, src, static_cast<DWORD>(src_len), &written,
+                   nullptr)) {
+    DWORD err = ::GetLastError();
+    status = (err == ERROR_BROKEN_PIPE || err == ERROR_NO_DATA)
+                 ? eConnectionStatusEndOfFile
+                 : eConnectionStatusError;
+    if (error_ptr)
+      *error_ptr = Status(err, lldb::eErrorTypeWin32);
+    return written;
+  }
+  status = eConnectionStatusSuccess;
+  return written;
 }

--- a/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.cpp
@@ -749,4 +749,19 @@ void NativeProcessWindows::STDIOReadThreadBytesReceived(void *baton,
   self->m_delegate.NewProcessOutput(
       self, llvm::StringRef(static_cast<const char *>(src), src_len));
 }
+
+size_t NativeProcessWindows::WriteStdin(const void *buf, size_t len,
+                                        Status &error) {
+  if (!m_stdio_communication.HasConnection()) {
+    error = Status::FromErrorString(
+        "no ConPTY connection on this NativeProcessWindows");
+    return 0;
+  }
+  ConnectionStatus status;
+  size_t written = m_stdio_communication.Write(buf, len, status, &error);
+  if (status != eConnectionStatusSuccess && error.Success())
+    error = Status::FromErrorStringWithFormatv(
+        "ConPTY stdin write returned status {0}", static_cast<int>(status));
+  return written;
+}
 } // namespace lldb_private

--- a/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.h
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.h
@@ -107,6 +107,13 @@ public:
 
   bool HasPendingLibraryEvents() override;
 
+  /// Forward bytes from the gdb-remote `I` packet into the inferior's
+  /// ConPTY-backed stdin via `m_stdio_communication.Write` →
+  /// `ConnectionConPTY::Write` → `WriteFile` on the parent-side STDIN
+  /// HANDLE. Returns the number of bytes written (0 if the PTY is
+  /// disconnected or write fails).
+  size_t WriteStdin(const void *buf, size_t len, Status &error) override;
+
   // ProcessDebugger Overrides
   void OnExitProcess(uint32_t exit_code) override;
   void OnDebuggerConnected(lldb::addr_t image_base) override;

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -46,7 +46,6 @@
 #include "ExceptionRecord.h"
 #include "ForwardDecl.h"
 #include "LocalDebugDelegate.h"
-#include "Plugins/Process/Utility/IOHandlerProcessSTDIOWindows.h"
 #include "ProcessWindowsLog.h"
 #include "TargetThreadWindows.h"
 

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -46,6 +46,7 @@
 #include "ExceptionRecord.h"
 #include "ForwardDecl.h"
 #include "LocalDebugDelegate.h"
+#include "Plugins/Process/Utility/IOHandlerProcessSTDIOWindows.h"
 #include "ProcessWindowsLog.h"
 #include "TargetThreadWindows.h"
 

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -2572,7 +2572,9 @@ GDBRemoteCommunicationServerLLGS::Handle_I(StringExtractorGDBRemote &packet) {
     Status error;
 
 #if defined(_WIN32)
-    // On Windows the inferior's stdio is owned by NativeProcessWindows.
+    // On Windows the inferior's stdio is owned by NativeProcessWindows (which
+    // holds the ConPTY). Route stdin through NativeProcessProtocol::WriteStdin
+    // rather than m_stdio_communication, which is unconnected on Windows.
     if (m_current_process->WriteStdin(tmp, read, error) != read || error.Fail())
       return SendErrorResponse(0x15);
 #else

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -2569,12 +2569,19 @@ GDBRemoteCommunicationServerLLGS::Handle_I(StringExtractorGDBRemote &packet) {
     // write directly to stdin *this might block if stdin buffer is full*
     // TODO: enqueue this block in circular buffer and send window size to
     // remote host
-    ConnectionStatus status;
     Status error;
+
+#if defined(_WIN32)
+    // On Windows the inferior's stdio is owned by NativeProcessWindows.
+    if (m_current_process->WriteStdin(tmp, read, error) != read || error.Fail())
+      return SendErrorResponse(0x15);
+#else
+    ConnectionStatus status;
     m_stdio_communication.WriteAll(tmp, read, status, &error);
     if (error.Fail()) {
       return SendErrorResponse(0x15);
     }
+#endif
   }
 
   return SendOKResponse();

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -59,6 +59,7 @@
 #include "lldb/Target/ABI.h"
 #include "lldb/Target/DynamicLoader.h"
 #include "lldb/Target/MemoryRegionInfo.h"
+#include "lldb/Target/ProcessIOHandler.h"
 #include "lldb/Target/RegisterFlags.h"
 #include "lldb/Target/SystemRuntime.h"
 #include "lldb/Target/Target.h"
@@ -100,10 +101,6 @@
 #include "llvm/Support/FormatAdapters.h"
 #include "llvm/Support/Threading.h"
 #include "llvm/Support/raw_ostream.h"
-
-#ifdef _WIN32
-#include "Plugins/Process/Windows/Common/IOHandlerProcessSTDIOWindows.h"
-#endif
 
 #if defined(__APPLE__)
 #define DEBUGSERVER_BASENAME "debugserver"

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -101,6 +101,10 @@
 #include "llvm/Support/Threading.h"
 #include "llvm/Support/raw_ostream.h"
 
+#ifdef _WIN32
+#include "Plugins/Process/Windows/Common/IOHandlerProcessSTDIOWindows.h"
+#endif
+
 #if defined(__APPLE__)
 #define DEBUGSERVER_BASENAME "debugserver"
 #elif defined(_WIN32)
@@ -879,8 +883,18 @@ Status ProcessGDBRemote::DoLaunch(lldb_private::Module *exe_module,
       SetPrivateState(SetThreadStopInfo(response));
 
       if (!disable_stdio) {
-        if (pty.GetPrimaryFileDescriptor() != PseudoTerminal::invalid_fd)
+        if (pty.GetPrimaryFileDescriptor() != PseudoTerminal::invalid_fd) {
           SetSTDIOFileDescriptor(pty.ReleasePrimaryFileDescriptor());
+        }
+#ifdef _WIN32
+        else if (m_stdin_forward) {
+          // No client-side PTY FD on Windows.
+          std::lock_guard<std::mutex> guard(m_process_input_reader_mutex);
+          if (!m_process_input_reader)
+            m_process_input_reader =
+                std::make_shared<IOHandlerProcessSTDIOWindows>(this);
+        }
+#endif
       }
     }
   } else {


### PR DESCRIPTION
This patch uses `IOHandlerProcessSTDIOWindows` to add support for STDIN forwarding in `lldb-server.exe`.

This is part 1/3 of a set of 3 patches, which together, fix 2 dap tests on Windows when using `LLDB_USE_LLDB_SERVER=1`:
- https://github.com/llvm/llvm-project/pull/201884
- https://github.com/llvm/llvm-project/pull/201885

This requires https://github.com/llvm/llvm-project/pull/202353.

rdar://178725947