### PR TITLE
[MIPS] int <-> `half` conversions with `+msa`

### DIFF
--- a/llvm/lib/Target/Mips/MipsSEISelLowering.cpp
+++ b/llvm/lib/Target/Mips/MipsSEISelLowering.cpp
@@ -193,6 +193,10 @@ MipsSETargetLowering::MipsSETargetLowering(const MipsTargetMachine &TM,
     setOperationAction(ISD::FMINIMUM, MVT::f16, Promote);
     setOperationAction(ISD::FMAXIMUM, MVT::f16, Promote);
 
+    setOperationAction(ISD::SINT_TO_FP, MVT::i32, Custom);
+    if (Subtarget.isGP64bit())
+      setOperationAction(ISD::SINT_TO_FP, MVT::i64, Custom);
+
     setTargetDAGCombine({ISD::AND, ISD::OR, ISD::SRA, ISD::VSELECT, ISD::XOR});
   }
 
@@ -515,6 +519,20 @@ SDValue MipsSETargetLowering::lowerSELECT(SDValue Op, SelectionDAG &DAG) const {
                      Op->getOperand(2));
 }
 
+SDValue MipsSETargetLowering::lowerINT_TO_FP(SDValue Op,
+                                             SelectionDAG &DAG) const {
+  // The f32/f64 case is already legal.
+  if (Op.getValueType() != MVT::f16)
+    return Op;
+
+  // The f16 type is storage-only, and hence needs special handling. An
+  // f16 cannot be produced directly, so convert the integer to f32 and round
+  // the result down to f16.
+  SDLoc DL(Op);
+  SDValue FP = DAG.getNode(Op.getOpcode(), DL, MVT::f32, Op.getOperand(0));
+  return DAG.getFPExtendOrRound(FP, DL, MVT::f16);
+}
+
 bool MipsSETargetLowering::allowsMisalignedMemoryAccesses(
     EVT VT, unsigned, Align, MachineMemOperand::Flags, unsigned *Fast) const {
   MVT::SimpleValueType SVT = VT.getSimpleVT().SimpleTy;
@@ -562,6 +580,8 @@ SDValue MipsSETargetLowering::LowerOperation(SDValue Op,
   case ISD::BUILD_VECTOR:       return lowerBUILD_VECTOR(Op, DAG);
   case ISD::VECTOR_SHUFFLE:     return lowerVECTOR_SHUFFLE(Op, DAG);
   case ISD::SELECT:             return lowerSELECT(Op, DAG);
+  case ISD::SINT_TO_FP:
+    return lowerINT_TO_FP(Op, DAG);
   case ISD::BITCAST:            return lowerBITCAST(Op, DAG);
   case ISD::FADD:
     return lowerR5900FPOp(Op, DAG, RTLIB::ADD_F32);

--- a/llvm/lib/Target/Mips/MipsSEISelLowering.cpp
+++ b/llvm/lib/Target/Mips/MipsSEISelLowering.cpp
@@ -193,9 +193,19 @@ MipsSETargetLowering::MipsSETargetLowering(const MipsTargetMachine &TM,
     setOperationAction(ISD::FMINIMUM, MVT::f16, Promote);
     setOperationAction(ISD::FMAXIMUM, MVT::f16, Promote);
 
+    // Integer <-> Float conversions are keyed on the integer type. Make these
+    // custom so that we can handle the f16 case. Other float types use their
+    // default expansion.
     setOperationAction(ISD::SINT_TO_FP, MVT::i32, Custom);
     if (Subtarget.isGP64bit())
       setOperationAction(ISD::SINT_TO_FP, MVT::i64, Custom);
+
+    setOperationAction(ISD::FP_TO_SINT, MVT::i32, Custom);
+    setOperationAction(ISD::FP_TO_UINT, MVT::i32, Custom);
+    setOperationAction(ISD::FP_TO_SINT, MVT::i64, Custom);
+    setOperationAction(ISD::FP_TO_UINT, MVT::i64, Custom);
+    setOperationAction(ISD::FP_TO_SINT, MVT::i128, Custom);
+    setOperationAction(ISD::FP_TO_UINT, MVT::i128, Custom);
 
     setTargetDAGCombine({ISD::AND, ISD::OR, ISD::SRA, ISD::VSELECT, ISD::XOR});
   }
@@ -525,12 +535,39 @@ SDValue MipsSETargetLowering::lowerINT_TO_FP(SDValue Op,
   if (Op.getValueType() != MVT::f16)
     return Op;
 
-  // The f16 type is storage-only, and hence needs special handling. An
-  // f16 cannot be produced directly, so convert the integer to f32 and round
-  // the result down to f16.
+  // For f16, first convert the integer to f32, then convert to f16.
   SDLoc DL(Op);
   SDValue FP = DAG.getNode(Op.getOpcode(), DL, MVT::f32, Op.getOperand(0));
   return DAG.getFPExtendOrRound(FP, DL, MVT::f16);
+}
+
+SDValue MipsSETargetLowering::lowerFP_TO_INT(SDValue Op,
+                                             SelectionDAG &DAG) const {
+  SDValue InOp = Op.getOperand(0);
+
+  // For f16, first convert to f32 and go from there.
+  if (InOp.getValueType() == MVT::f16) {
+    EVT VT = Op.getValueType();
+
+    assert((VT == MVT::i32 || VT == MVT::i64 || VT == MVT::i128) &&
+           "Unexpected result type for f16 -> integer conversion");
+
+    SDLoc DL(Op);
+    SDValue FP = DAG.getFPExtendOrRound(InOp, DL, MVT::f32);
+
+    // Use a trick from TargetLowering::expandFP_TO_UINT: we know that every
+    // integer value that can be represented by f16 is representable by i32, so
+    // fptoui and fptosi are equivalent.
+    //
+    // NOTE: the result of fptoui is poison when the value does not fit in the
+    // destination type (e.g. because it is negative).
+    return DAG.getNode(ISD::FP_TO_SINT, DL, VT, FP);
+  }
+
+  // Use the default lowering for f32/f64.
+  if (!isTypeLegal(Op.getValueType()))
+    return SDValue();
+  return MipsTargetLowering::LowerOperation(Op, DAG);
 }
 
 bool MipsSETargetLowering::allowsMisalignedMemoryAccesses(
@@ -582,6 +619,9 @@ SDValue MipsSETargetLowering::LowerOperation(SDValue Op,
   case ISD::SELECT:             return lowerSELECT(Op, DAG);
   case ISD::SINT_TO_FP:
     return lowerINT_TO_FP(Op, DAG);
+  case ISD::FP_TO_SINT:
+  case ISD::FP_TO_UINT:
+    return lowerFP_TO_INT(Op, DAG);
   case ISD::BITCAST:            return lowerBITCAST(Op, DAG);
   case ISD::FADD:
     return lowerR5900FPOp(Op, DAG, RTLIB::ADD_F32);

--- a/llvm/lib/Target/Mips/MipsSEISelLowering.h
+++ b/llvm/lib/Target/Mips/MipsSEISelLowering.h
@@ -92,6 +92,7 @@ class TargetRegisterClass;
     /// depending on the indices in the shuffle.
     SDValue lowerVECTOR_SHUFFLE(SDValue Op, SelectionDAG &DAG) const;
     SDValue lowerSELECT(SDValue Op, SelectionDAG &DAG) const;
+    SDValue lowerINT_TO_FP(SDValue Op, SelectionDAG &DAG) const;
 
     MachineBasicBlock *emitBPOSGE32(MachineInstr &MI,
                                     MachineBasicBlock *BB) const;

--- a/llvm/lib/Target/Mips/MipsSEISelLowering.h
+++ b/llvm/lib/Target/Mips/MipsSEISelLowering.h
@@ -93,6 +93,7 @@ class TargetRegisterClass;
     SDValue lowerVECTOR_SHUFFLE(SDValue Op, SelectionDAG &DAG) const;
     SDValue lowerSELECT(SDValue Op, SelectionDAG &DAG) const;
     SDValue lowerINT_TO_FP(SDValue Op, SelectionDAG &DAG) const;
+    SDValue lowerFP_TO_INT(SDValue Op, SelectionDAG &DAG) const;
 
     MachineBasicBlock *emitBPOSGE32(MachineInstr &MI,
                                     MachineBasicBlock *BB) const;

--- a/llvm/test/CodeGen/Mips/msa/f16-llvm-ir.ll
+++ b/llvm/test/CodeGen/Mips/msa/f16-llvm-ir.ll
@@ -262,12 +262,9 @@ define i32 @ffptoui() {
 ; MIPS32-NEXT:    lh $1, 0($1)
 ; MIPS32-NEXT:    fill.h $w0, $1
 ; MIPS32-NEXT:    fexupr.w $w0, $w0
-; MIPS32-NEXT:    fexupr.d $w0, $w0
 ; MIPS32-NEXT:    copy_s.w $1, $w0[0]
-; MIPS32-NEXT:    mtc1 $1, $f1
-; MIPS32-NEXT:    copy_s.w $1, $w0[1]
-; MIPS32-NEXT:    mthc1 $1, $f1
-; MIPS32-NEXT:    trunc.w.d $f0, $f1
+; MIPS32-NEXT:    mtc1 $1, $f0
+; MIPS32-NEXT:    trunc.w.s $f0, $f0
 ; MIPS32-NEXT:    jr $ra
 ; MIPS32-NEXT:    mfc1 $2, $f0
 ;
@@ -280,10 +277,9 @@ define i32 @ffptoui() {
 ; MIPS64-N32-NEXT:    lh $1, 0($1)
 ; MIPS64-N32-NEXT:    fill.h $w0, $1
 ; MIPS64-N32-NEXT:    fexupr.w $w0, $w0
-; MIPS64-N32-NEXT:    fexupr.d $w0, $w0
-; MIPS64-N32-NEXT:    copy_s.d $1, $w0[0]
-; MIPS64-N32-NEXT:    dmtc1 $1, $f0
-; MIPS64-N32-NEXT:    trunc.w.d $f0, $f0
+; MIPS64-N32-NEXT:    copy_s.w $1, $w0[0]
+; MIPS64-N32-NEXT:    mtc1 $1, $f0
+; MIPS64-N32-NEXT:    trunc.w.s $f0, $f0
 ; MIPS64-N32-NEXT:    jr $ra
 ; MIPS64-N32-NEXT:    mfc1 $2, $f0
 ;
@@ -296,10 +292,9 @@ define i32 @ffptoui() {
 ; MIPS64-N64-NEXT:    lh $1, 0($1)
 ; MIPS64-N64-NEXT:    fill.h $w0, $1
 ; MIPS64-N64-NEXT:    fexupr.w $w0, $w0
-; MIPS64-N64-NEXT:    fexupr.d $w0, $w0
-; MIPS64-N64-NEXT:    copy_s.d $1, $w0[0]
-; MIPS64-N64-NEXT:    dmtc1 $1, $f0
-; MIPS64-N64-NEXT:    trunc.w.d $f0, $f0
+; MIPS64-N64-NEXT:    copy_s.w $1, $w0[0]
+; MIPS64-N64-NEXT:    mtc1 $1, $f0
+; MIPS64-N64-NEXT:    trunc.w.s $f0, $f0
 ; MIPS64-N64-NEXT:    jr $ra
 ; MIPS64-N64-NEXT:    mfc1 $2, $f0
 entry:
@@ -318,12 +313,9 @@ define i32 @ffptosi() {
 ; MIPS32-NEXT:    lh $1, 0($1)
 ; MIPS32-NEXT:    fill.h $w0, $1
 ; MIPS32-NEXT:    fexupr.w $w0, $w0
-; MIPS32-NEXT:    fexupr.d $w0, $w0
 ; MIPS32-NEXT:    copy_s.w $1, $w0[0]
-; MIPS32-NEXT:    mtc1 $1, $f1
-; MIPS32-NEXT:    copy_s.w $1, $w0[1]
-; MIPS32-NEXT:    mthc1 $1, $f1
-; MIPS32-NEXT:    trunc.w.d $f0, $f1
+; MIPS32-NEXT:    mtc1 $1, $f0
+; MIPS32-NEXT:    trunc.w.s $f0, $f0
 ; MIPS32-NEXT:    jr $ra
 ; MIPS32-NEXT:    mfc1 $2, $f0
 ;
@@ -336,10 +328,9 @@ define i32 @ffptosi() {
 ; MIPS64-N32-NEXT:    lh $1, 0($1)
 ; MIPS64-N32-NEXT:    fill.h $w0, $1
 ; MIPS64-N32-NEXT:    fexupr.w $w0, $w0
-; MIPS64-N32-NEXT:    fexupr.d $w0, $w0
-; MIPS64-N32-NEXT:    copy_s.d $1, $w0[0]
-; MIPS64-N32-NEXT:    dmtc1 $1, $f0
-; MIPS64-N32-NEXT:    trunc.w.d $f0, $f0
+; MIPS64-N32-NEXT:    copy_s.w $1, $w0[0]
+; MIPS64-N32-NEXT:    mtc1 $1, $f0
+; MIPS64-N32-NEXT:    trunc.w.s $f0, $f0
 ; MIPS64-N32-NEXT:    jr $ra
 ; MIPS64-N32-NEXT:    mfc1 $2, $f0
 ;
@@ -352,10 +343,9 @@ define i32 @ffptosi() {
 ; MIPS64-N64-NEXT:    lh $1, 0($1)
 ; MIPS64-N64-NEXT:    fill.h $w0, $1
 ; MIPS64-N64-NEXT:    fexupr.w $w0, $w0
-; MIPS64-N64-NEXT:    fexupr.d $w0, $w0
-; MIPS64-N64-NEXT:    copy_s.d $1, $w0[0]
-; MIPS64-N64-NEXT:    dmtc1 $1, $f0
-; MIPS64-N64-NEXT:    trunc.w.d $f0, $f0
+; MIPS64-N64-NEXT:    copy_s.w $1, $w0[0]
+; MIPS64-N64-NEXT:    mtc1 $1, $f0
+; MIPS64-N64-NEXT:    trunc.w.s $f0, $f0
 ; MIPS64-N64-NEXT:    jr $ra
 ; MIPS64-N64-NEXT:    mfc1 $2, $f0
 entry:
@@ -3862,12 +3852,9 @@ define i32 @fptosi_f16_i32(ptr %p) {
 ; MIPS32-NEXT:    lh $1, 0($4)
 ; MIPS32-NEXT:    fill.h $w0, $1
 ; MIPS32-NEXT:    fexupr.w $w0, $w0
-; MIPS32-NEXT:    fexupr.d $w0, $w0
 ; MIPS32-NEXT:    copy_s.w $1, $w0[0]
-; MIPS32-NEXT:    mtc1 $1, $f1
-; MIPS32-NEXT:    copy_s.w $1, $w0[1]
-; MIPS32-NEXT:    mthc1 $1, $f1
-; MIPS32-NEXT:    trunc.w.d $f0, $f1
+; MIPS32-NEXT:    mtc1 $1, $f0
+; MIPS32-NEXT:    trunc.w.s $f0, $f0
 ; MIPS32-NEXT:    jr $ra
 ; MIPS32-NEXT:    mfc1 $2, $f0
 ;
@@ -3877,10 +3864,9 @@ define i32 @fptosi_f16_i32(ptr %p) {
 ; MIPS64-N32-NEXT:    lh $1, 0($1)
 ; MIPS64-N32-NEXT:    fill.h $w0, $1
 ; MIPS64-N32-NEXT:    fexupr.w $w0, $w0
-; MIPS64-N32-NEXT:    fexupr.d $w0, $w0
-; MIPS64-N32-NEXT:    copy_s.d $1, $w0[0]
-; MIPS64-N32-NEXT:    dmtc1 $1, $f0
-; MIPS64-N32-NEXT:    trunc.w.d $f0, $f0
+; MIPS64-N32-NEXT:    copy_s.w $1, $w0[0]
+; MIPS64-N32-NEXT:    mtc1 $1, $f0
+; MIPS64-N32-NEXT:    trunc.w.s $f0, $f0
 ; MIPS64-N32-NEXT:    jr $ra
 ; MIPS64-N32-NEXT:    mfc1 $2, $f0
 ;
@@ -3889,10 +3875,9 @@ define i32 @fptosi_f16_i32(ptr %p) {
 ; MIPS64-N64-NEXT:    lh $1, 0($4)
 ; MIPS64-N64-NEXT:    fill.h $w0, $1
 ; MIPS64-N64-NEXT:    fexupr.w $w0, $w0
-; MIPS64-N64-NEXT:    fexupr.d $w0, $w0
-; MIPS64-N64-NEXT:    copy_s.d $1, $w0[0]
-; MIPS64-N64-NEXT:    dmtc1 $1, $f0
-; MIPS64-N64-NEXT:    trunc.w.d $f0, $f0
+; MIPS64-N64-NEXT:    copy_s.w $1, $w0[0]
+; MIPS64-N64-NEXT:    mtc1 $1, $f0
+; MIPS64-N64-NEXT:    trunc.w.s $f0, $f0
 ; MIPS64-N64-NEXT:    jr $ra
 ; MIPS64-N64-NEXT:    mfc1 $2, $f0
 entry:
@@ -3907,12 +3892,9 @@ define i32 @fptoui_f16_i32(ptr %p) {
 ; MIPS32-NEXT:    lh $1, 0($4)
 ; MIPS32-NEXT:    fill.h $w0, $1
 ; MIPS32-NEXT:    fexupr.w $w0, $w0
-; MIPS32-NEXT:    fexupr.d $w0, $w0
 ; MIPS32-NEXT:    copy_s.w $1, $w0[0]
-; MIPS32-NEXT:    mtc1 $1, $f1
-; MIPS32-NEXT:    copy_s.w $1, $w0[1]
-; MIPS32-NEXT:    mthc1 $1, $f1
-; MIPS32-NEXT:    trunc.w.d $f0, $f1
+; MIPS32-NEXT:    mtc1 $1, $f0
+; MIPS32-NEXT:    trunc.w.s $f0, $f0
 ; MIPS32-NEXT:    jr $ra
 ; MIPS32-NEXT:    mfc1 $2, $f0
 ;
@@ -3922,10 +3904,9 @@ define i32 @fptoui_f16_i32(ptr %p) {
 ; MIPS64-N32-NEXT:    lh $1, 0($1)
 ; MIPS64-N32-NEXT:    fill.h $w0, $1
 ; MIPS64-N32-NEXT:    fexupr.w $w0, $w0
-; MIPS64-N32-NEXT:    fexupr.d $w0, $w0
-; MIPS64-N32-NEXT:    copy_s.d $1, $w0[0]
-; MIPS64-N32-NEXT:    dmtc1 $1, $f0
-; MIPS64-N32-NEXT:    trunc.w.d $f0, $f0
+; MIPS64-N32-NEXT:    copy_s.w $1, $w0[0]
+; MIPS64-N32-NEXT:    mtc1 $1, $f0
+; MIPS64-N32-NEXT:    trunc.w.s $f0, $f0
 ; MIPS64-N32-NEXT:    jr $ra
 ; MIPS64-N32-NEXT:    mfc1 $2, $f0
 ;
@@ -3934,16 +3915,259 @@ define i32 @fptoui_f16_i32(ptr %p) {
 ; MIPS64-N64-NEXT:    lh $1, 0($4)
 ; MIPS64-N64-NEXT:    fill.h $w0, $1
 ; MIPS64-N64-NEXT:    fexupr.w $w0, $w0
-; MIPS64-N64-NEXT:    fexupr.d $w0, $w0
-; MIPS64-N64-NEXT:    copy_s.d $1, $w0[0]
-; MIPS64-N64-NEXT:    dmtc1 $1, $f0
-; MIPS64-N64-NEXT:    trunc.w.d $f0, $f0
+; MIPS64-N64-NEXT:    copy_s.w $1, $w0[0]
+; MIPS64-N64-NEXT:    mtc1 $1, $f0
+; MIPS64-N64-NEXT:    trunc.w.s $f0, $f0
 ; MIPS64-N64-NEXT:    jr $ra
 ; MIPS64-N64-NEXT:    mfc1 $2, $f0
 entry:
   %x = load half, ptr %p, align 2
   %r = fptoui half %x to i32
   ret i32 %r
+}
+
+define i64 @fptosi_f16_i64(ptr %p) {
+; MIPS32-LABEL: fptosi_f16_i64:
+; MIPS32:       # %bb.0: # %entry
+; MIPS32-NEXT:    lui $2, %hi(_gp_disp)
+; MIPS32-NEXT:    addiu $2, $2, %lo(_gp_disp)
+; MIPS32-NEXT:    addiu $sp, $sp, -24
+; MIPS32-NEXT:    .cfi_def_cfa_offset 24
+; MIPS32-NEXT:    sw $ra, 20($sp) # 4-byte Folded Spill
+; MIPS32-NEXT:    .cfi_offset 31, -4
+; MIPS32-NEXT:    addu $gp, $2, $25
+; MIPS32-NEXT:    lh $1, 0($4)
+; MIPS32-NEXT:    fill.h $w0, $1
+; MIPS32-NEXT:    fexupr.w $w0, $w0
+; MIPS32-NEXT:    copy_s.w $1, $w0[0]
+; MIPS32-NEXT:    lw $25, %call16(__fixsfdi)($gp)
+; MIPS32-NEXT:    jalr $25
+; MIPS32-NEXT:    mtc1 $1, $f12
+; MIPS32-NEXT:    lw $ra, 20($sp) # 4-byte Folded Reload
+; MIPS32-NEXT:    jr $ra
+; MIPS32-NEXT:    addiu $sp, $sp, 24
+;
+; MIPS64-N32-LABEL: fptosi_f16_i64:
+; MIPS64-N32:       # %bb.0: # %entry
+; MIPS64-N32-NEXT:    sll $1, $4, 0
+; MIPS64-N32-NEXT:    lh $1, 0($1)
+; MIPS64-N32-NEXT:    fill.h $w0, $1
+; MIPS64-N32-NEXT:    fexupr.w $w0, $w0
+; MIPS64-N32-NEXT:    copy_s.w $1, $w0[0]
+; MIPS64-N32-NEXT:    mtc1 $1, $f0
+; MIPS64-N32-NEXT:    trunc.l.s $f0, $f0
+; MIPS64-N32-NEXT:    jr $ra
+; MIPS64-N32-NEXT:    dmfc1 $2, $f0
+;
+; MIPS64-N64-LABEL: fptosi_f16_i64:
+; MIPS64-N64:       # %bb.0: # %entry
+; MIPS64-N64-NEXT:    lh $1, 0($4)
+; MIPS64-N64-NEXT:    fill.h $w0, $1
+; MIPS64-N64-NEXT:    fexupr.w $w0, $w0
+; MIPS64-N64-NEXT:    copy_s.w $1, $w0[0]
+; MIPS64-N64-NEXT:    mtc1 $1, $f0
+; MIPS64-N64-NEXT:    trunc.l.s $f0, $f0
+; MIPS64-N64-NEXT:    jr $ra
+; MIPS64-N64-NEXT:    dmfc1 $2, $f0
+entry:
+  %x = load half, ptr %p, align 2
+  %r = fptosi half %x to i64
+  ret i64 %r
+}
+
+define i64 @fptoui_f16_i64(ptr %p) {
+; MIPS32-LABEL: fptoui_f16_i64:
+; MIPS32:       # %bb.0: # %entry
+; MIPS32-NEXT:    lui $2, %hi(_gp_disp)
+; MIPS32-NEXT:    addiu $2, $2, %lo(_gp_disp)
+; MIPS32-NEXT:    addiu $sp, $sp, -24
+; MIPS32-NEXT:    .cfi_def_cfa_offset 24
+; MIPS32-NEXT:    sw $ra, 20($sp) # 4-byte Folded Spill
+; MIPS32-NEXT:    .cfi_offset 31, -4
+; MIPS32-NEXT:    addu $gp, $2, $25
+; MIPS32-NEXT:    lh $1, 0($4)
+; MIPS32-NEXT:    fill.h $w0, $1
+; MIPS32-NEXT:    fexupr.w $w0, $w0
+; MIPS32-NEXT:    copy_s.w $1, $w0[0]
+; MIPS32-NEXT:    lw $25, %call16(__fixsfdi)($gp)
+; MIPS32-NEXT:    jalr $25
+; MIPS32-NEXT:    mtc1 $1, $f12
+; MIPS32-NEXT:    lw $ra, 20($sp) # 4-byte Folded Reload
+; MIPS32-NEXT:    jr $ra
+; MIPS32-NEXT:    addiu $sp, $sp, 24
+;
+; MIPS64-N32-LABEL: fptoui_f16_i64:
+; MIPS64-N32:       # %bb.0: # %entry
+; MIPS64-N32-NEXT:    sll $1, $4, 0
+; MIPS64-N32-NEXT:    lh $1, 0($1)
+; MIPS64-N32-NEXT:    fill.h $w0, $1
+; MIPS64-N32-NEXT:    fexupr.w $w0, $w0
+; MIPS64-N32-NEXT:    copy_s.w $1, $w0[0]
+; MIPS64-N32-NEXT:    mtc1 $1, $f0
+; MIPS64-N32-NEXT:    trunc.l.s $f0, $f0
+; MIPS64-N32-NEXT:    jr $ra
+; MIPS64-N32-NEXT:    dmfc1 $2, $f0
+;
+; MIPS64-N64-LABEL: fptoui_f16_i64:
+; MIPS64-N64:       # %bb.0: # %entry
+; MIPS64-N64-NEXT:    lh $1, 0($4)
+; MIPS64-N64-NEXT:    fill.h $w0, $1
+; MIPS64-N64-NEXT:    fexupr.w $w0, $w0
+; MIPS64-N64-NEXT:    copy_s.w $1, $w0[0]
+; MIPS64-N64-NEXT:    mtc1 $1, $f0
+; MIPS64-N64-NEXT:    trunc.l.s $f0, $f0
+; MIPS64-N64-NEXT:    jr $ra
+; MIPS64-N64-NEXT:    dmfc1 $2, $f0
+entry:
+  %x = load half, ptr %p, align 2
+  %r = fptoui half %x to i64
+  ret i64 %r
+}
+
+define i128 @fptosi_f16_i128(ptr %p) {
+; MIPS32-LABEL: fptosi_f16_i128:
+; MIPS32:       # %bb.0: # %entry
+; MIPS32-NEXT:    lui $2, %hi(_gp_disp)
+; MIPS32-NEXT:    addiu $2, $2, %lo(_gp_disp)
+; MIPS32-NEXT:    addiu $sp, $sp, -24
+; MIPS32-NEXT:    .cfi_def_cfa_offset 24
+; MIPS32-NEXT:    sw $ra, 20($sp) # 4-byte Folded Spill
+; MIPS32-NEXT:    .cfi_offset 31, -4
+; MIPS32-NEXT:    addu $gp, $2, $25
+; MIPS32-NEXT:    lh $1, 0($4)
+; MIPS32-NEXT:    fill.h $w0, $1
+; MIPS32-NEXT:    fexupr.w $w0, $w0
+; MIPS32-NEXT:    copy_s.w $1, $w0[0]
+; MIPS32-NEXT:    lw $25, %call16(__fixsfti)($gp)
+; MIPS32-NEXT:    jalr $25
+; MIPS32-NEXT:    mtc1 $1, $f12
+; MIPS32-NEXT:    lw $ra, 20($sp) # 4-byte Folded Reload
+; MIPS32-NEXT:    jr $ra
+; MIPS32-NEXT:    addiu $sp, $sp, 24
+;
+; MIPS64-N32-LABEL: fptosi_f16_i128:
+; MIPS64-N32:       # %bb.0: # %entry
+; MIPS64-N32-NEXT:    addiu $sp, $sp, -16
+; MIPS64-N32-NEXT:    .cfi_def_cfa_offset 16
+; MIPS64-N32-NEXT:    sd $ra, 8($sp) # 8-byte Folded Spill
+; MIPS64-N32-NEXT:    sd $gp, 0($sp) # 8-byte Folded Spill
+; MIPS64-N32-NEXT:    .cfi_offset 31, -8
+; MIPS64-N32-NEXT:    .cfi_offset 28, -16
+; MIPS64-N32-NEXT:    lui $1, %hi(%neg(%gp_rel(fptosi_f16_i128)))
+; MIPS64-N32-NEXT:    addu $1, $1, $25
+; MIPS64-N32-NEXT:    addiu $gp, $1, %lo(%neg(%gp_rel(fptosi_f16_i128)))
+; MIPS64-N32-NEXT:    sll $1, $4, 0
+; MIPS64-N32-NEXT:    lh $1, 0($1)
+; MIPS64-N32-NEXT:    fill.h $w0, $1
+; MIPS64-N32-NEXT:    fexupr.w $w0, $w0
+; MIPS64-N32-NEXT:    copy_s.w $1, $w0[0]
+; MIPS64-N32-NEXT:    lw $25, %call16(__fixsfti)($gp)
+; MIPS64-N32-NEXT:    jalr $25
+; MIPS64-N32-NEXT:    mtc1 $1, $f12
+; MIPS64-N32-NEXT:    ld $gp, 0($sp) # 8-byte Folded Reload
+; MIPS64-N32-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
+; MIPS64-N32-NEXT:    jr $ra
+; MIPS64-N32-NEXT:    addiu $sp, $sp, 16
+;
+; MIPS64-N64-LABEL: fptosi_f16_i128:
+; MIPS64-N64:       # %bb.0: # %entry
+; MIPS64-N64-NEXT:    daddiu $sp, $sp, -16
+; MIPS64-N64-NEXT:    .cfi_def_cfa_offset 16
+; MIPS64-N64-NEXT:    sd $ra, 8($sp) # 8-byte Folded Spill
+; MIPS64-N64-NEXT:    sd $gp, 0($sp) # 8-byte Folded Spill
+; MIPS64-N64-NEXT:    .cfi_offset 31, -8
+; MIPS64-N64-NEXT:    .cfi_offset 28, -16
+; MIPS64-N64-NEXT:    lui $1, %hi(%neg(%gp_rel(fptosi_f16_i128)))
+; MIPS64-N64-NEXT:    daddu $1, $1, $25
+; MIPS64-N64-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(fptosi_f16_i128)))
+; MIPS64-N64-NEXT:    lh $1, 0($4)
+; MIPS64-N64-NEXT:    fill.h $w0, $1
+; MIPS64-N64-NEXT:    fexupr.w $w0, $w0
+; MIPS64-N64-NEXT:    copy_s.w $1, $w0[0]
+; MIPS64-N64-NEXT:    ld $25, %call16(__fixsfti)($gp)
+; MIPS64-N64-NEXT:    jalr $25
+; MIPS64-N64-NEXT:    mtc1 $1, $f12
+; MIPS64-N64-NEXT:    ld $gp, 0($sp) # 8-byte Folded Reload
+; MIPS64-N64-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
+; MIPS64-N64-NEXT:    jr $ra
+; MIPS64-N64-NEXT:    daddiu $sp, $sp, 16
+entry:
+  %x = load half, ptr %p, align 2
+  %r = fptosi half %x to i128
+  ret i128 %r
+}
+
+define i128 @fptoui_f16_i128(ptr %p) {
+; MIPS32-LABEL: fptoui_f16_i128:
+; MIPS32:       # %bb.0: # %entry
+; MIPS32-NEXT:    lui $2, %hi(_gp_disp)
+; MIPS32-NEXT:    addiu $2, $2, %lo(_gp_disp)
+; MIPS32-NEXT:    addiu $sp, $sp, -24
+; MIPS32-NEXT:    .cfi_def_cfa_offset 24
+; MIPS32-NEXT:    sw $ra, 20($sp) # 4-byte Folded Spill
+; MIPS32-NEXT:    .cfi_offset 31, -4
+; MIPS32-NEXT:    addu $gp, $2, $25
+; MIPS32-NEXT:    lh $1, 0($4)
+; MIPS32-NEXT:    fill.h $w0, $1
+; MIPS32-NEXT:    fexupr.w $w0, $w0
+; MIPS32-NEXT:    copy_s.w $1, $w0[0]
+; MIPS32-NEXT:    lw $25, %call16(__fixsfti)($gp)
+; MIPS32-NEXT:    jalr $25
+; MIPS32-NEXT:    mtc1 $1, $f12
+; MIPS32-NEXT:    lw $ra, 20($sp) # 4-byte Folded Reload
+; MIPS32-NEXT:    jr $ra
+; MIPS32-NEXT:    addiu $sp, $sp, 24
+;
+; MIPS64-N32-LABEL: fptoui_f16_i128:
+; MIPS64-N32:       # %bb.0: # %entry
+; MIPS64-N32-NEXT:    addiu $sp, $sp, -16
+; MIPS64-N32-NEXT:    .cfi_def_cfa_offset 16
+; MIPS64-N32-NEXT:    sd $ra, 8($sp) # 8-byte Folded Spill
+; MIPS64-N32-NEXT:    sd $gp, 0($sp) # 8-byte Folded Spill
+; MIPS64-N32-NEXT:    .cfi_offset 31, -8
+; MIPS64-N32-NEXT:    .cfi_offset 28, -16
+; MIPS64-N32-NEXT:    lui $1, %hi(%neg(%gp_rel(fptoui_f16_i128)))
+; MIPS64-N32-NEXT:    addu $1, $1, $25
+; MIPS64-N32-NEXT:    addiu $gp, $1, %lo(%neg(%gp_rel(fptoui_f16_i128)))
+; MIPS64-N32-NEXT:    sll $1, $4, 0
+; MIPS64-N32-NEXT:    lh $1, 0($1)
+; MIPS64-N32-NEXT:    fill.h $w0, $1
+; MIPS64-N32-NEXT:    fexupr.w $w0, $w0
+; MIPS64-N32-NEXT:    copy_s.w $1, $w0[0]
+; MIPS64-N32-NEXT:    lw $25, %call16(__fixsfti)($gp)
+; MIPS64-N32-NEXT:    jalr $25
+; MIPS64-N32-NEXT:    mtc1 $1, $f12
+; MIPS64-N32-NEXT:    ld $gp, 0($sp) # 8-byte Folded Reload
+; MIPS64-N32-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
+; MIPS64-N32-NEXT:    jr $ra
+; MIPS64-N32-NEXT:    addiu $sp, $sp, 16
+;
+; MIPS64-N64-LABEL: fptoui_f16_i128:
+; MIPS64-N64:       # %bb.0: # %entry
+; MIPS64-N64-NEXT:    daddiu $sp, $sp, -16
+; MIPS64-N64-NEXT:    .cfi_def_cfa_offset 16
+; MIPS64-N64-NEXT:    sd $ra, 8($sp) # 8-byte Folded Spill
+; MIPS64-N64-NEXT:    sd $gp, 0($sp) # 8-byte Folded Spill
+; MIPS64-N64-NEXT:    .cfi_offset 31, -8
+; MIPS64-N64-NEXT:    .cfi_offset 28, -16
+; MIPS64-N64-NEXT:    lui $1, %hi(%neg(%gp_rel(fptoui_f16_i128)))
+; MIPS64-N64-NEXT:    daddu $1, $1, $25
+; MIPS64-N64-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(fptoui_f16_i128)))
+; MIPS64-N64-NEXT:    lh $1, 0($4)
+; MIPS64-N64-NEXT:    fill.h $w0, $1
+; MIPS64-N64-NEXT:    fexupr.w $w0, $w0
+; MIPS64-N64-NEXT:    copy_s.w $1, $w0[0]
+; MIPS64-N64-NEXT:    ld $25, %call16(__fixsfti)($gp)
+; MIPS64-N64-NEXT:    jalr $25
+; MIPS64-N64-NEXT:    mtc1 $1, $f12
+; MIPS64-N64-NEXT:    ld $gp, 0($sp) # 8-byte Folded Reload
+; MIPS64-N64-NEXT:    ld $ra, 8($sp) # 8-byte Folded Reload
+; MIPS64-N64-NEXT:    jr $ra
+; MIPS64-N64-NEXT:    daddiu $sp, $sp, 16
+entry:
+  %x = load half, ptr %p, align 2
+  %r = fptoui half %x to i128
+  ret i128 %r
 }
 
 attributes #0 = { nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none) }

--- a/llvm/test/CodeGen/Mips/msa/f16-llvm-ir.ll
+++ b/llvm/test/CodeGen/Mips/msa/f16-llvm-ir.ll
@@ -3376,4 +3376,485 @@ entry:
   ret void
 }
 
+define half @sitofp_i32_f16(i32 %x) {
+; MIPS32-LABEL: sitofp_i32_f16:
+; MIPS32:       # %bb.0: # %entry
+; MIPS32-NEXT:    mtc1 $5, $f0
+; MIPS32-NEXT:    cvt.s.w $f0, $f0
+; MIPS32-NEXT:    mfc1 $1, $f0
+; MIPS32-NEXT:    fill.w $w0, $1
+; MIPS32-NEXT:    fexdo.h $w0, $w0, $w0
+; MIPS32-NEXT:    copy_u.h $1, $w0[0]
+; MIPS32-NEXT:    jr $ra
+; MIPS32-NEXT:    sh $1, 0($4)
+;
+; MIPS64-N32-LABEL: sitofp_i32_f16:
+; MIPS64-N32:       # %bb.0: # %entry
+; MIPS64-N32-NEXT:    sll $1, $4, 0
+; MIPS64-N32-NEXT:    sll $2, $5, 0
+; MIPS64-N32-NEXT:    mtc1 $2, $f0
+; MIPS64-N32-NEXT:    cvt.s.w $f0, $f0
+; MIPS64-N32-NEXT:    mfc1 $2, $f0
+; MIPS64-N32-NEXT:    fill.w $w0, $2
+; MIPS64-N32-NEXT:    fexdo.h $w0, $w0, $w0
+; MIPS64-N32-NEXT:    copy_u.h $2, $w0[0]
+; MIPS64-N32-NEXT:    jr $ra
+; MIPS64-N32-NEXT:    sh $2, 0($1)
+;
+; MIPS64-N64-LABEL: sitofp_i32_f16:
+; MIPS64-N64:       # %bb.0: # %entry
+; MIPS64-N64-NEXT:    sll $1, $5, 0
+; MIPS64-N64-NEXT:    mtc1 $1, $f0
+; MIPS64-N64-NEXT:    cvt.s.w $f0, $f0
+; MIPS64-N64-NEXT:    mfc1 $1, $f0
+; MIPS64-N64-NEXT:    fill.w $w0, $1
+; MIPS64-N64-NEXT:    fexdo.h $w0, $w0, $w0
+; MIPS64-N64-NEXT:    copy_u.h $1, $w0[0]
+; MIPS64-N64-NEXT:    jr $ra
+; MIPS64-N64-NEXT:    sh $1, 0($4)
+entry:
+  %r = sitofp i32 %x to half
+  ret half %r
+}
+
+define half @sitofp_i64_f16(i64 %x) {
+; MIPS32-LABEL: sitofp_i64_f16:
+; MIPS32:       # %bb.0: # %entry
+; MIPS32-NEXT:    lui $2, %hi(_gp_disp)
+; MIPS32-NEXT:    addiu $2, $2, %lo(_gp_disp)
+; MIPS32-NEXT:    addiu $sp, $sp, -32
+; MIPS32-NEXT:    .cfi_def_cfa_offset 32
+; MIPS32-NEXT:    sw $ra, 28($sp) # 4-byte Folded Spill
+; MIPS32-NEXT:    sw $16, 24($sp) # 4-byte Folded Spill
+; MIPS32-NEXT:    .cfi_offset 31, -4
+; MIPS32-NEXT:    .cfi_offset 16, -8
+; MIPS32-NEXT:    addu $gp, $2, $25
+; MIPS32-NEXT:    move $16, $4
+; MIPS32-NEXT:    lw $25, %call16(__floatdihf)($gp)
+; MIPS32-NEXT:    jalr $25
+; MIPS32-NEXT:    addiu $4, $sp, 22
+; MIPS32-NEXT:    lh $1, 22($sp)
+; MIPS32-NEXT:    fill.h $w0, $1
+; MIPS32-NEXT:    copy_u.h $1, $w0[0]
+; MIPS32-NEXT:    sh $1, 0($16)
+; MIPS32-NEXT:    lw $16, 24($sp) # 4-byte Folded Reload
+; MIPS32-NEXT:    lw $ra, 28($sp) # 4-byte Folded Reload
+; MIPS32-NEXT:    jr $ra
+; MIPS32-NEXT:    addiu $sp, $sp, 32
+;
+; MIPS64-N32-LABEL: sitofp_i64_f16:
+; MIPS64-N32:       # %bb.0: # %entry
+; MIPS64-N32-NEXT:    sll $1, $4, 0
+; MIPS64-N32-NEXT:    dmtc1 $5, $f0
+; MIPS64-N32-NEXT:    cvt.s.l $f0, $f0
+; MIPS64-N32-NEXT:    mfc1 $2, $f0
+; MIPS64-N32-NEXT:    fill.w $w0, $2
+; MIPS64-N32-NEXT:    fexdo.h $w0, $w0, $w0
+; MIPS64-N32-NEXT:    copy_u.h $2, $w0[0]
+; MIPS64-N32-NEXT:    jr $ra
+; MIPS64-N32-NEXT:    sh $2, 0($1)
+;
+; MIPS64-N64-LABEL: sitofp_i64_f16:
+; MIPS64-N64:       # %bb.0: # %entry
+; MIPS64-N64-NEXT:    dmtc1 $5, $f0
+; MIPS64-N64-NEXT:    cvt.s.l $f0, $f0
+; MIPS64-N64-NEXT:    mfc1 $1, $f0
+; MIPS64-N64-NEXT:    fill.w $w0, $1
+; MIPS64-N64-NEXT:    fexdo.h $w0, $w0, $w0
+; MIPS64-N64-NEXT:    copy_u.h $1, $w0[0]
+; MIPS64-N64-NEXT:    jr $ra
+; MIPS64-N64-NEXT:    sh $1, 0($4)
+entry:
+  %r = sitofp i64 %x to half
+  ret half %r
+}
+
+define half @sitofp_i128_f16(i128 %x) {
+; MIPS32-LABEL: sitofp_i128_f16:
+; MIPS32:       # %bb.0: # %entry
+; MIPS32-NEXT:    lui $2, %hi(_gp_disp)
+; MIPS32-NEXT:    addiu $2, $2, %lo(_gp_disp)
+; MIPS32-NEXT:    addiu $sp, $sp, -40
+; MIPS32-NEXT:    .cfi_def_cfa_offset 40
+; MIPS32-NEXT:    sw $ra, 36($sp) # 4-byte Folded Spill
+; MIPS32-NEXT:    sw $16, 32($sp) # 4-byte Folded Spill
+; MIPS32-NEXT:    .cfi_offset 31, -4
+; MIPS32-NEXT:    .cfi_offset 16, -8
+; MIPS32-NEXT:    addu $gp, $2, $25
+; MIPS32-NEXT:    move $16, $4
+; MIPS32-NEXT:    lw $1, 60($sp)
+; MIPS32-NEXT:    sw $1, 20($sp)
+; MIPS32-NEXT:    lw $1, 56($sp)
+; MIPS32-NEXT:    sw $1, 16($sp)
+; MIPS32-NEXT:    lw $25, %call16(__floattihf)($gp)
+; MIPS32-NEXT:    jalr $25
+; MIPS32-NEXT:    addiu $4, $sp, 30
+; MIPS32-NEXT:    lh $1, 30($sp)
+; MIPS32-NEXT:    fill.h $w0, $1
+; MIPS32-NEXT:    copy_u.h $1, $w0[0]
+; MIPS32-NEXT:    sh $1, 0($16)
+; MIPS32-NEXT:    lw $16, 32($sp) # 4-byte Folded Reload
+; MIPS32-NEXT:    lw $ra, 36($sp) # 4-byte Folded Reload
+; MIPS32-NEXT:    jr $ra
+; MIPS32-NEXT:    addiu $sp, $sp, 40
+;
+; MIPS64-N32-LABEL: sitofp_i128_f16:
+; MIPS64-N32:       # %bb.0: # %entry
+; MIPS64-N32-NEXT:    addiu $sp, $sp, -32
+; MIPS64-N32-NEXT:    .cfi_def_cfa_offset 32
+; MIPS64-N32-NEXT:    sd $ra, 24($sp) # 8-byte Folded Spill
+; MIPS64-N32-NEXT:    sd $gp, 16($sp) # 8-byte Folded Spill
+; MIPS64-N32-NEXT:    sd $16, 8($sp) # 8-byte Folded Spill
+; MIPS64-N32-NEXT:    .cfi_offset 31, -8
+; MIPS64-N32-NEXT:    .cfi_offset 28, -16
+; MIPS64-N32-NEXT:    .cfi_offset 16, -24
+; MIPS64-N32-NEXT:    lui $1, %hi(%neg(%gp_rel(sitofp_i128_f16)))
+; MIPS64-N32-NEXT:    addu $1, $1, $25
+; MIPS64-N32-NEXT:    addiu $gp, $1, %lo(%neg(%gp_rel(sitofp_i128_f16)))
+; MIPS64-N32-NEXT:    move $16, $4
+; MIPS64-N32-NEXT:    lw $25, %call16(__floattihf)($gp)
+; MIPS64-N32-NEXT:    jalr $25
+; MIPS64-N32-NEXT:    addiu $4, $sp, 6
+; MIPS64-N32-NEXT:    sll $1, $16, 0
+; MIPS64-N32-NEXT:    lh $2, 6($sp)
+; MIPS64-N32-NEXT:    fill.h $w0, $2
+; MIPS64-N32-NEXT:    copy_u.h $2, $w0[0]
+; MIPS64-N32-NEXT:    sh $2, 0($1)
+; MIPS64-N32-NEXT:    ld $16, 8($sp) # 8-byte Folded Reload
+; MIPS64-N32-NEXT:    ld $gp, 16($sp) # 8-byte Folded Reload
+; MIPS64-N32-NEXT:    ld $ra, 24($sp) # 8-byte Folded Reload
+; MIPS64-N32-NEXT:    jr $ra
+; MIPS64-N32-NEXT:    addiu $sp, $sp, 32
+;
+; MIPS64-N64-LABEL: sitofp_i128_f16:
+; MIPS64-N64:       # %bb.0: # %entry
+; MIPS64-N64-NEXT:    daddiu $sp, $sp, -32
+; MIPS64-N64-NEXT:    .cfi_def_cfa_offset 32
+; MIPS64-N64-NEXT:    sd $ra, 24($sp) # 8-byte Folded Spill
+; MIPS64-N64-NEXT:    sd $gp, 16($sp) # 8-byte Folded Spill
+; MIPS64-N64-NEXT:    sd $16, 8($sp) # 8-byte Folded Spill
+; MIPS64-N64-NEXT:    .cfi_offset 31, -8
+; MIPS64-N64-NEXT:    .cfi_offset 28, -16
+; MIPS64-N64-NEXT:    .cfi_offset 16, -24
+; MIPS64-N64-NEXT:    lui $1, %hi(%neg(%gp_rel(sitofp_i128_f16)))
+; MIPS64-N64-NEXT:    daddu $1, $1, $25
+; MIPS64-N64-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(sitofp_i128_f16)))
+; MIPS64-N64-NEXT:    move $16, $4
+; MIPS64-N64-NEXT:    ld $25, %call16(__floattihf)($gp)
+; MIPS64-N64-NEXT:    jalr $25
+; MIPS64-N64-NEXT:    daddiu $4, $sp, 6
+; MIPS64-N64-NEXT:    lh $1, 6($sp)
+; MIPS64-N64-NEXT:    fill.h $w0, $1
+; MIPS64-N64-NEXT:    copy_u.h $1, $w0[0]
+; MIPS64-N64-NEXT:    sh $1, 0($16)
+; MIPS64-N64-NEXT:    ld $16, 8($sp) # 8-byte Folded Reload
+; MIPS64-N64-NEXT:    ld $gp, 16($sp) # 8-byte Folded Reload
+; MIPS64-N64-NEXT:    ld $ra, 24($sp) # 8-byte Folded Reload
+; MIPS64-N64-NEXT:    jr $ra
+; MIPS64-N64-NEXT:    daddiu $sp, $sp, 32
+entry:
+  %r = sitofp i128 %x to half
+  ret half %r
+}
+
+define half @uitofp_i32_f16(i32 %x) {
+; MIPS32-LABEL: uitofp_i32_f16:
+; MIPS32:       # %bb.0: # %entry
+; MIPS32-NEXT:    lui $2, %hi(_gp_disp)
+; MIPS32-NEXT:    addiu $2, $2, %lo(_gp_disp)
+; MIPS32-NEXT:    addiu $sp, $sp, -8
+; MIPS32-NEXT:    .cfi_def_cfa_offset 8
+; MIPS32-NEXT:    addu $1, $2, $25
+; MIPS32-NEXT:    lui $2, 17200
+; MIPS32-NEXT:    sw $2, 4($sp)
+; MIPS32-NEXT:    sw $5, 0($sp)
+; MIPS32-NEXT:    lw $1, %got($CPI37_0)($1)
+; MIPS32-NEXT:    ldc1 $f0, %lo($CPI37_0)($1)
+; MIPS32-NEXT:    ldc1 $f1, 0($sp)
+; MIPS32-NEXT:    sub.d $f0, $f1, $f0
+; MIPS32-NEXT:    mfc1 $1, $f0
+; MIPS32-NEXT:    fill.w $w1, $1
+; MIPS32-NEXT:    mfhc1 $1, $f0
+; MIPS32-NEXT:    insert.w $w1[1], $1
+; MIPS32-NEXT:    insert.w $w1[3], $1
+; MIPS32-NEXT:    fexdo.w $w0, $w1, $w1
+; MIPS32-NEXT:    fexdo.h $w0, $w0, $w0
+; MIPS32-NEXT:    copy_u.h $1, $w0[0]
+; MIPS32-NEXT:    sh $1, 0($4)
+; MIPS32-NEXT:    jr $ra
+; MIPS32-NEXT:    addiu $sp, $sp, 8
+;
+; MIPS64R5-N32-LABEL: uitofp_i32_f16:
+; MIPS64R5-N32:       # %bb.0: # %entry
+; MIPS64R5-N32-NEXT:    addiu $sp, $sp, -16
+; MIPS64R5-N32-NEXT:    .cfi_def_cfa_offset 16
+; MIPS64R5-N32-NEXT:    lui $1, %hi(%neg(%gp_rel(uitofp_i32_f16)))
+; MIPS64R5-N32-NEXT:    addu $1, $1, $25
+; MIPS64R5-N32-NEXT:    addiu $1, $1, %lo(%neg(%gp_rel(uitofp_i32_f16)))
+; MIPS64R5-N32-NEXT:    lui $2, 17200
+; MIPS64R5-N32-NEXT:    sw $2, 12($sp)
+; MIPS64R5-N32-NEXT:    sll $2, $5, 0
+; MIPS64R5-N32-NEXT:    sw $2, 8($sp)
+; MIPS64R5-N32-NEXT:    lw $1, %got_page(.LCPI37_0)($1)
+; MIPS64R5-N32-NEXT:    ldc1 $f0, %got_ofst(.LCPI37_0)($1)
+; MIPS64R5-N32-NEXT:    ldc1 $f1, 8($sp)
+; MIPS64R5-N32-NEXT:    sub.d $f0, $f1, $f0
+; MIPS64R5-N32-NEXT:    dmfc1 $1, $f0
+; MIPS64R5-N32-NEXT:    fill.d $w0, $1
+; MIPS64R5-N32-NEXT:    fexdo.w $w0, $w0, $w0
+; MIPS64R5-N32-NEXT:    fexdo.h $w0, $w0, $w0
+; MIPS64R5-N32-NEXT:    sll $1, $4, 0
+; MIPS64R5-N32-NEXT:    copy_u.h $2, $w0[0]
+; MIPS64R5-N32-NEXT:    sh $2, 0($1)
+; MIPS64R5-N32-NEXT:    jr $ra
+; MIPS64R5-N32-NEXT:    addiu $sp, $sp, 16
+;
+; MIPS64R5-N64-LABEL: uitofp_i32_f16:
+; MIPS64R5-N64:       # %bb.0: # %entry
+; MIPS64R5-N64-NEXT:    daddiu $sp, $sp, -16
+; MIPS64R5-N64-NEXT:    .cfi_def_cfa_offset 16
+; MIPS64R5-N64-NEXT:    lui $1, %hi(%neg(%gp_rel(uitofp_i32_f16)))
+; MIPS64R5-N64-NEXT:    daddu $1, $1, $25
+; MIPS64R5-N64-NEXT:    daddiu $1, $1, %lo(%neg(%gp_rel(uitofp_i32_f16)))
+; MIPS64R5-N64-NEXT:    lui $2, 17200
+; MIPS64R5-N64-NEXT:    sw $2, 12($sp)
+; MIPS64R5-N64-NEXT:    sll $2, $5, 0
+; MIPS64R5-N64-NEXT:    sw $2, 8($sp)
+; MIPS64R5-N64-NEXT:    ld $1, %got_page(.LCPI37_0)($1)
+; MIPS64R5-N64-NEXT:    ldc1 $f0, %got_ofst(.LCPI37_0)($1)
+; MIPS64R5-N64-NEXT:    ldc1 $f1, 8($sp)
+; MIPS64R5-N64-NEXT:    sub.d $f0, $f1, $f0
+; MIPS64R5-N64-NEXT:    dmfc1 $1, $f0
+; MIPS64R5-N64-NEXT:    fill.d $w0, $1
+; MIPS64R5-N64-NEXT:    fexdo.w $w0, $w0, $w0
+; MIPS64R5-N64-NEXT:    fexdo.h $w0, $w0, $w0
+; MIPS64R5-N64-NEXT:    copy_u.h $1, $w0[0]
+; MIPS64R5-N64-NEXT:    sh $1, 0($4)
+; MIPS64R5-N64-NEXT:    jr $ra
+; MIPS64R5-N64-NEXT:    daddiu $sp, $sp, 16
+;
+; MIPSR6-N32-LABEL: uitofp_i32_f16:
+; MIPSR6-N32:       # %bb.0: # %entry
+; MIPSR6-N32-NEXT:    addiu $sp, $sp, -16
+; MIPSR6-N32-NEXT:    .cfi_def_cfa_offset 16
+; MIPSR6-N32-NEXT:    lui $1, %hi(%neg(%gp_rel(uitofp_i32_f16)))
+; MIPSR6-N32-NEXT:    addu $1, $1, $25
+; MIPSR6-N32-NEXT:    addiu $1, $1, %lo(%neg(%gp_rel(uitofp_i32_f16)))
+; MIPSR6-N32-NEXT:    lui $2, 17200
+; MIPSR6-N32-NEXT:    sw $2, 12($sp)
+; MIPSR6-N32-NEXT:    sw $5, 8($sp)
+; MIPSR6-N32-NEXT:    lw $1, %got_page(.LCPI37_0)($1)
+; MIPSR6-N32-NEXT:    ldc1 $f0, %got_ofst(.LCPI37_0)($1)
+; MIPSR6-N32-NEXT:    ldc1 $f1, 8($sp)
+; MIPSR6-N32-NEXT:    sub.d $f0, $f1, $f0
+; MIPSR6-N32-NEXT:    dmfc1 $1, $f0
+; MIPSR6-N32-NEXT:    fill.d $w0, $1
+; MIPSR6-N32-NEXT:    fexdo.w $w0, $w0, $w0
+; MIPSR6-N32-NEXT:    fexdo.h $w0, $w0, $w0
+; MIPSR6-N32-NEXT:    sll $1, $4, 0
+; MIPSR6-N32-NEXT:    copy_u.h $2, $w0[0]
+; MIPSR6-N32-NEXT:    sh $2, 0($1)
+; MIPSR6-N32-NEXT:    jr $ra
+; MIPSR6-N32-NEXT:    addiu $sp, $sp, 16
+;
+; MIPSR6-N64-LABEL: uitofp_i32_f16:
+; MIPSR6-N64:       # %bb.0: # %entry
+; MIPSR6-N64-NEXT:    daddiu $sp, $sp, -16
+; MIPSR6-N64-NEXT:    .cfi_def_cfa_offset 16
+; MIPSR6-N64-NEXT:    lui $1, %hi(%neg(%gp_rel(uitofp_i32_f16)))
+; MIPSR6-N64-NEXT:    daddu $1, $1, $25
+; MIPSR6-N64-NEXT:    daddiu $1, $1, %lo(%neg(%gp_rel(uitofp_i32_f16)))
+; MIPSR6-N64-NEXT:    lui $2, 17200
+; MIPSR6-N64-NEXT:    sw $2, 12($sp)
+; MIPSR6-N64-NEXT:    sw $5, 8($sp)
+; MIPSR6-N64-NEXT:    ld $1, %got_page(.LCPI37_0)($1)
+; MIPSR6-N64-NEXT:    ldc1 $f0, %got_ofst(.LCPI37_0)($1)
+; MIPSR6-N64-NEXT:    ldc1 $f1, 8($sp)
+; MIPSR6-N64-NEXT:    sub.d $f0, $f1, $f0
+; MIPSR6-N64-NEXT:    dmfc1 $1, $f0
+; MIPSR6-N64-NEXT:    fill.d $w0, $1
+; MIPSR6-N64-NEXT:    fexdo.w $w0, $w0, $w0
+; MIPSR6-N64-NEXT:    fexdo.h $w0, $w0, $w0
+; MIPSR6-N64-NEXT:    copy_u.h $1, $w0[0]
+; MIPSR6-N64-NEXT:    sh $1, 0($4)
+; MIPSR6-N64-NEXT:    jr $ra
+; MIPSR6-N64-NEXT:    daddiu $sp, $sp, 16
+entry:
+  %r = uitofp i32 %x to half
+  ret half %r
+}
+
+define half @uitofp_i64_f16(i64 %x) {
+; MIPS32-LABEL: uitofp_i64_f16:
+; MIPS32:       # %bb.0: # %entry
+; MIPS32-NEXT:    lui $2, %hi(_gp_disp)
+; MIPS32-NEXT:    addiu $2, $2, %lo(_gp_disp)
+; MIPS32-NEXT:    addiu $sp, $sp, -32
+; MIPS32-NEXT:    .cfi_def_cfa_offset 32
+; MIPS32-NEXT:    sw $ra, 28($sp) # 4-byte Folded Spill
+; MIPS32-NEXT:    sw $16, 24($sp) # 4-byte Folded Spill
+; MIPS32-NEXT:    .cfi_offset 31, -4
+; MIPS32-NEXT:    .cfi_offset 16, -8
+; MIPS32-NEXT:    addu $gp, $2, $25
+; MIPS32-NEXT:    move $16, $4
+; MIPS32-NEXT:    lw $25, %call16(__floatundihf)($gp)
+; MIPS32-NEXT:    jalr $25
+; MIPS32-NEXT:    addiu $4, $sp, 22
+; MIPS32-NEXT:    lh $1, 22($sp)
+; MIPS32-NEXT:    fill.h $w0, $1
+; MIPS32-NEXT:    copy_u.h $1, $w0[0]
+; MIPS32-NEXT:    sh $1, 0($16)
+; MIPS32-NEXT:    lw $16, 24($sp) # 4-byte Folded Reload
+; MIPS32-NEXT:    lw $ra, 28($sp) # 4-byte Folded Reload
+; MIPS32-NEXT:    jr $ra
+; MIPS32-NEXT:    addiu $sp, $sp, 32
+;
+; MIPS64-N32-LABEL: uitofp_i64_f16:
+; MIPS64-N32:       # %bb.0: # %entry
+; MIPS64-N32-NEXT:    addiu $sp, $sp, -32
+; MIPS64-N32-NEXT:    .cfi_def_cfa_offset 32
+; MIPS64-N32-NEXT:    sd $ra, 24($sp) # 8-byte Folded Spill
+; MIPS64-N32-NEXT:    sd $gp, 16($sp) # 8-byte Folded Spill
+; MIPS64-N32-NEXT:    sd $16, 8($sp) # 8-byte Folded Spill
+; MIPS64-N32-NEXT:    .cfi_offset 31, -8
+; MIPS64-N32-NEXT:    .cfi_offset 28, -16
+; MIPS64-N32-NEXT:    .cfi_offset 16, -24
+; MIPS64-N32-NEXT:    lui $1, %hi(%neg(%gp_rel(uitofp_i64_f16)))
+; MIPS64-N32-NEXT:    addu $1, $1, $25
+; MIPS64-N32-NEXT:    addiu $gp, $1, %lo(%neg(%gp_rel(uitofp_i64_f16)))
+; MIPS64-N32-NEXT:    move $16, $4
+; MIPS64-N32-NEXT:    lw $25, %call16(__floatundihf)($gp)
+; MIPS64-N32-NEXT:    jalr $25
+; MIPS64-N32-NEXT:    addiu $4, $sp, 6
+; MIPS64-N32-NEXT:    sll $1, $16, 0
+; MIPS64-N32-NEXT:    lh $2, 6($sp)
+; MIPS64-N32-NEXT:    fill.h $w0, $2
+; MIPS64-N32-NEXT:    copy_u.h $2, $w0[0]
+; MIPS64-N32-NEXT:    sh $2, 0($1)
+; MIPS64-N32-NEXT:    ld $16, 8($sp) # 8-byte Folded Reload
+; MIPS64-N32-NEXT:    ld $gp, 16($sp) # 8-byte Folded Reload
+; MIPS64-N32-NEXT:    ld $ra, 24($sp) # 8-byte Folded Reload
+; MIPS64-N32-NEXT:    jr $ra
+; MIPS64-N32-NEXT:    addiu $sp, $sp, 32
+;
+; MIPS64-N64-LABEL: uitofp_i64_f16:
+; MIPS64-N64:       # %bb.0: # %entry
+; MIPS64-N64-NEXT:    daddiu $sp, $sp, -32
+; MIPS64-N64-NEXT:    .cfi_def_cfa_offset 32
+; MIPS64-N64-NEXT:    sd $ra, 24($sp) # 8-byte Folded Spill
+; MIPS64-N64-NEXT:    sd $gp, 16($sp) # 8-byte Folded Spill
+; MIPS64-N64-NEXT:    sd $16, 8($sp) # 8-byte Folded Spill
+; MIPS64-N64-NEXT:    .cfi_offset 31, -8
+; MIPS64-N64-NEXT:    .cfi_offset 28, -16
+; MIPS64-N64-NEXT:    .cfi_offset 16, -24
+; MIPS64-N64-NEXT:    lui $1, %hi(%neg(%gp_rel(uitofp_i64_f16)))
+; MIPS64-N64-NEXT:    daddu $1, $1, $25
+; MIPS64-N64-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(uitofp_i64_f16)))
+; MIPS64-N64-NEXT:    move $16, $4
+; MIPS64-N64-NEXT:    ld $25, %call16(__floatundihf)($gp)
+; MIPS64-N64-NEXT:    jalr $25
+; MIPS64-N64-NEXT:    daddiu $4, $sp, 6
+; MIPS64-N64-NEXT:    lh $1, 6($sp)
+; MIPS64-N64-NEXT:    fill.h $w0, $1
+; MIPS64-N64-NEXT:    copy_u.h $1, $w0[0]
+; MIPS64-N64-NEXT:    sh $1, 0($16)
+; MIPS64-N64-NEXT:    ld $16, 8($sp) # 8-byte Folded Reload
+; MIPS64-N64-NEXT:    ld $gp, 16($sp) # 8-byte Folded Reload
+; MIPS64-N64-NEXT:    ld $ra, 24($sp) # 8-byte Folded Reload
+; MIPS64-N64-NEXT:    jr $ra
+; MIPS64-N64-NEXT:    daddiu $sp, $sp, 32
+entry:
+  %r = uitofp i64 %x to half
+  ret half %r
+}
+
+define half @uitofp_i128_f16(i128 %x) {
+; MIPS32-LABEL: uitofp_i128_f16:
+; MIPS32:       # %bb.0: # %entry
+; MIPS32-NEXT:    lui $2, %hi(_gp_disp)
+; MIPS32-NEXT:    addiu $2, $2, %lo(_gp_disp)
+; MIPS32-NEXT:    addiu $sp, $sp, -40
+; MIPS32-NEXT:    .cfi_def_cfa_offset 40
+; MIPS32-NEXT:    sw $ra, 36($sp) # 4-byte Folded Spill
+; MIPS32-NEXT:    sw $16, 32($sp) # 4-byte Folded Spill
+; MIPS32-NEXT:    .cfi_offset 31, -4
+; MIPS32-NEXT:    .cfi_offset 16, -8
+; MIPS32-NEXT:    addu $gp, $2, $25
+; MIPS32-NEXT:    move $16, $4
+; MIPS32-NEXT:    lw $1, 60($sp)
+; MIPS32-NEXT:    sw $1, 20($sp)
+; MIPS32-NEXT:    lw $1, 56($sp)
+; MIPS32-NEXT:    sw $1, 16($sp)
+; MIPS32-NEXT:    lw $25, %call16(__floatuntihf)($gp)
+; MIPS32-NEXT:    jalr $25
+; MIPS32-NEXT:    addiu $4, $sp, 30
+; MIPS32-NEXT:    lh $1, 30($sp)
+; MIPS32-NEXT:    fill.h $w0, $1
+; MIPS32-NEXT:    copy_u.h $1, $w0[0]
+; MIPS32-NEXT:    sh $1, 0($16)
+; MIPS32-NEXT:    lw $16, 32($sp) # 4-byte Folded Reload
+; MIPS32-NEXT:    lw $ra, 36($sp) # 4-byte Folded Reload
+; MIPS32-NEXT:    jr $ra
+; MIPS32-NEXT:    addiu $sp, $sp, 40
+;
+; MIPS64-N32-LABEL: uitofp_i128_f16:
+; MIPS64-N32:       # %bb.0: # %entry
+; MIPS64-N32-NEXT:    addiu $sp, $sp, -32
+; MIPS64-N32-NEXT:    .cfi_def_cfa_offset 32
+; MIPS64-N32-NEXT:    sd $ra, 24($sp) # 8-byte Folded Spill
+; MIPS64-N32-NEXT:    sd $gp, 16($sp) # 8-byte Folded Spill
+; MIPS64-N32-NEXT:    sd $16, 8($sp) # 8-byte Folded Spill
+; MIPS64-N32-NEXT:    .cfi_offset 31, -8
+; MIPS64-N32-NEXT:    .cfi_offset 28, -16
+; MIPS64-N32-NEXT:    .cfi_offset 16, -24
+; MIPS64-N32-NEXT:    lui $1, %hi(%neg(%gp_rel(uitofp_i128_f16)))
+; MIPS64-N32-NEXT:    addu $1, $1, $25
+; MIPS64-N32-NEXT:    addiu $gp, $1, %lo(%neg(%gp_rel(uitofp_i128_f16)))
+; MIPS64-N32-NEXT:    move $16, $4
+; MIPS64-N32-NEXT:    lw $25, %call16(__floatuntihf)($gp)
+; MIPS64-N32-NEXT:    jalr $25
+; MIPS64-N32-NEXT:    addiu $4, $sp, 6
+; MIPS64-N32-NEXT:    sll $1, $16, 0
+; MIPS64-N32-NEXT:    lh $2, 6($sp)
+; MIPS64-N32-NEXT:    fill.h $w0, $2
+; MIPS64-N32-NEXT:    copy_u.h $2, $w0[0]
+; MIPS64-N32-NEXT:    sh $2, 0($1)
+; MIPS64-N32-NEXT:    ld $16, 8($sp) # 8-byte Folded Reload
+; MIPS64-N32-NEXT:    ld $gp, 16($sp) # 8-byte Folded Reload
+; MIPS64-N32-NEXT:    ld $ra, 24($sp) # 8-byte Folded Reload
+; MIPS64-N32-NEXT:    jr $ra
+; MIPS64-N32-NEXT:    addiu $sp, $sp, 32
+;
+; MIPS64-N64-LABEL: uitofp_i128_f16:
+; MIPS64-N64:       # %bb.0: # %entry
+; MIPS64-N64-NEXT:    daddiu $sp, $sp, -32
+; MIPS64-N64-NEXT:    .cfi_def_cfa_offset 32
+; MIPS64-N64-NEXT:    sd $ra, 24($sp) # 8-byte Folded Spill
+; MIPS64-N64-NEXT:    sd $gp, 16($sp) # 8-byte Folded Spill
+; MIPS64-N64-NEXT:    sd $16, 8($sp) # 8-byte Folded Spill
+; MIPS64-N64-NEXT:    .cfi_offset 31, -8
+; MIPS64-N64-NEXT:    .cfi_offset 28, -16
+; MIPS64-N64-NEXT:    .cfi_offset 16, -24
+; MIPS64-N64-NEXT:    lui $1, %hi(%neg(%gp_rel(uitofp_i128_f16)))
+; MIPS64-N64-NEXT:    daddu $1, $1, $25
+; MIPS64-N64-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(uitofp_i128_f16)))
+; MIPS64-N64-NEXT:    move $16, $4
+; MIPS64-N64-NEXT:    ld $25, %call16(__floatuntihf)($gp)
+; MIPS64-N64-NEXT:    jalr $25
+; MIPS64-N64-NEXT:    daddiu $4, $sp, 6
+; MIPS64-N64-NEXT:    lh $1, 6($sp)
+; MIPS64-N64-NEXT:    fill.h $w0, $1
+; MIPS64-N64-NEXT:    copy_u.h $1, $w0[0]
+; MIPS64-N64-NEXT:    sh $1, 0($16)
+; MIPS64-N64-NEXT:    ld $16, 8($sp) # 8-byte Folded Reload
+; MIPS64-N64-NEXT:    ld $gp, 16($sp) # 8-byte Folded Reload
+; MIPS64-N64-NEXT:    ld $ra, 24($sp) # 8-byte Folded Reload
+; MIPS64-N64-NEXT:    jr $ra
+; MIPS64-N64-NEXT:    daddiu $sp, $sp, 32
+entry:
+  %r = uitofp i128 %x to half
+  ret half %r
+}
+
+
 attributes #0 = { nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none) }

--- a/llvm/test/CodeGen/Mips/msa/f16-llvm-ir.ll
+++ b/llvm/test/CodeGen/Mips/msa/f16-llvm-ir.ll
@@ -3856,5 +3856,94 @@ entry:
   ret half %r
 }
 
+define i32 @fptosi_f16_i32(ptr %p) {
+; MIPS32-LABEL: fptosi_f16_i32:
+; MIPS32:       # %bb.0: # %entry
+; MIPS32-NEXT:    lh $1, 0($4)
+; MIPS32-NEXT:    fill.h $w0, $1
+; MIPS32-NEXT:    fexupr.w $w0, $w0
+; MIPS32-NEXT:    fexupr.d $w0, $w0
+; MIPS32-NEXT:    copy_s.w $1, $w0[0]
+; MIPS32-NEXT:    mtc1 $1, $f1
+; MIPS32-NEXT:    copy_s.w $1, $w0[1]
+; MIPS32-NEXT:    mthc1 $1, $f1
+; MIPS32-NEXT:    trunc.w.d $f0, $f1
+; MIPS32-NEXT:    jr $ra
+; MIPS32-NEXT:    mfc1 $2, $f0
+;
+; MIPS64-N32-LABEL: fptosi_f16_i32:
+; MIPS64-N32:       # %bb.0: # %entry
+; MIPS64-N32-NEXT:    sll $1, $4, 0
+; MIPS64-N32-NEXT:    lh $1, 0($1)
+; MIPS64-N32-NEXT:    fill.h $w0, $1
+; MIPS64-N32-NEXT:    fexupr.w $w0, $w0
+; MIPS64-N32-NEXT:    fexupr.d $w0, $w0
+; MIPS64-N32-NEXT:    copy_s.d $1, $w0[0]
+; MIPS64-N32-NEXT:    dmtc1 $1, $f0
+; MIPS64-N32-NEXT:    trunc.w.d $f0, $f0
+; MIPS64-N32-NEXT:    jr $ra
+; MIPS64-N32-NEXT:    mfc1 $2, $f0
+;
+; MIPS64-N64-LABEL: fptosi_f16_i32:
+; MIPS64-N64:       # %bb.0: # %entry
+; MIPS64-N64-NEXT:    lh $1, 0($4)
+; MIPS64-N64-NEXT:    fill.h $w0, $1
+; MIPS64-N64-NEXT:    fexupr.w $w0, $w0
+; MIPS64-N64-NEXT:    fexupr.d $w0, $w0
+; MIPS64-N64-NEXT:    copy_s.d $1, $w0[0]
+; MIPS64-N64-NEXT:    dmtc1 $1, $f0
+; MIPS64-N64-NEXT:    trunc.w.d $f0, $f0
+; MIPS64-N64-NEXT:    jr $ra
+; MIPS64-N64-NEXT:    mfc1 $2, $f0
+entry:
+  %x = load half, ptr %p, align 2
+  %r = fptosi half %x to i32
+  ret i32 %r
+}
+
+define i32 @fptoui_f16_i32(ptr %p) {
+; MIPS32-LABEL: fptoui_f16_i32:
+; MIPS32:       # %bb.0: # %entry
+; MIPS32-NEXT:    lh $1, 0($4)
+; MIPS32-NEXT:    fill.h $w0, $1
+; MIPS32-NEXT:    fexupr.w $w0, $w0
+; MIPS32-NEXT:    fexupr.d $w0, $w0
+; MIPS32-NEXT:    copy_s.w $1, $w0[0]
+; MIPS32-NEXT:    mtc1 $1, $f1
+; MIPS32-NEXT:    copy_s.w $1, $w0[1]
+; MIPS32-NEXT:    mthc1 $1, $f1
+; MIPS32-NEXT:    trunc.w.d $f0, $f1
+; MIPS32-NEXT:    jr $ra
+; MIPS32-NEXT:    mfc1 $2, $f0
+;
+; MIPS64-N32-LABEL: fptoui_f16_i32:
+; MIPS64-N32:       # %bb.0: # %entry
+; MIPS64-N32-NEXT:    sll $1, $4, 0
+; MIPS64-N32-NEXT:    lh $1, 0($1)
+; MIPS64-N32-NEXT:    fill.h $w0, $1
+; MIPS64-N32-NEXT:    fexupr.w $w0, $w0
+; MIPS64-N32-NEXT:    fexupr.d $w0, $w0
+; MIPS64-N32-NEXT:    copy_s.d $1, $w0[0]
+; MIPS64-N32-NEXT:    dmtc1 $1, $f0
+; MIPS64-N32-NEXT:    trunc.w.d $f0, $f0
+; MIPS64-N32-NEXT:    jr $ra
+; MIPS64-N32-NEXT:    mfc1 $2, $f0
+;
+; MIPS64-N64-LABEL: fptoui_f16_i32:
+; MIPS64-N64:       # %bb.0: # %entry
+; MIPS64-N64-NEXT:    lh $1, 0($4)
+; MIPS64-N64-NEXT:    fill.h $w0, $1
+; MIPS64-N64-NEXT:    fexupr.w $w0, $w0
+; MIPS64-N64-NEXT:    fexupr.d $w0, $w0
+; MIPS64-N64-NEXT:    copy_s.d $1, $w0[0]
+; MIPS64-N64-NEXT:    dmtc1 $1, $f0
+; MIPS64-N64-NEXT:    trunc.w.d $f0, $f0
+; MIPS64-N64-NEXT:    jr $ra
+; MIPS64-N64-NEXT:    mfc1 $2, $f0
+entry:
+  %x = load half, ptr %p, align 2
+  %r = fptoui half %x to i32
+  ret i32 %r
+}
 
 attributes #0 = { nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none) }


### PR DESCRIPTION
Currently these conversions hit an instruction selection failure https://godbolt.org/z/5YK4T71Wf. The backend marks most operations on `f16` as `Promote`, but these conversions were (I assume) forgotten.

I've modeled this based on the implementation for s390x, because like MIPS the `f16` type is storage-only there: you can pass it around etc. but actual operations are done via promotion to `f32` or `f64`.

https://github.com/llvm/llvm-project/blob/a4e48b5d1a5dc7af00c4adb4076145afd9846739/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp#L7027-L7091

