### PR TITLE
[cmake] Add llvm-nm before lldb

### DIFF
--- a/llvm/tools/CMakeLists.txt
+++ b/llvm/tools/CMakeLists.txt
@@ -35,6 +35,7 @@ add_llvm_tool_subdirectory(llvm-config)
 add_llvm_tool_subdirectory(llvm-ctxprof-util)
 add_llvm_tool_subdirectory(llvm-lto)
 add_llvm_tool_subdirectory(llvm-profdata)
+add_llvm_tool_subdirectory(llvm-nm)
 
 # Projects supported via LLVM_EXTERNAL_*_SOURCE_DIR need to be explicitly
 # specified.


### PR DESCRIPTION
After #199152, CMake failed for me with:

```
CMake Error at cmake/modules/AddLLVM.cmake:2805 (get_target_property):
  get_target_property() called with non-existent target "llvm-nm".
Call Stack (most recent call first):
  F:/Dev/llvm-project/lldb/source/API/CMakeLists.txt:205 (get_host_tool_path)
```

I'm not sure why it didn't fail in CI or on the buildbots. The fix here is to add llvm-nm before lldb like we do with other projects.