### PR TITLE
[LLDB] Fix race/collision in TestGlobalModuleCache.py

### DIFF
--- a/lldb/test/API/python_api/global_module_cache/TestGlobalModuleCache.py
+++ b/lldb/test/API/python_api/global_module_cache/TestGlobalModuleCache.py
@@ -99,6 +99,14 @@ class GlobalModuleCacheTestCase(TestBase):
         self.copy_to_main(two_print_path, main_c_path)
 
         self.build(dictionary={"C_SOURCES": main_c_path, "EXE": "a.out"})
+
+        # Force a different mtime for the new binary to avoid cache collision
+        # if the build happened in the same second as the first build.
+        new_a_out = os.path.join(self.getBuildDir(), "a.out")
+        if os.path.exists(new_a_out):
+            future_time = time.time() + 2
+            os.utime(new_a_out, (future_time, future_time))
+
         error = lldb.SBError()
         if one_debugger:
             if one_target:


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/201561 sped up the test so much that, on very fast machines, there is now a collision. The two different a.out files get created with the exact same timestmp, which confuses the module caching and can result in odd test failures:

make: Leaving directory '/build/work/8a9b9199309f6c504f12c8bdaef77b319248/google3/tmp/lldb-test-build.noindex/python_api/global_module_cache/TestGlobalModuleCache.test_TwoTargetsOneDebugger_dwarf'

Unable to load lldb extension module.  Possible reasons for this include:
  1) LLDB was built with LLDB_ENABLE_PYTHON=0
  2) PYTHONPATH and PYTHONHOME are not set correctly.  PYTHONHOME should refer to
     the version of Python that LLDB built and linked against, and PYTHONPATH
     should contain the Lib directory for the same python distro, as well as the
     location of LLDB's site-packages folder.
  3) A different version of Python than that which was built against is exported in
     the system's PATH environment variable, causing conflicts.
  4) The executable '/build/work/8a9b9199309f6c504f12c8bdaef77b319248/google3/runfiles/google3/third_party/llvm/llvm-project/lldb/lldb' could not be found.  Please check
     that it exists and is executable.

This PR fixes that by future-dating the second a.out file.

AI-assisted by Gemini.