### PR TITLE
[clang-tidy] Preserve line endings in macro-to-enum fixes

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/MacroToEnumCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/MacroToEnumCheck.cpp
@@ -472,16 +472,13 @@ void MacroToEnumCallbacks::fixEnumMacro(const MacroList &MacroList) const {
       MacroList.front().Directive->getMacroInfo()->getDefinitionLoc();
   const StringRef LineEnding =
       SM.getBufferData(SM.getFileID(Begin)).detectEOL();
-  std::string EnumBegin = "enum {";
-  EnumBegin += LineEnding;
-  std::string EnumEnd = "};";
-  EnumEnd += LineEnding;
 
   Begin = SM.translateLineCol(SM.getFileID(Begin),
                               SM.getSpellingLineNumber(Begin), 1);
   const DiagnosticBuilder Diagnostic =
       Check->diag(Begin, "replace macro with enum")
-      << FixItHint::CreateInsertion(Begin, EnumBegin);
+      << FixItHint::CreateInsertion(Begin,
+                                    (llvm::Twine("enum {") + LineEnding).str());
 
   for (size_t I = 0U; I < MacroList.size(); ++I) {
     const EnumMacro &Macro = MacroList[I];
@@ -510,7 +507,8 @@ void MacroToEnumCallbacks::fixEnumMacro(const MacroList &MacroList) const {
       LangOpts);
   End = SM.translateLineCol(SM.getFileID(End),
                             SM.getSpellingLineNumber(End) + 1, 1);
-  Diagnostic << FixItHint::CreateInsertion(End, EnumEnd);
+  Diagnostic << FixItHint::CreateInsertion(
+      End, (llvm::Twine("};") + LineEnding).str());
 }
 
 void MacroToEnumCheck::registerPPCallbacks(const SourceManager &SM,

--- a/clang-tools-extra/clang-tidy/modernize/MacroToEnumCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/MacroToEnumCheck.cpp
@@ -470,11 +470,18 @@ void MacroToEnumCallbacks::warnMacroEnum(const EnumMacro &Macro) const {
 void MacroToEnumCallbacks::fixEnumMacro(const MacroList &MacroList) const {
   SourceLocation Begin =
       MacroList.front().Directive->getMacroInfo()->getDefinitionLoc();
+  const StringRef LineEnding =
+      SM.getBufferData(SM.getFileID(Begin)).detectEOL();
+  std::string EnumBegin = "enum {";
+  EnumBegin += LineEnding;
+  std::string EnumEnd = "};";
+  EnumEnd += LineEnding;
+
   Begin = SM.translateLineCol(SM.getFileID(Begin),
                               SM.getSpellingLineNumber(Begin), 1);
   const DiagnosticBuilder Diagnostic =
       Check->diag(Begin, "replace macro with enum")
-      << FixItHint::CreateInsertion(Begin, "enum {\n");
+      << FixItHint::CreateInsertion(Begin, EnumBegin);
 
   for (size_t I = 0U; I < MacroList.size(); ++I) {
     const EnumMacro &Macro = MacroList[I];
@@ -503,7 +510,7 @@ void MacroToEnumCallbacks::fixEnumMacro(const MacroList &MacroList) const {
       LangOpts);
   End = SM.translateLineCol(SM.getFileID(End),
                             SM.getSpellingLineNumber(End) + 1, 1);
-  Diagnostic << FixItHint::CreateInsertion(End, "};\n");
+  Diagnostic << FixItHint::CreateInsertion(End, EnumEnd);
 }
 
 void MacroToEnumCheck::registerPPCallbacks(const SourceManager &SM,

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -568,6 +568,10 @@ Changes in existing checks
   positives on project headers that use the same name as a standard library
   header.
 
+- Improved :doc:`modernize-macro-to-enum
+  <clang-tidy/checks/modernize/macro-to-enum>` check by preserving source file
+  line endings in fix-it replacements.
+
 - Improved :doc:`modernize-pass-by-value
   <clang-tidy/checks/modernize/pass-by-value>` check by adding `IgnoreMacros`
   option to suppress warnings in macros.

--- a/clang-tools-extra/test/.gitattributes
+++ b/clang-tools-extra/test/.gitattributes
@@ -13,3 +13,5 @@ clang-tidy/infrastructure/export-diagnostics.cpp -text
 # These test input files rely on two-byte Windows (CRLF) line endings.
 clang-apply-replacements/Inputs/crlf/crlf.cpp -text
 clang-apply-replacements/Inputs/crlf/crlf.cpp.expected -text
+clang-tidy/checkers/modernize/Inputs/macro-to-enum/crlf.cpp -text
+clang-tidy/checkers/modernize/Inputs/macro-to-enum/crlf.cpp.expected -text

--- a/clang-tools-extra/test/.gitattributes
+++ b/clang-tools-extra/test/.gitattributes
@@ -13,5 +13,3 @@ clang-tidy/infrastructure/export-diagnostics.cpp -text
 # These test input files rely on two-byte Windows (CRLF) line endings.
 clang-apply-replacements/Inputs/crlf/crlf.cpp -text
 clang-apply-replacements/Inputs/crlf/crlf.cpp.expected -text
-clang-tidy/checkers/modernize/Inputs/macro-to-enum/crlf.cpp -text
-clang-tidy/checkers/modernize/Inputs/macro-to-enum/crlf.cpp.expected -text

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/Inputs/macro-to-enum/crlf.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/Inputs/macro-to-enum/crlf.cpp
@@ -1,2 +1,0 @@
-#define RED 1
-#define GREEN 2

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/Inputs/macro-to-enum/crlf.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/Inputs/macro-to-enum/crlf.cpp
@@ -1,0 +1,2 @@
+#define RED 1
+#define GREEN 2

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/Inputs/macro-to-enum/crlf.cpp.expected
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/Inputs/macro-to-enum/crlf.cpp.expected
@@ -1,4 +1,0 @@
-enum {
-RED = 1,
-GREEN = 2
-};

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/Inputs/macro-to-enum/crlf.cpp.expected
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/Inputs/macro-to-enum/crlf.cpp.expected
@@ -1,0 +1,4 @@
+enum {
+RED = 1,
+GREEN = 2
+};

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/macro-to-enum-crlf.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/macro-to-enum-crlf.cpp
@@ -1,0 +1,4 @@
+// RUN: cp %S/Inputs/macro-to-enum/crlf.cpp %t.cpp
+// RUN: chmod u+w %t.cpp
+// RUN: clang-tidy %t.cpp -fix --checks='-*,modernize-macro-to-enum' --config={} -- --std=c++14 > %t.out 2>&1
+// RUN: diff %t.cpp %S/Inputs/macro-to-enum/crlf.cpp.expected

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/macro-to-enum-crlf.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/macro-to-enum-crlf.cpp
@@ -1,4 +1,6 @@
+// Verify the fix-it preserves CRLF line endings.
+
 // RUN: cp %S/Inputs/macro-to-enum/crlf.cpp %t.cpp
 // RUN: chmod u+w %t.cpp
-// RUN: clang-tidy %t.cpp -fix --checks='-*,modernize-macro-to-enum' --config={} -- --std=c++14 > %t.out 2>&1
+// RUN: clang-tidy %t.cpp -fix --checks='-*,modernize-macro-to-enum' > %t.out 2>&1
 // RUN: diff %t.cpp %S/Inputs/macro-to-enum/crlf.cpp.expected

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/macro-to-enum-crlf.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/macro-to-enum-crlf.cpp
@@ -1,3 +1,4 @@
-// RUN: %python -c "from pathlib import Path; Path(r'%/t.cpp').write_bytes(b'#define RED 1\r\n#define GREEN 2\r\n')"
+// RUN: cp %S/Inputs/macro-to-enum/crlf.cpp %t.cpp
+// RUN: chmod u+w %t.cpp
 // RUN: clang-tidy %t.cpp -fix --checks='-*,modernize-macro-to-enum' --config={} -- --std=c++14 > %t.out 2>&1
-// RUN: %python -c "from pathlib import Path; data = Path(r'%/t.cpp').read_bytes(); expected = b'enum {\r\nRED = 1,\r\nGREEN = 2\r\n};\r\n'; assert data == expected, data"
+// RUN: diff %t.cpp %S/Inputs/macro-to-enum/crlf.cpp.expected

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/macro-to-enum-crlf.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/macro-to-enum-crlf.cpp
@@ -1,4 +1,3 @@
-// RUN: cp %S/Inputs/macro-to-enum/crlf.cpp %t.cpp
-// RUN: chmod u+w %t.cpp
+// RUN: %python -c "from pathlib import Path; Path(r'%/t.cpp').write_bytes(b'#define RED 1\r\n#define GREEN 2\r\n')"
 // RUN: clang-tidy %t.cpp -fix --checks='-*,modernize-macro-to-enum' --config={} -- --std=c++14 > %t.out 2>&1
-// RUN: diff %t.cpp %S/Inputs/macro-to-enum/crlf.cpp.expected
+// RUN: %python -c "from pathlib import Path; data = Path(r'%/t.cpp').read_bytes(); expected = b'enum {\r\nRED = 1,\r\nGREEN = 2\r\n};\r\n'; assert data == expected, data"


### PR DESCRIPTION
Use `StringRef::detectEOL()` when inserting enum braces so fix-its do not mix LF into CRLF source files.

Closes https://github.com/llvm/llvm-project/issues/61593