### PR TITLE
[clang][FreeBSD] Enable KASAN and KMSAN for riscv64

### DIFF
--- a/clang/lib/Driver/ToolChains/FreeBSD.cpp
+++ b/clang/lib/Driver/ToolChains/FreeBSD.cpp
@@ -487,6 +487,7 @@ FreeBSD::getSupportedSanitizers(BoundArch BA,
   const bool IsX86 = getTriple().getArch() == llvm::Triple::x86;
   const bool IsX86_64 = getTriple().getArch() == llvm::Triple::x86_64;
   const bool IsMIPS64 = getTriple().isMIPS64();
+  const bool IsRISCV64 = getTriple().getArch() == llvm::Triple::riscv64;
   SanitizerMask Res = ToolChain::getSupportedSanitizers(BA, DeviceOffloadKind);
   Res |= SanitizerKind::Address;
   Res |= SanitizerKind::PointerCompare;
@@ -501,7 +502,7 @@ FreeBSD::getSupportedSanitizers(BoundArch BA,
     Res |= SanitizerKind::Fuzzer;
     Res |= SanitizerKind::FuzzerNoLink;
   }
-  if (IsAArch64 || IsX86_64) {
+  if (IsAArch64 || IsX86_64 || IsRISCV64) {
     Res |= SanitizerKind::KernelAddress;
     Res |= SanitizerKind::KernelMemory;
     Res |= SanitizerKind::Memory;

--- a/clang/test/Driver/fsanitize.c
+++ b/clang/test/Driver/fsanitize.c
@@ -406,10 +406,12 @@
 
 // RUN: %clang --target=x86_64--freebsd -fsanitize=kernel-address %s -### 2>&1 | FileCheck %s -check-prefix=KERNEL-ADDRESS-FREEBSD
 // RUN: %clang --target=aarch64--freebsd -fsanitize=kernel-address %s -### 2>&1 | FileCheck %s -check-prefix=KERNEL-ADDRESS-FREEBSD
+// RUN: %clang --target=riscv64--freebsd -fsanitize=kernel-address %s -### 2>&1 | FileCheck %s -check-prefix=KERNEL-ADDRESS-FREEBSD
 // KERNEL-ADDRESS-FREEBSD: "-fsanitize=kernel-address"
 
 // RUN: %clang --target=x86_64--freebsd -fsanitize=kernel-memory %s -### 2>&1 | FileCheck %s -check-prefix=KERNEL-MEMORY-FREEBSD
 // RUN: %clang --target=aarch64--freebsd -fsanitize=kernel-memory %s -### 2>&1 | FileCheck %s -check-prefix=KERNEL-MEMORY-FREEBSD
+// RUN: %clang --target=riscv64--freebsd -fsanitize=kernel-memory %s -### 2>&1 | FileCheck %s -check-prefix=KERNEL-MEMORY-FREEBSD
 // KERNEL-MEMORY-FREEBSD: "-fsanitize=kernel-memory"
 
 // * NetBSD; please keep ordered as in Sanitizers.def *


### PR DESCRIPTION
enables KASAN and KMSAN for the riscv64 freebsd target in the Clang driver.

The corresponding FreeBSD kernel runtime support for riscv64 KASAN is currently under active review.

Depends on: https://reviews.freebsd.org/D57381