### PR TITLE
[InstCombine] Drop ninf when folding shuffle of fp binop into passthrough lanes

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp
@@ -2313,6 +2313,14 @@ static Instruction *foldSelectShuffleWith1Binop(ShuffleVectorInst &Shuf,
   Instruction *NewBO = BinaryOperator::Create(BOpcode, X, NewC);
   NewBO->copyIRFlags(BO);
 
+  // A passthrough lane returns X unchanged, but the new binop now applies its
+  // flags to it. With 'ninf', an infinity in such a lane would become poison
+  // (e.g. `fmul ninf inf, 1.0 -> poison`), which the original passthrough did
+  // not. Drop ninf when X may be infinity.
+  if (Shuf.getType()->getElementType()->isFloatingPointTy() &&
+      NewBO->hasNoInfs() && !isKnownNeverInfinity(X, SQ))
+    NewBO->setHasNoInfs(false);
+
   // An undef shuffle mask element may propagate as an undef constant element in
   // the new binop. That would produce poison where the original code might not.
   // If we already made a safe constant, then there's no danger.

--- a/llvm/test/Transforms/InstCombine/shuffle_select.ll
+++ b/llvm/test/Transforms/InstCombine/shuffle_select.ll
@@ -372,10 +372,34 @@ define <4 x double> @fsub(<4 x double> %v) {
 
 define <4 x float> @fmul(<4 x float> nofpclass(nan) %v) {
 ; CHECK-LABEL: @fmul(
+; CHECK-NEXT:    [[S:%.*]] = fmul nnan <4 x float> [[V:%.*]], <float 4.100000e+01, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
+; CHECK-NEXT:    ret <4 x float> [[S]]
+;
+  %b = fmul nnan ninf <4 x float> %v, <float 41.0, float 42.0, float 43.0, float 44.0>
+  %s = shufflevector <4 x float> %b, <4 x float> %v, <4 x i32> <i32 0, i32 5, i32 6, i32 7>
+  ret <4 x float> %s
+}
+
+; 'ninf' is safe to keep here: %v can be neither nan nor inf, so routing a
+; passthrough lane through 'fmul ninf %v, 1.0' cannot introduce poison.
+define <4 x float> @fmul_ninf_never_inf(<4 x float> nofpclass(nan inf) %v) {
+; CHECK-LABEL: @fmul_ninf_never_inf(
 ; CHECK-NEXT:    [[S:%.*]] = fmul nnan ninf <4 x float> [[V:%.*]], <float 4.100000e+01, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
 ; CHECK-NEXT:    ret <4 x float> [[S]]
 ;
   %b = fmul nnan ninf <4 x float> %v, <float 41.0, float 42.0, float 43.0, float 44.0>
+  %s = shufflevector <4 x float> %b, <4 x float> %v, <4 x i32> <i32 0, i32 5, i32 6, i32 7>
+  ret <4 x float> %s
+}
+
+; No 'ninf', so an infinity passthrough lane is preserved (fmul inf, 1.0 = inf);
+; folding is safe even though %v may be infinity.
+define <4 x float> @fmul_no_ninf_maybe_inf(<4 x float> nofpclass(nan) %v) {
+; CHECK-LABEL: @fmul_no_ninf_maybe_inf(
+; CHECK-NEXT:    [[S:%.*]] = fmul nnan <4 x float> [[V:%.*]], <float 4.100000e+01, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>
+; CHECK-NEXT:    ret <4 x float> [[S]]
+;
+  %b = fmul nnan <4 x float> %v, <float 41.0, float 42.0, float 43.0, float 44.0>
   %s = shufflevector <4 x float> %b, <4 x float> %v, <4 x i32> <i32 0, i32 5, i32 6, i32 7>
   ret <4 x float> %s
 }


### PR DESCRIPTION
foldSelectShuffleWith1Binop folds

    shufflevector (fmul nnan ninf X, C), X, Mask  ->  fmul X, C'

placing the binop identity (1.0 for fmul) into the lanes that return X
unchanged. The new binop keeps the original fast-math flags, but a passthrough
lane is then computed as `fmul ninf X, 1.0`, which is poison when X is infinity
-- the original passthrough lane was a defined infinity. This introduces poison
where the original had none, a miscompile.

Drop the 'ninf' flag from the new binop when X may be infinity instead of giving
up the fold; clearing it on the genuinely-computed lanes only makes them more
defined. The NaN case still bails, since an fp op need not preserve a NaN
bit-pattern.