### PR TITLE
[AMDGPU] Drop docs for invalid load-release and store-acquire operations

### DIFF
--- a/llvm/docs/AMDGPUUsage.rst
+++ b/llvm/docs/AMDGPUUsage.rst
@@ -7214,15 +7214,6 @@ orderings (``acquire``, ``release``, ``acq_rel``, or ``seq_cst``).
 The memory model does not support the region address space which is treated as
 non-atomic.
 
-Acquire memory ordering is not meaningful on store atomic instructions and is
-treated as non-atomic.
-
-Release memory ordering is not meaningful on load atomic instructions and is
-treated as non-atomic.
-
-Acquire-release memory ordering is not meaningful on load or store atomic
-instructions and is treated as acquire and release respectively.
-
 The memory order also adds the single thread optimization constraints defined in
 table
 :ref:`amdgpu-amdhsa-memory-model-single-thread-optimization-constraints-table`.


### PR DESCRIPTION
The LangRef says "release and acq_rel orderings are not valid on load
instructions" [for loads](https://llvm.org/docs/LangRef.html#load-instruction)
and "acquire and acq_rel orderings aren't valid on store instructions"
[for stores](https://llvm.org/docs/LangRef.html#store-instruction).
Providing them in textual IR is diagnosed with an error.

Therefore, we should not define semantics for these invalid constructs.

Part of LCOMPILER-2273.