### PR TITLE
[VPlan] Use RUN_VPLAN_PASS for more VPlan transforms.

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -5896,9 +5896,9 @@ DenseMap<const SCEV *, Value *> LoopVectorizationPlanner::executePlan(
   if (BestVPlan.hasEarlyExit())
     ++LoopsEarlyExitVectorized;
 
-  VPlanTransforms::replaceWideCanonicalIVWithWideIV(
-      BestVPlan, *PSE.getSE(), CM.TTI, Config.CostKind, BestVF, BestUF,
-      CM.ValuesToIgnore);
+  RUN_VPLAN_PASS(VPlanTransforms::replaceWideCanonicalIVWithWideIV, BestVPlan,
+                 *PSE.getSE(), CM.TTI, Config.CostKind, BestVF, BestUF,
+                 CM.ValuesToIgnore);
   // TODO: Move to VPlan transform stage once the transition to the VPlan-based
   // cost model is complete for better cost estimates.
   RUN_VPLAN_PASS(VPlanTransforms::unrollByUF, BestVPlan, BestUF);
@@ -5915,9 +5915,9 @@ DenseMap<const SCEV *, Value *> LoopVectorizationPlanner::executePlan(
 
   if (CM.maskPartialAliasing()) {
     assert(CM.foldTailByMasking() && "Expected tail folding to be enabled");
-    VPlanTransforms::materializeAliasMaskCheckBlock(
-        BestVPlan, *CM.Legal->getRuntimePointerChecking()->getDiffChecks(),
-        HasBranchWeights);
+    RUN_VPLAN_PASS(VPlanTransforms::materializeAliasMaskCheckBlock, BestVPlan,
+                   *CM.Legal->getRuntimePointerChecking()->getDiffChecks(),
+                   HasBranchWeights);
     ++LoopsPartialAliasVectorized;
   }
 
@@ -6597,7 +6597,8 @@ void LoopVectorizationPlanner::buildVPlans(VPlan &VPlan1, ElementCount MinVF,
       RUN_VPLAN_PASS(VPlanTransforms::optimizeEVLMasks, *Plan);
     }
 
-    if (auto P = VPlanTransforms::narrowInterleaveGroups(*Plan, TTI))
+    if (auto P =
+            RUN_VPLAN_PASS(VPlanTransforms::narrowInterleaveGroups, *Plan, TTI))
       VPlans.push_back(std::move(P));
 
     RUN_VPLAN_PASS_NO_VERIFY(printOptimizedVPlan, *Plan);
@@ -6615,10 +6616,11 @@ VPlanPtr LoopVectorizationPlanner::tryToBuildVPlan(VPlanPtr Plan,
   if (Plan->isOuterLoop()) {
     for (ElementCount VF : Range)
       Plan->addVF(VF);
-    if (!VPlanTransforms::tryToConvertVPInstructionsToVPRecipes(*Plan, *TLI))
+    if (!RUN_VPLAN_PASS(VPlanTransforms::tryToConvertVPInstructionsToVPRecipes,
+                        *Plan, *TLI))
       return nullptr;
-    VPlanTransforms::optimizeInductionLiveOutUsers(*Plan, PSE,
-                                                   /*FoldTail=*/false);
+    RUN_VPLAN_PASS(VPlanTransforms::optimizeInductionLiveOutUsers, *Plan, PSE,
+                   /*FoldTail=*/false);
     return Plan;
   }
 

--- a/llvm/test/Transforms/LoopVectorize/VPlan/vplan-print-after-all.ll
+++ b/llvm/test/Transforms/LoopVectorize/VPlan/vplan-print-after-all.ll
@@ -49,8 +49,10 @@
 ; CHECK: VPlan for loop in 'foo' after mergeBlocksIntoPredecessors
 ; CHECK: VPlan for loop in 'foo' after licm
 ; CHECK: VPlan for loop in 'foo' after VPlanTransforms::optimize
+; CHECK: VPlan for loop in 'foo' after VPlanTransforms::narrowInterleaveGroups
 ; CHECK: VPlan for loop in 'foo' after printOptimizedVPlan
 ; CHECK: VPlan for loop in 'foo' after VPlanTransforms::addMinimumIterationCheck
+; CHECK: VPlan for loop in 'foo' after VPlanTransforms::replaceWideCanonicalIVWithWideIV
 ; CHECK: VPlan for loop in 'foo' after VPlanTransforms::unrollByUF
 ; CHECK: VPlan for loop in 'foo' after VPlanTransforms::materializePacksAndUnpacks
 ; CHECK: VPlan for loop in 'foo' after VPlanTransforms::materializeBroadcasts


### PR DESCRIPTION
Convert additional VPlan transform invocations to use RUN_VPLAN_PASS: replaceWideCanonicalIVWithWideIV, materializeAliasMaskCheckBlock, narrowInterleaveGroups, tryToConvertVPInstructionsToVPRecipes and optimizeInductionLiveOutUsers. This enables more accurate transform printing as well as extra verification.

The transforms in executePlan after dissolveLoopRegions are left as-is, as the verifier does not yet handle the intermediate dissolved states.