### PR TITLE
[clang][nvlink] Forward -z <keyword> to nvlink instead of parsing as input

### DIFF
--- a/clang/test/OffloadTools/clang-nvlink-wrapper/nvlink-wrapper.c
+++ b/clang/test/OffloadTools/clang-nvlink-wrapper/nvlink-wrapper.c
@@ -47,6 +47,14 @@ int baz() { return y + x; }
 // ARGS: nvlink{{.*}} -arch sm_52 -foo -o a.out [[INPUT:.+]].cubin
 
 //
+// Check that '-z <keyword>' is forwarded to 'nvlink' as a unit and that the
+// keyword is not mistaken for an input file.
+//
+// RUN: clang-nvlink-wrapper --dry-run --assume-device-object -arch sm_52 %t-u.o \
+// RUN:   -z relro -z now -o a.out 2>&1 | FileCheck %s --check-prefix=ZOPT
+// ZOPT: nvlink{{.*}} -arch sm_52 -z relro -z now -o a.out [[INPUT:.+]].cubin
+
+//
 // Check the symbol resolution for static archives. We expect to only link
 // `libx.a` and `liby.a` because extern weak symbols do not extract and `libz.a`
 // is not used at all.

--- a/clang/tools/clang-nvlink-wrapper/NVLinkOpts.td
+++ b/clang/tools/clang-nvlink-wrapper/NVLinkOpts.td
@@ -58,6 +58,9 @@ def lto_emit_asm : Flag<["--"], "lto-emit-asm">, Flags<[WrapperOnlyOption]>,
 def u : JoinedOrSeparate<["-"], "u">, HelpText<"Force undefined symbol during linking">;
 def undefined : JoinedOrSeparate<["--"], "undefined">, Alias<u>;
 
+def z : JoinedOrSeparate<["-"], "z">, MetaVarName<"<keyword>">,
+  HelpText<"Forwarded to 'nvlink' (e.g. -z relro / -z now)">;
+
 def O : Joined<["--", "-"], "plugin-opt=O">,
   Flags<[WrapperOnlyOption]>, MetaVarName<"<O0, O1, O2, or O3>">,
   HelpText<"Optimization level for LTO">;


### PR DESCRIPTION
clang-nvlink-wrapper forwards any option it does not handle to nvlink.
This relies on LLVM's OptTable correctly tokenizing the command line, but
OptTable only recognizes options declared in NVLinkOpts.td. Because -z was
never declared, the parser had no way to know it takes a value, so it split
"-z relro" into two tokens: "-z" (UNKNOWN, forwarded) and "relro" (a bare
prefix-less word classified as OPT_INPUT, indistinguishable from an input
file). The orphaned "relro" then flowed into getInput() and
resolveArchiveMembers(), which fails with "input file not found: 'relro'".

Declare -z as a JoinedOrSeparate option (without WrapperOnlyOption) so the
parser keeps -z bound to its keyword and the existing forward-by-exclusion
loop renders "-z relro" to nvlink as a unit. The clang driver emits these
via hardening flags like -Wl,-z,relro / -Wl,-z,now.

Co-Authored-By: Claude