### PR TITLE
[libc][ci] Add arm-linux-gnueabihf toolchain to libc docker image.

### DIFF
--- a/.github/workflows/containers/libc/Dockerfile
+++ b/.github/workflows/containers/libc/Dockerfile
@@ -26,6 +26,8 @@ RUN apt-get update && \
     libstdc++6-ppc64el-cross \
     gcc-powerpc64le-linux-gnu \
     g++-powerpc64le-linux-gnu \
+    gcc-12-arm-linux-gnueabihf \
+    g++-12-arm-linux-gnueabihf \
     sudo \
     sccache \
     wget \


### PR DESCRIPTION
To prevent regression for arm-linux-gnueabihf target.  See https://github.com/llvm/llvm-project/issues/201678