### PR TITLE
[libc++] LWG3767: `codecvt<charN_t, char8_t, mbstate_t>` incorrectly added to locale

### DIFF
--- a/libcxx/docs/Status/Cxx2cIssues.csv
+++ b/libcxx/docs/Status/Cxx2cIssues.csv
@@ -40,7 +40,7 @@
 "`LWG3990 <https://wg21.link/LWG3990>`__","Program-defined specializations of ``std::tuple`` and ``std::variant`` can't be properly supported","2023-11 (Kona)","|Complete|","21","`#105310 <https://github.com/llvm/llvm-project/issues/105310>`__",""
 "`LWG4001 <https://wg21.link/LWG4001>`__","``iota_view`` should provide ``empty``","2023-11 (Kona)","|Complete|","19","`#105311 <https://github.com/llvm/llvm-project/issues/105311>`__",""
 "","","","","","",""
-"`LWG3767 <https://wg21.link/LWG3767>`__","``codecvt<charN_t, char8_t, mbstate_t>`` incorrectly added to locale","2024-03 (Tokyo)","","","`#105313 <https://github.com/llvm/llvm-project/issues/105313>`__",""
+"`LWG3767 <https://wg21.link/LWG3767>`__","``codecvt<charN_t, char8_t, mbstate_t>`` incorrectly added to locale","2024-03 (Tokyo)","|Complete|","23","`#105313 <https://github.com/llvm/llvm-project/issues/105313>`__",""
 "`LWG3919 <https://wg21.link/LWG3919>`__","``enumerate_view`` may invoke UB for sized common non-forward underlying ranges","2024-03 (Tokyo)","|Complete|","23","`#105315 <https://github.com/llvm/llvm-project/issues/105315>`__",""
 "`LWG3950 <https://wg21.link/LWG3950>`__","``std::basic_string_view`` comparison operators are overspecified","2024-03 (Tokyo)","|Complete|","18","`#105316 <https://github.com/llvm/llvm-project/issues/105316>`__",""
 "`LWG3975 <https://wg21.link/LWG3975>`__","Specializations of ``basic_format_context`` should not be permitted","2024-03 (Tokyo)","|Nothing To Do|","","`#105317 <https://github.com/llvm/llvm-project/issues/105317>`__",""

--- a/libcxx/include/__locale
+++ b/libcxx/include/__locale
@@ -991,10 +991,11 @@ protected:
 
 #  if _LIBCPP_HAS_CHAR8_T
 
-// template <> class codecvt<char16_t, char8_t, mbstate_t> // C++20
+// template <> class codecvt<char16_t, char8_t, mbstate_t> // C++20, deprecated in C++20
 
 template <>
