### PR TITLE
[ADT] Don't use getEmptyKey() when hashing std::optional

### DIFF
--- a/llvm/include/llvm/ADT/DenseMapInfo.h
+++ b/llvm/include/llvm/ADT/DenseMapInfo.h
@@ -214,9 +214,9 @@ template <typename T> struct DenseMapInfo<std::optional<T>> {
   static constexpr Optional getEmptyKey() { return {Info::getEmptyKey()}; }
 
   static unsigned getHashValue(const Optional &OptionalVal) {
-    return detail::combineHashValue(
-        OptionalVal.has_value(),
-        Info::getHashValue(OptionalVal.value_or(Info::getEmptyKey())));
+    if (OptionalVal)
+      return detail::combineHashValue(1, Info::getHashValue(*OptionalVal));
+    return detail::combineHashValue(0, 0);
   }
 
   static bool isEqual(const Optional &LHS, const Optional &RHS) {

--- a/llvm/include/llvm/ADT/DenseMapInfo.h
+++ b/llvm/include/llvm/ADT/DenseMapInfo.h
@@ -216,7 +216,7 @@ template <typename T> struct DenseMapInfo<std::optional<T>> {
   static unsigned getHashValue(const Optional &OptionalVal) {
     if (OptionalVal)
       return detail::combineHashValue(1, Info::getHashValue(*OptionalVal));
-    return detail::combineHashValue(0, 0);
+    return 0;
   }
 
   static bool isEqual(const Optional &LHS, const Optional &RHS) {


### PR DESCRIPTION
DenseMapInfo<std::optional<T>>::getHashValue() calls T's getEmptyKey()
for the nullopt case. This blocks removing the now-unused getEmptyKey()
from DenseMapInfo specializations: a leaf type that drops getEmptyKey()
fails to compile wherever std::optional<T> is used as a DenseMap key
(e.g. DenseMapInfo<mlir::spirv::StorageClass>).

Compute the hash directly instead. Prerequisite for the getEmptyKey()
removal series; #201281 made getEmptyKey() unused by DenseMap.
