### PR TITLE
[gn] make bolt ProfileTests depend on TargetsToBuild

### DIFF
--- a/llvm/utils/gn/secondary/bolt/unittests/Profile/BUILD.gn
+++ b/llvm/utils/gn/secondary/bolt/unittests/Profile/BUILD.gn
@@ -2,7 +2,10 @@ import("//third-party/unittest/unittest.gni")
 
 unittest("ProfileTests") {
   configs += [ "//llvm/utils/gn/build:bolt_code" ]
-  deps = [ "//bolt/lib/Profile" ]
+  deps = [
+    "//bolt/lib/Profile",
+    "//llvm/lib/Target:TargetsToBuild",
+  ]
   sources = [
     "DataAggregator.cpp",
     "PerfScripts.cpp",


### PR DESCRIPTION
Added to CMake in f75973949b0e5, actually needed after
3e447333fe32785.