### PR TITLE
[alpha.webkit.UncountedCallArgsChecker] Improve the warning text

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
@@ -388,6 +388,20 @@ bool isAllocInit(const Expr *E, const Expr **InnerExpr) {
   return false;
 }
 
+ObjCInterfaceDecl *getObjCDeclFromObjCPtr(const Type *TypePtr) {
+  auto *PointeeType = TypePtr->getPointeeType().getTypePtrOrNull();
+  if (!PointeeType)
+    return nullptr;
+  auto *Desugared = PointeeType->getUnqualifiedDesugaredType();
+  if (!Desugared)
+    return nullptr;
+  if (auto *ObjCType = dyn_cast<ObjCInterfaceType>(Desugared))
+    return ObjCType->getDecl();
+  if (auto *ObjCType = dyn_cast<ObjCObjectType>(Desugared))
+    return ObjCType->getInterface();
+  return nullptr;
+}
+
 class EnsureFunctionVisitor
     : public ConstStmtVisitor<EnsureFunctionVisitor, bool> {
 public:

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.h
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.h
@@ -81,6 +81,9 @@ bool isExprToGetCheckedPtrCapableMember(const clang::Expr *E);
 /// Sets \p InnerExpr to the inner function call or selector invocation.
 bool isAllocInit(const Expr *E, const Expr **InnerExpr = nullptr);
 
+/// \returns ObjCInterfaceDecl from a pointer type.
+ObjCInterfaceDecl *getObjCDeclFromObjCPtr(const Type *TypePtr);
+
 /// \returns true if E is a CXXMemberCallExpr which returns a const smart
 /// pointer type.
 class EnsureFunctionAnalysis {

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -284,7 +284,7 @@ void RetainTypeChecker::visitTypedef(const TypedefDecl *TD) {
   for (auto *Redecl : RT->getDecl()->getMostRecentDecl()->redecls()) {
     if (Redecl->getAttr<ObjCBridgeAttr>() ||
         Redecl->getAttr<ObjCBridgeMutableAttr>()) {
-      CFPointees.insert(RT);
+      CFPointees.insert(std::make_pair(RT, TD));
       return;
     }
   }
@@ -297,6 +297,25 @@ bool RetainTypeChecker::isUnretained(const QualType QT, bool ignoreARC) {
           QT.getCanonicalType()->getPointeeType().getTypePtrOrNull()))
     return CFPointees.contains(RT);
   return RecordlessTypes.contains(QT.getTypePtr());
+}
+
+const TypedefDecl *RetainTypeChecker::getCanonicalDecl(QualType QT) {
+  if (auto *TT = dyn_cast_or_null<TypedefType>(QT.getTypePtrOrNull())) {
+    if (auto *TD = dyn_cast<TypedefDecl>(TT->getDecl()))
+      return TD;
+  }
+  QT = QT.getCanonicalType();
+  auto PointeeQT = QT.getCanonicalType()->getPointeeType();
+  auto *PointeeType = PointeeQT.getTypePtrOrNull();
+  if (!PointeeType)
+    return nullptr;
+  auto *RD = dyn_cast<RecordType>(PointeeType);
+  if (!RD)
+    return nullptr;
+  auto It = CFPointees.find(RD);
+  if (It == CFPointees.end())
+    return nullptr;
+  return It->second;
 }
 
 std::optional<bool> isUncounted(const CXXRecordDecl* Class)

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -284,7 +284,7 @@ void RetainTypeChecker::visitTypedef(const TypedefDecl *TD) {
   for (auto *Redecl : RT->getDecl()->getMostRecentDecl()->redecls()) {
     if (Redecl->getAttr<ObjCBridgeAttr>() ||
         Redecl->getAttr<ObjCBridgeMutableAttr>()) {
-      CFPointees.insert(std::make_pair(RT, TD));
+      CFPointees.insert({RT, TD});
       return;
     }
   }
@@ -305,17 +305,14 @@ const TypedefDecl *RetainTypeChecker::getCanonicalDecl(QualType QT) {
       return TD;
   }
   QT = QT.getCanonicalType();
-  auto PointeeQT = QT.getCanonicalType()->getPointeeType();
+  auto PointeeQT = QT->getPointeeType();
   auto *PointeeType = PointeeQT.getTypePtrOrNull();
   if (!PointeeType)
     return nullptr;
   auto *RD = dyn_cast<RecordType>(PointeeType);
   if (!RD)
     return nullptr;
-  auto It = CFPointees.find(RD);
-  if (It == CFPointees.end())
-    return nullptr;
-  return It->second;
+  return CFPointees.lookup(RD);
 }
 
 std::optional<bool> isUncounted(const CXXRecordDecl* Class)

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.h
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.h
@@ -80,7 +80,7 @@ std::optional<bool> isUnchecked(const clang::QualType T);
 /// An inter-procedural analysis facility that detects CF types with the
 /// underlying pointer type.
 class RetainTypeChecker {
-  llvm::DenseSet<const RecordType *> CFPointees;
+  llvm::DenseMap<const RecordType *, const TypedefDecl *> CFPointees;
   llvm::DenseSet<const Type *> RecordlessTypes;
   bool IsARCEnabled{false};
   bool DefaultSynthProperties{true};
@@ -91,6 +91,7 @@ public:
   bool isUnretained(const QualType, bool ignoreARC = false);
   bool isARCEnabled() const { return IsARCEnabled; }
   bool defaultSynthProperties() const { return DefaultSynthProperties; }
+  const TypedefDecl *getCanonicalDecl(QualType);
 };
 
 /// \returns true if \p Class is ref-countable AND not ref-counted, false if

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
@@ -14,6 +14,7 @@
 #include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/Analysis/DomainSpecific/CocoaConventions.h"
 #include "clang/Basic/SourceLocation.h"
+#include "clang/Lex/Lexer.h"
 #include "clang/StaticAnalyzer/Checkers/BuiltinCheckerRegistration.h"
 #include "clang/StaticAnalyzer/Core/BugReporter/BugReporter.h"
 #include "clang/StaticAnalyzer/Core/BugReporter/BugType.h"
@@ -47,7 +48,7 @@ public:
   virtual bool isSafePtrType(const QualType type) const = 0;
   virtual bool isSafeExpr(const Expr *) const { return false; }
   virtual bool isSafeDecl(const Decl *) const { return false; }
-  virtual const char *ptrKind() const = 0;
+  virtual const char *typeName() const = 0;
 
   void checkASTDecl(const TranslationUnitDecl *TUD, AnalysisManager &MGR,
                     BugReporter &BRArg) const {
@@ -118,14 +119,14 @@ public:
           isa<CXXOperatorCallExpr>(CE) && isa_and_nonnull<CXXMethodDecl>(F);
 
       if (auto *MemberCallExpr = dyn_cast<CXXMemberCallExpr>(CE))
-        checkThisArg(MemberCallExpr, D);
+        checkThisArg(F, MemberCallExpr, D);
 
       if (ArgIdx) {
         auto *Arg = CE->getArg(0);
         QualType ArgType = Arg->getType().getCanonicalType();
         std::optional<bool> IsUnsafe = isUnsafeType(ArgType);
         if (IsUnsafe && *IsUnsafe && !isPtrOriginSafe(Arg))
-          reportBugOnThis(Arg, D);
+          reportBugOnThis(F, Arg, D);
       }
 
       for (auto P = F->param_begin();
@@ -133,11 +134,11 @@ public:
         // TODO: attributes.
         // if ((*P)->hasAttr<SafeRefCntblRawPtrAttr>())
         //  continue;
-        checkArg(CE->getArg(ArgIdx), (*P)->getType(), *P, D);
+        checkArg(F, CE->getArg(ArgIdx), (*P)->getType(), *P, D);
       }
       for (; ArgIdx < CE->getNumArgs(); ++ArgIdx) {
         auto *Arg = CE->getArg(ArgIdx);
-        checkArg(Arg, Arg->getType(), nullptr, D);
+        checkArg(F, Arg, Arg->getType(), nullptr, D);
       }
     }
   }
@@ -153,15 +154,15 @@ public:
       if (auto *FnType = Decl->getFunctionType()) {
         if (auto *ProtoType = dyn_cast<FunctionProtoType>(FnType)) {
           if (auto *MemberCallExpr = dyn_cast<CXXMemberCallExpr>(CE))
-            checkThisArg(MemberCallExpr, D);
+            checkThisArg(nullptr, MemberCallExpr, D);
           unsigned ArgIdx = 0;
           for (auto PT = ProtoType->param_type_begin();
                PT < ProtoType->param_type_end() && ArgIdx < CE->getNumArgs();
                ++PT, ++ArgIdx)
-            checkArg(CE->getArg(ArgIdx), *PT, nullptr, D);
+            checkArg(nullptr, CE->getArg(ArgIdx), *PT, nullptr, D);
           for (; ArgIdx < CE->getNumArgs(); ++ArgIdx) {
             auto *Arg = CE->getArg(ArgIdx);
-            checkArg(Arg, Arg->getType(), nullptr, D);
+            checkArg(nullptr, Arg, Arg->getType(), nullptr, D);
           }
         }
       }
@@ -188,7 +189,7 @@ public:
         auto SelectorName = E->getSelector().getNameForSlot(0);
         if (SelectorName == "isEqual" || SelectorName == "isEqualToString")
           return;
-        reportBugOnReceiver(Receiver, D);
+        reportBugOnReceiver(E->getMethodDecl(), Receiver, D);
       }
     }
 
@@ -207,11 +208,12 @@ public:
         continue;
       if (isPtrOriginSafe(Arg))
         continue;
-      reportBug(Arg, Param, D);
+      reportBug(MethodDecl, Arg, Param, D);
     }
   }
 
-  void checkThisArg(const CXXMemberCallExpr *MemberCallExpr,
+  void checkThisArg(const NamedDecl *Callee,
+                    const CXXMemberCallExpr *MemberCallExpr,
                     const Decl *DeclWithIssue) const {
     if (auto *MD = MemberCallExpr->getMethodDecl()) {
       auto name = safeGetName(MD);
@@ -230,11 +232,11 @@ public:
     if (isPtrOriginSafe(ThisExpr))
       return;
 
-    reportBugOnThis(MemberCallExpr, DeclWithIssue);
+    reportBugOnThis(Callee, ThisExpr, DeclWithIssue);
   }
 
-  void checkArg(const Expr *Arg, QualType ParamType, const ParmVarDecl *Param,
-                const Decl *DeclWithIssue) const {
+  void checkArg(const NamedDecl *Callee, const Expr *Arg, QualType ParamType,
+                const ParmVarDecl *Param, const Decl *DeclWithIssue) const {
     std::optional<bool> IsUncounted = isUnsafePtr(ParamType);
     if (!IsUncounted || !(*IsUncounted))
       return;
@@ -245,7 +247,7 @@ public:
     if (isPtrOriginSafe(Arg))
       return;
 
-    reportBug(Arg, Param, DeclWithIssue);
+    reportBug(Callee, Arg, Param, DeclWithIssue);
   }
 
   bool isPtrOriginSafe(const Expr *Arg) const {
@@ -378,20 +380,44 @@ public:
             ClsName.ends_with("String"));
   }
 
-  void reportBug(const Expr *CallArg, const ParmVarDecl *Param,
-                 const Decl *DeclWithIssue) const {
+  void reportBug(const NamedDecl *Callee, const Expr *CallArg,
+                 const ParmVarDecl *Param, const Decl *DeclWithIssue) const {
     assert(CallArg);
 
     SmallString<100> Buf;
     llvm::raw_svector_ostream Os(Buf);
 
     const std::string paramName = safeGetName(Param);
-    Os << "Call argument";
+    Os << "Function argument";
+    printArgument(Os, CallArg, DeclWithIssue);
+    if (!paramName.empty() || Callee)
+      Os << " (";
     if (!paramName.empty()) {
-      Os << " for parameter ";
+      Os << "parameter ";
       printQuotedQualifiedName(Os, Param);
     }
-    Os << " is " << ptrKind() << " and unsafe.";
+    if (Callee) {
+      if (!paramName.empty())
+        Os << " ";
+      Os << "to ";
+      printQuotedQualifiedName(Os, Callee);
+    }
+    if (!paramName.empty() || Callee)
+      Os << ")";
+    Os << " is a ";
+    auto *ArgType = CallArg->getType().getTypePtr();
+
+    if (printPointer(Os, ArgType) == PrintDeclKind::Pointer) {
+      assert(RTC);
+      if (auto *Decl = RTC->getCanonicalDecl(CallArg->getType()))
+        printQuotedQualifiedName(Os, Decl);
+      else {
+        auto Typedef = ArgType->getAs<TypedefType>();
+        assert(Typedef);
+        printQuotedQualifiedName(Os, Typedef->getDecl());
+      }
+    } else
+      printType(Os, CallArg->getType());
 
     bool usesDefaultArgValue = isa<CXXDefaultArgExpr>(CallArg) && Param;
     const SourceLocation SrcLocToReport =
@@ -405,15 +431,23 @@ public:
     BR->emitReport(std::move(Report));
   }
 
-  void reportBugOnThis(const Expr *CallArg, const Decl *DeclWithIssue) const {
+  void reportBugOnThis(const NamedDecl *Callee, const Expr *CallArg,
+                       const Decl *DeclWithIssue) const {
     assert(CallArg);
 
     const SourceLocation SrcLocToReport = CallArg->getSourceRange().getBegin();
 
     SmallString<100> Buf;
     llvm::raw_svector_ostream Os(Buf);
-    Os << "Call argument for 'this' parameter is " << ptrKind();
-    Os << " and unsafe.";
+    Os << "Function argument";
+    printArgument(Os, CallArg, DeclWithIssue);
+    Os << " (parameter 'this'";
+    if (Callee) {
+      Os << " to ";
+      printQuotedQualifiedName(Os, Callee);
+    }
+    Os << ") is a raw pointer to " << typeName();
+    printType(Os, CallArg->getType());
 
     PathDiagnosticLocation BSLoc(SrcLocToReport, BR->getSourceManager());
     auto Report = std::make_unique<BasicBugReport>(Bug, Os.str(), BSLoc);
@@ -422,7 +456,7 @@ public:
     BR->emitReport(std::move(Report));
   }
 
-  void reportBugOnReceiver(const Expr *CallArg,
+  void reportBugOnReceiver(const NamedDecl *Callee, const Expr *CallArg,
                            const Decl *DeclWithIssue) const {
     assert(CallArg);
 
@@ -430,13 +464,62 @@ public:
 
     SmallString<100> Buf;
     llvm::raw_svector_ostream Os(Buf);
-    Os << "Receiver is " << ptrKind() << " and unsafe.";
+    Os << "Receiver";
+    printArgument(Os, CallArg, DeclWithIssue);
+    if (Callee) {
+      Os << " (to ";
+      printQuotedQualifiedName(Os, Callee);
+      Os << ")";
+    }
+    Os << " is a raw pointer to " << typeName();
+    printType(Os, CallArg->getType());
 
     PathDiagnosticLocation BSLoc(SrcLocToReport, BR->getSourceManager());
     auto Report = std::make_unique<BasicBugReport>(Bug, Os.str(), BSLoc);
     Report->addRange(CallArg->getSourceRange());
     Report->setDeclWithIssue(DeclWithIssue);
     BR->emitReport(std::move(Report));
+  }
+
+  void printArgument(llvm::raw_svector_ostream &Os, const Expr *Arg,
+                     const Decl *D) const {
+    SmallString<100> Buf;
+    llvm::raw_svector_ostream ArgOs(Buf);
+    Arg->printPretty(ArgOs, /*Helper=*/nullptr,
+                     D->getASTContext().getPrintingPolicy());
+    auto ArgCode = ArgOs.str();
+    if (ArgCode.contains('\n'))
+      return;
+    ArgCode = ArgCode.slice(0, 50);
+    if (ArgCode.size() == 50)
+      Os << " '" << ArgCode << "...'";
+    else
+      Os << " '" << ArgCode << "'";
+  }
+
+  enum class PrintDeclKind { Pointee, Pointer };
+  virtual PrintDeclKind printPointer(llvm::raw_svector_ostream &Os,
+                                     const Type *T) const {
+    T = T->getUnqualifiedDesugaredType();
+    bool IsPtr = isa<PointerType>(T) || isa<ObjCObjectPointerType>(T);
+    Os << "raw " << (IsPtr ? "pointer" : "reference") << " to " << typeName();
+    return PrintDeclKind::Pointee;
+  }
+
+  void printType(llvm::raw_svector_ostream &Os, const QualType QT) const {
+    auto *ArgType = QT.getTypePtr();
+    if (auto *CXXRD = ArgType->getPointeeCXXRecordDecl()) {
+      Os << " ";
+      printQuotedQualifiedName(Os, CXXRD);
+    } else if (auto *ObjCDecl = getObjCDeclFromObjCPtr(ArgType)) {
+      Os << " ";
+      printQuotedQualifiedName(Os, ObjCDecl);
+    } else if (!ArgType->isPointerOrReferenceType()) {
+      if (auto *RD = ArgType->getAsRecordDecl()) {
+        Os << " ";
+        printQuotedQualifiedName(Os, RD);
+      }
+    }
   }
 };
 
@@ -462,7 +545,7 @@ public:
     return isRefOrCheckedPtrType(type);
   }
 
-  const char *ptrKind() const final { return "uncounted"; }
+  const char *typeName() const final { return "RefPtr capable type"; }
 };
 
 class UncheckedCallArgsChecker final : public RawPtrRefCallArgsChecker {
@@ -491,7 +574,7 @@ public:
     return isExprToGetCheckedPtrCapableMember(E);
   }
 
-  const char *ptrKind() const final { return "unchecked"; }
+  const char *typeName() const final { return "CheckedPtr capable type"; }
 };
 
 class UnretainedCallArgsChecker final : public RawPtrRefCallArgsChecker {
@@ -523,7 +606,16 @@ public:
     return BR->getSourceManager().isInSystemHeader(D->getLocation());
   }
 
-  const char *ptrKind() const final { return "unretained"; }
+  PrintDeclKind printPointer(llvm::raw_svector_ostream &Os,
+                             const Type *T) const final {
+    if (!isa<ObjCObjectPointerType>(T) && T->getAs<TypedefType>()) {
+      Os << typeName() << " ";
+      return PrintDeclKind::Pointer;
+    }
+    return RawPtrRefCallArgsChecker::printPointer(Os, T);
+  }
+
+  const char *typeName() const final { return "RetainPtr capable type"; }
 };
 
 } // namespace

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
@@ -409,15 +409,16 @@ public:
 
     if (printPointer(Os, ArgType) == PrintDeclKind::Pointer) {
       assert(RTC);
-      if (auto *Decl = RTC->getCanonicalDecl(CallArg->getType()))
+      if (auto *Decl = RTC->getCanonicalDecl(CallArg->getType())) {
         printQuotedQualifiedName(Os, Decl);
-      else {
+      } else {
         auto Typedef = ArgType->getAs<TypedefType>();
         assert(Typedef);
         printQuotedQualifiedName(Os, Typedef->getDecl());
       }
-    } else
+    } else {
       printType(Os, CallArg->getType());
+    }
 
     bool usesDefaultArgValue = isa<CXXDefaultArgExpr>(CallArg) && Param;
     const SourceLocation SrcLocToReport =
