### PR TITLE
[clang-tidy] Preserve newline style in utility fix-its. NFC. [1/N]

### DIFF
--- a/clang-tools-extra/clang-tidy/utils/HeaderGuard.cpp
+++ b/clang-tools-extra/clang-tidy/utils/HeaderGuard.cpp
@@ -239,16 +239,21 @@ public:
       if (SeenMacro)
         continue;
 
+      const StringRef LineEnding = SM.getBufferData(FID).detectEOL();
+
       Check->diag(StartLoc, "header is missing header guard")
           << FixItHint::CreateInsertion(
-                 StartLoc,
-                 (Twine("#ifndef ") + CPPVar + "\n#define " + CPPVar + "\n\n")
-                     .str())
+                 StartLoc, (Twine("#ifndef ") + CPPVar + LineEnding +
+                            "#define " + CPPVar + LineEnding + LineEnding)
+                               .str())
           << FixItHint::CreateInsertion(
                  SM.getLocForEndOfFile(FID),
-                 Check->shouldSuggestEndifComment(FileName)
-                     ? "\n#" + Check->formatEndIf(CPPVar) + "\n"
-                     : "\n#endif\n");
+                 (Twine(LineEnding) + "#" +
+                  (Check->shouldSuggestEndifComment(FileName)
+                       ? Check->formatEndIf(CPPVar)
+                       : "endif") +
+                  LineEnding)
+                     .str());
     }
   }
 

--- a/clang-tools-extra/clang-tidy/utils/IncludeSorter.cpp
+++ b/clang-tools-extra/clang-tidy/utils/IncludeSorter.cpp
@@ -142,20 +142,24 @@ void IncludeSorter::addInclude(StringRef FileName, bool IsAngled,
 
 std::optional<FixItHint>
 IncludeSorter::createIncludeInsertion(StringRef FileName, bool IsAngled) {
+  const StringRef LineEnding =
+      SourceMgr->getBufferData(CurrentFileID).detectEOL();
   std::string IncludeStmt;
   if (Style == IncludeStyle::IS_Google_ObjC) {
-    IncludeStmt = IsAngled
-                      ? llvm::Twine("#import <" + FileName + ">\n").str()
-                      : llvm::Twine("#import \"" + FileName + "\"\n").str();
+    IncludeStmt =
+        IsAngled
+            ? llvm::Twine("#import <" + FileName + ">" + LineEnding).str()
+            : llvm::Twine("#import \"" + FileName + "\"" + LineEnding).str();
   } else {
-    IncludeStmt = IsAngled
-                      ? llvm::Twine("#include <" + FileName + ">\n").str()
-                      : llvm::Twine("#include \"" + FileName + "\"\n").str();
+    IncludeStmt =
+        IsAngled
+            ? llvm::Twine("#include <" + FileName + ">" + LineEnding).str()
+            : llvm::Twine("#include \"" + FileName + "\"" + LineEnding).str();
   }
   if (SourceLocations.empty()) {
     // If there are no includes in this file, add it in the first line.
     // FIXME: insert after the file comment or the header guard, if present.
-    IncludeStmt.append("\n");
+    IncludeStmt.append(LineEnding.data(), LineEnding.size());
     return FixItHint::CreateInsertion(
         SourceMgr->getLocForStartOfFile(CurrentFileID), IncludeStmt);
   }
@@ -201,7 +205,7 @@ IncludeSorter::createIncludeInsertion(StringRef FileName, bool IsAngled) {
     const std::string &LastInclude = IncludeBucket[NonEmptyKind].back();
     const SourceRange LastIncludeLocation =
         IncludeLocations[LastInclude].back();
-    IncludeStmt = '\n' + IncludeStmt;
+    IncludeStmt.insert(0, LineEnding.data(), LineEnding.size());
     return FixItHint::CreateInsertion(LastIncludeLocation.getEnd(),
                                       IncludeStmt);
   }
@@ -209,7 +213,7 @@ IncludeSorter::createIncludeInsertion(StringRef FileName, bool IsAngled) {
   const std::string &FirstInclude = IncludeBucket[NonEmptyKind][0];
   const SourceRange FirstIncludeLocation =
       IncludeLocations[FirstInclude].back();
-  IncludeStmt.append("\n");
+  IncludeStmt.append(LineEnding.data(), LineEnding.size());
   return FixItHint::CreateInsertion(FirstIncludeLocation.getBegin(),
                                     IncludeStmt);
 }

--- a/clang-tools-extra/clang-tidy/utils/IncludeSorter.cpp
+++ b/clang-tools-extra/clang-tidy/utils/IncludeSorter.cpp
@@ -159,7 +159,7 @@ IncludeSorter::createIncludeInsertion(StringRef FileName, bool IsAngled) {
   if (SourceLocations.empty()) {
     // If there are no includes in this file, add it in the first line.
     // FIXME: insert after the file comment or the header guard, if present.
-    IncludeStmt.append(LineEnding.data(), LineEnding.size());
+    IncludeStmt.append(LineEnding);
     return FixItHint::CreateInsertion(
         SourceMgr->getLocForStartOfFile(CurrentFileID), IncludeStmt);
   }
@@ -205,7 +205,7 @@ IncludeSorter::createIncludeInsertion(StringRef FileName, bool IsAngled) {
     const std::string &LastInclude = IncludeBucket[NonEmptyKind].back();
     const SourceRange LastIncludeLocation =
         IncludeLocations[LastInclude].back();
-    IncludeStmt.insert(0, LineEnding.data(), LineEnding.size());
+    IncludeStmt.insert(0, LineEnding);
     return FixItHint::CreateInsertion(LastIncludeLocation.getEnd(),
                                       IncludeStmt);
   }
@@ -213,7 +213,7 @@ IncludeSorter::createIncludeInsertion(StringRef FileName, bool IsAngled) {
   const std::string &FirstInclude = IncludeBucket[NonEmptyKind][0];
   const SourceRange FirstIncludeLocation =
       IncludeLocations[FirstInclude].back();
-  IncludeStmt.append(LineEnding.data(), LineEnding.size());
+  IncludeStmt.append(LineEnding);
   return FixItHint::CreateInsertion(FirstIncludeLocation.getBegin(),
                                     IncludeStmt);
 }


### PR DESCRIPTION
This commit avoids introducing LF-only lines into files that use CRLF when clang-tidy inserts new includes or adds missing header guards.

As of AI Usage: Assisted by Codex
Follow-up of #202271