### PR TITLE
[clang] Add -fcrash-diagnostics-tar for tarball of crash reproducer files

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -354,6 +354,9 @@ New Compiler Flags
   that ``bool`` values loaded from memory cannot have a bit pattern other
   than 0 or 1.
 
+- New option ``-fcrash-diagnostics-tar`` added to create an archive of crash
+  reproducer files for easier bug filing.
+
 Deprecated Compiler Flags
 -------------------------
 

--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -763,6 +763,10 @@ control the crash diagnostics.
    Like ``-fcrash-diagnostics-dir=<dir>``, specifies where to write the
    crash diagnostics files, but with lower precedence than the option.
 
+.. option:: -fcrash-diagnostics-tar=<path>
+
+  Specify where to write the crash diagnostics files as a tarball.
+
 Clang is also capable of generating preprocessed source file(s) and associated
 run script(s) even without a crash. This is especially useful when trying to
 generate a reproducer for warnings or errors while using modules.

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -2184,6 +2184,10 @@ def fcrash_diagnostics_dir : Joined<["-"], "fcrash-diagnostics-dir=">,
   Group<f_clang_Group>, Flags<[NoArgumentUnused]>,
   Visibility<[ClangOption, CLOption, DXCOption]>,
   HelpText<"Put crash-report files in <dir>">, MetaVarName<"<dir>">;
+def fcrash_diagnostics_tar : Joined<["-"], "fcrash-diagnostics-tar=">,
+  Group<f_clang_Group>, Flags<[NoArgumentUnused]>,
+  Visibility<[ClangOption, CLOption, DXCOption]>,
+  HelpText<"Put crash-report tarball at <path>">, MetaVarName<"<path>">;
 def fcreate_profile : Flag<["-"], "fcreate-profile">, Group<f_Group>;
 defm cxx_exceptions: BoolFOption<"cxx-exceptions",
   LangOpts<"CXXExceptions">, DefaultFalse,

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -98,12 +98,14 @@
 #include "llvm/Support/IOSandbox.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/MD5.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/Program.h"
 #include "llvm/Support/Regex.h"
 #include "llvm/Support/StringSaver.h"
+#include "llvm/Support/TarWriter.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Host.h"
@@ -1962,10 +1964,9 @@ bool Driver::getCrashDiagnosticFile(StringRef ReproCrashFilename,
   return false;
 }
 
-static const char BugReporMsg[] =
+static const char BugReportMsg[] =
     "\n********************\n\n"
-    "PLEASE ATTACH THE FOLLOWING FILES TO THE BUG REPORT:\n"
-    "Preprocessed source(s) and associated run script(s) are located at:";
+    "PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:";
 
 // When clang crashes, produce diagnostic information including the fully
 // preprocessed source file(s).  Request that the developer attach the