@@ -487,10 +488,10 @@ public:
     llvm::raw_svector_ostream ArgOs(Buf);
     Arg->printPretty(ArgOs, /*Helper=*/nullptr,
                      D->getASTContext().getPrintingPolicy());
-    auto ArgCode = ArgOs.str();
+    StringRef ArgCode = ArgOs.str();
     if (ArgCode.contains('\n'))
       return;
-    ArgCode = ArgCode.slice(0, 50);
+    ArgCode = ArgCode.take_front(50);
     if (ArgCode.size() == 50)
       Os << " '" << ArgCode << "...'";
     else
@@ -501,7 +502,7 @@ public:
   virtual PrintDeclKind printPointer(llvm::raw_svector_ostream &Os,
                                      const Type *T) const {
     T = T->getUnqualifiedDesugaredType();
-    bool IsPtr = isa<PointerType>(T) || isa<ObjCObjectPointerType>(T);
+    bool IsPtr = isa<PointerType,ObjCObjectPointerType>(T);
     Os << "raw " << (IsPtr ? "pointer" : "reference") << " to " << typeName();
     return PrintDeclKind::Pointee;
   }
@@ -545,7 +546,7 @@ public:
     return isRefOrCheckedPtrType(type);
   }
 
-  const char *typeName() const final { return "RefPtr capable type"; }
+  const char *typeName() const final { return "RefPtr-capable type"; }
 };
 
 class UncheckedCallArgsChecker final : public RawPtrRefCallArgsChecker {
@@ -574,7 +575,7 @@ public:
     return isExprToGetCheckedPtrCapableMember(E);
   }
 
-  const char *typeName() const final { return "CheckedPtr capable type"; }
+  const char *typeName() const final { return "CheckedPtr-capable type"; }
 };
 
 class UnretainedCallArgsChecker final : public RawPtrRefCallArgsChecker {
@@ -608,14 +609,14 @@ public:
 
   PrintDeclKind printPointer(llvm::raw_svector_ostream &Os,
                              const Type *T) const final {
-    if (!isa<ObjCObjectPointerType>(T) && T->getAs<TypedefType>()) {
+    if (isa<TypedefType>(T)) {
       Os << typeName() << " ";
       return PrintDeclKind::Pointer;
     }
     return RawPtrRefCallArgsChecker::printPointer(Os, T);
   }
 
-  const char *typeName() const final { return "RetainPtr capable type"; }
+  const char *typeName() const final { return "RetainPtr-capable type"; }
 };
 
 } // namespace

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
@@ -502,7 +502,7 @@ public:
   virtual PrintDeclKind printPointer(llvm::raw_svector_ostream &Os,
                                      const Type *T) const {
     T = T->getUnqualifiedDesugaredType();
-    bool IsPtr = isa<PointerType,ObjCObjectPointerType>(T);
+    bool IsPtr = isa<PointerType, ObjCObjectPointerType>(T);
     Os << "raw " << (IsPtr ? "pointer" : "reference") << " to " << typeName();
     return PrintDeclKind::Pointee;
   }

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefMemberChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefMemberChecker.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "ASTUtils.h"
 #include "DiagOutputUtils.h"
 #include "PtrTypesSemantics.h"
 #include "clang/AST/Decl.h"
@@ -108,22 +109,8 @@ public:
 
     if (auto *MemberCXXRD = MemberType->getPointeeCXXRecordDecl())
       reportBug(Member, MemberType, MemberCXXRD, RD);
-    else if (auto *ObjCDecl = getObjCDecl(MemberType))
+    else if (auto *ObjCDecl = getObjCDeclFromObjCPtr(MemberType))
       reportBug(Member, MemberType, ObjCDecl, RD);
-  }
-
-  ObjCInterfaceDecl *getObjCDecl(const Type *TypePtr) const {
-    auto *PointeeType = TypePtr->getPointeeType().getTypePtrOrNull();
-    if (!PointeeType)
-      return nullptr;
-    auto *Desugared = PointeeType->getUnqualifiedDesugaredType();
-    if (!Desugared)
-      return nullptr;
-    if (auto *ObjCType = dyn_cast<ObjCInterfaceType>(Desugared))
-      return ObjCType->getDecl();
-    if (auto *ObjCType = dyn_cast<ObjCObjectType>(Desugared))
-      return ObjCType->getInterface();
-    return nullptr;
   }
 
   void visitObjCDecl(const ObjCContainerDecl *CD) const {
@@ -169,7 +156,7 @@ public:
 
     if (auto *MemberCXXRD = IvarType->getPointeeCXXRecordDecl())
       reportBug(Ivar, IvarType, MemberCXXRD, CD);
-    else if (auto *ObjCDecl = getObjCDecl(IvarType))
+    else if (auto *ObjCDecl = getObjCDeclFromObjCPtr(IvarType))
       reportBug(Ivar, IvarType, ObjCDecl, CD);
   }
 
@@ -190,7 +177,7 @@ public:
 
     if (auto *MemberCXXRD = PropType->getPointeeCXXRecordDecl())
       reportBug(PD, PropType, MemberCXXRD, CD);
-    else if (auto *ObjCDecl = getObjCDecl(PropType))
+    else if (auto *ObjCDecl = getObjCDeclFromObjCPtr(PropType))
       reportBug(PD, PropType, ObjCDecl, CD);
   }
 
@@ -214,7 +201,7 @@ public:
 
     if (auto *MemberCXXRD = PropType->getPointeeCXXRecordDecl())
       reportBug(PropDecl, PropType, MemberCXXRD, CD);
-    else if (auto *ObjCDecl = getObjCDecl(PropType))
+    else if (auto *ObjCDecl = getObjCDeclFromObjCPtr(PropType))
       reportBug(PropDecl, PropType, ObjCDecl, CD);
   }
 

--- a/clang/test/Analysis/Checkers/WebKit/binding-to-refptr.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/binding-to-refptr.cpp
@@ -38,9 +38,9 @@ static void testUnpackedAssignmentWithWeak() {
   auto [a, b] = getStrongWeakPair();
   a->nextSibling();
   b->nextSibling();
-  // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe [alpha.webkit.UncountedCallArgsChecker]}}
+  // expected-warning@-1{{Function argument 'b' (parameter 'this' to 'Node::nextSibling') is a raw pointer to RefPtr capable type 'Node'}}
   auto [c, d] = getWeakStrongPair();
   c->nextSibling();
-  // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe [alpha.webkit.UncountedCallArgsChecker]}}
+  // expected-warning@-1{{Function argument 'c' (parameter 'this' to 'Node::nextSibling') is a raw pointer to RefPtr capable type 'Node'}}
   d->nextSibling();
 }

--- a/clang/test/Analysis/Checkers/WebKit/binding-to-refptr.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/binding-to-refptr.cpp
@@ -38,9 +38,9 @@ static void testUnpackedAssignmentWithWeak() {
   auto [a, b] = getStrongWeakPair();
   a->nextSibling();
   b->nextSibling();
-  // expected-warning@-1{{Function argument 'b' (parameter 'this' to 'Node::nextSibling') is a raw pointer to RefPtr capable type 'Node'}}
+  // expected-warning@-1{{Function argument 'b' (parameter 'this' to 'Node::nextSibling') is a raw pointer to RefPtr-capable type 'Node'}}
   auto [c, d] = getWeakStrongPair();
   c->nextSibling();
-  // expected-warning@-1{{Function argument 'c' (parameter 'this' to 'Node::nextSibling') is a raw pointer to RefPtr capable type 'Node'}}
+  // expected-warning@-1{{Function argument 'c' (parameter 'this' to 'Node::nextSibling') is a raw pointer to RefPtr-capable type 'Node'}}
   d->nextSibling();
 }

--- a/clang/test/Analysis/Checkers/WebKit/call-args-checked-const-member.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args-checked-const-member.cpp
@@ -17,7 +17,7 @@ private:
 void Foo::bar() {
   m_obj1->method();
   m_obj2->method();
-  // expected-warning@-1{{Call argument for 'this' parameter is unchecked and unsafe}}
+  // expected-warning@-1{{Function argument 'this->m_obj2' (parameter 'this' to 'CheckedObj::method') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
 }
 
 } // namespace call_args_const_checkedptr_member
@@ -37,7 +37,7 @@ private:
 void Foo::bar() {
   m_obj1->method();
   m_obj2->method();
-  // expected-warning@-1{{Call argument for 'this' parameter is unchecked and unsafe}}
+  // expected-warning@-1{{Function argument 'this->m_obj2' (parameter 'this' to 'CheckedObj::method') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
 }
 
 } // namespace call_args_const_checkedref_member
@@ -91,10 +91,10 @@ private:
 void Foo::bar() {
   m_obj1->method();
   m_obj2->method();
-  // expected-warning@-1{{Call argument for 'this' parameter is unchecked and unsafe}}
+  // expected-warning@-1{{Function argument 'this->m_obj2' (parameter 'this' to 'CheckedObj::method') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
   ensureObj3().method();
   badEnsureObj4().method();
-  // expected-warning@-1{{Call argument for 'this' parameter is unchecked and unsafe}}
+  // expected-warning@-1{{Function argument 'this->badEnsureObj4()' (parameter 'this' to 'CheckedObj::method') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
   ensureObj5()->method();
   ensureObj6()->method();
 }

--- a/clang/test/Analysis/Checkers/WebKit/call-args-checked-const-member.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args-checked-const-member.cpp
@@ -17,7 +17,7 @@ private:
 void Foo::bar() {
   m_obj1->method();
   m_obj2->method();
-  // expected-warning@-1{{Function argument 'this->m_obj2' (parameter 'this' to 'CheckedObj::method') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+  // expected-warning@-1{{Function argument 'this->m_obj2' (parameter 'this' to 'CheckedObj::method') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
 }
 
 } // namespace call_args_const_checkedptr_member
@@ -37,7 +37,7 @@ private:
 void Foo::bar() {
   m_obj1->method();
   m_obj2->method();
-  // expected-warning@-1{{Function argument 'this->m_obj2' (parameter 'this' to 'CheckedObj::method') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+  // expected-warning@-1{{Function argument 'this->m_obj2' (parameter 'this' to 'CheckedObj::method') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
 }
 
 } // namespace call_args_const_checkedref_member
@@ -91,10 +91,10 @@ private:
 void Foo::bar() {
   m_obj1->method();
   m_obj2->method();
-  // expected-warning@-1{{Function argument 'this->m_obj2' (parameter 'this' to 'CheckedObj::method') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+  // expected-warning@-1{{Function argument 'this->m_obj2' (parameter 'this' to 'CheckedObj::method') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
   ensureObj3().method();
   badEnsureObj4().method();
-  // expected-warning@-1{{Function argument 'this->badEnsureObj4()' (parameter 'this' to 'CheckedObj::method') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+  // expected-warning@-1{{Function argument 'this->badEnsureObj4()' (parameter 'this' to 'CheckedObj::method') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
   ensureObj5()->method();
   ensureObj6()->method();
 }

--- a/clang/test/Analysis/Checkers/WebKit/call-args-checked-ptr.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args-checked-ptr.cpp
@@ -9,7 +9,7 @@ void some_function();
 namespace simple {
   void foo() {
     consume_refcntbl(provide());
-    // expected-warning@-1{{Call argument is unchecked and unsafe}}
+    // expected-warning@-1{{Function argument 'provide()' (to 'consume_refcntbl') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
   }
 
   // Test that the checker works with [[clang::suppress]].
@@ -23,7 +23,7 @@ namespace multi_arg {
   void consume_refcntbl(int, CheckedObj* foo, bool);
   void foo() {
     consume_refcntbl(42, provide(), true);
-    // expected-warning@-1{{Call argument for parameter 'foo' is unchecked and unsafe}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'foo' to 'multi_arg::consume_refcntbl') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
   }
 }
 
@@ -47,9 +47,9 @@ namespace methods {
     Consumer c;
 
     c.consume_ptr(provide());
-    // expected-warning@-1{{Call argument for parameter 'ptr' is unchecked and unsafe}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'ptr' to 'methods::Consumer::consume_ptr') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
     c.consume_ref(*provide());
-    // expected-warning@-1{{Call argument for parameter 'ref' is unchecked and unsafe}}
+    // expected-warning@-1{{Function argument '*provide()' (parameter 'ref' to 'methods::Consumer::consume_ref') is a raw reference to CheckedPtr capable type 'CheckedObj'}}
   }
 
   void foo2() {
@@ -57,7 +57,7 @@ namespace methods {
       void consume(CheckedObj*) { some_function(); }
       void whatever() {
         consume(provide());
-        // expected-warning@-1{{Call argument is unchecked and unsafe}}
+        // expected-warning@-1{{Function argument 'provide()' (to 'methods::foo2()::Consumer::consume') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
       }
     };
   }
@@ -67,7 +67,7 @@ namespace methods {
       void consume(CheckedObj*) { some_function(); }
       void whatever() {
         this->consume(provide());
-        // expected-warning@-1{{Call argument is unchecked and unsafe}}
+        // expected-warning@-1{{Function argument 'provide()' (to 'methods::foo3()::Consumer::consume') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
       }
     };
   }
@@ -78,22 +78,22 @@ namespace casts {
 
   void foo() {
     consume_refcntbl(provide());
-    // expected-warning@-1{{Call argument is unchecked and unsafe}}
+    // expected-warning@-1{{Function argument 'provide()' (to 'consume_refcntbl') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
 
     consume_refcntbl(static_cast<CheckedObj*>(provide()));
-    // expected-warning@-1{{Call argument is unchecked and unsafe}}
+    // expected-warning@-1{{Function argument 'static_cast<CheckedObj *>(provide())' (to 'consume_refcntbl') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
 
     consume_refcntbl(dynamic_cast<CheckedObj*>(provide()));
-    // expected-warning@-1{{Call argument is unchecked and unsafe}}
+    // expected-warning@-1{{Function argument 'dynamic_cast<CheckedObj *>(provide())' (to 'consume_refcntbl') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
 
     consume_refcntbl(const_cast<CheckedObj*>(provide()));
-    // expected-warning@-1{{Call argument is unchecked and unsafe}}
+    // expected-warning@-1{{Function argument 'const_cast<CheckedObj *>(provide())' (to 'consume_refcntbl') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
 
     consume_refcntbl(reinterpret_cast<CheckedObj*>(provide()));
-    // expected-warning@-1{{Call argument is unchecked and unsafe}}
+    // expected-warning@-1{{Function argument 'reinterpret_cast<CheckedObj *>(provide())' (to 'consume_refcntbl') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
 
     consume_refcntbl(downcast(provide()));
-    // expected-warning@-1{{Call argument is unchecked and unsafe}}
+    // expected-warning@-1{{Function argument 'downcast(provide())' (to 'consume_refcntbl') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
 
     consume_refcntbl(
       static_cast<CheckedObj*>(
@@ -104,7 +104,7 @@ namespace casts {
         )
       )
     );
-    // expected-warning@-8{{Call argument is unchecked and unsafe}}
+    // expected-warning@-8{{Function argument 'static_cast<CheckedObj *>(downcast(static_cast<Che...' (to 'consume_refcntbl') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
   }
 }
 
@@ -124,7 +124,7 @@ namespace ref_counted_lookalike {
     Decoy D;
 
     consume_refcntbl(D.get());
-    // expected-warning@-1{{Call argument is unchecked and unsafe}}
+    // expected-warning@-1{{Function argument 'D.get()' (to 'consume_refcntbl') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
   }
 }
 
