### PR TITLE
[release] fix building zstd archives on Windows 11 ARM builds

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -60,6 +60,7 @@ jobs:
       build-flang: ${{ steps.vars.outputs.build-flang }}
       release-binary-basename: ${{ steps.vars.outputs.release-binary-basename }}
       release-binary-filename: ${{ steps.vars.outputs.release-binary-filename }}
+      release-binary-filename-zstd: ${{ steps.vars.outputs.release-binary-filename-zstd }}
       build-runs-on: ${{ steps.vars.outputs.build-runs-on }}
       test-runs-on: ${{ steps.vars.outputs.build-runs-on }}
       attestation-name: ${{ steps.vars.outputs.attestation-name }}
@@ -151,6 +152,7 @@ jobs:
         fi
         echo "release-binary-basename=$release_binary_basename" >> $GITHUB_OUTPUT
         echo "release-binary-filename=$release_binary_basename.tar.xz" >> $GITHUB_OUTPUT
+        echo "release-binary-filename-zstd=$release_binary_basename.tar.zst" >> $GITHUB_OUTPUT
 
         target="$RUNNER_OS-$RUNNER_ARCH"
 
@@ -292,6 +294,14 @@ jobs:
         mv $tarball $env:GITHUB_WORKSPACE
         echo "windows-installer-filename=$(Split-Path -Path $installer -Leaf)" >> $env:GITHUB_OUTPUT
 
+    - name: Create zstd compressed tarball
+      shell: bash
+      env:
+        RELEASE_BINARY_FILENAME: ${{ needs.prepare.outputs.release-binary-filename }}
+        RELEASE_BINARY_FILENAME_ZSTD: ${{ needs.prepare.outputs.release-binary-filename-zstd }}
+      run: |
+        xz -dc "$RELEASE_BINARY_FILENAME" | zstd --ultra -22 -T0 -o "$RELEASE_BINARY_FILENAME_ZSTD"
+
     - name: Generate sha256 digest for binaries
       id: digest
       shell: bash
@@ -299,6 +309,7 @@ jobs:
         RELEASE_BINARY_FILENAME: ${{ needs.prepare.outputs.release-binary-filename }}
         # This will be empty on non-Windows builds.
         WINDOWS_INSTALLER_FILENAME: ${{ steps.build-windows.outputs.windows-installer-filename }}
+        RELEASE_BINARY_FILENAME_ZSTD: ${{ needs.prepare.outputs.release-binary-filename-zstd }}
       run: |
           if [ "$RUNNER_OS" = "macOS" ]; then
             # Mac runners don't have sha256sum.
@@ -306,7 +317,7 @@ jobs:
           else
             sha256sum="sha256sum"
           fi
