### PR TITLE
[NFC][analyzer] Remove NodeBuilders in ObjC logic

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -594,6 +594,14 @@ public:
   void VisitObjCForCollectionStmt(const ObjCForCollectionStmt *S,
                                   ExplodedNode *Pred, ExplodedNodeSet &Dst);
 
+  /// Implementation detail of VisitObjCForCollectionStmt, which contains the
+  /// logic that needs to be executed both in the "container is empty" case
+  /// (HasElements=false) and the "container is not empty" case
+  /// (HasElements=true).
+  void populateObjCForDestinationSet(const ObjCForCollectionStmt *S,
+                                     ExplodedNode *Pred, ExplodedNodeSet &Dst,
+                                     SVal ElementV, bool HasElements);
+
   void VisitObjCMessage(const ObjCMessageExpr *ME, ExplodedNode *Pred,
                         ExplodedNodeSet &Dst);
 

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineObjC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineObjC.cpp
@@ -39,15 +39,13 @@ void ExprEngine::VisitObjCAtSynchronizedStmt(const ObjCAtSynchronizedStmt *S,
   getCheckerManager().runCheckersForPreStmt(Dst, Pred, S, *this);
 }
 
-/// Generate a node in \p Bldr for an iteration statement using ObjC
+/// Generate a node into \p Dst for an iteration statement using ObjC
 /// for-loop iterator.
