### PR TITLE
[clang][driver][darwin] DarwinSDKInfo fails to match 32 bit arm targets

### DIFF
--- a/clang/include/clang/Basic/DarwinSDKInfo.h
+++ b/clang/include/clang/Basic/DarwinSDKInfo.h
@@ -237,14 +237,7 @@ public:
                              const llvm::json::Object *Obj);
 
 private:
-  const SDKPlatformInfo *getPlatformInfo(const llvm::Triple &Triple) const {
-    for (const SDKPlatformInfo &PlatformInfo : PlatformInfos) {
-      const auto &Triples = PlatformInfo.getTriples();
-      if (llvm::find(Triples, Triple) != Triples.end())
-        return &PlatformInfo;
-    }
-    return nullptr;
-  }
+  const SDKPlatformInfo *getPlatformInfo(const llvm::Triple &Triple) const;
 
   std::string FilePath;
   llvm::Triple::OSType OS;

--- a/clang/lib/Basic/DarwinSDKInfo.cpp
+++ b/clang/lib/Basic/DarwinSDKInfo.cpp
@@ -12,6 +12,7 @@
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
+#include "llvm/TargetParser/ARMTargetParser.h"
 #include <optional>
 
 using namespace clang;
@@ -203,7 +204,7 @@ static DarwinSDKInfo::PlatformInfoStorageType parsePlatformInfos(
         SupportedTarget->getString("LLVMTargetTripleEnvironment");
     for (const auto &ArchValue : *Archs) {
       if (auto Arch = ArchValue.getAsString()) {
-        if (Environment)
+        if (Environment && !Environment->empty())
           Triples.emplace_back(*Arch, *Vendor, *OS, *Environment);
         else
           Triples.emplace_back(*Arch, *Vendor, *OS);
@@ -349,3 +350,25 @@ DarwinSDKInfo::DarwinSDKInfo(llvm::Triple::OSType OS,
     : DarwinSDKInfo("", OS, Environment, Version, DisplayName,
                     MaximumDeploymentTarget,
                     legacyPlatformInfos(OS, Environment)) {}
+
+const DarwinSDKInfo::SDKPlatformInfo *
+DarwinSDKInfo::getPlatformInfo(const llvm::Triple &Triple) const {
+  for (const DarwinSDKInfo::SDKPlatformInfo &PlatformInfo : PlatformInfos) {
+    const auto &Triples = PlatformInfo.getTriples();
+    if (llvm::find(Triples, Triple) != Triples.end())
+      return &PlatformInfo;
+  }
+  // Darwin usually specifies 32 bit ARM as "arm", but
+  // ToolChain::ComputeLLVMTriple(...) will often change that to "thumb". If
+  // there's no matching triple for thumb, look for an arm one instead.
+  if (Triple.getArch() == llvm::Triple::thumb) {
+    llvm::Triple ARMTriple(Triple);
+    llvm::ARM::ArchKind ArchKind =
+        llvm::ARM::parseArch(ARMTriple.getArchName());
+    ARMTriple.setArchName((llvm::Triple::getArchName(llvm::Triple::arm) +
+                           llvm::ARM::getSubArch(ArchKind).str())
+                              .str());
+    return getPlatformInfo(ARMTriple);
+  }
+  return nullptr;
+}

--- a/clang/test/Driver/incompatible_sysroot.c
+++ b/clang/test/Driver/incompatible_sysroot.c
@@ -9,6 +9,7 @@
 // RUN: %clang -target x86_64-apple-darwin -Wincompatible-sysroot -isysroot SDKs/iPhoneSimulator9.2.sdk -mios-version-min=9.0 -S -o - %s 2>&1 | FileCheck -check-prefix CHECK-IOS-IOSSIM %s
 // RUN: %clang -target x86_64-apple-darwin -Wno-incompatible-sysroot -isysroot SDKs/MacOSX10.9.sdk -mios-version-min=9.0 -S -o - %s 2>&1 | FileCheck -check-prefix CHECK-OSX-IOS-DISABLED %s
 
+// RUN: %clang -target armv7k-apple-watchos6.0 -Wincompatible-sysroot -isysroot %S/Inputs/WatchOS6.0.sdk -S -o - %s 2>&1 | FileCheck -check-prefix CHECK-WATCHOS %s
 // RUN: %clang -target arm64-apple-visionos1.0-simulator -Wincompatible-sysroot -isysroot %S/Inputs/XRSimulator1.0.sdk -S -o - %s 2>&1 | FileCheck -check-prefix CHECK-VISIONOSSIM %s
 // RUN: %clang -target arm64-apple-xros1.0 -Wincompatible-sysroot -isysroot %S/Inputs/XRSimulator1.0.sdk -S -o - %s 2>&1 | FileCheck -check-prefix CHECK-VISIONOSSIM-VISIONOS %s
 // RUN: %clang -target arm64-apple-ios17.1 -Wincompatible-sysroot -isysroot %S/Inputs/XRSimulator1.0.sdk -S -o - %s 2>&1 | FileCheck -check-prefix CHECK-VISIONOSSIM-IOS %s
@@ -23,6 +24,7 @@ int main() { return 0; }
 // CHECK-IOS-IOSSIM-NOT: warning: using sysroot for '{{.*}}' but targeting '{{.*}}'
 // CHECK-OSX-IOS-DISABLED-NOT: warning: using sysroot for '{{.*}}' but targeting '{{.*}}'
 
+// CHECK-WATCHOS-NOT: warning: using sysroot for '{{.*}}' but targeting '{{.*}}'
 // CHECK-VISIONOSSIM-NOT: warning: using sysroot for '{{.*}}' but targeting '{{.*}}'
 // CHECK-VISIONOSSIM-VISIONOS: warning: using sysroot for 'Simulator - visionOS 1.0' but targeting 'arm64-apple-xros1.0.0'
 // CHECK-VISIONOSSIM-IOS: warning: using sysroot for 'Simulator - visionOS 1.0' but targeting 'arm64-apple-ios17.1.0'


### PR DESCRIPTION
ToolChain::ComputeLLVMTriple(...) transforms arm*m and armv7 in Mach-O to thumb. In other words, 32 bit arm on Apple platforms pretty much always gets converted to thumb. That fails to match against DarwinSDKInfo which is set up with arm and doesn't go through the same driver transform. Repeating the transform in DarwinSDKInfo is impossible, since it relies on several other arguments like -march and -mcpu, and those don't apply to all triples in DarwinSDKInfo. Instead, if a thumb comparison fails, try an arm comparison.

rdar://178762118