### PR TITLE
[lldb][Windows] enable TestGdbRemote_qThreadStopInfo

### DIFF
--- a/lldb/test/API/tools/lldb-server/TestGdbRemote_qThreadStopInfo.py
+++ b/lldb/test/API/tools/lldb-server/TestGdbRemote_qThreadStopInfo.py
@@ -66,7 +66,6 @@ class TestGdbRemote_qThreadStopInfo(gdbremote_testcase.GdbRemoteTestCaseBase):
 
     @expectedFailureAll(oslist=["freebsd"], bugnumber="llvm.org/pr48418")
     @expectedFailureNetBSD
-    @expectedFailureAll(oslist=["windows"])  # Output forwarding not implemented
     def test_qThreadStopInfo_only_reports_one_thread_stop_reason_during_interrupt(self):
         self.build()
         self.set_inferior_startup_launch()


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/201595 and https://github.com/llvm/llvm-project/pull/201124 caused this test to pass. The CI was not rerun between each PR, causing the test to XPASS once both patches were merged.