### PR TITLE
[RISCV][TargetLowering][P-ext] Support sext_inreg or v2i32/v4i16 vectors on RV32.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorOps.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorOps.cpp
@@ -1562,15 +1562,12 @@ SDValue VectorLegalizer::ExpandSIGN_EXTEND_VECTOR_INREG(SDNode *Node) {
   // recurse through it.
   SDValue Op = DAG.getNode(ISD::ANY_EXTEND_VECTOR_INREG, DL, VT, Src);
 
-  // Now we need sign extend. Do this by shifting the elements. Even if these
-  // aren't legal operations, they have a better chance of being legalized
-  // without full scalarization than the sign extension does.
-  unsigned EltWidth = VT.getScalarSizeInBits();
-  unsigned SrcEltWidth = SrcVT.getScalarSizeInBits();
-  SDValue ShiftAmount = DAG.getConstant(EltWidth - SrcEltWidth, DL, VT);
-  return DAG.getNode(ISD::SRA, DL, VT,
-                     DAG.getNode(ISD::SHL, DL, VT, Op, ShiftAmount),
-                     ShiftAmount);
+  // Now we need sign extend. This will be exanded to shifts if it isn't
+  // supported.
+  EVT ExtVT = EVT::getVectorVT(*DAG.getContext(), SrcVT.getVectorElementType(),
+                               VT.getVectorNumElements());
+  return DAG.getNode(ISD::SIGN_EXTEND_INREG, DL, VT, Op,
+                     DAG.getValueType(ExtVT));
 }
 
 // Generically expand a vector zext in register to a shuffle of the relevant

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -665,6 +665,10 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
                          {MVT::v4i16, MVT::v2i32}, Legal);
       setOperationAction(ISD::ANY_EXTEND_VECTOR_INREG, {MVT::v4i16, MVT::v2i32},
                          Custom);
+      // LegalizeVectorOps uses result VT, LegalizeDAG uses ExtVT.
+      setOperationAction(ISD::SIGN_EXTEND_INREG,
+                         {MVT::v2i16, MVT::v4i8, MVT::v2i32, MVT::v4i16},
+                         Legal);
     }
   }
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -2555,5 +2555,10 @@ let append Predicates = [IsRV64] in {
   // Zero-extend patterns using zip*p with zero
   def : Pat<(v4i16 (zext_invec (v8i8 GPR:$rs))), (ZIP8P GPR:$rs, (v8i8 X0))>;
   def : Pat<(v2i32 (zext_invec (v4i16 GPR:$rs))), (ZIP16P GPR:$rs, (v4i16 X0))>;
+
+  // Sign extend inreg patterns using psext. sext_invec is lowered to
+  // zext_invec+sext_inreg.
+  def : Pat<(v4i16 (sext_inreg GPR:$rs1, v4i8)), (PSEXT_H_B GPR:$rs1)>;
+  def : Pat<(v2i32 (sext_inreg GPR:$rs1, v2i16)), (PSEXT_W_H GPR:$rs1)>;
 } // append Predicates = [IsRV64]
 } // Predicates = [HasStdExtP]

