### PR TITLE
[AMDGPU] Fix RewriteMFMAForm handling of mixed MAI/non-MAI reaching defs

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -35,6 +35,7 @@
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineBlockFrequencyInfo.h"
 #include "llvm/CodeGen/MachineBranchProbabilityInfo.h"
+#include "llvm/CodeGen/MachineDominators.h"
 #include "llvm/CodeGen/MachineOperand.h"
 #include "llvm/CodeGen/RegisterClassInfo.h"
 #include "llvm/CodeGen/Rematerializer.h"
@@ -1273,48 +1274,105 @@ bool GCNSchedStage::initGCNSchedStage() {
   return true;
 }
 
+// Collect all non-PHI reaching def SlotIndexes for a single LiveRange QR at
+// UseIdx into ResultSet (deduplicated).  If QR is a PHIDef at UseIdx, perform
+// a BFS across predecessor blocks to find the concrete defs on each path,
+// including loop-carried defs.  Self-referential defs (src2 == dst) are
+// filtered by isSameInstr.
+static void collectReachingDefsInRange(const LiveRange &QR,
+                                       MachineBasicBlock *UseMBB,
+                                       SlotIndex UseIdx,
+                                       const LiveIntervals *LIS,
+                                       SmallSet<SlotIndex, 8> &ResultSet) {
+  const VNInfo *VNI = QR.getVNInfoAt(UseIdx);
+  if (!VNI)
+    return;
+
+  if (!VNI->isPHIDef()) {
+    ResultSet.insert(VNI->def);
+    return;
+  }
+
+  SmallPtrSet<MachineBasicBlock *, 8> Visited;
+  SmallVector<MachineBasicBlock *, 8> Worklist;
+  for (MachineBasicBlock *PredMBB : UseMBB->predecessors())
+    if (Visited.insert(PredMBB).second)
+      Worklist.push_back(PredMBB);
+
+  while (!Worklist.empty()) {
+    MachineBasicBlock *CurrMBB = Worklist.pop_back_val();
+    SlotIndex CurrMBBEnd = LIS->getMBBEndIdx(CurrMBB).getPrevSlot();
+    const VNInfo *PredVNI = QR.getVNInfoAt(CurrMBBEnd);
+    if (!PredVNI)
+      continue;
+
+    if (!PredVNI->isPHIDef()) {
+      if (SlotIndex::isSameInstr(PredVNI->def, UseIdx))
+        continue;
+      ResultSet.insert(PredVNI->def);
+      continue;
+    }
+
+    MachineBasicBlock *DefMBB = LIS->getMBBFromIndex(PredVNI->def);
+    for (MachineBasicBlock *PredMBB : DefMBB->predecessors())
+      if (Visited.insert(PredMBB).second)
+        Worklist.push_back(PredMBB);
+  }
+}
+
 void RewriteMFMAFormStage::findReachingDefs(
     MachineOperand &UseMO, LiveIntervals *LIS,
     SmallVectorImpl<SlotIndex> &DefIdxs) {
   MachineInstr *UseMI = UseMO.getParent();
-  LiveInterval &UseLI = LIS->getInterval(UseMO.getReg());
-  VNInfo *VNI = UseLI.getVNInfoAt(LIS->getInstructionIndex(*UseMI));
+  Register UseReg = UseMO.getReg();
+  unsigned UseSubReg = UseMO.getSubReg();
 
-  // If the def is not a PHI, then it must be the only reaching def.
-  if (!VNI->isPHIDef()) {
-    DefIdxs.push_back(VNI->def);
+  if (!UseReg.isVirtual() || !LIS->hasInterval(UseReg))
     return;
-  }
 
-  SmallPtrSet<MachineBasicBlock *, 8> Visited = {UseMI->getParent()};
-  SmallVector<MachineBasicBlock *, 8> Worklist;
+  LiveInterval &UseLI = LIS->getInterval(UseReg);
+  SlotIndex UseIdx = LIS->getInstructionIndex(*UseMI);
 
-  // Mark the predecessor blocks for traversal
-  for (MachineBasicBlock *PredMBB : UseMI->getParent()->predecessors()) {
-    Worklist.push_back(PredMBB);
-    Visited.insert(PredMBB);
-  }
+  // Use a set to deduplicate: a full-reg def appears in every SubRange but
+  // must be inserted into DefIdxs only once.
+  SmallSet<SlotIndex, 8> ResultSet;
 
-  while (!Worklist.empty()) {
-    MachineBasicBlock *CurrMBB = Worklist.pop_back_val();
+  if (UseLI.hasSubRanges()) {
+    const TargetRegisterInfo *TRI = DAG.MRI.getTargetRegisterInfo();
 
-    SlotIndex CurrMBBEnd = LIS->getMBBEndIdx(CurrMBB);
-    VNInfo *VNI = UseLI.getVNInfoAt(CurrMBBEnd.getPrevSlot());
-
-    MachineBasicBlock *DefMBB = LIS->getMBBFromIndex(VNI->def);
-
-    // If there is a def in this block, then add it to the list. This is the
-    // reaching def of this path.
-    if (!VNI->isPHIDef()) {
-      DefIdxs.push_back(VNI->def);
-      continue;
+    if (UseSubReg) {
+      // Find the SubRange whose LaneMask fully covers the operand's lanes.
+      // If none does (e.g. register initialised via per-lane subreg writes),
+      // fall back to all overlapping SubRanges to capture every reaching def.
+      LaneBitmask UseLanes = TRI->getSubRegIndexLaneMask(UseSubReg);
+      bool FoundFullCoverage = false;
+      for (LiveInterval::SubRange &SR : UseLI.subranges()) {
+        if ((SR.LaneMask & UseLanes) == UseLanes) {
+          collectReachingDefsInRange(SR, UseMI->getParent(), UseIdx, LIS,
+                                     ResultSet);
+          FoundFullCoverage = true;
+          break;
+        }
+      }
+      if (!FoundFullCoverage) {
+        for (LiveInterval::SubRange &SR : UseLI.subranges())
+          if ((SR.LaneMask & UseLanes).any())
+            collectReachingDefsInRange(SR, UseMI->getParent(), UseIdx, LIS,
+                                       ResultSet);
+      }
+    } else {
+      // Full-reg use: query every subrange so that partial (subreg) defs on
+      // different lanes are all captured.
+      for (LiveInterval::SubRange &SR : UseLI.subranges())
+        collectReachingDefsInRange(SR, UseMI->getParent(), UseIdx, LIS,
+                                   ResultSet);
     }
-
-    for (MachineBasicBlock *PredMBB : DefMBB->predecessors()) {
-      if (Visited.insert(PredMBB).second)
-        Worklist.push_back(PredMBB);
-    }
+  } else {
+    collectReachingDefsInRange(UseLI, UseMI->getParent(), UseIdx, LIS,
+                               ResultSet);
   }
+
+  DefIdxs.append(ResultSet.begin(), ResultSet.end());
 }
 
 void RewriteMFMAFormStage::findReachingUses(
@@ -2252,14 +2310,48 @@ void GCNSchedStage::modifyRegionSchedule(unsigned RegionIdx,
 /// no bridge copy is needed at this reaching definition.
 static bool isReachingDefAGPRForm(MachineInstr *RD,
                                   const DenseSet<Register> &CandSrc2Regs,
-                                  const SIInstrInfo &TII) {
+                                  const SIInstrInfo &TII,
+                                  const LiveIntervals *LIS) {
   if (TII.isMAI(*RD))
     return true;
   if (RD->getOpcode() == AMDGPU::AV_MOV_B32_IMM_PSEUDO ||
       RD->getOpcode() == AMDGPU::AV_MOV_B64_IMM_PSEUDO)
     return true;
-  if (RD->isCopy() && CandSrc2Regs.contains(RD->getOperand(1).getReg()))
-    return true;
+  if (RD->isCopy()) {
+    if (CandSrc2Regs.contains(RD->getOperand(1).getReg()))
+      return true;
+    // A COPY whose source is defined by an AGPR-form instruction (AV_MOV or
+    // MAI) does not need a bridge copy — the value is already in AGPR form.
+    const MachineOperand &SrcMO = RD->getOperand(1);
+    if (SrcMO.isReg() && SrcMO.getReg().isVirtual() &&
+        LIS->hasInterval(SrcMO.getReg())) {
+      const LiveInterval &SrcLI = LIS->getInterval(SrcMO.getReg());
+      SlotIndex UseIdx =
+          LIS->getInstructionIndex(*RD).getRegSlot(SrcMO.isEarlyClobber());
+      const VNInfo *VNI = nullptr;
+      if (SrcMO.getSubReg() && SrcLI.hasSubRanges()) {
+        const TargetRegisterInfo *TRI =
+            RD->getParent()->getParent()->getSubtarget().getRegisterInfo();
+        LaneBitmask SrcLanes = TRI->getSubRegIndexLaneMask(SrcMO.getSubReg());
+        for (const LiveInterval::SubRange &SR : SrcLI.subranges()) {
+          if ((SR.LaneMask & SrcLanes).any()) {
+            VNI = SR.getVNInfoBefore(UseIdx);
+            break;
+          }
+        }
+      } else {
+        VNI = SrcLI.getVNInfoBefore(UseIdx);
+      }
+      if (VNI && !VNI->isPHIDef()) {
+        MachineInstr *SrcDef = LIS->getInstructionFromIndex(VNI->def);
+        if (SrcDef &&
+            (TII.isMAI(*SrcDef) ||
+             SrcDef->getOpcode() == AMDGPU::AV_MOV_B32_IMM_PSEUDO ||
+             SrcDef->getOpcode() == AMDGPU::AV_MOV_B64_IMM_PSEUDO))
+          return true;
+      }
+    }
+  }
   return false;
 }
 
@@ -2277,101 +2369,218 @@ bool RewriteMFMAFormStage::isRewriteCandidate(MachineInstr *MI) const {
   return true;
 }
 
+bool RewriteMFMAFormStage::hasDominanceConflict(ArrayRef<SlotIndex> DefIdxs,
+                                               Register Src2Reg) const {
+  auto &MDT = DAG.LIS->getDomTree();
+
+  SmallVector<MachineInstr *, 8> MAIMIs;
+  SmallPtrSet<MachineBasicBlock *, 8> BridgeCopyBlocks; // non-MAI def blocks
+
+  for (SlotIndex SI : DefIdxs) {
+    MachineInstr *MI = DAG.LIS->getInstructionFromIndex(SI);
+    if (TII->isMFMA(*MI))
+      MAIMIs.push_back(MI);
+    else
+      BridgeCopyBlocks.insert(MI->getParent());
+  }
+
+  if (BridgeCopyBlocks.empty())
+    return false; // All defs are MAI; no bridge copies needed.
+
+  // Check 1: MAI def dominates non-MAI def (partial subreg overwrite).
+  // The MFMA first writes all lanes (AGPR), then a non-MAI instruction
+  // partially overwrites some lanes.  A bridge copy at the non-MAI def
+  // would read an already-AGPR register and must partially update it —
+  // a read-modify-write that the bridge-copy mechanism cannot implement.
+  // MDT.dominates(MI_A, MI_B) uses program order for same-block pairs, so a
+  // non-MAI def that precedes the MAI def in the same block is not flagged.
+  if (!MAIMIs.empty()) {
+    SmallVector<MachineInstr *, 8> NonMAIMIs;
+    for (SlotIndex SI : DefIdxs) {
+      MachineInstr *MI = DAG.LIS->getInstructionFromIndex(SI);
+      if (!TII->isMFMA(*MI))
+        NonMAIMIs.push_back(MI);
+    }
+    for (MachineInstr *M : MAIMIs)
+      for (MachineInstr *N : NonMAIMIs)
+        if (MDT.dominates(M, N))
+          return true;
+  }
+
+  // Check 2: Bridge copy coverage.
+  // A bridge copy '%MappedReg = COPY Src2Reg' is inserted after each non-MAI
+  // reaching def.  '%MappedReg' replaces Src2Reg in the MFMA src2 and,
+  // through tied-def chains, may also appear in other use positions (e.g. a
+  // bridge block reachable via a bypass edge).  Every such use must be
+  // dominated by at least one bridge-copy block, otherwise '%MappedReg' would
+  // be undefined on some CFG path to that use.
+  for (const MachineOperand &UseMO :
+       DAG.MRI.use_nodbg_operands(Src2Reg)) {
+    const MachineBasicBlock *UseBlock = UseMO.getParent()->getParent();
+    bool Covered = any_of(BridgeCopyBlocks, [&](const MachineBasicBlock *B) {
+      return MDT.dominates(B, UseBlock);
+    });
+    if (!Covered)
+      return true;
+  }
+
+  return false;
+}
+
+void RewriteMFMAFormStage::propagateExclusionForward(
+    MachineInstr *Root, SmallPtrSetImpl<MachineInstr *> &ExcludedMFMAs) {
+  SmallVector<MachineInstr *, 8> Worklist = {Root};
+  while (!Worklist.empty()) {
+    MachineInstr *ExclMI = Worklist.pop_back_val();
+    MachineOperand &DstMO = ExclMI->getOperand(0);
+    if (!DstMO.isReg() || !DstMO.getReg().isVirtual())
+      continue;
+    Register DstReg = DstMO.getReg();
+    for (MachineOperand &UseMO : DAG.MRI.use_nodbg_operands(DstReg)) {
+      MachineInstr *UserMI = UseMO.getParent();
+      if (!isRewriteCandidate(UserMI))
+        continue;
+      MachineOperand *UserSrc2 =
+          TII->getNamedOperand(*UserMI, AMDGPU::OpName::src2);
+      if (!UserSrc2 || !UserSrc2->isReg() || UserSrc2->getReg() != DstReg)
+        continue;
+      if (ExcludedMFMAs.insert(UserMI).second) {
+        Worklist.push_back(UserMI);
+      }
+    }
+  }
+}
+
 bool RewriteMFMAFormStage::initHeuristics(
     std::vector<std::pair<MachineInstr *, unsigned>> &RewriteCands,
     DenseMap<MachineBasicBlock *, std::set<Register>> &CopyForUse,
     SmallPtrSetImpl<MachineInstr *> &CopyForDef) {
   bool Changed = false;
 
-  // Collect the candidate group, its members share AGPR-form operands
-  // post-rewrite, so reaching defs feeding any member don't need bridge copy.
-  SmallPtrSet<MachineInstr *, 16> RewriteSet;
-  DenseSet<Register> CandSrc2Regs;
-  for (MachineBasicBlock &MBB : MF) {
-    for (MachineInstr &MI : MBB) {
-      if (!isRewriteCandidate(&MI))
-        continue;
-      RewriteSet.insert(&MI);
-      MachineOperand *Src2 = TII->getNamedOperand(MI, AMDGPU::OpName::src2);
-      if (Src2 && Src2->isReg())
-        CandSrc2Regs.insert(Src2->getReg());
+  // Phase 1: enumerate rewrite candidates.
+  SmallVector<MachineInstr *, 16> AllCandidates;
+  for (MachineBasicBlock &MBB : MF)
+    for (MachineInstr &MI : MBB)
+      if (isRewriteCandidate(&MI))
+        AllCandidates.push_back(&MI);
+
+  // Phase 2: dominance-conflict exclusion.
+  //
+  // For each candidate, check whether its src2 has both MAI and non-MAI
+  // reaching defs with a dominance relationship.  If so, exclude it and
+  // propagate the exclusion forward (through the dst use chain) and backward
+  // (to any MAI reaching-def that is itself a candidate).
+  // All exclusion decisions are made before any setDesc/setRegClass changes.
+  SmallPtrSet<MachineInstr *, 16> ExcludedMFMAs;
+
+  for (MachineInstr *MI : AllCandidates) {
+    MachineOperand *Src2 = TII->getNamedOperand(*MI, AMDGPU::OpName::src2);
+    if (!Src2->isReg())
+      continue;
+
+    SmallVector<SlotIndex, 8> Src2Defs;
+    findReachingDefs(*Src2, DAG.LIS, Src2Defs);
+
+    if (!hasDominanceConflict(Src2Defs, Src2->getReg()))
+      continue;
+
+    // Exclude the use-site MFMA and propagate forward through its dst chain.
+    if (ExcludedMFMAs.insert(MI).second)
+      propagateExclusionForward(MI, ExcludedMFMAs);
+
+    // Backward: exclude MAI reaching-defs that are themselves candidates.
+    for (SlotIndex SI : Src2Defs) {
+      MachineInstr *DefMI = DAG.LIS->getInstructionFromIndex(SI);
+      if (TII->isMFMA(*DefMI) && isRewriteCandidate(DefMI) &&
+          ExcludedMFMAs.insert(DefMI).second) {
+        propagateExclusionForward(DefMI, ExcludedMFMAs);
+      }
     }
   }
 
-  // Prepare for the heuristics
-  for (MachineBasicBlock &MBB : MF) {
-    for (MachineInstr &MI : MBB) {
-      if (!isRewriteCandidate(&MI))
+  // Phase 3: speculatively rewrite non-excluded candidates and collect copy
+  // locations for cost estimation.
+  for (MachineInstr *MI : AllCandidates) {
+    if (ExcludedMFMAs.count(MI))
+      continue;
+
+    int ReplacementOp = AMDGPU::getMFMASrcCVDstAGPROp(MI->getOpcode());
+    assert(ReplacementOp != -1);
+
+    RewriteCands.push_back({MI, MI->getOpcode()});
+    MI->setDesc(TII->get(ReplacementOp));
+
+    MachineOperand *Src2 = TII->getNamedOperand(*MI, AMDGPU::OpName::src2);
+    if (Src2->isReg()) {
+      SmallVector<SlotIndex, 8> Src2ReachingDefs;
+      findReachingDefs(*Src2, DAG.LIS, Src2ReachingDefs);
+
+      // For non-MAI reaching defs, only the last def in each block matters:
+      // bridge copies for earlier defs in the same block are overwritten by the
+      // bridge copy after the last def and would be dead code.  Keep one def per
+      // block (the one with the highest slot index) to avoid over-counting cost.
+      DenseMap<MachineBasicBlock *, MachineInstr *> LastNonMAIPerBB;
+      for (SlotIndex RDIdx : Src2ReachingDefs) {
+        MachineInstr *RD = DAG.LIS->getInstructionFromIndex(RDIdx);
+        // Skip defs already in AGPR form; they do not need a bridge copy.
+        static const DenseSet<Register> EmptySet;
+        if (isReachingDefAGPRForm(RD, EmptySet, *TII, DAG.LIS))
+          continue;
+        MachineBasicBlock *BB = RD->getParent();
+        auto It = LastNonMAIPerBB.find(BB);
+        if (It == LastNonMAIPerBB.end() ||
+            DAG.LIS->getInstructionIndex(*It->second) <
+                DAG.LIS->getInstructionIndex(*RD))
+          LastNonMAIPerBB[BB] = RD;
+      }
+      for (auto &[BB, RD] : LastNonMAIPerBB)
+        CopyForDef.insert(RD);
+    }
+
+    MachineOperand &Dst = MI->getOperand(0);
+    SmallVector<MachineOperand *, 8> DstReachingUses;
+
+    findReachingUses(MI, DAG.LIS, DstReachingUses);
+
+    for (MachineOperand *RUOp : DstReachingUses) {
+      MachineInstr *UserMI = RUOp->getParent();
+      if (TII->isMFMA(*UserMI))
         continue;
 
-      int ReplacementOp = AMDGPU::getMFMASrcCVDstAGPROp(MI.getOpcode());
-      assert(ReplacementOp != -1);
+      // For any user of the result of the MFMA which is not an MFMA, we
+      // insert a copy. For a given register, we will only insert one copy
+      // per user block.
+      CopyForUse[UserMI->getParent()].insert(RUOp->getReg());
 
-      RewriteCands.push_back({&MI, MI.getOpcode()});
-      MI.setDesc(TII->get(ReplacementOp));
+      SmallVector<SlotIndex, 8> DstUsesReachingDefs;
+      findReachingDefs(*RUOp, DAG.LIS, DstUsesReachingDefs);
 
-      MachineOperand *Src2 = TII->getNamedOperand(MI, AMDGPU::OpName::src2);
-      if (Src2->isReg()) {
-        SmallVector<SlotIndex, 8> Src2ReachingDefs;
-        findReachingDefs(*Src2, DAG.LIS, Src2ReachingDefs);
-
-        for (SlotIndex RDIdx : Src2ReachingDefs) {
-          MachineInstr *RD = DAG.LIS->getInstructionFromIndex(RDIdx);
-          if (isReachingDefAGPRForm(RD, CandSrc2Regs, *TII))
-            continue;
-          CopyForDef.insert(RD);
-        }
-      }
-
-      MachineOperand &Dst = MI.getOperand(0);
-      SmallVector<MachineOperand *, 8> DstReachingUses;
-
-      findReachingUses(&MI, DAG.LIS, DstReachingUses);
-
-      for (MachineOperand *RUOp : DstReachingUses) {
-        MachineInstr *UserMI = RUOp->getParent();
-        // Group members read the AGPR result directly.
-        if (TII->isMAI(*UserMI) && RewriteSet.contains(UserMI))
+      for (SlotIndex RDIndex : DstUsesReachingDefs) {
+        MachineInstr *RD = DAG.LIS->getInstructionFromIndex(RDIndex);
+        if (TII->isMFMA(*RD))
           continue;
 
-        // For any user of the result of the MFMA which is not an MFMA, we
-        // insert a copy. For a given register, we will only insert one copy
-        // per user block.
-        CopyForUse[UserMI->getParent()].insert(RUOp->getReg());
-
-        if (TII->isMAI(*UserMI))
-          continue;
-
-        SmallVector<SlotIndex, 8> DstUsesReachingDefs;
-        findReachingDefs(*RUOp, DAG.LIS, DstUsesReachingDefs);
-
-        for (SlotIndex RDIndex : DstUsesReachingDefs) {
-          MachineInstr *RD = DAG.LIS->getInstructionFromIndex(RDIndex);
-          if (TII->isMAI(*RD))
-            continue;
-
-          // For any definition of the user of the MFMA which is not an MFMA,
-          // we insert a copy. We do this to transform all the reaching defs
-          // of this use to AGPR. By doing this, we can insert a copy from
-          // AGPR to VGPR at the user rather than after the MFMA.
-          CopyForDef.insert(RD);
-        }
+        // For any definition of the user of the MFMA which is not an MFMA,
+        // we insert a copy. We do this to transform all the reaching defs
+        // of this use to AGPR. By doing this, we can insert a copy from
+        // AGPR to VGPR at the user rather than after the MFMA.
+        CopyForDef.insert(RD);
       }
-
-      // Do the rewrite to allow for updated RP calculation.
-      const TargetRegisterClass *VDefRC = DAG.MRI.getRegClass(Dst.getReg());
-      const TargetRegisterClass *ADefRC = SRI->getEquivalentAGPRClass(VDefRC);
-      DAG.MRI.setRegClass(Dst.getReg(), ADefRC);
-      if (Src2->isReg()) {
-        // Have to get src types separately since subregs may cause C and D
-        // registers to be different types even though the actual operand is
-        // the same size.
-        const TargetRegisterClass *VUseRC = DAG.MRI.getRegClass(Src2->getReg());
-        const TargetRegisterClass *AUseRC = SRI->getEquivalentAGPRClass(VUseRC);
-        DAG.MRI.setRegClass(Src2->getReg(), AUseRC);
-      }
-      Changed = true;
     }
+
+    // Do the rewrite to allow for updated RP calculation.
+    const TargetRegisterClass *VDefRC = DAG.MRI.getRegClass(Dst.getReg());
+    const TargetRegisterClass *ADefRC = SRI->getEquivalentAGPRClass(VDefRC);
+    DAG.MRI.setRegClass(Dst.getReg(), ADefRC);
+    if (Src2->isReg()) {
+      // Have to get src types separately since subregs may cause C and D
+      // registers to be different types even though the actual operand is
+      // the same size.
+      const TargetRegisterClass *VUseRC = DAG.MRI.getRegClass(Src2->getReg());
+      const TargetRegisterClass *AUseRC = SRI->getEquivalentAGPRClass(VUseRC);
+      DAG.MRI.setRegClass(Src2->getReg(), AUseRC);
+    }
+    Changed = true;
   }
 
   return Changed;
@@ -2594,7 +2803,7 @@ bool RewriteMFMAFormStage::rewrite(
 
       for (SlotIndex RDIndex : Src2ReachingDefs) {
         MachineInstr *RD = DAG.LIS->getInstructionFromIndex(RDIndex);
-        if (isReachingDefAGPRForm(RD, RewriteSrc2Regs, *TII))
+        if (isReachingDefAGPRForm(RD, RewriteSrc2Regs, *TII, DAG.LIS))
           continue;
 
         Src2DefsReplace.insert(RD);

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
@@ -469,8 +469,25 @@ private:
   /// \returns true if this MI is a rewrite candidate.
   bool isRewriteCandidate(MachineInstr *MI) const;
 
-  /// Finds all the reaching defs of \p UseMO and stores the SlotIndexes into \p
-  /// DefIdxs
+  /// Returns true if rewriting the MFMA whose src2 is \p Src2Reg to AGPR form
+  /// is unsafe given \p DefIdxs as the reaching defs of that src2.
+  /// Two conditions trigger a conflict:
+  ///   1. A MAI reaching def dominates a non-MAI reaching def (partial subreg
+  ///      overwrite: bridge copies cannot implement the required read-modify-write).
+  ///   2. Some use of Src2Reg is not dominated by any bridge-copy location (=
+  ///      non-MAI reaching def block), meaning the bridge copy would be absent on
+  ///      some CFG path that reaches that use.
+  bool hasDominanceConflict(ArrayRef<SlotIndex> DefIdxs,
+                            Register Src2Reg) const;
+
+  /// Transitively exclude from \p ExcludedMFMAs any rewrite candidate whose
+  /// src2 is the dst of \p Root or of any already-excluded MFMA.
+  void propagateExclusionForward(MachineInstr *Root,
+                                 SmallPtrSetImpl<MachineInstr *> &ExcludedMFMAs);
+
+  /// Finds all the reaching defs of \p UseMO and stores the SlotIndexes into
+  /// \p DefIdxs. Handles registers with subranges by querying each subrange's
+  /// LiveRange independently, so subreg defs on different lanes are all found.
   void findReachingDefs(MachineOperand &UseMO, LiveIntervals *LIS,
                         SmallVectorImpl<SlotIndex> &DefIdxs);
 

--- a/llvm/test/CodeGen/AMDGPU/rewrite-mfma-form-src2-nonself-backeg-nonmfma.ll
+++ b/llvm/test/CodeGen/AMDGPU/rewrite-mfma-form-src2-nonself-backeg-nonmfma.ll
@@ -1,0 +1,124 @@
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950 -amdgpu-disable-rewrite-mfma-form-sched-stage=false -stop-after=machine-scheduler < %s | FileCheck %s --check-prefix=AFTER
+;
+; Test: RewriteMFMAFormStage — MFMA src2 sub-register overwrite creates SubRanges,
+; forcing findReachingDefs to use the SubRanges path where BFS sees MFMA_C (MAI)
+; as a direct reaching def on the back-edge.
+;
+; Sub-register overwrite mechanism:
+;   %acc_init is built by four insertelement calls (one per lane) → per-lane
+;   subreg defs.  After register coalescing, %acc and %r3 (MFMA_C dst) are the
+;   SAME virtual register (%acc = %r3, coalesced).  But the entry path initialises
+;   %acc per-lane via subreg COPYs (%acc.subN = COPY %acc_init.subN), while the
+;   back-edge path is a full-register MFMA_C write.  This mixed subreg/full-reg
+;   write pattern causes %acc's LiveInterval to have SubRanges: each SubRange's
+;   VNI at UseIdx is PHIDef (the per-lane entry COPY and the full-reg MFMA_C
+;   definition create a two-path join in each lane's SubRange).
+;
+; CFG:
+;
+;   entry ──► loop ──► bridge ──► (ret)
+;     │          ↑_____|
+;     │       (back-edge)
+;     └──────────────────────────► bridge   (bypass: n==0 skips loop)
+;
+; loop body (after coalescing, %acc = %r3 = same VReg):
+;   %acc  = phi [%acc_init, entry], [%acc, loop]  ; %acc written by MFMA_C each iter
+;   %r1   = MFMA_A(a, b, %acc)   dst → MFMA_B (MAI only)  → candidate
+;   %r2   = MFMA_B(a, b, %r1)   dst → MFMA_C (MAI only)  → candidate
+;   %acc  = MFMA_C(a, b, %r2)   full-reg write of %acc (= %r3) → candidate
+;
+; bridge: %p = phi [%acc, loop], [%acc_init, entry]
+;   Two predecessors → phi-elim emits separate subreg COPYs per predecessor,
+;   not coalesced → visible in stop-before (bb.1 bypass and bb.2 preheader).
+;
+; findReachingDefs for MFMA_A src2=%acc:
+;   %acc has SubRanges (subreg entry init) → full-reg use → queries all SubRanges.
+;   Each SubRange: VNI at UseIdx is PHIDef → BFS entered with Visited={}.
+;
+;   BFS traversal:
+;     bb.4(loop) end: SubRange VNI = MFMA_C def (full-reg write, opcode=MFMA)
+;                   → isSameInstr(MFMA_C_def, MFMA_A_UseIdx) = false
+;                   → ResultSet.insert(MFMA_C_def)  ← MAI
+;     bb.2(preheader) end: SubRange VNI = subreg COPY def (%acc.subN = COPY %acc_init.subN)
+;                   → ResultSet.insert(COPY_def)     ← non-MAI
+;
+;   hasDominanceConflict({MFMA_C(MAI), COPY(non-MAI)}):
+;     preheader-BB dominates loop-BB → true → MFMA_A excluded.
+;   Propagation: MFMA_B excluded (src2 = excluded MFMA_A dst),
+;                MFMA_C excluded (src2 = excluded MFMA_B dst).
+;   All three loop MFMAs stay in vreg form.
+
+declare <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.f16(<8 x half>, <8 x half>, <4 x float>, i32 immarg, i32 immarg, i32 immarg)
+
+define amdgpu_kernel void @test_src2_nonself_backedge(
+    ptr addrspace(1) %out,
+    <8 x half> %a,
+    <8 x half> %b,
+    float %f0, float %f1, float %f2, float %f3,
+    i32 %n) #0 {
+entry:
+  %i0 = insertelement <4 x float> undef, float %f0, i32 0
+  %i1 = insertelement <4 x float> %i0,  float %f1, i32 1
+  %i2 = insertelement <4 x float> %i1,  float %f2, i32 2
+  %acc_init = insertelement <4 x float> %i2,  float %f3, i32 3
+  %bypass = icmp eq i32 %n, 0
+  br i1 %bypass, label %bridge, label %loop
+
+loop:
+  %i    = phi i32         [ 0,         %entry ], [ %i.next, %loop ]
+  %acc  = phi <4 x float> [ %acc_init, %entry ], [ %r3,     %loop ]
+  %vc0  = phi <32 x float> [ zeroinitializer, %entry ], [ %vc0n, %loop ]
+  %vc1  = phi <32 x float> [ zeroinitializer, %entry ], [ %vc1n, %loop ]
+  %vc2  = phi <32 x float> [ zeroinitializer, %entry ], [ %vc2n, %loop ]
+  %vc3  = phi <32 x float> [ zeroinitializer, %entry ], [ %vc3n, %loop ]
+  %vc4  = phi <32 x float> [ zeroinitializer, %entry ], [ %vc4n, %loop ]
+  %vc5  = phi <32 x float> [ zeroinitializer, %entry ], [ %vc5n, %loop ]
+  %vc6  = phi <32 x float> [ zeroinitializer, %entry ], [ %vc6n, %loop ]
+  %vc7  = phi <32 x float> [ zeroinitializer, %entry ], [ %vc7n, %loop ]
+
+  ; MFMA_A: src2=%acc (≠ dst=%r1).  dst → MFMA_B (MAI) → candidate.
+  %r1 = call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.f16(
+      <8 x half> %a, <8 x half> %b, <4 x float> %acc, i32 0, i32 0, i32 0)
+
+  ; MFMA_B: dst → MFMA_C (MAI) + bridge phi COPY → candidate.
+  %r2 = call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.f16(
+      <8 x half> %a, <8 x half> %b, <4 x float> %r1, i32 0, i32 0, i32 0)
+
+  ; MFMA_C: dst → loop back-edge phi COPY → candidate.
+  %r3 = call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.f16(
+      <8 x half> %a, <8 x half> %b, <4 x float> %r2, i32 0, i32 0, i32 0)
+
+  %eidx = and i32 %i, 31
+  %v0e  = extractelement <32 x float> %vc0, i32 0
+  %vc0n = insertelement <32 x float> %vc0, float %v0e, i32 %eidx
+  %vc1n = insertelement <32 x float> %vc1, float %v0e, i32 %eidx
+  %vc2n = insertelement <32 x float> %vc2, float %v0e, i32 %eidx
+  %vc3n = insertelement <32 x float> %vc3, float %v0e, i32 %eidx
+  %vc4n = insertelement <32 x float> %vc4, float %v0e, i32 %eidx
+  %vc5n = insertelement <32 x float> %vc5, float %v0e, i32 %eidx
+  %vc6n = insertelement <32 x float> %vc6, float %v0e, i32 %eidx
+  %vc7n = insertelement <32 x float> %vc7, float %v0e, i32 %eidx
+  store volatile float %v0e, ptr addrspace(1) %out, align 4
+
+  %i.next = add i32 %i, 1
+  %cond   = icmp eq i32 %i.next, %n
+  br i1 %cond, label %bridge, label %loop
+
+bridge:
+  %p = phi <4 x float> [ %r3, %loop ], [ %acc_init, %entry ]
+  %bridge_mfma = call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.f16(
+      <8 x half> %a, <8 x half> %b, <4 x float> %p, i32 0, i32 0, i32 0)
+  %e1 = extractelement <4 x float> %bridge_mfma, i32 0
+  %s0 = fadd float %e1, %e1
+  store float %s0, ptr addrspace(1) %out, align 4
+  ret void
+}
+
+attributes #0 = { "amdgpu-waves-per-eu"="1,1" "amdgpu-flat-work-group-size"="64,64" }
+
+; AFTER-LABEL: name: test_src2_nonself_backedge
+; MFMA_A excluded (src2 dominance conflict: entry non-MAI + MFMA_C MAI on back-edge).
+; MFMA_B and MFMA_C excluded by forward propagation (src2 = excluded MFMA dst).
+; All three loop MFMAs stay in vreg form.
+; AFTER: bb.4.loop:
+; AFTER-COUNT-3: %{{[0-9]+}}:vreg_128_align2 = V_MFMA_F32_16X16X32_F16_vgprcd_e64

--- a/llvm/test/CodeGen/AMDGPU/rewrite-mfma-form-src2-subrange-nonmai-init.ll
+++ b/llvm/test/CodeGen/AMDGPU/rewrite-mfma-form-src2-subrange-nonmai-init.ll
@@ -1,0 +1,105 @@
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950 -amdgpu-disable-rewrite-mfma-form-sched-stage=false -stop-after=machine-scheduler < %s | FileCheck %s --check-prefix=AFTER
+;
+; Test: RewriteMFMAFormStage — self-referential MFMA with SubRanges from
+; per-lane insertelement initialisation.  Validates the isSameInstr guard and
+; the SubRange full-reg BFS path.
+;
+; After register coalescing, %acc and %r1 (MFMA_A dst) are the SAME VReg
+; (self-referential: MFMA_A src2 == dst).  The entry path initialises %acc
+; per-lane via insertelement → creates SubRanges on %acc's LiveInterval.
+;
+; CFG:
+;
+;   entry ──► loop ──► exit
+;               ↑_____|
+;            (back-edge)
+;
+; loop body (after coalescing, %acc = %r1 = same VReg):
+;   %acc = phi [%acc_init, entry], [%acc, loop]   ; self-ref: MFMA_A writes %acc
+;   %acc = MFMA_A(a, b, %acc)   src2==dst → candidate (dst only used by MFMA_B, MAI)
+;   %r2  = MFMA_B(a, b, %acc)   dst → extractelement (non-MAI) → NOT candidate
+;
+; findReachingDefs for MFMA_A src2=%acc:
+;   %acc has SubRanges (per-lane insertelement entry init) → full-reg use →
+;   queries all SubRanges.  Each SubRange VNI at UseIdx is PHIDef → BFS entered.
+;
+;   BFS traversal (Visited={}):
+;     BB#1(loop) end: SubRange VNI = MFMA_A def (self-ref: same instruction as use)
+;                   → isSameInstr(MFMA_A_def, MFMA_A_UseIdx) = true → SKIP
+;     BB#0(entry) end: SubRange VNI = subreg COPY (%acc.subN = COPY %acc_init.subN)
+;                   → ResultSet.insert(COPY_def)  ← non-MAI
+;
+;   ResultSet = {COPY_def (non-MAI only)} → hasDominanceConflict = false
+;   MFMA_A is a valid candidate; Cost = -220 < 0 → rewrite fires.
+;   Bridge copy for %acc_init (VGPR→AGPR) inserted after entry subreg COPY.
+
+declare <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.f16(<8 x half>, <8 x half>, <4 x float>, i32 immarg, i32 immarg, i32 immarg)
+
+define amdgpu_kernel void @test_src2_subrange_nonmai_init(
+    ptr addrspace(1) %out,
+    <8 x half> %a,
+    <8 x half> %b,
+    float %f0, float %f1, float %f2, float %f3,
+    i32 %n) #0 {
+entry:
+  ; Initialize accumulator lane-by-lane via insertelement (non-MAI).
+  ; Creates per-lane SubRanges; no single SubRange covers the full operand.
+  %i0 = insertelement <4 x float> undef, float %f0, i32 0
+  %i1 = insertelement <4 x float> %i0,  float %f1, i32 1
+  %i2 = insertelement <4 x float> %i1,  float %f2, i32 2
+  %acc_init = insertelement <4 x float> %i2, float %f3, i32 3
+  br label %loop
+
+loop:
+  %i    = phi i32         [ 0,              %entry ], [ %i.next, %loop ]
+  %acc  = phi <4 x float> [ %acc_init,      %entry ], [ %r1,     %loop ]
+
+  ; 8 × <32 x float> carriers = 256 ArchVGPRs (pressure for rewrite stage).
+  %vc0  = phi <32 x float> [ zeroinitializer, %entry ], [ %vc0n, %loop ]
+  %vc1  = phi <32 x float> [ zeroinitializer, %entry ], [ %vc1n, %loop ]
+  %vc2  = phi <32 x float> [ zeroinitializer, %entry ], [ %vc2n, %loop ]
+  %vc3  = phi <32 x float> [ zeroinitializer, %entry ], [ %vc3n, %loop ]
+  %vc4  = phi <32 x float> [ zeroinitializer, %entry ], [ %vc4n, %loop ]
+  %vc5  = phi <32 x float> [ zeroinitializer, %entry ], [ %vc5n, %loop ]
+  %vc6  = phi <32 x float> [ zeroinitializer, %entry ], [ %vc6n, %loop ]
+  %vc7  = phi <32 x float> [ zeroinitializer, %entry ], [ %vc7n, %loop ]
+
+  ; MFMA_A: src2==dst (self-ref after coalescing).  isRewriteCandidate = true
+  ; (dst only used by MFMA_B, MAI).  BFS skips self-ref back-edge def via
+  ; isSameInstr; entry subreg COPY (non-MAI) is the only reaching def.
+  ; hasDominanceConflict = false; Cost = -220 → rewritten to AGPR.
+  %r1 = call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.f16(
+      <8 x half> %a, <8 x half> %b, <4 x float> %acc, i32 0, i32 0, i32 0)
+
+  ; MFMA_B: dst used by extractelement (non-MAI) → isRewriteCandidate = false.
+  %r2 = call <4 x float> @llvm.amdgcn.mfma.f32.16x16x32.f16(
+      <8 x half> %a, <8 x half> %b, <4 x float> %r1, i32 0, i32 0, i32 0)
+
+  %eidx = and i32 %i, 31
+  %v0e  = extractelement <32 x float> %vc0, i32 0
+  %vc0n = insertelement <32 x float> %vc0, float %v0e, i32 %eidx
+  %vc1n = insertelement <32 x float> %vc1, float %v0e, i32 %eidx
+  %vc2n = insertelement <32 x float> %vc2, float %v0e, i32 %eidx
+  %vc3n = insertelement <32 x float> %vc3, float %v0e, i32 %eidx
+  %vc4n = insertelement <32 x float> %vc4, float %v0e, i32 %eidx
+  %vc5n = insertelement <32 x float> %vc5, float %v0e, i32 %eidx
+  %vc6n = insertelement <32 x float> %vc6, float %v0e, i32 %eidx
+  %vc7n = insertelement <32 x float> %vc7, float %v0e, i32 %eidx
+  store volatile float %v0e, ptr addrspace(1) %out, align 4
+
+  %i.next = add i32 %i, 1
+  %cond   = icmp eq i32 %i.next, %n
+  br i1 %cond, label %exit, label %loop
+
+exit:
+  %e = extractelement <4 x float> %r2, i32 0
+  store float %e, ptr addrspace(1) %out, align 4
+  ret void
+}
+
+attributes #0 = { "amdgpu-waves-per-eu"="1,1" "amdgpu-flat-work-group-size"="64,64" }
+
+; AFTER-LABEL: name: test_src2_subrange_nonmai_init
+; AFTER: bb.1.loop:
+; AFTER: %{{[0-9]+}}:areg_128_align2 = V_MFMA_F32_16X16X32_F16_e64
+; AFTER: %{{[0-9]+}}:vreg_128_align2 = V_MFMA_F32_16X16X32_F16_vgprcd_e64

--- a/llvm/test/CodeGen/AMDGPU/rewrite-mfma-form-subreg-overwrite-cross-bb.mir
+++ b/llvm/test/CodeGen/AMDGPU/rewrite-mfma-form-subreg-overwrite-cross-bb.mir
@@ -1,0 +1,105 @@
+# RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a \
+# RUN:     -run-pass=machine-scheduler \
+# RUN:     -amdgpu-disable-rewrite-mfma-form-sched-stage=false \
+# RUN:     %s -o - | FileCheck %s
+#
+# Test: RewriteMFMAFormStage — cross-BB sub-register overwrites (diamond CFG)
+# produce mixed MAI/non-MAI reaching defs; hasDominanceConflict blocks rewrite.
+#
+# CFG (diamond):
+#
+#          bb.0  ← %acc = MFMA(...)        MAI full-reg def, all lanes
+#         /    \
+#       bb.1  bb.2  ← non-MAI subreg overwrites: bb.1: %acc.sub0 = V_MOV 1
+#         \    /                                  bb.2: %acc.sub1 = V_MOV 2
+#          bb.3  ← %res  = MFMA(..., %acc) UseSubReg=0, full-reg use
+#                  %res2 = MFMA(..., %res) chained
+#
+# %res and %res2 are rewrite candidates (MAI-only dst users).
+# 9 × vreg_1024 = 288 ArchVGPRs > gfx90a limit 256 → ExcessArchVGPR fires.
+#
+# findReachingDefs for %res src2=%acc (full-reg use → all SubRanges queried):
+#   %acc has SubRanges because the diamond creates per-lane mixed definitions.
+#   sub0: only bb.0 MFMA reaches bb.3 via non-bb.1 path → non-PHIDef at UseIdx
+#         → direct path → MAI def inserted into ResultSet.
+#   sub1: bb.0 MFMA (via bb.2) and bb.2 V_MOV both reach bb.3 → PHIDef
+#         → BFS → MAI(MFMA, bb.0) + non-MAI(V_MOV, bb.2) in ResultSet.
+#   sub2/sub3: similar → MAI(MFMA, bb.0) + non-MAI(V_MOV, bb.1 or bb.2).
+#   ResultSet = {MFMA(MAI), V_MOV×2(non-MAI)}.
+#
+# hasDominanceConflict: bb.0 dominates bb.1 and bb.2 → MFMA(bb.0) dominates
+#   V_MOV(bb.1/bb.2) → conflict detected → %res excluded.
+# Propagation: %res2 excluded (src2 = excluded %res dst).
+#              %acc MFMA excluded (MAI reaching-def of conflicted src2).
+#
+# CHECK-LABEL: name: test_subreg_overwrite_cross_bb
+# CHECK: bb.0:
+# CHECK:   %acc:vreg_128_align2 = nofpexcept V_MFMA_F32_16X16X4F32_vgprcd_e64
+# CHECK: bb.3:
+# CHECK:   %res:vreg_128_align2 = nofpexcept V_MFMA_F32_16X16X4F32_vgprcd_e64
+# CHECK:   %res2:vreg_128_align2 = nofpexcept V_MFMA_F32_16X16X4F32_vgprcd_e64
+# CHECK-NOT: areg_128_align2
+
+--- |
+  define void @test_subreg_overwrite_cross_bb() #0 {
+  entry:
+    unreachable
+  }
+  attributes #0 = { "amdgpu-waves-per-eu"="1,1" "amdgpu-flat-work-group-size"="64,64" }
+...
+
+---
+name:            test_subreg_overwrite_cross_bb
+tracksRegLiveness: true
+body: |
+  bb.0:
+    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    liveins: $vgpr0, $sgpr4_sgpr5, $sgpr6
+
+    %p0:vreg_1024 = IMPLICIT_DEF
+    %p1:vreg_1024 = IMPLICIT_DEF
+    %p2:vreg_1024 = IMPLICIT_DEF
+    %p3:vreg_1024 = IMPLICIT_DEF
+    %p4:vreg_1024 = IMPLICIT_DEF
+    %p5:vreg_1024 = IMPLICIT_DEF
+    %p6:vreg_1024 = IMPLICIT_DEF
+    %p7:vreg_1024 = IMPLICIT_DEF
+    %p8:vreg_1024 = IMPLICIT_DEF
+
+    %srca:vgpr_32 = IMPLICIT_DEF
+    %srcb:vgpr_32 = IMPLICIT_DEF
+
+    ; MAI full-reg def of %acc (all 4 lanes) — contributes MAI to ResultSet.
+    %acc:vreg_128_align2 = nofpexcept V_MFMA_F32_16X16X4F32_vgprcd_e64 %srca:vgpr_32, %srcb:vgpr_32, 0, 0, 0, 0, implicit $mode, implicit $exec
+
+    SCHED_BARRIER 0
+
+    S_CMP_EQ_U32 $sgpr6, 0, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.2, implicit $scc
+
+  ; bb.1: non-MAI sub0 overwrite — contributes non-MAI to ResultSet.
+  bb.1:
+    successors: %bb.3(0x80000000)
+
+    %acc.sub0:vreg_128_align2 = V_MOV_B32_e32 1, implicit $exec
+
+    S_BRANCH %bb.3
+
+  ; bb.2: non-MAI sub1 overwrite — contributes non-MAI to ResultSet.
+  bb.2:
+    successors: %bb.3(0x80000000)
+
+    %acc.sub1:vreg_128_align2 = V_MOV_B32_e32 2, implicit $exec
+
+    S_BRANCH %bb.3
+
+  ; bb.3: hasDominanceConflict(%acc)=true → %res/%res2 excluded → no rewrite.
+  bb.3:
+    %res:vreg_128_align2 = nofpexcept V_MFMA_F32_16X16X4F32_vgprcd_e64 %srca:vgpr_32, %srcb:vgpr_32, %acc:vreg_128_align2, 0, 0, 0, implicit $mode, implicit $exec
+
+    ; Chain the result into another MFMA (MAI use of %res -> CopyForUse = 0).
+    %res2:vreg_128_align2 = nofpexcept V_MFMA_F32_16X16X4F32_vgprcd_e64 %srca:vgpr_32, %srcb:vgpr_32, %res:vreg_128_align2, 0, 0, 0, implicit $mode, implicit $exec
+
+    KILL %p0, %p1, %p2, %p3, %p4, %p5, %p6, %p7, %p8
+
+    S_ENDPGM 0


### PR DESCRIPTION
Rework findReachingDefs to correctly handle registers with subranges by querying each subrange's LiveRange independently via collectReachingDefsInRange. This avoids missing non-MAI subreg defs (e.g. V_MOV writing a sub-register) that are invisible when only the main LiveInterval is queried.

Add hasDominanceConflict: when a src2 operand has both MAI and non-MAI reaching defs with a dominance relationship (same-BB ordering or cross-BB dominator), the MFMA cannot be safely rewritten to AGPR form. Conflicting candidates (and their downstream dst-chain consumers) are excluded from the rewrite set via ExcludedMFMAs before any setDesc/setRegClass changes are applied, eliminating the need for rollback.

Add propagateExclusionForward to transitively exclude any downstream MFMA whose src2 is the dst of an excluded MFMA, preserving accumulator chain correctness.