### PR TITLE
[mlir] Fix crash in test type converter for 1->N result conversion

### DIFF
--- a/mlir/test/Transforms/test-legalizer.mlir
+++ b/mlir/test/Transforms/test-legalizer.mlir
@@ -302,6 +302,12 @@ func.func @caller() {
 
 // -----
 
+// Regression test for https://github.com/llvm/llvm-project/issues/201521
+// CHECK-LABEL: func.func private @callee_multi_result(f64) -> (f64, i32, i32, f16, f16)
+func.func private @callee_multi_result(i64) -> (i64, i32, i32, f32)
+
+// -----
+
 //      CHECK: func.func @use_of_replaced_bbarg(
 // CHECK-SAME:     %[[arg0:.*]]: f64)
 //      CHECK:   "test.valid"(%[[arg0]])

--- a/mlir/test/lib/Dialect/Test/TestPatterns.cpp
+++ b/mlir/test/lib/Dialect/Test/TestPatterns.cpp
@@ -1531,7 +1531,7 @@ struct TestTypeConverter : public TypeConverter {
 
     // Split F32 into F16,F16.
     if (t.isF32()) {
-      results.assign(2, Float16Type::get(t.getContext()));
+      results.append(2, Float16Type::get(t.getContext()));
       return success();
     }
 


### PR DESCRIPTION
Use `results.append` instead of `results.assign`, preserving previous results.

Fixes https://github.com/llvm/llvm-project/issues/201521