### PR TITLE
[flang][OpenMP] Move TargetOMPContext to shared FlangOMPContext (NFC)

### DIFF
--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -4650,49 +4650,6 @@ static void genOMP(lower::AbstractConverter &converter, lower::SymMap &symTable,
 }
 
 namespace {
-struct TargetOMPContext final : public llvm::omp::OMPContext {
-  TargetOMPContext(mlir::ModuleOp module,
-                   llvm::ArrayRef<llvm::omp::TraitProperty> constructTraits)
-      // Metadirective lowering has no selected target device, so construct the
-      // context with an unknown device number. Target-device selectors are
-      // rejected before matching because OMPContext would otherwise describe
-      // the host device in this mode.
-      : OMPContext(isDeviceCompilation(module), fir::getTargetTriple(module),
-                   getOffloadTargetTriple(module),
-                   /*DeviceNum=*/-1),
-        targetFeatures(fir::getTargetFeatures(module)) {
-    for (llvm::omp::TraitProperty trait : constructTraits)
-      addTrait(trait);
-  }
-
-  bool matchesISATrait(llvm::StringRef rawString) const override {
-    if (!targetFeatures || targetFeatures.nullOrEmpty())
-      return false;
-    return targetFeatures.contains(("+" + rawString).str());
-  }
-
-private:
-  static bool isDeviceCompilation(mlir::ModuleOp module) {
-    return llvm::cast<mlir::omp::OffloadModuleInterface>(*module.getOperation())
-        .getIsTargetDevice();
-  }
-
-  static llvm::Triple getOffloadTargetTriple(mlir::ModuleOp module) {
-    auto offloadMod =
-        llvm::cast<mlir::omp::OffloadModuleInterface>(*module.getOperation());
-    auto targetTriples = offloadMod.getTargetTriples();
-
-    if (!targetTriples.empty())
-      if (auto tripleAttr =
-              llvm::dyn_cast<mlir::StringAttr>(targetTriples.front()))
-        return llvm::Triple(tripleAttr.getValue());
-
-    return llvm::Triple();
-  }
-
-  mlir::LLVM::TargetFeaturesAttr targetFeatures;
-};
-
 struct MetadirectiveCandidate {
   MetadirectiveCandidate(
       const parser::OmpDirectiveSpecification *spec,
@@ -4742,7 +4699,7 @@ static void genMetadirective(lower::AbstractConverter &converter,
     appendConstructTraits(op, constructTraits);
 
   std::reverse(constructTraits.begin(), constructTraits.end());
-  TargetOMPContext ompCtx(builder.getModule(), constructTraits);
+  FlangOMPContext ompCtx(builder.getModule(), constructTraits);
 
   llvm::SmallVector<MetadirectiveCandidate, 4> candidates;
   // A null directive specification represents either the implicit `nothing`
@@ -4923,7 +4880,7 @@ static void genMetadirective(lower::AbstractConverter &converter,
   auto selectBestCandidate =
       [](llvm::ArrayRef<unsigned> candidateIndices,
          llvm::ArrayRef<MetadirectiveCandidate> candidates,
-         const TargetOMPContext &ompCtx) -> std::optional<unsigned> {
+         const FlangOMPContext &ompCtx) -> std::optional<unsigned> {
     if (candidateIndices.empty())
       return std::nullopt;
     if (candidateIndices.size() == 1)

--- a/flang/lib/Lower/OpenMP/Utils.cpp
+++ b/flang/lib/Lower/OpenMP/Utils.cpp
@@ -15,6 +15,8 @@
 #include "ClauseFinder.h"
 #include "flang/Evaluate/fold.h"
 #include "flang/Evaluate/tools.h"
+#include "flang/Optimizer/Dialect/Support/FIRContext.h"
+#include "mlir/Dialect/OpenMP/OpenMPInterfaces.h"
 #include <flang/Lower/AbstractConverter.h>
 #include <flang/Lower/ConvertType.h>
 #include <flang/Lower/DirectivesCommon.h>
@@ -1240,6 +1242,46 @@ makeVariantMatchInfo(llvm::omp::VariantMatchInfo &vmi,
   }
 
   return dynamicCond;
+}
+
+// ---------------------------------------------------------------------------
+// FlangOMPContext — shared OMPContext for metadirective variant-matching
+// ---------------------------------------------------------------------------
+
+static llvm::Triple getOffloadTargetTriple(mlir::ModuleOp module) {
+  auto iface =
+      llvm::cast<mlir::omp::OffloadModuleInterface>(module.getOperation());
+  auto targetTriples = iface.getTargetTriples();
+  if (!targetTriples.empty())
+    if (auto tripleAttr =
+            llvm::dyn_cast<mlir::StringAttr>(targetTriples.front()))
+      return llvm::Triple(tripleAttr.getValue());
+  return llvm::Triple();
+}
+
+bool FlangOMPContext::isDeviceCompilation(mlir::ModuleOp module) {
+  return llvm::cast<mlir::omp::OffloadModuleInterface>(module.getOperation())
+      .getIsTargetDevice();
+}
+
+FlangOMPContext::FlangOMPContext(
+    mlir::ModuleOp module,
+    llvm::ArrayRef<llvm::omp::TraitProperty> constructTraits)
+    // No specific device is selected during variant matching; use an unknown
+    // device number so OMPContext does not inadvertently describe the host
+    // device (which would cause target-device selectors to match incorrectly).
+    : OMPContext(isDeviceCompilation(module), fir::getTargetTriple(module),
+                 getOffloadTargetTriple(module),
+                 /*DeviceNum=*/-1),
+      targetFeatures(fir::getTargetFeatures(module)) {
+  for (llvm::omp::TraitProperty trait : constructTraits)
+    addTrait(trait);
+}
+
+bool FlangOMPContext::matchesISATrait(llvm::StringRef rawString) const {
+  if (!targetFeatures || targetFeatures.nullOrEmpty())
+    return false;
+  return targetFeatures.contains(("+" + rawString).str());
 }
 
 } // namespace omp

--- a/flang/lib/Lower/OpenMP/Utils.h
+++ b/flang/lib/Lower/OpenMP/Utils.h
@@ -11,6 +11,7 @@
 
 #include "flang/Lower/OpenMP/Clauses.h"
 #include "flang/Optimizer/Builder/HLFIRTools.h"
+#include "mlir/Dialect/LLVMIR/LLVMAttrs.h"
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/IR/Location.h"
 #include "mlir/IR/Value.h"
@@ -244,6 +245,19 @@ std::optional<DynamicUserCondition>
 makeVariantMatchInfo(llvm::omp::VariantMatchInfo &vmi,
                      const parser::modifier::OmpContextSelector &ctxSel,
                      semantics::SemanticsContext &semaCtx, mlir::Location loc);
+
+/// `OMPContext` flavour used by Flang's OpenMP variant matching. Adds an
+/// ISA-trait override based on the module's target-features attribute.
+class FlangOMPContext final : public llvm::omp::OMPContext {
+public:
+  FlangOMPContext(mlir::ModuleOp module,
+                  llvm::ArrayRef<llvm::omp::TraitProperty> constructTraits);
+  bool matchesISATrait(llvm::StringRef rawString) const override;
+
+private:
+  static bool isDeviceCompilation(mlir::ModuleOp module);
+  mlir::LLVM::TargetFeaturesAttr targetFeatures;
+};
 
 } // namespace omp
 } // namespace lower


### PR DESCRIPTION
Moving the class to shared code makes it available for reuse by forthcoming DECLARE VARIANT lowering without any functional change to existing metadirective lowering.