### PR TITLE
[CIR] Lower sret returns in CallConvLowering

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
@@ -8,6 +8,7 @@
 
 #include "CIRABIRewriteContext.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/Dominance.h"
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 
@@ -15,14 +16,15 @@ using namespace cir;
 using namespace mlir;
 using namespace mlir::abi;
 
-// This rewrite context currently supports only the Direct (no coercion) and
-// Ignore classifications.  All other ArgKinds emit an errorNYI here rather
-// than silently passing through, because the IR they would produce is wrong
+// This rewrite context supports the Direct (with or without coercion),
+// Extend, Ignore, and Indirect-return (sret) classifications.  Indirect
+// arguments (byval) and Expand still emit an errorNYI here rather than
+// silently passing through, because the IR they would produce is wrong
 // (e.g. Expand should flatten an aggregate into multiple primitives, not
-// pass it through as a single value).  Subsequent PRs in the
-// CallConvLowering split series add the remaining kinds and the
-// signature-shaping behavior that goes with them (sret / byval insert
-// extra arguments, struct coercion replaces one argument with several).
+// pass it through as a single value).  byval and struct coercion are not
+// yet handled here; they need the signature-shaping that goes with them
+// (byval inserts an extra pointer argument, struct coercion replaces one
+// argument with several).
 
 namespace {
 
@@ -40,10 +42,10 @@ bool needsRewrite(const FunctionClassification &fc) {
 }
 
 /// Build the new argument-type list for a function whose ABI classification
-/// is \p fc.  This currently handles only Direct (no coercion) and Ignore;
-/// other kinds emit an error.  Classifications that add arguments (e.g.
-/// Indirect-sret would prepend a return-pointer arg) are not yet
-/// implemented and will arrive in a subsequent PR.
+/// is \p fc.  Handles Direct (with or without coercion), Extend, and Ignore.
+/// Indirect (byval) arguments and Expand emit an error.  The sret return
+/// pointer, when present, is prepended by rewriteFunctionDefinition rather
+/// than here.
 LogicalResult buildNewArgTypes(ArrayRef<Type> oldArgTypes,
                                const FunctionClassification &fc,
                                SmallVectorImpl<Type> &newArgTypes,
@@ -85,8 +87,9 @@ LogicalResult buildNewArgTypes(ArrayRef<Type> oldArgTypes,
 }
 
 /// Compute the new return type for a function whose return classification
-/// is \p retInfo.  As with `buildNewArgTypes`, only Direct (no coercion)
-/// and Ignore are implemented here; the remaining kinds emit an error.
+/// is \p retInfo.  Direct returns keep (or coerce to) their type, Ignore and
+/// Indirect (sret) returns become void, Extend keeps its type; Expand emits
+/// an error.
 Type computeNewReturnType(Type origRetTy, const ArgClassification &retInfo,
                           MLIRContext *ctx,
                           function_ref<InFlightDiagnostic()> emitError) {
@@ -107,9 +110,10 @@ Type computeNewReturnType(Type origRetTy, const ArgClassification &retInfo,
     // llvm.signext / llvm.zeroext res attribute attached separately below.
     return origRetTy;
   case ArgKind::Indirect:
-    emitError() << "Indirect return (sret) not yet implemented in "
-                << "CallConvLowering";
-    return nullptr;
+    // sret: the value is returned through a hidden pointer argument that
+    // rewriteFunctionDefinition prepends to the argument list, so the wire
+    // return type becomes void.
+    return cir::VoidType::get(ctx);
   }
   llvm_unreachable("all ArgKind cases handled");
 }
@@ -274,9 +278,12 @@ void insertReturnCoercion(FunctionOpInterface funcOp, Type origRetTy,
 /// For each Direct arg with a coerced type, change the block argument's type
 /// to the coerced type and insert a coercion at function entry that maps it
 /// back to the original type for body uses.
+/// \p sretOffset is 1 when the function has an sret return (a hidden return
+/// pointer is prepended as block argument 0), so classification index \p idx
+/// maps to block argument \p idx + \p sretOffset.
 void insertArgCoercion(FunctionOpInterface funcOp,
                        const FunctionClassification &fc, OpBuilder &rewriter,
-                       const DataLayout &dl) {
+                       const DataLayout &dl, unsigned sretOffset) {
   Region &body = funcOp->getRegion(0);
   if (body.empty())
     return;
@@ -285,10 +292,11 @@ void insertArgCoercion(FunctionOpInterface funcOp,
   for (auto [idx, ac] : llvm::enumerate(fc.argInfos)) {
     if (ac.kind != ArgKind::Direct || !ac.coercedType)
       continue;
-    if (idx >= entry.getNumArguments())
+    unsigned blockIdx = idx + sretOffset;
+    if (blockIdx >= entry.getNumArguments())
       continue;
 
-    BlockArgument blockArg = entry.getArgument(idx);
+    BlockArgument blockArg = entry.getArgument(blockIdx);
     Type oldArgTy = blockArg.getType();
     Type newArgTy = ac.coercedType;
     if (oldArgTy == newArgTy)
@@ -307,6 +315,111 @@ void insertArgCoercion(FunctionOpInterface funcOp,
     // (now of the original type != the alloca's pointee type).
     blockArg.replaceAllUsesExcept(adapted, coercionOps);
   }
+}
+
+/// Rewrite each cir.return so the return value flows through the sret
+/// pointer (the prepended first block argument) and the function returns
+/// void.
+///
+/// CIRGen emits a local `__retval` alloca and emits `cir.return %loaded`
+/// where `%loaded = cir.load __retval`.  The naive lowering -- store the
+/// loaded SSA value through the sret pointer -- byte-copies the record,
+/// which is wrong for non-trivially-copyable types: e.g. libstdc++'s SSO
+/// `std::string` has a `_M_p` pointer that aliases the source's internal
+/// `_M_local_buf`, so a byte-copy leaves the destination pointing at the
+/// source's (now-dying) stack storage and the destination's destructor
+/// later `free()`s a stack pointer.
+///
+/// Instead, route construction directly into the sret slot: find the
+/// `__retval` alloca, replace its uses with the sret pointer, and drop the
+/// trailing `cir.load __retval` so the rewritten return has no operand.
+/// The CIRGen-emitted constructor / store-into-`__retval` then targets the
+/// sret slot uniformly, matching classic CodeGen's "construct directly into
+/// `%agg.result`" pattern.
+///
+/// CIRGen emits one `%v = cir.load %__retval` / `cir.return %v` pair per
+/// return statement, and every such load reads the single `__retval`
+/// alloca (CIR does not merge returns into a shared epilogue block).  The
+/// alloca is therefore rewired to the sret pointer once; each cir.return is
+/// then collapsed to a bare return and its now-dead load erased.  This
+/// `cir.return (cir.load <alloca>)` shape is an invariant guaranteed by
+/// CIRGen, so it is asserted via `cast<>` rather than guarded with a
+/// fallback.
+void insertSRetStores(FunctionOpInterface funcOp, Type origRetTy,
+                      OpBuilder &rewriter) {
+  Value sretPtr = funcOp.getArguments()[0];
+
+  SmallVector<cir::ReturnOp> returnOps;
+  funcOp->walk([&](cir::ReturnOp retOp) { returnOps.push_back(retOp); });
+
+  cir::AllocaOp retAlloca = nullptr;
+  for (cir::ReturnOp retOp : returnOps) {
+    if (retOp.getInput().empty())
+      continue;
+
+    cir::LoadOp retLoad =
+        cast<cir::LoadOp>(retOp.getInput()[0].getDefiningOp());
+
+    // Rewire the shared `__retval` alloca to the sret pointer once; all
+    // other returns' loads point at the same alloca and are updated by the
+    // replaceAllUsesWith below.
+    if (!retAlloca) {
+      retAlloca = cast<cir::AllocaOp>(retLoad.getAddr().getDefiningOp());
+      retAlloca.getResult().replaceAllUsesWith(sretPtr);
+      retAlloca->erase();
+    }
+
+    rewriter.setInsertionPoint(retOp);
+    cir::ReturnOp::create(rewriter, retOp.getLoc());
+    retOp->erase();
+    if (retLoad.use_empty())
+      retLoad->erase();
+  }
+}
+
+/// Build the attribute dictionary for the sret slot (slot 0 of an
+/// sret-returning function or call).  Matches classic CodeGen's
+/// `sret(T) align A [noalias] writable dead_on_unwind`.  noalias is only
+/// valid on the callee's parameter, not at the call site, so it is gated by
+/// \p withNoalias.  Key order is irrelevant: DictionaryAttr sorts by name.
+SmallVector<NamedAttribute> buildSretSlotAttrs(OpBuilder &rewriter, Type retTy,
+                                               uint64_t align,
+                                               bool withNoalias) {
+  SmallVector<NamedAttribute> attrs;
+  attrs.push_back(rewriter.getNamedAttr("llvm.sret", TypeAttr::get(retTy)));
+  attrs.push_back(
+      rewriter.getNamedAttr("llvm.align", rewriter.getI64IntegerAttr(align)));
+  if (withNoalias)
+    attrs.push_back(
+        rewriter.getNamedAttr("llvm.noalias", rewriter.getUnitAttr()));
+  attrs.push_back(
+      rewriter.getNamedAttr("llvm.writable", rewriter.getUnitAttr()));
+  attrs.push_back(
+      rewriter.getNamedAttr("llvm.dead_on_unwind", rewriter.getUnitAttr()));
+  return attrs;
+}
+
+/// Prepend the sret slot's attrs at position 0 of newCall's arg_attrs.
+/// Called after the call has been rewritten with the sret pointer at
+/// operand 0, so the operand count now includes the sret slot.  \p argAttrs
+/// must already be shaped for the rewritten argument list (Extend slots
+/// carry signext/zeroext, Ignore slots dropped); it is shifted to slots
+/// 1..N behind the sret slot.
+void applySretSlotAttrs(cir::CallOp newCall, ArrayAttr argAttrs, Type retTy,
+                        uint64_t align, OpBuilder &rewriter) {
+  MLIRContext *ctx = newCall->getContext();
+  SmallVector<NamedAttribute> sretAttrs =
+      buildSretSlotAttrs(rewriter, retTy, align, /*withNoalias=*/false);
+
+  SmallVector<Attribute> newArgAttrs;
+  newArgAttrs.reserve(newCall.getArgOperands().size());
+  newArgAttrs.push_back(DictionaryAttr::get(ctx, sretAttrs));
+  if (argAttrs)
+    for (Attribute a : argAttrs)
+      newArgAttrs.push_back(a);
+  while (newArgAttrs.size() < newCall.getArgOperands().size())
+    newArgAttrs.push_back(DictionaryAttr::get(ctx));
+  newCall->setAttr("arg_attrs", ArrayAttr::get(ctx, newArgAttrs));
 }
 
 } // namespace
@@ -347,9 +460,28 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
     return failure();
   SmallVector<Type> newResultTypes = {newRetTy};
 
+  // sret return: the value is returned through a hidden pointer prepended as
+  // argument 0.  The wire return type was already set to void by
+  // computeNewReturnType.  Every classification index therefore maps to a
+  // block argument shifted by this offset in the body handling below.
+  bool hasSRet =
+      fc.returnInfo.kind == ArgKind::Indirect && !oldResultTypes.empty();
+  if (hasSRet)
+    newArgTypes.insert(newArgTypes.begin(), cir::PointerType::get(origRetTy));
+  unsigned sretOffset = hasSRet ? 1 : 0;
+
   if (funcOp.isDefinition()) {
     Region &body = funcOp->getRegion(0);
     if (!body.empty()) {
+      // Prepend the sret pointer block argument and route every cir.return
+      // through it before any index-based argument handling below (which
+      // then accounts for the +1 offset).
+      if (hasSRet) {
+        body.front().insertArgument(0u, cir::PointerType::get(origRetTy),
+                                    funcOp.getLoc());
+        insertSRetStores(funcOp, origRetTy, builder);
+      }
+
       // In-body coercion for Direct-with-coerce / Extend args: change
       // block-arg types to the coerced types and insert a memory roundtrip
       // at the top of the entry block that converts each coerced value back
@@ -357,7 +489,7 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
       // in-body cir.call operands) through the recovered value.  Done before
       // the Ignore-drop below so the entry block argument indices used here
       // still refer to the original positions.
-      insertArgCoercion(funcOp, fc, builder, dl);
+      insertArgCoercion(funcOp, fc, builder, dl, sretOffset);
 
       // Direct return with coerced type: insert a coercion at every
       // cir.return so the returned value matches the (coerced) return
@@ -379,16 +511,17 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
            blockIdx >= 0; --blockIdx) {
         if (fc.argInfos[blockIdx].kind != ArgKind::Ignore)
           continue;
-        if (static_cast<unsigned>(blockIdx) >= entry.getNumArguments())
+        unsigned realIdx = static_cast<unsigned>(blockIdx) + sretOffset;
+        if (realIdx >= entry.getNumArguments())
           continue;
-        BlockArgument arg = entry.getArgument(blockIdx);
+        BlockArgument arg = entry.getArgument(realIdx);
         if (!arg.use_empty()) {
           builder.setInsertionPointToStart(&entry);
           Value poison =
               createIgnoredValue(builder, funcOp.getLoc(), arg.getType());
           arg.replaceAllUsesWith(poison);
         }
-        entry.eraseArgument(blockIdx);
+        entry.eraseArgument(realIdx);
       }
     }
 
@@ -416,15 +549,31 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
   Type newFnTy = funcOp.cloneTypeWith(newArgTypes, newResultTypes);
   funcOp.setFunctionTypeAttr(TypeAttr::get(newFnTy));
 
-  // Rebuild arg_attrs when any arg is Ignore (dropped from the output array)
+  // Rebuild arg_attrs when the function has an sret slot (slot 0 needs the
+  // sret attribute set) or any arg is Ignore (dropped from the output array)
   // or Extend (needs llvm.signext / llvm.zeroext layered on).
   bool needsArgAttrUpdate =
-      llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
+      hasSRet || llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
         return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend;
       });
   if (needsArgAttrUpdate) {
     auto existing = funcOp->getAttrOfType<ArrayAttr>("arg_attrs");
-    funcOp->setAttr("arg_attrs", updateArgAttrs(ctx, existing, fc));
+    ArrayAttr updated = updateArgAttrs(ctx, existing, fc);
+    if (hasSRet) {
+      // Prepend the sret slot's attribute dict (slot 0); the per-argument
+      // dicts shift to slots 1..N.  noalias is valid only on the callee's
+      // parameter, so it is added only for definitions.
+      SmallVector<NamedAttribute> sretAttrs = buildSretSlotAttrs(
+          builder, origRetTy, fc.returnInfo.indirectAlign.value(),
+          /*withNoalias=*/funcOp.isDefinition());
+      SmallVector<Attribute> withSret;
+      withSret.push_back(DictionaryAttr::get(ctx, sretAttrs));
+      for (Attribute a : updated)
+        withSret.push_back(a);
+      funcOp->setAttr("arg_attrs", ArrayAttr::get(ctx, withSret));
+    } else {
+      funcOp->setAttr("arg_attrs", updated);
+    }
   }
 
   // Rebuild res_attrs: layer llvm.signext / llvm.zeroext onto an Extend
@@ -496,6 +645,90 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
   bool hasResult = call.getNumResults() > 0;
   Type origRetTy =
       hasResult ? call.getResult().getType() : cir::VoidType::get(ctx);
+
+  // sret return: prepend a return-slot pointer to the call, make the call
+  // return void, and load the result back out of the slot.  Handled as an
+  // early return because the coerce / extend / ignore return handling below
+  // does not apply to an indirect return.
+  if (fc.returnInfo.kind == ArgKind::Indirect && hasResult) {
+    auto ptrTy = cir::PointerType::get(origRetTy);
+    builder.setInsertionPoint(call);
+    uint64_t sretAlign = fc.returnInfo.indirectAlign.value();
+
+    // CIRGen emits `cir.store %callResult, %dest` when the call's result is
+    // bound to a local (e.g. `T s = make();`).  Allocating a fresh sret slot
+    // and copying into %dest would byte-copy the record, which is wrong for
+    // non-trivially-copyable types (the libstdc++ SSO `_M_p` pointer
+    // survives a byte-copy but ends up pointing at the dying temp's local
+    // buffer, so the destination's destructor later `free()`s a stack
+    // pointer).  When the result has a single store-into-%dest use, use
+    // %dest as the sret slot directly so construction flows into it,
+    // matching classic CodeGen's "pass %s as sret" pattern.  %dest must
+    // dominate the call so the rewritten call (which takes it as operand 0)
+    // does not use a value before its definition.
+    Value sretSlot = nullptr;
+    cir::StoreOp reuseStore = nullptr;
+    if (call.getResult().hasOneUse()) {
+      Operation *user = *call.getResult().getUsers().begin();
+      if (auto store = dyn_cast<cir::StoreOp>(user))
+        if (store.getValue() == call.getResult() &&
+            store.getAddr().getType() == ptrTy &&
+            mlir::DominanceInfo().properlyDominates(store.getAddr(), call)) {
+          sretSlot = store.getAddr();
+          reuseStore = store;
+        }
+    }
+    if (!sretSlot) {
+      auto alloca = cir::AllocaOp::create(
+          builder, call.getLoc(), ptrTy, origRetTy,
+          /*name=*/builder.getStringAttr("sret"),
+          /*alignment=*/builder.getI64IntegerAttr(sretAlign));
+      sretSlot = alloca;
+    }
+
+    SmallVector<Value> sretArgs;
+    sretArgs.push_back(sretSlot);
+    sretArgs.append(newArgs.begin(), newArgs.end());
+
+    Type sretVoidTy = cir::VoidType::get(ctx);
+    auto newCall = cir::CallOp::create(
+        builder, call.getLoc(), call.getCalleeAttr(), sretVoidTy, sretArgs);
+    for (NamedAttribute attr : call->getAttrs())
+      if (!newCall->hasAttr(attr.getName()))
+        newCall->setAttr(attr.getName(), attr.getValue());
+
+    // Shape the per-argument attrs exactly as the non-sret path does
+    // (signext / zeroext for Extend, drop Ignore slots) before prepending
+    // the sret slot, so sret composes correctly with Extend / Ignore args.
+    ArrayAttr argAttrs = call->getAttrOfType<ArrayAttr>("arg_attrs");
+    bool needsArgAttrUpdate =
+        llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
+          return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend;
+        });
+    if (needsArgAttrUpdate)
+      argAttrs = updateArgAttrs(ctx, argAttrs, fc);
+    applySretSlotAttrs(newCall, argAttrs, origRetTy, sretAlign, builder);
+
+    if (reuseStore) {
+      // The callee now constructs directly into the destination slot, so the
+      // original store-from-result is redundant; dropping it avoids a
+      // byte-copy of the record.
+      reuseStore->erase();
+    } else {
+      builder.setInsertionPointAfter(newCall);
+      auto load =
+          cir::LoadOp::create(builder, call.getLoc(), origRetTy, sretSlot,
+                              /*isDeref=*/mlir::UnitAttr(),
+                              /*isVolatile=*/mlir::UnitAttr(),
+                              /*alignment=*/mlir::IntegerAttr(),
+                              /*sync_scope=*/cir::SyncScopeKindAttr(),
+                              /*mem_order=*/cir::MemOrderAttr());
+      call.getResult().replaceAllUsesWith(load);
+    }
+    call->erase();
+    return success();
+  }
+
   Type callRetTy = origRetTy;
   if (fc.returnInfo.kind == ArgKind::Ignore && hasResult)
     callRetTy = cir::VoidType::get(ctx);

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
@@ -111,8 +111,9 @@ computeNewReturnType(mlir::Type origRetTy, const ArgClassification &retInfo,
     // llvm.signext / llvm.zeroext res attribute attached separately below.
     return origRetTy;
   case ArgKind::Indirect:
-    // sret: the value is returned through a hidden pointer argument that
-    // rewriteFunctionDefinition prepends to the argument list, so the wire
+    // sret: the value is returned through a pointer argument that the ABI
+    // synthesizes (rewriteFunctionDefinition prepends it to the argument
+    // list); it is not part of the source-level signature, so the wire
     // return type becomes void.
     return cir::VoidType::get(ctx);
   }
