### PR TITLE
[NFC][lldb][Windows] Clean up NativeThreadWindows

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/NativeThreadWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeThreadWindows.cpp
@@ -13,12 +13,10 @@
 #include "lldb/Host/windows/HostThreadWindows.h"
 #include "lldb/Host/windows/LazyImport.h"
 #include "lldb/Host/windows/windows.h"
-#include "lldb/Target/Process.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/State.h"
 
-#include "lldb/lldb-forward.h"
 #include <llvm/Support/ConvertUTF.h>
 
 using namespace lldb;
@@ -61,8 +59,7 @@ Status NativeThreadWindows::DoResume(lldb::StateType resume_state) {
             eRegisterKindGeneric, LLDB_REGNUM_GENERIC_FLAGS);
     uint64_t flags_value =
         GetRegisterContext().ReadRegisterAsUnsigned(flags_index, 0);
-    NativeProcessProtocol &process = GetProcess();
-    const ArchSpec &arch = process.GetArchitecture();
+    const ArchSpec &arch = GetProcess().GetArchitecture();
     switch (arch.GetMachine()) {
     case llvm::Triple::x86:
     case llvm::Triple::x86_64:
@@ -154,11 +151,8 @@ bool NativeThreadWindows::GetStopReason(ThreadStopInfo &stop_info,
   case eStateRunning:
   case eStateStepping:
   case eStateDetached:
-    if (log) {
-      log->Printf("NativeThreadWindows::%s tid %" PRIu64
-                  " in state %s cannot answer stop reason",
-                  __FUNCTION__, GetID(), StateAsCString(m_state));
-    }
+    LLDB_LOGF(log, "tid %" PRIu64 " in state %s cannot answer stop reason",
+              GetID(), StateAsCString(m_state));
     return false;
   }
   llvm_unreachable("unhandled StateType!");


### PR DESCRIPTION
- Drop unused #includes lldb/Target/Process.h and lldb/lldb-forward.h.
- Inline the one-shot NativeProcessProtocol& local in DoResume and modernize GetStopReason's stale legacy log->Printf idiom to LLDB_LOGF.