### PR TITLE
[LoopFusion][NFC] Fix NumSunkInsts statistic description (NFC)

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopFuse.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopFuse.cpp
@@ -94,7 +94,7 @@ STATISTIC(NotRotated, "Candidate is not rotated");
 STATISTIC(OnlySecondCandidateIsGuarded,
           "The second candidate is guarded while the first one is not");
 STATISTIC(NumHoistedInsts, "Number of hoisted preheader instructions.");
-STATISTIC(NumSunkInsts, "Number of hoisted preheader instructions.");
+STATISTIC(NumSunkInsts, "Number of sunk preheader instructions.");
 STATISTIC(NumDA, "DA checks passed");
 
 static cl::opt<unsigned> FusionPeelMaxCount(


### PR DESCRIPTION
The NumSunkInsts counter was described as "Number of hoisted preheader instructions.", a copy of NumHoistedInsts. It counts sunk instructions.