### PR TITLE
[Matrix][HLSL]  Fix transpose matrix layout bugs

### DIFF
--- a/clang/include/clang/Sema/SemaHLSL.h
+++ b/clang/include/clang/Sema/SemaHLSL.h
@@ -192,6 +192,9 @@ public:
   Attr *buildMatrixLayoutTypeAttr(QualType T, const ParsedAttr &AL);
   bool diagnoseMatrixLayoutInstantiation(attr::Kind K, QualType T,
                                          SourceLocation Loc);
+  // Re-type a layout-adapting matrix builtin call \p E with \p DestType's
+  // row_major/column_major sugar so CodeGen lowers it into that layout.
+  void propagateContextualMatrixLayout(Expr *E, QualType DestType);
   bool handleResourceTypeAttr(QualType T, const ParsedAttr &AL);
 
   template <typename T>

--- a/clang/lib/CodeGen/CGHLSLBuiltins.cpp
+++ b/clang/lib/CodeGen/CGHLSLBuiltins.cpp
@@ -1281,21 +1281,17 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
     unsigned Rows = MatTy->getNumRows();
     unsigned Cols = MatTy->getNumColumns();
     llvm::MatrixBuilder MB(Builder);
-    // The flattened in-register layout of an HLSL matrix depends on its
-    // declared row_major/column_major layout, so the correct lowering of a
-    // transpose depends on both the source layout and the result layout.
+    // The correct lowering of a transpose depends on both the source layout
+    // and the result layout.
     bool SrcRowMajor = isMatrixRowMajor(getLangOpts(), E->getArg(0)->getType());
     bool DstRowMajor = isMatrixRowMajor(getLangOpts(), E->getType());
-    // A row-major RxC matrix and a column-major CxR matrix share the same
-    // flattened representation. When the source and result layouts differ, the
-    // operand already holds the transposed result, so the transpose is a no-op
-    // on the underlying vector.
+    //  When the source & result layouts differ, the operand already holds the
+    //  transposed result, ie transpose is a no-op on the underlying vector.
     if (SrcRowMajor != DstRowMajor)
       return Op0;
-    // When the source and result share a layout, emit a real transpose. For
-    // row-major operands the dimensions are swapped because a row-major RxC
-    // matrix is laid out like a column-major CxR matrix.
+    // When the source and result share a layout, emit a transpose.
     if (SrcRowMajor)
+      // For row-major operands the dimensions are swapped
       return MB.CreateMatrixTranspose(Op0, Cols, Rows);
     return MB.CreateMatrixTranspose(Op0, Rows, Cols);
   }

--- a/clang/lib/CodeGen/CGHLSLBuiltins.cpp
+++ b/clang/lib/CodeGen/CGHLSLBuiltins.cpp
@@ -1281,12 +1281,21 @@ Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
     unsigned Rows = MatTy->getNumRows();
     unsigned Cols = MatTy->getNumColumns();
     llvm::MatrixBuilder MB(Builder);
-    // The matrix transpose intrinsic operates on column-major matrices.
-    // For row-major, a row-major RxC matrix is equivalent to a column-major
-    // CxR matrix, so transposing with swapped dimensions produces the correct
-    // row-major CxR result directly.
-    bool IsRowMajor = isMatrixRowMajor(getLangOpts(), E->getArg(0)->getType());
-    if (IsRowMajor)
+    // The flattened in-register layout of an HLSL matrix depends on its
+    // declared row_major/column_major layout, so the correct lowering of a
+    // transpose depends on both the source layout and the result layout.
+    bool SrcRowMajor = isMatrixRowMajor(getLangOpts(), E->getArg(0)->getType());
+    bool DstRowMajor = isMatrixRowMajor(getLangOpts(), E->getType());
+    // A row-major RxC matrix and a column-major CxR matrix share the same
+    // flattened representation. When the source and result layouts differ, the
+    // operand already holds the transposed result, so the transpose is a no-op
+    // on the underlying vector.
+    if (SrcRowMajor != DstRowMajor)
+      return Op0;
+    // When the source and result share a layout, emit a real transpose. For
+    // row-major operands the dimensions are swapped because a row-major RxC
+    // matrix is laid out like a column-major CxR matrix.
+    if (SrcRowMajor)
       return MB.CreateMatrixTranspose(Op0, Cols, Rows);
     return MB.CreateMatrixTranspose(Op0, Rows, Cols);
   }

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -2804,6 +2804,39 @@ bool SemaHLSL::diagnoseMatrixLayoutInstantiation(attr::Kind K, QualType T,
   return true;
 }
 
