### PR TITLE
[ORC] Add missing dependency on intrinsics_gen to Debugging library

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/Debugging/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/Orc/Debugging/CMakeLists.txt
@@ -14,6 +14,9 @@ add_llvm_component_library(LLVMOrcDebugging
   ADDITIONAL_HEADER_DIRS
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/ExecutionEngine/Orc/Debugging/
 
+  DEPENDS
+  intrinsics_gen
+
   LINK_LIBS
   ${LLVM_PTHREAD_LIB}
   ${rt_lib}


### PR DESCRIPTION
The Debugging library includes llvm/IR/Attributes.inc so it needs to depend on intrinsics_gen to make sure the file is generated before it's used.