### PR TITLE
[lldb] Add missing includes to some tests

### DIFF
--- a/lldb/test/API/iohandler/sigint/cat.cpp
+++ b/lldb/test/API/iohandler/sigint/cat.cpp
@@ -1,3 +1,4 @@
+#include <cerrno>
 #include <cstdio>
 #include <string>
 #include <unistd.h>

--- a/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_breakpointLocations.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_breakpointLocations.py
@@ -80,10 +80,10 @@ class TestDAP_breakpointLocations(lldbdap_testcase.DAPTestCaseBase):
         # test more portable, only check that all expected breakpoints are
         # presented, but also accept additional breakpoints.
         expected_breakpoints = [
-            {"column": 39, "line": 40},
-            {"column": 51, "line": 40},
-            {"column": 3, "line": 42},
-            {"column": 18, "line": 42},
+            {"column": 39, "line": 41},
+            {"column": 51, "line": 41},
+            {"column": 3, "line": 43},
+            {"column": 18, "line": 43},
         ]
         for bp in expected_breakpoints:
             self.assertIn(bp, response["body"]["breakpoints"])

--- a/lldb/test/API/tools/lldb-dap/breakpoint/main.cpp
+++ b/lldb/test/API/tools/lldb-dap/breakpoint/main.cpp
@@ -1,6 +1,7 @@
 #include <dlfcn.h>
 #include <stdexcept>
 #include <stdio.h>
+#include <stdlib.h>
 
 int twelve(int i) {
   return 12 + i; // break 12


### PR DESCRIPTION
#195509 removed a bunch of transitive includes from libc++, causing the test to fail.