### PR TITLE
[clang] Disable crash-diagnostic-tar.c if backtraces are disabled

### DIFF
--- a/clang/test/Driver/crash-diagnostics-tar.c
+++ b/clang/test/Driver/crash-diagnostics-tar.c
@@ -1,3 +1,4 @@
+// REQUIRES: backtrace
 // RUN: export LSAN_OPTIONS=detect_leaks=0
 // RUN: rm -rf %t && mkdir %t
 // RUN: cd %t


### PR DESCRIPTION
PR #201643 adds a test that fails if backtraces are disabled, e.g. in tests for a stripped build. This was failing the Fuchsia CI, so this change disables this test in such cases. It is likely possible to make this test finer-grained to allow it to succeed with backtraces disabled.