### PR TITLE
[AMDGPU][MFI] Implement missing deserialization of dynamicVGPRBlockSize

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIMachineFunctionInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIMachineFunctionInfo.cpp
@@ -804,6 +804,10 @@ bool SIMachineFunctionInfo::initializeBaseYamlFields(
   ReturnsVoid = YamlMFI.ReturnsVoid;
   IsWholeWaveFunction = YamlMFI.IsWholeWaveFunction;
   MinNumAGPRs = YamlMFI.MinNumAGPRs;
+  // A non-zero value means that we got this value from the function attribute.
+  // It takes precedence over the MFI value.
+  if (DynamicVGPRBlockSize == 0)
+    DynamicVGPRBlockSize = YamlMFI.DynamicVGPRBlockSize;
 
   UserSGPRInfo.allocKernargPreloadSGPRs(YamlMFI.NumKernargPreloadSGPRs);
 

--- a/llvm/lib/Target/AMDGPU/SIMachineFunctionInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIMachineFunctionInfo.cpp
@@ -804,10 +804,10 @@ bool SIMachineFunctionInfo::initializeBaseYamlFields(
   ReturnsVoid = YamlMFI.ReturnsVoid;
   IsWholeWaveFunction = YamlMFI.IsWholeWaveFunction;
   MinNumAGPRs = YamlMFI.MinNumAGPRs;
-  // A non-zero value means that we got this value from the function attribute.
-  // It takes precedence over the MFI value.
-  if (DynamicVGPRBlockSize == 0)
-    DynamicVGPRBlockSize = YamlMFI.DynamicVGPRBlockSize;
+  // This can also be set by the function attribute, MFI has higher precedence
+  // though.
+  if (YamlMFI.DynamicVGPRBlockSize != std::nullopt)
+    DynamicVGPRBlockSize = *YamlMFI.DynamicVGPRBlockSize;
 
   UserSGPRInfo.allocKernargPreloadSGPRs(YamlMFI.NumKernargPreloadSGPRs);
 

--- a/llvm/lib/Target/AMDGPU/SIMachineFunctionInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIMachineFunctionInfo.h
@@ -303,7 +303,7 @@ struct SIMachineFunctionInfo final : public yaml::MachineFunctionInfo {
   bool HasInitWholeWave = false;
   bool IsWholeWaveFunction = false;
 
-  unsigned DynamicVGPRBlockSize = 0;
+  std::optional<unsigned> DynamicVGPRBlockSize;
   unsigned ScratchReservedForDynamicVGPRs = 0;
 
   unsigned NumKernargPreloadSGPRs = 0;
@@ -362,7 +362,7 @@ template <> struct MappingTraits<SIMachineFunctionInfo> {
     YamlIO.mapOptional("longBranchReservedReg", MFI.LongBranchReservedReg,
                        StringValue());
     YamlIO.mapOptional("hasInitWholeWave", MFI.HasInitWholeWave, false);
-    YamlIO.mapOptional("dynamicVGPRBlockSize", MFI.DynamicVGPRBlockSize, false);
+    YamlIO.mapOptional("dynamicVGPRBlockSize", MFI.DynamicVGPRBlockSize);
     YamlIO.mapOptional("scratchReservedForDynamicVGPRs",
                        MFI.ScratchReservedForDynamicVGPRs, 0);
     YamlIO.mapOptional("numKernargPreloadSGPRs", MFI.NumKernargPreloadSGPRs, 0);

--- a/llvm/test/CodeGen/AMDGPU/mir-dynamic-vgpr-block-size-roundtrip.mir
+++ b/llvm/test/CodeGen/AMDGPU/mir-dynamic-vgpr-block-size-roundtrip.mir
@@ -5,6 +5,8 @@
 --- |
   define amdgpu_ps void @dynvgpr_roundtrip_no_fn_attr() { ret void }
   define amdgpu_ps void @dynvgpr_roundtrip_with_fn_attr() #0 { ret void }
+  define amdgpu_ps void @dynvgpr_roundtrip_with_fn_attr_no_mfi() #0 { ret void }
+  define amdgpu_ps void @dynvgpr_roundtrip_with_fn_attr_mfi_zero() #0  { ret void }
   attributes #0 = { "amdgpu-dynamic-vgpr-block-size" = "16" }
 ...
 
@@ -21,14 +23,40 @@ body: |
 ...
 
 # In this test the function attribute is 16 but MFI is set to 32.
-# The attribute takes precedence over MFI, so check for 16.
+# MFI takes precedence over MFI, so check for 32.
 
 # CHECK-LABEL: name: dynvgpr_roundtrip_with_fn_attr
-# CHECK: dynamicVGPRBlockSize: 16
+# CHECK: dynamicVGPRBlockSize: 32
 ---
 name: dynvgpr_roundtrip_with_fn_attr
 machineFunctionInfo:
   dynamicVGPRBlockSize: 32
+body: |
+  bb.0:
+    S_ENDPGM 0
+...
+
+# In this test the function attribute is 16 but MFI is not set.
+# Make sure the MFI dump shows 16.
+
+# CHECK-LABEL: name: dynvgpr_roundtrip_with_fn_attr_no_mfi
+# CHECK: dynamicVGPRBlockSize: 16
+---
+name: dynvgpr_roundtrip_with_fn_attr_no_mfi
+body: |
+  bb.0:
+    S_ENDPGM 0
+...
+
+# In this test the function attribute is 16 but MFI is set to 0.
+# Check that this works and the MFI dump shows 0.
+
+# CHECK-LABEL: name: dynvgpr_roundtrip_with_fn_attr_mfi_zero
+# CHECK: dynamicVGPRBlockSize: 0
+---
+name: dynvgpr_roundtrip_with_fn_attr_mfi_zero
+machineFunctionInfo:
+  dynamicVGPRBlockSize: 0
 body: |
   bb.0:
     S_ENDPGM 0

--- a/llvm/test/CodeGen/AMDGPU/mir-dynamic-vgpr-block-size-roundtrip.mir
+++ b/llvm/test/CodeGen/AMDGPU/mir-dynamic-vgpr-block-size-roundtrip.mir
@@ -1,0 +1,35 @@
+# RUN: llc -mtriple=amdgcn-amd-amdpal -mcpu=gfx1200 -run-pass=none -o - %s | FileCheck %s
+
+# Test that dynamicVGPRBlockSize round-trips through MIR serialization.
+
+--- |
+  define amdgpu_ps void @dynvgpr_roundtrip_no_fn_attr() { ret void }
+  define amdgpu_ps void @dynvgpr_roundtrip_with_fn_attr() #0 { ret void }
+  attributes #0 = { "amdgpu-dynamic-vgpr-block-size" = "16" }
+...
+
+# CHECK-LABEL: name: dynvgpr_roundtrip_no_fn_attr
+# CHECK: dynamicVGPRBlockSize: 32
+
+---
+name: dynvgpr_roundtrip_no_fn_attr
+machineFunctionInfo:
+  dynamicVGPRBlockSize: 32
+body: |
+  bb.0:
+    S_ENDPGM 0
+...
+
+# In this test the function attribute is 16 but MFI is set to 32.
+# The attribute takes precedence over MFI, so check for 16.
+
+# CHECK-LABEL: name: dynvgpr_roundtrip_with_fn_attr
+# CHECK: dynamicVGPRBlockSize: 16
+---
+name: dynvgpr_roundtrip_with_fn_attr
+machineFunctionInfo:
+  dynamicVGPRBlockSize: 32
+body: |
+  bb.0:
+    S_ENDPGM 0
+...

--- a/llvm/test/CodeGen/AMDGPU/mir-dynamic-vgpr-block-size-roundtrip.mir
+++ b/llvm/test/CodeGen/AMDGPU/mir-dynamic-vgpr-block-size-roundtrip.mir
@@ -23,7 +23,7 @@ body: |
 ...
 
 # In this test the function attribute is 16 but MFI is set to 32.
-# MFI takes precedence over MFI, so check for 32.
+# MFI takes precedence over the attribute, so check for 32.
 
 # CHECK-LABEL: name: dynvgpr_roundtrip_with_fn_attr
 # CHECK: dynamicVGPRBlockSize: 32

--- a/llvm/test/CodeGen/MIR/AMDGPU/machine-function-info-no-ir.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/machine-function-info-no-ir.mir
@@ -88,6 +88,7 @@
 # SIMPLE-NEXT: workItemIDY:     { reg: '$vgpr31', mask: 1047552 }
 # SIMPLE-NEXT: workItemIDZ:     { reg: '$vgpr31', mask: 1072693248 }
 # SIMPLE-NEXT: occupancy: 8
+# SIMPLE-NEXT: dynamicVGPRBlockSize: 0
 # SIMPLE-NEXT: body:
 name: kernel0
 machineFunctionInfo:
@@ -187,6 +188,7 @@ body:             |
 # SIMPLE-NEXT: workItemIDY:     { reg: '$vgpr31', mask: 1047552 }
 # SIMPLE-NEXT: workItemIDZ:     { reg: '$vgpr31', mask: 1072693248 }
 # SIMPLE-NEXT:  occupancy: 10
+# SIMPLE-NEXT: dynamicVGPRBlockSize: 0
 # SIMPLE-NEXT: body:
 
 name: no_mfi
@@ -269,6 +271,7 @@ body:             |
 # SIMPLE-NEXT: workItemIDY:     { reg: '$vgpr31', mask: 1047552 }
 # SIMPLE-NEXT: workItemIDZ:     { reg: '$vgpr31', mask: 1072693248 }
 # SIMPLE-NEXT:  occupancy: 10
+# SIMPLE-NEXT: dynamicVGPRBlockSize: 0
 # SIMPLE-NEXT: body:
 
 name: empty_mfi
@@ -353,6 +356,7 @@ body:             |
 # SIMPLE-NEXT: workItemIDY:     { reg: '$vgpr31', mask: 1047552 }
 # SIMPLE-NEXT: workItemIDZ:     { reg: '$vgpr31', mask: 1072693248 }
 # SIMPLE-NEXT: occupancy: 10
+# SIMPLE-NEXT: dynamicVGPRBlockSize: 0
 # SIMPLE-NEXT: body:
 
 name: empty_mfi_entry_func


### PR DESCRIPTION
dynamicVGPRBlockSize can be set by the amdgpu-dynamic-vgpr-block-size attribute. MFI takes precedence when we deserialize.