### PR TITLE
[cmake] Add llvm-readobj before lldb

### DIFF
--- a/llvm/tools/CMakeLists.txt
+++ b/llvm/tools/CMakeLists.txt
@@ -36,6 +36,7 @@ add_llvm_tool_subdirectory(llvm-ctxprof-util)
 add_llvm_tool_subdirectory(llvm-lto)
 add_llvm_tool_subdirectory(llvm-profdata)
 add_llvm_tool_subdirectory(llvm-nm)
+add_llvm_tool_subdirectory(llvm-readobj)
 
 # Projects supported via LLVM_EXTERNAL_*_SOURCE_DIR need to be explicitly
 # specified.


### PR DESCRIPTION
After #199152, following CMake error is found when building llvm-lit:

```
CMake Error at cmake/modules/AddLLVM.cmake:2816 (get_target_property):
  get_target_property() called with non-existent target "llvm-readobj".
Call Stack (most recent call first):
  cmake/modules/AddLLVM.cmake:1513 (get_host_tool_path)
  cmake/modules/AddLLVM.cmake:1556 (export_executable_symbols)
  tools/llvm-lto2/CMakeLists.txt:27 (export_executable_symbols_for_plugins)
```
Fixed by adding llvm-readobj before lldb. (Similar to https://github.com/llvm/llvm-project/pull/201648)