### PR TITLE
[clang] Reuse driver option strings in CompilerInvocation

### DIFF
--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -252,12 +252,8 @@ CowCompilerInvocation::getMutPreprocessorOutputOpts() {
 
 using ArgumentConsumer = CompilerInvocation::ArgumentConsumer;
 
-#define OPTTABLE_STR_TABLE_CODE
-#include "clang/Options/Options.inc"
-#undef OPTTABLE_STR_TABLE_CODE
-
 static llvm::StringRef lookupStrInTable(unsigned Offset) {
-  return OptionStrTable[Offset];
+  return getDriverOptTable().getStrTable()[Offset];
 }
 
 #define SIMPLE_ENUM_VALUE_TABLE


### PR DESCRIPTION
CompilerInvocation emits a second copy of clang/Options/Options.inc with OPTTABLE_STR_TABLE_CODE only to implement lookupStrInTable(). The driver OptTable already owns the identical string table.

On an arm64 Release build, fully stripped standalone clang shrinks from 94,570,224 to 94,537,216 bytes, saving 33,008 bytes (0.035%).

Work towards #202616

AI tool disclosure: Co-authored with OpenAI Codex.