### PR TITLE
[FuzzMutate] Reject invalid inputs in the IR fuzzers

### DIFF
--- a/llvm/tools/llvm-isel-fuzzer/llvm-isel-fuzzer.cpp
+++ b/llvm/tools/llvm-isel-fuzzer/llvm-isel-fuzzer.cpp
@@ -87,7 +87,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
   auto M = parseAndVerify(Data, Size, Context);
   if (!M) {
     errs() << "error: input module is broken!\n";
-    return 0;
+    return -1; // Ignore this input.
   }
 
   // Set up the module to build for our target.

--- a/llvm/tools/llvm-opt-fuzzer/llvm-opt-fuzzer.cpp
+++ b/llvm/tools/llvm-opt-fuzzer/llvm-opt-fuzzer.cpp
@@ -118,7 +118,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
   auto M = parseAndVerify(Data, Size, Context);
   if (!M) {
     errs() << "error: input module is broken!\n";
-    return 0;
+    return -1; // Ignore this input.
   }
 
   // Set up target dependant options


### PR DESCRIPTION
In llvm-isel-fuzzer and llvm-opt-fuzzer return -1 from LLVMFuzzerTestOneInput to ignore an invalid input. This will remove it from in-memory corpus and prevent sending it to the custom mutators (useless and crashes llvm-isel-fuzzer). libfuzzer truncates with -max_len so inputs above the limit are automatically invalid.