### PR TITLE
Revert "[test][Support] Disable CFI-icall for DynamicLibrary Overload test"

### DIFF
--- a/llvm/unittests/Support/DynamicLibrary/DynamicLibraryTest.cpp
+++ b/llvm/unittests/Support/DynamicLibrary/DynamicLibraryTest.cpp
@@ -59,7 +59,7 @@ static const char *OverloadTestA() { return "OverloadCall"; }
 
 std::string StdString(const char *Ptr) { return Ptr ? Ptr : ""; }
 
-TEST(DynamicLibrary, Overload) __attribute__((no_sanitize("cfi-icall"))) {
+TEST(DynamicLibrary, Overload) {
   {
     std::string Err;
     DynamicLibrary DL =


### PR DESCRIPTION
Reverts llvm/llvm-project#202446