### PR TITLE
[SPIRV] Add SPV_KHR_ray_query lowering

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsSPIRV.td
+++ b/llvm/include/llvm/IR/IntrinsicsSPIRV.td
@@ -365,5 +365,17 @@ def int_spv_rsqrt : DefaultAttrsIntrinsic<[LLVMMatchType<0>], [llvm_anyfloat_ty]
   def int_spv_unpackhalf2x16 : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [llvm_i32_ty], [IntrNoMem]>;
   def int_spv_packhalf2x16 : DefaultAttrsIntrinsic<[llvm_anyint_ty], [llvm_anyfloat_ty], [IntrNoMem]>;
 
-
+  // SPV_KHR_ray_query operations. The ray query object is a function-local
+  // pointer to target("spirv.RayQueryKHR") and is mutated, so no IntrNoMem.
+  def int_spv_ray_query_initialize
+    : Intrinsic<[], [llvm_ptr_ty, llvm_any_ty, llvm_i32_ty, llvm_i32_ty,
+                     llvm_v3f32_ty, llvm_float_ty, llvm_v3f32_ty, llvm_float_ty]>;
+  def int_spv_ray_query_proceed
+    : Intrinsic<[llvm_i1_ty], [llvm_ptr_ty]>;
+  def int_spv_ray_query_get_intersection_type
+    : Intrinsic<[llvm_i32_ty], [llvm_ptr_ty, llvm_i32_ty]>;
+  // The primitive index of the candidate or committed intersection.
+  // Args: rq ptr, intersection (0/1).
+  def int_spv_ray_query_get_intersection_primitive_index
+    : Intrinsic<[llvm_i32_ty], [llvm_ptr_ty, llvm_i32_ty]>;
 }

--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.td
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.td
@@ -1811,6 +1811,8 @@ def : BuiltinType<"spirv.SignedImage", OpTypeImage>;
 def : BuiltinType<"spirv.SampledImage", OpTypeSampledImage>;
 def : BuiltinType<"spirv.Pipe", OpTypePipe>;
 def : BuiltinType<"spirv.CooperativeMatrixKHR", OpTypeCooperativeMatrixKHR>;
+def : BuiltinType<"spirv.RayQueryKHR", OpTypeRayQueryKHR>;
+def : BuiltinType<"spirv.AccelerationStructureKHR", OpTypeAccelerationStructureKHR>;
 
 //===----------------------------------------------------------------------===//
 // Class matching an OpenCL builtin type name to an equivalent SPIR-V

--- a/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
+++ b/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
@@ -213,6 +213,21 @@ def OpTypeCooperativeMatrixNV: Op<5358, (outs TYPE:$res),
 def OpTypeCooperativeMatrixKHR: Op<4456, (outs TYPE:$res),
                   (ins TYPE:$compType, ID:$scope, ID:$rows, ID:$cols, ID:$use),
                   "$res = OpTypeCooperativeMatrixKHR $compType $scope $rows $cols $use">;
+def OpTypeRayQueryKHR: Op<4472, (outs TYPE:$res), (ins),
+                  "$res = OpTypeRayQueryKHR">;
+def OpTypeAccelerationStructureKHR: Op<5341, (outs TYPE:$res), (ins),
+                  "$res = OpTypeAccelerationStructureKHR">;
+def OpRayQueryInitializeKHR: Op<4473, (outs),
+                  (ins ID:$rq, ID:$accel, ID:$flags, ID:$mask, ID:$origin, ID:$tmin, ID:$dir, ID:$tmax),
+                  "OpRayQueryInitializeKHR $rq $accel $flags $mask $origin $tmin $dir $tmax">;
+def OpRayQueryProceedKHR: Op<4477, (outs ID:$res), (ins TYPE:$resType, ID:$rq),
+                  "$res = OpRayQueryProceedKHR $resType $rq">;
+def OpRayQueryGetIntersectionTypeKHR: Op<4479, (outs ID:$res),
+                  (ins TYPE:$resType, ID:$rq, ID:$intersection),
+                  "$res = OpRayQueryGetIntersectionTypeKHR $resType $rq $intersection">;
+def OpRayQueryGetIntersectionPrimitiveIndexKHR: Op<6023, (outs ID:$res),
+                  (ins TYPE:$resType, ID:$rq, ID:$intersection),
+                  "$res = OpRayQueryGetIntersectionPrimitiveIndexKHR $resType $rq $intersection">;
 
 // 3.42.7 Constant-Creation Instructions
 

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -452,6 +452,7 @@ private:
   bool selectGatherIntrinsic(Register &ResVReg, SPIRVTypeInst ResType,
                              MachineInstr &I) const;
   bool selectImageWriteIntrinsic(MachineInstr &I) const;
