### PR TITLE
[SelectionDAG] Restrict ABI vector repacking to equal-width intermediates

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -330,6 +330,33 @@ static void diagnosePossiblyInvalidConstraint(LLVMContext &Ctx, const Value *V,
   return Ctx.emitError(I, ErrMsg);
 }
 
+static bool getNonABIVectorTypeBreakdown(const TargetLowering &TLI,
+                                         SelectionDAG &DAG, EVT ValueVT,
+                                         EVT ABIIntermediateVT,
+                                         unsigned ABINumIntermediates,
+                                         unsigned ABINumRegs, MVT ABIRegisterVT,
+                                         EVT &NormalIntermediateVT,
+                                         unsigned &NormalNumIntermediates) {
+  if (ValueVT.isScalableVector())
+    return false;
+
+  MVT NormalRegisterVT;
+  unsigned NormalNumRegs = TLI.getVectorTypeBreakdown(
+      *DAG.getContext(), ValueVT, NormalIntermediateVT, NormalNumIntermediates,
+      NormalRegisterVT);
+
+  if (NormalNumIntermediates == 0 || ABINumRegs % NormalNumIntermediates != 0 ||
+      NormalNumRegs * NormalRegisterVT.getSizeInBits() !=
+          ABINumRegs * ABIRegisterVT.getSizeInBits())
+    return false;
+
+  unsigned NormalVectorBits =
+      NormalIntermediateVT.getSizeInBits() * NormalNumIntermediates;
+  unsigned ABIVectorBits =
+      ABIIntermediateVT.getSizeInBits() * ABINumIntermediates;
+  return NormalVectorBits == ABIVectorBits;
+}
+
 /// getCopyFromPartsVector - Create a value that contains the specified legal
 /// parts combined into the value they represent.  If the parts combine to a
 /// type larger than ValueVT then AssertOp can be used to specify whether the
