### PR TITLE
[clang-tidy] Avoid token merging in redundant-parentheses fix-its

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/RedundantParenthesesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantParenthesesCheck.cpp
@@ -13,6 +13,7 @@
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/ASTMatchers/ASTMatchersMacros.h"
+#include "clang/Lex/Lexer.h"
 #include <cassert>
 
 using namespace clang::ast_matchers;
@@ -30,6 +31,23 @@ AST_MATCHER(ParenExpr, isInMacro) {
   const Expr *E = Node.getSubExpr();
   return Node.getLParen().isMacroID() || Node.getRParen().isMacroID() ||
          E->getBeginLoc().isMacroID() || E->getEndLoc().isMacroID();
+}
+
+static FixItHint createSpacedRemoval(SourceLocation Loc,
+                                     const SourceManager &SM,
+                                     const LangOptions &LangOpts) {
+  if (Loc.isValid() && !Loc.isMacroID()) {
+    auto LocInfo = SM.getDecomposedLoc(Loc);
+    bool Invalid = false;
+    StringRef Buffer = SM.getBufferData(LocInfo.first, &Invalid);
+    if (!Invalid && LocInfo.second > 0 && LocInfo.second + 1 < Buffer.size() &&
+        Lexer::isAsciiIdentifierContinueChar(Buffer[LocInfo.second - 1],
+                                             LangOpts) &&
+        Lexer::isAsciiIdentifierContinueChar(Buffer[LocInfo.second + 1],
+                                             LangOpts))
+      return FixItHint::CreateReplacement(SourceRange(Loc, Loc), " ");
+  }
+  return FixItHint::CreateRemoval(Loc);
 }
 
 } // namespace
@@ -66,7 +84,8 @@ void RedundantParenthesesCheck::registerMatchers(MatchFinder *Finder) {
 void RedundantParenthesesCheck::check(const MatchFinder::MatchResult &Result) {
   const auto *PE = Result.Nodes.getNodeAs<ParenExpr>("dup");
   diag(PE->getBeginLoc(), "redundant parentheses around expression")
-      << FixItHint::CreateRemoval(PE->getLParen())
+      << createSpacedRemoval(PE->getLParen(), *Result.SourceManager,
+                             getLangOpts())
       << FixItHint::CreateRemoval(PE->getRParen());
 }
 

--- a/clang-tools-extra/clang-tidy/readability/RedundantParenthesesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantParenthesesCheck.cpp
@@ -33,6 +33,8 @@ AST_MATCHER(ParenExpr, isInMacro) {
          E->getBeginLoc().isMacroID() || E->getEndLoc().isMacroID();
 }
 
+} // namespace
+
 static FixItHint createSpacedRemoval(SourceLocation Loc,
                                      const SourceManager &SM,
                                      const LangOptions &LangOpts) {
@@ -49,8 +51,6 @@ static FixItHint createSpacedRemoval(SourceLocation Loc,
   }
   return FixItHint::CreateRemoval(Loc);
 }
-
-} // namespace
 
 RedundantParenthesesCheck::RedundantParenthesesCheck(StringRef Name,
                                                      ClangTidyContext *Context)

--- a/clang-tools-extra/clangd/unittests/DiagnosticsTests.cpp
+++ b/clang-tools-extra/clangd/unittests/DiagnosticsTests.cpp
@@ -359,6 +359,29 @@ TEST(DiagnosticsTest, ClangTidy) {
                "function 'bar' is within a recursive call chain"))));
 }
 
+TEST(DiagnosticsTest, ClangTidyRedundantParenthesesFix) {
+  Annotations Test(R"cpp(
+    int func() {
+      return$lparen[[(]]0$rparen[[)]];
+    }
+  )cpp");
+  auto TU = TestTU::withCode(Test.code());
+  TU.ClangTidyProvider = addTidyChecks("readability-redundant-parentheses");
+
+  clangd::Fix ExpectedFix;
+  ExpectedFix.Message = "redundant parentheses around expression";
+  ExpectedFix.Edits.push_back(TextEdit{Test.range("lparen"), " "});
+  ExpectedFix.Edits.push_back(TextEdit{Test.range("rparen"), ""});
+
+  EXPECT_THAT(
+      TU.build().getDiagnostics(),
+      ifTidyChecks(ElementsAre(AllOf(
+          Diag(Test.range("lparen"), "redundant parentheses around expression"),
+          diagSource(Diag::ClangTidy),
+          diagName("readability-redundant-parentheses"),
+          withFix(equalToFix(ExpectedFix))))));
+}
+
 TEST(DiagnosticsTest, ClangTidyEOF) {
   // clang-format off
   Annotations Test(R"cpp(

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -802,9 +802,13 @@ Changes in existing checks
   macros that may expand differently in other configurations.
 
 - Improved :doc:`readability-redundant-parentheses
-  <clang-tidy/checks/readability/redundant-parentheses>` check by fixing a
-  false positive for parentheses present around an overloaded operator in the
-  context of a binary operation.
+  <clang-tidy/checks/readability/redundant-parentheses>` check:
+
+  - Fixed a false positive for parentheses present around an overloaded operator
+    in the context of a binary operation.
+
+  - Fixed a bug where clients that apply fix-its without :program:`clang-tidy`'s
+    cleanup could produce invalid code by joining adjacent tokens.
 
 - Improved :doc:`readability-redundant-preprocessor
   <clang-tidy/checks/readability/redundant-preprocessor>` check by fixing a


### PR DESCRIPTION
The readability-redundant-parentheses check emitted fix-its that simply removed both parentheses. Tools that apply those fix-its directly could join adjacent tokens and produce invalid code, e.g. `return(0)` becoming `return0`.

Replace the opening parenthesis with a space when removing it would merge identifier characters across the removed token.

AI Usage: Test assisted by Codex.
Closes https://github.com/llvm/llvm-project/issues/185108