### PR TITLE
Revert "[docs] update CI to use latest release of doxygen"

### DIFF
--- a/.github/workflows/release-doxygen.yml
+++ b/.github/workflows/release-doxygen.yml
@@ -93,17 +93,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
+              doxygen \
               graphviz \
               python3-github \
               ninja-build \
               texlive-font-utils
           pip3 install --require-hashes --user -r ./llvm/docs/requirements.txt
-
-      - name: Install Doxygen
-        run: |
-          curl -L https://github.com/doxygen/doxygen/releases/download/Release_1_17_0/doxygen-1.17.0.linux.bin.tar.gz -o doxygen.tar.gz
-          tar -xf doxygen.tar.gz
-          sudo install -m 755 doxygen-1.17.0/bin/doxygen /usr/local/bin/doxygen
 
       - name: Build Doxygen
         env:

--- a/bolt/docs/CMakeLists.txt
+++ b/bolt/docs/CMakeLists.txt
@@ -48,8 +48,8 @@ if (LLVM_ENABLE_DOXYGEN)
     set(bolt_doxygen_qhp_cust_filter_attrs "")
   endif()
 
-  include(HandleDoxygen)
-  llvm_configure_doxygen()
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doxygen.cfg.in
+    ${CMAKE_CURRENT_BINARY_DIR}/doxygen.cfg @ONLY)
 
   set(abs_top_srcdir)
   set(abs_top_builddir)

--- a/bolt/docs/doxygen.cfg.in
+++ b/bolt/docs/doxygen.cfg.in
@@ -392,8 +392,6 @@ LOOKUP_CACHE_SIZE      = 0
 # Build related configuration options
 #---------------------------------------------------------------------------
 
-NUM_PROC_THREADS       = @DOXYGEN_NUM_PROC_THREADS@
-
 # If the EXTRACT_ALL tag is set to YES doxygen will assume all entities in
 # documentation are documented, even if no documentation was available. Private
 # class members and static file members will be hidden unless the

--- a/clang-tools-extra/docs/CMakeLists.txt
+++ b/clang-tools-extra/docs/CMakeLists.txt
@@ -46,8 +46,8 @@ if (DOXYGEN_FOUND)
       set(clang_tools_doxygen_qhp_cust_filter_attrs "")
     endif()
 
-    include(HandleDoxygen)
-    llvm_configure_doxygen()
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doxygen.cfg.in
+      ${CMAKE_CURRENT_BINARY_DIR}/doxygen.cfg @ONLY)
 
     set(abs_top_srcdir)
     set(abs_top_builddir)

--- a/clang-tools-extra/docs/doxygen.cfg.in
+++ b/clang-tools-extra/docs/doxygen.cfg.in
@@ -390,8 +390,6 @@ LOOKUP_CACHE_SIZE      = 2
 # Build related configuration options
 #---------------------------------------------------------------------------
 
-NUM_PROC_THREADS       = @DOXYGEN_NUM_PROC_THREADS@
-
 # If the EXTRACT_ALL tag is set to YES doxygen will assume all entities in
 # documentation are documented, even if no documentation was available. Private
 # class members and static file members will be hidden unless the

--- a/clang/docs/CMakeLists.txt
+++ b/clang/docs/CMakeLists.txt
@@ -47,8 +47,8 @@ if (LLVM_ENABLE_DOXYGEN)
     set(clang_doxygen_qhp_cust_filter_attrs "")
   endif()
 
-  include(HandleDoxygen)
-  llvm_configure_doxygen()
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doxygen.cfg.in
+    ${CMAKE_CURRENT_BINARY_DIR}/doxygen.cfg @ONLY)
 
   set(abs_top_srcdir)
   set(abs_top_builddir)

--- a/clang/docs/doxygen.cfg.in
+++ b/clang/docs/doxygen.cfg.in
@@ -390,8 +390,6 @@ LOOKUP_CACHE_SIZE      = 3
 # Build related configuration options
 #---------------------------------------------------------------------------
 
-NUM_PROC_THREADS       = @DOXYGEN_NUM_PROC_THREADS@
-
 # If the EXTRACT_ALL tag is set to YES doxygen will assume all entities in
 # documentation are documented, even if no documentation was available. Private
 # class members and static file members will be hidden unless the

--- a/cmake/Modules/HandleDoxygen.cmake
+++ b/cmake/Modules/HandleDoxygen.cmake
@@ -17,9 +17,9 @@ function(llvm_find_program name)
 endfunction()
 
 if (LLVM_ENABLE_DOXYGEN)
