### PR TITLE
[LLDB] Skip JITLoaderGDB for post-mortem processes

### DIFF
--- a/lldb/source/Plugins/JITLoader/GDB/JITLoaderGDB.cpp
+++ b/lldb/source/Plugins/JITLoader/GDB/JITLoaderGDB.cpp
@@ -421,7 +421,13 @@ JITLoaderSP JITLoaderGDB::CreateInstance(Process *process, bool force) {
       break;
     case EnableJITLoaderGDB::eEnableJITLoaderGDBDefault:
       ArchSpec arch(process->GetTarget().GetArchitecture());
-      enable = arch.GetTriple().getVendor() != llvm::Triple::Apple;
+      // Do not load the plugin for post-mortem processes because they do not
+      // support runtime-generated code. `JITLoaderGDB::DidAttach()` attempts
+      // to set up symbolic breakpoints, which may force loading of more debug
+      // information than necessary. Disabling the plugin speeds up loading of
+      // core dumps and other post-mortem files.
+      enable = process->IsLiveDebugSession() &&
+               arch.GetTriple().getVendor() != llvm::Triple::Apple;
       break;
   }
   if (enable)

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
@@ -603,17 +603,6 @@ bool ProcessMinidump::GetProcessInfo(ProcessInstanceInfo &info) {
   return true;
 }
 
-// For minidumps there's no runtime generated code so we don't need JITLoader(s)
-// Avoiding them will also speed up minidump loading since JITLoaders normally
-// try to set up symbolic breakpoints, which in turn may force loading more
-// debug information than needed.
-JITLoaderList &ProcessMinidump::GetJITLoaders() {
-  if (!m_jit_loaders_up) {
-    m_jit_loaders_up = std::make_unique<JITLoaderList>();
-  }
-  return *m_jit_loaders_up;
-}
-
 #define INIT_BOOL(VAR, LONG, SHORT, DESC) \
     VAR(LLDB_OPT_SET_1, false, LONG, SHORT, DESC, false, true)
 #define APPEND_OPT(VAR) \

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.h
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.h
@@ -103,8 +103,6 @@ protected:
                                    llvm::StringRef name,
                                    lldb_private::ModuleSpec module_spec);
 
-  JITLoaderList &GetJITLoaders() override;
-
 private:
   lldb::DataBufferSP m_core_data;
   llvm::ArrayRef<minidump::Thread> m_thread_list;


### PR DESCRIPTION
Post-mortem processes do not support runtime-generated code, making the JITLoaderGDB plugin unnecessary. During initialization, the plugin attempts to set up symbolic breakpoints, which forces symbol loading. Disabling the plugin reduces load time for core dumps from large projects.