### PR TITLE
[X86] Disallow immediate address calls when position independent

### DIFF
--- a/llvm/lib/Target/X86/X86Subtarget.cpp
+++ b/llvm/lib/Target/X86/X86Subtarget.cpp
@@ -241,7 +241,7 @@ bool X86Subtarget::isLegalToCallImmediateAddr() const {
   // FIXME: I386 PE/COFF supports PC relative calls using IMAGE_REL_I386_REL32
   // but WinCOFFObjectWriter::RecordRelocation cannot emit them.  Once it does,
   // the following check for Win32 should be removed.
-  if (Is64Bit || isTargetWin32())
+  if (Is64Bit || isTargetWin32() || isPositionIndependent())
     return false;
   return isTargetELF() || TM.getRelocationModel() == Reloc::Static;
 }

--- a/llvm/test/CodeGen/X86/call-imm.ll
+++ b/llvm/test/CodeGen/X86/call-imm.ll
@@ -1,6 +1,7 @@
 ; RUN: llc < %s -mtriple=i386-apple-darwin -relocation-model=static | FileCheck -check-prefix X86STA %s
 ; RUN: llc < %s -mtriple=i386-apple-darwin -relocation-model=pic | FileCheck -check-prefix X86PIC %s
 ; RUN: llc < %s -mtriple=i386-pc-linux -relocation-model=dynamic-no-pic | FileCheck -check-prefix X86DYN %s
+; RUN: llc < %s -mtriple=i386-pc-linux -relocation-model=pic | FileCheck -check-prefix X86ELFPIC %s
 ; RUN: llc < %s -mtriple=i386-pc-win32 -relocation-model=static | FileCheck -check-prefix X86WINSTA %s
 
 ; Call to immediate is not safe on x86-64 unless we *know* that the
@@ -21,5 +22,6 @@ entry:
 ; X86STA: {{call.*12345678}}
 ; X86PIC-NOT: {{call.*12345678}}
 ; X86DYN: {{call.*12345678}}
+; X86ELFPIC: {{call.*[*]%eax}}
 ; X86WINSTA: {{call.*[*]%eax}}
 ; X64: {{call.*[*]%rax}}


### PR DESCRIPTION
Causes problems with mold linker, and was determined to be a compiler bug. See:
See https://github.com/rui314/mold/pull/1601#issuecomment-4628653209