### PR TITLE
[win][x64] Windows x64 unwind v3: Update epilog inheritance per spec clarification

### DIFF
--- a/llvm/lib/MC/MCWin64EH.cpp
+++ b/llvm/lib/MC/MCWin64EH.cpp
@@ -714,6 +714,7 @@ static void EmitUnwindInfoV3(MCStreamer &Streamer, WinEH::FrameInfo *Info) {
 
   // --- Emit epilog descriptors ---
   const MCSymbol *PrevEpilogStart = nullptr;
+  uint8_t BaseEpiFlags = 0;
   for (const auto &EI : EpilogInfos) {
     const auto &Epilog = *EI.Epilog;
 
@@ -728,6 +729,12 @@ static void EmitUnwindInfoV3(MCStreamer &Streamer, WinEH::FrameInfo *Info) {
     uint8_t EpiFlags = 0;
     if (EI.NeedsLarge)
       EpiFlags |= Win64EH::EPILOG_INFO_LARGE;
+    // An inherited descriptor must replicate the base descriptor's flags bits
+    // 0 and 1; verify we are about to emit a byte consistent with the base.
+    assert((!EI.Inherited || (EpiFlags & 0x03) == (BaseEpiFlags & 0x03)) &&
+           "inherited epilog must replicate base descriptor's flags bits 0-1");
+    if (!EI.Inherited)
+      BaseEpiFlags = EpiFlags;
     uint8_t EpiNumOps = EI.Inherited ? 0 : EI.NumberOfOps;
     Streamer.emitInt8((EpiNumOps << 3) | EpiFlags);
 

--- a/llvm/lib/MC/MCWin64EH.cpp
+++ b/llvm/lib/MC/MCWin64EH.cpp
@@ -584,16 +584,22 @@ static void EmitUnwindInfoV3(MCStreamer &Streamer, WinEH::FrameInfo *Info) {
   // array from the first preceding descriptor with NumberOfOps != 0 (the
   // "base"), not necessarily the immediately preceding descriptor. An epilog
   // can therefore use the inherited (3-byte) descriptor when FirstOp,
-  // NumberOfOps, NeedsLarge, and relative IP offsets all match that base.
+  // NumberOfOps, and relative IP offsets all match that base. NeedsLarge is a
+  // deterministic function of those fields (it is set when an IP offset exceeds
+  // the 1-byte range), so a matching FirstOp/NumberOfOps and IP offsets imply a
+  // matching NeedsLarge; we assert that invariant rather than test it.
   for (unsigned I = 1, Base = 0; I < EpilogInfos.size(); ++I) {
     auto &BaseEI = EpilogInfos[Base];
     auto &Curr = EpilogInfos[I];
     if (Curr.FirstOp == BaseEI.FirstOp &&
         Curr.NumberOfOps == BaseEI.NumberOfOps &&
-        Curr.NeedsLarge == BaseEI.NeedsLarge &&
-        EpilogIpOffsetsMatch(*Curr.Epilog, *BaseEI.Epilog, OS->getAssembler()))
+        EpilogIpOffsetsMatch(*Curr.Epilog, *BaseEI.Epilog,
+                             OS->getAssembler())) {
+      assert(Curr.NeedsLarge == BaseEI.NeedsLarge &&
+             "NeedsLarge must follow from matching FirstOp, NumberOfOps, and "
+             "IP offsets");
       Curr.Inherited = true;
-    else
+    } else
       Base = I; // Curr is a full descriptor; it becomes the new base.
   }
 

--- a/llvm/lib/MC/MCWin64EH.cpp
+++ b/llvm/lib/MC/MCWin64EH.cpp
@@ -579,16 +579,22 @@ static void EmitUnwindInfoV3(MCStreamer &Streamer, WinEH::FrameInfo *Info) {
                           Twine(EpilogInfos.size()));
 
   // --- Inheritance decisions ---
-  // An epilog can use the inherited (3-byte) descriptor when FirstOp,
-  // NumberOfOps, NeedsLarge, and relative IP offsets all match the previous
-  // epilog.
-  for (unsigned I = 1; I < EpilogInfos.size(); ++I) {
-    auto &Prev = EpilogInfos[I - 1];
+  // Per the V3 spec, an epilog descriptor with NumberOfOps == 0 inherits its
+  // effective NumberOfOps, FirstOp, IpOffsetOfLastInstruction, and IP offset
+  // array from the first preceding descriptor with NumberOfOps != 0 (the
+  // "base"), not necessarily the immediately preceding descriptor. An epilog
+  // can therefore use the inherited (3-byte) descriptor when FirstOp,
+  // NumberOfOps, NeedsLarge, and relative IP offsets all match that base.
+  for (unsigned I = 1, Base = 0; I < EpilogInfos.size(); ++I) {
+    auto &BaseEI = EpilogInfos[Base];
     auto &Curr = EpilogInfos[I];
-    if (Curr.FirstOp == Prev.FirstOp && Curr.NumberOfOps == Prev.NumberOfOps &&
-        Curr.NeedsLarge == Prev.NeedsLarge &&
-        EpilogIpOffsetsMatch(*Curr.Epilog, *Prev.Epilog, OS->getAssembler()))
+    if (Curr.FirstOp == BaseEI.FirstOp &&
+        Curr.NumberOfOps == BaseEI.NumberOfOps &&
+        Curr.NeedsLarge == BaseEI.NeedsLarge &&
+        EpilogIpOffsetsMatch(*Curr.Epilog, *BaseEI.Epilog, OS->getAssembler()))
       Curr.Inherited = true;
+    else
+      Base = I; // Curr is a full descriptor; it becomes the new base.
   }
 
   // --- Compute payload sizes ---
@@ -707,8 +713,14 @@ static void EmitUnwindInfoV3(MCStreamer &Streamer, WinEH::FrameInfo *Info) {
 
     // FlagsAndNumOps: bits [2:0] = flags, bits [7:3] = NumberOfOps.
     // For inherited descriptors, NumberOfOps = 0.
+    //
+    // Per the V3 spec, Flags bits 0 and 1 are NOT inherited by a descriptor
+    // with NumberOfOps == 0; the producer must replicate them so they have the
+    // same value as the base descriptor's. Since inheritance requires a
+    // matching NeedsLarge value, EI.NeedsLarge already equals the base's, so we
+    // emit EPILOG_INFO_LARGE for inherited descriptors too.
     uint8_t EpiFlags = 0;
-    if (EI.NeedsLarge && !EI.Inherited)
+    if (EI.NeedsLarge)
       EpiFlags |= Win64EH::EPILOG_INFO_LARGE;
     uint8_t EpiNumOps = EI.Inherited ? 0 : EI.NumberOfOps;
     Streamer.emitInt8((EpiNumOps << 3) | EpiFlags);

--- a/llvm/lib/Support/Win64EH.cpp
+++ b/llvm/lib/Support/Win64EH.cpp
@@ -250,6 +250,11 @@ Win64EH::decodeUnwindInfoV3(ArrayRef<uint8_t> Data) {
 
   // Read epilog descriptors
   int32_t PrevResolvedOffset = 0;
+  // Index of the most recent full descriptor (NumberOfOps != 0). Per the V3
+  // spec, a descriptor with NumberOfOps == 0 inherits its effective fields
+  // from the first *preceding* descriptor with NumberOfOps != 0, which is not
+  // necessarily the immediately preceding descriptor.
+  int BaseEpilogIdx = -1;
   for (unsigned I = 0; I < Info.NumberOfEpilogs; ++I) {
     DecodedEpilogV3 Epi;
     if (Offset >= PayloadEnd)
@@ -277,26 +282,24 @@ Win64EH::decodeUnwindInfoV3(ArrayRef<uint8_t> Data) {
 
     // Inherited descriptors (NumberOfOps == 0) are only 3 bytes:
     // FlagsAndNumOps(1) + EpilogOffset(2). They have no FirstOp,
-    // IpOffsetOfLastInstruction, or IP offset fields appended; instead,
-    // the previous epilog's Flags bits 0 and 1, FirstOp,
-    // IpOffsetOfLastInstruction, and IP offset array are inherited.
+    // IpOffsetOfLastInstruction, or IP offset fields appended; instead, the
+    // effective NumberOfOps, FirstOp, IpOffsetOfLastInstruction, and IP offset
+    // array are inherited from the first preceding descriptor with
+    // NumberOfOps != 0 (the "base"). Per the V3 spec, Flags bits 0 and 1 are
+    // NOT inherited: the producer is required to replicate them into this
+    // record, so we keep the value read from this descriptor's own flags byte.
     //
-    // If this is the first epilog there is no previous descriptor to
-    // inherit from — the record is malformed. We leave the extended fields
-    // zero-initialized so callers can still see the (broken) header and
-    // EpilogOffset; downstream consumers (e.g. the dumpers) surface a
-    // warning when they encounter NumberOfOps == 0 at index 0.
+    // If there is no preceding base descriptor to inherit from — the record is
+    // malformed. We leave the extended fields zero-initialized so callers can
+    // still see the (broken) header and EpilogOffset; downstream consumers
+    // (e.g. the dumpers) surface a warning when they encounter NumberOfOps == 0
+    // at index 0.
     if (Epi.NumberOfOps == 0) {
-      if (!Info.Epilogs.empty()) {
-        const DecodedEpilogV3 &Prev = Info.Epilogs.back();
-        // Flags bits 0 (EPILOG_INFO_PARENT_FRAGMENT_TRANSFER) and 1
-        // (EPILOG_INFO_LARGE) are inherited from the previous epilog; any
-        // bits present in this descriptor's own flags byte at those
-        // positions are ignored. Bit 2 (reserved) keeps its raw read value.
-        Epi.Flags = (Epi.Flags & uint8_t{0xFC}) | (Prev.Flags & uint8_t{0x03});
-        Epi.FirstOp = Prev.FirstOp;
-        Epi.IpOffsetOfLastInstruction = Prev.IpOffsetOfLastInstruction;
-        Epi.IpOffsets = Prev.IpOffsets;
+      if (BaseEpilogIdx >= 0) {
+        const DecodedEpilogV3 &Base = Info.Epilogs[BaseEpilogIdx];
+        Epi.FirstOp = Base.FirstOp;
+        Epi.IpOffsetOfLastInstruction = Base.IpOffsetOfLastInstruction;
+        Epi.IpOffsets = Base.IpOffsets;
       } else {
         Epi.FirstOp = 0;
         Epi.IpOffsetOfLastInstruction = 0;
@@ -345,6 +348,9 @@ Win64EH::decodeUnwindInfoV3(ArrayRef<uint8_t> Data) {
       }
     }
 
+    // This is a full descriptor (NumberOfOps != 0); it becomes the base that
+    // subsequent inherited descriptors reference.
+    BaseEpilogIdx = Info.Epilogs.size();
     Info.Epilogs.push_back(std::move(Epi));
   }
 

--- a/llvm/lib/Support/Win64EH.cpp
+++ b/llvm/lib/Support/Win64EH.cpp
@@ -297,6 +297,14 @@ Win64EH::decodeUnwindInfoV3(ArrayRef<uint8_t> Data) {
     if (Epi.NumberOfOps == 0) {
       if (BaseEpilogIdx >= 0) {
         const DecodedEpilogV3 &Base = Info.Epilogs[BaseEpilogIdx];
+        // Flags bits 0 and 1 are producer-replicated, not inherited: a
+        // compliant producer must have written the base's values into this
+        // descriptor's own flags byte, so they should already match the base.
+        // We intentionally keep this record's own bits (rather than copying
+        // the base's) so a non-compliant producer is not silently masked. This
+        // decoder runs on potentially-malformed object files, so a mismatch is
+        // not asserted here; downstream consumers (the dumpers) surface a
+        // warning when the replicated bits disagree with the base.
         Epi.FirstOp = Base.FirstOp;
         Epi.IpOffsetOfLastInstruction = Base.IpOffsetOfLastInstruction;
         Epi.IpOffsets = Base.IpOffsets;

--- a/llvm/test/MC/COFF/seh-unwindv3-inheritance.s
+++ b/llvm/test/MC/COFF/seh-unwindv3-inheritance.s
@@ -73,7 +73,7 @@ different_numops:
     .seh_endepilogue
     retq
 .L_DIFFOPS_ELSE:
-    // Epilog 1: partial ΓÇö only dealloc, no pop
+    // Epilog 1: partial -> only dealloc, no pop
     .seh_startepilogue
     .seh_stackalloc 32
     addq    $32, %rsp
@@ -87,7 +87,7 @@ different_numops:
 // CHECK:          NumberOfOps: 2
 // CHECK:          FirstOp: 0x0
 // CHECK:        }
-// Epilog 1: different NumberOfOps ΓÇö gets its own full descriptor, not inherited
+// Epilog 1: different NumberOfOps -> gets its own full descriptor, not inherited
 // CHECK:        Epilog [1] {
 // CHECK:          NumberOfOps: 1
 // CHECK:          FirstOp: 0x0
@@ -130,8 +130,67 @@ different_wods:
 // CHECK:          NumberOfOps: 1
 // CHECK:          PUSH Reg=RDI
 // CHECK:        }
-// Epilog 1: PUSH RBX ΓÇö different FirstOp, so NOT inherited
+// Epilog 1: PUSH RBX -> different FirstOp, so NOT inherited
 // CHECK:        Epilog [1] {
 // CHECK:          NumberOfOps: 1
 // CHECK:          PUSH Reg=RBX
+// CHECK:        }
+
+// --- Test 4: two identical LARGE mirror epilogs -> second inherits ---
+// Each epilog has 260 NOPs between its two unwind ops, pushing the IP
+// offsets past 255 so EPILOG_INFO_LARGE is required. The two epilogs are
+// byte-identical, so the second is encoded as an inherited (NumberOfOps == 0)
+// descriptor. Per the V3 spec, Flags bits 0 and 1 are not inherited and the
+// producer must replicate them, so the inherited descriptor must still carry
+// the Large flag.
+large_inherit:
+    .seh_proc large_inherit
+    .seh_unwindversion 3
+    .seh_pushreg %rbx
+    pushq   %rbx
+    .seh_stackalloc 32
+    subq    $32, %rsp
+    .seh_endprologue
+    callq   c
+    testl   %eax, %eax
+    jle     .L_LARGE_INHERIT_ELSE
+    // Epilog 0: large mirror
+    .seh_startepilogue
+    .seh_stackalloc 32
+    addq    $32, %rsp
+    .rept 260
+    nop
+    .endr
+    .seh_pushreg %rbx
+    popq    %rbx
+    .seh_endepilogue
+    retq
+.L_LARGE_INHERIT_ELSE:
+    // Epilog 1: identical large mirror
+    .seh_startepilogue
+    .seh_stackalloc 32
+    addq    $32, %rsp
+    .rept 260
+    nop
+    .endr
+    .seh_pushreg %rbx
+    popq    %rbx
+    .seh_endepilogue
+    retq
+    .seh_endproc
+// CHECK-LABEL:  StartAddress: large_inherit
+// CHECK:        NumberOfEpilogs: 2
+// CHECK:        Epilog [0] {
+// CHECK:          Flags [ (0x2)
+// CHECK-NEXT:       Large (0x2)
+// CHECK-NEXT:     ]
+// CHECK:          NumberOfOps: 2
+// CHECK:        }
+// Epilog 1 inherits, but must still carry the Large flag in its own byte.
+// CHECK:        Epilog [1] {
+// CHECK:          Flags [ (0x2)
+// CHECK-NEXT:       Large (0x2)
+// CHECK-NEXT:     ]
+// CHECK:          NumberOfOps: 0
+// CHECK:          (inherits
 // CHECK:       ]

--- a/llvm/test/tools/llvm-objdump/COFF/win64-unwindv3-multi-epilog.yaml
+++ b/llvm/test/tools/llvm-objdump/COFF/win64-unwindv3-multi-epilog.yaml
@@ -51,7 +51,7 @@
 # CHECK-NEXT:         [1] IP +0x0004: WOD_PUSH Reg=RSI
 # CHECK-NEXT:         [2] IP +0x0005: WOD_PUSH Reg=RDI
 # CHECK-NEXT:       Epilog [1] (Flags=0x00, Offset=+0x1E) [inherited]:
-# CHECK-NEXT:         (inherits from previous epilog: FirstOp=0x0, IpOfLast=+0x6, 3 ops)
+# CHECK-NEXT:         (inherits from base epilog: FirstOp=0x0, IpOfLast=+0x6, 3 ops)
 # CHECK-NEXT:       Epilog [2] (Flags=0x00, Offset=+0x23, IpOfLast=+0x3) [2 ops, FirstOp=0x1]:
 # CHECK-NEXT:         [0] IP +0x0000: WOD_PUSH Reg=RSI
 # CHECK-NEXT:         [1] IP +0x0001: WOD_PUSH Reg=RDI

--- a/llvm/test/tools/llvm-readobj/COFF/unwind-x86_64-v3-multi-epilog.yaml
+++ b/llvm/test/tools/llvm-readobj/COFF/unwind-x86_64-v3-multi-epilog.yaml
@@ -60,7 +60,7 @@
 # CHECK-NEXT:           ]
 # CHECK-NEXT:           EpilogOffset: +0x1E
 # CHECK-NEXT:           NumberOfOps: 0
-# CHECK-NEXT:           (inherits from previous epilog: FirstOp=0x0, IpOffsetOfLastInstruction=0x6, 3 ops)
+# CHECK-NEXT:           (inherits from base epilog: FirstOp=0x0, IpOffsetOfLastInstruction=0x6, 3 ops)
 # CHECK-NEXT:         }
 # CHECK-NEXT:         Epilog [2] {
 # CHECK-NEXT:           Flags [ (0x0)

--- a/llvm/tools/llvm-objdump/COFFDump.cpp
+++ b/llvm/tools/llvm-objdump/COFFDump.cpp
@@ -805,6 +805,8 @@ static void printWin64EHUnwindInfoV3(ArrayRef<uint8_t> Data) {
                    Info.NumberOfOps, "      ");
 
   // Epilog descriptors
+  uint8_t BaseEpilogFlags = 0;
+  bool HaveBaseEpilog = false;
   for (unsigned I = 0; I < Info.NumberOfEpilogs; ++I) {
     const DecodedEpilogV3 &Epi = Info.Epilogs[I];
 
@@ -836,6 +838,14 @@ static void printWin64EHUnwindInfoV3(ArrayRef<uint8_t> Data) {
         WithColor::warning(errs())
             << "first epilog cannot inherit (NumberOfOps=0)\n";
       } else {
+        // Per the V3 spec, Flags bits 0 and 1 are producer-replicated into an
+        // inherited descriptor, so they must match the base epilog. Warn if a
+        // non-compliant producer left them inconsistent.
+        if (HaveBaseEpilog && (Epi.Flags & 0x03) != (BaseEpilogFlags & 0x03))
+          WithColor::warning(errs())
+              << format("inherited epilog flags (0x%X) do not match base "
+                        "epilog flags (0x%X)\n",
+                        Epi.Flags & 0x03, BaseEpilogFlags & 0x03);
         // Surface the values inherited from the base epilog so a
         // reader can see what the unwinder will actually execute.
         outs() << format("      (inherits from base epilog: FirstOp=0x%X, "
@@ -853,6 +863,10 @@ static void printWin64EHUnwindInfoV3(ArrayRef<uint8_t> Data) {
           Epi.FirstOp);
       printWODSequence(Info.WODPool, Epi.FirstOp, ArrayRef(Epi.IpOffsets),
                        Epi.NumberOfOps, "      ");
+      // This is a full descriptor; it becomes the base that subsequent
+      // inherited descriptors replicate their flags from.
+      BaseEpilogFlags = Epi.Flags;
+      HaveBaseEpilog = true;
     }
   }
 

--- a/llvm/tools/llvm-objdump/COFFDump.cpp
+++ b/llvm/tools/llvm-objdump/COFFDump.cpp
@@ -836,9 +836,9 @@ static void printWin64EHUnwindInfoV3(ArrayRef<uint8_t> Data) {
         WithColor::warning(errs())
             << "first epilog cannot inherit (NumberOfOps=0)\n";
       } else {
-        // Surface the values inherited from the previous epilog so a
+        // Surface the values inherited from the base epilog so a
         // reader can see what the unwinder will actually execute.
-        outs() << format("      (inherits from previous epilog: FirstOp=0x%X, "
+        outs() << format("      (inherits from base epilog: FirstOp=0x%X, "
                          "IpOfLast=+0x%X, %u ops)\n",
                          Epi.FirstOp,
                          static_cast<unsigned>(Epi.IpOffsetOfLastInstruction),

--- a/llvm/tools/llvm-readobj/Win64EHDumper.cpp
+++ b/llvm/tools/llvm-readobj/Win64EHDumper.cpp
@@ -576,10 +576,10 @@ void Dumper::printUnwindInfoV3(const Context &Ctx,
         WithColor::warning(errs())
             << "first epilog cannot inherit (NumberOfOps=0)\n";
       } else {
-        // Surface the values inherited from the previous epilog so a
+        // Surface the values inherited from the base epilog so a
         // reader can see what the unwinder will actually execute.
         SW.startLine() << format(
-            "(inherits from previous epilog: FirstOp=0x%X, "
+            "(inherits from base epilog: FirstOp=0x%X, "
             "IpOffsetOfLastInstruction=0x%X, %u ops)\n",
             Epi.FirstOp, static_cast<unsigned>(Epi.IpOffsetOfLastInstruction),
             static_cast<unsigned>(Epi.IpOffsets.size()));

--- a/llvm/tools/llvm-readobj/Win64EHDumper.cpp
+++ b/llvm/tools/llvm-readobj/Win64EHDumper.cpp
@@ -551,6 +551,8 @@ void Dumper::printUnwindInfoV3(const Context &Ctx,
   }
 
   // Print epilog descriptors
+  uint8_t BaseEpilogFlags = 0;
+  bool HaveBaseEpilog = false;
   for (unsigned I = 0; I < Info.NumberOfEpilogs; ++I) {
     const DecodedEpilogV3 &Epi = Info.Epilogs[I];
 
@@ -576,6 +578,14 @@ void Dumper::printUnwindInfoV3(const Context &Ctx,
         WithColor::warning(errs())
             << "first epilog cannot inherit (NumberOfOps=0)\n";
       } else {
+        // Per the V3 spec, Flags bits 0 and 1 are producer-replicated into an
+        // inherited descriptor, so they must match the base epilog. Warn if a
+        // non-compliant producer left them inconsistent.
+        if (HaveBaseEpilog && (Epi.Flags & 0x03) != (BaseEpilogFlags & 0x03))
+          WithColor::warning(errs())
+              << format("inherited epilog flags (0x%X) do not match base "
+                        "epilog flags (0x%X)\n",
+                        Epi.Flags & 0x03, BaseEpilogFlags & 0x03);
         // Surface the values inherited from the base epilog so a
         // reader can see what the unwinder will actually execute.
         SW.startLine() << format(
@@ -589,6 +599,10 @@ void Dumper::printUnwindInfoV3(const Context &Ctx,
       SW.printHex("IpOffsetOfLastInstruction", Epi.IpOffsetOfLastInstruction);
       printWODSequence(SW, OS, Info.WODPool, Epi.FirstOp,
                        ArrayRef(Epi.IpOffsets), Epi.NumberOfOps);
+      // This is a full descriptor; it becomes the base that subsequent
+      // inherited descriptors replicate their flags from.
+      BaseEpilogFlags = Epi.Flags;
+      HaveBaseEpilog = true;
     }
   }
 


### PR DESCRIPTION
The Windows x64 unwind v3 spec was clarified (MicrosoftDocs/cpp-docs#5936) to state that an EPILOG_INFO_V3 record with `NumberOfOps == 0` inherits its effective fields from the first *preceding* descriptor with `NumberOfOps != 0` (the "base"), not the immediately preceding one. Additionally, Flags bits 0 and 1 are no longer inherited; the producer must replicate them so they match the base descriptor.

- Encoder (MCWin64EH.cpp): compare each epilog against the tracked base descriptor, and emit EPILOG_INFO_LARGE in inherited descriptors' own flags byte.
- Decoder (Win64EH.cpp): track the base index and inherit from it; keep the record's own flags byte instead of copying the previous record's.
- Dumpers (llvm-readobj, llvm-objdump): reword "previous epilog" to "base epilog".
- Tests: update multi-epilog expectations and add a LARGE inherited-epilog case to seh-unwindv3-inheritance.s.