### PR TITLE
[orc] Add missing <iterator> include

### DIFF
--- a/compiler-rt/lib/orc/record_section_tracker.h
+++ b/compiler-rt/lib/orc/record_section_tracker.h
@@ -17,6 +17,7 @@
 #include "error.h"
 #include "executor_address.h"
 #include <algorithm>
+#include <iterator>
 #include <vector>
 
 namespace orc_rt {


### PR DESCRIPTION
Fixes build after libc++ PR #195509 which drops transitive includes.