### PR TITLE
[clang-cl] Fix friend class warning on Windows

### DIFF
--- a/llvm/include/llvm/SandboxIR/Use.h
+++ b/llvm/include/llvm/SandboxIR/Use.h
@@ -50,14 +50,14 @@ class Use {
       : LLVMUse(LLVMUse), Usr(Usr), Ctx(&Ctx) {}
   Use() : LLVMUse(nullptr), Ctx(nullptr) {}
 
-  friend class ::llvm::sandboxir::Value;              // For constructor
-  friend class ::llvm::sandboxir::User;               // For constructor
-  friend class ::llvm::sandboxir::OperandUseIterator; // For constructor
-  friend class ::llvm::sandboxir::UserUseIterator;    // For accessing members
-  friend class ::llvm::sandboxir::CallBase;           // For LLVMUse
-  friend class ::llvm::sandboxir::PHINode;            // For LLVMUse
+  friend ::llvm::sandboxir::Value;              // For constructor
+  friend ::llvm::sandboxir::User;               // For constructor
+  friend ::llvm::sandboxir::OperandUseIterator; // For constructor
+  friend ::llvm::sandboxir::UserUseIterator;    // For accessing members
+  friend ::llvm::sandboxir::CallBase;           // For LLVMUse
+  friend ::llvm::sandboxir::PHINode;            // For LLVMUse
   // Friend instructions so that they can call the constructor if needed.
-#define DEF_INSTR(ID, OPC, CLASS) friend class ::llvm::sandboxir::CLASS;
+#define DEF_INSTR(ID, OPC, CLASS) friend ::llvm::sandboxir::CLASS;
 #define DEF_DISABLE_AUTO_UNDEF // ValuesDefFilesList.def includes multiple .def
 #include "llvm/SandboxIR/ValuesDefFilesList.def"
 #undef DEF_INSTR

--- a/llvm/include/llvm/SandboxIR/Use.h
+++ b/llvm/include/llvm/SandboxIR/Use.h
@@ -22,9 +22,19 @@ namespace llvm::sandboxir {
 class Context;
 class Value;
 class User;
+class OperandUseIterator;
+class UserUseIterator;
 class CallBase;
 class CallBrInst;
 class PHINode;
+
+// Forward declare instruction wrapper classes so qualified friend
+// declarations below refer to SandboxIR classes instead of introducing new
+// unqualified declarations.
+#define DEF_INSTR(ID, OPC, CLASS) class CLASS;
+#define DEF_DISABLE_AUTO_UNDEF // ValuesDefFilesList.def includes multiple .def
+#include "llvm/SandboxIR/ValuesDefFilesList.def"
+#undef DEF_INSTR
 
 /// Represents a Def-use/Use-def edge in SandboxIR.
 /// NOTE: Unlike llvm::Use, this is not an integral part of the use-def chains.
@@ -40,14 +50,14 @@ class Use {
       : LLVMUse(LLVMUse), Usr(Usr), Ctx(&Ctx) {}
   Use() : LLVMUse(nullptr), Ctx(nullptr) {}
 
-  friend class Value;              // For constructor
-  friend class User;               // For constructor
-  friend class OperandUseIterator; // For constructor
-  friend class UserUseIterator;    // For accessing members
-  friend class CallBase;           // For LLVMUse
-  friend class PHINode;            // For LLVMUse
+  friend class ::llvm::sandboxir::Value;              // For constructor
+  friend class ::llvm::sandboxir::User;               // For constructor
+  friend class ::llvm::sandboxir::OperandUseIterator; // For constructor
+  friend class ::llvm::sandboxir::UserUseIterator;    // For accessing members
+  friend class ::llvm::sandboxir::CallBase;           // For LLVMUse
+  friend class ::llvm::sandboxir::PHINode;            // For LLVMUse
   // Friend instructions so that they can call the constructor if needed.
-#define DEF_INSTR(ID, OPC, CLASS) friend class CLASS;
+#define DEF_INSTR(ID, OPC, CLASS) friend class ::llvm::sandboxir::CLASS;
 #define DEF_DISABLE_AUTO_UNDEF // ValuesDefFilesList.def includes multiple .def
 #include "llvm/SandboxIR/ValuesDefFilesList.def"
 #undef DEF_INSTR


### PR DESCRIPTION
clang-cl warned on "friend class CallInst;" because MSVC may resolve that to "friend llvm::CallInst" instead of the sbox IR mirrored hierarch. Drop the class tag and refer to forward declared names instead.