### PR TITLE
[AMDGPU] Cache results in a bitvector for VOPDPairingMutation

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNVOPDUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNVOPDUtils.cpp
@@ -289,14 +289,15 @@ struct VOPDPairingMutation : ScheduleDAGMutation {
     for (auto ISUI = DAG->SUnits.begin(), E = DAG->SUnits.end(); ISUI != E;
          ++ISUI, ++IIdx) {
       const MachineInstr *IMI = ISUI->getInstr();
-      if (shouldScheduleAdjacent(TII, ST, nullptr, *IMI))
+      if (shouldScheduleAdjacent(TII, ST, nullptr, *IMI) &&
+          hasLessThanNumFused(*ISUI, 2))
         VOPDCapable[IIdx] = true;
     }
 
     IIdx = 0;
     for (auto ISUI = DAG->SUnits.begin(), E = DAG->SUnits.end(); ISUI != E;
          ++ISUI, ++IIdx) {
-      if (!VOPDCapable[IIdx] || !hasLessThanNumFused(*ISUI, 2))
+      if (!VOPDCapable[IIdx])
         continue;
       const MachineInstr *IMI = ISUI->getInstr();
       unsigned JIdx = IIdx + 1;

--- a/llvm/lib/Target/AMDGPU/GCNVOPDUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNVOPDUtils.cpp
@@ -284,23 +284,34 @@ struct VOPDPairingMutation : ScheduleDAGMutation {
       return;
     }
 
-    std::vector<SUnit>::iterator ISUI, JSUI;
-    for (ISUI = DAG->SUnits.begin(); ISUI != DAG->SUnits.end(); ++ISUI) {
+    BitVector VOPDCapable(DAG->SUnits.size());
+    unsigned IIdx = 0;
+    for (auto ISUI = DAG->SUnits.begin(), E = DAG->SUnits.end(); ISUI != E;
+         ++ISUI, ++IIdx) {
       const MachineInstr *IMI = ISUI->getInstr();
-      if (!shouldScheduleAdjacent(TII, ST, nullptr, *IMI))
-        continue;
-      if (!hasLessThanNumFused(*ISUI, 2))
-        continue;
+      if (shouldScheduleAdjacent(TII, ST, nullptr, *IMI))
+        VOPDCapable[IIdx] = true;
+    }
 
-      for (JSUI = ISUI + 1; JSUI != DAG->SUnits.end(); ++JSUI) {
-        if (JSUI->isBoundaryNode())
+    IIdx = 0;
+    for (auto ISUI = DAG->SUnits.begin(), E = DAG->SUnits.end(); ISUI != E;
+         ++ISUI, ++IIdx) {
+      if (!VOPDCapable[IIdx] || !hasLessThanNumFused(*ISUI, 2))
+        continue;
+      const MachineInstr *IMI = ISUI->getInstr();
+      unsigned JIdx = IIdx + 1;
+      for (auto JSUI = ISUI + 1; JSUI != E; ++JSUI, ++JIdx) {
+        if (!VOPDCapable[JIdx] || JSUI->isBoundaryNode())
           continue;
         const MachineInstr *JMI = JSUI->getInstr();
         if (!hasLessThanNumFused(*JSUI, 2) ||
             !shouldScheduleAdjacent(TII, ST, IMI, *JMI))
           continue;
-        if (fuseInstructionPair(*DAG, *ISUI, *JSUI))
+        if (fuseInstructionPair(*DAG, *ISUI, *JSUI)) {
+          // Clear to prevent future checks/fusing
+          VOPDCapable[JIdx] = false;
           break;
+        }
       }
     }
     LLVM_DEBUG(dbgs() << "Completed VOPDPairingMutation\n");

--- a/llvm/lib/Target/AMDGPU/GCNVOPDUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNVOPDUtils.cpp
@@ -286,6 +286,7 @@ struct VOPDPairingMutation : ScheduleDAGMutation {
 
     BitVector VOPDCapable(DAG->SUnits.size());
     unsigned IIdx = 0;
+    // Pre-compute whether each individual instruction can be VOPD
     for (auto ISUI = DAG->SUnits.begin(), E = DAG->SUnits.end(); ISUI != E;
          ++ISUI, ++IIdx) {
       const MachineInstr *IMI = ISUI->getInstr();


### PR DESCRIPTION
With this change the code no longer checks `(I, J)` pair when it is known that `(_, J)` is not a valid VOPD instruction. The saving is achieved by precomputing `(_, Y)` into a bitvector, that is also used by `(_, I)` check, so the `(_, J)` check is "free".

Co-authored-by: Antonio Carpio