### PR TITLE
[SelectionDAG] Compact generated SDNode descriptions

### DIFF
--- a/llvm/include/llvm/CodeGen/SDNodeInfo.h
+++ b/llvm/include/llvm/CodeGen/SDNodeInfo.h
@@ -44,8 +44,9 @@ enum SDTC : uint8_t {
   SDTCisSameSizeAs,
 };
 
-enum SDNF {
+enum SDNF : uint8_t {
   SDNFIsStrictFP,
+  SDNFIsMemOperand,
 };
 
 struct VTByHwModePair {
@@ -68,33 +69,46 @@ struct SDTypeConstraint {
 using SDNodeTSFlags = uint32_t;
 
 struct SDNodeDesc {
+  uint16_t NameOffset;
+  uint8_t TSFlags;
+  uint8_t Flags;
+
+  bool hasFlag(SDNF Flag) const { return Flags & (1 << Flag); }
+};
+
+static_assert(sizeof(SDNodeDesc) == 4,
+              "Keep target SDNode descriptions compact");
+
+struct SDNodeVerifyDesc {
   uint16_t NumResults;
   int16_t NumOperands;
   uint32_t Properties;
-  uint32_t Flags;
-  SDNodeTSFlags TSFlags;
-  unsigned NameOffset;
   unsigned ConstraintOffset;
   unsigned ConstraintCount;
 
   bool hasProperty(SDNP Property) const { return Properties & (1 << Property); }
+};
 
-  bool hasFlag(SDNF Flag) const { return Flags & (1 << Flag); }
+static_assert(sizeof(SDNodeVerifyDesc) == 16,
+              "Keep target SDNode verification descriptions compact");
+
+struct SDNodeVerifyInfo {
+  const SDNodeVerifyDesc *Descs;
+  const VTByHwModePair *VTByHwModeTable;
+  const SDTypeConstraint *Constraints;
 };
 
 class SDNodeInfo final {
   unsigned NumOpcodes;
   const SDNodeDesc *Descs;
   StringTable Names;
-  const VTByHwModePair *VTByHwModeTable;
-  const SDTypeConstraint *Constraints;
+  const SDNodeVerifyInfo *VerifyInfo;
 
 public:
   constexpr SDNodeInfo(unsigned NumOpcodes, const SDNodeDesc *Descs,
-                       StringTable Names, const VTByHwModePair *VTByHwModeTable,
-                       const SDTypeConstraint *Constraints)
+                       StringTable Names, const SDNodeVerifyInfo *VerifyInfo)
       : NumOpcodes(NumOpcodes), Descs(Descs), Names(Names),
-        VTByHwModeTable(VTByHwModeTable), Constraints(Constraints) {}
+        VerifyInfo(VerifyInfo) {}
 
   /// Returns true if there is a generated description for a node with the given
   /// target-specific opcode.
@@ -109,11 +123,26 @@ public:
     return Descs[Opcode - ISD::BUILTIN_OP_END];
   }
 
+#ifndef NDEBUG
+  /// Returns the verification description of a node with the given opcode.
+  const SDNodeVerifyDesc &getVerifyDesc(unsigned Opcode) const {
+    assert(hasDesc(Opcode));
+    assert(VerifyInfo);
+    return VerifyInfo->Descs[Opcode - ISD::BUILTIN_OP_END];
+  }
+
   /// Returns operand constraints for a node with the given opcode.
   ArrayRef<SDTypeConstraint> getConstraints(unsigned Opcode) const {
-    const SDNodeDesc &Desc = getDesc(Opcode);
-    return ArrayRef(&Constraints[Desc.ConstraintOffset], Desc.ConstraintCount);
+    const SDNodeVerifyDesc &Desc = getVerifyDesc(Opcode);
+    return ArrayRef(&VerifyInfo->Constraints[Desc.ConstraintOffset],
+                    Desc.ConstraintCount);
   }
+
+  const VTByHwModePair *getVTByHwModeTable() const {
+    assert(VerifyInfo);
+    return VerifyInfo->VTByHwModeTable;
+  }
+#endif
 
   /// Returns the name of the given target-specific opcode, suitable for
   /// debug printing.
@@ -123,6 +152,9 @@ public:
 
   LLVM_ABI void verifyNode(const SelectionDAG &DAG, const SDNode *N) const;
 };
+
+static_assert(sizeof(SDNodeInfo) == 5 * sizeof(void *),
+              "Keep target SDNode information compact");
 
 } // namespace llvm
 

--- a/llvm/include/llvm/CodeGen/SelectionDAGTargetInfo.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGTargetInfo.h
@@ -226,7 +226,7 @@ public:
 
   bool isTargetMemoryOpcode(unsigned Opcode) const override {
     if (GenNodeInfo.hasDesc(Opcode))
-      return GenNodeInfo.getDesc(Opcode).hasProperty(SDNPMemOperand);
+      return GenNodeInfo.getDesc(Opcode).hasFlag(SDNFIsMemOperand);
     return false;
   }
 

--- a/llvm/lib/CodeGen/SelectionDAG/SDNodeInfo.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SDNodeInfo.cpp
@@ -14,6 +14,8 @@
 
 using namespace llvm;
 
