### PR TITLE
[SPIRV] Handle atomic users in SPIRVLegalizePointerCast

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
@@ -530,6 +530,15 @@ class SPIRVLegalizePointerCastImpl {
         continue;
       }
 
+      // A raw atomicrmw or cmpxchg consumes the pointer directly, so the
+      // spurious ptrcast ahead of it can be bypassed instead of reaching the
+      // unreachable below.
+      if (isa<AtomicRMWInst>(User) || isa<AtomicCmpXchgInst>(User)) {
+        GR->replaceAllUsesWith(CastedOperand, OriginalOperand,
+                               /* DeleteOld= */ false);
+        continue;
+      }
+
       if (IntrinsicInst *Intrin = dyn_cast<IntrinsicInst>(User)) {
         if (Intrin->getIntrinsicID() == Intrinsic::spv_assign_ptr_type) {
           DeadInstructions.push_back(Intrin);
@@ -537,6 +546,14 @@ class SPIRVLegalizePointerCastImpl {
         }
 
         if (Intrin->getIntrinsicID() == Intrinsic::spv_gep) {
+          GR->replaceAllUsesWith(CastedOperand, OriginalOperand,
+                                 /* DeleteOld= */ false);
+          continue;
+        }
+
+        // spv_cmpxchg consumes the pointer directly; bypass the spurious
+        // ptrcast.
+        if (Intrin->getIntrinsicID() == Intrinsic::spv_cmpxchg) {
           GR->replaceAllUsesWith(CastedOperand, OriginalOperand,
                                  /* DeleteOld= */ false);
           continue;

--- a/llvm/test/CodeGen/SPIRV/passes/SPIRVLegalizePointerCast.ll
+++ b/llvm/test/CodeGen/SPIRV/passes/SPIRVLegalizePointerCast.ll
@@ -6,6 +6,7 @@
 
 @M = internal addrspace(10) global [4 x <2 x float>] zeroinitializer, align 4
 @OUT = internal addrspace(10) global float zeroinitializer, align 4
+@OUTI = internal addrspace(10) global i32 zeroinitializer, align 4
 
 ; Loading a <5 x float> through a [4 x <2 x float>] forces emit-intrinsics to
 ; insert spv.ptrcast; legalize-pointer-cast lowers it to typed <2 x float>
@@ -22,6 +23,35 @@ entry:
   %v = load <5 x float>, ptr addrspace(10) @M, align 4
   %x = extractelement <5 x float> %v, i32 4
   store float %x, ptr addrspace(10) @OUT, align 4
+  ret void
+}
+
+; A cmpxchg whose pointer flows through an spv.ptrcast is handled by
+; legalize-pointer-cast: the cmpxchg consumes the original pointer directly, so
+; the spurious ptrcast is dropped.
+
+define spir_func void @cmpxchg_through_ptrcast() #0 {
+; CHECK-LABEL: define spir_func void @cmpxchg_through_ptrcast(
+; CHECK-NOT: call {{.*}}@llvm.spv.ptrcast
+; CHECK: call i32 {{.*}}@llvm.spv.cmpxchg.p10(ptr addrspace(10) @M,
+entry:
+  %pair = cmpxchg ptr addrspace(10) @M, i32 0, i32 1 monotonic monotonic
+  %old = extractvalue { i32, i1 } %pair, 0
+  store i32 %old, ptr addrspace(10) @OUTI, align 4
+  ret void
+}
+
+; An atomicrmw whose pointer flows through a ptrcast is likewise handled: the
+; atomic consumes the original pointer directly, so the spurious ptrcast is
+; dropped.
+
+define spir_func void @atomicrmw_through_ptrcast() #0 {
+; CHECK-LABEL: define spir_func void @atomicrmw_through_ptrcast(
+; CHECK-NOT: call {{.*}}@llvm.spv.ptrcast
+; CHECK: atomicrmw add ptr addrspace(10) @M,
+entry:
+  %old = atomicrmw add ptr addrspace(10) @M, i32 1 monotonic
+  store i32 %old, ptr addrspace(10) @OUTI, align 4
   ret void
 }
 


### PR DESCRIPTION
`SPIRVLegalizePointerCast` rewrites the users of an `llvm.spv.ptrcast`, but it only handles `load`, `store`, `spv.gep`, `spv.store` and `spv.assign_ptr_type` users. Every other user falls through to

```cpp
llvm_unreachable("Unsupported ptrcast user. Please fix.");
```

a crash in a release (NDEBUG) build.

**Atomic** accesses through a ptrcast were unhandled. This happens when an atomic reads/writes a scalar element of a (possibly aggregate) pointee:

- An `i32` `atomicrmw` / `cmpxchg` whose pointer is a spurious ptrcast (e.g. on a descriptor-bound buffer element)
- An atomic on element 0 of an aggregate (e.g. a Workgroup `shared` array), where the element GEP folds to the aggregate base, so `spirv-emit-intrinsics` inserts an aggregate→scalar ptrcast ahead of the atomic.

Load/store users of such a cast are already legalized; atomics were not. HLSL's interlocked ops lower their pointer differently, so the in-tree frontends never exercised it (surfaced by an out-of-tree frontend emitting `atomicrmw` / `atomicCompareExchange` on buffers and on `shared` memory).

Handle the `atomicrmw` / `cmpxchg` / `llvm.spv.cmpxchg` users the same way as `spv.gep`: replace the casted pointer with the original operand and drop the cast.  Regression cases (cmpxchg + atomicrmw through a ptrcast) are added to `CodeGen/SPIRV/passes/SPIRVLegalizePointerCast.ll`.
---

**AI-tool disclosure** (per the [LLVM AI Tool Policy](https://llvm.org/docs/AIToolPolicy.html)): substantial portions of this change were drafted with Claude, an AI assistant from Anthropic, with the PR author as the human in the loop — reviewing, testing, and taking responsibility for all generated code and tests.

Assisted-by: Claude (Anthropic)
