### PR TITLE
[MC][TableGen] Pack MCInstrDesc fields into 24 bytes

### DIFF
--- a/bolt/lib/Core/MCPlusBuilder.cpp
+++ b/bolt/lib/Core/MCPlusBuilder.cpp
@@ -546,7 +546,7 @@ bool MCPlusBuilder::hasDefOfPhysReg(const MCInst &MI, unsigned Reg) const {
 
 bool MCPlusBuilder::hasUseOfPhysReg(const MCInst &MI, unsigned Reg) const {
   const MCInstrDesc &InstInfo = Info->get(MI.getOpcode());
-  for (int I = InstInfo.NumDefs; I < InstInfo.NumOperands; ++I)
+  for (unsigned I = InstInfo.getNumDefs(); I < InstInfo.getNumOperands(); ++I)
     if (MI.getOperand(I).isReg() && MI.getOperand(I).getReg() &&
         RegInfo->isSubRegisterEq(Reg, MI.getOperand(I).getReg()))
       return true;

--- a/bolt/lib/Target/X86/X86MCPlusBuilder.cpp
+++ b/bolt/lib/Target/X86/X86MCPlusBuilder.cpp
@@ -105,7 +105,7 @@ public:
   unsigned getCondCode(const MCInst &Inst) const override {
     unsigned Opcode = Inst.getOpcode();
     if (X86::isJCC(Opcode))
-      return Inst.getOperand(Info->get(Opcode).NumOperands - 1).getImm();
+      return Inst.getOperand(Info->get(Opcode).getNumOperands() - 1).getImm();
     return X86::COND_INVALID;
   }
 
@@ -2810,7 +2810,8 @@ public:
                               MCContext *Ctx) const override {
     unsigned InvCC = getInvertedCondCode(getCondCode(Inst));
     assert(InvCC != X86::COND_INVALID && "invalid branch instruction");
-    Inst.getOperand(Info->get(Inst.getOpcode()).NumOperands - 1).setImm(InvCC);
+    Inst.getOperand(Info->get(Inst.getOpcode()).getNumOperands() - 1)
+        .setImm(InvCC);
     Inst.getOperand(0) =
         MCOperand::createExpr(MCSymbolRefExpr::create(TBB, *Ctx));
   }
@@ -2819,7 +2820,8 @@ public:
                               unsigned CC) const override {
     if (CC == X86::COND_INVALID)
       return false;
-    Inst.getOperand(Info->get(Inst.getOpcode()).NumOperands - 1).setImm(CC);
+    Inst.getOperand(Info->get(Inst.getOpcode()).getNumOperands() - 1)
+        .setImm(CC);
     Inst.getOperand(0) =
         MCOperand::createExpr(MCSymbolRefExpr::create(TBB, *Ctx));
     return true;

--- a/llvm/include/llvm/MC/MCInstrDesc.h
+++ b/llvm/include/llvm/MC/MCInstrDesc.h
@@ -144,8 +144,8 @@ public:
 namespace MCID {
 /// These should be considered private to the implementation of the
 /// MCInstrDesc class.  Clients should use the predicate methods on MCInstrDesc,
-/// not use these directly.  These all correspond to bitfields in the
-/// MCInstrDesc::Flags field.
+/// not use these directly. These all correspond to bits returned by
+/// MCInstrDesc::getFlags().
 enum Flag {
   PreISelOpcode = 0,
   Variadic,
@@ -188,6 +188,7 @@ enum Flag {
   Trap,
   VariadicOpsAreDefs,
   Authenticated,
+  NumFlags,
 };
 } // namespace MCID
 
@@ -203,23 +204,107 @@ public:
   // the <Target>Insts table because they rely on knowing their own address to
   // find other information elsewhere in the same table.
 
-  uint32_t Opcode;         // The opcode number.
-  uint16_t NumOperands;    // Num of args (may be more if variable_ops)
-  uint8_t NumDefs;         // Num of args that are definitions
-  uint8_t Size;            // Number of bytes in encoding.
-  uint16_t SchedClass;     // enum identifying instr sched class
-  uint8_t NumImplicitUses; // Num of regs implicitly used
-  uint8_t NumImplicitDefs; // Num of regs implicitly defined
-  uint16_t OpInfoOffset;   // Offset to info about operands
-  uint16_t ImplicitOffset; // Offset to start of implicit op list
-  uint64_t Flags;          // Flags identifying machine instr class
-  uint64_t TSFlags;        // Target Specific Flag values
+  uint64_t TSFlags; // Target-specific flag values.
+
+  /// Defines the MCInstrDesc representation emitted by InstrInfoEmitter.
+  /// InstrInfoEmitter uses this interface to encode each MCInstrDesc before
+  /// emitting the generated instruction table.
+  struct TableGenEncoding {
+    static constexpr unsigned FlagsShift = 0;
+    static constexpr unsigned ImplicitOffsetShift = 41;
+    static constexpr unsigned SizeShift = 56;
+
+    static constexpr unsigned OpcodeShift = 0;
+    static constexpr unsigned NumOperandsShift = 16;
+    static constexpr unsigned NumDefsShift = 24;
+    static constexpr unsigned OpInfoOffsetShift = 32;
+    static constexpr unsigned SchedClassShift = 48;
+
+    static constexpr unsigned NumImplicitBits = 6;
+    static constexpr unsigned NumImplicitDefsShift = NumImplicitBits;
+
+    static constexpr uint64_t mask(unsigned BitCount) {
+      return (uint64_t(1) << BitCount) - 1;
+    }
+
+    static constexpr MCPhysReg encodeImplicitHeader(unsigned NumImplicitUses,
+                                                    unsigned NumImplicitDefs) {
+      return NumImplicitUses | (NumImplicitDefs << NumImplicitDefsShift);
+    }
+
+    static constexpr uint64_t encodeFlagsAndImplicit(uint64_t Flags,
+                                                     unsigned Size,
+                                                     unsigned ImplicitOffset) {
+      return (Flags << FlagsShift) | (uint64_t(Size) << SizeShift) |
+             (uint64_t(ImplicitOffset) << ImplicitOffsetShift);
+    }
+
+    static constexpr uint64_t encodeOpcodeAndOperands(unsigned Opcode,
+                                                      unsigned NumOperands,
+                                                      unsigned NumDefs,
+                                                      unsigned SchedClass,
+                                                      unsigned OpInfoOffset) {
+      return (uint64_t(Opcode) << OpcodeShift) |
+             (uint64_t(NumOperands) << NumOperandsShift) |
+             (uint64_t(NumDefs) << NumDefsShift) |
+             (uint64_t(SchedClass) << SchedClassShift) |
+             (uint64_t(OpInfoOffset) << OpInfoOffsetShift);
+    }
+  };
+
+private:
+  static constexpr unsigned NumImplicitMask =
+      (1U << TableGenEncoding::NumImplicitBits) - 1;
+
+  static constexpr uint64_t extract(uint64_t Value, unsigned Shift,
+                                    unsigned BitCount) {
+    return (Value >> Shift) & TableGenEncoding::mask(BitCount);
+  }
+
+  uint64_t FlagsAndImplicit;
+  uint64_t OpcodeAndOperands;
+
+  unsigned getOpInfoOffset() const {
+    return extract(OpcodeAndOperands, TableGenEncoding::OpInfoOffsetShift, 16);
+  }
+  unsigned getImplicitOffset() const {
+    return extract(FlagsAndImplicit, TableGenEncoding::ImplicitOffsetShift, 15);
+  }
+  /// Return the implicit operand list header. The low six bits contain the
+  /// number of uses and the next six bits contain the number of definitions.
+  const MCPhysReg *getImplicitList(unsigned ImplicitOffset) const {
+    assert(ImplicitOffset && "the empty implicit operand list has no header");
+    return reinterpret_cast<const MCPhysReg *>(this + getOpcode() + 1) +
+           ImplicitOffset;
+  }
+  bool hasFlag(unsigned Flag) const {
+    return FlagsAndImplicit & (uint64_t(1) << Flag);
+  }
+
+public:
+  /// Construct an MCInstrDesc encoded by InstrInfoEmitter.
+  constexpr MCInstrDesc(TableGenEncoding, uint64_t TSFlags,
+                        uint64_t FlagsAndImplicit, uint64_t OpcodeAndOperands)
+      : TSFlags(TSFlags), FlagsAndImplicit(FlagsAndImplicit),
+        OpcodeAndOperands(OpcodeAndOperands) {}
+
+  /// Construct a descriptor without implicit operands and with any operand
+  /// information immediately after the descriptor. Generated descriptors use
+  /// the TableGenEncoding constructor above.
+  constexpr MCInstrDesc(uint16_t Opcode = 0, uint8_t NumOperands = 0,
+                        uint8_t NumDefs = 0, uint8_t Size = 0,
+                        uint16_t SchedClass = 0, uint64_t Flags = 0,
+                        uint64_t TSFlags = 0)
+      : MCInstrDesc(TableGenEncoding{}, TSFlags,
+                    TableGenEncoding::encodeFlagsAndImplicit(Flags, Size, 0),
+                    TableGenEncoding::encodeOpcodeAndOperands(
+                        Opcode, NumOperands, NumDefs, SchedClass, 0)) {}
 
   /// Returns the value of the specified operand constraint if
   /// it is present. Returns -1 if it is not present.
   int getOperandConstraint(unsigned OpNum,
                            MCOI::OperandConstraint Constraint) const {
-    if (OpNum < NumOperands &&
+    if (OpNum < getNumOperands() &&
         (operands()[OpNum].Constraints & (1 << Constraint))) {
       unsigned ValuePos = 4 + Constraint * 4;
       return (int)(operands()[OpNum].Constraints >> ValuePos) & 0x0f;
@@ -228,70 +313,97 @@ public:
   }
 
   /// Return the opcode number for this descriptor.
-  unsigned getOpcode() const { return Opcode; }
+  unsigned getOpcode() const {
+    return extract(OpcodeAndOperands, TableGenEncoding::OpcodeShift, 16);
+  }
 
   /// Return the number of declared MachineOperands for this
   /// MachineInstruction.  Note that variadic (isVariadic() returns true)
   /// instructions may have additional operands at the end of the list, and note
   /// that the machine instruction may include implicit register def/uses as
   /// well.
-  unsigned getNumOperands() const { return NumOperands; }
+  unsigned getNumOperands() const {
+    return extract(OpcodeAndOperands, TableGenEncoding::NumOperandsShift, 8);
+  }
 
   ArrayRef<MCOperandInfo> operands() const {
-    auto OpInfo = reinterpret_cast<const MCOperandInfo *>(this + Opcode + 1);
-    return ArrayRef(OpInfo + OpInfoOffset, NumOperands);
+    auto OpInfo =
+        reinterpret_cast<const MCOperandInfo *>(this + getOpcode() + 1);
+    return ArrayRef(OpInfo + getOpInfoOffset(), getNumOperands());
   }
 
   /// Return the number of MachineOperands that are register
   /// definitions.  Register definitions always occur at the start of the
   /// machine operand list.  This is the number of "outs" in the .td file,
   /// and does not include implicit defs.
-  unsigned getNumDefs() const { return NumDefs; }
+  unsigned getNumDefs() const {
+    return extract(OpcodeAndOperands, TableGenEncoding::NumDefsShift, 8);
+  }
+
+  /// Return the number of implicitly used registers.
+  unsigned getNumImplicitUses() const {
+    unsigned ImplicitOffset = getImplicitOffset();
+    if (!ImplicitOffset)
+      return 0;
+    return *getImplicitList(ImplicitOffset) & NumImplicitMask;
+  }
+
+  /// Return the number of implicitly defined registers.
+  unsigned getNumImplicitDefs() const {
+    unsigned ImplicitOffset = getImplicitOffset();
+    if (!ImplicitOffset)
+      return 0;
+    return (*getImplicitList(ImplicitOffset) >>
+            TableGenEncoding::NumImplicitDefsShift) &
+           NumImplicitMask;
+  }
 
   /// Return flags of this instruction.
-  uint64_t getFlags() const { return Flags; }
+  uint64_t getFlags() const {
+    return extract(FlagsAndImplicit, TableGenEncoding::FlagsShift, 41);
+  }
 
   /// \returns true if this instruction is emitted before instruction selection
   /// and should be legalized/regbankselected/selected.
-  bool isPreISelOpcode() const { return Flags & (1ULL << MCID::PreISelOpcode); }
+  bool isPreISelOpcode() const { return hasFlag(MCID::PreISelOpcode); }
 
   /// Return true if this instruction can have a variable number of
   /// operands.  In this case, the variable operands will be after the normal
   /// operands but before the implicit definitions and uses (if any are
   /// present).
-  bool isVariadic() const { return Flags & (1ULL << MCID::Variadic); }
+  bool isVariadic() const { return hasFlag(MCID::Variadic); }
 
   /// Set if this instruction has an optional definition, e.g.
   /// ARM instructions which can set condition code if 's' bit is set.
-  bool hasOptionalDef() const { return Flags & (1ULL << MCID::HasOptionalDef); }
+  bool hasOptionalDef() const { return hasFlag(MCID::HasOptionalDef); }
 
   /// Return true if this is a pseudo instruction that doesn't
   /// correspond to a real machine instruction.
-  bool isPseudo() const { return Flags & (1ULL << MCID::Pseudo); }
+  bool isPseudo() const { return hasFlag(MCID::Pseudo); }
 
   /// Return true if this is a meta instruction that doesn't
   /// produce any output in the form of executable instructions.
-  bool isMetaInstruction() const { return Flags & (1ULL << MCID::Meta); }
+  bool isMetaInstruction() const { return hasFlag(MCID::Meta); }
 
   /// Return true if the instruction is a return.
-  bool isReturn() const { return Flags & (1ULL << MCID::Return); }
+  bool isReturn() const { return hasFlag(MCID::Return); }
 
   /// Return true if the instruction is an add instruction.
-  bool isAdd() const { return Flags & (1ULL << MCID::Add); }
+  bool isAdd() const { return hasFlag(MCID::Add); }
 
   /// Return true if this instruction is a trap.
-  bool isTrap() const { return Flags & (1ULL << MCID::Trap); }
+  bool isTrap() const { return hasFlag(MCID::Trap); }
 
   /// Return true if the instruction is a register to register move.
-  bool isMoveReg() const { return Flags & (1ULL << MCID::MoveReg); }
+  bool isMoveReg() const { return hasFlag(MCID::MoveReg); }
 
   ///  Return true if the instruction is a call.
-  bool isCall() const { return Flags & (1ULL << MCID::Call); }
+  bool isCall() const { return hasFlag(MCID::Call); }
 
   /// Returns true if the specified instruction stops control flow
   /// from executing the instruction immediately following it.  Examples include
   /// unconditional branches and return instructions.
-  bool isBarrier() const { return Flags & (1ULL << MCID::Barrier); }
+  bool isBarrier() const { return hasFlag(MCID::Barrier); }
 
   /// Returns true if this instruction part of the terminator for
   /// a basic block.  Typically this is things like return and branch
@@ -299,17 +411,17 @@ public:
   ///
   /// Various passes use this to insert code into the bottom of a basic block,
   /// but before control flow occurs.
-  bool isTerminator() const { return Flags & (1ULL << MCID::Terminator); }
+  bool isTerminator() const { return hasFlag(MCID::Terminator); }
 
   /// Returns true if this is a conditional, unconditional, or
   /// indirect branch.  Predicates below can be used to discriminate between
   /// these cases, and the TargetInstrInfo::analyzeBranch method can be used to
   /// get more information.
-  bool isBranch() const { return Flags & (1ULL << MCID::Branch); }
+  bool isBranch() const { return hasFlag(MCID::Branch); }
 
   /// Return true if this is an indirect branch, such as a
   /// branch through a register.
-  bool isIndirectBranch() const { return Flags & (1ULL << MCID::IndirectBranch); }
+  bool isIndirectBranch() const { return hasFlag(MCID::IndirectBranch); }
 
   /// Return true if this is a branch which may fall
   /// through to the next instruction or may transfer control flow to some other
@@ -337,29 +449,29 @@ public:
   /// that controls execution. It may be set to 'always', or may be set to other
   /// values. There are various methods in TargetInstrInfo that can be used to
   /// control and modify the predicate in this instruction.
-  bool isPredicable() const { return Flags & (1ULL << MCID::Predicable); }
+  bool isPredicable() const { return hasFlag(MCID::Predicable); }
 
   /// Return true if this instruction is a comparison.
-  bool isCompare() const { return Flags & (1ULL << MCID::Compare); }
+  bool isCompare() const { return hasFlag(MCID::Compare); }
 
   /// Return true if this instruction is a move immediate
   /// (including conditional moves) instruction.
-  bool isMoveImmediate() const { return Flags & (1ULL << MCID::MoveImm); }
+  bool isMoveImmediate() const { return hasFlag(MCID::MoveImm); }
 
   /// Return true if this instruction is a bitcast instruction.
-  bool isBitcast() const { return Flags & (1ULL << MCID::Bitcast); }
+  bool isBitcast() const { return hasFlag(MCID::Bitcast); }
 
   /// Return true if this is a select instruction.
-  bool isSelect() const { return Flags & (1ULL << MCID::Select); }
+  bool isSelect() const { return hasFlag(MCID::Select); }
 
   /// Return true if this instruction cannot be safely
   /// duplicated.  For example, if the instruction has a unique labels attached
   /// to it, duplicating it would cause multiple definition errors.
-  bool isNotDuplicable() const { return Flags & (1ULL << MCID::NotDuplicable); }
+  bool isNotDuplicable() const { return hasFlag(MCID::NotDuplicable); }
 
   /// Returns true if the specified instruction has a delay slot which
   /// must be filled by the code generator.
-  bool hasDelaySlot() const { return Flags & (1ULL << MCID::DelaySlot); }
+  bool hasDelaySlot() const { return hasFlag(MCID::DelaySlot); }
 
   /// Return true for instructions that can be folded as memory operands
   /// in other instructions. The most common use for this is instructions that
@@ -368,7 +480,7 @@ public:
   /// constant-pool loads, such as V_SETALLONES on x86, to allow them to be
   /// folded when it is beneficial.  This should only be set on instructions
   /// that return a value in their only virtual register definition.
-  bool canFoldAsLoad() const { return Flags & (1ULL << MCID::FoldableAsLoad); }
+  bool canFoldAsLoad() const { return hasFlag(MCID::FoldableAsLoad); }
 
   /// Return true if this instruction behaves
   /// the same way as the generic REG_SEQUENCE instructions.
@@ -380,7 +492,7 @@ public:
   /// Note that for the optimizers to be able to take advantage of
   /// this property, TargetInstrInfo::getRegSequenceLikeInputs has to be
   /// override accordingly.
-  bool isRegSequenceLike() const { return Flags & (1ULL << MCID::RegSequence); }
+  bool isRegSequenceLike() const { return hasFlag(MCID::RegSequence); }
 
   /// Return true if this instruction behaves
   /// the same way as the generic EXTRACT_SUBREG instructions.
@@ -393,9 +505,7 @@ public:
   /// Note that for the optimizers to be able to take advantage of
   /// this property, TargetInstrInfo::getExtractSubregLikeInputs has to be
   /// override accordingly.
-  bool isExtractSubregLike() const {
-    return Flags & (1ULL << MCID::ExtractSubreg);
-  }
+  bool isExtractSubregLike() const { return hasFlag(MCID::ExtractSubreg); }
 
   /// Return true if this instruction behaves
   /// the same way as the generic INSERT_SUBREG instructions.
@@ -407,28 +517,23 @@ public:
   /// Note that for the optimizers to be able to take advantage of
   /// this property, TargetInstrInfo::getInsertSubregLikeInputs has to be
   /// override accordingly.
-  bool isInsertSubregLike() const { return Flags & (1ULL << MCID::InsertSubreg); }
-
+  bool isInsertSubregLike() const { return hasFlag(MCID::InsertSubreg); }
 
   /// Return true if this instruction is convergent.
   ///
   /// Convergent instructions may not be made control-dependent on any
   /// additional values.
-  bool isConvergent() const { return Flags & (1ULL << MCID::Convergent); }
+  bool isConvergent() const { return hasFlag(MCID::Convergent); }
 
   /// Return true if variadic operands of this instruction are definitions.
-  bool variadicOpsAreDefs() const {
-    return Flags & (1ULL << MCID::VariadicOpsAreDefs);
-  }
+  bool variadicOpsAreDefs() const { return hasFlag(MCID::VariadicOpsAreDefs); }
 
   /// Return true if this instruction authenticates a pointer (e.g. LDRAx/BRAx
   /// from ARMv8.3, which perform loads/branches with authentication).
   ///
   /// An authenticated instruction may fail in an ABI-defined manner when
   /// operating on an invalid signed pointer.
-  bool isAuthenticated() const {
-    return Flags & (1ULL << MCID::Authenticated);
-  }
+  bool isAuthenticated() const { return hasFlag(MCID::Authenticated); }
 
   //===--------------------------------------------------------------------===//
   // Side Effect Analysis
@@ -437,17 +542,17 @@ public:
   /// Return true if this instruction could possibly read memory.
   /// Instructions with this flag set are not necessarily simple load
   /// instructions, they may load a value and modify it, for example.
-  bool mayLoad() const { return Flags & (1ULL << MCID::MayLoad); }
+  bool mayLoad() const { return hasFlag(MCID::MayLoad); }
 
   /// Return true if this instruction could possibly modify memory.
   /// Instructions with this flag set are not necessarily simple store
   /// instructions, they may store a modified value based on their operands, or
   /// may not actually modify anything, for example.
-  bool mayStore() const { return Flags & (1ULL << MCID::MayStore); }
+  bool mayStore() const { return hasFlag(MCID::MayStore); }
 
   /// Return true if this instruction may raise a floating-point exception.
   bool mayRaiseFPException() const {
-    return Flags & (1ULL << MCID::MayRaiseFPException);
+    return hasFlag(MCID::MayRaiseFPException);
   }
 
   /// Return true if this instruction has side
@@ -463,7 +568,7 @@ public:
   /// a control register, flushing a cache, modifying a register invisible to
   /// LLVM, etc.
   bool hasUnmodeledSideEffects() const {
-    return Flags & (1ULL << MCID::UnmodeledSideEffects);
+    return hasFlag(MCID::UnmodeledSideEffects);
   }
 
   //===--------------------------------------------------------------------===//
@@ -480,7 +585,7 @@ public:
   /// sometimes.  In these cases, the call to commuteInstruction will fail.
   /// Also note that some instructions require non-trivial modification to
   /// commute them.
-  bool isCommutable() const { return Flags & (1ULL << MCID::Commutable); }
+  bool isCommutable() const { return hasFlag(MCID::Commutable); }
 
   /// Return true if this is a 2-address instruction which can be changed
   /// into a 3-address instruction if needed.  Doing this transformation can be
@@ -497,7 +602,7 @@ public:
   /// instruction (e.g. shl reg, 4 on x86).
   ///
   bool isConvertibleTo3Addr() const {
-    return Flags & (1ULL << MCID::ConvertibleTo3Addr);
+    return hasFlag(MCID::ConvertibleTo3Addr);
   }
 
   /// Return true if this instruction requires custom insertion support
@@ -509,23 +614,21 @@ public:
   /// If this is true, the TargetLoweringInfo::InsertAtEndOfBasicBlock method
   /// is used to insert this into the MachineBasicBlock.
   bool usesCustomInsertionHook() const {
-    return Flags & (1ULL << MCID::UsesCustomInserter);
+    return hasFlag(MCID::UsesCustomInserter);
   }
 
   /// Return true if this instruction requires *adjustment* after
   /// instruction selection by calling a target hook. For example, this can be
   /// used to fill in ARM 's' optional operand depending on whether the
   /// conditional flag register is used.
-  bool hasPostISelHook() const { return Flags & (1ULL << MCID::HasPostISelHook); }
+  bool hasPostISelHook() const { return hasFlag(MCID::HasPostISelHook); }
 
   /// Returns true if this instruction is a candidate for remat. This
   /// flag is only used in TargetInstrInfo method isTriviallyRematerializable.
   ///
   /// If this flag is set, the isReMaterializableImpl() method is
   /// called to verify the instruction is really rematerializable.
-  bool isRematerializable() const {
-    return Flags & (1ULL << MCID::Rematerializable);
-  }
+  bool isRematerializable() const { return hasFlag(MCID::Rematerializable); }
 
   /// Returns true if this instruction has the same cost (or less) than a
   /// move instruction. This is useful during certain types of optimizations
@@ -536,7 +639,7 @@ public:
   ///
   /// This method could be called by interface TargetInstrInfo::isAsCheapAsAMove
   /// for different subtargets.
-  bool isAsCheapAsAMove() const { return Flags & (1ULL << MCID::CheapAsAMove); }
+  bool isAsCheapAsAMove() const { return hasFlag(MCID::CheapAsAMove); }
 
   /// Returns true if this instruction source operands have special
   /// register allocation requirements that are not captured by the operand
@@ -545,7 +648,7 @@ public:
   /// allocation passes should not attempt to change allocations for sources of
   /// instructions with this flag.
   bool hasExtraSrcRegAllocReq() const {
-    return Flags & (1ULL << MCID::ExtraSrcRegAllocReq);
+    return hasFlag(MCID::ExtraSrcRegAllocReq);
   }
 
   /// Returns true if this instruction def operands have special register
@@ -555,7 +658,7 @@ public:
   /// allocation passes should not attempt to change allocations for definitions
   /// of instructions with this flag.
   bool hasExtraDefRegAllocReq() const {
-    return Flags & (1ULL << MCID::ExtraDefRegAllocReq);
+    return hasFlag(MCID::ExtraDefRegAllocReq);
   }
 
   /// Return a list of registers that are potentially read by any
@@ -565,9 +668,12 @@ public:
   /// reading the flags.  Likewise, the variable shift instruction on X86 is
   /// marked as implicitly reading the 'CL' register, which it always does.
   ArrayRef<MCPhysReg> implicit_uses() const {
-    auto ImplicitOps =
-        reinterpret_cast<const MCPhysReg *>(this + Opcode + 1) + ImplicitOffset;
-    return {ImplicitOps, NumImplicitUses};
+    unsigned ImplicitOffset = getImplicitOffset();
+    if (!ImplicitOffset)
+      return {};
+    const MCPhysReg *ImplicitList = getImplicitList(ImplicitOffset);
+    unsigned NumImplicitUses = *ImplicitList & NumImplicitMask;
+    return {ImplicitList + 1, NumImplicitUses};
   }
 
   /// Return a list of registers that are potentially written by any
@@ -579,9 +685,15 @@ public:
   /// registers.  For that instruction, this will return a list containing the
   /// EAX/EDX/EFLAGS registers.
   ArrayRef<MCPhysReg> implicit_defs() const {
-    auto ImplicitOps =
-        reinterpret_cast<const MCPhysReg *>(this + Opcode + 1) + ImplicitOffset;
-    return {ImplicitOps + NumImplicitUses, NumImplicitDefs};
+    unsigned ImplicitOffset = getImplicitOffset();
+    if (!ImplicitOffset)
+      return {};
+    const MCPhysReg *ImplicitList = getImplicitList(ImplicitOffset);
+    unsigned Header = *ImplicitList++;
+    unsigned NumImplicitUses = Header & NumImplicitMask;
+    unsigned NumImplicitDefs =
+        (Header >> TableGenEncoding::NumImplicitDefsShift) & NumImplicitMask;
+    return {ImplicitList + NumImplicitUses, NumImplicitDefs};
   }
 
   /// Return true if this instruction implicitly
@@ -600,11 +712,15 @@ public:
   /// scheduling class is an index into the InstrItineraryData table.  This
   /// returns zero if there is no known scheduling information for the
   /// instruction.
-  unsigned getSchedClass() const { return SchedClass; }
+  unsigned getSchedClass() const {
+    return extract(OpcodeAndOperands, TableGenEncoding::SchedClassShift, 16);
+  }
 
   /// Return the number of bytes in the encoding of this instruction,
   /// or zero if the encoding size cannot be known from the opcode.
-  unsigned getSize() const { return Size; }
+  unsigned getSize() const {
+    return extract(FlagsAndImplicit, TableGenEncoding::SizeShift, 8);
+  }
 
   /// Find the index of the first operand in the
   /// operand list that is used to represent the predicate. It returns -1 if
@@ -628,6 +744,9 @@ public:
   LLVM_ABI bool hasDefOfPhysReg(const MCInst &MI, MCRegister Reg,
                                 const MCRegisterInfo &RI) const;
 };
+
+static_assert(MCID::NumFlags <= 41);
+static_assert(sizeof(MCInstrDesc) == 24);
 
 } // end namespace llvm
 

--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -100,7 +100,7 @@ void MachineInstr::addImplicitDefUseOperands(MachineFunction &MF) {
 MachineInstr::MachineInstr(MachineFunction &MF, const MCInstrDesc &TID,
                            DebugLoc DL, bool NoImp)
     : MCID(&TID), NumOperands(0), Flags(0), AsmPrinterFlags(0),
-      Opcode(TID.Opcode), DebugInstrNum(0), DbgLoc(std::move(DL)) {
+      Opcode(TID.getOpcode()), DebugInstrNum(0), DbgLoc(std::move(DL)) {
   // Reserve space for the expected number of operands.
   if (unsigned NumOps = MCID->getNumOperands() + MCID->implicit_defs().size() +
                         MCID->implicit_uses().size()) {
@@ -142,7 +142,7 @@ void MachineInstr::setDesc(const MCInstrDesc &TID) {
   if (getParent())
     getMF()->handleChangeDesc(*this, TID);
   MCID = &TID;
-  Opcode = TID.Opcode;
+  Opcode = TID.getOpcode();
 }
 
 void MachineInstr::moveBefore(MachineInstr *MovePos) {
@@ -1719,7 +1719,7 @@ void MachineInstr::copyImplicitOps(MachineFunction &MF,
 
 bool MachineInstr::hasComplexRegisterTies() const {
   const MCInstrDesc &MCID = getDesc();
-  if (MCID.Opcode == TargetOpcode::STATEPOINT)
+  if (MCID.getOpcode() == TargetOpcode::STATEPOINT)
     return true;
   for (unsigned I = 0, E = getNumOperands(); I < E; ++I) {
     const auto &Operand = getOperand(I);
@@ -2396,7 +2396,7 @@ MachineInstrBuilder llvm::BuildMI(MachineFunction &MF, const DebugLoc &DL,
   assert(cast<DIExpression>(Expr)->isValid() && "not an expression");
   assert(cast<DILocalVariable>(Variable)->isValidLocationForIntrinsic(DL) &&
          "Expected inlined-at fields to agree");
-  if (MCID.Opcode == TargetOpcode::DBG_VALUE) {
+  if (MCID.getOpcode() == TargetOpcode::DBG_VALUE) {
     assert(DebugOps.size() == 1 &&
            "DBG_VALUE must contain exactly one debug operand");
     MachineOperand DebugOp = DebugOps[0];

--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -2607,7 +2607,7 @@ MachineVerifier::visitMachineOperand(const MachineOperand *MO, unsigned MONum) {
   if (MCID.getOpcode() == TargetOpcode::PATCHPOINT)
     NumDefs = (MONum == 0 && MO->isReg()) ? NumDefs : 0;
 
-  // The first MCID.NumDefs operands must be explicit register defines
+  // The first NumDefs operands must be explicit register definitions.
   if (MONum < NumDefs) {
     const MCOperandInfo &MCOI = MCID.operands()[MONum];
     if (!MO->isReg())

--- a/llvm/lib/CodeGen/ScoreboardHazardRecognizer.cpp
+++ b/llvm/lib/CodeGen/ScoreboardHazardRecognizer.cpp
@@ -176,7 +176,7 @@ void ScoreboardHazardRecognizer::EmitInstruction(SUnit *SU) {
   // in the scoreboard at the appropriate future cycles.
   const MCInstrDesc *MCID = DAG->getInstrDesc(SU);
   assert(MCID && "The scheduler must filter non-machineinstrs");
-  if (DAG->TII->isZeroCost(MCID->Opcode))
+  if (DAG->TII->isZeroCost(MCID->getOpcode()))
     return;
 
   ++IssueCount;

--- a/llvm/lib/DWARFCFIChecker/DWARFCFIAnalysis.cpp
+++ b/llvm/lib/DWARFCFIChecker/DWARFCFIAnalysis.cpp
@@ -135,9 +135,8 @@ void DWARFCFIAnalysis::update(const MCInst &Inst,
     State.update(Directive);
 
   SmallSet<DWARFRegNum, 4> Writes;
-  for (unsigned I = 0; I < MCInstInfo.NumImplicitDefs; I++)
-    Writes.insert(MCRI->getDwarfRegNum(
-        getSuperReg(MCRI, MCInstInfo.implicit_defs()[I]), IsEH));
+  for (MCPhysReg Reg : MCInstInfo.implicit_defs())
+    Writes.insert(MCRI->getDwarfRegNum(getSuperReg(MCRI, Reg), IsEH));
 
   for (unsigned I = 0; I < Inst.getNumOperands(); I++) {
     auto &&Op = Inst.getOperand(I);

--- a/llvm/lib/MC/MCInstrDesc.cpp
+++ b/llvm/lib/MC/MCInstrDesc.cpp
@@ -39,12 +39,12 @@ bool MCInstrDesc::hasImplicitDefOfPhysReg(MCRegister Reg,
 
 bool MCInstrDesc::hasExplicitDefOfPhysReg(const MCInst &MI, MCRegister Reg,
                                           const MCRegisterInfo &RI) const {
-  for (int i = 0, e = NumDefs; i != e; ++i)
+  for (int i = 0, e = getNumDefs(); i != e; ++i)
     if (MI.getOperand(i).isReg() && MI.getOperand(i).getReg() &&
         RI.isSubRegisterEq(Reg, MI.getOperand(i).getReg()))
       return true;
   if (variadicOpsAreDefs())
-    for (int i = NumOperands - 1, e = MI.getNumOperands(); i != e; ++i)
+    for (int i = getNumOperands() - 1, e = MI.getNumOperands(); i != e; ++i)
       if (MI.getOperand(i).isReg() &&
           RI.isSubRegisterEq(Reg, MI.getOperand(i).getReg()))
         return true;

--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -1388,7 +1388,7 @@ class AMDGPUAsmParser : public MCTargetAsmParser {
 
   /// Get size of register operand
   unsigned getRegOperandSize(const MCInstrDesc &Desc, unsigned OpNo) const {
-    assert(OpNo < Desc.NumOperands);
+    assert(OpNo < Desc.getNumOperands());
     int16_t RCID = MII.getOpRegClassID(Desc.operands()[OpNo], HwMode);
     return getRegBitWidth(RCID) / 8;
   }
@@ -9497,7 +9497,7 @@ static bool isRegOrImmWithInputMods(const MCInstrDesc &Desc, unsigned OpNum) {
       // 1. This operand is input modifiers
       Desc.operands()[OpNum].OperandType == AMDGPU::OPERAND_INPUT_MODS
       // 2. This is not last operand
-      && Desc.NumOperands > (OpNum + 1)
+      && Desc.getNumOperands() > (OpNum + 1)
       // 3. Next operand is register class
       && Desc.operands()[OpNum + 1].RegClass != -1
       // 4. Next register is not tied to any other operand

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -257,8 +257,8 @@ bool SIInstrInfo::areLoadsFromSameBasePtr(SDNode *Load0, SDNode *Load1,
     // getNamedOperandIdx returns the index for MachineInstrs.  Since they
     // include the output in the operand list, but SDNodes don't, we need to
     // subtract the index by one.
-    Offset0Idx -= get(Opc0).NumDefs;
-    Offset1Idx -= get(Opc1).NumDefs;
+    Offset0Idx -= get(Opc0).getNumDefs();
+    Offset1Idx -= get(Opc1).getNumDefs();
     Offset0 = Load0->getConstantOperandVal(Offset0Idx);
     Offset1 = Load1->getConstantOperandVal(Offset1Idx);
     return true;
@@ -314,8 +314,8 @@ bool SIInstrInfo::areLoadsFromSameBasePtr(SDNode *Load0, SDNode *Load1,
     // getNamedOperandIdx returns the index for MachineInstrs.  Since they
     // include the output in the operand list, but SDNodes don't, we need to
     // subtract the index by one.
-    OffIdx0 -= get(Opc0).NumDefs;
-    OffIdx1 -= get(Opc1).NumDefs;
+    OffIdx0 -= get(Opc0).getNumDefs();
+    OffIdx1 -= get(Opc1).getNumDefs();
 
     SDValue Off0 = Load0->getOperand(OffIdx0);
     SDValue Off1 = Load1->getOperand(OffIdx1);

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -1316,8 +1316,8 @@ public:
                         const MachineOperand &UseMO,
                         const MachineOperand &DefMO) const {
     assert(UseMO.getParent() == &MI);
-    int OpIdx = UseMO.getOperandNo();
-    if (OpIdx >= MI.getDesc().NumOperands)
+    unsigned OpIdx = UseMO.getOperandNo();
+    if (OpIdx >= MI.getDesc().getNumOperands())
       return false;
 
     return isInlineConstant(DefMO, MI.getDesc().operands()[OpIdx]);
@@ -1332,7 +1332,7 @@ public:
 
   bool isInlineConstant(const MachineInstr &MI, unsigned OpIdx,
                         int64_t ImmVal) const {
-    if (OpIdx >= MI.getDesc().NumOperands)
+    if (OpIdx >= MI.getDesc().getNumOperands())
       return false;
 
     if (isCopyInstr(MI)) {

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -2868,14 +2868,14 @@ bool isInlineValue(MCRegister Reg) {
 #undef MAP_REG2REG
 
 bool isKImmOperand(const MCInstrDesc &Desc, unsigned OpNo) {
-  assert(OpNo < Desc.NumOperands);
+  assert(OpNo < Desc.getNumOperands());
   unsigned OpType = Desc.operands()[OpNo].OperandType;
   return OpType >= AMDGPU::OPERAND_KIMM_FIRST &&
          OpType <= AMDGPU::OPERAND_KIMM_LAST;
 }
 
 bool isSISrcFPOperand(const MCInstrDesc &Desc, unsigned OpNo) {
-  assert(OpNo < Desc.NumOperands);
+  assert(OpNo < Desc.getNumOperands());
   unsigned OpType = Desc.operands()[OpNo].OperandType;
   switch (OpType) {
   case AMDGPU::OPERAND_REG_IMM_FP32:
@@ -2898,7 +2898,7 @@ bool isSISrcFPOperand(const MCInstrDesc &Desc, unsigned OpNo) {
 }
 
 bool isSISrcInlinableOperand(const MCInstrDesc &Desc, unsigned OpNo) {
-  assert(OpNo < Desc.NumOperands);
+  assert(OpNo < Desc.getNumOperands());
   unsigned OpType = Desc.operands()[OpNo].OperandType;
   return (OpType >= AMDGPU::OPERAND_REG_INLINE_C_FIRST &&
           OpType <= AMDGPU::OPERAND_REG_INLINE_C_LAST) ||

--- a/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
@@ -4282,7 +4282,7 @@ ARMBaseInstrInfo::getOperandLatency(const InstrItineraryData *ItinData,
 
   const MCInstrDesc &DefMCID = get(DefNode->getMachineOpcode());
 
-  if (isZeroCost(DefMCID.Opcode))
+  if (isZeroCost(DefMCID.getOpcode()))
     return 0;
 
   if (!ItinData || ItinData->isEmpty())

--- a/llvm/lib/Target/ARM/AsmParser/ARMAsmParser.cpp
+++ b/llvm/lib/Target/ARM/AsmParser/ARMAsmParser.cpp
@@ -7636,7 +7636,7 @@ bool ARMAsmParser::validateLDRDSTRD(MCInst &Inst, const OperandVector &Operands,
 }
 
 static int findFirstVectorPredOperandIdx(const MCInstrDesc &MCID) {
-  for (unsigned i = 0; i < MCID.NumOperands; ++i) {
+  for (unsigned i = 0; i < MCID.getNumOperands(); ++i) {
     if (ARM::isVpred(MCID.operands()[i].OperandType))
       return i;
   }
@@ -11199,11 +11199,11 @@ unsigned ARMAsmParser::checkTargetMatchPredicate(MCInst &Inst) {
   if (MCID.TSFlags & ARMII::ThumbArithFlagSetting) {
     assert(MCID.hasOptionalDef() &&
            "optionally flag setting instruction missing optional def operand");
-    assert(MCID.NumOperands == Inst.getNumOperands() &&
+    assert(MCID.getNumOperands() == Inst.getNumOperands() &&
            "operand count mismatch!");
     bool IsCPSR = false;
     // Check if the instruction has CPSR set.
-    for (unsigned OpNo = 0; OpNo < MCID.NumOperands; ++OpNo) {
+    for (unsigned OpNo = 0; OpNo < MCID.getNumOperands(); ++OpNo) {
       if (MCID.operands()[OpNo].isOptionalDef() &&
           Inst.getOperand(OpNo).isReg() &&
           Inst.getOperand(OpNo).getReg() == ARM::CPSR)
@@ -11290,7 +11290,7 @@ unsigned ARMAsmParser::checkTargetMatchPredicate(MCInst &Inst) {
     break;
   }
 
-  for (unsigned I = 0; I < MCID.NumOperands; ++I)
+  for (unsigned I = 0; I < MCID.getNumOperands(); ++I)
     if (MCID.operands()[I].RegClass == ARM::rGPRRegClassID) {
       // rGPRRegClass excludes PC, and also excluded SP before ARMv8
       const auto &Op = Inst.getOperand(I);

--- a/llvm/lib/Target/ARM/Disassembler/ARMDisassembler.cpp
+++ b/llvm/lib/Target/ARM/Disassembler/ARMDisassembler.cpp
@@ -6242,7 +6242,7 @@ DecodeStatus ARMDisassembler::getARMInstruction(MCInst &MI, uint64_t &Size,
 
 bool ARMDisassembler::isVectorPredicable(const MCInst &MI) const {
   const MCInstrDesc &MCID = MCII->get(MI.getOpcode());
-  for (unsigned i = 0; i < MCID.NumOperands; ++i) {
+  for (unsigned i = 0; i < MCID.getNumOperands(); ++i) {
     if (ARM::isVpred(MCID.operands()[i].OperandType))
       return true;
   }
@@ -6332,7 +6332,7 @@ void ARMDisassembler::UpdateThumbPredicate(DecodeStatus &S, MCInst &MI) const {
   const MCInstrDesc &MCID = MCII->get(MI.getOpcode());
   ArrayRef<MCOperandInfo> OpInfo = MCID.operands();
   MCInst::iterator I = MI.begin();
-  unsigned short NumOps = MCID.NumOperands;
+  unsigned short NumOps = MCID.getNumOperands();
   for (unsigned i = 0; i < NumOps; ++i, ++I) {
     if (OpInfo[i].isPredicate() ) {
       if (CC != ARMCC::AL && !MCID.isPredicable())

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMMCTargetDesc.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMMCTargetDesc.cpp
@@ -572,7 +572,7 @@ std::optional<uint64_t> ARMMCInstrAnalysis::evaluateMemoryOperandAddress(
     return std::nullopt;
 
   // Find the memory addressing operand in the instruction.
-  unsigned OpIndex = Desc.NumDefs;
+  unsigned OpIndex = Desc.getNumDefs();
   while (OpIndex < Desc.getNumOperands() &&
          Desc.operands()[OpIndex].OperandType != MCOI::OPERAND_MEMORY)
     ++OpIndex;

--- a/llvm/lib/Target/Mips/MipsSEInstrInfo.cpp
+++ b/llvm/lib/Target/Mips/MipsSEInstrInfo.cpp
@@ -772,7 +772,7 @@ std::pair<bool, bool>
 MipsSEInstrInfo::compareOpndSize(unsigned Opc,
                                  const MachineFunction &MF) const {
   const MCInstrDesc &Desc = get(Opc);
-  assert(Desc.NumOperands == 2 && "Unary instruction expected.");
+  assert(Desc.getNumOperands() == 2 && "Unary instruction expected.");
   const MipsRegisterInfo *RI = &getRegisterInfo();
   unsigned DstRegSize = RI->getRegSizeInBits(*getRegClass(Desc, 0));
   unsigned SrcRegSize = RI->getRegSizeInBits(*getRegClass(Desc, 1));

--- a/llvm/lib/Target/RISCV/RISCVPushPopOptimizer.cpp
+++ b/llvm/lib/Target/RISCV/RISCVPushPopOptimizer.cpp
@@ -86,8 +86,8 @@ bool RISCVPushPopOpt::usePopRet(MachineBasicBlock::iterator &MBBI,
   // on what register list has been picked during frame lowering.
   const MCInstrDesc &PopDesc = MBBI->getDesc();
   unsigned FirstNonDeclaredOp = PopDesc.getNumOperands() +
-                                PopDesc.NumImplicitUses +
-                                PopDesc.NumImplicitDefs;
+                                PopDesc.getNumImplicitUses() +
+                                PopDesc.getNumImplicitDefs();
   for (unsigned i = FirstNonDeclaredOp; i < MBBI->getNumOperands(); ++i)
     PopRetBuilder.add(MBBI->getOperand(i));
 

--- a/llvm/lib/Target/WebAssembly/MCTargetDesc/WebAssemblyInstPrinter.cpp
+++ b/llvm/lib/Target/WebAssembly/MCTargetDesc/WebAssemblyInstPrinter.cpp
@@ -280,7 +280,7 @@ void WebAssemblyInstPrinter::printInst(const MCInst *MI, uint64_t Address,
 
     // Annotate any control flow label references.
 
-    unsigned NumFixedOperands = Desc.NumOperands;
+    unsigned NumFixedOperands = Desc.getNumOperands();
     SmallSet<uint64_t, 8> Printed;
     for (unsigned I = 0, E = MI->getNumOperands(); I < E; ++I) {
       // See if this operand denotes a basic block target.

--- a/llvm/lib/Target/WebAssembly/WebAssemblyMCInstLower.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyMCInstLower.cpp
@@ -234,7 +234,8 @@ void WebAssemblyMCInstLower::lower(const MachineInstr *MI,
       // Currently this is the only way that CImmediates show up so panic if we
       // get confused.
       unsigned DescIndex = I - NumVariadicDefs;
-      assert(DescIndex < Desc.NumOperands && "unexpected CImmediate operand");
+      assert(DescIndex < Desc.getNumOperands() &&
+             "unexpected CImmediate operand");
       auto Operands = Desc.operands();
       const MCOperandInfo &Info = Operands[DescIndex];
       assert(Info.OperandType == WebAssembly::OPERAND_TYPEINDEX &&
@@ -245,7 +246,7 @@ void WebAssemblyMCInstLower::lower(const MachineInstr *MI,
     }
     case MachineOperand::MO_Immediate: {
       unsigned DescIndex = I - NumVariadicDefs;
-      if (DescIndex < Desc.NumOperands) {
+      if (DescIndex < Desc.getNumOperands()) {
         auto Operands = Desc.operands();
         const MCOperandInfo &Info = Operands[DescIndex];
         // Replace type index placeholder with actual type index. The type index

--- a/llvm/lib/Target/X86/MCTargetDesc/X86BaseInfo.h
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86BaseInfo.h
@@ -1264,7 +1264,7 @@ inline bool canUseApxExtendedReg(const MCInstrDesc &Desc) {
   if (Encoding == X86II::EVEX)
     return true;
 
-  unsigned Opcode = Desc.Opcode;
+  unsigned Opcode = Desc.getOpcode();
   if (isPseudo(TSFlags)) {
     switch (Opcode) {
     default:

--- a/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -8764,7 +8764,7 @@ bool X86InstrInfo::unfoldMemoryOperand(
   MachineFunction &MF = DAG.getMachineFunction();
   const TargetRegisterInfo &TRI = *MF.getSubtarget().getRegisterInfo();
   const TargetRegisterClass *RC = getRegClass(MCID, Index);
-  unsigned NumDefs = MCID.NumDefs;
+  unsigned NumDefs = MCID.getNumDefs();
   std::vector<SDValue> AddrOps;
   std::vector<SDValue> BeforeOps;
   std::vector<SDValue> AfterOps;

--- a/llvm/test/TableGen/InstrInfoEmitterErrors.td
+++ b/llvm/test/TableGen/InstrInfoEmitterErrors.td
@@ -1,0 +1,20 @@
+// RUN: not llvm-tblgen -gen-instr-info -I %p/../../include %s 2>&1 | FileCheck %s
+
+include "llvm/Target/Target.td"
+
+def Reg : Register<"reg">;
+def Regs : RegisterClass<"test", [i32], 0, (add Reg)>;
+
+def TestInstrInfo : InstrInfo;
+def TestTarget : Target {
+  let InstructionSet = TestInstrInfo;
+}
+
+// CHECK: error: instruction size does not fit in 8 bits
+def InvalidSize : Instruction {
+  let Namespace = "Test";
+  let OutOperandList = (outs);
+  let InOperandList = (ins);
+  let AsmString = "";
+  let Size = 320;
+}

--- a/llvm/test/TableGen/InstrInfoEmitterImplicitLists.td
+++ b/llvm/test/TableGen/InstrInfoEmitterImplicitLists.td
@@ -1,0 +1,47 @@
+// RUN: llvm-tblgen -gen-instr-info -I %p/../../include %s -o - | FileCheck %s
+
+include "llvm/Target/Target.td"
+
+class TestRegister<string Name> : Register<Name> {
+  let Namespace = "Test";
+}
+
+def R0 : TestRegister<"r0">;
+def R1 : TestRegister<"r1">;
+def TestRegisters : RegisterClass<"Test", [i32], 32, (add R0, R1)>;
+
+class TestInstruction : Instruction {
+  let Namespace = "Test";
+  let OutOperandList = (outs);
+  let InOperandList = (ins);
+  let AsmString = "";
+}
+
+def Empty : TestInstruction;
+def UsesR0DefsR1 : TestInstruction {
+  let Uses = [R0];
+  let Defs = [R1];
+}
+def UsesR0R1 : TestInstruction {
+  let Uses = [R0, R1];
+}
+def DuplicateUsesR0DefsR1 : TestInstruction {
+  let Uses = [R0];
+  let Defs = [R1];
+}
+
+def TestInstrInfo : InstrInfo;
+def TestTarget : Target {
+  let InstructionSet = TestInstrInfo;
+}
+
+defm remaps : RemapAllTargetPseudoPointerOperands<TestRegisters>;
+
+// Offset zero is the empty-list sentinel. The two lists containing R0 and R1
+// have distinct headers because their use/definition boundaries differ. The
+// duplicate list is emitted only once.
+// CHECK: MCPhysReg ImplicitOps[7];
+// CHECK: /* 0 */ 0,
+// CHECK-NEXT: /* 1 */ 65, Test::R0, Test::R1,
+// CHECK-NEXT: /* 4 */ 2, Test::R0, Test::R1,
+// CHECK-NOT: Test::R0, Test::R1,

--- a/llvm/test/TableGen/RegClassByHwMode.td
+++ b/llvm/test/TableGen/RegClassByHwMode.td
@@ -24,7 +24,7 @@ include "Common/RegClassByHwModeCommon.td"
 // INSTRINFO-NEXT: } // namespace llvm::MyTarget
 
 
-// INSTRINFO: { [[LOAD_STACK_GUARD_OPCODE]],	1,	1,	0,	0,	0,	0,	MyTargetOpInfoBase + [[LOAD_STACK_GUARD_OP_INDEX:[0-9]+]],	0,	0|(1ULL<<MCID::Pseudo)|(1ULL<<MCID::MayLoad)|(1ULL<<MCID::Rematerializable)|(1ULL<<MCID::ExtraSrcRegAllocReq)|(1ULL<<MCID::ExtraDefRegAllocReq), 0x0ULL },  // anonymous_
+// INSTRINFO: { MCInstrDesc::TableGenEncoding{}, 0x0ULL, 0x1a0080008ULL, 0x101001eULL | (uint64_t(MyTargetOpInfoBase + [[LOAD_STACK_GUARD_OP_INDEX:[0-9]+]]) << MCInstrDesc::TableGenEncoding::OpInfoOffsetShift) },  // anonymous_
 
 // INSTRINFO: /* [[LOAD_STACK_GUARD_OP_INDEX]] */ { MyTarget::XRegs_EvenIfRequired, 0|(1<<MCOI::LookupRegClassByHwMode), MCOI::OPERAND_REGISTER, 0 },
 // INSTRINFO: { MyTarget::XRegs_EvenIfRequired, 0|(1<<MCOI::LookupRegClassByHwMode), MCOI::OPERAND_REGISTER, 0 }, { -1, 0, MCOI::OPERAND_IMMEDIATE, 0 }, { -1, 0, MCOI::OPERAND_IMMEDIATE, 0 },

--- a/llvm/test/TableGen/def-multiple-operands.td
+++ b/llvm/test/TableGen/def-multiple-operands.td
@@ -23,8 +23,7 @@ def Reg3Opnd : Operand<OtherVT> {
 
 // CHECK: archInstrTable {{.* = \{}}
 // CHECK: {{\{}}
-// CHECK: {{\{}} [[ID:[0-9]+]], 4, 3, 13, {{.+\}, \/\/}}
-// CHECK-SAME: InstA
+// CHECK: { MCInstrDesc::TableGenEncoding{}, 0x0ULL, 0xd00000180000000ULL, 0x304014aULL | (uint64_t(archOpInfoBase + {{[0-9]+}}) << MCInstrDesc::TableGenEncoding::OpInfoOffsetShift) },  // InstA
 def InstA : Instruction {
   let Namespace = "MyNS";
   let Size = 13;

--- a/llvm/test/TableGen/target-specialized-pseudos.td
+++ b/llvm/test/TableGen/target-specialized-pseudos.td
@@ -22,13 +22,13 @@
 
 // CHECK: extern const MyTargetInstrTable MyTargetDescs = {
 // CHECK-NEXT: {
-// CHECK-NEXT: { [[MY_MOV_OPCODE]],	2,	1,	2,	0,	0,	0,	MyTargetOpInfoBase + {{[0-9]+}},	0,	0|(1ULL<<MCID::ExtraSrcRegAllocReq)|(1ULL<<MCID::ExtraDefRegAllocReq), 0x0ULL },  // MY_MOV
-// CHECK-NEXT: { [[G_UBFX_OPCODE]],	4,	1,	0,	0,	0,	0,	MyTargetOpInfoBase + {{[0-9]+}},	0,	0|(1ULL<<MCID::PreISelOpcode)|(1ULL<<MCID::Pseudo)|(1ULL<<MCID::ExtraSrcRegAllocReq)|(1ULL<<MCID::ExtraDefRegAllocReq), 0x0ULL },  // G_UBFX
+// CHECK-NEXT: { MCInstrDesc::TableGenEncoding{}, 0x0ULL, 0x200000180000000ULL, 0x102014aULL | (uint64_t(MyTargetOpInfoBase + {{[0-9]+}}) << MCInstrDesc::TableGenEncoding::OpInfoOffsetShift) },  // MY_MOV
+// CHECK-NEXT: { MCInstrDesc::TableGenEncoding{}, 0x0ULL, 0x180000009ULL, 0x1040149ULL | (uint64_t(MyTargetOpInfoBase + {{[0-9]+}}) << MCInstrDesc::TableGenEncoding::OpInfoOffsetShift) },  // G_UBFX
 
-// ALLCASES: { [[PATCHABLE_TYPED_EVENT_CALL_OPCODE]],	3,	0,	0,	0,	0,	0,	MyTargetOpInfoBase + [[PATCHABLE_TYPED_EVENT_CALL_OP_ENTRY:[0-9]+]],	0,	0|(1ULL<<MCID::Pseudo)|(1ULL<<MCID::Call)|(1ULL<<MCID::MayLoad)|(1ULL<<MCID::MayStore)|(1ULL<<MCID::UsesCustomInserter)|(1ULL<<MCID::UnmodeledSideEffects)|(1ULL<<MCID::ExtraSrcRegAllocReq)|(1ULL<<MCID::ExtraDefRegAllocReq), 0x0ULL },  // anonymous_
-// ALLCASES: { [[PATCHABLE_EVENT_CALL_OPCODE]],	2,	0,	0,	0,	0,	0,	MyTargetOpInfoBase + [[PATCHABLE_EVENT_CALL_OP_ENTRY:[0-9]+]],	0, 0|(1ULL<<MCID::Pseudo)|(1ULL<<MCID::Call)|(1ULL<<MCID::MayLoad)|(1ULL<<MCID::MayStore)|(1ULL<<MCID::UsesCustomInserter)|(1ULL<<MCID::UnmodeledSideEffects)|(1ULL<<MCID::ExtraSrcRegAllocReq)|(1ULL<<MCID::ExtraDefRegAllocReq), 0x0ULL },  // anonymous_
-// ALLCASES: { [[PREALLOCATED_ARG_OPCODE]],	3,	1,	0,	0,	0,	0,	MyTargetOpInfoBase + [[PREALLOCATED_ARG_OP_ENTRY:[0-9]+]],	0,	0|(1ULL<<MCID::Pseudo)|(1ULL<<MCID::UsesCustomInserter)|(1ULL<<MCID::UnmodeledSideEffects)|(1ULL<<MCID::ExtraSrcRegAllocReq)|(1ULL<<MCID::ExtraDefRegAllocReq), 0x0ULL },  // anonymous_
-// ALLCASES: { [[LOAD_STACK_GUARD_OPCODE]],	1,	1,	0,	0,	0,	0,	MyTargetOpInfoBase + [[LOAD_STACK_GUARD_OP_ENTRY:[0-9]+]],	0,	0|(1ULL<<MCID::Pseudo)|(1ULL<<MCID::MayLoad)|(1ULL<<MCID::Rematerializable)|(1ULL<<MCID::ExtraSrcRegAllocReq)|(1ULL<<MCID::ExtraDefRegAllocReq), 0x0ULL },  // anonymous_
+// ALLCASES: { MCInstrDesc::TableGenEncoding{}, 0x0ULL, 0x189180088ULL, 0x3002aULL | (uint64_t(MyTargetOpInfoBase + [[PATCHABLE_TYPED_EVENT_CALL_OP_ENTRY:[0-9]+]]) << MCInstrDesc::TableGenEncoding::OpInfoOffsetShift) },  // anonymous_
+// ALLCASES: { MCInstrDesc::TableGenEncoding{}, 0x0ULL, 0x189180088ULL, 0x20029ULL | (uint64_t(MyTargetOpInfoBase + [[PATCHABLE_EVENT_CALL_OP_ENTRY:[0-9]+]]) << MCInstrDesc::TableGenEncoding::OpInfoOffsetShift) },  // anonymous_
+// ALLCASES: { MCInstrDesc::TableGenEncoding{}, 0x0ULL, 0x189000008ULL, 0x1030020ULL | (uint64_t(MyTargetOpInfoBase + [[PREALLOCATED_ARG_OP_ENTRY:[0-9]+]]) << MCInstrDesc::TableGenEncoding::OpInfoOffsetShift) },  // anonymous_
+// ALLCASES: { MCInstrDesc::TableGenEncoding{}, 0x0ULL, 0x1a0080008ULL, 0x101001eULL | (uint64_t(MyTargetOpInfoBase + [[LOAD_STACK_GUARD_OP_ENTRY:[0-9]+]]) << MCInstrDesc::TableGenEncoding::OpInfoOffsetShift) },  // anonymous_
 
 // CHECK: /* 0 */ { -1, 0, MCOI::OPERAND_UNKNOWN, 0 },
 

--- a/llvm/tools/llvm-exegesis/lib/CodeTemplate.cpp
+++ b/llvm/tools/llvm-exegesis/lib/CodeTemplate.cpp
@@ -65,7 +65,7 @@ bool InstructionTemplate::hasImmediateVariables() const {
 
 MCInst InstructionTemplate::build() const {
   MCInst Result;
-  Result.setOpcode(Instr->Description.Opcode);
+  Result.setOpcode(Instr->getOpcode());
   for (const auto &Op : Instr->Operands)
     if (Op.isExplicit())
       Result.addOperand(getValueFor(Op));

--- a/llvm/tools/llvm-exegesis/lib/X86/Target.cpp
+++ b/llvm/tools/llvm-exegesis/lib/X86/Target.cpp
@@ -178,10 +178,10 @@ static const char *isInvalidMemoryInstr(const Instruction &Instr) {
   case X86II::RawFrmImm8:
     return nullptr;
   case X86II::AddRegFrm:
-    return (Instr.Description.Opcode == X86::POP16r ||
-            Instr.Description.Opcode == X86::POP32r ||
-            Instr.Description.Opcode == X86::PUSH16r ||
-            Instr.Description.Opcode == X86::PUSH32r)
+    return (Instr.getOpcode() == X86::POP16r ||
+            Instr.getOpcode() == X86::POP32r ||
+            Instr.getOpcode() == X86::PUSH16r ||
+            Instr.getOpcode() == X86::PUSH32r)
                ? "unsupported opcode: unsupported memory access"
                : nullptr;
   // These access memory and are handled.
@@ -221,7 +221,7 @@ static const char *isInvalidOpcode(const Instruction &Instr) {
       OpcodeName.starts_with("PUSH") ||
       OpcodeName.starts_with("ADJCALLSTACK") || OpcodeName.starts_with("LEAVE"))
     return "unsupported opcode: Push/Pop/AdjCallStack/Leave";
-  switch (Instr.Description.Opcode) {
+  switch (Instr.getOpcode()) {
   case X86::LFS16rm:
   case X86::LFS32rm:
   case X86::LFS64rm:
@@ -786,7 +786,7 @@ private:
   }
 
   bool allowAsBackToBack(const Instruction &Instr) const override {
-    const unsigned Opcode = Instr.Description.Opcode;
+    const unsigned Opcode = Instr.getOpcode();
     return !isInvalidOpcode(Instr) && Opcode != X86::LEA64r &&
            Opcode != X86::LEA64_32r && Opcode != X86::LEA16r;
   }

--- a/llvm/unittests/CodeGen/LexicalScopesTest.cpp
+++ b/llvm/unittests/CodeGen/LexicalScopesTest.cpp
@@ -60,19 +60,15 @@ public:
   // Some meaningless instructions -- the first is fully meaningless,
   // while the second is supposed to impersonate DBG_VALUEs through its
   // opcode.
-  MCInstrDesc BeanInst{};
-  MCInstrDesc DbgValueInst{};
+  MCInstrDesc BeanInst;
+  MCInstrDesc DbgValueInst;
 
-  LexicalScopesTest() : Ctx(), Mod("beehives", Ctx) {
-    memset(&BeanInst, 0, sizeof(BeanInst));
-    BeanInst.Opcode = 1;
-    BeanInst.Size = 1;
-
-    memset(&DbgValueInst, 0, sizeof(MCInstrDesc));
-    DbgValueInst.Opcode = TargetOpcode::DBG_VALUE;
-    DbgValueInst.Size = 1;
-    DbgValueInst.Flags = 1U << MCID::Meta;
-
+  LexicalScopesTest()
+      : Ctx(), Mod("beehives", Ctx), BeanInst(/*Opcode=*/1, /*NumOperands=*/0,
+                                              /*NumDefs=*/0, /*Size=*/1),
+        DbgValueInst(TargetOpcode::DBG_VALUE, /*NumOperands=*/0,
+                     /*NumDefs=*/0, /*Size=*/1, /*SchedClass=*/0,
+                     /*Flags=*/1U << MCID::Meta) {
     // Boilerplate that creates a MachineFunction and associated blocks.
     MF = createMachineFunction(Ctx, Mod);
     llvm::Function &F = const_cast<llvm::Function &>(MF->getFunction());

--- a/llvm/unittests/CodeGen/MachineBasicBlockTest.cpp
+++ b/llvm/unittests/CodeGen/MachineBasicBlockTest.cpp
@@ -67,8 +67,8 @@ TEST(FindDebugLocTest, DifferentIterators) {
 
   // Insert two MIs with DebugLoc DL1 and DL3.
   // Also add a DBG_VALUE with a different DebugLoc in between.
-  MCInstrDesc COPY = {TargetOpcode::COPY, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-  MCInstrDesc DBG = {TargetOpcode::DBG_VALUE, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  MCInstrDesc COPY(TargetOpcode::COPY);
+  MCInstrDesc DBG(TargetOpcode::DBG_VALUE);
   auto MI3 = MF->CreateMachineInstr(COPY, DL3);
   MBB.insert(MBB.begin(), MI3);
   auto MI2 = MF->CreateMachineInstr(DBG, DL2);

--- a/llvm/unittests/CodeGen/MachineInstrTest.cpp
+++ b/llvm/unittests/CodeGen/MachineInstrTest.cpp
@@ -56,15 +56,14 @@ TEST(IsIdenticalToTest, DifferentDefs) {
   Module Mod("Module", Ctx);
   auto MF = createMachineFunction(Ctx, Mod);
 
-  unsigned short NumOps = 2;
+  unsigned char NumOps = 2;
   unsigned char NumDefs = 1;
   struct {
     MCInstrDesc MCID;
     MCOperandInfo OpInfo[2];
-  } Table = {
-      {0, NumOps, NumDefs, 0, 0, 0, 0, 0, 0, 1ULL << MCID::HasOptionalDef, 0},
-      {{0, 0, MCOI::OPERAND_REGISTER, 0},
-       {0, 1 << MCOI::OptionalDef, MCOI::OPERAND_REGISTER, 0}}};
+  } Table = {{0, NumOps, NumDefs, 0, 0, 1ULL << MCID::HasOptionalDef},
+             {{0, 0, MCOI::OPERAND_REGISTER, 0},
+              {0, 1 << MCOI::OptionalDef, MCOI::OPERAND_REGISTER, 0}}};
 
   // Create two MIs with different virtual reg defs and the same uses.
   unsigned VirtualDef1 = -42; // The value doesn't matter, but the sign does.
@@ -128,15 +127,14 @@ TEST(MachineInstrExpressionTraitTest, IsEqualAgreesWithGetHashValue) {
   Module Mod("Module", Ctx);
   auto MF = createMachineFunction(Ctx, Mod);
 
-  unsigned short NumOps = 2;
+  unsigned char NumOps = 2;
   unsigned char NumDefs = 1;
   struct {
     MCInstrDesc MCID;
     MCOperandInfo OpInfo[2];
-  } Table = {
-      {0, NumOps, NumDefs, 0, 0, 0, 0, 0, 0, 1ULL << MCID::HasOptionalDef, 0},
-      {{0, 0, MCOI::OPERAND_REGISTER, 0},
-       {0, 1 << MCOI::OptionalDef, MCOI::OPERAND_REGISTER, 0}}};
+  } Table = {{0, NumOps, NumDefs, 0, 0, 1ULL << MCID::HasOptionalDef},
+             {{0, 0, MCOI::OPERAND_REGISTER, 0},
+              {0, 1 << MCOI::OptionalDef, MCOI::OPERAND_REGISTER, 0}}};
 
   // Define a series of instructions with different kinds of operands and make
   // sure that the hash function is consistent with isEqual for various
@@ -212,8 +210,7 @@ TEST(MachineInstrPrintingTest, DebugLocPrinting) {
   struct {
     MCInstrDesc MCID;
     MCOperandInfo OpInfo;
-  } Table = {{0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0},
-             {0, 0, MCOI::OPERAND_REGISTER, 0}};
+  } Table = {{0, 1, 1}, {0, 0, MCOI::OPERAND_REGISTER, 0}};
 
   DIFile *DIF = DIFile::getDistinct(Ctx, "filename", "");
   DISubprogram *DIS = DISubprogram::getDistinct(
@@ -238,7 +235,7 @@ TEST(MachineInstrSpan, DistanceBegin) {
   auto MF = createMachineFunction(Ctx, Mod);
   auto MBB = MF->CreateMachineBasicBlock();
 
-  MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  MCInstrDesc MCID;
 
   auto MII = MBB->begin();
   MachineInstrSpan MIS(MII, MBB);
@@ -255,7 +252,7 @@ TEST(MachineInstrSpan, DistanceEnd) {
   auto MF = createMachineFunction(Ctx, Mod);
   auto MBB = MF->CreateMachineBasicBlock();
 
-  MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  MCInstrDesc MCID;
 
   auto MII = MBB->end();
   MachineInstrSpan MIS(MII, MBB);
@@ -270,7 +267,7 @@ TEST(MachineInstrExtraInfo, AddExtraInfo) {
   LLVMContext Ctx;
   Module Mod("Module", Ctx);
   auto MF = createMachineFunction(Ctx, Mod);
-  MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  MCInstrDesc MCID;
 
   auto MI = MF->CreateMachineInstr(MCID, DebugLoc());
   auto MAI = MCAsmInfo(MCOptions);
@@ -351,7 +348,7 @@ TEST(MachineInstrExtraInfo, ChangeExtraInfo) {
   LLVMContext Ctx;
   Module Mod("Module", Ctx);
   auto MF = createMachineFunction(Ctx, Mod);
-  MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  MCInstrDesc MCID;
 
   auto MI = MF->CreateMachineInstr(MCID, DebugLoc());
   auto MAI = MCAsmInfo(MCOptions);
@@ -406,7 +403,7 @@ TEST(MachineInstrExtraInfo, RemoveExtraInfo) {
   LLVMContext Ctx;
   Module Mod("Module", Ctx);
   auto MF = createMachineFunction(Ctx, Mod);
-  MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  MCInstrDesc MCID;
 
   auto MI = MF->CreateMachineInstr(MCID, DebugLoc());
   auto MAI = MCAsmInfo(MCOptions);
@@ -488,10 +485,8 @@ TEST(MachineInstrDebugValue, AddDebugValueOperand) {
        {TargetOpcode::DBG_VALUE, TargetOpcode::DBG_VALUE_LIST,
         TargetOpcode::DBG_INSTR_REF, TargetOpcode::DBG_PHI,
         TargetOpcode::DBG_LABEL}) {
-    const MCInstrDesc MCID = {
-        Opcode, 0, 0, 0, 0,
-        0,      0, 0, 0, (1ULL << MCID::Pseudo) | (1ULL << MCID::Variadic),
-        0};
+    const MCInstrDesc MCID(Opcode, 0, 0, 0, 0,
+                           (1ULL << MCID::Pseudo) | (1ULL << MCID::Variadic));
 
     auto *MI = MF->CreateMachineInstr(MCID, DebugLoc());
     MI->addOperand(*MF, MachineOperand::CreateReg(0, /*isDef*/ false));
@@ -525,7 +520,7 @@ TEST(MachineInstrBuilder, BuildMI) {
   Module Mod("Module", Ctx);
   auto MF = createMachineFunction(Ctx, Mod);
   auto MBB = MF->CreateMachineBasicBlock();
-  MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  MCInstrDesc MCID;
   EXPECT_THAT(BuildMI(*MF, MIMD, MCID), HasMIMetadata(MIMD));
   EXPECT_THAT(BuildMI(*MF, MIMD, MCID), HasMIMetadata(MIMD));
   EXPECT_THAT(BuildMI(*MBB, MBB->end(), MIMD, MCID), HasMIMetadata(MIMD));
@@ -543,17 +538,8 @@ TEST(MachineInstrTest, SpliceOperands) {
   Module Mod("Module", Ctx);
   std::unique_ptr<MachineFunction> MF = createMachineFunction(Ctx, Mod);
   MachineBasicBlock *MBB = MF->CreateMachineBasicBlock();
-  MCInstrDesc MCID = {TargetOpcode::INLINEASM,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0,
-                      0,
-                      (1ULL << MCID::Pseudo) | (1ULL << MCID::Variadic),
-                      0};
+  MCInstrDesc MCID(TargetOpcode::INLINEASM, 0, 0, 0, 0,
+                   (1ULL << MCID::Pseudo) | (1ULL << MCID::Variadic));
   MachineInstr *MI = MF->CreateMachineInstr(MCID, DebugLoc());
   MBB->insert(MBB->begin(), MI);
   MI->addOperand(MachineOperand::CreateImm(0));
@@ -629,7 +615,7 @@ TEST(MachineInstr, EraseFromParentReturnedIterator) {
   auto MF = createMachineFunction(Ctx, Mod);
   auto MBB = MF->CreateMachineBasicBlock();
 
-  MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  MCInstrDesc MCID;
   MachineInstr *MI1 = MF->CreateMachineInstr(MCID, DebugLoc());
   MBB->insert(MBB->end(), MI1);
   MachineInstr *MI2 = MF->CreateMachineInstr(MCID, DebugLoc());
@@ -648,7 +634,7 @@ TEST(MachineInstr, EraseFromParentReturnedIteratorBundle) {
   Module Mod("Module", Ctx);
   auto MF = createMachineFunction(Ctx, Mod);
   auto MBB = MF->CreateMachineBasicBlock();
-  MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  MCInstrDesc MCID;
 
   // Bundle1 {
   //   MI1B1

--- a/llvm/unittests/CodeGen/MachineOperandTest.cpp
+++ b/llvm/unittests/CodeGen/MachineOperandTest.cpp
@@ -450,7 +450,7 @@ TEST(MachineOperandTest, RegisterLiveOutHashValue) {
   Module Mod("Module", Ctx);
   auto MF = createMachineFunction(Ctx, Mod);
   MachineBasicBlock *MBB = MF->CreateMachineBasicBlock();
-  MCInstrDesc MCID = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  MCInstrDesc MCID;
   auto *MI1 = MF->CreateMachineInstr(MCID, DebugLoc());
   auto *MI2 = MF->CreateMachineInstr(MCID, DebugLoc());
   MBB->insert(MBB->begin(), MI1);

--- a/llvm/unittests/CodeGen/RegAllocScoreTest.cpp
+++ b/llvm/unittests/CodeGen/RegAllocScoreTest.cpp
@@ -68,8 +68,7 @@ enum MockInstrId {
 };
 
 const std::array<MCInstrDesc, MockInstrId::TotalMockInstrs> MockInstrDescs{{
-#define MOCK_SPEC(IGNORE, OPCODE, FLAGS)                                       \
-  {OPCODE, 0, 0, 0, 0, 0, 0, 0, 0, FLAGS, 0},
+#define MOCK_SPEC(IGNORE, OPCODE, FLAGS) {OPCODE, 0, 0, 0, 0, FLAGS},
     MOCK_INSTR(MOCK_SPEC)
 #undef MOCK_SPEC
 }};

--- a/llvm/unittests/MC/CMakeLists.txt
+++ b/llvm/unittests/MC/CMakeLists.txt
@@ -20,8 +20,8 @@ add_llvm_unittest(MCTests
   DwarfLineTables.cpp
   DwarfLineTableHeaders.cpp
   MCInstPrinter.cpp
+  MCInstrDescTest.cpp
   StringTableBuilderTest.cpp
   TargetRegistry.cpp
   MCDisassemblerTest.cpp
   )
-

--- a/llvm/unittests/MC/MCInstrDescTest.cpp
+++ b/llvm/unittests/MC/MCInstrDescTest.cpp
@@ -1,0 +1,82 @@
+//===- MCInstrDescTest.cpp - MCInstrDesc unit tests -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/MC/MCInstrDesc.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+
+namespace {
+
+TEST(MCInstrDescTest, PackedFields) {
+  struct OperandCounts {
+    unsigned NumOperands;
+    unsigned NumDefs;
+  };
+
+  constexpr OperandCounts TestCounts[] = {
+      {0, 0},   {1, 0},     {1, 1},    {33, 8},    {67, 65},
+      {130, 0}, {131, 129}, {255, 31}, {255, 224}, {255, 255}};
+  for (OperandCounts Counts : TestCounts) {
+    for (unsigned Size : {0U, 2U, 3U, 4U, 63U, 64U, 252U, 255U}) {
+      constexpr uint64_t Flags = (1ULL << MCID::Authenticated) | 1;
+      MCInstrDesc Desc(
+          MCInstrDesc::TableGenEncoding{}, UINT64_MAX,
+          MCInstrDesc::TableGenEncoding::encodeFlagsAndImplicit(Flags, Size, 0),
+          MCInstrDesc::TableGenEncoding::encodeOpcodeAndOperands(
+              65535, Counts.NumOperands, Counts.NumDefs, 65535, 65535));
+
+      EXPECT_EQ(Desc.getOpcode(), 65535U);
+      EXPECT_EQ(Desc.getNumOperands(), Counts.NumOperands);
+      EXPECT_EQ(Desc.getNumDefs(), Counts.NumDefs);
+      EXPECT_EQ(Desc.getSize(), Size);
+      EXPECT_EQ(Desc.getSchedClass(), 65535U);
+      EXPECT_TRUE(Desc.isPreISelOpcode());
+      EXPECT_TRUE(Desc.isAuthenticated());
+      EXPECT_EQ(Desc.TSFlags, UINT64_MAX);
+    }
+  }
+}
+
+TEST(MCInstrDescTest, EmptyImplicitOperands) {
+  MCInstrDesc Desc;
+  EXPECT_EQ(Desc.getNumImplicitUses(), 0U);
+  EXPECT_EQ(Desc.getNumImplicitDefs(), 0U);
+  EXPECT_TRUE(Desc.implicit_uses().empty());
+  EXPECT_TRUE(Desc.implicit_defs().empty());
+}
+
+TEST(MCInstrDescTest, ImplicitOperands) {
+  constexpr unsigned NumImplicitUses = 2;
+  constexpr unsigned NumImplicitDefs = 3;
+  constexpr MCPhysReg Header =
+      MCInstrDesc::TableGenEncoding::encodeImplicitHeader(NumImplicitUses,
+                                                          NumImplicitDefs);
+  struct InstrTable {
+    MCInstrDesc Insts[1];
+    MCPhysReg ImplicitOps[2 + NumImplicitUses + NumImplicitDefs];
+  } Table{{MCInstrDesc(
+              MCInstrDesc::TableGenEncoding{}, 0,
+              MCInstrDesc::TableGenEncoding::encodeFlagsAndImplicit(0, 0, 1),
+              MCInstrDesc::TableGenEncoding::encodeOpcodeAndOperands(0, 0, 0, 0,
+                                                                     0))},
+          {0, Header, 11, 12, 13, 14, 15}};
+
+  const MCInstrDesc &Desc = Table.Insts[0];
+  EXPECT_EQ(Desc.getNumImplicitUses(), NumImplicitUses);
+  EXPECT_EQ(Desc.getNumImplicitDefs(), NumImplicitDefs);
+  ASSERT_EQ(Desc.implicit_uses().size(), NumImplicitUses);
+  EXPECT_EQ(Desc.implicit_uses()[0], 11);
+  EXPECT_EQ(Desc.implicit_uses()[1], 12);
+  ASSERT_EQ(Desc.implicit_defs().size(), NumImplicitDefs);
+  EXPECT_EQ(Desc.implicit_defs()[0], 13);
+  EXPECT_EQ(Desc.implicit_defs()[1], 14);
+  EXPECT_EQ(Desc.implicit_defs()[2], 15);
+}
+
+} // namespace

--- a/llvm/utils/TableGen/InstrInfoEmitter.cpp
+++ b/llvm/utils/TableGen/InstrInfoEmitter.cpp
@@ -25,6 +25,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/MC/MCInstrDesc.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/SourceMgr.h"
@@ -34,6 +35,7 @@
 #include "llvm/TableGen/Record.h"
 #include "llvm/TableGen/TGTimer.h"
 #include "llvm/TableGen/TableGenBackend.h"
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <iterator>
@@ -71,6 +73,8 @@ private:
   using OperandInfoTy = std::vector<std::string>;
   using OperandInfoListTy = std::vector<OperandInfoTy>;
   using OperandInfoMapTy = std::map<OperandInfoTy, unsigned>;
+  using ImplicitListTy = std::pair<unsigned, std::vector<const Record *>>;
+  using ImplicitListMapTy = std::map<ImplicitListTy, unsigned>;
 
   DenseMap<const CodeGenInstruction *, const CodeGenInstruction *>
       TargetSpecializedPseudoInsts;
@@ -94,8 +98,7 @@ private:
   /// Write verifyInstructionPredicates methods.
   void emitFeatureVerifier(raw_ostream &OS, const CodeGenTarget &Target);
   void emitRecord(const CodeGenInstruction &Inst, unsigned Num,
-                  const Record *InstrInfo,
-                  std::map<std::vector<const Record *>, unsigned> &EL,
+                  const Record *InstrInfo, ImplicitListMapTy &EmittedLists,
                   const OperandInfoMapTy &OperandInfo, raw_ostream &OS);
   void emitOperandTypeMappings(
       raw_ostream &OS, const CodeGenTarget &Target,
@@ -934,22 +937,34 @@ void InstrInfoEmitter::run(raw_ostream &OS) {
   bool HasUseNamedOperandTable = false;
 
   Timer.startTimer("Collect uses/defs");
-  std::map<std::vector<const Record *>, unsigned> EmittedLists;
-  std::vector<std::vector<const Record *>> ImplicitLists;
-  unsigned ImplicitListSize = 0;
+  ImplicitListMapTy EmittedLists;
+  std::vector<ImplicitListTy> ImplicitLists;
+  ImplicitListTy EmptyImplicitList{0, {}};
+  EmittedLists.emplace(EmptyImplicitList, 0);
+  ImplicitLists.push_back(EmptyImplicitList);
+  unsigned ImplicitListSize = 1;
   for (const CodeGenInstruction *Inst : NumberedInstructions) {
     HasUseLogicalOperandMappings |=
         Inst->TheDef->getValueAsBit("UseLogicalOperandMappings");
     HasUseNamedOperandTable |=
         Inst->TheDef->getValueAsBit("UseNamedOperandTable");
 
-    std::vector<const Record *> ImplicitOps = Inst->ImplicitUses;
-    llvm::append_range(ImplicitOps, Inst->ImplicitDefs);
-    if (EmittedLists.try_emplace(ImplicitOps, ImplicitListSize).second) {
-      ImplicitLists.push_back(ImplicitOps);
-      ImplicitListSize += ImplicitOps.size();
+    const CodeGenInstruction *EffectiveInst = Inst;
+    auto OverrideEntry = TargetSpecializedPseudoInsts.find(Inst);
+    if (OverrideEntry != TargetSpecializedPseudoInsts.end())
+      EffectiveInst = OverrideEntry->second;
+
+    std::vector<const Record *> ImplicitOps = EffectiveInst->ImplicitUses;
+    llvm::append_range(ImplicitOps, EffectiveInst->ImplicitDefs);
+    ImplicitListTy ImplicitList{EffectiveInst->ImplicitUses.size(),
+                                std::move(ImplicitOps)};
+    if (EmittedLists.try_emplace(ImplicitList, ImplicitListSize).second) {
+      ImplicitListSize += 1 + ImplicitList.second.size();
+      ImplicitLists.push_back(std::move(ImplicitList));
     }
   }
+  if (ImplicitListSize > (1U << 15))
+    PrintFatalError("implicit operand table does not fit in 15-bit offsets");
 
   {
     IfGuardEmitter IfGuard(
@@ -1002,7 +1017,10 @@ void InstrInfoEmitter::run(raw_ostream &OS) {
        << "InstrTable::Padding) % sizeof(MCOperandInfo) == 0);\n";
     OS << "static constexpr unsigned " << TargetName << "OpInfoBase = (sizeof "
        << TargetName << "InstrTable::ImplicitOps + sizeof " << TargetName
-       << "InstrTable::Padding) / sizeof(MCOperandInfo);\n\n";
+       << "InstrTable::Padding) / sizeof(MCOperandInfo);\n";
+    OS << "static_assert(" << TargetName << "OpInfoBase + " << OperandInfoSize
+       << " <= (1U << 16), "
+          "\"operand info table does not fit in 16-bit offsets\");\n\n";
 
     OS << "extern const " << TargetName << "InstrTable " << TargetName
        << "Descs = {\n  {\n";
@@ -1022,11 +1040,17 @@ void InstrInfoEmitter::run(raw_ostream &OS) {
 
     OS << "  }, {\n";
 
-    // Emit all of the instruction's implicit uses and defs.
+    // Emit each implicit operand list. The first MCPhysReg stores the number of
+    // uses in its low six bits and the number of definitions in its next six
+    // bits.
     Timer.startTimer("Emit uses/defs");
-    for (auto &List : ImplicitLists) {
-      OS << "    /* " << EmittedLists[List] << " */";
-      for (auto &Reg : List)
+    for (const ImplicitListTy &List : ImplicitLists) {
+      unsigned NumImplicitUses = List.first;
+      unsigned NumImplicitDefs = List.second.size() - NumImplicitUses;
+      MCPhysReg Header = MCInstrDesc::TableGenEncoding::encodeImplicitHeader(
+          NumImplicitUses, NumImplicitDefs);
+      OS << "    /* " << EmittedLists[List] << " */ " << Header << ',';
+      for (const Record *Reg : List.second)
         OS << ' ' << getQualifiedName(Reg) << ',';
       OS << '\n';
     }
@@ -1279,10 +1303,11 @@ void InstrInfoEmitter::run(raw_ostream &OS) {
   EmitMapTable(Records, OS);
 }
 
-void InstrInfoEmitter::emitRecord(
-    const CodeGenInstruction &Inst, unsigned Num, const Record *InstrInfo,
-    std::map<std::vector<const Record *>, unsigned> &EmittedLists,
-    const OperandInfoMapTy &OperandInfoMap, raw_ostream &OS) {
+void InstrInfoEmitter::emitRecord(const CodeGenInstruction &Inst, unsigned Num,
+                                  const Record *InstrInfo,
+                                  ImplicitListMapTy &EmittedLists,
+                                  const OperandInfoMapTy &OperandInfoMap,
+                                  raw_ostream &OS) {
   int MinOperands = 0;
   if (!Inst.Operands.empty())
     // Each logical operand can be multiple MI operands.
@@ -1295,109 +1320,127 @@ void InstrInfoEmitter::emitRecord(
     DefOperands = Opnd.MIOperandNo + Opnd.MINumOperands;
   }
 
-  OS << "    { ";
-  OS << Num << ",\t" << MinOperands << ",\t" << DefOperands << ",\t"
-     << Inst.TheDef->getValueAsInt("Size") << ",\t"
-     << SchedModels.getSchedClassIdx(Inst) << ",\t";
+  int64_t Size = Inst.TheDef->getValueAsInt("Size");
+  unsigned SchedClass = SchedModels.getSchedClassIdx(Inst);
+  if (!isUInt<16>(Num))
+    PrintFatalError(Inst.TheDef, "instruction opcode does not fit in 16 bits");
+  if (!isUInt<8>(MinOperands))
+    PrintFatalError(Inst.TheDef,
+                    "instruction operand count does not fit in 8 bits");
+  if (DefOperands > MinOperands)
+    PrintFatalError(Inst.TheDef,
+                    "instruction definition count exceeds operand count");
+  if (!isUInt<8>(DefOperands))
+    PrintFatalError(Inst.TheDef,
+                    "instruction definition count does not fit in 8 bits");
+  if (!isUInt<8>(Size))
+    PrintFatalError(Inst.TheDef, "instruction size does not fit in 8 bits");
+  if (!isUInt<16>(SchedClass))
+    PrintFatalError(Inst.TheDef,
+                    "instruction scheduling class does not fit in 16 bits");
+  if (!isUInt<6>(Inst.ImplicitUses.size()) ||
+      !isUInt<6>(Inst.ImplicitDefs.size()))
+    PrintFatalError(Inst.TheDef,
+                    "implicit register count does not fit in 6 bits");
 
   const CodeGenTarget &Target = CDP.getTargetInfo();
 
-  // Emit the implicit use/def list...
-  OS << Inst.ImplicitUses.size() << ",\t" << Inst.ImplicitDefs.size() << ",\t";
+  // Collect the implicit use/def list.
   std::vector<const Record *> ImplicitOps = Inst.ImplicitUses;
   llvm::append_range(ImplicitOps, Inst.ImplicitDefs);
+  ImplicitListTy ImplicitList{Inst.ImplicitUses.size(), std::move(ImplicitOps)};
 
-  // Emit the operand info offset.
   OperandInfoTy OperandInfo = GetOperandInfo(Inst);
-  OS << Target.getName() << "OpInfoBase + "
-     << OperandInfoMap.find(OperandInfo)->second << ",\t";
+  unsigned OperandInfoOffset = OperandInfoMap.find(OperandInfo)->second;
+  auto ImplicitListEntry = EmittedLists.find(ImplicitList);
+  if (ImplicitListEntry == EmittedLists.end())
+    PrintFatalError(Inst.TheDef, "missing implicit operand list");
+  unsigned ImplicitOffset = ImplicitListEntry->second;
 
-  // Emit implicit operand base.
-  OS << EmittedLists[ImplicitOps] << ",\t0";
-
-  // Emit all of the target independent flags...
+  // Collect all of the target-independent flags.
+  uint64_t Flags = 0;
   if (Inst.isPreISelOpcode)
-    OS << "|(1ULL<<MCID::PreISelOpcode)";
+    Flags |= 1ULL << MCID::PreISelOpcode;
   if (Inst.isPseudo)
-    OS << "|(1ULL<<MCID::Pseudo)";
+    Flags |= 1ULL << MCID::Pseudo;
   if (Inst.isMeta)
-    OS << "|(1ULL<<MCID::Meta)";
+    Flags |= 1ULL << MCID::Meta;
   if (Inst.isReturn)
-    OS << "|(1ULL<<MCID::Return)";
+    Flags |= 1ULL << MCID::Return;
   if (Inst.isEHScopeReturn)
-    OS << "|(1ULL<<MCID::EHScopeReturn)";
+    Flags |= 1ULL << MCID::EHScopeReturn;
   if (Inst.isBranch)
-    OS << "|(1ULL<<MCID::Branch)";
+    Flags |= 1ULL << MCID::Branch;
   if (Inst.isIndirectBranch)
-    OS << "|(1ULL<<MCID::IndirectBranch)";
+    Flags |= 1ULL << MCID::IndirectBranch;
   if (Inst.isCompare)
-    OS << "|(1ULL<<MCID::Compare)";
+    Flags |= 1ULL << MCID::Compare;
   if (Inst.isMoveImm)
-    OS << "|(1ULL<<MCID::MoveImm)";
+    Flags |= 1ULL << MCID::MoveImm;
   if (Inst.isMoveReg)
-    OS << "|(1ULL<<MCID::MoveReg)";
+    Flags |= 1ULL << MCID::MoveReg;
   if (Inst.isBitcast)
-    OS << "|(1ULL<<MCID::Bitcast)";
+    Flags |= 1ULL << MCID::Bitcast;
   if (Inst.isAdd)
-    OS << "|(1ULL<<MCID::Add)";
+    Flags |= 1ULL << MCID::Add;
   if (Inst.isTrap)
-    OS << "|(1ULL<<MCID::Trap)";
+    Flags |= 1ULL << MCID::Trap;
   if (Inst.isSelect)
-    OS << "|(1ULL<<MCID::Select)";
+    Flags |= 1ULL << MCID::Select;
   if (Inst.isBarrier)
-    OS << "|(1ULL<<MCID::Barrier)";
+    Flags |= 1ULL << MCID::Barrier;
   if (Inst.hasDelaySlot)
-    OS << "|(1ULL<<MCID::DelaySlot)";
+    Flags |= 1ULL << MCID::DelaySlot;
   if (Inst.isCall)
-    OS << "|(1ULL<<MCID::Call)";
+    Flags |= 1ULL << MCID::Call;
   if (Inst.canFoldAsLoad)
-    OS << "|(1ULL<<MCID::FoldableAsLoad)";
+    Flags |= 1ULL << MCID::FoldableAsLoad;
   if (Inst.mayLoad)
-    OS << "|(1ULL<<MCID::MayLoad)";
+    Flags |= 1ULL << MCID::MayLoad;
   if (Inst.mayStore)
-    OS << "|(1ULL<<MCID::MayStore)";
+    Flags |= 1ULL << MCID::MayStore;
   if (Inst.mayRaiseFPException)
-    OS << "|(1ULL<<MCID::MayRaiseFPException)";
+    Flags |= 1ULL << MCID::MayRaiseFPException;
   if (Inst.isPredicable)
-    OS << "|(1ULL<<MCID::Predicable)";
+    Flags |= 1ULL << MCID::Predicable;
   if (Inst.isConvertibleToThreeAddress)
-    OS << "|(1ULL<<MCID::ConvertibleTo3Addr)";
+    Flags |= 1ULL << MCID::ConvertibleTo3Addr;
   if (Inst.isCommutable)
-    OS << "|(1ULL<<MCID::Commutable)";
+    Flags |= 1ULL << MCID::Commutable;
   if (Inst.isTerminator)
-    OS << "|(1ULL<<MCID::Terminator)";
+    Flags |= 1ULL << MCID::Terminator;
   if (Inst.isReMaterializable)
-    OS << "|(1ULL<<MCID::Rematerializable)";
+    Flags |= 1ULL << MCID::Rematerializable;
   if (Inst.isNotDuplicable)
-    OS << "|(1ULL<<MCID::NotDuplicable)";
+    Flags |= 1ULL << MCID::NotDuplicable;
   if (Inst.Operands.hasOptionalDef)
-    OS << "|(1ULL<<MCID::HasOptionalDef)";
+    Flags |= 1ULL << MCID::HasOptionalDef;
   if (Inst.usesCustomInserter)
-    OS << "|(1ULL<<MCID::UsesCustomInserter)";
+    Flags |= 1ULL << MCID::UsesCustomInserter;
   if (Inst.hasPostISelHook)
-    OS << "|(1ULL<<MCID::HasPostISelHook)";
+    Flags |= 1ULL << MCID::HasPostISelHook;
   if (Inst.Operands.isVariadic)
-    OS << "|(1ULL<<MCID::Variadic)";
+    Flags |= 1ULL << MCID::Variadic;
   if (Inst.hasSideEffects)
-    OS << "|(1ULL<<MCID::UnmodeledSideEffects)";
+    Flags |= 1ULL << MCID::UnmodeledSideEffects;
   if (Inst.isAsCheapAsAMove)
-    OS << "|(1ULL<<MCID::CheapAsAMove)";
+    Flags |= 1ULL << MCID::CheapAsAMove;
   if (!Target.getAllowRegisterRenaming() || Inst.hasExtraSrcRegAllocReq)
-    OS << "|(1ULL<<MCID::ExtraSrcRegAllocReq)";
+    Flags |= 1ULL << MCID::ExtraSrcRegAllocReq;
   if (!Target.getAllowRegisterRenaming() || Inst.hasExtraDefRegAllocReq)
-    OS << "|(1ULL<<MCID::ExtraDefRegAllocReq)";
+    Flags |= 1ULL << MCID::ExtraDefRegAllocReq;
   if (Inst.isRegSequence)
-    OS << "|(1ULL<<MCID::RegSequence)";
+    Flags |= 1ULL << MCID::RegSequence;
   if (Inst.isExtractSubreg)
-    OS << "|(1ULL<<MCID::ExtractSubreg)";
+    Flags |= 1ULL << MCID::ExtractSubreg;
   if (Inst.isInsertSubreg)
-    OS << "|(1ULL<<MCID::InsertSubreg)";
+    Flags |= 1ULL << MCID::InsertSubreg;
   if (Inst.isConvergent)
-    OS << "|(1ULL<<MCID::Convergent)";
+    Flags |= 1ULL << MCID::Convergent;
   if (Inst.variadicOpsAreDefs)
-    OS << "|(1ULL<<MCID::VariadicOpsAreDefs)";
+    Flags |= 1ULL << MCID::VariadicOpsAreDefs;
   if (Inst.isAuthenticated)
-    OS << "|(1ULL<<MCID::Authenticated)";
+    Flags |= 1ULL << MCID::Authenticated;
 
   // Emit all of the target-specific flags...
   const BitsInit *TSF = Inst.TheDef->getValueAsBitsInit("TSFlags");
@@ -1407,11 +1450,23 @@ void InstrInfoEmitter::emitRecord(
   if (!Value)
     PrintFatalError(Inst.TheDef, "Invalid TSFlags bit in " + Inst.getName());
 
-  OS << ", 0x";
-  OS.write_hex(*Value);
-  OS << "ULL";
+  uint64_t FlagsAndImplicit =
+      MCInstrDesc::TableGenEncoding::encodeFlagsAndImplicit(Flags, Size,
+                                                            ImplicitOffset);
+  uint64_t OpcodeAndOperands =
+      MCInstrDesc::TableGenEncoding::encodeOpcodeAndOperands(
+          Num, MinOperands, DefOperands, SchedClass, 0);
 
-  OS << " },  // " << Inst.getName() << '\n';
+  OS << "    { MCInstrDesc::TableGenEncoding{}, 0x";
+  OS.write_hex(*Value);
+  OS << "ULL, 0x";
+  OS.write_hex(FlagsAndImplicit);
+  OS << "ULL, 0x";
+  OS.write_hex(OpcodeAndOperands);
+  OS << "ULL | (uint64_t(" << Target.getName() << "OpInfoBase + "
+     << OperandInfoOffset
+     << ") << MCInstrDesc::TableGenEncoding::OpInfoOffsetShift) },  // "
+     << Inst.getName() << '\n';
 }
 
 // emitEnums - Print out enum values for all of the instructions.

--- a/llvm/utils/gn/secondary/llvm/unittests/MC/BUILD.gn
+++ b/llvm/utils/gn/secondary/llvm/unittests/MC/BUILD.gn
@@ -14,6 +14,7 @@ unittest("MCTests") {
     "DwarfLineTableHeaders.cpp",
     "DwarfLineTables.cpp",
     "MCDisassemblerTest.cpp",
+    "MCInstrDescTest.cpp",
     "MCInstPrinter.cpp",
     "StringTableBuilderTest.cpp",
     "TargetRegistry.cpp",


### PR DESCRIPTION
Pack generated `MCInstrDesc` fields after `TSFlags` into two `uint64_t` words while keeping `Opcode`, `NumOperands`, `NumDefs`, and `Size` in fixed positions. `InstrInfoEmitter` pre-encodes the words and stores implicit-use and implicit-definition counts in a 16-bit header before each deduplicated nonempty implicit-register list; offset zero represents an empty list. TableGen validates the packed ranges, and `sizeof(MCInstrDesc)` remains statically checked at 24 bytes.

Across 21 generated instruction tables, table payload falls by 1,184,318 bytes; earlier arm64 llvm-mca and multicall descriptor arrays fall by 82,576 and 891,632 bytes respectively; tracker Clang file size falls from 137,673 to 137,507 KiB, with 0.03%-0.07% more retired instructions than the unpacked baseline and 0.02%-0.06% fewer than the previous packed layout.

Validated by rebuilding `llvm-tblgen`, all enabled target descriptor tables and consumers, running all 23 MCTests and 323 CodeGenTests, and running the affected TableGen tests plus a 421-test TableGen sweep (the only unavailable tests require `split-file`).

Work towards #202616

AI tool disclosure: Co-authored with OpenAI Codex.
