### PR TITLE
Update remaining tests for usage of CLANG_RESOURCE_DIR

### DIFF
--- a/clang/test/Driver/hexagon-toolchain-picolibc.c
+++ b/clang/test/Driver/hexagon-toolchain-picolibc.c
@@ -5,13 +5,13 @@
 // -----------------------------------------------------------------------------
 // RUN: %clang -### --target=hexagon-none-elf --cstdlib=picolibc \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-C-INCLUDES -DRESOURCE_DIR=%clang-resource-dir %s
-// CHECK-C-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\}}include"
+// CHECK-C-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
 // CHECK-C-INCLUDES: "-internal-externc-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-none-elf{{/|\\\\}}include"
 
 // RUN: %clangxx -### --target=hexagon-none-elf --cstdlib=picolibc \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-CXX-INCLUDES -DRESOURCE_DIR=%clang-resource-dir %s
 // CHECK-CXX-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-none-elf{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
-// CHECK-CXX-INCLUDES: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\}}include"
+// CHECK-CXX-INCLUDES: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
 // CHECK-CXX-INCLUDES: "-internal-externc-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-none-elf{{/|\\\\}}include"
 // -----------------------------------------------------------------------------
 // Passing start files for Picolibc
@@ -129,13 +129,13 @@
 // -----------------------------------------------------------------------------
 // RUN: %clang -### --target=hexagon-h2-elf --cstdlib=picolibc \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-H2-C-INCLUDES -DRESOURCE_DIR=%clang-resource-dir %s
-// CHECK-H2-C-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\}}include"
+// CHECK-H2-C-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
 // CHECK-H2-C-INCLUDES: "-internal-externc-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-h2-elf{{/|\\\\}}include"
 
 // RUN: %clangxx -### --target=hexagon-h2-elf --cstdlib=picolibc \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-H2-CXX-INCLUDES -DRESOURCE_DIR=%clang-resource-dir %s
 // CHECK-H2-CXX-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-h2-elf{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
-// CHECK-H2-CXX-INCLUDES: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\}}include"
+// CHECK-H2-CXX-INCLUDES: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
 // CHECK-H2-CXX-INCLUDES: "-internal-externc-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-h2-elf{{/|\\\\}}include"
 
 // -----------------------------------------------------------------------------

--- a/clang/test/Driver/hexagon-toolchain-picolibc.c
+++ b/clang/test/Driver/hexagon-toolchain-picolibc.c
@@ -5,13 +5,13 @@
 // -----------------------------------------------------------------------------
 // RUN: %clang -### --target=hexagon-none-elf --cstdlib=picolibc \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-C-INCLUDES -DRESOURCE_DIR=%clang-resource-dir %s
-// CHECK-C-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "[[RESOURCE_DIR]]/include"
+// CHECK-C-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\}}include"
 // CHECK-C-INCLUDES: "-internal-externc-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-none-elf{{/|\\\\}}include"
 
 // RUN: %clangxx -### --target=hexagon-none-elf --cstdlib=picolibc \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-CXX-INCLUDES -DRESOURCE_DIR=%clang-resource-dir %s
 // CHECK-CXX-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-none-elf{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
-// CHECK-CXX-INCLUDES: "-internal-isystem" "[[RESOURCE_DIR]]/include"
+// CHECK-CXX-INCLUDES: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\}}include"
 // CHECK-CXX-INCLUDES: "-internal-externc-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-none-elf{{/|\\\\}}include"
 // -----------------------------------------------------------------------------
 // Passing start files for Picolibc
@@ -129,13 +129,13 @@
 // -----------------------------------------------------------------------------
 // RUN: %clang -### --target=hexagon-h2-elf --cstdlib=picolibc \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-H2-C-INCLUDES -DRESOURCE_DIR=%clang-resource-dir %s
-// CHECK-H2-C-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "[[RESOURCE_DIR]]/include"
+// CHECK-H2-C-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\}}include"
 // CHECK-H2-C-INCLUDES: "-internal-externc-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-h2-elf{{/|\\\\}}include"
 
 // RUN: %clangxx -### --target=hexagon-h2-elf --cstdlib=picolibc \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-H2-CXX-INCLUDES -DRESOURCE_DIR=%clang-resource-dir %s
 // CHECK-H2-CXX-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-h2-elf{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
