### PR TITLE
[LLD][ELF] Add missing initialization of Symbol `used` member.

### DIFF
--- a/lld/ELF/Symbols.h
+++ b/lld/ELF/Symbols.h
@@ -243,11 +243,11 @@ protected:
          uint8_t stOther, uint8_t type)
       : file(file), nameData(name.data()), nameSize(name.size()), type(type),
         binding(binding), stOther(stOther), symbolKind(k), isPreemptible(false),
-        isUsedInRegularObj(false), isExported(false), ltoCanOmit(false),
-        traced(false), hasVersionSuffix(false), isInIplt(false),
-        gotInIgot(false), folded(false), archSpecificBit(false),
-        scriptDefined(false), dsoDefined(false), dsoProtected(false),
-        versionScriptAssigned(false), thunkAccessed(false),
+        isUsedInRegularObj(false), used(false), isExported(false),
+        ltoCanOmit(false), traced(false), hasVersionSuffix(false),
+        isInIplt(false), gotInIgot(false), folded(false),
+        archSpecificBit(false), scriptDefined(false), dsoDefined(false),
+        dsoProtected(false), versionScriptAssigned(false), thunkAccessed(false),
         inDynamicList(false), referenced(false), referencedAfterWrap(false) {}
 
   void overwrite(Symbol &sym, Kind k) const {


### PR DESCRIPTION
On the "main" branch, Symbol no longer has the `used` member which was moved in PR #190117 (commit 6a874161). Therefore, when the cherry pick from PR #198129 (commit 905a88b9) was merged to the "release/22.x" branch, the initialization of `used` was lost.