### PR TITLE
[bazel] Add `LLVM_BUILD_STATIC` to `llvm-lto2`

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -5622,7 +5622,7 @@ cc_binary(
     ]),
     copts = llvm_copts,
     defines = [
-        "LLVM_BUILD_STATIC", # Provided by add_llvm_tool
+        "LLVM_BUILD_STATIC",  # Provided by add_llvm_tool
     ],
     stamp = 0,
     deps = [

--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -5621,6 +5621,9 @@ cc_binary(
         "tools/llvm-lto2/*.cpp",
     ]),
     copts = llvm_copts,
+    defines = [
+        "LLVM_BUILD_STATIC", # Provided by add_llvm_tool
+    ],
     stamp = 0,
     deps = [
         ":AllTargetsAsmParsers",


### PR DESCRIPTION
This is added by add_llvm_tool in CMake side and affects `DTLTO` inline ctor. (Introduced in #192629)