+  bool selectRayQueryInitialize(MachineInstr &I) const;
   bool selectResourceGetPointer(Register &ResVReg, SPIRVTypeInst ResType,
                                 MachineInstr &I) const;
   bool selectPushConstantGetPointer(Register &ResVReg, SPIRVTypeInst ResType,
@@ -780,6 +781,8 @@ static bool isOpcodeWithNoSideEffects(unsigned Opcode) {
   case SPIRV::OpTypeAccelerationStructureNV:
   case SPIRV::OpTypeCooperativeMatrixNV:
   case SPIRV::OpTypeCooperativeMatrixKHR:
+  case SPIRV::OpTypeRayQueryKHR:
+  case SPIRV::OpTypeAccelerationStructureKHR:
     return true;
   default:
     return false;
@@ -1607,6 +1610,16 @@ bool SPIRVInstructionSelector::selectSincos(Register ResVReg,
     return true;
   }
   return false;
+}
+
+bool SPIRVInstructionSelector::selectRayQueryInitialize(MachineInstr &I) const {
+  // Operands 1..8: rq ptr, accel, rayFlags, cullMask, origin, tMin, dir, tMax.
+  auto MIB = BuildMI(*I.getParent(), I, I.getDebugLoc(),
+                     TII.get(SPIRV::OpRayQueryInitializeKHR));
+  for (unsigned i = 1; i < I.getNumOperands(); ++i)
+    MIB.addUse(I.getOperand(i).getReg());
+  MIB.constrainAllUses(TII, TRI, RBI);
+  return true;
 }
 
 bool SPIRVInstructionSelector::selectOpWithSrcs(Register ResVReg,
@@ -4947,6 +4960,21 @@ bool SPIRVInstructionSelector::selectIntrinsic(Register ResVReg,
       report_fatal_error("incompatible result and operand types in a bitcast");
     return selectOpWithSrcs(ResVReg, ResType, I, {OpReg}, SPIRV::OpBitcast);
   }
+  case Intrinsic::spv_ray_query_initialize:
+    return selectRayQueryInitialize(I);
+  case Intrinsic::spv_ray_query_proceed:
+    return selectOpWithSrcs(ResVReg, ResType, I, {I.getOperand(2).getReg()},
+                            SPIRV::OpRayQueryProceedKHR);
+  case Intrinsic::spv_ray_query_get_intersection_type:
+    return selectOpWithSrcs(
+        ResVReg, ResType, I,
+        {I.getOperand(2).getReg(), I.getOperand(3).getReg()},
+        SPIRV::OpRayQueryGetIntersectionTypeKHR);
+  case Intrinsic::spv_ray_query_get_intersection_primitive_index:
+    return selectOpWithSrcs(
+        ResVReg, ResType, I,
+        {I.getOperand(2).getReg(), I.getOperand(3).getReg()},
+        SPIRV::OpRayQueryGetIntersectionPrimitiveIndexKHR);
   case Intrinsic::spv_unref_global:
   case Intrinsic::spv_init_global: {
     MachineInstr *MI = MRI->getVRegDef(I.getOperand(1).getReg());

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -2087,6 +2087,22 @@ void addInstrRequirements(const MachineInstr &MI,
       Reqs.addCapability(SPIRV::Capability::AsmINTEL);
     }
     break;
+  case SPIRV::OpTypeRayQueryKHR:
+    if (!ST.canUseExtension(SPIRV::Extension::SPV_KHR_ray_query))
+      report_fatal_error("OpTypeRayQueryKHR type requires the "
+                         "following SPIR-V extension: SPV_KHR_ray_query",
+                         false);
+    Reqs.addExtension(SPIRV::Extension::SPV_KHR_ray_query);
+    Reqs.addCapability(SPIRV::Capability::RayQueryKHR);
+    break;
+  case SPIRV::OpTypeAccelerationStructureKHR:
+    if (!ST.canUseExtension(SPIRV::Extension::SPV_KHR_ray_query))
+      report_fatal_error("OpTypeAccelerationStructureKHR type requires the "
+                         "following SPIR-V extension: SPV_KHR_ray_query",
+                         false);
+    Reqs.addExtension(SPIRV::Extension::SPV_KHR_ray_query);
+    Reqs.addCapability(SPIRV::Capability::RayQueryKHR);
+    break;
   case SPIRV::OpTypeCooperativeMatrixKHR: {
     if (!ST.canUseExtension(SPIRV::Extension::SPV_KHR_cooperative_matrix))
       report_fatal_error(

--- a/llvm/lib/Target/SPIRV/SPIRVSymbolicOperands.td
+++ b/llvm/lib/Target/SPIRV/SPIRVSymbolicOperands.td
@@ -603,6 +603,7 @@ defm HostAccessINTEL : CapabilityOperand<6188, 0, 0, [SPV_INTEL_global_variable_
 defm GlobalVariableFPGADecorationsINTEL : CapabilityOperand<6189, 0, 0, [SPV_INTEL_global_variable_fpga_decorations], []>;
 defm CacheControlsINTEL : CapabilityOperand<6441, 0, 0, [SPV_INTEL_cache_controls], []>;
 defm CooperativeMatrixKHR : CapabilityOperand<6022, 0, 0, [SPV_KHR_cooperative_matrix], []>;
+defm RayQueryKHR : CapabilityOperand<4472, 0, 0, [SPV_KHR_ray_query], []>;
 defm ArithmeticFenceEXT : CapabilityOperand<6144, 0, 0, [SPV_EXT_arithmetic_fence], []>;
 defm AbortKHR : CapabilityOperand<5120, 0, 0, [SPV_KHR_abort], []>;
 defm SplitBarrierINTEL : CapabilityOperand<6141, 0, 0, [SPV_INTEL_split_barrier], []>;

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_ray_query/acceleration_structure_type.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_ray_query/acceleration_structure_type.ll
@@ -1,0 +1,17 @@
+; Check that target("spirv.AccelerationStructureKHR") lowers to
+; OpTypeAccelerationStructureKHR, gated by the RayQueryKHR capability and the
+; SPV_KHR_ray_query extension.
+
+; RUN: not llc -O0 -mtriple=spirv-unknown-vulkan1.3-compute %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan1.3-compute --spirv-ext=+SPV_KHR_ray_query %s -o - | FileCheck %s
+
+; CHECK-ERROR: LLVM ERROR: OpTypeAccelerationStructureKHR type requires the following SPIR-V extension: SPV_KHR_ray_query
+
+; CHECK-DAG: OpCapability RayQueryKHR
+; CHECK-DAG: OpExtension "SPV_KHR_ray_query"
+; CHECK-DAG: {{%[0-9]+}} = OpTypeAccelerationStructureKHR
+
+define spir_func void @use_accel(target("spirv.AccelerationStructureKHR") %as) {
+entry:
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_ray_query/ray_query_kernel.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_ray_query/ray_query_kernel.ll
@@ -1,0 +1,51 @@
+; A GLCompute kernel using SPV_KHR_ray_query against a descriptor-bound
+; acceleration structure (a UniformConstant global decorated DescriptorSet and
+; Binding, materialized via llvm.spv.resource.handlefrombinding). It initializes
+; a ray, proceeds over candidates, inspects the candidate intersection type, and
+; reads the committed type. The module must pass spirv-val --target-env vulkan1.3.
+
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv-unknown-vulkan1.3-compute --spirv-ext=+SPV_KHR_ray_query %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan1.3-compute --spirv-ext=+SPV_KHR_ray_query %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; CHECK-DAG: OpCapability RayQueryKHR
+; CHECK-DAG: OpExtension "SPV_KHR_ray_query"
+; CHECK-DAG: OpEntryPoint GLCompute %[[#entry:]] "main"
+; CHECK-DAG: OpDecorate %[[#AS:]] DescriptorSet 0
+; CHECK-DAG: OpDecorate %[[#AS]] Binding 0
+; CHECK-DAG: %[[#ASTy:]] = OpTypeAccelerationStructureKHR
+; CHECK-DAG: %[[#RQTy:]] = OpTypeRayQueryKHR
+; CHECK: %[[#RQ:]] = OpVariable %[[#]] Function
+; CHECK: OpRayQueryInitializeKHR %[[#RQ]]
+; CHECK: %[[#]] = OpRayQueryProceedKHR
+; CHECK: %[[#]] = OpRayQueryGetIntersectionTypeKHR
+
+@.str.as = private unnamed_addr constant [3 x i8] c"as\00", align 1
+
+define void @main() local_unnamed_addr #0 {
+entry:
+  %as = tail call target("spirv.AccelerationStructureKHR")
+      @llvm.spv.resource.handlefrombinding.tspirv.AccelerationStructureKHR(
+          i32 0, i32 0, i32 1, i32 0, ptr nonnull @.str.as)
+  %rq = alloca target("spirv.RayQueryKHR"), align 8
+  call void @llvm.spv.ray.query.initialize(ptr %rq,
+      target("spirv.AccelerationStructureKHR") %as,
+      i32 0, i32 255,
+      <3 x float> zeroinitializer, float 0.000000e+00,
+      <3 x float> <float 0.000000e+00, float 0.000000e+00, float 1.000000e+00>,
+      float 0.000000e+00)
+  br label %loop.header
+
+loop.header:
+  %more = call i1 @llvm.spv.ray.query.proceed(ptr %rq)
+  br i1 %more, label %loop.body, label %loop.exit
+
+loop.body:
+  %cand = call i32 @llvm.spv.ray.query.get.intersection.type(ptr %rq, i32 0)
+  br label %loop.header
+
+loop.exit:
+  %committed = call i32 @llvm.spv.ray.query.get.intersection.type(ptr %rq, i32 1)
+  ret void
+}
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_ray_query/ray_query_ops.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_ray_query/ray_query_ops.ll
@@ -1,0 +1,21 @@
+; SPV_KHR_ray_query operations via llvm.spv.ray.query.* intrinsics and GlobalISel
+; selection, used because the __spirv_* builtin path is OpenCL-only and cannot
+; lower ray query, which is a Vulkan-only extension.
+
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan1.3-compute --spirv-ext=+SPV_KHR_ray_query %s -o - | FileCheck %s
+
+; CHECK-DAG: OpCapability RayQueryKHR
+; CHECK-DAG: OpExtension "SPV_KHR_ray_query"
+; CHECK-DAG: %[[#RQTy:]] = OpTypeRayQueryKHR
+; CHECK: OpRayQueryInitializeKHR
+; CHECK: %[[#]] = OpRayQueryProceedKHR
+; CHECK: %[[#]] = OpRayQueryGetIntersectionTypeKHR
+
+define void @ray_query_ops(target("spirv.AccelerationStructureKHR") %as) {
+entry:
+  %rq = alloca target("spirv.RayQueryKHR"), align 8
+  call void @llvm.spv.ray.query.initialize(ptr %rq, target("spirv.AccelerationStructureKHR") %as, i32 0, i32 255, <3 x float> zeroinitializer, float 0.000000e+00, <3 x float> <float 0.000000e+00, float 0.000000e+00, float 1.000000e+00>, float 1.000000e+03)
+  %p = call i1 @llvm.spv.ray.query.proceed(ptr %rq)
+  %t = call i32 @llvm.spv.ray.query.get.intersection.type(ptr %rq, i32 0)
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_ray_query/ray_query_type.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_ray_query/ray_query_type.ll
@@ -1,0 +1,19 @@
+; Check that target("spirv.RayQueryKHR") lowers to OpTypeRayQueryKHR under the
+; Vulkan flavor, gated behind the RayQueryKHR capability and the SPV_KHR_ray_query
+; extension, and that it errors cleanly without the extension enabled.
+
+; RUN: not llc -O0 -mtriple=spirv-unknown-vulkan1.3-compute %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan1.3-compute --spirv-ext=+SPV_KHR_ray_query %s -o - | FileCheck %s
+
+; CHECK-ERROR: LLVM ERROR: OpTypeRayQueryKHR type requires the following SPIR-V extension: SPV_KHR_ray_query
+
+; CHECK-DAG: OpCapability RayQueryKHR
+; CHECK-DAG: OpExtension "SPV_KHR_ray_query"
+; CHECK-DAG: {{%[0-9]+}} = OpTypeRayQueryKHR
+
+; A by-value parameter of the opaque type forces OpTypeRayQueryKHR into the module
+; (referenced by OpTypeFunction — cannot be eliminated like an unused local).
+define spir_func void @use_ray_query(target("spirv.RayQueryKHR") %rq) {
+entry:
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_ray_query/ray_query_type.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_ray_query/ray_query_type.ll
@@ -12,7 +12,7 @@
 ; CHECK-DAG: {{%[0-9]+}} = OpTypeRayQueryKHR
 
 ; A by-value parameter of the opaque type forces OpTypeRayQueryKHR into the module
-; (referenced by OpTypeFunction — cannot be eliminated like an unused local).
+; (referenced by OpTypeFunction, so it is not eliminated like an unused local).
 define spir_func void @use_ray_query(target("spirv.RayQueryKHR") %rq) {
 entry:
   ret void


### PR DESCRIPTION
Make ray query (SPV_KHR_ray_query) reachable from the Vulkan/Shader flavor via
llvm.spv intrinsics + GlobalISel selection (the texture / cooperative-matrix
pattern), since the OpenCL __spirv_* builtin path is isShader()-gated off.

- SPIRVInstrInfo.td: OpType{RayQuery,AccelerationStructure}KHR opaque types, and
  OpRayQuery{Initialize,Proceed,GetIntersectionType,
  GetIntersectionPrimitiveIndex}KHR.
- SPIRVBuiltins.td: spirv.{RayQueryKHR,AccelerationStructureKHR} builtin types,
  lowered flavor-agnostically by the existing BuiltinType machinery.
- IntrinsicsSPIRV.td: llvm.spv.ray_query.{initialize,proceed,
  get_intersection_type,get_intersection_primitive_index}. The ray query object
  is a function-local variable pointer; the ops are side-effecting.
- SPIRVInstructionSelector.cpp: GlobalISel selection for the four ops; the
  opaque types are side-effect-free.
- SPIRVModuleAnalysis.cpp / SPIRVSymbolicOperands.td: the RayQueryKHR capability
  and SPV_KHR_ray_query extension requirement on the opaque types.
- Tests: ray_query_{type,ops,kernel}.ll, acceleration_structure_type.ll.

---
*Verified against current `llvm/main`: applies cleanly, the SPIR-V target builds, and the included lit test(s) pass (`llc … | FileCheck`, + `spirv-val` where applicable).*
---

**AI-tool disclosure** (per the [LLVM AI Tool Policy](https://llvm.org/docs/AIToolPolicy.html)): substantial portions of this change were drafted with Claude, an AI assistant from Anthropic, with the PR author as the human in the loop — reviewing, testing, and taking responsibility for all generated code and tests.

Assisted-by: Claude (Anthropic)
