### PR TITLE
[OFFLOAD][L0] Use counter-based events for inorder queues

### DIFF
--- a/offload/plugins-nextgen/level_zero/dynamic_l0/level_zero/ze_api.h
+++ b/offload/plugins-nextgen/level_zero/dynamic_l0/level_zero/ze_api.h
@@ -169,6 +169,7 @@ typedef enum _ze_structure_type_t {
   ZE_STRUCTURE_TYPE_DEVICE_IP_VERSION_EXT = 0x1000f,
   ZE_STRUCTURE_TYPE_COMMAND_LIST_APPEND_PARAM_COOPERATIVE_DESC = 0x00020036,
   ZE_STRUCTURE_TYPE_RELAXED_ALLOCATION_LIMITS_EXP_DESC = 0x00020001,
+  ZE_STRUCTURE_TYPE_COUNTER_BASED_EVENT_POOL_EXP_DESC = 0x00020014,
   ZE_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
 } ze_structure_type_t;
 
@@ -285,6 +286,14 @@ typedef enum _ze_event_pool_flag_t {
   ZE_EVENT_POOL_FLAG_KERNEL_MAPPED_TIMESTAMP = ZE_BIT(3),
   ZE_EVENT_POOL_FLAG_FORCE_UINT32 = 0x7fffffff
 } ze_event_pool_flag_t;
+
+/* Counter-based event pool flags */
+typedef uint32_t ze_event_pool_counter_based_exp_flags_t;
+typedef enum _ze_event_pool_counter_based_exp_flag_t {
+  ZE_EVENT_POOL_COUNTER_BASED_EXP_FLAG_IMMEDIATE = ZE_BIT(0),
+  ZE_EVENT_POOL_COUNTER_BASED_EXP_FLAG_NON_IMMEDIATE = ZE_BIT(1),
+  ZE_EVENT_POOL_COUNTER_BASED_EXP_FLAG_FORCE_UINT32 = 0x7fffffff
+} ze_event_pool_counter_based_exp_flag_t;
 
 /* Event scope flags */
 typedef uint32_t ze_event_scope_flags_t;
@@ -599,6 +608,13 @@ typedef struct _ze_event_pool_desc_t {
   ze_event_pool_flags_t flags;
   uint32_t count;
 } ze_event_pool_desc_t;