+// Transpose and matrix mul need to read the destination layout.
+// Elementwise builtins reuse the operand layout instead.
+static bool isLayoutAdaptingMatrixBuiltin(unsigned BuiltinID) {
+  switch (BuiltinID) {
+  case Builtin::BI__builtin_hlsl_mul:
+  case Builtin::BI__builtin_hlsl_transpose:
+    return true;
+  default:
+    return false;
+  }
+}
+
+void SemaHLSL::propagateContextualMatrixLayout(Expr *E, QualType DestType) {
+  if (!E || DestType.isNull())
+    return;
+  const auto *DestMat = DestType->getAs<ConstantMatrixType>();
+  if (!DestMat)
+    return;
+  auto *Call = dyn_cast<CallExpr>(E->IgnoreParenImpCasts());
+  if (!Call)
+    return;
+  const FunctionDecl *Callee = Call->getDirectCallee();
+  if (!Callee || !isLayoutAdaptingMatrixBuiltin(Callee->getBuiltinID()))
+    return;
+  const auto *CallMat = Call->getType()->getAs<ConstantMatrixType>();
+  if (!CallMat || CallMat->getNumRows() != DestMat->getNumRows() ||
+      CallMat->getNumColumns() != DestMat->getNumColumns())
+    return;
+  // Re-type the call with the destination sugar so CodeGen lowers into that
+  // layout, not the TU default.
+  Call->setType(DestType.getUnqualifiedType());
+}
+
 namespace {
 
 /// This class implements HLSL availability diagnostics for default

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -34,6 +34,7 @@
 #include "clang/Sema/Scope.h"
 #include "clang/Sema/ScopeInfo.h"
 #include "clang/Sema/SemaCUDA.h"
+#include "clang/Sema/SemaHLSL.h"
 #include "clang/Sema/SemaObjC.h"
 #include "clang/Sema/SemaOpenMP.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -4223,6 +4224,11 @@ StmtResult Sema::BuildReturnStmt(SourceLocation ReturnLoc, Expr *RetValExp,
         return StmtError();
       }
       RetValExp = Res.getAs<Expr>();
+
+      // A returned HLSL matrix may need its layout reconciled with the
+      // function's row_major/column_major return type.
+      if (getLangOpts().HLSL && RetValExp && RetType->isMatrixType())
+        HLSL().propagateContextualMatrixLayout(RetValExp, RetType);
 
       // If we have a related result type, we need to implicitly
       // convert back to the formal result type.  We can't pretend to

--- a/clang/test/CodeGenHLSL/matrix-layout-attr-overrides-default.hlsl
+++ b/clang/test/CodeGenHLSL/matrix-layout-attr-overrides-default.hlsl
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes -fmatrix-memory-layout=column-major -o - | FileCheck %s
-// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes -fmatrix-memory-layout=row-major -o - | FileCheck %s
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes -fmatrix-memory-layout=column-major -o - | FileCheck %s --check-prefixes=CHECK,COL
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes -fmatrix-memory-layout=row-major -o - | FileCheck %s --check-prefixes=CHECK,ROW
 
 // Verifies that a per-decl `[[hlsl::row_major]]` / `[[hlsl::column_major]]`
 // (spelled `row_major` / `column_major` in HLSL) overrides the