-class _LIBCPP_EXPORTED_FROM_ABI codecvt<char16_t, char8_t, mbstate_t> : public locale::facet, public codecvt_base {
+class _LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_EXPORTED_FROM_ABI codecvt<char16_t, char8_t, mbstate_t>
+    : public locale::facet, public codecvt_base {
 public:
   typedef char16_t intern_type;
   typedef char8_t extern_type;
@@ -1154,10 +1155,11 @@ protected:
 
 #  if _LIBCPP_HAS_CHAR8_T
 
-// template <> class codecvt<char32_t, char8_t, mbstate_t> // C++20
+// template <> class codecvt<char32_t, char8_t, mbstate_t> // C++20, deprecated in C++20
 
 template <>
-class _LIBCPP_EXPORTED_FROM_ABI codecvt<char32_t, char8_t, mbstate_t> : public locale::facet, public codecvt_base {
+class _LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_EXPORTED_FROM_ABI codecvt<char32_t, char8_t, mbstate_t>
+    : public locale::facet, public codecvt_base {
 public:
   typedef char32_t intern_type;
   typedef char8_t extern_type;
@@ -1263,8 +1265,10 @@ _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS codecvt_byname<char16_t, char, mbstate_t>; // d
 extern template class _LIBCPP_DEPRECATED_IN_CXX20
 _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS codecvt_byname<char32_t, char, mbstate_t>; // deprecated in C++20
 #  if _LIBCPP_HAS_CHAR8_T
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS codecvt_byname<char16_t, char8_t, mbstate_t>; // C++20
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS codecvt_byname<char32_t, char8_t, mbstate_t>; // C++20
+extern template class _LIBCPP_DEPRECATED_IN_CXX20
+_LIBCPP_EXTERN_TEMPLATE_TYPE_VIS codecvt_byname<char16_t, char8_t, mbstate_t>; // C++20, deprecated in C++20
+extern template class _LIBCPP_DEPRECATED_IN_CXX20
+_LIBCPP_EXTERN_TEMPLATE_TYPE_VIS codecvt_byname<char32_t, char8_t, mbstate_t>; // C++20, deprecated in C++20
 #  endif
 
 template <size_t _Np>

--- a/libcxx/src/locale.cpp
+++ b/libcxx/src/locale.cpp
@@ -159,11 +159,11 @@ locale::__imp::__imp(size_t refs) : facet(refs), facets_(N), name_("C") {
   _LIBCPP_SUPPRESS_DEPRECATED_PUSH
   install(&make<codecvt<char16_t, char, mbstate_t> >(1u));
   install(&make<codecvt<char32_t, char, mbstate_t> >(1u));
-  _LIBCPP_SUPPRESS_DEPRECATED_POP
 #if _LIBCPP_HAS_CHAR8_T
   install(&make<codecvt<char16_t, char8_t, mbstate_t> >(1u));
   install(&make<codecvt<char32_t, char8_t, mbstate_t> >(1u));
 #endif
+  _LIBCPP_SUPPRESS_DEPRECATED_POP
   install(&make<numpunct<char> >(1u));
 #if _LIBCPP_HAS_WIDE_CHARACTERS
   install(&make<numpunct<wchar_t> >(1u));
@@ -229,11 +229,11 @@ locale::__imp::__imp(const string& name, size_t refs) : facet(refs), facets_(N),
   _LIBCPP_SUPPRESS_DEPRECATED_PUSH
   install(new codecvt_byname<char16_t, char, mbstate_t>(name_));
   install(new codecvt_byname<char32_t, char, mbstate_t>(name_));
-  _LIBCPP_SUPPRESS_DEPRECATED_POP
 #if _LIBCPP_HAS_CHAR8_T
   install(new codecvt_byname<char16_t, char8_t, mbstate_t>(name_));
   install(new codecvt_byname<char32_t, char8_t, mbstate_t>(name_));
 #endif
+  _LIBCPP_SUPPRESS_DEPRECATED_POP
   install(new numpunct_byname<char>(name_));
 #if _LIBCPP_HAS_WIDE_CHARACTERS
   install(new numpunct_byname<wchar_t>(name_));
@@ -295,11 +295,11 @@ locale::__imp::__imp(const __imp& other, const string& name, locale::category c)
     _LIBCPP_SUPPRESS_DEPRECATED_PUSH
     install(new codecvt_byname<char16_t, char, mbstate_t>(name));
     install(new codecvt_byname<char32_t, char, mbstate_t>(name));
-    _LIBCPP_SUPPRESS_DEPRECATED_POP
 #if _LIBCPP_HAS_CHAR8_T
     install(new codecvt_byname<char16_t, char8_t, mbstate_t>(name));
     install(new codecvt_byname<char32_t, char8_t, mbstate_t>(name));
 #endif
+    _LIBCPP_SUPPRESS_DEPRECATED_POP
   }
   if (c & locale::monetary) {
     install(new moneypunct_byname<char, false>(name));
@@ -367,11 +367,11 @@ locale::__imp::__imp(const __imp& other, const __imp& one, locale::category c)
     _LIBCPP_SUPPRESS_DEPRECATED_PUSH
     install_from<std::codecvt<char16_t, char, mbstate_t> >(one);
     install_from<std::codecvt<char32_t, char, mbstate_t> >(one);
-    _LIBCPP_SUPPRESS_DEPRECATED_POP
 #if _LIBCPP_HAS_CHAR8_T
     install_from<std::codecvt<char16_t, char8_t, mbstate_t> >(one);
     install_from<std::codecvt<char32_t, char8_t, mbstate_t> >(one);
 #endif
+    _LIBCPP_SUPPRESS_DEPRECATED_POP
 #if _LIBCPP_HAS_WIDE_CHARACTERS
     install_from<std::codecvt<wchar_t, char, mbstate_t> >(one);
 #endif
@@ -5652,8 +5652,10 @@ template class _LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_
 template class _LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS
     codecvt_byname<char32_t, char, mbstate_t>;
 #if _LIBCPP_HAS_CHAR8_T
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS codecvt_byname<char16_t, char8_t, mbstate_t>;
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS codecvt_byname<char32_t, char8_t, mbstate_t>;
+template class _LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS
+    codecvt_byname<char16_t, char8_t, mbstate_t>;
+template class _LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS
+    codecvt_byname<char32_t, char8_t, mbstate_t>;
 #endif
 
 _LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt.byname/codecvt_byname_char16_t_char8_t.depr_in_cxx20.verify.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt.byname/codecvt_byname_char16_t_char8_t.depr_in_cxx20.verify.cpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <locale>
+
+// codecvt_byname<char16_t, char8_t, mbstate_t>
+//  deprecated in C++20, per LWG3767
+
+// REQUIRES: std-at-least-c++20
+// XFAIL: availability-char8_t_support-missing
+
+#include <locale>
+
+#include "../with_public_dtor.hpp"
+
+void test() {
+  // Don't test for the exact type since the underlying type of std::mbstate_t depends on implementation details.
+
+  // expected-warning-re@+1 {{'codecvt_byname<char16_t, char8_t, {{.*}}>' is deprecated}}
+  [[maybe_unused]] with_public_dtor<std::codecvt_byname<char16_t, char8_t, std::mbstate_t>> cvt("", 0);
+}

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt.byname/codecvt_byname_char32_t_char8_t.depr_in_cxx20.verify.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt.byname/codecvt_byname_char32_t_char8_t.depr_in_cxx20.verify.cpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <locale>
+
+// codecvt_byname<char32_t, char8_t, mbstate_t>
+//  deprecated in C++20, per LWG3767
+
+// REQUIRES: std-at-least-c++20
+// XFAIL: availability-char8_t_support-missing
+
+#include <locale>
+
+#include "../with_public_dtor.hpp"
+
+void test() {
+  // Don't test for the exact type since the underlying type of std::mbstate_t depends on implementation details.
+
+  // expected-warning-re@+1 {{'codecvt_byname<char32_t, char8_t, {{.*}}>' is deprecated}}
+  [[maybe_unused]] with_public_dtor<std::codecvt_byname<char32_t, char8_t, std::mbstate_t>> cvt("", 0);
+}

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt.byname/ctor_char16_t_char8_t.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt.byname/ctor_char16_t_char8_t.pass.cpp
@@ -10,6 +10,10 @@
 
 // XFAIL: availability-char8_t_support-missing
 
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+
+// This test runs in C++20, but we have deprecated codecvt_byname<char16_t, char8_t, mbstate_t> in C++20.
+
 // <locale>
 
 // template <> class codecvt_byname<char16_t, char8_t, mbstate_t>

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt.byname/ctor_char32_t_char8_t.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt.byname/ctor_char32_t_char8_t.pass.cpp
@@ -10,6 +10,10 @@
 
 // XFAIL: availability-char8_t_support-missing
 
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+
+// This test runs in C++20, but we have deprecated codecvt_byname<char32_t, char8_t, mbstate_t> in C++20.
+
 // <locale>
 
 // template <> class codecvt_byname<char32_t, char8_t, mbstate_t>

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/codecvt_char16_t_char8_t.depr_in_cxx20.verify.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/codecvt_char16_t_char8_t.depr_in_cxx20.verify.cpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <locale>
+
+// codecvt<char16_t, char8_t, mbstate_t>
+//  deprecated in C++20, per LWG3767
+
+// REQUIRES: std-at-least-c++20
+// XFAIL: availability-char8_t_support-missing
+
+#include <locale>
+
+#include "../with_public_dtor.hpp"
+
+void test() {
+  // Don't test for the exact type since the underlying type of std::mbstate_t depends on implementation details.
+
+  // expected-warning-re@+1 {{'codecvt<char16_t, char8_t, {{.*}}>' is deprecated}}
+  [[maybe_unused]] with_public_dtor<std::codecvt<char16_t, char8_t, std::mbstate_t>> cvt("", 0);
+}

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/codecvt_char32_t_char8_t.depr_in_cxx20.verify.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/codecvt_char32_t_char8_t.depr_in_cxx20.verify.cpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <locale>
+
+// codecvt<char32_t, char8_t, mbstate_t>
+//  deprecated in C++20, per LWG3767
+
+// REQUIRES: std-at-least-c++20
+// XFAIL: availability-char8_t_support-missing
+
+#include <locale>
+
+#include "../with_public_dtor.hpp"
+
+void test() {
+  // Don't test for the exact type since the underlying type of std::mbstate_t depends on implementation details.
+
+  // expected-warning-re@+1 {{'codecvt<char32_t, char8_t, {{.*}}>' is deprecated}}
+  [[maybe_unused]] with_public_dtor<std::codecvt<char32_t, char8_t, std::mbstate_t>> cvt("", 0);
+}

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/ctor_char16_t_char8_t.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/ctor_char16_t_char8_t.pass.cpp
@@ -10,6 +10,10 @@
 
 // XFAIL: availability-char8_t_support-missing
 
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+
+// This test runs in C++20, but we have deprecated codecvt<char16_t, char8_t, mbstate_t> in C++20.
+
 // <locale>
 
 // template <> class codecvt<char16_t, char8_t, mbstate_t>

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/ctor_char32_t_char8_t.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/ctor_char32_t_char8_t.pass.cpp
@@ -10,6 +10,10 @@
 
 // XFAIL: availability-char8_t_support-missing
 
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+
+// This test runs in C++20, but we have deprecated codecvt<char32_t, char8_t, mbstate_t> in C++20.
+
 // <locale>
 
 // template <> class codecvt<char32_t, char8_t, mbstate_t>

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char16_t_char8_t_always_noconv.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char16_t_char8_t_always_noconv.pass.cpp
@@ -10,6 +10,10 @@
 
 // XFAIL: availability-char8_t_support-missing
 
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+
+// This test runs in C++20, but we have deprecated codecvt<char16_t, char8_t, mbstate_t> in C++20.
+
 // <locale>
 
 // template <> class codecvt<char16_t, char8_t, mbstate_t>

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char16_t_char8_t_encoding.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char16_t_char8_t_encoding.pass.cpp
@@ -10,6 +10,10 @@
 
 // XFAIL: availability-char8_t_support-missing
 
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+
+// This test runs in C++20, but we have deprecated codecvt<char16_t, char8_t, mbstate_t> in C++20.
+
 // <locale>
 
 // template <> class codecvt<char16_t, char8_t, mbstate_t>

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char16_t_char8_t_in.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char16_t_char8_t_in.pass.cpp
@@ -10,6 +10,10 @@
 
 // XFAIL: availability-char8_t_support-missing
 
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+
+// This test runs in C++20, but we have deprecated codecvt<char16_t, char8_t, mbstate_t> in C++20.
+
 // <locale>
 
 // template <> class codecvt<char16_t, char8_t, mbstate_t>

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char16_t_char8_t_length.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char16_t_char8_t_length.pass.cpp
@@ -10,6 +10,10 @@
 
 // XFAIL: availability-char8_t_support-missing
 
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+
+// This test runs in C++20, but we have deprecated codecvt<char16_t, char8_t, mbstate_t> in C++20.
+
 // <locale>
 
 // template <> class codecvt<char16_t, char8_t, mbstate_t>

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char16_t_char8_t_max_length.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char16_t_char8_t_max_length.pass.cpp
@@ -10,6 +10,10 @@
 
 // XFAIL: availability-char8_t_support-missing
 
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+
+// This test runs in C++20, but we have deprecated codecvt<char16_t, char8_t, mbstate_t> in C++20.
+
 // <locale>
 
 // template <> class codecvt<char16_t, char8_t, mbstate_t>

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char16_t_char8_t_out.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char16_t_char8_t_out.pass.cpp
@@ -10,6 +10,10 @@
 
 // XFAIL: availability-char8_t_support-missing
 
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+
+// This test runs in C++20, but we have deprecated codecvt<char16_t, char8_t, mbstate_t> in C++20.
+
 // <locale>
 
 // template <> class codecvt<char16_t, char8_t, mbstate_t>

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char16_t_char8_t_unshift.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char16_t_char8_t_unshift.pass.cpp
@@ -10,6 +10,10 @@
 
 // XFAIL: availability-char8_t_support-missing
 
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+
+// This test runs in C++20, but we have deprecated codecvt<char16_t, char8_t, mbstate_t> in C++20.
+
 // <locale>
 
 // template <> class codecvt<char16_t, char8_t, mbstate_t>

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char32_t_char8_t_always_noconv.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char32_t_char8_t_always_noconv.pass.cpp
@@ -10,6 +10,10 @@
 
 // XFAIL: availability-char8_t_support-missing
 
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+
+// This test runs in C++20, but we have deprecated codecvt<char32_t, char8_t, mbstate_t> in C++20.
+
 // <locale>
 
 // template <> class codecvt<char32_t, char8_t, mbstate_t>

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char32_t_char8_t_encoding.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char32_t_char8_t_encoding.pass.cpp
@@ -10,6 +10,10 @@
 
 // XFAIL: availability-char8_t_support-missing
 
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+
+// This test runs in C++20, but we have deprecated codecvt<char32_t, char8_t, mbstate_t> in C++20.
+
 // <locale>
 
 // template <> class codecvt<char32_t, char8_t, mbstate_t>

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char32_t_char8_t_in.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char32_t_char8_t_in.pass.cpp
@@ -10,6 +10,10 @@
 
 // XFAIL: availability-char8_t_support-missing
 
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+
+// This test runs in C++20, but we have deprecated codecvt<char32_t, char8_t, mbstate_t> in C++20.
+
 // <locale>
 
 // template <> class codecvt<char32_t, char8_t, mbstate_t>

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char32_t_char8_t_length.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char32_t_char8_t_length.pass.cpp
@@ -10,6 +10,10 @@
 
 // XFAIL: availability-char8_t_support-missing
 
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+
+// This test runs in C++20, but we have deprecated codecvt<char32_t, char8_t, mbstate_t> in C++20.
+
 // <locale>
 
 // template <> class codecvt<char32_t, char8_t, mbstate_t>

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char32_t_char8_t_max_length.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char32_t_char8_t_max_length.pass.cpp
@@ -10,6 +10,10 @@
 
 // XFAIL: availability-char8_t_support-missing
 
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+
+// This test runs in C++20, but we have deprecated codecvt<char32_t, char8_t, mbstate_t> in C++20.
+
 // <locale>
 
 // template <> class codecvt<char32_t, char8_t, mbstate_t>

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char32_t_char8_t_out.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char32_t_char8_t_out.pass.cpp
@@ -10,6 +10,10 @@
 
 // XFAIL: availability-char8_t_support-missing
 
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+
+// This test runs in C++20, but we have deprecated codecvt<char32_t, char8_t, mbstate_t> in C++20.
+
 // <locale>
 
 // template <> class codecvt<char32_t, char8_t, mbstate_t>

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char32_t_char8_t_unshift.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char32_t_char8_t_unshift.pass.cpp
@@ -10,6 +10,10 @@
 
 // XFAIL: availability-char8_t_support-missing
 
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+
+// This test runs in C++20, but we have deprecated codecvt<char32_t, char8_t, mbstate_t> in C++20.
+
 // <locale>
 
 // template <> class codecvt<char32_t, char8_t, mbstate_t>

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/types_char16_t_char8_t.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/types_char16_t_char8_t.pass.cpp
@@ -10,6 +10,10 @@
 
 // XFAIL: availability-char8_t_support-missing
 
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+
+// This test runs in C++20, but we have deprecated codecvt<char16_t, char8_t, mbstate_t> in C++20.
+
 // <locale>
 
 // template <>

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/types_char32_t_char8_t.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.codecvt/types_char32_t_char8_t.pass.cpp
@@ -10,6 +10,10 @@
 
 // XFAIL: availability-char8_t_support-missing
 
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+
+// This test runs in C++20, but we have deprecated codecvt<char32_t, char8_t, mbstate_t> in C++20.
+
 // <locale>
 
 // template <>


### PR DESCRIPTION
Implement it as a DR against C++20, patching P0482R6.

Fixes #105313.