### PR TITLE
[GlobalISel] Use more inline elements in a match table SmallVector

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/GIMatchTableExecutorImpl.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/GIMatchTableExecutorImpl.h
@@ -51,7 +51,7 @@ bool GIMatchTableExecutor::executeMatchTable(
     CodeGenCoverage *CoverageInfo) const {
 
   uint64_t CurrentIdx = 0;
-  SmallVector<uint64_t, 4> OnFailResumeAt;
+  SmallVector<uint64_t, 8> OnFailResumeAt;
   NewMIVector OutMIs;
 
   GISelChangeObserver *Observer = Builder.getObserver();


### PR DESCRIPTION
The 4 inline elements for OnFailResumeAt only cover 36.8% (33455 / 90902) of
aarch64-isel executeMatchTable invocations encountered while compiling sqlite3
on aarch64-O0-g.

The 8 inline elements cover 100% (maximum observed depth was 6). Small -0.09%
CTMark geomean improvement on aarch64-O0-g.

https://llvm-compile-time-tracker.com/compare.php?from=2de2edb943fe1b83d79bdffa03606eb8c5452e9b&to=8deb4f949b5f80a26a8a61775fb411bf30fefd80&stat=instructions%3Au

Assisted-by: codex