@@ -306,7 +306,7 @@ namespace default_arg {
   CheckedObj* global;
 
   void function_with_default_arg(CheckedObj* param = global);
-  // expected-warning@-1{{Call argument for parameter 'param' is unchecked and unsafe}}
+  // expected-warning@-1{{Function argument 'global' (parameter 'param' to 'default_arg::function_with_default_arg') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
 
   void foo() {
     function_with_default_arg();
@@ -318,7 +318,7 @@ namespace cxx_member_func {
   void foo() {
     provide()->trivial();
     provide()->method();
-    // expected-warning@-1{{Call argument for 'this' parameter is unchecked and unsafe}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'this' to 'CheckedObj::method') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
     provideProtected()->method();
     (provideProtected())->method();
   };
@@ -337,11 +337,11 @@ namespace cxx_member_operator_call {
   void foo() {
     Foo f;
     f + global;
-    // expected-warning@-1{{Call argument for parameter 'bad' is unchecked and unsafe}}
+    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::Foo::operator+') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
     f - global;
-    // expected-warning@-1{{Call argument for parameter 'bad' is unchecked and unsafe}}
+    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::operator-') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
     f(global);
-    // expected-warning@-1{{Call argument for parameter 'bad' is unchecked and unsafe}}
+    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::Foo::operator()') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
   }
 }
 
@@ -353,9 +353,9 @@ namespace call_with_ptr_on_ref {
     bar(v ? nullptr : provideProtected().ptr());
     bar(baz() ? provideProtected().ptr() : nullptr);
     bar(v ? provide() : provideProtected().ptr());
-    // expected-warning@-1{{Call argument for parameter 'bad' is unchecked and unsafe}}
+    // expected-warning@-1{{Function argument 'v ? provide() : provideProtected().ptr()' (parameter 'bad' to 'call_with_ptr_on_ref::bar') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
     bar(v ? provideProtected().ptr() : provide());
-    // expected-warning@-1{{Call argument for parameter 'bad' is unchecked and unsafe}}
+    // expected-warning@-1{{Function argument 'v ? provideProtected().ptr() : provide()' (parameter 'bad' to 'call_with_ptr_on_ref::bar') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
   }
 }
 

--- a/clang/test/Analysis/Checkers/WebKit/call-args-checked-ptr.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args-checked-ptr.cpp
@@ -9,7 +9,7 @@ void some_function();
 namespace simple {
   void foo() {
     consume_refcntbl(provide());
-    // expected-warning@-1{{Function argument 'provide()' (to 'consume_refcntbl') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Function argument 'provide()' (to 'consume_refcntbl') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
   }
 
   // Test that the checker works with [[clang::suppress]].
@@ -23,7 +23,7 @@ namespace multi_arg {
   void consume_refcntbl(int, CheckedObj* foo, bool);
   void foo() {
     consume_refcntbl(42, provide(), true);
-    // expected-warning@-1{{Function argument 'provide()' (parameter 'foo' to 'multi_arg::consume_refcntbl') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'foo' to 'multi_arg::consume_refcntbl') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
   }
 }
 
@@ -47,9 +47,9 @@ namespace methods {
     Consumer c;
 
     c.consume_ptr(provide());
-    // expected-warning@-1{{Function argument 'provide()' (parameter 'ptr' to 'methods::Consumer::consume_ptr') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'ptr' to 'methods::Consumer::consume_ptr') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
     c.consume_ref(*provide());
-    // expected-warning@-1{{Function argument '*provide()' (parameter 'ref' to 'methods::Consumer::consume_ref') is a raw reference to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Function argument '*provide()' (parameter 'ref' to 'methods::Consumer::consume_ref') is a raw reference to CheckedPtr-capable type 'CheckedObj'}}
   }
 
   void foo2() {
@@ -57,7 +57,7 @@ namespace methods {
       void consume(CheckedObj*) { some_function(); }
       void whatever() {
         consume(provide());
-        // expected-warning@-1{{Function argument 'provide()' (to 'methods::foo2()::Consumer::consume') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+        // expected-warning@-1{{Function argument 'provide()' (to 'methods::foo2()::Consumer::consume') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
       }
     };
   }
@@ -67,7 +67,7 @@ namespace methods {
       void consume(CheckedObj*) { some_function(); }
       void whatever() {
         this->consume(provide());
-        // expected-warning@-1{{Function argument 'provide()' (to 'methods::foo3()::Consumer::consume') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+        // expected-warning@-1{{Function argument 'provide()' (to 'methods::foo3()::Consumer::consume') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
       }
     };
   }
@@ -78,22 +78,22 @@ namespace casts {
 
   void foo() {
     consume_refcntbl(provide());
-    // expected-warning@-1{{Function argument 'provide()' (to 'consume_refcntbl') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Function argument 'provide()' (to 'consume_refcntbl') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
 
     consume_refcntbl(static_cast<CheckedObj*>(provide()));
-    // expected-warning@-1{{Function argument 'static_cast<CheckedObj *>(provide())' (to 'consume_refcntbl') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Function argument 'static_cast<CheckedObj *>(provide())' (to 'consume_refcntbl') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
 
     consume_refcntbl(dynamic_cast<CheckedObj*>(provide()));
-    // expected-warning@-1{{Function argument 'dynamic_cast<CheckedObj *>(provide())' (to 'consume_refcntbl') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Function argument 'dynamic_cast<CheckedObj *>(provide())' (to 'consume_refcntbl') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
 
     consume_refcntbl(const_cast<CheckedObj*>(provide()));
-    // expected-warning@-1{{Function argument 'const_cast<CheckedObj *>(provide())' (to 'consume_refcntbl') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Function argument 'const_cast<CheckedObj *>(provide())' (to 'consume_refcntbl') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
 
     consume_refcntbl(reinterpret_cast<CheckedObj*>(provide()));
-    // expected-warning@-1{{Function argument 'reinterpret_cast<CheckedObj *>(provide())' (to 'consume_refcntbl') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Function argument 'reinterpret_cast<CheckedObj *>(provide())' (to 'consume_refcntbl') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
 
     consume_refcntbl(downcast(provide()));
-    // expected-warning@-1{{Function argument 'downcast(provide())' (to 'consume_refcntbl') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Function argument 'downcast(provide())' (to 'consume_refcntbl') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
 
     consume_refcntbl(
       static_cast<CheckedObj*>(
@@ -104,7 +104,7 @@ namespace casts {
         )
       )
     );
-    // expected-warning@-8{{Function argument 'static_cast<CheckedObj *>(downcast(static_cast<Che...' (to 'consume_refcntbl') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-8{{Function argument 'static_cast<CheckedObj *>(downcast(static_cast<Che...' (to 'consume_refcntbl') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
   }
 }
 
@@ -124,7 +124,7 @@ namespace ref_counted_lookalike {
     Decoy D;
 
     consume_refcntbl(D.get());
-    // expected-warning@-1{{Function argument 'D.get()' (to 'consume_refcntbl') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Function argument 'D.get()' (to 'consume_refcntbl') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
   }
 }
 
@@ -306,7 +306,7 @@ namespace default_arg {
   CheckedObj* global;
 
   void function_with_default_arg(CheckedObj* param = global);
-  // expected-warning@-1{{Function argument 'global' (parameter 'param' to 'default_arg::function_with_default_arg') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+  // expected-warning@-1{{Function argument 'global' (parameter 'param' to 'default_arg::function_with_default_arg') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
 
   void foo() {
     function_with_default_arg();
@@ -318,7 +318,7 @@ namespace cxx_member_func {
   void foo() {
     provide()->trivial();
     provide()->method();
-    // expected-warning@-1{{Function argument 'provide()' (parameter 'this' to 'CheckedObj::method') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'this' to 'CheckedObj::method') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
     provideProtected()->method();
     (provideProtected())->method();
   };
@@ -337,11 +337,11 @@ namespace cxx_member_operator_call {
   void foo() {
     Foo f;
     f + global;
-    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::Foo::operator+') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::Foo::operator+') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
     f - global;
-    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::operator-') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::operator-') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
     f(global);
-    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::Foo::operator()') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::Foo::operator()') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
   }
 }
 
@@ -353,9 +353,9 @@ namespace call_with_ptr_on_ref {
     bar(v ? nullptr : provideProtected().ptr());
     bar(baz() ? provideProtected().ptr() : nullptr);
     bar(v ? provide() : provideProtected().ptr());
-    // expected-warning@-1{{Function argument 'v ? provide() : provideProtected().ptr()' (parameter 'bad' to 'call_with_ptr_on_ref::bar') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Function argument 'v ? provide() : provideProtected().ptr()' (parameter 'bad' to 'call_with_ptr_on_ref::bar') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
     bar(v ? provideProtected().ptr() : provide());
-    // expected-warning@-1{{Function argument 'v ? provideProtected().ptr() : provide()' (parameter 'bad' to 'call_with_ptr_on_ref::bar') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Function argument 'v ? provideProtected().ptr() : provide()' (parameter 'bad' to 'call_with_ptr_on_ref::bar') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
   }
 }
 

--- a/clang/test/Analysis/Checkers/WebKit/call-args-checked.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args-checked.cpp
@@ -10,7 +10,7 @@ namespace call_args_unchecked_uncounted {
 
 static void foo() {
   someFunction(makeObj());
-  // expected-warning@-1{{Call argument is unchecked and unsafe [alpha.webkit.UncheckedCallArgsChecker]}}
+  // expected-warning@-1{{Function argument 'makeObj()' (to 'someFunction') is a raw pointer to CheckedPtr capable type 'RefCountableAndCheckable'}}
 }
 
 } // namespace call_args_unchecked_uncounted
@@ -42,11 +42,11 @@ struct WrapperObj {
   void foo() {
     consume(checked);
     consume(checkedRef);
-    // expected-warning@-1{{Call argument is unchecked and unsafe [alpha.webkit.UncheckedCallArgsChecker]}}
+    // expected-warning@-1{{Function argument 'this->checkedRef' (to 'call_args_member::consume') is a raw reference to CheckedPtr capable type 'CheckedObj'}}
   }
   void bar(WrapperObj& other) {
     consume(other.checked);
-    // expected-warning@-1{{Call argument is unchecked and unsafe [alpha.webkit.UncheckedCallArgsChecker]}}
+    // expected-warning@-1{{Function argument 'other.checked' (to 'call_args_member::consume') is a raw reference to CheckedPtr capable type 'CheckedObj'}}
   }
 };
 
@@ -55,7 +55,7 @@ struct WrapperObj {
 namespace call_args_default {
 
 void someFunction(RefCountableAndCheckable* = makeObj());
-// expected-warning@-1{{Call argument is unchecked and unsafe [alpha.webkit.UncheckedCallArgsChecker]}}
+// expected-warning@-1{{Function argument 'makeObj()' (to 'call_args_default::someFunction') is a raw pointer to CheckedPtr capable type 'RefCountableAndCheckable'}}
 void otherFunction(RefCountableAndCheckable* = makeObjChecked().ptr());
 
 void foo() {

--- a/clang/test/Analysis/Checkers/WebKit/call-args-checked.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args-checked.cpp
@@ -10,7 +10,7 @@ namespace call_args_unchecked_uncounted {
 
 static void foo() {
   someFunction(makeObj());
-  // expected-warning@-1{{Function argument 'makeObj()' (to 'someFunction') is a raw pointer to CheckedPtr capable type 'RefCountableAndCheckable'}}
+  // expected-warning@-1{{Function argument 'makeObj()' (to 'someFunction') is a raw pointer to CheckedPtr-capable type 'RefCountableAndCheckable'}}
 }
 
 } // namespace call_args_unchecked_uncounted
@@ -42,11 +42,11 @@ struct WrapperObj {
   void foo() {
     consume(checked);
     consume(checkedRef);
-    // expected-warning@-1{{Function argument 'this->checkedRef' (to 'call_args_member::consume') is a raw reference to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Function argument 'this->checkedRef' (to 'call_args_member::consume') is a raw reference to CheckedPtr-capable type 'CheckedObj'}}
   }
   void bar(WrapperObj& other) {
     consume(other.checked);
-    // expected-warning@-1{{Function argument 'other.checked' (to 'call_args_member::consume') is a raw reference to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Function argument 'other.checked' (to 'call_args_member::consume') is a raw reference to CheckedPtr-capable type 'CheckedObj'}}
   }
 };
 
@@ -55,7 +55,7 @@ struct WrapperObj {
 namespace call_args_default {
 
 void someFunction(RefCountableAndCheckable* = makeObj());
-// expected-warning@-1{{Function argument 'makeObj()' (to 'call_args_default::someFunction') is a raw pointer to CheckedPtr capable type 'RefCountableAndCheckable'}}
+// expected-warning@-1{{Function argument 'makeObj()' (to 'call_args_default::someFunction') is a raw pointer to CheckedPtr-capable type 'RefCountableAndCheckable'}}
 void otherFunction(RefCountableAndCheckable* = makeObjChecked().ptr());
 
 void foo() {

--- a/clang/test/Analysis/Checkers/WebKit/call-args-counted-const-member.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args-counted-const-member.cpp
@@ -20,7 +20,7 @@ private:
 void Foo::bar() {
   m_obj1->method();
   m_obj2->method();
-  // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+  // expected-warning@-1{{Function argument 'this->m_obj2' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr capable type 'RefCountable'}}
 }
 
 } // namespace call_args_const_refptr_member
@@ -41,7 +41,7 @@ private:
 void Foo::bar() {
   m_obj1->method();
   m_obj2->method();
-  // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+  // expected-warning@-1{{Function argument 'this->m_obj2' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr capable type 'RefCountable'}}
   obj1().method();
 }
 
@@ -87,10 +87,10 @@ private:
 void Foo::bar() {
   m_obj1->method();
   m_obj2->method();
-  // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+  // expected-warning@-1{{Function argument 'this->m_obj2' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr capable type 'RefCountable'}}
   ensureObj3().method();
   badEnsureObj4().method();
-  // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+  // expected-warning@-1{{Function argument 'this->badEnsureObj4()' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr capable type 'RefCountable'}}
   ensureObj5()->method();
 }
 
@@ -112,7 +112,7 @@ private:
 void Foo::bar() {
   m_obj1->method();
   m_obj2->method();
-  // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+  // expected-warning@-1{{Function argument 'this->m_obj2' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr capable type 'RefCountable'}}
   obj1().method();
 }
 

--- a/clang/test/Analysis/Checkers/WebKit/call-args-counted-const-member.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args-counted-const-member.cpp
@@ -20,7 +20,7 @@ private:
 void Foo::bar() {
   m_obj1->method();
   m_obj2->method();
-  // expected-warning@-1{{Function argument 'this->m_obj2' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr capable type 'RefCountable'}}
+  // expected-warning@-1{{Function argument 'this->m_obj2' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr-capable type 'RefCountable'}}
 }
 
 } // namespace call_args_const_refptr_member
@@ -41,7 +41,7 @@ private:
 void Foo::bar() {
   m_obj1->method();
   m_obj2->method();
-  // expected-warning@-1{{Function argument 'this->m_obj2' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr capable type 'RefCountable'}}
+  // expected-warning@-1{{Function argument 'this->m_obj2' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr-capable type 'RefCountable'}}
   obj1().method();
 }
 
@@ -87,10 +87,10 @@ private:
 void Foo::bar() {
   m_obj1->method();
   m_obj2->method();
-  // expected-warning@-1{{Function argument 'this->m_obj2' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr capable type 'RefCountable'}}
+  // expected-warning@-1{{Function argument 'this->m_obj2' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr-capable type 'RefCountable'}}
   ensureObj3().method();
   badEnsureObj4().method();
-  // expected-warning@-1{{Function argument 'this->badEnsureObj4()' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr capable type 'RefCountable'}}
+  // expected-warning@-1{{Function argument 'this->badEnsureObj4()' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr-capable type 'RefCountable'}}
   ensureObj5()->method();
 }
 
@@ -112,7 +112,7 @@ private:
 void Foo::bar() {
   m_obj1->method();
   m_obj2->method();
-  // expected-warning@-1{{Function argument 'this->m_obj2' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr capable type 'RefCountable'}}
+  // expected-warning@-1{{Function argument 'this->m_obj2' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr-capable type 'RefCountable'}}
   obj1().method();
 }
 

--- a/clang/test/Analysis/Checkers/WebKit/call-args-loop-init-opaque-value.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args-loop-init-opaque-value.cpp
@@ -60,5 +60,5 @@ bool someFunction(Component* other) {
 
 bool otherFunction(Component* other) {
     return provide()->isNonTrivialEqual(*other);
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'this' to 'Component::isNonTrivialEqual') is a raw pointer to RefPtr capable type 'Component'}}
 }

--- a/clang/test/Analysis/Checkers/WebKit/call-args-loop-init-opaque-value.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args-loop-init-opaque-value.cpp
@@ -60,5 +60,5 @@ bool someFunction(Component* other) {
 
 bool otherFunction(Component* other) {
     return provide()->isNonTrivialEqual(*other);
-    // expected-warning@-1{{Function argument 'provide()' (parameter 'this' to 'Component::isNonTrivialEqual') is a raw pointer to RefPtr capable type 'Component'}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'this' to 'Component::isNonTrivialEqual') is a raw pointer to RefPtr-capable type 'Component'}}
 }

--- a/clang/test/Analysis/Checkers/WebKit/call-args-safe-functions.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args-safe-functions.cpp
@@ -63,7 +63,7 @@ void foo(OtherObject* other)
     uncheckedDowncast<SubDerived>(other->obj());
     newCastFunction<SubDerived>(other->obj());
     badCastFunction<SubDerived>(other->obj());
-    // expected-warning@-1{{Call argument is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'other->obj()' (to 'badCastFunction<SubDerived, Derived>') is a raw pointer to RefPtr capable type 'Derived'}}
     toString(other->obj());
 }
 

--- a/clang/test/Analysis/Checkers/WebKit/call-args-safe-functions.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args-safe-functions.cpp
@@ -63,7 +63,7 @@ void foo(OtherObject* other)
     uncheckedDowncast<SubDerived>(other->obj());
     newCastFunction<SubDerived>(other->obj());
     badCastFunction<SubDerived>(other->obj());
-    // expected-warning@-1{{Function argument 'other->obj()' (to 'badCastFunction<SubDerived, Derived>') is a raw pointer to RefPtr capable type 'Derived'}}
+    // expected-warning@-1{{Function argument 'other->obj()' (to 'badCastFunction<SubDerived, Derived>') is a raw pointer to RefPtr-capable type 'Derived'}}
     toString(other->obj());
 }
 

--- a/clang/test/Analysis/Checkers/WebKit/call-args-wtf-containers.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args-wtf-containers.cpp
@@ -225,26 +225,26 @@ void test() {
   set.find(*object());
   set.contains(*object());
   set.add(*object());
-  // expected-warning@-1{{Call argument is uncounted and unsafe}}
+  // expected-warning@-1{{Function argument '*object()' (to 'WTF::HashSet<RefPtr<RefCounted>>::add<RefCounted>') is a raw reference to RefPtr capable type 'RefCounted'}}
   set.remove(*object());
-  // expected-warning@-1{{Call argument is uncounted and unsafe}}
+  // expected-warning@-1{{Function argument '*object()' (to 'WTF::HashSet<RefPtr<RefCounted>>::remove<RefCounted>') is a raw reference to RefPtr capable type 'RefCounted'}}
 
   HashMap<Ref<RefCounted>, unsigned> map;
   map.find(*object());
   map.contains(*object());
   map.inlineGet(*object());
   map.add(*object());
-  // expected-warning@-1{{Call argument is uncounted and unsafe}}
+  // expected-warning@-1{{Function argument '*object()' (to 'WTF::HashMap<Ref<RefCounted>, unsigned int>::add<RefCounted>') is a raw reference to RefPtr capable type 'RefCounted'}}
   map.remove(*object());
-  // expected-warning@-1{{Call argument is uncounted and unsafe}}
+  // expected-warning@-1{{Function argument '*object()' (to 'WTF::HashMap<Ref<RefCounted>, unsigned int>::remove<RefCounted>') is a raw reference to RefPtr capable type 'RefCounted'}}
 
   WeakHashSet<Ref<RefCounted>> weakSet;
   weakSet.find(*object());
   weakSet.contains(*object());
   weakSet.add(*object());
-  // expected-warning@-1{{Call argument is uncounted and unsafe}}
+  // expected-warning@-1{{Function argument '*object()' (to 'WTF::WeakHashSet<Ref<RefCounted>>::add<RefCounted>') is a raw reference to RefPtr capable type 'RefCounted'}}
   weakSet.remove(*object());
-  // expected-warning@-1{{Call argument is uncounted and unsafe}}
+  // expected-warning@-1{{Function argument '*object()' (to 'WTF::WeakHashSet<Ref<RefCounted>>::remove<RefCounted>') is a raw reference to RefPtr capable type 'RefCounted'}}
 
   Vector<Ref<RefCounted>> vector;
   vector.at(0);
@@ -253,9 +253,9 @@ void test() {
   vector.reverseFind(*object());
   vector.contains(*object());
   vector.append(*object());
-  // expected-warning@-1{{Call argument is uncounted and unsafe}}
+  // expected-warning@-1{{Function argument '*object()' (to 'WTF::Vector<Ref<RefCounted>>::append<RefCounted>') is a raw reference to RefPtr capable type 'RefCounted'}}
   vector.remove(*object());
-  // expected-warning@-1{{Call argument is uncounted and unsafe}}
+  // expected-warning@-1{{Function argument '*object()' (to 'WTF::Vector<Ref<RefCounted>>::remove<RefCounted>') is a raw reference to RefPtr capable type 'RefCounted'}}
 
   auto* obj = object();
   vector.findIf([&](Ref<RefCounted> key) { return key.ptr() == obj; });

--- a/clang/test/Analysis/Checkers/WebKit/call-args-wtf-containers.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args-wtf-containers.cpp
@@ -225,26 +225,26 @@ void test() {
   set.find(*object());
   set.contains(*object());
   set.add(*object());
-  // expected-warning@-1{{Function argument '*object()' (to 'WTF::HashSet<RefPtr<RefCounted>>::add<RefCounted>') is a raw reference to RefPtr capable type 'RefCounted'}}
+  // expected-warning@-1{{Function argument '*object()' (to 'WTF::HashSet<RefPtr<RefCounted>>::add<RefCounted>') is a raw reference to RefPtr-capable type 'RefCounted'}}
   set.remove(*object());
-  // expected-warning@-1{{Function argument '*object()' (to 'WTF::HashSet<RefPtr<RefCounted>>::remove<RefCounted>') is a raw reference to RefPtr capable type 'RefCounted'}}
+  // expected-warning@-1{{Function argument '*object()' (to 'WTF::HashSet<RefPtr<RefCounted>>::remove<RefCounted>') is a raw reference to RefPtr-capable type 'RefCounted'}}
 
   HashMap<Ref<RefCounted>, unsigned> map;
   map.find(*object());
   map.contains(*object());
   map.inlineGet(*object());
   map.add(*object());
-  // expected-warning@-1{{Function argument '*object()' (to 'WTF::HashMap<Ref<RefCounted>, unsigned int>::add<RefCounted>') is a raw reference to RefPtr capable type 'RefCounted'}}
+  // expected-warning@-1{{Function argument '*object()' (to 'WTF::HashMap<Ref<RefCounted>, unsigned int>::add<RefCounted>') is a raw reference to RefPtr-capable type 'RefCounted'}}
   map.remove(*object());
-  // expected-warning@-1{{Function argument '*object()' (to 'WTF::HashMap<Ref<RefCounted>, unsigned int>::remove<RefCounted>') is a raw reference to RefPtr capable type 'RefCounted'}}
+  // expected-warning@-1{{Function argument '*object()' (to 'WTF::HashMap<Ref<RefCounted>, unsigned int>::remove<RefCounted>') is a raw reference to RefPtr-capable type 'RefCounted'}}
 
   WeakHashSet<Ref<RefCounted>> weakSet;
   weakSet.find(*object());
   weakSet.contains(*object());
   weakSet.add(*object());
-  // expected-warning@-1{{Function argument '*object()' (to 'WTF::WeakHashSet<Ref<RefCounted>>::add<RefCounted>') is a raw reference to RefPtr capable type 'RefCounted'}}
+  // expected-warning@-1{{Function argument '*object()' (to 'WTF::WeakHashSet<Ref<RefCounted>>::add<RefCounted>') is a raw reference to RefPtr-capable type 'RefCounted'}}
   weakSet.remove(*object());
-  // expected-warning@-1{{Function argument '*object()' (to 'WTF::WeakHashSet<Ref<RefCounted>>::remove<RefCounted>') is a raw reference to RefPtr capable type 'RefCounted'}}
+  // expected-warning@-1{{Function argument '*object()' (to 'WTF::WeakHashSet<Ref<RefCounted>>::remove<RefCounted>') is a raw reference to RefPtr-capable type 'RefCounted'}}
 
   Vector<Ref<RefCounted>> vector;
   vector.at(0);
@@ -253,9 +253,9 @@ void test() {
   vector.reverseFind(*object());
   vector.contains(*object());
   vector.append(*object());
-  // expected-warning@-1{{Function argument '*object()' (to 'WTF::Vector<Ref<RefCounted>>::append<RefCounted>') is a raw reference to RefPtr capable type 'RefCounted'}}
+  // expected-warning@-1{{Function argument '*object()' (to 'WTF::Vector<Ref<RefCounted>>::append<RefCounted>') is a raw reference to RefPtr-capable type 'RefCounted'}}
   vector.remove(*object());
-  // expected-warning@-1{{Function argument '*object()' (to 'WTF::Vector<Ref<RefCounted>>::remove<RefCounted>') is a raw reference to RefPtr capable type 'RefCounted'}}
+  // expected-warning@-1{{Function argument '*object()' (to 'WTF::Vector<Ref<RefCounted>>::remove<RefCounted>') is a raw reference to RefPtr-capable type 'RefCounted'}}
 
   auto* obj = object();
   vector.findIf([&](Ref<RefCounted> key) { return key.ptr() == obj; });

--- a/clang/test/Analysis/Checkers/WebKit/call-args.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args.cpp
@@ -9,7 +9,7 @@ void some_function();
 namespace simple {
   void foo() {
     consume_refcntbl(provide());
-    // expected-warning@-1{{Call argument is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'provide()' (to 'consume_refcntbl') is a raw pointer to RefPtr capable type 'RefCountable'}}
   }
 
   // Test that the checker works with [[clang::suppress]].
@@ -23,7 +23,7 @@ namespace multi_arg {
   void consume_refcntbl(int, RefCountable* foo, bool);
   void foo() {
     consume_refcntbl(42, provide(), true);
-    // expected-warning@-1{{Call argument for parameter 'foo' is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'foo' to 'multi_arg::consume_refcntbl') is a raw pointer to RefPtr capable type 'RefCountable'}}
   }
 }
 
@@ -47,9 +47,9 @@ namespace methods {
     Consumer c;
 
     c.consume_ptr(provide());
-    // expected-warning@-1{{Call argument for parameter 'ptr' is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'ptr' to 'methods::Consumer::consume_ptr') is a raw pointer to RefPtr capable type 'RefCountable'}}
     c.consume_ref(*provide());
-    // expected-warning@-1{{Call argument for parameter 'ref' is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument '*provide()' (parameter 'ref' to 'methods::Consumer::consume_ref') is a raw reference to RefPtr capable type}}
   }
 
   void foo2() {
@@ -57,7 +57,7 @@ namespace methods {
       void consume(RefCountable*) { some_function(); }
       void whatever() {
         consume(provide());
-        // expected-warning@-1{{Call argument is uncounted and unsafe}}
+        // expected-warning@-1{{Function argument 'provide()' (to 'methods::foo2()::Consumer::consume') is a raw pointer to RefPtr capable type 'RefCountable'}}
       }
     };
   }
@@ -67,7 +67,7 @@ namespace methods {
       void consume(RefCountable*) { some_function(); }
       void whatever() {
         this->consume(provide());
-        // expected-warning@-1{{Call argument is uncounted and unsafe}}
+        // expected-warning@-1{{Function argument 'provide()' (to 'methods::foo3()::Consumer::consume') is a raw pointer to RefPtr capable type 'RefCountable'}}
       }
     };
   }
@@ -78,22 +78,22 @@ namespace casts {
 
   void foo() {
     consume_refcntbl(provide());
-    // expected-warning@-1{{Call argument is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'provide()' (to 'consume_refcntbl') is a raw pointer to RefPtr capable type 'RefCountable'}}
 
     consume_refcntbl(static_cast<RefCountable*>(provide()));
-    // expected-warning@-1{{Call argument is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'static_cast<RefCountable *>(provide())' (to 'consume_refcntbl') is a raw pointer to RefPtr capable type 'RefCountable'}}
 
     consume_refcntbl(dynamic_cast<RefCountable*>(provide()));
-    // expected-warning@-1{{Call argument is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'dynamic_cast<RefCountable *>(provide())' (to 'consume_refcntbl') is a raw pointer to RefPtr capable type 'RefCountable'}}
 
     consume_refcntbl(const_cast<RefCountable*>(provide()));
-    // expected-warning@-1{{Call argument is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'const_cast<RefCountable *>(provide())' (to 'consume_refcntbl') is a raw pointer to RefPtr capable type 'RefCountable'}}
 
     consume_refcntbl(reinterpret_cast<RefCountable*>(provide()));
-    // expected-warning@-1{{Call argument is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'reinterpret_cast<RefCountable *>(provide())' (to 'consume_refcntbl') is a raw pointer to RefPtr capable type 'RefCountable'}}
 
     consume_refcntbl(downcast(provide()));
-    // expected-warning@-1{{Call argument is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'downcast(provide())' (to 'consume_refcntbl') is a raw pointer to RefPtr capable type 'RefCountable'}}
 
     consume_refcntbl(
       static_cast<RefCountable*>(
@@ -104,7 +104,7 @@ namespace casts {
         )
       )
     );
-    // expected-warning@-8{{Call argument is uncounted and unsafe}}
+    // expected-warning@-8{{Function argument 'static_cast<RefCountable *>(downcast(static_cast<R...' (to 'consume_refcntbl') is a raw pointer to RefPtr capable type 'RefCountable'}}
   }
 }
 
@@ -124,7 +124,7 @@ namespace ref_counted_lookalike {
     Decoy D;
 
     consume_refcntbl(D.get());
-    // expected-warning@-1{{Call argument is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'D.get()' (to 'consume_refcntbl') is a raw pointer to RefPtr capable type 'RefCountable'}}
   }
 }
 
@@ -306,7 +306,7 @@ namespace default_arg {
   RefCountable* global;
 
   void function_with_default_arg(RefCountable* param = global);
-  // expected-warning@-1{{Call argument for parameter 'param' is uncounted and unsafe}}
+  // expected-warning@-1{{Function argument 'global' (parameter 'param' to 'default_arg::function_with_default_arg') is a raw pointer to RefPtr capable type 'RefCountable'}}
 
   void foo() {
     function_with_default_arg();
@@ -318,7 +318,7 @@ namespace cxx_member_func {
   void foo() {
     provide()->trivial();
     provide()->method();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr capable type 'RefCountable'}}
     provideProtected()->method();
     (provideProtected())->method();
   };
@@ -347,13 +347,13 @@ namespace cxx_member_operator_call {
   void foo12() {
     Foo f;
     f + global;
-    // expected-warning@-1{{Call argument for parameter 'bad' is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::Foo::operator+') is a raw pointer to RefPtr capable type 'RefCountable'}}
     f - global;
-    // expected-warning@-1{{Call argument for parameter 'bad' is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::operator-') is a raw pointer to RefPtr capable type 'RefCountable'}}
     f(global);
-    // expected-warning@-1{{Call argument for parameter 'bad' is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::Foo::operator()') is a raw pointer to RefPtr capable type 'RefCountable'}}
     container()[0] = 3;
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'container()' (parameter 'this' to 'cxx_member_operator_call::Container::operator[]') is a raw pointer to RefPtr capable type 'cxx_member_operator_call::Container'}}
   }
 }
 
@@ -367,11 +367,11 @@ namespace call_function_ptr {
 
   void foo(void (*consume)(void*, RefCountableWithWeakPtr*), void (*consumeVar)(RefCountableWithWeakPtr*, ...), void (RefCountableWithWeakPtr::*method)()) {
     consume(nullptr, provide());
-    // expected-warning@-1{{Call argument is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'provide()' is a raw pointer to RefPtr capable type 'call_function_ptr::RefCountableWithWeakPtr}}
     consumeVar(nullptr, provide());
-    // expected-warning@-1{{Call argument is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'provide()' is a raw pointer to RefPtr capable type 'call_function_ptr::RefCountableWithWeakPtr}}
     (provide()->*method)();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'this') is a raw pointer to RefPtr capable type 'call_function_ptr::RefCountableWithWeakPtr'}}
   }
 
   template <typename T, typename U, typename... Arg>
@@ -388,9 +388,9 @@ namespace call_with_ptr_on_ref {
     bar(v ? nullptr : provideProtected().ptr());
     bar(baz() ? provideProtected().ptr() : nullptr);
     bar(v ? provide() : provideProtected().ptr());
-    // expected-warning@-1{{Call argument for parameter 'bad' is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'v ? provide() : provideProtected().ptr()' (parameter 'bad' to 'call_with_ptr_on_ref::bar') is a raw pointer to RefPtr capable type 'RefCountable'}}
     bar(v ? provideProtected().ptr() : provide());
-    // expected-warning@-1{{Call argument for parameter 'bad' is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'v ? provideProtected().ptr() : provide()' (parameter 'bad' to 'call_with_ptr_on_ref::bar') is a raw pointer to RefPtr capable type 'RefCountable'}}
   }
 }
 
