### PR TITLE
[clang][cmake-caches] add check-clang targets to the BOLT-PGO cmake cache

### DIFF
--- a/clang/cmake/caches/BOLT-PGO.cmake
+++ b/clang/cmake/caches/BOLT-PGO.cmake
@@ -3,11 +3,13 @@ set(LLVM_ENABLE_PROJECTS "bolt;clang;lld" CACHE STRING "")
 
 set(CLANG_BOOTSTRAP_TARGETS
   stage2-clang-bolt
+  stage2-check-clang
   stage2-distribution
   stage2-install-distribution
   CACHE STRING "")
 set(BOOTSTRAP_CLANG_BOOTSTRAP_TARGETS
   clang-bolt
+  check-clang
   distribution
   install-distribution
   CACHE STRING "")


### PR DESCRIPTION
Without the `stage2-check-clang` target (and the `check-clang` target needed by it) it is impossible to test the optimized clang binary.

With this target available, execution of the `stage2-check-clang` target reports the use of the correct `clang` binary:

```
llvm-lit: llvm/utils/lit/lit/llvm/config.py:569: note: using clang: build/stage/product_build/tools/clang/stage2-instrumented-bins/tools/clang/stage2-bins/bin/clang
llvm-lit: llvm/utils/lit/lit/llvm/config.py:569: note: using ld.lld: build/stage/product_build/tools/clang/stage2-instrumented-bins/tools/clang/stage2-bins/bin/ld.lld
llvm-lit: llvm/utils/lit/lit/llvm/config.py:569: note: using lld-link: build/stage/product_build/tools/clang/stage2-instrumented-bins/tools/clang/stage2-bins/bin/lld-link
llvm-lit: llvm/utils/lit/lit/llvm/config.py:569: note: using ld64.lld: build/stage/product_build/tools/clang/stage2-instrumented-bins/tools/clang/stage2-bins/bin/ld64.lld
llvm-lit: llvm/utils/lit/lit/llvm/config.py:569: note: using wasm-ld: build/stage/product_build/tools/clang/stage2-instrumented-bins/tools/clang/stage2-bins/bin/wasm-ld
llvm-lit: llvm/utils/lit/lit/llvm/config.py:569: note: using ld.lld: build/stage/product_build/tools/clang/stage2-instrumented-bins/tools/clang/stage2-bins/bin/ld.lld
llvm-lit: llvm/utils/lit/lit/llvm/config.py:569: note: using lld-link: build/stage/product_build/tools/clang/stage2-instrumented-bins/tools/clang/stage2-bins/bin/lld-link
llvm-lit: llvm/utils/lit/lit/llvm/config.py:569: note: using ld64.lld: build/stage/product_build/tools/clang/stage2-instrumented-bins/tools/clang/stage2-bins/bin/ld64.lld
llvm-lit: llvm/utils/lit/lit/llvm/config.py:569: note: using wasm-ld: build/stage/product_build/tools/clang/stage2-instrumented-bins/tools/clang/stage2-bins/bin/wasm-ld
-- Testing: 25786 tests, 256 workers --
Testing:  0.. 10.. 20.. 30.. 40.. 50.. 60.. 70.. 80.. 90..

Testing Time: 49.85s

Total Discovered Tests: 52284
Skipped          :    13 (0.02%)
Unsupported      :  4995 (9.55%)
Passed           : 47250 (90.37%)
Expectedly Failed:    26 (0.05%)
```