### PR TITLE
[mlir][nvgpu] Add negative tests for warpgroup MMA accumulator ops

### DIFF
--- a/mlir/test/Dialect/NVGPU/invalid.mlir
+++ b/mlir/test/Dialect/NVGPU/invalid.mlir
@@ -423,3 +423,45 @@ func.func @mma_sparse_sync_invalid_shape_4_elements(%arg0: vector<2x2xf16>, %arg
        (vector<2x2xf16>, vector<2x2xf16>, vector<2x2xf16>) -> vector<2x2xf16>
   return %d : vector<2x2xf16>
 }
+
+// -----
+
+func.func @warpgroup_mma_init_accumulator_invalid_m() {
+  // expected-error @+1 {{does not fit into warp-group level}}
+  %acc = nvgpu.warpgroup.mma.init.accumulator
+      -> !nvgpu.warpgroup.accumulator<fragmented = vector<65x128xf32>>
+  return
+}
+
+// -----
+
+func.func @warpgroup_mma_init_accumulator_invalid_n() {
+  // expected-error @+1 {{does not fit into warp-group level}}
+  %acc = nvgpu.warpgroup.mma.init.accumulator
+      -> !nvgpu.warpgroup.accumulator<fragmented = vector<64x121xf32>>
+  return
+}
+
+// -----
+
+func.func @warpgroup_mma_store_non_f32_result(
+    %acc: !nvgpu.warpgroup.accumulator<fragmented = vector<64x128xf16>>,
+    %dst: memref<64x128xf16, 3>) {
+  // expected-error @+1 {{only f32 results for the time being}}
+  nvgpu.warpgroup.mma.store %acc, %dst :
+      !nvgpu.warpgroup.accumulator<fragmented = vector<64x128xf16>>
+      to memref<64x128xf16, 3>
+  return
+}
+
+// -----
+
+func.func @warpgroup_mma_store_mismatched_shape(
+    %acc: !nvgpu.warpgroup.accumulator<fragmented = vector<64x128xf32>>,
+    %dst: memref<64x64xf32, 3>) {
+  // expected-error @+1 {{does not have same size as results}}
+  nvgpu.warpgroup.mma.store %acc, %dst :
+      !nvgpu.warpgroup.accumulator<fragmented = vector<64x128xf32>>
+      to memref<64x64xf32, 3>
+  return
+}


### PR DESCRIPTION
Add verifier tests for warpgroup MMA accumulator initialization
and store operations.

The tests cover invalid accumulator shapes, unsupported non-f32
store results, and mismatched store destination shapes.

The verifier logic for these cases exists in
WarpgroupMmaInitAccumulatorOp::verify() and
WarpgroupMmaStoreOp::verify(), but lacked explicit negative test
coverage in invalid.mlir.