### PR TITLE
[lldb] Fixup address in JSONUtils::ValuePointsToCode

### DIFF
--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -352,6 +352,7 @@ bool ValuePointsToCode(lldb::SBValue v) {
 
   lldb::SBError error;
   lldb::addr_t addr = v.GetData().GetAddress(error, 0);
+  addr = v.GetProcess().FixAddress(addr);
   lldb::SBLineEntry line_entry =
       v.GetTarget().ResolveLoadAddress(addr).GetLineEntry();
 


### PR DESCRIPTION
On platforms with metadata in pointers (i.e. arm64e), the address must be fixed up before requesting a load address.

This fixes TestDAP_evaluate.py for arm64e.