### PR TITLE
[lldb-dap][windows] replay module load events

### DIFF
--- a/lldb/test/API/tools/lldb-dap/attach-commands/TestDAP_attachCommands.py
+++ b/lldb/test/API/tools/lldb-dap/attach-commands/TestDAP_attachCommands.py
@@ -12,7 +12,6 @@ import time
 class TestDAP_attachCommands(lldbdap_testcase.DAPTestCaseBase):
     SHARED_BUILD_TESTCASE = False
 
-    @skipIfWindows  # Wait for module events fails.
     @skipIfNetBSD  # Hangs on NetBSD as well
     def test_commands(self):
         """

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_extra_launch_commands.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch_extra_launch_commands.py
@@ -2,7 +2,7 @@
 Test lldb-dap launch request.
 """
 
-from lldbsuite.test.decorators import skipIf, skipIfWindows
+from lldbsuite.test.decorators import skipIf
 from lldbsuite.test.lldbtest import line_number
 import lldbdap_testcase
 
@@ -12,7 +12,6 @@ class TestDAP_launch_extra_launch_commands(lldbdap_testcase.DAPTestCaseBase):
     Tests the "launchCommands" with extra launching settings
     """
 
-    @skipIfWindows  # Wait for module events fails.
     # Flakey on 32-bit Arm Linux.
     @skipIf(oslist=["linux"], archs=["arm$"])
     def test(self):

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -802,6 +802,28 @@ void DAP::SetTarget(const lldb::SBTarget target) {
             lldb::SBTarget::eBroadcastBitNewTargetCreated);
     listener.StartListeningForEvents(this->broadcaster,
                                      eBroadcastBitStopEventThread);
+
+    // Replay "module"/eReasonNew events for any modules already loaded into
+    // the target.
+    lldb::SBMutex api_mutex = this->target.GetAPIMutex();
+    const std::scoped_lock<lldb::SBMutex, std::mutex> guard(
+        api_mutex, this->modules_mutex);
+    const uint32_t num_modules = this->target.GetNumModules();
+    for (uint32_t i = 0; i < num_modules; ++i) {
+      lldb::SBModule module = this->target.GetModuleAtIndex(i);
+      std::optional<protocol::Module> p_module =
+          CreateModule(this->target, module);
+      if (!p_module)
+        continue;
+      llvm::StringRef module_id = p_module->id;
+      if (this->modules.contains(module_id))
+        continue;
+      this->modules.insert(module_id);
+      Send(protocol::Event{
+          "module",
+          protocol::ModuleEventBody{std::move(p_module).value(),
+                                    protocol::ModuleEventBody::eReasonNew}});
+    }
   }
 }
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/200133 added `wait_for_module_events()` assertions to `TestDAP_attachCommands.py` and `TestDAP_launch_extra_launch_commands.py`. However, `SetTarget` is called after the `Run*Commands`, so this fails on Windows, because it loads modules early during the process startup. The module-load events are not listened to.

This patch replays the module load events in `DAP::SetTarget`.

This is a follow up to https://github.com/llvm/llvm-project/pull/201796 which skipped the tests.