### PR TITLE
[AMDGPU] Track VALU instructions separately for WMMA coexecution hazards

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
@@ -83,6 +83,8 @@ GCNHazardRecognizer::GCNHazardRecognizer(const MachineFunction &MF,
 
 void GCNHazardRecognizer::Reset() {
   EmittedInstrs.clear();
+  EmittedVALUInstrs.clear();
+  HasPendingWMMACoexecHazard = false;
 }
 
 void GCNHazardRecognizer::EmitInstruction(SUnit *SU) {
@@ -208,8 +210,10 @@ GCNHazardRecognizer::getHazardType(SUnit *SU, int Stalls) {
 
   // Hazards which cannot be mitigated with S_NOPs.
   if (!IsHazardRecognizerMode) {
-    if (checkWMMACoexecutionHazards(MI) > 0)
+    if (checkWMMACoexecutionHazards(MI) > 0) {
+      HasPendingWMMACoexecHazard = true;
       return Hazard;
+    }
   }
 
   if (ST.hasNoDataDepHazard())
@@ -419,8 +423,13 @@ void GCNHazardRecognizer::AdvanceCycle() {
   // emitting any instructions.
   if (!CurrCycleInstr) {
     EmittedInstrs.push_front(nullptr);
+
+    if (HasPendingWMMACoexecHazard)
+      EmittedVALUInstrs.push_front(nullptr);
     return;
   }
+
+  HasPendingWMMACoexecHazard = false;
 
   if (CurrCycleInstr->isBundle()) {
     processBundle();
@@ -436,6 +445,20 @@ void GCNHazardRecognizer::AdvanceCycle() {
   // Keep track of emitted instructions
   EmittedInstrs.push_front(CurrCycleInstr);
 
+  bool IsVALUOrWMMA = SIInstrInfo::isVALU(*CurrCycleInstr) ||
+                      SIInstrInfo::isWMMA(*CurrCycleInstr) ||
+                      SIInstrInfo::isSWMMAC(*CurrCycleInstr);
+  if (IsVALUOrWMMA) {
+    EmittedVALUInstrs.push_front(CurrCycleInstr);
+  } else {
+    // A pending WMMA co-execution hazard optimistically records stall cycles as
+    // future V_NOPs. If the scheduler instead stalls for a different
+    // (S_NOP-resolvable) hazard and schedules a non-VALU into those cycles,
+    // they will not resolve the VALU-pipe hazard, so drop them here.
+    while (!EmittedVALUInstrs.empty() && EmittedVALUInstrs.front() == nullptr)
+      EmittedVALUInstrs.pop_front();
+  }
+
   // Add a nullptr for each additional wait state after the first.  Make sure
   // not to add more than getMaxLookAhead() items to the list, since we
   // truncate the list to that size right after this loop.
@@ -448,6 +471,8 @@ void GCNHazardRecognizer::AdvanceCycle() {
   // to insert, so there is no point in keeping track of more than that many
   // wait states.
   EmittedInstrs.resize(getMaxLookAhead());
+  if (EmittedVALUInstrs.size() > MaxVALULookAhead)
+    EmittedVALUInstrs.resize(MaxVALULookAhead);
 
   CurrCycleInstr = nullptr;
 }
@@ -632,6 +657,35 @@ int GCNHazardRecognizer::getWaitStatesSince(
 int GCNHazardRecognizer::getWaitStatesSince(IsHazardFn IsHazard,
                                             int Limit) const {
   return getWaitStatesSince(IsHazard, Limit, SIInstrInfo::getNumWaitStates);
+}
+
+int GCNHazardRecognizer::getWaitStatesSinceVALU(IsHazardFn IsHazard,
+                                                int Limit) const {
+  if (IsHazardRecognizerMode) {
+    auto GetVALUWaitStates = [](const MachineInstr &MI) -> unsigned {
+      return SIInstrInfo::isVALU(MI) ? 1 : 0;
+    };
+    return getWaitStatesSince(IsHazard, Limit, GetVALUWaitStates);
+  }
+
+  // EmittedVALUInstrs is capped at MaxVALULookAhead, so a Limit beyond that
+  // window could miss a hazard. Keep the cap in sync with the wait-state
+  // tables.
+  assert(Limit <= (int)MaxVALULookAhead &&
+         "Limit exceeds the EmittedVALUInstrs lookahead window");
+  int WaitStates = 0;
+  for (MachineInstr *MI : EmittedVALUInstrs) {
+    if (MI) {
+      if (IsHazard(*MI))
+        return WaitStates;
+    }
+
+    ++WaitStates;
+
+    if (WaitStates >= Limit)
+      break;
+  }
+  return std::numeric_limits<int>::max();
 }
 
 int GCNHazardRecognizer::getWaitStatesSinceDef(unsigned Reg,
@@ -2166,15 +2220,12 @@ int GCNHazardRecognizer::checkWMMACoexecutionHazards(MachineInstr *MI) const {
     return hasWMMAToVALURegOverlap(I, *MI);
   };
 
-  auto GetWaitStatesFn = [](const MachineInstr &I) {
-    return SIInstrInfo::isVALU(I) ? 1 : 0;
-  };
-
   int WaitStatesNeeded = -1;
   int ExistingVALUs = 0; // Existing number of VALU ops in between.
   bool IsLowestRateWMMA = ST.hasGFX125xLowestRateWMMA();
 
-  // getWaitStatesSince checks for a hazard between instruction 'I' and 'MI':
+  // getWaitStatesSinceVALU checks for a hazard between instruction 'I' and
+  // 'MI':
   // - If a hazard exists: returns the number of VALUs in between and sets
   //   'Category' via IsWMMAHazardFn/IsVALUHazardFn for instruction 'I'.
   // - If no hazard exists: returns INT_MAX, making WaitStatesNeeded negative,
@@ -2182,14 +2233,12 @@ int GCNHazardRecognizer::checkWMMACoexecutionHazards(MachineInstr *MI) const {
   if (TII->isXDLWMMA(*MI)) {
     // Maximum of MMAWaitStates.
     const int WMMAWaitsLimit = IsLowestRateWMMA ? 17 : 9;
-    ExistingVALUs =
-        getWaitStatesSince(IsWMMAHazardFn, WMMAWaitsLimit, GetWaitStatesFn);
+    ExistingVALUs = getWaitStatesSinceVALU(IsWMMAHazardFn, WMMAWaitsLimit);
     WaitStatesNeeded = WMMAWaitStates[Category] - ExistingVALUs;
   } else { // Must be a co-executable VALU.
            // Maximum of VALUWaitStates.
     const int VALUWaitsLimit = IsLowestRateWMMA ? 16 : 8;
-    ExistingVALUs =
-        getWaitStatesSince(IsVALUHazardFn, VALUWaitsLimit, GetWaitStatesFn);
+    ExistingVALUs = getWaitStatesSinceVALU(IsVALUHazardFn, VALUWaitsLimit);
     WaitStatesNeeded = VALUWaitStates[Category] - ExistingVALUs;
   }
 

--- a/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.h
+++ b/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.h
@@ -45,6 +45,21 @@ private:
   // called.
   MachineInstr *CurrCycleInstr;
   std::list<MachineInstr*> EmittedInstrs;
+
+  // WMMA co-execution hazards are only resolved by VALU-pipe activity (VALU
+  // ops or V_NOPs), never by S_NOPs, so track those instructions separately
+  // from EmittedInstrs.
+  std::list<MachineInstr *> EmittedVALUInstrs;
+  // Lookahead bound for EmittedVALUInstrs. It must be at least as large as the
+  // largest WMMA co-execution wait-state requirement (the maximum value in
+  // WMMAWaitStates/VALUWaitStates in checkWMMACoexecutionHazards). Increase
+  // this if those wait-state limits grow.
+  static constexpr unsigned MaxVALULookAhead = 18;
+  // When true, an unresolved WMMA co-execution hazard is pending, so stall
+  // cycles are optimistically recorded in EmittedVALUInstrs (they will become
+  // V_NOPs unless a non-VALU instruction is scheduled into them).
+  bool HasPendingWMMACoexecHazard = false;
+
   const MachineFunction &MF;
   const GCNSubtarget &ST;
   const SIInstrInfo &TII;
@@ -84,6 +99,7 @@ private:
   int getWaitStatesSince(IsHazardFn IsHazard, int Limit,
                          GetNumWaitStatesFn GetNumWaitStates) const;
   int getWaitStatesSince(IsHazardFn IsHazard, int Limit) const;
+  int getWaitStatesSinceVALU(IsHazardFn IsHazard, int Limit) const;
   int getWaitStatesSinceDef(unsigned Reg, IsHazardFn IsHazardDef,
                             int Limit) const;
   int getWaitStatesSinceSetReg(IsHazardFn IsHazard, int Limit) const;

--- a/llvm/test/CodeGen/AMDGPU/misched-into-wmma-hazard-shadow.mir
+++ b/llvm/test/CodeGen/AMDGPU/misched-into-wmma-hazard-shadow.mir
@@ -54,3 +54,39 @@ body:             |
     GLOBAL_STORE_DWORDX4 renamable $vgpr44_vgpr45, killed renamable $vgpr46_vgpr47_vgpr48_vgpr49, 64, 0, implicit $exec
     S_ENDPGM 0
 ...
+
+# SALU instructions do not resolve WMMA->VALU hazards.
+
+---
+name:            test_wmma_salu_does_not_resolve_hazard
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15, $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23, $vgpr24, $vgpr25, $vgpr26, $vgpr27, $vgpr28, $sgpr0, $sgpr1, $sgpr2, $sgpr3
+
+    ; GCN-LABEL: name: test_wmma_salu_does_not_resolve_hazard
+    ; GCN: liveins: $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15, $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23, $vgpr24, $vgpr25, $vgpr26, $vgpr27, $vgpr28, $sgpr0, $sgpr1, $sgpr2, $sgpr3
+    ; GCN-NEXT: {{  $}}
+    ; GCN-NEXT: early-clobber $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23 = V_WMMA_F32_16X16X32_BF16_w32_twoaddr killed $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, killed $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15, 8, killed $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23, 0, 0, 0, 0, implicit $exec
+    ; GCN-NEXT: $vgpr31 = V_MOV_B32_e32 killed $vgpr26, implicit $exec
+    ; GCN-NEXT: $vgpr32 = V_MOV_B32_e32 killed $vgpr27, implicit $exec
+    ; GCN-NEXT: $vgpr33 = V_MOV_B32_e32 killed $vgpr28, implicit $exec
+    ; GCN-NEXT: $sgpr4 = S_MOV_B32 killed $sgpr0
+    ; GCN-NEXT: $sgpr5 = S_MOV_B32 killed $sgpr1
+    ; GCN-NEXT: $sgpr6 = S_MOV_B32 killed $sgpr2
+    ; GCN-NEXT: $sgpr7 = S_MOV_B32 killed $sgpr3
+    ; GCN-NEXT: $vgpr30 = V_MOV_B32_e32 killed $vgpr25, implicit $exec
+    ; GCN-NEXT: $vgpr29 = V_ADD_F32_e32 killed $vgpr24, killed $vgpr16, implicit $mode, implicit $exec
+    ; GCN-NEXT: S_ENDPGM 0, implicit killed $vgpr29, implicit killed $vgpr30, implicit killed $vgpr31, implicit killed $vgpr32, implicit killed $vgpr33, implicit killed $sgpr4, implicit killed $sgpr5, implicit killed $sgpr6, implicit killed $sgpr7
+    early-clobber $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23 = V_WMMA_F32_16X16X32_BF16_w32_twoaddr $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15, 8, $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23, 0, 0, 0, 0, implicit $exec
+    $sgpr4 = S_MOV_B32 $sgpr0
+    $sgpr5 = S_MOV_B32 $sgpr1
+    $sgpr6 = S_MOV_B32 $sgpr2
+    $sgpr7 = S_MOV_B32 $sgpr3
+    $vgpr29 = V_ADD_F32_e32 $vgpr24, $vgpr16, implicit $mode, implicit $exec
+    $vgpr30 = V_MOV_B32_e32 $vgpr25, implicit $exec
+    $vgpr31 = V_MOV_B32_e32 $vgpr26, implicit $exec
+    $vgpr32 = V_MOV_B32_e32 $vgpr27, implicit $exec
+    $vgpr33 = V_MOV_B32_e32 $vgpr28, implicit $exec
+    S_ENDPGM 0, implicit $vgpr29, implicit $vgpr30, implicit $vgpr31, implicit $vgpr32, implicit $vgpr33, implicit $sgpr4, implicit $sgpr5, implicit $sgpr6, implicit $sgpr7
+...


### PR DESCRIPTION
WMMA coexecution hazards can only be resolved by VALU instructions, not S_NOPs. Track VALU/WMMA instructions separately so the scheduler can accurately determine stall cycles.