### PR TITLE
[SPIRV] Fix crash in addOpAccessChainReqs on index-less access chains

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -1372,9 +1372,13 @@ void addOpAccessChainReqs(const MachineInstr &Instr,
   bool IsNonUniform =
       hasNonUniformDecoration(Instr.getOperand(0).getReg(), MRI);
 
-  auto FirstIndexReg = Instr.getOperand(3).getReg();
-  bool FirstIndexIsConstant =
-      Subtarget.getInstrInfo()->isConstantInstr(*MRI.getVRegDef(FirstIndexReg));
+  // Guard against lack of index operands.
+  bool FirstIndexIsConstant = true;
+  if (Instr.getNumOperands() > 3) {
+    Register FirstIndexReg = Instr.getOperand(3).getReg();
+    FirstIndexIsConstant = Subtarget.getInstrInfo()->isConstantInstr(
+        *MRI.getVRegDef(FirstIndexReg));
+  }
 
   if (StorageClass == SPIRV::StorageClass::StorageClass::StorageBuffer) {
     if (IsNonUniform)

--- a/llvm/test/CodeGen/SPIRV/pointers/access-chain-no-index-crash.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/access-chain-no-index-crash.ll
@@ -1,0 +1,21 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan1.3 %s -o - | FileCheck %s
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; A byte getelementptr on a pointer whose pointee is not i8 lowers to an
+; OpAccessChain with no explicit index operands. The SPIR-V requirement
+; analysis used to unconditionally read the (non-existent) first-index operand
+; of every OpAccessChain, which indexed past the end of the instruction's
+; operand list and crashed. Check that such an access chain now compiles
+; without crashing and still emits the OpAccessChain.
+
+; CHECK: OpFunction
+; CHECK: %[[#PTR:]] = OpFunctionParameter
+; CHECK: %[[#]] = OpAccessChain %[[#]] %[[#PTR]]
+; CHECK: OpReturnValue
+; CHECK: OpFunctionEnd
+
+define ptr addrspace(2) @access_chain_no_index(ptr addrspace(2) %p) {
+  %gep = getelementptr i8, ptr addrspace(2) %p, i64 8
+  ret ptr addrspace(2) %gep
+}


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/201662
See the tagged issue for more information.

addOpAccessChainReqs() unconditionally read the first-index operand (operand 3) of every OpAccessChain to decide whether the access uses dynamic array indexing. However, an OpAccessChain can have no index operands at all -- for example, a byte getelementptr on a pointer whose pointee type is not i8 lowers to an access chain with only a result-type and a base-pointer operand and no explicit indices. In that case Instr.getOperand(3) indexes past the end of the instruction's operand list, and the subsequent MachineRegisterInfo::getVRegDef() call dereferences the resulting garbage register, crashing the SPIR-V module analysis pass.

Guard the first-index inspection with an operand-count check. When the access chain has no index, there is no dynamic array indexing, so the index is treated as constant and no array-dynamic-indexing capability is required.

Fixes a SIGSEGV reachable from
  llc -mtriple=spirv-unknown-vulkan1.3 -filetype=obj

----

AI disclaimer: I used Claude code to understand the bug/crash, isolate it in a minimal repro and then fix it