### PR TITLE
[Frontend][Offloading] Fix GCC 7 build error in ArchiveLinker

### DIFF
--- a/llvm/lib/Frontend/Offloading/ArchiveLinker.cpp
+++ b/llvm/lib/Frontend/Offloading/ArchiveLinker.cpp
@@ -294,7 +294,7 @@ resolveArchiveMembers(ArrayRef<InputDesc> Order,
     }
   }
 
-  return Result;
+  return std::move(Result);
 }
 
 } // namespace offloading


### PR DESCRIPTION
GCC 7 cannot perform implicit move construction when converting `ResolvedInputs` to `Expected<ResolvedInputs>`.

The issue is exposed in [this comment](https://github.com/llvm/llvm-project/pull/201253#issuecomment-4636496605).