### PR TITLE
[Clang][Driver] default-on include path backslash warning on PS5

### DIFF
--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -650,7 +650,8 @@ void toolchains::PS4PS5Base::addClangTargetOptions(
   }
 }
 
-void toolchains::PS4PS5Base::addClangWarningOptions(ArgStringList &CC1Args) const {
+void toolchains::PS4PS5Base::addClangWarningOptions(
+    ArgStringList &CC1Args) const {
   CC1Args.push_back("-Wnonportable-include-path-separator");
   CC1Args.push_back("-Wnonportable-system-include-path");
 }

--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -650,6 +650,11 @@ void toolchains::PS4PS5Base::addClangTargetOptions(
   }
 }
 
+void toolchains::PS4PS5Base::addClangWarningOptions(ArgStringList &CC1Args) const {
+  CC1Args.push_back("-Wnonportable-include-path-separator");
+  CC1Args.push_back("-Wnonportable-system-include-path");
+}
+
 // PS4 toolchain.
 toolchains::PS4CPU::PS4CPU(const Driver &D, const llvm::Triple &Triple,
                            const llvm::opt::ArgList &Args)

--- a/clang/lib/Driver/ToolChains/PS4CPU.h
+++ b/clang/lib/Driver/ToolChains/PS4CPU.h
@@ -114,6 +114,8 @@ public:
       const llvm::opt::ArgList &DriverArgs, llvm::opt::ArgStringList &CC1Args,
       Action::OffloadKind DeviceOffloadingKind) const override;
 
+  void addClangWarningOptions(llvm::opt::ArgStringList &CC1Args) const override;
+
   llvm::DenormalMode getDefaultDenormalModeForType(
       const llvm::opt::ArgList &DriverArgs, const JobAction &JA,
       const llvm::fltSemantics *FPType) const override {

--- a/clang/test/Driver/ps4-ps5-toolchain.c
+++ b/clang/test/Driver/ps4-ps5-toolchain.c
@@ -16,3 +16,8 @@
 // RUN: %clang %s -target x86_64-sie-ps5 -### 2>&1 | FileCheck -check-prefix=JUMPTABLESIZES %s
 // JUMPTABLESIZES: "-mllvm" "-emit-jump-table-sizes-section"
 // JUMPTABLESIZES: "-plugin-opt=-emit-jump-table-sizes-section"
+
+// Verify non-portable include path diagnostics are enabled.
+// RUN: %clang %s -target x86_64-sie-ps5 -### 2>&1 | FileCheck --check-prefix=NONPORTABLE-INCLUDE %s
+// NONPORTABLE-INCLUDE: "-Wnonportable-include-path-separator"
+// NONPORTABLE-INCLUDE: "-Wnonportable-system-include-path"


### PR DESCRIPTION
It seems like there is precedent for using addClangWarningOptions in the driver to set warning default states per-target, in e.g. AMDGPU.

These warnings are usually disabled by default to avoid overdiagnosing common patterns on Windows host+target builds which don't care about portability. Since PS5 builds are cross-compiled it makes less sense to assume things about the host, so we want to diagnose portability issues more eagerly.