### PR TITLE
[CIR] Fix bitfield post-increment return value

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -725,7 +725,7 @@ public:
 
     // Store the updated result through the lvalue
     if (lv.isBitField())
-      return cgf.emitStoreThroughBitfieldLValue(RValue::get(value), lv);
+      value = cgf.emitStoreThroughBitfieldLValue(RValue::get(value), lv);
     else
       cgf.emitStoreThroughLValue(RValue::get(value), lv);
 

--- a/clang/test/CIR/CodeGen/bitfield-postinc.cpp
+++ b/clang/test/CIR/CodeGen/bitfield-postinc.cpp
@@ -1,0 +1,63 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s --check-prefixes=LLVM,LLVM-CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s --check-prefixes=LLVM,OGCG
+
+struct S { unsigned type : 6; unsigned nRefs : 26; };
+
+// Post-increment: returns OLD value, stores OLD+1.
+int postinc(S *s) {
+  return s->nRefs++;
+}
+
+// Pre-increment: returns NEW value, stores OLD+1.
+int preinc(S *s) {
+  return ++s->nRefs;
+}
+
+// CIR-LABEL: @_Z7postincP1S
+// CIR:         %[[OLD:.*]] = cir.get_bitfield
+// CIR:         %[[INC:.*]] = cir.inc %[[OLD]]
+// CIR:         cir.set_bitfield {{.*}} %[[INC]]
+// CIR:         cir.cast integral %[[OLD]]
+// CIR-NOT:     cir.cast integral %[[INC]]
+
+// CIR-LABEL: @_Z6preincP1S
+// CIR:         %[[OLD2:.*]] = cir.get_bitfield
+// CIR:         %[[INC2:.*]] = cir.inc %[[OLD2]]
+// CIR:         %[[STORED:.*]] = cir.set_bitfield {{.*}} %[[INC2]]
+// CIR:         cir.cast integral %[[STORED]]
+
+// Postinc returns the pre-increment value.
+// LLVM-LABEL: @_Z7postincP1S
+// LLVM:         %[[WORD:.*]] = load i32, ptr %[[PTR:.*]], align 4
+// LLVM:         %[[OLD:.*]] = lshr i32 %[[WORD]], 6
+// LLVM:         %[[INC:.*]] = add i32 %[[OLD]], 1
+// LLVM:         %[[WORD2:.*]] = load i32, ptr %[[PTR]], align 4
+// LLVM:         %[[VAL:.*]] = and i32 %[[INC]], 67108863
+// LLVM:         %[[SHL:.*]] = shl i32 %[[VAL]], 6
+// LLVM:         %[[CLEAR:.*]] = and i32 %[[WORD2]], 63
+// LLVM:         %[[SET:.*]] = or i32 %[[CLEAR]], %[[SHL]]
+// LLVM:         store i32 %[[SET]], ptr %[[PTR]], align 4
+// LLVM-CIR:     store i32 %[[OLD]], ptr %[[RET:.*]], align 4
+// LLVM-CIR:     %[[RV:.*]] = load i32, ptr %[[RET]], align 4
+// LLVM-CIR:     ret i32 %[[RV]]
+// OGCG:         ret i32 %[[OLD]]
+
+// Preinc returns the post-increment (masked new) value.
+// LLVM-LABEL: @_Z6preincP1S
+// LLVM:         %[[WORD_P:.*]] = load i32, ptr %[[PTR_P:.*]], align 4
+// LLVM:         %[[OLD_P:.*]] = lshr i32 %[[WORD_P]], 6
+// LLVM:         %[[INC_P:.*]] = add i32 %[[OLD_P]], 1
+// LLVM:         %[[WORD2_P:.*]] = load i32, ptr %[[PTR_P]], align 4
+// LLVM:         %[[VAL_P:.*]] = and i32 %[[INC_P]], 67108863
+// LLVM:         %[[SHL_P:.*]] = shl i32 %[[VAL_P]], 6
+// LLVM:         %[[CLEAR_P:.*]] = and i32 %[[WORD2_P]], 63
+// LLVM:         %[[SET_P:.*]] = or i32 %[[CLEAR_P]], %[[SHL_P]]
+// LLVM:         store i32 %[[SET_P]], ptr %[[PTR_P]], align 4
+// LLVM-CIR:     store i32 %[[VAL_P]], ptr %[[RET_P:.*]], align 4
+// LLVM-CIR:     %[[RV_P:.*]] = load i32, ptr %[[RET_P]], align 4
+// LLVM-CIR:     ret i32 %[[RV_P]]
+// OGCG:         ret i32 %[[VAL_P]]


### PR DESCRIPTION
In \`emitScalarPrePostIncDec\`, the bitfield branch called \`emitStoreThroughBitfieldLValue\` and returned its result directly, bypassing the \`return e->isPrefix() ? value : input\` logic that selects old vs new for post vs pre-increment.  For post-increment on a bitfield, this returned the new (incremented) value instead of the old one, so \`if (s->nRefs++)\` always evaluated true even when \`nRefs\` was zero on entry.

Fix by assigning the store result to \`value\` and falling through to the existing prefix/postfix selector, mirroring the non-bitfield path.

Found via the SPEC CPU 2026 abc_r benchmark: \`Cnf_ManScanMapping_rec\` uses \`if (pObj->nRefs++)\` on a 26-bit bitfield to detect already-visited AIG nodes.  With the bug, every call returned true (already visited) immediately, producing an empty CNF mapping and a spuriously satisfiable SAT problem (133 variables instead of 3018).