### PR TITLE
[CI][Offload] Fix offload depends on openmp

### DIFF
--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -90,7 +90,7 @@ DEPENDENT_RUNTIMES_TO_TEST = {
     "flang": {"flang-rt"},
     "flang-rt": {"flang-rt"},
     "openmp": {"openmp"},
-    "offload": {"offload"},
+    "offload": {"offload", "openmp"},
     ".ci": {"compiler-rt", "libc", "flang-rt", "libclc", "openmp", "offload"},
 }
 DEPENDENT_RUNTIMES_TO_TEST_NEEDS_RECONFIG = {


### PR DESCRIPTION
It appears that Offload depends on OpenMP. Thus, enable OpenMP as a runtime to test when offload has changes.