### PR TITLE
[InstCombine] Freeze X in fabs(X) op fabs(X) -> X op X to fix undef unsoundness

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
@@ -616,8 +616,11 @@ Instruction *InstCombinerImpl::foldFPSignBitOps(BinaryOperator &I) {
 
   // fabs(X) * fabs(X) -> X * X
   // fabs(X) / fabs(X) -> X / X
-  if (Op0 == Op1 && match(Op0, m_FAbs(m_Value(X))))
+  if (Op0 == Op1 && match(Op0, m_FAbs(m_Value(X)))) {
+    if (!I.hasNoNaNs() && !I.hasNoInfs() && !isGuaranteedNotToBeUndef(X))
+      X = Builder.CreateFreeze(X, X->getName() + ".fr");
     return BinaryOperator::CreateWithCopiedFlags(Opcode, X, X, &I);
+  }
 
   // fabs(X) * fabs(Y) --> fabs(X * Y)
   // fabs(X) / fabs(Y) --> fabs(X / Y)

--- a/llvm/test/Transforms/InstCombine/fdiv.ll
+++ b/llvm/test/Transforms/InstCombine/fdiv.ll
@@ -591,7 +591,8 @@ define float @fdiv_fneg1_extra_use(float %x, float %y) {
 
 define float @fabs_same_op(float %x) {
 ; CHECK-LABEL: @fabs_same_op(
-; CHECK-NEXT:    [[R:%.*]] = fdiv float [[X_FR:%.*]], [[X_FR]]
+; CHECK-NEXT:    [[X_FR:%.*]] = freeze float [[X:%.*]]
+; CHECK-NEXT:    [[R:%.*]] = fdiv float [[X_FR]], [[X_FR]]
 ; CHECK-NEXT:    ret float [[R]]
 ;
   %a = call float @llvm.fabs.f32(float %x)
@@ -624,7 +625,8 @@ define float @fabs_same_op_ninf(float %x) {
 
 define float @fabs_same_op_nsz(float %x) {
 ; CHECK-LABEL: @fabs_same_op_nsz(
-; CHECK-NEXT:    [[R:%.*]] = fdiv nsz float [[X_FR:%.*]], [[X_FR]]
+; CHECK-NEXT:    [[X_FR:%.*]] = freeze float [[X:%.*]]
+; CHECK-NEXT:    [[R:%.*]] = fdiv nsz float [[X_FR]], [[X_FR]]
 ; CHECK-NEXT:    ret float [[R]]
 ;
   %a = call float @llvm.fabs.f32(float %x)

--- a/llvm/test/Transforms/InstCombine/fdiv.ll
+++ b/llvm/test/Transforms/InstCombine/fdiv.ll
@@ -591,7 +591,7 @@ define float @fdiv_fneg1_extra_use(float %x, float %y) {
 
 define float @fabs_same_op(float %x) {
 ; CHECK-LABEL: @fabs_same_op(
-; CHECK-NEXT:    [[R:%.*]] = fdiv float [[X:%.*]], [[X]]
+; CHECK-NEXT:    [[R:%.*]] = fdiv float [[X_FR:%.*]], [[X_FR]]
 ; CHECK-NEXT:    ret float [[R]]
 ;
   %a = call float @llvm.fabs.f32(float %x)
@@ -601,14 +601,34 @@ define float @fabs_same_op(float %x) {
 
 define float @fabs_same_op_extra_use(float %x) {
 ; CHECK-LABEL: @fabs_same_op_extra_use(
-; CHECK-NEXT:    [[A:%.*]] = call float @llvm.fabs.f32(float [[X:%.*]])
+; CHECK-NEXT:    [[A:%.*]] = call float @llvm.fabs.f32(float [[X_FR:%.*]])
 ; CHECK-NEXT:    call void @use_f32(float [[A]])
-; CHECK-NEXT:    [[R:%.*]] = fdiv reassoc ninf float [[X]], [[X]]
+; CHECK-NEXT:    [[R:%.*]] = fdiv reassoc ninf float [[X_FR]], [[X_FR]]
 ; CHECK-NEXT:    ret float [[R]]
 ;
   %a = call float @llvm.fabs.f32(float %x)
   call void @use_f32(float %a)
   %r = fdiv ninf reassoc float %a, %a
+  ret float %r
+}
+
+define float @fabs_same_op_ninf(float %x) {
+; CHECK-LABEL: @fabs_same_op_ninf(
+; CHECK-NEXT:    [[R:%.*]] = fdiv ninf float [[X:%.*]], [[X]]
+; CHECK-NEXT:    ret float [[R]]
+;
+  %a = call float @llvm.fabs.f32(float %x)
+  %r = fdiv ninf float %a, %a
+  ret float %r
+}
+
+define float @fabs_same_op_nsz(float %x) {
+; CHECK-LABEL: @fabs_same_op_nsz(
+; CHECK-NEXT:    [[R:%.*]] = fdiv nsz float [[X_FR:%.*]], [[X_FR]]
+; CHECK-NEXT:    ret float [[R]]
+;
+  %a = call float @llvm.fabs.f32(float %x)
+  %r = fdiv nsz float %a, %a
   ret float %r
 }
 

--- a/llvm/test/Transforms/InstCombine/fmul.ll
+++ b/llvm/test/Transforms/InstCombine/fmul.ll
@@ -462,7 +462,8 @@ declare float @llvm.fabs.f32(float) nounwind readnone
 
 define float @fabs_squared(float %x) {
 ; CHECK-LABEL: @fabs_squared(
-; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X_FR:%.*]], [[X_FR]]
+; CHECK-NEXT:    [[X_FR:%.*]] = freeze float [[X:%.*]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X_FR]], [[X_FR]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %x.fabs = call float @llvm.fabs.f32(float %x)
@@ -502,7 +503,8 @@ define float @fabs_squared_ninf(float %x) {
 
 define float @fabs_squared_nsz(float %x) {
 ; CHECK-LABEL: @fabs_squared_nsz(
-; CHECK-NEXT:    [[MUL:%.*]] = fmul nsz float [[X_FR:%.*]], [[X_FR]]
+; CHECK-NEXT:    [[X_FR:%.*]] = freeze float [[X:%.*]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nsz float [[X_FR]], [[X_FR]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %x.fabs = call float @llvm.fabs.f32(float %x)

--- a/llvm/test/Transforms/InstCombine/fmul.ll
+++ b/llvm/test/Transforms/InstCombine/fmul.ll
@@ -462,7 +462,7 @@ declare float @llvm.fabs.f32(float) nounwind readnone
 
 define float @fabs_squared(float %x) {
 ; CHECK-LABEL: @fabs_squared(
-; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X:%.*]], [[X]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X_FR:%.*]], [[X_FR]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %x.fabs = call float @llvm.fabs.f32(float %x)
@@ -472,11 +472,51 @@ define float @fabs_squared(float %x) {
 
 define float @fabs_squared_fast(float %x) {
 ; CHECK-LABEL: @fabs_squared_fast(
-; CHECK-NEXT:    [[MUL:%.*]] = fmul fast float [[X:%.*]], [[X]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul fast float [[X_FR:%.*]], [[X_FR]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %x.fabs = call float @llvm.fabs.f32(float %x)
   %mul = fmul fast float %x.fabs, %x.fabs
+  ret float %mul
+}
+
+define float @fabs_squared_nnan(float %x) {
+; CHECK-LABEL: @fabs_squared_nnan(
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan float [[X:%.*]], [[X]]
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %x.fabs = call float @llvm.fabs.f32(float %x)
+  %mul = fmul nnan float %x.fabs, %x.fabs
+  ret float %mul
+}
+
+define float @fabs_squared_ninf(float %x) {
+; CHECK-LABEL: @fabs_squared_ninf(
+; CHECK-NEXT:    [[MUL:%.*]] = fmul ninf float [[X:%.*]], [[X]]
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %x.fabs = call float @llvm.fabs.f32(float %x)
+  %mul = fmul ninf float %x.fabs, %x.fabs
+  ret float %mul
+}
+
+define float @fabs_squared_nsz(float %x) {
+; CHECK-LABEL: @fabs_squared_nsz(
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nsz float [[X_FR:%.*]], [[X_FR]]
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %x.fabs = call float @llvm.fabs.f32(float %x)
+  %mul = fmul nsz float %x.fabs, %x.fabs
+  ret float %mul
+}
+
+define float @fabs_squared_noundef(float noundef %x) {
+; CHECK-LABEL: @fabs_squared_noundef(
+; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X:%.*]], [[X]]
+; CHECK-NEXT:    ret float [[MUL]]
+;
+  %x.fabs = call float @llvm.fabs.f32(float %x)
+  %mul = fmul float %x.fabs, %x.fabs
   ret float %mul
 }
 


### PR DESCRIPTION
[InstCombine] Freeze X in fabs(X) op fabs(X) -> X op X to fix undef unsoundness
Folding
```
Y = fabs(X);
Z = Y * Y;
```
into
```
Z = X * X;
```
is unsound when X is undef, because each use of X may take a different value.
The same applies to fdiv fabs(X), fabs(X) -> X / X (which may then fold to 1.0).

Fix this by freezing X when needed. The freeze is unnecessary when the fmul or
fdiv carries a fast-math flag that can produce poison (nnan or ninf): undef can
be refined to a value that makes the result poison, and poison can be refined to
any value, so reusing X is sound without the freeze.