### PR TITLE
[test][Support] Disable CFI-icall for DynamicLibrary Overload test (#202446)

### DIFF
--- a/llvm/unittests/Support/DynamicLibrary/DynamicLibraryTest.cpp
+++ b/llvm/unittests/Support/DynamicLibrary/DynamicLibraryTest.cpp
@@ -59,7 +59,7 @@ static const char *OverloadTestA() { return "OverloadCall"; }
 
 std::string StdString(const char *Ptr) { return Ptr ? Ptr : ""; }
 
-TEST(DynamicLibrary, Overload) {
+TEST(DynamicLibrary, Overload) LLVM_NO_SANITIZE("cfi-icall") {
   {
     std::string Err;
     DynamicLibrary DL =


### PR DESCRIPTION
The test performs manual symbol lookup and calls, which triggers
Control Flow Integrity indirect call checks.

Reland of #202446 reverted with #202550.

Here we are going to use LLVM_NO_SANITIZE.
