### PR TITLE
[flang][OpenMP] Fix failure in linear-clause01.f90 test

### DIFF
--- a/flang/test/Semantics/OpenMP/linear-clause01.f90
+++ b/flang/test/Semantics/OpenMP/linear-clause01.f90
@@ -46,6 +46,6 @@ subroutine linear_clause_03(arg)
     !ERROR: The list item `i` must be a dummy argument
     !$omp declare simd linear(i)
 
-    !ERROR: 'cc' is a common block name and must not appear in a LINEAR clause
+    !ERROR: The list item `i` must be a dummy argument
     !$omp declare simd linear(/cc/)
 end subroutine linear_clause_03


### PR DESCRIPTION
Apparently the order of some OpenMP checks changed since the pre-commit
CI tested PR #189170.
Now the error `The list item 'i' must be a dummy argument` occurs
instead of
`'cc' is a common block name and must not appear in a LINEAR clause`.
