### PR TITLE
[InstCombine] Generalize sub(C, or(X, C)) --> and(X, ~C) fold to all valid C

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1,4 +1,4 @@
-  //===- InstCombineAddSub.cpp ------------------------------------*- C++ -*-===//
+//===- InstCombineAddSub.cpp ------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1,4 +1,4 @@
-//===- InstCombineAddSub.cpp ------------------------------------*- C++ -*-===//
+  //===- InstCombineAddSub.cpp ------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -2484,6 +2484,21 @@ Instruction *InstCombinerImpl::visitSub(BinaryOperator &I) {
           X, ConstantFoldBinaryInstruction(Instruction::Xor, C1, C2));
   }
 
+  // (C - (X | C)) --> (X & ~C)
+  {
+    const APInt *C1, *C2;
+    Value *X;
+    if (!I.hasNoSignedWrap() && !I.hasNoUnsignedWrap() &&
+        match(&I, m_Sub(m_APInt(C1), m_c_Or(m_Value(X), m_APInt(C2)))) &&
+        *C1 == *C2) {
+      APInt NotC = ~(*C1);
+      if (NotC.isZero() || NotC.isPowerOf2()) {
+        return BinaryOperator::CreateAnd(
+            X, ConstantInt::get(I.getType(), NotC));
+      }
+    }
+  }
+ 
   // Reassociate sub/add sequences to create more add instructions and
   // reduce dependency chains:
   // ((X - Y) + Z) - Op1 --> (X + Z) - (Y + Op1)

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -2493,12 +2493,12 @@ Instruction *InstCombinerImpl::visitSub(BinaryOperator &I) {
         *C1 == *C2) {
       APInt NotC = ~(*C1);
       if (NotC.isZero() || NotC.isPowerOf2()) {
-        return BinaryOperator::CreateAnd(
-            X, ConstantInt::get(I.getType(), NotC));
+        return BinaryOperator::CreateAnd(X,
+                                         ConstantInt::get(I.getType(), NotC));
       }
     }
   }
- 
+
   // Reassociate sub/add sequences to create more add instructions and
   // reduce dependency chains:
   // ((X - Y) + Z) - Op1 --> (X + Z) - (Y + Op1)

--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -2492,7 +2492,7 @@ Instruction *InstCombinerImpl::visitSub(BinaryOperator &I) {
         match(&I, m_Sub(m_APInt(C1), m_c_Or(m_Value(X), m_APInt(C2)))) &&
         *C1 == *C2) {
       APInt NotC = ~(*C1);
-      if (NotC.isZero() || NotC.isPowerOf2()) {
+      if (NotC.isZero() || NotC.isSignMask()) {
         return BinaryOperator::CreateAnd(X,
                                          ConstantInt::get(I.getType(), NotC));
       }

--- a/llvm/test/Transforms/InstCombine/sub-minmax.ll
+++ b/llvm/test/Transforms/InstCombine/sub-minmax.ll
@@ -1140,6 +1140,61 @@ define <2 x i8> @sub_max_min_vec_multi_use(<2 x i8> %a, <2 x i8> %b) {
   ret <2 x i8> %ab
 }
 
+define i32 @fold_smax_i32(i32 %x) {
+; CHECK-LABEL: define {{[^@]+}}@fold_smax_i32
+; CHECK-SAME: (i32 [[X:%.*]]) {
+; CHECK-NEXT:    [[R:%.*]] = and i32 [[X]], -2147483648
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %a = or i32 %x, 2147483647
+  %b = sub i32 2147483647, %a
+  ret i32 %b
+}
+
+define i32 @fold_allones_i32(i32 %x) {
+; CHECK-LABEL: define {{[^@]+}}@fold_allones_i32
+; CHECK-SAME: (i32 [[X:%.*]]) {
+; CHECK-NEXT:    ret i32 0
+;
+  %a = or i32 %x, -1
+  %b = sub i32 -1, %a
+  ret i32 %b
+}
+
+define i16 @fold_smax_i16(i16 %x) {
+; CHECK-LABEL: define {{[^@]+}}@fold_smax_i16
+; CHECK-SAME: (i16 [[X:%.*]]) {
+; CHECK-NEXT:    [[B:%.*]] = and i16 [[X]], -32768
+; CHECK-NEXT:    ret i16 [[B]]
+;
+  %a = or i16 %x, 32767
+  %b = sub i16 32767, %a
+  ret i16 %b
+}
+
+define i32 @fold_smax_commuted(i32 %x) {
+; CHECK-LABEL: define {{[^@]+}}@fold_smax_commuted
+; CHECK-SAME: (i32 [[X:%.*]]) {
+; CHECK-NEXT:    [[B:%.*]] = and i32 [[X]], -2147483648
+; CHECK-NEXT:    ret i32 [[B]]
+;
+  %a = or i32 2147483647, %x
+  %b = sub i32 2147483647, %a
+  ret i32 %b
+}
+
+define i32 @no_fold_arbitrary_const(i32 %x) {
+; CHECK-LABEL: define {{[^@]+}}@no_fold_arbitrary_const
+; CHECK-SAME: (i32 [[X:%.*]]) {
+; CHECK-NEXT:    [[A:%.*]] = or i32 [[X]], 1073741823
+; CHECK-NEXT:    [[B:%.*]] = sub i32 1073741823, [[A]]
+; CHECK-NEXT:    ret i32 [[B]]
+;
+  %a = or i32 %x, 1073741823
+  %b = sub i32 1073741823, %a
+  ret i32 %b
+}
+
 declare void @use8(i8)
 declare void @use32(i32 %u)
 


### PR DESCRIPTION
Generalizes the fold introduced in #202274 to cover all constants `C` where `((~C) << 1) == 0`, i.e. where `~C` has at most the sign bit set.

The original PR handled only `C = smax`. This extension also covers `C = -1` (the degenerate case where the result is always 0), and correctly rejects all other constants where carry propagation across bit regions would make the fold unsound.