### PR TITLE
[flang][OpenMP] Fix privatization of linear in TARGET

### DIFF
--- a/flang/lib/Lower/OpenMP/DataSharingProcessor.cpp
+++ b/flang/lib/Lower/OpenMP/DataSharingProcessor.cpp
@@ -492,6 +492,22 @@ void DataSharingProcessor::collectPrivatizedSymbols(
   }
 
   auto shouldCollectSymbol = [&](const semantics::Symbol *sym) {
+    // Linear symbols are privatized by OpenMP IRBuilder, except when they are
+    // enclosed within TARGET.
+    bool inTarget = false;
+    mlir::Operation *currentOp =
+        firOpBuilder.getInsertionBlock()->getParentOp();
+    while (currentOp) {
+      if (mlir::dyn_cast<mlir::omp::TargetOp>(currentOp)) {
+        inTarget = true;
+        break;
+      }
+      currentOp = currentOp->getParentOp();
+    }
+
+    if (sym->test(semantics::Symbol::Flag::OmpLinear) && !inTarget)
+      return false;
+
     if (collectImplicit) {
       // If we're a combined construct with a target region, implicit
       // firstprivate captures, should only belong to the target region
@@ -533,9 +549,6 @@ void DataSharingProcessor::collectPrivatizedSymbols(
 
   for (const auto *sym : allSymbols) {
     if (semantics::omp::IsPrivatizable(*sym) &&
-        // Linear symbols are privatized by OpenMP IRBuilder. See comments
-        // in collectSymbolsForPrivatization() for more details.
-        !sym->test(semantics::Symbol::Flag::OmpLinear) &&
         !symbolsInNestedRegions.contains(sym) &&
         !explicitlyPrivatizedSymbols.contains(sym) &&
         shouldCollectSymbol(sym) && clauseScopes.contains(&sym->owner())) {

--- a/flang/lib/Lower/OpenMP/DataSharingProcessor.cpp
+++ b/flang/lib/Lower/OpenMP/DataSharingProcessor.cpp
@@ -494,16 +494,11 @@ void DataSharingProcessor::collectPrivatizedSymbols(
   auto shouldCollectSymbol = [&](const semantics::Symbol *sym) {
     // Linear symbols are privatized by OpenMP IRBuilder, except when they are
     // enclosed within TARGET.
-    bool inTarget = false;
     mlir::Operation *currentOp =
         firOpBuilder.getInsertionBlock()->getParentOp();
-    while (currentOp) {
-      if (mlir::dyn_cast<mlir::omp::TargetOp>(currentOp)) {
-        inTarget = true;
-        break;
-      }
-      currentOp = currentOp->getParentOp();
-    }
+    bool inTarget =
+        currentOp && (mlir::isa<mlir::omp::TargetOp>(currentOp) ||
+                      currentOp->getParentOfType<mlir::omp::TargetOp>());
 
     if (sym->test(semantics::Symbol::Flag::OmpLinear) && !inTarget)
       return false;

--- a/flang/test/Lower/OpenMP/distribute-parallel-do-simd.f90
+++ b/flang/test/Lower/OpenMP/distribute-parallel-do-simd.f90
@@ -150,3 +150,16 @@ integer :: i,j
     enddo
   enddo
 end subroutine
+
+! CHECK-LABEL:   func.func @_QPtarget_teams_distribute_parallel_do_simd_linear
+subroutine target_teams_distribute_parallel_do_simd_linear()
+  implicit none
+  integer :: iv
+
+  ! CHECK: omp.target
+  ! CHECK: %[[IV:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFtarget_teams_distribute_parallel_do_simd_linearEiv"}
+  ! CHECK: omp.simd private(@_QFtarget_teams_distribute_parallel_do_simd_linearEiv_private_i32 %[[IV]]#0 -> %{{.*}} : !fir.ref<i32>)
+  !$omp target teams distribute parallel do simd
+  do iv = 1, 10
+  end do
+end subroutine


### PR DESCRIPTION
Linear symbols are privatized by OpenMP IRBuilder, except when they are
enclosed within TARGET, in which case their privatization must occur in
DataSharingProcessor.

Fixes #201628
