### PR TITLE
[DemandedBits] Track demanded bits for clmul instrinsics

### DIFF
--- a/llvm/lib/Analysis/DemandedBits.cpp
+++ b/llvm/lib/Analysis/DemandedBits.cpp
@@ -114,6 +114,11 @@ void DemandedBits::determineLiveOperandBits(
         // the output.
         AB = AOut.reverseBits();
         break;
+      case Intrinsic::clmul:
+        // Output bits only depend on input bits with lower or
+        // equal bit index.
+        AB = APInt::getLowBitsSet(BitWidth, AOut.getActiveBits());
+        break;
       case Intrinsic::ctlz:
         if (OperandNo == 0) {
           // We need some output bits, so we need all bits of the

--- a/llvm/test/Analysis/DemandedBits/intrinsics.ll
+++ b/llvm/test/Analysis/DemandedBits/intrinsics.ll
@@ -109,3 +109,16 @@ define i33 @test_fshr_non_pow2_bitwidth(i33 %x, i33 %y, i33 %z) {
   %r = and i33 %f, 65535
   ret i33 %r
 }
+
+; CHECK-LABEL: Printing analysis 'Demanded Bits Analysis' for function 'test_clmul':
+; CHECK-DAG: DemandedBits: 0xffff for   %x2 = or i32 %x, 1
+; CHECK-DAG: DemandedBits: 0xffff for   %y2 = or i32 %y, 1
+; CHECK-DAG: DemandedBits: 0xff00 for   %z = call i32 @llvm.clmul.i32(i32 %x2, i32 %y2)
+; CHECK-DAG: DemandedBits: 0xffffffff for   %r = and i32 %z, 65280
+define i32 @test_clmul(i32 %x, i32 %y) {
+  %x2 = or i32 %x, 1
+  %y2 = or i32 %y, 1
+  %z = call i32 @llvm.clmul.i32(i32 %x2, i32 %y2)
+  %r = and i32 %z, 65280
+  ret i32 %r
+}


### PR DESCRIPTION
Similar to regular multiplication, carryless multiplication does not depend on bits in positions higher than the output bits.

No alive2 proof since clmul is not supported, but the implementation is the same as for Instruction::mul.