--- a/llvm/test/CodeGen/RISCV/rvp-simd-32.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-simd-32.ll
@@ -1285,8 +1285,7 @@ define <4 x i8> @test_pmulhsu_b(<4 x i8> %a, <4 x i8> %b) {
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    pwcvtu.b a0, a0
 ; RV64-NEXT:    pwcvtu.b a1, a1
-; RV64-NEXT:    pslli.h a0, a0, 8
-; RV64-NEXT:    psrai.h a0, a0, 8
+; RV64-NEXT:    psext.h.b a0, a0
 ; RV64-NEXT:    pmul.w.h11 a2, a0, a1
 ; RV64-NEXT:    pmul.w.h00 a0, a0, a1
 ; RV64-NEXT:    ppaire.h a0, a0, a2
@@ -1326,8 +1325,7 @@ define <4 x i8> @test_pmulhsu_b_commuted(<4 x i8> %a, <4 x i8> %b) {
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    pwcvtu.b a0, a0
 ; RV64-NEXT:    pwcvtu.b a1, a1
-; RV64-NEXT:    pslli.h a1, a1, 8
-; RV64-NEXT:    psrai.h a1, a1, 8
+; RV64-NEXT:    psext.h.b a1, a1
 ; RV64-NEXT:    pmul.w.h11 a2, a0, a1
 ; RV64-NEXT:    pmul.w.h00 a0, a0, a1
 ; RV64-NEXT:    ppaire.h a0, a0, a2

--- a/llvm/test/CodeGen/RISCV/rvp-simd-64.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-simd-64.ll
@@ -2413,25 +2413,23 @@ define <8 x i8> @test_pmulhsu_b(<8 x i8> %a, <8 x i8> %b) {
 ; RV64-NEXT:    ppaire.b a5, a6, a5
 ; RV64-NEXT:    pwcvtu.b a0, a0
 ; RV64-NEXT:    pwcvtu.b a1, a1
-; RV64-NEXT:    pslli.h a0, a0, 8
+; RV64-NEXT:    psext.h.b a0, a0
 ; RV64-NEXT:    ppaire.h a2, a4, a2
-; RV64-NEXT:    psrai.h a0, a0, 8
 ; RV64-NEXT:    ppaire.h a3, a5, a3
-; RV64-NEXT:    pwcvtu.b a2, a2
-; RV64-NEXT:    pwcvtu.b a3, a3
 ; RV64-NEXT:    pmul.w.h11 a4, a0, a1
 ; RV64-NEXT:    pmul.w.h00 a0, a0, a1
-; RV64-NEXT:    pslli.h a1, a2, 8
+; RV64-NEXT:    pwcvtu.b a1, a2
+; RV64-NEXT:    pwcvtu.b a2, a3
 ; RV64-NEXT:    ppaire.h a0, a0, a4
-; RV64-NEXT:    psrai.h a1, a1, 8
+; RV64-NEXT:    psext.h.b a1, a1
 ; RV64-NEXT:    psrli.h a0, a0, 8
-; RV64-NEXT:    pmul.w.h11 a2, a1, a3
-; RV64-NEXT:    pmul.w.h00 a1, a1, a3
-; RV64-NEXT:    srli a3, a0, 48
+; RV64-NEXT:    pmul.w.h11 a3, a1, a2
+; RV64-NEXT:    pmul.w.h00 a1, a1, a2
+; RV64-NEXT:    srli a2, a0, 48
 ; RV64-NEXT:    srli a4, a0, 32
 ; RV64-NEXT:    srli a5, a0, 16
-; RV64-NEXT:    ppaire.h a1, a1, a2
-; RV64-NEXT:    ppaire.b a2, a4, a3
+; RV64-NEXT:    ppaire.h a1, a1, a3
+; RV64-NEXT:    ppaire.b a2, a4, a2
 ; RV64-NEXT:    ppaire.b a0, a0, a5
 ; RV64-NEXT:    psrli.h a1, a1, 8
 ; RV64-NEXT:    srli a3, a1, 48
@@ -2496,20 +2494,18 @@ define <8 x i8> @test_pmulhsu_b_commuted(<8 x i8> %a, <8 x i8> %b) {
 ; RV64-NEXT:    ppaire.b a5, a6, a5
 ; RV64-NEXT:    pwcvtu.b a0, a0
 ; RV64-NEXT:    pwcvtu.b a1, a1
-; RV64-NEXT:    pslli.h a1, a1, 8
+; RV64-NEXT:    psext.h.b a1, a1
 ; RV64-NEXT:    ppaire.h a2, a4, a2
 ; RV64-NEXT:    ppaire.h a3, a5, a3
-; RV64-NEXT:    psrai.h a1, a1, 8
-; RV64-NEXT:    pwcvtu.b a2, a2
-; RV64-NEXT:    pwcvtu.b a3, a3
 ; RV64-NEXT:    pmul.w.h11 a4, a0, a1
 ; RV64-NEXT:    pmul.w.h00 a0, a0, a1
-; RV64-NEXT:    pslli.h a1, a3, 8
+; RV64-NEXT:    pwcvtu.b a1, a2
+; RV64-NEXT:    pwcvtu.b a2, a3
 ; RV64-NEXT:    ppaire.h a0, a0, a4
-; RV64-NEXT:    psrai.h a1, a1, 8
+; RV64-NEXT:    psext.h.b a2, a2
 ; RV64-NEXT:    psrli.h a0, a0, 8
-; RV64-NEXT:    pmul.w.h11 a3, a2, a1
-; RV64-NEXT:    pmul.w.h00 a1, a2, a1
+; RV64-NEXT:    pmul.w.h11 a3, a1, a2
+; RV64-NEXT:    pmul.w.h00 a1, a1, a2
 ; RV64-NEXT:    srli a2, a0, 48
 ; RV64-NEXT:    srli a4, a0, 32
 ; RV64-NEXT:    srli a5, a0, 16
@@ -4624,7 +4620,6 @@ define <2 x i32> @test_zext_v2i16_to_v2i32(<2 x i16> %a) {
   ret <2 x i32> %res
 }
 
-; FIXME: Should use psext.h.b on RV64.
 define <4 x i16> @test_sext_v4i8_to_v4i16(<4 x i8> %a) {
 ; RV32-LABEL: test_sext_v4i8_to_v4i16:
 ; RV32:       # %bb.0:
@@ -4634,14 +4629,12 @@ define <4 x i16> @test_sext_v4i8_to_v4i16(<4 x i8> %a) {
 ; RV64-LABEL: test_sext_v4i8_to_v4i16:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    pwcvtu.b a0, a0
-; RV64-NEXT:    pslli.h a0, a0, 8
-; RV64-NEXT:    psrai.h a0, a0, 8
+; RV64-NEXT:    psext.h.b a0, a0
 ; RV64-NEXT:    ret
   %res = sext <4 x i8> %a to <4 x i16>
   ret <4 x i16> %res
 }
 
-; FIXME: Should use psext.w.h on RV64.
 define <2 x i32> @test_sext_v2i16_to_v2i32(<2 x i16> %a) {
 ; RV32-LABEL: test_sext_v2i16_to_v2i32:
 ; RV32:       # %bb.0:
@@ -4651,8 +4644,7 @@ define <2 x i32> @test_sext_v2i16_to_v2i32(<2 x i16> %a) {
 ; RV64-LABEL: test_sext_v2i16_to_v2i32:
 ; RV64:       # %bb.0:
 ; RV64-NEXT:    pwcvtu.h a0, a0
-; RV64-NEXT:    pslli.w a0, a0, 16
-; RV64-NEXT:    psrai.w a0, a0, 16
+; RV64-NEXT:    psext.w.h a0, a0
 ; RV64-NEXT:    ret
   %res = sext <2 x i16> %a to <2 x i32>
   ret <2 x i32> %res


### PR DESCRIPTION
Update sext_vector_inreg expansion to use sext_inreg. Previously it emitted 2 shifts that wouldn't be combined.