### PR TITLE
[clang-doc] Move Generator classes into the anonymous namespace

### DIFF
--- a/clang-tools-extra/clang-doc/HTMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/HTMLGenerator.cpp
@@ -21,19 +21,17 @@
 using namespace llvm;
 using namespace llvm::json;
 using namespace llvm::mustache;
+using namespace clang::doc;
 
-namespace clang {
-namespace doc {
+namespace {
 
 static std::unique_ptr<MustacheTemplateFile> NamespaceTemplate = nullptr;
-
 static std::unique_ptr<MustacheTemplateFile> RecordTemplate = nullptr;
-
 static std::unique_ptr<MustacheTemplateFile> IndexTemplate = nullptr;
 
 class HTMLGenerator : public MustacheGenerator {
 public:
-  static const char *Format;
+  static StringRef Format;
   Error createResources(ClangDocContext &CDCtx) override;
   Error generateDocForInfo(Info *I, raw_ostream &OS,
                            const ClangDocContext &CDCtx) override;
@@ -45,10 +43,12 @@ public:
   Error setupTemplateResources(const ClangDocContext &CDCtx, json::Value &V,
                                SmallString<128> RelativeRootPath);
   llvm::Error generateDocumentation(StringRef RootDir,
-                                    llvm::StringMap<doc::Info *> Infos,
+                                    llvm::StringMap<Info *> Infos,
                                     const ClangDocContext &CDCtx,
                                     std::string DirName) override;
 };
+
+} // namespace
 
 Error HTMLGenerator::setupTemplateFiles(const ClangDocContext &CDCtx) {
   // Template files need to use the native path when they're opened,
@@ -184,21 +184,20 @@ Error HTMLGenerator::createResources(ClangDocContext &CDCtx) {
 }
 
 Error HTMLGenerator::generateDocumentation(StringRef RootDir,
-                                           llvm::StringMap<doc::Info *> Infos,
+                                           llvm::StringMap<Info *> Infos,
                                            const ClangDocContext &CDCtx,
                                            std::string DirName) {
   return MustacheGenerator::generateDocumentation(RootDir, std::move(Infos),
                                                   CDCtx, "html");
 }
 
-const char *HTMLGenerator::Format = "html";
+StringRef HTMLGenerator::Format = "html";
 
 static GeneratorRegistry::Add<HTMLGenerator>
     HTML(HTMLGenerator::Format, "Generator for mustache HTML output.");
 
+namespace clang::doc {
 // This anchor is used to force the linker to link in the generated object
 // file and thus register the generator.
 volatile int HTMLGeneratorAnchorSource = 0;
-
-} // namespace doc
-} // namespace clang
+} // namespace clang::doc

--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -21,9 +21,7 @@
 
 using namespace llvm;
 using namespace llvm::json;
-
-namespace clang {
-namespace doc {
+using namespace clang::doc;
 
 template <typename Container, typename SerializationFunc>
 static void serializeArray(
@@ -35,6 +33,7 @@ static void serializeArray(
 // sophisticated heuristic than number of parameters.
 constexpr static unsigned getMaxParamWrapLimit() { return 2; }
 
+namespace {
 typedef std::function<void(const Reference &, Object &)> ReferenceFunc;
 
 class JSONGenerator : public Generator {
@@ -81,15 +80,14 @@ class JSONGenerator : public Generator {
   }
 
   llvm::DenseMap<const Info *, SmallVector<Context, 4>> ContextsMap;
-  llvm::StringMap<doc::Info *> *Infos = nullptr;
+  llvm::StringMap<Info *> *Infos = nullptr;
   const ClangDocContext *CDCtx;
   bool Markdown;
 
 public:
   static const char *Format;
 
-  Error generateDocumentation(StringRef RootDir,
-                              llvm::StringMap<doc::Info *> Infos,
+  Error generateDocumentation(StringRef RootDir, llvm::StringMap<Info *> Infos,
                               const ClangDocContext &CDCtx,
                               std::string DirName) override;
   Error createResources(ClangDocContext &CDCtx) override;
@@ -98,6 +96,8 @@ public:
   Error generateDocForInfo(Info *I, llvm::raw_ostream &OS,
                            const ClangDocContext &CDCtx) override;
 };
+
+} // namespace
 
 const char *JSONGenerator::Format = "json";
 
@@ -589,11 +589,11 @@ void JSONGenerator::serializeInfo(const TemplateInfo &Template, Object &Obj) {
 
   if (!Template.Params.empty()) {
     bool VerticalDisplay = Template.Params.size() > getMaxParamWrapLimit();
-    serializeArray(Template.Params, TemplateObj, "Parameters",
-                   SerializeTemplateParam, "End",
-                   [VerticalDisplay](Object &JsonObj) {
-                     JsonObj["VerticalDisplay"] = VerticalDisplay;
-                   });
+    ::serializeArray(Template.Params, TemplateObj, "Parameters",
+                     SerializeTemplateParam, "End",
+                     [VerticalDisplay](Object &JsonObj) {
+                       JsonObj["VerticalDisplay"] = VerticalDisplay;
+                     });
   }
 
   if (!Template.Constraints.empty())
@@ -738,10 +738,10 @@ void JSONGenerator::serializeInfo(const RecordInfo &I, json::Object &Obj) {
       json::Value FunctionVal = Object();
       auto &FunctionObj = *FunctionVal.getAsObject();
       serializeInfo(Function, FunctionObj);
-      AccessSpecifier Access = Function->Access;
-      if (Access == AccessSpecifier::AS_public)
+      clang::AccessSpecifier Access = Function->Access;
+      if (Access == clang::AccessSpecifier::AS_public)
         PubFunctionsArrayRef.push_back(FunctionVal);
-      else if (Access == AccessSpecifier::AS_protected)
+      else if (Access == clang::AccessSpecifier::AS_protected)
         ProtFunctionsArrayRef.push_back(FunctionVal);
     }
 
@@ -767,11 +767,11 @@ void JSONGenerator::serializeInfo(const RecordInfo &I, json::Object &Obj) {
       MemberObj["Type"] = Member.Type.Name;
       MemberObj["IsStatic"] = Member.IsStatic;
 
-      if (Member.Access == AccessSpecifier::AS_public)
+      if (Member.Access == clang::AccessSpecifier::AS_public)
         PubMembersArrayRef.push_back(MemberVal);
-      else if (Member.Access == AccessSpecifier::AS_protected)
+      else if (Member.Access == clang::AccessSpecifier::AS_protected)
         ProtMembersArrayRef.push_back(MemberVal);
-      else if (Member.Access == AccessSpecifier::AS_private)
+      else if (Member.Access == clang::AccessSpecifier::AS_private)
         PrivateMembersArrayRef.push_back(MemberVal);
     }
 
@@ -945,7 +945,7 @@ Error JSONGenerator::serializeIndex(StringRef RootDir) {
     json::Value IdxVal = Object();
     auto &IdxObj = *IdxVal.getAsObject();
     if (Markdown)
-      TypeStr.at(0) = toUppercase(TypeStr.at(0));
+      TypeStr.at(0) = clang::toUppercase(TypeStr.at(0));
     IdxObj["Type"] = TypeStr;
     serializeReference(*Idx, IdxObj);
     IndexArrayRef.push_back(IdxVal);
@@ -994,13 +994,13 @@ void JSONGenerator::serializeContexts(Info *I, StringMap<Info *> &Infos) {
 }
 
 Error JSONGenerator::generateDocumentation(StringRef RootDir,
-                                           llvm::StringMap<doc::Info *> Infos,
+                                           llvm::StringMap<Info *> Infos,
                                            const ClangDocContext &CDCtx,
                                            std::string DirName) {
   this->CDCtx = &CDCtx;
   this->Infos = &Infos;
   StringSet<> CreatedDirs;
-  StringMap<std::vector<doc::Info *>> FileToInfos;
+  StringMap<std::vector<Info *>> FileToInfos;
   for (const auto &Group : Infos) {
     Info *Info = Group.getValue();
 
@@ -1067,10 +1067,8 @@ Error JSONGenerator::generateDocForInfo(Info *I, raw_ostream &OS,
   case InfoType::IT_default:
     return createStringError(inconvertibleErrorCode(), "unexpected info type");
   }
-  if (CDCtx.Pretty)
-    OS << llvm::formatv("{0:2}", llvm::json::Value(std::move(Obj)));
-  else
-    OS << llvm::formatv("{0}", llvm::json::Value(std::move(Obj)));
+  StringRef Fmt = CDCtx.Pretty ? "{0:2}" : "{0}";
+  OS << llvm::formatv(Fmt.data(), llvm::json::Value(std::move(Obj)));
   return Error::success();
 }
 
@@ -1080,6 +1078,6 @@ Error JSONGenerator::createResources(ClangDocContext &CDCtx) {
 
 static GeneratorRegistry::Add<JSONGenerator> JSON(JSONGenerator::Format,
                                                   "Generator for JSON output.");
+namespace clang::doc {
 volatile int JSONGeneratorAnchorSource = 0;
-} // namespace doc
-} // namespace clang
+} // namespace clang::doc

--- a/clang-tools-extra/clang-doc/MDGenerator.cpp
+++ b/clang-tools-extra/clang-doc/MDGenerator.cpp
@@ -17,9 +17,7 @@
 #include <string>
 
 using namespace llvm;
-
-namespace clang {
-namespace doc {
+using namespace clang::doc;
 
 // Markdown generation
 
@@ -495,32 +493,35 @@ static llvm::Error genIndex(ClangDocContext &CDCtx) {
   return llvm::Error::success();
 }
 
+namespace {
 /// Generator for Markdown documentation.
 class MDGenerator : public Generator {
 public:
-  static const char *Format;
+  static StringRef Format;
 
   llvm::Error generateDocumentation(StringRef RootDir,
-                                    llvm::StringMap<doc::Info *> Infos,
+                                    llvm::StringMap<Info *> Infos,
                                     const ClangDocContext &CDCtx,
                                     std::string DirName) override;
   llvm::Error createResources(ClangDocContext &CDCtx) override;
   llvm::Error generateDocForInfo(Info *I, llvm::raw_ostream &OS,
                                  const ClangDocContext &CDCtx) override;
 };
+} // namespace
 
-const char *MDGenerator::Format = "md";
+StringRef MDGenerator::Format = "md";
 
-llvm::Error MDGenerator::generateDocumentation(
-    StringRef RootDir, llvm::StringMap<doc::Info *> Infos,
-    const ClangDocContext &CDCtx, std::string DirName) {
+llvm::Error MDGenerator::generateDocumentation(StringRef RootDir,
+                                               llvm::StringMap<Info *> Infos,
+                                               const ClangDocContext &CDCtx,
+                                               std::string DirName) {
   // Track which directories we already tried to create.
   llvm::StringSet<> CreatedDirs;
 
   // Collect all output by file name and create the necessary directories.
-  llvm::StringMap<std::vector<doc::Info *>> FileToInfos;
+  llvm::StringMap<std::vector<Info *>> FileToInfos;
   for (const auto &Group : Infos) {
-    doc::Info *Info = Group.getValue();
+    Info *Info = Group.getValue();
 
     llvm::SmallString<128> Path;
     llvm::sys::path::native(RootDir, Path);
@@ -602,6 +603,9 @@ llvm::Error MDGenerator::createResources(ClangDocContext &CDCtx) {
 
 static GeneratorRegistry::Add<MDGenerator> MD(MDGenerator::Format,
                                               "Generator for MD output.");
+
+namespace clang {
+namespace doc {
 
 // This anchor is used to force the linker to link in the generated object
 // file and thus register the generator.

--- a/clang-tools-extra/clang-doc/MDMustacheGenerator.cpp
+++ b/clang-tools-extra/clang-doc/MDMustacheGenerator.cpp
@@ -16,9 +16,9 @@
 
 #include "Generators.h"
 
-namespace clang {
 using namespace llvm;
-namespace doc {
+using namespace clang::doc;
+
 static std::unique_ptr<MustacheTemplateFile> RecordTemplate = nullptr;
 
 static std::unique_ptr<MustacheTemplateFile> NamespaceTemplate = nullptr;
@@ -27,9 +27,10 @@ static std::unique_ptr<MustacheTemplateFile> AllFilesTemplate = nullptr;
 
 static std::unique_ptr<MustacheTemplateFile> IndexTemplate = nullptr;
 
+namespace {
 struct MDMustacheGenerator : public MustacheGenerator {
   static const char *Format;
-  Error generateDocumentation(StringRef RootDir, StringMap<doc::Info *> Infos,
+  Error generateDocumentation(StringRef RootDir, StringMap<Info *> Infos,
                               const ClangDocContext &CDCtx,
                               std::string DirName) override;
   Error setupTemplateFiles(const ClangDocContext &CDCtx) override;
@@ -42,6 +43,7 @@ struct MDMustacheGenerator : public MustacheGenerator {
   Error generateDocForInfo(Info *I, llvm::raw_ostream &OS,
                            const ClangDocContext &CDCtx) override;
 };
+} // namespace
 
 Error MDMustacheGenerator::setupTemplateFiles(const ClangDocContext &CDCtx) {
   std::string ClassFilePath = CDCtx.MustacheTemplates.lookup("class-template");
@@ -74,7 +76,7 @@ Error MDMustacheGenerator::setupTemplateFiles(const ClangDocContext &CDCtx) {
 }
 
 Error MDMustacheGenerator::generateDocumentation(
-    StringRef RootDir, StringMap<doc::Info *> Infos,
+    StringRef RootDir, StringMap<Info *> Infos,
     const clang::doc::ClangDocContext &CDCtx, std::string Dirname) {
   return MustacheGenerator::generateDocumentation(RootDir, std::move(Infos),
                                                   CDCtx, "md");
@@ -112,6 +114,8 @@ static GeneratorRegistry::Add<MDMustacheGenerator>
     MDMustache(MDMustacheGenerator::Format,
                "Generator for mustache Markdown output.");
 
+namespace clang {
+namespace doc {
 volatile int MDMustacheGeneratorAnchorSource = 0;
 } // namespace doc
 } // namespace clang


### PR DESCRIPTION
Clang-Tidy suggest moving these classes into the anonymous namespace,
to enforce internal linkage.