### PR TITLE
[BOLT] fix hugify for old kernels

### DIFF
--- a/bolt/lib/Passes/LongJmp.cpp
+++ b/bolt/lib/Passes/LongJmp.cpp
@@ -367,11 +367,11 @@ LongJmpPass::tentativeLayoutRelocMode(const BinaryContext &BC,
   CurrentIndex = 0;
   bool ColdLayoutDone = false;
   auto runColdLayout = [&]() {
-    // Mirror the extra hugify alignment inserted by final section allocation
+    // Mirror the extra hugify page inserted by final section allocation
     // after the last non-cold section. Account for it before assigning cold
     // fragment addresses so range checks see the hot-to-cold gap.
     if (opts::Hugify && !BC.HasFixedLoadAddress && !opts::HotFunctionsAtEnd)
-      DotAddress = alignTo(DotAddress, opts::AlignText);
+      DotAddress += BC.PageAlign;
     DotAddress = tentativeLayoutRelocColdPart(BC, SortedFunctions, DotAddress);
     ColdLayoutDone = true;
     if (opts::HotFunctionsAtEnd)

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -4253,7 +4253,7 @@ void RewriteInstance::mapCodeSections(BOLTLinker::SectionMapper MapSection) {
       // weird ASLR mapping addresses (4KB aligned)
       if (opts::Hugify && !BC->HasFixedLoadAddress &&
           Section->getName() == LastNonColdSectionName)
-        Address = alignTo(Address, Section->getAlignment());
+        Address += BC->PageAlign;
     }
 
     // Make sure we allocate enough space for huge pages.

--- a/bolt/test/runtime/hugify.c
+++ b/bolt/test/runtime/hugify.c
@@ -2,6 +2,18 @@
 
 #include <stdio.h>
 
+// The dummy var is used for testing the hugify feature on pre-5.10 kernels,
+// which do not include the patch "fs/binfmt_elf: use PT_LOAD p_align values for
+// suitable start address".
+// The code size of the hugify test with the dummy var is about 2 MB. This
+// allows testing a corner case where the left (rounded down) and right (rounded
+// up) boundaries are located in different hugepages when the segment is mapped
+// with page alignment instead of the expected segment alignment. It is expected
+// that the hugified binary (PIE only) doesn't crash with a segfault, even in
+// the case of unexpected segment alignment, on pre-5.10 kernels.
+const char dummy_const_var_in_text[2 * 1024 * 1024 - 0x1000]
+    __attribute__((section(".text")));
+
 int main(int argc, char **argv) {
   printf("Hello world\n");
   return 0;


### PR DESCRIPTION
The PIE binary optimized with hugify option may crash on kernels below 5.10 due to unexpected segment alignment.

Fixes: https://github.com/llvm/llvm-project/issues/201813