+#ifndef NDEBUG
+
 static void reportNodeError(const SelectionDAG &DAG, const SDNode *N,
                             const Twine &Msg) {
   std::string S;
@@ -70,7 +72,7 @@ public:
 } // namespace
 
 void SDNodeInfo::verifyNode(const SelectionDAG &DAG, const SDNode *N) const {
-  const SDNodeDesc &Desc = getDesc(N->getOpcode());
+  const SDNodeVerifyDesc &Desc = getVerifyDesc(N->getOpcode());
   bool HasChain = Desc.hasProperty(SDNPHasChain);
   bool HasOutGlue = Desc.hasProperty(SDNPOutGlue);
   bool HasInGlue = Desc.hasProperty(SDNPInGlue);
@@ -172,7 +174,7 @@ void SDNodeInfo::verifyNode(const SelectionDAG &DAG, const SDNode *N) const {
   auto GetConstraintVT = [&](const SDTypeConstraint &C) {
     if (!C.NumHwModes)
       return static_cast<MVT::SimpleValueType>(C.VT);
-    for (auto [Mode, VT] : ArrayRef(&VTByHwModeTable[C.VT], C.NumHwModes))
+    for (auto [Mode, VT] : ArrayRef(&getVTByHwModeTable()[C.VT], C.NumHwModes))
       if (Mode == VTHwMode)
         return VT;
     llvm_unreachable("No value type for this HW mode");
@@ -242,3 +244,9 @@ void SDNodeInfo::verifyNode(const SelectionDAG &DAG, const SDNode *N) const {
     }
   }
 }
+
+#else
+
+void SDNodeInfo::verifyNode(const SelectionDAG &, const SDNode *) const {}
+
+#endif // NDEBUG

--- a/llvm/test/TableGen/SDNodeInfoEmitter/advanced.td
+++ b/llvm/test/TableGen/SDNodeInfoEmitter/advanced.td
@@ -65,7 +65,14 @@ def my_node_3 : SDNode<
 // CHECK-NEXT:    "MyTargetISD::NODE_3\0"
 // CHECK-NEXT:    ;
 
-// CHECK:       static const VTByHwModePair MyTargetVTByHwModeTable[] = {
+// CHECK:       static const SDNodeDesc MyTargetSDNodeDescs[] = {
+// CHECK-NEXT:      {1, 0, 0}, // NODE_1
+// CHECK-NEXT:      {21, 42, 0|1<<SDNFIsMemOperand}, // NODE_2
+// CHECK-NEXT:      {41, 24, 0|1<<SDNFIsStrictFP}, // NODE_3
+// CHECK-NEXT:  };
+// CHECK-EMPTY:
+// CHECK-NEXT:  #ifndef NDEBUG
+// CHECK-NEXT:  static const VTByHwModePair MyTargetVTByHwModeTable[] = {
 // CHECK-NEXT:   /* dummy */ {0, MVT::INVALID_SIMPLE_VALUE_TYPE}
 // CHECK-NEXT:  };
 // CHECK-EMPTY:
@@ -87,12 +94,23 @@ def my_node_3 : SDNode<
 // CHECK-SAME:            {SDTCisVT, 0, 0, 0, MVT::i1},
 // CHECK-NEXT:  };
 // CHECK-EMPTY:
-// CHECK-NEXT:  static const SDNodeDesc MyTargetSDNodeDescs[] = {
-// CHECK-NEXT:          {1, 1, 0|1<<SDNPHasChain, 0, 0, 1, 0, 2}, // NODE_1
-// CHECK-NEXT:          {3, 1, 0|1<<SDNPVariadic|1<<SDNPMemOperand, 0, 42, 21, 11, 4}, // NODE_2
-// CHECK-NEXT:          {2, -1, 0|1<<SDNPHasChain|1<<SDNPOutGlue|1<<SDNPInGlue|1<<SDNPOptInGlue, 0|1<<SDNFIsStrictFP, 24, 41, 2, 13}, // NODE_3
+// CHECK-NEXT:  static const SDNodeVerifyDesc MyTargetSDNodeVerifyDescs[] = {
+// CHECK-NEXT:      {1, 1, 0|1<<SDNPHasChain, 0, 2}, // NODE_1
+// CHECK-NEXT:      {3, 1, 0|1<<SDNPVariadic|1<<SDNPMemOperand, 11, 4}, // NODE_2
+// CHECK-NEXT:      {2, -1, 0|1<<SDNPHasChain|1<<SDNPOutGlue|1<<SDNPInGlue|1<<SDNPOptInGlue, 2, 13}, // NODE_3
 // CHECK-NEXT:  };
 // CHECK-EMPTY:
-// CHECK-NEXT: static const SDNodeInfo MyTargetGenSDNodeInfo(
-// CHECK-NEXT:     /*NumOpcodes=*/3, MyTargetSDNodeDescs, MyTargetSDNodeNames,
-// CHECK-NEXT:     MyTargetVTByHwModeTable, MyTargetSDTypeConstraints);
+// CHECK-NEXT:  static const SDNodeVerifyInfo MyTargetSDNodeVerifyInfo = {
+// CHECK-NEXT:      MyTargetSDNodeVerifyDescs, MyTargetVTByHwModeTable,
+// CHECK-NEXT:      MyTargetSDTypeConstraints};
+// CHECK-NEXT:  #endif // NDEBUG
+// CHECK-EMPTY:
+// CHECK-NEXT:  #ifndef NDEBUG
+// CHECK-NEXT:  static const SDNodeInfo MyTargetGenSDNodeInfo(
+// CHECK-NEXT:      /*NumOpcodes=*/3, MyTargetSDNodeDescs, MyTargetSDNodeNames,
+// CHECK-NEXT:      &MyTargetSDNodeVerifyInfo);
+// CHECK-NEXT:  #else
+// CHECK-NEXT:  static const SDNodeInfo MyTargetGenSDNodeInfo(
+// CHECK-NEXT:      /*NumOpcodes=*/3, MyTargetSDNodeDescs, MyTargetSDNodeNames,
+// CHECK-NEXT:      nullptr);
+// CHECK-NEXT:  #endif // NDEBUG

--- a/llvm/test/TableGen/SDNodeInfoEmitter/ambiguous-constraints-1.td
+++ b/llvm/test/TableGen/SDNodeInfoEmitter/ambiguous-constraints-1.td
@@ -16,7 +16,12 @@ def my_node_b : SDNode<"MyTargetISD::NODE", SDTypeProfile<1, 0, [SDTCisVT<0, f32
 // CHECK-NEXT:    "MyTargetISD::NODE\0"
 // CHECK-NEXT:    ;
 
-// CHECK:       static const VTByHwModePair MyTargetVTByHwModeTable[] = {
+// CHECK:       static const SDNodeDesc MyTargetSDNodeDescs[] = {
+// CHECK-NEXT:      {1, 0, 0}, // NODE
+// CHECK-NEXT:  };
+// CHECK-EMPTY:
+// CHECK-NEXT:  #ifndef NDEBUG
+// CHECK-NEXT:  static const VTByHwModePair MyTargetVTByHwModeTable[] = {
 // CHECK-NEXT:   /* dummy */ {0, MVT::INVALID_SIMPLE_VALUE_TYPE}
 // CHECK-NEXT:  };
 // CHECK-EMPTY:
@@ -24,10 +29,21 @@ def my_node_b : SDNode<"MyTargetISD::NODE", SDTypeProfile<1, 0, [SDTCisVT<0, f32
 // CHECK-NEXT:    /* dummy */ {SDTCisVT, 0, 0, 0, MVT::INVALID_SIMPLE_VALUE_TYPE}
 // CHECK-NEXT:  };
 // CHECK-EMPTY:
-// CHECK-NEXT:  static const SDNodeDesc MyTargetSDNodeDescs[] = {
-// CHECK-NEXT:      {1, 0, 0, 0, 0, 1, 0, 0}, // NODE
+// CHECK-NEXT:  static const SDNodeVerifyDesc MyTargetSDNodeVerifyDescs[] = {
+// CHECK-NEXT:      {1, 0, 0, 0, 0}, // NODE
 // CHECK-NEXT:  };
 // CHECK-EMPTY:
+// CHECK-NEXT:  static const SDNodeVerifyInfo MyTargetSDNodeVerifyInfo = {
+// CHECK-NEXT:      MyTargetSDNodeVerifyDescs, MyTargetVTByHwModeTable,
+// CHECK-NEXT:      MyTargetSDTypeConstraints};
+// CHECK-NEXT:  #endif // NDEBUG
+// CHECK-EMPTY:
+// CHECK-NEXT:  #ifndef NDEBUG
 // CHECK-NEXT:  static const SDNodeInfo MyTargetGenSDNodeInfo(
 // CHECK-NEXT:      /*NumOpcodes=*/1, MyTargetSDNodeDescs, MyTargetSDNodeNames,
-// CHECK-NEXT:      MyTargetVTByHwModeTable, MyTargetSDTypeConstraints);
+// CHECK-NEXT:      &MyTargetSDNodeVerifyInfo);
+// CHECK-NEXT:  #else
+// CHECK-NEXT:  static const SDNodeInfo MyTargetGenSDNodeInfo(
+// CHECK-NEXT:      /*NumOpcodes=*/1, MyTargetSDNodeDescs, MyTargetSDNodeNames,
+// CHECK-NEXT:      nullptr);
+// CHECK-NEXT:  #endif // NDEBUG

--- a/llvm/test/TableGen/SDNodeInfoEmitter/ambiguous-constraints-2.td
+++ b/llvm/test/TableGen/SDNodeInfoEmitter/ambiguous-constraints-2.td
@@ -26,7 +26,13 @@ def my_node_2b : SDNode<"MyTargetISD::NODE_2", SDTypeProfile<1, 0, [SDTCisVT<0, 
 // CHECK-NEXT:    "MyTargetISD::NODE_2\0"
 // CHECK-NEXT:    ;
 
-// CHECK:       static const VTByHwModePair MyTargetVTByHwModeTable[] = {
+// CHECK:       static const SDNodeDesc MyTargetSDNodeDescs[] = {
+// CHECK-NEXT:      {1, 0, 0}, // NODE_1
+// CHECK-NEXT:      {21, 0, 0}, // NODE_2
+// CHECK-NEXT:  };
+// CHECK-EMPTY:
+// CHECK-NEXT:  #ifndef NDEBUG
+// CHECK-NEXT:  static const VTByHwModePair MyTargetVTByHwModeTable[] = {
 // CHECK-NEXT:   /* dummy */ {0, MVT::INVALID_SIMPLE_VALUE_TYPE}
 // CHECK-NEXT:  };
 // CHECK-EMPTY:
@@ -34,11 +40,22 @@ def my_node_2b : SDNode<"MyTargetISD::NODE_2", SDTypeProfile<1, 0, [SDTCisVT<0, 
 // CHECK-NEXT:    /* 0 */ {SDTCisVT, 0, 0, 0, MVT::i32},
 // CHECK-NEXT:  };
 // CHECK-EMPTY:
-// CHECK-NEXT:  static const SDNodeDesc MyTargetSDNodeDescs[] = {
-// CHECK-NEXT:      {1, 0, 0, 0, 0, 1, 0, 1}, // NODE_1
-// CHECK-NEXT:      {1, 0, 0, 0, 0, 21, 0, 0}, // NODE_2
+// CHECK-NEXT:  static const SDNodeVerifyDesc MyTargetSDNodeVerifyDescs[] = {
+// CHECK-NEXT:      {1, 0, 0, 0, 1}, // NODE_1
+// CHECK-NEXT:      {1, 0, 0, 0, 0}, // NODE_2
 // CHECK-NEXT:  };
 // CHECK-EMPTY:
+// CHECK-NEXT:  static const SDNodeVerifyInfo MyTargetSDNodeVerifyInfo = {
+// CHECK-NEXT:      MyTargetSDNodeVerifyDescs, MyTargetVTByHwModeTable,
+// CHECK-NEXT:      MyTargetSDTypeConstraints};
+// CHECK-NEXT:  #endif // NDEBUG
+// CHECK-EMPTY:
+// CHECK-NEXT:  #ifndef NDEBUG
 // CHECK-NEXT:  static const SDNodeInfo MyTargetGenSDNodeInfo(
 // CHECK-NEXT:      /*NumOpcodes=*/2, MyTargetSDNodeDescs, MyTargetSDNodeNames,
-// CHECK-NEXT:      MyTargetVTByHwModeTable, MyTargetSDTypeConstraints);
+// CHECK-NEXT:      &MyTargetSDNodeVerifyInfo);
+// CHECK-NEXT:  #else
+// CHECK-NEXT:  static const SDNodeInfo MyTargetGenSDNodeInfo(
+// CHECK-NEXT:      /*NumOpcodes=*/2, MyTargetSDNodeDescs, MyTargetSDNodeNames,
+// CHECK-NEXT:      nullptr);
+// CHECK-NEXT:  #endif // NDEBUG

--- a/llvm/test/TableGen/SDNodeInfoEmitter/hw-mode.td
+++ b/llvm/test/TableGen/SDNodeInfoEmitter/hw-mode.td
@@ -39,7 +39,14 @@ def my_node_3 : SDNode<
     ]>
 >;
 
-// CHECK:       static const VTByHwModePair MyTargetVTByHwModeTable[] = {
+// CHECK:       static const SDNodeDesc MyTargetSDNodeDescs[] = {
+// CHECK-NEXT:      {1, 0, 0}, // NODE_1
+// CHECK-NEXT:      {21, 0, 0}, // NODE_2
+// CHECK-NEXT:      {41, 0, 0}, // NODE_3
+// CHECK-NEXT:  };
+// CHECK-EMPTY:
+// CHECK-NEXT:  #ifndef NDEBUG
+// CHECK-NEXT:  static const VTByHwModePair MyTargetVTByHwModeTable[] = {
 // CHECK-NEXT:    /* 0 */ {0, MVT::i8}, {1, MVT::i1}, {2, MVT::i2}, {3, MVT::i4},
 // CHECK-NEXT:    /* 4 */ {1, MVT::i1},
 // CHECK-NEXT:    /* 5 */ {2, MVT::i2},
@@ -54,8 +61,13 @@ def my_node_3 : SDNode<
 // CHECK-SAME:            {SDTCVecEltisVT, 0, 0, 4, 0},
 // CHECK-NEXT:  };
 // CHECK-EMPTY:
-// CHECK-NEXT:  static const SDNodeDesc MyTargetSDNodeDescs[] = {
-// CHECK-NEXT:      {0, 5, 0, 0, 0, 1, 1, 5}, // NODE_1
-// CHECK-NEXT:      {1, 2, 0, 0, 0, 21, 3, 3}, // NODE_2
-// CHECK-NEXT:      {1, 0, 0, 0, 0, 41, 0, 1}, // NODE_3
+// CHECK-NEXT:  static const SDNodeVerifyDesc MyTargetSDNodeVerifyDescs[] = {
+// CHECK-NEXT:      {0, 5, 0, 1, 5}, // NODE_1
+// CHECK-NEXT:      {1, 2, 0, 3, 3}, // NODE_2
+// CHECK-NEXT:      {1, 0, 0, 0, 1}, // NODE_3
 // CHECK-NEXT:  };
+// CHECK-EMPTY:
+// CHECK-NEXT:  static const SDNodeVerifyInfo MyTargetSDNodeVerifyInfo = {
+// CHECK-NEXT:      MyTargetSDNodeVerifyDescs, MyTargetVTByHwModeTable,
+// CHECK-NEXT:      MyTargetSDTypeConstraints};
+// CHECK-NEXT:  #endif // NDEBUG

--- a/llvm/test/TableGen/SDNodeInfoEmitter/layout-errors.td
+++ b/llvm/test/TableGen/SDNodeInfoEmitter/layout-errors.td
@@ -1,0 +1,61 @@
+// RUN: rm -rf %t && split-file %s %t
+// RUN: not llvm-tblgen -gen-sd-node-info -I %p/../../../include \
+// RUN:   %t/tsflags.td -o /dev/null 2>&1 | FileCheck %t/tsflags.td
+// RUN: not llvm-tblgen -gen-sd-node-info -I %p/../../../include \
+// RUN:   %t/name-offset.td -o /dev/null 2>&1 | FileCheck %t/name-offset.td
+// RUN: not llvm-tblgen -gen-sd-node-info -I %p/../../../include \
+// RUN:   %t/result-count.td -o /dev/null 2>&1 | FileCheck %t/result-count.td
+// RUN: not llvm-tblgen -gen-sd-node-info -I %p/../../../include \
+// RUN:   %t/operand-count.td -o /dev/null 2>&1 | FileCheck %t/operand-count.td
+
+//--- tsflags.td
+include "llvm/Target/Target.td"
+
+def MyTarget : Target;
+
+let TSFlags = 256 in
+def bad : SDNode<"MyTargetISD::BAD", SDTypeProfile<0, 0, []>>;
+// CHECK: error: SDNode TSFlags value 256 does not fit in 8 bits
+
+//--- name-offset.td
+include "llvm/Target/Target.td"
+
+def MyTarget : Target;
+
+defvar S2 = !strconcat("x", "x");
+defvar S4 = !strconcat(S2, S2);
+defvar S8 = !strconcat(S4, S4);
+defvar S16 = !strconcat(S8, S8);
+defvar S32 = !strconcat(S16, S16);
+defvar S64 = !strconcat(S32, S32);
+defvar S128 = !strconcat(S64, S64);
+defvar S256 = !strconcat(S128, S128);
+defvar S512 = !strconcat(S256, S256);
+defvar S1024 = !strconcat(S512, S512);
+defvar S2048 = !strconcat(S1024, S1024);
+defvar S4096 = !strconcat(S2048, S2048);
+defvar S8192 = !strconcat(S4096, S4096);
+defvar S16384 = !strconcat(S8192, S8192);
+defvar S32768 = !strconcat(S16384, S16384);
+defvar S65536 = !strconcat(S32768, S32768);
+
+def first :
+    SDNode<!strconcat("MyTargetISD::A", S65536), SDTypeProfile<0, 0, []>>;
+def bad : SDNode<"MyTargetISD::Z", SDTypeProfile<0, 0, []>>;
+// CHECK: error: generated SDNode name offset {{[0-9]+}} does not fit in 16 bits
+
+//--- result-count.td
+include "llvm/Target/Target.td"
+
+def MyTarget : Target;
+
+def bad : SDNode<"MyTargetISD::BAD", SDTypeProfile<65536, 0, []>>;
+// CHECK: error: SDNode result count 65536 does not fit in 16 bits
+
+//--- operand-count.td
+include "llvm/Target/Target.td"
+
+def MyTarget : Target;
+
+def bad : SDNode<"MyTargetISD::BAD", SDTypeProfile<0, 32768, []>>;
+// CHECK: error: SDNode operand count 32768 does not fit in 16 bits

--- a/llvm/test/TableGen/SDNodeInfoEmitter/namespace.td
+++ b/llvm/test/TableGen/SDNodeInfoEmitter/namespace.td
@@ -23,16 +23,31 @@ def node_2 : SDNode<"MyCustomISD::NODE", SDTypeProfile<0, 1, [SDTCisVT<0, i2>]>>
 // EMPTY-NEXT:     "\0"
 // EMPTY-NEXT:     ;
 
+// EMPTY:        static const SDNodeDesc MyTargetSDNodeDescs[] = {
+// EMPTY-NEXT:   };
+// EMPTY-EMPTY:
+// EMPTY-NEXT:   #ifndef NDEBUG
 // EMPTY:        static const SDTypeConstraint MyTargetSDTypeConstraints[] = {
 // EMPTY-NEXT:     /* dummy */ {SDTCisVT, 0, 0, 0, MVT::INVALID_SIMPLE_VALUE_TYPE}
 // EMPTY-NEXT:   };
 // EMPTY-EMPTY:
-// EMPTY-NEXT:   static const SDNodeDesc MyTargetSDNodeDescs[] = {
+// EMPTY-NEXT:   static const SDNodeVerifyDesc MyTargetSDNodeVerifyDescs[] = {
 // EMPTY-NEXT:   };
 // EMPTY-EMPTY:
+// EMPTY-NEXT:   static const SDNodeVerifyInfo MyTargetSDNodeVerifyInfo = {
+// EMPTY-NEXT:       MyTargetSDNodeVerifyDescs, MyTargetVTByHwModeTable,
+// EMPTY-NEXT:       MyTargetSDTypeConstraints};
+// EMPTY-NEXT:   #endif // NDEBUG
+// EMPTY-EMPTY:
+// EMPTY-NEXT:   #ifndef NDEBUG
 // EMPTY-NEXT:   static const SDNodeInfo MyTargetGenSDNodeInfo(
 // EMPTY-NEXT:       /*NumOpcodes=*/0, MyTargetSDNodeDescs, MyTargetSDNodeNames,
-// EMPTY-NEXT:       MyTargetVTByHwModeTable, MyTargetSDTypeConstraints);
+// EMPTY-NEXT:       &MyTargetSDNodeVerifyInfo);
+// EMPTY-NEXT:   #else
+// EMPTY-NEXT:   static const SDNodeInfo MyTargetGenSDNodeInfo(
+// EMPTY-NEXT:       /*NumOpcodes=*/0, MyTargetSDNodeDescs, MyTargetSDNodeNames,
+// EMPTY-NEXT:       nullptr);
+// EMPTY-NEXT:   #endif // NDEBUG
 
 // COMMON:       namespace llvm::[[NS]] {
 // COMMON-EMPTY:
@@ -49,7 +64,13 @@ def node_2 : SDNode<"MyCustomISD::NODE", SDTypeProfile<0, 1, [SDTCisVT<0, i2>]>>
 // COMMON-NEXT:    "[[NS]]::NODE\0"
 // COMMON-NEXT:    ;
 
-// COMMON:       static const VTByHwModePair MyTargetVTByHwModeTable[] = {
+// COMMON:       static const SDNodeDesc MyTargetSDNodeDescs[] = {
+// TARGET-NEXT:      {1, 0, 0}, // NODE
+// CUSTOM-NEXT:      {1, 0, 0}, // NODE
+// COMMON-NEXT:  };
+// COMMON-EMPTY:
+// COMMON-NEXT:  #ifndef NDEBUG
+// COMMON-NEXT:  static const VTByHwModePair MyTargetVTByHwModeTable[] = {
 // COMMON-NEXT:    /* dummy */ {0, MVT::INVALID_SIMPLE_VALUE_TYPE}
 // COMMON-NEXT:  };
 
@@ -58,11 +79,22 @@ def node_2 : SDNode<"MyCustomISD::NODE", SDTypeProfile<0, 1, [SDTCisVT<0, i2>]>>
 // CUSTOM-NEXT:    /* 0 */ {SDTCisVT, 0, 0, 0, MVT::i2},
 // COMMON-NEXT:  };
 // COMMON-EMPTY:
-// COMMON-NEXT:  static const SDNodeDesc MyTargetSDNodeDescs[] = {
-// TARGET-NEXT:      {1, 0, 0, 0, 0, 1, 0, 1}, // NODE
-// CUSTOM-NEXT:      {0, 1, 0, 0, 0, 1, 0, 1}, // NODE
+// COMMON-NEXT:  static const SDNodeVerifyDesc MyTargetSDNodeVerifyDescs[] = {
+// TARGET-NEXT:      {1, 0, 0, 0, 1}, // NODE
+// CUSTOM-NEXT:      {0, 1, 0, 0, 1}, // NODE
 // COMMON-NEXT:  };
 // COMMON-EMPTY:
+// COMMON-NEXT:  static const SDNodeVerifyInfo MyTargetSDNodeVerifyInfo = {
+// COMMON-NEXT:      MyTargetSDNodeVerifyDescs, MyTargetVTByHwModeTable,
+// COMMON-NEXT:      MyTargetSDTypeConstraints};
+// COMMON-NEXT:  #endif // NDEBUG
+// COMMON-EMPTY:
+// COMMON-NEXT:  #ifndef NDEBUG
 // COMMON-NEXT:  static const SDNodeInfo MyTargetGenSDNodeInfo(
 // COMMON-NEXT:      /*NumOpcodes=*/1, MyTargetSDNodeDescs, MyTargetSDNodeNames,
-// COMMON-NEXT:      MyTargetVTByHwModeTable, MyTargetSDTypeConstraints);
+// COMMON-NEXT:      &MyTargetSDNodeVerifyInfo);
+// COMMON-NEXT:  #else
+// COMMON-NEXT:  static const SDNodeInfo MyTargetGenSDNodeInfo(
+// COMMON-NEXT:      /*NumOpcodes=*/1, MyTargetSDNodeDescs, MyTargetSDNodeNames,
+// COMMON-NEXT:      nullptr);
+// COMMON-NEXT:  #endif // NDEBUG

--- a/llvm/test/TableGen/SDNodeInfoEmitter/no-nodes.td
+++ b/llvm/test/TableGen/SDNodeInfoEmitter/no-nodes.td
@@ -35,6 +35,10 @@ def MyTarget : Target;
 // CHECK-NEXT:  static constexpr llvm::StringTable
 // CHECK-NEXT:  MyTargetSDNodeNames = MyTargetSDNodeNamesStorage;
 // CHECK-EMPTY:
+// CHECK-NEXT:  static const SDNodeDesc MyTargetSDNodeDescs[] = {
+// CHECK-NEXT:  };
+// CHECK-EMPTY:
+// CHECK-NEXT:  #ifndef NDEBUG
 // CHECK-NEXT:  static const VTByHwModePair MyTargetVTByHwModeTable[] = {
 // CHECK-NEXT:   /* dummy */ {0, MVT::INVALID_SIMPLE_VALUE_TYPE}
 // CHECK-NEXT:  };
@@ -43,12 +47,23 @@ def MyTarget : Target;
 // CHECK-NEXT:    /* dummy */ {SDTCisVT, 0, 0, 0, MVT::INVALID_SIMPLE_VALUE_TYPE}
 // CHECK-NEXT:  };
 // CHECK-EMPTY:
-// CHECK-NEXT:  static const SDNodeDesc MyTargetSDNodeDescs[] = {
+// CHECK-NEXT:  static const SDNodeVerifyDesc MyTargetSDNodeVerifyDescs[] = {
 // CHECK-NEXT:  };
 // CHECK-EMPTY:
+// CHECK-NEXT:  static const SDNodeVerifyInfo MyTargetSDNodeVerifyInfo = {
+// CHECK-NEXT:      MyTargetSDNodeVerifyDescs, MyTargetVTByHwModeTable,
+// CHECK-NEXT:      MyTargetSDTypeConstraints};
+// CHECK-NEXT:  #endif // NDEBUG
+// CHECK-EMPTY:
+// CHECK-NEXT:  #ifndef NDEBUG
 // CHECK-NEXT:  static const SDNodeInfo MyTargetGenSDNodeInfo(
 // CHECK-NEXT:      /*NumOpcodes=*/0, MyTargetSDNodeDescs, MyTargetSDNodeNames,
-// CHECK-NEXT:      MyTargetVTByHwModeTable, MyTargetSDTypeConstraints);
+// CHECK-NEXT:      &MyTargetSDNodeVerifyInfo);
+// CHECK-NEXT:  #else
+// CHECK-NEXT:  static const SDNodeInfo MyTargetGenSDNodeInfo(
+// CHECK-NEXT:      /*NumOpcodes=*/0, MyTargetSDNodeDescs, MyTargetSDNodeNames,
+// CHECK-NEXT:      nullptr);
+// CHECK-NEXT:  #endif // NDEBUG
 // CHECK-EMPTY:
 // CHECK-NEXT:  } // namespace llvm
 // CHECK-EMPTY:

--- a/llvm/test/TableGen/SDNodeInfoEmitter/skipped-nodes.td
+++ b/llvm/test/TableGen/SDNodeInfoEmitter/skipped-nodes.td
@@ -74,17 +74,33 @@ def node_5b : SDNode<"MyTargetISD::NODE_5", SDTypeProfile<0, 0, []>, [SDNPHasCha
 // CHECK-NEXT:    "MyTargetISD::COMPAT\0"
 // CHECK-NEXT:    ;
 
+// CHECK:       static const SDNodeDesc MyTargetSDNodeDescs[] = {
+// CHECK-NEXT:      {1, 0, 0}, // COMPAT
+// CHECK-NEXT:  };
+// CHECK-EMPTY:
+// CHECK-NEXT:  #ifndef NDEBUG
 // CHECK:       static const SDTypeConstraint MyTargetSDTypeConstraints[] = {
 // CHECK-NEXT:    /* dummy */ {SDTCisVT, 0, 0, 0, MVT::INVALID_SIMPLE_VALUE_TYPE}
 // CHECK-NEXT:  };
 // CHECK-EMPTY:
-// CHECK-NEXT:  static const SDNodeDesc MyTargetSDNodeDescs[] = {
-// CHECK-NEXT:      {1, -1, 0, 0, 0, 1, 0, 0}, // COMPAT
+// CHECK-NEXT:  static const SDNodeVerifyDesc MyTargetSDNodeVerifyDescs[] = {
+// CHECK-NEXT:      {1, -1, 0, 0, 0}, // COMPAT
 // CHECK-NEXT:  };
 // CHECK-EMPTY:
+// CHECK-NEXT:  static const SDNodeVerifyInfo MyTargetSDNodeVerifyInfo = {
+// CHECK-NEXT:      MyTargetSDNodeVerifyDescs, MyTargetVTByHwModeTable,
+// CHECK-NEXT:      MyTargetSDTypeConstraints};
+// CHECK-NEXT:  #endif // NDEBUG
+// CHECK-EMPTY:
+// CHECK-NEXT:  #ifndef NDEBUG
 // CHECK-NEXT:  static const SDNodeInfo MyTargetGenSDNodeInfo(
 // CHECK-NEXT:      /*NumOpcodes=*/1, MyTargetSDNodeDescs, MyTargetSDNodeNames,
-// CHECK-NEXT:      MyTargetVTByHwModeTable, MyTargetSDTypeConstraints);
+// CHECK-NEXT:      &MyTargetSDNodeVerifyInfo);
+// CHECK-NEXT:  #else
+// CHECK-NEXT:  static const SDNodeInfo MyTargetGenSDNodeInfo(
+// CHECK-NEXT:      /*NumOpcodes=*/1, MyTargetSDNodeDescs, MyTargetSDNodeNames,
+// CHECK-NEXT:      nullptr);
+// CHECK-NEXT:  #endif // NDEBUG
 
 def compat_a : SDNode<"MyTargetISD::COMPAT", SDTypeProfile<1, -1, []>>;
 def compat_b : SDNode<"MyTargetISD::COMPAT", SDTypeProfile<1, -1, [SDTCisVT<0, untyped>]>>;

--- a/llvm/test/TableGen/SDNodeInfoEmitter/trivial-node.td
+++ b/llvm/test/TableGen/SDNodeInfoEmitter/trivial-node.td
@@ -21,7 +21,12 @@ def my_noop : SDNode<"MyTargetISD::NOOP", SDTypeProfile<0, 0, []>>;
 // CHECK-NEXT:    "MyTargetISD::NOOP\0"
 // CHECK-NEXT:    ;
 
-// CHECK:       static const VTByHwModePair MyTargetVTByHwModeTable[] = {
+// CHECK:       static const SDNodeDesc MyTargetSDNodeDescs[] = {
+// CHECK-NEXT:      {1, 0, 0}, // NOOP
+// CHECK-NEXT:  };
+// CHECK-EMPTY:
+// CHECK-NEXT:  #ifndef NDEBUG
+// CHECK-NEXT:  static const VTByHwModePair MyTargetVTByHwModeTable[] = {
 // CHECK-NEXT:   /* dummy */ {0, MVT::INVALID_SIMPLE_VALUE_TYPE}
 // CHECK-NEXT:  };
 // CHECK-EMPTY:
@@ -29,10 +34,21 @@ def my_noop : SDNode<"MyTargetISD::NOOP", SDTypeProfile<0, 0, []>>;
 // CHECK-NEXT:    /* dummy */ {SDTCisVT, 0, 0, 0, MVT::INVALID_SIMPLE_VALUE_TYPE}
 // CHECK-NEXT:  };
 // CHECK-EMPTY:
-// CHECK-NEXT:  static const SDNodeDesc MyTargetSDNodeDescs[] = {
-// CHECK-NEXT:      {0, 0, 0, 0, 0, 1, 0, 0}, // NOOP
+// CHECK-NEXT:  static const SDNodeVerifyDesc MyTargetSDNodeVerifyDescs[] = {
+// CHECK-NEXT:      {0, 0, 0, 0, 0}, // NOOP
 // CHECK-NEXT:  };
 // CHECK-EMPTY:
+// CHECK-NEXT:  static const SDNodeVerifyInfo MyTargetSDNodeVerifyInfo = {
+// CHECK-NEXT:      MyTargetSDNodeVerifyDescs, MyTargetVTByHwModeTable,
+// CHECK-NEXT:      MyTargetSDTypeConstraints};
+// CHECK-NEXT:  #endif // NDEBUG
+// CHECK-EMPTY:
+// CHECK-NEXT:  #ifndef NDEBUG
 // CHECK-NEXT:  static const SDNodeInfo MyTargetGenSDNodeInfo(
 // CHECK-NEXT:      /*NumOpcodes=*/1, MyTargetSDNodeDescs, MyTargetSDNodeNames,
-// CHECK-NEXT:      MyTargetVTByHwModeTable, MyTargetSDTypeConstraints);
+// CHECK-NEXT:      &MyTargetSDNodeVerifyInfo);
+// CHECK-NEXT:  #else
+// CHECK-NEXT:  static const SDNodeInfo MyTargetGenSDNodeInfo(
+// CHECK-NEXT:      /*NumOpcodes=*/1, MyTargetSDNodeDescs, MyTargetSDNodeNames,
+// CHECK-NEXT:      nullptr);
+// CHECK-NEXT:  #endif // NDEBUG

--- a/llvm/utils/TableGen/SDNodeInfoEmitter.cpp
+++ b/llvm/utils/TableGen/SDNodeInfoEmitter.cpp
@@ -10,6 +10,7 @@
 #include "Common/CodeGenDAGPatterns.h" // For SDNodeInfo.
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/MathExtras.h"
 #include "llvm/TableGen/CodeGenHelpers.h"
 #include "llvm/TableGen/Error.h"
 #include "llvm/TableGen/StringToOffsetTable.h"
@@ -337,10 +338,45 @@ SDNodeInfoEmitter::emitTypeConstraints(raw_ostream &OS) const {
 }
 
 static void emitDesc(raw_ostream &OS, StringRef EnumName,
-                     ArrayRef<SDNodeInfo> Nodes, unsigned NameOffset,
-                     unsigned ConstraintsOffset, unsigned ConstraintCount) {
+                     ArrayRef<SDNodeInfo> Nodes, unsigned NameOffset) {
   assert(haveCompatibleDescriptions(Nodes));
   const SDNodeInfo &N = Nodes.front();
+
+  if (!isUInt<16>(NameOffset))
+    PrintFatalError(N.getRecord()->getLoc(), "generated SDNode name offset " +
+                                                 Twine(NameOffset) +
+                                                 " does not fit in 16 bits");
+  if (!isUInt<8>(N.getTSFlags()))
+    PrintFatalError(N.getRecord()->getLoc(), "SDNode TSFlags value " +
+                                                 Twine(N.getTSFlags()) +
+                                                 " does not fit in 8 bits");
+
+  OS << "    {" << NameOffset << ", " << N.getTSFlags() << ", 0";
+
+  if (N.isStrictFP())
+    OS << "|1<<SDNFIsStrictFP";
+  if (N.getProperties() & (1 << SDNPMemOperand))
+    OS << "|1<<SDNFIsMemOperand";
+
+  OS << "}, // " << EnumName << '\n';
+}
+
+static void emitVerifyDesc(raw_ostream &OS, StringRef EnumName,
+                           ArrayRef<SDNodeInfo> Nodes,
+                           unsigned ConstraintsOffset,
+                           unsigned ConstraintCount) {
+  assert(haveCompatibleDescriptions(Nodes));
+  const SDNodeInfo &N = Nodes.front();
+
+  if (!isUInt<16>(N.getNumResults()))
+    PrintFatalError(N.getRecord()->getLoc(), "SDNode result count " +
+                                                 Twine(N.getNumResults()) +
+                                                 " does not fit in 16 bits");
+  if (!isInt<16>(N.getNumOperands()))
+    PrintFatalError(N.getRecord()->getLoc(), "SDNode operand count " +
+                                                 Twine(N.getNumOperands()) +
+                                                 " does not fit in 16 bits");
+
   OS << "    {" << N.getNumResults() << ", " << N.getNumOperands() << ", 0";
 
   // Emitted properties must be kept in sync with haveCompatibleDescriptions.
@@ -358,12 +394,8 @@ static void emitDesc(raw_ostream &OS, StringRef EnumName,
   if (Properties & (1 << SDNPMemOperand))
     OS << "|1<<SDNPMemOperand";
 
-  OS << ", 0";
-  if (N.isStrictFP())
-    OS << "|1<<SDNFIsStrictFP";
-
-  OS << formatv(", {}, {}, {}, {}}, // {}\n", N.getTSFlags(), NameOffset,
-                ConstraintsOffset, ConstraintCount, EnumName);
+  OS << formatv(", {}, {}}, // {}\n", ConstraintsOffset, ConstraintCount,
+                EnumName);
 }
 
 void SDNodeInfoEmitter::emitDescs(raw_ostream &OS) const {
@@ -373,21 +405,46 @@ void SDNodeInfoEmitter::emitDescs(raw_ostream &OS) const {
   NamespaceEmitter NS(OS, "llvm");
 
   std::vector<unsigned> NameOffsets = emitNodeNames(OS);
-  std::vector<std::pair<unsigned, unsigned>> ConstraintOffsetsAndCounts =
-      emitTypeConstraints(OS);
 
   OS << "static const SDNodeDesc " << TargetName << "SDNodeDescs[] = {\n";
 
-  for (const auto &[NameAndNodes, NameOffset, ConstraintOffsetAndCount] :
-       zip_equal(NodesByName, NameOffsets, ConstraintOffsetsAndCounts))
-    emitDesc(OS, NameAndNodes.first, NameAndNodes.second, NameOffset,
-             ConstraintOffsetAndCount.first, ConstraintOffsetAndCount.second);
+  for (const auto &[NameAndNodes, NameOffset] :
+       zip_equal(NodesByName, NameOffsets))
+    emitDesc(OS, NameAndNodes.first, NameAndNodes.second, NameOffset);
 
   OS << "};\n\n";
 
-  OS << formatv("static const SDNodeInfo {0}GenSDNodeInfo(\n"
+  OS << "#ifndef NDEBUG\n";
+
+  std::vector<std::pair<unsigned, unsigned>> ConstraintOffsetsAndCounts =
+      emitTypeConstraints(OS);
+
+  OS << "static const SDNodeVerifyDesc " << TargetName
+     << "SDNodeVerifyDescs[] = {\n";
+
+  for (const auto &[NameAndNodes, ConstraintOffsetAndCount] :
+       zip_equal(NodesByName, ConstraintOffsetsAndCounts))
+    emitVerifyDesc(OS, NameAndNodes.first, NameAndNodes.second,
+                   ConstraintOffsetAndCount.first,
+                   ConstraintOffsetAndCount.second);
+
+  OS << "};\n\n";
+
+  OS << formatv("static const SDNodeVerifyInfo {0}SDNodeVerifyInfo = {\n"
+                "    {0}SDNodeVerifyDescs, {0}VTByHwModeTable,\n"
+                "    {0}SDTypeConstraints};\n",
+                TargetName);
+  OS << "#endif // NDEBUG\n\n";
+
+  OS << formatv("#ifndef NDEBUG\n"
+                "static const SDNodeInfo {0}GenSDNodeInfo(\n"
                 "    /*NumOpcodes=*/{1}, {0}SDNodeDescs, {0}SDNodeNames,\n"
-                "    {0}VTByHwModeTable, {0}SDTypeConstraints);\n",
+                "    &{0}SDNodeVerifyInfo);\n"
+                "#else\n"
+                "static const SDNodeInfo {0}GenSDNodeInfo(\n"
+                "    /*NumOpcodes=*/{1}, {0}SDNodeDescs, {0}SDNodeNames,\n"
+                "    nullptr);\n"
+                "#endif // NDEBUG\n",
                 TargetName, NodesByName.size());
 }
 


### PR DESCRIPTION
SDNodeDesc stores node verification properties and type constraints in every release build even though SDNodeInfo::verifyNode only consumes them in assertion-enabled builds. Split those fields into SDNodeVerifyDesc and emit the verification descriptions, constraints, and hardware-mode tables only when assertions are enabled.

Keep the release SDNodeDesc at four bytes: a 16-bit name offset, an 8-bit target flag value, and flags for strict floating-point and memory nodes. Add TableGen diagnostics for each narrowed field. Consolidate the verification table pointers so SDNodeInfo decreases from 48 to 40 bytes on 64-bit targets. Add compile-time assertions for SDNodeDesc, SDNodeVerifyDesc, and SDNodeInfo.

Across all 23 generated targets, release SDNode metadata decreases from 85,812 to 10,168 bytes, saving 75,644 bytes (88.2%). In the LLVM 22 Bazel build, stripped llc decreases from 78,530,560 to 78,497,384 bytes, saving 33,176 bytes (0.042%). The stripped multicall binary decreases from 142,924,144 to 142,889,168 bytes, saving 34,976 bytes.

A 12-pair alternating llc -O0 compile of tramp3d measured 1.0117 seconds mean user CPU before the change and 0.9975 seconds after it. Mean wall time was 1.2317 seconds before and 1.2333 seconds after. Both binaries produced byte-identical Mach-O objects.

Validate all nine SDNodeInfoEmitter tests with llvm-tblgen and FileCheck, build LLVMSelectionDAG with assertions enabled, and build the complete release multicall binary.

Work towards #202616

AI tool disclosure: Co-authored with OpenAI Codex.