### PR TITLE
compiler-rt: Suppress -g error for gpu builds

### DIFF
--- a/compiler-rt/CMakeLists.txt
+++ b/compiler-rt/CMakeLists.txt
@@ -523,7 +523,6 @@ if (APPLE AND NOT CMAKE_LINKER MATCHES ".*lld.*")
 endif()
 
 # Build sanitizer runtimes with debug info.
-# GPU targets (amdgcn, nvptx, spirv64) may not support debug info flags.
 if(MSVC)
   # Use /Z7 instead of /Zi for the asan runtime. This avoids the LNK4099
   # warning from the MS linker complaining that it can't find the 'vc140.pdb'
@@ -536,19 +535,17 @@ if(MSVC)
     string(REGEX REPLACE "(^| )/Z[i7I]($| )" " /Z7 "
            "${var_to_update}" "${${var_to_update}}")
   endforeach()
-elseif(NOT "${COMPILER_RT_DEFAULT_TARGET_ARCH}" MATCHES "amdgcn|nvptx|spirv64")
-  if(APPLE)
-    # On Apple platforms use full debug info (i.e. not `-gline-tables-only`)
-    # for all build types so that the runtime can be debugged.
-    if(NOT COMPILER_RT_HAS_G_FLAG)
-      message(FATAL_ERROR "-g is not supported by host compiler")
-    endif()
-    list(APPEND SANITIZER_COMMON_CFLAGS -g)
-  elseif(COMPILER_RT_HAS_GLINE_TABLES_ONLY_FLAG AND NOT COMPILER_RT_DEBUG)
-    list(APPEND SANITIZER_COMMON_CFLAGS -gline-tables-only)
-  elseif(COMPILER_RT_HAS_G_FLAG)
-    list(APPEND SANITIZER_COMMON_CFLAGS -g)
+elseif("${COMPILER_RT_DEFAULT_TARGET_TRIPLE}" MATCHES "apple")
+  # On Apple platforms use full debug info (i.e. not `-gline-tables-only`)
+  # for all build types so that the runtime can be debugged.
+  if(NOT COMPILER_RT_HAS_G_FLAG)
+    message(FATAL_ERROR "-g is not supported by host compiler")
   endif()
+  list(APPEND SANITIZER_COMMON_CFLAGS -g)
+elseif(COMPILER_RT_HAS_GLINE_TABLES_ONLY_FLAG AND NOT COMPILER_RT_DEBUG)
+  list(APPEND SANITIZER_COMMON_CFLAGS -gline-tables-only)
+elseif(COMPILER_RT_HAS_G_FLAG)
+  list(APPEND SANITIZER_COMMON_CFLAGS -g)
 endif()
 
 if(LLVM_ENABLE_MODULES)

--- a/compiler-rt/CMakeLists.txt
+++ b/compiler-rt/CMakeLists.txt
@@ -523,6 +523,7 @@ if (APPLE AND NOT CMAKE_LINKER MATCHES ".*lld.*")
 endif()
 
 # Build sanitizer runtimes with debug info.
+# GPU targets (amdgcn, nvptx, spirv64) may not support debug info flags.
 if(MSVC)
   # Use /Z7 instead of /Zi for the asan runtime. This avoids the LNK4099
   # warning from the MS linker complaining that it can't find the 'vc140.pdb'
@@ -535,17 +536,19 @@ if(MSVC)
     string(REGEX REPLACE "(^| )/Z[i7I]($| )" " /Z7 "
            "${var_to_update}" "${${var_to_update}}")
   endforeach()
-elseif(APPLE)
-  # On Apple platforms use full debug info (i.e. not `-gline-tables-only`)
-  # for all build types so that the runtime can be debugged.
-  if(NOT COMPILER_RT_HAS_G_FLAG)
-    message(FATAL_ERROR "-g is not supported by host compiler")
+elseif(NOT "${COMPILER_RT_DEFAULT_TARGET_ARCH}" MATCHES "amdgcn|nvptx|spirv64")
+  if(APPLE)
+    # On Apple platforms use full debug info (i.e. not `-gline-tables-only`)
+    # for all build types so that the runtime can be debugged.
+    if(NOT COMPILER_RT_HAS_G_FLAG)
+      message(FATAL_ERROR "-g is not supported by host compiler")
+    endif()
+    list(APPEND SANITIZER_COMMON_CFLAGS -g)
+  elseif(COMPILER_RT_HAS_GLINE_TABLES_ONLY_FLAG AND NOT COMPILER_RT_DEBUG)
+    list(APPEND SANITIZER_COMMON_CFLAGS -gline-tables-only)
+  elseif(COMPILER_RT_HAS_G_FLAG)
+    list(APPEND SANITIZER_COMMON_CFLAGS -g)
   endif()
-  list(APPEND SANITIZER_COMMON_CFLAGS -g)
-elseif(COMPILER_RT_HAS_GLINE_TABLES_ONLY_FLAG AND NOT COMPILER_RT_DEBUG)
-  list(APPEND SANITIZER_COMMON_CFLAGS -gline-tables-only)
-elseif(COMPILER_RT_HAS_G_FLAG)
-  list(APPEND SANITIZER_COMMON_CFLAGS -g)
 endif()
 
 if(LLVM_ENABLE_MODULES)

--- a/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
@@ -426,7 +426,6 @@ macro(construct_compiler_rt_default_triple)
     # Pass the necessary flags to make flag detection work.
     if("${COMPILER_RT_DEFAULT_TARGET_ARCH}" MATCHES "amdgcn")
       set(COMPILER_RT_GPU_BUILD ON)
-      set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -nogpulib")
     elseif("${COMPILER_RT_DEFAULT_TARGET_ARCH}" MATCHES "nvptx|spirv64")
       set(COMPILER_RT_GPU_BUILD ON)
       set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -flto -c")

--- a/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
@@ -426,6 +426,7 @@ macro(construct_compiler_rt_default_triple)
     # Pass the necessary flags to make flag detection work.
     if("${COMPILER_RT_DEFAULT_TARGET_ARCH}" MATCHES "amdgcn")
       set(COMPILER_RT_GPU_BUILD ON)
+      set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -nogpulib")
     elseif("${COMPILER_RT_DEFAULT_TARGET_ARCH}" MATCHES "nvptx|spirv64")
       set(COMPILER_RT_GPU_BUILD ON)
       set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -flto -c")


### PR DESCRIPTION
Currently a RelWithDebInfo build fails when gpu targets
are enabled enabled as runtime targets on apple hosts. if (APPLE) is true
even when the compile target is not apple, so match against the vendor
part of the triple instead. Also perform the -g test with -nogpulib for amdgpu,
so the check doesn't fail due to not finding device libs.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>