### PR TITLE
[compiler-rt] Add stdlib include to OutOfProcessFuzzTarget.cpp

### DIFF
--- a/compiler-rt/test/fuzzer/OutOfProcessFuzzTarget.cpp
+++ b/compiler-rt/test/fuzzer/OutOfProcessFuzzTarget.cpp
@@ -32,6 +32,7 @@
 #include <fcntl.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>


### PR DESCRIPTION
Fixes test after libc++ PR #195509 which drops transitive includes.