### PR TITLE
[AlignmentFromAssumes] Skip huge alignment

### DIFF
--- a/llvm/lib/Transforms/Scalar/AlignmentFromAssumptions.cpp
+++ b/llvm/lib/Transforms/Scalar/AlignmentFromAssumptions.cpp
@@ -178,6 +178,9 @@ bool AlignmentFromAssumptionsPass::extractAlignmentInfo(CallInst *I,
   if (!cast<SCEVConstant>(AlignSCEV)->getAPInt().isPowerOf2())
     // Only power of two alignments are supported.
     return false;
+  if (cast<SCEVConstant>(AlignSCEV)->getAPInt().ugt(Value::MaximumAlignment))
+    // Alignment exceeds what LLVM instructions can represent; skip.
+    return false;
   if (AlignOB.Inputs.size() == 3)
     OffSCEV = SE->getSCEV(AlignOB.Inputs[2].get());
   else

--- a/llvm/test/Transforms/AlignmentFromAssumptions/simple.ll
+++ b/llvm/test/Transforms/AlignmentFromAssumptions/simple.ll
@@ -395,6 +395,18 @@ entry:
   ret i32 %0
 }
 
+define i32 @align_63bit(ptr %p) {
+; CHECK-LABEL: define i32 @align_63bit
+; CHECK-SAME: (ptr [[P:%.*]]) {
+; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "align"(ptr [[P]], i64 -9223372036854775808) ]
+; CHECK-NEXT:    [[V:%.*]] = load i32, ptr [[P]], align 4
+; CHECK-NEXT:    ret i32 [[V]]
+;
+  call void @llvm.assume(i1 true) [ "align"(ptr %p, i64 -9223372036854775808) ]
+  %v = load i32, ptr %p, align 4
+  ret i32 %v
+}
+
 declare void @llvm.assume(i1) nounwind
 
 declare void @llvm.memset.p0.i64(ptr nocapture, i8, i64, i1) nounwind


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/202043
Though `align` on huge alignment is not supported, the case below confirms we allow huge alignment in `assume`: https://github.com/llvm/llvm-project/blob/c4f4206ff3ab97db9577f11bb2dabd40896bcca9/llvm/test/Transforms/InstCombine/assume.ll#L71
In this case, we should skip huge alignment in AlignmentFromAssumes.