### PR TITLE
[Target] Remove unused DenseMapInfo::getEmptyKey

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64StackTaggingPreRA.cpp
+++ b/llvm/lib/Target/AArch64/AArch64StackTaggingPreRA.cpp
@@ -231,7 +231,6 @@ struct SlotWithTag {
 
 namespace llvm {
 template <> struct DenseMapInfo<SlotWithTag> {
-  static inline SlotWithTag getEmptyKey() { return {-2, -2}; }
   static unsigned getHashValue(const SlotWithTag &V) {
     return hash_combine(DenseMapInfo<int>::getHashValue(V.FI),
                         DenseMapInfo<int>::getHashValue(V.Tag));

--- a/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
@@ -479,11 +479,6 @@ hasHazard(StateT InitialState,
     }
   };
   struct StateMapKeyTraits : DenseMapInfo<StateMapKey> {
-    static inline StateMapKey getEmptyKey() {
-      return {static_cast<SmallVectorImpl<StateT> *>(
-                  DenseMapInfo<void *>::getEmptyKey()),
-              DenseMapInfo<unsigned>::getEmptyKey()};
-    }
     static unsigned getHashValue(const StateMapKey &Key) {
       return StateT::getHashValue((*Key.States)[Key.Idx]);
     }
@@ -491,14 +486,9 @@ hasHazard(StateT InitialState,
       return StateT::getHashValue(State);
     }
     static bool isEqual(const StateMapKey &LHS, const StateMapKey &RHS) {
-      const auto EKey = getEmptyKey();
-      if (StateMapKey::isEqual(LHS, EKey) || StateMapKey::isEqual(RHS, EKey))
-        return StateMapKey::isEqual(LHS, RHS);
       return StateT::isEqual((*LHS.States)[LHS.Idx], (*RHS.States)[RHS.Idx]);
     }
     static bool isEqual(const StateT &LHS, const StateMapKey &RHS) {
-      if (StateMapKey::isEqual(RHS, getEmptyKey()))
-        return false;
       return StateT::isEqual(LHS, (*RHS.States)[RHS.Idx]);
     }
   };

--- a/llvm/lib/Target/CSKY/MCTargetDesc/CSKYTargetStreamer.h
+++ b/llvm/lib/Target/CSKY/MCTargetDesc/CSKYTargetStreamer.h
@@ -75,9 +75,6 @@ public:
 };
 
 template <> struct DenseMapInfo<CSKYTargetStreamer::SymbolIndex> {
-  static inline CSKYTargetStreamer::SymbolIndex getEmptyKey() {
-    return {nullptr, CSKY::S_Invalid};
-  }
   static unsigned getHashValue(const CSKYTargetStreamer::SymbolIndex &V) {
     return hash_combine(DenseMapInfo<const MCSymbol *>::getHashValue(V.sym),
                         DenseMapInfo<int>::getHashValue(V.kind));

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -124,7 +124,6 @@ template <>
 struct DenseMapInfo<std::pair<const MCSymbol *, PPCMCExpr::Specifier>> {
   using TOCKey = std::pair<const MCSymbol *, PPCMCExpr::Specifier>;
 
-  static inline TOCKey getEmptyKey() { return {nullptr, PPC::S_None}; }
   static unsigned getHashValue(const TOCKey &PairVal) {
     return detail::combineHashValue(
         DenseMapInfo<const MCSymbol *>::getHashValue(PairVal.first),

--- a/llvm/lib/Target/SPIRV/SPIRVTypeInst.h
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeInst.h
@@ -61,9 +61,6 @@ public:
 
 template <> struct DenseMapInfo<SPIRVTypeInst> {
   using MIInfo = DenseMapInfo<MachineInstr *>;
-  static SPIRVTypeInst getEmptyKey() {
-    return {MIInfo::getEmptyKey(), SPIRVTypeInst::UncheckedConstructor()};
-  }
   static unsigned getHashValue(SPIRVTypeInst Ty) {
     return MIInfo::getHashValue(Ty.MI);
   }

--- a/llvm/lib/Target/X86/X86OptimizeLEAs.cpp
+++ b/llvm/lib/Target/X86/X86OptimizeLEAs.cpp
@@ -118,17 +118,7 @@ namespace llvm {
 template <> struct DenseMapInfo<MemOpKey> {
   using PtrInfo = DenseMapInfo<const MachineOperand *>;
 
-  static inline MemOpKey getEmptyKey() {
-    return MemOpKey(PtrInfo::getEmptyKey(), PtrInfo::getEmptyKey(),
-                    PtrInfo::getEmptyKey(), PtrInfo::getEmptyKey(),
-                    PtrInfo::getEmptyKey());
-  }
-
   static unsigned getHashValue(const MemOpKey &Val) {
-    // Checking any field of MemOpKey is enough to determine if the key is
-    // empty.
-    assert(Val.Disp != PtrInfo::getEmptyKey() && "Cannot hash the empty key");
-
     hash_code Hash = hash_combine(*Val.Operands[0], *Val.Operands[1],
                                   *Val.Operands[2], *Val.Operands[3]);
 
@@ -166,10 +156,6 @@ template <> struct DenseMapInfo<MemOpKey> {
   }
 
   static bool isEqual(const MemOpKey &LHS, const MemOpKey &RHS) {
-    // Checking any field of MemOpKey is enough to determine if the key is
-    // empty.
-    if (RHS.Disp == PtrInfo::getEmptyKey())
-      return LHS.Disp == PtrInfo::getEmptyKey();
     return LHS == RHS;
   }
 };


### PR DESCRIPTION
After #201281 DenseMapInfo<T>::getEmptyKey() is no longer used by
DenseMap. Remove the unused getEmptyKey definitions and dead sentinel
uses.
