### PR TITLE
[libc][math] Fix arm-linux-gnueabihf target when building with gcc/g++.

### DIFF
--- a/libc/include/llvm-libc-macros/stdfix-macros.h
+++ b/libc/include/llvm-libc-macros/stdfix-macros.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_MACROS_STDFIX_MACROS_H
 #define LLVM_LIBC_MACROS_STDFIX_MACROS_H
 
-#ifdef __FRACT_FBIT__
+#if defined(__FRACT_FBIT__) && defined(__clang__)
 // _Fract and _Accum types are available
 #define LIBC_COMPILER_HAS_FIXED_POINT
 #endif // __FRACT_FBIT__

--- a/libc/src/__support/FPUtil/arm/sqrt.h
+++ b/libc/src/__support/FPUtil/arm/sqrt.h
@@ -26,7 +26,7 @@ namespace fputil {
 #ifdef LIBC_TARGET_CPU_HAS_FPU_FLOAT
 template <> LIBC_INLINE float sqrt<float>(float x) {
   float y;
-  asm("vsqrt %0, %1\n\t" : "=w"(y) : "w"(x));
+  asm("vsqrt.f32 %0, %1\n\t" : "=w"(y) : "w"(x));
   return y;
 }
 #endif // LIBC_TARGET_CPU_HAS_FPU_FLOAT
@@ -34,7 +34,7 @@ template <> LIBC_INLINE float sqrt<float>(float x) {
 #ifdef LIBC_TARGET_CPU_HAS_FPU_DOUBLE
 template <> LIBC_INLINE double sqrt<double>(double x) {
   double y;
-  asm("vsqrt %0, %1\n\t" : "=w"(y) : "w"(x));
+  asm("vsqrt.f64 %P0, %P1\n\t" : "=w"(y) : "w"(x));
   return y;
 }
 #endif // LIBC_TARGET_CPU_HAS_FPU_DOUBLE


### PR DESCRIPTION
- `arm-linux-gnueabihf-gcc` defines fixed point macros (like `__FRACT_FBIT__`) but does not support `_Fract` and `_Accum` types by default.  We just limit the fixed point support to clang for now.
- Specify the types for the sqrt instructions we use for ARM target.

Tested with:
```
$ cmake ../runtimes -GNinja -DLLVM_ENABLE_RUNTIMES=libc -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc-12 \
    -DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g++-12 \
    -DLIBC_TARGET_TRIPLE=arm-linux-gnueabihf
$ export QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf
$ ninja libc-shared-tests
```

https://github.com/llvm/llvm-project/issues/201678.
