### PR TITLE
[Driver][RISCV] Fix musl dynamic linker path for RISC-V sf/sp ABI

### DIFF
--- a/clang/lib/Driver/ToolChains/Linux.cpp
+++ b/clang/lib/Driver/ToolChains/Linux.cpp
@@ -607,6 +607,14 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
     if (Arch == llvm::Triple::ppc &&
         Triple.getSubArch() == llvm::Triple::PPCSubArch_spe)
       ArchName = "powerpc-sf";
+    if (Triple.isRISCV()) {
+      StringRef ABIName = tools::riscv::getRISCVABI(Args, Triple);
+      if (ABIName == "ilp32" || ABIName == "lp64") {
+        ArchName += "-sf";
+      } else if (ABIName == "ilp32f" || ABIName == "lp64f") {
+        ArchName += "-sp";
+      }
+    }
 
     return "/lib/ld-musl-" + ArchName + ".so.1";
   }

--- a/clang/test/Driver/linux-ld.c
+++ b/clang/test/Driver/linux-ld.c
@@ -1702,6 +1702,24 @@
 // RUN: %clang -### %s -no-pie 2>&1 \
 // RUN:     --target=aarch64_be-pc-linux-musl \
 // RUN:   | FileCheck --check-prefix=CHECK-MUSL-AARCH64_BE %s
+// RUN: %clang -### %s -no-pie 2>&1 \
+// RUN:     --target=riscv32-pc-linux-musl -march=rv32im -mabi=ilp32 \
+// RUN:   | FileCheck --check-prefix=CHECK-MUSL-RISCV32-SF %s
+// RUN: %clang -### %s -no-pie 2>&1 \
+// RUN:     --target=riscv32-pc-linux-musl -march=rv32imf -mabi=ilp32f \
+// RUN:   | FileCheck --check-prefix=CHECK-MUSL-RISCV32-SP %s
+// RUN: %clang -### %s -no-pie 2>&1 \
+// RUN:     --target=riscv32-pc-linux-musl -march=rv32imfd -mabi=ilp32d \
+// RUN:   | FileCheck --check-prefix=CHECK-MUSL-RISCV32 %s
+// RUN: %clang -### %s -no-pie 2>&1 \
+// RUN:     --target=riscv64-pc-linux-musl -march=rv64im -mabi=lp64 \
+// RUN:   | FileCheck --check-prefix=CHECK-MUSL-RISCV64-SF %s
+// RUN: %clang -### %s -no-pie 2>&1 \
+// RUN:     --target=riscv64-pc-linux-musl -march=rv64imf -mabi=lp64f \
+// RUN:   | FileCheck --check-prefix=CHECK-MUSL-RISCV64-SP %s
+// RUN: %clang -### %s -no-pie 2>&1 \
+// RUN:     --target=riscv64-pc-linux-musl -march=rv64imfd -mabi=lp64d \
+// RUN:   | FileCheck --check-prefix=CHECK-MUSL-RISCV64 %s
 // CHECK-MUSL-X86:        "-dynamic-linker" "/lib/ld-musl-i386.so.1"
 // CHECK-MUSL-X86_64:     "-dynamic-linker" "/lib/ld-musl-x86_64.so.1"
 // CHECK-MUSL-MIPS:       "-dynamic-linker" "/lib/ld-musl-mips.so.1"
@@ -1717,6 +1735,12 @@
 // CHECK-MUSL-ARMEBHF:    "-dynamic-linker" "/lib/ld-musl-armebhf.so.1"
 // CHECK-MUSL-AARCH64:    "-dynamic-linker" "/lib/ld-musl-aarch64.so.1"
 // CHECK-MUSL-AARCH64_BE: "-dynamic-linker" "/lib/ld-musl-aarch64_be.so.1"
+// CHECK-MUSL-RISCV32-SF: "-dynamic-linker" "/lib/ld-musl-riscv32-sf.so.1"
+// CHECK-MUSL-RISCV32-SP: "-dynamic-linker" "/lib/ld-musl-riscv32-sp.so.1"
+// CHECK-MUSL-RISCV32:    "-dynamic-linker" "/lib/ld-musl-riscv32.so.1"
+// CHECK-MUSL-RISCV64-SF: "-dynamic-linker" "/lib/ld-musl-riscv64-sf.so.1"
+// CHECK-MUSL-RISCV64-SP: "-dynamic-linker" "/lib/ld-musl-riscv64-sp.so.1"
+// CHECK-MUSL-RISCV64:    "-dynamic-linker" "/lib/ld-musl-riscv64.so.1"
 
 // Check whether multilib gcc install works fine on Gentoo with gcc-config
 // RUN: %clang -### %s -Werror -no-pie 2>&1 \

