### PR TITLE
[HLSL][CBuffer][Matrix] Honor row_major/column_major keyword in cbuffer layout

### DIFF
--- a/clang/lib/CodeGen/HLSLBufferLayoutBuilder.cpp
+++ b/clang/lib/CodeGen/HLSLBufferLayoutBuilder.cpp
@@ -131,13 +131,13 @@ llvm::Type *HLSLBufferLayoutBuilder::layOutArray(const ConstantArrayType *AT) {
   return padArrayElements(EltTy, Count);
 }
 
-llvm::Type *
-HLSLBufferLayoutBuilder::layOutMatrix(const ConstantMatrixType *MT) {
+llvm::Type *HLSLBufferLayoutBuilder::layOutMatrix(QualType Ty) {
   // ConvertTypeForMem already handles row/column-major layout and bool
   // promotion, producing [Count x <VecLen x EltTy>]. We just need to add
-  // cbuffer padding between the array elements.
+  // cbuffer padding between the array elements. Pass the sugared QualType so
+  // that the `row_major`/`column_major` orientation attribute is preserved.
   llvm::ArrayType *MemTy =
-      cast<llvm::ArrayType>(CGM.getTypes().ConvertTypeForMem(QualType(MT, 0)));
+      cast<llvm::ArrayType>(CGM.getTypes().ConvertTypeForMem(Ty));
   return padArrayElements(MemTy->getElementType(), MemTy->getNumElements());
 }
 
@@ -150,10 +150,8 @@ llvm::Type *HLSLBufferLayoutBuilder::layOutType(QualType Ty) {
     return layOutStruct(Ty->getAsCanonical<RecordType>(), EmptyOffsets);
   }
 
-  if (Ty->isConstantMatrixType()) {
-    const auto *MT = Ty->castAs<ConstantMatrixType>();
-    return layOutMatrix(MT);
-  }
+  if (Ty->isConstantMatrixType())
+    return layOutMatrix(Ty);
 
   return CGM.getTypes().ConvertTypeForMem(Ty);
 }

--- a/clang/lib/CodeGen/HLSLBufferLayoutBuilder.h
+++ b/clang/lib/CodeGen/HLSLBufferLayoutBuilder.h
@@ -49,8 +49,10 @@ public:
   /// Lays out an array type following HLSL buffer rules.
   llvm::Type *layOutArray(const ConstantArrayType *AT);
 
-  /// Lays out a matrix type following HLSL buffer rules.
-  llvm::Type *layOutMatrix(const ConstantMatrixType *MT);
+  /// Lays out a matrix type following HLSL buffer rules. The QualType must
+  /// retain any `row_major`/`column_major` sugar so that the correct memory
+  /// orientation is used.
+  llvm::Type *layOutMatrix(QualType Ty);
 
   /// Lays out a type following HLSL buffer rules. Arrays and structures will be
   /// padded appropriately and nested objects will be converted as appropriate.

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -525,6 +525,17 @@ static const Type *createHostLayoutType(Sema &S, const Type *Ty) {
   return Ty;
 }
 
