### PR TITLE
[compiler-rt] Add missing <pthread.h> include

### DIFF
--- a/compiler-rt/lib/sanitizer_common/symbolizer/sanitizer_wrappers.cpp
+++ b/compiler-rt/lib/sanitizer_common/symbolizer/sanitizer_wrappers.cpp
@@ -14,6 +14,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
+#include <pthread.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <unistd.h>


### PR DESCRIPTION
#195509 removed a bunch of transitive includes from libc++, causing the build to fail.