### PR TITLE
[lit] Add lit.llvm.decorate: --param decorate=PROG prepends PROG to a pipeline stage

### DIFF
--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -39,6 +39,13 @@ extra_substitutions = extra_substitutions = (
 )
 config.test_format = lit.formats.ShTest(not use_lit_shell, extra_substitutions)
 
+# --param decorate=PROG prepends PROG to a pipeline stage (debugger, profiler,
+# etc.). Registered before fn_param so subsequent fn_extract substitutions
+# correctly retarget the now-decorated stage.
+from lit.llvm import decorate
+
+decorate.install(config, lit_config)
+
 # --param fn=NAMES narrows compilation to the named functions and their
 # transitive dependencies. See lit.llvm.fn_param.install for dispatch details.
 from lit.llvm import fn_param

--- a/llvm/utils/lit/lit/llvm/decorate.py
+++ b/llvm/utils/lit/lit/llvm/decorate.py
@@ -1,0 +1,30 @@
+"""`--param decorate=PROG[@N]` prepends PROG to pipeline stage N (0-indexed,
+default 0) of every RUN line, so the downstream tool can be run under a
+debugger, profiler, etc. Examples:
+
+    --param 'decorate=gdb --args'   # run stage 0 under gdb
+    --param decorate=perf            # profile stage 0
+    --param decorate=time@1          # time the second stage
+
+A stage index past the end of a pipeline is a no-op for that RUN line."""
+
+import re
+
+from lit.llvm.fn_param import add_capture_sub
+
+_TRAILING_INDEX = re.compile(r"^(.+)@(\d+)$")
+
+
+def install(config, lit_config):
+    prog = lit_config.params.get("decorate")
+    if not prog:
+        return
+    m = _TRAILING_INDEX.match(prog)
+    if m:
+        prog, stage = m.group(1), m.group(2)
+    else:
+        stage = "0"
+    # Match (optional %dbg marker)(stage many `|`-delimited stages and their
+    # bars) and insert PROG after, preserving everything captured.
+    pattern = r"^(%dbg\([^)]*\)\s*)?((?:[^|]*\|\s*){" + stage + r"})"
+    add_capture_sub(config, pattern, r"\1\2" + prog + " ")

--- a/llvm/utils/lit/tests/Inputs/decorate/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/decorate/lit.cfg
@@ -1,0 +1,10 @@
+import lit.formats
+from lit.llvm import decorate
+
+config.name = "decorate"
+config.suffixes = [".ll"]
+config.test_format = lit.formats.ShTest()
+config.test_source_root = None
+config.test_exec_root = None
+
+decorate.install(config, lit_config)

--- a/llvm/utils/lit/tests/Inputs/decorate/sample.ll
+++ b/llvm/utils/lit/tests/Inputs/decorate/sample.ll
@@ -1,0 +1,1 @@
+; RUN: echo opt %s -S -passes='instcombine' | echo FileCheck %s

--- a/llvm/utils/lit/tests/Inputs/narrow-and-decorate/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/narrow-and-decorate/lit.cfg
@@ -1,0 +1,16 @@
+import lit.formats
+import shutil
+from lit.llvm import decorate, fn_param
+
+config.name = "narrow-and-decorate"
+config.suffixes = [".ll"]
+config.test_format = lit.formats.ShTest()
+config.test_source_root = None
+config.test_exec_root = None
+
+for tool in ("opt", "llvm-extract", "FileCheck"):
+    if shutil.which(tool):
+        config.available_features.add(tool)
+
+decorate.install(config, lit_config)
+fn_param.install(config, lit_config)

--- a/llvm/utils/lit/tests/Inputs/narrow-and-decorate/sample.ll
+++ b/llvm/utils/lit/tests/Inputs/narrow-and-decorate/sample.ll
@@ -1,0 +1,21 @@
+; REQUIRES: opt
+;
+; RUN: opt -S < %s -passes=instcombine | FileCheck %s --check-prefix=ALL
+; RUN: opt -S < %s -passes=instcombine | FileCheck %s --check-prefix=ONLYFOO
+
+define i32 @foo(i32 %x) {
+  ret i32 %x
+}
+
+define i32 @bar(i32 %x) {
+  ret i32 %x
+}
+
+; ALL-LABEL: @foo
+; ALL: ret i32 %x
+
+; ALL-LABEL: @bar
+; ALL: ret i32 FILTER_AWAY
+
+; ONLYFOO-LABEL: @foo
+; ONLYFOO: ret i32 %x

