### PR TITLE
[libclang/python] Upgrade latest Python version in CI to 3.14

### DIFF
--- a/.github/workflows/libclang-python-tests.yml
+++ b/.github/workflows/libclang-python-tests.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.13"]
+        python-version: ["3.8", "3.14"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
As pointed out in https://discourse.llvm.org/t/libclang-python-binding-tests-seem-inefficient/90984/3, the latest Python version currently used in the bindings tests is not the latest stable version. 
Upgrade to the latest stable Python version (3.14), see here: https://devguide.python.org/versions/