### PR TITLE
[Offload] define MSVC byte-order macros for rtl endianness checks

### DIFF
--- a/offload/plugins-nextgen/host/src/rtl.cpp
+++ b/offload/plugins-nextgen/host/src/rtl.cpp
@@ -30,19 +30,9 @@
 #include "llvm/Frontend/OpenMP/OMPDeviceConstants.h"
 #include "llvm/Frontend/OpenMP/OMPGridValues.h"
 #include "llvm/Support/DynamicLibrary.h"
+#include "llvm/Support/Endian.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/raw_ostream.h"
-
-#if !defined(__BYTE_ORDER__) || !defined(__ORDER_LITTLE_ENDIAN__) ||           \
-    !defined(__ORDER_BIG_ENDIAN__)
-#error "Missing preprocessor definitions for endianness detection."
-#endif
-
-#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
-#define LITTLEENDIAN_CPU
-#elif defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
-#define BIGENDIAN_CPU
-#endif
 
 // The number of devices in this plugin.
 #define NUM_DEVICES 4
@@ -59,6 +49,7 @@ struct GenELF64KernelTy;
 struct GenELF64DeviceTy;
 struct GenELF64PluginTy;
 
+using llvm::endianness;
 using llvm::sys::DynamicLibrary;
 using namespace error;
 
@@ -543,17 +534,15 @@ struct GenELF64PluginTy final : public GenericPluginTy {
 #elif defined(__s390x__)
     return llvm::Triple::systemz;
 #elif defined(__aarch64__)
-#ifdef LITTLEENDIAN_CPU
-    return llvm::Triple::aarch64;
-#else
-    return llvm::Triple::aarch64_be;
-#endif
+    if constexpr (endianness::native == endianness::little)
+      return llvm::Triple::aarch64;
+    else
+      return llvm::Triple::aarch64_be;
 #elif defined(__powerpc64__)
-#ifdef LITTLEENDIAN_CPU
-    return llvm::Triple::ppc64le;
-#else
-    return llvm::Triple::ppc64;
-#endif
+    if constexpr (endianness::native == endianness::little)
+      return llvm::Triple::ppc64le;
+    else
+      return llvm::Triple::ppc64;
 #elif defined(__riscv) && (__riscv_xlen == 64)
     return llvm::Triple::riscv64;
 #elif defined(__loongarch__) && (__loongarch_grlen == 64)


### PR DESCRIPTION
Define MSVC byte-order macros for rtl endianness checks
Ref: https://github.com/llvm/llvm-project/pull/199901