### PR TITLE
 [clang] -funique-internal-linkage-names should not be applied to asm label

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2258,6 +2258,7 @@ static bool isUniqueInternalLinkageDecl(GlobalDecl GD,
                                         CodeGenModule &CGM) {
   const Decl *D = GD.getDecl();
   return !CGM.getModuleNameHash().empty() && isa<FunctionDecl>(D) &&
+         !D->hasAttr<AsmLabelAttr>() &&
          (CGM.getFunctionLinkage(GD) == llvm::GlobalValue::InternalLinkage);
 }
 

--- a/clang/test/CodeGen/unique-internal-linkage-names.c
+++ b/clang/test/CodeGen/unique-internal-linkage-names.c
@@ -5,6 +5,15 @@
 inline void overloaded_external() {}
 extern void overloaded_external();
 
+// A prototyped static function gets a unique suffix...
+// CHECK: define internal i32 @_ZL7uniquedv.__uniq.{{[0-9]+}}(
+static int uniqued(void) { return 0; }
+
+// Check that a static function with asm label keeps its original name.
+// CHECK: define internal i32 @"\01custom_label"
+static int asm_label(void) asm("custom_label");
+static int asm_label(void) { return 0; }
+
 // CHECK: define internal void @overloaded_internal() [[ATTR:#[0-9]+]] {
 static void overloaded_internal() {}
 extern void overloaded_internal();
@@ -12,6 +21,8 @@ extern void overloaded_internal();
 void markUsed() {
   overloaded_external();
   overloaded_internal();
+  uniqued();
+  asm_label();
 }
 
 // CHECK: attributes [[ATTR]] =

--- a/clang/test/CodeGen/unique-internal-linkage-names.c
+++ b/clang/test/CodeGen/unique-internal-linkage-names.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -emit-llvm -funique-internal-linkage-names -o - | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-linux-gnu %s -emit-llvm -funique-internal-linkage-names -o - | FileCheck %s
 
 // Check that we do not crash when overloading extern functions.
 
@@ -10,7 +10,7 @@ extern void overloaded_external();
 static int uniqued(void) { return 0; }
 
 // Check that a static function with asm label keeps its original name.
-// CHECK: define internal i32 @"\01custom_label"
+// CHECK: define internal i32 @custom_label(
 static int asm_label(void) asm("custom_label");
 static int asm_label(void) { return 0; }
 

--- a/clang/test/CodeGen/unique-internal-linkage-names.cpp
+++ b/clang/test/CodeGen/unique-internal-linkage-names.cpp
@@ -54,6 +54,11 @@ void test() {
   A a;
 }
 
+// Check a static function with an asm label must keep original name.
+static int asm_label() asm("custom_label");
+static int asm_label() { return 0; }
+int call_asm_label() { return asm_label(); }
+
 // PLAIN: @_ZL4glob = internal global
 // PLAIN: @_ZZ8retAnonMvE5fGlob = internal global
 // PLAIN: @_ZN12_GLOBAL__N_16anon_mE = internal global
@@ -62,6 +67,7 @@ void test() {
 // PLAIN: define internal ptr @_ZL4mverv.resolver()
 // PLAIN: define internal void @_ZN12_GLOBAL__N_11AC1Ev
 // PLAIN: define internal void @_ZN12_GLOBAL__N_11AD1Ev
+// PLAIN: define internal noundef i32 @custom_label()
 // PLAIN: define internal noundef i32 @_ZL4mverv()
 // PLAIN: define internal noundef i32 @_ZL4mverv.sse4.2()
 // PLAIN-NOT: "sample-profile-suffix-elision-policy"
@@ -73,6 +79,7 @@ void test() {
 // UNIQUE: define internal ptr @_ZL4mverv.[[MODHASH]].resolver()
 // UNIQUE: define internal void @_ZN12_GLOBAL__N_11AC1Ev.__uniq.68358509610070717889884130747296293671
 // UNIQUE: define internal void @_ZN12_GLOBAL__N_11AD1Ev.__uniq.68358509610070717889884130747296293671
+// UNIQUE: define internal noundef i32 @custom_label()
 // UNIQUE: define internal noundef i32 @_ZL4mverv.[[MODHASH]]()
 // UNIQUE: define internal noundef i32 @_ZL4mverv.[[MODHASH]].sse4.2
 // UNIQUE: attributes #[[#ATTR]] = { {{.*}}"sample-profile-suffix-elision-policy"{{.*}} }


### PR DESCRIPTION
When `-funique-internal-linkage-names` is supplied, a unique suffix is appended even for a static function with an asm label, when it really shouldn't have.

```c
static int impl(int x) asm("__impl"); // __impl.uniq.68358509610070717889884130747296293671
static int impl(int x) { return x + 1; }
```
