### PR TITLE
[lld-macho] Replace unordered_{map,set} with Dense{Map,Set}

### DIFF
--- a/lld/MachO/ExportTrie.cpp
+++ b/lld/MachO/ExportTrie.cpp
@@ -38,10 +38,10 @@
 #include "Symbols.h"
 
 #include "lld/Common/ErrorHandler.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/BinaryFormat/MachO.h"
 #include "llvm/Support/LEB128.h"
 #include <optional>
-#include <unordered_set>
 
 using namespace llvm;
 using namespace lld;
@@ -302,10 +302,10 @@ public:
       : fileName(fileName), start(buf), end(start + size), callback(callback) {}
 
   void parse(const uint8_t *buf, const Twine &cumulativeString,
-             std::unordered_set<size_t> &visited);
+             DenseSet<size_t> &visited);
 
   void parse() {
-    std::unordered_set<size_t> visited;
+    DenseSet<size_t> visited;
     parse(start, "", visited);
   }
 
@@ -318,7 +318,7 @@ public:
 } // namespace
 
 void TrieParser::parse(const uint8_t *buf, const Twine &cumulativeString,
-                       std::unordered_set<size_t> &visited) {
+                       DenseSet<size_t> &visited) {
   if (buf >= end)
     fatal(fileName + ": export trie node offset points outside export section");
 

--- a/lld/MachO/SyntheticSections.cpp
+++ b/lld/MachO/SyntheticSections.cpp
@@ -1870,7 +1870,7 @@ void WordLiteralSection::finalizeContents() {
         if (!isec->isLive(off))
           continue;
         uint32_t value = *reinterpret_cast<const uint32_t *>(buf + off);
-        literal4Map.emplace(value, literal4Map.size());
+        literal4Map.try_emplace(value, literal4Map.size());
       }
       break;
     }
@@ -1879,7 +1879,7 @@ void WordLiteralSection::finalizeContents() {
         if (!isec->isLive(off))
           continue;
         uint64_t value = *reinterpret_cast<const uint64_t *>(buf + off);
-        literal8Map.emplace(value, literal8Map.size());
+        literal8Map.try_emplace(value, literal8Map.size());
       }
       break;
     }
@@ -1888,7 +1888,7 @@ void WordLiteralSection::finalizeContents() {
         if (!isec->isLive(off))
           continue;
         UInt128 value = *reinterpret_cast<const UInt128 *>(buf + off);
-        literal16Map.emplace(value, literal16Map.size());
+        literal16Map.try_emplace(value, literal16Map.size());
       }
       break;
     }

--- a/lld/MachO/SyntheticSections.h
+++ b/lld/MachO/SyntheticSections.h
@@ -618,7 +618,7 @@ public:
 private:
   std::vector<WordLiteralInputSection *> inputs;
 
-  // DenseMap supports all possible integer values.
+  // Literal values can be any bit pattern.
   llvm::DenseMap<UInt128, uint64_t> literal16Map;
   llvm::DenseMap<uint64_t, uint64_t> literal8Map;
   llvm::DenseMap<uint32_t, uint64_t> literal4Map;

--- a/lld/MachO/SyntheticSections.h
+++ b/lld/MachO/SyntheticSections.h
@@ -18,14 +18,11 @@
 #include "Writer.h"
 
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/BinaryFormat/MachO.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
-
-#include <unordered_map>
 
 namespace llvm {
 class DWARFUnit;
@@ -621,15 +618,10 @@ public:
 private:
   std::vector<WordLiteralInputSection *> inputs;
 
-  template <class T> struct Hasher {
-    llvm::hash_code operator()(T v) const { return llvm::hash_value(v); }
-  };
-  // We're using unordered_map instead of DenseMap here because we need to
-  // support all possible integer values -- there are no suitable tombstone
-  // values for DenseMap.
-  std::unordered_map<UInt128, uint64_t, Hasher<UInt128>> literal16Map;
-  std::unordered_map<uint64_t, uint64_t> literal8Map;
-  std::unordered_map<uint32_t, uint64_t> literal4Map;
+  // DenseMap supports all possible integer values.
+  llvm::DenseMap<UInt128, uint64_t> literal16Map;
+  llvm::DenseMap<uint64_t, uint64_t> literal8Map;
+  llvm::DenseMap<uint32_t, uint64_t> literal4Map;
 };
 
 class ObjCImageInfoSection final : public SyntheticSection {


### PR DESCRIPTION
DenseMap no longer uses in-band sentinel keys (#201281) and is strictly
superior to unordered_map.
