### PR TITLE
[Mips] Fix $gp was restored when used as global register variable

### DIFF
--- a/llvm/lib/Target/Mips/MipsCallingConv.td
+++ b/llvm/lib/Target/Mips/MipsCallingConv.td
@@ -362,15 +362,28 @@ def CSR_O32_FP64 :
 def CSR_N32 : CalleeSavedRegs<(add(decimate(sequence "D%u_64", 30, 20), 2),
                   RA_64, FP_64, GP_64, (sequence "S%u_64", 7, 0))>;
 
+def CSR_N32_NoGP : CalleeSavedRegs<(add(decimate(sequence "D%u_64", 30, 20), 2),
+                  RA_64, FP_64, (sequence "S%u_64", 7, 0))>;
+
 def CSR_N32_SingleFloat
     : CalleeSavedRegs<(add(decimate(sequence "F%u", 30, 20), 2), RA_64, FP_64,
           GP_64, (sequence "S%u_64", 7, 0))>;
 
+def CSR_N32_SingleFloat_NoGP
+    : CalleeSavedRegs<(add(decimate(sequence "F%u", 30, 20), 2), RA_64, FP_64,
+          (sequence "S%u_64", 7, 0))>;
+
 def CSR_N64 : CalleeSavedRegs<(add (sequence "D%u_64", 31, 24), RA_64, FP_64,
                                    GP_64, (sequence "S%u_64", 7, 0))>;
 
+def CSR_N64_NoGP : CalleeSavedRegs<(add (sequence "D%u_64", 31, 24), RA_64, FP_64,
+                                   (sequence "S%u_64", 7, 0))>;
+
 def CSR_N64_SingleFloat : CalleeSavedRegs<(add(sequence "F%u", 31, 24), RA_64,
                               FP_64, GP_64, (sequence "S%u_64", 7, 0))>;
