### PR TITLE
[AMDGPU] Fix GISel lowering for amdgcn_s_quadmask, amdgcn_s_wqm

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
@@ -1744,9 +1744,9 @@ RegBankLegalizeRules::RegBankLegalizeRules(const GCNSubtarget &_ST,
   addRulesForIOpcs({amdgcn_readlane}, StandardB)
       .Uni(B32, {{SgprB32}, {IntrId, VgprB32, SgprB32_ReadFirstLane}});
 
-  addRulesForIOpcs({amdgcn_s_quadmask, amdgcn_s_wqm})
-      .Any({{B32}, {{SgprB32}, {IntrId, SgprB32_ReadFirstLane}}})
-      .Any({{B64}, {{SgprB64}, {IntrId, SgprB64_ReadFirstLane}}});
+  addRulesForIOpcs({amdgcn_s_quadmask, amdgcn_s_wqm}, StandardB)
+      .Uni(B32, {{SgprB32}, {IntrId, SgprB32_ReadFirstLane}})
+      .Uni(B64, {{SgprB64}, {IntrId, SgprB64_ReadFirstLane}});
 
   addRulesForIOpcs({amdgcn_writelane}, StandardB)
       .Div(B32,

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
@@ -1744,11 +1744,9 @@ RegBankLegalizeRules::RegBankLegalizeRules(const GCNSubtarget &_ST,
   addRulesForIOpcs({amdgcn_readlane}, StandardB)
       .Uni(B32, {{SgprB32}, {IntrId, VgprB32, SgprB32_ReadFirstLane}});
 
-  addRulesForIOpcs({amdgcn_s_quadmask, amdgcn_s_wqm}, StandardB)
-      .Uni(B32, {{SgprB32}, {IntrId, SgprB32}})
-      .Div(B32, {{Sgpr32ToVgprDst}, {IntrId, SgprB32_ReadFirstLane}})
-      .Uni(B64, {{SgprB64}, {IntrId, SgprB64}})
-      .Div(B64, {{Sgpr64ToVgprDst}, {IntrId, SgprB64_ReadFirstLane}});
+  addRulesForIOpcs({amdgcn_s_quadmask, amdgcn_s_wqm})
+      .Any({{B32}, {{SgprB32}, {IntrId, SgprB32_ReadFirstLane}}})
+      .Any({{B64}, {{SgprB64}, {IntrId, SgprB64_ReadFirstLane}}});
 
   addRulesForIOpcs({amdgcn_writelane}, StandardB)
       .Div(B32,

--- a/llvm/lib/Target/AMDGPU/AMDGPUSearchableTables.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPUSearchableTables.td
@@ -420,6 +420,8 @@ def : AlwaysUniform<int_amdgcn_s_getpc>;
 def : AlwaysUniform<int_amdgcn_s_getreg>;
 def : AlwaysUniform<int_amdgcn_s_memrealtime>;
 def : AlwaysUniform<int_amdgcn_s_memtime>;
+def : AlwaysUniform<int_amdgcn_s_quadmask>;
+def : AlwaysUniform<int_amdgcn_s_wqm>;
 
 def AMDGPUImageDMaskIntrinsicTable : GenericTable {
   let FilterClass = "AMDGPUImageDMaskIntrinsic";

--- a/llvm/test/Analysis/UniformityAnalysis/AMDGPU/always_uniform.ll
+++ b/llvm/test/Analysis/UniformityAnalysis/AMDGPU/always_uniform.ll
@@ -119,6 +119,38 @@ define void @s_getreg(ptr addrspace(1) inreg %out) {
   ret void
 }
 
+; CHECK-LABEL: for function 's_quadmask_i32':
+; CHECK: DIVERGENT: i32 %mask
+; CHECK-NOT: DIVERGENT
+define i32 @s_quadmask_i32(i32 %mask) {
+  %result = call i32 @llvm.amdgcn.s.quadmask.i32(i32 %mask)
+  ret i32 %result
+}
+
+; CHECK-LABEL: for function 's_quadmask_i64':
+; CHECK: DIVERGENT: i64 %mask
+; CHECK-NOT: DIVERGENT
+define i64 @s_quadmask_i64(i64 %mask) {
+  %result = call i64 @llvm.amdgcn.s.quadmask.i64(i64 %mask)
+  ret i64 %result
+}
+
+; CHECK-LABEL: for function 's_wqm_i32':
+; CHECK: DIVERGENT: i32 %mask
+; CHECK-NOT: DIVERGENT
+define i32 @s_wqm_i32(i32 %mask) {
+  %result = call i32 @llvm.amdgcn.s.wqm.i32(i32 %mask)
+  ret i32 %result
+}
+
+; CHECK-LABEL: for function 's_wqm_i64':
+; CHECK: DIVERGENT: i64 %mask
+; CHECK-NOT: DIVERGENT
+define i64 @s_wqm_i64(i64 %mask) {
+  %result = call i64 @llvm.amdgcn.s.wqm.i64(i64 %mask)
+  ret i64 %result
+}
+
 ; CHECK-LABEL: for function 's_get_barrier_state':
 ; CHECK: DIVERGENT: i32 %bar
 ; CHECK-NOT: DIVERGENT


### PR DESCRIPTION
This change also marks the intrinsics 
`amdgcn_s_quadmask` and `amdgcn_s_wqm` 
as AlwaysUniform.