### PR TITLE
[CIR] Lower byval/byref args in CallConvLowering

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
@@ -17,14 +17,13 @@ using namespace mlir;
 using namespace mlir::abi;
 
 // This rewrite context supports the Direct (with or without coercion),
-// Extend, Ignore, and Indirect-return (sret) classifications.  Indirect
-// arguments (byval) and Expand still emit an errorNYI here rather than
-// silently passing through, because the IR they would produce is wrong
-// (e.g. Expand should flatten an aggregate into multiple primitives, not
-// pass it through as a single value).  byval and struct coercion are not
-// yet handled here; they need the signature-shaping that goes with them
-// (byval inserts an extra pointer argument, struct coercion replaces one
-// argument with several).
+// Extend, Ignore, Indirect-return (sret), and Indirect-argument (byval and
+// byref) classifications.  For byval (ArgClassification::byVal == true) the
+// callee gets llvm.byval + llvm.noalias + llvm.noundef; for byref (byVal ==
+// false) the callee gets llvm.byref without the ownership attrs.  Both pass
+// through an alloca+store at the call site; the attribute distinction
+// communicates ownership semantics to the optimizer.  Expand still emits an
+// errorNYI rather than silently passing through.
 
 namespace {
 
@@ -42,10 +41,10 @@ bool needsRewrite(const FunctionClassification &fc) {
 }
 
 /// Build the new argument-type list for a function whose ABI classification
-/// is \p fc.  Handles Direct (with or without coercion), Extend, and Ignore.
-/// Indirect (byval) arguments and Expand emit an error.  The sret return
-/// pointer, when present, is prepended by rewriteFunctionDefinition rather
-/// than here.
+/// is \p fc.  Handles Direct (with or without coercion), Extend, Ignore, and
+/// Indirect (byval and byref) arguments.  Expand emits an error.  The sret
+/// return pointer, when present, is prepended by rewriteFunctionDefinition
+/// rather than here.
 mlir::LogicalResult
 buildNewArgTypes(ArrayRef<mlir::Type> oldArgTypes,
                  const FunctionClassification &fc,
@@ -79,9 +78,13 @@ buildNewArgTypes(ArrayRef<mlir::Type> oldArgTypes,
       newArgTypes.push_back(origTy);
       break;
     case ArgKind::Indirect:
-      emitError() << "Indirect at arg " << idx
-                  << " not yet implemented in CallConvLowering";
-      return mlir::failure();
+      // byval and byref both use a pointer wire type.  The attribute
+      // distinction (llvm.byval vs llvm.byref) is applied in updateArgAttrs;
+      // the call-site rewrite guards against byref separately because passing
+      // a byref pointer from a CIR value requires the original alloca address,
+      // which the rewriter does not yet track.
+      newArgTypes.push_back(cir::PointerType::get(origTy));
+      break;
     }
   }
   return mlir::success();
@@ -131,37 +134,65 @@ mlir::Value createIgnoredValue(mlir::OpBuilder &builder, mlir::Location loc,
   return cir::ConstantOp::create(builder, loc, ty, cir::PoisonAttr::get(ty));
 }
 
-/// Build an updated arg_attrs ArrayAttr that drops Ignore'd args and adds
-/// llvm.signext / llvm.zeroext on Extend args.  Preserves any existing arg
-/// attributes on retained arg slots.
+/// Build an updated arg_attrs ArrayAttr that drops Ignore'd args, adds
+/// llvm.signext / llvm.zeroext on Extend args, and adds llvm.byval /
+/// llvm.align on Indirect args.  Preserves any existing arg attributes on
+/// retained arg slots.  \p origArgTypes provides the pre-rewrite type for
+/// each arg slot (needed to compute the llvm.byval pointee type).
 mlir::ArrayAttr updateArgAttrs(mlir::MLIRContext *ctx,
+                               ArrayRef<mlir::Type> origArgTypes,
                                mlir::ArrayAttr existingArgAttrs,
                                const FunctionClassification &fc) {
+  mlir::Builder builder(ctx);
   SmallVector<mlir::Attribute> newArgAttrs;
   newArgAttrs.reserve(fc.argInfos.size());
   for (auto [oldIdx, ac] : llvm::enumerate(fc.argInfos)) {
     if (ac.kind == ArgKind::Ignore)
       continue;
-    mlir::DictionaryAttr existing = mlir::DictionaryAttr::get(ctx);
+    mlir::DictionaryAttr existing = builder.getDictionaryAttr({});
     if (existingArgAttrs && oldIdx < existingArgAttrs.size())
       existing = mlir::cast<mlir::DictionaryAttr>(existingArgAttrs[oldIdx]);
     if (ac.kind == ArgKind::Extend) {
       StringRef attrName = ac.signExtend ? "llvm.signext" : "llvm.zeroext";
-      mlir::NamedAttribute extAttr(mlir::StringAttr::get(ctx, attrName),
-                                   mlir::UnitAttr::get(ctx));
-      if (existing.empty()) {
-        newArgAttrs.push_back(mlir::DictionaryAttr::get(ctx, {extAttr}));
-      } else {
-        SmallVector<mlir::NamedAttribute> attrs(existing.begin(),
-                                                existing.end());
-        attrs.push_back(extAttr);
-        newArgAttrs.push_back(mlir::DictionaryAttr::get(ctx, attrs));
+      SmallVector<mlir::NamedAttribute> attrs(existing.begin(), existing.end());
+      attrs.push_back(builder.getNamedAttr(attrName, builder.getUnitAttr()));
+      newArgAttrs.push_back(builder.getDictionaryAttr(attrs));
+    } else if (ac.kind == ArgKind::Indirect) {
+      // byval: caller-allocated copy; callee receives pointer to copy.
+      // byref: callee receives pointer to the caller's original storage.
+      // Both use llvm.align(A).  The ownership flag differs: llvm.byval(T)
+      // vs llvm.byref(T).  Both are typed attributes carrying the pointee
+      // type T (the pre-rewrite arg type); T is recorded explicitly because
+      // it cannot be recovered from the opaque LLVM pointer after lowering.
+      //
+      // For byval, two additional attributes match classic CodeGen:
+      //   llvm.noundef -- the copy is always fully defined (the caller's
+      //     original must be defined or UB has already occurred, and the
+      //     copy inherits that property).
+      //   llvm.noalias -- the copy is a fresh caller-allocated alloca that
+      //     no other pointer in the function can alias.  Classic CodeGen
+      //     emits this when -fpass-by-value-is-noalias is set; here we
+      //     emit it unconditionally because our call-site rewrite always
+      //     produces a fresh alloca+store.
+      mlir::Type pointeeTy = origArgTypes[oldIdx];
+      StringRef ownershipAttr = ac.byVal ? "llvm.byval" : "llvm.byref";
+      SmallVector<mlir::NamedAttribute> attrs(existing.begin(), existing.end());
+      attrs.push_back(builder.getNamedAttr(
+          "llvm.align", builder.getI64IntegerAttr(ac.indirectAlign.value())));
+      attrs.push_back(
+          builder.getNamedAttr(ownershipAttr, mlir::TypeAttr::get(pointeeTy)));
+      if (ac.byVal) {
+        attrs.push_back(
+            builder.getNamedAttr("llvm.noalias", builder.getUnitAttr()));
+        attrs.push_back(
+            builder.getNamedAttr("llvm.noundef", builder.getUnitAttr()));
       }
+      newArgAttrs.push_back(builder.getDictionaryAttr(attrs));
     } else {
       newArgAttrs.push_back(existing);
     }
   }
-  return mlir::ArrayAttr::get(ctx, newArgAttrs);
+  return builder.getArrayAttr(newArgAttrs);
 }
 
 /// Build an updated res_attrs ArrayAttr (single entry, since CIR funcs have
@@ -308,30 +339,53 @@ void insertArgCoercion(mlir::FunctionOpInterface funcOp,
   mlir::Block &entry = body.front();
 
   for (auto [idx, ac] : llvm::enumerate(fc.argInfos)) {
-    if (ac.kind != ArgKind::Direct || !ac.coercedType)
+    // Only two classifications need an entry-block fixup: a Direct arg with a
+    // coerced wire type, and an Indirect (byval/byref) arg.  Extend, Ignore,
+    // and Direct-without-coercion keep the original block-argument type, so
+    // the body already sees the right value and there is nothing to do.
+    bool needsCoercion = ac.kind == ArgKind::Direct && ac.coercedType;
+    if (!needsCoercion && ac.kind != ArgKind::Indirect)
       continue;
+
     unsigned blockIdx = idx + hasSRetArg;
     if (blockIdx >= entry.getNumArguments())
       continue;
 
     mlir::BlockArgument blockArg = entry.getArgument(blockIdx);
-    mlir::Type oldArgTy = blockArg.getType();
-    mlir::Type newArgTy = ac.coercedType;
-    if (oldArgTy == newArgTy)
-      continue;
 
-    blockArg.setType(newArgTy);
+    if (needsCoercion) {
+      mlir::Type oldArgTy = blockArg.getType();
+      mlir::Type newArgTy = ac.coercedType;
+      if (oldArgTy == newArgTy)
+        continue;
 
-    builder.setInsertionPointToStart(&entry);
-    SmallPtrSet<mlir::Operation *, 4> coercionOps;
-    mlir::Value adapted = emitCoercion(builder, funcOp.getLoc(), oldArgTy,
-                                       blockArg, funcOp, dl, coercionOps);
+      blockArg.setType(newArgTy);
 
-    // Replace blockArg uses with the adapted value, except inside the helper
-    // ops we just created.  This is critical: the StoreOp's value operand is
-    // blockArg, and if we naively replaceAllUses it gets swapped to adapted
-    // (now of the original type != the alloca's pointee type).
-    blockArg.replaceAllUsesExcept(adapted, coercionOps);
+      builder.setInsertionPointToStart(&entry);
+      SmallPtrSet<mlir::Operation *, 4> coercionOps;
+      mlir::Value adapted = emitCoercion(builder, funcOp.getLoc(), oldArgTy,
+                                         blockArg, funcOp, dl, coercionOps);
+
+      // Replace blockArg uses with the adapted value, except inside the
+      // helper ops we just created.  This is critical: the StoreOp's value
+      // operand is blockArg, and if we naively replaceAllUses it gets swapped
+      // to adapted (now of the original type != the alloca's pointee type).
+      blockArg.replaceAllUsesExcept(adapted, coercionOps);
+    } else {
+      // ArgKind::Indirect.  byval and byref: the wire type is !cir.ptr<T>.
+      // Change the block arg to the pointer type and insert a load so the
+      // body sees the original T.  The body transformation is the same for
+      // both; the distinction between byval (llvm.byval) and byref
+      // (llvm.byref) is in the arg attributes applied by updateArgAttrs.
+      mlir::Type origTy = blockArg.getType();
+      auto ptrTy = cir::PointerType::get(origTy);
+      blockArg.setType(ptrTy);
+
+      builder.setInsertionPointToStart(&entry);
+      auto loadOp = cir::LoadOp::create(builder, funcOp.getLoc(), blockArg);
+      SmallPtrSet<mlir::Operation *, 1> loadOps = {loadOp};
+      blockArg.replaceAllUsesExcept(loadOp.getResult(), loadOps);
+    }
   }
 }
 
@@ -462,7 +516,9 @@ void applySretSlotAttrs(cir::CallOp newCall, mlir::ArrayAttr argAttrs,
 void rewriteIndirectReturnCall(cir::CallOp call,
                                const FunctionClassification &fc,
                                ArrayRef<mlir::Value> newArgs,
-                               mlir::Type origRetTy, mlir::OpBuilder &builder) {
+                               mlir::Type origRetTy,
+                               ArrayRef<mlir::Type> origCallArgTypes,
+                               mlir::OpBuilder &builder) {
   mlir::MLIRContext *ctx = call->getContext();
   auto ptrTy = cir::PointerType::get(origRetTy);
   builder.setInsertionPoint(call);
@@ -511,15 +567,17 @@ void rewriteIndirectReturnCall(cir::CallOp call,
       newCall->setAttr(attr.getName(), attr.getValue());
 
   // Shape the per-argument attrs exactly as the non-sret path does
-  // (signext / zeroext for Extend, drop Ignore slots) before prepending
-  // the sret slot, so sret composes correctly with Extend / Ignore args.
+  // (signext / zeroext for Extend, drop Ignore slots, byval / align for
+  // Indirect) before prepending the sret slot, so sret composes correctly
+  // with Extend / Ignore / Indirect args.
   mlir::ArrayAttr argAttrs = call->getAttrOfType<mlir::ArrayAttr>("arg_attrs");
   bool needsArgAttrUpdate =
       llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
-        return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend;
+        return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend ||
+               ac.kind == ArgKind::Indirect;
       });
   if (needsArgAttrUpdate)
-    argAttrs = updateArgAttrs(ctx, argAttrs, fc);
+    argAttrs = updateArgAttrs(ctx, origCallArgTypes, argAttrs, fc);
   applySretSlotAttrs(newCall, argAttrs, origRetTy, sretAlign, builder);
 
   if (reuseStore) {
@@ -670,15 +728,17 @@ mlir::LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
   funcOp.setFunctionTypeAttr(mlir::TypeAttr::get(newFnTy));
 
   // Rebuild arg_attrs when the function has an sret slot (slot 0 needs the
-  // sret attribute set) or any arg is Ignore (dropped from the output array)
-  // or Extend (needs llvm.signext / llvm.zeroext layered on).
+  // sret attribute set) or any arg is Ignore (dropped from the output array),
+  // Extend (needs llvm.signext / llvm.zeroext), or Indirect (needs
+  // llvm.byval / llvm.align).
   bool needsArgAttrUpdate =
       hasSRet || llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
-        return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend;
+        return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend ||
+               ac.kind == ArgKind::Indirect;
       });
   if (needsArgAttrUpdate) {
     auto existing = funcOp->getAttrOfType<mlir::ArrayAttr>("arg_attrs");
-    mlir::ArrayAttr updated = updateArgAttrs(ctx, existing, fc);
+    mlir::ArrayAttr updated = updateArgAttrs(ctx, oldArgTypes, existing, fc);
     if (hasSRet) {
       // Prepend the sret slot's attribute dict (slot 0); the per-argument
       // dicts shift to slots 1..N.  noalias is valid only on the callee's
@@ -728,16 +788,12 @@ CIRABIRewriteContext::rewriteCallSite(mlir::Operation *callOp,
     switch (ac.kind) {
     case ArgKind::Direct:
     case ArgKind::Ignore:
+    case ArgKind::Extend:
+    case ArgKind::Indirect:
+      // All handled in the arg-building loop below.
       break;
     case ArgKind::Expand:
       return call.emitOpError() << "Expand at call-site arg " << idx
-                                << " not yet implemented in CallConvLowering";
-    case ArgKind::Extend:
-      // Direct (with or without coercion), Ignore, Expand, and Extend are
-      // all handled below.  Extend is attribute-only at the IR level.
-      break;
-    case ArgKind::Indirect:
-      return call.emitOpError() << "Indirect at call-site arg " << idx
                                 << " not yet implemented in CallConvLowering";
     }
   }
@@ -747,6 +803,12 @@ CIRABIRewriteContext::rewriteCallSite(mlir::Operation *callOp,
   SmallVector<mlir::Value> newArgs;
   mlir::ValueRange argOperands = call.getArgOperands();
   newArgs.reserve(argOperands.size());
+
+  // Capture original arg types before building newArgs (byval slots change
+  // the wire argument from T to !cir.ptr<T>, so we save the pre-rewrite
+  // types here for use in updateArgAttrs).
+  SmallVector<mlir::Type> origCallArgTypes;
+  llvm::append_range(origCallArgTypes, argOperands.getTypes());
   if (argOperands.size() > fc.argInfos.size())
     return call.emitOpError()
            << "variadic arguments not yet implemented in CallConvLowering";
@@ -757,9 +819,25 @@ CIRABIRewriteContext::rewriteCallSite(mlir::Operation *callOp,
       continue;
     mlir::Value arg = argOperands[idx];
     if (ac.kind == ArgKind::Direct && ac.coercedType &&
-        arg.getType() != ac.coercedType)
+        arg.getType() != ac.coercedType) {
       arg = emitCoercion(builder, call.getLoc(), ac.coercedType, arg,
                          enclosingFunc, dl);
+    } else if (ac.kind == ArgKind::Indirect) {
+      // byval and byref: allocate a stack slot, copy the value in, and pass
+      // the pointer.  The alloca+store pattern is identical for both; the
+      // attribute distinction (llvm.byval vs llvm.byref) is applied by
+      // updateArgAttrs.  byref does not receive llvm.noalias or llvm.noundef
+      // because it does not assert exclusive ownership of the storage.
+      mlir::Type argTy = arg.getType();
+      auto ptrTy = cir::PointerType::get(argTy);
+      uint64_t align = ac.indirectAlign.value();
+      StringRef slotName = ac.byVal ? "byval" : "byref";
+      auto slot = cir::AllocaOp::create(builder, call.getLoc(), ptrTy,
+                                        builder.getStringAttr(slotName),
+                                        builder.getI64IntegerAttr(align));
+      cir::StoreOp::create(builder, call.getLoc(), arg, slot);
+      arg = slot;
+    }
     newArgs.push_back(arg);
   }
 
@@ -772,7 +850,8 @@ CIRABIRewriteContext::rewriteCallSite(mlir::Operation *callOp,
   // through a prepended pointer slot, not as a result), so dispatch to a
   // dedicated helper for it; everything below handles the by-value returns.
   if (fc.returnInfo.kind == ArgKind::Indirect && hasResult) {
-    rewriteIndirectReturnCall(call, fc, newArgs, origRetTy, builder);
+    rewriteIndirectReturnCall(call, fc, newArgs, origRetTy, origCallArgTypes,
+                              builder);
     return mlir::success();
   }
 
@@ -803,15 +882,17 @@ CIRABIRewriteContext::rewriteCallSite(mlir::Operation *callOp,
   }
 
   // Layer llvm.signext / llvm.zeroext onto the new call's arg_attrs and
-  // res_attrs for Extend args/return.  Ignore args also require a rebuild
-  // because their slots are dropped from the output array.
+  // res_attrs for Extend args/return.  Ignore args require a rebuild because
+  // their slots are dropped; Indirect args need llvm.byval / llvm.align.
   bool needsArgAttrUpdate =
       llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
-        return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend;
+        return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend ||
+               ac.kind == ArgKind::Indirect;
       });
   if (needsArgAttrUpdate) {
     auto existing = call->getAttrOfType<mlir::ArrayAttr>("arg_attrs");
-    newCall->setAttr("arg_attrs", updateArgAttrs(ctx, existing, fc));
+    newCall->setAttr("arg_attrs",
+                     updateArgAttrs(ctx, origCallArgTypes, existing, fc));
   }
   if (fc.returnInfo.kind == ArgKind::Extend) {
     auto existing = call->getAttrOfType<mlir::ArrayAttr>("res_attrs");

--- a/clang/test/CIR/Transforms/abi-lowering/indirect-byval.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/indirect-byval.cir
@@ -1,0 +1,242 @@
+// RUN: cir-opt %s -cir-call-conv-lowering="classification-attr=test_classify" \
+// RUN:   | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+!rec_Big = !cir.struct<"Big" {!s64i, !s64i, !s64i, !s64i}>
+
+#byval_arg = {
+  return = { kind = "direct" },
+  args   = [ { kind = "indirect", indirect_align = 8 } ]
+}
+
+#byval_arg_ext_return = {
+  return = { kind = "extend", coerced_type = !cir.int<s, 32>,
+             sign_extend = true },
+  args   = [ { kind = "indirect", indirect_align = 8 } ]
+}
+
+#byval_ignore_arg = {
+  return = { kind = "direct" },
+  args   = [ { kind = "indirect", indirect_align = 8 },
+             { kind = "ignore" } ]
+}
+
+#two_byval = {
+  return = { kind = "direct" },
+  args   = [ { kind = "indirect", indirect_align = 8 },
+             { kind = "indirect", indirect_align = 8 } ]
+}
+
+#sret_byval = {
+  return = { kind = "indirect", indirect_align = 8 },
+  args   = [ { kind = "indirect", indirect_align = 8 } ]
+}
+
+#byref_arg = {
+  return = { kind = "direct" },
+  args   = [ { kind = "indirect", indirect_align = 8, byval = false } ]
+}
+
+#passthrough = {
+  return = { kind = "direct" },
+  args   = [ ]
+}
+
+module attributes {
+  dlti.dl_spec = #dlti.dl_spec<
+    #dlti.dl_entry<i8, dense<8>: vector<2xi64>>,
+    #dlti.dl_entry<i32, dense<32>: vector<2xi64>>,
+    #dlti.dl_entry<i64, dense<64>: vector<2xi64>>>
+} {
+
+  // The byval arg becomes a pointer with llvm.byval, llvm.align, llvm.noalias,
+  // and llvm.noundef.  A load is inserted at entry so the body sees the
+  // original value type.
+  cir.func @takes_big(%arg0: !rec_Big) -> !s32i
+      attributes { test_classify = #byval_arg } {
+    %r = cir.const #cir.int<0> : !s32i
+    cir.return %r : !s32i
+  }
+
+  // CHECK:      cir.func{{.*}} @takes_big(%[[ARG:.*]]: !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.align = 8 : i64
+  // CHECK-SAME:     llvm.byval = !rec_Big
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.noundef
+  // CHECK:        %{{.*}} = cir.load %[[ARG]] : !cir.ptr<!rec_Big>, !rec_Big
+  // CHECK-NEXT:   %{{.*}} = cir.const #cir.int<0> : !s32i
+
+  // byval composes with an Extend return: the pointer parameter carries all
+  // four byval attrs and the return value carries llvm.signext.
+  cir.func @takes_big_ext(%arg0: !rec_Big) -> !s32i
+      attributes { test_classify = #byval_arg_ext_return } {
+    %r = cir.const #cir.int<0> : !s32i
+    cir.return %r : !s32i
+  }
+
+  // CHECK:      cir.func{{.*}} @takes_big_ext(%{{.*}}: !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.byval = !rec_Big
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.noundef
+  // CHECK-SAME:   ) -> (!s32i {llvm.signext})
+
+  // byval composes with an Ignored second argument: the ignored arg is dropped
+  // from the signature and the byval slot is the only argument.
+  cir.func @takes_big_ignore(%arg0: !rec_Big, %arg1: !s32i) -> !s32i
+      attributes { test_classify = #byval_ignore_arg } {
+    %r = cir.const #cir.int<0> : !s32i
+    cir.return %r : !s32i
+  }
+
+  // CHECK:      cir.func{{.*}} @takes_big_ignore(%{{.*}}: !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.byval = !rec_Big
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.noundef
+  // CHECK-SAME:   ) -> !s32i
+  // CHECK-NOT:    !s32i {{.*}}!s32i
+
+  // A forward declaration: signature is rewritten but no body to touch.
+  cir.func private @takes_big_decl(%arg0: !rec_Big) -> !s32i
+      attributes { test_classify = #byval_arg }
+
+  // CHECK:      cir.func{{.*}} @takes_big_decl(!cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.byval = !rec_Big
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.noundef
+
+  // Caller: byval argument is copied into a fresh alloca; the pointer is
+  // passed with llvm.byval, llvm.noalias, and llvm.noundef on the call
+  // operand, matching classic CodeGen's -fpass-by-value-is-noalias output.
+  cir.func @caller(%s: !rec_Big) -> !s32i
+      attributes { test_classify = #passthrough } {
+    %r = cir.call @takes_big(%s) : (!rec_Big) -> !s32i
+    cir.return %r : !s32i
+  }
+
+  // CHECK:      cir.func{{.*}} @caller(%[[S:.*]]: !rec_Big) -> !s32i
+  // CHECK:        %[[SLOT:.*]] = cir.alloca "byval" align(8) : !cir.ptr<!rec_Big>
+  // CHECK-NEXT:   cir.store %[[S]], %[[SLOT]] : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK-NEXT:   %{{.*}} = cir.call @takes_big(%[[SLOT]]) :
+  // CHECK-SAME:     llvm.byval = !rec_Big
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.noundef
+
+  // A body that actually uses the byval arg value: the existing use in
+  // cir.return is rerouted through the load inserted at entry.
+  cir.func @takes_big_uses_arg(%arg0: !rec_Big) -> !rec_Big
+      attributes { test_classify = #byval_arg } {
+    cir.return %arg0 : !rec_Big
+  }
+
+  // CHECK:      cir.func{{.*}} @takes_big_uses_arg(%[[PTR:.*]]: !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.byval = !rec_Big
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.noundef
+  // CHECK:        %[[LOADED:.*]] = cir.load %[[PTR]] : !cir.ptr<!rec_Big>, !rec_Big
+  // CHECK-NEXT:   cir.return %[[LOADED]] : !rec_Big
+
+  // Two byval arguments: each gets its own alloca at the call site, and both
+  // block args are changed to pointers with loads at the callee entry.
+  cir.func @two_byval(%a: !rec_Big, %b: !rec_Big) -> !rec_Big
+      attributes { test_classify = #two_byval } {
+    cir.return %b : !rec_Big
+  }
+
+  // Both byval slots carry the full attribute set.  Match in appearance order.
+  // CHECK:      cir.func{{.*}} @two_byval(
+  // CHECK-SAME:     !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.byval = !rec_Big
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.noundef
+  // CHECK-SAME:     !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.byval = !rec_Big
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.noundef
+
+  cir.func @caller_two(%s: !rec_Big, %t: !rec_Big) -> !rec_Big
+      attributes { test_classify = #passthrough } {
+    %r = cir.call @two_byval(%s, %t) : (!rec_Big, !rec_Big) -> !rec_Big
+    cir.return %r : !rec_Big
+  }
+
+  // CHECK:      cir.func{{.*}} @caller_two
+  // CHECK:        %[[A:.*]] = cir.alloca "byval" align(8) : !cir.ptr<!rec_Big>
+  // CHECK-NEXT:   cir.store %{{.*}}, %[[A]] : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK-NEXT:   %[[B:.*]] = cir.alloca "byval" align(8) : !cir.ptr<!rec_Big>
+  // CHECK-NEXT:   cir.store %{{.*}}, %[[B]] : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK-NEXT:   %{{.*}} = cir.call @two_byval(%[[A]], %[[B]]) :
+  // CHECK-SAME:     llvm.byval = !rec_Big
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.noundef
+  // CHECK-SAME:     !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.byval = !rec_Big
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.noundef
+
+  // sret return + byval arg: the sret pointer is prepended at slot 0 and the
+  // byval arg shifts to slot 1 (sretOffset = 1).  The byval slot carries all
+  // four byval attrs; the sret slot carries its own standard set.
+  cir.func @byval_and_sret(%arg0: !rec_Big) -> !rec_Big
+      attributes { test_classify = #sret_byval } {
+    %0 = cir.alloca "__retval" align(8) : !cir.ptr<!rec_Big>
+    %z = cir.const #cir.zero : !rec_Big
+    cir.store %z, %0 : !rec_Big, !cir.ptr<!rec_Big>
+    %1 = cir.load %0 : !cir.ptr<!rec_Big>, !rec_Big
+    cir.return %1 : !rec_Big
+  }
+
+  // CHECK:      cir.func{{.*}} @byval_and_sret(
+  // CHECK-SAME:     llvm.sret = !rec_Big
+  // CHECK-SAME:     !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.byval = !rec_Big
+  // CHECK-SAME:     llvm.noalias
+  // CHECK-SAME:     llvm.noundef
+  // CHECK-NOT:    -> !rec_Big
+  // CHECK:        cir.store %{{.*}}, %{{.*}} : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK:        cir.return
+
+  // byref callee definition: the parameter gets llvm.byref instead of
+  // llvm.byval.  noalias and noundef are NOT added (byref passes the
+  // original, which may alias and may carry padding).  The body
+  // transformation (ptr + load at entry) is identical to byval.
+  cir.func @takes_big_byref(%arg0: !rec_Big) -> !rec_Big
+      attributes { test_classify = #byref_arg } {
+    cir.return %arg0 : !rec_Big
+  }
+
+  // CHECK:      cir.func{{.*}} @takes_big_byref(%[[PTR:.*]]: !cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.align = 8 : i64
+  // CHECK-SAME:     llvm.byref = !rec_Big
+  // CHECK-NOT:    llvm.noalias
+  // CHECK-NOT:    llvm.noundef
+  // CHECK:        %[[L:.*]] = cir.load %[[PTR]] : !cir.ptr<!rec_Big>, !rec_Big
+  // CHECK-NEXT:   cir.return %[[L]] : !rec_Big
+
+  // byref forward declaration: signature gets llvm.byref, no body.
+  cir.func private @takes_big_byref_decl(%arg0: !rec_Big) -> !rec_Big
+      attributes { test_classify = #byref_arg }
+
+  // CHECK:      cir.func{{.*}} @takes_big_byref_decl(!cir.ptr<!rec_Big>
+  // CHECK-SAME:     llvm.byref = !rec_Big
+  // CHECK-NOT:    llvm.noalias
+  // CHECK-NOT:    llvm.noundef
+
+  // byref call site: same alloca+store pattern as byval, but the pointer
+  // carries llvm.byref (and no llvm.noalias / llvm.noundef since byref
+  // does not assert exclusive ownership of the storage).
+  cir.func @caller_byref(%s: !rec_Big) -> !rec_Big
+      attributes { test_classify = #passthrough } {
+    %r = cir.call @takes_big_byref(%s) : (!rec_Big) -> !rec_Big
+    cir.return %r : !rec_Big
+  }
+
+  // CHECK:      cir.func{{.*}} @caller_byref(%[[S:.*]]: !rec_Big) -> !rec_Big
+  // CHECK:        %[[SLOT:.*]] = cir.alloca "byref" align(8) : !cir.ptr<!rec_Big>
+  // CHECK-NEXT:   cir.store %[[S]], %[[SLOT]] : !rec_Big, !cir.ptr<!rec_Big>
+  // CHECK-NEXT:   %{{.*}} = cir.call @takes_big_byref(%[[SLOT]]) :
+  // CHECK-SAME:     llvm.byref = !rec_Big
+  // CHECK-NOT:    llvm.noalias
+  // CHECK-NOT:    llvm.noundef
+
+}


### PR DESCRIPTION
ArgKind::Indirect arguments were hitting an errorNYI in
CIRABIRewriteContext.  Add the lowering: in the callee the block argument
type changes to !cir.ptr<T>, a load is inserted at entry so the body sees
the original value type, and llvm.byval or llvm.byref is attached based on
ownership.  At call sites, both byval and byref are lowered by allocating a
stack slot, copying the value in, and passing the pointer.

For byval, llvm.noalias and llvm.noundef are also added — llvm.noalias
because the call-site rewrite always produces a fresh alloca+store
(equivalent to -fpass-by-value-is-noalias), and llvm.noundef because the
copy is always fully defined.  byref carries only llvm.byref and llvm.align
since it does not assert exclusive ownership.