### PR TITLE
[clang] Fix PredefinedSugarType reported as CXType_Unexposed

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -2653,6 +2653,7 @@ class TypeKind(BaseEnumeration):
     HLSLRESOURCE = 179
     HLSLATTRIBUTEDRESOURCE = 180
     HLSLINLINESPIRV = 181
+    PREDEFINEDSUGAR = 182
 
 class RefQualifierKind(BaseEnumeration):
     """Describes a specific ref-qualifier of a type."""

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -915,6 +915,9 @@ libclang
 - Fix crash in clang_getBinaryOperatorKindSpelling and clang_getUnaryOperatorKindSpelling
 - The clang_Module_getASTFile API is deprecated and now always returns nullptr
 - The clang_Cursor_getCommentRange API will now return a comment range for macro definitions that have documentation comments.
+- Added CXType_PredefinedSugar for __ptrdiff_t, __size_t, and
+  __signed_size_t types, which are no longer exposed as
+  CXType_Unexposed.
 
 Code Completion
 ---------------

--- a/clang/include/clang-c/Index.h
+++ b/clang/include/clang-c/Index.h
@@ -3043,7 +3043,9 @@ enum CXTypeKind {
   /* HLSL Types */
   CXType_HLSLResource = 179,
   CXType_HLSLAttributedResource = 180,
-  CXType_HLSLInlineSpirv = 181
+  CXType_HLSLInlineSpirv = 181,
+
+  CXType_PredefinedSugar = 182
 };
 
 /**

--- a/clang/test/Index/print-type-predefined-sugar.cpp
+++ b/clang/test/Index/print-type-predefined-sugar.cpp
@@ -1,0 +1,12 @@
+// RUN: c-index-test -test-print-type %s -target x86_64-pc-linux-gnu -std=c++23 | FileCheck %s
+
+typedef struct { void **unused; } S;
+void test(S *x, S *y) {
+  (void)(x - y);
+  (void)sizeof(*x);
+  (void)0z;
+}
+
+// CHECK: BinaryOperator=- [type=__ptrdiff_t] [typekind=PredefinedSugar] [canonicaltype=long] [canonicaltypekind=Long] [isPOD=1]
+// CHECK: UnaryExpr= [type=__size_t] [typekind=PredefinedSugar] [canonicaltype=unsigned long] [canonicaltypekind=ULong] [isPOD=1]
+// CHECK: IntegerLiteral= [type=__signed_size_t] [typekind=PredefinedSugar] [canonicaltype=long] [canonicaltypekind=Long] [isPOD=1]

--- a/clang/tools/libclang/CXType.cpp
+++ b/clang/tools/libclang/CXType.cpp
@@ -122,6 +122,7 @@ static CXTypeKind GetTypeKind(QualType T) {
     TKCASE(Attributed);
     TKCASE(BTFTagAttributed);
     TKCASE(Atomic);
+    TKCASE(PredefinedSugar);
     default:
       return CXType_Unexposed;
   }
@@ -651,6 +652,7 @@ CXString clang_getTypeKindSpelling(enum CXTypeKind K) {
     TKIND(BTFTagAttributed);
     TKIND(HLSLAttributedResource);
     TKIND(HLSLInlineSpirv);
+    TKIND(PredefinedSugar);
     TKIND(BFloat16);
 #define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) TKIND(Id);
 #include "clang/Basic/OpenCLImageTypes.def"


### PR DESCRIPTION
Fix #192268.