### PR TITLE
[PowerPC]optimize the epilogue for restore non volatile cr fields

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
@@ -1768,6 +1768,28 @@ void PPCFrameLowering::emitEpilogue(MachineFunction &MF,
     }
   }
   assert(RBReg != ScratchReg && "Should have avoided ScratchReg");
+
+  // Lambda to build MTCRF/MTOCRF instruction for restoring CR fields
+  auto BuildMoveToCR = [&](MachineBasicBlock::iterator InsertPt,
+                           Register SrcReg) {
+    if (MustSaveCRs.size() == 1) {
+      // Use MTOCRF for single CR field
+      BuildMI(MBB, InsertPt, dl, MoveToCRInst, MustSaveCRs[0])
+          .addReg(SrcReg, getKillRegState(true));
+    } else {
+      // Build CR mask for MTCRF - more efficient than multiple MTOCRF
+      unsigned CRMask = 0;
+      for (unsigned CRField : MustSaveCRs) {
+        unsigned CRNum = CRField - PPC::CR0;
+        CRMask |= (0x80 >> CRNum);
+      }
+      // Use single MTCRF to restore multi CR fields at once
+      BuildMI(MBB, InsertPt, dl, TII.get(isPPC64 ? PPC::MTCRF8 : PPC::MTCRF))
+          .addImm(CRMask)
+          .addReg(SrcReg, getKillRegState(true));
+    }
+  };
+
   // If there is no red zone, ScratchReg may be needed for holding a useful
   // value (although not the base register). Make sure it is not overwritten
   // too early.
@@ -1781,9 +1803,7 @@ void PPCFrameLowering::emitEpilogue(MachineFunction &MF,
     BuildMI(MBB, MBBI, dl, LoadWordInst, TempReg)
       .addImm(CRSaveOffset)
       .addReg(SPReg);
-    for (unsigned i = 0, e = MustSaveCRs.size(); i != e; ++i)
-      BuildMI(MBB, MBBI, dl, MoveToCRInst, MustSaveCRs[i])
-        .addReg(TempReg, getKillRegState(i == e-1));
+    BuildMoveToCR(MBBI, TempReg);
   }
 
   // Delay restoring of the LR if ScratchReg is needed. This is ok, since
