### PR TITLE
[InstCombine] Fix UB in align-assume check

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3689,8 +3689,8 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
 
         // Compute known bits for the pointer and drop the assume if the
         // known alignment isn't increased by it.
-        if ((1ULL << computeKnownBits(RK.WasOn, II).countMinTrailingZeros()) <
-            RK.ArgValue)
+        if (computeKnownBits(RK.WasOn, II).countMinTrailingZeros() <
+            Log2_64_Ceil(RK.ArgValue))
           continue;
         return CallBase::removeOperandBundleAt(II, Idx);
       }

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3690,7 +3690,7 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
         // Compute known bits for the pointer and drop the assume if the
         // known alignment isn't increased by it.
         if (computeKnownBits(RK.WasOn, II).countMinTrailingZeros() <
-            Log2_64_Ceil(RK.ArgValue))
+            Log2_64(RK.ArgValue))
           continue;
         return CallBase::removeOperandBundleAt(II, Idx);
       }

--- a/llvm/test/Transforms/InstCombine/assume-align.ll
+++ b/llvm/test/Transforms/InstCombine/assume-align.ll
@@ -272,7 +272,6 @@ define ptr @assume_align_1(ptr %p) {
 
 define ptr @redundant_assume_align_null() {
 ; CHECK-LABEL: @redundant_assume_align_null(
-; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "align"(ptr null, i64 8) ]
 ; CHECK-NEXT:    call void @foo(ptr null)
 ; CHECK-NEXT:    ret ptr null
 ;

--- a/llvm/test/Transforms/InstCombine/assume-align.ll
+++ b/llvm/test/Transforms/InstCombine/assume-align.ll
@@ -210,6 +210,19 @@ define ptr @assume_align_16_via_align_metadata(ptr %p) {
   ret ptr %p2
 }
 
+define ptr @assume_align_6_via_align_metadata(ptr %p) {
+; CHECK-LABEL: @assume_align_6_via_align_metadata(
+; CHECK-NEXT:    [[P2:%.*]] = load ptr, ptr [[P:%.*]], align 8, !align [[META1:![0-9]+]]
+; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "align"(ptr [[P2]], i64 6) ]
+; CHECK-NEXT:    call void @foo(ptr [[P2]])
+; CHECK-NEXT:    ret ptr [[P2]]
+;
+  %p2 = load ptr, ptr %p, !align !{i64 4}
+  call void @llvm.assume(i1 true) [ "align"(ptr %p2, i64 6) ]
+  call void @foo(ptr %p2)
+  ret ptr %p2
+}
+
 define ptr @redundant_assume_align_8_via_align_attribute(ptr align 8 %p) {
 ; CHECK-LABEL: @redundant_assume_align_8_via_align_attribute(
 ; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "align"(ptr [[P:%.*]], i32 8) ]
@@ -257,6 +270,17 @@ define ptr @assume_align_1(ptr %p) {
   ret ptr %p
 }
 
+define ptr @redundant_assume_align_null() {
+; CHECK-LABEL: @redundant_assume_align_null(
+; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "align"(ptr null, i64 8) ]
+; CHECK-NEXT:    call void @foo(ptr null)
+; CHECK-NEXT:    ret ptr null
+;
+  call void @llvm.assume(i1 true) [ "align"(ptr null, i64 8) ]
+  call void @foo(ptr null)
+  ret ptr null
+}
+
 declare void @foo(ptr)
 
 ; !align must have a constant integer alignment.
@@ -273,4 +297,5 @@ define ptr @assume_load_pointer_result(ptr %p, i64 %align) {
 
 ;.
 ; CHECK: [[META0]] = !{i64 8}
+; CHECK: [[META1]] = !{i64 4}
 ;.

--- a/llvm/test/Transforms/InstCombine/assume-align.ll
+++ b/llvm/test/Transforms/InstCombine/assume-align.ll
@@ -210,19 +210,6 @@ define ptr @assume_align_16_via_align_metadata(ptr %p) {
   ret ptr %p2
 }
 
-define ptr @assume_align_6_via_align_metadata(ptr %p) {
-; CHECK-LABEL: @assume_align_6_via_align_metadata(
-; CHECK-NEXT:    [[P2:%.*]] = load ptr, ptr [[P:%.*]], align 8, !align [[META1:![0-9]+]]
-; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "align"(ptr [[P2]], i64 6) ]
-; CHECK-NEXT:    call void @foo(ptr [[P2]])
-; CHECK-NEXT:    ret ptr [[P2]]
-;
-  %p2 = load ptr, ptr %p, !align !{i64 4}
-  call void @llvm.assume(i1 true) [ "align"(ptr %p2, i64 6) ]
-  call void @foo(ptr %p2)
-  ret ptr %p2
-}
-
 define ptr @redundant_assume_align_8_via_align_attribute(ptr align 8 %p) {
 ; CHECK-LABEL: @redundant_assume_align_8_via_align_attribute(
 ; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "align"(ptr [[P:%.*]], i32 8) ]
@@ -270,14 +257,12 @@ define ptr @assume_align_1(ptr %p) {
   ret ptr %p
 }
 
-define ptr @redundant_assume_align_null() {
+define void @redundant_assume_align_null() {
 ; CHECK-LABEL: @redundant_assume_align_null(
-; CHECK-NEXT:    call void @foo(ptr null)
-; CHECK-NEXT:    ret ptr null
+; CHECK-NEXT:    ret void
 ;
   call void @llvm.assume(i1 true) [ "align"(ptr null, i64 8) ]
-  call void @foo(ptr null)
-  ret ptr null
+  ret void
 }
 
 declare void @foo(ptr)
@@ -296,5 +281,4 @@ define ptr @assume_load_pointer_result(ptr %p, i64 %align) {
 
 ;.
 ; CHECK: [[META0]] = !{i64 8}
-; CHECK: [[META1]] = !{i64 4}
 ;.


### PR DESCRIPTION
When we have a `NULL` pointer the `1ULL << computeKnownBits(RK.WasOn, II).countMinTrailingZeros()` check becomes `1ULL << 64` which is UB.

We hit the following error in our downstream sanitizer builder: 

> llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp: runtime error: shift exponent 64 is too large for 64-bit type 'unsigned long long'

Tests were generated using an AI.