### PR TITLE
[docs] Kaleidoscope Tutorial Chapter 7 - base class Value* used for AllocaInst for assignment expression

### DIFF
--- a/llvm/docs/tutorial/MyFirstLanguageFrontend/LangImpl07.rst
+++ b/llvm/docs/tutorial/MyFirstLanguageFrontend/LangImpl07.rst
@@ -600,11 +600,11 @@ allowed.
           return nullptr;
 
         // Look up the name.
-        Value *Variable = NamedValues[LHSE->getName()];
-        if (!Variable)
+        AllocaInst *Alloca = NamedValues[LHSE->getName()];
+        if (!Alloca)
           return LogErrorV("Unknown variable name");
 
-        Builder->CreateStore(Val, Variable);
+        Builder->CreateStore(Val, Alloca);
         return Val;
       }
       ...

--- a/llvm/examples/Kaleidoscope/Chapter7/toy.cpp
+++ b/llvm/examples/Kaleidoscope/Chapter7/toy.cpp
@@ -791,11 +791,11 @@ Value *BinaryExprAST::codegen() {
       return nullptr;
 
     // Look up the name.
-    Value *Variable = NamedValues[LHSE->getName()];
-    if (!Variable)
+    AllocaInst *Alloca = NamedValues[LHSE->getName()];
+    if (!Alloca)
       return LogErrorV("Unknown variable name");
 
-    Builder->CreateStore(Val, Variable);
+    Builder->CreateStore(Val, Alloca);
     return Val;
   }
 


### PR DESCRIPTION
Eariler in this chapther, the value type of `NamedValues` was changed to `AllocaInst*`, and so did all other occurs for example in `VariableExprAST` and `ForExprAST`.

https://github.com/llvm/llvm-project/blob/6f8a363a483489687597e29b8bda0975e821f188/llvm/docs/tutorial/MyFirstLanguageFrontend/LangImpl07.rst?plain=1#L321-L324

However, the newly added assignment expression is still using `Value*` as the type for LHS. Although `Value` is the base class of `AllocaInst` therefore the code compiles and works well, it's better to keep it consistent

