### PR TITLE
[CIR][NFC] Fix converting AtomicType after RecordType modification

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -643,9 +643,9 @@ mlir::Type CIRGenTypes::convertType(QualType type) {
       auto paddingArray =
           cir::ArrayType::get(cgm.sInt8Ty, (atomicSize - valueSize) / 8);
       mlir::Type elements[] = {resultType, paddingArray};
-      resultType = cir::RecordType::get(&getMLIRContext(), /*members=*/elements,
+      resultType = cir::StructType::get(&getMLIRContext(), /*members=*/elements,
                                         /*packed=*/false, /*padded=*/false,
-                                        /*kind=*/cir::RecordType::Struct);
+                                        /*is_class=*/false);
     }
 
     break;


### PR DESCRIPTION
Fix the conversion of the AtomicType after the change in the structure in #199790 and #200668

Fix #202031