### PR TITLE
[CIR] Implement ArgKind::Expand in CallConvLowering

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
@@ -17,13 +17,20 @@ using namespace mlir;
 using namespace mlir::abi;
 
 // This rewrite context supports the Direct (with or without coercion),
-// Extend, Ignore, Indirect-return (sret), and Indirect-argument (byval and
-// byref) classifications.  For byval (ArgClassification::byVal == true) the
-// callee gets llvm.byval + llvm.noalias + llvm.noundef; for byref (byVal ==
-// false) the callee gets llvm.byref without the ownership attrs.  Both pass
-// through an alloca+store at the call site; the attribute distinction
-// communicates ownership semantics to the optimizer.  Expand still emits an
-// errorNYI rather than silently passing through.
+// Extend, Ignore, Indirect-return (sret), Indirect-argument (byval and
+// byref), and Expand (struct flattening) classifications.
+//
+// For byval (ArgClassification::byVal == true) the callee gets
+// llvm.byval + llvm.noalias + llvm.noundef; for byref (byVal == false)
+// the callee gets llvm.byref without the ownership attrs.  Both pass
+// through an alloca+store at the call site.
+//
+// For Expand, the single struct argument is replaced by N scalar arguments
+// (one per field).  At the callee, the N field block arguments are stored
+// directly into the parameter's own alloca (the CIRGen spill slot).  At the
+// call site, the struct operand is decomposed into its fields by reading
+// each member from the source alloca (get_member + load) when the operand is
+// a load of an alloca, or via cir.extract_member otherwise.
 
 namespace {
 
@@ -41,10 +48,10 @@ bool needsRewrite(const FunctionClassification &fc) {
 }
 
 /// Build the new argument-type list for a function whose ABI classification
-/// is \p fc.  Handles Direct (with or without coercion), Extend, Ignore, and
-/// Indirect (byval and byref) arguments.  Expand emits an error.  The sret
-/// return pointer, when present, is prepended by rewriteFunctionDefinition
-/// rather than here.
+/// is \p fc.  Handles Direct (with or without coercion), Extend, Ignore,
+/// Indirect (byval and byref), and Expand (struct flattening) arguments.
+/// The sret return pointer, when present, is prepended by
+/// rewriteFunctionDefinition rather than here.
 mlir::LogicalResult
 buildNewArgTypes(ArrayRef<mlir::Type> oldArgTypes,
                  const FunctionClassification &fc,
@@ -64,10 +71,18 @@ buildNewArgTypes(ArrayRef<mlir::Type> oldArgTypes,
       break;
     case ArgKind::Ignore:
       break;
-    case ArgKind::Expand:
-      emitError() << "Expand at arg " << idx
-                  << " not yet implemented in CallConvLowering";
-      return mlir::failure();
+    case ArgKind::Expand: {
+      // Flatten the struct into one wire argument per field.  The
+      // reassembly in the callee body and the decomposition at the call
+      // site are handled by insertArgCoercion and rewriteCallSite.
+      auto recTy = cast<cir::RecordType>(origTy);
+      assert(recTy.isStruct() &&
+             "Expand classification requires a struct type, not a union");
+      assert(!recTy.getMembers().empty() &&
+             "Expand classification requires at least one struct field");
+      llvm::append_range(newArgTypes, recTy.getMembers());
+      break;
+    }
     case ArgKind::Extend:
       // Extend keeps the original (narrow) type in the signature; the
       // sign/zero extension is communicated to LLVM via the llvm.signext /
@@ -152,7 +167,12 @@ mlir::ArrayAttr updateArgAttrs(mlir::MLIRContext *ctx,
     mlir::DictionaryAttr existing = builder.getDictionaryAttr({});
     if (existingArgAttrs && oldIdx < existingArgAttrs.size())
       existing = mlir::cast<mlir::DictionaryAttr>(existingArgAttrs[oldIdx]);
-    if (ac.kind == ArgKind::Extend) {
+    if (ac.kind == ArgKind::Expand) {
+      // Push one empty attribute dict per expanded field; the flattened
+      // scalar arguments carry no special ABI attributes.
+      auto recTy = cast<cir::RecordType>(origArgTypes[oldIdx]);
+      newArgAttrs.append(recTy.getNumElements(), builder.getDictionaryAttr({}));
+    } else if (ac.kind == ArgKind::Extend) {
       StringRef attrName = ac.signExtend ? "llvm.signext" : "llvm.zeroext";
       SmallVector<mlir::NamedAttribute> attrs(existing.begin(), existing.end());
       attrs.push_back(builder.getNamedAttr(attrName, builder.getUnitAttr()));
@@ -322,13 +342,18 @@ void insertReturnCoercion(mlir::FunctionOpInterface funcOp,
 
 /// For each Direct arg with a coerced type, change the block argument's type
 /// to the coerced type and insert a coercion at function entry that maps it
-/// back to the original type for body uses.
+/// back to the original type for body uses.  For each Indirect (byval/byref)
+/// arg, change the block argument's type to a pointer and insert a load at
+/// entry so the body sees the original value type.  For each Expand arg,
+/// replace the single struct block argument with N scalar block arguments (one
+/// per field) and store each field directly into the parameter's own alloca
+/// (the CIRGen spill slot), erasing the original whole-struct store.
 ///
-/// The entry block arguments mirror the function's ABI signature: argument
-/// \p hasSRetArg shifts the classification index by one because a hidden
-/// sret pointer occupies block argument 0 when the function returns by
-/// reference.  So fc.argInfos[i] corresponds to block argument
-/// i + hasSRetArg.
+/// \p hasSRetArg is true when the function has an sret return (a hidden return
+/// pointer is prepended as block argument 0).  Expand arguments expand the
+/// block argument count, so a running index tracks the current block argument
+/// position rather than computing the classification index + \p hasSRetArg
+/// directly.
 void insertArgCoercion(mlir::FunctionOpInterface funcOp,
                        const FunctionClassification &fc,
                        mlir::OpBuilder &builder, const mlir::DataLayout &dl,
@@ -338,27 +363,97 @@ void insertArgCoercion(mlir::FunctionOpInterface funcOp,
     return;
   mlir::Block &entry = body.front();
 
-  for (auto [idx, ac] : llvm::enumerate(fc.argInfos)) {
-    // Only two classifications need an entry-block fixup: a Direct arg with a
-    // coerced wire type, and an Indirect (byval/byref) arg.  Extend, Ignore,
-    // and Direct-without-coercion keep the original block-argument type, so
-    // the body already sees the right value and there is nothing to do.
-    bool needsCoercion = ac.kind == ArgKind::Direct && ac.coercedType;
-    if (!needsCoercion && ac.kind != ArgKind::Indirect)
+  // Running block argument index.  Each non-Expand classification occupies
+  // one block argument slot; each Expand classification occupies N slots
+  // (one per struct field), so the running index must be incremented by N
+  // rather than 1 after processing an Expand arg.
+  unsigned blockArgIdx = hasSRetArg ? 1 : 0;
+
+  for (const ArgClassification &ac : fc.argInfos) {
+    assert(blockArgIdx < entry.getNumArguments() &&
+           "classification count must not exceed entry block arguments");
+
+    if (ac.kind == ArgKind::Expand) {
+      // The block arg at blockArgIdx currently has the original struct type.
+      // Replace it with N scalar args (one per field) and store each field
+      // directly into the parameter's own alloca.
+      mlir::BlockArgument origArg = entry.getArgument(blockArgIdx);
+      auto recTy = cast<cir::RecordType>(origArg.getType());
+      assert(recTy.isStruct() &&
+             "Expand classification requires a struct type, not a union");
+      unsigned numFields = recTy.getNumElements();
+      assert(numFields > 0 &&
+             "Expand classification requires at least one struct field");
+      mlir::Location loc = funcOp.getLoc();
+
+      // CIRGen spills every by-value struct parameter into its local alloca
+      // with a single store before any other use, so the struct block arg's
+      // only use is that spill.  Capture it and the destination alloca so the
+      // expanded fields can be stored straight into that alloca, preserving
+      // the alloca's variable name and `init` flag and avoiding a
+      // reassemble-then-reload roundtrip.  DCE may have run earlier and
+      // removed the spill (leaving the block arg unused); tolerate that by
+      // only flattening the signature and emitting no field stores.
+      cir::StoreOp paramStore;
+      cir::AllocaOp destAlloca;
+      if (!origArg.use_empty()) {
+        assert(origArg.hasOneUse() &&
+               "Expand arg must have exactly one use (the CIRGen param spill)");
+        paramStore = cast<cir::StoreOp>(*origArg.user_begin());
+        assert(paramStore.getValue() == origArg &&
+               "Expand arg's use must be the value operand of its store");
+        destAlloca = cast<cir::AllocaOp>(paramStore.getAddr().getDefiningOp());
+      }
+
+      // Erase the original whole-struct spill before retyping the block
+      // argument, so the store is never left feeding a type-mismatched value.
+      // The field stores take its place, just before the following operation
+      // (the spill always precedes the entry block's terminator).
+      mlir::Operation *fieldStoreInsertPt = nullptr;
+      if (paramStore) {
+        fieldStoreInsertPt = paramStore->getNextNode();
+        assert(fieldStoreInsertPt &&
+               "param spill must be followed by a block terminator");
+        paramStore->erase();
+      }
+
+      // Split the single struct block arg into N scalar field block args (slot
+      // 0 reuses the original; slots 1..N-1 are inserted after it).  The
+      // reshape needs no insertion point.  The field stores are gated on the
+      // same destAlloca condition: when the spill survived we set the insert
+      // point to its old slot (which sits after the CIRGen allocas) and store
+      // each field there; when DCE removed the spill the parameter is dead, so
+      // we only reshape the signature and emit no stores.
+      if (destAlloca)
+        builder.setInsertionPoint(fieldStoreInsertPt);
+      for (auto [f, fieldTy] : llvm::enumerate(recTy.getMembers())) {
+        if (f == 0)
+          origArg.setType(fieldTy);
+        else
+          entry.insertArgument(blockArgIdx + f, fieldTy, loc);
+        if (!destAlloca)
+          continue;
+        mlir::Type fieldPtrTy = cir::PointerType::get(fieldTy);
+        auto fieldPtr = cir::GetMemberOp::create(builder, loc, fieldPtrTy,
+                                                 destAlloca, /*name=*/"",
+                                                 /*index=*/f);
+        cir::StoreOp::create(builder, loc, entry.getArgument(blockArgIdx + f),
+                             fieldPtr);
+      }
+
+      blockArgIdx += numFields;
       continue;
+    }
 
-    unsigned blockIdx = idx + hasSRetArg;
-    if (blockIdx >= entry.getNumArguments())
-      continue;
+    mlir::BlockArgument blockArg = entry.getArgument(blockArgIdx);
 
-    mlir::BlockArgument blockArg = entry.getArgument(blockIdx);
-
-    if (needsCoercion) {
+    if (ac.kind == ArgKind::Direct && ac.coercedType) {
       mlir::Type oldArgTy = blockArg.getType();
       mlir::Type newArgTy = ac.coercedType;
-      if (oldArgTy == newArgTy)
+      if (oldArgTy == newArgTy) {
+        ++blockArgIdx;
         continue;
-
+      }
       blockArg.setType(newArgTy);
 
       builder.setInsertionPointToStart(&entry);
@@ -371,12 +466,12 @@ void insertArgCoercion(mlir::FunctionOpInterface funcOp,
       // operand is blockArg, and if we naively replaceAllUses it gets swapped
       // to adapted (now of the original type != the alloca's pointee type).
       blockArg.replaceAllUsesExcept(adapted, coercionOps);
-    } else {
-      // ArgKind::Indirect.  byval and byref: the wire type is !cir.ptr<T>.
-      // Change the block arg to the pointer type and insert a load so the
-      // body sees the original T.  The body transformation is the same for
-      // both; the distinction between byval (llvm.byval) and byref
-      // (llvm.byref) is in the arg attributes applied by updateArgAttrs.
+    } else if (ac.kind == ArgKind::Indirect) {
+      // byval and byref: the wire type is !cir.ptr<T>.  Change the block arg
+      // to the pointer type and insert a load so the body sees the original
+      // T.  The body transformation is the same for both; the distinction
+      // between byval (llvm.byval) and byref (llvm.byref) is in the arg
+      // attributes applied by updateArgAttrs.
       mlir::Type origTy = blockArg.getType();
       auto ptrTy = cir::PointerType::get(origTy);
       blockArg.setType(ptrTy);
@@ -386,6 +481,9 @@ void insertArgCoercion(mlir::FunctionOpInterface funcOp,
       SmallPtrSet<mlir::Operation *, 1> loadOps = {loadOp};
       blockArg.replaceAllUsesExcept(loadOp.getResult(), loadOps);
     }
+    // Ignore, Extend, and Direct-without-coerce need no block-level changes.
+
+    ++blockArgIdx;
   }
 }
 
@@ -568,13 +666,13 @@ void rewriteIndirectReturnCall(cir::CallOp call,
 
   // Shape the per-argument attrs exactly as the non-sret path does
   // (signext / zeroext for Extend, drop Ignore slots, byval / align for
-  // Indirect) before prepending the sret slot, so sret composes correctly
-  // with Extend / Ignore / Indirect args.
+  // Indirect, flatten for Expand) before prepending the sret slot, so sret
+  // composes correctly with Extend / Ignore / Indirect / Expand args.
   mlir::ArrayAttr argAttrs = call->getAttrOfType<mlir::ArrayAttr>("arg_attrs");
   bool needsArgAttrUpdate =
       llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
         return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend ||
-               ac.kind == ArgKind::Indirect;
+               ac.kind == ArgKind::Indirect || ac.kind == ArgKind::Expand;
       });
   if (needsArgAttrUpdate)
     argAttrs = updateArgAttrs(ctx, origCallArgTypes, argAttrs, fc);
@@ -679,27 +777,32 @@ mlir::LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
 
       mlir::Block &entry = body.front();
 
-      // For each Ignored argument: drop the block argument and, if the
-      // body still references it, replace those uses with a poison
-      // constant.  Ignore classifications mean the value is empty / not
-      // passed at the ABI level, so any remaining uses are vacuous;
-      // poison says exactly that.  Iterate in reverse so that earlier
-      // indices stay stable as later ones are erased.
-      for (int argInfoIdx = static_cast<int>(fc.argInfos.size()) - 1;
-           argInfoIdx >= 0; --argInfoIdx) {
-        if (fc.argInfos[argInfoIdx].kind != ArgKind::Ignore)
+      // Drop each Ignored argument's block argument, replacing any remaining
+      // body uses with a poison constant (an Ignore arg is not passed at the
+      // ABI level, so any use is vacuous; poison says exactly that).  Walk
+      // forward with a running block-argument index that mirrors
+      // insertArgCoercion: an Expand arg occupies N slots, every other kept
+      // kind one.  On erase, do not advance the index -- the next block
+      // argument shifts into the vacated slot.
+      unsigned blockArgIdx = hasSRet ? 1 : 0;
+      for (auto [i, ac] : llvm::enumerate(fc.argInfos)) {
+        if (blockArgIdx >= entry.getNumArguments())
+          break;
+        if (ac.kind == ArgKind::Ignore) {
+          mlir::BlockArgument arg = entry.getArgument(blockArgIdx);
+          if (!arg.use_empty()) {
+            builder.setInsertionPointToStart(&entry);
+            mlir::Value poison =
+                createIgnoredValue(builder, funcOp.getLoc(), arg.getType());
+            arg.replaceAllUsesWith(poison);
+          }
+          entry.eraseArgument(blockArgIdx);
           continue;
-        unsigned blockIdx = static_cast<unsigned>(argInfoIdx) + hasSRet;
-        if (blockIdx >= entry.getNumArguments())
-          continue;
-        mlir::BlockArgument arg = entry.getArgument(blockIdx);
-        if (!arg.use_empty()) {
-          builder.setInsertionPointToStart(&entry);
-          mlir::Value poison =
-              createIgnoredValue(builder, funcOp.getLoc(), arg.getType());
-          arg.replaceAllUsesWith(poison);
         }
-        entry.eraseArgument(blockIdx);
+        if (ac.kind == ArgKind::Expand)
+          blockArgIdx += cast<cir::RecordType>(oldArgTypes[i]).getNumElements();
+        else
+          ++blockArgIdx;
       }
     }
 
@@ -729,12 +832,12 @@ mlir::LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
 
   // Rebuild arg_attrs when the function has an sret slot (slot 0 needs the
   // sret attribute set) or any arg is Ignore (dropped from the output array),
-  // Extend (needs llvm.signext / llvm.zeroext), or Indirect (needs
-  // llvm.byval / llvm.align).
+  // Extend (needs llvm.signext / llvm.zeroext), Indirect (needs
+  // llvm.byval / llvm.align), or Expand (changes the argument count).
   bool needsArgAttrUpdate =
       hasSRet || llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
         return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend ||
-               ac.kind == ArgKind::Indirect;
+               ac.kind == ArgKind::Indirect || ac.kind == ArgKind::Expand;
       });
   if (needsArgAttrUpdate) {
     auto existing = funcOp->getAttrOfType<mlir::ArrayAttr>("arg_attrs");
@@ -784,25 +887,16 @@ CIRABIRewriteContext::rewriteCallSite(mlir::Operation *callOp,
   mlir::MLIRContext *ctx = callOp->getContext();
   auto enclosingFunc = call->getParentOfType<mlir::FunctionOpInterface>();
 
-  for (auto [idx, ac] : llvm::enumerate(fc.argInfos)) {
-    switch (ac.kind) {
-    case ArgKind::Direct:
-    case ArgKind::Ignore:
-    case ArgKind::Extend:
-    case ArgKind::Indirect:
-      // All handled in the arg-building loop below.
-      break;
-    case ArgKind::Expand:
-      return call.emitOpError() << "Expand at call-site arg " << idx
-                                << " not yet implemented in CallConvLowering";
-    }
-  }
-
   builder.setInsertionPoint(call);
 
   SmallVector<mlir::Value> newArgs;
   mlir::ValueRange argOperands = call.getArgOperands();
   newArgs.reserve(argOperands.size());
+
+  // Whole-struct loads replaced by direct member loads for Expand operands.
+  // They can only be erased once the original call (their remaining user) is
+  // gone, so collect them and erase the dead ones at the end.
+  SmallVector<cir::LoadOp> replacedWholeLoads;
 
   // Capture original arg types before building newArgs (byval slots change
   // the wire argument from T to !cir.ptr<T>, so we save the pre-rewrite
@@ -818,10 +912,47 @@ CIRABIRewriteContext::rewriteCallSite(mlir::Operation *callOp,
     if (ac.kind == ArgKind::Ignore)
       continue;
     mlir::Value arg = argOperands[idx];
-    if (ac.kind == ArgKind::Direct && ac.coercedType &&
-        arg.getType() != ac.coercedType) {
+    if (ac.kind == ArgKind::Expand) {
+      // Decompose the struct value into its constituent scalar fields and
+      // pass each as a separate argument.
+      auto recTy = cast<cir::RecordType>(arg.getType());
+      assert(recTy.isStruct() &&
+             "Expand classification requires a struct type, not a union");
+
+      // When the operand is a load straight from an alloca, read each member
+      // directly from that alloca (get_member + load) instead of loading the
+      // whole struct and extracting from it; this matches classic CodeGen.
+      // The member loads are emitted at the original load's position so they
+      // observe the same memory state.  When there is no source alloca (a
+      // call result, compound literal, etc.) cir.extract_member on the value
+      // is the only correct lowering.
+      auto wholeLoad = arg.getDefiningOp<cir::LoadOp>();
+      cir::AllocaOp srcAlloca;
+      if (wholeLoad)
+        srcAlloca = wholeLoad.getAddr().getDefiningOp<cir::AllocaOp>();
+
+      if (srcAlloca) {
+        mlir::OpBuilder::InsertionGuard guard(builder);
+        builder.setInsertionPoint(wholeLoad);
+        for (auto [f, fieldTy] : llvm::enumerate(recTy.getMembers())) {
+          mlir::Type fieldPtrTy = cir::PointerType::get(fieldTy);
+          mlir::Value fieldPtr = cir::GetMemberOp::create(
+              builder, call.getLoc(), fieldPtrTy, srcAlloca, /*name=*/"",
+              /*index=*/f);
+          newArgs.push_back(
+              cir::LoadOp::create(builder, call.getLoc(), fieldPtr));
+        }
+        replacedWholeLoads.push_back(wholeLoad);
+      } else {
+        for (unsigned f = 0; f < recTy.getNumElements(); ++f)
+          newArgs.push_back(
+              cir::ExtractMemberOp::create(builder, call.getLoc(), arg, f));
+      }
+    } else if (ac.kind == ArgKind::Direct && ac.coercedType &&
+               arg.getType() != ac.coercedType) {
       arg = emitCoercion(builder, call.getLoc(), ac.coercedType, arg,
                          enclosingFunc, dl);
+      newArgs.push_back(arg);
     } else if (ac.kind == ArgKind::Indirect) {
       // byval and byref: allocate a stack slot, copy the value in, and pass
       // the pointer.  The alloca+store pattern is identical for both; the
@@ -837,8 +968,10 @@ CIRABIRewriteContext::rewriteCallSite(mlir::Operation *callOp,
                                         builder.getI64IntegerAttr(align));
       cir::StoreOp::create(builder, call.getLoc(), arg, slot);
       arg = slot;
+      newArgs.push_back(arg);
+    } else {
+      newArgs.push_back(arg);
     }
-    newArgs.push_back(arg);
   }
 
   bool hasResult = call.getNumResults() > 0;
@@ -883,11 +1016,12 @@ CIRABIRewriteContext::rewriteCallSite(mlir::Operation *callOp,
 
   // Layer llvm.signext / llvm.zeroext onto the new call's arg_attrs and
   // res_attrs for Extend args/return.  Ignore args require a rebuild because
-  // their slots are dropped; Indirect args need llvm.byval / llvm.align.
+  // their slots are dropped; Indirect args need llvm.byval / llvm.align;
+  // Expand args change the argument count.
   bool needsArgAttrUpdate =
       llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
         return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend ||
-               ac.kind == ArgKind::Indirect;
+               ac.kind == ArgKind::Indirect || ac.kind == ArgKind::Expand;
       });
   if (needsArgAttrUpdate) {
     auto existing = call->getAttrOfType<mlir::ArrayAttr>("arg_attrs");
@@ -916,5 +1050,16 @@ CIRABIRewriteContext::rewriteCallSite(mlir::Operation *callOp,
   }
 
   call->erase();
+
+  // Now that the original call is gone, drop any whole-struct loads whose
+  // members we read directly from the source alloca, if nothing else uses
+  // them.  A single load can feed several Expand operands (e.g. after CSE
+  // merges identical loads), so dedupe before erasing to avoid touching a
+  // freed op twice.
+  SmallPtrSet<mlir::Operation *, 4> erased;
+  for (cir::LoadOp wholeLoad : replacedWholeLoads)
+    if (erased.insert(wholeLoad).second && wholeLoad.use_empty())
+      wholeLoad->erase();
+
   return mlir::success();
 }

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.h
@@ -12,8 +12,8 @@
 // the ABI-lowered shape.
 //
 // This file handles Direct (pass-through and coerce-in-registers), Extend,
-// Ignore, and an Indirect (sret) return.  Indirect arguments (byval) and
-// Expand still emit an errorNYI.
+// Ignore, Indirect (sret return, byval and byref arguments), and Expand
+// (struct flattening into scalar fields).
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/test/CIR/Transforms/abi-lowering/expand-struct-arg.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/expand-struct-arg.cir
@@ -1,0 +1,280 @@
+// RUN: cir-opt %s -cir-call-conv-lowering="classification-attr=test_classify" \
+// RUN:   | FileCheck %s
+
+!s64i = !cir.int<s, 64>
+!s32i = !cir.int<s, 32>
+!rec_TwoLong = !cir.struct<"TwoLong" {!s64i, !s64i}>
+!rec_ThreeInt = !cir.struct<"ThreeInt" {!s32i, !s32i, !s32i}>
+!rec_OneInt = !cir.struct<"OneInt" {!s32i}>
+
+#expand_two = {
+  return = { kind = "direct" },
+  args   = [ { kind = "expand" } ]
+}
+
+#expand_three = {
+  return = { kind = "direct" },
+  args   = [ { kind = "expand" } ]
+}
+
+#expand_one = {
+  return = { kind = "direct" },
+  args   = [ { kind = "expand" } ]
+}
+
+#expand_expand = {
+  return = { kind = "direct" },
+  args   = [ { kind = "expand" }, { kind = "expand" } ]
+}
+
+#expand_ignore_expand = {
+  return = { kind = "direct" },
+  args   = [ { kind = "expand" },
+             { kind = "ignore" },
+             { kind = "expand" } ]
+}
+
+#sret_expand = {
+  return = { kind = "indirect", indirect_align = 8 },
+  args   = [ { kind = "expand" } ]
+}
+
+#passthrough = {
+  return = { kind = "direct" },
+  args   = [ ]
+}
+
+module attributes {
+  dlti.dl_spec = #dlti.dl_spec<
+    #dlti.dl_entry<i32, dense<32>: vector<2xi64>>,
+    #dlti.dl_entry<i64, dense<64>: vector<2xi64>>>
+} {
+
+// The single struct arg becomes two i64 block args, stored field-by-field
+// straight into the parameter's own alloca; the original whole-struct store
+// is gone and no scratch alloca/reload is introduced.
+
+cir.func @takes_two_long(%arg0: !rec_TwoLong)
+    attributes { test_classify = #expand_two } {
+  %0 = cir.alloca "p" align(8) init : !cir.ptr<!rec_TwoLong>
+  cir.store %arg0, %0 : !rec_TwoLong, !cir.ptr<!rec_TwoLong>
+  cir.return
+}
+
+// CHECK-LABEL: cir.func{{.*}} @takes_two_long(
+// CHECK-SAME:    %[[F0:.*]]: !s64i, %[[F1:.*]]: !s64i)
+// CHECK-NOT:     ["expand"]
+// CHECK:         %[[P:.*]] = cir.alloca "p" {{.*}} init : !cir.ptr<!rec_TwoLong>
+// CHECK:         %[[P0:.*]] = cir.get_member %[[P]][0]
+// CHECK:         cir.store %[[F0]], %[[P0]] : !s64i, !cir.ptr<!s64i>
+// CHECK:         %[[P1:.*]] = cir.get_member %[[P]][1]
+// CHECK:         cir.store %[[F1]], %[[P1]] : !s64i, !cir.ptr<!s64i>
+// CHECK-NOT:     cir.load %[[P]] : !cir.ptr<!rec_TwoLong>
+
+// The body loads the spilled struct back (here for the return), so that load
+// stays; only the original arg store is replaced.
+
+cir.func @returns_expanded(%arg0: !rec_TwoLong) -> !rec_TwoLong
+    attributes { test_classify = #expand_two } {
+  %0 = cir.alloca "s" align(8) init : !cir.ptr<!rec_TwoLong>
+  cir.store %arg0, %0 : !rec_TwoLong, !cir.ptr<!rec_TwoLong>
+  %1 = cir.load %0 : !cir.ptr<!rec_TwoLong>, !rec_TwoLong
+  cir.return %1 : !rec_TwoLong
+}
+
+// CHECK-LABEL: cir.func{{.*}} @returns_expanded(
+// CHECK-SAME:    %[[F0:.*]]: !s64i, %[[F1:.*]]: !s64i) -> !rec_TwoLong
+// CHECK:         %[[S:.*]] = cir.alloca "s" {{.*}} init : !cir.ptr<!rec_TwoLong>
+// CHECK:         %[[P0:.*]] = cir.get_member %[[S]][0]
+// CHECK:         cir.store %[[F0]], %[[P0]] : !s64i, !cir.ptr<!s64i>
+// CHECK:         %[[P1:.*]] = cir.get_member %[[S]][1]
+// CHECK:         cir.store %[[F1]], %[[P1]] : !s64i, !cir.ptr<!s64i>
+// CHECK:         %[[STRUCT:.*]] = cir.load %[[S]] : !cir.ptr<!rec_TwoLong>, !rec_TwoLong
+// CHECK:         cir.return %[[STRUCT]] : !rec_TwoLong
+
+// Three-field expansion.
+
+cir.func @takes_three_int(%arg0: !rec_ThreeInt)
+    attributes { test_classify = #expand_three } {
+  %0 = cir.alloca "s" align(4) init : !cir.ptr<!rec_ThreeInt>
+  cir.store %arg0, %0 : !rec_ThreeInt, !cir.ptr<!rec_ThreeInt>
+  cir.return
+}
+
+// CHECK-LABEL: cir.func{{.*}} @takes_three_int(
+// CHECK-SAME:    %[[A:.*]]: !s32i, %[[B:.*]]: !s32i, %[[C:.*]]: !s32i)
+// CHECK:         %[[S:.*]] = cir.alloca "s" {{.*}} init : !cir.ptr<!rec_ThreeInt>
+// CHECK:         %[[P0:.*]] = cir.get_member %[[S]][0]
+// CHECK:         cir.store %[[A]], %[[P0]] : !s32i, !cir.ptr<!s32i>
+// CHECK:         %[[P1:.*]] = cir.get_member %[[S]][1]
+// CHECK:         cir.store %[[B]], %[[P1]] : !s32i, !cir.ptr<!s32i>
+// CHECK:         %[[P2:.*]] = cir.get_member %[[S]][2]
+// CHECK:         cir.store %[[C]], %[[P2]] : !s32i, !cir.ptr<!s32i>
+
+// Forward declaration: signature is flattened, no body to instrument.
+
+cir.func private @takes_two_long_decl(!rec_TwoLong)
+    attributes { test_classify = #expand_two }
+
+// CHECK-LABEL: cir.func{{.*}} @takes_two_long_decl(!s64i, !s64i)
+// CHECK-NOT:   !rec_TwoLong
+
+// Caller whose operand is a load of an alloca: read each member directly
+// from that alloca (get_member + load); the whole-struct load is dropped.
+
+cir.func @caller_two_long() attributes { test_classify = #passthrough } {
+  %0 = cir.alloca "s" align(8) : !cir.ptr<!rec_TwoLong>
+  %1 = cir.load %0 : !cir.ptr<!rec_TwoLong>, !rec_TwoLong
+  cir.call @takes_two_long(%1) : (!rec_TwoLong) -> ()
+  cir.return
+}
+
+// CHECK-LABEL: cir.func{{.*}} @caller_two_long()
+// CHECK:         %[[S:.*]] = cir.alloca "s" {{.*}}: !cir.ptr<!rec_TwoLong>
+// CHECK-NOT:     cir.load %[[S]] : !cir.ptr<!rec_TwoLong>
+// CHECK:         %[[P0:.*]] = cir.get_member %[[S]][0]
+// CHECK:         %[[F0:.*]] = cir.load %[[P0]] : !cir.ptr<!s64i>, !s64i
+// CHECK:         %[[P1:.*]] = cir.get_member %[[S]][1]
+// CHECK:         %[[F1:.*]] = cir.load %[[P1]] : !cir.ptr<!s64i>, !s64i
+// CHECK:         cir.call @takes_two_long(%[[F0]], %[[F1]]) : (!s64i, !s64i) -> ()
+
+// Expand composed with Ignore: the middle arg is dropped; the two Expand
+// args each store their two fields into their own alloca.
+
+cir.func @expand_ignore_expand_callee(
+    %a: !rec_TwoLong, %b: !rec_TwoLong, %c: !rec_TwoLong)
+    attributes { test_classify = #expand_ignore_expand } {
+  %0 = cir.alloca "a" align(8) init : !cir.ptr<!rec_TwoLong>
+  %1 = cir.alloca "c" align(8) init : !cir.ptr<!rec_TwoLong>
+  cir.store %a, %0 : !rec_TwoLong, !cir.ptr<!rec_TwoLong>
+  cir.store %c, %1 : !rec_TwoLong, !cir.ptr<!rec_TwoLong>
+  cir.return
+}
+
+// CHECK-LABEL: cir.func{{.*}} @expand_ignore_expand_callee(
+// CHECK-SAME:    %[[A0:.*]]: !s64i, %[[A1:.*]]: !s64i, %[[C0:.*]]: !s64i, %[[C1:.*]]: !s64i)
+// CHECK:         %[[A:.*]] = cir.alloca "a" {{.*}} init : !cir.ptr<!rec_TwoLong>
+// CHECK:         %[[C:.*]] = cir.alloca "c" {{.*}} init : !cir.ptr<!rec_TwoLong>
+// CHECK:         %[[AP0:.*]] = cir.get_member %[[A]][0]
+// CHECK:         cir.store %[[A0]], %[[AP0]] : !s64i, !cir.ptr<!s64i>
+// CHECK:         %[[AP1:.*]] = cir.get_member %[[A]][1]
+// CHECK:         cir.store %[[A1]], %[[AP1]] : !s64i, !cir.ptr<!s64i>
+// CHECK:         %[[CP0:.*]] = cir.get_member %[[C]][0]
+// CHECK:         cir.store %[[C0]], %[[CP0]] : !s64i, !cir.ptr<!s64i>
+// CHECK:         %[[CP1:.*]] = cir.get_member %[[C]][1]
+// CHECK:         cir.store %[[C1]], %[[CP1]] : !s64i, !cir.ptr<!s64i>
+
+// One-field expansion: the single block arg is retyped in place.
+
+cir.func @takes_one_int(%arg0: !rec_OneInt)
+    attributes { test_classify = #expand_one } {
+  %0 = cir.alloca "s" align(4) init : !cir.ptr<!rec_OneInt>
+  cir.store %arg0, %0 : !rec_OneInt, !cir.ptr<!rec_OneInt>
+  cir.return
+}
+
+// CHECK-LABEL: cir.func{{.*}} @takes_one_int(
+// CHECK-SAME:    %[[F:.*]]: !s32i)
+// CHECK:         %[[S:.*]] = cir.alloca "s" {{.*}} init : !cir.ptr<!rec_OneInt>
+// CHECK:         %[[P:.*]] = cir.get_member %[[S]][0]
+// CHECK:         cir.store %[[F]], %[[P]] : !s32i, !cir.ptr<!s32i>
+
+// Two consecutive Expand args: exercises the running block-arg index across
+// multiple expansions.  Each expansion stores into its own alloca at its own
+// store position, so the field-store ordering is deterministic.
+
+cir.func @two_expand_args(%a: !rec_TwoLong, %b: !rec_ThreeInt)
+    attributes { test_classify = #expand_expand } {
+  %0 = cir.alloca "a" align(8) init : !cir.ptr<!rec_TwoLong>
+  %1 = cir.alloca "b" align(4) init : !cir.ptr<!rec_ThreeInt>
+  cir.store %a, %0 : !rec_TwoLong, !cir.ptr<!rec_TwoLong>
+  cir.store %b, %1 : !rec_ThreeInt, !cir.ptr<!rec_ThreeInt>
+  cir.return
+}
+
+// CHECK-LABEL: cir.func{{.*}} @two_expand_args(
+// CHECK-SAME:    %[[A0:.*]]: !s64i, %[[A1:.*]]: !s64i, %[[B0:.*]]: !s32i, %[[B1:.*]]: !s32i, %[[B2:.*]]: !s32i)
+// CHECK:         %[[A:.*]] = cir.alloca "a" {{.*}} init : !cir.ptr<!rec_TwoLong>
+// CHECK:         %[[B:.*]] = cir.alloca "b" {{.*}} init : !cir.ptr<!rec_ThreeInt>
+// CHECK:         cir.get_member %[[A]][0]
+// CHECK:         cir.store %[[A0]], %{{.*}} : !s64i, !cir.ptr<!s64i>
+// CHECK:         cir.get_member %[[B]][0]
+// CHECK:         cir.store %[[B0]], %{{.*}} : !s32i, !cir.ptr<!s32i>
+
+// Caller with two Expand operands, both loads of allocas.
+
+cir.func @caller_two_expand() attributes { test_classify = #passthrough } {
+  %0 = cir.alloca "a" align(8) : !cir.ptr<!rec_TwoLong>
+  %1 = cir.alloca "b" align(4) : !cir.ptr<!rec_ThreeInt>
+  %a = cir.load %0 : !cir.ptr<!rec_TwoLong>, !rec_TwoLong
+  %b = cir.load %1 : !cir.ptr<!rec_ThreeInt>, !rec_ThreeInt
+  cir.call @two_expand_args(%a, %b) : (!rec_TwoLong, !rec_ThreeInt) -> ()
+  cir.return
+}
+
+// CHECK-LABEL: cir.func{{.*}} @caller_two_expand()
+// CHECK:         %[[A:.*]] = cir.alloca "a" {{.*}}: !cir.ptr<!rec_TwoLong>
+// CHECK:         %[[B:.*]] = cir.alloca "b" {{.*}}: !cir.ptr<!rec_ThreeInt>
+// CHECK-NOT:     cir.load %[[A]] : !cir.ptr<!rec_TwoLong>
+// CHECK-NOT:     cir.load %[[B]] : !cir.ptr<!rec_ThreeInt>
+// CHECK:         cir.get_member %[[A]][0]
+// CHECK:         cir.get_member %[[A]][1]
+// CHECK:         cir.get_member %[[B]][0]
+// CHECK:         cir.get_member %[[B]][1]
+// CHECK:         cir.get_member %[[B]][2]
+// CHECK:         cir.call @two_expand_args(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (!s64i, !s64i, !s32i, !s32i, !s32i) -> ()
+
+// Fallback: the operand is not a load of an alloca (here a struct constant),
+// so members are taken with cir.extract_member on the value.
+
+cir.func @caller_const() attributes { test_classify = #passthrough } {
+  %v = cir.const #cir.zero : !rec_TwoLong
+  cir.call @takes_two_long(%v) : (!rec_TwoLong) -> ()
+  cir.return
+}
+
+// CHECK-LABEL: cir.func{{.*}} @caller_const()
+// CHECK:         %[[V:.*]] = cir.const #cir.zero : !rec_TwoLong
+// CHECK:         %[[F0:.*]] = cir.extract_member %[[V]][0] : !rec_TwoLong -> !s64i
+// CHECK:         %[[F1:.*]] = cir.extract_member %[[V]][1] : !rec_TwoLong -> !s64i
+// CHECK:         cir.call @takes_two_long(%[[F0]], %[[F1]]) : (!s64i, !s64i) -> ()
+
+// sret return + Expand arg: the sret pointer is block arg 0 (sretOffset = 1)
+// and the Expand arg's two scalar block args follow at slots 1 and 2.
+
+cir.func @sret_and_expand(%arg0: !rec_TwoLong) -> !rec_TwoLong
+    attributes { test_classify = #sret_expand } {
+  %0 = cir.alloca "s" align(8) init : !cir.ptr<!rec_TwoLong>
+  cir.store %arg0, %0 : !rec_TwoLong, !cir.ptr<!rec_TwoLong>
+  %1 = cir.alloca "__retval" align(8) : !cir.ptr<!rec_TwoLong>
+  %z = cir.const #cir.zero : !rec_TwoLong
+  cir.store %z, %1 : !rec_TwoLong, !cir.ptr<!rec_TwoLong>
+  %2 = cir.load %1 : !cir.ptr<!rec_TwoLong>, !rec_TwoLong
+  cir.return %2 : !rec_TwoLong
+}
+
+// CHECK-LABEL: cir.func{{.*}} @sret_and_expand(
+// CHECK-SAME:     llvm.sret = !rec_TwoLong
+// CHECK-SAME:     %[[F0:.*]]: !s64i, %[[F1:.*]]: !s64i)
+// CHECK-NOT:   -> !rec_TwoLong
+// CHECK:         %[[S:.*]] = cir.alloca "s" {{.*}} init : !cir.ptr<!rec_TwoLong>
+// CHECK:         %[[P0:.*]] = cir.get_member %[[S]][0]
+// CHECK:         cir.store %[[F0]], %[[P0]] : !s64i, !cir.ptr<!s64i>
+// CHECK:         %[[P1:.*]] = cir.get_member %[[S]][1]
+// CHECK:         cir.store %[[F1]], %[[P1]] : !s64i, !cir.ptr<!s64i>
+
+// The block arg has no spill store (e.g. DCE removed it): the signature is
+// still flattened to scalar field args, but no get_member/store is emitted.
+
+cir.func @takes_two_long_unused(%arg0: !rec_TwoLong)
+    attributes { test_classify = #expand_two } {
+  cir.return
+}
+
+// CHECK-LABEL: cir.func{{.*}} @takes_two_long_unused(
+// CHECK-SAME:    %{{.*}}: !s64i, %{{.*}}: !s64i)
+// CHECK-NOT:     cir.get_member
+// CHECK-NOT:     cir.store
+// CHECK:         cir.return
+
+}


### PR DESCRIPTION
ArgKind::Expand classifies a struct argument for flattening: each field
becomes a separate scalar argument at the ABI level.  Classic CodeGen
calls this "struct expansion" — used on targets like MIPS and some ARM
calling conventions.

CIRABIRewriteContext previously emitted errorNYI at both classification
sites.  The replacement covers three call paths.  In buildNewArgTypes,
the original struct type is replaced by one wire type per field.  In
insertArgCoercion, the single struct block argument is replaced by N
scalar block arguments and an alloca+get_member+store+load sequence at
the entry block reassembles them for body uses; a running block-argument
index (rather than classIdx + sretOffset) correctly tracks the expanded
slot count when multiple Expand args or sret+Expand combinations appear.
The Ignore-drop loop gains a classToBlockArg pre-computation so that
Ignore args following Expand args are erased at the correct index.  In
rewriteCallSite, cir.extract_member decomposes the struct operand into
its constituent fields, which become separate call arguments.

Asserts guard the two structural invariants: Expand requires a struct
type (not a union) and at least one field.