### PR TITLE
Revert "[clang][lex] Store `HeaderFileInfo` in a `DenseMap`"

### DIFF
--- a/clang/include/clang/Basic/FileManager.h
+++ b/clang/include/clang/Basic/FileManager.h
@@ -306,6 +306,11 @@ public:
   bool makeAbsolutePath(SmallVectorImpl<char> &Path,
                         bool Canonicalize = false) const;
 
+  /// Produce an array mapping from the unique IDs assigned to each
+  /// file to the corresponding FileEntryRef.
+  void
+  GetUniqueIDMapping(SmallVectorImpl<OptionalFileEntryRef> &UIDToFiles) const;
+
   /// Retrieve the canonical name for a given directory.
   ///
   /// This is a very expensive operation, despite its results being cached,

--- a/clang/include/clang/Lex/HeaderSearch.h
+++ b/clang/include/clang/Lex/HeaderSearch.h
@@ -286,8 +286,9 @@ class HeaderSearch {
   /// SpecificModuleCachePath.
   size_t NormalizedModuleCachePathLen = 0;
 
-  /// All the preprocessor-specific data about files that are included.
-  mutable llvm::DenseMap<FileEntryRef, HeaderFileInfo> FileInfo;
+  /// All of the preprocessor-specific data about files that are
+  /// included, indexed by the FileEntry's UID.
+  mutable std::vector<HeaderFileInfo> FileInfo;
 
   /// Keeps track of each lookup performed by LookupFile.
   struct LookupFileCacheInfo {
@@ -898,6 +899,8 @@ public:
   /// Retrieve the module map.
   const ModuleMap &getModuleMap() const { return ModMap; }
 
+  unsigned header_file_size() const { return FileInfo.size(); }
+
   /// Return the HeaderFileInfo structure for the specified FileEntry, in
   /// preparation for updating it in some way.
   HeaderFileInfo &getFileInfo(FileEntryRef FE);
@@ -906,10 +909,9 @@ public:
   /// ever been filled in (either locally or externally).
   const HeaderFileInfo *getExistingFileInfo(FileEntryRef FE) const;
 
-  /// Iterate HeaderFileInfo structures and their corresponding FileEntryRef, if
-  /// they have ever been filled in locally.
-  void forEachExistingLocalFileInfo(
-      llvm::function_ref<void(FileEntryRef, const HeaderFileInfo &)> Fn) const;
+  /// Return the headerFileInfo structure for the specified FileEntry, if it has
+  /// ever been filled in locally.
+  const HeaderFileInfo *getExistingLocalFileInfo(FileEntryRef FE) const;
 
   SearchDirIterator search_dir_begin() { return {*this, 0}; }
   SearchDirIterator search_dir_end() { return {*this, SearchDirs.size()}; }

--- a/clang/lib/Basic/FileManager.cpp
+++ b/clang/lib/Basic/FileManager.cpp
@@ -642,6 +642,24 @@ std::error_code FileManager::getStatValue(StringRef Path,
   return std::error_code();
 }
 
+void FileManager::GetUniqueIDMapping(
+    SmallVectorImpl<OptionalFileEntryRef> &UIDToFiles) const {
+  UIDToFiles.clear();
+  UIDToFiles.resize(NextFileUID);
+
+  for (const auto &Entry : SeenFileEntries) {
+    // Only return files that exist and are not redirected.
+    if (!Entry.getValue() || !isa<FileEntry *>(Entry.getValue()->V))
+      continue;
+    FileEntryRef FE(Entry);
+    // Add this file if it's the first one with the UID, or if its name is
+    // better than the existing one.
+    OptionalFileEntryRef &ExistingFE = UIDToFiles[FE.getUID()];
+    if (!ExistingFE || FE.getName() < ExistingFE->getName())
+      ExistingFE = FE;
+  }
+}
+
 StringRef FileManager::getCanonicalName(DirectoryEntryRef Dir) {
   return getCanonicalName(Dir, Dir.getName());
 }

--- a/clang/lib/Lex/HeaderSearch.cpp
+++ b/clang/lib/Lex/HeaderSearch.cpp
@@ -91,8 +91,8 @@ void HeaderSearch::PrintStats() {
   llvm::errs() << "\n*** HeaderSearch Stats:\n"
                << FileInfo.size() << " files tracked.\n";
   unsigned NumOnceOnlyFiles = 0;
-  for (const auto &[FE, HFI] : FileInfo)
-    NumOnceOnlyFiles += (HFI.isPragmaOnce || HFI.isImport);
+  for (unsigned i = 0, e = FileInfo.size(); i != e; ++i)
+    NumOnceOnlyFiles += (FileInfo[i].isPragmaOnce || FileInfo[i].isImport);
   llvm::errs() << "  " << NumOnceOnlyFiles << " #import/#pragma once files.\n";
 
   llvm::errs() << "  " << NumIncluded << " #include/#include_next/#import.\n"
@@ -1376,7 +1376,10 @@ static void mergeHeaderFileInfo(HeaderFileInfo &HFI,
 }
 
 HeaderFileInfo &HeaderSearch::getFileInfo(FileEntryRef FE) {
-  HeaderFileInfo *HFI = &FileInfo[FE];
+  if (FE.getUID() >= FileInfo.size())
+    FileInfo.resize(FE.getUID() + 1);
+
+  HeaderFileInfo *HFI = &FileInfo[FE.getUID()];
   // FIXME: Use a generation count to check whether this is really up to date.
   if (ExternalSource && !HFI->Resolved) {
     auto ExternalHFI = ExternalSource->GetHeaderFileInfo(FE);
@@ -1397,7 +1400,10 @@ HeaderFileInfo &HeaderSearch::getFileInfo(FileEntryRef FE) {
 const HeaderFileInfo *HeaderSearch::getExistingFileInfo(FileEntryRef FE) const {
   HeaderFileInfo *HFI;
   if (ExternalSource) {
-    HFI = &FileInfo[FE];
+    if (FE.getUID() >= FileInfo.size())
+      FileInfo.resize(FE.getUID() + 1);
+
+    HFI = &FileInfo[FE.getUID()];
     // FIXME: Use a generation count to check whether this is really up to date.
     if (!HFI->Resolved) {
       auto ExternalHFI = ExternalSource->GetHeaderFileInfo(FE);
@@ -1407,8 +1413,8 @@ const HeaderFileInfo *HeaderSearch::getExistingFileInfo(FileEntryRef FE) const {
           mergeHeaderFileInfo(*HFI, ExternalHFI);
       }
     }
-  } else if (auto It = FileInfo.find(FE); It != FileInfo.end()) {
-    HFI = &It->second;
+  } else if (FE.getUID() < FileInfo.size()) {
+    HFI = &FileInfo[FE.getUID()];
   } else {
     HFI = nullptr;
   }
@@ -1416,11 +1422,16 @@ const HeaderFileInfo *HeaderSearch::getExistingFileInfo(FileEntryRef FE) const {
   return (HFI && HFI->IsValid) ? HFI : nullptr;
 }
 
-void HeaderSearch::forEachExistingLocalFileInfo(
-    llvm::function_ref<void(FileEntryRef, const HeaderFileInfo &)> Fn) const {
-  for (const auto &[FE, HFI] : FileInfo)
-    if (HFI.IsValid && !HFI.External)
-      Fn(FE, HFI);
+const HeaderFileInfo *
+HeaderSearch::getExistingLocalFileInfo(FileEntryRef FE) const {
+  HeaderFileInfo *HFI;
+  if (FE.getUID() < FileInfo.size()) {
+    HFI = &FileInfo[FE.getUID()];
+  } else {
+    HFI = nullptr;
+  }
+
+  return (HFI && HFI->IsValid && !HFI->External) ? HFI : nullptr;
 }
 
 bool HeaderSearch::isFileMultipleIncludeGuarded(FileEntryRef File) const {

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -246,17 +246,30 @@ GetAffectingModuleMaps(const Preprocessor &PP, Module *RootModule) {
   }
 
   // Handle textually-included headers that belong to other modules.
-  HS.forEachExistingLocalFileInfo(
-      [&](FileEntryRef File, const HeaderFileInfo &HFI) {
-        if (!HFI.isCompilingModuleHeader && HFI.isModuleHeader)
-          return; // Modular header, handled in the above module-based loop.
-        if (!HFI.isCompilingModuleHeader && !HFI.IsLocallyIncluded)
-          return; // Non-modular header not included locally is not affecting.
 
-        for (const auto &KH : HS.findResolvedModulesForHeader(File))
-          if (const Module *M = KH.getModule())
-            CollectModuleMapsForHierarchy(M, AR_TextualHeader);
-      });
+  SmallVector<OptionalFileEntryRef, 16> FilesByUID;
+  HS.getFileMgr().GetUniqueIDMapping(FilesByUID);
+
+  if (FilesByUID.size() > HS.header_file_size())
+    FilesByUID.resize(HS.header_file_size());
+
+  for (unsigned UID = 0, LastUID = FilesByUID.size(); UID != LastUID; ++UID) {
+    OptionalFileEntryRef File = FilesByUID[UID];
+    if (!File)
+      continue;
+
+    const HeaderFileInfo *HFI = HS.getExistingLocalFileInfo(*File);
+    if (!HFI)
+      continue; // We have no information on this being a header file.
+    if (!HFI->isCompilingModuleHeader && HFI->isModuleHeader)
+      continue; // Modular header, handled in the above module-based loop.
+    if (!HFI->isCompilingModuleHeader && !HFI->IsLocallyIncluded)
+      continue; // Non-modular header not included locally is not affecting.
+
+    for (const auto &KH : HS.findResolvedModulesForHeader(*File))
+      if (const Module *M = KH.getModule())
+        CollectModuleMapsForHierarchy(M, AR_TextualHeader);
+  }
 
   // FIXME: This algorithm is not correct for module map hierarchies where
   // module map file defining a (sub)module of a top-level module X includes
@@ -2239,36 +2252,46 @@ void ASTWriter::WriteHeaderSearch(const HeaderSearch &HS) {
     }
   }
 
-  HS.forEachExistingLocalFileInfo(
-      [&](FileEntryRef File, const HeaderFileInfo &HFI) {
-        if (!HFI.isCompilingModuleHeader && HFI.isModuleHeader)
-          return; // Header file info is tracked by the owning module file.
-        if (!HFI.isCompilingModuleHeader && !HFI.IsLocallyIncluded)
-          return; // Header file info is tracked by the including module file.
+  SmallVector<OptionalFileEntryRef, 16> FilesByUID;
+  HS.getFileMgr().GetUniqueIDMapping(FilesByUID);
 
-        // Massage the file path into an appropriate form.
-        StringRef Filename = File.getName();
-        SmallString<128> FilenameTmp(Filename);
-        if (PreparePathForOutput(FilenameTmp)) {
-          // If we performed any translation on the file name at all, we need to
-          // save this string, since the generator will refer to it later.
-          Filename = StringRef(strdup(FilenameTmp.c_str()));
-          SavedStrings.push_back(Filename.data());
-        }
+  if (FilesByUID.size() > HS.header_file_size())
+    FilesByUID.resize(HS.header_file_size());
 
-        bool Included = HFI.IsLocallyIncluded || PP->alreadyIncluded(File);
+  for (unsigned UID = 0, LastUID = FilesByUID.size(); UID != LastUID; ++UID) {
+    OptionalFileEntryRef File = FilesByUID[UID];
+    if (!File)
+      continue;
 
-        HeaderFileInfoTrait::key_type Key = {
-            Filename, File.getSize(),
-            getTimestampForOutput(File.getModificationTime())};
-        HeaderFileInfoTrait::data_type Data = {
-            HFI,
-            Included,
-            HS.getModuleMap().findResolvedModulesForHeader(File),
-            {}};
-        Generator.insert(Key, Data, GeneratorTrait);
-        ++NumHeaderSearchEntries;
-      });
+    const HeaderFileInfo *HFI = HS.getExistingLocalFileInfo(*File);
+    if (!HFI)
+      continue; // We have no information on this being a header file.
+    if (!HFI->isCompilingModuleHeader && HFI->isModuleHeader)
+      continue; // Header file info is tracked by the owning module file.
+    if (!HFI->isCompilingModuleHeader && !HFI->IsLocallyIncluded)
+      continue; // Header file info is tracked by the including module file.
+
+    // Massage the file path into an appropriate form.
+    StringRef Filename = File->getName();
+    SmallString<128> FilenameTmp(Filename);
+    if (PreparePathForOutput(FilenameTmp)) {
+      // If we performed any translation on the file name at all, we need to
+      // save this string, since the generator will refer to it later.
+      Filename = StringRef(strdup(FilenameTmp.c_str()));
+      SavedStrings.push_back(Filename.data());
+    }
+
+    bool Included = HFI->IsLocallyIncluded || PP->alreadyIncluded(*File);
+
+    HeaderFileInfoTrait::key_type Key = {
+        Filename, File->getSize(),
+        getTimestampForOutput(File->getModificationTime())};
+    HeaderFileInfoTrait::data_type Data = {
+      *HFI, Included, HS.getModuleMap().findResolvedModulesForHeader(*File), {}
+    };
+    Generator.insert(Key, Data, GeneratorTrait);
+    ++NumHeaderSearchEntries;
+  }
 
   // Create the on-disk hash table in a buffer.
   SmallString<4096> TableData;


### PR DESCRIPTION
Reverts llvm/llvm-project#200968

This is causing some non-determinism in PCM files in the `clang/test/Modules/rebuild.m` test.