### PR TITLE
[X86] Replace alignedstore/alignedload custom predicates with MinAlignment. NFC

### DIFF
--- a/llvm/lib/Target/X86/X86InstrAVX512.td
+++ b/llvm/lib/Target/X86/X86InstrAVX512.td
@@ -3424,13 +3424,13 @@ multiclass avx512_alignedstore_vl<bits<8> opc, string OpcodeStr,
                                   X86SchedWriteMoveLSWidths Sched,
                                   bit NoMRPattern = 0> {
   let Predicates = [prd] in
-  defm Z : avx512_store<opc, OpcodeStr, NAME, _.info512, alignedstore,
+  defm Z : avx512_store<opc, OpcodeStr, NAME, _.info512, alignedstore512,
                         masked_store_aligned, Sched.ZMM, NoMRPattern>, EVEX_V512;
 
   let Predicates = [prd, HasVLX] in {
-    defm Z256 : avx512_store<opc, OpcodeStr, NAME, _.info256, alignedstore,
+    defm Z256 : avx512_store<opc, OpcodeStr, NAME, _.info256, alignedstore256,
                              masked_store_aligned, Sched.YMM, NoMRPattern>, EVEX_V256;
-    defm Z128 : avx512_store<opc, OpcodeStr, NAME, _.info128, alignedstore,
+    defm Z128 : avx512_store<opc, OpcodeStr, NAME, _.info128, alignedstore128,
                              masked_store_aligned, Sched.XMM, NoMRPattern>, EVEX_V128;
   }
 }
