### PR TITLE
[SelectionDAG] Fix -Wunused-variable

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -5665,7 +5665,7 @@ bool SelectionDAG::isGuaranteedNotToBeUndefOrPoison(SDValue Op,
     unsigned SrcEltBits = SrcVT.getScalarSizeInBits();
     unsigned DstEltBits = DstVT.getScalarSizeInBits();
     ElementCount NumSrcElts = SrcVT.getVectorElementCount();
-    ElementCount NumDstElts = DstVT.getVectorElementCount();
+    [[maybe_unused]] ElementCount NumDstElts = DstVT.getVectorElementCount();
 
     if (SrcEltBits == DstEltBits)
       return isGuaranteedNotToBeUndefOrPoison(Src, DemandedElts, Kind,


### PR DESCRIPTION
NumDstElts is only used in assertions so mark it [[maybe_unused]] to
prevent any issues with non-asserts builds and -Wunused-variable.