### PR TITLE
[PassManager] Outline pipeline name printing

### DIFF
--- a/llvm/include/llvm/IR/PassManager.h
+++ b/llvm/include/llvm/IR/PassManager.h
@@ -68,6 +68,14 @@ template <typename DerivedT> struct InfoMixin {
     return Name;
   }
 };
+
+LLVM_ABI void
+printPassPipelineName(raw_ostream &OS,
+                      function_ref<StringRef(StringRef)> MapClassName2PassName,
+                      StringRef ClassName);
+LLVM_ABI void printAnalysisPassPipelineName(
+    raw_ostream &OS, function_ref<StringRef(StringRef)> MapClassName2PassName,
+    StringRef ClassName, bool IsInvalidate);
 } // namespace detail
 
 class Function;
@@ -89,9 +97,7 @@ template <typename DerivedT>
 struct PassInfoMixin : detail::InfoMixin<DerivedT> {
   void printPipeline(raw_ostream &OS,
                      function_ref<StringRef(StringRef)> MapClassName2PassName) {
-    StringRef ClassName = DerivedT::name();
-    auto PassName = MapClassName2PassName(ClassName);
-    OS << PassName;
+    detail::printPassPipelineName(OS, MapClassName2PassName, DerivedT::name());
   }
 
   // TODO: remove once out of tree users are updated.
@@ -936,9 +942,8 @@ struct RequireAnalysisPass
   }
   void printPipeline(raw_ostream &OS,
                      function_ref<StringRef(StringRef)> MapClassName2PassName) {
-    auto ClassName = AnalysisT::name();
-    auto PassName = MapClassName2PassName(ClassName);
-    OS << "require<" << PassName << '>';
+    detail::printAnalysisPassPipelineName(OS, MapClassName2PassName,
+                                          AnalysisT::name(), false);
   }
 };
 
@@ -961,9 +966,8 @@ struct InvalidateAnalysisPass
   }
   void printPipeline(raw_ostream &OS,
                      function_ref<StringRef(StringRef)> MapClassName2PassName) {
-    auto ClassName = AnalysisT::name();
-    auto PassName = MapClassName2PassName(ClassName);
-    OS << "invalidate<" << PassName << '>';
+    detail::printAnalysisPassPipelineName(OS, MapClassName2PassName,
+                                          AnalysisT::name(), true);
   }
 };
 

--- a/llvm/lib/IR/PassManager.cpp
+++ b/llvm/lib/IR/PassManager.cpp
@@ -15,6 +15,21 @@
 using namespace llvm;
 
 namespace llvm {
+namespace detail {
+void printPassPipelineName(
+    raw_ostream &OS, function_ref<StringRef(StringRef)> MapClassName2PassName,
+    StringRef ClassName) {
+  OS << MapClassName2PassName(ClassName);
+}
+
+void printAnalysisPassPipelineName(
+    raw_ostream &OS, function_ref<StringRef(StringRef)> MapClassName2PassName,
+    StringRef ClassName, bool IsInvalidate) {
+  OS << (IsInvalidate ? "invalidate<" : "require<")
+     << MapClassName2PassName(ClassName) << '>';
+}
+} // namespace detail
+
 // Explicit template instantiations and specialization defininitions for core
 // template typedefs.
 template class LLVM_EXPORT_TEMPLATE AllAnalysesOn<Module>;


### PR DESCRIPTION
PassInfoMixin, RequireAnalysisPass, and InvalidateAnalysisPass instantiate their raw_ostream formatting in every erased pass model. These methods are retained through pass-manager vtables even though pipeline printing is a diagnostic path.

The LLVM multicall binary shrinks from 161,570,320 to 161,471,536 bytes (-98,784, -0.061%).

Work towards #202616

AI tool disclosure: Co-authored with OpenAI Codex.