### PR TITLE
[LLVM][Runtimes] Fix path attempting to install to wrong location

### DIFF
--- a/runtimes/CMakeLists.txt
+++ b/runtimes/CMakeLists.txt
@@ -63,18 +63,14 @@ function(runtime_register_component name)
   set_property(GLOBAL APPEND PROPERTY SUB_COMPONENTS ${name})
 endfunction()
 
-find_package(LLVM
-  PATHS
-    "${LLVM_BINARY_DIR}"
-    "${LLVM_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm"
-  NO_DEFAULT_PATH
-  NO_CMAKE_FIND_ROOT_PATH)
-find_package(Clang
-  PATHS
-    "${LLVM_BINARY_DIR}"
-    "${LLVM_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/cmake/clang"
-  NO_DEFAULT_PATH
-  NO_CMAKE_FIND_ROOT_PATH)
+set(llvm_search_paths "${LLVM_BINARY_DIR}")
+set(clang_search_paths "${LLVM_BINARY_DIR}")
+if(LLVM_BINARY_DIR)
+  list(APPEND llvm_search_paths "${LLVM_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm")
+  list(APPEND clang_search_paths "${LLVM_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/cmake/clang")
+endif()
+find_package(LLVM PATHS ${llvm_search_paths} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+find_package(Clang PATHS ${clang_search_paths} NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
 
 set(LLVM_THIRD_PARTY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../third-party")
 


### PR DESCRIPTION
Summary:
When LLVM_BINARY_DIR was not set this should default to a root location
and configuration would fail by trying to write to some random system
location with insufficient perms.

Fixes the failure introduced in https://github.com/llvm/llvm-project/commit/b4f5ae234c6d
