### PR TITLE
[compiler-rt] Add missing test stdlib.h include

### DIFF
--- a/compiler-rt/test/hwasan/TestCases/try-catch.cpp
+++ b/compiler-rt/test/hwasan/TestCases/try-catch.cpp
@@ -16,6 +16,7 @@
 #include <pthread.h>
 #include <sanitizer/hwasan_interface.h>
 #include <stdexcept>
+#include <stdlib.h>
 #include <string.h>
 
 static void optimization_barrier(void* arg) {


### PR DESCRIPTION
Fixes test after libc++ PR #195509 which drops transitive includes.