### PR TITLE
[ARM][LLD] Remove large files at end of test [NFC]

### DIFF
--- a/lld/test/ELF/arm-bl-v6.s
+++ b/lld/test/ELF/arm-bl-v6.s
@@ -18,6 +18,7 @@
 // RUN: llvm-objdump --no-print-imm-hex -d --triple=thumbv6eb-none-linux-gnueabi %t2 --start-address=0x21008 --stop-address=0x2100c | FileCheck --check-prefix=CHECK-THUMB1 %s
 // RUN: llvm-objdump --no-print-imm-hex -d --triple=armv6eb-none-linux-gnueabi --start-address=0x22100c --stop-address=0x221014 %t2 | FileCheck --check-prefix=CHECK-ARM2-EB %s
 // RUN: llvm-objdump --no-print-imm-hex -d --triple=thumbv6eb-none-linux-gnueabi %t2 --start-address=0x622000 --stop-address=0x622002 | FileCheck --check-prefix=CHECK-THUMB2 %s
+// RUN: rm %t %t2
 
 /// On Arm v6 the range of a Thumb BL instruction is only 4 megabytes as the
 /// extended range encoding is not supported. The following example has a Thumb

--- a/lld/test/ELF/arm-fix-cortex-a8-thunk-align.s
+++ b/lld/test/ELF/arm-fix-cortex-a8-thunk-align.s
@@ -2,6 +2,7 @@
 // RUN: llvm-mc -filetype=obj -triple=armv7a-linux-gnueabihf --arm-add-build-attributes %s -o %t.o
 // RUN: ld.lld --fix-cortex-a8 --shared %t.o -o %t2
 // RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn %t2 | FileCheck %s
+// RUN: rm %t.o %t2
 
 /// Test case that for an OutputSection larger than the ThunkSectionSpacing
 /// --fix-cortex-a8 will cause the size of the ThunkSection to be rounded up to

--- a/lld/test/ELF/arm-fix-cortex-a8-toolarge.s
+++ b/lld/test/ELF/arm-fix-cortex-a8-toolarge.s
@@ -1,6 +1,8 @@
 // REQUIRES: arm
 // RUN: llvm-mc -filetype=obj -triple=armv7a-linux-gnueabihf --arm-add-build-attributes %s -o %t.o
 // RUN: ld.lld --fix-cortex-a8 -verbose %t.o -o /dev/null 2>&1 | FileCheck %s
+// RUN: rm %t.o
+
 /// Test that we warn, but don't attempt to patch when it is impossible to
 /// redirect the branch as the Section is too large.
 

--- a/lld/test/ELF/arm-thumb-condbranch-thunk.s
+++ b/lld/test/ELF/arm-thumb-condbranch-thunk.s
@@ -10,6 +10,7 @@
 // RUN: llvm-objdump -d %t --print-imm-hex --start-address=0x580000 --stop-address=0x580006 | FileCheck --check-prefix=CHECK5 %s
 // RUN: llvm-objdump -d %t --print-imm-hex --start-address=0x1000004 --stop-address=0x100000c | FileCheck --check-prefix=CHECK6 %s
 // RUN: llvm-objdump -d %t --print-imm-hex --start-address=0x1100000 --stop-address=0x1100006 | FileCheck --check-prefix=CHECK7 %s
+// RUN: rm %t.o %t
 // Test Range extension Thunks for the Thumb conditional branch instruction.
 // This instruction only has a range of 1Mb whereas all the other Thumb wide
 // Branch instructions have 16Mb range. We still place our pre-created Thunk

--- a/lld/test/ELF/arm-thumb-mix-range-thunk-os.s
+++ b/lld/test/ELF/arm-thumb-mix-range-thunk-os.s
@@ -14,6 +14,7 @@
 // RUN: llvm-objdump --no-print-imm-hex -d %t2 --start-address=0x3300004 --stop-address=0x3300010 | FileCheck --check-prefix=CHECK9 %s
 // RUN: llvm-objdump --no-print-imm-hex -d %t2 --start-address=0x4100000 --stop-address=0x410000c --triple=armv7a-linux-gnueabihf | FileCheck --check-prefix=CHECK10 %s
 // RUN: llvm-objdump --no-print-imm-hex -d %t2 --start-address=0x4200000 --stop-address=0x4200008 | FileCheck --check-prefix=CHECK11 %s
