### PR TITLE
[mlir][acc] Add ignore-default-none option to ACCImplicitData

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/OpenACC/Transforms/Passes.td
@@ -79,7 +79,14 @@ def ACCImplicitData : Pass<"acc-implicit-data", "mlir::ModuleOp"> {
            "variables between combined constructs (e.g., 'parallel loop') and "
            "separate constructs (e.g., 'parallel' followed by 'loop'), where "
            "the OpenACC spec requires copy semantics for the former but "
-           "firstprivate would normally apply for the latter.">
+           "firstprivate would normally apply for the latter.">,
+    Option<"ignoreDefaultNone", "ignore-default-none", "bool", "false",
+           "When disabled (default), if the region has a default(none) clause, "
+           "this pass does not generate implicit data attributes. When enabled, "
+           "implicit data is generated even with default(none). This is useful "
+           "when the frontend has robust default(none) verification: user "
+           "variables are already verified, so any remaining live-ins are "
+           "variables that still need mapping handling.">
   ];
 }
 

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCImplicitData.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCImplicitData.cpp
@@ -708,12 +708,14 @@ void ACCImplicitData::generateImplicitDataOps(
     std::optional<acc::ClauseDefaultValue> &defaultClause,
     acc::OpenACCSupport &accSupport) {
   // Implicit data attributes are only applied if "[t]here is no default(none)
-  // clause visible at the compute construct."
-  if (defaultClause.has_value() &&
+  // clause visible at the compute construct", unless ignoreDefaultNone is set.
+  if (!ignoreDefaultNone && defaultClause.has_value() &&
       defaultClause.value() == acc::ClauseDefaultValue::None)
     return;
   assert(!defaultClause.has_value() ||
-         defaultClause.value() == acc::ClauseDefaultValue::Present);
+         defaultClause.value() == acc::ClauseDefaultValue::Present ||
+         (ignoreDefaultNone &&
+          defaultClause.value() == acc::ClauseDefaultValue::None));
 
   // 1) Collect live-in values.
   Region &accRegion = computeConstructOp->getRegion(0);

--- a/mlir/test/Dialect/OpenACC/acc-implicit-data-defaultnone.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-implicit-data-defaultnone.mlir
@@ -1,0 +1,23 @@
+// RUN: mlir-opt %s -acc-implicit-data=ignore-default-none=false -split-input-file | FileCheck %s
+// RUN: mlir-opt %s -acc-implicit-data=ignore-default-none=true -split-input-file | FileCheck %s --check-prefix=ENABLED
+
+// -----
+
+// Test scalar in parallel with default(none) - should NOT generate implicit
+// data when ignore-default-none is disabled. Otherwise, it should generate
+// implicit firstprivate.
+func.func @test_scalar_parallel_defaultnone() {
+  %alloc = memref.alloca() : memref<f32>
+  acc.parallel {
+    %load = memref.load %alloc[] : memref<f32>
+    acc.yield
+  } attributes {defaultAttr = #acc<defaultvalue none>}
+  return
+}
+
+// CHECK-LABEL: func.func @test_scalar_parallel_defaultnone
+// CHECK-NOT: acc.firstprivate
+// CHECK-NOT: acc.copyin
+
+// ENABLED-LABEL: func.func @test_scalar_parallel_defaultnone
+// ENABLED: acc.firstprivate varPtr({{.*}} : memref<f32>) recipe({{.*}}) -> memref<f32> {implicit = true, name = ""}


### PR DESCRIPTION
ACCImplicitData currently skips implicit data mapping when a visible default(none) clause is present, per the OpenACC rule that no implicit data attributes apply in that case.

That default is reasonable when a frontend already verifies default(none) and ensures all user variables have an explicit data clause. Without that checking, generating implicit mappings would risk silently mapping user variables that should have been explicit under default(none).

There are still cases where implicit mapping is needed even with default(none):
- The frontend reports default(none) violations as warnings and compilation continues, so some user variables may reach this pass without explicit data clauses and still need implicit mapping.
- Compiler-generated temps or interior pointers may be live-in to the region and still require implicit mapping even when all user variables are already explicitly mapped.

In those cases, skipping implicit data entirely is too conservative.

Add an ignore-default-none pass option (default: false) to generate implicit data mappings even when default(none) is present.