### PR TITLE
[lldb][Windows] extend @skipIfWindows to lldb-server or in process

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -676,6 +676,36 @@ def expectedFailureWindows(bugnumber=None):
     return expectedFailureOS(["windows"], bugnumber)
 
 
+def _usingLLDBServerOnWindows():
+    """Return True if Windows tests should drive lldb-server instead of the
+    in-process Win32 ``windows`` process plugin.
+
+    The choice is controlled by the ``LLDB_USE_LLDB_SERVER`` environment
+    variable: unset/off selects the default in-process plugin, on selects
+    the gdb-remote path through ``lldb-server``.
+    """
+    return os.environ.get("LLDB_USE_LLDB_SERVER", "").lower() in (
+        "on",
+        "yes",
+        "1",
+        "true",
+    )
+
+
+def expectedFailureWindowsAndLLDBServer(bugnumber=None):
+    """Mark a test as xfail on Windows when driving lldb-server."""
+    if not _usingLLDBServerOnWindows():
+        return lambda func: func
+    return expectedFailureOS(["windows"], bugnumber)
+
+
+def expectedFailureWindowsAndNoLLDBServer(bugnumber=None):
+    """Mark a test as xfail on Windows when using the in-process plugin."""
+    if _usingLLDBServerOnWindows():
+        return lambda func: func
+    return expectedFailureOS(["windows"], bugnumber)
+
+
 # TODO: This decorator does not do anything. Remove it.
 def expectedFlakey(expected_fn, bugnumber=None):
     def expectedFailure_impl(func):
@@ -914,6 +944,20 @@ def skipIfWindows(func=None, windows_version=None):
     if func is not None:
         return decorator(func)
     return decorator
+
+
+def skipIfWindowsAndLLDBServer(func):
+    """Skip tests on Windows when driving lldb-server."""
+    if not _usingLLDBServerOnWindows():
+        return func
+    return skipIfPlatform(["windows"])(func)
+
+
+def skipIfWindowsAndNoLLDBServer(func):
+    """Skip tests on Windows when using the in-process plugin."""
+    if _usingLLDBServerOnWindows():
+        return func
+    return skipIfPlatform(["windows"])(func)
 
 
 def skipIfWindowsAndNonEnglish(func):

--- a/lldb/test/API/commands/platform/connect/TestPlatformConnect.py
+++ b/lldb/test/API/commands/platform/connect/TestPlatformConnect.py
@@ -13,7 +13,7 @@ class TestPlatformProcessConnect(TestBase):
     @skipIfRemote
     @expectedFailureAll(hostoslist=["windows"], triple=".*-android")
     @skipIfDarwin  # lldb-server not found correctly
-    @expectedFailureAll(oslist=["windows"])  # process modules not loaded
+    @expectedFailureWindowsAndNoLLDBServer()  # process modules not loaded
     # lldb-server platform times out waiting for the gdbserver port number to be
     # written to the pipe, yet it seems the gdbserver already has written it.
     @expectedFailureAll(
@@ -62,7 +62,7 @@ class TestPlatformProcessConnect(TestBase):
     @skipIfRemote
     @expectedFailureAll(hostoslist=["windows"], triple=".*-android")
     @skipIfDarwin  # lldb-server not found correctly
-    @expectedFailureAll(oslist=["windows"])  # process modules not loaded
+    @expectedFailureWindowsAndNoLLDBServer()  # process modules not loaded
     # lldb-server platform times out waiting for the gdbserver port number to be
     # written to the pipe, yet it seems the gdbserver already has written it.
     @expectedFailureAll(

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_command/TestBreakpointCommand.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_command/TestBreakpointCommand.py
@@ -16,7 +16,7 @@ class BreakpointCommandTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     SHARED_BUILD_TESTCASE = False
 
-    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24528")
+    @expectedFailureWindowsAndNoLLDBServer(bugnumber="llvm.org/pr24528")
     def test_breakpoint_command_sequence(self):
         """Test a sequence of breakpoint command add, list, and delete."""
         self.build()

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_locations/TestBreakpointLocations.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_locations/TestBreakpointLocations.py
@@ -10,7 +10,7 @@ from lldbsuite.test import lldbutil
 
 
 class BreakpointLocationsTestCase(TestBase):
-    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24528")
+    @expectedFailureWindowsAndNoLLDBServer(bugnumber="llvm.org/pr24528")
     def test_enable(self):
         """Test breakpoint enable/disable for a breakpoint ID with multiple locations."""
         self.build()

--- a/lldb/test/API/functionalities/breakpoint/delayed_breakpoints/TestDelayedBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/delayed_breakpoints/TestDelayedBreakpoint.py
@@ -5,7 +5,7 @@ from lldbsuite.test import lldbutil
 import os
 
 
-@skipIfWindows
+@skipIfWindowsAndNoLLDBServer
 class TestDelayedBreakpoint(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/functionalities/scripted_frame_provider/circular_dependency/TestFrameProviderCircularDependency.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/circular_dependency/TestFrameProviderCircularDependency.py
@@ -47,7 +47,7 @@ class FrameProviderCircularDependencyTestCase(TestBase):
         return target, thread
 
     @expectedFailureAll(oslist=["linux"], archs=["arm$"])
-    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24778")
+    @expectedFailureWindowsAndNoLLDBServer(bugnumber="llvm.org/pr24778")
     def test_circular_dependency_with_function_replacement(self):
         """
         Test the circular dependency fix with a provider that replaces function names.
@@ -165,7 +165,7 @@ class FrameProviderCircularDependencyTestCase(TestBase):
                 frame.GetFunctionName(), f"Frame {i} should have function name"
             )
 
-    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24778")
+    @expectedFailureWindowsAndNoLLDBServer(bugnumber="llvm.org/pr24778")
     def test_circular_dependency_evaluate_expression_in_get_frame(self):
         """
         Test that calling EvaluateExpression in get_frame_at_index doesn't


### PR DESCRIPTION
Some tests fail when using `lldb-server.exe` and pass when using the in process plugin and vice-versa.

This patch adds the `skipIfWindowsAndNoLLDBServer` and `expectedFailureWindowsAndNoLLDBServer` decorators (and their opposites) to only skip tests if they run on `lldb-server` or the in process plugin.

This fixes 4 XPASS when running tests with `USE_LLDB_SERVER=1`.

rdar://179117754