+// RUN: rm %t %t2
 
 // Test the Range extension Thunks for ARM and Thumb when all the code is in a
 // single OutputSection. The ARM branches and branch and link instructions

--- a/lld/test/ELF/arm-thumb-range-thunk-os-no-ext.s
+++ b/lld/test/ELF/arm-thumb-range-thunk-os-no-ext.s
@@ -12,6 +12,7 @@
 // RUN: llvm-objdump --no-show-raw-insn -d %t2 --start-address=0x900000 --stop-address=0x900004 | FileCheck --check-prefix=CHECK7 %s
 // RUN: llvm-objdump --no-show-raw-insn -d %t2 --start-address=0xa00000 --stop-address=0xa00018 | FileCheck --check-prefix=CHECK8 %s
 // RUN: llvm-objdump --no-show-raw-insn -d %t2 --start-address=0xb00000 --stop-address=0xb00004 | FileCheck --check-prefix=CHECK9 %s
+// RUN: rm %t.o %t2
 
 /// Test the Range extension Thunks for Thumb when all the code is in a single
 /// OutputSection. The Thumb BL instruction has a range of 4Mb. We create a

--- a/lld/test/ELF/arm-thumb-range-thunk-os.s
+++ b/lld/test/ELF/arm-thumb-range-thunk-os.s
@@ -13,6 +13,7 @@
 // RUN: llvm-objdump --no-print-imm-hex -d %t2 --start-address=0x1e00000 --stop-address=0x1e00006 | FileCheck --check-prefix=CHECK8 %s
 // RUN: llvm-objdump --no-print-imm-hex -d %t2 --start-address=0x2200000 --stop-address=0x220000a | FileCheck --check-prefix=CHECK9 %s
 // RUN: llvm-objdump --no-print-imm-hex -d %t2 --start-address=0x2300000 --stop-address=0x230000a | FileCheck --check-prefix=CHECK10 %s
+// RUN: rm %t %t2
 
 // Test the Range extension Thunks for Thumb when all the code is in a single
 // OutputSection. The Thumb unconditional branch b.w and branch and link bl

--- a/lld/test/ELF/arm-thumb-thunk-empty-pass.s
+++ b/lld/test/ELF/arm-thumb-thunk-empty-pass.s
@@ -2,6 +2,7 @@
 // RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=thumbv7a-none-linux-gnueabi %s -o %t.o
 // RUN: ld.lld %t.o -o %t
 // RUN: llvm-objdump --no-print-imm-hex -d %t | FileCheck %s
+// RUN: rm %t.o %t
  .syntax unified
  .global _start, foo
  .type _start, %function

--- a/lld/test/ELF/arm-thunk-largesection.s
+++ b/lld/test/ELF/arm-thunk-largesection.s
@@ -22,6 +22,8 @@
 // RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn --start-address=0x2012ff8 --stop-address=0x2021ffc %t2 | FileCheck --check-prefix=CHECK4 %s
 // RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn --start-address=0x3021fec --stop-address=0x3021ff6 %t2 | FileCheck --check-prefix=CHECK5 %s
 
+// RUN: rm %t %t2
+
  .syntax unified
  .balign 0x1000
  .thumb

--- a/lld/test/ELF/arm-thunk-multipass-plt.s
+++ b/lld/test/ELF/arm-thunk-multipass-plt.s
@@ -11,6 +11,8 @@
 // RUN: llvm-objdump --no-print-imm-hex --no-show-raw-insn --start-address=0x80000c --stop-address=0x800010 -d %t2 | FileCheck %s --check-prefix=CHECK-CALL
 // RUN: llvm-objdump --no-print-imm-hex --no-show-raw-insn --start-address=0xd00020 --stop-address=0xd00060 --triple=armv5eb-none-linux-gnueabi -d %t2 | FileCheck %s --check-prefix=CHECK-PLT
 