@@ -107,19 +107,28 @@ export float2x2 mat_mat_cm_rm(column_major float2x3 a, row_major float3x2 b) { r
 // CHECK: call {{.*}} <4 x float> @llvm.matrix.multiply.v4f32.v6f32.v6f32(<6 x float> [[AMat]], <6 x float> [[T]], i32 2, i32 3, i32 2)
 
 // -----------------------------------------------------------------------------
-// __builtin_hlsl_transpose: row-major operand swaps Rows/Cols passed to the
-// underlying intrinsic.
+// __builtin_hlsl_transpose: the lowering depends on both the operand layout and
+// the result layout. The builtin's result type carries the TU default layout,
+// so when the operand's per-decl layout differs from the default the operand
+// already holds the transposed bits and no intrinsic is emitted. When the
+// layouts match a real transpose is emitted (row-major swaps Rows/Cols).
 // -----------------------------------------------------------------------------
 
-// Row-major float2x3 transposed: passes (Cols=3, Rows=2) to the intrinsic.
+// Row-major float2x3 operand. With a column-major default result the layouts
+// differ -> no intrinsic. With a row-major default they match -> transpose
+// (Cols=3, Rows=2).
 export float3x2 transpose_rm(row_major float2x3 m) { return transpose(m); }
 // CHECK-LABEL: define {{.*}} <6 x float> @_Z12transpose_rmu11matrix_typeILm2ELm3EfE
-// CHECK: call {{.*}} <6 x float> @llvm.matrix.transpose.v6f32(<6 x float> %{{.*}}, i32 3, i32 2)
+// COL-NOT: @llvm.matrix.transpose
+// ROW: call {{.*}} <6 x float> @llvm.matrix.transpose.v6f32(<6 x float> %{{.*}}, i32 3, i32 2)
 
-// Column-major float2x3 transposed: passes (Rows=2, Cols=3) to the intrinsic.
+// Column-major float2x3 operand. With a column-major default result the layouts
+// match -> transpose (Rows=2, Cols=3). With a row-major default they differ ->
+// no intrinsic.
 export float3x2 transpose_cm(column_major float2x3 m) { return transpose(m); }
 // CHECK-LABEL: define {{.*}} <6 x float> @_Z12transpose_cmu11matrix_typeILm2ELm3EfE
-// CHECK: call {{.*}} <6 x float> @llvm.matrix.transpose.v6f32(<6 x float> %{{.*}}, i32 2, i32 3)
+// COL: call {{.*}} <6 x float> @llvm.matrix.transpose.v6f32(<6 x float> %{{.*}}, i32 2, i32 3)
+// ROW-NOT: @llvm.matrix.transpose
 
 // -----------------------------------------------------------------------------
 // CK_HLSLMatrixTruncation: the shuffle mask that picks elements from the

--- a/clang/test/CodeGenHLSL/matrix-layout-attr-overrides-default.hlsl
+++ b/clang/test/CodeGenHLSL/matrix-layout-attr-overrides-default.hlsl
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes -fmatrix-memory-layout=column-major -o - | FileCheck %s --check-prefixes=CHECK,COL
-// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes -fmatrix-memory-layout=row-major -o - | FileCheck %s --check-prefixes=CHECK,ROW
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes -fmatrix-memory-layout=column-major -o - | FileCheck %s --check-prefixes=CHECK,COLMAJOR
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes -fmatrix-memory-layout=row-major -o - | FileCheck %s --check-prefixes=CHECK,ROWMAJOR
 
 // Verifies that a per-decl `[[hlsl::row_major]]` / `[[hlsl::column_major]]`
 // (spelled `row_major` / `column_major` in HLSL) overrides the
@@ -106,29 +106,57 @@ export float2x2 mat_mat_cm_rm(column_major float2x3 a, row_major float3x2 b) { r
 // CHECK: [[T:%.*]] = call {{.*}} <6 x float> @llvm.matrix.transpose.v6f32(<6 x float> [[BMat]], i32 2, i32 3)
 // CHECK: call {{.*}} <4 x float> @llvm.matrix.multiply.v4f32.v6f32.v6f32(<6 x float> [[AMat]], <6 x float> [[T]], i32 2, i32 3, i32 2)
 
-// -----------------------------------------------------------------------------
-// __builtin_hlsl_transpose: the lowering depends on both the operand layout and
-// the result layout. The builtin's result type carries the TU default layout,
-// so when the operand's per-decl layout differs from the default the operand
-// already holds the transposed bits and no intrinsic is emitted. When the
-// layouts match a real transpose is emitted (row-major swaps Rows/Cols).
-// -----------------------------------------------------------------------------
+// Column-major return: result transform tracks the TU default, not the keyword.
+export column_major float2x2 mat_mat_dst_cm(column_major float2x3 a, column_major float3x2 b) { return mul(a, b); }
+// CHECK-LABEL: define {{.*}} <4 x float> @_Z14mat_mat_dst_cm
+// CHECK: [[MUL:%.*]] = call {{.*}} <4 x float> @llvm.matrix.multiply.v4f32.v6f32.v6f32(<6 x float> %{{.*}}, <6 x float> %{{.*}}, i32 2, i32 3, i32 2)
+// CHECK-NOT: @llvm.matrix.transpose
 
-// Row-major float2x3 operand. With a column-major default result the layouts
-// differ -> no intrinsic. With a row-major default they match -> transpose
-// (Cols=3, Rows=2).
+// Row-major return: same result as above; the keyword does not force a transform.
+export row_major float2x2 mat_mat_dst_rm(column_major float2x3 a, column_major float3x2 b) { return mul(a, b); }
+// CHECK-LABEL: define {{.*}} <4 x float> @_Z14mat_mat_dst_rm
+// CHECK: [[MUL:%.*]] = call {{.*}} <4 x float> @llvm.matrix.multiply.v4f32.v6f32.v6f32(<6 x float> %{{.*}}, <6 x float> %{{.*}}, i32 2, i32 3, i32 2)
+// CHECK: call {{.*}} <4 x float> @llvm.matrix.transpose.v4f32(<4 x float> [[MUL]], i32 2, i32 2)
+
+
+// Row-major source -> column-major destination: bits already transposed, no-op.
+export column_major float3x2 transpose_rm_to_cm(row_major float2x3 m) { return transpose(m); }
+// CHECK-LABEL: define {{.*}} <6 x float> @_Z18transpose_rm_to_cmu11matrix_typeILm2ELm3EfE
+// CHECK-NOT: @llvm.matrix.transpose
+// CHECK: ret <6 x float>
+
+// Column-major source -> row-major destination: bits already transposed, no-op.
+export row_major float3x2 transpose_cm_to_rm(column_major float2x3 m) { return transpose(m); }
+// CHECK-LABEL: define {{.*}} <6 x float> @_Z18transpose_cm_to_rmu11matrix_typeILm2ELm3EfE
+// CHECK-NOT: @llvm.matrix.transpose
+// CHECK: ret <6 x float>
+
+// Row-major source -> row-major destination: real transpose, dims swapped.
+export row_major float3x2 transpose_rm_to_rm(row_major float2x3 m) { return transpose(m); }
+// CHECK-LABEL: define {{.*}} <6 x float> @_Z18transpose_rm_to_rmu11matrix_typeILm2ELm3EfE
+// CHECK: call {{.*}} <6 x float> @llvm.matrix.transpose.v6f32(<6 x float> %{{.*}}, i32 3, i32 2)
+
+// Column-major source -> column-major destination: real transpose, natural dims.
+export column_major float3x2 transpose_cm_to_cm(column_major float2x3 m) { return transpose(m); }
+// CHECK-LABEL: define {{.*}} <6 x float> @_Z18transpose_cm_to_cmu11matrix_typeILm2ELm3EfE
+// CHECK: call {{.*}} <6 x float> @llvm.matrix.transpose.v6f32(<6 x float> %{{.*}}, i32 2, i32 3)
+
+// Default-layout return type: the TU `-fmatrix-memory-layout=` default 
+// flips between a real transpose and a no-op depending on the default.
 export float3x2 transpose_rm(row_major float2x3 m) { return transpose(m); }
 // CHECK-LABEL: define {{.*}} <6 x float> @_Z12transpose_rmu11matrix_typeILm2ELm3EfE
-// COL-NOT: @llvm.matrix.transpose
-// ROW: call {{.*}} <6 x float> @llvm.matrix.transpose.v6f32(<6 x float> %{{.*}}, i32 3, i32 2)
+// COLMAJOR-NOT: @llvm.matrix.transpose
+// COLMAJOR: ret <6 x float>
+// ROWMAJOR: call {{.*}} <6 x float> @llvm.matrix.transpose.v6f32(<6 x float> %{{.*}}, i32 3, i32 2)
 
-// Column-major float2x3 operand. With a column-major default result the layouts
-// match -> transpose (Rows=2, Cols=3). With a row-major default they differ ->
-// no intrinsic.
+
+// column-major default: src/dst match -> real transpose, natural dims.
+// row-major default: src/dst differ -> bits already transposed, no-op.
 export float3x2 transpose_cm(column_major float2x3 m) { return transpose(m); }
 // CHECK-LABEL: define {{.*}} <6 x float> @_Z12transpose_cmu11matrix_typeILm2ELm3EfE
-// COL: call {{.*}} <6 x float> @llvm.matrix.transpose.v6f32(<6 x float> %{{.*}}, i32 2, i32 3)
-// ROW-NOT: @llvm.matrix.transpose
+// COLMAJOR: call {{.*}} <6 x float> @llvm.matrix.transpose.v6f32(<6 x float> %{{.*}}, i32 2, i32 3)
+// ROWMAJOR-NOT: @llvm.matrix.transpose
+// ROWMAJOR: ret <6 x float>
 
 // -----------------------------------------------------------------------------
 // CK_HLSLMatrixTruncation: the shuffle mask that picks elements from the

--- a/clang/test/CodeGenHLSL/matrix-layout-attr-overrides-default.hlsl
+++ b/clang/test/CodeGenHLSL/matrix-layout-attr-overrides-default.hlsl
@@ -106,13 +106,13 @@ export float2x2 mat_mat_cm_rm(column_major float2x3 a, row_major float3x2 b) { r
 // CHECK: [[T:%.*]] = call {{.*}} <6 x float> @llvm.matrix.transpose.v6f32(<6 x float> [[BMat]], i32 2, i32 3)
 // CHECK: call {{.*}} <4 x float> @llvm.matrix.multiply.v4f32.v6f32.v6f32(<6 x float> [[AMat]], <6 x float> [[T]], i32 2, i32 3, i32 2)
 
-// Column-major return: result transform tracks the TU default, not the keyword.
+// Destination layout: the result is column-major, so no transpose is needed.
 export column_major float2x2 mat_mat_dst_cm(column_major float2x3 a, column_major float3x2 b) { return mul(a, b); }
 // CHECK-LABEL: define {{.*}} <4 x float> @_Z14mat_mat_dst_cm
 // CHECK: [[MUL:%.*]] = call {{.*}} <4 x float> @llvm.matrix.multiply.v4f32.v6f32.v6f32(<6 x float> %{{.*}}, <6 x float> %{{.*}}, i32 2, i32 3, i32 2)
 // CHECK-NOT: @llvm.matrix.transpose
 
-// Row-major return: same result as above; the keyword does not force a transform.
+// Destination layout: the result is row-major, so a transpose is needed.
 export row_major float2x2 mat_mat_dst_rm(column_major float2x3 a, column_major float3x2 b) { return mul(a, b); }
 // CHECK-LABEL: define {{.*}} <4 x float> @_Z14mat_mat_dst_rm
 // CHECK: [[MUL:%.*]] = call {{.*}} <4 x float> @llvm.matrix.multiply.v4f32.v6f32.v6f32(<6 x float> %{{.*}}, <6 x float> %{{.*}}, i32 2, i32 3, i32 2)


### PR DESCRIPTION

This change will resolve https://github.com/llvm/wg-hlsl/issues/305

It is a two-part change. First, we had a bug. The transpose builtin was previously only considering the Src for RowMajor when we also need to consider the  Dst RowMajor.

The second issue was the return stmt  needs us to  re-type the call with the sugared typed. We only want to do this for what I am calling  Layout Adapting Matrix Builtins ie transpose and matrix multiply  builtins. 

Assisted by Claude Opus 4.8