### PR TITLE
[ObjectYAML] Fix yaml2obj crash when BBAddrMap entry has invalid feature

### DIFF
--- a/llvm/lib/ObjectYAML/ELFEmitter.cpp
+++ b/llvm/lib/ObjectYAML/ELFEmitter.cpp
@@ -1480,11 +1480,12 @@ void ELFState<ELFT>::writeSectionContent(
       }
     }
     auto FeatureOrErr = llvm::object::BBAddrMap::Features::decode(E.Feature);
-    bool MultiBBRangeFeatureEnabled = false;
-    if (!FeatureOrErr)
+    if (!FeatureOrErr) {
+      // Invalid feature: warn and skip the entry; the payload is unparseable.
       WithColor::warning() << toString(FeatureOrErr.takeError());
-    else
-      MultiBBRangeFeatureEnabled = FeatureOrErr->MultiBBRange;
+      continue;
+    }
+    bool MultiBBRangeFeatureEnabled = FeatureOrErr->MultiBBRange;
     bool MultiBBRange =
         MultiBBRangeFeatureEnabled ||
         (E.NumBBRanges.has_value() && E.NumBBRanges.value() != 1) ||

--- a/llvm/lib/ObjectYAML/ELFEmitter.cpp
+++ b/llvm/lib/ObjectYAML/ELFEmitter.cpp
@@ -1481,7 +1481,7 @@ void ELFState<ELFT>::writeSectionContent(
     }
     auto FeatureOrErr = llvm::object::BBAddrMap::Features::decode(E.Feature);
     if (!FeatureOrErr) {
-      // Invalid feature: warn and skip the entry; the payload is unparseable.
+      // Invalid feature: warn and skip the entry.
       WithColor::warning() << toString(FeatureOrErr.takeError());
       continue;
     }

--- a/llvm/test/tools/yaml2obj/ELF/bb-addr-map-pgo-analysis-map.yaml
+++ b/llvm/test/tools/yaml2obj/ELF/bb-addr-map-pgo-analysis-map.yaml
@@ -73,8 +73,9 @@ Sections:
 # RUN: llvm-readobj --sections --section-data %t2 | FileCheck %s --check-prefix=INVALID-FEATURE-DATA
 # INVALID-FEATURE: warning: invalid encoding for BBAddrMap::Features: 0x100
 # INVALID-FEATURE-DATA:      Name: .llvm_bb_addr_map
+# INVALID-FEATURE-DATA:      Size: 3
 # INVALID-FEATURE-DATA:      SectionData (
-# INVALID-FEATURE-DATA-NEXT:   0000: 0200 |
+# INVALID-FEATURE-DATA-NEXT:   0000: 050001 {{ *}}|
 # INVALID-FEATURE-DATA-NEXT: )
 
 --- !ELF
@@ -86,7 +87,7 @@ Sections:
   - Name: '.llvm_bb_addr_map'
     Type: SHT_LLVM_BB_ADDR_MAP
     Entries:
-      - Version: 2
+      - Version: 5
 ##  Specify unsupported feature
         Feature: 0x100
         BBRanges:

--- a/llvm/test/tools/yaml2obj/ELF/bb-addr-map-pgo-analysis-map.yaml
+++ b/llvm/test/tools/yaml2obj/ELF/bb-addr-map-pgo-analysis-map.yaml
@@ -67,9 +67,15 @@ Sections:
                Size:          0x00000002
                Metadata:      0x00000003
 
-## Check that yaml2obj generates a warning when we use unsupported feature.
-# RUN: yaml2obj --docnum=2  %s 2>&1 | FileCheck %s --check-prefix=INVALID-FEATURE
+## An invalid feature warns and skips the entry: only the version and feature
+## bytes are emitted, even when BBRanges/PGOAnalyses follow.
+# RUN: yaml2obj --docnum=2 %s -o %t2 2>&1 | FileCheck %s --check-prefix=INVALID-FEATURE
+# RUN: llvm-readobj --sections --section-data %t2 | FileCheck %s --check-prefix=INVALID-FEATURE-DATA
 # INVALID-FEATURE: warning: invalid encoding for BBAddrMap::Features: 0x100
+# INVALID-FEATURE-DATA:      Name: .llvm_bb_addr_map
+# INVALID-FEATURE-DATA:      SectionData (
+# INVALID-FEATURE-DATA-NEXT:   0000: 0200 |
+# INVALID-FEATURE-DATA-NEXT: )
 
 --- !ELF
 FileHeader:
@@ -83,3 +89,14 @@ Sections:
       - Version: 2
 ##  Specify unsupported feature
         Feature: 0x100
+        BBRanges:
+          - BaseAddress: 0x0000000000000020
+            BBEntries:
+              - ID:            1
+                AddressOffset: 0x00000001
+                Size:          0x00000002
+                Metadata:      0x00000003
+    PGOAnalyses:
+      - FuncEntryCount: 100
+        PGOBBEntries:
+          - BBFreq: 100


### PR DESCRIPTION
Warn and skip the entry instead of dereferencing the Error-holding Expected returned by Features::decode.