### PR TITLE
[BitstreamReader] Fix 32-bit overflow in skipRecord

### DIFF
--- a/llvm/lib/Bitstream/Reader/BitstreamReader.cpp
+++ b/llvm/lib/Bitstream/Reader/BitstreamReader.cpp
@@ -195,7 +195,8 @@ Expected<unsigned> BitstreamCursor::skipRecord(unsigned AbbrevID) {
     SkipToFourByteBoundary();  // 32-bit alignment
 
     // Figure out where the end of this blob will be including tail padding.
-    const size_t NewEnd = GetCurrentBitNo() + alignTo(NumElts, 4) * 8;
+    const size_t NewEnd =
+        GetCurrentBitNo() + static_cast<uint64_t>(alignTo(NumElts, 4)) * 8;
 
     // If this would read off the end of the bitcode file, just set the
     // record to empty and return.


### PR DESCRIPTION
Follow up on #117363, which landed the fix in `readRecord`. The same fix applies to `skipRecord`.