@@ -1857,9 +1877,7 @@ void PPCFrameLowering::emitEpilogue(MachineFunction &MF,
 
   if (MustSaveCR &&
       !(SingleScratchReg && MustSaveLR))
-    for (unsigned i = 0, e = MustSaveCRs.size(); i != e; ++i)
-      BuildMI(MBB, MBBI, dl, MoveToCRInst, MustSaveCRs[i])
-        .addReg(TempReg, getKillRegState(i == e-1));
+    BuildMoveToCR(MBBI, TempReg);
 
   if (MustSaveLR) {
     // If ROP protection is required, an extra instruction is added to compute a
@@ -2545,19 +2563,28 @@ static void restoreCRs(bool is31, bool CR2Spilled, bool CR3Spilled,
   MBB.insert(MI,
              addFrameReference(BuildMI(*MF, DL, TII.get(PPC::LWZ), MoveReg),
                                CSI[CSIIndex].getFrameIdx()));
+  // Count how many CR fields need restoring
+  unsigned NumCRs =
+      (CR2Spilled ? 1 : 0) + (CR3Spilled ? 1 : 0) + (CR4Spilled ? 1 : 0);
 
-  unsigned RestoreOp = PPC::MTOCRF;
-  if (CR2Spilled)
-    MBB.insert(MI, BuildMI(*MF, DL, TII.get(RestoreOp), PPC::CR2)
-               .addReg(MoveReg, getKillRegState(!CR3Spilled && !CR4Spilled)));
-
-  if (CR3Spilled)
-    MBB.insert(MI, BuildMI(*MF, DL, TII.get(RestoreOp), PPC::CR3)
-               .addReg(MoveReg, getKillRegState(!CR4Spilled)));
-
-  if (CR4Spilled)
-    MBB.insert(MI, BuildMI(*MF, DL, TII.get(RestoreOp), PPC::CR4)
-               .addReg(MoveReg, getKillRegState(true)));
+  if (NumCRs == 1) {
+    // Use MTOCRF for single field
+    unsigned CRReg = CR2Spilled ? PPC::CR2 : (CR3Spilled ? PPC::CR3 : PPC::CR4);
+    MBB.insert(MI, BuildMI(*MF, DL, TII.get(PPC::MTOCRF), CRReg)
+                       .addReg(MoveReg, getKillRegState(true)));
+  } else if (NumCRs > 1) {
+    // Use MTCRF for multiple fields (1 instruction vs N)
+    unsigned CRMask = 0;
+    if (CR2Spilled)
+      CRMask |= 0x20;
+    if (CR3Spilled)
+      CRMask |= 0x10;
+    if (CR4Spilled)
+      CRMask |= 0x08;
+    MBB.insert(MI, BuildMI(*MF, DL, TII.get(PPC::MTCRF))
+                       .addImm(CRMask)
+                       .addReg(MoveReg, getKillRegState(true)));
+  }
 }
 
 MachineBasicBlock::iterator PPCFrameLowering::

--- a/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
@@ -1777,13 +1777,11 @@ void PPCFrameLowering::emitEpilogue(MachineFunction &MF,
       BuildMI(MBB, InsertPt, dl, MoveToCRInst, MustSaveCRs[0])
           .addReg(SrcReg, getKillRegState(true));
     } else {
-      // Build CR mask for MTCRF - more efficient than multiple MTOCRF
+      // Build CR mask for MTCRF.
       unsigned CRMask = 0;
       for (unsigned CRField : MustSaveCRs) {
-        unsigned CRNum = CRField - PPC::CR0;
-        CRMask |= (0x80 >> CRNum);
+        CRMask |= (0x80 >> CRField - PPC::CR0);
       }
-      // Use single MTCRF to restore multi CR fields at once
       BuildMI(MBB, InsertPt, dl, TII.get(isPPC64 ? PPC::MTCRF8 : PPC::MTCRF))
           .addImm(CRMask)
           .addReg(SrcReg, getKillRegState(true));
@@ -2567,13 +2565,16 @@ static void restoreCRs(bool is31, bool CR2Spilled, bool CR3Spilled,
   unsigned NumCRs =
       (CR2Spilled ? 1 : 0) + (CR3Spilled ? 1 : 0) + (CR4Spilled ? 1 : 0);
 
+  assert(NumCRs >= 1 &&
+         "Requires at least one non-volatile CR field to be restored.");
+
   if (NumCRs == 1) {
-    // Use MTOCRF for single field
+    // Use MTOCRF for single CR field
     unsigned CRReg = CR2Spilled ? PPC::CR2 : (CR3Spilled ? PPC::CR3 : PPC::CR4);
     MBB.insert(MI, BuildMI(*MF, DL, TII.get(PPC::MTOCRF), CRReg)
                        .addReg(MoveReg, getKillRegState(true)));
-  } else if (NumCRs > 1) {
-    // Use MTCRF for multiple fields (1 instruction vs N)
+  } else {
+    // Use MTCRF for multiple CR fields.
     unsigned CRMask = 0;
     if (CR2Spilled)
       CRMask |= 0x20;

--- a/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
@@ -1772,11 +1772,11 @@ void PPCFrameLowering::emitEpilogue(MachineFunction &MF,
   // Lambda to build MTCRF/MTOCRF instruction for restoring CR fields
   auto BuildMoveToCR = [&](MachineBasicBlock::iterator InsertPt,
                            Register SrcReg) {
-    if (MustSaveCRs.size() == 1) {
+    if (MustSaveCRs.size() == 1)
       // Use MTOCRF for single CR field
       BuildMI(MBB, InsertPt, dl, MoveToCRInst, MustSaveCRs[0])
           .addReg(SrcReg, getKillRegState(true));
-    } else {
+    else {
       // Build CR mask for MTCRF.
       unsigned CRMask = 0;
       for (unsigned CRField : MustSaveCRs) {

--- a/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
@@ -1780,7 +1780,7 @@ void PPCFrameLowering::emitEpilogue(MachineFunction &MF,
       // Build CR mask for MTCRF.
       unsigned CRMask = 0;
       for (unsigned CRField : MustSaveCRs) {
-        CRMask |= (0x80 >> CRField - PPC::CR0);
+        CRMask |= 0x80 >> (CRField - PPC::CR0);
       }
       BuildMI(MBB, InsertPt, dl, TII.get(isPPC64 ? PPC::MTCRF8 : PPC::MTCRF))
           .addImm(CRMask)

--- a/llvm/test/CodeGen/PowerPC/2010-02-12-saveCR.ll
+++ b/llvm/test/CodeGen/PowerPC/2010-02-12-saveCR.ll
@@ -21,8 +21,7 @@ entry:
 return:                                           ; preds = %entry
 ; CHECK: ori [[T2]], [[T2]], 34492
 ; CHECK: lwzx [[T1]], 1, [[T2]]
-; CHECK: mtcrf 32, [[T1]]
-; CHECK: mtcrf 16, [[T1]]
+; CHECK: mtcrf 48, [[T1]]
   ret void
 }
 

--- a/llvm/test/CodeGen/PowerPC/aix-crspill.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-crspill.ll
@@ -63,9 +63,7 @@ declare signext i32 @do_something(i32 signext)
 ; 64BIT-NEXT:   ld 0, 16(1)
 ; 64BIT-NEXT:   lwz 12, 8(1)
 ; 64BIT-NEXT:   mtlr 0
-; 64BIT-NEXT:   mtocrf 32, 12
-; 64BIT-NEXT:   mtocrf 16, 12
-; 64BIT-NEXT:   mtocrf 8, 12
+; 64BIT-NEXT:   mtcrf 56, 12
 ; 64BIT-NEXT:   blr
 
 
@@ -75,7 +73,5 @@ declare signext i32 @do_something(i32 signext)
 ; 32BIT-NEXT:   lwz 0, 8(1)
 ; 32BIT-NEXT:   lwz 12, 4(1)
 ; 32BIT-NEXT:   mtlr 0
-; 32BIT-NEXT:   mtocrf 32, 12
-; 32BIT-NEXT:   mtocrf 16, 12
-; 32BIT-NEXT:   mtocrf 8, 12
+; 32BIT-NEXT:   mtcrf 56, 12
 ; 32BIT-NEXT:   blr

--- a/llvm/test/CodeGen/PowerPC/aix32-crsave.mir
+++ b/llvm/test/CodeGen/PowerPC/aix32-crsave.mir
@@ -46,8 +46,7 @@ body:             |
     ; CHECK-NEXT: $r30 = LWZ -8, $r1 :: (load (s32) from %fixed-stack.1, align 8)
     ; CHECK-NEXT: $r29 = LWZ -12, $r1 :: (load (s32) from %fixed-stack.2)
     ; CHECK-NEXT: $r12 = LWZ 4, $r1
-    ; CHECK-NEXT: $cr2 = MTOCRF $r12
-    ; CHECK-NEXT: $cr4 = MTOCRF killed $r12
+    ; CHECK-NEXT: MTCRF 40, killed $r12
 
 ...
 ---

--- a/llvm/test/CodeGen/PowerPC/cc.ll
+++ b/llvm/test/CodeGen/PowerPC/cc.ll
@@ -29,9 +29,7 @@ end:
 ; CHECK: mtocrf 128, [[REG3]]
 
 ; CHECK: lwz [[REG4:[0-9]+]], 8(1)
-; CHECK-DAG: mtocrf 32, [[REG4]]
-; CHECK-DAG: mtocrf 16, [[REG4]]
-; CHECK-DAG: mtocrf 8, [[REG4]]
+; CHECK-DAG: mtcrf 56, [[REG4]]
 ; CHECK: blr
 }
 
@@ -62,9 +60,7 @@ end:
 ; CHECK: mtocrf 128, [[REG3]]
 
 ; CHECK: lwz [[REG4:[0-9]+]], 8(1)
-; CHECK-DAG: mtocrf 32, [[REG4]]
-; CHECK-DAG: mtocrf 16, [[REG4]]
-; CHECK-DAG: mtocrf 8, [[REG4]]
+; CHECK-DAG: mtcrf 56, [[REG4]]
 ; CHECK: blr
 }
 

--- a/llvm/test/CodeGen/PowerPC/crsave.ll
+++ b/llvm/test/CodeGen/PowerPC/crsave.ll
@@ -137,9 +137,7 @@ define i32 @test_cr234() nounwind {
 ; PPC32-NEXT:    bl foo
 ; PPC32-NEXT:    lwz 3, 20(31)
 ; PPC32-NEXT:    lwz 12, 24(31)
-; PPC32-NEXT:    mtocrf 32, 12
-; PPC32-NEXT:    mtocrf 16, 12
-; PPC32-NEXT:    mtocrf 8, 12
+; PPC32-NEXT:    mtcrf 56, 12
 ; PPC32-NEXT:    lwz 0, 36(1)
 ; PPC32-NEXT:    lwz 31, 28(1)
 ; PPC32-NEXT:    addi 1, 1, 32
@@ -172,9 +170,7 @@ define i32 @test_cr234() nounwind {
 ; PPC64-NEXT:    addi 1, 1, 128
 ; PPC64-NEXT:    ld 0, 16(1)
 ; PPC64-NEXT:    lwz 12, 8(1)
-; PPC64-NEXT:    mtocrf 32, 12
-; PPC64-NEXT:    mtocrf 16, 12
-; PPC64-NEXT:    mtocrf 8, 12
+; PPC64-NEXT:    mtcrf 56, 12
 ; PPC64-NEXT:    mtlr 0
 ; PPC64-NEXT:    blr
 ;
@@ -204,9 +200,7 @@ define i32 @test_cr234() nounwind {
 ; PPC64-ELFv2-NEXT:    addi 1, 1, 112
 ; PPC64-ELFv2-NEXT:    ld 0, 16(1)
 ; PPC64-ELFv2-NEXT:    lwz 12, 8(1)
-; PPC64-ELFv2-NEXT:    mtocrf 32, 12
-; PPC64-ELFv2-NEXT:    mtocrf 16, 12
-; PPC64-ELFv2-NEXT:    mtocrf 8, 12
+; PPC64-ELFv2-NEXT:    mtcrf 56, 12
 ; PPC64-ELFv2-NEXT:    mtlr 0
 ; PPC64-ELFv2-NEXT:    blr
 entry:
@@ -285,9 +279,7 @@ define void @cloberAllNvCrField() {
 ; PPC32-NEXT:    # clobbers
 ; PPC32-NEXT:    #NO_APP
 ; PPC32-NEXT:    lwz 12, 24(31)
-; PPC32-NEXT:    mtocrf 32, 12
-; PPC32-NEXT:    mtocrf 16, 12
-; PPC32-NEXT:    mtocrf 8, 12
+; PPC32-NEXT:    mtcrf 56, 12
 ; PPC32-NEXT:    lwz 31, 28(1)
 ; PPC32-NEXT:    addi 1, 1, 32
 ; PPC32-NEXT:    blr
@@ -300,9 +292,7 @@ define void @cloberAllNvCrField() {
 ; PPC64-NEXT:    # clobbers
 ; PPC64-NEXT:    #NO_APP
 ; PPC64-NEXT:    lwz 12, 8(1)
-; PPC64-NEXT:    mtocrf 32, 12
-; PPC64-NEXT:    mtocrf 16, 12
-; PPC64-NEXT:    mtocrf 8, 12
+; PPC64-NEXT:    mtcrf 56, 12
 ; PPC64-NEXT:    blr
 ;
 ; PPC64-ELFv2-LABEL: cloberAllNvCrField:
@@ -313,9 +303,7 @@ define void @cloberAllNvCrField() {
 ; PPC64-ELFv2-NEXT:    # clobbers
 ; PPC64-ELFv2-NEXT:    #NO_APP
 ; PPC64-ELFv2-NEXT:    lwz 12, 8(1)
-; PPC64-ELFv2-NEXT:    mtocrf 32, 12
-; PPC64-ELFv2-NEXT:    mtocrf 16, 12
-; PPC64-ELFv2-NEXT:    mtocrf 8, 12
+; PPC64-ELFv2-NEXT:    mtcrf 56, 12
 ; PPC64-ELFv2-NEXT:    blr
 entry:
   tail call void asm sideeffect "# clobbers", "~{cr2},~{cr3},~{cr4}"()

--- a/llvm/test/CodeGen/PowerPC/p10-spill-creq.ll
+++ b/llvm/test/CodeGen/PowerPC/p10-spill-creq.ll
@@ -122,9 +122,7 @@ define dso_local double @P10_Spill_CR_EQ(ptr %arg) local_unnamed_addr #0 {
 ; CHECK-NEXT:    mtocrf 128, r7
 ; CHECK-NEXT:    isel r5, 0, r6, 4*cr6+lt
 ; CHECK-NEXT:    isel r3, 0, r3, 4*cr1+eq
-; CHECK-NEXT:    mtocrf 32, r12
-; CHECK-NEXT:    mtocrf 16, r12
-; CHECK-NEXT:    mtocrf 8, r12
+; CHECK-NEXT:    mtcrf 56, r12
 ; CHECK-NEXT:    crandc 4*cr5+lt, 4*cr5+lt, eq
 ; CHECK-NEXT:    isel r5, 0, r5, 4*cr7+eq
 ; CHECK-NEXT:    crnor 4*cr5+lt, 4*cr5+un, 4*cr5+lt

--- a/llvm/test/CodeGen/PowerPC/p10-spill-crgt.ll
+++ b/llvm/test/CodeGen/PowerPC/p10-spill-crgt.ll
@@ -185,9 +185,7 @@ define dso_local fastcc void @P10_Spill_CR_GT(ptr %p) unnamed_addr {
 ; CHECK-NEXT:    ld r0, 16(r1)
 ; CHECK-NEXT:    lwz r12, 8(r1)
 ; CHECK-NEXT:    mtlr r0
-; CHECK-NEXT:    mtocrf 32, r12
-; CHECK-NEXT:    mtocrf 16, r12
-; CHECK-NEXT:    mtocrf 8, r12
+; CHECK-NEXT:    mtcrf 56, r12
 ; CHECK-NEXT:    blr
 ; CHECK-NEXT:  .LBB0_32: # %bb29
 ; CHECK-NEXT:    crmove eq, 4*cr3+eq
@@ -382,9 +380,7 @@ define dso_local fastcc void @P10_Spill_CR_GT(ptr %p) unnamed_addr {
 ; CHECK-BE-NEXT:    ld r0, 16(r1)
 ; CHECK-BE-NEXT:    lwz r12, 8(r1)
 ; CHECK-BE-NEXT:    mtlr r0
-; CHECK-BE-NEXT:    mtocrf 32, r12
-; CHECK-BE-NEXT:    mtocrf 16, r12
-; CHECK-BE-NEXT:    mtocrf 8, r12
+; CHECK-BE-NEXT:    mtcrf 56, r12
 ; CHECK-BE-NEXT:    blr
 ; CHECK-BE-NEXT:  .LBB0_32: # %bb29
 ; CHECK-BE-NEXT:    crmove eq, 4*cr3+eq

--- a/llvm/test/CodeGen/PowerPC/p10-spill-crun.ll
+++ b/llvm/test/CodeGen/PowerPC/p10-spill-crun.ll
@@ -173,9 +173,7 @@ define dso_local void @P10_Spill_CR_UN(ptr %arg, ptr %arg1, i32 %arg2) local_unn
 ; CHECK-NEXT:    ld r0, 16(r1)
 ; CHECK-NEXT:    lwz r12, 8(r1)
 ; CHECK-NEXT:    mtlr r0
-; CHECK-NEXT:    mtocrf 32, r12
-; CHECK-NEXT:    mtocrf 16, r12
-; CHECK-NEXT:    mtocrf 8, r12
+; CHECK-NEXT:    mtcrf 56, r12
 ; CHECK-NEXT:    blr
 ; CHECK-NEXT:  .LBB0_18: # %bb30
 ; CHECK-NEXT:    stb r3, 181(r1)
@@ -333,9 +331,7 @@ define dso_local void @P10_Spill_CR_UN(ptr %arg, ptr %arg1, i32 %arg2) local_unn
 ; CHECK-BE-NEXT:    ld r0, 16(r1)
 ; CHECK-BE-NEXT:    lwz r12, 8(r1)
 ; CHECK-BE-NEXT:    mtlr r0
-; CHECK-BE-NEXT:    mtocrf 32, r12
-; CHECK-BE-NEXT:    mtocrf 16, r12
-; CHECK-BE-NEXT:    mtocrf 8, r12
+; CHECK-BE-NEXT:    mtcrf 56, r12
 ; CHECK-BE-NEXT:    blr
 ; CHECK-BE-NEXT:  .LBB0_18: # %bb30
 ; CHECK-BE-NEXT:    stb r3, 197(r1)

--- a/llvm/test/CodeGen/PowerPC/ppc64-crsave.mir
+++ b/llvm/test/CodeGen/PowerPC/ppc64-crsave.mir
@@ -29,8 +29,7 @@ body:             |
     ; SAVEONE-NEXT: renamable $cr2lt = COPY $cr0gt
     ; SAVEONE-NEXT: renamable $cr4lt = COPY $cr0gt
     ; SAVEONE-NEXT: $x12 = LWZ8 8, $x1
-    ; SAVEONE-NEXT: $cr2 = MTOCRF8 $x12
-    ; SAVEONE-NEXT: $cr4 = MTOCRF8 killed $x12
+    ; SAVEONE-NEXT: MTCRF8 40, killed $x12
     ; SAVEONE-NEXT: BLR8 implicit $lr8, implicit $rm, implicit $x3
     ;
     ; SAVEALL-LABEL: name: CRAllSave
@@ -42,8 +41,7 @@ body:             |
     ; SAVEALL-NEXT: renamable $cr2lt = COPY $cr0gt
     ; SAVEALL-NEXT: renamable $cr4lt = COPY $cr0gt
     ; SAVEALL-NEXT: $x12 = LWZ8 8, $x1
-    ; SAVEALL-NEXT: $cr2 = MTOCRF8 $x12
-    ; SAVEALL-NEXT: $cr4 = MTOCRF8 killed $x12
+    ; SAVEALL-NEXT: MTCRF8 40, killed $x12
     ; SAVEALL-NEXT: BLR8 implicit $lr8, implicit $rm, implicit $x3
     renamable $x3 = ANDI8_rec killed renamable $x3, 1, implicit-def dead $cr0, implicit-def $cr0gt
     renamable $cr2lt = COPY $cr0gt

--- a/llvm/test/CodeGen/PowerPC/ppc64-rop-protection-aix.ll
+++ b/llvm/test/CodeGen/PowerPC/ppc64-rop-protection-aix.ll
@@ -399,9 +399,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-P10-NEXT:    lwz r12, 8(r1)
 ; BE-P10-NEXT:    mtlr r0
 ; BE-P10-NEXT:    hashchk r0, -488(r1)
-; BE-P10-NEXT:    mtocrf 32, r12
-; BE-P10-NEXT:    mtocrf 16, r12
-; BE-P10-NEXT:    mtocrf 8, r12
+; BE-P10-NEXT:    mtcrf 56, r12
 ; BE-P10-NEXT:    blr
 ;
 ; BE-P9-LABEL: spill:
@@ -526,9 +524,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-P9-NEXT:    lwz r12, 8(r1)
 ; BE-P9-NEXT:    mtlr r0
 ; BE-P9-NEXT:    hashchk r0, -488(r1)
-; BE-P9-NEXT:    mtocrf 32, r12
-; BE-P9-NEXT:    mtocrf 16, r12
-; BE-P9-NEXT:    mtocrf 8, r12
+; BE-P9-NEXT:    mtcrf 56, r12
 ; BE-P9-NEXT:    blr
 ;
 ; BE-P8-LABEL: spill:
@@ -677,9 +673,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-P8-NEXT:    lwz r12, 8(r1)
 ; BE-P8-NEXT:    hashchk r0, -488(r1)
 ; BE-P8-NEXT:    mtlr r0
-; BE-P8-NEXT:    mtocrf 32, r12
-; BE-P8-NEXT:    mtocrf 16, r12
-; BE-P8-NEXT:    mtocrf 8, r12
+; BE-P8-NEXT:    mtcrf 56, r12
 ; BE-P8-NEXT:    blr
 ;
 ; BE-32BIT-P10-LABEL: spill:
@@ -805,9 +799,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-32BIT-P10-NEXT:    lwz r12, 4(r1)
 ; BE-32BIT-P10-NEXT:    mtlr r0
 ; BE-32BIT-P10-NEXT:    hashchk r0, -424(r1)
-; BE-32BIT-P10-NEXT:    mtocrf 32, r12
-; BE-32BIT-P10-NEXT:    mtocrf 16, r12
-; BE-32BIT-P10-NEXT:    mtocrf 8, r12
+; BE-32BIT-P10-NEXT:    mtcrf 56, r12
 ; BE-32BIT-P10-NEXT:    blr
 ;
 ; BE-32BIT-P9-LABEL: spill:
@@ -933,9 +925,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-32BIT-P9-NEXT:    lwz r12, 4(r1)
 ; BE-32BIT-P9-NEXT:    mtlr r0
 ; BE-32BIT-P9-NEXT:    hashchk r0, -424(r1)
-; BE-32BIT-P9-NEXT:    mtocrf 32, r12
-; BE-32BIT-P9-NEXT:    mtocrf 16, r12
-; BE-32BIT-P9-NEXT:    mtocrf 8, r12
+; BE-32BIT-P9-NEXT:    mtcrf 56, r12
 ; BE-32BIT-P9-NEXT:    blr
 ;
 ; BE-32BIT-P8-LABEL: spill:
@@ -1085,9 +1075,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-32BIT-P8-NEXT:    lwz r12, 4(r1)
 ; BE-32BIT-P8-NEXT:    hashchk r0, -424(r1)
 ; BE-32BIT-P8-NEXT:    mtlr r0
-; BE-32BIT-P8-NEXT:    mtocrf 32, r12
-; BE-32BIT-P8-NEXT:    mtocrf 16, r12
-; BE-32BIT-P8-NEXT:    mtocrf 8, r12
+; BE-32BIT-P8-NEXT:    mtcrf 56, r12
 ; BE-32BIT-P8-NEXT:    blr
 ;
 ; BE-P10-PRIV-LABEL: spill:
@@ -1212,9 +1200,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-P10-PRIV-NEXT:    lwz r12, 8(r1)
 ; BE-P10-PRIV-NEXT:    mtlr r0
 ; BE-P10-PRIV-NEXT:    hashchkp r0, -488(r1)
-; BE-P10-PRIV-NEXT:    mtocrf 32, r12
-; BE-P10-PRIV-NEXT:    mtocrf 16, r12
-; BE-P10-PRIV-NEXT:    mtocrf 8, r12
+; BE-P10-PRIV-NEXT:    mtcrf 56, r12
 ; BE-P10-PRIV-NEXT:    blr
 ;
 ; BE-P9-PRIV-LABEL: spill:
@@ -1339,9 +1325,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-P9-PRIV-NEXT:    lwz r12, 8(r1)
 ; BE-P9-PRIV-NEXT:    mtlr r0
 ; BE-P9-PRIV-NEXT:    hashchkp r0, -488(r1)
-; BE-P9-PRIV-NEXT:    mtocrf 32, r12
-; BE-P9-PRIV-NEXT:    mtocrf 16, r12
-; BE-P9-PRIV-NEXT:    mtocrf 8, r12
+; BE-P9-PRIV-NEXT:    mtcrf 56, r12
 ; BE-P9-PRIV-NEXT:    blr
 ;
 ; BE-P8-PRIV-LABEL: spill:
@@ -1490,9 +1474,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-P8-PRIV-NEXT:    lwz r12, 8(r1)
 ; BE-P8-PRIV-NEXT:    hashchkp r0, -488(r1)
 ; BE-P8-PRIV-NEXT:    mtlr r0
-; BE-P8-PRIV-NEXT:    mtocrf 32, r12
-; BE-P8-PRIV-NEXT:    mtocrf 16, r12
-; BE-P8-PRIV-NEXT:    mtocrf 8, r12
+; BE-P8-PRIV-NEXT:    mtcrf 56, r12
 ; BE-P8-PRIV-NEXT:    blr
 ;
 ; BE-32BIT-P10-PRIV-LABEL: spill:
@@ -1618,9 +1600,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-32BIT-P10-PRIV-NEXT:    lwz r12, 4(r1)
 ; BE-32BIT-P10-PRIV-NEXT:    mtlr r0
 ; BE-32BIT-P10-PRIV-NEXT:    hashchkp r0, -424(r1)
-; BE-32BIT-P10-PRIV-NEXT:    mtocrf 32, r12
-; BE-32BIT-P10-PRIV-NEXT:    mtocrf 16, r12
-; BE-32BIT-P10-PRIV-NEXT:    mtocrf 8, r12
+; BE-32BIT-P10-PRIV-NEXT:    mtcrf 56, r12
 ; BE-32BIT-P10-PRIV-NEXT:    blr
 ;
 ; BE-32BIT-P9-PRIV-LABEL: spill:
@@ -1746,9 +1726,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-32BIT-P9-PRIV-NEXT:    lwz r12, 4(r1)
 ; BE-32BIT-P9-PRIV-NEXT:    mtlr r0
 ; BE-32BIT-P9-PRIV-NEXT:    hashchkp r0, -424(r1)
-; BE-32BIT-P9-PRIV-NEXT:    mtocrf 32, r12
-; BE-32BIT-P9-PRIV-NEXT:    mtocrf 16, r12
-; BE-32BIT-P9-PRIV-NEXT:    mtocrf 8, r12
+; BE-32BIT-P9-PRIV-NEXT:    mtcrf 56, r12
 ; BE-32BIT-P9-PRIV-NEXT:    blr
 ;
 ; BE-32BIT-P8-PRIV-LABEL: spill:
@@ -1898,9 +1876,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-32BIT-P8-PRIV-NEXT:    lwz r12, 4(r1)
 ; BE-32BIT-P8-PRIV-NEXT:    hashchkp r0, -424(r1)
 ; BE-32BIT-P8-PRIV-NEXT:    mtlr r0
-; BE-32BIT-P8-PRIV-NEXT:    mtocrf 32, r12
-; BE-32BIT-P8-PRIV-NEXT:    mtocrf 16, r12
-; BE-32BIT-P8-PRIV-NEXT:    mtocrf 8, r12
+; BE-32BIT-P8-PRIV-NEXT:    mtcrf 56, r12
 ; BE-32BIT-P8-PRIV-NEXT:    blr
 entry:
   %local = alloca i32, align 4

--- a/llvm/test/CodeGen/PowerPC/ppc64-rop-protection.ll
+++ b/llvm/test/CodeGen/PowerPC/ppc64-rop-protection.ll
@@ -535,9 +535,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; LE-P10-NEXT:    lwz r12, 8(r1)
 ; LE-P10-NEXT:    mtlr r0
 ; LE-P10-NEXT:    hashchk r0, -488(r1)
-; LE-P10-NEXT:    mtocrf 32, r12
-; LE-P10-NEXT:    mtocrf 16, r12
-; LE-P10-NEXT:    mtocrf 8, r12
+; LE-P10-NEXT:    mtcrf 56, r12
 ; LE-P10-NEXT:    blr
 ;
 ; LE-P9-LABEL: spill:
@@ -662,9 +660,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; LE-P9-NEXT:    lwz r12, 8(r1)
 ; LE-P9-NEXT:    mtlr r0
 ; LE-P9-NEXT:    hashchk r0, -488(r1)
-; LE-P9-NEXT:    mtocrf 32, r12
-; LE-P9-NEXT:    mtocrf 16, r12
-; LE-P9-NEXT:    mtocrf 8, r12
+; LE-P9-NEXT:    mtcrf 56, r12
 ; LE-P9-NEXT:    blr
 ;
 ; LE-P8-LABEL: spill:
@@ -813,9 +809,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; LE-P8-NEXT:    lwz r12, 8(r1)
 ; LE-P8-NEXT:    hashchk r0, -488(r1)
 ; LE-P8-NEXT:    mtlr r0
-; LE-P8-NEXT:    mtocrf 32, r12
-; LE-P8-NEXT:    mtocrf 16, r12
-; LE-P8-NEXT:    mtocrf 8, r12
+; LE-P8-NEXT:    mtcrf 56, r12
 ; LE-P8-NEXT:    blr
 ;
 ; LE-P10-O0-LABEL: spill:
@@ -939,9 +933,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; LE-P10-O0-NEXT:    addi r1, r1, 544
 ; LE-P10-O0-NEXT:    ld r0, 16(r1)
 ; LE-P10-O0-NEXT:    lwz r12, 8(r1)
-; LE-P10-O0-NEXT:    mtocrf 32, r12
-; LE-P10-O0-NEXT:    mtocrf 16, r12
-; LE-P10-O0-NEXT:    mtocrf 8, r12
+; LE-P10-O0-NEXT:    mtcrf 56, r12
 ; LE-P10-O0-NEXT:    hashchk r0, -488(r1)
 ; LE-P10-O0-NEXT:    mtlr r0
 ; LE-P10-O0-NEXT:    blr
@@ -1067,9 +1059,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; LE-P9-O0-NEXT:    addi r1, r1, 608
 ; LE-P9-O0-NEXT:    ld r0, 16(r1)
 ; LE-P9-O0-NEXT:    lwz r12, 8(r1)
-; LE-P9-O0-NEXT:    mtocrf 32, r12
-; LE-P9-O0-NEXT:    mtocrf 16, r12
-; LE-P9-O0-NEXT:    mtocrf 8, r12
+; LE-P9-O0-NEXT:    mtcrf 56, r12
 ; LE-P9-O0-NEXT:    hashchk r0, -488(r1)
 ; LE-P9-O0-NEXT:    mtlr r0
 ; LE-P9-O0-NEXT:    blr
@@ -1219,9 +1209,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; LE-P8-O0-NEXT:    addi r1, r1, 608
 ; LE-P8-O0-NEXT:    ld r0, 16(r1)
 ; LE-P8-O0-NEXT:    lwz r12, 8(r1)
-; LE-P8-O0-NEXT:    mtocrf 32, r12
-; LE-P8-O0-NEXT:    mtocrf 16, r12
-; LE-P8-O0-NEXT:    mtocrf 8, r12
+; LE-P8-O0-NEXT:    mtcrf 56, r12
 ; LE-P8-O0-NEXT:    hashchk r0, -488(r1)
 ; LE-P8-O0-NEXT:    mtlr r0
 ; LE-P8-O0-NEXT:    blr
@@ -1348,9 +1336,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-P10-NEXT:    lwz r12, 8(r1)
 ; BE-P10-NEXT:    mtlr r0
 ; BE-P10-NEXT:    hashchk r0, -488(r1)
-; BE-P10-NEXT:    mtocrf 32, r12
-; BE-P10-NEXT:    mtocrf 16, r12
-; BE-P10-NEXT:    mtocrf 8, r12
+; BE-P10-NEXT:    mtcrf 56, r12
 ; BE-P10-NEXT:    blr
 ;
 ; BE-P9-LABEL: spill:
@@ -1475,9 +1461,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-P9-NEXT:    lwz r12, 8(r1)
 ; BE-P9-NEXT:    mtlr r0
 ; BE-P9-NEXT:    hashchk r0, -488(r1)
-; BE-P9-NEXT:    mtocrf 32, r12
-; BE-P9-NEXT:    mtocrf 16, r12
-; BE-P9-NEXT:    mtocrf 8, r12
+; BE-P9-NEXT:    mtcrf 56, r12
 ; BE-P9-NEXT:    blr
 ;
 ; BE-P8-LABEL: spill:
@@ -1626,9 +1610,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-P8-NEXT:    lwz r12, 8(r1)
 ; BE-P8-NEXT:    hashchk r0, -488(r1)
 ; BE-P8-NEXT:    mtlr r0
-; BE-P8-NEXT:    mtocrf 32, r12
-; BE-P8-NEXT:    mtocrf 16, r12
-; BE-P8-NEXT:    mtocrf 8, r12
+; BE-P8-NEXT:    mtcrf 56, r12
 ; BE-P8-NEXT:    blr
 ;
 ; BE-32BIT-P10-LABEL: spill:
@@ -1728,9 +1710,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-32BIT-P10-NEXT:    lwz r4, 16(r4)
 ; BE-32BIT-P10-NEXT:    add r3, r4, r3
 ; BE-32BIT-P10-NEXT:    lwz r12, 228(r1)
-; BE-32BIT-P10-NEXT:    mtocrf 32, r12
-; BE-32BIT-P10-NEXT:    mtocrf 16, r12
-; BE-32BIT-P10-NEXT:    mtocrf 8, r12
+; BE-32BIT-P10-NEXT:    mtcrf 56, r12
 ; BE-32BIT-P10-NEXT:    lfd f14, 304(r1) # 8-byte Folded Reload
 ; BE-32BIT-P10-NEXT:    lwz r31, 300(r1) # 4-byte Folded Reload
 ; BE-32BIT-P10-NEXT:    lwz r30, 296(r1) # 4-byte Folded Reload
@@ -1873,9 +1853,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-32BIT-P9-NEXT:    lwz r14, 232(r1) # 4-byte Folded Reload
 ; BE-32BIT-P9-NEXT:    lfd f14, 304(r1) # 8-byte Folded Reload
 ; BE-32BIT-P9-NEXT:    lwz r0, 452(r1)
-; BE-32BIT-P9-NEXT:    mtocrf 32, r12
-; BE-32BIT-P9-NEXT:    mtocrf 16, r12
-; BE-32BIT-P9-NEXT:    mtocrf 8, r12
+; BE-32BIT-P9-NEXT:    mtcrf 56, r12
 ; BE-32BIT-P9-NEXT:    addi r1, r1, 448
 ; BE-32BIT-P9-NEXT:    mtlr r0
 ; BE-32BIT-P9-NEXT:    hashchk r0, -424(r1)
@@ -2022,9 +2000,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-32BIT-P8-NEXT:    lwz r15, 236(r1) # 4-byte Folded Reload
 ; BE-32BIT-P8-NEXT:    lwz r14, 232(r1) # 4-byte Folded Reload
 ; BE-32BIT-P8-NEXT:    lwz r0, 452(r1)
-; BE-32BIT-P8-NEXT:    mtocrf 32, r12
-; BE-32BIT-P8-NEXT:    mtocrf 16, r12
-; BE-32BIT-P8-NEXT:    mtocrf 8, r12
+; BE-32BIT-P8-NEXT:    mtcrf 56, r12
 ; BE-32BIT-P8-NEXT:    addi r1, r1, 448
 ; BE-32BIT-P8-NEXT:    mtlr r0
 ; BE-32BIT-P8-NEXT:    hashchk r0, -424(r1)
@@ -2151,9 +2127,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; LE-P10-PRIV-NEXT:    lwz r12, 8(r1)
 ; LE-P10-PRIV-NEXT:    mtlr r0
 ; LE-P10-PRIV-NEXT:    hashchkp r0, -488(r1)
-; LE-P10-PRIV-NEXT:    mtocrf 32, r12
-; LE-P10-PRIV-NEXT:    mtocrf 16, r12
-; LE-P10-PRIV-NEXT:    mtocrf 8, r12
+; LE-P10-PRIV-NEXT:    mtcrf 56, r12
 ; LE-P10-PRIV-NEXT:    blr
 ;
 ; LE-P9-PRIV-LABEL: spill:
@@ -2278,9 +2252,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; LE-P9-PRIV-NEXT:    lwz r12, 8(r1)
 ; LE-P9-PRIV-NEXT:    mtlr r0
 ; LE-P9-PRIV-NEXT:    hashchkp r0, -488(r1)
-; LE-P9-PRIV-NEXT:    mtocrf 32, r12
-; LE-P9-PRIV-NEXT:    mtocrf 16, r12
-; LE-P9-PRIV-NEXT:    mtocrf 8, r12
+; LE-P9-PRIV-NEXT:    mtcrf 56, r12
 ; LE-P9-PRIV-NEXT:    blr
 ;
 ; LE-P8-PRIV-LABEL: spill:
@@ -2429,9 +2401,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; LE-P8-PRIV-NEXT:    lwz r12, 8(r1)
 ; LE-P8-PRIV-NEXT:    hashchkp r0, -488(r1)
 ; LE-P8-PRIV-NEXT:    mtlr r0
-; LE-P8-PRIV-NEXT:    mtocrf 32, r12
-; LE-P8-PRIV-NEXT:    mtocrf 16, r12
-; LE-P8-PRIV-NEXT:    mtocrf 8, r12
+; LE-P8-PRIV-NEXT:    mtcrf 56, r12
 ; LE-P8-PRIV-NEXT:    blr
 ;
 ; BE-P10-PRIV-LABEL: spill:
@@ -2556,9 +2526,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-P10-PRIV-NEXT:    lwz r12, 8(r1)
 ; BE-P10-PRIV-NEXT:    mtlr r0
 ; BE-P10-PRIV-NEXT:    hashchkp r0, -488(r1)
-; BE-P10-PRIV-NEXT:    mtocrf 32, r12
-; BE-P10-PRIV-NEXT:    mtocrf 16, r12
-; BE-P10-PRIV-NEXT:    mtocrf 8, r12
+; BE-P10-PRIV-NEXT:    mtcrf 56, r12
 ; BE-P10-PRIV-NEXT:    blr
 ;
 ; BE-P9-PRIV-LABEL: spill:
@@ -2683,9 +2651,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-P9-PRIV-NEXT:    lwz r12, 8(r1)
 ; BE-P9-PRIV-NEXT:    mtlr r0
 ; BE-P9-PRIV-NEXT:    hashchkp r0, -488(r1)
-; BE-P9-PRIV-NEXT:    mtocrf 32, r12
-; BE-P9-PRIV-NEXT:    mtocrf 16, r12
-; BE-P9-PRIV-NEXT:    mtocrf 8, r12
+; BE-P9-PRIV-NEXT:    mtcrf 56, r12
 ; BE-P9-PRIV-NEXT:    blr
 ;
 ; BE-P8-PRIV-LABEL: spill:
@@ -2834,9 +2800,7 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-P8-PRIV-NEXT:    lwz r12, 8(r1)
 ; BE-P8-PRIV-NEXT:    hashchkp r0, -488(r1)
 ; BE-P8-PRIV-NEXT:    mtlr r0
-; BE-P8-PRIV-NEXT:    mtocrf 32, r12
-; BE-P8-PRIV-NEXT:    mtocrf 16, r12
-; BE-P8-PRIV-NEXT:    mtocrf 8, r12
+; BE-P8-PRIV-NEXT:    mtcrf 56, r12
 ; BE-P8-PRIV-NEXT:    blr
 entry:
   %local = alloca i32, align 4


### PR DESCRIPTION
For AIX and ELFv2 ABI, 
1. When we only spill one non-volatile CR field , using one mfocrf/mtocrf instruction.
2. when spill two or more non-volatile CR fields, using one mfcr/mtcr instead of multi mfocrf/mtocrf instructions