### PR TITLE
[flang][acc] Attach FortranObjectViewOpInterface to acc.unwrap_private

### DIFF
--- a/flang/include/flang/Optimizer/OpenACC/Support/FIROpenACCOpsInterfaces.h
+++ b/flang/include/flang/Optimizer/OpenACC/Support/FIROpenACCOpsInterfaces.h
@@ -132,13 +132,23 @@ struct OperationMoveModel : public fir::OperationMoveOpInterface::ExternalModel<
   bool canMoveOutOf(mlir::Operation *op, mlir::Operation *candidate) const;
 };
 
-struct ReductionInitOpFortranObjectViewModel
+namespace detail {
+void verifyFortranObjectViewResult(mlir::Operation *op,
+                                   mlir::OpResult resultView);
+}
+
+/// External model for acc ops whose result is a zero-offset view of an operand.
+template <typename Op>
+struct AccFortranObjectViewModel
     : public fir::FortranObjectViewOpInterface::ExternalModel<
-          ReductionInitOpFortranObjectViewModel, mlir::acc::ReductionInitOp> {
+          AccFortranObjectViewModel<Op>, Op> {
   mlir::Value getViewSource(mlir::Operation *op,
                             mlir::OpResult resultView) const;
   std::optional<std::int64_t> getViewOffset(mlir::Operation *op,
-                                            mlir::OpResult resultView) const;
+                                            mlir::OpResult resultView) const {
+    detail::verifyFortranObjectViewResult(op, resultView);
+    return 0;
+  }
 };
 
 } // namespace fir::acc

--- a/flang/lib/Optimizer/OpenACC/Support/FIROpenACCOpsInterfaces.cpp
+++ b/flang/lib/Optimizer/OpenACC/Support/FIROpenACCOpsInterfaces.cpp
@@ -18,15 +18,25 @@
 #include "flang/Optimizer/Support/InternalNames.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
 #include "llvm/ADT/SmallSet.h"
 
 namespace fir::acc {
+namespace detail {
 
-mlir::Value ReductionInitOpFortranObjectViewModel::getViewSource(
-    mlir::Operation *op, mlir::OpResult resultView) const {
+void verifyFortranObjectViewResult(mlir::Operation *op,
+                                   mlir::OpResult resultView) {
   assert(resultView.getOwner() == op && "result value must be the op's result");
-  assert(op->getNumResults() == 1 &&
-         "definition of acc.reduction_init changed");
+  assert(op->getNumResults() == 1 && "only expected single-result");
+}
+
+} // namespace detail
+
+template <>
+mlir::Value
+AccFortranObjectViewModel<mlir::acc::ReductionInitOp>::getViewSource(
+    mlir::Operation *op, mlir::OpResult resultView) const {
+  detail::verifyFortranObjectViewResult(op, resultView);
   auto iface = mlir::cast<mlir::RegionBranchOpInterface>(op);
   llvm::SmallVector<mlir::Value, 1> resultValues;
   iface.getPredecessorValues(mlir::RegionSuccessor::parent(), /*index=*/0,
@@ -45,11 +55,12 @@ mlir::Value ReductionInitOpFortranObjectViewModel::getViewSource(
   return passThroughValue;
 }
 
-std::optional<std::int64_t>
-ReductionInitOpFortranObjectViewModel::getViewOffset(
+template <>
+mlir::Value
+AccFortranObjectViewModel<mlir::acc::UnwrapPrivateOp>::getViewSource(
     mlir::Operation *op, mlir::OpResult resultView) const {
-  assert(resultView.getOwner() == op && "result value must be the op's result");
-  return 0;
+  detail::verifyFortranObjectViewResult(op, resultView);
+  return mlir::cast<mlir::acc::UnwrapPrivateOp>(op).getViewSource();
 }
 
 template <>

--- a/flang/lib/Optimizer/OpenACC/Support/RegisterOpenACCExtensions.cpp
+++ b/flang/lib/Optimizer/OpenACC/Support/RegisterOpenACCExtensions.cpp
@@ -113,7 +113,9 @@ void registerOpenACCExtensions(mlir::DialectRegistry &registry) {
     mlir::acc::SerialOp::attachInterface<
         OperationMoveModel<mlir::acc::SerialOp>>(*ctx);
     mlir::acc::ReductionInitOp::attachInterface<
-        fir::acc::ReductionInitOpFortranObjectViewModel>(*ctx);
+        fir::acc::AccFortranObjectViewModel<mlir::acc::ReductionInitOp>>(*ctx);
+    mlir::acc::UnwrapPrivateOp::attachInterface<
+        fir::acc::AccFortranObjectViewModel<mlir::acc::UnwrapPrivateOp>>(*ctx);
   });
 
   registerAttrsExtensions(registry);


### PR DESCRIPTION
Since this operation is simply a zero-offset view, attach the FortranObjectViewOpInterface to allow FIR AA to walk this if needed.