### PR TITLE
[AMDGPU] Apply target flag specifier when lowering MO_ExternalSymbol operands

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUMCInstLower.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMCInstLower.cpp
@@ -103,7 +103,8 @@ bool AMDGPUMCInstLower::lowerOperand(const MachineOperand &MO,
   }
   case MachineOperand::MO_ExternalSymbol: {
     MCSymbol *Sym = Ctx.getOrCreateSymbol(StringRef(MO.getSymbolName()));
-    const MCSymbolRefExpr *Expr = MCSymbolRefExpr::create(Sym, Ctx);
+    const MCExpr *Expr =
+        MCSymbolRefExpr::create(Sym, getSpecifier(MO.getTargetFlags()), Ctx);
     MCOp = MCOperand::createExpr(Expr);
     return true;
   }

--- a/llvm/test/CodeGen/AMDGPU/mcinstlower-external-symbol-reloc.mir
+++ b/llvm/test/CodeGen/AMDGPU/mcinstlower-external-symbol-reloc.mir
@@ -1,0 +1,19 @@
+# RUN: llc -mtriple=amdgcn -mcpu=gfx900 -start-after=prologepilog %s -o - | FileCheck --check-prefix=ASM %s
+# RUN: llc -mtriple=amdgcn -mcpu=gfx900 -start-after=prologepilog -filetype=obj %s -o %t.o && llvm-readobj -r %t.o | FileCheck --check-prefix=ELF %s
+
+# AMDGPUMCInstLower must apply the operand's target flag specifier when
+# lowering an MO_ExternalSymbol operand, just like it does for
+# MO_GlobalAddress.
+
+# ASM: s_mov_b32 s0, external_sym@abs32@lo
+
+# ELF: R_AMDGPU_ABS32_LO external_sym{{$}}
+
+---
+name: external_symbol_reloc
+tracksRegLiveness: true
+body: |
+  bb.0:
+    $sgpr0 = S_MOV_B32 target-flags(amdgpu-abs32-lo) &external_sym, implicit-def $scc
+    S_ENDPGM 0
+...


### PR DESCRIPTION
The MO_ExternalSymbol case in AMDGPUMCInstLower dropped the operand target flags emitting the wrong relocation type