### PR TITLE
[clang][bytecode] Loosen a __builtin_subcb assertion

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -1025,7 +1025,8 @@ static bool interp__builtin_carryop(InterpState &S, CodePtr OpPC,
   if (CarryOutPtr.canBeInitialized())
     CarryOutPtr.initialize();
 
-  assert(Call->getType() == Call->getArg(0)->getType());
+  assert(S.getASTContext().hasSimilarType(Call->getType(),
+                                          Call->getArg(0)->getType()));
   pushInteger(S, Result, Call->getType());
   return true;
 }

--- a/clang/test/AST/ByteCode/builtin-functions.cpp
+++ b/clang/test/AST/ByteCode/builtin-functions.cpp
@@ -2071,4 +2071,12 @@ namespace SubCb {
     return __builtin_subcb(lhs, rhs, carry, &rhs);
   }
   static_assert(subcb(10, 15, 1) == 250);
+
+  using u8 = unsigned char;
+  constexpr int subcb2() {
+    u8 a = 0, b = 0, c = 0;
+    __builtin_subcb(a, b, c, &c);
+    return 0;
+  }
+  static_assert(subcb2() == 0);
 }


### PR DESCRIPTION
The types should match, but `QualType`s can't be compared with `==` like that.