### PR TITLE
[NFC][lldb] Delete dead variables in AppleObjCClassDescriptor

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
@@ -527,19 +527,12 @@ llvm::Error ClassDescriptorV2::ProcessRelativeMethodLists(
     if (!method_list)
       return method_list.takeError();
 
-    // 5. Cache the result so we don't need to reconstruct it later.
-    m_image_to_method_lists[entry.m_image_index].emplace_back(*method_list);
-
-    // 6. If the relevant image is loaded, add the methods to the Decl
+    // 5. If the relevant image is loaded, add the methods to the Decl
     if (!m_runtime.IsSharedCacheImageLoaded(entry.m_image_index))
       continue;
 
     ProcessMethodList(instance_method_func, *method_list);
   }
-
-  // We need to keep track of the last time we updated so we can re-update the
-  // type information in the future
-  m_last_version_updated = m_runtime.GetSharedCacheImageHeaderVersion();
 
   return llvm::Error::success();
 }

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.h
@@ -247,8 +247,7 @@ private:
   ClassDescriptorV2(AppleObjCRuntimeV2 &runtime,
                     ObjCLanguageRuntime::ObjCISA isa, const char *name)
       : m_runtime(runtime), m_objc_class_ptr(isa), m_name(name),
-        m_ivars_storage(), m_image_to_method_lists(), m_last_version_updated() {
-  }
+        m_ivars_storage() {}
 
   static llvm::Expected<class_ro_t>
   Read_class_row(Process *process, const objc_class_t &objc_class);
@@ -269,10 +268,6 @@ private:
                                  // their ISA)
   ConstString m_name;            // May be NULL
   iVarsStorage m_ivars_storage;
-
-  mutable std::map<uint16_t, std::vector<method_list_t>>
-      m_image_to_method_lists;
-  mutable std::optional<uint64_t> m_last_version_updated;
 };
 
 // tagged pointer descriptor


### PR DESCRIPTION
Some of those were related to caching of information. However, this cache is never consulted, making the current code misleading: one may think we are benefiting from the cache, but we're not.