@@ -459,7 +459,7 @@ namespace call_with_explicit_construct {
   class Obj {
   public:
     Obj(RefCountable* obj = provide(), RefCountable* otherObj = nullptr) {
-      // expected-warning@-1{{Call argument for parameter 'obj' is uncounted and unsafe}}
+      // expected-warning@-1{{Function argument 'provide()' (parameter 'obj' to 'call_with_explicit_construct::Obj::Obj') is a raw pointer to RefPtr capable type 'RefCountable'}}
       consume_refcntbl(obj);
       if (otherObj)
         otherObj->method();
@@ -472,13 +472,13 @@ namespace call_with_explicit_construct {
   void foo(RefCountable* arg) {
     Obj obj1;
     Obj obj2(provide());
-    // expected-warning@-1{{Call argument for parameter 'obj' is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'obj' to 'call_with_explicit_construct::Obj::Obj') is a raw pointer to RefPtr capable type 'RefCountable'}}
     Obj obj3(*provide());
-    // expected-warning@-1{{Call argument for parameter 'obj' is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument '*provide()' (parameter 'obj' to 'call_with_explicit_construct::Obj::Obj') is a raw reference to RefPtr capable type 'RefCountable'}}
     Obj obj4(Ref<RefCountable> { *provide() }.get());
     Obj obj5(arg);
     Obj obj6(arg, provide());
-    // expected-warning@-1{{Call argument for parameter 'otherObj' is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'otherObj' to 'call_with_explicit_construct::Obj::Obj') is a raw pointer to RefPtr capable type 'RefCountable'}}
   }
 }
 
@@ -511,9 +511,9 @@ namespace call_on_member {
 
     void doWork() {
       m_obj->method();
-      // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+      // expected-warning@-1{{Function argument 'this->m_obj' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr capable type 'RefCountable'}}
       m_obj.get()->method();
-      // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+      // expected-warning@-1{{Function argument 'this->m_obj.get()' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr capable type 'RefCountable'}}
       m_constObj->method();
     }
 
@@ -546,7 +546,7 @@ namespace call_on_member {
 
   void foo() {
     provide()->constObj().method();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'provide()->constObj()' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr capable type 'RefCountable'}}
     Ref { provide()->constObj() }->method();
     RefPtr { provide() }->constObj().method();
   }
@@ -564,9 +564,9 @@ namespace call_with_weak_ptr {
   void foo() {
     WeakPtr weakPtr = provide();
     consume(weakPtr);
-    // expected-warning@-1{{Call argument is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'weakPtr' (to 'call_with_weak_ptr::consume') is a raw pointer to RefPtr capable type 'call_with_weak_ptr::RefCountableWithWeakPtr'}}
     weakPtr->method();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'weakPtr' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr capable type 'RefCountable'}}
   }
 
   struct Provider {

--- a/clang/test/Analysis/Checkers/WebKit/call-args.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args.cpp
@@ -9,7 +9,7 @@ void some_function();
 namespace simple {
   void foo() {
     consume_refcntbl(provide());
-    // expected-warning@-1{{Function argument 'provide()' (to 'consume_refcntbl') is a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Function argument 'provide()' (to 'consume_refcntbl') is a raw pointer to RefPtr-capable type 'RefCountable'}}
   }
 
   // Test that the checker works with [[clang::suppress]].
@@ -23,7 +23,7 @@ namespace multi_arg {
   void consume_refcntbl(int, RefCountable* foo, bool);
   void foo() {
     consume_refcntbl(42, provide(), true);
-    // expected-warning@-1{{Function argument 'provide()' (parameter 'foo' to 'multi_arg::consume_refcntbl') is a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'foo' to 'multi_arg::consume_refcntbl') is a raw pointer to RefPtr-capable type 'RefCountable'}}
   }
 }
 
@@ -47,9 +47,9 @@ namespace methods {
     Consumer c;
 
     c.consume_ptr(provide());
-    // expected-warning@-1{{Function argument 'provide()' (parameter 'ptr' to 'methods::Consumer::consume_ptr') is a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'ptr' to 'methods::Consumer::consume_ptr') is a raw pointer to RefPtr-capable type 'RefCountable'}}
     c.consume_ref(*provide());
-    // expected-warning@-1{{Function argument '*provide()' (parameter 'ref' to 'methods::Consumer::consume_ref') is a raw reference to RefPtr capable type}}
+    // expected-warning@-1{{Function argument '*provide()' (parameter 'ref' to 'methods::Consumer::consume_ref') is a raw reference to RefPtr-capable type}}
   }
 
   void foo2() {
@@ -57,7 +57,7 @@ namespace methods {
       void consume(RefCountable*) { some_function(); }
       void whatever() {
         consume(provide());
-        // expected-warning@-1{{Function argument 'provide()' (to 'methods::foo2()::Consumer::consume') is a raw pointer to RefPtr capable type 'RefCountable'}}
+        // expected-warning@-1{{Function argument 'provide()' (to 'methods::foo2()::Consumer::consume') is a raw pointer to RefPtr-capable type 'RefCountable'}}
       }
     };
   }
@@ -67,7 +67,7 @@ namespace methods {
       void consume(RefCountable*) { some_function(); }
       void whatever() {
         this->consume(provide());
-        // expected-warning@-1{{Function argument 'provide()' (to 'methods::foo3()::Consumer::consume') is a raw pointer to RefPtr capable type 'RefCountable'}}
+        // expected-warning@-1{{Function argument 'provide()' (to 'methods::foo3()::Consumer::consume') is a raw pointer to RefPtr-capable type 'RefCountable'}}
       }
     };
   }
@@ -78,22 +78,22 @@ namespace casts {
 
   void foo() {
     consume_refcntbl(provide());
-    // expected-warning@-1{{Function argument 'provide()' (to 'consume_refcntbl') is a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Function argument 'provide()' (to 'consume_refcntbl') is a raw pointer to RefPtr-capable type 'RefCountable'}}
 
     consume_refcntbl(static_cast<RefCountable*>(provide()));
-    // expected-warning@-1{{Function argument 'static_cast<RefCountable *>(provide())' (to 'consume_refcntbl') is a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Function argument 'static_cast<RefCountable *>(provide())' (to 'consume_refcntbl') is a raw pointer to RefPtr-capable type 'RefCountable'}}
 
     consume_refcntbl(dynamic_cast<RefCountable*>(provide()));
-    // expected-warning@-1{{Function argument 'dynamic_cast<RefCountable *>(provide())' (to 'consume_refcntbl') is a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Function argument 'dynamic_cast<RefCountable *>(provide())' (to 'consume_refcntbl') is a raw pointer to RefPtr-capable type 'RefCountable'}}
 
     consume_refcntbl(const_cast<RefCountable*>(provide()));
-    // expected-warning@-1{{Function argument 'const_cast<RefCountable *>(provide())' (to 'consume_refcntbl') is a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Function argument 'const_cast<RefCountable *>(provide())' (to 'consume_refcntbl') is a raw pointer to RefPtr-capable type 'RefCountable'}}
 
     consume_refcntbl(reinterpret_cast<RefCountable*>(provide()));
-    // expected-warning@-1{{Function argument 'reinterpret_cast<RefCountable *>(provide())' (to 'consume_refcntbl') is a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Function argument 'reinterpret_cast<RefCountable *>(provide())' (to 'consume_refcntbl') is a raw pointer to RefPtr-capable type 'RefCountable'}}
 
     consume_refcntbl(downcast(provide()));
-    // expected-warning@-1{{Function argument 'downcast(provide())' (to 'consume_refcntbl') is a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Function argument 'downcast(provide())' (to 'consume_refcntbl') is a raw pointer to RefPtr-capable type 'RefCountable'}}
 
     consume_refcntbl(
       static_cast<RefCountable*>(
@@ -104,7 +104,7 @@ namespace casts {
         )
       )
     );
-    // expected-warning@-8{{Function argument 'static_cast<RefCountable *>(downcast(static_cast<R...' (to 'consume_refcntbl') is a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-8{{Function argument 'static_cast<RefCountable *>(downcast(static_cast<R...' (to 'consume_refcntbl') is a raw pointer to RefPtr-capable type 'RefCountable'}}
   }
 }
 
@@ -124,7 +124,7 @@ namespace ref_counted_lookalike {
     Decoy D;
 
     consume_refcntbl(D.get());
-    // expected-warning@-1{{Function argument 'D.get()' (to 'consume_refcntbl') is a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Function argument 'D.get()' (to 'consume_refcntbl') is a raw pointer to RefPtr-capable type 'RefCountable'}}
   }
 }
 
@@ -306,7 +306,7 @@ namespace default_arg {
   RefCountable* global;
 
   void function_with_default_arg(RefCountable* param = global);
-  // expected-warning@-1{{Function argument 'global' (parameter 'param' to 'default_arg::function_with_default_arg') is a raw pointer to RefPtr capable type 'RefCountable'}}
+  // expected-warning@-1{{Function argument 'global' (parameter 'param' to 'default_arg::function_with_default_arg') is a raw pointer to RefPtr-capable type 'RefCountable'}}
 
   void foo() {
     function_with_default_arg();
@@ -318,7 +318,7 @@ namespace cxx_member_func {
   void foo() {
     provide()->trivial();
     provide()->method();
-    // expected-warning@-1{{Function argument 'provide()' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr-capable type 'RefCountable'}}
     provideProtected()->method();
     (provideProtected())->method();
   };
@@ -347,13 +347,13 @@ namespace cxx_member_operator_call {
   void foo12() {
     Foo f;
     f + global;
-    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::Foo::operator+') is a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::Foo::operator+') is a raw pointer to RefPtr-capable type 'RefCountable'}}
     f - global;
-    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::operator-') is a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::operator-') is a raw pointer to RefPtr-capable type 'RefCountable'}}
     f(global);
-    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::Foo::operator()') is a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::Foo::operator()') is a raw pointer to RefPtr-capable type 'RefCountable'}}
     container()[0] = 3;