-// CHECK-H2-CXX-INCLUDES: "-internal-isystem" "[[RESOURCE_DIR]]/include"
+// CHECK-H2-CXX-INCLUDES: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\}}include"
 // CHECK-H2-CXX-INCLUDES: "-internal-externc-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-h2-elf{{/|\\\\}}include"
 
 // -----------------------------------------------------------------------------

--- a/clang/test/Driver/hexagon-toolchain-picolibc.c
+++ b/clang/test/Driver/hexagon-toolchain-picolibc.c
@@ -4,14 +4,14 @@
 // Test standard include paths
 // -----------------------------------------------------------------------------
 // RUN: %clang -### --target=hexagon-none-elf --cstdlib=picolibc \
-// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-C-INCLUDES %s
-// CHECK-C-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "{{.*}}{{/|\\\\}}lib{{/|\\\\}}clang{{/|\\\\}}{{[0-9]+}}{{/|\\\\}}include"
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-C-INCLUDES -DRESOURCE_DIR=%clang-resource-dir %s
+// CHECK-C-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "[[RESOURCE_DIR]]/include"
 // CHECK-C-INCLUDES: "-internal-externc-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-none-elf{{/|\\\\}}include"
 
 // RUN: %clangxx -### --target=hexagon-none-elf --cstdlib=picolibc \
-// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-CXX-INCLUDES %s
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-CXX-INCLUDES -DRESOURCE_DIR=%clang-resource-dir %s
 // CHECK-CXX-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-none-elf{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
-// CHECK-CXX-INCLUDES: "-internal-isystem" "{{.*}}{{/|\\\\}}lib{{/|\\\\}}clang{{/|\\\\}}{{[0-9]+}}{{/|\\\\}}include"
+// CHECK-CXX-INCLUDES: "-internal-isystem" "[[RESOURCE_DIR]]/include"
 // CHECK-CXX-INCLUDES: "-internal-externc-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-none-elf{{/|\\\\}}include"
 // -----------------------------------------------------------------------------
 // Passing start files for Picolibc
@@ -128,14 +128,14 @@
 // Test standard include paths for H2
 // -----------------------------------------------------------------------------
 // RUN: %clang -### --target=hexagon-h2-elf --cstdlib=picolibc \
-// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-H2-C-INCLUDES %s
-// CHECK-H2-C-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "{{.*}}{{/|\\\\}}lib{{/|\\\\}}clang{{/|\\\\}}{{[0-9]+}}{{/|\\\\}}include"
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-H2-C-INCLUDES -DRESOURCE_DIR=%clang-resource-dir %s
+// CHECK-H2-C-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "[[RESOURCE_DIR]]/include"
 // CHECK-H2-C-INCLUDES: "-internal-externc-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-h2-elf{{/|\\\\}}include"
 
 // RUN: %clangxx -### --target=hexagon-h2-elf --cstdlib=picolibc \
-// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-H2-CXX-INCLUDES %s
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-H2-CXX-INCLUDES -DRESOURCE_DIR=%clang-resource-dir %s
 // CHECK-H2-CXX-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-h2-elf{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
-// CHECK-H2-CXX-INCLUDES: "-internal-isystem" "{{.*}}{{/|\\\\}}lib{{/|\\\\}}clang{{/|\\\\}}{{[0-9]+}}{{/|\\\\}}include"
+// CHECK-H2-CXX-INCLUDES: "-internal-isystem" "[[RESOURCE_DIR]]/include"
 // CHECK-H2-CXX-INCLUDES: "-internal-externc-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-h2-elf{{/|\\\\}}include"
 
 // -----------------------------------------------------------------------------

--- a/clang/test/Driver/hexagon-toolchain-picolibc.c
+++ b/clang/test/Driver/hexagon-toolchain-picolibc.c
@@ -1,15 +1,19 @@
 // REQUIRES: hexagon-registered-target
 
+// Escape the value of clang-resource-dir if needed (mainly on Windows)
+// RUN: rm -rf %t && mkdir %t
+// RUN: echo %clang-resource-dir | tr -d '\n' | sed 's/\\/\\\\/g' > %t/resource-dir
+
 // -----------------------------------------------------------------------------
 // Test standard include paths
 // -----------------------------------------------------------------------------
 // RUN: %clang -### --target=hexagon-none-elf --cstdlib=picolibc \
-// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-C-INCLUDES -DRESOURCE_DIR=%clang-resource-dir %s
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-C-INCLUDES -DRESOURCE_DIR="%{readfile:%t/resource-dir}" %s
 // CHECK-C-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
 // CHECK-C-INCLUDES: "-internal-externc-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-none-elf{{/|\\\\}}include"
 
 // RUN: %clangxx -### --target=hexagon-none-elf --cstdlib=picolibc \
-// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-CXX-INCLUDES -DRESOURCE_DIR=%clang-resource-dir %s
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-CXX-INCLUDES -DRESOURCE_DIR="%{readfile:%t/resource-dir}" %s
 // CHECK-CXX-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-none-elf{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
 // CHECK-CXX-INCLUDES: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
 // CHECK-CXX-INCLUDES: "-internal-externc-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-none-elf{{/|\\\\}}include"
@@ -128,12 +132,12 @@
 // Test standard include paths for H2
 // -----------------------------------------------------------------------------
 // RUN: %clang -### --target=hexagon-h2-elf --cstdlib=picolibc \
-// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-H2-C-INCLUDES -DRESOURCE_DIR=%clang-resource-dir %s
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-H2-C-INCLUDES -DRESOURCE_DIR="%{readfile:%t/resource-dir}" %s
 // CHECK-H2-C-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
 // CHECK-H2-C-INCLUDES: "-internal-externc-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-h2-elf{{/|\\\\}}include"
 
 // RUN: %clangxx -### --target=hexagon-h2-elf --cstdlib=picolibc \
-// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-H2-CXX-INCLUDES -DRESOURCE_DIR=%clang-resource-dir %s
+// RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK-H2-CXX-INCLUDES -DRESOURCE_DIR="%{readfile:%t/resource-dir}" %s
 // CHECK-H2-CXX-INCLUDES: "-cc1" {{.*}} "-internal-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-h2-elf{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}v1"
 // CHECK-H2-CXX-INCLUDES: "-internal-isystem" "[[RESOURCE_DIR]]{{/|\\\\}}include"
 // CHECK-H2-CXX-INCLUDES: "-internal-externc-isystem" "{{.*}}{{/|\\\\}}Inputs{{/|\\\\}}hexagon_tree{{/|\\\\}}Tools{{/|\\\\}}bin{{/|\\\\}}..{{/|\\\\}}target{{/|\\\\}}picolibc{{/|\\\\}}hexagon-unknown-h2-elf{{/|\\\\}}include"

--- a/clang/test/Driver/hip-include-path.hip
+++ b/clang/test/Driver/hip-include-path.hip
@@ -24,7 +24,7 @@
 // NOHIP-NOT: "-include" "__clang_hip_runtime_wrapper.h"
 // skip check of standard C++ include path
 // CLANG-SAME: "-internal-isystem" "[[RESOURCE_DIR]]/include"
-// NOCLANG-NOT: [[RESOURCE_DIR]]/include"
+// NOCLANG-NOT: "[[RESOURCE_DIR]]/include"
 // NOHIP-NOT: "{{.*}}Inputs/rocm/include"
 
 // COMMON-LABEL: "{{[^"]*}}clang{{[^"]*}}" "-cc1"

--- a/clang/test/Driver/hip-include-path.hip
+++ b/clang/test/Driver/hip-include-path.hip
@@ -2,50 +2,50 @@
 
 // RUN: %clang -c -### --target=x86_64-unknown-linux-gnu --cuda-gpu-arch=gfx900 \
 // RUN:   -std=c++11 --rocm-path=%S/Inputs/rocm -nogpulib %s 2>&1 \
-// RUN:   | FileCheck -check-prefixes=COMMON,CLANG,HIP %s
+// RUN:   | FileCheck -check-prefixes=COMMON,CLANG,HIP -DRESOURCE_DIR=%clang-resource-dir %s
 
 // RUN: %clang -c -### --target=x86_64-unknown-linux-gnu --cuda-gpu-arch=gfx900 \
 // RUN:   -std=c++11 --rocm-path=%S/Inputs/rocm -nobuiltininc -nogpulib %s 2>&1 \
