### PR TITLE
[Polly] Remove unused DenseMapInfo::getEmptyKey

### DIFF
--- a/polly/include/polly/Support/VirtualInstruction.h
+++ b/polly/include/polly/Support/VirtualInstruction.h
@@ -322,13 +322,6 @@ public:
                                                 RHS.getInstruction());
   }
 
-  static polly::VirtualInstruction getEmptyKey() {
-    polly::VirtualInstruction EmptyKey;
-    EmptyKey.Stmt = DenseMapInfo<polly::ScopStmt *>::getEmptyKey();
-    EmptyKey.Inst = DenseMapInfo<Instruction *>::getEmptyKey();
-    return EmptyKey;
-  }
-
   static unsigned getHashValue(polly::VirtualInstruction Val) {
     return DenseMapInfo<std::pair<polly::ScopStmt *, Instruction *>>::
         getHashValue(std::make_pair(Val.getStmt(), Val.getInstruction()));


### PR DESCRIPTION
After #201281 DenseMapInfo<T>::getEmptyKey() is no longer used by
DenseMap. Remove the unused getEmptyKey definitions and dead sentinel
uses.
