### PR TITLE
[Flang][Driver] Fix -foffload-device misspelling

### DIFF
--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -692,8 +692,8 @@ void Flang::addOffloadOptions(Compilation &C, const InputInfoList &Inputs,
 
   // Tell the frontend when it is compiling for an offloading device, regardless
   // of offloading programming model.
-  if (IsHostOffloadingAction)
-    CmdArgs.push_back("-offload-device");
+  if (JA.getOffloadingDeviceKind() > Action::OFK_Host)
+    CmdArgs.push_back("-foffload-device");
 
   // Skips the primary input file, which is the input file that the compilation
   // proccess will be executed upon (e.g. the host bitcode file) and

--- a/flang/test/Driver/offload-device.f90
+++ b/flang/test/Driver/offload-device.f90
@@ -1,0 +1,24 @@
+! -foffload-device tells the frontend we are compiling for the auxiliary target,
+! i.e. not the host device.
+
+! RUN: %flang -target aarch64-linux-gnu --offload-arch=sm_80 --offload-arch=gfx90a -### %s -fopenmp 2>&1 | FileCheck %s --check-prefixes=CHECK,OPENMP
+! RUN: %flang -target aarch64-linux-gnu --offload-arch=sm_80 -### -xcuda %s 2>&1 | FileCheck %s --check-prefixes=CHECK,CUDA
+
+! Compiled as CUDA, device-compilation is done first
+! CUDA: flang{{(\.exe)?}}" "-fc1" "-triple" "nvptx64-nvidia-cuda"
+! CUDA-SAME: "-foffload-device"
+
+! Host invocation
+! CHECK: flang{{(\.exe)?}}" "-fc1" "-triple" "aarch64-unknown-linux-gnu"
+! CHECK-NOT: -foffload-device
+
+! Compiled as OpenMP, device-code is compiled after host-code compilation,
+! once for each --offload-arch argument
+! OPENMP: flang{{(\.exe)?}}" "-fc1" "-triple" "amdgcn-amd-amdhsa"
+! OPENMP-SAME: "-foffload-device"
+! OPENMP: flang{{(\.exe)?}}" "-fc1" "-triple" "nvptx64-nvidia-cuda"
+! OPENMP-SAME: "-foffload-device"
+
+
+module device_modfile
+end module

--- a/flang/test/Driver/offload-device.f90
+++ b/flang/test/Driver/offload-device.f90
@@ -1,8 +1,8 @@
 ! -foffload-device tells the frontend we are compiling for the auxiliary target,
-! i.e. not the host device.
+! i.e. not the host device. Test for CUDA and OpenMP offloading modes.
 
-! RUN: %flang -target aarch64-linux-gnu --offload-arch=sm_80 --offload-arch=gfx90a -### %s -fopenmp 2>&1 | FileCheck %s --check-prefixes=CHECK,OPENMP
-! RUN: %flang -target aarch64-linux-gnu --offload-arch=sm_80 -### -xcuda %s 2>&1 | FileCheck %s --check-prefixes=CHECK,CUDA
+! RUN: %flang -target aarch64-linux-gnu --no-offloadlib --offload-arch=sm_80 --offload-arch=gfx90a %s -fopenmp -### 2>&1 | FileCheck %s --check-prefixes=CHECK,OPENMP
+! RUN: %flang -target aarch64-linux-gnu --no-offloadlib --offload-arch=sm_80 -xcuda %s -### 2>&1 | FileCheck %s --check-prefixes=CHECK,CUDA
 
 ! Compiled as CUDA, device-compilation is done first
 ! CUDA: flang{{(\.exe)?}}" "-fc1" "-triple" "nvptx64-nvidia-cuda"
@@ -20,5 +20,5 @@
 ! OPENMP-SAME: "-foffload-device"
 
 
-module device_modfile
+module offload_device
 end module


### PR DESCRIPTION
#200863 added a new `-foffload-device` argument for informing the frontend that it compiling for the device-side (and as a consequence must not overwrite any module files compiled for the host), but the driver was mistakenly adding `-offload-device`.

Also fix the condition and add a regression test for the driver.