### PR TITLE
[ARM][LLD] Reduce thunk test case size, linkerscript changes [NFC]

### DIFF
--- a/lld/test/ELF/Inputs/arm-long-thunk-converge.lds
+++ b/lld/test/ELF/Inputs/arm-long-thunk-converge.lds
@@ -1,4 +1,0 @@
-SECTIONS {
-  .foo : { *(.foo) }
-  .bar 0x2000000 : { *(.bar) }
-}

--- a/lld/test/ELF/arm-bl-v6-inrange.s
+++ b/lld/test/ELF/arm-bl-v6-inrange.s
@@ -1,11 +1,18 @@
 // REQUIRES: arm
-// RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv6-none-linux-gnueabi %s -o %t
-// RUN: echo "SECTIONS { \
-// RUN:          .callee1 0x100004 : { *(.callee_low) } \
-// RUN:          .caller  0x500000 : { *(.text) } \
-// RUN:          .callee2 0x900004 : { *(.callee_high) } } " > %t.script
-// RUN: ld.lld %t --script %t.script -o %t2
-// RUN: llvm-objdump -d --triple=armv6-none-linux-gnueabi %t2 | FileCheck %s
+// RUN: rm -rf %t && split-file %s %t && cd %t
+// RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv6-none-linux-gnueabi a.s -o a.o
+// RUN: ld.lld a.o --script a.lds -o exe
+// RUN: llvm-objdump -d --triple=armv6-none-linux-gnueabi exe | FileCheck %s
+
+//--- a.lds
+
+SECTIONS {
+  .callee1 0x100004 : AT(0x100004) { *(.callee_low) }
+  .caller  0x500000 : AT(0x500000) { *(.text) }
+  .callee2 0x900004 : AT(0x900004) { *(.callee_high) }
+}
+
+//--- a.s
 
 // On older Arm Architectures such as v5 and v6 the Thumb BL and BLX relocation
 // uses a slightly different encoding that has a lower range. These relocations

--- a/lld/test/ELF/arm-fix-cortex-a8-thunk.s
+++ b/lld/test/ELF/arm-fix-cortex-a8-thunk.s
@@ -1,17 +1,25 @@
 // REQUIRES: arm
-// RUN: llvm-mc -filetype=obj -triple=armv7a-linux-gnueabihf --arm-add-build-attributes %s -o %t.o
-// RUN: echo "SECTIONS { \
-// RUN:          .text0 0x011006 : { *(.text.00) } \
-// RUN:          .text1 0x110000 : { *(.text.01) *(.text.02) *(.text.03) \
-// RUN:                             *(.text.04) } \
-// RUN:          .text2 0x210000 : { *(.text.05) } } " > %t.script
-// RUN: ld.lld --script %t.script --fix-cortex-a8 --shared -verbose %t.o -o %t2 2>&1
-// RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn %t2 | FileCheck %s
+// RUN: rm -rf %t && split-file %s %t && cd %t
+// RUN: llvm-mc -filetype=obj -triple=armv7a-linux-gnueabihf --arm-add-build-attributes a.s -o a.o
+// RUN: ld.lld --script a.lds --fix-cortex-a8 --shared -verbose a.o -o exe 2>&1
+// RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn exe | FileCheck %s
 
 /// Test cases for Cortex-a8 Erratum 657417 that involve interactions with
 /// range extension thunks. Both erratum fixes and range extension thunks need
 /// precise information and after creation alter address information.
- .thumb
+
+//--- a.lds
+
+SECTIONS {
+  .text0 0x011006 : AT(0x011006) { *(.text.00) }
+  .text1 0x110000 : AT(0x110000) { *(.text.01) *(.text.02) *(.text.03)
+                      *(.text.04) }
+  .text2 0x210000 : AT(0x210000) { *(.text.05) }
+}
+
+//--- a.s
+
+.thumb
 
  .section .text.00, "ax", %progbits
  .thumb_func

--- a/lld/test/ELF/arm-force-pi-thunk.s
+++ b/lld/test/ELF/arm-force-pi-thunk.s
@@ -1,15 +1,20 @@
 // REQUIRES: arm
-// RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv7a-none-linux-gnueabi %s -o %t
-// RUN: echo "SECTIONS { \
-// RUN:       . = SIZEOF_HEADERS; \
-// RUN:       .text_low : { *(.text_low) *(.text_low2) } \
-// RUN:       .text_high 0x2000000 : { *(.text_high) *(.text_high2) } \
-// RUN:       } " > %t.script
-// RUN: ld.lld --pic-veneer --no-rosegment --script %t.script %t -o %t2
-// RUN: llvm-objdump --no-print-imm-hex -d %t2 | FileCheck %s
+// RUN: rm -rf %t && split-file %s %t && cd %t
+// RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv7a-none-linux-gnueabi a.s -o a.o
+// RUN: ld.lld --pic-veneer --no-rosegment --script a.lds a.o -o exe
+// RUN: llvm-objdump --no-print-imm-hex -d exe | FileCheck %s
 
 // Test that we can force generation of position independent thunks even when
 // inputs are not pic.
+
+//--- a.lds
+
+SECTIONS {
+  .text_low 0x94 : AT(0x94) { *(.text_low) *(.text_low2) }
+  .text_high 0x2000000 : AT(0x2000000) { *(.text_high) *(.text_high2) }
+}
+
+//--- a.s
 
  .syntax unified
  .section .text_low, "ax", %progbits

--- a/lld/test/ELF/arm-long-thunk-converge.s
+++ b/lld/test/ELF/arm-long-thunk-converge.s
@@ -1,9 +1,18 @@
 // REQUIRES: arm
-// RUN: llvm-mc -triple armv7-unknown-gnu -arm-add-build-attributes -filetype=obj -o %t %s
-// RUN: ld.lld %t %S/Inputs/arm-long-thunk-converge.lds -o %t2
-// RUN: llvm-objdump --no-print-imm-hex -d --start-address=0x00000000 --stop-address=0x00000010 --triple=armv7a-linux-gnueabihf %t2 | FileCheck --check-prefix=CHECK1 %s
-// RUN: llvm-objdump --no-print-imm-hex -d --start-address=0x02000000 --stop-address=0x02000010 --triple=armv7a-linux-gnueabihf %t2 | FileCheck --check-prefix=CHECK2 %s
-// RUN: rm -f %t2
+// RUN: rm -rf %t && split-file %s %t && cd %t
+// RUN: llvm-mc -triple armv7-unknown-gnu -arm-add-build-attributes -filetype=obj -o a.o a.s
+// RUN: ld.lld a.o a.lds -o exe
+// RUN: llvm-objdump --no-print-imm-hex -d --start-address=0x00000000 --stop-address=0x00000010 --triple=armv7a-linux-gnueabihf exe | FileCheck --check-prefix=CHECK1 %s
+// RUN: llvm-objdump --no-print-imm-hex -d --start-address=0x02000000 --stop-address=0x02000010 --triple=armv7a-linux-gnueabihf exe | FileCheck --check-prefix=CHECK2 %s
+// RUN: rm -f a.o exe
+
+//--- a.lds
+SECTIONS {
+  .foo 0x0 : AT(0x0) { *(.foo) }
+  .bar 0x2000000 : AT(0x2000000) { *(.bar) }
+}
+
+//--- a.s
 
 // CHECK1: <__ARMv7ABSLongThunk_bar>:
 // CHECK1-NEXT:        0:       e300c00c        movw    r12, #12

--- a/lld/test/ELF/arm-thumb-thunk-v6m.s
+++ b/lld/test/ELF/arm-thumb-thunk-v6m.s
@@ -1,19 +1,31 @@
 // REQUIRES: arm
-// RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv6m-none-eabi %s -o %t
-// RUN: echo "SECTIONS { \
-// RUN:       . = SIZEOF_HEADERS; \
-// RUN:       .text_low : { *(.text_low) *(.text_low2) } \
-// RUN:       .text_high 0x2000000 : { *(.text_high) *(.text_high2) } \
-// RUN:       } " > %t.script
-// RUN: ld.lld --no-rosegment --script %t.script %t -o %t2
-// RUN: llvm-objdump --no-print-imm-hex -d %t2 --triple=armv6m-none-eabi | FileCheck %s
-// RUN: ld.lld --no-rosegment --script %t.script %t -o %t3 --pie
-// RUN: llvm-objdump --no-print-imm-hex -d %t3 --triple=armv6m-none-eabi | FileCheck --check-prefix=CHECK-PI %s
+// RUN: rm -rf %t && split-file %s %t && cd %t
+// RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv6m-none-eabi a.s -o a.o
+// RUN: ld.lld --no-rosegment --script a.lds a.o -o exe
+// RUN: llvm-objdump --no-print-imm-hex -d exe --triple=armv6m-none-eabi | FileCheck %s
+// RUN: ld.lld --no-rosegment --script a-pi.lds a.o -o exe --pie
+// RUN: llvm-objdump --no-print-imm-hex -d exe --triple=armv6m-none-eabi | FileCheck --check-prefix=CHECK-PI %s
 
 // Range extension thunks for Arm Architecture v6m. Only Thumb instructions
 // are permitted which limits the access to instructions that can access the
 // high registers (r8 - r15), this means that the thunks have to spill
 // low registers (r0 - r7) in order to perform the transfer of control.
+
+//--- a.lds
+
+SECTIONS {
+  .text_low 0x94 : AT(0x94) { *(.text_low) *(.text_low2) }
+  .text_high 0x2000000 : AT(0x2000000) { *(.text_high) *(.text_high2) }
+}
+
+//--- a-pi.lds
+
+SECTIONS {
+  .text_low 0x130 : AT(0x130) { *(.text_low) *(.text_low2) }
+  .text_high 0x2000000 : AT(0x2000000) { *(.text_high) *(.text_high2) }
+}
+
+//--- a.s
 
  .syntax unified
  .section .text_low, "ax", %progbits

--- a/lld/test/ELF/arm-thunk-linkerscript-dotexpr.s
+++ b/lld/test/ELF/arm-thunk-linkerscript-dotexpr.s
@@ -1,23 +1,35 @@
 // REQUIRES: arm
-// RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv7a-none-linux-gnueabi %s -o %t
-// RUN: echo "SECTIONS { \
-// RUN:       . = SIZEOF_HEADERS; \
-// RUN:       .text_low : { *(.text_low) *(.text_low2) . = . + 0x2000000 ; *(.text_high) *(.text_high2) } \
-// RUN:       } " > %t.script
-// RUN: ld.lld --no-rosegment --script %t.script %t -o %t2
-// RUN: llvm-objdump --no-print-imm-hex -d %t2 --start-address=0x94 --stop-address=0xbc | FileCheck --check-prefix=CHECK1 %s
-// RUN: llvm-objdump --no-print-imm-hex -d %t2 --start-address=0x20000bc --stop-address=0x20000de | FileCheck --check-prefix=CHECK2 %s
+// RUN: rm -rf %t && split-file %s %t && cd %t
+// RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv7a-none-linux-gnueabi a.s -o a.o
+// RUN: ld.lld --no-rosegment --script a.lds a.o -o exe
+// RUN: llvm-objdump --no-print-imm-hex -d exe --start-address=0x94 --stop-address=0xbc | FileCheck --check-prefix=CHECK1 %s
+// RUN: llvm-objdump --no-print-imm-hex -d exe --start-address=0x20000bc --stop-address=0x20000de | FileCheck --check-prefix=CHECK2 %s
 
-// RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv7aeb-none-linux-gnueabi -mcpu=cortex-a8 %s -o %t
-// RUN: ld.lld --no-rosegment --script %t.script %t -o %t2
-// RUN: llvm-objdump --no-print-imm-hex -d %t2 --start-address=0x94 --stop-address=0xbc | FileCheck --check-prefix=CHECK1 %s
-// RUN: llvm-objdump --no-print-imm-hex -d %t2 --start-address=0x20000bc --stop-address=0x20000de | FileCheck --check-prefix=CHECK2 %s
-// RUN: ld.lld --be8 --no-rosegment --script %t.script %t -o %t2
-// RUN: llvm-objdump --no-print-imm-hex -d %t2 --start-address=0x94 --stop-address=0xbc | FileCheck --check-prefix=CHECK1 %s
-// RUN: llvm-objdump --no-print-imm-hex -d %t2 --start-address=0x20000bc --stop-address=0x20000de | FileCheck --check-prefix=CHECK2 %s
+// RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv7aeb-none-linux-gnueabi -mcpu=cortex-a8 a.s -o a.o
+// RUN: ld.lld --no-rosegment --script a.lds a.o -o exe
+// RUN: llvm-objdump --no-print-imm-hex -d exe --start-address=0x94 --stop-address=0xbc | FileCheck --check-prefix=CHECK1 %s
+// RUN: llvm-objdump --no-print-imm-hex -d exe --start-address=0x20000bc --stop-address=0x20000de | FileCheck --check-prefix=CHECK2 %s
+// RUN: ld.lld --be8 --no-rosegment --script a.lds a.o -o exe
+// RUN: llvm-objdump --no-print-imm-hex -d exe --start-address=0x94 --stop-address=0xbc | FileCheck --check-prefix=CHECK1 %s
+// RUN: llvm-objdump --no-print-imm-hex -d exe --start-address=0x20000bc --stop-address=0x20000de | FileCheck --check-prefix=CHECK2 %s
+// RUN: rm a.o exe
 
 // Test that range extension thunks can handle location expressions within
 // a Section Description
