### PR TITLE
[compiler-rt][ARM] Fix clobbered fetch value in sync_fetch_and_minmax_8

### DIFF
--- a/compiler-rt/lib/builtins/arm/sync-ops.h
+++ b/compiler-rt/lib/builtins/arm/sync-ops.h
@@ -41,8 +41,8 @@
   .syntax unified;                                                             \
   DEFINE_COMPILERRT_FUNCTION(__sync_fetch_and_##op)                            \
   push {r4, r5, r6, lr};                                                       \
-  DMB;                                                                         \
   mov r12, r0;                                                                 \
+  DMB;                                                                         \
   LOCAL_LABEL(tryatomic_##op) : ldrexd r0, r1, [r12];                          \
   op(r4, r5, r0, r1, r2, r3);                                                  \
   strexd r6, r4, r5, [r12];                                                    \
@@ -52,14 +52,14 @@
   pop { r4, r5, r6, pc }
 
 #define MINMAX_4(rD, rN, rM, cmp_kind)                                         \
-  cmp rN, rM;                                                                  \
   mov rD, rM;                                                                  \
+  cmp rN, rM;                                                                  \
   it cmp_kind;                                                                 \
   mov##cmp_kind rD, rN
 
 #define MINMAX_8(rD_LO, rD_HI, rN_LO, rN_HI, rM_LO, rM_HI, cmp_kind)           \
   cmp rN_LO, rM_LO;                                                            \
-  sbcs rN_HI, rM_HI;                                                           \
+  sbcs rD_HI, rN_HI, rM_HI;                                                    \
   mov rD_LO, rM_LO;                                                            \
   mov rD_HI, rM_HI;                                                            \
   itt cmp_kind;                                                                \


### PR DESCRIPTION
This fixes the function's return value, and the stored value when the fetched value is selected as the minimum or maximum.

Additionally, reordered instructions in sync_fetch_and_minmax_4 to take advantage of a potential load-use interlock cycle, and reordered the DMB in sync_*_8 functions to be as late as possible before the first fetch.