@@ -776,15 +803,30 @@ static void getCopyToPartsVector(SelectionDAG &DAG, const SDLoc &DL,
   assert(IntermediateVT.isScalableVector() == ValueVT.isScalableVector() &&
          "Mixing scalable and fixed vectors when copying in parts");
 
+  EVT BuildIntermediateVT = IntermediateVT;
+  unsigned BuildNumIntermediates = NumIntermediates;
+  EVT NormalIntermediateVT;
+  unsigned NormalNumIntermediates;
+  bool PackToABI = false;
+  if (IsABIRegCopy &&
+      getNonABIVectorTypeBreakdown(
+          TLI, DAG, ValueVT, IntermediateVT, NumIntermediates, NumRegs,
+          RegisterVT, NormalIntermediateVT, NormalNumIntermediates)) {
+    BuildIntermediateVT = NormalIntermediateVT;
+    BuildNumIntermediates = NormalNumIntermediates;
+    PackToABI = true;
+  }
+
   std::optional<ElementCount> DestEltCnt;
 
-  if (IntermediateVT.isVector())
-    DestEltCnt = IntermediateVT.getVectorElementCount() * NumIntermediates;
+  if (BuildIntermediateVT.isVector())
+    DestEltCnt =
+        BuildIntermediateVT.getVectorElementCount() * BuildNumIntermediates;
   else
-    DestEltCnt = ElementCount::getFixed(NumIntermediates);
+    DestEltCnt = ElementCount::getFixed(BuildNumIntermediates);
 
   EVT BuiltVectorTy = EVT::getVectorVT(
-      *DAG.getContext(), IntermediateVT.getScalarType(), *DestEltCnt);
+      *DAG.getContext(), BuildIntermediateVT.getScalarType(), *DestEltCnt);
 
   if (ValueVT == BuiltVectorTy) {
     // Nothing to do.
@@ -807,6 +849,22 @@ static void getCopyToPartsVector(SelectionDAG &DAG, const SDLoc &DL,
   }
 
   assert(Val.getValueType() == BuiltVectorTy && "Unexpected vector value type");
+
+  if (PackToABI) {
+    EVT ABIBuiltVectorTy =
+        IntermediateVT.isVector()
+            ? EVT::getVectorVT(
+                  *DAG.getContext(), IntermediateVT.getScalarType(),
+                  IntermediateVT.getVectorElementCount() * NumIntermediates)
+            : EVT::getVectorVT(*DAG.getContext(),
+                               IntermediateVT.getScalarType(),
+                               NumIntermediates);
+    if (Val.getValueType() != ABIBuiltVectorTy &&
+        Val.getValueType().getSizeInBits() == ABIBuiltVectorTy.getSizeInBits())
+      Val = DAG.getNode(ISD::BITCAST, DL, ABIBuiltVectorTy, Val);
+    assert(Val.getValueType() == ABIBuiltVectorTy &&
+           "Unexpected ABI vector value type");
+  }
 
   // Split the vector into intermediate operands.
   SmallVector<SDValue, 8> Ops(NumIntermediates);

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -335,26 +335,26 @@ static bool getNonABIVectorTypeBreakdown(const TargetLowering &TLI,
                                          EVT ABIIntermediateVT,
                                          unsigned ABINumIntermediates,
                                          unsigned ABINumRegs, MVT ABIRegisterVT,
-                                         EVT &NormalIntermediateVT,
-                                         unsigned &NormalNumIntermediates) {
+                                         EVT &LegalIntermediateVT,
+                                         unsigned &LegalNumIntermediates) {
   if (ValueVT.isScalableVector())
     return false;
 
-  MVT NormalRegisterVT;
-  unsigned NormalNumRegs = TLI.getVectorTypeBreakdown(
-      *DAG.getContext(), ValueVT, NormalIntermediateVT, NormalNumIntermediates,
-      NormalRegisterVT);
+  MVT LegalRegisterVT;
+  unsigned LegalNumRegs = TLI.getVectorTypeBreakdown(
+      *DAG.getContext(), ValueVT, LegalIntermediateVT, LegalNumIntermediates,
+      LegalRegisterVT);
 
-  if (NormalNumIntermediates == 0 || ABINumRegs % NormalNumIntermediates != 0 ||
-      NormalNumRegs * NormalRegisterVT.getSizeInBits() !=
+  if (LegalNumIntermediates == 0 || ABINumRegs % LegalNumIntermediates != 0 ||
+      LegalNumRegs * LegalRegisterVT.getSizeInBits() !=
           ABINumRegs * ABIRegisterVT.getSizeInBits())
     return false;
 
-  unsigned NormalVectorBits =
-      NormalIntermediateVT.getSizeInBits() * NormalNumIntermediates;
+  unsigned LegalVectorBits =
+      LegalIntermediateVT.getSizeInBits() * LegalNumIntermediates;
   unsigned ABIVectorBits =
       ABIIntermediateVT.getSizeInBits() * ABINumIntermediates;
-  return NormalVectorBits == ABIVectorBits;
+  return LegalVectorBits == ABIVectorBits;
 }
 
 /// getCopyFromPartsVector - Create a value that contains the specified legal
@@ -805,16 +805,14 @@ static void getCopyToPartsVector(SelectionDAG &DAG, const SDLoc &DL,
 
   EVT BuildIntermediateVT = IntermediateVT;
   unsigned BuildNumIntermediates = NumIntermediates;
-  EVT NormalIntermediateVT;
-  unsigned NormalNumIntermediates;
-  bool PackToABI = false;
+  EVT LegalIntermediateVT;
+  unsigned LegalNumIntermediates;
   if (IsABIRegCopy &&
       getNonABIVectorTypeBreakdown(
           TLI, DAG, ValueVT, IntermediateVT, NumIntermediates, NumRegs,
-          RegisterVT, NormalIntermediateVT, NormalNumIntermediates)) {
-    BuildIntermediateVT = NormalIntermediateVT;
-    BuildNumIntermediates = NormalNumIntermediates;
-    PackToABI = true;
+          RegisterVT, LegalIntermediateVT, LegalNumIntermediates)) {
+    BuildIntermediateVT = LegalIntermediateVT;
+    BuildNumIntermediates = LegalNumIntermediates;
   }
 
   std::optional<ElementCount> DestEltCnt;
@@ -850,20 +848,15 @@ static void getCopyToPartsVector(SelectionDAG &DAG, const SDLoc &DL,
 
   assert(Val.getValueType() == BuiltVectorTy && "Unexpected vector value type");
 
-  if (PackToABI) {
-    EVT ABIBuiltVectorTy =
+  if (IsABIRegCopy) {
+    ElementCount ABIDestEltCnt =
         IntermediateVT.isVector()
-            ? EVT::getVectorVT(
-                  *DAG.getContext(), IntermediateVT.getScalarType(),
-                  IntermediateVT.getVectorElementCount() * NumIntermediates)
-            : EVT::getVectorVT(*DAG.getContext(),
-                               IntermediateVT.getScalarType(),
-                               NumIntermediates);
-    if (Val.getValueType() != ABIBuiltVectorTy &&
-        Val.getValueType().getSizeInBits() == ABIBuiltVectorTy.getSizeInBits())
+            ? IntermediateVT.getVectorElementCount() * NumIntermediates
+            : ElementCount::getFixed(NumIntermediates);
+    EVT ABIBuiltVectorTy = EVT::getVectorVT(
+        *DAG.getContext(), IntermediateVT.getScalarType(), ABIDestEltCnt);
+    if (BuiltVectorTy != ABIBuiltVectorTy)
       Val = DAG.getNode(ISD::BITCAST, DL, ABIBuiltVectorTy, Val);
-    assert(Val.getValueType() == ABIBuiltVectorTy &&
-           "Unexpected ABI vector value type");
   }
 
   // Split the vector into intermediate operands.

--- a/llvm/test/CodeGen/AMDGPU/irregular-width-vector-return.ll
+++ b/llvm/test/CodeGen/AMDGPU/irregular-width-vector-return.ll
@@ -1,0 +1,44 @@
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx700 -o - < %s | FileCheck %s
+
+define <4 x i63> @v4i63_zero() {
+; CHECK-LABEL: v4i63_zero:
+; CHECK:       ; %bb.0:
+; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    v_mov_b32_e32 v0, 0
+; CHECK-NEXT:    v_mov_b32_e32 v1, 0
+; CHECK-NEXT:    v_mov_b32_e32 v2, 0
+; CHECK-NEXT:    v_mov_b32_e32 v3, 0
+; CHECK-NEXT:    v_mov_b32_e32 v4, 0
+; CHECK-NEXT:    v_mov_b32_e32 v5, 0
+; CHECK-NEXT:    v_mov_b32_e32 v6, 0
+; CHECK-NEXT:    v_mov_b32_e32 v7, 0
+; CHECK-NEXT:    s_setpc_b64 s[30:31]
+  ret <4 x i63> zeroinitializer
+}
+
+define <4 x i63> @v4i63_const() {
+; CHECK-LABEL: v4i63_const:
+; CHECK:       ; %bb.0:
+; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    v_mov_b32_e32 v0, -1
+; CHECK-NEXT:    v_not_b32_e32 v1, -2.0
+; CHECK-NEXT:    v_mov_b32_e32 v2, 1
+; CHECK-NEXT:    v_mov_b32_e32 v3, 0
+; CHECK-NEXT:    v_mov_b32_e32 v4, 0
+; CHECK-NEXT:    v_bfrev_b32_e32 v5, 4
+; CHECK-NEXT:    v_mov_b32_e32 v6, -1
+; CHECK-NEXT:    v_bfrev_b32_e32 v7, -2
+; CHECK-NEXT:    s_setpc_b64 s[30:31]
+  ret <4 x i63> <i63 4611686018427387903, i63 1, i63 2305843009213693952, i63 9223372036854775807>
+}
+
+declare <4 x i63> @callee_v4i63()
+
+define <4 x i63> @call_v4i63() {
+; CHECK-LABEL: call_v4i63:
+; CHECK:       ; %bb.0:
+; CHECK:       s_swappc_b64
+; CHECK:       s_setpc_b64 s[30:31]
+  %v = call <4 x i63> @callee_v4i63()
+  ret <4 x i63> %v
+}

--- a/llvm/test/CodeGen/AMDGPU/irregular-width-vector-return.ll
+++ b/llvm/test/CodeGen/AMDGPU/irregular-width-vector-return.ll
@@ -1,4 +1,16 @@
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx700 -o - < %s | FileCheck %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx700 < %s | FileCheck %s
+
+define <2 x i33> @v2i33_zero() {
+; CHECK-LABEL: v2i33_zero:
+; CHECK:       ; %bb.0:
+; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    v_mov_b32_e32 v0, 0
+; CHECK-NEXT:    v_mov_b32_e32 v1, 0
+; CHECK-NEXT:    v_mov_b32_e32 v2, 0
+; CHECK-NEXT:    v_mov_b32_e32 v3, 0
+; CHECK-NEXT:    s_setpc_b64 s[30:31]
+  ret <2 x i33> zeroinitializer
+}
 
 define <4 x i63> @v4i63_zero() {
 ; CHECK-LABEL: v4i63_zero:


### PR DESCRIPTION
### Summary
This PR resolves https://github.com/llvm/llvm-project/issues/197482. Only repack ABI vector return values through the normal vector type breakdown when the ABI and non-ABI intermediate vectors have the same total bit width.

This avoids treating promoted irregular-width element vectors, such as AMDGPU <2 x i24> or <2 x i4>, as bitcast-compatible with their ABI intermediate form. Those cases need the original ABI breakdown path. Keep the repacking limited to copy-to-parts so argument lowering is not perturbed.