### PR TITLE
[Bazel] Key llvm-driver tools by package and target

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/driver.bzl
+++ b/utils/bazel/llvm-project-overlay/llvm/driver.bzl
@@ -117,18 +117,20 @@ def select_driver_tools(flag):
     return tools
 
 def _generate_driver_tools_def_impl(ctx):
-    # Depending on how the LLVM build files are included,
-    # it may or may not have the @llvm-project repo prefix.
-    # Compare just on the name. We could also include the package,
-    # but the name itself is unique in practice.
-    label_to_name = {Label(v).name: k for k, v in _TOOLS.items()}
+    label_to_name = {
+        (Label(v).package, Label(v).name): k
+        for k, v in _TOOLS.items()
+    }
 
     # Reverse sort by the *main* tool name, but keep aliases together.
     # This is consistent with how tools/llvm-driver/CMakeLists.txt does it,
     # and this makes sure that more specific tools are checked first.
     # For example, "clang-scan-deps" should not match "clang".
     tools = sorted(
-        [label_to_name[tool.label.name] for tool in ctx.attr.driver_tools],
+        [
+            label_to_name[(tool.label.package, tool.label.name)]
+            for tool in ctx.attr.driver_tools
+        ],
         reverse = True,
     )
     tool_alias_pairs = []


### PR DESCRIPTION
The llvm-driver rule previously keyed _TOOLS entries only by Label.name. Targets such as clang, clangd, and clang-tidy can use identical target names in different Bazel packages, so the name-only map can select the wrong LLVM_DRIVER_TOOL entry.

Key label_to_name by (Label.package, Label.name) and perform the same lookup for ctx.attr.driver_tools. This changes only tool selection while preserving the existing reverse sort and alias ordering.

This change has no binary-size effect.

Validation:

- bazel build @llvm-project//llvm --config=prebuilt --config=remote

- The resulting multicall binary dispatched clang-format, clang-tidy, clangd, clang, llvm-ar, and llvm-objdump to their expected --version output.

Work towards #202616

AI tool disclosure: Co-authored with OpenAI Codex.