### PR TITLE
[TableGen] Fix crash of !switch parse in defvar context

### DIFF
--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -2865,10 +2865,12 @@ const Init *TGParser::ParseOperationSwitch(Record *CurRec,
 
     // Parse the mandatory default value.
     if (consume(tgtok::r_paren)) {
-      // The default value was parsed without the ItemType hint. Coerce it now
-      // to match case-value parses.
-      if (const Init *Coerced = V->convertInitializerTo(ItemType))
-        V = Coerced;
+      if (ItemType) {
+        // The default value was parsed without the ItemType hint. Coerce it now
+        // to match case-value parses.
+        if (const Init *Coerced = V->convertInitializerTo(ItemType))
+          V = Coerced;
+      }
       // Push the default value as the last element of the vector for
       // type-checking.
       Vals.push_back(V);

--- a/llvm/test/TableGen/switch.td
+++ b/llvm/test/TableGen/switch.td
@@ -11,6 +11,34 @@ def rec_b : Rec<20>;
 def rec_c : Rec<30>;
 def rec_d : Rec<40>;
 
+// Regression test for a crash in ParseOperationSwitch - convertInitializerTo()
+// dereferenced the null target type in a defvar context.
+// (99 / "k99") misses, so the mandatory default is selected.
+// CHECK-LABEL: def defvar_default
+// CHECK:   color = "default";
+// CHECK:   age = 10;
+// CHECK:   rec_val = rec_a;
+// CHECK:   string_key = "v1";
+// CHECK:   bits_val = { 1, 1 };
+// CHECK:   single_bit = 1;
+// CHECK:   list_val = [7, 8, 9];
+defvar dv_color = !switch(99, 1: "red", 2: "green", 3: "blue", "default");
+defvar dv_age = !switch(99, 1: 20, 2: 30, 3: 40, 10);
+defvar dv_rec_val = !switch(99, 1: rec_b, 2: rec_c, 3: rec_d, rec_a);
+defvar dv_string_key = !switch("k99", "k1": "v2", "k2": "v3", "k3": "v4", "v1");
+defvar dv_bits_val = !switch(99, 1: {0, 1}, 2: {1, 0}, {1, 1});
+defvar dv_single_bit = !switch(99, 1: !eq(0, 0), 2: !eq(0, 1), !eq(1, 1));
+defvar dv_list_val = !switch(99, 1: [1, 2, 3], 2: [4, 5, 6], [7, 8, 9]);
+def defvar_default {
+  string color = dv_color;
+  int age = dv_age;
+  Rec rec_val = dv_rec_val;
+  string string_key = dv_string_key;
+  bits<2> bits_val = dv_bits_val;
+  bit single_bit = dv_single_bit;
+  list<int> list_val = dv_list_val;
+}
+
 // Used inside a class (resolution is deferred until template-arg substitution)
 class Labeled<int N> {
   string label = !switch(N, 1: "one", 2: "two", 3: "three", "many");


### PR DESCRIPTION
`ListInit::convertInitializerTo()` and similar variants do not perform a nullptr check. Adding a check to the caller parse method and a test case for defvar.