### PR TITLE
[llvm][TableGen] Split builtin lookup tables

### DIFF
--- a/llvm/test/TableGen/intrinsic-builtin-table-layout.td
+++ b/llvm/test/TableGen/intrinsic-builtin-table-layout.td
@@ -1,0 +1,66 @@
+// RUN: llvm-tblgen -gen-intrinsic-impl -I %p/../../include %s -DTEST_INTRINSICS_SUPPRESS_DEFS | FileCheck %s
+
+include "llvm/IR/Intrinsics.td"
+
+def int_zeta : Intrinsic<[]>, ClangBuiltin<"__builtin_alpha">;
+def int_alpha : Intrinsic<[]>, ClangBuiltin<"__builtin_beta">;
+
+let TargetPrefix = "other" in
+def int_other_zeta : Intrinsic<[]>, ClangBuiltin<"__builtin_other_one">;
+
+let TargetPrefix = "target" in {
+  def int_target_zeta : Intrinsic<[]>, ClangBuiltin<"__builtin_target_one">;
+  def int_target_alpha : Intrinsic<[]>, ClangBuiltin<"__builtin_target_two">;
+}
+
+// CHECK-LABEL: struct BuiltinNameEntry {
+// CHECK-NEXT: uint32_t StrTabOffset;
+// CHECK-NOT: IntrinsicID
+// CHECK: };
+// CHECK: static_assert(sizeof(BuiltinNameEntry) == sizeof(uint32_t),
+// CHECK: static_assert(sizeof(BuiltinNamesStorage) <=
+// CHECK-LABEL: static constexpr BuiltinNameEntry BuiltinNameEntries[] = {
+// CHECK-NEXT: // Target independent builtins.
+// CHECK-NEXT: {{    \{[0-9]+\}, // __builtin_alpha}}
+// CHECK-NEXT: {{    \{[0-9]+\}, // __builtin_beta}}
+// CHECK-NEXT: // Builtins for other.
+// CHECK-NEXT: {{    \{[0-9]+\}, // __builtin_other_one}}
+// CHECK-NEXT: // Builtins for target.
+// CHECK-NEXT: {{    \{[0-9]+\}, // __builtin_target_one}}
+// CHECK-NEXT: {{    \{[0-9]+\}, // __builtin_target_two}}
+// CHECK-NEXT: };
+// CHECK: static_assert(2 <= uint16_t(-1),
+// CHECK-LABEL: static constexpr uint16_t BuiltinIntrinsicIDs[] = {
+// CHECK-NEXT: zeta, // __builtin_alpha
+// CHECK-NEXT: alpha, // __builtin_beta
+// CHECK-NEXT: other_zeta, // __builtin_other_one
+// CHECK-NEXT: target_zeta, // __builtin_target_one
+// CHECK-NEXT: target_alpha, // __builtin_target_two
+// CHECK-NEXT: };
+// CHECK: static_assert(target_zeta <= uint16_t(-1),
+// CHECK: static_assert(std::size(BuiltinNameEntries) ==
+// CHECK: static_assert(std::size(BuiltinIntrinsicIDs) <=
+// CHECK-LABEL: struct TargetEntry {
+// CHECK-NEXT: uint32_t TargetPrefixOffset;
+// CHECK-NEXT: uint16_t EntryOffset;
+// CHECK-NEXT: uint16_t NumEntries;
+// CHECK-NEXT: uint32_t CommonPrefixOffset;
+// CHECK: StringRef getTargetPrefix() const {
+// CHECK-NEXT: return BuiltinNames[TargetPrefixOffset];
+// CHECK: StringRef getCommonPrefix() const {
+// CHECK-NEXT: return BuiltinNames[CommonPrefixOffset];
+// CHECK: static_assert(sizeof(TargetEntry) ==
+// CHECK-SAME: 3 * sizeof(uint32_t),
+// CHECK: {{\{[0-9]+, 2, 1, [0-9]+\},}}
+// CHECK: {{\{[0-9]+, 3, 2, [0-9]+\},}}
+// CHECK: ArrayRef<BuiltinNameEntry> Names(BuiltinNameEntries + 0, 2);
+// CHECK: auto II = llvm::lower_bound(Names, Suffix);
+// CHECK: return static_cast<ID>(BuiltinIntrinsicIDs[0 +
+// CHECK-NEXT: (II - Names.begin())]);
+// CHECK: TI->getTargetPrefix() != TargetPrefix
+// CHECK: BuiltinName.consume_front(TI->getCommonPrefix())
+// CHECK: ArrayRef<BuiltinNameEntry> TargetNames(BuiltinNameEntries + TI->EntryOffset,
+// CHECK-NEXT: TI->NumEntries);
+// CHECK: auto II = llvm::lower_bound(TargetNames, BuiltinName);
+// CHECK: BuiltinIntrinsicIDs[TI->EntryOffset +
+// CHECK-NEXT: (II - TargetNames.begin())]);

