### PR TITLE
[libclc][Test] Don't hard code `clang` path in update_libclc_tests.py

### DIFF
--- a/libclc/test/update_libclc_tests.py
+++ b/libclc/test/update_libclc_tests.py
@@ -19,6 +19,7 @@ Usage:
 import argparse
 import os
 import re
+import shutil
 import subprocess
 import sys
 from concurrent.futures import ProcessPoolExecutor, as_completed
@@ -51,7 +52,6 @@ ARCH_TO_REQUIRES = {
 SCRIPT_DIR = Path(__file__).parent
 REPO_ROOT = SCRIPT_DIR.parent.parent
 UPDATE_SCRIPT = REPO_ROOT / "llvm" / "utils" / "update_cc_test_checks.py"
-CLANG = REPO_ROOT / "build" / "bin" / "clang"
 
 
 def find_cl_files(test_dir: Path):
@@ -92,7 +92,7 @@ def file_requires_feature(path: Path, feature: str) -> bool:
     return False
 
 
-def process_file(cl_file: Path, triple: str, cpu: str, check_prefix: str) -> bool:
+def process_file(cl_file: Path, triple: str, cpu: str, check_prefix: str, clang: Path) -> bool:
     original = cl_file.read_bytes()
     orig_lines = original.splitlines(keepends=True)
     saved_run = {i: orig_lines[i] for i in _run_line_indices(original)}
@@ -101,7 +101,7 @@ def process_file(cl_file: Path, triple: str, cpu: str, check_prefix: str) -> boo
         sys.executable,
         str(UPDATE_SCRIPT),
         "--clang",
-        str(CLANG),
+        str(clang),
         str(cl_file),
     ]
     print(f"  update: {cl_file.relative_to(REPO_ROOT)}")
@@ -126,7 +126,24 @@ def main():
         choices=list(ARCH_TO_TRIPLE.keys()),
         help="Target arch: amdgpu, amdgcn, nvptx64, spirv, spirv64",
     )
+    parser.add_argument(
+        "--clang-binary",
+        default=None,
+        help="The clang binary used to generate the test case (default: clang from PATH)",
+    )
     args = parser.parse_args()
+
+    if args.clang_binary:
+        clang = Path(args.clang_binary)
+        if not clang.is_file():
+            print(f"Error: clang binary not found: {clang}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        clang_in_path = shutil.which("clang")
+        if not clang_in_path:
+            print("Error: clang not found in PATH; use --clang-binary to specify.", file=sys.stderr)
+            sys.exit(1)
+        clang = Path(clang_in_path)
 
     arch = args.arch.lower()
     triple = ARCH_TO_TRIPLE[arch]
@@ -147,7 +164,7 @@ def main():
         return
 
     print(
-        f"arch={arch}  triple={triple}  cpu={cpu}  check_prefix={check_prefix}  requires={requires_feature}"
+        f"arch={arch}  triple={triple}  cpu={cpu}  check_prefix={check_prefix}  requires={requires_feature}  clang={clang}"
     )
     print(f"Processing {len(target_files)} file(s)...")
 
@@ -155,7 +172,7 @@ def main():
     num_workers = max(1, os.cpu_count() // 2)
     with ProcessPoolExecutor(max_workers=num_workers) as executor:
         futures = {
-            executor.submit(process_file, f, triple, cpu, check_prefix): f
+            executor.submit(process_file, f, triple, cpu, check_prefix, clang): f
             for f in target_files
         }
         for future in as_completed(futures):

--- a/libclc/test/update_libclc_tests.py
+++ b/libclc/test/update_libclc_tests.py
@@ -92,7 +92,9 @@ def file_requires_feature(path: Path, feature: str) -> bool:
     return False
 
 
-def process_file(cl_file: Path, triple: str, cpu: str, check_prefix: str, clang: Path) -> bool:
+def process_file(
+    cl_file: Path, triple: str, cpu: str, check_prefix: str, clang: Path
+) -> bool:
     original = cl_file.read_bytes()
     orig_lines = original.splitlines(keepends=True)
     saved_run = {i: orig_lines[i] for i in _run_line_indices(original)}
@@ -141,7 +143,10 @@ def main():
     else:
         clang_in_path = shutil.which("clang")
         if not clang_in_path:
-            print("Error: clang not found in PATH; use --clang-binary to specify.", file=sys.stderr)
+            print(
+                "Error: clang not found in PATH; use --clang-binary to specify.",
+                file=sys.stderr,
+            )
             sys.exit(1)
         clang = Path(clang_in_path)
 


### PR DESCRIPTION
In #201773, build folder is `redhat-linux-build` rather than `build`. Detect clang from PATH. Also add --clang-binary option to specify clang path.