--- a/llvm/utils/lit/tests/decorate.py
+++ b/llvm/utils/lit/tests/decorate.py
@@ -1,0 +1,30 @@
+# Verify --param decorate=PROG[@N] prepends PROG to pipeline stage N (default 0).
+
+# --- Default stage (0): PROG prepended to the first stage ---
+# RUN: %{lit} -a --param decorate=time %{inputs}/decorate/sample.ll \
+# RUN:   | FileCheck --check-prefix=STAGE0 %s
+#
+# STAGE0: time echo opt {{.*}}sample.ll -S -passes='instcombine' | echo FileCheck {{.*}}sample.ll
+
+# --- Explicit @0 is the same as default ---
+# RUN: %{lit} -a --param decorate=time@0 %{inputs}/decorate/sample.ll \
+# RUN:   | FileCheck --check-prefix=STAGE0 %s
+
+# --- @1: PROG prepended to the second stage ---
+# RUN: %{lit} -a --param decorate=time@1 %{inputs}/decorate/sample.ll \
+# RUN:   | FileCheck --check-prefix=STAGE1 %s
+#
+# STAGE1: echo opt {{.*}}sample.ll -S -passes='instcombine' | time echo FileCheck {{.*}}sample.ll
+
+# --- @N past the end: no-op, pipeline unchanged ---
+# RUN: %{lit} -a --param decorate=time@9 %{inputs}/decorate/sample.ll \
+# RUN:   | FileCheck --check-prefix=OOB %s
+#
+# OOB-NOT: time
+# OOB: echo opt {{.*}}sample.ll -S -passes='instcombine' | echo FileCheck {{.*}}sample.ll
+
+# --- No --param decorate: pipeline unchanged ---
+# RUN: %{lit} -a %{inputs}/decorate/sample.ll | FileCheck --check-prefix=NONE %s
+#
+# NONE-NOT: time
+# NONE: echo opt {{.*}}sample.ll -S -passes='instcombine' | echo FileCheck {{.*}}sample.ll

--- a/llvm/utils/lit/tests/narrow-and-decorate.py
+++ b/llvm/utils/lit/tests/narrow-and-decorate.py
@@ -1,0 +1,41 @@
+# End-to-end check that --check, --param fn=, and --param decorate= compose
+# correctly on a real opt+FileCheck pipeline. The inner sample has two RUN
+# lines and a deliberately-wrong CHECK in @bar's section.
+
+# --- No params: RUN 0 fails on @bar's FILTER_AWAY check ---
+# RUN: not %{lit} -a %{inputs}/narrow-and-decorate/sample.ll 2>&1 \
+# RUN:   | FileCheck --check-prefix=BASE_FAIL %s
+#
+# BASE_FAIL: FAIL:
+# BASE_FAIL: FILTER_AWAY
+
+# --- --check=1: skip RUN 0, run only the ONLYFOO prefix RUN, which passes ---
+# RUN: %{lit} --check=1 %{inputs}/narrow-and-decorate/sample.ll \
+# RUN:   | FileCheck --check-prefix=PASS %s
+#
+# PASS: Passed: 1
+
+# --- --param fn=foo --check=0: extract drops @bar; filter drops its CHECK ---
+# RUN: %{lit} -a --param fn=foo --check=0 %{inputs}/narrow-and-decorate/sample.ll \
+# RUN:   | FileCheck --check-prefix=FN %s
+#
+# FN: llvm-extract --func=foo
+# FN: --filter-label=foo
+# FN: Passed:
+
+# --- All three: --check=0 + --param fn=foo + --param decorate=time ---
+# RUN: %{lit} -a --param fn=foo --param decorate=time --check=0 \
+# RUN:   %{inputs}/narrow-and-decorate/sample.ll \
+# RUN:   | FileCheck --check-prefix=ALL %s
+#
+# ALL: llvm-extract --func=foo
+# ALL: time {{.*}}opt
+# ALL: --filter-label=foo
+# ALL: Passed:
+
+# --- --param decorate=time alone: pipeline still has the wrong CHECK, fails ---
+# RUN: not %{lit} -a --param decorate=time %{inputs}/narrow-and-decorate/sample.ll 2>&1 \
+# RUN:   | FileCheck --check-prefix=DEC_FAIL %s
+#
+# DEC_FAIL: time {{.*}}opt
+# DEC_FAIL: FILTER_AWAY


### PR DESCRIPTION
Prepends PROG to pipeline stage N (default stage 0) of each RUN line, so the real tool runs under a debugger, profiler, etc.:

`llvm-lit --param 'decorate=gdb --args' test.ll`
`llvm-lit --param 'decorate=perf record --' test.ll`
`llvm-lit --param 'decorate=time@1' test.ll   # decorate the second stage`