### PR TITLE
[CodeGen] Add v2048bf16 vector type

### DIFF
--- a/llvm/include/llvm/CodeGen/ValueTypes.td
+++ b/llvm/include/llvm/CodeGen/ValueTypes.td
@@ -213,6 +213,7 @@ def v64bf16   : VTVec<64,   bf16>; //   64 x bf16 vector value
 def v128bf16  : VTVec<128,  bf16>; //  128 x bf16 vector value
 def v256bf16  : VTVec<256,  bf16>; //  256 x bf16 vector value
 def v512bf16  : VTVec<512,  bf16>; //  512 x bf16 vector value
+def v2048bf16 : VTVec<2048, bf16>; // 2048 x bf16 vector value
 def v4096bf16 : VTVec<4096, bf16>; // 4096 x bf16 vector value
 
 def v1f32    : VTVec<1,    f32>; //    1 x f32 vector value

--- a/llvm/test/TableGen/CPtrWildcard.td
+++ b/llvm/test/TableGen/CPtrWildcard.td
@@ -8,13 +8,13 @@
 // CHECK-NEXT:/*     3*/ OPC_CheckChild0Integer, [[#]],
 // CHECK-NEXT:/*     5*/ OPC_RecordChild1, // #0 = $src
 // CHECK-NEXT:/*     6*/ OPC_Scope /*2 children */, 9, // ->17
-// CHECK-NEXT:/*     8*/  OPC_CheckChild1Type, /*MVT::c64*/5|128,2/*261*/,
+// CHECK-NEXT:/*     8*/  OPC_CheckChild1Type, /*MVT::c64*/6|128,2/*262*/,
 // CHECK-NEXT:/*    11*/  OPC_MorphNodeTo1None, TARGET_VAL(MyTarget::C64_TO_I64),
 // CHECK-NEXT:                MVT::i64, 1/*#Ops*/, /*OperandList*/0, // Ops = #0
 // CHECK-NEXT:            // Src: (intrinsic_wo_chain:{ *:[i64] } [[#]]:{ *:[iPTR] }, c64:{ *:[c64] }:$src) - Complexity = 8
 // CHECK-NEXT:            // Dst: (C64_TO_I64:{ *:[i64] } ?:{ *:[c64] }:$src)
 // CHECK-NEXT:/*    17*/ /*Scope*/ 9, // ->27
-// CHECK-NEXT:/*    18*/  OPC_CheckChild1Type, /*MVT::c128*/6|128,2/*262*/,
+// CHECK-NEXT:/*    18*/  OPC_CheckChild1Type, /*MVT::c128*/7|128,2/*263*/,
 // CHECK-NEXT:/*    21*/  OPC_MorphNodeTo1None, TARGET_VAL(MyTarget::C128_TO_I64),
 // CHECK-NEXT:                MVT::i64, 1/*#Ops*/, /*OperandList*/0, // Ops = #0
 // CHECK-NEXT:            // Src: (intrinsic_wo_chain:{ *:[i64] } [[#]]:{ *:[iPTR] }, c128:{ *:[c128] }:$src) - Complexity = 8


### PR DESCRIPTION
Define v2048bf16 vector type in ValueTypes.td. This is useful for targets that support packed bf16 operations with large vector widths (e.g. Google TPU).