### PR TITLE
[clang][z/OS] Add test for TypeLoc tail padding alignment

### DIFF
--- a/clang/test/AST/tyloctype_alignment.cpp
+++ b/clang/test/AST/tyloctype_alignment.cpp
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -ast-dump  %s | FileCheck %s
+
+// Regression test for assertion failure in CreateTypeSourceInfo
+// due to incorrect TypeLoc data size alignment.
+
+// CHECK: FunctionTemplateDecl {{.*}} fpclassify
+template<class T>
+int fpclassify(T v);
+template<>
+int fpclassify<float> (float v);

--- a/clang/test/Driver/tyloctype_alignment.cpp
+++ b/clang/test/Driver/tyloctype_alignment.cpp
@@ -1,0 +1,6 @@
+// RUN: %clang -c %s
+
+template<class T>
+int fpclassify(T v);
+template<>
+int fpclassify<float> (float v);

--- a/clang/test/Driver/tyloctype_alignment.cpp
+++ b/clang/test/Driver/tyloctype_alignment.cpp
@@ -1,6 +1,0 @@
-// RUN: %clang -c %s
-
-template<class T>
-int fpclassify(T v);
-template<>
-int fpclassify<float> (float v);


### PR DESCRIPTION
This adds a test for the TypeLoc tail padding fix that was merged in commit 89305c3.