### PR TITLE
[CIR] Handle scalar-type element GEP in GlobalView offset computation

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
@@ -148,19 +148,22 @@ void CIRGenBuilderTy::computeGlobalViewIndicesFromFlatOffset(
             }
             llvm_unreachable("offset was not found within the record");
           })
-          .Default([&](mlir::Type otherTy) -> mlir::Type {
-            // Scalar or pointer type: the offset is a flat element count.
-            // This covers pointer arithmetic through a plain scalar base, e.g.
-            // a char* GlobalViewAttr whose pointee is !s8i rather than an
-            // array — the generated GEP is getelementptr i8, ptr @sym, i64 N.
+          .Case<cir::IntType>([&](cir::IntType intTy) -> mlir::Type {
+            // Integer element type: the offset is a flat element count.
+            // This covers pointer arithmetic through a plain integer base,
+            // e.g. a char* GlobalViewAttr whose pointee type is !s8i rather
+            // than an array — the GEP is getelementptr i8, ptr @sym, i64 N.
             int64_t eltSize =
-                (int64_t)layout.getTypeAllocSize(otherTy).getFixedValue();
+                (int64_t)layout.getTypeAllocSize(intTy).getFixedValue();
             assert(eltSize > 0 && "element size must be positive");
             const auto [index, newOffset] =
                 getIndexAndNewOffset(offset, eltSize);
             indices.push_back(index);
             offset = newOffset;
-            return otherTy;
+            return intTy;
+          })
+          .Default([](mlir::Type) -> mlir::Type {
+            llvm_unreachable("unexpected type");
           });
 
   assert(subType);
@@ -182,9 +185,11 @@ uint64_t CIRGenBuilderTy::computeOffsetFromGlobalViewIndices(
     } else if (auto arrayTy = dyn_cast<cir::ArrayType>(ty)) {
       ty = arrayTy.getElementType();
       offset += layout.getTypeAllocSize(ty) * idx;
-    } else {
-      // Scalar or pointer type: the index is a flat element count.
+    } else if (mlir::isa<cir::IntType>(ty)) {
+      // Integer element type: the index is a flat element count.
       offset += (int64_t)layout.getTypeAllocSize(ty).getFixedValue() * idx;
+    } else {
+      llvm_unreachable("unexpected type");
     }
   }
   return offset;

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
@@ -148,11 +148,19 @@ void CIRGenBuilderTy::computeGlobalViewIndicesFromFlatOffset(
             }
             llvm_unreachable("offset was not found within the record");
           })
-          .Default([](mlir::Type otherTy) {
-            llvm_unreachable("unexpected type");
-            return otherTy; // Even though this is unreachable, we need to
-                            // return a type to satisfy the return type of the
-                            // lambda.
+          .Default([&](mlir::Type otherTy) -> mlir::Type {
+            // Scalar or pointer type: the offset is a flat element count.
+            // This covers pointer arithmetic through a plain scalar base, e.g.
+            // a char* GlobalViewAttr whose pointee is !s8i rather than an
+            // array — the generated GEP is getelementptr i8, ptr @sym, i64 N.
+            int64_t eltSize =
+                (int64_t)layout.getTypeAllocSize(otherTy).getFixedValue();
+            assert(eltSize > 0 && "element size must be positive");
+            const auto [index, newOffset] =
+                getIndexAndNewOffset(offset, eltSize);
+            indices.push_back(index);
+            offset = newOffset;
+            return otherTy;
           });
 
   assert(subType);
@@ -175,7 +183,8 @@ uint64_t CIRGenBuilderTy::computeOffsetFromGlobalViewIndices(
       ty = arrayTy.getElementType();
       offset += layout.getTypeAllocSize(ty) * idx;
     } else {
-      llvm_unreachable("unexpected type");
+      // Scalar or pointer type: the index is a flat element count.
+      offset += (int64_t)layout.getTypeAllocSize(ty).getFixedValue() * idx;
     }
   }
   return offset;

--- a/clang/test/CIR/CodeGen/constexpr-ptr-offset.cpp
+++ b/clang/test/CIR/CodeGen/constexpr-ptr-offset.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+struct View {
+  const char *ptr;
+  int len;
+  constexpr View(const char *p, int n) : ptr(p), len(n) {}
+};
+
+constexpr const char *global_str = "hello";
+
+void test() {
+  constexpr View v(global_str + 2, 3);
+  (void)v;
+}
+
+// CIR-LABEL: @_Z4testv
+// CIR: #cir.global_view<@{{.*}}str{{.*}}, [2 : i32]> : !cir.ptr<!s8i>
+
+// LLVM: getelementptr{{.*}}(i8, ptr @{{.*}}str{{.*}}, i64 2)


### PR DESCRIPTION
computeGlobalViewIndicesFromFlatOffset navigated into array and record types to convert a flat byte offset into structured GEP indices, but fell through to llvm_unreachable("unexpected type") when the pointee type was scalar (e.g. !s8i for const char *).

This occurs when a constexpr struct is initialized with a pointer field whose value is a global-string-literal address plus a non-zero byte offset.  Classic CodeGen emits getelementptr i8, ptr @str, i64 N for this case; CIR represents the same thing as a GlobalViewAttr with index [N].  getAddrOfConstantStringFromLiteral creates the GlobalViewAttr with ptr-to-char as the pointee type (not ptr-to-array), so applyOffset passes a char type to the offset navigator rather than an array type.

The fix treats any non-array, non-record pointee type as a scalar element and computes offset / sizeof(element) as the GEP index, mirroring the array-element logic.  The same change applies to the inverse function computeOffsetFromGlobalViewIndices.