### PR TITLE
[X86] LowerRESET_FPENV - use MOLoad for the constant-pool FLDENVm MMO

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -29473,7 +29473,7 @@ SDValue X86TargetLowering::LowerRESET_FPENV(SDValue Op,
   MachinePointerInfo MPI =
       MachinePointerInfo::getConstantPool(DAG.getMachineFunction());
   MachineMemOperand *MMO = MF.getMachineMemOperand(
-      MPI, MachineMemOperand::MOStore, X87StateSize, Align(4));
+      MPI, MachineMemOperand::MOLoad, X87StateSize, Align(4));
 
   return createSetFPEnvNodes(Env, Chain, DL, MVT::i32, MMO, DAG, Subtarget);
 }

--- a/llvm/test/CodeGen/X86/reset-fpenv-mmo.ll
+++ b/llvm/test/CodeGen/X86/reset-fpenv-mmo.ll
@@ -1,0 +1,18 @@
+; RUN: llc -mtriple=x86_64-unknown-linux-gnu -stop-after=finalize-isel < %s | FileCheck %s
+
+; LowerRESET_FPENV builds a MachineMemOperand for the constant-pool blob it
+; loads via FLDENVm. The flag must be MOLoad: FLDENVm is mayLoad = 1, so a
+; MOStore-flagged MMO is silently dropped by SelectionDAGISel's memref
+; filter, leaving FLDENVm with no memrefs at all. Verify the load-direction
+; MMO survives to the final MachineInstr.
+
+declare void @llvm.reset.fpenv()
+
+define void @reset_fpenv_mmo() nounwind {
+  ; CHECK-LABEL: name: reset_fpenv_mmo
+  ; CHECK: FLDENVm {{.*}} :: (load (s224) from constant-pool, align 4)
+  ; CHECK-NEXT: LDMXCSR {{.*}} implicit-def dead $mxcsr
+  ; CHECK-NEXT: RET 0
+  call void @llvm.reset.fpenv()
+  ret void
+}


### PR DESCRIPTION
LowerRESET_FPENV builds a MachineMemOperand with the MOStore flag and attaches it to X86ISD::FLDENVm, which is mayLoad = 1. The direction contradicts the SDNode, and SelectionDAGISel's memref filter (in SelectCodeCommon) silently drops the MMO, leaving the final MachineInstr without any memrefs - no miscompile, but no useful load-side metadata either.

Sister path LowerGET_FPENV_MEM already flips MOStore -> MOLoad before attaching its MMO to FLDENVm. Match that here so the MMO survives ISel.

Adds a MIR-trailer regression test asserting FLDENVm carries the expected `:: (load (s224) from constant-pool, align 4)` memref.

This was found as part of @jlebar's X86 LLVM bug hunt / FuzzX effort:
https://github.com/SemiAnalysisAI/FuzzX/tree/master/x86 : x86/bugs/014-resetfpenv-mmo-flagged-as-store-on-load

cc @jlebar 