### PR TITLE
[Clang][test] Add inferred nofree to attr-counted-by-issue200014.c checks

### DIFF
--- a/clang/test/CodeGen/attr-counted-by-issue200014.c
+++ b/clang/test/CodeGen/attr-counted-by-issue200014.c
@@ -282,7 +282,7 @@ size_t global_addrof(void) {
 // FRONTEND-NEXT:    ret i64 [[TMP1]]
 //
 // O2-LABEL: define dso_local range(i64 0, -9223372036854775808) i64 @ptr_fam(
-// O2-SAME: ptr noundef readonly captures(none) [[P:%.*]]) local_unnamed_addr #[[ATTR4:[0-9]+]] {
+// O2-SAME: ptr nofree noundef readonly captures(none) [[P:%.*]]) local_unnamed_addr #[[ATTR4:[0-9]+]] {
 // O2-NEXT:  [[ENTRY:.*:]]
 // O2-NEXT:    [[COUNTED_BY_LOAD:%.*]] = load i64, ptr [[P]], align 4
 // O2-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.smax.i64(i64 [[COUNTED_BY_LOAD]], i64 0)
@@ -310,7 +310,7 @@ size_t ptr_fam(struct annotated_flex *p) {
 // FRONTEND-NEXT:    ret i64 [[TMP2]]
 //
 // O2-LABEL: define dso_local range(i64 0, -9223372036854775808) i64 @ptr_subscript(
-// O2-SAME: ptr noundef readonly captures(none) [[P:%.*]]) local_unnamed_addr #[[ATTR4]] {
+// O2-SAME: ptr nofree noundef readonly captures(none) [[P:%.*]]) local_unnamed_addr #[[ATTR4]] {
 // O2-NEXT:  [[ENTRY:.*:]]
 // O2-NEXT:    [[COUNTED_BY_LOAD:%.*]] = load i64, ptr [[P]], align 4
 // O2-NEXT:    [[RESULT:%.*]] = add i64 [[COUNTED_BY_LOAD]], -3
@@ -332,7 +332,7 @@ size_t ptr_subscript(struct annotated_flex *p) {
 // FRONTEND-NEXT:    ret i64 [[TMP0]]
 //
 // O2-LABEL: define dso_local i64 @ptr_addrof(
-// O2-SAME: ptr noundef readnone [[P:%.*]]) local_unnamed_addr #[[ATTR3]] {
+// O2-SAME: ptr nofree noundef readnone [[P:%.*]]) local_unnamed_addr #[[ATTR3]] {
 // O2-NEXT:  [[ENTRY:.*:]]
 // O2-NEXT:    ret i64 -1
 //


### PR DESCRIPTION
Commit 89905ff21441 ("[FunctionAttrs] Add support for nofree argument inference", #201591) infers a `nofree` parameter attribute at `-O2`. The test `attr-counted-by-issue200014.c` (added later in #201161) was generated before that change, so its `O2-SAME` lines omit `nofree` and currently fail on `main`:

```
O2-SAME: ptr noundef readonly captures(none) ...   (expected by test)
         ptr nofree noundef readonly captures(none) ...   (actual codegen)
```

This regenerates the checks with `update_cc_test_checks.py`. Test-only, NFC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)