### PR TITLE
AMDGPU/UniformityAnalysis: MIR Uniformity analysis for INLINEASM

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -11014,6 +11014,19 @@ ValueUniformity SIInstrInfo::getValueUniformity(const MachineInstr &MI) const {
       opcode == AMDGPU::SI_RESTORE_S32_FROM_VGPR)
     return ValueUniformity::AlwaysUniform;
 
+  // If any of defs is divergent, report as NeverUniform. isUniformReg will
+  // calculate in more detail for each def from its reg class, if available.
+  if (MI.isInlineAsm()) {
+    for (const MachineOperand &MO : MI.operands()) {
+      if (!MO.isReg() || !MO.isDef())
+        continue;
+      const TargetRegisterClass *RC =
+          MI.getRegClassConstraint(MO.getOperandNo(), this, &RI);
+      if (!RC || !RI.isSGPRClass(RC))
+        return ValueUniformity::NeverUniform;
+    }
+  }
+
   if (isCopyInstr(MI)) {
     const MachineOperand &srcOp = MI.getOperand(1);
     if (srcOp.isReg() && srcOp.getReg().isPhysical()) {

--- a/llvm/test/Analysis/UniformityAnalysis/AMDGPU/MIR/inline-asm.mir
+++ b/llvm/test/Analysis/UniformityAnalysis/AMDGPU/MIR/inline-asm.mir
@@ -16,7 +16,7 @@ body:             |
 
 # CHECK-LABEL: MachineUniformityInfo for function:  @inlineasm_v
 # CHECK-LABEL: BLOCK bb.0
-# CHECK-NOT: DIVERGENT: %0: INLINEASM
+# CHECK: DIVERGENT: %0: INLINEASM
 ---
 name:            inlineasm_v
 tracksRegLiveness: true
@@ -30,7 +30,7 @@ body:             |
 # CHECK-LABEL: MachineUniformityInfo for function:  @inlineasm_sv
 # CHECK-LABEL: BLOCK bb.0
 # CHECK-NOT: DIVERGENT: %0: INLINEASM
-# CHECK-NOT: DIVERGENT: %1: INLINEASM
+# CHECK: DIVERGENT: %1: INLINEASM
 ---
 name:            inlineasm_sv
 tracksRegLiveness: true
@@ -45,7 +45,7 @@ body:             |
 # CHECK-LABEL: MachineUniformityInfo for function:  @inlineasm_svs
 # CHECK-LABEL: BLOCK bb.0
 # CHECK-NOT: DIVERGENT: %0: INLINEASM
-# CHECK-NOT: DIVERGENT: %1: INLINEASM
+# CHECK: DIVERGENT: %1: INLINEASM
 # CHECK-NOT: DIVERGENT: %2: INLINEASM
 ---
 name:            inlineasm_svs


### PR DESCRIPTION
If any of the defs are divergent, need to report instruction as
NeverUniform so that isUniformReg can calculate uniformity for each def.