### PR TITLE
[clang] Add concepts to XML comment schema, add tests

### DIFF
--- a/clang/bindings/xml/comment-xml-schema.rng
+++ b/clang/bindings/xml/comment-xml-schema.rng
@@ -14,6 +14,7 @@
       <ref name="Namespace" />
       <ref name="Typedef" />
       <ref name="Enum" />
+      <ref name="Concept" />
     </choice>
   </start>
 
@@ -287,6 +288,41 @@
       <optional>
         <ref name="TemplateParameters" />
       </optional>
+      <optional>
+        <ref name="Parameters" />
+      </optional>
+      <optional>
+        <ref name="ResultDiscussion" />
+      </optional>
+
+      <optional>
+        <ref name="Discussion" />
+      </optional>
+    </element>
+  </define>
+
+  <define name="Concept">
+    <element name="Concept">
+      <ref name="attrSourceLocation" />
+      <ref name="Name" />
+      <optional>
+        <ref name="USR" />
+      </optional>
+      <optional>
+        <ref name="Headerfile" />
+      </optional>
+      <optional>
+        <ref name="Declaration" />
+      </optional>
+      <optional>
+        <ref name="Abstract" />
+      </optional>
+      <optional>
+        <ref name="TemplateParameters" />
+      </optional>
+
+      <!-- Parameters and results don't make sense for concepts, but the user
+           can specify \param or \returns in a comment anyway. -->
       <optional>
         <ref name="Parameters" />
       </optional>

--- a/clang/test/Index/Inputs/CommentXML/invalid-concept-01.xml
+++ b/clang/test/Index/Inputs/CommentXML/invalid-concept-01.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Concept>
+<Abstract><Para>Aaa.</Para></Abstract>
+</Concept>

--- a/clang/test/Index/Inputs/CommentXML/valid-concept-01.xml
+++ b/clang/test/Index/Inputs/CommentXML/valid-concept-01.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Concept>
+<Name>aaa</Name>
+<Abstract><Para>Aaa.</Para></Abstract>
+</Concept>

--- a/clang/test/Index/Inputs/CommentXML/valid-concept-02.xml
+++ b/clang/test/Index/Inputs/CommentXML/valid-concept-02.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Concept>
+<Name>aaa</Name>
+<Abstract><Para>Aaa.</Para></Abstract>
+<TemplateParameters>
+  <Parameter>
+    <Name>T</Name>
+    <Index>0</Index>
+    <Discussion><Para>template parameter T</Para></Discussion>
+  </Parameter>
+</TemplateParameters>
+</Concept>

--- a/clang/test/Index/comment-xml-schema.c
+++ b/clang/test/Index/comment-xml-schema.c
@@ -35,6 +35,9 @@
 // RUN: xmllint --noout --relaxng %S/../../bindings/xml/comment-xml-schema.rng %S/Inputs/CommentXML/valid-para-kind-01.xml
 //
 // RUN: xmllint --noout --relaxng %S/../../bindings/xml/comment-xml-schema.rng %S/Inputs/CommentXML/valid-inline-command-01.xml
+//
+// RUN: xmllint --noout --relaxng %S/../../bindings/xml/comment-xml-schema.rng %S/Inputs/CommentXML/valid-concept-01.xml
+// RUN: xmllint --noout --relaxng %S/../../bindings/xml/comment-xml-schema.rng %S/Inputs/CommentXML/valid-concept-02.xml
 
 // RUN: not xmllint --noout --relaxng %S/../../bindings/xml/comment-xml-schema.rng %S/Inputs/CommentXML/invalid-function-01.xml 2>&1 | FileCheck %s -check-prefix=CHECK-INVALID
 // RUN: not xmllint --noout --relaxng %S/../../bindings/xml/comment-xml-schema.rng %S/Inputs/CommentXML/invalid-function-02.xml 2>&1 | FileCheck %s -check-prefix=CHECK-INVALID
@@ -52,6 +55,9 @@
 //
 // RUN: not xmllint --noout --relaxng %S/../../bindings/xml/comment-xml-schema.rng %S/Inputs/CommentXML/invalid-para-kind-01.xml 2>&1 | FileCheck %s -check-prefix=CHECK-INVALID
 // RUN: not xmllint --noout --relaxng %S/../../bindings/xml/comment-xml-schema.rng %S/Inputs/CommentXML/invalid-para-kind-02.xml 2>&1 | FileCheck %s -check-prefix=CHECK-INVALID
+//
+// RUN: not xmllint --noout --relaxng %S/../../bindings/xml/comment-xml-schema.rng %S/Inputs/CommentXML/invalid-concept-01.xml 2>&1 | FileCheck %s -check-prefix=CHECK-INVALID
+//
 
 // CHECK-INVALID: fails to validate
 


### PR DESCRIPTION
After concepts were added as a valid type for `DeclInfo::DeclKind`, XML
tags were added for them in CommentToXML.cpp but they weren't added to
the schema. This caused validation issues when running XML validation on
the comment tests.

Fixes #202610