### PR TITLE
[CIR] Implement Direct+canFlatten in CallConvLowering

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
@@ -202,7 +202,7 @@ mlir::ArrayAttr updateArgAttrs(mlir::MLIRContext *ctx,
     mlir::DictionaryAttr existing = builder.getDictionaryAttr({});
     if (existingArgAttrs && oldIdx < existingArgAttrs.size())
       existing = mlir::cast<mlir::DictionaryAttr>(existingArgAttrs[oldIdx]);
-    if (auto flatTy = getFlattenedCoercedType(ac)) {
+    if (cir::RecordType flatTy = getFlattenedCoercedType(ac)) {
       // Direct + canFlatten: one empty attribute dict per flattened field; the
       // flattened scalar arguments carry no special ABI attributes.
       newArgAttrs.append(flatTy.getNumElements(),
@@ -394,6 +394,44 @@ void insertReturnCoercion(mlir::FunctionOpInterface funcOp,
     mlir::Value coerced =
         emitCoercion(builder, r.getLoc(), coercedRetTy, origVal, funcOp, dl);
     r->setOperand(0, coerced);
+  }
+}
+
+/// Decompose a struct value into one scalar call argument per field of \p
+/// recTy, appending the field values to \p newArgs.  When \p structVal is a
+/// plain (non-volatile, non-atomic) load straight from an alloca, read each
+/// field with cir.get_member + cir.load from that alloca, emitted at the
+/// original load's position so they observe the same memory state, and record
+/// the now-dead whole-struct load in \p replacedWholeLoads for later erasure.
+/// Otherwise (a call result, compound literal, or qualified load) extract each
+/// field from the value with cir.extract_member.  Loading the members from the
+/// alloca rather than extracting from a whole-struct value keeps the result in
+/// a form SROA can promote (it does not reason about extractvalue).  Shared by
+/// the Expand and Direct+canFlatten argument paths.
+static void
+emitStructFieldArgs(mlir::OpBuilder &builder, mlir::Location loc,
+                    mlir::Value structVal, cir::RecordType recTy,
+                    SmallVectorImpl<mlir::Value> &newArgs,
+                    SmallVectorImpl<cir::LoadOp> &replacedWholeLoads) {
+  cir::LoadOp wholeLoad = structVal.getDefiningOp<cir::LoadOp>();
+  cir::AllocaOp srcAlloca;
+  if (wholeLoad && !wholeLoad.getIsVolatile() && !wholeLoad.getMemOrder())
+    srcAlloca = wholeLoad.getAddr().getDefiningOp<cir::AllocaOp>();
+
+  if (srcAlloca) {
+    mlir::OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPoint(wholeLoad);
+    for (auto [f, fieldTy] : llvm::enumerate(recTy.getMembers())) {
+      mlir::Type fieldPtrTy = cir::PointerType::get(fieldTy);
+      mlir::Value fieldPtr = cir::GetMemberOp::create(
+          builder, loc, fieldPtrTy, srcAlloca, /*name=*/"", /*index=*/f);
+      newArgs.push_back(cir::LoadOp::create(builder, loc, fieldPtr));
+    }
+    replacedWholeLoads.push_back(wholeLoad);
+  } else {
+    for (unsigned f = 0; f < recTy.getNumElements(); ++f)
+      newArgs.push_back(
+          cir::ExtractMemberOp::create(builder, loc, structVal, f));
   }
 }
 
@@ -915,7 +953,7 @@ mlir::LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
           entry.eraseArgument(blockArgIdx);
           continue;
         }
-        if (auto flatTy = getFlattenedCoercedType(ac))
+        if (cir::RecordType flatTy = getFlattenedCoercedType(ac))
           blockArgIdx += flatTy.getNumElements();
         else if (ac.kind == ArgKind::Expand)
           blockArgIdx += cast<cir::RecordType>(oldArgTypes[i]).getNumElements();
@@ -1032,14 +1070,13 @@ CIRABIRewriteContext::rewriteCallSite(mlir::Operation *callOp,
     if (ac.kind == ArgKind::Ignore)
       continue;
     mlir::Value arg = argOperands[idx];
-    if (auto flatTy = getFlattenedCoercedType(ac)) {
+    if (cir::RecordType flatTy = getFlattenedCoercedType(ac)) {
       // Direct + canFlatten: pass one scalar call argument per field of the
       // ABI-coerced struct.  When the original and coerced types differ in
       // layout, coerce through a memory slot and read each field with
-      // cir.get_member + cir.load from that slot, rather than loading the
-      // whole coerced struct and extracting members from the value.  When the
-      // types are already identical there is no backing slot (arg is a plain
-      // struct value), so extract each field directly from the value.
+      // cir.get_member + cir.load from that slot.  When the types already
+      // match, decompose the struct value directly (reading from its source
+      // alloca when possible).
       if (arg.getType() != flatTy) {
         SmallPtrSet<mlir::Operation *, 4> coercionOps;
         mlir::Value coercedPtr =
@@ -1054,9 +1091,8 @@ CIRABIRewriteContext::rewriteCallSite(mlir::Operation *callOp,
                                                 fieldPtr.getResult()));
         }
       } else {
-        for (unsigned f = 0; f < flatTy.getNumElements(); ++f)
-          newArgs.push_back(
-              cir::ExtractMemberOp::create(builder, call.getLoc(), arg, f));
+        emitStructFieldArgs(builder, call.getLoc(), arg, flatTy, newArgs,
+                            replacedWholeLoads);
       }
     } else if (ac.kind == ArgKind::Expand) {
       // Decompose the struct value into its constituent scalar fields and
@@ -1064,36 +1100,8 @@ CIRABIRewriteContext::rewriteCallSite(mlir::Operation *callOp,
       auto recTy = cast<cir::RecordType>(arg.getType());
       assert(recTy.isStruct() &&
              "Expand classification requires a struct type, not a union");
-
-      // When the operand is a load straight from an alloca, read each member
-      // directly from that alloca (get_member + load) instead of loading the
-      // whole struct and extracting from it; this matches classic CodeGen.
-      // The member loads are emitted at the original load's position so they
-      // observe the same memory state.  When there is no source alloca (a
-      // call result, compound literal, etc.) cir.extract_member on the value
-      // is the only correct lowering.
-      auto wholeLoad = arg.getDefiningOp<cir::LoadOp>();
-      cir::AllocaOp srcAlloca;
-      if (wholeLoad)
-        srcAlloca = wholeLoad.getAddr().getDefiningOp<cir::AllocaOp>();
-
-      if (srcAlloca) {
-        mlir::OpBuilder::InsertionGuard guard(builder);
-        builder.setInsertionPoint(wholeLoad);
-        for (auto [f, fieldTy] : llvm::enumerate(recTy.getMembers())) {
-          mlir::Type fieldPtrTy = cir::PointerType::get(fieldTy);
-          mlir::Value fieldPtr = cir::GetMemberOp::create(
-              builder, call.getLoc(), fieldPtrTy, srcAlloca, /*name=*/"",
-              /*index=*/f);
-          newArgs.push_back(
-              cir::LoadOp::create(builder, call.getLoc(), fieldPtr));
-        }
-        replacedWholeLoads.push_back(wholeLoad);
-      } else {
-        for (unsigned f = 0; f < recTy.getNumElements(); ++f)
-          newArgs.push_back(
-              cir::ExtractMemberOp::create(builder, call.getLoc(), arg, f));
-      }
+      emitStructFieldArgs(builder, call.getLoc(), arg, recTy, newArgs,
+                          replacedWholeLoads);
     } else if (ac.kind == ArgKind::Direct && ac.coercedType &&
                arg.getType() != ac.coercedType) {
       arg = emitCoercion(builder, call.getLoc(), ac.coercedType, arg,

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRABIRewriteContext.cpp
@@ -31,6 +31,13 @@ using namespace mlir::abi;
 // call site, the struct operand is decomposed into its fields by reading
 // each member from the source alloca (get_member + load) when the operand is
 // a load of an alloca, or via cir.extract_member otherwise.
+//
+// For Direct + canFlatten (where the coerced type is a multi-field struct),
+// the coerced struct is similarly flattened into N individual wire arguments.
+// The callee reassembles the N scalar block args into the coerced struct,
+// then coerces to the original argument type if the two types differ.  The
+// call site coerces the original type to the coerced struct, then extracts
+// each field as a separate call argument.
 
 namespace {
 
@@ -45,6 +52,26 @@ bool needsRewrite(const FunctionClassification &fc) {
     if ((ac.kind != ArgKind::Direct) || ac.coercedType)
       return true;
   return false;
+}
+
+/// Return the coerced RecordType for a Direct classification that should be
+/// flattened into individual scalar arguments, or a null type if the
+/// classification does not call for flattening.
+///
+/// Flattening applies when all four conditions hold:
+///   1. The classification is Direct with a non-null coercedType.
+///   2. canFlatten is set.
+///   3. The coercedType is a struct (not a union).
+///   4. The struct has more than one field (single-field structs are already
+///      scalar; flattening them produces no benefit and classic CodeGen skips
+///      them for the same reason).
+cir::RecordType getFlattenedCoercedType(const ArgClassification &ac) {
+  if (ac.kind != ArgKind::Direct || !ac.coercedType || !ac.canFlatten)
+    return {};
+  auto recTy = dyn_cast<cir::RecordType>(ac.coercedType);
+  if (!recTy || !recTy.isStruct() || recTy.getNumElements() <= 1)
+    return {};
+  return recTy;
 }
 
 /// Build the new argument-type list for a function whose ABI classification
@@ -63,11 +90,19 @@ buildNewArgTypes(ArrayRef<mlir::Type> oldArgTypes,
     mlir::Type origTy = oldArgTypes[idx];
     switch (ac.kind) {
     case ArgKind::Direct:
-      // Direct with a coerced type means the wire signature uses the
-      // coerced type; the body still expects origTy and we'll insert a
-      // coercion at the entry block.  Direct without a coerced type is a
-      // true pass-through.
-      newArgTypes.push_back(ac.coercedType ? ac.coercedType : origTy);
+      // Direct with canFlatten and a struct coerced type: push one wire type
+      // per field of the coerced struct rather than the struct itself.
+      // Single-field coerced structs fall through to the non-flatten path —
+      // the struct is already scalar-sized and flattening adds no value.
+      if (cir::RecordType flatTy = getFlattenedCoercedType(ac)) {
+        llvm::append_range(newArgTypes, flatTy.getMembers());
+      } else {
+        // Direct with a coerced type: the wire signature uses the coerced
+        // type; the body still expects origTy and insertArgCoercion recovers
+        // it via a memory round-trip.  Direct without coercion is a
+        // pass-through.
+        newArgTypes.push_back(ac.coercedType ? ac.coercedType : origTy);
+      }
       break;
     case ArgKind::Ignore:
       break;
@@ -167,7 +202,12 @@ mlir::ArrayAttr updateArgAttrs(mlir::MLIRContext *ctx,
     mlir::DictionaryAttr existing = builder.getDictionaryAttr({});
     if (existingArgAttrs && oldIdx < existingArgAttrs.size())
       existing = mlir::cast<mlir::DictionaryAttr>(existingArgAttrs[oldIdx]);
-    if (ac.kind == ArgKind::Expand) {
+    if (auto flatTy = getFlattenedCoercedType(ac)) {
+      // Direct + canFlatten: one empty attribute dict per flattened field; the
+      // flattened scalar arguments carry no special ABI attributes.
+      newArgAttrs.append(flatTy.getNumElements(),
+                         builder.getDictionaryAttr({}));
+    } else if (ac.kind == ArgKind::Expand) {
       // Push one empty attribute dict per expanded field; the flattened
       // scalar arguments carry no special ABI attributes.
       auto recTy = cast<cir::RecordType>(origArgTypes[oldIdx]);
@@ -235,18 +275,22 @@ mlir::ArrayAttr updateResAttrs(mlir::MLIRContext *ctx,
   return mlir::ArrayAttr::get(ctx, {mlir::DictionaryAttr::get(ctx, attrs)});
 }
 
-/// Coerce \p src to type \p dstTy at the current builder insertion point by
-/// going through memory: allocate a slot, store the source, then load the
-/// destination type back out.  Lowers uniformly for scalar, vector, and
-/// record types.
+/// Coerce \p src into a temporary memory slot typed for \p dstTy at the
+/// current builder insertion point, and return the destination-typed pointer
+/// to that slot without loading the value back out.  This is the shared
+/// memory half of emitCoercion: callers that want the whole coerced value use
+/// emitCoercion (below); callers that want to read individual members of a
+/// coerced struct (the call-site struct flattening) take the returned pointer
+/// and emit their own cir.get_member + cir.load per field.  Lowers uniformly
+/// for scalar, vector, and record types.
 ///
-/// The slot is sized to the larger of the two types so that neither the
-/// store nor the load ever runs past it: the coerced ABI type can be larger
-/// than the original (e.g. a 12-byte aggregate returned as `{i64, i64}`), so
-/// loading the destination out of a source-sized slot would over-read.
+/// The slot is sized to the larger of the two types so that neither the store
+/// nor a later load ever runs past it: the coerced ABI type can be larger
+/// than the original (e.g. a 12-byte aggregate passed as `{i64, i64}`), so
+/// accessing the destination through a source-sized slot would over-read.
 /// Alignment is max(srcAlign, dstAlign) to satisfy both accesses.  The slot
-/// is accessed through a source-typed view for the store and a
-/// destination-typed view for the load.
+/// is written through a source-typed view and returned as a destination-typed
+/// view.
 ///
 /// The temporary alloca is placed at the start of the enclosing function's
 /// entry block so that it composes correctly with the HoistAllocas pass
@@ -255,11 +299,12 @@ mlir::ArrayAttr updateResAttrs(mlir::MLIRContext *ctx,
 /// Any operations the helper creates are appended to \p createdOps so the
 /// caller can pass them to replaceAllUsesExcept and avoid clobbering the
 /// store's value operand when later rewiring the source value.
-mlir::Value emitCoercion(mlir::OpBuilder &builder, mlir::Location loc,
-                         mlir::Type dstTy, mlir::Value src,
-                         mlir::FunctionOpInterface funcOp,
-                         const mlir::DataLayout &dl,
-                         SmallPtrSetImpl<mlir::Operation *> &createdOps) {
+mlir::Value
+emitCoercionToMemory(mlir::OpBuilder &builder, mlir::Location loc,
+                     mlir::Type dstTy, mlir::Value src,
+                     mlir::FunctionOpInterface funcOp,
+                     const mlir::DataLayout &dl,
+                     SmallPtrSetImpl<mlir::Operation *> &createdOps) {
   mlir::Type srcTy = src.getType();
   assert(srcTy != dstTy &&
          "emitCoercion callers must pre-check that the types differ");
@@ -296,14 +341,26 @@ mlir::Value emitCoercion(mlir::OpBuilder &builder, mlir::Location loc,
   auto store = cir::StoreOp::create(builder, loc, src, srcSlot);
   createdOps.insert(store);
 
-  // Load through a destination-typed view of the slot.
-  mlir::Value dstSlot = alloca;
+  // Return a destination-typed view of the slot.
   if (slotTy != dstTy) {
     auto dstCast = cir::CastOp::create(builder, loc, dstPtrTy,
                                        cir::CastKind::bitcast, alloca);
     createdOps.insert(dstCast);
-    dstSlot = dstCast;
+    return dstCast;
   }
+  return alloca;
+}
+
+/// Coerce \p src to type \p dstTy by going through memory and load the whole
+/// coerced value back out.  Builds on emitCoercionToMemory, adding the final
+/// load of the destination-typed view.
+mlir::Value emitCoercion(mlir::OpBuilder &builder, mlir::Location loc,
+                         mlir::Type dstTy, mlir::Value src,
+                         mlir::FunctionOpInterface funcOp,
+                         const mlir::DataLayout &dl,
+                         SmallPtrSetImpl<mlir::Operation *> &createdOps) {
+  mlir::Value dstSlot =
+      emitCoercionToMemory(builder, loc, dstTy, src, funcOp, dl, createdOps);
   auto load = cir::LoadOp::create(builder, loc, dstSlot);
   createdOps.insert(load);
   return load;
@@ -446,6 +503,63 @@ void insertArgCoercion(mlir::FunctionOpInterface funcOp,
     }
 
     mlir::BlockArgument blockArg = entry.getArgument(blockArgIdx);
+
+    if (cir::RecordType flatTy = getFlattenedCoercedType(ac)) {
+      // Direct + canFlatten: the coerced type is a struct whose fields become
+      // individual wire arguments.  The reconstruction mirrors the Expand path
+      // — replace the single block arg with N scalar block args, store them
+      // into an alloca of the coerced struct type, reload — but then applies
+      // an additional coercion from the coerced struct type to the original
+      // argument type if the two differ in layout.
+      unsigned numFields = flatTy.getNumElements();
+      assert(numFields >= 2 && "getFlattenedCoercedType guarantees >1 fields");
+      Type origTy = blockArg.getType();
+      Location loc = funcOp.getLoc();
+
+      // Change slot 0 to field 0's type; insert slots 1..N-1 after it.
+      blockArg.setType(flatTy.getElementType(0));
+      for (unsigned f = 1; f < numFields; ++f)
+        entry.insertArgument(blockArgIdx + f, flatTy.getElementType(f), loc);
+
+      // setInsertionPointToStart: see comment in the Expand arm above.
+      builder.setInsertionPointToStart(&entry);
+      auto flatPtrTy = cir::PointerType::get(flatTy);
+      uint64_t flatAlign = dl.getTypeABIAlignment(flatTy);
+      auto flatSlot = cir::AllocaOp::create(
+          builder, loc, flatPtrTy, builder.getStringAttr("coerce"),
+          builder.getI64IntegerAttr(flatAlign));
+      SmallPtrSet<Operation *, 8> flattenOps = {flatSlot};
+      for (auto [f, fieldTy] : llvm::enumerate(flatTy.getMembers())) {
+        Type fieldPtrTy = cir::PointerType::get(fieldTy);
+        auto fieldPtr = cir::GetMemberOp::create(builder, loc, fieldPtrTy,
+                                                 flatSlot, /*name=*/"",
+                                                 /*index=*/f);
+        flattenOps.insert(fieldPtr);
+        auto storeOp = cir::StoreOp::create(
+            builder, loc, entry.getArgument(blockArgIdx + f), fieldPtr);
+        flattenOps.insert(storeOp);
+      }
+      auto flatLoaded =
+          cir::LoadOp::create(builder, loc, flatTy, flatSlot.getResult());
+      flattenOps.insert(flatLoaded);
+
+      // If the coerced struct type differs from the original argument type,
+      // insert a memory round-trip to recover the original type for body uses.
+      Value finalVal = flatLoaded;
+      if (origTy != flatTy) {
+        SmallPtrSet<Operation *, 4> coercionOps;
+        finalVal = emitCoercion(builder, loc, origTy, flatLoaded, funcOp, dl,
+                                coercionOps);
+        flattenOps.insert(coercionOps.begin(), coercionOps.end());
+      }
+
+      // Replace all original body uses of the struct block arg (now field 0)
+      // with the recovered original-type value.
+      blockArg.replaceAllUsesExcept(finalVal, flattenOps);
+
+      blockArgIdx += numFields;
+      continue;
+    }
 
     if (ac.kind == ArgKind::Direct && ac.coercedType) {
       mlir::Type oldArgTy = blockArg.getType();
@@ -666,13 +780,15 @@ void rewriteIndirectReturnCall(cir::CallOp call,
 
   // Shape the per-argument attrs exactly as the non-sret path does
   // (signext / zeroext for Extend, drop Ignore slots, byval / align for
-  // Indirect, flatten for Expand) before prepending the sret slot, so sret
-  // composes correctly with Extend / Ignore / Indirect / Expand args.
+  // Indirect, flatten for Expand and Direct+canFlatten) before prepending the
+  // sret slot, so sret composes correctly with Extend / Ignore / Indirect /
+  // Expand / Direct+canFlatten args.
   mlir::ArrayAttr argAttrs = call->getAttrOfType<mlir::ArrayAttr>("arg_attrs");
   bool needsArgAttrUpdate =
       llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
         return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend ||
-               ac.kind == ArgKind::Indirect || ac.kind == ArgKind::Expand;
+               ac.kind == ArgKind::Indirect || ac.kind == ArgKind::Expand ||
+               getFlattenedCoercedType(ac);
       });
   if (needsArgAttrUpdate)
     argAttrs = updateArgAttrs(ctx, origCallArgTypes, argAttrs, fc);
@@ -781,9 +897,9 @@ mlir::LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
       // body uses with a poison constant (an Ignore arg is not passed at the
       // ABI level, so any use is vacuous; poison says exactly that).  Walk
       // forward with a running block-argument index that mirrors
-      // insertArgCoercion: an Expand arg occupies N slots, every other kept
-      // kind one.  On erase, do not advance the index -- the next block
-      // argument shifts into the vacated slot.
+      // insertArgCoercion: an Expand arg or a Direct+canFlatten arg occupies N
+      // slots, every other kept kind one.  On erase, do not advance the index
+      // -- the next block argument shifts into the vacated slot.
       unsigned blockArgIdx = hasSRet ? 1 : 0;
       for (auto [i, ac] : llvm::enumerate(fc.argInfos)) {
         if (blockArgIdx >= entry.getNumArguments())
@@ -799,7 +915,9 @@ mlir::LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
           entry.eraseArgument(blockArgIdx);
           continue;
         }
-        if (ac.kind == ArgKind::Expand)
+        if (auto flatTy = getFlattenedCoercedType(ac))
+          blockArgIdx += flatTy.getNumElements();
+        else if (ac.kind == ArgKind::Expand)
           blockArgIdx += cast<cir::RecordType>(oldArgTypes[i]).getNumElements();
         else
           ++blockArgIdx;
@@ -833,11 +951,13 @@ mlir::LogicalResult CIRABIRewriteContext::rewriteFunctionDefinition(
   // Rebuild arg_attrs when the function has an sret slot (slot 0 needs the
   // sret attribute set) or any arg is Ignore (dropped from the output array),
   // Extend (needs llvm.signext / llvm.zeroext), Indirect (needs
-  // llvm.byval / llvm.align), or Expand (changes the argument count).
+  // llvm.byval / llvm.align), Expand or Direct+canFlatten (both change the
+  // argument count).
   bool needsArgAttrUpdate =
       hasSRet || llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
         return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend ||
-               ac.kind == ArgKind::Indirect || ac.kind == ArgKind::Expand;
+               ac.kind == ArgKind::Indirect || ac.kind == ArgKind::Expand ||
+               getFlattenedCoercedType(ac);
       });
   if (needsArgAttrUpdate) {
     auto existing = funcOp->getAttrOfType<mlir::ArrayAttr>("arg_attrs");
@@ -912,7 +1032,33 @@ CIRABIRewriteContext::rewriteCallSite(mlir::Operation *callOp,
     if (ac.kind == ArgKind::Ignore)
       continue;
     mlir::Value arg = argOperands[idx];
-    if (ac.kind == ArgKind::Expand) {
+    if (auto flatTy = getFlattenedCoercedType(ac)) {
+      // Direct + canFlatten: pass one scalar call argument per field of the
+      // ABI-coerced struct.  When the original and coerced types differ in
+      // layout, coerce through a memory slot and read each field with
+      // cir.get_member + cir.load from that slot, rather than loading the
+      // whole coerced struct and extracting members from the value.  When the
+      // types are already identical there is no backing slot (arg is a plain
+      // struct value), so extract each field directly from the value.
+      if (arg.getType() != flatTy) {
+        SmallPtrSet<mlir::Operation *, 4> coercionOps;
+        mlir::Value coercedPtr =
+            emitCoercionToMemory(builder, call.getLoc(), flatTy, arg,
+                                 enclosingFunc, dl, coercionOps);
+        for (auto [f, fieldTy] : llvm::enumerate(flatTy.getMembers())) {
+          mlir::Type fieldPtrTy = cir::PointerType::get(fieldTy);
+          auto fieldPtr =
+              cir::GetMemberOp::create(builder, call.getLoc(), fieldPtrTy,
+                                       coercedPtr, /*name=*/"", /*index=*/f);
+          newArgs.push_back(cir::LoadOp::create(builder, call.getLoc(), fieldTy,
+                                                fieldPtr.getResult()));
+        }
+      } else {
+        for (unsigned f = 0; f < flatTy.getNumElements(); ++f)
+          newArgs.push_back(
+              cir::ExtractMemberOp::create(builder, call.getLoc(), arg, f));
+      }
+    } else if (ac.kind == ArgKind::Expand) {
       // Decompose the struct value into its constituent scalar fields and
       // pass each as a separate argument.
       auto recTy = cast<cir::RecordType>(arg.getType());
@@ -1017,11 +1163,12 @@ CIRABIRewriteContext::rewriteCallSite(mlir::Operation *callOp,
   // Layer llvm.signext / llvm.zeroext onto the new call's arg_attrs and
   // res_attrs for Extend args/return.  Ignore args require a rebuild because
   // their slots are dropped; Indirect args need llvm.byval / llvm.align;
-  // Expand args change the argument count.
+  // Expand and Direct+canFlatten args change the argument count.
   bool needsArgAttrUpdate =
       llvm::any_of(fc.argInfos, [](const ArgClassification &ac) {
         return ac.kind == ArgKind::Ignore || ac.kind == ArgKind::Extend ||
-               ac.kind == ArgKind::Indirect || ac.kind == ArgKind::Expand;
+               ac.kind == ArgKind::Indirect || ac.kind == ArgKind::Expand ||
+               getFlattenedCoercedType(ac);
       });
   if (needsArgAttrUpdate) {
     auto existing = call->getAttrOfType<mlir::ArrayAttr>("arg_attrs");

--- a/clang/test/CIR/Transforms/abi-lowering/coerce-record-to-record-via-memory.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/coerce-record-to-record-via-memory.cir
@@ -8,7 +8,7 @@
 
 #coerce_vec4_to_twoi64 = {
   return = { kind = "direct" },
-  args   = [ { kind = "direct", coerced_type = !rec_TwoI64 } ]
+  args   = [ { kind = "direct", coerced_type = !rec_TwoI64, can_flatten = false } ]
 }
 
 #caller_no_args = {

--- a/clang/test/CIR/Transforms/abi-lowering/direct-flatten.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/direct-flatten.cir
@@ -46,8 +46,8 @@
 }
 
 // Arg whose original type already equals its coerced struct type: the
-// callee skips the back-coercion and the call site extracts fields straight
-// from the value (no coerce-slot round-trip).
+// callee skips the back-coercion and the call site reads each field from the
+// operand (from its source alloca when available, else by extraction).
 #flatten_self = {
   return = { kind = "direct" },
   args   = [ { kind = "direct", coerced_type = !rec_coerced_two,
@@ -219,7 +219,8 @@ cir.func @flatten_ignore_flatten_callee(
 
 // Arg type already equals the coerced struct type (origTy == flatTy): the
 // callee reassembles the fields but skips the back-coercion, and the call site
-// extracts each field directly from the value with no coerce-slot round-trip.
+// reads each field from the operand's source alloca (get_member + load) with
+// no coerce-slot round-trip.
 
 cir.func @takes_self_flat(%arg0: !rec_coerced_two)
     attributes { test_classify = #flatten_self } {
@@ -249,11 +250,30 @@ cir.func @caller_self_flat() attributes { test_classify = #passthrough } {
 }
 
 // CHECK:      cir.func{{.*}} @caller_self_flat()
-// Types already match, so each field is extracted directly from the loaded
-// value with cir.extract_member -- no coerce slot, no get_member + load.
-// CHECK:        %[[VAL:.*]] = cir.load %{{.*}} : !cir.ptr<!rec_anon_struct>, !rec_anon_struct
-// CHECK:        %[[F0:.*]] = cir.extract_member %[[VAL]][0] : !rec_anon_struct -> !s64i
-// CHECK:        %[[F1:.*]] = cir.extract_member %[[VAL]][1] : !rec_anon_struct -> !s64i
+// CHECK:        %[[A:.*]] = cir.alloca "s"
+// The operand already has the coerced layout and comes from an alloca, so each
+// field is read with get_member + load straight from that alloca; the
+// whole-struct load is erased and there is no coerce-slot round-trip.
+// CHECK-NOT:    cir.alloca "coerce"
+// CHECK:        %[[P0:.*]] = cir.get_member %[[A]][0] {{.*}} -> !cir.ptr<!s64i>
+// CHECK:        %[[F0:.*]] = cir.load %[[P0]] : !cir.ptr<!s64i>, !s64i
+// CHECK:        %[[P1:.*]] = cir.get_member %[[A]][1] {{.*}} -> !cir.ptr<!s64i>
+// CHECK:        %[[F1:.*]] = cir.load %[[P1]] : !cir.ptr<!s64i>, !s64i
 // CHECK:        cir.call @takes_self_flat(%[[F0]], %[[F1]]) : (!s64i, !s64i) -> ()
+
+// Same origTy == flatTy case, but the operand is a struct value with no source
+// alloca (a constant): each field is extracted from the value directly.
+
+cir.func @caller_self_flat_const() attributes { test_classify = #passthrough } {
+  %v = cir.const #cir.zero : !rec_coerced_two
+  cir.call @takes_self_flat(%v) : (!rec_coerced_two) -> ()
+  cir.return
+}
+
+// CHECK:      cir.func{{.*}} @caller_self_flat_const()
+// CHECK:        %[[V:.*]] = cir.const #cir.zero : !rec_anon_struct
+// CHECK:        %[[G0:.*]] = cir.extract_member %[[V]][0] : !rec_anon_struct -> !s64i
+// CHECK:        %[[G1:.*]] = cir.extract_member %[[V]][1] : !rec_anon_struct -> !s64i
+// CHECK:        cir.call @takes_self_flat(%[[G0]], %[[G1]]) : (!s64i, !s64i) -> ()
 
 }

--- a/clang/test/CIR/Transforms/abi-lowering/direct-flatten.cir
+++ b/clang/test/CIR/Transforms/abi-lowering/direct-flatten.cir
@@ -1,0 +1,259 @@
+// RUN: cir-opt %s -cir-call-conv-lowering="classification-attr=test_classify" \
+// RUN:   | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+
+// Named source structs.
+!rec_TwoLong  = !cir.struct<"TwoLong"  {!s64i, !s64i}>
+!rec_ThreeInt = !cir.struct<"ThreeInt" {!s32i, !s32i, !s32i}>
+// dim3-equivalent: three i32 fields totalling 12 bytes.
+!rec_Dim3     = !cir.struct<"Dim3"     {!s32i, !s32i, !s32i}>
+
+// ABI-coerced anonymous structs.  MLIR auto-generates their aliases
+// (!rec_anon_struct, !rec_anon_struct1, etc.) in encounter order.
+!rec_coerced_two   = !cir.struct<{!s64i, !s64i}>
+!rec_coerced_three = !cir.struct<{!s32i, !s32i, !s32i}>
+// x86-64 SysV packs dim3's first two i32s into an i64; the third i32
+// is a separate half of the second eightbyte.
+!rec_coerced_dim3  = !cir.struct<{!s64i, !s32i}>
+
+#flatten_two = {
+  return = { kind = "direct" },
+  args   = [ { kind = "direct", coerced_type = !rec_coerced_two,
+               can_flatten = true } ]
+}
+
+#flatten_three = {
+  return = { kind = "direct" },
+  args   = [ { kind = "direct", coerced_type = !rec_coerced_three,
+               can_flatten = true } ]
+}
+
+#flatten_dim3 = {
+  return = { kind = "direct" },
+  args   = [ { kind = "direct", coerced_type = !rec_coerced_dim3,
+               can_flatten = true } ]
+}
+
+#flatten_ignore_flatten = {
+  return = { kind = "direct" },
+  args   = [ { kind = "direct", coerced_type = !rec_coerced_two,
+               can_flatten = true },
+             { kind = "ignore" },
+             { kind = "direct", coerced_type = !rec_coerced_two,
+               can_flatten = true } ]
+}
+
+// Arg whose original type already equals its coerced struct type: the
+// callee skips the back-coercion and the call site extracts fields straight
+// from the value (no coerce-slot round-trip).
+#flatten_self = {
+  return = { kind = "direct" },
+  args   = [ { kind = "direct", coerced_type = !rec_coerced_two,
+               can_flatten = true } ]
+}
+
+#passthrough = {
+  return = { kind = "direct" },
+  args   = [ ]
+}
+
+module attributes {
+  dlti.dl_spec = #dlti.dl_spec<
+    #dlti.dl_entry<i32, dense<32>: vector<2xi64>>,
+    #dlti.dl_entry<i64, dense<64>: vector<2xi64>>>
+} {
+
+// Callee: the single TwoLong arg is replaced by two i64 block args.  At entry
+// the scalars are stored into a coerced-struct alloca, then coerced back to
+// TwoLong for body uses.
+
+cir.func @takes_two_long(%arg0: !rec_TwoLong)
+    attributes { test_classify = #flatten_two } {
+  %0 = cir.alloca "p" align(8) : !cir.ptr<!rec_TwoLong>
+  cir.store %arg0, %0 : !rec_TwoLong, !cir.ptr<!rec_TwoLong>
+  cir.return
+}
+
+// CHECK:      cir.func{{.*}} @takes_two_long(%[[F0:.*]]: !s64i, %[[F1:.*]]: !s64i)
+// Two ["coerce"] allocas: the coercion round-trip alloca and the flatSlot.
+// CHECK:        %{{.*}} = cir.alloca "coerce"
+// CHECK:        %[[FSLOT:.*]] = cir.alloca "coerce"
+// Store each field block arg into the flat slot.
+// CHECK:        %[[P0:.*]] = cir.get_member %[[FSLOT]][0]
+// CHECK:        cir.store %[[F0]], %[[P0]] : !s64i, !cir.ptr<!s64i>
+// CHECK:        %[[P1:.*]] = cir.get_member %[[FSLOT]][1]
+// CHECK:        cir.store %[[F1]], %[[P1]] : !s64i, !cir.ptr<!s64i>
+// Reload the coerced struct, coerce to TwoLong, use in body.
+// CHECK:        %{{.*}} = cir.load %[[FSLOT]]
+// CHECK:        cir.cast bitcast %{{.*}} : !cir.ptr<{{.*}}> -> !cir.ptr<!rec_TwoLong>
+// CHECK:        %[[TVAL:.*]] = cir.load %{{.*}} : !cir.ptr<!rec_TwoLong>, !rec_TwoLong
+// CHECK:        %[[P:.*]] = cir.alloca "p" {{.*}} : !cir.ptr<!rec_TwoLong>
+// CHECK:        cir.store %[[TVAL]], %[[P]] : !rec_TwoLong, !cir.ptr<!rec_TwoLong>
+
+// Forward declaration: two i64 wire args, no body.
+
+cir.func private @takes_two_long_decl(!rec_TwoLong)
+    attributes { test_classify = #flatten_two }
+
+// CHECK:      cir.func{{.*}} @takes_two_long_decl(!s64i, !s64i)
+// CHECK-NOT:  !rec_TwoLong
+
+// Caller: the TwoLong operand is coerced into a coerced-struct slot via a
+// memory round-trip, then each field is read from that slot with
+// get_member + load and passed as a separate call argument.
+
+cir.func @caller_two_long() attributes { test_classify = #passthrough } {
+  %0 = cir.alloca "s" align(8) : !cir.ptr<!rec_TwoLong>
+  %1 = cir.load %0 : !cir.ptr<!rec_TwoLong>, !rec_TwoLong
+  cir.call @takes_two_long(%1) : (!rec_TwoLong) -> ()
+  cir.return
+}
+
+// CHECK:      cir.func{{.*}} @caller_two_long()
+// CHECK:        %[[COERCE:.*]] = cir.alloca "coerce"
+// CHECK:        %[[VAL:.*]] = cir.load %{{.*}} : !cir.ptr<!rec_TwoLong>, !rec_TwoLong
+// Store the source value into the coerce slot, then read each field through a
+// coerced-struct view with get_member + load.
+// CHECK:        cir.store %[[VAL]], %[[COERCE]] : !rec_TwoLong, !cir.ptr<!rec_TwoLong>
+// CHECK:        %[[CAST:.*]] = cir.cast bitcast %[[COERCE]] : !cir.ptr<!rec_TwoLong> -> !cir.ptr<{{.*}}>
+// CHECK:        %[[P0:.*]] = cir.get_member %[[CAST]][0] {{.*}} -> !cir.ptr<!s64i>
+// CHECK:        %[[F0:.*]] = cir.load %[[P0]] : !cir.ptr<!s64i>, !s64i
+// CHECK:        %[[P1:.*]] = cir.get_member %[[CAST]][1] {{.*}} -> !cir.ptr<!s64i>
+// CHECK:        %[[F1:.*]] = cir.load %[[P1]] : !cir.ptr<!s64i>, !s64i
+// CHECK:        cir.call @takes_two_long(%[[F0]], %[[F1]]) : (!s64i, !s64i) -> ()
+
+// Three-field flatten (CUDA dim3 with 3 equal-width fields → 3 scalar args).
+// Covers the numFields == 3 path in insertArgCoercion.
+
+cir.func @takes_three_int(%arg0: !rec_ThreeInt)
+    attributes { test_classify = #flatten_three } {
+  cir.return
+}
+
+// CHECK:      cir.func{{.*}} @takes_three_int(%[[A:.*]]: !s32i, %[[B:.*]]: !s32i, %[[C:.*]]: !s32i)
+// Two ["coerce"] allocas appear; the fields are stored via the second one.
+// CHECK:        cir.alloca "coerce"
+// CHECK:        cir.alloca "coerce"
+// CHECK:        %[[PA:.*]] = cir.get_member %{{.*}}[0]
+// CHECK:        cir.store %[[A]], %[[PA]] : !s32i, !cir.ptr<!s32i>
+// CHECK:        %[[PB:.*]] = cir.get_member %{{.*}}[1]
+// CHECK:        cir.store %[[B]], %[[PB]] : !s32i, !cir.ptr<!s32i>
+// CHECK:        %[[PC:.*]] = cir.get_member %{{.*}}[2]
+// CHECK:        cir.store %[[C]], %[[PC]] : !s32i, !cir.ptr<!s32i>
+
+cir.func @caller_three_int() attributes { test_classify = #passthrough } {
+  %0 = cir.alloca "s" align(4) : !cir.ptr<!rec_ThreeInt>
+  %1 = cir.load %0 : !cir.ptr<!rec_ThreeInt>, !rec_ThreeInt
+  cir.call @takes_three_int(%1) : (!rec_ThreeInt) -> ()
+  cir.return
+}
+
+// CHECK:      cir.func{{.*}} @caller_three_int()
+// CHECK:        %[[COERCE:.*]] = cir.alloca "coerce"
+// CHECK:        %[[VAL:.*]] = cir.load %{{.*}} : !cir.ptr<!rec_ThreeInt>, !rec_ThreeInt
+// CHECK:        cir.store %[[VAL]], %[[COERCE]] : !rec_ThreeInt, !cir.ptr<!rec_ThreeInt>
+// CHECK:        %[[CAST:.*]] = cir.cast bitcast %[[COERCE]] : !cir.ptr<!rec_ThreeInt> -> !cir.ptr<{{.*}}>
+// CHECK:        %[[P0:.*]] = cir.get_member %[[CAST]][0] {{.*}} -> !cir.ptr<!s32i>
+// CHECK:        %[[F0:.*]] = cir.load %[[P0]] : !cir.ptr<!s32i>, !s32i
+// CHECK:        %[[P1:.*]] = cir.get_member %[[CAST]][1] {{.*}} -> !cir.ptr<!s32i>
+// CHECK:        %[[F1:.*]] = cir.load %[[P1]] : !cir.ptr<!s32i>, !s32i
+// CHECK:        %[[P2:.*]] = cir.get_member %[[CAST]][2] {{.*}} -> !cir.ptr<!s32i>
+// CHECK:        %[[F2:.*]] = cir.load %[[P2]] : !cir.ptr<!s32i>, !s32i
+// CHECK:        cir.call @takes_three_int(%[[F0]], %[[F1]], %[[F2]]) : (!s32i, !s32i, !s32i) -> ()
+
+// Mixed-packing case (x86-64 SysV dim3 pattern): struct { uint x, y, z; }
+// is coerced to {i64, i32} — the first two i32s are packed into an i64,
+// producing 2 wire arguments from a 3-field source struct.
+
+cir.func @takes_dim3(%arg0: !rec_Dim3)
+    attributes { test_classify = #flatten_dim3 } {
+  cir.return
+}
+
+// CHECK:      cir.func{{.*}} @takes_dim3(%[[D0:.*]]: !s64i, %[[D1:.*]]: !s32i)
+// Two ["coerce"] allocas appear; the {i64, i32} fields are stored into the second.
+// CHECK:        cir.alloca "coerce"
+// CHECK:        cir.alloca "coerce"
+// CHECK:        %{{.*}} = cir.get_member %{{.*}}[0]
+// CHECK:        cir.store %[[D0]], %{{.*}} : !s64i
+// CHECK:        %{{.*}} = cir.get_member %{{.*}}[1]
+// CHECK:        cir.store %[[D1]], %{{.*}} : !s32i
+
+cir.func @caller_dim3() attributes { test_classify = #passthrough } {
+  %0 = cir.alloca "d" align(4) : !cir.ptr<!rec_Dim3>
+  %1 = cir.load %0 : !cir.ptr<!rec_Dim3>, !rec_Dim3
+  cir.call @takes_dim3(%1) : (!rec_Dim3) -> ()
+  cir.return
+}
+
+// CHECK:      cir.func{{.*}} @caller_dim3()
+// Coerce Dim3 into the {i64, i32} slot, then read the two fields from the
+// slot with get_member + load.  The coerced struct is larger than Dim3, so
+// the slot is the coerced type and the bitcast is on the store (source) side.
+// CHECK:        %[[COERCE:.*]] = cir.alloca "coerce"
+// CHECK:        %[[VAL:.*]] = cir.load %{{.*}} : !cir.ptr<!rec_Dim3>, !rec_Dim3
+// CHECK:        %[[CAST:.*]] = cir.cast bitcast %[[COERCE]] : {{.*}} -> !cir.ptr<!rec_Dim3>
+// CHECK:        cir.store %[[VAL]], %[[CAST]] : !rec_Dim3, !cir.ptr<!rec_Dim3>
+// CHECK:        %[[P0:.*]] = cir.get_member %[[COERCE]][0] {{.*}} -> !cir.ptr<!s64i>
+// CHECK:        %[[E0:.*]] = cir.load %[[P0]] : !cir.ptr<!s64i>, !s64i
+// CHECK:        %[[P1:.*]] = cir.get_member %[[COERCE]][1] {{.*}} -> !cir.ptr<!s32i>
+// CHECK:        %[[E1:.*]] = cir.load %[[P1]] : !cir.ptr<!s32i>, !s32i
+// CHECK:        cir.call @takes_dim3(%[[E0]], %[[E1]]) : (!s64i, !s32i) -> ()
+
+// Two flatten args with an Ignore in between: exercises the Ignore-drop loop's
+// running block-argument index when canFlatten args occupy multiple slots.
+
+cir.func @flatten_ignore_flatten_callee(
+    %a: !rec_TwoLong, %b: !rec_TwoLong, %c: !rec_TwoLong)
+    attributes { test_classify = #flatten_ignore_flatten } {
+  cir.return
+}
+
+// CHECK:      cir.func{{.*}} @flatten_ignore_flatten_callee(
+// CHECK-SAME:     %{{.*}}: !s64i, %{{.*}}: !s64i, %{{.*}}: !s64i, %{{.*}}: !s64i)
+// The middle ignored arg is dropped; two flatten slots produce four block args.
+// CHECK-DAG:    cir.alloca "coerce"
+// CHECK-DAG:    cir.alloca "coerce"
+
+// Arg type already equals the coerced struct type (origTy == flatTy): the
+// callee reassembles the fields but skips the back-coercion, and the call site
+// extracts each field directly from the value with no coerce-slot round-trip.
+
+cir.func @takes_self_flat(%arg0: !rec_coerced_two)
+    attributes { test_classify = #flatten_self } {
+  %0 = cir.alloca "p" align(8) : !cir.ptr<!rec_coerced_two>
+  cir.store %arg0, %0 : !rec_coerced_two, !cir.ptr<!rec_coerced_two>
+  cir.return
+}
+
+// CHECK:      cir.func{{.*}} @takes_self_flat(%[[A:.*]]: !s64i, %[[B:.*]]: !s64i)
+// Only one "coerce" reassembly slot, and the reloaded coerced struct is stored
+// straight into the parameter alloca with no bitcast -- the arg type already
+// equals the coerced struct type, so there is no back-coercion.
+// CHECK:        %[[SLOT:.*]] = cir.alloca "coerce"
+// CHECK:        %[[P0:.*]] = cir.get_member %[[SLOT]][0]
+// CHECK:        cir.store %[[A]], %[[P0]] : !s64i, !cir.ptr<!s64i>
+// CHECK:        %[[P1:.*]] = cir.get_member %[[SLOT]][1]
+// CHECK:        cir.store %[[B]], %[[P1]] : !s64i, !cir.ptr<!s64i>
+// CHECK:        %[[RV:.*]] = cir.load %[[SLOT]] : !cir.ptr<!rec_anon_struct>, !rec_anon_struct
+// CHECK:        %[[P:.*]] = cir.alloca "p"
+// CHECK:        cir.store %[[RV]], %[[P]] : !rec_anon_struct, !cir.ptr<!rec_anon_struct>
+
+cir.func @caller_self_flat() attributes { test_classify = #passthrough } {
+  %0 = cir.alloca "s" align(8) : !cir.ptr<!rec_coerced_two>
+  %1 = cir.load %0 : !cir.ptr<!rec_coerced_two>, !rec_coerced_two
+  cir.call @takes_self_flat(%1) : (!rec_coerced_two) -> ()
+  cir.return
+}
+
+// CHECK:      cir.func{{.*}} @caller_self_flat()
+// Types already match, so each field is extracted directly from the loaded
+// value with cir.extract_member -- no coerce slot, no get_member + load.
+// CHECK:        %[[VAL:.*]] = cir.load %{{.*}} : !cir.ptr<!rec_anon_struct>, !rec_anon_struct
+// CHECK:        %[[F0:.*]] = cir.extract_member %[[VAL]][0] : !rec_anon_struct -> !s64i
+// CHECK:        %[[F1:.*]] = cir.extract_member %[[VAL]][1] : !rec_anon_struct -> !s64i
+// CHECK:        cir.call @takes_self_flat(%[[F0]], %[[F1]]) : (!s64i, !s64i) -> ()
+
+}


### PR DESCRIPTION
CallConvLowering previously ignored the `canFlatten` flag on Direct classifications: a Direct arg with a multi-field struct coerced type was passed as a single struct argument rather than N scalar register arguments.  This is the register-passing pattern the x86-64 SysV ABI uses for structs like `struct { long a, b; }`.

A new helper `getFlattenedCoercedType` centralizes the detection (Direct classification, multi-field coerced struct, `canFlatten` set); the three lowering sites in `CIRABIRewriteContext.cpp` follow.

Depends on [#201718](https://github.com/llvm/llvm-project/pull/201718).
