### PR TITLE
Add migration shell script to modernize-type-traits.rst

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/type-traits.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/type-traits.rst
@@ -47,3 +47,37 @@ Limitations
 Does not currently diagnose uses of type traits with nested name
 specifiers (e.g. ``std::chrono::is_clock``,
 ``std::chrono::treat_as_floating_point``).
+
+
+Quick-and-dirty migration script
+--------------------------------
+
+The following (hacky) Bash script can be used to migrate files en mass via Perl, with the obvious caveat that operates textually and thus may misunderstand complex code:
+
+.. code-block:: shell
+
+  #!/usr/bin/env bash
+
+  symbols=($(\
+    clang++ -D_LIBCPP_ENABLE_CXX20_REMOVED_TYPE_TRAITS -std=c++26 -E -P -stdlib=libc++ -include type_traits -x c++ /dev/null \
+    | perl -0777 -n -l -e '$seen{$1}++ while />[^;{}]*(?:using|const)[^{};]*\b([a-z][a-z0-9_]+_[vt])\b[^=;{}]*=/g; END { print "$_\n" for sort keys %seen }'
+  ))
+  
+  t="$(printf "%s|" "${symbols[@]}" | sed 's/\b[^|]*_v\b//; s/_t\b//g; s/|\+/|/g; s/^|\||$//g')"
+  v="$(printf "%s|" "${symbols[@]}" | sed 's/\b[^|]*_t\b//; s/_v\b//g; s/|\+/|/g; s/^|\||$//g')"
+  
+  perl -0777 -i -p -e '
+    BEGIN {
+      our ($G, $P, $B, $C);
+      $P = qr/(?>(?:[^""'\'\''()]+|\((??{$P})\))*)/;
+      $B = qr/(?>(?:[^""'\'\''\[\]]+|\[(??{$B})\])*)/;
+      $C = qr/(?>(?:[^""'\'\''<>]+|<(??{$C})>)*)/;
+      $G = qr/(?>[^""'\'\''()\[\]<>]|\((??{$P})\)|\[(??{$B})\]|<(??{$C})>)*/;
+    }
+    1 while (
+      s/(\b(?:typename\s+))((?<!\w)(?:(?:::\s*)?std\s*::\s*(?:'"${t}"')))(?<!_t)(\s*<(??{$G})>\s*)::\s*type\b(\s*::)?((?=>))?/
+        (defined $4 ? $1 : "") . $2 . "_t" . $3 . $4 . (defined $5 ? " " : "")/ge
+      or
+      s/((?<!\w)(?:(?:::\s*)?std\s*::\s*'"${v}"'))(?<!_v)\s*<((??{$G}))>\s*::\s*value/$1_v<$2>/g
+    )
+  ' "$@"


### PR DESCRIPTION
Adds a Perl-based Bash script to quickly modernize C++ type trait usage:

```
#!/usr/bin/env bash

symbols=($(\
  clang++ -D_LIBCPP_ENABLE_CXX20_REMOVED_TYPE_TRAITS -std=c++26 -E -P -stdlib=libc++ -include type_traits -x c++ /dev/null \
  | perl -0777 -n -l -e '$seen{$1}++ while />[^;{}]*(?:using|const)[^{};]*\b([a-z][a-z0-9_]+_[vt])\b[^=;{}]*=/g; END { print "$_\n" for sort keys %seen }'
))

t="$(printf "%s|" "${symbols[@]}" | sed 's/\b[^|]*_v\b//; s/_t\b//g; s/|\+/|/g; s/^|\||$//g')"
v="$(printf "%s|" "${symbols[@]}" | sed 's/\b[^|]*_t\b//; s/_v\b//g; s/|\+/|/g; s/^|\||$//g')"

perl -0777 -i -p -e '
  BEGIN {
    our ($G, $P, $B, $C);
    $P = qr/(?>(?:[^""'\'\''()]+|\((??{$P})\))*)/;
    $B = qr/(?>(?:[^""'\'\''\[\]]+|\[(??{$B})\])*)/;
    $C = qr/(?>(?:[^""'\'\''<>]+|<(??{$C})>)*)/;
    $G = qr/(?>[^""'\'\''()\[\]<>]|\((??{$P})\)|\[(??{$B})\]|<(??{$C})>)*/;
  }
  1 while (
    s/(\b(?:typename\s+))((?<!\w)(?:(?:::\s*)?std\s*::\s*(?:'"${t}"')))(?<!_t)(\s*<(??{$G})>\s*)::\s*type\b(\s*::)?((?=>))?/
      (defined $4 ? $1 : "") . $2 . "_t" . $3 . $4 . (defined $5 ? " " : "")/ge
    or
    s/((?<!\w)(?:(?:::\s*)?std\s*::\s*'"${v}"'))(?<!_v)\s*<((??{$G}))>\s*::\s*value/$1_v<$2>/g
  )
' "$@"
```