--- a/clang/test/Driver/linux-ld.c
+++ b/clang/test/Driver/linux-ld.c
@@ -1702,24 +1702,18 @@
 // RUN: %clang -### %s -no-pie 2>&1 \
 // RUN:     --target=aarch64_be-pc-linux-musl \
 // RUN:   | FileCheck --check-prefix=CHECK-MUSL-AARCH64_BE %s
-// RUN: %clang -### %s -no-pie 2>&1 \
-// RUN:     --target=riscv32-pc-linux-musl -march=rv32im -mabi=ilp32 \
-// RUN:   | FileCheck --check-prefix=CHECK-MUSL-RISCV32-SF %s
-// RUN: %clang -### %s -no-pie 2>&1 \
-// RUN:     --target=riscv32-pc-linux-musl -march=rv32imf -mabi=ilp32f \
-// RUN:   | FileCheck --check-prefix=CHECK-MUSL-RISCV32-SP %s
-// RUN: %clang -### %s -no-pie 2>&1 \
-// RUN:     --target=riscv32-pc-linux-musl -march=rv32imfd -mabi=ilp32d \
-// RUN:   | FileCheck --check-prefix=CHECK-MUSL-RISCV32 %s
-// RUN: %clang -### %s -no-pie 2>&1 \
-// RUN:     --target=riscv64-pc-linux-musl -march=rv64im -mabi=lp64 \
-// RUN:   | FileCheck --check-prefix=CHECK-MUSL-RISCV64-SF %s
-// RUN: %clang -### %s -no-pie 2>&1 \
-// RUN:     --target=riscv64-pc-linux-musl -march=rv64imf -mabi=lp64f \
-// RUN:   | FileCheck --check-prefix=CHECK-MUSL-RISCV64-SP %s
-// RUN: %clang -### %s -no-pie 2>&1 \
-// RUN:     --target=riscv64-pc-linux-musl -march=rv64imfd -mabi=lp64d \
-// RUN:   | FileCheck --check-prefix=CHECK-MUSL-RISCV64 %s
+// RUN: %clang -### %s --target=riscv32-pc-linux-musl -march=rv32im -mabi=ilp32 2>&1 | \
+// RUN:   FileCheck --check-prefix=CHECK-MUSL-RISCV32-SF %s
+// RUN: %clang -### %s --target=riscv32-pc-linux-musl -march=rv32imf -mabi=ilp32f 2>&1 | \
+// RUN:   FileCheck --check-prefix=CHECK-MUSL-RISCV32-SP %s
+// RUN: %clang -### %s --target=riscv32-pc-linux-musl -march=rv32imfd -mabi=ilp32d 2>&1 | \
+// RUN:   FileCheck --check-prefix=CHECK-MUSL-RISCV32 %s
+// RUN: %clang -### %s --target=riscv64-pc-linux-musl -march=rv64im -mabi=lp64 2>&1 | \
+// RUN:   FileCheck --check-prefix=CHECK-MUSL-RISCV64-SF %s
+// RUN: %clang -### %s --target=riscv64-pc-linux-musl -march=rv64imf -mabi=lp64f 2>&1 | \
+// RUN:   FileCheck --check-prefix=CHECK-MUSL-RISCV64-SP %s
+// RUN: %clang -### %s --target=riscv64-pc-linux-musl -march=rv64imfd -mabi=lp64d 2>&1 | \
+// RUN:   FileCheck --check-prefix=CHECK-MUSL-RISCV64 %s
 // CHECK-MUSL-X86:        "-dynamic-linker" "/lib/ld-musl-i386.so.1"
 // CHECK-MUSL-X86_64:     "-dynamic-linker" "/lib/ld-musl-x86_64.so.1"
 // CHECK-MUSL-MIPS:       "-dynamic-linker" "/lib/ld-musl-mips.so.1"


### PR DESCRIPTION
Musl adds -sf or -sp suffixes to the path of dynamic linker (e.g., ld-musl-riscv64-sf.so.1):

https://git.musl-libc.org/cgit/musl/tree/configure?h=v1.2.6&id=9fa28ece75d8a2191de7c5bb53bed224c5947417#n732