### PR TITLE
[libc++] Remove redundant `_LIBCPP_HIDE_FROM_ABI` from detail headers a-c

### DIFF
--- a/libcxx/include/__algorithm/adjacent_find.h
+++ b/libcxx/include/__algorithm/adjacent_find.h
@@ -26,7 +26,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Iter, class _Sent, class _Pred, class _Proj>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _Iter
+[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX20 _Iter
 __adjacent_find(_Iter __first, _Sent __last, _Pred& __pred, _Proj& __proj) {
   if (__first == __last)
     return __first;
@@ -41,14 +41,14 @@ __adjacent_find(_Iter __first, _Sent __last, _Pred& __pred, _Proj& __proj) {
 }
 
 template <class _ForwardIterator, class _BinaryPredicate>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 adjacent_find(_ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred) {
   __identity __proj;
   return std::__adjacent_find(std::move(__first), std::move(__last), __pred, __proj);
 }
 
 template <class _ForwardIterator>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 adjacent_find(_ForwardIterator __first, _ForwardIterator __last) {
   return std::adjacent_find(std::move(__first), std::move(__last), __equal_to());
 }

--- a/libcxx/include/__algorithm/all_of.h
+++ b/libcxx/include/__algorithm/all_of.h
@@ -27,15 +27,14 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Iter, class _Sent, class _Proj, class _Pred>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
-__all_of(_Iter __first, _Sent __last, _Pred& __pred, _Proj& __proj) {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 bool __all_of(_Iter __first, _Sent __last, _Pred& __pred, _Proj& __proj) {
   using _Ref          = decltype(std::__invoke(__proj, *__first));
   auto __negated_pred = [&__pred](_Ref __arg) -> bool { return !std::__invoke(__pred, std::forward<_Ref>(__arg)); };
   return !std::__any_of(std::move(__first), std::move(__last), __negated_pred, __proj);
 }
 
 template <class _InputIterator, class _Predicate>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 all_of(_InputIterator __first, _InputIterator __last, _Predicate __pred) {
   __identity __proj;
   return std::__all_of(__first, __last, __pred, __proj);

--- a/libcxx/include/__algorithm/any_of.h
+++ b/libcxx/include/__algorithm/any_of.h
@@ -21,8 +21,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Iter, class _Sent, class _Proj, class _Pred>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
-__any_of(_Iter __first, _Sent __last, _Pred& __pred, _Proj& __proj) {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 bool __any_of(_Iter __first, _Sent __last, _Pred& __pred, _Proj& __proj) {
   for (; __first != __last; ++__first) {
     if (std::__invoke(__pred, std::__invoke(__proj, *__first)))
       return true;
@@ -31,7 +30,7 @@ __any_of(_Iter __first, _Sent __last, _Pred& __pred, _Proj& __proj) {
 }
 
 template <class _InputIterator, class _Predicate>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 any_of(_InputIterator __first, _InputIterator __last, _Predicate __pred) {
   __identity __proj;
   return std::__any_of(__first, __last, __pred, __proj);

--- a/libcxx/include/__algorithm/binary_search.h
+++ b/libcxx/include/__algorithm/binary_search.h
@@ -21,14 +21,14 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _ForwardIterator, class _Tp, class _Compare>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 binary_search(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value, _Compare __comp) {
   __first = std::lower_bound<_ForwardIterator, _Tp, __comp_ref_type<_Compare> >(__first, __last, __value, __comp);
   return __first != __last && !__comp(__value, *__first);
 }
 
 template <class _ForwardIterator, class _Tp>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 binary_search(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) {
   return std::binary_search(__first, __last, __value, __less<>());
 }

--- a/libcxx/include/__algorithm/clamp.h
+++ b/libcxx/include/__algorithm/clamp.h
@@ -21,7 +21,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp, class _Compare>
-[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI constexpr const _Tp&
+[[nodiscard]] inline constexpr const _Tp&
 clamp(_LIBCPP_LIFETIMEBOUND const _Tp& __v,
       _LIBCPP_LIFETIMEBOUND const _Tp& __lo,
       _LIBCPP_LIFETIMEBOUND const _Tp& __hi,
@@ -31,7 +31,7 @@ clamp(_LIBCPP_LIFETIMEBOUND const _Tp& __v,
 }
 
 template <class _Tp>
-[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI constexpr const _Tp&
+[[nodiscard]] inline constexpr const _Tp&
 clamp(_LIBCPP_LIFETIMEBOUND const _Tp& __v,
       _LIBCPP_LIFETIMEBOUND const _Tp& __lo,
       _LIBCPP_LIFETIMEBOUND const _Tp& __hi) {

--- a/libcxx/include/__algorithm/comp.h
+++ b/libcxx/include/__algorithm/comp.h
@@ -22,7 +22,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 struct __equal_to {
   template <class _T1, class _T2>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator()(const _T1& __x, const _T2& __y) const {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator()(const _T1& __x, const _T2& __y) const {
     return __x == __y;
   }
 };
@@ -38,7 +38,7 @@ struct __less {};
 template <>
 struct __less<void, void> {
   template <class _Tp, class _Up>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator()(const _Tp& __lhs, const _Up& __rhs) const {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator()(const _Tp& __lhs, const _Up& __rhs) const {
     return __lhs < __rhs;
   }
 };

--- a/libcxx/include/__algorithm/comp_ref_type.h
+++ b/libcxx/include/__algorithm/comp_ref_type.h
@@ -22,10 +22,10 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 template <class _Compare>
 struct __debug_less {
   _Compare& __comp_;
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI __debug_less(_Compare& __c) : __comp_(__c) {}
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 __debug_less(_Compare& __c) : __comp_(__c) {}
 
   template <class _Tp, class _Up>
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool operator()(const _Tp& __x, const _Up& __y) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator()(const _Tp& __x, const _Up& __y) {
     bool __r = __comp_(__x, __y);
     if (__r)
       __do_compare_assert(0, __y, __x);
@@ -33,7 +33,7 @@ struct __debug_less {
   }
 
   template <class _Tp, class _Up>
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool operator()(_Tp& __x, _Up& __y) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator()(_Tp& __x, _Up& __y) {
     bool __r = __comp_(__x, __y);
     if (__r)
       __do_compare_assert(0, __y, __x);
@@ -41,16 +41,16 @@ struct __debug_less {
   }
 
   template <class _LHS, class _RHS>
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 inline
-      _LIBCPP_HIDE_FROM_ABI decltype((void)std::declval<_Compare&>()(std::declval<_LHS&>(), std::declval<_RHS&>()))
-      __do_compare_assert(int, _LHS& __l, _RHS& __r) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 inline decltype((void)std::declval<_Compare&>()(
+      std::declval<_LHS&>(), std::declval<_RHS&>()))
+  __do_compare_assert(int, _LHS& __l, _RHS& __r) {
     _LIBCPP_ASSERT_SEMANTIC_REQUIREMENT(!__comp_(__l, __r), "Comparator does not induce a strict weak ordering");
     (void)__l;
     (void)__r;
   }
 
   template <class _LHS, class _RHS>
-  _LIBCPP_CONSTEXPR_SINCE_CXX14 inline _LIBCPP_HIDE_FROM_ABI void __do_compare_assert(long, _LHS&, _RHS&) {}
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 inline void __do_compare_assert(long, _LHS&, _RHS&) {}
 };
 
 // Pass the comparator by lvalue reference. Or in the debug mode, using a debugging wrapper that stores a reference.

--- a/libcxx/include/__algorithm/copy.h
+++ b/libcxx/include/__algorithm/copy.h
@@ -31,12 +31,11 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _InputIterator, class _OutputIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
 copy(_InputIterator __first, _InputIterator __last, _OutputIterator __result);
 
 template <class _InIter, class _Sent, class _OutIter>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
-    __copy(_InIter, _Sent, _OutIter);
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter> __copy(_InIter, _Sent, _OutIter);
 
 struct __copy_impl {
   template <class _InIter,
@@ -46,7 +45,7 @@ struct __copy_impl {
                                                    __iterator_pair<_InIter, _Sent>,
                                                    __single_iterator<_OutIter> >::__has_algorithm,
                           int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _Sent __last, _OutIter __result) const {
     while (__first != __last) {
       *__result = *__first;
@@ -64,14 +63,14 @@ struct __copy_impl {
                                                   __iterator_pair<_InIter, _Sent>,
                                                   __single_iterator<_OutIter> >::__has_algorithm,
                           int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 static __in_out_result<_InIter, _OutIter>
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 static __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _Sent __last, _OutIter __result) {
     return __specialized_algorithm<_Algorithm::__copy, __iterator_pair<_InIter, _Sent>, __single_iterator<_OutIter> >()(
         std::move(__first), std::move(__last), std::move(__result));
   }
 
   template <class _InIter, class _OutIter, __enable_if_t<__is_segmented_iterator_v<_InIter>, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _InIter __last, _OutIter __result) const {
     using __local_iterator = typename __segmented_iterator_traits<_InIter>::__local_iterator;
     std::__for_each_segment(__first, __last, [&__result](__local_iterator __lfirst, __local_iterator __llast) {
@@ -85,7 +84,7 @@ struct __copy_impl {
             __enable_if_t<__has_random_access_iterator_category<_InIter>::value &&
                               !__is_segmented_iterator_v<_InIter> && __is_segmented_iterator_v<_OutIter>,
                           int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _InIter __last, _OutIter __result) const {
     using _Traits = __segmented_iterator_traits<_OutIter>;
     using _DiffT =
@@ -111,20 +110,20 @@ struct __copy_impl {
 
   // At this point, the iterators have been unwrapped so any `contiguous_iterator` has been unwrapped to a pointer.
   template <class _In, class _Out, __enable_if_t<__can_lower_copy_assignment_to_memmove<_In, _Out>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_In*, _Out*>
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_In*, _Out*>
   operator()(_In* __first, _In* __last, _Out* __result) const {
     return std::__copy_trivial_impl(__first, __last, __result);
   }
 };
 
 template <class _InIter, class _Sent, class _OutIter>
-__in_out_result<_InIter, _OutIter> inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
+__in_out_result<_InIter, _OutIter> inline _LIBCPP_CONSTEXPR_SINCE_CXX14
 __copy(_InIter __first, _Sent __last, _OutIter __result) {
   return std::__copy_move_unwrap_iters<__copy_impl>(std::move(__first), std::move(__last), std::move(__result));
 }
 
 template <class _InputIterator, class _OutputIterator>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
+_LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
 copy(_InputIterator __first, _InputIterator __last, _OutputIterator __result) {
   return std::__copy(__first, __last, __result).__out_;
 }

--- a/libcxx/include/__algorithm/copy_backward.h
+++ b/libcxx/include/__algorithm/copy_backward.h
@@ -35,11 +35,11 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, class _InIter, class _Sent, class _OutIter>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_InIter, _OutIter>
+_LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_InIter, _OutIter>
 __copy_backward(_InIter __first, _Sent __last, _OutIter __result);
 
 template <class _Cp, bool _IsConst>
-_LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI __bit_iterator<_Cp, false> __copy_backward_aligned(
+_LIBCPP_CONSTEXPR_SINCE_CXX20 __bit_iterator<_Cp, false> __copy_backward_aligned(
     __bit_iterator<_Cp, _IsConst> __first, __bit_iterator<_Cp, _IsConst> __last, __bit_iterator<_Cp, false> __result) {
   using _In             = __bit_iterator<_Cp, _IsConst>;
   using difference_type = typename _In::difference_type;
@@ -81,7 +81,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI __bit_iterator<_Cp, false> _
 }
 
 template <class _Cp, bool _IsConst>
-_LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI __bit_iterator<_Cp, false> __copy_backward_unaligned(
+_LIBCPP_CONSTEXPR_SINCE_CXX20 __bit_iterator<_Cp, false> __copy_backward_unaligned(
     __bit_iterator<_Cp, _IsConst> __first, __bit_iterator<_Cp, _IsConst> __last, __bit_iterator<_Cp, false> __result) {
   using _In             = __bit_iterator<_Cp, _IsConst>;
   using difference_type = typename _In::difference_type;
@@ -159,7 +159,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI __bit_iterator<_Cp, false> _
 template <class _AlgPolicy>
 struct __copy_backward_impl {
   template <class _InIter, class _Sent, class _OutIter>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _Sent __last, _OutIter __result) const {
     auto __last_iter          = _IterOps<_AlgPolicy>::next(__first, __last);
     auto __original_last_iter = __last_iter;
@@ -172,7 +172,7 @@ struct __copy_backward_impl {
   }
 
   template <class _InIter, class _OutIter, __enable_if_t<__is_segmented_iterator_v<_InIter>, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _InIter __last, _OutIter __result) const {
     using __local_iterator = typename __segmented_iterator_traits<_InIter>::__local_iterator;
     std::__for_each_segment_backward(__first, __last, [&__result](__local_iterator __lfirst, __local_iterator __llast) {
@@ -186,7 +186,7 @@ struct __copy_backward_impl {
             __enable_if_t<__has_random_access_iterator_category<_InIter>::value &&
                               !__is_segmented_iterator_v<_InIter> && __is_segmented_iterator_v<_OutIter>,
                           int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _InIter __last, _OutIter __result) const {
     using _Traits           = __segmented_iterator_traits<_OutIter>;
     auto __orig_last        = __last;
@@ -214,7 +214,7 @@ struct __copy_backward_impl {
   }
 
   template <class _Cp, bool _IsConst>
-  _LIBCPP_HIDE_FROM_ABI
+
   _LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<__bit_iterator<_Cp, _IsConst>, __bit_iterator<_Cp, false> >
   operator()(__bit_iterator<_Cp, _IsConst> __first,
              __bit_iterator<_Cp, _IsConst> __last,
@@ -226,21 +226,21 @@ struct __copy_backward_impl {
 
   // At this point, the iterators have been unwrapped so any `contiguous_iterator` has been unwrapped to a pointer.
   template <class _In, class _Out, __enable_if_t<__can_lower_copy_assignment_to_memmove<_In, _Out>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_In*, _Out*>
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_In*, _Out*>
   operator()(_In* __first, _In* __last, _Out* __result) const {
     return std::__copy_backward_trivial_impl(__first, __last, __result);
   }
 };
 
 template <class _AlgPolicy, class _BidirectionalIterator1, class _Sentinel, class _BidirectionalIterator2>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_BidirectionalIterator1, _BidirectionalIterator2>
+_LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_BidirectionalIterator1, _BidirectionalIterator2>
 __copy_backward(_BidirectionalIterator1 __first, _Sentinel __last, _BidirectionalIterator2 __result) {
   return std::__copy_move_unwrap_iters<__copy_backward_impl<_AlgPolicy> >(
       std::move(__first), std::move(__last), std::move(__result));
 }
 
 template <class _BidirectionalIterator1, class _BidirectionalIterator2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _BidirectionalIterator2
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _BidirectionalIterator2
 copy_backward(_BidirectionalIterator1 __first, _BidirectionalIterator1 __last, _BidirectionalIterator2 __result) {
   static_assert(std::is_copy_constructible<_BidirectionalIterator1>::value &&
                     std::is_copy_constructible<_BidirectionalIterator1>::value,

--- a/libcxx/include/__algorithm/copy_if.h
+++ b/libcxx/include/__algorithm/copy_if.h
@@ -26,7 +26,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _InIter, class _Sent, class _OutIter, class _Proj, class _Pred>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
+_LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
 __copy_if(_InIter __first, _Sent __last, _OutIter __result, _Pred& __pred, _Proj& __proj) {
   for (; __first != __last; ++__first) {
     if (std::__invoke(__pred, std::__invoke(__proj, *__first))) {
@@ -38,7 +38,7 @@ __copy_if(_InIter __first, _Sent __last, _OutIter __result, _Pred& __pred, _Proj
 }
 
 template <class _InputIterator, class _OutputIterator, class _Predicate>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
 copy_if(_InputIterator __first, _InputIterator __last, _OutputIterator __result, _Predicate __pred) {
   __identity __proj;
   return std::__copy_if(__first, __last, __result, __pred, __proj).__out_;

--- a/libcxx/include/__algorithm/copy_move_common.h
+++ b/libcxx/include/__algorithm/copy_move_common.h
@@ -54,7 +54,7 @@ struct __can_lower_move_assignment_to_memmove {
 // `memmove` algorithms implementation.
 
 template <class _In, class _Out>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_In*, _Out*>
+_LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_In*, _Out*>
 __copy_trivial_impl(_In* __first, _In* __last, _Out* __result) {
   const size_t __n = static_cast<size_t>(__last - __first);
 
@@ -64,7 +64,7 @@ __copy_trivial_impl(_In* __first, _In* __last, _Out* __result) {
 }
 
 template <class _In, class _Out>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_In*, _Out*>
+_LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_In*, _Out*>
 __copy_backward_trivial_impl(_In* __first, _In* __last, _Out* __result) {
   const size_t __n = static_cast<size_t>(__last - __first);
   __result -= __n;
@@ -85,7 +85,7 @@ template <class _Algorithm,
           class _Sent,
           class _OutIter,
           __enable_if_t<__can_rewrap<_InIter, _OutIter>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 __in_out_result<_InIter, _OutIter>
+_LIBCPP_CONSTEXPR_SINCE_CXX17 __in_out_result<_InIter, _OutIter>
 __copy_move_unwrap_iters(_InIter __first, _Sent __last, _OutIter __out_first) {
   auto __range  = std::__unwrap_range(__first, std::move(__last));
   auto __result = _Algorithm()(std::move(__range.first), std::move(__range.second), std::__unwrap_iter(__out_first));
@@ -98,7 +98,7 @@ template <class _Algorithm,
           class _Sent,
           class _OutIter,
           __enable_if_t<!__can_rewrap<_InIter, _OutIter>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 __in_out_result<_InIter, _OutIter>
+_LIBCPP_CONSTEXPR_SINCE_CXX17 __in_out_result<_InIter, _OutIter>
 __copy_move_unwrap_iters(_InIter __first, _Sent __last, _OutIter __out_first) {
   return _Algorithm()(std::move(__first), std::move(__last), std::move(__out_first));
 }

--- a/libcxx/include/__algorithm/copy_n.h
+++ b/libcxx/include/__algorithm/copy_n.h
@@ -31,7 +31,7 @@ template <class _AlgPolicy,
           class _InIter,
           class _OutIter,
           __enable_if_t<__has_random_access_iterator_category<_InIter>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_InIter, _OutIter>
+_LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_InIter, _OutIter>
 __copy_n(_InIter __first, typename _IterOps<_AlgPolicy>::template __difference_type<_InIter> __n, _OutIter __result) {
   return std::__copy(__first, __first + __n, std::move(__result));
 }
@@ -40,7 +40,7 @@ template <class _AlgPolicy,
           class _InIter,
           class _OutIter,
           __enable_if_t<!__has_random_access_iterator_category<_InIter>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_InIter, _OutIter>
+_LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_InIter, _OutIter>
 __copy_n(_InIter __first, typename _IterOps<_AlgPolicy>::template __difference_type<_InIter> __n, _OutIter __result) {
   while (__n != 0) {
     *__result = *__first;
@@ -59,8 +59,7 @@ template <class _InputIterator,
           class _Size,
           class _OutputIterator,
           __enable_if_t<__has_exactly_input_iterator_category<_InputIterator>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
-copy_n(_InputIterator __first, _Size __n, _OutputIterator __result) {
+_LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator copy_n(_InputIterator __first, _Size __n, _OutputIterator __result) {
   using _IntegralSize       = decltype(std::__convert_to_integral(__n));
   _IntegralSize __converted = __n;
   if (__converted > 0) {
@@ -79,8 +78,7 @@ template <class _InputIterator,
           class _Size,
           class _OutputIterator,
           __enable_if_t<!__has_exactly_input_iterator_category<_InputIterator>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
-copy_n(_InputIterator __first, _Size __n, _OutputIterator __result) {
+_LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator copy_n(_InputIterator __first, _Size __n, _OutputIterator __result) {
   using _IntegralSize       = decltype(std::__convert_to_integral(__n));
   _IntegralSize __converted = __n;
   return std::__copy_n<_ClassicAlgPolicy>(__first, __iterator_difference_type<_InputIterator>(__converted), __result)

--- a/libcxx/include/__algorithm/count.h
+++ b/libcxx/include/__algorithm/count.h
@@ -32,7 +32,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 // generic implementation
 template <class _AlgPolicy, class _Iter, class _Sent, class _Tp, class _Proj>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 typename _IterOps<_AlgPolicy>::template __difference_type<_Iter>
+_LIBCPP_CONSTEXPR_SINCE_CXX20 typename _IterOps<_AlgPolicy>::template __difference_type<_Iter>
 __count(_Iter __first, _Sent __last, const _Tp& __value, _Proj& __proj) {
   typename _IterOps<_AlgPolicy>::template __difference_type<_Iter> __r(0);
   for (; __first != __last; ++__first)
@@ -43,7 +43,7 @@ __count(_Iter __first, _Sent __last, const _Tp& __value, _Proj& __proj) {
 
 // __bit_iterator implementation
 template <bool _ToCount, class _Cp, bool _IsConst>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 typename __bit_iterator<_Cp, _IsConst>::difference_type
+_LIBCPP_CONSTEXPR_SINCE_CXX20 typename __bit_iterator<_Cp, _IsConst>::difference_type
 __count_bool(__bit_iterator<_Cp, _IsConst> __first, typename __size_difference_type_traits<_Cp>::size_type __n) {
   using _It             = __bit_iterator<_Cp, _IsConst>;
   using __storage_type  = typename _It::__storage_type;
@@ -72,7 +72,7 @@ __count_bool(__bit_iterator<_Cp, _IsConst> __first, typename __size_difference_t
 }
 
 template <class, class _Cp, bool _IsConst, class _Tp, class _Proj, __enable_if_t<__is_identity<_Proj>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __iterator_difference_type<__bit_iterator<_Cp, _IsConst> >
+_LIBCPP_CONSTEXPR_SINCE_CXX20 __iterator_difference_type<__bit_iterator<_Cp, _IsConst> >
 __count(__bit_iterator<_Cp, _IsConst> __first, __bit_iterator<_Cp, _IsConst> __last, const _Tp& __value, _Proj&) {
   if (__value)
     return std::__count_bool<true>(
@@ -82,7 +82,7 @@ __count(__bit_iterator<_Cp, _IsConst> __first, __bit_iterator<_Cp, _IsConst> __l
 }
 
 template <class _InputIterator, class _Tp>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __iterator_difference_type<_InputIterator>
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 __iterator_difference_type<_InputIterator>
 count(_InputIterator __first, _InputIterator __last, const _Tp& __value) {
   __identity __proj;
   return std::__count<_ClassicAlgPolicy>(__first, __last, __value, __proj);

--- a/libcxx/include/__algorithm/count_if.h
+++ b/libcxx/include/__algorithm/count_if.h
@@ -23,7 +23,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, class _Iter, class _Sent, class _Proj, class _Pred>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __policy_iter_diff_t<_AlgPolicy, _Iter>
+_LIBCPP_CONSTEXPR_SINCE_CXX14 __policy_iter_diff_t<_AlgPolicy, _Iter>
 __count_if(_Iter __first, _Sent __last, _Pred& __pred, _Proj& __proj) {
   __policy_iter_diff_t<_AlgPolicy, _Iter> __counter(0);
   for (; __first != __last; ++__first) {
@@ -34,8 +34,7 @@ __count_if(_Iter __first, _Sent __last, _Pred& __pred, _Proj& __proj) {
 }
 
 template <class _InputIterator, class _Predicate>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
-typename iterator_traits<_InputIterator>::difference_type
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 typename iterator_traits<_InputIterator>::difference_type
 count_if(_InputIterator __first, _InputIterator __last, _Predicate __pred) {
   __identity __proj;
   return std::__count_if<_ClassicAlgPolicy>(__first, __last, __pred, __proj);

--- a/libcxx/include/__algorithm/equal.h
+++ b/libcxx/include/__algorithm/equal.h
@@ -40,7 +40,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Cp, bool _IsConst1, bool _IsConst2>
-[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI bool
+[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 __equal_unaligned(__bit_iterator<_Cp, _IsConst1> __first1,
                   __bit_iterator<_Cp, _IsConst1> __last1,
                   __bit_iterator<_Cp, _IsConst2> __first2) {
@@ -118,7 +118,7 @@ __equal_unaligned(__bit_iterator<_Cp, _IsConst1> __first1,
 }
 
 template <class _Cp, bool _IsConst1, bool _IsConst2>
-[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI bool
+[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 __equal_aligned(__bit_iterator<_Cp, _IsConst1> __first1,
                 __bit_iterator<_Cp, _IsConst1> __last1,
                 __bit_iterator<_Cp, _IsConst2> __first2) {
@@ -167,7 +167,7 @@ template <class _Cp,
           __enable_if_t<__is_identity<_Proj1>::value && __is_identity<_Proj2>::value &&
                             __desugars_to_v<__equal_tag, _BinaryPredicate, bool, bool>,
                         int> = 0>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __equal_iter_impl(
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __equal_iter_impl(
     __bit_iterator<_Cp, _IsConst1> __first1,
     __bit_iterator<_Cp, _IsConst1> __last1,
     __bit_iterator<_Cp, _IsConst2> __first2,
@@ -188,13 +188,13 @@ template <class _Tp,
                             __desugars_to_v<__equal_tag, _BinaryPredicate, _Tp, _Up> && !is_volatile<_Tp>::value &&
                             !is_volatile<_Up>::value && __is_trivially_equality_comparable_v<_Tp, _Up>,
                         int> = 0>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 __equal_iter_impl(_Tp* __first1, _Tp* __last1, _Up* __first2, _BinaryPredicate&, _Proj1&, _Proj2&) {
   return std::__constexpr_memcmp_equal(__first1, __first2, __element_count(__last1 - __first1));
 }
 
 template <class _InIter1, class _Sent1, class _InIter2, class _Pred, class _Proj1, class _Proj2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __equal_iter_impl(
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __equal_iter_impl(
     _InIter1 __first1, _Sent1 __last1, _InIter2 __first2, _Pred& __pred, _Proj1& __proj1, _Proj2& __proj2) {
 #ifndef _LIBCPP_CXX03_LANG
   if constexpr (__has_random_access_iterator_category<_InIter1>::value &&
@@ -246,7 +246,7 @@ template <class _InIter1, class _Sent1, class _InIter2, class _Pred, class _Proj
 }
 
 template <class _InputIterator1, class _InputIterator2, class _BinaryPredicate>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 equal(_InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2, _BinaryPredicate __pred) {
   __identity __proj;
   return std::__equal_iter_impl(
@@ -254,7 +254,7 @@ equal(_InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first
 }
 
 template <class _InputIterator1, class _InputIterator2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 equal(_InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2) {
   return std::equal(__first1, __last1, __first2, __equal_to());
 }
@@ -269,7 +269,7 @@ template <bool __known_equal_length,
           class _Pred,
           class _Proj1,
           class _Proj2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __equal_impl(
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __equal_impl(
     _Iter1 __first1, _Sent1 __last1, _Iter2 __first2, _Sent2 __last2, _Pred& __comp, _Proj1& __proj1, _Proj2& __proj2) {
   if constexpr (__known_equal_length) {
     return std::__equal_iter_impl(
@@ -286,7 +286,7 @@ template <bool __known_equal_length,
 }
 
 template <class _InputIterator1, class _InputIterator2, class _BinaryPredicate>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 equal(_InputIterator1 __first1,
       _InputIterator1 __last1,
       _InputIterator2 __first2,
@@ -311,7 +311,7 @@ equal(_InputIterator1 __first1,
 }
 
 template <class _InputIterator1, class _InputIterator2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 equal(_InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2, _InputIterator2 __last2) {
   return std::equal(__first1, __last1, __first2, __last2, __equal_to());
 }

--- a/libcxx/include/__algorithm/equal_range.h
+++ b/libcxx/include/__algorithm/equal_range.h
@@ -33,7 +33,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, class _Compare, class _Iter, class _Sent, class _Tp, class _Proj>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_Iter, _Iter>
+_LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_Iter, _Iter>
 __equal_range(_Iter __first, _Sent __last, const _Tp& __value, _Compare&& __comp, _Proj&& __proj) {
   auto __len  = _IterOps<_AlgPolicy>::distance(__first, __last);
   _Iter __end = _IterOps<_AlgPolicy>::next(__first, __last);
@@ -56,7 +56,7 @@ __equal_range(_Iter __first, _Sent __last, const _Tp& __value, _Compare&& __comp
 }
 
 template <class _ForwardIterator, class _Tp, class _Compare>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_ForwardIterator, _ForwardIterator>
+[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_ForwardIterator, _ForwardIterator>
 equal_range(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value, _Compare __comp) {
   static_assert(__is_callable<_Compare&, decltype(*__first), const _Tp&>::value, "The comparator has to be callable");
   static_assert(is_copy_constructible<_ForwardIterator>::value, "Iterator has to be copy constructible");
@@ -69,7 +69,7 @@ equal_range(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __valu
 }
 
 template <class _ForwardIterator, class _Tp>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_ForwardIterator, _ForwardIterator>
+[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_ForwardIterator, _ForwardIterator>
 equal_range(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) {
   return std::equal_range(std::move(__first), std::move(__last), __value, __less<>());
 }

--- a/libcxx/include/__algorithm/fill.h
+++ b/libcxx/include/__algorithm/fill.h
@@ -26,7 +26,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // fill isn't specialized for std::memset, because the compiler already optimizes the loop to a call to std::memset.
 
 template <class _ForwardIterator, class _Sentinel, class _Tp>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 __fill(_ForwardIterator __first, _Sentinel __last, const _Tp& __value) {
 #ifndef _LIBCPP_CXX03_LANG
   if constexpr (is_same<_ForwardIterator, _Sentinel>::value && __is_segmented_iterator_v<_ForwardIterator>) {
@@ -47,14 +47,13 @@ template <class _RandomAccessIterator,
           __enable_if_t<__has_random_access_iterator_category<_RandomAccessIterator>::value &&
                             !__is_segmented_iterator_v<_RandomAccessIterator>,
                         int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _RandomAccessIterator
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _RandomAccessIterator
 __fill(_RandomAccessIterator __first, _RandomAccessIterator __last, const _Tp& __value) {
   return std::__fill_n(__first, __last - __first, __value);
 }
 
 template <class _ForwardIterator, class _Tp>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
-fill(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) {
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void fill(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) {
   std::__fill(__first, __last, __value);
 }
 

--- a/libcxx/include/__algorithm/fill_n.h
+++ b/libcxx/include/__algorithm/fill_n.h
@@ -35,8 +35,7 @@ template <
     class _Tp,
     __enable_if_t<!__specialized_algorithm<_Algorithm::__fill_n, __single_iterator<_OutputIterator> >::__has_algorithm,
                   int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
-__fill_n(_OutputIterator __first, _Size __n, const _Tp& __value) {
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator __fill_n(_OutputIterator __first, _Size __n, const _Tp& __value) {
 #ifndef _LIBCPP_CXX03_LANG
   if constexpr (__is_segmented_iterator_v<_OutputIterator>) {
     using __local_iterator = typename __segmented_iterator_traits<_OutputIterator>::__local_iterator;
@@ -57,14 +56,13 @@ template <class _OutIter,
           class _Tp,
           __enable_if_t<__specialized_algorithm<_Algorithm::__fill_n, __single_iterator<_OutIter> >::__has_algorithm,
                         int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutIter __fill_n(_OutIter __first, _Size __n, const _Tp& __value) {
+_LIBCPP_CONSTEXPR_SINCE_CXX20 _OutIter __fill_n(_OutIter __first, _Size __n, const _Tp& __value) {
   return __specialized_algorithm<_Algorithm::__fill_n, __single_iterator<_OutIter> >()(
       std::move(__first), __n, __value);
 }
 
 template <class _OutputIterator, class _Size, class _Tp>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
-fill_n(_OutputIterator __first, _Size __n, const _Tp& __value) {
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator fill_n(_OutputIterator __first, _Size __n, const _Tp& __value) {
   return std::__fill_n(__first, std::__convert_to_integral(__n), __value);
 }
 

--- a/libcxx/include/__algorithm/find.h
+++ b/libcxx/include/__algorithm/find.h
@@ -47,8 +47,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 // generic implementation
 template <class _Iter, class _Sent, class _Tp, class _Proj>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Iter
-__find_generic(_Iter __first, _Sent __last, const _Tp& __value, _Proj& __proj) {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 _Iter __find_generic(_Iter __first, _Sent __last, const _Tp& __value, _Proj& __proj) {
   return std::__find_if(
       std::move(__first),
       std::move(__last),
@@ -57,14 +56,13 @@ __find_generic(_Iter __first, _Sent __last, const _Tp& __value, _Proj& __proj) {
 }
 
 template <class _Iter, class _Sent, class _Tp, class _Proj>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Iter
-__find(_Iter __first, _Sent __last, const _Tp& __value, _Proj& __proj) {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 _Iter __find(_Iter __first, _Sent __last, const _Tp& __value, _Proj& __proj) {
   return std::__find_generic(std::move(__first), std::move(__last), __value, __proj);
 }
 
 #if _LIBCPP_VECTORIZE_ALGORITHMS
 template <class _Tp, class _Up>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI
+[[__nodiscard__]]
 _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp* __find_vectorized(_Tp* __first, _Tp* __last, _Up __value) {
   if (!__libcpp_is_constant_evaluated()) {
     constexpr size_t __unroll_count = 4;
@@ -120,7 +118,7 @@ template <class _Tp,
           class _Up,
           class _Proj,
           __enable_if_t<__is_identity<_Proj>::value && __is_trivially_equality_comparable_v<_Tp, _Up>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp* __find(_Tp* __first, _Tp* __last, const _Up& __value, _Proj&) {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp* __find(_Tp* __first, _Tp* __last, const _Up& __value, _Proj&) {
   if constexpr (sizeof(_Tp) == 1) {
     if (auto __ret = std::__constexpr_memchr(__first, __value, __last - __first))
       return __ret;
@@ -154,8 +152,7 @@ template <class _Tp,
                             is_integral<_Tp>::value && is_integral<_Up>::value &&
                             is_signed<_Tp>::value == is_signed<_Up>::value,
                         int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp*
-__find(_Tp* __first, _Tp* __last, const _Up& __value, _Proj& __proj) {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp* __find(_Tp* __first, _Tp* __last, const _Up& __value, _Proj& __proj) {
   if (__value < numeric_limits<_Tp>::min() || __value > numeric_limits<_Tp>::max())
     return __last;
   return std::__find(__first, __last, _Tp(__value), __proj);
@@ -163,7 +160,7 @@ __find(_Tp* __first, _Tp* __last, const _Up& __value, _Proj& __proj) {
 
 // __bit_iterator implementation
 template <bool _ToFind, class _Cp, bool _IsConst>
-_LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI __bit_iterator<_Cp, _IsConst>
+_LIBCPP_CONSTEXPR_SINCE_CXX20 __bit_iterator<_Cp, _IsConst>
 __find_bool(__bit_iterator<_Cp, _IsConst> __first, typename __size_difference_type_traits<_Cp>::size_type __n) {
   using _It            = __bit_iterator<_Cp, _IsConst>;
   using __storage_type = typename _It::__storage_type;
@@ -199,7 +196,7 @@ __find_bool(__bit_iterator<_Cp, _IsConst> __first, typename __size_difference_ty
 }
 
 template <class _Cp, bool _IsConst, class _Tp, class _Proj, __enable_if_t<__is_identity<_Proj>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __bit_iterator<_Cp, _IsConst>
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 __bit_iterator<_Cp, _IsConst>
 __find(__bit_iterator<_Cp, _IsConst> __first, __bit_iterator<_Cp, _IsConst> __last, const _Tp& __value, _Proj&) {
   if (static_cast<bool>(__value))
     return std::__find_bool<true>(
@@ -214,7 +211,7 @@ template <class _SegmentedIterator,
           class _Tp,
           class _Proj,
           __enable_if_t<__is_segmented_iterator_v<_SegmentedIterator>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _SegmentedIterator
+_LIBCPP_CONSTEXPR_SINCE_CXX14 _SegmentedIterator
 __find(_SegmentedIterator __first, _SegmentedIterator __last, const _Tp& __value, _Proj& __proj) {
   using __local_iterator = typename __segmented_iterator_traits<_SegmentedIterator>::__local_iterator;
   return std::__find_segment_if(
@@ -226,7 +223,7 @@ __find(_SegmentedIterator __first, _SegmentedIterator __last, const _Tp& __value
 
 // public API
 template <class _InputIterator, class _Tp>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _InputIterator
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _InputIterator
 find(_InputIterator __first, _InputIterator __last, const _Tp& __value) {
   __identity __proj;
   return std::__rewrap_iter(

--- a/libcxx/include/__algorithm/find_end.h
+++ b/libcxx/include/__algorithm/find_end.h
@@ -32,7 +32,7 @@ template < class _AlgPolicy,
            class _Pred,
            class _Proj1,
            class _Proj2>
-_LIBCPP_HIDE_FROM_ABI inline _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter1, _Iter1> __find_end_impl(
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter1, _Iter1> __find_end_impl(
     _Iter1 __first1,
     _Sent1 __last1,
     _Iter2 __first2,
@@ -84,7 +84,7 @@ template <class _AlgPolicy,
           class _Sent2,
           class _Proj1,
           class _Proj2>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_Iter1, _Iter1> __find_end_impl(
+_LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_Iter1, _Iter1> __find_end_impl(
     _Iter1 __first1,
     _Sent1 __sent1,
     _Iter2 __first2,
@@ -136,7 +136,7 @@ template <class _AlgPolicy,
           class _Sent2,
           class _Proj1,
           class _Proj2>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter1, _Iter1> __find_end_impl(
+_LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter1, _Iter1> __find_end_impl(
     _Iter1 __first1,
     _Sent1 __sent1,
     _Iter2 __first2,
@@ -182,7 +182,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter1, _Iter1> __find_
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator1 __find_end_classic(
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator1 __find_end_classic(
     _ForwardIterator1 __first1,
     _ForwardIterator1 __last1,
     _ForwardIterator2 __first2,
@@ -203,7 +203,7 @@ template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredica
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator1 find_end(
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator1 find_end(
     _ForwardIterator1 __first1,
     _ForwardIterator1 __last1,
     _ForwardIterator2 __first2,
@@ -213,7 +213,7 @@ template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredica
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator1
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator1
 find_end(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2) {
   return std::find_end(__first1, __last1, __first2, __last2, __equal_to());
 }

--- a/libcxx/include/__algorithm/find_first_of.h
+++ b/libcxx/include/__algorithm/find_first_of.h
@@ -20,7 +20,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator1 __find_first_of_ce(
+_LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator1 __find_first_of_ce(
     _ForwardIterator1 __first1,
     _ForwardIterator1 __last1,
     _ForwardIterator2 __first2,
@@ -34,7 +34,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator1 __find_fir
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator1 find_first_of(
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator1 find_first_of(
     _ForwardIterator1 __first1,
     _ForwardIterator1 __last1,
     _ForwardIterator2 __first2,
@@ -44,7 +44,7 @@ template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredica
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator1 find_first_of(
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator1 find_first_of(
     _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2) {
   return std::__find_first_of_ce(__first1, __last1, __first2, __last2, __equal_to());
 }

--- a/libcxx/include/__algorithm/find_if.h
+++ b/libcxx/include/__algorithm/find_if.h
@@ -22,8 +22,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Iter, class _Sent, class _Pred, class _Proj>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 _Iter
-__find_if(_Iter __first, _Sent __last, _Pred&& __pred, _Proj&& __proj) {
+_LIBCPP_CONSTEXPR_SINCE_CXX17 _Iter __find_if(_Iter __first, _Sent __last, _Pred&& __pred, _Proj&& __proj) {
   std::__assume_valid_range(__first, __last);
 
   for (; __first != __last; ++__first)
@@ -33,7 +32,7 @@ __find_if(_Iter __first, _Sent __last, _Pred&& __pred, _Proj&& __proj) {
 }
 
 template <class _InputIterator, class _Predicate>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _InputIterator
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _InputIterator
 find_if(_InputIterator __first, _InputIterator __last, _Predicate __pred) {
   return std::__find_if(__first, __last, __pred, __identity());
 }

--- a/libcxx/include/__algorithm/find_if_not.h
+++ b/libcxx/include/__algorithm/find_if_not.h
@@ -26,8 +26,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Iter, class _Sent, class _Pred, class _Proj>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _Iter
-__find_if_not(_Iter __first, _Sent __last, _Pred&& __pred, _Proj&& __proj) {
+_LIBCPP_CONSTEXPR_SINCE_CXX20 _Iter __find_if_not(_Iter __first, _Sent __last, _Pred&& __pred, _Proj&& __proj) {
   return std::__find_if(
       std::move(__first),
       std::move(__last),
@@ -36,7 +35,7 @@ __find_if_not(_Iter __first, _Sent __last, _Pred&& __pred, _Proj&& __proj) {
 }
 
 template <class _InputIterator, class _Predicate>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _InputIterator
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _InputIterator
 find_if_not(_InputIterator __first, _InputIterator __last, _Predicate __pred) {
   return std::__find_if_not(__first, __last, __pred, __identity());
 }

--- a/libcxx/include/__algorithm/find_segment_if.h
+++ b/libcxx/include/__algorithm/find_segment_if.h
@@ -24,7 +24,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // no match.
 
 template <class _SegmentedIterator, class _Pred>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _SegmentedIterator
+_LIBCPP_CONSTEXPR_SINCE_CXX14 _SegmentedIterator
 __find_segment_if(_SegmentedIterator __first, _SegmentedIterator __last, _Pred __pred) {
   using _Traits = __segmented_iterator_traits<_SegmentedIterator>;
 

--- a/libcxx/include/__algorithm/for_each.h
+++ b/libcxx/include/__algorithm/for_each.h
@@ -25,7 +25,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _InputIterator, class _Sent, class _Func, class _Proj>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _InputIterator
+_LIBCPP_CONSTEXPR_SINCE_CXX20 _InputIterator
 __for_each(_InputIterator __first, _Sent __last, _Func&& __func, _Proj& __proj) {
 #ifndef _LIBCPP_CXX03_LANG
   if constexpr (using _SpecialAlg =
@@ -47,8 +47,7 @@ __for_each(_InputIterator __first, _Sent __last, _Func&& __func, _Proj& __proj) 
 }
 
 template <class _InputIterator, class _Func>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _Func
-for_each(_InputIterator __first, _InputIterator __last, _Func __f) {
+_LIBCPP_CONSTEXPR_SINCE_CXX20 _Func for_each(_InputIterator __first, _InputIterator __last, _Func __f) {
   __identity __proj;
   std::__for_each(__first, __last, __f, __proj);
   return __f;

--- a/libcxx/include/__algorithm/for_each_n.h
+++ b/libcxx/include/__algorithm/for_each_n.h
@@ -31,7 +31,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _InputIterator, class _Size, class _Func, class _Proj>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _InputIterator
+_LIBCPP_CONSTEXPR_SINCE_CXX20 _InputIterator
 __for_each_n(_InputIterator __first, _Size __orig_n, _Func&& __f, _Proj& __proj) {
   typedef decltype(std::__convert_to_integral(__orig_n)) _IntegralSize;
   _IntegralSize __n = __orig_n;
@@ -61,8 +61,7 @@ __for_each_n(_InputIterator __first, _Size __orig_n, _Func&& __f, _Proj& __proj)
 #if _LIBCPP_STD_VER >= 17
 
 template <class _InputIterator, class _Size, class _Func>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _InputIterator
-for_each_n(_InputIterator __first, _Size __orig_n, _Func __f) {
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _InputIterator for_each_n(_InputIterator __first, _Size __orig_n, _Func __f) {
   __identity __proj;
   return std::__for_each_n(__first, __orig_n, __f, __proj);
 }

--- a/libcxx/include/__algorithm/for_each_n_segment.h
+++ b/libcxx/include/__algorithm/for_each_n_segment.h
@@ -25,7 +25,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // last processed element in the input range.
 
 template <class _SegmentedIterator, class _Size, class _Functor>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _SegmentedIterator
+_LIBCPP_CONSTEXPR_SINCE_CXX14 _SegmentedIterator
 __for_each_n_segment(_SegmentedIterator __first, _Size __orig_n, _Functor __func) {
   static_assert(__is_segmented_iterator_v<_SegmentedIterator> &&
                     __has_random_access_iterator_category<

--- a/libcxx/include/__algorithm/for_each_segment.h
+++ b/libcxx/include/__algorithm/for_each_segment.h
@@ -23,7 +23,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // Anything that is returned from __func is ignored.
 
 template <class _SegmentedIterator, class _Functor>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void
+_LIBCPP_CONSTEXPR_SINCE_CXX14 void
 __for_each_segment(_SegmentedIterator __first, _SegmentedIterator __last, _Functor __func) {
   using _Traits = __segmented_iterator_traits<_SegmentedIterator>;
 
@@ -49,7 +49,7 @@ __for_each_segment(_SegmentedIterator __first, _SegmentedIterator __last, _Funct
 }
 
 template <class _SegmentedIterator, class _Functor>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void
+_LIBCPP_CONSTEXPR_SINCE_CXX14 void
 __for_each_segment_backward(_SegmentedIterator __first, _SegmentedIterator __last, _Functor __func) {
   using _Traits = __segmented_iterator_traits<_SegmentedIterator>;
 

--- a/libcxx/include/__algorithm/generate.h
+++ b/libcxx/include/__algorithm/generate.h
@@ -20,7 +20,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _ForwardIterator, class _Generator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 generate(_ForwardIterator __first, _ForwardIterator __last, _Generator __gen) {
   using __iter_ref = decltype(*__first);
   std::for_each(__first, __last, [&](__iter_ref __element) { std::forward<__iter_ref>(__element) = __gen(); });

--- a/libcxx/include/__algorithm/generate_n.h
+++ b/libcxx/include/__algorithm/generate_n.h
@@ -25,7 +25,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _OutputIterator, class _Size, class _Generator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
 __generate_n(_OutputIterator __first, _Size __orig_n, _Generator& __gen) {
   using __iter_ref = decltype(*__first);
   __identity __proj;
@@ -37,7 +37,7 @@ __generate_n(_OutputIterator __first, _Size __orig_n, _Generator& __gen) {
 }
 
 template <class _OutputIterator, class _Size, class _Generator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
 generate_n(_OutputIterator __first, _Size __orig_n, _Generator __gen) {
   return std::__generate_n(std::move(__first), __orig_n, __gen);
 }

--- a/libcxx/include/__algorithm/half_positive.h
+++ b/libcxx/include/__algorithm/half_positive.h
@@ -23,12 +23,12 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // Perform division by two quickly for positive integers (llvm.org/PR39129)
 
 template <typename _Integral, __enable_if_t<is_integral<_Integral>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _Integral __half_positive(_Integral __value) {
+_LIBCPP_CONSTEXPR _Integral __half_positive(_Integral __value) {
   return static_cast<_Integral>(static_cast<__make_unsigned_t<_Integral> >(__value) / 2);
 }
 
 template <typename _Tp, __enable_if_t<!is_integral<_Tp>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _Tp __half_positive(_Tp __value) {
+_LIBCPP_CONSTEXPR _Tp __half_positive(_Tp __value) {
   return __value / 2;
 }
 

--- a/libcxx/include/__algorithm/in_found_result.h
+++ b/libcxx/include/__algorithm/in_found_result.h
@@ -33,13 +33,13 @@ struct in_found_result {
 
   template <class _InIter2>
     requires convertible_to<const _InIter1&, _InIter2>
-  _LIBCPP_HIDE_FROM_ABI constexpr operator in_found_result<_InIter2>() const& {
+  constexpr operator in_found_result<_InIter2>() const& {
     return {in, found};
   }
 
   template <class _InIter2>
     requires convertible_to<_InIter1, _InIter2>
-  _LIBCPP_HIDE_FROM_ABI constexpr operator in_found_result<_InIter2>() && {
+  constexpr operator in_found_result<_InIter2>() && {
     return {std::move(in), found};
   }
 };

--- a/libcxx/include/__algorithm/in_fun_result.h
+++ b/libcxx/include/__algorithm/in_fun_result.h
@@ -33,13 +33,13 @@ struct in_fun_result {
 
   template <class _InIter2, class _Func2>
     requires convertible_to<const _InIter1&, _InIter2> && convertible_to<const _Func1&, _Func2>
-  _LIBCPP_HIDE_FROM_ABI constexpr operator in_fun_result<_InIter2, _Func2>() const& {
+  constexpr operator in_fun_result<_InIter2, _Func2>() const& {
     return {in, fun};
   }
 
   template <class _InIter2, class _Func2>
     requires convertible_to<_InIter1, _InIter2> && convertible_to<_Func1, _Func2>
-  _LIBCPP_HIDE_FROM_ABI constexpr operator in_fun_result<_InIter2, _Func2>() && {
+  constexpr operator in_fun_result<_InIter2, _Func2>() && {
     return {std::move(in), std::move(fun)};
   }
 };

--- a/libcxx/include/__algorithm/in_in_out_result.h
+++ b/libcxx/include/__algorithm/in_in_out_result.h
@@ -36,14 +36,14 @@ struct in_in_out_result {
   template <class _InIter3, class _InIter4, class _OutIter2>
     requires convertible_to<const _InIter1&, _InIter3> && convertible_to<const _InIter2&, _InIter4> &&
              convertible_to<const _OutIter1&, _OutIter2>
-  _LIBCPP_HIDE_FROM_ABI constexpr operator in_in_out_result<_InIter3, _InIter4, _OutIter2>() const& {
+  constexpr operator in_in_out_result<_InIter3, _InIter4, _OutIter2>() const& {
     return {in1, in2, out};
   }
 
   template <class _InIter3, class _InIter4, class _OutIter2>
     requires convertible_to<_InIter1, _InIter3> && convertible_to<_InIter2, _InIter4> &&
              convertible_to<_OutIter1, _OutIter2>
-  _LIBCPP_HIDE_FROM_ABI constexpr operator in_in_out_result<_InIter3, _InIter4, _OutIter2>() && {
+  constexpr operator in_in_out_result<_InIter3, _InIter4, _OutIter2>() && {
     return {std::move(in1), std::move(in2), std::move(out)};
   }
 };

--- a/libcxx/include/__algorithm/in_in_result.h
+++ b/libcxx/include/__algorithm/in_in_result.h
@@ -34,13 +34,13 @@ struct in_in_result {
 
   template <class _InIter3, class _InIter4>
     requires convertible_to<const _InIter1&, _InIter3> && convertible_to<const _InIter2&, _InIter4>
-  _LIBCPP_HIDE_FROM_ABI constexpr operator in_in_result<_InIter3, _InIter4>() const& {
+  constexpr operator in_in_result<_InIter3, _InIter4>() const& {
     return {in1, in2};
   }
 
   template <class _InIter3, class _InIter4>
     requires convertible_to<_InIter1, _InIter3> && convertible_to<_InIter2, _InIter4>
-  _LIBCPP_HIDE_FROM_ABI constexpr operator in_in_result<_InIter3, _InIter4>() && {
+  constexpr operator in_in_result<_InIter3, _InIter4>() && {
     return {std::move(in1), std::move(in2)};
   }
 };

--- a/libcxx/include/__algorithm/in_out_out_result.h
+++ b/libcxx/include/__algorithm/in_out_out_result.h
@@ -35,14 +35,14 @@ struct in_out_out_result {
   template <class _InIter2, class _OutIter3, class _OutIter4>
     requires convertible_to<const _InIter1&, _InIter2> && convertible_to<const _OutIter1&, _OutIter3> &&
              convertible_to<const _OutIter2&, _OutIter4>
-  _LIBCPP_HIDE_FROM_ABI constexpr operator in_out_out_result<_InIter2, _OutIter3, _OutIter4>() const& {
+  constexpr operator in_out_out_result<_InIter2, _OutIter3, _OutIter4>() const& {
     return {in, out1, out2};
   }
 
   template <class _InIter2, class _OutIter3, class _OutIter4>
     requires convertible_to<_InIter1, _InIter2> && convertible_to<_OutIter1, _OutIter3> &&
              convertible_to<_OutIter2, _OutIter4>
-  _LIBCPP_HIDE_FROM_ABI constexpr operator in_out_out_result<_InIter2, _OutIter3, _OutIter4>() && {
+  constexpr operator in_out_out_result<_InIter2, _OutIter3, _OutIter4>() && {
     return {std::move(in), std::move(out1), std::move(out2)};
   }
 };

--- a/libcxx/include/__algorithm/in_out_result.h
+++ b/libcxx/include/__algorithm/in_out_result.h
@@ -34,13 +34,13 @@ struct in_out_result {
 
   template <class _InIter2, class _OutIter2>
     requires convertible_to<const _InIter1&, _InIter2> && convertible_to<const _OutIter1&, _OutIter2>
-  _LIBCPP_HIDE_FROM_ABI constexpr operator in_out_result<_InIter2, _OutIter2>() const& {
+  constexpr operator in_out_result<_InIter2, _OutIter2>() const& {
     return {in, out};
   }
 
   template <class _InIter2, class _OutIter2>
     requires convertible_to<_InIter1, _InIter2> && convertible_to<_OutIter1, _OutIter2>
-  _LIBCPP_HIDE_FROM_ABI constexpr operator in_out_result<_InIter2, _OutIter2>() && {
+  constexpr operator in_out_result<_InIter2, _OutIter2>() && {
     return {std::move(in), std::move(out)};
   }
 };

--- a/libcxx/include/__algorithm/includes.h
+++ b/libcxx/include/__algorithm/includes.h
@@ -27,7 +27,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Iter1, class _Sent1, class _Iter2, class _Sent2, class _Comp, class _Proj1, class _Proj2>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __includes(
+_LIBCPP_CONSTEXPR_SINCE_CXX20 bool __includes(
     _Iter1 __first1,
     _Sent1 __last1,
     _Iter2 __first2,
@@ -46,7 +46,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __includes(
 }
 
 template <class _InputIterator1, class _InputIterator2, class _Compare>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 includes(_InputIterator1 __first1,
          _InputIterator1 __last1,
          _InputIterator2 __first2,
@@ -66,7 +66,7 @@ includes(_InputIterator1 __first1,
 }
 
 template <class _InputIterator1, class _InputIterator2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 includes(_InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2, _InputIterator2 __last2) {
   return std::includes(std::move(__first1), std::move(__last1), std::move(__first2), std::move(__last2), __less<>());
 }

--- a/libcxx/include/__algorithm/inplace_merge.h
+++ b/libcxx/include/__algorithm/inplace_merge.h
@@ -45,17 +45,17 @@ private:
   _Predicate __p_;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 __invert() {}
+  _LIBCPP_CONSTEXPR_SINCE_CXX26 __invert() {}
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 explicit __invert(_Predicate __p) : __p_(__p) {}
+  _LIBCPP_CONSTEXPR_SINCE_CXX26 explicit __invert(_Predicate __p) : __p_(__p) {}
 
   template <class _T1>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 bool operator()(const _T1& __x) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX26 bool operator()(const _T1& __x) {
     return !__p_(__x);
   }
 
   template <class _T1, class _T2>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 bool operator()(const _T1& __x, const _T2& __y) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX26 bool operator()(const _T1& __x, const _T2& __y) {
     return __p_(__y, __x);
   }
 };
@@ -67,7 +67,7 @@ template <class _AlgPolicy,
           class _InputIterator2,
           class _Sent2,
           class _OutputIterator>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void __half_inplace_merge(
+_LIBCPP_CONSTEXPR_SINCE_CXX26 void __half_inplace_merge(
     _InputIterator1 __first1,
     _Sent1 __last1,
     _InputIterator2 __first2,
@@ -92,7 +92,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void __half_inplace_merge(
 }
 
 template <class _AlgPolicy, class _Compare, class _BidirectionalIterator>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void __buffered_inplace_merge(
+_LIBCPP_CONSTEXPR_SINCE_CXX26 void __buffered_inplace_merge(
     _BidirectionalIterator __first,
     _BidirectionalIterator __middle,
     _BidirectionalIterator __last,
@@ -204,7 +204,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX26 void __inplace_merge(
 }
 
 template <class _AlgPolicy, class _BidirectionalIterator, class _Compare>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void __inplace_merge(
+_LIBCPP_CONSTEXPR_SINCE_CXX26 void __inplace_merge(
     _BidirectionalIterator __first, _BidirectionalIterator __middle, _BidirectionalIterator __last, _Compare&& __comp) {
   typedef typename iterator_traits<_BidirectionalIterator>::value_type value_type;
   typedef typename iterator_traits<_BidirectionalIterator>::difference_type difference_type;
@@ -224,14 +224,14 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void __inplace_merge(
 }
 
 template <class _BidirectionalIterator, class _Compare>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void inplace_merge(
+inline _LIBCPP_CONSTEXPR_SINCE_CXX26 void inplace_merge(
     _BidirectionalIterator __first, _BidirectionalIterator __middle, _BidirectionalIterator __last, _Compare __comp) {
   std::__inplace_merge<_ClassicAlgPolicy>(
       std::move(__first), std::move(__middle), std::move(__last), static_cast<__comp_ref_type<_Compare> >(__comp));
 }
 
 template <class _BidirectionalIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void
+inline _LIBCPP_CONSTEXPR_SINCE_CXX26 void
 inplace_merge(_BidirectionalIterator __first, _BidirectionalIterator __middle, _BidirectionalIterator __last) {
   std::inplace_merge(std::move(__first), std::move(__middle), std::move(__last), __less<>());
 }

--- a/libcxx/include/__algorithm/is_heap.h
+++ b/libcxx/include/__algorithm/is_heap.h
@@ -21,13 +21,13 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _RandomAccessIterator, class _Compare>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 is_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
   return std::__is_heap_until(__first, __last, static_cast<__comp_ref_type<_Compare> >(__comp)) == __last;
 }
 
 template <class _RandomAccessIterator>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 is_heap(_RandomAccessIterator __first, _RandomAccessIterator __last) {
   return std::is_heap(__first, __last, __less<>());
 }

--- a/libcxx/include/__algorithm/is_heap_until.h
+++ b/libcxx/include/__algorithm/is_heap_until.h
@@ -21,7 +21,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Compare, class _RandomAccessIterator>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _RandomAccessIterator
+_LIBCPP_CONSTEXPR_SINCE_CXX20 _RandomAccessIterator
 __is_heap_until(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare&& __comp) {
   typedef typename iterator_traits<_RandomAccessIterator>::difference_type difference_type;
   difference_type __len      = __last - __first;
@@ -46,13 +46,13 @@ __is_heap_until(_RandomAccessIterator __first, _RandomAccessIterator __last, _Co
 }
 
 template <class _RandomAccessIterator, class _Compare>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _RandomAccessIterator
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _RandomAccessIterator
 is_heap_until(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
   return std::__is_heap_until(__first, __last, static_cast<__comp_ref_type<_Compare> >(__comp));
 }
 
 template <class _RandomAccessIterator>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _RandomAccessIterator
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _RandomAccessIterator
 is_heap_until(_RandomAccessIterator __first, _RandomAccessIterator __last) {
   return std::__is_heap_until(__first, __last, __less<>());
 }

--- a/libcxx/include/__algorithm/is_partitioned.h
+++ b/libcxx/include/__algorithm/is_partitioned.h
@@ -18,7 +18,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _InputIterator, class _Predicate>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
+[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 is_partitioned(_InputIterator __first, _InputIterator __last, _Predicate __pred) {
   for (; __first != __last; ++__first)
     if (!__pred(*__first))

--- a/libcxx/include/__algorithm/is_permutation.h
+++ b/libcxx/include/__algorithm/is_permutation.h
@@ -70,7 +70,7 @@ template <class _AlgPolicy,
           class _Proj1,
           class _Proj2,
           class _Pred>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __is_permutation_impl(
+_LIBCPP_CONSTEXPR_SINCE_CXX20 bool __is_permutation_impl(
     _Iter1 __first1,
     _Sent1 __last1,
     _Iter2 __first2,
@@ -114,7 +114,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __is_permutation_impl(
 
 // 2+1 iterators, predicate. Not used by range algorithms.
 template <class _AlgPolicy, class _ForwardIterator1, class _Sentinel1, class _ForwardIterator2, class _BinaryPredicate>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __is_permutation(
+[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __is_permutation(
     _ForwardIterator1 __first1, _Sentinel1 __last1, _ForwardIterator2 __first2, _BinaryPredicate&& __pred) {
   // Shorten sequences as much as possible by lopping of any equal prefix.
   for (; __first1 != __last1; ++__first1, (void)++__first2) {
@@ -151,7 +151,7 @@ template <class _AlgPolicy,
           class _Proj1,
           class _Proj2,
           class _Pred>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __is_permutation(
+_LIBCPP_CONSTEXPR_SINCE_CXX20 bool __is_permutation(
     _Iter1 __first1,
     _Sent1 __last1,
     _Iter2 __first2,
@@ -194,7 +194,7 @@ template <class _AlgPolicy,
           class _Proj1,
           class _Proj2,
           class _Pred>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __is_permutation(
+_LIBCPP_CONSTEXPR_SINCE_CXX20 bool __is_permutation(
     _Iter1 __first1,
     _Sent1 __last1,
     _Iter2 __first2,
@@ -225,7 +225,7 @@ template <class _AlgPolicy,
           class _Proj1,
           class _Proj2,
           class _Pred>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __is_permutation(
+_LIBCPP_CONSTEXPR_SINCE_CXX20 bool __is_permutation(
     _Iter1 __first1,
     _Sent1 __last1,
     _Iter2 __first2,
@@ -248,7 +248,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __is_permutation(
 
 // 2+1 iterators, predicate
 template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool is_permutation(
+[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX20 bool is_permutation(
     _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _BinaryPredicate __pred) {
   static_assert(__is_callable<_BinaryPredicate&, decltype(*__first1), decltype(*__first2)>::value,
                 "The comparator has to be callable");
@@ -258,7 +258,7 @@ template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredica
 
 // 2+1 iterators
 template <class _ForwardIterator1, class _ForwardIterator2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 is_permutation(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2) {
   return std::is_permutation(__first1, __last1, __first2, __equal_to());
 }
@@ -267,7 +267,7 @@ is_permutation(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIt
 
 // 2+2 iterators
 template <class _ForwardIterator1, class _ForwardIterator2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool is_permutation(
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool is_permutation(
     _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2) {
   return std::__is_permutation<_ClassicAlgPolicy>(
       std::move(__first1),
@@ -281,7 +281,7 @@ template <class _ForwardIterator1, class _ForwardIterator2>
 
 // 2+2 iterators, predicate
 template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool is_permutation(
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool is_permutation(
     _ForwardIterator1 __first1,
     _ForwardIterator1 __last1,
     _ForwardIterator2 __first2,

--- a/libcxx/include/__algorithm/is_sorted.h
+++ b/libcxx/include/__algorithm/is_sorted.h
@@ -21,13 +21,13 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _ForwardIterator, class _Compare>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 is_sorted(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp) {
   return std::__is_sorted_until<__comp_ref_type<_Compare> >(__first, __last, __comp) == __last;
 }
 
 template <class _ForwardIterator>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 is_sorted(_ForwardIterator __first, _ForwardIterator __last) {
   return std::is_sorted(__first, __last, __less<>());
 }

--- a/libcxx/include/__algorithm/is_sorted_until.h
+++ b/libcxx/include/__algorithm/is_sorted_until.h
@@ -20,7 +20,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Compare, class _ForwardIterator>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
+_LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 __is_sorted_until(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp) {
   if (__first != __last) {
     _ForwardIterator __i = __first;
@@ -34,13 +34,13 @@ __is_sorted_until(_ForwardIterator __first, _ForwardIterator __last, _Compare __
 }
 
 template <class _ForwardIterator, class _Compare>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 is_sorted_until(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp) {
   return std::__is_sorted_until<__comp_ref_type<_Compare> >(__first, __last, __comp);
 }
 
 template <class _ForwardIterator>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 is_sorted_until(_ForwardIterator __first, _ForwardIterator __last) {
   return std::is_sorted_until(__first, __last, __less<>());
 }

--- a/libcxx/include/__algorithm/iter_swap.h
+++ b/libcxx/include/__algorithm/iter_swap.h
@@ -20,7 +20,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _ForwardIterator1, class _ForwardIterator2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void iter_swap(_ForwardIterator1 __a, _ForwardIterator2 __b)
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void iter_swap(_ForwardIterator1 __a, _ForwardIterator2 __b)
     //                                  _NOEXCEPT_(_NOEXCEPT_(swap(*__a, *__b)))
     _NOEXCEPT_(_NOEXCEPT_(swap(*std::declval<_ForwardIterator1>(), *std::declval<_ForwardIterator2>()))) {
   swap(*__a, *__b);

--- a/libcxx/include/__algorithm/iterator_operations.h
+++ b/libcxx/include/__algorithm/iterator_operations.h
@@ -82,13 +82,13 @@ struct _IterOps<_ClassicAlgPolicy> {
 
   // advance
   template <class _Iter, class _Distance>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 static void advance(_Iter& __iter, _Distance __count) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 static void advance(_Iter& __iter, _Distance __count) {
     std::advance(__iter, __count);
   }
 
   // distance
   template <class _Iter>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 static typename iterator_traits<_Iter>::difference_type
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 static typename iterator_traits<_Iter>::difference_type
   distance(_Iter __first, _Iter __last) {
     return std::distance(__first, __last);
   }
@@ -100,7 +100,7 @@ struct _IterOps<_ClassicAlgPolicy> {
   using __move_t _LIBCPP_NODEBUG = decltype(std::move(*std::declval<_Iter&>()));
 
   template <class _Iter>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 static void __validate_iter_reference() {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 static void __validate_iter_reference() {
     static_assert(
         is_same<__deref_t<_Iter>, typename iterator_traits<__remove_cvref_t<_Iter> >::reference>::value,
         "It looks like your iterator's `iterator_traits<It>::reference` does not match the return type of "
@@ -110,23 +110,21 @@ struct _IterOps<_ClassicAlgPolicy> {
 
   // iter_move
   template <class _Iter, __enable_if_t<is_reference<__deref_t<_Iter> >::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 static
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 static
       // If the result of dereferencing `_Iter` is a reference type, deduce the result of calling `std::move` on it.
       // Note that the C++03 mode doesn't support `decltype(auto)` as the return type.
-      __move_t<_Iter>
-      __iter_move(_Iter&& __i) {
+      __move_t<_Iter> __iter_move(_Iter&& __i) {
     __validate_iter_reference<_Iter>();
 
     return std::move(*std::forward<_Iter>(__i));
   }
 
   template <class _Iter, __enable_if_t<!is_reference<__deref_t<_Iter> >::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 static
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 static
       // If the result of dereferencing `_Iter` is a value type, deduce the return value of this function to also be a
       // value -- otherwise, after `operator*` returns a temporary, this function would return a dangling reference to
       // that temporary. Note that the C++03 mode doesn't support `auto` as the return type.
-      __deref_t<_Iter>
-      __iter_move(_Iter&& __i) {
+      __deref_t<_Iter> __iter_move(_Iter&& __i) {
     __validate_iter_reference<_Iter>();
 
     return *std::forward<_Iter>(__i);
@@ -134,37 +132,37 @@ struct _IterOps<_ClassicAlgPolicy> {
 
   // iter_swap
   template <class _Iter1, class _Iter2>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 static void iter_swap(_Iter1&& __a, _Iter2&& __b) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 static void iter_swap(_Iter1&& __a, _Iter2&& __b) {
     std::iter_swap(std::forward<_Iter1>(__a), std::forward<_Iter2>(__b));
   }
 
   // next
   template <class _Iterator>
-  _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX14 _Iterator next(_Iterator, _Iterator __last) {
+  static _LIBCPP_CONSTEXPR_SINCE_CXX14 _Iterator next(_Iterator, _Iterator __last) {
     return __last;
   }
 
   template <class _Iter>
-  _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX14 __remove_cvref_t<_Iter>
+  static _LIBCPP_CONSTEXPR_SINCE_CXX14 __remove_cvref_t<_Iter>
   next(_Iter&& __it, typename iterator_traits<__remove_cvref_t<_Iter> >::difference_type __n = 1) {
     return std::next(std::forward<_Iter>(__it), __n);
   }
 
   // prev
   template <class _Iter>
-  _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX14 __remove_cvref_t<_Iter>
+  static _LIBCPP_CONSTEXPR_SINCE_CXX14 __remove_cvref_t<_Iter>
   prev(_Iter&& __iter, typename iterator_traits<__remove_cvref_t<_Iter> >::difference_type __n = 1) {
     return std::prev(std::forward<_Iter>(__iter), __n);
   }
 
   template <class _Iter>
-  _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX14 void __advance_to(_Iter& __first, _Iter __last) {
+  static _LIBCPP_CONSTEXPR_SINCE_CXX14 void __advance_to(_Iter& __first, _Iter __last) {
     __first = __last;
   }
 
   // advance with sentinel, a la std::ranges::advance
   template <class _Iter>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 static __difference_type<_Iter>
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 static __difference_type<_Iter>
   __advance_to(_Iter& __iter, __difference_type<_Iter> __count, const _Iter& __sentinel) {
     return _IterOps::__advance_to(__iter, __count, __sentinel, typename iterator_traits<_Iter>::iterator_category());
   }
@@ -172,7 +170,7 @@ struct _IterOps<_ClassicAlgPolicy> {
 private:
   // advance with sentinel, a la std::ranges::advance -- InputIterator specialization
   template <class _InputIter>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 static __difference_type<_InputIter> __advance_to(
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 static __difference_type<_InputIter> __advance_to(
       _InputIter& __iter, __difference_type<_InputIter> __count, const _InputIter& __sentinel, input_iterator_tag) {
     __difference_type<_InputIter> __dist = 0;
     for (; __dist < __count && __iter != __sentinel; ++__dist)
@@ -182,7 +180,7 @@ private:
 
   // advance with sentinel, a la std::ranges::advance -- BidirectionalIterator specialization
   template <class _BiDirIter>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 static __difference_type<_BiDirIter>
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 static __difference_type<_BiDirIter>
   __advance_to(_BiDirIter& __iter,
                __difference_type<_BiDirIter> __count,
                const _BiDirIter& __sentinel,
@@ -199,7 +197,7 @@ private:
 
   // advance with sentinel, a la std::ranges::advance -- RandomIterator specialization
   template <class _RandIter>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 static __difference_type<_RandIter>
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 static __difference_type<_RandIter>
   __advance_to(_RandIter& __iter,
                __difference_type<_RandIter> __count,
                const _RandIter& __sentinel,

--- a/libcxx/include/__algorithm/lexicographical_compare.h
+++ b/libcxx/include/__algorithm/lexicographical_compare.h
@@ -40,7 +40,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Iter1, class _Sent1, class _Iter2, class _Sent2, class _Proj1, class _Proj2, class _Comp>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __lexicographical_compare(
+_LIBCPP_CONSTEXPR_SINCE_CXX20 bool __lexicographical_compare(
     _Iter1 __first1, _Sent1 __last1, _Iter2 __first2, _Sent2 __last2, _Comp& __comp, _Proj1& __proj1, _Proj2& __proj2) {
   while (__first2 != __last2) {
     if (__first1 == __last1 ||
@@ -69,7 +69,7 @@ template <class _Tp,
                             __is_trivially_equality_comparable_v<_Tp, _Tp> && __is_identity<_Proj1>::value &&
                             __is_identity<_Proj2>::value,
                         int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
+_LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 __lexicographical_compare(_Tp* __first1, _Tp* __last1, _Tp* __first2, _Tp* __last2, _Comp&, _Proj1&, _Proj2&) {
   if constexpr (__is_trivially_lexicographically_comparable_v<_Tp, _Tp>) {
     auto __res =
@@ -99,7 +99,7 @@ __lexicographical_compare(_Tp* __first1, _Tp* __last1, _Tp* __first2, _Tp* __las
 #endif // _LIBCPP_STD_VER >= 14
 
 template <class _InputIterator1, class _InputIterator2, class _Compare>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool lexicographical_compare(
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool lexicographical_compare(
     _InputIterator1 __first1,
     _InputIterator1 __last1,
     _InputIterator2 __first2,
@@ -117,7 +117,7 @@ template <class _InputIterator1, class _InputIterator2, class _Compare>
 }
 
 template <class _InputIterator1, class _InputIterator2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool lexicographical_compare(
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool lexicographical_compare(
     _InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2, _InputIterator2 __last2) {
   return std::lexicographical_compare(__first1, __last1, __first2, __last2, __less<>());
 }

--- a/libcxx/include/__algorithm/lexicographical_compare_three_way.h
+++ b/libcxx/include/__algorithm/lexicographical_compare_three_way.h
@@ -34,7 +34,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // Fast path for random access iterators which computes the number of loop iterations up-front and
 // then skips the iterator comparisons inside the loop.
 template <class _InputIterator1, class _InputIterator2, class _Cmp>
-_LIBCPP_HIDE_FROM_ABI constexpr auto __lexicographical_compare_three_way_fast_path(
+constexpr auto __lexicographical_compare_three_way_fast_path(
     _InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2, _InputIterator2 __last2, _Cmp& __comp)
     -> decltype(__comp(*__first1, *__first2)) {
   static_assert(signed_integral<__iterator_difference_type<_InputIterator1>>,
@@ -64,7 +64,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr auto __lexicographical_compare_three_way_fast_pa
 
 // Unoptimized implementation which compares the iterators against the end in every loop iteration
 template <class _InputIterator1, class _InputIterator2, class _Cmp>
-_LIBCPP_HIDE_FROM_ABI constexpr auto __lexicographical_compare_three_way_slow_path(
+constexpr auto __lexicographical_compare_three_way_slow_path(
     _InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2, _InputIterator2 __last2, _Cmp& __comp)
     -> decltype(__comp(*__first1, *__first2)) {
   while (true) {
@@ -90,7 +90,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr auto __lexicographical_compare_three_way_slow_pa
 }
 
 template <class _InputIterator1, class _InputIterator2, class _Cmp>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto lexicographical_compare_three_way(
+[[nodiscard]] constexpr auto lexicographical_compare_three_way(
     _InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2, _InputIterator2 __last2, _Cmp __comp)
     -> decltype(__comp(*__first1, *__first2)) {
   static_assert(__comparison_category<decltype(__comp(*__first1, *__first2))>,
@@ -110,7 +110,7 @@ template <class _InputIterator1, class _InputIterator2, class _Cmp>
 }
 
 template <class _InputIterator1, class _InputIterator2>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto lexicographical_compare_three_way(
+[[nodiscard]] constexpr auto lexicographical_compare_three_way(
     _InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2, _InputIterator2 __last2) {
   return std::lexicographical_compare_three_way(
       std::move(__first1), std::move(__last1), std::move(__first2), std::move(__last2), std::compare_three_way());

--- a/libcxx/include/__algorithm/lower_bound.h
+++ b/libcxx/include/__algorithm/lower_bound.h
@@ -27,7 +27,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, class _Iter, class _Type, class _Proj, class _Comp>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _Iter __lower_bound_bisecting(
+[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX20 _Iter __lower_bound_bisecting(
     _Iter __first,
     const _Type& __value,
     typename iterator_traits<_Iter>::difference_type __len,
@@ -57,7 +57,7 @@ template <class _AlgPolicy, class _Iter, class _Type, class _Proj, class _Comp>
 // whereas the one-sided version will yield O(n) operations on both counts, with a \Omega(log(n)) bound on the number of
 // comparisons.
 template <class _AlgPolicy, class _ForwardIterator, class _Sent, class _Type, class _Proj, class _Comp>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
+[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 __lower_bound_onesided(_ForwardIterator __first, _Sent __last, const _Type& __value, _Comp& __comp, _Proj& __proj) {
   // step = 0, ensuring we can always short-circuit when distance is 1 later on
   if (__first == __last || !std::__invoke(__comp, std::__invoke(__proj, *__first), __value))
@@ -83,14 +83,14 @@ __lower_bound_onesided(_ForwardIterator __first, _Sent __last, const _Type& __va
 }
 
 template <class _AlgPolicy, class _ForwardIterator, class _Sent, class _Type, class _Proj, class _Comp>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 __lower_bound(_ForwardIterator __first, _Sent __last, const _Type& __value, _Comp& __comp, _Proj& __proj) {
   const auto __dist = _IterOps<_AlgPolicy>::distance(__first, __last);
   return std::__lower_bound_bisecting<_AlgPolicy>(__first, __value, __dist, __comp, __proj);
 }
 
 template <class _ForwardIterator, class _Tp, class _Compare>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 lower_bound(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value, _Compare __comp) {
   static_assert(__is_callable<_Compare&, decltype(*__first), const _Tp&>::value, "The comparator has to be callable");
   auto __proj = std::__identity();
@@ -98,7 +98,7 @@ lower_bound(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __valu
 }
 
 template <class _ForwardIterator, class _Tp>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 lower_bound(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) {
   return std::lower_bound(__first, __last, __value, __less<>());
 }

--- a/libcxx/include/__algorithm/make_heap.h
+++ b/libcxx/include/__algorithm/make_heap.h
@@ -29,7 +29,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, class _Compare, class _RandomAccessIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 void
 __make_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare&& __comp) {
   __comp_ref_type<_Compare> __comp_ref = __comp;
 
@@ -54,14 +54,13 @@ __make_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compar
 }
 
 template <class _RandomAccessIterator, class _Compare>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 make_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
   std::__make_heap<_ClassicAlgPolicy>(std::move(__first), std::move(__last), __comp);
 }
 
 template <class _RandomAccessIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
-make_heap(_RandomAccessIterator __first, _RandomAccessIterator __last) {
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void make_heap(_RandomAccessIterator __first, _RandomAccessIterator __last) {
   std::make_heap(std::move(__first), std::move(__last), __less<>());
 }
 

--- a/libcxx/include/__algorithm/make_projected.h
+++ b/libcxx/include/__algorithm/make_projected.h
@@ -30,12 +30,11 @@ struct _ProjectedPred {
   _Pred& __pred; // Can be a unary or a binary predicate.
   _Proj& __proj;
 
-  _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI _ProjectedPred(_Pred& __pred_arg, _Proj& __proj_arg)
-      : __pred(__pred_arg), __proj(__proj_arg) {}
+  _LIBCPP_CONSTEXPR _ProjectedPred(_Pred& __pred_arg, _Proj& __proj_arg) : __pred(__pred_arg), __proj(__proj_arg) {}
 
   template <class _Tp>
   __invoke_result_t<_Pred&, decltype(std::__invoke(std::declval<_Proj&>(), std::declval<_Tp>()))> _LIBCPP_CONSTEXPR
-  _LIBCPP_HIDE_FROM_ABI
+
   operator()(_Tp&& __v) const {
     return std::__invoke(__pred, std::__invoke(__proj, std::forward<_Tp>(__v)));
   }
@@ -44,7 +43,7 @@ struct _ProjectedPred {
   __invoke_result_t<_Pred&,
                     decltype(std::__invoke(std::declval<_Proj&>(), std::declval<_T1>())),
                     decltype(std::__invoke(std::declval<_Proj&>(), std::declval<_T2>()))> _LIBCPP_CONSTEXPR
-  _LIBCPP_HIDE_FROM_ABI
+
   operator()(_T1&& __lhs, _T2&& __rhs) const {
     return std::__invoke(
         __pred, std::__invoke(__proj, std::forward<_T1>(__lhs)), std::__invoke(__proj, std::forward<_T2>(__rhs)));
@@ -55,7 +54,7 @@ template <
     class _Pred,
     class _Proj,
     __enable_if_t<!(!is_member_pointer<__decay_t<_Pred> >::value && __is_identity<__decay_t<_Proj> >::value), int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _ProjectedPred<_Pred, _Proj> __make_projected(_Pred& __pred, _Proj& __proj) {
+_LIBCPP_CONSTEXPR _ProjectedPred<_Pred, _Proj> __make_projected(_Pred& __pred, _Proj& __proj) {
   return _ProjectedPred<_Pred, _Proj>(__pred, __proj);
 }
 
@@ -66,7 +65,7 @@ template <
     class _Pred,
     class _Proj,
     __enable_if_t<!is_member_pointer<__decay_t<_Pred> >::value && __is_identity<__decay_t<_Proj> >::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _Pred& __make_projected(_Pred& __pred, _Proj&) {
+_LIBCPP_CONSTEXPR _Pred& __make_projected(_Pred& __pred, _Proj&) {
   return __pred;
 }
 
@@ -79,7 +78,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 
 template <class _Comp, class _Proj1, class _Proj2>
-_LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) __make_projected_comp(_Comp& __comp, _Proj1& __proj1, _Proj2& __proj2) {
+constexpr decltype(auto) __make_projected_comp(_Comp& __comp, _Proj1& __proj1, _Proj2& __proj2) {
   if constexpr (__is_identity<decay_t<_Proj1>>::value && __is_identity<decay_t<_Proj2>>::value &&
                 !is_member_pointer_v<decay_t<_Comp>>) {
     // Avoid creating the lambda and just use the pristine comparator -- for certain algorithms, this would enable

--- a/libcxx/include/__algorithm/max.h
+++ b/libcxx/include/__algorithm/max.h
@@ -25,13 +25,13 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, class _Compare>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Tp&
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Tp&
 max(_LIBCPP_LIFETIMEBOUND const _Tp& __a, _LIBCPP_LIFETIMEBOUND const _Tp& __b, _Compare __comp) {
   return __comp(__a, __b) ? __b : __a;
 }
 
 template <class _Tp>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Tp&
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Tp&
 max(_LIBCPP_LIFETIMEBOUND const _Tp& __a, _LIBCPP_LIFETIMEBOUND const _Tp& __b) {
   return std::max(__a, __b, __less<>());
 }
@@ -39,13 +39,12 @@ max(_LIBCPP_LIFETIMEBOUND const _Tp& __a, _LIBCPP_LIFETIMEBOUND const _Tp& __b) 
 #ifndef _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Compare>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp
-max(initializer_list<_Tp> __t, _Compare __comp) {
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp max(initializer_list<_Tp> __t, _Compare __comp) {
   return *std::__max_element<__comp_ref_type<_Compare> >(__t.begin(), __t.end(), __comp);
 }
 
 template <class _Tp>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp max(initializer_list<_Tp> __t) {
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp max(initializer_list<_Tp> __t) {
   return *std::max_element(__t.begin(), __t.end(), __less<>());
 }
 

--- a/libcxx/include/__algorithm/max_element.h
+++ b/libcxx/include/__algorithm/max_element.h
@@ -22,7 +22,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Compare, class _ForwardIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator
 __max_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp) {
   static_assert(
       __has_forward_iterator_category<_ForwardIterator>::value, "std::max_element requires a ForwardIterator");
@@ -36,7 +36,7 @@ __max_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp
 }
 
 template <class _ForwardIterator, class _Compare>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator
 max_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp) {
   static_assert(
       __is_callable<_Compare&, decltype(*__first), decltype(*__first)>::value, "The comparator has to be callable");
@@ -44,7 +44,7 @@ max_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp) 
 }
 
 template <class _ForwardIterator>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator
 max_element(_ForwardIterator __first, _ForwardIterator __last) {
   return std::max_element(__first, __last, __less<>());
 }

--- a/libcxx/include/__algorithm/merge.h
+++ b/libcxx/include/__algorithm/merge.h
@@ -21,7 +21,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Compare, class _InputIterator1, class _InputIterator2, class _OutputIterator>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator __merge(
+_LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator __merge(
     _InputIterator1 __first1,
     _InputIterator1 __last1,
     _InputIterator2 __first2,
@@ -43,7 +43,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator __merge(
 }
 
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator, class _Compare>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
 merge(_InputIterator1 __first1,
       _InputIterator1 __last1,
       _InputIterator2 __first2,
@@ -54,7 +54,7 @@ merge(_InputIterator1 __first1,
 }
 
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
 merge(_InputIterator1 __first1,
       _InputIterator1 __last1,
       _InputIterator2 __first2,

--- a/libcxx/include/__algorithm/min.h
+++ b/libcxx/include/__algorithm/min.h
@@ -25,13 +25,13 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, class _Compare>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Tp&
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Tp&
 min(_LIBCPP_LIFETIMEBOUND const _Tp& __a, _LIBCPP_LIFETIMEBOUND const _Tp& __b, _Compare __comp) {
   return __comp(__b, __a) ? __b : __a;
 }
 
 template <class _Tp>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Tp&
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Tp&
 min(_LIBCPP_LIFETIMEBOUND const _Tp& __a, _LIBCPP_LIFETIMEBOUND const _Tp& __b) {
   return std::min(__a, __b, __less<>());
 }
@@ -39,13 +39,12 @@ min(_LIBCPP_LIFETIMEBOUND const _Tp& __a, _LIBCPP_LIFETIMEBOUND const _Tp& __b) 
 #ifndef _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Compare>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp
-min(initializer_list<_Tp> __t, _Compare __comp) {
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp min(initializer_list<_Tp> __t, _Compare __comp) {
   return *std::__min_element<__comp_ref_type<_Compare> >(__t.begin(), __t.end(), __comp);
 }
 
 template <class _Tp>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp min(initializer_list<_Tp> __t) {
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp min(initializer_list<_Tp> __t) {
   return *std::min_element(__t.begin(), __t.end(), __less<>());
 }
 

--- a/libcxx/include/__algorithm/min_element.h
+++ b/libcxx/include/__algorithm/min_element.h
@@ -28,8 +28,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Comp, class _Iter, class _Sent, class _Proj>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Iter
-__min_element(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 _Iter __min_element(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
   if (__first == __last)
     return __first;
 
@@ -42,13 +41,13 @@ __min_element(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
 }
 
 template <class _Comp, class _Iter, class _Sent>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Iter __min_element(_Iter __first, _Sent __last, _Comp __comp) {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 _Iter __min_element(_Iter __first, _Sent __last, _Comp __comp) {
   auto __proj = __identity();
   return std::__min_element<_Comp>(std::move(__first), std::move(__last), __comp, __proj);
 }
 
 template <class _ForwardIterator, class _Compare>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator
 min_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp) {
   static_assert(
       __has_forward_iterator_category<_ForwardIterator>::value, "std::min_element requires a ForwardIterator");
@@ -59,7 +58,7 @@ min_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp) 
 }
 
 template <class _ForwardIterator>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator
 min_element(_ForwardIterator __first, _ForwardIterator __last) {
   return std::min_element(__first, __last, __less<>());
 }

--- a/libcxx/include/__algorithm/min_max_result.h
+++ b/libcxx/include/__algorithm/min_max_result.h
@@ -34,13 +34,13 @@ struct min_max_result {
 
   template <class _T2>
     requires convertible_to<const _T1&, _T2>
-  _LIBCPP_HIDE_FROM_ABI constexpr operator min_max_result<_T2>() const& {
+  constexpr operator min_max_result<_T2>() const& {
     return {min, max};
   }
 
   template <class _T2>
     requires convertible_to<_T1, _T2>
-  _LIBCPP_HIDE_FROM_ABI constexpr operator min_max_result<_T2>() && {
+  constexpr operator min_max_result<_T2>() && {
     return {std::move(min), std::move(max)};
   }
 };

--- a/libcxx/include/__algorithm/minmax.h
+++ b/libcxx/include/__algorithm/minmax.h
@@ -24,13 +24,13 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, class _Compare>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<const _Tp&, const _Tp&>
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<const _Tp&, const _Tp&>
 minmax(_LIBCPP_LIFETIMEBOUND const _Tp& __a, _LIBCPP_LIFETIMEBOUND const _Tp& __b, _Compare __comp) {
   return __comp(__b, __a) ? pair<const _Tp&, const _Tp&>(__b, __a) : pair<const _Tp&, const _Tp&>(__a, __b);
 }
 
 template <class _Tp>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<const _Tp&, const _Tp&>
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<const _Tp&, const _Tp&>
 minmax(_LIBCPP_LIFETIMEBOUND const _Tp& __a, _LIBCPP_LIFETIMEBOUND const _Tp& __b) {
   return std::minmax(__a, __b, __less<>());
 }
@@ -38,8 +38,8 @@ minmax(_LIBCPP_LIFETIMEBOUND const _Tp& __a, _LIBCPP_LIFETIMEBOUND const _Tp& __
 #ifndef _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Compare>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Tp, _Tp>
-minmax(initializer_list<_Tp> __t, _Compare __comp) {
+[[__nodiscard__]] inline
+    _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Tp, _Tp> minmax(initializer_list<_Tp> __t, _Compare __comp) {
   static_assert(__is_callable<_Compare&, _Tp, _Tp>::value, "The comparator has to be callable");
   __identity __proj;
   auto __ret = std::__minmax_element_impl(__t.begin(), __t.end(), __comp, __proj);
@@ -47,8 +47,7 @@ minmax(initializer_list<_Tp> __t, _Compare __comp) {
 }
 
 template <class _Tp>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Tp, _Tp>
-minmax(initializer_list<_Tp> __t) {
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Tp, _Tp> minmax(initializer_list<_Tp> __t) {
   return std::minmax(__t, __less<>());
 }
 

--- a/libcxx/include/__algorithm/minmax_element.h
+++ b/libcxx/include/__algorithm/minmax_element.h
@@ -29,17 +29,16 @@ class _MinmaxElementLessFunc {
   _Proj& __proj_;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _MinmaxElementLessFunc(_Comp& __comp, _Proj& __proj)
-      : __comp_(__comp), __proj_(__proj) {}
+  _LIBCPP_CONSTEXPR _MinmaxElementLessFunc(_Comp& __comp, _Proj& __proj) : __comp_(__comp), __proj_(__proj) {}
 
   template <class _Iter>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator()(_Iter& __it1, _Iter& __it2) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator()(_Iter& __it1, _Iter& __it2) {
     return std::__invoke(__comp_, std::__invoke(__proj_, *__it1), std::__invoke(__proj_, *__it2));
   }
 };
 
 template <class _Iter, class _Sent, class _Proj, class _Comp>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter, _Iter>
+_LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter, _Iter>
 __minmax_element_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
   auto __less = _MinmaxElementLessFunc<_Comp, _Proj>(__comp, __proj);
 
@@ -79,7 +78,7 @@ __minmax_element_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj)
 }
 
 template <class _ForwardIterator, class _Compare>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_ForwardIterator, _ForwardIterator>
+[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_ForwardIterator, _ForwardIterator>
 minmax_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp) {
   static_assert(
       __has_forward_iterator_category<_ForwardIterator>::value, "std::minmax_element requires a ForwardIterator");
@@ -90,7 +89,7 @@ minmax_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __com
 }
 
 template <class _ForwardIterator>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_ForwardIterator, _ForwardIterator>
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_ForwardIterator, _ForwardIterator>
 minmax_element(_ForwardIterator __first, _ForwardIterator __last) {
   return std::minmax_element(__first, __last, __less<>());
 }

--- a/libcxx/include/__algorithm/mismatch.h
+++ b/libcxx/include/__algorithm/mismatch.h
@@ -38,7 +38,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Iter1, class _Sent1, class _Iter2, class _Pred, class _Proj1, class _Proj2>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_Iter1, _Iter2>
+[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_Iter1, _Iter2>
 __mismatch_loop(_Iter1 __first1, _Sent1 __last1, _Iter2 __first2, _Pred& __pred, _Proj1& __proj1, _Proj2& __proj2) {
   while (__first1 != __last1) {
     if (!std::__invoke(__pred, std::__invoke(__proj1, *__first1), std::__invoke(__proj2, *__first2)))
@@ -50,7 +50,7 @@ __mismatch_loop(_Iter1 __first1, _Sent1 __last1, _Iter2 __first2, _Pred& __pred,
 }
 
 template <class _Iter1, class _Sent1, class _Iter2, class _Pred, class _Proj1, class _Proj2>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_Iter1, _Iter2>
+[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_Iter1, _Iter2>
 __mismatch(_Iter1 __first1, _Sent1 __last1, _Iter2 __first2, _Pred& __pred, _Proj1& __proj1, _Proj2& __proj2) {
   return std::__mismatch_loop(__first1, __last1, __first2, __pred, __proj1, __proj2);
 }
@@ -58,8 +58,8 @@ __mismatch(_Iter1 __first1, _Sent1 __last1, _Iter2 __first2, _Pred& __pred, _Pro
 #if _LIBCPP_VECTORIZE_ALGORITHMS
 
 template <class _Iter>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_Iter, _Iter>
-__mismatch_vectorized(_Iter __first1, _Iter __last1, _Iter __first2) {
+[[__nodiscard__]]
+_LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_Iter, _Iter> __mismatch_vectorized(_Iter __first1, _Iter __last1, _Iter __first2) {
   using __value_type              = __iterator_value_type<_Iter>;
   constexpr size_t __unroll_count = 4;
   constexpr size_t __vec_size     = __native_vector_size<__value_type>;
@@ -125,7 +125,7 @@ template <class _Tp,
           __enable_if_t<is_integral<_Tp>::value && __desugars_to_v<__equal_tag, _Pred, _Tp, _Tp> &&
                             __is_identity<_Proj1>::value && __is_identity<_Proj2>::value,
                         int> = 0>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_Tp*, _Tp*>
+[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_Tp*, _Tp*>
 __mismatch(_Tp* __first1, _Tp* __last1, _Tp* __first2, _Pred&, _Proj1&, _Proj2&) {
   return std::__mismatch_vectorized(__first1, __last1, __first2);
 }
@@ -138,7 +138,7 @@ template <class _Tp,
                             __is_identity<_Proj1>::value && __is_identity<_Proj2>::value &&
                             __can_map_to_integer_v<_Tp> && __is_trivially_equality_comparable_v<_Tp, _Tp>,
                         int> = 0>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_Tp*, _Tp*>
+[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_Tp*, _Tp*>
 __mismatch(_Tp* __first1, _Tp* __last1, _Tp* __first2, _Pred& __pred, _Proj1& __proj1, _Proj2& __proj2) {
   if (__libcpp_is_constant_evaluated()) {
     return std::__mismatch_loop(__first1, __last1, __first2, __pred, __proj1, __proj2);
@@ -151,7 +151,7 @@ __mismatch(_Tp* __first1, _Tp* __last1, _Tp* __first2, _Pred& __pred, _Proj1& __
 #endif // _LIBCPP_VECTORIZE_ALGORITHMS
 
 template <class _InputIterator1, class _InputIterator2, class _BinaryPredicate>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_InputIterator1, _InputIterator2>
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_InputIterator1, _InputIterator2>
 mismatch(_InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2, _BinaryPredicate __pred) {
   __identity __proj;
   auto __res = std::__mismatch(
@@ -160,14 +160,14 @@ mismatch(_InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __fi
 }
 
 template <class _InputIterator1, class _InputIterator2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_InputIterator1, _InputIterator2>
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_InputIterator1, _InputIterator2>
 mismatch(_InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2) {
   return std::mismatch(__first1, __last1, __first2, __equal_to());
 }
 
 #if _LIBCPP_STD_VER >= 14
 template <class _Iter1, class _Sent1, class _Iter2, class _Sent2, class _Pred, class _Proj1, class _Proj2>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_Iter1, _Iter2> __mismatch(
+[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_Iter1, _Iter2> __mismatch(
     _Iter1 __first1, _Sent1 __last1, _Iter2 __first2, _Sent2 __last2, _Pred& __pred, _Proj1& __proj1, _Proj2& __proj2) {
   while (__first1 != __last1 && __first2 != __last2) {
     if (!std::__invoke(__pred, std::__invoke(__proj1, *__first1), std::__invoke(__proj2, *__first2)))
@@ -179,14 +179,14 @@ template <class _Iter1, class _Sent1, class _Iter2, class _Sent2, class _Pred, c
 }
 
 template <class _Tp, class _Pred, class _Proj1, class _Proj2>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_Tp*, _Tp*>
+[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_Tp*, _Tp*>
 __mismatch(_Tp* __first1, _Tp* __last1, _Tp* __first2, _Tp* __last2, _Pred& __pred, _Proj1& __proj1, _Proj2& __proj2) {
   auto __len = std::min(__last1 - __first1, __last2 - __first2);
   return std::__mismatch(__first1, __first1 + __len, __first2, __pred, __proj1, __proj2);
 }
 
 template <class _InputIterator1, class _InputIterator2, class _BinaryPredicate>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_InputIterator1, _InputIterator2>
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_InputIterator1, _InputIterator2>
 mismatch(_InputIterator1 __first1,
          _InputIterator1 __last1,
          _InputIterator2 __first2,
@@ -205,7 +205,7 @@ mismatch(_InputIterator1 __first1,
 }
 
 template <class _InputIterator1, class _InputIterator2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_InputIterator1, _InputIterator2>
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_InputIterator1, _InputIterator2>
 mismatch(_InputIterator1 __first1, _InputIterator1 __last1, _InputIterator2 __first2, _InputIterator2 __last2) {
   return std::mismatch(__first1, __last1, __first2, __last2, __equal_to());
 }

--- a/libcxx/include/__algorithm/move.h
+++ b/libcxx/include/__algorithm/move.h
@@ -34,13 +34,13 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, class _InIter, class _Sent, class _OutIter>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
 __move(_InIter __first, _Sent __last, _OutIter __result);
 
 template <class _AlgPolicy>
 struct __move_impl {
   template <class _InIter, class _Sent, class _OutIter>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _Sent __last, _OutIter __result) const {
     while (__first != __last) {
       *__result = _IterOps<_AlgPolicy>::__iter_move(__first);
@@ -51,7 +51,7 @@ struct __move_impl {
   }
 
   template <class _InIter, class _OutIter, __enable_if_t<__is_segmented_iterator_v<_InIter>, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _InIter __last, _OutIter __result) const {
     using __local_iterator = typename __segmented_iterator_traits<_InIter>::__local_iterator;
     std::__for_each_segment(__first, __last, [&__result](__local_iterator __lfirst, __local_iterator __llast) {
@@ -65,7 +65,7 @@ struct __move_impl {
             __enable_if_t<__has_random_access_iterator_category<_InIter>::value &&
                               !__is_segmented_iterator_v<_InIter> && __is_segmented_iterator_v<_OutIter>,
                           int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _InIter __last, _OutIter __result) const {
     using _Traits = __segmented_iterator_traits<_OutIter>;
     using _DiffT =
@@ -90,7 +90,7 @@ struct __move_impl {
   }
 
   template <class _Cp, bool _IsConst>
-  _LIBCPP_HIDE_FROM_ABI
+
   _LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<__bit_iterator<_Cp, _IsConst>, __bit_iterator<_Cp, false> >
   operator()(__bit_iterator<_Cp, _IsConst> __first,
              __bit_iterator<_Cp, _IsConst> __last,
@@ -100,21 +100,21 @@ struct __move_impl {
 
   // At this point, the iterators have been unwrapped so any `contiguous_iterator` has been unwrapped to a pointer.
   template <class _In, class _Out, __enable_if_t<__can_lower_move_assignment_to_memmove<_In, _Out>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_In*, _Out*>
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_In*, _Out*>
   operator()(_In* __first, _In* __last, _Out* __result) const {
     return std::__copy_trivial_impl(__first, __last, __result);
   }
 };
 
 template <class _AlgPolicy, class _InIter, class _Sent, class _OutIter>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
 __move(_InIter __first, _Sent __last, _OutIter __result) {
   return std::__copy_move_unwrap_iters<__move_impl<_AlgPolicy> >(
       std::move(__first), std::move(__last), std::move(__result));
 }
 
 template <class _InputIterator, class _OutputIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
 move(_InputIterator __first, _InputIterator __last, _OutputIterator __result) {
   static_assert(is_copy_constructible<_InputIterator>::value, "Iterators has to be copy constructible.");
   static_assert(is_copy_constructible<_OutputIterator>::value, "The output iterator has to be copy constructible.");

--- a/libcxx/include/__algorithm/move_backward.h
+++ b/libcxx/include/__algorithm/move_backward.h
@@ -35,13 +35,13 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, class _BidirectionalIterator1, class _Sentinel, class _BidirectionalIterator2>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_BidirectionalIterator1, _BidirectionalIterator2>
+_LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_BidirectionalIterator1, _BidirectionalIterator2>
 __move_backward(_BidirectionalIterator1 __first, _Sentinel __last, _BidirectionalIterator2 __result);
 
 template <class _AlgPolicy>
 struct __move_backward_impl {
   template <class _InIter, class _Sent, class _OutIter>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _Sent __last, _OutIter __result) const {
     auto __last_iter          = _IterOps<_AlgPolicy>::next(__first, __last);
     auto __original_last_iter = __last_iter;
@@ -54,7 +54,7 @@ struct __move_backward_impl {
   }
 
   template <class _InIter, class _OutIter, __enable_if_t<__is_segmented_iterator_v<_InIter>, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _InIter __last, _OutIter __result) const {
     using __local_iterator = typename __segmented_iterator_traits<_InIter>::__local_iterator;
     std::__for_each_segment_backward(__first, __last, [&__result](__local_iterator __lfirst, __local_iterator __llast) {
@@ -68,7 +68,7 @@ struct __move_backward_impl {
             __enable_if_t<__has_random_access_iterator_category<_InIter>::value &&
                               !__is_segmented_iterator_v<_InIter> && __is_segmented_iterator_v<_OutIter>,
                           int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _InIter __last, _OutIter __result) const {
     using _Traits = __segmented_iterator_traits<_OutIter>;
     using _DiffT =
@@ -96,7 +96,7 @@ struct __move_backward_impl {
   }
 
   template <class _Cp, bool _IsConst>
-  _LIBCPP_HIDE_FROM_ABI
+
   _LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<__bit_iterator<_Cp, _IsConst>, __bit_iterator<_Cp, false> >
   operator()(__bit_iterator<_Cp, _IsConst> __first,
              __bit_iterator<_Cp, _IsConst> __last,
@@ -106,14 +106,14 @@ struct __move_backward_impl {
 
   // At this point, the iterators have been unwrapped so any `contiguous_iterator` has been unwrapped to a pointer.
   template <class _In, class _Out, __enable_if_t<__can_lower_move_assignment_to_memmove<_In, _Out>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_In*, _Out*>
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_In*, _Out*>
   operator()(_In* __first, _In* __last, _Out* __result) const {
     return std::__copy_backward_trivial_impl(__first, __last, __result);
   }
 };
 
 template <class _AlgPolicy, class _BidirectionalIterator1, class _Sentinel, class _BidirectionalIterator2>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_BidirectionalIterator1, _BidirectionalIterator2>
+_LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_BidirectionalIterator1, _BidirectionalIterator2>
 __move_backward(_BidirectionalIterator1 __first, _Sentinel __last, _BidirectionalIterator2 __result) {
   static_assert(std::is_copy_constructible<_BidirectionalIterator1>::value &&
                     std::is_copy_constructible<_BidirectionalIterator1>::value,
@@ -124,7 +124,7 @@ __move_backward(_BidirectionalIterator1 __first, _Sentinel __last, _Bidirectiona
 }
 
 template <class _BidirectionalIterator1, class _BidirectionalIterator2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _BidirectionalIterator2
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _BidirectionalIterator2
 move_backward(_BidirectionalIterator1 __first, _BidirectionalIterator1 __last, _BidirectionalIterator2 __result) {
   return std::__move_backward<_ClassicAlgPolicy>(std::move(__first), std::move(__last), std::move(__result)).__out_;
 }

--- a/libcxx/include/__algorithm/next_permutation.h
+++ b/libcxx/include/__algorithm/next_permutation.h
@@ -28,7 +28,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, class _Compare, class _BidirectionalIterator, class _Sentinel>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_BidirectionalIterator, bool>
+_LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_BidirectionalIterator, bool>
 __next_permutation(_BidirectionalIterator __first, _Sentinel __last, _Compare&& __comp) {
   using _Result = pair<_BidirectionalIterator, bool>;
 
@@ -55,7 +55,7 @@ __next_permutation(_BidirectionalIterator __first, _Sentinel __last, _Compare&& 
 }
 
 template <class _BidirectionalIterator, class _Compare>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 next_permutation(_BidirectionalIterator __first, _BidirectionalIterator __last, _Compare __comp) {
   return std::__next_permutation<_ClassicAlgPolicy>(
              std::move(__first), std::move(__last), static_cast<__comp_ref_type<_Compare> >(__comp))
@@ -63,7 +63,7 @@ next_permutation(_BidirectionalIterator __first, _BidirectionalIterator __last, 
 }
 
 template <class _BidirectionalIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 next_permutation(_BidirectionalIterator __first, _BidirectionalIterator __last) {
   return std::next_permutation(__first, __last, __less<>());
 }

--- a/libcxx/include/__algorithm/none_of.h
+++ b/libcxx/include/__algorithm/none_of.h
@@ -21,7 +21,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _InputIterator, class _Predicate>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 none_of(_InputIterator __first, _InputIterator __last, _Predicate __pred) {
   __identity __proj;
   return !std::__any_of(__first, __last, __pred, __proj);

--- a/libcxx/include/__algorithm/nth_element.h
+++ b/libcxx/include/__algorithm/nth_element.h
@@ -29,7 +29,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Compare, class _RandomAccessIterator>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool __nth_element_find_guard(
+_LIBCPP_CONSTEXPR_SINCE_CXX14 bool __nth_element_find_guard(
     _RandomAccessIterator& __i, _RandomAccessIterator& __j, _RandomAccessIterator __m, _Compare __comp) {
   // manually guard downward moving __j against __i
   while (true) {
@@ -43,7 +43,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool __nth_element_find_guar
 }
 
 template <class _AlgPolicy, class _Compare, class _RandomAccessIterator>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void
+_LIBCPP_CONSTEXPR_SINCE_CXX14 void
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 __nth_element(
     _RandomAccessIterator __first, _RandomAccessIterator __nth, _RandomAccessIterator __last, _Compare __comp) {
@@ -227,7 +227,7 @@ __nth_element(
 }
 
 template <class _AlgPolicy, class _RandomAccessIterator, class _Compare>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __nth_element_impl(
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void __nth_element_impl(
     _RandomAccessIterator __first, _RandomAccessIterator __nth, _RandomAccessIterator __last, _Compare& __comp) {
   if (__nth == __last)
     return;
@@ -243,13 +243,13 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __nth_element_im
 }
 
 template <class _RandomAccessIterator, class _Compare>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 nth_element(_RandomAccessIterator __first, _RandomAccessIterator __nth, _RandomAccessIterator __last, _Compare __comp) {
   std::__nth_element_impl<_ClassicAlgPolicy>(std::move(__first), std::move(__nth), std::move(__last), __comp);
 }
 
 template <class _RandomAccessIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 nth_element(_RandomAccessIterator __first, _RandomAccessIterator __nth, _RandomAccessIterator __last) {
   std::nth_element(std::move(__first), std::move(__nth), std::move(__last), __less<>());
 }

--- a/libcxx/include/__algorithm/out_value_result.h
+++ b/libcxx/include/__algorithm/out_value_result.h
@@ -34,13 +34,13 @@ struct out_value_result {
 
   template <class _OutIter2, class _ValType2>
     requires convertible_to<const _OutIter1&, _OutIter2> && convertible_to<const _ValType1&, _ValType2>
-  _LIBCPP_HIDE_FROM_ABI constexpr operator out_value_result<_OutIter2, _ValType2>() const& {
+  constexpr operator out_value_result<_OutIter2, _ValType2>() const& {
     return {out, value};
   }
 
   template <class _OutIter2, class _ValType2>
     requires convertible_to<_OutIter1, _OutIter2> && convertible_to<_ValType1, _ValType2>
-  _LIBCPP_HIDE_FROM_ABI constexpr operator out_value_result<_OutIter2, _ValType2>() && {
+  constexpr operator out_value_result<_OutIter2, _ValType2>() && {
     return {std::move(out), std::move(value)};
   }
 };

--- a/libcxx/include/__algorithm/partial_sort.h
+++ b/libcxx/include/__algorithm/partial_sort.h
@@ -32,7 +32,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, class _Compare, class _RandomAccessIterator, class _Sentinel>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _RandomAccessIterator __partial_sort_impl(
+_LIBCPP_CONSTEXPR_SINCE_CXX20 _RandomAccessIterator __partial_sort_impl(
     _RandomAccessIterator __first, _RandomAccessIterator __middle, _Sentinel __last, _Compare&& __comp) {
   if (__first == __middle) {
     return _IterOps<_AlgPolicy>::next(__middle, __last);
@@ -54,7 +54,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _RandomAccessIterator __part
 }
 
 template <class _AlgPolicy, class _Compare, class _RandomAccessIterator, class _Sentinel>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _RandomAccessIterator
+_LIBCPP_CONSTEXPR_SINCE_CXX20 _RandomAccessIterator
 __partial_sort(_RandomAccessIterator __first, _RandomAccessIterator __middle, _Sentinel __last, _Compare& __comp) {
   if (__first == __middle)
     return _IterOps<_AlgPolicy>::next(__middle, __last);
@@ -70,7 +70,7 @@ __partial_sort(_RandomAccessIterator __first, _RandomAccessIterator __middle, _S
 }
 
 template <class _RandomAccessIterator, class _Compare>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void partial_sort(
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void partial_sort(
     _RandomAccessIterator __first, _RandomAccessIterator __middle, _RandomAccessIterator __last, _Compare __comp) {
   static_assert(std::is_copy_constructible<_RandomAccessIterator>::value, "Iterators must be copy constructible.");
   static_assert(std::is_copy_assignable<_RandomAccessIterator>::value, "Iterators must be copy assignable.");
@@ -79,7 +79,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void partial_sort(
 }
 
 template <class _RandomAccessIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 partial_sort(_RandomAccessIterator __first, _RandomAccessIterator __middle, _RandomAccessIterator __last) {
   std::partial_sort(__first, __middle, __last, __less<>());
 }

--- a/libcxx/include/__algorithm/partial_sort_copy.h
+++ b/libcxx/include/__algorithm/partial_sort_copy.h
@@ -42,8 +42,7 @@ template <class _AlgPolicy,
           class _Sentinel2,
           class _Proj1,
           class _Proj2>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_InputIterator, _RandomAccessIterator>
-__partial_sort_copy(
+_LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_InputIterator, _RandomAccessIterator> __partial_sort_copy(
     _InputIterator __first,
     _Sentinel1 __last,
     _RandomAccessIterator __result_first,
@@ -71,7 +70,7 @@ __partial_sort_copy(
 }
 
 template <class _InputIterator, class _RandomAccessIterator, class _Compare>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _RandomAccessIterator partial_sort_copy(
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _RandomAccessIterator partial_sort_copy(
     _InputIterator __first,
     _InputIterator __last,
     _RandomAccessIterator __result_first,
@@ -92,7 +91,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _RandomAccessIterator
 }
 
 template <class _InputIterator, class _RandomAccessIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _RandomAccessIterator partial_sort_copy(
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _RandomAccessIterator partial_sort_copy(
     _InputIterator __first,
     _InputIterator __last,
     _RandomAccessIterator __result_first,

--- a/libcxx/include/__algorithm/partition.h
+++ b/libcxx/include/__algorithm/partition.h
@@ -26,7 +26,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Predicate, class _AlgPolicy, class _ForwardIterator, class _Sentinel>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_ForwardIterator, _ForwardIterator>
+_LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_ForwardIterator, _ForwardIterator>
 __partition_impl(_ForwardIterator __first, _Sentinel __last, _Predicate __pred, forward_iterator_tag) {
   while (true) {
     if (__first == __last)
@@ -47,7 +47,7 @@ __partition_impl(_ForwardIterator __first, _Sentinel __last, _Predicate __pred, 
 }
 
 template <class _Predicate, class _AlgPolicy, class _BidirectionalIterator, class _Sentinel>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_BidirectionalIterator, _BidirectionalIterator>
+_LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_BidirectionalIterator, _BidirectionalIterator>
 __partition_impl(_BidirectionalIterator __first, _Sentinel __sentinel, _Predicate __pred, bidirectional_iterator_tag) {
   _BidirectionalIterator __original_last = _IterOps<_AlgPolicy>::next(__first, __sentinel);
   _BidirectionalIterator __last          = __original_last;
@@ -70,14 +70,14 @@ __partition_impl(_BidirectionalIterator __first, _Sentinel __sentinel, _Predicat
 }
 
 template <class _AlgPolicy, class _ForwardIterator, class _Sentinel, class _Predicate, class _IterCategory>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_ForwardIterator, _ForwardIterator>
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_ForwardIterator, _ForwardIterator>
 __partition(_ForwardIterator __first, _Sentinel __last, _Predicate&& __pred, _IterCategory __iter_category) {
   return std::__partition_impl<__remove_cvref_t<_Predicate>&, _AlgPolicy>(
       std::move(__first), std::move(__last), __pred, __iter_category);
 }
 
 template <class _ForwardIterator, class _Predicate>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 partition(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred) {
   using _IterCategory = typename iterator_traits<_ForwardIterator>::iterator_category;
   auto __result = std::__partition<_ClassicAlgPolicy>(std::move(__first), std::move(__last), __pred, _IterCategory());

--- a/libcxx/include/__algorithm/partition_copy.h
+++ b/libcxx/include/__algorithm/partition_copy.h
@@ -20,7 +20,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _InputIterator, class _OutputIterator1, class _OutputIterator2, class _Predicate>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_OutputIterator1, _OutputIterator2> partition_copy(
+_LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_OutputIterator1, _OutputIterator2> partition_copy(
     _InputIterator __first,
     _InputIterator __last,
     _OutputIterator1 __out_true,

--- a/libcxx/include/__algorithm/partition_point.h
+++ b/libcxx/include/__algorithm/partition_point.h
@@ -22,7 +22,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _ForwardIterator, class _Predicate>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
+_LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 partition_point(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred) {
   typedef typename iterator_traits<_ForwardIterator>::difference_type difference_type;
   difference_type __len = std::distance(__first, __last);

--- a/libcxx/include/__algorithm/pop_heap.h
+++ b/libcxx/include/__algorithm/pop_heap.h
@@ -31,7 +31,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, class _Compare, class _RandomAccessIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 void
 __pop_heap(_RandomAccessIterator __first,
            _RandomAccessIterator __last,
            _Compare& __comp,
@@ -59,7 +59,7 @@ __pop_heap(_RandomAccessIterator __first,
 }
 
 template <class _RandomAccessIterator, class _Compare>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 pop_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
   static_assert(std::is_copy_constructible<_RandomAccessIterator>::value, "Iterators must be copy constructible.");
   static_assert(std::is_copy_assignable<_RandomAccessIterator>::value, "Iterators must be copy assignable.");
@@ -69,8 +69,7 @@ pop_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare _
 }
 
 template <class _RandomAccessIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
-pop_heap(_RandomAccessIterator __first, _RandomAccessIterator __last) {
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void pop_heap(_RandomAccessIterator __first, _RandomAccessIterator __last) {
   std::pop_heap(std::move(__first), std::move(__last), __less<>());
 }
 

--- a/libcxx/include/__algorithm/prev_permutation.h
+++ b/libcxx/include/__algorithm/prev_permutation.h
@@ -28,7 +28,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, class _Compare, class _BidirectionalIterator, class _Sentinel>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_BidirectionalIterator, bool>
+_LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_BidirectionalIterator, bool>
 __prev_permutation(_BidirectionalIterator __first, _Sentinel __last, _Compare&& __comp) {
   using _Result = pair<_BidirectionalIterator, bool>;
 
@@ -55,7 +55,7 @@ __prev_permutation(_BidirectionalIterator __first, _Sentinel __last, _Compare&& 
 }
 
 template <class _BidirectionalIterator, class _Compare>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 prev_permutation(_BidirectionalIterator __first, _BidirectionalIterator __last, _Compare __comp) {
   return std::__prev_permutation<_ClassicAlgPolicy>(
              std::move(__first), std::move(__last), static_cast<__comp_ref_type<_Compare> >(__comp))
@@ -63,7 +63,7 @@ prev_permutation(_BidirectionalIterator __first, _BidirectionalIterator __last, 
 }
 
 template <class _BidirectionalIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
 prev_permutation(_BidirectionalIterator __first, _BidirectionalIterator __last) {
   return std::prev_permutation(__first, __last, __less<>());
 }

--- a/libcxx/include/__algorithm/pstl.h
+++ b/libcxx/include/__algorithm/pstl.h
@@ -39,7 +39,7 @@ template <class _ExecutionPolicy,
           class _Predicate,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool
+[[nodiscard]] bool
 any_of(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "any_of requires a ForwardIterator");
   using _Implementation = __pstl::__dispatch<__pstl::__any_of, __pstl::__current_configuration, _RawPolicy>;
@@ -52,7 +52,7 @@ template <class _ExecutionPolicy,
           class _Pred,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool
+[[nodiscard]] bool
 all_of(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Pred __pred) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "all_of requires a ForwardIterator");
   using _Implementation = __pstl::__dispatch<__pstl::__all_of, __pstl::__current_configuration, _RawPolicy>;
@@ -65,7 +65,7 @@ template <class _ExecutionPolicy,
           class _Pred,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool
+[[nodiscard]] bool
 none_of(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Pred __pred) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "none_of requires a ForwardIterator");
   using _Implementation = __pstl::__dispatch<__pstl::__none_of, __pstl::__current_configuration, _RawPolicy>;
@@ -78,7 +78,7 @@ template <class _ExecutionPolicy,
           class _ForwardOutIterator,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _ForwardOutIterator
+_ForwardOutIterator
 copy(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _ForwardOutIterator __result) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(
       _ForwardIterator, "copy(first, last, result) requires [first, last) to be ForwardIterators");
@@ -97,7 +97,7 @@ template <class _ExecutionPolicy,
           class _Size,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _ForwardOutIterator
+_ForwardOutIterator
 copy_n(_ExecutionPolicy&& __policy, _ForwardIterator __first, _Size __n, _ForwardOutIterator __result) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(
       _ForwardIterator, "copy_n(first, n, result) requires first to be a ForwardIterator");
@@ -115,7 +115,7 @@ template <class _ExecutionPolicy,
           class _Predicate,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI __iterator_difference_type<_ForwardIterator>
+[[nodiscard]] __iterator_difference_type<_ForwardIterator>
 count_if(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(
       _ForwardIterator, "count_if(first, last, pred) requires [first, last) to be ForwardIterators");
@@ -129,7 +129,7 @@ template <class _ExecutionPolicy,
           class _Tp,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI __iterator_difference_type<_ForwardIterator>
+[[nodiscard]] __iterator_difference_type<_ForwardIterator>
 count(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(
       _ForwardIterator, "count(first, last, val) requires [first, last) to be ForwardIterators");
@@ -144,7 +144,7 @@ template <class _ExecutionPolicy,
           class _Pred,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool
+[[nodiscard]] bool
 equal(_ExecutionPolicy&& __policy,
       _ForwardIterator1 __first1,
       _ForwardIterator1 __last1,
@@ -166,7 +166,7 @@ template <class _ExecutionPolicy,
           class _ForwardIterator2,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool
+[[nodiscard]] bool
 equal(_ExecutionPolicy&& __policy, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator1, "equal requires ForwardIterators");
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator2, "equal requires ForwardIterators");
@@ -185,7 +185,7 @@ template <class _ExecutionPolicy,
           class _Pred,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool
+[[nodiscard]] bool
 equal(_ExecutionPolicy&& __policy,
       _ForwardIterator1 __first1,
       _ForwardIterator1 __last1,
@@ -209,7 +209,7 @@ template <class _ExecutionPolicy,
           class _ForwardIterator2,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool
+[[nodiscard]] bool
 equal(_ExecutionPolicy&& __policy,
       _ForwardIterator1 __first1,
       _ForwardIterator1 __last1,
@@ -232,8 +232,7 @@ template <class _ExecutionPolicy,
           class _Tp,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI void
-fill(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) {
+void fill(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "fill requires ForwardIterators");
   using _Implementation = __pstl::__dispatch<__pstl::__fill, __pstl::__current_configuration, _RawPolicy>;
   __pstl::__handle_exception<_Implementation>(
@@ -246,8 +245,7 @@ template <class _ExecutionPolicy,
           class _Tp,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI void
-fill_n(_ExecutionPolicy&& __policy, _ForwardIterator __first, _Size __n, const _Tp& __value) {
+void fill_n(_ExecutionPolicy&& __policy, _ForwardIterator __first, _Size __n, const _Tp& __value) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "fill_n requires a ForwardIterator");
   using _Implementation = __pstl::__dispatch<__pstl::__fill_n, __pstl::__current_configuration, _RawPolicy>;
   __pstl::__handle_exception<_Implementation>(
@@ -259,7 +257,7 @@ template <class _ExecutionPolicy,
           class _Predicate,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI _ForwardIterator
+[[nodiscard]] _ForwardIterator
 find_if(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "find_if requires ForwardIterators");
   using _Implementation = __pstl::__dispatch<__pstl::__find_if, __pstl::__current_configuration, _RawPolicy>;
@@ -272,7 +270,7 @@ template <class _ExecutionPolicy,
           class _Predicate,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI _ForwardIterator
+[[nodiscard]] _ForwardIterator
 find_if_not(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "find_if_not requires ForwardIterators");
   using _Implementation = __pstl::__dispatch<__pstl::__find_if_not, __pstl::__current_configuration, _RawPolicy>;
@@ -285,7 +283,7 @@ template <class _ExecutionPolicy,
           class _Tp,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI _ForwardIterator
+[[nodiscard]] _ForwardIterator
 find(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "find requires ForwardIterators");
   using _Implementation = __pstl::__dispatch<__pstl::__find, __pstl::__current_configuration, _RawPolicy>;
@@ -298,8 +296,7 @@ template <class _ExecutionPolicy,
           class _Function,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI void
-for_each(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Function __func) {
+void for_each(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Function __func) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "for_each requires ForwardIterators");
   using _Implementation = __pstl::__dispatch<__pstl::__for_each, __pstl::__current_configuration, _RawPolicy>;
   __pstl::__handle_exception<_Implementation>(
@@ -312,8 +309,7 @@ template <class _ExecutionPolicy,
           class _Function,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI void
-for_each_n(_ExecutionPolicy&& __policy, _ForwardIterator __first, _Size __size, _Function __func) {
+void for_each_n(_ExecutionPolicy&& __policy, _ForwardIterator __first, _Size __size, _Function __func) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "for_each_n requires a ForwardIterator");
   using _Implementation = __pstl::__dispatch<__pstl::__for_each_n, __pstl::__current_configuration, _RawPolicy>;
   __pstl::__handle_exception<_Implementation>(
@@ -325,8 +321,7 @@ template <class _ExecutionPolicy,
           class _Generator,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI void
-generate(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Generator __gen) {
+void generate(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Generator __gen) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "generate requires ForwardIterators");
   using _Implementation = __pstl::__dispatch<__pstl::__generate, __pstl::__current_configuration, _RawPolicy>;
   __pstl::__handle_exception<_Implementation>(
@@ -339,8 +334,7 @@ template <class _ExecutionPolicy,
           class _Generator,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI void
-generate_n(_ExecutionPolicy&& __policy, _ForwardIterator __first, _Size __n, _Generator __gen) {
+void generate_n(_ExecutionPolicy&& __policy, _ForwardIterator __first, _Size __n, _Generator __gen) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "generate_n requires a ForwardIterator");
   using _Implementation = __pstl::__dispatch<__pstl::__generate_n, __pstl::__current_configuration, _RawPolicy>;
   __pstl::__handle_exception<_Implementation>(
@@ -352,7 +346,7 @@ template <class _ExecutionPolicy,
           class _Predicate,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool
+[[nodiscard]] bool
 is_partitioned(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "is_partitioned requires ForwardIterators");
   using _Implementation = __pstl::__dispatch<__pstl::__is_partitioned, __pstl::__current_configuration, _RawPolicy>;
@@ -367,7 +361,7 @@ template <class _ExecutionPolicy,
           class _Comp,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _ForwardOutIterator
+_ForwardOutIterator
 merge(_ExecutionPolicy&& __policy,
       _ForwardIterator1 __first1,
       _ForwardIterator1 __last1,
@@ -396,7 +390,7 @@ template <class _ExecutionPolicy,
           class _ForwardOutIterator,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _ForwardOutIterator
+_ForwardOutIterator
 merge(_ExecutionPolicy&& __policy,
       _ForwardIterator1 __first1,
       _ForwardIterator1 __last1,
@@ -423,7 +417,7 @@ template <class _ExecutionPolicy,
           class _ForwardOutIterator,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _ForwardOutIterator
+_ForwardOutIterator
 move(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _ForwardOutIterator __result) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "move requires ForwardIterators");
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardOutIterator, "move requires an OutputIterator");
@@ -440,12 +434,11 @@ template <class _ExecutionPolicy,
           class _Tp,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI void
-replace_if(_ExecutionPolicy&& __policy,
-           _ForwardIterator __first,
-           _ForwardIterator __last,
-           _Pred __pred,
-           const _Tp& __new_value) {
+void replace_if(_ExecutionPolicy&& __policy,
+                _ForwardIterator __first,
+                _ForwardIterator __last,
+                _Pred __pred,
+                const _Tp& __new_value) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "replace_if requires ForwardIterators");
   using _Implementation = __pstl::__dispatch<__pstl::__replace_if, __pstl::__current_configuration, _RawPolicy>;
   __pstl::__handle_exception<_Implementation>(
@@ -457,12 +450,11 @@ template <class _ExecutionPolicy,
           class _Tp,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI void
-replace(_ExecutionPolicy&& __policy,
-        _ForwardIterator __first,
-        _ForwardIterator __last,
-        const _Tp& __old_value,
-        const _Tp& __new_value) {
+void replace(_ExecutionPolicy&& __policy,
+             _ForwardIterator __first,
+             _ForwardIterator __last,
+             const _Tp& __old_value,
+             const _Tp& __new_value) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "replace requires ForwardIterators");
   using _Implementation = __pstl::__dispatch<__pstl::__replace, __pstl::__current_configuration, _RawPolicy>;
   __pstl::__handle_exception<_Implementation>(
@@ -476,7 +468,7 @@ template <class _ExecutionPolicy,
           class _Tp,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI void replace_copy_if(
+void replace_copy_if(
     _ExecutionPolicy&& __policy,
     _ForwardIterator __first,
     _ForwardIterator __last,
@@ -504,13 +496,12 @@ template <class _ExecutionPolicy,
           class _Tp,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI void replace_copy(
-    _ExecutionPolicy&& __policy,
-    _ForwardIterator __first,
-    _ForwardIterator __last,
-    _ForwardOutIterator __result,
-    const _Tp& __old_value,
-    const _Tp& __new_value) {
+void replace_copy(_ExecutionPolicy&& __policy,
+                  _ForwardIterator __first,
+                  _ForwardIterator __last,
+                  _ForwardOutIterator __result,
+                  const _Tp& __old_value,
+                  const _Tp& __new_value) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "replace_copy requires ForwardIterators");
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardOutIterator, "replace_copy requires ForwardIterators");
   _LIBCPP_REQUIRE_CPP17_OUTPUT_ITERATOR(
@@ -531,12 +522,12 @@ template <class _ExecutionPolicy,
           class _ForwardOutIterator,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _ForwardOutIterator rotate_copy(
-    _ExecutionPolicy&& __policy,
-    _ForwardIterator __first,
-    _ForwardIterator __middle,
-    _ForwardIterator __last,
-    _ForwardOutIterator __result) {
+_ForwardOutIterator
+rotate_copy(_ExecutionPolicy&& __policy,
+            _ForwardIterator __first,
+            _ForwardIterator __middle,
+            _ForwardIterator __last,
+            _ForwardOutIterator __result) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "rotate_copy requires ForwardIterators");
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardOutIterator, "rotate_copy requires ForwardIterators");
   _LIBCPP_REQUIRE_CPP17_OUTPUT_ITERATOR(
@@ -555,8 +546,7 @@ template <class _ExecutionPolicy,
           class _Comp,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI void
-sort(_ExecutionPolicy&& __policy, _RandomAccessIterator __first, _RandomAccessIterator __last, _Comp __comp) {
+void sort(_ExecutionPolicy&& __policy, _RandomAccessIterator __first, _RandomAccessIterator __last, _Comp __comp) {
   _LIBCPP_REQUIRE_CPP17_RANDOM_ACCESS_ITERATOR(_RandomAccessIterator, "sort requires RandomAccessIterators");
   using _Implementation = __pstl::__dispatch<__pstl::__sort, __pstl::__current_configuration, _RawPolicy>;
   __pstl::__handle_exception<_Implementation>(
@@ -567,8 +557,7 @@ template <class _ExecutionPolicy,
           class _RandomAccessIterator,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI void
-sort(_ExecutionPolicy&& __policy, _RandomAccessIterator __first, _RandomAccessIterator __last) {
+void sort(_ExecutionPolicy&& __policy, _RandomAccessIterator __first, _RandomAccessIterator __last) {
   _LIBCPP_REQUIRE_CPP17_RANDOM_ACCESS_ITERATOR(_RandomAccessIterator, "sort requires RandomAccessIterators");
   using _Implementation = __pstl::__dispatch<__pstl::__sort, __pstl::__current_configuration, _RawPolicy>;
   __pstl::__handle_exception<_Implementation>(
@@ -580,8 +569,8 @@ template <class _ExecutionPolicy,
           class _Comp,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI void
-stable_sort(_ExecutionPolicy&& __policy, _RandomAccessIterator __first, _RandomAccessIterator __last, _Comp __comp) {
+void stable_sort(
+    _ExecutionPolicy&& __policy, _RandomAccessIterator __first, _RandomAccessIterator __last, _Comp __comp) {
   _LIBCPP_REQUIRE_CPP17_RANDOM_ACCESS_ITERATOR(_RandomAccessIterator, "stable_sort requires RandomAccessIterators");
   using _Implementation = __pstl::__dispatch<__pstl::__stable_sort, __pstl::__current_configuration, _RawPolicy>;
   __pstl::__handle_exception<_Implementation>(
@@ -592,8 +581,7 @@ template <class _ExecutionPolicy,
           class _RandomAccessIterator,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI void
-stable_sort(_ExecutionPolicy&& __policy, _RandomAccessIterator __first, _RandomAccessIterator __last) {
+void stable_sort(_ExecutionPolicy&& __policy, _RandomAccessIterator __first, _RandomAccessIterator __last) {
   _LIBCPP_REQUIRE_CPP17_RANDOM_ACCESS_ITERATOR(_RandomAccessIterator, "stable_sort requires RandomAccessIterators");
   using _Implementation = __pstl::__dispatch<__pstl::__stable_sort, __pstl::__current_configuration, _RawPolicy>;
   __pstl::__handle_exception<_Implementation>(
@@ -606,12 +594,12 @@ template <class _ExecutionPolicy,
           class _UnaryOperation,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _ForwardOutIterator transform(
-    _ExecutionPolicy&& __policy,
-    _ForwardIterator __first,
-    _ForwardIterator __last,
-    _ForwardOutIterator __result,
-    _UnaryOperation __op) {
+_ForwardOutIterator
+transform(_ExecutionPolicy&& __policy,
+          _ForwardIterator __first,
+          _ForwardIterator __last,
+          _ForwardOutIterator __result,
+          _UnaryOperation __op) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "transform requires ForwardIterators");
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardOutIterator, "transform requires an OutputIterator");
   _LIBCPP_REQUIRE_CPP17_OUTPUT_ITERATOR(
@@ -632,13 +620,13 @@ template <class _ExecutionPolicy,
           class _BinaryOperation,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _ForwardOutIterator transform(
-    _ExecutionPolicy&& __policy,
-    _ForwardIterator1 __first1,
-    _ForwardIterator1 __last1,
-    _ForwardIterator2 __first2,
-    _ForwardOutIterator __result,
-    _BinaryOperation __op) {
+_ForwardOutIterator
+transform(_ExecutionPolicy&& __policy,
+          _ForwardIterator1 __first1,
+          _ForwardIterator1 __last1,
+          _ForwardIterator2 __first2,
+          _ForwardOutIterator __result,
+          _BinaryOperation __op) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator1, "transform requires ForwardIterators");
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator2, "transform requires ForwardIterators");
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardOutIterator, "transform requires an OutputIterator");
@@ -658,8 +646,7 @@ template <class _ExecutionPolicy,
           class _ForwardIterator,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool
-is_sorted(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last) {
+[[nodiscard]] bool is_sorted(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "is_sorted requires ForwardIterators");
   using _Implementation = __pstl::__dispatch<__pstl::__is_sorted, __pstl::__current_configuration, _RawPolicy>;
   return __pstl::__handle_exception<_Implementation>(
@@ -671,7 +658,7 @@ template <class _ExecutionPolicy,
           class _Comp,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool
+[[nodiscard]] bool
 is_sorted(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Comp __comp) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "is_sorted requires ForwardIterators");
   using _Implementation = __pstl::__dispatch<__pstl::__is_sorted, __pstl::__current_configuration, _RawPolicy>;

--- a/libcxx/include/__algorithm/push_heap.h
+++ b/libcxx/include/__algorithm/push_heap.h
@@ -28,7 +28,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, class _Compare, class _RandomAccessIterator>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void
+_LIBCPP_CONSTEXPR_SINCE_CXX14 void
 __sift_up(_RandomAccessIterator __first,
           _RandomAccessIterator __last,
           _Compare&& __comp,
@@ -56,14 +56,14 @@ __sift_up(_RandomAccessIterator __first,
 }
 
 template <class _AlgPolicy, class _RandomAccessIterator, class _Compare>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 void
 __push_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare& __comp) {
   typename iterator_traits<_RandomAccessIterator>::difference_type __len = __last - __first;
   std::__sift_up<_AlgPolicy, __comp_ref_type<_Compare> >(std::move(__first), std::move(__last), __comp, __len);
 }
 
 template <class _RandomAccessIterator, class _Compare>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 push_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
   static_assert(std::is_copy_constructible<_RandomAccessIterator>::value, "Iterators must be copy constructible.");
   static_assert(std::is_copy_assignable<_RandomAccessIterator>::value, "Iterators must be copy assignable.");
@@ -72,8 +72,7 @@ push_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare 
 }
 
 template <class _RandomAccessIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
-push_heap(_RandomAccessIterator __first, _RandomAccessIterator __last) {
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void push_heap(_RandomAccessIterator __first, _RandomAccessIterator __last) {
   std::push_heap(std::move(__first), std::move(__last), __less<>());
 }
 

--- a/libcxx/include/__algorithm/radix_sort.h
+++ b/libcxx/include/__algorithm/radix_sort.h
@@ -72,7 +72,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 14
 
 template <class _InputIterator, class _OutputIterator>
-_LIBCPP_HIDE_FROM_ABI constexpr pair<_OutputIterator, __iterator_value_type<_InputIterator>>
+constexpr pair<_OutputIterator, __iterator_value_type<_InputIterator>>
 __partial_sum_max(_InputIterator __first, _InputIterator __last, _OutputIterator __result) {
   if (__first == __last)
     return {__result, 0};
@@ -114,7 +114,7 @@ struct __counting_sort_traits {
 };
 
 template <class _Radix, class _Integer>
-_LIBCPP_HIDE_FROM_ABI constexpr auto __nth_radix(size_t __radix_number, _Radix __radix, _Integer __n) {
+constexpr auto __nth_radix(size_t __radix_number, _Radix __radix, _Integer __n) {
   static_assert(is_unsigned<_Integer>::value);
   using __traits = __counting_sort_traits<_Integer, _Radix>;
 
@@ -122,7 +122,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr auto __nth_radix(size_t __radix_number, _Radix _
 }
 
 template <class _ForwardIterator, class _Map, class _RandomAccessIterator>
-_LIBCPP_HIDE_FROM_ABI constexpr void
+constexpr void
 __collect(_ForwardIterator __first, _ForwardIterator __last, _Map __map, _RandomAccessIterator __counters) {
   using __value_type = __iterator_value_type<_ForwardIterator>;
   using __traits     = __counting_sort_traits<__value_type, _Map>;
@@ -134,7 +134,7 @@ __collect(_ForwardIterator __first, _ForwardIterator __last, _Map __map, _Random
 }
 
 template <class _ForwardIterator, class _RandomAccessIterator1, class _Map, class _RandomAccessIterator2>
-_LIBCPP_HIDE_FROM_ABI constexpr void
+constexpr void
 __dispose(_ForwardIterator __first,
           _ForwardIterator __last,
           _RandomAccessIterator1 __result,
@@ -152,7 +152,7 @@ template <class _ForwardIterator,
           class _RandomAccessIterator1,
           class _RandomAccessIterator2,
           size_t... _Radices>
-_LIBCPP_HIDE_FROM_ABI constexpr bool __collect_impl(
+constexpr bool __collect_impl(
     _ForwardIterator __first,
     _ForwardIterator __last,
     _Map __map,
@@ -182,7 +182,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr bool __collect_impl(
 }
 
 template <class _ForwardIterator, class _Map, class _Radix, class _RandomAccessIterator1, class _RandomAccessIterator2>
-_LIBCPP_HIDE_FROM_ABI constexpr bool
+constexpr bool
 __collect(_ForwardIterator __first,
           _ForwardIterator __last,
           _Map __map,
@@ -196,7 +196,7 @@ __collect(_ForwardIterator __first,
 }
 
 template <class _BidirectionalIterator, class _RandomAccessIterator1, class _Map, class _RandomAccessIterator2>
-_LIBCPP_HIDE_FROM_ABI constexpr void __dispose_backward(
+constexpr void __dispose_backward(
     _BidirectionalIterator __first,
     _BidirectionalIterator __last,
     _RandomAccessIterator1 __result,
@@ -211,7 +211,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr void __dispose_backward(
 }
 
 template <class _ForwardIterator, class _RandomAccessIterator, class _Map>
-_LIBCPP_HIDE_FROM_ABI constexpr _RandomAccessIterator
+constexpr _RandomAccessIterator
 __counting_sort_impl(_ForwardIterator __first, _ForwardIterator __last, _RandomAccessIterator __result, _Map __map) {
   using __value_type = __iterator_value_type<_ForwardIterator>;
   using __traits     = __counting_sort_traits<__value_type, _Map>;
@@ -231,7 +231,7 @@ template <
     class _Radix,
     enable_if_t<__radix_sort_traits<__iterator_value_type<_RandomAccessIterator1>, _Map, _Radix>::__radix_count == 1,
                 int> = 0>
-_LIBCPP_HIDE_FROM_ABI constexpr void __radix_sort_impl(
+constexpr void __radix_sort_impl(
     _RandomAccessIterator1 __first,
     _RandomAccessIterator1 __last,
     _RandomAccessIterator2 __buffer,
@@ -251,7 +251,7 @@ template <class _RandomAccessIterator1,
           enable_if_t<
               __radix_sort_traits<__iterator_value_type<_RandomAccessIterator1>, _Map, _Radix>::__radix_count % 2 == 0,
               int> = 0>
-_LIBCPP_HIDE_FROM_ABI constexpr void __radix_sort_impl(
+constexpr void __radix_sort_impl(
     _RandomAccessIterator1 __first,
     _RandomAccessIterator1 __last,
     _RandomAccessIterator2 __buffer_begin,
@@ -296,10 +296,10 @@ _LIBCPP_HIDE_FROM_ABI constexpr void __radix_sort_impl(
   }
 }
 
-_LIBCPP_HIDE_FROM_ABI constexpr auto __shift_to_unsigned(bool __b) { return __b; }
+constexpr auto __shift_to_unsigned(bool __b) { return __b; }
 
 template <class _Ip>
-_LIBCPP_HIDE_FROM_ABI constexpr auto __shift_to_unsigned(_Ip __n) {
+constexpr auto __shift_to_unsigned(_Ip __n) {
   constexpr const auto __min_value = numeric_limits<_Ip>::min();
   return static_cast<make_unsigned_t<_Ip> >(__n ^ __min_value);
 }
@@ -344,7 +344,7 @@ using __unsigned_representation_for_t _LIBCPP_NODEBUG = __unsigned_integer_of_si
 // Returns an integer representation such that for any `x` and `y` such that `x < y`, the expression
 // `__to_ordered_integral(x) < __to_ordered_integral(y)` is true, where `x`, `y` are integers or IEEE 754 floats.
 template <class _Integral, enable_if_t< is_integral<_Integral>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI constexpr auto __to_ordered_integral(_Integral __n) {
+constexpr auto __to_ordered_integral(_Integral __n) {
   return __n;
 }
 
@@ -368,7 +368,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr auto __to_ordered_integral(_Integral __n) {
 // Thus, in final integral representation, we have reversed the order for negative floats and made all negative floats
 // smaller than all positive numbers (by inverting the sign bit).
 template <class _Floating, enable_if_t< numeric_limits<_Floating>::is_iec559, int> = 0>
-_LIBCPP_HIDE_FROM_ABI constexpr auto __to_ordered_integral(_Floating __f) {
+constexpr auto __to_ordered_integral(_Floating __f) {
   using __integral_type          = __unsigned_representation_for_t<_Floating>;
   constexpr auto __bit_count     = std::numeric_limits<__integral_type>::digits;
   constexpr auto __sign_bit_mask = static_cast<__integral_type>(__integral_type{1} << (__bit_count - 1));
@@ -380,11 +380,11 @@ _LIBCPP_HIDE_FROM_ABI constexpr auto __to_ordered_integral(_Floating __f) {
 
 // There may exist user-defined comparison for enum, so we cannot compare enums just like integers.
 template <class _Enum, enable_if_t< is_enum<_Enum>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI constexpr auto __to_ordered_integral(_Enum __e) = delete;
+constexpr auto __to_ordered_integral(_Enum __e) = delete;
 
 // `long double` varies significantly across platforms and compilers, making it practically
 // impossible to determine its actual bit width for conversion to an ordered integer.
-inline _LIBCPP_HIDE_FROM_ABI constexpr auto __to_ordered_integral(long double) = delete;
+inline constexpr auto __to_ordered_integral(long double) = delete;
 
 template <class _Tp, class = void>
 inline const bool __is_ordered_integer_representable_v = false;
@@ -396,7 +396,7 @@ inline const bool
 
 struct __low_byte_fn {
   template <class _Ip>
-  _LIBCPP_HIDE_FROM_ABI constexpr uint8_t operator()(_Ip __integer) const {
+  constexpr uint8_t operator()(_Ip __integer) const {
     static_assert(is_unsigned<_Ip>::value);
 
     return static_cast<uint8_t>(__integer & 0xff);
@@ -404,7 +404,7 @@ struct __low_byte_fn {
 };
 
 template <class _RandomAccessIterator1, class _RandomAccessIterator2, class _Map, class _Radix>
-_LIBCPP_HIDE_FROM_ABI constexpr void
+constexpr void
 __radix_sort(_RandomAccessIterator1 __first,
              _RandomAccessIterator1 __last,
              _RandomAccessIterator2 __buffer,
@@ -417,7 +417,7 @@ __radix_sort(_RandomAccessIterator1 __first,
 }
 
 template <class _RandomAccessIterator1, class _RandomAccessIterator2>
-_LIBCPP_HIDE_FROM_ABI constexpr void
+constexpr void
 __radix_sort(_RandomAccessIterator1 __first, _RandomAccessIterator1 __last, _RandomAccessIterator2 __buffer) {
   std::__radix_sort(__first, __last, __buffer, __identity{}, __low_byte_fn{});
 }

--- a/libcxx/include/__algorithm/ranges_adjacent_find.h
+++ b/libcxx/include/__algorithm/ranges_adjacent_find.h
@@ -37,8 +37,7 @@ struct __adjacent_find {
             sentinel_for<_Iter> _Sent,
             class _Proj                                                                       = identity,
             indirect_binary_predicate<projected<_Iter, _Proj>, projected<_Iter, _Proj>> _Pred = ranges::equal_to>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Iter
-  operator()(_Iter __first, _Sent __last, _Pred __pred = {}, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr _Iter operator()(_Iter __first, _Sent __last, _Pred __pred = {}, _Proj __proj = {}) const {
     return std::__adjacent_find(std::move(__first), std::move(__last), __pred, __proj);
   }
 
@@ -46,7 +45,7 @@ struct __adjacent_find {
             class _Proj = identity,
             indirect_binary_predicate<projected<iterator_t<_Range>, _Proj>, projected<iterator_t<_Range>, _Proj>>
                 _Pred = ranges::equal_to>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Range>
+  [[nodiscard]] constexpr borrowed_iterator_t<_Range>
   operator()(_Range&& __range, _Pred __pred = {}, _Proj __proj = {}) const {
     return std::__adjacent_find(ranges::begin(__range), ranges::end(__range), __pred, __proj);
   }

--- a/libcxx/include/__algorithm/ranges_all_of.h
+++ b/libcxx/include/__algorithm/ranges_all_of.h
@@ -36,16 +36,14 @@ struct __all_of {
             sentinel_for<_Iter> _Sent,
             class _Proj = identity,
             indirect_unary_predicate<projected<_Iter, _Proj>> _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool
-  operator()(_Iter __first, _Sent __last, _Pred __pred, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr bool operator()(_Iter __first, _Sent __last, _Pred __pred, _Proj __proj = {}) const {
     return std::__all_of(std::move(__first), std::move(__last), __pred, __proj);
   }
 
   template <input_range _Range,
             class _Proj = identity,
             indirect_unary_predicate<projected<iterator_t<_Range>, _Proj>> _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool
-  operator()(_Range&& __range, _Pred __pred, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr bool operator()(_Range&& __range, _Pred __pred, _Proj __proj = {}) const {
     return std::__all_of(ranges::begin(__range), ranges::end(__range), __pred, __proj);
   }
 };

--- a/libcxx/include/__algorithm/ranges_any_of.h
+++ b/libcxx/include/__algorithm/ranges_any_of.h
@@ -35,16 +35,14 @@ struct __any_of {
             sentinel_for<_Iter> _Sent,
             class _Proj = identity,
             indirect_unary_predicate<projected<_Iter, _Proj>> _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool
-  operator()(_Iter __first, _Sent __last, _Pred __pred = {}, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr bool operator()(_Iter __first, _Sent __last, _Pred __pred = {}, _Proj __proj = {}) const {
     return std::__any_of(std::move(__first), std::move(__last), __pred, __proj);
   }
 
   template <input_range _Range,
             class _Proj = identity,
             indirect_unary_predicate<projected<iterator_t<_Range>, _Proj>> _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool
-  operator()(_Range&& __range, _Pred __pred, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr bool operator()(_Range&& __range, _Pred __pred, _Proj __proj = {}) const {
     return std::__any_of(ranges::begin(__range), ranges::end(__range), __pred, __proj);
   }
 };

--- a/libcxx/include/__algorithm/ranges_binary_search.h
+++ b/libcxx/include/__algorithm/ranges_binary_search.h
@@ -38,7 +38,7 @@ struct __binary_search {
             class _Type,
             class _Proj                                                             = identity,
             indirect_strict_weak_order<const _Type*, projected<_Iter, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool
+  [[nodiscard]] constexpr bool
   operator()(_Iter __first, _Sent __last, const _Type& __value, _Comp __comp = {}, _Proj __proj = {}) const {
     auto __ret = std::__lower_bound<_RangeAlgPolicy>(__first, __last, __value, __comp, __proj);
     return __ret != __last && !std::invoke(__comp, __value, std::invoke(__proj, *__ret));
@@ -48,7 +48,7 @@ struct __binary_search {
             class _Type,
             class _Proj                                                                          = identity,
             indirect_strict_weak_order<const _Type*, projected<iterator_t<_Range>, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool
+  [[nodiscard]] constexpr bool
   operator()(_Range&& __r, const _Type& __value, _Comp __comp = {}, _Proj __proj = {}) const {
     auto __first = ranges::begin(__r);
     auto __last  = ranges::end(__r);

--- a/libcxx/include/__algorithm/ranges_clamp.h
+++ b/libcxx/include/__algorithm/ranges_clamp.h
@@ -34,7 +34,7 @@ struct __clamp {
   template <class _Type,
             class _Proj                                                      = identity,
             indirect_strict_weak_order<projected<const _Type*, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr const _Type& operator()(
+  [[nodiscard]] constexpr const _Type& operator()(
       const _Type& __value, const _Type& __low, const _Type& __high, _Comp __comp = {}, _Proj __proj = {}) const {
     _LIBCPP_ASSERT_ARGUMENT_WITHIN_DOMAIN(
         !bool(std::invoke(__comp, std::invoke(__proj, __high), std::invoke(__proj, __low))),

--- a/libcxx/include/__algorithm/ranges_contains.h
+++ b/libcxx/include/__algorithm/ranges_contains.h
@@ -36,15 +36,13 @@ namespace ranges {
 struct __contains {
   template <input_iterator _Iter, sentinel_for<_Iter> _Sent, class _Type, class _Proj = identity>
     requires indirect_binary_predicate<ranges::equal_to, projected<_Iter, _Proj>, const _Type*>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool static
-  operator()(_Iter __first, _Sent __last, const _Type& __value, _Proj __proj = {}) {
+  [[nodiscard]] constexpr bool static operator()(_Iter __first, _Sent __last, const _Type& __value, _Proj __proj = {}) {
     return ranges::find(std::move(__first), __last, __value, std::ref(__proj)) != __last;
   }
 
   template <input_range _Range, class _Type, class _Proj = identity>
     requires indirect_binary_predicate<ranges::equal_to, projected<iterator_t<_Range>, _Proj>, const _Type*>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool static
-  operator()(_Range&& __range, const _Type& __value, _Proj __proj = {}) {
+  [[nodiscard]] constexpr bool static operator()(_Range&& __range, const _Type& __value, _Proj __proj = {}) {
     return ranges::find(ranges::begin(__range), ranges::end(__range), __value, std::ref(__proj)) !=
            ranges::end(__range);
   }

--- a/libcxx/include/__algorithm/ranges_contains_subrange.h
+++ b/libcxx/include/__algorithm/ranges_contains_subrange.h
@@ -44,7 +44,7 @@ struct __contains_subrange {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires indirectly_comparable<_Iter1, _Iter2, _Pred, _Proj1, _Proj2>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool static operator()(
+  [[nodiscard]] constexpr bool static operator()(
       _Iter1 __first1,
       _Sent1 __last1,
       _Iter2 __first2,
@@ -66,7 +66,7 @@ struct __contains_subrange {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires indirectly_comparable<iterator_t<_Range1>, iterator_t<_Range2>, _Pred, _Proj1, _Proj2>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool static
+  [[nodiscard]] constexpr bool static
   operator()(_Range1&& __range1, _Range2&& __range2, _Pred __pred = {}, _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) {
     if constexpr (sized_range<_Range2>) {
       if (ranges::size(__range2) == 0)

--- a/libcxx/include/__algorithm/ranges_copy.h
+++ b/libcxx/include/__algorithm/ranges_copy.h
@@ -39,15 +39,13 @@ using copy_result = in_out_result<_InIter, _OutIter>;
 struct __copy {
   template <input_iterator _InIter, sentinel_for<_InIter> _Sent, weakly_incrementable _OutIter>
     requires indirectly_copyable<_InIter, _OutIter>
-  _LIBCPP_HIDE_FROM_ABI constexpr copy_result<_InIter, _OutIter>
-  operator()(_InIter __first, _Sent __last, _OutIter __result) const {
+  constexpr copy_result<_InIter, _OutIter> operator()(_InIter __first, _Sent __last, _OutIter __result) const {
     return std::__copy(std::move(__first), std::move(__last), std::move(__result));
   }
 
   template <input_range _Range, weakly_incrementable _OutIter>
     requires indirectly_copyable<iterator_t<_Range>, _OutIter>
-  _LIBCPP_HIDE_FROM_ABI constexpr copy_result<borrowed_iterator_t<_Range>, _OutIter>
-  operator()(_Range&& __r, _OutIter __result) const {
+  constexpr copy_result<borrowed_iterator_t<_Range>, _OutIter> operator()(_Range&& __r, _OutIter __result) const {
     return std::__copy(ranges::begin(__r), ranges::end(__r), std::move(__result));
   }
 };

--- a/libcxx/include/__algorithm/ranges_copy_backward.h
+++ b/libcxx/include/__algorithm/ranges_copy_backward.h
@@ -38,15 +38,14 @@ using copy_backward_result = in_out_result<_Ip, _Op>;
 struct __copy_backward {
   template <bidirectional_iterator _InIter1, sentinel_for<_InIter1> _Sent1, bidirectional_iterator _InIter2>
     requires indirectly_copyable<_InIter1, _InIter2>
-  _LIBCPP_HIDE_FROM_ABI constexpr copy_backward_result<_InIter1, _InIter2>
+  constexpr copy_backward_result<_InIter1, _InIter2>
   operator()(_InIter1 __first, _Sent1 __last, _InIter2 __result) const {
     return std::__copy_backward<_RangeAlgPolicy>(std::move(__first), std::move(__last), std::move(__result));
   }
 
   template <bidirectional_range _Range, bidirectional_iterator _Iter>
     requires indirectly_copyable<iterator_t<_Range>, _Iter>
-  _LIBCPP_HIDE_FROM_ABI constexpr copy_backward_result<borrowed_iterator_t<_Range>, _Iter>
-  operator()(_Range&& __r, _Iter __result) const {
+  constexpr copy_backward_result<borrowed_iterator_t<_Range>, _Iter> operator()(_Range&& __r, _Iter __result) const {
     return std::__copy_backward<_RangeAlgPolicy>(ranges::begin(__r), ranges::end(__r), std::move(__result));
   }
 };

--- a/libcxx/include/__algorithm/ranges_copy_if.h
+++ b/libcxx/include/__algorithm/ranges_copy_if.h
@@ -44,7 +44,7 @@ struct __copy_if {
             class _Proj = identity,
             indirect_unary_predicate<projected<_Iter, _Proj>> _Pred>
     requires indirectly_copyable<_Iter, _OutIter>
-  _LIBCPP_HIDE_FROM_ABI constexpr copy_if_result<_Iter, _OutIter>
+  constexpr copy_if_result<_Iter, _OutIter>
   operator()(_Iter __first, _Sent __last, _OutIter __result, _Pred __pred, _Proj __proj = {}) const {
     return std::__copy_if(std::move(__first), std::move(__last), std::move(__result), __pred, __proj);
   }
@@ -54,7 +54,7 @@ struct __copy_if {
             class _Proj = identity,
             indirect_unary_predicate<projected<iterator_t<_Range>, _Proj>> _Pred>
     requires indirectly_copyable<iterator_t<_Range>, _OutIter>
-  _LIBCPP_HIDE_FROM_ABI constexpr copy_if_result<borrowed_iterator_t<_Range>, _OutIter>
+  constexpr copy_if_result<borrowed_iterator_t<_Range>, _OutIter>
   operator()(_Range&& __r, _OutIter __result, _Pred __pred, _Proj __proj = {}) const {
     return std::__copy_if(ranges::begin(__r), ranges::end(__r), std::move(__result), __pred, __proj);
   }

--- a/libcxx/include/__algorithm/ranges_copy_n.h
+++ b/libcxx/include/__algorithm/ranges_copy_n.h
@@ -36,8 +36,7 @@ using copy_n_result = in_out_result<_Ip, _Op>;
 struct __copy_n {
   template <input_iterator _Ip, weakly_incrementable _Op>
     requires indirectly_copyable<_Ip, _Op>
-  _LIBCPP_HIDE_FROM_ABI constexpr copy_n_result<_Ip, _Op>
-  operator()(_Ip __first, iter_difference_t<_Ip> __n, _Op __result) const {
+  constexpr copy_n_result<_Ip, _Op> operator()(_Ip __first, iter_difference_t<_Ip> __n, _Op __result) const {
     return std::__copy_n<_RangeAlgPolicy>(std::move(__first), __n, std::move(__result));
   }
 };

--- a/libcxx/include/__algorithm/ranges_count.h
+++ b/libcxx/include/__algorithm/ranges_count.h
@@ -37,14 +37,14 @@ namespace ranges {
 struct __count {
   template <input_iterator _Iter, sentinel_for<_Iter> _Sent, class _Type, class _Proj = identity>
     requires indirect_binary_predicate<ranges::equal_to, projected<_Iter, _Proj>, const _Type*>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr iter_difference_t<_Iter>
+  [[nodiscard]] constexpr iter_difference_t<_Iter>
   operator()(_Iter __first, _Sent __last, const _Type& __value, _Proj __proj = {}) const {
     return std::__count<_RangeAlgPolicy>(std::move(__first), std::move(__last), __value, __proj);
   }
 
   template <input_range _Range, class _Type, class _Proj = identity>
     requires indirect_binary_predicate<ranges::equal_to, projected<iterator_t<_Range>, _Proj>, const _Type*>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr range_difference_t<_Range>
+  [[nodiscard]] constexpr range_difference_t<_Range>
   operator()(_Range&& __r, const _Type& __value, _Proj __proj = {}) const {
     return std::__count<_RangeAlgPolicy>(ranges::begin(__r), ranges::end(__r), __value, __proj);
   }

--- a/libcxx/include/__algorithm/ranges_count_if.h
+++ b/libcxx/include/__algorithm/ranges_count_if.h
@@ -39,7 +39,7 @@ struct __count_if {
             sentinel_for<_Iter> _Sent,
             class _Proj = identity,
             indirect_unary_predicate<projected<_Iter, _Proj>> _Predicate>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr iter_difference_t<_Iter>
+  [[nodiscard]] constexpr iter_difference_t<_Iter>
   operator()(_Iter __first, _Sent __last, _Predicate __pred, _Proj __proj = {}) const {
     return std::__count_if<_RangeAlgPolicy>(std::move(__first), std::move(__last), __pred, __proj);
   }
@@ -47,7 +47,7 @@ struct __count_if {
   template <input_range _Range,
             class _Proj = identity,
             indirect_unary_predicate<projected<iterator_t<_Range>, _Proj>> _Predicate>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr range_difference_t<_Range>
+  [[nodiscard]] constexpr range_difference_t<_Range>
   operator()(_Range&& __r, _Predicate __pred, _Proj __proj = {}) const {
     return std::__count_if<_RangeAlgPolicy>(ranges::begin(__r), ranges::end(__r), __pred, __proj);
   }

--- a/libcxx/include/__algorithm/ranges_ends_with.h
+++ b/libcxx/include/__algorithm/ranges_ends_with.h
@@ -39,7 +39,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __ends_with {
   template <class _Iter1, class _Sent1, class _Iter2, class _Sent2, class _Pred, class _Proj1, class _Proj2>
-  _LIBCPP_HIDE_FROM_ABI static constexpr bool __ends_with_fn_impl_bidirectional(
+  static constexpr bool __ends_with_fn_impl_bidirectional(
       _Iter1 __first1,
       _Sent1 __last1,
       _Iter2 __first2,
@@ -56,7 +56,7 @@ struct __ends_with {
   }
 
   template <class _Iter1, class _Sent1, class _Iter2, class _Sent2, class _Pred, class _Proj1, class _Proj2>
-  _LIBCPP_HIDE_FROM_ABI static constexpr bool __ends_with_fn_impl(
+  static constexpr bool __ends_with_fn_impl(
       _Iter1 __first1,
       _Sent1 __last1,
       _Iter2 __first2,
@@ -96,7 +96,7 @@ struct __ends_with {
             class _Proj1,
             class _Proj2,
             class _Offset>
-  static _LIBCPP_HIDE_FROM_ABI constexpr bool __ends_with_fn_impl_with_offset(
+  static constexpr bool __ends_with_fn_impl_with_offset(
       _Iter1 __first1,
       _Sent1 __last1,
       _Iter2 __first2,
@@ -133,7 +133,7 @@ struct __ends_with {
     requires(forward_iterator<_Iter1> || sized_sentinel_for<_Sent1, _Iter1>) &&
             (forward_iterator<_Iter2> || sized_sentinel_for<_Sent2, _Iter2>) &&
             indirectly_comparable<_Iter1, _Iter2, _Pred, _Proj1, _Proj2>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool operator()(
+  [[nodiscard]] constexpr bool operator()(
       _Iter1 __first1,
       _Sent1 __last1,
       _Iter2 __first2,
@@ -152,7 +152,7 @@ struct __ends_with {
             class _Proj2 = identity>
     requires(forward_range<_Range1> || sized_range<_Range1>) && (forward_range<_Range2> || sized_range<_Range2>) &&
             indirectly_comparable<iterator_t<_Range1>, iterator_t<_Range2>, _Pred, _Proj1, _Proj2>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool operator()(
+  [[nodiscard]] constexpr bool operator()(
       _Range1&& __range1, _Range2&& __range2, _Pred __pred = {}, _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const {
     if constexpr (sized_range<_Range1> && sized_range<_Range2>) {
       auto __n1 = ranges::size(__range1);

--- a/libcxx/include/__algorithm/ranges_equal.h
+++ b/libcxx/include/__algorithm/ranges_equal.h
@@ -42,7 +42,7 @@ struct __equal {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires indirectly_comparable<_Iter1, _Iter2, _Pred, _Proj1, _Proj2>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool operator()(
+  [[nodiscard]] constexpr bool operator()(
       _Iter1 __first1,
       _Sent1 __last1,
       _Iter2 __first2,
@@ -69,7 +69,7 @@ struct __equal {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires indirectly_comparable<iterator_t<_Range1>, iterator_t<_Range2>, _Pred, _Proj1, _Proj2>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool operator()(
+  [[nodiscard]] constexpr bool operator()(
       _Range1&& __range1, _Range2&& __range2, _Pred __pred = {}, _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const {
     constexpr bool __both_sized = sized_range<_Range1> && sized_range<_Range2>;
     if constexpr (__both_sized) {

--- a/libcxx/include/__algorithm/ranges_equal_range.h
+++ b/libcxx/include/__algorithm/ranges_equal_range.h
@@ -44,7 +44,7 @@ struct __equal_range {
             class _Tp,
             class _Proj                                                           = identity,
             indirect_strict_weak_order<const _Tp*, projected<_Iter, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr subrange<_Iter>
+  [[nodiscard]] constexpr subrange<_Iter>
   operator()(_Iter __first, _Sent __last, const _Tp& __value, _Comp __comp = {}, _Proj __proj = {}) const {
     auto __ret = std::__equal_range<_RangeAlgPolicy>(std::move(__first), std::move(__last), __value, __comp, __proj);
     return {std::move(__ret.first), std::move(__ret.second)};
@@ -54,7 +54,7 @@ struct __equal_range {
             class _Tp,
             class _Proj                                                                        = identity,
             indirect_strict_weak_order<const _Tp*, projected<iterator_t<_Range>, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr borrowed_subrange_t<_Range>
+  [[nodiscard]] constexpr borrowed_subrange_t<_Range>
   operator()(_Range&& __range, const _Tp& __value, _Comp __comp = {}, _Proj __proj = {}) const {
     auto __ret =
         std::__equal_range<_RangeAlgPolicy>(ranges::begin(__range), ranges::end(__range), __value, __comp, __proj);

--- a/libcxx/include/__algorithm/ranges_fill.h
+++ b/libcxx/include/__algorithm/ranges_fill.h
@@ -32,7 +32,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __fill {
   template <class _Type, output_iterator<const _Type&> _Iter, sentinel_for<_Iter> _Sent>
-  _LIBCPP_HIDE_FROM_ABI constexpr _Iter operator()(_Iter __first, _Sent __last, const _Type& __value) const {
+  constexpr _Iter operator()(_Iter __first, _Sent __last, const _Type& __value) const {
     if constexpr (sized_sentinel_for<_Sent, _Iter>) {
       auto __n = __last - __first;
       return std::__fill_n(std::move(__first), __n, __value);
@@ -42,7 +42,7 @@ struct __fill {
   }
 
   template <class _Type, output_range<const _Type&> _Range>
-  _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Range> operator()(_Range&& __range, const _Type& __value) const {
+  constexpr borrowed_iterator_t<_Range> operator()(_Range&& __range, const _Type& __value) const {
     return (*this)(ranges::begin(__range), ranges::end(__range), __value);
   }
 };

--- a/libcxx/include/__algorithm/ranges_fill_n.h
+++ b/libcxx/include/__algorithm/ranges_fill_n.h
@@ -29,8 +29,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __fill_n {
   template <class _Type, output_iterator<const _Type&> _Iter>
-  _LIBCPP_HIDE_FROM_ABI constexpr _Iter
-  operator()(_Iter __first, iter_difference_t<_Iter> __n, const _Type& __value) const {
+  constexpr _Iter operator()(_Iter __first, iter_difference_t<_Iter> __n, const _Type& __value) const {
     return std::__fill_n(std::move(__first), __n, __value);
   }
 };

--- a/libcxx/include/__algorithm/ranges_find.h
+++ b/libcxx/include/__algorithm/ranges_find.h
@@ -38,8 +38,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __find {
   template <class _Iter, class _Sent, class _Tp, class _Proj>
-  _LIBCPP_HIDE_FROM_ABI static constexpr _Iter
-  __find_unwrap(_Iter __first, _Sent __last, const _Tp& __value, _Proj& __proj) {
+  static constexpr _Iter __find_unwrap(_Iter __first, _Sent __last, const _Tp& __value, _Proj& __proj) {
     if constexpr (forward_iterator<_Iter>) {
       auto [__first_un, __last_un] = std::__unwrap_range(__first, std::move(__last));
       return std::__rewrap_range<_Sent>(
@@ -51,15 +50,13 @@ struct __find {
 
   template <input_iterator _Ip, sentinel_for<_Ip> _Sp, class _Tp, class _Proj = identity>
     requires indirect_binary_predicate<ranges::equal_to, projected<_Ip, _Proj>, const _Tp*>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Ip
-  operator()(_Ip __first, _Sp __last, const _Tp& __value, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr _Ip operator()(_Ip __first, _Sp __last, const _Tp& __value, _Proj __proj = {}) const {
     return __find_unwrap(std::move(__first), std::move(__last), __value, __proj);
   }
 
   template <input_range _Rp, class _Tp, class _Proj = identity>
     requires indirect_binary_predicate<ranges::equal_to, projected<iterator_t<_Rp>, _Proj>, const _Tp*>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Rp>
-  operator()(_Rp&& __r, const _Tp& __value, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr borrowed_iterator_t<_Rp> operator()(_Rp&& __r, const _Tp& __value, _Proj __proj = {}) const {
     return __find_unwrap(ranges::begin(__r), ranges::end(__r), __value, __proj);
   }
 };

--- a/libcxx/include/__algorithm/ranges_find_end.h
+++ b/libcxx/include/__algorithm/ranges_find_end.h
@@ -44,7 +44,7 @@ struct __find_end {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires indirectly_comparable<_Iter1, _Iter2, _Pred, _Proj1, _Proj2>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr subrange<_Iter1> operator()(
+  [[nodiscard]] constexpr subrange<_Iter1> operator()(
       _Iter1 __first1,
       _Sent1 __last1,
       _Iter2 __first2,
@@ -71,7 +71,7 @@ struct __find_end {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires indirectly_comparable<iterator_t<_Range1>, iterator_t<_Range2>, _Pred, _Proj1, _Proj2>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr borrowed_subrange_t<_Range1> operator()(
+  [[nodiscard]] constexpr borrowed_subrange_t<_Range1> operator()(
       _Range1&& __range1, _Range2&& __range2, _Pred __pred = {}, _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const {
     auto __ret = std::__find_end_impl<_RangeAlgPolicy>(
         ranges::begin(__range1),

--- a/libcxx/include/__algorithm/ranges_find_first_of.h
+++ b/libcxx/include/__algorithm/ranges_find_first_of.h
@@ -34,7 +34,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __find_first_of {
   template <class _Iter1, class _Sent1, class _Iter2, class _Sent2, class _Pred, class _Proj1, class _Proj2>
-  _LIBCPP_HIDE_FROM_ABI constexpr static _Iter1 __find_first_of_impl(
+  constexpr static _Iter1 __find_first_of_impl(
       _Iter1 __first1,
       _Sent1 __last1,
       _Iter2 __first2,
@@ -59,7 +59,7 @@ struct __find_first_of {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires indirectly_comparable<_Iter1, _Iter2, _Pred, _Proj1, _Proj2>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Iter1 operator()(
+  [[nodiscard]] constexpr _Iter1 operator()(
       _Iter1 __first1,
       _Sent1 __last1,
       _Iter2 __first2,
@@ -77,7 +77,7 @@ struct __find_first_of {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires indirectly_comparable<iterator_t<_Range1>, iterator_t<_Range2>, _Pred, _Proj1, _Proj2>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Range1> operator()(
+  [[nodiscard]] constexpr borrowed_iterator_t<_Range1> operator()(
       _Range1&& __range1, _Range2&& __range2, _Pred __pred = {}, _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const {
     return __find_first_of_impl(
         ranges::begin(__range1),

--- a/libcxx/include/__algorithm/ranges_find_if.h
+++ b/libcxx/include/__algorithm/ranges_find_if.h
@@ -38,14 +38,12 @@ struct __find_if {
             sentinel_for<_Ip> _Sp,
             class _Proj = identity,
             indirect_unary_predicate<projected<_Ip, _Proj>> _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Ip
-  operator()(_Ip __first, _Sp __last, _Pred __pred, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr _Ip operator()(_Ip __first, _Sp __last, _Pred __pred, _Proj __proj = {}) const {
     return std::__find_if(std::move(__first), std::move(__last), __pred, __proj);
   }
 
   template <input_range _Rp, class _Proj = identity, indirect_unary_predicate<projected<iterator_t<_Rp>, _Proj>> _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Rp>
-  operator()(_Rp&& __r, _Pred __pred, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr borrowed_iterator_t<_Rp> operator()(_Rp&& __r, _Pred __pred, _Proj __proj = {}) const {
     return std::__find_if(ranges::begin(__r), ranges::end(__r), __pred, __proj);
   }
 };

--- a/libcxx/include/__algorithm/ranges_find_if_not.h
+++ b/libcxx/include/__algorithm/ranges_find_if_not.h
@@ -36,14 +36,12 @@ struct __find_if_not {
             sentinel_for<_Ip> _Sp,
             class _Proj = identity,
             indirect_unary_predicate<projected<_Ip, _Proj>> _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Ip
-  operator()(_Ip __first, _Sp __last, _Pred __pred, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr _Ip operator()(_Ip __first, _Sp __last, _Pred __pred, _Proj __proj = {}) const {
     return std::__find_if_not(std::move(__first), std::move(__last), __pred, __proj);
   }
 
   template <input_range _Rp, class _Proj = identity, indirect_unary_predicate<projected<iterator_t<_Rp>, _Proj>> _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Rp>
-  operator()(_Rp&& __r, _Pred __pred, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr borrowed_iterator_t<_Rp> operator()(_Rp&& __r, _Pred __pred, _Proj __proj = {}) const {
     return std::__find_if_not(ranges::begin(__r), ranges::end(__r), __pred, __proj);
   }
 };

--- a/libcxx/include/__algorithm/ranges_find_last.h
+++ b/libcxx/include/__algorithm/ranges_find_last.h
@@ -38,8 +38,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 
 template <class _Iter, class _Sent, class _Pred, class _Proj>
-_LIBCPP_HIDE_FROM_ABI constexpr subrange<_Iter>
-__find_last_impl(_Iter __first, _Sent __last, _Pred __pred, _Proj& __proj) {
+constexpr subrange<_Iter> __find_last_impl(_Iter __first, _Sent __last, _Pred __pred, _Proj& __proj) {
   if (__first == __last) {
     return subrange<_Iter>(__first, __first);
   }
@@ -78,21 +77,21 @@ struct __find_last {
   struct __op {
     const _Type& __value;
     template <class _Elem>
-    _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) operator()(_Elem&& __elem) const {
+    constexpr decltype(auto) operator()(_Elem&& __elem) const {
       return std::forward<_Elem>(__elem) == __value;
     }
   };
 
   template <forward_iterator _Iter, sentinel_for<_Iter> _Sent, class _Type, class _Proj = identity>
     requires indirect_binary_predicate<ranges::equal_to, projected<_Iter, _Proj>, const _Type*>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr static subrange<_Iter>
+  [[nodiscard]] constexpr static subrange<_Iter>
   operator()(_Iter __first, _Sent __last, const _Type& __value, _Proj __proj = {}) {
     return ranges::__find_last_impl(std::move(__first), std::move(__last), __op<_Type>{__value}, __proj);
   }
 
   template <forward_range _Range, class _Type, class _Proj = identity>
     requires indirect_binary_predicate<ranges::equal_to, projected<iterator_t<_Range>, _Proj>, const _Type*>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr static borrowed_subrange_t<_Range>
+  [[nodiscard]] constexpr static borrowed_subrange_t<_Range>
   operator()(_Range&& __range, const _Type& __value, _Proj __proj = {}) {
     return ranges::__find_last_impl(ranges::begin(__range), ranges::end(__range), __op<_Type>{__value}, __proj);
   }
@@ -103,7 +102,7 @@ struct __find_last_if {
   struct __op {
     _Pred& __pred;
     template <class _Elem>
-    _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) operator()(_Elem&& __elem) const {
+    constexpr decltype(auto) operator()(_Elem&& __elem) const {
       return std::invoke(__pred, std::forward<_Elem>(__elem));
     }
   };
@@ -112,7 +111,7 @@ struct __find_last_if {
             sentinel_for<_Iter> _Sent,
             class _Proj = identity,
             indirect_unary_predicate<projected<_Iter, _Proj>> _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr static subrange<_Iter>
+  [[nodiscard]] constexpr static subrange<_Iter>
   operator()(_Iter __first, _Sent __last, _Pred __pred, _Proj __proj = {}) {
     return ranges::__find_last_impl(std::move(__first), std::move(__last), __op<_Pred>{__pred}, __proj);
   }
@@ -120,7 +119,7 @@ struct __find_last_if {
   template <forward_range _Range,
             class _Proj = identity,
             indirect_unary_predicate<projected<iterator_t<_Range>, _Proj>> _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr static borrowed_subrange_t<_Range>
+  [[nodiscard]] constexpr static borrowed_subrange_t<_Range>
   operator()(_Range&& __range, _Pred __pred, _Proj __proj = {}) {
     return ranges::__find_last_impl(ranges::begin(__range), ranges::end(__range), __op<_Pred>{__pred}, __proj);
   }
@@ -131,7 +130,7 @@ struct __find_last_if_not {
   struct __op {
     _Pred& __pred;
     template <class _Elem>
-    _LIBCPP_HIDE_FROM_ABI constexpr decltype(auto) operator()(_Elem&& __elem) const {
+    constexpr decltype(auto) operator()(_Elem&& __elem) const {
       return !std::invoke(__pred, std::forward<_Elem>(__elem));
     }
   };
@@ -140,7 +139,7 @@ struct __find_last_if_not {
             sentinel_for<_Iter> _Sent,
             class _Proj = identity,
             indirect_unary_predicate<projected<_Iter, _Proj>> _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr static subrange<_Iter>
+  [[nodiscard]] constexpr static subrange<_Iter>
   operator()(_Iter __first, _Sent __last, _Pred __pred, _Proj __proj = {}) {
     return ranges::__find_last_impl(std::move(__first), std::move(__last), __op<_Pred>{__pred}, __proj);
   }
@@ -148,7 +147,7 @@ struct __find_last_if_not {
   template <forward_range _Range,
             class _Proj = identity,
             indirect_unary_predicate<projected<iterator_t<_Range>, _Proj>> _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr static borrowed_subrange_t<_Range>
+  [[nodiscard]] constexpr static borrowed_subrange_t<_Range>
   operator()(_Range&& __range, _Pred __pred, _Proj __proj = {}) {
     return ranges::__find_last_impl(ranges::begin(__range), ranges::end(__range), __op<_Pred>{__pred}, __proj);
   }

--- a/libcxx/include/__algorithm/ranges_fold.h
+++ b/libcxx/include/__algorithm/ranges_fold.h
@@ -53,13 +53,13 @@ struct in_value_result {
 
   template <class _I2, class _T2>
     requires convertible_to<const _Ip&, _I2> && convertible_to<const _Tp&, _T2>
-  _LIBCPP_HIDE_FROM_ABI constexpr operator in_value_result<_I2, _T2>() const& {
+  constexpr operator in_value_result<_I2, _T2>() const& {
     return {in, value};
   }
 
   template <class _I2, class _T2>
     requires convertible_to<_Ip, _I2> && convertible_to<_Tp, _T2>
-  _LIBCPP_HIDE_FROM_ABI constexpr operator in_value_result<_I2, _T2>() && {
+  constexpr operator in_value_result<_I2, _T2>() && {
     return {std::move(in), std::move(value)};
   }
 };
@@ -103,7 +103,7 @@ concept __indirectly_binary_right_foldable =
 
 struct __fold_left_with_iter {
   template <input_iterator _Ip, sentinel_for<_Ip> _Sp, class _Tp, __indirectly_binary_left_foldable<_Tp, _Ip> _Fp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr auto operator()(_Ip __first, _Sp __last, _Tp __init, _Fp __f) {
+  [[nodiscard]] static constexpr auto operator()(_Ip __first, _Sp __last, _Tp __init, _Fp __f) {
     using _Up = decay_t<invoke_result_t<_Fp&, _Tp, iter_reference_t<_Ip>>>;
 
     if (__first == __last) {
@@ -125,7 +125,7 @@ struct __fold_left_with_iter {
   }
 
   template <input_range _Rp, class _Tp, __indirectly_binary_left_foldable<_Tp, iterator_t<_Rp>> _Fp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr auto operator()(_Rp&& __r, _Tp __init, _Fp __f) {
+  [[nodiscard]] static constexpr auto operator()(_Rp&& __r, _Tp __init, _Fp __f) {
     auto __result = operator()(ranges::begin(__r), ranges::end(__r), std::move(__init), std::ref(__f));
 
     using _Up = decay_t<invoke_result_t<_Fp&, _Tp, range_reference_t<_Rp>>>;
@@ -137,12 +137,12 @@ inline constexpr auto fold_left_with_iter = __fold_left_with_iter();
 
 struct __fold_left {
   template <input_iterator _Ip, sentinel_for<_Ip> _Sp, class _Tp, __indirectly_binary_left_foldable<_Tp, _Ip> _Fp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr auto operator()(_Ip __first, _Sp __last, _Tp __init, _Fp __f) {
+  [[nodiscard]] static constexpr auto operator()(_Ip __first, _Sp __last, _Tp __init, _Fp __f) {
     return fold_left_with_iter(std::move(__first), std::move(__last), std::move(__init), std::ref(__f)).value;
   }
 
   template <input_range _Rp, class _Tp, __indirectly_binary_left_foldable<_Tp, iterator_t<_Rp>> _Fp>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr auto operator()(_Rp&& __r, _Tp __init, _Fp __f) {
+  [[nodiscard]] static constexpr auto operator()(_Rp&& __r, _Tp __init, _Fp __f) {
     return fold_left_with_iter(ranges::begin(__r), ranges::end(__r), std::move(__init), std::ref(__f)).value;
   }
 };
@@ -154,7 +154,7 @@ struct __fold_left_first_with_iter {
             sentinel_for<_Iter> _Sent,
             __indirectly_binary_left_foldable<iter_value_t<_Iter>, _Iter> _Func>
     requires constructible_from<iter_value_t<_Iter>, iter_reference_t<_Iter>>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr auto operator()(_Iter __first, _Sent __last, _Func __func) {
+  [[nodiscard]] static constexpr auto operator()(_Iter __first, _Sent __last, _Func __func) {
     using _Up = decltype(fold_left(std::move(__first), __last, iter_value_t<_Iter>(*__first), __func));
 
     if (__first == __last)
@@ -176,7 +176,7 @@ struct __fold_left_first_with_iter {
 
   template <input_range _Range, __indirectly_binary_left_foldable<range_value_t<_Range>, iterator_t<_Range>> _Func>
     requires constructible_from<range_value_t<_Range>, range_reference_t<_Range>>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr auto operator()(_Range&& __range, _Func __func) {
+  [[nodiscard]] static constexpr auto operator()(_Range&& __range, _Func __func) {
     auto __result = operator()(ranges::begin(__range), ranges::end(__range), std::ref(__func));
 
     using _Up = decltype(fold_left(
@@ -193,13 +193,13 @@ struct __fold_left_first {
             sentinel_for<_Iter> _Sent,
             __indirectly_binary_left_foldable<iter_value_t<_Iter>, _Iter> _Func>
     requires constructible_from<iter_value_t<_Iter>, iter_reference_t<_Iter>>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr auto operator()(_Iter __first, _Sent __last, _Func __func) {
+  [[nodiscard]] static constexpr auto operator()(_Iter __first, _Sent __last, _Func __func) {
     return fold_left_first_with_iter(std::move(__first), std::move(__last), std::ref(__func)).value;
   }
 
   template <input_range _Range, __indirectly_binary_left_foldable<range_value_t<_Range>, iterator_t<_Range>> _Func>
     requires constructible_from<range_value_t<_Range>, range_reference_t<_Range>>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr auto operator()(_Range&& __range, _Func __func) {
+  [[nodiscard]] static constexpr auto operator()(_Range&& __range, _Func __func) {
     return fold_left_first_with_iter(ranges::begin(__range), ranges::end(__range), std::ref(__func)).value;
   }
 };
@@ -211,8 +211,7 @@ struct __fold_right {
             sentinel_for<_Iter> _Sp,
             class _Tp,
             __indirectly_binary_right_foldable<_Tp, _Iter> _Func>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr auto
-  operator()(_Iter __first, _Sp __last, _Tp __init, _Func __func) {
+  [[nodiscard]] static constexpr auto operator()(_Iter __first, _Sp __last, _Tp __init, _Func __func) {
     using _Up = decay_t<invoke_result_t<_Func&, iter_reference_t<_Iter>, _Tp>>;
 
     if (__first == __last)
@@ -229,7 +228,7 @@ struct __fold_right {
   }
 
   template <bidirectional_range _Range, class _Tp, __indirectly_binary_right_foldable<_Tp, iterator_t<_Range>> _Func>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr auto operator()(_Range&& __range, _Tp __init, _Func __func) {
+  [[nodiscard]] static constexpr auto operator()(_Range&& __range, _Tp __init, _Func __func) {
     return operator()(ranges::begin(__range), ranges::end(__range), std::move(__init), std::ref(__func));
   }
 };
@@ -240,7 +239,7 @@ struct __fold_right_last {
   template <bidirectional_iterator _Iter,
             sentinel_for<_Iter> _Sp,
             __indirectly_binary_right_foldable<iter_value_t<_Iter>, _Iter> _Func>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr auto operator()(_Iter __first, _Sp __last, _Func __func) {
+  [[nodiscard]] static constexpr auto operator()(_Iter __first, _Sp __last, _Func __func) {
     using _Up = decltype(fold_right(__first, __last, iter_value_t<_Iter>(*__first), __func));
 
     if (__first == __last)
@@ -253,7 +252,7 @@ struct __fold_right_last {
 
   template <bidirectional_range _Range,
             __indirectly_binary_right_foldable<range_value_t<_Range>, iterator_t<_Range>> _Func>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr auto operator()(_Range&& __range, _Func __func) {
+  [[nodiscard]] static constexpr auto operator()(_Range&& __range, _Func __func) {
     return operator()(ranges::begin(__range), ranges::end(__range), std::ref(__func));
   }
 };

--- a/libcxx/include/__algorithm/ranges_for_each.h
+++ b/libcxx/include/__algorithm/ranges_for_each.h
@@ -43,7 +43,7 @@ using for_each_result = in_fun_result<_Iter, _Func>;
 struct __for_each {
 private:
   template <class _Iter, class _Sent, class _Proj, class _Func>
-  _LIBCPP_HIDE_FROM_ABI constexpr static for_each_result<_Iter, _Func>
+  constexpr static for_each_result<_Iter, _Func>
   __for_each_impl(_Iter __first, _Sent __last, _Func& __func, _Proj& __proj) {
     // In the case where we have different iterator and sentinel types, the segmented iterator optimization
     // in std::for_each will not kick in. Therefore, we prefer std::for_each_n in that case (whenever we can
@@ -63,7 +63,7 @@ public:
             sentinel_for<_Iter> _Sent,
             class _Proj = identity,
             indirectly_unary_invocable<projected<_Iter, _Proj>> _Func>
-  _LIBCPP_HIDE_FROM_ABI constexpr for_each_result<_Iter, _Func>
+  constexpr for_each_result<_Iter, _Func>
   operator()(_Iter __first, _Sent __last, _Func __func, _Proj __proj = {}) const {
     return __for_each_impl(std::move(__first), std::move(__last), __func, __proj);
   }
@@ -71,7 +71,7 @@ public:
   template <input_range _Range,
             class _Proj = identity,
             indirectly_unary_invocable<projected<iterator_t<_Range>, _Proj>> _Func>
-  _LIBCPP_HIDE_FROM_ABI constexpr for_each_result<borrowed_iterator_t<_Range>, _Func>
+  constexpr for_each_result<borrowed_iterator_t<_Range>, _Func>
   operator()(_Range&& __range, _Func __func, _Proj __proj = {}) const {
     using _SpecialAlg = __specialized_algorithm<_Algorithm::__for_each, __single_range<remove_cvref_t<_Range>>>;
     if constexpr (_SpecialAlg::__has_algorithm) {

--- a/libcxx/include/__algorithm/ranges_for_each_n.h
+++ b/libcxx/include/__algorithm/ranges_for_each_n.h
@@ -38,7 +38,7 @@ using for_each_n_result = in_fun_result<_Iter, _Func>;
 
 struct __for_each_n {
   template <input_iterator _Iter, class _Proj = identity, indirectly_unary_invocable<projected<_Iter, _Proj>> _Func>
-  _LIBCPP_HIDE_FROM_ABI constexpr for_each_n_result<_Iter, _Func>
+  constexpr for_each_n_result<_Iter, _Func>
   operator()(_Iter __first, iter_difference_t<_Iter> __count, _Func __func, _Proj __proj = {}) const {
     auto __last = std::__for_each_n(std::move(__first), __count, __func, __proj);
     return {std::move(__last), std::move(__func)};

--- a/libcxx/include/__algorithm/ranges_generate.h
+++ b/libcxx/include/__algorithm/ranges_generate.h
@@ -34,7 +34,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __generate {
   template <class _OutIter, class _Sent, class _Func>
-  _LIBCPP_HIDE_FROM_ABI constexpr static _OutIter __generate_fn_impl(_OutIter __first, _Sent __last, _Func& __gen) {
+  constexpr static _OutIter __generate_fn_impl(_OutIter __first, _Sent __last, _Func& __gen) {
     for (; __first != __last; ++__first) {
       *__first = __gen();
     }
@@ -44,13 +44,13 @@ struct __generate {
 
   template <input_or_output_iterator _OutIter, sentinel_for<_OutIter> _Sent, copy_constructible _Func>
     requires invocable<_Func&> && indirectly_writable<_OutIter, invoke_result_t<_Func&>>
-  _LIBCPP_HIDE_FROM_ABI constexpr _OutIter operator()(_OutIter __first, _Sent __last, _Func __gen) const {
+  constexpr _OutIter operator()(_OutIter __first, _Sent __last, _Func __gen) const {
     return __generate_fn_impl(std::move(__first), std::move(__last), __gen);
   }
 
   template <class _Range, copy_constructible _Func>
     requires invocable<_Func&> && output_range<_Range, invoke_result_t<_Func&>>
-  _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Range> operator()(_Range&& __range, _Func __gen) const {
+  constexpr borrowed_iterator_t<_Range> operator()(_Range&& __range, _Func __gen) const {
     return __generate_fn_impl(ranges::begin(__range), ranges::end(__range), __gen);
   }
 };

--- a/libcxx/include/__algorithm/ranges_generate_n.h
+++ b/libcxx/include/__algorithm/ranges_generate_n.h
@@ -37,8 +37,7 @@ namespace ranges {
 struct __generate_n {
   template <input_or_output_iterator _OutIter, copy_constructible _Func>
     requires invocable<_Func&> && indirectly_writable<_OutIter, invoke_result_t<_Func&>>
-  _LIBCPP_HIDE_FROM_ABI constexpr _OutIter
-  operator()(_OutIter __first, iter_difference_t<_OutIter> __n, _Func __gen) const {
+  constexpr _OutIter operator()(_OutIter __first, iter_difference_t<_OutIter> __n, _Func __gen) const {
     return std::__generate_n(std::move(__first), __n, __gen);
   }
 };

--- a/libcxx/include/__algorithm/ranges_includes.h
+++ b/libcxx/include/__algorithm/ranges_includes.h
@@ -43,7 +43,7 @@ struct __includes {
             class _Proj1                                                                           = identity,
             class _Proj2                                                                           = identity,
             indirect_strict_weak_order<projected<_Iter1, _Proj1>, projected<_Iter2, _Proj2>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool operator()(
+  [[nodiscard]] constexpr bool operator()(
       _Iter1 __first1,
       _Sent1 __last1,
       _Iter2 __first2,
@@ -67,7 +67,7 @@ struct __includes {
             class _Proj2 = identity,
             indirect_strict_weak_order<projected<iterator_t<_Range1>, _Proj1>, projected<iterator_t<_Range2>, _Proj2>>
                 _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool operator()(
+  [[nodiscard]] constexpr bool operator()(
       _Range1&& __range1, _Range2&& __range2, _Comp __comp = {}, _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const {
     return std::__includes(
         ranges::begin(__range1),

--- a/libcxx/include/__algorithm/ranges_inplace_merge.h
+++ b/libcxx/include/__algorithm/ranges_inplace_merge.h
@@ -41,7 +41,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __inplace_merge {
   template <class _Iter, class _Sent, class _Comp, class _Proj>
-  _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX26 auto
+  static _LIBCPP_CONSTEXPR_SINCE_CXX26 auto
   __inplace_merge_impl(_Iter __first, _Iter __middle, _Sent __last, _Comp&& __comp, _Proj&& __proj) {
     auto __last_iter = ranges::next(__middle, __last);
     std::__inplace_merge<_RangeAlgPolicy>(
@@ -51,7 +51,7 @@ struct __inplace_merge {
 
   template <bidirectional_iterator _Iter, sentinel_for<_Iter> _Sent, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<_Iter, _Comp, _Proj>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 _Iter
+  _LIBCPP_CONSTEXPR_SINCE_CXX26 _Iter
   operator()(_Iter __first, _Iter __middle, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
     return __inplace_merge_impl(
         std::move(__first), std::move(__middle), std::move(__last), std::move(__comp), std::move(__proj));
@@ -59,7 +59,7 @@ struct __inplace_merge {
 
   template <bidirectional_range _Range, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<iterator_t<_Range>, _Comp, _Proj>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 borrowed_iterator_t<_Range>
+  _LIBCPP_CONSTEXPR_SINCE_CXX26 borrowed_iterator_t<_Range>
   operator()(_Range&& __range, iterator_t<_Range> __middle, _Comp __comp = {}, _Proj __proj = {}) const {
     return __inplace_merge_impl(
         ranges::begin(__range), std::move(__middle), ranges::end(__range), std::move(__comp), std::move(__proj));

--- a/libcxx/include/__algorithm/ranges_is_heap.h
+++ b/libcxx/include/__algorithm/ranges_is_heap.h
@@ -36,8 +36,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __is_heap {
   template <class _Iter, class _Sent, class _Proj, class _Comp>
-  _LIBCPP_HIDE_FROM_ABI constexpr static bool
-  __is_heap_fn_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
+  constexpr static bool __is_heap_fn_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
     auto __last_iter        = ranges::next(__first, __last);
     auto&& __projected_comp = std::__make_projected(__comp, __proj);
 
@@ -49,16 +48,14 @@ struct __is_heap {
             sentinel_for<_Iter> _Sent,
             class _Proj                                               = identity,
             indirect_strict_weak_order<projected<_Iter, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool
-  operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr bool operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
     return __is_heap_fn_impl(std::move(__first), std::move(__last), __comp, __proj);
   }
 
   template <random_access_range _Range,
             class _Proj                                                            = identity,
             indirect_strict_weak_order<projected<iterator_t<_Range>, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool
-  operator()(_Range&& __range, _Comp __comp = {}, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr bool operator()(_Range&& __range, _Comp __comp = {}, _Proj __proj = {}) const {
     return __is_heap_fn_impl(ranges::begin(__range), ranges::end(__range), __comp, __proj);
   }
 };

--- a/libcxx/include/__algorithm/ranges_is_heap_until.h
+++ b/libcxx/include/__algorithm/ranges_is_heap_until.h
@@ -37,8 +37,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __is_heap_until {
   template <class _Iter, class _Sent, class _Proj, class _Comp>
-  _LIBCPP_HIDE_FROM_ABI constexpr static _Iter
-  __is_heap_until_fn_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
+  constexpr static _Iter __is_heap_until_fn_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
     auto __last_iter        = ranges::next(__first, __last);
     auto&& __projected_comp = std::__make_projected(__comp, __proj);
 
@@ -49,15 +48,14 @@ struct __is_heap_until {
             sentinel_for<_Iter> _Sent,
             class _Proj                                               = identity,
             indirect_strict_weak_order<projected<_Iter, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Iter
-  operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr _Iter operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
     return __is_heap_until_fn_impl(std::move(__first), std::move(__last), __comp, __proj);
   }
 
   template <random_access_range _Range,
             class _Proj                                                            = identity,
             indirect_strict_weak_order<projected<iterator_t<_Range>, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Range>
+  [[nodiscard]] constexpr borrowed_iterator_t<_Range>
   operator()(_Range&& __range, _Comp __comp = {}, _Proj __proj = {}) const {
     return __is_heap_until_fn_impl(ranges::begin(__range), ranges::end(__range), __comp, __proj);
   }

--- a/libcxx/include/__algorithm/ranges_is_partitioned.h
+++ b/libcxx/include/__algorithm/ranges_is_partitioned.h
@@ -33,8 +33,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __is_partitioned {
   template <class _Iter, class _Sent, class _Proj, class _Pred>
-  _LIBCPP_HIDE_FROM_ABI constexpr static bool
-  __is_partitioned_impl(_Iter __first, _Sent __last, _Pred& __pred, _Proj& __proj) {
+  constexpr static bool __is_partitioned_impl(_Iter __first, _Sent __last, _Pred& __pred, _Proj& __proj) {
     for (; __first != __last; ++__first) {
       if (!std::invoke(__pred, std::invoke(__proj, *__first)))
         break;
@@ -56,16 +55,14 @@ struct __is_partitioned {
             sentinel_for<_Iter> _Sent,
             class _Proj = identity,
             indirect_unary_predicate<projected<_Iter, _Proj>> _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool
-  operator()(_Iter __first, _Sent __last, _Pred __pred, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr bool operator()(_Iter __first, _Sent __last, _Pred __pred, _Proj __proj = {}) const {
     return __is_partitioned_impl(std::move(__first), std::move(__last), __pred, __proj);
   }
 
   template <input_range _Range,
             class _Proj = identity,
             indirect_unary_predicate<projected<iterator_t<_Range>, _Proj>> _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool
-  operator()(_Range&& __range, _Pred __pred, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr bool operator()(_Range&& __range, _Pred __pred, _Proj __proj = {}) const {
     return __is_partitioned_impl(ranges::begin(__range), ranges::end(__range), __pred, __proj);
   }
 };

--- a/libcxx/include/__algorithm/ranges_is_permutation.h
+++ b/libcxx/include/__algorithm/ranges_is_permutation.h
@@ -35,7 +35,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __is_permutation {
   template <class _Iter1, class _Sent1, class _Iter2, class _Sent2, class _Proj1, class _Proj2, class _Pred>
-  _LIBCPP_HIDE_FROM_ABI constexpr static bool __is_permutation_func_impl(
+  constexpr static bool __is_permutation_func_impl(
       _Iter1 __first1,
       _Sent1 __last1,
       _Iter2 __first2,
@@ -55,7 +55,7 @@ struct __is_permutation {
       class _Proj1                                                                              = identity,
       class _Proj2                                                                              = identity,
       indirect_equivalence_relation<projected<_Iter1, _Proj1>, projected<_Iter2, _Proj2>> _Pred = ranges::equal_to>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool operator()(
+  [[nodiscard]] constexpr bool operator()(
       _Iter1 __first1,
       _Sent1 __last1,
       _Iter2 __first2,
@@ -73,7 +73,7 @@ struct __is_permutation {
             class _Proj2                                                                = identity,
             indirect_equivalence_relation<projected<iterator_t<_Range1>, _Proj1>,
                                           projected<iterator_t<_Range2>, _Proj2>> _Pred = ranges::equal_to>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool operator()(
+  [[nodiscard]] constexpr bool operator()(
       _Range1&& __range1, _Range2&& __range2, _Pred __pred = {}, _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const {
     if constexpr (sized_range<_Range1> && sized_range<_Range2>) {
       if (ranges::distance(__range1) != ranges::distance(__range2))

--- a/libcxx/include/__algorithm/ranges_is_sorted.h
+++ b/libcxx/include/__algorithm/ranges_is_sorted.h
@@ -36,16 +36,14 @@ struct __is_sorted {
             sentinel_for<_Iter> _Sent,
             class _Proj                                               = identity,
             indirect_strict_weak_order<projected<_Iter, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool
-  operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr bool operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
     return ranges::__is_sorted_until_impl(std::move(__first), __last, __comp, __proj) == __last;
   }
 
   template <forward_range _Range,
             class _Proj                                                            = identity,
             indirect_strict_weak_order<projected<iterator_t<_Range>, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool
-  operator()(_Range&& __range, _Comp __comp = {}, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr bool operator()(_Range&& __range, _Comp __comp = {}, _Proj __proj = {}) const {
     auto __last = ranges::end(__range);
     return ranges::__is_sorted_until_impl(ranges::begin(__range), __last, __comp, __proj) == __last;
   }

--- a/libcxx/include/__algorithm/ranges_is_sorted_until.h
+++ b/libcxx/include/__algorithm/ranges_is_sorted_until.h
@@ -34,8 +34,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 
 template <class _Iter, class _Sent, class _Proj, class _Comp>
-_LIBCPP_HIDE_FROM_ABI constexpr _Iter
-__is_sorted_until_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
+constexpr _Iter __is_sorted_until_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
   if (__first == __last)
     return __first;
   auto __i = __first;
@@ -52,15 +51,14 @@ struct __is_sorted_until {
             sentinel_for<_Iter> _Sent,
             class _Proj                                               = identity,
             indirect_strict_weak_order<projected<_Iter, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Iter
-  operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr _Iter operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
     return ranges::__is_sorted_until_impl(std::move(__first), std::move(__last), __comp, __proj);
   }
 
   template <forward_range _Range,
             class _Proj                                                            = identity,
             indirect_strict_weak_order<projected<iterator_t<_Range>, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Range>
+  [[nodiscard]] constexpr borrowed_iterator_t<_Range>
   operator()(_Range&& __range, _Comp __comp = {}, _Proj __proj = {}) const {
     return ranges::__is_sorted_until_impl(ranges::begin(__range), ranges::end(__range), __comp, __proj);
   }

--- a/libcxx/include/__algorithm/ranges_lexicographical_compare.h
+++ b/libcxx/include/__algorithm/ranges_lexicographical_compare.h
@@ -35,7 +35,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __lexicographical_compare {
   template <class _Iter1, class _Sent1, class _Iter2, class _Sent2, class _Proj1, class _Proj2, class _Comp>
-  static _LIBCPP_HIDE_FROM_ABI constexpr bool __lexicographical_compare_unwrap(
+  static constexpr bool __lexicographical_compare_unwrap(
       _Iter1 __first1,
       _Sent1 __last1,
       _Iter2 __first2,
@@ -62,7 +62,7 @@ struct __lexicographical_compare {
             class _Proj1                                                                           = identity,
             class _Proj2                                                                           = identity,
             indirect_strict_weak_order<projected<_Iter1, _Proj1>, projected<_Iter2, _Proj2>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool operator()(
+  [[nodiscard]] constexpr bool operator()(
       _Iter1 __first1,
       _Sent1 __last1,
       _Iter2 __first2,
@@ -80,7 +80,7 @@ struct __lexicographical_compare {
             class _Proj2 = identity,
             indirect_strict_weak_order<projected<iterator_t<_Range1>, _Proj1>, projected<iterator_t<_Range2>, _Proj2>>
                 _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool operator()(
+  [[nodiscard]] constexpr bool operator()(
       _Range1&& __range1, _Range2&& __range2, _Comp __comp = {}, _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const {
     return __lexicographical_compare_unwrap(
         ranges::begin(__range1),

--- a/libcxx/include/__algorithm/ranges_lower_bound.h
+++ b/libcxx/include/__algorithm/ranges_lower_bound.h
@@ -42,7 +42,7 @@ struct __lower_bound {
             class _Type,
             class _Proj                                                             = identity,
             indirect_strict_weak_order<const _Type*, projected<_Iter, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Iter
+  [[nodiscard]] constexpr _Iter
   operator()(_Iter __first, _Sent __last, const _Type& __value, _Comp __comp = {}, _Proj __proj = {}) const {
     return std::__lower_bound<_RangeAlgPolicy>(__first, __last, __value, __comp, __proj);
   }
@@ -51,7 +51,7 @@ struct __lower_bound {
             class _Type,
             class _Proj                                                                          = identity,
             indirect_strict_weak_order<const _Type*, projected<iterator_t<_Range>, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Range>
+  [[nodiscard]] constexpr borrowed_iterator_t<_Range>
   operator()(_Range&& __r, const _Type& __value, _Comp __comp = {}, _Proj __proj = {}) const {
     return std::__lower_bound<_RangeAlgPolicy>(ranges::begin(__r), ranges::end(__r), __value, __comp, __proj);
   }

--- a/libcxx/include/__algorithm/ranges_make_heap.h
+++ b/libcxx/include/__algorithm/ranges_make_heap.h
@@ -42,8 +42,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __make_heap {
   template <class _Iter, class _Sent, class _Comp, class _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr static _Iter
-  __make_heap_fn_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
+  constexpr static _Iter __make_heap_fn_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
     auto __last_iter = ranges::next(__first, __last);
 
     auto&& __projected_comp = std::__make_projected(__comp, __proj);
@@ -54,15 +53,13 @@ struct __make_heap {
 
   template <random_access_iterator _Iter, sentinel_for<_Iter> _Sent, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<_Iter, _Comp, _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr _Iter
-  operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
+  constexpr _Iter operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
     return __make_heap_fn_impl(std::move(__first), std::move(__last), __comp, __proj);
   }
 
   template <random_access_range _Range, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<iterator_t<_Range>, _Comp, _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Range>
-  operator()(_Range&& __r, _Comp __comp = {}, _Proj __proj = {}) const {
+  constexpr borrowed_iterator_t<_Range> operator()(_Range&& __r, _Comp __comp = {}, _Proj __proj = {}) const {
     return __make_heap_fn_impl(ranges::begin(__r), ranges::end(__r), __comp, __proj);
   }
 };

--- a/libcxx/include/__algorithm/ranges_max.h
+++ b/libcxx/include/__algorithm/ranges_max.h
@@ -40,7 +40,7 @@ struct __max {
   template <class _Tp,
             class _Proj                                                    = identity,
             indirect_strict_weak_order<projected<const _Tp*, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr const _Tp&
+  [[nodiscard]] constexpr const _Tp&
   operator()(_LIBCPP_LIFETIMEBOUND const _Tp& __a,
              _LIBCPP_LIFETIMEBOUND const _Tp& __b,
              _Comp __comp = {},
@@ -51,8 +51,7 @@ struct __max {
   template <copyable _Tp,
             class _Proj                                                    = identity,
             indirect_strict_weak_order<projected<const _Tp*, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Tp
-  operator()(initializer_list<_Tp> __il, _Comp __comp = {}, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr _Tp operator()(initializer_list<_Tp> __il, _Comp __comp = {}, _Proj __proj = {}) const {
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(
         __il.begin() != __il.end(), "initializer_list must contain at least one element");
 
@@ -64,8 +63,7 @@ struct __max {
             class _Proj                                                         = identity,
             indirect_strict_weak_order<projected<iterator_t<_Rp>, _Proj>> _Comp = ranges::less>
     requires indirectly_copyable_storable<iterator_t<_Rp>, range_value_t<_Rp>*>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr range_value_t<_Rp>
-  operator()(_Rp&& __r, _Comp __comp = {}, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr range_value_t<_Rp> operator()(_Rp&& __r, _Comp __comp = {}, _Proj __proj = {}) const {
     auto __first = ranges::begin(__r);
     auto __last  = ranges::end(__r);
 

--- a/libcxx/include/__algorithm/ranges_max_element.h
+++ b/libcxx/include/__algorithm/ranges_max_element.h
@@ -37,8 +37,7 @@ struct __max_element {
             sentinel_for<_Ip> _Sp,
             class _Proj                                             = identity,
             indirect_strict_weak_order<projected<_Ip, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Ip
-  operator()(_Ip __first, _Sp __last, _Comp __comp = {}, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr _Ip operator()(_Ip __first, _Sp __last, _Comp __comp = {}, _Proj __proj = {}) const {
     auto __comp_lhs_rhs_swapped = [&](auto&& __lhs, auto&& __rhs) -> bool { return std::invoke(__comp, __rhs, __lhs); };
     return std::__min_element(__first, __last, __comp_lhs_rhs_swapped, __proj);
   }
@@ -46,8 +45,7 @@ struct __max_element {
   template <forward_range _Rp,
             class _Proj                                                         = identity,
             indirect_strict_weak_order<projected<iterator_t<_Rp>, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Rp>
-  operator()(_Rp&& __r, _Comp __comp = {}, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr borrowed_iterator_t<_Rp> operator()(_Rp&& __r, _Comp __comp = {}, _Proj __proj = {}) const {
     auto __comp_lhs_rhs_swapped = [&](auto&& __lhs, auto&& __rhs) -> bool { return std::invoke(__comp, __rhs, __lhs); };
     return std::__min_element(ranges::begin(__r), ranges::end(__r), __comp_lhs_rhs_swapped, __proj);
   }

--- a/libcxx/include/__algorithm/ranges_merge.h
+++ b/libcxx/include/__algorithm/ranges_merge.h
@@ -49,7 +49,7 @@ struct __merge {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires mergeable<_InIter1, _InIter2, _OutIter, _Comp, _Proj1, _Proj2>
-  _LIBCPP_HIDE_FROM_ABI constexpr merge_result<_InIter1, _InIter2, _OutIter> operator()(
+  constexpr merge_result<_InIter1, _InIter2, _OutIter> operator()(
       _InIter1 __first1,
       _Sent1 __last1,
       _InIter2 __first2,
@@ -68,7 +68,7 @@ struct __merge {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires mergeable<iterator_t<_Range1>, iterator_t<_Range2>, _OutIter, _Comp, _Proj1, _Proj2>
-  _LIBCPP_HIDE_FROM_ABI constexpr merge_result<borrowed_iterator_t<_Range1>, borrowed_iterator_t<_Range2>, _OutIter>
+  constexpr merge_result<borrowed_iterator_t<_Range1>, borrowed_iterator_t<_Range2>, _OutIter>
   operator()(_Range1&& __range1,
              _Range2&& __range2,
              _OutIter __result,
@@ -94,9 +94,7 @@ struct __merge {
              class _Comp,
              class _Proj1,
              class _Proj2>
-  _LIBCPP_HIDE_FROM_ABI static constexpr merge_result<__remove_cvref_t<_InIter1>,
-                                                      __remove_cvref_t<_InIter2>,
-                                                      __remove_cvref_t<_OutIter>>
+  static constexpr merge_result<__remove_cvref_t<_InIter1>, __remove_cvref_t<_InIter2>, __remove_cvref_t<_OutIter>>
   __merge_impl(_InIter1&& __first1,
                _Sent1&& __last1,
                _InIter2&& __first2,

--- a/libcxx/include/__algorithm/ranges_min.h
+++ b/libcxx/include/__algorithm/ranges_min.h
@@ -39,7 +39,7 @@ struct __min {
   template <class _Tp,
             class _Proj                                                    = identity,
             indirect_strict_weak_order<projected<const _Tp*, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr const _Tp&
+  [[nodiscard]] constexpr const _Tp&
   operator()(_LIBCPP_LIFETIMEBOUND const _Tp& __a,
              _LIBCPP_LIFETIMEBOUND const _Tp& __b,
              _Comp __comp = {},
@@ -50,8 +50,7 @@ struct __min {
   template <copyable _Tp,
             class _Proj                                                    = identity,
             indirect_strict_weak_order<projected<const _Tp*, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Tp
-  operator()(initializer_list<_Tp> __il, _Comp __comp = {}, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr _Tp operator()(initializer_list<_Tp> __il, _Comp __comp = {}, _Proj __proj = {}) const {
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(
         __il.begin() != __il.end(), "initializer_list must contain at least one element");
     return *std::__min_element(__il.begin(), __il.end(), __comp, __proj);
@@ -61,8 +60,7 @@ struct __min {
             class _Proj                                                         = identity,
             indirect_strict_weak_order<projected<iterator_t<_Rp>, _Proj>> _Comp = ranges::less>
     requires indirectly_copyable_storable<iterator_t<_Rp>, range_value_t<_Rp>*>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr range_value_t<_Rp>
-  operator()(_Rp&& __r, _Comp __comp = {}, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr range_value_t<_Rp> operator()(_Rp&& __r, _Comp __comp = {}, _Proj __proj = {}) const {
     auto __first = ranges::begin(__r);
     auto __last  = ranges::end(__r);
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(__first != __last, "range must contain at least one element");

--- a/libcxx/include/__algorithm/ranges_min_element.h
+++ b/libcxx/include/__algorithm/ranges_min_element.h
@@ -38,16 +38,14 @@ struct __min_element {
             sentinel_for<_Ip> _Sp,
             class _Proj                                             = identity,
             indirect_strict_weak_order<projected<_Ip, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Ip
-  operator()(_Ip __first, _Sp __last, _Comp __comp = {}, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr _Ip operator()(_Ip __first, _Sp __last, _Comp __comp = {}, _Proj __proj = {}) const {
     return std::__min_element(__first, __last, __comp, __proj);
   }
 
   template <forward_range _Rp,
             class _Proj                                                         = identity,
             indirect_strict_weak_order<projected<iterator_t<_Rp>, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Rp>
-  operator()(_Rp&& __r, _Comp __comp = {}, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr borrowed_iterator_t<_Rp> operator()(_Rp&& __r, _Comp __comp = {}, _Proj __proj = {}) const {
     return std::__min_element(ranges::begin(__r), ranges::end(__r), __comp, __proj);
   }
 };

--- a/libcxx/include/__algorithm/ranges_minmax.h
+++ b/libcxx/include/__algorithm/ranges_minmax.h
@@ -52,7 +52,7 @@ struct __minmax {
   template <class _Type,
             class _Proj                                                      = identity,
             indirect_strict_weak_order<projected<const _Type*, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr ranges::minmax_result<const _Type&>
+  [[nodiscard]] constexpr ranges::minmax_result<const _Type&>
   operator()(_LIBCPP_LIFETIMEBOUND const _Type& __a,
              _LIBCPP_LIFETIMEBOUND const _Type& __b,
              _Comp __comp = {},
@@ -65,7 +65,7 @@ struct __minmax {
   template <copyable _Type,
             class _Proj                                                      = identity,
             indirect_strict_weak_order<projected<const _Type*, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr ranges::minmax_result<_Type>
+  [[nodiscard]] constexpr ranges::minmax_result<_Type>
   operator()(initializer_list<_Type> __il, _Comp __comp = {}, _Proj __proj = {}) const {
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(
         __il.begin() != __il.end(), "initializer_list has to contain at least one element");
@@ -77,7 +77,7 @@ struct __minmax {
             class _Proj                                                            = identity,
             indirect_strict_weak_order<projected<iterator_t<_Range>, _Proj>> _Comp = ranges::less>
     requires indirectly_copyable_storable<iterator_t<_Range>, range_value_t<_Range>*>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr ranges::minmax_result<range_value_t<_Range>>
+  [[nodiscard]] constexpr ranges::minmax_result<range_value_t<_Range>>
   operator()(_Range&& __r, _Comp __comp = {}, _Proj __proj = {}) const {
     auto __first  = ranges::begin(__r);
     auto __last   = ranges::end(__r);

--- a/libcxx/include/__algorithm/ranges_minmax_element.h
+++ b/libcxx/include/__algorithm/ranges_minmax_element.h
@@ -45,7 +45,7 @@ struct __minmax_element {
             sentinel_for<_Ip> _Sp,
             class _Proj                                             = identity,
             indirect_strict_weak_order<projected<_Ip, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr ranges::minmax_element_result<_Ip>
+  [[nodiscard]] constexpr ranges::minmax_element_result<_Ip>
   operator()(_Ip __first, _Sp __last, _Comp __comp = {}, _Proj __proj = {}) const {
     auto __ret = std::__minmax_element_impl(std::move(__first), std::move(__last), __comp, __proj);
     return {__ret.first, __ret.second};
@@ -54,7 +54,7 @@ struct __minmax_element {
   template <forward_range _Rp,
             class _Proj                                                         = identity,
             indirect_strict_weak_order<projected<iterator_t<_Rp>, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr ranges::minmax_element_result<borrowed_iterator_t<_Rp>>
+  [[nodiscard]] constexpr ranges::minmax_element_result<borrowed_iterator_t<_Rp>>
   operator()(_Rp&& __r, _Comp __comp = {}, _Proj __proj = {}) const {
     auto __ret = std::__minmax_element_impl(ranges::begin(__r), ranges::end(__r), __comp, __proj);
     return {__ret.first, __ret.second};

--- a/libcxx/include/__algorithm/ranges_mismatch.h
+++ b/libcxx/include/__algorithm/ranges_mismatch.h
@@ -41,7 +41,7 @@ using mismatch_result = in_in_result<_I1, _I2>;
 
 struct __mismatch {
   template <class _I1, class _S1, class _I2, class _S2, class _Pred, class _Proj1, class _Proj2>
-  static _LIBCPP_HIDE_FROM_ABI constexpr mismatch_result<_I1, _I2>
+  static constexpr mismatch_result<_I1, _I2>
   __go(_I1 __first1, _S1 __last1, _I2 __first2, _S2 __last2, _Pred& __pred, _Proj1& __proj1, _Proj2& __proj2) {
     if constexpr (forward_iterator<_I1> && forward_iterator<_I2>) {
       auto __range1 = std::__unwrap_range(__first1, __last1);
@@ -64,7 +64,7 @@ struct __mismatch {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires indirectly_comparable<_I1, _I2, _Pred, _Proj1, _Proj2>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr mismatch_result<_I1, _I2> operator()(
+  [[nodiscard]] constexpr mismatch_result<_I1, _I2> operator()(
       _I1 __first1, _S1 __last1, _I2 __first2, _S2 __last2, _Pred __pred = {}, _Proj1 __proj1 = {}, _Proj2 __proj2 = {})
       const {
     return __go(std::move(__first1), __last1, std::move(__first2), __last2, __pred, __proj1, __proj2);
@@ -76,8 +76,7 @@ struct __mismatch {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires indirectly_comparable<iterator_t<_R1>, iterator_t<_R2>, _Pred, _Proj1, _Proj2>
-  [[nodiscard]]
-  _LIBCPP_HIDE_FROM_ABI constexpr mismatch_result<borrowed_iterator_t<_R1>, borrowed_iterator_t<_R2>>
+  [[nodiscard]] constexpr mismatch_result<borrowed_iterator_t<_R1>, borrowed_iterator_t<_R2>>
   operator()(_R1&& __r1, _R2&& __r2, _Pred __pred = {}, _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const {
     return __go(
         ranges::begin(__r1), ranges::end(__r1), ranges::begin(__r2), ranges::end(__r2), __pred, __proj1, __proj2);

--- a/libcxx/include/__algorithm/ranges_move.h
+++ b/libcxx/include/__algorithm/ranges_move.h
@@ -38,15 +38,13 @@ using move_result = in_out_result<_InIter, _OutIter>;
 struct __move {
   template <input_iterator _InIter, sentinel_for<_InIter> _Sent, weakly_incrementable _OutIter>
     requires indirectly_movable<_InIter, _OutIter>
-  _LIBCPP_HIDE_FROM_ABI constexpr move_result<_InIter, _OutIter>
-  operator()(_InIter __first, _Sent __last, _OutIter __result) const {
+  constexpr move_result<_InIter, _OutIter> operator()(_InIter __first, _Sent __last, _OutIter __result) const {
     return std::__move<_RangeAlgPolicy>(std::move(__first), std::move(__last), std::move(__result));
   }
 
   template <input_range _Range, weakly_incrementable _OutIter>
     requires indirectly_movable<iterator_t<_Range>, _OutIter>
-  _LIBCPP_HIDE_FROM_ABI constexpr move_result<borrowed_iterator_t<_Range>, _OutIter>
-  operator()(_Range&& __range, _OutIter __result) const {
+  constexpr move_result<borrowed_iterator_t<_Range>, _OutIter> operator()(_Range&& __range, _OutIter __result) const {
     return std::__move<_RangeAlgPolicy>(ranges::begin(__range), ranges::end(__range), std::move(__result));
   }
 };

--- a/libcxx/include/__algorithm/ranges_move_backward.h
+++ b/libcxx/include/__algorithm/ranges_move_backward.h
@@ -40,14 +40,13 @@ using move_backward_result = in_out_result<_InIter, _OutIter>;
 struct __move_backward {
   template <bidirectional_iterator _InIter, sentinel_for<_InIter> _Sent, bidirectional_iterator _OutIter>
     requires indirectly_movable<_InIter, _OutIter>
-  _LIBCPP_HIDE_FROM_ABI constexpr move_backward_result<_InIter, _OutIter>
-  operator()(_InIter __first, _Sent __last, _OutIter __result) const {
+  constexpr move_backward_result<_InIter, _OutIter> operator()(_InIter __first, _Sent __last, _OutIter __result) const {
     return std::__move_backward<_RangeAlgPolicy>(std::move(__first), std::move(__last), std::move(__result));
   }
 
   template <bidirectional_range _Range, bidirectional_iterator _Iter>
     requires indirectly_movable<iterator_t<_Range>, _Iter>
-  _LIBCPP_HIDE_FROM_ABI constexpr move_backward_result<borrowed_iterator_t<_Range>, _Iter>
+  constexpr move_backward_result<borrowed_iterator_t<_Range>, _Iter>
   operator()(_Range&& __range, _Iter __result) const {
     return std::__move_backward<_RangeAlgPolicy>(ranges::begin(__range), ranges::end(__range), std::move(__result));
   }

--- a/libcxx/include/__algorithm/ranges_next_permutation.h
+++ b/libcxx/include/__algorithm/ranges_next_permutation.h
@@ -43,7 +43,7 @@ using next_permutation_result = in_found_result<_InIter>;
 struct __next_permutation {
   template <bidirectional_iterator _Iter, sentinel_for<_Iter> _Sent, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<_Iter, _Comp, _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr next_permutation_result<_Iter>
+  constexpr next_permutation_result<_Iter>
   operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
     auto __result = std::__next_permutation<_RangeAlgPolicy>(
         std::move(__first), std::move(__last), std::__make_projected(__comp, __proj));
@@ -52,7 +52,7 @@ struct __next_permutation {
 
   template <bidirectional_range _Range, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<iterator_t<_Range>, _Comp, _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr next_permutation_result<borrowed_iterator_t<_Range>>
+  constexpr next_permutation_result<borrowed_iterator_t<_Range>>
   operator()(_Range&& __range, _Comp __comp = {}, _Proj __proj = {}) const {
     auto __result = std::__next_permutation<_RangeAlgPolicy>(
         ranges::begin(__range), ranges::end(__range), std::__make_projected(__comp, __proj));

--- a/libcxx/include/__algorithm/ranges_none_of.h
+++ b/libcxx/include/__algorithm/ranges_none_of.h
@@ -32,8 +32,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __none_of {
   template <class _Iter, class _Sent, class _Proj, class _Pred>
-  _LIBCPP_HIDE_FROM_ABI constexpr static bool
-  __none_of_impl(_Iter __first, _Sent __last, _Pred& __pred, _Proj& __proj) {
+  constexpr static bool __none_of_impl(_Iter __first, _Sent __last, _Pred& __pred, _Proj& __proj) {
     for (; __first != __last; ++__first) {
       if (std::invoke(__pred, std::invoke(__proj, *__first)))
         return false;
@@ -45,16 +44,14 @@ struct __none_of {
             sentinel_for<_Iter> _Sent,
             class _Proj = identity,
             indirect_unary_predicate<projected<_Iter, _Proj>> _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool
-  operator()(_Iter __first, _Sent __last, _Pred __pred = {}, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr bool operator()(_Iter __first, _Sent __last, _Pred __pred = {}, _Proj __proj = {}) const {
     return __none_of_impl(std::move(__first), std::move(__last), __pred, __proj);
   }
 
   template <input_range _Range,
             class _Proj = identity,
             indirect_unary_predicate<projected<iterator_t<_Range>, _Proj>> _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool
-  operator()(_Range&& __range, _Pred __pred, _Proj __proj = {}) const {
+  [[nodiscard]] constexpr bool operator()(_Range&& __range, _Pred __pred, _Proj __proj = {}) const {
     return __none_of_impl(ranges::begin(__range), ranges::end(__range), __pred, __proj);
   }
 };

--- a/libcxx/include/__algorithm/ranges_nth_element.h
+++ b/libcxx/include/__algorithm/ranges_nth_element.h
@@ -41,8 +41,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __nth_element {
   template <class _Iter, class _Sent, class _Comp, class _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr static _Iter
-  __nth_element_fn_impl(_Iter __first, _Iter __nth, _Sent __last, _Comp& __comp, _Proj& __proj) {
+  constexpr static _Iter __nth_element_fn_impl(_Iter __first, _Iter __nth, _Sent __last, _Comp& __comp, _Proj& __proj) {
     auto __last_iter = ranges::next(__first, __last);
 
     auto&& __projected_comp = std::__make_projected(__comp, __proj);
@@ -53,14 +52,13 @@ struct __nth_element {
 
   template <random_access_iterator _Iter, sentinel_for<_Iter> _Sent, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<_Iter, _Comp, _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr _Iter
-  operator()(_Iter __first, _Iter __nth, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
+  constexpr _Iter operator()(_Iter __first, _Iter __nth, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
     return __nth_element_fn_impl(std::move(__first), std::move(__nth), std::move(__last), __comp, __proj);
   }
 
   template <random_access_range _Range, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<iterator_t<_Range>, _Comp, _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Range>
+  constexpr borrowed_iterator_t<_Range>
   operator()(_Range&& __r, iterator_t<_Range> __nth, _Comp __comp = {}, _Proj __proj = {}) const {
     return __nth_element_fn_impl(ranges::begin(__r), std::move(__nth), ranges::end(__r), __comp, __proj);
   }

--- a/libcxx/include/__algorithm/ranges_partial_sort.h
+++ b/libcxx/include/__algorithm/ranges_partial_sort.h
@@ -43,7 +43,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __partial_sort {
   template <class _Iter, class _Sent, class _Comp, class _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr static _Iter
+  constexpr static _Iter
   __partial_sort_fn_impl(_Iter __first, _Iter __middle, _Sent __last, _Comp& __comp, _Proj& __proj) {
     auto&& __projected_comp = std::__make_projected(__comp, __proj);
     return std::__partial_sort<_RangeAlgPolicy>(std::move(__first), std::move(__middle), __last, __projected_comp);
@@ -51,14 +51,13 @@ struct __partial_sort {
 
   template <random_access_iterator _Iter, sentinel_for<_Iter> _Sent, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<_Iter, _Comp, _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr _Iter
-  operator()(_Iter __first, _Iter __middle, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
+  constexpr _Iter operator()(_Iter __first, _Iter __middle, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
     return __partial_sort_fn_impl(std::move(__first), std::move(__middle), std::move(__last), __comp, __proj);
   }
 
   template <random_access_range _Range, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<iterator_t<_Range>, _Comp, _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Range>
+  constexpr borrowed_iterator_t<_Range>
   operator()(_Range&& __r, iterator_t<_Range> __middle, _Comp __comp = {}, _Proj __proj = {}) const {
     return __partial_sort_fn_impl(ranges::begin(__r), std::move(__middle), ranges::end(__r), __comp, __proj);
   }

--- a/libcxx/include/__algorithm/ranges_partial_sort_copy.h
+++ b/libcxx/include/__algorithm/ranges_partial_sort_copy.h
@@ -52,7 +52,7 @@ struct __partial_sort_copy {
             class _Proj2 = identity>
     requires indirectly_copyable<_Iter1, _Iter2> && sortable<_Iter2, _Comp, _Proj2> &&
              indirect_strict_weak_order<_Comp, projected<_Iter1, _Proj1>, projected<_Iter2, _Proj2>>
-  _LIBCPP_HIDE_FROM_ABI constexpr partial_sort_copy_result<_Iter1, _Iter2> operator()(
+  constexpr partial_sort_copy_result<_Iter1, _Iter2> operator()(
       _Iter1 __first,
       _Sent1 __last,
       _Iter2 __result_first,
@@ -80,8 +80,7 @@ struct __partial_sort_copy {
              indirect_strict_weak_order<_Comp,
                                         projected<iterator_t<_Range1>, _Proj1>,
                                         projected<iterator_t<_Range2>, _Proj2>>
-  _LIBCPP_HIDE_FROM_ABI constexpr partial_sort_copy_result<borrowed_iterator_t<_Range1>, borrowed_iterator_t<_Range2>>
-  operator()(
+  constexpr partial_sort_copy_result<borrowed_iterator_t<_Range1>, borrowed_iterator_t<_Range2>> operator()(
       _Range1&& __range, _Range2&& __result_range, _Comp __comp = {}, _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const {
     return std::__partial_sort_copy<_RangeAlgPolicy>(
         ranges::begin(__range),

--- a/libcxx/include/__algorithm/ranges_partition.h
+++ b/libcxx/include/__algorithm/ranges_partition.h
@@ -43,7 +43,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __partition {
   template <class _Iter, class _Sent, class _Proj, class _Pred>
-  _LIBCPP_HIDE_FROM_ABI static constexpr subrange<__remove_cvref_t<_Iter>>
+  static constexpr subrange<__remove_cvref_t<_Iter>>
   __partition_fn_impl(_Iter&& __first, _Sent&& __last, _Pred&& __pred, _Proj&& __proj) {
     auto&& __projected_pred = std::__make_projected(__pred, __proj);
     auto __result           = std::__partition<_RangeAlgPolicy>(
@@ -56,8 +56,7 @@ struct __partition {
             sentinel_for<_Iter> _Sent,
             class _Proj = identity,
             indirect_unary_predicate<projected<_Iter, _Proj>> _Pred>
-  _LIBCPP_HIDE_FROM_ABI constexpr subrange<_Iter>
-  operator()(_Iter __first, _Sent __last, _Pred __pred, _Proj __proj = {}) const {
+  constexpr subrange<_Iter> operator()(_Iter __first, _Sent __last, _Pred __pred, _Proj __proj = {}) const {
     return __partition_fn_impl(__first, __last, __pred, __proj);
   }
 
@@ -65,8 +64,7 @@ struct __partition {
             class _Proj = identity,
             indirect_unary_predicate<projected<iterator_t<_Range>, _Proj>> _Pred>
     requires permutable<iterator_t<_Range>>
-  _LIBCPP_HIDE_FROM_ABI constexpr borrowed_subrange_t<_Range>
-  operator()(_Range&& __range, _Pred __pred, _Proj __proj = {}) const {
+  constexpr borrowed_subrange_t<_Range> operator()(_Range&& __range, _Pred __pred, _Proj __proj = {}) const {
     return __partition_fn_impl(ranges::begin(__range), ranges::end(__range), __pred, __proj);
   }
 };

--- a/libcxx/include/__algorithm/ranges_partition_copy.h
+++ b/libcxx/include/__algorithm/ranges_partition_copy.h
@@ -41,9 +41,9 @@ using partition_copy_result = in_out_out_result<_InIter, _OutIter1, _OutIter2>;
 struct __partition_copy {
   // TODO(ranges): delegate to the classic algorithm.
   template <class _InIter, class _Sent, class _OutIter1, class _OutIter2, class _Proj, class _Pred>
-  _LIBCPP_HIDE_FROM_ABI constexpr static partition_copy_result<__remove_cvref_t<_InIter>,
-                                                               __remove_cvref_t<_OutIter1>,
-                                                               __remove_cvref_t<_OutIter2> >
+  constexpr static partition_copy_result<__remove_cvref_t<_InIter>,
+                                         __remove_cvref_t<_OutIter1>,
+                                         __remove_cvref_t<_OutIter2> >
   __partition_copy_fn_impl(
       _InIter&& __first,
       _Sent&& __last,
@@ -72,7 +72,7 @@ struct __partition_copy {
             class _Proj = identity,
             indirect_unary_predicate<projected<_InIter, _Proj>> _Pred>
     requires indirectly_copyable<_InIter, _OutIter1> && indirectly_copyable<_InIter, _OutIter2>
-  _LIBCPP_HIDE_FROM_ABI constexpr partition_copy_result<_InIter, _OutIter1, _OutIter2> operator()(
+  constexpr partition_copy_result<_InIter, _OutIter1, _OutIter2> operator()(
       _InIter __first, _Sent __last, _OutIter1 __out_true, _OutIter2 __out_false, _Pred __pred, _Proj __proj = {})
       const {
     return __partition_copy_fn_impl(
@@ -85,7 +85,7 @@ struct __partition_copy {
             class _Proj = identity,
             indirect_unary_predicate<projected<iterator_t<_Range>, _Proj>> _Pred>
     requires indirectly_copyable<iterator_t<_Range>, _OutIter1> && indirectly_copyable<iterator_t<_Range>, _OutIter2>
-  _LIBCPP_HIDE_FROM_ABI constexpr partition_copy_result<borrowed_iterator_t<_Range>, _OutIter1, _OutIter2>
+  constexpr partition_copy_result<borrowed_iterator_t<_Range>, _OutIter1, _OutIter2>
   operator()(_Range&& __range, _OutIter1 __out_true, _OutIter2 __out_false, _Pred __pred, _Proj __proj = {}) const {
     return __partition_copy_fn_impl(
         ranges::begin(__range), ranges::end(__range), std::move(__out_true), std::move(__out_false), __pred, __proj);

--- a/libcxx/include/__algorithm/ranges_partition_point.h
+++ b/libcxx/include/__algorithm/ranges_partition_point.h
@@ -38,8 +38,7 @@ namespace ranges {
 struct __partition_point {
   // TODO(ranges): delegate to the classic algorithm.
   template <class _Iter, class _Sent, class _Proj, class _Pred>
-  _LIBCPP_HIDE_FROM_ABI constexpr static _Iter
-  __partition_point_fn_impl(_Iter&& __first, _Sent&& __last, _Pred& __pred, _Proj& __proj) {
+  constexpr static _Iter __partition_point_fn_impl(_Iter&& __first, _Sent&& __last, _Pred& __pred, _Proj& __proj) {
     auto __len = ranges::distance(__first, __last);
 
     while (__len != 0) {
@@ -62,15 +61,14 @@ struct __partition_point {
             sentinel_for<_Iter> _Sent,
             class _Proj = identity,
             indirect_unary_predicate<projected<_Iter, _Proj>> _Pred>
-  _LIBCPP_HIDE_FROM_ABI constexpr _Iter operator()(_Iter __first, _Sent __last, _Pred __pred, _Proj __proj = {}) const {
+  constexpr _Iter operator()(_Iter __first, _Sent __last, _Pred __pred, _Proj __proj = {}) const {
     return __partition_point_fn_impl(std::move(__first), std::move(__last), __pred, __proj);
   }
 
   template <forward_range _Range,
             class _Proj = identity,
             indirect_unary_predicate<projected<iterator_t<_Range>, _Proj>> _Pred>
-  _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Range>
-  operator()(_Range&& __range, _Pred __pred, _Proj __proj = {}) const {
+  constexpr borrowed_iterator_t<_Range> operator()(_Range&& __range, _Pred __pred, _Proj __proj = {}) const {
     return __partition_point_fn_impl(ranges::begin(__range), ranges::end(__range), __pred, __proj);
   }
 };

--- a/libcxx/include/__algorithm/ranges_pop_heap.h
+++ b/libcxx/include/__algorithm/ranges_pop_heap.h
@@ -42,8 +42,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __pop_heap {
   template <class _Iter, class _Sent, class _Comp, class _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr static _Iter
-  __pop_heap_fn_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
+  constexpr static _Iter __pop_heap_fn_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
     auto __last_iter = ranges::next(__first, __last);
     auto __len       = __last_iter - __first;
 
@@ -55,15 +54,13 @@ struct __pop_heap {
 
   template <random_access_iterator _Iter, sentinel_for<_Iter> _Sent, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<_Iter, _Comp, _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr _Iter
-  operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
+  constexpr _Iter operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
     return __pop_heap_fn_impl(std::move(__first), std::move(__last), __comp, __proj);
   }
 
   template <random_access_range _Range, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<iterator_t<_Range>, _Comp, _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Range>
-  operator()(_Range&& __r, _Comp __comp = {}, _Proj __proj = {}) const {
+  constexpr borrowed_iterator_t<_Range> operator()(_Range&& __r, _Comp __comp = {}, _Proj __proj = {}) const {
     return __pop_heap_fn_impl(ranges::begin(__r), ranges::end(__r), __comp, __proj);
   }
 };

--- a/libcxx/include/__algorithm/ranges_prev_permutation.h
+++ b/libcxx/include/__algorithm/ranges_prev_permutation.h
@@ -43,7 +43,7 @@ using prev_permutation_result = in_found_result<_InIter>;
 struct __prev_permutation {
   template <bidirectional_iterator _Iter, sentinel_for<_Iter> _Sent, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<_Iter, _Comp, _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr prev_permutation_result<_Iter>
+  constexpr prev_permutation_result<_Iter>
   operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
     auto __result = std::__prev_permutation<_RangeAlgPolicy>(
         std::move(__first), std::move(__last), std::__make_projected(__comp, __proj));
@@ -52,7 +52,7 @@ struct __prev_permutation {
 
   template <bidirectional_range _Range, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<iterator_t<_Range>, _Comp, _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr prev_permutation_result<borrowed_iterator_t<_Range>>
+  constexpr prev_permutation_result<borrowed_iterator_t<_Range>>
   operator()(_Range&& __range, _Comp __comp = {}, _Proj __proj = {}) const {
     auto __result = std::__prev_permutation<_RangeAlgPolicy>(
         ranges::begin(__range), ranges::end(__range), std::__make_projected(__comp, __proj));

--- a/libcxx/include/__algorithm/ranges_push_heap.h
+++ b/libcxx/include/__algorithm/ranges_push_heap.h
@@ -42,8 +42,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __push_heap {
   template <class _Iter, class _Sent, class _Comp, class _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr static _Iter
-  __push_heap_fn_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
+  constexpr static _Iter __push_heap_fn_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
     auto __last_iter = ranges::next(__first, __last);
 
     auto&& __projected_comp = std::__make_projected(__comp, __proj);
@@ -54,15 +53,13 @@ struct __push_heap {
 
   template <random_access_iterator _Iter, sentinel_for<_Iter> _Sent, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<_Iter, _Comp, _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr _Iter
-  operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
+  constexpr _Iter operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
     return __push_heap_fn_impl(std::move(__first), std::move(__last), __comp, __proj);
   }
 
   template <random_access_range _Range, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<iterator_t<_Range>, _Comp, _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Range>
-  operator()(_Range&& __r, _Comp __comp = {}, _Proj __proj = {}) const {
+  constexpr borrowed_iterator_t<_Range> operator()(_Range&& __r, _Comp __comp = {}, _Proj __proj = {}) const {
     return __push_heap_fn_impl(ranges::begin(__r), ranges::end(__r), __comp, __proj);
   }
 };

--- a/libcxx/include/__algorithm/ranges_remove.h
+++ b/libcxx/include/__algorithm/ranges_remove.h
@@ -36,7 +36,7 @@ namespace ranges {
 struct __remove {
   template <permutable _Iter, sentinel_for<_Iter> _Sent, class _Type, class _Proj = identity>
     requires indirect_binary_predicate<ranges::equal_to, projected<_Iter, _Proj>, const _Type*>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr subrange<_Iter>
+  [[nodiscard]] constexpr subrange<_Iter>
   operator()(_Iter __first, _Sent __last, const _Type& __value, _Proj __proj = {}) const {
     auto __pred = [&](auto&& __other) -> bool { return __value == __other; };
     return ranges::__remove_if_impl(std::move(__first), std::move(__last), __pred, __proj);
@@ -45,7 +45,7 @@ struct __remove {
   template <forward_range _Range, class _Type, class _Proj = identity>
     requires permutable<iterator_t<_Range>> &&
              indirect_binary_predicate<ranges::equal_to, projected<iterator_t<_Range>, _Proj>, const _Type*>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr borrowed_subrange_t<_Range>
+  [[nodiscard]] constexpr borrowed_subrange_t<_Range>
   operator()(_Range&& __range, const _Type& __value, _Proj __proj = {}) const {
     auto __pred = [&](auto&& __other) -> bool { return __value == __other; };
     return ranges::__remove_if_impl(ranges::begin(__range), ranges::end(__range), __pred, __proj);

--- a/libcxx/include/__algorithm/ranges_remove_copy.h
+++ b/libcxx/include/__algorithm/ranges_remove_copy.h
@@ -46,7 +46,7 @@ struct __remove_copy {
             class _Proj = identity>
     requires indirectly_copyable<_InIter, _OutIter> &&
              indirect_binary_predicate<ranges::equal_to, projected<_InIter, _Proj>, const _Type*>
-  _LIBCPP_HIDE_FROM_ABI constexpr remove_copy_result<_InIter, _OutIter>
+  constexpr remove_copy_result<_InIter, _OutIter>
   operator()(_InIter __first, _Sent __last, _OutIter __result, const _Type& __value, _Proj __proj = {}) const {
     auto __pred = [&](auto&& __val) -> bool { return __value == __val; };
     return ranges::__remove_copy_if_impl(std::move(__first), std::move(__last), std::move(__result), __pred, __proj);
@@ -55,7 +55,7 @@ struct __remove_copy {
   template <input_range _Range, weakly_incrementable _OutIter, class _Type, class _Proj = identity>
     requires indirectly_copyable<iterator_t<_Range>, _OutIter> &&
              indirect_binary_predicate<ranges::equal_to, projected<iterator_t<_Range>, _Proj>, const _Type*>
-  _LIBCPP_HIDE_FROM_ABI constexpr remove_copy_result<borrowed_iterator_t<_Range>, _OutIter>
+  constexpr remove_copy_result<borrowed_iterator_t<_Range>, _OutIter>
   operator()(_Range&& __range, _OutIter __result, const _Type& __value, _Proj __proj = {}) const {
     auto __pred = [&](auto&& __val) -> bool { return __value == __val; };
     return ranges::__remove_copy_if_impl(

--- a/libcxx/include/__algorithm/ranges_remove_copy_if.h
+++ b/libcxx/include/__algorithm/ranges_remove_copy_if.h
@@ -42,7 +42,7 @@ template <class _InIter, class _OutIter>
 using remove_copy_if_result = in_out_result<_InIter, _OutIter>;
 
 template <class _InIter, class _Sent, class _OutIter, class _Proj, class _Pred>
-_LIBCPP_HIDE_FROM_ABI constexpr in_out_result<_InIter, _OutIter>
+constexpr in_out_result<_InIter, _OutIter>
 __remove_copy_if_impl(_InIter __first, _Sent __last, _OutIter __result, _Pred& __pred, _Proj& __proj) {
   for (; __first != __last; ++__first) {
     if (!std::invoke(__pred, std::invoke(__proj, *__first))) {
@@ -60,7 +60,7 @@ struct __remove_copy_if {
             class _Proj = identity,
             indirect_unary_predicate<projected<_InIter, _Proj>> _Pred>
     requires indirectly_copyable<_InIter, _OutIter>
-  _LIBCPP_HIDE_FROM_ABI constexpr remove_copy_if_result<_InIter, _OutIter>
+  constexpr remove_copy_if_result<_InIter, _OutIter>
   operator()(_InIter __first, _Sent __last, _OutIter __result, _Pred __pred, _Proj __proj = {}) const {
     return ranges::__remove_copy_if_impl(std::move(__first), std::move(__last), std::move(__result), __pred, __proj);
   }
@@ -70,7 +70,7 @@ struct __remove_copy_if {
             class _Proj = identity,
             indirect_unary_predicate<projected<iterator_t<_Range>, _Proj>> _Pred>
     requires indirectly_copyable<iterator_t<_Range>, _OutIter>
-  _LIBCPP_HIDE_FROM_ABI constexpr remove_copy_if_result<borrowed_iterator_t<_Range>, _OutIter>
+  constexpr remove_copy_if_result<borrowed_iterator_t<_Range>, _OutIter>
   operator()(_Range&& __range, _OutIter __result, _Pred __pred, _Proj __proj = {}) const {
     return ranges::__remove_copy_if_impl(
         ranges::begin(__range), ranges::end(__range), std::move(__result), __pred, __proj);

--- a/libcxx/include/__algorithm/ranges_remove_if.h
+++ b/libcxx/include/__algorithm/ranges_remove_if.h
@@ -36,8 +36,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 
 template <class _Iter, class _Sent, class _Proj, class _Pred>
-_LIBCPP_HIDE_FROM_ABI constexpr subrange<_Iter>
-__remove_if_impl(_Iter __first, _Sent __last, _Pred& __pred, _Proj& __proj) {
+constexpr subrange<_Iter> __remove_if_impl(_Iter __first, _Sent __last, _Pred& __pred, _Proj& __proj) {
   auto __new_end = std::__find_if(__first, __last, __pred, __proj);
   if (__new_end == __last)
     return {__new_end, __new_end};
@@ -57,7 +56,7 @@ struct __remove_if {
             sentinel_for<_Iter> _Sent,
             class _Proj = identity,
             indirect_unary_predicate<projected<_Iter, _Proj>> _Pred>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr subrange<_Iter>
+  [[nodiscard]] constexpr subrange<_Iter>
   operator()(_Iter __first, _Sent __last, _Pred __pred, _Proj __proj = {}) const {
     return ranges::__remove_if_impl(std::move(__first), std::move(__last), __pred, __proj);
   }
@@ -66,7 +65,7 @@ struct __remove_if {
             class _Proj = identity,
             indirect_unary_predicate<projected<iterator_t<_Range>, _Proj>> _Pred>
     requires permutable<iterator_t<_Range>>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr borrowed_subrange_t<_Range>
+  [[nodiscard]] constexpr borrowed_subrange_t<_Range>
   operator()(_Range&& __range, _Pred __pred, _Proj __proj = {}) const {
     return ranges::__remove_if_impl(ranges::begin(__range), ranges::end(__range), __pred, __proj);
   }

--- a/libcxx/include/__algorithm/ranges_replace.h
+++ b/libcxx/include/__algorithm/ranges_replace.h
@@ -36,7 +36,7 @@ struct __replace {
   template <input_iterator _Iter, sentinel_for<_Iter> _Sent, class _Type1, class _Type2, class _Proj = identity>
     requires indirectly_writable<_Iter, const _Type2&> &&
              indirect_binary_predicate<ranges::equal_to, projected<_Iter, _Proj>, const _Type1*>
-  _LIBCPP_HIDE_FROM_ABI constexpr _Iter operator()(
+  constexpr _Iter operator()(
       _Iter __first, _Sent __last, const _Type1& __old_value, const _Type2& __new_value, _Proj __proj = {}) const {
     auto __pred = [&](const auto& __val) -> bool { return __val == __old_value; };
     return ranges::__replace_if_impl(std::move(__first), std::move(__last), __pred, __new_value, __proj);
@@ -45,7 +45,7 @@ struct __replace {
   template <input_range _Range, class _Type1, class _Type2, class _Proj = identity>
     requires indirectly_writable<iterator_t<_Range>, const _Type2&> &&
              indirect_binary_predicate<ranges::equal_to, projected<iterator_t<_Range>, _Proj>, const _Type1*>
-  _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Range>
+  constexpr borrowed_iterator_t<_Range>
   operator()(_Range&& __range, const _Type1& __old_value, const _Type2& __new_value, _Proj __proj = {}) const {
     auto __pred = [&](auto&& __val) -> bool { return __val == __old_value; };
     return ranges::__replace_if_impl(ranges::begin(__range), ranges::end(__range), __pred, __new_value, __proj);

--- a/libcxx/include/__algorithm/ranges_replace_copy.h
+++ b/libcxx/include/__algorithm/ranges_replace_copy.h
@@ -47,7 +47,7 @@ struct __replace_copy {
             class _Proj = identity>
     requires indirectly_copyable<_InIter, _OutIter> &&
              indirect_binary_predicate<ranges::equal_to, projected<_InIter, _Proj>, const _OldType*>
-  _LIBCPP_HIDE_FROM_ABI constexpr replace_copy_result<_InIter, _OutIter>
+  constexpr replace_copy_result<_InIter, _OutIter>
   operator()(_InIter __first,
              _Sent __last,
              _OutIter __result,
@@ -66,7 +66,7 @@ struct __replace_copy {
             class _Proj = identity>
     requires indirectly_copyable<iterator_t<_Range>, _OutIter> &&
              indirect_binary_predicate<ranges::equal_to, projected<iterator_t<_Range>, _Proj>, const _OldType*>
-  _LIBCPP_HIDE_FROM_ABI constexpr replace_copy_result<borrowed_iterator_t<_Range>, _OutIter> operator()(
+  constexpr replace_copy_result<borrowed_iterator_t<_Range>, _OutIter> operator()(
       _Range&& __range, _OutIter __result, const _OldType& __old_value, const _NewType& __new_value, _Proj __proj = {})
       const {
     auto __pred = [&](const auto& __value) -> bool { return __value == __old_value; };

--- a/libcxx/include/__algorithm/ranges_replace_copy_if.h
+++ b/libcxx/include/__algorithm/ranges_replace_copy_if.h
@@ -37,7 +37,7 @@ template <class _InIter, class _OutIter>
 using replace_copy_if_result = in_out_result<_InIter, _OutIter>;
 
 template <class _InIter, class _Sent, class _OutIter, class _Pred, class _Type, class _Proj>
-_LIBCPP_HIDE_FROM_ABI constexpr replace_copy_if_result<_InIter, _OutIter> __replace_copy_if_impl(
+constexpr replace_copy_if_result<_InIter, _OutIter> __replace_copy_if_impl(
     _InIter __first, _Sent __last, _OutIter __result, _Pred& __pred, const _Type& __new_value, _Proj& __proj) {
   while (__first != __last) {
     if (std::invoke(__pred, std::invoke(__proj, *__first)))
@@ -60,7 +60,7 @@ struct __replace_copy_if {
             class _Proj = identity,
             indirect_unary_predicate<projected<_InIter, _Proj>> _Pred>
     requires indirectly_copyable<_InIter, _OutIter>
-  _LIBCPP_HIDE_FROM_ABI constexpr replace_copy_if_result<_InIter, _OutIter> operator()(
+  constexpr replace_copy_if_result<_InIter, _OutIter> operator()(
       _InIter __first, _Sent __last, _OutIter __result, _Pred __pred, const _Type& __new_value, _Proj __proj = {})
       const {
     return ranges::__replace_copy_if_impl(
@@ -73,7 +73,7 @@ struct __replace_copy_if {
             class _Proj = identity,
             indirect_unary_predicate<projected<iterator_t<_Range>, _Proj>> _Pred>
     requires indirectly_copyable<iterator_t<_Range>, _OutIter>
-  _LIBCPP_HIDE_FROM_ABI constexpr replace_copy_if_result<borrowed_iterator_t<_Range>, _OutIter>
+  constexpr replace_copy_if_result<borrowed_iterator_t<_Range>, _OutIter>
   operator()(_Range&& __range, _OutIter __result, _Pred __pred, const _Type& __new_value, _Proj __proj = {}) const {
     return ranges::__replace_copy_if_impl(
         ranges::begin(__range), ranges::end(__range), std::move(__result), __pred, __new_value, __proj);

--- a/libcxx/include/__algorithm/ranges_replace_if.h
+++ b/libcxx/include/__algorithm/ranges_replace_if.h
@@ -33,8 +33,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 
 template <class _Iter, class _Sent, class _Type, class _Proj, class _Pred>
-_LIBCPP_HIDE_FROM_ABI constexpr _Iter
-__replace_if_impl(_Iter __first, _Sent __last, _Pred& __pred, const _Type& __new_value, _Proj& __proj) {
+constexpr _Iter __replace_if_impl(_Iter __first, _Sent __last, _Pred& __pred, const _Type& __new_value, _Proj& __proj) {
   for (; __first != __last; ++__first) {
     if (std::invoke(__pred, std::invoke(__proj, *__first)))
       *__first = __new_value;
@@ -49,7 +48,7 @@ struct __replace_if {
             class _Proj = identity,
             indirect_unary_predicate<projected<_Iter, _Proj>> _Pred>
     requires indirectly_writable<_Iter, const _Type&>
-  _LIBCPP_HIDE_FROM_ABI constexpr _Iter
+  constexpr _Iter
   operator()(_Iter __first, _Sent __last, _Pred __pred, const _Type& __new_value, _Proj __proj = {}) const {
     return ranges::__replace_if_impl(std::move(__first), std::move(__last), __pred, __new_value, __proj);
   }
@@ -59,7 +58,7 @@ struct __replace_if {
             class _Proj = identity,
             indirect_unary_predicate<projected<iterator_t<_Range>, _Proj>> _Pred>
     requires indirectly_writable<iterator_t<_Range>, const _Type&>
-  _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Range>
+  constexpr borrowed_iterator_t<_Range>
   operator()(_Range&& __range, _Pred __pred, const _Type& __new_value, _Proj __proj = {}) const {
     return ranges::__replace_if_impl(ranges::begin(__range), ranges::end(__range), __pred, __new_value, __proj);
   }

--- a/libcxx/include/__algorithm/ranges_reverse.h
+++ b/libcxx/include/__algorithm/ranges_reverse.h
@@ -30,7 +30,7 @@ namespace ranges {
 struct __reverse {
   template <bidirectional_iterator _Iter, sentinel_for<_Iter> _Sent>
     requires permutable<_Iter>
-  _LIBCPP_HIDE_FROM_ABI constexpr _Iter operator()(_Iter __first, _Sent __last) const {
+  constexpr _Iter operator()(_Iter __first, _Sent __last) const {
     if constexpr (random_access_iterator<_Iter>) {
       if (__first == __last)
         return __first;
@@ -60,7 +60,7 @@ struct __reverse {
 
   template <bidirectional_range _Range>
     requires permutable<iterator_t<_Range>>
-  _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Range> operator()(_Range&& __range) const {
+  constexpr borrowed_iterator_t<_Range> operator()(_Range&& __range) const {
     return (*this)(ranges::begin(__range), ranges::end(__range));
   }
 };

--- a/libcxx/include/__algorithm/ranges_reverse_copy.h
+++ b/libcxx/include/__algorithm/ranges_reverse_copy.h
@@ -41,14 +41,13 @@ using reverse_copy_result = in_out_result<_InIter, _OutIter>;
 struct __reverse_copy {
   template <bidirectional_iterator _InIter, sentinel_for<_InIter> _Sent, weakly_incrementable _OutIter>
     requires indirectly_copyable<_InIter, _OutIter>
-  _LIBCPP_HIDE_FROM_ABI constexpr reverse_copy_result<_InIter, _OutIter>
-  operator()(_InIter __first, _Sent __last, _OutIter __result) const {
+  constexpr reverse_copy_result<_InIter, _OutIter> operator()(_InIter __first, _Sent __last, _OutIter __result) const {
     return (*this)(subrange(std::move(__first), std::move(__last)), std::move(__result));
   }
 
   template <bidirectional_range _Range, weakly_incrementable _OutIter>
     requires indirectly_copyable<iterator_t<_Range>, _OutIter>
-  _LIBCPP_HIDE_FROM_ABI constexpr reverse_copy_result<borrowed_iterator_t<_Range>, _OutIter>
+  constexpr reverse_copy_result<borrowed_iterator_t<_Range>, _OutIter>
   operator()(_Range&& __range, _OutIter __result) const {
     auto __ret = ranges::copy(__range | views::reverse, std::move(__result));
     return {ranges::next(ranges::begin(__range), ranges::end(__range)), std::move(__ret.out)};

--- a/libcxx/include/__algorithm/ranges_rotate.h
+++ b/libcxx/include/__algorithm/ranges_rotate.h
@@ -35,20 +35,19 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __rotate {
   template <class _Iter, class _Sent>
-  _LIBCPP_HIDE_FROM_ABI constexpr static subrange<_Iter> __rotate_fn_impl(_Iter __first, _Iter __middle, _Sent __last) {
+  constexpr static subrange<_Iter> __rotate_fn_impl(_Iter __first, _Iter __middle, _Sent __last) {
     auto __ret = std::__rotate<_RangeAlgPolicy>(std::move(__first), std::move(__middle), std::move(__last));
     return {std::move(__ret.first), std::move(__ret.second)};
   }
 
   template <permutable _Iter, sentinel_for<_Iter> _Sent>
-  _LIBCPP_HIDE_FROM_ABI constexpr subrange<_Iter> operator()(_Iter __first, _Iter __middle, _Sent __last) const {
+  constexpr subrange<_Iter> operator()(_Iter __first, _Iter __middle, _Sent __last) const {
     return __rotate_fn_impl(std::move(__first), std::move(__middle), std::move(__last));
   }
 
   template <forward_range _Range>
     requires permutable<iterator_t<_Range>>
-  _LIBCPP_HIDE_FROM_ABI constexpr borrowed_subrange_t<_Range>
-  operator()(_Range&& __range, iterator_t<_Range> __middle) const {
+  constexpr borrowed_subrange_t<_Range> operator()(_Range&& __range, iterator_t<_Range> __middle) const {
     return __rotate_fn_impl(ranges::begin(__range), std::move(__middle), ranges::end(__range));
   }
 };

--- a/libcxx/include/__algorithm/ranges_rotate_copy.h
+++ b/libcxx/include/__algorithm/ranges_rotate_copy.h
@@ -37,7 +37,7 @@ using rotate_copy_result = in_out_result<_InIter, _OutIter>;
 struct __rotate_copy {
   template <forward_iterator _InIter, sentinel_for<_InIter> _Sent, weakly_incrementable _OutIter>
     requires indirectly_copyable<_InIter, _OutIter>
-  _LIBCPP_HIDE_FROM_ABI constexpr rotate_copy_result<_InIter, _OutIter>
+  constexpr rotate_copy_result<_InIter, _OutIter>
   operator()(_InIter __first, _InIter __middle, _Sent __last, _OutIter __result) const {
     auto __res1 = ranges::copy(__middle, __last, std::move(__result));
     auto __res2 = ranges::copy(__first, __middle, std::move(__res1.out));
@@ -46,7 +46,7 @@ struct __rotate_copy {
 
   template <forward_range _Range, weakly_incrementable _OutIter>
     requires indirectly_copyable<iterator_t<_Range>, _OutIter>
-  _LIBCPP_HIDE_FROM_ABI constexpr rotate_copy_result<borrowed_iterator_t<_Range>, _OutIter>
+  constexpr rotate_copy_result<borrowed_iterator_t<_Range>, _OutIter>
   operator()(_Range&& __range, iterator_t<_Range> __middle, _OutIter __result) const {
     return (*this)(ranges::begin(__range), std::move(__middle), ranges::end(__range), std::move(__result));
   }

--- a/libcxx/include/__algorithm/ranges_sample.h
+++ b/libcxx/include/__algorithm/ranges_sample.h
@@ -39,7 +39,7 @@ struct __sample {
   template <input_iterator _Iter, sentinel_for<_Iter> _Sent, weakly_incrementable _OutIter, class _Gen>
     requires(forward_iterator<_Iter> || random_access_iterator<_OutIter>) && indirectly_copyable<_Iter, _OutIter> &&
             uniform_random_bit_generator<remove_reference_t<_Gen>>
-  _LIBCPP_HIDE_FROM_ABI _OutIter
+  _OutIter
   operator()(_Iter __first, _Sent __last, _OutIter __out_first, iter_difference_t<_Iter> __n, _Gen&& __gen) const {
     _ClassicGenAdaptor<_Gen> __adapted_gen(__gen);
     return std::__sample<_RangeAlgPolicy>(
@@ -49,8 +49,7 @@ struct __sample {
   template <input_range _Range, weakly_incrementable _OutIter, class _Gen>
     requires(forward_range<_Range> || random_access_iterator<_OutIter>) &&
             indirectly_copyable<iterator_t<_Range>, _OutIter> && uniform_random_bit_generator<remove_reference_t<_Gen>>
-  _LIBCPP_HIDE_FROM_ABI _OutIter
-  operator()(_Range&& __range, _OutIter __out_first, range_difference_t<_Range> __n, _Gen&& __gen) const {
+  _OutIter operator()(_Range&& __range, _OutIter __out_first, range_difference_t<_Range> __n, _Gen&& __gen) const {
     return (*this)(
         ranges::begin(__range), ranges::end(__range), std::move(__out_first), __n, std::forward<_Gen>(__gen));
   }

--- a/libcxx/include/__algorithm/ranges_search.h
+++ b/libcxx/include/__algorithm/ranges_search.h
@@ -35,7 +35,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __search {
   template <class _Iter1, class _Sent1, class _Iter2, class _Sent2, class _Pred, class _Proj1, class _Proj2>
-  _LIBCPP_HIDE_FROM_ABI static constexpr subrange<_Iter1> __ranges_search_impl(
+  static constexpr subrange<_Iter1> __ranges_search_impl(
       _Iter1 __first1,
       _Sent1 __last1,
       _Iter2 __first2,
@@ -76,7 +76,7 @@ struct __search {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires indirectly_comparable<_Iter1, _Iter2, _Pred, _Proj1, _Proj2>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr subrange<_Iter1> operator()(
+  [[nodiscard]] constexpr subrange<_Iter1> operator()(
       _Iter1 __first1,
       _Sent1 __last1,
       _Iter2 __first2,
@@ -93,7 +93,7 @@ struct __search {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires indirectly_comparable<iterator_t<_Range1>, iterator_t<_Range2>, _Pred, _Proj1, _Proj2>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr borrowed_subrange_t<_Range1> operator()(
+  [[nodiscard]] constexpr borrowed_subrange_t<_Range1> operator()(
       _Range1&& __range1, _Range2&& __range2, _Pred __pred = {}, _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const {
     auto __first1 = ranges::begin(__range1);
     if constexpr (sized_range<_Range2>) {

--- a/libcxx/include/__algorithm/ranges_search_n.h
+++ b/libcxx/include/__algorithm/ranges_search_n.h
@@ -41,7 +41,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __search_n {
   template <class _Iter1, class _Sent1, class _SizeT, class _Type, class _Pred, class _Proj>
-  _LIBCPP_HIDE_FROM_ABI static constexpr subrange<_Iter1> __ranges_search_n_impl(
+  static constexpr subrange<_Iter1> __ranges_search_n_impl(
       _Iter1 __first, _Sent1 __last, _SizeT __count, const _Type& __value, _Pred& __pred, _Proj& __proj) {
     if (__count == 0)
       return {__first, __first};
@@ -70,7 +70,7 @@ struct __search_n {
             class _Pred = ranges::equal_to,
             class _Proj = identity>
     requires indirectly_comparable<_Iter, const _Type*, _Pred, _Proj>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr subrange<_Iter>
+  [[nodiscard]] constexpr subrange<_Iter>
   operator()(_Iter __first,
              _Sent __last,
              iter_difference_t<_Iter> __count,
@@ -82,7 +82,7 @@ struct __search_n {
 
   template <forward_range _Range, class _Type, class _Pred = ranges::equal_to, class _Proj = identity>
     requires indirectly_comparable<iterator_t<_Range>, const _Type*, _Pred, _Proj>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr borrowed_subrange_t<_Range> operator()(
+  [[nodiscard]] constexpr borrowed_subrange_t<_Range> operator()(
       _Range&& __range, range_difference_t<_Range> __count, const _Type& __value, _Pred __pred = {}, _Proj __proj = {})
       const {
     auto __first = ranges::begin(__range);

--- a/libcxx/include/__algorithm/ranges_set_difference.h
+++ b/libcxx/include/__algorithm/ranges_set_difference.h
@@ -48,7 +48,7 @@ struct __set_difference {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires mergeable<_InIter1, _InIter2, _OutIter, _Comp, _Proj1, _Proj2>
-  _LIBCPP_HIDE_FROM_ABI constexpr set_difference_result<_InIter1, _OutIter> operator()(
+  constexpr set_difference_result<_InIter1, _OutIter> operator()(
       _InIter1 __first1,
       _Sent1 __last1,
       _InIter2 __first2,
@@ -68,7 +68,7 @@ struct __set_difference {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires mergeable<iterator_t<_Range1>, iterator_t<_Range2>, _OutIter, _Comp, _Proj1, _Proj2>
-  _LIBCPP_HIDE_FROM_ABI constexpr set_difference_result<borrowed_iterator_t<_Range1>, _OutIter>
+  constexpr set_difference_result<borrowed_iterator_t<_Range1>, _OutIter>
   operator()(_Range1&& __range1,
              _Range2&& __range2,
              _OutIter __result,

--- a/libcxx/include/__algorithm/ranges_set_intersection.h
+++ b/libcxx/include/__algorithm/ranges_set_intersection.h
@@ -50,7 +50,7 @@ struct __set_intersection {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires mergeable<_InIter1, _InIter2, _OutIter, _Comp, _Proj1, _Proj2>
-  _LIBCPP_HIDE_FROM_ABI constexpr set_intersection_result<_InIter1, _InIter2, _OutIter> operator()(
+  constexpr set_intersection_result<_InIter1, _InIter2, _OutIter> operator()(
       _InIter1 __first1,
       _Sent1 __last1,
       _InIter2 __first2,
@@ -76,9 +76,7 @@ struct __set_intersection {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires mergeable<iterator_t<_Range1>, iterator_t<_Range2>, _OutIter, _Comp, _Proj1, _Proj2>
-  _LIBCPP_HIDE_FROM_ABI constexpr set_intersection_result<borrowed_iterator_t<_Range1>,
-                                                          borrowed_iterator_t<_Range2>,
-                                                          _OutIter>
+  constexpr set_intersection_result<borrowed_iterator_t<_Range1>, borrowed_iterator_t<_Range2>, _OutIter>
   operator()(_Range1&& __range1,
              _Range2&& __range2,
              _OutIter __result,

--- a/libcxx/include/__algorithm/ranges_set_symmetric_difference.h
+++ b/libcxx/include/__algorithm/ranges_set_symmetric_difference.h
@@ -49,7 +49,7 @@ struct __set_symmetric_difference {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires mergeable<_InIter1, _InIter2, _OutIter, _Comp, _Proj1, _Proj2>
-  _LIBCPP_HIDE_FROM_ABI constexpr set_symmetric_difference_result<_InIter1, _InIter2, _OutIter> operator()(
+  constexpr set_symmetric_difference_result<_InIter1, _InIter2, _OutIter> operator()(
       _InIter1 __first1,
       _Sent1 __last1,
       _InIter2 __first2,
@@ -75,9 +75,7 @@ struct __set_symmetric_difference {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires mergeable<iterator_t<_Range1>, iterator_t<_Range2>, _OutIter, _Comp, _Proj1, _Proj2>
-  _LIBCPP_HIDE_FROM_ABI constexpr set_symmetric_difference_result<borrowed_iterator_t<_Range1>,
-                                                                  borrowed_iterator_t<_Range2>,
-                                                                  _OutIter>
+  constexpr set_symmetric_difference_result<borrowed_iterator_t<_Range1>, borrowed_iterator_t<_Range2>, _OutIter>
   operator()(_Range1&& __range1,
              _Range2&& __range2,
              _OutIter __result,

--- a/libcxx/include/__algorithm/ranges_set_union.h
+++ b/libcxx/include/__algorithm/ranges_set_union.h
@@ -52,7 +52,7 @@ struct __set_union {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires mergeable<_InIter1, _InIter2, _OutIter, _Comp, _Proj1, _Proj2>
-  _LIBCPP_HIDE_FROM_ABI constexpr set_union_result<_InIter1, _InIter2, _OutIter> operator()(
+  constexpr set_union_result<_InIter1, _InIter2, _OutIter> operator()(
       _InIter1 __first1,
       _Sent1 __last1,
       _InIter2 __first2,
@@ -78,7 +78,7 @@ struct __set_union {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires mergeable<iterator_t<_Range1>, iterator_t<_Range2>, _OutIter, _Comp, _Proj1, _Proj2>
-  _LIBCPP_HIDE_FROM_ABI constexpr set_union_result<borrowed_iterator_t<_Range1>, borrowed_iterator_t<_Range2>, _OutIter>
+  constexpr set_union_result<borrowed_iterator_t<_Range1>, borrowed_iterator_t<_Range2>, _OutIter>
   operator()(_Range1&& __range1,
              _Range2&& __range2,
              _OutIter __result,

--- a/libcxx/include/__algorithm/ranges_shift_left.h
+++ b/libcxx/include/__algorithm/ranges_shift_left.h
@@ -37,16 +37,14 @@ namespace __shift_left {
 
 struct __fn {
   template <permutable _Iter, sentinel_for<_Iter> _Sent>
-  _LIBCPP_HIDE_FROM_ABI static constexpr subrange<_Iter>
-  operator()(_Iter __first, _Sent __last, iter_difference_t<_Iter> __n) {
+  static constexpr subrange<_Iter> operator()(_Iter __first, _Sent __last, iter_difference_t<_Iter> __n) {
     auto __ret = std::__shift_left<_RangeAlgPolicy>(std::move(__first), std::move(__last), std::move(__n));
     return {std::move(__ret.first), std::move(__ret.second)};
   }
 
   template <forward_range _Range>
     requires permutable<iterator_t<_Range>>
-  _LIBCPP_HIDE_FROM_ABI static constexpr borrowed_subrange_t<_Range>
-  operator()(_Range&& __range, range_difference_t<_Range> __n) {
+  static constexpr borrowed_subrange_t<_Range> operator()(_Range&& __range, range_difference_t<_Range> __n) {
     if constexpr (sized_range<_Range>) {
       if (__n >= ranges::distance(__range)) {
         return {ranges::begin(__range), ranges::begin(__range)};

--- a/libcxx/include/__algorithm/ranges_shift_right.h
+++ b/libcxx/include/__algorithm/ranges_shift_right.h
@@ -37,16 +37,14 @@ namespace __shift_right {
 
 struct __fn {
   template <permutable _Iter, sentinel_for<_Iter> _Sent>
-  _LIBCPP_HIDE_FROM_ABI static constexpr subrange<_Iter>
-  operator()(_Iter __first, _Sent __last, iter_difference_t<_Iter> __n) {
+  static constexpr subrange<_Iter> operator()(_Iter __first, _Sent __last, iter_difference_t<_Iter> __n) {
     auto __ret = std::__shift_right<_RangeAlgPolicy>(std::move(__first), std::move(__last), std::move(__n));
     return {std::move(__ret.first), std::move(__ret.second)};
   }
 
   template <forward_range _Range>
     requires permutable<iterator_t<_Range>>
-  _LIBCPP_HIDE_FROM_ABI static constexpr borrowed_subrange_t<_Range>
-  operator()(_Range&& __range, range_difference_t<_Range> __n) {
+  static constexpr borrowed_subrange_t<_Range> operator()(_Range&& __range, range_difference_t<_Range> __n) {
     if constexpr (sized_range<_Range>) {
       if (__n >= ranges::distance(__range)) {
         auto __iter = ranges::begin(__range);

--- a/libcxx/include/__algorithm/ranges_shuffle.h
+++ b/libcxx/include/__algorithm/ranges_shuffle.h
@@ -42,14 +42,14 @@ namespace ranges {
 struct __shuffle {
   template <random_access_iterator _Iter, sentinel_for<_Iter> _Sent, class _Gen>
     requires permutable<_Iter> && uniform_random_bit_generator<remove_reference_t<_Gen>>
-  _LIBCPP_HIDE_FROM_ABI _Iter operator()(_Iter __first, _Sent __last, _Gen&& __gen) const {
+  _Iter operator()(_Iter __first, _Sent __last, _Gen&& __gen) const {
     _ClassicGenAdaptor<_Gen> __adapted_gen(__gen);
     return std::__shuffle<_RangeAlgPolicy>(std::move(__first), std::move(__last), __adapted_gen);
   }
 
   template <random_access_range _Range, class _Gen>
     requires permutable<iterator_t<_Range>> && uniform_random_bit_generator<remove_reference_t<_Gen>>
-  _LIBCPP_HIDE_FROM_ABI borrowed_iterator_t<_Range> operator()(_Range&& __range, _Gen&& __gen) const {
+  borrowed_iterator_t<_Range> operator()(_Range&& __range, _Gen&& __gen) const {
     return (*this)(ranges::begin(__range), ranges::end(__range), std::forward<_Gen>(__gen));
   }
 };

--- a/libcxx/include/__algorithm/ranges_sort.h
+++ b/libcxx/include/__algorithm/ranges_sort.h
@@ -41,8 +41,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __sort {
   template <class _Iter, class _Sent, class _Comp, class _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr static _Iter
-  __sort_fn_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
+  constexpr static _Iter __sort_fn_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
     auto __last_iter = ranges::next(__first, __last);
 
     auto&& __projected_comp = std::__make_projected(__comp, __proj);
@@ -53,15 +52,13 @@ struct __sort {
 
   template <random_access_iterator _Iter, sentinel_for<_Iter> _Sent, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<_Iter, _Comp, _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr _Iter
-  operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
+  constexpr _Iter operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
     return __sort_fn_impl(std::move(__first), std::move(__last), __comp, __proj);
   }
 
   template <random_access_range _Range, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<iterator_t<_Range>, _Comp, _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Range>
-  operator()(_Range&& __r, _Comp __comp = {}, _Proj __proj = {}) const {
+  constexpr borrowed_iterator_t<_Range> operator()(_Range&& __r, _Comp __comp = {}, _Proj __proj = {}) const {
     return __sort_fn_impl(ranges::begin(__r), ranges::end(__r), __comp, __proj);
   }
 };

--- a/libcxx/include/__algorithm/ranges_sort_heap.h
+++ b/libcxx/include/__algorithm/ranges_sort_heap.h
@@ -42,8 +42,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __sort_heap {
   template <class _Iter, class _Sent, class _Comp, class _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr static _Iter
-  __sort_heap_fn_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
+  constexpr static _Iter __sort_heap_fn_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
     auto __last_iter = ranges::next(__first, __last);
 
     auto&& __projected_comp = std::__make_projected(__comp, __proj);
@@ -54,15 +53,13 @@ struct __sort_heap {
 
   template <random_access_iterator _Iter, sentinel_for<_Iter> _Sent, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<_Iter, _Comp, _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr _Iter
-  operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
+  constexpr _Iter operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
     return __sort_heap_fn_impl(std::move(__first), std::move(__last), __comp, __proj);
   }
 
   template <random_access_range _Range, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<iterator_t<_Range>, _Comp, _Proj>
-  _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Range>
-  operator()(_Range&& __r, _Comp __comp = {}, _Proj __proj = {}) const {
+  constexpr borrowed_iterator_t<_Range> operator()(_Range&& __r, _Comp __comp = {}, _Proj __proj = {}) const {
     return __sort_heap_fn_impl(ranges::begin(__r), ranges::end(__r), __comp, __proj);
   }
 };

--- a/libcxx/include/__algorithm/ranges_stable_partition.h
+++ b/libcxx/include/__algorithm/ranges_stable_partition.h
@@ -44,7 +44,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __stable_partition {
   template <class _Iter, class _Sent, class _Proj, class _Pred>
-  _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX26 subrange<__remove_cvref_t<_Iter>>
+  static _LIBCPP_CONSTEXPR_SINCE_CXX26 subrange<__remove_cvref_t<_Iter>>
   __stable_partition_fn_impl(_Iter&& __first, _Sent&& __last, _Pred&& __pred, _Proj&& __proj) {
     auto __last_iter = ranges::next(__first, __last);
 
@@ -60,7 +60,7 @@ struct __stable_partition {
             class _Proj = identity,
             indirect_unary_predicate<projected<_Iter, _Proj>> _Pred>
     requires permutable<_Iter>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 subrange<_Iter>
+  _LIBCPP_CONSTEXPR_SINCE_CXX26 subrange<_Iter>
   operator()(_Iter __first, _Sent __last, _Pred __pred, _Proj __proj = {}) const {
     return __stable_partition_fn_impl(__first, __last, __pred, __proj);
   }
@@ -69,7 +69,7 @@ struct __stable_partition {
             class _Proj = identity,
             indirect_unary_predicate<projected<iterator_t<_Range>, _Proj>> _Pred>
     requires permutable<iterator_t<_Range>>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 borrowed_subrange_t<_Range>
+  _LIBCPP_CONSTEXPR_SINCE_CXX26 borrowed_subrange_t<_Range>
   operator()(_Range&& __range, _Pred __pred, _Proj __proj = {}) const {
     return __stable_partition_fn_impl(ranges::begin(__range), ranges::end(__range), __pred, __proj);
   }

--- a/libcxx/include/__algorithm/ranges_stable_sort.h
+++ b/libcxx/include/__algorithm/ranges_stable_sort.h
@@ -41,7 +41,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace ranges {
 struct __stable_sort {
   template <class _Iter, class _Sent, class _Comp, class _Proj>
-  _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX26 _Iter
+  static _LIBCPP_CONSTEXPR_SINCE_CXX26 _Iter
   __stable_sort_fn_impl(_Iter __first, _Sent __last, _Comp& __comp, _Proj& __proj) {
     auto __last_iter = ranges::next(__first, __last);
 
@@ -53,14 +53,14 @@ struct __stable_sort {
 
   template <random_access_iterator _Iter, sentinel_for<_Iter> _Sent, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<_Iter, _Comp, _Proj>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 _Iter
+  _LIBCPP_CONSTEXPR_SINCE_CXX26 _Iter
   operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
     return __stable_sort_fn_impl(std::move(__first), std::move(__last), __comp, __proj);
   }
 
   template <random_access_range _Range, class _Comp = ranges::less, class _Proj = identity>
     requires sortable<iterator_t<_Range>, _Comp, _Proj>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 borrowed_iterator_t<_Range>
+  _LIBCPP_CONSTEXPR_SINCE_CXX26 borrowed_iterator_t<_Range>
   operator()(_Range&& __r, _Comp __comp = {}, _Proj __proj = {}) const {
     return __stable_sort_fn_impl(ranges::begin(__r), ranges::end(__r), __comp, __proj);
   }

--- a/libcxx/include/__algorithm/ranges_starts_with.h
+++ b/libcxx/include/__algorithm/ranges_starts_with.h
@@ -41,7 +41,7 @@ struct __starts_with {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires indirectly_comparable<_Iter1, _Iter2, _Pred, _Proj1, _Proj2>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr bool operator()(
+  [[nodiscard]] static constexpr bool operator()(
       _Iter1 __first1,
       _Sent1 __last1,
       _Iter2 __first2,
@@ -66,7 +66,7 @@ struct __starts_with {
             class _Proj1 = identity,
             class _Proj2 = identity>
     requires indirectly_comparable<iterator_t<_Range1>, iterator_t<_Range2>, _Pred, _Proj1, _Proj2>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr bool
+  [[nodiscard]] static constexpr bool
   operator()(_Range1&& __range1, _Range2&& __range2, _Pred __pred = {}, _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) {
     return __mismatch::__go(
                ranges::begin(__range1),

--- a/libcxx/include/__algorithm/ranges_swap_ranges.h
+++ b/libcxx/include/__algorithm/ranges_swap_ranges.h
@@ -42,8 +42,7 @@ using swap_ranges_result = in_in_result<_I1, _I2>;
 struct __swap_ranges {
   template <input_iterator _I1, sentinel_for<_I1> _S1, input_iterator _I2, sentinel_for<_I2> _S2>
     requires indirectly_swappable<_I1, _I2>
-  _LIBCPP_HIDE_FROM_ABI constexpr swap_ranges_result<_I1, _I2>
-  operator()(_I1 __first1, _S1 __last1, _I2 __first2, _S2 __last2) const {
+  constexpr swap_ranges_result<_I1, _I2> operator()(_I1 __first1, _S1 __last1, _I2 __first2, _S2 __last2) const {
     if constexpr (sized_sentinel_for<_I1, _S1> && sized_sentinel_for<_I2, _S2> &&
                   (random_access_iterator<_I1> || random_access_iterator<_I2> ||
                    (is_same_v<_I1, _S1> && is_same_v<_I2, _S2>))) {
@@ -75,7 +74,7 @@ struct __swap_ranges {
 
   template <input_range _R1, input_range _R2>
     requires indirectly_swappable<iterator_t<_R1>, iterator_t<_R2>>
-  _LIBCPP_HIDE_FROM_ABI constexpr swap_ranges_result<borrowed_iterator_t<_R1>, borrowed_iterator_t<_R2>>
+  constexpr swap_ranges_result<borrowed_iterator_t<_R1>, borrowed_iterator_t<_R2>>
   operator()(_R1&& __r1, _R2&& __r2) const {
     return operator()(ranges::begin(__r1), ranges::end(__r1), ranges::begin(__r2), ranges::end(__r2));
   }

--- a/libcxx/include/__algorithm/ranges_transform.h
+++ b/libcxx/include/__algorithm/ranges_transform.h
@@ -44,7 +44,7 @@ using binary_transform_result = in_in_out_result<_I1, _I2, _O1>;
 struct __transform {
 private:
   template <class _InIter, class _Sent, class _OutIter, class _Func, class _Proj>
-  _LIBCPP_HIDE_FROM_ABI static constexpr unary_transform_result<_InIter, _OutIter>
+  static constexpr unary_transform_result<_InIter, _OutIter>
   __unary(_InIter __first, _Sent __last, _OutIter __result, _Func& __operation, _Proj& __projection) {
     while (__first != __last) {
       *__result = std::invoke(__operation, std::invoke(__projection, *__first));
@@ -63,7 +63,7 @@ private:
             class _Func,
             class _Proj1,
             class _Proj2>
-  _LIBCPP_HIDE_FROM_ABI static constexpr binary_transform_result<_InIter1, _InIter2, _OutIter>
+  static constexpr binary_transform_result<_InIter1, _InIter2, _OutIter>
   __binary(_InIter1 __first1,
            _Sent1 __last1,
            _InIter2 __first2,
@@ -89,14 +89,14 @@ public:
             copy_constructible _Func,
             class _Proj = identity>
     requires indirectly_writable<_OutIter, indirect_result_t<_Func&, projected<_InIter, _Proj>>>
-  _LIBCPP_HIDE_FROM_ABI constexpr unary_transform_result<_InIter, _OutIter>
+  constexpr unary_transform_result<_InIter, _OutIter>
   operator()(_InIter __first, _Sent __last, _OutIter __result, _Func __operation, _Proj __proj = {}) const {
     return __unary(std::move(__first), std::move(__last), std::move(__result), __operation, __proj);
   }
 
   template <input_range _Range, weakly_incrementable _OutIter, copy_constructible _Func, class _Proj = identity>
     requires indirectly_writable<_OutIter, indirect_result_t<_Func, projected<iterator_t<_Range>, _Proj>>>
-  _LIBCPP_HIDE_FROM_ABI constexpr unary_transform_result<borrowed_iterator_t<_Range>, _OutIter>
+  constexpr unary_transform_result<borrowed_iterator_t<_Range>, _OutIter>
   operator()(_Range&& __range, _OutIter __result, _Func __operation, _Proj __projection = {}) const {
     return __unary(ranges::begin(__range), ranges::end(__range), std::move(__result), __operation, __projection);
   }
@@ -111,7 +111,7 @@ public:
             class _Proj2 = identity>
     requires indirectly_writable<_OutIter,
                                  indirect_result_t<_Func&, projected<_InIter1, _Proj1>, projected<_InIter2, _Proj2>>>
-  _LIBCPP_HIDE_FROM_ABI constexpr binary_transform_result<_InIter1, _InIter2, _OutIter> operator()(
+  constexpr binary_transform_result<_InIter1, _InIter2, _OutIter> operator()(
       _InIter1 __first1,
       _Sent1 __last1,
       _InIter2 __first2,
@@ -140,9 +140,7 @@ public:
     requires indirectly_writable<
         _OutIter,
         indirect_result_t<_Func&, projected<iterator_t<_Range1>, _Proj1>, projected<iterator_t<_Range2>, _Proj2>>>
-  _LIBCPP_HIDE_FROM_ABI constexpr binary_transform_result<borrowed_iterator_t<_Range1>,
-                                                          borrowed_iterator_t<_Range2>,
-                                                          _OutIter>
+  constexpr binary_transform_result<borrowed_iterator_t<_Range1>, borrowed_iterator_t<_Range2>, _OutIter>
   operator()(_Range1&& __range1,
              _Range2&& __range2,
              _OutIter __result,

--- a/libcxx/include/__algorithm/ranges_unique.h
+++ b/libcxx/include/__algorithm/ranges_unique.h
@@ -45,7 +45,7 @@ struct __unique {
             sentinel_for<_Iter> _Sent,
             class _Proj                                                  = identity,
             indirect_equivalence_relation<projected<_Iter, _Proj>> _Comp = ranges::equal_to>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr subrange<_Iter>
+  [[nodiscard]] constexpr subrange<_Iter>
   operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
     auto __ret =
         std::__unique<_RangeAlgPolicy>(std::move(__first), std::move(__last), std::__make_projected(__comp, __proj));
@@ -56,7 +56,7 @@ struct __unique {
             class _Proj                                                               = identity,
             indirect_equivalence_relation<projected<iterator_t<_Range>, _Proj>> _Comp = ranges::equal_to>
     requires permutable<iterator_t<_Range>>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr borrowed_subrange_t<_Range>
+  [[nodiscard]] constexpr borrowed_subrange_t<_Range>
   operator()(_Range&& __range, _Comp __comp = {}, _Proj __proj = {}) const {
     auto __ret = std::__unique<_RangeAlgPolicy>(
         ranges::begin(__range), ranges::end(__range), std::__make_projected(__comp, __proj));

--- a/libcxx/include/__algorithm/ranges_unique_copy.h
+++ b/libcxx/include/__algorithm/ranges_unique_copy.h
@@ -70,7 +70,7 @@ struct __unique_copy {
              (forward_iterator<_InIter> ||
               (input_iterator<_OutIter> && same_as<iter_value_t<_InIter>, iter_value_t<_OutIter>>) ||
               indirectly_copyable_storable<_InIter, _OutIter>)
-  _LIBCPP_HIDE_FROM_ABI constexpr unique_copy_result<_InIter, _OutIter>
+  constexpr unique_copy_result<_InIter, _OutIter>
   operator()(_InIter __first, _Sent __last, _OutIter __result, _Comp __comp = {}, _Proj __proj = {}) const {
     return std::__unique_copy<_RangeAlgPolicy>(
         std::move(__first),
@@ -88,7 +88,7 @@ struct __unique_copy {
              (forward_iterator<iterator_t<_Range>> ||
               (input_iterator<_OutIter> && same_as<range_value_t<_Range>, iter_value_t<_OutIter>>) ||
               indirectly_copyable_storable<iterator_t<_Range>, _OutIter>)
-  _LIBCPP_HIDE_FROM_ABI constexpr unique_copy_result<borrowed_iterator_t<_Range>, _OutIter>
+  constexpr unique_copy_result<borrowed_iterator_t<_Range>, _OutIter>
   operator()(_Range&& __range, _OutIter __result, _Comp __comp = {}, _Proj __proj = {}) const {
     return std::__unique_copy<_RangeAlgPolicy>(
         ranges::begin(__range),

--- a/libcxx/include/__algorithm/ranges_upper_bound.h
+++ b/libcxx/include/__algorithm/ranges_upper_bound.h
@@ -36,7 +36,7 @@ struct __upper_bound {
             class _Type,
             class _Proj                                                             = identity,
             indirect_strict_weak_order<const _Type*, projected<_Iter, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Iter
+  [[nodiscard]] constexpr _Iter
   operator()(_Iter __first, _Sent __last, const _Type& __value, _Comp __comp = {}, _Proj __proj = {}) const {
     auto __comp_lhs_rhs_swapped = [&](const auto& __lhs, const auto& __rhs) -> bool {
       return !std::invoke(__comp, __rhs, __lhs);
@@ -49,7 +49,7 @@ struct __upper_bound {
             class _Type,
             class _Proj                                                                          = identity,
             indirect_strict_weak_order<const _Type*, projected<iterator_t<_Range>, _Proj>> _Comp = ranges::less>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr borrowed_iterator_t<_Range>
+  [[nodiscard]] constexpr borrowed_iterator_t<_Range>
   operator()(_Range&& __r, const _Type& __value, _Comp __comp = {}, _Proj __proj = {}) const {
     auto __comp_lhs_rhs_swapped = [&](const auto& __lhs, const auto& __rhs) -> bool {
       return !std::invoke(__comp, __rhs, __lhs);

--- a/libcxx/include/__algorithm/remove.h
+++ b/libcxx/include/__algorithm/remove.h
@@ -24,7 +24,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _ForwardIterator, class _Tp>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
+[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 remove(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) {
   __first = std::find(__first, __last, __value);
   if (__first != __last) {

--- a/libcxx/include/__algorithm/remove_copy.h
+++ b/libcxx/include/__algorithm/remove_copy.h
@@ -18,7 +18,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _InputIterator, class _OutputIterator, class _Tp>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
 remove_copy(_InputIterator __first, _InputIterator __last, _OutputIterator __result, const _Tp& __value) {
   for (; __first != __last; ++__first) {
     if (!(*__first == __value)) {

--- a/libcxx/include/__algorithm/remove_copy_if.h
+++ b/libcxx/include/__algorithm/remove_copy_if.h
@@ -18,7 +18,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _InputIterator, class _OutputIterator, class _Predicate>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
 remove_copy_if(_InputIterator __first, _InputIterator __last, _OutputIterator __result, _Predicate __pred) {
   for (; __first != __last; ++__first) {
     if (!__pred(*__first)) {

--- a/libcxx/include/__algorithm/remove_if.h
+++ b/libcxx/include/__algorithm/remove_if.h
@@ -23,7 +23,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _ForwardIterator, class _Predicate>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
+[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 remove_if(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred) {
   __first = std::find_if<_ForwardIterator, _Predicate&>(__first, __last, __pred);
   if (__first != __last) {

--- a/libcxx/include/__algorithm/replace.h
+++ b/libcxx/include/__algorithm/replace.h
@@ -18,7 +18,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _ForwardIterator, class _Tp>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 replace(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __old_value, const _Tp& __new_value) {
   for (; __first != __last; ++__first)
     if (*__first == __old_value)

--- a/libcxx/include/__algorithm/replace_copy.h
+++ b/libcxx/include/__algorithm/replace_copy.h
@@ -18,7 +18,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _InputIterator, class _OutputIterator, class _Tp>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator replace_copy(
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator replace_copy(
     _InputIterator __first,
     _InputIterator __last,
     _OutputIterator __result,

--- a/libcxx/include/__algorithm/replace_copy_if.h
+++ b/libcxx/include/__algorithm/replace_copy_if.h
@@ -18,7 +18,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _InputIterator, class _OutputIterator, class _Predicate, class _Tp>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator replace_copy_if(
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator replace_copy_if(
     _InputIterator __first,
     _InputIterator __last,
     _OutputIterator __result,

--- a/libcxx/include/__algorithm/replace_if.h
+++ b/libcxx/include/__algorithm/replace_if.h
@@ -18,7 +18,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _ForwardIterator, class _Predicate, class _Tp>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 replace_if(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred, const _Tp& __new_value) {
   for (; __first != __last; ++__first)
     if (__pred(*__first))

--- a/libcxx/include/__algorithm/reverse.h
+++ b/libcxx/include/__algorithm/reverse.h
@@ -25,7 +25,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, class _BidirectionalIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 __reverse_impl(_BidirectionalIterator __first, _BidirectionalIterator __last, bidirectional_iterator_tag) {
   while (__first != __last) {
     if (__first == --__last)
@@ -36,7 +36,7 @@ __reverse_impl(_BidirectionalIterator __first, _BidirectionalIterator __last, bi
 }
 
 template <class _AlgPolicy, class _RandomAccessIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 __reverse_impl(_RandomAccessIterator __first, _RandomAccessIterator __last, random_access_iterator_tag) {
   if (__first != __last)
     for (; __first < --__last; ++__first)
@@ -44,14 +44,13 @@ __reverse_impl(_RandomAccessIterator __first, _RandomAccessIterator __last, rand
 }
 
 template <class _AlgPolicy, class _BidirectionalIterator, class _Sentinel>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __reverse(_BidirectionalIterator __first, _Sentinel __last) {
+_LIBCPP_CONSTEXPR_SINCE_CXX20 void __reverse(_BidirectionalIterator __first, _Sentinel __last) {
   using _IterCategory = typename _IterOps<_AlgPolicy>::template __iterator_category<_BidirectionalIterator>;
   std::__reverse_impl<_AlgPolicy>(std::move(__first), std::move(__last), _IterCategory());
 }
 
 template <class _BidirectionalIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
-reverse(_BidirectionalIterator __first, _BidirectionalIterator __last) {
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void reverse(_BidirectionalIterator __first, _BidirectionalIterator __last) {
   std::__reverse<_ClassicAlgPolicy>(std::move(__first), std::move(__last));
 }
 

--- a/libcxx/include/__algorithm/reverse_copy.h
+++ b/libcxx/include/__algorithm/reverse_copy.h
@@ -18,7 +18,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _BidirectionalIterator, class _OutputIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
 reverse_copy(_BidirectionalIterator __first, _BidirectionalIterator __last, _OutputIterator __result) {
   for (; __first != __last; ++__result)
     *__result = *--__last;

--- a/libcxx/include/__algorithm/rotate.h
+++ b/libcxx/include/__algorithm/rotate.h
@@ -33,8 +33,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, class _ForwardIterator>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator
-__rotate_left(_ForwardIterator __first, _ForwardIterator __last) {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator __rotate_left(_ForwardIterator __first, _ForwardIterator __last) {
   typedef typename iterator_traits<_ForwardIterator>::value_type value_type;
   using _Ops = _IterOps<_AlgPolicy>;
 
@@ -45,7 +44,7 @@ __rotate_left(_ForwardIterator __first, _ForwardIterator __last) {
 }
 
 template <class _AlgPolicy, class _BidirectionalIterator>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _BidirectionalIterator
+_LIBCPP_CONSTEXPR_SINCE_CXX14 _BidirectionalIterator
 __rotate_right(_BidirectionalIterator __first, _BidirectionalIterator __last) {
   typedef typename iterator_traits<_BidirectionalIterator>::value_type value_type;
   using _Ops = _IterOps<_AlgPolicy>;
@@ -58,7 +57,7 @@ __rotate_right(_BidirectionalIterator __first, _BidirectionalIterator __last) {
 }
 
 template <class _AlgPolicy, class _ForwardIterator>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 _ForwardIterator
+_LIBCPP_CONSTEXPR_SINCE_CXX17 _ForwardIterator
 __rotate_forward(_ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last) {
   _ForwardIterator __i = __middle;
   while (true) {
@@ -87,8 +86,7 @@ __rotate_forward(_ForwardIterator __first, _ForwardIterator __middle, _ForwardIt
 }
 
 template <class _AlgPolicy, class _Iter, class _Sent>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 _Iter
-__rotate_random_access(_Iter __first, _Iter __middle, _Sent __sent) {
+_LIBCPP_CONSTEXPR_SINCE_CXX17 _Iter __rotate_random_access(_Iter __first, _Iter __middle, _Sent __sent) {
   auto __left  = _IterOps<_AlgPolicy>::distance(__first, __middle);
   auto __right = _IterOps<_AlgPolicy>::distance(__middle, __sent);
   auto __last  = __first + __right;
@@ -115,7 +113,7 @@ __rotate_random_access(_Iter __first, _Iter __middle, _Sent __sent) {
 }
 
 template <class _AlgPolicy, class _ForwardIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 _ForwardIterator
 __rotate_impl(_ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last, std::forward_iterator_tag) {
   typedef typename iterator_traits<_ForwardIterator>::value_type value_type;
   if (is_trivially_move_assignable<value_type>::value) {
@@ -126,7 +124,7 @@ __rotate_impl(_ForwardIterator __first, _ForwardIterator __middle, _ForwardItera
 }
 
 template <class _AlgPolicy, class _BidirectionalIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _BidirectionalIterator __rotate_impl(
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 _BidirectionalIterator __rotate_impl(
     _BidirectionalIterator __first,
     _BidirectionalIterator __middle,
     _BidirectionalIterator __last,
@@ -142,7 +140,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _BidirectionalIterato
 }
 
 template <class _AlgPolicy, class _RandomAccessIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _RandomAccessIterator __rotate_impl(
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 _RandomAccessIterator __rotate_impl(
     _RandomAccessIterator __first,
     _RandomAccessIterator __middle,
     _RandomAccessIterator __last,
@@ -159,7 +157,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _RandomAccessIterator
 }
 
 template <class _AlgPolicy, class _Iterator, class _Sentinel>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iterator, _Iterator>
+_LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iterator, _Iterator>
 __rotate(_Iterator __first, _Iterator __middle, _Sentinel __last) {
   using _Ret            = pair<_Iterator, _Iterator>;
   _Iterator __last_iter = _IterOps<_AlgPolicy>::next(__middle, __last);
@@ -176,7 +174,7 @@ __rotate(_Iterator __first, _Iterator __middle, _Sentinel __last) {
 }
 
 template <class, class _Cp>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<__bit_iterator<_Cp, false>, __bit_iterator<_Cp, false> >
+_LIBCPP_CONSTEXPR_SINCE_CXX20 pair<__bit_iterator<_Cp, false>, __bit_iterator<_Cp, false> >
 __rotate(__bit_iterator<_Cp, false> __first, __bit_iterator<_Cp, false> __middle, __bit_iterator<_Cp, false> __last) {
   using _I1             = __bit_iterator<_Cp, false>;
   using difference_type = typename _I1::difference_type;
@@ -214,7 +212,7 @@ __rotate(__bit_iterator<_Cp, false> __first, __bit_iterator<_Cp, false> __middle
 }
 
 template <class _ForwardIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 rotate(_ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last) {
   return std::__rotate<_ClassicAlgPolicy>(std::move(__first), std::move(__middle), std::move(__last)).first;
 }

--- a/libcxx/include/__algorithm/rotate_copy.h
+++ b/libcxx/include/__algorithm/rotate_copy.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _ForwardIterator, class _OutputIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
 rotate_copy(_ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last, _OutputIterator __result) {
   return std::copy(__first, __middle, std::copy(__middle, __last, __result));
 }

--- a/libcxx/include/__algorithm/sample.h
+++ b/libcxx/include/__algorithm/sample.h
@@ -34,13 +34,13 @@ template <class _AlgPolicy,
           class _SampleIterator,
           class _Distance,
           class _UniformRandomNumberGenerator>
-_LIBCPP_HIDE_FROM_ABI _SampleIterator __sample(
-    _PopulationIterator __first,
-    _PopulationSentinel __last,
-    _SampleIterator __output_iter,
-    _Distance __n,
-    _UniformRandomNumberGenerator& __g,
-    input_iterator_tag) {
+_SampleIterator
+__sample(_PopulationIterator __first,
+         _PopulationSentinel __last,
+         _SampleIterator __output_iter,
+         _Distance __n,
+         _UniformRandomNumberGenerator& __g,
+         input_iterator_tag) {
   _Distance __k = 0;
   for (; __first != __last && __k < __n; ++__first, (void)++__k)
     __output_iter[__k] = *__first;
@@ -59,13 +59,13 @@ template <class _AlgPolicy,
           class _SampleIterator,
           class _Distance,
           class _UniformRandomNumberGenerator>
-_LIBCPP_HIDE_FROM_ABI _SampleIterator __sample(
-    _PopulationIterator __first,
-    _PopulationSentinel __last,
-    _SampleIterator __output_iter,
-    _Distance __n,
-    _UniformRandomNumberGenerator& __g,
-    forward_iterator_tag) {
+_SampleIterator
+__sample(_PopulationIterator __first,
+         _PopulationSentinel __last,
+         _SampleIterator __output_iter,
+         _Distance __n,
+         _UniformRandomNumberGenerator& __g,
+         forward_iterator_tag) {
   _Distance __unsampled_sz = _IterOps<_AlgPolicy>::distance(__first, __last);
   for (__n = std::min(__n, __unsampled_sz); __n != 0; ++__first) {
     _Distance __r = uniform_int_distribution<_Distance>(0, --__unsampled_sz)(__g);
@@ -83,12 +83,12 @@ template <class _AlgPolicy,
           class _SampleIterator,
           class _Distance,
           class _UniformRandomNumberGenerator>
-_LIBCPP_HIDE_FROM_ABI _SampleIterator __sample(
-    _PopulationIterator __first,
-    _PopulationSentinel __last,
-    _SampleIterator __output_iter,
-    _Distance __n,
-    _UniformRandomNumberGenerator& __g) {
+_SampleIterator
+__sample(_PopulationIterator __first,
+         _PopulationSentinel __last,
+         _SampleIterator __output_iter,
+         _Distance __n,
+         _UniformRandomNumberGenerator& __g) {
   _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(__n >= 0, "N must be a positive number.");
 
   using _PopIterCategory = typename _IterOps<_AlgPolicy>::template __iterator_category<_PopulationIterator>;
@@ -101,7 +101,7 @@ _LIBCPP_HIDE_FROM_ABI _SampleIterator __sample(
 
 #if _LIBCPP_STD_VER >= 17
 template <class _PopulationIterator, class _SampleIterator, class _Distance, class _UniformRandomNumberGenerator>
-inline _LIBCPP_HIDE_FROM_ABI _SampleIterator
+inline _SampleIterator
 sample(_PopulationIterator __first,
        _PopulationIterator __last,
        _SampleIterator __output_iter,

--- a/libcxx/include/__algorithm/search.h
+++ b/libcxx/include/__algorithm/search.h
@@ -36,7 +36,7 @@ template <class _AlgPolicy,
           class _Pred,
           class _Proj1,
           class _Proj2>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter1, _Iter1> __search_forward_impl(
+_LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter1, _Iter1> __search_forward_impl(
     _Iter1 __first1, _Sent1 __last1, _Iter2 __first2, _Sent2 __last2, _Pred& __pred, _Proj1& __proj1, _Proj2& __proj2) {
   if (__first2 == __last2)
     return std::make_pair(__first1, __first1); // Everything matches an empty sequence
@@ -80,7 +80,7 @@ template <class _AlgPolicy,
           class _Proj2,
           class _DiffT1,
           class _DiffT2>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter1, _Iter1> __search_random_access_impl(
+_LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter1, _Iter1> __search_random_access_impl(
     _Iter1 __first1,
     _Sent1 __last1,
     _Iter2 __first2,
@@ -127,7 +127,7 @@ template <class _Iter1,
           __enable_if_t<__has_random_access_iterator_category<_Iter1>::value &&
                             __has_random_access_iterator_category<_Iter2>::value,
                         int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter1, _Iter1> __search_impl(
+_LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter1, _Iter1> __search_impl(
     _Iter1 __first1, _Sent1 __last1, _Iter2 __first2, _Sent2 __last2, _Pred& __pred, _Proj1& __proj1, _Proj2& __proj2) {
   auto __size2 = __last2 - __first2;
   if (__size2 == 0)
@@ -154,13 +154,13 @@ template <
                       !(__has_random_access_iterator_category<_Iter1>::value &&
                         __has_random_access_iterator_category<_Iter2>::value),
                   int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter1, _Iter1> __search_impl(
+_LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter1, _Iter1> __search_impl(
     _Iter1 __first1, _Sent1 __last1, _Iter2 __first2, _Sent2 __last2, _Pred& __pred, _Proj1& __proj1, _Proj2& __proj2) {
   return std::__search_forward_impl<_ClassicAlgPolicy>(__first1, __last1, __first2, __last2, __pred, __proj1, __proj2);
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator1
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator1
 search(_ForwardIterator1 __first1,
        _ForwardIterator1 __last1,
        _ForwardIterator2 __first2,
@@ -173,15 +173,15 @@ search(_ForwardIterator1 __first1,
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator1
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator1
 search(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2) {
   return std::search(__first1, __last1, __first2, __last2, __equal_to());
 }
 
 #if _LIBCPP_STD_VER >= 17
 template <class _ForwardIterator, class _Searcher>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
-search(_ForwardIterator __f, _ForwardIterator __l, const _Searcher& __s) {
+[[nodiscard]] _LIBCPP_CONSTEXPR_SINCE_CXX20
+_ForwardIterator search(_ForwardIterator __f, _ForwardIterator __l, const _Searcher& __s) {
   return __s(__f, __l).first;
 }
 

--- a/libcxx/include/__algorithm/search_n.h
+++ b/libcxx/include/__algorithm/search_n.h
@@ -28,7 +28,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, class _Pred, class _Iter, class _Sent, class _SizeT, class _Type, class _Proj>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter, _Iter> __search_n_forward_impl(
+_LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter, _Iter> __search_n_forward_impl(
     _Iter __first, _Sent __last, _SizeT __count, const _Type& __value, _Pred& __pred, _Proj& __proj) {
   if (__count <= 0)
     return std::make_pair(__first, __first);
@@ -66,7 +66,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter, _Iter> __search_
 
 // Finds the longest suffix in [__first, __last) where each element satisfies __pred.
 template <class _RAIter, class _Pred, class _Proj, class _ValueT>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _RAIter
+_LIBCPP_CONSTEXPR_SINCE_CXX14 _RAIter
 __find_longest_suffix(_RAIter __first, _RAIter __last, const _ValueT& __value, _Pred& __pred, _Proj& __proj) {
   while (__first != __last) {
     if (!std::__invoke(__pred, std::__invoke(__proj, *--__last), __value)) {
@@ -77,7 +77,7 @@ __find_longest_suffix(_RAIter __first, _RAIter __last, const _ValueT& __value, _
 }
 
 template <class _AlgPolicy, class _Pred, class _Iter, class _SizeT, class _Type, class _Proj, class _DiffT>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 std::pair<_Iter, _Iter> __search_n_random_access_impl(
+_LIBCPP_CONSTEXPR_SINCE_CXX14 std::pair<_Iter, _Iter> __search_n_random_access_impl(
     _Iter __first, _SizeT __count_in, const _Type& __value, _Pred& __pred, _Proj& __proj, _DiffT __size) {
   auto __last  = __first + __size;
   auto __count = static_cast<_DiffT>(__count_in);
@@ -128,7 +128,7 @@ template <class _Iter,
           class _Pred,
           class _Proj,
           __enable_if_t<__has_random_access_iterator_category<_Iter>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter, _Iter>
+_LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter, _Iter>
 __search_n_impl(_Iter __first, _Sent __last, _DiffT __count, const _Type& __value, _Pred& __pred, _Proj& __proj) {
   return std::__search_n_random_access_impl<_ClassicAlgPolicy>(
       __first, __count, __value, __pred, __proj, __last - __first);
@@ -143,13 +143,13 @@ template <class _Iter1,
           __enable_if_t<__has_forward_iterator_category<_Iter1>::value &&
                             !__has_random_access_iterator_category<_Iter1>::value,
                         int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter1, _Iter1>
+_LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_Iter1, _Iter1>
 __search_n_impl(_Iter1 __first, _Sent1 __last, _DiffT __count, const _Type& __value, _Pred& __pred, _Proj& __proj) {
   return std::__search_n_forward_impl<_ClassicAlgPolicy>(__first, __last, __count, __value, __pred, __proj);
 }
 
 template <class _ForwardIterator, class _Size, class _Tp, class _BinaryPredicate>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator search_n(
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator search_n(
     _ForwardIterator __first, _ForwardIterator __last, _Size __count, const _Tp& __value, _BinaryPredicate __pred) {
   static_assert(
       __is_callable<_BinaryPredicate&, decltype(*__first), const _Tp&>::value, "The comparator has to be callable");
@@ -158,7 +158,7 @@ template <class _ForwardIterator, class _Size, class _Tp, class _BinaryPredicate
 }
 
 template <class _ForwardIterator, class _Size, class _Tp>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 search_n(_ForwardIterator __first, _ForwardIterator __last, _Size __count, const _Tp& __value) {
   return std::search_n(__first, __last, std::__convert_to_integral(__count), __value, __equal_to());
 }

--- a/libcxx/include/__algorithm/set_difference.h
+++ b/libcxx/include/__algorithm/set_difference.h
@@ -27,9 +27,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Comp, class _InIter1, class _Sent1, class _InIter2, class _Sent2, class _OutIter>
-_LIBCPP_HIDE_FROM_ABI
-_LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<__remove_cvref_t<_InIter1>, __remove_cvref_t<_OutIter> >
-__set_difference(
+_LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<__remove_cvref_t<_InIter1>, __remove_cvref_t<_OutIter> > __set_difference(
     _InIter1&& __first1, _Sent1&& __last1, _InIter2&& __first2, _Sent2&& __last2, _OutIter&& __result, _Comp&& __comp) {
   while (__first1 != __last1 && __first2 != __last2) {
     if (__comp(*__first1, *__first2)) {
@@ -47,7 +45,7 @@ __set_difference(
 }
 
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator, class _Compare>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator set_difference(
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator set_difference(
     _InputIterator1 __first1,
     _InputIterator1 __last1,
     _InputIterator2 __first2,
@@ -59,7 +57,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator set_d
 }
 
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator set_difference(
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator set_difference(
     _InputIterator1 __first1,
     _InputIterator1 __last1,
     _InputIterator2 __first2,

--- a/libcxx/include/__algorithm/set_intersection.h
+++ b/libcxx/include/__algorithm/set_intersection.h
@@ -39,7 +39,7 @@ struct __set_intersection_result {
   _OutIter __out_;
 
   // need a constructor as C++03 aggregate init is hard
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
+  _LIBCPP_CONSTEXPR_SINCE_CXX20
   __set_intersection_result(_InIter1&& __in_iter1, _InIter2&& __in_iter2, _OutIter&& __out_iter)
       : __in1_(std::move(__in_iter1)), __in2_(std::move(__in_iter2)), __out_(std::move(__out_iter)) {}
 };
@@ -49,7 +49,7 @@ struct __set_intersection_result {
 // the way it is used and doesn't attempt to abstract that, it's not appropriate for general usage outside of its
 // context.
 template <class _InForwardIter1, class _InForwardIter2, class _OutIter>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __set_intersection_add_output_if_equal(
+_LIBCPP_CONSTEXPR_SINCE_CXX20 void __set_intersection_add_output_if_equal(
     bool __may_be_equal,
     _InForwardIter1& __first1,
     _InForwardIter2& __first2,
@@ -85,9 +85,8 @@ template <class _AlgPolicy,
           class _InForwardIter2,
           class _Sent2,
           class _OutIter>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI
-_LIBCPP_CONSTEXPR_SINCE_CXX20 __set_intersection_result<_InForwardIter1, _InForwardIter2, _OutIter>
-__set_intersection(
+[[__nodiscard__]]
+_LIBCPP_CONSTEXPR_SINCE_CXX20 __set_intersection_result<_InForwardIter1, _InForwardIter2, _OutIter> __set_intersection(
     _InForwardIter1 __first1,
     _Sent1 __last1,
     _InForwardIter2 __first2,
@@ -130,9 +129,8 @@ template <class _AlgPolicy,
           class _InInputIter2,
           class _Sent2,
           class _OutIter>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI
-_LIBCPP_CONSTEXPR_SINCE_CXX20 __set_intersection_result<_InInputIter1, _InInputIter2, _OutIter>
-__set_intersection(
+[[__nodiscard__]]
+_LIBCPP_CONSTEXPR_SINCE_CXX20 __set_intersection_result<_InInputIter1, _InInputIter2, _OutIter> __set_intersection(
     _InInputIter1 __first1,
     _Sent1 __last1,
     _InInputIter2 __first2,
@@ -161,9 +159,8 @@ __set_intersection(
 }
 
 template <class _AlgPolicy, class _Compare, class _InIter1, class _Sent1, class _InIter2, class _Sent2, class _OutIter>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI
-_LIBCPP_CONSTEXPR_SINCE_CXX20 __set_intersection_result<_InIter1, _InIter2, _OutIter>
-__set_intersection(
+[[__nodiscard__]]
+_LIBCPP_CONSTEXPR_SINCE_CXX20 __set_intersection_result<_InIter1, _InIter2, _OutIter> __set_intersection(
     _InIter1 __first1, _Sent1 __last1, _InIter2 __first2, _Sent2 __last2, _OutIter __result, _Compare&& __comp) {
   return std::__set_intersection<_AlgPolicy>(
       std::move(__first1),
@@ -177,7 +174,7 @@ __set_intersection(
 }
 
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator, class _Compare>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator set_intersection(
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator set_intersection(
     _InputIterator1 __first1,
     _InputIterator1 __last1,
     _InputIterator2 __first2,
@@ -195,7 +192,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator set_i
 }
 
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator set_intersection(
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator set_intersection(
     _InputIterator1 __first1,
     _InputIterator1 __last1,
     _InputIterator2 __first2,

--- a/libcxx/include/__algorithm/set_symmetric_difference.h
+++ b/libcxx/include/__algorithm/set_symmetric_difference.h
@@ -33,13 +33,13 @@ struct __set_symmetric_difference_result {
   _OutIter __out_;
 
   // need a constructor as C++03 aggregate init is hard
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
+  _LIBCPP_CONSTEXPR_SINCE_CXX20
   __set_symmetric_difference_result(_InIter1&& __in_iter1, _InIter2&& __in_iter2, _OutIter&& __out_iter)
       : __in1_(std::move(__in_iter1)), __in2_(std::move(__in_iter2)), __out_(std::move(__out_iter)) {}
 };
 
 template <class _Compare, class _InIter1, class _Sent1, class _InIter2, class _Sent2, class _OutIter>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __set_symmetric_difference_result<_InIter1, _InIter2, _OutIter>
+_LIBCPP_CONSTEXPR_SINCE_CXX20 __set_symmetric_difference_result<_InIter1, _InIter2, _OutIter>
 __set_symmetric_difference(
     _InIter1 __first1, _Sent1 __last1, _InIter2 __first2, _Sent2 __last2, _OutIter __result, _Compare&& __comp) {
   while (__first1 != __last1) {
@@ -68,7 +68,7 @@ __set_symmetric_difference(
 }
 
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator, class _Compare>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator set_symmetric_difference(
+_LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator set_symmetric_difference(
     _InputIterator1 __first1,
     _InputIterator1 __last1,
     _InputIterator2 __first2,
@@ -86,7 +86,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator set_symmetri
 }
 
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator set_symmetric_difference(
+_LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator set_symmetric_difference(
     _InputIterator1 __first1,
     _InputIterator1 __last1,
     _InputIterator2 __first2,

--- a/libcxx/include/__algorithm/set_union.h
+++ b/libcxx/include/__algorithm/set_union.h
@@ -33,13 +33,12 @@ struct __set_union_result {
   _OutIter __out_;
 
   // need a constructor as C++03 aggregate init is hard
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
-  __set_union_result(_InIter1&& __in_iter1, _InIter2&& __in_iter2, _OutIter&& __out_iter)
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 __set_union_result(_InIter1&& __in_iter1, _InIter2&& __in_iter2, _OutIter&& __out_iter)
       : __in1_(std::move(__in_iter1)), __in2_(std::move(__in_iter2)), __out_(std::move(__out_iter)) {}
 };
 
 template <class _Compare, class _InIter1, class _Sent1, class _InIter2, class _Sent2, class _OutIter>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __set_union_result<_InIter1, _InIter2, _OutIter> __set_union(
+_LIBCPP_CONSTEXPR_SINCE_CXX20 __set_union_result<_InIter1, _InIter2, _OutIter> __set_union(
     _InIter1 __first1, _Sent1 __last1, _InIter2 __first2, _Sent2 __last2, _OutIter __result, _Compare&& __comp) {
   for (; __first1 != __last1; ++__result) {
     if (__first2 == __last2) {
@@ -64,7 +63,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __set_union_result<_InIter1,
 }
 
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator, class _Compare>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator set_union(
+_LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator set_union(
     _InputIterator1 __first1,
     _InputIterator1 __last1,
     _InputIterator2 __first2,
@@ -82,7 +81,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator set_union(
 }
 
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator set_union(
+_LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator set_union(
     _InputIterator1 __first1,
     _InputIterator1 __last1,
     _InputIterator2 __first2,

--- a/libcxx/include/__algorithm/shift_left.h
+++ b/libcxx/include/__algorithm/shift_left.h
@@ -30,7 +30,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 20
 
 template <class _AlgPolicy, class _Iter, class _Sent>
-_LIBCPP_HIDE_FROM_ABI constexpr pair<_Iter, _Iter>
+constexpr pair<_Iter, _Iter>
 __shift_left(_Iter __first, _Sent __last, typename _IterOps<_AlgPolicy>::template __difference_type<_Iter> __n) {
   _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(__n >= 0, "n must be greater than or equal to 0");
 
@@ -60,7 +60,7 @@ __shift_left(_Iter __first, _Sent __last, typename _IterOps<_AlgPolicy>::templat
 }
 
 template <class _ForwardIterator>
-_LIBCPP_HIDE_FROM_ABI constexpr _ForwardIterator
+constexpr _ForwardIterator
 shift_left(_ForwardIterator __first,
            _ForwardIterator __last,
            typename iterator_traits<_ForwardIterator>::difference_type __n) {

--- a/libcxx/include/__algorithm/shift_right.h
+++ b/libcxx/include/__algorithm/shift_right.h
@@ -34,7 +34,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 20
 
 template <class _AlgPolicy, class _Iter, class _Sent>
-_LIBCPP_HIDE_FROM_ABI constexpr pair<_Iter, _Iter>
+constexpr pair<_Iter, _Iter>
 __shift_right(_Iter __first, _Sent __last, typename _IterOps<_AlgPolicy>::template __difference_type<_Iter> __n) {
   _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(__n >= 0, "Providing a negative shift amount to shift_right is UB");
   if (__n == 0) {
@@ -115,7 +115,7 @@ __shift_right(_Iter __first, _Sent __last, typename _IterOps<_AlgPolicy>::templa
 }
 
 template <class _ForwardIterator>
-_LIBCPP_HIDE_FROM_ABI constexpr _ForwardIterator
+constexpr _ForwardIterator
 shift_right(_ForwardIterator __first,
             _ForwardIterator __last,
             typename iterator_traits<_ForwardIterator>::difference_type __n) {

--- a/libcxx/include/__algorithm/sift_down.h
+++ b/libcxx/include/__algorithm/sift_down.h
@@ -25,7 +25,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, bool __assume_both_children, class _Compare, class _RandomAccessIterator>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void
+_LIBCPP_CONSTEXPR_SINCE_CXX14 void
 __sift_down(_RandomAccessIterator __first,
             _Compare&& __comp,
             __iterator_difference_type<_RandomAccessIterator> __len,
@@ -81,7 +81,7 @@ __sift_down(_RandomAccessIterator __first,
 }
 
 template <class _AlgPolicy, class _Compare, class _RandomAccessIterator>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _RandomAccessIterator __floyd_sift_down(
+_LIBCPP_CONSTEXPR_SINCE_CXX14 _RandomAccessIterator __floyd_sift_down(
     _RandomAccessIterator __first,
     _Compare&& __comp,
     typename iterator_traits<_RandomAccessIterator>::difference_type __len) {

--- a/libcxx/include/__algorithm/simd_utils.h
+++ b/libcxx/include/__algorithm/simd_utils.h
@@ -99,7 +99,7 @@ template <class _Tp, size_t _Np>
 inline constexpr size_t __simd_vector_size_v<__simd_vector<_Tp, _Np>> = _Np;
 
 template <class _Tp, size_t _Np>
-_LIBCPP_HIDE_FROM_ABI _Tp __simd_vector_underlying_type_impl(__simd_vector<_Tp, _Np>) {
+_Tp __simd_vector_underlying_type_impl(__simd_vector<_Tp, _Np>) {
   return _Tp{};
 }
 
@@ -108,7 +108,7 @@ using __simd_vector_underlying_type_t _LIBCPP_NODEBUG = decltype(std::__simd_vec
 
 // This isn't inlined without always_inline when loading chars.
 template <class _VecT, class _Iter>
-[[__nodiscard__]] _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI _VecT __load_vector(_Iter __iter) noexcept {
+[[__nodiscard__]] _LIBCPP_ALWAYS_INLINE _VecT __load_vector(_Iter __iter) noexcept {
   return [=]<size_t... _Indices>(index_sequence<_Indices...>) _LIBCPP_ALWAYS_INLINE noexcept {
     return _VecT{__iter[_Indices]...};
   }(make_index_sequence<__simd_vector_size_v<_VecT>>{});
@@ -118,7 +118,7 @@ template <class _VecT, class _Iter>
 _LIBCPP_DIAGNOSTIC_PUSH
 _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wpsabi")
 template <class _VecT, size_t _Np, class _Iter>
-[[__nodiscard__]] _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI _VecT __partial_load(_Iter __iter) noexcept {
+[[__nodiscard__]] _LIBCPP_ALWAYS_INLINE _VecT __partial_load(_Iter __iter) noexcept {
   return [=]<size_t... _LoadIndices, size_t... _ZeroIndices>(
              index_sequence<_LoadIndices...>, index_sequence<_ZeroIndices...>) _LIBCPP_ALWAYS_INLINE noexcept {
     return _VecT{__iter[_LoadIndices]..., ((void)_ZeroIndices, 0)...};
@@ -127,8 +127,7 @@ template <class _VecT, size_t _Np, class _Iter>
 
 // Create a vector where every elements is __val
 template <class _VecT>
-[[__nodiscard__]] _LIBCPP_ALWAYS_INLINE _LIBCPP_HIDE_FROM_ABI _VecT
-__broadcast(__simd_vector_underlying_type_t<_VecT> __val) {
+[[__nodiscard__]] _LIBCPP_ALWAYS_INLINE _VecT __broadcast(__simd_vector_underlying_type_t<_VecT> __val) {
   return [&]<std::size_t... _Indices>(index_sequence<_Indices...>) {
     return _VecT{((void)_Indices, __val)...};
   }(make_index_sequence<__simd_vector_size_v<_VecT>>());
@@ -136,22 +135,22 @@ __broadcast(__simd_vector_underlying_type_t<_VecT> __val) {
 _LIBCPP_DIAGNOSTIC_POP
 
 template <class _Tp, size_t _Np>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool __any_of(__simd_vector<_Tp, _Np> __vec) noexcept {
+[[__nodiscard__]] bool __any_of(__simd_vector<_Tp, _Np> __vec) noexcept {
   return __builtin_reduce_or(__builtin_convertvector(__vec, __simd_vector<bool, _Np>));
 }
 
 template <class _Tp, size_t _Np>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool __all_of(__simd_vector<_Tp, _Np> __vec) noexcept {
+[[__nodiscard__]] bool __all_of(__simd_vector<_Tp, _Np> __vec) noexcept {
   return __builtin_reduce_and(__builtin_convertvector(__vec, __simd_vector<bool, _Np>));
 }
 
 template <class _Tp, size_t _Np>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool __none_of(__simd_vector<_Tp, _Np> __vec) noexcept {
+[[__nodiscard__]] bool __none_of(__simd_vector<_Tp, _Np> __vec) noexcept {
   return !__builtin_reduce_or(__builtin_convertvector(__vec, __simd_vector<bool, _Np>));
 }
 
 template <class _Tp, size_t _Np>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI size_t __find_first_set(__simd_vector<_Tp, _Np> __vec) noexcept {
+[[__nodiscard__]] size_t __find_first_set(__simd_vector<_Tp, _Np> __vec) noexcept {
   using __mask_vec = __simd_vector<bool, _Np>;
 
   // This has MSan disabled du to https://llvm.org/PR85876
@@ -180,7 +179,7 @@ template <class _Tp, size_t _Np>
 }
 
 template <class _Tp, size_t _Np>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI size_t __find_first_not_set(__simd_vector<_Tp, _Np> __vec) noexcept {
+[[__nodiscard__]] size_t __find_first_not_set(__simd_vector<_Tp, _Np> __vec) noexcept {
   return std::__find_first_set(~__vec);
 }
 

--- a/libcxx/include/__algorithm/sort.h
+++ b/libcxx/include/__algorithm/sort.h
@@ -64,7 +64,7 @@ enum { __block_size = sizeof(uint64_t) * 8 };
 
 // Ensures that __c(*__x, *__y) is true by swapping *__x and *__y if necessary.
 template <class _Compare, class _RandomAccessIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
 __cond_swap(_RandomAccessIterator __x, _RandomAccessIterator __y, _Compare __c) {
   // Note: this function behaves correctly even with proxy iterators (because it relies on `value_type`).
   using value_type = typename iterator_traits<_RandomAccessIterator>::value_type;
@@ -78,7 +78,7 @@ __cond_swap(_RandomAccessIterator __x, _RandomAccessIterator __y, _Compare __c) 
 // Ensures that *__x, *__y and *__z are ordered according to the comparator __c,
 // under the assumption that *__y and *__z are already ordered.
 template <class _Compare, class _RandomAccessIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
 __partially_sorted_swap(_RandomAccessIterator __x, _RandomAccessIterator __y, _RandomAccessIterator __z, _Compare __c) {
   // Note: this function behaves correctly even with proxy iterators (because it relies on `value_type`).
   using value_type = typename iterator_traits<_RandomAccessIterator>::value_type;
@@ -97,7 +97,7 @@ template <class,
           class _Compare,
           class _RandomAccessIterator,
           __enable_if_t<__use_branchless_sort<_Compare, _RandomAccessIterator>, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
 __sort3(_RandomAccessIterator __x1, _RandomAccessIterator __x2, _RandomAccessIterator __x3, _Compare __c) {
   bool __swapped1 = std::__cond_swap<_Compare>(__x2, __x3, __c);
   bool __swapped2 = std::__partially_sorted_swap<_Compare>(__x1, __x2, __x3, __c);
@@ -108,7 +108,7 @@ template <class _AlgPolicy,
           class _Compare,
           class _RandomAccessIterator,
           __enable_if_t<!__use_branchless_sort<_Compare, _RandomAccessIterator>, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
 __sort3(_RandomAccessIterator __x, _RandomAccessIterator __y, _RandomAccessIterator __z, _Compare __c) {
   using _Ops = _IterOps<_AlgPolicy>;
 
@@ -140,7 +140,7 @@ template <class,
           class _Compare,
           class _RandomAccessIterator,
           __enable_if_t<__use_branchless_sort<_Compare, _RandomAccessIterator>, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI void
+inline void
 __sort4(_RandomAccessIterator __x1,
         _RandomAccessIterator __x2,
         _RandomAccessIterator __x3,
@@ -157,7 +157,7 @@ template <class _AlgPolicy,
           class _Compare,
           class _RandomAccessIterator,
           __enable_if_t<!__use_branchless_sort<_Compare, _RandomAccessIterator>, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI void
+inline void
 __sort4(_RandomAccessIterator __x1,
         _RandomAccessIterator __x2,
         _RandomAccessIterator __x3,
@@ -182,7 +182,7 @@ template <class _AlgPolicy,
           class _Compare,
           class _RandomAccessIterator,
           __enable_if_t<__use_branchless_sort<_Compare, _RandomAccessIterator>, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI void
+inline void
 __sort5(_RandomAccessIterator __x1,
         _RandomAccessIterator __x2,
         _RandomAccessIterator __x3,
@@ -201,7 +201,7 @@ template <class _AlgPolicy,
           class _Compare,
           class _RandomAccessIterator,
           __enable_if_t<!__use_branchless_sort<_Compare, _RandomAccessIterator>, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI void
+inline void
 __sort5(_RandomAccessIterator __x1,
         _RandomAccessIterator __x2,
         _RandomAccessIterator __x3,
@@ -227,7 +227,7 @@ __sort5(_RandomAccessIterator __x1,
 
 // Assumes size > 0
 template <class _AlgPolicy, class _Compare, class _BidirectionalIterator>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void
+_LIBCPP_CONSTEXPR_SINCE_CXX14 void
 __selection_sort(_BidirectionalIterator __first, _BidirectionalIterator __last, _Compare __comp) {
   _BidirectionalIterator __lm1 = __last;
   for (--__lm1; __first != __lm1; ++__first) {
@@ -240,7 +240,7 @@ __selection_sort(_BidirectionalIterator __first, _BidirectionalIterator __last, 
 // Sort the iterator range [__first, __last) using the comparator __comp using
 // the insertion sort algorithm.
 template <class _AlgPolicy, class _Compare, class _BidirectionalIterator>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void
+_LIBCPP_CONSTEXPR_SINCE_CXX26 void
 __insertion_sort(_BidirectionalIterator __first, _BidirectionalIterator __last, _Compare __comp) {
   using _Ops = _IterOps<_AlgPolicy>;
 
@@ -270,8 +270,7 @@ __insertion_sort(_BidirectionalIterator __first, _BidirectionalIterator __last, 
 // Assumes that there is an element in the position (__first - 1) and that each
 // element in the input range is greater or equal to the element at __first - 1.
 template <class _AlgPolicy, class _Compare, class _RandomAccessIterator>
-_LIBCPP_HIDE_FROM_ABI void
-__insertion_sort_unguarded(_RandomAccessIterator const __first, _RandomAccessIterator __last, _Compare __comp) {
+void __insertion_sort_unguarded(_RandomAccessIterator const __first, _RandomAccessIterator __last, _Compare __comp) {
   using _Ops = _IterOps<_AlgPolicy>;
   typedef typename iterator_traits<_RandomAccessIterator>::difference_type difference_type;
   typedef typename iterator_traits<_RandomAccessIterator>::value_type value_type;
@@ -298,8 +297,7 @@ __insertion_sort_unguarded(_RandomAccessIterator const __first, _RandomAccessIte
 }
 
 template <class _AlgPolicy, class _Comp, class _RandomAccessIterator>
-_LIBCPP_HIDE_FROM_ABI bool
-__insertion_sort_incomplete(_RandomAccessIterator __first, _RandomAccessIterator __last, _Comp __comp) {
+bool __insertion_sort_incomplete(_RandomAccessIterator __first, _RandomAccessIterator __last, _Comp __comp) {
   using _Ops = _IterOps<_AlgPolicy>;
 
   typedef typename iterator_traits<_RandomAccessIterator>::difference_type difference_type;
@@ -352,7 +350,7 @@ __insertion_sort_incomplete(_RandomAccessIterator __first, _RandomAccessIterator
 }
 
 template <class _AlgPolicy, class _RandomAccessIterator>
-inline _LIBCPP_HIDE_FROM_ABI void __swap_bitmap_pos(
+inline void __swap_bitmap_pos(
     _RandomAccessIterator __first, _RandomAccessIterator __last, uint64_t& __left_bitset, uint64_t& __right_bitset) {
   using _Ops = _IterOps<_AlgPolicy>;
   typedef typename std::iterator_traits<_RandomAccessIterator>::difference_type difference_type;
@@ -370,7 +368,7 @@ inline _LIBCPP_HIDE_FROM_ABI void __swap_bitmap_pos(
 template <class _Compare,
           class _RandomAccessIterator,
           class _ValueType = typename iterator_traits<_RandomAccessIterator>::value_type>
-inline _LIBCPP_HIDE_FROM_ABI void
+inline void
 __populate_left_bitset(_RandomAccessIterator __first, _Compare __comp, _ValueType& __pivot, uint64_t& __left_bitset) {
   // Possible vectorization. With a proper "-march" flag, the following loop
   // will be compiled into a set of SIMD instructions.
@@ -386,7 +384,7 @@ __populate_left_bitset(_RandomAccessIterator __first, _Compare __comp, _ValueTyp
 template <class _Compare,
           class _RandomAccessIterator,
           class _ValueType = typename iterator_traits<_RandomAccessIterator>::value_type>
-inline _LIBCPP_HIDE_FROM_ABI void
+inline void
 __populate_right_bitset(_RandomAccessIterator __lm1, _Compare __comp, _ValueType& __pivot, uint64_t& __right_bitset) {
   // Possible vectorization. With a proper "-march" flag, the following loop
   // will be compiled into a set of SIMD instructions.
@@ -403,7 +401,7 @@ template <class _AlgPolicy,
           class _Compare,
           class _RandomAccessIterator,
           class _ValueType = typename iterator_traits<_RandomAccessIterator>::value_type>
-inline _LIBCPP_HIDE_FROM_ABI void __bitset_partition_partial_blocks(
+inline void __bitset_partition_partial_blocks(
     _RandomAccessIterator& __first,
     _RandomAccessIterator& __lm1,
     _Compare __comp,
@@ -450,7 +448,7 @@ inline _LIBCPP_HIDE_FROM_ABI void __bitset_partition_partial_blocks(
 }
 
 template <class _AlgPolicy, class _RandomAccessIterator>
-inline _LIBCPP_HIDE_FROM_ABI void __swap_bitmap_pos_within(
+inline void __swap_bitmap_pos_within(
     _RandomAccessIterator& __first, _RandomAccessIterator& __lm1, uint64_t& __left_bitset, uint64_t& __right_bitset) {
   using _Ops = _IterOps<_AlgPolicy>;
   typedef typename std::iterator_traits<_RandomAccessIterator>::difference_type difference_type;
@@ -491,7 +489,7 @@ inline _LIBCPP_HIDE_FROM_ABI void __swap_bitmap_pos_within(
 // __bitset_partition uses bitsets for storing outcomes of the comparisons
 // between the pivot and other elements.
 template <class _AlgPolicy, class _RandomAccessIterator, class _Compare>
-_LIBCPP_HIDE_FROM_ABI std::pair<_RandomAccessIterator, bool>
+std::pair<_RandomAccessIterator, bool>
 __bitset_partition(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
   using _Ops = _IterOps<_AlgPolicy>;
   typedef typename std::iterator_traits<_RandomAccessIterator>::value_type value_type;
@@ -583,7 +581,7 @@ __bitset_partition(_RandomAccessIterator __first, _RandomAccessIterator __last, 
 // the provided range is already sorted, false otherwise.  We assume that the
 // length of the range is at least three elements.
 template <class _AlgPolicy, class _RandomAccessIterator, class _Compare>
-_LIBCPP_HIDE_FROM_ABI std::pair<_RandomAccessIterator, bool>
+std::pair<_RandomAccessIterator, bool>
 __partition_with_equals_on_right(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
   using _Ops = _IterOps<_AlgPolicy>;
   typedef typename iterator_traits<_RandomAccessIterator>::difference_type difference_type;
@@ -651,7 +649,7 @@ __partition_with_equals_on_right(_RandomAccessIterator __first, _RandomAccessIte
 // Similar to the above function.  Elements equivalent to the pivot are put to
 // the left of the pivot.  Returns the iterator to the pivot element.
 template <class _AlgPolicy, class _RandomAccessIterator, class _Compare>
-_LIBCPP_HIDE_FROM_ABI _RandomAccessIterator
+_RandomAccessIterator
 __partition_with_equals_on_left(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
   using _Ops = _IterOps<_AlgPolicy>;
   typedef typename iterator_traits<_RandomAccessIterator>::difference_type difference_type;
@@ -799,9 +797,9 @@ void __introsort(_RandomAccessIterator __first,
       continue;
     }
     // Use bitset partition only if asked for.
-    auto __ret                = _UseBitSetPartition
-                                  ? std::__bitset_partition<_AlgPolicy, _RandomAccessIterator, _Compare>(__first, __last, __comp)
-                                  : std::__partition_with_equals_on_right<_AlgPolicy, _RandomAccessIterator, _Compare>(
+    auto __ret = _UseBitSetPartition
+                   ? std::__bitset_partition<_AlgPolicy, _RandomAccessIterator, _Compare>(__first, __last, __comp)
+                   : std::__partition_with_equals_on_right<_AlgPolicy, _RandomAccessIterator, _Compare>(
                          __first, __last, __comp);
     _RandomAccessIterator __i = __ret.first;
     // [__first, __i) < *__i and *__i <= [__i+1, __last)
@@ -860,7 +858,7 @@ __sort<__less<long double>&, long double*>(long double*, long double*, __less<lo
 _LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS
 
 template <class _AlgPolicy, class _RandomAccessIterator, class _Comp>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
+_LIBCPP_CONSTEXPR_SINCE_CXX20 void
 __sort_dispatch(_RandomAccessIterator __first, _RandomAccessIterator __last, _Comp& __comp) {
   if (__first == __last) // log(0) is undefined, so don't try computing the depth
     return;
@@ -900,20 +898,20 @@ using __sort_is_specialized_in_library _LIBCPP_NODEBUG = __is_any_of<
     long double>;
 
 template <class _AlgPolicy, class _Type, __enable_if_t<__sort_is_specialized_in_library<_Type>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI void __sort_dispatch(_Type* __first, _Type* __last, __less<>&) {
+void __sort_dispatch(_Type* __first, _Type* __last, __less<>&) {
   __less<_Type> __comp;
   std::__sort<__less<_Type>&, _Type*>(__first, __last, __comp);
 }
 
 template <class _AlgPolicy, class _Type, __enable_if_t<__sort_is_specialized_in_library<_Type>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI void __sort_dispatch(_Type* __first, _Type* __last, less<_Type>&) {
+void __sort_dispatch(_Type* __first, _Type* __last, less<_Type>&) {
   __less<_Type> __comp;
   std::__sort<__less<_Type>&, _Type*>(__first, __last, __comp);
 }
 
 #if _LIBCPP_STD_VER >= 14
 template <class _AlgPolicy, class _Type, __enable_if_t<__sort_is_specialized_in_library<_Type>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI void __sort_dispatch(_Type* __first, _Type* __last, less<>&) {
+void __sort_dispatch(_Type* __first, _Type* __last, less<>&) {
   __less<_Type> __comp;
   std::__sort<__less<_Type>&, _Type*>(__first, __last, __comp);
 }
@@ -921,14 +919,14 @@ _LIBCPP_HIDE_FROM_ABI void __sort_dispatch(_Type* __first, _Type* __last, less<>
 
 #if _LIBCPP_STD_VER >= 20
 template <class _AlgPolicy, class _Type, __enable_if_t<__sort_is_specialized_in_library<_Type>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI void __sort_dispatch(_Type* __first, _Type* __last, ranges::less&) {
+void __sort_dispatch(_Type* __first, _Type* __last, ranges::less&) {
   __less<_Type> __comp;
   std::__sort<__less<_Type>&, _Type*>(__first, __last, __comp);
 }
 #endif
 
 template <class _AlgPolicy, class _RandomAccessIterator, class _Comp>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 __sort_impl(_RandomAccessIterator __first, _RandomAccessIterator __last, _Comp& __comp) {
   std::__debug_randomize_range<_AlgPolicy>(__first, __last);
 
@@ -942,14 +940,13 @@ __sort_impl(_RandomAccessIterator __first, _RandomAccessIterator __last, _Comp& 
 }
 
 template <class _RandomAccessIterator, class _Comp>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 sort(_RandomAccessIterator __first, _RandomAccessIterator __last, _Comp __comp) {
   std::__sort_impl<_ClassicAlgPolicy>(std::move(__first), std::move(__last), __comp);
 }
 
 template <class _RandomAccessIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
-sort(_RandomAccessIterator __first, _RandomAccessIterator __last) {
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void sort(_RandomAccessIterator __first, _RandomAccessIterator __last) {
   std::sort(__first, __last, __less<>());
 }
 

--- a/libcxx/include/__algorithm/sort_heap.h
+++ b/libcxx/include/__algorithm/sort_heap.h
@@ -30,7 +30,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, class _Compare, class _RandomAccessIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 void
 __sort_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare&& __comp) {
   _RandomAccessIterator __saved_last   = __last;
   __comp_ref_type<_Compare> __comp_ref = __comp;
@@ -42,7 +42,7 @@ __sort_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compar
 }
 
 template <class _RandomAccessIterator, class _Compare>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 sort_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
   static_assert(std::is_copy_constructible<_RandomAccessIterator>::value, "Iterators must be copy constructible.");
   static_assert(std::is_copy_assignable<_RandomAccessIterator>::value, "Iterators must be copy assignable.");
@@ -51,8 +51,7 @@ sort_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare 
 }
 
 template <class _RandomAccessIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
-sort_heap(_RandomAccessIterator __first, _RandomAccessIterator __last) {
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void sort_heap(_RandomAccessIterator __first, _RandomAccessIterator __last) {
   std::sort_heap(std::move(__first), std::move(__last), __less<>());
 }
 

--- a/libcxx/include/__algorithm/stable_partition.h
+++ b/libcxx/include/__algorithm/stable_partition.h
@@ -34,7 +34,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, class _Predicate, class _ForwardIterator, class _Distance, class _Pair>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 _ForwardIterator __stable_partition_impl(
+_LIBCPP_CONSTEXPR_SINCE_CXX26 _ForwardIterator __stable_partition_impl(
     _ForwardIterator __first,
     _ForwardIterator __last,
     _Predicate __pred,
@@ -117,7 +117,7 @@ __second_half_done:
 }
 
 template <class _AlgPolicy, class _Predicate, class _ForwardIterator>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 _ForwardIterator
+_LIBCPP_CONSTEXPR_SINCE_CXX26 _ForwardIterator
 __stable_partition_impl(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred, forward_iterator_tag) {
   typedef typename iterator_traits<_ForwardIterator>::difference_type difference_type;
   typedef typename iterator_traits<_ForwardIterator>::value_type value_type;
@@ -248,7 +248,7 @@ __second_half_done:
 }
 
 template <class _AlgPolicy, class _Predicate, class _BidirectionalIterator>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 _BidirectionalIterator __stable_partition_impl(
+_LIBCPP_CONSTEXPR_SINCE_CXX26 _BidirectionalIterator __stable_partition_impl(
     _BidirectionalIterator __first, _BidirectionalIterator __last, _Predicate __pred, bidirectional_iterator_tag) {
   typedef typename iterator_traits<_BidirectionalIterator>::difference_type difference_type;
   typedef typename iterator_traits<_BidirectionalIterator>::value_type value_type;
@@ -284,14 +284,14 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 _BidirectionalIterator __sta
 }
 
 template <class _AlgPolicy, class _Predicate, class _ForwardIterator, class _IterCategory>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 _ForwardIterator __stable_partition(
+_LIBCPP_CONSTEXPR_SINCE_CXX26 _ForwardIterator __stable_partition(
     _ForwardIterator __first, _ForwardIterator __last, _Predicate&& __pred, _IterCategory __iter_category) {
   return std::__stable_partition_impl<_AlgPolicy, __remove_cvref_t<_Predicate>&>(
       std::move(__first), std::move(__last), __pred, __iter_category);
 }
 
 template <class _ForwardIterator, class _Predicate>
-_LIBCPP_HIDE_FROM_ABI inline _LIBCPP_CONSTEXPR_SINCE_CXX26 _ForwardIterator
+inline _LIBCPP_CONSTEXPR_SINCE_CXX26 _ForwardIterator
 stable_partition(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred) {
   using _IterCategory = typename iterator_traits<_ForwardIterator>::iterator_category;
   return std::__stable_partition<_ClassicAlgPolicy, _Predicate&>(

--- a/libcxx/include/__algorithm/stable_sort.h
+++ b/libcxx/include/__algorithm/stable_sort.h
@@ -41,7 +41,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, class _Compare, class _BidirectionalIterator>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void __insertion_sort_move(
+_LIBCPP_CONSTEXPR_SINCE_CXX26 void __insertion_sort_move(
     _BidirectionalIterator __first1,
     _BidirectionalIterator __last1,
     typename iterator_traits<_BidirectionalIterator>::value_type* __first2,
@@ -74,7 +74,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void __insertion_sort_move(
 }
 
 template <class _AlgPolicy, class _Compare, class _InputIterator1, class _InputIterator2>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void __merge_move_construct(
+_LIBCPP_CONSTEXPR_SINCE_CXX26 void __merge_move_construct(
     _InputIterator1 __first1,
     _InputIterator1 __last1,
     _InputIterator2 __first2,
@@ -112,7 +112,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void __merge_move_construct(
 }
 
 template <class _AlgPolicy, class _Compare, class _InputIterator1, class _InputIterator2, class _OutputIterator>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void __merge_move_assign(
+_LIBCPP_CONSTEXPR_SINCE_CXX26 void __merge_move_assign(
     _InputIterator1 __first1,
     _InputIterator1 __last1,
     _InputIterator2 __first2,
@@ -199,7 +199,7 @@ struct __stable_sort_switch {
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI constexpr unsigned __radix_sort_min_bound() {
+constexpr unsigned __radix_sort_min_bound() {
   static_assert(__is_ordered_integer_representable_v<_Tp>);
   if constexpr (sizeof(_Tp) == 1) {
     return 1 << 8;
@@ -209,7 +209,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr unsigned __radix_sort_min_bound() {
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI constexpr unsigned __radix_sort_max_bound() {
+constexpr unsigned __radix_sort_max_bound() {
   static_assert(__is_ordered_integer_representable_v<_Tp>);
   if constexpr (sizeof(_Tp) >= 8) {
     return 1 << 15;
@@ -287,7 +287,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX26 void __stable_sort(
 }
 
 template <class _AlgPolicy, class _RandomAccessIterator, class _Compare>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void
+_LIBCPP_CONSTEXPR_SINCE_CXX26 void
 __stable_sort_impl(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare& __comp) {
   using value_type      = typename iterator_traits<_RandomAccessIterator>::value_type;
   using difference_type = typename iterator_traits<_RandomAccessIterator>::difference_type;
@@ -306,14 +306,13 @@ __stable_sort_impl(_RandomAccessIterator __first, _RandomAccessIterator __last, 
 }
 
 template <class _RandomAccessIterator, class _Compare>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void
+_LIBCPP_CONSTEXPR_SINCE_CXX26 void
 stable_sort(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
   std::__stable_sort_impl<_ClassicAlgPolicy>(std::move(__first), std::move(__last), __comp);
 }
 
 template <class _RandomAccessIterator>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void
-stable_sort(_RandomAccessIterator __first, _RandomAccessIterator __last) {
+_LIBCPP_CONSTEXPR_SINCE_CXX26 void stable_sort(_RandomAccessIterator __first, _RandomAccessIterator __last) {
   std::stable_sort(__first, __last, __less<>());
 }
 

--- a/libcxx/include/__algorithm/swap_ranges.h
+++ b/libcxx/include/__algorithm/swap_ranges.h
@@ -33,8 +33,7 @@ template <
     class _SpecialAlg =
         __specialized_algorithm<_Algorithm::__swap_ranges, __iterator_pair<_Iter1, _Sent1>, __single_iterator<_Iter2> >,
     __enable_if_t<_SpecialAlg::__has_algorithm, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_Iter1, _Iter2>
-__swap_ranges(_Iter1 __first1, _Sent1 __last1, _Iter2 __first2) {
+_LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_Iter1, _Iter2> __swap_ranges(_Iter1 __first1, _Sent1 __last1, _Iter2 __first2) {
   return _SpecialAlg()(std::move(__first1), std::move(__last1), std::move(__first2));
 }
 
@@ -46,8 +45,7 @@ template <
     class _SpecialAlg =
         __specialized_algorithm<_Algorithm::__swap_ranges, __iterator_pair<_Iter1, _Sent1>, __single_iterator<_Iter2> >,
     __enable_if_t<!_SpecialAlg::__has_algorithm, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_Iter1, _Iter2>
-__swap_ranges(_Iter1 __first1, _Sent1 __last1, _Iter2 __first2) {
+_LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_Iter1, _Iter2> __swap_ranges(_Iter1 __first1, _Sent1 __last1, _Iter2 __first2) {
   while (__first1 != __last1) {
     _IterOps<_AlgPolicy>::iter_swap(__first1, __first2);
     ++__first1;
@@ -58,7 +56,7 @@ __swap_ranges(_Iter1 __first1, _Sent1 __last1, _Iter2 __first2) {
 }
 
 template <class _ForwardIterator1, class _ForwardIterator2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator2
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator2
 swap_ranges(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2) {
   return std::__swap_ranges<_ClassicAlgPolicy>(std::move(__first1), std::move(__last1), std::move(__first2)).second;
 }

--- a/libcxx/include/__algorithm/three_way_comp_ref_type.h
+++ b/libcxx/include/__algorithm/three_way_comp_ref_type.h
@@ -26,10 +26,10 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 template <class _Comp>
 struct __debug_three_way_comp {
   _Comp& __comp_;
-  _LIBCPP_HIDE_FROM_ABI constexpr __debug_three_way_comp(_Comp& __c) : __comp_(__c) {}
+  constexpr __debug_three_way_comp(_Comp& __c) : __comp_(__c) {}
 
   template <class _Tp, class _Up>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(const _Tp& __x, const _Up& __y) {
+  constexpr auto operator()(const _Tp& __x, const _Up& __y) {
     auto __r = __comp_(__x, __y);
     if constexpr (__comparison_category<decltype(__comp_(__x, __y))>)
       __do_compare_assert(__y, __x, __r);
@@ -37,7 +37,7 @@ struct __debug_three_way_comp {
   }
 
   template <class _Tp, class _Up>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp& __x, _Up& __y) {
+  constexpr auto operator()(_Tp& __x, _Up& __y) {
     auto __r = __comp_(__x, __y);
     if constexpr (__comparison_category<decltype(__comp_(__x, __y))>)
       __do_compare_assert(__y, __x, __r);
@@ -45,7 +45,7 @@ struct __debug_three_way_comp {
   }
 
   template <class _LHS, class _RHS, class _Order>
-  _LIBCPP_HIDE_FROM_ABI constexpr void __do_compare_assert(_LHS& __l, _RHS& __r, _Order __o) {
+  constexpr void __do_compare_assert(_LHS& __l, _RHS& __r, _Order __o) {
     _Order __expected = __o;
     if (__o == _Order::less)
       __expected = _Order::greater;

--- a/libcxx/include/__algorithm/transform.h
+++ b/libcxx/include/__algorithm/transform.h
@@ -18,7 +18,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _InputIterator, class _OutputIterator, class _UnaryOperation>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
 transform(_InputIterator __first, _InputIterator __last, _OutputIterator __result, _UnaryOperation __op) {
   for (; __first != __last; ++__first, (void)++__result)
     *__result = __op(*__first);
@@ -26,7 +26,7 @@ transform(_InputIterator __first, _InputIterator __last, _OutputIterator __resul
 }
 
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator, class _BinaryOperation>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator transform(
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator transform(
     _InputIterator1 __first1,
     _InputIterator1 __last1,
     _InputIterator2 __first2,

--- a/libcxx/include/__algorithm/uniform_random_bit_generator_adaptor.h
+++ b/libcxx/include/__algorithm/uniform_random_bit_generator_adaptor.h
@@ -41,12 +41,12 @@ private:
 public:
   using result_type = invoke_result_t<_Gen&>;
 
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto min() { return __remove_cvref_t<_Gen>::min(); }
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto max() { return __remove_cvref_t<_Gen>::max(); }
+  static constexpr auto min() { return __remove_cvref_t<_Gen>::min(); }
+  static constexpr auto max() { return __remove_cvref_t<_Gen>::max(); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit _ClassicGenAdaptor(_Gen& __g) : __gen_(__g) {}
+  constexpr explicit _ClassicGenAdaptor(_Gen& __g) : __gen_(__g) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto operator()() const { return __gen_(); }
+  constexpr auto operator()() const { return __gen_(); }
 };
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/unique.h
+++ b/libcxx/include/__algorithm/unique.h
@@ -30,7 +30,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // unique
 
 template <class _AlgPolicy, class _Iter, class _Sent, class _BinaryPredicate>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 std::pair<_Iter, _Iter>
+[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX20 std::pair<_Iter, _Iter>
 __unique(_Iter __first, _Sent __last, _BinaryPredicate&& __pred) {
   __identity __proj;
   __first = std::__adjacent_find(__first, __last, __pred, __proj);
@@ -48,13 +48,13 @@ __unique(_Iter __first, _Sent __last, _BinaryPredicate&& __pred) {
 }
 
 template <class _ForwardIterator, class _BinaryPredicate>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
+[[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 unique(_ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred) {
   return std::__unique<_ClassicAlgPolicy>(std::move(__first), std::move(__last), __pred).first;
 }
 
 template <class _ForwardIterator>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 unique(_ForwardIterator __first, _ForwardIterator __last) {
   return std::unique(__first, __last, __equal_to());
 }

--- a/libcxx/include/__algorithm/unique_copy.h
+++ b/libcxx/include/__algorithm/unique_copy.h
@@ -37,7 +37,7 @@ struct __read_from_tmp_value_tag {};
 } // namespace __unique_copy_tags
 
 template <class _AlgPolicy, class _BinaryPredicate, class _InputIterator, class _Sent, class _OutputIterator>
-_LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI __in_out_result<_InputIterator, _OutputIterator>
+_LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_InputIterator, _OutputIterator>
 __unique_copy(_InputIterator __first,
               _Sent __last,
               _OutputIterator __result,
@@ -59,7 +59,7 @@ __unique_copy(_InputIterator __first,
 }
 
 template <class _AlgPolicy, class _BinaryPredicate, class _ForwardIterator, class _Sent, class _OutputIterator>
-_LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI __in_out_result<_ForwardIterator, _OutputIterator>
+_LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_ForwardIterator, _OutputIterator>
 __unique_copy(_ForwardIterator __first,
               _Sent __last,
               _OutputIterator __result,
@@ -81,7 +81,7 @@ __unique_copy(_ForwardIterator __first,
 }
 
 template <class _AlgPolicy, class _BinaryPredicate, class _InputIterator, class _Sent, class _InputAndOutputIterator>
-_LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI __in_out_result<_InputIterator, _InputAndOutputIterator>
+_LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_InputIterator, _InputAndOutputIterator>
 __unique_copy(_InputIterator __first,
               _Sent __last,
               _InputAndOutputIterator __result,
@@ -98,7 +98,7 @@ __unique_copy(_InputIterator __first,
 }
 
 template <class _InputIterator, class _OutputIterator, class _BinaryPredicate>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
 unique_copy(_InputIterator __first, _InputIterator __last, _OutputIterator __result, _BinaryPredicate __pred) {
   using __algo_tag = __conditional_t<
       is_base_of<forward_iterator_tag, typename iterator_traits<_InputIterator>::iterator_category>::value,
@@ -115,7 +115,7 @@ unique_copy(_InputIterator __first, _InputIterator __last, _OutputIterator __res
 }
 
 template <class _InputIterator, class _OutputIterator>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
+inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
 unique_copy(_InputIterator __first, _InputIterator __last, _OutputIterator __result) {
   return std::unique_copy(std::move(__first), std::move(__last), std::move(__result), __equal_to());
 }

--- a/libcxx/include/__algorithm/unwrap_iter.h
+++ b/libcxx/include/__algorithm/unwrap_iter.h
@@ -36,8 +36,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // Default case - we can't unwrap anything
 template <class _Iter, bool = __libcpp_is_contiguous_iterator<_Iter>::value>
 struct __unwrap_iter_impl {
-  static _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _Iter __rewrap(_Iter, _Iter __iter) { return __iter; }
-  static _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _Iter __unwrap(_Iter __i) _NOEXCEPT { return __i; }
+  static _LIBCPP_CONSTEXPR _Iter __rewrap(_Iter, _Iter __iter) { return __iter; }
+  static _LIBCPP_CONSTEXPR _Iter __unwrap(_Iter __i) _NOEXCEPT { return __i; }
 };
 
 // TODO(hardening): make sure that the following unwrapping doesn't unexpectedly turn hardened iterators into raw
@@ -48,17 +48,15 @@ template <class _Iter>
 struct __unwrap_iter_impl<_Iter, true> {
   using _ToAddressT _LIBCPP_NODEBUG = decltype(std::__to_address(std::declval<_Iter>()));
 
-  static _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _Iter __rewrap(_Iter __orig_iter, _ToAddressT __unwrapped_iter) {
+  static _LIBCPP_CONSTEXPR _Iter __rewrap(_Iter __orig_iter, _ToAddressT __unwrapped_iter) {
     return __orig_iter + (__unwrapped_iter - std::__to_address(__orig_iter));
   }
 
-  static _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _ToAddressT __unwrap(_Iter __i) _NOEXCEPT {
-    return std::__to_address(__i);
-  }
+  static _LIBCPP_CONSTEXPR _ToAddressT __unwrap(_Iter __i) _NOEXCEPT { return std::__to_address(__i); }
 };
 
 template <class _Iter, class _Impl = __unwrap_iter_impl<_Iter> >
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 decltype(_Impl::__unwrap(std::declval<_Iter>()))
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 decltype(_Impl::__unwrap(std::declval<_Iter>()))
 __unwrap_iter(_Iter __i) _NOEXCEPT {
 // Allow input_iterators to be passed to __unwrap_iter (but not __rewrap_iter)
 #if _LIBCPP_STD_VER >= 20
@@ -72,7 +70,7 @@ __unwrap_iter(_Iter __i) _NOEXCEPT {
 }
 
 template <class _OrigIter, class _Iter, class _Impl = __unwrap_iter_impl<_OrigIter> >
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _OrigIter __rewrap_iter(_OrigIter __orig_iter, _Iter __iter) _NOEXCEPT {
+_LIBCPP_CONSTEXPR _OrigIter __rewrap_iter(_OrigIter __orig_iter, _Iter __iter) _NOEXCEPT {
   return _Impl::__rewrap(std::move(__orig_iter), std::move(__iter));
 }
 

--- a/libcxx/include/__algorithm/unwrap_range.h
+++ b/libcxx/include/__algorithm/unwrap_range.h
@@ -32,7 +32,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if _LIBCPP_STD_VER >= 20
 template <class _Iter, class _Sent>
-_LIBCPP_HIDE_FROM_ABI constexpr auto __unwrap_range(_Iter __first, _Sent __last) {
+constexpr auto __unwrap_range(_Iter __first, _Sent __last) {
   if constexpr (is_same_v<_Iter, _Sent>)
     return pair{std::__unwrap_iter(std::move(__first)), std::__unwrap_iter(std::move(__last))};
   else if constexpr (random_access_iterator<_Iter> && sized_sentinel_for<_Sent, _Iter>) {
@@ -43,7 +43,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr auto __unwrap_range(_Iter __first, _Sent __last)
 }
 
 template < class _Sent, class _Iter, class _Unwrapped>
-_LIBCPP_HIDE_FROM_ABI constexpr _Iter __rewrap_range(_Iter __orig_iter, _Unwrapped __iter) {
+constexpr _Iter __rewrap_range(_Iter __orig_iter, _Unwrapped __iter) {
   if constexpr (is_same_v<_Iter, _Sent>)
     return std::__rewrap_iter(std::move(__orig_iter), std::move(__iter));
   else if constexpr (random_access_iterator<_Iter> && sized_sentinel_for<_Sent, _Iter>)
@@ -53,12 +53,12 @@ _LIBCPP_HIDE_FROM_ABI constexpr _Iter __rewrap_range(_Iter __orig_iter, _Unwrapp
 }
 #else  // _LIBCPP_STD_VER >= 20
 template <class _Iter, class _Unwrapped = decltype(std::__unwrap_iter(std::declval<_Iter>()))>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR pair<_Unwrapped, _Unwrapped> __unwrap_range(_Iter __first, _Iter __last) {
+_LIBCPP_CONSTEXPR pair<_Unwrapped, _Unwrapped> __unwrap_range(_Iter __first, _Iter __last) {
   return std::make_pair(std::__unwrap_iter(std::move(__first)), std::__unwrap_iter(std::move(__last)));
 }
 
 template <class _Iter, class _Unwrapped>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _Iter __rewrap_range(_Iter __orig_iter, _Unwrapped __iter) {
+_LIBCPP_CONSTEXPR _Iter __rewrap_range(_Iter __orig_iter, _Unwrapped __iter) {
   return std::__rewrap_iter(std::move(__orig_iter), std::move(__iter));
 }
 #endif // _LIBCPP_STD_VER >= 20

--- a/libcxx/include/__algorithm/upper_bound.h
+++ b/libcxx/include/__algorithm/upper_bound.h
@@ -33,7 +33,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, class _Compare, class _Iter, class _Sent, class _Tp, class _Proj>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _Iter
+_LIBCPP_CONSTEXPR_SINCE_CXX20 _Iter
 __upper_bound(_Iter __first, _Sent __last, const _Tp& __value, _Compare&& __comp, _Proj&& __proj) {
   auto __len = _IterOps<_AlgPolicy>::distance(__first, __last);
   while (__len != 0) {
@@ -50,7 +50,7 @@ __upper_bound(_Iter __first, _Sent __last, const _Tp& __value, _Compare&& __comp
 }
 
 template <class _ForwardIterator, class _Tp, class _Compare>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 upper_bound(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value, _Compare __comp) {
   static_assert(__is_callable<_Compare&, const _Tp&, decltype(*__first)>::value, "The comparator has to be callable");
   static_assert(is_copy_constructible<_ForwardIterator>::value, "Iterator has to be copy constructible");
@@ -59,7 +59,7 @@ upper_bound(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __valu
 }
 
 template <class _ForwardIterator, class _Tp>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 upper_bound(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) {
   return std::upper_bound(std::move(__first), std::move(__last), __value, __less<>());
 }

--- a/libcxx/include/__atomic/atomic.h
+++ b/libcxx/include/__atomic/atomic.h
@@ -47,91 +47,82 @@ struct __atomic_base // false
   static constexpr bool is_always_lock_free = __libcpp_is_always_lock_free<__cxx_atomic_impl<_Tp> >::__value;
 #endif
 
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool is_lock_free() const volatile _NOEXCEPT {
+  [[__nodiscard__]] bool is_lock_free() const volatile _NOEXCEPT {
     return __cxx_atomic_is_lock_free(sizeof(__cxx_atomic_impl<_Tp>));
   }
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool is_lock_free() const _NOEXCEPT {
+  [[__nodiscard__]] bool is_lock_free() const _NOEXCEPT {
     return static_cast<__atomic_base const volatile*>(this)->is_lock_free();
   }
-  _LIBCPP_HIDE_FROM_ABI void store(_Tp __d, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT
+  void store(_Tp __d, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT
       _LIBCPP_CHECK_STORE_MEMORY_ORDER(__m) {
     std::__cxx_atomic_store(std::addressof(__a_), __d, __m);
   }
-  _LIBCPP_HIDE_FROM_ABI void store(_Tp __d, memory_order __m = memory_order_seq_cst) _NOEXCEPT
-      _LIBCPP_CHECK_STORE_MEMORY_ORDER(__m) {
+  void store(_Tp __d, memory_order __m = memory_order_seq_cst) _NOEXCEPT _LIBCPP_CHECK_STORE_MEMORY_ORDER(__m) {
     std::__cxx_atomic_store(std::addressof(__a_), __d, __m);
   }
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _Tp load(memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
+  [[__nodiscard__]] _Tp load(memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT
       _LIBCPP_CHECK_LOAD_MEMORY_ORDER(__m) {
     return std::__cxx_atomic_load(std::addressof(__a_), __m);
   }
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _Tp load(memory_order __m = memory_order_seq_cst) const _NOEXCEPT
+  [[__nodiscard__]] _Tp load(memory_order __m = memory_order_seq_cst) const _NOEXCEPT
       _LIBCPP_CHECK_LOAD_MEMORY_ORDER(__m) {
     return std::__cxx_atomic_load(std::addressof(__a_), __m);
   }
-  _LIBCPP_HIDE_FROM_ABI operator _Tp() const volatile _NOEXCEPT { return load(); }
-  _LIBCPP_HIDE_FROM_ABI operator _Tp() const _NOEXCEPT { return load(); }
-  _LIBCPP_HIDE_FROM_ABI _Tp exchange(_Tp __d, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
+  operator _Tp() const volatile _NOEXCEPT { return load(); }
+  operator _Tp() const _NOEXCEPT { return load(); }
+  _Tp exchange(_Tp __d, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
     return std::__cxx_atomic_exchange(std::addressof(__a_), __d, __m);
   }
-  _LIBCPP_HIDE_FROM_ABI _Tp exchange(_Tp __d, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
+  _Tp exchange(_Tp __d, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
     return std::__cxx_atomic_exchange(std::addressof(__a_), __d, __m);
   }
-  _LIBCPP_HIDE_FROM_ABI bool
-  compare_exchange_weak(_Tp& __e, _Tp __d, memory_order __s, memory_order __f) volatile _NOEXCEPT
+  bool compare_exchange_weak(_Tp& __e, _Tp __d, memory_order __s, memory_order __f) volatile _NOEXCEPT
       _LIBCPP_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f) {
     return std::__cxx_atomic_compare_exchange_weak(std::addressof(__a_), std::addressof(__e), __d, __s, __f);
   }
-  _LIBCPP_HIDE_FROM_ABI bool compare_exchange_weak(_Tp& __e, _Tp __d, memory_order __s, memory_order __f) _NOEXCEPT
+  bool compare_exchange_weak(_Tp& __e, _Tp __d, memory_order __s, memory_order __f) _NOEXCEPT
       _LIBCPP_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f) {
     return std::__cxx_atomic_compare_exchange_weak(std::addressof(__a_), std::addressof(__e), __d, __s, __f);
   }
-  _LIBCPP_HIDE_FROM_ABI bool
-  compare_exchange_strong(_Tp& __e, _Tp __d, memory_order __s, memory_order __f) volatile _NOEXCEPT
+  bool compare_exchange_strong(_Tp& __e, _Tp __d, memory_order __s, memory_order __f) volatile _NOEXCEPT
       _LIBCPP_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f) {
     return std::__cxx_atomic_compare_exchange_strong(std::addressof(__a_), std::addressof(__e), __d, __s, __f);
   }
-  _LIBCPP_HIDE_FROM_ABI bool compare_exchange_strong(_Tp& __e, _Tp __d, memory_order __s, memory_order __f) _NOEXCEPT
+  bool compare_exchange_strong(_Tp& __e, _Tp __d, memory_order __s, memory_order __f) _NOEXCEPT
       _LIBCPP_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f) {
     return std::__cxx_atomic_compare_exchange_strong(std::addressof(__a_), std::addressof(__e), __d, __s, __f);
   }
-  _LIBCPP_HIDE_FROM_ABI bool
-  compare_exchange_weak(_Tp& __e, _Tp __d, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
+  bool compare_exchange_weak(_Tp& __e, _Tp __d, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
     return std::__cxx_atomic_compare_exchange_weak(std::addressof(__a_), std::addressof(__e), __d, __m, __m);
   }
-  _LIBCPP_HIDE_FROM_ABI bool
-  compare_exchange_weak(_Tp& __e, _Tp __d, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
+  bool compare_exchange_weak(_Tp& __e, _Tp __d, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
     return std::__cxx_atomic_compare_exchange_weak(std::addressof(__a_), std::addressof(__e), __d, __m, __m);
   }
-  _LIBCPP_HIDE_FROM_ABI bool
-  compare_exchange_strong(_Tp& __e, _Tp __d, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
+  bool compare_exchange_strong(_Tp& __e, _Tp __d, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
     return std::__cxx_atomic_compare_exchange_strong(std::addressof(__a_), std::addressof(__e), __d, __m, __m);
   }
-  _LIBCPP_HIDE_FROM_ABI bool
-  compare_exchange_strong(_Tp& __e, _Tp __d, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
+  bool compare_exchange_strong(_Tp& __e, _Tp __d, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
     return std::__cxx_atomic_compare_exchange_strong(std::addressof(__a_), std::addressof(__e), __d, __m, __m);
   }
 
 #if _LIBCPP_STD_VER >= 20
-  _LIBCPP_HIDE_FROM_ABI void wait(_Tp __v, memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT {
+  void wait(_Tp __v, memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT {
     std::__atomic_wait(*this, __v, __m);
   }
-  _LIBCPP_HIDE_FROM_ABI void wait(_Tp __v, memory_order __m = memory_order_seq_cst) const _NOEXCEPT {
-    std::__atomic_wait(*this, __v, __m);
-  }
-  _LIBCPP_HIDE_FROM_ABI void notify_one() volatile _NOEXCEPT { std::__atomic_notify_one(*this); }
-  _LIBCPP_HIDE_FROM_ABI void notify_one() _NOEXCEPT { std::__atomic_notify_one(*this); }
-  _LIBCPP_HIDE_FROM_ABI void notify_all() volatile _NOEXCEPT { std::__atomic_notify_all(*this); }
-  _LIBCPP_HIDE_FROM_ABI void notify_all() _NOEXCEPT { std::__atomic_notify_all(*this); }
+  void wait(_Tp __v, memory_order __m = memory_order_seq_cst) const _NOEXCEPT { std::__atomic_wait(*this, __v, __m); }
+  void notify_one() volatile _NOEXCEPT { std::__atomic_notify_one(*this); }
+  void notify_one() _NOEXCEPT { std::__atomic_notify_one(*this); }
+  void notify_all() volatile _NOEXCEPT { std::__atomic_notify_all(*this); }
+  void notify_all() _NOEXCEPT { std::__atomic_notify_all(*this); }
 #endif //  _LIBCPP_STD_VER >= 20
 
 #if _LIBCPP_STD_VER >= 20
-  _LIBCPP_HIDE_FROM_ABI constexpr __atomic_base() noexcept(is_nothrow_default_constructible_v<_Tp>) : __a_(_Tp()) {}
+  constexpr __atomic_base() noexcept(is_nothrow_default_constructible_v<_Tp>) : __a_(_Tp()) {}
 #else
-  _LIBCPP_HIDE_FROM_ABI __atomic_base() _NOEXCEPT = default;
+  __atomic_base() _NOEXCEPT = default;
 #endif
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR __atomic_base(_Tp __d) _NOEXCEPT : __a_(__d) {}
+  _LIBCPP_CONSTEXPR __atomic_base(_Tp __d) _NOEXCEPT : __a_(__d) {}
 
   __atomic_base(const __atomic_base&) = delete;
 };
@@ -144,59 +135,59 @@ struct __atomic_base<_Tp, true> : public __atomic_base<_Tp, false> {
 
   using difference_type = typename __base::value_type;
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __atomic_base() _NOEXCEPT = default;
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 __atomic_base() _NOEXCEPT = default;
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR __atomic_base(_Tp __d) _NOEXCEPT : __base(__d) {}
+  _LIBCPP_CONSTEXPR __atomic_base(_Tp __d) _NOEXCEPT : __base(__d) {}
 
-  _LIBCPP_HIDE_FROM_ABI _Tp fetch_add(_Tp __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
+  _Tp fetch_add(_Tp __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
     return std::__cxx_atomic_fetch_add(std::addressof(this->__a_), __op, __m);
   }
-  _LIBCPP_HIDE_FROM_ABI _Tp fetch_add(_Tp __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
+  _Tp fetch_add(_Tp __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
     return std::__cxx_atomic_fetch_add(std::addressof(this->__a_), __op, __m);
   }
-  _LIBCPP_HIDE_FROM_ABI _Tp fetch_sub(_Tp __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
+  _Tp fetch_sub(_Tp __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
     return std::__cxx_atomic_fetch_sub(std::addressof(this->__a_), __op, __m);
   }
-  _LIBCPP_HIDE_FROM_ABI _Tp fetch_sub(_Tp __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
+  _Tp fetch_sub(_Tp __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
     return std::__cxx_atomic_fetch_sub(std::addressof(this->__a_), __op, __m);
   }
-  _LIBCPP_HIDE_FROM_ABI _Tp fetch_and(_Tp __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
+  _Tp fetch_and(_Tp __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
     return std::__cxx_atomic_fetch_and(std::addressof(this->__a_), __op, __m);
   }
-  _LIBCPP_HIDE_FROM_ABI _Tp fetch_and(_Tp __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
+  _Tp fetch_and(_Tp __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
     return std::__cxx_atomic_fetch_and(std::addressof(this->__a_), __op, __m);
   }
-  _LIBCPP_HIDE_FROM_ABI _Tp fetch_or(_Tp __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
+  _Tp fetch_or(_Tp __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
     return std::__cxx_atomic_fetch_or(std::addressof(this->__a_), __op, __m);
   }
-  _LIBCPP_HIDE_FROM_ABI _Tp fetch_or(_Tp __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
+  _Tp fetch_or(_Tp __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
     return std::__cxx_atomic_fetch_or(std::addressof(this->__a_), __op, __m);
   }
-  _LIBCPP_HIDE_FROM_ABI _Tp fetch_xor(_Tp __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
+  _Tp fetch_xor(_Tp __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
     return std::__cxx_atomic_fetch_xor(std::addressof(this->__a_), __op, __m);
   }
-  _LIBCPP_HIDE_FROM_ABI _Tp fetch_xor(_Tp __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
+  _Tp fetch_xor(_Tp __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
     return std::__cxx_atomic_fetch_xor(std::addressof(this->__a_), __op, __m);
   }
 
-  _LIBCPP_HIDE_FROM_ABI _Tp operator++(int) volatile _NOEXCEPT { return fetch_add(_Tp(1)); }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator++(int) _NOEXCEPT { return fetch_add(_Tp(1)); }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator--(int) volatile _NOEXCEPT { return fetch_sub(_Tp(1)); }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator--(int) _NOEXCEPT { return fetch_sub(_Tp(1)); }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator++() volatile _NOEXCEPT { return fetch_add(_Tp(1)) + _Tp(1); }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator++() _NOEXCEPT { return fetch_add(_Tp(1)) + _Tp(1); }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator--() volatile _NOEXCEPT { return fetch_sub(_Tp(1)) - _Tp(1); }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator--() _NOEXCEPT { return fetch_sub(_Tp(1)) - _Tp(1); }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator+=(_Tp __op) volatile _NOEXCEPT { return fetch_add(__op) + __op; }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator+=(_Tp __op) _NOEXCEPT { return fetch_add(__op) + __op; }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator-=(_Tp __op) volatile _NOEXCEPT { return fetch_sub(__op) - __op; }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator-=(_Tp __op) _NOEXCEPT { return fetch_sub(__op) - __op; }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator&=(_Tp __op) volatile _NOEXCEPT { return fetch_and(__op) & __op; }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator&=(_Tp __op) _NOEXCEPT { return fetch_and(__op) & __op; }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator|=(_Tp __op) volatile _NOEXCEPT { return fetch_or(__op) | __op; }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator|=(_Tp __op) _NOEXCEPT { return fetch_or(__op) | __op; }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator^=(_Tp __op) volatile _NOEXCEPT { return fetch_xor(__op) ^ __op; }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator^=(_Tp __op) _NOEXCEPT { return fetch_xor(__op) ^ __op; }
+  _Tp operator++(int) volatile _NOEXCEPT { return fetch_add(_Tp(1)); }
+  _Tp operator++(int) _NOEXCEPT { return fetch_add(_Tp(1)); }
+  _Tp operator--(int) volatile _NOEXCEPT { return fetch_sub(_Tp(1)); }
+  _Tp operator--(int) _NOEXCEPT { return fetch_sub(_Tp(1)); }
+  _Tp operator++() volatile _NOEXCEPT { return fetch_add(_Tp(1)) + _Tp(1); }
+  _Tp operator++() _NOEXCEPT { return fetch_add(_Tp(1)) + _Tp(1); }
+  _Tp operator--() volatile _NOEXCEPT { return fetch_sub(_Tp(1)) - _Tp(1); }
+  _Tp operator--() _NOEXCEPT { return fetch_sub(_Tp(1)) - _Tp(1); }
+  _Tp operator+=(_Tp __op) volatile _NOEXCEPT { return fetch_add(__op) + __op; }
+  _Tp operator+=(_Tp __op) _NOEXCEPT { return fetch_add(__op) + __op; }
+  _Tp operator-=(_Tp __op) volatile _NOEXCEPT { return fetch_sub(__op) - __op; }
+  _Tp operator-=(_Tp __op) _NOEXCEPT { return fetch_sub(__op) - __op; }
+  _Tp operator&=(_Tp __op) volatile _NOEXCEPT { return fetch_and(__op) & __op; }
+  _Tp operator&=(_Tp __op) _NOEXCEPT { return fetch_and(__op) & __op; }
+  _Tp operator|=(_Tp __op) volatile _NOEXCEPT { return fetch_or(__op) | __op; }
+  _Tp operator|=(_Tp __op) _NOEXCEPT { return fetch_or(__op) | __op; }
+  _Tp operator^=(_Tp __op) volatile _NOEXCEPT { return fetch_xor(__op) ^ __op; }
+  _Tp operator^=(_Tp __op) _NOEXCEPT { return fetch_xor(__op) ^ __op; }
 };
 
 #if _LIBCPP_STD_VER >= 20
@@ -208,21 +199,19 @@ template <class _Tp, bool _IsIntegral>
 struct __atomic_waitable_traits<__atomic_base<_Tp, _IsIntegral> > {
   using __value_type _LIBCPP_NODEBUG = _Tp;
 
-  static _LIBCPP_HIDE_FROM_ABI _Tp __atomic_load(const __atomic_base<_Tp, _IsIntegral>& __a, memory_order __order) {
+  static _Tp __atomic_load(const __atomic_base<_Tp, _IsIntegral>& __a, memory_order __order) {
     return __a.load(__order);
   }
 
-  static _LIBCPP_HIDE_FROM_ABI _Tp
-  __atomic_load(const volatile __atomic_base<_Tp, _IsIntegral>& __this, memory_order __order) {
+  static _Tp __atomic_load(const volatile __atomic_base<_Tp, _IsIntegral>& __this, memory_order __order) {
     return __this.load(__order);
   }
 
-  static _LIBCPP_HIDE_FROM_ABI const __cxx_atomic_impl<_Tp>*
-  __atomic_contention_address(const __atomic_base<_Tp, _IsIntegral>& __a) {
+  static const __cxx_atomic_impl<_Tp>* __atomic_contention_address(const __atomic_base<_Tp, _IsIntegral>& __a) {
     return std::addressof(__a.__a_);
   }
 
-  static _LIBCPP_HIDE_FROM_ABI const volatile __cxx_atomic_impl<_Tp>*
+  static const volatile __cxx_atomic_impl<_Tp>*
   __atomic_contention_address(const volatile __atomic_base<_Tp, _IsIntegral>& __this) {
     return std::addressof(__this.__a_);
   }
@@ -241,18 +230,18 @@ struct atomic : public __atomic_base<typename __check_atomic_mandates<_Tp>::type
   using __base _LIBCPP_NODEBUG = __atomic_base<_Tp>;
 
 #if _LIBCPP_STD_VER >= 20
-  _LIBCPP_HIDE_FROM_ABI atomic() = default;
+  atomic() = default;
 #else
-  _LIBCPP_HIDE_FROM_ABI atomic() _NOEXCEPT = default;
+  atomic() _NOEXCEPT = default;
 #endif
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR atomic(_Tp __d) _NOEXCEPT : __base(__d) {}
+  _LIBCPP_CONSTEXPR atomic(_Tp __d) _NOEXCEPT : __base(__d) {}
 
-  _LIBCPP_HIDE_FROM_ABI _Tp operator=(_Tp __d) volatile _NOEXCEPT {
+  _Tp operator=(_Tp __d) volatile _NOEXCEPT {
     __base::store(__d);
     return __d;
   }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator=(_Tp __d) _NOEXCEPT {
+  _Tp operator=(_Tp __d) _NOEXCEPT {
     __base::store(__d);
     return __d;
   }
@@ -269,55 +258,55 @@ struct atomic<_Tp*> : public __atomic_base<_Tp*> {
 
   using difference_type = ptrdiff_t;
 
-  _LIBCPP_HIDE_FROM_ABI atomic() _NOEXCEPT = default;
+  atomic() _NOEXCEPT = default;
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR atomic(_Tp* __d) _NOEXCEPT : __base(__d) {}
+  _LIBCPP_CONSTEXPR atomic(_Tp* __d) _NOEXCEPT : __base(__d) {}
 
-  _LIBCPP_HIDE_FROM_ABI _Tp* operator=(_Tp* __d) volatile _NOEXCEPT {
+  _Tp* operator=(_Tp* __d) volatile _NOEXCEPT {
     __base::store(__d);
     return __d;
   }
-  _LIBCPP_HIDE_FROM_ABI _Tp* operator=(_Tp* __d) _NOEXCEPT {
+  _Tp* operator=(_Tp* __d) _NOEXCEPT {
     __base::store(__d);
     return __d;
   }
 
-  _LIBCPP_HIDE_FROM_ABI _Tp* fetch_add(ptrdiff_t __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
+  _Tp* fetch_add(ptrdiff_t __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
     // __atomic_fetch_add accepts function pointers, guard against them.
     static_assert(!is_function<__remove_pointer_t<_Tp> >::value, "Pointer to function isn't allowed");
     return std::__cxx_atomic_fetch_add(std::addressof(this->__a_), __op, __m);
   }
 
-  _LIBCPP_HIDE_FROM_ABI _Tp* fetch_add(ptrdiff_t __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
+  _Tp* fetch_add(ptrdiff_t __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
     // __atomic_fetch_add accepts function pointers, guard against them.
     static_assert(!is_function<__remove_pointer_t<_Tp> >::value, "Pointer to function isn't allowed");
     return std::__cxx_atomic_fetch_add(std::addressof(this->__a_), __op, __m);
   }
 
-  _LIBCPP_HIDE_FROM_ABI _Tp* fetch_sub(ptrdiff_t __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
+  _Tp* fetch_sub(ptrdiff_t __op, memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
     // __atomic_fetch_sub accepts function pointers, guard against them.
     static_assert(!is_function<__remove_pointer_t<_Tp> >::value, "Pointer to function isn't allowed");
     return std::__cxx_atomic_fetch_sub(std::addressof(this->__a_), __op, __m);
   }
 
-  _LIBCPP_HIDE_FROM_ABI _Tp* fetch_sub(ptrdiff_t __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
+  _Tp* fetch_sub(ptrdiff_t __op, memory_order __m = memory_order_seq_cst) _NOEXCEPT {
     // __atomic_fetch_sub accepts function pointers, guard against them.
     static_assert(!is_function<__remove_pointer_t<_Tp> >::value, "Pointer to function isn't allowed");
     return std::__cxx_atomic_fetch_sub(std::addressof(this->__a_), __op, __m);
   }
 
-  _LIBCPP_HIDE_FROM_ABI _Tp* operator++(int) volatile _NOEXCEPT { return fetch_add(1); }
-  _LIBCPP_HIDE_FROM_ABI _Tp* operator++(int) _NOEXCEPT { return fetch_add(1); }
-  _LIBCPP_HIDE_FROM_ABI _Tp* operator--(int) volatile _NOEXCEPT { return fetch_sub(1); }
-  _LIBCPP_HIDE_FROM_ABI _Tp* operator--(int) _NOEXCEPT { return fetch_sub(1); }
-  _LIBCPP_HIDE_FROM_ABI _Tp* operator++() volatile _NOEXCEPT { return fetch_add(1) + 1; }
-  _LIBCPP_HIDE_FROM_ABI _Tp* operator++() _NOEXCEPT { return fetch_add(1) + 1; }
-  _LIBCPP_HIDE_FROM_ABI _Tp* operator--() volatile _NOEXCEPT { return fetch_sub(1) - 1; }
-  _LIBCPP_HIDE_FROM_ABI _Tp* operator--() _NOEXCEPT { return fetch_sub(1) - 1; }
-  _LIBCPP_HIDE_FROM_ABI _Tp* operator+=(ptrdiff_t __op) volatile _NOEXCEPT { return fetch_add(__op) + __op; }
-  _LIBCPP_HIDE_FROM_ABI _Tp* operator+=(ptrdiff_t __op) _NOEXCEPT { return fetch_add(__op) + __op; }
-  _LIBCPP_HIDE_FROM_ABI _Tp* operator-=(ptrdiff_t __op) volatile _NOEXCEPT { return fetch_sub(__op) - __op; }
-  _LIBCPP_HIDE_FROM_ABI _Tp* operator-=(ptrdiff_t __op) _NOEXCEPT { return fetch_sub(__op) - __op; }
+  _Tp* operator++(int) volatile _NOEXCEPT { return fetch_add(1); }
+  _Tp* operator++(int) _NOEXCEPT { return fetch_add(1); }
+  _Tp* operator--(int) volatile _NOEXCEPT { return fetch_sub(1); }
+  _Tp* operator--(int) _NOEXCEPT { return fetch_sub(1); }
+  _Tp* operator++() volatile _NOEXCEPT { return fetch_add(1) + 1; }
+  _Tp* operator++() _NOEXCEPT { return fetch_add(1) + 1; }
+  _Tp* operator--() volatile _NOEXCEPT { return fetch_sub(1) - 1; }
+  _Tp* operator--() _NOEXCEPT { return fetch_sub(1) - 1; }
+  _Tp* operator+=(ptrdiff_t __op) volatile _NOEXCEPT { return fetch_add(__op) + __op; }
+  _Tp* operator+=(ptrdiff_t __op) _NOEXCEPT { return fetch_add(__op) + __op; }
+  _Tp* operator-=(ptrdiff_t __op) volatile _NOEXCEPT { return fetch_sub(__op) - __op; }
+  _Tp* operator-=(ptrdiff_t __op) _NOEXCEPT { return fetch_sub(__op) - __op; }
 
   atomic& operator=(const atomic&)          = delete;
   atomic& operator=(const atomic&) volatile = delete;
@@ -332,7 +321,7 @@ template <class _Tp>
 struct atomic<_Tp> : __atomic_base<_Tp> {
 private:
   template <class _This, class _Operation, class _BuiltinOp>
-  _LIBCPP_HIDE_FROM_ABI static _Tp
+  static _Tp
   __rmw_op(_This&& __self, _Tp __operand, memory_order __m, _Operation __operation, _BuiltinOp __builtin_op) {
     if constexpr (std::__has_rmw_builtin<_Tp>()) {
       return __builtin_op(std::addressof(std::forward<_This>(__self).__a_), __operand, __m);
@@ -355,7 +344,7 @@ private:
   }
 
   template <class _This>
-  _LIBCPP_HIDE_FROM_ABI static _Tp __fetch_add(_This&& __self, _Tp __operand, memory_order __m) {
+  static _Tp __fetch_add(_This&& __self, _Tp __operand, memory_order __m) {
     auto __builtin_op = [](auto __a, auto __builtin_operand, auto __order) {
       return std::__cxx_atomic_fetch_add(__a, __builtin_operand, __order);
     };
@@ -364,7 +353,7 @@ private:
   }
 
   template <class _This>
-  _LIBCPP_HIDE_FROM_ABI static _Tp __fetch_sub(_This&& __self, _Tp __operand, memory_order __m) {
+  static _Tp __fetch_sub(_This&& __self, _Tp __operand, memory_order __m) {
     auto __builtin_op = [](auto __a, auto __builtin_operand, auto __order) {
       return std::__cxx_atomic_fetch_sub(__a, __builtin_operand, __order);
     };
@@ -377,59 +366,55 @@ public:
   using value_type             = _Tp;
   using difference_type        = value_type;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr atomic() noexcept = default;
-  _LIBCPP_HIDE_FROM_ABI constexpr atomic(_Tp __d) noexcept : __base(__d) {}
+  constexpr atomic() noexcept = default;
+  constexpr atomic(_Tp __d) noexcept : __base(__d) {}
 
   atomic(const atomic&)                     = delete;
   atomic& operator=(const atomic&)          = delete;
   atomic& operator=(const atomic&) volatile = delete;
 
-  _LIBCPP_HIDE_FROM_ABI _Tp operator=(_Tp __d) volatile noexcept
+  _Tp operator=(_Tp __d) volatile noexcept
     requires __base::is_always_lock_free
   {
     __base::store(__d);
     return __d;
   }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator=(_Tp __d) noexcept {
+  _Tp operator=(_Tp __d) noexcept {
     __base::store(__d);
     return __d;
   }
 
-  _LIBCPP_HIDE_FROM_ABI _Tp fetch_add(_Tp __op, memory_order __m = memory_order_seq_cst) volatile noexcept
+  _Tp fetch_add(_Tp __op, memory_order __m = memory_order_seq_cst) volatile noexcept
     requires __base::is_always_lock_free
   {
     return __fetch_add(*this, __op, __m);
   }
 
-  _LIBCPP_HIDE_FROM_ABI _Tp fetch_add(_Tp __op, memory_order __m = memory_order_seq_cst) noexcept {
-    return __fetch_add(*this, __op, __m);
-  }
+  _Tp fetch_add(_Tp __op, memory_order __m = memory_order_seq_cst) noexcept { return __fetch_add(*this, __op, __m); }
 
-  _LIBCPP_HIDE_FROM_ABI _Tp fetch_sub(_Tp __op, memory_order __m = memory_order_seq_cst) volatile noexcept
+  _Tp fetch_sub(_Tp __op, memory_order __m = memory_order_seq_cst) volatile noexcept
     requires __base::is_always_lock_free
   {
     return __fetch_sub(*this, __op, __m);
   }
 
-  _LIBCPP_HIDE_FROM_ABI _Tp fetch_sub(_Tp __op, memory_order __m = memory_order_seq_cst) noexcept {
-    return __fetch_sub(*this, __op, __m);
-  }
+  _Tp fetch_sub(_Tp __op, memory_order __m = memory_order_seq_cst) noexcept { return __fetch_sub(*this, __op, __m); }
 
-  _LIBCPP_HIDE_FROM_ABI _Tp operator+=(_Tp __op) volatile noexcept
+  _Tp operator+=(_Tp __op) volatile noexcept
     requires __base::is_always_lock_free
   {
     return fetch_add(__op) + __op;
   }
 
-  _LIBCPP_HIDE_FROM_ABI _Tp operator+=(_Tp __op) noexcept { return fetch_add(__op) + __op; }
+  _Tp operator+=(_Tp __op) noexcept { return fetch_add(__op) + __op; }
 
-  _LIBCPP_HIDE_FROM_ABI _Tp operator-=(_Tp __op) volatile noexcept
+  _Tp operator-=(_Tp __op) volatile noexcept
     requires __base::is_always_lock_free
   {
     return fetch_sub(__op) - __op;
   }
 
-  _LIBCPP_HIDE_FROM_ABI _Tp operator-=(_Tp __op) noexcept { return fetch_sub(__op) - __op; }
+  _Tp operator-=(_Tp __op) noexcept { return fetch_sub(__op) - __op; }
 };
 
 #endif // _LIBCPP_STD_VER >= 20
@@ -437,53 +422,50 @@ public:
 // atomic_is_lock_free
 
 template <class _Tp>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool atomic_is_lock_free(const volatile atomic<_Tp>* __o) _NOEXCEPT {
+[[__nodiscard__]] bool atomic_is_lock_free(const volatile atomic<_Tp>* __o) _NOEXCEPT {
   return __o->is_lock_free();
 }
 
 template <class _Tp>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool atomic_is_lock_free(const atomic<_Tp>* __o) _NOEXCEPT {
+[[__nodiscard__]] bool atomic_is_lock_free(const atomic<_Tp>* __o) _NOEXCEPT {
   return __o->is_lock_free();
 }
 
 // atomic_init
 
 template <class _Tp>
-_LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_HIDE_FROM_ABI void
+_LIBCPP_DEPRECATED_IN_CXX20 void
 atomic_init(volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __d) _NOEXCEPT {
   std::__cxx_atomic_init(std::addressof(__o->__a_), __d);
 }
 
 template <class _Tp>
-_LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_HIDE_FROM_ABI void
-atomic_init(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __d) _NOEXCEPT {
+_LIBCPP_DEPRECATED_IN_CXX20 void atomic_init(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __d) _NOEXCEPT {
   std::__cxx_atomic_init(std::addressof(__o->__a_), __d);
 }
 
 // atomic_store
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI void atomic_store(volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __d) _NOEXCEPT {
+void atomic_store(volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __d) _NOEXCEPT {
   __o->store(__d);
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI void atomic_store(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __d) _NOEXCEPT {
+void atomic_store(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __d) _NOEXCEPT {
   __o->store(__d);
 }
 
 // atomic_store_explicit
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI void
-atomic_store_explicit(volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __d, memory_order __m) _NOEXCEPT
+void atomic_store_explicit(volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __d, memory_order __m) _NOEXCEPT
     _LIBCPP_CHECK_STORE_MEMORY_ORDER(__m) {
   __o->store(__d, __m);
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI void
-atomic_store_explicit(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __d, memory_order __m) _NOEXCEPT
+void atomic_store_explicit(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __d, memory_order __m) _NOEXCEPT
     _LIBCPP_CHECK_STORE_MEMORY_ORDER(__m) {
   __o->store(__d, __m);
 }
@@ -491,25 +473,25 @@ atomic_store_explicit(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __d, me
 // atomic_load
 
 template <class _Tp>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _Tp atomic_load(const volatile atomic<_Tp>* __o) _NOEXCEPT {
+[[__nodiscard__]] _Tp atomic_load(const volatile atomic<_Tp>* __o) _NOEXCEPT {
   return __o->load();
 }
 
 template <class _Tp>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _Tp atomic_load(const atomic<_Tp>* __o) _NOEXCEPT {
+[[__nodiscard__]] _Tp atomic_load(const atomic<_Tp>* __o) _NOEXCEPT {
   return __o->load();
 }
 
 // atomic_load_explicit
 
 template <class _Tp>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _Tp
-atomic_load_explicit(const volatile atomic<_Tp>* __o, memory_order __m) _NOEXCEPT _LIBCPP_CHECK_LOAD_MEMORY_ORDER(__m) {
+[[__nodiscard__]] _Tp atomic_load_explicit(const volatile atomic<_Tp>* __o, memory_order __m) _NOEXCEPT
+    _LIBCPP_CHECK_LOAD_MEMORY_ORDER(__m) {
   return __o->load(__m);
 }
 
 template <class _Tp>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _Tp atomic_load_explicit(const atomic<_Tp>* __o, memory_order __m) _NOEXCEPT
+[[__nodiscard__]] _Tp atomic_load_explicit(const atomic<_Tp>* __o, memory_order __m) _NOEXCEPT
     _LIBCPP_CHECK_LOAD_MEMORY_ORDER(__m) {
   return __o->load(__m);
 }
@@ -517,39 +499,38 @@ template <class _Tp>
 // atomic_exchange
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp atomic_exchange(volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __d) _NOEXCEPT {
+_Tp atomic_exchange(volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __d) _NOEXCEPT {
   return __o->exchange(__d);
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp atomic_exchange(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __d) _NOEXCEPT {
+_Tp atomic_exchange(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __d) _NOEXCEPT {
   return __o->exchange(__d);
 }
 
 // atomic_exchange_explicit
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-atomic_exchange_explicit(volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __d, memory_order __m) _NOEXCEPT {
+_Tp atomic_exchange_explicit(
+    volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __d, memory_order __m) _NOEXCEPT {
   return __o->exchange(__d, __m);
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-atomic_exchange_explicit(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __d, memory_order __m) _NOEXCEPT {
+_Tp atomic_exchange_explicit(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __d, memory_order __m) _NOEXCEPT {
   return __o->exchange(__d, __m);
 }
 
 // atomic_compare_exchange_weak
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI bool atomic_compare_exchange_weak(
+bool atomic_compare_exchange_weak(
     volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type* __e, typename atomic<_Tp>::value_type __d) _NOEXCEPT {
   return __o->compare_exchange_weak(*__e, __d);
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI bool atomic_compare_exchange_weak(
+bool atomic_compare_exchange_weak(
     atomic<_Tp>* __o, typename atomic<_Tp>::value_type* __e, typename atomic<_Tp>::value_type __d) _NOEXCEPT {
   return __o->compare_exchange_weak(*__e, __d);
 }
@@ -557,13 +538,13 @@ _LIBCPP_HIDE_FROM_ABI bool atomic_compare_exchange_weak(
 // atomic_compare_exchange_strong
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI bool atomic_compare_exchange_strong(
+bool atomic_compare_exchange_strong(
     volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type* __e, typename atomic<_Tp>::value_type __d) _NOEXCEPT {
   return __o->compare_exchange_strong(*__e, __d);
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI bool atomic_compare_exchange_strong(
+bool atomic_compare_exchange_strong(
     atomic<_Tp>* __o, typename atomic<_Tp>::value_type* __e, typename atomic<_Tp>::value_type __d) _NOEXCEPT {
   return __o->compare_exchange_strong(*__e, __d);
 }
@@ -571,7 +552,7 @@ _LIBCPP_HIDE_FROM_ABI bool atomic_compare_exchange_strong(
 // atomic_compare_exchange_weak_explicit
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI bool atomic_compare_exchange_weak_explicit(
+bool atomic_compare_exchange_weak_explicit(
     volatile atomic<_Tp>* __o,
     typename atomic<_Tp>::value_type* __e,
     typename atomic<_Tp>::value_type __d,
@@ -581,7 +562,7 @@ _LIBCPP_HIDE_FROM_ABI bool atomic_compare_exchange_weak_explicit(
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI bool atomic_compare_exchange_weak_explicit(
+bool atomic_compare_exchange_weak_explicit(
     atomic<_Tp>* __o,
     typename atomic<_Tp>::value_type* __e,
     typename atomic<_Tp>::value_type __d,
@@ -593,7 +574,7 @@ _LIBCPP_HIDE_FROM_ABI bool atomic_compare_exchange_weak_explicit(
 // atomic_compare_exchange_strong_explicit
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI bool atomic_compare_exchange_strong_explicit(
+bool atomic_compare_exchange_strong_explicit(
     volatile atomic<_Tp>* __o,
     typename atomic<_Tp>::value_type* __e,
     typename atomic<_Tp>::value_type __d,
@@ -603,7 +584,7 @@ _LIBCPP_HIDE_FROM_ABI bool atomic_compare_exchange_strong_explicit(
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI bool atomic_compare_exchange_strong_explicit(
+bool atomic_compare_exchange_strong_explicit(
     atomic<_Tp>* __o,
     typename atomic<_Tp>::value_type* __e,
     typename atomic<_Tp>::value_type __d,
@@ -617,28 +598,25 @@ _LIBCPP_HIDE_FROM_ABI bool atomic_compare_exchange_strong_explicit(
 // atomic_wait
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI void
-atomic_wait(const volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __v) _NOEXCEPT {
+void atomic_wait(const volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __v) _NOEXCEPT {
   return __o->wait(__v);
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI void atomic_wait(const atomic<_Tp>* __o, typename atomic<_Tp>::value_type __v) _NOEXCEPT {
+void atomic_wait(const atomic<_Tp>* __o, typename atomic<_Tp>::value_type __v) _NOEXCEPT {
   return __o->wait(__v);
 }
 
 // atomic_wait_explicit
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI void
-atomic_wait_explicit(const volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __v, memory_order __m) _NOEXCEPT
-    _LIBCPP_CHECK_LOAD_MEMORY_ORDER(__m) {
+void atomic_wait_explicit(const volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __v, memory_order __m)
+    _NOEXCEPT _LIBCPP_CHECK_LOAD_MEMORY_ORDER(__m) {
   return __o->wait(__v, __m);
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI void
-atomic_wait_explicit(const atomic<_Tp>* __o, typename atomic<_Tp>::value_type __v, memory_order __m) _NOEXCEPT
+void atomic_wait_explicit(const atomic<_Tp>* __o, typename atomic<_Tp>::value_type __v, memory_order __m) _NOEXCEPT
     _LIBCPP_CHECK_LOAD_MEMORY_ORDER(__m) {
   return __o->wait(__v, __m);
 }
@@ -646,22 +624,22 @@ atomic_wait_explicit(const atomic<_Tp>* __o, typename atomic<_Tp>::value_type __
 // atomic_notify_one
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI void atomic_notify_one(volatile atomic<_Tp>* __o) _NOEXCEPT {
+void atomic_notify_one(volatile atomic<_Tp>* __o) _NOEXCEPT {
   __o->notify_one();
 }
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI void atomic_notify_one(atomic<_Tp>* __o) _NOEXCEPT {
+void atomic_notify_one(atomic<_Tp>* __o) _NOEXCEPT {
   __o->notify_one();
 }
 
 // atomic_notify_all
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI void atomic_notify_all(volatile atomic<_Tp>* __o) _NOEXCEPT {
+void atomic_notify_all(volatile atomic<_Tp>* __o) _NOEXCEPT {
   __o->notify_all();
 }
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI void atomic_notify_all(atomic<_Tp>* __o) _NOEXCEPT {
+void atomic_notify_all(atomic<_Tp>* __o) _NOEXCEPT {
   __o->notify_all();
 }
 
@@ -670,132 +648,127 @@ _LIBCPP_HIDE_FROM_ABI void atomic_notify_all(atomic<_Tp>* __o) _NOEXCEPT {
 // atomic_fetch_add
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-atomic_fetch_add(volatile atomic<_Tp>* __o, typename atomic<_Tp>::difference_type __op) _NOEXCEPT {
+_Tp atomic_fetch_add(volatile atomic<_Tp>* __o, typename atomic<_Tp>::difference_type __op) _NOEXCEPT {
   return __o->fetch_add(__op);
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp atomic_fetch_add(atomic<_Tp>* __o, typename atomic<_Tp>::difference_type __op) _NOEXCEPT {
+_Tp atomic_fetch_add(atomic<_Tp>* __o, typename atomic<_Tp>::difference_type __op) _NOEXCEPT {
   return __o->fetch_add(__op);
 }
 
 // atomic_fetch_add_explicit
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp atomic_fetch_add_explicit(
+_Tp atomic_fetch_add_explicit(
     volatile atomic<_Tp>* __o, typename atomic<_Tp>::difference_type __op, memory_order __m) _NOEXCEPT {
   return __o->fetch_add(__op, __m);
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-atomic_fetch_add_explicit(atomic<_Tp>* __o, typename atomic<_Tp>::difference_type __op, memory_order __m) _NOEXCEPT {
+_Tp atomic_fetch_add_explicit(
+    atomic<_Tp>* __o, typename atomic<_Tp>::difference_type __op, memory_order __m) _NOEXCEPT {
   return __o->fetch_add(__op, __m);
 }
 
 // atomic_fetch_sub
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-atomic_fetch_sub(volatile atomic<_Tp>* __o, typename atomic<_Tp>::difference_type __op) _NOEXCEPT {
+_Tp atomic_fetch_sub(volatile atomic<_Tp>* __o, typename atomic<_Tp>::difference_type __op) _NOEXCEPT {
   return __o->fetch_sub(__op);
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp atomic_fetch_sub(atomic<_Tp>* __o, typename atomic<_Tp>::difference_type __op) _NOEXCEPT {
+_Tp atomic_fetch_sub(atomic<_Tp>* __o, typename atomic<_Tp>::difference_type __op) _NOEXCEPT {
   return __o->fetch_sub(__op);
 }
 
 // atomic_fetch_sub_explicit
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp atomic_fetch_sub_explicit(
+_Tp atomic_fetch_sub_explicit(
     volatile atomic<_Tp>* __o, typename atomic<_Tp>::difference_type __op, memory_order __m) _NOEXCEPT {
   return __o->fetch_sub(__op, __m);
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-atomic_fetch_sub_explicit(atomic<_Tp>* __o, typename atomic<_Tp>::difference_type __op, memory_order __m) _NOEXCEPT {
+_Tp atomic_fetch_sub_explicit(
+    atomic<_Tp>* __o, typename atomic<_Tp>::difference_type __op, memory_order __m) _NOEXCEPT {
   return __o->fetch_sub(__op, __m);
 }
 
 // atomic_fetch_and
 
 template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _Tp atomic_fetch_and(volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op) _NOEXCEPT {
+_Tp atomic_fetch_and(volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op) _NOEXCEPT {
   return __o->fetch_and(__op);
 }
 
 template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _Tp atomic_fetch_and(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op) _NOEXCEPT {
+_Tp atomic_fetch_and(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op) _NOEXCEPT {
   return __o->fetch_and(__op);
 }
 
 // atomic_fetch_and_explicit
 
 template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _Tp atomic_fetch_and_explicit(
+_Tp atomic_fetch_and_explicit(
     volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op, memory_order __m) _NOEXCEPT {
   return __o->fetch_and(__op, __m);
 }
 
 template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _Tp
-atomic_fetch_and_explicit(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op, memory_order __m) _NOEXCEPT {
+_Tp atomic_fetch_and_explicit(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op, memory_order __m) _NOEXCEPT {
   return __o->fetch_and(__op, __m);
 }
 
 // atomic_fetch_or
 
 template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _Tp atomic_fetch_or(volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op) _NOEXCEPT {
+_Tp atomic_fetch_or(volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op) _NOEXCEPT {
   return __o->fetch_or(__op);
 }
 
 template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _Tp atomic_fetch_or(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op) _NOEXCEPT {
+_Tp atomic_fetch_or(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op) _NOEXCEPT {
   return __o->fetch_or(__op);
 }
 
 // atomic_fetch_or_explicit
 
 template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _Tp
-atomic_fetch_or_explicit(volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op, memory_order __m) _NOEXCEPT {
+_Tp atomic_fetch_or_explicit(
+    volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op, memory_order __m) _NOEXCEPT {
   return __o->fetch_or(__op, __m);
 }
 
 template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _Tp
-atomic_fetch_or_explicit(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op, memory_order __m) _NOEXCEPT {
+_Tp atomic_fetch_or_explicit(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op, memory_order __m) _NOEXCEPT {
   return __o->fetch_or(__op, __m);
 }
 
 // atomic_fetch_xor
 
 template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _Tp atomic_fetch_xor(volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op) _NOEXCEPT {
+_Tp atomic_fetch_xor(volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op) _NOEXCEPT {
   return __o->fetch_xor(__op);
 }
 
 template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _Tp atomic_fetch_xor(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op) _NOEXCEPT {
+_Tp atomic_fetch_xor(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op) _NOEXCEPT {
   return __o->fetch_xor(__op);
 }
 
 // atomic_fetch_xor_explicit
 
 template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _Tp atomic_fetch_xor_explicit(
+_Tp atomic_fetch_xor_explicit(
     volatile atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op, memory_order __m) _NOEXCEPT {
   return __o->fetch_xor(__op, __m);
 }
 
 template <class _Tp, __enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _Tp
-atomic_fetch_xor_explicit(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op, memory_order __m) _NOEXCEPT {
+_Tp atomic_fetch_xor_explicit(atomic<_Tp>* __o, typename atomic<_Tp>::value_type __op, memory_order __m) _NOEXCEPT {
   return __o->fetch_xor(__op, __m);
 }
 

--- a/libcxx/include/__atomic/atomic_flag.h
+++ b/libcxx/include/__atomic/atomic_flag.h
@@ -25,46 +25,46 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 struct atomic_flag {
   __cxx_atomic_impl<_LIBCPP_ATOMIC_FLAG_TYPE> __a_;
 
-  _LIBCPP_HIDE_FROM_ABI bool test(memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT {
+  bool test(memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT {
     return _LIBCPP_ATOMIC_FLAG_TYPE(true) == __cxx_atomic_load(&__a_, __m);
   }
-  _LIBCPP_HIDE_FROM_ABI bool test(memory_order __m = memory_order_seq_cst) const _NOEXCEPT {
+  bool test(memory_order __m = memory_order_seq_cst) const _NOEXCEPT {
     return _LIBCPP_ATOMIC_FLAG_TYPE(true) == __cxx_atomic_load(&__a_, __m);
   }
 
-  _LIBCPP_HIDE_FROM_ABI bool test_and_set(memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
+  bool test_and_set(memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
     return __cxx_atomic_exchange(&__a_, _LIBCPP_ATOMIC_FLAG_TYPE(true), __m);
   }
-  _LIBCPP_HIDE_FROM_ABI bool test_and_set(memory_order __m = memory_order_seq_cst) _NOEXCEPT {
+  bool test_and_set(memory_order __m = memory_order_seq_cst) _NOEXCEPT {
     return __cxx_atomic_exchange(&__a_, _LIBCPP_ATOMIC_FLAG_TYPE(true), __m);
   }
-  _LIBCPP_HIDE_FROM_ABI void clear(memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
+  void clear(memory_order __m = memory_order_seq_cst) volatile _NOEXCEPT {
     __cxx_atomic_store(&__a_, _LIBCPP_ATOMIC_FLAG_TYPE(false), __m);
   }
-  _LIBCPP_HIDE_FROM_ABI void clear(memory_order __m = memory_order_seq_cst) _NOEXCEPT {
+  void clear(memory_order __m = memory_order_seq_cst) _NOEXCEPT {
     __cxx_atomic_store(&__a_, _LIBCPP_ATOMIC_FLAG_TYPE(false), __m);
   }
 
 #if _LIBCPP_STD_VER >= 20
-  _LIBCPP_HIDE_FROM_ABI void wait(bool __v, memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT {
+  void wait(bool __v, memory_order __m = memory_order_seq_cst) const volatile _NOEXCEPT {
     std::__atomic_wait(*this, _LIBCPP_ATOMIC_FLAG_TYPE(__v), __m);
   }
-  _LIBCPP_HIDE_FROM_ABI void wait(bool __v, memory_order __m = memory_order_seq_cst) const _NOEXCEPT {
+  void wait(bool __v, memory_order __m = memory_order_seq_cst) const _NOEXCEPT {
     std::__atomic_wait(*this, _LIBCPP_ATOMIC_FLAG_TYPE(__v), __m);
   }
-  _LIBCPP_HIDE_FROM_ABI void notify_one() volatile _NOEXCEPT { std::__atomic_notify_one(*this); }
-  _LIBCPP_HIDE_FROM_ABI void notify_one() _NOEXCEPT { std::__atomic_notify_one(*this); }
-  _LIBCPP_HIDE_FROM_ABI void notify_all() volatile _NOEXCEPT { std::__atomic_notify_all(*this); }
-  _LIBCPP_HIDE_FROM_ABI void notify_all() _NOEXCEPT { std::__atomic_notify_all(*this); }
+  void notify_one() volatile _NOEXCEPT { std::__atomic_notify_one(*this); }
+  void notify_one() _NOEXCEPT { std::__atomic_notify_one(*this); }
+  void notify_all() volatile _NOEXCEPT { std::__atomic_notify_all(*this); }
+  void notify_all() _NOEXCEPT { std::__atomic_notify_all(*this); }
 #endif
 
 #if _LIBCPP_STD_VER >= 20
-  _LIBCPP_HIDE_FROM_ABI constexpr atomic_flag() _NOEXCEPT : __a_(false) {}
+  constexpr atomic_flag() _NOEXCEPT : __a_(false) {}
 #else
   atomic_flag() _NOEXCEPT = default;
 #endif
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR atomic_flag(bool __b) _NOEXCEPT : __a_(__b) {} // EXTENSION
+  _LIBCPP_CONSTEXPR atomic_flag(bool __b) _NOEXCEPT : __a_(__b) {} // EXTENSION
 
   atomic_flag(const atomic_flag&)                     = delete;
   atomic_flag& operator=(const atomic_flag&)          = delete;
@@ -76,88 +76,72 @@ template <>
 struct __atomic_waitable_traits<atomic_flag> {
   using __value_type _LIBCPP_NODEBUG = _LIBCPP_ATOMIC_FLAG_TYPE;
 
-  static _LIBCPP_HIDE_FROM_ABI _LIBCPP_ATOMIC_FLAG_TYPE __atomic_load(const atomic_flag& __a, memory_order __order) {
+  static _LIBCPP_ATOMIC_FLAG_TYPE __atomic_load(const atomic_flag& __a, memory_order __order) {
     return std::__cxx_atomic_load(&__a.__a_, __order);
   }
 
-  static _LIBCPP_HIDE_FROM_ABI _LIBCPP_ATOMIC_FLAG_TYPE
-  __atomic_load(const volatile atomic_flag& __a, memory_order __order) {
+  static _LIBCPP_ATOMIC_FLAG_TYPE __atomic_load(const volatile atomic_flag& __a, memory_order __order) {
     return std::__cxx_atomic_load(&__a.__a_, __order);
   }
 
-  static _LIBCPP_HIDE_FROM_ABI const __cxx_atomic_impl<_LIBCPP_ATOMIC_FLAG_TYPE>*
-  __atomic_contention_address(const atomic_flag& __a) {
+  static const __cxx_atomic_impl<_LIBCPP_ATOMIC_FLAG_TYPE>* __atomic_contention_address(const atomic_flag& __a) {
     return std::addressof(__a.__a_);
   }
 
-  static _LIBCPP_HIDE_FROM_ABI const volatile __cxx_atomic_impl<_LIBCPP_ATOMIC_FLAG_TYPE>*
+  static const volatile __cxx_atomic_impl<_LIBCPP_ATOMIC_FLAG_TYPE>*
   __atomic_contention_address(const volatile atomic_flag& __a) {
     return std::addressof(__a.__a_);
   }
 };
 #endif // _LIBCPP_STD_VER >= 20
 
-inline _LIBCPP_HIDE_FROM_ABI bool atomic_flag_test(const volatile atomic_flag* __o) _NOEXCEPT { return __o->test(); }
+inline bool atomic_flag_test(const volatile atomic_flag* __o) _NOEXCEPT { return __o->test(); }
 
-inline _LIBCPP_HIDE_FROM_ABI bool atomic_flag_test(const atomic_flag* __o) _NOEXCEPT { return __o->test(); }
+inline bool atomic_flag_test(const atomic_flag* __o) _NOEXCEPT { return __o->test(); }
 
-inline _LIBCPP_HIDE_FROM_ABI bool
-atomic_flag_test_explicit(const volatile atomic_flag* __o, memory_order __m) _NOEXCEPT {
+inline bool atomic_flag_test_explicit(const volatile atomic_flag* __o, memory_order __m) _NOEXCEPT {
   return __o->test(__m);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI bool atomic_flag_test_explicit(const atomic_flag* __o, memory_order __m) _NOEXCEPT {
-  return __o->test(__m);
-}
+inline bool atomic_flag_test_explicit(const atomic_flag* __o, memory_order __m) _NOEXCEPT { return __o->test(__m); }
 
-inline _LIBCPP_HIDE_FROM_ABI bool atomic_flag_test_and_set(volatile atomic_flag* __o) _NOEXCEPT {
-  return __o->test_and_set();
-}
+inline bool atomic_flag_test_and_set(volatile atomic_flag* __o) _NOEXCEPT { return __o->test_and_set(); }
 
-inline _LIBCPP_HIDE_FROM_ABI bool atomic_flag_test_and_set(atomic_flag* __o) _NOEXCEPT { return __o->test_and_set(); }
+inline bool atomic_flag_test_and_set(atomic_flag* __o) _NOEXCEPT { return __o->test_and_set(); }
 
-inline _LIBCPP_HIDE_FROM_ABI bool
-atomic_flag_test_and_set_explicit(volatile atomic_flag* __o, memory_order __m) _NOEXCEPT {
+inline bool atomic_flag_test_and_set_explicit(volatile atomic_flag* __o, memory_order __m) _NOEXCEPT {
   return __o->test_and_set(__m);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI bool atomic_flag_test_and_set_explicit(atomic_flag* __o, memory_order __m) _NOEXCEPT {
+inline bool atomic_flag_test_and_set_explicit(atomic_flag* __o, memory_order __m) _NOEXCEPT {
   return __o->test_and_set(__m);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI void atomic_flag_clear(volatile atomic_flag* __o) _NOEXCEPT { __o->clear(); }
+inline void atomic_flag_clear(volatile atomic_flag* __o) _NOEXCEPT { __o->clear(); }
 
-inline _LIBCPP_HIDE_FROM_ABI void atomic_flag_clear(atomic_flag* __o) _NOEXCEPT { __o->clear(); }
+inline void atomic_flag_clear(atomic_flag* __o) _NOEXCEPT { __o->clear(); }
 
-inline _LIBCPP_HIDE_FROM_ABI void atomic_flag_clear_explicit(volatile atomic_flag* __o, memory_order __m) _NOEXCEPT {
-  __o->clear(__m);
-}
+inline void atomic_flag_clear_explicit(volatile atomic_flag* __o, memory_order __m) _NOEXCEPT { __o->clear(__m); }
 
-inline _LIBCPP_HIDE_FROM_ABI void atomic_flag_clear_explicit(atomic_flag* __o, memory_order __m) _NOEXCEPT {
-  __o->clear(__m);
-}
+inline void atomic_flag_clear_explicit(atomic_flag* __o, memory_order __m) _NOEXCEPT { __o->clear(__m); }
 
 #if _LIBCPP_STD_VER >= 20
-inline _LIBCPP_HIDE_FROM_ABI void atomic_flag_wait(const volatile atomic_flag* __o, bool __v) _NOEXCEPT {
-  __o->wait(__v);
-}
+inline void atomic_flag_wait(const volatile atomic_flag* __o, bool __v) _NOEXCEPT { __o->wait(__v); }
 
-inline _LIBCPP_HIDE_FROM_ABI void atomic_flag_wait(const atomic_flag* __o, bool __v) _NOEXCEPT { __o->wait(__v); }
+inline void atomic_flag_wait(const atomic_flag* __o, bool __v) _NOEXCEPT { __o->wait(__v); }
 
-inline _LIBCPP_HIDE_FROM_ABI void
-atomic_flag_wait_explicit(const volatile atomic_flag* __o, bool __v, memory_order __m) _NOEXCEPT {
+inline void atomic_flag_wait_explicit(const volatile atomic_flag* __o, bool __v, memory_order __m) _NOEXCEPT {
   __o->wait(__v, __m);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI void
-atomic_flag_wait_explicit(const atomic_flag* __o, bool __v, memory_order __m) _NOEXCEPT {
+inline void atomic_flag_wait_explicit(const atomic_flag* __o, bool __v, memory_order __m) _NOEXCEPT {
   __o->wait(__v, __m);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI void atomic_flag_notify_one(volatile atomic_flag* __o) _NOEXCEPT { __o->notify_one(); }
-inline _LIBCPP_HIDE_FROM_ABI void atomic_flag_notify_one(atomic_flag* __o) _NOEXCEPT { __o->notify_one(); }
-inline _LIBCPP_HIDE_FROM_ABI void atomic_flag_notify_all(volatile atomic_flag* __o) _NOEXCEPT { __o->notify_all(); }
-inline _LIBCPP_HIDE_FROM_ABI void atomic_flag_notify_all(atomic_flag* __o) _NOEXCEPT { __o->notify_all(); }
+inline void atomic_flag_notify_one(volatile atomic_flag* __o) _NOEXCEPT { __o->notify_one(); }
+inline void atomic_flag_notify_one(atomic_flag* __o) _NOEXCEPT { __o->notify_one(); }
+inline void atomic_flag_notify_all(volatile atomic_flag* __o) _NOEXCEPT { __o->notify_all(); }
+inline void atomic_flag_notify_all(atomic_flag* __o) _NOEXCEPT { __o->notify_all(); }
 #endif // _LIBCPP_STD_VER >= 20
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__atomic/atomic_ref.h
+++ b/libcxx/include/__atomic/atomic_ref.h
@@ -63,7 +63,7 @@ struct __get_aligner_instance {
 template <class _Tp>
 struct __atomic_ref_base {
 private:
-  _LIBCPP_HIDE_FROM_ABI static _Tp* __clear_padding(_Tp& __val) noexcept {
+  static _Tp* __clear_padding(_Tp& __val) noexcept {
     _Tp* __ptr = std::addressof(__val);
 #  if __has_builtin(__builtin_clear_padding)
     __builtin_clear_padding(__ptr);
@@ -71,7 +71,7 @@ private:
     return __ptr;
   }
 
-  _LIBCPP_HIDE_FROM_ABI static bool __compare_exchange(
+  static bool __compare_exchange(
       _Tp* __ptr, _Tp* __expected, _Tp* __desired, bool __is_weak, int __success, int __failure) noexcept {
     if constexpr (
 #  if __has_builtin(__builtin_clear_padding)
@@ -124,11 +124,9 @@ public:
   static constexpr bool is_always_lock_free =
       __atomic_always_lock_free(sizeof(_Tp), std::addressof(__get_aligner_instance<required_alignment>::__instance));
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool is_lock_free() const noexcept {
-    return __atomic_is_lock_free(sizeof(_Tp), __ptr_);
-  }
+  [[nodiscard]] bool is_lock_free() const noexcept { return __atomic_is_lock_free(sizeof(_Tp), __ptr_); }
 
-  _LIBCPP_HIDE_FROM_ABI void store(_Tp __desired, memory_order __order = memory_order::seq_cst) const noexcept
+  void store(_Tp __desired, memory_order __order = memory_order::seq_cst) const noexcept
       _LIBCPP_CHECK_STORE_MEMORY_ORDER(__order) {
     _LIBCPP_ASSERT_ARGUMENT_WITHIN_DOMAIN(
         __order == memory_order::relaxed || __order == memory_order::release || __order == memory_order::seq_cst,
@@ -136,12 +134,12 @@ public:
     __atomic_store(__ptr_, __clear_padding(__desired), std::__to_gcc_order(__order));
   }
 
-  _LIBCPP_HIDE_FROM_ABI _Tp operator=(_Tp __desired) const noexcept {
+  _Tp operator=(_Tp __desired) const noexcept {
     store(__desired);
     return __desired;
   }
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI _Tp load(memory_order __order = memory_order::seq_cst) const noexcept
+  [[nodiscard]] _Tp load(memory_order __order = memory_order::seq_cst) const noexcept
       _LIBCPP_CHECK_LOAD_MEMORY_ORDER(__order) {
     _LIBCPP_ASSERT_ARGUMENT_WITHIN_DOMAIN(
         __order == memory_order::relaxed || __order == memory_order::consume || __order == memory_order::acquire ||
@@ -153,16 +151,16 @@ public:
     return *__ret;
   }
 
-  _LIBCPP_HIDE_FROM_ABI operator _Tp() const noexcept { return load(); }
+  operator _Tp() const noexcept { return load(); }
 
-  _LIBCPP_HIDE_FROM_ABI _Tp exchange(_Tp __desired, memory_order __order = memory_order::seq_cst) const noexcept {
+  _Tp exchange(_Tp __desired, memory_order __order = memory_order::seq_cst) const noexcept {
     alignas(_Tp) byte __mem[sizeof(_Tp)];
     auto* __ret = reinterpret_cast<_Tp*>(__mem);
     __atomic_exchange(__ptr_, __clear_padding(__desired), __ret, std::__to_gcc_order(__order));
     return *__ret;
   }
 
-  _LIBCPP_HIDE_FROM_ABI bool
+  bool
   compare_exchange_weak(_Tp& __expected, _Tp __desired, memory_order __success, memory_order __failure) const noexcept
       _LIBCPP_CHECK_EXCHANGE_MEMORY_ORDER(__success, __failure) {
     _LIBCPP_ASSERT_ARGUMENT_WITHIN_DOMAIN(
@@ -177,7 +175,7 @@ public:
         std::__to_gcc_order(__success),
         std::__to_gcc_order(__failure));
   }
-  _LIBCPP_HIDE_FROM_ABI bool
+  bool
   compare_exchange_strong(_Tp& __expected, _Tp __desired, memory_order __success, memory_order __failure) const noexcept
       _LIBCPP_CHECK_EXCHANGE_MEMORY_ORDER(__success, __failure) {
     _LIBCPP_ASSERT_ARGUMENT_WITHIN_DOMAIN(
@@ -193,7 +191,7 @@ public:
         std::__to_gcc_order(__failure));
   }
 
-  _LIBCPP_HIDE_FROM_ABI bool
+  bool
   compare_exchange_weak(_Tp& __expected, _Tp __desired, memory_order __order = memory_order::seq_cst) const noexcept {
     return __compare_exchange(
         __ptr_,
@@ -203,7 +201,7 @@ public:
         std::__to_gcc_order(__order),
         std::__to_gcc_failure_order(__order));
   }
-  _LIBCPP_HIDE_FROM_ABI bool
+  bool
   compare_exchange_strong(_Tp& __expected, _Tp __desired, memory_order __order = memory_order::seq_cst) const noexcept {
     return __compare_exchange(
         __ptr_,
@@ -214,7 +212,7 @@ public:
         std::__to_gcc_failure_order(__order));
   }
 
-  _LIBCPP_HIDE_FROM_ABI void wait(_Tp __old, memory_order __order = memory_order::seq_cst) const noexcept
+  void wait(_Tp __old, memory_order __order = memory_order::seq_cst) const noexcept
       _LIBCPP_CHECK_WAIT_MEMORY_ORDER(__order) {
     _LIBCPP_ASSERT_ARGUMENT_WITHIN_DOMAIN(
         __order == memory_order::relaxed || __order == memory_order::consume || __order == memory_order::acquire ||
@@ -222,29 +220,25 @@ public:
         "atomic_ref: memory order argument to atomic wait operation is invalid");
     std::__atomic_wait(*this, __old, __order);
   }
-  _LIBCPP_HIDE_FROM_ABI void notify_one() const noexcept { std::__atomic_notify_one(*this); }
-  _LIBCPP_HIDE_FROM_ABI void notify_all() const noexcept { std::__atomic_notify_all(*this); }
+  void notify_one() const noexcept { std::__atomic_notify_one(*this); }
+  void notify_all() const noexcept { std::__atomic_notify_all(*this); }
 #  if _LIBCPP_STD_VER >= 26
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr __copy_cv_t<_Tp, void>* address() const noexcept { return __ptr_; }
+  [[nodiscard]] constexpr __copy_cv_t<_Tp, void>* address() const noexcept { return __ptr_; }
 #  endif
 
 protected:
   using _Aligned_Tp [[__gnu__::__aligned__(required_alignment), __gnu__::__nodebug__]] = _Tp;
   _Aligned_Tp* __ptr_;
 
-  _LIBCPP_HIDE_FROM_ABI __atomic_ref_base(_Tp& __obj) : __ptr_(std::addressof(__obj)) {}
+  __atomic_ref_base(_Tp& __obj) : __ptr_(std::addressof(__obj)) {}
 };
 
 template <class _Tp>
 struct __atomic_waitable_traits<__atomic_ref_base<_Tp>> {
   using __value_type _LIBCPP_NODEBUG = _Tp;
 
-  static _LIBCPP_HIDE_FROM_ABI _Tp __atomic_load(const __atomic_ref_base<_Tp>& __a, memory_order __order) {
-    return __a.load(__order);
-  }
-  static _LIBCPP_HIDE_FROM_ABI const _Tp* __atomic_contention_address(const __atomic_ref_base<_Tp>& __a) {
-    return __a.__ptr_;
-  }
+  static _Tp __atomic_load(const __atomic_ref_base<_Tp>& __a, memory_order __order) { return __a.load(__order); }
+  static const _Tp* __atomic_contention_address(const __atomic_ref_base<_Tp>& __a) { return __a.__ptr_; }
 };
 
 template <class _Tp>
@@ -253,15 +247,15 @@ struct atomic_ref : public __atomic_ref_base<_Tp> {
 
   using __base _LIBCPP_NODEBUG = __atomic_ref_base<_Tp>;
 
-  _LIBCPP_HIDE_FROM_ABI explicit atomic_ref(_Tp& __obj) : __base(__obj) {
+  explicit atomic_ref(_Tp& __obj) : __base(__obj) {
     _LIBCPP_ASSERT_ARGUMENT_WITHIN_DOMAIN(
         std::__is_sufficiently_aligned<__base::required_alignment>(std::addressof(__obj)),
         "atomic_ref ctor: referenced object must be aligned to required_alignment");
   }
 
-  _LIBCPP_HIDE_FROM_ABI atomic_ref(const atomic_ref&) noexcept = default;
+  atomic_ref(const atomic_ref&) noexcept = default;
 
-  _LIBCPP_HIDE_FROM_ABI _Tp operator=(_Tp __desired) const noexcept { return __base::operator=(__desired); }
+  _Tp operator=(_Tp __desired) const noexcept { return __base::operator=(__desired); }
 
   atomic_ref& operator=(const atomic_ref&) = delete;
 };
@@ -273,43 +267,43 @@ struct atomic_ref<_Tp> : public __atomic_ref_base<_Tp> {
 
   using difference_type = __base::value_type;
 
-  _LIBCPP_HIDE_FROM_ABI explicit atomic_ref(_Tp& __obj) : __base(__obj) {
+  explicit atomic_ref(_Tp& __obj) : __base(__obj) {
     _LIBCPP_ASSERT_ARGUMENT_WITHIN_DOMAIN(
         std::__is_sufficiently_aligned<__base::required_alignment>(std::addressof(__obj)),
         "atomic_ref ctor: referenced object must be aligned to required_alignment");
   }
 
-  _LIBCPP_HIDE_FROM_ABI atomic_ref(const atomic_ref&) noexcept = default;
+  atomic_ref(const atomic_ref&) noexcept = default;
 
-  _LIBCPP_HIDE_FROM_ABI _Tp operator=(_Tp __desired) const noexcept { return __base::operator=(__desired); }
+  _Tp operator=(_Tp __desired) const noexcept { return __base::operator=(__desired); }
 
   atomic_ref& operator=(const atomic_ref&) = delete;
 
-  _LIBCPP_HIDE_FROM_ABI _Tp fetch_add(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+  _Tp fetch_add(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
     return __atomic_fetch_add(this->__ptr_, __arg, std::__to_gcc_order(__order));
   }
-  _LIBCPP_HIDE_FROM_ABI _Tp fetch_sub(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+  _Tp fetch_sub(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
     return __atomic_fetch_sub(this->__ptr_, __arg, std::__to_gcc_order(__order));
   }
-  _LIBCPP_HIDE_FROM_ABI _Tp fetch_and(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+  _Tp fetch_and(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
     return __atomic_fetch_and(this->__ptr_, __arg, std::__to_gcc_order(__order));
   }
-  _LIBCPP_HIDE_FROM_ABI _Tp fetch_or(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+  _Tp fetch_or(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
     return __atomic_fetch_or(this->__ptr_, __arg, std::__to_gcc_order(__order));
   }
-  _LIBCPP_HIDE_FROM_ABI _Tp fetch_xor(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+  _Tp fetch_xor(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
     return __atomic_fetch_xor(this->__ptr_, __arg, std::__to_gcc_order(__order));
   }
 
-  _LIBCPP_HIDE_FROM_ABI _Tp operator++(int) const noexcept { return fetch_add(_Tp(1)); }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator--(int) const noexcept { return fetch_sub(_Tp(1)); }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator++() const noexcept { return fetch_add(_Tp(1)) + _Tp(1); }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator--() const noexcept { return fetch_sub(_Tp(1)) - _Tp(1); }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator+=(_Tp __arg) const noexcept { return fetch_add(__arg) + __arg; }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator-=(_Tp __arg) const noexcept { return fetch_sub(__arg) - __arg; }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator&=(_Tp __arg) const noexcept { return fetch_and(__arg) & __arg; }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator|=(_Tp __arg) const noexcept { return fetch_or(__arg) | __arg; }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator^=(_Tp __arg) const noexcept { return fetch_xor(__arg) ^ __arg; }
+  _Tp operator++(int) const noexcept { return fetch_add(_Tp(1)); }
+  _Tp operator--(int) const noexcept { return fetch_sub(_Tp(1)); }
+  _Tp operator++() const noexcept { return fetch_add(_Tp(1)) + _Tp(1); }
+  _Tp operator--() const noexcept { return fetch_sub(_Tp(1)) - _Tp(1); }
+  _Tp operator+=(_Tp __arg) const noexcept { return fetch_add(__arg) + __arg; }
+  _Tp operator-=(_Tp __arg) const noexcept { return fetch_sub(__arg) - __arg; }
+  _Tp operator&=(_Tp __arg) const noexcept { return fetch_and(__arg) & __arg; }
+  _Tp operator|=(_Tp __arg) const noexcept { return fetch_or(__arg) | __arg; }
+  _Tp operator^=(_Tp __arg) const noexcept { return fetch_xor(__arg) ^ __arg; }
 };
 
 template <class _Tp>
@@ -319,19 +313,19 @@ struct atomic_ref<_Tp> : public __atomic_ref_base<_Tp> {
 
   using difference_type = __base::value_type;
 
-  _LIBCPP_HIDE_FROM_ABI explicit atomic_ref(_Tp& __obj) : __base(__obj) {
+  explicit atomic_ref(_Tp& __obj) : __base(__obj) {
     _LIBCPP_ASSERT_ARGUMENT_WITHIN_DOMAIN(
         std::__is_sufficiently_aligned<__base::required_alignment>(std::addressof(__obj)),
         "atomic_ref ctor: referenced object must be aligned to required_alignment");
   }
 
-  _LIBCPP_HIDE_FROM_ABI atomic_ref(const atomic_ref&) noexcept = default;
+  atomic_ref(const atomic_ref&) noexcept = default;
 
-  _LIBCPP_HIDE_FROM_ABI _Tp operator=(_Tp __desired) const noexcept { return __base::operator=(__desired); }
+  _Tp operator=(_Tp __desired) const noexcept { return __base::operator=(__desired); }
 
   atomic_ref& operator=(const atomic_ref&) = delete;
 
-  _LIBCPP_HIDE_FROM_ABI _Tp fetch_add(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+  _Tp fetch_add(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
     if constexpr (std::__has_rmw_builtin<_Tp>()) {
       return __atomic_fetch_add(this->__ptr_, __arg, std::__to_gcc_order(__order));
     } else {
@@ -343,7 +337,7 @@ struct atomic_ref<_Tp> : public __atomic_ref_base<_Tp> {
       return __old;
     }
   }
-  _LIBCPP_HIDE_FROM_ABI _Tp fetch_sub(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+  _Tp fetch_sub(_Tp __arg, memory_order __order = memory_order_seq_cst) const noexcept {
     if constexpr (std::__has_rmw_builtin<_Tp>()) {
       return __atomic_fetch_sub(this->__ptr_, __arg, std::__to_gcc_order(__order));
     } else {
@@ -356,8 +350,8 @@ struct atomic_ref<_Tp> : public __atomic_ref_base<_Tp> {
     }
   }
 
-  _LIBCPP_HIDE_FROM_ABI _Tp operator+=(_Tp __arg) const noexcept { return fetch_add(__arg) + __arg; }
-  _LIBCPP_HIDE_FROM_ABI _Tp operator-=(_Tp __arg) const noexcept { return fetch_sub(__arg) - __arg; }
+  _Tp operator+=(_Tp __arg) const noexcept { return fetch_add(__arg) + __arg; }
+  _Tp operator-=(_Tp __arg) const noexcept { return fetch_sub(__arg) - __arg; }
 };
 
 template <class _Tp>
@@ -366,25 +360,25 @@ struct atomic_ref<_Tp*> : public __atomic_ref_base<_Tp*> {
 
   using difference_type = ptrdiff_t;
 
-  _LIBCPP_HIDE_FROM_ABI explicit atomic_ref(_Tp*& __ptr) : __base(__ptr) {}
+  explicit atomic_ref(_Tp*& __ptr) : __base(__ptr) {}
 
-  _LIBCPP_HIDE_FROM_ABI _Tp* operator=(_Tp* __desired) const noexcept { return __base::operator=(__desired); }
+  _Tp* operator=(_Tp* __desired) const noexcept { return __base::operator=(__desired); }
 
   atomic_ref& operator=(const atomic_ref&) = delete;
 
-  _LIBCPP_HIDE_FROM_ABI _Tp* fetch_add(ptrdiff_t __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+  _Tp* fetch_add(ptrdiff_t __arg, memory_order __order = memory_order_seq_cst) const noexcept {
     return __atomic_fetch_add(this->__ptr_, __arg * sizeof(_Tp), std::__to_gcc_order(__order));
   }
-  _LIBCPP_HIDE_FROM_ABI _Tp* fetch_sub(ptrdiff_t __arg, memory_order __order = memory_order_seq_cst) const noexcept {
+  _Tp* fetch_sub(ptrdiff_t __arg, memory_order __order = memory_order_seq_cst) const noexcept {
     return __atomic_fetch_sub(this->__ptr_, __arg * sizeof(_Tp), std::__to_gcc_order(__order));
   }
 
-  _LIBCPP_HIDE_FROM_ABI _Tp* operator++(int) const noexcept { return fetch_add(1); }
-  _LIBCPP_HIDE_FROM_ABI _Tp* operator--(int) const noexcept { return fetch_sub(1); }
-  _LIBCPP_HIDE_FROM_ABI _Tp* operator++() const noexcept { return fetch_add(1) + 1; }
-  _LIBCPP_HIDE_FROM_ABI _Tp* operator--() const noexcept { return fetch_sub(1) - 1; }
-  _LIBCPP_HIDE_FROM_ABI _Tp* operator+=(ptrdiff_t __arg) const noexcept { return fetch_add(__arg) + __arg; }
-  _LIBCPP_HIDE_FROM_ABI _Tp* operator-=(ptrdiff_t __arg) const noexcept { return fetch_sub(__arg) - __arg; }
+  _Tp* operator++(int) const noexcept { return fetch_add(1); }
+  _Tp* operator--(int) const noexcept { return fetch_sub(1); }
+  _Tp* operator++() const noexcept { return fetch_add(1) + 1; }
+  _Tp* operator--() const noexcept { return fetch_sub(1) - 1; }
+  _Tp* operator+=(ptrdiff_t __arg) const noexcept { return fetch_add(__arg) + __arg; }
+  _Tp* operator-=(ptrdiff_t __arg) const noexcept { return fetch_sub(__arg) - __arg; }
 };
 
 _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(atomic_ref);

--- a/libcxx/include/__atomic/atomic_sync.h
+++ b/libcxx/include/__atomic/atomic_sync.h
@@ -88,7 +88,7 @@ struct __atomic_wait_backoff_impl {
   using __waitable_traits _LIBCPP_NODEBUG = __atomic_waitable_traits<__decay_t<_AtomicWaitable> >;
   using __value_type _LIBCPP_NODEBUG      = typename __waitable_traits::__value_type;
 
-  _LIBCPP_HIDE_FROM_ABI __backoff_results operator()(chrono::nanoseconds __elapsed) const {
+  __backoff_results operator()(chrono::nanoseconds __elapsed) const {
     if (__elapsed > chrono::microseconds(4)) {
       auto __contention_address = const_cast<const void*>(
           static_cast<const volatile void*>(__waitable_traits::__atomic_contention_address(__a_)));
@@ -121,7 +121,7 @@ struct __atomic_wait_backoff_impl {
 
   using __waitable_traits _LIBCPP_NODEBUG = __atomic_waitable_traits<__decay_t<_AtomicWaitable> >;
 
-  _LIBCPP_HIDE_FROM_ABI bool
+  bool
   __update_monitor_val_and_poll(__cxx_atomic_contention_t const volatile*, __cxx_contention_t& __monitor_val) const {
     // In case the contention type happens to be __cxx_atomic_contention_t, i.e. __cxx_atomic_impl<int64_t>,
     // the platform wait is directly monitoring the atomic value itself.
@@ -133,7 +133,7 @@ struct __atomic_wait_backoff_impl {
     return __poll_(__monitor_val);
   }
 
-  _LIBCPP_HIDE_FROM_ABI bool
+  bool
   __update_monitor_val_and_poll(void const volatile* __contention_address, __cxx_contention_t& __monitor_val) const {
     // In case the contention type is anything else, platform wait is monitoring a __cxx_atomic_contention_t
     // from the global pool, the monitor comes from __libcpp_atomic_monitor
@@ -142,7 +142,7 @@ struct __atomic_wait_backoff_impl {
     return __poll_(__current_val);
   }
 
-  _LIBCPP_HIDE_FROM_ABI __backoff_results operator()(chrono::nanoseconds __elapsed) const {
+  __backoff_results operator()(chrono::nanoseconds __elapsed) const {
     if (__elapsed > chrono::microseconds(4)) {
       auto __contention_address = __waitable_traits::__atomic_contention_address(__a_);
       __cxx_contention_t __monitor_val;
@@ -166,7 +166,7 @@ struct __atomic_wait_backoff_impl {
 // `false`, it must set the argument to its current understanding of the atomic
 // value. The predicate function must not return `false` spuriously.
 template <class _AtomicWaitable, class _Poll>
-_LIBCPP_HIDE_FROM_ABI void __atomic_wait_unless(const _AtomicWaitable& __a, memory_order __order, _Poll&& __poll) {
+void __atomic_wait_unless(const _AtomicWaitable& __a, memory_order __order, _Poll&& __poll) {
   static_assert(__atomic_waitable<_AtomicWaitable>);
   __atomic_wait_backoff_impl<_AtomicWaitable, __decay_t<_Poll> > __backoff_fn = {__a, __poll, __order};
   std::__libcpp_thread_poll_with_backoff(
@@ -181,7 +181,7 @@ _LIBCPP_HIDE_FROM_ABI void __atomic_wait_unless(const _AtomicWaitable& __a, memo
 #    if _LIBCPP_AVAILABILITY_HAS_NEW_SYNC
 
 template <class _AtomicWaitable>
-_LIBCPP_HIDE_FROM_ABI void __atomic_notify_one(const _AtomicWaitable& __a) {
+void __atomic_notify_one(const _AtomicWaitable& __a) {
   static_assert(__atomic_waitable<_AtomicWaitable>);
   using __value_type _LIBCPP_NODEBUG = typename __atomic_waitable_traits<__decay_t<_AtomicWaitable> >::__value_type;
   using __waitable_traits _LIBCPP_NODEBUG = __atomic_waitable_traits<__decay_t<_AtomicWaitable> >;
@@ -195,7 +195,7 @@ _LIBCPP_HIDE_FROM_ABI void __atomic_notify_one(const _AtomicWaitable& __a) {
 }
 
 template <class _AtomicWaitable>
-_LIBCPP_HIDE_FROM_ABI void __atomic_notify_all(const _AtomicWaitable& __a) {
+void __atomic_notify_all(const _AtomicWaitable& __a) {
   static_assert(__atomic_waitable<_AtomicWaitable>);
   using __value_type _LIBCPP_NODEBUG = typename __atomic_waitable_traits<__decay_t<_AtomicWaitable> >::__value_type;
   using __waitable_traits _LIBCPP_NODEBUG = __atomic_waitable_traits<__decay_t<_AtomicWaitable> >;
@@ -211,13 +211,13 @@ _LIBCPP_HIDE_FROM_ABI void __atomic_notify_all(const _AtomicWaitable& __a) {
 #    else // _LIBCPP_AVAILABILITY_HAS_NEW_SYNC
 
 template <class _AtomicWaitable>
-_LIBCPP_HIDE_FROM_ABI void __atomic_notify_one(const _AtomicWaitable& __a) {
+void __atomic_notify_one(const _AtomicWaitable& __a) {
   static_assert(__atomic_waitable<_AtomicWaitable>);
   std::__cxx_atomic_notify_one(__atomic_waitable_traits<__decay_t<_AtomicWaitable> >::__atomic_contention_address(__a));
 }
 
 template <class _AtomicWaitable>
-_LIBCPP_HIDE_FROM_ABI void __atomic_notify_all(const _AtomicWaitable& __a) {
+void __atomic_notify_all(const _AtomicWaitable& __a) {
   static_assert(__atomic_waitable<_AtomicWaitable>);
   std::__cxx_atomic_notify_all(__atomic_waitable_traits<__decay_t<_AtomicWaitable> >::__atomic_contention_address(__a));
 }
@@ -227,7 +227,7 @@ _LIBCPP_HIDE_FROM_ABI void __atomic_notify_all(const _AtomicWaitable& __a) {
 #  else // _LIBCPP_HAS_THREADS
 
 template <class _AtomicWaitable, class _Poll>
-_LIBCPP_HIDE_FROM_ABI void __atomic_wait_unless(const _AtomicWaitable& __a, memory_order __order, _Poll&& __poll) {
+void __atomic_wait_unless(const _AtomicWaitable& __a, memory_order __order, _Poll&& __poll) {
   std::__libcpp_thread_poll_with_backoff(
       /* poll */
       [&]() {
@@ -238,20 +238,20 @@ _LIBCPP_HIDE_FROM_ABI void __atomic_wait_unless(const _AtomicWaitable& __a, memo
 }
 
 template <class _AtomicWaitable>
-_LIBCPP_HIDE_FROM_ABI void __atomic_notify_one(const _AtomicWaitable&) {}
+void __atomic_notify_one(const _AtomicWaitable&) {}
 
 template <class _AtomicWaitable>
-_LIBCPP_HIDE_FROM_ABI void __atomic_notify_all(const _AtomicWaitable&) {}
+void __atomic_notify_all(const _AtomicWaitable&) {}
 
 #  endif // _LIBCPP_HAS_THREADS
 
 template <typename _Tp>
-_LIBCPP_HIDE_FROM_ABI bool __cxx_nonatomic_compare_equal(_Tp const& __lhs, _Tp const& __rhs) {
+bool __cxx_nonatomic_compare_equal(_Tp const& __lhs, _Tp const& __rhs) {
   return std::memcmp(std::addressof(__lhs), std::addressof(__rhs), sizeof(_Tp)) == 0;
 }
 
 template <class _AtomicWaitable, class _Tp>
-_LIBCPP_HIDE_FROM_ABI void __atomic_wait(_AtomicWaitable& __a, _Tp __val, memory_order __order) {
+void __atomic_wait(_AtomicWaitable& __a, _Tp __val, memory_order __order) {
   static_assert(__atomic_waitable<_AtomicWaitable>);
   std::__atomic_wait_unless(__a, __order, [&](_Tp const& __current) {
     return !std::__cxx_nonatomic_compare_equal(__current, __val);

--- a/libcxx/include/__atomic/atomic_sync_timed.h
+++ b/libcxx/include/__atomic/atomic_sync_timed.h
@@ -54,7 +54,7 @@ struct __atomic_wait_timed_backoff_impl {
   using __waitable_traits _LIBCPP_NODEBUG = __atomic_waitable_traits<__decay_t<_AtomicWaitable> >;
   using __value_type _LIBCPP_NODEBUG      = typename __waitable_traits::__value_type;
 
-  _LIBCPP_HIDE_FROM_ABI __backoff_results operator()(chrono::nanoseconds __elapsed) const {
+  __backoff_results operator()(chrono::nanoseconds __elapsed) const {
     if (__elapsed > chrono::microseconds(4)) {
       auto __contention_address = const_cast<const void*>(
           static_cast<const volatile void*>(__waitable_traits::__atomic_contention_address(__a_)));
@@ -90,7 +90,7 @@ struct __atomic_wait_timed_backoff_impl {
 // `false`, it must set the argument to its current understanding of the atomic
 // value. The predicate function must not return `false` spuriously.
 template <class _AtomicWaitable, class _Poll, class _Rep, class _Period>
-_LIBCPP_HIDE_FROM_ABI bool __atomic_wait_unless_with_timeout(
+bool __atomic_wait_unless_with_timeout(
     const _AtomicWaitable& __a,
     memory_order __order,
     _Poll&& __poll,
@@ -113,7 +113,7 @@ _LIBCPP_HIDE_FROM_ABI bool __atomic_wait_unless_with_timeout(
 #  elif _LIBCPP_HAS_THREADS // _LIBCPP_HAS_THREADS && _LIBCPP_AVAILABILITY_HAS_NEW_SYNC
 
 template <class _AtomicWaitable, class _Poll, class _Rep, class _Period>
-_LIBCPP_HIDE_FROM_ABI bool __atomic_wait_unless_with_timeout(
+bool __atomic_wait_unless_with_timeout(
     const _AtomicWaitable& __a,
     memory_order __order,
     _Poll&& __poll,

--- a/libcxx/include/__atomic/atomic_waitable_traits.h
+++ b/libcxx/include/__atomic/atomic_waitable_traits.h
@@ -68,7 +68,7 @@ concept __atomic_waitable = requires(const _Tp __t, memory_order __order) {
 #  if defined(_LIBCPP_ABI_ATOMIC_WAIT_NATIVE_BY_SIZE)
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI constexpr bool __has_native_atomic_wait_impl() {
+constexpr bool __has_native_atomic_wait_impl() {
   if (alignof(_Tp) % sizeof(_Tp) != 0)
     return false;
   switch (sizeof(_Tp)) {

--- a/libcxx/include/__atomic/fence.h
+++ b/libcxx/include/__atomic/fence.h
@@ -19,9 +19,9 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-inline _LIBCPP_HIDE_FROM_ABI void atomic_thread_fence(memory_order __m) _NOEXCEPT { __cxx_atomic_thread_fence(__m); }
+inline void atomic_thread_fence(memory_order __m) _NOEXCEPT { __cxx_atomic_thread_fence(__m); }
 
-inline _LIBCPP_HIDE_FROM_ABI void atomic_signal_fence(memory_order __m) _NOEXCEPT { __cxx_atomic_signal_fence(__m); }
+inline void atomic_signal_fence(memory_order __m) _NOEXCEPT { __cxx_atomic_signal_fence(__m); }
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__atomic/floating_point_helper.h
+++ b/libcxx/include/__atomic/floating_point_helper.h
@@ -22,13 +22,13 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 20
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI constexpr bool __is_fp80_long_double() {
+constexpr bool __is_fp80_long_double() {
   // Only x87-fp80 long double has 64-bit mantissa
   return __LDBL_MANT_DIG__ == 64 && std::is_same_v<_Tp, long double>;
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI constexpr bool __has_rmw_builtin() {
+constexpr bool __has_rmw_builtin() {
   static_assert(std::is_floating_point_v<_Tp>);
 #  ifndef _LIBCPP_COMPILER_CLANG_BASED
   return false;

--- a/libcxx/include/__atomic/kill_dependency.h
+++ b/libcxx/include/__atomic/kill_dependency.h
@@ -18,7 +18,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp kill_dependency(_Tp __y) _NOEXCEPT {
+_Tp kill_dependency(_Tp __y) _NOEXCEPT {
   return __y;
 }
 

--- a/libcxx/include/__atomic/support.h
+++ b/libcxx/include/__atomic/support.h
@@ -112,8 +112,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <typename _Tp, typename _Base = __cxx_atomic_base_impl<_Tp> >
 struct __cxx_atomic_impl : public _Base {
-  _LIBCPP_HIDE_FROM_ABI __cxx_atomic_impl() _NOEXCEPT = default;
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR explicit __cxx_atomic_impl(_Tp __value) _NOEXCEPT : _Base(__value) {}
+  __cxx_atomic_impl() _NOEXCEPT = default;
+  _LIBCPP_CONSTEXPR explicit __cxx_atomic_impl(_Tp __value) _NOEXCEPT : _Base(__value) {}
 };
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__atomic/support/c11.h
+++ b/libcxx/include/__atomic/support/c11.h
@@ -27,12 +27,10 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <typename _Tp>
 struct __cxx_atomic_base_impl {
-  _LIBCPP_HIDE_FROM_ABI
 #ifndef _LIBCPP_CXX03_LANG
   __cxx_atomic_base_impl() _NOEXCEPT = default;
 #else
-  __cxx_atomic_base_impl() _NOEXCEPT : __a_value() {
-  }
+  __cxx_atomic_base_impl() _NOEXCEPT : __a_value() {}
 #endif // _LIBCPP_CXX03_LANG
   _LIBCPP_CONSTEXPR explicit __cxx_atomic_base_impl(_Tp __value) _NOEXCEPT : __a_value(__value) {}
   _Atomic(_Tp) __a_value;
@@ -40,77 +38,71 @@ struct __cxx_atomic_base_impl {
 
 #define __cxx_atomic_is_lock_free(__s) __c11_atomic_is_lock_free(__s)
 
-_LIBCPP_HIDE_FROM_ABI inline void __cxx_atomic_thread_fence(memory_order __order) _NOEXCEPT {
+inline void __cxx_atomic_thread_fence(memory_order __order) _NOEXCEPT {
   __c11_atomic_thread_fence(static_cast<__memory_order_underlying_t>(__order));
 }
 
-_LIBCPP_HIDE_FROM_ABI inline void __cxx_atomic_signal_fence(memory_order __order) _NOEXCEPT {
+inline void __cxx_atomic_signal_fence(memory_order __order) _NOEXCEPT {
   __c11_atomic_signal_fence(static_cast<__memory_order_underlying_t>(__order));
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI void __cxx_atomic_init(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __val) _NOEXCEPT {
+void __cxx_atomic_init(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __val) _NOEXCEPT {
   __c11_atomic_init(std::addressof(__a->__a_value), __val);
 }
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI void __cxx_atomic_init(__cxx_atomic_base_impl<_Tp>* __a, _Tp __val) _NOEXCEPT {
+void __cxx_atomic_init(__cxx_atomic_base_impl<_Tp>* __a, _Tp __val) _NOEXCEPT {
   __c11_atomic_init(std::addressof(__a->__a_value), __val);
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI void
-__cxx_atomic_store(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __val, memory_order __order) _NOEXCEPT {
+void __cxx_atomic_store(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __val, memory_order __order) _NOEXCEPT {
   __c11_atomic_store(std::addressof(__a->__a_value), __val, static_cast<__memory_order_underlying_t>(__order));
 }
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI void
-__cxx_atomic_store(__cxx_atomic_base_impl<_Tp>* __a, _Tp __val, memory_order __order) _NOEXCEPT {
+void __cxx_atomic_store(__cxx_atomic_base_impl<_Tp>* __a, _Tp __val, memory_order __order) _NOEXCEPT {
   __c11_atomic_store(std::addressof(__a->__a_value), __val, static_cast<__memory_order_underlying_t>(__order));
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-__cxx_atomic_load(__cxx_atomic_base_impl<_Tp> const volatile* __a, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_load(__cxx_atomic_base_impl<_Tp> const volatile* __a, memory_order __order) _NOEXCEPT {
   using __ptr_type = __remove_const_t<decltype(__a->__a_value)>*;
   return __c11_atomic_load(
       const_cast<__ptr_type>(std::addressof(__a->__a_value)), static_cast<__memory_order_underlying_t>(__order));
 }
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp __cxx_atomic_load(__cxx_atomic_base_impl<_Tp> const* __a, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_load(__cxx_atomic_base_impl<_Tp> const* __a, memory_order __order) _NOEXCEPT {
   using __ptr_type = __remove_const_t<decltype(__a->__a_value)>*;
   return __c11_atomic_load(
       const_cast<__ptr_type>(std::addressof(__a->__a_value)), static_cast<__memory_order_underlying_t>(__order));
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI void
-__cxx_atomic_load_inplace(__cxx_atomic_base_impl<_Tp> const volatile* __a, _Tp* __dst, memory_order __order) _NOEXCEPT {
+void __cxx_atomic_load_inplace(
+    __cxx_atomic_base_impl<_Tp> const volatile* __a, _Tp* __dst, memory_order __order) _NOEXCEPT {
   using __ptr_type = __remove_const_t<decltype(__a->__a_value)>*;
   *__dst           = __c11_atomic_load(
       const_cast<__ptr_type>(std::addressof(__a->__a_value)), static_cast<__memory_order_underlying_t>(__order));
 }
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI void
-__cxx_atomic_load_inplace(__cxx_atomic_base_impl<_Tp> const* __a, _Tp* __dst, memory_order __order) _NOEXCEPT {
+void __cxx_atomic_load_inplace(__cxx_atomic_base_impl<_Tp> const* __a, _Tp* __dst, memory_order __order) _NOEXCEPT {
   using __ptr_type = __remove_const_t<decltype(__a->__a_value)>*;
   *__dst           = __c11_atomic_load(
       const_cast<__ptr_type>(std::addressof(__a->__a_value)), static_cast<__memory_order_underlying_t>(__order));
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-__cxx_atomic_exchange(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __value, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_exchange(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __value, memory_order __order) _NOEXCEPT {
   return __c11_atomic_exchange(
       std::addressof(__a->__a_value), __value, static_cast<__memory_order_underlying_t>(__order));
 }
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-__cxx_atomic_exchange(__cxx_atomic_base_impl<_Tp>* __a, _Tp __value, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_exchange(__cxx_atomic_base_impl<_Tp>* __a, _Tp __value, memory_order __order) _NOEXCEPT {
   return __c11_atomic_exchange(
       std::addressof(__a->__a_value), __value, static_cast<__memory_order_underlying_t>(__order));
 }
 
-_LIBCPP_HIDE_FROM_ABI inline _LIBCPP_CONSTEXPR memory_order __to_failure_order(memory_order __order) {
+inline _LIBCPP_CONSTEXPR memory_order __to_failure_order(memory_order __order) {
   // Avoid switch statement to make this a constexpr.
   return __order == memory_order_release
            ? memory_order_relaxed
@@ -118,7 +110,7 @@ _LIBCPP_HIDE_FROM_ABI inline _LIBCPP_CONSTEXPR memory_order __to_failure_order(m
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI bool __cxx_atomic_compare_exchange_strong(
+bool __cxx_atomic_compare_exchange_strong(
     __cxx_atomic_base_impl<_Tp> volatile* __a,
     _Tp* __expected,
     _Tp __value,
@@ -132,7 +124,7 @@ _LIBCPP_HIDE_FROM_ABI bool __cxx_atomic_compare_exchange_strong(
       static_cast<__memory_order_underlying_t>(__to_failure_order(__failure)));
 }
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI bool __cxx_atomic_compare_exchange_strong(
+bool __cxx_atomic_compare_exchange_strong(
     __cxx_atomic_base_impl<_Tp>* __a, _Tp* __expected, _Tp __value, memory_order __success, memory_order __failure)
     _NOEXCEPT {
   return __c11_atomic_compare_exchange_strong(
@@ -144,7 +136,7 @@ _LIBCPP_HIDE_FROM_ABI bool __cxx_atomic_compare_exchange_strong(
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI bool __cxx_atomic_compare_exchange_weak(
+bool __cxx_atomic_compare_exchange_weak(
     __cxx_atomic_base_impl<_Tp> volatile* __a,
     _Tp* __expected,
     _Tp __value,
@@ -158,7 +150,7 @@ _LIBCPP_HIDE_FROM_ABI bool __cxx_atomic_compare_exchange_weak(
       static_cast<__memory_order_underlying_t>(__to_failure_order(__failure)));
 }
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI bool __cxx_atomic_compare_exchange_weak(
+bool __cxx_atomic_compare_exchange_weak(
     __cxx_atomic_base_impl<_Tp>* __a, _Tp* __expected, _Tp __value, memory_order __success, memory_order __failure)
     _NOEXCEPT {
   return __c11_atomic_compare_exchange_weak(
@@ -170,91 +162,79 @@ _LIBCPP_HIDE_FROM_ABI bool __cxx_atomic_compare_exchange_weak(
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-__cxx_atomic_fetch_add(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __delta, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_fetch_add(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __delta, memory_order __order) _NOEXCEPT {
   return __c11_atomic_fetch_add(
       std::addressof(__a->__a_value), __delta, static_cast<__memory_order_underlying_t>(__order));
 }
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-__cxx_atomic_fetch_add(__cxx_atomic_base_impl<_Tp>* __a, _Tp __delta, memory_order __order) _NOEXCEPT {
-  return __c11_atomic_fetch_add(
-      std::addressof(__a->__a_value), __delta, static_cast<__memory_order_underlying_t>(__order));
-}
-
-template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp*
-__cxx_atomic_fetch_add(__cxx_atomic_base_impl<_Tp*> volatile* __a, ptrdiff_t __delta, memory_order __order) _NOEXCEPT {
-  return __c11_atomic_fetch_add(
-      std::addressof(__a->__a_value), __delta, static_cast<__memory_order_underlying_t>(__order));
-}
-template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp*
-__cxx_atomic_fetch_add(__cxx_atomic_base_impl<_Tp*>* __a, ptrdiff_t __delta, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_fetch_add(__cxx_atomic_base_impl<_Tp>* __a, _Tp __delta, memory_order __order) _NOEXCEPT {
   return __c11_atomic_fetch_add(
       std::addressof(__a->__a_value), __delta, static_cast<__memory_order_underlying_t>(__order));
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-__cxx_atomic_fetch_sub(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __delta, memory_order __order) _NOEXCEPT {
+_Tp* __cxx_atomic_fetch_add(
+    __cxx_atomic_base_impl<_Tp*> volatile* __a, ptrdiff_t __delta, memory_order __order) _NOEXCEPT {
+  return __c11_atomic_fetch_add(
+      std::addressof(__a->__a_value), __delta, static_cast<__memory_order_underlying_t>(__order));
+}
+template <class _Tp>
+_Tp* __cxx_atomic_fetch_add(__cxx_atomic_base_impl<_Tp*>* __a, ptrdiff_t __delta, memory_order __order) _NOEXCEPT {
+  return __c11_atomic_fetch_add(
+      std::addressof(__a->__a_value), __delta, static_cast<__memory_order_underlying_t>(__order));
+}
+
+template <class _Tp>
+_Tp __cxx_atomic_fetch_sub(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __delta, memory_order __order) _NOEXCEPT {
   return __c11_atomic_fetch_sub(
       std::addressof(__a->__a_value), __delta, static_cast<__memory_order_underlying_t>(__order));
 }
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-__cxx_atomic_fetch_sub(__cxx_atomic_base_impl<_Tp>* __a, _Tp __delta, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_fetch_sub(__cxx_atomic_base_impl<_Tp>* __a, _Tp __delta, memory_order __order) _NOEXCEPT {
   return __c11_atomic_fetch_sub(
       std::addressof(__a->__a_value), __delta, static_cast<__memory_order_underlying_t>(__order));
 }
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp*
-__cxx_atomic_fetch_sub(__cxx_atomic_base_impl<_Tp*> volatile* __a, ptrdiff_t __delta, memory_order __order) _NOEXCEPT {
+_Tp* __cxx_atomic_fetch_sub(
+    __cxx_atomic_base_impl<_Tp*> volatile* __a, ptrdiff_t __delta, memory_order __order) _NOEXCEPT {
   return __c11_atomic_fetch_sub(
       std::addressof(__a->__a_value), __delta, static_cast<__memory_order_underlying_t>(__order));
 }
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp*
-__cxx_atomic_fetch_sub(__cxx_atomic_base_impl<_Tp*>* __a, ptrdiff_t __delta, memory_order __order) _NOEXCEPT {
+_Tp* __cxx_atomic_fetch_sub(__cxx_atomic_base_impl<_Tp*>* __a, ptrdiff_t __delta, memory_order __order) _NOEXCEPT {
   return __c11_atomic_fetch_sub(
       std::addressof(__a->__a_value), __delta, static_cast<__memory_order_underlying_t>(__order));
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-__cxx_atomic_fetch_and(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __pattern, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_fetch_and(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __pattern, memory_order __order) _NOEXCEPT {
   return __c11_atomic_fetch_and(
       std::addressof(__a->__a_value), __pattern, static_cast<__memory_order_underlying_t>(__order));
 }
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-__cxx_atomic_fetch_and(__cxx_atomic_base_impl<_Tp>* __a, _Tp __pattern, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_fetch_and(__cxx_atomic_base_impl<_Tp>* __a, _Tp __pattern, memory_order __order) _NOEXCEPT {
   return __c11_atomic_fetch_and(
       std::addressof(__a->__a_value), __pattern, static_cast<__memory_order_underlying_t>(__order));
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-__cxx_atomic_fetch_or(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __pattern, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_fetch_or(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __pattern, memory_order __order) _NOEXCEPT {
   return __c11_atomic_fetch_or(
       std::addressof(__a->__a_value), __pattern, static_cast<__memory_order_underlying_t>(__order));
 }
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-__cxx_atomic_fetch_or(__cxx_atomic_base_impl<_Tp>* __a, _Tp __pattern, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_fetch_or(__cxx_atomic_base_impl<_Tp>* __a, _Tp __pattern, memory_order __order) _NOEXCEPT {
   return __c11_atomic_fetch_or(
       std::addressof(__a->__a_value), __pattern, static_cast<__memory_order_underlying_t>(__order));
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-__cxx_atomic_fetch_xor(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __pattern, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_fetch_xor(__cxx_atomic_base_impl<_Tp> volatile* __a, _Tp __pattern, memory_order __order) _NOEXCEPT {
   return __c11_atomic_fetch_xor(
       std::addressof(__a->__a_value), __pattern, static_cast<__memory_order_underlying_t>(__order));
 }
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-__cxx_atomic_fetch_xor(__cxx_atomic_base_impl<_Tp>* __a, _Tp __pattern, memory_order __order) _NOEXCEPT {
+_Tp __cxx_atomic_fetch_xor(__cxx_atomic_base_impl<_Tp>* __a, _Tp __pattern, memory_order __order) _NOEXCEPT {
   return __c11_atomic_fetch_xor(
       std::addressof(__a->__a_value), __pattern, static_cast<__memory_order_underlying_t>(__order));
 }

--- a/libcxx/include/__atomic/support/gcc.h
+++ b/libcxx/include/__atomic/support/gcc.h
@@ -31,11 +31,11 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // the default operator= in an object is not volatile, a byte-by-byte copy
 // is required.
 template <typename _Tp, typename _Tv, __enable_if_t<is_assignable<_Tp&, _Tv>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI void __cxx_atomic_assign_volatile(_Tp& __a_value, _Tv const& __val) {
+void __cxx_atomic_assign_volatile(_Tp& __a_value, _Tv const& __val) {
   __a_value = __val;
 }
 template <typename _Tp, typename _Tv, __enable_if_t<is_assignable<_Tp&, _Tv>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI void __cxx_atomic_assign_volatile(_Tp volatile& __a_value, _Tv volatile const& __val) {
+void __cxx_atomic_assign_volatile(_Tp volatile& __a_value, _Tv volatile const& __val) {
   volatile char* __to         = reinterpret_cast<volatile char*>(std::addressof(__a_value));
   volatile char* __end        = __to + sizeof(_Tp);
   volatile const char* __from = reinterpret_cast<volatile const char*>(std::addressof(__val));
@@ -45,75 +45,65 @@ _LIBCPP_HIDE_FROM_ABI void __cxx_atomic_assign_volatile(_Tp volatile& __a_value,
 
 template <typename _Tp>
 struct __cxx_atomic_base_impl {
-  _LIBCPP_HIDE_FROM_ABI
 #ifndef _LIBCPP_CXX03_LANG
   __cxx_atomic_base_impl() _NOEXCEPT = default;
 #else
-  __cxx_atomic_base_impl() _NOEXCEPT : __a_value() {
-  }
+  __cxx_atomic_base_impl() _NOEXCEPT : __a_value() {}
 #endif // _LIBCPP_CXX03_LANG
   _LIBCPP_CONSTEXPR explicit __cxx_atomic_base_impl(_Tp value) _NOEXCEPT : __a_value(value) {}
   _Tp __a_value;
 };
 
 template <typename _Tp>
-_LIBCPP_HIDE_FROM_ABI void __cxx_atomic_init(volatile __cxx_atomic_base_impl<_Tp>* __a, _Tp __val) {
+void __cxx_atomic_init(volatile __cxx_atomic_base_impl<_Tp>* __a, _Tp __val) {
   __cxx_atomic_assign_volatile(__a->__a_value, __val);
 }
 
 template <typename _Tp>
-_LIBCPP_HIDE_FROM_ABI void __cxx_atomic_init(__cxx_atomic_base_impl<_Tp>* __a, _Tp __val) {
+void __cxx_atomic_init(__cxx_atomic_base_impl<_Tp>* __a, _Tp __val) {
   __a->__a_value = __val;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline void __cxx_atomic_thread_fence(memory_order __order) {
-  __atomic_thread_fence(__to_gcc_order(__order));
-}
+inline void __cxx_atomic_thread_fence(memory_order __order) { __atomic_thread_fence(__to_gcc_order(__order)); }
 
-_LIBCPP_HIDE_FROM_ABI inline void __cxx_atomic_signal_fence(memory_order __order) {
-  __atomic_signal_fence(__to_gcc_order(__order));
-}
+inline void __cxx_atomic_signal_fence(memory_order __order) { __atomic_signal_fence(__to_gcc_order(__order)); }
 
 template <typename _Tp>
-_LIBCPP_HIDE_FROM_ABI void
-__cxx_atomic_store(volatile __cxx_atomic_base_impl<_Tp>* __a, _Tp __val, memory_order __order) {
+void __cxx_atomic_store(volatile __cxx_atomic_base_impl<_Tp>* __a, _Tp __val, memory_order __order) {
   __atomic_store(std::addressof(__a->__a_value), std::addressof(__val), __to_gcc_order(__order));
 }
 
 template <typename _Tp>
-_LIBCPP_HIDE_FROM_ABI void __cxx_atomic_store(__cxx_atomic_base_impl<_Tp>* __a, _Tp __val, memory_order __order) {
+void __cxx_atomic_store(__cxx_atomic_base_impl<_Tp>* __a, _Tp __val, memory_order __order) {
   __atomic_store(std::addressof(__a->__a_value), std::addressof(__val), __to_gcc_order(__order));
 }
 
 template <typename _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp __cxx_atomic_load(const volatile __cxx_atomic_base_impl<_Tp>* __a, memory_order __order) {
+_Tp __cxx_atomic_load(const volatile __cxx_atomic_base_impl<_Tp>* __a, memory_order __order) {
   _Tp __ret;
   __atomic_load(std::addressof(__a->__a_value), std::addressof(__ret), __to_gcc_order(__order));
   return __ret;
 }
 
 template <typename _Tp>
-_LIBCPP_HIDE_FROM_ABI void
-__cxx_atomic_load_inplace(const volatile __cxx_atomic_base_impl<_Tp>* __a, _Tp* __dst, memory_order __order) {
+void __cxx_atomic_load_inplace(const volatile __cxx_atomic_base_impl<_Tp>* __a, _Tp* __dst, memory_order __order) {
   __atomic_load(std::addressof(__a->__a_value), __dst, __to_gcc_order(__order));
 }
 
 template <typename _Tp>
-_LIBCPP_HIDE_FROM_ABI void
-__cxx_atomic_load_inplace(const __cxx_atomic_base_impl<_Tp>* __a, _Tp* __dst, memory_order __order) {
+void __cxx_atomic_load_inplace(const __cxx_atomic_base_impl<_Tp>* __a, _Tp* __dst, memory_order __order) {
   __atomic_load(std::addressof(__a->__a_value), __dst, __to_gcc_order(__order));
 }
 
 template <typename _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp __cxx_atomic_load(const __cxx_atomic_base_impl<_Tp>* __a, memory_order __order) {
+_Tp __cxx_atomic_load(const __cxx_atomic_base_impl<_Tp>* __a, memory_order __order) {
   _Tp __ret;
   __atomic_load(std::addressof(__a->__a_value), std::addressof(__ret), __to_gcc_order(__order));
   return __ret;
 }
 
 template <typename _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-__cxx_atomic_exchange(volatile __cxx_atomic_base_impl<_Tp>* __a, _Tp __value, memory_order __order) {
+_Tp __cxx_atomic_exchange(volatile __cxx_atomic_base_impl<_Tp>* __a, _Tp __value, memory_order __order) {
   _Tp __ret;
   __atomic_exchange(
       std::addressof(__a->__a_value), std::addressof(__value), std::addressof(__ret), __to_gcc_order(__order));
@@ -121,7 +111,7 @@ __cxx_atomic_exchange(volatile __cxx_atomic_base_impl<_Tp>* __a, _Tp __value, me
 }
 
 template <typename _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp __cxx_atomic_exchange(__cxx_atomic_base_impl<_Tp>* __a, _Tp __value, memory_order __order) {
+_Tp __cxx_atomic_exchange(__cxx_atomic_base_impl<_Tp>* __a, _Tp __value, memory_order __order) {
   _Tp __ret;
   __atomic_exchange(
       std::addressof(__a->__a_value), std::addressof(__value), std::addressof(__ret), __to_gcc_order(__order));
@@ -129,7 +119,7 @@ _LIBCPP_HIDE_FROM_ABI _Tp __cxx_atomic_exchange(__cxx_atomic_base_impl<_Tp>* __a
 }
 
 template <typename _Tp>
-_LIBCPP_HIDE_FROM_ABI bool __cxx_atomic_compare_exchange_strong(
+bool __cxx_atomic_compare_exchange_strong(
     volatile __cxx_atomic_base_impl<_Tp>* __a,
     _Tp* __expected,
     _Tp __value,
@@ -145,7 +135,7 @@ _LIBCPP_HIDE_FROM_ABI bool __cxx_atomic_compare_exchange_strong(
 }
 
 template <typename _Tp>
-_LIBCPP_HIDE_FROM_ABI bool __cxx_atomic_compare_exchange_strong(
+bool __cxx_atomic_compare_exchange_strong(
     __cxx_atomic_base_impl<_Tp>* __a, _Tp* __expected, _Tp __value, memory_order __success, memory_order __failure) {
   return __atomic_compare_exchange(
       std::addressof(__a->__a_value),
@@ -157,7 +147,7 @@ _LIBCPP_HIDE_FROM_ABI bool __cxx_atomic_compare_exchange_strong(
 }
 
 template <typename _Tp>
-_LIBCPP_HIDE_FROM_ABI bool __cxx_atomic_compare_exchange_weak(
+bool __cxx_atomic_compare_exchange_weak(
     volatile __cxx_atomic_base_impl<_Tp>* __a,
     _Tp* __expected,
     _Tp __value,
@@ -173,7 +163,7 @@ _LIBCPP_HIDE_FROM_ABI bool __cxx_atomic_compare_exchange_weak(
 }
 
 template <typename _Tp>
-_LIBCPP_HIDE_FROM_ABI bool __cxx_atomic_compare_exchange_weak(
+bool __cxx_atomic_compare_exchange_weak(
     __cxx_atomic_base_impl<_Tp>* __a, _Tp* __expected, _Tp __value, memory_order __success, memory_order __failure) {
   return __atomic_compare_exchange(
       std::addressof(__a->__a_value),
@@ -202,59 +192,52 @@ template <typename _Tp, int n>
 struct __skip_amt<_Tp[n]> {};
 
 template <typename _Tp, typename _Td>
-_LIBCPP_HIDE_FROM_ABI _Tp
-__cxx_atomic_fetch_add(volatile __cxx_atomic_base_impl<_Tp>* __a, _Td __delta, memory_order __order) {
+_Tp __cxx_atomic_fetch_add(volatile __cxx_atomic_base_impl<_Tp>* __a, _Td __delta, memory_order __order) {
   return __atomic_fetch_add(std::addressof(__a->__a_value), __delta * __skip_amt<_Tp>::value, __to_gcc_order(__order));
 }
 
 template <typename _Tp, typename _Td>
-_LIBCPP_HIDE_FROM_ABI _Tp __cxx_atomic_fetch_add(__cxx_atomic_base_impl<_Tp>* __a, _Td __delta, memory_order __order) {
+_Tp __cxx_atomic_fetch_add(__cxx_atomic_base_impl<_Tp>* __a, _Td __delta, memory_order __order) {
   return __atomic_fetch_add(std::addressof(__a->__a_value), __delta * __skip_amt<_Tp>::value, __to_gcc_order(__order));
 }
 
 template <typename _Tp, typename _Td>
-_LIBCPP_HIDE_FROM_ABI _Tp
-__cxx_atomic_fetch_sub(volatile __cxx_atomic_base_impl<_Tp>* __a, _Td __delta, memory_order __order) {
+_Tp __cxx_atomic_fetch_sub(volatile __cxx_atomic_base_impl<_Tp>* __a, _Td __delta, memory_order __order) {
   return __atomic_fetch_sub(std::addressof(__a->__a_value), __delta * __skip_amt<_Tp>::value, __to_gcc_order(__order));
 }
 
 template <typename _Tp, typename _Td>
-_LIBCPP_HIDE_FROM_ABI _Tp __cxx_atomic_fetch_sub(__cxx_atomic_base_impl<_Tp>* __a, _Td __delta, memory_order __order) {
+_Tp __cxx_atomic_fetch_sub(__cxx_atomic_base_impl<_Tp>* __a, _Td __delta, memory_order __order) {
   return __atomic_fetch_sub(std::addressof(__a->__a_value), __delta * __skip_amt<_Tp>::value, __to_gcc_order(__order));
 }
 
 template <typename _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-__cxx_atomic_fetch_and(volatile __cxx_atomic_base_impl<_Tp>* __a, _Tp __pattern, memory_order __order) {
+_Tp __cxx_atomic_fetch_and(volatile __cxx_atomic_base_impl<_Tp>* __a, _Tp __pattern, memory_order __order) {
   return __atomic_fetch_and(std::addressof(__a->__a_value), __pattern, __to_gcc_order(__order));
 }
 
 template <typename _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-__cxx_atomic_fetch_and(__cxx_atomic_base_impl<_Tp>* __a, _Tp __pattern, memory_order __order) {
+_Tp __cxx_atomic_fetch_and(__cxx_atomic_base_impl<_Tp>* __a, _Tp __pattern, memory_order __order) {
   return __atomic_fetch_and(std::addressof(__a->__a_value), __pattern, __to_gcc_order(__order));
 }
 
 template <typename _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-__cxx_atomic_fetch_or(volatile __cxx_atomic_base_impl<_Tp>* __a, _Tp __pattern, memory_order __order) {
+_Tp __cxx_atomic_fetch_or(volatile __cxx_atomic_base_impl<_Tp>* __a, _Tp __pattern, memory_order __order) {
   return __atomic_fetch_or(std::addressof(__a->__a_value), __pattern, __to_gcc_order(__order));
 }
 
 template <typename _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp __cxx_atomic_fetch_or(__cxx_atomic_base_impl<_Tp>* __a, _Tp __pattern, memory_order __order) {
+_Tp __cxx_atomic_fetch_or(__cxx_atomic_base_impl<_Tp>* __a, _Tp __pattern, memory_order __order) {
   return __atomic_fetch_or(std::addressof(__a->__a_value), __pattern, __to_gcc_order(__order));
 }
 
 template <typename _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-__cxx_atomic_fetch_xor(volatile __cxx_atomic_base_impl<_Tp>* __a, _Tp __pattern, memory_order __order) {
+_Tp __cxx_atomic_fetch_xor(volatile __cxx_atomic_base_impl<_Tp>* __a, _Tp __pattern, memory_order __order) {
   return __atomic_fetch_xor(std::addressof(__a->__a_value), __pattern, __to_gcc_order(__order));
 }
 
 template <typename _Tp>
-_LIBCPP_HIDE_FROM_ABI _Tp
-__cxx_atomic_fetch_xor(__cxx_atomic_base_impl<_Tp>* __a, _Tp __pattern, memory_order __order) {
+_Tp __cxx_atomic_fetch_xor(__cxx_atomic_base_impl<_Tp>* __a, _Tp __pattern, memory_order __order) {
   return __atomic_fetch_xor(std::addressof(__a->__a_value), __pattern, __to_gcc_order(__order));
 }
 

--- a/libcxx/include/__atomic/to_gcc_order.h
+++ b/libcxx/include/__atomic/to_gcc_order.h
@@ -21,7 +21,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if defined(__ATOMIC_RELAXED) && defined(__ATOMIC_CONSUME) && defined(__ATOMIC_ACQUIRE) &&                             \
     defined(__ATOMIC_RELEASE) && defined(__ATOMIC_ACQ_REL) && defined(__ATOMIC_SEQ_CST)
 
-_LIBCPP_HIDE_FROM_ABI inline _LIBCPP_CONSTEXPR int __to_gcc_order(memory_order __order) {
+inline _LIBCPP_CONSTEXPR int __to_gcc_order(memory_order __order) {
   // Avoid switch statement to make this a constexpr.
   return __order == memory_order_relaxed
            ? __ATOMIC_RELAXED
@@ -34,7 +34,7 @@ _LIBCPP_HIDE_FROM_ABI inline _LIBCPP_CONSTEXPR int __to_gcc_order(memory_order _
                                 : (__order == memory_order_acq_rel ? __ATOMIC_ACQ_REL : __ATOMIC_CONSUME))));
 }
 
-_LIBCPP_HIDE_FROM_ABI inline _LIBCPP_CONSTEXPR int __to_gcc_failure_order(memory_order __order) {
+inline _LIBCPP_CONSTEXPR int __to_gcc_failure_order(memory_order __order) {
   // Avoid switch statement to make this a constexpr.
   return __order == memory_order_relaxed
            ? __ATOMIC_RELAXED

--- a/libcxx/include/__bit/bit_cast.h
+++ b/libcxx/include/__bit/bit_cast.h
@@ -22,7 +22,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #ifndef _LIBCPP_CXX03_LANG
 
 template <class _ToType, class _FromType>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI constexpr _ToType __bit_cast(const _FromType& __from) noexcept {
+[[__nodiscard__]] constexpr _ToType __bit_cast(const _FromType& __from) noexcept {
   return __builtin_bit_cast(_ToType, __from);
 }
 
@@ -33,7 +33,7 @@ template <class _ToType, class _FromType>
 template <class _ToType, class _FromType>
   requires(sizeof(_ToType) == sizeof(_FromType) && is_trivially_copyable_v<_ToType> &&
            is_trivially_copyable_v<_FromType>)
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _ToType bit_cast(const _FromType& __from) noexcept {
+[[nodiscard]] constexpr _ToType bit_cast(const _FromType& __from) noexcept {
   return __builtin_bit_cast(_ToType, __from);
 }
 

--- a/libcxx/include/__bit/bit_ceil.h
+++ b/libcxx/include/__bit/bit_ceil.h
@@ -24,7 +24,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 17
 
 template <class _Tp>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Tp __bit_ceil(_Tp __t) noexcept {
+[[nodiscard]] constexpr _Tp __bit_ceil(_Tp __t) noexcept {
   if (__t < 2)
     return 1;
   const unsigned __n = numeric_limits<_Tp>::digits - std::__countl_zero((_Tp)(__t - 1u));
@@ -42,7 +42,7 @@ template <class _Tp>
 #  if _LIBCPP_STD_VER >= 20
 
 template <__unsigned_integer _Tp>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Tp bit_ceil(_Tp __t) noexcept {
+[[nodiscard]] constexpr _Tp bit_ceil(_Tp __t) noexcept {
   return std::__bit_ceil(__t);
 }
 

--- a/libcxx/include/__bit/bit_floor.h
+++ b/libcxx/include/__bit/bit_floor.h
@@ -22,7 +22,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 20
 
 template <__unsigned_integer _Tp>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Tp bit_floor(_Tp __t) noexcept {
+[[nodiscard]] constexpr _Tp bit_floor(_Tp __t) noexcept {
   return __t == 0 ? 0 : _Tp{1} << std::__bit_log2(__t);
 }
 

--- a/libcxx/include/__bit/bit_log2.h
+++ b/libcxx/include/__bit/bit_log2.h
@@ -22,7 +22,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp __bit_log2(_Tp __t) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp __bit_log2(_Tp __t) _NOEXCEPT {
   static_assert(__is_unsigned_integer_v<_Tp>, "__bit_log2 requires an unsigned integer type");
   _LIBCPP_ASSERT_INTERNAL(__t != 0, "logarithm of 0 is undefined");
   return numeric_limits<_Tp>::digits - 1 - std::__countl_zero(__t);

--- a/libcxx/include/__bit/bit_width.h
+++ b/libcxx/include/__bit/bit_width.h
@@ -22,7 +22,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <__unsigned_integer _Tp>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr int bit_width(_Tp __t) noexcept {
+[[nodiscard]] constexpr int bit_width(_Tp __t) noexcept {
   return __t == 0 ? 0 : std::__bit_log2(__t) + 1;
 }
 

--- a/libcxx/include/__bit/blsr.h
+++ b/libcxx/include/__bit/blsr.h
@@ -17,15 +17,11 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR unsigned __libcpp_blsr(unsigned __x) _NOEXCEPT {
-  return __x ^ (__x & -__x);
-}
+inline _LIBCPP_CONSTEXPR unsigned __libcpp_blsr(unsigned __x) _NOEXCEPT { return __x ^ (__x & -__x); }
 
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR unsigned long __libcpp_blsr(unsigned long __x) _NOEXCEPT {
-  return __x ^ (__x & -__x);
-}
+inline _LIBCPP_CONSTEXPR unsigned long __libcpp_blsr(unsigned long __x) _NOEXCEPT { return __x ^ (__x & -__x); }
 
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR unsigned long long __libcpp_blsr(unsigned long long __x) _NOEXCEPT {
+inline _LIBCPP_CONSTEXPR unsigned long long __libcpp_blsr(unsigned long long __x) _NOEXCEPT {
   return __x ^ (__x & -__x);
 }
 

--- a/libcxx/include/__bit/byteswap.h
+++ b/libcxx/include/__bit/byteswap.h
@@ -27,7 +27,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 23
 
 template <integral _Tp>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Tp byteswap(_Tp __val) noexcept {
+[[nodiscard]] constexpr _Tp byteswap(_Tp __val) noexcept {
   // [bit.byteswap]/Mandates: T does not have padding bits.
   // bool is grandfathered: every shipping implementation admits it and the
   // size-1 identity path can't shuffle padding bits into value positions.

--- a/libcxx/include/__bit/countl.h
+++ b/libcxx/include/__bit/countl.h
@@ -23,19 +23,19 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 int __countl_zero(_Tp __t) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 int __countl_zero(_Tp __t) _NOEXCEPT {
   return __builtin_clzg(__t, numeric_limits<_Tp>::digits);
 }
 
 #if _LIBCPP_STD_VER >= 20
 
 template <__unsigned_integer _Tp>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr int countl_zero(_Tp __t) noexcept {
+[[nodiscard]] constexpr int countl_zero(_Tp __t) noexcept {
   return std::__countl_zero(__t);
 }
 
 template <__unsigned_integer _Tp>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr int countl_one(_Tp __t) noexcept {
+[[nodiscard]] constexpr int countl_one(_Tp __t) noexcept {
   return std::countl_zero(static_cast<_Tp>(~__t));
 }
 

--- a/libcxx/include/__bit/countr.h
+++ b/libcxx/include/__bit/countr.h
@@ -23,19 +23,19 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR int __countr_zero(_Tp __t) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_CONSTEXPR int __countr_zero(_Tp __t) _NOEXCEPT {
   return __builtin_ctzg(__t, numeric_limits<_Tp>::digits);
 }
 
 #if _LIBCPP_STD_VER >= 20
 
 template <__unsigned_integer _Tp>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr int countr_zero(_Tp __t) noexcept {
+[[nodiscard]] constexpr int countr_zero(_Tp __t) noexcept {
   return std::__countr_zero(__t);
 }
 
 template <__unsigned_integer _Tp>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr int countr_one(_Tp __t) noexcept {
+[[nodiscard]] constexpr int countr_one(_Tp __t) noexcept {
   return std::countr_zero(static_cast<_Tp>(~__t));
 }
 

--- a/libcxx/include/__bit/has_single_bit.h
+++ b/libcxx/include/__bit/has_single_bit.h
@@ -24,7 +24,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <__unsigned_integer _Tp>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool has_single_bit(_Tp __t) noexcept {
+[[nodiscard]] constexpr bool has_single_bit(_Tp __t) noexcept {
   return __builtin_popcountg(__t) == 1;
 }
 

--- a/libcxx/include/__bit/invert_if.h
+++ b/libcxx/include/__bit/invert_if.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <bool _Invert, class _Tp>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp __invert_if(_Tp __v) {
+_LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp __invert_if(_Tp __v) {
   if (_Invert)
     return ~__v;
   return __v;

--- a/libcxx/include/__bit/popcount.h
+++ b/libcxx/include/__bit/popcount.h
@@ -22,14 +22,14 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR int __popcount(_Tp __t) _NOEXCEPT {
+[[__nodiscard__]] _LIBCPP_CONSTEXPR int __popcount(_Tp __t) _NOEXCEPT {
   return __builtin_popcountg(__t);
 }
 
 #if _LIBCPP_STD_VER >= 20
 
 template <__unsigned_integer _Tp>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr int popcount(_Tp __t) noexcept {
+[[nodiscard]] constexpr int popcount(_Tp __t) noexcept {
   return std::__popcount(__t);
 }
 

--- a/libcxx/include/__bit/rotate.h
+++ b/libcxx/include/__bit/rotate.h
@@ -26,7 +26,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 20
 
 template <__unsigned_integer _Tp>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Tp rotl(_Tp __t, int __cnt) noexcept {
+[[nodiscard]] constexpr _Tp rotl(_Tp __t, int __cnt) noexcept {
   const int __n = numeric_limits<_Tp>::digits;
   int __r       = __cnt % __n;
 
@@ -40,7 +40,7 @@ template <__unsigned_integer _Tp>
 }
 
 template <__unsigned_integer _Tp>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Tp rotr(_Tp __t, int __cnt) noexcept {
+[[nodiscard]] constexpr _Tp rotr(_Tp __t, int __cnt) noexcept {
   const int __n = numeric_limits<_Tp>::digits;
   int __r       = __cnt % __n;
 

--- a/libcxx/include/__charconv/chars_format.h
+++ b/libcxx/include/__charconv/chars_format.h
@@ -23,33 +23,31 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 enum class chars_format { scientific = 0x1, fixed = 0x2, hex = 0x4, general = fixed | scientific };
 
-inline _LIBCPP_HIDE_FROM_ABI constexpr chars_format operator~(chars_format __x) {
-  return chars_format(~std::__to_underlying(__x));
-}
+inline constexpr chars_format operator~(chars_format __x) { return chars_format(~std::__to_underlying(__x)); }
 
-inline _LIBCPP_HIDE_FROM_ABI constexpr chars_format operator&(chars_format __x, chars_format __y) {
+inline constexpr chars_format operator&(chars_format __x, chars_format __y) {
   return chars_format(std::__to_underlying(__x) & std::__to_underlying(__y));
 }
 
-inline _LIBCPP_HIDE_FROM_ABI constexpr chars_format operator|(chars_format __x, chars_format __y) {
+inline constexpr chars_format operator|(chars_format __x, chars_format __y) {
   return chars_format(std::__to_underlying(__x) | std::__to_underlying(__y));
 }
 
-inline _LIBCPP_HIDE_FROM_ABI constexpr chars_format operator^(chars_format __x, chars_format __y) {
+inline constexpr chars_format operator^(chars_format __x, chars_format __y) {
   return chars_format(std::__to_underlying(__x) ^ std::__to_underlying(__y));
 }
 
-inline _LIBCPP_HIDE_FROM_ABI constexpr chars_format& operator&=(chars_format& __x, chars_format __y) {
+inline constexpr chars_format& operator&=(chars_format& __x, chars_format __y) {
   __x = __x & __y;
   return __x;
 }
 
-inline _LIBCPP_HIDE_FROM_ABI constexpr chars_format& operator|=(chars_format& __x, chars_format __y) {
+inline constexpr chars_format& operator|=(chars_format& __x, chars_format __y) {
   __x = __x | __y;
   return __x;
 }
 
-inline _LIBCPP_HIDE_FROM_ABI constexpr chars_format& operator^=(chars_format& __x, chars_format __y) {
+inline constexpr chars_format& operator^=(chars_format& __x, chars_format __y) {
   __x = __x ^ __y;
   return __x;
 }

--- a/libcxx/include/__charconv/from_chars_floating_point.h
+++ b/libcxx/include/__charconv/from_chars_floating_point.h
@@ -48,20 +48,19 @@ extern template __from_chars_result<double> __from_chars_floating_point(
 _LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS
 
 template <class _Fp>
-_LIBCPP_HIDE_FROM_ABI from_chars_result
-__from_chars(const char* __first, const char* __last, _Fp& __value, chars_format __fmt) {
+from_chars_result __from_chars(const char* __first, const char* __last, _Fp& __value, chars_format __fmt) {
   __from_chars_result<_Fp> __r = std::__from_chars_floating_point<_Fp>(__first, __last, __fmt);
   if (__r.__ec != errc::invalid_argument)
     __value = __r.__value;
   return {__first + __r.__n, __r.__ec};
 }
 
-_LIBCPP_AVAILABILITY_FROM_CHARS_FLOATING_POINT _LIBCPP_HIDE_FROM_ABI inline from_chars_result
+_LIBCPP_AVAILABILITY_FROM_CHARS_FLOATING_POINT inline from_chars_result
 from_chars(const char* __first, const char* __last, float& __value, chars_format __fmt = chars_format::general) {
   return std::__from_chars<float>(__first, __last, __value, __fmt);
 }
 
-_LIBCPP_AVAILABILITY_FROM_CHARS_FLOATING_POINT _LIBCPP_HIDE_FROM_ABI inline from_chars_result
+_LIBCPP_AVAILABILITY_FROM_CHARS_FLOATING_POINT inline from_chars_result
 from_chars(const char* __first, const char* __last, double& __value, chars_format __fmt = chars_format::general) {
   return std::__from_chars<double>(__first, __last, __value, __fmt);
 }

--- a/libcxx/include/__charconv/from_chars_integral.h
+++ b/libcxx/include/__charconv/from_chars_integral.h
@@ -36,7 +36,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 from_chars_result from_chars(const char*, const char*, bool, int = 10) = delete;
 
 template <typename _It, typename _Tp, typename _Fn, typename... _Ts>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI from_chars_result
+inline _LIBCPP_CONSTEXPR_SINCE_CXX23 from_chars_result
 __sign_combinator(_It __first, _It __last, _Tp& __value, _Fn __f, _Ts... __args) {
   using __tl = numeric_limits<_Tp>;
   decltype(std::__to_unsigned_like(__value)) __x;
@@ -68,7 +68,7 @@ __sign_combinator(_It __first, _It __last, _Tp& __value, _Fn __f, _Ts... __args)
 }
 
 template <typename _Tp>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool __in_pattern(_Tp __c) {
+inline _LIBCPP_CONSTEXPR_SINCE_CXX23 bool __in_pattern(_Tp __c) {
   return '0' <= __c && __c <= '9';
 }
 
@@ -76,11 +76,11 @@ struct _LIBCPP_HIDDEN __in_pattern_result {
   bool __ok;
   int __val;
 
-  explicit _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI operator bool() const { return __ok; }
+  explicit _LIBCPP_CONSTEXPR_SINCE_CXX23 operator bool() const { return __ok; }
 };
 
 template <typename _Tp>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI __in_pattern_result __in_pattern(_Tp __c, int __base) {
+inline _LIBCPP_CONSTEXPR_SINCE_CXX23 __in_pattern_result __in_pattern(_Tp __c, int __base) {
   if (__base <= 10)
     return {'0' <= __c && __c < '0' + __base, __c - '0'};
   else if (std::__in_pattern(__c))
@@ -92,7 +92,7 @@ inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI __in_pattern_result _
 }
 
 template <typename _It, typename _Tp, typename _Fn, typename... _Ts>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI from_chars_result
+inline _LIBCPP_CONSTEXPR_SINCE_CXX23 from_chars_result
 __subject_seq_combinator(_It __first, _It __last, _Tp& __value, _Fn __f, _Ts... __args) {
   auto __find_non_zero = [](_It __firstit, _It __lastit) {
     for (; __firstit != __lastit; ++__firstit)
@@ -123,7 +123,7 @@ __subject_seq_combinator(_It __first, _It __last, _Tp& __value, _Fn __f, _Ts... 
 }
 
 template <typename _Tp, __enable_if_t<is_unsigned<_Tp>::value, int> = 0>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI from_chars_result
+inline _LIBCPP_CONSTEXPR_SINCE_CXX23 from_chars_result
 __from_chars_atoi(const char* __first, const char* __last, _Tp& __value) {
   using __tx          = __itoa::__traits<_Tp>;
   using __output_type = typename __tx::type;
@@ -144,7 +144,7 @@ __from_chars_atoi(const char* __first, const char* __last, _Tp& __value) {
 }
 
 template <typename _Tp, __enable_if_t<is_signed<_Tp>::value, int> = 0>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI from_chars_result
+inline _LIBCPP_CONSTEXPR_SINCE_CXX23 from_chars_result
 __from_chars_atoi(const char* __first, const char* __last, _Tp& __value) {
   using __t = decltype(std::__to_unsigned_like(__value));
   return std::__sign_combinator(__first, __last, __value, __from_chars_atoi<__t>);
@@ -169,7 +169,7 @@ inline constexpr float __from_chars_log2f_lut[35] = {
     4.857981,  4.9068904, 4.9541965, 5,        5.044394,  5.087463, 5.129283, 5.169925};
 
 template <typename _Tp, __enable_if_t<is_unsigned<_Tp>::value, int> = 0>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI from_chars_result
+inline _LIBCPP_CONSTEXPR_SINCE_CXX23 from_chars_result
 __from_chars_integral(const char* __first, const char* __last, _Tp& __value, int __base) {
   if (__base == 10)
     return std::__from_chars_atoi(__first, __last, __value);
@@ -210,20 +210,20 @@ __from_chars_integral(const char* __first, const char* __last, _Tp& __value, int
 }
 
 template <typename _Tp, __enable_if_t<is_signed<_Tp>::value, int> = 0>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI from_chars_result
+inline _LIBCPP_CONSTEXPR_SINCE_CXX23 from_chars_result
 __from_chars_integral(const char* __first, const char* __last, _Tp& __value, int __base) {
   using __t = decltype(std::__to_unsigned_like(__value));
   return std::__sign_combinator(__first, __last, __value, __from_chars_integral<__t>, __base);
 }
 
 template <typename _Tp, __enable_if_t<is_integral<_Tp>::value, int> = 0>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI from_chars_result
+inline _LIBCPP_CONSTEXPR_SINCE_CXX23 from_chars_result
 from_chars(const char* __first, const char* __last, _Tp& __value) {
   return std::__from_chars_atoi(__first, __last, __value);
 }
 
 template <typename _Tp, __enable_if_t<is_integral<_Tp>::value, int> = 0>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI from_chars_result
+inline _LIBCPP_CONSTEXPR_SINCE_CXX23 from_chars_result
 from_chars(const char* __first, const char* __last, _Tp& __value, int __base) {
   _LIBCPP_ASSERT_UNCATEGORIZED(2 <= __base && __base <= 36, "base not in [2, 36]");
   return std::__from_chars_integral(__first, __last, __value, __base);

--- a/libcxx/include/__charconv/from_chars_result.h
+++ b/libcxx/include/__charconv/from_chars_result.h
@@ -25,10 +25,10 @@ struct from_chars_result {
   const char* ptr;
   errc ec;
 #  if _LIBCPP_STD_VER >= 20
-  _LIBCPP_HIDE_FROM_ABI friend bool operator==(const from_chars_result&, const from_chars_result&) = default;
+  friend bool operator==(const from_chars_result&, const from_chars_result&) = default;
 #  endif
 #  if _LIBCPP_STD_VER >= 26
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit operator bool() const noexcept { return ec == errc{}; }
+  constexpr explicit operator bool() const noexcept { return ec == errc{}; }
 #  endif
 };
 

--- a/libcxx/include/__charconv/to_chars_base_10.h
+++ b/libcxx/include/__charconv/to_chars_base_10.h
@@ -28,51 +28,50 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace __itoa {
 
-_LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI inline char* __append1(char* __first, uint32_t __value) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX23 inline char* __append1(char* __first, uint32_t __value) _NOEXCEPT {
   *__first = '0' + static_cast<char>(__value);
   return __first + 1;
 }
 
-_LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI inline char* __append2(char* __first, uint32_t __value) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX23 inline char* __append2(char* __first, uint32_t __value) _NOEXCEPT {
   return std::copy_n(&__digits_base_10[__value * 2], 2, __first);
 }
 
-_LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI inline char* __append3(char* __first, uint32_t __value) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX23 inline char* __append3(char* __first, uint32_t __value) _NOEXCEPT {
   return __itoa::__append2(__itoa::__append1(__first, __value / 100), __value % 100);
 }
 
-_LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI inline char* __append4(char* __first, uint32_t __value) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX23 inline char* __append4(char* __first, uint32_t __value) _NOEXCEPT {
   return __itoa::__append2(__itoa::__append2(__first, __value / 100), __value % 100);
 }
 
-_LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI inline char* __append5(char* __first, uint32_t __value) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX23 inline char* __append5(char* __first, uint32_t __value) _NOEXCEPT {
   return __itoa::__append4(__itoa::__append1(__first, __value / 10000), __value % 10000);
 }
 
-_LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI inline char* __append6(char* __first, uint32_t __value) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX23 inline char* __append6(char* __first, uint32_t __value) _NOEXCEPT {
   return __itoa::__append4(__itoa::__append2(__first, __value / 10000), __value % 10000);
 }
 
-_LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI inline char* __append7(char* __first, uint32_t __value) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX23 inline char* __append7(char* __first, uint32_t __value) _NOEXCEPT {
   return __itoa::__append6(__itoa::__append1(__first, __value / 1000000), __value % 1000000);
 }
 
-_LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI inline char* __append8(char* __first, uint32_t __value) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX23 inline char* __append8(char* __first, uint32_t __value) _NOEXCEPT {
   return __itoa::__append6(__itoa::__append2(__first, __value / 1000000), __value % 1000000);
 }
 
-_LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI inline char* __append9(char* __first, uint32_t __value) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX23 inline char* __append9(char* __first, uint32_t __value) _NOEXCEPT {
   return __itoa::__append8(__itoa::__append1(__first, __value / 100000000), __value % 100000000);
 }
 
 template <class _Tp>
-_LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI char* __append10(char* __first, _Tp __value) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX23 char* __append10(char* __first, _Tp __value) _NOEXCEPT {
   return __itoa::__append8(__itoa::__append2(__first, static_cast<uint32_t>(__value / 100000000)),
                            static_cast<uint32_t>(__value % 100000000));
 }
 
-_LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI inline char*
-__base_10_u32(char* __first, uint32_t __value) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX23 inline char* __base_10_u32(char* __first, uint32_t __value) _NOEXCEPT {
   if (__value < 1000000) {
     if (__value < 10000) {
       if (__value < 100) {
@@ -107,8 +106,7 @@ __base_10_u32(char* __first, uint32_t __value) _NOEXCEPT {
   return __itoa::__append10(__first, __value);
 }
 
-_LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI inline char*
-__base_10_u64(char* __buffer, uint64_t __value) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX23 inline char* __base_10_u64(char* __buffer, uint64_t __value) _NOEXCEPT {
   if (__value <= UINT32_MAX)
     return __itoa::__base_10_u32(__buffer, static_cast<uint32_t>(__value));
 
@@ -122,7 +120,7 @@ __base_10_u64(char* __buffer, uint64_t __value) _NOEXCEPT {
   return __itoa::__append10(__buffer, __value);
 }
 
-#  if _LIBCPP_HAS_INT128
+#if _LIBCPP_HAS_INT128
 /// \returns 10^\a exp
 ///
 /// \pre \a exp [19, 39]
@@ -130,13 +128,12 @@ __base_10_u64(char* __buffer, uint64_t __value) _NOEXCEPT {
 /// \note The lookup table contains a partial set of exponents limiting the
 /// range that can be used. However the range is sufficient for
 /// \ref __base_10_u128.
-_LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI inline __uint128_t __pow_10(int __exp) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX23 inline __uint128_t __pow_10(int __exp) _NOEXCEPT {
   _LIBCPP_ASSERT_INTERNAL(__exp >= __pow10_128_offset, "Index out of bounds");
   return __pow10_128[__exp - __pow10_128_offset];
 }
 
-_LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI inline char*
-__base_10_u128(char* __buffer, __uint128_t __value) _NOEXCEPT {
+_LIBCPP_CONSTEXPR_SINCE_CXX23 inline char* __base_10_u128(char* __buffer, __uint128_t __value) _NOEXCEPT {
   _LIBCPP_ASSERT_INTERNAL(
       __value > numeric_limits<uint64_t>::max(), "The optimizations for this algorithm fails when this isn't true.");
 
@@ -174,7 +171,7 @@ __base_10_u128(char* __buffer, __uint128_t __value) _NOEXCEPT {
 
   return __buffer;
 }
-#  endif
+#endif
 } // namespace __itoa
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__charconv/to_chars_integral.h
+++ b/libcxx/include/__charconv/to_chars_integral.h
@@ -41,11 +41,11 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <typename _Tp>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI __to_chars_result
+inline _LIBCPP_CONSTEXPR_SINCE_CXX23 __to_chars_result
 __to_chars_itoa(char* __first, char* __last, _Tp __value, false_type);
 
 template <typename _Tp>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI __to_chars_result
+inline _LIBCPP_CONSTEXPR_SINCE_CXX23 __to_chars_result
 __to_chars_itoa(char* __first, char* __last, _Tp __value, true_type) {
   auto __x = std::__to_unsigned_like(__value);
   if (__value < 0 && __first != __last) {
@@ -57,7 +57,7 @@ __to_chars_itoa(char* __first, char* __last, _Tp __value, true_type) {
 }
 
 template <typename _Tp>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI __to_chars_result
+inline _LIBCPP_CONSTEXPR_SINCE_CXX23 __to_chars_result
 __to_chars_itoa(char* __first, char* __last, _Tp __value, false_type) {
   using __tx  = __itoa::__traits<_Tp>;
   auto __diff = __last - __first;
@@ -68,10 +68,10 @@ __to_chars_itoa(char* __first, char* __last, _Tp __value, false_type) {
     return {__last, errc::value_too_large};
 }
 
-#  if _LIBCPP_HAS_INT128
+#if _LIBCPP_HAS_INT128
 template <>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI __to_chars_result
-__to_chars_itoa(char* __first, char* __last, __uint128_t __value, false_type) {
+inline _LIBCPP_CONSTEXPR_SINCE_CXX23
+__to_chars_result __to_chars_itoa(char* __first, char* __last, __uint128_t __value, false_type) {
   // When the value fits in 64-bits use the 64-bit code path. This reduces
   // the number of expensive calculations on 128-bit values.
   //
@@ -87,14 +87,14 @@ __to_chars_itoa(char* __first, char* __last, __uint128_t __value, false_type) {
   else
     return {__last, errc::value_too_large};
 }
-#  endif
+#endif
 
 template <class _Tp, __enable_if_t<!is_signed<_Tp>::value, int> = 0>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI __to_chars_result
-__to_chars_integral(char* __first, char* __last, _Tp __value, int __base);
+inline _LIBCPP_CONSTEXPR_SINCE_CXX23
+__to_chars_result __to_chars_integral(char* __first, char* __last, _Tp __value, int __base);
 
 template <class _Tp, __enable_if_t<is_signed<_Tp>::value, int> = 0>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI __to_chars_result
+inline _LIBCPP_CONSTEXPR_SINCE_CXX23 __to_chars_result
 __to_chars_integral(char* __first, char* __last, _Tp __value, int __base) {
   auto __x = std::__to_unsigned_like(__value);
   if (__value < 0 && __first != __last) {
@@ -113,15 +113,14 @@ struct _LIBCPP_HIDDEN __integral;
 template <>
 struct _LIBCPP_HIDDEN __integral<2> {
   template <typename _Tp>
-  _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR int __width(_Tp __value) _NOEXCEPT {
+  static _LIBCPP_CONSTEXPR int __width(_Tp __value) _NOEXCEPT {
     // If value == 0 still need one digit. If the value != this has no
     // effect since the code scans for the most significant bit set.
     return numeric_limits<_Tp>::digits - std::__countl_zero(__value | 1);
   }
 
   template <typename _Tp>
-  _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI static __to_chars_result
-  __to_chars(char* __first, char* __last, _Tp __value) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX23 static __to_chars_result __to_chars(char* __first, char* __last, _Tp __value) {
     ptrdiff_t __cap = __last - __first;
     int __n         = __width(__value);
     if (__n > __cap)
@@ -148,15 +147,14 @@ struct _LIBCPP_HIDDEN __integral<2> {
 template <>
 struct _LIBCPP_HIDDEN __integral<8> {
   template <typename _Tp>
-  _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR int __width(_Tp __value) _NOEXCEPT {
+  static _LIBCPP_CONSTEXPR int __width(_Tp __value) _NOEXCEPT {
     // If value == 0 still need one digit. If the value != this has no
     // effect since the code scans for the most significat bit set.
     return ((numeric_limits<_Tp>::digits - std::__countl_zero(__value | 1)) + 2) / 3;
   }
 
   template <typename _Tp>
-  _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI static __to_chars_result
-  __to_chars(char* __first, char* __last, _Tp __value) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX23 static __to_chars_result __to_chars(char* __first, char* __last, _Tp __value) {
     ptrdiff_t __cap = __last - __first;
     int __n         = __width(__value);
     if (__n > __cap)
@@ -183,15 +181,14 @@ struct _LIBCPP_HIDDEN __integral<8> {
 template <>
 struct _LIBCPP_HIDDEN __integral<16> {
   template <typename _Tp>
-  _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR int __width(_Tp __value) _NOEXCEPT {
+  static _LIBCPP_CONSTEXPR int __width(_Tp __value) _NOEXCEPT {
     // If value == 0 still need one digit. If the value != this has no
     // effect since the code scans for the most significat bit set.
     return (numeric_limits<_Tp>::digits - std::__countl_zero(__value | 1) + 3) / 4;
   }
 
   template <typename _Tp>
-  _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI static __to_chars_result
-  __to_chars(char* __first, char* __last, _Tp __value) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX23 static __to_chars_result __to_chars(char* __first, char* __last, _Tp __value) {
     ptrdiff_t __cap = __last - __first;
     int __n         = __width(__value);
     if (__n > __cap)
@@ -219,29 +216,27 @@ struct _LIBCPP_HIDDEN __integral<16> {
 } // namespace __itoa
 
 template <unsigned _Base, typename _Tp, __enable_if_t<(sizeof(_Tp) >= sizeof(unsigned)), int> = 0>
-_LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI int __to_chars_integral_width(_Tp __value) {
+_LIBCPP_CONSTEXPR_SINCE_CXX23 int __to_chars_integral_width(_Tp __value) {
   return __itoa::__integral<_Base>::__width(__value);
 }
 
 template <unsigned _Base, typename _Tp, __enable_if_t<(sizeof(_Tp) < sizeof(unsigned)), int> = 0>
-_LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI int __to_chars_integral_width(_Tp __value) {
+_LIBCPP_CONSTEXPR_SINCE_CXX23 int __to_chars_integral_width(_Tp __value) {
   return std::__to_chars_integral_width<_Base>(static_cast<unsigned>(__value));
 }
 
 template <unsigned _Base, typename _Tp, __enable_if_t<(sizeof(_Tp) >= sizeof(unsigned)), int> = 0>
-_LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI __to_chars_result
-__to_chars_integral(char* __first, char* __last, _Tp __value) {
+_LIBCPP_CONSTEXPR_SINCE_CXX23 __to_chars_result __to_chars_integral(char* __first, char* __last, _Tp __value) {
   return __itoa::__integral<_Base>::__to_chars(__first, __last, __value);
 }
 
 template <unsigned _Base, typename _Tp, __enable_if_t<(sizeof(_Tp) < sizeof(unsigned)), int> = 0>
-_LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI __to_chars_result
-__to_chars_integral(char* __first, char* __last, _Tp __value) {
+_LIBCPP_CONSTEXPR_SINCE_CXX23 __to_chars_result __to_chars_integral(char* __first, char* __last, _Tp __value) {
   return std::__to_chars_integral<_Base>(__first, __last, static_cast<unsigned>(__value));
 }
 
 template <typename _Tp>
-_LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI int __to_chars_integral_width(_Tp __value, unsigned __base) {
+_LIBCPP_CONSTEXPR_SINCE_CXX23 int __to_chars_integral_width(_Tp __value, unsigned __base) {
   _LIBCPP_ASSERT_INTERNAL(__value >= 0, "The function requires a non-negative value.");
 
   unsigned __base_2 = __base * __base;
@@ -267,7 +262,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI int __to_chars_integral_widt
 }
 
 template <class _Tp, __enable_if_t<!is_signed<_Tp>::value, int> >
-inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI __to_chars_result
+inline _LIBCPP_CONSTEXPR_SINCE_CXX23 __to_chars_result
 __to_chars_integral(char* __first, char* __last, _Tp __value, int __base) {
   if (__base == 10) [[likely]]
     return std::__to_chars_itoa(__first, __last, __value, false_type());
@@ -296,7 +291,7 @@ __to_chars_integral(char* __first, char* __last, _Tp __value, int __base) {
   return {__last, errc(0)};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline _LIBCPP_CONSTEXPR_SINCE_CXX14 char __hex_to_upper(char __c) {
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 char __hex_to_upper(char __c) {
   switch (__c) {
   case 'a':
     return 'A';
@@ -319,16 +314,14 @@ _LIBCPP_HIDE_FROM_ABI inline _LIBCPP_CONSTEXPR_SINCE_CXX14 char __hex_to_upper(c
 to_chars_result to_chars(char*, char*, bool, int = 10) = delete;
 
 template <typename _Tp, __enable_if_t<is_integral<_Tp>::value, int> = 0>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI to_chars_result
-to_chars(char* __first, char* __last, _Tp __value) {
+inline _LIBCPP_CONSTEXPR_SINCE_CXX23 to_chars_result to_chars(char* __first, char* __last, _Tp __value) {
   using _Type = __make_32_64_or_128_bit_t<_Tp>;
   static_assert(!is_same<_Type, void>::value, "unsupported integral type used in to_chars");
   return std::__to_chars_itoa(__first, __last, static_cast<_Type>(__value), is_signed<_Tp>());
 }
 
 template <typename _Tp, __enable_if_t<is_integral<_Tp>::value, int> = 0>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI to_chars_result
-to_chars(char* __first, char* __last, _Tp __value, int __base) {
+inline _LIBCPP_CONSTEXPR_SINCE_CXX23 to_chars_result to_chars(char* __first, char* __last, _Tp __value, int __base) {
   _LIBCPP_ASSERT_UNCATEGORIZED(2 <= __base && __base <= 36, "base not in [2, 36]");
 
   using _Type = __make_32_64_or_128_bit_t<_Tp>;

--- a/libcxx/include/__charconv/to_chars_result.h
+++ b/libcxx/include/__charconv/to_chars_result.h
@@ -25,10 +25,10 @@ struct to_chars_result {
   char* ptr;
   errc ec;
 #  if _LIBCPP_STD_VER >= 20
-  _LIBCPP_HIDE_FROM_ABI friend bool operator==(const to_chars_result&, const to_chars_result&) = default;
+  friend bool operator==(const to_chars_result&, const to_chars_result&) = default;
 #  endif
 #  if _LIBCPP_STD_VER >= 26
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit operator bool() const noexcept { return ec == errc{}; }
+  constexpr explicit operator bool() const noexcept { return ec == errc{}; }
 #  endif
 };
 
@@ -39,7 +39,7 @@ struct __to_chars_result {
   errc __ec;
 
 #if _LIBCPP_STD_VER >= 17
-  _LIBCPP_HIDE_FROM_ABI constexpr operator to_chars_result() { return {__ptr, __ec}; }
+  constexpr operator to_chars_result() { return {__ptr, __ec}; }
 #endif
 };
 

--- a/libcxx/include/__charconv/traits.h
+++ b/libcxx/include/__charconv/traits.h
@@ -44,18 +44,14 @@ struct _LIBCPP_HIDDEN __traits_base<_Tp, __enable_if_t<sizeof(_Tp) <= sizeof(uin
   /// The algorithm is based on
   /// http://graphics.stanford.edu/~seander/bithacks.html#IntegerLog10
   /// Instead of using IntegerLogBase2 it uses __countl_zero.
-  static _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI int __width(_Tp __v) {
+  static _LIBCPP_CONSTEXPR_SINCE_CXX23 int __width(_Tp __v) {
     auto __t = (32 - std::__countl_zero(static_cast<type>(__v | 1))) * 1233 >> 12;
     return __t - (__v < __itoa::__pow10_32[__t]) + 1;
   }
 
-  static _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI char* __convert(char* __p, _Tp __v) {
-    return __itoa::__base_10_u32(__p, __v);
-  }
+  static _LIBCPP_CONSTEXPR_SINCE_CXX23 char* __convert(char* __p, _Tp __v) { return __itoa::__base_10_u32(__p, __v); }
 
-  static _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI decltype(__pow10_32)& __pow() {
-    return __itoa::__pow10_32;
-  }
+  static _LIBCPP_CONSTEXPR_SINCE_CXX23 decltype(__pow10_32)& __pow() { return __itoa::__pow10_32; }
 };
 
 template <typename _Tp>
@@ -67,21 +63,17 @@ struct _LIBCPP_HIDDEN __traits_base<_Tp, __enable_if_t<sizeof(_Tp) == sizeof(uin
   /// The algorithm is based on
   /// http://graphics.stanford.edu/~seander/bithacks.html#IntegerLog10
   /// Instead of using IntegerLogBase2 it uses __countl_zero.
-  static _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI int __width(_Tp __v) {
+  static _LIBCPP_CONSTEXPR_SINCE_CXX23 int __width(_Tp __v) {
     auto __t = (64 - std::__countl_zero(static_cast<type>(__v | 1))) * 1233 >> 12;
     return __t - (__v < __itoa::__pow10_64[__t]) + 1;
   }
 
-  static _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI char* __convert(char* __p, _Tp __v) {
-    return __itoa::__base_10_u64(__p, __v);
-  }
+  static _LIBCPP_CONSTEXPR_SINCE_CXX23 char* __convert(char* __p, _Tp __v) { return __itoa::__base_10_u64(__p, __v); }
 
-  static _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI decltype(__pow10_64)& __pow() {
-    return __itoa::__pow10_64;
-  }
+  static _LIBCPP_CONSTEXPR_SINCE_CXX23 decltype(__pow10_64)& __pow() { return __itoa::__pow10_64; }
 };
 
-#  if _LIBCPP_HAS_INT128
+#if _LIBCPP_HAS_INT128
 template <typename _Tp>
 struct _LIBCPP_HIDDEN __traits_base<_Tp, __enable_if_t<sizeof(_Tp) == sizeof(__uint128_t)> > {
   using type = __uint128_t;
@@ -91,7 +83,7 @@ struct _LIBCPP_HIDDEN __traits_base<_Tp, __enable_if_t<sizeof(_Tp) == sizeof(__u
   /// The algorithm is based on
   /// http://graphics.stanford.edu/~seander/bithacks.html#IntegerLog10
   /// Instead of using IntegerLogBase2 it uses __countl_zero.
-  static _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI int __width(_Tp __v) {
+  static _LIBCPP_CONSTEXPR_SINCE_CXX23 int __width(_Tp __v) {
     _LIBCPP_ASSERT_INTERNAL(
         __v > numeric_limits<uint64_t>::max(), "The optimizations for this algorithm fail when this isn't true.");
     // There's always a bit set in the upper 64-bits.
@@ -101,20 +93,16 @@ struct _LIBCPP_HIDDEN __traits_base<_Tp, __enable_if_t<sizeof(_Tp) == sizeof(__u
     return __t - (__v < __itoa::__pow10_128[__t - __itoa::__pow10_128_offset]) + 1;
   }
 
-  static _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI char* __convert(char* __p, _Tp __v) {
-    return __itoa::__base_10_u128(__p, __v);
-  }
+  static _LIBCPP_CONSTEXPR_SINCE_CXX23 char* __convert(char* __p, _Tp __v) { return __itoa::__base_10_u128(__p, __v); }
 
   // TODO FMT This pow function should get an index.
   // By moving this to its own header it can be reused by the pow function in to_chars_base_10.
-  static _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI decltype(__pow10_128)& __pow() {
-    return __itoa::__pow10_128;
-  }
+  static _LIBCPP_CONSTEXPR_SINCE_CXX23 decltype(__pow10_128)& __pow() { return __itoa::__pow10_128; }
 };
-#  endif
+#endif
 
 template <typename _Tp, typename _Up>
-_LIBCPP_HIDE_FROM_ABI bool _LIBCPP_CONSTEXPR_SINCE_CXX23 __mul_overflowed(_Tp __a, _Up __b, _Tp& __r) {
+bool _LIBCPP_CONSTEXPR_SINCE_CXX23 __mul_overflowed(_Tp __a, _Up __b, _Tp& __r) {
   static_assert(is_unsigned<_Tp>::value);
   return __builtin_mul_overflow(__a, static_cast<_Tp>(__b), std::addressof(__r));
 }
@@ -126,8 +114,7 @@ struct _LIBCPP_HIDDEN __traits : __traits_base<_Tp> {
   using typename __traits_base<_Tp>::type;
 
   // precondition: at least one non-zero character available
-  static _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI char const*
-  __read(char const* __p, char const* __ep, type& __a, type& __b) {
+  static _LIBCPP_CONSTEXPR_SINCE_CXX23 char const* __read(char const* __p, char const* __ep, type& __a, type& __b) {
     type __cprod[digits];
     int __j = digits - 1;
     int __i = digits;
@@ -144,8 +131,7 @@ struct _LIBCPP_HIDDEN __traits : __traits_base<_Tp> {
   }
 
   template <typename _It1, typename _It2, class _Up>
-  static _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI _Up
-  __inner_product(_It1 __first1, _It1 __last1, _It2 __first2, _Up __init) {
+  static _LIBCPP_CONSTEXPR_SINCE_CXX23 _Up __inner_product(_It1 __first1, _It1 __last1, _It2 __first2, _Up __init) {
     for (; __first1 < __last1; ++__first1, ++__first2)
       __init = __init + *__first1 * *__first2;
     return __init;
@@ -155,7 +141,7 @@ struct _LIBCPP_HIDDEN __traits : __traits_base<_Tp> {
 } // namespace __itoa
 
 template <typename _Tp>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI _Tp __complement(_Tp __x) {
+inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _Tp __complement(_Tp __x) {
   static_assert(is_unsigned<_Tp>::value, "cast to unsigned first");
   return _Tp(~__x + 1);
 }

--- a/libcxx/include/__chrono/convert_to_timespec.h
+++ b/libcxx/include/__chrono/convert_to_timespec.h
@@ -26,7 +26,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // Convert a nanoseconds duration to the given TimeSpec type, which must have
 // the same properties as std::timespec.
 template <class _TimeSpec>
-_LIBCPP_HIDE_FROM_ABI inline _TimeSpec __convert_to_timespec(const chrono::nanoseconds& __ns) {
+inline _TimeSpec __convert_to_timespec(const chrono::nanoseconds& __ns) {
   using namespace chrono;
   seconds __s = duration_cast<seconds>(__ns);
   _TimeSpec __ts;

--- a/libcxx/include/__chrono/convert_to_tm.h
+++ b/libcxx/include/__chrono/convert_to_tm.h
@@ -67,7 +67,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // the year 2038 valid, so instead do the transformation manually.
 template <class _Tm, class _Date>
   requires(same_as<_Date, chrono::year_month_day> || same_as<_Date, chrono::year_month_day_last>)
-_LIBCPP_HIDE_FROM_ABI _Tm __convert_to_tm(const _Date& __date, chrono::weekday __weekday) {
+_Tm __convert_to_tm(const _Date& __date, chrono::weekday __weekday) {
   _Tm __result = {};
 #  ifdef __GLIBC__
   __result.tm_zone = "UTC";
@@ -85,7 +85,7 @@ _LIBCPP_HIDE_FROM_ABI _Tm __convert_to_tm(const _Date& __date, chrono::weekday _
 }
 
 template <class _Tm, class _Duration>
-_LIBCPP_HIDE_FROM_ABI _Tm __convert_to_tm(const chrono::sys_time<_Duration> __tp) {
+_Tm __convert_to_tm(const chrono::sys_time<_Duration> __tp) {
   chrono::sys_days __days = chrono::floor<chrono::days>(__tp);
   chrono::year_month_day __ymd{__days};
 
@@ -106,7 +106,7 @@ _LIBCPP_HIDE_FROM_ABI _Tm __convert_to_tm(const chrono::sys_time<_Duration> __tp
 #    if _LIBCPP_HAS_EXPERIMENTAL_TZDB
 
 template <class _Tm, class _Duration>
-_LIBCPP_HIDE_FROM_ABI _Tm __convert_to_tm(chrono::utc_time<_Duration> __tp) {
+_Tm __convert_to_tm(chrono::utc_time<_Duration> __tp) {
   _Tm __result = std::__convert_to_tm<_Tm>(chrono::utc_clock::to_sys(__tp));
 
   if (chrono::get_leap_second_info(__tp).is_leap_second)
@@ -116,7 +116,7 @@ _LIBCPP_HIDE_FROM_ABI _Tm __convert_to_tm(chrono::utc_time<_Duration> __tp) {
 }
 
 template <class _Tm, class _Duration>
-_LIBCPP_HIDE_FROM_ABI _Tm __convert_to_tm(chrono::tai_time<_Duration> __tp) {
+_Tm __convert_to_tm(chrono::tai_time<_Duration> __tp) {
   using _Rp = common_type_t<_Duration, chrono::seconds>;
   // The time between the TAI epoch (1958-01-01) and UNIX epoch (1970-01-01).
   // This avoids leap second conversion when going from TAI to UTC.
@@ -126,7 +126,7 @@ _LIBCPP_HIDE_FROM_ABI _Tm __convert_to_tm(chrono::tai_time<_Duration> __tp) {
 }
 
 template <class _Tm, class _Duration>
-_LIBCPP_HIDE_FROM_ABI _Tm __convert_to_tm(chrono::gps_time<_Duration> __tp) {
+_Tm __convert_to_tm(chrono::gps_time<_Duration> __tp) {
   using _Rp = common_type_t<_Duration, chrono::seconds>;
   // The time between the GPS epoch (1980-01-06) and UNIX epoch (1970-01-01).
   constexpr chrono::seconds __offset{3657 * 24 * 60 * 60};
@@ -139,7 +139,7 @@ _LIBCPP_HIDE_FROM_ABI _Tm __convert_to_tm(chrono::gps_time<_Duration> __tp) {
 // Convert a chrono (calendar) time point, or dururation to the given _Tm type,
 // which must have the same properties as std::tm.
 template <class _Tm, class _ChronoT>
-_LIBCPP_HIDE_FROM_ABI _Tm __convert_to_tm(const _ChronoT& __value) {
+_Tm __convert_to_tm(const _ChronoT& __value) {
   _Tm __result = {};
 #  ifdef __GLIBC__
   __result.tm_zone = "UTC";

--- a/libcxx/include/__chrono/day.h
+++ b/libcxx/include/__chrono/day.h
@@ -32,62 +32,57 @@ private:
 
 public:
   day() = default;
-  _LIBCPP_HIDE_FROM_ABI explicit inline constexpr day(unsigned __val) noexcept
-      : __d_(static_cast<unsigned char>(__val)) {}
-  _LIBCPP_HIDE_FROM_ABI inline constexpr day& operator++() noexcept {
+  explicit inline constexpr day(unsigned __val) noexcept : __d_(static_cast<unsigned char>(__val)) {}
+  inline constexpr day& operator++() noexcept {
     ++__d_;
     return *this;
   }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr day operator++(int) noexcept {
+  inline constexpr day operator++(int) noexcept {
     day __tmp = *this;
     ++(*this);
     return __tmp;
   }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr day& operator--() noexcept {
+  inline constexpr day& operator--() noexcept {
     --__d_;
     return *this;
   }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr day operator--(int) noexcept {
+  inline constexpr day operator--(int) noexcept {
     day __tmp = *this;
     --(*this);
     return __tmp;
   }
-  _LIBCPP_HIDE_FROM_ABI constexpr day& operator+=(const days& __dd) noexcept;
-  _LIBCPP_HIDE_FROM_ABI constexpr day& operator-=(const days& __dd) noexcept;
-  _LIBCPP_HIDE_FROM_ABI explicit inline constexpr operator unsigned() const noexcept { return __d_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __d_ >= 1 && __d_ <= 31; }
+  constexpr day& operator+=(const days& __dd) noexcept;
+  constexpr day& operator-=(const days& __dd) noexcept;
+  explicit inline constexpr operator unsigned() const noexcept { return __d_; }
+  [[nodiscard]] inline constexpr bool ok() const noexcept { return __d_ >= 1 && __d_ <= 31; }
 };
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr bool operator==(const day& __lhs, const day& __rhs) noexcept {
+inline constexpr bool operator==(const day& __lhs, const day& __rhs) noexcept {
   return static_cast<unsigned>(__lhs) == static_cast<unsigned>(__rhs);
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr strong_ordering operator<=>(const day& __lhs, const day& __rhs) noexcept {
+inline constexpr strong_ordering operator<=>(const day& __lhs, const day& __rhs) noexcept {
   return static_cast<unsigned>(__lhs) <=> static_cast<unsigned>(__rhs);
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr day operator+(const day& __lhs, const days& __rhs) noexcept {
+[[nodiscard]] inline constexpr day operator+(const day& __lhs, const days& __rhs) noexcept {
   return day(static_cast<unsigned>(__lhs) + __rhs.count());
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr day operator+(const days& __lhs, const day& __rhs) noexcept {
-  return __rhs + __lhs;
-}
+[[nodiscard]] inline constexpr day operator+(const days& __lhs, const day& __rhs) noexcept { return __rhs + __lhs; }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr day operator-(const day& __lhs, const days& __rhs) noexcept {
-  return __lhs + -__rhs;
-}
+[[nodiscard]] inline constexpr day operator-(const day& __lhs, const days& __rhs) noexcept { return __lhs + -__rhs; }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr days operator-(const day& __lhs, const day& __rhs) noexcept {
+[[nodiscard]] inline constexpr days operator-(const day& __lhs, const day& __rhs) noexcept {
   return days(static_cast<int>(static_cast<unsigned>(__lhs)) - static_cast<int>(static_cast<unsigned>(__rhs)));
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr day& day::operator+=(const days& __dd) noexcept {
+inline constexpr day& day::operator+=(const days& __dd) noexcept {
   *this = *this + __dd;
   return *this;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr day& day::operator-=(const days& __dd) noexcept {
+inline constexpr day& day::operator-=(const days& __dd) noexcept {
   *this = *this - __dd;
   return *this;
 }
@@ -98,9 +93,7 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr day& day::operator-=(const days& __dd) no
 
 template <>
 struct hash<chrono::day> {
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::day& __d) noexcept {
-    return static_cast<unsigned>(__d);
-  }
+  [[nodiscard]] static size_t operator()(const chrono::day& __d) noexcept { return static_cast<unsigned>(__d); }
 };
 
 #  endif // _LIBCPP_STD_VER >= 26

--- a/libcxx/include/__chrono/duration.h
+++ b/libcxx/include/__chrono/duration.h
@@ -71,14 +71,14 @@ struct __duration_cast;
 
 template <class _FromDuration, class _ToDuration, class _Period>
 struct __duration_cast<_FromDuration, _ToDuration, _Period, true, true> {
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _ToDuration operator()(const _FromDuration& __fd) const {
+  _LIBCPP_CONSTEXPR _ToDuration operator()(const _FromDuration& __fd) const {
     return _ToDuration(static_cast<typename _ToDuration::rep>(__fd.count()));
   }
 };
 
 template <class _FromDuration, class _ToDuration, class _Period>
 struct __duration_cast<_FromDuration, _ToDuration, _Period, true, false> {
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _ToDuration operator()(const _FromDuration& __fd) const {
+  _LIBCPP_CONSTEXPR _ToDuration operator()(const _FromDuration& __fd) const {
     typedef typename common_type<typename _ToDuration::rep, typename _FromDuration::rep, intmax_t>::type _Ct;
     return _ToDuration(
         static_cast<typename _ToDuration::rep>(static_cast<_Ct>(__fd.count()) / static_cast<_Ct>(_Period::den)));
@@ -87,7 +87,7 @@ struct __duration_cast<_FromDuration, _ToDuration, _Period, true, false> {
 
 template <class _FromDuration, class _ToDuration, class _Period>
 struct __duration_cast<_FromDuration, _ToDuration, _Period, false, true> {
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _ToDuration operator()(const _FromDuration& __fd) const {
+  _LIBCPP_CONSTEXPR _ToDuration operator()(const _FromDuration& __fd) const {
     typedef typename common_type<typename _ToDuration::rep, typename _FromDuration::rep, intmax_t>::type _Ct;
     return _ToDuration(
         static_cast<typename _ToDuration::rep>(static_cast<_Ct>(__fd.count()) * static_cast<_Ct>(_Period::num)));
@@ -96,7 +96,7 @@ struct __duration_cast<_FromDuration, _ToDuration, _Period, false, true> {
 
 template <class _FromDuration, class _ToDuration, class _Period>
 struct __duration_cast<_FromDuration, _ToDuration, _Period, false, false> {
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _ToDuration operator()(const _FromDuration& __fd) const {
+  _LIBCPP_CONSTEXPR _ToDuration operator()(const _FromDuration& __fd) const {
     typedef typename common_type<typename _ToDuration::rep, typename _FromDuration::rep, intmax_t>::type _Ct;
     return _ToDuration(static_cast<typename _ToDuration::rep>(
         static_cast<_Ct>(__fd.count()) * static_cast<_Ct>(_Period::num) / static_cast<_Ct>(_Period::den)));
@@ -104,8 +104,7 @@ struct __duration_cast<_FromDuration, _ToDuration, _Period, false, false> {
 };
 
 template <class _ToDuration, class _Rep, class _Period, __enable_if_t<__is_duration_v<_ToDuration>, int> = 0>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _ToDuration
-duration_cast(const duration<_Rep, _Period>& __fd) {
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR _ToDuration duration_cast(const duration<_Rep, _Period>& __fd) {
   return __duration_cast<duration<_Rep, _Period>, _ToDuration>()(__fd);
 }
 
@@ -120,18 +119,14 @@ inline constexpr bool treat_as_floating_point_v = treat_as_floating_point<_Rep>:
 template <class _Rep>
 struct duration_values {
 public:
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR _Rep zero() _NOEXCEPT { return _Rep(0); }
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR _Rep max() _NOEXCEPT {
-    return numeric_limits<_Rep>::max();
-  }
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR _Rep min() _NOEXCEPT {
-    return numeric_limits<_Rep>::lowest();
-  }
+  [[__nodiscard__]] static _LIBCPP_CONSTEXPR _Rep zero() _NOEXCEPT { return _Rep(0); }
+  [[__nodiscard__]] static _LIBCPP_CONSTEXPR _Rep max() _NOEXCEPT { return numeric_limits<_Rep>::max(); }
+  [[__nodiscard__]] static _LIBCPP_CONSTEXPR _Rep min() _NOEXCEPT { return numeric_limits<_Rep>::lowest(); }
 };
 
 #if _LIBCPP_STD_VER >= 17
 template <class _ToDuration, class _Rep, class _Period, enable_if_t<__is_duration_v<_ToDuration>, int> = 0>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _ToDuration floor(const duration<_Rep, _Period>& __d) {
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR _ToDuration floor(const duration<_Rep, _Period>& __d) {
   _ToDuration __t = chrono::duration_cast<_ToDuration>(__d);
   if (__t > __d)
     __t = __t - _ToDuration{1};
@@ -139,7 +134,7 @@ template <class _ToDuration, class _Rep, class _Period, enable_if_t<__is_duratio
 }
 
 template <class _ToDuration, class _Rep, class _Period, enable_if_t<__is_duration_v<_ToDuration>, int> = 0>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _ToDuration ceil(const duration<_Rep, _Period>& __d) {
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR _ToDuration ceil(const duration<_Rep, _Period>& __d) {
   _ToDuration __t = chrono::duration_cast<_ToDuration>(__d);
   if (__t < __d)
     __t = __t + _ToDuration{1};
@@ -147,7 +142,7 @@ template <class _ToDuration, class _Rep, class _Period, enable_if_t<__is_duratio
 }
 
 template <class _ToDuration, class _Rep, class _Period, enable_if_t<__is_duration_v<_ToDuration>, int> = 0>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _ToDuration round(const duration<_Rep, _Period>& __d) {
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR _ToDuration round(const duration<_Rep, _Period>& __d) {
   _ToDuration __lower = chrono::floor<_ToDuration>(__d);
   _ToDuration __upper = __lower + _ToDuration{1};
   auto __lower_diff   = __d - __lower;
@@ -206,14 +201,14 @@ public:
 #ifndef _LIBCPP_CXX03_LANG
   constexpr duration() = default;
 #else
-  _LIBCPP_HIDE_FROM_ABI duration() {}
+  duration() {}
 #endif
 
   template <class _Rep2,
             __enable_if_t<is_convertible<const _Rep2&, rep>::value &&
                               (treat_as_floating_point<rep>::value || !treat_as_floating_point<_Rep2>::value),
                           int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR explicit duration(const _Rep2& __r) : __rep_(__r) {}
+  _LIBCPP_CONSTEXPR explicit duration(const _Rep2& __r) : __rep_(__r) {}
 
   // conversions
   template <class _Rep2,
@@ -222,69 +217,65 @@ public:
                                                                      (__no_overflow<_Period2, period>::type::den == 1 &&
                                                                       !treat_as_floating_point<_Rep2>::value)),
                           int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR duration(const duration<_Rep2, _Period2>& __d)
+  _LIBCPP_CONSTEXPR duration(const duration<_Rep2, _Period2>& __d)
       : __rep_(chrono::duration_cast<duration>(__d).count()) {}
 
   // observer
 
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR rep count() const { return __rep_; }
+  [[__nodiscard__]] _LIBCPP_CONSTEXPR rep count() const { return __rep_; }
 
   // arithmetic
 
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR typename common_type<duration>::type operator+() const {
+  [[__nodiscard__]] _LIBCPP_CONSTEXPR typename common_type<duration>::type operator+() const {
     return typename common_type<duration>::type(*this);
   }
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR typename common_type<duration>::type operator-() const {
+  [[__nodiscard__]] _LIBCPP_CONSTEXPR typename common_type<duration>::type operator-() const {
     return typename common_type<duration>::type(-__rep_);
   }
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 duration& operator++() {
+  _LIBCPP_CONSTEXPR_SINCE_CXX17 duration& operator++() {
     ++__rep_;
     return *this;
   }
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 duration operator++(int) { return duration(__rep_++); }
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 duration& operator--() {
+  _LIBCPP_CONSTEXPR_SINCE_CXX17 duration operator++(int) { return duration(__rep_++); }
+  _LIBCPP_CONSTEXPR_SINCE_CXX17 duration& operator--() {
     --__rep_;
     return *this;
   }
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 duration operator--(int) { return duration(__rep_--); }
+  _LIBCPP_CONSTEXPR_SINCE_CXX17 duration operator--(int) { return duration(__rep_--); }
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 duration& operator+=(const duration& __d) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX17 duration& operator+=(const duration& __d) {
     __rep_ += __d.count();
     return *this;
   }
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 duration& operator-=(const duration& __d) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX17 duration& operator-=(const duration& __d) {
     __rep_ -= __d.count();
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 duration& operator*=(const rep& __rhs) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX17 duration& operator*=(const rep& __rhs) {
     __rep_ *= __rhs;
     return *this;
   }
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 duration& operator/=(const rep& __rhs) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX17 duration& operator/=(const rep& __rhs) {
     __rep_ /= __rhs;
     return *this;
   }
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 duration& operator%=(const rep& __rhs) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX17 duration& operator%=(const rep& __rhs) {
     __rep_ %= __rhs;
     return *this;
   }
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 duration& operator%=(const duration& __rhs) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX17 duration& operator%=(const duration& __rhs) {
     __rep_ %= __rhs.count();
     return *this;
   }
 
   // special values
 
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR duration zero() _NOEXCEPT {
+  [[__nodiscard__]] static _LIBCPP_CONSTEXPR duration zero() _NOEXCEPT {
     return duration(duration_values<rep>::zero());
   }
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR duration min() _NOEXCEPT {
-    return duration(duration_values<rep>::min());
-  }
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR duration max() _NOEXCEPT {
-    return duration(duration_values<rep>::max());
-  }
+  [[__nodiscard__]] static _LIBCPP_CONSTEXPR duration min() _NOEXCEPT { return duration(duration_values<rep>::min()); }
+  [[__nodiscard__]] static _LIBCPP_CONSTEXPR duration max() _NOEXCEPT { return duration(duration_values<rep>::max()); }
 };
 
 typedef duration<long long, nano> nanoseconds;
@@ -303,7 +294,7 @@ typedef duration<int, ratio<static_cast<int>(365.2425 * 60 * 60 * 24) / 12>> mon
 
 template <class _LhsDuration, class _RhsDuration>
 struct __duration_eq {
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool operator()(const _LhsDuration& __lhs, const _RhsDuration& __rhs) const {
+  _LIBCPP_CONSTEXPR bool operator()(const _LhsDuration& __lhs, const _RhsDuration& __rhs) const {
     typedef typename common_type<_LhsDuration, _RhsDuration>::type _Ct;
     return _Ct(__lhs).count() == _Ct(__rhs).count();
   }
@@ -311,13 +302,13 @@ struct __duration_eq {
 
 template <class _LhsDuration>
 struct __duration_eq<_LhsDuration, _LhsDuration> {
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool operator()(const _LhsDuration& __lhs, const _LhsDuration& __rhs) const {
+  _LIBCPP_CONSTEXPR bool operator()(const _LhsDuration& __lhs, const _LhsDuration& __rhs) const {
     return __lhs.count() == __rhs.count();
   }
 };
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool
+inline _LIBCPP_CONSTEXPR bool
 operator==(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
   return __duration_eq<duration<_Rep1, _Period1>, duration<_Rep2, _Period2> >()(__lhs, __rhs);
 }
@@ -327,7 +318,7 @@ operator==(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period
 // Duration !=
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool
+inline _LIBCPP_CONSTEXPR bool
 operator!=(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
   return !(__lhs == __rhs);
 }
@@ -338,7 +329,7 @@ operator!=(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period
 
 template <class _LhsDuration, class _RhsDuration>
 struct __duration_lt {
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool operator()(const _LhsDuration& __lhs, const _RhsDuration& __rhs) const {
+  _LIBCPP_CONSTEXPR bool operator()(const _LhsDuration& __lhs, const _RhsDuration& __rhs) const {
     typedef typename common_type<_LhsDuration, _RhsDuration>::type _Ct;
     return _Ct(__lhs).count() < _Ct(__rhs).count();
   }
@@ -346,13 +337,13 @@ struct __duration_lt {
 
 template <class _LhsDuration>
 struct __duration_lt<_LhsDuration, _LhsDuration> {
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool operator()(const _LhsDuration& __lhs, const _LhsDuration& __rhs) const {
+  _LIBCPP_CONSTEXPR bool operator()(const _LhsDuration& __lhs, const _LhsDuration& __rhs) const {
     return __lhs.count() < __rhs.count();
   }
 };
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool
+inline _LIBCPP_CONSTEXPR bool
 operator<(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
   return __duration_lt<duration<_Rep1, _Period1>, duration<_Rep2, _Period2> >()(__lhs, __rhs);
 }
@@ -360,7 +351,7 @@ operator<(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2
 // Duration >
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool
+inline _LIBCPP_CONSTEXPR bool
 operator>(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
   return __rhs < __lhs;
 }
@@ -368,7 +359,7 @@ operator>(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2
 // Duration <=
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool
+inline _LIBCPP_CONSTEXPR bool
 operator<=(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
   return !(__rhs < __lhs);
 }
@@ -376,7 +367,7 @@ operator<=(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period
 // Duration >=
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool
+inline _LIBCPP_CONSTEXPR bool
 operator>=(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
   return !(__lhs < __rhs);
 }
@@ -385,8 +376,7 @@ operator>=(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
   requires three_way_comparable<common_type_t<_Rep1, _Rep2>>
-_LIBCPP_HIDE_FROM_ABI constexpr auto
-operator<=>(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
+constexpr auto operator<=>(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
   using _Ct = common_type_t<duration<_Rep1, _Period1>, duration<_Rep2, _Period2>>;
   return _Ct(__lhs).count() <=> _Ct(__rhs).count();
 }
@@ -396,7 +386,7 @@ operator<=>(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Perio
 // Duration +
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR
 typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2> >::type
 operator+(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
   typedef typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2> >::type _Cd;
@@ -406,7 +396,7 @@ operator+(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2
 // Duration -
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR
 typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2> >::type
 operator-(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
   typedef typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2> >::type _Cd;
@@ -419,8 +409,7 @@ template <class _Rep1,
           class _Period,
           class _Rep2,
           __enable_if_t<is_convertible<const _Rep2&, typename common_type<_Rep1, _Rep2>::type>::value, int> = 0>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI
-_LIBCPP_CONSTEXPR duration<typename common_type<_Rep1, _Rep2>::type, _Period>
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR duration<typename common_type<_Rep1, _Rep2>::type, _Period>
 operator*(const duration<_Rep1, _Period>& __d, const _Rep2& __s) {
   typedef typename common_type<_Rep1, _Rep2>::type _Cr;
   typedef duration<_Cr, _Period> _Cd;
@@ -431,8 +420,7 @@ template <class _Rep1,
           class _Period,
           class _Rep2,
           __enable_if_t<is_convertible<const _Rep1&, typename common_type<_Rep1, _Rep2>::type>::value, int> = 0>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI
-_LIBCPP_CONSTEXPR duration<typename common_type<_Rep1, _Rep2>::type, _Period>
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR duration<typename common_type<_Rep1, _Rep2>::type, _Period>
 operator*(const _Rep1& __s, const duration<_Rep2, _Period>& __d) {
   return __d * __s;
 }
@@ -445,8 +433,7 @@ template <class _Rep1,
           __enable_if_t<!__is_duration_v<_Rep2> &&
                             is_convertible<const _Rep2&, typename common_type<_Rep1, _Rep2>::type>::value,
                         int> = 0>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI
-_LIBCPP_CONSTEXPR duration<typename common_type<_Rep1, _Rep2>::type, _Period>
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR duration<typename common_type<_Rep1, _Rep2>::type, _Period>
 operator/(const duration<_Rep1, _Period>& __d, const _Rep2& __s) {
   typedef typename common_type<_Rep1, _Rep2>::type _Cr;
   typedef duration<_Cr, _Period> _Cd;
@@ -454,7 +441,7 @@ operator/(const duration<_Rep1, _Period>& __d, const _Rep2& __s) {
 }
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR typename common_type<_Rep1, _Rep2>::type
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR typename common_type<_Rep1, _Rep2>::type
 operator/(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
   typedef typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2> >::type _Ct;
   return _Ct(__lhs).count() / _Ct(__rhs).count();
@@ -468,8 +455,7 @@ template <class _Rep1,
           __enable_if_t<!__is_duration_v<_Rep2> &&
                             is_convertible<const _Rep2&, typename common_type<_Rep1, _Rep2>::type>::value,
                         int> = 0>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI
-_LIBCPP_CONSTEXPR duration<typename common_type<_Rep1, _Rep2>::type, _Period>
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR duration<typename common_type<_Rep1, _Rep2>::type, _Period>
 operator%(const duration<_Rep1, _Period>& __d, const _Rep2& __s) {
   typedef typename common_type<_Rep1, _Rep2>::type _Cr;
   typedef duration<_Cr, _Period> _Cd;
@@ -477,7 +463,7 @@ operator%(const duration<_Rep1, _Period>& __d, const _Rep2& __s) {
 }
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR
 typename common_type<duration<_Rep1, _Period1>, duration<_Rep2, _Period2> >::type
 operator%(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
   typedef typename common_type<_Rep1, _Rep2>::type _Cr;
@@ -492,53 +478,51 @@ operator%(const duration<_Rep1, _Period1>& __lhs, const duration<_Rep2, _Period2
 inline namespace literals {
 inline namespace chrono_literals {
 
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::hours operator""h(unsigned long long __h) {
+[[__nodiscard__]] constexpr chrono::hours operator""h(unsigned long long __h) {
   return chrono::hours(static_cast<chrono::hours::rep>(__h));
 }
 
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::duration<long double, ratio<3600, 1>>
-operator""h(long double __h) {
+[[__nodiscard__]] constexpr chrono::duration<long double, ratio<3600, 1>> operator""h(long double __h) {
   return chrono::duration<long double, ratio<3600, 1>>(__h);
 }
 
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::minutes operator""min(unsigned long long __m) {
+[[__nodiscard__]] constexpr chrono::minutes operator""min(unsigned long long __m) {
   return chrono::minutes(static_cast<chrono::minutes::rep>(__m));
 }
 
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::duration<long double, ratio<60, 1>>
-operator""min(long double __m) {
+[[__nodiscard__]] constexpr chrono::duration<long double, ratio<60, 1>> operator""min(long double __m) {
   return chrono::duration<long double, ratio<60, 1>>(__m);
 }
 
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::seconds operator""s(unsigned long long __s) {
+[[__nodiscard__]] constexpr chrono::seconds operator""s(unsigned long long __s) {
   return chrono::seconds(static_cast<chrono::seconds::rep>(__s));
 }
 
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::duration<long double> operator""s(long double __s) {
+[[__nodiscard__]] constexpr chrono::duration<long double> operator""s(long double __s) {
   return chrono::duration<long double>(__s);
 }
 
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::milliseconds operator""ms(unsigned long long __ms) {
+[[__nodiscard__]] constexpr chrono::milliseconds operator""ms(unsigned long long __ms) {
   return chrono::milliseconds(static_cast<chrono::milliseconds::rep>(__ms));
 }
 
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::duration<long double, milli> operator""ms(long double __ms) {
+[[__nodiscard__]] constexpr chrono::duration<long double, milli> operator""ms(long double __ms) {
   return chrono::duration<long double, milli>(__ms);
 }
 
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::microseconds operator""us(unsigned long long __us) {
+[[__nodiscard__]] constexpr chrono::microseconds operator""us(unsigned long long __us) {
   return chrono::microseconds(static_cast<chrono::microseconds::rep>(__us));
 }
 
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::duration<long double, micro> operator""us(long double __us) {
+[[__nodiscard__]] constexpr chrono::duration<long double, micro> operator""us(long double __us) {
   return chrono::duration<long double, micro>(__us);
 }
 
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::nanoseconds operator""ns(unsigned long long __ns) {
+[[__nodiscard__]] constexpr chrono::nanoseconds operator""ns(unsigned long long __ns) {
   return chrono::nanoseconds(static_cast<chrono::nanoseconds::rep>(__ns));
 }
 
-[[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::duration<long double, nano> operator""ns(long double __ns) {
+[[__nodiscard__]] constexpr chrono::duration<long double, nano> operator""ns(long double __ns) {
   return chrono::duration<long double, nano>(__ns);
 }
 
@@ -556,7 +540,7 @@ using namespace literals::chrono_literals;
 template <class _Rep, class _Period>
   requires __has_enabled_hash<_Rep>::value
 struct hash<chrono::duration<_Rep, _Period>> {
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::duration<_Rep, _Period>& __d) {
+  [[nodiscard]] static size_t operator()(const chrono::duration<_Rep, _Period>& __d) {
     return hash<_Rep>{}(__d.count());
   }
 };

--- a/libcxx/include/__chrono/exception.h
+++ b/libcxx/include/__chrono/exception.h
@@ -40,7 +40,7 @@ namespace chrono {
 class nonexistent_local_time : public runtime_error {
 public:
   template <class _Duration>
-  _LIBCPP_HIDE_FROM_ABI nonexistent_local_time(const local_time<_Duration>& __time, const local_info& __info)
+  nonexistent_local_time(const local_time<_Duration>& __time, const local_info& __info)
       : runtime_error{__create_message(__time, __info)} {
     // [time.zone.exception.nonexist]/2
     //   Preconditions: i.result == local_info::nonexistent is true.
@@ -49,14 +49,14 @@ public:
                             "creating an nonexistent_local_time from a local_info that is not non-existent");
   }
 
-  _LIBCPP_HIDE_FROM_ABI nonexistent_local_time(const nonexistent_local_time&)            = default;
-  _LIBCPP_HIDE_FROM_ABI nonexistent_local_time& operator=(const nonexistent_local_time&) = default;
+  nonexistent_local_time(const nonexistent_local_time&)            = default;
+  nonexistent_local_time& operator=(const nonexistent_local_time&) = default;
 
   _LIBCPP_AVAILABILITY_TZDB _LIBCPP_EXPORTED_FROM_ABI ~nonexistent_local_time() override; // exported as key function
 
 private:
   template <class _Duration>
-  _LIBCPP_HIDE_FROM_ABI string __create_message(const local_time<_Duration>& __time, const local_info& __info) {
+  string __create_message(const local_time<_Duration>& __time, const local_info& __info) {
     return std::format(
         R"({} is in a gap between
 {} {} and
@@ -72,7 +72,7 @@ private:
 };
 
 template <class _Duration>
-[[noreturn]] _LIBCPP_AVAILABILITY_TZDB _LIBCPP_HIDE_FROM_ABI void __throw_nonexistent_local_time(
+[[noreturn]] _LIBCPP_AVAILABILITY_TZDB void __throw_nonexistent_local_time(
     [[maybe_unused]] const local_time<_Duration>& __time, [[maybe_unused]] const local_info& __info) {
 #    if _LIBCPP_HAS_EXCEPTIONS
   throw nonexistent_local_time(__time, __info);
@@ -84,7 +84,7 @@ template <class _Duration>
 class ambiguous_local_time : public runtime_error {
 public:
   template <class _Duration>
-  _LIBCPP_HIDE_FROM_ABI ambiguous_local_time(const local_time<_Duration>& __time, const local_info& __info)
+  ambiguous_local_time(const local_time<_Duration>& __time, const local_info& __info)
       : runtime_error{__create_message(__time, __info)} {
     // [time.zone.exception.ambig]/2
     //   Preconditions: i.result == local_info::ambiguous is true.
@@ -93,14 +93,14 @@ public:
                             "creating an ambiguous_local_time from a local_info that is not ambiguous");
   }
 
-  _LIBCPP_HIDE_FROM_ABI ambiguous_local_time(const ambiguous_local_time&)            = default;
-  _LIBCPP_HIDE_FROM_ABI ambiguous_local_time& operator=(const ambiguous_local_time&) = default;
+  ambiguous_local_time(const ambiguous_local_time&)            = default;
+  ambiguous_local_time& operator=(const ambiguous_local_time&) = default;
 
   _LIBCPP_AVAILABILITY_TZDB _LIBCPP_EXPORTED_FROM_ABI ~ambiguous_local_time() override; // exported as key function
 
 private:
   template <class _Duration>
-  _LIBCPP_HIDE_FROM_ABI string __create_message(const local_time<_Duration>& __time, const local_info& __info) {
+  string __create_message(const local_time<_Duration>& __time, const local_info& __info) {
     return std::format(
         // There are two spaces after the full-stop; this has been verified
         // in the sources of the Standard.
@@ -116,7 +116,7 @@ private:
 };
 
 template <class _Duration>
-[[noreturn]] _LIBCPP_AVAILABILITY_TZDB _LIBCPP_HIDE_FROM_ABI void __throw_ambiguous_local_time(
+[[noreturn]] _LIBCPP_AVAILABILITY_TZDB void __throw_ambiguous_local_time(
     [[maybe_unused]] const local_time<_Duration>& __time, [[maybe_unused]] const local_info& __info) {
 #    if _LIBCPP_HAS_EXCEPTIONS
   throw ambiguous_local_time(__time, __info);

--- a/libcxx/include/__chrono/formatter.h
+++ b/libcxx/include/__chrono/formatter.h
@@ -93,8 +93,7 @@ namespace __formatter {
 // fails compile-time due to the limited precision of the ratio (64-bit is too
 // small). Therefore a duration uses its own conversion.
 template <class _CharT, class _Rep, class _Period>
-_LIBCPP_HIDE_FROM_ABI void
-__format_sub_seconds(basic_stringstream<_CharT>& __sstr, const chrono::duration<_Rep, _Period>& __value) {
+void __format_sub_seconds(basic_stringstream<_CharT>& __sstr, const chrono::duration<_Rep, _Period>& __value) {
   __sstr << std::use_facet<numpunct<_CharT>>(__sstr.getloc()).decimal_point();
 
   using __duration = chrono::duration<_Rep, _Period>;
@@ -128,13 +127,12 @@ __format_sub_seconds(basic_stringstream<_CharT>& __sstr, const chrono::duration<
 }
 
 template <class _CharT, __is_time_point _Tp>
-_LIBCPP_HIDE_FROM_ABI void __format_sub_seconds(basic_stringstream<_CharT>& __sstr, const _Tp& __value) {
+void __format_sub_seconds(basic_stringstream<_CharT>& __sstr, const _Tp& __value) {
   __formatter::__format_sub_seconds(__sstr, __value.time_since_epoch());
 }
 
 template <class _CharT, class _Duration>
-_LIBCPP_HIDE_FROM_ABI void
-__format_sub_seconds(basic_stringstream<_CharT>& __sstr, const chrono::hh_mm_ss<_Duration>& __value) {
+void __format_sub_seconds(basic_stringstream<_CharT>& __sstr, const chrono::hh_mm_ss<_Duration>& __value) {
   __sstr << std::use_facet<numpunct<_CharT>>(__sstr.getloc()).decimal_point();
   if constexpr (chrono::treat_as_floating_point_v<typename _Duration::rep>)
     std::format_to(std::ostreambuf_iterator<_CharT>{__sstr},
@@ -150,8 +148,8 @@ __format_sub_seconds(basic_stringstream<_CharT>& __sstr, const chrono::hh_mm_ss<
 
 #    if _LIBCPP_HAS_EXPERIMENTAL_TZDB && _LIBCPP_HAS_TIME_ZONE_DATABASE && _LIBCPP_HAS_FILESYSTEM
 template <class _CharT, class _Duration, class _TimeZonePtr>
-_LIBCPP_HIDE_FROM_ABI void
-__format_sub_seconds(basic_stringstream<_CharT>& __sstr, const chrono::zoned_time<_Duration, _TimeZonePtr>& __value) {
+void __format_sub_seconds(basic_stringstream<_CharT>& __sstr,
+                          const chrono::zoned_time<_Duration, _TimeZonePtr>& __value) {
   __formatter::__format_sub_seconds(__sstr, __value.get_local_time().time_since_epoch());
 }
 #    endif
@@ -173,7 +171,7 @@ consteval bool __use_fraction() {
 }
 
 template <class _CharT>
-_LIBCPP_HIDE_FROM_ABI void __format_year(basic_stringstream<_CharT>& __sstr, int __year) {
+void __format_year(basic_stringstream<_CharT>& __sstr, int __year) {
   if (__year < 0) {
     __sstr << _CharT('-');
     __year = -__year;
@@ -189,7 +187,7 @@ _LIBCPP_HIDE_FROM_ABI void __format_year(basic_stringstream<_CharT>& __sstr, int
 }
 
 template <class _CharT>
-_LIBCPP_HIDE_FROM_ABI void __format_century(basic_stringstream<_CharT>& __sstr, int __year) {
+void __format_century(basic_stringstream<_CharT>& __sstr, int __year) {
   // TODO FMT Write an issue
   // [tab:time.format.spec]
   //   %C The year divided by 100 using floored division. If the result is a
@@ -204,8 +202,7 @@ _LIBCPP_HIDE_FROM_ABI void __format_century(basic_stringstream<_CharT>& __sstr, 
 // '__modifier' signals %Oz or %Ez were used. (Both modifiers behave the same,
 // so there is no need to distinguish between them.)
 template <class _CharT>
-_LIBCPP_HIDE_FROM_ABI void
-__format_zone_offset(basic_stringstream<_CharT>& __sstr, chrono::seconds __offset, bool __modifier) {
+void __format_zone_offset(basic_stringstream<_CharT>& __sstr, chrono::seconds __offset, bool __modifier) {
   if (__offset < 0s) {
     __sstr << _CharT('-');
     __offset = -__offset;
@@ -223,7 +220,7 @@ __format_zone_offset(basic_stringstream<_CharT>& __sstr, chrono::seconds __offse
 }
 
 // Helper to store the time zone information needed for formatting.
-struct _LIBCPP_HIDE_FROM_ABI __time_zone {
+struct __time_zone {
   // Typically these abbreviations are short and fit in the string's internal
   // buffer.
   string __abbrev;
@@ -231,7 +228,7 @@ struct _LIBCPP_HIDE_FROM_ABI __time_zone {
 };
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI __time_zone __convert_to_time_zone([[maybe_unused]] const _Tp& __value) {
+__time_zone __convert_to_time_zone([[maybe_unused]] const _Tp& __value) {
 #    if _LIBCPP_HAS_EXPERIMENTAL_TZDB
   if constexpr (same_as<_Tp, chrono::sys_info>)
     return {__value.abbrev, __value.offset};
@@ -249,7 +246,7 @@ _LIBCPP_HIDE_FROM_ABI __time_zone __convert_to_time_zone([[maybe_unused]] const 
 }
 
 template <class _CharT, class _Tp>
-_LIBCPP_HIDE_FROM_ABI void __format_chrono_using_chrono_specs(
+void __format_chrono_using_chrono_specs(
     basic_stringstream<_CharT>& __sstr, const _Tp& __value, basic_string_view<_CharT> __chrono_specs) {
   tm __t              = std::__convert_to_tm<tm>(__value);
   __time_zone __z     = __formatter::__convert_to_time_zone(__value);
@@ -417,7 +414,7 @@ _LIBCPP_HIDE_FROM_ABI void __format_chrono_using_chrono_specs(
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI constexpr bool __weekday_ok(const _Tp& __value) {
+constexpr bool __weekday_ok(const _Tp& __value) {
   if constexpr (__is_time_point<_Tp>)
     return true;
   else if constexpr (same_as<_Tp, chrono::day>)
@@ -467,7 +464,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr bool __weekday_ok(const _Tp& __value) {
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI constexpr bool __weekday_name_ok(const _Tp& __value) {
+constexpr bool __weekday_name_ok(const _Tp& __value) {
   if constexpr (__is_time_point<_Tp>)
     return true;
   else if constexpr (same_as<_Tp, chrono::day>)
@@ -517,7 +514,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr bool __weekday_name_ok(const _Tp& __value) {
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI constexpr bool __date_ok(const _Tp& __value) {
+constexpr bool __date_ok(const _Tp& __value) {
   if constexpr (__is_time_point<_Tp>)
     return true;
   else if constexpr (same_as<_Tp, chrono::day>)
@@ -567,7 +564,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr bool __date_ok(const _Tp& __value) {
 }
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI constexpr bool __month_name_ok(const _Tp& __value) {
+constexpr bool __month_name_ok(const _Tp& __value) {
   if constexpr (__is_time_point<_Tp>)
     return true;
   else if constexpr (same_as<_Tp, chrono::day>)
@@ -617,11 +614,10 @@ _LIBCPP_HIDE_FROM_ABI constexpr bool __month_name_ok(const _Tp& __value) {
 }
 
 template <class _CharT, class _Tp, class _FormatContext>
-_LIBCPP_HIDE_FROM_ABI auto
-__format_chrono(const _Tp& __value,
-                _FormatContext& __ctx,
-                __format_spec::__parsed_specifications<_CharT> __specs,
-                basic_string_view<_CharT> __chrono_specs) {
+auto __format_chrono(const _Tp& __value,
+                     _FormatContext& __ctx,
+                     __format_spec::__parsed_specifications<_CharT> __specs,
+                     basic_string_view<_CharT> __chrono_specs) {
   basic_stringstream<_CharT> __sstr;
   // [time.format]/2
   // 2.1 - the "C" locale if the L option is not present in chrono-format-spec, otherwise
@@ -703,13 +699,13 @@ template <__fmt_char_type _CharT>
 struct __formatter_chrono {
 public:
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator
+  constexpr typename _ParseContext::iterator
   __parse(_ParseContext& __ctx, __format_spec::__fields __fields, __format_spec::__flags __flags) {
     return __parser_.__parse(__ctx, __fields, __flags);
   }
 
   template <class _Tp, class _FormatContext>
-  _LIBCPP_HIDE_FROM_ABI typename _FormatContext::iterator format(const _Tp& __value, _FormatContext& __ctx) const {
+  typename _FormatContext::iterator format(const _Tp& __value, _FormatContext& __ctx) const {
     return __formatter::__format_chrono(
         __value, __ctx, __parser_.__parser_.__get_parsed_chrono_specifications(__ctx), __parser_.__chrono_specs_);
   }
@@ -723,7 +719,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__clock);
   }
 };
@@ -737,7 +733,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__clock);
   }
 };
@@ -748,7 +744,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__clock);
   }
 };
@@ -759,7 +755,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__clock);
   }
 };
@@ -773,7 +769,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__clock);
   }
 };
@@ -784,7 +780,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     // The flags are not __clock since there is no associated time-zone.
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__date_time);
   }
@@ -796,7 +792,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     // [time.format]/1
     // Giving a precision specification in the chrono-format-spec is valid only
     // for std::chrono::duration types where the representation type Rep is a
@@ -818,7 +814,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__day);
   }
 };
@@ -829,7 +825,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__month);
   }
 };
@@ -840,7 +836,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__year);
   }
 };
@@ -851,7 +847,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__weekday);
   }
 };
@@ -862,7 +858,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__weekday);
   }
 };
@@ -873,7 +869,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__weekday);
   }
 };
@@ -884,7 +880,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__month_day);
   }
 };
@@ -895,7 +891,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__month);
   }
 };
@@ -906,7 +902,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__month_weekday);
   }
 };
@@ -917,7 +913,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__month_weekday);
   }
 };
@@ -928,7 +924,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__year_month);
   }
 };
@@ -939,7 +935,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__date);
   }
 };
@@ -950,7 +946,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__date);
   }
 };
@@ -961,7 +957,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__date);
   }
 };
@@ -972,7 +968,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__date);
   }
 };
@@ -983,7 +979,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__time);
   }
 };
@@ -995,7 +991,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__time_zone);
   }
 };
@@ -1006,7 +1002,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags{});
   }
 };
@@ -1019,7 +1015,7 @@ public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
+  constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
     return _Base::__parse(__ctx, __format_spec::__fields_chrono, __format_spec::__flags::__clock);
   }
 };

--- a/libcxx/include/__chrono/gps_clock.h
+++ b/libcxx/include/__chrono/gps_clock.h
@@ -51,11 +51,10 @@ public:
   // The static difference between UTC and GPS time as specified in the Standard.
   static constexpr chrono::seconds __offset{315964809};
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static time_point now() { return from_utc(utc_clock::now()); }
+  [[nodiscard]] static time_point now() { return from_utc(utc_clock::now()); }
 
   template <class _Duration>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static utc_time<common_type_t<_Duration, seconds>>
-  to_utc(const gps_time<_Duration>& __time) noexcept {
+  [[nodiscard]] static utc_time<common_type_t<_Duration, seconds>> to_utc(const gps_time<_Duration>& __time) noexcept {
     using _Rp                    = common_type_t<_Duration, seconds>;
     _Duration __time_since_epoch = __time.time_since_epoch();
     _LIBCPP_ASSERT_ARGUMENT_WITHIN_DOMAIN(__time_since_epoch >= utc_time<_Rp>::min().time_since_epoch() + __offset,
@@ -65,7 +64,7 @@ public:
   }
 
   template <class _Duration>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static gps_time<common_type_t<_Duration, seconds>>
+  [[nodiscard]] static gps_time<common_type_t<_Duration, seconds>>
   from_utc(const utc_time<_Duration>& __time) noexcept {
     using _Rp                    = common_type_t<_Duration, seconds>;
     _Duration __time_since_epoch = __time.time_since_epoch();

--- a/libcxx/include/__chrono/hh_mm_ss.h
+++ b/libcxx/include/__chrono/hh_mm_ss.h
@@ -32,45 +32,45 @@ private:
   static_assert(__is_duration_v<_Duration>, "template parameter of hh_mm_ss must be a std::chrono::duration");
   using __CommonType _LIBCPP_NODEBUG = common_type_t<_Duration, chrono::seconds>;
 
-  _LIBCPP_HIDE_FROM_ABI static constexpr uint64_t __pow10(unsigned __exp) {
+  static constexpr uint64_t __pow10(unsigned __exp) {
     uint64_t __ret = 1;
     for (unsigned __i = 0; __i < __exp; ++__i)
       __ret *= 10U;
     return __ret;
   }
 
-  _LIBCPP_HIDE_FROM_ABI static constexpr unsigned __width(uint64_t __n, uint64_t __d = 10, unsigned __w = 0) {
+  static constexpr unsigned __width(uint64_t __n, uint64_t __d = 10, unsigned __w = 0) {
     if (__n >= 2 && __d != 0 && __w < 19)
       return 1 + __width(__n, __d % __n * 10, __w + 1);
     return 0;
   }
 
 public:
-  _LIBCPP_HIDE_FROM_ABI static unsigned constexpr fractional_width =
+  static unsigned constexpr fractional_width =
       __width(__CommonType::period::den) < 19 ? __width(__CommonType::period::den) : 6u;
   using precision = duration<typename __CommonType::rep, ratio<1, __pow10(fractional_width)>>;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr hh_mm_ss() noexcept : hh_mm_ss{_Duration::zero()} {}
+  constexpr hh_mm_ss() noexcept : hh_mm_ss{_Duration::zero()} {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit hh_mm_ss(_Duration __d) noexcept
+  constexpr explicit hh_mm_ss(_Duration __d) noexcept
       : __is_neg_(__d < _Duration(0)),
         __h_(chrono::duration_cast<chrono::hours>(chrono::abs(__d))),
         __m_(chrono::duration_cast<chrono::minutes>(chrono::abs(__d) - hours())),
         __s_(chrono::duration_cast<chrono::seconds>(chrono::abs(__d) - hours() - minutes())),
         __f_(chrono::duration_cast<precision>(chrono::abs(__d) - hours() - minutes() - seconds())) {}
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool is_negative() const noexcept { return __is_neg_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::hours hours() const noexcept { return __h_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::minutes minutes() const noexcept { return __m_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::seconds seconds() const noexcept { return __s_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr precision subseconds() const noexcept { return __f_; }
+  [[nodiscard]] constexpr bool is_negative() const noexcept { return __is_neg_; }
+  [[nodiscard]] constexpr chrono::hours hours() const noexcept { return __h_; }
+  [[nodiscard]] constexpr chrono::minutes minutes() const noexcept { return __m_; }
+  [[nodiscard]] constexpr chrono::seconds seconds() const noexcept { return __s_; }
+  [[nodiscard]] constexpr precision subseconds() const noexcept { return __f_; }
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr precision to_duration() const noexcept {
+  [[nodiscard]] constexpr precision to_duration() const noexcept {
     auto __dur = __h_ + __m_ + __s_ + __f_;
     return __is_neg_ ? -__dur : __dur;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit operator precision() const noexcept { return to_duration(); }
+  constexpr explicit operator precision() const noexcept { return to_duration(); }
 
 private:
   bool __is_neg_;
@@ -81,14 +81,10 @@ private:
 };
 _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(hh_mm_ss);
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool is_am(const hours& __h) noexcept {
-  return __h >= hours(0) && __h < hours(12);
-}
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool is_pm(const hours& __h) noexcept {
-  return __h >= hours(12) && __h < hours(24);
-}
+[[nodiscard]] inline constexpr bool is_am(const hours& __h) noexcept { return __h >= hours(0) && __h < hours(12); }
+[[nodiscard]] inline constexpr bool is_pm(const hours& __h) noexcept { return __h >= hours(12) && __h < hours(24); }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr hours make12(const hours& __h) noexcept {
+[[nodiscard]] inline constexpr hours make12(const hours& __h) noexcept {
   if (__h == hours(0))
     return hours(12);
   else if (__h <= hours(12))
@@ -97,7 +93,7 @@ _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(hh_mm_ss);
     return __h - hours(12);
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr hours make24(const hours& __h, bool __is_pm) noexcept {
+[[nodiscard]] inline constexpr hours make24(const hours& __h, bool __is_pm) noexcept {
   if (__is_pm)
     return __h == hours(12) ? __h : __h + hours(12);
   else

--- a/libcxx/include/__chrono/leap_second.h
+++ b/libcxx/include/__chrono/leap_second.h
@@ -38,16 +38,15 @@ namespace chrono {
 
 class leap_second {
 public:
-  [[nodiscard]]
-  _LIBCPP_HIDE_FROM_ABI explicit constexpr leap_second(__private_constructor_tag, sys_seconds __date, seconds __value)
+  [[nodiscard]] explicit constexpr leap_second(__private_constructor_tag, sys_seconds __date, seconds __value)
       : __date_(__date), __value_(__value) {}
 
-  _LIBCPP_HIDE_FROM_ABI leap_second(const leap_second&)            = default;
-  _LIBCPP_HIDE_FROM_ABI leap_second& operator=(const leap_second&) = default;
+  leap_second(const leap_second&)            = default;
+  leap_second& operator=(const leap_second&) = default;
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr sys_seconds date() const noexcept { return __date_; }
+  [[nodiscard]] constexpr sys_seconds date() const noexcept { return __date_; }
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr seconds value() const noexcept { return __value_; }
+  [[nodiscard]] constexpr seconds value() const noexcept { return __value_; }
 
 private:
   sys_seconds __date_;
@@ -62,62 +61,60 @@ private:
   // to make the funcion a hidden friend. For consistency make this change for
   // all comparison functions.
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const leap_second& __x, const leap_second& __y) {
-    return __x.date() == __y.date();
-  }
+  friend constexpr bool operator==(const leap_second& __x, const leap_second& __y) { return __x.date() == __y.date(); }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr strong_ordering operator<=>(const leap_second& __x, const leap_second& __y) {
+  friend constexpr strong_ordering operator<=>(const leap_second& __x, const leap_second& __y) {
     return __x.date() <=> __y.date();
   }
 
   template <class _Duration>
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const leap_second& __x, const sys_time<_Duration>& __y) {
+  friend constexpr bool operator==(const leap_second& __x, const sys_time<_Duration>& __y) {
     return __x.date() == __y;
   }
 
   template <class _Duration>
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator<(const leap_second& __x, const sys_time<_Duration>& __y) {
+  friend constexpr bool operator<(const leap_second& __x, const sys_time<_Duration>& __y) {
     return __x.date() < __y;
   }
 
   template <class _Duration>
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator<(const sys_time<_Duration>& __x, const leap_second& __y) {
+  friend constexpr bool operator<(const sys_time<_Duration>& __x, const leap_second& __y) {
     return __x < __y.date();
   }
 
   template <class _Duration>
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator>(const leap_second& __x, const sys_time<_Duration>& __y) {
+  friend constexpr bool operator>(const leap_second& __x, const sys_time<_Duration>& __y) {
     return __y < __x;
   }
 
   template <class _Duration>
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator>(const sys_time<_Duration>& __x, const leap_second& __y) {
+  friend constexpr bool operator>(const sys_time<_Duration>& __x, const leap_second& __y) {
     return __y < __x;
   }
 
   template <class _Duration>
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator<=(const leap_second& __x, const sys_time<_Duration>& __y) {
+  friend constexpr bool operator<=(const leap_second& __x, const sys_time<_Duration>& __y) {
     return !(__y < __x);
   }
 
   template <class _Duration>
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator<=(const sys_time<_Duration>& __x, const leap_second& __y) {
+  friend constexpr bool operator<=(const sys_time<_Duration>& __x, const leap_second& __y) {
     return !(__y < __x);
   }
 
   template <class _Duration>
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator>=(const leap_second& __x, const sys_time<_Duration>& __y) {
+  friend constexpr bool operator>=(const leap_second& __x, const sys_time<_Duration>& __y) {
     return !(__x < __y);
   }
 
   template <class _Duration>
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator>=(const sys_time<_Duration>& __x, const leap_second& __y) {
+  friend constexpr bool operator>=(const sys_time<_Duration>& __x, const leap_second& __y) {
     return !(__x < __y);
   }
 
   template <class _Duration>
     requires three_way_comparable_with<sys_seconds, sys_time<_Duration>>
-  _LIBCPP_HIDE_FROM_ABI friend constexpr auto operator<=>(const leap_second& __x, const sys_time<_Duration>& __y) {
+  friend constexpr auto operator<=>(const leap_second& __x, const sys_time<_Duration>& __y) {
     return __x.date() <=> __y;
   }
 };
@@ -128,7 +125,7 @@ private:
 
 template <>
 struct hash<chrono::leap_second> {
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::leap_second& __lp) noexcept {
+  [[nodiscard]] static size_t operator()(const chrono::leap_second& __lp) noexcept {
     return std::__hash_combine(hash<chrono::sys_seconds>{}(__lp.date()), hash<chrono::seconds>{}(__lp.value()));
   }
 };

--- a/libcxx/include/__chrono/literals.h
+++ b/libcxx/include/__chrono/literals.h
@@ -24,11 +24,11 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 inline namespace literals {
 inline namespace chrono_literals {
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::day operator""d(unsigned long long __d) noexcept {
+[[nodiscard]] constexpr chrono::day operator""d(unsigned long long __d) noexcept {
   return chrono::day(static_cast<unsigned>(__d));
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::year operator""y(unsigned long long __y) noexcept {
+[[nodiscard]] constexpr chrono::year operator""y(unsigned long long __y) noexcept {
   return chrono::year(static_cast<int>(__y));
 }
 } // namespace chrono_literals

--- a/libcxx/include/__chrono/month.h
+++ b/libcxx/include/__chrono/month.h
@@ -32,65 +32,64 @@ private:
 
 public:
   month() = default;
-  _LIBCPP_HIDE_FROM_ABI explicit inline constexpr month(unsigned __val) noexcept
-      : __m_(static_cast<unsigned char>(__val)) {}
-  _LIBCPP_HIDE_FROM_ABI inline constexpr month& operator++() noexcept {
+  explicit inline constexpr month(unsigned __val) noexcept : __m_(static_cast<unsigned char>(__val)) {}
+  inline constexpr month& operator++() noexcept {
     *this += months{1};
     return *this;
   }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr month operator++(int) noexcept {
+  inline constexpr month operator++(int) noexcept {
     month __tmp = *this;
     ++(*this);
     return __tmp;
   }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr month& operator--() noexcept {
+  inline constexpr month& operator--() noexcept {
     *this -= months{1};
     return *this;
   }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr month operator--(int) noexcept {
+  inline constexpr month operator--(int) noexcept {
     month __tmp = *this;
     --(*this);
     return __tmp;
   }
-  _LIBCPP_HIDE_FROM_ABI constexpr month& operator+=(const months& __m1) noexcept;
-  _LIBCPP_HIDE_FROM_ABI constexpr month& operator-=(const months& __m1) noexcept;
-  _LIBCPP_HIDE_FROM_ABI explicit inline constexpr operator unsigned() const noexcept { return __m_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __m_ >= 1 && __m_ <= 12; }
+  constexpr month& operator+=(const months& __m1) noexcept;
+  constexpr month& operator-=(const months& __m1) noexcept;
+  explicit inline constexpr operator unsigned() const noexcept { return __m_; }
+  [[nodiscard]] inline constexpr bool ok() const noexcept { return __m_ >= 1 && __m_ <= 12; }
 };
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr bool operator==(const month& __lhs, const month& __rhs) noexcept {
+inline constexpr bool operator==(const month& __lhs, const month& __rhs) noexcept {
   return static_cast<unsigned>(__lhs) == static_cast<unsigned>(__rhs);
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr strong_ordering operator<=>(const month& __lhs, const month& __rhs) noexcept {
+inline constexpr strong_ordering operator<=>(const month& __lhs, const month& __rhs) noexcept {
   return static_cast<unsigned>(__lhs) <=> static_cast<unsigned>(__rhs);
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month operator+(const month& __lhs, const months& __rhs) noexcept {
+[[nodiscard]] inline constexpr month operator+(const month& __lhs, const months& __rhs) noexcept {
   auto const __mu = static_cast<long long>(static_cast<unsigned>(__lhs)) + (__rhs.count() - 1);
   auto const __yr = (__mu >= 0 ? __mu : __mu - 11) / 12;
   return month{static_cast<unsigned>(__mu - __yr * 12 + 1)};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month operator+(const months& __lhs, const month& __rhs) noexcept {
+[[nodiscard]] inline constexpr month operator+(const months& __lhs, const month& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month operator-(const month& __lhs, const months& __rhs) noexcept {
+[[nodiscard]] inline constexpr month operator-(const month& __lhs, const months& __rhs) noexcept {
   return __lhs + -__rhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr months operator-(const month& __lhs, const month& __rhs) noexcept {
+[[nodiscard]] inline constexpr months operator-(const month& __lhs, const month& __rhs) noexcept {
   auto const __dm = static_cast<unsigned>(__lhs) - static_cast<unsigned>(__rhs);
   return months(__dm <= 11 ? __dm : __dm + 12);
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr month& month::operator+=(const months& __dm) noexcept {
+inline constexpr month& month::operator+=(const months& __dm) noexcept {
   *this = *this + __dm;
   return *this;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr month& month::operator-=(const months& __dm) noexcept {
+inline constexpr month& month::operator-=(const months& __dm) noexcept {
   *this = *this - __dm;
   return *this;
 }
@@ -114,9 +113,7 @@ inline constexpr month December{12};
 
 template <>
 struct hash<chrono::month> {
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::month& __m) noexcept {
-    return static_cast<unsigned>(__m);
-  }
+  [[nodiscard]] static size_t operator()(const chrono::month& __m) noexcept { return static_cast<unsigned>(__m); }
 };
 
 #  endif // _LIBCPP_STD_VER >= 26

--- a/libcxx/include/__chrono/month_weekday.h
+++ b/libcxx/include/__chrono/month_weekday.h
@@ -32,38 +32,30 @@ private:
   chrono::weekday_indexed __wdi_;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI constexpr month_weekday(const chrono::month& __mval,
-                                                const chrono::weekday_indexed& __wdival) noexcept
+  constexpr month_weekday(const chrono::month& __mval, const chrono::weekday_indexed& __wdival) noexcept
       : __m_{__mval}, __wdi_{__wdival} {}
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::weekday_indexed weekday_indexed() const noexcept {
-    return __wdi_;
-  }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __m_.ok() && __wdi_.ok(); }
+  [[nodiscard]] inline constexpr chrono::month month() const noexcept { return __m_; }
+  [[nodiscard]] inline constexpr chrono::weekday_indexed weekday_indexed() const noexcept { return __wdi_; }
+  [[nodiscard]] inline constexpr bool ok() const noexcept { return __m_.ok() && __wdi_.ok(); }
 };
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr bool
-operator==(const month_weekday& __lhs, const month_weekday& __rhs) noexcept {
+inline constexpr bool operator==(const month_weekday& __lhs, const month_weekday& __rhs) noexcept {
   return __lhs.month() == __rhs.month() && __lhs.weekday_indexed() == __rhs.weekday_indexed();
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday
-operator/(const month& __lhs, const weekday_indexed& __rhs) noexcept {
+[[nodiscard]] inline constexpr month_weekday operator/(const month& __lhs, const weekday_indexed& __rhs) noexcept {
   return month_weekday{__lhs, __rhs};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday
-operator/(int __lhs, const weekday_indexed& __rhs) noexcept {
+[[nodiscard]] inline constexpr month_weekday operator/(int __lhs, const weekday_indexed& __rhs) noexcept {
   return month_weekday{month(__lhs), __rhs};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday
-operator/(const weekday_indexed& __lhs, const month& __rhs) noexcept {
+[[nodiscard]] inline constexpr month_weekday operator/(const weekday_indexed& __lhs, const month& __rhs) noexcept {
   return month_weekday{__rhs, __lhs};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday
-operator/(const weekday_indexed& __lhs, int __rhs) noexcept {
+[[nodiscard]] inline constexpr month_weekday operator/(const weekday_indexed& __lhs, int __rhs) noexcept {
   return month_weekday{month(__rhs), __lhs};
 }
 
@@ -72,38 +64,30 @@ class month_weekday_last {
   chrono::weekday_last __wdl_;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI constexpr month_weekday_last(const chrono::month& __mval,
-                                                     const chrono::weekday_last& __wdlval) noexcept
+  constexpr month_weekday_last(const chrono::month& __mval, const chrono::weekday_last& __wdlval) noexcept
       : __m_{__mval}, __wdl_{__wdlval} {}
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::weekday_last weekday_last() const noexcept {
-    return __wdl_;
-  }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __m_.ok() && __wdl_.ok(); }
+  [[nodiscard]] inline constexpr chrono::month month() const noexcept { return __m_; }
+  [[nodiscard]] inline constexpr chrono::weekday_last weekday_last() const noexcept { return __wdl_; }
+  [[nodiscard]] inline constexpr bool ok() const noexcept { return __m_.ok() && __wdl_.ok(); }
 };
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr bool
-operator==(const month_weekday_last& __lhs, const month_weekday_last& __rhs) noexcept {
+inline constexpr bool operator==(const month_weekday_last& __lhs, const month_weekday_last& __rhs) noexcept {
   return __lhs.month() == __rhs.month() && __lhs.weekday_last() == __rhs.weekday_last();
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday_last
-operator/(const month& __lhs, const weekday_last& __rhs) noexcept {
+[[nodiscard]] inline constexpr month_weekday_last operator/(const month& __lhs, const weekday_last& __rhs) noexcept {
   return month_weekday_last{__lhs, __rhs};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday_last
-operator/(int __lhs, const weekday_last& __rhs) noexcept {
+[[nodiscard]] inline constexpr month_weekday_last operator/(int __lhs, const weekday_last& __rhs) noexcept {
   return month_weekday_last{month(__lhs), __rhs};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday_last
-operator/(const weekday_last& __lhs, const month& __rhs) noexcept {
+[[nodiscard]] inline constexpr month_weekday_last operator/(const weekday_last& __lhs, const month& __rhs) noexcept {
   return month_weekday_last{__rhs, __lhs};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday_last
-operator/(const weekday_last& __lhs, int __rhs) noexcept {
+[[nodiscard]] inline constexpr month_weekday_last operator/(const weekday_last& __lhs, int __rhs) noexcept {
   return month_weekday_last{month(__rhs), __lhs};
 }
 } // namespace chrono
@@ -112,7 +96,7 @@ operator/(const weekday_last& __lhs, int __rhs) noexcept {
 
 template <>
 struct hash<chrono::month_weekday> {
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::month_weekday& __mw) noexcept {
+  [[nodiscard]] static size_t operator()(const chrono::month_weekday& __mw) noexcept {
     return std::__hash_combine(
         hash<chrono::month>{}(__mw.month()), hash<chrono::weekday_indexed>{}(__mw.weekday_indexed()));
   }
@@ -120,7 +104,7 @@ struct hash<chrono::month_weekday> {
 
 template <>
 struct hash<chrono::month_weekday_last> {
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::month_weekday_last& __mwl) noexcept {
+  [[nodiscard]] static size_t operator()(const chrono::month_weekday_last& __mwl) noexcept {
     return std::__hash_combine(
         hash<chrono::month>{}(__mwl.month()), hash<chrono::weekday_last>{}(__mwl.weekday_last()));
   }

--- a/libcxx/include/__chrono/monthday.h
+++ b/libcxx/include/__chrono/monthday.h
@@ -35,14 +35,13 @@ private:
 
 public:
   month_day() = default;
-  _LIBCPP_HIDE_FROM_ABI constexpr month_day(const chrono::month& __mval, const chrono::day& __dval) noexcept
-      : __m_{__mval}, __d_{__dval} {}
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::day day() const noexcept { return __d_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool ok() const noexcept;
+  constexpr month_day(const chrono::month& __mval, const chrono::day& __dval) noexcept : __m_{__mval}, __d_{__dval} {}
+  [[nodiscard]] inline constexpr chrono::month month() const noexcept { return __m_; }
+  [[nodiscard]] inline constexpr chrono::day day() const noexcept { return __d_; }
+  [[nodiscard]] constexpr bool ok() const noexcept;
 };
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr bool month_day::ok() const noexcept {
+inline constexpr bool month_day::ok() const noexcept {
   if (!__m_.ok())
     return false;
   const unsigned __dval = static_cast<unsigned>(__d_);
@@ -59,36 +58,33 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr bool month_day::ok() const noexcept {
   return true;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr bool operator==(const month_day& __lhs, const month_day& __rhs) noexcept {
+inline constexpr bool operator==(const month_day& __lhs, const month_day& __rhs) noexcept {
   return __lhs.month() == __rhs.month() && __lhs.day() == __rhs.day();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr strong_ordering
-operator<=>(const month_day& __lhs, const month_day& __rhs) noexcept {
+inline constexpr strong_ordering operator<=>(const month_day& __lhs, const month_day& __rhs) noexcept {
   if (auto __c = __lhs.month() <=> __rhs.month(); __c != 0)
     return __c;
   return __lhs.day() <=> __rhs.day();
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_day
-operator/(const month& __lhs, const day& __rhs) noexcept {
+[[nodiscard]] inline constexpr month_day operator/(const month& __lhs, const day& __rhs) noexcept {
   return month_day{__lhs, __rhs};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_day
-operator/(const day& __lhs, const month& __rhs) noexcept {
+[[nodiscard]] inline constexpr month_day operator/(const day& __lhs, const month& __rhs) noexcept {
   return __rhs / __lhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_day operator/(const month& __lhs, int __rhs) noexcept {
+[[nodiscard]] inline constexpr month_day operator/(const month& __lhs, int __rhs) noexcept {
   return __lhs / day(__rhs);
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_day operator/(int __lhs, const day& __rhs) noexcept {
+[[nodiscard]] inline constexpr month_day operator/(int __lhs, const day& __rhs) noexcept {
   return month(__lhs) / __rhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_day operator/(const day& __lhs, int __rhs) noexcept {
+[[nodiscard]] inline constexpr month_day operator/(const day& __lhs, int __rhs) noexcept {
   return month(__rhs) / __lhs;
 }
 
@@ -97,34 +93,32 @@ private:
   chrono::month __m_;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI explicit constexpr month_day_last(const chrono::month& __val) noexcept : __m_{__val} {}
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __m_.ok(); }
+  explicit constexpr month_day_last(const chrono::month& __val) noexcept : __m_{__val} {}
+  [[nodiscard]] inline constexpr chrono::month month() const noexcept { return __m_; }
+  [[nodiscard]] inline constexpr bool ok() const noexcept { return __m_.ok(); }
 };
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr bool
-operator==(const month_day_last& __lhs, const month_day_last& __rhs) noexcept {
+inline constexpr bool operator==(const month_day_last& __lhs, const month_day_last& __rhs) noexcept {
   return __lhs.month() == __rhs.month();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr strong_ordering
-operator<=>(const month_day_last& __lhs, const month_day_last& __rhs) noexcept {
+inline constexpr strong_ordering operator<=>(const month_day_last& __lhs, const month_day_last& __rhs) noexcept {
   return __lhs.month() <=> __rhs.month();
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_day_last operator/(const month& __lhs, last_spec) noexcept {
+[[nodiscard]] inline constexpr month_day_last operator/(const month& __lhs, last_spec) noexcept {
   return month_day_last{__lhs};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_day_last operator/(last_spec, const month& __rhs) noexcept {
+[[nodiscard]] inline constexpr month_day_last operator/(last_spec, const month& __rhs) noexcept {
   return month_day_last{__rhs};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_day_last operator/(int __lhs, last_spec) noexcept {
+[[nodiscard]] inline constexpr month_day_last operator/(int __lhs, last_spec) noexcept {
   return month_day_last{month(__lhs)};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_day_last operator/(last_spec, int __rhs) noexcept {
+[[nodiscard]] inline constexpr month_day_last operator/(last_spec, int __rhs) noexcept {
   return month_day_last{month(__rhs)};
 }
 
@@ -134,14 +128,14 @@ operator<=>(const month_day_last& __lhs, const month_day_last& __rhs) noexcept {
 
 template <>
 struct hash<chrono::month_day> {
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::month_day& __md) noexcept {
+  [[nodiscard]] static size_t operator()(const chrono::month_day& __md) noexcept {
     return std::__hash_combine(hash<chrono::month>{}(__md.month()), hash<chrono::day>{}(__md.day()));
   }
 };
 
 template <>
 struct hash<chrono::month_day_last> {
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::month_day_last& __mdl) noexcept {
+  [[nodiscard]] static size_t operator()(const chrono::month_day_last& __mdl) noexcept {
     return hash<chrono::month>{}(__mdl.month());
   }
 };

--- a/libcxx/include/__chrono/ostream.h
+++ b/libcxx/include/__chrono/ostream.h
@@ -53,14 +53,12 @@ namespace chrono {
 
 template <class _CharT, class _Traits, class _Duration>
   requires(!treat_as_floating_point_v<typename _Duration::rep> && _Duration{1} < days{1})
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const sys_time<_Duration>& __tp) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const sys_time<_Duration>& __tp) {
   return __os << std::format(__os.getloc(), _LIBCPP_STATICALLY_WIDEN(_CharT, "{:L%F %T}"), __tp);
 }
 
 template <class _CharT, class _Traits>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const sys_days& __dp) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const sys_days& __dp) {
   return __os << year_month_day{__dp};
 }
 
@@ -68,20 +66,17 @@ operator<<(basic_ostream<_CharT, _Traits>& __os, const sys_days& __dp) {
 #      if _LIBCPP_HAS_EXPERIMENTAL_TZDB
 
 template <class _CharT, class _Traits, class _Duration>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const utc_time<_Duration>& __tp) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const utc_time<_Duration>& __tp) {
   return __os << std::format(__os.getloc(), _LIBCPP_STATICALLY_WIDEN(_CharT, "{:L%F %T}"), __tp);
 }
 
 template <class _CharT, class _Traits, class _Duration>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const tai_time<_Duration>& __tp) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const tai_time<_Duration>& __tp) {
   return __os << std::format(__os.getloc(), _LIBCPP_STATICALLY_WIDEN(_CharT, "{:L%F %T}"), __tp);
 }
 
 template <class _CharT, class _Traits, class _Duration>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const gps_time<_Duration>& __tp) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const gps_time<_Duration>& __tp) {
   return __os << std::format(__os.getloc(), _LIBCPP_STATICALLY_WIDEN(_CharT, "{:L%F %T}"), __tp);
 }
 
@@ -89,20 +84,18 @@ operator<<(basic_ostream<_CharT, _Traits>& __os, const gps_time<_Duration>& __tp
 #    endif   // _LIBCPP_HAS_TIME_ZONE_DATABASE && _LIBCPP_HAS_FILESYSTEM
 
 template <class _CharT, class _Traits, class _Duration>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const file_time<_Duration> __tp) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const file_time<_Duration> __tp) {
   return __os << std::format(__os.getloc(), _LIBCPP_STATICALLY_WIDEN(_CharT, "{:L%F %T}"), __tp);
 }
 
 template <class _CharT, class _Traits, class _Duration>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const local_time<_Duration> __tp) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const local_time<_Duration> __tp) {
   return __os << sys_time<_Duration>{__tp.time_since_epoch()};
 }
 
 // Depending on the type the return is a const _CharT* or a basic_string<_CharT>
 template <class _CharT, class _Period>
-_LIBCPP_HIDE_FROM_ABI auto __units_suffix() {
+auto __units_suffix() {
   // TODO FMT LWG issue the suffixes are always char and not STATICALLY-WIDEN'ed.
   if constexpr (same_as<typename _Period::type, atto>)
     return _LIBCPP_STATICALLY_WIDEN(_CharT, "as");
@@ -155,8 +148,7 @@ _LIBCPP_HIDE_FROM_ABI auto __units_suffix() {
 }
 
 template <class _CharT, class _Traits, class _Rep, class _Period>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const duration<_Rep, _Period>& __d) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const duration<_Rep, _Period>& __d) {
   basic_ostringstream<_CharT, _Traits> __s;
   __s.flags(__os.flags());
   __s.imbue(__os.getloc());
@@ -166,7 +158,7 @@ operator<<(basic_ostream<_CharT, _Traits>& __os, const duration<_Rep, _Period>& 
 }
 
 template <class _CharT, class _Traits>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const day& __d) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const day& __d) {
   return __os << (__d.ok() ? std::format(_LIBCPP_STATICALLY_WIDEN(_CharT, "{:%d}"), __d)
                            // Note this error differs from the wording of the Standard. The
                            // Standard wording doesn't work well on AIX or Windows. There
@@ -178,8 +170,7 @@ _LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_
 }
 
 template <class _CharT, class _Traits>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const month& __m) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const month& __m) {
   return __os << (__m.ok() ? std::format(__os.getloc(), _LIBCPP_STATICALLY_WIDEN(_CharT, "{:L%b}"), __m)
                            : std::format(__os.getloc(),
                                          _LIBCPP_STATICALLY_WIDEN(_CharT, "{} is not a valid month"),
@@ -187,15 +178,13 @@ operator<<(basic_ostream<_CharT, _Traits>& __os, const month& __m) {
 }
 
 template <class _CharT, class _Traits>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const year& __y) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const year& __y) {
   return __os << (__y.ok() ? std::format(_LIBCPP_STATICALLY_WIDEN(_CharT, "{:%Y}"), __y)
                            : std::format(_LIBCPP_STATICALLY_WIDEN(_CharT, "{:%Y} is not a valid year"), __y));
 }
 
 template <class _CharT, class _Traits>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const weekday& __wd) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const weekday& __wd) {
   return __os << (__wd.ok() ? std::format(__os.getloc(), _LIBCPP_STATICALLY_WIDEN(_CharT, "{:L%a}"), __wd)
                             : std::format(__os.getloc(), // TODO FMT Standard mandated locale isn't used.
                                           _LIBCPP_STATICALLY_WIDEN(_CharT, "{} is not a valid weekday"),
@@ -203,8 +192,7 @@ operator<<(basic_ostream<_CharT, _Traits>& __os, const weekday& __wd) {
 }
 
 template <class _CharT, class _Traits>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const weekday_indexed& __wdi) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const weekday_indexed& __wdi) {
   auto __i = __wdi.index();
   return __os << (__i >= 1 && __i <= 5
                       ? std::format(__os.getloc(), _LIBCPP_STATICALLY_WIDEN(_CharT, "{:L}[{}]"), __wdi.weekday(), __i)
@@ -215,62 +203,53 @@ operator<<(basic_ostream<_CharT, _Traits>& __os, const weekday_indexed& __wdi) {
 }
 
 template <class _CharT, class _Traits>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const weekday_last& __wdl) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const weekday_last& __wdl) {
   return __os << std::format(__os.getloc(), _LIBCPP_STATICALLY_WIDEN(_CharT, "{:L}[last]"), __wdl.weekday());
 }
 
 template <class _CharT, class _Traits>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const month_day& __md) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const month_day& __md) {
   // TODO FMT The Standard allows 30th of February to be printed.
   // It would be nice to show an error message instead.
   return __os << std::format(__os.getloc(), _LIBCPP_STATICALLY_WIDEN(_CharT, "{:L}/{}"), __md.month(), __md.day());
 }
 
 template <class _CharT, class _Traits>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const month_day_last& __mdl) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const month_day_last& __mdl) {
   return __os << std::format(__os.getloc(), _LIBCPP_STATICALLY_WIDEN(_CharT, "{:L}/last"), __mdl.month());
 }
 
 template <class _CharT, class _Traits>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const month_weekday& __mwd) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const month_weekday& __mwd) {
   return __os << std::format(
              __os.getloc(), _LIBCPP_STATICALLY_WIDEN(_CharT, "{:L}/{:L}"), __mwd.month(), __mwd.weekday_indexed());
 }
 
 template <class _CharT, class _Traits>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const month_weekday_last& __mwdl) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const month_weekday_last& __mwdl) {
   return __os << std::format(
              __os.getloc(), _LIBCPP_STATICALLY_WIDEN(_CharT, "{:L}/{:L}"), __mwdl.month(), __mwdl.weekday_last());
 }
 
 template <class _CharT, class _Traits>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const year_month& __ym) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const year_month& __ym) {
   return __os << std::format(__os.getloc(), _LIBCPP_STATICALLY_WIDEN(_CharT, "{}/{:L}"), __ym.year(), __ym.month());
 }
 
 template <class _CharT, class _Traits>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const year_month_day& __ymd) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const year_month_day& __ymd) {
   return __os << (__ymd.ok() ? std::format(_LIBCPP_STATICALLY_WIDEN(_CharT, "{:%F}"), __ymd)
                              : std::format(_LIBCPP_STATICALLY_WIDEN(_CharT, "{:%F} is not a valid date"), __ymd));
 }
 
 template <class _CharT, class _Traits>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const year_month_day_last& __ymdl) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const year_month_day_last& __ymdl) {
   return __os << std::format(
              __os.getloc(), _LIBCPP_STATICALLY_WIDEN(_CharT, "{}/{:L}"), __ymdl.year(), __ymdl.month_day_last());
 }
 
 template <class _CharT, class _Traits>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const year_month_weekday& __ymwd) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const year_month_weekday& __ymwd) {
   return __os << std::format(
              __os.getloc(),
              _LIBCPP_STATICALLY_WIDEN(_CharT, "{}/{:L}/{:L}"),
@@ -280,7 +259,7 @@ operator<<(basic_ostream<_CharT, _Traits>& __os, const year_month_weekday& __ymw
 }
 
 template <class _CharT, class _Traits>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
+basic_ostream<_CharT, _Traits>&
 operator<<(basic_ostream<_CharT, _Traits>& __os, const year_month_weekday_last& __ymwdl) {
   return __os << std::format(
              __os.getloc(),
@@ -291,16 +270,14 @@ operator<<(basic_ostream<_CharT, _Traits>& __os, const year_month_weekday_last& 
 }
 
 template <class _CharT, class _Traits, class _Duration>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const hh_mm_ss<_Duration> __hms) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const hh_mm_ss<_Duration> __hms) {
   return __os << std::format(__os.getloc(), _LIBCPP_STATICALLY_WIDEN(_CharT, "{:L%T}"), __hms);
 }
 
 #    if _LIBCPP_HAS_EXPERIMENTAL_TZDB
 
 template <class _CharT, class _Traits>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const sys_info& __info) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const sys_info& __info) {
   // __info.abbrev is always std::basic_string<char>.
   // Since these strings typically are short the conversion should be cheap.
   std::basic_string<_CharT> __abbrev{__info.abbrev.begin(), __info.abbrev.end()};
@@ -314,8 +291,7 @@ operator<<(basic_ostream<_CharT, _Traits>& __os, const sys_info& __info) {
 }
 
 template <class _CharT, class _Traits>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-operator<<(basic_ostream<_CharT, _Traits>& __os, const local_info& __info) {
+basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, const local_info& __info) {
   auto __result = [&]() -> basic_string<_CharT> {
     switch (__info.result) {
     case local_info::unique:
@@ -336,7 +312,7 @@ operator<<(basic_ostream<_CharT, _Traits>& __os, const local_info& __info) {
 
 #      if _LIBCPP_HAS_TIME_ZONE_DATABASE && _LIBCPP_HAS_FILESYSTEM
 template <class _CharT, class _Traits, class _Duration, class _TimeZonePtr>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
+basic_ostream<_CharT, _Traits>&
 operator<<(basic_ostream<_CharT, _Traits>& __os, const zoned_time<_Duration, _TimeZonePtr>& __tp) {
   return __os << std::format(__os.getloc(), _LIBCPP_STATICALLY_WIDEN(_CharT, "{:L%F %T %Z}"), __tp);
 }

--- a/libcxx/include/__chrono/parser_std_format_spec.h
+++ b/libcxx/include/__chrono/parser_std_format_spec.h
@@ -69,71 +69,71 @@ enum class __flags {
   __clock = __date_time | __time_zone
 };
 
-_LIBCPP_HIDE_FROM_ABI constexpr __flags operator&(__flags __lhs, __flags __rhs) {
+constexpr __flags operator&(__flags __lhs, __flags __rhs) {
   return static_cast<__flags>(static_cast<unsigned>(__lhs) & static_cast<unsigned>(__rhs));
 }
 
-_LIBCPP_HIDE_FROM_ABI constexpr void __validate_second(__flags __flags) {
+constexpr void __validate_second(__flags __flags) {
   if ((__flags & __flags::__second) != __flags::__second)
     std::__throw_format_error("The supplied date time doesn't contain a second");
 }
 
-_LIBCPP_HIDE_FROM_ABI constexpr void __validate_minute(__flags __flags) {
+constexpr void __validate_minute(__flags __flags) {
   if ((__flags & __flags::__minute) != __flags::__minute)
     std::__throw_format_error("The supplied date time doesn't contain a minute");
 }
 
-_LIBCPP_HIDE_FROM_ABI constexpr void __validate_hour(__flags __flags) {
+constexpr void __validate_hour(__flags __flags) {
   if ((__flags & __flags::__hour) != __flags::__hour)
     std::__throw_format_error("The supplied date time doesn't contain an hour");
 }
 
-_LIBCPP_HIDE_FROM_ABI constexpr void __validate_time(__flags __flags) {
+constexpr void __validate_time(__flags __flags) {
   if ((__flags & __flags::__time) != __flags::__time)
     std::__throw_format_error("The supplied date time doesn't contain a time");
 }
 
-_LIBCPP_HIDE_FROM_ABI constexpr void __validate_day(__flags __flags) {
+constexpr void __validate_day(__flags __flags) {
   if ((__flags & __flags::__day) != __flags::__day)
     std::__throw_format_error("The supplied date time doesn't contain a day");
 }
 
-_LIBCPP_HIDE_FROM_ABI constexpr void __validate_month(__flags __flags) {
+constexpr void __validate_month(__flags __flags) {
   if ((__flags & __flags::__month) != __flags::__month)
     std::__throw_format_error("The supplied date time doesn't contain a month");
 }
 
-_LIBCPP_HIDE_FROM_ABI constexpr void __validate_year(__flags __flags) {
+constexpr void __validate_year(__flags __flags) {
   if ((__flags & __flags::__year) != __flags::__year)
     std::__throw_format_error("The supplied date time doesn't contain a year");
 }
 
-_LIBCPP_HIDE_FROM_ABI constexpr void __validate_date(__flags __flags) {
+constexpr void __validate_date(__flags __flags) {
   if ((__flags & __flags::__date) != __flags::__date)
     std::__throw_format_error("The supplied date time doesn't contain a date");
 }
 
-_LIBCPP_HIDE_FROM_ABI constexpr void __validate_date_or_duration(__flags __flags) {
+constexpr void __validate_date_or_duration(__flags __flags) {
   if (((__flags & __flags::__date) != __flags::__date) && ((__flags & __flags::__duration) != __flags::__duration))
     std::__throw_format_error("The supplied date time doesn't contain a date or duration");
 }
 
-_LIBCPP_HIDE_FROM_ABI constexpr void __validate_date_time(__flags __flags) {
+constexpr void __validate_date_time(__flags __flags) {
   if ((__flags & __flags::__date_time) != __flags::__date_time)
     std::__throw_format_error("The supplied date time doesn't contain a date and time");
 }
 
-_LIBCPP_HIDE_FROM_ABI constexpr void __validate_weekday(__flags __flags) {
+constexpr void __validate_weekday(__flags __flags) {
   if ((__flags & __flags::__weekday) != __flags::__weekday)
     std::__throw_format_error("The supplied date time doesn't contain a weekday");
 }
 
-_LIBCPP_HIDE_FROM_ABI constexpr void __validate_duration(__flags __flags) {
+constexpr void __validate_duration(__flags __flags) {
   if ((__flags & __flags::__duration) != __flags::__duration)
     std::__throw_format_error("The supplied date time doesn't contain a duration");
 }
 
-_LIBCPP_HIDE_FROM_ABI constexpr void __validate_time_zone(__flags __flags) {
+constexpr void __validate_time_zone(__flags __flags) {
   if ((__flags & __flags::__time_zone) != __flags::__time_zone)
     std::__throw_format_error("The supplied date time doesn't contain a time zone");
 }
@@ -144,8 +144,7 @@ class __parser_chrono {
 
 public:
   template <class _ParseContext>
-  _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator
-  __parse(_ParseContext& __ctx, __fields __fields, __flags __flags) {
+  constexpr typename _ParseContext::iterator __parse(_ParseContext& __ctx, __fields __fields, __flags __flags) {
     _ConstIterator __begin = __parser_.__parse(__ctx, __fields);
     _ConstIterator __end   = __ctx.end();
     if (__begin == __end)
@@ -161,8 +160,7 @@ public:
   basic_string_view<_CharT> __chrono_specs_;
 
 private:
-  _LIBCPP_HIDE_FROM_ABI constexpr _ConstIterator
-  __parse_chrono_specs(_ConstIterator __begin, _ConstIterator __end, __flags __flags) {
+  constexpr _ConstIterator __parse_chrono_specs(_ConstIterator __begin, _ConstIterator __end, __flags __flags) {
     _LIBCPP_ASSERT_INTERNAL(__begin != __end,
                             "When called with an empty input the function will cause "
                             "undefined behavior by evaluating data not in the input");
@@ -194,8 +192,7 @@ private:
 
   /// \pre *__begin == '%'
   /// \post __begin points at the end parsed conversion-spec
-  _LIBCPP_HIDE_FROM_ABI constexpr void
-  __parse_conversion_spec(_ConstIterator& __begin, _ConstIterator __end, __flags __flags) {
+  constexpr void __parse_conversion_spec(_ConstIterator& __begin, _ConstIterator __end, __flags __flags) {
     ++__begin;
     if (__begin == __end)
       std::__throw_format_error("End of input while parsing a conversion specifier");
@@ -310,8 +307,7 @@ private:
 
   /// \pre *__begin == 'E'
   /// \post __begin is incremented by one.
-  _LIBCPP_HIDE_FROM_ABI constexpr void
-  __parse_modifier_E(_ConstIterator& __begin, _ConstIterator __end, __flags __flags) {
+  constexpr void __parse_modifier_E(_ConstIterator& __begin, _ConstIterator __end, __flags __flags) {
     ++__begin;
     if (__begin == __end)
       std::__throw_format_error("End of input while parsing the modifier E");
@@ -350,8 +346,7 @@ private:
 
   /// \pre *__begin == 'O'
   /// \post __begin is incremented by one.
-  _LIBCPP_HIDE_FROM_ABI constexpr void
-  __parse_modifier_O(_ConstIterator& __begin, _ConstIterator __end, __flags __flags) {
+  constexpr void __parse_modifier_O(_ConstIterator& __begin, _ConstIterator __end, __flags __flags) {
     ++__begin;
     if (__begin == __end)
       std::__throw_format_error("End of input while parsing the modifier O");

--- a/libcxx/include/__chrono/statically_widen.h
+++ b/libcxx/include/__chrono/statically_widen.h
@@ -26,7 +26,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
 template <__fmt_char_type _CharT>
-_LIBCPP_HIDE_FROM_ABI constexpr const _CharT* __statically_widen(const char* __str, const wchar_t* __wstr) {
+constexpr const _CharT* __statically_widen(const char* __str, const wchar_t* __wstr) {
   if constexpr (same_as<_CharT, char>)
     return __str;
   else
@@ -39,7 +39,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr const _CharT* __statically_widen(const char* __s
 // fails for the CI build "No wide characters". This seems like a bug.
 // TODO FMT investigate why this is needed.
 template <__fmt_char_type _CharT>
-_LIBCPP_HIDE_FROM_ABI constexpr const _CharT* __statically_widen(const char* __str) {
+constexpr const _CharT* __statically_widen(const char* __str) {
   return __str;
 }
 #    define _LIBCPP_STATICALLY_WIDEN(_CharT, __str) ::std::__statically_widen<_CharT>(__str)

--- a/libcxx/include/__chrono/tai_clock.h
+++ b/libcxx/include/__chrono/tai_clock.h
@@ -69,11 +69,10 @@ public:
   // The static difference between UTC and TAI time.
   static constexpr chrono::seconds __offset{378691210};
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static time_point now() { return from_utc(utc_clock::now()); }
+  [[nodiscard]] static time_point now() { return from_utc(utc_clock::now()); }
 
   template <class _Duration>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static utc_time<common_type_t<_Duration, seconds>>
-  to_utc(const tai_time<_Duration>& __time) noexcept {
+  [[nodiscard]] static utc_time<common_type_t<_Duration, seconds>> to_utc(const tai_time<_Duration>& __time) noexcept {
     using _Rp                    = common_type_t<_Duration, seconds>;
     _Duration __time_since_epoch = __time.time_since_epoch();
     _LIBCPP_ASSERT_ARGUMENT_WITHIN_DOMAIN(__time_since_epoch >= utc_time<_Rp>::min().time_since_epoch() + __offset,
@@ -83,7 +82,7 @@ public:
   }
 
   template <class _Duration>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static tai_time<common_type_t<_Duration, seconds>>
+  [[nodiscard]] static tai_time<common_type_t<_Duration, seconds>>
   from_utc(const utc_time<_Duration>& __time) noexcept {
     using _Rp                    = common_type_t<_Duration, seconds>;
     _Duration __time_since_epoch = __time.time_since_epoch();

--- a/libcxx/include/__chrono/time_point.h
+++ b/libcxx/include/__chrono/time_point.h
@@ -46,52 +46,45 @@ private:
   duration __d_;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 time_point() : __d_(duration::zero()) {}
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit time_point(const duration& __d) : __d_(__d) {}
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 time_point() : __d_(duration::zero()) {}
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit time_point(const duration& __d) : __d_(__d) {}
 
   // conversions
   template <class _Duration2, __enable_if_t<is_convertible<_Duration2, duration>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 time_point(const time_point<clock, _Duration2>& __t)
-      : __d_(__t.time_since_epoch()) {}
+  _LIBCPP_CONSTEXPR_SINCE_CXX14 time_point(const time_point<clock, _Duration2>& __t) : __d_(__t.time_since_epoch()) {}
 
   // observer
 
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 duration time_since_epoch() const {
-    return __d_;
-  }
+  [[__nodiscard__]] _LIBCPP_CONSTEXPR_SINCE_CXX14 duration time_since_epoch() const { return __d_; }
 
   // arithmetic
 
 #if _LIBCPP_STD_VER >= 20
-  _LIBCPP_HIDE_FROM_ABI constexpr time_point& operator++() {
+  constexpr time_point& operator++() {
     ++__d_;
     return *this;
   }
-  _LIBCPP_HIDE_FROM_ABI constexpr time_point operator++(int) { return time_point{__d_++}; }
-  _LIBCPP_HIDE_FROM_ABI constexpr time_point& operator--() {
+  constexpr time_point operator++(int) { return time_point{__d_++}; }
+  constexpr time_point& operator--() {
     --__d_;
     return *this;
   }
-  _LIBCPP_HIDE_FROM_ABI constexpr time_point operator--(int) { return time_point{__d_--}; }
+  constexpr time_point operator--(int) { return time_point{__d_--}; }
 #endif // _LIBCPP_STD_VER >= 20
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 time_point& operator+=(const duration& __d) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX17 time_point& operator+=(const duration& __d) {
     __d_ += __d;
     return *this;
   }
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 time_point& operator-=(const duration& __d) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX17 time_point& operator-=(const duration& __d) {
     __d_ -= __d;
     return *this;
   }
 
   // special values
 
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR time_point min() _NOEXCEPT {
-    return time_point(duration::min());
-  }
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR time_point max() _NOEXCEPT {
-    return time_point(duration::max());
-  }
+  [[__nodiscard__]] static _LIBCPP_CONSTEXPR time_point min() _NOEXCEPT { return time_point(duration::min()); }
+  [[__nodiscard__]] static _LIBCPP_CONSTEXPR time_point max() _NOEXCEPT { return time_point(duration::max()); }
 };
 
 } // namespace chrono
@@ -104,32 +97,29 @@ struct common_type<chrono::time_point<_Clock, _Duration1>, chrono::time_point<_C
 namespace chrono {
 
 template <class _ToDuration, class _Clock, class _Duration, __enable_if_t<__is_duration_v<_ToDuration>, int> = 0>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 time_point<_Clock, _ToDuration>
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 time_point<_Clock, _ToDuration>
 time_point_cast(const time_point<_Clock, _Duration>& __t) {
   return time_point<_Clock, _ToDuration>(chrono::duration_cast<_ToDuration>(__t.time_since_epoch()));
 }
 
 #if _LIBCPP_STD_VER >= 17
 template <class _ToDuration, class _Clock, class _Duration, enable_if_t<__is_duration_v<_ToDuration>, int> = 0>
-[[nodiscard]] inline
-    _LIBCPP_HIDE_FROM_ABI constexpr time_point<_Clock, _ToDuration> floor(const time_point<_Clock, _Duration>& __t) {
+[[nodiscard]] inline constexpr time_point<_Clock, _ToDuration> floor(const time_point<_Clock, _Duration>& __t) {
   return time_point<_Clock, _ToDuration>{chrono::floor<_ToDuration>(__t.time_since_epoch())};
 }
 
 template <class _ToDuration, class _Clock, class _Duration, enable_if_t<__is_duration_v<_ToDuration>, int> = 0>
-[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI constexpr time_point<_Clock, _ToDuration>
-ceil(const time_point<_Clock, _Duration>& __t) {
+[[nodiscard]] inline constexpr time_point<_Clock, _ToDuration> ceil(const time_point<_Clock, _Duration>& __t) {
   return time_point<_Clock, _ToDuration>{chrono::ceil<_ToDuration>(__t.time_since_epoch())};
 }
 
 template <class _ToDuration, class _Clock, class _Duration, enable_if_t<__is_duration_v<_ToDuration>, int> = 0>
-[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI constexpr time_point<_Clock, _ToDuration>
-round(const time_point<_Clock, _Duration>& __t) {
+[[nodiscard]] inline constexpr time_point<_Clock, _ToDuration> round(const time_point<_Clock, _Duration>& __t) {
   return time_point<_Clock, _ToDuration>{chrono::round<_ToDuration>(__t.time_since_epoch())};
 }
 
 template <class _Rep, class _Period, enable_if_t<numeric_limits<_Rep>::is_signed, int> = 0>
-[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI constexpr duration<_Rep, _Period> abs(duration<_Rep, _Period> __d) {
+[[nodiscard]] inline constexpr duration<_Rep, _Period> abs(duration<_Rep, _Period> __d) {
   return __d >= __d.zero() ? +__d : -__d;
 }
 #endif // _LIBCPP_STD_VER >= 17
@@ -137,7 +127,7 @@ template <class _Rep, class _Period, enable_if_t<numeric_limits<_Rep>::is_signed
 // time_point ==
 
 template <class _Clock, class _Duration1, class _Duration2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
 operator==(const time_point<_Clock, _Duration1>& __lhs, const time_point<_Clock, _Duration2>& __rhs) {
   return __lhs.time_since_epoch() == __rhs.time_since_epoch();
 }
@@ -147,7 +137,7 @@ operator==(const time_point<_Clock, _Duration1>& __lhs, const time_point<_Clock,
 // time_point !=
 
 template <class _Clock, class _Duration1, class _Duration2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
 operator!=(const time_point<_Clock, _Duration1>& __lhs, const time_point<_Clock, _Duration2>& __rhs) {
   return !(__lhs == __rhs);
 }
@@ -157,7 +147,7 @@ operator!=(const time_point<_Clock, _Duration1>& __lhs, const time_point<_Clock,
 // time_point <
 
 template <class _Clock, class _Duration1, class _Duration2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
 operator<(const time_point<_Clock, _Duration1>& __lhs, const time_point<_Clock, _Duration2>& __rhs) {
   return __lhs.time_since_epoch() < __rhs.time_since_epoch();
 }
@@ -165,7 +155,7 @@ operator<(const time_point<_Clock, _Duration1>& __lhs, const time_point<_Clock, 
 // time_point >
 
 template <class _Clock, class _Duration1, class _Duration2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
 operator>(const time_point<_Clock, _Duration1>& __lhs, const time_point<_Clock, _Duration2>& __rhs) {
   return __rhs < __lhs;
 }
@@ -173,7 +163,7 @@ operator>(const time_point<_Clock, _Duration1>& __lhs, const time_point<_Clock, 
 // time_point <=
 
 template <class _Clock, class _Duration1, class _Duration2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
 operator<=(const time_point<_Clock, _Duration1>& __lhs, const time_point<_Clock, _Duration2>& __rhs) {
   return !(__rhs < __lhs);
 }
@@ -181,7 +171,7 @@ operator<=(const time_point<_Clock, _Duration1>& __lhs, const time_point<_Clock,
 // time_point >=
 
 template <class _Clock, class _Duration1, class _Duration2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
+inline _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
 operator>=(const time_point<_Clock, _Duration1>& __lhs, const time_point<_Clock, _Duration2>& __rhs) {
   return !(__lhs < __rhs);
 }
@@ -189,8 +179,7 @@ operator>=(const time_point<_Clock, _Duration1>& __lhs, const time_point<_Clock,
 #if _LIBCPP_STD_VER >= 20
 
 template <class _Clock, class _Duration1, three_way_comparable_with<_Duration1> _Duration2>
-_LIBCPP_HIDE_FROM_ABI constexpr auto
-operator<=>(const time_point<_Clock, _Duration1>& __lhs, const time_point<_Clock, _Duration2>& __rhs) {
+constexpr auto operator<=>(const time_point<_Clock, _Duration1>& __lhs, const time_point<_Clock, _Duration2>& __rhs) {
   return __lhs.time_since_epoch() <=> __rhs.time_since_epoch();
 }
 
@@ -199,9 +188,9 @@ operator<=>(const time_point<_Clock, _Duration1>& __lhs, const time_point<_Clock
 // time_point operator+(time_point x, duration y);
 
 template <class _Clock, class _Duration1, class _Rep2, class _Period2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI
-_LIBCPP_CONSTEXPR_SINCE_CXX14 time_point<_Clock, typename common_type<_Duration1, duration<_Rep2, _Period2> >::type>
-operator+(const time_point<_Clock, _Duration1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
+[[__nodiscard__]] inline
+    _LIBCPP_CONSTEXPR_SINCE_CXX14 time_point<_Clock, typename common_type<_Duration1, duration<_Rep2, _Period2> >::type>
+    operator+(const time_point<_Clock, _Duration1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
   typedef time_point<_Clock, typename common_type<_Duration1, duration<_Rep2, _Period2> >::type> _Tr;
   return _Tr(__lhs.time_since_epoch() + __rhs);
 }
@@ -209,18 +198,18 @@ operator+(const time_point<_Clock, _Duration1>& __lhs, const duration<_Rep2, _Pe
 // time_point operator+(duration x, time_point y);
 
 template <class _Rep1, class _Period1, class _Clock, class _Duration2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI
-_LIBCPP_CONSTEXPR_SINCE_CXX14 time_point<_Clock, typename common_type<duration<_Rep1, _Period1>, _Duration2>::type>
-operator+(const duration<_Rep1, _Period1>& __lhs, const time_point<_Clock, _Duration2>& __rhs) {
+[[__nodiscard__]] inline
+    _LIBCPP_CONSTEXPR_SINCE_CXX14 time_point<_Clock, typename common_type<duration<_Rep1, _Period1>, _Duration2>::type>
+    operator+(const duration<_Rep1, _Period1>& __lhs, const time_point<_Clock, _Duration2>& __rhs) {
   return __rhs + __lhs;
 }
 
 // time_point operator-(time_point x, duration y);
 
 template <class _Clock, class _Duration1, class _Rep2, class _Period2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI
-_LIBCPP_CONSTEXPR_SINCE_CXX14 time_point<_Clock, typename common_type<_Duration1, duration<_Rep2, _Period2> >::type>
-operator-(const time_point<_Clock, _Duration1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
+[[__nodiscard__]] inline
+    _LIBCPP_CONSTEXPR_SINCE_CXX14 time_point<_Clock, typename common_type<_Duration1, duration<_Rep2, _Period2> >::type>
+    operator-(const time_point<_Clock, _Duration1>& __lhs, const duration<_Rep2, _Period2>& __rhs) {
   typedef time_point<_Clock, typename common_type<_Duration1, duration<_Rep2, _Period2> >::type> _Ret;
   return _Ret(__lhs.time_since_epoch() - __rhs);
 }
@@ -228,8 +217,7 @@ operator-(const time_point<_Clock, _Duration1>& __lhs, const duration<_Rep2, _Pe
 // duration operator-(time_point x, time_point y);
 
 template <class _Clock, class _Duration1, class _Duration2>
-[[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
-typename common_type<_Duration1, _Duration2>::type
+[[__nodiscard__]] inline _LIBCPP_CONSTEXPR_SINCE_CXX14 typename common_type<_Duration1, _Duration2>::type
 operator-(const time_point<_Clock, _Duration1>& __lhs, const time_point<_Clock, _Duration2>& __rhs) {
   return __lhs.time_since_epoch() - __rhs.time_since_epoch();
 }
@@ -241,7 +229,7 @@ operator-(const time_point<_Clock, _Duration1>& __lhs, const time_point<_Clock, 
 template <class _Clock, class _Duration>
   requires __has_enabled_hash<_Duration>::value
 struct hash<chrono::time_point<_Clock, _Duration>> {
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::time_point<_Clock, _Duration>& __tp) {
+  [[nodiscard]] static size_t operator()(const chrono::time_point<_Clock, _Duration>& __tp) {
     return hash<_Duration>{}(__tp.time_since_epoch());
   }
 };

--- a/libcxx/include/__chrono/time_zone_link.h
+++ b/libcxx/include/__chrono/time_zone_link.h
@@ -38,14 +38,14 @@ namespace chrono {
 class time_zone_link {
 public:
   [[nodiscard]]
-  _LIBCPP_HIDE_FROM_ABI explicit time_zone_link(__private_constructor_tag, string_view __name, string_view __target)
+  explicit time_zone_link(__private_constructor_tag, string_view __name, string_view __target)
       : __name_{__name}, __target_{__target} {}
 
-  _LIBCPP_HIDE_FROM_ABI time_zone_link(time_zone_link&&)            = default;
-  _LIBCPP_HIDE_FROM_ABI time_zone_link& operator=(time_zone_link&&) = default;
+  time_zone_link(time_zone_link&&)            = default;
+  time_zone_link& operator=(time_zone_link&&) = default;
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI string_view name() const noexcept { return __name_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI string_view target() const noexcept { return __target_; }
+  [[nodiscard]] string_view name() const noexcept { return __name_; }
+  [[nodiscard]] string_view target() const noexcept { return __target_; }
 
 private:
   string __name_;
@@ -55,12 +55,12 @@ private:
   string __target_;
 };
 
-[[nodiscard]] _LIBCPP_AVAILABILITY_TZDB _LIBCPP_HIDE_FROM_ABI inline bool
+[[nodiscard]] _LIBCPP_AVAILABILITY_TZDB inline bool
 operator==(const time_zone_link& __x, const time_zone_link& __y) noexcept {
   return __x.name() == __y.name();
 }
 
-[[nodiscard]] _LIBCPP_AVAILABILITY_TZDB _LIBCPP_HIDE_FROM_ABI inline strong_ordering
+[[nodiscard]] _LIBCPP_AVAILABILITY_TZDB inline strong_ordering
 operator<=>(const time_zone_link& __x, const time_zone_link& __y) noexcept {
   return __x.name() <=> __y.name();
 }

--- a/libcxx/include/__chrono/utc_clock.h
+++ b/libcxx/include/__chrono/utc_clock.h
@@ -47,15 +47,13 @@ public:
   using time_point                = chrono::time_point<utc_clock>;
   static constexpr bool is_steady = false; // The system_clock is not steady.
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static time_point now() { return from_sys(system_clock::now()); }
+  [[nodiscard]] static time_point now() { return from_sys(system_clock::now()); }
 
   template <class _Duration>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static sys_time<common_type_t<_Duration, seconds>>
-  to_sys(const utc_time<_Duration>& __time);
+  [[nodiscard]] static sys_time<common_type_t<_Duration, seconds>> to_sys(const utc_time<_Duration>& __time);
 
   template <class _Duration>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static utc_time<common_type_t<_Duration, seconds>>
-  from_sys(const sys_time<_Duration>& __time) {
+  [[nodiscard]] static utc_time<common_type_t<_Duration, seconds>> from_sys(const sys_time<_Duration>& __time) {
     using _Rp = utc_time<common_type_t<_Duration, seconds>>;
     // TODO TZDB investigate optimizations.
     //
@@ -109,7 +107,7 @@ struct leap_second_info {
 };
 
 template <class _Duration>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI leap_second_info get_leap_second_info(const utc_time<_Duration>& __time) {
+[[nodiscard]] leap_second_info get_leap_second_info(const utc_time<_Duration>& __time) {
   const tzdb& __tzdb = chrono::get_tzdb();
   if (__tzdb.leap_seconds.empty()) [[unlikely]]
     return {false, chrono::seconds{0}};
@@ -133,8 +131,7 @@ template <class _Duration>
 }
 
 template <class _Duration>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI sys_time<common_type_t<_Duration, seconds>>
-utc_clock::to_sys(const utc_time<_Duration>& __time) {
+[[nodiscard]] sys_time<common_type_t<_Duration, seconds>> utc_clock::to_sys(const utc_time<_Duration>& __time) {
   using _Dp               = common_type_t<_Duration, seconds>;
   leap_second_info __info = chrono::get_leap_second_info(__time);
 

--- a/libcxx/include/__chrono/weekday.h
+++ b/libcxx/include/__chrono/weekday.h
@@ -34,85 +34,79 @@ class weekday_last;
 class weekday {
 private:
   unsigned char __wd_;
-  _LIBCPP_HIDE_FROM_ABI static constexpr unsigned char __weekday_from_days(int __days) noexcept;
+  static constexpr unsigned char __weekday_from_days(int __days) noexcept;
 
 public:
   weekday() = default;
-  _LIBCPP_HIDE_FROM_ABI inline explicit constexpr weekday(unsigned __val) noexcept
+  inline explicit constexpr weekday(unsigned __val) noexcept
       : __wd_(static_cast<unsigned char>(__val == 7 ? 0 : __val)) {}
-  _LIBCPP_HIDE_FROM_ABI inline constexpr weekday(const sys_days& __sysd) noexcept
+  inline constexpr weekday(const sys_days& __sysd) noexcept
       : __wd_(__weekday_from_days(__sysd.time_since_epoch().count())) {}
-  _LIBCPP_HIDE_FROM_ABI inline explicit constexpr weekday(const local_days& __locd) noexcept
+  inline explicit constexpr weekday(const local_days& __locd) noexcept
       : __wd_(__weekday_from_days(__locd.time_since_epoch().count())) {}
 
-  _LIBCPP_HIDE_FROM_ABI inline constexpr weekday& operator++() noexcept {
+  inline constexpr weekday& operator++() noexcept {
     __wd_ = (__wd_ == 6 ? 0 : __wd_ + 1);
     return *this;
   }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr weekday operator++(int) noexcept {
+  inline constexpr weekday operator++(int) noexcept {
     weekday __tmp = *this;
     ++(*this);
     return __tmp;
   }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr weekday& operator--() noexcept {
+  inline constexpr weekday& operator--() noexcept {
     __wd_ = (__wd_ == 0 ? 6 : __wd_ - 1);
     return *this;
   }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr weekday operator--(int) noexcept {
+  inline constexpr weekday operator--(int) noexcept {
     weekday __tmp = *this;
     --(*this);
     return __tmp;
   }
-  _LIBCPP_HIDE_FROM_ABI constexpr weekday& operator+=(const days& __dd) noexcept;
-  _LIBCPP_HIDE_FROM_ABI constexpr weekday& operator-=(const days& __dd) noexcept;
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr unsigned c_encoding() const noexcept { return __wd_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr unsigned iso_encoding() const noexcept {
-    return __wd_ == 0u ? 7 : __wd_;
-  }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __wd_ <= 6; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr weekday_indexed operator[](unsigned __index) const noexcept;
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr weekday_last operator[](last_spec) const noexcept;
+  constexpr weekday& operator+=(const days& __dd) noexcept;
+  constexpr weekday& operator-=(const days& __dd) noexcept;
+  [[nodiscard]] inline constexpr unsigned c_encoding() const noexcept { return __wd_; }
+  [[nodiscard]] inline constexpr unsigned iso_encoding() const noexcept { return __wd_ == 0u ? 7 : __wd_; }
+  [[nodiscard]] inline constexpr bool ok() const noexcept { return __wd_ <= 6; }
+  [[nodiscard]] constexpr weekday_indexed operator[](unsigned __index) const noexcept;
+  [[nodiscard]] constexpr weekday_last operator[](last_spec) const noexcept;
 };
 
 // https://howardhinnant.github.io/date_algorithms.html#weekday_from_days
-_LIBCPP_HIDE_FROM_ABI inline constexpr unsigned char weekday::__weekday_from_days(int __days) noexcept {
+inline constexpr unsigned char weekday::__weekday_from_days(int __days) noexcept {
   return static_cast<unsigned char>(static_cast<unsigned>(__days >= -4 ? (__days + 4) % 7 : (__days + 5) % 7 + 6));
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr bool operator==(const weekday& __lhs, const weekday& __rhs) noexcept {
+inline constexpr bool operator==(const weekday& __lhs, const weekday& __rhs) noexcept {
   return __lhs.c_encoding() == __rhs.c_encoding();
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr weekday
-operator+(const weekday& __lhs, const days& __rhs) noexcept {
+[[nodiscard]] inline constexpr weekday operator+(const weekday& __lhs, const days& __rhs) noexcept {
   auto const __mu = static_cast<long long>(__lhs.c_encoding()) + __rhs.count();
   auto const __yr = (__mu >= 0 ? __mu : __mu - 6) / 7;
   return weekday{static_cast<unsigned>(__mu - __yr * 7)};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr weekday
-operator+(const days& __lhs, const weekday& __rhs) noexcept {
+[[nodiscard]] inline constexpr weekday operator+(const days& __lhs, const weekday& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr weekday
-operator-(const weekday& __lhs, const days& __rhs) noexcept {
+[[nodiscard]] inline constexpr weekday operator-(const weekday& __lhs, const days& __rhs) noexcept {
   return __lhs + -__rhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr days
-operator-(const weekday& __lhs, const weekday& __rhs) noexcept {
+[[nodiscard]] inline constexpr days operator-(const weekday& __lhs, const weekday& __rhs) noexcept {
   const int __wdu = __lhs.c_encoding() - __rhs.c_encoding();
   const int __wk  = (__wdu >= 0 ? __wdu : __wdu - 6) / 7;
   return days{__wdu - __wk * 7};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr weekday& weekday::operator+=(const days& __dd) noexcept {
+inline constexpr weekday& weekday::operator+=(const days& __dd) noexcept {
   *this = *this + __dd;
   return *this;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr weekday& weekday::operator-=(const days& __dd) noexcept {
+inline constexpr weekday& weekday::operator-=(const days& __dd) noexcept {
   *this = *this - __dd;
   return *this;
 }
@@ -124,17 +118,14 @@ private:
 
 public:
   weekday_indexed() = default;
-  _LIBCPP_HIDE_FROM_ABI inline constexpr weekday_indexed(const chrono::weekday& __wdval, unsigned __idxval) noexcept
+  inline constexpr weekday_indexed(const chrono::weekday& __wdval, unsigned __idxval) noexcept
       : __wd_{__wdval}, __idx_(__idxval) {}
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::weekday weekday() const noexcept { return __wd_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr unsigned index() const noexcept { return __idx_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept {
-    return __wd_.ok() && __idx_ >= 1 && __idx_ <= 5;
-  }
+  [[nodiscard]] inline constexpr chrono::weekday weekday() const noexcept { return __wd_; }
+  [[nodiscard]] inline constexpr unsigned index() const noexcept { return __idx_; }
+  [[nodiscard]] inline constexpr bool ok() const noexcept { return __wd_.ok() && __idx_ >= 1 && __idx_ <= 5; }
 };
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr bool
-operator==(const weekday_indexed& __lhs, const weekday_indexed& __rhs) noexcept {
+inline constexpr bool operator==(const weekday_indexed& __lhs, const weekday_indexed& __rhs) noexcept {
   return __lhs.weekday() == __rhs.weekday() && __lhs.index() == __rhs.index();
 }
 
@@ -143,22 +134,20 @@ private:
   chrono::weekday __wd_;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI explicit constexpr weekday_last(const chrono::weekday& __val) noexcept : __wd_{__val} {}
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::weekday weekday() const noexcept { return __wd_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool ok() const noexcept { return __wd_.ok(); }
+  explicit constexpr weekday_last(const chrono::weekday& __val) noexcept : __wd_{__val} {}
+  [[nodiscard]] constexpr chrono::weekday weekday() const noexcept { return __wd_; }
+  [[nodiscard]] constexpr bool ok() const noexcept { return __wd_.ok(); }
 };
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr bool operator==(const weekday_last& __lhs, const weekday_last& __rhs) noexcept {
+inline constexpr bool operator==(const weekday_last& __lhs, const weekday_last& __rhs) noexcept {
   return __lhs.weekday() == __rhs.weekday();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr weekday_indexed weekday::operator[](unsigned __index) const noexcept {
+inline constexpr weekday_indexed weekday::operator[](unsigned __index) const noexcept {
   return weekday_indexed{*this, __index};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr weekday_last weekday::operator[](last_spec) const noexcept {
-  return weekday_last{*this};
-}
+inline constexpr weekday_last weekday::operator[](last_spec) const noexcept { return weekday_last{*this}; }
 
 inline constexpr weekday Sunday{0};
 inline constexpr weekday Monday{1};
@@ -174,21 +163,19 @@ inline constexpr weekday Saturday{6};
 
 template <>
 struct hash<chrono::weekday> {
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::weekday& __w) noexcept {
-    return __w.c_encoding();
-  }
+  [[nodiscard]] static size_t operator()(const chrono::weekday& __w) noexcept { return __w.c_encoding(); }
 };
 
 template <>
 struct hash<chrono::weekday_indexed> {
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::weekday_indexed& __wi) noexcept {
+  [[nodiscard]] static size_t operator()(const chrono::weekday_indexed& __wi) noexcept {
     return std::__hash_combine(hash<chrono::weekday>{}(__wi.weekday()), __wi.index());
   }
 };
 
 template <>
 struct hash<chrono::weekday_last> {
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::weekday_last& __wl) noexcept {
+  [[nodiscard]] static size_t operator()(const chrono::weekday_last& __wl) noexcept {
     return hash<chrono::weekday>{}(__wl.weekday());
   }
 };

--- a/libcxx/include/__chrono/year.h
+++ b/libcxx/include/__chrono/year.h
@@ -36,75 +36,71 @@ private:
 
 public:
   year() = default;
-  _LIBCPP_HIDE_FROM_ABI explicit inline constexpr year(int __val) noexcept : __y_(static_cast<short>(__val)) {}
+  explicit inline constexpr year(int __val) noexcept : __y_(static_cast<short>(__val)) {}
 
-  _LIBCPP_HIDE_FROM_ABI inline constexpr year& operator++() noexcept {
+  inline constexpr year& operator++() noexcept {
     ++__y_;
     return *this;
   }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr year operator++(int) noexcept {
+  inline constexpr year operator++(int) noexcept {
     year __tmp = *this;
     ++(*this);
     return __tmp;
   }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr year& operator--() noexcept {
+  inline constexpr year& operator--() noexcept {
     --__y_;
     return *this;
   }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr year operator--(int) noexcept {
+  inline constexpr year operator--(int) noexcept {
     year __tmp = *this;
     --(*this);
     return __tmp;
   }
-  _LIBCPP_HIDE_FROM_ABI constexpr year& operator+=(const years& __dy) noexcept;
-  _LIBCPP_HIDE_FROM_ABI constexpr year& operator-=(const years& __dy) noexcept;
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year operator+() const noexcept { return *this; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year operator-() const noexcept { return year{-__y_}; }
+  constexpr year& operator+=(const years& __dy) noexcept;
+  constexpr year& operator-=(const years& __dy) noexcept;
+  [[nodiscard]] inline constexpr year operator+() const noexcept { return *this; }
+  [[nodiscard]] inline constexpr year operator-() const noexcept { return year{-__y_}; }
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool is_leap() const noexcept {
+  [[nodiscard]] inline constexpr bool is_leap() const noexcept {
     return __y_ % 4 == 0 && (__y_ % 100 != 0 || __y_ % 400 == 0);
   }
-  _LIBCPP_HIDE_FROM_ABI explicit inline constexpr operator int() const noexcept { return __y_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool ok() const noexcept;
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static inline constexpr year min() noexcept { return year{-32767}; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static inline constexpr year max() noexcept { return year{32767}; }
+  explicit inline constexpr operator int() const noexcept { return __y_; }
+  [[nodiscard]] constexpr bool ok() const noexcept;
+  [[nodiscard]] static inline constexpr year min() noexcept { return year{-32767}; }
+  [[nodiscard]] static inline constexpr year max() noexcept { return year{32767}; }
 };
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr bool operator==(const year& __lhs, const year& __rhs) noexcept {
+inline constexpr bool operator==(const year& __lhs, const year& __rhs) noexcept {
   return static_cast<int>(__lhs) == static_cast<int>(__rhs);
 }
 
-_LIBCPP_HIDE_FROM_ABI constexpr strong_ordering operator<=>(const year& __lhs, const year& __rhs) noexcept {
+constexpr strong_ordering operator<=>(const year& __lhs, const year& __rhs) noexcept {
   return static_cast<int>(__lhs) <=> static_cast<int>(__rhs);
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year operator+(const year& __lhs, const years& __rhs) noexcept {
+[[nodiscard]] inline constexpr year operator+(const year& __lhs, const years& __rhs) noexcept {
   return year(static_cast<int>(__lhs) + __rhs.count());
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year operator+(const years& __lhs, const year& __rhs) noexcept {
-  return __rhs + __lhs;
-}
+[[nodiscard]] inline constexpr year operator+(const years& __lhs, const year& __rhs) noexcept { return __rhs + __lhs; }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year operator-(const year& __lhs, const years& __rhs) noexcept {
-  return __lhs + -__rhs;
-}
+[[nodiscard]] inline constexpr year operator-(const year& __lhs, const years& __rhs) noexcept { return __lhs + -__rhs; }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr years operator-(const year& __lhs, const year& __rhs) noexcept {
+[[nodiscard]] inline constexpr years operator-(const year& __lhs, const year& __rhs) noexcept {
   return years{static_cast<int>(__lhs) - static_cast<int>(__rhs)};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year& year::operator+=(const years& __dy) noexcept {
+inline constexpr year& year::operator+=(const years& __dy) noexcept {
   *this = *this + __dy;
   return *this;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year& year::operator-=(const years& __dy) noexcept {
+inline constexpr year& year::operator-=(const years& __dy) noexcept {
   *this = *this - __dy;
   return *this;
 }
 
-_LIBCPP_HIDE_FROM_ABI constexpr bool year::ok() const noexcept {
+constexpr bool year::ok() const noexcept {
   static_assert(static_cast<int>(std::numeric_limits<decltype(__y_)>::max()) == static_cast<int>(max()));
   return static_cast<int>(min()) <= __y_;
 }
@@ -115,9 +111,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr bool year::ok() const noexcept {
 
 template <>
 struct hash<chrono::year> {
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::year& __y) noexcept {
-    return static_cast<int>(__y);
-  }
+  [[nodiscard]] static size_t operator()(const chrono::year& __y) noexcept { return static_cast<int>(__y); }
 };
 
 #  endif // _LIBCPP_STD_VER >= 26

--- a/libcxx/include/__chrono/year_month.h
+++ b/libcxx/include/__chrono/year_month.h
@@ -34,91 +34,82 @@ class year_month {
 
 public:
   year_month() = default;
-  _LIBCPP_HIDE_FROM_ABI constexpr year_month(const chrono::year& __yval, const chrono::month& __mval) noexcept
-      : __y_{__yval}, __m_{__mval} {}
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::year year() const noexcept { return __y_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr year_month& operator+=(const months& __dm) noexcept;
-  _LIBCPP_HIDE_FROM_ABI inline constexpr year_month& operator-=(const months& __dm) noexcept;
-  _LIBCPP_HIDE_FROM_ABI inline constexpr year_month& operator+=(const years& __dy) noexcept;
-  _LIBCPP_HIDE_FROM_ABI inline constexpr year_month& operator-=(const years& __dy) noexcept;
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __y_.ok() && __m_.ok(); }
+  constexpr year_month(const chrono::year& __yval, const chrono::month& __mval) noexcept : __y_{__yval}, __m_{__mval} {}
+  [[nodiscard]] inline constexpr chrono::year year() const noexcept { return __y_; }
+  [[nodiscard]] inline constexpr chrono::month month() const noexcept { return __m_; }
+  inline constexpr year_month& operator+=(const months& __dm) noexcept;
+  inline constexpr year_month& operator-=(const months& __dm) noexcept;
+  inline constexpr year_month& operator+=(const years& __dy) noexcept;
+  inline constexpr year_month& operator-=(const years& __dy) noexcept;
+  [[nodiscard]] inline constexpr bool ok() const noexcept { return __y_.ok() && __m_.ok(); }
 };
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month operator/(const year& __y, const month& __m) noexcept {
+[[nodiscard]] inline constexpr year_month operator/(const year& __y, const month& __m) noexcept {
   return year_month{__y, __m};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month operator/(const year& __y, int __m) noexcept {
+[[nodiscard]] inline constexpr year_month operator/(const year& __y, int __m) noexcept {
   return year_month{__y, month(__m)};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr bool operator==(const year_month& __lhs, const year_month& __rhs) noexcept {
+inline constexpr bool operator==(const year_month& __lhs, const year_month& __rhs) noexcept {
   return __lhs.year() == __rhs.year() && __lhs.month() == __rhs.month();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr strong_ordering
-operator<=>(const year_month& __lhs, const year_month& __rhs) noexcept {
+inline constexpr strong_ordering operator<=>(const year_month& __lhs, const year_month& __rhs) noexcept {
   if (auto __c = __lhs.year() <=> __rhs.year(); __c != 0)
     return __c;
   return __lhs.month() <=> __rhs.month();
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month
-operator+(const year_month& __lhs, const months& __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month operator+(const year_month& __lhs, const months& __rhs) noexcept {
   int __dmi      = static_cast<int>(static_cast<unsigned>(__lhs.month())) - 1 + __rhs.count();
   const int __dy = (__dmi >= 0 ? __dmi : __dmi - 11) / 12;
   __dmi          = __dmi - __dy * 12 + 1;
   return (__lhs.year() + years(__dy)) / month(static_cast<unsigned>(__dmi));
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month
-operator+(const months& __lhs, const year_month& __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month operator+(const months& __lhs, const year_month& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month
-operator+(const year_month& __lhs, const years& __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month operator+(const year_month& __lhs, const years& __rhs) noexcept {
   return (__lhs.year() + __rhs) / __lhs.month();
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month
-operator+(const years& __lhs, const year_month& __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month operator+(const years& __lhs, const year_month& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr months
-operator-(const year_month& __lhs, const year_month& __rhs) noexcept {
+[[nodiscard]] inline constexpr months operator-(const year_month& __lhs, const year_month& __rhs) noexcept {
   return (__lhs.year() - __rhs.year()) +
          months(static_cast<unsigned>(__lhs.month()) - static_cast<unsigned>(__rhs.month()));
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month
-operator-(const year_month& __lhs, const months& __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month operator-(const year_month& __lhs, const months& __rhs) noexcept {
   return __lhs + -__rhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month
-operator-(const year_month& __lhs, const years& __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month operator-(const year_month& __lhs, const years& __rhs) noexcept {
   return __lhs + -__rhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month& year_month::operator+=(const months& __dm) noexcept {
+inline constexpr year_month& year_month::operator+=(const months& __dm) noexcept {
   *this = *this + __dm;
   return *this;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month& year_month::operator-=(const months& __dm) noexcept {
+inline constexpr year_month& year_month::operator-=(const months& __dm) noexcept {
   *this = *this - __dm;
   return *this;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month& year_month::operator+=(const years& __dy) noexcept {
+inline constexpr year_month& year_month::operator+=(const years& __dy) noexcept {
   *this = *this + __dy;
   return *this;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month& year_month::operator-=(const years& __dy) noexcept {
+inline constexpr year_month& year_month::operator-=(const years& __dy) noexcept {
   *this = *this - __dy;
   return *this;
 }
@@ -129,7 +120,7 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr year_month& year_month::operator-=(const 
 
 template <>
 struct hash<chrono::year_month> {
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::year_month& __ym) noexcept {
+  [[nodiscard]] static size_t operator()(const chrono::year_month& __ym) noexcept {
     return std::__hash_combine(hash<chrono::year>{}(__ym.year()), hash<chrono::month>{}(__ym.month()));
   }
 };

--- a/libcxx/include/__chrono/year_month_day.h
+++ b/libcxx/include/__chrono/year_month_day.h
@@ -45,36 +45,34 @@ private:
 
 public:
   year_month_day() = default;
-  _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day(
+  inline constexpr year_month_day(
       const chrono::year& __yval, const chrono::month& __mval, const chrono::day& __dval) noexcept
       : __y_{__yval}, __m_{__mval}, __d_{__dval} {}
-  _LIBCPP_HIDE_FROM_ABI constexpr year_month_day(const year_month_day_last& __ymdl) noexcept;
-  _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day(const sys_days& __sysd) noexcept
+  constexpr year_month_day(const year_month_day_last& __ymdl) noexcept;
+  inline constexpr year_month_day(const sys_days& __sysd) noexcept
       : year_month_day(__from_days(__sysd.time_since_epoch())) {}
-  _LIBCPP_HIDE_FROM_ABI inline explicit constexpr year_month_day(const local_days& __locd) noexcept
+  inline explicit constexpr year_month_day(const local_days& __locd) noexcept
       : year_month_day(__from_days(__locd.time_since_epoch())) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr year_month_day& operator+=(const months& __dm) noexcept;
-  _LIBCPP_HIDE_FROM_ABI constexpr year_month_day& operator-=(const months& __dm) noexcept;
-  _LIBCPP_HIDE_FROM_ABI constexpr year_month_day& operator+=(const years& __dy) noexcept;
-  _LIBCPP_HIDE_FROM_ABI constexpr year_month_day& operator-=(const years& __dy) noexcept;
+  constexpr year_month_day& operator+=(const months& __dm) noexcept;
+  constexpr year_month_day& operator-=(const months& __dm) noexcept;
+  constexpr year_month_day& operator+=(const years& __dy) noexcept;
+  constexpr year_month_day& operator-=(const years& __dy) noexcept;
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::year year() const noexcept { return __y_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::day day() const noexcept { return __d_; }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr operator sys_days() const noexcept { return sys_days{__to_days()}; }
-  _LIBCPP_HIDE_FROM_ABI inline explicit constexpr operator local_days() const noexcept {
-    return local_days{__to_days()};
-  }
+  [[nodiscard]] inline constexpr chrono::year year() const noexcept { return __y_; }
+  [[nodiscard]] inline constexpr chrono::month month() const noexcept { return __m_; }
+  [[nodiscard]] inline constexpr chrono::day day() const noexcept { return __d_; }
+  inline constexpr operator sys_days() const noexcept { return sys_days{__to_days()}; }
+  inline explicit constexpr operator local_days() const noexcept { return local_days{__to_days()}; }
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool ok() const noexcept;
+  [[nodiscard]] constexpr bool ok() const noexcept;
 
-  _LIBCPP_HIDE_FROM_ABI static constexpr year_month_day __from_days(days __d) noexcept;
-  _LIBCPP_HIDE_FROM_ABI constexpr days __to_days() const noexcept;
+  static constexpr year_month_day __from_days(days __d) noexcept;
+  constexpr days __to_days() const noexcept;
 };
 
 // https://howardhinnant.github.io/date_algorithms.html#civil_from_days
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day year_month_day::__from_days(days __d) noexcept {
+inline constexpr year_month_day year_month_day::__from_days(days __d) noexcept {
   static_assert(numeric_limits<unsigned>::digits >= 18, "");
   static_assert(numeric_limits<int>::digits >= 20, "");
   const int __z        = __d.count() + 719468;
@@ -90,7 +88,7 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day year_month_day::__from_day
 }
 
 // https://howardhinnant.github.io/date_algorithms.html#days_from_civil
-_LIBCPP_HIDE_FROM_ABI inline constexpr days year_month_day::__to_days() const noexcept {
+inline constexpr days year_month_day::__to_days() const noexcept {
   static_assert(numeric_limits<unsigned>::digits >= 18, "");
   static_assert(numeric_limits<int>::digits >= 20, "");
 
@@ -105,13 +103,11 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr days year_month_day::__to_days() const no
   return days{__era * 146097 + static_cast<int>(__doe) - 719468};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr bool
-operator==(const year_month_day& __lhs, const year_month_day& __rhs) noexcept {
+inline constexpr bool operator==(const year_month_day& __lhs, const year_month_day& __rhs) noexcept {
   return __lhs.year() == __rhs.year() && __lhs.month() == __rhs.month() && __lhs.day() == __rhs.day();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr strong_ordering
-operator<=>(const year_month_day& __lhs, const year_month_day& __rhs) noexcept {
+inline constexpr strong_ordering operator<=>(const year_month_day& __lhs, const year_month_day& __rhs) noexcept {
   if (auto __c = __lhs.year() <=> __rhs.year(); __c != 0)
     return __c;
   if (auto __c = __lhs.month() <=> __rhs.month(); __c != 0)
@@ -119,79 +115,67 @@ operator<=>(const year_month_day& __lhs, const year_month_day& __rhs) noexcept {
   return __lhs.day() <=> __rhs.day();
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
-operator/(const year_month& __lhs, const day& __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month_day operator/(const year_month& __lhs, const day& __rhs) noexcept {
   return year_month_day{__lhs.year(), __lhs.month(), __rhs};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
-operator/(const year_month& __lhs, int __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month_day operator/(const year_month& __lhs, int __rhs) noexcept {
   return __lhs / day(__rhs);
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
-operator/(const year& __lhs, const month_day& __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month_day operator/(const year& __lhs, const month_day& __rhs) noexcept {
   return __lhs / __rhs.month() / __rhs.day();
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
-operator/(int __lhs, const month_day& __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month_day operator/(int __lhs, const month_day& __rhs) noexcept {
   return year(__lhs) / __rhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
-operator/(const month_day& __lhs, const year& __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month_day operator/(const month_day& __lhs, const year& __rhs) noexcept {
   return __rhs / __lhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
-operator/(const month_day& __lhs, int __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month_day operator/(const month_day& __lhs, int __rhs) noexcept {
   return year(__rhs) / __lhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
-operator+(const year_month_day& __lhs, const months& __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month_day operator+(const year_month_day& __lhs, const months& __rhs) noexcept {
   return (__lhs.year() / __lhs.month() + __rhs) / __lhs.day();
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
-operator+(const months& __lhs, const year_month_day& __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month_day operator+(const months& __lhs, const year_month_day& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
-operator-(const year_month_day& __lhs, const months& __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month_day operator-(const year_month_day& __lhs, const months& __rhs) noexcept {
   return __lhs + -__rhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
-operator+(const year_month_day& __lhs, const years& __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month_day operator+(const year_month_day& __lhs, const years& __rhs) noexcept {
   return (__lhs.year() + __rhs) / __lhs.month() / __lhs.day();
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
-operator+(const years& __lhs, const year_month_day& __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month_day operator+(const years& __lhs, const year_month_day& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
-operator-(const year_month_day& __lhs, const years& __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month_day operator-(const year_month_day& __lhs, const years& __rhs) noexcept {
   return __lhs + -__rhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day& year_month_day::operator+=(const months& __dm) noexcept {
+inline constexpr year_month_day& year_month_day::operator+=(const months& __dm) noexcept {
   *this = *this + __dm;
   return *this;
 }
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day& year_month_day::operator-=(const months& __dm) noexcept {
+inline constexpr year_month_day& year_month_day::operator-=(const months& __dm) noexcept {
   *this = *this - __dm;
   return *this;
 }
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day& year_month_day::operator+=(const years& __dy) noexcept {
+inline constexpr year_month_day& year_month_day::operator+=(const years& __dy) noexcept {
   *this = *this + __dy;
   return *this;
 }
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day& year_month_day::operator-=(const years& __dy) noexcept {
+inline constexpr year_month_day& year_month_day::operator-=(const years& __dy) noexcept {
   *this = *this - __dy;
   return *this;
 }
@@ -202,30 +186,24 @@ private:
   chrono::month_day_last __mdl_;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI constexpr year_month_day_last(const year& __yval, const month_day_last& __mdlval) noexcept
+  constexpr year_month_day_last(const year& __yval, const month_day_last& __mdlval) noexcept
       : __y_{__yval}, __mdl_{__mdlval} {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr year_month_day_last& operator+=(const months& __m) noexcept;
-  _LIBCPP_HIDE_FROM_ABI constexpr year_month_day_last& operator-=(const months& __m) noexcept;
-  _LIBCPP_HIDE_FROM_ABI constexpr year_month_day_last& operator+=(const years& __y) noexcept;
-  _LIBCPP_HIDE_FROM_ABI constexpr year_month_day_last& operator-=(const years& __y) noexcept;
+  constexpr year_month_day_last& operator+=(const months& __m) noexcept;
+  constexpr year_month_day_last& operator-=(const months& __m) noexcept;
+  constexpr year_month_day_last& operator+=(const years& __y) noexcept;
+  constexpr year_month_day_last& operator-=(const years& __y) noexcept;
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::year year() const noexcept { return __y_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __mdl_.month(); }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month_day_last month_day_last() const noexcept {
-    return __mdl_;
-  }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::day day() const noexcept;
-  _LIBCPP_HIDE_FROM_ABI inline constexpr operator sys_days() const noexcept {
-    return sys_days{year() / month() / day()};
-  }
-  _LIBCPP_HIDE_FROM_ABI inline explicit constexpr operator local_days() const noexcept {
-    return local_days{year() / month() / day()};
-  }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __y_.ok() && __mdl_.ok(); }
+  [[nodiscard]] inline constexpr chrono::year year() const noexcept { return __y_; }
+  [[nodiscard]] inline constexpr chrono::month month() const noexcept { return __mdl_.month(); }
+  [[nodiscard]] inline constexpr chrono::month_day_last month_day_last() const noexcept { return __mdl_; }
+  [[nodiscard]] constexpr chrono::day day() const noexcept;
+  inline constexpr operator sys_days() const noexcept { return sys_days{year() / month() / day()}; }
+  inline explicit constexpr operator local_days() const noexcept { return local_days{year() / month() / day()}; }
+  [[nodiscard]] inline constexpr bool ok() const noexcept { return __y_.ok() && __mdl_.ok(); }
 };
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr chrono::day year_month_day_last::day() const noexcept {
+inline constexpr chrono::day year_month_day_last::day() const noexcept {
   constexpr chrono::day __d[] = {
       chrono::day(31),
       chrono::day(28),
@@ -244,98 +222,88 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::day year_month_day_last::day() co
            : chrono::day{29};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr bool
-operator==(const year_month_day_last& __lhs, const year_month_day_last& __rhs) noexcept {
+inline constexpr bool operator==(const year_month_day_last& __lhs, const year_month_day_last& __rhs) noexcept {
   return __lhs.year() == __rhs.year() && __lhs.month_day_last() == __rhs.month_day_last();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr strong_ordering
+inline constexpr strong_ordering
 operator<=>(const year_month_day_last& __lhs, const year_month_day_last& __rhs) noexcept {
   if (auto __c = __lhs.year() <=> __rhs.year(); __c != 0)
     return __c;
   return __lhs.month_day_last() <=> __rhs.month_day_last();
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
-operator/(const year_month& __lhs, last_spec) noexcept {
+[[nodiscard]] inline constexpr year_month_day_last operator/(const year_month& __lhs, last_spec) noexcept {
   return year_month_day_last{__lhs.year(), month_day_last{__lhs.month()}};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
-operator/(const year& __lhs, const month_day_last& __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month_day_last operator/(const year& __lhs, const month_day_last& __rhs) noexcept {
   return year_month_day_last{__lhs, __rhs};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
-operator/(int __lhs, const month_day_last& __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month_day_last operator/(int __lhs, const month_day_last& __rhs) noexcept {
   return year_month_day_last{year{__lhs}, __rhs};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
-operator/(const month_day_last& __lhs, const year& __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month_day_last operator/(const month_day_last& __lhs, const year& __rhs) noexcept {
   return __rhs / __lhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
-operator/(const month_day_last& __lhs, int __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month_day_last operator/(const month_day_last& __lhs, int __rhs) noexcept {
   return year{__rhs} / __lhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
+[[nodiscard]] inline constexpr year_month_day_last
 operator+(const year_month_day_last& __lhs, const months& __rhs) noexcept {
   return (__lhs.year() / __lhs.month() + __rhs) / last;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
+[[nodiscard]] inline constexpr year_month_day_last
 operator+(const months& __lhs, const year_month_day_last& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
+[[nodiscard]] inline constexpr year_month_day_last
 operator-(const year_month_day_last& __lhs, const months& __rhs) noexcept {
   return __lhs + (-__rhs);
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
+[[nodiscard]] inline constexpr year_month_day_last
 operator+(const year_month_day_last& __lhs, const years& __rhs) noexcept {
   return year_month_day_last{__lhs.year() + __rhs, __lhs.month_day_last()};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
+[[nodiscard]] inline constexpr year_month_day_last
 operator+(const years& __lhs, const year_month_day_last& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
+[[nodiscard]] inline constexpr year_month_day_last
 operator-(const year_month_day_last& __lhs, const years& __rhs) noexcept {
   return __lhs + (-__rhs);
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last&
-year_month_day_last::operator+=(const months& __dm) noexcept {
+inline constexpr year_month_day_last& year_month_day_last::operator+=(const months& __dm) noexcept {
   *this = *this + __dm;
   return *this;
 }
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last&
-year_month_day_last::operator-=(const months& __dm) noexcept {
+inline constexpr year_month_day_last& year_month_day_last::operator-=(const months& __dm) noexcept {
   *this = *this - __dm;
   return *this;
 }
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last&
-year_month_day_last::operator+=(const years& __dy) noexcept {
+inline constexpr year_month_day_last& year_month_day_last::operator+=(const years& __dy) noexcept {
   *this = *this + __dy;
   return *this;
 }
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last&
-year_month_day_last::operator-=(const years& __dy) noexcept {
+inline constexpr year_month_day_last& year_month_day_last::operator-=(const years& __dy) noexcept {
   *this = *this - __dy;
   return *this;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day::year_month_day(const year_month_day_last& __ymdl) noexcept
+inline constexpr year_month_day::year_month_day(const year_month_day_last& __ymdl) noexcept
     : __y_{__ymdl.year()}, __m_{__ymdl.month()}, __d_{__ymdl.day()} {}
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr bool year_month_day::ok() const noexcept {
+inline constexpr bool year_month_day::ok() const noexcept {
   if (!__y_.ok() || !__m_.ok())
     return false;
   return chrono::day{1} <= __d_ && __d_ <= (__y_ / __m_ / last).day();
@@ -347,7 +315,7 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr bool year_month_day::ok() const noexcept 
 
 template <>
 struct hash<chrono::year_month_day> {
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::year_month_day& __ymd) noexcept {
+  [[nodiscard]] static size_t operator()(const chrono::year_month_day& __ymd) noexcept {
     return std::__hash_combine(
         hash<chrono::year>{}(__ymd.year()),
         std::__hash_combine(hash<chrono::month>{}(__ymd.month()), hash<chrono::day>{}(__ymd.day())));
@@ -356,7 +324,7 @@ struct hash<chrono::year_month_day> {
 
 template <>
 struct hash<chrono::year_month_day_last> {
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::year_month_day_last& __ymdl) noexcept {
+  [[nodiscard]] static size_t operator()(const chrono::year_month_day_last& __ymdl) noexcept {
     return std::__hash_combine(
         hash<chrono::year>{}(__ymdl.year()), hash<chrono::month_day_last>{}(__ymdl.month_day_last()));
   }

--- a/libcxx/include/__chrono/year_month_weekday.h
+++ b/libcxx/include/__chrono/year_month_weekday.h
@@ -42,33 +42,27 @@ class year_month_weekday {
 
 public:
   year_month_weekday() = default;
-  _LIBCPP_HIDE_FROM_ABI constexpr year_month_weekday(
+  constexpr year_month_weekday(
       const chrono::year& __yval, const chrono::month& __mval, const chrono::weekday_indexed& __wdival) noexcept
       : __y_{__yval}, __m_{__mval}, __wdi_{__wdival} {}
-  _LIBCPP_HIDE_FROM_ABI constexpr year_month_weekday(const sys_days& __sysd) noexcept
+  constexpr year_month_weekday(const sys_days& __sysd) noexcept
       : year_month_weekday(__from_days(__sysd.time_since_epoch())) {}
-  _LIBCPP_HIDE_FROM_ABI inline explicit constexpr year_month_weekday(const local_days& __locd) noexcept
+  inline explicit constexpr year_month_weekday(const local_days& __locd) noexcept
       : year_month_weekday(__from_days(__locd.time_since_epoch())) {}
-  _LIBCPP_HIDE_FROM_ABI constexpr year_month_weekday& operator+=(const months&) noexcept;
-  _LIBCPP_HIDE_FROM_ABI constexpr year_month_weekday& operator-=(const months&) noexcept;
-  _LIBCPP_HIDE_FROM_ABI constexpr year_month_weekday& operator+=(const years&) noexcept;
-  _LIBCPP_HIDE_FROM_ABI constexpr year_month_weekday& operator-=(const years&) noexcept;
+  constexpr year_month_weekday& operator+=(const months&) noexcept;
+  constexpr year_month_weekday& operator-=(const months&) noexcept;
+  constexpr year_month_weekday& operator+=(const years&) noexcept;
+  constexpr year_month_weekday& operator-=(const years&) noexcept;
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::year year() const noexcept { return __y_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::weekday weekday() const noexcept {
-    return __wdi_.weekday();
-  }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr unsigned index() const noexcept { return __wdi_.index(); }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::weekday_indexed weekday_indexed() const noexcept {
-    return __wdi_;
-  }
+  [[nodiscard]] inline constexpr chrono::year year() const noexcept { return __y_; }
+  [[nodiscard]] inline constexpr chrono::month month() const noexcept { return __m_; }
+  [[nodiscard]] inline constexpr chrono::weekday weekday() const noexcept { return __wdi_.weekday(); }
+  [[nodiscard]] inline constexpr unsigned index() const noexcept { return __wdi_.index(); }
+  [[nodiscard]] inline constexpr chrono::weekday_indexed weekday_indexed() const noexcept { return __wdi_; }
 
-  _LIBCPP_HIDE_FROM_ABI inline constexpr operator sys_days() const noexcept { return sys_days{__to_days()}; }
-  _LIBCPP_HIDE_FROM_ABI inline explicit constexpr operator local_days() const noexcept {
-    return local_days{__to_days()};
-  }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept {
+  inline constexpr operator sys_days() const noexcept { return sys_days{__to_days()}; }
+  inline explicit constexpr operator local_days() const noexcept { return local_days{__to_days()}; }
+  [[nodiscard]] inline constexpr bool ok() const noexcept {
     if (!__y_.ok() || !__m_.ok() || !__wdi_.ok())
       return false;
     if (__wdi_.index() <= 4)
@@ -78,96 +72,91 @@ public:
     return static_cast<unsigned>(__nth_weekday_day.count()) <= static_cast<unsigned>((__y_ / __m_ / last).day());
   }
 
-  _LIBCPP_HIDE_FROM_ABI static constexpr year_month_weekday __from_days(days __d) noexcept;
-  _LIBCPP_HIDE_FROM_ABI constexpr days __to_days() const noexcept;
+  static constexpr year_month_weekday __from_days(days __d) noexcept;
+  constexpr days __to_days() const noexcept;
 };
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday year_month_weekday::__from_days(days __d) noexcept {
+inline constexpr year_month_weekday year_month_weekday::__from_days(days __d) noexcept {
   const sys_days __sysd{__d};
   const chrono::weekday __wd = chrono::weekday(__sysd);
   const year_month_day __ymd = year_month_day(__sysd);
   return year_month_weekday{__ymd.year(), __ymd.month(), __wd[(static_cast<unsigned>(__ymd.day()) - 1) / 7 + 1]};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr days year_month_weekday::__to_days() const noexcept {
+inline constexpr days year_month_weekday::__to_days() const noexcept {
   const sys_days __sysd = sys_days(__y_ / __m_ / 1);
   return (__sysd + (__wdi_.weekday() - chrono::weekday(__sysd) + days{(__wdi_.index() - 1) * 7})).time_since_epoch();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr bool
-operator==(const year_month_weekday& __lhs, const year_month_weekday& __rhs) noexcept {
+inline constexpr bool operator==(const year_month_weekday& __lhs, const year_month_weekday& __rhs) noexcept {
   return __lhs.year() == __rhs.year() && __lhs.month() == __rhs.month() &&
          __lhs.weekday_indexed() == __rhs.weekday_indexed();
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
+[[nodiscard]] inline constexpr year_month_weekday
 operator/(const year_month& __lhs, const weekday_indexed& __rhs) noexcept {
   return year_month_weekday{__lhs.year(), __lhs.month(), __rhs};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
-operator/(const year& __lhs, const month_weekday& __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month_weekday operator/(const year& __lhs, const month_weekday& __rhs) noexcept {
   return year_month_weekday{__lhs, __rhs.month(), __rhs.weekday_indexed()};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
-operator/(int __lhs, const month_weekday& __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month_weekday operator/(int __lhs, const month_weekday& __rhs) noexcept {
   return year(__lhs) / __rhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
-operator/(const month_weekday& __lhs, const year& __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month_weekday operator/(const month_weekday& __lhs, const year& __rhs) noexcept {
   return __rhs / __lhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
-operator/(const month_weekday& __lhs, int __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month_weekday operator/(const month_weekday& __lhs, int __rhs) noexcept {
   return year(__rhs) / __lhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
+[[nodiscard]] inline constexpr year_month_weekday
 operator+(const year_month_weekday& __lhs, const months& __rhs) noexcept {
   return (__lhs.year() / __lhs.month() + __rhs) / __lhs.weekday_indexed();
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
+[[nodiscard]] inline constexpr year_month_weekday
 operator+(const months& __lhs, const year_month_weekday& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
+[[nodiscard]] inline constexpr year_month_weekday
 operator-(const year_month_weekday& __lhs, const months& __rhs) noexcept {
   return __lhs + (-__rhs);
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
+[[nodiscard]] inline constexpr year_month_weekday
 operator+(const year_month_weekday& __lhs, const years& __rhs) noexcept {
   return year_month_weekday{__lhs.year() + __rhs, __lhs.month(), __lhs.weekday_indexed()};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
+[[nodiscard]] inline constexpr year_month_weekday
 operator+(const years& __lhs, const year_month_weekday& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
+[[nodiscard]] inline constexpr year_month_weekday
 operator-(const year_month_weekday& __lhs, const years& __rhs) noexcept {
   return __lhs + (-__rhs);
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday& year_month_weekday::operator+=(const months& __dm) noexcept {
+inline constexpr year_month_weekday& year_month_weekday::operator+=(const months& __dm) noexcept {
   *this = *this + __dm;
   return *this;
 }
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday& year_month_weekday::operator-=(const months& __dm) noexcept {
+inline constexpr year_month_weekday& year_month_weekday::operator-=(const months& __dm) noexcept {
   *this = *this - __dm;
   return *this;
 }
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday& year_month_weekday::operator+=(const years& __dy) noexcept {
+inline constexpr year_month_weekday& year_month_weekday::operator+=(const years& __dy) noexcept {
   *this = *this + __dy;
   return *this;
 }
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday& year_month_weekday::operator-=(const years& __dy) noexcept {
+inline constexpr year_month_weekday& year_month_weekday::operator-=(const years& __dy) noexcept {
   *this = *this - __dy;
   return *this;
 }
@@ -179,115 +168,100 @@ private:
   chrono::weekday_last __wdl_;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI constexpr year_month_weekday_last(
+  constexpr year_month_weekday_last(
       const chrono::year& __yval, const chrono::month& __mval, const chrono::weekday_last& __wdlval) noexcept
       : __y_{__yval}, __m_{__mval}, __wdl_{__wdlval} {}
-  _LIBCPP_HIDE_FROM_ABI constexpr year_month_weekday_last& operator+=(const months& __dm) noexcept;
-  _LIBCPP_HIDE_FROM_ABI constexpr year_month_weekday_last& operator-=(const months& __dm) noexcept;
-  _LIBCPP_HIDE_FROM_ABI constexpr year_month_weekday_last& operator+=(const years& __dy) noexcept;
-  _LIBCPP_HIDE_FROM_ABI constexpr year_month_weekday_last& operator-=(const years& __dy) noexcept;
+  constexpr year_month_weekday_last& operator+=(const months& __dm) noexcept;
+  constexpr year_month_weekday_last& operator-=(const months& __dm) noexcept;
+  constexpr year_month_weekday_last& operator+=(const years& __dy) noexcept;
+  constexpr year_month_weekday_last& operator-=(const years& __dy) noexcept;
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::year year() const noexcept { return __y_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::weekday weekday() const noexcept {
-    return __wdl_.weekday();
-  }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::weekday_last weekday_last() const noexcept {
-    return __wdl_;
-  }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr operator sys_days() const noexcept { return sys_days{__to_days()}; }
-  _LIBCPP_HIDE_FROM_ABI inline explicit constexpr operator local_days() const noexcept {
-    return local_days{__to_days()};
-  }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept {
-    return __y_.ok() && __m_.ok() && __wdl_.ok();
-  }
+  [[nodiscard]] inline constexpr chrono::year year() const noexcept { return __y_; }
+  [[nodiscard]] inline constexpr chrono::month month() const noexcept { return __m_; }
+  [[nodiscard]] inline constexpr chrono::weekday weekday() const noexcept { return __wdl_.weekday(); }
+  [[nodiscard]] inline constexpr chrono::weekday_last weekday_last() const noexcept { return __wdl_; }
+  inline constexpr operator sys_days() const noexcept { return sys_days{__to_days()}; }
+  inline explicit constexpr operator local_days() const noexcept { return local_days{__to_days()}; }
+  [[nodiscard]] inline constexpr bool ok() const noexcept { return __y_.ok() && __m_.ok() && __wdl_.ok(); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr days __to_days() const noexcept;
+  constexpr days __to_days() const noexcept;
 };
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr days year_month_weekday_last::__to_days() const noexcept {
+inline constexpr days year_month_weekday_last::__to_days() const noexcept {
   const sys_days __last = sys_days{__y_ / __m_ / last};
   return (__last - (chrono::weekday{__last} - __wdl_.weekday())).time_since_epoch();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr bool
-operator==(const year_month_weekday_last& __lhs, const year_month_weekday_last& __rhs) noexcept {
+inline constexpr bool operator==(const year_month_weekday_last& __lhs, const year_month_weekday_last& __rhs) noexcept {
   return __lhs.year() == __rhs.year() && __lhs.month() == __rhs.month() && __lhs.weekday_last() == __rhs.weekday_last();
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
+[[nodiscard]] inline constexpr year_month_weekday_last
 operator/(const year_month& __lhs, const weekday_last& __rhs) noexcept {
   return year_month_weekday_last{__lhs.year(), __lhs.month(), __rhs};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
+[[nodiscard]] inline constexpr year_month_weekday_last
 operator/(const year& __lhs, const month_weekday_last& __rhs) noexcept {
   return year_month_weekday_last{__lhs, __rhs.month(), __rhs.weekday_last()};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
-operator/(int __lhs, const month_weekday_last& __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month_weekday_last operator/(int __lhs, const month_weekday_last& __rhs) noexcept {
   return year(__lhs) / __rhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
+[[nodiscard]] inline constexpr year_month_weekday_last
 operator/(const month_weekday_last& __lhs, const year& __rhs) noexcept {
   return __rhs / __lhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
-operator/(const month_weekday_last& __lhs, int __rhs) noexcept {
+[[nodiscard]] inline constexpr year_month_weekday_last operator/(const month_weekday_last& __lhs, int __rhs) noexcept {
   return year(__rhs) / __lhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
+[[nodiscard]] inline constexpr year_month_weekday_last
 operator+(const year_month_weekday_last& __lhs, const months& __rhs) noexcept {
   return (__lhs.year() / __lhs.month() + __rhs) / __lhs.weekday_last();
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
+[[nodiscard]] inline constexpr year_month_weekday_last
 operator+(const months& __lhs, const year_month_weekday_last& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
+[[nodiscard]] inline constexpr year_month_weekday_last
 operator-(const year_month_weekday_last& __lhs, const months& __rhs) noexcept {
   return __lhs + (-__rhs);
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
+[[nodiscard]] inline constexpr year_month_weekday_last
 operator+(const year_month_weekday_last& __lhs, const years& __rhs) noexcept {
   return year_month_weekday_last{__lhs.year() + __rhs, __lhs.month(), __lhs.weekday_last()};
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
+[[nodiscard]] inline constexpr year_month_weekday_last
 operator+(const years& __lhs, const year_month_weekday_last& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
+[[nodiscard]] inline constexpr year_month_weekday_last
 operator-(const year_month_weekday_last& __lhs, const years& __rhs) noexcept {
   return __lhs + (-__rhs);
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last&
-year_month_weekday_last::operator+=(const months& __dm) noexcept {
+inline constexpr year_month_weekday_last& year_month_weekday_last::operator+=(const months& __dm) noexcept {
   *this = *this + __dm;
   return *this;
 }
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last&
-year_month_weekday_last::operator-=(const months& __dm) noexcept {
+inline constexpr year_month_weekday_last& year_month_weekday_last::operator-=(const months& __dm) noexcept {
   *this = *this - __dm;
   return *this;
 }
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last&
-year_month_weekday_last::operator+=(const years& __dy) noexcept {
+inline constexpr year_month_weekday_last& year_month_weekday_last::operator+=(const years& __dy) noexcept {
   *this = *this + __dy;
   return *this;
 }
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last&
-year_month_weekday_last::operator-=(const years& __dy) noexcept {
+inline constexpr year_month_weekday_last& year_month_weekday_last::operator-=(const years& __dy) noexcept {
   *this = *this - __dy;
   return *this;
 }
@@ -298,7 +272,7 @@ year_month_weekday_last::operator-=(const years& __dy) noexcept {
 
 template <>
 struct hash<chrono::year_month_weekday> {
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::year_month_weekday& __ymw) noexcept {
+  [[nodiscard]] static size_t operator()(const chrono::year_month_weekday& __ymw) noexcept {
     return std::__hash_combine(
         hash<chrono::year>{}(__ymw.year()),
         std::__hash_combine(
@@ -308,7 +282,7 @@ struct hash<chrono::year_month_weekday> {
 
 template <>
 struct hash<chrono::year_month_weekday_last> {
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::year_month_weekday_last& __ymwl) noexcept {
+  [[nodiscard]] static size_t operator()(const chrono::year_month_weekday_last& __ymwl) noexcept {
     return std::__hash_combine(
         hash<chrono::year>{}(__ymwl.year()),
         std::__hash_combine(

--- a/libcxx/include/__chrono/zoned_time.h
+++ b/libcxx/include/__chrono/zoned_time.h
@@ -51,10 +51,8 @@ struct zoned_traits {};
 
 template <>
 struct zoned_traits<const time_zone*> {
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static const time_zone* default_zone() { return chrono::locate_zone("UTC"); }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static const time_zone* locate_zone(string_view __name) {
-    return chrono::locate_zone(__name);
-  }
+  [[nodiscard]] static const time_zone* default_zone() { return chrono::locate_zone("UTC"); }
+  [[nodiscard]] static const time_zone* locate_zone(string_view __name) { return chrono::locate_zone(__name); }
 };
 
 template <class _Duration, class _TimeZonePtr = const time_zone*>
@@ -73,92 +71,90 @@ class zoned_time {
 public:
   using duration = common_type_t<_Duration, seconds>;
 
-  _LIBCPP_HIDE_FROM_ABI zoned_time()
+  zoned_time()
     requires requires { __traits::default_zone(); }
       : __zone_{__traits::default_zone()}, __tp_{} {}
 
-  _LIBCPP_HIDE_FROM_ABI zoned_time(const zoned_time&)            = default;
-  _LIBCPP_HIDE_FROM_ABI zoned_time& operator=(const zoned_time&) = default;
+  zoned_time(const zoned_time&)            = default;
+  zoned_time& operator=(const zoned_time&) = default;
 
-  _LIBCPP_HIDE_FROM_ABI zoned_time(const sys_time<_Duration>& __tp)
+  zoned_time(const sys_time<_Duration>& __tp)
     requires requires { __traits::default_zone(); }
       : __zone_{__traits::default_zone()}, __tp_{__tp} {}
 
-  _LIBCPP_HIDE_FROM_ABI explicit zoned_time(_TimeZonePtr __zone) : __zone_{std::move(__zone)}, __tp_{} {}
+  explicit zoned_time(_TimeZonePtr __zone) : __zone_{std::move(__zone)}, __tp_{} {}
 
-  _LIBCPP_HIDE_FROM_ABI explicit zoned_time(string_view __name)
+  explicit zoned_time(string_view __name)
     requires(requires { __traits::locate_zone(string_view{}); } &&
              constructible_from<_TimeZonePtr, decltype(__traits::locate_zone(string_view{}))>)
       : __zone_{__traits::locate_zone(__name)}, __tp_{} {}
 
   template <class _Duration2>
-  _LIBCPP_HIDE_FROM_ABI zoned_time(const zoned_time<_Duration2, _TimeZonePtr>& __zt)
+  zoned_time(const zoned_time<_Duration2, _TimeZonePtr>& __zt)
     requires is_convertible_v<sys_time<_Duration2>, sys_time<_Duration>>
       : __zone_{__zt.get_time_zone()}, __tp_{__zt.get_sys_time()} {}
 
-  _LIBCPP_HIDE_FROM_ABI zoned_time(_TimeZonePtr __zone, const sys_time<_Duration>& __tp)
-      : __zone_{std::move(__zone)}, __tp_{__tp} {}
+  zoned_time(_TimeZonePtr __zone, const sys_time<_Duration>& __tp) : __zone_{std::move(__zone)}, __tp_{__tp} {}
 
-  _LIBCPP_HIDE_FROM_ABI zoned_time(string_view __name, const sys_time<_Duration>& __tp)
+  zoned_time(string_view __name, const sys_time<_Duration>& __tp)
     requires requires { _TimeZonePtr{__traits::locate_zone(string_view{})}; }
       : zoned_time{__traits::locate_zone(__name), __tp} {}
 
-  _LIBCPP_HIDE_FROM_ABI zoned_time(_TimeZonePtr __zone, const local_time<_Duration>& __tp)
-    requires(is_convertible_v<decltype(std::declval<_TimeZonePtr&>() -> to_sys(local_time<_Duration>{})),
+  zoned_time(_TimeZonePtr __zone, const local_time<_Duration>& __tp)
+    requires(is_convertible_v<decltype(std::declval<_TimeZonePtr&>()->to_sys(local_time<_Duration>{})),
                               sys_time<duration>>)
       : __zone_{std::move(__zone)}, __tp_{__zone_->to_sys(__tp)} {}
 
-  _LIBCPP_HIDE_FROM_ABI zoned_time(string_view __name, const local_time<_Duration>& __tp)
+  zoned_time(string_view __name, const local_time<_Duration>& __tp)
     requires(requires {
       _TimeZonePtr{__traits::locate_zone(string_view{})};
-    } && is_convertible_v<decltype(std::declval<_TimeZonePtr&>() -> to_sys(local_time<_Duration>{})),
-                          sys_time<duration>>)
+    } && is_convertible_v<decltype(std::declval<_TimeZonePtr&>()->to_sys(local_time<_Duration>{})), sys_time<duration>>)
       : zoned_time{__traits::locate_zone(__name), __tp} {}
 
-  _LIBCPP_HIDE_FROM_ABI zoned_time(_TimeZonePtr __zone, const local_time<_Duration>& __tp, choose __c)
+  zoned_time(_TimeZonePtr __zone, const local_time<_Duration>& __tp, choose __c)
     requires(is_convertible_v<
-                decltype(std::declval<_TimeZonePtr&>() -> to_sys(local_time<_Duration>{}, choose::earliest)),
+                decltype(std::declval<_TimeZonePtr&>()->to_sys(local_time<_Duration>{}, choose::earliest)),
                 sys_time<duration>>)
       : __zone_{std::move(__zone)}, __tp_{__zone_->to_sys(__tp, __c)} {}
 
-  _LIBCPP_HIDE_FROM_ABI zoned_time(string_view __name, const local_time<_Duration>& __tp, choose __c)
+  zoned_time(string_view __name, const local_time<_Duration>& __tp, choose __c)
     requires(requires {
       _TimeZonePtr{__traits::locate_zone(string_view{})};
-    } && is_convertible_v<decltype(std::declval<_TimeZonePtr&>() -> to_sys(local_time<_Duration>{}, choose::earliest)),
+    } && is_convertible_v<decltype(std::declval<_TimeZonePtr&>()->to_sys(local_time<_Duration>{}, choose::earliest)),
                           sys_time<duration>>)
       : zoned_time{__traits::locate_zone(__name), __tp, __c} {}
 
   template <class _Duration2, class _TimeZonePtr2>
-  _LIBCPP_HIDE_FROM_ABI zoned_time(_TimeZonePtr __zone, const zoned_time<_Duration2, _TimeZonePtr2>& __zt)
+  zoned_time(_TimeZonePtr __zone, const zoned_time<_Duration2, _TimeZonePtr2>& __zt)
     requires is_convertible_v<sys_time<_Duration2>, sys_time<_Duration>>
       : __zone_{std::move(__zone)}, __tp_{__zt.get_sys_time()} {}
 
   // per wording choose has no effect
   template <class _Duration2, class _TimeZonePtr2>
-  _LIBCPP_HIDE_FROM_ABI zoned_time(_TimeZonePtr __zone, const zoned_time<_Duration2, _TimeZonePtr2>& __zt, choose)
+  zoned_time(_TimeZonePtr __zone, const zoned_time<_Duration2, _TimeZonePtr2>& __zt, choose)
     requires is_convertible_v<sys_time<_Duration2>, sys_time<_Duration>>
       : __zone_{std::move(__zone)}, __tp_{__zt.get_sys_time()} {}
 
   template <class _Duration2, class _TimeZonePtr2>
-  _LIBCPP_HIDE_FROM_ABI zoned_time(string_view __name, const zoned_time<_Duration2, _TimeZonePtr2>& __zt)
+  zoned_time(string_view __name, const zoned_time<_Duration2, _TimeZonePtr2>& __zt)
     requires(requires {
       _TimeZonePtr{__traits::locate_zone(string_view{})};
     } && is_convertible_v<sys_time<_Duration2>, sys_time<_Duration>>)
       : zoned_time{__traits::locate_zone(__name), __zt} {}
 
   template <class _Duration2, class _TimeZonePtr2>
-  _LIBCPP_HIDE_FROM_ABI zoned_time(string_view __name, const zoned_time<_Duration2, _TimeZonePtr2>& __zt, choose __c)
+  zoned_time(string_view __name, const zoned_time<_Duration2, _TimeZonePtr2>& __zt, choose __c)
     requires(requires {
       _TimeZonePtr{__traits::locate_zone(string_view{})};
     } && is_convertible_v<sys_time<_Duration2>, sys_time<_Duration>>)
       : zoned_time{__traits::locate_zone(__name), __zt, __c} {}
 
-  _LIBCPP_HIDE_FROM_ABI zoned_time& operator=(const sys_time<_Duration>& __tp) {
+  zoned_time& operator=(const sys_time<_Duration>& __tp) {
     __tp_ = __tp;
     return *this;
   }
 
-  _LIBCPP_HIDE_FROM_ABI zoned_time& operator=(const local_time<_Duration>& __tp) {
+  zoned_time& operator=(const local_time<_Duration>& __tp) {
     // TODO TZDB This seems wrong.
     // Assigning a non-existent or ambiguous time will throw and not satisfy
     // the post condition. This seems quite odd; I constructed an object with
@@ -169,13 +165,13 @@ public:
     return *this;
   }
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI operator sys_time<duration>() const { return get_sys_time(); }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI explicit operator local_time<duration>() const { return get_local_time(); }
+  [[nodiscard]] operator sys_time<duration>() const { return get_sys_time(); }
+  [[nodiscard]] explicit operator local_time<duration>() const { return get_local_time(); }
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI _TimeZonePtr get_time_zone() const { return __zone_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI local_time<duration> get_local_time() const { return __zone_->to_local(__tp_); }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI sys_time<duration> get_sys_time() const { return __tp_; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI sys_info get_info() const { return __zone_->get_info(__tp_); }
+  [[nodiscard]] _TimeZonePtr get_time_zone() const { return __zone_; }
+  [[nodiscard]] local_time<duration> get_local_time() const { return __zone_->to_local(__tp_); }
+  [[nodiscard]] sys_time<duration> get_sys_time() const { return __tp_; }
+  [[nodiscard]] sys_info get_info() const { return __zone_->get_info(__tp_); }
 
 private:
   _TimeZonePtr __zone_;
@@ -211,8 +207,7 @@ zoned_time(_TimeZonePtrOrName&&, zoned_time<_Duration, _TimeZonePtr2>, choose = 
 using zoned_seconds = zoned_time<seconds>;
 
 template <class _Duration1, class _Duration2, class _TimeZonePtr>
-_LIBCPP_HIDE_FROM_ABI bool
-operator==(const zoned_time<_Duration1, _TimeZonePtr>& __lhs, const zoned_time<_Duration2, _TimeZonePtr>& __rhs) {
+bool operator==(const zoned_time<_Duration1, _TimeZonePtr>& __lhs, const zoned_time<_Duration2, _TimeZonePtr>& __rhs) {
   return __lhs.get_time_zone() == __rhs.get_time_zone() && __lhs.get_sys_time() == __rhs.get_sys_time();
 }
 
@@ -223,8 +218,7 @@ operator==(const zoned_time<_Duration1, _TimeZonePtr>& __lhs, const zoned_time<_
 template <class _Duration, class _TimeZonePtr>
   requires __has_enabled_hash<_Duration>::value && __has_enabled_hash<_TimeZonePtr>::value
 struct hash<chrono::zoned_time<_Duration, _TimeZonePtr>> {
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t
-  operator()(const chrono::zoned_time<_Duration, _TimeZonePtr>& __zt) {
+  [[nodiscard]] static size_t operator()(const chrono::zoned_time<_Duration, _TimeZonePtr>& __zt) {
     return std::__hash_combine(
         hash<chrono::sys_time<_Duration>>{}(__zt.get_sys_time()), hash<_TimeZonePtr>{}(__zt.get_time_zone()));
   }

--- a/libcxx/include/__compare/common_comparison_category.h
+++ b/libcxx/include/__compare/common_comparison_category.h
@@ -27,7 +27,7 @@ namespace __comp_detail {
 enum _ClassifyCompCategory : unsigned { _None, _PartialOrd, _WeakOrd, _StrongOrd, _CCC_Size };
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI constexpr _ClassifyCompCategory __type_to_enum() noexcept {
+constexpr _ClassifyCompCategory __type_to_enum() noexcept {
   if (is_same_v<_Tp, partial_ordering>)
     return _PartialOrd;
   if (is_same_v<_Tp, weak_ordering>)
@@ -38,8 +38,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr _ClassifyCompCategory __type_to_enum() noexcept 
 }
 
 template <size_t _Size>
-_LIBCPP_HIDE_FROM_ABI constexpr _ClassifyCompCategory
-__compute_comp_type(const _ClassifyCompCategory (&__types)[_Size]) {
+constexpr _ClassifyCompCategory __compute_comp_type(const _ClassifyCompCategory (&__types)[_Size]) {
   int __seen[_CCC_Size] = {};
   for (auto __type : __types)
     ++__seen[__type];
@@ -53,7 +52,7 @@ __compute_comp_type(const _ClassifyCompCategory (&__types)[_Size]) {
 }
 
 template <class... _Ts, bool _False = false>
-_LIBCPP_HIDE_FROM_ABI constexpr auto __get_comp_type() {
+constexpr auto __get_comp_type() {
   using _CCC                    = _ClassifyCompCategory;
   constexpr _CCC __type_kinds[] = {_StrongOrd, __comp_detail::__type_to_enum<_Ts>()...};
   constexpr _CCC __cat          = __comp_detail::__compute_comp_type(__type_kinds);

--- a/libcxx/include/__compare/compare_partial_order_fallback.h
+++ b/libcxx/include/__compare/compare_partial_order_fallback.h
@@ -31,7 +31,7 @@ namespace __compare_partial_order_fallback {
 struct __fn {
   template <class _Tp, class _Up>
     requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto __go(_Tp&& __t, _Up&& __u, __priority_tag<1>) noexcept(
+  static constexpr auto __go(_Tp&& __t, _Up&& __u, __priority_tag<1>) noexcept(
       noexcept(std::partial_order(std::forward<_Tp>(__t), std::forward<_Up>(__u))))
       -> decltype(std::partial_order(std::forward<_Tp>(__t), std::forward<_Up>(__u))) {
     return std::partial_order(std::forward<_Tp>(__t), std::forward<_Up>(__u));
@@ -43,11 +43,12 @@ struct __fn {
       { std::forward<_Tp>(__t) < std::forward<_Up>(__u) } -> __boolean_testable;
       { std::forward<_Up>(__u) < std::forward<_Tp>(__t) } -> __boolean_testable;
     }
-  _LIBCPP_HIDE_FROM_ABI static constexpr partial_ordering __go(_Tp&& __t, _Up&& __u, __priority_tag<0>) noexcept(
-      noexcept(std::forward<_Tp>(__t) == std::forward<_Up>(__u)  ? partial_ordering::equivalent
-               : std::forward<_Tp>(__t) < std::forward<_Up>(__u) ? partial_ordering::less
-               : std::forward<_Up>(__u) < std::forward<_Tp>(__t) ? partial_ordering::greater
-                                                                 : partial_ordering::unordered)) {
+  static constexpr partial_ordering __go(_Tp&& __t, _Up&& __u, __priority_tag<0>) noexcept(noexcept(
+      std::forward<_Tp>(__t) == std::forward<_Up>(__u)  ? partial_ordering::equivalent
+      : std::forward<_Tp>(__t) < std::forward<_Up>(__u) ? partial_ordering::less
+      : std::forward<_Up>(__u) < std::forward<_Tp>(__t)
+          ? partial_ordering::greater
+          : partial_ordering::unordered)) {
     return std::forward<_Tp>(__t) == std::forward<_Up>(__u) ? partial_ordering::equivalent
          : std::forward<_Tp>(__t) < std::forward<_Up>(__u)  ? partial_ordering::less
          : std::forward<_Up>(__u) < std::forward<_Tp>(__t)
@@ -56,7 +57,7 @@ struct __fn {
   }
 
   template <class _Tp, class _Up>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t, _Up&& __u) const
+  constexpr auto operator()(_Tp&& __t, _Up&& __u) const
       noexcept(noexcept(__go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<1>())))
           -> decltype(__go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<1>())) {
     return __go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<1>());

--- a/libcxx/include/__compare/compare_strong_order_fallback.h
+++ b/libcxx/include/__compare/compare_strong_order_fallback.h
@@ -31,7 +31,7 @@ namespace __compare_strong_order_fallback {
 struct __fn {
   template <class _Tp, class _Up>
     requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto __go(_Tp&& __t, _Up&& __u, __priority_tag<1>) noexcept(
+  static constexpr auto __go(_Tp&& __t, _Up&& __u, __priority_tag<1>) noexcept(
       noexcept(std::strong_order(std::forward<_Tp>(__t), std::forward<_Up>(__u))))
       -> decltype(std::strong_order(std::forward<_Tp>(__t), std::forward<_Up>(__u))) {
     return std::strong_order(std::forward<_Tp>(__t), std::forward<_Up>(__u));
@@ -42,10 +42,11 @@ struct __fn {
       { std::forward<_Tp>(__t) == std::forward<_Up>(__u) } -> __boolean_testable;
       { std::forward<_Tp>(__t) < std::forward<_Up>(__u) } -> __boolean_testable;
     }
-  _LIBCPP_HIDE_FROM_ABI static constexpr strong_ordering __go(_Tp&& __t, _Up&& __u, __priority_tag<0>) noexcept(
-      noexcept(std::forward<_Tp>(__t) == std::forward<_Up>(__u)  ? strong_ordering::equal
-               : std::forward<_Tp>(__t) < std::forward<_Up>(__u) ? strong_ordering::less
-                                                                 : strong_ordering::greater)) {
+  static constexpr strong_ordering __go(_Tp&& __t, _Up&& __u, __priority_tag<0>) noexcept(noexcept(
+      std::forward<_Tp>(__t) == std::forward<_Up>(__u) ? strong_ordering::equal
+      : std::forward<_Tp>(__t) < std::forward<_Up>(__u)
+          ? strong_ordering::less
+          : strong_ordering::greater)) {
     return std::forward<_Tp>(__t) == std::forward<_Up>(__u) ? strong_ordering::equal
          : std::forward<_Tp>(__t) < std::forward<_Up>(__u)
              ? strong_ordering::less
@@ -53,7 +54,7 @@ struct __fn {
   }
 
   template <class _Tp, class _Up>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t, _Up&& __u) const
+  constexpr auto operator()(_Tp&& __t, _Up&& __u) const
       noexcept(noexcept(__go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<1>())))
           -> decltype(__go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<1>())) {
     return __go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<1>());

--- a/libcxx/include/__compare/compare_three_way.h
+++ b/libcxx/include/__compare/compare_three_way.h
@@ -25,7 +25,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 struct compare_three_way {
   template <class _T1, class _T2>
     requires three_way_comparable_with<_T1, _T2>
-  constexpr _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
+  constexpr auto operator()(_T1&& __t, _T2&& __u) const
       noexcept(noexcept(std::forward<_T1>(__t) <=> std::forward<_T2>(__u))) {
     return std::forward<_T1>(__t) <=> std::forward<_T2>(__u);
   }

--- a/libcxx/include/__compare/compare_three_way_result.h
+++ b/libcxx/include/__compare/compare_three_way_result.h
@@ -22,10 +22,10 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 20
 
 template <class, class, class>
-struct _LIBCPP_HIDE_FROM_ABI __compare_three_way_result {};
+struct __compare_three_way_result {};
 
 template <class _Tp, class _Up>
-struct _LIBCPP_HIDE_FROM_ABI __compare_three_way_result<
+struct __compare_three_way_result<
     _Tp,
     _Up,
     decltype(std::declval<__make_const_lvalue_ref<_Tp>>() <=> std::declval<__make_const_lvalue_ref<_Up>>(), void())> {

--- a/libcxx/include/__compare/compare_weak_order_fallback.h
+++ b/libcxx/include/__compare/compare_weak_order_fallback.h
@@ -31,7 +31,7 @@ namespace __compare_weak_order_fallback {
 struct __fn {
   template <class _Tp, class _Up>
     requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto __go(_Tp&& __t, _Up&& __u, __priority_tag<1>) noexcept(
+  static constexpr auto __go(_Tp&& __t, _Up&& __u, __priority_tag<1>) noexcept(
       noexcept(std::weak_order(std::forward<_Tp>(__t), std::forward<_Up>(__u))))
       -> decltype(std::weak_order(std::forward<_Tp>(__t), std::forward<_Up>(__u))) {
     return std::weak_order(std::forward<_Tp>(__t), std::forward<_Up>(__u));
@@ -42,7 +42,7 @@ struct __fn {
       { std::forward<_Tp>(__t) == std::forward<_Up>(__u) } -> __boolean_testable;
       { std::forward<_Tp>(__t) < std::forward<_Up>(__u) } -> __boolean_testable;
     }
-  _LIBCPP_HIDE_FROM_ABI static constexpr weak_ordering __go(_Tp&& __t, _Up&& __u, __priority_tag<0>) noexcept(noexcept(
+  static constexpr weak_ordering __go(_Tp&& __t, _Up&& __u, __priority_tag<0>) noexcept(noexcept(
       std::forward<_Tp>(__t) == std::forward<_Up>(__u) ? weak_ordering::equivalent
       : std::forward<_Tp>(__t) < std::forward<_Up>(__u)
           ? weak_ordering::less
@@ -54,7 +54,7 @@ struct __fn {
   }
 
   template <class _Tp, class _Up>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t, _Up&& __u) const
+  constexpr auto operator()(_Tp&& __t, _Up&& __u) const
       noexcept(noexcept(__go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<1>())))
           -> decltype(__go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<1>())) {
     return __go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<1>());

--- a/libcxx/include/__compare/is_eq.h
+++ b/libcxx/include/__compare/is_eq.h
@@ -20,12 +20,12 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if _LIBCPP_STD_VER >= 20
 
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool is_eq(partial_ordering __c) noexcept { return __c == 0; }
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool is_neq(partial_ordering __c) noexcept { return __c != 0; }
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool is_lt(partial_ordering __c) noexcept { return __c < 0; }
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool is_lteq(partial_ordering __c) noexcept { return __c <= 0; }
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool is_gt(partial_ordering __c) noexcept { return __c > 0; }
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool is_gteq(partial_ordering __c) noexcept { return __c >= 0; }
+[[nodiscard]] inline constexpr bool is_eq(partial_ordering __c) noexcept { return __c == 0; }
+[[nodiscard]] inline constexpr bool is_neq(partial_ordering __c) noexcept { return __c != 0; }
+[[nodiscard]] inline constexpr bool is_lt(partial_ordering __c) noexcept { return __c < 0; }
+[[nodiscard]] inline constexpr bool is_lteq(partial_ordering __c) noexcept { return __c <= 0; }
+[[nodiscard]] inline constexpr bool is_gt(partial_ordering __c) noexcept { return __c > 0; }
+[[nodiscard]] inline constexpr bool is_gteq(partial_ordering __c) noexcept { return __c >= 0; }
 
 #endif // _LIBCPP_STD_VER >= 20
 

--- a/libcxx/include/__compare/ordering.h
+++ b/libcxx/include/__compare/ordering.h
@@ -41,7 +41,7 @@ struct _CmpUnspecifiedParam {
   // The alternative to the `__enable_if__` attribute would be to use the fact that a pointer
   // can be constructed from literal 0, but this conflicts with `-Wzero-as-null-pointer-constant`.
   template <class _Tp, class = __enable_if_t<is_same_v<_Tp, int> > >
-  _LIBCPP_HIDE_FROM_ABI consteval _CmpUnspecifiedParam(_Tp __zero) noexcept
+  consteval _CmpUnspecifiedParam(_Tp __zero) noexcept
 #  if __has_attribute(__enable_if__)
       __attribute__((__enable_if__(
           __zero == 0, "Only literal 0 is allowed as the operand of a comparison with one of the ordering types")))
@@ -52,7 +52,7 @@ struct _CmpUnspecifiedParam {
 };
 
 class partial_ordering {
-  _LIBCPP_HIDE_FROM_ABI explicit constexpr partial_ordering(_PartialOrdResult __v) noexcept : __value_(__v) {}
+  explicit constexpr partial_ordering(_PartialOrdResult __v) noexcept : __value_(__v) {}
 
 public:
   // valid values
@@ -62,51 +62,47 @@ public:
   static const partial_ordering unordered;
 
   // comparisons
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(partial_ordering, partial_ordering) noexcept = default;
+  friend constexpr bool operator==(partial_ordering, partial_ordering) noexcept = default;
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(partial_ordering __v, _CmpUnspecifiedParam) noexcept {
+  friend constexpr bool operator==(partial_ordering __v, _CmpUnspecifiedParam) noexcept {
     return __v.__value_ == _PartialOrdResult::__equiv;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator<(partial_ordering __v, _CmpUnspecifiedParam) noexcept {
+  friend constexpr bool operator<(partial_ordering __v, _CmpUnspecifiedParam) noexcept {
     return __v.__value_ == _PartialOrdResult::__less;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator<=(partial_ordering __v, _CmpUnspecifiedParam) noexcept {
+  friend constexpr bool operator<=(partial_ordering __v, _CmpUnspecifiedParam) noexcept {
     return __v.__value_ == _PartialOrdResult::__equiv || __v.__value_ == _PartialOrdResult::__less;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator>(partial_ordering __v, _CmpUnspecifiedParam) noexcept {
+  friend constexpr bool operator>(partial_ordering __v, _CmpUnspecifiedParam) noexcept {
     return __v.__value_ == _PartialOrdResult::__greater;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator>=(partial_ordering __v, _CmpUnspecifiedParam) noexcept {
+  friend constexpr bool operator>=(partial_ordering __v, _CmpUnspecifiedParam) noexcept {
     return __v.__value_ == _PartialOrdResult::__equiv || __v.__value_ == _PartialOrdResult::__greater;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator<(_CmpUnspecifiedParam, partial_ordering __v) noexcept {
+  friend constexpr bool operator<(_CmpUnspecifiedParam, partial_ordering __v) noexcept {
     return __v.__value_ == _PartialOrdResult::__greater;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator<=(_CmpUnspecifiedParam, partial_ordering __v) noexcept {
+  friend constexpr bool operator<=(_CmpUnspecifiedParam, partial_ordering __v) noexcept {
     return __v.__value_ == _PartialOrdResult::__equiv || __v.__value_ == _PartialOrdResult::__greater;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator>(_CmpUnspecifiedParam, partial_ordering __v) noexcept {
+  friend constexpr bool operator>(_CmpUnspecifiedParam, partial_ordering __v) noexcept {
     return __v.__value_ == _PartialOrdResult::__less;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator>=(_CmpUnspecifiedParam, partial_ordering __v) noexcept {
+  friend constexpr bool operator>=(_CmpUnspecifiedParam, partial_ordering __v) noexcept {
     return __v.__value_ == _PartialOrdResult::__equiv || __v.__value_ == _PartialOrdResult::__less;
   }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr partial_ordering
-  operator<=>(partial_ordering __v, _CmpUnspecifiedParam) noexcept {
-    return __v;
-  }
+  friend constexpr partial_ordering operator<=>(partial_ordering __v, _CmpUnspecifiedParam) noexcept { return __v; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr partial_ordering
-  operator<=>(_CmpUnspecifiedParam, partial_ordering __v) noexcept {
+  friend constexpr partial_ordering operator<=>(_CmpUnspecifiedParam, partial_ordering __v) noexcept {
     return __v < 0 ? partial_ordering::greater : (__v > 0 ? partial_ordering::less : __v);
   }
 
@@ -122,62 +118,42 @@ inline constexpr partial_ordering partial_ordering::unordered(_PartialOrdResult:
 class weak_ordering {
   using _ValueT _LIBCPP_NODEBUG = signed char;
 
-  _LIBCPP_HIDE_FROM_ABI explicit constexpr weak_ordering(_OrdResult __v) noexcept : __value_(_ValueT(__v)) {}
+  explicit constexpr weak_ordering(_OrdResult __v) noexcept : __value_(_ValueT(__v)) {}
 
 public:
   static const weak_ordering less;
   static const weak_ordering equivalent;
   static const weak_ordering greater;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr operator partial_ordering() const noexcept {
+  constexpr operator partial_ordering() const noexcept {
     return __value_ == 0 ? partial_ordering::equivalent
                          : (__value_ < 0 ? partial_ordering::less : partial_ordering::greater);
   }
 
   // comparisons
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(weak_ordering, weak_ordering) noexcept = default;
+  friend constexpr bool operator==(weak_ordering, weak_ordering) noexcept = default;
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(weak_ordering __v, _CmpUnspecifiedParam) noexcept {
-    return __v.__value_ == 0;
-  }
+  friend constexpr bool operator==(weak_ordering __v, _CmpUnspecifiedParam) noexcept { return __v.__value_ == 0; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator<(weak_ordering __v, _CmpUnspecifiedParam) noexcept {
-    return __v.__value_ < 0;
-  }
+  friend constexpr bool operator<(weak_ordering __v, _CmpUnspecifiedParam) noexcept { return __v.__value_ < 0; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator<=(weak_ordering __v, _CmpUnspecifiedParam) noexcept {
-    return __v.__value_ <= 0;
-  }
+  friend constexpr bool operator<=(weak_ordering __v, _CmpUnspecifiedParam) noexcept { return __v.__value_ <= 0; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator>(weak_ordering __v, _CmpUnspecifiedParam) noexcept {
-    return __v.__value_ > 0;
-  }
+  friend constexpr bool operator>(weak_ordering __v, _CmpUnspecifiedParam) noexcept { return __v.__value_ > 0; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator>=(weak_ordering __v, _CmpUnspecifiedParam) noexcept {
-    return __v.__value_ >= 0;
-  }
+  friend constexpr bool operator>=(weak_ordering __v, _CmpUnspecifiedParam) noexcept { return __v.__value_ >= 0; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator<(_CmpUnspecifiedParam, weak_ordering __v) noexcept {
-    return 0 < __v.__value_;
-  }
+  friend constexpr bool operator<(_CmpUnspecifiedParam, weak_ordering __v) noexcept { return 0 < __v.__value_; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator<=(_CmpUnspecifiedParam, weak_ordering __v) noexcept {
-    return 0 <= __v.__value_;
-  }
+  friend constexpr bool operator<=(_CmpUnspecifiedParam, weak_ordering __v) noexcept { return 0 <= __v.__value_; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator>(_CmpUnspecifiedParam, weak_ordering __v) noexcept {
-    return 0 > __v.__value_;
-  }
+  friend constexpr bool operator>(_CmpUnspecifiedParam, weak_ordering __v) noexcept { return 0 > __v.__value_; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator>=(_CmpUnspecifiedParam, weak_ordering __v) noexcept {
-    return 0 >= __v.__value_;
-  }
+  friend constexpr bool operator>=(_CmpUnspecifiedParam, weak_ordering __v) noexcept { return 0 >= __v.__value_; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr weak_ordering operator<=>(weak_ordering __v, _CmpUnspecifiedParam) noexcept {
-    return __v;
-  }
+  friend constexpr weak_ordering operator<=>(weak_ordering __v, _CmpUnspecifiedParam) noexcept { return __v; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr weak_ordering operator<=>(_CmpUnspecifiedParam, weak_ordering __v) noexcept {
+  friend constexpr weak_ordering operator<=>(_CmpUnspecifiedParam, weak_ordering __v) noexcept {
     return __v < 0 ? weak_ordering::greater : (__v > 0 ? weak_ordering::less : __v);
   }
 
@@ -192,7 +168,7 @@ inline constexpr weak_ordering weak_ordering::greater(_OrdResult::__greater);
 class strong_ordering {
   using _ValueT _LIBCPP_NODEBUG = signed char;
 
-  _LIBCPP_HIDE_FROM_ABI explicit constexpr strong_ordering(_OrdResult __v) noexcept : __value_(_ValueT(__v)) {}
+  explicit constexpr strong_ordering(_OrdResult __v) noexcept : __value_(_ValueT(__v)) {}
 
 public:
   static const strong_ordering less;
@@ -201,61 +177,39 @@ public:
   static const strong_ordering greater;
 
   // conversions
-  _LIBCPP_HIDE_FROM_ABI constexpr operator partial_ordering() const noexcept {
+  constexpr operator partial_ordering() const noexcept {
     return __value_ == 0 ? partial_ordering::equivalent
                          : (__value_ < 0 ? partial_ordering::less : partial_ordering::greater);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr operator weak_ordering() const noexcept {
+  constexpr operator weak_ordering() const noexcept {
     return __value_ == 0 ? weak_ordering::equivalent : (__value_ < 0 ? weak_ordering::less : weak_ordering::greater);
   }
 
   // comparisons
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(strong_ordering, strong_ordering) noexcept = default;
+  friend constexpr bool operator==(strong_ordering, strong_ordering) noexcept = default;
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(strong_ordering __v, _CmpUnspecifiedParam) noexcept {
-    return __v.__value_ == 0;
-  }
+  friend constexpr bool operator==(strong_ordering __v, _CmpUnspecifiedParam) noexcept { return __v.__value_ == 0; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator<(strong_ordering __v, _CmpUnspecifiedParam) noexcept {
-    return __v.__value_ < 0;
-  }
+  friend constexpr bool operator<(strong_ordering __v, _CmpUnspecifiedParam) noexcept { return __v.__value_ < 0; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator<=(strong_ordering __v, _CmpUnspecifiedParam) noexcept {
-    return __v.__value_ <= 0;
-  }
+  friend constexpr bool operator<=(strong_ordering __v, _CmpUnspecifiedParam) noexcept { return __v.__value_ <= 0; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator>(strong_ordering __v, _CmpUnspecifiedParam) noexcept {
-    return __v.__value_ > 0;
-  }
+  friend constexpr bool operator>(strong_ordering __v, _CmpUnspecifiedParam) noexcept { return __v.__value_ > 0; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator>=(strong_ordering __v, _CmpUnspecifiedParam) noexcept {
-    return __v.__value_ >= 0;
-  }
+  friend constexpr bool operator>=(strong_ordering __v, _CmpUnspecifiedParam) noexcept { return __v.__value_ >= 0; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator<(_CmpUnspecifiedParam, strong_ordering __v) noexcept {
-    return 0 < __v.__value_;
-  }
+  friend constexpr bool operator<(_CmpUnspecifiedParam, strong_ordering __v) noexcept { return 0 < __v.__value_; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator<=(_CmpUnspecifiedParam, strong_ordering __v) noexcept {
-    return 0 <= __v.__value_;
-  }
+  friend constexpr bool operator<=(_CmpUnspecifiedParam, strong_ordering __v) noexcept { return 0 <= __v.__value_; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator>(_CmpUnspecifiedParam, strong_ordering __v) noexcept {
-    return 0 > __v.__value_;
-  }
+  friend constexpr bool operator>(_CmpUnspecifiedParam, strong_ordering __v) noexcept { return 0 > __v.__value_; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator>=(_CmpUnspecifiedParam, strong_ordering __v) noexcept {
-    return 0 >= __v.__value_;
-  }
+  friend constexpr bool operator>=(_CmpUnspecifiedParam, strong_ordering __v) noexcept { return 0 >= __v.__value_; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr strong_ordering
-  operator<=>(strong_ordering __v, _CmpUnspecifiedParam) noexcept {
-    return __v;
-  }
+  friend constexpr strong_ordering operator<=>(strong_ordering __v, _CmpUnspecifiedParam) noexcept { return __v; }
 
-  _LIBCPP_HIDE_FROM_ABI friend constexpr strong_ordering
-  operator<=>(_CmpUnspecifiedParam, strong_ordering __v) noexcept {
+  friend constexpr strong_ordering operator<=>(_CmpUnspecifiedParam, strong_ordering __v) noexcept {
     return __v < 0 ? strong_ordering::greater : (__v > 0 ? strong_ordering::less : __v);
   }
 

--- a/libcxx/include/__compare/partial_order.h
+++ b/libcxx/include/__compare/partial_order.h
@@ -34,7 +34,7 @@ struct __fn {
   // NOLINTBEGIN(libcpp-robust-against-adl) partial_order should use ADL, but only here
   template <class _Tp, class _Up>
     requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto __go(_Tp&& __t, _Up&& __u, __priority_tag<2>) noexcept(
+  static constexpr auto __go(_Tp&& __t, _Up&& __u, __priority_tag<2>) noexcept(
       noexcept(partial_ordering(partial_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)))))
       -> decltype(partial_ordering(partial_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)))) {
     return partial_ordering(partial_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)));
@@ -43,7 +43,7 @@ struct __fn {
 
   template <class _Tp, class _Up>
     requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto __go(_Tp&& __t, _Up&& __u, __priority_tag<1>) noexcept(
+  static constexpr auto __go(_Tp&& __t, _Up&& __u, __priority_tag<1>) noexcept(
       noexcept(partial_ordering(compare_three_way()(std::forward<_Tp>(__t), std::forward<_Up>(__u)))))
       -> decltype(partial_ordering(compare_three_way()(std::forward<_Tp>(__t), std::forward<_Up>(__u)))) {
     return partial_ordering(compare_three_way()(std::forward<_Tp>(__t), std::forward<_Up>(__u)));
@@ -51,14 +51,14 @@ struct __fn {
 
   template <class _Tp, class _Up>
     requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto __go(_Tp&& __t, _Up&& __u, __priority_tag<0>) noexcept(
+  static constexpr auto __go(_Tp&& __t, _Up&& __u, __priority_tag<0>) noexcept(
       noexcept(partial_ordering(std::weak_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)))))
       -> decltype(partial_ordering(std::weak_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)))) {
     return partial_ordering(std::weak_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)));
   }
 
   template <class _Tp, class _Up>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t, _Up&& __u) const
+  constexpr auto operator()(_Tp&& __t, _Up&& __u) const
       noexcept(noexcept(__go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<2>())))
           -> decltype(__go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<2>())) {
     return __go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<2>());

--- a/libcxx/include/__compare/strong_order.h
+++ b/libcxx/include/__compare/strong_order.h
@@ -42,7 +42,7 @@ struct __fn {
   // NOLINTBEGIN(libcpp-robust-against-adl) strong_order should use ADL, but only here
   template <class _Tp, class _Up>
     requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto __go(_Tp&& __t, _Up&& __u, __priority_tag<2>) noexcept(
+  static constexpr auto __go(_Tp&& __t, _Up&& __u, __priority_tag<2>) noexcept(
       noexcept(strong_ordering(strong_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)))))
       -> decltype(strong_ordering(strong_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)))) {
     return strong_ordering(strong_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)));
@@ -51,7 +51,7 @@ struct __fn {
 
   template <class _Tp, class _Up, class _Dp = decay_t<_Tp>>
     requires is_same_v<_Dp, decay_t<_Up>> && is_floating_point_v<_Dp>
-  _LIBCPP_HIDE_FROM_ABI static constexpr strong_ordering __go(_Tp&& __t, _Up&& __u, __priority_tag<1>) noexcept {
+  static constexpr strong_ordering __go(_Tp&& __t, _Up&& __u, __priority_tag<1>) noexcept {
     if constexpr (numeric_limits<_Dp>::is_iec559 &&
                   (sizeof(_Dp) == sizeof(int32_t) || sizeof(_Dp) == sizeof(int64_t))) {
       using _IntT = conditional_t<sizeof(_Dp) == sizeof(int32_t), int32_t, int64_t>;
@@ -97,14 +97,14 @@ struct __fn {
 
   template <class _Tp, class _Up>
     requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto __go(_Tp&& __t, _Up&& __u, __priority_tag<0>) noexcept(
+  static constexpr auto __go(_Tp&& __t, _Up&& __u, __priority_tag<0>) noexcept(
       noexcept(strong_ordering(compare_three_way()(std::forward<_Tp>(__t), std::forward<_Up>(__u)))))
       -> decltype(strong_ordering(compare_three_way()(std::forward<_Tp>(__t), std::forward<_Up>(__u)))) {
     return strong_ordering(compare_three_way()(std::forward<_Tp>(__t), std::forward<_Up>(__u)));
   }
 
   template <class _Tp, class _Up>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t, _Up&& __u) const
+  constexpr auto operator()(_Tp&& __t, _Up&& __u) const
       noexcept(noexcept(__go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<2>())))
           -> decltype(__go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<2>())) {
     return __go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<2>());

--- a/libcxx/include/__compare/synth_three_way.h
+++ b/libcxx/include/__compare/synth_three_way.h
@@ -25,7 +25,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 // [expos.only.func]
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr auto __synth_three_way = []<class _Tp, class _Up>(const _Tp& __t, const _Up& __u)
+inline constexpr auto __synth_three_way = []<class _Tp, class _Up>(const _Tp& __t, const _Up& __u)
   requires requires {
     { __t < __u } -> __boolean_testable;
     { __u < __t } -> __boolean_testable;

--- a/libcxx/include/__compare/weak_order.h
+++ b/libcxx/include/__compare/weak_order.h
@@ -36,7 +36,7 @@ struct __fn {
   // NOLINTBEGIN(libcpp-robust-against-adl) weak_order should use ADL, but only here
   template <class _Tp, class _Up>
     requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto __go(_Tp&& __t, _Up&& __u, __priority_tag<3>) noexcept(
+  static constexpr auto __go(_Tp&& __t, _Up&& __u, __priority_tag<3>) noexcept(
       noexcept(weak_ordering(weak_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)))))
       -> decltype(weak_ordering(weak_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)))) {
     return weak_ordering(weak_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)));
@@ -45,7 +45,7 @@ struct __fn {
 
   template <class _Tp, class _Up, class _Dp = decay_t<_Tp>>
     requires is_same_v<_Dp, decay_t<_Up>> && is_floating_point_v<_Dp>
-  _LIBCPP_HIDE_FROM_ABI static constexpr weak_ordering __go(_Tp&& __t, _Up&& __u, __priority_tag<2>) noexcept {
+  static constexpr weak_ordering __go(_Tp&& __t, _Up&& __u, __priority_tag<2>) noexcept {
     partial_ordering __po = (__t <=> __u);
     if (__po == partial_ordering::less) {
       return weak_ordering::less;
@@ -71,7 +71,7 @@ struct __fn {
 
   template <class _Tp, class _Up>
     requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto __go(_Tp&& __t, _Up&& __u, __priority_tag<1>) noexcept(
+  static constexpr auto __go(_Tp&& __t, _Up&& __u, __priority_tag<1>) noexcept(
       noexcept(weak_ordering(compare_three_way()(std::forward<_Tp>(__t), std::forward<_Up>(__u)))))
       -> decltype(weak_ordering(compare_three_way()(std::forward<_Tp>(__t), std::forward<_Up>(__u)))) {
     return weak_ordering(compare_three_way()(std::forward<_Tp>(__t), std::forward<_Up>(__u)));
@@ -79,14 +79,14 @@ struct __fn {
 
   template <class _Tp, class _Up>
     requires is_same_v<decay_t<_Tp>, decay_t<_Up>>
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto __go(_Tp&& __t, _Up&& __u, __priority_tag<0>) noexcept(
+  static constexpr auto __go(_Tp&& __t, _Up&& __u, __priority_tag<0>) noexcept(
       noexcept(weak_ordering(std::strong_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)))))
       -> decltype(weak_ordering(std::strong_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)))) {
     return weak_ordering(std::strong_order(std::forward<_Tp>(__t), std::forward<_Up>(__u)));
   }
 
   template <class _Tp, class _Up>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t, _Up&& __u) const
+  constexpr auto operator()(_Tp&& __t, _Up&& __u) const
       noexcept(noexcept(__go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<3>())))
           -> decltype(__go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<3>())) {
     return __go(std::forward<_Tp>(__t), std::forward<_Up>(__u), __priority_tag<3>());

--- a/libcxx/include/__concepts/swappable.h
+++ b/libcxx/include/__concepts/swappable.h
@@ -72,7 +72,7 @@ struct __fn {
   // *The name `swap` is used here unqualified.
   template <class _Tp, class _Up>
     requires __unqualified_swappable_with<_Tp, _Up>
-  _LIBCPP_HIDE_FROM_ABI constexpr void operator()(_Tp&& __t, _Up&& __u) const
+  constexpr void operator()(_Tp&& __t, _Up&& __u) const
       noexcept(noexcept(swap(std::forward<_Tp>(__t), std::forward<_Up>(__u)))) {
     swap(std::forward<_Tp>(__t), std::forward<_Up>(__u));
   }
@@ -80,8 +80,7 @@ struct __fn {
   // 2.2   Otherwise, if `E1` and `E2` are lvalues of array types with equal extent and...
   template <class _Tp, class _Up, size_t _Size>
     requires __swappable_arrays<_Tp, _Up, _Size>
-  _LIBCPP_HIDE_FROM_ABI constexpr void operator()(_Tp (&__t)[_Size], _Up (&__u)[_Size]) const
-      noexcept(noexcept((*this)(*__t, *__u))) {
+  constexpr void operator()(_Tp (&__t)[_Size], _Up (&__u)[_Size]) const noexcept(noexcept((*this)(*__t, *__u))) {
     // TODO(cjdb): replace with `ranges::swap_ranges`.
     for (size_t __i = 0; __i < _Size; ++__i) {
       (*this)(__t[__i], __u[__i]);
@@ -90,7 +89,7 @@ struct __fn {
 
   // 2.3   Otherwise, if `E1` and `E2` are lvalues of the same type `T` that models...
   template <__exchangeable _Tp>
-  _LIBCPP_HIDE_FROM_ABI constexpr void operator()(_Tp& __x, _Tp& __y) const
+  constexpr void operator()(_Tp& __x, _Tp& __y) const
       noexcept(is_nothrow_move_constructible_v<_Tp> && is_nothrow_move_assignable_v<_Tp>) {
     __y = std::exchange(__x, std::move(__y));
   }

--- a/libcxx/include/__condition_variable/condition_variable.h
+++ b/libcxx/include/__condition_variable/condition_variable.h
@@ -41,7 +41,7 @@ _LIBCPP_DECLARE_STRONG_ENUM(cv_status){no_timeout, timeout};
 _LIBCPP_DECLARE_STRONG_ENUM_EPILOG(cv_status)
 
 template <class _Rep, class _Period, __enable_if_t<is_floating_point<_Rep>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI chrono::nanoseconds __safe_nanosecond_cast(chrono::duration<_Rep, _Period> __d) {
+inline chrono::nanoseconds __safe_nanosecond_cast(chrono::duration<_Rep, _Period> __d) {
   using namespace chrono;
   using __ratio       = ratio_divide<_Period, nano>;
   using __ns_rep      = nanoseconds::rep;
@@ -61,7 +61,7 @@ inline _LIBCPP_HIDE_FROM_ABI chrono::nanoseconds __safe_nanosecond_cast(chrono::
 }
 
 template <class _Rep, class _Period, __enable_if_t<!is_floating_point<_Rep>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI chrono::nanoseconds __safe_nanosecond_cast(chrono::duration<_Rep, _Period> __d) {
+inline chrono::nanoseconds __safe_nanosecond_cast(chrono::duration<_Rep, _Period> __d) {
   using namespace chrono;
   if (__d.count() == 0) {
     return nanoseconds(0);
@@ -91,7 +91,7 @@ class _LIBCPP_EXPORTED_FROM_ABI condition_variable {
   __libcpp_condvar_t __cv_ = _LIBCPP_CONDVAR_INITIALIZER;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR condition_variable() _NOEXCEPT = default;
+  _LIBCPP_CONSTEXPR condition_variable() _NOEXCEPT = default;
 
 #  if _LIBCPP_HAS_TRIVIAL_CONDVAR_DESTRUCTION
   ~condition_variable() = default;
@@ -108,14 +108,13 @@ public:
   void wait(unique_lock<mutex>& __lk) _NOEXCEPT;
 
   template <class _Predicate>
-  _LIBCPP_HIDE_FROM_ABI void wait(unique_lock<mutex>& __lk, _Predicate __pred) {
+  void wait(unique_lock<mutex>& __lk, _Predicate __pred) {
     while (!__pred())
       wait(__lk);
   }
 
   template <class _Clock, class _Duration>
-  _LIBCPP_HIDE_FROM_ABI cv_status
-  wait_until(unique_lock<mutex>& __lk, const chrono::time_point<_Clock, _Duration>& __t) {
+  cv_status wait_until(unique_lock<mutex>& __lk, const chrono::time_point<_Clock, _Duration>& __t) {
     using namespace chrono;
     using __clock_tp_ns = time_point<_Clock, nanoseconds>;
 
@@ -130,8 +129,7 @@ public:
   }
 
   template <class _Clock, class _Duration, class _Predicate>
-  _LIBCPP_HIDE_FROM_ABI bool
-  wait_until(unique_lock<mutex>& __lk, const chrono::time_point<_Clock, _Duration>& __t, _Predicate __pred) {
+  bool wait_until(unique_lock<mutex>& __lk, const chrono::time_point<_Clock, _Duration>& __t, _Predicate __pred) {
     while (!__pred()) {
       if (wait_until(__lk, __t) == cv_status::timeout)
         return __pred();
@@ -140,7 +138,7 @@ public:
   }
 
   template <class _Rep, class _Period>
-  _LIBCPP_HIDE_FROM_ABI cv_status wait_for(unique_lock<mutex>& __lk, const chrono::duration<_Rep, _Period>& __d) {
+  cv_status wait_for(unique_lock<mutex>& __lk, const chrono::duration<_Rep, _Period>& __d) {
     using namespace chrono;
     if (__d <= __d.zero())
       return cv_status::timeout;
@@ -167,22 +165,20 @@ public:
   }
 
   template <class _Rep, class _Period, class _Predicate>
-  bool _LIBCPP_HIDE_FROM_ABI
-  wait_for(unique_lock<mutex>& __lk, const chrono::duration<_Rep, _Period>& __d, _Predicate __pred);
+  bool wait_for(unique_lock<mutex>& __lk, const chrono::duration<_Rep, _Period>& __d, _Predicate __pred);
 
   typedef __libcpp_condvar_t* native_handle_type;
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI native_handle_type native_handle() { return &__cv_; }
+  [[__nodiscard__]] native_handle_type native_handle() { return &__cv_; }
 
 private:
   void
   __do_timed_wait(unique_lock<mutex>& __lk, chrono::time_point<chrono::system_clock, chrono::nanoseconds>) _NOEXCEPT;
 #  if _LIBCPP_HAS_COND_CLOCKWAIT
-  _LIBCPP_HIDE_FROM_ABI void
+  void
   __do_timed_wait(unique_lock<mutex>& __lk, chrono::time_point<chrono::steady_clock, chrono::nanoseconds>) _NOEXCEPT;
 #  endif
   template <class _Clock>
-  _LIBCPP_HIDE_FROM_ABI void
-  __do_timed_wait(unique_lock<mutex>& __lk, chrono::time_point<_Clock, chrono::nanoseconds>) _NOEXCEPT;
+  void __do_timed_wait(unique_lock<mutex>& __lk, chrono::time_point<_Clock, chrono::nanoseconds>) _NOEXCEPT;
 };
 #endif // _LIBCPP_HAS_THREADS
 

--- a/libcxx/include/__coroutine/coroutine_handle.h
+++ b/libcxx/include/__coroutine/coroutine_handle.h
@@ -36,46 +36,46 @@ public:
   // [coroutine.handle.con], construct/reset
   constexpr coroutine_handle() noexcept = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr coroutine_handle(nullptr_t) noexcept {}
+  constexpr coroutine_handle(nullptr_t) noexcept {}
 
-  _LIBCPP_HIDE_FROM_ABI coroutine_handle& operator=(nullptr_t) noexcept {
+  coroutine_handle& operator=(nullptr_t) noexcept {
     __handle_ = nullptr;
     return *this;
   }
 
   // [coroutine.handle.export.import], export/import
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr void* address() const noexcept { return __handle_; }
+  [[nodiscard]] constexpr void* address() const noexcept { return __handle_; }
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr coroutine_handle from_address(void* __addr) noexcept {
+  [[nodiscard]] static constexpr coroutine_handle from_address(void* __addr) noexcept {
     coroutine_handle __tmp;
     __tmp.__handle_ = __addr;
     return __tmp;
   }
 
   // [coroutine.handle.observers], observers
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit operator bool() const noexcept { return __handle_ != nullptr; }
+  constexpr explicit operator bool() const noexcept { return __handle_ != nullptr; }
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool done() const {
+  [[nodiscard]] bool done() const {
     _LIBCPP_ASSERT_VALID_EXTERNAL_API_CALL(__is_suspended(), "done() can be called only on suspended coroutines");
     return __builtin_coro_done(__handle_);
   }
 
   // [coroutine.handle.resumption], resumption
-  _LIBCPP_HIDE_FROM_ABI void operator()() const { resume(); }
+  void operator()() const { resume(); }
 
-  _LIBCPP_HIDE_FROM_ABI void resume() const {
+  void resume() const {
     _LIBCPP_ASSERT_VALID_EXTERNAL_API_CALL(__is_suspended(), "resume() can be called only on suspended coroutines");
     _LIBCPP_ASSERT_VALID_EXTERNAL_API_CALL(!done(), "resume() has undefined behavior when the coroutine is done");
     __builtin_coro_resume(__handle_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI void destroy() const {
+  void destroy() const {
     _LIBCPP_ASSERT_VALID_EXTERNAL_API_CALL(__is_suspended(), "destroy() can be called only on suspended coroutines");
     __builtin_coro_destroy(__handle_);
   }
 
 private:
-  _LIBCPP_HIDE_FROM_ABI bool __is_suspended() const {
+  bool __is_suspended() const {
     // FIXME actually implement a check for if the coro is suspended.
     return __handle_ != nullptr;
   }
@@ -84,11 +84,10 @@ private:
 };
 
 // [coroutine.handle.compare]
-inline _LIBCPP_HIDE_FROM_ABI constexpr bool operator==(coroutine_handle<> __x, coroutine_handle<> __y) noexcept {
+inline constexpr bool operator==(coroutine_handle<> __x, coroutine_handle<> __y) noexcept {
   return __x.address() == __y.address();
 }
-inline _LIBCPP_HIDE_FROM_ABI constexpr strong_ordering
-operator<=>(coroutine_handle<> __x, coroutine_handle<> __y) noexcept {
+inline constexpr strong_ordering operator<=>(coroutine_handle<> __x, coroutine_handle<> __y) noexcept {
   return compare_three_way()(__x.address(), __y.address());
 }
 
@@ -98,9 +97,9 @@ public:
   // [coroutine.handle.con], construct/reset
   constexpr coroutine_handle() noexcept = default;
 
-  _LIBCPP_HIDE_FROM_ABI constexpr coroutine_handle(nullptr_t) noexcept {}
+  constexpr coroutine_handle(nullptr_t) noexcept {}
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static coroutine_handle from_promise(_Promise& __promise) {
+  [[nodiscard]] static coroutine_handle from_promise(_Promise& __promise) {
     using _RawPromise = __remove_cv_t<_Promise>;
     coroutine_handle __tmp;
     __tmp.__handle_ =
@@ -108,54 +107,52 @@ public:
     return __tmp;
   }
 
-  _LIBCPP_HIDE_FROM_ABI coroutine_handle& operator=(nullptr_t) noexcept {
+  coroutine_handle& operator=(nullptr_t) noexcept {
     __handle_ = nullptr;
     return *this;
   }
 
   // [coroutine.handle.export.import], export/import
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr void* address() const noexcept { return __handle_; }
+  [[nodiscard]] constexpr void* address() const noexcept { return __handle_; }
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr coroutine_handle from_address(void* __addr) noexcept {
+  [[nodiscard]] static constexpr coroutine_handle from_address(void* __addr) noexcept {
     coroutine_handle __tmp;
     __tmp.__handle_ = __addr;
     return __tmp;
   }
 
   // [coroutine.handle.conv], conversion
-  _LIBCPP_HIDE_FROM_ABI constexpr operator coroutine_handle<>() const noexcept {
-    return coroutine_handle<>::from_address(address());
-  }
+  constexpr operator coroutine_handle<>() const noexcept { return coroutine_handle<>::from_address(address()); }
 
   // [coroutine.handle.observers], observers
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit operator bool() const noexcept { return __handle_ != nullptr; }
+  constexpr explicit operator bool() const noexcept { return __handle_ != nullptr; }
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool done() const {
+  [[nodiscard]] bool done() const {
     _LIBCPP_ASSERT_VALID_EXTERNAL_API_CALL(__is_suspended(), "done() can be called only on suspended coroutines");
     return __builtin_coro_done(__handle_);
   }
 
   // [coroutine.handle.resumption], resumption
-  _LIBCPP_HIDE_FROM_ABI void operator()() const { resume(); }
+  void operator()() const { resume(); }
 
-  _LIBCPP_HIDE_FROM_ABI void resume() const {
+  void resume() const {
     _LIBCPP_ASSERT_VALID_EXTERNAL_API_CALL(__is_suspended(), "resume() can be called only on suspended coroutines");
     _LIBCPP_ASSERT_VALID_EXTERNAL_API_CALL(!done(), "resume() has undefined behavior when the coroutine is done");
     __builtin_coro_resume(__handle_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI void destroy() const {
+  void destroy() const {
     _LIBCPP_ASSERT_VALID_EXTERNAL_API_CALL(__is_suspended(), "destroy() can be called only on suspended coroutines");
     __builtin_coro_destroy(__handle_);
   }
 
   // [coroutine.handle.promise], promise access
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI _Promise& promise() const {
+  [[nodiscard]] _Promise& promise() const {
     return *static_cast<_Promise*>(__builtin_coro_promise(this->__handle_, alignof(_Promise), false));
   }
 
 private:
-  _LIBCPP_HIDE_FROM_ABI bool __is_suspended() const {
+  bool __is_suspended() const {
     // FIXME actually implement a check for if the coro is suspended.
     return __handle_ != nullptr;
   }
@@ -165,7 +162,7 @@ private:
 // [coroutine.handle.hash]
 template <class _Tp>
 struct hash<coroutine_handle<_Tp>> {
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI size_t operator()(const coroutine_handle<_Tp>& __v) const noexcept {
+  [[nodiscard]] size_t operator()(const coroutine_handle<_Tp>& __v) const noexcept {
     return hash<void*>()(__v.address());
   }
 };

--- a/libcxx/include/__coroutine/noop_coroutine_handle.h
+++ b/libcxx/include/__coroutine/noop_coroutine_handle.h
@@ -29,33 +29,31 @@ template <>
 struct coroutine_handle<noop_coroutine_promise> {
 public:
   // [coroutine.handle.noop.conv], conversion
-  _LIBCPP_HIDE_FROM_ABI constexpr operator coroutine_handle<>() const noexcept {
-    return coroutine_handle<>::from_address(address());
-  }
+  constexpr operator coroutine_handle<>() const noexcept { return coroutine_handle<>::from_address(address()); }
 
   // [coroutine.handle.noop.observers], observers
-  _LIBCPP_HIDE_FROM_ABI constexpr explicit operator bool() const noexcept { return true; }
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool done() const noexcept { return false; }
+  constexpr explicit operator bool() const noexcept { return true; }
+  [[nodiscard]] constexpr bool done() const noexcept { return false; }
 
   // [coroutine.handle.noop.resumption], resumption
-  _LIBCPP_HIDE_FROM_ABI constexpr void operator()() const noexcept {}
-  _LIBCPP_HIDE_FROM_ABI constexpr void resume() const noexcept {}
-  _LIBCPP_HIDE_FROM_ABI constexpr void destroy() const noexcept {}
+  constexpr void operator()() const noexcept {}
+  constexpr void resume() const noexcept {}
+  constexpr void destroy() const noexcept {}
 
   // [coroutine.handle.noop.promise], promise access
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI noop_coroutine_promise& promise() const noexcept {
+  [[nodiscard]] noop_coroutine_promise& promise() const noexcept {
     return *static_cast<noop_coroutine_promise*>(
         __builtin_coro_promise(this->__handle_, alignof(noop_coroutine_promise), false));
   }
 
   // [coroutine.handle.noop.address], address
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr void* address() const noexcept { return __handle_; }
+  [[nodiscard]] constexpr void* address() const noexcept { return __handle_; }
 
 private:
-  _LIBCPP_HIDE_FROM_ABI friend coroutine_handle<noop_coroutine_promise> noop_coroutine() noexcept;
+  friend coroutine_handle<noop_coroutine_promise> noop_coroutine() noexcept;
 
 #  if __has_builtin(__builtin_coro_noop)
-  _LIBCPP_HIDE_FROM_ABI coroutine_handle() noexcept { this->__handle_ = __builtin_coro_noop(); }
+  coroutine_handle() noexcept { this->__handle_ = __builtin_coro_noop(); }
 
   void* __handle_ = nullptr;
 
@@ -74,7 +72,7 @@ private:
 
   void* __handle_ = &__noop_coroutine_frame_;
 
-  _LIBCPP_HIDE_FROM_ABI coroutine_handle() noexcept = default;
+  coroutine_handle() noexcept = default;
 
 #  endif // __has_builtin(__builtin_coro_noop)
 };
@@ -86,9 +84,7 @@ inline noop_coroutine_handle::__noop_coroutine_frame_ty_ noop_coroutine_handle::
 #  endif
 
 // [coroutine.noop.coroutine]
-[[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI noop_coroutine_handle noop_coroutine() noexcept {
-  return noop_coroutine_handle();
-}
+[[nodiscard]] inline noop_coroutine_handle noop_coroutine() noexcept { return noop_coroutine_handle(); }
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__coroutine/trivial_awaitables.h
+++ b/libcxx/include/__coroutine/trivial_awaitables.h
@@ -22,15 +22,15 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 // [coroutine.trivial.awaitables]
 struct suspend_never {
-  _LIBCPP_HIDE_FROM_ABI constexpr bool await_ready() const noexcept { return true; }
-  _LIBCPP_HIDE_FROM_ABI constexpr void await_suspend(coroutine_handle<>) const noexcept {}
-  _LIBCPP_HIDE_FROM_ABI constexpr void await_resume() const noexcept {}
+  constexpr bool await_ready() const noexcept { return true; }
+  constexpr void await_suspend(coroutine_handle<>) const noexcept {}
+  constexpr void await_resume() const noexcept {}
 };
 
 struct suspend_always {
-  _LIBCPP_HIDE_FROM_ABI constexpr bool await_ready() const noexcept { return false; }
-  _LIBCPP_HIDE_FROM_ABI constexpr void await_suspend(coroutine_handle<>) const noexcept {}
-  _LIBCPP_HIDE_FROM_ABI constexpr void await_resume() const noexcept {}
+  constexpr bool await_ready() const noexcept { return false; }
+  constexpr void await_suspend(coroutine_handle<>) const noexcept {}
+  constexpr void await_resume() const noexcept {}
 };
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__cstddef/byte.h
+++ b/libcxx/include/__cstddef/byte.h
@@ -23,59 +23,53 @@ _LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
 
 enum class byte : unsigned char {};
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr byte operator|(byte __lhs, byte __rhs) noexcept {
+inline constexpr byte operator|(byte __lhs, byte __rhs) noexcept {
   return static_cast<byte>(
       static_cast<unsigned char>(static_cast<unsigned int>(__lhs) | static_cast<unsigned int>(__rhs)));
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr byte& operator|=(byte& __lhs, byte __rhs) noexcept {
-  return __lhs = __lhs | __rhs;
-}
+inline constexpr byte& operator|=(byte& __lhs, byte __rhs) noexcept { return __lhs = __lhs | __rhs; }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr byte operator&(byte __lhs, byte __rhs) noexcept {
+inline constexpr byte operator&(byte __lhs, byte __rhs) noexcept {
   return static_cast<byte>(
       static_cast<unsigned char>(static_cast<unsigned int>(__lhs) & static_cast<unsigned int>(__rhs)));
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr byte& operator&=(byte& __lhs, byte __rhs) noexcept {
-  return __lhs = __lhs & __rhs;
-}
+inline constexpr byte& operator&=(byte& __lhs, byte __rhs) noexcept { return __lhs = __lhs & __rhs; }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr byte operator^(byte __lhs, byte __rhs) noexcept {
+inline constexpr byte operator^(byte __lhs, byte __rhs) noexcept {
   return static_cast<byte>(
       static_cast<unsigned char>(static_cast<unsigned int>(__lhs) ^ static_cast<unsigned int>(__rhs)));
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr byte& operator^=(byte& __lhs, byte __rhs) noexcept {
-  return __lhs = __lhs ^ __rhs;
-}
+inline constexpr byte& operator^=(byte& __lhs, byte __rhs) noexcept { return __lhs = __lhs ^ __rhs; }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr byte operator~(byte __b) noexcept {
+inline constexpr byte operator~(byte __b) noexcept {
   return static_cast<byte>(static_cast<unsigned char>(~static_cast<unsigned int>(__b)));
 }
 
 template <class _Integer, __enable_if_t<is_integral<_Integer>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI constexpr byte& operator<<=(byte& __lhs, _Integer __shift) noexcept {
+constexpr byte& operator<<=(byte& __lhs, _Integer __shift) noexcept {
   return __lhs = __lhs << __shift;
 }
 
 template <class _Integer, __enable_if_t<is_integral<_Integer>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI constexpr byte operator<<(byte __lhs, _Integer __shift) noexcept {
+constexpr byte operator<<(byte __lhs, _Integer __shift) noexcept {
   return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(__lhs) << __shift));
 }
 
 template <class _Integer, __enable_if_t<is_integral<_Integer>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI constexpr byte& operator>>=(byte& __lhs, _Integer __shift) noexcept {
+constexpr byte& operator>>=(byte& __lhs, _Integer __shift) noexcept {
   return __lhs = __lhs >> __shift;
 }
 
 template <class _Integer, __enable_if_t<is_integral<_Integer>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI constexpr byte operator>>(byte __lhs, _Integer __shift) noexcept {
+constexpr byte operator>>(byte __lhs, _Integer __shift) noexcept {
   return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(__lhs) >> __shift));
 }
 
 template <class _Integer, __enable_if_t<is_integral<_Integer>::value, int> = 0>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Integer to_integer(byte __b) noexcept {
+[[nodiscard]] constexpr _Integer to_integer(byte __b) noexcept {
   return static_cast<_Integer>(__b);
 }
 


### PR DESCRIPTION
This is the first bulk-removal patch of `_LIBCPP_HIDE_FROM_ABI`. While
this is something we could do over time, actively removing the redundant
annotations significanly improves readability, and QoI.
This happens in a few patches to keep the size somewhat manageable.
