### PR TITLE
[clang][Tooling] Reuse standard-library symbol descriptors

### DIFF
--- a/clang/lib/Tooling/Inclusions/Stdlib/StandardLibrary.cpp
+++ b/clang/lib/Tooling/Inclusions/Stdlib/StandardLibrary.cpp
@@ -10,11 +10,15 @@
 #include "clang/AST/Decl.h"
 #include "clang/Basic/LangOptions.h"
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/Enum.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/ErrorHandling.h"
+#include <cstdint>
+#include <limits>
 #include <optional>
+#include <utility>
 
 namespace clang {
 namespace tooling {
@@ -23,6 +27,72 @@ namespace stdlib {
 namespace {
 // Symbol name -> Symbol::ID, within a namespace.
 using NSSymbolMap = llvm::DenseMap<llvm::StringRef, unsigned>;
+
+using SymbolNamespaceLength = uint8_t;
+using SymbolMappingDef = llvm::EnumStringDef<SymbolNamespaceLength>;
+using SymbolMapping = llvm::EnumString<SymbolNamespaceLength>;
+using SymbolMappingTable = llvm::EnumStrings<SymbolNamespaceLength>;
+static_assert(sizeof(SymbolMapping) == 4,
+              "update the standard symbol table partition size");
+
+template <size_t Size>
+constexpr SymbolNamespaceLength getSymbolNamespaceLength(const char (&)[Size]) {
+  static_assert(Size - 1 <= std::numeric_limits<SymbolNamespaceLength>::max(),
+                "symbol namespace length does not fit in one byte");
+  return static_cast<SymbolNamespaceLength>(Size - 1);
+}
+
+static constexpr SymbolMappingDef CSymbolDefs[] = {
+#define SYMBOL(Name, NS, Header)                                               \
+  {{llvm::StringLiteral::withInnerNUL(#NS #Name "\0" #Header)},                \
+   getSymbolNamespaceLength(#NS)},
+#include "CSpecialSymbolMap.inc"
+#include "CSymbolMap.inc"
+#undef SYMBOL
+};
+static constexpr auto CSymbols = BUILD_ENUM_STRINGS(CSymbolDefs);
+
+static constexpr SymbolMappingDef CXXSpecialSymbolDefs[] = {
+#define SYMBOL(Name, NS, Header)                                               \
+  {{llvm::StringLiteral::withInnerNUL(#NS #Name "\0" #Header)},                \
+   getSymbolNamespaceLength(#NS)},
+#include "StdSpecialSymbolMap.inc"
+#undef SYMBOL
+};
+static constexpr auto CXXSpecialSymbols =
+    BUILD_ENUM_STRINGS(CXXSpecialSymbolDefs);
+
+#define SYMBOL_MAP_BEGIN(Index)                                                \
+  static constexpr SymbolMappingDef CXXSymbolDefs##Index[] = {
+#define SYMBOL(Name, NS, Header)                                               \
+  {{llvm::StringLiteral::withInnerNUL(#NS #Name "\0" #Header)},                \
+   getSymbolNamespaceLength(#NS)},
+#define SYMBOL_MAP_END(Index)                                                  \
+  }                                                                            \
+  ;                                                                            \
+  static constexpr auto CXXSymbols##Index =                                    \
+      BUILD_ENUM_STRINGS(CXXSymbolDefs##Index);
+#include "StdSymbolMap.inc"
+#undef SYMBOL_MAP_END
+#undef SYMBOL
+#undef SYMBOL_MAP_BEGIN
+
+static constexpr SymbolMappingDef CXXTsSymbolDefs[] = {
+#define SYMBOL(Name, NS, Header)                                               \
+  {{llvm::StringLiteral::withInnerNUL(#NS #Name "\0" #Header)},                \
+   getSymbolNamespaceLength(#NS)},
+#include "StdTsSymbolMap.inc"
+#undef SYMBOL
+};
+static constexpr auto CXXTsSymbols = BUILD_ENUM_STRINGS(CXXTsSymbolDefs);
+
+static std::pair<StringRef, StringRef>
+splitSymbolMapping(const SymbolMapping &Mapping) {
+  StringRef Name = Mapping.name();
+  size_t Delimiter = Name.find('\0');
+  assert(Delimiter != StringRef::npos && "missing symbol mapping delimiter");
+  return {Name.take_front(Delimiter), Name.drop_front(Delimiter + 1)};
+}
 
 // A Mapping per language.
 struct SymbolHeaderMapping {
@@ -54,37 +124,27 @@ static const SymbolHeaderMapping *getMappingPerLang(Lang L) {
   return LanguageMappings[static_cast<unsigned>(L)];
 }
 
-static int countSymbols(Lang Language) {
-  ArrayRef<const char *> Symbols;
-#define SYMBOL(Name, NS, Header) #NS #Name,
-  switch (Language) {
-  case Lang::C: {
-    static constexpr const char *CSymbols[] = {
-#include "CSpecialSymbolMap.inc"
-#include "CSymbolMap.inc"
-    };
-    Symbols = CSymbols;
-    break;
+static unsigned countSymbols(ArrayRef<SymbolMappingTable> SymbolMappingTables) {
+  unsigned Count = 0;
+  StringRef Previous;
+  for (const SymbolMappingTable &Table : SymbolMappingTables) {
+    for (const SymbolMapping &Mapping : Table) {
+      StringRef QName = splitSymbolMapping(Mapping).first;
+      if (Previous != QName) {
+        ++Count;
+        Previous = QName;
+      }
+    }
   }
-  case Lang::CXX: {
-    static constexpr const char *CXXSymbols[] = {
-#include "StdSpecialSymbolMap.inc"
-#include "StdSymbolMap.inc"
-#include "StdTsSymbolMap.inc"
-    };
-    Symbols = CXXSymbols;
-    break;
-  }
-  }
-#undef SYMBOL
-  return llvm::DenseSet<StringRef>(llvm::from_range, Symbols).size();
+  return Count;
 }
 
-static int initialize(Lang Language) {
+static int initialize(Lang Language,
+                      ArrayRef<SymbolMappingTable> SymbolMappingTables) {
   SymbolHeaderMapping *Mapping = new SymbolHeaderMapping();
   LanguageMappings[static_cast<unsigned>(Language)] = Mapping;
 
-  unsigned SymCount = countSymbols(Language);
+  unsigned SymCount = countSymbols(SymbolMappingTables);
   Mapping->SymbolCount = SymCount;
   Mapping->SymbolNames =
       new std::remove_reference_t<decltype(*Mapping->SymbolNames)>[SymCount];
@@ -137,42 +197,40 @@ static int initialize(Lang Language) {
     NSSymbols.try_emplace(QName.drop_front(NSLen), SymIndex);
   };
 
-  struct Symbol {
-    const char *QName;
-    unsigned NSLen;
-    const char *HeaderName;
-  };
-#define SYMBOL(Name, NS, Header)                                               \
-  {#NS #Name, static_cast<decltype(Symbol::NSLen)>(StringRef(#NS).size()),     \
-   #Header},
-  switch (Language) {
-  case Lang::C: {
-    static constexpr Symbol CSymbols[] = {
-#include "CSpecialSymbolMap.inc"
-#include "CSymbolMap.inc"
-    };
-    for (const Symbol &S : CSymbols)
-      Add(S.QName, S.NSLen, S.HeaderName);
-    break;
+  for (const SymbolMappingTable &Table : SymbolMappingTables) {
+    for (const SymbolMapping &Mapping : Table) {
+      auto [QName, HeaderName] = splitSymbolMapping(Mapping);
+      Add(QName, Mapping.value(), HeaderName);
+    }
   }
-  case Lang::CXX: {
-    static constexpr Symbol CXXSymbols[] = {
-#include "StdSpecialSymbolMap.inc"
-#include "StdSymbolMap.inc"
-#include "StdTsSymbolMap.inc"
-    };
-    for (const Symbol &S : CXXSymbols)
-      Add(S.QName, S.NSLen, S.HeaderName);
-    break;
-  }
-  }
-#undef SYMBOL
 
   Mapping->HeaderNames = new llvm::StringRef[Mapping->HeaderIDs->size()];
   for (const auto &E : *Mapping->HeaderIDs)
     Mapping->HeaderNames[E.second] = E.first;
 
   return 0;
+}
+
+static int initialize(Lang Language) {
+  switch (Language) {
+  case Lang::C: {
+    const SymbolMappingTable SymbolMappingTables[] = {CSymbols};
+    return initialize(Language, SymbolMappingTables);
+  }
+  case Lang::CXX: {
+    const SymbolMappingTable SymbolMappingTables[] = {CXXSpecialSymbols,
+#define SYMBOL(Name, NS, Header)
+#define SYMBOL_MAP_BEGIN(Index) CXXSymbols##Index,
+#define SYMBOL_MAP_END(Index)
+#include "StdSymbolMap.inc"
+#undef SYMBOL_MAP_END
+#undef SYMBOL_MAP_BEGIN
+#undef SYMBOL
+                                                      CXXTsSymbols};
+    return initialize(Language, SymbolMappingTables);
+  }
+  }
+  llvm_unreachable("unknown language");
 }
 
 static void ensureInitialized() {

--- a/clang/lib/Tooling/Inclusions/Stdlib/StdSymbolMap.inc
+++ b/clang/lib/Tooling/Inclusions/Stdlib/StdSymbolMap.inc
@@ -9,6 +9,7 @@
 // Generated from cppreference offline HTML book (modified on 2024-11-10).
 //===----------------------------------------------------------------------===//
 
+SYMBOL_MAP_BEGIN(0)
 SYMBOL(ATOMIC_BOOL_LOCK_FREE, None, <atomic>)
 SYMBOL(ATOMIC_CHAR16_T_LOCK_FREE, None, <atomic>)
 SYMBOL(ATOMIC_CHAR32_T_LOCK_FREE, None, <atomic>)
@@ -2289,6 +2290,8 @@ SYMBOL(nextafterf, std::, <cmath>)
 SYMBOL(nextafterf, None, <cmath>)
 SYMBOL(nextafterf, None, <math.h>)
 SYMBOL(nextafterl, std::, <cmath>)
+SYMBOL_MAP_END(0)
+SYMBOL_MAP_BEGIN(1)
 SYMBOL(nextafterl, None, <cmath>)
 SYMBOL(nextafterl, None, <math.h>)
 SYMBOL(nexttoward, std::, <cmath>)
@@ -3985,3 +3988,4 @@ SYMBOL(transform, std::views::, <ranges>)
 SYMBOL(values, std::views::, <ranges>)
 SYMBOL(zip, std::views::, <ranges>)
 SYMBOL(zip_transform, std::views::, <ranges>)
+SYMBOL_MAP_END(1)

--- a/clang/tools/include-mapping/gen_std.py
+++ b/clang/tools/include-mapping/gen_std.py
@@ -55,6 +55,58 @@ CODE_PREFIX = """\
 //===----------------------------------------------------------------------===//
 """
 
+# EnumString<uint8_t, 1> stores a 4-byte record for each string. Its 16-bit
+# offset must address the string data from the record.
+MAX_SYMBOL_TABLE_STORAGE_BYTES = (1 << 16) - 1
+SYMBOL_TABLE_RECORD_BYTES = 4
+
+
+def SymbolTableRowSize(symbol_row):
+    name, namespace, header = symbol_row
+    string_size = len(("%s%s\0%s" % (namespace, name, header)).encode("utf-8"))
+    return SYMBOL_TABLE_RECORD_BYTES + string_size
+
+
+def EmitSymbolRows(symbol_rows, partition_symbol_tables):
+    if not partition_symbol_tables:
+        for name, namespace, header in symbol_rows:
+            print("SYMBOL(%s, %s, %s)" % (name, namespace, header))
+        return
+
+    symbol_groups = []
+    for symbol_row in symbol_rows:
+        qualified_name = symbol_row[1], symbol_row[0]
+        if not symbol_groups or symbol_groups[-1][0] != qualified_name:
+            symbol_groups.append((qualified_name, []))
+        symbol_groups[-1][1].append(symbol_row)
+
+    symbol_tables = []
+    current_symbol_table = []
+    current_symbol_table_size = 0
+    for _, symbol_group in symbol_groups:
+        group_size = sum(SymbolTableRowSize(row) for row in symbol_group)
+        if group_size > MAX_SYMBOL_TABLE_STORAGE_BYTES:
+            raise ValueError("symbol mapping group exceeds symbol table limit")
+        if (
+            current_symbol_table
+            and current_symbol_table_size + group_size > MAX_SYMBOL_TABLE_STORAGE_BYTES
+        ):
+            symbol_tables.append(current_symbol_table)
+            current_symbol_table = []
+            current_symbol_table_size = 0
+        current_symbol_table.extend(symbol_group)
+        current_symbol_table_size += group_size
+    if current_symbol_table:
+        symbol_tables.append(current_symbol_table)
+    if not symbol_tables:
+        symbol_tables.append([])
+
+    for table_index, symbol_table in enumerate(symbol_tables):
+        print("SYMBOL_MAP_BEGIN(%d)" % table_index)
+        for name, namespace, header in symbol_table:
+            print("SYMBOL(%s, %s, %s)" % (name, namespace, header))
+        print("SYMBOL_MAP_END(%d)" % table_index)
+
 
 def ParseArg():
     parser = argparse.ArgumentParser(description="Generate StdGen file")
@@ -263,6 +315,7 @@ def main():
         exit("Path %s doesn't exist!" % symbol_index_root)
 
     symbols = cppreference_parser.GetSymbols(parse_pages)
+    symbol_rows = []
 
     # We don't have version information from the unzipped offline HTML files.
     # so we use the modified time of the symbol_index.html as the version.
@@ -279,7 +332,7 @@ def main():
                 s.headers.extend(AdditionalHeadersForIOSymbols(s))
                 for header in s.headers:
                     # SYMBOL(unqualified_name, namespace, header)
-                    print("SYMBOL(%s, %s, %s)" % (s.name, s.namespace, header))
+                    symbol_rows.append((s.name, s.namespace, header))
         elif len(symbol.headers) == 0:
             sys.stderr.write("No header found for symbol %s\n" % symbol.name)
         else:
@@ -288,6 +341,7 @@ def main():
                 "Ambiguous header for symbol %s: %s\n"
                 % (symbol.name, ", ".join(symbol.headers))
             )
+    EmitSymbolRows(symbol_rows, args.symbols == "cpp")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
StandardLibrary.cpp emits the generated C and C++ symbol mappings once to initialize SymbolHeaderMapping and a second time to count unique symbols. The second expansion costs about 46 KiB of read-only data and constructs a DenseSet during initialization.

Store each generated qualified name and header name as one `QName\0Header` name in `EnumStringDef<uint8_t, 1>`, with the namespace length in `value()`. `BUILD_ENUM_STRINGS` produces pointer-free tables, and `StdSymbolMap.inc` is partitioned to keep 16-bit name offsets in range. `SymbolHeaderMapping` counts and initializes from the same tables.

On arm64, linked clangd decreases by 66,496 bytes (66,056 bytes stripped) and linked fixups decrease by 17,289.

Work towards #202616

AI tool disclosure: Co-authored with OpenAI Codex.