### PR TITLE
[Support] Compact EnumEntry string storage

### DIFF
--- a/llvm/include/llvm/Object/ELFObjectFile.h
+++ b/llvm/include/llvm/Object/ELFObjectFile.h
@@ -200,7 +200,7 @@ public:
     uint8_t Type = getELFType();
     for (const auto &EE : ElfSymbolTypes) {
       if (EE.Value == Type) {
-        return EE.AltName;
+        return EE.getAltName();
       }
     }
     return "";

--- a/llvm/include/llvm/Support/ScopedPrinter.h
+++ b/llvm/include/llvm/Support/ScopedPrinter.h
@@ -25,7 +25,23 @@
 namespace llvm {
 
 template <typename T> struct EnumEntry {
-  StringRef Name;
+private:
+  const char *NameData;
+  const char *AltNameData;
+
+public:
+  T Value;
+
+private:
+  uint16_t NameLength;
+  uint16_t AltNameLength;
+
+  template <size_t N> static constexpr uint16_t literalLength() {
+    static_assert(N - 1 <= UINT16_MAX, "EnumEntry names must fit in uint16_t");
+    return N - 1;
+  }
+
+public:
   // While Name suffices in most of the cases, in certain cases
   // GNU style and LLVM style of ELFDumper do not
   // display same string for same enum. The AltName if initialized appropriately
@@ -33,12 +49,29 @@ template <typename T> struct EnumEntry {
   // Example:
   // "EM_X86_64" string on LLVM style for Elf_Ehdr->e_machine corresponds to
   // "Advanced Micro Devices X86-64" on GNU style
-  StringRef AltName;
-  T Value;
-  constexpr EnumEntry(StringRef N, StringRef A, T V)
-      : Name(N), AltName(A), Value(V) {}
-  constexpr EnumEntry(StringRef N, T V) : Name(N), AltName(N), Value(V) {}
+  template <size_t N, size_t A>
+  constexpr EnumEntry(const char (&Name)[N], const char (&AltName)[A], T Value)
+      : NameData(Name), AltNameData(AltName), Value(Value),
+        NameLength(literalLength<N>()), AltNameLength(literalLength<A>()) {}
+
+  template <size_t N>
+  constexpr EnumEntry(const char (&Name)[N], T Value)
+      : NameData(Name), AltNameData(nullptr), Value(Value),
+        NameLength(literalLength<N>()), AltNameLength(0) {}
+
+  constexpr StringRef getName() const {
+    return StringRef(NameData, NameLength);
+  }
+
+  constexpr StringRef getAltName() const {
+    return AltNameData ? StringRef(AltNameData, AltNameLength) : getName();
+  }
 };
+
+static_assert(sizeof(EnumEntry<uint32_t>) == 2 * sizeof(const char *) +
+                                                 sizeof(uint32_t) +
+                                                 2 * sizeof(uint16_t),
+              "EnumEntry<uint32_t> must remain compact");
 
 struct HexNumber {
   // To avoid sign-extension we have to explicitly cast to the appropriate
@@ -103,7 +136,7 @@ template <typename T, typename TEnum>
 std::string enumToString(T Value, ArrayRef<EnumEntry<TEnum>> EnumValues) {
   for (const EnumEntry<TEnum> &EnumItem : EnumValues)
     if (EnumItem.Value == Value)
-      return std::string(EnumItem.AltName);
+      return std::string(EnumItem.getAltName());
   return utohexstr(Value, true);
 }
 
@@ -114,7 +147,7 @@ template <typename T, typename TEnum>
 StringRef enumToStringRef(T Value, ArrayRef<EnumEntry<TEnum>> EnumValues) {
   for (const EnumEntry<TEnum> &EnumItem : EnumValues)
     if (EnumItem.Value == Value)
-      return EnumItem.AltName;
+      return EnumItem.getAltName();
   return "";
 }
 
@@ -166,7 +199,7 @@ public:
     bool Found = false;
     for (const auto &EnumItem : EnumValues) {
       if (EnumItem.Value == Value) {
-        Name = EnumItem.Name;
+        Name = EnumItem.getName();
         Found = true;
         break;
       }
@@ -198,7 +231,7 @@ public:
       bool IsEnum = (Flag.Value & EnumMask) != TFlag{};
       if ((!IsEnum && (Value & Flag.Value) == Flag.Value) ||
           (IsEnum && (Value & EnumMask) == Flag.Value)) {
-        SetFlags.emplace_back(Flag.Name, Flag.Value);
+        SetFlags.emplace_back(Flag.getName(), Flag.Value);
       }
     }
 

--- a/llvm/lib/BinaryFormat/DXContainer.cpp
+++ b/llvm/lib/BinaryFormat/DXContainer.cpp
@@ -333,7 +333,7 @@ StringRef SourceInfo::getSectionName(SourceInfo::SectionType Type) {
   auto V = to_underlying(Type);
   if (!isValidSectionType(V))
     return StringRef();
-  return getSectionTypes()[V].Name;
+  return getSectionTypes()[V].getName();
 }
 
 static const EnumEntry<SourceInfo::Contents::CompressionType>

--- a/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
@@ -3192,7 +3192,7 @@ void CodeViewDebug::endCVSubsection(MCSymbol *EndLabel) {
 static StringRef getSymbolName(SymbolKind SymKind) {
   for (const EnumEntry<SymbolKind> &EE : getSymbolTypeNames())
     if (EE.Value == SymKind)
-      return EE.Name;
+      return EE.getName();
   return "";
 }
 

--- a/llvm/lib/DebugInfo/CodeView/TypeRecordMapping.cpp
+++ b/llvm/lib/DebugInfo/CodeView/TypeRecordMapping.cpp
@@ -59,7 +59,7 @@ static StringRef getLeafTypeName(TypeLeafKind LT) {
 
 template <typename T>
 static bool compEnumNames(const EnumEntry<T> &lhs, const EnumEntry<T> &rhs) {
-  return lhs.Name < rhs.Name;
+  return lhs.getName() < rhs.getName();
 }
 
 template <typename T, typename TFlag>
@@ -88,7 +88,7 @@ static std::string getFlagNames(CodeViewRecordIO &IO, T Value,
     else
       FlagLabel += (" | ");
 
-    FlagLabel += (Flag.Name.str() + " (0x" + utohexstr(Flag.Value) + ")");
+    FlagLabel += (Flag.getName().str() + " (0x" + utohexstr(Flag.Value) + ")");
   }
 
   if (!FlagLabel.empty()) {
@@ -107,7 +107,7 @@ static StringRef getEnumName(CodeViewRecordIO &IO, T Value,
   StringRef Name;
   for (const auto &EnumItem : EnumValues) {
     if (EnumItem.Value == Value) {
-      Name = EnumItem.Name;
+      Name = EnumItem.getName();
       break;
     }
   }

--- a/llvm/lib/ObjectYAML/CodeViewYAMLSymbols.cpp
+++ b/llvm/lib/ObjectYAML/CodeViewYAMLSymbols.cpp
@@ -80,7 +80,7 @@ void ScalarEnumerationTraits<SymbolKind>::enumeration(IO &io,
                                                       SymbolKind &Value) {
   auto SymbolNames = getSymbolTypeNames();
   for (const auto &E : SymbolNames)
-    io.enumCase(Value, E.Name, E.Value);
+    io.enumCase(Value, E.getName(), E.Value);
   io.enumFallback<yaml::Hex16>(Value);
 }
 
@@ -88,7 +88,7 @@ void ScalarBitSetTraits<CompileSym2Flags>::bitset(IO &io,
                                                   CompileSym2Flags &Flags) {
   auto FlagNames = getCompileSym2FlagNames();
   for (const auto &E : FlagNames) {
-    io.bitSetCase(Flags, E.Name, static_cast<CompileSym2Flags>(E.Value));
+    io.bitSetCase(Flags, E.getName(), static_cast<CompileSym2Flags>(E.Value));
   }
 }
 
@@ -96,35 +96,35 @@ void ScalarBitSetTraits<CompileSym3Flags>::bitset(IO &io,
                                                   CompileSym3Flags &Flags) {
   auto FlagNames = getCompileSym3FlagNames();
   for (const auto &E : FlagNames) {
-    io.bitSetCase(Flags, E.Name, static_cast<CompileSym3Flags>(E.Value));
+    io.bitSetCase(Flags, E.getName(), static_cast<CompileSym3Flags>(E.Value));
   }
 }
 
 void ScalarBitSetTraits<ExportFlags>::bitset(IO &io, ExportFlags &Flags) {
   auto FlagNames = getExportSymFlagNames();
   for (const auto &E : FlagNames) {
-    io.bitSetCase(Flags, E.Name, static_cast<ExportFlags>(E.Value));
+    io.bitSetCase(Flags, E.getName(), static_cast<ExportFlags>(E.Value));
   }
 }
 
 void ScalarBitSetTraits<PublicSymFlags>::bitset(IO &io, PublicSymFlags &Flags) {
   auto FlagNames = getPublicSymFlagNames();
   for (const auto &E : FlagNames) {
-    io.bitSetCase(Flags, E.Name, static_cast<PublicSymFlags>(E.Value));
+    io.bitSetCase(Flags, E.getName(), static_cast<PublicSymFlags>(E.Value));
   }
 }
 
 void ScalarBitSetTraits<LocalSymFlags>::bitset(IO &io, LocalSymFlags &Flags) {
   auto FlagNames = getLocalFlagNames();
   for (const auto &E : FlagNames) {
-    io.bitSetCase(Flags, E.Name, static_cast<LocalSymFlags>(E.Value));
+    io.bitSetCase(Flags, E.getName(), static_cast<LocalSymFlags>(E.Value));
   }
 }
 
 void ScalarBitSetTraits<ProcSymFlags>::bitset(IO &io, ProcSymFlags &Flags) {
   auto FlagNames = getProcSymFlagNames();
   for (const auto &E : FlagNames) {
-    io.bitSetCase(Flags, E.Name, static_cast<ProcSymFlags>(E.Value));
+    io.bitSetCase(Flags, E.getName(), static_cast<ProcSymFlags>(E.Value));
   }
 }
 
@@ -132,14 +132,15 @@ void ScalarBitSetTraits<FrameProcedureOptions>::bitset(
     IO &io, FrameProcedureOptions &Flags) {
   auto FlagNames = getFrameProcSymFlagNames();
   for (const auto &E : FlagNames) {
-    io.bitSetCase(Flags, E.Name, static_cast<FrameProcedureOptions>(E.Value));
+    io.bitSetCase(Flags, E.getName(),
+                  static_cast<FrameProcedureOptions>(E.Value));
   }
 }
 
 void ScalarEnumerationTraits<CPUType>::enumeration(IO &io, CPUType &Cpu) {
   auto CpuNames = getCPUTypeNames();
   for (const auto &E : CpuNames) {
-    io.enumCase(Cpu, E.Name, static_cast<CPUType>(E.Value));
+    io.enumCase(Cpu, E.getName(), static_cast<CPUType>(E.Value));
   }
 }
 
@@ -171,7 +172,7 @@ void ScalarEnumerationTraits<RegisterId>::enumeration(IO &io, RegisterId &Reg) {
     RegNames = getRegisterNames(*CpuType);
 
   for (const auto &E : RegNames) {
-    io.enumCase(Reg, E.Name, static_cast<RegisterId>(E.Value));
+    io.enumCase(Reg, E.getName(), static_cast<RegisterId>(E.Value));
   }
   io.enumFallback<Hex16>(Reg);
 }
@@ -180,7 +181,7 @@ void ScalarEnumerationTraits<TrampolineType>::enumeration(
     IO &io, TrampolineType &Tramp) {
   auto TrampNames = getTrampolineNames();
   for (const auto &E : TrampNames) {
-    io.enumCase(Tramp, E.Name, static_cast<TrampolineType>(E.Value));
+    io.enumCase(Tramp, E.getName(), static_cast<TrampolineType>(E.Value));
   }
 }
 
@@ -188,7 +189,7 @@ void ScalarEnumerationTraits<ThunkOrdinal>::enumeration(IO &io,
                                                         ThunkOrdinal &Ord) {
   auto ThunkNames = getThunkOrdinalNames();
   for (const auto &E : ThunkNames) {
-    io.enumCase(Ord, E.Name, static_cast<ThunkOrdinal>(E.Value));
+    io.enumCase(Ord, E.getName(), static_cast<ThunkOrdinal>(E.Value));
   }
 }
 
@@ -196,7 +197,7 @@ void ScalarEnumerationTraits<FrameCookieKind>::enumeration(
     IO &io, FrameCookieKind &FC) {
   auto ThunkNames = getFrameCookieKindNames();
   for (const auto &E : ThunkNames) {
-    io.enumCase(FC, E.Name, static_cast<FrameCookieKind>(E.Value));
+    io.enumCase(FC, E.getName(), static_cast<FrameCookieKind>(E.Value));
   }
 }
 
@@ -204,7 +205,7 @@ void ScalarEnumerationTraits<JumpTableEntrySize>::enumeration(
     IO &io, JumpTableEntrySize &FC) {
   auto ThunkNames = getJumpTableEntrySizeNames();
   for (const auto &E : ThunkNames) {
-    io.enumCase(FC, E.Name, static_cast<JumpTableEntrySize>(E.Value));
+    io.enumCase(FC, E.getName(), static_cast<JumpTableEntrySize>(E.Value));
   }
 }
 

--- a/llvm/lib/ObjectYAML/DXContainerYAML.cpp
+++ b/llvm/lib/ObjectYAML/DXContainerYAML.cpp
@@ -621,55 +621,55 @@ void MappingTraits<DXContainerYAML::StringTableEntry>::mapping(
 void ScalarEnumerationTraits<dxbc::PSV::SemanticKind>::enumeration(
     IO &IO, dxbc::PSV::SemanticKind &Value) {
   for (const auto &E : dxbc::PSV::getSemanticKinds())
-    IO.enumCase(Value, E.Name, E.Value);
+    IO.enumCase(Value, E.getName(), E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::PSV::ComponentType>::enumeration(
     IO &IO, dxbc::PSV::ComponentType &Value) {
   for (const auto &E : dxbc::PSV::getComponentTypes())
-    IO.enumCase(Value, E.Name, E.Value);
+    IO.enumCase(Value, E.getName(), E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::PSV::InterpolationMode>::enumeration(
     IO &IO, dxbc::PSV::InterpolationMode &Value) {
   for (const auto &E : dxbc::PSV::getInterpolationModes())
-    IO.enumCase(Value, E.Name, E.Value);
+    IO.enumCase(Value, E.getName(), E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::PSV::ResourceType>::enumeration(
     IO &IO, dxbc::PSV::ResourceType &Value) {
   for (const auto &E : dxbc::PSV::getResourceTypes())
-    IO.enumCase(Value, E.Name, E.Value);
+    IO.enumCase(Value, E.getName(), E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::PSV::ResourceKind>::enumeration(
     IO &IO, dxbc::PSV::ResourceKind &Value) {
   for (const auto &E : dxbc::PSV::getResourceKinds())
-    IO.enumCase(Value, E.Name, E.Value);
+    IO.enumCase(Value, E.getName(), E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::D3DSystemValue>::enumeration(
     IO &IO, dxbc::D3DSystemValue &Value) {
   for (const auto &E : dxbc::getD3DSystemValues())
-    IO.enumCase(Value, E.Name, E.Value);
+    IO.enumCase(Value, E.getName(), E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::SigMinPrecision>::enumeration(
     IO &IO, dxbc::SigMinPrecision &Value) {
   for (const auto &E : dxbc::getSigMinPrecisions())
-    IO.enumCase(Value, E.Name, E.Value);
+    IO.enumCase(Value, E.getName(), E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::SigComponentType>::enumeration(
     IO &IO, dxbc::SigComponentType &Value) {
   for (const auto &E : dxbc::getSigComponentTypes())
-    IO.enumCase(Value, E.Name, E.Value);
+    IO.enumCase(Value, E.getName(), E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::RootParameterType>::enumeration(
     IO &IO, dxbc::RootParameterType &Value) {
   for (const auto &E : dxbc::getRootParameterTypes())
-    IO.enumCase(Value, E.Name, E.Value);
+    IO.enumCase(Value, E.getName(), E.Value);
 }
 
 void ScalarEnumerationTraits<dxil::ResourceClass>::enumeration(
@@ -682,43 +682,43 @@ void ScalarEnumerationTraits<dxil::ResourceClass>::enumeration(
   };
 
   for (const auto &E : ResourceClasses)
-    IO.enumCase(Value, E.Name, E.Value);
+    IO.enumCase(Value, E.getName(), E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::SamplerFilter>::enumeration(
     IO &IO, dxbc::SamplerFilter &Value) {
   for (const auto &E : dxbc::getSamplerFilters())
-    IO.enumCase(Value, E.Name, E.Value);
+    IO.enumCase(Value, E.getName(), E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::StaticBorderColor>::enumeration(
     IO &IO, dxbc::StaticBorderColor &Value) {
   for (const auto &E : dxbc::getStaticBorderColors())
-    IO.enumCase(Value, E.Name, E.Value);
+    IO.enumCase(Value, E.getName(), E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::TextureAddressMode>::enumeration(
     IO &IO, dxbc::TextureAddressMode &Value) {
   for (const auto &E : dxbc::getTextureAddressModes())
-    IO.enumCase(Value, E.Name, E.Value);
+    IO.enumCase(Value, E.getName(), E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::ShaderVisibility>::enumeration(
     IO &IO, dxbc::ShaderVisibility &Value) {
   for (const auto &E : dxbc::getShaderVisibility())
-    IO.enumCase(Value, E.Name, E.Value);
+    IO.enumCase(Value, E.getName(), E.Value);
 }
 
 void ScalarEnumerationTraits<dxbc::ComparisonFunc>::enumeration(
     IO &IO, dxbc::ComparisonFunc &Value) {
   for (const auto &E : dxbc::getComparisonFuncs())
-    IO.enumCase(Value, E.Name, E.Value);
+    IO.enumCase(Value, E.getName(), E.Value);
 }
 
 void ScalarEnumerationTraits<llvm::dxbc::SourceInfo::SectionType>::enumeration(
     IO &IO, llvm::dxbc::SourceInfo::SectionType &Value) {
   for (const auto &E : dxbc::SourceInfo::getSectionTypes())
-    IO.enumCase(Value, E.Name, E.Value);
+    IO.enumCase(Value, E.getName(), E.Value);
 }
 
 void ScalarEnumerationTraits<
@@ -726,7 +726,7 @@ void ScalarEnumerationTraits<
     enumeration(IO &IO,
                 llvm::dxbc::SourceInfo::Contents::CompressionType &Value) {
   for (const auto &E : dxbc::SourceInfo::Contents::getCompressionTypes())
-    IO.enumCase(Value, E.Name, E.Value);
+    IO.enumCase(Value, E.getName(), E.Value);
 }
 
 void MappingTraits<llvm::DXContainerYAML::SourceInfo::Header>::mapping(

--- a/llvm/tools/llvm-objdump/COFFDump.cpp
+++ b/llvm/tools/llvm-objdump/COFFDump.cpp
@@ -86,7 +86,7 @@ static void printOptionalEnumName(T Value,
                                   ArrayRef<EnumEntry<TEnum>> EnumValues) {
   for (const EnumEntry<TEnum> &I : EnumValues)
     if (I.Value == Value) {
-      outs() << "\t(" << I.Name << ')';
+      outs() << "\t(" << I.getName() << ')';
       return;
     }
 }

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -694,7 +694,7 @@ private:
           (IsEnum && (Value & EnumMask) == Flag.Value)) {
         if (!Str.empty())
           Str += ", ";
-        Str += Flag.AltName;
+        Str += Flag.getAltName();
       }
     }
     return Str;
@@ -1469,10 +1469,10 @@ static std::string getGNUFlags(unsigned EOSAbi, unsigned EMachine,
     // Find the flag in the known flags list.
     auto I = llvm::find_if(FlagsList, [=](const EnumEntry<unsigned> &E) {
       // Flags with empty names are not printed in GNU style output.
-      return E.Value == Flag && !E.AltName.empty();
+      return E.Value == Flag && !E.getAltName().empty();
     });
     if (I != FlagsList.end()) {
-      Str += I->AltName;
+      Str += I->getAltName();
       continue;
     }
 
@@ -2320,7 +2320,7 @@ void printFlags(T Value, ArrayRef<EnumEntry<TFlag>> Flags, raw_ostream &OS) {
       SetFlags.push_back(Flag);
 
   for (const EnumEntry<TFlag> &Flag : SetFlags)
-    OS << Flag.Name << " ";
+    OS << Flag.getName() << " ";
 }
 
 template <class ELFT>
@@ -2625,7 +2625,7 @@ static Error checkHashTable(const ELFDumper<ELFT> &Dumper,
     return createError("the hash table at 0x" + Twine::utohexstr(SecOffset) +
                        " is not supported: it contains non-standard 8 "
                        "byte entries on " +
-                       It->AltName + " platform");
+                       It->getAltName() + " platform");
   }
 
   auto MakeError = [&](const Twine &Msg = "") {
@@ -3679,7 +3679,7 @@ template <class ELFT> void GNUELFDumper<ELFT>::printFileHeaders() {
               "ABI Version:", std::to_string(e.e_ident[ELF::EI_ABIVERSION]));
 
   if (const EnumEntry<unsigned> *E = getObjectFileEnumEntry(e.e_type)) {
-    Str = E->AltName.str();
+    Str = E->getAltName().str();
   } else {
     if (e.e_type >= ET_LOPROC)
       Str = "Processor Specific: (" + utohexstr(e.e_type, /*LowerCase=*/true) + ")";
@@ -7524,7 +7524,7 @@ template <class ELFT> void LLVMELFDumper<ELFT>::printFileHeaders() {
 
     std::string TypeStr;
     if (const EnumEntry<unsigned> *Ent = getObjectFileEnumEntry(E.e_type)) {
-      TypeStr = Ent->Name.str();
+      TypeStr = Ent->getName().str();
     } else {
       if (E.e_type >= ET_LOPROC)
         TypeStr = "Processor Specific";
@@ -7928,7 +7928,7 @@ void JSONELFDumper<ELFT>::printAuxillaryDynamicTableEntryInfo(
     ListScope L(this->W, "Flags");
     for (const auto &Flag : Flags) {
       if (Flag.Value != 0 && (Value & Flag.Value) == Flag.Value)
-        this->W.printString(Flag.Name);
+        this->W.printString(Flag.getName());
     }
   };
   switch (Entry.getTag()) {


### PR DESCRIPTION
EnumEntry stores two StringRef values even though all entries use string literals. On 64-bit targets this makes EnumEntry<uint32_t> 40 bytes, and the large CodeView and object-format enum tables account for tens of kilobytes of read-only data.

Store literal pointers and 16-bit lengths instead. Represent an alternate name that matches the primary name with a null pointer, and reconstruct StringRef values in accessors. Add a static assertion that keeps EnumEntry<uint32_t> at 24 bytes on LP64.

In an LLVM 22 arm64 release build, standalone llvm-readobj shrinks from 7,553,456 to 7,487,376 bytes (-66,080, -0.875%); its stripped size falls by 66,064 bytes. In the full LLVM multicall binary, size falls from 161,373,760 to 161,324,192 bytes (-49,568); stripped size falls by 49,552 bytes.

All 1,685 Support unit tests pass (1,658 passed and 27 skipped), including all ScopedPrinter tests. llvm-readobj output is byte-identical for representative ELF, COFF, Mach-O, and supported Wasm views. Across 80 randomized paired llvm-readobj trials, candidate/baseline CPU time was 0.9953 with a 95% bootstrap confidence interval of [0.9807, 1.0101].

Work towards #202616