+  message(STATUS "Doxygen enabled.")
   llvm_find_program(dot)
   find_package(Doxygen REQUIRED)
-  message(STATUS "Doxygen enabled (${DOXYGEN_VERSION}).")
 
   if (DOXYGEN_FOUND)
     # If we find doxygen and we want to enable doxygen by default create a
@@ -35,22 +35,6 @@ if (LLVM_ENABLE_DOXYGEN)
       set(LLVM_DOXYGEN_SEARCH_MAPPINGS "" CACHE STRING "Doxygen Search Mappings")
     endif()
   endif()
-
-  # Uses all CPUs for doxygen >= 1.17 where multi-threading is fast, and
-  # single-threaded (1) for older versions where multi-threading is slower than
-  # single-threaded.
-  if (DOXYGEN_VERSION VERSION_GREATER_EQUAL "1.17")
-    set(DOXYGEN_NUM_PROC_THREADS 0)
-  else()
-    set(DOXYGEN_NUM_PROC_THREADS 1)
-  endif()
 else()
   message(STATUS "Doxygen disabled.")
 endif()
-
-# Configure doxygen.cfg.in -> doxygen.cfg, using a macro here to ensure that
-# DOXYGEN_NUM_PROC_THREADS has been set.
-macro(llvm_configure_doxygen)
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doxygen.cfg.in
-    ${CMAKE_CURRENT_BINARY_DIR}/doxygen.cfg @ONLY)
-endmacro()

--- a/flang/docs/CMakeLists.txt
+++ b/flang/docs/CMakeLists.txt
@@ -48,8 +48,8 @@ if (LLVM_ENABLE_DOXYGEN)
     set(flang_doxygen_qhp_cust_filter_attrs "")
   endif()
 
-  include(HandleDoxygen)
-  llvm_configure_doxygen()
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doxygen.cfg.in
+    ${CMAKE_CURRENT_BINARY_DIR}/doxygen.cfg @ONLY)
 
   set(abs_top_srcdir)
   set(abs_top_builddir)

--- a/flang/docs/doxygen.cfg.in
+++ b/flang/docs/doxygen.cfg.in
@@ -392,8 +392,6 @@ LOOKUP_CACHE_SIZE      = 0
 # Build related configuration options
 #---------------------------------------------------------------------------
 
-NUM_PROC_THREADS       = @DOXYGEN_NUM_PROC_THREADS@
-
 # If the EXTRACT_ALL tag is set to YES doxygen will assume all entities in
 # documentation are documented, even if no documentation was available. Private
 # class members and static file members will be hidden unless the

--- a/lldb/docs/CMakeLists.txt
+++ b/lldb/docs/CMakeLists.txt
@@ -5,8 +5,8 @@ if(DOXYGEN_FOUND)
   set(DOT dot)
   set(PACKAGE_VERSION mainline)
   set(abs_top_builddir ..)
-  include(HandleDoxygen)
-  llvm_configure_doxygen()
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doxygen.cfg.in
+  ${CMAKE_CURRENT_BINARY_DIR}/doxygen.cfg @ONLY)
 
   add_custom_target(lldb-cpp-doc
     ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/doxygen.cfg

--- a/lldb/docs/doxygen.cfg.in
+++ b/lldb/docs/doxygen.cfg.in
@@ -293,8 +293,6 @@ SYMBOL_CACHE_SIZE      = 0
 # Build related configuration options
 #---------------------------------------------------------------------------
 
-NUM_PROC_THREADS       = @DOXYGEN_NUM_PROC_THREADS@
-
 # If the EXTRACT_ALL tag is set to YES doxygen will assume all entities in
 # documentation are documented, even if no documentation was available.
 # Private class members and static file members will be hidden unless

--- a/llvm/docs/CMakeLists.txt
+++ b/llvm/docs/CMakeLists.txt
@@ -56,8 +56,8 @@ if (LLVM_ENABLE_DOXYGEN)
     set(llvm_doxygen_qhp_cust_filter_attrs "")
   endif()
 
-  include(HandleDoxygen)
-  llvm_configure_doxygen()
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doxygen.cfg.in
+    ${CMAKE_CURRENT_BINARY_DIR}/doxygen.cfg @ONLY)
 
   set(abs_top_srcdir)
   set(abs_top_builddir)

