### PR TITLE
[flang] __fortran_builtins: Update __builtin_team_type to meet PRIF specification

### DIFF
--- a/flang-rt/lib/runtime/__fortran_builtins.f90
+++ b/flang-rt/lib/runtime/__fortran_builtins.f90
@@ -99,8 +99,13 @@ module __fortran_builtins
     __builtin_ieee_other = &
       __builtin_ieee_round_type(_FORTRAN_RUNTIME_IEEE_OTHER)
 
+  type, private :: __builtin_dummy_team_descriptor_type
+    ! this type is a placeholder for the opaque PRIF type
+    integer(kind=int64), private :: __placeholder = -1
+  end type
+
   type, public :: __builtin_team_type
-    integer(kind=int64), private :: __id = -1
+    type(__builtin_dummy_team_descriptor_type), pointer, private :: info => null()
   end type
 
   integer, parameter, public :: __builtin_atomic_int_kind = selected_int_kind(18)

--- a/flang/CMakeLists.txt
+++ b/flang/CMakeLists.txt
@@ -590,3 +590,4 @@ install(
   COMPONENT flang-fortran-binding)
 add_llvm_install_targets(install-flang-fortran-binding
   COMPONENT flang-fortran-binding)
+


### PR DESCRIPTION
The representation of `TEAM_TYPE` in the `ISO_FORTRAN_ENV` module is opaque to the compiler, but the size (and alignment) needs to match the PRIF specification for `prif_team_type` to ensure ABI compatibility with the multi-image runtime library.

Flang's old definition as a derived type containing only an `integer(int64)` component was leading to an 8-byte `TEAM_TYPE`. However PRIF specifies the `prif_team_type` component as a `pointer` to an opaque scalar type, which flang compiles to a 40-byte representation.

This mismatch was leading to incorrect behavior at runtime for programs compiled with `-fcoarray` and using `TEAM_TYPE`, where `TEAM_TYPE` values returned by PRIF were being silently truncated by the compiler.

Change the declaration of `__builtin_team_type` to match the PRIF specification, thus ensuring the representation of `TEAM_TYPE` has the required size.