### PR TITLE
CodeGen: Fix CGPassBuilderOption::EnableGlobalISelOption for -global-isel=0

### DIFF
--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -505,7 +505,8 @@ CGPassBuilderOption llvm::getCGPassBuilderOption() {
 
   SET_OPTION(EnableFastISelOption)
   SET_OPTION(EnableGlobalISelAbort)
-  SET_OPTION(EnableGlobalISelOption)
+  if (EnableGlobalISelOption.getNumOccurrences())
+    Opt.EnableGlobalISelOption = (EnableGlobalISelOption == cl::BOU_TRUE);
   SET_OPTION(EnableIPRA)
   SET_OPTION(OptimizeRegAlloc)
   SET_OPTION(VerifyMachineCode)

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -1630,7 +1630,7 @@ bool GCNPassConfig::addPreISel() {
 
   // SDAG requires LCSSA, GlobalISel does not. Disable LCSSA for -global-isel
   // with -new-reg-bank-select and without any of the fallback options.
-  if (!getCGPassBuilderOption().EnableGlobalISelOption ||
+  if (getCGPassBuilderOption().EnableGlobalISelOption != true ||
       !isGlobalISelAbortEnabled() || !NewRegBankSelect)
     addPass(createLCSSAPass());
 
@@ -2394,7 +2394,7 @@ void AMDGPUCodeGenPassBuilder::addPreISel(PassManagerWrapper &PMW) const {
   // control flow modifications.
   addFunctionPass(AMDGPURewriteUndefForPHIPass(), PMW);
 
-  if (!getCGPassBuilderOption().EnableGlobalISelOption ||
+  if (getCGPassBuilderOption().EnableGlobalISelOption != true ||
       !isGlobalISelAbortEnabled() || !NewRegBankSelect)
     addFunctionPass(LCSSAPass(), PMW);
 

--- a/llvm/unittests/CodeGen/CGPassBuilderOptionTest.cpp
+++ b/llvm/unittests/CodeGen/CGPassBuilderOptionTest.cpp
@@ -1,0 +1,51 @@
+//===- CGPassBuilderOptionTest.cpp ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Target/CGPassBuilderOption.h"
+#include "llvm/Support/CommandLine.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+
+namespace {
+
+// Round-trip "-global-isel=<v>" through the cl::opt parser into
+// CGPassBuilderOption and check the optional<bool> reflects the user's choice.
+// This guards against the enum->bool conversion that previously collapsed
+// BOU_FALSE (=2) to `true`.
+
+static void parseArgs(std::initializer_list<const char *> Args) {
+  cl::ResetAllOptionOccurrences();
+  SmallVector<const char *, 4> Argv;
+  Argv.push_back("CGPassBuilderOptionTest");
+  for (const char *A : Args)
+    Argv.push_back(A);
+  cl::ParseCommandLineOptions(Argv.size(), Argv.data());
+}
+
+TEST(CGPassBuilderOption, GlobalISelNotSpecified) {
+  parseArgs({});
+  auto Opt = getCGPassBuilderOption();
+  EXPECT_FALSE(Opt.EnableGlobalISelOption.has_value());
+}
+
+TEST(CGPassBuilderOption, GlobalISelEnabled) {
+  parseArgs({"-global-isel=1"});
+  auto Opt = getCGPassBuilderOption();
+  ASSERT_TRUE(Opt.EnableGlobalISelOption.has_value());
+  EXPECT_TRUE(*Opt.EnableGlobalISelOption);
+}
+
+TEST(CGPassBuilderOption, GlobalISelDisabled) {
+  parseArgs({"-global-isel=0"});
+  auto Opt = getCGPassBuilderOption();
+  ASSERT_TRUE(Opt.EnableGlobalISelOption.has_value());
+  EXPECT_FALSE(*Opt.EnableGlobalISelOption);
+}
+
+} // namespace

--- a/llvm/unittests/CodeGen/CMakeLists.txt
+++ b/llvm/unittests/CodeGen/CMakeLists.txt
@@ -24,6 +24,7 @@ add_llvm_unittest(CodeGenTests
   AMDGPUMetadataTest.cpp
   AsmPrinterDwarfTest.cpp
   CCStateTest.cpp
+  CGPassBuilderOptionTest.cpp
   DIEHashTest.cpp
   DIETest.cpp
   DroppedVariableStatsMIRTest.cpp


### PR DESCRIPTION
SET_OPTION assigned the cl::boolOrDefault into std::optional<bool>;
BOU_FALSE (=2) converts to true, so -global-isel=0 was stored as true
instead of false.