### PR TITLE
[clang][NFC]: Fix typo in comment in `ASTReader.h`

### DIFF
--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -246,7 +246,7 @@ public:
     return true;
   }
 
-  /// Similiar to member function of \c visitInputFile but should
+  /// Similar to member function of \c visitInputFile but should
   /// be defined when there is a distinction between the file name
   /// and the name-as-requested. For example, when deserializing input
   /// files from precompiled AST files.


### PR DESCRIPTION
Similiar -> Similar