@@ -410,6 +411,9 @@ llvm::SmallVector<mlir::NamedAttribute>
 buildSretSlotAttrs(mlir::OpBuilder &builder, mlir::Type retTy, uint64_t align,
                    bool withNoalias) {
   llvm::SmallVector<mlir::NamedAttribute> attrs;
+  // The sret type must be carried explicitly: LLVM's sret attribute requires
+  // it, and once the CIR `!cir.ptr<retTy>` lowers to an opaque LLVM `ptr` the
+  // pointee type can no longer be recovered from the pointer.
   attrs.push_back(
       builder.getNamedAttr("llvm.sret", mlir::TypeAttr::get(retTy)));
   attrs.push_back(
@@ -440,10 +444,11 @@ void applySretSlotAttrs(cir::CallOp newCall, mlir::ArrayAttr argAttrs,
   newArgAttrs.reserve(newCall.getArgOperands().size());
   newArgAttrs.push_back(mlir::DictionaryAttr::get(ctx, sretAttrs));
   if (argAttrs)
-    for (mlir::Attribute a : argAttrs)
-      newArgAttrs.push_back(a);
-  while (newArgAttrs.size() < newCall.getArgOperands().size())
-    newArgAttrs.push_back(mlir::DictionaryAttr::get(ctx));
+    llvm::append_range(newArgAttrs, argAttrs);
+  assert(newArgAttrs.size() <= newCall.getArgOperands().size() &&
+         "arg_attrs wider than the rewritten call's operand list");
+  newArgAttrs.resize(newCall.getArgOperands().size(),
+                     mlir::DictionaryAttr::get(ctx));
   newCall->setAttr("arg_attrs", mlir::ArrayAttr::get(ctx, newArgAttrs));
 }
 
@@ -485,10 +490,12 @@ mlir::LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
     return mlir::failure();
   llvm::SmallVector<mlir::Type> newResultTypes = {newRetTy};
 
-  // sret return: the value is returned through a hidden pointer prepended as
-  // argument 0.  The wire return type was already set to void by
-  // computeNewReturnType.  Every classification index therefore maps to a
-  // block argument shifted by one in the body handling below.
+  // sret return: the value is returned through a pointer the ABI inserts as
+  // argument 0.  This pointer is not part of the function's source-level
+  // signature -- it is synthesized here -- and the wire return type was
+  // already set to void by computeNewReturnType.  Every classification index
+  // therefore maps to a block argument shifted by one in the body handling
+  // below.
   bool hasSRet =
       fc.returnInfo.kind == ArgKind::Indirect && !oldResultTypes.empty();
   if (hasSRet)
@@ -531,21 +538,21 @@ mlir::LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
       // passed at the ABI level, so any remaining uses are vacuous;
       // poison says exactly that.  Iterate in reverse so that earlier
       // indices stay stable as later ones are erased.
-      for (int blockIdx = static_cast<int>(fc.argInfos.size()) - 1;
-           blockIdx >= 0; --blockIdx) {
-        if (fc.argInfos[blockIdx].kind != ArgKind::Ignore)
+      for (int argInfoIdx = static_cast<int>(fc.argInfos.size()) - 1;
+           argInfoIdx >= 0; --argInfoIdx) {
+        if (fc.argInfos[argInfoIdx].kind != ArgKind::Ignore)
           continue;
-        unsigned realIdx = static_cast<unsigned>(blockIdx) + hasSRet;
-        if (realIdx >= entry.getNumArguments())
+        unsigned blockIdx = static_cast<unsigned>(argInfoIdx) + hasSRet;
+        if (blockIdx >= entry.getNumArguments())
           continue;
-        mlir::BlockArgument arg = entry.getArgument(realIdx);
+        mlir::BlockArgument arg = entry.getArgument(blockIdx);
         if (!arg.use_empty()) {
           builder.setInsertionPointToStart(&entry);
           mlir::Value poison =
               createIgnoredValue(builder, funcOp.getLoc(), arg.getType());
           arg.replaceAllUsesWith(poison);
         }
-        entry.eraseArgument(realIdx);
+        entry.eraseArgument(blockIdx);
       }
     }
 
@@ -592,8 +599,7 @@ mlir::LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
           /*withNoalias=*/funcOp.isDefinition());
       llvm::SmallVector<mlir::Attribute> withSret;
       withSret.push_back(mlir::DictionaryAttr::get(ctx, sretAttrs));
-      for (mlir::Attribute a : updated)
-        withSret.push_back(a);
+      llvm::append_range(withSret, updated);
       funcOp->setAttr("arg_attrs", mlir::ArrayAttr::get(ctx, withSret));
     } else {
       funcOp->setAttr("arg_attrs", updated);

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
@@ -13,7 +13,6 @@
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 
 using namespace cir;
-using namespace mlir;
 using namespace mlir::abi;
 
 // This rewrite context supports the Direct (with or without coercion),
@@ -46,14 +45,15 @@ bool needsRewrite(const FunctionClassification &fc) {
 /// Indirect (byval) arguments and Expand emit an error.  The sret return
 /// pointer, when present, is prepended by rewriteFunctionDefinition rather
 /// than here.
-LogicalResult buildNewArgTypes(ArrayRef<Type> oldArgTypes,
-                               const FunctionClassification &fc,
-                               SmallVectorImpl<Type> &newArgTypes,
-                               function_ref<InFlightDiagnostic()> emitError) {
+mlir::LogicalResult
+buildNewArgTypes(llvm::ArrayRef<mlir::Type> oldArgTypes,
+                 const FunctionClassification &fc,
+                 llvm::SmallVectorImpl<mlir::Type> &newArgTypes,
+                 llvm::function_ref<mlir::InFlightDiagnostic()> emitError) {
   assert(newArgTypes.empty() && "expected an empty output vector");
   newArgTypes.reserve(oldArgTypes.size());
   for (auto [idx, ac] : llvm::enumerate(fc.argInfos)) {
-    Type origTy = oldArgTypes[idx];
+    mlir::Type origTy = oldArgTypes[idx];
     switch (ac.kind) {
     case ArgKind::Direct:
       // Direct with a coerced type means the wire signature uses the
@@ -67,7 +67,7 @@ LogicalResult buildNewArgTypes(ArrayRef<Type> oldArgTypes,
     case ArgKind::Expand:
       emitError() << "Expand at arg " << idx
                   << " not yet implemented in CallConvLowering";
-      return failure();
+      return mlir::failure();
     case ArgKind::Extend:
       // Extend keeps the original (narrow) type in the signature; the
       // sign/zero extension is communicated to LLVM via the llvm.signext /
@@ -80,19 +80,20 @@ LogicalResult buildNewArgTypes(ArrayRef<Type> oldArgTypes,
     case ArgKind::Indirect:
       emitError() << "Indirect at arg " << idx
                   << " not yet implemented in CallConvLowering";
-      return failure();
+      return mlir::failure();
     }
   }
-  return success();
+  return mlir::success();
 }
 
 /// Compute the new return type for a function whose return classification
 /// is \p retInfo.  Direct returns keep (or coerce to) their type, Ignore and
 /// Indirect (sret) returns become void, Extend keeps its type; Expand emits
 /// an error.
-Type computeNewReturnType(Type origRetTy, const ArgClassification &retInfo,
-                          MLIRContext *ctx,
-                          function_ref<InFlightDiagnostic()> emitError) {
+mlir::Type
+computeNewReturnType(mlir::Type origRetTy, const ArgClassification &retInfo,
+                     mlir::MLIRContext *ctx,
+                     llvm::function_ref<mlir::InFlightDiagnostic()> emitError) {
   switch (retInfo.kind) {
   case ArgKind::Direct:
     // Direct return with a coerced type uses the coerced type on the wire;
@@ -123,57 +124,64 @@ Type computeNewReturnType(Type origRetTy, const ArgClassification &retInfo,
 /// classification is Ignore.  Using poison is honest -- the value is
 /// genuinely unused at the ABI boundary -- and avoids a fake alloca+load
 /// pattern that would suggest we have a value when we don't.
-Value createIgnoredValue(OpBuilder &builder, Location loc, Type ty) {
+mlir::Value createIgnoredValue(mlir::OpBuilder &builder, mlir::Location loc,
+                               mlir::Type ty) {
   return cir::ConstantOp::create(builder, loc, ty, cir::PoisonAttr::get(ty));
 }
 
 /// Build an updated arg_attrs ArrayAttr that drops Ignore'd args and adds
 /// llvm.signext / llvm.zeroext on Extend args.  Preserves any existing arg
 /// attributes on retained arg slots.
-ArrayAttr updateArgAttrs(MLIRContext *ctx, ArrayAttr existingArgAttrs,
-                         const FunctionClassification &fc) {
-  SmallVector<Attribute> newArgAttrs;
+mlir::ArrayAttr updateArgAttrs(mlir::MLIRContext *ctx,
+                               mlir::ArrayAttr existingArgAttrs,
+                               const FunctionClassification &fc) {
+  llvm::SmallVector<mlir::Attribute> newArgAttrs;
   newArgAttrs.reserve(fc.argInfos.size());
   for (auto [oldIdx, ac] : llvm::enumerate(fc.argInfos)) {
     if (ac.kind == ArgKind::Ignore)
       continue;
-    DictionaryAttr existing = DictionaryAttr::get(ctx);
+    mlir::DictionaryAttr existing = mlir::DictionaryAttr::get(ctx);
     if (existingArgAttrs && oldIdx < existingArgAttrs.size())
-      existing = cast<DictionaryAttr>(existingArgAttrs[oldIdx]);
+      existing = mlir::cast<mlir::DictionaryAttr>(existingArgAttrs[oldIdx]);
     if (ac.kind == ArgKind::Extend) {
-      StringRef attrName = ac.signExtend ? "llvm.signext" : "llvm.zeroext";
-      NamedAttribute extAttr(StringAttr::get(ctx, attrName),
-                             UnitAttr::get(ctx));
+      llvm::StringRef attrName =
+          ac.signExtend ? "llvm.signext" : "llvm.zeroext";
+      mlir::NamedAttribute extAttr(mlir::StringAttr::get(ctx, attrName),
+                                   mlir::UnitAttr::get(ctx));
       if (existing.empty()) {
-        newArgAttrs.push_back(DictionaryAttr::get(ctx, {extAttr}));
+        newArgAttrs.push_back(mlir::DictionaryAttr::get(ctx, {extAttr}));
       } else {
-        SmallVector<NamedAttribute> attrs(existing.begin(), existing.end());
+        llvm::SmallVector<mlir::NamedAttribute> attrs(existing.begin(),
+                                                      existing.end());
         attrs.push_back(extAttr);
-        newArgAttrs.push_back(DictionaryAttr::get(ctx, attrs));
+        newArgAttrs.push_back(mlir::DictionaryAttr::get(ctx, attrs));
       }
     } else {
       newArgAttrs.push_back(existing);
     }
   }
-  return ArrayAttr::get(ctx, newArgAttrs);
+  return mlir::ArrayAttr::get(ctx, newArgAttrs);
 }
 
 /// Build an updated res_attrs ArrayAttr (single entry, since CIR funcs have
 /// at most one result) that adds llvm.signext / llvm.zeroext on an Extend
 /// return.  Preserves any existing res attributes.
-ArrayAttr updateResAttrs(MLIRContext *ctx, ArrayAttr existingResAttrs,
-                         const ArgClassification &retInfo) {
+mlir::ArrayAttr updateResAttrs(mlir::MLIRContext *ctx,
+                               mlir::ArrayAttr existingResAttrs,
+                               const ArgClassification &retInfo) {
   if (retInfo.kind != ArgKind::Extend)
     return existingResAttrs;
 
-  SmallVector<NamedAttribute> attrs;
+  llvm::SmallVector<mlir::NamedAttribute> attrs;
   if (existingResAttrs && !existingResAttrs.empty())
-    for (NamedAttribute na : cast<DictionaryAttr>(existingResAttrs[0]))
+    for (mlir::NamedAttribute na :
+         mlir::cast<mlir::DictionaryAttr>(existingResAttrs[0]))
       attrs.push_back(na);
-  StringRef attrName = retInfo.signExtend ? "llvm.signext" : "llvm.zeroext";
-  attrs.push_back(
-      NamedAttribute(StringAttr::get(ctx, attrName), UnitAttr::get(ctx)));
-  return ArrayAttr::get(ctx, {DictionaryAttr::get(ctx, attrs)});
+  llvm::StringRef attrName =
+      retInfo.signExtend ? "llvm.signext" : "llvm.zeroext";
+  attrs.push_back(mlir::NamedAttribute(mlir::StringAttr::get(ctx, attrName),
+                                       mlir::UnitAttr::get(ctx)));
+  return mlir::ArrayAttr::get(ctx, {mlir::DictionaryAttr::get(ctx, attrs)});
 }
 
 /// Coerce \p src to type \p dstTy at the current builder insertion point by
@@ -196,17 +204,20 @@ ArrayAttr updateResAttrs(MLIRContext *ctx, ArrayAttr existingResAttrs,
 /// Any operations the helper creates are appended to \p createdOps so the
 /// caller can pass them to replaceAllUsesExcept and avoid clobbering the
 /// store's value operand when later rewiring the source value.
-Value emitCoercion(OpBuilder &rewriter, Location loc, Type dstTy, Value src,
-                   FunctionOpInterface funcOp, const DataLayout &dl,
-                   SmallPtrSetImpl<Operation *> &createdOps) {
-  Type srcTy = src.getType();
+mlir::Value emitCoercion(mlir::OpBuilder &builder, mlir::Location loc,
+                         mlir::Type dstTy, mlir::Value src,
+                         mlir::FunctionOpInterface funcOp,
+                         const mlir::DataLayout &dl,
+                         llvm::SmallPtrSetImpl<mlir::Operation *> &createdOps) {
+  mlir::Type srcTy = src.getType();
   assert(srcTy != dstTy &&
          "emitCoercion callers must pre-check that the types differ");
 
   uint64_t srcAlign = dl.getTypeABIAlignment(srcTy);
   uint64_t dstAlign = dl.getTypeABIAlignment(dstTy);
   uint64_t allocaAlign = std::max(srcAlign, dstAlign);
-  Type slotTy = dl.getTypeSize(srcTy) >= dl.getTypeSize(dstTy) ? srcTy : dstTy;
+  mlir::Type slotTy =
+      dl.getTypeSize(srcTy) >= dl.getTypeSize(dstTy) ? srcTy : dstTy;
 
   auto slotPtrTy = cir::PointerType::get(slotTy);
   auto srcPtrTy = cir::PointerType::get(srcTy);
@@ -214,63 +225,66 @@ Value emitCoercion(OpBuilder &rewriter, Location loc, Type dstTy, Value src,
 
   cir::AllocaOp alloca;
   {
-    OpBuilder::InsertionGuard guard(rewriter);
-    Block &entry = funcOp->getRegion(0).front();
-    rewriter.setInsertionPointToStart(&entry);
-    alloca = cir::AllocaOp::create(rewriter, loc, slotPtrTy,
-                                   rewriter.getStringAttr("coerce"),
-                                   rewriter.getI64IntegerAttr(allocaAlign));
+    mlir::OpBuilder::InsertionGuard guard(builder);
+    mlir::Block &entry = funcOp->getRegion(0).front();
+    builder.setInsertionPointToStart(&entry);
+    alloca = cir::AllocaOp::create(builder, loc, slotPtrTy,
+                                   builder.getStringAttr("coerce"),
+                                   builder.getI64IntegerAttr(allocaAlign));
   }
   createdOps.insert(alloca);
 
   // Store through a source-typed view of the slot.
-  Value srcSlot = alloca;
+  mlir::Value srcSlot = alloca;
   if (slotTy != srcTy) {
-    auto srcCast = cir::CastOp::create(rewriter, loc, srcPtrTy,
+    auto srcCast = cir::CastOp::create(builder, loc, srcPtrTy,
                                        cir::CastKind::bitcast, alloca);
     createdOps.insert(srcCast);
     srcSlot = srcCast;
   }
-  auto store = cir::StoreOp::create(rewriter, loc, src, srcSlot);
+  auto store = cir::StoreOp::create(builder, loc, src, srcSlot);
   createdOps.insert(store);
 
   // Load through a destination-typed view of the slot.
-  Value dstSlot = alloca;
+  mlir::Value dstSlot = alloca;
   if (slotTy != dstTy) {
-    auto dstCast = cir::CastOp::create(rewriter, loc, dstPtrTy,
+    auto dstCast = cir::CastOp::create(builder, loc, dstPtrTy,
                                        cir::CastKind::bitcast, alloca);
     createdOps.insert(dstCast);
     dstSlot = dstCast;
   }
-  auto load = cir::LoadOp::create(rewriter, loc, dstSlot);
+  auto load = cir::LoadOp::create(builder, loc, dstSlot);
   createdOps.insert(load);
   return load;
 }
 
 /// Convenience overload for callers that don't need the createdOps set
 /// (e.g. call-site coercion where we don't replaceAllUsesExcept).
-Value emitCoercion(OpBuilder &rewriter, Location loc, Type dstTy, Value src,
-                   FunctionOpInterface funcOp, const DataLayout &dl) {
-  SmallPtrSet<Operation *, 4> ignored;
-  return emitCoercion(rewriter, loc, dstTy, src, funcOp, dl, ignored);
+mlir::Value emitCoercion(mlir::OpBuilder &builder, mlir::Location loc,
+                         mlir::Type dstTy, mlir::Value src,
+                         mlir::FunctionOpInterface funcOp,
+                         const mlir::DataLayout &dl) {
+  llvm::SmallPtrSet<mlir::Operation *, 4> ignored;
+  return emitCoercion(builder, loc, dstTy, src, funcOp, dl, ignored);
 }
 
 /// Insert coercion before each cir.return so the returned value matches the
 /// new (coerced) return type.
-void insertReturnCoercion(FunctionOpInterface funcOp, Type origRetTy,
-                          Type coercedRetTy, OpBuilder &rewriter,
-                          const DataLayout &dl) {
-  SmallVector<cir::ReturnOp> returns;
+void insertReturnCoercion(mlir::FunctionOpInterface funcOp,
+                          mlir::Type origRetTy, mlir::Type coercedRetTy,
+                          mlir::OpBuilder &builder,
+                          const mlir::DataLayout &dl) {
+  llvm::SmallVector<cir::ReturnOp> returns;
   funcOp.walk([&](cir::ReturnOp r) { returns.push_back(r); });
   for (cir::ReturnOp r : returns) {
     if (r.getInput().empty())
       continue;
-    Value origVal = r.getInput()[0];
+    mlir::Value origVal = r.getInput()[0];
     if (origVal.getType() == coercedRetTy)
       continue;
-    rewriter.setInsertionPoint(r);
-    Value coerced =
-        emitCoercion(rewriter, r.getLoc(), coercedRetTy, origVal, funcOp, dl);
+    builder.setInsertionPoint(r);
+    mlir::Value coerced =
+        emitCoercion(builder, r.getLoc(), coercedRetTy, origVal, funcOp, dl);
     r->setOperand(0, coerced);
   }
 }
@@ -278,36 +292,40 @@ void insertReturnCoercion(FunctionOpInterface funcOp, Type origRetTy,
 /// For each Direct arg with a coerced type, change the block argument's type
 /// to the coerced type and insert a coercion at function entry that maps it
 /// back to the original type for body uses.
-/// \p sretOffset is 1 when the function has an sret return (a hidden return
-/// pointer is prepended as block argument 0), so classification index \p idx
-/// maps to block argument \p idx + \p sretOffset.
-void insertArgCoercion(FunctionOpInterface funcOp,
-                       const FunctionClassification &fc, OpBuilder &rewriter,
-                       const DataLayout &dl, unsigned sretOffset) {
-  Region &body = funcOp->getRegion(0);
+///
+/// The entry block arguments mirror the function's ABI signature: argument
+/// \p hasSRetArg shifts the classification index by one because a hidden
+/// sret pointer occupies block argument 0 when the function returns by
+/// reference.  So fc.argInfos[i] corresponds to block argument
+/// i + hasSRetArg.
+void insertArgCoercion(mlir::FunctionOpInterface funcOp,
+                       const FunctionClassification &fc,
+                       mlir::OpBuilder &builder, const mlir::DataLayout &dl,
+                       bool hasSRetArg) {
+  mlir::Region &body = funcOp->getRegion(0);
   if (body.empty())
     return;
-  Block &entry = body.front();
+  mlir::Block &entry = body.front();
 
   for (auto [idx, ac] : llvm::enumerate(fc.argInfos)) {
     if (ac.kind != ArgKind::Direct || !ac.coercedType)
       continue;
-    unsigned blockIdx = idx + sretOffset;
+    unsigned blockIdx = idx + hasSRetArg;
     if (blockIdx >= entry.getNumArguments())
       continue;
 
-    BlockArgument blockArg = entry.getArgument(blockIdx);
-    Type oldArgTy = blockArg.getType();
-    Type newArgTy = ac.coercedType;
+    mlir::BlockArgument blockArg = entry.getArgument(blockIdx);
+    mlir::Type oldArgTy = blockArg.getType();
+    mlir::Type newArgTy = ac.coercedType;
     if (oldArgTy == newArgTy)
       continue;
 
     blockArg.setType(newArgTy);
 
-    rewriter.setInsertionPointToStart(&entry);
-    SmallPtrSet<Operation *, 4> coercionOps;
-    Value adapted = emitCoercion(rewriter, funcOp.getLoc(), oldArgTy, blockArg,
-                                 funcOp, dl, coercionOps);
+    builder.setInsertionPointToStart(&entry);
+    llvm::SmallPtrSet<mlir::Operation *, 4> coercionOps;
+    mlir::Value adapted = emitCoercion(builder, funcOp.getLoc(), oldArgTy,
+                                       blockArg, funcOp, dl, coercionOps);
 
     // Replace blockArg uses with the adapted value, except inside the helper
     // ops we just created.  This is critical: the StoreOp's value operand is
@@ -345,32 +363,38 @@ void insertArgCoercion(FunctionOpInterface funcOp,
 /// `cir.return (cir.load <alloca>)` shape is an invariant guaranteed by
 /// CIRGen, so it is asserted via `cast<>` rather than guarded with a
 /// fallback.
-void insertSRetStores(FunctionOpInterface funcOp, Type origRetTy,
-                      OpBuilder &rewriter) {
-  Value sretPtr = funcOp.getArguments()[0];
+void insertSRetStores(mlir::FunctionOpInterface funcOp, mlir::Type origRetTy,
+                      mlir::OpBuilder &builder) {
+  mlir::Value sretPtr = funcOp.getArguments()[0];
 
-  SmallVector<cir::ReturnOp> returnOps;
+  llvm::SmallVector<cir::ReturnOp> returnOps;
   funcOp->walk([&](cir::ReturnOp retOp) { returnOps.push_back(retOp); });
 
   cir::AllocaOp retAlloca = nullptr;
   for (cir::ReturnOp retOp : returnOps) {
-    if (retOp.getInput().empty())
-      continue;
+    // Every cir.return in an sret function must carry the loaded return
+    // value -- a bare return would mean the sret slot was never written.
+    assert(!retOp.getInput().empty() &&
+           "cir.return in sret function must have an operand");
 
     cir::LoadOp retLoad =
-        cast<cir::LoadOp>(retOp.getInput()[0].getDefiningOp());
+        mlir::cast<cir::LoadOp>(retOp.getInput()[0].getDefiningOp());
 
-    // Rewire the shared `__retval` alloca to the sret pointer once; all
-    // other returns' loads point at the same alloca and are updated by the
-    // replaceAllUsesWith below.
+    // Rewire the shared `__retval` alloca to the sret pointer once.
+    // replaceAllUsesWith updates every load of the alloca (including those
+    // feeding the other cir.return ops) to read from sretPtr instead, so
+    // all returns are covered by this single rewiring.  Only then is the
+    // now-unused alloca safe to erase.
     if (!retAlloca) {
-      retAlloca = cast<cir::AllocaOp>(retLoad.getAddr().getDefiningOp());
+      retAlloca = mlir::cast<cir::AllocaOp>(retLoad.getAddr().getDefiningOp());
       retAlloca.getResult().replaceAllUsesWith(sretPtr);
       retAlloca->erase();
     }
 
-    rewriter.setInsertionPoint(retOp);
-    cir::ReturnOp::create(rewriter, retOp.getLoc());
+    // The sret slot now holds the return value directly; replace the
+    // value-carrying return with a void return (no operand).
+    builder.setInsertionPoint(retOp);
+    cir::ReturnOp::create(builder, retOp.getLoc());
     retOp->erase();
     if (retLoad.use_empty())
       retLoad->erase();
@@ -382,20 +406,20 @@ void insertSRetStores(FunctionOpInterface funcOp, Type origRetTy,
 /// `sret(T) align A [noalias] writable dead_on_unwind`.  noalias is only
 /// valid on the callee's parameter, not at the call site, so it is gated by
 /// \p withNoalias.  Key order is irrelevant: DictionaryAttr sorts by name.
-SmallVector<NamedAttribute> buildSretSlotAttrs(OpBuilder &rewriter, Type retTy,
-                                               uint64_t align,
-                                               bool withNoalias) {
-  SmallVector<NamedAttribute> attrs;
-  attrs.push_back(rewriter.getNamedAttr("llvm.sret", TypeAttr::get(retTy)));
+llvm::SmallVector<mlir::NamedAttribute>
+buildSretSlotAttrs(mlir::OpBuilder &builder, mlir::Type retTy, uint64_t align,
+                   bool withNoalias) {
+  llvm::SmallVector<mlir::NamedAttribute> attrs;
   attrs.push_back(
-      rewriter.getNamedAttr("llvm.align", rewriter.getI64IntegerAttr(align)));
+      builder.getNamedAttr("llvm.sret", mlir::TypeAttr::get(retTy)));
+  attrs.push_back(
+      builder.getNamedAttr("llvm.align", builder.getI64IntegerAttr(align)));
   if (withNoalias)
     attrs.push_back(
-        rewriter.getNamedAttr("llvm.noalias", rewriter.getUnitAttr()));
+        builder.getNamedAttr("llvm.noalias", builder.getUnitAttr()));
+  attrs.push_back(builder.getNamedAttr("llvm.writable", builder.getUnitAttr()));
   attrs.push_back(
-      rewriter.getNamedAttr("llvm.writable", rewriter.getUnitAttr()));
-  attrs.push_back(
-      rewriter.getNamedAttr("llvm.dead_on_unwind", rewriter.getUnitAttr()));
+      builder.getNamedAttr("llvm.dead_on_unwind", builder.getUnitAttr()));
   return attrs;
 }
 
@@ -405,41 +429,42 @@ SmallVector<NamedAttribute> buildSretSlotAttrs(OpBuilder &rewriter, Type retTy,
 /// must already be shaped for the rewritten argument list (Extend slots
 /// carry signext/zeroext, Ignore slots dropped); it is shifted to slots
 /// 1..N behind the sret slot.
-void applySretSlotAttrs(cir::CallOp newCall, ArrayAttr argAttrs, Type retTy,
-                        uint64_t align, OpBuilder &rewriter) {
-  MLIRContext *ctx = newCall->getContext();
-  SmallVector<NamedAttribute> sretAttrs =
-      buildSretSlotAttrs(rewriter, retTy, align, /*withNoalias=*/false);
+void applySretSlotAttrs(cir::CallOp newCall, mlir::ArrayAttr argAttrs,
+                        mlir::Type retTy, uint64_t align,
+                        mlir::OpBuilder &builder) {
+  mlir::MLIRContext *ctx = newCall->getContext();
+  llvm::SmallVector<mlir::NamedAttribute> sretAttrs =
+      buildSretSlotAttrs(builder, retTy, align, /*withNoalias=*/false);
 
-  SmallVector<Attribute> newArgAttrs;
+  llvm::SmallVector<mlir::Attribute> newArgAttrs;
   newArgAttrs.reserve(newCall.getArgOperands().size());
-  newArgAttrs.push_back(DictionaryAttr::get(ctx, sretAttrs));
+  newArgAttrs.push_back(mlir::DictionaryAttr::get(ctx, sretAttrs));
   if (argAttrs)
-    for (Attribute a : argAttrs)
+    for (mlir::Attribute a : argAttrs)
       newArgAttrs.push_back(a);
   while (newArgAttrs.size() < newCall.getArgOperands().size())
-    newArgAttrs.push_back(DictionaryAttr::get(ctx));
-  newCall->setAttr("arg_attrs", ArrayAttr::get(ctx, newArgAttrs));
+    newArgAttrs.push_back(mlir::DictionaryAttr::get(ctx));
+  newCall->setAttr("arg_attrs", mlir::ArrayAttr::get(ctx, newArgAttrs));
 }
 
 } // namespace
 
-LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
-    FunctionOpInterface funcOpInterface, const FunctionClassification &fc,
-    OpBuilder &builder) {
+mlir::LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
+    mlir::FunctionOpInterface funcOpInterface, const FunctionClassification &fc,
+    mlir::OpBuilder &builder) {
   // The pass driver (CallConvLoweringPass) only ever hands us cir.func ops.
   // Cast once at the top so the rest of the function reads in CIR's own
   // vocabulary, and so we can dispatch to the CIRGlobalValueInterface for
   // isDefinition() (FunctionOpInterface alone does not inherit from
   // CIRGlobalValueInterface).
-  cir::FuncOp funcOp = cast<cir::FuncOp>(funcOpInterface);
+  cir::FuncOp funcOp = mlir::cast<cir::FuncOp>(funcOpInterface);
 
   if (!needsRewrite(fc))
-    return success();
+    return mlir::success();
 
-  ArrayRef<Type> oldArgTypes = funcOp.getArgumentTypes();
-  ArrayRef<Type> oldResultTypes = funcOp.getResultTypes();
-  MLIRContext *ctx = funcOp->getContext();
+  llvm::ArrayRef<mlir::Type> oldArgTypes = funcOp.getArgumentTypes();
+  llvm::ArrayRef<mlir::Type> oldResultTypes = funcOp.getResultTypes();
+  mlir::MLIRContext *ctx = funcOp->getContext();
 
   // CIR follows LLVM IR's single-result rule: a function returns either
   // zero or one value.  Document the invariant so a future multi-result
@@ -447,31 +472,30 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
   assert(oldResultTypes.size() <= 1 &&
          "CIR functions return zero or one value");
 
-  SmallVector<Type> newArgTypes;
-  if (failed(buildNewArgTypes(oldArgTypes, fc, newArgTypes,
-                              [&]() { return funcOp.emitOpError(); })))
-    return failure();
+  llvm::SmallVector<mlir::Type> newArgTypes;
+  if (mlir::failed(buildNewArgTypes(oldArgTypes, fc, newArgTypes,
+                                    [&]() { return funcOp.emitOpError(); })))
+    return mlir::failure();
 
-  Type voidTy = cir::VoidType::get(ctx);
-  Type origRetTy = oldResultTypes.empty() ? voidTy : oldResultTypes[0];
-  Type newRetTy = computeNewReturnType(origRetTy, fc.returnInfo, ctx,
-                                       [&]() { return funcOp.emitOpError(); });
+  mlir::Type voidTy = cir::VoidType::get(ctx);
+  mlir::Type origRetTy = oldResultTypes.empty() ? voidTy : oldResultTypes[0];
+  mlir::Type newRetTy = computeNewReturnType(
+      origRetTy, fc.returnInfo, ctx, [&]() { return funcOp.emitOpError(); });
   if (!newRetTy)
-    return failure();
-  SmallVector<Type> newResultTypes = {newRetTy};
+    return mlir::failure();
+  llvm::SmallVector<mlir::Type> newResultTypes = {newRetTy};
 
   // sret return: the value is returned through a hidden pointer prepended as
   // argument 0.  The wire return type was already set to void by
   // computeNewReturnType.  Every classification index therefore maps to a
-  // block argument shifted by this offset in the body handling below.
+  // block argument shifted by one in the body handling below.
   bool hasSRet =
       fc.returnInfo.kind == ArgKind::Indirect && !oldResultTypes.empty();
   if (hasSRet)
     newArgTypes.insert(newArgTypes.begin(), cir::PointerType::get(origRetTy));
-  unsigned sretOffset = hasSRet ? 1 : 0;
 
   if (funcOp.isDefinition()) {
-    Region &body = funcOp->getRegion(0);
+    mlir::Region &body = funcOp->getRegion(0);
     if (!body.empty()) {
       // Prepend the sret pointer block argument and route every cir.return
       // through it before any index-based argument handling below (which
@@ -489,7 +513,7 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
       // in-body cir.call operands) through the recovered value.  Done before
       // the Ignore-drop below so the entry block argument indices used here
       // still refer to the original positions.
-      insertArgCoercion(funcOp, fc, builder, dl, sretOffset);
+      insertArgCoercion(funcOp, fc, builder, dl, hasSRet);
 
       // Direct return with coerced type: insert a coercion at every
       // cir.return so the returned value matches the (coerced) return
@@ -499,7 +523,7 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
         insertReturnCoercion(funcOp, origRetTy, fc.returnInfo.coercedType,
                              builder, dl);
 
-      Block &entry = body.front();
+      mlir::Block &entry = body.front();
 
       // For each Ignored argument: drop the block argument and, if the
       // body still references it, replace those uses with a poison
@@ -511,13 +535,13 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
            blockIdx >= 0; --blockIdx) {
         if (fc.argInfos[blockIdx].kind != ArgKind::Ignore)
           continue;
-        unsigned realIdx = static_cast<unsigned>(blockIdx) + sretOffset;
+        unsigned realIdx = static_cast<unsigned>(blockIdx) + hasSRet;
         if (realIdx >= entry.getNumArguments())
           continue;
-        BlockArgument arg = entry.getArgument(realIdx);
+        mlir::BlockArgument arg = entry.getArgument(realIdx);
         if (!arg.use_empty()) {
           builder.setInsertionPointToStart(&entry);
-          Value poison =
+          mlir::Value poison =
               createIgnoredValue(builder, funcOp.getLoc(), arg.getType());
           arg.replaceAllUsesWith(poison);
         }
@@ -532,9 +556,9 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
     // updated below to match.  Asserting this keeps the dependency
     // explicit.
     if (fc.returnInfo.kind == ArgKind::Ignore && !oldResultTypes.empty()) {
-      assert(isa<cir::VoidType>(newRetTy) &&
+      assert(mlir::isa<cir::VoidType>(newRetTy) &&
              "Ignore-return path requires the new return type to be void");
-      SmallVector<cir::ReturnOp> returns;
+      llvm::SmallVector<cir::ReturnOp> returns;
       funcOp.walk([&](cir::ReturnOp r) { returns.push_back(r); });
       for (cir::ReturnOp r : returns) {
         if (r.getNumOperands() == 0)
@@ -546,8 +570,8 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
     }
   }
 
-  Type newFnTy = funcOp.cloneTypeWith(newArgTypes, newResultTypes);
-  funcOp.setFunctionTypeAttr(TypeAttr::get(newFnTy));
+  mlir::Type newFnTy = funcOp.cloneTypeWith(newArgTypes, newResultTypes);
+  funcOp.setFunctionTypeAttr(mlir::TypeAttr::get(newFnTy));
 
   // Rebuild arg_attrs when the function has an sret slot (slot 0 needs the
   // sret attribute set) or any arg is Ignore (dropped from the output array)
@@ -557,20 +581,20 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
         return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend;
       });
   if (needsArgAttrUpdate) {
-    auto existing = funcOp->getAttrOfType<ArrayAttr>("arg_attrs");
-    ArrayAttr updated = updateArgAttrs(ctx, existing, fc);
+    auto existing = funcOp->getAttrOfType<mlir::ArrayAttr>("arg_attrs");
+    mlir::ArrayAttr updated = updateArgAttrs(ctx, existing, fc);
     if (hasSRet) {
       // Prepend the sret slot's attribute dict (slot 0); the per-argument
       // dicts shift to slots 1..N.  noalias is valid only on the callee's
       // parameter, so it is added only for definitions.
-      SmallVector<NamedAttribute> sretAttrs = buildSretSlotAttrs(
+      llvm::SmallVector<mlir::NamedAttribute> sretAttrs = buildSretSlotAttrs(
           builder, origRetTy, fc.returnInfo.indirectAlign.value(),
           /*withNoalias=*/funcOp.isDefinition());
-      SmallVector<Attribute> withSret;
-      withSret.push_back(DictionaryAttr::get(ctx, sretAttrs));
-      for (Attribute a : updated)
+      llvm::SmallVector<mlir::Attribute> withSret;
+      withSret.push_back(mlir::DictionaryAttr::get(ctx, sretAttrs));
+      for (mlir::Attribute a : updated)
         withSret.push_back(a);
-      funcOp->setAttr("arg_attrs", ArrayAttr::get(ctx, withSret));
+      funcOp->setAttr("arg_attrs", mlir::ArrayAttr::get(ctx, withSret));
     } else {
       funcOp->setAttr("arg_attrs", updated);
     }
@@ -579,29 +603,31 @@ LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
   // Rebuild res_attrs: layer llvm.signext / llvm.zeroext onto an Extend
   // return.
   if (fc.returnInfo.kind == ArgKind::Extend) {
-    auto existing = funcOp->getAttrOfType<ArrayAttr>("res_attrs");
+    auto existing = funcOp->getAttrOfType<mlir::ArrayAttr>("res_attrs");
     funcOp->setAttr("res_attrs", updateResAttrs(ctx, existing, fc.returnInfo));
   }
 
-  return success();
+  return mlir::success();
 }
 
-LogicalResult CIRABIRewriteContext::rewriteCallSite(
-    Operation *callOp, const FunctionClassification &fc, OpBuilder &builder) {
+mlir::LogicalResult
+CIRABIRewriteContext::rewriteCallSite(mlir::Operation *callOp,
+                                      const FunctionClassification &fc,
+                                      mlir::OpBuilder &builder) {
   if (!needsRewrite(fc))
-    return success();
+    return mlir::success();
 
-  if (isa<cir::TryCallOp>(callOp))
+  if (mlir::isa<cir::TryCallOp>(callOp))
     return callOp->emitOpError()
            << "TryCallOp not yet implemented in CallConvLowering";
 
-  auto call = cast<cir::CallOp>(callOp);
+  auto call = mlir::cast<cir::CallOp>(callOp);
   if (call.isIndirect())
     return call.emitOpError()
            << "indirect call not yet implemented in CallConvLowering";
 
-  MLIRContext *ctx = callOp->getContext();
-  auto enclosingFunc = call->getParentOfType<FunctionOpInterface>();
+  mlir::MLIRContext *ctx = callOp->getContext();
+  auto enclosingFunc = call->getParentOfType<mlir::FunctionOpInterface>();
 
   for (auto [idx, ac] : llvm::enumerate(fc.argInfos)) {
     switch (ac.kind) {
@@ -623,8 +649,8 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
 
   builder.setInsertionPoint(call);
 
-  SmallVector<Value> newArgs;
-  ValueRange argOperands = call.getArgOperands();
+  llvm::SmallVector<mlir::Value> newArgs;
+  mlir::ValueRange argOperands = call.getArgOperands();
   newArgs.reserve(argOperands.size());
   if (argOperands.size() > fc.argInfos.size())
     return call.emitOpError()
@@ -634,7 +660,7 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
   for (auto [idx, ac] : llvm::enumerate(fc.argInfos)) {
     if (ac.kind == ArgKind::Ignore)
       continue;
-    Value arg = argOperands[idx];
+    mlir::Value arg = argOperands[idx];
     if (ac.kind == ArgKind::Direct && ac.coercedType &&
         arg.getType() != ac.coercedType)
       arg = emitCoercion(builder, call.getLoc(), ac.coercedType, arg,
@@ -643,7 +669,7 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
   }
 
   bool hasResult = call.getNumResults() > 0;
-  Type origRetTy =
+  mlir::Type origRetTy =
       hasResult ? call.getResult().getType() : cir::VoidType::get(ctx);
 
   // sret return: prepend a return-slot pointer to the call, make the call
@@ -666,11 +692,11 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
     // matching classic CodeGen's "pass %s as sret" pattern.  %dest must
     // dominate the call so the rewritten call (which takes it as operand 0)
     // does not use a value before its definition.
-    Value sretSlot = nullptr;
+    mlir::Value sretSlot = nullptr;
     cir::StoreOp reuseStore = nullptr;
     if (call.getResult().hasOneUse()) {
-      Operation *user = *call.getResult().getUsers().begin();
-      if (auto store = dyn_cast<cir::StoreOp>(user))
+      mlir::Operation *user = *call.getResult().getUsers().begin();
+      if (auto store = mlir::dyn_cast<cir::StoreOp>(user))
         if (store.getValue() == call.getResult() &&
             store.getAddr().getType() == ptrTy &&
             mlir::DominanceInfo().properlyDominates(store.getAddr(), call)) {
@@ -686,21 +712,22 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
       sretSlot = alloca;
     }
 
-    SmallVector<Value> sretArgs;
+    llvm::SmallVector<mlir::Value> sretArgs;
     sretArgs.push_back(sretSlot);
     sretArgs.append(newArgs.begin(), newArgs.end());
 
-    Type sretVoidTy = cir::VoidType::get(ctx);
+    mlir::Type sretVoidTy = cir::VoidType::get(ctx);
     auto newCall = cir::CallOp::create(
         builder, call.getLoc(), call.getCalleeAttr(), sretVoidTy, sretArgs);
-    for (NamedAttribute attr : call->getAttrs())
+    for (mlir::NamedAttribute attr : call->getAttrs())
       if (!newCall->hasAttr(attr.getName()))
         newCall->setAttr(attr.getName(), attr.getValue());
 
     // Shape the per-argument attrs exactly as the non-sret path does
     // (signext / zeroext for Extend, drop Ignore slots) before prepending
     // the sret slot, so sret composes correctly with Extend / Ignore args.
-    ArrayAttr argAttrs = call->getAttrOfType<ArrayAttr>("arg_attrs");
+    mlir::ArrayAttr argAttrs =
+        call->getAttrOfType<mlir::ArrayAttr>("arg_attrs");
     bool needsArgAttrUpdate =
         llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
           return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend;
@@ -726,10 +753,10 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
       call.getResult().replaceAllUsesWith(load);
     }
     call->erase();
-    return success();
+    return mlir::success();
   }
 
-  Type callRetTy = origRetTy;
+  mlir::Type callRetTy = origRetTy;
   if (fc.returnInfo.kind == ArgKind::Ignore && hasResult)
     callRetTy = cir::VoidType::get(ctx);
   bool returnNeedsCoercion =
@@ -741,7 +768,7 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
   builder.setInsertionPoint(call);
   auto newCall = cir::CallOp::create(builder, call.getLoc(),
                                      call.getCalleeAttr(), callRetTy, newArgs);
-  for (NamedAttribute attr : call->getAttrs())
+  for (mlir::NamedAttribute attr : call->getAttrs())
     if (!newCall->hasAttr(attr.getName()))
       newCall->setAttr(attr.getName(), attr.getValue());
 
@@ -749,8 +776,9 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
   // emit a coercion back to the original type for the call's existing uses.
   if (returnNeedsCoercion) {
     builder.setInsertionPointAfter(newCall);
-    Value coercedBack = emitCoercion(builder, call.getLoc(), origRetTy,
-                                     newCall.getResult(), enclosingFunc, dl);
+    mlir::Value coercedBack =
+        emitCoercion(builder, call.getLoc(), origRetTy, newCall.getResult(),
+                     enclosingFunc, dl);
     call.getResult().replaceAllUsesWith(coercedBack);
   }
 
@@ -762,11 +790,11 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
         return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend;
       });
   if (needsArgAttrUpdate) {
-    auto existing = call->getAttrOfType<ArrayAttr>("arg_attrs");
+    auto existing = call->getAttrOfType<mlir::ArrayAttr>("arg_attrs");
     newCall->setAttr("arg_attrs", updateArgAttrs(ctx, existing, fc));
   }
   if (fc.returnInfo.kind == ArgKind::Extend) {
-    auto existing = call->getAttrOfType<ArrayAttr>("res_attrs");
+    auto existing = call->getAttrOfType<mlir::ArrayAttr>("res_attrs");
     newCall->setAttr("res_attrs", updateResAttrs(ctx, existing, fc.returnInfo));
   }
 
@@ -777,7 +805,8 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
     // value at the ABI boundary.
     if (!call.getResult().use_empty()) {
       builder.setInsertionPointAfter(newCall);
-      Value poison = createIgnoredValue(builder, call.getLoc(), origRetTy);
+      mlir::Value poison =
+          createIgnoredValue(builder, call.getLoc(), origRetTy);
       call.getResult().replaceAllUsesWith(poison);
     }
   } else if (hasResult && !returnNeedsCoercion) {
@@ -786,5 +815,5 @@ LogicalResult CIRABIRewriteContext::rewriteCallSite(
   }
 
   call->erase();
-  return success();
+  return mlir::success();
 }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
@@ -13,6 +13,7 @@
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 
 using namespace cir;
+using namespace mlir;
 using namespace mlir::abi;
 
 // This rewrite context supports the Direct (with or without coercion),
@@ -46,10 +47,10 @@ bool needsRewrite(const FunctionClassification &fc) {
 /// pointer, when present, is prepended by rewriteFunctionDefinition rather
 /// than here.
 mlir::LogicalResult
-buildNewArgTypes(llvm::ArrayRef<mlir::Type> oldArgTypes,
+buildNewArgTypes(ArrayRef<mlir::Type> oldArgTypes,
                  const FunctionClassification &fc,
-                 llvm::SmallVectorImpl<mlir::Type> &newArgTypes,
-                 llvm::function_ref<mlir::InFlightDiagnostic()> emitError) {
+                 SmallVectorImpl<mlir::Type> &newArgTypes,
+                 function_ref<mlir::InFlightDiagnostic()> emitError) {
   assert(newArgTypes.empty() && "expected an empty output vector");
   newArgTypes.reserve(oldArgTypes.size());
   for (auto [idx, ac] : llvm::enumerate(fc.argInfos)) {
@@ -93,7 +94,7 @@ buildNewArgTypes(llvm::ArrayRef<mlir::Type> oldArgTypes,
 mlir::Type
 computeNewReturnType(mlir::Type origRetTy, const ArgClassification &retInfo,
                      mlir::MLIRContext *ctx,
-                     llvm::function_ref<mlir::InFlightDiagnostic()> emitError) {
+                     function_ref<mlir::InFlightDiagnostic()> emitError) {
   switch (retInfo.kind) {
   case ArgKind::Direct:
     // Direct return with a coerced type uses the coerced type on the wire;
@@ -136,7 +137,7 @@ mlir::Value createIgnoredValue(mlir::OpBuilder &builder, mlir::Location loc,
 mlir::ArrayAttr updateArgAttrs(mlir::MLIRContext *ctx,
                                mlir::ArrayAttr existingArgAttrs,
                                const FunctionClassification &fc) {
-  llvm::SmallVector<mlir::Attribute> newArgAttrs;
+  SmallVector<mlir::Attribute> newArgAttrs;
   newArgAttrs.reserve(fc.argInfos.size());
   for (auto [oldIdx, ac] : llvm::enumerate(fc.argInfos)) {
     if (ac.kind == ArgKind::Ignore)
@@ -145,15 +146,14 @@ mlir::ArrayAttr updateArgAttrs(mlir::MLIRContext *ctx,
     if (existingArgAttrs && oldIdx < existingArgAttrs.size())
       existing = mlir::cast<mlir::DictionaryAttr>(existingArgAttrs[oldIdx]);
     if (ac.kind == ArgKind::Extend) {
-      llvm::StringRef attrName =
-          ac.signExtend ? "llvm.signext" : "llvm.zeroext";
+      StringRef attrName = ac.signExtend ? "llvm.signext" : "llvm.zeroext";
       mlir::NamedAttribute extAttr(mlir::StringAttr::get(ctx, attrName),
                                    mlir::UnitAttr::get(ctx));
       if (existing.empty()) {
         newArgAttrs.push_back(mlir::DictionaryAttr::get(ctx, {extAttr}));
       } else {
-        llvm::SmallVector<mlir::NamedAttribute> attrs(existing.begin(),
-                                                      existing.end());
+        SmallVector<mlir::NamedAttribute> attrs(existing.begin(),
+                                                existing.end());
         attrs.push_back(extAttr);
         newArgAttrs.push_back(mlir::DictionaryAttr::get(ctx, attrs));
       }
@@ -173,13 +173,12 @@ mlir::ArrayAttr updateResAttrs(mlir::MLIRContext *ctx,
   if (retInfo.kind != ArgKind::Extend)
     return existingResAttrs;
 
-  llvm::SmallVector<mlir::NamedAttribute> attrs;
+  SmallVector<mlir::NamedAttribute> attrs;
   if (existingResAttrs && !existingResAttrs.empty())
     for (mlir::NamedAttribute na :
          mlir::cast<mlir::DictionaryAttr>(existingResAttrs[0]))
       attrs.push_back(na);
-  llvm::StringRef attrName =
-      retInfo.signExtend ? "llvm.signext" : "llvm.zeroext";
+  StringRef attrName = retInfo.signExtend ? "llvm.signext" : "llvm.zeroext";
   attrs.push_back(mlir::NamedAttribute(mlir::StringAttr::get(ctx, attrName),
                                        mlir::UnitAttr::get(ctx)));
   return mlir::ArrayAttr::get(ctx, {mlir::DictionaryAttr::get(ctx, attrs)});
@@ -209,7 +208,7 @@ mlir::Value emitCoercion(mlir::OpBuilder &builder, mlir::Location loc,
                          mlir::Type dstTy, mlir::Value src,
                          mlir::FunctionOpInterface funcOp,
                          const mlir::DataLayout &dl,
-                         llvm::SmallPtrSetImpl<mlir::Operation *> &createdOps) {
+                         SmallPtrSetImpl<mlir::Operation *> &createdOps) {
   mlir::Type srcTy = src.getType();
   assert(srcTy != dstTy &&
          "emitCoercion callers must pre-check that the types differ");
@@ -265,7 +264,7 @@ mlir::Value emitCoercion(mlir::OpBuilder &builder, mlir::Location loc,
                          mlir::Type dstTy, mlir::Value src,
                          mlir::FunctionOpInterface funcOp,
                          const mlir::DataLayout &dl) {
-  llvm::SmallPtrSet<mlir::Operation *, 4> ignored;
+  SmallPtrSet<mlir::Operation *, 4> ignored;
   return emitCoercion(builder, loc, dstTy, src, funcOp, dl, ignored);
 }
 
@@ -275,7 +274,7 @@ void insertReturnCoercion(mlir::FunctionOpInterface funcOp,
                           mlir::Type origRetTy, mlir::Type coercedRetTy,
                           mlir::OpBuilder &builder,
                           const mlir::DataLayout &dl) {
-  llvm::SmallVector<cir::ReturnOp> returns;
+  SmallVector<cir::ReturnOp> returns;
   funcOp.walk([&](cir::ReturnOp r) { returns.push_back(r); });
   for (cir::ReturnOp r : returns) {
     if (r.getInput().empty())
@@ -324,7 +323,7 @@ void insertArgCoercion(mlir::FunctionOpInterface funcOp,
     blockArg.setType(newArgTy);
 
     builder.setInsertionPointToStart(&entry);
-    llvm::SmallPtrSet<mlir::Operation *, 4> coercionOps;
+    SmallPtrSet<mlir::Operation *, 4> coercionOps;
     mlir::Value adapted = emitCoercion(builder, funcOp.getLoc(), oldArgTy,
                                        blockArg, funcOp, dl, coercionOps);
 
@@ -368,7 +367,7 @@ void insertSRetStores(mlir::FunctionOpInterface funcOp, mlir::Type origRetTy,
                       mlir::OpBuilder &builder) {
   mlir::Value sretPtr = funcOp.getArguments()[0];
 
-  llvm::SmallVector<cir::ReturnOp> returnOps;
+  SmallVector<cir::ReturnOp> returnOps;
   funcOp->walk([&](cir::ReturnOp retOp) { returnOps.push_back(retOp); });
 
   cir::AllocaOp retAlloca = nullptr;
@@ -407,10 +406,11 @@ void insertSRetStores(mlir::FunctionOpInterface funcOp, mlir::Type origRetTy,
 /// `sret(T) align A [noalias] writable dead_on_unwind`.  noalias is only
 /// valid on the callee's parameter, not at the call site, so it is gated by
 /// \p withNoalias.  Key order is irrelevant: DictionaryAttr sorts by name.
-llvm::SmallVector<mlir::NamedAttribute>
-buildSretSlotAttrs(mlir::OpBuilder &builder, mlir::Type retTy, uint64_t align,
-                   bool withNoalias) {
-  llvm::SmallVector<mlir::NamedAttribute> attrs;
+SmallVector<mlir::NamedAttribute> buildSretSlotAttrs(mlir::OpBuilder &builder,
+                                                     mlir::Type retTy,
+                                                     uint64_t align,
+                                                     bool withNoalias) {
+  SmallVector<mlir::NamedAttribute> attrs;
   // The sret type must be carried explicitly: LLVM's sret attribute requires
   // it, and once the CIR `!cir.ptr<retTy>` lowers to an opaque LLVM `ptr` the
   // pointee type can no longer be recovered from the pointer.
@@ -437,10 +437,10 @@ void applySretSlotAttrs(cir::CallOp newCall, mlir::ArrayAttr argAttrs,
                         mlir::Type retTy, uint64_t align,
                         mlir::OpBuilder &builder) {
   mlir::MLIRContext *ctx = newCall->getContext();
-  llvm::SmallVector<mlir::NamedAttribute> sretAttrs =
+  SmallVector<mlir::NamedAttribute> sretAttrs =
       buildSretSlotAttrs(builder, retTy, align, /*withNoalias=*/false);
 
-  llvm::SmallVector<mlir::Attribute> newArgAttrs;
+  SmallVector<mlir::Attribute> newArgAttrs;
   newArgAttrs.reserve(newCall.getArgOperands().size());
   newArgAttrs.push_back(mlir::DictionaryAttr::get(ctx, sretAttrs));
   if (argAttrs)
@@ -461,7 +461,7 @@ void applySretSlotAttrs(cir::CallOp newCall, mlir::ArrayAttr argAttrs,
 /// call has a result and an indirect-return classification.
 void rewriteIndirectReturnCall(cir::CallOp call,
                                const FunctionClassification &fc,
-                               llvm::ArrayRef<mlir::Value> newArgs,
+                               ArrayRef<mlir::Value> newArgs,
                                mlir::Type origRetTy, mlir::OpBuilder &builder) {
   mlir::MLIRContext *ctx = call->getContext();
   auto ptrTy = cir::PointerType::get(origRetTy);
@@ -493,13 +493,13 @@ void rewriteIndirectReturnCall(cir::CallOp call,
   }
   if (!sretSlot) {
     auto alloca = cir::AllocaOp::create(
-        builder, call.getLoc(), ptrTy, origRetTy,
+        builder, call.getLoc(), ptrTy,
         /*name=*/builder.getStringAttr("sret"),
         /*alignment=*/builder.getI64IntegerAttr(sretAlign));
     sretSlot = alloca;
   }
 
-  llvm::SmallVector<mlir::Value> sretArgs;
+  SmallVector<mlir::Value> sretArgs;
   sretArgs.push_back(sretSlot);
   sretArgs.append(newArgs.begin(), newArgs.end());
 
@@ -555,8 +555,8 @@ mlir::LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
   if (!needsRewrite(fc))
     return mlir::success();
 
-  llvm::ArrayRef<mlir::Type> oldArgTypes = funcOp.getArgumentTypes();
-  llvm::ArrayRef<mlir::Type> oldResultTypes = funcOp.getResultTypes();
+  ArrayRef<mlir::Type> oldArgTypes = funcOp.getArgumentTypes();
+  ArrayRef<mlir::Type> oldResultTypes = funcOp.getResultTypes();
   mlir::MLIRContext *ctx = funcOp->getContext();
 
   // CIR follows LLVM IR's single-result rule: a function returns either
@@ -565,7 +565,7 @@ mlir::LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
   assert(oldResultTypes.size() <= 1 &&
          "CIR functions return zero or one value");
 
-  llvm::SmallVector<mlir::Type> newArgTypes;
+  SmallVector<mlir::Type> newArgTypes;
   if (mlir::failed(buildNewArgTypes(oldArgTypes, fc, newArgTypes,
                                     [&]() { return funcOp.emitOpError(); })))
     return mlir::failure();
@@ -576,7 +576,7 @@ mlir::LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
       origRetTy, fc.returnInfo, ctx, [&]() { return funcOp.emitOpError(); });
   if (!newRetTy)
     return mlir::failure();
-  llvm::SmallVector<mlir::Type> newResultTypes = {newRetTy};
+  SmallVector<mlir::Type> newResultTypes = {newRetTy};
 
   // sret return: the value is returned through a pointer the ABI inserts as
   // argument 0.  This pointer is not part of the function's source-level
@@ -653,7 +653,7 @@ mlir::LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
     if (fc.returnInfo.kind == ArgKind::Ignore && !oldResultTypes.empty()) {
       assert(mlir::isa<cir::VoidType>(newRetTy) &&
              "Ignore-return path requires the new return type to be void");
-      llvm::SmallVector<cir::ReturnOp> returns;
+      SmallVector<cir::ReturnOp> returns;
       funcOp.walk([&](cir::ReturnOp r) { returns.push_back(r); });
       for (cir::ReturnOp r : returns) {
         if (r.getNumOperands() == 0)
@@ -682,10 +682,10 @@ mlir::LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
       // Prepend the sret slot's attribute dict (slot 0); the per-argument
       // dicts shift to slots 1..N.  noalias is valid only on the callee's
       // parameter, so it is added only for definitions.
-      llvm::SmallVector<mlir::NamedAttribute> sretAttrs = buildSretSlotAttrs(
+      SmallVector<mlir::NamedAttribute> sretAttrs = buildSretSlotAttrs(
           builder, origRetTy, fc.returnInfo.indirectAlign.value(),
           /*withNoalias=*/funcOp.isDefinition());
-      llvm::SmallVector<mlir::Attribute> withSret;
+      SmallVector<mlir::Attribute> withSret;
       withSret.push_back(mlir::DictionaryAttr::get(ctx, sretAttrs));
       llvm::append_range(withSret, updated);
       funcOp->setAttr("arg_attrs", mlir::ArrayAttr::get(ctx, withSret));
@@ -743,7 +743,7 @@ CIRABIRewriteContext::rewriteCallSite(mlir::Operation *callOp,
 
   builder.setInsertionPoint(call);
 
-  llvm::SmallVector<mlir::Value> newArgs;
+  SmallVector<mlir::Value> newArgs;
   mlir::ValueRange argOperands = call.getArgOperands();
   newArgs.reserve(argOperands.size());
   if (argOperands.size() > fc.argInfos.size())

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
@@ -452,6 +452,94 @@ void applySretSlotAttrs(cir::CallOp newCall, mlir::ArrayAttr argAttrs,
   newCall->setAttr("arg_attrs", mlir::ArrayAttr::get(ctx, newArgAttrs));
 }
 
+/// Rewrite an indirect-return (sret) call site: prepend a return-slot
+/// pointer as operand 0, make the call return void, and either reuse a
+/// dominating single-use store destination as the slot (so construction
+/// flows directly into it) or allocate a fresh slot and load the result
+/// back out.  \p newArgs is the already-shaped (Ignore-dropped,
+/// coercion-applied) non-sret argument list.  The caller guarantees the
+/// call has a result and an indirect-return classification.
+void rewriteIndirectReturnCall(cir::CallOp call,
+                               const FunctionClassification &fc,
+                               llvm::ArrayRef<mlir::Value> newArgs,
+                               mlir::Type origRetTy, mlir::OpBuilder &builder) {
+  mlir::MLIRContext *ctx = call->getContext();
+  auto ptrTy = cir::PointerType::get(origRetTy);
+  builder.setInsertionPoint(call);
+  uint64_t sretAlign = fc.returnInfo.indirectAlign.value();
+
+  // CIRGen emits `cir.store %callResult, %dest` when the call's result is
+  // bound to a local (e.g. `T s = make();`).  Allocating a fresh sret slot
+  // and copying into %dest would byte-copy the record, which is wrong for
+  // non-trivially-copyable types (the libstdc++ SSO `_M_p` pointer
+  // survives a byte-copy but ends up pointing at the dying temp's local
+  // buffer, so the destination's destructor later `free()`s a stack
+  // pointer).  When the result has a single store-into-%dest use, use
+  // %dest as the sret slot directly so construction flows into it,
+  // matching classic CodeGen's "pass %s as sret" pattern.  %dest must
+  // dominate the call so the rewritten call (which takes it as operand 0)
+  // does not use a value before its definition.
+  mlir::Value sretSlot = nullptr;
+  cir::StoreOp reuseStore = nullptr;
+  if (call.getResult().hasOneUse()) {
+    mlir::Operation *user = *call.getResult().getUsers().begin();
+    if (auto store = mlir::dyn_cast<cir::StoreOp>(user))
+      if (store.getValue() == call.getResult() &&
+          store.getAddr().getType() == ptrTy &&
+          mlir::DominanceInfo().properlyDominates(store.getAddr(), call)) {
+        sretSlot = store.getAddr();
+        reuseStore = store;
+      }
+  }
+  if (!sretSlot) {
+    auto alloca = cir::AllocaOp::create(
+        builder, call.getLoc(), ptrTy, origRetTy,
+        /*name=*/builder.getStringAttr("sret"),
+        /*alignment=*/builder.getI64IntegerAttr(sretAlign));
+    sretSlot = alloca;
+  }
+
+  llvm::SmallVector<mlir::Value> sretArgs;
+  sretArgs.push_back(sretSlot);
+  sretArgs.append(newArgs.begin(), newArgs.end());
+
+  mlir::Type sretVoidTy = cir::VoidType::get(ctx);
+  auto newCall = cir::CallOp::create(
+      builder, call.getLoc(), call.getCalleeAttr(), sretVoidTy, sretArgs);
+  for (mlir::NamedAttribute attr : call->getAttrs())
+    if (!newCall->hasAttr(attr.getName()))
+      newCall->setAttr(attr.getName(), attr.getValue());
+
+  // Shape the per-argument attrs exactly as the non-sret path does
+  // (signext / zeroext for Extend, drop Ignore slots) before prepending
+  // the sret slot, so sret composes correctly with Extend / Ignore args.
+  mlir::ArrayAttr argAttrs = call->getAttrOfType<mlir::ArrayAttr>("arg_attrs");
+  bool needsArgAttrUpdate =
+      llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
+        return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend;
+      });
+  if (needsArgAttrUpdate)
+    argAttrs = updateArgAttrs(ctx, argAttrs, fc);
+  applySretSlotAttrs(newCall, argAttrs, origRetTy, sretAlign, builder);
+
+  if (reuseStore) {
+    // The callee now constructs directly into the destination slot, so the
+    // original store-from-result is redundant; dropping it avoids a
+    // byte-copy of the record.
+    reuseStore->erase();
+  } else {
+    builder.setInsertionPointAfter(newCall);
+    auto load = cir::LoadOp::create(builder, call.getLoc(), origRetTy, sretSlot,
+                                    /*isDeref=*/mlir::UnitAttr(),
+                                    /*isVolatile=*/mlir::UnitAttr(),
+                                    /*alignment=*/mlir::IntegerAttr(),
+                                    /*sync_scope=*/cir::SyncScopeKindAttr(),
+                                    /*mem_order=*/cir::MemOrderAttr());
+    call.getResult().replaceAllUsesWith(load);
+  }
+  call->erase();
+}
+
 } // namespace
 
 mlir::LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
@@ -678,87 +766,12 @@ CIRABIRewriteContext::rewriteCallSite(mlir::Operation *callOp,
   mlir::Type origRetTy =
       hasResult ? call.getResult().getType() : cir::VoidType::get(ctx);
 
-  // sret return: prepend a return-slot pointer to the call, make the call
-  // return void, and load the result back out of the slot.  Handled as an
-  // early return because the coerce / extend / ignore return handling below
-  // does not apply to an indirect return.
+  // An indirect (sret) return has a different call shape than the coerce /
+  // extend / ignore return handling further down (the value is returned
+  // through a prepended pointer slot, not as a result), so dispatch to a
+  // dedicated helper for it; everything below handles the by-value returns.
   if (fc.returnInfo.kind == ArgKind::Indirect && hasResult) {
-    auto ptrTy = cir::PointerType::get(origRetTy);
-    builder.setInsertionPoint(call);
-    uint64_t sretAlign = fc.returnInfo.indirectAlign.value();
-
-    // CIRGen emits `cir.store %callResult, %dest` when the call's result is
-    // bound to a local (e.g. `T s = make();`).  Allocating a fresh sret slot
-    // and copying into %dest would byte-copy the record, which is wrong for
-    // non-trivially-copyable types (the libstdc++ SSO `_M_p` pointer
-    // survives a byte-copy but ends up pointing at the dying temp's local
-    // buffer, so the destination's destructor later `free()`s a stack
-    // pointer).  When the result has a single store-into-%dest use, use
-    // %dest as the sret slot directly so construction flows into it,
-    // matching classic CodeGen's "pass %s as sret" pattern.  %dest must
-    // dominate the call so the rewritten call (which takes it as operand 0)
-    // does not use a value before its definition.
-    mlir::Value sretSlot = nullptr;
-    cir::StoreOp reuseStore = nullptr;
-    if (call.getResult().hasOneUse()) {
-      mlir::Operation *user = *call.getResult().getUsers().begin();
-      if (auto store = mlir::dyn_cast<cir::StoreOp>(user))
-        if (store.getValue() == call.getResult() &&
-            store.getAddr().getType() == ptrTy &&
-            mlir::DominanceInfo().properlyDominates(store.getAddr(), call)) {
-          sretSlot = store.getAddr();
-          reuseStore = store;
-        }
-    }
-    if (!sretSlot) {
-      auto alloca = cir::AllocaOp::create(
-          builder, call.getLoc(), ptrTy, origRetTy,
-          /*name=*/builder.getStringAttr("sret"),
-          /*alignment=*/builder.getI64IntegerAttr(sretAlign));
-      sretSlot = alloca;
-    }
-
-    llvm::SmallVector<mlir::Value> sretArgs;
-    sretArgs.push_back(sretSlot);
-    sretArgs.append(newArgs.begin(), newArgs.end());
-
-    mlir::Type sretVoidTy = cir::VoidType::get(ctx);
-    auto newCall = cir::CallOp::create(
-        builder, call.getLoc(), call.getCalleeAttr(), sretVoidTy, sretArgs);
-    for (mlir::NamedAttribute attr : call->getAttrs())
-      if (!newCall->hasAttr(attr.getName()))
-        newCall->setAttr(attr.getName(), attr.getValue());
-
-    // Shape the per-argument attrs exactly as the non-sret path does
-    // (signext / zeroext for Extend, drop Ignore slots) before prepending
-    // the sret slot, so sret composes correctly with Extend / Ignore args.
-    mlir::ArrayAttr argAttrs =
-        call->getAttrOfType<mlir::ArrayAttr>("arg_attrs");
-    bool needsArgAttrUpdate =
-        llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
-          return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend;
-        });
-    if (needsArgAttrUpdate)
-      argAttrs = updateArgAttrs(ctx, argAttrs, fc);
-    applySretSlotAttrs(newCall, argAttrs, origRetTy, sretAlign, builder);
-
-    if (reuseStore) {
-      // The callee now constructs directly into the destination slot, so the
-      // original store-from-result is redundant; dropping it avoids a
-      // byte-copy of the record.
-      reuseStore->erase();
-    } else {
-      builder.setInsertionPointAfter(newCall);
-      auto load =
-          cir::LoadOp::create(builder, call.getLoc(), origRetTy, sretSlot,
-                              /*isDeref=*/mlir::UnitAttr(),
-                              /*isVolatile=*/mlir::UnitAttr(),
-                              /*alignment=*/mlir::IntegerAttr(),
-                              /*sync_scope=*/cir::SyncScopeKindAttr(),
-                              /*mem_order=*/cir::MemOrderAttr());
-      call.getResult().replaceAllUsesWith(load);
-    }
-    call->erase();
+    rewriteIndirectReturnCall(call, fc, newArgs, origRetTy, builder);
     return mlir::success();
   }
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.h
@@ -11,10 +11,9 @@
 // rewrites a cir.func signature, the function body, and call sites to match
 // the ABI-lowered shape.
 //
-// This file currently handles Direct (pass-through and coerce-in-registers),
-// Extend, and Ignore.  The remaining ArgKind handlers (Indirect, Expand)
-// are added by subsequent PRs in the calling-convention-lowering split
-// series.
+// This file handles Direct (pass-through and coerce-in-registers), Extend,
+// Ignore, and an Indirect (sret) return.  Indirect arguments (byval) and
+// Expand still emit an errorNYI.
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/test/CIR/Transforms/abi-lowering/indirect-return-sret.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/indirect-return-sret.cir
@@ -1,0 +1,200 @@
+// RUN: cir-opt %s -cir-call-conv-lowering="classification-attr=test_classify" \
+// RUN:   | FileCheck %s
+
+!s8i = !cir.int<s, 8>
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+!rec_Big = !cir.struct<"Big" {!s64i, !s64i, !s64i, !s64i}>
+
+#indirect_return = {
+  return = { kind = "indirect", indirect_align = 8 },
+  args   = [ ]
+}
+
+#indirect_return_ext = {
+  return = { kind = "indirect", indirect_align = 8 },
+  args   = [ { kind = "extend", coerced_type = !cir.int<s, 32>,
+               sign_extend = true } ]
+}
+
+#indirect_return_bool = {
+  return = { kind = "indirect", indirect_align = 8 },
+  args   = [ { kind = "direct" } ]
+}
+
+#indirect_return_ignore = {
+  return = { kind = "indirect", indirect_align = 8 },
+  args   = [ { kind = "ignore" } ]
+}
+
+#caller_cls = {
+  return = { kind = "direct" },
+  args   = [ ]
+}
+
+module attributes {
+  dlti.dl_spec = #dlti.dl_spec<
+    #dlti.dl_entry<i8, dense<8>: vector<2xi64>>,
+    #dlti.dl_entry<i32, dense<32>: vector<2xi64>>,
+    #dlti.dl_entry<i64, dense<64>: vector<2xi64>>>
+} {
+
+  cir.func @returns_big() -> !rec_Big
+      attributes { test_classify = #indirect_return } {
+    %0 = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["__retval"] {alignment = 8 : i64}
+    %z = cir.const #cir.zero : !rec_Big
+    cir.store %z, %0 : !rec_Big, !cir.ptr<!rec_Big>
+    %1 = cir.load %0 : !cir.ptr<!rec_Big>, !rec_Big
+    cir.return %1 : !rec_Big
+  }
+
+  // The indirect return becomes a hidden sret pointer prepended as argument 0,
+  // the wire return type becomes void, the __retval alloca is rewired to the
+  // sret pointer, and the trailing load/return collapses to a bare return.
+  // CHECK:      cir.func{{.*}} @returns_big(%[[SRET:.*]]: !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.align = 8 : i64
+  // CHECK-SAME:     llvm.dead_on_unwind
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.sret = !rec_Big
+  // CHECK-SAME:     llvm.writable
+  // CHECK-NOT:    -> !rec_Big
+  // CHECK:        %[[Z:.*]] = cir.const #cir.zero : !rec_Big
+  // CHECK:        cir.store %[[Z]], %[[SRET]] : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK:        cir.return
+  // CHECK-NOT:    cir.return %{{.*}} : !rec_Big
+
+  // A call whose result is bound to a single local reuses that local as the
+  // sret slot directly, so construction flows straight into it and the
+  // original store-from-result is dropped (no byte-copy, no load-back).
+  cir.func @caller() -> !s32i
+      attributes { test_classify = #caller_cls } {
+    %1 = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["s"] {alignment = 8 : i64}
+    %0 = cir.call @returns_big() : () -> !rec_Big
+    cir.store %0, %1 : !rec_Big, !cir.ptr<!rec_Big>
+    %z = cir.const #cir.int<0> : !s32i
+    cir.return %z : !s32i
+  }
+
+  // CHECK:      cir.func{{.*}} @caller() -> !s32i
+  // CHECK:        %[[DEST:.*]] = cir.alloca !rec_Big, {{.*}} ["s"]
+  // CHECK:        cir.call @returns_big(%[[DEST]]) : (!cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.sret = !rec_Big
+  // CHECK-SAME:     -> ()
+  // CHECK-NOT:    cir.load
+  // CHECK-NOT:    cir.store
+  // CHECK:        cir.return %{{.*}} : !s32i
+
+  // A call whose result has more than one use cannot reuse a destination, so a
+  // fresh sret slot is allocated and the result is loaded back out of it.
+  cir.func @caller_multi() -> !s32i
+      attributes { test_classify = #caller_cls } {
+    %a = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["a"] {alignment = 8 : i64}
+    %b = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["b"] {alignment = 8 : i64}
+    %0 = cir.call @returns_big() : () -> !rec_Big
+    cir.store %0, %a : !rec_Big, !cir.ptr<!rec_Big>
+    cir.store %0, %b : !rec_Big, !cir.ptr<!rec_Big>
+    %z = cir.const #cir.int<0> : !s32i
+    cir.return %z : !s32i
+  }
+
+  // CHECK:      cir.func{{.*}} @caller_multi() -> !s32i
+  // CHECK:        %[[SLOT:.*]] = cir.alloca !rec_Big, {{.*}} ["sret"]
+  // CHECK:        cir.call @returns_big(%[[SLOT]]) : (!cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.sret = !rec_Big
+  // CHECK-SAME:     -> ()
+  // CHECK:        %[[LD:.*]] = cir.load %[[SLOT]] : !cir.ptr<!rec_Big>, !rec_Big
+  // CHECK:        cir.store %[[LD]], %{{.*}} : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK:        cir.store %[[LD]], %{{.*}} : !rec_Big, !cir.ptr<!rec_Big>
+
+  // sret composes with an Extend argument: the sret slot is prepended and the
+  // s8 argument is still extended to s32 with llvm.signext on both the callee
+  // signature and the call site.
+  cir.func @returns_big_ext(%arg0: !s8i) -> !rec_Big
+      attributes { test_classify = #indirect_return_ext } {
+    %0 = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["__retval"] {alignment = 8 : i64}
+    %z = cir.const #cir.zero : !rec_Big
+    cir.store %z, %0 : !rec_Big, !cir.ptr<!rec_Big>
+    %1 = cir.load %0 : !cir.ptr<!rec_Big>, !rec_Big
+    cir.return %1 : !rec_Big
+  }
+
+  // CHECK:      cir.func{{.*}} @returns_big_ext(%[[SRET2:.*]]: !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.sret = !rec_Big
+  // CHECK-SAME:   %{{.*}}: !s8i {llvm.signext}
+  // CHECK-NOT:    -> !rec_Big
+  // CHECK:        cir.store %{{.*}}, %[[SRET2]] : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK:        cir.return
+
+  cir.func @caller_ext(%arg0: !s8i) -> !s32i
+      attributes { test_classify = #caller_cls } {
+    %1 = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["s"] {alignment = 8 : i64}
+    %0 = cir.call @returns_big_ext(%arg0) : (!s8i) -> !rec_Big
+    cir.store %0, %1 : !rec_Big, !cir.ptr<!rec_Big>
+    %z = cir.const #cir.int<0> : !s32i
+    cir.return %z : !s32i
+  }
+
+  // CHECK:      cir.func{{.*}} @caller_ext(%[[ARG:.*]]: !s8i) -> !s32i
+  // CHECK:        %[[DEST2:.*]] = cir.alloca !rec_Big, {{.*}} ["s"]
+  // CHECK:        cir.call @returns_big_ext(%[[DEST2]], %[[ARG]]) : (!cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.sret = !rec_Big
+  // CHECK-SAME:   !s8i {llvm.signext}
+  // CHECK-SAME:     -> ()
+
+  // Multiple return statements share one __retval alloca (CIR does not merge
+  // returns into a single epilogue), so every cir.return must be routed
+  // through the sret pointer and the shared alloca rewired exactly once.
+  cir.func @returns_big_cond(%cond: !cir.bool) -> !rec_Big
+      attributes { test_classify = #indirect_return_bool } {
+    %0 = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["__retval"] {alignment = 8 : i64}
+    %z = cir.const #cir.zero : !rec_Big
+    cir.if %cond {
+      cir.store %z, %0 : !rec_Big, !cir.ptr<!rec_Big>
+      %r1 = cir.load %0 : !cir.ptr<!rec_Big>, !rec_Big
+      cir.return %r1 : !rec_Big
+    }
+    cir.store %z, %0 : !rec_Big, !cir.ptr<!rec_Big>
+    %r2 = cir.load %0 : !cir.ptr<!rec_Big>, !rec_Big
+    cir.return %r2 : !rec_Big
+  }
+
+  // CHECK:      cir.func{{.*}} @returns_big_cond(%[[SRETC:.*]]: !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.sret = !rec_Big
+  // CHECK-NOT:    -> !rec_Big
+  // CHECK:        cir.store %{{.*}}, %[[SRETC]] : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK:        cir.return
+  // CHECK:        cir.store %{{.*}}, %[[SRETC]] : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK:        cir.return
+  // CHECK-NOT:    cir.return %{{.*}} : !rec_Big
+
+  // sret composes with an Ignore argument: the ignored arg is dropped from the
+  // signature and the sretOffset shift keeps the remaining block args aligned.
+  cir.func @returns_big_ignore(%ignored: !s32i) -> !rec_Big
+      attributes { test_classify = #indirect_return_ignore } {
+    %0 = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["__retval"] {alignment = 8 : i64}
+    %z = cir.const #cir.zero : !rec_Big
+    cir.store %z, %0 : !rec_Big, !cir.ptr<!rec_Big>
+    %1 = cir.load %0 : !cir.ptr<!rec_Big>, !rec_Big
+    cir.return %1 : !rec_Big
+  }
+
+  // CHECK:      cir.func{{.*}} @returns_big_ignore(%[[SRETI:.*]]: !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.sret = !rec_Big
+  // CHECK-NOT:    !s32i
+  // CHECK-NOT:    -> !rec_Big
+  // CHECK:        cir.store %{{.*}}, %[[SRETI]] : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK:        cir.return
+
+  // An sret declaration gets the hidden pointer and the sret slot attributes,
+  // but llvm.noalias is omitted: noalias on the sret parameter is only valid
+  // when the function body is present.  Kept last so the CHECK-NOT below
+  // scopes to this declaration.
+  cir.func private @returns_big_decl() -> !rec_Big
+      attributes { test_classify = #indirect_return }
+
+  // CHECK:      cir.func{{.*}} @returns_big_decl(!cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.sret = !rec_Big
+  // CHECK-NOT:    llvm.noalias
+  // CHECK-NOT:    -> !rec_Big
+
+}

--- a/clang/test/CIR/Transforms/abi-lowering/indirect-return-sret.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/indirect-return-sret.cir
@@ -46,7 +46,7 @@ module attributes {
 
   cir.func @returns_big() -> !rec_Big
       attributes { test_classify = #indirect_return } {
-    %0 = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["__retval"] {alignment = 8 : i64}
+    %0 = cir.alloca "__retval" align(8) : !cir.ptr<!rec_Big>
     %z = cir.const #cir.zero : !rec_Big
     cir.store %z, %0 : !rec_Big, !cir.ptr<!rec_Big>
     %1 = cir.load %0 : !cir.ptr<!rec_Big>, !rec_Big
@@ -73,7 +73,7 @@ module attributes {
   // original store-from-result is dropped (no byte-copy, no load-back).
   cir.func @caller() -> !s32i
       attributes { test_classify = #caller_cls } {
-    %1 = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["s"] {alignment = 8 : i64}
+    %1 = cir.alloca "s" align(8) : !cir.ptr<!rec_Big>
     %0 = cir.call @returns_big() : () -> !rec_Big
     cir.store %0, %1 : !rec_Big, !cir.ptr<!rec_Big>
     %z = cir.const #cir.int<0> : !s32i
@@ -81,7 +81,7 @@ module attributes {
   }
 
   // CHECK:      cir.func{{.*}} @caller() -> !s32i
-  // CHECK:        %[[DEST:.*]] = cir.alloca !rec_Big, {{.*}} ["s"]
+  // CHECK:        %[[DEST:.*]] = cir.alloca "s" {{.*}}: !cir.ptr<!rec_Big>
   // CHECK:        cir.call @returns_big(%[[DEST]]) : (!cir.ptr<!rec_Big>
   // CHECK-SAME:     llvm.sret = !rec_Big
   // CHECK-SAME:     -> ()
@@ -93,8 +93,8 @@ module attributes {
   // fresh sret slot is allocated and the result is loaded back out of it.
   cir.func @caller_multi() -> !s32i
       attributes { test_classify = #caller_cls } {
-    %a = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["a"] {alignment = 8 : i64}
-    %b = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["b"] {alignment = 8 : i64}
+    %a = cir.alloca "a" align(8) : !cir.ptr<!rec_Big>
+    %b = cir.alloca "b" align(8) : !cir.ptr<!rec_Big>
     %0 = cir.call @returns_big() : () -> !rec_Big
     cir.store %0, %a : !rec_Big, !cir.ptr<!rec_Big>
     cir.store %0, %b : !rec_Big, !cir.ptr<!rec_Big>
@@ -103,9 +103,9 @@ module attributes {
   }
 
   // CHECK:      cir.func{{.*}} @caller_multi() -> !s32i
-  // CHECK:        %[[A:.*]] = cir.alloca !rec_Big, {{.*}} ["a"]
-  // CHECK:        %[[B:.*]] = cir.alloca !rec_Big, {{.*}} ["b"]
-  // CHECK:        %[[SLOT:.*]] = cir.alloca !rec_Big, {{.*}} ["sret"]
+  // CHECK:        %[[A:.*]] = cir.alloca "a" {{.*}}: !cir.ptr<!rec_Big>
+  // CHECK:        %[[B:.*]] = cir.alloca "b" {{.*}}: !cir.ptr<!rec_Big>
+  // CHECK:        %[[SLOT:.*]] = cir.alloca "sret" {{.*}}: !cir.ptr<!rec_Big>
   // CHECK:        cir.call @returns_big(%[[SLOT]]) : (!cir.ptr<!rec_Big>
   // CHECK-SAME:     llvm.sret = !rec_Big
   // CHECK-SAME:     -> ()
@@ -118,7 +118,7 @@ module attributes {
   // signature and the call site.
   cir.func @returns_big_ext(%arg0: !s8i) -> !rec_Big
       attributes { test_classify = #indirect_return_ext } {
-    %0 = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["__retval"] {alignment = 8 : i64}
+    %0 = cir.alloca "__retval" align(8) : !cir.ptr<!rec_Big>
     %z = cir.const #cir.zero : !rec_Big
     cir.store %z, %0 : !rec_Big, !cir.ptr<!rec_Big>
     %1 = cir.load %0 : !cir.ptr<!rec_Big>, !rec_Big
@@ -134,7 +134,7 @@ module attributes {
 
   cir.func @caller_ext(%arg0: !s8i) -> !s32i
       attributes { test_classify = #caller_cls } {
-    %1 = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["s"] {alignment = 8 : i64}
+    %1 = cir.alloca "s" align(8) : !cir.ptr<!rec_Big>
     %0 = cir.call @returns_big_ext(%arg0) : (!s8i) -> !rec_Big
     cir.store %0, %1 : !rec_Big, !cir.ptr<!rec_Big>
     %z = cir.const #cir.int<0> : !s32i
@@ -142,7 +142,7 @@ module attributes {
   }
 
   // CHECK:      cir.func{{.*}} @caller_ext(%[[ARG:.*]]: !s8i) -> !s32i
-  // CHECK:        %[[DEST2:.*]] = cir.alloca !rec_Big, {{.*}} ["s"]
+  // CHECK:        %[[DEST2:.*]] = cir.alloca "s" {{.*}}: !cir.ptr<!rec_Big>
   // CHECK:        cir.call @returns_big_ext(%[[DEST2]], %[[ARG]]) : (!cir.ptr<!rec_Big>
   // CHECK-SAME:     llvm.sret = !rec_Big
   // CHECK-SAME:   !s8i {llvm.signext}
@@ -153,7 +153,7 @@ module attributes {
   // through the sret pointer and the shared alloca rewired exactly once.
   cir.func @returns_big_cond(%cond: !cir.bool) -> !rec_Big
       attributes { test_classify = #indirect_return_bool } {
-    %0 = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["__retval"] {alignment = 8 : i64}
+    %0 = cir.alloca "__retval" align(8) : !cir.ptr<!rec_Big>
     %z = cir.const #cir.zero : !rec_Big
     cir.if %cond {
       cir.store %z, %0 : !rec_Big, !cir.ptr<!rec_Big>
@@ -184,7 +184,7 @@ module attributes {
 
   cir.func @returns_big_ctor(%cond: !cir.bool) -> !rec_Big
       attributes { test_classify = #indirect_return_bool } {
-    %0 = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["__retval"] {alignment = 8 : i64}
+    %0 = cir.alloca "__retval" align(8) : !cir.ptr<!rec_Big>
     cir.if %cond {
       cir.call @make_big(%0) : (!cir.ptr<!rec_Big>) -> ()
       %r1 = cir.load %0 : !cir.ptr<!rec_Big>, !rec_Big
@@ -208,7 +208,7 @@ module attributes {
   // signature and the sretOffset shift keeps the remaining block args aligned.
   cir.func @returns_big_ignore(%ignored: !s32i) -> !rec_Big
       attributes { test_classify = #indirect_return_ignore } {
-    %0 = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["__retval"] {alignment = 8 : i64}
+    %0 = cir.alloca "__retval" align(8) : !cir.ptr<!rec_Big>
     %z = cir.const #cir.zero : !rec_Big
     cir.store %z, %0 : !rec_Big, !cir.ptr<!rec_Big>
     %1 = cir.load %0 : !cir.ptr<!rec_Big>, !rec_Big

--- a/clang/test/CIR/Transforms/abi-lowering/indirect-return-sret.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/indirect-return-sret.cir
@@ -32,6 +32,11 @@
   args   = [ ]
 }
 
+#direct_ptr_arg = {
+  return = { kind = "direct" },
+  args   = [ { kind = "direct" } ]
+}
+
 module attributes {
   dlti.dl_spec = #dlti.dl_spec<
     #dlti.dl_entry<i8, dense<8>: vector<2xi64>>,
@@ -51,12 +56,12 @@ module attributes {
   // The indirect return becomes a hidden sret pointer prepended as argument 0,
   // the wire return type becomes void, the __retval alloca is rewired to the
   // sret pointer, and the trailing load/return collapses to a bare return.
-  // CHECK:      cir.func{{.*}} @returns_big(%[[SRET:.*]]: !cir.ptr<!rec_Big>
+  // CHECK:      cir.func{{.*}} @returns_big(%[[SRET:.*]]: !cir.ptr<!rec_Big> {
   // CHECK-SAME:     llvm.align = 8 : i64
   // CHECK-SAME:     llvm.dead_on_unwind
   // CHECK-SAME:     llvm.noalias
   // CHECK-SAME:     llvm.sret = !rec_Big
-  // CHECK-SAME:     llvm.writable
+  // CHECK-SAME:     llvm.writable}
   // CHECK-NOT:    -> !rec_Big
   // CHECK:        %[[Z:.*]] = cir.const #cir.zero : !rec_Big
   // CHECK:        cir.store %[[Z]], %[[SRET]] : !rec_Big, !cir.ptr<!rec_Big>
@@ -98,13 +103,15 @@ module attributes {
   }
 
   // CHECK:      cir.func{{.*}} @caller_multi() -> !s32i
+  // CHECK:        %[[A:.*]] = cir.alloca !rec_Big, {{.*}} ["a"]
+  // CHECK:        %[[B:.*]] = cir.alloca !rec_Big, {{.*}} ["b"]
   // CHECK:        %[[SLOT:.*]] = cir.alloca !rec_Big, {{.*}} ["sret"]
   // CHECK:        cir.call @returns_big(%[[SLOT]]) : (!cir.ptr<!rec_Big>
   // CHECK-SAME:     llvm.sret = !rec_Big
   // CHECK-SAME:     -> ()
   // CHECK:        %[[LD:.*]] = cir.load %[[SLOT]] : !cir.ptr<!rec_Big>, !rec_Big
-  // CHECK:        cir.store %[[LD]], %{{.*}} : !rec_Big, !cir.ptr<!rec_Big>
-  // CHECK:        cir.store %[[LD]], %{{.*}} : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK:        cir.store %[[LD]], %[[A]] : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK:        cir.store %[[LD]], %[[B]] : !rec_Big, !cir.ptr<!rec_Big>
 
   // sret composes with an Extend argument: the sret slot is prepended and the
   // s8 argument is still extended to s32 with llvm.signext on both the callee
@@ -118,7 +125,7 @@ module attributes {
     cir.return %1 : !rec_Big
   }
 
-  // CHECK:      cir.func{{.*}} @returns_big_ext(%[[SRET2:.*]]: !cir.ptr<!rec_Big>
+  // CHECK:      cir.func{{.*}} @returns_big_ext(%[[SRET2:.*]]: !cir.ptr<!rec_Big> {
   // CHECK-SAME:     llvm.sret = !rec_Big
   // CHECK-SAME:   %{{.*}}: !s8i {llvm.signext}
   // CHECK-NOT:    -> !rec_Big
@@ -158,13 +165,43 @@ module attributes {
     cir.return %r2 : !rec_Big
   }
 
-  // CHECK:      cir.func{{.*}} @returns_big_cond(%[[SRETC:.*]]: !cir.ptr<!rec_Big>
+  // CHECK:      cir.func{{.*}} @returns_big_cond(%[[SRETC:.*]]: !cir.ptr<!rec_Big> {
   // CHECK-SAME:     llvm.sret = !rec_Big
   // CHECK-NOT:    -> !rec_Big
   // CHECK:        cir.store %{{.*}}, %[[SRETC]] : !rec_Big, !cir.ptr<!rec_Big>
   // CHECK:        cir.return
   // CHECK:        cir.store %{{.*}}, %[[SRETC]] : !rec_Big, !cir.ptr<!rec_Big>
   // CHECK:        cir.return
+  // CHECK-NOT:    cir.return %{{.*}} : !rec_Big
+
+  // Multiple returns whose value is constructed in place via a call into
+  // __retval (no const store).  After lowering, __retval is rewired to the
+  // sret pointer, so both constructor calls take the sret pointer directly,
+  // both returns collapse to a bare cir.return, and nothing is stored to the
+  // sret slot at all.
+  cir.func private @make_big(!cir.ptr<!rec_Big>)
+      attributes { test_classify = #direct_ptr_arg }
+
+  cir.func @returns_big_ctor(%cond: !cir.bool) -> !rec_Big
+      attributes { test_classify = #indirect_return_bool } {
+    %0 = cir.alloca !rec_Big, !cir.ptr<!rec_Big>, ["__retval"] {alignment = 8 : i64}
+    cir.if %cond {
+      cir.call @make_big(%0) : (!cir.ptr<!rec_Big>) -> ()
+      %r1 = cir.load %0 : !cir.ptr<!rec_Big>, !rec_Big
+      cir.return %r1 : !rec_Big
+    }
+    cir.call @make_big(%0) : (!cir.ptr<!rec_Big>) -> ()
+    %r2 = cir.load %0 : !cir.ptr<!rec_Big>, !rec_Big
+    cir.return %r2 : !rec_Big
+  }
+
+  // CHECK:      cir.func{{.*}} @returns_big_ctor(%[[SRETCTOR:.*]]: !cir.ptr<!rec_Big> {
+  // CHECK-SAME:     llvm.sret = !rec_Big
+  // CHECK-NOT:    -> !rec_Big
+  // CHECK:        cir.call @make_big(%[[SRETCTOR]]) : (!cir.ptr<!rec_Big>) -> ()
+  // CHECK-NEXT:   cir.return
+  // CHECK:        cir.call @make_big(%[[SRETCTOR]]) : (!cir.ptr<!rec_Big>) -> ()
+  // CHECK-NEXT:   cir.return
   // CHECK-NOT:    cir.return %{{.*}} : !rec_Big
 
   // sret composes with an Ignore argument: the ignored arg is dropped from the
@@ -178,7 +215,7 @@ module attributes {
     cir.return %1 : !rec_Big
   }
 
-  // CHECK:      cir.func{{.*}} @returns_big_ignore(%[[SRETI:.*]]: !cir.ptr<!rec_Big>
+  // CHECK:      cir.func{{.*}} @returns_big_ignore(%[[SRETI:.*]]: !cir.ptr<!rec_Big> {
   // CHECK-SAME:     llvm.sret = !rec_Big
   // CHECK-NOT:    !s32i
   // CHECK-NOT:    -> !rec_Big
@@ -192,7 +229,7 @@ module attributes {
   cir.func private @returns_big_decl() -> !rec_Big
       attributes { test_classify = #indirect_return }
 
-  // CHECK:      cir.func{{.*}} @returns_big_decl(!cir.ptr<!rec_Big>
+  // CHECK:      cir.func{{.*}} @returns_big_decl(!cir.ptr<!rec_Big> {
   // CHECK-SAME:     llvm.sret = !rec_Big
   // CHECK-NOT:    llvm.noalias
   // CHECK-NOT:    -> !rec_Big


### PR DESCRIPTION
Functions that return an aggregate by value classify their return as
ArgKind::Indirect, but CallConvLowering reached an errorNYI for that
case, so the whole CallConv pass refused to lower any struct-returning
function.

rewriteFunctionDefinition now recognizes an Indirect return: the wire
return type becomes void, a hidden sret pointer is prepended as block
argument 0, and every cir.return is routed through that pointer.  Rather
than storing the loaded return value through the sret pointer (a
byte-copy that breaks non-trivially-copyable types -- libstdc++'s SSO
std::string keeps a _M_p pointer into its own _M_local_buf, so a
byte-copy leaves the destination aliasing the source's dying stack
storage), insertSRetStores rewires the __retval alloca to the sret
pointer so construction flows directly into the caller's slot, matching
classic CodeGen's "construct into %agg.result" pattern.  CIRGen emits one
cir.load __retval / cir.return pair per return statement, all reading the
single __retval alloca, so the alloca is rewired once and every return is
collapsed to a bare return.  That cir.return (cir.load <alloca>) shape is
treated as an invariant and asserted with cast<> rather than guarded by a
fallback.  The sret parameter carries sret(T) align A writable
dead_on_unwind, plus noalias on definitions.

rewriteCallSite prepends the return slot, makes the call return void,
and reads the result back.  When the result has a single store-into-dest
use whose destination dominates the call, it reuses that destination as
the sret slot and drops the redundant store, so the callee writes
straight into the local with no copy; otherwise it allocates a fresh slot
and loads the value out.  The slot's
per-argument attributes go through the same updateArgAttrs path as the
non-sret case, so sret composes with Extend (signext/zeroext) and Ignore
arguments.

byval indirect arguments and Expand are still errorNYI.

Co-authored-by: Cursor <cursoragent@cursor.com>