### PR TITLE
[CIR] Implement Direct+canFlatten in CallConvLowering

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
@@ -8,6 +8,7 @@
 
 #include "CIRABIRewriteContext.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/Dominance.h"
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 
@@ -15,14 +16,15 @@ using namespace cir;
 using namespace mlir;
 using namespace mlir::abi;
 
-// This rewrite context currently supports only the Direct (no coercion) and
-// Ignore classifications.  All other ArgKinds emit an errorNYI here rather
-// than silently passing through, because the IR they would produce is wrong
+// This rewrite context supports the Direct (with or without coercion),
+// Extend, Ignore, and Indirect-return (sret) classifications.  Indirect
+// arguments (byval) and Expand still emit an errorNYI here rather than
+// silently passing through, because the IR they would produce is wrong
 // (e.g. Expand should flatten an aggregate into multiple primitives, not
-// pass it through as a single value).  Subsequent PRs in the
-// CallConvLowering split series add the remaining kinds and the
-// signature-shaping behavior that goes with them (sret / byval insert
-// extra arguments, struct coercion replaces one argument with several).
+// pass it through as a single value).  byval and struct coercion are not
+// yet handled here; they need the signature-shaping that goes with them
+// (byval inserts an extra pointer argument, struct coercion replaces one
+// argument with several).
 
 namespace {
 
@@ -40,10 +42,10 @@ bool needsRewrite(const FunctionClassification &fc) {
 }
 
 /// Build the new argument-type list for a function whose ABI classification
-/// is \p fc.  This currently handles only Direct (no coercion) and Ignore;
-/// other kinds emit an error.  Classifications that add arguments (e.g.
-/// Indirect-sret would prepend a return-pointer arg) are not yet
-/// implemented and will arrive in a subsequent PR.
+/// is \p fc.  Handles Direct (with or without coercion), Extend, and Ignore.
+/// Indirect (byval) arguments and Expand emit an error.  The sret return
+/// pointer, when present, is prepended by rewriteFunctionDefinition rather
+/// than here.
 LogicalResult buildNewArgTypes(ArrayRef<Type> oldArgTypes,
                                const FunctionClassification &fc,
                                SmallVectorImpl<Type> &newArgTypes,
@@ -85,8 +87,9 @@ LogicalResult buildNewArgTypes(ArrayRef<Type> oldArgTypes,
 }
 
 /// Compute the new return type for a function whose return classification
-/// is \p retInfo.  As with `buildNewArgTypes`, only Direct (no coercion)
-/// and Ignore are implemented here; the remaining kinds emit an error.
+/// is \p retInfo.  Direct returns keep (or coerce to) their type, Ignore and
+/// Indirect (sret) returns become void, Extend keeps its type; Expand emits
+/// an error.
 Type computeNewReturnType(Type origRetTy, const ArgClassification &retInfo,
                           MLIRContext *ctx,
                           function_ref<InFlightDiagnostic()> emitError) {
@@ -107,9 +110,10 @@ Type computeNewReturnType(Type origRetTy, const ArgClassification &retInfo,
     // llvm.signext / llvm.zeroext res attribute attached separately below.
     return origRetTy;
   case ArgKind::Indirect:
-    emitError() << "Indirect return (sret) not yet implemented in "
-                << "CallConvLowering";
-    return nullptr;
+    // sret: the value is returned through a hidden pointer argument that
+    // rewriteFunctionDefinition prepends to the argument list, so the wire
+    // return type becomes void.
+    return cir::VoidType::get(ctx);
   }
   llvm_unreachable("all ArgKind cases handled");
 }
@@ -274,9 +278,12 @@ void insertReturnCoercion(FunctionOpInterface funcOp, Type origRetTy,
 /// For each Direct arg with a coerced type, change the block argument's type
 /// to the coerced type and insert a coercion at function entry that maps it
 /// back to the original type for body uses.
+/// \p sretOffset is 1 when the function has an sret return (a hidden return
+/// pointer is prepended as block argument 0), so classification index \p idx
+/// maps to block argument \p idx + \p sretOffset.
 void insertArgCoercion(FunctionOpInterface funcOp,
                        const FunctionClassification &fc, OpBuilder &rewriter,
-                       const DataLayout &dl) {
+                       const DataLayout &dl, unsigned sretOffset) {
   Region &body = funcOp->getRegion(0);
   if (body.empty())
     return;
@@ -285,10 +292,11 @@ void insertArgCoercion(FunctionOpInterface funcOp,
   for (auto [idx, ac] : llvm::enumerate(fc.argInfos)) {
     if (ac.kind != ArgKind::Direct || !ac.coercedType)
       continue;
-    if (idx >= entry.getNumArguments())
+    unsigned blockIdx = idx + sretOffset;
+    if (blockIdx >= entry.getNumArguments())
       continue;
 
-    BlockArgument blockArg = entry.getArgument(idx);
+    BlockArgument blockArg = entry.getArgument(blockIdx);
     Type oldArgTy = blockArg.getType();
     Type newArgTy = ac.coercedType;
     if (oldArgTy == newArgTy)
@@ -307,6 +315,111 @@ void insertArgCoercion(FunctionOpInterface funcOp,
     // (now of the original type != the alloca's pointee type).
     blockArg.replaceAllUsesExcept(adapted, coercionOps);
   }
+}
+
+/// Rewrite each cir.return so the return value flows through the sret
+/// pointer (the prepended first block argument) and the function returns
+/// void.
+///
+/// CIRGen emits a local `__retval` alloca and emits `cir.return %loaded`
+/// where `%loaded = cir.load __retval`.  The naive lowering -- store the
+/// loaded SSA value through the sret pointer -- byte-copies the record,
+/// which is wrong for non-trivially-copyable types: e.g. libstdc++'s SSO
+/// `std::string` has a `_M_p` pointer that aliases the source's internal
+/// `_M_local_buf`, so a byte-copy leaves the destination pointing at the
+/// source's (now-dying) stack storage and the destination's destructor
+/// later `free()`s a stack pointer.
+///
+/// Instead, route construction directly into the sret slot: find the
+/// `__retval` alloca, replace its uses with the sret pointer, and drop the
+/// trailing `cir.load __retval` so the rewritten return has no operand.
+/// The CIRGen-emitted constructor / store-into-`__retval` then targets the
+/// sret slot uniformly, matching classic CodeGen's "construct directly into
+/// `%agg.result`" pattern.
+///
+/// CIRGen emits one `%v = cir.load %__retval` / `cir.return %v` pair per
+/// return statement, and every such load reads the single `__retval`
+/// alloca (CIR does not merge returns into a shared epilogue block).  The
+/// alloca is therefore rewired to the sret pointer once; each cir.return is
+/// then collapsed to a bare return and its now-dead load erased.  This
+/// `cir.return (cir.load <alloca>)` shape is an invariant guaranteed by
+/// CIRGen, so it is asserted via `cast<>` rather than guarded with a
+/// fallback.
+void insertSRetStores(FunctionOpInterface funcOp, Type origRetTy,
+                      OpBuilder &rewriter) {
+  Value sretPtr = funcOp.getArguments()[0];
+
+  SmallVector<cir::ReturnOp> returnOps;
+  funcOp->walk([&](cir::ReturnOp retOp) { returnOps.push_back(retOp); });
+
+  cir::AllocaOp retAlloca = nullptr;
+  for (cir::ReturnOp retOp : returnOps) {
+    if (retOp.getInput().empty())
+      continue;
+
+    cir::LoadOp retLoad =
+        cast<cir::LoadOp>(retOp.getInput()[0].getDefiningOp());
+
+    // Rewire the shared `__retval` alloca to the sret pointer once; all
+    // other returns' loads point at the same alloca and are updated by the
+    // replaceAllUsesWith below.
+    if (!retAlloca) {
+      retAlloca = cast<cir::AllocaOp>(retLoad.getAddr().getDefiningOp());
+      retAlloca.getResult().replaceAllUsesWith(sretPtr);
+      retAlloca->erase();
+    }
+
+    rewriter.setInsertionPoint(retOp);
+    cir::ReturnOp::create(rewriter, retOp.getLoc());
+    retOp->erase();
+    if (retLoad.use_empty())
+      retLoad->erase();
+  }
+}
+
+/// Build the attribute dictionary for the sret slot (slot 0 of an
+/// sret-returning function or call).  Matches classic CodeGen's
+/// `sret(T) align A [noalias] writable dead_on_unwind`.  noalias is only
+/// valid on the callee's parameter, not at the call site, so it is gated by
+/// \p withNoalias.  Key order is irrelevant: DictionaryAttr sorts by name.
+SmallVector<NamedAttribute> buildSretSlotAttrs(OpBuilder &rewriter, Type retTy,
+                                               uint64_t align,
+                                               bool withNoalias) {
+  SmallVector<NamedAttribute> attrs;
+  attrs.push_back(rewriter.getNamedAttr("llvm.sret", TypeAttr::get(retTy)));
+  attrs.push_back(
+      rewriter.getNamedAttr("llvm.align", rewriter.getI64IntegerAttr(align)));
+  if (withNoalias)
+    attrs.push_back(
+        rewriter.getNamedAttr("llvm.noalias", rewriter.getUnitAttr()));
+  attrs.push_back(
+      rewriter.getNamedAttr("llvm.writable", rewriter.getUnitAttr()));
+  attrs.push_back(
+      rewriter.getNamedAttr("llvm.dead_on_unwind", rewriter.getUnitAttr()));
+  return attrs;
+}
+
+/// Prepend the sret slot's attrs at position 0 of newCall's arg_attrs.
+/// Called after the call has been rewritten with the sret pointer at
+/// operand 0, so the operand count now includes the sret slot.  \p argAttrs
+/// must already be shaped for the rewritten argument list (Extend slots
+/// carry signext/zeroext, Ignore slots dropped); it is shifted to slots
+/// 1..N behind the sret slot.
+void applySretSlotAttrs(cir::CallOp newCall, ArrayAttr argAttrs, Type retTy,
+                        uint64_t align, OpBuilder &rewriter) {
+  MLIRContext *ctx = newCall->getContext();
+  SmallVector<NamedAttribute> sretAttrs =
+      buildSretSlotAttrs(rewriter, retTy, align, /*withNoalias=*/false);
+
+  SmallVector<Attribute> newArgAttrs;
+  newArgAttrs.reserve(newCall.getArgOperands().size());
+  newArgAttrs.push_back(DictionaryAttr::get(ctx, sretAttrs));
+  if (argAttrs)
+    for (Attribute a : argAttrs)
+      newArgAttrs.push_back(a);
+  while (newArgAttrs.size() < newCall.getArgOperands().size())
+    newArgAttrs.push_back(DictionaryAttr::get(ctx));
+  newCall->setAttr("arg_attrs", ArrayAttr::get(ctx, newArgAttrs));
 }
 
 } // namespace
@@ -347,9 +460,28 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
     return failure();
   SmallVector<Type> newResultTypes = {newRetTy};
 
+  // sret return: the value is returned through a hidden pointer prepended as
+  // argument 0.  The wire return type was already set to void by
+  // computeNewReturnType.  Every classification index therefore maps to a
+  // block argument shifted by this offset in the body handling below.
+  bool hasSRet =
+      fc.returnInfo.kind == ArgKind::Indirect && !oldResultTypes.empty();
+  if (hasSRet)
+    newArgTypes.insert(newArgTypes.begin(), cir::PointerType::get(origRetTy));
+  unsigned sretOffset = hasSRet ? 1 : 0;
+
   if (funcOp.isDefinition()) {
     Region &body = funcOp->getRegion(0);
     if (!body.empty()) {
+      // Prepend the sret pointer block argument and route every cir.return
+      // through it before any index-based argument handling below (which
+      // then accounts for the +1 offset).
+      if (hasSRet) {
+        body.front().insertArgument(0u, cir::PointerType::get(origRetTy),
+                                    funcOp.getLoc());
+        insertSRetStores(funcOp, origRetTy, builder);
+      }
+
       // In-body coercion for Direct-with-coerce / Extend args: change
       // block-arg types to the coerced types and insert a memory roundtrip
       // at the top of the entry block that converts each coerced value back
@@ -357,7 +489,7 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
       // in-body cir.call operands) through the recovered value.  Done before
       // the Ignore-drop below so the entry block argument indices used here
       // still refer to the original positions.
-      insertArgCoercion(funcOp, fc, builder, dl);
+      insertArgCoercion(funcOp, fc, builder, dl, sretOffset);
 
       // Direct return with coerced type: insert a coercion at every
       // cir.return so the returned value matches the (coerced) return
@@ -379,16 +511,17 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
            blockIdx >= 0; --blockIdx) {
         if (fc.argInfos[blockIdx].kind != ArgKind::Ignore)
           continue;
-        if (static_cast<unsigned>(blockIdx) >= entry.getNumArguments())
+        unsigned realIdx = static_cast<unsigned>(blockIdx) + sretOffset;
+        if (realIdx >= entry.getNumArguments())
           continue;
-        BlockArgument arg = entry.getArgument(blockIdx);
+        BlockArgument arg = entry.getArgument(realIdx);
         if (!arg.use_empty()) {
           builder.setInsertionPointToStart(&entry);
           Value poison =
               createIgnoredValue(builder, funcOp.getLoc(), arg.getType());
           arg.replaceAllUsesWith(poison);
         }
-        entry.eraseArgument(blockIdx);
+        entry.eraseArgument(realIdx);
       }
     }
 
@@ -416,15 +549,31 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
   Type newFnTy = funcOp.cloneTypeWith(newArgTypes, newResultTypes);
   funcOp.setFunctionTypeAttr(TypeAttr::get(newFnTy));
 
-  // Rebuild arg_attrs when any arg is Ignore (dropped from the output array)
+  // Rebuild arg_attrs when the function has an sret slot (slot 0 needs the
+  // sret attribute set) or any arg is Ignore (dropped from the output array)
   // or Extend (needs llvm.signext / llvm.zeroext layered on).
   bool needsArgAttrUpdate =
-      llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
+      hasSRet || llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
         return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend;
       });
   if (needsArgAttrUpdate) {
     auto existing = funcOp->getAttrOfType<ArrayAttr>("arg_attrs");
-    funcOp->setAttr("arg_attrs", updateArgAttrs(ctx, existing, fc));
+    ArrayAttr updated = updateArgAttrs(ctx, existing, fc);
+    if (hasSRet) {
+      // Prepend the sret slot's attribute dict (slot 0); the per-argument
+      // dicts shift to slots 1..N.  noalias is valid only on the callee's
+      // parameter, so it is added only for definitions.
+      SmallVector<NamedAttribute> sretAttrs = buildSretSlotAttrs(
+          builder, origRetTy, fc.returnInfo.indirectAlign.value(),
+          /*withNoalias=*/funcOp.isDefinition());
+      SmallVector<Attribute> withSret;
+      withSret.push_back(DictionaryAttr::get(ctx, sretAttrs));
+      for (Attribute a : updated)
+        withSret.push_back(a);
+      funcOp->setAttr("arg_attrs", ArrayAttr::get(ctx, withSret));
+    } else {
+      funcOp->setAttr("arg_attrs", updated);
+    }
   }
 
   // Rebuild res_attrs: layer llvm.signext / llvm.zeroext onto an Extend
@@ -496,6 +645,90 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
   bool hasResult = call.getNumResults() > 0;
   Type origRetTy =
       hasResult ? call.getResult().getType() : cir::VoidType::get(ctx);
+
+  // sret return: prepend a return-slot pointer to the call, make the call
+  // return void, and load the result back out of the slot.  Handled as an
+  // early return because the coerce / extend / ignore return handling below
+  // does not apply to an indirect return.
+  if (fc.returnInfo.kind == ArgKind::Indirect && hasResult) {
+    auto ptrTy = cir::PointerType::get(origRetTy);
+    builder.setInsertionPoint(call);
+    uint64_t sretAlign = fc.returnInfo.indirectAlign.value();
+
+    // CIRGen emits `cir.store %callResult, %dest` when the call's result is
+    // bound to a local (e.g. `T s = make();`).  Allocating a fresh sret slot
+    // and copying into %dest would byte-copy the record, which is wrong for
+    // non-trivially-copyable types (the libstdc++ SSO `_M_p` pointer
+    // survives a byte-copy but ends up pointing at the dying temp's local
+    // buffer, so the destination's destructor later `free()`s a stack
+    // pointer).  When the result has a single store-into-%dest use, use
+    // %dest as the sret slot directly so construction flows into it,
+    // matching classic CodeGen's "pass %s as sret" pattern.  %dest must
+    // dominate the call so the rewritten call (which takes it as operand 0)
+    // does not use a value before its definition.
+    Value sretSlot = nullptr;
+    cir::StoreOp reuseStore = nullptr;
+    if (call.getResult().hasOneUse()) {
+      Operation *user = *call.getResult().getUsers().begin();
+      if (auto store = dyn_cast<cir::StoreOp>(user))
+        if (store.getValue() == call.getResult() &&
+            store.getAddr().getType() == ptrTy &&
+            mlir::DominanceInfo().properlyDominates(store.getAddr(), call)) {
+          sretSlot = store.getAddr();
+          reuseStore = store;
+        }
+    }
+    if (!sretSlot) {
+      auto alloca = cir::AllocaOp::create(
+          builder, call.getLoc(), ptrTy, origRetTy,
+          /*name=*/builder.getStringAttr("sret"),
+          /*alignment=*/builder.getI64IntegerAttr(sretAlign));
+      sretSlot = alloca;
+    }
+
+    SmallVector<Value> sretArgs;
+    sretArgs.push_back(sretSlot);
+    sretArgs.append(newArgs.begin(), newArgs.end());
+
+    Type sretVoidTy = cir::VoidType::get(ctx);
+    auto newCall = cir::CallOp::create(
+        builder, call.getLoc(), call.getCalleeAttr(), sretVoidTy, sretArgs);
+    for (NamedAttribute attr : call->getAttrs())
+      if (!newCall->hasAttr(attr.getName()))
+        newCall->setAttr(attr.getName(), attr.getValue());
+
+    // Shape the per-argument attrs exactly as the non-sret path does
+    // (signext / zeroext for Extend, drop Ignore slots) before prepending
+    // the sret slot, so sret composes correctly with Extend / Ignore args.
+    ArrayAttr argAttrs = call->getAttrOfType<ArrayAttr>("arg_attrs");
+    bool needsArgAttrUpdate =
+        llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
+          return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend;
+        });
+    if (needsArgAttrUpdate)
+      argAttrs = updateArgAttrs(ctx, argAttrs, fc);
+    applySretSlotAttrs(newCall, argAttrs, origRetTy, sretAlign, builder);
+
+    if (reuseStore) {
+      // The callee now constructs directly into the destination slot, so the
+      // original store-from-result is redundant; dropping it avoids a
+      // byte-copy of the record.
+      reuseStore->erase();
+    } else {
+      builder.setInsertionPointAfter(newCall);
+      auto load =
+          cir::LoadOp::create(builder, call.getLoc(), origRetTy, sretSlot,
+                              /*isDeref=*/mlir::UnitAttr(),
+                              /*isVolatile=*/mlir::UnitAttr(),
+                              /*alignment=*/mlir::IntegerAttr(),
+                              /*sync_scope=*/cir::SyncScopeKindAttr(),
+                              /*mem_order=*/cir::MemOrderAttr());
+      call.getResult().replaceAllUsesWith(load);
+    }
+    call->erase();
+    return success();
+  }
+
   Type callRetTy = origRetTy;
   if (fc.returnInfo.kind == ArgKind::Ignore && hasResult)
     callRetTy = cir::VoidType::get(ctx);

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
@@ -17,13 +17,19 @@ using namespace mlir;
 using namespace mlir::abi;
 
 // This rewrite context supports the Direct (with or without coercion),
