### PR TITLE
[DirectX][ObjectYAML] Fix SRCI Names parsing on Big Endian

### DIFF
--- a/llvm/lib/Object/DXContainer.cpp
+++ b/llvm/lib/Object/DXContainer.cpp
@@ -228,8 +228,6 @@ static Expected<size_t> parseNames(StringRef Section,
                                                             HeaderOnDisk))
     return Err;
   Names.Parameters = HeaderOnDisk;
-  if (sys::IsBigEndianHost)
-    Names.Parameters.swapBytes();
   Current += sizeof(HeaderOnDisk);
 
   if (Names.Parameters.Flags)


### PR DESCRIPTION
```
Names.Parameters = HeaderOnDisk;
```
converts SRCI Names section header from little endian to platform native byte order (in converting constructor).
Therefore, extra
```
  if (sys::IsBigEndianHost)
    Names.Parameters.swapBytes();
```
can swap bytes of the header fields again, causing an error on SPARC:
```
SRCI Names section content ends beyond the section boundary
```

Fix that.