### PR TITLE
[clang] Optimize RecursiveASTVisitor instantiations for size

### DIFF
--- a/clang/include/clang/AST/RecursiveASTVisitor.h
+++ b/clang/include/clang/AST/RecursiveASTVisitor.h
@@ -153,6 +153,10 @@ isSameMethod([[maybe_unused]] FirstMethodPtrTy FirstMethodPtr,
 /// By default, this visitor preorder traverses the AST. If postorder traversal
 /// is needed, the \c shouldTraversePostOrder method needs to be overridden
 /// to return \c true.
+#ifdef __clang__
+#pragma clang attribute push(__attribute__((minsize)), apply_to = function)
+#endif
+
 template <typename Derived> class RecursiveASTVisitor {
 public:
   /// A queue used for performing data recursion over statements.
@@ -4349,6 +4353,10 @@ DEF_TRAVERSE_STMT(HLSLOutArgExpr, {})
 #undef DEF_TRAVERSE_STMT
 #undef TRAVERSE_STMT
 #undef TRAVERSE_STMT_BASE
+
+#ifdef __clang__
+#pragma clang attribute pop
+#endif
 
 #undef TRY_TO
 


### PR DESCRIPTION
RecursiveASTVisitor is a CRTP template instantiated by hundreds of Clang tools and checks. The optimizer currently duplicates large traversal functions in each instantiation.

Apply Clang minsize to every RecursiveASTVisitor member function. minsize enables size-oriented inlining and outlining for the generated traversal functions without changing RecursiveASTVisitor dispatch or traversal order.

In the stripped all-tools multicall binary, this reduces size from 152,475,496 bytes to 150,635,672 bytes, saving 1,839,824 bytes (1.207%).

Correctness validation:

- bazel build @llvm-project//llvm --config=prebuilt --config=remote

- clang-tidy --checks=* produced byte-identical 13,886-line output before and after the change on a 1,500-line generated C file.

Performance validation:

- The LLVM repository has no RecursiveASTVisitor benchmark target.

- hyperfine --warmup 3 --runs 15 measured clang-tidy --checks=* on the same file.

- Baseline user time: 435.5 ms; patched user time: 428.9 ms. The result shows no performance regression.

Work towards #202616

AI tool disclosure: Co-authored with OpenAI Codex.