@@ -1975,6 +1976,8 @@ void Driver::generateCompilationDiagnostics(
     StringRef AdditionalInformation, CompilationDiagnosticReport *Report) {
   if (C.getArgs().hasArg(options::OPT_fno_crash_diagnostics))
     return;
+
+  bool HasCrashTar = C.getArgs().hasArg(options::OPT_fcrash_diagnostics_tar);
 
   unsigned Level = 1;
   if (Arg *A = C.getArgs().getLastArg(options::OPT_fcrash_diagnostics_EQ)) {
@@ -2036,7 +2039,7 @@ void Driver::generateCompilationDiagnostics(
 
     // Redirect stdout/stderr to /dev/null.
     NewLLDInvocation.Execute({std::nullopt, {""}, {""}}, nullptr, nullptr);
-    Diag(clang::diag::note_drv_command_failed_diag_msg) << BugReporMsg;
+    Diag(clang::diag::note_drv_command_failed_diag_msg) << BugReportMsg;
     Diag(clang::diag::note_drv_command_failed_diag_msg) << TmpName;
     Diag(clang::diag::note_drv_command_failed_diag_msg)
         << "\n\n********************";
@@ -2177,12 +2180,13 @@ void Driver::generateCompilationDiagnostics(
     TempFiles.push_back(std::string(Path.begin(), Path.end()));
   }
 
-  Diag(clang::diag::note_drv_command_failed_diag_msg) << BugReporMsg;
+  Diag(clang::diag::note_drv_command_failed_diag_msg) << BugReportMsg;
 
   SmallString<128> VFS;
   SmallString<128> ReproCrashFilename;
   for (std::string &TempFile : TempFiles) {
-    Diag(clang::diag::note_drv_command_failed_diag_msg) << TempFile;
+    if (!HasCrashTar)
+      Diag(clang::diag::note_drv_command_failed_diag_msg) << TempFile;
     if (Report)
       Report->TemporaryFiles.push_back(TempFile);
     if (ReproCrashFilename.empty()) {
@@ -2224,7 +2228,69 @@ void Driver::generateCompilationDiagnostics(
                << "\n";
     if (Report)
       Report->TemporaryFiles.push_back(std::string(Script));
-    Diag(clang::diag::note_drv_command_failed_diag_msg) << Script;
+    TempFiles.push_back(std::string(Script));
+    ScriptOS.close();
+    if (!HasCrashTar)
+      Diag(clang::diag::note_drv_command_failed_diag_msg) << Script;
+  }
+
+  if (Arg *A = C.getArgs().getLastArg(options::OPT_fcrash_diagnostics_tar)) {
+    StringRef CrashDiagnosticsTar = A->getValue();
+    Expected<std::unique_ptr<llvm::TarWriter>> TarOrErr =
+        llvm::TarWriter::create(CrashDiagnosticsTar,
+                                llvm::sys::path::stem(CrashDiagnosticsTar));
+    if (!TarOrErr) {
+      Diag(clang::diag::note_drv_command_failed_diag_msg)
+          << (std::string("Error creating reproducer tarball: ") +
+              llvm::toString(TarOrErr.takeError()));
+    } else {
+      std::unique_ptr<llvm::TarWriter> &Tar = *TarOrErr;
+      for (const std::string &TempFile : TempFiles) {
+        if (llvm::sys::fs::is_directory(TempFile)) {
+          std::error_code EC;
+          for (llvm::sys::fs::recursive_directory_iterator I(TempFile, EC), E;
+               I != E && !EC; I.increment(EC)) {
+            if (llvm::sys::fs::is_regular_file(I->path())) {
+              auto BufferOrErr = llvm::MemoryBuffer::getFile(I->path());
+              if (BufferOrErr) {
+                // Construct path of file relative to TempFile.
+                llvm::SmallString<128> PathInTar =
+                    llvm::sys::path::filename(TempFile);
+                StringRef SubPath = I->path();
+                if (SubPath.consume_front(TempFile)) {
+                  if (!SubPath.empty() &&
+                      llvm::sys::path::is_separator(SubPath.front())) {
+                    SubPath = SubPath.drop_front();
+                  }
+                  llvm::sys::path::append(PathInTar, SubPath);
+                  Tar->append(PathInTar, (*BufferOrErr)->getBuffer());
+                }
+              } else {
+                Diag(clang::diag::note_drv_command_failed_diag_msg)
+                    << (std::string("Error reading file for tarball: ") +
+                        I->path());
+              }
+            }
+          }
+          if (EC) {
+            Diag(clang::diag::note_drv_command_failed_diag_msg)
+                << (std::string("Error iterating directory for tarball: ") +
+                    TempFile + " " + EC.message());
+          }
+        } else {
+          auto BufferOrErr = llvm::MemoryBuffer::getFile(TempFile);
+          if (BufferOrErr) {
+            Tar->append(llvm::sys::path::filename(TempFile),
+                        (*BufferOrErr)->getBuffer());
+          } else {
+            Diag(clang::diag::note_drv_command_failed_diag_msg)
+                << (std::string("Error reading file for tarball: ") + TempFile);
+          }
+        }
+      }
+      Diag(clang::diag::note_drv_command_failed_diag_msg)
+          << CrashDiagnosticsTar;
+    }
   }
 
   // On darwin, provide information about the .crash diagnostic report.

--- a/clang/test/Driver/Inputs/empty.h
+++ b/clang/test/Driver/Inputs/empty.h
@@ -1,0 +1,1 @@
+// Empty header

--- a/clang/test/Driver/Inputs/module.modulemap
+++ b/clang/test/Driver/Inputs/module.modulemap
@@ -1,0 +1,3 @@
+module Empty {
+  header "empty.h"
+}

--- a/clang/test/Driver/crash-diagnostics-dir-3.c
+++ b/clang/test/Driver/crash-diagnostics-dir-3.c
@@ -2,5 +2,5 @@
 // RUN: rm -rf %t
 // RUN: not %crash_opt env CLANG_CRASH_DIAGNOSTICS_DIR=%t %clang -c %s -o - 2>&1 | FileCheck %s
 #pragma clang __debug parser_crash
-// CHECK: Preprocessed source(s) and associated run script(s) are located at:
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CHECK: diagnostic msg: {{.*}}{{/|\\}}crash-diagnostics-dir-3.c.tmp{{(/|\\).*}}.c

--- a/clang/test/Driver/crash-diagnostics-dir.c
+++ b/clang/test/Driver/crash-diagnostics-dir.c
@@ -2,5 +2,5 @@
 // RUN: rm -rf %t
 // RUN: not %crash_opt %clang -fcrash-diagnostics-dir=%t -c %s -o - 2>&1 | FileCheck %s
 #pragma clang __debug parser_crash
-// CHECK: Preprocessed source(s) and associated run script(s) are located at:
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CHECK: diagnostic msg: {{.*}}{{/|\\}}crash-diagnostics-dir.c.tmp{{(/|\\).*}}.c

--- a/clang/test/Driver/crash-diagnostics-modules.c
+++ b/clang/test/Driver/crash-diagnostics-modules.c
@@ -1,0 +1,16 @@
+// RUN: export LSAN_OPTIONS=detect_leaks=0
+// RUN: rm -rf %t && mkdir %t
+// RUN: cd %t
+// RUN: not %crash_opt %clang -fcrash-diagnostics-tar=repro.tar -fmodules -fmodules-cache-path=cache -I %S/Inputs -c %s -o /dev/null 2>&1 | FileCheck %s
+// RUN: tar -tf repro.tar | FileCheck %s --check-prefix=TAR
+
+#include "empty.h"
+
+#pragma clang __debug parser_crash
+
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
+// CHECK: repro.tar
+
+// TAR-DAG: .c
+// TAR-DAG: .sh
+// TAR-DAG: .cache/{{.*}}module.modulemap

--- a/clang/test/Driver/crash-diagnostics-tar.c
+++ b/clang/test/Driver/crash-diagnostics-tar.c
@@ -18,13 +18,13 @@
 
 // TAR: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // TAR: repro.tar
-// TAR-NOT: .c
-// TAR-NOT: .sh
+// TAR-NOT: .c{{$}}
+// TAR-NOT: .sh{{$}}
 
 // NOTAR: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
-// NOTAR: .c
-// NOTAR: .sh
-// NOTAR-NOT: .tar
+// NOTAR: .c{{$}}
+// NOTAR: .sh{{$}}
+// NOTAR-NOT: .tar{{$}}
 
 // INVALID: Error creating reproducer tarball:
 

--- a/clang/test/Driver/crash-diagnostics-tar.c
+++ b/clang/test/Driver/crash-diagnostics-tar.c
@@ -1,0 +1,36 @@
+// RUN: export LSAN_OPTIONS=detect_leaks=0
+// RUN: rm -rf %t && mkdir %t
+// RUN: cd %t
+// RUN: not %crash_opt %clang -fcrash-diagnostics-tar=repro.tar -c %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=TAR
+// RUN: mkdir extract
+// RUN: tar -xf repro.tar -C extract
+// RUN: FileCheck %s --check-prefix=SH < extract/*/crash-diagnostics-tar-*.sh
+// RUN: FileCheck %s --check-prefix=C < extract/*/crash-diagnostics-tar-*.c
+
+// RUN: not %crash_opt %clang -c %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=NOTAR
+
+// RUN: not %crash_opt %clang -fcrash-diagnostics-tar=%t/nonexistent/repro.tar -c %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=INVALID
+
+// RUN: not %crash_opt %clang -fcrash-diagnostics-tar=repro-stdin.tar -c -x c - -o /dev/null < %s 2>&1 | FileCheck %s --check-prefix=STDIN
+// RUN: not ls repro-stdin.tar
+
+#pragma clang __debug parser_crash
+
+// TAR: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
+// TAR: repro.tar
+// TAR-NOT: .c
+// TAR-NOT: .sh
+
+// NOTAR: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
+// NOTAR: .c
+// NOTAR: .sh
+// NOTAR-NOT: .tar
+
+// INVALID: Error creating reproducer tarball:
+
+// SH: # Crash reproducer for
+// C: # 1 "
+
+// STDIN: PLEASE submit a bug report to
+// STDIN: note: diagnostic msg: Error generating preprocessed source(s) - ignoring input from stdin.
+// STDIN: note: diagnostic msg: Error generating preprocessed source(s) - no preprocessable inputs.

--- a/clang/test/Driver/crash-ir-repro.cpp
+++ b/clang/test/Driver/crash-ir-repro.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang -S -emit-llvm -o %t.ll %s
 // RUN: not %crash_opt %clang -S -DCRASH %s -o %t.ll 2>&1 | FileCheck %s
 
-// CHECK: Preprocessed source(s) and associated run script(s) are located at:
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CHECK-NEXT: clang: note: diagnostic msg: {{.*}}.cpp
 // CHECK-NEXT: clang: note: diagnostic msg: {{.*}}.sh
 

--- a/clang/test/Driver/crash-report-clang-cl.cpp
+++ b/clang/test/Driver/crash-report-clang-cl.cpp
@@ -11,7 +11,7 @@
 
 #pragma clang __debug crash
 
-// CHECK: Preprocessed source(s) and associated run script(s) are located at:
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 
 // __has_feature(cxx_exceptions) is default-off in the cl-compatible driver.
 FOO

--- a/clang/test/Driver/crash-report-crashfile.m
+++ b/clang/test/Driver/crash-report-crashfile.m
@@ -19,7 +19,7 @@ const int x = MODULE_MACRO;
 
 // CRASH_ENV: PLEASE submit a bug report to {{.*}} and include the crash backtrace, preprocessed source, and associated run script.
 // CRASH_ENV: failing because environment variable 'FORCE_CLANG_DIAGNOSTICS_CRASH' is set
-// CRASH_ENV: Preprocessed source(s) and associated run script(s) are located at:
+// CRASH_ENV: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CRASH_ENV-NEXT: note: diagnostic msg: {{.*}}.m
 // CRASH_ENV-NEXT: note: diagnostic msg: {{.*}}.cache
 // CRASH_ENV-NEXT: note: diagnostic msg: {{.*}}.sh
@@ -27,7 +27,7 @@ const int x = MODULE_MACRO;
 // CRASH_ENV-NEXT: note: diagnostic msg: {{.*}}Library/Logs/DiagnosticReports{{.*}}
 
 // CRASH_FLAG: failing because '-gen-reproducer' is used
-// CRASH_FLAG: Preprocessed source(s) and associated run script(s) are located at:
+// CRASH_FLAG: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CRASH_FLAG-NEXT: note: diagnostic msg: {{.*}}.m
 // CRASH_FLAG-NEXT: note: diagnostic msg: {{.*}}.cache
 // CRASH_FLAG-NEXT: note: diagnostic msg: {{.*}}.sh

--- a/clang/test/Driver/crash-report-crashfile.m
+++ b/clang/test/Driver/crash-report-crashfile.m
@@ -17,7 +17,7 @@
 @import simple;
 const int x = MODULE_MACRO;
 
-// CRASH_ENV: PLEASE submit a bug report to {{.*}} and include the crash backtrace, preprocessed source, and associated run script.
+// CRASH_ENV: PLEASE submit a bug report to {{.*}} and include the crash backtrace and dumped files.
 // CRASH_ENV: failing because environment variable 'FORCE_CLANG_DIAGNOSTICS_CRASH' is set
 // CRASH_ENV: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CRASH_ENV-NEXT: note: diagnostic msg: {{.*}}.m

--- a/clang/test/Driver/crash-report-header.h
+++ b/clang/test/Driver/crash-report-header.h
@@ -7,7 +7,7 @@
 // REQUIRES: crash-recovery
 
 #pragma clang __debug parser_crash
-// CHECK: Preprocessed source(s) and associated run script(s) are located at:
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.h
 FOO
 // CHECKSRC: FOO

--- a/clang/test/Driver/crash-report-modules.m
+++ b/clang/test/Driver/crash-report-modules.m
@@ -16,8 +16,8 @@
 @import simple;
 const int x = MODULE_MACRO;
 
-// CHECK: PLEASE submit a bug report to {{.*}} and include the crash backtrace, preprocessed source, and associated run script.
-// CHECK: Preprocessed source(s) and associated run script(s) are located at:
+// CHECK: PLEASE submit a bug report to {{.*}} and include the crash backtrace and dumped files.
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.m
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.cache
 

--- a/clang/test/Driver/crash-report-multi-arch.c
+++ b/clang/test/Driver/crash-report-multi-arch.c
@@ -38,7 +38,7 @@
 // REQUIRES: crash-recovery, system-darwin
 // REQUIRES: aarch64-registered-target, x86-registered-target
 
-// CHECK: Preprocessed source(s) and associated run script(s) are located at:
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CHECK-NEXT: note: diagnostic msg: {{.*}}crash-report-{{.*}}.c
 
 // CHECKSH-x86_64: # Crash reproducer

--- a/clang/test/Driver/crash-report-null.test
+++ b/clang/test/Driver/crash-report-null.test
@@ -3,6 +3,6 @@
 // FIXME: Investigating. "fatal error: file 'nul' modified since it was first processed"
 // UNSUPPORTED: system-windows
 
-// CHECK: PLEASE submit a bug report to {{.*}} and include the crash backtrace, preprocessed source, and associated run script.
-// CHECK: Preprocessed source(s) and associated run script(s) are located at:
+// CHECK: PLEASE submit a bug report to {{.*}} and include the crash backtrace and dumped files.
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CHECK-NEXT: note: diagnostic msg: {{.*}}null-{{.*}}.c

--- a/clang/test/Driver/crash-report-spaces.c
+++ b/clang/test/Driver/crash-report-spaces.c
@@ -8,7 +8,7 @@
 // REQUIRES: crash-recovery
 
 #pragma clang __debug parser_crash
-// CHECK: Preprocessed source(s) and associated run script(s) are located at:
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.c
 FOO
 // CHECKSRC: FOO

--- a/clang/test/Driver/crash-report-with-asserts.c
+++ b/clang/test/Driver/crash-report-with-asserts.c
@@ -30,7 +30,7 @@
 #pragma clang __debug llvm_unreachable
 #endif
 
-// CHECK: Preprocessed source(s) and associated run script(s) are located at:
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CHECK-NEXT: note: diagnostic msg: {{.*}}crash-report-with-asserts-{{.*}}.c
 FOO
 // CHECKSRC: FOO

--- a/clang/test/Driver/crash-report.cpp
+++ b/clang/test/Driver/crash-report.cpp
@@ -61,7 +61,7 @@
 #pragma clang __debug llvm_fatal_error
 #endif
 
-// CHECK: Preprocessed source(s) and associated run script(s) are located at:
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CHECK-NEXT: note: diagnostic msg: {{.*}}crash-report-{{.*}}.cpp
 
 // __has_feature(cxx_exceptions) is default-on in the gcc-compatible driver.

--- a/clang/test/Driver/lld-repro.c
+++ b/clang/test/Driver/lld-repro.c
@@ -15,7 +15,7 @@
 // check that we still get lld's output
 // CHECK: error: undefined symbol: {{_?}}a
 
-// CHECK: Preprocessed source(s) and associated run script(s) are located at:
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CHECK-NEXT: note: diagnostic msg: {{.*}}linker-crash-{{.*}}.tar
 // CHECK-NEXT: note: diagnostic msg:
 // CHECK: ********************
@@ -25,7 +25,7 @@
 // RUN: not %clang %s @%t.rsp -o /dev/null 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=NO-LINKER
 
-// NO-LINKER-NOT: Preprocessed source(s) and associated run script(s) are located at:
+// NO-LINKER-NOT: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 
 extern int a;
 int main() {

--- a/clang/test/Modules/crash-vfs-headermaps.m
+++ b/clang/test/Modules/crash-vfs-headermaps.m
@@ -16,7 +16,7 @@
 #include "Foo.h"
 #include "Foo.h"
 
-// CHECK: Preprocessed source(s) and associated run script(s) are located at:
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.m
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.cache
 

--- a/clang/test/Modules/crash-vfs-include-pch.m
+++ b/clang/test/Modules/crash-vfs-include-pch.m
@@ -21,7 +21,7 @@
 void f() { SPXTrace(); }
 void g() { double x = DBL_MAX; }
 
-// CHECK: Preprocessed source(s) and associated run script(s) are located at:
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.m
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.cache
 

--- a/clang/test/Modules/crash-vfs-ivfsoverlay.m
+++ b/clang/test/Modules/crash-vfs-ivfsoverlay.m
@@ -21,7 +21,7 @@
 
 #include <stdio.h>
 
-// CHECK: Preprocessed source(s) and associated run script(s) are located at:
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.m
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.cache
 

--- a/clang/test/Modules/crash-vfs-path-emptydir-entries.m
+++ b/clang/test/Modules/crash-vfs-path-emptydir-entries.m
@@ -24,7 +24,7 @@
 
 #include "usr/include/stdio.h"
 
-// CHECK: Preprocessed source(s) and associated run script(s) are located at:
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.m
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.cache
 

--- a/clang/test/Modules/crash-vfs-path-symlink-component.m
+++ b/clang/test/Modules/crash-vfs-path-symlink-component.m
@@ -26,7 +26,7 @@
 
 #include "usr/x/../stdio.h"
 
-// CHECK: Preprocessed source(s) and associated run script(s) are located at:
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.m
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.cache
 

--- a/clang/test/Modules/crash-vfs-path-symlink-topheader.m
+++ b/clang/test/Modules/crash-vfs-path-symlink-topheader.m
@@ -25,7 +25,7 @@
 
 #include "usr/include/stdio.h"
 
-// CHECK: Preprocessed source(s) and associated run script(s) are located at:
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.m
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.cache
 

--- a/clang/test/Modules/crash-vfs-path-traversal.m
+++ b/clang/test/Modules/crash-vfs-path-traversal.m
@@ -24,7 +24,7 @@
 
 #include "usr/././//////include/../include/./././../include/stdio.h"
 
-// CHECK: Preprocessed source(s) and associated run script(s) are located at:
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.m
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.cache
 

--- a/clang/test/Modules/crash-vfs-relative-incdir.m
+++ b/clang/test/Modules/crash-vfs-relative-incdir.m
@@ -17,7 +17,7 @@
 
 #include <stdio.h>
 
-// CHECK: Preprocessed source(s) and associated run script(s) are located at:
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.m
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.cache
 

--- a/clang/test/Modules/crash-vfs-relative-overlay.m
+++ b/clang/test/Modules/crash-vfs-relative-overlay.m
@@ -21,7 +21,7 @@
 
 #include <stdio.h>
 
-// CHECK: Preprocessed source(s) and associated run script(s) are located at:
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.m
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.cache
 

--- a/clang/test/Modules/crash-vfs-run-reproducer.m
+++ b/clang/test/Modules/crash-vfs-run-reproducer.m
@@ -17,7 +17,7 @@
 
 #include <stdio.h>
 
-// CHECK: Preprocessed source(s) and associated run script(s) are located at:
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.m
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.cache
 

--- a/clang/test/Modules/crash-vfs-umbrella-frameworks.m
+++ b/clang/test/Modules/crash-vfs-umbrella-frameworks.m
@@ -18,7 +18,7 @@
 // RUN: find %t/crash-vfs-*.cache/vfs | \
 // RUN:   grep "B.framework/Headers/B.h" | count 1
 
-// CHECK: Preprocessed source(s) and associated run script(s) are located at:
+// CHECK: PLEASE ATTACH THE FOLLOWING CRASH REPRODUCER FILES TO THE BUG REPORT:
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.m
 // CHECK-NEXT: note: diagnostic msg: {{.*}}.cache
 

--- a/clang/tools/driver/driver.cpp
+++ b/clang/tools/driver/driver.cpp
@@ -242,8 +242,8 @@ static int ExecuteCC1Tool(SmallVectorImpl<const char *> &ArgV,
 int clang_main(int Argc, char **Argv, const llvm::ToolContext &ToolContext) {
   noteBottomOfStack();
   llvm::setBugReportMsg("PLEASE submit a bug report to " BUG_REPORT_URL
-                        " and include the crash backtrace, preprocessed "
-                        "source, and associated run script.\n");
+                        " and include the crash backtrace and"
+                        " dumped files.\n");
   SmallVector<const char *, 256> Args(Argv, Argv + Argc);
 
   if (llvm::sys::Process::FixupStandardFileDescriptors())


### PR DESCRIPTION
Makes it easier to move around crash diagnostics.

Reland of #198838 with crash-diagnostics-tar.c and crash-report-crashfile.m fixed.