### PR TITLE
[BOLT] Remove unused DenseMapInfo::getEmptyKey

### DIFF
--- a/bolt/include/bolt/Passes/DataflowAnalysis.h
+++ b/bolt/include/bolt/Passes/DataflowAnalysis.h
@@ -565,11 +565,6 @@ public:
 /// DenseMapInfo allows us to use the DenseMap LLVM data structure to store
 /// ProgramPoints.
 template <> struct DenseMapInfo<bolt::ProgramPoint> {
-  static inline bolt::ProgramPoint getEmptyKey() {
-    uintptr_t Val = static_cast<uintptr_t>(-1);
-    Val <<= PointerLikeTypeTraits<MCInst *>::NumLowBitsAvailable;
-    return bolt::ProgramPoint(reinterpret_cast<MCInst *>(Val));
-  }
   static unsigned getHashValue(const bolt::ProgramPoint &PP) {
     return (unsigned((uintptr_t)PP.Data.BB) >> 4) ^
            (unsigned((uintptr_t)PP.Data.BB) >> 9);

--- a/bolt/include/bolt/Passes/SplitFunctions.h
+++ b/bolt/include/bolt/Passes/SplitFunctions.h
@@ -42,7 +42,6 @@ private:
     TrampolineKey(const FragmentNum SourceFN, const MCSymbol *const Target)
         : SourceFN(SourceFN), Target(Target) {}
 
-    static inline TrampolineKey getEmptyKey() { return TrampolineKey(); };
     static unsigned getHashValue(const TrampolineKey &Val) {
       return llvm::hash_combine(Val.SourceFN.get(), Val.Target);
     }

--- a/bolt/include/bolt/Profile/DataReader.h
+++ b/bolt/include/bolt/Profile/DataReader.h
@@ -488,9 +488,6 @@ public:
 /// DenseMapInfo allows us to use the DenseMap LLVM data structure to store
 /// Locations
 template <> struct DenseMapInfo<bolt::Location> {
-  static inline bolt::Location getEmptyKey() {
-    return bolt::Location(true, StringRef(), static_cast<uint64_t>(-1LL));
-  }
   static unsigned getHashValue(const bolt::Location &L) {
     return (unsigned(DenseMapInfo<StringRef>::getHashValue(L.Name)) >> 4) ^
            (unsigned(L.Offset));


### PR DESCRIPTION
After #201281 DenseMapInfo<T>::getEmptyKey() is no longer used by
DenseMap. Remove the unused getEmptyKey definitions and dead sentinel
uses.
