### PR TITLE
[clang-sycl-linker] Add mising dependency on BitReader

### DIFF
--- a/clang/tools/clang-sycl-linker/CMakeLists.txt
+++ b/clang/tools/clang-sycl-linker/CMakeLists.txt
@@ -2,6 +2,7 @@ set(LLVM_LINK_COMPONENTS
   ${LLVM_TARGETS_TO_BUILD}
   Analysis
   BinaryFormat
+  BitReader
   BitWriter
   Core
   FrontendOffloading


### PR DESCRIPTION
This fixes the shared library build configuration.