### PR TITLE
[lldb] Fix infinite recursion in Mach-O export trie parsing

### DIFF
--- a/lldb/source/Plugins/ObjectFile/Mach-O/MachOTrie.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/MachOTrie.cpp
@@ -37,14 +37,22 @@ void TrieEntryWithOffset::Dump(uint32_t idx) const {
   entry.Dump();
 }
 
-bool lldb_private::ParseTrieEntries(
-    DataExtractor &data, lldb::offset_t offset, const bool is_arm,
-    lldb::addr_t text_seg_base_addr, std::string &prefix,
-    std::set<lldb::addr_t> &resolver_addresses,
-    std::vector<TrieEntryWithOffset> &reexports,
-    std::vector<TrieEntryWithOffset> &ext_symbols) {
+namespace {
+
+bool ParseTrieEntriesImpl(DataExtractor &data, lldb::offset_t offset,
+                          const bool is_arm, addr_t text_seg_base_addr,
+                          std::string &prefix,
+                          std::set<lldb::addr_t> &resolver_addresses,
+                          std::vector<TrieEntryWithOffset> &reexports,
+                          std::vector<TrieEntryWithOffset> &ext_symbols,
+                          std::set<lldb::offset_t> &visited_nodes) {
   if (!data.ValidOffset(offset))
     return true;
+
+  // Every node in a well-formed trie is reached by exactly one path, so a node
+  // offset seen twice means the trie is corrupt.
+  if (!visited_nodes.insert(offset).second)
+    return false;
 
   // Terminal node -- end of a branch, possibly add this to
   // the symbol table or resolver table.
@@ -114,13 +122,27 @@ bool lldb_private::ParseTrieEntries(
     prefix.append(cstr);
     lldb::offset_t childNodeOffset = data.GetULEB128(&children_offset);
     if (childNodeOffset) {
-      if (!ParseTrieEntries(data, childNodeOffset, is_arm, text_seg_base_addr,
-                            prefix, resolver_addresses, reexports,
-                            ext_symbols)) {
+      if (!ParseTrieEntriesImpl(data, childNodeOffset, is_arm,
+                                text_seg_base_addr, prefix, resolver_addresses,
+                                reexports, ext_symbols, visited_nodes)) {
         return false;
       }
     }
     prefix.resize(prevSize);
   }
   return true;
+}
+
+} // namespace
+
+bool lldb_private::ParseTrieEntries(
+    DataExtractor &data, lldb::offset_t offset, const bool is_arm,
+    lldb::addr_t text_seg_base_addr, std::string &prefix,
+    std::set<lldb::addr_t> &resolver_addresses,
+    std::vector<TrieEntryWithOffset> &reexports,
+    std::vector<TrieEntryWithOffset> &ext_symbols) {
+  std::set<lldb::offset_t> visited_nodes;
+  return ParseTrieEntriesImpl(data, offset, is_arm, text_seg_base_addr, prefix,
+                              resolver_addresses, reexports, ext_symbols,
+                              visited_nodes);
 }

--- a/lldb/unittests/ObjectFile/MachO/MachOTrieTest.cpp
+++ b/lldb/unittests/ObjectFile/MachO/MachOTrieTest.cpp
@@ -297,3 +297,42 @@ TEST(MachOTrieTest, TerminalNodeWithChildren) {
     names.insert(e.entry.name.GetStringRef().str());
   EXPECT_EQ(names, (std::set<std::string>{"foo", "foobar"}));
 }
+
+TEST(MachOTrieTest, MalformedSelfCycle) {
+  // Root --"a"--> node1 (@9) --"b"--> node1 (points to itself).
+  std::vector<uint8_t> t;
+  AppendULEB128(t, 0); // root terminalSize
+  t.push_back(1);      // root childrenCount
+  AppendCStr(t, "a");
+  AppendOffset(t, 9); // root SelfSize == 1 + 1 + 2 + 5 == 9
+  ASSERT_EQ(t.size(), 9u);
+  AppendULEB128(t, 0); // node1 terminalSize
+  t.push_back(1);      // node1 childrenCount
+  AppendCStr(t, "b");
+  AppendOffset(t, 9); // points back at node1 -> cycle
+
+  ParseResult result = Parse(t);
+  EXPECT_FALSE(result.ok);
+}
+
+TEST(MachOTrieTest, MalformedBackEdgeCycle) {
+  // Root(@0) --"a"--> n1(@9) --"b"--> n2(@18) --"c"--> n1 (ancestor).
+  std::vector<uint8_t> t;
+  AppendULEB128(t, 0);
+  t.push_back(1);
+  AppendCStr(t, "a");
+  AppendOffset(t, 9);
+  ASSERT_EQ(t.size(), 9u);
+  AppendULEB128(t, 0);
+  t.push_back(1);
+  AppendCStr(t, "b");
+  AppendOffset(t, 18);
+  ASSERT_EQ(t.size(), 18u);
+  AppendULEB128(t, 0);
+  t.push_back(1);
+  AppendCStr(t, "c");
+  AppendOffset(t, 9); // back edge to n1
+
+  ParseResult result = Parse(t);
+  EXPECT_FALSE(result.ok);
+}


### PR DESCRIPTION
A malformed (or hostile) export trie whose child offset points back to a node already on the path from the root (a cycle) made ParseTrieEntries recurse forever and overflow the stack.

Track the node offsets visited during the walk and reject any trie that revisits one. Add unit tests for a self-cycle and a back-edge cycle.