### PR TITLE
[IR] Avoid unnecessary canBeFreed() calls (NFC)

### DIFF
--- a/llvm/lib/IR/Value.cpp
+++ b/llvm/lib/IR/Value.cpp
@@ -902,7 +902,7 @@ uint64_t Value::getPointerDereferenceableBytes(const DataLayout &DL,
 
   uint64_t DerefBytes = 0;
   CanBeNull = false;
-  CanBeFreed = UseDerefAtPointSemantics && canBeFreed();
+  bool CanNotBeFreed = false;
   if (const Argument *A = dyn_cast<Argument>(this)) {
     DerefBytes = A->getDereferenceableBytes();
     if (DerefBytes == 0) {
@@ -955,7 +955,7 @@ uint64_t Value::getPointerDereferenceableBytes(const DataLayout &DL,
     if (std::optional<TypeSize> Size = AI->getAllocationSize(DL)) {
       DerefBytes = Size->getKnownMinValue();
       CanBeNull = false;
-      CanBeFreed = false;
+      CanNotBeFreed = true;
     }
   } else if (auto *GV = dyn_cast<GlobalVariable>(this)) {
     if (GV->getValueType()->isSized() && !GV->hasExternalWeakLinkage()) {
@@ -963,9 +963,17 @@ uint64_t Value::getPointerDereferenceableBytes(const DataLayout &DL,
       // CanBeNull flag.
       DerefBytes = DL.getTypeStoreSize(GV->getValueType()).getFixedValue();
       CanBeNull = false;
-      CanBeFreed = false;
+      CanNotBeFreed = true;
     }
   }
+
+  // Call canBeFreed() only if there are dereferenceable bytes and it's not
+  // one of the cases that can never be freed.
+  if (!CanNotBeFreed && DerefBytes != 0)
+    CanBeFreed = UseDerefAtPointSemantics && canBeFreed();
+  else
+    CanBeFreed = false;
+
   return DerefBytes;
 }
 


### PR DESCRIPTION
Do not call canBeFreed() if the value can't ever be freed (e.g. for globals) or if there are no known dereferenceable bytes. The check is relatively expensive.

(The compile-time impact is only visible when enabling deref-at-point semantics.)