### PR TITLE
[Github] Drop persist-credentials from setup-python

### DIFF
--- a/.github/workflows/libclang-python-tests.yml
+++ b/.github/workflows/libclang-python-tests.yml
@@ -38,7 +38,6 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          persist-credentials: false
           python-version: ${{ matrix.python-version }}
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@33522472633dbd32578e909b315f5ee43ba878ce # v1.2.22


### PR DESCRIPTION
bd46a7d172661d4477737a65b107bf40782c7e40 attempted to do this but
accidentally modified the setup-python action instead of the checkout
action. bde6226911f6a95daf71bbc468046dbe53f8f92b fixed this partially by
adding persist-credentials to the checkout action, but failed to remove
the errant addition. This patch fixes that.