--- a/llvm/utils/TableGen/Basic/IntrinsicEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/IntrinsicEmitter.cpp
@@ -892,11 +892,15 @@ void IntrinsicEmitter::EmitIntrinsicToBuiltinMap(
   using BIMEntryTy =
       std::pair<std::map<StringRef, StringRef>, std::optional<StringRef>>;
   std::map<StringRef, BIMEntryTy> BuiltinMap;
+  // EmitEnum assigns IDs in CodeGenIntrinsicTable order, so the last builtin
+  // encountered has the greatest intrinsic enum value among all builtins.
+  StringRef MaxBuiltinIntrinsicEnumName;
 
   for (const CodeGenIntrinsic &Int : Ints) {
     StringRef BuiltinName = IsClang ? Int.ClangBuiltinName : Int.MSBuiltinName;
     if (BuiltinName.empty())
       continue;
+    MaxBuiltinIntrinsicEnumName = Int.EnumName;
     // Get the map for this target prefix.
     auto &[Map, CommonPrefix] = BuiltinMap[Int.TargetPrefix];
 
@@ -918,11 +922,15 @@ void IntrinsicEmitter::EmitIntrinsicToBuiltinMap(
     *CommonPrefix = CommonPrefix->take_front(Mismatch - CommonPrefix->begin());
   }
 
-  // Populate the string table with the names of all the builtins after
-  // removing this common prefix.
+  // Populate the string table with target prefixes, common builtin prefixes,
+  // and builtin name suffixes.
   StringToOffsetTable Table;
   for (const auto &[TargetPrefix, Entry] : BuiltinMap) {
     auto &[Map, CommonPrefix] = Entry;
+    if (!TargetPrefix.empty()) {
+      Table.GetOrAddStringOffset(TargetPrefix);
+      Table.GetOrAddStringOffset(*CommonPrefix);
+    }
     for (auto &[BuiltinName, EnumName] : Map) {
       StringRef Suffix = BuiltinName.substr(CommonPrefix->size());
       Table.GetOrAddStringOffset(Suffix);
@@ -952,21 +960,30 @@ Intrinsic::getIntrinsicFor{}Builtin(StringRef TargetPrefix,
     Table.EmitStringTableDef(OS, "BuiltinNames");
 
     OS << R"(
-  struct BuiltinEntry {
-    ID IntrinsicID;
-    unsigned StrTabOffset;
+  struct BuiltinNameEntry {
+    uint32_t StrTabOffset;
+
     const char *getName() const { return BuiltinNames[StrTabOffset].data(); }
     bool operator<(StringRef RHS) const {
       return strncmp(getName(), RHS.data(), RHS.size()) < 0;
     }
   };
-
+  static_assert(sizeof(BuiltinNameEntry) == sizeof(uint32_t),
+                "BuiltinNameEntry must remain packed");
+  static_assert(sizeof(BuiltinNamesStorage) <=
+                    uint64_t(uint32_t(-1)) + 1,
+                "builtin name offsets do not fit in uint32_t");
 )";
   }
 
-  // Emit a per target table of bultin names.
+  // Emit builtin name offsets for all targets in map order.
   bool HasTargetIndependentBuiltins = false;
   StringRef TargetIndepndentCommonPrefix;
+  size_t TargetIndependentIntrinsicIDOffset = 0;
+  size_t TargetIndependentBuiltinCount = 0;
+  size_t IntrinsicIDOffset = 0;
+  size_t MaxTargetBuiltinCount = 0;
+  OS << "  static constexpr BuiltinNameEntry BuiltinNameEntries[] = {\n";
   for (const auto &[TargetPrefix, Entry] : BuiltinMap) {
     const auto &[Map, CommonPrefix] = Entry;
     if (!TargetPrefix.empty()) {
@@ -975,74 +992,119 @@ Intrinsic::getIntrinsicFor{}Builtin(StringRef TargetPrefix,
       OS << "  // Target independent builtins.\n";
       HasTargetIndependentBuiltins = true;
       TargetIndepndentCommonPrefix = *CommonPrefix;
+      TargetIndependentIntrinsicIDOffset = IntrinsicIDOffset;
+      TargetIndependentBuiltinCount = Map.size();
     }
 
-    // Emit the builtin table for this target prefix.
-    OS << formatv("  static constexpr BuiltinEntry {}Names[] = {{\n",
-                  TargetPrefix);
     for (const auto &[BuiltinName, EnumName] : Map) {
       StringRef Suffix = BuiltinName.substr(CommonPrefix->size());
-      OS << formatv("    {{{}, {}}, // {}\n", EnumName,
-                    *Table.GetStringOffset(Suffix), BuiltinName);
+      OS << "    {" << *Table.GetStringOffset(Suffix) << "}, // " << BuiltinName
+         << "\n";
     }
-    OS << formatv("  }; // {}Names\n\n", TargetPrefix);
+    if (!TargetPrefix.empty())
+      MaxTargetBuiltinCount = std::max(MaxTargetBuiltinCount, Map.size());
+    IntrinsicIDOffset += Map.size();
   }
+  OS << "  };\n";
+  OS << formatv(R"(  static_assert({0} <= uint16_t(-1),
+                "target builtin count does not fit in TargetEntry");
+)",
+                MaxTargetBuiltinCount);
+
+  OS << "  static constexpr uint16_t BuiltinIntrinsicIDs[] = {\n";
+  for (const auto &[TargetPrefix, Entry] : BuiltinMap)
+    for (const auto &[BuiltinName, EnumName] : Entry.first)
+      OS << "    " << EnumName << ", // " << BuiltinName << "\n";
+  OS << "  };\n";
+  OS << formatv(R"(  static_assert({0} <= uint16_t(-1),
+                "builtin intrinsic IDs do not fit in uint16_t");
+)",
+                MaxBuiltinIntrinsicEnumName);
+  OS << R"(  static_assert(std::size(BuiltinNameEntries) ==
+                    std::size(BuiltinIntrinsicIDs),
+                "builtin name and ID tables must have the same size");
+  static_assert(std::size(BuiltinIntrinsicIDs) <=
+                    uint32_t(uint16_t(-1)) + 1,
+                "builtin ID offsets do not fit in TargetEntry");
+
+)";
 
   // After emitting the builtin tables for all targets, emit a lookup table for
   // all targets. We will use binary search, similar to the table for builtin
   // names to lookup into this table.
   OS << R"(
   struct TargetEntry {
-    StringLiteral TargetPrefix;
-    ArrayRef<BuiltinEntry> Names;
-    StringLiteral CommonPrefix;
+    uint32_t TargetPrefixOffset;
+    uint16_t EntryOffset;
+    uint16_t NumEntries;
+    uint32_t CommonPrefixOffset;
+
+    StringRef getTargetPrefix() const {
+      return BuiltinNames[TargetPrefixOffset];
+    }
+    StringRef getCommonPrefix() const {
+      return BuiltinNames[CommonPrefixOffset];
+    }
     bool operator<(StringRef RHS) const {
-      return TargetPrefix < RHS;
+      return getTargetPrefix() < RHS;
     };
   };
