### PR TITLE
[lldb] Ignore async notification packets while waiting for a response

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/gdbclientutils.py
+++ b/lldb/packages/Python/lldbsuite/test/gdbclientutils.py
@@ -22,15 +22,18 @@ def checksum(message):
     return check % 256
 
 
-def frame_packet(message):
+def frame_packet(message, prefix):
     """
     Create a framed packet that's ready to send over the GDB connection
     channel.
 
-    Framing includes surrounding the message between $ and #, and appending
-    a two character hex checksum.
+    Framing means:
+    * Attaching the prefix. Which is usually '$' but for notifications will be
+      '%'.
+    * Appending a '#'.
+    * Adding a two character hex checksum.
     """
-    return "$%s#%02x" % (message, checksum(message))
+    return "%s%s#%02x" % (prefix, message, checksum(message))
 
 
 def escape_binary(message):
@@ -694,9 +697,9 @@ class MockGDBServer:
         self._receivedDataOffset = 0
         return packet
 
-    def _sendPacket(self, packet: str):
+    def _sendPacket(self, packet: str, prefix="$"):
         assert self._socket is not None
-        framed_packet = seven.bitcast_to_bytes(frame_packet(packet))
+        framed_packet = seven.bitcast_to_bytes(frame_packet(packet, prefix))
         self._socket.sendall(framed_packet)
 
     def _handlePacket(self, packet):

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
@@ -242,7 +242,17 @@ GDBRemoteCommunication::WaitForPacketNoLock(StringExtractorGDBRemote &packet,
   Log *log = GetLog(GDBRLog::Packets);
 
   // Check for a packet from our cache first without trying any reading...
-  if (CheckForPacket(nullptr, 0, packet) != PacketType::Invalid)
+  // Async notification packets (e.g. OpenOCD's "oocd_keepalive", sent during
+  // long memory operations) are not responses to our request. GDB silently
+  // drops such notifications while waiting for a packet; do the same and keep
+  // looking for the actual response.
+  PacketType packet_type = CheckForPacket(nullptr, 0, packet);
+  while (packet_type == PacketType::Notify) {
+    LLDB_LOGF(log, "GDBRemoteCommunication::%s ignoring notification packet",
+              __FUNCTION__);
+    packet_type = CheckForPacket(nullptr, 0, packet);
+  }
+  if (packet_type != PacketType::Invalid)
     return PacketResult::Success;
 
   bool timed_out = false;
@@ -258,7 +268,17 @@ GDBRemoteCommunication::WaitForPacketNoLock(StringExtractorGDBRemote &packet,
                      error, bytes_read);
 
     if (bytes_read > 0) {
-      if (CheckForPacket(buffer, bytes_read, packet) != PacketType::Invalid)
+      // Drop any async notification packets (see above) and keep waiting for
+      // the actual response. Once the freshly-read bytes have been consumed,
+      // re-check the cache for any further buffered packets.
+      packet_type = CheckForPacket(buffer, bytes_read, packet);
+      while (packet_type == PacketType::Notify) {
+        LLDB_LOGF(log,
+                  "GDBRemoteCommunication::%s ignoring notification packet",
+                  __FUNCTION__);
+        packet_type = CheckForPacket(nullptr, 0, packet);
+      }
+      if (packet_type != PacketType::Invalid)
         return PacketResult::Success;
     } else {
       switch (status) {

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
@@ -269,8 +269,7 @@ GDBRemoteCommunication::WaitForPacketNoLock(StringExtractorGDBRemote &packet,
 
     if (bytes_read > 0) {
       // Drop any async notification packets (see above) and keep waiting for
-      // the actual response. Once the freshly-read bytes have been consumed,
-      // re-check the cache for any further buffered packets.
+      // the actual response.
       packet_type = CheckForPacket(buffer, bytes_read, packet);
       while (packet_type == PacketType::Notify) {
         LLDB_LOGF(log,

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
@@ -232,6 +232,24 @@ GDBRemoteCommunication::ReadPacket(StringExtractorGDBRemote &response,
   }
 }
 
+GDBRemoteCommunication::PacketType
+GDBRemoteCommunication::GetNextNonNotifyPacket(
+    const uint8_t *src, size_t src_len, StringExtractorGDBRemote &packet) {
+  // Async notification packets (e.g. OpenOCD's "oocd_keepalive", sent during
+  // long memory operations) are not responses to our request. GDB silently
+  // drops unknown notifications while waiting for a packet; do the same and
+  // keep looking for the actual response. After the freshly-read bytes are
+  // consumed, drain any further buffered packets from the cache.
+  Log *log = GetLog(GDBRLog::Packets);
+  PacketType packet_type = CheckForPacket(src, src_len, packet);
+  while (packet_type == PacketType::Notify) {
+    LLDB_LOGF(log, "GDBRemoteCommunication::%s ignoring notification packet",
+              __FUNCTION__);
+    packet_type = CheckForPacket(nullptr, 0, packet);
+  }
+  return packet_type;
+}
+
 GDBRemoteCommunication::PacketResult
 GDBRemoteCommunication::WaitForPacketNoLock(StringExtractorGDBRemote &packet,
                                             Timeout<std::micro> timeout,
@@ -242,17 +260,7 @@ GDBRemoteCommunication::WaitForPacketNoLock(StringExtractorGDBRemote &packet,
   Log *log = GetLog(GDBRLog::Packets);
 
   // Check for a packet from our cache first without trying any reading...
-  // Async notification packets (e.g. OpenOCD's "oocd_keepalive", sent during
-  // long memory operations) are not responses to our request. GDB silently
-  // drops such notifications while waiting for a packet; do the same and keep
-  // looking for the actual response.
-  PacketType packet_type = CheckForPacket(nullptr, 0, packet);
-  while (packet_type == PacketType::Notify) {
-    LLDB_LOGF(log, "GDBRemoteCommunication::%s ignoring notification packet",
-              __FUNCTION__);
-    packet_type = CheckForPacket(nullptr, 0, packet);
-  }
-  if (packet_type != PacketType::Invalid)
+  if (GetNextNonNotifyPacket(nullptr, 0, packet) != PacketType::Invalid)
     return PacketResult::Success;
 
   bool timed_out = false;
@@ -268,16 +276,8 @@ GDBRemoteCommunication::WaitForPacketNoLock(StringExtractorGDBRemote &packet,
                      error, bytes_read);
 
     if (bytes_read > 0) {
-      // Drop any async notification packets (see above) and keep waiting for
-      // the actual response.
-      packet_type = CheckForPacket(buffer, bytes_read, packet);
-      while (packet_type == PacketType::Notify) {
-        LLDB_LOGF(log,
-                  "GDBRemoteCommunication::%s ignoring notification packet",
-                  __FUNCTION__);
-        packet_type = CheckForPacket(nullptr, 0, packet);
-      }
-      if (packet_type != PacketType::Invalid)
+      if (GetNextNonNotifyPacket(buffer, bytes_read, packet) !=
+          PacketType::Invalid)
         return PacketResult::Success;
     } else {
       switch (status) {

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
@@ -376,6 +376,11 @@ GDBRemoteCommunication::WaitForPacketNoLock(StringExtractorGDBRemote &packet,
         }
         break;
       case eConnectionStatusSuccess:
+        // Read() can return zero bytes with a success status (e.g. a spurious
+        // readable wakeup that yields EAGAIN on a non-socket connection). That
+        // is neither EOF nor an error, so keep looping -- we may still be
+        // waiting for the actual response, for instance after dropping the
+        // async notification packets handled above.
         // printf ("status = success but error = %s\n",
         // error.AsCString("<invalid>"));
         break;

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
@@ -235,11 +235,13 @@ GDBRemoteCommunication::ReadPacket(StringExtractorGDBRemote &response,
 GDBRemoteCommunication::PacketType
 GDBRemoteCommunication::GetNextNonNotifyPacket(
     const uint8_t *src, size_t src_len, StringExtractorGDBRemote &packet) {
-  // Async notification packets (e.g. OpenOCD's "oocd_keepalive", sent during
-  // long memory operations) are not responses to our request. GDB silently
-  // drops unknown notifications while waiting for a packet; do the same and
-  // keep looking for the actual response. After the freshly-read bytes are
-  // consumed, drain any further buffered packets from the cache.
+  // Return the type of the next packet that is not an async notification.
+  // Notification packets (e.g. OpenOCD's "oocd_keepalive", sent during long
+  // memory operations) are not responses to our request; like GDB, silently
+  // drop them and keep looking for the actual response. CheckForPacket()
+  // appends src/src_len to its buffer and returns one packet per call, so the
+  // loop passes nullptr/0 to read each subsequent buffered packet until a
+  // non-notification packet (or PacketType::Invalid) is returned.
   Log *log = GetLog(GDBRLog::Packets);
   PacketType packet_type = CheckForPacket(src, src_len, packet);
   while (packet_type == PacketType::Notify) {

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.h
@@ -119,6 +119,11 @@ public:
   PacketType CheckForPacket(const uint8_t *src, size_t src_len,
                             StringExtractorGDBRemote &packet);
 
+  // Like CheckForPacket, but silently drops any async notification packets and
+  // returns the type of the next non-notification packet. See the definition.
+  PacketType GetNextNonNotifyPacket(const uint8_t *src, size_t src_len,
+                                    StringExtractorGDBRemote &packet);
+
   bool GetSendAcks() { return m_send_acks; }
 
   // Set the global packet timeout.

--- a/lldb/test/API/functionalities/gdb_remote_client/TestIgnoringNotifications.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestIgnoringNotifications.py
@@ -1,0 +1,67 @@
+"""
+Test that LLDB ignores notification packets (those beginning with '%')
+when waiting for a response to a '$' packet.
+
+OpenOCD is one debug server that uses notification packets to reset
+the connection timeout if a memory read takes too long. So that's what
+we test here, but it should apply to any exchange.
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+from lldbsuite.test.gdbclientutils import *
+from lldbsuite.test.lldbgdbclient import GDBRemoteTestBase
+
+
+class NotifyingServerResponder(MockGDBServerResponder):
+    def readMemory(self, addr, length):
+        return "01" * length
+
+
+class NotifyingServer(MockGDBServer):
+    def __init__(self, socket):
+        self._socket = socket
+        self.responder = NotifyingServerResponder()
+        self.sent_notification = False
+
+    def _sendPacket(self, packet: str, prefix="$"):
+        # In theory we could add notifies before all packets, but it always
+        # goes through the same code and just makes the test take longer.
+        if packet == "01010101":
+            # Send more than one to make sure we clear them all to find
+            # the real response.
+            super()._sendPacket("this_is_a_notification", prefix="%")
+            super()._sendPacket("this_is_a_2nd_notification", prefix="%")
+            self.sent_notification = True
+
+        super()._sendPacket(packet)
+
+
+class TestIgnoringNotifications(GDBRemoteTestBase):
+    def setUp(self):
+        TestBase.setUp(self)
+        self.server = NotifyingServer(self.server_socket_class())
+        self.server.start()
+
+    @skipIfLLVMTargetMissing("AArch64")
+    def test(self):
+        target = self.createTarget("basic_eh_frame-aarch64.yaml")
+
+        if self.TraceOn():
+            self.runCmd("log enable gdb-remote packets")
+            self.addTearDownHook(lambda: self.runCmd("log disable gdb-remote packets"))
+
+        process = self.connect(target)
+        lldbutil.expect_state_changes(
+            self, self.dbg.GetListener(), process, [lldb.eStateStopped]
+        )
+
+        # Disabling cache is not required but makes debugging this test easier.
+        self.runCmd("settings set target.process.disable-memory-cache true")
+
+        # Should succeed despite getting a notification before the real result.
+        self.expect("memory read --format hex 0x1234 0x1238", substrs=["0x01010101"])
+
+        # Check we didn't succeed because lldb got memory in some other way.
+        self.assertTrue(self.server.sent_notification)

--- a/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationTest.cpp
+++ b/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationTest.cpp
@@ -75,6 +75,25 @@ TEST_F(GDBRemoteCommunicationTest, ReadPacket) {
   }
 }
 
+// Test that async notification packets received while waiting for a response
+// are silently dropped and that we keep looking for the actual response.
+// OpenOCD sends a "%oocd_keepalive:XX#cc" notification during long memory
+// operations; like GDB (since 7.0), LLDB must ignore it rather than mistake it
+// for the response. See https://github.com/llvm/llvm-project/issues/197944.
+TEST_F(GDBRemoteCommunicationTest, ReadPacketIgnoresNotifications) {
+  StringExtractorGDBRemote response;
+
+  // A single notification ahead of the response.
+  ASSERT_TRUE(Write("%oocd_keepalive:00#54$OK#9a"));
+  ASSERT_EQ(PacketResult::Success, client.ReadPacket(response));
+  EXPECT_EQ("OK", response.GetStringRef());
+
+  // Several notifications ahead of the response.
+  ASSERT_TRUE(Write("%oocd_keepalive:01#55%oocd_keepalive:02#56$OK#9a"));
+  ASSERT_EQ(PacketResult::Success, client.ReadPacket(response));
+  EXPECT_EQ("OK", response.GetStringRef());
+}
+
 // Test that packets with incorrect RLE sequences do not cause a crash and
 // reported as invalid.
 TEST_F(GDBRemoteCommunicationTest, CheckForPacket) {

--- a/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationTest.cpp
+++ b/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationTest.cpp
@@ -92,6 +92,11 @@ TEST_F(GDBRemoteCommunicationTest, ReadPacketIgnoresNotifications) {
   ASSERT_TRUE(Write("%oocd_keepalive:01#55%oocd_keepalive:02#56$OK#9a"));
   ASSERT_EQ(PacketResult::Success, client.ReadPacket(response));
   EXPECT_EQ("OK", response.GetStringRef());
+
+  // A notification with no response following it is dropped, and the read
+  // fails (times out) rather than returning the notification.
+  ASSERT_TRUE(Write("%oocd_keepalive:03#57"));
+  EXPECT_EQ(PacketResult::ErrorReplyTimeout, client.ReadPacket(response));
 }
 
 // Test that packets with incorrect RLE sequences do not cause a crash and

--- a/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationTest.cpp
+++ b/lldb/unittests/Process/gdb-remote/GDBRemoteCommunicationTest.cpp
@@ -10,6 +10,9 @@
 #include "lldb/Host/ConnectionFileDescriptor.h"
 #include "llvm/Testing/Support/Error.h"
 
+#include <chrono>
+#include <thread>
+
 using namespace lldb_private::process_gdb_remote;
 using namespace lldb_private;
 using namespace lldb;
@@ -97,6 +100,32 @@ TEST_F(GDBRemoteCommunicationTest, ReadPacketIgnoresNotifications) {
   // fails (times out) rather than returning the notification.
   ASSERT_TRUE(Write("%oocd_keepalive:03#57"));
   EXPECT_EQ(PacketResult::ErrorReplyTimeout, client.ReadPacket(response));
+}
+
+// Test the case where the notification and the actual response do NOT arrive
+// together in a single read: the notification is sent first, and the response
+// follows only after the client has already consumed the notification and gone
+// back to waiting. The notification must still be dropped and the client must
+// keep reading until the real response arrives, rather than giving up once the
+// receive buffer briefly drains.
+TEST_F(GDBRemoteCommunicationTest, ReadPacketIgnoresNotificationsAcrossReads) {
+  StringExtractorGDBRemote response;
+
+  // Send the notification on its own. The client should read it, drop it, and
+  // block on the next read with the buffer empty.
+  ASSERT_TRUE(Write("%oocd_keepalive:00#54"));
+
+  // Send the response from another thread after a short delay, so it lands in
+  // a separate read once the client is already waiting again.
+  std::thread responder([this] {
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    Write("$OK#9a");
+  });
+
+  EXPECT_EQ(PacketResult::Success, client.ReadPacket(response));
+  EXPECT_EQ("OK", response.GetStringRef());
+
+  responder.join();
 }
 
 // Test that packets with incorrect RLE sequences do not cause a crash and


### PR DESCRIPTION
OpenOCD's gdbserver sends an async notification packet
("%oocd_keepalive:XX#cc") roughly every 500ms while a long memory
read/write is in progress. WaitForPacketNoLock() treated any non-invalid
packet returned by CheckForPacket() -- including a PacketType::Notify --
as the response to the pending request, so a keepalive arriving during a
memory write produced:

  unexpected response to GDB server memory write packet
  'M2ffff8,4:54430000': 'oocd_keepalive:00'

GDB has silently dropped unknown notifications received while waiting for
a packet since 7.0 (2009).

The protocol spec also states that we should do this https://sourceware.org/gdb/current/onlinedocs/gdb.html/Notification-Packets.html#Notification-Packets:
> Recipients should silently ignore corrupted notifications and notifications they do not understand. Recipients should restart timeout periods on receipt of a well-formed notification, whether or not they understand it.

Match that behaviour: drop notification
packets and keep waiting for the actual response. The LLDB client does
not otherwise consume '%' notifications, so this is safe

Adds a unit test covering single and multiple notifications preceding the
response.

Fixes #197944.



Assisted-by: Claude Code (Anthropic)
