### PR TITLE
[libc++][array] Test `[[nodicard]]`  with `array::const_iterator`

### DIFF
--- a/libcxx/test/libcxx/containers/sequences/array/nodiscard.iterator.verify.cpp
+++ b/libcxx/test/libcxx/containers/sequences/array/nodiscard.iterator.verify.cpp
@@ -17,23 +17,36 @@
 void test() {
   typedef std::array<int, 94> Container;
   Container c;
-  Container::iterator it = c.begin();
+  Container::iterator it        = c.begin();
+  Container::const_iterator cit = c.cbegin();
 
   // expected-warning-re@+1 {{{{(ignoring return value of function declared with 'nodiscard' attribute|expression result unused)}}}}
   *it;
+  // expected-warning-re@+1 {{{{(ignoring return value of function declared with 'nodiscard' attribute|expression result unused)}}}}
+  *cit;
 
   // expected-warning-re@+1 {{{{(ignoring return value of function declared with 'nodiscard' attribute|expression result unused)}}}}
   it[0];
+  // expected-warning-re@+1 {{{{(ignoring return value of function declared with 'nodiscard' attribute|expression result unused)}}}}
+  cit[0];
 
   // expected-warning-re@+1 {{{{(ignoring return value of function declared with 'nodiscard' attribute|expression result unused)}}}}
   it + 1;
+  // expected-warning-re@+1 {{{{(ignoring return value of function declared with 'nodiscard' attribute|expression result unused)}}}}
+  cit + 1;
 
   // expected-warning-re@+1 {{{{(ignoring return value of function declared with 'nodiscard' attribute|expression result unused)}}}}
   1 + it;
+  // expected-warning-re@+1 {{{{(ignoring return value of function declared with 'nodiscard' attribute|expression result unused)}}}}
+  1 + cit;
 
   // expected-warning-re@+1 {{{{(ignoring return value of function declared with 'nodiscard' attribute|expression result unused)}}}}
   it - 1;
+  // expected-warning-re@+1 {{{{(ignoring return value of function declared with 'nodiscard' attribute|expression result unused)}}}}
+  cit - 1;
 
   // expected-warning-re@+1 {{{{(ignoring return value of function declared with 'nodiscard' attribute|expression result unused)}}}}
   it - it;
+  // expected-warning-re@+1 {{{{(ignoring return value of function declared with 'nodiscard' attribute|expression result unused)}}}}
+  cit - cit;
 }


### PR DESCRIPTION
Added tests with `array::const_iterator` for completeness.

Implemented in https://github.com/llvm/llvm-project/pull/198492

Towards #172124