### PR TITLE
[clang-format] annotate inline assembly parens

### DIFF
--- a/clang/lib/Format/FormatToken.h
+++ b/clang/lib/Format/FormatToken.h
@@ -99,6 +99,7 @@ namespace format {
   TYPE(InheritanceComma)                                                       \
   TYPE(InlineASMBrace)                                                         \
   TYPE(InlineASMColon)                                                         \
+  TYPE(InlineASMParen)                                                         \
   TYPE(InlineASMSymbolicNameLSquare)                                           \
   TYPE(JavaAnnotation)                                                         \
   TYPE(JsAndAndEqual)                                                          \

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -2536,6 +2536,8 @@ private:
     } else if (Current.is(tok::r_paren)) {
       if (rParenEndsCast(Current))
         Current.setType(TT_CastRParen);
+      if (Current.MatchingParen && Current.MatchingParen->is(TT_InlineASMParen))
+        Current.setType(TT_InlineASMParen);
       if (Current.MatchingParen && Current.Next &&
           !Current.Next->isBinaryOperator() &&
           Current.Next->isNoneOf(

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -1508,23 +1508,47 @@ void UnwrappedLineParser::parseStructuralElement(
     return;
   }
   switch (FormatTok->Tok.getKind()) {
-  case tok::kw_asm:
+  case tok::kw_asm: {
+    bool DoNotFormat = false;
+    tok::TokenKind OpenType;
+    tok::TokenKind CloseType;
     nextToken();
-    if (FormatTok->is(tok::l_brace)) {
+    while (FormatTok &&
+           FormatTok->isOneOf(tok::kw_volatile, tok::kw_inline, tok::kw_goto)) {
+      nextToken();
+    }
+    if (FormatTok && FormatTok->is(tok::l_brace)) {
       FormatTok->setFinalizedType(TT_InlineASMBrace);
+      OpenType = tok::l_brace;
+      CloseType = tok::r_brace;
+      DoNotFormat = true;
+    } else if (FormatTok && FormatTok->is(tok::l_paren)) {
+      OpenType = tok::l_paren;
+      CloseType = tok::r_paren;
+      FormatTok->setFinalizedType(TT_InlineASMParen);
+    }
+    if (DoNotFormat) {
+      FormatToken *OpenTok = FormatTok;
+      int NestLevel = 0;
       nextToken();
       while (FormatTok && !eof()) {
-        if (FormatTok->is(tok::r_brace)) {
-          FormatTok->setFinalizedType(TT_InlineASMBrace);
-          nextToken();
-          addUnwrappedLine();
-          break;
+        if (FormatTok->is(OpenType)) {
+          ++NestLevel;
+        } else if (FormatTok->is(CloseType)) {
+          --NestLevel;
+          if (NestLevel < 1) {
+            FormatTok->setFinalizedType(OpenTok->getType());
+            nextToken();
+            addUnwrappedLine();
+            break;
+          }
         }
         FormatTok->Finalized = true;
         nextToken();
       }
     }
     break;
+  }
   case tok::kw_namespace:
     parseNamespace();
     return;

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -1509,6 +1509,9 @@ void UnwrappedLineParser::parseStructuralElement(
   }
   switch (FormatTok->Tok.getKind()) {
   case tok::kw_asm: {
+    // Track whether to skip formatting the inline asm block with a variable.
+    // Formatting is skipped for any asm blocks inside of braces by default.
+    // A style option could be added to also skip formatting inside parens.
     bool DoNotFormat = false;
     tok::TokenKind OpenType;
     tok::TokenKind CloseType;
@@ -1528,6 +1531,8 @@ void UnwrappedLineParser::parseStructuralElement(
       OpenType = tok::l_paren;
       CloseType = tok::r_paren;
       FormatTok->setFinalizedType(TT_InlineASMParen);
+    } else {
+      break;
     }
     if (DoNotFormat) {
       FormatToken *OpenTok = FormatTok;

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -1517,12 +1517,14 @@ void UnwrappedLineParser::parseStructuralElement(
            FormatTok->isOneOf(tok::kw_volatile, tok::kw_inline, tok::kw_goto)) {
       nextToken();
     }
-    if (FormatTok && FormatTok->is(tok::l_brace)) {
+    if (!FormatTok)
+      break;
+    if (FormatTok->is(tok::l_brace)) {
       FormatTok->setFinalizedType(TT_InlineASMBrace);
       OpenType = tok::l_brace;
       CloseType = tok::r_brace;
       DoNotFormat = true;
-    } else if (FormatTok && FormatTok->is(tok::l_paren)) {
+    } else if (FormatTok->is(tok::l_paren)) {
       OpenType = tok::l_paren;
       CloseType = tok::r_paren;
       FormatTok->setFinalizedType(TT_InlineASMParen);

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -1509,8 +1509,8 @@ void UnwrappedLineParser::parseStructuralElement(
   }
   switch (FormatTok->Tok.getKind()) {
   case tok::kw_asm: {
-    // Track whether to skip formatting the inline asm block with a variable.
-    // Formatting is skipped for any asm blocks inside of braces by default.
+    // Track whether to skip formatting inline asm by finalizing the tokens
+    // in the block. Formatting is skipped inside of braces by default.
     // A style option could be added to also skip formatting inside parens.
     bool DoNotFormat = false;
     tok::TokenKind OpenType;

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -2002,50 +2002,15 @@ TEST_F(TokenAnnotatorTest, UnderstandsAsm) {
   EXPECT_TOKEN(Tokens[6], tok::l_square, TT_InlineASMSymbolicNameLSquare);
   EXPECT_TOKEN(Tokens[18], tok::r_paren, TT_InlineASMParen);
 
-  Tokens = annotate("__asm__ inline (\n"
-                    "\"ldr r1, [r0, %%[sym]]\"\n"
-                    ":\n"
-                    ": [sym] \"J\" (aaaaa(aaaa, aaaa))\n"
-                    ");");
-  ASSERT_EQ(Tokens.size(), 21u) << Tokens;
-  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
-  EXPECT_TOKEN(Tokens[2], tok::l_paren, TT_InlineASMParen);
-  EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[6], tok::l_square, TT_InlineASMSymbolicNameLSquare);
-  EXPECT_TOKEN(Tokens[18], tok::r_paren, TT_InlineASMParen);
-
-  Tokens = annotate("asm goto (\n"
-                    "\"btl %1, %0\\n\\t\" \"jc %l2\"\n"
-                    ":\n"
-                    ": \"r\"(a), \"r\"(b)\n"
-                    ": \"cc\"\n"
-                    ": carry\n"
-                    ");");
-  ASSERT_EQ(Tokens.size(), 23u) << Tokens;
-  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
-  EXPECT_TOKEN(Tokens[2], tok::l_paren, TT_InlineASMParen);
-  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[16], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[18], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[20], tok::r_paren, TT_InlineASMParen);
-
-  Tokens = annotate("__asm__ volatile inline goto (\n"
-                    "\"btl %1, %0\\n\\t\" \"jc %l2\"\n"
-                    ":\n"
-                    ": \"r\"(a), \"r\"(b)\n"
-                    ": \"cc\"\n"
-                    ": carry\n"
-                    ");");
-  ASSERT_EQ(Tokens.size(), 25u) << Tokens;
+  Tokens = annotate("__asm__ volatile inline goto (\"nop\" : : : : l );");
+  ASSERT_EQ(Tokens.size(), 14u) << Tokens;
   EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
   EXPECT_TOKEN(Tokens[4], tok::l_paren, TT_InlineASMParen);
+  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[7], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[8], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[18], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[20], tok::colon, TT_InlineASMColon);
-  EXPECT_TOKEN(Tokens[22], tok::r_paren, TT_InlineASMParen);
+  EXPECT_TOKEN(Tokens[9], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[11], tok::r_paren, TT_InlineASMParen);
 }
 
 TEST_F(TokenAnnotatorTest, UnderstandsObjCBlock) {

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -2001,6 +2001,51 @@ TEST_F(TokenAnnotatorTest, UnderstandsAsm) {
   EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[6], tok::l_square, TT_InlineASMSymbolicNameLSquare);
   EXPECT_TOKEN(Tokens[18], tok::r_paren, TT_InlineASMParen);
+
+  Tokens = annotate("__asm__ inline (\n"
+                    "\"ldr r1, [r0, %%[sym]]\"\n"
+                    ":\n"
+                    ": [sym] \"J\" (aaaaa(aaaa, aaaa))\n"
+                    ");");
+  ASSERT_EQ(Tokens.size(), 21u) << Tokens;
+  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[2], tok::l_paren, TT_InlineASMParen);
+  EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[6], tok::l_square, TT_InlineASMSymbolicNameLSquare);
+  EXPECT_TOKEN(Tokens[18], tok::r_paren, TT_InlineASMParen);
+
+  Tokens = annotate("asm goto (\n"
+                    "\"btl %1, %0\\n\\t\" \"jc %l2\"\n"
+                    ":\n"
+                    ": \"r\"(a), \"r\"(b)\n"
+                    ": \"cc\"\n"
+                    ": carry\n"
+                    ");");
+  ASSERT_EQ(Tokens.size(), 23u) << Tokens;
+  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[2], tok::l_paren, TT_InlineASMParen);
+  EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[16], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[18], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[20], tok::r_paren, TT_InlineASMParen);
+
+  Tokens = annotate("__asm__ volatile inline goto (\n"
+                    "\"btl %1, %0\\n\\t\" \"jc %l2\"\n"
+                    ":\n"
+                    ": \"r\"(a), \"r\"(b)\n"
+                    ": \"cc\"\n"
+                    ": carry\n"
+                    ");");
+  ASSERT_EQ(Tokens.size(), 25u) << Tokens;
+  EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[4], tok::l_paren, TT_InlineASMParen);
+  EXPECT_TOKEN(Tokens[7], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[8], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[18], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[20], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[22], tok::r_paren, TT_InlineASMParen);
 }
 
 TEST_F(TokenAnnotatorTest, UnderstandsObjCBlock) {

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -1930,9 +1930,11 @@ TEST_F(TokenAnnotatorTest, UnderstandsAsm) {
                     ":);");
   ASSERT_EQ(Tokens.size(), 10u) << Tokens;
   EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[1], tok::l_paren, TT_InlineASMParen);
   EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[7], tok::r_paren, TT_InlineASMParen);
 
   Tokens = annotate("asm volatile (\n"
                     "\"a_label:\"\n"
@@ -1941,9 +1943,11 @@ TEST_F(TokenAnnotatorTest, UnderstandsAsm) {
                     ":);");
   ASSERT_EQ(Tokens.size(), 11u) << Tokens;
   EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[2], tok::l_paren, TT_InlineASMParen);
   EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[7], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[8], tok::r_paren, TT_InlineASMParen);
 
   Tokens = annotate("__asm__(\n"
                     "\"a_label:\"\n"
@@ -1952,9 +1956,11 @@ TEST_F(TokenAnnotatorTest, UnderstandsAsm) {
                     ": y);");
   ASSERT_EQ(Tokens.size(), 11u) << Tokens;
   EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[1], tok::l_paren, TT_InlineASMParen);
   EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[8], tok::r_paren, TT_InlineASMParen);
 
   Tokens = annotate("__asm volatile (\n"
                     "\"a_label:\"\n"
@@ -1964,9 +1970,11 @@ TEST_F(TokenAnnotatorTest, UnderstandsAsm) {
                     ":);");
   ASSERT_EQ(Tokens.size(), 12u) << Tokens;
   EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[2], tok::l_paren, TT_InlineASMParen);
   EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[6], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[8], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[9], tok::r_paren, TT_InlineASMParen);
 
   Tokens = annotate("asm(\n"
                     "\"insn\"\n"
@@ -1975,9 +1983,11 @@ TEST_F(TokenAnnotatorTest, UnderstandsAsm) {
                     ": \"memory\");");
   ASSERT_EQ(Tokens.size(), 19u) << Tokens;
   EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[1], tok::l_paren, TT_InlineASMParen);
   EXPECT_TOKEN(Tokens[3], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[13], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[14], tok::colon, TT_InlineASMColon);
+  EXPECT_TOKEN(Tokens[16], tok::r_paren, TT_InlineASMParen);
 
   Tokens = annotate("__asm__ volatile (\n"
                     "\"ldr r1, [r0, %%[sym]]\"\n"
@@ -1986,9 +1996,11 @@ TEST_F(TokenAnnotatorTest, UnderstandsAsm) {
                     ");");
   ASSERT_EQ(Tokens.size(), 21u) << Tokens;
   EXPECT_TOKEN(Tokens[0], tok::kw_asm, TT_Unknown);
+  EXPECT_TOKEN(Tokens[2], tok::l_paren, TT_InlineASMParen);
   EXPECT_TOKEN(Tokens[4], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[5], tok::colon, TT_InlineASMColon);
   EXPECT_TOKEN(Tokens[6], tok::l_square, TT_InlineASMSymbolicNameLSquare);
+  EXPECT_TOKEN(Tokens[18], tok::r_paren, TT_InlineASMParen);
 }
 
 TEST_F(TokenAnnotatorTest, UnderstandsObjCBlock) {


### PR DESCRIPTION
Annotate the opening and closing parens of inline assembly. This will make other improvements related to inline assembly easier.