### PR TITLE
[lit] Migrate lit to ProcessPoolExecutor

### DIFF
--- a/llvm/utils/lit/lit/main.py
+++ b/llvm/utils/lit/lit/main.py
@@ -278,6 +278,8 @@ def run_tests(tests, lit_config, opts, discovered_tests):
         error = "warning: reached maximum number of test failures"
     except lit.run.TimeoutError:
         error = "warning: reached timeout"
+    except lit.run.WorkerCrashError as e:
+        lit_config.error(f"a worker process crashed: {e}")
 
     display.clear(interrupted)
     if error:

--- a/llvm/utils/lit/lit/run.py
+++ b/llvm/utils/lit/lit/run.py
@@ -1,7 +1,12 @@
 import multiprocessing
 import os
 import platform
+import sys
 import time
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+from concurrent.futures.process import BrokenProcessPool
+import concurrent.futures.process
 
 import lit.Test
 import lit.util
@@ -21,6 +26,11 @@ class MaxFailuresError(Exception):
 
 
 class TimeoutError(Exception):
+    pass
+
+
+class WorkerCrashError(Exception):
+    """A worker process died abrupty (segfault, OOM-kill, abort) instead of returning a result."""
     pass
 
 
@@ -71,6 +81,46 @@ class Run:
                 if test.result is None:
                     test.setResult(skipped)
 
+    def _abort_executors(self, executors, future_to_test):
+        """SIGKILL all workers on abort (ctrl-C, --max-failures, --max-time,
+        worker crash). Pre-3.14 ProcessPoolExecutor has no force-stop."""
+        try:
+            # We don't call ex.shutdown() here: it joins the management thread,
+            # which is blocked reading the queue we just corrupted.
+            # On 3.8 / 3.9, cancel() races with the call-queue feeder thread and can
+            # deadlock or corrupt the queue (https://github.com/python/cpython/issues/94440).
+            # Skipping it is safe because we SIGKILL workers below, so no pending future
+            # will ever be dispatched. cancel() on 3.10+ is a clean hint.
+            if sys.version_info >= (3, 10):
+                for future in future_to_test:
+                    future.cancel()
+            # Killing worker processes can corrupt the executor's queues, which makes it
+            # unsafe for its atexit hooks to join their threads. Disable those hooks
+            # before terminating workers (a second ctrl-C should not bypass this cleanup).
+            # This applies to call-queue feeder threads and management threads.
+            # Otherwise, a thread blocked on a partially written pipe may require multiple
+            # ctrl-C to unblock.
+            # See: https://github.com/python/cpython/issues/125886
+            # These threads are daemonic on Python 3.8, so disabling them is harmless.
+            for ex in executors:
+                if hasattr(ex, "_call_queue") and ex._call_queue is not None:
+                    ex._call_queue.cancel_join_thread()
+            if hasattr(concurrent.futures.process, "_threads_wakeups"):
+                concurrent.futures.process._threads_wakeups.clear()
+            tree_kill_ok, _ = lit.util.killProcessAndChildrenIsSupported()
+            for ex in executors:
+                for pid, proc in list((ex._processes or {}).items()):
+                    if tree_kill_ok:
+                        lit.util.killProcessAndChildren(pid)
+                    else:
+                        proc.kill()
+            # TODO: Python>=3.14 adds ex.kill_workers(), which stops the workers cleanly
+            # without corrupting the queues. However kill_workers() won't reap the
+            # llc / FileCheck grandchildren the workers spawned.
+            # https://github.com/python/cpython/issues/128041
+        except Exception:
+            pass
+
     def _execute(self, deadline):
         self._increase_process_limit()
 
@@ -103,59 +153,44 @@ class Run:
                 % (num_pools, self.workers, workers_per_pool_list)
             )
 
-        # Create multiple pools
-        pools = []
-        for pool_size in workers_per_pool_list:
-            pool = multiprocessing.Pool(
-                pool_size, lit.worker.initialize, (self.lit_config, semaphores)
+        executors = [
+            ProcessPoolExecutor(
+                max_workers=pool_size,
+                initializer=lit.worker.initialize,
+                initargs=(self.lit_config, semaphores),
             )
-            pools.append(pool)
+            for pool_size in workers_per_pool_list
+        ]
 
-        # Distribute tests across pools
-        tests_per_pool = _ceilDiv(len(self.tests), num_pools)
-        async_results = []
-
-        for pool_idx, pool in enumerate(pools):
-            start_idx = pool_idx * tests_per_pool
-            end_idx = min(start_idx + tests_per_pool, len(self.tests))
-            for test in self.tests[start_idx:end_idx]:
-                ar = pool.apply_async(
-                    lit.worker.execute, args=[test], callback=self.progress_callback
-                )
-                async_results.append(ar)
-
-        # Close all pools
-        for pool in pools:
-            pool.close()
+        future_to_test = {}
+        for i, test in enumerate(self.tests):
+            ex = executors[i % len(executors)]
+            future_to_test[ex.submit(lit.worker.execute, test)] = test
 
         try:
-            self._wait_for(async_results, deadline)
-        except:
-            # Terminate all pools on exception
-            for pool in pools:
-                pool.terminate()
+            self._wait_for(future_to_test, deadline)
+        except BaseException:
+            self._abort_executors(executors, future_to_test)
             raise
-        finally:
-            # Join all pools
-            for pool in pools:
-                pool.join()
+        else:
+            for ex in executors:
+                ex.shutdown(wait=True)
 
-    def _wait_for(self, async_results, deadline):
-        timeout = deadline - time.time()
-        idx = 0
-        while len(async_results) > 0:
-            try:
-                ar = async_results.pop(0)
-                test = ar.get(timeout)
-            except multiprocessing.TimeoutError:
-                raise TimeoutError()
-            else:
-                self._update_test(self.tests[idx], test)
-                if test.isFailure():
+    def _wait_for(self, future_to_test, deadline):
+        try:
+            for future in as_completed(future_to_test, timeout=deadline - time.time()):
+                remote_test = future.result()
+                local_test = future_to_test[future]
+                self._update_test(local_test, remote_test)
+                self.progress_callback(remote_test)
+                if remote_test.isFailure():
                     self.failures += 1
                     if self.failures == self.max_failures:
                         raise MaxFailuresError()
-            idx += 1
+        except FuturesTimeoutError:
+            raise TimeoutError()
+        except BrokenProcessPool as e:
+            raise WorkerCrashError(str(e))
 
     # Update local test object "in place" from remote test object.  This
     # ensures that the original test object which is used for printing test


### PR DESCRIPTION
This PR is a foundational refactor for the lit single-process re-architecture.

It migrates test execution from `multiprocessing.Pool` to `concurrent.futures.ProcessPoolExecutor`. While the process model remains unchanged (this is purely correctness and API modernization with no behavior change on a passing suite), this migration establishes the `concurrent.futures` API foundation required to introduce a `ThreadPoolExecutor` backend in future PRs.

By collecting results with `as_completed` via an explicit `{future: test}` map, this refactor also fixes two latent bugs:
1. **Stale timeout bug**: The per-iteration timeout budget was previously computed once and reused. It is now correctly anchored to an absolute deadline.
2. **Submission-order coupling**: Results are now safely routed by future identity rather than submission index.
