### PR TITLE
[Clang] Fixed an assertion when ``__attribute__((alloc_size))`` is ued with an argument type wider than the target's pointer width

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -672,6 +672,7 @@ Bug Fixes in This Version
 - Fixed a crash when ``#embed`` is used with C++ modules (#GH195350)
 - Fixed an issue where ``__typeof_unqual`` and ``__typeof_unqual__`` were rejected as a declaration specifier in block scope in C++.
 - Fixed crash when checking for overflow for unary operator that can't overflow (#GH170072)
+- Fixed an assertion when ``__attribute__((alloc_size))`` is used with an argument type wider than the target's pointer width. (#GH190445)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -3622,7 +3622,7 @@ CallExpr::evaluateBytesReturnedByAllocSizeCall(const ASTContext &Ctx) const {
     Into = ExprResult.Val.getInt();
     if (Into.isNegative() || !Into.isIntN(BitsInSizeT))
       return false;
-    Into = Into.zext(BitsInSizeT);
+    Into = Into.extOrTrunc(BitsInSizeT);
     return true;
   };
 

--- a/clang/test/Sema/warn-alloc-size.c
+++ b/clang/test/Sema/warn-alloc-size.c
@@ -44,3 +44,10 @@ void alloc_foo(void) {
   int *zero_alloc1 = my_malloc(0);
   int *zero_alloc2 = (int *)my_malloc(0);
 }
+
+void *my_malloc_wide(__int128) __attribute__((alloc_size(1)));
+
+void alloc_foo_wide(void) {
+  struct Foo *ptr = (struct Foo *)my_malloc_wide(sizeof(*ptr));
+  struct Foo *ptr_wrong = (struct Foo *)my_malloc_wide(4); // expected-warning {{allocation of insufficient size '4' for type 'struct Foo' with size '40'}}
+}


### PR DESCRIPTION
Replace `zext()` with `extOrTrunc()` when normalizing the `APInt` value to `BitsInSizeT`.

fix #190445 