@@ -3615,15 +3615,15 @@ let Predicates = [HasAVX512] in {
             (VMOVDQU64Zrm addr:$src)>;
 
   // 512-bit store.
-  def : Pat<(alignedstore (v16i32 VR512:$src), addr:$dst),
+  def : Pat<(alignedstore512 (v16i32 VR512:$src), addr:$dst),
             (VMOVDQA64Zmr addr:$dst, VR512:$src)>;
-  def : Pat<(alignedstore (v32i16 VR512:$src), addr:$dst),
+  def : Pat<(alignedstore512 (v32i16 VR512:$src), addr:$dst),
             (VMOVDQA64Zmr addr:$dst, VR512:$src)>;
-  def : Pat<(alignedstore (v32f16 VR512:$src), addr:$dst),
+  def : Pat<(alignedstore512 (v32f16 VR512:$src), addr:$dst),
             (VMOVAPSZmr addr:$dst, VR512:$src)>;
-  def : Pat<(alignedstore (v32bf16 VR512:$src), addr:$dst),
+  def : Pat<(alignedstore512 (v32bf16 VR512:$src), addr:$dst),
             (VMOVAPSZmr addr:$dst, VR512:$src)>;
-  def : Pat<(alignedstore (v64i8 VR512:$src), addr:$dst),
+  def : Pat<(alignedstore512 (v64i8 VR512:$src), addr:$dst),
             (VMOVDQA64Zmr addr:$dst, VR512:$src)>;
   def : Pat<(store (v16i32 VR512:$src), addr:$dst),
             (VMOVDQU64Zmr addr:$dst, VR512:$src)>;
@@ -3661,15 +3661,15 @@ let Predicates = [HasVLX] in {
             (VMOVDQU64Z128rm addr:$src)>;
 
   // 128-bit store.
-  def : Pat<(alignedstore (v4i32 VR128X:$src), addr:$dst),
+  def : Pat<(alignedstore128 (v4i32 VR128X:$src), addr:$dst),
             (VMOVDQA64Z128mr addr:$dst, VR128X:$src)>;
-  def : Pat<(alignedstore (v8i16 VR128X:$src), addr:$dst),
+  def : Pat<(alignedstore128 (v8i16 VR128X:$src), addr:$dst),
             (VMOVDQA64Z128mr addr:$dst, VR128X:$src)>;
-  def : Pat<(alignedstore (v8f16 VR128X:$src), addr:$dst),
+  def : Pat<(alignedstore128 (v8f16 VR128X:$src), addr:$dst),
             (VMOVAPSZ128mr addr:$dst, VR128X:$src)>;
-  def : Pat<(alignedstore (v8bf16 VR128X:$src), addr:$dst),
+  def : Pat<(alignedstore128 (v8bf16 VR128X:$src), addr:$dst),
             (VMOVAPSZ128mr addr:$dst, VR128X:$src)>;
-  def : Pat<(alignedstore (v16i8 VR128X:$src), addr:$dst),
+  def : Pat<(alignedstore128 (v16i8 VR128X:$src), addr:$dst),
             (VMOVDQA64Z128mr addr:$dst, VR128X:$src)>;
   def : Pat<(store (v4i32 VR128X:$src), addr:$dst),
             (VMOVDQU64Z128mr addr:$dst, VR128X:$src)>;
@@ -3705,15 +3705,15 @@ let Predicates = [HasVLX] in {
             (VMOVDQU64Z256rm addr:$src)>;
 
   // 256-bit store.
-  def : Pat<(alignedstore (v8i32 VR256X:$src), addr:$dst),
+  def : Pat<(alignedstore256 (v8i32 VR256X:$src), addr:$dst),
             (VMOVDQA64Z256mr addr:$dst, VR256X:$src)>;
-  def : Pat<(alignedstore (v16i16 VR256X:$src), addr:$dst),
+  def : Pat<(alignedstore256 (v16i16 VR256X:$src), addr:$dst),
             (VMOVDQA64Z256mr addr:$dst, VR256X:$src)>;
-  def : Pat<(alignedstore (v16f16 VR256X:$src), addr:$dst),
+  def : Pat<(alignedstore256 (v16f16 VR256X:$src), addr:$dst),
             (VMOVAPSZ256mr addr:$dst, VR256X:$src)>;
-  def : Pat<(alignedstore (v16bf16 VR256X:$src), addr:$dst),
+  def : Pat<(alignedstore256 (v16bf16 VR256X:$src), addr:$dst),
             (VMOVAPSZ256mr addr:$dst, VR256X:$src)>;
-  def : Pat<(alignedstore (v32i8 VR256X:$src), addr:$dst),
+  def : Pat<(alignedstore256 (v32i8 VR256X:$src), addr:$dst),
             (VMOVDQA64Z256mr addr:$dst, VR256X:$src)>;
   def : Pat<(store (v8i32 VR256X:$src), addr:$dst),
             (VMOVDQU64Z256mr addr:$dst, VR256X:$src)>;

--- a/llvm/lib/Target/X86/X86InstrFragmentsSIMD.td
+++ b/llvm/lib/Target/X86/X86InstrFragmentsSIMD.td
@@ -1255,83 +1255,80 @@ def extloadv8f16 : PatFrag<(ops node:$ptr), (extloadvf16 node:$ptr)>;
 def extloadv16f16 : PatFrag<(ops node:$ptr), (extloadvf16 node:$ptr)>;
 
 // Like 'store', but always requires vector size alignment.
-def alignedstore : PatFrag<(ops node:$val, node:$ptr),
-                           (store node:$val, node:$ptr), [{
-  auto *St = cast<StoreSDNode>(N);
-  return St->getAlign() >= St->getMemoryVT().getStoreSize();
-}]> {
-  let GISelPredicateCode = [{
-    auto &LdSt = cast<GLoadStore>(MI);
-    return LdSt.getAlign() >= LdSt.getMemSize().getValue();
-  }];
+class alignedstore_frag<int Alignment>
+    : PatFrag<(ops node:$val, node:$ptr), (store node:$val, node:$ptr)> {
+  let IsStore = true;
+  let MinAlignment = Alignment;
 }
+def alignedstore128 : alignedstore_frag<16>;
+def alignedstore256 : alignedstore_frag<32>;
+def alignedstore512 : alignedstore_frag<64>;
 
 // Like 'load', but always requires vector size alignment.
-def alignedload : PatFrag<(ops node:$ptr), (load node:$ptr), [{
-  auto *Ld = cast<LoadSDNode>(N);
-  return Ld->getAlign() >= Ld->getMemoryVT().getStoreSize();
-}]> {
-  let GISelPredicateCode = [{
-    auto &LdSt = cast<GLoadStore>(MI);
-    return LdSt.getAlign() >= LdSt.getMemSize().getValue();
-  }];
+class alignedload_frag<int Alignment>
+    : PatFrag<(ops node:$ptr), (load node:$ptr)> {
+  let IsLoad = true;
+  let MinAlignment = Alignment;
 }
+def alignedload128 : alignedload_frag<16>;
+def alignedload256 : alignedload_frag<32>;
+def alignedload512 : alignedload_frag<64>;
 
 // 128-bit aligned load pattern fragments
 // NOTE: all 128-bit integer vector loads are promoted to v2i64
 def alignedloadv8f16 : PatFrag<(ops node:$ptr),
-                               (v8f16 (alignedload node:$ptr))>;
+                               (v8f16 (alignedload128 node:$ptr))>;
 def alignedloadv8bf16 : PatFrag<(ops node:$ptr),
-                                (v8bf16 (alignedload node:$ptr))>;
+                                (v8bf16 (alignedload128 node:$ptr))>;
 def alignedloadv4f32 : PatFrag<(ops node:$ptr),
-                               (v4f32 (alignedload node:$ptr))>;
+                               (v4f32 (alignedload128 node:$ptr))>;
 def alignedloadv2f64 : PatFrag<(ops node:$ptr),
-                               (v2f64 (alignedload node:$ptr))>;
+                               (v2f64 (alignedload128 node:$ptr))>;
 def alignedloadv2i64 : PatFrag<(ops node:$ptr),
-                               (v2i64 (alignedload node:$ptr))>;
+                               (v2i64 (alignedload128 node:$ptr))>;
 def alignedloadv4i32 : PatFrag<(ops node:$ptr),
-                               (v4i32 (alignedload node:$ptr))>;
+                               (v4i32 (alignedload128 node:$ptr))>;
 def alignedloadv8i16 : PatFrag<(ops node:$ptr),
-                               (v8i16 (alignedload node:$ptr))>;
+                               (v8i16 (alignedload128 node:$ptr))>;
 def alignedloadv16i8 : PatFrag<(ops node:$ptr),
-                               (v16i8 (alignedload node:$ptr))>;
+                               (v16i8 (alignedload128 node:$ptr))>;
 
 // 256-bit aligned load pattern fragments
 // NOTE: all 256-bit integer vector loads are promoted to v4i64
 def alignedloadv16f16 : PatFrag<(ops node:$ptr),
-                                (v16f16 (alignedload node:$ptr))>;
+                                (v16f16 (alignedload256 node:$ptr))>;
 def alignedloadv16bf16 : PatFrag<(ops node:$ptr),
-                                 (v16bf16 (alignedload node:$ptr))>;
+                                 (v16bf16 (alignedload256 node:$ptr))>;
 def alignedloadv8f32  : PatFrag<(ops node:$ptr),
-                                (v8f32  (alignedload node:$ptr))>;
+                                (v8f32  (alignedload256 node:$ptr))>;
 def alignedloadv4f64  : PatFrag<(ops node:$ptr),
-                                (v4f64  (alignedload node:$ptr))>;
+                                (v4f64  (alignedload256 node:$ptr))>;
 def alignedloadv4i64  : PatFrag<(ops node:$ptr),
-                                (v4i64  (alignedload node:$ptr))>;
+                                (v4i64  (alignedload256 node:$ptr))>;
 def alignedloadv8i32  : PatFrag<(ops node:$ptr),
-                                (v8i32  (alignedload node:$ptr))>;
+                                (v8i32  (alignedload256 node:$ptr))>;
 def alignedloadv16i16 : PatFrag<(ops node:$ptr),
-                                (v16i16 (alignedload node:$ptr))>;
+                                (v16i16 (alignedload256 node:$ptr))>;
 def alignedloadv32i8  : PatFrag<(ops node:$ptr),
-                                (v32i8  (alignedload node:$ptr))>;
+                                (v32i8  (alignedload256 node:$ptr))>;
 
 // 512-bit aligned load pattern fragments
 def alignedloadv32f16 : PatFrag<(ops node:$ptr),
-                                (v32f16 (alignedload node:$ptr))>;
+                                (v32f16 (alignedload512 node:$ptr))>;
 def alignedloadv32bf16 : PatFrag<(ops node:$ptr),
-                                 (v32bf16 (alignedload node:$ptr))>;
+                                 (v32bf16 (alignedload512 node:$ptr))>;
 def alignedloadv16f32 : PatFrag<(ops node:$ptr),
-                                (v16f32 (alignedload node:$ptr))>;
+                                (v16f32 (alignedload512 node:$ptr))>;
 def alignedloadv8f64  : PatFrag<(ops node:$ptr),
-                                (v8f64  (alignedload node:$ptr))>;
+                                (v8f64  (alignedload512 node:$ptr))>;
 def alignedloadv8i64  : PatFrag<(ops node:$ptr),
-                                (v8i64  (alignedload node:$ptr))>;
+                                (v8i64  (alignedload512 node:$ptr))>;
 def alignedloadv16i32 : PatFrag<(ops node:$ptr),
-                                (v16i32 (alignedload node:$ptr))>;
+                                (v16i32 (alignedload512 node:$ptr))>;
 def alignedloadv32i16 : PatFrag<(ops node:$ptr),
-                                (v32i16 (alignedload node:$ptr))>;
+                                (v32i16 (alignedload512 node:$ptr))>;
 def alignedloadv64i8  : PatFrag<(ops node:$ptr),
-                                (v64i8  (alignedload node:$ptr))>;
+                                (v64i8  (alignedload512 node:$ptr))>;
 
 // Like 'load', but uses special alignment checks suitable for use in
 // memory operands in most SSE instructions, which are required to

--- a/llvm/lib/Target/X86/X86InstrSSE.td
+++ b/llvm/lib/Target/X86/X86InstrSSE.td
@@ -410,11 +410,11 @@ let Predicates = [HasAVX, NoVLX]  in {
 let SchedRW = [SchedWriteFMoveLS.XMM.MR] in {
 def VMOVAPSmr : VPSI<0x29, MRMDestMem, (outs), (ins f128mem:$dst, VR128:$src),
                    "movaps\t{$src, $dst|$dst, $src}",
-                   [(alignedstore (v4f32 VR128:$src), addr:$dst)]>,
+                   [(alignedstore128 (v4f32 VR128:$src), addr:$dst)]>,
                    VEX, WIG;
 def VMOVAPDmr : VPDI<0x29, MRMDestMem, (outs), (ins f128mem:$dst, VR128:$src),
                    "movapd\t{$src, $dst|$dst, $src}",
-                   [(alignedstore (v2f64 VR128:$src), addr:$dst)]>,
+                   [(alignedstore128 (v2f64 VR128:$src), addr:$dst)]>,
                    VEX, WIG;
 def VMOVUPSmr : VPSI<0x11, MRMDestMem, (outs), (ins f128mem:$dst, VR128:$src),
                    "movups\t{$src, $dst|$dst, $src}",
@@ -429,11 +429,11 @@ def VMOVUPDmr : VPDI<0x11, MRMDestMem, (outs), (ins f128mem:$dst, VR128:$src),
 let SchedRW = [SchedWriteFMoveLS.YMM.MR] in {
 def VMOVAPSYmr : VPSI<0x29, MRMDestMem, (outs), (ins f256mem:$dst, VR256:$src),
                    "movaps\t{$src, $dst|$dst, $src}",
-                   [(alignedstore (v8f32 VR256:$src), addr:$dst)]>,
+                   [(alignedstore256 (v8f32 VR256:$src), addr:$dst)]>,
                    VEX, VEX_L, WIG;
 def VMOVAPDYmr : VPDI<0x29, MRMDestMem, (outs), (ins f256mem:$dst, VR256:$src),
                    "movapd\t{$src, $dst|$dst, $src}",
-                   [(alignedstore (v4f64 VR256:$src), addr:$dst)]>,
+                   [(alignedstore256 (v4f64 VR256:$src), addr:$dst)]>,
                    VEX, VEX_L, WIG;
 def VMOVUPSYmr : VPSI<0x11, MRMDestMem, (outs), (ins f256mem:$dst, VR256:$src),
                    "movups\t{$src, $dst|$dst, $src}",
@@ -509,10 +509,10 @@ def : InstAlias<"vmovupd.s\t{$src, $dst|$dst, $src}",
 let SchedRW = [SchedWriteFMoveLS.XMM.MR] in {
 def MOVAPSmr : PSI<0x29, MRMDestMem, (outs), (ins f128mem:$dst, VR128:$src),
                    "movaps\t{$src, $dst|$dst, $src}",
-                   [(alignedstore (v4f32 VR128:$src), addr:$dst)]>;
+                   [(alignedstore128 (v4f32 VR128:$src), addr:$dst)]>;
 def MOVAPDmr : PDI<0x29, MRMDestMem, (outs), (ins f128mem:$dst, VR128:$src),
                    "movapd\t{$src, $dst|$dst, $src}",
-                   [(alignedstore (v2f64 VR128:$src), addr:$dst)]>;
+                   [(alignedstore128 (v2f64 VR128:$src), addr:$dst)]>;
 def MOVUPSmr : PSI<0x11, MRMDestMem, (outs), (ins f128mem:$dst, VR128:$src),
                    "movups\t{$src, $dst|$dst, $src}",
                    [(store (v4f32 VR128:$src), addr:$dst)]>;
@@ -565,13 +565,13 @@ let Predicates = [HasAVX, NoVLX] in {
   def : Pat<(loadv32i8 addr:$src),
             (VMOVUPSYrm addr:$src)>;
 
-  def : Pat<(alignedstore (v4i64 VR256:$src), addr:$dst),
+  def : Pat<(alignedstore256 (v4i64 VR256:$src), addr:$dst),
             (VMOVAPSYmr addr:$dst, VR256:$src)>;
-  def : Pat<(alignedstore (v8i32 VR256:$src), addr:$dst),
+  def : Pat<(alignedstore256 (v8i32 VR256:$src), addr:$dst),
             (VMOVAPSYmr addr:$dst, VR256:$src)>;
-  def : Pat<(alignedstore (v16i16 VR256:$src), addr:$dst),
+  def : Pat<(alignedstore256 (v16i16 VR256:$src), addr:$dst),
             (VMOVAPSYmr addr:$dst, VR256:$src)>;
-  def : Pat<(alignedstore (v32i8 VR256:$src), addr:$dst),
+  def : Pat<(alignedstore256 (v32i8 VR256:$src), addr:$dst),
             (VMOVAPSYmr addr:$dst, VR256:$src)>;
   def : Pat<(store (v4i64 VR256:$src), addr:$dst),
             (VMOVUPSYmr addr:$dst, VR256:$src)>;
@@ -590,9 +590,9 @@ let Predicates = [HasAVX, NoVLX] in {
             (VMOVUPSrm addr:$src)>;
   def : Pat<(loadv8bf16 addr:$src),
             (VMOVUPSrm addr:$src)>;
-  def : Pat<(alignedstore (v8f16 VR128:$src), addr:$dst),
+  def : Pat<(alignedstore128 (v8f16 VR128:$src), addr:$dst),
             (VMOVAPSmr addr:$dst, VR128:$src)>;
-  def : Pat<(alignedstore (v8bf16 VR128:$src), addr:$dst),
+  def : Pat<(alignedstore128 (v8bf16 VR128:$src), addr:$dst),
             (VMOVAPSmr addr:$dst, VR128:$src)>;
   def : Pat<(store (v8f16 VR128:$src), addr:$dst),
             (VMOVUPSmr addr:$dst, VR128:$src)>;
@@ -607,9 +607,9 @@ let Predicates = [HasAVX, NoVLX] in {
             (VMOVUPSYrm addr:$src)>;
   def : Pat<(loadv16bf16 addr:$src),
             (VMOVUPSYrm addr:$src)>;
-  def : Pat<(alignedstore (v16f16 VR256:$src), addr:$dst),
+  def : Pat<(alignedstore256 (v16f16 VR256:$src), addr:$dst),
             (VMOVAPSYmr addr:$dst, VR256:$src)>;
-  def : Pat<(alignedstore (v16bf16 VR256:$src), addr:$dst),
+  def : Pat<(alignedstore256 (v16bf16 VR256:$src), addr:$dst),
             (VMOVAPSYmr addr:$dst, VR256:$src)>;
   def : Pat<(store (v16f16 VR256:$src), addr:$dst),
             (VMOVUPSYmr addr:$dst, VR256:$src)>;
@@ -638,13 +638,13 @@ let Predicates = [UseSSE1] in {
   def : Pat<(loadv16i8 addr:$src),
             (MOVUPSrm addr:$src)>;
 
-  def : Pat<(alignedstore (v2i64 VR128:$src), addr:$dst),
+  def : Pat<(alignedstore128 (v2i64 VR128:$src), addr:$dst),
             (MOVAPSmr addr:$dst, VR128:$src)>;
-  def : Pat<(alignedstore (v4i32 VR128:$src), addr:$dst),
+  def : Pat<(alignedstore128 (v4i32 VR128:$src), addr:$dst),
             (MOVAPSmr addr:$dst, VR128:$src)>;
-  def : Pat<(alignedstore (v8i16 VR128:$src), addr:$dst),
+  def : Pat<(alignedstore128 (v8i16 VR128:$src), addr:$dst),
             (MOVAPSmr addr:$dst, VR128:$src)>;
-  def : Pat<(alignedstore (v16i8 VR128:$src), addr:$dst),
+  def : Pat<(alignedstore128 (v16i8 VR128:$src), addr:$dst),
             (MOVAPSmr addr:$dst, VR128:$src)>;
   def : Pat<(store (v2i64 VR128:$src), addr:$dst),
             (MOVUPSmr addr:$dst, VR128:$src)>;
@@ -661,7 +661,7 @@ let Predicates = [UseSSE2] in {
             (MOVAPSrm addr:$src)>;
   def : Pat<(loadv8f16 addr:$src),
             (MOVUPSrm addr:$src)>;
-  def : Pat<(alignedstore (v8f16 VR128:$src), addr:$dst),
+  def : Pat<(alignedstore128 (v8f16 VR128:$src), addr:$dst),
             (MOVAPSmr addr:$dst, VR128:$src)>;
   def : Pat<(store (v8f16 VR128:$src), addr:$dst),
             (MOVUPSmr addr:$dst, VR128:$src)>;
@@ -3363,7 +3363,7 @@ let mayStore = 1, hasSideEffects = 0, Predicates = [HasAVX,NoVLX] in {
 def VMOVDQAmr  : VPDI<0x7F, MRMDestMem, (outs),
                       (ins i128mem:$dst, VR128:$src),
                       "movdqa\t{$src, $dst|$dst, $src}",
-                      [(alignedstore (v2i64 VR128:$src), addr:$dst)]>,
+                      [(alignedstore128 (v2i64 VR128:$src), addr:$dst)]>,
                       Sched<[SchedWriteVecMoveLS.XMM.MR]>, VEX, WIG;
 def VMOVDQAYmr : VPDI<0x7F, MRMDestMem, (outs),
                       (ins i256mem:$dst, VR256:$src),
@@ -3414,7 +3414,7 @@ let mayStore = 1, hasSideEffects = 0,
     SchedRW = [SchedWriteVecMoveLS.XMM.MR] in {
 def MOVDQAmr : PDI<0x7F, MRMDestMem, (outs), (ins i128mem:$dst, VR128:$src),
                    "movdqa\t{$src, $dst|$dst, $src}",
-                   [/*(alignedstore (v2i64 VR128:$src), addr:$dst)*/]>;
+                   [/*(alignedstore128 (v2i64 VR128:$src), addr:$dst)*/]>;
 def MOVDQUmr :   I<0x7F, MRMDestMem, (outs), (ins i128mem:$dst, VR128:$src),
                    "movdqu\t{$src, $dst|$dst, $src}",
                    [/*(store (v2i64 VR128:$src), addr:$dst)*/]>,
@@ -3458,13 +3458,13 @@ let Predicates = [HasAVX, NoVLX] in {
   def : Pat<(loadv16i8 addr:$src),
             (VMOVDQUrm addr:$src)>;
 
-  def : Pat<(alignedstore (v4i32 VR128:$src), addr:$dst),
+  def : Pat<(alignedstore128 (v4i32 VR128:$src), addr:$dst),
             (VMOVDQAmr addr:$dst, VR128:$src)>;
-  def : Pat<(alignedstore (v8i16 VR128:$src), addr:$dst),
+  def : Pat<(alignedstore128 (v8i16 VR128:$src), addr:$dst),
             (VMOVDQAmr addr:$dst, VR128:$src)>;
-  def : Pat<(alignedstore (v8f16 VR128:$src), addr:$dst),
+  def : Pat<(alignedstore128 (v8f16 VR128:$src), addr:$dst),
             (VMOVDQAmr addr:$dst, VR128:$src)>;
-  def : Pat<(alignedstore (v16i8 VR128:$src), addr:$dst),
+  def : Pat<(alignedstore128 (v16i8 VR128:$src), addr:$dst),
             (VMOVDQAmr addr:$dst, VR128:$src)>;
   def : Pat<(store (v4i32 VR128:$src), addr:$dst),
             (VMOVDQUmr addr:$dst, VR128:$src)>;

--- a/llvm/lib/Target/X86/X86InstrVecCompiler.td
+++ b/llvm/lib/Target/X86/X86InstrVecCompiler.td
@@ -388,7 +388,7 @@ let Predicates = [HasBWI] in {
 
 // movaps is shorter than movdqa. movaps is in SSE and movdqa is in SSE2.
 let Predicates = [NoAVX] in {
-def : Pat<(alignedstore (f128 VR128:$src), addr:$dst),
+def : Pat<(alignedstore128 (f128 VR128:$src), addr:$dst),
           (MOVAPSmr addr:$dst, VR128:$src)>;
 def : Pat<(store (f128 VR128:$src), addr:$dst),
           (MOVUPSmr addr:$dst, VR128:$src)>;
@@ -400,7 +400,7 @@ def : Pat<(loadf128 addr:$src),
 }
 
 let Predicates = [HasAVX, NoVLX] in {
-def : Pat<(alignedstore (f128 VR128:$src), addr:$dst),
+def : Pat<(alignedstore128 (f128 VR128:$src), addr:$dst),
           (VMOVAPSmr addr:$dst, VR128:$src)>;
 def : Pat<(store (f128 VR128:$src), addr:$dst),
           (VMOVUPSmr addr:$dst, VR128:$src)>;
@@ -412,7 +412,7 @@ def : Pat<(loadf128 addr:$src),
 }
 
 let Predicates = [HasVLX] in {
-def : Pat<(alignedstore (f128 VR128X:$src), addr:$dst),
+def : Pat<(alignedstore128 (f128 VR128X:$src), addr:$dst),
           (VMOVAPSZ128mr addr:$dst, VR128X:$src)>;
 def : Pat<(store (f128 VR128X:$src), addr:$dst),
           (VMOVUPSZ128mr addr:$dst, VR128X:$src)>;


### PR DESCRIPTION
These custom alignment predicates predate PatFrag's dedicated MinAlignment field. Replace them with per-size fragments (alignedstore128/256/512, alignedload128/256/512) so both SelectionDAG and GlobalISel get the alignment check without hand-written predicate code.

Stacked above https://github.com/llvm/llvm-project/pull/197860; stacked below https://github.com/llvm/llvm-project/pull/197861.