### PR TITLE
[NFC][lldb] move m_stop_info and m_stop_description up a class

### DIFF
--- a/lldb/include/lldb/Host/common/NativeThreadProtocol.h
+++ b/lldb/include/lldb/Host/common/NativeThreadProtocol.h
@@ -10,6 +10,7 @@
 #define LLDB_HOST_COMMON_NATIVETHREADPROTOCOL_H
 
 #include <memory>
+#include <string>
 
 #include "lldb/Host/Debug.h"
 #include "lldb/Utility/UnimplementedError.h"
@@ -57,8 +58,15 @@ public:
   }
 
 protected:
+  void ClearStopInfo() {
+    m_stop_info = ThreadStopInfo();
+    m_stop_description.clear();
+  }
+
   NativeProcessProtocol &m_process;
   lldb::tid_t m_tid;
+  ThreadStopInfo m_stop_info = {};
+  std::string m_stop_description;
 };
 }
 

--- a/lldb/source/Plugins/Process/FreeBSD/NativeThreadFreeBSD.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD/NativeThreadFreeBSD.cpp
@@ -35,11 +35,9 @@ using namespace lldb_private::process_freebsd;
 NativeThreadFreeBSD::NativeThreadFreeBSD(NativeProcessFreeBSD &process,
                                          lldb::tid_t tid)
     : NativeThreadProtocol(process, tid), m_state(StateType::eStateInvalid),