-    // expected-warning@-1{{Function argument 'container()' (parameter 'this' to 'cxx_member_operator_call::Container::operator[]') is a raw pointer to RefPtr capable type 'cxx_member_operator_call::Container'}}
+    // expected-warning@-1{{Function argument 'container()' (parameter 'this' to 'cxx_member_operator_call::Container::operator[]') is a raw pointer to RefPtr-capable type 'cxx_member_operator_call::Container'}}
   }
 }
 
@@ -367,11 +367,11 @@ namespace call_function_ptr {
 
   void foo(void (*consume)(void*, RefCountableWithWeakPtr*), void (*consumeVar)(RefCountableWithWeakPtr*, ...), void (RefCountableWithWeakPtr::*method)()) {
     consume(nullptr, provide());
-    // expected-warning@-1{{Function argument 'provide()' is a raw pointer to RefPtr capable type 'call_function_ptr::RefCountableWithWeakPtr}}
+    // expected-warning@-1{{Function argument 'provide()' is a raw pointer to RefPtr-capable type 'call_function_ptr::RefCountableWithWeakPtr}}
     consumeVar(nullptr, provide());
-    // expected-warning@-1{{Function argument 'provide()' is a raw pointer to RefPtr capable type 'call_function_ptr::RefCountableWithWeakPtr}}
+    // expected-warning@-1{{Function argument 'provide()' is a raw pointer to RefPtr-capable type 'call_function_ptr::RefCountableWithWeakPtr}}
     (provide()->*method)();
-    // expected-warning@-1{{Function argument 'provide()' (parameter 'this') is a raw pointer to RefPtr capable type 'call_function_ptr::RefCountableWithWeakPtr'}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'this') is a raw pointer to RefPtr-capable type 'call_function_ptr::RefCountableWithWeakPtr'}}
   }
 
   template <typename T, typename U, typename... Arg>
@@ -388,9 +388,9 @@ namespace call_with_ptr_on_ref {
     bar(v ? nullptr : provideProtected().ptr());
     bar(baz() ? provideProtected().ptr() : nullptr);
     bar(v ? provide() : provideProtected().ptr());
-    // expected-warning@-1{{Function argument 'v ? provide() : provideProtected().ptr()' (parameter 'bad' to 'call_with_ptr_on_ref::bar') is a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Function argument 'v ? provide() : provideProtected().ptr()' (parameter 'bad' to 'call_with_ptr_on_ref::bar') is a raw pointer to RefPtr-capable type 'RefCountable'}}
     bar(v ? provideProtected().ptr() : provide());
-    // expected-warning@-1{{Function argument 'v ? provideProtected().ptr() : provide()' (parameter 'bad' to 'call_with_ptr_on_ref::bar') is a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Function argument 'v ? provideProtected().ptr() : provide()' (parameter 'bad' to 'call_with_ptr_on_ref::bar') is a raw pointer to RefPtr-capable type 'RefCountable'}}
   }
 }
 
@@ -459,7 +459,7 @@ namespace call_with_explicit_construct {
   class Obj {
   public:
     Obj(RefCountable* obj = provide(), RefCountable* otherObj = nullptr) {
-      // expected-warning@-1{{Function argument 'provide()' (parameter 'obj' to 'call_with_explicit_construct::Obj::Obj') is a raw pointer to RefPtr capable type 'RefCountable'}}
+      // expected-warning@-1{{Function argument 'provide()' (parameter 'obj' to 'call_with_explicit_construct::Obj::Obj') is a raw pointer to RefPtr-capable type 'RefCountable'}}
       consume_refcntbl(obj);
       if (otherObj)
         otherObj->method();
@@ -472,13 +472,13 @@ namespace call_with_explicit_construct {
   void foo(RefCountable* arg) {
     Obj obj1;
     Obj obj2(provide());
-    // expected-warning@-1{{Function argument 'provide()' (parameter 'obj' to 'call_with_explicit_construct::Obj::Obj') is a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'obj' to 'call_with_explicit_construct::Obj::Obj') is a raw pointer to RefPtr-capable type 'RefCountable'}}
     Obj obj3(*provide());
-    // expected-warning@-1{{Function argument '*provide()' (parameter 'obj' to 'call_with_explicit_construct::Obj::Obj') is a raw reference to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Function argument '*provide()' (parameter 'obj' to 'call_with_explicit_construct::Obj::Obj') is a raw reference to RefPtr-capable type 'RefCountable'}}
     Obj obj4(Ref<RefCountable> { *provide() }.get());
     Obj obj5(arg);
     Obj obj6(arg, provide());
-    // expected-warning@-1{{Function argument 'provide()' (parameter 'otherObj' to 'call_with_explicit_construct::Obj::Obj') is a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'otherObj' to 'call_with_explicit_construct::Obj::Obj') is a raw pointer to RefPtr-capable type 'RefCountable'}}
   }
 }
 
@@ -511,9 +511,9 @@ namespace call_on_member {
 
     void doWork() {
       m_obj->method();
-      // expected-warning@-1{{Function argument 'this->m_obj' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr capable type 'RefCountable'}}
+      // expected-warning@-1{{Function argument 'this->m_obj' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr-capable type 'RefCountable'}}
       m_obj.get()->method();
-      // expected-warning@-1{{Function argument 'this->m_obj.get()' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr capable type 'RefCountable'}}
+      // expected-warning@-1{{Function argument 'this->m_obj.get()' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr-capable type 'RefCountable'}}
       m_constObj->method();
     }
 
@@ -546,7 +546,7 @@ namespace call_on_member {
 
   void foo() {
     provide()->constObj().method();
-    // expected-warning@-1{{Function argument 'provide()->constObj()' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Function argument 'provide()->constObj()' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr-capable type 'RefCountable'}}
     Ref { provide()->constObj() }->method();
     RefPtr { provide() }->constObj().method();
   }
@@ -564,9 +564,9 @@ namespace call_with_weak_ptr {
   void foo() {
     WeakPtr weakPtr = provide();
     consume(weakPtr);
-    // expected-warning@-1{{Function argument 'weakPtr' (to 'call_with_weak_ptr::consume') is a raw pointer to RefPtr capable type 'call_with_weak_ptr::RefCountableWithWeakPtr'}}
+    // expected-warning@-1{{Function argument 'weakPtr' (to 'call_with_weak_ptr::consume') is a raw pointer to RefPtr-capable type 'call_with_weak_ptr::RefCountableWithWeakPtr'}}
     weakPtr->method();
-    // expected-warning@-1{{Function argument 'weakPtr' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Function argument 'weakPtr' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr-capable type 'RefCountable'}}
   }
 
   struct Provider {

--- a/clang/test/Analysis/Checkers/WebKit/ref-countable-default-arg-nullptr.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/ref-countable-default-arg-nullptr.cpp
@@ -12,13 +12,13 @@ public:
 
 void someFunction(Obj*, Obj* = nullptr);
 void otherFunction(Obj*, Obj* = Obj::get());
-// expected-warning@-1{{Call argument is uncounted and unsafe [alpha.webkit.UncountedCallArgsChecker]}}
+// expected-warning@-1{{Function argument 'Obj::get()' (to 'otherFunction') is a raw pointer to RefPtr capable type 'Obj'}}
 void anotherFunction(Obj*, Obj* = Obj::create().get());
 
 void otherFunction() {
   someFunction(nullptr);
   someFunction(Obj::get());
-  // expected-warning@-1{{Call argument is uncounted and unsafe [alpha.webkit.UncountedCallArgsChecker]}}
+  // expected-warning@-1{{Function argument 'Obj::get()' (to 'someFunction') is a raw pointer to RefPtr capable type 'Obj'}}
   someFunction(Obj::create().get());
   otherFunction(nullptr);
   anotherFunction(nullptr);

--- a/clang/test/Analysis/Checkers/WebKit/ref-countable-default-arg-nullptr.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/ref-countable-default-arg-nullptr.cpp
@@ -12,13 +12,13 @@ public:
 
 void someFunction(Obj*, Obj* = nullptr);
 void otherFunction(Obj*, Obj* = Obj::get());
-// expected-warning@-1{{Function argument 'Obj::get()' (to 'otherFunction') is a raw pointer to RefPtr capable type 'Obj'}}
+// expected-warning@-1{{Function argument 'Obj::get()' (to 'otherFunction') is a raw pointer to RefPtr-capable type 'Obj'}}
 void anotherFunction(Obj*, Obj* = Obj::create().get());
 
 void otherFunction() {
   someFunction(nullptr);
   someFunction(Obj::get());
-  // expected-warning@-1{{Function argument 'Obj::get()' (to 'someFunction') is a raw pointer to RefPtr capable type 'Obj'}}
+  // expected-warning@-1{{Function argument 'Obj::get()' (to 'someFunction') is a raw pointer to RefPtr-capable type 'Obj'}}
   someFunction(Obj::create().get());
   otherFunction(nullptr);
   anotherFunction(nullptr);

--- a/clang/test/Analysis/Checkers/WebKit/unchecked-call-arg.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/unchecked-call-arg.cpp
@@ -30,7 +30,7 @@ public:
 CheckedObject* provide();
 void foo() {
   provide()->doWork();
-  // expected-warning@-1{{Call argument for 'this' parameter is unchecked and unsafe}}
+  // expected-warning@-1{{Function argument 'provide()' (parameter 'this' to 'CheckedObject::doWork') is a raw pointer to CheckedPtr capable type 'CheckedObject'}}
 }
 
 void doWorkWithObject(const CheckedObject&);

--- a/clang/test/Analysis/Checkers/WebKit/unchecked-call-arg.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/unchecked-call-arg.cpp
@@ -30,7 +30,7 @@ public:
 CheckedObject* provide();
 void foo() {
   provide()->doWork();
-  // expected-warning@-1{{Function argument 'provide()' (parameter 'this' to 'CheckedObject::doWork') is a raw pointer to CheckedPtr capable type 'CheckedObject'}}
+  // expected-warning@-1{{Function argument 'provide()' (parameter 'this' to 'CheckedObject::doWork') is a raw pointer to CheckedPtr-capable type 'CheckedObject'}}
 }
 
 void doWorkWithObject(const CheckedObject&);

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
@@ -480,19 +480,19 @@ public:
 
   int nonTrivial13() { return ~otherFunction(); }
   int nonTrivial14() { int r = 0xff; r |= otherFunction(); return r; }
-  void nonTrivial15() { ++complex; } // expected-warning{{Call argument for 'this' parameter is uncounted and unsafe}}
-  void nonTrivial16() { complex++; } // expected-warning{{Call argument for 'this' parameter is uncounted and unsafe}}
+  void nonTrivial15() { ++complex; } // expected-warning{{Function argument 'this->complex' (parameter 'this' to 'ComplexNumber::operator++') is a raw pointer to RefPtr capable type 'ComplexNumber'}}
+  void nonTrivial16() { complex++; } // expected-warning{{Function argument 'this->complex' (parameter 'this' to 'ComplexNumber::operator++') is a raw pointer to RefPtr capable type 'ComplexNumber'}}
   ComplexNumber nonTrivial17() {
-    return complex << 2; // expected-warning{{Call argument for 'this' parameter is uncounted and unsafe}}
-    // expected-warning@-1{{Call argument is uncounted and unsafe}}
+    return complex << 2; // expected-warning{{Function argument 'this->complex << 2' (to 'ComplexNumber::ComplexNumber') is a raw reference to RefPtr capable type 'ComplexNumber'}}
+    // expected-warning@-1{{Function argument 'this->complex' (parameter 'this' to 'ComplexNumber::operator<<') is a raw pointer to RefPtr capable type 'ComplexNumber'}}
   }
   ComplexNumber nonTrivial18() {
-    return +complex; // expected-warning{{Call argument for 'this' parameter is uncounted and unsafe}}
-    // expected-warning@-1{{Call argument is uncounted and unsafe}}
+    return +complex; // expected-warning{{Function argument 'this->complex' (parameter 'this' to 'ComplexNumber::operator+') is a raw pointer to RefPtr capable type}}
+    // expected-warning@-1{{Function argument '+ this->complex' (to 'ComplexNumber::ComplexNumber') is a raw reference to RefPtr capable type 'ComplexNumber'}}
   }
   ComplexNumber* nonTrivial19() {
     return new ComplexNumber(complex);
-    // expected-warning@-1{{Call argument is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->complex' (to 'ComplexNumber::ComplexNumber') is a raw reference to RefPtr capable type 'ComplexNumber'}}
   }
   unsigned nonTrivial20() { return ObjectWithMutatingDestructor { 7 }.value(); }
   unsigned nonTrivial21() { return Number("123").value(); }
@@ -518,7 +518,7 @@ RefCounted* refCountedObj();
 void test()
 {
   refCountedObj()->someFunction();
-  // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+  // expected-warning@-1{{Function argument 'refCountedObj()' (parameter 'this' to 'RefCounted::someFunction') is a raw pointer to RefPtr capable type 'RefCounted'}}
 }
 
 class UnrelatedClass {
@@ -616,80 +616,81 @@ public:
 
     getFieldTrivial().recursiveTrivialFunction(7); // no-warning
     getFieldTrivial().recursiveComplexFunction(9);
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::recursiveComplexFunction') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().mutuallyRecursiveFunction1(11); // no-warning
     getFieldTrivial().mutuallyRecursiveFunction2(13); // no-warning
     getFieldTrivial().mutuallyRecursiveFunction3(17);
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::mutuallyRecursiveFunction3') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().mutuallyRecursiveFunction4(19);
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::mutuallyRecursiveFunction4') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().recursiveFunction5(23); // no-warning
     getFieldTrivial().recursiveFunction6(29); // no-warning
     getFieldTrivial().recursiveFunction7(31); // no-warning
 
     getFieldTrivial().mutuallyRecursive8();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::mutuallyRecursive8') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().mutuallyRecursive9();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::mutuallyRecursive9') is a raw pointer to RefPtr capable type 'RefCounted'}}
 
     getFieldTrivial().recursiveCost(); // no-warning
 
     getFieldTrivial().someFunction();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::someFunction') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial1();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial1') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial2();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial2') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial3();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial3') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial4();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial4') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial5();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial5') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial6();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial6') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial7();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial7') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial8();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial8') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial9();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial9') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial10();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial10') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial11();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial11') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial12();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial12') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial13();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial13') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial14();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial14') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial15();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial15') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial16();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial16') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial17();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial17') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial18();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial18') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial19();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial19') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial20();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial20') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial21();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial21') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial22();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial22') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial23();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial23') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial24();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial24') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial25();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial25') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial()->complex();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'ComplexNumber::complex') is a raw pointer to RefPtr capable type 'ComplexNumber'}}
+    // expected-warning@-2{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::operator->') is a raw pointer to RefPtr capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial26(ComparedObj { });
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial26') is a raw pointer to RefPtr capable type 'RefCounted'}}
   }
 
   void setField(RefCounted*);
@@ -719,7 +720,7 @@ public:
     getFieldTrivialRecursively().trivial1(); // no-warning
     getFieldTrivialTernary()->trivial2(); // no-warning
     getFieldTrivialRecursively().someFunction();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivialRecursively()' (parameter 'this' to 'RefCounted::someFunction') is a raw pointer to RefPtr capable type 'RefCounted'}}
     callSetField(getFieldTrivial(), refCountedObj()); // no-warning
   }
 };

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
@@ -480,19 +480,19 @@ public:
 
   int nonTrivial13() { return ~otherFunction(); }
   int nonTrivial14() { int r = 0xff; r |= otherFunction(); return r; }
-  void nonTrivial15() { ++complex; } // expected-warning{{Function argument 'this->complex' (parameter 'this' to 'ComplexNumber::operator++') is a raw pointer to RefPtr capable type 'ComplexNumber'}}
-  void nonTrivial16() { complex++; } // expected-warning{{Function argument 'this->complex' (parameter 'this' to 'ComplexNumber::operator++') is a raw pointer to RefPtr capable type 'ComplexNumber'}}
+  void nonTrivial15() { ++complex; } // expected-warning{{Function argument 'this->complex' (parameter 'this' to 'ComplexNumber::operator++') is a raw pointer to RefPtr-capable type 'ComplexNumber'}}
+  void nonTrivial16() { complex++; } // expected-warning{{Function argument 'this->complex' (parameter 'this' to 'ComplexNumber::operator++') is a raw pointer to RefPtr-capable type 'ComplexNumber'}}
   ComplexNumber nonTrivial17() {
-    return complex << 2; // expected-warning{{Function argument 'this->complex << 2' (to 'ComplexNumber::ComplexNumber') is a raw reference to RefPtr capable type 'ComplexNumber'}}
-    // expected-warning@-1{{Function argument 'this->complex' (parameter 'this' to 'ComplexNumber::operator<<') is a raw pointer to RefPtr capable type 'ComplexNumber'}}
+    return complex << 2; // expected-warning{{Function argument 'this->complex << 2' (to 'ComplexNumber::ComplexNumber') is a raw reference to RefPtr-capable type 'ComplexNumber'}}
+    // expected-warning@-1{{Function argument 'this->complex' (parameter 'this' to 'ComplexNumber::operator<<') is a raw pointer to RefPtr-capable type 'ComplexNumber'}}
   }
   ComplexNumber nonTrivial18() {
-    return +complex; // expected-warning{{Function argument 'this->complex' (parameter 'this' to 'ComplexNumber::operator+') is a raw pointer to RefPtr capable type}}
-    // expected-warning@-1{{Function argument '+ this->complex' (to 'ComplexNumber::ComplexNumber') is a raw reference to RefPtr capable type 'ComplexNumber'}}
+    return +complex; // expected-warning{{Function argument 'this->complex' (parameter 'this' to 'ComplexNumber::operator+') is a raw pointer to RefPtr-capable type}}
+    // expected-warning@-1{{Function argument '+ this->complex' (to 'ComplexNumber::ComplexNumber') is a raw reference to RefPtr-capable type 'ComplexNumber'}}
   }
   ComplexNumber* nonTrivial19() {
     return new ComplexNumber(complex);
-    // expected-warning@-1{{Function argument 'this->complex' (to 'ComplexNumber::ComplexNumber') is a raw reference to RefPtr capable type 'ComplexNumber'}}
+    // expected-warning@-1{{Function argument 'this->complex' (to 'ComplexNumber::ComplexNumber') is a raw reference to RefPtr-capable type 'ComplexNumber'}}
   }
   unsigned nonTrivial20() { return ObjectWithMutatingDestructor { 7 }.value(); }
   unsigned nonTrivial21() { return Number("123").value(); }
