### PR TITLE
[Clang][ItaniumMangle] Skip requires-expression body contexts

### DIFF
--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -2206,7 +2206,7 @@ void CXXNameMangler::manglePrefix(const DeclContext *DC, bool NoFunction) {
   assert(!isa<LinkageSpecDecl>(DC) && "prefix cannot be LinkageSpecDecl");
 
   while (DC->isRequiresExprBody())
-      DC = Context.getEffectiveParentContext(DC);
+    DC = Context.getEffectiveParentContext(DC);
 
   if (DC->isTranslationUnit())
     return;

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -1090,7 +1090,7 @@ void CXXNameMangler::mangleNameWithAbiTags(
   }
 
   while (DC->isRequiresExprBody())
-    DC = DC->getParent();
+    DC = Context.getEffectiveParentContext(DC);
 
   if (DC->isTranslationUnit() || isStdNamespace(DC)) {
     // Check if we have a template.
@@ -2204,6 +2204,9 @@ void CXXNameMangler::manglePrefix(const DeclContext *DC, bool NoFunction) {
   //           ::= <substitution>
 
   assert(!isa<LinkageSpecDecl>(DC) && "prefix cannot be LinkageSpecDecl");
+
+  while (DC->isRequiresExprBody())
+      DC = Context.getEffectiveParentContext(DC);
 
   if (DC->isTranslationUnit())
     return;

--- a/clang/test/CodeGenCXX/mangle-lambdas-gh181933.cpp
+++ b/clang/test/CodeGenCXX/mangle-lambdas-gh181933.cpp
@@ -1,0 +1,42 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -emit-llvm -o /dev/null %s
+
+namespace GH181933 {
+template <typename Predicate>
+void foo(Predicate pred) {
+  pred(42);
+}
+
+template <typename Predicate>
+auto bar(Predicate pred) {
+  foo(pred);
+}
+
+template <typename T>
+concept Baz = requires(const T& x) {
+  {
+    bar([](const auto&) { return true; })
+  };
+};
+
+static_assert(Baz<int>);
+}
+
+namespace PR {
+template <typename Predicate>
+void foo(Predicate pred) {
+  pred(42);
+}
+
+template <typename Predicate>
+auto bar(Predicate pred) {
+  foo(pred);
+}
+
+extern "C++" {
+static_assert(requires(const int& x) {
+  {
+    bar([](const auto&) { return true; })
+  };
+});
+}
+}


### PR DESCRIPTION
DC's parent may not be a `RequiresExprBody`, but a `RequiresExprBody` may indirectly exist in the context chain. In this case, `RequiresExprBody` will leak into `manglePrefix` and cause a crash. This patch makes `manglePrefix` skip `RequiresExprBody` DCs to fix it.

Use `getEffectiveParentContext` instead of `getParent` because some contexts, such as `extern`, also cannot be leaked into the next mangling step.

Fixes #181933