-          echo "digest=$(cat $WINDOWS_INSTALLER_FILENAME $RELEASE_BINARY_FILENAME | $sha256sum | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+          echo "digest=$(cat $WINDOWS_INSTALLER_FILENAME $RELEASE_BINARY_FILENAME $RELEASE_BINARY_FILENAME_ZSTD | $sha256sum | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
 
     - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       id: artifact-upload
@@ -317,6 +328,7 @@ jobs:
         # The steps.build-windows.* variables will be empty on Linux/MacOS.
         path: |
           ${{ needs.prepare.outputs.release-binary-filename }}
+          ${{ needs.prepare.outputs.release-binary-filename-zstd }}
           ${{ steps.build-windows.outputs.windows-installer-filename }}
 
     - name: Run Tests

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -61,6 +61,7 @@ jobs:
       release-binary-basename: ${{ steps.vars.outputs.release-binary-basename }}
       release-binary-filename: ${{ steps.vars.outputs.release-binary-filename }}
       release-binary-filename-zstd: ${{ steps.vars.outputs.release-binary-filename-zstd }}
+      zstd-bin-dir: ${{ steps.vars.outputs.zstd-bin-dir }}
       build-runs-on: ${{ steps.vars.outputs.build-runs-on }}
       test-runs-on: ${{ steps.vars.outputs.build-runs-on }}
       attestation-name: ${{ steps.vars.outputs.attestation-name }}
@@ -82,9 +83,7 @@ jobs:
     # zstd is missing from the windows-11-arm runner
     - name: Install zstd on windows-11-arm runner
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
-      run: |
-        vcpkg install "zstd[tools]:arm64-windows"
-        echo "$env:VCPKG_INSTALLATION_ROOT\installed\arm64-windows\bin" >> $env:GITHUB_PATH
+      run: vcpkg install "zstd[tools]:arm64-windows"
 
     - name: Checkout LLVM
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -160,6 +159,11 @@ jobs:
         echo "release-binary-basename=$release_binary_basename" >> $GITHUB_OUTPUT
         echo "release-binary-filename=$release_binary_basename.tar.xz" >> $GITHUB_OUTPUT
         echo "release-binary-filename-zstd=$release_binary_basename.tar.zst" >> $GITHUB_OUTPUT
+
+        # Export the zstd path if we are on a Windows ARM64 runner
+        if [ "$RUNNER_OS" = "Windows" ] && [ "$RUNNER_ARCH" = "ARM64" ]; then
+          echo "zstd-bin-dir=$VCPKG_INSTALLATION_ROOT\installed\arm64-windows\bin" >> $GITHUB_OUTPUT
+        fi
 
         target="$RUNNER_OS-$RUNNER_ARCH"
 
@@ -300,6 +304,10 @@ jobs:
         mv $installer $env:GITHUB_WORKSPACE
         mv $tarball $env:GITHUB_WORKSPACE
         echo "windows-installer-filename=$(Split-Path -Path $installer -Leaf)" >> $env:GITHUB_OUTPUT
+
+    - name: Activate Windows ARM zstd Path
+      if: needs.prepare.outputs.zstd-bin-dir != ''
+      run: echo "${{ needs.prepare.outputs.zstd-bin-dir }}" >> $env:GITHUB_PATH
 
     - name: Create zstd compressed tarball
       shell: bash

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -79,6 +79,13 @@ jobs:
         vcpkg install openssl:arm64-windows-static-md
         echo "OPENSSL_DIR=$env:VCPKG_INSTALLATION_ROOT\installed\arm64-windows-static-md" >> $env:GITHUB_ENV
 
+    # zstd is missing from the windows-11-arm runner
+    - name: Install zstd on windows-11-arm runner
+      if: runner.os == 'Windows' && runner.arch == 'ARM64'
+      run: |
+        vcpkg install "zstd[tools]:arm64-windows"
+        echo "$env:VCPKG_INSTALLATION_ROOT\installed\arm64-windows\bin" >> $env:GITHUB_PATH
+
     - name: Checkout LLVM
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -55,18 +55,22 @@ release_links = (
     (
         (
             "LINUX_X86",
-            "* [Linux x86_64]({0}) ([signature]({1}))",
+            "* Linux x86_64: [xz archive]({0}) ([signature]({1})), [zstd archive]({2}) ([signature]({3}))",
             (
                 "LLVM-{release}-Linux-X64.tar.xz",
                 "LLVM-{release}-Linux-X64.tar.xz.jsonl",
+                "LLVM-{release}-Linux-X64.tar.zst",
+                "LLVM-{release}-Linux-X64.tar.zst.jsonl",
             ),
         ),
         (
             "LINUX_ARM64",
-            "* [Linux Arm64]({0}) ([signature]({1}))",
+            "* Linux Arm64: [xz archive]({0}) ([signature]({1})), [zstd archive]({2}) ([signature]({3}))",
             (
                 "LLVM-{release}-Linux-ARM64.tar.xz",
                 "LLVM-{release}-Linux-ARM64.tar.xz.jsonl",
+                "LLVM-{release}-Linux-ARM64.tar.zst",
+                "LLVM-{release}-Linux-ARM64.tar.zst.jsonl",
             ),
         ),
         (
@@ -81,30 +85,36 @@ release_links = (
     (
         (
             "MACOS_ARM64",
-            "* [macOS Apple Silicon]({0}) (ARM64) ([signature]({1}))",
+            "* macOS Apple Silicon (ARM64): [xz archive]({0}) ([signature]({1})), [zstd archive]({2}) ([signature]({3}))",
             (
                 "LLVM-{release}-macOS-ARM64.tar.xz",
                 "LLVM-{release}-macOS-ARM64.tar.xz.jsonl",
+                "LLVM-{release}-macOS-ARM64.tar.zst",
+                "LLVM-{release}-macOS-ARM64.tar.zst.jsonl",
             ),
         ),
         (
             "MACOS_X86",
-            "* [macOS Intel]({0}) (x86-64) ([signature]({1}))",
+            "* macOS Intel (x86-64): [xz archive]({0}) ([signature]({1})), [zstd archive]({2}) ([signature]({3}))",
             (
                 "LLVM-{release}-macOS-X64.tar.xz",
                 "LLVM-{release}-macOS-X64.tar.xz.jsonl",
+                "LLVM-{release}-macOS-X64.tar.zst",
+                "LLVM-{release}-macOS-X64.tar.zst.jsonl",
             ),
         ),
     ),
     (
         (
             "WINDOWS_X64",
-            "* Windows x64 (64-bit): [installer]({0}) ([signature]({1})), [archive]({2}) ([signature]({3}))",
+            "* Windows x64 (64-bit): [installer]({0}) ([signature]({1})), [xz archive]({2}) ([signature]({3})), [zstd archive]({4}) ([signature]({5}))",
             (
                 "LLVM-{release}-win64.exe",
                 "LLVM-{release}-win64.exe.jsonl",
                 "clang+llvm-{release}-x86_64-pc-windows-msvc.tar.xz",
                 "clang+llvm-{release}-x86_64-pc-windows-msvc.tar.xz.jsonl",
+                "clang+llvm-{release}-x86_64-pc-windows-msvc.tar.zst",
+                "clang+llvm-{release}-x86_64-pc-windows-msvc.tar.zst.jsonl",
             ),
         ),
         (
@@ -114,12 +124,14 @@ release_links = (
         ),
         (
             "WINDOWS_ARM64",
-            "* Windows on Arm (ARM64): [installer]({0}) ([signature]({1})), [archive]({2}) ([signature]({3}))",
+            "* Windows on Arm (ARM64): [installer]({0}) ([signature]({1})), [xz archive]({2}) ([signature]({3})), [zstd archive]({4}) ([signature]({5}))",
             (
                 "LLVM-{release}-woa64.exe",
                 "LLVM-{release}-woa64.exe.jsonl",
                 "clang+llvm-{release}-aarch64-pc-windows-msvc.tar.xz",
                 "clang+llvm-{release}-aarch64-pc-windows-msvc.tar.xz.jsonl",
+                "clang+llvm-{release}-aarch64-pc-windows-msvc.tar.zst",
+                "clang+llvm-{release}-aarch64-pc-windows-msvc.tar.zst.jsonl",
             ),
         ),
     ),
@@ -170,7 +182,7 @@ If you do not find a release package for your platform, you may be able to find 
 
 ## Package Types
 
-Each platform has one binary release package. The file name starts with either `LLVM-` or `clang+llvm-` and ends with the platform's name. For example, `LLVM-{release}-Linux-ARM64.tar.xz` contains LLVM binaries for Arm64 Linux.
+Each platform has binary release packages. The file name starts with either `LLVM-` or `clang+llvm-` and ends with the platform's name. For example, `LLVM-{release}-Linux-ARM64.tar.xz` contains LLVM binaries for Arm64 Linux. Binary archive packages may be available as `.tar.xz` or `.tar.zst` files. The `.tar.zst` files contain the same package contents, but use zstd compression.
 
 Except for Windows. Where `LLVM-*.exe` is an installer intended for using LLVM as a toolchain and the archive `clang+llvm-` contains the contents of the installer, plus libraries and tools not normally used in a toolchain. You most likely want the `LLVM-` installer, unless you are developing software which itself uses LLVM, in which case choose `clang+llvm-`.
 


### PR DESCRIPTION
The Windows 11 ARM runner doesn't have zstd installed by default.
This installs zstd from source through vcpkg to address this.

Fixes https://github.com/llvm/llvm-project/pull/201518 (on which it depends).