### PR TITLE
[InstCombine] Drop non-power-of-two alignment assumptions

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -3158,8 +3158,7 @@ The following attributes are currently accepted:
   Equivalent to :ref:`align(%align) <attr_align>` on ``%p``, or ``%p - %offset``
   if the ``%offset`` argument exists, except that ``%align`` may be a
   non-power-of-two alignment (including a zero alignment). If ``%align`` is not
-  a power of two the pointer value must be all-zero. Otherwise the behavior is
-  undefined.
+  a power of two the bundle is meaningless.
 
 ``"cold"()``
   Equivalent to :ref:`cold <attr_cold>`.

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -3158,7 +3158,8 @@ The following attributes are currently accepted:
   Equivalent to :ref:`align(%align) <attr_align>` on ``%p``, or ``%p - %offset``
   if the ``%offset`` argument exists, except that ``%align`` may be a
   non-power-of-two alignment (including a zero alignment). If ``%align`` is not
-  a power of two the bundle is meaningless.
+  a power of two the pointer value must be all-zero. Otherwise the behavior is
+  undefined.
 
 ``"cold"()``
   Equivalent to :ref:`cold <attr_cold>`.

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3659,7 +3659,7 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
         if (!Alignment || !Offset || *Offset != 0)
           break;
 
-        // Remove align 1 and non-power-of-wto bundles; they don't add any
+        // Remove align 1 and non-power-of-two bundles; they don't add any
         // useful information.
         if (*Alignment == 1 || !isPowerOf2_64(*Alignment))
           return CallBase::removeOperandBundleAt(II, Idx);

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3656,11 +3656,12 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
         // Try to remove redundant alignment assumptions.
         auto [Ptr, _, Alignment, Offset] = getAssumeAlignInfo(OBU);
 
-        if (!Alignment || !Offset || *Offset != 0 || !isPowerOf2_64(*Alignment))
+        if (!Alignment || !Offset || *Offset != 0)
           break;
 
-        // Remove align 1 bundles; they don't add any useful information.
-        if (*Alignment == 1)
+        // Remove align 1 and non-power-of-wto bundles; they don't add any
+        // useful information.
+        if (*Alignment == 1 || !isPowerOf2_64(*Alignment))
           return CallBase::removeOperandBundleAt(II, Idx);
 
         // Don't try to remove align assumptions for pointers derived from

--- a/llvm/test/Transforms/InstCombine/assume-align.ll
+++ b/llvm/test/Transforms/InstCombine/assume-align.ll
@@ -103,8 +103,7 @@ declare void @g(i64)
 
 define i8 @assume_align_zero(ptr %p) {
 ; CHECK-LABEL: @assume_align_zero(
-; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "align"(ptr [[P:%.*]], i64 0) ]
-; CHECK-NEXT:    [[V:%.*]] = load i8, ptr [[P]], align 1
+; CHECK-NEXT:    [[V:%.*]] = load i8, ptr [[P:%.*]], align 1
 ; CHECK-NEXT:    ret i8 [[V]]
 ;
   call void @llvm.assume(i1 true) [ "align"(ptr %p, i64 0) ]
@@ -114,8 +113,7 @@ define i8 @assume_align_zero(ptr %p) {
 
 define i8 @assume_align_non_pow2(ptr %p) {
 ; CHECK-LABEL: @assume_align_non_pow2(
-; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "align"(ptr [[P:%.*]], i64 123) ]
-; CHECK-NEXT:    [[V:%.*]] = load i8, ptr [[P]], align 1
+; CHECK-NEXT:    [[V:%.*]] = load i8, ptr [[P:%.*]], align 1
 ; CHECK-NEXT:    ret i8 [[V]]
 ;
   call void @llvm.assume(i1 true) [ "align"(ptr %p, i64 123) ]
@@ -152,7 +150,6 @@ define ptr @dont_fold_assume_align_pow2_of_loaded_pointer_into_align_metadata_du
 define ptr @dont_fold_assume_align_non_pow2_of_loaded_pointer_into_align_metadata(ptr %p) {
 ; CHECK-LABEL: @dont_fold_assume_align_non_pow2_of_loaded_pointer_into_align_metadata(
 ; CHECK-NEXT:    [[P2:%.*]] = load ptr, ptr [[P:%.*]], align 8
-; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "align"(ptr [[P2]], i64 13) ]
 ; CHECK-NEXT:    ret ptr [[P2]]
 ;
   %p2 = load ptr, ptr %p
@@ -164,7 +161,6 @@ define ptr @dont_fold_assume_align_non_pow2_of_loaded_pointer_into_align_metadat
 define ptr @dont_fold_assume_align_zero_of_loaded_pointer_into_align_metadata(ptr %p) {
 ; CHECK-LABEL: @dont_fold_assume_align_zero_of_loaded_pointer_into_align_metadata(
 ; CHECK-NEXT:    [[P2:%.*]] = load ptr, ptr [[P:%.*]], align 8
-; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "align"(ptr [[P2]], i64 0) ]
 ; CHECK-NEXT:    ret ptr [[P2]]
 ;
   %p2 = load ptr, ptr %p

--- a/llvm/test/Transforms/InstCombine/assume.ll
+++ b/llvm/test/Transforms/InstCombine/assume.ll
@@ -204,6 +204,14 @@ define void @redundant_align() {
   ret void
 }
 
+define void @non_power_of_two_align(ptr %ptr) {
+; CHECK-LABEL: @non_power_of_two_align(
+; CHECK-NEXT:    ret void
+;
+  call void @llvm.assume(i1 true) [ "align"(ptr %ptr, i64 3) ]
+  ret void
+}
+
 ; Same check as in @foo1, but make sure it works if the assume is first too.
 
 define i32 @foo2(ptr %a) #0 {


### PR DESCRIPTION
These assumptions aren't actually used anywhere, so we might as well drop them. We might want consider emitting an assumption that the value is zero at some point, but we don't have the bundles for that currently and it seems rather low priority.