### PR TITLE
[NFC][lldb][Windows] Clean up TargetThreadWindows

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/TargetThreadWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/TargetThreadWindows.cpp
@@ -33,7 +33,7 @@ using namespace lldb_private;
 TargetThreadWindows::TargetThreadWindows(ProcessWindows &process,
                                          const HostThread &thread)
     : Thread(process, thread.GetNativeThread().GetThreadId()),
-      m_thread_reg_ctx_sp(), m_host_thread(thread) {}
+      m_host_thread(thread) {}
 
 TargetThreadWindows::~TargetThreadWindows() { DestroyThread(); }
 

--- a/lldb/source/Plugins/Process/Windows/Common/TargetThreadWindows.h
+++ b/lldb/source/Plugins/Process/Windows/Common/TargetThreadWindows.h
@@ -9,7 +9,6 @@
 #ifndef liblldb_Plugins_Process_Windows_TargetThreadWindows_H_
 #define liblldb_Plugins_Process_Windows_TargetThreadWindows_H_
 
-//#include "ForwardDecl.h"
 #include "lldb/Host/HostThread.h"
 #include "lldb/Target/Thread.h"
 #include "lldb/lldb-forward.h"
@@ -18,7 +17,6 @@
 
 namespace lldb_private {
 class ProcessWindows;
-class HostThread;
 class StackFrame;
 
 class TargetThreadWindows : public lldb_private::Thread {


### PR DESCRIPTION
- Drop dead `//#include "ForwardDecl.h"` and stale `class HostThread;` forward declaration.
- Remove redundant `m_thread_reg_ctx_sp()` default-init in the constructor initializer list.