@@ -518,7 +518,7 @@ RefCounted* refCountedObj();
 void test()
 {
   refCountedObj()->someFunction();
-  // expected-warning@-1{{Function argument 'refCountedObj()' (parameter 'this' to 'RefCounted::someFunction') is a raw pointer to RefPtr capable type 'RefCounted'}}
+  // expected-warning@-1{{Function argument 'refCountedObj()' (parameter 'this' to 'RefCounted::someFunction') is a raw pointer to RefPtr-capable type 'RefCounted'}}
 }
 
 class UnrelatedClass {
@@ -616,81 +616,81 @@ public:
 
     getFieldTrivial().recursiveTrivialFunction(7); // no-warning
     getFieldTrivial().recursiveComplexFunction(9);
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::recursiveComplexFunction') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::recursiveComplexFunction') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().mutuallyRecursiveFunction1(11); // no-warning
     getFieldTrivial().mutuallyRecursiveFunction2(13); // no-warning
     getFieldTrivial().mutuallyRecursiveFunction3(17);
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::mutuallyRecursiveFunction3') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::mutuallyRecursiveFunction3') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().mutuallyRecursiveFunction4(19);
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::mutuallyRecursiveFunction4') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::mutuallyRecursiveFunction4') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().recursiveFunction5(23); // no-warning
     getFieldTrivial().recursiveFunction6(29); // no-warning
     getFieldTrivial().recursiveFunction7(31); // no-warning
 
     getFieldTrivial().mutuallyRecursive8();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::mutuallyRecursive8') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::mutuallyRecursive8') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().mutuallyRecursive9();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::mutuallyRecursive9') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::mutuallyRecursive9') is a raw pointer to RefPtr-capable type 'RefCounted'}}
 
     getFieldTrivial().recursiveCost(); // no-warning
 
     getFieldTrivial().someFunction();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::someFunction') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::someFunction') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial1();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial1') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial1') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial2();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial2') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial2') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial3();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial3') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial3') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial4();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial4') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial4') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial5();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial5') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial5') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial6();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial6') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial6') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial7();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial7') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial7') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial8();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial8') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial8') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial9();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial9') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial9') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial10();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial10') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial10') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial11();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial11') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial11') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial12();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial12') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial12') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial13();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial13') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial13') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial14();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial14') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial14') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial15();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial15') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial15') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial16();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial16') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial16') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial17();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial17') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial17') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial18();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial18') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial18') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial19();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial19') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial19') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial20();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial20') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial20') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial21();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial21') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial21') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial22();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial22') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial22') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial23();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial23') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial23') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial24();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial24') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial24') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial25();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial25') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial25') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial()->complex();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'ComplexNumber::complex') is a raw pointer to RefPtr capable type 'ComplexNumber'}}
-    // expected-warning@-2{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::operator->') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'ComplexNumber::complex') is a raw pointer to RefPtr-capable type 'ComplexNumber'}}
+    // expected-warning@-2{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::operator->') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     getFieldTrivial().nonTrivial26(ComparedObj { });
-    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial26') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivial()' (parameter 'this' to 'RefCounted::nonTrivial26') is a raw pointer to RefPtr-capable type 'RefCounted'}}
   }
 
   void setField(RefCounted*);
@@ -720,7 +720,7 @@ public:
     getFieldTrivialRecursively().trivial1(); // no-warning
     getFieldTrivialTernary()->trivial2(); // no-warning
     getFieldTrivialRecursively().someFunction();
-    // expected-warning@-1{{Function argument 'this->getFieldTrivialRecursively()' (parameter 'this' to 'RefCounted::someFunction') is a raw pointer to RefPtr capable type 'RefCounted'}}
+    // expected-warning@-1{{Function argument 'this->getFieldTrivialRecursively()' (parameter 'this' to 'RefCounted::someFunction') is a raw pointer to RefPtr-capable type 'RefCounted'}}
     callSetField(getFieldTrivial(), refCountedObj()); // no-warning
   }
 };

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.mm
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.mm
@@ -24,7 +24,7 @@
   _obj1.get().method();
   (*_obj2).method();
   _obj3->method();
-  // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+  // expected-warning@-1{{Function argument 'self->_obj3' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr capable type 'RefCountable'}}
 }
 
 - (RefPtr<RefCountable>)_protectedRefCountable {

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.mm
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.mm
@@ -24,7 +24,7 @@
   _obj1.get().method();
   (*_obj2).method();
   _obj3->method();
-  // expected-warning@-1{{Function argument 'self->_obj3' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr capable type 'RefCountable'}}
+  // expected-warning@-1{{Function argument 'self->_obj3' (parameter 'this' to 'RefCountable::method') is a raw pointer to RefPtr-capable type 'RefCountable'}}
 }
 
 - (RefPtr<RefCountable>)_protectedRefCountable {

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-obj-const-v-muable.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-obj-const-v-muable.cpp
@@ -21,7 +21,7 @@ private:
 void Caller::someFunction()
 {
     m_obj->constFunc();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->m_obj' (parameter 'this' to 'Object::constFunc') is a raw pointer to RefPtr capable type 'Object'}}
     m_obj->mutableFunc();
-    // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+    // expected-warning@-1{{Function argument 'this->m_obj' (parameter 'this' to 'Object::mutableFunc') is a raw pointer to RefPtr capable type 'Object'}}
 }

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-obj-const-v-muable.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-obj-const-v-muable.cpp
@@ -21,7 +21,7 @@ private:
 void Caller::someFunction()
 {
     m_obj->constFunc();
-    // expected-warning@-1{{Function argument 'this->m_obj' (parameter 'this' to 'Object::constFunc') is a raw pointer to RefPtr capable type 'Object'}}
+    // expected-warning@-1{{Function argument 'this->m_obj' (parameter 'this' to 'Object::constFunc') is a raw pointer to RefPtr-capable type 'Object'}}
     m_obj->mutableFunc();
-    // expected-warning@-1{{Function argument 'this->m_obj' (parameter 'this' to 'Object::mutableFunc') is a raw pointer to RefPtr capable type 'Object'}}
+    // expected-warning@-1{{Function argument 'this->m_obj' (parameter 'this' to 'Object::mutableFunc') is a raw pointer to RefPtr-capable type 'Object'}}
 }

--- a/clang/test/Analysis/Checkers/WebKit/unretained-call-args-arc.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-call-args-arc.mm
@@ -14,7 +14,7 @@ namespace raw_ptr {
 void foo() {
   [provide() doWork];
   CFArrayAppendValue(provide_cf(), nullptr);
-  // expected-warning@-1{{Call argument for parameter 'theArray' is unretained and unsafe [alpha.webkit.UnretainedCallArgsChecker]}}
+  // expected-warning@-1{{Function argument 'provide_cf()' (parameter 'theArray' to 'CFArrayAppendValue') is a RetainPtr capable type 'CFMutableArrayRef'}}
   dispatch_queue_get_label(provide_os());
 }
 
@@ -35,7 +35,7 @@ CFDictionaryRef provide_dict();
 dispatch_queue_t provide_dispatch();
 void use_const_local() {
   doWork(provide_str(), provide_dict(), provide_dispatch());
-  // expected-warning@-1{{Call argument for parameter 'dict' is unretained and unsafe}}
+  // expected-warning@-1{{Function argument 'provide_dict()' (parameter 'dict' to 'const_global::doWork') is a RetainPtr capable type 'CFDictionaryRef'}}
 }
 
 } // namespace const_global
@@ -50,7 +50,7 @@ void use_const_local() {
   [obj doWork];
   [provide() doWork];
   CFArrayAppendValue(provide_cf(), nullptr);
-  // expected-warning@-1{{Call argument for parameter 'theArray' is unretained and unsafe [alpha.webkit.UnretainedCallArgsChecker]}}
+  // expected-warning@-1{{Function argument 'provide_cf()' (parameter 'theArray' to 'CFArrayAppendValue') is a RetainPtr capable type 'CFMutableArrayRef'}}
 }
 
 - (SomeObj *)getSomeObj {

--- a/clang/test/Analysis/Checkers/WebKit/unretained-call-args-arc.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-call-args-arc.mm
@@ -14,7 +14,7 @@ namespace raw_ptr {
 void foo() {
   [provide() doWork];
   CFArrayAppendValue(provide_cf(), nullptr);
-  // expected-warning@-1{{Function argument 'provide_cf()' (parameter 'theArray' to 'CFArrayAppendValue') is a RetainPtr capable type 'CFMutableArrayRef'}}
+  // expected-warning@-1{{Function argument 'provide_cf()' (parameter 'theArray' to 'CFArrayAppendValue') is a RetainPtr-capable type 'CFMutableArrayRef'}}
   dispatch_queue_get_label(provide_os());
 }
 
@@ -35,7 +35,7 @@ CFDictionaryRef provide_dict();
 dispatch_queue_t provide_dispatch();
 void use_const_local() {
   doWork(provide_str(), provide_dict(), provide_dispatch());
-  // expected-warning@-1{{Function argument 'provide_dict()' (parameter 'dict' to 'const_global::doWork') is a RetainPtr capable type 'CFDictionaryRef'}}
+  // expected-warning@-1{{Function argument 'provide_dict()' (parameter 'dict' to 'const_global::doWork') is a RetainPtr-capable type 'CFDictionaryRef'}}
 }
 
 } // namespace const_global
@@ -50,7 +50,7 @@ void use_const_local() {
   [obj doWork];
   [provide() doWork];
   CFArrayAppendValue(provide_cf(), nullptr);
-  // expected-warning@-1{{Function argument 'provide_cf()' (parameter 'theArray' to 'CFArrayAppendValue') is a RetainPtr capable type 'CFMutableArrayRef'}}
+  // expected-warning@-1{{Function argument 'provide_cf()' (parameter 'theArray' to 'CFArrayAppendValue') is a RetainPtr-capable type 'CFMutableArrayRef'}}
 }
 
 - (SomeObj *)getSomeObj {

--- a/clang/test/Analysis/Checkers/WebKit/unretained-call-args-member.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-call-args-member.mm
@@ -20,7 +20,7 @@ private:
 
 void Foo::bar() {
   [m_constObj doWork]; // no-warning
-  [m_obj doWork]; // expected-warning{{Receiver is unretained and unsafe}}
+  [m_obj doWork]; // expected-warning{{Receiver 'this->m_obj' (to 'SomeObj::doWork') is a raw pointer to RetainPtr capable type 'SomeObj'}}
 }
 
 } // namespace call_args_const_retainptr_member
@@ -39,7 +39,7 @@ private:
 
 void Foo::bar() {
   consume_cf(m_cf1.get()); // no-warning
-  consume_cf(m_cf2.get()); // expected-warning{{Call argument is unretained and unsafe}}
+  consume_cf(m_cf2.get()); // expected-warning{{Function argument 'this->m_cf2.get()' (to 'consume_cf') is a RetainPtr capable type 'CFArrayRef'}}
 }
 
 } // namespace call_args_const_retainptr_cf_member
@@ -56,7 +56,7 @@ struct Bar {
 
 void Bar::baz() {
   [m_constObj doWork]; // no-warning
-  [m_obj doWork]; // expected-warning{{Receiver is unretained and unsafe}}
+  [m_obj doWork]; // expected-warning{{Receiver 'this->m_obj' (to 'SomeObj::doWork') is a raw pointer to RetainPtr capable type 'SomeObj'}}
 }
 
 } // namespace call_args_const_retainptr_struct_member
@@ -73,7 +73,7 @@ struct Bar {
 
 void Bar::baz() {
   consume_cf(m_cf1.get()); // no-warning
-  consume_cf(m_cf2.get()); // expected-warning{{Call argument is unretained and unsafe}}
+  consume_cf(m_cf2.get()); // expected-warning{{Function argument 'this->m_cf2.get()' (to 'consume_cf') is a RetainPtr capable type 'CFArrayRef'}}
 }
 
 } // namespace call_args_const_retainptr_cf_struct_member
@@ -92,7 +92,7 @@ private:
 
 void Foo::bar() {
   consume_obj(m_constObj.get()); // no-warning
-  consume_obj(m_obj.get()); // expected-warning{{Call argument is unretained and unsafe}}
+  consume_obj(m_obj.get()); // expected-warning{{Function argument 'this->m_obj.get()' (to 'consume_obj') is a RetainPtr capable type 'WTF::RetainPtr<SomeObj>::PtrType'}}
 }
 
 } // namespace call_args_const_retainptr_get_as_objc_arg
@@ -111,7 +111,7 @@ private:
 
 void Foo::bar() {
   consume_obj(m_constObj); // no-warning
-  consume_obj(m_obj); // expected-warning{{Call argument is unretained and unsafe}}
+  consume_obj(m_obj); // expected-warning{{Function argument 'this->m_obj' (to 'consume_obj') is a RetainPtr capable type 'WTF::RetainPtr<SomeObj>::PtrType'}}
 }
 
 } // namespace call_args_const_retainptr_implicit_conv_arg
@@ -130,7 +130,7 @@ private:
 
 void Foo::bar() {
   consume_obj(m_constObj.get()); // no-warning
-  consume_obj(m_obj.get()); // expected-warning{{Call argument is unretained and unsafe}}
+  consume_obj(m_obj.get()); // expected-warning{{Function argument 'this->m_obj.get()' (to 'consume_obj') is a raw pointer to RetainPtr capable type 'SomeObj'}}
 }
 
 } // namespace call_args_const_osobjectptr_member
@@ -149,7 +149,7 @@ private:
 
 void Foo::bar() {
   [m_constObj doWork]; // no-warning
-  [m_obj doWork]; // expected-warning{{Receiver is unretained and unsafe}}
+  [m_obj doWork]; // expected-warning{{Receiver 'this->m_obj' (to 'SomeObj::doWork') is a raw pointer to RetainPtr capable type 'SomeObj'}}
 }
 
 } // namespace call_args_const_osobjectptr_receiver

--- a/clang/test/Analysis/Checkers/WebKit/unretained-call-args-member.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-call-args-member.mm
@@ -20,7 +20,7 @@ private:
 
 void Foo::bar() {
   [m_constObj doWork]; // no-warning
-  [m_obj doWork]; // expected-warning{{Receiver 'this->m_obj' (to 'SomeObj::doWork') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+  [m_obj doWork]; // expected-warning{{Receiver 'this->m_obj' (to 'SomeObj::doWork') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
 }
 
 } // namespace call_args_const_retainptr_member
@@ -39,7 +39,7 @@ private:
 
 void Foo::bar() {
   consume_cf(m_cf1.get()); // no-warning
-  consume_cf(m_cf2.get()); // expected-warning{{Function argument 'this->m_cf2.get()' (to 'consume_cf') is a RetainPtr capable type 'CFArrayRef'}}
+  consume_cf(m_cf2.get()); // expected-warning{{Function argument 'this->m_cf2.get()' (to 'consume_cf') is a RetainPtr-capable type 'CFArrayRef'}}
 }
 
 } // namespace call_args_const_retainptr_cf_member
@@ -56,7 +56,7 @@ struct Bar {
 
 void Bar::baz() {
   [m_constObj doWork]; // no-warning
-  [m_obj doWork]; // expected-warning{{Receiver 'this->m_obj' (to 'SomeObj::doWork') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+  [m_obj doWork]; // expected-warning{{Receiver 'this->m_obj' (to 'SomeObj::doWork') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
 }
 
 } // namespace call_args_const_retainptr_struct_member
@@ -73,7 +73,7 @@ struct Bar {
 
 void Bar::baz() {
   consume_cf(m_cf1.get()); // no-warning
-  consume_cf(m_cf2.get()); // expected-warning{{Function argument 'this->m_cf2.get()' (to 'consume_cf') is a RetainPtr capable type 'CFArrayRef'}}
+  consume_cf(m_cf2.get()); // expected-warning{{Function argument 'this->m_cf2.get()' (to 'consume_cf') is a RetainPtr-capable type 'CFArrayRef'}}
 }
 
 } // namespace call_args_const_retainptr_cf_struct_member
@@ -92,7 +92,7 @@ private:
 
 void Foo::bar() {
   consume_obj(m_constObj.get()); // no-warning
-  consume_obj(m_obj.get()); // expected-warning{{Function argument 'this->m_obj.get()' (to 'consume_obj') is a RetainPtr capable type 'WTF::RetainPtr<SomeObj>::PtrType'}}
+  consume_obj(m_obj.get()); // expected-warning{{Function argument 'this->m_obj.get()' (to 'consume_obj') is a RetainPtr-capable type 'WTF::RetainPtr<SomeObj>::PtrType'}}
 }
 
 } // namespace call_args_const_retainptr_get_as_objc_arg
@@ -111,7 +111,7 @@ private:
 
 void Foo::bar() {
   consume_obj(m_constObj); // no-warning
-  consume_obj(m_obj); // expected-warning{{Function argument 'this->m_obj' (to 'consume_obj') is a RetainPtr capable type 'WTF::RetainPtr<SomeObj>::PtrType'}}
+  consume_obj(m_obj); // expected-warning{{Function argument 'this->m_obj' (to 'consume_obj') is a RetainPtr-capable type 'WTF::RetainPtr<SomeObj>::PtrType'}}
 }
 
 } // namespace call_args_const_retainptr_implicit_conv_arg
@@ -130,7 +130,7 @@ private:
 
 void Foo::bar() {
   consume_obj(m_constObj.get()); // no-warning
-  consume_obj(m_obj.get()); // expected-warning{{Function argument 'this->m_obj.get()' (to 'consume_obj') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+  consume_obj(m_obj.get()); // expected-warning{{Function argument 'this->m_obj.get()' (to 'consume_obj') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
 }
 
 } // namespace call_args_const_osobjectptr_member
@@ -149,7 +149,7 @@ private:
 
 void Foo::bar() {
   [m_constObj doWork]; // no-warning
-  [m_obj doWork]; // expected-warning{{Receiver 'this->m_obj' (to 'SomeObj::doWork') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+  [m_obj doWork]; // expected-warning{{Receiver 'this->m_obj' (to 'SomeObj::doWork') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
 }
 
 } // namespace call_args_const_osobjectptr_receiver

