### PR TITLE
[NVPTX] pass variadics frame as local pointer

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXTargetMachine.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXTargetMachine.cpp
@@ -359,6 +359,9 @@ void NVPTXPassConfig::addIRPasses() {
   addPass(createNVPTXAssignValidGlobalNamesPass());
   addPass(createGenericToNVVMLegacyPass());
 
+  // Lower variadic calls before address space inference.
+  addPass(createExpandVariadicsPass(ExpandVariadicsMode::Lowering));
+
   // NVPTXLowerArgs is required for correctness and should be run right
   // before the address space inference passes.
   if (getNVPTXTargetMachine().getDrvInterface() == NVPTX::CUDA)
@@ -371,7 +374,6 @@ void NVPTXPassConfig::addIRPasses() {
   }
 
   addPass(createAtomicExpandLegacyPass());
-  addPass(createExpandVariadicsPass(ExpandVariadicsMode::Lowering));
   addPass(createNVPTXCtorDtorLoweringLegacyPass());
 
   // === LSR and other generic IR passes ===

--- a/llvm/lib/Transforms/IPO/ExpandVariadics.cpp
+++ b/llvm/lib/Transforms/IPO/ExpandVariadics.cpp
@@ -62,6 +62,7 @@
 #include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/NVPTXAddrSpace.h"
 #include "llvm/TargetParser/Triple.h"
 #include "llvm/Transforms/Utils/ModuleUtils.h"
 
@@ -887,7 +888,13 @@ bool ExpandVariadics::expandVAIntrinsicCall(IRBuilder<> &Builder,
     // to it, then create a va_copy. When vaCopyIsMemcpy(), this optimises to a
     // store to the VaStartArg.
     assert(ABI->vaCopyIsMemcpy());
-    Builder.CreateStore(PassedVaList, VaStartArg);
+    // The va_list parameter may be passed in a different address space than
+    // the va_list object iterates in (e.g. NVPTX passes a local pointer but
+    // stores a generic cursor). Cast it to the type va_arg expects to load.
+    Value *Cursor = PassedVaList;
+    if (Cursor->getType() != VaStartArg->getType())
+      Cursor = Builder.CreateAddrSpaceCast(Cursor, VaStartArg->getType());
+    Builder.CreateStore(Cursor, VaStartArg);
   } else {
 
     // Otherwise emit a vacopy to pick up target-specific handling if any
@@ -1008,7 +1015,7 @@ struct NVPTX final : public VariadicABIInfo {
   }
 
   Type *vaListParameterType(Module &M) override {
-    return PointerType::getUnqual(M.getContext());
+    return PointerType::get(M.getContext(), NVPTXAS::ADDRESS_SPACE_LOCAL);
   }
 
   Value *initializeVaList(Module &M, LLVMContext &Ctx, IRBuilder<> &Builder,

--- a/llvm/lib/Transforms/IPO/ExpandVariadics.cpp
+++ b/llvm/lib/Transforms/IPO/ExpandVariadics.cpp
@@ -619,11 +619,12 @@ ExpandVariadics::defineVariadicWrapper(Module &M, IRBuilder<> &Builder,
 
   SmallVector<Value *> Args(llvm::make_pointer_range(F.args()));
 
-  Type *ParameterType = ABI->vaListParameterType(M);
+  Value *VaListValue = VaListInstance;
   if (ABI->vaListPassedInSSARegister())
-    Args.push_back(Builder.CreateLoad(ParameterType, VaListInstance));
-  else
-    Args.push_back(Builder.CreateAddrSpaceCast(VaListInstance, ParameterType));
+    VaListValue = Builder.CreateLoad(VaListTy, VaListInstance);
+
+  Type *ParameterType = ABI->vaListParameterType(M);
+  Args.push_back(Builder.CreateAddrSpaceCast(VaListValue, ParameterType));
 
   CallInst *Result = Builder.CreateCall(FixedArityReplacement, Args);
 

--- a/llvm/test/CodeGen/NVPTX/convert-call-to-indirect.ll
+++ b/llvm/test/CodeGen/NVPTX/convert-call-to-indirect.ll
@@ -118,13 +118,12 @@ define %struct.64 @test_return_type_mismatch_variadic(ptr %p) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    mov.b64 %SPL, __local_depot3;
-; CHECK-NEXT:    cvta.local.u64 %SP, %SPL;
 ; CHECK-NEXT:    ld.param.b64 %rd1, [test_return_type_mismatch_variadic_param_0];
+; CHECK-NEXT:    add.u64 %rd2, %SPL, 0;
 ; CHECK-NEXT:    { // callseq 3, 0
 ; CHECK-NEXT:    .param .b64 param0;
 ; CHECK-NEXT:    .param .b64 param1;
 ; CHECK-NEXT:    .param .align 1 .b8 retval0[8];
-; CHECK-NEXT:    add.u64 %rd2, %SP, 0;
 ; CHECK-NEXT:    st.param.b64 [param1], %rd2;
 ; CHECK-NEXT:    st.param.b64 [param0], %rd1;
 ; CHECK-NEXT:    prototype_3 : .callprototype (.param .align 1 .b8 _[8]) _ (.param .b64 _, .param .b64 _);
@@ -183,14 +182,13 @@ define i64 @test_param_type_mismatch_variadic(ptr %p) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    mov.b64 %SPL, __local_depot4;
-; CHECK-NEXT:    cvta.local.u64 %SP, %SPL;
 ; CHECK-NEXT:    ld.param.b64 %rd1, [test_param_type_mismatch_variadic_param_0];
-; CHECK-NEXT:    st.b64 [%SP], 7;
+; CHECK-NEXT:    add.u64 %rd2, %SPL, 0;
+; CHECK-NEXT:    st.local.b64 [%rd2], 7;
 ; CHECK-NEXT:    { // callseq 4, 0
 ; CHECK-NEXT:    .param .b64 param0;
 ; CHECK-NEXT:    .param .b64 param1;
 ; CHECK-NEXT:    .param .b64 retval0;
-; CHECK-NEXT:    add.u64 %rd2, %SP, 0;
 ; CHECK-NEXT:    st.param.b64 [param1], %rd2;
 ; CHECK-NEXT:    st.param.b64 [param0], %rd1;
 ; CHECK-NEXT:    call.uni (retval0), callee_variadic, (param0, param1);
@@ -212,14 +210,13 @@ define i64 @test_param_count_mismatch_variadic(ptr %p) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    mov.b64 %SPL, __local_depot5;
-; CHECK-NEXT:    cvta.local.u64 %SP, %SPL;
 ; CHECK-NEXT:    ld.param.b64 %rd1, [test_param_count_mismatch_variadic_param_0];
-; CHECK-NEXT:    st.b64 [%SP], 7;
+; CHECK-NEXT:    add.u64 %rd2, %SPL, 0;
+; CHECK-NEXT:    st.local.b64 [%rd2], 7;
 ; CHECK-NEXT:    { // callseq 5, 0
 ; CHECK-NEXT:    .param .b64 param0;
 ; CHECK-NEXT:    .param .b64 param1;
 ; CHECK-NEXT:    .param .b64 retval0;
-; CHECK-NEXT:    add.u64 %rd2, %SP, 0;
 ; CHECK-NEXT:    st.param.b64 [param1], %rd2;
 ; CHECK-NEXT:    st.param.b64 [param0], %rd1;
 ; CHECK-NEXT:    call.uni (retval0), callee_variadic, (param0, param1);

--- a/llvm/test/CodeGen/NVPTX/vaargs.ll
+++ b/llvm/test/CodeGen/NVPTX/vaargs.ll
@@ -16,7 +16,7 @@ define i32 @foo(i32 %a, ...) {
 ; CHECK32-NEXT:    .local .align 8 .b8 __local_depot0[32];
 ; CHECK32-NEXT:    .reg .b32 %SP;
 ; CHECK32-NEXT:    .reg .b32 %SPL;
-; CHECK32-NEXT:    .reg .b32 %r<29>;
+; CHECK32-NEXT:    .reg .b32 %r<30>;
 ; CHECK32-NEXT:    .reg .b64 %rd<3>;
 ; CHECK32-EMPTY:
 ; CHECK32-NEXT:  // %bb.0: // %entry
@@ -24,33 +24,34 @@ define i32 @foo(i32 %a, ...) {
 ; CHECK32-NEXT:    cvta.local.u32 %SP, %SPL;
 ; CHECK32-NEXT:    ld.param.b32 %r2, [foo_param_1];
 ; CHECK32-NEXT:    ld.param.b32 %r1, [foo_param_0];
-; CHECK32-NEXT:    st.b32 [%SP], %r2;
-; CHECK32-NEXT:    ld.b32 %r3, [%SP];
-; CHECK32-NEXT:    st.b32 [%SP+16], %r3;
+; CHECK32-NEXT:    cvta.local.u32 %r3, %r2;
+; CHECK32-NEXT:    st.b32 [%SP], %r3;
 ; CHECK32-NEXT:    ld.b32 %r4, [%SP];
-; CHECK32-NEXT:    add.s32 %r5, %r4, 3;
-; CHECK32-NEXT:    and.b32 %r6, %r5, -4;
-; CHECK32-NEXT:    add.s32 %r7, %r6, 4;
-; CHECK32-NEXT:    st.b32 [%SP], %r7;
-; CHECK32-NEXT:    ld.b32 %r8, [%r6];
-; CHECK32-NEXT:    ld.b32 %r9, [%SP];
-; CHECK32-NEXT:    add.s32 %r10, %r9, 7;
-; CHECK32-NEXT:    and.b32 %r11, %r10, -8;
-; CHECK32-NEXT:    add.s32 %r12, %r11, 8;
-; CHECK32-NEXT:    st.b32 [%SP], %r12;
-; CHECK32-NEXT:    ld.b64 %rd1, [%r11];
-; CHECK32-NEXT:    ld.b32 %r13, [%SP];
-; CHECK32-NEXT:    add.s32 %r14, %r13, 7;
-; CHECK32-NEXT:    and.b32 %r15, %r14, -8;
-; CHECK32-NEXT:    add.s32 %r16, %r15, 8;
-; CHECK32-NEXT:    st.b32 [%SP], %r16;
-; CHECK32-NEXT:    ld.b64 %rd2, [%r15];
-; CHECK32-NEXT:    ld.b32 %r17, [%SP];
-; CHECK32-NEXT:    add.s32 %r18, %r17, 3;
-; CHECK32-NEXT:    and.b32 %r19, %r18, -4;
-; CHECK32-NEXT:    add.s32 %r20, %r19, 4;
-; CHECK32-NEXT:    st.b32 [%SP], %r20;
-; CHECK32-NEXT:    ld.b32 %r21, [%r19];
+; CHECK32-NEXT:    st.b32 [%SP+16], %r4;
+; CHECK32-NEXT:    ld.b32 %r5, [%SP];
+; CHECK32-NEXT:    add.s32 %r6, %r5, 3;
+; CHECK32-NEXT:    and.b32 %r7, %r6, -4;
+; CHECK32-NEXT:    add.s32 %r8, %r7, 4;
+; CHECK32-NEXT:    st.b32 [%SP], %r8;
+; CHECK32-NEXT:    ld.b32 %r9, [%r7];
+; CHECK32-NEXT:    ld.b32 %r10, [%SP];
+; CHECK32-NEXT:    add.s32 %r11, %r10, 7;
+; CHECK32-NEXT:    and.b32 %r12, %r11, -8;
+; CHECK32-NEXT:    add.s32 %r13, %r12, 8;
+; CHECK32-NEXT:    st.b32 [%SP], %r13;
+; CHECK32-NEXT:    ld.b64 %rd1, [%r12];
+; CHECK32-NEXT:    ld.b32 %r14, [%SP];
+; CHECK32-NEXT:    add.s32 %r15, %r14, 7;
+; CHECK32-NEXT:    and.b32 %r16, %r15, -8;
+; CHECK32-NEXT:    add.s32 %r17, %r16, 8;
+; CHECK32-NEXT:    st.b32 [%SP], %r17;
+; CHECK32-NEXT:    ld.b64 %rd2, [%r16];
+; CHECK32-NEXT:    ld.b32 %r18, [%SP];
+; CHECK32-NEXT:    add.s32 %r19, %r18, 3;
+; CHECK32-NEXT:    and.b32 %r20, %r19, -4;
+; CHECK32-NEXT:    add.s32 %r21, %r20, 4;
+; CHECK32-NEXT:    st.b32 [%SP], %r21;
+; CHECK32-NEXT:    ld.b32 %r22, [%r20];
 ; CHECK32-NEXT:    { // callseq 0, 0
 ; CHECK32-NEXT:    .param .b32 param0;
 ; CHECK32-NEXT:    .param .b32 param1;
@@ -58,22 +59,22 @@ define i32 @foo(i32 %a, ...) {
 ; CHECK32-NEXT:    .param .b64 param3;
 ; CHECK32-NEXT:    .param .b32 param4;
 ; CHECK32-NEXT:    .param .b32 retval0;
-; CHECK32-NEXT:    st.param.b32 [param4], %r21;
+; CHECK32-NEXT:    st.param.b32 [param4], %r22;
 ; CHECK32-NEXT:    st.param.b64 [param3], %rd2;
 ; CHECK32-NEXT:    st.param.b64 [param2], %rd1;
-; CHECK32-NEXT:    st.param.b32 [param1], %r8;
+; CHECK32-NEXT:    st.param.b32 [param1], %r9;
 ; CHECK32-NEXT:    st.param.b32 [param0], %r1;
 ; CHECK32-NEXT:    call.uni (retval0), bar, (param0, param1, param2, param3, param4);
-; CHECK32-NEXT:    ld.param.b32 %r22, [retval0];
+; CHECK32-NEXT:    ld.param.b32 %r23, [retval0];
 ; CHECK32-NEXT:    } // callseq 0
-; CHECK32-NEXT:    ld.b32 %r23, [%SP+16];
-; CHECK32-NEXT:    add.s32 %r24, %r23, 3;
-; CHECK32-NEXT:    and.b32 %r25, %r24, -4;
-; CHECK32-NEXT:    add.s32 %r26, %r25, 4;
-; CHECK32-NEXT:    st.b32 [%SP+16], %r26;
-; CHECK32-NEXT:    ld.b32 %r27, [%r25];
-; CHECK32-NEXT:    add.s32 %r28, %r22, %r27;
-; CHECK32-NEXT:    st.param.b32 [func_retval0], %r28;
+; CHECK32-NEXT:    ld.b32 %r24, [%SP+16];
+; CHECK32-NEXT:    add.s32 %r25, %r24, 3;
+; CHECK32-NEXT:    and.b32 %r26, %r25, -4;
+; CHECK32-NEXT:    add.s32 %r27, %r26, 4;
+; CHECK32-NEXT:    st.b32 [%SP+16], %r27;
+; CHECK32-NEXT:    ld.b32 %r28, [%r26];
+; CHECK32-NEXT:    add.s32 %r29, %r23, %r28;
+; CHECK32-NEXT:    st.param.b32 [func_retval0], %r29;
 ; CHECK32-NEXT:    ret;
 ;
 ; CHECK64-LABEL: foo(
@@ -82,40 +83,41 @@ define i32 @foo(i32 %a, ...) {
 ; CHECK64-NEXT:    .reg .b64 %SP;
 ; CHECK64-NEXT:    .reg .b64 %SPL;
 ; CHECK64-NEXT:    .reg .b32 %r<6>;
-; CHECK64-NEXT:    .reg .b64 %rd<26>;
+; CHECK64-NEXT:    .reg .b64 %rd<27>;
 ; CHECK64-EMPTY:
 ; CHECK64-NEXT:  // %bb.0: // %entry
 ; CHECK64-NEXT:    mov.b64 %SPL, __local_depot0;
 ; CHECK64-NEXT:    cvta.local.u64 %SP, %SPL;
 ; CHECK64-NEXT:    ld.param.b64 %rd1, [foo_param_1];
 ; CHECK64-NEXT:    ld.param.b32 %r1, [foo_param_0];
-; CHECK64-NEXT:    st.b64 [%SP], %rd1;
-; CHECK64-NEXT:    ld.b64 %rd2, [%SP];
-; CHECK64-NEXT:    st.b64 [%SP+24], %rd2;
+; CHECK64-NEXT:    cvta.local.u64 %rd2, %rd1;
+; CHECK64-NEXT:    st.b64 [%SP], %rd2;
 ; CHECK64-NEXT:    ld.b64 %rd3, [%SP];
-; CHECK64-NEXT:    add.s64 %rd4, %rd3, 3;
-; CHECK64-NEXT:    and.b64 %rd5, %rd4, -4;
-; CHECK64-NEXT:    add.s64 %rd6, %rd5, 4;
-; CHECK64-NEXT:    st.b64 [%SP], %rd6;
-; CHECK64-NEXT:    ld.b32 %r2, [%rd5];
-; CHECK64-NEXT:    ld.b64 %rd7, [%SP];
-; CHECK64-NEXT:    add.s64 %rd8, %rd7, 7;
-; CHECK64-NEXT:    and.b64 %rd9, %rd8, -8;
-; CHECK64-NEXT:    add.s64 %rd10, %rd9, 8;
-; CHECK64-NEXT:    st.b64 [%SP], %rd10;
-; CHECK64-NEXT:    ld.b64 %rd11, [%rd9];
-; CHECK64-NEXT:    ld.b64 %rd12, [%SP];
-; CHECK64-NEXT:    add.s64 %rd13, %rd12, 7;
-; CHECK64-NEXT:    and.b64 %rd14, %rd13, -8;
-; CHECK64-NEXT:    add.s64 %rd15, %rd14, 8;
-; CHECK64-NEXT:    st.b64 [%SP], %rd15;
-; CHECK64-NEXT:    ld.b64 %rd16, [%rd14];
-; CHECK64-NEXT:    ld.b64 %rd17, [%SP];
-; CHECK64-NEXT:    add.s64 %rd18, %rd17, 7;
-; CHECK64-NEXT:    and.b64 %rd19, %rd18, -8;
-; CHECK64-NEXT:    add.s64 %rd20, %rd19, 8;
-; CHECK64-NEXT:    st.b64 [%SP], %rd20;
-; CHECK64-NEXT:    ld.b64 %rd21, [%rd19];
+; CHECK64-NEXT:    st.b64 [%SP+24], %rd3;
+; CHECK64-NEXT:    ld.b64 %rd4, [%SP];
+; CHECK64-NEXT:    add.s64 %rd5, %rd4, 3;
+; CHECK64-NEXT:    and.b64 %rd6, %rd5, -4;
+; CHECK64-NEXT:    add.s64 %rd7, %rd6, 4;
+; CHECK64-NEXT:    st.b64 [%SP], %rd7;
+; CHECK64-NEXT:    ld.b32 %r2, [%rd6];
+; CHECK64-NEXT:    ld.b64 %rd8, [%SP];
+; CHECK64-NEXT:    add.s64 %rd9, %rd8, 7;
+; CHECK64-NEXT:    and.b64 %rd10, %rd9, -8;
+; CHECK64-NEXT:    add.s64 %rd11, %rd10, 8;
+; CHECK64-NEXT:    st.b64 [%SP], %rd11;
+; CHECK64-NEXT:    ld.b64 %rd12, [%rd10];
+; CHECK64-NEXT:    ld.b64 %rd13, [%SP];
+; CHECK64-NEXT:    add.s64 %rd14, %rd13, 7;
+; CHECK64-NEXT:    and.b64 %rd15, %rd14, -8;
+; CHECK64-NEXT:    add.s64 %rd16, %rd15, 8;
+; CHECK64-NEXT:    st.b64 [%SP], %rd16;
+; CHECK64-NEXT:    ld.b64 %rd17, [%rd15];
+; CHECK64-NEXT:    ld.b64 %rd18, [%SP];
+; CHECK64-NEXT:    add.s64 %rd19, %rd18, 7;
+; CHECK64-NEXT:    and.b64 %rd20, %rd19, -8;
+; CHECK64-NEXT:    add.s64 %rd21, %rd20, 8;
+; CHECK64-NEXT:    st.b64 [%SP], %rd21;
+; CHECK64-NEXT:    ld.b64 %rd22, [%rd20];
 ; CHECK64-NEXT:    { // callseq 0, 0
 ; CHECK64-NEXT:    .param .b32 param0;
 ; CHECK64-NEXT:    .param .b32 param1;
@@ -123,20 +125,20 @@ define i32 @foo(i32 %a, ...) {
 ; CHECK64-NEXT:    .param .b64 param3;
 ; CHECK64-NEXT:    .param .b64 param4;
 ; CHECK64-NEXT:    .param .b32 retval0;
-; CHECK64-NEXT:    st.param.b64 [param4], %rd21;
-; CHECK64-NEXT:    st.param.b64 [param3], %rd16;
-; CHECK64-NEXT:    st.param.b64 [param2], %rd11;
+; CHECK64-NEXT:    st.param.b64 [param4], %rd22;
+; CHECK64-NEXT:    st.param.b64 [param3], %rd17;
+; CHECK64-NEXT:    st.param.b64 [param2], %rd12;
 ; CHECK64-NEXT:    st.param.b32 [param1], %r2;
 ; CHECK64-NEXT:    st.param.b32 [param0], %r1;
 ; CHECK64-NEXT:    call.uni (retval0), bar, (param0, param1, param2, param3, param4);
 ; CHECK64-NEXT:    ld.param.b32 %r3, [retval0];
 ; CHECK64-NEXT:    } // callseq 0
-; CHECK64-NEXT:    ld.b64 %rd22, [%SP+24];
-; CHECK64-NEXT:    add.s64 %rd23, %rd22, 3;
-; CHECK64-NEXT:    and.b64 %rd24, %rd23, -4;
-; CHECK64-NEXT:    add.s64 %rd25, %rd24, 4;
-; CHECK64-NEXT:    st.b64 [%SP+24], %rd25;
-; CHECK64-NEXT:    ld.b32 %r4, [%rd24];
+; CHECK64-NEXT:    ld.b64 %rd23, [%SP+24];
+; CHECK64-NEXT:    add.s64 %rd24, %rd23, 3;
+; CHECK64-NEXT:    and.b64 %rd25, %rd24, -4;
+; CHECK64-NEXT:    add.s64 %rd26, %rd25, 4;
+; CHECK64-NEXT:    st.b64 [%SP+24], %rd26;
+; CHECK64-NEXT:    ld.b32 %r4, [%rd25];
 ; CHECK64-NEXT:    add.s32 %r5, %r3, %r4;
 ; CHECK64-NEXT:    st.param.b32 [func_retval0], %r5;
 ; CHECK64-NEXT:    ret;
@@ -184,7 +186,7 @@ define i32 @test_foo(i32 %i, i64 %l, double %d, ptr %p) {
 ; CHECK32-NEXT:    .local .align 8 .b8 __local_depot1[32];
 ; CHECK32-NEXT:    .reg .b32 %SP;
 ; CHECK32-NEXT:    .reg .b32 %SPL;
-; CHECK32-NEXT:    .reg .b32 %r<8>;
+; CHECK32-NEXT:    .reg .b32 %r<9>;
 ; CHECK32-NEXT:    .reg .b64 %rd<3>;
 ; CHECK32-EMPTY:
 ; CHECK32-NEXT:  // %bb.0: // %entry
@@ -201,18 +203,19 @@ define i32 @test_foo(i32 %i, i64 %l, double %d, ptr %p) {
 ; CHECK32-NEXT:    st.b64 [%SP+8], %rd1;
 ; CHECK32-NEXT:    st.b64 [%SP+16], %rd2;
 ; CHECK32-NEXT:    st.b32 [%SP+24], %r2;
+; CHECK32-NEXT:    add.u32 %r6, %SP, 0;
+; CHECK32-NEXT:    cvta.to.local.u32 %r7, %r6;
 ; CHECK32-NEXT:    { // callseq 1, 0
 ; CHECK32-NEXT:    .param .b32 param0;
 ; CHECK32-NEXT:    .param .b32 param1;
 ; CHECK32-NEXT:    .param .b32 retval0;
-; CHECK32-NEXT:    add.u32 %r6, %SP, 0;
-; CHECK32-NEXT:    st.param.b32 [param1], %r6;
+; CHECK32-NEXT:    st.param.b32 [param1], %r7;
 ; CHECK32-NEXT:    prototype_1 : .callprototype (.param .b32 _) _ (.param .b32 _, .param .b32 _);
 ; CHECK32-NEXT:    st.param.b32 [param0], 4;
 ; CHECK32-NEXT:    call (retval0), %r5, (param0, param1), prototype_1;
-; CHECK32-NEXT:    ld.param.b32 %r7, [retval0];
+; CHECK32-NEXT:    ld.param.b32 %r8, [retval0];
 ; CHECK32-NEXT:    } // callseq 1
-; CHECK32-NEXT:    st.param.b32 [func_retval0], %r7;
+; CHECK32-NEXT:    st.param.b32 [func_retval0], %r8;
 ; CHECK32-NEXT:    ret;
 ;
 ; CHECK64-LABEL: test_foo(
@@ -221,7 +224,7 @@ define i32 @test_foo(i32 %i, i64 %l, double %d, ptr %p) {
 ; CHECK64-NEXT:    .reg .b64 %SP;
 ; CHECK64-NEXT:    .reg .b64 %SPL;
 ; CHECK64-NEXT:    .reg .b32 %r<3>;
-; CHECK64-NEXT:    .reg .b64 %rd<8>;
+; CHECK64-NEXT:    .reg .b64 %rd<9>;
 ; CHECK64-EMPTY:
 ; CHECK64-NEXT:  // %bb.0: // %entry
 ; CHECK64-NEXT:    mov.b64 %SPL, __local_depot1;
@@ -237,12 +240,13 @@ define i32 @test_foo(i32 %i, i64 %l, double %d, ptr %p) {
 ; CHECK64-NEXT:    st.b64 [%SP+8], %rd1;
 ; CHECK64-NEXT:    st.b64 [%SP+16], %rd2;
 ; CHECK64-NEXT:    st.b64 [%SP+24], %rd3;
+; CHECK64-NEXT:    add.u64 %rd7, %SP, 0;
+; CHECK64-NEXT:    cvta.to.local.u64 %rd8, %rd7;
 ; CHECK64-NEXT:    { // callseq 1, 0
 ; CHECK64-NEXT:    .param .b32 param0;
 ; CHECK64-NEXT:    .param .b64 param1;
 ; CHECK64-NEXT:    .param .b32 retval0;
-; CHECK64-NEXT:    add.u64 %rd7, %SP, 0;
-; CHECK64-NEXT:    st.param.b64 [param1], %rd7;
+; CHECK64-NEXT:    st.param.b64 [param1], %rd8;
 ; CHECK64-NEXT:    prototype_1 : .callprototype (.param .b32 _) _ (.param .b32 _, .param .b64 _);
 ; CHECK64-NEXT:    st.param.b32 [param0], 4;
 ; CHECK64-NEXT:    call (retval0), %rd6, (param0, param1), prototype_1;

--- a/llvm/test/CodeGen/NVPTX/variadics-backend.ll
+++ b/llvm/test/CodeGen/NVPTX/variadics-backend.ll
@@ -17,27 +17,27 @@ define dso_local i32 @variadics1(i32 noundef %first, ...) {
 ; CHECK-PTX-NEXT:  // %bb.0: // %entry
 ; CHECK-PTX-NEXT:    ld.param.b32 %r1, [variadics1_param_0];
 ; CHECK-PTX-NEXT:    ld.param.b64 %rd1, [variadics1_param_1];
-; CHECK-PTX-NEXT:    ld.b32 %r2, [%rd1];
+; CHECK-PTX-NEXT:    ld.local.b32 %r2, [%rd1];
 ; CHECK-PTX-NEXT:    add.s32 %r3, %r1, %r2;
-; CHECK-PTX-NEXT:    ld.b32 %r4, [%rd1+4];
+; CHECK-PTX-NEXT:    ld.local.b32 %r4, [%rd1+4];
 ; CHECK-PTX-NEXT:    add.s32 %r5, %r3, %r4;
-; CHECK-PTX-NEXT:    ld.b32 %r6, [%rd1+8];
+; CHECK-PTX-NEXT:    ld.local.b32 %r6, [%rd1+8];
 ; CHECK-PTX-NEXT:    add.s32 %r7, %r5, %r6;
 ; CHECK-PTX-NEXT:    add.s64 %rd2, %rd1, 19;
 ; CHECK-PTX-NEXT:    and.b64 %rd3, %rd2, -8;
-; CHECK-PTX-NEXT:    ld.b64 %rd4, [%rd3];
+; CHECK-PTX-NEXT:    ld.local.b64 %rd4, [%rd3];
 ; CHECK-PTX-NEXT:    cvt.u64.u32 %rd5, %r7;
 ; CHECK-PTX-NEXT:    add.s64 %rd6, %rd5, %rd4;
 ; CHECK-PTX-NEXT:    cvt.u32.u64 %r8, %rd6;
 ; CHECK-PTX-NEXT:    add.s64 %rd7, %rd3, 15;
 ; CHECK-PTX-NEXT:    and.b64 %rd8, %rd7, -8;
-; CHECK-PTX-NEXT:    ld.b64 %rd9, [%rd8];
+; CHECK-PTX-NEXT:    ld.local.b64 %rd9, [%rd8];
 ; CHECK-PTX-NEXT:    cvt.rn.f64.s32 %rd10, %r8;
 ; CHECK-PTX-NEXT:    add.rn.f64 %rd11, %rd10, %rd9;
 ; CHECK-PTX-NEXT:    cvt.rzi.s32.f64 %r9, %rd11;
 ; CHECK-PTX-NEXT:    add.s64 %rd12, %rd8, 15;
 ; CHECK-PTX-NEXT:    and.b64 %rd13, %rd12, -8;
-; CHECK-PTX-NEXT:    ld.b64 %rd14, [%rd13];
+; CHECK-PTX-NEXT:    ld.local.b64 %rd14, [%rd13];
 ; CHECK-PTX-NEXT:    cvt.rn.f64.s32 %rd15, %r9;
 ; CHECK-PTX-NEXT:    add.rn.f64 %rd16, %rd15, %rd14;
 ; CHECK-PTX-NEXT:    cvt.rzi.s32.f64 %r10, %rd16;
@@ -109,17 +109,17 @@ define dso_local i32 @foo() {
 ; CHECK-PTX-EMPTY:
 ; CHECK-PTX-NEXT:  // %bb.0: // %entry
 ; CHECK-PTX-NEXT:    mov.b64 %SPL, __local_depot1;
-; CHECK-PTX-NEXT:    cvta.local.u64 %SP, %SPL;
-; CHECK-PTX-NEXT:    st.b64 [%SP], 4294967297;
-; CHECK-PTX-NEXT:    st.b32 [%SP+8], 1;
-; CHECK-PTX-NEXT:    st.b64 [%SP+16], 1;
-; CHECK-PTX-NEXT:    st.b64 [%SP+24], 4607182418800017408;
-; CHECK-PTX-NEXT:    st.b64 [%SP+32], 4607182418800017408;
+; CHECK-PTX-NEXT:    add.u64 %rd1, %SPL, 0;
+; CHECK-PTX-NEXT:    st.local.b32 [%rd1], 1;
+; CHECK-PTX-NEXT:    st.local.b32 [%rd1+4], 1;
+; CHECK-PTX-NEXT:    st.local.b32 [%rd1+8], 1;
+; CHECK-PTX-NEXT:    st.local.b64 [%rd1+16], 1;
+; CHECK-PTX-NEXT:    st.local.b64 [%rd1+24], 4607182418800017408;
+; CHECK-PTX-NEXT:    st.local.b64 [%rd1+32], 4607182418800017408;
 ; CHECK-PTX-NEXT:    { // callseq 0, 0
 ; CHECK-PTX-NEXT:    .param .b32 param0;
 ; CHECK-PTX-NEXT:    .param .b64 param1;
 ; CHECK-PTX-NEXT:    .param .b32 retval0;
-; CHECK-PTX-NEXT:    add.u64 %rd1, %SP, 0;
 ; CHECK-PTX-NEXT:    st.param.b64 [param1], %rd1;
 ; CHECK-PTX-NEXT:    st.param.b32 [param0], 1;
 ; CHECK-PTX-NEXT:    call.uni (retval0), variadics1, (param0, param1);
@@ -152,15 +152,15 @@ define dso_local i32 @variadics2(i32 noundef %first, ...) {
 ; CHECK-PTX-NEXT:    add.u64 %rd2, %SPL, 0;
 ; CHECK-PTX-NEXT:    add.s64 %rd3, %rd1, 7;
 ; CHECK-PTX-NEXT:    and.b64 %rd4, %rd3, -8;
-; CHECK-PTX-NEXT:    ld.b32 %r2, [%rd4];
-; CHECK-PTX-NEXT:    ld.s8 %r3, [%rd4+4];
-; CHECK-PTX-NEXT:    ld.b8 %rs1, [%rd4+7];
+; CHECK-PTX-NEXT:    ld.local.b32 %r2, [%rd4];
+; CHECK-PTX-NEXT:    ld.local.s8 %r3, [%rd4+4];
+; CHECK-PTX-NEXT:    ld.local.b8 %rs1, [%rd4+7];
 ; CHECK-PTX-NEXT:    st.local.b8 [%rd2+2], %rs1;
-; CHECK-PTX-NEXT:    ld.b8 %rs2, [%rd4+6];
+; CHECK-PTX-NEXT:    ld.local.b8 %rs2, [%rd4+6];
 ; CHECK-PTX-NEXT:    st.local.b8 [%rd2+1], %rs2;
-; CHECK-PTX-NEXT:    ld.b8 %rs3, [%rd4+5];
+; CHECK-PTX-NEXT:    ld.local.b8 %rs3, [%rd4+5];
 ; CHECK-PTX-NEXT:    st.local.b8 [%rd2], %rs3;
-; CHECK-PTX-NEXT:    ld.b64 %rd5, [%rd4+8];
+; CHECK-PTX-NEXT:    ld.local.b64 %rd5, [%rd4+8];
 ; CHECK-PTX-NEXT:    add.s32 %r4, %r1, %r2;
 ; CHECK-PTX-NEXT:    add.s32 %r5, %r4, %r3;
 ; CHECK-PTX-NEXT:    cvt.u64.u32 %rd6, %r5;
@@ -207,22 +207,21 @@ define dso_local i32 @bar() {
 ; CHECK-PTX-EMPTY:
 ; CHECK-PTX-NEXT:  // %bb.0: // %entry
 ; CHECK-PTX-NEXT:    mov.b64 %SPL, __local_depot3;
-; CHECK-PTX-NEXT:    cvta.local.u64 %SP, %SPL;
 ; CHECK-PTX-NEXT:    add.u64 %rd1, %SPL, 0;
+; CHECK-PTX-NEXT:    add.u64 %rd2, %SPL, 8;
 ; CHECK-PTX-NEXT:    ld.global.nc.b8 %rs1, [__const_$_bar_$_s1+7];
 ; CHECK-PTX-NEXT:    st.local.b8 [%rd1+2], %rs1;
 ; CHECK-PTX-NEXT:    ld.global.nc.b8 %rs2, [__const_$_bar_$_s1+6];
 ; CHECK-PTX-NEXT:    st.local.b8 [%rd1+1], %rs2;
 ; CHECK-PTX-NEXT:    ld.global.nc.b8 %rs3, [__const_$_bar_$_s1+5];
 ; CHECK-PTX-NEXT:    st.local.b8 [%rd1], %rs3;
-; CHECK-PTX-NEXT:    st.b32 [%SP+8], 1;
-; CHECK-PTX-NEXT:    st.b8 [%SP+12], 1;
-; CHECK-PTX-NEXT:    st.b64 [%SP+16], 1;
+; CHECK-PTX-NEXT:    st.local.b32 [%rd2], 1;
+; CHECK-PTX-NEXT:    st.local.b8 [%rd2+4], 1;
+; CHECK-PTX-NEXT:    st.local.b64 [%rd2+8], 1;
 ; CHECK-PTX-NEXT:    { // callseq 1, 0
 ; CHECK-PTX-NEXT:    .param .b32 param0;
 ; CHECK-PTX-NEXT:    .param .b64 param1;
 ; CHECK-PTX-NEXT:    .param .b32 retval0;
-; CHECK-PTX-NEXT:    add.u64 %rd2, %SP, 8;
 ; CHECK-PTX-NEXT:    st.param.b64 [param1], %rd2;
 ; CHECK-PTX-NEXT:    st.param.b32 [param0], 1;
 ; CHECK-PTX-NEXT:    call.uni (retval0), variadics2, (param0, param1);
@@ -250,7 +249,7 @@ define dso_local i32 @variadics3(i32 noundef %first, ...) {
 ; CHECK-PTX-NEXT:    ld.param.b64 %rd1, [variadics3_param_1];
 ; CHECK-PTX-NEXT:    add.s64 %rd2, %rd1, 15;
 ; CHECK-PTX-NEXT:    and.b64 %rd3, %rd2, -16;
-; CHECK-PTX-NEXT:    ld.v4.b32 {%r1, %r2, %r3, %r4}, [%rd3];
+; CHECK-PTX-NEXT:    ld.local.v4.b32 {%r1, %r2, %r3, %r4}, [%rd3];
 ; CHECK-PTX-NEXT:    add.s32 %r5, %r1, %r2;
 ; CHECK-PTX-NEXT:    add.s32 %r6, %r5, %r3;
 ; CHECK-PTX-NEXT:    add.s32 %r7, %r6, %r4;
@@ -287,13 +286,12 @@ define dso_local i32 @baz() {
 ; CHECK-PTX-EMPTY:
 ; CHECK-PTX-NEXT:  // %bb.0: // %entry
 ; CHECK-PTX-NEXT:    mov.b64 %SPL, __local_depot5;
-; CHECK-PTX-NEXT:    cvta.local.u64 %SP, %SPL;
-; CHECK-PTX-NEXT:    st.v4.b32 [%SP], {1, 1, 1, 1};
+; CHECK-PTX-NEXT:    add.u64 %rd1, %SPL, 0;
+; CHECK-PTX-NEXT:    st.local.v4.b32 [%rd1], {1, 1, 1, 1};
 ; CHECK-PTX-NEXT:    { // callseq 2, 0
 ; CHECK-PTX-NEXT:    .param .b32 param0;
 ; CHECK-PTX-NEXT:    .param .b64 param1;
 ; CHECK-PTX-NEXT:    .param .b32 retval0;
-; CHECK-PTX-NEXT:    add.u64 %rd1, %SP, 0;
 ; CHECK-PTX-NEXT:    st.param.b64 [param1], %rd1;
 ; CHECK-PTX-NEXT:    st.param.b32 [param0], 1;
 ; CHECK-PTX-NEXT:    call.uni (retval0), variadics3, (param0, param1);
@@ -315,7 +313,7 @@ define dso_local i32 @variadics4(ptr noundef byval(%struct.S2) align 8 %first, .
 ; CHECK-PTX-NEXT:    ld.param.b64 %rd1, [variadics4_param_1];
 ; CHECK-PTX-NEXT:    add.s64 %rd2, %rd1, 7;
 ; CHECK-PTX-NEXT:    and.b64 %rd3, %rd2, -8;
-; CHECK-PTX-NEXT:    ld.b64 %rd4, [%rd3];
+; CHECK-PTX-NEXT:    ld.local.b64 %rd4, [%rd3];
 ; CHECK-PTX-NEXT:    ld.param.b64 %rd5, [variadics4_param_0];
 ; CHECK-PTX-NEXT:    ld.param.b64 %rd6, [variadics4_param_0+8];
 ; CHECK-PTX-NEXT:    add.s64 %rd7, %rd5, %rd6;
@@ -352,19 +350,18 @@ define dso_local void @qux() {
 ; CHECK-PTX-EMPTY:
 ; CHECK-PTX-NEXT:  // %bb.0: // %entry
 ; CHECK-PTX-NEXT:    mov.b64 %SPL, __local_depot7;
-; CHECK-PTX-NEXT:    cvta.local.u64 %SP, %SPL;
 ; CHECK-PTX-NEXT:    add.u64 %rd1, %SPL, 0;
-; CHECK-PTX-NEXT:    ld.global.nc.b64 %rd2, [__const_$_qux_$_s+8];
-; CHECK-PTX-NEXT:    st.local.b64 [%rd1+8], %rd2;
-; CHECK-PTX-NEXT:    ld.global.nc.b64 %rd3, [__const_$_qux_$_s];
-; CHECK-PTX-NEXT:    st.local.b64 [%rd1], %rd3;
-; CHECK-PTX-NEXT:    st.b64 [%SP+16], 1;
+; CHECK-PTX-NEXT:    add.u64 %rd2, %SPL, 16;
+; CHECK-PTX-NEXT:    ld.global.nc.b64 %rd3, [__const_$_qux_$_s+8];
+; CHECK-PTX-NEXT:    st.local.b64 [%rd1+8], %rd3;
+; CHECK-PTX-NEXT:    ld.global.nc.b64 %rd4, [__const_$_qux_$_s];
+; CHECK-PTX-NEXT:    st.local.b64 [%rd1], %rd4;
+; CHECK-PTX-NEXT:    st.local.b64 [%rd2], 1;
 ; CHECK-PTX-NEXT:    { // callseq 3, 0
 ; CHECK-PTX-NEXT:    .param .align 8 .b8 param0[16];
 ; CHECK-PTX-NEXT:    .param .b64 param1;
 ; CHECK-PTX-NEXT:    .param .b32 retval0;
-; CHECK-PTX-NEXT:    add.u64 %rd4, %SP, 16;
-; CHECK-PTX-NEXT:    st.param.b64 [param1], %rd4;
+; CHECK-PTX-NEXT:    st.param.b64 [param1], %rd2;
 ; CHECK-PTX-NEXT:    ld.local.b64 %rd5, [%rd1+8];
 ; CHECK-PTX-NEXT:    st.param.b64 [param0+8], %rd5;
 ; CHECK-PTX-NEXT:    ld.local.b64 %rd6, [%rd1];

--- a/llvm/test/CodeGen/NVPTX/variadics-lowering.ll
+++ b/llvm/test/CodeGen/NVPTX/variadics-lowering.ll
@@ -9,10 +9,11 @@
 
 define dso_local i32 @variadics1(i32 noundef %first, ...) {
 ; CHECK-LABEL: define dso_local i32 @variadics1(
-; CHECK-SAME: i32 noundef [[FIRST:%.*]], ptr [[VARARGS:%.*]]) {
+; CHECK-SAME: i32 noundef [[FIRST:%.*]], ptr addrspace(5) [[VARARGS:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[VLIST:%.*]] = alloca ptr, align 8
-; CHECK-NEXT:    store ptr [[VARARGS]], ptr [[VLIST]], align 8
+; CHECK-NEXT:    [[TMP9:%.*]] = addrspacecast ptr addrspace(5) [[VARARGS]] to ptr
+; CHECK-NEXT:    store ptr [[TMP9]], ptr [[VLIST]], align 8
 ; CHECK-NEXT:    [[ARGP_CUR:%.*]] = load ptr, ptr [[VLIST]], align 8
 ; CHECK-NEXT:    [[ARGP_NEXT:%.*]] = getelementptr inbounds i8, ptr [[ARGP_CUR]], i64 4
 ; CHECK-NEXT:    store ptr [[ARGP_NEXT]], ptr [[VLIST]], align 8
@@ -132,7 +133,8 @@ define dso_local i32 @foo() {
 ; CHECK-NEXT:    store double [[CONV2]], ptr [[TMP4]], align 8
 ; CHECK-NEXT:    [[TMP5:%.*]] = getelementptr inbounds nuw [[FOO_VARARG]], ptr [[VARARG_BUFFER]], i32 0, i32 6
 ; CHECK-NEXT:    store double 1.000000e+00, ptr [[TMP5]], align 8
-; CHECK-NEXT:    [[CALL:%.*]] = call i32 @variadics1(i32 noundef 1, ptr [[VARARG_BUFFER]])
+; CHECK-NEXT:    [[TMP6:%.*]] = addrspacecast ptr [[VARARG_BUFFER]] to ptr addrspace(5)
+; CHECK-NEXT:    [[CALL:%.*]] = call i32 @variadics1(i32 noundef 1, ptr addrspace(5) [[TMP6]])
 ; CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr [[VARARG_BUFFER]])
 ; CHECK-NEXT:    ret i32 [[CALL]]
 ;
@@ -146,11 +148,12 @@ entry:
 
 define dso_local i32 @variadics2(i32 noundef %first, ...) {
 ; CHECK-LABEL: define dso_local i32 @variadics2(
-; CHECK-SAME: i32 noundef [[FIRST:%.*]], ptr [[VARARGS:%.*]]) {
+; CHECK-SAME: i32 noundef [[FIRST:%.*]], ptr addrspace(5) [[VARARGS:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[VLIST:%.*]] = alloca ptr, align 8
 ; CHECK-NEXT:    [[S1_SROA_3:%.*]] = alloca [3 x i8], align 1
-; CHECK-NEXT:    store ptr [[VARARGS]], ptr [[VLIST]], align 8
+; CHECK-NEXT:    [[TMP1:%.*]] = addrspacecast ptr addrspace(5) [[VARARGS]] to ptr
+; CHECK-NEXT:    store ptr [[TMP1]], ptr [[VLIST]], align 8
 ; CHECK-NEXT:    [[ARGP_CUR:%.*]] = load ptr, ptr [[VLIST]], align 8
 ; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr inbounds i8, ptr [[ARGP_CUR]], i32 7
 ; CHECK-NEXT:    [[ARGP_CUR_ALIGNED:%.*]] = call ptr @llvm.ptrmask.p0.i64(ptr [[TMP0]], i64 -8)
@@ -215,7 +218,8 @@ define dso_local i32 @bar() {
 ; CHECK-NEXT:    store i8 [[S1_SROA_2_0_COPYLOAD]], ptr [[TMP1]], align 1
 ; CHECK-NEXT:    [[TMP2:%.*]] = getelementptr inbounds nuw [[BAR_VARARG]], ptr [[VARARG_BUFFER]], i32 0, i32 3
 ; CHECK-NEXT:    store i64 [[S1_SROA_31_0_COPYLOAD]], ptr [[TMP2]], align 8
-; CHECK-NEXT:    [[CALL:%.*]] = call i32 @variadics2(i32 noundef 1, ptr [[VARARG_BUFFER]])
+; CHECK-NEXT:    [[TMP3:%.*]] = addrspacecast ptr [[VARARG_BUFFER]] to ptr addrspace(5)
+; CHECK-NEXT:    [[CALL:%.*]] = call i32 @variadics2(i32 noundef 1, ptr addrspace(5) [[TMP3]])
 ; CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr [[VARARG_BUFFER]])
 ; CHECK-NEXT:    ret i32 [[CALL]]
 ;
@@ -231,10 +235,11 @@ entry:
 
 define dso_local i32 @variadics3(i32 noundef %first, ...) {
 ; CHECK-LABEL: define dso_local i32 @variadics3(
-; CHECK-SAME: i32 noundef [[FIRST:%.*]], ptr [[VARARGS:%.*]]) {
+; CHECK-SAME: i32 noundef [[FIRST:%.*]], ptr addrspace(5) [[VARARGS:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[VLIST:%.*]] = alloca ptr, align 8
-; CHECK-NEXT:    store ptr [[VARARGS]], ptr [[VLIST]], align 8
+; CHECK-NEXT:    [[TMP6:%.*]] = addrspacecast ptr addrspace(5) [[VARARGS]] to ptr
+; CHECK-NEXT:    store ptr [[TMP6]], ptr [[VLIST]], align 8
 ; CHECK-NEXT:    [[ARGP_CUR:%.*]] = load ptr, ptr [[VLIST]], align 8
 ; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr inbounds i8, ptr [[ARGP_CUR]], i32 15
 ; CHECK-NEXT:    [[ARGP_CUR_ALIGNED:%.*]] = call ptr @llvm.ptrmask.p0.i64(ptr [[TMP0]], i64 -16)
@@ -277,7 +282,8 @@ define dso_local i32 @baz() {
 ; CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr [[VARARG_BUFFER]])
 ; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr inbounds nuw [[BAZ_VARARG]], ptr [[VARARG_BUFFER]], i32 0, i32 0
 ; CHECK-NEXT:    store <4 x i32> splat (i32 1), ptr [[TMP0]], align 16
-; CHECK-NEXT:    [[CALL:%.*]] = call i32 @variadics3(i32 noundef 1, ptr [[VARARG_BUFFER]])
+; CHECK-NEXT:    [[TMP1:%.*]] = addrspacecast ptr [[VARARG_BUFFER]] to ptr addrspace(5)
+; CHECK-NEXT:    [[CALL:%.*]] = call i32 @variadics3(i32 noundef 1, ptr addrspace(5) [[TMP1]])
 ; CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr [[VARARG_BUFFER]])
 ; CHECK-NEXT:    ret i32 [[CALL]]
 ;
@@ -288,10 +294,11 @@ entry:
 
 define dso_local i32 @variadics4(ptr noundef byval(%struct.S2) align 8 %first, ...) {
 ; CHECK-LABEL: define dso_local i32 @variadics4(
-; CHECK-SAME: ptr noundef byval([[STRUCT_S2:%.*]]) align 8 [[FIRST:%.*]], ptr [[VARARGS:%.*]]) {
+; CHECK-SAME: ptr noundef byval([[STRUCT_S2:%.*]]) align 8 [[FIRST:%.*]], ptr addrspace(5) [[VARARGS:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[VLIST:%.*]] = alloca ptr, align 8
-; CHECK-NEXT:    store ptr [[VARARGS]], ptr [[VLIST]], align 8
+; CHECK-NEXT:    [[TMP4:%.*]] = addrspacecast ptr addrspace(5) [[VARARGS]] to ptr
+; CHECK-NEXT:    store ptr [[TMP4]], ptr [[VLIST]], align 8
 ; CHECK-NEXT:    [[ARGP_CUR:%.*]] = load ptr, ptr [[VLIST]], align 8
 ; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr inbounds i8, ptr [[ARGP_CUR]], i32 7
 ; CHECK-NEXT:    [[ARGP_CUR_ALIGNED:%.*]] = call ptr @llvm.ptrmask.p0.i64(ptr [[TMP0]], i64 -8)
@@ -336,7 +343,8 @@ define dso_local void @qux() {
 ; CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr [[VARARG_BUFFER]])
 ; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr inbounds nuw [[QUX_VARARG]], ptr [[VARARG_BUFFER]], i32 0, i32 0
 ; CHECK-NEXT:    store i64 1, ptr [[TMP0]], align 8
-; CHECK-NEXT:    [[CALL:%.*]] = call i32 @variadics4(ptr noundef byval([[STRUCT_S2]]) align 8 [[S]], ptr [[VARARG_BUFFER]])
+; CHECK-NEXT:    [[TMP1:%.*]] = addrspacecast ptr [[VARARG_BUFFER]] to ptr addrspace(5)
+; CHECK-NEXT:    [[CALL:%.*]] = call i32 @variadics4(ptr noundef byval([[STRUCT_S2]]) align 8 [[S]], ptr addrspace(5) [[TMP1]])
 ; CHECK-NEXT:    call void @llvm.lifetime.end.p0(ptr [[VARARG_BUFFER]])
 ; CHECK-NEXT:    ret void
 ;


### PR DESCRIPTION
Pass the pointer for variadics as a local (addrspace(5)) pointer. This enables InferAddressSpace to convert loads of vaargs to local loads (pipeline reordered to accomadate) and will also save a register in short pointer mode. We leave vaListType as a generic pointer and cast when expanding va_start to maintain backwards compatibility with IR written expecting the va_list to be a generic pointer. 