### PR TITLE
[BOLT] Add test for perf2bolt perfscript profile output

### DIFF
--- a/bolt/test/perf2bolt/perf_brstack.test
+++ b/bolt/test/perf2bolt/perf_brstack.test
@@ -1,12 +1,18 @@
-# Check perf2bolt pre-aggregated profile emission from branch-stack perf data.
+# Check perf2bolt pre-aggregated and perfscript profile emission from branch-stack perf data.
 
 REQUIRES: system-linux, perf-brstack
 
 RUN: %clang %S/Inputs/perf_test.c -no-pie -fuse-ld=lld -o %t
 RUN: perf record -Fmax -j any,u -e cycles:u -o %t.perf.data -- %t
 RUN: perf2bolt %t -p=%t.perf.data -o %t.fdata -ignore-build-id
-RUN: perf2bolt %t -p=%t.perf.data -o %t.preagg -ignore-build-id --profile-format=preagg
-RUN: perf2bolt %t -pa -p=%t.preagg -o %t.roundtrip.fdata -ignore-build-id
 RUN: sort %t.fdata > %t.fdata.sorted
-RUN: sort %t.roundtrip.fdata > %t.roundtrip.fdata.sorted
-RUN: diff %t.fdata.sorted %t.roundtrip.fdata.sorted
+# Pre-aggregated output: compare perf->preagg->fdata vs perf->fdata
+RUN: perf2bolt %t -p=%t.perf.data -o %t.preagg -ignore-build-id --profile-format=preagg
+RUN: perf2bolt %t -pa -p=%t.preagg -o %t.pa.roundtrip.fdata -ignore-build-id
+RUN: sort %t.pa.roundtrip.fdata > %t.pa.roundtrip.fdata.sorted
+RUN: diff %t.fdata.sorted %t.pa.roundtrip.fdata.sorted
+# Perfscript output: compare perf->perfscript->fdata vs perf->fdata
+RUN: perf2bolt %t -p=%t.perf.data -o %t.perfscript -ignore-build-id --profile-format=perfscript
+RUN: perf2bolt %t -ps -p=%t.perfscript -o %t.ps.roundtrip.fdata -ignore-build-id
+RUN: sort %t.ps.roundtrip.fdata > %t.ps.roundtrip.fdata.sorted
+RUN: diff %t.fdata.sorted %t.ps.roundtrip.fdata.sorted

--- a/bolt/test/perf2bolt/perf_test.test
+++ b/bolt/test/perf2bolt/perf_test.test
@@ -21,6 +21,10 @@ RUN: cmp %t3.x2 %t3.multi.x2
 RUN: perf2bolt %t -p=%t2 -o %t2.pa -ba -ignore-build-id --profile-format=preagg
 RUN: perf2bolt %t -p=%t2.pa -o %t2.pa.fdata -ba -pa
 RUN: cmp %t2.pa.fdata %t3
+# PerfScript output: compare perf->perfscript->fdata vs perf->fdata
+RUN: perf2bolt %t -p=%t2 -o %t2.ps -ba -ignore-build-id --profile-format=perfscript
+RUN: perf2bolt %t -p=%t2.ps -o %t2.ps.fdata -ba -ps
+RUN: cmp %t2.ps.fdata %t3
 
 CHECK-NOT: PERF2BOLT-ERROR
 CHECK-NOT: !! WARNING !! This high mismatch ratio indicates the input binary is probably not the same binary used during profiling collection.


### PR DESCRIPTION
Perf2bolt is able to generate perfscript output format (`--profile-format=perfscript`) from perf.data, and use it as an input with -ps.

Updated the existing perf_test.test and perf_brstack.test to cover the generation and parse of perfscript format.

Pull Requests:
https://github.com/llvm/llvm-project/pull/171144
https://github.com/llvm/llvm-project/pull/163785