+
+/* Counter-based event pool descriptor */
+typedef struct _ze_event_pool_counter_based_exp_desc_t {
+  ze_structure_type_t stype;
+  const void *pNext;
+  ze_event_pool_counter_based_exp_flags_t flags;
+} ze_event_pool_counter_based_exp_desc_t;
 
 /* Event descriptor */
 typedef struct _ze_event_desc_t {

--- a/offload/plugins-nextgen/level_zero/include/L0Event.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Event.h
@@ -33,9 +33,10 @@ public:
   ze_event_handle_t getZeEvent() const { return ZeEvent; }
   L0QueueTy *getQueue() const { return Queue; }
 
-  Error reset() {
+  Error reset(bool SkipEventReset) {
     Queue = nullptr;
-    CALL_ZE_RET_ERROR(zeEventHostReset, ZeEvent);
+    if (!SkipEventReset)
+      CALL_ZE_RET_ERROR(zeEventHostReset, ZeEvent);
     return Plugin::success();
   }
 
@@ -71,6 +72,9 @@ class EventPoolTy {
   /// Additional event pool flags common to this pool.
   uint32_t Flags = 0;
 
+  /// Whether counter-based events are being used (don't need reset).
+  bool UseCounterBasedEvents = false;
+
   /// Protection.
   std::unique_ptr<std::mutex> Mtx;
 
@@ -89,9 +93,13 @@ class EventPoolTy {
 
 public:
   /// Initialize context, flags, and mutex.
-  Error init(ze_context_handle_t ContextIn, uint32_t FlagsIn) {
+  Error init(ze_context_handle_t ContextIn, bool UseCounterBased,
+             uint32_t FlagsIn) {
     Context = ContextIn;
     Flags = FlagsIn;
+    UseCounterBasedEvents = UseCounterBased;
+    if (UseCounterBasedEvents)
+      Flags |= ZE_EVENT_POOL_FLAG_KERNEL_TIMESTAMP;
     Mtx.reset(new std::mutex);
     return Plugin::success();
   }

--- a/offload/plugins-nextgen/level_zero/include/L0Event.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Event.h
@@ -98,8 +98,6 @@ public:
     Context = ContextIn;
     Flags = FlagsIn;
     UseCounterBasedEvents = UseCounterBased;
-    if (UseCounterBasedEvents)
-      Flags |= ZE_EVENT_POOL_FLAG_KERNEL_TIMESTAMP;
     Mtx.reset(new std::mutex);
     return Plugin::success();
   }

--- a/offload/plugins-nextgen/level_zero/include/L0Event.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Event.h
@@ -26,16 +26,18 @@ class L0QueueTy;
 
 class L0EventTy {
   ze_event_handle_t ZeEvent = nullptr;
+  bool CounterBased = false;
   L0QueueTy *Queue = nullptr;
 
 public:
-  L0EventTy(ze_event_handle_t ZeEvent) : ZeEvent(ZeEvent) {}
+  L0EventTy(ze_event_handle_t ZeEvent, bool CounterBased)
+      : ZeEvent(ZeEvent), CounterBased(CounterBased) {}
   ze_event_handle_t getZeEvent() const { return ZeEvent; }
   L0QueueTy *getQueue() const { return Queue; }
 
-  Error reset(bool SkipEventReset) {
+  Error reset() {
     Queue = nullptr;
-    if (!SkipEventReset)
+    if (!CounterBased)
       CALL_ZE_RET_ERROR(zeEventHostReset, ZeEvent);
     return Plugin::success();
   }

--- a/offload/plugins-nextgen/level_zero/src/L0Context.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Context.cpp
@@ -28,7 +28,19 @@ Error L0ContextTy::init() {
 
   ze_context_desc_t Desc{ZE_STRUCTURE_TYPE_CONTEXT_DESC, nullptr, 0};
   CALL_ZE_RET_ERROR(zeContextCreate, zeDriver, &Desc, &zeContext);
-  if (auto Err = EventPool.init(zeContext, 0)) {
+
+  const auto &Options = Plugin.getOptions();
+  bool UseCounterBasedEvents = Options.CommandMode == CommandModeTy::InOrder ||
+                               Options.CommandMode == CommandModeTy::Sync;
+  if (UseCounterBasedEvents)
+    ODBG(OLDT_Init) << "Using counter-based events for "
+                    << (Options.CommandMode == CommandModeTy::InOrder
+                            ? "InOrder"
+                            : "Sync")
+                    << " command mode";
+
+  if (auto Err = EventPool.init(zeContext, UseCounterBasedEvents,
+                                /* Flags */ 0)) {
     cleanupOnError();
     return Err;
   }

--- a/offload/plugins-nextgen/level_zero/src/L0Event.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Event.cpp
@@ -81,7 +81,7 @@ Expected<L0EventTy *> EventPoolTy::getEventObject() {
   }
 
   auto *Ret = EventObjects.back();
-  if (auto Err = Ret->reset(/* SkipZeReset */ UseCounterBasedEvents))
+  if (auto Err = Ret->reset(/* SkipEventReset */ UseCounterBasedEvents))
     return std::move(Err);
 
   EventObjects.pop_back();

--- a/offload/plugins-nextgen/level_zero/src/L0Event.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Event.cpp
@@ -62,7 +62,8 @@ Expected<ze_event_handle_t> EventPoolTy::getEventLocked() {
 /// Return an event to the pool.
 Error EventPoolTy::releaseEvent(ze_event_handle_t Event) {
   std::lock_guard<std::mutex> Lock(*Mtx);
-  CALL_ZE_RET_ERROR(zeEventHostReset, Event);
+  if (!UseCounterBasedEvents)
+    CALL_ZE_RET_ERROR(zeEventHostReset, Event);
   Events.push_back(Event);
   return Plugin::success();
 }
@@ -80,7 +81,7 @@ Expected<L0EventTy *> EventPoolTy::getEventObject() {
   }
 
   auto *Ret = EventObjects.back();
-  if (auto Err = Ret->reset())
+  if (auto Err = Ret->reset(/* SkipZeReset */ UseCounterBasedEvents))
     return std::move(Err);
 
   EventObjects.pop_back();

--- a/offload/plugins-nextgen/level_zero/src/L0Event.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Event.cpp
@@ -25,6 +25,13 @@ Expected<ze_event_handle_t> EventPoolTy::getEventLocked() {
                               /* count */ 0};
     Desc.flags = ZE_EVENT_POOL_FLAG_HOST_VISIBLE | Flags;
     Desc.count = static_cast<uint32_t>(PoolSize);
+
+    ze_event_pool_counter_based_exp_desc_t counterBasedDesc = {ZE_STRUCTURE_TYPE_COUNTER_BASED_EVENT_POOL_EXP_DESC};
+    counterBasedDesc.flags = ZE_EVENT_POOL_COUNTER_BASED_EXP_FLAG_IMMEDIATE;
+
+    if (UseCounterBasedEvents)
+      Desc.pNext = &counterBasedDesc;
+
     ze_event_pool_handle_t Pool;
     CALL_ZE_RET_ERROR(zeEventPoolCreate, Context, &Desc, 0, nullptr, &Pool);
     Pools.push_back(Pool);

--- a/offload/plugins-nextgen/level_zero/src/L0Event.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Event.cpp
@@ -27,7 +27,9 @@ Expected<ze_event_handle_t> EventPoolTy::getEventLocked() {
     Desc.count = static_cast<uint32_t>(PoolSize);
 
     ze_event_pool_counter_based_exp_desc_t counterBasedDesc = {
-        ZE_STRUCTURE_TYPE_COUNTER_BASED_EVENT_POOL_EXP_DESC};
+        ZE_STRUCTURE_TYPE_COUNTER_BASED_EVENT_POOL_EXP_DESC,
+        /* pNext */ nullptr,
+        /* flags */ 0};
     counterBasedDesc.flags = ZE_EVENT_POOL_COUNTER_BASED_EXP_FLAG_IMMEDIATE;
 
     if (UseCounterBasedEvents)

--- a/offload/plugins-nextgen/level_zero/src/L0Event.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Event.cpp
@@ -26,14 +26,14 @@ Expected<ze_event_handle_t> EventPoolTy::getEventLocked() {
     Desc.flags = ZE_EVENT_POOL_FLAG_HOST_VISIBLE | Flags;
     Desc.count = static_cast<uint32_t>(PoolSize);
 
-    ze_event_pool_counter_based_exp_desc_t counterBasedDesc = {
+    ze_event_pool_counter_based_exp_desc_t CounterBasedDesc = {
         ZE_STRUCTURE_TYPE_COUNTER_BASED_EVENT_POOL_EXP_DESC,
         /* pNext */ nullptr,
         /* flags */ 0};
-    counterBasedDesc.flags = ZE_EVENT_POOL_COUNTER_BASED_EXP_FLAG_IMMEDIATE;
+    CounterBasedDesc.flags = ZE_EVENT_POOL_COUNTER_BASED_EXP_FLAG_IMMEDIATE;
 
     if (UseCounterBasedEvents)
-      Desc.pNext = &counterBasedDesc;
+      Desc.pNext = &CounterBasedDesc;
 
     ze_event_pool_handle_t Pool;
     CALL_ZE_RET_ERROR(zeEventPoolCreate, Context, &Desc, 0, nullptr, &Pool);

--- a/offload/plugins-nextgen/level_zero/src/L0Event.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Event.cpp
@@ -26,7 +26,8 @@ Expected<ze_event_handle_t> EventPoolTy::getEventLocked() {
     Desc.flags = ZE_EVENT_POOL_FLAG_HOST_VISIBLE | Flags;
     Desc.count = static_cast<uint32_t>(PoolSize);
 
-    ze_event_pool_counter_based_exp_desc_t counterBasedDesc = {ZE_STRUCTURE_TYPE_COUNTER_BASED_EVENT_POOL_EXP_DESC};
+    ze_event_pool_counter_based_exp_desc_t counterBasedDesc = {
+        ZE_STRUCTURE_TYPE_COUNTER_BASED_EVENT_POOL_EXP_DESC};
     counterBasedDesc.flags = ZE_EVENT_POOL_COUNTER_BASED_EXP_FLAG_IMMEDIATE;
 
     if (UseCounterBasedEvents)
@@ -83,12 +84,12 @@ Expected<L0EventTy *> EventPoolTy::getEventObject() {
     if (!EventOrErr)
       return EventOrErr.takeError();
     auto Event = *EventOrErr;
-    auto *EventObj = new L0EventTy(Event);
+    auto *EventObj = new L0EventTy(Event, UseCounterBasedEvents);
     return EventObj;
   }
 
   auto *Ret = EventObjects.back();
-  if (auto Err = Ret->reset(/* SkipEventReset */ UseCounterBasedEvents))
+  if (auto Err = Ret->reset())
     return std::move(Err);
 
   EventObjects.pop_back();


### PR DESCRIPTION
Inorder queues can use counter-based events which have better performance and provide early-reused semantics.

Assisted by Claude.