--- a/llvm/docs/doxygen.cfg.in
+++ b/llvm/docs/doxygen.cfg.in
@@ -391,8 +391,6 @@ LOOKUP_CACHE_SIZE      = 4
 # Build related configuration options
 #---------------------------------------------------------------------------
 
-NUM_PROC_THREADS       = @DOXYGEN_NUM_PROC_THREADS@
-
 # If the EXTRACT_ALL tag is set to YES doxygen will assume all entities in
 # documentation are documented, even if no documentation was available. Private
 # class members and static file members will be hidden unless the

--- a/mlir/docs/CMakeLists.txt
+++ b/mlir/docs/CMakeLists.txt
@@ -47,8 +47,8 @@ if (LLVM_ENABLE_DOXYGEN)
     set(mlir_doxygen_qhp_cust_filter_attrs "")
   endif()
 
-  include(HandleDoxygen)
-  llvm_configure_doxygen()
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doxygen.cfg.in
+    ${CMAKE_CURRENT_BINARY_DIR}/doxygen.cfg @ONLY)
 
   set(abs_top_srcdir)
   set(abs_top_builddir)

--- a/mlir/docs/doxygen.cfg.in
+++ b/mlir/docs/doxygen.cfg.in
@@ -391,8 +391,6 @@ LOOKUP_CACHE_SIZE      = 4
 # Build related configuration options
 #---------------------------------------------------------------------------
 
-NUM_PROC_THREADS       = @DOXYGEN_NUM_PROC_THREADS@
-
 # If the EXTRACT_ALL tag is set to YES doxygen will assume all entities in
 # documentation are documented, even if no documentation was available. Private
 # class members and static file members will be hidden unless the

--- a/openmp/docs/CMakeLists.txt
+++ b/openmp/docs/CMakeLists.txt
@@ -47,8 +47,8 @@ if (LLVM_ENABLE_DOXYGEN)
     set(openmp_doxygen_qhp_cust_filter_attrs "")
   endif()
 
-  include(HandleDoxygen)
-  llvm_configure_doxygen()
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doxygen.cfg.in
+    ${CMAKE_CURRENT_BINARY_DIR}/doxygen.cfg @ONLY)
 
   set(abs_top_srcdir)
   set(abs_top_builddir)

--- a/openmp/docs/doxygen.cfg.in
+++ b/openmp/docs/doxygen.cfg.in
@@ -390,8 +390,6 @@ LOOKUP_CACHE_SIZE      = 3
 # Build related configuration options
 #---------------------------------------------------------------------------
 
-NUM_PROC_THREADS       = @DOXYGEN_NUM_PROC_THREADS@
-
 # If the EXTRACT_ALL tag is set to YES doxygen will assume all entities in
 # documentation are documented, even if no documentation was available. Private
 # class members and static file members will be hidden unless the

--- a/polly/docs/CMakeLists.txt
+++ b/polly/docs/CMakeLists.txt
@@ -46,8 +46,8 @@ if (LLVM_ENABLE_DOXYGEN)
     set(polly_doxygen_qhp_cust_filter_attrs "")
   endif()
 
-  include(HandleDoxygen)
-  llvm_configure_doxygen()
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doxygen.cfg.in
+    ${CMAKE_CURRENT_BINARY_DIR}/doxygen.cfg @ONLY)
 
   set(abs_top_srcdir)
   set(abs_top_builddir)

--- a/polly/docs/doxygen.cfg.in
+++ b/polly/docs/doxygen.cfg.in
@@ -390,8 +390,6 @@ LOOKUP_CACHE_SIZE      = 2
 # Build related configuration options
 #---------------------------------------------------------------------------
 
-NUM_PROC_THREADS       = @DOXYGEN_NUM_PROC_THREADS@
-
 # If the EXTRACT_ALL tag is set to YES doxygen will assume all entities in
 # documentation are documented, even if no documentation was available. Private
 # class members and static file members will be hidden unless the


### PR DESCRIPTION
Reverts llvm/llvm-project#191501 as cmake CI is having an issue with it:

```
-- Doxygen enabled (1.14.0).
CMake Error at /work/as-worker-4/publish-doxygen-docs/llvm-project/cmake/Modules/HandleDoxygen.cmake:29 (add_custom_target):
  add_custom_target cannot create target "doxygen" because another target
  with the same name already exists.  The existing target is a custom target
  created in source directory
  "/work/as-worker-4/publish-doxygen-docs/llvm-project/llvm".  See
  documentation for policy CMP0002 for more details.
Call Stack (most recent call first):
  docs/CMakeLists.txt:59 (include)
```