+  static_assert(sizeof(TargetEntry) == 3 * sizeof(uint32_t),
+                "TargetEntry must remain packed");
   static constexpr TargetEntry TargetTable[] = {
 )";
-
+  IntrinsicIDOffset = 0;
   for (const auto &[TargetPrefix, Entry] : BuiltinMap) {
     const auto &[Map, CommonPrefix] = Entry;
-    if (TargetPrefix.empty())
+    if (TargetPrefix.empty()) {
+      IntrinsicIDOffset += Map.size();
       continue;
-    OS << formatv(R"(    {{"{0}", {0}Names, "{1}"},)", TargetPrefix,
-                  CommonPrefix)
-       << "\n";
+    }
+    OS << "    {" << *Table.GetStringOffset(TargetPrefix) << ", "
+       << IntrinsicIDOffset << ", " << Map.size() << ", "
+       << *Table.GetStringOffset(*CommonPrefix) << "},\n";
+    IntrinsicIDOffset += Map.size();
   }
   OS << "  };\n";
 
   // Now for the actual lookup, first check the target independent table if
   // we emitted one.
   if (HasTargetIndependentBuiltins) {
-    OS << formatv(R"(
+    OS << formatv(
+        R"(
   // Check if it's a target independent builtin.
   // Copy the builtin name so we can use it in consume_front without clobbering
   // if for the lookup in the target specific table.
   StringRef Suffix = BuiltinName;
   if (Suffix.consume_front("{}")) {{
-    auto II = lower_bound(Names, Suffix);
-    if (II != std::end(Names) && II->getName() == Suffix)
-      return II->IntrinsicID;
+    ArrayRef<BuiltinNameEntry> Names(BuiltinNameEntries + {}, {});
+    auto II = llvm::lower_bound(Names, Suffix);
+    if (II != Names.end() && II->getName() == Suffix)
+      return static_cast<ID>(BuiltinIntrinsicIDs[{} +
+                                                 (II - Names.begin())]);
   }
 )",
-                  TargetIndepndentCommonPrefix);
+        TargetIndepndentCommonPrefix, TargetIndependentIntrinsicIDOffset,
+        TargetIndependentBuiltinCount, TargetIndependentIntrinsicIDOffset);
   }
 
   // If a target independent builtin was not found, lookup the target specific.
   OS << R"(
   auto TI = lower_bound(TargetTable, TargetPrefix);
