### PR TITLE
[InstCombine] Don't copy ninf when narrowing fptrunc(binop(fpext, fpext))

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -2206,6 +2206,12 @@ Instruction *InstCombinerImpl::visitFPTrunc(FPTruncInst &FPT) {
     unsigned RHSWidth = RHSMinType->getFPMantissaWidth();
     unsigned SrcWidth = std::max(LHSWidth, RHSWidth);
     unsigned DstWidth = Ty->getFPMantissaWidth();
+
+    // Narrowing recomputes the binop in a smaller type, which can overflow to
+    // inf where the wide op was finite. Therefore we have to drop ninf.
+    FastMathFlags NarrowFMF = BO->getFastMathFlags();
+    NarrowFMF.setNoInfs(false);
+
     switch (BO->getOpcode()) {
       default: break;
       case Instruction::FAdd:
@@ -2232,7 +2238,7 @@ Instruction *InstCombinerImpl::visitFPTrunc(FPTruncInst &FPT) {
           Value *LHS = Builder.CreateFPTrunc(BO->getOperand(0), Ty);
           Value *RHS = Builder.CreateFPTrunc(BO->getOperand(1), Ty);
           Instruction *RI = BinaryOperator::Create(BO->getOpcode(), LHS, RHS);
-          RI->copyFastMathFlags(BO);
+          RI->setFastMathFlags(NarrowFMF);
           return RI;
         }
         break;
@@ -2245,7 +2251,7 @@ Instruction *InstCombinerImpl::visitFPTrunc(FPTruncInst &FPT) {
         if (OpWidth >= LHSWidth + RHSWidth && DstWidth >= SrcWidth) {
           Value *LHS = Builder.CreateFPTrunc(BO->getOperand(0), Ty);
           Value *RHS = Builder.CreateFPTrunc(BO->getOperand(1), Ty);
-          return BinaryOperator::CreateFMulFMF(LHS, RHS, BO);
+          return BinaryOperator::CreateFMulFMF(LHS, RHS, NarrowFMF);
         }
         break;
       case Instruction::FDiv:
@@ -2258,7 +2264,7 @@ Instruction *InstCombinerImpl::visitFPTrunc(FPTruncInst &FPT) {
         if (OpWidth >= 2*DstWidth && DstWidth >= SrcWidth) {
           Value *LHS = Builder.CreateFPTrunc(BO->getOperand(0), Ty);
           Value *RHS = Builder.CreateFPTrunc(BO->getOperand(1), Ty);
-          return BinaryOperator::CreateFDivFMF(LHS, RHS, BO);
+          return BinaryOperator::CreateFDivFMF(LHS, RHS, NarrowFMF);
         }
         break;
       case Instruction::FRem: {

--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -2207,10 +2207,14 @@ Instruction *InstCombinerImpl::visitFPTrunc(FPTruncInst &FPT) {
     unsigned SrcWidth = std::max(LHSWidth, RHSWidth);
     unsigned DstWidth = Ty->getFPMantissaWidth();
 
-    // Narrowing recomputes the binop in a smaller type, which can overflow to
-    // inf where the wide op was finite. Therefore we have to drop ninf.
+    // The narrowed binop keeps ninf only if both the binop and the fptrunc
+    // have it. ninf constrains both operands and result: the binop's ninf
+    // covers the (bit-identical) narrow operands but not the result, since
+    // narrowing can overflow to inf where the wide op was finite; the
+    // fptrunc's ninf covers the result (whose value the narrowed binop
+    // takes over) but not the operands.
     FastMathFlags NarrowFMF = BO->getFastMathFlags();
-    NarrowFMF.setNoInfs(false);
+    NarrowFMF.setNoInfs(NarrowFMF.noInfs() && FPT.hasNoInfs());
 
     switch (BO->getOpcode()) {
       default: break;

--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -2207,12 +2207,9 @@ Instruction *InstCombinerImpl::visitFPTrunc(FPTruncInst &FPT) {
     unsigned SrcWidth = std::max(LHSWidth, RHSWidth);
     unsigned DstWidth = Ty->getFPMantissaWidth();
 
-    // The narrowed binop keeps ninf only if both the binop and the fptrunc
-    // have it. ninf constrains both operands and result: the binop's ninf
-    // covers the (bit-identical) narrow operands but not the result, since
-    // narrowing can overflow to inf where the wide op was finite; the
-    // fptrunc's ninf covers the result (whose value the narrowed binop
-    // takes over) but not the operands.
+    // Narrowing recomputes the binop in a smaller type, which can overflow to
+    // inf where the wide op was finite. Therefore we can only keep ninf if
+    // both the binop and the fptrunc have that flag.
     FastMathFlags NarrowFMF = BO->getFastMathFlags();
     NarrowFMF.setNoInfs(NarrowFMF.noInfs() && FPT.hasNoInfs());
 

--- a/llvm/test/Transforms/InstCombine/fptrunc.ll
+++ b/llvm/test/Transforms/InstCombine/fptrunc.ll
@@ -288,3 +288,84 @@ define float @fptrunc_narrow_outside_float_range(i64 %x) {
   %conv4 = fptrunc double %div3 to float
   ret float %conv4
 }
+
+; Narrowing fptrunc(binop(fpext,fpext)) recomputes the binop in a smaller type,
+; which can overflow to inf where the wide op was finite. ninf must NOT be
+; copied to the narrowed op (it would make that inf poison: miscompile). nnan is
+; value-based and stays sound, so it is preserved.
+
+define half @fmul_narrow_drop_ninf(half %x, half %y) {
+; CHECK-LABEL: @fmul_narrow_drop_ninf(
+; CHECK-NEXT:    [[R:%.*]] = fmul half [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    ret half [[R]]
+;
+  %wx = fpext half %x to float
+  %wy = fpext half %y to float
+  %m = fmul ninf float %wx, %wy
+  %r = fptrunc float %m to half
+  ret half %r
+}
+
+define half @fadd_narrow_drop_ninf(half %x, half %y) {
+; CHECK-LABEL: @fadd_narrow_drop_ninf(
+; CHECK-NEXT:    [[R:%.*]] = fadd half [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    ret half [[R]]
+;
+  %wx = fpext half %x to float
+  %wy = fpext half %y to float
+  %m = fadd ninf float %wx, %wy
+  %r = fptrunc float %m to half
+  ret half %r
+}
+
+define half @fsub_narrow_drop_ninf(half %x, half %y) {
+; CHECK-LABEL: @fsub_narrow_drop_ninf(
+; CHECK-NEXT:    [[R:%.*]] = fsub half [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    ret half [[R]]
+;
+  %wx = fpext half %x to float
+  %wy = fpext half %y to float
+  %m = fsub ninf float %wx, %wy
+  %r = fptrunc float %m to half
+  ret half %r
+}
+
+define half @fdiv_narrow_drop_ninf(half %x, half %y) {
+; CHECK-LABEL: @fdiv_narrow_drop_ninf(
+; CHECK-NEXT:    [[R:%.*]] = fdiv half [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    ret half [[R]]
+;
+  %wx = fpext half %x to float
+  %wy = fpext half %y to float
+  %m = fdiv ninf float %wx, %wy
+  %r = fptrunc float %m to half
+  ret half %r
+}
+
+; nnan is sound to keep; ninf is still dropped.
+
+define half @fmul_narrow_keep_nnan_drop_ninf(half %x, half %y) {
+; CHECK-LABEL: @fmul_narrow_keep_nnan_drop_ninf(
+; CHECK-NEXT:    [[R:%.*]] = fmul nnan half [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    ret half [[R]]
+;
+  %wx = fpext half %x to float
+  %wy = fpext half %y to float
+  %m = fmul nnan ninf float %wx, %wy
+  %r = fptrunc float %m to half
+  ret half %r
+}
+
+; Other flags (reassoc) are preserved; only ninf is cleared.
+
+define half @fmul_narrow_keep_reassoc_drop_ninf(half %x, half %y) {
+; CHECK-LABEL: @fmul_narrow_keep_reassoc_drop_ninf(
+; CHECK-NEXT:    [[R:%.*]] = fmul reassoc half [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    ret half [[R]]
+;
+  %wx = fpext half %x to float
+  %wy = fpext half %y to float
+  %m = fmul reassoc ninf float %wx, %wy
+  %r = fptrunc float %m to half
+  ret half %r
+}

--- a/llvm/test/Transforms/InstCombine/fptrunc.ll
+++ b/llvm/test/Transforms/InstCombine/fptrunc.ll
@@ -290,9 +290,11 @@ define float @fptrunc_narrow_outside_float_range(i64 %x) {
 }
 
 ; Narrowing fptrunc(binop(fpext,fpext)) recomputes the binop in a smaller type,
-; which can overflow to inf where the wide op was finite. ninf must NOT be
-; copied to the narrowed op (it would make that inf poison: miscompile). nnan is
-; value-based and stays sound, so it is preserved.
+; which can overflow to inf where the wide op was finite, so the binop's ninf
+; alone must NOT be copied to the narrowed op (it would make that inf poison:
+; miscompile). nnan is value-based and stays sound, so it is preserved. ninf
+; survives only when both the binop and the fptrunc have it: the binop's ninf
+; covers the narrowed op's operands, the fptrunc's covers its result.
 
 define half @fmul_narrow_drop_ninf(half %x, half %y) {
 ; CHECK-LABEL: @fmul_narrow_drop_ninf(
@@ -367,5 +369,64 @@ define half @fmul_narrow_keep_reassoc_drop_ninf(half %x, half %y) {
   %wy = fpext half %y to float
   %m = fmul reassoc ninf float %wx, %wy
   %r = fptrunc float %m to half
+  ret half %r
+}
+
+; ninf on the fptrunc alone must NOT transfer to the narrowed binop either:
+; ninf also constrains the operands. With x = inf, y = 0.0, the wide fmul is
+; nan and fptrunc ninf of nan is well-defined, but fmul ninf half inf, 0.0
+; would be poison.
+
+define half @fmul_narrow_ninf_only_on_fptrunc(half %x, half %y) {
+; CHECK-LABEL: @fmul_narrow_ninf_only_on_fptrunc(
+; CHECK-NEXT:    [[R:%.*]] = fmul half [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    ret half [[R]]
+;
+  %wx = fpext half %x to float
+  %wy = fpext half %y to float
+  %m = fmul float %wx, %wy
+  %r = fptrunc ninf float %m to half
+  ret half %r
+}
+
+; ninf on both the binop and the fptrunc is kept.
+
+define half @fmul_narrow_ninf_on_both(half %x, half %y) {
+; CHECK-LABEL: @fmul_narrow_ninf_on_both(
+; CHECK-NEXT:    [[R:%.*]] = fmul ninf half [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    ret half [[R]]
+;
+  %wx = fpext half %x to float
+  %wy = fpext half %y to float
+  %m = fmul ninf float %wx, %wy
+  %r = fptrunc ninf float %m to half
+  ret half %r
+}
+
+; Same for fdiv, where even a finite result shows it: with x = 1.0, y = inf,
+; the wide fdiv is 0.0 and the fptrunc ninf is fully defined, but
+; fdiv ninf half 1.0, inf would be poison.
+
+define half @fdiv_narrow_ninf_only_on_fptrunc(half %x, half %y) {
+; CHECK-LABEL: @fdiv_narrow_ninf_only_on_fptrunc(
+; CHECK-NEXT:    [[R:%.*]] = fdiv half [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    ret half [[R]]
+;
+  %wx = fpext half %x to float
+  %wy = fpext half %y to float
+  %m = fdiv float %wx, %wy
+  %r = fptrunc ninf float %m to half
+  ret half %r
+}
+
+define half @fdiv_narrow_ninf_on_both(half %x, half %y) {
+; CHECK-LABEL: @fdiv_narrow_ninf_on_both(
+; CHECK-NEXT:    [[R:%.*]] = fdiv ninf half [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    ret half [[R]]
+;
+  %wx = fpext half %x to float
+  %wy = fpext half %y to float
+  %m = fdiv ninf float %wx, %wy
+  %r = fptrunc ninf float %m to half
   ret half %r
 }


### PR DESCRIPTION
The fold narrows fptrunc(BO(fpext x, fpext y)) -> BO(x, y) for
fadd/fsub/fmul/fdiv, recomputing the binop directly in the narrower type.

Even if the original BO returns a finite result, the fptrunc may produce
inf. Therefore even if the original BO has ninf, we have to drop it on
the new BO.