-      m_stop_info(),
       m_reg_context_up(
           NativeRegisterContextFreeBSD::CreateHostNativeRegisterContextFreeBSD(
-              process.GetArchitecture(), *this)),
-      m_stop_description() {}
+              process.GetArchitecture(), *this)) {}
 
 Status NativeThreadFreeBSD::Resume() {
   Status ret = NativeProcessFreeBSD::PtraceWrapper(PT_RESUME, GetID());
@@ -171,12 +169,12 @@ void NativeThreadFreeBSD::SetStopped() {
 
 void NativeThreadFreeBSD::SetRunning() {
   m_state = StateType::eStateRunning;
-  m_stop_info.reason = StopReason::eStopReasonNone;
+  ClearStopInfo();
 }
 
 void NativeThreadFreeBSD::SetStepping() {
   m_state = StateType::eStateStepping;
-  m_stop_info.reason = StopReason::eStopReasonNone;
+  ClearStopInfo();
 }
 
 std::string NativeThreadFreeBSD::GetName() {

--- a/lldb/source/Plugins/Process/FreeBSD/NativeThreadFreeBSD.h
+++ b/lldb/source/Plugins/Process/FreeBSD/NativeThreadFreeBSD.h
@@ -76,9 +76,7 @@ private:
 
   // Member Variables
   lldb::StateType m_state;
-  ThreadStopInfo m_stop_info;
   std::unique_ptr<NativeRegisterContextFreeBSD> m_reg_context_up;
-  std::string m_stop_description;
   using WatchpointIndexMap = std::map<lldb::addr_t, uint32_t>;
   WatchpointIndexMap m_watchpoint_index_map;
   WatchpointIndexMap m_hw_break_index_map;

--- a/lldb/source/Plugins/Process/Linux/NativeThreadLinux.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeThreadLinux.cpp
@@ -95,11 +95,9 @@ void LogThreadStopInfo(Log &log, const ThreadStopInfo &stop_info,
 NativeThreadLinux::NativeThreadLinux(NativeProcessLinux &process,
                                      lldb::tid_t tid)
     : NativeThreadProtocol(process, tid), m_state(StateType::eStateInvalid),
-      m_stop_info(),
       m_reg_context_up(
           NativeRegisterContextLinux::CreateHostNativeRegisterContextLinux(
-              process.GetArchitecture(), *this)),
-      m_stop_description() {}
+              process.GetArchitecture(), *this)) {}
 
 std::string NativeThreadLinux::GetName() {
   NativeProcessLinux &process = GetProcess();
@@ -214,8 +212,7 @@ Status NativeThreadLinux::Resume(uint32_t signo) {
   MaybeLogStateChange(new_state);
   m_state = new_state;
 
-  m_stop_info.reason = StopReason::eStopReasonNone;
-  m_stop_description.clear();
+  ClearStopInfo();
 
   // If watchpoints have been set, but none on this thread, then this is a new
   // thread. So set all existing watchpoints.
@@ -255,7 +252,7 @@ Status NativeThreadLinux::SingleStep(uint32_t signo) {
   const StateType new_state = StateType::eStateStepping;
   MaybeLogStateChange(new_state);
   m_state = new_state;
-  m_stop_info.reason = StopReason::eStopReasonNone;
+  ClearStopInfo();
 
   if(!m_step_workaround) {
     // If we already hava a workaround inplace, don't reset it. Otherwise, the

--- a/lldb/source/Plugins/Process/Linux/NativeThreadLinux.h
+++ b/lldb/source/Plugins/Process/Linux/NativeThreadLinux.h
@@ -114,9 +114,7 @@ private:
 
   // Member Variables
   lldb::StateType m_state;
-  ThreadStopInfo m_stop_info;
   std::unique_ptr<NativeRegisterContextLinux> m_reg_context_up;
-  std::string m_stop_description;
   using WatchpointIndexMap = std::map<lldb::addr_t, uint32_t>;
   WatchpointIndexMap m_watchpoint_index_map;
   WatchpointIndexMap m_hw_break_index_map;

--- a/lldb/source/Plugins/Process/NetBSD/NativeThreadNetBSD.cpp
+++ b/lldb/source/Plugins/Process/NetBSD/NativeThreadNetBSD.cpp
@@ -36,9 +36,9 @@ using namespace lldb_private::process_netbsd;
 NativeThreadNetBSD::NativeThreadNetBSD(NativeProcessNetBSD &process,
                                        lldb::tid_t tid)
     : NativeThreadProtocol(process, tid), m_state(StateType::eStateInvalid),
-      m_stop_info(), m_reg_context_up(
-NativeRegisterContextNetBSD::CreateHostNativeRegisterContextNetBSD(process.GetArchitecture(), *this)
-), m_stop_description() {}
+      m_reg_context_up(
+          NativeRegisterContextNetBSD::CreateHostNativeRegisterContextNetBSD(
+              process.GetArchitecture(), *this)) {}
 
 Status NativeThreadNetBSD::Resume() {
   Status ret = NativeProcessNetBSD::PtraceWrapper(PT_RESUME, m_process.GetID(),
@@ -170,12 +170,12 @@ void NativeThreadNetBSD::SetStopped() {
 
 void NativeThreadNetBSD::SetRunning() {
   m_state = StateType::eStateRunning;
-  m_stop_info.reason = StopReason::eStopReasonNone;
+  ClearStopInfo();
 }
 
 void NativeThreadNetBSD::SetStepping() {
   m_state = StateType::eStateStepping;
-  m_stop_info.reason = StopReason::eStopReasonNone;
+  ClearStopInfo();
 }
 
 std::string NativeThreadNetBSD::GetName() {

--- a/lldb/source/Plugins/Process/NetBSD/NativeThreadNetBSD.h
+++ b/lldb/source/Plugins/Process/NetBSD/NativeThreadNetBSD.h
@@ -71,9 +71,7 @@ private:
 
   // Member Variables
   lldb::StateType m_state;
-  ThreadStopInfo m_stop_info;
   std::unique_ptr<NativeRegisterContextNetBSD> m_reg_context_up;
-  std::string m_stop_description;
   using WatchpointIndexMap = std::map<lldb::addr_t, uint32_t>;
   WatchpointIndexMap m_watchpoint_index_map;
   WatchpointIndexMap m_hw_break_index_map;

--- a/lldb/source/Plugins/Process/Windows/Common/NativeThreadWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeThreadWindows.cpp
@@ -27,7 +27,7 @@ using namespace lldb_private;
 NativeThreadWindows::NativeThreadWindows(NativeProcessWindows &process,
                                          const HostThread &thread)
     : NativeThreadProtocol(process, thread.GetNativeThread().GetThreadId()),
-      m_stop_info(), m_stop_description(), m_host_thread(thread) {
+      m_host_thread(thread) {
   m_reg_context_up =
       (NativeRegisterContextWindows::CreateHostNativeRegisterContextWindows(
           process.GetArchitecture(), *this));
@@ -82,9 +82,7 @@ Status NativeThreadWindows::DoResume(lldb::StateType resume_state) {
 
   if (resume_state == eStateStepping || resume_state == eStateRunning) {
     // Clear any stop info left over from a previous stop.
-    m_stop_info = ThreadStopInfo();
-    m_stop_info.reason = lldb::eStopReasonNone;
-    m_stop_description.clear();
+    ClearStopInfo();
 
     DWORD previous_suspend_count = 0;
     HANDLE thread_handle = m_host_thread.GetNativeThread().GetSystemHandle();

--- a/lldb/source/Plugins/Process/Windows/Common/NativeThreadWindows.h
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeThreadWindows.h
@@ -55,8 +55,6 @@ public:
 protected:
   lldb::StateType m_state = lldb::StateType::eStateInvalid;
   std::string m_name;
-  ThreadStopInfo m_stop_info;
-  std::string m_stop_description;
   std::unique_ptr<NativeRegisterContextWindows> m_reg_context_up;
   // Cache address and index of the watchpoints and hardware breakpoints since
   // the register context does not.


### PR DESCRIPTION
Now that Windows also clears stale thread info on resume (https://github.com/llvm/llvm-project/pull/201595), `m_stop_description` and `m_stop_info` can be moved into `NativeThreadProtocol`.

rdar://178725507