### PR TITLE
[bazel] Mark llvm_configure reproducible

### DIFF
--- a/utils/bazel/configure.bzl
+++ b/utils/bazel/configure.bzl
@@ -198,10 +198,10 @@ def _llvm_configure_impl(repository_ctx):
         executable = False,
     )
 
+    return repository_ctx.repo_metadata(reproducible = True)
+
 llvm_configure = repository_rule(
     implementation = _llvm_configure_impl,
-    local = True,
-    configure = True,
     attrs = {
         "targets": attr.string_list(default = DEFAULT_TARGETS),
     },


### PR DESCRIPTION
## Summary

Make `llvm_configure` return `repo_metadata(reproducible = True)` and remove `local = True` and `configure = True` from the repository rule declaration.

## Why

`llvm_configure` originally searched `PATH` for Python and executed `overlay_directories.py` with the host Python interpreter. Those host dependencies justified `local = True` and `configure = True` when the rule was introduced in `4aeb2e60df98`.

Commit `744480a2a6b8` rewrote overlay creation in Starlark and removed the host Python lookup and process execution. The current implementation reads `@llvm-raw` and its checked-in Bazel overlay, reads checked-in CMake files, and creates repository output files and symlinks. It does not read environment variables, inspect `PATH`, or execute host tools.

Returning reproducible repository metadata lets Bazel cache and reuse the repository output according to the repository inputs. The `local` and `configure` classifications are no longer accurate.

## Validation

- `buildifier -mode=check utils/bazel/configure.bzl`
- `git diff --check`
- applied the same patch through hermetic-llvm and ran `bazel mod deps` with Bazel 9.1.0
