### PR TITLE
[lldb] Extract Mach-O export trie parsing into MachOTrie.{h,cpp} (NFC)

### DIFF
--- a/lldb/source/Plugins/ObjectFile/Mach-O/CMakeLists.txt
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_lldb_library(lldbPluginObjectFileMachO PLUGIN
   ObjectFileMachO.cpp
+  MachOTrie.cpp
 
   LINK_COMPONENTS
     Support

--- a/lldb/source/Plugins/ObjectFile/Mach-O/MachOTrie.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/MachOTrie.cpp
@@ -1,0 +1,126 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "MachOTrie.h"
+
+#include "lldb/Utility/DataExtractor.h"
+#include "lldb/Utility/Flags.h"
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/BinaryFormat/MachO.h"
+
+#include <cstdio>
+
+using namespace lldb;
+using namespace lldb_private;
+using namespace llvm::MachO;
+
+void TrieEntry::Dump() const {
+  printf("0x%16.16llx 0x%16.16llx 0x%16.16llx \"%s\"",
+         static_cast<unsigned long long>(address),
+         static_cast<unsigned long long>(flags),
+         static_cast<unsigned long long>(other), name.GetCString());
+  if (import_name)
+    printf(" -> \"%s\"\n", import_name.GetCString());
+  else
+    printf("\n");
+}
+
+void TrieEntryWithOffset::Dump(uint32_t idx) const {
+  printf("[%3u] 0x%16.16llx: ", idx,
+         static_cast<unsigned long long>(nodeOffset));
+  entry.Dump();
+}
+
+bool lldb_private::ParseTrieEntries(
+    DataExtractor &data, lldb::offset_t offset, const bool is_arm,
+    lldb::addr_t text_seg_base_addr, std::string &prefix,
+    std::set<lldb::addr_t> &resolver_addresses,
+    std::vector<TrieEntryWithOffset> &reexports,
+    std::vector<TrieEntryWithOffset> &ext_symbols) {
+  if (!data.ValidOffset(offset))
+    return true;
+
+  // Terminal node -- end of a branch, possibly add this to
+  // the symbol table or resolver table.
+  const uint64_t terminalSize = data.GetULEB128(&offset);
+  lldb::offset_t children_offset = offset + terminalSize;
+  if (terminalSize != 0) {
+    TrieEntryWithOffset e(offset);
+    e.entry.flags = data.GetULEB128(&offset);
+    const char *import_name = nullptr;
+    if (e.entry.flags & EXPORT_SYMBOL_FLAGS_REEXPORT) {
+      e.entry.address = 0;
+      e.entry.other = data.GetULEB128(&offset); // dylib ordinal
+      import_name = data.GetCStr(&offset);
+    } else {
+      e.entry.address = data.GetULEB128(&offset);
+      if (text_seg_base_addr != LLDB_INVALID_ADDRESS)
+        e.entry.address += text_seg_base_addr;
+      if (e.entry.flags & EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER) {
+        e.entry.other = data.GetULEB128(&offset);
+        uint64_t resolver_addr = e.entry.other;
+        if (text_seg_base_addr != LLDB_INVALID_ADDRESS)
+          resolver_addr += text_seg_base_addr;
+        if (is_arm)
+          resolver_addr &= THUMB_ADDRESS_BIT_MASK;
+        resolver_addresses.insert(resolver_addr);
+      } else
+        e.entry.other = 0;
+    }
+    bool add_this_entry = false;
+    if (Flags(e.entry.flags).Test(EXPORT_SYMBOL_FLAGS_REEXPORT) &&
+        import_name && import_name[0]) {
+      // add symbols that are reexport symbols with a valid import name.
+      add_this_entry = true;
+    } else if (e.entry.flags == 0 &&
+               (import_name == nullptr || import_name[0] == '\0')) {
+      // add externally visible symbols, in case the nlist record has
+      // been stripped/omitted.
+      add_this_entry = true;
+    }
+    if (add_this_entry) {
+      if (prefix.size() > 1) {
+        // Skip the leading '_'
+        e.entry.name.SetString(llvm::StringRef(prefix).drop_front());
+      }
+      if (import_name) {
+        // Skip the leading '_'
+        e.entry.import_name.SetCString(import_name + 1);
+      }
+      if (Flags(e.entry.flags).Test(EXPORT_SYMBOL_FLAGS_REEXPORT)) {
+        reexports.push_back(e);
+      } else {
+        if (is_arm && (e.entry.address & 1)) {
+          e.entry.flags |= TRIE_SYMBOL_IS_THUMB;
+          e.entry.address &= THUMB_ADDRESS_BIT_MASK;
+        }
+        ext_symbols.push_back(e);
+      }
+    }
+  }
+
+  const uint8_t childrenCount = data.GetU8(&children_offset);
+  for (uint8_t i = 0; i < childrenCount; ++i) {
+    const char *cstr = data.GetCStr(&children_offset);
+    if (!cstr)
+      return false; // Corrupt data
+    const size_t prevSize = prefix.size();
+    prefix.append(cstr);
+    lldb::offset_t childNodeOffset = data.GetULEB128(&children_offset);
+    if (childNodeOffset) {
+      if (!ParseTrieEntries(data, childNodeOffset, is_arm, text_seg_base_addr,
+                            prefix, resolver_addresses, reexports,
+                            ext_symbols)) {
+        return false;
+      }
+    }
+    prefix.resize(prevSize);
+  }
+  return true;
+}

--- a/lldb/source/Plugins/ObjectFile/Mach-O/MachOTrie.h
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/MachOTrie.h
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SOURCE_PLUGINS_OBJECTFILE_MACH_O_MACHOTRIE_H
+#define LLDB_SOURCE_PLUGINS_OBJECTFILE_MACH_O_MACHOTRIE_H
+
+#include "lldb/Utility/ConstString.h"
+#include "lldb/lldb-defines.h"
+#include "lldb/lldb-types.h"
+
+#include <cstdint>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace lldb_private {
+
+class DataExtractor;
+
+/// Set on TrieEntry::flags for an ARM symbol whose address has the low Thumb
+/// bit set; the bit is stripped from the address and recorded here instead.
+inline constexpr uint64_t TRIE_SYMBOL_IS_THUMB = 1ULL << 63;
+
+/// Mask that clears the low Thumb bit from an ARM function address.
+inline constexpr uint64_t THUMB_ADDRESS_BIT_MASK = 0xfffffffffffffffeull;
+
+/// A single symbol recovered from the Mach-O export trie.
+struct TrieEntry {
+  void Dump() const;
+
+  ConstString name;
+  uint64_t address = LLDB_INVALID_ADDRESS;
+  uint64_t flags =
+      0; // EXPORT_SYMBOL_FLAGS_REEXPORT, EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER,
+         // TRIE_SYMBOL_IS_THUMB
+  uint64_t other = 0;
+  ConstString import_name;
+};
+
+/// A TrieEntry paired with the offset of the trie node it was parsed from.
+struct TrieEntryWithOffset {
+  lldb::offset_t nodeOffset;
+  TrieEntry entry;
+
+  TrieEntryWithOffset(lldb::offset_t offset) : nodeOffset(offset), entry() {}
+
+  void Dump(uint32_t idx) const;
+
+  bool operator<(const TrieEntryWithOffset &other) const {
+    return (nodeOffset < other.nodeOffset);
+  }
+};
+
+/// Parse the Mach-O export trie (the dyld symbol trie from LC_DYLD_INFO or
+/// LC_DYLD_EXPORTS_TRIE) starting at \a offset in \a data, collecting exported
+/// and re-exported symbols and any stub resolver addresses.
+///
+/// \param[in] data The buffer holding the raw export trie.
+/// \param[in] offset The node offset to start parsing from (0 for the root).
+/// \param[in] is_arm Whether the image is ARM, which governs Thumb-bit
+/// handling.
+/// \param[in] text_seg_base_addr The __TEXT segment file address added to each
+///     symbol address, or LLDB_INVALID_ADDRESS to leave addresses unbiased.
+/// \param[in,out] prefix The accumulated symbol-name prefix; pass an empty
+///     string for the root call.
+/// \param[out] resolver_addresses Stub-and-resolver addresses encountered.
+/// \param[out] reexports Re-export entries with a valid import name.
+/// \param[out] ext_symbols Externally visible (non-re-export) entries.
+///
+/// \return false if the trie is detectably corrupt, true otherwise.
+bool ParseTrieEntries(DataExtractor &data, lldb::offset_t offset,
+                      const bool is_arm, lldb::addr_t text_seg_base_addr,
+                      std::string &prefix,
+                      std::set<lldb::addr_t> &resolver_addresses,
+                      std::vector<TrieEntryWithOffset> &reexports,
+                      std::vector<TrieEntryWithOffset> &ext_symbols);
+
+} // namespace lldb_private
+
+#endif // LLDB_SOURCE_PLUGINS_OBJECTFILE_MACH_O_MACHOTRIE_H

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -49,6 +49,7 @@
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/MemoryBuffer.h"
 
