### PR TITLE
[openmp] Fix export file paths

### DIFF
--- a/openmp/runtime/cmake/LibompExports.cmake
+++ b/openmp/runtime/cmake/LibompExports.cmake
@@ -61,7 +61,7 @@ add_custom_command(TARGET omp POST_BUILD
 )
 if(LIBOMP_OMPT_SUPPORT)
   add_custom_command(TARGET omp POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy omp-tools.h ${LIBOMP_EXPORTS_CMN_DIR}
+    COMMAND ${CMAKE_COMMAND} -E copy "${LIBOMP_HEADERS_INTDIR}/omp-tools.h" ${LIBOMP_EXPORTS_CMN_DIR}
   )
 endif()
 if(LIBOMP_FORTRAN_MODULES)
@@ -74,7 +74,7 @@ if(LIBOMP_FORTRAN_MODULES)
   )
   add_dependencies(omp libomp-mod)
   add_custom_command(TARGET omp POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy omp_lib.h ${LIBOMP_EXPORTS_CMN_DIR}
+    COMMAND ${CMAKE_COMMAND} -E copy "${RUNTIMES_OUTPUT_RESOURCE_MOD_DIR}/omp_lib.h" ${LIBOMP_EXPORTS_CMN_DIR}
   )
 endif()
 


### PR DESCRIPTION
The files omp_lib.h and omp-tools.h are the outputs of two configure_file invocations which specify the full path of the outputs. Use these full paths in LibompExports.cmake so they can actually be found.