### PR TITLE
[libcxx] Make std::pair pretty-printer ABI-independent

### DIFF
--- a/libcxx/test/libcxx/gdb/gdb_pretty_printer_test.sh.cpp
+++ b/libcxx/test/libcxx/gdb/gdb_pretty_printer_test.sh.cpp
@@ -41,6 +41,7 @@
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 
 #include "test_macros.h"
 
@@ -293,6 +294,17 @@ void tuple_test() {
   ComparePrettyPrintToChars(
       test1,
       "empty std::tuple");
+}
+
+void pair_test() {
+  std::pair<int, int> ints(1, 2);
+  ComparePrettyPrintToChars(ints, "{first = 1, second = 2}");
+
+  std::pair<std::string, int> mixed("hello", 42);
+  ComparePrettyPrintToChars(mixed, "{first = \"hello\", second = 42}");
+
+  std::pair<int, std::pair<int, int>> nested(1, {2, 3});
+  ComparePrettyPrintToChars(nested, "{first = 1, second = {first = 2, second = 3}}");
 }
 
 void unique_ptr_test() {
@@ -747,6 +759,7 @@ int main(int, char**) {
   //u16string_test();
   u32string_test();
   tuple_test();
+  pair_test();
   unique_ptr_test();
   shared_ptr_test();
   bitset_test();

--- a/libcxx/utils/gdb/libcxx/printers.py
+++ b/libcxx/utils/gdb/libcxx/printers.py
@@ -182,6 +182,20 @@ class StdTuplePrinter(object):
             return iter(())
         return self._Children(self.val)
 
+
+class StdPairPrinter(object):
+    """Print a std::pair.
+
+    Note that we don't rely on GDB's default struct formatting so that we can
+    provide a stable output for std::pair regardless of libc++'s ABI configuration.
+    """
+
+    def __init__(self, val):
+        self.val = val
+
+    def children(self):
+        return iter([("first", self.val["first"]), ("second", self.val["second"])])
+
 class StdStringPrinter(object):
     """Print a std::string."""
 
@@ -901,6 +915,7 @@ class LibcxxPrettyPrinter(object):
             "basic_string": StdStringPrinter,
             "string": StdStringPrinter,
             "string_view": StdStringViewPrinter,
+            "pair": StdPairPrinter,
             "tuple": StdTuplePrinter,
             "unique_ptr": StdUniquePtrPrinter,
             "shared_ptr": StdSharedPointerPrinter,


### PR DESCRIPTION
std::pair is printed explicitly instead of relying on GDB's default struct formatting to keep output stable across ABI configurations.

With _LIBCPP_DEPRECATED_ABI_DISABLE_PAIR_TRIVIAL_COPY_CTOR (default on some platforms, e.g. FreeBSD), std::pair gains an empty __non_trivially_copyable_base base class. GDB would otherwise render this as <...__non_trivially_copyable_base<...>> = {<No data fields>}, which makes output ABI-dependent.

Only first and second are meaningful, so print them directly.