+#include "MachOTrie.h"
 #include "ObjectFileMachO.h"
 
 #if defined(__APPLE__)
@@ -129,7 +130,6 @@
 #undef PLATFORM_WATCHOSSIMULATOR
 #endif
 
-#define THUMB_ADDRESS_BIT_MASK 0xfffffffffffffffeull
 using namespace lldb;
 using namespace lldb_private;
 using namespace llvm::MachO;
@@ -1956,132 +1956,6 @@ protected:
   SectionList *m_section_list;
   std::vector<SectionInfo> m_section_infos;
 };
-
-#define TRIE_SYMBOL_IS_THUMB (1ULL << 63)
-struct TrieEntry {
-  void Dump() const {
-    printf("0x%16.16llx 0x%16.16llx 0x%16.16llx \"%s\"",
-           static_cast<unsigned long long>(address),
-           static_cast<unsigned long long>(flags),
-           static_cast<unsigned long long>(other), name.GetCString());
-    if (import_name)
-      printf(" -> \"%s\"\n", import_name.GetCString());
-    else
-      printf("\n");
-  }
-  ConstString name;
-  uint64_t address = LLDB_INVALID_ADDRESS;
-  uint64_t flags =
-      0; // EXPORT_SYMBOL_FLAGS_REEXPORT, EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER,
-         // TRIE_SYMBOL_IS_THUMB
-  uint64_t other = 0;
-  ConstString import_name;
-};
-
-struct TrieEntryWithOffset {
-  lldb::offset_t nodeOffset;
-  TrieEntry entry;
-
-  TrieEntryWithOffset(lldb::offset_t offset) : nodeOffset(offset), entry() {}
-
-  void Dump(uint32_t idx) const {
-    printf("[%3u] 0x%16.16llx: ", idx,
-           static_cast<unsigned long long>(nodeOffset));
-    entry.Dump();
-  }
-
-  bool operator<(const TrieEntryWithOffset &other) const {
-    return (nodeOffset < other.nodeOffset);
-  }
-};
-
-static bool ParseTrieEntries(DataExtractor &data, lldb::offset_t offset,
-                             const bool is_arm, addr_t text_seg_base_addr,
-                             std::string &prefix,
-                             std::set<lldb::addr_t> &resolver_addresses,
-                             std::vector<TrieEntryWithOffset> &reexports,
-                             std::vector<TrieEntryWithOffset> &ext_symbols) {
-  if (!data.ValidOffset(offset))
-    return true;
-
-  // Terminal node -- end of a branch, possibly add this to
-  // the symbol table or resolver table.
-  const uint64_t terminalSize = data.GetULEB128(&offset);
-  lldb::offset_t children_offset = offset + terminalSize;
-  if (terminalSize != 0) {
-    TrieEntryWithOffset e(offset);
-    e.entry.flags = data.GetULEB128(&offset);
-    const char *import_name = nullptr;
-    if (e.entry.flags & EXPORT_SYMBOL_FLAGS_REEXPORT) {
-      e.entry.address = 0;
-      e.entry.other = data.GetULEB128(&offset); // dylib ordinal
-      import_name = data.GetCStr(&offset);
-    } else {
-      e.entry.address = data.GetULEB128(&offset);
-      if (text_seg_base_addr != LLDB_INVALID_ADDRESS)
-        e.entry.address += text_seg_base_addr;
-      if (e.entry.flags & EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER) {
-        e.entry.other = data.GetULEB128(&offset);
-        uint64_t resolver_addr = e.entry.other;
-        if (text_seg_base_addr != LLDB_INVALID_ADDRESS)
-          resolver_addr += text_seg_base_addr;
-        if (is_arm)
-          resolver_addr &= THUMB_ADDRESS_BIT_MASK;
-        resolver_addresses.insert(resolver_addr);
-      } else
-        e.entry.other = 0;
-    }
-    bool add_this_entry = false;
-    if (Flags(e.entry.flags).Test(EXPORT_SYMBOL_FLAGS_REEXPORT) &&
-        import_name && import_name[0]) {
-      // add symbols that are reexport symbols with a valid import name.
-      add_this_entry = true;
-    } else if (e.entry.flags == 0 &&
-               (import_name == nullptr || import_name[0] == '\0')) {
-      // add externally visible symbols, in case the nlist record has
-      // been stripped/omitted.
-      add_this_entry = true;
-    }
-    if (add_this_entry) {
-      if (prefix.size() > 1) {
-        // Skip the leading '_'
-        e.entry.name.SetString(llvm::StringRef(prefix).drop_front());
-      }
-      if (import_name) {
-        // Skip the leading '_'
-        e.entry.import_name.SetCString(import_name + 1);
-      }
-      if (Flags(e.entry.flags).Test(EXPORT_SYMBOL_FLAGS_REEXPORT)) {
-        reexports.push_back(e);
-      } else {
-        if (is_arm && (e.entry.address & 1)) {
-          e.entry.flags |= TRIE_SYMBOL_IS_THUMB;
-          e.entry.address &= THUMB_ADDRESS_BIT_MASK;
-        }
-        ext_symbols.push_back(e);
-      }
-    }
-  }
-
-  const uint8_t childrenCount = data.GetU8(&children_offset);
-  for (uint8_t i = 0; i < childrenCount; ++i) {
-    const char *cstr = data.GetCStr(&children_offset);
-    if (!cstr)
-      return false; // Corrupt data
-    const size_t prevSize = prefix.size();
-    prefix.append(cstr);
-    lldb::offset_t childNodeOffset = data.GetULEB128(&children_offset);
-    if (childNodeOffset) {
-      if (!ParseTrieEntries(data, childNodeOffset, is_arm, text_seg_base_addr,
-                            prefix, resolver_addresses, reexports,
-                            ext_symbols)) {
-        return false;
-      }
-    }
-    prefix.resize(prevSize);
-  }
-  return true;
-}
 
 static bool
 TryParseV2ObjCMetadataSymbol(const char *&symbol_name,


### PR DESCRIPTION
ParseTrieEntries and its TrieEntry helpers were file-local statics in ObjectFileMachO.cpp, unreachable from tests. Move them into a self-contained translation unit (depending only on lldbUtility) so the parser can be exercised in isolation.