### PR TITLE
[clang][SSAF] Propagate parent linkage to sub-entity decls

### DIFF
--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/Model/EntityLinkage.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/Model/EntityLinkage.h
@@ -15,7 +15,7 @@
 namespace clang::ssaf {
 
 enum class EntityLinkageType {
-  None,     ///< local variables, function parameters
+  None,     ///< no linkage
   Internal, ///< static functions/variables, anonymous namespace
   External  ///< globally visible across translation units
 };

--- a/clang/lib/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractor.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractor.cpp
@@ -18,6 +18,16 @@ using namespace clang;
 using namespace ssaf;
 
 static EntityLinkageType getLinkageForDecl(const Decl *D) {
+  // Per the C++ standard, function parameter and return entities have no linkage.
+  // For the purpose of relating them across translation units, we assign them
+  // the linkage of their enclosing function.=
+  if (const auto *PVD = dyn_cast<ParmVarDecl>(D)) {
+    if (const auto *FD =
+            dyn_cast_or_null<FunctionDecl>(PVD->getParentFunctionOrMethod()))
+      return getLinkageForDecl(FD);
+    return EntityLinkageType::None;
+  }
+
   const auto *ND = dyn_cast<NamedDecl>(D);
   if (!ND)
     return EntityLinkageType::None;

--- a/clang/unittests/ScalableStaticAnalysisFramework/TUSummaryBuilderTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/TUSummaryBuilderTest.cpp
@@ -336,4 +336,55 @@ TEST_F(TUSummaryBuilderLinkageTest, ConstGlobalHasInternalLinkage) {
   EXPECT_EQ(getLinkageFor(Extractor.addEntity(VD)), Internal);
 }
 
+TEST_F(TUSummaryBuilderLinkageTest, ParamOfExternalFunctionIsExternal) {
+  AST = tooling::buildASTFromCode("void target(int *p) {}");
+  const auto *PVD = findDeclByName<ParmVarDecl>("p", AST->getASTContext());
+  ASSERT_TRUE(PVD);
+  EXPECT_EQ(getLinkageFor(Extractor.addEntity(PVD)), External);
+}
+
+TEST_F(TUSummaryBuilderLinkageTest, ParamOfInlineFunctionIsExternal) {
+  AST = tooling::buildASTFromCode("inline void target(int *p) {}");
+  const auto *PVD = findDeclByName<ParmVarDecl>("p", AST->getASTContext());
+  ASSERT_TRUE(PVD);
+  EXPECT_EQ(getLinkageFor(Extractor.addEntity(PVD)), External);
+}
+
+TEST_F(TUSummaryBuilderLinkageTest, ParamOfStaticFunctionIsInternal) {
+  AST = tooling::buildASTFromCode("static void target(int *p) {}");
+  const auto *PVD = findDeclByName<ParmVarDecl>("p", AST->getASTContext());
+  ASSERT_TRUE(PVD);
+  EXPECT_EQ(getLinkageFor(Extractor.addEntity(PVD)), Internal);
+}
+
+TEST_F(TUSummaryBuilderLinkageTest, ParamOfAnonNamespaceFunctionIsInternal) {
+  AST = tooling::buildASTFromCode("namespace {\n"
+                                  "  void target(int *p) {}\n"
+                                  "}");
+  const auto *PVD = findDeclByName<ParmVarDecl>("p", AST->getASTContext());
+  ASSERT_TRUE(PVD);
+  EXPECT_EQ(getLinkageFor(Extractor.addEntity(PVD)), Internal);
+}
+
+TEST_F(TUSummaryBuilderLinkageTest, FieldOfExternalClassIsExternal) {
+  AST = tooling::buildASTFromCode("struct S { int *p; };");
+  const auto *FD = findDeclByName<FieldDecl>("p", AST->getASTContext());
+  ASSERT_TRUE(FD);
+  EXPECT_EQ(getLinkageFor(Extractor.addEntity(FD)), External);
+}
+
+TEST_F(TUSummaryBuilderLinkageTest, ReturnSlotInheritsParentLinkage) {
+  AST = tooling::buildASTFromCode("int *target() { return nullptr; }");
+  const FunctionDecl *Fn = findFnByName("target");
+  ASSERT_TRUE(Fn);
+  EXPECT_EQ(getLinkageFor(Extractor.addEntityForReturn(Fn)), External);
+}
+
+TEST_F(TUSummaryBuilderLinkageTest, ReturnSlotInheritsParentLinkageInternal) {
+  AST = tooling::buildASTFromCode("static int *target() { return nullptr; }");
+  const FunctionDecl *Fn = findFnByName("target");
+  ASSERT_TRUE(Fn);
+  EXPECT_EQ(getLinkageFor(Extractor.addEntityForReturn(Fn)), Internal);
+}
+
 } // namespace


### PR DESCRIPTION
A sub-entity's cross-TU identity is derived from its parent context. clang-ssaf-linker links entities based on the linkage alone; without propagation, function parameter and return value entities would never get related.