### PR TITLE
[ARM] Remove llvm/test/MC/COFF/ARM/lit.local.cfg. NFC

### DIFF
--- a/llvm/test/MC/COFF/ARM/lit.local.cfg
+++ b/llvm/test/MC/COFF/ARM/lit.local.cfg
@@ -1,2 +1,0 @@
-if not "ARM" in config.root.targets:
-    config.unsupported = True


### PR DESCRIPTION
Given there are no files in this folder (since
ff1d084aa2f07927f3c63c93f3286822abe9d1ac) the unused lit.local.cfg can be
removed.