+
+//--- a.lds
+SECTIONS {
+  . = SIZEOF_HEADERS;
+  .text_low : {
+	*(.text_low) *(.text_low2)
+	. = . + 0x2000000 ;
+	*(.text_high) *(.text_high2)
+  }
+}
+
+
+//--- a.s
+
  .syntax unified
  .section .text_low, "ax", %progbits
  .thumb

--- a/lld/test/ELF/arm-thunk-linkerscript-large.s
+++ b/lld/test/ELF/arm-thunk-linkerscript-large.s
@@ -1,19 +1,25 @@
 // REQUIRES: arm
-// RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=thumbv7a-none-linux-gnueabi %s -o %t
-// RUN: echo "SECTIONS { \
-// RUN:       .text 0x100000 : { *(.text) } \
-// RUN:       .textl : { *(.text_l0*) *(.text_l1*) *(.text_l2*) *(.text_l3*) } \
-// RUN:       .texth : { *(.text_h0*) *(.text_h1*) *(.text_h2*) *(.text_h3*) } \
-// RUN:       }" > %t.script
-// RUN: ld.lld --script %t.script %t -o %t2
+// RUN: rm -rf %t && split-file %s %t && cd %t
+// RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=thumbv7a-none-linux-gnueabi a.s -o a.o
+// RUN: ld.lld --script a.lds a.o -o exe
 // The output file is large, most of it zeroes. We dissassemble only the
 // parts we need to speed up the test and avoid a large output file
-// RUN: llvm-objdump --no-print-imm-hex -d %t2 --start-address=0x100000 --stop-address=0x100012 | FileCheck --check-prefix=CHECK1 %s
-// RUN: llvm-objdump --no-print-imm-hex -d %t2 --start-address=0x200000 --stop-address=0x200008 | FileCheck --check-prefix=CHECK2 %s
-// RUN: llvm-objdump --no-print-imm-hex -d %t2 --start-address=0xb00004 --stop-address=0xb0000e | FileCheck --check-prefix=CHECK3 %s
-// RUN: llvm-objdump --no-print-imm-hex -d %t2 --start-address=0x2100000 --stop-address=0x210001a | FileCheck --check-prefix=CHECK4 %s
-// RUN: llvm-objdump --no-print-imm-hex -d %t2 --start-address=0x2200000 --stop-address=0x220000e | FileCheck --check-prefix=CHECK5 %s
-// RUN: llvm-objdump --no-print-imm-hex -d %t2 --start-address=0x4100000 --stop-address=0x4100020 | FileCheck --check-prefix=CHECK6 %s
+// RUN: llvm-objdump --no-print-imm-hex -d exe --start-address=0x100000 --stop-address=0x100012 | FileCheck --check-prefix=CHECK1 %s
+// RUN: llvm-objdump --no-print-imm-hex -d exe --start-address=0x200000 --stop-address=0x200008 | FileCheck --check-prefix=CHECK2 %s
+// RUN: llvm-objdump --no-print-imm-hex -d exe --start-address=0xb00004 --stop-address=0xb0000e | FileCheck --check-prefix=CHECK3 %s
+// RUN: llvm-objdump --no-print-imm-hex -d exe --start-address=0x2100000 --stop-address=0x210001a | FileCheck --check-prefix=CHECK4 %s
+// RUN: llvm-objdump --no-print-imm-hex -d exe --start-address=0x2200000 --stop-address=0x220000e | FileCheck --check-prefix=CHECK5 %s
+// RUN: llvm-objdump --no-print-imm-hex -d exe --start-address=0x4100000 --stop-address=0x4100020 | FileCheck --check-prefix=CHECK6 %s
+// RUN: rm a.o exe
+
+//--- a.lds
+SECTIONS {
+  .text 0x100000 : { *(.text) }
+  .textl : { *(.text_l0*) *(.text_l1*) *(.text_l2*) *(.text_l3*) }
+  .texth : { *(.text_h0*) *(.text_h1*) *(.text_h2*) *(.text_h3*) }
+}
+
+//--- a.s
 
 // Test the range extensions in a linker script where there are several
 // OutputSections requiring range extension Thunks. We should be able to reuse

