### PR TITLE
[InstCombine] Fold afn powi(2.0, x) to ldexp(1.0, x)

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -2521,11 +2521,12 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
     }
     if (ConstantFP *Base = dyn_cast<ConstantFP>(II->getArgOperand(0))) {
       Value *Exp = II->getArgOperand(1);
+      Type *Ty = Base->getType();
       // powi(2.0, p) -> ldexp(1.0, p)
-      if (Base->isExactlyValue(2.0) && II->hasApproxFunc()) {
-        ConstantFP *One = ConstantFP::get(Base->getType(), 1.0);
-        Value *Ldexp = Builder.CreateIntrinsic(
-            Intrinsic::ldexp, {II->getType(), Exp->getType()}, {One, Exp}, II);
+      if (II->hasApproxFunc() && Ty->isFloatingPointTy() &&
+          Base->isExactlyValue(2.0)) {
+        ConstantFP *One = ConstantFP::get(Ty, 1.0);
+        Value *Ldexp = Builder.CreateLdexp(One, Exp, II);
         return replaceInstUsesWith(*II, Ldexp);
       }
     }

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -2523,9 +2523,10 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
       Value *Exp = II->getArgOperand(1);
       Type *Ty = Base->getType();
       // powi(2.0, p) -> ldexp(1.0, p)
-      if (II->hasApproxFunc() && Ty->isFloatingPointTy() &&
-          Base->isExactlyValue(2.0)) {
+      if (II->hasApproxFunc() && Base->isExactlyValue(2.0)) {
         ConstantFP *One = ConstantFP::get(Ty, 1.0);
+        if (auto *VTy = dyn_cast<VectorType>(Ty))
+          Exp = Builder.CreateVectorSplat(VTy->getElementCount(), Exp);
         Value *Ldexp = Builder.CreateLdexp(One, Exp, II);
         return replaceInstUsesWith(*II, Ldexp);
       }

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -2522,7 +2522,7 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
     if (ConstantFP *Base = dyn_cast<ConstantFP>(II->getArgOperand(0))) {
       Value *Exp = II->getArgOperand(1);
       // powi(2.0, p) -> ldexp(1.0, p)
-      if (Base->isExactlyValue(2.f) && II->hasApproxFunc()) {
+      if (Base->isExactlyValue(2.0) && II->hasApproxFunc()) {
         ConstantFP *One = ConstantFP::get(Base->getType(), 1.0);
         Value *Ldexp = Builder.CreateIntrinsic(
             Intrinsic::ldexp, {II->getType(), Exp->getType()}, {One, Exp}, II);

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -2494,7 +2494,7 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
     if (auto *SkippedBarrier = simplifyInvariantGroupIntrinsic(*II, *this))
       return replaceInstUsesWith(*II, SkippedBarrier);
     break;
-  case Intrinsic::powi:
+  case Intrinsic::powi: {
     if (ConstantInt *Power = dyn_cast<ConstantInt>(II->getArgOperand(1))) {
       // 0 and 1 are handled in instsimplify
       // powi(x, -1) -> 1/x
@@ -2519,7 +2519,18 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
           return replaceOperand(*II, 0, X);
       }
     }
+    if (ConstantFP *Base = dyn_cast<ConstantFP>(II->getArgOperand(0))) {
+      Value *Exp = II->getArgOperand(1);
+      // powi(2.0, p) -> ldexp(1.0, p)
+      if (Base->isExactlyValue(2.f) && II->hasApproxFunc()) {
+        ConstantFP *One = ConstantFP::get(Base->getType(), 1.0);
+        Value *Ldexp = Builder.CreateIntrinsic(
+            Intrinsic::ldexp, {II->getType(), Exp->getType()}, {One, Exp}, II);
+        return replaceInstUsesWith(*II, Ldexp);
+      }
+    }
     break;
+  }
 
   case Intrinsic::cttz:
   case Intrinsic::ctlz:

--- a/llvm/test/Transforms/InstCombine/powi.ll
+++ b/llvm/test/Transforms/InstCombine/powi.ll
@@ -662,35 +662,64 @@ define float @pow_2_i_ldexp_1_i_afn_f32(i32 %i) {
 ; CHECK-NEXT:    [[TMP1:%.*]] = call afn float @llvm.ldexp.f32.i32(float 1.000000e+00, i32 [[I:%.*]])
 ; CHECK-NEXT:    ret float [[TMP1]]
 ;
-  %1 = tail call afn float @llvm.powi.f32.i32(float 2.000000e+00, i32 %i)
+  %1 = call afn float @llvm.powi.f32.i32(float 2.000000e+00, i32 %i)
   ret float %1
 }
 
-define float @fmul_a_pow_2_i_ldexp_1_a_afn_f32(float %a, i32 %i) {
-; CHECK-LABEL: @fmul_a_pow_2_i_ldexp_1_a_afn_f32(
+define float @fmul_a_pow_2_i_ldexp_a_i_afn_f32(float %a, i32 %i) {
+; CHECK-LABEL: @fmul_a_pow_2_i_ldexp_a_i_afn_f32(
 ; CHECK-NEXT:    [[TMP1:%.*]] = call reassoc float @llvm.ldexp.f32.i32(float [[A:%.*]], i32 [[I:%.*]])
 ; CHECK-NEXT:    ret float [[TMP1]]
 ;
-  %1 = tail call afn reassoc float @llvm.powi.f32.i32(float 2.000000e+00, i32 %i)
+  %1 = call afn reassoc float @llvm.powi.f32.i32(float 2.000000e+00, i32 %i)
   %2 = fmul reassoc float %a, %1
   ret float %2
 }
 
-define double @pow_2_i_ldexp_1_a_afn_f64(i32 %i) {
-; CHECK-LABEL: @pow_2_i_ldexp_1_a_afn_f64(
+define double @pow_2_i_ldexp_1_i_afn_f64(i32 %i) {
+; CHECK-LABEL: @pow_2_i_ldexp_1_i_afn_f64(
 ; CHECK-NEXT:    [[TMP1:%.*]] = call afn double @llvm.ldexp.f64.i32(double 1.000000e+00, i32 [[I:%.*]])
 ; CHECK-NEXT:    ret double [[TMP1]]
 ;
-  %1 = tail call afn double @llvm.powi.f64.i32(double 2.000000e+00, i32 %i)
+  %1 = call afn double @llvm.powi.f64.i32(double 2.000000e+00, i32 %i)
   ret double %1
 }
 
-define double @fmul_a_pow_2_i_ldexp_1_a_afn_f64(double %a, i32 %i) {
-; CHECK-LABEL: @fmul_a_pow_2_i_ldexp_1_a_afn_f64(
+define double @fmul_a_pow_2_i_ldexp_a_i_afn_f64(double %a, i32 %i) {
+; CHECK-LABEL: @fmul_a_pow_2_i_ldexp_a_i_afn_f64(
 ; CHECK-NEXT:    [[TMP1:%.*]] = call reassoc double @llvm.ldexp.f64.i32(double [[A:%.*]], i32 [[I:%.*]])
 ; CHECK-NEXT:    ret double [[TMP1]]
 ;
-  %1 = tail call afn reassoc double @llvm.powi.f64.i32(double 2.000000e+00, i32 %i)
+  %1 = call afn reassoc double @llvm.powi.f64.i32(double 2.000000e+00, i32 %i)
   %2 = fmul reassoc double %a, %1
   ret double %2
+}
+
+define <4 x float> @pow_2_i_ldexp_1_i_afn_v4f32(i32 %i) {
+; CHECK-LABEL: @pow_2_i_ldexp_1_i_afn_v4f32(
+; CHECK-NEXT:    [[TMP1:%.*]] = call afn <4 x float> @llvm.ldexp.v4f32.i32(<4 x float> splat (float 1.000000e+00), i32 [[I:%.*]])
+; CHECK-NEXT:    ret <4 x float> [[TMP1]]
+;
+  %1 = call afn <4 x float> @llvm.powi.v4f32.i32(<4 x float> <float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00>, i32 %i)
+  ret <4 x float> %1
+}
+
+define <4 x float> @pow_2_i_ldexp_a_i_afn_v4f32(<4 x float> %a, i32 %i) {
+; CHECK-LABEL: @pow_2_i_ldexp_a_i_afn_v4f32(
+; CHECK-NEXT:    [[TMP1:%.*]] = call reassoc <4 x float> @llvm.ldexp.v4f32.i32(<4 x float> [[A:%.*]], i32 [[I:%.*]])
+; CHECK-NEXT:    ret <4 x float> [[TMP1]]
+;
+  %1 = call afn reassoc <4 x float> @llvm.powi.v4f32.i32(<4 x float> <float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00>, i32 %i)
+  %2 = fmul reassoc <4 x float> %a, %1
+  ret <4 x float> %2
+}
+
+define <4 x double> @pow_2_i_ldexp_a_i_afn_v4f64(<4 x double> %a, i32 %i) {
+; CHECK-LABEL: @pow_2_i_ldexp_a_i_afn_v4f64(
+; CHECK-NEXT:    [[TMP1:%.*]] = call reassoc <4 x double> @llvm.ldexp.v4f64.i32(<4 x double> [[A:%.*]], i32 [[I:%.*]])
+; CHECK-NEXT:    ret <4 x double> [[TMP1]]
+;
+  %1 = call afn reassoc <4 x double> @llvm.powi.v4f64.i32(<4 x double> <double 2.000000e+00, double 2.000000e+00, double 2.000000e+00, double 2.000000e+00>, i32 %i)
+  %2 = fmul reassoc <4 x double> %a, %1
+  ret <4 x double> %2
 }

--- a/llvm/test/Transforms/InstCombine/powi.ll
+++ b/llvm/test/Transforms/InstCombine/powi.ll
@@ -646,3 +646,32 @@ define <3 x float> @powi_unary_shuffle_ops_use(<3 x float> %x, i32 %power, ptr %
   %r = call <3 x float> @llvm.powi(<3 x float> %sx, i32 %power)
   ret <3 x float> %r
 }
+
+; Negative test: Missing afn flag on call
+define float @pow_i_2_ldexp_1_no_afn(i32 %i) {
+; CHECK-LABEL: @pow_i_2_ldexp_1_no_afn(
+; CHECK-NEXT:    [[TMP1:%.*]] = tail call float @llvm.powi.f32.i32(float 2.000000e+00, i32 [[I:%.*]])
+; CHECK-NEXT:    ret float [[TMP1]]
+;
+  %1 = tail call float @llvm.powi.f32.i32(float 2.000000e+00, i32 %i)
+  ret float %1
+}
+
+define float @pow_i_2_ldexp_1_afn(i32 %i) {
+; CHECK-LABEL: @pow_i_2_ldexp_1_afn(
+; CHECK-NEXT:    [[TMP1:%.*]] = call afn float @llvm.ldexp.f32.i32(float 1.000000e+00, i32 [[I:%.*]])
+; CHECK-NEXT:    ret float [[TMP1]]
+;
+  %1 = tail call afn float @llvm.powi.f32.i32(float 2.000000e+00, i32 %i)
+  ret float %1
+}
+
+define float @a_fmul_pow_i_2_ldexp_a_afn(float %a, i32 %i) {
+; CHECK-LABEL: @a_fmul_pow_i_2_ldexp_a_afn(
+; CHECK-NEXT:    [[TMP1:%.*]] = call reassoc float @llvm.ldexp.f32.i32(float [[A:%.*]], i32 [[I:%.*]])
+; CHECK-NEXT:    ret float [[TMP1]]
+;
+  %1 = tail call afn reassoc float @llvm.powi.f32.i32(float 2.000000e+00, i32 %i)
+  %2 = fmul reassoc float %a, %1
+  ret float %2
+}

--- a/llvm/test/Transforms/InstCombine/powi.ll
+++ b/llvm/test/Transforms/InstCombine/powi.ll
@@ -648,8 +648,8 @@ define <3 x float> @powi_unary_shuffle_ops_use(<3 x float> %x, i32 %power, ptr %
 }
 
 ; Negative test: Missing afn flag on call
-define float @pow_i_2_ldexp_1_no_afn_f32(i32 %i) {
-; CHECK-LABEL: @pow_i_2_ldexp_1_no_afn_f32(
+define float @pow_2_i_ldexp_1_i_no_afn_f32(i32 %i) {
+; CHECK-LABEL: @pow_2_i_ldexp_1_i_no_afn_f32(
 ; CHECK-NEXT:    [[TMP1:%.*]] = tail call float @llvm.powi.f32.i32(float 2.000000e+00, i32 [[I:%.*]])
 ; CHECK-NEXT:    ret float [[TMP1]]
 ;
@@ -657,8 +657,8 @@ define float @pow_i_2_ldexp_1_no_afn_f32(i32 %i) {
   ret float %1
 }
 
-define float @pow_i_2_ldexp_1_afn_f32(i32 %i) {
-; CHECK-LABEL: @pow_i_2_ldexp_1_afn_f32(
+define float @pow_2_i_ldexp_1_i_afn_f32(i32 %i) {
+; CHECK-LABEL: @pow_2_i_ldexp_1_i_afn_f32(
 ; CHECK-NEXT:    [[TMP1:%.*]] = call afn float @llvm.ldexp.f32.i32(float 1.000000e+00, i32 [[I:%.*]])
 ; CHECK-NEXT:    ret float [[TMP1]]
 ;
@@ -666,8 +666,8 @@ define float @pow_i_2_ldexp_1_afn_f32(i32 %i) {
   ret float %1
 }
 
-define float @a_fmul_pow_i_2_ldexp_a_afn_f32(float %a, i32 %i) {
-; CHECK-LABEL: @a_fmul_pow_i_2_ldexp_a_afn_f32(
+define float @fmul_a_pow_2_i_ldexp_1_a_afn_f32(float %a, i32 %i) {
+; CHECK-LABEL: @fmul_a_pow_2_i_ldexp_1_a_afn_f32(
 ; CHECK-NEXT:    [[TMP1:%.*]] = call reassoc float @llvm.ldexp.f32.i32(float [[A:%.*]], i32 [[I:%.*]])
 ; CHECK-NEXT:    ret float [[TMP1]]
 ;
@@ -676,8 +676,8 @@ define float @a_fmul_pow_i_2_ldexp_a_afn_f32(float %a, i32 %i) {
   ret float %2
 }
 
-define double @pow_i_2_ldexp_1_afn_f64(i32 %i) {
-; CHECK-LABEL: @pow_i_2_ldexp_1_afn_f64(
+define double @pow_2_i_ldexp_1_a_afn_f64(i32 %i) {
+; CHECK-LABEL: @pow_2_i_ldexp_1_a_afn_f64(
 ; CHECK-NEXT:    [[TMP1:%.*]] = call afn double @llvm.ldexp.f64.i32(double 1.000000e+00, i32 [[I:%.*]])
 ; CHECK-NEXT:    ret double [[TMP1]]
 ;
@@ -685,8 +685,8 @@ define double @pow_i_2_ldexp_1_afn_f64(i32 %i) {
   ret double %1
 }
 
-define double @a_fmul_pow_i_2_ldexp_a_afn_f64(double %a, i32 %i) {
-; CHECK-LABEL: @a_fmul_pow_i_2_ldexp_a_afn_f64(
+define double @fmul_a_pow_2_i_ldexp_1_a_afn_f64(double %a, i32 %i) {
+; CHECK-LABEL: @fmul_a_pow_2_i_ldexp_1_a_afn_f64(
 ; CHECK-NEXT:    [[TMP1:%.*]] = call reassoc double @llvm.ldexp.f64.i32(double [[A:%.*]], i32 [[I:%.*]])
 ; CHECK-NEXT:    ret double [[TMP1]]
 ;

--- a/llvm/test/Transforms/InstCombine/powi.ll
+++ b/llvm/test/Transforms/InstCombine/powi.ll
@@ -695,18 +695,21 @@ define double @fmul_a_pow_2_i_ldexp_a_i_afn_f64(double %a, i32 %i) {
   ret double %2
 }
 
+; Negative test: Vector base
 define <4 x float> @pow_2_i_ldexp_1_i_afn_v4f32(i32 %i) {
 ; CHECK-LABEL: @pow_2_i_ldexp_1_i_afn_v4f32(
-; CHECK-NEXT:    [[TMP1:%.*]] = call afn <4 x float> @llvm.ldexp.v4f32.i32(<4 x float> splat (float 1.000000e+00), i32 [[I:%.*]])
+; CHECK-NEXT:    [[TMP1:%.*]] = call afn <4 x float> @llvm.powi.v4f32.i32(<4 x float> splat (float 2.000000e+00), i32 [[I:%.*]])
 ; CHECK-NEXT:    ret <4 x float> [[TMP1]]
 ;
   %1 = call afn <4 x float> @llvm.powi.v4f32.i32(<4 x float> <float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00>, i32 %i)
   ret <4 x float> %1
 }
 
+; Negative test: Vector base
 define <4 x float> @pow_2_i_ldexp_a_i_afn_v4f32(<4 x float> %a, i32 %i) {
 ; CHECK-LABEL: @pow_2_i_ldexp_a_i_afn_v4f32(
-; CHECK-NEXT:    [[TMP1:%.*]] = call reassoc <4 x float> @llvm.ldexp.v4f32.i32(<4 x float> [[A:%.*]], i32 [[I:%.*]])
+; CHECK-NEXT:    [[TMP2:%.*]] = call reassoc afn <4 x float> @llvm.powi.v4f32.i32(<4 x float> splat (float 2.000000e+00), i32 [[I:%.*]])
+; CHECK-NEXT:    [[TMP1:%.*]] = fmul reassoc <4 x float> [[A:%.*]], [[TMP2]]
 ; CHECK-NEXT:    ret <4 x float> [[TMP1]]
 ;
   %1 = call afn reassoc <4 x float> @llvm.powi.v4f32.i32(<4 x float> <float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00>, i32 %i)
@@ -714,9 +717,11 @@ define <4 x float> @pow_2_i_ldexp_a_i_afn_v4f32(<4 x float> %a, i32 %i) {
   ret <4 x float> %2
 }
 
+; Negative test: Vector base
 define <4 x double> @pow_2_i_ldexp_a_i_afn_v4f64(<4 x double> %a, i32 %i) {
 ; CHECK-LABEL: @pow_2_i_ldexp_a_i_afn_v4f64(
-; CHECK-NEXT:    [[TMP1:%.*]] = call reassoc <4 x double> @llvm.ldexp.v4f64.i32(<4 x double> [[A:%.*]], i32 [[I:%.*]])
+; CHECK-NEXT:    [[TMP2:%.*]] = call reassoc afn <4 x double> @llvm.powi.v4f64.i32(<4 x double> splat (double 2.000000e+00), i32 [[I:%.*]])
+; CHECK-NEXT:    [[TMP1:%.*]] = fmul reassoc <4 x double> [[A:%.*]], [[TMP2]]
 ; CHECK-NEXT:    ret <4 x double> [[TMP1]]
 ;
   %1 = call afn reassoc <4 x double> @llvm.powi.v4f64.i32(<4 x double> <double 2.000000e+00, double 2.000000e+00, double 2.000000e+00, double 2.000000e+00>, i32 %i)

--- a/llvm/test/Transforms/InstCombine/powi.ll
+++ b/llvm/test/Transforms/InstCombine/powi.ll
@@ -695,20 +695,22 @@ define double @fmul_a_pow_2_i_ldexp_a_i_afn_f64(double %a, i32 %i) {
   ret double %2
 }
 
-; Negative test: Vector base
 define <4 x float> @pow_2_i_ldexp_1_i_afn_v4f32(i32 %i) {
 ; CHECK-LABEL: @pow_2_i_ldexp_1_i_afn_v4f32(
-; CHECK-NEXT:    [[TMP1:%.*]] = call afn <4 x float> @llvm.powi.v4f32.i32(<4 x float> splat (float 2.000000e+00), i32 [[I:%.*]])
+; CHECK-NEXT:    [[DOTSPLATINSERT:%.*]] = insertelement <4 x i32> poison, i32 [[I:%.*]], i64 0
+; CHECK-NEXT:    [[TMP2:%.*]] = call afn <4 x float> @llvm.ldexp.v4f32.v4i32(<4 x float> <float 1.000000e+00, float poison, float poison, float poison>, <4 x i32> [[DOTSPLATINSERT]])
+; CHECK-NEXT:    [[TMP1:%.*]] = shufflevector <4 x float> [[TMP2]], <4 x float> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    ret <4 x float> [[TMP1]]
 ;
   %1 = call afn <4 x float> @llvm.powi.v4f32.i32(<4 x float> <float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00>, i32 %i)
   ret <4 x float> %1
 }
 
-; Negative test: Vector base
 define <4 x float> @pow_2_i_ldexp_a_i_afn_v4f32(<4 x float> %a, i32 %i) {
 ; CHECK-LABEL: @pow_2_i_ldexp_a_i_afn_v4f32(
-; CHECK-NEXT:    [[TMP2:%.*]] = call reassoc afn <4 x float> @llvm.powi.v4f32.i32(<4 x float> splat (float 2.000000e+00), i32 [[I:%.*]])
+; CHECK-NEXT:    [[DOTSPLATINSERT:%.*]] = insertelement <4 x i32> poison, i32 [[I:%.*]], i64 0
+; CHECK-NEXT:    [[TMP3:%.*]] = call reassoc nnan afn <4 x float> @llvm.ldexp.v4f32.v4i32(<4 x float> <float 1.000000e+00, float poison, float poison, float poison>, <4 x i32> [[DOTSPLATINSERT]])
+; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <4 x float> [[TMP3]], <4 x float> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    [[TMP1:%.*]] = fmul reassoc <4 x float> [[A:%.*]], [[TMP2]]
 ; CHECK-NEXT:    ret <4 x float> [[TMP1]]
 ;
@@ -717,10 +719,11 @@ define <4 x float> @pow_2_i_ldexp_a_i_afn_v4f32(<4 x float> %a, i32 %i) {
   ret <4 x float> %2
 }
 
-; Negative test: Vector base
 define <4 x double> @pow_2_i_ldexp_a_i_afn_v4f64(<4 x double> %a, i32 %i) {
 ; CHECK-LABEL: @pow_2_i_ldexp_a_i_afn_v4f64(
-; CHECK-NEXT:    [[TMP2:%.*]] = call reassoc afn <4 x double> @llvm.powi.v4f64.i32(<4 x double> splat (double 2.000000e+00), i32 [[I:%.*]])
+; CHECK-NEXT:    [[DOTSPLATINSERT:%.*]] = insertelement <4 x i32> poison, i32 [[I:%.*]], i64 0
+; CHECK-NEXT:    [[TMP3:%.*]] = call reassoc nnan afn <4 x double> @llvm.ldexp.v4f64.v4i32(<4 x double> <double 1.000000e+00, double poison, double poison, double poison>, <4 x i32> [[DOTSPLATINSERT]])
+; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <4 x double> [[TMP3]], <4 x double> poison, <4 x i32> zeroinitializer
 ; CHECK-NEXT:    [[TMP1:%.*]] = fmul reassoc <4 x double> [[A:%.*]], [[TMP2]]
 ; CHECK-NEXT:    ret <4 x double> [[TMP1]]
 ;

--- a/llvm/test/Transforms/InstCombine/powi.ll
+++ b/llvm/test/Transforms/InstCombine/powi.ll
@@ -648,8 +648,8 @@ define <3 x float> @powi_unary_shuffle_ops_use(<3 x float> %x, i32 %power, ptr %
 }
 
 ; Negative test: Missing afn flag on call
-define float @pow_i_2_ldexp_1_no_afn(i32 %i) {
-; CHECK-LABEL: @pow_i_2_ldexp_1_no_afn(
+define float @pow_i_2_ldexp_1_no_afn_f32(i32 %i) {
+; CHECK-LABEL: @pow_i_2_ldexp_1_no_afn_f32(
 ; CHECK-NEXT:    [[TMP1:%.*]] = tail call float @llvm.powi.f32.i32(float 2.000000e+00, i32 [[I:%.*]])
 ; CHECK-NEXT:    ret float [[TMP1]]
 ;
@@ -657,8 +657,8 @@ define float @pow_i_2_ldexp_1_no_afn(i32 %i) {
   ret float %1
 }
 
-define float @pow_i_2_ldexp_1_afn(i32 %i) {
-; CHECK-LABEL: @pow_i_2_ldexp_1_afn(
+define float @pow_i_2_ldexp_1_afn_f32(i32 %i) {
+; CHECK-LABEL: @pow_i_2_ldexp_1_afn_f32(
 ; CHECK-NEXT:    [[TMP1:%.*]] = call afn float @llvm.ldexp.f32.i32(float 1.000000e+00, i32 [[I:%.*]])
 ; CHECK-NEXT:    ret float [[TMP1]]
 ;
@@ -666,12 +666,31 @@ define float @pow_i_2_ldexp_1_afn(i32 %i) {
   ret float %1
 }
 
-define float @a_fmul_pow_i_2_ldexp_a_afn(float %a, i32 %i) {
-; CHECK-LABEL: @a_fmul_pow_i_2_ldexp_a_afn(
+define float @a_fmul_pow_i_2_ldexp_a_afn_f32(float %a, i32 %i) {
+; CHECK-LABEL: @a_fmul_pow_i_2_ldexp_a_afn_f32(
 ; CHECK-NEXT:    [[TMP1:%.*]] = call reassoc float @llvm.ldexp.f32.i32(float [[A:%.*]], i32 [[I:%.*]])
 ; CHECK-NEXT:    ret float [[TMP1]]
 ;
   %1 = tail call afn reassoc float @llvm.powi.f32.i32(float 2.000000e+00, i32 %i)
   %2 = fmul reassoc float %a, %1
   ret float %2
+}
+
+define double @pow_i_2_ldexp_1_afn_f64(i32 %i) {
+; CHECK-LABEL: @pow_i_2_ldexp_1_afn_f64(
+; CHECK-NEXT:    [[TMP1:%.*]] = call afn double @llvm.ldexp.f64.i32(double 1.000000e+00, i32 [[I:%.*]])
+; CHECK-NEXT:    ret double [[TMP1]]
+;
+  %1 = tail call afn double @llvm.powi.f64.i32(double 2.000000e+00, i32 %i)
+  ret double %1
+}
+
+define double @a_fmul_pow_i_2_ldexp_a_afn_f64(double %a, i32 %i) {
+; CHECK-LABEL: @a_fmul_pow_i_2_ldexp_a_afn_f64(
+; CHECK-NEXT:    [[TMP1:%.*]] = call reassoc double @llvm.ldexp.f64.i32(double [[A:%.*]], i32 [[I:%.*]])
+; CHECK-NEXT:    ret double [[TMP1]]
+;
+  %1 = tail call afn reassoc double @llvm.powi.f64.i32(double 2.000000e+00, i32 %i)
+  %2 = fmul reassoc double %a, %1
+  ret double %2
 }


### PR DESCRIPTION
This PR adds a conservative InstCombine fold `powi(2.0, x) -> ldexp(1.0, x)` with an `afn` flag.
This together with the existing fold `y * ldexp(1.0, x) -> ldexp(y, x)` makes it possible to optimize cases like `y * __builtin_powif(2.0f, x)` under fast-math.

The fold is intentionally limited to cases where the base is exactly 2.0 for now to make it simple.

Fixes #200654