### PR TITLE
[CIR] Implement bind temporary lvalue

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -2135,6 +2135,16 @@ LValue CIRGenFunction::emitCallExprLValue(const CallExpr *e) {
   return makeNaturalAlignPointeeAddrLValue(rv.getValue(), e->getType());
 }
 
+LValue
+CIRGenFunction::emitCXXBindTemporaryLValue(const CXXBindTemporaryExpr *e) {
+  AggValueSlot slot =
+      createAggTemp(e->getType(), getLoc(e->getSourceRange()), "temp.lvalue");
+  slot.setExternallyDestructed();
+  emitAggExpr(e->getSubExpr(), slot);
+  emitCXXTemporary(e->getTemporary(), e->getType(), slot.getAddress());
+  return makeAddrLValue(slot.getAddress(), e->getType(), AlignmentSource::Decl);
+}
+
 LValue CIRGenFunction::emitBinaryOperatorLValue(const BinaryOperator *e) {
   // Comma expressions just emit their LHS then their RHS as an l-value.
   if (e->getOpcode() == BO_Comma) {

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -1224,9 +1224,7 @@ LValue CIRGenFunction::emitLValue(const Expr *e) {
                                "emitLValue: CXXConstructExpr");
     return LValue();
   case Expr::CXXBindTemporaryExprClass:
-    getCIRGenModule().errorNYI(e->getSourceRange(),
-                               "emitLValue: CXXBindTemporaryExpr");
-    return LValue();
+    return emitCXXBindTemporaryLValue(cast<CXXBindTemporaryExpr>(e));
   case Expr::CXXUuidofExprClass:
     getCIRGenModule().errorNYI(e->getSourceRange(),
                                "emitLValue: CXXUuidofExpr");

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1753,6 +1753,8 @@ public:
   RValue emitCallExpr(const clang::CallExpr *e,
                       ReturnValueSlot returnValue = ReturnValueSlot());
   LValue emitCallExprLValue(const clang::CallExpr *e);
+
+  LValue emitCXXBindTemporaryLValue(const CXXBindTemporaryExpr *e);
   CIRGenCallee emitCallee(const clang::Expr *e);
 
   template <typename T>

--- a/clang/test/CIR/CodeGen/bind-temporary-lvalue.cpp
+++ b/clang/test/CIR/CodeGen/bind-temporary-lvalue.cpp
@@ -1,0 +1,42 @@
+// RUN: %clang_cc1 -std=c++03 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+// RUN: %clang_cc1 -std=c++03 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s --check-prefixes=LLVM,LLVMCIR
+// RUN: %clang_cc1 -std=c++03 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s --check-prefixes=LLVM,OGCG
+
+struct S {
+  ~S();
+  int x;
+};
+
+S getS();
+
+int f() { return getS().x; }
+
+// CIR: cir.func {{.*}}@_Z1fv()
+// CIR:   %[[RET:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
+// CIR:   %[[TMP:.*]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["temp.lvalue"]
+// CIR:   %[[CALL:.*]] = cir.call @_Z4getSv() : () -> !rec_S
+// CIR:   cir.store{{.*}} %[[CALL]], %[[TMP]]
+// CIR:   cir.cleanup.scope {
+// CIR:     %[[X:.*]] = cir.get_member %[[TMP]][0] {name = "x"} : !cir.ptr<!rec_S> -> !cir.ptr<!s32i>
+// CIR:     %[[VAL:.*]] = cir.load{{.*}} %[[X]] : !cir.ptr<!s32i>, !s32i
+// CIR:     cir.store{{.*}} %[[VAL]], %[[RET]]
+// CIR:   } cleanup normal {
+// CIR:     cir.call @_ZN1SD1Ev(%[[TMP]])
+// CIR:   }
+// CIR:   %[[RES:.*]] = cir.load %[[RET]] : !cir.ptr<!s32i>, !s32i
+// CIR:   cir.return %[[RES]]
+
+// FIXME(cir): The difference below is due to ABI lowering not being implemented for CIR.
+
+// LLVM:      define {{.*}}@_Z1fv()
+// LLVM:        %[[TMP:.*]] = alloca %struct.S
+// LLVMCIR:     %[[CALL:.*]] = call %struct.S @_Z4getSv()
+// LLVMCIR:     store %struct.S %[[CALL]], ptr %[[TMP]]
+// OGCG:        call void @_Z4getSv(ptr {{.*}} sret(%struct.S) {{.*}} %[[TMP]])
+// LLVM:        %[[X:.*]] = getelementptr inbounds {{.*}} %struct.S, ptr %[[TMP]], i32 0, i32 0
+// LLVM:        %[[VAL:.*]] = load i32, ptr %[[X]]
+// LLVM:        call void @_ZN1SD1Ev(ptr {{.*}} %[[TMP]])
+// LLVM:        ret i32


### PR DESCRIPTION
This change implements the handling to emit a CXXBindTemporaryExpr l-value. This is a very direct port from the classic codegen implementation, leveraging existing functions in CIR.