### PR TITLE
[AArch64][LLD] Update tests to reduce file size [NFC]

### DIFF
--- a/lld/test/ELF/aarch64-cortex-a53-843419-thunk-relocation-crash.s
+++ b/lld/test/ELF/aarch64-cortex-a53-843419-thunk-relocation-crash.s
@@ -4,6 +4,7 @@
 // RUN: ld.lld --script lds -fix-cortex-a53-843419 -verbose a.o -o exe \
 // RUN:   2>&1 | FileCheck -check-prefix=CHECK-PRINT %s
 // RUN: llvm-objdump --no-print-imm-hex --no-show-raw-insn --triple=aarch64-linux-gnu -d exe | FileCheck %s
+// RUN: rm exe a.o
 
 /// Test case for specific crash wrt interaction between thunks and errata
 /// patches where the size of the added thunks meant that a range-extension

--- a/lld/test/ELF/aarch64-long-thunk-converge.s
+++ b/lld/test/ELF/aarch64-long-thunk-converge.s
@@ -1,10 +1,10 @@
 // REQUIRES: aarch64
-// RUN: rm -rf %t && split-file %s %t
-// RUN: llvm-mc -triple aarch64-none-elf -filetype=obj -o %t/a.o %t/a.s
-// RUN: ld.lld --shared %t/a.o -T %t/a.t -o %t/a
-// RUN: llvm-objdump --no-show-raw-insn -d --start-address=0x7001004 --stop-address=0x7001010 %t/a | FileCheck %s
-// RUN: llvm-objdump --no-show-raw-insn -d --start-address=0x11001008 --stop-address=0x11001014 %t/a | FileCheck --check-prefix=CHECK2 %s
-// RUN: rm -f %t/a
+// RUN: rm -rf %t && split-file %s %t && cd %t
+// RUN: llvm-mc -triple aarch64-none-elf -filetype=obj -o a.o a.s
+// RUN: ld.lld --shared a.o -T a.lds -o a
+// RUN: llvm-objdump --no-show-raw-insn -d --start-address=0x7001004 --stop-address=0x7001010 a | FileCheck %s
+// RUN: llvm-objdump --no-show-raw-insn -d --start-address=0x11001008 --stop-address=0x11001014 a | FileCheck --check-prefix=CHECK2 %s
+// RUN: rm -f a a.o
 /// This test shows that once a long-range thunk has been generated it
 /// cannot be written as a short-range thunk. This prevents oscillations
 /// in size that can prevent convergence.
@@ -24,7 +24,7 @@
 // CHECK2-NEXT:           br      x16
 
 
-//--- a.t
+//--- a.lds
 SECTIONS {
   .foo 0x1000 : { *(.foo.*) }
   .bar 0x11001000 : { *(.bar.*) }

--- a/lld/test/ELF/aarch64-thunk-reuse2.s
+++ b/lld/test/ELF/aarch64-thunk-reuse2.s
@@ -2,6 +2,7 @@
 # RUN: llvm-mc -filetype=obj -triple=aarch64 %s -o %t.o
 # RUN: ld.lld -pie -Ttext=0x10300 %t.o -o %t
 # RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn --disassemble-symbols=dest,__AArch64ADRPThunk_,high %t | FileCheck %s
+# RUN: rm %t.o %t
 
 ## We create initial ThunkSection before the gap. Because the ThunkSection
 ## selection code isn't so precise, we may create an unused thunk there (0x10704).


### PR DESCRIPTION
Remove large object and executable files after running test. Some tests need to run within a single OutputSection and cannot use a Linker Script to increase distance without a large object and corresponding executable file.

Fixes AArch64 part of #202261