### PR TITLE
[DirectX] Move getNonDXILAttributeMask to DirectXIRPasses

### DIFF
--- a/llvm/lib/Target/DirectX/DXILPrepare.cpp
+++ b/llvm/lib/Target/DirectX/DXILPrepare.cpp
@@ -14,6 +14,7 @@
 #include "DXILRootSignature.h"
 #include "DXILShaderFlags.h"
 #include "DirectX.h"
+#include "DirectXIRPasses/DXILAttributes.h"
 #include "DirectXIRPasses/PointerTypeAnalysis.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringSet.h"
@@ -32,70 +33,6 @@
 
 using namespace llvm;
 using namespace llvm::dxil;
-
-namespace llvm {
-namespace dxil {
-const AttributeMask &getNonDXILAttributeMask() {
-  static const AttributeMask Result = [] {
-    AttributeMask DXILAttributeMask;
-    for (Attribute::AttrKind Kind : {Attribute::Alignment,
-                                     Attribute::AlwaysInline,
-                                     Attribute::Builtin,
-                                     Attribute::ByVal,
-                                     Attribute::InAlloca,
-                                     Attribute::Cold,
-                                     Attribute::Convergent,
-                                     Attribute::InlineHint,
-                                     Attribute::InReg,
-                                     Attribute::JumpTable,
-                                     Attribute::MinSize,
-                                     Attribute::Naked,
-                                     Attribute::Nest,
-                                     Attribute::NoAlias,
-                                     Attribute::NoBuiltin,
-                                     Attribute::NoDuplicate,
-                                     Attribute::NoImplicitFloat,
-                                     Attribute::NoInline,
-                                     Attribute::NonLazyBind,
-                                     Attribute::NonNull,
-                                     Attribute::Dereferenceable,
-                                     Attribute::DereferenceableOrNull,
-                                     Attribute::Memory,
-                                     Attribute::NoRedZone,
-                                     Attribute::NoReturn,
-                                     Attribute::NoUnwind,
-                                     Attribute::OptimizeForSize,
-                                     Attribute::OptimizeNone,
-                                     Attribute::ReadNone,
-                                     Attribute::ReadOnly,
-                                     Attribute::Returned,
-                                     Attribute::ReturnsTwice,
-                                     Attribute::SExt,
-                                     Attribute::StackAlignment,
-                                     Attribute::StackProtect,
-                                     Attribute::StackProtectReq,
-                                     Attribute::StackProtectStrong,
-                                     Attribute::SafeStack,
-                                     Attribute::StructRet,
-                                     Attribute::SanitizeAddress,
-                                     Attribute::SanitizeThread,
-                                     Attribute::SanitizeMemory,
-                                     Attribute::UWTable,
-                                     Attribute::ZExt})
-      DXILAttributeMask.addAttribute(Kind);
-    AttributeMask Result;
-    for (Attribute::AttrKind Kind = Attribute::None;
-         Kind != Attribute::EndAttrKinds;
-         Kind = Attribute::AttrKind(Kind + 1)) {
-      if (!DXILAttributeMask.contains(Kind))
-        Result.addAttribute(Kind);
-    }
-    return Result;
-  }();
-  return Result;
-}
-} // namespace dxil
-} // namespace llvm
 
 namespace {
 

--- a/llvm/lib/Target/DirectX/DirectX.h
+++ b/llvm/lib/Target/DirectX/DirectX.h
@@ -126,10 +126,6 @@ void initializeDXILFinalizeLinkageLegacyPass(PassRegistry &);
 
 /// Pass to finalize linkage of functions.
 ModulePass *createDXILFinalizeLinkageLegacyPass();
-
-namespace dxil {
-const AttributeMask &getNonDXILAttributeMask();
-} // namespace dxil
 } // namespace llvm
 
 #endif // LLVM_LIB_TARGET_DIRECTX_DIRECTX_H

