### PR TITLE
[NFC][LLVM] Introduce `IIT_MATCH` to represents `LLVMMatchType`

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.h
+++ b/llvm/include/llvm/IR/Intrinsics.h
@@ -182,6 +182,7 @@ struct IITDescriptor {
     Overloaded, // AnyKind and overload index in OverloadInfo.
 
     // Fully dependent types. Overload index in OverloadInfo.
+    Match,
     Extend,
     Trunc,
     OneNthEltsVec,
@@ -212,10 +213,11 @@ struct IITDescriptor {
   };
 
   unsigned getOverloadIndex() const {
-    assert(Kind == Overloaded || Kind == Extend || Kind == Trunc ||
-           Kind == SameVecWidth || Kind == VecElement || Kind == Subdivide2 ||
-           Kind == Subdivide4 || Kind == VecOfBitcastsToInt ||
-           Kind == VecOfAnyPtrsToElt || Kind == OneNthEltsVec);
+    assert(Kind == Overloaded || Kind == Match || Kind == Extend ||
+           Kind == Trunc || Kind == SameVecWidth || Kind == VecElement ||
+           Kind == Subdivide2 || Kind == Subdivide4 ||
+           Kind == VecOfBitcastsToInt || Kind == VecOfAnyPtrsToElt ||
+           Kind == OneNthEltsVec);
     // Overload index is packed into lower 5 bits.
     return OverloadInfo & 0x1f;
   }

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -244,8 +244,6 @@ def AnyKind {
   int AnyFloat   = 2;
   int AnyVector  = 3;
   int AnyPointer = 4;
-
-  int MatchType  = 7;
 }
 
 // Placeholder to encode the overload index of the current type. We encode bit
@@ -255,7 +253,7 @@ def AnyKind {
 // Note that this is just a transient representation till its gets processed
 // by `DoPatchOverloadIndex` below, so this is *not* the encoding of the
 // final type signature.
-class OverloadIndexPlaceholder <int AnyKindVal> {
+class OverloadIndexPlaceholder<int AnyKindVal> {
   int ID = 0x100;
   int ret = !or(ID, AnyKindVal);
 }
@@ -329,7 +327,7 @@ def IIT_V64 : IIT_Vec<64, 16>;
 def IIT_MMX : IIT_VT<x86mmx, 17>;
 def IIT_TOKEN : IIT_VT<token, 18>;
 def IIT_METADATA : IIT_VT<MetadataVT, 19>;
-// Note: Unused IIT code 20.
+def IIT_MATCH : IIT_Base<20>;
 def IIT_STRUCT : IIT_Base<21>;
 def IIT_EXTEND_ARG : IIT_Base<22>;
 def IIT_TRUNC_ARG : IIT_Base<23>;
@@ -454,7 +452,7 @@ class LLVMFullyDependentType<int oidx, IIT_Base IIT_Info>
   // followed by the overload index of the overload type it depends on.
   let Sig = [
     IIT_Info.Number,
-    PackOverloadIndex<OverloadIndex, AnyKind.MatchType>.ret
+    PackOverloadIndex<OverloadIndex, 0>.ret
   ];
 }
 
@@ -466,7 +464,7 @@ class LLVMPartiallyDependentType<int oidx, IIT_Base IIT_Info>
   let Sig = [
     IIT_Info.Number,
     // This types overload index, arg kind ignored.
-    OverloadIndexPlaceholder <0>.ret,
+    OverloadIndexPlaceholder<0>.ret,
     // Overload index of the reference overload type, arg kind ignored.
     PackOverloadIndex<OverloadIndex, 0>.ret,
   ];
@@ -494,7 +492,7 @@ class LLVMPartiallyDependentType<int oidx, IIT_Base IIT_Info>
 //
 // LLVMMatchType<0> therefore will match the return type, and
 // LLVMMatchType<2> will match the 3rd argument.
-class LLVMMatchType<int oidx> : LLVMFullyDependentType<oidx, IIT_ANY>;
+class LLVMMatchType<int oidx> : LLVMFullyDependentType<oidx, IIT_MATCH>;
 
 // Match the type of another intrinsic parameter that is expected to be based on
 // an integral type (i.e. either iN or <N x iM>), but change the scalar size to

--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -376,6 +376,12 @@ DecodeIITType(unsigned &NextElt, ArrayRef<unsigned char> Infos,
         IITDescriptor::get(IITDescriptor::Overloaded, OverloadInfo));
     return;
   }
+  case IIT_MATCH: {
+    unsigned OverloadIndex = Infos[NextElt++];
+    OutputTable.push_back(
+        IITDescriptor::get(IITDescriptor::Match, OverloadIndex));
+    return;
+  }
   case IIT_EXTEND_ARG: {
     unsigned OverloadIndex = Infos[NextElt++];
     OutputTable.push_back(
@@ -564,10 +570,12 @@ static Type *DecodeFixedType(ArrayRef<Intrinsic::IITDescriptor> &Infos,
       Elts.push_back(DecodeFixedType(Infos, OverloadTys, Context));
     return StructType::get(Context, Elts);
   }
-  // For any overload kind or partially dependent type, substitute it with the
-  // corresponding concrete type from OverloadTys.
+  // For any overload type or partially dependent type, substitute it with the
+  // corresponding concrete type from OverloadTys. Additionally, do the same
+  // for the fully dependent type that matches an overload type.
   case IITDescriptor::Overloaded:
   case IITDescriptor::VecOfAnyPtrsToElt:
+  case IITDescriptor::Match:
     return OverloadTys[D.getOverloadIndex()];
   case IITDescriptor::Extend:
     return OverloadTys[D.getOverloadIndex()]->getExtendedType();
@@ -1064,15 +1072,6 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
 
   case IITDescriptor::Overloaded: {
     unsigned OIdx = D.getOverloadIndex();
-    if (D.getOverloadKind() == IITDescriptor::AK_MatchType) {
-      // This is a dependent type instance, check it similarly to other
-      // dependent types.
-      if (OIdx >= OverloadTys.size())
-        return IsDeferredCheck || DeferCheck(Ty);
-      return PrintMsgInvalidDepType(Ty == OverloadTys[OIdx], "matching",
-                                    formatv("{}", *OverloadTys[OIdx]), OIdx);
-    }
-
     assert(OIdx == OverloadTys.size() && !IsDeferredCheck &&
            "Table consistency error");
     OverloadTys.push_back(Ty);
@@ -1089,10 +1088,16 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
       return PrintMsg(isa<VectorType>(Ty), "any vector type", OIdx);
     case IITDescriptor::AK_AnyPointer:
       return PrintMsg(isa<PointerType>(Ty), "any pointer type", OIdx);
-    default:
-      break;
     }
     llvm_unreachable("all argument kinds not covered");
+  }
+
+  case IITDescriptor::Match: {
+    unsigned OIdx = D.getOverloadIndex();
+    if (OIdx >= OverloadTys.size())
+      return IsDeferredCheck || DeferCheck(Ty);
+    return PrintMsgInvalidDepType(Ty == OverloadTys[OIdx], "matching",
+                                  formatv("{}", *OverloadTys[OIdx]), OIdx);
   }
 
   case IITDescriptor::Extend:


### PR DESCRIPTION
Currently, the fully dependent identity type `LLVMMatchType` is represented in the IIT encoding table as `IIT_ANY` with `AK_MatchType` argument kind. Instead, add a new IIT code `IIT_MATCH` to represent such dependent types, so that `IIT_ANY` is used to represent just the core overload types.