### PR TITLE
[SSAF] Let function parameters inherit linkage from their parent functions

### DIFF
--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/Model/EntityLinkage.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/Model/EntityLinkage.h
@@ -15,8 +15,7 @@
 namespace clang::ssaf {
 
 enum class EntityLinkageType {
-  None,     ///< local variables, parameters of functions with no external
-            ///< linkage
+  None,     ///< local variables
   Internal, ///< static functions/variables, anonymous namespace
   External  ///< globally visible across translation units (including parameters
             ///< of functions with external linkage)

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/Model/EntityLinkage.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/Model/EntityLinkage.h
@@ -15,9 +15,11 @@
 namespace clang::ssaf {
 
 enum class EntityLinkageType {
-  None,     ///< local variables, function parameters
+  None,     ///< local variables, parameters of functions with no external
+            ///< linkage
   Internal, ///< static functions/variables, anonymous namespace
-  External  ///< globally visible across translation units
+  External  ///< globally visible across translation units (including parameters
+            ///< of functions with external linkage)
 };
 
 /// Represents the linkage properties of an entity in the program model.

--- a/clang/lib/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractor.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractor.cpp
@@ -34,7 +34,7 @@ static EntityLinkageType getLinkageForDecl(const Decl *D) {
   //   to be assigned different EntityIDs. As a result, the behavior of the
   //   parameter across multiple TUs cannot be correlated.
   if (const auto *PVD = dyn_cast<ParmVarDecl>(D)) {
-    if (const auto *FD = llvm::dyn_cast<FunctionDecl>(
+    if (const auto *FD = llvm::dyn_cast_or_null<FunctionDecl>(
             PVD->getParentFunctionOrMethod())) {
       return getLinkageForDecl(FD);
     }

--- a/clang/lib/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractor.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractor.cpp
@@ -8,10 +8,12 @@
 
 #include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractor.h"
 #include "clang/AST/Decl.h"
+#include "clang/AST/DeclBase.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/ASTEntityMapping.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/Model/EntityId.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/Model/EntityLinkage.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryBuilder.h"
+#include "llvm/Support/Casting.h"
 #include <optional>
 
 using namespace clang;
@@ -21,6 +23,22 @@ static EntityLinkageType getLinkageForDecl(const Decl *D) {
   const auto *ND = dyn_cast<NamedDecl>(D);
   if (!ND)
     return EntityLinkageType::None;
+
+  // Parameters have no linkage in C++, but SSAF needs them to inherit
+  // the external linkage from their parent functions.
+  // Here is why:
+  //   SSAF treats parameters as entities and may not always associate them back
+  //   to their parent functions. Therefore, it needs to identify parameters of
+  //   functions with external linkage across different TUs. Treating them as
+  //   having no linkage (as in C++) causes the same parameter in different TUs
+  //   to be assigned different EntityIDs. As a result, the behavior of the
+  //   parameter across multiple TUs cannot be correlated.
+  if (const auto *PVD = dyn_cast<ParmVarDecl>(D)) {
+    if (const FunctionDecl *FD = llvm::dyn_cast_or_null<FunctionDecl>(
+            PVD->getParentFunctionOrMethod())) {
+      return getLinkageForDecl(FD);
+    }
+  }
 
   switch (ND->getFormalLinkage()) {
   case Linkage::Invalid: {

--- a/clang/lib/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractor.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractor.cpp
@@ -34,7 +34,7 @@ static EntityLinkageType getLinkageForDecl(const Decl *D) {
   //   to be assigned different EntityIDs. As a result, the behavior of the
   //   parameter across multiple TUs cannot be correlated.
   if (const auto *PVD = dyn_cast<ParmVarDecl>(D)) {
-    if (const FunctionDecl *FD = llvm::dyn_cast_or_null<FunctionDecl>(
+    if (const auto *FD = llvm::dyn_cast<FunctionDecl>(
             PVD->getParentFunctionOrMethod())) {
       return getLinkageForDecl(FD);
     }

--- a/clang/test/Analysis/Scalable/PointerFlow/external-inline-function-in-multi-tu.test
+++ b/clang/test/Analysis/Scalable/PointerFlow/external-inline-function-in-multi-tu.test
@@ -1,0 +1,63 @@
+// For an 'inline' function with multiple definitions in different
+// translation units (TUs), its call sites in different TUs and one of
+// its definitions, which is chosen by the linker, are properly connected
+// during bounds propagation.
+
+
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+
+// Extract per-TU PointerFlow + UnsafeBufferUsage summaries.
+// RUN: %clang_cc1 -fsyntax-only -I %t %t/tu1.cpp \
+// RUN:   --ssaf-extract-summaries=PointerFlow \
+// RUN:   --ssaf-extract-summaries=UnsafeBufferUsage \
+// RUN:   --ssaf-tu-summary-file=%t/tu1.summary.json
+// RUN: %clang_cc1 -fsyntax-only -I %t %t/tu2.cpp \
+// RUN:   --ssaf-extract-summaries=PointerFlow \
+// RUN:   --ssaf-extract-summaries=UnsafeBufferUsage \
+// RUN:   --ssaf-tu-summary-file=%t/tu2.summary.json
+
+// Link the two TU summaries into a single LU summary.
+// RUN: clang-ssaf-linker %t/tu1.summary.json %t/tu2.summary.json \
+// RUN:   -o %t/lu.json
+
+// Run UnsafeBufferReachableAnalysis on the linked LU summary.
+// RUN: clang-ssaf-analyzer %t/lu.json -o %t/wpa.json \
+// RUN:   -a UnsafeBufferReachableAnalysisResult
+
+// RUN: FileCheck %s --input-file=%t/wpa.json
+
+//--- shared.h
+inline int shared_inline(int *p) {
+  int * l = p;      
+  return l[5];
+}
+
+//--- tu1.cpp
+#include "shared.h"
+int f(int *x) {
+  return shared_inline(x);
+}
+
+//--- tu2.cpp
+#include "shared.h"
+int g(int *y) {
+  return shared_inline(y);
+}
+
+
+// Check that these parameters are all reachable from the local variable 'l':
+// parameter 'y' of function 'g',
+// parameter 'x' of function 'f', and
+// parameter 'p' of function 'shared_inline'
+
+// CHECK-DAG: "suffix": "1",{{[[:space:]]+}}"usr": "c:@F@f#*I#"
+// CHECK-DAG: "suffix": "1",{{[[:space:]]+}}"usr": "c:@F@g#*I#"
+// CHECK-DAG: "suffix": "1",{{[[:space:]]+}}"usr": "c:@F@shared_inline#*I#"
+// CHECK-DAG: "usr": "c:shared.h@{{[0-9]+}}@F@shared_inline#{{.*}}@l"
+
+// Confirm UnsafeBufferReachableAnalysisResult is present in the output.
+// CHECK: "analysis_name": "UnsafeBufferReachableAnalysisResult"
+
+

--- a/clang/test/Analysis/Scalable/PointerFlow/external-inline-function-in-multi-tu.test
+++ b/clang/test/Analysis/Scalable/PointerFlow/external-inline-function-in-multi-tu.test
@@ -4,19 +4,15 @@
 // during bounds propagation.
 
 
+// DEFINE: %{extract} = %clang_cc1 -fsyntax-only -I %t --ssaf-extract-summaries=PointerFlow,UnsafeBufferUsage
+
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
 // RUN: split-file %s %t
 
 // Extract per-TU PointerFlow + UnsafeBufferUsage summaries.
-// RUN: %clang_cc1 -fsyntax-only -I %t %t/tu1.cpp \
-// RUN:   --ssaf-extract-summaries=PointerFlow \
-// RUN:   --ssaf-extract-summaries=UnsafeBufferUsage \
-// RUN:   --ssaf-tu-summary-file=%t/tu1.summary.json
-// RUN: %clang_cc1 -fsyntax-only -I %t %t/tu2.cpp \
-// RUN:   --ssaf-extract-summaries=PointerFlow \
-// RUN:   --ssaf-extract-summaries=UnsafeBufferUsage \
-// RUN:   --ssaf-tu-summary-file=%t/tu2.summary.json
+// RUN: %{extract} %t/tu1.cpp --ssaf-tu-summary-file=%t/tu1.summary.json
+// RUN: %{extract} %t/tu2.cpp --ssaf-tu-summary-file=%t/tu2.summary.json
 
 // Link the two TU summaries into a single LU summary.
 // RUN: clang-ssaf-linker %t/tu1.summary.json %t/tu2.summary.json \

--- a/clang/unittests/ScalableStaticAnalysisFramework/TUSummaryBuilderTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/TUSummaryBuilderTest.cpp
@@ -275,6 +275,7 @@ struct TUSummaryBuilderLinkageTest : TUSummaryBuilderTest {
   std::unique_ptr<ASTUnit> AST;
   static constexpr auto Internal = EntityLinkageType::Internal;
   static constexpr auto External = EntityLinkageType::External;
+  static constexpr auto None = EntityLinkageType::None;
 
   const FunctionDecl *findFnByName(StringRef Name) {
     return ssaf::findFnByName(Name, AST->getASTContext());
@@ -334,6 +335,47 @@ TEST_F(TUSummaryBuilderLinkageTest, ConstGlobalHasInternalLinkage) {
   const auto *VD = findDeclByName<VarDecl>("glob", AST->getASTContext());
   ASSERT_TRUE(VD);
   EXPECT_EQ(getLinkageFor(Extractor.addEntity(VD)), Internal);
+}
+
+// See 'getLinkageForDecl' in
+// ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractor.cpp
+
+TEST_F(TUSummaryBuilderLinkageTest, ParamOfExternalFunctionIsExternal) {
+  AST = tooling::buildASTFromCode("void target(int *ptr) {}");
+  const auto *PVD = findDeclByName<ParmVarDecl>("ptr", AST->getASTContext());
+  ASSERT_TRUE(PVD);
+  EXPECT_EQ(getLinkageFor(Extractor.addEntity(PVD)), External);
+}
+
+TEST_F(TUSummaryBuilderLinkageTest, ParamOfInlineFunctionIsExternal) {
+  AST = tooling::buildASTFromCode("inline void target(int *ptr) {}");
+  const auto *PVD = findDeclByName<ParmVarDecl>("ptr", AST->getASTContext());
+  ASSERT_TRUE(PVD);
+  EXPECT_EQ(getLinkageFor(Extractor.addEntity(PVD)), External);
+}
+
+TEST_F(TUSummaryBuilderLinkageTest, ParamOfStaticFunctionIsInternal) {
+  AST = tooling::buildASTFromCode("static void target(int *ptr) {}");
+  const auto *PVD = findDeclByName<ParmVarDecl>("ptr", AST->getASTContext());
+  ASSERT_TRUE(PVD);
+  EXPECT_EQ(getLinkageFor(Extractor.addEntity(PVD)), Internal);
+}
+
+TEST_F(TUSummaryBuilderLinkageTest, ParamOfAnonNamespaceFunctionIsInternal) {
+  AST = tooling::buildASTFromCode("namespace {\n"
+                                  "  void target(int *ptr) {}\n"
+                                  "}");
+  const auto *PVD = findDeclByName<ParmVarDecl>("ptr", AST->getASTContext());
+  ASSERT_TRUE(PVD);
+  EXPECT_EQ(getLinkageFor(Extractor.addEntity(PVD)), Internal);
+}
+
+TEST_F(TUSummaryBuilderLinkageTest, ParamOfClassMemberFunctionIsExternal) {
+  AST = tooling::buildASTFromCode(
+      "class C { public: void target(int *ptr) {} };");
+  const auto *PVD = findDeclByName<ParmVarDecl>("ptr", AST->getASTContext());
+  ASSERT_TRUE(PVD);
+  EXPECT_EQ(getLinkageFor(Extractor.addEntity(PVD)), External);
 }
 
 } // namespace

--- a/clang/unittests/ScalableStaticAnalysisFramework/TUSummaryBuilderTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/TUSummaryBuilderTest.cpp
@@ -377,4 +377,25 @@ TEST_F(TUSummaryBuilderLinkageTest, ParamOfClassMemberFunctionIsExternal) {
   EXPECT_EQ(getLinkageFor(Extractor.addEntity(PVD)), External);
 }
 
+TEST_F(TUSummaryBuilderLinkageTest, FieldOfExternalClassIsExternal) {
+  AST = tooling::buildASTFromCode("struct S { int *p; };");
+  const auto *FD = findDeclByName<FieldDecl>("p", AST->getASTContext());
+  ASSERT_TRUE(FD);
+  EXPECT_EQ(getLinkageFor(Extractor.addEntity(FD)), External);
+}
+
+TEST_F(TUSummaryBuilderLinkageTest, ReturnSlotInheritsParentLinkage) {
+  AST = tooling::buildASTFromCode("int *target() { return nullptr; }");
+  const FunctionDecl *Fn = findFnByName("target");
+  ASSERT_TRUE(Fn);
+  EXPECT_EQ(getLinkageFor(Extractor.addEntityForReturn(Fn)), External);
+}
+
+TEST_F(TUSummaryBuilderLinkageTest, ReturnSlotInheritsParentLinkageInternal) {
+  AST = tooling::buildASTFromCode("static int *target() { return nullptr; }");
+  const FunctionDecl *Fn = findFnByName("target");
+  ASSERT_TRUE(Fn);
+  EXPECT_EQ(getLinkageFor(Extractor.addEntityForReturn(Fn)), Internal);
+}
+
 } // namespace

--- a/clang/unittests/ScalableStaticAnalysisFramework/TUSummaryBuilderTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/TUSummaryBuilderTest.cpp
@@ -275,7 +275,6 @@ struct TUSummaryBuilderLinkageTest : TUSummaryBuilderTest {
   std::unique_ptr<ASTUnit> AST;
   static constexpr auto Internal = EntityLinkageType::Internal;
   static constexpr auto External = EntityLinkageType::External;
-  static constexpr auto None = EntityLinkageType::None;
 
   const FunctionDecl *findFnByName(StringRef Name) {
     return ssaf::findFnByName(Name, AST->getASTContext());


### PR DESCRIPTION
SSAF treats parameters as entities and may not always associate them back to their parent functions. Therefore, it needs to identify parameters of functions with external linkage across different TUs. Treating them as having no linkage (as in C++) causes the same parameter in different TUs to be assigned different EntityIDs. As a result, the behavior of the parameter across multiple TUs cannot be correlated.

rdar://178844032