### PR TITLE
[libc++] Fill in Apple availability for LLVM 21

### DIFF
--- a/libcxx/include/__configuration/availability.h
+++ b/libcxx/include/__configuration/availability.h
@@ -39,6 +39,9 @@
 // in all versions of the library are available.
 #if !_LIBCPP_HAS_VENDOR_AVAILABILITY_ANNOTATIONS
 
+#  define _LIBCPP_INTRODUCED_IN_LLVM_23 1
+#  define _LIBCPP_INTRODUCED_IN_LLVM_23_ATTRIBUTE /* nothing */
+
 #  define _LIBCPP_INTRODUCED_IN_LLVM_22 1
 #  define _LIBCPP_INTRODUCED_IN_LLVM_22_ATTRIBUTE /* nothing */
 
@@ -69,6 +72,11 @@
 #elif defined(__APPLE__)
 
 // clang-format off
+
+// LLVM 23
+// TODO: Fill this in
+#  define _LIBCPP_INTRODUCED_IN_LLVM_23 0
+#  define _LIBCPP_INTRODUCED_IN_LLVM_23_ATTRIBUTE __attribute__((unavailable))
 
 // LLVM 22
 // TODO: Fill this in

--- a/libcxx/include/__configuration/availability.h
+++ b/libcxx/include/__configuration/availability.h
@@ -76,9 +76,23 @@
 #  define _LIBCPP_INTRODUCED_IN_LLVM_22_ATTRIBUTE __attribute__((unavailable))
 
 // LLVM 21