+// Returns the type to use for a host layout struct field. For most types this
+// is the unqualified desugared type. Matrix types, however, retain their sugar
+// so that the row_major/column_major orientation (carried as an AttributedType)
+// is preserved; the orientation determines the in-memory cbuffer layout.
+static const Type *getHostLayoutFieldType(QualType QT) {
+  const Type *Desugared = QT->getUnqualifiedDesugaredType();
+  if (Desugared->isConstantMatrixType())
+    return QT.getTypePtr();
+  return Desugared;
+}
+
 // Creates a field declaration of given name and type for HLSL buffer layout
 // struct. Returns nullptr if the type cannot be use in HLSL Buffer layout.
 static FieldDecl *createFieldForHostLayoutStruct(Sema &S, const Type *Ty,
@@ -597,7 +608,7 @@ static CXXRecordDecl *createHostLayoutStruct(Sema &S,
 
   // filter struct fields
   for (const FieldDecl *FD : StructDecl->fields()) {
-    const Type *Ty = FD->getType()->getUnqualifiedDesugaredType();
+    const Type *Ty = getHostLayoutFieldType(FD->getType());
     if (FieldDecl *NewFD =
             createFieldForHostLayoutStruct(S, Ty, FD->getIdentifier(), LS))
       LS->addDecl(NewFD);
@@ -635,7 +646,7 @@ static void createHostLayoutStructForBuffer(Sema &S, HLSLBufferDecl *BufDecl) {
     if (!VD || VD->getStorageClass() == SC_Static ||
         VD->getType().getAddressSpace() == LangAS::hlsl_groupshared)
       continue;
-    const Type *Ty = VD->getType()->getUnqualifiedDesugaredType();
+    const Type *Ty = getHostLayoutFieldType(VD->getType());
 
     FieldDecl *FD =
         createFieldForHostLayoutStruct(S, Ty, VD->getIdentifier(), LS);

--- a/clang/test/CodeGenHLSL/cbuffer-matrix-layout-keyword.hlsl
+++ b/clang/test/CodeGenHLSL/cbuffer-matrix-layout-keyword.hlsl
@@ -1,0 +1,41 @@
+// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.3-compute %s -emit-llvm -disable-llvm-passes -fmatrix-memory-layout=column-major -o - | FileCheck %s
+// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.3-compute %s -emit-llvm -disable-llvm-passes -fmatrix-memory-layout=row-major -o - | FileCheck %s
+
+// row_major float2x3 -> 2 rows of <3 x float>, 16-byte row stride:
+//   { [1 x { <3 x float>, pad(4) }], <3 x float> }
+// CHECK: %__cblayout_CB_RM = type <{ <{ [1 x <{ <3 x float>, target("dx.Padding", 4) }>], <3 x float> }> }>
+
+// column_major float2x3 -> 3 columns of <2 x float>, 16-byte column stride:
+//   { [2 x { <2 x float>, pad(8) }], <2 x float> }
+// CHECK: %__cblayout_CB_CM = type <{ <{ [2 x <{ <2 x float>, target("dx.Padding", 8) }>], <2 x float> }> }>
+
+// CHECK: @CB_RM.cb = global target("dx.CBuffer", %__cblayout_CB_RM)
+// CHECK: @rm = external hidden addrspace(2) global <{ [1 x <{ <3 x float>, target("dx.Padding", 4) }>], <3 x float> }>, align 4
+// CHECK: @CB_CM.cb = global target("dx.CBuffer", %__cblayout_CB_CM)
+// CHECK: @cm = external hidden addrspace(2) global <{ [2 x <{ <2 x float>, target("dx.Padding", 8) }>], <2 x float> }>, align 4
+
+cbuffer CB_RM {
+  row_major float2x3 rm;
+}
+cbuffer CB_CM {
+  column_major float2x3 cm;
+}
+
+RWBuffer<float> Out;
+
+[numthreads(1,1,1)]
+void main() {
+  Out[0] = rm[0][0] + cm[0][0];
+}
+
+// row_major copy: dest is [2 x <3 x float>]; load two <3 x float> rows at +0/+16.
+// CHECK-LABEL: define internal void @_Z4mainv()
+// CHECK: %matrix.buf.copy = alloca [2 x <3 x float>], align 4
+// CHECK: %matrix.buf.copy2 = alloca [3 x <2 x float>], align 4
+// CHECK: load <3 x float>, ptr addrspace(2) @rm, align 4
+// CHECK: load <3 x float>, ptr addrspace(2) getelementptr inbounds nuw (i8, ptr addrspace(2) @rm, i32 16), align 4
+
+// column_major copy: dest is [3 x <2 x float>]; load three <2 x float> columns at +0/+16/+32.
+// CHECK: load <2 x float>, ptr addrspace(2) @cm, align 4
+// CHECK: load <2 x float>, ptr addrspace(2) getelementptr inbounds nuw (i8, ptr addrspace(2) @cm, i32 16), align 4
+// CHECK: load <2 x float>, ptr addrspace(2) getelementptr inbounds nuw (i8, ptr addrspace(2) @cm, i32 32), align 4


### PR DESCRIPTION
fixes #201668

A per-declaration `row_major`/`column_major` keyword on a cbuffer matrix was being dropped when building the cbuffer layout, so the layout struct and the buffer-layout copy fell back to the translation-unit `-fmatrix-memory-layout=`

Needed to fix the desugar in two places:
* HLSLBufferLayoutBuilder::layOutMatrix took a `const ConstantMatrixType *` and called ConvertTypeForMem(QualType(MT, 0)), discarding the sugar. It now takes the sugared QualType.
* SemaHLSL's host-layout struct construction called getUnqualifiedDesugaredType() on each field, erasing the orientation attribute. A getHostLayoutFieldType() helper now keeps the sugared type for constant matrices while desugaring everything else.