### PR TITLE
[clang] Use DynamicRecursiveASTVisitor for AST listing

### DIFF
--- a/clang/lib/Frontend/ASTConsumers.cpp
+++ b/clang/lib/Frontend/ASTConsumers.cpp
@@ -13,6 +13,7 @@
 #include "clang/Frontend/ASTConsumers.h"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/AST/PrettyPrinter.h"
 #include "clang/AST/RecordLayout.h"
 #include "clang/AST/RecursiveASTVisitor.h"
@@ -142,18 +143,18 @@ namespace {
   };
 
   class ASTDeclNodeLister : public ASTConsumer,
-                     public RecursiveASTVisitor<ASTDeclNodeLister> {
+                            public DynamicRecursiveASTVisitor {
   public:
     ASTDeclNodeLister(raw_ostream *Out = nullptr)
-        : Out(Out ? *Out : llvm::outs()) {}
+        : Out(Out ? *Out : llvm::outs()) {
+      ShouldWalkTypesOfTypeLocs = false;
+    }
 
     void HandleTranslationUnit(ASTContext &Context) override {
       TraverseDecl(Context.getTranslationUnitDecl());
     }
 
-    bool shouldWalkTypesOfTypeLocs() const { return false; }
-
-    bool VisitNamedDecl(NamedDecl *D) {
+    bool VisitNamedDecl(NamedDecl *D) override {
       D->printQualifiedName(Out);
       Out << '\n';
       return true;


### PR DESCRIPTION
Replace `ASTDeclNodeLister`'s CRTP `RecursiveASTVisitor` with
`DynamicRecursiveASTVisitor` while keeping `ASTPrinter` and
`ASTDeclNodeLister` separate. Set `ShouldWalkTypesOfTypeLocs` to false to
preserve the previous traversal.

In identical arm64 release builds, standalone clang shrinks by 251,840 bytes
(0.215%), stripped clang by 149,488 bytes, and `ASTConsumers.cpp.o` by 153,352
bytes; linked `__TEXT` falls by 147,456 bytes and linked fixups increase by
1,040.

The `-ast-list` output is byte-identical on the existing clang-check input and
`ASTConsumers.cpp` (150,918 lines); two reversed-order ten-run timing passes
have overlapping wall-time distributions and a 0.4% combined mean user
CPU-time increase.

Work towards #202616

AI tool disclosure: Co-authored with OpenAI Codex.
