### PR TITLE
[lldb][Windows] skip TestDAP_attachCommands.py and TestDAP_launch_extra_launch_commands.py

### DIFF
--- a/lldb/test/API/tools/lldb-dap/attach-commands/TestDAP_attachCommands.py
+++ b/lldb/test/API/tools/lldb-dap/attach-commands/TestDAP_attachCommands.py
@@ -12,7 +12,7 @@ import time
 class TestDAP_attachCommands(lldbdap_testcase.DAPTestCaseBase):
     SHARED_BUILD_TESTCASE = False
 
-    @skipIfWindows  # Fails in pre-merge CI
+    @skipIfWindows  # Wait for module events fails.
     @skipIfNetBSD  # Hangs on NetBSD as well
     def test_commands(self):
         """

--- a/lldb/test/API/tools/lldb-dap/attach-commands/TestDAP_attachCommands.py
+++ b/lldb/test/API/tools/lldb-dap/attach-commands/TestDAP_attachCommands.py
@@ -12,6 +12,7 @@ import time
 class TestDAP_attachCommands(lldbdap_testcase.DAPTestCaseBase):
     SHARED_BUILD_TESTCASE = False
 
+    @skipIfWindows  # Fails in pre-merge CI
     @skipIfNetBSD  # Hangs on NetBSD as well
     def test_commands(self):
         """

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_extra_launch_commands.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_extra_launch_commands.py
@@ -2,7 +2,7 @@
 Test lldb-dap launch request.
 """
 
-from lldbsuite.test.decorators import skipIf
+from lldbsuite.test.decorators import skipIf, skipIfWindows
 from lldbsuite.test.lldbtest import line_number
 import lldbdap_testcase
 
@@ -12,6 +12,7 @@ class TestDAP_launch_extra_launch_commands(lldbdap_testcase.DAPTestCaseBase):
     Tests the "launchCommands" with extra launching settings
     """
 
+    @skipIfWindows  # Fails in pre-merge CI
     # Flakey on 32-bit Arm Linux.
     @skipIf(oslist=["linux"], archs=["arm$"])
     def test(self):

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_extra_launch_commands.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_extra_launch_commands.py
@@ -12,7 +12,7 @@ class TestDAP_launch_extra_launch_commands(lldbdap_testcase.DAPTestCaseBase):
     Tests the "launchCommands" with extra launching settings
     """
 
-    @skipIfWindows  # Fails in pre-merge CI
+    @skipIfWindows  # Wait for module events fails.
     # Flakey on 32-bit Arm Linux.
     @skipIf(oslist=["linux"], archs=["arm$"])
     def test(self):


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/200133 was merged between https://github.com/llvm/llvm-project/pull/198906's CI running and merging it. This introduces some regressions in the pre-merge CI, blocking PR testing.

This patch unblocks the CI while investigating the failures.