--- a/clang/test/Analysis/Checkers/WebKit/unretained-call-args.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-call-args.mm
@@ -22,11 +22,11 @@ void some_function();
 namespace simple {
   void foo() {
     consume_obj(provide());
-    // expected-warning@-1{{Call argument is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'provide()' (to 'consume_obj') is a raw pointer to RetainPtr capable type 'SomeObj'}}
     consume_cf(provide_cf());
-    // expected-warning@-1{{Call argument is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'provide_cf()' (to 'consume_cf') is a RetainPtr capable type 'CFMutableArrayRef'}}
     consume_dispatch(provide_dispatch());
-    // expected-warning@-1{{Call argument is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'provide_dispatch()' (to 'consume_dispatch') is a RetainPtr capable type 'dispatch_queue_t'}}
   }
 
   // Test that the checker works with [[clang::suppress]].
@@ -41,17 +41,17 @@ namespace multi_arg {
   void consume_retainable(int, SomeObj* foo, CFMutableArrayRef bar, dispatch_queue_t baz, bool);
   void foo() {
     consume_retainable(42, provide(), provide_cf(), provide_dispatch(), true);
-    // expected-warning@-1{{Call argument for parameter 'foo' is unretained and unsafe}}
-    // expected-warning@-2{{Call argument for parameter 'bar' is unretained and unsafe}}
-    // expected-warning@-3{{Call argument for parameter 'baz' is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'foo' to 'multi_arg::consume_retainable') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+    // expected-warning@-2{{Function argument 'provide_cf()' (parameter 'bar' to 'multi_arg::consume_retainable') is a RetainPtr capable type 'CFMutableArrayRef'}}
+    // expected-warning@-3{{Function argument 'provide_dispatch()' (parameter 'baz' to 'multi_arg::consume_retainable') is a RetainPtr capable type 'dispatch_queue_t'}}
   }
 
   void consume_retainable(SomeObj* foo, ...);
   void bar() {
     consume_retainable(provide(), 1, provide_cf(), RetainPtr<CFMutableArrayRef> { provide_cf() }.get(), provide_dispatch());
-    // expected-warning@-1{{Call argument for parameter 'foo' is unretained and unsafe}}
-    // expected-warning@-2{{Call argument is unretained and unsafe}}
-    // expected-warning@-3{{Call argument is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'foo' to 'multi_arg::consume_retainable') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+    // expected-warning@-2{{Function argument 'provide_cf()' (to 'multi_arg::consume_retainable') is a RetainPtr capable type 'CFMutableArrayRef'}}
+    // expected-warning@-3{{Function argument 'provide_dispatch()' (to 'multi_arg::consume_retainable') is a RetainPtr capable type 'dispatch_queue_t'}}
      consume_retainable(RetainPtr<SomeObj> { provide() }.get(), 1, RetainPtr<CFMutableArrayRef> { provide_cf() }.get());
   }
 }
@@ -78,11 +78,11 @@ namespace methods {
     Consumer c;
 
     c.consume_obj(provide());
-    // expected-warning@-1{{Call argument for parameter 'ptr' is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'ptr' to 'methods::Consumer::consume_obj') is a raw pointer to RetainPtr capable type 'SomeObj'}}
     c.consume_cf(provide_cf());
-    // expected-warning@-1{{Call argument for parameter 'ref' is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'provide_cf()' (parameter 'ref' to 'methods::Consumer::consume_cf') is a RetainPtr capable type 'CFMutableArrayRef'}}
     c.consume_dispatch(provide_dispatch());
-    // expected-warning@-1{{Call argument for parameter 'ptr' is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'provide_dispatch()' (parameter 'ptr' to 'methods::Consumer::consume_dispatch') is a RetainPtr capable type 'dispatch_queue_t'}}
   }
 
   void foo2() {
@@ -90,19 +90,19 @@ namespace methods {
       void consume(SomeObj*) { some_function(); }
       void whatever() {
         consume(provide());
-        // expected-warning@-1{{Call argument is unretained and unsafe}}
+        // expected-warning@-1{{Function argument 'provide()' (to 'methods::foo2()::Consumer::consume') is a raw pointer to RetainPtr capable type 'SomeObj'}}
       }
 
       void consume_cf(CFMutableArrayRef) { some_function(); }
       void something() {
         consume_cf(provide_cf());
-        // expected-warning@-1{{Call argument is unretained and unsafe}}
+        // expected-warning@-1{{Function argument 'provide_cf()' (to 'methods::foo2()::Consumer::consume_cf') is a RetainPtr capable type 'CFMutableArrayRef'}}
       }
 
       void consume_dispatch(dispatch_queue_t) { some_function(); }
       void anything() {
         consume_dispatch(provide_dispatch());
-        // expected-warning@-1{{Call argument is unretained and unsafe}}
+        // expected-warning@-1{{Function argument 'provide_dispatch()' (to 'methods::foo2()::Consumer::consume_dispatch') is a RetainPtr capable type 'dispatch_queue_t'}}
       }
     };
   }
@@ -112,19 +112,19 @@ namespace methods {
       void consume(SomeObj*) { some_function(); }
       void whatever() {
         this->consume(provide());
-        // expected-warning@-1{{Call argument is unretained and unsafe}}
+        // expected-warning@-1{{Function argument 'provide()' (to 'methods::foo3()::Consumer::consume') is a raw pointer to RetainPtr capable type 'SomeObj'}}
       }
 
       void consume_cf(CFMutableArrayRef) { some_function(); }
       void something() {
         this->consume_cf(provide_cf());
-        // expected-warning@-1{{Call argument is unretained and unsafe}}
+        // expected-warning@-1{{Function argument 'provide_cf()' (to 'methods::foo3()::Consumer::consume_cf') is a RetainPtr capable type 'CFMutableArrayRef'}}
       }
 
       void consume_dispatch(dispatch_queue_t) { some_function(); }
       void anything() {
         this->consume_dispatch(provide_dispatch());
-        // expected-warning@-1{{Call argument is unretained and unsafe}}
+        // expected-warning@-1{{Function argument 'provide_dispatch()' (to 'methods::foo3()::Consumer::consume_dispatch') is a RetainPtr capable type 'dispatch_queue_t'}}
       }
     };
   }