-// RUN:   | FileCheck -check-prefixes=COMMON,NOCLANG,HIP %s
+// RUN:   | FileCheck -check-prefixes=COMMON,NOCLANG,HIP -DRESOURCE_DIR=%clang-resource-dir %s
 
 // RUN: %clang -c -### --target=x86_64-unknown-linux-gnu --cuda-gpu-arch=gfx900 \
 // RUN:   -std=c++11 --rocm-path=%S/Inputs/rocm -nogpuinc -nogpulib %s 2>&1 \
-// RUN:   | FileCheck -check-prefixes=COMMON,CLANG,NOHIP %s
+// RUN:   | FileCheck -check-prefixes=COMMON,CLANG,NOHIP -DRESOURCE_DIR=%clang-resource-dir %s
 
 // RUN: %clang -c -### --target=x86_64-unknown-linux-gnu --cuda-gpu-arch=gfx900 \
 // RUN:   -std=c++11 --rocm-path=%S/Inputs/rocm --no-offload-inc -nogpulib --offload-inc %s 2>&1 \
-// RUN:   | FileCheck -check-prefixes=COMMON,CLANG,HIP %s
+// RUN:   | FileCheck -check-prefixes=COMMON,CLANG,HIP -DRESOURCE_DIR=%clang-resource-dir %s
 
 // COMMON-LABEL: "{{[^"]*}}clang{{[^"]*}}" "-cc1"
-// CLANG-SAME: "-internal-isystem" "{{[^"]*}}/lib{{[^"]*}}/clang/{{[^"]*}}/include/cuda_wrappers"
-// NOCLANG-NOT: "{{[^"]*}}/lib{{[^"]*}}/clang/{{[^"]*}}/include/cuda_wrappers"
+// CLANG-SAME: "-internal-isystem" "[[RESOURCE_DIR]]/include/cuda_wrappers"
+// NOCLANG-NOT: "[[RESOURCE_DIR]]/include/cuda_wrappers"
 // HIP-SAME: "-idirafter" "{{[^"]*}}Inputs/rocm/include"
 // HIP-SAME: "-include" "__clang_hip_runtime_wrapper.h"
 // NOHIP-NOT: "-include" "__clang_hip_runtime_wrapper.h"
 // skip check of standard C++ include path
-// CLANG-SAME: "-internal-isystem" "{{[^"]*}}/lib{{[^"]*}}/clang/{{[^"]*}}/include"
-// NOCLANG-NOT: "{{[^"]*}}/lib{{[^"]*}}/clang/{{[^"]*}}/include"
+// CLANG-SAME: "-internal-isystem" "[[RESOURCE_DIR]]/include"
+// NOCLANG-NOT: [[RESOURCE_DIR]]/include"
 // NOHIP-NOT: "{{.*}}Inputs/rocm/include"
 
 // COMMON-LABEL: "{{[^"]*}}clang{{[^"]*}}" "-cc1"
-// CLANG-SAME: "-internal-isystem" "{{[^"]*}}/lib{{[^"]*}}/clang/{{[^"]*}}/include/cuda_wrappers"
-// NOCLANG-NOT: "{{[^"]*}}/lib{{[^"]*}}/clang/{{[^"]*}}/include/cuda_wrappers"
+// CLANG-SAME: "-internal-isystem" "[[RESOURCE_DIR]]/include/cuda_wrappers"
+// NOCLANG-NOT: "[[RESOURCE_DIR]]/include/cuda_wrappers"
 // HIP-SAME: "-idirafter" "{{[^"]*}}Inputs/rocm/include"
 // HIP-SAME: "-include" "__clang_hip_runtime_wrapper.h"
 // NOHIP-NOT: "-include" "__clang_hip_runtime_wrapper.h"
 // skip check of standard C++ include path
-// CLANG-SAME: "-internal-isystem" "{{[^"]*}}/lib{{[^"]*}}/clang/{{[^"]*}}/include"
-// NOCLANG-NOT: "{{[^"]*}}/lib{{[^"]*}}/clang/{{[^"]*}}/include"
+// CLANG-SAME: "-internal-isystem" "[[RESOURCE_DIR]]/include"
+// NOCLANG-NOT: "[[RESOURCE_DIR]]/include"
 // NOHIP-NOT: "{{.*}}Inputs/rocm/include"
 
 // RUN: %clang -c -### --target=x86_64-unknown-linux-gnu --cuda-gpu-arch=gfx900 \
 // RUN:   -std=c++11 --rocm-path=%S/Inputs/rocm -nogpulib %s 2>&1 \
