### PR TITLE
[flang] Update a test case for AIX (NFC)

### DIFF
--- a/flang/test/Driver/function-sections.f90
+++ b/flang/test/Driver/function-sections.f90
@@ -5,8 +5,11 @@
 ! CHECK-DS: "-fdata-sections"
 ! CHECK-NODS-NOT: "-fdata-sections"
 
-! RUN: %flang -### %s 2>&1 \
+! RUN: %flang -### -target x86_64-none-linux-gnu %s 2>&1 \
 ! RUN:   | FileCheck %s --check-prefix=CHECK-NOFS --check-prefix=CHECK-NODS
+
+! RUN: %flang -### -target powerpc64-ibm-aix-xcoff %s 2>&1 \
+! RUN:   | FileCheck %s --check-prefix=CHECK-NOFS
 
 ! RUN: %flang -### %s -ffunction-sections 2>&1 \
 ! RUN:   | FileCheck %s --check-prefix=CHECK-FS

--- a/flang/test/Driver/function-sections.f90
+++ b/flang/test/Driver/function-sections.f90
@@ -8,6 +8,9 @@
 ! RUN: %flang -### -target x86_64-none-linux-gnu %s 2>&1 \
 ! RUN:   | FileCheck %s --check-prefix=CHECK-NOFS --check-prefix=CHECK-NODS
 
+! RUN: %flang -### -target aarch64-unknown-linux-gnu %s 2>&1 \
+! RUN:   | FileCheck %s --check-prefix=CHECK-NOFS --check-prefix=CHECK-NODS
+
 ! RUN: %flang -### -target powerpc64-ibm-aix-xcoff %s 2>&1 \
 ! RUN:   | FileCheck %s --check-prefix=CHECK-NOFS
 


### PR DESCRIPTION
-fdata-sections is specified by default on AIX. This patch is to adjust the testing for the case that the option is off and on by default.