### PR TITLE
[lld] Remove unused DenseMapInfo::getEmptyKey

### DIFF
--- a/lld/COFF/Chunks.h
+++ b/lld/COFF/Chunks.h
@@ -721,9 +721,6 @@ struct ChunkAndOffset {
   uint32_t offset;
 
   struct DenseMapInfo {
-    static ChunkAndOffset getEmptyKey() {
-      return {llvm::DenseMapInfo<Chunk *>::getEmptyKey(), 0};
-    }
     static unsigned getHashValue(const ChunkAndOffset &co) {
       return llvm::DenseMapInfo<std::pair<Chunk *, uint32_t>>::getHashValue(
           {co.inputChunk, co.offset});

--- a/lld/MachO/ConcatOutputSection.h
+++ b/lld/MachO/ConcatOutputSection.h
@@ -144,19 +144,11 @@ struct ThunkKey {
   ThunkKey(Symbol *sym, int64_t addend) : sym(sym), addend(addend) {}
   ThunkKey(Relocation &r) : ThunkKey(cast<Symbol *>(r.referent), r.addend) {}
 
-  static ThunkKey getEmptyKey() {
-    return {llvm::DenseMapInfo<Symbol *>::getEmptyKey(), 0};
-  }
-  bool isSentinel() const {
-    return sym == llvm::DenseMapInfo<Symbol *>::getEmptyKey();
-  }
   bool operator==(const ThunkKey &other) const {
     if (addend != other.addend)
       return false;
     if (sym == other.sym)
       return true;
-    if (isSentinel() || other.isSentinel())
-      return false;
     const auto *dl = dyn_cast<Defined>(sym);
     const auto *dr = dyn_cast<Defined>(other.sym);
     if (dl && dr)
@@ -166,10 +158,7 @@ struct ThunkKey {
 };
 
 struct ThunkMapKeyInfo {
-  static ThunkKey getEmptyKey() { return ThunkKey::getEmptyKey(); }
   static unsigned getHashValue(const ThunkKey &k) {
-    if (k.isSentinel())
-      return llvm::hash_value(k.sym);
     if (const auto *d = dyn_cast<Defined>(k.sym))
       return llvm::hash_combine(d->isec(), d->value, k.addend);
     return llvm::hash_combine(k.sym, k.addend);

--- a/lld/wasm/SyntheticSections.h
+++ b/lld/wasm/SyntheticSections.h
@@ -131,11 +131,6 @@ inline bool operator==(const ImportKey<T> &lhs, const ImportKey<T> &rhs) {
 // key in a `DenseMap`.
 namespace llvm {
 template <typename T> struct DenseMapInfo<lld::wasm::ImportKey<T>> {
-  static lld::wasm::ImportKey<T> getEmptyKey() {
-    typename lld::wasm::ImportKey<T> key(llvm::DenseMapInfo<T>::getEmptyKey());
-    key.state = lld::wasm::ImportKey<T>::State::Empty;
-    return key;
-  }
   static unsigned getHashValue(const lld::wasm::ImportKey<T> &key) {
     uintptr_t hash = hash_value(key.importModule);
     hash = hash_combine(hash, key.importName);


### PR DESCRIPTION
After #201281 DenseMapInfo<T>::getEmptyKey() is no longer used by
DenseMap. Remove the unused getEmptyKey definitions and dead sentinel
uses.
