### PR TITLE
[MLIR][EmitC] Add optional pure attribute to CastOp

### DIFF
--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -394,8 +394,11 @@ def EmitC_MemberCallOpaqueOp : EmitC_Op<"member_call_opaque", [CExpressionInterf
 }
 
 def EmitC_CastOp : EmitC_Op<"cast",
-    [Pure, CExpressionInterface,
-     DeclareOpInterfaceMethods<CastOpInterface>]> {
+    [CExpressionInterface,
+     DeclareOpInterfaceMethods<CastOpInterface>,
+     DeclareOpInterfaceMethods<ConditionallySpeculatable>,
+     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+    ]> {
   let summary = "Cast operation";
   let description = [{
     The `emitc.cast` operation performs an explicit type conversion and is emitted
@@ -414,7 +417,10 @@ def EmitC_CastOp : EmitC_Op<"cast",
     ```
   }];
 
-  let arguments = (ins EmitCType:$source);
+  let arguments = (ins EmitCType:$source,
+    UnitAttr:$pure
+  );
+
   let results = (outs EmitCType:$dest);
   let assemblyFormat = "$source attr-dict `:` type($source) `to` type($dest)";
 
@@ -422,6 +428,8 @@ def EmitC_CastOp : EmitC_Op<"cast",
     bool hasSideEffects() {
       return false;
     }
+
+    bool isPure();
   }];
 }
 

--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -394,7 +394,7 @@ def EmitC_MemberCallOpaqueOp : EmitC_Op<"member_call_opaque", [CExpressionInterf
 }
 
 def EmitC_CastOp : EmitC_Op<"cast",
-    [CExpressionInterface,
+    [Pure, CExpressionInterface,
      DeclareOpInterfaceMethods<CastOpInterface>]> {
   let summary = "Cast operation";
   let description = [{

--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -434,10 +434,10 @@ def EmitC_CastOp : EmitC_Op<"cast",
 
   let extraClassDeclaration = [{
     bool hasSideEffects() {
-      return false;
+      // Use the "pure" attribute to see whether this CastOp has side effects.
+      // Note that by default, `pure` is not set.
+      return getPure();
     }
-
-    bool isPure();
   }];
 }
 

--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -418,6 +418,14 @@ def EmitC_CastOp : EmitC_Op<"cast",
   }];
 
   let arguments = (ins EmitCType:$source,
+    // In general, C++ cast expressions cannot always be assumed to be pure: they
+    // may invoke user-defined conversions or be affected by floating-point
+    // environment settings. However, in many practical cases, such as integer casts
+    // without operator overloading, the cast is pure and can be treated as
+    // speculatable and side-effect free.
+    //
+    // When this attribute is set, `getSpeculatability()` returns `Speculatable`
+    // and `getEffects()` reports no effects.
     UnitAttr:$pure
   );
 

--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -415,17 +415,21 @@ def EmitC_CastOp : EmitC_Op<"cast",
     %1 = emitc.cast %arg1 :
         !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<i32>
     ```
+
+    In general, C++ cast expressions cannot always be assumed to be pure:
+    they may invoke user-defined conversions or be affected by floating-point
+    environment settings. However, in many practical cases, such as integer
+    casts without operator overloading, the cast is pure and can be treated as
+    speculatable and side-effect-free. For such cases, the `pure` attribute
+    may be used.
+
+    When `pure` attribute is set, `getSpeculatability()` returns `Speculatable`
+    and `getEffects()` reports no effects. It is UB if the `pure` attribute is
+    set and the actual conversion is not pure, e.g. when the user-defined
+    conversion has memory effects.
   }];
 
   let arguments = (ins EmitCType:$source,
-    // In general, C++ cast expressions cannot always be assumed to be pure: they
-    // may invoke user-defined conversions or be affected by floating-point
-    // environment settings. However, in many practical cases, such as integer casts
-    // without operator overloading, the cast is pure and can be treated as
-    // speculatable and side-effect free.
-    //
-    // When this attribute is set, `getSpeculatability()` returns `Speculatable`
-    // and `getEffects()` reports no effects.
     UnitAttr:$pure
   );
 

--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -336,6 +336,21 @@ bool CastOp::areCastCompatible(TypeRange inputs, TypeRange outputs) {
        emitc::isSupportedFloatType(output) || isa<emitc::PointerType>(output)));
 }
 
+bool CastOp::isPure() { return static_cast<bool>(getPureAttr()); }
+
+Speculation::Speculatability emitc::CastOp::getSpeculatability() {
+  return getPure() ? Speculation::Speculatable : Speculation::NotSpeculatable;
+}
+
+void emitc::CastOp::getEffects(
+    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  if (getPure())
+    return;
+
+  effects.emplace_back(MemoryEffects::Read::get());
+  effects.emplace_back(MemoryEffects::Write::get());
+}
+
 //===----------------------------------------------------------------------===//
 // CallOpaqueOp
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -336,8 +336,6 @@ bool CastOp::areCastCompatible(TypeRange inputs, TypeRange outputs) {
        emitc::isSupportedFloatType(output) || isa<emitc::PointerType>(output)));
 }
 
-bool CastOp::isPure() { return static_cast<bool>(getPureAttr()); }
-
 Speculation::Speculatability emitc::CastOp::getSpeculatability() {
   return getPure() ? Speculation::Speculatable : Speculation::NotSpeculatable;
 }

--- a/mlir/test/Dialect/EmitC/canonicalize.mlir
+++ b/mlir/test/Dialect/EmitC/canonicalize.mlir
@@ -1,9 +1,13 @@
 // RUN: mlir-opt %s -canonicalize="test-convergence" -split-input-file | FileCheck %s
 
-// While there is no dedicated folder for CastOp, it is Pure and hence should
-// be "folded away".
-func.func @cast(%arg0: i32) {
-  // CHECK-NOT: emitc.cast
+func.func @no_fold_cast_to_f32(%arg0: i32) {
+  // CHECK: emitc.cast
   %1 = emitc.cast %arg0: i32 to f32
+  return
+}
+
+func.func @fold_cast_to_i64(%arg0: i32) {
+  // CHECK-NOT: emitc.cast
+  %1 = emitc.cast %arg0 {pure} : i32 to i64
   return
 }

--- a/mlir/test/Dialect/EmitC/canonicalize.mlir
+++ b/mlir/test/Dialect/EmitC/canonicalize.mlir
@@ -1,0 +1,9 @@
+// RUN: mlir-opt %s -canonicalize="test-convergence" -split-input-file | FileCheck %s
+
+// While there is no dedicated folder for CastOp, it is Pure and hence should
+// be "folded away".
+func.func @cast(%arg0: i32) {
+  // CHECK-NOT: emitc.cast
+  %1 = emitc.cast %arg0: i32 to f32
+  return
+}


### PR DESCRIPTION
In general, C++ cast expressions cannot always be assumed to be pure: they may
invoke user-defined conversions or be affected by floating-point environment
settings. However, in many practical cases, such as integer casts without
operator overloading, the cast is pure and can be treated as speculatable and
side-effect-free. For such cases, the newly added `pure` attribute may be used.

When `pure` attribute is set, `getSpeculatability()` returns `Speculatable` and
`getEffects()` reports no effects. It is UB if the `pure` attribute is set and
the actual conversion is not pure, e.g. when the user-defined conversion has
memory effects.