### PR TITLE
[clang-format] Fix a bug in aligning comments above finalized line

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -3657,22 +3657,29 @@ void TokenAnnotator::setCommentLineLevels(
 
     // If the comment is currently aligned with the line immediately following
     // it, that's probably intentional and we should keep it.
-    if (NextNonCommentLine && NextNonCommentLine->First->NewlinesBefore < 2 &&
+    if (const auto Column = Line->First->OriginalColumn;
+        NextNonCommentLine && NextNonCommentLine->First->NewlinesBefore < 2 &&
         Line->isComment() && !isClangFormatOff(Line->First->TokenText) &&
-        NextNonCommentLine->First->OriginalColumn ==
-            Line->First->OriginalColumn) {
+        NextNonCommentLine->First->OriginalColumn == Column) {
       const bool PPDirectiveOrImportStmt =
           NextNonCommentLine->Type == LT_PreprocessorDirective ||
           NextNonCommentLine->Type == LT_ImportStatement;
       if (PPDirectiveOrImportStmt)
         Line->Type = LT_CommentAbovePPDirective;
-      // Align comments for preprocessor lines with the # in column 0 if
-      // preprocessor lines are not indented. Otherwise, align with the next
-      // line.
-      Line->Level = Style.IndentPPDirectives < FormatStyle::PPDIS_BeforeHash &&
-                            PPDirectiveOrImportStmt
-                        ? 0
-                        : NextNonCommentLine->Level;
+      if (const auto IndentWidth = Style.IndentWidth;
+          NextNonCommentLine->First->Finalized && IndentWidth > 0 &&
+          Column % IndentWidth == 0) {
+        Line->Level = Column / IndentWidth;
+      } else {
+        // Align comments for preprocessor lines with the # in column 0 if
+        // preprocessor lines are not indented. Otherwise, align with the next
+        // line.
+        Line->Level =
+            Style.IndentPPDirectives < FormatStyle::PPDIS_BeforeHash &&
+                    PPDirectiveOrImportStmt
+                ? 0
+                : NextNonCommentLine->Level;
+      }
     } else {
       NextNonCommentLine = Line->First->isNot(tok::r_brace) ? Line : nullptr;
     }

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -22495,6 +22495,12 @@ TEST_F(FormatTest, OneLineFormatOffRegex) {
                  "   MACRO_TEST2( );",
                  Style);
 
+  Style.OneLineFormatOffRegex = "//(< clang-format off| NO_TRANSLATION)$";
+  verifyNoChange(
+      " int i ;  //< clang-format off\n"
+      " msg = sprintf(\"Long string with placeholders.\"); // NO_TRANSLATION",
+      Style);
+
   Style.ColumnLimit = 50;
   Style.OneLineFormatOffRegex = "^LogErrorPrint$";
   verifyFormat(" myproject::LogErrorPrint(logger, \"Don't split me!\");\n"
@@ -22504,11 +22510,31 @@ TEST_F(FormatTest, OneLineFormatOffRegex) {
                " myproject::MyLogErrorPrinter(myLogger, \"Split me!\");",
                Style);
 
-  Style.OneLineFormatOffRegex = "//(< clang-format off| NO_TRANSLATION)$";
-  verifyNoChange(
-      " int i ;  //< clang-format off\n"
-      " msg = sprintf(\"Long string with placeholders.\"); // NO_TRANSLATION",
-      Style);
+  Style.ColumnLimit = 20;
+  Style.OneLineFormatOffRegex = "^pragma$";
+  verifyFormat("void pragmas() {\n"
+               "  // a comment\n"
+               "  // that's too long\n"
+               "  #pragma omp\n"
+               "  my_pragma();\n"
+               "}",
+               "void pragmas () {\n"
+               "  // a comment that's\n"
+               "  // too long\n"
+               "  #pragma omp\n"
+               " my_pragma();\n"
+               "}",
+               Style);
+
+  Style.OneLineFormatOffRegex = "// FormatOff$";
+  verifyFormat("  // comment too\n"
+               "  // long\n"
+               "  tm t; // FormatOff\n"
+               "int i;",
+               "  // comment too long\n"
+               "  tm t; // FormatOff\n"
+               " int i;",
+               Style);
 }
 
 TEST_F(FormatTest, DoNotCrashOnInvalidInput) {

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -22516,13 +22516,13 @@ TEST_F(FormatTest, OneLineFormatOffRegex) {
                "  // a comment\n"
                "  // that's too long\n"
                "  #pragma omp\n"
-               "  my_pragma();\n"
+               "  _pragma();\n"
                "}",
                "void pragmas () {\n"
                "  // a comment that's\n"
                "  // too long\n"
                "  #pragma omp\n"
-               " my_pragma();\n"
+               " _pragma();\n"
                "}",
                Style);
 


### PR DESCRIPTION
Don't change the indent level of the comments if they are already aligned with the finalized line below.

Fixes #200521