-static void populateObjCForDestinationSet(ExplodedNode *Pred,
-                                          SValBuilder &svalBuilder,
-                                          const ObjCForCollectionStmt *S,
-                                          ConstCFGElementRef elem,
-                                          SVal elementV, SymbolManager &SymMgr,
-                                          unsigned NumVisitedCurrent,
-                                          NodeBuilder &Bldr, bool hasElements) {
+static void populateObjCForDestinationSet(
+    ExplodedNode *Pred, SValBuilder &svalBuilder,
+    const ObjCForCollectionStmt *S, ConstCFGElementRef elem, SVal elementV,
+    SymbolManager &SymMgr, unsigned NumVisitedCurrent, ExplodedNodeSet &Dst,
+    CoreEngine &Engine, bool hasElements) {
 
   ProgramStateRef state = Pred->getState();
   const StackFrame *SF = Pred->getStackFrame();
@@ -74,7 +72,7 @@ static void populateObjCForDestinationSet(ExplodedNode *Pred,
       nextState = nextState->bindLoc(elementV, V, SF);
     }
 
-  Bldr.generateNode(S, Pred, nextState);
+  Dst.insert(Engine.makePostStmtNode(S, nextState, Pred));
 }
 
 void ExprEngine::VisitObjCForCollectionStmt(const ObjCForCollectionStmt *S,
@@ -128,17 +126,16 @@ void ExprEngine::VisitObjCForCollectionStmt(const ObjCForCollectionStmt *S,
 
   for (ExplodedNode *dstLocation : DstLocation) {
     ExplodedNodeSet Tmp;
-    NodeBuilder Bldr(dstLocation, Tmp, *currBldrCtx);
 
     if (!isContainerNull)
-      populateObjCForDestinationSet(dstLocation, svalBuilder, S,
-                                    elemRef, elementV, SymMgr,
-                                    getNumVisitedCurrent(), Bldr,
+      populateObjCForDestinationSet(dstLocation, svalBuilder, S, elemRef,
+                                    elementV, SymMgr, getNumVisitedCurrent(),
+                                    Tmp, Engine,
                                     /*hasElements=*/true);
 
     populateObjCForDestinationSet(dstLocation, svalBuilder, S, elemRef,
-                                  elementV, SymMgr, getNumVisitedCurrent(),
-                                  Bldr,
+                                  elementV, SymMgr, getNumVisitedCurrent(), Tmp,
+                                  Engine,
                                   /*hasElements=*/false);
 
     // Finally, run any custom checkers.

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineObjC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineObjC.cpp
@@ -196,11 +196,9 @@ void ExprEngine::VisitObjCMessage(const ObjCMessageExpr *ME,
 
       // Receiver is definitely nil, so run ObjCMessageNil callbacks and return.
       if (nilState && !notNilState) {
-        ExplodedNodeSet dstNil;
-        NodeBuilder Bldr(Pred, dstNil, *currBldrCtx);
         bool HasTag = Pred->getLocation().getTag();
-        Pred = Bldr.generateNode(ME, Pred, nilState, nullptr,
-                                 ProgramPoint::PreStmtKind);
+        PreStmt PS(ME, Pred->getStackFrame(), nullptr);
+        Pred = Engine.makeNode(PS, nilState, Pred);
         assert((Pred || HasTag) && "Should have cached out already!");
         (void)HasTag;
         if (!Pred)
@@ -214,13 +212,11 @@ void ExprEngine::VisitObjCMessage(const ObjCMessageExpr *ME,
         return;
       }
 
-      ExplodedNodeSet dstNonNil;
-      NodeBuilder Bldr(Pred, dstNonNil, *currBldrCtx);
       // Generate a transition to the non-nil state, dropping any potential
       // nil flow.
       if (notNilState != State) {
         bool HasTag = Pred->getLocation().getTag();
-        Pred = Bldr.generateNode(ME, Pred, notNilState);
+        Pred = Engine.makePostStmtNode(ME, notNilState, Pred);
         assert((Pred || HasTag) && "Should have cached out already!");
         (void)HasTag;
         if (!Pred)

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineObjC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineObjC.cpp
@@ -41,7 +41,7 @@ void ExprEngine::VisitObjCAtSynchronizedStmt(const ObjCAtSynchronizedStmt *S,
 
 /// Generate a node in \p Bldr for an iteration statement using ObjC
 /// for-loop iterator.
-static void populateObjCForDestinationSet(ExplodedNodeSet &dstLocation,
+static void populateObjCForDestinationSet(ExplodedNode *Pred,
                                           SValBuilder &svalBuilder,
                                           const ObjCForCollectionStmt *S,
                                           ConstCFGElementRef elem,
@@ -49,34 +49,32 @@ static void populateObjCForDestinationSet(ExplodedNodeSet &dstLocation,
                                           unsigned NumVisitedCurrent,
                                           NodeBuilder &Bldr, bool hasElements) {
 
-  for (ExplodedNode *Pred : dstLocation) {
-    ProgramStateRef state = Pred->getState();
-    const StackFrame *SF = Pred->getStackFrame();
+  ProgramStateRef state = Pred->getState();
+  const StackFrame *SF = Pred->getStackFrame();
 
-    ProgramStateRef nextState =
-        ExprEngine::setWhetherHasMoreIteration(state, S, SF, hasElements);
+  ProgramStateRef nextState =
+      ExprEngine::setWhetherHasMoreIteration(state, S, SF, hasElements);
 
-    if (auto MV = elementV.getAs<loc::MemRegionVal>())
-      if (const auto *R = dyn_cast<TypedValueRegion>(MV->getRegion())) {
-        // FIXME: The proper thing to do is to really iterate over the
-        //  container.  We will do this with dispatch logic to the store.
-        //  For now, just 'conjure' up a symbolic value.
-        QualType T = R->getValueType();
-        assert(Loc::isLocType(T));
+  if (auto MV = elementV.getAs<loc::MemRegionVal>())
+    if (const auto *R = dyn_cast<TypedValueRegion>(MV->getRegion())) {
+      // FIXME: The proper thing to do is to really iterate over the
+      //  container.  We will do this with dispatch logic to the store.
+      //  For now, just 'conjure' up a symbolic value.
+      QualType T = R->getValueType();
+      assert(Loc::isLocType(T));
 
-        SVal V;
-        if (hasElements) {
-          SymbolRef Sym = SymMgr.conjureSymbol(elem, SF, T, NumVisitedCurrent);
-          V = svalBuilder.makeLoc(Sym);
-        } else {
-          V = svalBuilder.makeIntVal(0, T);
-        }
-
-        nextState = nextState->bindLoc(elementV, V, SF);
+      SVal V;
+      if (hasElements) {
+        SymbolRef Sym = SymMgr.conjureSymbol(elem, SF, T, NumVisitedCurrent);
+        V = svalBuilder.makeLoc(Sym);
+      } else {
+        V = svalBuilder.makeIntVal(0, T);
       }
 
-    Bldr.generateNode(S, Pred, nextState);
-  }
+      nextState = nextState->bindLoc(elementV, V, SF);
+    }
+
+  Bldr.generateNode(S, Pred, nextState);
 }
 
 void ExprEngine::VisitObjCForCollectionStmt(const ObjCForCollectionStmt *S,
@@ -129,16 +127,16 @@ void ExprEngine::VisitObjCForCollectionStmt(const ObjCForCollectionStmt *S,
   evalLocation(DstLocation, S, elem, Pred, state, elementV, false);
 
   for (ExplodedNode *dstLocation : DstLocation) {
-    ExplodedNodeSet DstLocationSingleton{dstLocation}, Tmp;
+    ExplodedNodeSet Tmp;
     NodeBuilder Bldr(dstLocation, Tmp, *currBldrCtx);
 
     if (!isContainerNull)
-      populateObjCForDestinationSet(DstLocationSingleton, svalBuilder, S,
+      populateObjCForDestinationSet(dstLocation, svalBuilder, S,
                                     elemRef, elementV, SymMgr,
                                     getNumVisitedCurrent(), Bldr,
                                     /*hasElements=*/true);
 
-    populateObjCForDestinationSet(DstLocationSingleton, svalBuilder, S, elemRef,
+    populateObjCForDestinationSet(dstLocation, svalBuilder, S, elemRef,
                                   elementV, SymMgr, getNumVisitedCurrent(),
                                   Bldr,
                                   /*hasElements=*/false);

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineObjC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineObjC.cpp
@@ -42,15 +42,14 @@ void ExprEngine::VisitObjCAtSynchronizedStmt(const ObjCAtSynchronizedStmt *S,
 void ExprEngine::populateObjCForDestinationSet(const ObjCForCollectionStmt *S,
                                                ExplodedNode *Pred,
                                                ExplodedNodeSet &Dst,
-                                               SVal elementV,
-                                               bool hasElements) {
-  ProgramStateRef state = Pred->getState();
+                                               SVal ElementV,
+                                               bool HasElements) {
+  ProgramStateRef State = Pred->getState();
   const StackFrame *SF = Pred->getStackFrame();
 
-  ProgramStateRef nextState =
-      ExprEngine::setWhetherHasMoreIteration(state, S, SF, hasElements);
+  State = ExprEngine::setWhetherHasMoreIteration(State, S, SF, HasElements);
 
-  if (auto MV = elementV.getAs<loc::MemRegionVal>())
+  if (auto MV = ElementV.getAs<loc::MemRegionVal>())
     if (const auto *R = dyn_cast<TypedValueRegion>(MV->getRegion())) {
       // FIXME: The proper thing to do is to really iterate over the
       //  container.  We will do this with dispatch logic to the store.
@@ -59,7 +58,7 @@ void ExprEngine::populateObjCForDestinationSet(const ObjCForCollectionStmt *S,
       assert(Loc::isLocType(T));
 
       SVal V;
-      if (hasElements) {
+      if (HasElements) {
         SymbolRef Sym = SymMgr.conjureSymbol(getCFGElementRef(), SF, T,
                                              getNumVisitedCurrent());
         V = svalBuilder.makeLoc(Sym);
@@ -67,10 +66,10 @@ void ExprEngine::populateObjCForDestinationSet(const ObjCForCollectionStmt *S,
         V = svalBuilder.makeIntVal(0, T);
       }
 
-      nextState = nextState->bindLoc(elementV, V, SF);
+      State = State->bindLoc(ElementV, V, SF);
     }
 
-  Dst.insert(Engine.makePostStmtNode(S, nextState, Pred));
+  Dst.insert(Engine.makePostStmtNode(S, State, Pred));
 }
 
 void ExprEngine::VisitObjCForCollectionStmt(const ObjCForCollectionStmt *S,

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineObjC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineObjC.cpp
@@ -39,14 +39,11 @@ void ExprEngine::VisitObjCAtSynchronizedStmt(const ObjCAtSynchronizedStmt *S,
   getCheckerManager().runCheckersForPreStmt(Dst, Pred, S, *this);
 }
 
-/// Generate a node into \p Dst for an iteration statement using ObjC
-/// for-loop iterator.
-static void populateObjCForDestinationSet(
-    ExplodedNode *Pred, SValBuilder &svalBuilder,
-    const ObjCForCollectionStmt *S, ConstCFGElementRef elem, SVal elementV,
-    SymbolManager &SymMgr, unsigned NumVisitedCurrent, ExplodedNodeSet &Dst,
-    CoreEngine &Engine, bool hasElements) {
-
+void ExprEngine::populateObjCForDestinationSet(const ObjCForCollectionStmt *S,
+                                               ExplodedNode *Pred,
+                                               ExplodedNodeSet &Dst,
+                                               SVal elementV,
+                                               bool hasElements) {
   ProgramStateRef state = Pred->getState();
   const StackFrame *SF = Pred->getStackFrame();
 
@@ -63,7 +60,8 @@ static void populateObjCForDestinationSet(
 
       SVal V;
       if (hasElements) {
-        SymbolRef Sym = SymMgr.conjureSymbol(elem, SF, T, NumVisitedCurrent);
+        SymbolRef Sym = SymMgr.conjureSymbol(getCFGElementRef(), SF, T,
+                                             getNumVisitedCurrent());
         V = svalBuilder.makeLoc(Sym);
       } else {
         V = svalBuilder.makeIntVal(0, T);
@@ -105,7 +103,6 @@ void ExprEngine::VisitObjCForCollectionStmt(const ObjCForCollectionStmt *S,
 
   const Stmt *elem = S->getElement();
   const Expr *collection = S->getCollection();
-  const ConstCFGElementRef &elemRef = getCFGElementRef();
   ProgramStateRef state = Pred->getState();
 
   SVal collectionV = state->getSVal(collection, Pred->getStackFrame());
@@ -128,14 +125,10 @@ void ExprEngine::VisitObjCForCollectionStmt(const ObjCForCollectionStmt *S,
     ExplodedNodeSet Tmp;
 
     if (!isContainerNull)
-      populateObjCForDestinationSet(dstLocation, svalBuilder, S, elemRef,
-                                    elementV, SymMgr, getNumVisitedCurrent(),
-                                    Tmp, Engine,
+      populateObjCForDestinationSet(S, dstLocation, Tmp, elementV,
                                     /*hasElements=*/true);
 
-    populateObjCForDestinationSet(dstLocation, svalBuilder, S, elemRef,
-                                  elementV, SymMgr, getNumVisitedCurrent(), Tmp,
-                                  Engine,
+    populateObjCForDestinationSet(S, dstLocation, Tmp, elementV,
                                   /*hasElements=*/false);
 
     // Finally, run any custom checkers.

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineObjC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineObjC.cpp
@@ -231,9 +231,7 @@ void ExprEngine::VisitObjCMessage(const ObjCMessageExpr *ME,
   ExplodedNodeSet dstEval;
   NodeBuilder Bldr(dstGenericPrevisit, dstEval, *currBldrCtx);
 
-  for (ExplodedNodeSet::iterator DI = dstGenericPrevisit.begin(),
-       DE = dstGenericPrevisit.end(); DI != DE; ++DI) {
-    ExplodedNode *Pred = *DI;
+  for (ExplodedNode *Pred : dstGenericPrevisit) {
     ProgramStateRef State = Pred->getState();
     CallEventRef<ObjCMethodCall> UpdatedMsg = Msg.cloneWithState(State);
 

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineObjC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineObjC.cpp
@@ -26,13 +26,11 @@ void ExprEngine::VisitLvalObjCIvarRefExpr(const ObjCIvarRefExpr *Ex,
   SVal baseVal = state->getSVal(Ex->getBase(), SF);
   SVal location = state->getLValue(Ex->getDecl(), baseVal);
 
-  ExplodedNodeSet dstIvar;
-  NodeBuilder Bldr(Pred, dstIvar, *currBldrCtx);
-  Bldr.generateNode(Ex, Pred, state->BindExpr(Ex, SF, location));
+  ExplodedNode *N = Engine.makeNodeWithBinding(Pred, Ex, location);
 
   // Perform the post-condition check of the ObjCIvarRefExpr and store
   // the created nodes in 'Dst'.
-  getCheckerManager().runCheckersForPostStmt(Dst, dstIvar, Ex, *this);
+  getCheckerManager().runCheckersForPostStmt(Dst, N, Ex, *this);
 }
 
 void ExprEngine::VisitObjCAtSynchronizedStmt(const ObjCAtSynchronizedStmt *S,

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineObjC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineObjC.cpp
@@ -120,15 +120,13 @@ void ExprEngine::VisitObjCForCollectionStmt(const ObjCForCollectionStmt *S,
   ExplodedNodeSet DstLocation; // states in `DstLocation` may differ from `Pred`
   evalLocation(DstLocation, S, elem, Pred, state, elementV, false);
 
-  for (ExplodedNode *dstLocation : DstLocation) {
+  for (ExplodedNode *N : DstLocation) {
     ExplodedNodeSet Tmp;
 
     if (!isContainerNull)
-      populateObjCForDestinationSet(S, dstLocation, Tmp, elementV,
-                                    /*hasElements=*/true);
+      populateObjCForDestinationSet(S, N, Tmp, elementV, /*hasElements=*/true);
 
-    populateObjCForDestinationSet(S, dstLocation, Tmp, elementV,
-                                  /*hasElements=*/false);
+    populateObjCForDestinationSet(S, N, Tmp, elementV, /*hasElements=*/false);
 
     // Finally, run any custom checkers.
     // FIXME: Eventually all pre- and post-checks should live in VisitStmt.

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineObjC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineObjC.cpp
@@ -196,11 +196,8 @@ void ExprEngine::VisitObjCMessage(const ObjCMessageExpr *ME,
 
       // Receiver is definitely nil, so run ObjCMessageNil callbacks and return.
       if (nilState && !notNilState) {
-        bool HasTag = Pred->getLocation().getTag();
         PreStmt PS(ME, Pred->getStackFrame(), nullptr);
         Pred = Engine.makeNode(PS, nilState, Pred);
-        assert((Pred || HasTag) && "Should have cached out already!");
-        (void)HasTag;
         if (!Pred)
           return;
 
@@ -215,10 +212,7 @@ void ExprEngine::VisitObjCMessage(const ObjCMessageExpr *ME,
       // Generate a transition to the non-nil state, dropping any potential
       // nil flow.
       if (notNilState != State) {
-        bool HasTag = Pred->getLocation().getTag();
         Pred = Engine.makePostStmtNode(ME, notNilState, Pred);
-        assert((Pred || HasTag) && "Should have cached out already!");
-        (void)HasTag;
         if (!Pred)
           return;
       }

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineObjC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineObjC.cpp
@@ -231,7 +231,9 @@ void ExprEngine::VisitObjCMessage(const ObjCMessageExpr *ME,
   ExplodedNodeSet dstEval;
   NodeBuilder Bldr(dstGenericPrevisit, dstEval, *currBldrCtx);
 
-  for (ExplodedNode *Pred : dstGenericPrevisit) {
+  for (ExplodedNodeSet::iterator DI = dstGenericPrevisit.begin(),
+       DE = dstGenericPrevisit.end(); DI != DE; ++DI) {
+    ExplodedNode *Pred = *DI;
     ProgramStateRef State = Pred->getState();
     CallEventRef<ObjCMethodCall> UpdatedMsg = Msg.cloneWithState(State);
 


### PR DESCRIPTION
This change removes the remaining `NodeBuilder`s from `ExprEngineObjC.cpp` as a step of my project to gradually replace the class `NodeBuilder` with more straightforward tools. (One other `NodeBuilder` in `VisitObjCMessage` was removed by 236f63474d40850a33fd4bcc6d8d63a31cebb8f1.)

The `NodeBuilder`s that I remove were all used in very simple patterns, especially the two `NodeBuilder`s in `VisitObjCMessage` where the `Frontier` set is thrown away and the code continues with the return value of `generateNode` (which is exactly the same as the return value of the appropriate `makeNode` call).

In addition to the removal of the `NodeBuilder`s, this change also includes two additional NFC improvements:

1.  `populateObjCForDestinationSet` was previously a static helper function with nine (!) awkward arguments; this change turns it into a method of `ExprEngine` with only five arguments (and the first three arguments are customary: _expression_, `Pred`, `Dst` as in the transfer functions). This change was necessary for the `NodeBuilder` removal: without this cleanup I would have had to add a tenth argument.

2. In `VisitObjCMessage` I remove two complex and pointless assertions. The ancestor of these was a simple and useful
```c++
  Pred = Bldr.generateNode(currStmt, Pred, notNilState);
  assert(Pred && "Should have cached out already!");
```
introduced in 2012 by 5481cfefa63624c4a91da0e05a1140e29ce6f65a in a checker, but since then it was relocated to the engine, duplicated and weakened to `assert(Pred || HasTag)`.

As `HasTag` can easily be true and is independent of everything else in this function, the current assertions (which are removed in this change) don't provide any helpful invariant, they just state that "`Pred` is not null ... except when it is null".

------

Note for reviewers: this PR consists of nine commits, and the individual commit messages explain why each change is NFC.