### PR TITLE
[Frontend][Offloading] Restore silent ignore for non-existing input files in nvlink (#202352)

### DIFF
--- a/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
+++ b/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
@@ -208,6 +208,16 @@ getInput(const ArgList &Args) {
                          ? offloading::InputDesc::Kind::Library
                          : offloading::InputDesc::Kind::File;
     Desc.WholeArchive = WholeArchive;
+
+    // Validate positional file inputs exist before passing to
+    // resolveArchiveMembers (which silently skips non-existent paths).
+    if (Desc.InputKind == offloading::InputDesc::Kind::File) {
+      if (!sys::fs::exists(Desc.Value))
+        return createStringError("input file not found: '" + Desc.Value + "'");
+      if (sys::fs::is_directory(Desc.Value))
+        return createStringError("'" + Desc.Value + "': Is a directory");
+    }
+
     InputDescs.push_back(Desc);
   }
 

--- a/llvm/lib/Frontend/Offloading/ArchiveLinker.cpp
+++ b/llvm/lib/Frontend/Offloading/ArchiveLinker.cpp
@@ -214,10 +214,8 @@ resolveArchiveMembers(ArrayRef<InputDesc> Order,
       if (sys::fs::is_directory(*Filename))
         return createStringError("'%s': Is a directory", Filename->c_str());
     } else {
-      if (!sys::fs::exists(Desc.Value))
-        return createStringError("input file not found: '" + Desc.Value + "'");
-      if (sys::fs::is_directory(Desc.Value))
-        return createStringError("'" + Desc.Value + "': Is a directory");
+      if (!sys::fs::exists(Desc.Value) || sys::fs::is_directory(Desc.Value))
+        continue;
       Filename = Desc.Value.str();
     }
 


### PR DESCRIPTION
Partially revert commit https://github.com/llvm/llvm-project/commit/a0ccab35110951afc9adc5d7dc733ba8c58cf3f9 to restore
the original behavior of silently skipping non-existent positional input files
in resolveArchiveMembers(), while preserving strict validation in
clang-sycl-linker.

Background:
The original commit added error reporting for non-existent input files in the
shared resolveArchiveMembers() function to catch genuine user errors. However,
this broke clang-nvlink-wrapper when unrecognized options were misparsed as
input files (e.g., "relro" from "-z relro" before the -z option was properly
declared in NVLinkOpts.td).

Temporary solution:
- Restore the silent skip behavior in resolveArchiveMembers() for positional
  input files that don't exist or are directories
- Move the input validation to clang-sycl-linker's getInput() function, where
  strict checking is appropriate for SYCL's more controlled linking environment
- This preserves the existing test expectations:
  * clang-nvlink-wrapper silently ignores non-existent inputs
  * clang-sycl-linker reports "input file not found" errors

See discussion: https://github.com/llvm/llvm-project/pull/201253#discussion_r3364244664
 and comment https://github.com/llvm/llvm-project/pull/201253#issuecomment-4651284736.

Co-Authored-By: Claude