### PR TITLE
[AMDGPU] remove DefIsPriv mapping

### DIFF
--- a/clang/lib/Basic/Targets/AMDGPU.cpp
+++ b/clang/lib/Basic/Targets/AMDGPU.cpp
@@ -27,7 +27,7 @@ namespace targets {
 // If you edit the description strings, make sure you update
 // getPointerWidthV().
 
-const LangASMap AMDGPUTargetInfo::AMDGPUDefIsGenMap = {
+const LangASMap AMDGPUTargetInfo::AMDGPUAddrSpaceMap = {
     llvm::AMDGPUAS::FLAT_ADDRESS,     // Default
     llvm::AMDGPUAS::GLOBAL_ADDRESS,   // opencl_global
     llvm::AMDGPUAS::LOCAL_ADDRESS,    // opencl_local
@@ -58,35 +58,6 @@ const LangASMap AMDGPUTargetInfo::AMDGPUDefIsGenMap = {
     llvm::AMDGPUAS::GLOBAL_ADDRESS,  // hlsl_push_constant
 };
 
-const LangASMap AMDGPUTargetInfo::AMDGPUDefIsPrivMap = {
-    llvm::AMDGPUAS::PRIVATE_ADDRESS,  // Default
-    llvm::AMDGPUAS::GLOBAL_ADDRESS,   // opencl_global
-    llvm::AMDGPUAS::LOCAL_ADDRESS,    // opencl_local
-    llvm::AMDGPUAS::CONSTANT_ADDRESS, // opencl_constant
-    llvm::AMDGPUAS::PRIVATE_ADDRESS,  // opencl_private
-    llvm::AMDGPUAS::FLAT_ADDRESS,     // opencl_generic
-    llvm::AMDGPUAS::GLOBAL_ADDRESS,   // opencl_global_device
-    llvm::AMDGPUAS::GLOBAL_ADDRESS,   // opencl_global_host
-    llvm::AMDGPUAS::GLOBAL_ADDRESS,   // cuda_device
-    llvm::AMDGPUAS::CONSTANT_ADDRESS, // cuda_constant
-    llvm::AMDGPUAS::LOCAL_ADDRESS,    // cuda_shared
-    // SYCL address space values for this map are dummy
-    llvm::AMDGPUAS::FLAT_ADDRESS,     // sycl_global
-    llvm::AMDGPUAS::FLAT_ADDRESS,     // sycl_global_device
-    llvm::AMDGPUAS::FLAT_ADDRESS,     // sycl_global_host
-    llvm::AMDGPUAS::FLAT_ADDRESS,     // sycl_local
-    llvm::AMDGPUAS::FLAT_ADDRESS,     // sycl_private
-    llvm::AMDGPUAS::FLAT_ADDRESS,     // ptr32_sptr
-    llvm::AMDGPUAS::FLAT_ADDRESS,     // ptr32_uptr
-    llvm::AMDGPUAS::FLAT_ADDRESS,     // ptr64
-    llvm::AMDGPUAS::FLAT_ADDRESS,     // hlsl_groupshared
-    llvm::AMDGPUAS::CONSTANT_ADDRESS, // hlsl_constant
-    llvm::AMDGPUAS::PRIVATE_ADDRESS,  // hlsl_private
-    llvm::AMDGPUAS::GLOBAL_ADDRESS,   // hlsl_device
-    llvm::AMDGPUAS::PRIVATE_ADDRESS,  // hlsl_input
-    llvm::AMDGPUAS::PRIVATE_ADDRESS,  // hlsl_output
-    llvm::AMDGPUAS::GLOBAL_ADDRESS,   // hlsl_push_constant
-};
 } // namespace targets
 } // namespace clang
 
@@ -217,10 +188,6 @@ void AMDGPUTargetInfo::fillValidCPUList(
     llvm::AMDGPU::fillValidArchListR600(Values);
 }
 
-void AMDGPUTargetInfo::setAddressSpaceMap(bool DefaultIsPrivate) {
-  AddrSpaceMap = DefaultIsPrivate ? &AMDGPUDefIsPrivMap : &AMDGPUDefIsGenMap;
-}
-
 AMDGPUTargetInfo::AMDGPUTargetInfo(const llvm::Triple &Triple,
                                    const TargetOptions &Opts)
     : TargetInfo(Triple),
@@ -230,8 +197,7 @@ AMDGPUTargetInfo::AMDGPUTargetInfo(const llvm::Triple &Triple,
                                     : llvm::AMDGPU::getArchAttrR600(GPUKind)) {
   resetDataLayout();
 
-  setAddressSpaceMap(Triple.getOS() == llvm::Triple::Mesa3D ||
-                     !Triple.isAMDGCN());
+  AddrSpaceMap = &AMDGPUAddrSpaceMap;
   UseAddrSpaceMapMangling = true;
 
   if (Triple.isAMDGCN()) {
@@ -268,12 +234,6 @@ AMDGPUTargetInfo::AMDGPUTargetInfo(const llvm::Triple &Triple,
 void AMDGPUTargetInfo::adjust(DiagnosticsEngine &Diags, LangOptions &Opts,
                               const TargetInfo *Aux) {
   TargetInfo::adjust(Diags, Opts, Aux);
-  // ToDo: There are still a few places using default address space as private
-  // address space in OpenCL, which needs to be cleaned up, then the references
-  // to OpenCL can be removed from the following line.
-  setAddressSpaceMap((Opts.OpenCL && !Opts.OpenCLGenericAddressSpace) ||
-                     !getTriple().isAMDGCN());
-
   AtomicOpts = AtomicOptions(Opts);
 }
 

--- a/clang/lib/Basic/Targets/AMDGPU.h
+++ b/clang/lib/Basic/Targets/AMDGPU.h
@@ -30,8 +30,7 @@ class LLVM_LIBRARY_VISIBILITY AMDGPUTargetInfo final : public TargetInfo {
 
   static const char *const GCCRegNames[];
 
-  static const LangASMap AMDGPUDefIsGenMap;
-  static const LangASMap AMDGPUDefIsPrivMap;
+  static const LangASMap AMDGPUAddrSpaceMap;
 
   llvm::AMDGPU::GPUKind GPUKind;
   unsigned GPUFeatures;
@@ -96,8 +95,6 @@ class LLVM_LIBRARY_VISIBILITY AMDGPUTargetInfo final : public TargetInfo {
 
 public:
   AMDGPUTargetInfo(const llvm::Triple &Triple, const TargetOptions &Opts);
-
-  void setAddressSpaceMap(bool DefaultIsPrivate);
 
   void adjust(DiagnosticsEngine &Diags, LangOptions &Opts,
               const TargetInfo *Aux) override;


### PR DESCRIPTION
Since various commits that now avoid immediately casting most temporaries, and now follow Sema for variables, this looks like tests pass now without needing a second map to correct those issues afterwards. Ideally AMDGPU folks would be able to test this on any of their private CI before merging, so we're less likely to have to revert if we find out about any other CreateMem calls that have been missed getting updated, but sometimes maybe that is the only way to fix those.