+// RUN: rm %t %t2
+
 /// When we create a thunk to a PLT entry the relocation is redirected to the
 /// Thunk, changing its expression to a non-PLT equivalent. If the thunk
 /// becomes unusable we need to restore the relocation expression to the PLT

--- a/lld/test/ELF/arm-thunk-multipass.s
+++ b/lld/test/ELF/arm-thunk-multipass.s
@@ -6,6 +6,7 @@
 // RUN: llvm-objdump --no-print-imm-hex -d %t2 --start-address=0x100002 --stop-address=0x10000a  | FileCheck --check-prefix=CHECK1 %s
 // RUN: llvm-objdump --no-print-imm-hex -d %t2 --start-address=0x1000004 --stop-address=0x1000026  | FileCheck --check-prefix=CHECK2 %s
 // RUN: llvm-objdump --no-print-imm-hex -d %t2 --start-address=0x1100014 --stop-address=0x1100022  | FileCheck --check-prefix=CHECK3 %s
+// RUN: rm %t %t2
 // In this test case a branch that is in range and does not need its range
 // extended can be pushed out of range by another Thunk, necessitating another
 // pass

--- a/lld/test/ELF/arm-thunk-nosuitable.s
+++ b/lld/test/ELF/arm-thunk-nosuitable.s
@@ -9,6 +9,8 @@
 // RUN: ld.lld --be8 %t.o -o %t
 // RUN: llvm-objdump -d --start-address=0x2200b4 --stop-address=0x2200be %t | FileCheck %s
 
+// RUN: rm %t.o %t
+
         /// Create a conditional branch too far away from a precreated thunk
         /// section. This will need a thunk section created within range.
         .syntax unified

--- a/lld/test/ELF/arm-thunk-re-add.s
+++ b/lld/test/ELF/arm-thunk-re-add.s
@@ -136,4 +136,5 @@ callers:
 // RUN: llvm-objdump --no-print-imm-hex -d %t.so --start-address=0x1000004 --stop-address=0x100001c | FileCheck --check-prefix=CHECK1 %s
 // RUN: llvm-objdump --no-print-imm-hex -d %t.so --start-address=0x1100008 --stop-address=0x1100022 | FileCheck --check-prefix=CHECK2 %s
 // RUN: llvm-objdump --no-print-imm-hex -d %t.so --start-address=0x1100020 --stop-address=0x1100064 --triple=armv7aeb-linux-gnueabihf | FileCheck --check-prefix=CHECK3 %s
+// RUN: rm %t %t.so
 

--- a/lld/test/ELF/arm-thunk-section-too-large.s
+++ b/lld/test/ELF/arm-thunk-section-too-large.s
@@ -8,6 +8,8 @@
 // RUN: not ld.lld %t.o -o /dev/null 2>&1 | FileCheck %s
 // RUN: not ld.lld --be8 %t.o -o /dev/null 2>&1 | FileCheck %s
 
+// RUN: rm %t.o
+
 // CHECK: InputSection too large for range extension thunk
         .syntax unified
         .thumb

--- a/lld/test/ELF/arm-thunk-toolargesection.s
+++ b/lld/test/ELF/arm-thunk-toolargesection.s
@@ -8,6 +8,8 @@
 // RUN: not ld.lld %t -o /dev/null 2>&1 | FileCheck %s
 // RUN: not ld.lld --be8 %t -o /dev/null 2>&1 | FileCheck %s
 
+// RUN: rm %t
+
  .syntax unified
  .balign 0x1000
  .thumb


### PR DESCRIPTION
Some range extension and erratum fix thunks can't easily use a linker script to make gaps that don't result in a large output. Explicitly remove the large object and linker output files to reduce storage usage.

Related to #202261