### PR TITLE
[llvm-objdump] Remove path from test output

### DIFF
--- a/llvm/test/tools/llvm-objdump/MachO/function-starts.test
+++ b/llvm/test/tools/llvm-objdump/MachO/function-starts.test
@@ -1,34 +1,28 @@
 ## This test verifies that llvm-objdump correctly prints function starts data.
 
-## Note: we read input from stdin instead of from a file, because llvm-objdump prints
-## the filename in its output. If the filename contains the string "_main", then the
-## check will incorrectly get triggered. 
-
-RUN: llvm-objdump --no-leading-headers --macho --function-starts - < %p/Inputs/hello.exe.macho-i386 | FileCheck %s --check-prefix=32-BIT --implicit-check-not=_main
-RUN: llvm-objdump --no-leading-headers --macho --function-starts=addrs - < %p/Inputs/hello.exe.macho-i386 | FileCheck %s --check-prefix=32-BIT --implicit-check-not=_main
+RUN: llvm-objdump --no-leading-headers --macho --function-starts %p/Inputs/hello.exe.macho-i386 | FileCheck %s --check-prefix=32-BIT --implicit-check-not=_main
+RUN: llvm-objdump --no-leading-headers --macho --function-starts=addrs %p/Inputs/hello.exe.macho-i386 | FileCheck %s --check-prefix=32-BIT --implicit-check-not=_main
 32-BIT: 00001f40
 
-RUN: llvm-objdump --macho --function-starts=names - < %p/Inputs/hello.exe.macho-i386 | FileCheck %s --check-prefix=32-BIT-NAMES
+RUN: llvm-objdump --macho --function-starts=names %p/Inputs/hello.exe.macho-i386 | FileCheck %s --check-prefix=32-BIT-NAMES
 32-BIT-NAMES: {{^}}_main
 
-RUN: llvm-objdump --macho --function-starts=both - < %p/Inputs/hello.exe.macho-i386 | FileCheck %s --check-prefix=32-BIT-BOTH
+RUN: llvm-objdump --macho --function-starts=both %p/Inputs/hello.exe.macho-i386 | FileCheck %s --check-prefix=32-BIT-BOTH
 32-BIT-BOTH: 00001f40 _main
 
-RUN: llvm-objdump --no-leading-headers --macho --function-starts - < %p/Inputs/hello.exe.macho-x86_64 | FileCheck %s --check-prefix=64-BIT --implicit-check-not=_main
-RUN: llvm-objdump --no-leading-headers --macho --function-starts=addrs - < %p/Inputs/hello.exe.macho-x86_64 | FileCheck %s --check-prefix=64-BIT --implicit-check-not=_main
+RUN: llvm-objdump --no-leading-headers --macho --function-starts %p/Inputs/hello.exe.macho-x86_64 | FileCheck %s --check-prefix=64-BIT --implicit-check-not=_main
+RUN: llvm-objdump --no-leading-headers --macho --function-starts=addrs %p/Inputs/hello.exe.macho-x86_64 | FileCheck %s --check-prefix=64-BIT --implicit-check-not=_main
 64-BIT: 0000000100000f30
 
-RUN: llvm-objdump --macho --function-starts=names - < %p/Inputs/hello.exe.macho-x86_64 | FileCheck %s --check-prefix=64-BIT-NAMES
+RUN: llvm-objdump --macho --function-starts=names %p/Inputs/hello.exe.macho-x86_64 | FileCheck %s --check-prefix=64-BIT-NAMES
 64-BIT-NAMES: {{^}}_main
 
-RUN: llvm-objdump --macho --function-starts=both - < %p/Inputs/hello.exe.macho-x86_64 | FileCheck %s --check-prefix=64-BIT-BOTH
+RUN: llvm-objdump --macho --function-starts=both %p/Inputs/hello.exe.macho-x86_64 | FileCheck %s --check-prefix=64-BIT-BOTH
 64-BIT-BOTH: 0000000100000f30 _main
 
 RUN: llvm-strip  %p/Inputs/hello.exe.macho-x86_64 -o %t.stripped
