### PR TITLE
[libc] Fix putting tuple_size into libc++ namespace.

### DIFF
--- a/libc/src/__support/CPP/tuple.h
+++ b/libc/src/__support/CPP/tuple.h
@@ -131,10 +131,9 @@ LIBC_INLINE constexpr auto tuple_cat(const Tuples &...tuples) {
 
 // Standard namespace definitions required for structured binding support.
 
-#ifdef _LIBCPP_BEGIN_NAMESPACE_STD
-_LIBCPP_BEGIN_NAMESPACE_STD
-#else
 namespace std {
+#ifdef _LIBCPP_ABI_NAMESPACE
+inline namespace _LIBCPP_ABI_NAMESPACE {
 #endif
 
 template <class T> struct tuple_size;
@@ -149,10 +148,9 @@ struct tuple_element<Idx, LIBC_NAMESPACE::cpp::tuple<Ts...>>
     : LIBC_NAMESPACE::cpp::tuple_element<Idx,
                                          LIBC_NAMESPACE::cpp::tuple<Ts...>> {};
 
-#ifdef _LIBCPP_END_NAMESPACE_STD
-_LIBCPP_END_NAMESPACE_STD
-#else
-} // namespace std
+#ifdef _LIBCPP_ABI_NAMESPACE
+} // namespace _LIBCPP_ABI_NAMESPACE
 #endif
+} // namespace std
 
 #endif // LLVM_LIBC_SRC___SUPPORT_CPP_UTILITY_TUPLE_H


### PR DESCRIPTION
633539bfa1516e616b798b2eae98bea689b3c410 added special-case for putting `tuple_size` into correct namespace when building with libc++. It uses `_LIBCPP_BEGIN_NAMESPACE_STD` macro, which recently started to contain more logic, including the Clang pragmas to ensure correct visibility. It also may also introduce warnings for `-Wpragma-clang-attribute` which need to be suppressed. After fad51d3f41482e148683e12741ac9abfbe49742d, this suppression only works for libc++ headers themselves (which define `#pragma GCC system_header`), but not for the user code. 

This change bypasses explicit ABI annotation macros in libc++ by switching to using `_LIBCPP_ABI_NAMESPACE` (that libc++ uses under the hood) if it's available.