-// TODO: Fill this in
-#  define _LIBCPP_INTRODUCED_IN_LLVM_21 0
-#  define _LIBCPP_INTRODUCED_IN_LLVM_21_ATTRIBUTE __attribute__((unavailable))
+#  if (defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 260400) ||       \
+      (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 260400) ||     \
+      (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 260400) ||             \
+      (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 260400) ||       \
+      (defined(__ENVIRONMENT_BRIDGE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_BRIDGE_OS_VERSION_MIN_REQUIRED__ < 100400) ||     \
+      (defined(__ENVIRONMENT_DRIVERKIT_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_DRIVERKIT_VERSION_MIN_REQUIRED__ < 250400)
+#    define _LIBCPP_INTRODUCED_IN_LLVM_21 0
+#  else
+#    define _LIBCPP_INTRODUCED_IN_LLVM_21 1
+#  endif
+#  define _LIBCPP_INTRODUCED_IN_LLVM_21_ATTRIBUTE                                                                 \
+    __attribute__((availability(macos, strict, introduced = 26.4)))                                               \
+    __attribute__((availability(ios, strict, introduced = 26.4)))                                                 \
+    __attribute__((availability(tvos, strict, introduced = 26.4)))                                                \
+    __attribute__((availability(watchos, strict, introduced = 26.4)))                                             \
+    __attribute__((availability(bridgeos, strict, introduced = 10.4)))                                            \
+    __attribute__((availability(driverkit, strict, introduced = 25.4)))
 
 // LLVM 20
 //
@@ -87,7 +101,8 @@
       (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 260000) ||     \
       (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 260000) ||             \
       (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 260000) ||       \
-      (defined(__ENVIRONMENT_BRIDGE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_BRIDGE_OS_VERSION_MIN_REQUIRED__ < 100000)
+      (defined(__ENVIRONMENT_BRIDGE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_BRIDGE_OS_VERSION_MIN_REQUIRED__ < 100000) ||     \
+      (defined(__ENVIRONMENT_DRIVERKIT_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_DRIVERKIT_VERSION_MIN_REQUIRED__ < 250000)
 #    define _LIBCPP_INTRODUCED_IN_LLVM_20 0
 #  else
 #    define _LIBCPP_INTRODUCED_IN_LLVM_20 1
@@ -97,14 +112,16 @@
     __attribute__((availability(ios, strict, introduced = 26.0)))                                                 \
     __attribute__((availability(tvos, strict, introduced = 26.0)))                                                \
     __attribute__((availability(watchos, strict, introduced = 26.0)))                                             \
-    __attribute__((availability(bridgeos, strict, introduced = 10.0)))
+    __attribute__((availability(bridgeos, strict, introduced = 10.0)))                                            \
+    __attribute__((availability(driverkit, strict, introduced = 25.0)))
 
 // LLVM 19
 #  if (defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 150400) ||       \
       (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 180400) ||     \
       (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 180400) ||             \
       (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 110400) ||       \
-      (defined(__ENVIRONMENT_BRIDGE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_BRIDGE_OS_VERSION_MIN_REQUIRED__ < 90400)
+      (defined(__ENVIRONMENT_BRIDGE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_BRIDGE_OS_VERSION_MIN_REQUIRED__ < 90400) ||       \
+      (defined(__ENVIRONMENT_DRIVERKIT_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_DRIVERKIT_VERSION_MIN_REQUIRED__ < 240400)
 #    define _LIBCPP_INTRODUCED_IN_LLVM_19 0
 #  else
 #    define _LIBCPP_INTRODUCED_IN_LLVM_19 1
@@ -114,7 +131,8 @@
     __attribute__((availability(ios, strict, introduced = 18.4)))                                                 \
     __attribute__((availability(tvos, strict, introduced = 18.4)))                                                \
     __attribute__((availability(watchos, strict, introduced = 11.4)))                                             \
-    __attribute__((availability(bridgeos, strict, introduced = 9.4)))
+    __attribute__((availability(bridgeos, strict, introduced = 9.4)))                                             \
+    __attribute__((availability(driverkit, strict, introduced = 24.4)))
 
 // LLVM 18
 #  if (defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 150000) ||       \

--- a/libcxx/test/std/strings/basic.string/string.capacity/over_max_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.capacity/over_max_size.pass.cpp
@@ -14,7 +14,7 @@
 // than it really is, and we fail to throw `length_error` from `string::resize()`,
 // which is explicitly instantiated in the built library.
 //
-// UNSUPPORTED: using-built-library-before-llvm-21
+// XFAIL: using-built-library-before-llvm-21
 
 // <string>
 

--- a/libcxx/utils/libcxx/test/features/availability.py
+++ b/libcxx/utils/libcxx/test/features/availability.py
@@ -22,14 +22,14 @@ features = [
     Feature(
         name="_target-has-llvm-21",
         when=lambda cfg: BooleanExpression.evaluate(
-            "TBD",
+            r"_target-has-llvm-22 || target={{.+}}-apple-macosx{{26.[4-9](.\d+)?}}",
             cfg.available_features,
         ),
     ),
     Feature(
         name="_target-has-llvm-20",
         when=lambda cfg: BooleanExpression.evaluate(
-            r"_target-has-llvm-21 || target={{.+}}-apple-macosx{{26.[0-9](.\d+)?}}",
+            r"_target-has-llvm-21 || target={{.+}}-apple-macosx{{26.[0-3](.\d+)?}}",
             cfg.available_features,
         ),
     ),

--- a/libcxx/utils/libcxx/test/features/availability.py
+++ b/libcxx/utils/libcxx/test/features/availability.py
@@ -13,9 +13,16 @@ from lit.BooleanExpression import BooleanExpression
 # Those are used for backdeployment features below, do not use directly in tests.
 features = [
     Feature(
-        name="_target-has-llvm-22",
+        name="_target-has-llvm-23",
         when=lambda cfg: BooleanExpression.evaluate(
             "TBD",
+            cfg.available_features,
+        ),
+    ),
+    Feature(
+        name="_target-has-llvm-22",
+        when=lambda cfg: BooleanExpression.evaluate(
+            "_target-has-llvm-23",
             cfg.available_features,
         ),
     ),
@@ -128,7 +135,7 @@ features = [
 # a libc++ flavor that enables availability markup. Similarly, a test could fail when
 # run against the system library of an older version of FreeBSD, even though FreeBSD
 # doesn't provide availability markup at the time of writing this.
-for version in ("12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22"):
+for version in ("12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23"):
     features.append(
         Feature(
             name="using-built-library-before-llvm-{}".format(version),

--- a/libcxxabi/test/test_demangle.pass.cpp
+++ b/libcxxabi/test/test_demangle.pass.cpp
@@ -17,6 +17,11 @@
 // 20f56d140909a01c74e9981835373eaab6021af9.
 // UNSUPPORTED: using-built-library-before-llvm-21
 
+// This test exercises support for stripping the __alloc_token_ prefix
+// (fb6f1bde00c4) and for pack indexing type/expression mangling
+// (68e8dd698dc6), both introduced in the LLVM 23 release.
+// XFAIL: using-built-library-before-llvm-23
+
 // XFAIL: win32-broken-printf-a-precision
 
 #include "support/timer.h"


### PR DESCRIPTION
macOS 26.4 and aligned platforms have been released and they are roughly synchronized to libc++ 21. As a drive-by, also add missing versions for previous releases.

This also allows reverting #199682 which moved an XFAIL to UNSUPPORTED to silence CI failures temporarily.