-RUN: llvm-objdump --macho --function-starts=both - < %t.stripped | FileCheck %s --check-prefix=BOTH-STRIPPED
+RUN: llvm-objdump --macho --function-starts=both %t.stripped | FileCheck %s --check-prefix=BOTH-STRIPPED
 BOTH-STRIPPED: 0000000100000f30 ?
 
 RUN: llvm-strip %p/Inputs/hello.exe.macho-x86_64 -o %t.stripped
-RUN: llvm-objdump --macho --function-starts=names - < %t.stripped | FileCheck %s --check-prefix=NAMES-STRIPPED
-NAMES-STRIPPED: -:
-NAMES-STRIPPED-EMPTY:
+RUN: llvm-objdump --no-leading-headers --macho --function-starts=names %t.stripped | count 0

--- a/llvm/test/tools/llvm-objdump/MachO/function-starts.test
+++ b/llvm/test/tools/llvm-objdump/MachO/function-starts.test
@@ -4,8 +4,8 @@
 ## the filename in its output. If the filename contains the string "_main", then the
 ## check will incorrectly get triggered. 
 
-RUN: llvm-objdump --macho --function-starts - < %p/Inputs/hello.exe.macho-i386 | FileCheck %s --check-prefix=32-BIT --implicit-check-not=_main
-RUN: llvm-objdump --macho --function-starts=addrs - < %p/Inputs/hello.exe.macho-i386 | FileCheck %s --check-prefix=32-BIT --implicit-check-not=_main
+RUN: llvm-objdump --no-leading-headers --macho --function-starts - < %p/Inputs/hello.exe.macho-i386 | FileCheck %s --check-prefix=32-BIT --implicit-check-not=_main
+RUN: llvm-objdump --no-leading-headers --macho --function-starts=addrs - < %p/Inputs/hello.exe.macho-i386 | FileCheck %s --check-prefix=32-BIT --implicit-check-not=_main
 32-BIT: 00001f40
 
 RUN: llvm-objdump --macho --function-starts=names - < %p/Inputs/hello.exe.macho-i386 | FileCheck %s --check-prefix=32-BIT-NAMES
@@ -14,8 +14,8 @@ RUN: llvm-objdump --macho --function-starts=names - < %p/Inputs/hello.exe.macho-
 RUN: llvm-objdump --macho --function-starts=both - < %p/Inputs/hello.exe.macho-i386 | FileCheck %s --check-prefix=32-BIT-BOTH
 32-BIT-BOTH: 00001f40 _main
 
-RUN: llvm-objdump --macho --function-starts - < %p/Inputs/hello.exe.macho-x86_64 | FileCheck %s --check-prefix=64-BIT --implicit-check-not=_main
-RUN: llvm-objdump --macho --function-starts=addrs - < %p/Inputs/hello.exe.macho-x86_64 | FileCheck %s --check-prefix=64-BIT --implicit-check-not=_main
+RUN: llvm-objdump --no-leading-headers --macho --function-starts - < %p/Inputs/hello.exe.macho-x86_64 | FileCheck %s --check-prefix=64-BIT --implicit-check-not=_main
+RUN: llvm-objdump --no-leading-headers --macho --function-starts=addrs - < %p/Inputs/hello.exe.macho-x86_64 | FileCheck %s --check-prefix=64-BIT --implicit-check-not=_main
 64-BIT: 0000000100000f30
 
 RUN: llvm-objdump --macho --function-starts=names - < %p/Inputs/hello.exe.macho-x86_64 | FileCheck %s --check-prefix=64-BIT-NAMES


### PR DESCRIPTION
Without `--no-leading-headers`, `llvm-objdump` will emit the full path in the output. If the path happens to contain `_main`, then `--implicit-check-not=_main` will fail `FileCheck` and the test will fail. Don't emit the full path to prevent this.