### PR TITLE
[mlir][LLVM] Verify address space in memref.alloca lowering

### DIFF
--- a/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
+++ b/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
@@ -360,6 +360,11 @@ struct AllocaOpLowering : public ConvertOpToLLVMPattern<memref::AllocaOp> {
         getTypeConverter()->getMemRefAddressSpace(op.getType());
     assert(succeeded(maybeAddressSpace) && "unsupported address space");
     unsigned addrSpace = *maybeAddressSpace;
+    if (addrSpace != getTypeConverter()->getDataLayout().getAllocaAddrSpace()) {
+        return rewriter.notifyMatchFailure(
+          op, "memref.alloca address space does not match the target's "
+              "legal stack allocation address space.");
+    }    
     auto elementPtrType =
         LLVM::LLVMPointerType::get(rewriter.getContext(), addrSpace);
 

--- a/mlir/test/Conversion/MemRefToLLVM/invalid.mlir
+++ b/mlir/test/Conversion/MemRefToLLVM/invalid.mlir
@@ -52,3 +52,13 @@ func.func @test_atomic_exch(%arg0: memref<?xi32>, %idx: index, %value: i32) {
   }
   func.return
 }
+
+// -----
+
+func.func @invalid_shared_alloca() {
+    // expected-error @+1 {{memref.alloca address space does not match the target's legal stack allocation address space.}}
+    %0 = memref.alloca() : memref<128xf32, 3>
+    return
+  }
+
+}


### PR DESCRIPTION
Ensure that `memref.alloca` rejects lowering if its requested address space does not match the target's legal stack allocation address space defined in the DataLayout.