### PR TITLE
[ConstantFolding] Fix dropped bits in non-integer-ratio bitcast with undef lane

### DIFF
--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -359,7 +359,7 @@ Constant *FoldBitCast(Constant *C, Type *DestTy, const DataLayout &DL) {
         UndefMask.setBits(BitPosition, BitPosition + SrcBitSize);
         if (isa<PoisonValue>(Element))
           PoisonMask.setBits(BitPosition, BitPosition + SrcBitSize);
-        SrcValue = APInt::getZero(DstBitSize);
+        SrcValue = APInt::getZero(SrcBitSize);
       } else {
         auto *Src = dyn_cast<ConstantInt>(Element);
         if (!Src)

--- a/llvm/test/Transforms/InstSimplify/bitcast-vector-fold.ll
+++ b/llvm/test/Transforms/InstSimplify/bitcast-vector-fold.ll
@@ -412,7 +412,7 @@ define <3 x i32> @bitcast_constexpr_3i32_4i24_n1255uu() {
 ; LE-NEXT:    ret <3 x i32> <i32 -1, i32 0, i32 undef>
 ;
 ; BE-LABEL: @bitcast_constexpr_3i32_4i24_n1255uu(
-; BE-NEXT:    ret <3 x i32> <i32 -256, i32 0, i32 undef>
+; BE-NEXT:    ret <3 x i32> <i32 -256, i32 16711680, i32 undef>
 ;
   %cast = bitcast <4 x i24><i24 -1, i24 255, i24 undef, i24 undef> to <3 x i32>
   ret <3 x i32> %cast


### PR DESCRIPTION
When constant-folding a vector bitcast(e.g. <4 x i24> -> <3 x i32>), an undef source element inserted a DstBitSize-wide zero placeholder into the bit buffer. This could clobber defined source element, producing a wrong result on big-endian targets.

Fix by inserting SrcBitSize-wide zero instead.

Alive2 proof:
  before (unsound): https://alive2.llvm.org/ce/z/R_ZQ75
  after  (verified): https://alive2.llvm.org/ce/z/VuV3mz