-  if (TI == std::end(TargetTable) || TI->TargetPrefix != TargetPrefix)
+  if (TI == std::end(TargetTable) ||
+      TI->getTargetPrefix() != TargetPrefix)
     return not_intrinsic;
   // This is the last use of BuiltinName, so no need to copy before using it in
   // consume_front.
-  if (!BuiltinName.consume_front(TI->CommonPrefix))
+  if (!BuiltinName.consume_front(TI->getCommonPrefix()))
     return not_intrinsic;
-  auto II = lower_bound(TI->Names, BuiltinName);
-  if (II == std::end(TI->Names) || II->getName() != BuiltinName)
+  ArrayRef<BuiltinNameEntry> TargetNames(BuiltinNameEntries + TI->EntryOffset,
+                                         TI->NumEntries);
+  auto II = llvm::lower_bound(TargetNames, BuiltinName);
+  if (II == TargetNames.end() || II->getName() != BuiltinName)
     return not_intrinsic;
-  return II->IntrinsicID;
+  return static_cast<ID>(BuiltinIntrinsicIDs[TI->EntryOffset +
+                                             (II - TargetNames.begin())]);
 }
 )";
 }


### PR DESCRIPTION
Store builtin name offsets in a four-byte `BuiltinNameEntry` array and intrinsic IDs in a parallel `uint16_t` array. Store target prefixes and common prefixes in the same string table, reduce `TargetEntry` from 48 to 12 bytes on LP64, and use `llvm::lower_bound` for both builtin-name searches.

In an arm64 Release build, `Intrinsics.cpp.o` and `libLLVMCore.a` each decrease by 20,104 bytes, and the standalone intrinsic-lookup executable decreases by 17,952 bytes raw or 16,512 bytes fully stripped; linked fixups decrease by 48.

`intrinsic-builtin-table-layout.td`, `LLVMCore`, `llvm-tblgen`, and the standalone Clang builtin lookup executable pass validation.

Work towards #202616

AI tool disclosure: Co-authored with OpenAI Codex.
