### PR TITLE
[openmp][omptest] Include cstdlib for malloc()

### DIFF
--- a/openmp/tools/omptest/src/OmptAssertEvent.cpp
+++ b/openmp/tools/omptest/src/OmptAssertEvent.cpp
@@ -14,6 +14,8 @@
 #include "OmptAssertEvent.h"
 #include <omp-tools.h>
 
+#include <cstdlib>
+
 using namespace omptest;
 
 const char *omptest::to_string(ObserveState State) {


### PR DESCRIPTION
This is to address the error appearing when building this code with somewhat more recent compilers:

```
Use of undeclared identifier 'malloc'
```

Such inclusion has already been added to the OmptTester.cpp file.