### PR TITLE
[clang][bytecode] Fix an assertion failure in visitDtorCall()

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -5418,6 +5418,11 @@ bool Compiler<Emitter>::visitDtorCall(const VarDecl *VD, const APValue &Value) {
   if (!D)
     return false;
 
+  // FIXME: Would be nice if we didn't allocate the descriptor at all in this
+  // case.
+  if (D->hasTrivialDtor())
+    return true;
+
   Scope::Local Local = this->createLocal(D);
   Locals.insert({VD, Local});
   VarScope->addForScopeKind(Local, ScopeKind::Block);

--- a/clang/test/AST/ByteCode/unions.cpp
+++ b/clang/test/AST/ByteCode/unions.cpp
@@ -1084,3 +1084,15 @@ namespace Revive {
                             // both-note {{in call to}}
 }
 #endif
+
+namespace TrivialDtorInEvaluateDtor{
+  template <class T> void foo() {
+    union { // both-error {{attempt to use a deleted function}}
+      T t; // both-note {{implicitly deleted}}
+    };
+  }
+  struct S {
+    ~S();
+  };
+  template void foo<S>(); // both-note {{in instantiation of function template specialization}}
+}


### PR DESCRIPTION
In `emitDestructionPop()`, we assert that the Descriptor has a non-trivial dtor. Check this first here so we don't do all this work for nothing.