-// RUN:   --hip-version=3.5 | FileCheck -check-prefixes=ROCM35 %s
+// RUN:   --hip-version=3.5 | FileCheck -check-prefixes=ROCM35 -DRESOURCE_DIR=%clang-resource-dir %s
 
 // ROCM35-LABEL: "{{[^"]*}}clang{{[^"]*}}" "-cc1"
-// ROCM35-NOT: "{{[^"]*}}/lib{{[^"]*}}/clang/{{[^"]*}}/include/cuda_wrappers"
-// ROCM35-SAME: "-internal-isystem" "{{[^"]*}}/lib{{[^"]*}}/clang/{{[^"]*}}"
+// ROCM35-NOT: "[[RESOURCE_DIR]]/include/cuda_wrappers"
+// ROCM35-SAME: "-internal-isystem" "[[RESOURCE_DIR]]"
 // ROCM35-SAME: "-idirafter" "{{[^"]*}}Inputs/rocm/include"
 // ROCM35-NOT: "-include" "__clang_hip_runtime_wrapper.h"
 // skip check of standard C++ include path
-// ROCM35-SAME: "-internal-isystem" "{{[^"]*}}/lib{{[^"]*}}/clang/{{[^"]*}}/include"
+// ROCM35-SAME: "-internal-isystem" "[[RESOURCE_DIR]]/include"

--- a/clang/test/Preprocessor/iwithprefix.c
+++ b/clang/test/Preprocessor/iwithprefix.c
@@ -9,6 +9,6 @@
 
 // CHECK: #include <...> search starts here:
 // CHECK: {{.*}}.tmps/first
-// CHECK: [[RESOURCE_DIR]]{{[\/]}}include
+// CHECK: [[RESOURCE_DIR]]{{/|\\}}include
 // CHECK: {{.*}}.tmps/second
 // CHECK-NOT: {{.*}}.tmps

--- a/clang/test/Preprocessor/iwithprefix.c
+++ b/clang/test/Preprocessor/iwithprefix.c
@@ -5,10 +5,10 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-unknown \
 // RUN:   -iprefix %t.tmps/ -iwithprefix second \
 // RUN:    -isystem %t.tmps/first -v %s 2> %t.out
-// RUN: FileCheck %s < %t.out
+// RUN: FileCheck %s -DRESOURCE_DIR=%clang-resource-dir < %t.out
 
 // CHECK: #include <...> search starts here:
 // CHECK: {{.*}}.tmps/first
-// CHECK: {{/|\\}}clang{{/|\\}}{{[.0-9]+}}{{/|\\}}include
+// CHECK: [[RESOURCE_DIR]]{{[\/]}}include
 // CHECK: {{.*}}.tmps/second
 // CHECK-NOT: {{.*}}.tmps

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -425,8 +425,6 @@ if config.clang:
     clang_resource_dir = subprocess.run(
         [config.clang, "-print-resource-dir"], stdout=subprocess.PIPE, text=True
     ).stdout.rstrip()
-    if platform.system() is "Windows":
-        clang_resource_dir = clang_resource_dir.replace('\\', '\\\\')
     config.substitutions.append(("%clang-resource-dir", clang_resource_dir))
 
 # Check if we should allow outputs to console.

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -425,6 +425,8 @@ if config.clang:
     clang_resource_dir = subprocess.run(
         [config.clang, "-print-resource-dir"], stdout=subprocess.PIPE, text=True
     ).stdout.rstrip()
+    if platform.system() is "Windows":
+        clang_resource_dir = clang_resource_dir.replace('\\', '\\\\')
     config.substitutions.append(("%clang-resource-dir", clang_resource_dir))
 
 # Check if we should allow outputs to console.


### PR DESCRIPTION
We would like to enable the clang CMake option CLANG_RESOURCE_DIR on our build bots, but found that a few tests that need updating since they make assumptions about compiler paths that are modified when using CLANG_RESOURCE_DIR. This is the final change to update the remaining 3 test failures we found.

In the previous change (#197154), I added a definition for `%clang-resource-dir` which contains the path printed by the compiler when run with `-print-resource-dir`. We pass that value to the remaining tests where needed through the RUN lines and use that to verify the correct path rather than just trying to guess at it using a complex regex.