### PR TITLE
[DenseMap] Fix ubsan error after #201281

### DIFF
--- a/llvm/include/llvm/ADT/DenseMap.h
+++ b/llvm/include/llvm/ADT/DenseMap.h
@@ -489,9 +489,11 @@ protected:
 
     assert((getNumBuckets() & (getNumBuckets() - 1)) == 0 &&
            "# initial buckets must be a power of two!");
-    std::memset(getUsed(), 0,
-                llvm::densemap::detail::usedWords(getNumBuckets()) *
-                    sizeof(UsedT));
+    if (getNumBuckets()) {
+      std::memset(getUsed(), 0,
+                  llvm::densemap::detail::usedWords(getNumBuckets()) *
+                      sizeof(UsedT));
+    }
   }
 
   /// Returns the number of buckets to allocate to ensure that the DenseMap can


### PR DESCRIPTION
```
/home/b/sanitizer-aarch64-linux-bootstrap-ubsan/build/llvm-project/llvm/include/llvm/ADT/DenseMap.h:492:17: runtime error: null pointer passed as argument 1, which is declared to never be null
```