### PR TITLE
[compiler-rt] Add missing cstdlib include to signal_line.cpp test

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/signal_line.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/signal_line.cpp
@@ -7,6 +7,7 @@
 // RUN: %env_tool_opts=handle_segv=1:print_stacktrace=1 not %run %t 2 2>&1 | FileCheck --check-prefixes=CHECK2,CHECK %s
 
 #include <cstdio>
+#include <cstdlib>
 #include <string>
 
 // CHECK: [[SAN:.*Sanitizer]]:DEADLYSIGNAL


### PR DESCRIPTION
Fixes test after libc++ PR #195509 which drops transitive includes.