### PR TITLE
[mlir][acc] Format consistency for reduction accumulate

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
@@ -153,7 +153,7 @@ def OpenACC_ReductionAccumulateOp
       }
     } {acc.par_dims = #acc<par_dims[thread_x]>}
     acc.reduction_accumulate %partial to %private <add>
-        : f32 -> memref<i32> {par_dims = #acc<par_dims[thread_x]>}
+        : i32 -> memref<i32> {par_dims = #acc<par_dims[thread_x]>}
     acc.reduction_combine %private into %shared <add> : memref<i32>
         {acc.par_dims = #acc<par_dims[thread_x]>}
     ```

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCCGOps.td
@@ -152,8 +152,8 @@ def OpenACC_ReductionAccumulateOp
         scf.reduce.return %sum : i32
       }
     } {acc.par_dims = #acc<par_dims[thread_x]>}
-    acc.reduction_accumulate (%partial) to (%private) <add>
-        : (i32) -> (memref<i32>) {par_dims = #acc<par_dims[thread_x]>}
+    acc.reduction_accumulate %partial to %private <add>
+        : f32 -> memref<i32> {par_dims = #acc<par_dims[thread_x]>}
     acc.reduction_combine %private into %shared <add> : memref<i32>
         {acc.par_dims = #acc<par_dims[thread_x]>}
     ```
@@ -165,7 +165,7 @@ def OpenACC_ReductionAccumulateOp
                        OpenACC_ReductionOperatorAttr:$reductionOperator,
                        OpenACC_GPUParallelDimsAttr:$par_dims);
   let assemblyFormat = [{
-    `(` $value `)` `to` `(` $memref `)` $reductionOperator `:` `(` type($value) `)` `->` `(` type($memref) `)` attr-dict
+    $value `to` $memref $reductionOperator `:` type($value) `->` type($memref) attr-dict
   }];
   let hasVerifier = 1;
 }

--- a/mlir/test/Dialect/OpenACC/invalid-cg.mlir
+++ b/mlir/test/Dialect/OpenACC/invalid-cg.mlir
@@ -44,8 +44,8 @@ acc.compute_region launch(%arg0 = %c32) {
 func.func @reduction_accumulate_invalid_operator() {
   %partial = arith.constant 1.0 : f32
   %private = memref.alloca() : memref<f32>
-  acc.reduction_accumulate (%partial) to (%private) <addi>
-      : (f32) -> (memref<f32>) {par_dims = #acc<par_dims[thread_x]>}
+  acc.reduction_accumulate %partial to %private <addi>
+      : f32 -> memref<f32> {par_dims = #acc<par_dims[thread_x]>}
   // expected-error@-2 {{expected ::mlir::acc::ReductionOperator to be one of}}
   // expected-error@-3 {{failed to parse OpenACC_ReductionOperatorAttr}}
   return
@@ -57,8 +57,8 @@ func.func @reduction_accumulate_type_mismatch() {
   %wrong_ty = arith.constant 3.0 : f32
   %private_i32 = memref.alloca() : memref<i32>
   // expected-error@+1 {{pointer-like element type must match value type}}
-  acc.reduction_accumulate (%wrong_ty) to (%private_i32) <add>
-      : (f32) -> (memref<i32>) {par_dims = #acc<par_dims[thread_x]>}
+  acc.reduction_accumulate %wrong_ty to %private_i32 <add>
+      : f32 -> memref<i32> {par_dims = #acc<par_dims[thread_x]>}
   return
 }
 
@@ -68,7 +68,7 @@ func.func @reduction_accumulate_empty_par_dims() {
   %partial3 = arith.constant 4 : i32
   %private4 = memref.alloca() : memref<i32>
   // expected-error@+1 {{par_dims must specify at least one parallel dimension}}
-  acc.reduction_accumulate (%partial3) to (%private4) <add>
-      : (i32) -> (memref<i32>) {par_dims = #acc<par_dims[]>}
+  acc.reduction_accumulate %partial3 to %private4 <add>
+      : i32 -> memref<i32> {par_dims = #acc<par_dims[]>}
   return
 }

--- a/mlir/test/Dialect/OpenACC/ops-cg.mlir
+++ b/mlir/test/Dialect/OpenACC/ops-cg.mlir
@@ -286,8 +286,8 @@ func.func @parallel_reduction_pattern(%data: memref<8xi32>, %shared: memref<i32>
       scf.reduce.return %sum : i32
     }
   } {acc.par_dims = #acc<par_dims[thread_x]>}
-  acc.reduction_accumulate (%partial) to (%private) <add>
-      : (i32) -> (memref<i32>) {par_dims = #acc<par_dims[thread_x]>}
+  acc.reduction_accumulate %partial to %private <add>
+      : i32 -> memref<i32> {par_dims = #acc<par_dims[thread_x]>}
   acc.reduction_combine %private into %shared <add> : memref<i32>
       {acc.par_dims = #acc<par_dims[thread_x]>}
   return
@@ -295,28 +295,28 @@ func.func @parallel_reduction_pattern(%data: memref<8xi32>, %shared: memref<i32>
 // CHECK: memref.alloca() {acc.par_dims = #acc<par_dims[thread_x]>}
 // CHECK: scf.parallel
 // CHECK: scf.reduce
-// CHECK: acc.reduction_accumulate(%{{.*}}) to(%{{.*}}) <add> : (i32) -> (memref<i32>) {par_dims = #acc<par_dims[thread_x]>}
+// CHECK: acc.reduction_accumulate %{{.*}} to %{{.*}} <add> : i32 -> memref<i32> {par_dims = #acc<par_dims[thread_x]>}
 // CHECK: acc.reduction_combine %{{.*}} into %{{.*}} <add> : memref<i32> {acc.par_dims = #acc<par_dims[thread_x]>}
 
 // -----
 
 // CHECK-LABEL: func @reduction_accumulate_thread_x
 func.func @reduction_accumulate_thread_x(%partial: f32, %private: memref<f32>) {
-  acc.reduction_accumulate (%partial) to (%private) <add>
-      : (f32) -> (memref<f32>) {par_dims = #acc<par_dims[thread_x]>}
+  acc.reduction_accumulate %partial to %private <add>
+      : f32 -> memref<f32> {par_dims = #acc<par_dims[thread_x]>}
   return
 }
-// CHECK: acc.reduction_accumulate(%{{.*}}) to(%{{.*}}) <add> : (f32) -> (memref<f32>) {par_dims = #acc<par_dims[thread_x]>}
+// CHECK: acc.reduction_accumulate %{{.*}} to %{{.*}} <add> : f32 -> memref<f32> {par_dims = #acc<par_dims[thread_x]>}
 
 // -----
 
 // CHECK-LABEL: func @reduction_accumulate_block_thread
 func.func @reduction_accumulate_block_thread(%partial: i32, %private: memref<i32>) {
-  acc.reduction_accumulate (%partial) to (%private) <add>
-      : (i32) -> (memref<i32>) {par_dims = #acc<par_dims[block_x, thread_x]>}
+  acc.reduction_accumulate %partial to %private <add>
+      : i32 -> memref<i32> {par_dims = #acc<par_dims[block_x, thread_x]>}
   return
 }
-// CHECK: acc.reduction_accumulate(%{{.*}}) to(%{{.*}}) <add> : (i32) -> (memref<i32>) {par_dims = #acc<par_dims[block_x, thread_x]>}
+// CHECK: acc.reduction_accumulate %{{.*}} to %{{.*}} <add> : i32 -> memref<i32> {par_dims = #acc<par_dims[block_x, thread_x]>}
 
 // -----
 


### PR DESCRIPTION
Avoid use of parentheses so that format for
`acc.reduction_accumulate` is consistent with rest of acc reduction operations.