### PR TITLE
[libc++][span] Test `[[nodiscard]]` applied to `span::iterator`

### DIFF
--- a/libcxx/test/libcxx/containers/views/views.span/nodiscard.iterator.verify.cpp
+++ b/libcxx/test/libcxx/containers/views/views.span/nodiscard.iterator.verify.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: std-at-least-c++20
+
+// <span>
+
+// Check that functions are marked [[nodiscard]]
+
+#include <span>
+
+#include "test_macros.h"
+
+void test() {
+  using Container = std::span<int, 82>;
+
+  int arr[82] = {};
+  Container c{arr};
+  Container::iterator it = c.begin();
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  *it;
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  it[0];
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  it + 1;
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  1 + it;
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  it - 1;
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  it - it;
+}


### PR DESCRIPTION
Adds test coverage.

`[[nodicard]]` applied in:
- https://github.com/llvm/llvm-project/pull/198489
- https://github.com/llvm/llvm-project/pull/198492

Towards #172124