### PR TITLE
[SystemZ][NFC] Sync downstream zos-abi.c test changes

### DIFF
--- a/clang/test/CodeGen/SystemZ/zos-abi.c
+++ b/clang/test/CodeGen/SystemZ/zos-abi.c
@@ -21,6 +21,9 @@
 
 // Scalar types
 
+char pass_char(char arg) { return arg; }
+// CHECK-LABEL: define signext i8 @pass_char(i8 signext %{{.*}})
+
 signed char pass_schar(signed char arg) { return arg; }
 // CHECK-LABEL: define signext i8 @pass_schar(i8 signext %{{.*}})
 
@@ -74,8 +77,8 @@ _Complex long double pass_complex_longdouble(_Complex long double arg) { return 
 
 // Verify that the following are complex-like types
 struct complexlike_float { float re, im; };
-struct complexlike_float pass_complexlike_float2(struct complexlike_float arg) { return arg; }
-// CHECK-LABEL: define %struct.complexlike_float @pass_complexlike_float2({ float, float } %{{.*}})
+struct complexlike_float pass_complexlike_float(struct complexlike_float arg) { return arg; }
+// CHECK-LABEL: define %struct.complexlike_float @pass_complexlike_float({ float, float } %{{.*}})
 
 struct complexlike_double { double re, im; };
 struct complexlike_double pass_complexlike_double(struct complexlike_double arg) { return arg; }


### PR DESCRIPTION
Syncs downstream changes to SystemZ zos-abi.c test:

1. Add test for char type parameter passing with sign extension
2. Rename pass_complexlike_float2 to pass_complexlike_float for consistency

NFC - test-only changes.