--- a/llvm/lib/Target/DirectX/DirectXIRPasses/CMakeLists.txt
+++ b/llvm/lib/Target/DirectX/DirectXIRPasses/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_llvm_component_library(LLVMDirectXIRPasses
+  DXILAttributes.cpp
   DXILDebugInfo.cpp
   PointerTypeAnalysis.cpp
 

--- a/llvm/lib/Target/DirectX/DirectXIRPasses/DXILAttributes.cpp
+++ b/llvm/lib/Target/DirectX/DirectXIRPasses/DXILAttributes.cpp
@@ -1,0 +1,77 @@
+//===--- DXILAttributes.cpp - attribute helper function -------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "DXILAttributes.h"
+#include "llvm/IR/AttributeMask.h"
+
+using namespace llvm;
+using namespace llvm::dxil;
+
+namespace llvm {
+namespace dxil {
+const AttributeMask &getNonDXILAttributeMask() {
+  static const AttributeMask Result = [] {
+    AttributeMask DXILAttributeMask;
+    for (Attribute::AttrKind Kind : {Attribute::Alignment,
+                                     Attribute::AlwaysInline,
+                                     Attribute::Builtin,
+                                     Attribute::ByVal,
+                                     Attribute::InAlloca,
+                                     Attribute::Cold,
+                                     Attribute::Convergent,
+                                     Attribute::InlineHint,
+                                     Attribute::InReg,
+                                     Attribute::JumpTable,
+                                     Attribute::MinSize,
+                                     Attribute::Naked,
+                                     Attribute::Nest,
+                                     Attribute::NoAlias,
+                                     Attribute::NoBuiltin,
+                                     Attribute::NoDuplicate,
+                                     Attribute::NoImplicitFloat,
+                                     Attribute::NoInline,
+                                     Attribute::NonLazyBind,
+                                     Attribute::NonNull,
+                                     Attribute::Dereferenceable,
+                                     Attribute::DereferenceableOrNull,
+                                     Attribute::Memory,
+                                     Attribute::NoRedZone,
+                                     Attribute::NoReturn,
+                                     Attribute::NoUnwind,
+                                     Attribute::OptimizeForSize,
+                                     Attribute::OptimizeNone,
+                                     Attribute::ReadNone,
+                                     Attribute::ReadOnly,
+                                     Attribute::Returned,
+                                     Attribute::ReturnsTwice,
+                                     Attribute::SExt,
+                                     Attribute::StackAlignment,
+                                     Attribute::StackProtect,
+                                     Attribute::StackProtectReq,
+                                     Attribute::StackProtectStrong,
+                                     Attribute::SafeStack,
+                                     Attribute::StructRet,
+                                     Attribute::SanitizeAddress,
+                                     Attribute::SanitizeThread,
+                                     Attribute::SanitizeMemory,
+                                     Attribute::UWTable,
+                                     Attribute::ZExt})
+      DXILAttributeMask.addAttribute(Kind);
+    AttributeMask Result;
+    for (Attribute::AttrKind Kind = Attribute::None;
+         Kind != Attribute::EndAttrKinds;
+         Kind = Attribute::AttrKind(Kind + 1)) {
+      if (!DXILAttributeMask.contains(Kind))
+        Result.addAttribute(Kind);
+    }
+    return Result;
+  }();
+  return Result;
+}
+} // namespace dxil
+} // namespace llvm

--- a/llvm/lib/Target/DirectX/DirectXIRPasses/DXILAttributes.h
+++ b/llvm/lib/Target/DirectX/DirectXIRPasses/DXILAttributes.h
@@ -1,0 +1,22 @@
+//===- DXILAttributes.h - DirectX attributes ------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_DIRECTX_DXILATTRIBUTES_H
+#define LLVM_LIB_TARGET_DIRECTX_DXILATTRIBUTES_H
+
+namespace llvm {
+class AttributeMask;
+
+namespace dxil {
+const AttributeMask &getNonDXILAttributeMask();
+} // namespace dxil
+} // namespace llvm
+
+#endif // LLVM_LIB_TARGET_DIRECTX_DXILATTRIBUTES_H

--- a/llvm/lib/Target/DirectX/DirectXIRPasses/DXILDebugInfo.cpp
+++ b/llvm/lib/Target/DirectX/DirectXIRPasses/DXILDebugInfo.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "DXILDebugInfo.h"
-#include "DirectX.h"
+#include "DXILAttributes.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/IR/AttributeMask.h"
 #include "llvm/IR/DebugInfo.h"


### PR DESCRIPTION
DXILDebugInfo.cpp uses it and is part of DirectXIRPasses, but DXILPrepare.cpp defined it and is part of DirectXCodeGen. DirectXCodeGen has a dependency on DirectXIRPasses, so we cannot also add a dependency from DirectXIRPasses back on DirectXCodeGen, and we need to move the definition of getNonDXILAttributeMask() instead.

Fixes: #201336