### PR TITLE
[lldb][gdb-remote] Plumb interrupt_timeout through SendStdinNotification

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -1442,13 +1442,14 @@ bool GDBRemoteCommunicationClient::GetHostInfo(bool force) {
   return m_qHostInfo_is_valid == eLazyBoolYes;
 }
 
-int GDBRemoteCommunicationClient::SendStdinNotification(const char *data,
-                                                        size_t data_len) {
+int GDBRemoteCommunicationClient::SendStdinNotification(
+    const char *data, size_t data_len, std::chrono::seconds interrupt_timeout) {
   StreamString packet;
   packet.PutCString("I");
   packet.PutBytesAsRawHex8(data, data_len);
   StringExtractorGDBRemote response;
-  if (SendPacketAndWaitForResponse(packet.GetString(), response) ==
+  if (SendPacketAndWaitForResponse(packet.GetString(), response,
+                                   interrupt_timeout) ==
       PacketResult::Success) {
     return 0;
   }

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.h
@@ -129,7 +129,8 @@ public:
   ///
   /// \param[in] interrupt_timeout
   ///     If the inferior is running, how long to wait for a `\x03` BREAK
-  ///     to interrupt it before giving up. Pass zero only when the caller knows the inferior is stopped.
+  ///     to interrupt it before giving up. Pass zero only when the caller knows
+  ///     the inferior is stopped.
   ///
   /// \return
   ///     Zero if the attach was successful, or an error indicating

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.h
@@ -127,10 +127,16 @@ public:
   /// \param[in] data_len
   ///     The number of bytes available at \a data.
   ///
+  /// \param[in] interrupt_timeout
+  ///     If the inferior is running, how long to wait for a `\x03` BREAK
+  ///     to interrupt it before giving up. Pass zero only when the caller knows the inferior is stopped.
+  ///
   /// \return
   ///     Zero if the attach was successful, or an error indicating
   ///     an error code.
-  int SendStdinNotification(const char *data, size_t data_len);
+  int SendStdinNotification(
+      const char *data, size_t data_len,
+      std::chrono::seconds interrupt_timeout = std::chrono::seconds(0));
 
   /// Sets the path to use for stdin/out/err for a process
   /// that will be launched with the 'A' packet.

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -3338,7 +3338,7 @@ size_t ProcessGDBRemote::PutSTDIN(const char *src, size_t src_len,
     ConnectionStatus status;
     m_stdio_communication.WriteAll(src, src_len, status, nullptr);
   } else if (m_stdin_forward) {
-    m_gdb_comm.SendStdinNotification(src, src_len);
+    m_gdb_comm.SendStdinNotification(src, src_len, GetInterruptTimeout());
   }
   return 0;
 }


### PR DESCRIPTION
`ProcessGDBRemote::PutSTDIN` calls `SendStdinNotification` with `interrupt_timeout  == 0`. While the debuggee is running, `GDBRemoteClientBase::Lock::SyncWithContinueThread` treats that as "do not interrupt the continue thread" and returns without acquiring the lock, so `SendPacketAndWaitForResponse` fails and does not send the I packet. This silently drops the STDIN keystroke.

This patch plumbs the process's `GetInterruptTimeout()` through `SendStdinNotification` so that we:
- Send \x03
- Wait for the SIGSTOP stop reply
- Delivers the I packet
- Let `ContinueLock::lock` to re-issue the continue.

This is a follow up to https://github.com/llvm/llvm-project/pull/201638.

rdar://178725947