### PR TITLE
Revert "[test][Support] Disable CFI-icall for DynamicLibrary Overload test (#202446)"

### DIFF
--- a/llvm/unittests/Support/DynamicLibrary/DynamicLibraryTest.cpp
+++ b/llvm/unittests/Support/DynamicLibrary/DynamicLibraryTest.cpp
@@ -59,7 +59,7 @@ static const char *OverloadTestA() { return "OverloadCall"; }
 
 std::string StdString(const char *Ptr) { return Ptr ? Ptr : ""; }
 
-TEST(DynamicLibrary, Overload) LLVM_NO_SANITIZE("cfi-icall") {
+TEST(DynamicLibrary, Overload) {
   {
     std::string Err;
     DynamicLibrary DL =


### PR DESCRIPTION
Reverts llvm/llvm-project#202684

This breaks builds with some gcc versions (at least v14).

```
/home/aidengrossman/llvm-project/llvm/unittests/Support/DynamicLibrary/DynamicLibraryTest.cpp:62:32: error: attributes are not allowed on a function-definition
   62 | TEST(DynamicLibrary, Overload) __attribute__((no_sanitize("cfi-icall"))) {
      |                                ^~~~~~~~~~~~~
```