### PR TITLE
[test] Regenerate CSKY/M68k codegen tests after atomic and error-message changes

### DIFF
--- a/llvm/test/CodeGen/CSKY/atomic-rmw.ll
+++ b/llvm/test/CodeGen/CSKY/atomic-rmw.ll
@@ -14,7 +14,7 @@ define i8 @atomicrmw_xchg_i8_monotonic(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI0_0:
 ; CSKY-NEXT:    .long __atomic_exchange_1
   %1 = atomicrmw xchg ptr %a, i8 %b monotonic
@@ -33,7 +33,7 @@ define i8 @atomicrmw_xchg_i8_acquire(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI1_0:
 ; CSKY-NEXT:    .long __atomic_exchange_1
   %1 = atomicrmw xchg ptr %a, i8 %b acquire
@@ -52,7 +52,7 @@ define i8 @atomicrmw_xchg_i8_release(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI2_0:
 ; CSKY-NEXT:    .long __atomic_exchange_1
   %1 = atomicrmw xchg ptr %a, i8 %b release
@@ -71,7 +71,7 @@ define i8 @atomicrmw_xchg_i8_acq_rel(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI3_0:
 ; CSKY-NEXT:    .long __atomic_exchange_1
   %1 = atomicrmw xchg ptr %a, i8 %b acq_rel
@@ -90,7 +90,7 @@ define i8 @atomicrmw_xchg_i8_seq_cst(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI4_0:
 ; CSKY-NEXT:    .long __atomic_exchange_1
   %1 = atomicrmw xchg ptr %a, i8 %b seq_cst
@@ -109,7 +109,7 @@ define i8 @atomicrmw_add_i8_monotonic(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI5_0:
 ; CSKY-NEXT:    .long __atomic_fetch_add_1
   %1 = atomicrmw add ptr %a, i8 %b monotonic
@@ -128,7 +128,7 @@ define i8 @atomicrmw_add_i8_acquire(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI6_0:
 ; CSKY-NEXT:    .long __atomic_fetch_add_1
   %1 = atomicrmw add ptr %a, i8 %b acquire
@@ -147,7 +147,7 @@ define i8 @atomicrmw_add_i8_release(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI7_0:
 ; CSKY-NEXT:    .long __atomic_fetch_add_1
   %1 = atomicrmw add ptr %a, i8 %b release
@@ -166,7 +166,7 @@ define i8 @atomicrmw_add_i8_acq_rel(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI8_0:
 ; CSKY-NEXT:    .long __atomic_fetch_add_1
   %1 = atomicrmw add ptr %a, i8 %b acq_rel
@@ -185,7 +185,7 @@ define i8 @atomicrmw_add_i8_seq_cst(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI9_0:
 ; CSKY-NEXT:    .long __atomic_fetch_add_1
   %1 = atomicrmw add ptr %a, i8 %b seq_cst
@@ -204,7 +204,7 @@ define i8 @atomicrmw_sub_i8_monotonic(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI10_0:
 ; CSKY-NEXT:    .long __atomic_fetch_sub_1
   %1 = atomicrmw sub ptr %a, i8 %b monotonic
@@ -223,7 +223,7 @@ define i8 @atomicrmw_sub_i8_acquire(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI11_0:
 ; CSKY-NEXT:    .long __atomic_fetch_sub_1
   %1 = atomicrmw sub ptr %a, i8 %b acquire
@@ -242,7 +242,7 @@ define i8 @atomicrmw_sub_i8_release(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI12_0:
 ; CSKY-NEXT:    .long __atomic_fetch_sub_1
   %1 = atomicrmw sub ptr %a, i8 %b release
@@ -261,7 +261,7 @@ define i8 @atomicrmw_sub_i8_acq_rel(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI13_0:
 ; CSKY-NEXT:    .long __atomic_fetch_sub_1
   %1 = atomicrmw sub ptr %a, i8 %b acq_rel
@@ -280,7 +280,7 @@ define i8 @atomicrmw_sub_i8_seq_cst(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI14_0:
 ; CSKY-NEXT:    .long __atomic_fetch_sub_1
   %1 = atomicrmw sub ptr %a, i8 %b seq_cst
@@ -299,7 +299,7 @@ define i8 @atomicrmw_and_i8_monotonic(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI15_0:
 ; CSKY-NEXT:    .long __atomic_fetch_and_1
   %1 = atomicrmw and ptr %a, i8 %b monotonic
@@ -318,7 +318,7 @@ define i8 @atomicrmw_and_i8_acquire(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI16_0:
 ; CSKY-NEXT:    .long __atomic_fetch_and_1
   %1 = atomicrmw and ptr %a, i8 %b acquire
@@ -337,7 +337,7 @@ define i8 @atomicrmw_and_i8_release(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI17_0:
 ; CSKY-NEXT:    .long __atomic_fetch_and_1
   %1 = atomicrmw and ptr %a, i8 %b release
@@ -356,7 +356,7 @@ define i8 @atomicrmw_and_i8_acq_rel(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI18_0:
 ; CSKY-NEXT:    .long __atomic_fetch_and_1
   %1 = atomicrmw and ptr %a, i8 %b acq_rel
@@ -375,7 +375,7 @@ define i8 @atomicrmw_and_i8_seq_cst(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI19_0:
 ; CSKY-NEXT:    .long __atomic_fetch_and_1
   %1 = atomicrmw and ptr %a, i8 %b seq_cst
@@ -394,7 +394,7 @@ define i8 @atomicrmw_nand_i8_monotonic(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI20_0:
 ; CSKY-NEXT:    .long __atomic_fetch_nand_1
   %1 = atomicrmw nand ptr %a, i8 %b monotonic
@@ -413,7 +413,7 @@ define i8 @atomicrmw_nand_i8_acquire(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI21_0:
 ; CSKY-NEXT:    .long __atomic_fetch_nand_1
   %1 = atomicrmw nand ptr %a, i8 %b acquire
@@ -432,7 +432,7 @@ define i8 @atomicrmw_nand_i8_release(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI22_0:
 ; CSKY-NEXT:    .long __atomic_fetch_nand_1
   %1 = atomicrmw nand ptr %a, i8 %b release
@@ -451,7 +451,7 @@ define i8 @atomicrmw_nand_i8_acq_rel(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI23_0:
 ; CSKY-NEXT:    .long __atomic_fetch_nand_1
   %1 = atomicrmw nand ptr %a, i8 %b acq_rel
@@ -470,7 +470,7 @@ define i8 @atomicrmw_nand_i8_seq_cst(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI24_0:
 ; CSKY-NEXT:    .long __atomic_fetch_nand_1
   %1 = atomicrmw nand ptr %a, i8 %b seq_cst
@@ -489,7 +489,7 @@ define i8 @atomicrmw_or_i8_monotonic(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI25_0:
 ; CSKY-NEXT:    .long __atomic_fetch_or_1
   %1 = atomicrmw or ptr %a, i8 %b monotonic
@@ -508,7 +508,7 @@ define i8 @atomicrmw_or_i8_acquire(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI26_0:
 ; CSKY-NEXT:    .long __atomic_fetch_or_1
   %1 = atomicrmw or ptr %a, i8 %b acquire
@@ -527,7 +527,7 @@ define i8 @atomicrmw_or_i8_release(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI27_0:
 ; CSKY-NEXT:    .long __atomic_fetch_or_1
   %1 = atomicrmw or ptr %a, i8 %b release
@@ -546,7 +546,7 @@ define i8 @atomicrmw_or_i8_acq_rel(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI28_0:
 ; CSKY-NEXT:    .long __atomic_fetch_or_1
   %1 = atomicrmw or ptr %a, i8 %b acq_rel
@@ -565,7 +565,7 @@ define i8 @atomicrmw_or_i8_seq_cst(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI29_0:
 ; CSKY-NEXT:    .long __atomic_fetch_or_1
   %1 = atomicrmw or ptr %a, i8 %b seq_cst
@@ -584,7 +584,7 @@ define i8 @atomicrmw_xor_i8_monotonic(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI30_0:
 ; CSKY-NEXT:    .long __atomic_fetch_xor_1
   %1 = atomicrmw xor ptr %a, i8 %b monotonic
@@ -603,7 +603,7 @@ define i8 @atomicrmw_xor_i8_acquire(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI31_0:
 ; CSKY-NEXT:    .long __atomic_fetch_xor_1
   %1 = atomicrmw xor ptr %a, i8 %b acquire
@@ -622,7 +622,7 @@ define i8 @atomicrmw_xor_i8_release(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI32_0:
 ; CSKY-NEXT:    .long __atomic_fetch_xor_1
   %1 = atomicrmw xor ptr %a, i8 %b release
@@ -641,7 +641,7 @@ define i8 @atomicrmw_xor_i8_acq_rel(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI33_0:
 ; CSKY-NEXT:    .long __atomic_fetch_xor_1
   %1 = atomicrmw xor ptr %a, i8 %b acq_rel
@@ -660,7 +660,7 @@ define i8 @atomicrmw_xor_i8_seq_cst(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI34_0:
 ; CSKY-NEXT:    .long __atomic_fetch_xor_1
   %1 = atomicrmw xor ptr %a, i8 %b seq_cst
@@ -679,21 +679,22 @@ define i8 @atomicrmw_max_i8_monotonic(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.b a0, (a0, 0)
-; CSKY-NEXT:    sextb16 l2, a1
-; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI35_0]
+; CSKY-NEXT:    sextb16 l3, l0
 ; CSKY-NEXT:  .LBB35_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    sextb16 a1, a0
-; CSKY-NEXT:    cmplt16 l2, a1
+; CSKY-NEXT:    cmplt16 l3, a1
 ; CSKY-NEXT:    mov16 a2, l0
 ; CSKY-NEXT:    movt32 a2, a0
 ; CSKY-NEXT:    st32.b a0, (sp, 7)
-; CSKY-NEXT:    st16.w l3, (sp, 0)
+; CSKY-NEXT:    st16.w l2, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 7
 ; CSKY-NEXT:    movi16 a3, 0
-; CSKY-NEXT:    jsri32 [.LCPI35_0]
+; CSKY-NEXT:    jsri32 [.LCPI35_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.b a0, (sp, 7)
 ; CSKY-NEXT:    bez32 a1, .LBB35_1
@@ -708,8 +709,10 @@ define i8 @atomicrmw_max_i8_monotonic(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI35_0:
+; CSKY-NEXT:    .long __atomic_load_1
+; CSKY-NEXT:  .LCPI35_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_1
   %1 = atomicrmw max ptr %a, i8 %b monotonic
   ret i8 %1
@@ -727,8 +730,9 @@ define i8 @atomicrmw_max_i8_acquire(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.b a0, (a0, 0)
-; CSKY-NEXT:    sextb16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI36_0]
+; CSKY-NEXT:    sextb16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:  .LBB36_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -741,7 +745,7 @@ define i8 @atomicrmw_max_i8_acquire(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 7
 ; CSKY-NEXT:    movi16 a3, 2
-; CSKY-NEXT:    jsri32 [.LCPI36_0]
+; CSKY-NEXT:    jsri32 [.LCPI36_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.b a0, (sp, 7)
 ; CSKY-NEXT:    bez32 a1, .LBB36_1
@@ -756,8 +760,10 @@ define i8 @atomicrmw_max_i8_acquire(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI36_0:
+; CSKY-NEXT:    .long __atomic_load_1
+; CSKY-NEXT:  .LCPI36_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_1
   %1 = atomicrmw max ptr %a, i8 %b acquire
   ret i8 %1
@@ -775,21 +781,22 @@ define i8 @atomicrmw_max_i8_release(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.b a0, (a0, 0)
-; CSKY-NEXT:    sextb16 l2, a1
-; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI37_0]
+; CSKY-NEXT:    sextb16 l3, l0
 ; CSKY-NEXT:  .LBB37_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    sextb16 a1, a0
-; CSKY-NEXT:    cmplt16 l2, a1
+; CSKY-NEXT:    cmplt16 l3, a1
 ; CSKY-NEXT:    mov16 a2, l0
 ; CSKY-NEXT:    movt32 a2, a0
 ; CSKY-NEXT:    st32.b a0, (sp, 7)
-; CSKY-NEXT:    st16.w l3, (sp, 0)
+; CSKY-NEXT:    st16.w l2, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 7
 ; CSKY-NEXT:    movi16 a3, 3
-; CSKY-NEXT:    jsri32 [.LCPI37_0]
+; CSKY-NEXT:    jsri32 [.LCPI37_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.b a0, (sp, 7)
 ; CSKY-NEXT:    bez32 a1, .LBB37_1
@@ -804,8 +811,10 @@ define i8 @atomicrmw_max_i8_release(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI37_0:
+; CSKY-NEXT:    .long __atomic_load_1
+; CSKY-NEXT:  .LCPI37_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_1
   %1 = atomicrmw max ptr %a, i8 %b release
   ret i8 %1
@@ -823,8 +832,9 @@ define i8 @atomicrmw_max_i8_acq_rel(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.b a0, (a0, 0)
-; CSKY-NEXT:    sextb16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI38_0]
+; CSKY-NEXT:    sextb16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:  .LBB38_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -837,7 +847,7 @@ define i8 @atomicrmw_max_i8_acq_rel(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 7
 ; CSKY-NEXT:    movi16 a3, 4
-; CSKY-NEXT:    jsri32 [.LCPI38_0]
+; CSKY-NEXT:    jsri32 [.LCPI38_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.b a0, (sp, 7)
 ; CSKY-NEXT:    bez32 a1, .LBB38_1
@@ -852,8 +862,10 @@ define i8 @atomicrmw_max_i8_acq_rel(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI38_0:
+; CSKY-NEXT:    .long __atomic_load_1
+; CSKY-NEXT:  .LCPI38_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_1
   %1 = atomicrmw max ptr %a, i8 %b acq_rel
   ret i8 %1
@@ -871,8 +883,9 @@ define i8 @atomicrmw_max_i8_seq_cst(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.b a0, (a0, 0)
-; CSKY-NEXT:    sextb16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI39_0]
+; CSKY-NEXT:    sextb16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 5
 ; CSKY-NEXT:  .LBB39_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -885,7 +898,7 @@ define i8 @atomicrmw_max_i8_seq_cst(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 7
 ; CSKY-NEXT:    movi16 a3, 5
-; CSKY-NEXT:    jsri32 [.LCPI39_0]
+; CSKY-NEXT:    jsri32 [.LCPI39_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.b a0, (sp, 7)
 ; CSKY-NEXT:    bez32 a1, .LBB39_1
@@ -900,8 +913,10 @@ define i8 @atomicrmw_max_i8_seq_cst(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI39_0:
+; CSKY-NEXT:    .long __atomic_load_1
+; CSKY-NEXT:  .LCPI39_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_1
   %1 = atomicrmw max ptr %a, i8 %b seq_cst
   ret i8 %1
@@ -919,21 +934,22 @@ define i8 @atomicrmw_min_i8_monotonic(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.b a0, (a0, 0)
-; CSKY-NEXT:    sextb16 l2, a1
-; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI40_0]
+; CSKY-NEXT:    sextb16 l3, l0
 ; CSKY-NEXT:  .LBB40_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    sextb16 a1, a0
-; CSKY-NEXT:    cmplt16 l2, a1
+; CSKY-NEXT:    cmplt16 l3, a1
 ; CSKY-NEXT:    mov16 a2, l0
 ; CSKY-NEXT:    movf32 a2, a0
 ; CSKY-NEXT:    st32.b a0, (sp, 7)
-; CSKY-NEXT:    st16.w l3, (sp, 0)
+; CSKY-NEXT:    st16.w l2, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 7
 ; CSKY-NEXT:    movi16 a3, 0
-; CSKY-NEXT:    jsri32 [.LCPI40_0]
+; CSKY-NEXT:    jsri32 [.LCPI40_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.b a0, (sp, 7)
 ; CSKY-NEXT:    bez32 a1, .LBB40_1
@@ -948,8 +964,10 @@ define i8 @atomicrmw_min_i8_monotonic(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI40_0:
+; CSKY-NEXT:    .long __atomic_load_1
+; CSKY-NEXT:  .LCPI40_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_1
   %1 = atomicrmw min ptr %a, i8 %b monotonic
   ret i8 %1
@@ -967,8 +985,9 @@ define i8 @atomicrmw_min_i8_acquire(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.b a0, (a0, 0)
-; CSKY-NEXT:    sextb16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI41_0]
+; CSKY-NEXT:    sextb16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:  .LBB41_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -981,7 +1000,7 @@ define i8 @atomicrmw_min_i8_acquire(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 7
 ; CSKY-NEXT:    movi16 a3, 2
-; CSKY-NEXT:    jsri32 [.LCPI41_0]
+; CSKY-NEXT:    jsri32 [.LCPI41_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.b a0, (sp, 7)
 ; CSKY-NEXT:    bez32 a1, .LBB41_1
@@ -996,8 +1015,10 @@ define i8 @atomicrmw_min_i8_acquire(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI41_0:
+; CSKY-NEXT:    .long __atomic_load_1
+; CSKY-NEXT:  .LCPI41_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_1
   %1 = atomicrmw min ptr %a, i8 %b acquire
   ret i8 %1
@@ -1015,21 +1036,22 @@ define i8 @atomicrmw_min_i8_release(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.b a0, (a0, 0)
-; CSKY-NEXT:    sextb16 l2, a1
-; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI42_0]
+; CSKY-NEXT:    sextb16 l3, l0
 ; CSKY-NEXT:  .LBB42_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    sextb16 a1, a0
-; CSKY-NEXT:    cmplt16 l2, a1
+; CSKY-NEXT:    cmplt16 l3, a1
 ; CSKY-NEXT:    mov16 a2, l0
 ; CSKY-NEXT:    movf32 a2, a0
 ; CSKY-NEXT:    st32.b a0, (sp, 7)
-; CSKY-NEXT:    st16.w l3, (sp, 0)
+; CSKY-NEXT:    st16.w l2, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 7
 ; CSKY-NEXT:    movi16 a3, 3
-; CSKY-NEXT:    jsri32 [.LCPI42_0]
+; CSKY-NEXT:    jsri32 [.LCPI42_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.b a0, (sp, 7)
 ; CSKY-NEXT:    bez32 a1, .LBB42_1
@@ -1044,8 +1066,10 @@ define i8 @atomicrmw_min_i8_release(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI42_0:
+; CSKY-NEXT:    .long __atomic_load_1
+; CSKY-NEXT:  .LCPI42_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_1
   %1 = atomicrmw min ptr %a, i8 %b release
   ret i8 %1
@@ -1063,8 +1087,9 @@ define i8 @atomicrmw_min_i8_acq_rel(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.b a0, (a0, 0)
-; CSKY-NEXT:    sextb16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI43_0]
+; CSKY-NEXT:    sextb16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:  .LBB43_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -1077,7 +1102,7 @@ define i8 @atomicrmw_min_i8_acq_rel(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 7
 ; CSKY-NEXT:    movi16 a3, 4
-; CSKY-NEXT:    jsri32 [.LCPI43_0]
+; CSKY-NEXT:    jsri32 [.LCPI43_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.b a0, (sp, 7)
 ; CSKY-NEXT:    bez32 a1, .LBB43_1
@@ -1092,8 +1117,10 @@ define i8 @atomicrmw_min_i8_acq_rel(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI43_0:
+; CSKY-NEXT:    .long __atomic_load_1
+; CSKY-NEXT:  .LCPI43_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_1
   %1 = atomicrmw min ptr %a, i8 %b acq_rel
   ret i8 %1
@@ -1111,8 +1138,9 @@ define i8 @atomicrmw_min_i8_seq_cst(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.b a0, (a0, 0)
-; CSKY-NEXT:    sextb16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI44_0]
+; CSKY-NEXT:    sextb16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 5
 ; CSKY-NEXT:  .LBB44_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -1125,7 +1153,7 @@ define i8 @atomicrmw_min_i8_seq_cst(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 7
 ; CSKY-NEXT:    movi16 a3, 5
-; CSKY-NEXT:    jsri32 [.LCPI44_0]
+; CSKY-NEXT:    jsri32 [.LCPI44_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.b a0, (sp, 7)
 ; CSKY-NEXT:    bez32 a1, .LBB44_1
@@ -1140,8 +1168,10 @@ define i8 @atomicrmw_min_i8_seq_cst(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI44_0:
+; CSKY-NEXT:    .long __atomic_load_1
+; CSKY-NEXT:  .LCPI44_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_1
   %1 = atomicrmw min ptr %a, i8 %b seq_cst
   ret i8 %1
@@ -1159,21 +1189,22 @@ define i8 @atomicrmw_umax_i8_monotonic(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.b a0, (a0, 0)
-; CSKY-NEXT:    zextb16 l2, a1
-; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI45_0]
+; CSKY-NEXT:    zextb16 l3, l0
 ; CSKY-NEXT:  .LBB45_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    zextb16 a1, a0
-; CSKY-NEXT:    cmphs16 l2, a1
+; CSKY-NEXT:    cmphs16 l3, a1
 ; CSKY-NEXT:    mov16 a2, l0
 ; CSKY-NEXT:    movf32 a2, a0
 ; CSKY-NEXT:    st32.b a0, (sp, 7)
-; CSKY-NEXT:    st16.w l3, (sp, 0)
+; CSKY-NEXT:    st16.w l2, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 7
 ; CSKY-NEXT:    movi16 a3, 0
-; CSKY-NEXT:    jsri32 [.LCPI45_0]
+; CSKY-NEXT:    jsri32 [.LCPI45_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.b a0, (sp, 7)
 ; CSKY-NEXT:    bez32 a1, .LBB45_1
@@ -1188,8 +1219,10 @@ define i8 @atomicrmw_umax_i8_monotonic(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI45_0:
+; CSKY-NEXT:    .long __atomic_load_1
+; CSKY-NEXT:  .LCPI45_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_1
   %1 = atomicrmw umax ptr %a, i8 %b monotonic
   ret i8 %1
@@ -1207,8 +1240,9 @@ define i8 @atomicrmw_umax_i8_acquire(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.b a0, (a0, 0)
-; CSKY-NEXT:    zextb16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI46_0]
+; CSKY-NEXT:    zextb16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:  .LBB46_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -1221,7 +1255,7 @@ define i8 @atomicrmw_umax_i8_acquire(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 7
 ; CSKY-NEXT:    movi16 a3, 2
-; CSKY-NEXT:    jsri32 [.LCPI46_0]
+; CSKY-NEXT:    jsri32 [.LCPI46_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.b a0, (sp, 7)
 ; CSKY-NEXT:    bez32 a1, .LBB46_1
@@ -1236,8 +1270,10 @@ define i8 @atomicrmw_umax_i8_acquire(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI46_0:
+; CSKY-NEXT:    .long __atomic_load_1
+; CSKY-NEXT:  .LCPI46_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_1
   %1 = atomicrmw umax ptr %a, i8 %b acquire
   ret i8 %1
@@ -1255,21 +1291,22 @@ define i8 @atomicrmw_umax_i8_release(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.b a0, (a0, 0)
-; CSKY-NEXT:    zextb16 l2, a1
-; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI47_0]
+; CSKY-NEXT:    zextb16 l3, l0
 ; CSKY-NEXT:  .LBB47_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    zextb16 a1, a0
-; CSKY-NEXT:    cmphs16 l2, a1
+; CSKY-NEXT:    cmphs16 l3, a1
 ; CSKY-NEXT:    mov16 a2, l0
 ; CSKY-NEXT:    movf32 a2, a0
 ; CSKY-NEXT:    st32.b a0, (sp, 7)
-; CSKY-NEXT:    st16.w l3, (sp, 0)
+; CSKY-NEXT:    st16.w l2, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 7
 ; CSKY-NEXT:    movi16 a3, 3
-; CSKY-NEXT:    jsri32 [.LCPI47_0]
+; CSKY-NEXT:    jsri32 [.LCPI47_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.b a0, (sp, 7)
 ; CSKY-NEXT:    bez32 a1, .LBB47_1
@@ -1284,8 +1321,10 @@ define i8 @atomicrmw_umax_i8_release(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI47_0:
+; CSKY-NEXT:    .long __atomic_load_1
+; CSKY-NEXT:  .LCPI47_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_1
   %1 = atomicrmw umax ptr %a, i8 %b release
   ret i8 %1
@@ -1303,8 +1342,9 @@ define i8 @atomicrmw_umax_i8_acq_rel(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.b a0, (a0, 0)
-; CSKY-NEXT:    zextb16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI48_0]
+; CSKY-NEXT:    zextb16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:  .LBB48_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -1317,7 +1357,7 @@ define i8 @atomicrmw_umax_i8_acq_rel(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 7
 ; CSKY-NEXT:    movi16 a3, 4
-; CSKY-NEXT:    jsri32 [.LCPI48_0]
+; CSKY-NEXT:    jsri32 [.LCPI48_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.b a0, (sp, 7)
 ; CSKY-NEXT:    bez32 a1, .LBB48_1
@@ -1332,8 +1372,10 @@ define i8 @atomicrmw_umax_i8_acq_rel(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI48_0:
+; CSKY-NEXT:    .long __atomic_load_1
+; CSKY-NEXT:  .LCPI48_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_1
   %1 = atomicrmw umax ptr %a, i8 %b acq_rel
   ret i8 %1
@@ -1351,8 +1393,9 @@ define i8 @atomicrmw_umax_i8_seq_cst(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.b a0, (a0, 0)
-; CSKY-NEXT:    zextb16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI49_0]
+; CSKY-NEXT:    zextb16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 5
 ; CSKY-NEXT:  .LBB49_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -1365,7 +1408,7 @@ define i8 @atomicrmw_umax_i8_seq_cst(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 7
 ; CSKY-NEXT:    movi16 a3, 5
-; CSKY-NEXT:    jsri32 [.LCPI49_0]
+; CSKY-NEXT:    jsri32 [.LCPI49_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.b a0, (sp, 7)
 ; CSKY-NEXT:    bez32 a1, .LBB49_1
@@ -1380,8 +1423,10 @@ define i8 @atomicrmw_umax_i8_seq_cst(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI49_0:
+; CSKY-NEXT:    .long __atomic_load_1
+; CSKY-NEXT:  .LCPI49_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_1
   %1 = atomicrmw umax ptr %a, i8 %b seq_cst
   ret i8 %1
@@ -1399,21 +1444,22 @@ define i8 @atomicrmw_umin_i8_monotonic(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.b a0, (a0, 0)
-; CSKY-NEXT:    zextb16 l2, a1
-; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI50_0]
+; CSKY-NEXT:    zextb16 l3, l0
 ; CSKY-NEXT:  .LBB50_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    zextb16 a1, a0
-; CSKY-NEXT:    cmphs16 l2, a1
+; CSKY-NEXT:    cmphs16 l3, a1
 ; CSKY-NEXT:    mov16 a2, l0
 ; CSKY-NEXT:    movt32 a2, a0
 ; CSKY-NEXT:    st32.b a0, (sp, 7)
-; CSKY-NEXT:    st16.w l3, (sp, 0)
+; CSKY-NEXT:    st16.w l2, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 7
 ; CSKY-NEXT:    movi16 a3, 0
-; CSKY-NEXT:    jsri32 [.LCPI50_0]
+; CSKY-NEXT:    jsri32 [.LCPI50_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.b a0, (sp, 7)
 ; CSKY-NEXT:    bez32 a1, .LBB50_1
@@ -1428,8 +1474,10 @@ define i8 @atomicrmw_umin_i8_monotonic(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI50_0:
+; CSKY-NEXT:    .long __atomic_load_1
+; CSKY-NEXT:  .LCPI50_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_1
   %1 = atomicrmw umin ptr %a, i8 %b monotonic
   ret i8 %1
@@ -1447,8 +1495,9 @@ define i8 @atomicrmw_umin_i8_acquire(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.b a0, (a0, 0)
-; CSKY-NEXT:    zextb16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI51_0]
+; CSKY-NEXT:    zextb16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:  .LBB51_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -1461,7 +1510,7 @@ define i8 @atomicrmw_umin_i8_acquire(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 7
 ; CSKY-NEXT:    movi16 a3, 2
-; CSKY-NEXT:    jsri32 [.LCPI51_0]
+; CSKY-NEXT:    jsri32 [.LCPI51_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.b a0, (sp, 7)
 ; CSKY-NEXT:    bez32 a1, .LBB51_1
@@ -1476,8 +1525,10 @@ define i8 @atomicrmw_umin_i8_acquire(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI51_0:
+; CSKY-NEXT:    .long __atomic_load_1
+; CSKY-NEXT:  .LCPI51_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_1
   %1 = atomicrmw umin ptr %a, i8 %b acquire
   ret i8 %1
@@ -1495,21 +1546,22 @@ define i8 @atomicrmw_umin_i8_release(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.b a0, (a0, 0)
-; CSKY-NEXT:    zextb16 l2, a1
-; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI52_0]
+; CSKY-NEXT:    zextb16 l3, l0
 ; CSKY-NEXT:  .LBB52_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    zextb16 a1, a0
-; CSKY-NEXT:    cmphs16 l2, a1
+; CSKY-NEXT:    cmphs16 l3, a1
 ; CSKY-NEXT:    mov16 a2, l0
 ; CSKY-NEXT:    movt32 a2, a0
 ; CSKY-NEXT:    st32.b a0, (sp, 7)
-; CSKY-NEXT:    st16.w l3, (sp, 0)
+; CSKY-NEXT:    st16.w l2, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 7
 ; CSKY-NEXT:    movi16 a3, 3
-; CSKY-NEXT:    jsri32 [.LCPI52_0]
+; CSKY-NEXT:    jsri32 [.LCPI52_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.b a0, (sp, 7)
 ; CSKY-NEXT:    bez32 a1, .LBB52_1
@@ -1524,8 +1576,10 @@ define i8 @atomicrmw_umin_i8_release(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI52_0:
+; CSKY-NEXT:    .long __atomic_load_1
+; CSKY-NEXT:  .LCPI52_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_1
   %1 = atomicrmw umin ptr %a, i8 %b release
   ret i8 %1
@@ -1543,8 +1597,9 @@ define i8 @atomicrmw_umin_i8_acq_rel(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.b a0, (a0, 0)
-; CSKY-NEXT:    zextb16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI53_0]
+; CSKY-NEXT:    zextb16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:  .LBB53_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -1557,7 +1612,7 @@ define i8 @atomicrmw_umin_i8_acq_rel(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 7
 ; CSKY-NEXT:    movi16 a3, 4
-; CSKY-NEXT:    jsri32 [.LCPI53_0]
+; CSKY-NEXT:    jsri32 [.LCPI53_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.b a0, (sp, 7)
 ; CSKY-NEXT:    bez32 a1, .LBB53_1
@@ -1572,8 +1627,10 @@ define i8 @atomicrmw_umin_i8_acq_rel(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI53_0:
+; CSKY-NEXT:    .long __atomic_load_1
+; CSKY-NEXT:  .LCPI53_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_1
   %1 = atomicrmw umin ptr %a, i8 %b acq_rel
   ret i8 %1
@@ -1591,8 +1648,9 @@ define i8 @atomicrmw_umin_i8_seq_cst(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.b a0, (a0, 0)
-; CSKY-NEXT:    zextb16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI54_0]
+; CSKY-NEXT:    zextb16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 5
 ; CSKY-NEXT:  .LBB54_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -1605,7 +1663,7 @@ define i8 @atomicrmw_umin_i8_seq_cst(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 7
 ; CSKY-NEXT:    movi16 a3, 5
-; CSKY-NEXT:    jsri32 [.LCPI54_0]
+; CSKY-NEXT:    jsri32 [.LCPI54_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.b a0, (sp, 7)
 ; CSKY-NEXT:    bez32 a1, .LBB54_1
@@ -1620,8 +1678,10 @@ define i8 @atomicrmw_umin_i8_seq_cst(ptr %a, i8 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI54_0:
+; CSKY-NEXT:    .long __atomic_load_1
+; CSKY-NEXT:  .LCPI54_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_1
   %1 = atomicrmw umin ptr %a, i8 %b seq_cst
   ret i8 %1
@@ -1639,7 +1699,7 @@ define i16 @atomicrmw_xchg_i16_monotonic(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI55_0:
 ; CSKY-NEXT:    .long __atomic_exchange_2
   %1 = atomicrmw xchg ptr %a, i16 %b monotonic
@@ -1658,7 +1718,7 @@ define i16 @atomicrmw_xchg_i16_acquire(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI56_0:
 ; CSKY-NEXT:    .long __atomic_exchange_2
   %1 = atomicrmw xchg ptr %a, i16 %b acquire
@@ -1677,7 +1737,7 @@ define i16 @atomicrmw_xchg_i16_release(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI57_0:
 ; CSKY-NEXT:    .long __atomic_exchange_2
   %1 = atomicrmw xchg ptr %a, i16 %b release
@@ -1696,7 +1756,7 @@ define i16 @atomicrmw_xchg_i16_acq_rel(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI58_0:
 ; CSKY-NEXT:    .long __atomic_exchange_2
   %1 = atomicrmw xchg ptr %a, i16 %b acq_rel
@@ -1715,7 +1775,7 @@ define i16 @atomicrmw_xchg_i16_seq_cst(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI59_0:
 ; CSKY-NEXT:    .long __atomic_exchange_2
   %1 = atomicrmw xchg ptr %a, i16 %b seq_cst
@@ -1734,7 +1794,7 @@ define i16 @atomicrmw_add_i16_monotonic(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI60_0:
 ; CSKY-NEXT:    .long __atomic_fetch_add_2
   %1 = atomicrmw add ptr %a, i16 %b monotonic
@@ -1753,7 +1813,7 @@ define i16 @atomicrmw_add_i16_acquire(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI61_0:
 ; CSKY-NEXT:    .long __atomic_fetch_add_2
   %1 = atomicrmw add ptr %a, i16 %b acquire
@@ -1772,7 +1832,7 @@ define i16 @atomicrmw_add_i16_release(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI62_0:
 ; CSKY-NEXT:    .long __atomic_fetch_add_2
   %1 = atomicrmw add ptr %a, i16 %b release
@@ -1791,7 +1851,7 @@ define i16 @atomicrmw_add_i16_acq_rel(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI63_0:
 ; CSKY-NEXT:    .long __atomic_fetch_add_2
   %1 = atomicrmw add ptr %a, i16 %b acq_rel
@@ -1810,7 +1870,7 @@ define i16 @atomicrmw_add_i16_seq_cst(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI64_0:
 ; CSKY-NEXT:    .long __atomic_fetch_add_2
   %1 = atomicrmw add ptr %a, i16 %b seq_cst
@@ -1829,7 +1889,7 @@ define i16 @atomicrmw_sub_i16_monotonic(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI65_0:
 ; CSKY-NEXT:    .long __atomic_fetch_sub_2
   %1 = atomicrmw sub ptr %a, i16 %b monotonic
@@ -1848,7 +1908,7 @@ define i16 @atomicrmw_sub_i16_acquire(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI66_0:
 ; CSKY-NEXT:    .long __atomic_fetch_sub_2
   %1 = atomicrmw sub ptr %a, i16 %b acquire
@@ -1867,7 +1927,7 @@ define i16 @atomicrmw_sub_i16_release(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI67_0:
 ; CSKY-NEXT:    .long __atomic_fetch_sub_2
   %1 = atomicrmw sub ptr %a, i16 %b release
@@ -1886,7 +1946,7 @@ define i16 @atomicrmw_sub_i16_acq_rel(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI68_0:
 ; CSKY-NEXT:    .long __atomic_fetch_sub_2
   %1 = atomicrmw sub ptr %a, i16 %b acq_rel
@@ -1905,7 +1965,7 @@ define i16 @atomicrmw_sub_i16_seq_cst(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI69_0:
 ; CSKY-NEXT:    .long __atomic_fetch_sub_2
   %1 = atomicrmw sub ptr %a, i16 %b seq_cst
@@ -1924,7 +1984,7 @@ define i16 @atomicrmw_and_i16_monotonic(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI70_0:
 ; CSKY-NEXT:    .long __atomic_fetch_and_2
   %1 = atomicrmw and ptr %a, i16 %b monotonic
@@ -1943,7 +2003,7 @@ define i16 @atomicrmw_and_i16_acquire(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI71_0:
 ; CSKY-NEXT:    .long __atomic_fetch_and_2
   %1 = atomicrmw and ptr %a, i16 %b acquire
@@ -1962,7 +2022,7 @@ define i16 @atomicrmw_and_i16_release(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI72_0:
 ; CSKY-NEXT:    .long __atomic_fetch_and_2
   %1 = atomicrmw and ptr %a, i16 %b release
@@ -1981,7 +2041,7 @@ define i16 @atomicrmw_and_i16_acq_rel(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI73_0:
 ; CSKY-NEXT:    .long __atomic_fetch_and_2
   %1 = atomicrmw and ptr %a, i16 %b acq_rel
@@ -2000,7 +2060,7 @@ define i16 @atomicrmw_and_i16_seq_cst(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI74_0:
 ; CSKY-NEXT:    .long __atomic_fetch_and_2
   %1 = atomicrmw and ptr %a, i16 %b seq_cst
@@ -2019,7 +2079,7 @@ define i16 @atomicrmw_nand_i16_monotonic(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI75_0:
 ; CSKY-NEXT:    .long __atomic_fetch_nand_2
   %1 = atomicrmw nand ptr %a, i16 %b monotonic
@@ -2038,7 +2098,7 @@ define i16 @atomicrmw_nand_i16_acquire(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI76_0:
 ; CSKY-NEXT:    .long __atomic_fetch_nand_2
   %1 = atomicrmw nand ptr %a, i16 %b acquire
@@ -2057,7 +2117,7 @@ define i16 @atomicrmw_nand_i16_release(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI77_0:
 ; CSKY-NEXT:    .long __atomic_fetch_nand_2
   %1 = atomicrmw nand ptr %a, i16 %b release
@@ -2076,7 +2136,7 @@ define i16 @atomicrmw_nand_i16_acq_rel(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI78_0:
 ; CSKY-NEXT:    .long __atomic_fetch_nand_2
   %1 = atomicrmw nand ptr %a, i16 %b acq_rel
@@ -2095,7 +2155,7 @@ define i16 @atomicrmw_nand_i16_seq_cst(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI79_0:
 ; CSKY-NEXT:    .long __atomic_fetch_nand_2
   %1 = atomicrmw nand ptr %a, i16 %b seq_cst
@@ -2114,7 +2174,7 @@ define i16 @atomicrmw_or_i16_monotonic(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI80_0:
 ; CSKY-NEXT:    .long __atomic_fetch_or_2
   %1 = atomicrmw or ptr %a, i16 %b monotonic
@@ -2133,7 +2193,7 @@ define i16 @atomicrmw_or_i16_acquire(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI81_0:
 ; CSKY-NEXT:    .long __atomic_fetch_or_2
   %1 = atomicrmw or ptr %a, i16 %b acquire
@@ -2152,7 +2212,7 @@ define i16 @atomicrmw_or_i16_release(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI82_0:
 ; CSKY-NEXT:    .long __atomic_fetch_or_2
   %1 = atomicrmw or ptr %a, i16 %b release
@@ -2171,7 +2231,7 @@ define i16 @atomicrmw_or_i16_acq_rel(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI83_0:
 ; CSKY-NEXT:    .long __atomic_fetch_or_2
   %1 = atomicrmw or ptr %a, i16 %b acq_rel
@@ -2190,7 +2250,7 @@ define i16 @atomicrmw_or_i16_seq_cst(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI84_0:
 ; CSKY-NEXT:    .long __atomic_fetch_or_2
   %1 = atomicrmw or ptr %a, i16 %b seq_cst
@@ -2209,7 +2269,7 @@ define i16 @atomicrmw_xor_i16_monotonic(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI85_0:
 ; CSKY-NEXT:    .long __atomic_fetch_xor_2
   %1 = atomicrmw xor ptr %a, i16 %b monotonic
@@ -2228,7 +2288,7 @@ define i16 @atomicrmw_xor_i16_acquire(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI86_0:
 ; CSKY-NEXT:    .long __atomic_fetch_xor_2
   %1 = atomicrmw xor ptr %a, i16 %b acquire
@@ -2247,7 +2307,7 @@ define i16 @atomicrmw_xor_i16_release(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI87_0:
 ; CSKY-NEXT:    .long __atomic_fetch_xor_2
   %1 = atomicrmw xor ptr %a, i16 %b release
@@ -2266,7 +2326,7 @@ define i16 @atomicrmw_xor_i16_acq_rel(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI88_0:
 ; CSKY-NEXT:    .long __atomic_fetch_xor_2
   %1 = atomicrmw xor ptr %a, i16 %b acq_rel
@@ -2285,7 +2345,7 @@ define i16 @atomicrmw_xor_i16_seq_cst(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI89_0:
 ; CSKY-NEXT:    .long __atomic_fetch_xor_2
   %1 = atomicrmw xor ptr %a, i16 %b seq_cst
@@ -2304,21 +2364,22 @@ define i16 @atomicrmw_max_i16_monotonic(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.h a0, (a0, 0)
-; CSKY-NEXT:    sexth16 l2, a1
-; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI90_0]
+; CSKY-NEXT:    sexth16 l3, l0
 ; CSKY-NEXT:  .LBB90_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    sexth16 a1, a0
-; CSKY-NEXT:    cmplt16 l2, a1
+; CSKY-NEXT:    cmplt16 l3, a1
 ; CSKY-NEXT:    mov16 a2, l0
 ; CSKY-NEXT:    movt32 a2, a0
 ; CSKY-NEXT:    st32.h a0, (sp, 6)
-; CSKY-NEXT:    st16.w l3, (sp, 0)
+; CSKY-NEXT:    st16.w l2, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 6
 ; CSKY-NEXT:    movi16 a3, 0
-; CSKY-NEXT:    jsri32 [.LCPI90_0]
+; CSKY-NEXT:    jsri32 [.LCPI90_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.h a0, (sp, 6)
 ; CSKY-NEXT:    bez32 a1, .LBB90_1
@@ -2333,8 +2394,10 @@ define i16 @atomicrmw_max_i16_monotonic(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI90_0:
+; CSKY-NEXT:    .long __atomic_load_2
+; CSKY-NEXT:  .LCPI90_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_2
   %1 = atomicrmw max ptr %a, i16 %b monotonic
   ret i16 %1
@@ -2352,8 +2415,9 @@ define i16 @atomicrmw_max_i16_acquire(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.h a0, (a0, 0)
-; CSKY-NEXT:    sexth16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI91_0]
+; CSKY-NEXT:    sexth16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:  .LBB91_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -2366,7 +2430,7 @@ define i16 @atomicrmw_max_i16_acquire(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 6
 ; CSKY-NEXT:    movi16 a3, 2
-; CSKY-NEXT:    jsri32 [.LCPI91_0]
+; CSKY-NEXT:    jsri32 [.LCPI91_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.h a0, (sp, 6)
 ; CSKY-NEXT:    bez32 a1, .LBB91_1
@@ -2381,8 +2445,10 @@ define i16 @atomicrmw_max_i16_acquire(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI91_0:
+; CSKY-NEXT:    .long __atomic_load_2
+; CSKY-NEXT:  .LCPI91_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_2
   %1 = atomicrmw max ptr %a, i16 %b acquire
   ret i16 %1
@@ -2400,21 +2466,22 @@ define i16 @atomicrmw_max_i16_release(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.h a0, (a0, 0)
-; CSKY-NEXT:    sexth16 l2, a1
-; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI92_0]
+; CSKY-NEXT:    sexth16 l3, l0
 ; CSKY-NEXT:  .LBB92_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    sexth16 a1, a0
-; CSKY-NEXT:    cmplt16 l2, a1
+; CSKY-NEXT:    cmplt16 l3, a1
 ; CSKY-NEXT:    mov16 a2, l0
 ; CSKY-NEXT:    movt32 a2, a0
 ; CSKY-NEXT:    st32.h a0, (sp, 6)
-; CSKY-NEXT:    st16.w l3, (sp, 0)
+; CSKY-NEXT:    st16.w l2, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 6
 ; CSKY-NEXT:    movi16 a3, 3
-; CSKY-NEXT:    jsri32 [.LCPI92_0]
+; CSKY-NEXT:    jsri32 [.LCPI92_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.h a0, (sp, 6)
 ; CSKY-NEXT:    bez32 a1, .LBB92_1
@@ -2429,8 +2496,10 @@ define i16 @atomicrmw_max_i16_release(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI92_0:
+; CSKY-NEXT:    .long __atomic_load_2
+; CSKY-NEXT:  .LCPI92_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_2
   %1 = atomicrmw max ptr %a, i16 %b release
   ret i16 %1
@@ -2448,8 +2517,9 @@ define i16 @atomicrmw_max_i16_acq_rel(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.h a0, (a0, 0)
-; CSKY-NEXT:    sexth16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI93_0]
+; CSKY-NEXT:    sexth16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:  .LBB93_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -2462,7 +2532,7 @@ define i16 @atomicrmw_max_i16_acq_rel(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 6
 ; CSKY-NEXT:    movi16 a3, 4
-; CSKY-NEXT:    jsri32 [.LCPI93_0]
+; CSKY-NEXT:    jsri32 [.LCPI93_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.h a0, (sp, 6)
 ; CSKY-NEXT:    bez32 a1, .LBB93_1
@@ -2477,8 +2547,10 @@ define i16 @atomicrmw_max_i16_acq_rel(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI93_0:
+; CSKY-NEXT:    .long __atomic_load_2
+; CSKY-NEXT:  .LCPI93_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_2
   %1 = atomicrmw max ptr %a, i16 %b acq_rel
   ret i16 %1
@@ -2496,8 +2568,9 @@ define i16 @atomicrmw_max_i16_seq_cst(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.h a0, (a0, 0)
-; CSKY-NEXT:    sexth16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI94_0]
+; CSKY-NEXT:    sexth16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 5
 ; CSKY-NEXT:  .LBB94_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -2510,7 +2583,7 @@ define i16 @atomicrmw_max_i16_seq_cst(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 6
 ; CSKY-NEXT:    movi16 a3, 5
-; CSKY-NEXT:    jsri32 [.LCPI94_0]
+; CSKY-NEXT:    jsri32 [.LCPI94_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.h a0, (sp, 6)
 ; CSKY-NEXT:    bez32 a1, .LBB94_1
@@ -2525,8 +2598,10 @@ define i16 @atomicrmw_max_i16_seq_cst(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI94_0:
+; CSKY-NEXT:    .long __atomic_load_2
+; CSKY-NEXT:  .LCPI94_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_2
   %1 = atomicrmw max ptr %a, i16 %b seq_cst
   ret i16 %1
@@ -2544,21 +2619,22 @@ define i16 @atomicrmw_min_i16_monotonic(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.h a0, (a0, 0)
-; CSKY-NEXT:    sexth16 l2, a1
-; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI95_0]
+; CSKY-NEXT:    sexth16 l3, l0
 ; CSKY-NEXT:  .LBB95_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    sexth16 a1, a0
-; CSKY-NEXT:    cmplt16 l2, a1
+; CSKY-NEXT:    cmplt16 l3, a1
 ; CSKY-NEXT:    mov16 a2, l0
 ; CSKY-NEXT:    movf32 a2, a0
 ; CSKY-NEXT:    st32.h a0, (sp, 6)
-; CSKY-NEXT:    st16.w l3, (sp, 0)
+; CSKY-NEXT:    st16.w l2, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 6
 ; CSKY-NEXT:    movi16 a3, 0
-; CSKY-NEXT:    jsri32 [.LCPI95_0]
+; CSKY-NEXT:    jsri32 [.LCPI95_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.h a0, (sp, 6)
 ; CSKY-NEXT:    bez32 a1, .LBB95_1
@@ -2573,8 +2649,10 @@ define i16 @atomicrmw_min_i16_monotonic(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI95_0:
+; CSKY-NEXT:    .long __atomic_load_2
+; CSKY-NEXT:  .LCPI95_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_2
   %1 = atomicrmw min ptr %a, i16 %b monotonic
   ret i16 %1
@@ -2592,8 +2670,9 @@ define i16 @atomicrmw_min_i16_acquire(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.h a0, (a0, 0)
-; CSKY-NEXT:    sexth16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI96_0]
+; CSKY-NEXT:    sexth16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:  .LBB96_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -2606,7 +2685,7 @@ define i16 @atomicrmw_min_i16_acquire(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 6
 ; CSKY-NEXT:    movi16 a3, 2
-; CSKY-NEXT:    jsri32 [.LCPI96_0]
+; CSKY-NEXT:    jsri32 [.LCPI96_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.h a0, (sp, 6)
 ; CSKY-NEXT:    bez32 a1, .LBB96_1
@@ -2621,8 +2700,10 @@ define i16 @atomicrmw_min_i16_acquire(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI96_0:
+; CSKY-NEXT:    .long __atomic_load_2
+; CSKY-NEXT:  .LCPI96_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_2
   %1 = atomicrmw min ptr %a, i16 %b acquire
   ret i16 %1
@@ -2640,21 +2721,22 @@ define i16 @atomicrmw_min_i16_release(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.h a0, (a0, 0)
-; CSKY-NEXT:    sexth16 l2, a1
-; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI97_0]
+; CSKY-NEXT:    sexth16 l3, l0
 ; CSKY-NEXT:  .LBB97_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    sexth16 a1, a0
-; CSKY-NEXT:    cmplt16 l2, a1
+; CSKY-NEXT:    cmplt16 l3, a1
 ; CSKY-NEXT:    mov16 a2, l0
 ; CSKY-NEXT:    movf32 a2, a0
 ; CSKY-NEXT:    st32.h a0, (sp, 6)
-; CSKY-NEXT:    st16.w l3, (sp, 0)
+; CSKY-NEXT:    st16.w l2, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 6
 ; CSKY-NEXT:    movi16 a3, 3
-; CSKY-NEXT:    jsri32 [.LCPI97_0]
+; CSKY-NEXT:    jsri32 [.LCPI97_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.h a0, (sp, 6)
 ; CSKY-NEXT:    bez32 a1, .LBB97_1
@@ -2669,8 +2751,10 @@ define i16 @atomicrmw_min_i16_release(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI97_0:
+; CSKY-NEXT:    .long __atomic_load_2
+; CSKY-NEXT:  .LCPI97_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_2
   %1 = atomicrmw min ptr %a, i16 %b release
   ret i16 %1
@@ -2688,8 +2772,9 @@ define i16 @atomicrmw_min_i16_acq_rel(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.h a0, (a0, 0)
-; CSKY-NEXT:    sexth16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI98_0]
+; CSKY-NEXT:    sexth16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:  .LBB98_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -2702,7 +2787,7 @@ define i16 @atomicrmw_min_i16_acq_rel(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 6
 ; CSKY-NEXT:    movi16 a3, 4
-; CSKY-NEXT:    jsri32 [.LCPI98_0]
+; CSKY-NEXT:    jsri32 [.LCPI98_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.h a0, (sp, 6)
 ; CSKY-NEXT:    bez32 a1, .LBB98_1
@@ -2717,8 +2802,10 @@ define i16 @atomicrmw_min_i16_acq_rel(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI98_0:
+; CSKY-NEXT:    .long __atomic_load_2
+; CSKY-NEXT:  .LCPI98_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_2
   %1 = atomicrmw min ptr %a, i16 %b acq_rel
   ret i16 %1
@@ -2736,8 +2823,9 @@ define i16 @atomicrmw_min_i16_seq_cst(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.h a0, (a0, 0)
-; CSKY-NEXT:    sexth16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI99_0]
+; CSKY-NEXT:    sexth16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 5
 ; CSKY-NEXT:  .LBB99_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -2750,7 +2838,7 @@ define i16 @atomicrmw_min_i16_seq_cst(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 6
 ; CSKY-NEXT:    movi16 a3, 5
-; CSKY-NEXT:    jsri32 [.LCPI99_0]
+; CSKY-NEXT:    jsri32 [.LCPI99_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.h a0, (sp, 6)
 ; CSKY-NEXT:    bez32 a1, .LBB99_1
@@ -2765,8 +2853,10 @@ define i16 @atomicrmw_min_i16_seq_cst(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI99_0:
+; CSKY-NEXT:    .long __atomic_load_2
+; CSKY-NEXT:  .LCPI99_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_2
   %1 = atomicrmw min ptr %a, i16 %b seq_cst
   ret i16 %1
@@ -2784,21 +2874,22 @@ define i16 @atomicrmw_umax_i16_monotonic(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.h a0, (a0, 0)
-; CSKY-NEXT:    zexth16 l2, a1
-; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI100_0]
+; CSKY-NEXT:    zexth16 l3, l0
 ; CSKY-NEXT:  .LBB100_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    zexth16 a1, a0
-; CSKY-NEXT:    cmphs16 l2, a1
+; CSKY-NEXT:    cmphs16 l3, a1
 ; CSKY-NEXT:    mov16 a2, l0
 ; CSKY-NEXT:    movf32 a2, a0
 ; CSKY-NEXT:    st32.h a0, (sp, 6)
-; CSKY-NEXT:    st16.w l3, (sp, 0)
+; CSKY-NEXT:    st16.w l2, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 6
 ; CSKY-NEXT:    movi16 a3, 0
-; CSKY-NEXT:    jsri32 [.LCPI100_0]
+; CSKY-NEXT:    jsri32 [.LCPI100_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.h a0, (sp, 6)
 ; CSKY-NEXT:    bez32 a1, .LBB100_1
@@ -2813,8 +2904,10 @@ define i16 @atomicrmw_umax_i16_monotonic(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI100_0:
+; CSKY-NEXT:    .long __atomic_load_2
+; CSKY-NEXT:  .LCPI100_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_2
   %1 = atomicrmw umax ptr %a, i16 %b monotonic
   ret i16 %1
@@ -2832,8 +2925,9 @@ define i16 @atomicrmw_umax_i16_acquire(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.h a0, (a0, 0)
-; CSKY-NEXT:    zexth16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI101_0]
+; CSKY-NEXT:    zexth16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:  .LBB101_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -2846,7 +2940,7 @@ define i16 @atomicrmw_umax_i16_acquire(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 6
 ; CSKY-NEXT:    movi16 a3, 2
-; CSKY-NEXT:    jsri32 [.LCPI101_0]
+; CSKY-NEXT:    jsri32 [.LCPI101_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.h a0, (sp, 6)
 ; CSKY-NEXT:    bez32 a1, .LBB101_1
@@ -2861,8 +2955,10 @@ define i16 @atomicrmw_umax_i16_acquire(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI101_0:
+; CSKY-NEXT:    .long __atomic_load_2
+; CSKY-NEXT:  .LCPI101_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_2
   %1 = atomicrmw umax ptr %a, i16 %b acquire
   ret i16 %1
@@ -2880,21 +2976,22 @@ define i16 @atomicrmw_umax_i16_release(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.h a0, (a0, 0)
-; CSKY-NEXT:    zexth16 l2, a1
-; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI102_0]
+; CSKY-NEXT:    zexth16 l3, l0
 ; CSKY-NEXT:  .LBB102_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    zexth16 a1, a0
-; CSKY-NEXT:    cmphs16 l2, a1
+; CSKY-NEXT:    cmphs16 l3, a1
 ; CSKY-NEXT:    mov16 a2, l0
 ; CSKY-NEXT:    movf32 a2, a0
 ; CSKY-NEXT:    st32.h a0, (sp, 6)
-; CSKY-NEXT:    st16.w l3, (sp, 0)
+; CSKY-NEXT:    st16.w l2, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 6
 ; CSKY-NEXT:    movi16 a3, 3
-; CSKY-NEXT:    jsri32 [.LCPI102_0]
+; CSKY-NEXT:    jsri32 [.LCPI102_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.h a0, (sp, 6)
 ; CSKY-NEXT:    bez32 a1, .LBB102_1
@@ -2909,8 +3006,10 @@ define i16 @atomicrmw_umax_i16_release(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI102_0:
+; CSKY-NEXT:    .long __atomic_load_2
+; CSKY-NEXT:  .LCPI102_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_2
   %1 = atomicrmw umax ptr %a, i16 %b release
   ret i16 %1
@@ -2928,8 +3027,9 @@ define i16 @atomicrmw_umax_i16_acq_rel(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.h a0, (a0, 0)
-; CSKY-NEXT:    zexth16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI103_0]
+; CSKY-NEXT:    zexth16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:  .LBB103_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -2942,7 +3042,7 @@ define i16 @atomicrmw_umax_i16_acq_rel(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 6
 ; CSKY-NEXT:    movi16 a3, 4
-; CSKY-NEXT:    jsri32 [.LCPI103_0]
+; CSKY-NEXT:    jsri32 [.LCPI103_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.h a0, (sp, 6)
 ; CSKY-NEXT:    bez32 a1, .LBB103_1
@@ -2957,8 +3057,10 @@ define i16 @atomicrmw_umax_i16_acq_rel(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI103_0:
+; CSKY-NEXT:    .long __atomic_load_2
+; CSKY-NEXT:  .LCPI103_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_2
   %1 = atomicrmw umax ptr %a, i16 %b acq_rel
   ret i16 %1
@@ -2976,8 +3078,9 @@ define i16 @atomicrmw_umax_i16_seq_cst(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.h a0, (a0, 0)
-; CSKY-NEXT:    zexth16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI104_0]
+; CSKY-NEXT:    zexth16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 5
 ; CSKY-NEXT:  .LBB104_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -2990,7 +3093,7 @@ define i16 @atomicrmw_umax_i16_seq_cst(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 6
 ; CSKY-NEXT:    movi16 a3, 5
-; CSKY-NEXT:    jsri32 [.LCPI104_0]
+; CSKY-NEXT:    jsri32 [.LCPI104_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.h a0, (sp, 6)
 ; CSKY-NEXT:    bez32 a1, .LBB104_1
@@ -3005,8 +3108,10 @@ define i16 @atomicrmw_umax_i16_seq_cst(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI104_0:
+; CSKY-NEXT:    .long __atomic_load_2
+; CSKY-NEXT:  .LCPI104_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_2
   %1 = atomicrmw umax ptr %a, i16 %b seq_cst
   ret i16 %1
@@ -3024,21 +3129,22 @@ define i16 @atomicrmw_umin_i16_monotonic(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.h a0, (a0, 0)
-; CSKY-NEXT:    zexth16 l2, a1
-; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI105_0]
+; CSKY-NEXT:    zexth16 l3, l0
 ; CSKY-NEXT:  .LBB105_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    zexth16 a1, a0
-; CSKY-NEXT:    cmphs16 l2, a1
+; CSKY-NEXT:    cmphs16 l3, a1
 ; CSKY-NEXT:    mov16 a2, l0
 ; CSKY-NEXT:    movt32 a2, a0
 ; CSKY-NEXT:    st32.h a0, (sp, 6)
-; CSKY-NEXT:    st16.w l3, (sp, 0)
+; CSKY-NEXT:    st16.w l2, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 6
 ; CSKY-NEXT:    movi16 a3, 0
-; CSKY-NEXT:    jsri32 [.LCPI105_0]
+; CSKY-NEXT:    jsri32 [.LCPI105_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.h a0, (sp, 6)
 ; CSKY-NEXT:    bez32 a1, .LBB105_1
@@ -3053,8 +3159,10 @@ define i16 @atomicrmw_umin_i16_monotonic(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI105_0:
+; CSKY-NEXT:    .long __atomic_load_2
+; CSKY-NEXT:  .LCPI105_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_2
   %1 = atomicrmw umin ptr %a, i16 %b monotonic
   ret i16 %1
@@ -3072,8 +3180,9 @@ define i16 @atomicrmw_umin_i16_acquire(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.h a0, (a0, 0)
-; CSKY-NEXT:    zexth16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI106_0]
+; CSKY-NEXT:    zexth16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:  .LBB106_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -3086,7 +3195,7 @@ define i16 @atomicrmw_umin_i16_acquire(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 6
 ; CSKY-NEXT:    movi16 a3, 2
-; CSKY-NEXT:    jsri32 [.LCPI106_0]
+; CSKY-NEXT:    jsri32 [.LCPI106_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.h a0, (sp, 6)
 ; CSKY-NEXT:    bez32 a1, .LBB106_1
@@ -3101,8 +3210,10 @@ define i16 @atomicrmw_umin_i16_acquire(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI106_0:
+; CSKY-NEXT:    .long __atomic_load_2
+; CSKY-NEXT:  .LCPI106_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_2
   %1 = atomicrmw umin ptr %a, i16 %b acquire
   ret i16 %1
@@ -3120,21 +3231,22 @@ define i16 @atomicrmw_umin_i16_release(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.h a0, (a0, 0)
-; CSKY-NEXT:    zexth16 l2, a1
-; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI107_0]
+; CSKY-NEXT:    zexth16 l3, l0
 ; CSKY-NEXT:  .LBB107_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    zexth16 a1, a0
-; CSKY-NEXT:    cmphs16 l2, a1
+; CSKY-NEXT:    cmphs16 l3, a1
 ; CSKY-NEXT:    mov16 a2, l0
 ; CSKY-NEXT:    movt32 a2, a0
 ; CSKY-NEXT:    st32.h a0, (sp, 6)
-; CSKY-NEXT:    st16.w l3, (sp, 0)
+; CSKY-NEXT:    st16.w l2, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 6
 ; CSKY-NEXT:    movi16 a3, 3
-; CSKY-NEXT:    jsri32 [.LCPI107_0]
+; CSKY-NEXT:    jsri32 [.LCPI107_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.h a0, (sp, 6)
 ; CSKY-NEXT:    bez32 a1, .LBB107_1
@@ -3149,8 +3261,10 @@ define i16 @atomicrmw_umin_i16_release(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI107_0:
+; CSKY-NEXT:    .long __atomic_load_2
+; CSKY-NEXT:  .LCPI107_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_2
   %1 = atomicrmw umin ptr %a, i16 %b release
   ret i16 %1
@@ -3168,8 +3282,9 @@ define i16 @atomicrmw_umin_i16_acq_rel(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.h a0, (a0, 0)
-; CSKY-NEXT:    zexth16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI108_0]
+; CSKY-NEXT:    zexth16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:  .LBB108_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -3182,7 +3297,7 @@ define i16 @atomicrmw_umin_i16_acq_rel(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 6
 ; CSKY-NEXT:    movi16 a3, 4
-; CSKY-NEXT:    jsri32 [.LCPI108_0]
+; CSKY-NEXT:    jsri32 [.LCPI108_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.h a0, (sp, 6)
 ; CSKY-NEXT:    bez32 a1, .LBB108_1
@@ -3197,8 +3312,10 @@ define i16 @atomicrmw_umin_i16_acq_rel(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI108_0:
+; CSKY-NEXT:    .long __atomic_load_2
+; CSKY-NEXT:  .LCPI108_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_2
   %1 = atomicrmw umin ptr %a, i16 %b acq_rel
   ret i16 %1
@@ -3216,8 +3333,9 @@ define i16 @atomicrmw_umin_i16_seq_cst(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.h a0, (a0, 0)
-; CSKY-NEXT:    zexth16 l2, a1
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI109_0]
+; CSKY-NEXT:    zexth16 l2, l0
 ; CSKY-NEXT:    movi16 l3, 5
 ; CSKY-NEXT:  .LBB109_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -3230,7 +3348,7 @@ define i16 @atomicrmw_umin_i16_seq_cst(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi32 a1, sp, 6
 ; CSKY-NEXT:    movi16 a3, 5
-; CSKY-NEXT:    jsri32 [.LCPI109_0]
+; CSKY-NEXT:    jsri32 [.LCPI109_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld32.h a0, (sp, 6)
 ; CSKY-NEXT:    bez32 a1, .LBB109_1
@@ -3245,8 +3363,10 @@ define i16 @atomicrmw_umin_i16_seq_cst(ptr %a, i16 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI109_0:
+; CSKY-NEXT:    .long __atomic_load_2
+; CSKY-NEXT:  .LCPI109_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_2
   %1 = atomicrmw umin ptr %a, i16 %b seq_cst
   ret i16 %1
@@ -3264,7 +3384,7 @@ define i32 @atomicrmw_xchg_i32_monotonic(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI110_0:
 ; CSKY-NEXT:    .long __atomic_exchange_4
   %1 = atomicrmw xchg ptr %a, i32 %b monotonic
@@ -3283,7 +3403,7 @@ define i32 @atomicrmw_xchg_i32_acquire(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI111_0:
 ; CSKY-NEXT:    .long __atomic_exchange_4
   %1 = atomicrmw xchg ptr %a, i32 %b acquire
@@ -3302,7 +3422,7 @@ define i32 @atomicrmw_xchg_i32_release(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI112_0:
 ; CSKY-NEXT:    .long __atomic_exchange_4
   %1 = atomicrmw xchg ptr %a, i32 %b release
@@ -3321,7 +3441,7 @@ define i32 @atomicrmw_xchg_i32_acq_rel(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI113_0:
 ; CSKY-NEXT:    .long __atomic_exchange_4
   %1 = atomicrmw xchg ptr %a, i32 %b acq_rel
@@ -3340,7 +3460,7 @@ define i32 @atomicrmw_xchg_i32_seq_cst(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI114_0:
 ; CSKY-NEXT:    .long __atomic_exchange_4
   %1 = atomicrmw xchg ptr %a, i32 %b seq_cst
@@ -3359,7 +3479,7 @@ define i32 @atomicrmw_add_i32_monotonic(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI115_0:
 ; CSKY-NEXT:    .long __atomic_fetch_add_4
   %1 = atomicrmw add ptr %a, i32 %b monotonic
@@ -3378,7 +3498,7 @@ define i32 @atomicrmw_add_i32_acquire(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI116_0:
 ; CSKY-NEXT:    .long __atomic_fetch_add_4
   %1 = atomicrmw add ptr %a, i32 %b acquire
@@ -3397,7 +3517,7 @@ define i32 @atomicrmw_add_i32_release(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI117_0:
 ; CSKY-NEXT:    .long __atomic_fetch_add_4
   %1 = atomicrmw add ptr %a, i32 %b release
@@ -3416,7 +3536,7 @@ define i32 @atomicrmw_add_i32_acq_rel(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI118_0:
 ; CSKY-NEXT:    .long __atomic_fetch_add_4
   %1 = atomicrmw add ptr %a, i32 %b acq_rel
@@ -3435,7 +3555,7 @@ define i32 @atomicrmw_add_i32_seq_cst(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI119_0:
 ; CSKY-NEXT:    .long __atomic_fetch_add_4
   %1 = atomicrmw add ptr %a, i32 %b seq_cst
@@ -3454,7 +3574,7 @@ define i32 @atomicrmw_sub_i32_monotonic(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI120_0:
 ; CSKY-NEXT:    .long __atomic_fetch_sub_4
   %1 = atomicrmw sub ptr %a, i32 %b monotonic
@@ -3473,7 +3593,7 @@ define i32 @atomicrmw_sub_i32_acquire(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI121_0:
 ; CSKY-NEXT:    .long __atomic_fetch_sub_4
   %1 = atomicrmw sub ptr %a, i32 %b acquire
@@ -3492,7 +3612,7 @@ define i32 @atomicrmw_sub_i32_release(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI122_0:
 ; CSKY-NEXT:    .long __atomic_fetch_sub_4
   %1 = atomicrmw sub ptr %a, i32 %b release
@@ -3511,7 +3631,7 @@ define i32 @atomicrmw_sub_i32_acq_rel(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI123_0:
 ; CSKY-NEXT:    .long __atomic_fetch_sub_4
   %1 = atomicrmw sub ptr %a, i32 %b acq_rel
@@ -3530,7 +3650,7 @@ define i32 @atomicrmw_sub_i32_seq_cst(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI124_0:
 ; CSKY-NEXT:    .long __atomic_fetch_sub_4
   %1 = atomicrmw sub ptr %a, i32 %b seq_cst
@@ -3549,7 +3669,7 @@ define i32 @atomicrmw_and_i32_monotonic(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI125_0:
 ; CSKY-NEXT:    .long __atomic_fetch_and_4
   %1 = atomicrmw and ptr %a, i32 %b monotonic
@@ -3568,7 +3688,7 @@ define i32 @atomicrmw_and_i32_acquire(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI126_0:
 ; CSKY-NEXT:    .long __atomic_fetch_and_4
   %1 = atomicrmw and ptr %a, i32 %b acquire
@@ -3587,7 +3707,7 @@ define i32 @atomicrmw_and_i32_release(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI127_0:
 ; CSKY-NEXT:    .long __atomic_fetch_and_4
   %1 = atomicrmw and ptr %a, i32 %b release
@@ -3606,7 +3726,7 @@ define i32 @atomicrmw_and_i32_acq_rel(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI128_0:
 ; CSKY-NEXT:    .long __atomic_fetch_and_4
   %1 = atomicrmw and ptr %a, i32 %b acq_rel
@@ -3625,7 +3745,7 @@ define i32 @atomicrmw_and_i32_seq_cst(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI129_0:
 ; CSKY-NEXT:    .long __atomic_fetch_and_4
   %1 = atomicrmw and ptr %a, i32 %b seq_cst
@@ -3644,7 +3764,7 @@ define i32 @atomicrmw_nand_i32_monotonic(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI130_0:
 ; CSKY-NEXT:    .long __atomic_fetch_nand_4
   %1 = atomicrmw nand ptr %a, i32 %b monotonic
@@ -3663,7 +3783,7 @@ define i32 @atomicrmw_nand_i32_acquire(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI131_0:
 ; CSKY-NEXT:    .long __atomic_fetch_nand_4
   %1 = atomicrmw nand ptr %a, i32 %b acquire
@@ -3682,7 +3802,7 @@ define i32 @atomicrmw_nand_i32_release(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI132_0:
 ; CSKY-NEXT:    .long __atomic_fetch_nand_4
   %1 = atomicrmw nand ptr %a, i32 %b release
@@ -3701,7 +3821,7 @@ define i32 @atomicrmw_nand_i32_acq_rel(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI133_0:
 ; CSKY-NEXT:    .long __atomic_fetch_nand_4
   %1 = atomicrmw nand ptr %a, i32 %b acq_rel
@@ -3720,7 +3840,7 @@ define i32 @atomicrmw_nand_i32_seq_cst(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI134_0:
 ; CSKY-NEXT:    .long __atomic_fetch_nand_4
   %1 = atomicrmw nand ptr %a, i32 %b seq_cst
@@ -3739,7 +3859,7 @@ define i32 @atomicrmw_or_i32_monotonic(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI135_0:
 ; CSKY-NEXT:    .long __atomic_fetch_or_4
   %1 = atomicrmw or ptr %a, i32 %b monotonic
@@ -3758,7 +3878,7 @@ define i32 @atomicrmw_or_i32_acquire(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI136_0:
 ; CSKY-NEXT:    .long __atomic_fetch_or_4
   %1 = atomicrmw or ptr %a, i32 %b acquire
@@ -3777,7 +3897,7 @@ define i32 @atomicrmw_or_i32_release(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI137_0:
 ; CSKY-NEXT:    .long __atomic_fetch_or_4
   %1 = atomicrmw or ptr %a, i32 %b release
@@ -3796,7 +3916,7 @@ define i32 @atomicrmw_or_i32_acq_rel(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI138_0:
 ; CSKY-NEXT:    .long __atomic_fetch_or_4
   %1 = atomicrmw or ptr %a, i32 %b acq_rel
@@ -3815,7 +3935,7 @@ define i32 @atomicrmw_or_i32_seq_cst(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI139_0:
 ; CSKY-NEXT:    .long __atomic_fetch_or_4
   %1 = atomicrmw or ptr %a, i32 %b seq_cst
@@ -3834,7 +3954,7 @@ define i32 @atomicrmw_xor_i32_monotonic(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI140_0:
 ; CSKY-NEXT:    .long __atomic_fetch_xor_4
   %1 = atomicrmw xor ptr %a, i32 %b monotonic
@@ -3853,7 +3973,7 @@ define i32 @atomicrmw_xor_i32_acquire(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI141_0:
 ; CSKY-NEXT:    .long __atomic_fetch_xor_4
   %1 = atomicrmw xor ptr %a, i32 %b acquire
@@ -3872,7 +3992,7 @@ define i32 @atomicrmw_xor_i32_release(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI142_0:
 ; CSKY-NEXT:    .long __atomic_fetch_xor_4
   %1 = atomicrmw xor ptr %a, i32 %b release
@@ -3891,7 +4011,7 @@ define i32 @atomicrmw_xor_i32_acq_rel(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI143_0:
 ; CSKY-NEXT:    .long __atomic_fetch_xor_4
   %1 = atomicrmw xor ptr %a, i32 %b acq_rel
@@ -3910,7 +4030,7 @@ define i32 @atomicrmw_xor_i32_seq_cst(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI144_0:
 ; CSKY-NEXT:    .long __atomic_fetch_xor_4
   %1 = atomicrmw xor ptr %a, i32 %b seq_cst
@@ -3928,8 +4048,9 @@ define i32 @atomicrmw_max_i32_monotonic(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
 ; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI145_0]
 ; CSKY-NEXT:  .LBB145_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    cmplt16 l0, a0
@@ -3940,7 +4061,7 @@ define i32 @atomicrmw_max_i32_monotonic(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi16 a1, sp, 4
 ; CSKY-NEXT:    movi16 a3, 0
-; CSKY-NEXT:    jsri32 [.LCPI145_0]
+; CSKY-NEXT:    jsri32 [.LCPI145_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld16.w a0, (sp, 4)
 ; CSKY-NEXT:    bez32 a1, .LBB145_1
@@ -3954,8 +4075,10 @@ define i32 @atomicrmw_max_i32_monotonic(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI145_0:
+; CSKY-NEXT:    .long __atomic_load_4
+; CSKY-NEXT:  .LCPI145_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_4
   %1 = atomicrmw max ptr %a, i32 %b monotonic
   ret i32 %1
@@ -3972,7 +4095,8 @@ define i32 @atomicrmw_max_i32_acquire(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI146_0]
 ; CSKY-NEXT:    movi16 l2, 2
 ; CSKY-NEXT:  .LBB146_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -3984,7 +4108,7 @@ define i32 @atomicrmw_max_i32_acquire(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi16 a1, sp, 4
 ; CSKY-NEXT:    movi16 a3, 2
-; CSKY-NEXT:    jsri32 [.LCPI146_0]
+; CSKY-NEXT:    jsri32 [.LCPI146_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld16.w a0, (sp, 4)
 ; CSKY-NEXT:    bez32 a1, .LBB146_1
@@ -3998,8 +4122,10 @@ define i32 @atomicrmw_max_i32_acquire(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI146_0:
+; CSKY-NEXT:    .long __atomic_load_4
+; CSKY-NEXT:  .LCPI146_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_4
   %1 = atomicrmw max ptr %a, i32 %b acquire
   ret i32 %1
@@ -4016,8 +4142,9 @@ define i32 @atomicrmw_max_i32_release(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
 ; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI147_0]
 ; CSKY-NEXT:  .LBB147_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    cmplt16 l0, a0
@@ -4028,7 +4155,7 @@ define i32 @atomicrmw_max_i32_release(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi16 a1, sp, 4
 ; CSKY-NEXT:    movi16 a3, 3
-; CSKY-NEXT:    jsri32 [.LCPI147_0]
+; CSKY-NEXT:    jsri32 [.LCPI147_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld16.w a0, (sp, 4)
 ; CSKY-NEXT:    bez32 a1, .LBB147_1
@@ -4042,8 +4169,10 @@ define i32 @atomicrmw_max_i32_release(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI147_0:
+; CSKY-NEXT:    .long __atomic_load_4
+; CSKY-NEXT:  .LCPI147_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_4
   %1 = atomicrmw max ptr %a, i32 %b release
   ret i32 %1
@@ -4060,7 +4189,8 @@ define i32 @atomicrmw_max_i32_acq_rel(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI148_0]
 ; CSKY-NEXT:    movi16 l2, 2
 ; CSKY-NEXT:  .LBB148_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -4072,7 +4202,7 @@ define i32 @atomicrmw_max_i32_acq_rel(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi16 a1, sp, 4
 ; CSKY-NEXT:    movi16 a3, 4
-; CSKY-NEXT:    jsri32 [.LCPI148_0]
+; CSKY-NEXT:    jsri32 [.LCPI148_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld16.w a0, (sp, 4)
 ; CSKY-NEXT:    bez32 a1, .LBB148_1
@@ -4086,8 +4216,10 @@ define i32 @atomicrmw_max_i32_acq_rel(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI148_0:
+; CSKY-NEXT:    .long __atomic_load_4
+; CSKY-NEXT:  .LCPI148_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_4
   %1 = atomicrmw max ptr %a, i32 %b acq_rel
   ret i32 %1
@@ -4104,7 +4236,8 @@ define i32 @atomicrmw_max_i32_seq_cst(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI149_0]
 ; CSKY-NEXT:    movi16 l2, 5
 ; CSKY-NEXT:  .LBB149_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -4116,7 +4249,7 @@ define i32 @atomicrmw_max_i32_seq_cst(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi16 a1, sp, 4
 ; CSKY-NEXT:    movi16 a3, 5
-; CSKY-NEXT:    jsri32 [.LCPI149_0]
+; CSKY-NEXT:    jsri32 [.LCPI149_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld16.w a0, (sp, 4)
 ; CSKY-NEXT:    bez32 a1, .LBB149_1
@@ -4130,8 +4263,10 @@ define i32 @atomicrmw_max_i32_seq_cst(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI149_0:
+; CSKY-NEXT:    .long __atomic_load_4
+; CSKY-NEXT:  .LCPI149_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_4
   %1 = atomicrmw max ptr %a, i32 %b seq_cst
   ret i32 %1
@@ -4148,8 +4283,9 @@ define i32 @atomicrmw_min_i32_monotonic(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
 ; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI150_0]
 ; CSKY-NEXT:  .LBB150_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    cmplt16 l0, a0
@@ -4160,7 +4296,7 @@ define i32 @atomicrmw_min_i32_monotonic(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi16 a1, sp, 4
 ; CSKY-NEXT:    movi16 a3, 0
-; CSKY-NEXT:    jsri32 [.LCPI150_0]
+; CSKY-NEXT:    jsri32 [.LCPI150_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld16.w a0, (sp, 4)
 ; CSKY-NEXT:    bez32 a1, .LBB150_1
@@ -4174,8 +4310,10 @@ define i32 @atomicrmw_min_i32_monotonic(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI150_0:
+; CSKY-NEXT:    .long __atomic_load_4
+; CSKY-NEXT:  .LCPI150_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_4
   %1 = atomicrmw min ptr %a, i32 %b monotonic
   ret i32 %1
@@ -4192,7 +4330,8 @@ define i32 @atomicrmw_min_i32_acquire(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI151_0]
 ; CSKY-NEXT:    movi16 l2, 2
 ; CSKY-NEXT:  .LBB151_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -4204,7 +4343,7 @@ define i32 @atomicrmw_min_i32_acquire(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi16 a1, sp, 4
 ; CSKY-NEXT:    movi16 a3, 2
-; CSKY-NEXT:    jsri32 [.LCPI151_0]
+; CSKY-NEXT:    jsri32 [.LCPI151_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld16.w a0, (sp, 4)
 ; CSKY-NEXT:    bez32 a1, .LBB151_1
@@ -4218,8 +4357,10 @@ define i32 @atomicrmw_min_i32_acquire(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI151_0:
+; CSKY-NEXT:    .long __atomic_load_4
+; CSKY-NEXT:  .LCPI151_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_4
   %1 = atomicrmw min ptr %a, i32 %b acquire
   ret i32 %1
@@ -4236,8 +4377,9 @@ define i32 @atomicrmw_min_i32_release(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
 ; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI152_0]
 ; CSKY-NEXT:  .LBB152_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    cmplt16 l0, a0
@@ -4248,7 +4390,7 @@ define i32 @atomicrmw_min_i32_release(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi16 a1, sp, 4
 ; CSKY-NEXT:    movi16 a3, 3
-; CSKY-NEXT:    jsri32 [.LCPI152_0]
+; CSKY-NEXT:    jsri32 [.LCPI152_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld16.w a0, (sp, 4)
 ; CSKY-NEXT:    bez32 a1, .LBB152_1
@@ -4262,8 +4404,10 @@ define i32 @atomicrmw_min_i32_release(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI152_0:
+; CSKY-NEXT:    .long __atomic_load_4
+; CSKY-NEXT:  .LCPI152_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_4
   %1 = atomicrmw min ptr %a, i32 %b release
   ret i32 %1
@@ -4280,7 +4424,8 @@ define i32 @atomicrmw_min_i32_acq_rel(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI153_0]
 ; CSKY-NEXT:    movi16 l2, 2
 ; CSKY-NEXT:  .LBB153_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -4292,7 +4437,7 @@ define i32 @atomicrmw_min_i32_acq_rel(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi16 a1, sp, 4
 ; CSKY-NEXT:    movi16 a3, 4
-; CSKY-NEXT:    jsri32 [.LCPI153_0]
+; CSKY-NEXT:    jsri32 [.LCPI153_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld16.w a0, (sp, 4)
 ; CSKY-NEXT:    bez32 a1, .LBB153_1
@@ -4306,8 +4451,10 @@ define i32 @atomicrmw_min_i32_acq_rel(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI153_0:
+; CSKY-NEXT:    .long __atomic_load_4
+; CSKY-NEXT:  .LCPI153_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_4
   %1 = atomicrmw min ptr %a, i32 %b acq_rel
   ret i32 %1
@@ -4324,7 +4471,8 @@ define i32 @atomicrmw_min_i32_seq_cst(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI154_0]
 ; CSKY-NEXT:    movi16 l2, 5
 ; CSKY-NEXT:  .LBB154_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -4336,7 +4484,7 @@ define i32 @atomicrmw_min_i32_seq_cst(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi16 a1, sp, 4
 ; CSKY-NEXT:    movi16 a3, 5
-; CSKY-NEXT:    jsri32 [.LCPI154_0]
+; CSKY-NEXT:    jsri32 [.LCPI154_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld16.w a0, (sp, 4)
 ; CSKY-NEXT:    bez32 a1, .LBB154_1
@@ -4350,8 +4498,10 @@ define i32 @atomicrmw_min_i32_seq_cst(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI154_0:
+; CSKY-NEXT:    .long __atomic_load_4
+; CSKY-NEXT:  .LCPI154_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_4
   %1 = atomicrmw min ptr %a, i32 %b seq_cst
   ret i32 %1
@@ -4368,8 +4518,9 @@ define i32 @atomicrmw_umax_i32_monotonic(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
 ; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI155_0]
 ; CSKY-NEXT:  .LBB155_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    cmphs16 l0, a0
@@ -4380,7 +4531,7 @@ define i32 @atomicrmw_umax_i32_monotonic(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi16 a1, sp, 4
 ; CSKY-NEXT:    movi16 a3, 0
-; CSKY-NEXT:    jsri32 [.LCPI155_0]
+; CSKY-NEXT:    jsri32 [.LCPI155_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld16.w a0, (sp, 4)
 ; CSKY-NEXT:    bez32 a1, .LBB155_1
@@ -4394,8 +4545,10 @@ define i32 @atomicrmw_umax_i32_monotonic(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI155_0:
+; CSKY-NEXT:    .long __atomic_load_4
+; CSKY-NEXT:  .LCPI155_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_4
   %1 = atomicrmw umax ptr %a, i32 %b monotonic
   ret i32 %1
@@ -4412,7 +4565,8 @@ define i32 @atomicrmw_umax_i32_acquire(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI156_0]
 ; CSKY-NEXT:    movi16 l2, 2
 ; CSKY-NEXT:  .LBB156_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -4424,7 +4578,7 @@ define i32 @atomicrmw_umax_i32_acquire(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi16 a1, sp, 4
 ; CSKY-NEXT:    movi16 a3, 2
-; CSKY-NEXT:    jsri32 [.LCPI156_0]
+; CSKY-NEXT:    jsri32 [.LCPI156_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld16.w a0, (sp, 4)
 ; CSKY-NEXT:    bez32 a1, .LBB156_1
@@ -4438,8 +4592,10 @@ define i32 @atomicrmw_umax_i32_acquire(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI156_0:
+; CSKY-NEXT:    .long __atomic_load_4
+; CSKY-NEXT:  .LCPI156_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_4
   %1 = atomicrmw umax ptr %a, i32 %b acquire
   ret i32 %1
@@ -4456,8 +4612,9 @@ define i32 @atomicrmw_umax_i32_release(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
 ; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI157_0]
 ; CSKY-NEXT:  .LBB157_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    cmphs16 l0, a0
@@ -4468,7 +4625,7 @@ define i32 @atomicrmw_umax_i32_release(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi16 a1, sp, 4
 ; CSKY-NEXT:    movi16 a3, 3
-; CSKY-NEXT:    jsri32 [.LCPI157_0]
+; CSKY-NEXT:    jsri32 [.LCPI157_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld16.w a0, (sp, 4)
 ; CSKY-NEXT:    bez32 a1, .LBB157_1
@@ -4482,8 +4639,10 @@ define i32 @atomicrmw_umax_i32_release(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI157_0:
+; CSKY-NEXT:    .long __atomic_load_4
+; CSKY-NEXT:  .LCPI157_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_4
   %1 = atomicrmw umax ptr %a, i32 %b release
   ret i32 %1
@@ -4500,7 +4659,8 @@ define i32 @atomicrmw_umax_i32_acq_rel(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI158_0]
 ; CSKY-NEXT:    movi16 l2, 2
 ; CSKY-NEXT:  .LBB158_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -4512,7 +4672,7 @@ define i32 @atomicrmw_umax_i32_acq_rel(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi16 a1, sp, 4
 ; CSKY-NEXT:    movi16 a3, 4
-; CSKY-NEXT:    jsri32 [.LCPI158_0]
+; CSKY-NEXT:    jsri32 [.LCPI158_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld16.w a0, (sp, 4)
 ; CSKY-NEXT:    bez32 a1, .LBB158_1
@@ -4526,8 +4686,10 @@ define i32 @atomicrmw_umax_i32_acq_rel(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI158_0:
+; CSKY-NEXT:    .long __atomic_load_4
+; CSKY-NEXT:  .LCPI158_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_4
   %1 = atomicrmw umax ptr %a, i32 %b acq_rel
   ret i32 %1
@@ -4544,7 +4706,8 @@ define i32 @atomicrmw_umax_i32_seq_cst(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI159_0]
 ; CSKY-NEXT:    movi16 l2, 5
 ; CSKY-NEXT:  .LBB159_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -4556,7 +4719,7 @@ define i32 @atomicrmw_umax_i32_seq_cst(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi16 a1, sp, 4
 ; CSKY-NEXT:    movi16 a3, 5
-; CSKY-NEXT:    jsri32 [.LCPI159_0]
+; CSKY-NEXT:    jsri32 [.LCPI159_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld16.w a0, (sp, 4)
 ; CSKY-NEXT:    bez32 a1, .LBB159_1
@@ -4570,8 +4733,10 @@ define i32 @atomicrmw_umax_i32_seq_cst(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI159_0:
+; CSKY-NEXT:    .long __atomic_load_4
+; CSKY-NEXT:  .LCPI159_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_4
   %1 = atomicrmw umax ptr %a, i32 %b seq_cst
   ret i32 %1
@@ -4588,8 +4753,9 @@ define i32 @atomicrmw_umin_i32_monotonic(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
 ; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI160_0]
 ; CSKY-NEXT:  .LBB160_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    cmphs16 l0, a0
@@ -4600,7 +4766,7 @@ define i32 @atomicrmw_umin_i32_monotonic(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi16 a1, sp, 4
 ; CSKY-NEXT:    movi16 a3, 0
-; CSKY-NEXT:    jsri32 [.LCPI160_0]
+; CSKY-NEXT:    jsri32 [.LCPI160_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld16.w a0, (sp, 4)
 ; CSKY-NEXT:    bez32 a1, .LBB160_1
@@ -4614,8 +4780,10 @@ define i32 @atomicrmw_umin_i32_monotonic(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI160_0:
+; CSKY-NEXT:    .long __atomic_load_4
+; CSKY-NEXT:  .LCPI160_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_4
   %1 = atomicrmw umin ptr %a, i32 %b monotonic
   ret i32 %1
@@ -4632,7 +4800,8 @@ define i32 @atomicrmw_umin_i32_acquire(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI161_0]
 ; CSKY-NEXT:    movi16 l2, 2
 ; CSKY-NEXT:  .LBB161_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -4644,7 +4813,7 @@ define i32 @atomicrmw_umin_i32_acquire(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi16 a1, sp, 4
 ; CSKY-NEXT:    movi16 a3, 2
-; CSKY-NEXT:    jsri32 [.LCPI161_0]
+; CSKY-NEXT:    jsri32 [.LCPI161_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld16.w a0, (sp, 4)
 ; CSKY-NEXT:    bez32 a1, .LBB161_1
@@ -4658,8 +4827,10 @@ define i32 @atomicrmw_umin_i32_acquire(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI161_0:
+; CSKY-NEXT:    .long __atomic_load_4
+; CSKY-NEXT:  .LCPI161_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_4
   %1 = atomicrmw umin ptr %a, i32 %b acquire
   ret i32 %1
@@ -4676,8 +4847,9 @@ define i32 @atomicrmw_umin_i32_release(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
 ; CSKY-NEXT:    movi16 l2, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI162_0]
 ; CSKY-NEXT:  .LBB162_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    cmphs16 l0, a0
@@ -4688,7 +4860,7 @@ define i32 @atomicrmw_umin_i32_release(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi16 a1, sp, 4
 ; CSKY-NEXT:    movi16 a3, 3
-; CSKY-NEXT:    jsri32 [.LCPI162_0]
+; CSKY-NEXT:    jsri32 [.LCPI162_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld16.w a0, (sp, 4)
 ; CSKY-NEXT:    bez32 a1, .LBB162_1
@@ -4702,8 +4874,10 @@ define i32 @atomicrmw_umin_i32_release(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI162_0:
+; CSKY-NEXT:    .long __atomic_load_4
+; CSKY-NEXT:  .LCPI162_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_4
   %1 = atomicrmw umin ptr %a, i32 %b release
   ret i32 %1
@@ -4720,7 +4894,8 @@ define i32 @atomicrmw_umin_i32_acq_rel(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI163_0]
 ; CSKY-NEXT:    movi16 l2, 2
 ; CSKY-NEXT:  .LBB163_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -4732,7 +4907,7 @@ define i32 @atomicrmw_umin_i32_acq_rel(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi16 a1, sp, 4
 ; CSKY-NEXT:    movi16 a3, 4
-; CSKY-NEXT:    jsri32 [.LCPI163_0]
+; CSKY-NEXT:    jsri32 [.LCPI163_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld16.w a0, (sp, 4)
 ; CSKY-NEXT:    bez32 a1, .LBB163_1
@@ -4746,8 +4921,10 @@ define i32 @atomicrmw_umin_i32_acq_rel(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI163_0:
+; CSKY-NEXT:    .long __atomic_load_4
+; CSKY-NEXT:  .LCPI163_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_4
   %1 = atomicrmw umin ptr %a, i32 %b acq_rel
   ret i32 %1
@@ -4764,7 +4941,8 @@ define i32 @atomicrmw_umin_i32_seq_cst(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    subi16 sp, sp, 8
 ; CSKY-NEXT:    mov16 l0, a1
 ; CSKY-NEXT:    mov16 l1, a0
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI164_0]
 ; CSKY-NEXT:    movi16 l2, 5
 ; CSKY-NEXT:  .LBB164_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -4776,7 +4954,7 @@ define i32 @atomicrmw_umin_i32_seq_cst(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    mov16 a0, l1
 ; CSKY-NEXT:    addi16 a1, sp, 4
 ; CSKY-NEXT:    movi16 a3, 5
-; CSKY-NEXT:    jsri32 [.LCPI164_0]
+; CSKY-NEXT:    jsri32 [.LCPI164_1]
 ; CSKY-NEXT:    mov16 a1, a0
 ; CSKY-NEXT:    ld16.w a0, (sp, 4)
 ; CSKY-NEXT:    bez32 a1, .LBB164_1
@@ -4790,8 +4968,10 @@ define i32 @atomicrmw_umin_i32_seq_cst(ptr %a, i32 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI164_0:
+; CSKY-NEXT:    .long __atomic_load_4
+; CSKY-NEXT:  .LCPI164_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_4
   %1 = atomicrmw umin ptr %a, i32 %b seq_cst
   ret i32 %1
@@ -4809,7 +4989,7 @@ define i64 @atomicrmw_xchg_i64_monotonic(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI165_0:
 ; CSKY-NEXT:    .long __atomic_exchange_8
   %1 = atomicrmw xchg ptr %a, i64 %b monotonic
@@ -4828,7 +5008,7 @@ define i64 @atomicrmw_xchg_i64_acquire(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI166_0:
 ; CSKY-NEXT:    .long __atomic_exchange_8
   %1 = atomicrmw xchg ptr %a, i64 %b acquire
@@ -4847,7 +5027,7 @@ define i64 @atomicrmw_xchg_i64_release(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI167_0:
 ; CSKY-NEXT:    .long __atomic_exchange_8
   %1 = atomicrmw xchg ptr %a, i64 %b release
@@ -4866,7 +5046,7 @@ define i64 @atomicrmw_xchg_i64_acq_rel(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI168_0:
 ; CSKY-NEXT:    .long __atomic_exchange_8
   %1 = atomicrmw xchg ptr %a, i64 %b acq_rel
@@ -4885,7 +5065,7 @@ define i64 @atomicrmw_xchg_i64_seq_cst(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI169_0:
 ; CSKY-NEXT:    .long __atomic_exchange_8
   %1 = atomicrmw xchg ptr %a, i64 %b seq_cst
@@ -4904,7 +5084,7 @@ define i64 @atomicrmw_add_i64_monotonic(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI170_0:
 ; CSKY-NEXT:    .long __atomic_fetch_add_8
   %1 = atomicrmw add ptr %a, i64 %b monotonic
@@ -4923,7 +5103,7 @@ define i64 @atomicrmw_add_i64_acquire(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI171_0:
 ; CSKY-NEXT:    .long __atomic_fetch_add_8
   %1 = atomicrmw add ptr %a, i64 %b acquire
@@ -4942,7 +5122,7 @@ define i64 @atomicrmw_add_i64_release(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI172_0:
 ; CSKY-NEXT:    .long __atomic_fetch_add_8
   %1 = atomicrmw add ptr %a, i64 %b release
@@ -4961,7 +5141,7 @@ define i64 @atomicrmw_add_i64_acq_rel(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI173_0:
 ; CSKY-NEXT:    .long __atomic_fetch_add_8
   %1 = atomicrmw add ptr %a, i64 %b acq_rel
@@ -4980,7 +5160,7 @@ define i64 @atomicrmw_add_i64_seq_cst(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI174_0:
 ; CSKY-NEXT:    .long __atomic_fetch_add_8
   %1 = atomicrmw add ptr %a, i64 %b seq_cst
@@ -4999,7 +5179,7 @@ define i64 @atomicrmw_sub_i64_monotonic(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI175_0:
 ; CSKY-NEXT:    .long __atomic_fetch_sub_8
   %1 = atomicrmw sub ptr %a, i64 %b monotonic
@@ -5018,7 +5198,7 @@ define i64 @atomicrmw_sub_i64_acquire(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI176_0:
 ; CSKY-NEXT:    .long __atomic_fetch_sub_8
   %1 = atomicrmw sub ptr %a, i64 %b acquire
@@ -5037,7 +5217,7 @@ define i64 @atomicrmw_sub_i64_release(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI177_0:
 ; CSKY-NEXT:    .long __atomic_fetch_sub_8
   %1 = atomicrmw sub ptr %a, i64 %b release
@@ -5056,7 +5236,7 @@ define i64 @atomicrmw_sub_i64_acq_rel(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI178_0:
 ; CSKY-NEXT:    .long __atomic_fetch_sub_8
   %1 = atomicrmw sub ptr %a, i64 %b acq_rel
@@ -5075,7 +5255,7 @@ define i64 @atomicrmw_sub_i64_seq_cst(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI179_0:
 ; CSKY-NEXT:    .long __atomic_fetch_sub_8
   %1 = atomicrmw sub ptr %a, i64 %b seq_cst
@@ -5094,7 +5274,7 @@ define i64 @atomicrmw_and_i64_monotonic(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI180_0:
 ; CSKY-NEXT:    .long __atomic_fetch_and_8
   %1 = atomicrmw and ptr %a, i64 %b monotonic
@@ -5113,7 +5293,7 @@ define i64 @atomicrmw_and_i64_acquire(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI181_0:
 ; CSKY-NEXT:    .long __atomic_fetch_and_8
   %1 = atomicrmw and ptr %a, i64 %b acquire
@@ -5132,7 +5312,7 @@ define i64 @atomicrmw_and_i64_release(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI182_0:
 ; CSKY-NEXT:    .long __atomic_fetch_and_8
   %1 = atomicrmw and ptr %a, i64 %b release
@@ -5151,7 +5331,7 @@ define i64 @atomicrmw_and_i64_acq_rel(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI183_0:
 ; CSKY-NEXT:    .long __atomic_fetch_and_8
   %1 = atomicrmw and ptr %a, i64 %b acq_rel
@@ -5170,7 +5350,7 @@ define i64 @atomicrmw_and_i64_seq_cst(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI184_0:
 ; CSKY-NEXT:    .long __atomic_fetch_and_8
   %1 = atomicrmw and ptr %a, i64 %b seq_cst
@@ -5189,7 +5369,7 @@ define i64 @atomicrmw_nand_i64_monotonic(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI185_0:
 ; CSKY-NEXT:    .long __atomic_fetch_nand_8
   %1 = atomicrmw nand ptr %a, i64 %b monotonic
@@ -5208,7 +5388,7 @@ define i64 @atomicrmw_nand_i64_acquire(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI186_0:
 ; CSKY-NEXT:    .long __atomic_fetch_nand_8
   %1 = atomicrmw nand ptr %a, i64 %b acquire
@@ -5227,7 +5407,7 @@ define i64 @atomicrmw_nand_i64_release(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI187_0:
 ; CSKY-NEXT:    .long __atomic_fetch_nand_8
   %1 = atomicrmw nand ptr %a, i64 %b release
@@ -5246,7 +5426,7 @@ define i64 @atomicrmw_nand_i64_acq_rel(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI188_0:
 ; CSKY-NEXT:    .long __atomic_fetch_nand_8
   %1 = atomicrmw nand ptr %a, i64 %b acq_rel
@@ -5265,7 +5445,7 @@ define i64 @atomicrmw_nand_i64_seq_cst(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI189_0:
 ; CSKY-NEXT:    .long __atomic_fetch_nand_8
   %1 = atomicrmw nand ptr %a, i64 %b seq_cst
@@ -5284,7 +5464,7 @@ define i64 @atomicrmw_or_i64_monotonic(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI190_0:
 ; CSKY-NEXT:    .long __atomic_fetch_or_8
   %1 = atomicrmw or ptr %a, i64 %b monotonic
@@ -5303,7 +5483,7 @@ define i64 @atomicrmw_or_i64_acquire(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI191_0:
 ; CSKY-NEXT:    .long __atomic_fetch_or_8
   %1 = atomicrmw or ptr %a, i64 %b acquire
@@ -5322,7 +5502,7 @@ define i64 @atomicrmw_or_i64_release(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI192_0:
 ; CSKY-NEXT:    .long __atomic_fetch_or_8
   %1 = atomicrmw or ptr %a, i64 %b release
@@ -5341,7 +5521,7 @@ define i64 @atomicrmw_or_i64_acq_rel(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI193_0:
 ; CSKY-NEXT:    .long __atomic_fetch_or_8
   %1 = atomicrmw or ptr %a, i64 %b acq_rel
@@ -5360,7 +5540,7 @@ define i64 @atomicrmw_or_i64_seq_cst(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI194_0:
 ; CSKY-NEXT:    .long __atomic_fetch_or_8
   %1 = atomicrmw or ptr %a, i64 %b seq_cst
@@ -5379,7 +5559,7 @@ define i64 @atomicrmw_xor_i64_monotonic(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI195_0:
 ; CSKY-NEXT:    .long __atomic_fetch_xor_8
   %1 = atomicrmw xor ptr %a, i64 %b monotonic
@@ -5398,7 +5578,7 @@ define i64 @atomicrmw_xor_i64_acquire(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI196_0:
 ; CSKY-NEXT:    .long __atomic_fetch_xor_8
   %1 = atomicrmw xor ptr %a, i64 %b acquire
@@ -5417,7 +5597,7 @@ define i64 @atomicrmw_xor_i64_release(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI197_0:
 ; CSKY-NEXT:    .long __atomic_fetch_xor_8
   %1 = atomicrmw xor ptr %a, i64 %b release
@@ -5436,7 +5616,7 @@ define i64 @atomicrmw_xor_i64_acq_rel(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI198_0:
 ; CSKY-NEXT:    .long __atomic_fetch_xor_8
   %1 = atomicrmw xor ptr %a, i64 %b acq_rel
@@ -5455,7 +5635,7 @@ define i64 @atomicrmw_xor_i64_seq_cst(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.1:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI199_0:
 ; CSKY-NEXT:    .long __atomic_fetch_xor_8
   %1 = atomicrmw xor ptr %a, i64 %b seq_cst
@@ -5475,9 +5655,9 @@ define i64 @atomicrmw_max_i64_monotonic(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    mov16 l0, a2
 ; CSKY-NEXT:    mov16 l1, a1
 ; CSKY-NEXT:    mov16 l2, a0
-; CSKY-NEXT:    ld16.w a1, (a0, 4)
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
 ; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI200_0]
 ; CSKY-NEXT:  .LBB200_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    cmplt16 l0, a1
@@ -5505,7 +5685,7 @@ define i64 @atomicrmw_max_i64_monotonic(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    st16.w l3, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l2
 ; CSKY-NEXT:    addi16 a1, sp, 20
-; CSKY-NEXT:    jsri32 [.LCPI200_0]
+; CSKY-NEXT:    jsri32 [.LCPI200_1]
 ; CSKY-NEXT:    mov16 a2, a0
 ; CSKY-NEXT:    ld16.w a1, (sp, 24)
 ; CSKY-NEXT:    ld16.w a0, (sp, 20)
@@ -5521,8 +5701,10 @@ define i64 @atomicrmw_max_i64_monotonic(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI200_0:
+; CSKY-NEXT:    .long __atomic_load_8
+; CSKY-NEXT:  .LCPI200_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_8
   %1 = atomicrmw max ptr %a, i64 %b monotonic
   ret i64 %1
@@ -5541,8 +5723,8 @@ define i64 @atomicrmw_max_i64_acquire(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    mov16 l0, a2
 ; CSKY-NEXT:    mov16 l1, a1
 ; CSKY-NEXT:    mov16 l2, a0
-; CSKY-NEXT:    ld16.w a1, (a0, 4)
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI201_0]
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:  .LBB201_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -5571,7 +5753,7 @@ define i64 @atomicrmw_max_i64_acquire(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    st16.w l3, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l2
 ; CSKY-NEXT:    addi16 a1, sp, 20
-; CSKY-NEXT:    jsri32 [.LCPI201_0]
+; CSKY-NEXT:    jsri32 [.LCPI201_1]
 ; CSKY-NEXT:    mov16 a2, a0
 ; CSKY-NEXT:    ld16.w a1, (sp, 24)
 ; CSKY-NEXT:    ld16.w a0, (sp, 20)
@@ -5587,8 +5769,10 @@ define i64 @atomicrmw_max_i64_acquire(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI201_0:
+; CSKY-NEXT:    .long __atomic_load_8
+; CSKY-NEXT:  .LCPI201_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_8
   %1 = atomicrmw max ptr %a, i64 %b acquire
   ret i64 %1
@@ -5608,9 +5792,9 @@ define i64 @atomicrmw_max_i64_release(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    mov16 l0, a2
 ; CSKY-NEXT:    mov16 l1, a1
 ; CSKY-NEXT:    mov16 l2, a0
-; CSKY-NEXT:    ld16.w a1, (a0, 4)
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
 ; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI202_0]
 ; CSKY-NEXT:    movi32 l4, 3
 ; CSKY-NEXT:  .LBB202_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -5639,7 +5823,7 @@ define i64 @atomicrmw_max_i64_release(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    st32.w l4, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l2
 ; CSKY-NEXT:    addi16 a1, sp, 20
-; CSKY-NEXT:    jsri32 [.LCPI202_0]
+; CSKY-NEXT:    jsri32 [.LCPI202_1]
 ; CSKY-NEXT:    mov16 a2, a0
 ; CSKY-NEXT:    ld16.w a1, (sp, 24)
 ; CSKY-NEXT:    ld16.w a0, (sp, 20)
@@ -5656,8 +5840,10 @@ define i64 @atomicrmw_max_i64_release(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI202_0:
+; CSKY-NEXT:    .long __atomic_load_8
+; CSKY-NEXT:  .LCPI202_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_8
   %1 = atomicrmw max ptr %a, i64 %b release
   ret i64 %1
@@ -5677,8 +5863,8 @@ define i64 @atomicrmw_max_i64_acq_rel(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    mov16 l0, a2
 ; CSKY-NEXT:    mov16 l1, a1
 ; CSKY-NEXT:    mov16 l2, a0
-; CSKY-NEXT:    ld16.w a1, (a0, 4)
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI203_0]
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:    movi32 l4, 4
 ; CSKY-NEXT:  .LBB203_1: # %atomicrmw.start
@@ -5708,7 +5894,7 @@ define i64 @atomicrmw_max_i64_acq_rel(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    st32.w l4, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l2
 ; CSKY-NEXT:    addi16 a1, sp, 20
-; CSKY-NEXT:    jsri32 [.LCPI203_0]
+; CSKY-NEXT:    jsri32 [.LCPI203_1]
 ; CSKY-NEXT:    mov16 a2, a0
 ; CSKY-NEXT:    ld16.w a1, (sp, 24)
 ; CSKY-NEXT:    ld16.w a0, (sp, 20)
@@ -5725,8 +5911,10 @@ define i64 @atomicrmw_max_i64_acq_rel(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI203_0:
+; CSKY-NEXT:    .long __atomic_load_8
+; CSKY-NEXT:  .LCPI203_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_8
   %1 = atomicrmw max ptr %a, i64 %b acq_rel
   ret i64 %1
@@ -5745,8 +5933,8 @@ define i64 @atomicrmw_max_i64_seq_cst(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    mov16 l0, a2
 ; CSKY-NEXT:    mov16 l1, a1
 ; CSKY-NEXT:    mov16 l2, a0
-; CSKY-NEXT:    ld16.w a1, (a0, 4)
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI204_0]
 ; CSKY-NEXT:    movi16 l3, 5
 ; CSKY-NEXT:  .LBB204_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -5775,7 +5963,7 @@ define i64 @atomicrmw_max_i64_seq_cst(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    st16.w l3, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l2
 ; CSKY-NEXT:    addi16 a1, sp, 20
-; CSKY-NEXT:    jsri32 [.LCPI204_0]
+; CSKY-NEXT:    jsri32 [.LCPI204_1]
 ; CSKY-NEXT:    mov16 a2, a0
 ; CSKY-NEXT:    ld16.w a1, (sp, 24)
 ; CSKY-NEXT:    ld16.w a0, (sp, 20)
@@ -5791,8 +5979,10 @@ define i64 @atomicrmw_max_i64_seq_cst(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI204_0:
+; CSKY-NEXT:    .long __atomic_load_8
+; CSKY-NEXT:  .LCPI204_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_8
   %1 = atomicrmw max ptr %a, i64 %b seq_cst
   ret i64 %1
@@ -5811,9 +6001,9 @@ define i64 @atomicrmw_min_i64_monotonic(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    mov16 l0, a2
 ; CSKY-NEXT:    mov16 l1, a1
 ; CSKY-NEXT:    mov16 l2, a0
-; CSKY-NEXT:    ld16.w a1, (a0, 4)
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
 ; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI205_0]
 ; CSKY-NEXT:  .LBB205_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    cmphs16 l1, a0
@@ -5841,7 +6031,7 @@ define i64 @atomicrmw_min_i64_monotonic(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    st16.w l3, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l2
 ; CSKY-NEXT:    addi16 a1, sp, 20
-; CSKY-NEXT:    jsri32 [.LCPI205_0]
+; CSKY-NEXT:    jsri32 [.LCPI205_1]
 ; CSKY-NEXT:    mov16 a2, a0
 ; CSKY-NEXT:    ld16.w a1, (sp, 24)
 ; CSKY-NEXT:    ld16.w a0, (sp, 20)
@@ -5857,8 +6047,10 @@ define i64 @atomicrmw_min_i64_monotonic(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI205_0:
+; CSKY-NEXT:    .long __atomic_load_8
+; CSKY-NEXT:  .LCPI205_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_8
   %1 = atomicrmw min ptr %a, i64 %b monotonic
   ret i64 %1
@@ -5877,8 +6069,8 @@ define i64 @atomicrmw_min_i64_acquire(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    mov16 l0, a2
 ; CSKY-NEXT:    mov16 l1, a1
 ; CSKY-NEXT:    mov16 l2, a0
-; CSKY-NEXT:    ld16.w a1, (a0, 4)
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI206_0]
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:  .LBB206_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -5907,7 +6099,7 @@ define i64 @atomicrmw_min_i64_acquire(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    st16.w l3, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l2
 ; CSKY-NEXT:    addi16 a1, sp, 20
-; CSKY-NEXT:    jsri32 [.LCPI206_0]
+; CSKY-NEXT:    jsri32 [.LCPI206_1]
 ; CSKY-NEXT:    mov16 a2, a0
 ; CSKY-NEXT:    ld16.w a1, (sp, 24)
 ; CSKY-NEXT:    ld16.w a0, (sp, 20)
@@ -5923,8 +6115,10 @@ define i64 @atomicrmw_min_i64_acquire(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI206_0:
+; CSKY-NEXT:    .long __atomic_load_8
+; CSKY-NEXT:  .LCPI206_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_8
   %1 = atomicrmw min ptr %a, i64 %b acquire
   ret i64 %1
@@ -5944,9 +6138,9 @@ define i64 @atomicrmw_min_i64_release(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    mov16 l0, a2
 ; CSKY-NEXT:    mov16 l1, a1
 ; CSKY-NEXT:    mov16 l2, a0
-; CSKY-NEXT:    ld16.w a1, (a0, 4)
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
 ; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI207_0]
 ; CSKY-NEXT:    movi32 l4, 3
 ; CSKY-NEXT:  .LBB207_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -5975,7 +6169,7 @@ define i64 @atomicrmw_min_i64_release(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    st32.w l4, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l2
 ; CSKY-NEXT:    addi16 a1, sp, 20
-; CSKY-NEXT:    jsri32 [.LCPI207_0]
+; CSKY-NEXT:    jsri32 [.LCPI207_1]
 ; CSKY-NEXT:    mov16 a2, a0
 ; CSKY-NEXT:    ld16.w a1, (sp, 24)
 ; CSKY-NEXT:    ld16.w a0, (sp, 20)
@@ -5992,8 +6186,10 @@ define i64 @atomicrmw_min_i64_release(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI207_0:
+; CSKY-NEXT:    .long __atomic_load_8
+; CSKY-NEXT:  .LCPI207_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_8
   %1 = atomicrmw min ptr %a, i64 %b release
   ret i64 %1
@@ -6013,8 +6209,8 @@ define i64 @atomicrmw_min_i64_acq_rel(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    mov16 l0, a2
 ; CSKY-NEXT:    mov16 l1, a1
 ; CSKY-NEXT:    mov16 l2, a0
-; CSKY-NEXT:    ld16.w a1, (a0, 4)
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI208_0]
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:    movi32 l4, 4
 ; CSKY-NEXT:  .LBB208_1: # %atomicrmw.start
@@ -6044,7 +6240,7 @@ define i64 @atomicrmw_min_i64_acq_rel(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    st32.w l4, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l2
 ; CSKY-NEXT:    addi16 a1, sp, 20
-; CSKY-NEXT:    jsri32 [.LCPI208_0]
+; CSKY-NEXT:    jsri32 [.LCPI208_1]
 ; CSKY-NEXT:    mov16 a2, a0
 ; CSKY-NEXT:    ld16.w a1, (sp, 24)
 ; CSKY-NEXT:    ld16.w a0, (sp, 20)
@@ -6061,8 +6257,10 @@ define i64 @atomicrmw_min_i64_acq_rel(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI208_0:
+; CSKY-NEXT:    .long __atomic_load_8
+; CSKY-NEXT:  .LCPI208_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_8
   %1 = atomicrmw min ptr %a, i64 %b acq_rel
   ret i64 %1
@@ -6081,8 +6279,8 @@ define i64 @atomicrmw_min_i64_seq_cst(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    mov16 l0, a2
 ; CSKY-NEXT:    mov16 l1, a1
 ; CSKY-NEXT:    mov16 l2, a0
-; CSKY-NEXT:    ld16.w a1, (a0, 4)
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI209_0]
 ; CSKY-NEXT:    movi16 l3, 5
 ; CSKY-NEXT:  .LBB209_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -6111,7 +6309,7 @@ define i64 @atomicrmw_min_i64_seq_cst(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    st16.w l3, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l2
 ; CSKY-NEXT:    addi16 a1, sp, 20
-; CSKY-NEXT:    jsri32 [.LCPI209_0]
+; CSKY-NEXT:    jsri32 [.LCPI209_1]
 ; CSKY-NEXT:    mov16 a2, a0
 ; CSKY-NEXT:    ld16.w a1, (sp, 24)
 ; CSKY-NEXT:    ld16.w a0, (sp, 20)
@@ -6127,8 +6325,10 @@ define i64 @atomicrmw_min_i64_seq_cst(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI209_0:
+; CSKY-NEXT:    .long __atomic_load_8
+; CSKY-NEXT:  .LCPI209_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_8
   %1 = atomicrmw min ptr %a, i64 %b seq_cst
   ret i64 %1
@@ -6147,9 +6347,9 @@ define i64 @atomicrmw_umax_i64_monotonic(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    mov16 l0, a2
 ; CSKY-NEXT:    mov16 l1, a1
 ; CSKY-NEXT:    mov16 l2, a0
-; CSKY-NEXT:    ld16.w a1, (a0, 4)
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
 ; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI210_0]
 ; CSKY-NEXT:  .LBB210_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    cmpne16 a1, l0
@@ -6173,7 +6373,7 @@ define i64 @atomicrmw_umax_i64_monotonic(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    st16.w l3, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l2
 ; CSKY-NEXT:    addi16 a1, sp, 16
-; CSKY-NEXT:    jsri32 [.LCPI210_0]
+; CSKY-NEXT:    jsri32 [.LCPI210_1]
 ; CSKY-NEXT:    mov16 a2, a0
 ; CSKY-NEXT:    ld16.w a1, (sp, 20)
 ; CSKY-NEXT:    ld16.w a0, (sp, 16)
@@ -6189,8 +6389,10 @@ define i64 @atomicrmw_umax_i64_monotonic(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI210_0:
+; CSKY-NEXT:    .long __atomic_load_8
+; CSKY-NEXT:  .LCPI210_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_8
   %1 = atomicrmw umax ptr %a, i64 %b monotonic
   ret i64 %1
@@ -6209,8 +6411,8 @@ define i64 @atomicrmw_umax_i64_acquire(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    mov16 l0, a2
 ; CSKY-NEXT:    mov16 l1, a1
 ; CSKY-NEXT:    mov16 l2, a0
-; CSKY-NEXT:    ld16.w a1, (a0, 4)
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI211_0]
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:  .LBB211_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -6235,7 +6437,7 @@ define i64 @atomicrmw_umax_i64_acquire(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    st16.w l3, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l2
 ; CSKY-NEXT:    addi16 a1, sp, 16
-; CSKY-NEXT:    jsri32 [.LCPI211_0]
+; CSKY-NEXT:    jsri32 [.LCPI211_1]
 ; CSKY-NEXT:    mov16 a2, a0
 ; CSKY-NEXT:    ld16.w a1, (sp, 20)
 ; CSKY-NEXT:    ld16.w a0, (sp, 16)
@@ -6251,8 +6453,10 @@ define i64 @atomicrmw_umax_i64_acquire(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI211_0:
+; CSKY-NEXT:    .long __atomic_load_8
+; CSKY-NEXT:  .LCPI211_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_8
   %1 = atomicrmw umax ptr %a, i64 %b acquire
   ret i64 %1
@@ -6272,9 +6476,9 @@ define i64 @atomicrmw_umax_i64_release(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    mov16 l0, a2
 ; CSKY-NEXT:    mov16 l1, a1
 ; CSKY-NEXT:    mov16 l2, a0
-; CSKY-NEXT:    ld16.w a1, (a0, 4)
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
 ; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI212_0]
 ; CSKY-NEXT:    movi32 l4, 3
 ; CSKY-NEXT:  .LBB212_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -6299,7 +6503,7 @@ define i64 @atomicrmw_umax_i64_release(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    st32.w l4, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l2
 ; CSKY-NEXT:    addi16 a1, sp, 16
-; CSKY-NEXT:    jsri32 [.LCPI212_0]
+; CSKY-NEXT:    jsri32 [.LCPI212_1]
 ; CSKY-NEXT:    mov16 a2, a0
 ; CSKY-NEXT:    ld16.w a1, (sp, 20)
 ; CSKY-NEXT:    ld16.w a0, (sp, 16)
@@ -6316,8 +6520,10 @@ define i64 @atomicrmw_umax_i64_release(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI212_0:
+; CSKY-NEXT:    .long __atomic_load_8
+; CSKY-NEXT:  .LCPI212_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_8
   %1 = atomicrmw umax ptr %a, i64 %b release
   ret i64 %1
@@ -6337,8 +6543,8 @@ define i64 @atomicrmw_umax_i64_acq_rel(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    mov16 l0, a2
 ; CSKY-NEXT:    mov16 l1, a1
 ; CSKY-NEXT:    mov16 l2, a0
-; CSKY-NEXT:    ld16.w a1, (a0, 4)
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI213_0]
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:    movi32 l4, 4
 ; CSKY-NEXT:  .LBB213_1: # %atomicrmw.start
@@ -6364,7 +6570,7 @@ define i64 @atomicrmw_umax_i64_acq_rel(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    st32.w l4, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l2
 ; CSKY-NEXT:    addi16 a1, sp, 16
-; CSKY-NEXT:    jsri32 [.LCPI213_0]
+; CSKY-NEXT:    jsri32 [.LCPI213_1]
 ; CSKY-NEXT:    mov16 a2, a0
 ; CSKY-NEXT:    ld16.w a1, (sp, 20)
 ; CSKY-NEXT:    ld16.w a0, (sp, 16)
@@ -6381,8 +6587,10 @@ define i64 @atomicrmw_umax_i64_acq_rel(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI213_0:
+; CSKY-NEXT:    .long __atomic_load_8
+; CSKY-NEXT:  .LCPI213_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_8
   %1 = atomicrmw umax ptr %a, i64 %b acq_rel
   ret i64 %1
@@ -6401,8 +6609,8 @@ define i64 @atomicrmw_umax_i64_seq_cst(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    mov16 l0, a2
 ; CSKY-NEXT:    mov16 l1, a1
 ; CSKY-NEXT:    mov16 l2, a0
-; CSKY-NEXT:    ld16.w a1, (a0, 4)
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI214_0]
 ; CSKY-NEXT:    movi16 l3, 5
 ; CSKY-NEXT:  .LBB214_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -6427,7 +6635,7 @@ define i64 @atomicrmw_umax_i64_seq_cst(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    st16.w l3, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l2
 ; CSKY-NEXT:    addi16 a1, sp, 16
-; CSKY-NEXT:    jsri32 [.LCPI214_0]
+; CSKY-NEXT:    jsri32 [.LCPI214_1]
 ; CSKY-NEXT:    mov16 a2, a0
 ; CSKY-NEXT:    ld16.w a1, (sp, 20)
 ; CSKY-NEXT:    ld16.w a0, (sp, 16)
@@ -6443,8 +6651,10 @@ define i64 @atomicrmw_umax_i64_seq_cst(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI214_0:
+; CSKY-NEXT:    .long __atomic_load_8
+; CSKY-NEXT:  .LCPI214_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_8
   %1 = atomicrmw umax ptr %a, i64 %b seq_cst
   ret i64 %1
@@ -6463,9 +6673,9 @@ define i64 @atomicrmw_umin_i64_monotonic(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    mov16 l0, a2
 ; CSKY-NEXT:    mov16 l1, a1
 ; CSKY-NEXT:    mov16 l2, a0
-; CSKY-NEXT:    ld16.w a1, (a0, 4)
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
 ; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI215_0]
 ; CSKY-NEXT:  .LBB215_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
 ; CSKY-NEXT:    cmphs16 l1, a0
@@ -6497,7 +6707,7 @@ define i64 @atomicrmw_umin_i64_monotonic(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    st16.w l3, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l2
 ; CSKY-NEXT:    addi16 a1, sp, 24
-; CSKY-NEXT:    jsri32 [.LCPI215_0]
+; CSKY-NEXT:    jsri32 [.LCPI215_1]
 ; CSKY-NEXT:    mov16 a2, a0
 ; CSKY-NEXT:    ld16.w a1, (sp, 28)
 ; CSKY-NEXT:    ld16.w a0, (sp, 24)
@@ -6513,8 +6723,10 @@ define i64 @atomicrmw_umin_i64_monotonic(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI215_0:
+; CSKY-NEXT:    .long __atomic_load_8
+; CSKY-NEXT:  .LCPI215_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_8
   %1 = atomicrmw umin ptr %a, i64 %b monotonic
   ret i64 %1
@@ -6533,8 +6745,8 @@ define i64 @atomicrmw_umin_i64_acquire(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    mov16 l0, a2
 ; CSKY-NEXT:    mov16 l1, a1
 ; CSKY-NEXT:    mov16 l2, a0
-; CSKY-NEXT:    ld16.w a1, (a0, 4)
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI216_0]
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:  .LBB216_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -6567,7 +6779,7 @@ define i64 @atomicrmw_umin_i64_acquire(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    st16.w l3, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l2
 ; CSKY-NEXT:    addi16 a1, sp, 24
-; CSKY-NEXT:    jsri32 [.LCPI216_0]
+; CSKY-NEXT:    jsri32 [.LCPI216_1]
 ; CSKY-NEXT:    mov16 a2, a0
 ; CSKY-NEXT:    ld16.w a1, (sp, 28)
 ; CSKY-NEXT:    ld16.w a0, (sp, 24)
@@ -6583,8 +6795,10 @@ define i64 @atomicrmw_umin_i64_acquire(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI216_0:
+; CSKY-NEXT:    .long __atomic_load_8
+; CSKY-NEXT:  .LCPI216_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_8
   %1 = atomicrmw umin ptr %a, i64 %b acquire
   ret i64 %1
@@ -6604,9 +6818,9 @@ define i64 @atomicrmw_umin_i64_release(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    mov16 l0, a2
 ; CSKY-NEXT:    mov16 l1, a1
 ; CSKY-NEXT:    mov16 l2, a0
-; CSKY-NEXT:    ld16.w a1, (a0, 4)
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
 ; CSKY-NEXT:    movi16 l3, 0
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI217_0]
 ; CSKY-NEXT:    movi32 l4, 3
 ; CSKY-NEXT:  .LBB217_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -6639,7 +6853,7 @@ define i64 @atomicrmw_umin_i64_release(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    st32.w l4, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l2
 ; CSKY-NEXT:    addi16 a1, sp, 24
-; CSKY-NEXT:    jsri32 [.LCPI217_0]
+; CSKY-NEXT:    jsri32 [.LCPI217_1]
 ; CSKY-NEXT:    mov16 a2, a0
 ; CSKY-NEXT:    ld16.w a1, (sp, 28)
 ; CSKY-NEXT:    ld16.w a0, (sp, 24)
@@ -6656,8 +6870,10 @@ define i64 @atomicrmw_umin_i64_release(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI217_0:
+; CSKY-NEXT:    .long __atomic_load_8
+; CSKY-NEXT:  .LCPI217_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_8
   %1 = atomicrmw umin ptr %a, i64 %b release
   ret i64 %1
@@ -6677,8 +6893,8 @@ define i64 @atomicrmw_umin_i64_acq_rel(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    mov16 l0, a2
 ; CSKY-NEXT:    mov16 l1, a1
 ; CSKY-NEXT:    mov16 l2, a0
-; CSKY-NEXT:    ld16.w a1, (a0, 4)
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI218_0]
 ; CSKY-NEXT:    movi16 l3, 2
 ; CSKY-NEXT:    movi32 l4, 4
 ; CSKY-NEXT:  .LBB218_1: # %atomicrmw.start
@@ -6712,7 +6928,7 @@ define i64 @atomicrmw_umin_i64_acq_rel(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    st32.w l4, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l2
 ; CSKY-NEXT:    addi16 a1, sp, 24
-; CSKY-NEXT:    jsri32 [.LCPI218_0]
+; CSKY-NEXT:    jsri32 [.LCPI218_1]
 ; CSKY-NEXT:    mov16 a2, a0
 ; CSKY-NEXT:    ld16.w a1, (sp, 28)
 ; CSKY-NEXT:    ld16.w a0, (sp, 24)
@@ -6729,8 +6945,10 @@ define i64 @atomicrmw_umin_i64_acq_rel(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI218_0:
+; CSKY-NEXT:    .long __atomic_load_8
+; CSKY-NEXT:  .LCPI218_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_8
   %1 = atomicrmw umin ptr %a, i64 %b acq_rel
   ret i64 %1
@@ -6749,8 +6967,8 @@ define i64 @atomicrmw_umin_i64_seq_cst(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    mov16 l0, a2
 ; CSKY-NEXT:    mov16 l1, a1
 ; CSKY-NEXT:    mov16 l2, a0
-; CSKY-NEXT:    ld16.w a1, (a0, 4)
-; CSKY-NEXT:    ld16.w a0, (a0, 0)
+; CSKY-NEXT:    movi16 a1, 0
+; CSKY-NEXT:    jsri32 [.LCPI219_0]
 ; CSKY-NEXT:    movi16 l3, 5
 ; CSKY-NEXT:  .LBB219_1: # %atomicrmw.start
 ; CSKY-NEXT:    # =>This Inner Loop Header: Depth=1
@@ -6783,7 +7001,7 @@ define i64 @atomicrmw_umin_i64_seq_cst(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    st16.w l3, (sp, 0)
 ; CSKY-NEXT:    mov16 a0, l2
 ; CSKY-NEXT:    addi16 a1, sp, 24
-; CSKY-NEXT:    jsri32 [.LCPI219_0]
+; CSKY-NEXT:    jsri32 [.LCPI219_1]
 ; CSKY-NEXT:    mov16 a2, a0
 ; CSKY-NEXT:    ld16.w a1, (sp, 28)
 ; CSKY-NEXT:    ld16.w a0, (sp, 24)
@@ -6799,8 +7017,10 @@ define i64 @atomicrmw_umin_i64_seq_cst(ptr %a, i64 %b) nounwind {
 ; CSKY-NEXT:    rts16
 ; CSKY-NEXT:    .p2align 1
 ; CSKY-NEXT:  # %bb.3:
-; CSKY-NEXT:    .p2align 2
+; CSKY-NEXT:    .p2align 2, 0x0
 ; CSKY-NEXT:  .LCPI219_0:
+; CSKY-NEXT:    .long __atomic_load_8
+; CSKY-NEXT:  .LCPI219_1:
 ; CSKY-NEXT:    .long __atomic_compare_exchange_8
   %1 = atomicrmw umin ptr %a, i64 %b seq_cst
   ret i64 %1

--- a/llvm/test/CodeGen/CSKY/inline-asm-invalid.ll
+++ b/llvm/test/CodeGen/CSKY/inline-asm-invalid.ll
@@ -2,9 +2,9 @@
 ; RUN: not llc -mtriple=csky < %s 2>&1 | FileCheck %s
 
 define void @constraint_f() nounwind {
-; CHECK: error: couldn't allocate input reg for constraint 'v'
+; CHECK: error: could not allocate input reg for constraint 'v'
   tail call void asm "fadds fa0, fa0, $0", "v"(float 0.0)
-; CHECK: error: couldn't allocate input reg for constraint 'v'
+; CHECK: error: could not allocate input reg for constraint 'v'
   tail call void asm "faddd fa0, fa0, $0", "v"(double 0.0)
   ret void
 }

--- a/llvm/test/CodeGen/M68k/Atomics/rmw.ll
+++ b/llvm/test/CodeGen/M68k/Atomics/rmw.ll
@@ -329,13 +329,14 @@ define i64 @atomicrmw_max_i64(i64 %val, ptr %ptr) {
 ; NO-ATOMIC-NEXT:  ; %bb.0:
 ; NO-ATOMIC-NEXT:    suba.l #52, %sp
 ; NO-ATOMIC-NEXT:    .cfi_def_cfa_offset -56
-; NO-ATOMIC-NEXT:    movem.l %d2-%d4/%a2-%a3, (32,%sp) ; 24-byte Folded Spill
-; NO-ATOMIC-NEXT:    move.l (60,%sp), %d3
-; NO-ATOMIC-NEXT:    move.l (56,%sp), %d4
-; NO-ATOMIC-NEXT:    move.l (64,%sp), %a2
-; NO-ATOMIC-NEXT:    move.l (4,%a2), %d1
-; NO-ATOMIC-NEXT:    move.l (%a2), %d0
-; NO-ATOMIC-NEXT:    lea (24,%sp), %a3
+; NO-ATOMIC-NEXT:    movem.l %d2-%d5/%a2, (32,%sp) ; 24-byte Folded Spill
+; NO-ATOMIC-NEXT:    move.l (64,%sp), %d3
+; NO-ATOMIC-NEXT:    move.l %d3, (%sp)
+; NO-ATOMIC-NEXT:    move.l #0, (4,%sp)
+; NO-ATOMIC-NEXT:    move.l (60,%sp), %d4
+; NO-ATOMIC-NEXT:    move.l (56,%sp), %d5
+; NO-ATOMIC-NEXT:    jsr __atomic_load_8
+; NO-ATOMIC-NEXT:    lea (24,%sp), %a2
 ; NO-ATOMIC-NEXT:    bra .LBB7_1
 ; NO-ATOMIC-NEXT:  .LBB7_3: ; %atomicrmw.start
 ; NO-ATOMIC-NEXT:    ; in Loop: Header=BB7_1 Depth=1
@@ -353,22 +354,22 @@ define i64 @atomicrmw_max_i64(i64 %val, ptr %ptr) {
 ; NO-ATOMIC-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; NO-ATOMIC-NEXT:    move.l %d0, (24,%sp)
 ; NO-ATOMIC-NEXT:    move.l %d1, (28,%sp)
-; NO-ATOMIC-NEXT:    move.l %a2, (%sp)
-; NO-ATOMIC-NEXT:    move.l %a3, (4,%sp)
-; NO-ATOMIC-NEXT:    move.l %d3, %d2
-; NO-ATOMIC-NEXT:    sub.l %d1, %d2
+; NO-ATOMIC-NEXT:    move.l %d3, (%sp)
+; NO-ATOMIC-NEXT:    move.l %a2, (4,%sp)
 ; NO-ATOMIC-NEXT:    move.l %d4, %d2
+; NO-ATOMIC-NEXT:    sub.l %d1, %d2
+; NO-ATOMIC-NEXT:    move.l %d5, %d2
 ; NO-ATOMIC-NEXT:    subx.l %d0, %d2
 ; NO-ATOMIC-NEXT:    slt %d2
 ; NO-ATOMIC-NEXT:    cmpi.b #0, %d2
 ; NO-ATOMIC-NEXT:    bne .LBB7_3
 ; NO-ATOMIC-NEXT:  ; %bb.2: ; %atomicrmw.start
 ; NO-ATOMIC-NEXT:    ; in Loop: Header=BB7_1 Depth=1
-; NO-ATOMIC-NEXT:    move.l %d3, %d1
-; NO-ATOMIC-NEXT:    move.l %d4, %d0
+; NO-ATOMIC-NEXT:    move.l %d4, %d1
+; NO-ATOMIC-NEXT:    move.l %d5, %d0
 ; NO-ATOMIC-NEXT:    bra .LBB7_3
 ; NO-ATOMIC-NEXT:  .LBB7_4: ; %atomicrmw.end
-; NO-ATOMIC-NEXT:    movem.l (32,%sp), %d2-%d4/%a2-%a3 ; 24-byte Folded Reload
+; NO-ATOMIC-NEXT:    movem.l (32,%sp), %d2-%d5/%a2 ; 24-byte Folded Reload
 ; NO-ATOMIC-NEXT:    adda.l #52, %sp
 ; NO-ATOMIC-NEXT:    rts
 ;
@@ -377,13 +378,14 @@ define i64 @atomicrmw_max_i64(i64 %val, ptr %ptr) {
 ; ATOMIC-NEXT:  ; %bb.0:
 ; ATOMIC-NEXT:    suba.l #52, %sp
 ; ATOMIC-NEXT:    .cfi_def_cfa_offset -56
-; ATOMIC-NEXT:    movem.l %d2-%d4/%a2-%a3, (32,%sp) ; 24-byte Folded Spill
-; ATOMIC-NEXT:    move.l (60,%sp), %d3
-; ATOMIC-NEXT:    move.l (56,%sp), %d4
-; ATOMIC-NEXT:    move.l (64,%sp), %a2
-; ATOMIC-NEXT:    move.l (4,%a2), %d1
-; ATOMIC-NEXT:    move.l (%a2), %d0
-; ATOMIC-NEXT:    lea (24,%sp), %a3
+; ATOMIC-NEXT:    movem.l %d2-%d5/%a2, (32,%sp) ; 24-byte Folded Spill
+; ATOMIC-NEXT:    move.l (64,%sp), %d3
+; ATOMIC-NEXT:    move.l %d3, (%sp)
+; ATOMIC-NEXT:    move.l #0, (4,%sp)
+; ATOMIC-NEXT:    move.l (60,%sp), %d4
+; ATOMIC-NEXT:    move.l (56,%sp), %d5
+; ATOMIC-NEXT:    jsr __atomic_load_8
+; ATOMIC-NEXT:    lea (24,%sp), %a2
 ; ATOMIC-NEXT:    bra .LBB7_1
 ; ATOMIC-NEXT:  .LBB7_3: ; %atomicrmw.start
 ; ATOMIC-NEXT:    ; in Loop: Header=BB7_1 Depth=1
@@ -401,22 +403,22 @@ define i64 @atomicrmw_max_i64(i64 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; ATOMIC-NEXT:    move.l %d0, (24,%sp)
 ; ATOMIC-NEXT:    move.l %d1, (28,%sp)
-; ATOMIC-NEXT:    move.l %a2, (%sp)
-; ATOMIC-NEXT:    move.l %a3, (4,%sp)
-; ATOMIC-NEXT:    move.l %d3, %d2
-; ATOMIC-NEXT:    sub.l %d1, %d2
+; ATOMIC-NEXT:    move.l %d3, (%sp)
+; ATOMIC-NEXT:    move.l %a2, (4,%sp)
 ; ATOMIC-NEXT:    move.l %d4, %d2
+; ATOMIC-NEXT:    sub.l %d1, %d2
+; ATOMIC-NEXT:    move.l %d5, %d2
 ; ATOMIC-NEXT:    subx.l %d0, %d2
 ; ATOMIC-NEXT:    slt %d2
 ; ATOMIC-NEXT:    cmpi.b #0, %d2
 ; ATOMIC-NEXT:    bne .LBB7_3
 ; ATOMIC-NEXT:  ; %bb.2: ; %atomicrmw.start
 ; ATOMIC-NEXT:    ; in Loop: Header=BB7_1 Depth=1
-; ATOMIC-NEXT:    move.l %d3, %d1
-; ATOMIC-NEXT:    move.l %d4, %d0
+; ATOMIC-NEXT:    move.l %d4, %d1
+; ATOMIC-NEXT:    move.l %d5, %d0
 ; ATOMIC-NEXT:    bra .LBB7_3
 ; ATOMIC-NEXT:  .LBB7_4: ; %atomicrmw.end
-; ATOMIC-NEXT:    movem.l (32,%sp), %d2-%d4/%a2-%a3 ; 24-byte Folded Reload
+; ATOMIC-NEXT:    movem.l (32,%sp), %d2-%d5/%a2 ; 24-byte Folded Reload
 ; ATOMIC-NEXT:    adda.l #52, %sp
 ; ATOMIC-NEXT:    rts
   %old = atomicrmw max ptr %ptr, i64 %val seq_cst

--- a/llvm/test/CodeGen/M68k/CodeModel/Large/Atomics/rmw.ll
+++ b/llvm/test/CodeGen/M68k/CodeModel/Large/Atomics/rmw.ll
@@ -624,13 +624,14 @@ define i64 @atomicrmw_max_i64(i64 %val, ptr %ptr) {
 ; NO-ATOMIC-NEXT:  ; %bb.0:
 ; NO-ATOMIC-NEXT:    suba.l #52, %sp
 ; NO-ATOMIC-NEXT:    .cfi_def_cfa_offset -56
-; NO-ATOMIC-NEXT:    movem.l %d2-%d4/%a2-%a3, (32,%sp) ; 24-byte Folded Spill
-; NO-ATOMIC-NEXT:    move.l (60,%sp), %d3
-; NO-ATOMIC-NEXT:    move.l (56,%sp), %d4
-; NO-ATOMIC-NEXT:    move.l (64,%sp), %a2
-; NO-ATOMIC-NEXT:    move.l (4,%a2), %d1
-; NO-ATOMIC-NEXT:    move.l (%a2), %d0
-; NO-ATOMIC-NEXT:    lea (24,%sp), %a3
+; NO-ATOMIC-NEXT:    movem.l %d2-%d5/%a2, (32,%sp) ; 24-byte Folded Spill
+; NO-ATOMIC-NEXT:    move.l (64,%sp), %d3
+; NO-ATOMIC-NEXT:    move.l %d3, (%sp)
+; NO-ATOMIC-NEXT:    move.l #0, (4,%sp)
+; NO-ATOMIC-NEXT:    move.l (60,%sp), %d4
+; NO-ATOMIC-NEXT:    move.l (56,%sp), %d5
+; NO-ATOMIC-NEXT:    jsr __atomic_load_8
+; NO-ATOMIC-NEXT:    lea (24,%sp), %a2
 ; NO-ATOMIC-NEXT:    bra .LBB7_1
 ; NO-ATOMIC-NEXT:  .LBB7_3: ; %atomicrmw.start
 ; NO-ATOMIC-NEXT:    ; in Loop: Header=BB7_1 Depth=1
@@ -648,22 +649,22 @@ define i64 @atomicrmw_max_i64(i64 %val, ptr %ptr) {
 ; NO-ATOMIC-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; NO-ATOMIC-NEXT:    move.l %d0, (24,%sp)
 ; NO-ATOMIC-NEXT:    move.l %d1, (28,%sp)
-; NO-ATOMIC-NEXT:    move.l %a2, (%sp)
-; NO-ATOMIC-NEXT:    move.l %a3, (4,%sp)
-; NO-ATOMIC-NEXT:    move.l %d3, %d2
-; NO-ATOMIC-NEXT:    sub.l %d1, %d2
+; NO-ATOMIC-NEXT:    move.l %d3, (%sp)
+; NO-ATOMIC-NEXT:    move.l %a2, (4,%sp)
 ; NO-ATOMIC-NEXT:    move.l %d4, %d2
+; NO-ATOMIC-NEXT:    sub.l %d1, %d2
+; NO-ATOMIC-NEXT:    move.l %d5, %d2
 ; NO-ATOMIC-NEXT:    subx.l %d0, %d2
 ; NO-ATOMIC-NEXT:    slt %d2
 ; NO-ATOMIC-NEXT:    cmpi.b #0, %d2
 ; NO-ATOMIC-NEXT:    bne .LBB7_3
 ; NO-ATOMIC-NEXT:  ; %bb.2: ; %atomicrmw.start
 ; NO-ATOMIC-NEXT:    ; in Loop: Header=BB7_1 Depth=1
-; NO-ATOMIC-NEXT:    move.l %d3, %d1
-; NO-ATOMIC-NEXT:    move.l %d4, %d0
+; NO-ATOMIC-NEXT:    move.l %d4, %d1
+; NO-ATOMIC-NEXT:    move.l %d5, %d0
 ; NO-ATOMIC-NEXT:    bra .LBB7_3
 ; NO-ATOMIC-NEXT:  .LBB7_4: ; %atomicrmw.end
-; NO-ATOMIC-NEXT:    movem.l (32,%sp), %d2-%d4/%a2-%a3 ; 24-byte Folded Reload
+; NO-ATOMIC-NEXT:    movem.l (32,%sp), %d2-%d5/%a2 ; 24-byte Folded Reload
 ; NO-ATOMIC-NEXT:    adda.l #52, %sp
 ; NO-ATOMIC-NEXT:    rts
 ;
@@ -672,13 +673,14 @@ define i64 @atomicrmw_max_i64(i64 %val, ptr %ptr) {
 ; NO-ATOMIC-PIC-NEXT:  ; %bb.0:
 ; NO-ATOMIC-PIC-NEXT:    suba.l #52, %sp
 ; NO-ATOMIC-PIC-NEXT:    .cfi_def_cfa_offset -56
-; NO-ATOMIC-PIC-NEXT:    movem.l %d2-%d4/%a2-%a3, (32,%sp) ; 24-byte Folded Spill
-; NO-ATOMIC-PIC-NEXT:    move.l (60,%sp), %d3
-; NO-ATOMIC-PIC-NEXT:    move.l (56,%sp), %d4
-; NO-ATOMIC-PIC-NEXT:    move.l (64,%sp), %a2
-; NO-ATOMIC-PIC-NEXT:    move.l (4,%a2), %d1
-; NO-ATOMIC-PIC-NEXT:    move.l (%a2), %d0
-; NO-ATOMIC-PIC-NEXT:    lea (24,%sp), %a3
+; NO-ATOMIC-PIC-NEXT:    movem.l %d2-%d5/%a2, (32,%sp) ; 24-byte Folded Spill
+; NO-ATOMIC-PIC-NEXT:    move.l (64,%sp), %d3
+; NO-ATOMIC-PIC-NEXT:    move.l %d3, (%sp)
+; NO-ATOMIC-PIC-NEXT:    move.l #0, (4,%sp)
+; NO-ATOMIC-PIC-NEXT:    move.l (60,%sp), %d4
+; NO-ATOMIC-PIC-NEXT:    move.l (56,%sp), %d5
+; NO-ATOMIC-PIC-NEXT:    jsr (__atomic_load_8@PLT,%pc)
+; NO-ATOMIC-PIC-NEXT:    lea (24,%sp), %a2
 ; NO-ATOMIC-PIC-NEXT:    bra .LBB7_1
 ; NO-ATOMIC-PIC-NEXT:  .LBB7_3: ; %atomicrmw.start
 ; NO-ATOMIC-PIC-NEXT:    ; in Loop: Header=BB7_1 Depth=1
@@ -696,22 +698,22 @@ define i64 @atomicrmw_max_i64(i64 %val, ptr %ptr) {
 ; NO-ATOMIC-PIC-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; NO-ATOMIC-PIC-NEXT:    move.l %d0, (24,%sp)
 ; NO-ATOMIC-PIC-NEXT:    move.l %d1, (28,%sp)
-; NO-ATOMIC-PIC-NEXT:    move.l %a2, (%sp)
-; NO-ATOMIC-PIC-NEXT:    move.l %a3, (4,%sp)
-; NO-ATOMIC-PIC-NEXT:    move.l %d3, %d2
-; NO-ATOMIC-PIC-NEXT:    sub.l %d1, %d2
+; NO-ATOMIC-PIC-NEXT:    move.l %d3, (%sp)
+; NO-ATOMIC-PIC-NEXT:    move.l %a2, (4,%sp)
 ; NO-ATOMIC-PIC-NEXT:    move.l %d4, %d2
+; NO-ATOMIC-PIC-NEXT:    sub.l %d1, %d2
+; NO-ATOMIC-PIC-NEXT:    move.l %d5, %d2
 ; NO-ATOMIC-PIC-NEXT:    subx.l %d0, %d2
 ; NO-ATOMIC-PIC-NEXT:    slt %d2
 ; NO-ATOMIC-PIC-NEXT:    cmpi.b #0, %d2
 ; NO-ATOMIC-PIC-NEXT:    bne .LBB7_3
 ; NO-ATOMIC-PIC-NEXT:  ; %bb.2: ; %atomicrmw.start
 ; NO-ATOMIC-PIC-NEXT:    ; in Loop: Header=BB7_1 Depth=1
-; NO-ATOMIC-PIC-NEXT:    move.l %d3, %d1
-; NO-ATOMIC-PIC-NEXT:    move.l %d4, %d0
+; NO-ATOMIC-PIC-NEXT:    move.l %d4, %d1
+; NO-ATOMIC-PIC-NEXT:    move.l %d5, %d0
 ; NO-ATOMIC-PIC-NEXT:    bra .LBB7_3
 ; NO-ATOMIC-PIC-NEXT:  .LBB7_4: ; %atomicrmw.end
-; NO-ATOMIC-PIC-NEXT:    movem.l (32,%sp), %d2-%d4/%a2-%a3 ; 24-byte Folded Reload
+; NO-ATOMIC-PIC-NEXT:    movem.l (32,%sp), %d2-%d5/%a2 ; 24-byte Folded Reload
 ; NO-ATOMIC-PIC-NEXT:    adda.l #52, %sp
 ; NO-ATOMIC-PIC-NEXT:    rts
 ;
@@ -720,13 +722,14 @@ define i64 @atomicrmw_max_i64(i64 %val, ptr %ptr) {
 ; ATOMIC-NEXT:  ; %bb.0:
 ; ATOMIC-NEXT:    suba.l #52, %sp
 ; ATOMIC-NEXT:    .cfi_def_cfa_offset -56
-; ATOMIC-NEXT:    movem.l %d2-%d4/%a2-%a3, (32,%sp) ; 24-byte Folded Spill
-; ATOMIC-NEXT:    move.l (60,%sp), %d3
-; ATOMIC-NEXT:    move.l (56,%sp), %d4
-; ATOMIC-NEXT:    move.l (64,%sp), %a2
-; ATOMIC-NEXT:    move.l (4,%a2), %d1
-; ATOMIC-NEXT:    move.l (%a2), %d0
-; ATOMIC-NEXT:    lea (24,%sp), %a3
+; ATOMIC-NEXT:    movem.l %d2-%d5/%a2, (32,%sp) ; 24-byte Folded Spill
+; ATOMIC-NEXT:    move.l (64,%sp), %d3
+; ATOMIC-NEXT:    move.l %d3, (%sp)
+; ATOMIC-NEXT:    move.l #0, (4,%sp)
+; ATOMIC-NEXT:    move.l (60,%sp), %d4
+; ATOMIC-NEXT:    move.l (56,%sp), %d5
+; ATOMIC-NEXT:    jsr __atomic_load_8
+; ATOMIC-NEXT:    lea (24,%sp), %a2
 ; ATOMIC-NEXT:    bra .LBB7_1
 ; ATOMIC-NEXT:  .LBB7_3: ; %atomicrmw.start
 ; ATOMIC-NEXT:    ; in Loop: Header=BB7_1 Depth=1
@@ -744,22 +747,22 @@ define i64 @atomicrmw_max_i64(i64 %val, ptr %ptr) {
 ; ATOMIC-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; ATOMIC-NEXT:    move.l %d0, (24,%sp)
 ; ATOMIC-NEXT:    move.l %d1, (28,%sp)
-; ATOMIC-NEXT:    move.l %a2, (%sp)
-; ATOMIC-NEXT:    move.l %a3, (4,%sp)
-; ATOMIC-NEXT:    move.l %d3, %d2
-; ATOMIC-NEXT:    sub.l %d1, %d2
+; ATOMIC-NEXT:    move.l %d3, (%sp)
+; ATOMIC-NEXT:    move.l %a2, (4,%sp)
 ; ATOMIC-NEXT:    move.l %d4, %d2
+; ATOMIC-NEXT:    sub.l %d1, %d2
+; ATOMIC-NEXT:    move.l %d5, %d2
 ; ATOMIC-NEXT:    subx.l %d0, %d2
 ; ATOMIC-NEXT:    slt %d2
 ; ATOMIC-NEXT:    cmpi.b #0, %d2
 ; ATOMIC-NEXT:    bne .LBB7_3
 ; ATOMIC-NEXT:  ; %bb.2: ; %atomicrmw.start
 ; ATOMIC-NEXT:    ; in Loop: Header=BB7_1 Depth=1
-; ATOMIC-NEXT:    move.l %d3, %d1
-; ATOMIC-NEXT:    move.l %d4, %d0
+; ATOMIC-NEXT:    move.l %d4, %d1
+; ATOMIC-NEXT:    move.l %d5, %d0
 ; ATOMIC-NEXT:    bra .LBB7_3
 ; ATOMIC-NEXT:  .LBB7_4: ; %atomicrmw.end
-; ATOMIC-NEXT:    movem.l (32,%sp), %d2-%d4/%a2-%a3 ; 24-byte Folded Reload
+; ATOMIC-NEXT:    movem.l (32,%sp), %d2-%d5/%a2 ; 24-byte Folded Reload
 ; ATOMIC-NEXT:    adda.l #52, %sp
 ; ATOMIC-NEXT:    rts
 ;
@@ -768,13 +771,14 @@ define i64 @atomicrmw_max_i64(i64 %val, ptr %ptr) {
 ; ATOMIC-PIC-NEXT:  ; %bb.0:
 ; ATOMIC-PIC-NEXT:    suba.l #52, %sp
 ; ATOMIC-PIC-NEXT:    .cfi_def_cfa_offset -56
-; ATOMIC-PIC-NEXT:    movem.l %d2-%d4/%a2-%a3, (32,%sp) ; 24-byte Folded Spill
-; ATOMIC-PIC-NEXT:    move.l (60,%sp), %d3
-; ATOMIC-PIC-NEXT:    move.l (56,%sp), %d4
-; ATOMIC-PIC-NEXT:    move.l (64,%sp), %a2
-; ATOMIC-PIC-NEXT:    move.l (4,%a2), %d1
-; ATOMIC-PIC-NEXT:    move.l (%a2), %d0
-; ATOMIC-PIC-NEXT:    lea (24,%sp), %a3
+; ATOMIC-PIC-NEXT:    movem.l %d2-%d5/%a2, (32,%sp) ; 24-byte Folded Spill
+; ATOMIC-PIC-NEXT:    move.l (64,%sp), %d3
+; ATOMIC-PIC-NEXT:    move.l %d3, (%sp)
+; ATOMIC-PIC-NEXT:    move.l #0, (4,%sp)
+; ATOMIC-PIC-NEXT:    move.l (60,%sp), %d4
+; ATOMIC-PIC-NEXT:    move.l (56,%sp), %d5
+; ATOMIC-PIC-NEXT:    jsr (__atomic_load_8@PLT,%pc)
+; ATOMIC-PIC-NEXT:    lea (24,%sp), %a2
 ; ATOMIC-PIC-NEXT:    bra .LBB7_1
 ; ATOMIC-PIC-NEXT:  .LBB7_3: ; %atomicrmw.start
 ; ATOMIC-PIC-NEXT:    ; in Loop: Header=BB7_1 Depth=1
@@ -792,22 +796,22 @@ define i64 @atomicrmw_max_i64(i64 %val, ptr %ptr) {
 ; ATOMIC-PIC-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; ATOMIC-PIC-NEXT:    move.l %d0, (24,%sp)
 ; ATOMIC-PIC-NEXT:    move.l %d1, (28,%sp)
-; ATOMIC-PIC-NEXT:    move.l %a2, (%sp)
-; ATOMIC-PIC-NEXT:    move.l %a3, (4,%sp)
-; ATOMIC-PIC-NEXT:    move.l %d3, %d2
-; ATOMIC-PIC-NEXT:    sub.l %d1, %d2
+; ATOMIC-PIC-NEXT:    move.l %d3, (%sp)
+; ATOMIC-PIC-NEXT:    move.l %a2, (4,%sp)
 ; ATOMIC-PIC-NEXT:    move.l %d4, %d2
+; ATOMIC-PIC-NEXT:    sub.l %d1, %d2
+; ATOMIC-PIC-NEXT:    move.l %d5, %d2
 ; ATOMIC-PIC-NEXT:    subx.l %d0, %d2
 ; ATOMIC-PIC-NEXT:    slt %d2
 ; ATOMIC-PIC-NEXT:    cmpi.b #0, %d2
 ; ATOMIC-PIC-NEXT:    bne .LBB7_3
 ; ATOMIC-PIC-NEXT:  ; %bb.2: ; %atomicrmw.start
 ; ATOMIC-PIC-NEXT:    ; in Loop: Header=BB7_1 Depth=1
-; ATOMIC-PIC-NEXT:    move.l %d3, %d1
-; ATOMIC-PIC-NEXT:    move.l %d4, %d0
+; ATOMIC-PIC-NEXT:    move.l %d4, %d1
+; ATOMIC-PIC-NEXT:    move.l %d5, %d0
 ; ATOMIC-PIC-NEXT:    bra .LBB7_3
 ; ATOMIC-PIC-NEXT:  .LBB7_4: ; %atomicrmw.end
-; ATOMIC-PIC-NEXT:    movem.l (32,%sp), %d2-%d4/%a2-%a3 ; 24-byte Folded Reload
+; ATOMIC-PIC-NEXT:    movem.l (32,%sp), %d2-%d5/%a2 ; 24-byte Folded Reload
 ; ATOMIC-PIC-NEXT:    adda.l #52, %sp
 ; ATOMIC-PIC-NEXT:    rts
   %old = atomicrmw max ptr %ptr, i64 %val seq_cst


### PR DESCRIPTION
Fix tests after #195308 ([AtomicExpand] Preserve flags expanding
loads/stores to cmpxchg/atomicrmw) and ([CodeGen][NFC] Remove
contractions in error messages).