-// Extend, Ignore, Indirect-return (sret), and Indirect-argument (byval and
-// byref) classifications.  For byval (ArgClassification::byVal == true) the
-// callee gets llvm.byval + llvm.noalias + llvm.noundef; for byref (byVal ==
-// false) the callee gets llvm.byref without the ownership attrs.  Both pass
-// through an alloca+store at the call site; the attribute distinction
-// communicates ownership semantics to the optimizer.  Expand still emits an
-// errorNYI rather than silently passing through.
+// Extend, Ignore, Indirect-return (sret), Indirect-argument (byval and
+// byref), and Expand (struct flattening) classifications.
+//
+// For byval (ArgClassification::byVal == true) the callee gets
+// llvm.byval + llvm.noalias + llvm.noundef; for byref (byVal == false)
+// the callee gets llvm.byref without the ownership attrs.  Both pass
+// through an alloca+store at the call site.
+//
+// For Expand, the single struct argument is replaced by N scalar arguments
+// (one per field).  At the callee, the N block arguments are reassembled
+// into the struct via an alloca+get_member+store+load sequence.  At the
+// call site, the struct operand is decomposed into its fields using
+// cir.extract_member.
 
 namespace {
 
@@ -41,10 +47,10 @@ bool needsRewrite(const FunctionClassification &fc) {
 }
 
 /// Build the new argument-type list for a function whose ABI classification
-/// is \p fc.  Handles Direct (with or without coercion), Extend, Ignore, and
-/// Indirect (byval and byref) arguments.  Expand emits an error.  The sret
-/// return pointer, when present, is prepended by rewriteFunctionDefinition
-/// rather than here.
+/// is \p fc.  Handles Direct (with or without coercion), Extend, Ignore,
+/// Indirect (byval and byref), and Expand (struct flattening) arguments.
+/// The sret return pointer, when present, is prepended by
+/// rewriteFunctionDefinition rather than here.
 LogicalResult buildNewArgTypes(ArrayRef<Type> oldArgTypes,
                                const FunctionClassification &fc,
                                SmallVectorImpl<Type> &newArgTypes,
@@ -63,10 +69,19 @@ LogicalResult buildNewArgTypes(ArrayRef<Type> oldArgTypes,
       break;
     case ArgKind::Ignore:
       break;
-    case ArgKind::Expand:
-      emitError() << "Expand at arg " << idx
-                  << " not yet implemented in CallConvLowering";
-      return failure();
+    case ArgKind::Expand: {
+      // Flatten the struct into one wire argument per field.  The
+      // reassembly in the callee body and the decomposition at the call
+      // site are handled by insertArgCoercion and rewriteCallSite.
+      auto recTy = cast<cir::RecordType>(origTy);
+      assert(recTy.isStruct() &&
+             "Expand classification requires a struct type, not a union");
+      assert(!recTy.getMembers().empty() &&
+             "Expand classification requires at least one struct field");
+      for (Type memberTy : recTy.getMembers())
+        newArgTypes.push_back(memberTy);
+      break;
+    }
     case ArgKind::Extend:
       // Extend keeps the original (narrow) type in the signature; the
       // sign/zero extension is communicated to LLVM via the llvm.signext /
@@ -146,7 +161,13 @@ ArrayAttr updateArgAttrs(MLIRContext *ctx, ArrayRef<Type> origArgTypes,
     DictionaryAttr existing = DictionaryAttr::get(ctx);
     if (existingArgAttrs && oldIdx < existingArgAttrs.size())
       existing = cast<DictionaryAttr>(existingArgAttrs[oldIdx]);
-    if (ac.kind == ArgKind::Extend) {
+    if (ac.kind == ArgKind::Expand) {
+      // Push one empty attribute dict per expanded field; the flattened
+      // scalar arguments carry no special ABI attributes.
+      auto recTy = cast<cir::RecordType>(origArgTypes[oldIdx]);
+      for (unsigned i = 0; i < recTy.getNumElements(); ++i)
+        newArgAttrs.push_back(DictionaryAttr::get(ctx));
+    } else if (ac.kind == ArgKind::Extend) {
       StringRef attrName = ac.signExtend ? "llvm.signext" : "llvm.zeroext";
       NamedAttribute extAttr(StringAttr::get(ctx, attrName),
                              UnitAttr::get(ctx));
@@ -314,12 +335,17 @@ void insertReturnCoercion(FunctionOpInterface funcOp, Type origRetTy,
 
 /// For each Direct arg with a coerced type, change the block argument's type
 /// to the coerced type and insert a coercion at function entry that maps it
-/// back to the original type for body uses.  For each Indirect (byval) arg,
-/// change the block argument's type to a pointer and insert a load at entry
-/// so the body sees the original value type.
+/// back to the original type for body uses.  For each Indirect (byval/byref)
+/// arg, change the block argument's type to a pointer and insert a load at
+/// entry so the body sees the original value type.  For each Expand arg,
+/// replace the single struct block argument with N scalar block arguments (one
+/// per field) and insert an alloca+get_member+store+load sequence at entry to
+/// reassemble the struct for body uses.
+///
 /// \p sretOffset is 1 when the function has an sret return (a hidden return
-/// pointer is prepended as block argument 0), so classification index \p idx
-/// maps to block argument \p idx + \p sretOffset.
+/// pointer is prepended as block argument 0).  Expand arguments expand the
+/// block argument count, so a running index tracks the current block argument
+/// position rather than computing \p classIdx + \p sretOffset directly.
 void insertArgCoercion(FunctionOpInterface funcOp,
                        const FunctionClassification &fc, OpBuilder &rewriter,
                        const DataLayout &dl, unsigned sretOffset) {
@@ -328,19 +354,78 @@ void insertArgCoercion(FunctionOpInterface funcOp,
     return;
   Block &entry = body.front();
 
-  for (auto [idx, ac] : llvm::enumerate(fc.argInfos)) {
-    unsigned blockIdx = idx + sretOffset;
-    if (blockIdx >= entry.getNumArguments())
-      continue;
+  // Running block argument index.  Each non-Expand classification occupies
+  // one block argument slot; each Expand classification occupies N slots
+  // (one per struct field), so the running index must be incremented by N
+  // rather than 1 after processing an Expand arg.
+  unsigned blockArgIdx = sretOffset;
 
-    BlockArgument blockArg = entry.getArgument(blockIdx);
+  for (const ArgClassification &ac : fc.argInfos) {
+    if (blockArgIdx >= entry.getNumArguments())
+      break;
+
+    if (ac.kind == ArgKind::Expand) {
+      // The block arg at blockArgIdx currently has the original struct type.
+      // Replace it with N scalar args (one per field) and insert an entry
+      // sequence that reassembles them back into the struct.
+      BlockArgument origArg = entry.getArgument(blockArgIdx);
+      auto recTy = cast<cir::RecordType>(origArg.getType());
+      assert(recTy.isStruct() &&
+             "Expand classification requires a struct type, not a union");
+      unsigned numFields = recTy.getNumElements();
+      assert(numFields > 0 &&
+             "Expand classification requires at least one struct field");
+      Location loc = funcOp.getLoc();
+
+      // Change slot 0 to field 0's type; insert slots 1..N-1 after it.
+      origArg.setType(recTy.getElementType(0));
+      for (unsigned f = 1; f < numFields; ++f)
+        entry.insertArgument(blockArgIdx + f, recTy.getElementType(f), loc);
+
+      // setInsertionPointToStart places each Expand arg's prolog at the
+      // top of the entry block.  When multiple Expand args are present
+      // the second call pushes its prolog before the first one, inverting
+      // the emission order relative to the classification order.  The SSA
+      // subgraphs are fully independent — each alloca is written through
+      // its own field block args — so the inverted ordering is safe.
+      rewriter.setInsertionPointToStart(&entry);
+      auto ptrTy = cir::PointerType::get(recTy);
+      uint64_t align = dl.getTypeABIAlignment(recTy);
+      auto slot = cir::AllocaOp::create(rewriter, loc, ptrTy, recTy,
+                                        rewriter.getStringAttr("expand"),
+                                        rewriter.getI64IntegerAttr(align));
+      SmallPtrSet<Operation *, 8> expandOps = {slot};
+      for (unsigned f = 0; f < numFields; ++f) {
+        Type fieldPtrTy = cir::PointerType::get(recTy.getElementType(f));
+        auto fieldPtr = cir::GetMemberOp::create(rewriter, loc, fieldPtrTy,
+                                                 slot, /*name=*/"",
+                                                 /*index=*/f);
+        expandOps.insert(fieldPtr);
+        auto storeOp = cir::StoreOp::create(
+            rewriter, loc, entry.getArgument(blockArgIdx + f), fieldPtr);
+        expandOps.insert(storeOp);
+      }
+      auto loaded = cir::LoadOp::create(rewriter, loc, recTy, slot.getResult());
+      expandOps.insert(loaded);
+
+      // Replace all original body uses of the struct block arg with the
+      // reassembled value.  The store for field 0 uses origArg and is
+      // in expandOps, so it is preserved.
+      origArg.replaceAllUsesExcept(loaded, expandOps);
+
+      blockArgIdx += numFields;
+      continue;
+    }
+
+    BlockArgument blockArg = entry.getArgument(blockArgIdx);
 
     if (ac.kind == ArgKind::Direct && ac.coercedType) {
       Type oldArgTy = blockArg.getType();
       Type newArgTy = ac.coercedType;
-      if (oldArgTy == newArgTy)
+      if (oldArgTy == newArgTy) {
+        blockArgIdx++;
         continue;
-
+      }
       blockArg.setType(newArgTy);
 
       rewriter.setInsertionPointToStart(&entry);
@@ -349,9 +434,10 @@ void insertArgCoercion(FunctionOpInterface funcOp,
                                    blockArg, funcOp, dl, coercionOps);
 
       // Replace blockArg uses with the adapted value, except inside the
-      // helper ops we just created.  This is critical: the StoreOp's value
-      // operand is blockArg, and if we naively replaceAllUses it gets swapped
-      // to adapted (now of the original type != the alloca's pointee type).
+      // helper ops we just created.  This is critical: the StoreOp's
+      // value operand is blockArg, and if we naively replaceAllUses it
+      // gets swapped to adapted (now of the original type != the alloca's
+      // pointee type).
       blockArg.replaceAllUsesExcept(adapted, coercionOps);
     } else if (ac.kind == ArgKind::Indirect) {
       // byval and byref: the wire type is !cir.ptr<T>.  Change the block arg
@@ -369,6 +455,9 @@ void insertArgCoercion(FunctionOpInterface funcOp,
       SmallPtrSet<Operation *, 1> loadOps = {loadOp};
       blockArg.replaceAllUsesExcept(loadOp.getResult(), loadOps);
     }
+    // Ignore, Extend, and Direct-without-coerce need no block-level changes.
+
+    blockArgIdx++;
   }
 }
 
@@ -556,17 +645,38 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
 
       Block &entry = body.front();
 
+      // Build a mapping from classification index to the block argument
+      // start index it occupies after insertArgCoercion has run.  Each
+      // non-Expand classification occupies one block argument slot; each
+      // Expand classification occupies N slots (its number of fields).
+      // This mapping is needed because the Ignore-drop loop below erases
+      // by block argument index, not by classification index.
+      SmallVector<unsigned> classToBlockArg(fc.argInfos.size());
+      {
+        unsigned runningIdx = sretOffset;
+        for (unsigned i = 0; i < fc.argInfos.size(); ++i) {
+          classToBlockArg[i] = runningIdx;
+          if (fc.argInfos[i].kind == ArgKind::Expand) {
+            auto recTy = cast<cir::RecordType>(oldArgTypes[i]);
+            runningIdx += recTy.getNumElements();
+          } else {
+            runningIdx += 1;
+          }
+        }
+      }
+
       // For each Ignored argument: drop the block argument and, if the
       // body still references it, replace those uses with a poison
       // constant.  Ignore classifications mean the value is empty / not
       // passed at the ABI level, so any remaining uses are vacuous;
-      // poison says exactly that.  Iterate in reverse so that earlier
-      // indices stay stable as later ones are erased.
-      for (int blockIdx = static_cast<int>(fc.argInfos.size()) - 1;
-           blockIdx >= 0; --blockIdx) {
-        if (fc.argInfos[blockIdx].kind != ArgKind::Ignore)
+      // poison says exactly that.  Iterate in reverse classification
+      // order so that erasing a later block argument does not shift the
+      // block argument indices for earlier classifications.
+      for (int classIdx = static_cast<int>(fc.argInfos.size()) - 1;
+           classIdx >= 0; --classIdx) {
+        if (fc.argInfos[classIdx].kind != ArgKind::Ignore)
           continue;
-        unsigned realIdx = static_cast<unsigned>(blockIdx) + sretOffset;
+        unsigned realIdx = classToBlockArg[classIdx];
         if (realIdx >= entry.getNumArguments())
           continue;
         BlockArgument arg = entry.getArgument(realIdx);
@@ -606,12 +716,12 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
 
   // Rebuild arg_attrs when the function has an sret slot (slot 0 needs the
   // sret attribute set) or any arg is Ignore (dropped from the output array),
-  // Extend (needs llvm.signext / llvm.zeroext), or Indirect (needs
-  // llvm.byval / llvm.align).
+  // Extend (needs llvm.signext / llvm.zeroext), Indirect (needs
+  // llvm.byval / llvm.align), or Expand (changes the argument count).
   bool needsArgAttrUpdate =
       hasSRet || llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
         return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend ||
-               ac.kind == ArgKind::Indirect;
+               ac.kind == ArgKind::Indirect || ac.kind == ArgKind::Expand;
       });
   if (needsArgAttrUpdate) {
     auto existing = funcOp->getAttrOfType<ArrayAttr>("arg_attrs");
@@ -660,20 +770,6 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
   MLIRContext *ctx = callOp->getContext();
   auto enclosingFunc = call->getParentOfType<FunctionOpInterface>();
 
-  for (auto [idx, ac] : llvm::enumerate(fc.argInfos)) {
-    switch (ac.kind) {
-    case ArgKind::Direct:
-    case ArgKind::Ignore:
-    case ArgKind::Extend:
-    case ArgKind::Indirect:
-      // All handled in the arg-building loop below.
-      break;
-    case ArgKind::Expand:
-      return call.emitOpError() << "Expand at call-site arg " << idx
-                                << " not yet implemented in CallConvLowering";
-    }
-  }
-
   builder.setInsertionPoint(call);
 
   SmallVector<Value> newArgs;
@@ -696,11 +792,24 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
     if (ac.kind == ArgKind::Ignore)
       continue;
     Value arg = argOperands[idx];
-    if (ac.kind == ArgKind::Direct && ac.coercedType &&
-        arg.getType() != ac.coercedType)
+    if (ac.kind == ArgKind::Expand) {
+      // Decompose the struct value into its constituent scalar fields and
+      // pass each as a separate argument.  cir.extract_member extracts the
+      // field value directly without a memory round-trip.
+      auto recTy = cast<cir::RecordType>(arg.getType());
+      assert(recTy.isStruct() &&
+             "Expand classification requires a struct type, not a union");
+      for (unsigned f = 0; f < recTy.getNumElements(); ++f) {
+        Value field =
+            cir::ExtractMemberOp::create(builder, call.getLoc(), arg, f);
+        newArgs.push_back(field);
+      }
+    } else if (ac.kind == ArgKind::Direct && ac.coercedType &&
+               arg.getType() != ac.coercedType) {
       arg = emitCoercion(builder, call.getLoc(), ac.coercedType, arg,
                          enclosingFunc, dl);
-    else if (ac.kind == ArgKind::Indirect) {
+      newArgs.push_back(arg);
+    } else if (ac.kind == ArgKind::Indirect) {
       // byval and byref: allocate a stack slot, copy the value in, and pass
       // the pointer.  The alloca+store pattern is identical for both; the
       // attribute distinction (llvm.byval vs llvm.byref) is applied by
@@ -715,8 +824,10 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
                                         builder.getI64IntegerAttr(align));
       cir::StoreOp::create(builder, call.getLoc(), arg, slot);
       arg = slot;
+      newArgs.push_back(arg);
+    } else {
+      newArgs.push_back(arg);
     }
-    newArgs.push_back(arg);
   }
 
   bool hasResult = call.getNumResults() > 0;
@@ -776,12 +887,12 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
 
     // Shape the per-argument attrs exactly as the non-sret path does
     // (signext / zeroext for Extend, drop Ignore slots, byval / align for
-    // Indirect) before prepending the sret slot.
+    // Indirect, flatten for Expand) before prepending the sret slot.
     ArrayAttr argAttrs = call->getAttrOfType<ArrayAttr>("arg_attrs");
     bool needsArgAttrUpdate =
         llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
           return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend ||
-                 ac.kind == ArgKind::Indirect;
+                 ac.kind == ArgKind::Indirect || ac.kind == ArgKind::Expand;
         });
     if (needsArgAttrUpdate)
       argAttrs = updateArgAttrs(ctx, origCallArgTypes, argAttrs, fc);
@@ -834,11 +945,12 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
 
   // Layer llvm.signext / llvm.zeroext onto the new call's arg_attrs and
   // res_attrs for Extend args/return.  Ignore args require a rebuild because
-  // their slots are dropped; Indirect args need llvm.byval / llvm.align.
+  // their slots are dropped; Indirect args need llvm.byval / llvm.align;
+  // Expand args change the argument count.
   bool needsArgAttrUpdate =
       llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
         return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend ||
-               ac.kind == ArgKind::Indirect;
+               ac.kind == ArgKind::Indirect || ac.kind == ArgKind::Expand;
       });
   if (needsArgAttrUpdate) {
     auto existing = call->getAttrOfType<ArrayAttr>("arg_attrs");

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
@@ -17,14 +17,13 @@ using namespace mlir;
 using namespace mlir::abi;
 
 // This rewrite context supports the Direct (with or without coercion),
-// Extend, Ignore, and Indirect-return (sret) classifications.  Indirect
-// arguments (byval) and Expand still emit an errorNYI here rather than
-// silently passing through, because the IR they would produce is wrong
-// (e.g. Expand should flatten an aggregate into multiple primitives, not
-// pass it through as a single value).  byval and struct coercion are not
-// yet handled here; they need the signature-shaping that goes with them
-// (byval inserts an extra pointer argument, struct coercion replaces one
-// argument with several).
+// Extend, Ignore, Indirect-return (sret), and Indirect-argument (byval and
+// byref) classifications.  For byval (ArgClassification::byVal == true) the
+// callee gets llvm.byval + llvm.noalias + llvm.noundef; for byref (byVal ==
+// false) the callee gets llvm.byref without the ownership attrs.  Both pass
+// through an alloca+store at the call site; the attribute distinction
+// communicates ownership semantics to the optimizer.  Expand still emits an
+// errorNYI rather than silently passing through.
 
 namespace {
 
@@ -42,10 +41,10 @@ bool needsRewrite(const FunctionClassification &fc) {
 }
 
 /// Build the new argument-type list for a function whose ABI classification
-/// is \p fc.  Handles Direct (with or without coercion), Extend, and Ignore.
-/// Indirect (byval) arguments and Expand emit an error.  The sret return
-/// pointer, when present, is prepended by rewriteFunctionDefinition rather
-/// than here.
+/// is \p fc.  Handles Direct (with or without coercion), Extend, Ignore, and
+/// Indirect (byval and byref) arguments.  Expand emits an error.  The sret
+/// return pointer, when present, is prepended by rewriteFunctionDefinition
+/// rather than here.
 LogicalResult buildNewArgTypes(ArrayRef<Type> oldArgTypes,
                                const FunctionClassification &fc,
                                SmallVectorImpl<Type> &newArgTypes,
@@ -78,9 +77,13 @@ LogicalResult buildNewArgTypes(ArrayRef<Type> oldArgTypes,
       newArgTypes.push_back(origTy);
       break;
     case ArgKind::Indirect:
-      emitError() << "Indirect at arg " << idx
-                  << " not yet implemented in CallConvLowering";
-      return failure();
+      // byval and byref both use a pointer wire type.  The attribute
+      // distinction (llvm.byval vs llvm.byref) is applied in updateArgAttrs;
+      // the call-site rewrite guards against byref separately because passing
+      // a byref pointer from a CIR value requires the original alloca address,
+      // which the rewriter does not yet track.
+      newArgTypes.push_back(cir::PointerType::get(origTy));
+      break;
     }
   }
   return success();
@@ -127,10 +130,13 @@ Value createIgnoredValue(OpBuilder &builder, Location loc, Type ty) {
   return cir::ConstantOp::create(builder, loc, ty, cir::PoisonAttr::get(ty));
 }
 
-/// Build an updated arg_attrs ArrayAttr that drops Ignore'd args and adds
-/// llvm.signext / llvm.zeroext on Extend args.  Preserves any existing arg
-/// attributes on retained arg slots.
-ArrayAttr updateArgAttrs(MLIRContext *ctx, ArrayAttr existingArgAttrs,
+/// Build an updated arg_attrs ArrayAttr that drops Ignore'd args, adds
+/// llvm.signext / llvm.zeroext on Extend args, and adds llvm.byval /
+/// llvm.align on Indirect args.  Preserves any existing arg attributes on
+/// retained arg slots.  \p origArgTypes provides the pre-rewrite type for
+/// each arg slot (needed to compute the llvm.byval pointee type).
+ArrayAttr updateArgAttrs(MLIRContext *ctx, ArrayRef<Type> origArgTypes,
+                         ArrayAttr existingArgAttrs,
                          const FunctionClassification &fc) {
   SmallVector<Attribute> newArgAttrs;
   newArgAttrs.reserve(fc.argInfos.size());
@@ -151,6 +157,37 @@ ArrayAttr updateArgAttrs(MLIRContext *ctx, ArrayAttr existingArgAttrs,
         attrs.push_back(extAttr);
         newArgAttrs.push_back(DictionaryAttr::get(ctx, attrs));
       }
+    } else if (ac.kind == ArgKind::Indirect) {
+      // byval: caller-allocated copy; callee receives pointer to copy.
+      // byref: callee receives pointer to the caller's original storage.
+      // Both use llvm.align(A).  The ownership flag differs: llvm.byval(T)
+      // vs llvm.byref(T).  The pointee type T is the pre-rewrite arg type.
+      //
+      // For byval, two additional attributes match classic CodeGen:
+      //   llvm.noundef — the copy is always fully defined (the caller's
+      //     original must be defined or UB has already occurred, and the
+      //     copy inherits that property).
+      //   llvm.noalias — the copy is a fresh caller-allocated alloca that
+      //     no other pointer in the function can alias.  Classic CodeGen
+      //     emits this when -fpass-by-value-is-noalias is set; here we
+      //     emit it unconditionally because our call-site rewrite always
+      //     produces a fresh alloca+store.
+      Type pointeeTy = origArgTypes[oldIdx];
+      StringRef ownershipAttr = ac.byVal ? "llvm.byval" : "llvm.byref";
+      SmallVector<NamedAttribute> attrs(existing.begin(), existing.end());
+      attrs.push_back(
+          NamedAttribute(StringAttr::get(ctx, "llvm.align"),
+                         IntegerAttr::get(IntegerType::get(ctx, 64),
+                                          ac.indirectAlign.value())));
+      attrs.push_back(NamedAttribute(StringAttr::get(ctx, ownershipAttr),
+                                     TypeAttr::get(pointeeTy)));
+      if (ac.byVal) {
+        attrs.push_back(NamedAttribute(StringAttr::get(ctx, "llvm.noalias"),
+                                       UnitAttr::get(ctx)));
+        attrs.push_back(NamedAttribute(StringAttr::get(ctx, "llvm.noundef"),
+                                       UnitAttr::get(ctx)));
+      }
+      newArgAttrs.push_back(DictionaryAttr::get(ctx, attrs));
     } else {
       newArgAttrs.push_back(existing);
     }
@@ -277,7 +314,9 @@ void insertReturnCoercion(FunctionOpInterface funcOp, Type origRetTy,
 
 /// For each Direct arg with a coerced type, change the block argument's type
 /// to the coerced type and insert a coercion at function entry that maps it
-/// back to the original type for body uses.
+/// back to the original type for body uses.  For each Indirect (byval) arg,
+/// change the block argument's type to a pointer and insert a load at entry
+/// so the body sees the original value type.
 /// \p sretOffset is 1 when the function has an sret return (a hidden return
 /// pointer is prepended as block argument 0), so classification index \p idx
 /// maps to block argument \p idx + \p sretOffset.
@@ -290,30 +329,46 @@ void insertArgCoercion(FunctionOpInterface funcOp,
   Block &entry = body.front();
 
   for (auto [idx, ac] : llvm::enumerate(fc.argInfos)) {
-    if (ac.kind != ArgKind::Direct || !ac.coercedType)
-      continue;
     unsigned blockIdx = idx + sretOffset;
     if (blockIdx >= entry.getNumArguments())
       continue;
 
     BlockArgument blockArg = entry.getArgument(blockIdx);
-    Type oldArgTy = blockArg.getType();
-    Type newArgTy = ac.coercedType;
-    if (oldArgTy == newArgTy)
-      continue;
 
-    blockArg.setType(newArgTy);
+    if (ac.kind == ArgKind::Direct && ac.coercedType) {
+      Type oldArgTy = blockArg.getType();
+      Type newArgTy = ac.coercedType;
+      if (oldArgTy == newArgTy)
+        continue;
 
-    rewriter.setInsertionPointToStart(&entry);
-    SmallPtrSet<Operation *, 4> coercionOps;
-    Value adapted = emitCoercion(rewriter, funcOp.getLoc(), oldArgTy, blockArg,
-                                 funcOp, dl, coercionOps);
+      blockArg.setType(newArgTy);
 
-    // Replace blockArg uses with the adapted value, except inside the helper
-    // ops we just created.  This is critical: the StoreOp's value operand is
-    // blockArg, and if we naively replaceAllUses it gets swapped to adapted
-    // (now of the original type != the alloca's pointee type).
-    blockArg.replaceAllUsesExcept(adapted, coercionOps);
+      rewriter.setInsertionPointToStart(&entry);
+      SmallPtrSet<Operation *, 4> coercionOps;
+      Value adapted = emitCoercion(rewriter, funcOp.getLoc(), oldArgTy,
+                                   blockArg, funcOp, dl, coercionOps);
+
+      // Replace blockArg uses with the adapted value, except inside the
+      // helper ops we just created.  This is critical: the StoreOp's value
+      // operand is blockArg, and if we naively replaceAllUses it gets swapped
+      // to adapted (now of the original type != the alloca's pointee type).
+      blockArg.replaceAllUsesExcept(adapted, coercionOps);
+    } else if (ac.kind == ArgKind::Indirect) {
+      // byval and byref: the wire type is !cir.ptr<T>.  Change the block arg
+      // to the pointer type and insert a load so the body sees the original T.
+      // The body transformation is the same for both; the distinction between
+      // byval (llvm.byval) and byref (llvm.byref) is in the arg attributes
+      // applied by updateArgAttrs.
+      Type origTy = blockArg.getType();
+      auto ptrTy = cir::PointerType::get(origTy);
+      blockArg.setType(ptrTy);
+
+      rewriter.setInsertionPointToStart(&entry);
+      auto loadOp =
+          cir::LoadOp::create(rewriter, funcOp.getLoc(), origTy, blockArg);
+      SmallPtrSet<Operation *, 1> loadOps = {loadOp};
+      blockArg.replaceAllUsesExcept(loadOp.getResult(), loadOps);
+    }
   }
 }
 
@@ -550,15 +605,17 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
   funcOp.setFunctionTypeAttr(TypeAttr::get(newFnTy));
 
   // Rebuild arg_attrs when the function has an sret slot (slot 0 needs the
-  // sret attribute set) or any arg is Ignore (dropped from the output array)
-  // or Extend (needs llvm.signext / llvm.zeroext layered on).
+  // sret attribute set) or any arg is Ignore (dropped from the output array),
+  // Extend (needs llvm.signext / llvm.zeroext), or Indirect (needs
+  // llvm.byval / llvm.align).
   bool needsArgAttrUpdate =
       hasSRet || llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
-        return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend;
+        return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend ||
+               ac.kind == ArgKind::Indirect;
       });
   if (needsArgAttrUpdate) {
     auto existing = funcOp->getAttrOfType<ArrayAttr>("arg_attrs");
-    ArrayAttr updated = updateArgAttrs(ctx, existing, fc);
+    ArrayAttr updated = updateArgAttrs(ctx, oldArgTypes, existing, fc);
     if (hasSRet) {
       // Prepend the sret slot's attribute dict (slot 0); the per-argument
       // dicts shift to slots 1..N.  noalias is valid only on the callee's
@@ -607,16 +664,12 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
     switch (ac.kind) {
     case ArgKind::Direct:
     case ArgKind::Ignore:
+    case ArgKind::Extend:
+    case ArgKind::Indirect:
+      // All handled in the arg-building loop below.
       break;
     case ArgKind::Expand:
       return call.emitOpError() << "Expand at call-site arg " << idx
-                                << " not yet implemented in CallConvLowering";
-    case ArgKind::Extend:
-      // Direct (with or without coercion), Ignore, Expand, and Extend are
-      // all handled below.  Extend is attribute-only at the IR level.
-      break;
-    case ArgKind::Indirect:
-      return call.emitOpError() << "Indirect at call-site arg " << idx
                                 << " not yet implemented in CallConvLowering";
     }
   }
@@ -626,6 +679,14 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
   SmallVector<Value> newArgs;
   ValueRange argOperands = call.getArgOperands();
   newArgs.reserve(argOperands.size());
+
+  // Capture original arg types before building newArgs (byval slots change
+  // the wire argument from T to !cir.ptr<T>, so we save the pre-rewrite
+  // types here for use in updateArgAttrs).
+  SmallVector<Type> origCallArgTypes;
+  origCallArgTypes.reserve(argOperands.size());
+  for (Value v : argOperands)
+    origCallArgTypes.push_back(v.getType());
   if (argOperands.size() > fc.argInfos.size())
     return call.emitOpError()
            << "variadic arguments not yet implemented in CallConvLowering";
@@ -639,6 +700,22 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
         arg.getType() != ac.coercedType)
       arg = emitCoercion(builder, call.getLoc(), ac.coercedType, arg,
                          enclosingFunc, dl);
+    else if (ac.kind == ArgKind::Indirect) {
+      // byval and byref: allocate a stack slot, copy the value in, and pass
+      // the pointer.  The alloca+store pattern is identical for both; the
+      // attribute distinction (llvm.byval vs llvm.byref) is applied by
+      // updateArgAttrs.  byref does not receive llvm.noalias or llvm.noundef
+      // because it does not assert exclusive ownership of the storage.
+      Type argTy = arg.getType();
+      auto ptrTy = cir::PointerType::get(argTy);
+      uint64_t align = ac.indirectAlign.value();
+      StringRef slotName = ac.byVal ? "byval" : "byref";
+      auto slot = cir::AllocaOp::create(builder, call.getLoc(), ptrTy, argTy,
+                                        builder.getStringAttr(slotName),
+                                        builder.getI64IntegerAttr(align));
+      cir::StoreOp::create(builder, call.getLoc(), arg, slot);
+      arg = slot;
+    }
     newArgs.push_back(arg);
   }
 
@@ -698,15 +775,16 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
         newCall->setAttr(attr.getName(), attr.getValue());
 
     // Shape the per-argument attrs exactly as the non-sret path does
-    // (signext / zeroext for Extend, drop Ignore slots) before prepending
-    // the sret slot, so sret composes correctly with Extend / Ignore args.
+    // (signext / zeroext for Extend, drop Ignore slots, byval / align for
+    // Indirect) before prepending the sret slot.
     ArrayAttr argAttrs = call->getAttrOfType<ArrayAttr>("arg_attrs");
     bool needsArgAttrUpdate =
         llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
-          return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend;
+          return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend ||
+                 ac.kind == ArgKind::Indirect;
         });
     if (needsArgAttrUpdate)
-      argAttrs = updateArgAttrs(ctx, argAttrs, fc);
+      argAttrs = updateArgAttrs(ctx, origCallArgTypes, argAttrs, fc);
     applySretSlotAttrs(newCall, argAttrs, origRetTy, sretAlign, builder);
 
     if (reuseStore) {
@@ -755,15 +833,17 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
   }
 
   // Layer llvm.signext / llvm.zeroext onto the new call's arg_attrs and
-  // res_attrs for Extend args/return.  Ignore args also require a rebuild
-  // because their slots are dropped from the output array.
+  // res_attrs for Extend args/return.  Ignore args require a rebuild because
+  // their slots are dropped; Indirect args need llvm.byval / llvm.align.
   bool needsArgAttrUpdate =
       llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
-        return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend;
+        return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend ||
+               ac.kind == ArgKind::Indirect;
       });
   if (needsArgAttrUpdate) {
     auto existing = call->getAttrOfType<ArrayAttr>("arg_attrs");
-    newCall->setAttr("arg_attrs", updateArgAttrs(ctx, existing, fc));
+    newCall->setAttr("arg_attrs",
+                     updateArgAttrs(ctx, origCallArgTypes, existing, fc));
   }
   if (fc.returnInfo.kind == ArgKind::Extend) {
     auto existing = call->getAttrOfType<ArrayAttr>("res_attrs");

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
@@ -30,6 +30,13 @@ using namespace mlir::abi;
 // into the struct via an alloca+get_member+store+load sequence.  At the
 // call site, the struct operand is decomposed into its fields using
 // cir.extract_member.
+//
+// For Direct + canFlatten (where the coerced type is a multi-field struct),
+// the coerced struct is similarly flattened into N individual wire arguments.
+// The callee reassembles the N scalar block args into the coerced struct,
+// then coerces to the original argument type if the two types differ.  The
+// call site coerces the original type to the coerced struct, then extracts
+// each field as a separate call argument.
 
 namespace {
 
@@ -44,6 +51,26 @@ bool needsRewrite(const FunctionClassification &fc) {
     if ((ac.kind != ArgKind::Direct) || ac.coercedType)
       return true;
   return false;
+}
+
+/// Return the coerced RecordType for a Direct classification that should be
+/// flattened into individual scalar arguments, or a null type if the
+/// classification does not call for flattening.
+///
+/// Flattening applies when all four conditions hold:
+///   1. The classification is Direct with a non-null coercedType.
+///   2. canFlatten is set.
+///   3. The coercedType is a struct (not a union).
+///   4. The struct has more than one field (single-field structs are already
+///      scalar; flattening them produces no benefit and classic CodeGen skips
+///      them for the same reason).
+cir::RecordType getFlattenedCoercedType(const ArgClassification &ac) {
+  if (ac.kind != ArgKind::Direct || !ac.coercedType || !ac.canFlatten)
+    return {};
+  auto recTy = dyn_cast<cir::RecordType>(ac.coercedType);
+  if (!recTy || !recTy.isStruct() || recTy.getNumElements() <= 1)
+    return {};
+  return recTy;
 }
 
 /// Build the new argument-type list for a function whose ABI classification
@@ -61,11 +88,20 @@ LogicalResult buildNewArgTypes(ArrayRef<Type> oldArgTypes,
     Type origTy = oldArgTypes[idx];
     switch (ac.kind) {
     case ArgKind::Direct:
-      // Direct with a coerced type means the wire signature uses the
-      // coerced type; the body still expects origTy and we'll insert a
-      // coercion at the entry block.  Direct without a coerced type is a
-      // true pass-through.
-      newArgTypes.push_back(ac.coercedType ? ac.coercedType : origTy);
+      // Direct with canFlatten and a struct coerced type: push one wire type
+      // per field of the coerced struct rather than the struct itself.
+      // Single-field coerced structs fall through to the non-flatten path —
+      // the struct is already scalar-sized and flattening adds no value.
+      if (auto flatTy = getFlattenedCoercedType(ac)) {
+        for (Type memberTy : flatTy.getMembers())
+          newArgTypes.push_back(memberTy);
+      } else {
+        // Direct with a coerced type: the wire signature uses the coerced
+        // type; the body still expects origTy and insertArgCoercion recovers
+        // it via a memory round-trip.  Direct without coercion is a
+        // pass-through.
+        newArgTypes.push_back(ac.coercedType ? ac.coercedType : origTy);
+      }
       break;
     case ArgKind::Ignore:
       break;
@@ -161,9 +197,12 @@ ArrayAttr updateArgAttrs(MLIRContext *ctx, ArrayRef<Type> origArgTypes,
     DictionaryAttr existing = DictionaryAttr::get(ctx);
     if (existingArgAttrs && oldIdx < existingArgAttrs.size())
       existing = cast<DictionaryAttr>(existingArgAttrs[oldIdx]);
-    if (ac.kind == ArgKind::Expand) {
-      // Push one empty attribute dict per expanded field; the flattened
-      // scalar arguments carry no special ABI attributes.
+    if (auto flatTy = getFlattenedCoercedType(ac)) {
+      // Direct + canFlatten: one empty dict per flattened field.
+      for (unsigned i = 0; i < flatTy.getNumElements(); ++i)
+        newArgAttrs.push_back(DictionaryAttr::get(ctx));
+    } else if (ac.kind == ArgKind::Expand) {
+      // Pure Expand: one empty dict per struct field.
       auto recTy = cast<cir::RecordType>(origArgTypes[oldIdx]);
       for (unsigned i = 0; i < recTy.getNumElements(); ++i)
         newArgAttrs.push_back(DictionaryAttr::get(ctx));
@@ -419,6 +458,63 @@ void insertArgCoercion(FunctionOpInterface funcOp,
 
     BlockArgument blockArg = entry.getArgument(blockArgIdx);
 
+    if (auto flatTy = getFlattenedCoercedType(ac)) {
+      // Direct + canFlatten: the coerced type is a struct whose fields become
+      // individual wire arguments.  The reconstruction mirrors the Expand path
+      // — replace the single block arg with N scalar block args, store them
+      // into an alloca of the coerced struct type, reload — but then applies
+      // an additional coercion from the coerced struct type to the original
+      // argument type if the two differ in layout.
+      unsigned numFields = flatTy.getNumElements();
+      assert(numFields >= 2 && "getFlattenedCoercedType guarantees >1 fields");
+      Type origTy = blockArg.getType();
+      Location loc = funcOp.getLoc();
+
+      // Change slot 0 to field 0's type; insert slots 1..N-1 after it.
+      blockArg.setType(flatTy.getElementType(0));
+      for (unsigned f = 1; f < numFields; ++f)
+        entry.insertArgument(blockArgIdx + f, flatTy.getElementType(f), loc);
+
+      // setInsertionPointToStart: see comment in the Expand arm above.
+      rewriter.setInsertionPointToStart(&entry);
+      auto flatPtrTy = cir::PointerType::get(flatTy);
+      uint64_t flatAlign = dl.getTypeABIAlignment(flatTy);
+      auto flatSlot = cir::AllocaOp::create(
+          rewriter, loc, flatPtrTy, flatTy, rewriter.getStringAttr("coerce"),
+          rewriter.getI64IntegerAttr(flatAlign));
+      SmallPtrSet<Operation *, 8> flattenOps = {flatSlot};
+      for (unsigned f = 0; f < numFields; ++f) {
+        Type fieldPtrTy = cir::PointerType::get(flatTy.getElementType(f));
+        auto fieldPtr = cir::GetMemberOp::create(rewriter, loc, fieldPtrTy,
+                                                 flatSlot, /*name=*/"",
+                                                 /*index=*/f);
+        flattenOps.insert(fieldPtr);
+        auto storeOp = cir::StoreOp::create(
+            rewriter, loc, entry.getArgument(blockArgIdx + f), fieldPtr);
+        flattenOps.insert(storeOp);
+      }
+      auto flatLoaded =
+          cir::LoadOp::create(rewriter, loc, flatTy, flatSlot.getResult());
+      flattenOps.insert(flatLoaded);
+
+      // If the coerced struct type differs from the original argument type,
+      // insert a memory round-trip to recover the original type for body uses.
+      Value finalVal = flatLoaded;
+      if (origTy != flatTy) {
+        SmallPtrSet<Operation *, 4> coercionOps;
+        finalVal = emitCoercion(rewriter, loc, origTy, flatLoaded, funcOp, dl,
+                                coercionOps);
+        flattenOps.insert(coercionOps.begin(), coercionOps.end());
+      }
+
+      // Replace all original body uses of the struct block arg (now field 0)
+      // with the recovered original-type value.
+      blockArg.replaceAllUsesExcept(finalVal, flattenOps);
+
+      blockArgIdx += numFields;
+      continue;
+    }
+
     if (ac.kind == ArgKind::Direct && ac.coercedType) {
       Type oldArgTy = blockArg.getType();
       Type newArgTy = ac.coercedType;
@@ -656,7 +752,10 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
         unsigned runningIdx = sretOffset;
         for (unsigned i = 0; i < fc.argInfos.size(); ++i) {
           classToBlockArg[i] = runningIdx;
-          if (fc.argInfos[i].kind == ArgKind::Expand) {
+          if (auto flatTy = getFlattenedCoercedType(fc.argInfos[i])) {
+            // Direct + canFlatten: N slots, one per coerced struct field.
+            runningIdx += flatTy.getNumElements();
+          } else if (fc.argInfos[i].kind == ArgKind::Expand) {
             auto recTy = cast<cir::RecordType>(oldArgTypes[i]);
             runningIdx += recTy.getNumElements();
           } else {
@@ -717,11 +816,13 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
   // Rebuild arg_attrs when the function has an sret slot (slot 0 needs the
   // sret attribute set) or any arg is Ignore (dropped from the output array),
   // Extend (needs llvm.signext / llvm.zeroext), Indirect (needs
-  // llvm.byval / llvm.align), or Expand (changes the argument count).
+  // llvm.byval / llvm.align), Expand or Direct+canFlatten (both change the
+  // argument count).
   bool needsArgAttrUpdate =
       hasSRet || llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
         return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend ||
-               ac.kind == ArgKind::Indirect || ac.kind == ArgKind::Expand;
+               ac.kind == ArgKind::Indirect || ac.kind == ArgKind::Expand ||
+               getFlattenedCoercedType(ac);
       });
   if (needsArgAttrUpdate) {
     auto existing = funcOp->getAttrOfType<ArrayAttr>("arg_attrs");
@@ -792,7 +893,21 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
     if (ac.kind == ArgKind::Ignore)
       continue;
     Value arg = argOperands[idx];
-    if (ac.kind == ArgKind::Expand) {
+    if (auto flatTy = getFlattenedCoercedType(ac)) {
+      // Direct + canFlatten: coerce the struct to the ABI-coerced struct type
+      // and then extract each field as a separate call argument.  The coercion
+      // is a memory round-trip when the original and coerced types differ in
+      // layout; when they are the same CIR type the coercion is skipped.
+      Value coerced = arg;
+      if (arg.getType() != flatTy)
+        coerced = emitCoercion(builder, call.getLoc(), flatTy, arg,
+                               enclosingFunc, dl);
+      for (unsigned f = 0; f < flatTy.getNumElements(); ++f) {
+        Value field =
+            cir::ExtractMemberOp::create(builder, call.getLoc(), coerced, f);
+        newArgs.push_back(field);
+      }
+    } else if (ac.kind == ArgKind::Expand) {
       // Decompose the struct value into its constituent scalar fields and
       // pass each as a separate argument.  cir.extract_member extracts the
       // field value directly without a memory round-trip.
@@ -887,12 +1002,14 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
 
     // Shape the per-argument attrs exactly as the non-sret path does
     // (signext / zeroext for Extend, drop Ignore slots, byval / align for
-    // Indirect, flatten for Expand) before prepending the sret slot.
+    // Indirect, flatten for Expand and Direct+canFlatten) before prepending
+    // the sret slot.
     ArrayAttr argAttrs = call->getAttrOfType<ArrayAttr>("arg_attrs");
     bool needsArgAttrUpdate =
         llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
           return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend ||
-                 ac.kind == ArgKind::Indirect || ac.kind == ArgKind::Expand;
+                 ac.kind == ArgKind::Indirect || ac.kind == ArgKind::Expand ||
+                 getFlattenedCoercedType(ac);
         });
     if (needsArgAttrUpdate)
       argAttrs = updateArgAttrs(ctx, origCallArgTypes, argAttrs, fc);
@@ -946,11 +1063,12 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
   // Layer llvm.signext / llvm.zeroext onto the new call's arg_attrs and
   // res_attrs for Extend args/return.  Ignore args require a rebuild because
   // their slots are dropped; Indirect args need llvm.byval / llvm.align;
-  // Expand args change the argument count.
+  // Expand and Direct+canFlatten args change the argument count.
   bool needsArgAttrUpdate =
       llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
         return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend ||
-               ac.kind == ArgKind::Indirect || ac.kind == ArgKind::Expand;
+               ac.kind == ArgKind::Indirect || ac.kind == ArgKind::Expand ||
+               getFlattenedCoercedType(ac);
       });
   if (needsArgAttrUpdate) {
     auto existing = call->getAttrOfType<ArrayAttr>("arg_attrs");

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.h
@@ -11,10 +11,9 @@
 // rewrites a cir.func signature, the function body, and call sites to match
 // the ABI-lowered shape.
 //
-// This file currently handles Direct (pass-through and coerce-in-registers),
-// Extend, and Ignore.  The remaining ArgKind handlers (Indirect, Expand)
-// are added by subsequent PRs in the calling-convention-lowering split
-// series.
+// This file handles Direct (pass-through and coerce-in-registers), Extend,
+// Ignore, and an Indirect (sret) return.  Indirect arguments (byval) and
+// Expand still emit an errorNYI.
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.h
@@ -12,8 +12,8 @@
 // the ABI-lowered shape.
 //
 // This file handles Direct (pass-through and coerce-in-registers), Extend,
-// Ignore, and an Indirect (sret) return.  Indirect arguments (byval) and
-// Expand still emit an errorNYI.
+// Ignore, Indirect (sret return, byval and byref arguments), and Expand
+// (struct flattening into scalar fields).
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/test/CIR/Transforms/abi-lowering/coerce-record-to-record-via-memory.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/coerce-record-to-record-via-memory.cir
@@ -8,7 +8,7 @@
 
 #coerce_vec4_to_twoi64 = {
   return = { kind = "direct" },
-  args   = [ { kind = "direct", coerced_type = !rec_TwoI64 } ]
+  args   = [ { kind = "direct", coerced_type = !rec_TwoI64, can_flatten = false } ]
 }
 
 #caller_no_args = {

--- a/clang/test/CIR/Transforms/abi-lowering/direct-flatten.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/direct-flatten.cir
@@ -1,0 +1,190 @@
+// RUN: cir-opt %s -cir-call-conv-lowering="classification-attr=test_classify" \
+// RUN:   | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+
+// Named source structs.
+!rec_TwoLong  = !cir.struct<"TwoLong"  {!s64i, !s64i}>
+!rec_ThreeInt = !cir.struct<"ThreeInt" {!s32i, !s32i, !s32i}>
+// dim3-equivalent: three i32 fields totalling 12 bytes.
+!rec_Dim3     = !cir.struct<"Dim3"     {!s32i, !s32i, !s32i}>
+
+// ABI-coerced anonymous structs.  MLIR auto-generates their aliases
+// (!rec_anon_struct, !rec_anon_struct1, etc.) in encounter order.
+!rec_coerced_two   = !cir.struct<{!s64i, !s64i}>
+!rec_coerced_three = !cir.struct<{!s32i, !s32i, !s32i}>
+// x86-64 SysV packs dim3's first two i32s into an i64; the third i32
+// is a separate half of the second eightbyte.
+!rec_coerced_dim3  = !cir.struct<{!s64i, !s32i}>
+
+#flatten_two = {
+  return = { kind = "direct" },
+  args   = [ { kind = "direct", coerced_type = !rec_coerced_two,
+               can_flatten = true } ]
+}
+
+#flatten_three = {
+  return = { kind = "direct" },
+  args   = [ { kind = "direct", coerced_type = !rec_coerced_three,
+               can_flatten = true } ]
+}
+
+#flatten_dim3 = {
+  return = { kind = "direct" },
+  args   = [ { kind = "direct", coerced_type = !rec_coerced_dim3,
+               can_flatten = true } ]
+}
+
+#flatten_ignore_flatten = {
+  return = { kind = "direct" },
+  args   = [ { kind = "direct", coerced_type = !rec_coerced_two,
+               can_flatten = true },
+             { kind = "ignore" },
+             { kind = "direct", coerced_type = !rec_coerced_two,
+               can_flatten = true } ]
+}
+
+#passthrough = {
+  return = { kind = "direct" },
+  args   = [ ]
+}
+
+module attributes {
+  dlti.dl_spec = #dlti.dl_spec<
+    #dlti.dl_entry<i32, dense<32>: vector<2xi64>>,
+    #dlti.dl_entry<i64, dense<64>: vector<2xi64>>>
+} {
+
+// Callee: the single TwoLong arg is replaced by two i64 block args.  At entry
+// the scalars are stored into a coerced-struct alloca, then coerced back to
+// TwoLong for body uses.
+
+cir.func @takes_two_long(%arg0: !rec_TwoLong)
+    attributes { test_classify = #flatten_two } {
+  %0 = cir.alloca !rec_TwoLong, !cir.ptr<!rec_TwoLong>, ["p"] {alignment = 8 : i64}
+  cir.store %arg0, %0 : !rec_TwoLong, !cir.ptr<!rec_TwoLong>
+  cir.return
+}
+
+// CHECK:      cir.func{{.*}} @takes_two_long(%[[F0:.*]]: !s64i, %[[F1:.*]]: !s64i)
+// Two ["coerce"] allocas: the coercion round-trip alloca and the flatSlot.
+// CHECK:        %{{.*}} = cir.alloca {{.*}} ["coerce"]
+// CHECK:        %[[FSLOT:.*]] = cir.alloca {{.*}} ["coerce"]
+// Store each field block arg into the flat slot.
+// CHECK:        %[[P0:.*]] = cir.get_member %[[FSLOT]][0]
+// CHECK:        cir.store %[[F0]], %[[P0]] : !s64i, !cir.ptr<!s64i>
+// CHECK:        %[[P1:.*]] = cir.get_member %[[FSLOT]][1]
+// CHECK:        cir.store %[[F1]], %[[P1]] : !s64i, !cir.ptr<!s64i>
+// Reload the coerced struct, coerce to TwoLong, use in body.
+// CHECK:        %{{.*}} = cir.load %[[FSLOT]]
+// CHECK:        cir.cast bitcast %{{.*}} : !cir.ptr<{{.*}}> -> !cir.ptr<!rec_TwoLong>
+// CHECK:        %[[TVAL:.*]] = cir.load %{{.*}} : !cir.ptr<!rec_TwoLong>, !rec_TwoLong
+// CHECK:        %[[P:.*]] = cir.alloca !rec_TwoLong, !cir.ptr<!rec_TwoLong>, ["p"]
+// CHECK:        cir.store %[[TVAL]], %[[P]] : !rec_TwoLong, !cir.ptr<!rec_TwoLong>
+
+// Forward declaration: two i64 wire args, no body.
+
+cir.func private @takes_two_long_decl(!rec_TwoLong)
+    attributes { test_classify = #flatten_two }
+
+// CHECK:      cir.func{{.*}} @takes_two_long_decl(!s64i, !s64i)
+// CHECK-NOT:  !rec_TwoLong
+
+// Caller: the TwoLong operand is coerced to the anonymous struct type via a
+// memory round-trip, then each field is extracted as a separate call argument.
+
+cir.func @caller_two_long() attributes { test_classify = #passthrough } {
+  %0 = cir.alloca !rec_TwoLong, !cir.ptr<!rec_TwoLong>, ["s"] {alignment = 8 : i64}
+  %1 = cir.load %0 : !cir.ptr<!rec_TwoLong>, !rec_TwoLong
+  cir.call @takes_two_long(%1) : (!rec_TwoLong) -> ()
+  cir.return
+}
+
+// CHECK:      cir.func{{.*}} @caller_two_long()
+// CHECK:        %[[VAL:.*]] = cir.load %{{.*}} : !cir.ptr<!rec_TwoLong>, !rec_TwoLong
+// Coerce TwoLong → coerced struct then extract fields.
+// CHECK:        %[[CV:.*]] = cir.load %{{.*}} : !cir.ptr<{{.*}}>, {{.*}}
+// CHECK:        %[[F0:.*]] = cir.extract_member %[[CV]][0] : {{.*}} -> !s64i
+// CHECK:        %[[F1:.*]] = cir.extract_member %[[CV]][1] : {{.*}} -> !s64i
+// CHECK:        cir.call @takes_two_long(%[[F0]], %[[F1]]) : (!s64i, !s64i) -> ()
+
+// Three-field flatten (CUDA dim3 with 3 equal-width fields → 3 scalar args).
+// Covers the numFields == 3 path in insertArgCoercion.
+
+cir.func @takes_three_int(%arg0: !rec_ThreeInt)
+    attributes { test_classify = #flatten_three } {
+  cir.return
+}
+
+// CHECK:      cir.func{{.*}} @takes_three_int(%[[A:.*]]: !s32i, %[[B:.*]]: !s32i, %[[C:.*]]: !s32i)
+// Two ["coerce"] allocas appear; the fields are stored via the second one.
+// CHECK:        cir.alloca {{.*}} ["coerce"]
+// CHECK:        cir.alloca {{.*}} ["coerce"]
+// CHECK:        %[[PA:.*]] = cir.get_member %{{.*}}[0]
+// CHECK:        cir.store %[[A]], %[[PA]] : !s32i, !cir.ptr<!s32i>
+// CHECK:        %[[PB:.*]] = cir.get_member %{{.*}}[1]
+// CHECK:        cir.store %[[B]], %[[PB]] : !s32i, !cir.ptr<!s32i>
+// CHECK:        %[[PC:.*]] = cir.get_member %{{.*}}[2]
+// CHECK:        cir.store %[[C]], %[[PC]] : !s32i, !cir.ptr<!s32i>
+
+cir.func @caller_three_int() attributes { test_classify = #passthrough } {
+  %0 = cir.alloca !rec_ThreeInt, !cir.ptr<!rec_ThreeInt>, ["s"] {alignment = 4 : i64}
+  %1 = cir.load %0 : !cir.ptr<!rec_ThreeInt>, !rec_ThreeInt
+  cir.call @takes_three_int(%1) : (!rec_ThreeInt) -> ()
+  cir.return
+}
+
+// CHECK:      cir.func{{.*}} @caller_three_int()
+// CHECK:        %[[F0:.*]] = cir.extract_member %{{.*}}[0] : {{.*}} -> !s32i
+// CHECK:        %[[F1:.*]] = cir.extract_member %{{.*}}[1] : {{.*}} -> !s32i
+// CHECK:        %[[F2:.*]] = cir.extract_member %{{.*}}[2] : {{.*}} -> !s32i
+// CHECK:        cir.call @takes_three_int(%[[F0]], %[[F1]], %[[F2]]) : (!s32i, !s32i, !s32i) -> ()
+
+// Mixed-packing case (x86-64 SysV dim3 pattern): struct { uint x, y, z; }
+// is coerced to {i64, i32} — the first two i32s are packed into an i64,
+// producing 2 wire arguments from a 3-field source struct.
+
+cir.func @takes_dim3(%arg0: !rec_Dim3)
+    attributes { test_classify = #flatten_dim3 } {
+  cir.return
+}
+
+// CHECK:      cir.func{{.*}} @takes_dim3(%[[D0:.*]]: !s64i, %[[D1:.*]]: !s32i)
+// Two ["coerce"] allocas appear; the {i64, i32} fields are stored into the second.
+// CHECK:        cir.alloca {{.*}} ["coerce"]
+// CHECK:        cir.alloca {{.*}} ["coerce"]
+// CHECK:        %{{.*}} = cir.get_member %{{.*}}[0]
+// CHECK:        cir.store %[[D0]], %{{.*}} : !s64i
+// CHECK:        %{{.*}} = cir.get_member %{{.*}}[1]
+// CHECK:        cir.store %[[D1]], %{{.*}} : !s32i
+
+cir.func @caller_dim3() attributes { test_classify = #passthrough } {
+  %0 = cir.alloca !rec_Dim3, !cir.ptr<!rec_Dim3>, ["d"] {alignment = 4 : i64}
+  %1 = cir.load %0 : !cir.ptr<!rec_Dim3>, !rec_Dim3
+  cir.call @takes_dim3(%1) : (!rec_Dim3) -> ()
+  cir.return
+}
+
+// CHECK:      cir.func{{.*}} @caller_dim3()
+// Coerce Dim3 → {i64, i32} then extract two fields.
+// CHECK:        %[[E0:.*]] = cir.extract_member %{{.*}}[0] : {{.*}} -> !s64i
+// CHECK:        %[[E1:.*]] = cir.extract_member %{{.*}}[1] : {{.*}} -> !s32i
+// CHECK:        cir.call @takes_dim3(%[[E0]], %[[E1]]) : (!s64i, !s32i) -> ()
+
+// Two flatten args with an Ignore in between: exercises the Ignore-drop loop's
+// classToBlockArg mapping when canFlatten args occupy multiple block arg slots.
+
+cir.func @flatten_ignore_flatten_callee(
+    %a: !rec_TwoLong, %b: !rec_TwoLong, %c: !rec_TwoLong)
+    attributes { test_classify = #flatten_ignore_flatten } {
+  cir.return
+}
+
+// CHECK:      cir.func{{.*}} @flatten_ignore_flatten_callee(
+// CHECK-SAME:     %{{.*}}: !s64i, %{{.*}}: !s64i, %{{.*}}: !s64i, %{{.*}}: !s64i)
+// The middle ignored arg is dropped; two flatten slots produce four block args.
+// CHECK-DAG:    cir.alloca {{.*}} ["coerce"]
+// CHECK-DAG:    cir.alloca {{.*}} ["coerce"]
+
+}

--- a/clang/test/CIR/Transforms/abi-lowering/expand-struct-arg.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/expand-struct-arg.cir
@@ -1,0 +1,224 @@
+// RUN: cir-opt %s -cir-call-conv-lowering="classification-attr=test_classify" \
+// RUN:   | FileCheck %s
+
+!s64i = !cir.int<s, 64>
+!s32i = !cir.int<s, 32>
+!rec_TwoLong = !cir.struct<"TwoLong" {!s64i, !s64i}>
+!rec_ThreeInt = !cir.struct<"ThreeInt" {!s32i, !s32i, !s32i}>
+!rec_OneInt = !cir.struct<"OneInt" {!s32i}>
+
+#expand_two = {
+  return = { kind = "direct" },
+  args   = [ { kind = "expand" } ]
+}
+
+#expand_three = {
+  return = { kind = "direct" },
+  args   = [ { kind = "expand" } ]
+}
+
+#expand_one = {
+  return = { kind = "direct" },
+  args   = [ { kind = "expand" } ]
+}
+
+#expand_expand = {
+  return = { kind = "direct" },
+  args   = [ { kind = "expand" }, { kind = "expand" } ]
+}
+
+#expand_ignore_expand = {
+  return = { kind = "direct" },
+  args   = [ { kind = "expand" },
+             { kind = "ignore" },
+             { kind = "expand" } ]
+}
+
+#sret_expand = {
+  return = { kind = "indirect", indirect_align = 8 },
+  args   = [ { kind = "expand" } ]
+}
+
+#passthrough = {
+  return = { kind = "direct" },
+  args   = [ ]
+}
+
+module attributes {
+  dlti.dl_spec = #dlti.dl_spec<
+    #dlti.dl_entry<i32, dense<32>: vector<2xi64>>,
+    #dlti.dl_entry<i64, dense<64>: vector<2xi64>>>
+} {
+
+// Callee: the single struct arg is replaced by two i64 block args.  At
+// function entry an alloca+get_member+store+load sequence reassembles
+// the struct for the body.
+
+cir.func @takes_two_long(%arg0: !rec_TwoLong)
+    attributes { test_classify = #expand_two } {
+  %0 = cir.alloca !rec_TwoLong, !cir.ptr<!rec_TwoLong>, ["p"] {alignment = 8 : i64}
+  cir.store %arg0, %0 : !rec_TwoLong, !cir.ptr<!rec_TwoLong>
+  cir.return
+}
+
+// CHECK:      cir.func{{.*}} @takes_two_long(%[[F0:.*]]: !s64i, %[[F1:.*]]: !s64i)
+// CHECK-NOT:  !rec_TwoLong
+// CHECK:        %[[SLOT:.*]] = cir.alloca !rec_TwoLong, !cir.ptr<!rec_TwoLong>, ["expand"]
+// CHECK:        %[[P0:.*]] = cir.get_member %[[SLOT]][0]
+// CHECK:        cir.store %[[F0]], %[[P0]] : !s64i, !cir.ptr<!s64i>
+// CHECK:        %[[P1:.*]] = cir.get_member %[[SLOT]][1]
+// CHECK:        cir.store %[[F1]], %[[P1]] : !s64i, !cir.ptr<!s64i>
+// CHECK:        %[[STRUCT:.*]] = cir.load %[[SLOT]] : !cir.ptr<!rec_TwoLong>, !rec_TwoLong
+// CHECK:        %[[P:.*]] = cir.alloca !rec_TwoLong, !cir.ptr<!rec_TwoLong>, ["p"]
+// CHECK:        cir.store %[[STRUCT]], %[[P]] : !rec_TwoLong, !cir.ptr<!rec_TwoLong>
+
+// Callee that uses the expanded arg directly in the return.
+
+cir.func @returns_expanded(%arg0: !rec_TwoLong) -> !rec_TwoLong
+    attributes { test_classify = #expand_two } {
+  cir.return %arg0 : !rec_TwoLong
+}
+
+// CHECK:      cir.func{{.*}} @returns_expanded(%[[F0:.*]]: !s64i, %[[F1:.*]]: !s64i) -> !rec_TwoLong
+// CHECK:        %[[SLOT:.*]] = cir.alloca !rec_TwoLong, !cir.ptr<!rec_TwoLong>, ["expand"]
+// CHECK:        %[[P0:.*]] = cir.get_member %[[SLOT]][0]
+// CHECK:        cir.store %[[F0]], %[[P0]] : !s64i, !cir.ptr<!s64i>
+// CHECK:        %[[P1:.*]] = cir.get_member %[[SLOT]][1]
+// CHECK:        cir.store %[[F1]], %[[P1]] : !s64i, !cir.ptr<!s64i>
+// CHECK:        %[[STRUCT:.*]] = cir.load %[[SLOT]] : !cir.ptr<!rec_TwoLong>, !rec_TwoLong
+// CHECK:        cir.return %[[STRUCT]] : !rec_TwoLong
+
+// Three-field expansion.
+
+cir.func @takes_three_int(%arg0: !rec_ThreeInt)
+    attributes { test_classify = #expand_three } {
+  cir.return
+}
+
+// CHECK:      cir.func{{.*}} @takes_three_int(%[[A:.*]]: !s32i, %[[B:.*]]: !s32i, %[[C:.*]]: !s32i)
+// CHECK:        %[[SLOT:.*]] = cir.alloca !rec_ThreeInt, !cir.ptr<!rec_ThreeInt>, ["expand"]
+// CHECK:        %[[P0:.*]] = cir.get_member %[[SLOT]][0]
+// CHECK:        cir.store %[[A]], %[[P0]] : !s32i, !cir.ptr<!s32i>
+// CHECK:        %[[P1:.*]] = cir.get_member %[[SLOT]][1]
+// CHECK:        cir.store %[[B]], %[[P1]] : !s32i, !cir.ptr<!s32i>
+// CHECK:        %[[P2:.*]] = cir.get_member %[[SLOT]][2]
+// CHECK:        cir.store %[[C]], %[[P2]] : !s32i, !cir.ptr<!s32i>
+
+// Forward declaration: signature is rewritten with the flattened types but
+// there is no body to instrument.
+
+cir.func private @takes_two_long_decl(!rec_TwoLong)
+    attributes { test_classify = #expand_two }
+
+// CHECK:      cir.func{{.*}} @takes_two_long_decl(!s64i, !s64i)
+// CHECK-NOT:  !rec_TwoLong
+
+// Caller: the struct operand is decomposed into individual scalar fields via
+// cir.extract_member and each field becomes a separate call argument.
+
+cir.func @caller_two_long() attributes { test_classify = #passthrough } {
+  %0 = cir.alloca !rec_TwoLong, !cir.ptr<!rec_TwoLong>, ["s"] {alignment = 8 : i64}
+  %1 = cir.load %0 : !cir.ptr<!rec_TwoLong>, !rec_TwoLong
+  cir.call @takes_two_long(%1) : (!rec_TwoLong) -> ()
+  cir.return
+}
+
+// CHECK:      cir.func{{.*}} @caller_two_long()
+// CHECK:        %[[VAL:.*]] = cir.load %{{.*}} : !cir.ptr<!rec_TwoLong>, !rec_TwoLong
+// CHECK:        %[[F0:.*]] = cir.extract_member %[[VAL]][0] : !rec_TwoLong -> !s64i
+// CHECK:        %[[F1:.*]] = cir.extract_member %[[VAL]][1] : !rec_TwoLong -> !s64i
+// CHECK:        cir.call @takes_two_long(%[[F0]], %[[F1]]) : (!s64i, !s64i) -> ()
+
+// Expand composed with Ignore: the middle arg is dropped; the two Expand
+// args each expand to 2 fields.  The Ignore-drop loop uses a classification-
+// aware index to erase the correct block argument.
+
+cir.func @expand_ignore_expand_callee(
+    %a: !rec_TwoLong, %b: !rec_TwoLong, %c: !rec_TwoLong)
+    attributes { test_classify = #expand_ignore_expand } {
+  cir.return
+}
+
+// The middle ignored arg is dropped; the two Expand slots produce four
+// flattened block args (two per struct).
+// CHECK:      cir.func{{.*}} @expand_ignore_expand_callee(%[[A0:.*]]: !s64i, %[[A1:.*]]: !s64i, %[[C0:.*]]: !s64i, %[[C1:.*]]: !s64i)
+// CHECK-NOT:  !rec_TwoLong{{.*}}arg
+// Two alloca+reassembly sequences appear in the entry block (order may
+// vary due to setInsertionPointToStart stacking).
+// CHECK-DAG:    cir.alloca !rec_TwoLong, !cir.ptr<!rec_TwoLong>, ["expand"]
+// CHECK-DAG:    cir.alloca !rec_TwoLong, !cir.ptr<!rec_TwoLong>, ["expand"]
+
+// One-field expansion: the single block arg is retyped in place; no
+// insertArgument call occurs.
+
+cir.func @takes_one_int(%arg0: !rec_OneInt)
+    attributes { test_classify = #expand_one } {
+  cir.return
+}
+
+// CHECK:      cir.func{{.*}} @takes_one_int(%[[F:.*]]: !s32i)
+// CHECK:        %[[SLOT:.*]] = cir.alloca !rec_OneInt, !cir.ptr<!rec_OneInt>, ["expand"]
+// CHECK:        %[[P:.*]] = cir.get_member %[[SLOT]][0]
+// CHECK:        cir.store %[[F]], %[[P]] : !s32i, !cir.ptr<!s32i>
+// CHECK:        %[[STRUCT:.*]] = cir.load %[[SLOT]] : !cir.ptr<!rec_OneInt>, !rec_OneInt
+
+// Two consecutive Expand args: exercises the running blockArgIdx across
+// multiple expansions and the inverted setInsertionPointToStart ordering.
+
+cir.func @two_expand_args(%a: !rec_TwoLong, %b: !rec_ThreeInt)
+    attributes { test_classify = #expand_expand } {
+  cir.return
+}
+
+// CHECK:      cir.func{{.*}} @two_expand_args(%[[A0:.*]]: !s64i, %[[A1:.*]]: !s64i, %[[B0:.*]]: !s32i, %[[B1:.*]]: !s32i, %[[B2:.*]]: !s32i)
+// The prolog for %b (second Expand) appears before %a (first Expand) due
+// to setInsertionPointToStart stacking; both chains are independent.
+// CHECK-DAG:    cir.alloca !rec_TwoLong, !cir.ptr<!rec_TwoLong>, ["expand"]
+// CHECK-DAG:    cir.alloca !rec_ThreeInt, !cir.ptr<!rec_ThreeInt>, ["expand"]
+
+cir.func @caller_two_expand() attributes { test_classify = #passthrough } {
+  %0 = cir.alloca !rec_TwoLong, !cir.ptr<!rec_TwoLong>, ["a"] {alignment = 8 : i64}
+  %1 = cir.alloca !rec_ThreeInt, !cir.ptr<!rec_ThreeInt>, ["b"] {alignment = 4 : i64}
+  %a = cir.load %0 : !cir.ptr<!rec_TwoLong>, !rec_TwoLong
+  %b = cir.load %1 : !cir.ptr<!rec_ThreeInt>, !rec_ThreeInt
+  cir.call @two_expand_args(%a, %b) : (!rec_TwoLong, !rec_ThreeInt) -> ()
+  cir.return
+}
+
+// CHECK:      cir.func{{.*}} @caller_two_expand()
+// CHECK:        %[[A:.*]] = cir.load %{{.*}} : !cir.ptr<!rec_TwoLong>, !rec_TwoLong
+// CHECK:        %[[B:.*]] = cir.load %{{.*}} : !cir.ptr<!rec_ThreeInt>, !rec_ThreeInt
+// CHECK:        %[[A0:.*]] = cir.extract_member %[[A]][0] : !rec_TwoLong -> !s64i
+// CHECK:        %[[A1:.*]] = cir.extract_member %[[A]][1] : !rec_TwoLong -> !s64i
+// CHECK:        %[[B0:.*]] = cir.extract_member %[[B]][0] : !rec_ThreeInt -> !s32i
+// CHECK:        %[[B1:.*]] = cir.extract_member %[[B]][1] : !rec_ThreeInt -> !s32i
+// CHECK:        %[[B2:.*]] = cir.extract_member %[[B]][2] : !rec_ThreeInt -> !s32i
+// CHECK:        cir.call @two_expand_args(%[[A0]], %[[A1]], %[[B0]], %[[B1]], %[[B2]]) : (!s64i, !s64i, !s32i, !s32i, !s32i) -> ()
+
+// sret return + Expand arg: the sret pointer is prepended as block argument 0
+// (sretOffset = 1) and the Expand arg's two scalar block arguments follow at
+// slots 1 and 2.  This exercises the running block-argument index when
+// sretOffset > 0.
+
+cir.func @sret_and_expand(%arg0: !rec_TwoLong) -> !rec_TwoLong
+    attributes { test_classify = #sret_expand } {
+  %0 = cir.alloca !rec_TwoLong, !cir.ptr<!rec_TwoLong>, ["__retval"] {alignment = 8 : i64}
+  %z = cir.const #cir.zero : !rec_TwoLong
+  cir.store %z, %0 : !rec_TwoLong, !cir.ptr<!rec_TwoLong>
+  %1 = cir.load %0 : !cir.ptr<!rec_TwoLong>, !rec_TwoLong
+  cir.return %1 : !rec_TwoLong
+}
+
+// CHECK:      cir.func{{.*}} @sret_and_expand(
+// CHECK-SAME:     llvm.sret = !rec_TwoLong
+// CHECK-SAME:     %[[F0:.*]]: !s64i, %[[F1:.*]]: !s64i)
+// CHECK-NOT:  -> !rec_TwoLong
+// The sret pointer is slot 0; the Expand block args start at slot 1.
+// CHECK:        %[[SLOT:.*]] = cir.alloca !rec_TwoLong, !cir.ptr<!rec_TwoLong>, ["expand"]
+// CHECK:        %[[P0:.*]] = cir.get_member %[[SLOT]][0]
+// CHECK:        cir.store %[[F0]], %[[P0]] : !s64i, !cir.ptr<!s64i>
+// CHECK:        %[[P1:.*]] = cir.get_member %[[SLOT]][1]
+// CHECK:        cir.store %[[F1]], %[[P1]] : !s64i, !cir.ptr<!s64i>
+// CHECK:        %[[STRUCT:.*]] = cir.load %[[SLOT]] : !cir.ptr<!rec_TwoLong>, !rec_TwoLong
+
+}

--- a/clang/test/CIR/Transforms/abi-lowering/indirect-byval.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/indirect-byval.cir
@@ -1,0 +1,242 @@
+// RUN: cir-opt %s -cir-call-conv-lowering="classification-attr=test_classify" \
+// RUN:   | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+!rec_Big = !cir.struct<"Big" {!s64i, !s64i, !s64i, !s64i}>
+
+#byval_arg = {
+  return = { kind = "direct" },
+  args   = [ { kind = "indirect", indirect_align = 8 } ]
+}
+
+#byval_arg_ext_return = {
+  return = { kind = "extend", coerced_type = !cir.int<s, 32>,
+             sign_extend = true },
+  args   = [ { kind = "indirect", indirect_align = 8 } ]
+}
+
+#byval_ignore_arg = {
+  return = { kind = "direct" },
+  args   = [ { kind = "indirect", indirect_align = 8 },
+             { kind = "ignore" } ]
+}
+
+#two_byval = {
+  return = { kind = "direct" },
+  args   = [ { kind = "indirect", indirect_align = 8 },
+             { kind = "indirect", indirect_align = 8 } ]
+}
+
+#sret_byval = {
+  return = { kind = "indirect", indirect_align = 8 },
+  args   = [ { kind = "indirect", indirect_align = 8 } ]
+}
+
+#byref_arg = {
+  return = { kind = "direct" },
+  args   = [ { kind = "indirect", indirect_align = 8, byval = false } ]
+}
+
+#passthrough = {
+  return = { kind = "direct" },
+  args   = [ ]
+}
+
+module attributes {
+  dlti.dl_spec = #dlti.dl_spec<
+    #dlti.dl_entry<i8, dense<8>: vector<2xi64>>,
+    #dlti.dl_entry<i32, dense<32>: vector<2xi64>>,
+    #dlti.dl_entry<i64, dense<64>: vector<2xi64>>>
+} {
+
+  // The byval arg becomes a pointer with llvm.byval, llvm.align, llvm.noalias,
+  // and llvm.noundef.  A load is inserted at entry so the body sees the
+  // original value type.
+  cir.func @takes_big(%arg0: !rec_Big) -> !s32i
+      attributes { test_classify = #byval_arg } {
+    %r = cir.const #cir.int<0> : !s32i
+    cir.return %r : !s32i
+  }
+
+  // CHECK:      cir.func{{.*}} @takes_big(%[[ARG:.*]]: !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.align = 8 : i64
+  // CHECK-SAME:     llvm.byval = !rec_Big
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.noundef
+  // CHECK:        %{{.*}} = cir.load %[[ARG]] : !cir.ptr<!rec_Big>, !rec_Big
+  // CHECK-NEXT:   %{{.*}} = cir.const #cir.int<0> : !s32i
+
+  // byval composes with an Extend return: the pointer parameter carries all
+  // four byval attrs and the return value carries llvm.signext.
+  cir.func @takes_big_ext(%arg0: !rec_Big) -> !s32i
+      attributes { test_classify = #byval_arg_ext_return } {
+    %r = cir.const #cir.int<0> : !s32i
+    cir.return %r : !s32i
+  }
+
+  // CHECK:      cir.func{{.*}} @takes_big_ext(%{{.*}}: !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.byval = !rec_Big
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.noundef
+  // CHECK-SAME:   ) -> (!s32i {llvm.signext})
+
+  // byval composes with an Ignored second argument: the ignored arg is dropped
+  // from the signature and the byval slot is the only argument.
+  cir.func @takes_big_ignore(%arg0: !rec_Big, %arg1: !s32i) -> !s32i
+      attributes { test_classify = #byval_ignore_arg } {
+    %r = cir.const #cir.int<0> : !s32i
+    cir.return %r : !s32i
+  }
+
+  // CHECK:      cir.func{{.*}} @takes_big_ignore(%{{.*}}: !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.byval = !rec_Big
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.noundef
+  // CHECK-SAME:   ) -> !s32i
+  // CHECK-NOT:    !s32i {{.*}}!s32i
+
+  // A forward declaration: signature is rewritten but no body to touch.
+  cir.func private @takes_big_decl(%arg0: !rec_Big) -> !s32i
+      attributes { test_classify = #byval_arg }
+
+  // CHECK:      cir.func{{.*}} @takes_big_decl(!cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.byval = !rec_Big
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.noundef
+
+  // Caller: byval argument is copied into a fresh alloca; the pointer is
+  // passed with llvm.byval, llvm.noalias, and llvm.noundef on the call
+  // operand, matching classic CodeGen's -fpass-by-value-is-noalias output.
+  cir.func @caller(%s: !rec_Big) -> !s32i
+      attributes { test_classify = #passthrough } {
+    %r = cir.call @takes_big(%s) : (!rec_Big) -> !s32i
+    cir.return %r : !s32i
+  }
+
+  // CHECK:      cir.func{{.*}} @caller(%[[S:.*]]: !rec_Big) -> !s32i
+  // CHECK:        %[[SLOT:.*]] = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["byval"]
+  // CHECK-NEXT:   cir.store %[[S]], %[[SLOT]] : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK-NEXT:   %{{.*}} = cir.call @takes_big(%[[SLOT]]) :
+  // CHECK-SAME:     llvm.byval = !rec_Big
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.noundef
+
+  // A body that actually uses the byval arg value: the existing use in
+  // cir.return is rerouted through the load inserted at entry.
+  cir.func @takes_big_uses_arg(%arg0: !rec_Big) -> !rec_Big
+      attributes { test_classify = #byval_arg } {
+    cir.return %arg0 : !rec_Big
+  }
+
+  // CHECK:      cir.func{{.*}} @takes_big_uses_arg(%[[PTR:.*]]: !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.byval = !rec_Big
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.noundef
+  // CHECK:        %[[LOADED:.*]] = cir.load %[[PTR]] : !cir.ptr<!rec_Big>, !rec_Big
+  // CHECK-NEXT:   cir.return %[[LOADED]] : !rec_Big
+
+  // Two byval arguments: each gets its own alloca at the call site, and both
+  // block args are changed to pointers with loads at the callee entry.
+  cir.func @two_byval(%a: !rec_Big, %b: !rec_Big) -> !rec_Big
+      attributes { test_classify = #two_byval } {
+    cir.return %b : !rec_Big
+  }
+
+  // Both byval slots carry the full attribute set.  Match in appearance order.
+  // CHECK:      cir.func{{.*}} @two_byval(
+  // CHECK-SAME:     !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.byval = !rec_Big
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.noundef
+  // CHECK-SAME:     !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.byval = !rec_Big
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.noundef
+
+  cir.func @caller_two(%s: !rec_Big, %t: !rec_Big) -> !rec_Big
+      attributes { test_classify = #passthrough } {
+    %r = cir.call @two_byval(%s, %t) : (!rec_Big, !rec_Big) -> !rec_Big
+    cir.return %r : !rec_Big
+  }
+
+  // CHECK:      cir.func{{.*}} @caller_two
+  // CHECK:        %[[A:.*]] = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["byval"]
+  // CHECK-NEXT:   cir.store %{{.*}}, %[[A]] : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK-NEXT:   %[[B:.*]] = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["byval"]
+  // CHECK-NEXT:   cir.store %{{.*}}, %[[B]] : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK-NEXT:   %{{.*}} = cir.call @two_byval(%[[A]], %[[B]]) :
+  // CHECK-SAME:     llvm.byval = !rec_Big
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.noundef
+  // CHECK-SAME:     !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.byval = !rec_Big
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.noundef
+
+  // sret return + byval arg: the sret pointer is prepended at slot 0 and the
+  // byval arg shifts to slot 1 (sretOffset = 1).  The byval slot carries all
+  // four byval attrs; the sret slot carries its own standard set.
+  cir.func @byval_and_sret(%arg0: !rec_Big) -> !rec_Big
+      attributes { test_classify = #sret_byval } {
+    %0 = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["__retval"] {alignment = 8 : i64}
+    %z = cir.const #cir.zero : !rec_Big
+    cir.store %z, %0 : !rec_Big, !cir.ptr<!rec_Big>
+    %1 = cir.load %0 : !cir.ptr<!rec_Big>, !rec_Big
+    cir.return %1 : !rec_Big
+  }
+
+  // CHECK:      cir.func{{.*}} @byval_and_sret(
+  // CHECK-SAME:     llvm.sret = !rec_Big
+  // CHECK-SAME:     !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.byval = !rec_Big
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.noundef
+  // CHECK-NOT:    -> !rec_Big
+  // CHECK:        cir.store %{{.*}}, %{{.*}} : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK:        cir.return
+
+  // byref callee definition: the parameter gets llvm.byref instead of
+  // llvm.byval.  noalias and noundef are NOT added (byref passes the
+  // original, which may alias and may carry padding).  The body
+  // transformation (ptr + load at entry) is identical to byval.
+  cir.func @takes_big_byref(%arg0: !rec_Big) -> !rec_Big
+      attributes { test_classify = #byref_arg } {
+    cir.return %arg0 : !rec_Big
+  }
+
+  // CHECK:      cir.func{{.*}} @takes_big_byref(%[[PTR:.*]]: !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.align = 8 : i64
+  // CHECK-SAME:     llvm.byref = !rec_Big
+  // CHECK-NOT:    llvm.noalias
+  // CHECK-NOT:    llvm.noundef
+  // CHECK:        %[[L:.*]] = cir.load %[[PTR]] : !cir.ptr<!rec_Big>, !rec_Big
+  // CHECK-NEXT:   cir.return %[[L]] : !rec_Big
+
+  // byref forward declaration: signature gets llvm.byref, no body.
+  cir.func private @takes_big_byref_decl(%arg0: !rec_Big) -> !rec_Big
+      attributes { test_classify = #byref_arg }
+
+  // CHECK:      cir.func{{.*}} @takes_big_byref_decl(!cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.byref = !rec_Big
+  // CHECK-NOT:    llvm.noalias
+  // CHECK-NOT:    llvm.noundef
+
+  // byref call site: same alloca+store pattern as byval, but the pointer
+  // carries llvm.byref (and no llvm.noalias / llvm.noundef since byref
+  // does not assert exclusive ownership of the storage).
+  cir.func @caller_byref(%s: !rec_Big) -> !rec_Big
+      attributes { test_classify = #passthrough } {
+    %r = cir.call @takes_big_byref(%s) : (!rec_Big) -> !rec_Big
+    cir.return %r : !rec_Big
+  }
+
+  // CHECK:      cir.func{{.*}} @caller_byref(%[[S:.*]]: !rec_Big) -> !rec_Big
+  // CHECK:        %[[SLOT:.*]] = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["byref"]
+  // CHECK-NEXT:   cir.store %[[S]], %[[SLOT]] : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK-NEXT:   %{{.*}} = cir.call @takes_big_byref(%[[SLOT]]) :
+  // CHECK-SAME:     llvm.byref = !rec_Big
+  // CHECK-NOT:    llvm.noalias
+  // CHECK-NOT:    llvm.noundef
+
+}

--- a/clang/test/CIR/Transforms/abi-lowering/indirect-return-sret.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/indirect-return-sret.cir
@@ -1,0 +1,200 @@
+// RUN: cir-opt %s -cir-call-conv-lowering="classification-attr=test_classify" \
+// RUN:   | FileCheck %s
+
+!s8i = !cir.int<s, 8>
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+!rec_Big = !cir.struct<"Big" {!s64i, !s64i, !s64i, !s64i}>
+
+#indirect_return = {
+  return = { kind = "indirect", indirect_align = 8 },
+  args   = [ ]
+}
+
+#indirect_return_ext = {
+  return = { kind = "indirect", indirect_align = 8 },
+  args   = [ { kind = "extend", coerced_type = !cir.int<s, 32>,
+               sign_extend = true } ]
+}
+
+#indirect_return_bool = {
+  return = { kind = "indirect", indirect_align = 8 },
+  args   = [ { kind = "direct" } ]
+}
+
+#indirect_return_ignore = {
+  return = { kind = "indirect", indirect_align = 8 },
+  args   = [ { kind = "ignore" } ]
+}
+
+#caller_cls = {
+  return = { kind = "direct" },
+  args   = [ ]
+}
+
+module attributes {
+  dlti.dl_spec = #dlti.dl_spec<
+    #dlti.dl_entry<i8, dense<8>: vector<2xi64>>,
+    #dlti.dl_entry<i32, dense<32>: vector<2xi64>>,
+    #dlti.dl_entry<i64, dense<64>: vector<2xi64>>>
+} {
+
+  cir.func @returns_big() -> !rec_Big
+      attributes { test_classify = #indirect_return } {
+    %0 = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["__retval"] {alignment = 8 : i64}
+    %z = cir.const #cir.zero : !rec_Big
+    cir.store %z, %0 : !rec_Big, !cir.ptr<!rec_Big>
+    %1 = cir.load %0 : !cir.ptr<!rec_Big>, !rec_Big
+    cir.return %1 : !rec_Big
+  }
+
+  // The indirect return becomes a hidden sret pointer prepended as argument 0,
+  // the wire return type becomes void, the __retval alloca is rewired to the
+  // sret pointer, and the trailing load/return collapses to a bare return.
+  // CHECK:      cir.func{{.*}} @returns_big(%[[SRET:.*]]: !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.align = 8 : i64
+  // CHECK-SAME:     llvm.dead_on_unwind
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.sret = !rec_Big
+  // CHECK-SAME:     llvm.writable
+  // CHECK-NOT:    -> !rec_Big
+  // CHECK:        %[[Z:.*]] = cir.const #cir.zero : !rec_Big
+  // CHECK:        cir.store %[[Z]], %[[SRET]] : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK:        cir.return
+  // CHECK-NOT:    cir.return %{{.*}} : !rec_Big
+
+  // A call whose result is bound to a single local reuses that local as the
+  // sret slot directly, so construction flows straight into it and the
+  // original store-from-result is dropped (no byte-copy, no load-back).
+  cir.func @caller() -> !s32i
+      attributes { test_classify = #caller_cls } {
+    %1 = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["s"] {alignment = 8 : i64}
+    %0 = cir.call @returns_big() : () -> !rec_Big
+    cir.store %0, %1 : !rec_Big, !cir.ptr<!rec_Big>
+    %z = cir.const #cir.int<0> : !s32i
+    cir.return %z : !s32i
+  }
+
+  // CHECK:      cir.func{{.*}} @caller() -> !s32i
+  // CHECK:        %[[DEST:.*]] = cir.alloca !rec_Big, {{.*}} ["s"]
+  // CHECK:        cir.call @returns_big(%[[DEST]]) : (!cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.sret = !rec_Big
+  // CHECK-SAME:     -> ()
+  // CHECK-NOT:    cir.load
+  // CHECK-NOT:    cir.store
+  // CHECK:        cir.return %{{.*}} : !s32i
+
+  // A call whose result has more than one use cannot reuse a destination, so a
+  // fresh sret slot is allocated and the result is loaded back out of it.
+  cir.func @caller_multi() -> !s32i
+      attributes { test_classify = #caller_cls } {
+    %a = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["a"] {alignment = 8 : i64}
+    %b = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["b"] {alignment = 8 : i64}
+    %0 = cir.call @returns_big() : () -> !rec_Big
+    cir.store %0, %a : !rec_Big, !cir.ptr<!rec_Big>
+    cir.store %0, %b : !rec_Big, !cir.ptr<!rec_Big>
+    %z = cir.const #cir.int<0> : !s32i
+    cir.return %z : !s32i
+  }
+
+  // CHECK:      cir.func{{.*}} @caller_multi() -> !s32i
+  // CHECK:        %[[SLOT:.*]] = cir.alloca !rec_Big, {{.*}} ["sret"]
+  // CHECK:        cir.call @returns_big(%[[SLOT]]) : (!cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.sret = !rec_Big
+  // CHECK-SAME:     -> ()
+  // CHECK:        %[[LD:.*]] = cir.load %[[SLOT]] : !cir.ptr<!rec_Big>, !rec_Big
+  // CHECK:        cir.store %[[LD]], %{{.*}} : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK:        cir.store %[[LD]], %{{.*}} : !rec_Big, !cir.ptr<!rec_Big>
+
+  // sret composes with an Extend argument: the sret slot is prepended and the
+  // s8 argument is still extended to s32 with llvm.signext on both the callee
+  // signature and the call site.
+  cir.func @returns_big_ext(%arg0: !s8i) -> !rec_Big
+      attributes { test_classify = #indirect_return_ext } {
+    %0 = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["__retval"] {alignment = 8 : i64}
+    %z = cir.const #cir.zero : !rec_Big
+    cir.store %z, %0 : !rec_Big, !cir.ptr<!rec_Big>
+    %1 = cir.load %0 : !cir.ptr<!rec_Big>, !rec_Big
+    cir.return %1 : !rec_Big
+  }
+
+  // CHECK:      cir.func{{.*}} @returns_big_ext(%[[SRET2:.*]]: !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.sret = !rec_Big
+  // CHECK-SAME:   %{{.*}}: !s8i {llvm.signext}
+  // CHECK-NOT:    -> !rec_Big
+  // CHECK:        cir.store %{{.*}}, %[[SRET2]] : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK:        cir.return
+
+  cir.func @caller_ext(%arg0: !s8i) -> !s32i
+      attributes { test_classify = #caller_cls } {
+    %1 = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["s"] {alignment = 8 : i64}
+    %0 = cir.call @returns_big_ext(%arg0) : (!s8i) -> !rec_Big
+    cir.store %0, %1 : !rec_Big, !cir.ptr<!rec_Big>
+    %z = cir.const #cir.int<0> : !s32i
+    cir.return %z : !s32i
+  }
+
+  // CHECK:      cir.func{{.*}} @caller_ext(%[[ARG:.*]]: !s8i) -> !s32i
+  // CHECK:        %[[DEST2:.*]] = cir.alloca !rec_Big, {{.*}} ["s"]
+  // CHECK:        cir.call @returns_big_ext(%[[DEST2]], %[[ARG]]) : (!cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.sret = !rec_Big
+  // CHECK-SAME:   !s8i {llvm.signext}
+  // CHECK-SAME:     -> ()
+
+  // Multiple return statements share one __retval alloca (CIR does not merge
+  // returns into a single epilogue), so every cir.return must be routed
+  // through the sret pointer and the shared alloca rewired exactly once.
+  cir.func @returns_big_cond(%cond: !cir.bool) -> !rec_Big
+      attributes { test_classify = #indirect_return_bool } {
+    %0 = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["__retval"] {alignment = 8 : i64}
+    %z = cir.const #cir.zero : !rec_Big
+    cir.if %cond {
+      cir.store %z, %0 : !rec_Big, !cir.ptr<!rec_Big>
+      %r1 = cir.load %0 : !cir.ptr<!rec_Big>, !rec_Big
+      cir.return %r1 : !rec_Big
+    }
+    cir.store %z, %0 : !rec_Big, !cir.ptr<!rec_Big>
+    %r2 = cir.load %0 : !cir.ptr<!rec_Big>, !rec_Big
+    cir.return %r2 : !rec_Big
+  }
+
+  // CHECK:      cir.func{{.*}} @returns_big_cond(%[[SRETC:.*]]: !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.sret = !rec_Big
+  // CHECK-NOT:    -> !rec_Big
+  // CHECK:        cir.store %{{.*}}, %[[SRETC]] : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK:        cir.return
+  // CHECK:        cir.store %{{.*}}, %[[SRETC]] : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK:        cir.return
+  // CHECK-NOT:    cir.return %{{.*}} : !rec_Big
+
+  // sret composes with an Ignore argument: the ignored arg is dropped from the
+  // signature and the sretOffset shift keeps the remaining block args aligned.
+  cir.func @returns_big_ignore(%ignored: !s32i) -> !rec_Big
+      attributes { test_classify = #indirect_return_ignore } {
+    %0 = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["__retval"] {alignment = 8 : i64}
+    %z = cir.const #cir.zero : !rec_Big
+    cir.store %z, %0 : !rec_Big, !cir.ptr<!rec_Big>
+    %1 = cir.load %0 : !cir.ptr<!rec_Big>, !rec_Big
+    cir.return %1 : !rec_Big
+  }
+
+  // CHECK:      cir.func{{.*}} @returns_big_ignore(%[[SRETI:.*]]: !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.sret = !rec_Big
+  // CHECK-NOT:    !s32i
+  // CHECK-NOT:    -> !rec_Big
+  // CHECK:        cir.store %{{.*}}, %[[SRETI]] : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK:        cir.return
+
+  // An sret declaration gets the hidden pointer and the sret slot attributes,
+  // but llvm.noalias is omitted: noalias on the sret parameter is only valid
+  // when the function body is present.  Kept last so the CHECK-NOT below
+  // scopes to this declaration.
+  cir.func private @returns_big_decl() -> !rec_Big
+      attributes { test_classify = #indirect_return }
+
+  // CHECK:      cir.func{{.*}} @returns_big_decl(!cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.sret = !rec_Big
+  // CHECK-NOT:    llvm.noalias
+  // CHECK-NOT:    -> !rec_Big
+
+}


### PR DESCRIPTION
CallConvLowering previously ignored the \`canFlatten\` flag on Direct classifications: a Direct arg with a multi-field struct coerced type was passed as a single struct argument rather than N scalar register arguments.  This is the register-passing pattern the x86-64 SysV ABI uses for structs like \`struct { long a, b; }\`.

A new helper \`getFlattenedCoercedType\` centralizes the detection (Direct classification, multi-field coerced struct, \`canFlatten\` set); the three lowering sites in \`CIRABIRewriteContext.cpp\` follow.

Depends on [#201707](https://github.com/llvm/llvm-project/pull/201707).