### PR TITLE
[clang] fix assertion for DeducedAsPack DeducedTemplateSpecializationType

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -6943,11 +6943,6 @@ QualType ASTContext::getUnconstrainedType(QualType T) const {
 QualType ASTContext::getDeducedTemplateSpecializationType(
     DeducedKind DK, QualType DeducedAsType, ElaboratedTypeKeyword Keyword,
     TemplateName Template) const {
-  // DeducedAsPack only ever occurs for lambda init-capture pack, which always
-  // use AutoType.
-  assert(DK != DeducedKind::DeducedAsPack &&
-         "unexpected DeducedAsPack for DeducedTemplateSpecializationType");
-
   // Look in the folding set for an existing type.
   void *InsertPos = nullptr;
   llvm::FoldingSetNodeID ID;

--- a/clang/test/SemaTemplate/ctad.cpp
+++ b/clang/test/SemaTemplate/ctad.cpp
@@ -124,3 +124,19 @@ namespace GH167513 {
   template <class T> using AA = A<T, T{}>;
   AA b{0};
 } // namespace GH167513
+
+#if __cplusplus >= 202002L
+namespace GH200418 {
+  template <template <class> class... Ts> struct S {
+    template <Ts... Vs> using X = decltype((Vs , ...));
+  };
+
+  template <class> struct A {
+    constexpr A(int) {}
+  };
+  A(int) -> A<int>;
+
+  using T = A<int>;
+  using T = S<A>::X<0>;
+} // namespace GH200418
+#endif


### PR DESCRIPTION
This fixes a regression introduced in #186727, which was never released, so there are no release notes.

Fixes #200418