--- a/lld/test/ELF/arm-thunk-linkerscript-orphan.s
+++ b/lld/test/ELF/arm-thunk-linkerscript-orphan.s
@@ -1,12 +1,19 @@
 // REQUIRES: arm
-// RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=thumbv7a-none-linux-gnueabi %s -o %t
-// RUN: echo "SECTIONS { \
-// RUN:       .text_low 0x100000 : { *(.text_low) } \
-// RUN:       .text_high 0x2000000 : { *(.text_high) } \
-// RUN:       .data : { *(.data) } \
-// RUN:       }" > %t.script
-// RUN: ld.lld --script %t.script %t -o %t2
-// RUN: llvm-objdump --no-print-imm-hex -d %t2 | FileCheck %s
+// RUN: rm -rf %t && split-file %s %t && cd %t
+// RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=thumbv7a-none-linux-gnueabi a.s -o a.o
+// RUN: ld.lld --script a.lds a.o -o exe
+// RUN: llvm-objdump --no-print-imm-hex -d exe | FileCheck %s
+
+//--- a.lds
+
+SECTIONS {
+  .text_low 0x100000 : AT(0x100000) { *(.text_low) }
+  .text_high 0x2000000 : AT(0x2000000) { *(.text_high) }
+  .data : { *(.data) }
+}
+
+//--- a.s
+
  .syntax unified
  .section .text_low, "ax", %progbits
  .thumb

--- a/lld/test/ELF/arm-thunk-linkerscript-sort.s
+++ b/lld/test/ELF/arm-thunk-linkerscript-sort.s
@@ -1,11 +1,17 @@
 // REQUIRES: arm
-// RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=thumbv7a-none-linux-gnueabi %s -o %t
-// RUN: echo "SECTIONS { \
-// RUN:       .text 0x100000 : { *(SORT_BY_NAME(.text.*)) } \
-// RUN:       }" > %t.script
-// RUN: ld.lld --script %t.script %t -o %t2
-// RUN: llvm-objdump -d %t2 --start-address=0x100000 --stop-address=0x100008 | FileCheck --check-prefix=CHECK1 %s
-// RUN: llvm-objdump -d %t2 --start-address=0x1000004 --stop-address=0x100000e | FileCheck --check-prefix=CHECK2 %s
+// RUN: rm -rf %t && split-file %s %t && cd %t
+// RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=thumbv7a-none-linux-gnueabi a.s -o a.o
+// RUN: ld.lld --script a.lds a.o -o exe
+// RUN: llvm-objdump -d exe --start-address=0x100000 --stop-address=0x100008 | FileCheck --check-prefix=CHECK1 %s
+// RUN: llvm-objdump -d exe --start-address=0x1000004 --stop-address=0x100000e | FileCheck --check-prefix=CHECK2 %s
+// RUN: rm -rf a.o exe
+
+//--- a.lds
+SECTIONS {
+  .text 0x100000 : { *(SORT_BY_NAME(.text.*)) }
+}
+
+//--- a.s
 
  .syntax unified
 

--- a/lld/test/ELF/arm-thunk-linkerscript.s
+++ b/lld/test/ELF/arm-thunk-linkerscript.s
@@ -1,18 +1,22 @@
 // REQUIRES: arm
-// RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv7a-none-linux-gnueabi %s -o %t
-// RUN: echo "SECTIONS { \
-// RUN:       . = SIZEOF_HEADERS; \
-// RUN:       .text_low : { *(.text_low) *(.text_low2) } \
-// RUN:       .text_high 0x2000000 : { *(.text_high) *(.text_high2) } \
-// RUN:       } " > %t.script
-// RUN: ld.lld --no-rosegment --script %t.script %t -o %t2
-// RUN: llvm-objdump --no-print-imm-hex -d %t2 | FileCheck %s
+// RUN: rm -rf %t && split-file %s %t && cd %t
+// RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv7a-none-linux-gnueabi a.s -o a.o
+// RUN: ld.lld --no-rosegment --script a.lds a.o -o exe
+// RUN: llvm-objdump --no-print-imm-hex -d exe | FileCheck %s
+// RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv7aeb-none-linux-gnueabi -mcpu=cortex-a8 a.s -o a.o
+// RUN: ld.lld --no-rosegment --script a.lds a.o -o exe
+// RUN: llvm-objdump --no-print-imm-hex -d exe | FileCheck %s
+// RUN: ld.lld --be8 --no-rosegment --script a.lds a.o -o %t2
+// RUN: llvm-objdump --no-print-imm-hex -d exe | FileCheck %s
 
-// RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv7aeb-none-linux-gnueabi -mcpu=cortex-a8 %s -o %t
-// RUN: ld.lld --no-rosegment --script %t.script %t -o %t2
-// RUN: llvm-objdump --no-print-imm-hex -d %t2 | FileCheck %s
-// RUN: ld.lld --be8 --no-rosegment --script %t.script %t -o %t2
-// RUN: llvm-objdump --no-print-imm-hex -d %t2 | FileCheck %s
+//--- a.lds
+
+SECTIONS {
+  .text_low 0x94 : AT(0x94) { *(.text_low) *(.text_low2) }
+  .text_high 0x2000000 : AT(0x2000000) { *(.text_high) *(.text_high2) }
+}
+
+//--- a.s
 
 // Simple test that we can support range extension thunks with linker scripts
  .syntax unified

--- a/lld/test/ELF/arm-thunk-many-passes.s
+++ b/lld/test/ELF/arm-thunk-many-passes.s
@@ -1,13 +1,10 @@
 // REQUIRES: arm
-// RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv7a-linux-gnueabihf %s -o %t
-// RUN: echo "SECTIONS { \
-// RUN:       . = SIZEOF_HEADERS; \
-// RUN:       .text 0x00011000 : { *(.text.*) } \
-// RUN:       } \
-// RUN:       sym = .;" > %t.script
-// RUN: ld.lld --script %t.script %t -o %t2
-// RUN: llvm-readobj --sections --symbols %t2 | FileCheck --check-prefix=CHECK-ELF %s
-// RUN: llvm-objdump --no-show-raw-insn --start-address=0x11000 --stop-address=0x11048 -d %t2 | FileCheck %s
+// RUN: rm -rf %t && split-file %s %t && cd %t
+// RUN: llvm-mc -arm-add-build-attributes -filetype=obj -triple=armv7a-linux-gnueabihf a.s -o a.o
+// RUN: ld.lld --script a.lds a.o -o exe
+// RUN: llvm-readobj --sections --symbols exe | FileCheck --check-prefix=CHECK-ELF %s
+// RUN: llvm-objdump --no-show-raw-insn --start-address=0x11000 --stop-address=0x11048 -d exe | FileCheck %s
+// RUN: rm a.o exe
 
 // An example of thunk generation that takes the maximum number of permitted
 // passes to converge. We start with a set of branches of which all but one are
@@ -54,6 +51,14 @@
 // CHECK-NEXT:    11040:       b.w     0xe11068 <__Thumbv7ABSLongThunk_f10>
 // CHECK-NEXT:    11044:       b.w     0xe11068 <__Thumbv7ABSLongThunk_f10>
 
+//--- a.lds
+SECTIONS {
+  . = SIZEOF_HEADERS;
+  .text 0x00011000 : { *(.text.*) }
+}
+sym = .;
+
+//--- a.s
 
         .thumb
         .section .text.00, "ax", %progbits


### PR DESCRIPTION
These changes either do some refactoring to use split-file and then delete the outputs as the size saving is not large. Or it adapts the linker script to reduce the size by introducing sparse program segments.

All these cases are fairly simple changes, and have made minimal changes to the CHECK lines.

Related to #202261