### PR TITLE
[flang] Remove unused DenseMapInfo::getEmptyKey

### DIFF
--- a/flang/include/flang/Lower/IterationSpace.h
+++ b/flang/include/flang/Lower/IterationSpace.h
@@ -294,9 +294,6 @@ bool isEqual(const ExplicitSpaceArrayBases &x,
 namespace llvm {
 template <>
 struct DenseMapInfo<Fortran::lower::ExplicitSpaceArrayBases> {
-  static inline Fortran::lower::ExplicitSpaceArrayBases getEmptyKey() {
-    return reinterpret_cast<Fortran::lower::FrontEndSymbol>(~0);
-  }
   static unsigned
   getHashValue(const Fortran::lower::ExplicitSpaceArrayBases &v) {
     return Fortran::lower::getHashValue(v);

--- a/flang/include/flang/Lower/Support/Utils.h
+++ b/flang/include/flang/Lower/Support/Utils.h
@@ -129,9 +129,6 @@ void privatizeSymbol(
 namespace llvm {
 template <>
 struct DenseMapInfo<const Fortran::lower::SomeExpr *> {
-  static inline const Fortran::lower::SomeExpr *getEmptyKey() {
-    return reinterpret_cast<Fortran::lower::SomeExpr *>(~0);
-  }
   static unsigned getHashValue(const Fortran::lower::SomeExpr *v) {
     return Fortran::lower::getHashValue(v);
   }
@@ -144,9 +141,6 @@ struct DenseMapInfo<const Fortran::lower::SomeExpr *> {
 // DenseMapInfo for pointers to Fortran::evaluate::Component.
 template <>
 struct DenseMapInfo<const Fortran::evaluate::Component *> {
-  static inline const Fortran::evaluate::Component *getEmptyKey() {
-    return reinterpret_cast<Fortran::evaluate::Component *>(~0);
-  }
   static unsigned getHashValue(const Fortran::evaluate::Component *v) {
     return Fortran::lower::getHashValue(v);
   }

--- a/flang/include/flang/Semantics/symbol.h
+++ b/flang/include/flang/Semantics/symbol.h
@@ -1256,11 +1256,6 @@ SourceOrderedSymbolSet OrderBySourcePosition(const A &container) {
 // Define required  info so that SymbolRef can be used inside llvm::DenseMap.
 namespace llvm {
 template <> struct DenseMapInfo<Fortran::semantics::SymbolRef> {
-  static inline Fortran::semantics::SymbolRef getEmptyKey() {
-    auto ptr = DenseMapInfo<const Fortran::semantics::Symbol *>::getEmptyKey();
-    return *reinterpret_cast<Fortran::semantics::SymbolRef *>(&ptr);
-  }
-
   static unsigned getHashValue(const Fortran::semantics::SymbolRef &sym) {
     return DenseMapInfo<const Fortran::semantics::Symbol *>::getHashValue(
         &sym.get());

--- a/flang/lib/Lower/Support/Utils.cpp
+++ b/flang/lib/Lower/Support/Utils.cpp
@@ -631,10 +631,6 @@ unsigned getHashValue(const Fortran::evaluate::Component *x) {
 
 bool isEqual(const Fortran::lower::SomeExpr *x,
              const Fortran::lower::SomeExpr *y) {
-  const auto *empty =
-      llvm::DenseMapInfo<const Fortran::lower::SomeExpr *>::getEmptyKey();
-  if (x == empty || y == empty)
-    return x == y;
   return x == y || IsEqualEvaluateExpr::isEqual(*x, *y);
 }
 
@@ -660,10 +656,6 @@ bool isEqual(const Fortran::lower::ExplicitIterSpace::ArrayBases &x,
 
 bool isEqual(const Fortran::evaluate::Component *x,
              const Fortran::evaluate::Component *y) {
-  const auto *empty =
-      llvm::DenseMapInfo<const Fortran::evaluate::Component *>::getEmptyKey();
-  if (x == empty || y == empty)
-    return x == y;
   return x == y || IsEqualEvaluateExpr::isEqual(*x, *y);
 }
 


### PR DESCRIPTION
After #201281 DenseMapInfo<T>::getEmptyKey() is no longer used by
DenseMap. Remove the unused getEmptyKey definitions and dead sentinel
uses.
