### PR TITLE
[clang-tidy] Avoid invalid fixes in `readability-delete-null-pointer`

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/DeleteNullPointerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/DeleteNullPointerCheck.cpp
@@ -34,8 +34,14 @@ void DeleteNullPointerCheck::registerMatchers(MatchFinder *Finder) {
   const auto BinaryPointerCheckCondition = binaryOperator(hasOperands(
       anyOf(cxxNullPtrLiteralExpr(), integerLiteral(equals(0))), PointerExpr));
 
+  const auto IfWithScopedCondition =
+      ifStmt(anyOf(hasInitStatement(stmt()),
+                   hasConditionVariableStatement(declStmt())))
+          .bind("ifWithScopedCondition");
+
   Finder->addMatcher(
       ifStmt(hasCondition(anyOf(PointerExpr, BinaryPointerCheckCondition)),
+             optionally(IfWithScopedCondition),
              hasThen(anyOf(
                  DeleteExpr, DeleteMemberExpr,
                  compoundStmt(anyOf(has(DeleteExpr), has(DeleteMemberExpr)),
@@ -47,12 +53,14 @@ void DeleteNullPointerCheck::registerMatchers(MatchFinder *Finder) {
 
 void DeleteNullPointerCheck::check(const MatchFinder::MatchResult &Result) {
   const auto *IfWithDelete = Result.Nodes.getNodeAs<IfStmt>("ifWithDelete");
+  const bool HasScopedCondition =
+      Result.Nodes.getNodeAs<IfStmt>("ifWithScopedCondition") != nullptr;
   const auto *Compound = Result.Nodes.getNodeAs<CompoundStmt>("compound");
 
   auto Diag = diag(
       IfWithDelete->getBeginLoc(),
       "'if' statement is unnecessary; deleting null pointer has no effect");
-  if (IfWithDelete->hasElseStorage())
+  if (HasScopedCondition || IfWithDelete->hasElseStorage())
     return;
   // FIXME: generate fixit for this case.
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -714,6 +714,10 @@ Changes in existing checks
   - Correctly detecting ``this`` usage when a generic lambda calls an overloaded
     member function.
 
+- Improved :doc:`readability-delete-null-pointer
+  <clang-tidy/checks/readability/delete-null-pointer>` check by avoiding invalid
+  fix-its for ``if`` statements with condition variables or initializers.
+
 - Improved :doc:`readability-else-after-return
   <clang-tidy/checks/readability/else-after-return>` check:
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/delete-null-pointer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/delete-null-pointer.cpp
@@ -156,3 +156,32 @@ void g() {
     delete p6;
   }
 }
+
+struct X {};
+X *makeX();
+struct Y {};
+Y *makeY();
+
+void conditionVariable() {
+  if (X *x = makeX())
+    delete x;
+  // CHECK-MESSAGES: :[[@LINE-2]]:3: warning: 'if' statement is unnecessary; deleting null pointer has no effect [readability-delete-null-pointer]
+
+  // CHECK-FIXES: if (X *x = makeX())
+  // CHECK-FIXES-NEXT: delete x;
+
+  if (X *x = makeX(); x)
+    delete x;
+  // CHECK-MESSAGES: :[[@LINE-2]]:3: warning: 'if' statement is unnecessary; deleting null pointer has no effect [readability-delete-null-pointer]
+
+  // CHECK-FIXES: if (X *x = makeX(); x)
+  // CHECK-FIXES-NEXT: delete x;
+
+  X *x = makeX();
+  if (Y *y = makeY(); x)
+    delete x;
+  // CHECK-MESSAGES: :[[@LINE-2]]:3: warning: 'if' statement is unnecessary; deleting null pointer has no effect [readability-delete-null-pointer]
+
+  // CHECK-FIXES: if (Y *y = makeY(); x)
+  // CHECK-FIXES-NEXT: delete x;
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/delete-null-pointer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/delete-null-pointer.cpp
@@ -167,21 +167,12 @@ void conditionVariable() {
     delete x;
   // CHECK-MESSAGES: :[[@LINE-2]]:3: warning: 'if' statement is unnecessary; deleting null pointer has no effect [readability-delete-null-pointer]
 
-  // CHECK-FIXES: if (X *x = makeX())
-  // CHECK-FIXES-NEXT: delete x;
-
   if (X *x = makeX(); x)
     delete x;
   // CHECK-MESSAGES: :[[@LINE-2]]:3: warning: 'if' statement is unnecessary; deleting null pointer has no effect [readability-delete-null-pointer]
-
-  // CHECK-FIXES: if (X *x = makeX(); x)
-  // CHECK-FIXES-NEXT: delete x;
 
   X *x = makeX();
   if (Y *y = makeY(); x)
     delete x;
   // CHECK-MESSAGES: :[[@LINE-2]]:3: warning: 'if' statement is unnecessary; deleting null pointer has no effect [readability-delete-null-pointer]
-
-  // CHECK-FIXES: if (Y *y = makeY(); x)
-  // CHECK-FIXES-NEXT: delete x;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/delete-null-pointer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/delete-null-pointer.cpp
@@ -169,10 +169,10 @@ void conditionVariable() {
 
   if (X *x = makeX(); x)
     delete x;
-  // CHECK-MESSAGES: :[[@LINE-2]]:3: warning: 'if' statement is unnecessary; deleting null pointer has no effect [readability-delete-null-pointer]
+  // CHECK-MESSAGES: :[[@LINE-2]]:3: warning: 'if' statement is unnecessary; deleting null pointer has no effect
 
   X *x = makeX();
   if (Y *y = makeY(); x)
     delete x;
-  // CHECK-MESSAGES: :[[@LINE-2]]:3: warning: 'if' statement is unnecessary; deleting null pointer has no effect [readability-delete-null-pointer]
+  // CHECK-MESSAGES: :[[@LINE-2]]:3: warning: 'if' statement is unnecessary; deleting null pointer has no effect
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/delete-null-pointer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/delete-null-pointer.cpp
@@ -165,7 +165,7 @@ Y *makeY();
 void conditionVariable() {
   if (X *x = makeX())
     delete x;
-// CHECK-MESSAGES: :[[@LINE-2]]:3: warning: 'if' statement is unnecessary; deleting null pointer has no effect
+  // CHECK-MESSAGES: :[[@LINE-2]]:3: warning: 'if' statement is unnecessary; deleting null pointer has no effect
 
   if (X *x = makeX(); x)
     delete x;

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/delete-null-pointer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/delete-null-pointer.cpp
@@ -165,7 +165,7 @@ Y *makeY();
 void conditionVariable() {
   if (X *x = makeX())
     delete x;
-  // CHECK-MESSAGES: :[[@LINE-2]]:3: warning: 'if' statement is unnecessary; deleting null pointer has no effect [readability-delete-null-pointer]
+// CHECK-MESSAGES: :[[@LINE-2]]:3: warning: 'if' statement is unnecessary; deleting null pointer has no effect
 
   if (X *x = makeX(); x)
     delete x;


### PR DESCRIPTION
Only provide warnings (not fixits) when `IfStmt` has condition variable or initializer.

Note that i didn't provide fixit for the situation that conditon variable is different with the pointer variable being cast to bool because i think this is rare. (the third newly added testcase)

Closes #202312.