+
+def CSR_N64_SingleFloat_NoGP : CalleeSavedRegs<(add(sequence "F%u", 31, 24), RA_64,
+                              FP_64, (sequence "S%u_64", 7, 0))>;
 
 def CSR_Mips16RetHelper :
   CalleeSavedRegs<(add V0, V1, FP,

--- a/llvm/lib/Target/Mips/MipsRegisterInfo.cpp
+++ b/llvm/lib/Target/Mips/MipsRegisterInfo.cpp
@@ -25,6 +25,7 @@
 #include "llvm/CodeGen/TargetRegisterInfo.h"
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
 #include "llvm/IR/Function.h"
+#include "llvm/IR/Module.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
@@ -75,6 +76,13 @@ MipsRegisterInfo::getRegPressureLimit(const TargetRegisterClass *RC,
 // Callee Saved Registers methods
 //===----------------------------------------------------------------------===//
 
+/// Check if the user has declared $gp/$28 as a global regiater.
+bool isGPUsedAsGlobalRegister(const MachineFunction &MF) {
+  const Module *Module = MF.getFunction().getParent();
+
+  return Module->getNamedMetadata("llvm.named.register.$28");
+}
+
 /// Mips Callee Saved Registers
 const MCPhysReg *
 MipsRegisterInfo::getCalleeSavedRegs(const MachineFunction *MF) const {
@@ -89,20 +97,23 @@ MipsRegisterInfo::getCalleeSavedRegs(const MachineFunction *MF) const {
                                      : CSR_Interrupt_32_SaveList;
   }
 
+  bool GPIsGlobal = isGPUsedAsGlobalRegister(*MF);
   // N64 ABI
   if (Subtarget.isABI_N64()) {
     if (Subtarget.isSingleFloat())
-      return CSR_N64_SingleFloat_SaveList;
+      return GPIsGlobal ? CSR_N64_SingleFloat_NoGP_SaveList
+                        : CSR_N64_SingleFloat_SaveList;
 
-    return CSR_N64_SaveList;
+    return GPIsGlobal ? CSR_N64_NoGP_SaveList : CSR_N64_SaveList;
   }
 
   // N32 ABI
   if (Subtarget.isABI_N32()) {
     if (Subtarget.isSingleFloat())
-      return CSR_N32_SingleFloat_SaveList;
+      return GPIsGlobal ? CSR_N32_SingleFloat_NoGP_SaveList
+                        : CSR_N32_SingleFloat_SaveList;
 
-    return CSR_N32_SaveList;
+    return GPIsGlobal ? CSR_N32_NoGP_SaveList : CSR_N32_SaveList;
   }
 
   // O32 ABI
@@ -175,7 +186,8 @@ getReservedRegs(const MachineFunction &MF) const {
     Reserved.set(R);
 
   // For mno-abicalls, GP is a program invariant!
-  if (!Subtarget.isABICalls()) {
+  bool GPIsGlobal = isGPUsedAsGlobalRegister(MF);
+  if (!Subtarget.isABICalls() || GPIsGlobal) {
     Reserved.set(Mips::GP);
     Reserved.set(Mips::GP_64);
   }

--- a/llvm/test/CodeGen/Mips/write_register_gp.ll
+++ b/llvm/test/CodeGen/Mips/write_register_gp.ll
@@ -1,0 +1,23 @@
+; RUN: llc -mtriple=mips64el -mcpu=mips64r2 < %s | FileCheck %s -check-prefix=MIPS64
+
+; Test that when a user declares $28 as a global register, assignments to it are
+; not optimizes away.
+; Clang previously generated no instruction, which GCC generated `move $gp, $4`.
+; This test ensures Clang matches GCC behavior.
+
+define void @setglobal_$28(i64 %x) nounwind {
+; MIPS64-LABEL: setglobal_$28:
+; MIPS64:       # %bb.0: # %entry
+; MIPS64-NEXT:    jr $ra
+; MIPS64-NEXT:    move $gp, $4
+
+entry:
+  tail call void @llvm.write_register.i64(metadata !0, i64 %x)
+  ret void
+}
+
+declare void @llvm.write_register.i64(metadata, i64) nounwind
+
+!llvm.named.register.$28 = !{!0}
+!0 = !{!"$28"}
+

--- a/llvm/test/CodeGen/Mips/write_register_gp.ll
+++ b/llvm/test/CodeGen/Mips/write_register_gp.ll
@@ -1,15 +1,23 @@
-; RUN: llc -mtriple=mips64el -mcpu=mips64r2 < %s | FileCheck %s -check-prefix=MIPS64
+; RUN: llc -mtriple=mips64el-unknown-linux-gnu -mcpu=mips64r2 -target-abi=n32 < %s -filetype=asm -o - \
+; RUN:   | FileCheck  -check-prefixes=N32 %s
+; RUN: llc -mtriple=mips64el-unknown-linux-gnu -mcpu=mips64r2 -target-abi=n64 < %s -filetype=asm -o - \
+; RUN:   | FileCheck -check-prefixes=N64 %s
 
 ; Test that when a user declares $28 as a global register, assignments to it are
-; not optimizes away.
+; not optimized away.
 ; Clang previously generated no instruction, which GCC generated `move $gp, $4`.
 ; This test ensures Clang matches GCC behavior.
 
-define void @setglobal_$28(i64 %x) nounwind {
-; MIPS64-LABEL: setglobal_$28:
-; MIPS64:       # %bb.0: # %entry
-; MIPS64-NEXT:    jr $ra
-; MIPS64-NEXT:    move $gp, $4
+define void @setglobal(i64 %x) nounwind {
+; N32-LABEL: setglobal:
+; N32:       # %bb.0: # %entry
+; N32-NEXT:    jr $ra
+; N32-NEXT:    move $gp, $4
+
+; N64-LABEL: setglobal:
+; N64:       # %bb.0: # %entry
+; N64-NEXT:    jr $ra
+; N64-NEXT:    move $gp, $4
 
 entry:
   tail call void @llvm.write_register.i64(metadata !0, i64 %x)

--- a/llvm/test/CodeGen/Mips/write_register_gp.ll
+++ b/llvm/test/CodeGen/Mips/write_register_gp.ll
@@ -1,6 +1,6 @@
-; RUN: llc -mtriple=mips64el-unknown-linux-gnu -mcpu=mips64r2 -target-abi=n32 < %s -filetype=asm -o - \
+; RUN: llc -mtriple=mips64el-unknown-linux-gnu -mcpu=mips64r2 -target-abi=n32 < %s -o - \
 ; RUN:   | FileCheck  -check-prefixes=N32 %s
-; RUN: llc -mtriple=mips64el-unknown-linux-gnu -mcpu=mips64r2 -target-abi=n64 < %s -filetype=asm -o - \
+; RUN: llc -mtriple=mips64el-unknown-linux-gnu -mcpu=mips64r2 < %s -o - \
 ; RUN:   | FileCheck -check-prefixes=N64 %s
 
 ; Test that when a user declares $28 as a global register, assignments to it are


### PR DESCRIPTION
The function `eliminateDeadMI` would check `if (MRI.isReserved(Reg))`, now we only set GP to reserved when `!Subtarget.isABICalls()`. So `eliminateDeadMI` delete the `move $gp, $4`. And we would restore $gp after instr selection through `$gp_64 = LD $sp_64, 8`.

Check the module metadata `llvm.named.register.$28` to detect if $28 is used as global register. Then append new conditon when set $gp to reserverd status and return CalleeSavedRegs without $gp.

Fix #176546.