### PR TITLE
[NFC][analyzer] Refactor VisitReturnStmt

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
@@ -1310,14 +1310,14 @@ void ExprEngine::BifurcateCall(const MemRegion *BifurReg,
 
 void ExprEngine::VisitReturnStmt(const ReturnStmt *RS, ExplodedNode *Pred,
                                  ExplodedNodeSet &Dst) {
-  ExplodedNodeSet dstPreVisit;
-  getCheckerManager().runCheckersForPreStmt(dstPreVisit, Pred, RS, *this);
+  ExplodedNodeSet DstPreVisit;
+  getCheckerManager().runCheckersForPreStmt(DstPreVisit, Pred, RS, *this);
 
   if (RS->getRetValue()) {
-    for (ExplodedNode *N : dstPreVisit) {
+    for (ExplodedNode *N : DstPreVisit) {
       Dst.insert(Engine.makePostStmtNode(RS, N->getState(), N));
     }
   } else {
-    Dst.insert(dstPreVisit);
+    Dst.insert(DstPreVisit);
   }
 }

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
@@ -1316,9 +1316,8 @@ void ExprEngine::VisitReturnStmt(const ReturnStmt *RS, ExplodedNode *Pred,
   NodeBuilder B(dstPreVisit, Dst, *currBldrCtx);
 
   if (RS->getRetValue()) {
-    for (ExplodedNodeSet::iterator it = dstPreVisit.begin(),
-                                  ei = dstPreVisit.end(); it != ei; ++it) {
-      B.generateNode(RS, *it, (*it)->getState());
+    for (ExplodedNode *N : dstPreVisit) {
+      B.generateNode(RS, N, N->getState());
     }
   }
 }

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineCallAndReturn.cpp
@@ -1313,11 +1313,11 @@ void ExprEngine::VisitReturnStmt(const ReturnStmt *RS, ExplodedNode *Pred,
   ExplodedNodeSet dstPreVisit;
   getCheckerManager().runCheckersForPreStmt(dstPreVisit, Pred, RS, *this);
 
-  NodeBuilder B(dstPreVisit, Dst, *currBldrCtx);
-
   if (RS->getRetValue()) {
     for (ExplodedNode *N : dstPreVisit) {
-      B.generateNode(RS, N, N->getState());
+      Dst.insert(Engine.makePostStmtNode(RS, N->getState(), N));
     }
+  } else {
+    Dst.insert(dstPreVisit);
   }
 }


### PR DESCRIPTION
Simplify an old-style for loop that used explicit iterator manipulation, and clarify the manipulation of the exploded nodes by removing the `NodeBuilder`.

This is part of my commit series that gradually removes the class `NodeBuilder`.