### PR TITLE
[clang] Emit i32 args for __builtin_prefetch

### DIFF
--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -4289,7 +4289,6 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   case Builtin::BI__builtin_prefetch: {
     Value *Locality, *RW, *Address = EmitScalarExpr(E->getArg(0));
     unsigned ICEArguments = (1 << 1) | (1 << 2);
-    // FIXME: Technically these constants should of type 'int', yes?
     RW = (E->getNumArgs() > 1) ? EmitScalarOrConstFoldImmArg(ICEArguments, 1, E)
                                : llvm::ConstantInt::get(Int32Ty, 0);
     Locality = (E->getNumArgs() > 2)

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -6492,9 +6492,14 @@ bool Sema::BuiltinPrefetch(CallExpr *TheCall) {
 
   // Argument 0 is checked for us and the remaining arguments must be
   // constant integers.
-  for (unsigned i = 1; i != NumArgs; ++i)
+  for (unsigned i = 1; i != NumArgs; ++i) {
     if (BuiltinConstantArgRange(TheCall, i, 0, i == 1 ? 1 : 3))
       return true;
+
+    ExprResult Arg =
+        ImpCastExprToType(TheCall->getArg(i), Context.IntTy, CK_IntegralCast);
+    TheCall->setArg(i, Arg.get());
+  }
 
   return false;
 }

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -6493,12 +6493,13 @@ bool Sema::BuiltinPrefetch(CallExpr *TheCall) {
   // Argument 0 is checked for us and the remaining arguments must be
   // constant integers.
   for (unsigned i = 1; i != NumArgs; ++i) {
+    Expr *Arg = TheCall->getArg(i);
+    if (convertArgumentToType(*this, Arg, Context.IntTy))
+      return true;
+    TheCall->setArg(i, Arg);
+
     if (BuiltinConstantArgRange(TheCall, i, 0, i == 1 ? 1 : 3))
       return true;
-
-    ExprResult Arg =
-        ImpCastExprToType(TheCall->getArg(i), Context.IntTy, CK_IntegralCast);
-    TheCall->setArg(i, Arg.get());
   }
 
   return false;

--- a/clang/test/CodeGen/PR32874.c
+++ b/clang/test/CodeGen/PR32874.c
@@ -23,6 +23,16 @@ void foo(const int *p) {
   __builtin_prefetch(p, 3U % 2U, 3U % 1U);
 }
 
+// CHECK-LABEL: define{{.*}} void @prefetch_non_int_constant_types
+// CHECK: call void @llvm.prefetch.p0(ptr {{.*}}, i32 0, i32 3, i32 1)
+// CHECK: call void @llvm.prefetch.p0(ptr {{.*}}, i32 0, i32 0, i32 1)
+// CHECK: call void @llvm.prefetch.p0(ptr {{.*}}, i32 1, i32 3, i32 1)
+void prefetch_non_int_constant_types(const int *p) {
+  __builtin_prefetch(p, 0 * sizeof(int));
+  __builtin_prefetch(p, 0, 0 * sizeof(int));
+  __builtin_prefetch(p, 1ULL, 3ULL);
+}
+
 // CHECK-LABEL: define{{.*}} void @ub_constant_arithmetic
 void ub_constant_arithmetic(void) {
   // Check that we still instrument unsafe arithmetic, even if it is known to

--- a/clang/test/Sema/builtin-prefetch.c
+++ b/clang/test/Sema/builtin-prefetch.c
@@ -6,7 +6,7 @@ void foo(void) {
   __builtin_prefetch(&a, 1);
   __builtin_prefetch(&a, 1, 2);
   __builtin_prefetch(&a, 1, 9, 3); // expected-error{{too many arguments to function}}
-  __builtin_prefetch(&a, "hello", 2); // expected-error{{argument to '__builtin_prefetch' must be a constant integer}}
+  __builtin_prefetch(&a, "hello", 2); // expected-error{{incompatible pointer to integer conversion passing 'char *' to parameter of type 'int'}} expected-error{{argument to '__builtin_prefetch' must be a constant integer}}
   __builtin_prefetch(&a, a, 2); // expected-error{{argument to '__builtin_prefetch' must be a constant integer}}
   __builtin_prefetch(&a, 2); // expected-error{{argument value 2 is outside the valid range [0, 1]}}
   __builtin_prefetch(&a, 0, 4); // expected-error{{argument value 4 is outside the valid range [0, 3]}}

--- a/clang/test/SemaCXX/prefetch-enum.cpp
+++ b/clang/test/SemaCXX/prefetch-enum.cpp
@@ -4,7 +4,17 @@
 
 enum X { A = 3 };
 
+struct ReadWrite {
+  constexpr operator int() const { return 1; }
+};
+
+struct Locality {
+  constexpr operator int() const { return 3; }
+};
+
 void Test() {
   char ch;
   __builtin_prefetch(&ch, 0, A);
+  __builtin_prefetch(&ch, ReadWrite());
+  __builtin_prefetch(&ch, 0, Locality());
 }


### PR DESCRIPTION
I fixed a Clang CodeGen crash where valid __builtin_prefetch calls using non-int constant expressions, like sizeof or ULL constants, could produce LLVM IR arguments with the wrong type. The optional prefetch arguments are already checked by Sema as small integer constants, so this change lowers them directly as i32 constants to match llvm.prefetch’s immarg signature. I also added a regression test covering sizeof and unsigned long long constants.

Fixes #202061