@@ -134,16 +134,16 @@ namespace methods {
 namespace casts {
   void foo() {
     consume_obj(provide());
-    // expected-warning@-1{{Call argument is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'provide()' (to 'consume_obj') is a raw pointer to RetainPtr capable type 'SomeObj'}}
 
     consume_obj(static_cast<OtherObj*>(provide()));
-    // expected-warning@-1{{Call argument is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'static_cast<OtherObj *>(provide())' (to 'consume_obj') is a raw pointer to RetainPtr capable type 'SomeObj'}}
 
     consume_obj(reinterpret_cast<OtherObj*>(provide()));
-    // expected-warning@-1{{Call argument is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'reinterpret_cast<OtherObj *>(provide())' (to 'consume_obj') is a raw pointer to RetainPtr capable type 'SomeObj'}}
 
     consume_obj(downcast<OtherObj>(provide()));
-    // expected-warning@-1{{Call argument is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'downcast<OtherObj>(provide())' (to 'consume_obj') is a raw pointer to RetainPtr capable type 'SomeObj'}}
   }
 }
 
@@ -167,7 +167,7 @@ namespace retain_ptr_lookalike {
     Decoy D;
 
     consume_obj(D.get());
-    // expected-warning@-1{{Call argument is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'D.get()' (to 'consume_obj') is a raw pointer to RetainPtr capable type 'SomeObj'}}
   }
 
   struct Decoy2 {
@@ -178,7 +178,7 @@ namespace retain_ptr_lookalike {
     Decoy2 D;
 
     consume_cf(D.get());
-    // expected-warning@-1{{Call argument is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'D.get()' (to 'consume_cf') is a RetainPtr capable type 'CFMutableArrayRef'}}
   }
 }
 
@@ -260,13 +260,13 @@ namespace default_arg {
   dispatch_queue_t global_dispatch;
 
   void function_with_default_arg1(SomeObj* param = global);
-  // expected-warning@-1{{Call argument for parameter 'param' is unretained and unsafe}}
+  // expected-warning@-1{{Function argument 'global' (parameter 'param' to 'default_arg::function_with_default_arg1') is a raw pointer to RetainPtr capable type 'SomeObj'}}
 
   void function_with_default_arg2(CFMutableArrayRef param = global_cf);
-  // expected-warning@-1{{Call argument for parameter 'param' is unretained and unsafe}}
+  // expected-warning@-1{{Function argument 'global_cf' (parameter 'param' to 'default_arg::function_with_default_arg2') is a RetainPtr capable type 'CFMutableArrayRef'}}
 
   void function_with_default_arg3(dispatch_queue_t param = global_dispatch);
-  // expected-warning@-1{{Call argument for parameter 'param' is unretained and unsafe}}
+  // expected-warning@-1{{Function argument 'global_dispatch' (parameter 'param' to 'default_arg::function_with_default_arg3') is a RetainPtr capable type 'dispatch_queue_t'}}
 
   void foo() {
     function_with_default_arg1();
@@ -281,17 +281,17 @@ namespace cxx_member_func {
 
   void foo() {
     [provide() doWork];
-    // expected-warning@-1{{Receiver is unretained and unsafe}}
+    // expected-warning@-1{{Receiver 'provide()' (to 'SomeObj::doWork') is a raw pointer to RetainPtr capable type 'SomeObj'}}
     [protectedProvide().get() doWork];
 
     CFArrayAppendValue(provide_cf(), nullptr);
-    // expected-warning@-1{{Call argument for parameter 'theArray' is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'provide_cf()' (parameter 'theArray' to 'CFArrayAppendValue') is a RetainPtr capable type 'CFMutableArrayRef'}}
     CFArrayAppendValue(protectedProvideCF(), nullptr);
   };
 
   void bar() {
     [downcast<OtherObj>(protectedProvide().get()) doMoreWork:downcast<OtherObj>(provide())];
-    // expected-warning@-1{{Call argument for parameter 'other' is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'downcast<OtherObj>(provide())' (parameter 'other' to 'OtherObj::doMoreWork:') is a raw pointer to RetainPtr capable type 'OtherObj'}}
     [protectedProvide().get() doWork];
   };
 
@@ -312,13 +312,13 @@ namespace cxx_member_operator_call {
   void foo() {
     Foo f;
     f + global;
-    // expected-warning@-1{{Call argument for parameter 'bad' is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::Foo::operator+') is a raw pointer to RetainPtr capable type 'SomeObj'}}
     f - global;
-    // expected-warning@-1{{Call argument for parameter 'bad' is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::operator-') is a raw pointer to RetainPtr capable type 'SomeObj'}}
     f(global);
-    // expected-warning@-1{{Call argument for parameter 'bad' is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::Foo::operator()') is a raw pointer to RetainPtr capable type 'SomeObj'}}
     f << global_dispatch;
-    // expected-warning@-1{{Call argument for parameter 'bad' is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'global_dispatch' (parameter 'bad' to 'cxx_member_operator_call::Foo::operator<<') is a RetainPtr capable type 'dispatch_queue_t'}}
   }
 }
 
@@ -346,23 +346,23 @@ namespace call_with_ptr_on_ref {
     bar(v ? nullptr : provideProtected().get());
     bar(baz() ? provideProtected().get() : nullptr);
     bar(v ? provide() : provideProtected().get());
-    // expected-warning@-1{{Call argument for parameter 'bad' is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'v ? provide() : provideProtected().get()' (parameter 'bad' to 'call_with_ptr_on_ref::bar') is a raw pointer to RetainPtr capable type 'SomeObj'}}
     bar(v ? provideProtected().get() : provide());
-    // expected-warning@-1{{Call argument for parameter 'bad' is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'v ? provideProtected().get() : provide()' (parameter 'bad' to 'call_with_ptr_on_ref::bar') is a raw pointer to RetainPtr capable type 'SomeObj'}}
 
     bar_cf(v ? nullptr : provideProtectedCF().get());
     bar_cf(baz() ? provideProtectedCF().get() : nullptr);
     bar_cf(v ? provide_cf() : provideProtectedCF().get());
-    // expected-warning@-1{{Call argument for parameter 'bad' is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'v ? provide_cf() : provideProtectedCF().get()' (parameter 'bad' to 'call_with_ptr_on_ref::bar_cf') is a raw pointer to RetainPtr capable type '__CFArray'}}
     bar_cf(v ? provideProtectedCF().get() : provide_cf());
-    // expected-warning@-1{{Call argument for parameter 'bad' is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'v ? provideProtectedCF().get() : provide_cf()' (parameter 'bad' to 'call_with_ptr_on_ref::bar_cf') is a raw pointer to RetainPtr capable type '__CFArray'}}
 
     bar_dispatch(v ? nullptr : provideProtectedDispatch().get());
     bar_dispatch(baz() ? provideProtectedDispatch().get() : nullptr);
     bar_dispatch(v ? provide_dispatch() : provideProtectedDispatch().get());
-    // expected-warning@-1{{Call argument is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'v ? provide_dispatch() : provideProtectedDispatch(...' (to 'call_with_ptr_on_ref::bar_dispatch') is a raw pointer to RetainPtr capable type 'NSObject'}}
     bar_dispatch(v ? provideProtectedDispatch().get() : provide_dispatch());
-    // expected-warning@-1{{Call argument is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'v ? provideProtectedDispatch().get() : provide_dis...' (to 'call_with_ptr_on_ref::bar_dispatch') is a raw pointer to RetainPtr capable type 'NSObject'}}
   }
 }
 
@@ -516,9 +516,9 @@ NSString *provide_str();
 CFDictionaryRef provide_dict();
 void use_const_local() {
   doWork(provide_str(), provide_dict(), provide_dispatch());
-  // expected-warning@-1{{Call argument for parameter 'str' is unretained and unsafe}}
-  // expected-warning@-2{{Call argument for parameter 'dict' is unretained and unsafe}}
-  // expected-warning@-3{{Call argument for parameter 'dispatch' is unretained and unsafe}}
+  // expected-warning@-1{{Function argument 'provide_str()' (parameter 'str' to 'const_global::doWork') is a raw pointer to RetainPtr capable type 'NSString}}
+  // expected-warning@-2{{Function argument 'provide_dict()' (parameter 'dict' to 'const_global::doWork') is a RetainPtr capable type 'CFDictionaryRef'}}
+  // expected-warning@-3{{Function argument 'provide_dispatch()' (parameter 'dispatch' to 'const_global::doWork') is a RetainPtr capable type 'dispatch_queue_t'}}
 }
 
 } // namespace const_global
@@ -541,7 +541,7 @@ typedef Class (Bar::*SomeObjectSingleton)();
 
 bool bar(NSObject *obj, Bar *bar, SomeObjectSingleton someObjSingleton) {
   return [obj isKindOfClass:(bar->*someObjSingleton)()];
-  // expected-warning@-1{{Call argument for parameter 'aClass' is unretained and unsafe}}
+  // expected-warning@-1{{Function argument '(bar ->* someObjSingleton)()' (parameter 'aClass' to 'NSObject::isKindOfClass:') is a RetainPtr capable type 'Class'}}
 }
 
 bool baz(NSObject *obj) {
@@ -656,9 +656,9 @@ SomeObj *allocObj();
 - (void)doWorkOnSelf {
   [self doWork:nil];
   [self doWork:@"hello", provide(), provide_cf(), provide_dispatch()];
-  // expected-warning@-1{{Call argument is unretained and unsafe}}
-  // expected-warning@-2{{Call argument is unretained and unsafe}}
-  // expected-warning@-3{{Call argument is unretained and unsafe}}
+  // expected-warning@-1{{Function argument 'provide()' (to 'TestObject::doWork:') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+  // expected-warning@-2{{Function argument 'provide_cf()' (to 'TestObject::doWork:') is a RetainPtr capable type 'CFMutableArrayRef'}}
+  // expected-warning@-3{{Function argument 'provide_dispatch()' (to 'TestObject::doWork:') is a RetainPtr capable type 'dispatch_queue_t'}}
   [self doWork:@"hello", RetainPtr<SomeObj> { provide() }.get(), RetainPtr<CFMutableArrayRef> { provide_cf() }.get(), OSObjectPtr { provide_dispatch() }.get()];
   [self doWork:__null];
   [self doWork:nil];
@@ -681,7 +681,7 @@ SomeObj *allocObj();
 
 - (void)doWorkOnSomeObj {
     [[self getSomeObj] doWork];
-    // expected-warning@-1{{Receiver is unretained and unsafe}}
+    // expected-warning@-1{{Receiver '[self getSomeObj]' (to 'SomeObj::doWork') is a raw pointer to RetainPtr capable type 'SomeObj'}}
     [[TestObject sharedObj] doWork];
 }
 

--- a/clang/test/Analysis/Checkers/WebKit/unretained-call-args.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-call-args.mm
@@ -22,11 +22,11 @@ void some_function();
 namespace simple {
   void foo() {
     consume_obj(provide());
-    // expected-warning@-1{{Function argument 'provide()' (to 'consume_obj') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+    // expected-warning@-1{{Function argument 'provide()' (to 'consume_obj') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
     consume_cf(provide_cf());
-    // expected-warning@-1{{Function argument 'provide_cf()' (to 'consume_cf') is a RetainPtr capable type 'CFMutableArrayRef'}}
+    // expected-warning@-1{{Function argument 'provide_cf()' (to 'consume_cf') is a RetainPtr-capable type 'CFMutableArrayRef'}}
     consume_dispatch(provide_dispatch());
-    // expected-warning@-1{{Function argument 'provide_dispatch()' (to 'consume_dispatch') is a RetainPtr capable type 'dispatch_queue_t'}}
+    // expected-warning@-1{{Function argument 'provide_dispatch()' (to 'consume_dispatch') is a RetainPtr-capable type 'dispatch_queue_t'}}
   }
 
   // Test that the checker works with [[clang::suppress]].
@@ -41,17 +41,17 @@ namespace multi_arg {
   void consume_retainable(int, SomeObj* foo, CFMutableArrayRef bar, dispatch_queue_t baz, bool);
   void foo() {
     consume_retainable(42, provide(), provide_cf(), provide_dispatch(), true);
-    // expected-warning@-1{{Function argument 'provide()' (parameter 'foo' to 'multi_arg::consume_retainable') is a raw pointer to RetainPtr capable type 'SomeObj'}}
-    // expected-warning@-2{{Function argument 'provide_cf()' (parameter 'bar' to 'multi_arg::consume_retainable') is a RetainPtr capable type 'CFMutableArrayRef'}}
-    // expected-warning@-3{{Function argument 'provide_dispatch()' (parameter 'baz' to 'multi_arg::consume_retainable') is a RetainPtr capable type 'dispatch_queue_t'}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'foo' to 'multi_arg::consume_retainable') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
+    // expected-warning@-2{{Function argument 'provide_cf()' (parameter 'bar' to 'multi_arg::consume_retainable') is a RetainPtr-capable type 'CFMutableArrayRef'}}
+    // expected-warning@-3{{Function argument 'provide_dispatch()' (parameter 'baz' to 'multi_arg::consume_retainable') is a RetainPtr-capable type 'dispatch_queue_t'}}
   }
 
   void consume_retainable(SomeObj* foo, ...);
   void bar() {
     consume_retainable(provide(), 1, provide_cf(), RetainPtr<CFMutableArrayRef> { provide_cf() }.get(), provide_dispatch());
-    // expected-warning@-1{{Function argument 'provide()' (parameter 'foo' to 'multi_arg::consume_retainable') is a raw pointer to RetainPtr capable type 'SomeObj'}}
-    // expected-warning@-2{{Function argument 'provide_cf()' (to 'multi_arg::consume_retainable') is a RetainPtr capable type 'CFMutableArrayRef'}}
-    // expected-warning@-3{{Function argument 'provide_dispatch()' (to 'multi_arg::consume_retainable') is a RetainPtr capable type 'dispatch_queue_t'}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'foo' to 'multi_arg::consume_retainable') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
+    // expected-warning@-2{{Function argument 'provide_cf()' (to 'multi_arg::consume_retainable') is a RetainPtr-capable type 'CFMutableArrayRef'}}
+    // expected-warning@-3{{Function argument 'provide_dispatch()' (to 'multi_arg::consume_retainable') is a RetainPtr-capable type 'dispatch_queue_t'}}
      consume_retainable(RetainPtr<SomeObj> { provide() }.get(), 1, RetainPtr<CFMutableArrayRef> { provide_cf() }.get());
   }
 }
@@ -78,11 +78,11 @@ namespace methods {
     Consumer c;
 
     c.consume_obj(provide());
-    // expected-warning@-1{{Function argument 'provide()' (parameter 'ptr' to 'methods::Consumer::consume_obj') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+    // expected-warning@-1{{Function argument 'provide()' (parameter 'ptr' to 'methods::Consumer::consume_obj') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
     c.consume_cf(provide_cf());
-    // expected-warning@-1{{Function argument 'provide_cf()' (parameter 'ref' to 'methods::Consumer::consume_cf') is a RetainPtr capable type 'CFMutableArrayRef'}}
+    // expected-warning@-1{{Function argument 'provide_cf()' (parameter 'ref' to 'methods::Consumer::consume_cf') is a RetainPtr-capable type 'CFMutableArrayRef'}}
     c.consume_dispatch(provide_dispatch());
-    // expected-warning@-1{{Function argument 'provide_dispatch()' (parameter 'ptr' to 'methods::Consumer::consume_dispatch') is a RetainPtr capable type 'dispatch_queue_t'}}
+    // expected-warning@-1{{Function argument 'provide_dispatch()' (parameter 'ptr' to 'methods::Consumer::consume_dispatch') is a RetainPtr-capable type 'dispatch_queue_t'}}
   }
 
   void foo2() {
@@ -90,19 +90,19 @@ namespace methods {
       void consume(SomeObj*) { some_function(); }
       void whatever() {
         consume(provide());
-        // expected-warning@-1{{Function argument 'provide()' (to 'methods::foo2()::Consumer::consume') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+        // expected-warning@-1{{Function argument 'provide()' (to 'methods::foo2()::Consumer::consume') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
       }
 
       void consume_cf(CFMutableArrayRef) { some_function(); }
       void something() {
         consume_cf(provide_cf());
-        // expected-warning@-1{{Function argument 'provide_cf()' (to 'methods::foo2()::Consumer::consume_cf') is a RetainPtr capable type 'CFMutableArrayRef'}}
+        // expected-warning@-1{{Function argument 'provide_cf()' (to 'methods::foo2()::Consumer::consume_cf') is a RetainPtr-capable type 'CFMutableArrayRef'}}
       }
 
       void consume_dispatch(dispatch_queue_t) { some_function(); }
       void anything() {
         consume_dispatch(provide_dispatch());
-        // expected-warning@-1{{Function argument 'provide_dispatch()' (to 'methods::foo2()::Consumer::consume_dispatch') is a RetainPtr capable type 'dispatch_queue_t'}}
+        // expected-warning@-1{{Function argument 'provide_dispatch()' (to 'methods::foo2()::Consumer::consume_dispatch') is a RetainPtr-capable type 'dispatch_queue_t'}}
       }
     };
   }
@@ -112,19 +112,19 @@ namespace methods {
       void consume(SomeObj*) { some_function(); }
       void whatever() {
         this->consume(provide());
-        // expected-warning@-1{{Function argument 'provide()' (to 'methods::foo3()::Consumer::consume') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+        // expected-warning@-1{{Function argument 'provide()' (to 'methods::foo3()::Consumer::consume') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
       }
 
       void consume_cf(CFMutableArrayRef) { some_function(); }
       void something() {
         this->consume_cf(provide_cf());
-        // expected-warning@-1{{Function argument 'provide_cf()' (to 'methods::foo3()::Consumer::consume_cf') is a RetainPtr capable type 'CFMutableArrayRef'}}
+        // expected-warning@-1{{Function argument 'provide_cf()' (to 'methods::foo3()::Consumer::consume_cf') is a RetainPtr-capable type 'CFMutableArrayRef'}}
       }
 
       void consume_dispatch(dispatch_queue_t) { some_function(); }
       void anything() {
         this->consume_dispatch(provide_dispatch());
-        // expected-warning@-1{{Function argument 'provide_dispatch()' (to 'methods::foo3()::Consumer::consume_dispatch') is a RetainPtr capable type 'dispatch_queue_t'}}
+        // expected-warning@-1{{Function argument 'provide_dispatch()' (to 'methods::foo3()::Consumer::consume_dispatch') is a RetainPtr-capable type 'dispatch_queue_t'}}
       }
     };
   }
@@ -134,16 +134,16 @@ namespace methods {
 namespace casts {
   void foo() {
     consume_obj(provide());
-    // expected-warning@-1{{Function argument 'provide()' (to 'consume_obj') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+    // expected-warning@-1{{Function argument 'provide()' (to 'consume_obj') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
 
     consume_obj(static_cast<OtherObj*>(provide()));
-    // expected-warning@-1{{Function argument 'static_cast<OtherObj *>(provide())' (to 'consume_obj') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+    // expected-warning@-1{{Function argument 'static_cast<OtherObj *>(provide())' (to 'consume_obj') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
 
     consume_obj(reinterpret_cast<OtherObj*>(provide()));
-    // expected-warning@-1{{Function argument 'reinterpret_cast<OtherObj *>(provide())' (to 'consume_obj') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+    // expected-warning@-1{{Function argument 'reinterpret_cast<OtherObj *>(provide())' (to 'consume_obj') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
 
     consume_obj(downcast<OtherObj>(provide()));
-    // expected-warning@-1{{Function argument 'downcast<OtherObj>(provide())' (to 'consume_obj') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+    // expected-warning@-1{{Function argument 'downcast<OtherObj>(provide())' (to 'consume_obj') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
   }
 }
 
@@ -167,7 +167,7 @@ namespace retain_ptr_lookalike {
     Decoy D;
 
     consume_obj(D.get());
-    // expected-warning@-1{{Function argument 'D.get()' (to 'consume_obj') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+    // expected-warning@-1{{Function argument 'D.get()' (to 'consume_obj') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
   }
 
   struct Decoy2 {
@@ -178,7 +178,7 @@ namespace retain_ptr_lookalike {
     Decoy2 D;
 
     consume_cf(D.get());
-    // expected-warning@-1{{Function argument 'D.get()' (to 'consume_cf') is a RetainPtr capable type 'CFMutableArrayRef'}}
+    // expected-warning@-1{{Function argument 'D.get()' (to 'consume_cf') is a RetainPtr-capable type 'CFMutableArrayRef'}}
   }
 }
 
@@ -260,13 +260,13 @@ namespace default_arg {
   dispatch_queue_t global_dispatch;
 
   void function_with_default_arg1(SomeObj* param = global);
-  // expected-warning@-1{{Function argument 'global' (parameter 'param' to 'default_arg::function_with_default_arg1') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+  // expected-warning@-1{{Function argument 'global' (parameter 'param' to 'default_arg::function_with_default_arg1') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
 
   void function_with_default_arg2(CFMutableArrayRef param = global_cf);
-  // expected-warning@-1{{Function argument 'global_cf' (parameter 'param' to 'default_arg::function_with_default_arg2') is a RetainPtr capable type 'CFMutableArrayRef'}}
+  // expected-warning@-1{{Function argument 'global_cf' (parameter 'param' to 'default_arg::function_with_default_arg2') is a RetainPtr-capable type 'CFMutableArrayRef'}}
 
   void function_with_default_arg3(dispatch_queue_t param = global_dispatch);
-  // expected-warning@-1{{Function argument 'global_dispatch' (parameter 'param' to 'default_arg::function_with_default_arg3') is a RetainPtr capable type 'dispatch_queue_t'}}
+  // expected-warning@-1{{Function argument 'global_dispatch' (parameter 'param' to 'default_arg::function_with_default_arg3') is a RetainPtr-capable type 'dispatch_queue_t'}}
 
   void foo() {
     function_with_default_arg1();
@@ -281,17 +281,17 @@ namespace cxx_member_func {
 
   void foo() {
     [provide() doWork];
-    // expected-warning@-1{{Receiver 'provide()' (to 'SomeObj::doWork') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+    // expected-warning@-1{{Receiver 'provide()' (to 'SomeObj::doWork') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
     [protectedProvide().get() doWork];
 
     CFArrayAppendValue(provide_cf(), nullptr);
-    // expected-warning@-1{{Function argument 'provide_cf()' (parameter 'theArray' to 'CFArrayAppendValue') is a RetainPtr capable type 'CFMutableArrayRef'}}
+    // expected-warning@-1{{Function argument 'provide_cf()' (parameter 'theArray' to 'CFArrayAppendValue') is a RetainPtr-capable type 'CFMutableArrayRef'}}
     CFArrayAppendValue(protectedProvideCF(), nullptr);
   };
 
   void bar() {
     [downcast<OtherObj>(protectedProvide().get()) doMoreWork:downcast<OtherObj>(provide())];
-    // expected-warning@-1{{Function argument 'downcast<OtherObj>(provide())' (parameter 'other' to 'OtherObj::doMoreWork:') is a raw pointer to RetainPtr capable type 'OtherObj'}}
+    // expected-warning@-1{{Function argument 'downcast<OtherObj>(provide())' (parameter 'other' to 'OtherObj::doMoreWork:') is a raw pointer to RetainPtr-capable type 'OtherObj'}}
     [protectedProvide().get() doWork];
   };
 
@@ -312,13 +312,13 @@ namespace cxx_member_operator_call {
   void foo() {
     Foo f;
     f + global;
-    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::Foo::operator+') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::Foo::operator+') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
     f - global;
-    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::operator-') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::operator-') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
     f(global);
-    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::Foo::operator()') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+    // expected-warning@-1{{Function argument 'global' (parameter 'bad' to 'cxx_member_operator_call::Foo::operator()') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
     f << global_dispatch;
-    // expected-warning@-1{{Function argument 'global_dispatch' (parameter 'bad' to 'cxx_member_operator_call::Foo::operator<<') is a RetainPtr capable type 'dispatch_queue_t'}}
+    // expected-warning@-1{{Function argument 'global_dispatch' (parameter 'bad' to 'cxx_member_operator_call::Foo::operator<<') is a RetainPtr-capable type 'dispatch_queue_t'}}
   }
 }
 
@@ -346,23 +346,23 @@ namespace call_with_ptr_on_ref {
     bar(v ? nullptr : provideProtected().get());
     bar(baz() ? provideProtected().get() : nullptr);
     bar(v ? provide() : provideProtected().get());
-    // expected-warning@-1{{Function argument 'v ? provide() : provideProtected().get()' (parameter 'bad' to 'call_with_ptr_on_ref::bar') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+    // expected-warning@-1{{Function argument 'v ? provide() : provideProtected().get()' (parameter 'bad' to 'call_with_ptr_on_ref::bar') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
     bar(v ? provideProtected().get() : provide());
-    // expected-warning@-1{{Function argument 'v ? provideProtected().get() : provide()' (parameter 'bad' to 'call_with_ptr_on_ref::bar') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+    // expected-warning@-1{{Function argument 'v ? provideProtected().get() : provide()' (parameter 'bad' to 'call_with_ptr_on_ref::bar') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
 
     bar_cf(v ? nullptr : provideProtectedCF().get());
     bar_cf(baz() ? provideProtectedCF().get() : nullptr);
     bar_cf(v ? provide_cf() : provideProtectedCF().get());
-    // expected-warning@-1{{Function argument 'v ? provide_cf() : provideProtectedCF().get()' (parameter 'bad' to 'call_with_ptr_on_ref::bar_cf') is a raw pointer to RetainPtr capable type '__CFArray'}}
+    // expected-warning@-1{{Function argument 'v ? provide_cf() : provideProtectedCF().get()' (parameter 'bad' to 'call_with_ptr_on_ref::bar_cf') is a raw pointer to RetainPtr-capable type '__CFArray'}}
     bar_cf(v ? provideProtectedCF().get() : provide_cf());
-    // expected-warning@-1{{Function argument 'v ? provideProtectedCF().get() : provide_cf()' (parameter 'bad' to 'call_with_ptr_on_ref::bar_cf') is a raw pointer to RetainPtr capable type '__CFArray'}}
+    // expected-warning@-1{{Function argument 'v ? provideProtectedCF().get() : provide_cf()' (parameter 'bad' to 'call_with_ptr_on_ref::bar_cf') is a raw pointer to RetainPtr-capable type '__CFArray'}}
 
     bar_dispatch(v ? nullptr : provideProtectedDispatch().get());
     bar_dispatch(baz() ? provideProtectedDispatch().get() : nullptr);
     bar_dispatch(v ? provide_dispatch() : provideProtectedDispatch().get());
-    // expected-warning@-1{{Function argument 'v ? provide_dispatch() : provideProtectedDispatch(...' (to 'call_with_ptr_on_ref::bar_dispatch') is a raw pointer to RetainPtr capable type 'NSObject'}}
+    // expected-warning@-1{{Function argument 'v ? provide_dispatch() : provideProtectedDispatch(...' (to 'call_with_ptr_on_ref::bar_dispatch') is a raw pointer to RetainPtr-capable type 'NSObject'}}
     bar_dispatch(v ? provideProtectedDispatch().get() : provide_dispatch());
-    // expected-warning@-1{{Function argument 'v ? provideProtectedDispatch().get() : provide_dis...' (to 'call_with_ptr_on_ref::bar_dispatch') is a raw pointer to RetainPtr capable type 'NSObject'}}
+    // expected-warning@-1{{Function argument 'v ? provideProtectedDispatch().get() : provide_dis...' (to 'call_with_ptr_on_ref::bar_dispatch') is a raw pointer to RetainPtr-capable type 'NSObject'}}
   }
 }
 
@@ -516,9 +516,9 @@ NSString *provide_str();
 CFDictionaryRef provide_dict();
 void use_const_local() {
   doWork(provide_str(), provide_dict(), provide_dispatch());
-  // expected-warning@-1{{Function argument 'provide_str()' (parameter 'str' to 'const_global::doWork') is a raw pointer to RetainPtr capable type 'NSString}}
-  // expected-warning@-2{{Function argument 'provide_dict()' (parameter 'dict' to 'const_global::doWork') is a RetainPtr capable type 'CFDictionaryRef'}}
-  // expected-warning@-3{{Function argument 'provide_dispatch()' (parameter 'dispatch' to 'const_global::doWork') is a RetainPtr capable type 'dispatch_queue_t'}}
+  // expected-warning@-1{{Function argument 'provide_str()' (parameter 'str' to 'const_global::doWork') is a raw pointer to RetainPtr-capable type 'NSString}}
+  // expected-warning@-2{{Function argument 'provide_dict()' (parameter 'dict' to 'const_global::doWork') is a RetainPtr-capable type 'CFDictionaryRef'}}
+  // expected-warning@-3{{Function argument 'provide_dispatch()' (parameter 'dispatch' to 'const_global::doWork') is a RetainPtr-capable type 'dispatch_queue_t'}}
 }
 
 } // namespace const_global
@@ -541,7 +541,7 @@ typedef Class (Bar::*SomeObjectSingleton)();
 
 bool bar(NSObject *obj, Bar *bar, SomeObjectSingleton someObjSingleton) {
   return [obj isKindOfClass:(bar->*someObjSingleton)()];
-  // expected-warning@-1{{Function argument '(bar ->* someObjSingleton)()' (parameter 'aClass' to 'NSObject::isKindOfClass:') is a RetainPtr capable type 'Class'}}
+  // expected-warning@-1{{Function argument '(bar ->* someObjSingleton)()' (parameter 'aClass' to 'NSObject::isKindOfClass:') is a RetainPtr-capable type 'Class'}}
 }
 
 bool baz(NSObject *obj) {
@@ -656,9 +656,9 @@ SomeObj *allocObj();
 - (void)doWorkOnSelf {
   [self doWork:nil];
   [self doWork:@"hello", provide(), provide_cf(), provide_dispatch()];
-  // expected-warning@-1{{Function argument 'provide()' (to 'TestObject::doWork:') is a raw pointer to RetainPtr capable type 'SomeObj'}}
-  // expected-warning@-2{{Function argument 'provide_cf()' (to 'TestObject::doWork:') is a RetainPtr capable type 'CFMutableArrayRef'}}
-  // expected-warning@-3{{Function argument 'provide_dispatch()' (to 'TestObject::doWork:') is a RetainPtr capable type 'dispatch_queue_t'}}
+  // expected-warning@-1{{Function argument 'provide()' (to 'TestObject::doWork:') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
+  // expected-warning@-2{{Function argument 'provide_cf()' (to 'TestObject::doWork:') is a RetainPtr-capable type 'CFMutableArrayRef'}}
+  // expected-warning@-3{{Function argument 'provide_dispatch()' (to 'TestObject::doWork:') is a RetainPtr-capable type 'dispatch_queue_t'}}
   [self doWork:@"hello", RetainPtr<SomeObj> { provide() }.get(), RetainPtr<CFMutableArrayRef> { provide_cf() }.get(), OSObjectPtr { provide_dispatch() }.get()];
   [self doWork:__null];
   [self doWork:nil];
@@ -681,7 +681,7 @@ SomeObj *allocObj();
 
 - (void)doWorkOnSomeObj {
     [[self getSomeObj] doWork];
-    // expected-warning@-1{{Receiver '[self getSomeObj]' (to 'SomeObj::doWork') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+    // expected-warning@-1{{Receiver '[self getSomeObj]' (to 'SomeObj::doWork') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
     [[TestObject sharedObj] doWork];
 }
 

--- a/clang/test/Analysis/Checkers/WebKit/unretained-obj-arg.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-obj-arg.mm
@@ -11,8 +11,8 @@ extern "C" NSString *LocalGlobalNSString;
 void foo() {
   consumeCFString(kCFURLTagNamesKey);
   consumeCFString(LocalGlobalCFString);
-    // expected-warning@-1{{Call argument is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'LocalGlobalCFString' (to 'consumeCFString') is a RetainPtr capable type 'CFStringRef'}}
   consumeNSString(NSApplicationDidBecomeActiveNotification);
   consumeNSString(LocalGlobalNSString);
-    // expected-warning@-1{{Call argument is unretained and unsafe}}
+    // expected-warning@-1{{Function argument 'LocalGlobalNSString' (to 'consumeNSString') is a raw pointer to RetainPtr capable type 'NSString'}}
 }

--- a/clang/test/Analysis/Checkers/WebKit/unretained-obj-arg.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-obj-arg.mm
@@ -11,8 +11,8 @@ extern "C" NSString *LocalGlobalNSString;
 void foo() {
   consumeCFString(kCFURLTagNamesKey);
   consumeCFString(LocalGlobalCFString);
-    // expected-warning@-1{{Function argument 'LocalGlobalCFString' (to 'consumeCFString') is a RetainPtr capable type 'CFStringRef'}}
+    // expected-warning@-1{{Function argument 'LocalGlobalCFString' (to 'consumeCFString') is a RetainPtr-capable type 'CFStringRef'}}
   consumeNSString(NSApplicationDidBecomeActiveNotification);
   consumeNSString(LocalGlobalNSString);
-    // expected-warning@-1{{Function argument 'LocalGlobalNSString' (to 'consumeNSString') is a raw pointer to RetainPtr capable type 'NSString'}}
+    // expected-warning@-1{{Function argument 'LocalGlobalNSString' (to 'consumeNSString') is a raw pointer to RetainPtr-capable type 'NSString'}}
 }


### PR DESCRIPTION
This PR improves UncountedCallArgsChecker and its variant's warning message to explicitly state the argument expression, the qualified callee type as well as the type which needs to be kept alive.