### PR TITLE
[lld][WebAssembly] Add missing space in unmodeled diagnostic

### DIFF
--- a/lld/wasm/InputFiles.cpp
+++ b/lld/wasm/InputFiles.cpp
@@ -91,7 +91,7 @@ InputFile *createObjectFile(MemoryBufferRef mb, StringRef archiveName,
     auto *obj = cast<WasmObjectFile>(bin.get());
     if (obj->hasUnmodeledTypes())
       fatal(toString(mb.getBufferIdentifier()) +
-            "file has unmodeled reference or GC types");
+            " file has unmodeled reference or GC types");
     if (obj->isSharedObject())
       return make<SharedFile>(mb);
     return make<ObjFile>(mb, archiveName, lazy);


### PR DESCRIPTION
This is just a nit change, I hit this fatal while trying to use a GC object, and noticed that the diagnostic showed `foo.ofile has unmodeled reference or GC types`