### PR TITLE
[Option] Store generated option strings as offsets

### DIFF
--- a/clang-tools-extra/clangd/CompileCommands.cpp
+++ b/clang-tools-extra/clangd/CompileCommands.cpp
@@ -473,7 +473,7 @@ llvm::ArrayRef<ArgStripper::Rule> ArgStripper::rulesFor(llvm::StringRef Arg) {
     struct {
       DriverID ID;
       DriverID AliasID;
-      const void *AliasArgs;
+      unsigned AliasArgsOffset;
     } AliasTable[] = {
 #define OPTION(PREFIX, PREFIXED_NAME, ID, KIND, GROUP, ALIAS, ALIASARGS,       \
                FLAGS, VISIBILITY, PARAM, HELPTEXT, HELPTEXTSFORVARIANTS,       \
@@ -483,7 +483,7 @@ llvm::ArrayRef<ArgStripper::Rule> ArgStripper::rulesFor(llvm::StringRef Arg) {
 #undef OPTION
     };
     for (auto &E : AliasTable)
-      if (E.AliasID != DriverID::OPT_INVALID && E.AliasArgs == nullptr)
+      if (E.AliasID != DriverID::OPT_INVALID && E.AliasArgsOffset == 0)
         AddAlias(E.ID, E.AliasID);
 
     auto Result = std::make_unique<TableTy>();

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -252,12 +252,12 @@ CowCompilerInvocation::getMutPreprocessorOutputOpts() {
 
 using ArgumentConsumer = CompilerInvocation::ArgumentConsumer;
 
-#define OPTTABLE_STR_TABLE_CODE
+#define OPTTABLE_OPTION_STR_TABLE_CODE
 #include "clang/Options/Options.inc"
-#undef OPTTABLE_STR_TABLE_CODE
+#undef OPTTABLE_OPTION_STR_TABLE_CODE
 
 static llvm::StringRef lookupStrInTable(unsigned Offset) {
-  return OptionStrTable[Offset];
+  return llvm::StringTable(OptionNameStrTable)[Offset];
 }
 
 #define SIMPLE_ENUM_VALUE_TABLE

--- a/clang/lib/Options/DriverOptions.cpp
+++ b/clang/lib/Options/DriverOptions.cpp
@@ -41,7 +41,10 @@ class DriverOptTable : public PrecomputedOptTable {
 public:
   DriverOptTable()
       : PrecomputedOptTable(OptionStrTable, OptionPrefixesTable, InfoTable,
-                            OptionPrefixesUnion) {}
+                            OptionPrefixesUnion, /*IgnoreCase=*/false,
+                            /*SubCommands=*/{},
+                            /*SubCommandIDsTable=*/{}, OptionHelpTextVariants,
+                            getGeneratedOptionValues) {}
 };
 } // anonymous namespace
 

--- a/lld/MachO/DriverUtils.cpp
+++ b/lld/MachO/DriverUtils.cpp
@@ -48,19 +48,19 @@ static constexpr OptTable::Info optInfo[] = {
                VALUES, SUBCOMMANDIDS_OFFSET)                                   \
   {PREFIX,                                                                     \
    NAME,                                                                       \
+   HELPTEXT,                                                                   \
+   METAVAR,                                                                    \
+   ALIASARGS,                                                                  \
+   VALUES,                                                                     \
    OPT_##ID,                                                                   \
    FLAGS,                                                                      \
    VISIBILITY,                                                                 \
    SUBCOMMANDIDS_OFFSET,                                                       \
    OPT_##GROUP,                                                                \
    OPT_##ALIAS,                                                                \
-   opt::Option::KIND##Class,                                                   \
-   PARAM,                                                                      \
    HELPTEXTSFORVARIANTS,                                                       \
-   HELPTEXT,                                                                   \
-   METAVAR,                                                                    \
-   ALIASARGS,                                                                  \
-   VALUES},
+   opt::Option::KIND##Class,                                                   \
+   PARAM},
 #include "Options.inc"
 #undef OPTION
 };

--- a/lld/MachO/DriverUtils.cpp
+++ b/lld/MachO/DriverUtils.cpp
@@ -48,19 +48,19 @@ static constexpr OptTable::Info optInfo[] = {
                VALUES, SUBCOMMANDIDS_OFFSET)                                   \
   {PREFIX,                                                                     \
    NAME,                                                                       \
-   HELPTEXT,                                                                   \
-   HELPTEXTSFORVARIANTS,                                                       \
-   METAVAR,                                                                    \
    OPT_##ID,                                                                   \
-   opt::Option::KIND##Class,                                                   \
-   PARAM,                                                                      \
    FLAGS,                                                                      \
    VISIBILITY,                                                                 \
+   SUBCOMMANDIDS_OFFSET,                                                       \
    OPT_##GROUP,                                                                \
    OPT_##ALIAS,                                                                \
+   opt::Option::KIND##Class,                                                   \
+   PARAM,                                                                      \
+   HELPTEXTSFORVARIANTS,                                                       \
+   HELPTEXT,                                                                   \
+   METAVAR,                                                                    \
    ALIASARGS,                                                                  \
-   VALUES,                                                                     \
-   SUBCOMMANDIDS_OFFSET},
+   VALUES},
 #include "Options.inc"
 #undef OPTION
 };

--- a/lld/MinGW/Driver.cpp
+++ b/lld/MinGW/Driver.cpp
@@ -73,19 +73,19 @@ static constexpr opt::OptTable::Info infoTable[] = {
                VALUES, SUBCOMMANDIDS_OFFSET)                                   \
   {PREFIX,                                                                     \
    NAME,                                                                       \
+   HELPTEXT,                                                                   \
+   METAVAR,                                                                    \
+   ALIASARGS,                                                                  \
+   VALUES,                                                                     \
    OPT_##ID,                                                                   \
    FLAGS,                                                                      \
    VISIBILITY,                                                                 \
    SUBCOMMANDIDS_OFFSET,                                                       \
    OPT_##GROUP,                                                                \
    OPT_##ALIAS,                                                                \
-   opt::Option::KIND##Class,                                                   \
-   PARAM,                                                                      \
    HELPTEXTSFORVARIANTS,                                                       \
-   HELPTEXT,                                                                   \
-   METAVAR,                                                                    \
-   ALIASARGS,                                                                  \
-   VALUES},
+   opt::Option::KIND##Class,                                                   \
+   PARAM},
 #include "Options.inc"
 #undef OPTION
 };

--- a/lld/MinGW/Driver.cpp
+++ b/lld/MinGW/Driver.cpp
@@ -73,19 +73,19 @@ static constexpr opt::OptTable::Info infoTable[] = {
                VALUES, SUBCOMMANDIDS_OFFSET)                                   \
   {PREFIX,                                                                     \
    NAME,                                                                       \
-   HELPTEXT,                                                                   \
-   HELPTEXTSFORVARIANTS,                                                       \
-   METAVAR,                                                                    \
    OPT_##ID,                                                                   \
-   opt::Option::KIND##Class,                                                   \
-   PARAM,                                                                      \
    FLAGS,                                                                      \
    VISIBILITY,                                                                 \
+   SUBCOMMANDIDS_OFFSET,                                                       \
    OPT_##GROUP,                                                                \
    OPT_##ALIAS,                                                                \
+   opt::Option::KIND##Class,                                                   \
+   PARAM,                                                                      \
+   HELPTEXTSFORVARIANTS,                                                       \
+   HELPTEXT,                                                                   \
+   METAVAR,                                                                    \
    ALIASARGS,                                                                  \
-   VALUES,                                                                     \
-   SUBCOMMANDIDS_OFFSET},
+   VALUES},
 #include "Options.inc"
 #undef OPTION
 };

--- a/lld/wasm/Driver.cpp
+++ b/lld/wasm/Driver.cpp
@@ -160,19 +160,19 @@ static constexpr opt::OptTable::Info optInfo[] = {
                VALUES, SUBCOMMANDIDS_OFFSET)                                   \
   {PREFIX,                                                                     \
    NAME,                                                                       \
-   HELPTEXT,                                                                   \
-   HELPTEXTSFORVARIANTS,                                                       \
-   METAVAR,                                                                    \
    OPT_##ID,                                                                   \
-   opt::Option::KIND##Class,                                                   \
-   PARAM,                                                                      \
    FLAGS,                                                                      \
    VISIBILITY,                                                                 \
+   SUBCOMMANDIDS_OFFSET,                                                       \
    OPT_##GROUP,                                                                \
    OPT_##ALIAS,                                                                \
+   opt::Option::KIND##Class,                                                   \
+   PARAM,                                                                      \
+   HELPTEXTSFORVARIANTS,                                                       \
+   HELPTEXT,                                                                   \
+   METAVAR,                                                                    \
    ALIASARGS,                                                                  \
-   VALUES,                                                                     \
-   SUBCOMMANDIDS_OFFSET},
+   VALUES},
 #include "Options.inc"
 #undef OPTION
 };

--- a/lld/wasm/Driver.cpp
+++ b/lld/wasm/Driver.cpp
@@ -160,19 +160,19 @@ static constexpr opt::OptTable::Info optInfo[] = {
                VALUES, SUBCOMMANDIDS_OFFSET)                                   \
   {PREFIX,                                                                     \
    NAME,                                                                       \
+   HELPTEXT,                                                                   \
+   METAVAR,                                                                    \
+   ALIASARGS,                                                                  \
+   VALUES,                                                                     \
    OPT_##ID,                                                                   \
    FLAGS,                                                                      \
    VISIBILITY,                                                                 \
    SUBCOMMANDIDS_OFFSET,                                                       \
    OPT_##GROUP,                                                                \
    OPT_##ALIAS,                                                                \
-   opt::Option::KIND##Class,                                                   \
-   PARAM,                                                                      \
    HELPTEXTSFORVARIANTS,                                                       \
-   HELPTEXT,                                                                   \
-   METAVAR,                                                                    \
-   ALIASARGS,                                                                  \
-   VALUES},
+   opt::Option::KIND##Class,                                                   \
+   PARAM},
 #include "Options.inc"
 #undef OPTION
 };

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -58,9 +58,9 @@
 using namespace lldb;
 using namespace lldb_private;
 
-#define OPTTABLE_STR_TABLE_CODE
+#define OPTTABLE_OPTION_STR_TABLE_CODE
 #include "clang/Options/Options.inc"
-#undef OPTTABLE_STR_TABLE_CODE
+#undef OPTTABLE_OPTION_STR_TABLE_CODE
 
 static Status ExceptionMaskValidator(const char *string, void *unused) {
   Status error;
@@ -1182,7 +1182,8 @@ void PlatformDarwin::AddClangModuleCompilationOptionsForSDKType(
   if (!version.empty() && sdk_type != XcodeSDK::Type::Linux &&
       sdk_type != XcodeSDK::Type::XROS) {
 #define OPTION(PREFIX_OFFSET, NAME_OFFSET, VAR, ...)                           \
-  llvm::StringRef opt_##VAR = OptionStrTable[NAME_OFFSET];                     \
+  llvm::StringRef opt_##VAR =                                                  \
+      llvm::StringTable(OptionNameStrTable)[NAME_OFFSET];                      \
   (void)opt_##VAR;
 #include "clang/Options/Options.inc"
 #undef OPTION

--- a/llvm/examples/OptSubcommand/llvm-hello-sub.cpp
+++ b/llvm/examples/OptSubcommand/llvm-hello-sub.cpp
@@ -78,8 +78,8 @@ int main(int argc, char **argv) {
   InputArgList Args = T.ParseArgs(ArrayRef(argv + 1, argc - 1), MissingArgIndex,
                                   MissingArgCount);
 
-  StringRef SubCommand = Args.getSubCommand(
-      T.getSubCommands(), HandleMultipleSubcommands, HandleOtherPositionals);
+  StringRef SubCommand =
+      Args.getSubCommand(T, HandleMultipleSubcommands, HandleOtherPositionals);
   // Handle help. When help options is found, ignore all other options and exit
   // after printing help.
 

--- a/llvm/include/llvm/Option/ArgList.h
+++ b/llvm/include/llvm/Option/ArgList.h
@@ -283,7 +283,7 @@ public:
 
   /// getSubCommand - Find subcommand from the arguments if the usage is valid.
   ///
-  /// \param AllSubCommands - A list of all valid subcommands.
+  /// \param Options - The option table containing all valid subcommands.
   /// \param HandleMultipleSubcommands - A callback for the case where multiple
   /// subcommands are present in the arguments. It gets a list of all found
   /// subcommands.
@@ -293,7 +293,7 @@ public:
   /// this returns an empty StringRef. If multiple subcommands are found, the
   /// first one is returned.
   LLVM_ABI_FOR_TEST StringRef getSubCommand(
-      ArrayRef<OptTable::SubCommand> AllSubCommands,
+      const OptTable &Options,
       std::function<void(ArrayRef<StringRef>)> HandleMultipleSubcommands,
       std::function<void(ArrayRef<StringRef>)> HandleOtherPositionals) const;
 

--- a/llvm/include/llvm/Option/OptTable.h
+++ b/llvm/include/llvm/Option/OptTable.h
@@ -17,6 +17,7 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/StringSaver.h"
 #include <cassert>
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -55,21 +56,32 @@ class LLVM_ABI OptTable {
 public:
   /// Represents a subcommand and its options in the option table.
   struct SubCommand {
-    const char *Name;
-    const char *HelpText;
-    const char *Usage;
+    StringTable::Offset NameOffset;
+    StringTable::Offset HelpTextOffset;
+    StringTable::Offset UsageOffset;
   };
 
-  struct HelpTextVariants {
-    const char *Default;
-    const char *Text;
+  struct HelpTextVariant {
+    // A one-based offset into the string table.
+    unsigned TextOffset;
     unsigned VisibilityMask;
   };
+
+  static constexpr unsigned ValuesCodeFlag = 1U << 31;
+  using ValuesCodeResolver = const char *(*)(unsigned);
 
   /// Entry for a single option instance in the option data table.
   struct Info {
     unsigned PrefixesOffset;
     StringTable::Offset PrefixedNameOffset;
+    // One-based offsets into the string table. Zero represents an absent
+    // optional string, while one represents the empty string at offset zero.
+    unsigned HelpTextOffset;
+    unsigned MetaVarOffset;
+    unsigned AliasArgsOffset;
+    // A one-based offset into the string table, or ValuesCodeFlag plus an index
+    // into generated ValuesCode.
+    unsigned Values;
     unsigned ID;
     unsigned Flags;
     unsigned Visibility;
@@ -77,25 +89,35 @@ public:
     unsigned SubCommandIDsOffset;
     unsigned short GroupID;
     unsigned short AliasID;
+    // A one-based index into OptTable's HelpTextVariants table.
+    uint16_t HelpTextVariantIndex;
     unsigned char Kind;
     unsigned char Param;
-    bool HasHelpTextVariants;
-    // Points to a C string unless HasHelpTextVariants is set, in which case it
-    // points to a HelpTextVariants descriptor.
-    const void *HelpText;
-    const char *MetaVar;
-    const char *AliasArgs;
-    const char *Values;
 
     bool hasNoPrefix() const { return PrefixesOffset == 0; }
 
-    const char *getHelpText(
+    unsigned getHelpTextOffset(
+        ArrayRef<HelpTextVariant> HelpTextVariants,
         llvm::opt::Visibility VisibilityMask = llvm::opt::Visibility(0)) const {
-      if (!HasHelpTextVariants)
-        return static_cast<const char *>(HelpText);
-      const auto *Variants = static_cast<const HelpTextVariants *>(HelpText);
-      return Variants->VisibilityMask & VisibilityMask ? Variants->Text
-                                                       : Variants->Default;
+      if (!HelpTextVariantIndex)
+        return HelpTextOffset;
+      if (HelpTextVariantIndex > HelpTextVariants.size())
+        return HelpTextOffset;
+      const HelpTextVariant &Variant =
+          HelpTextVariants[HelpTextVariantIndex - 1];
+      return Variant.VisibilityMask & VisibilityMask ? Variant.TextOffset
+                                                     : HelpTextOffset;
+    }
+
+    bool hasValues() const { return Values != 0; }
+    bool hasValuesCode() const { return Values & ValuesCodeFlag; }
+    unsigned getValuesCodeIndex() const {
+      assert(hasValuesCode());
+      return Values & ~ValuesCodeFlag;
+    }
+    StringTable::Offset getValuesOffset() const {
+      assert(hasValues() && !hasValuesCode());
+      return Values - 1;
     }
 
     unsigned getNumPrefixes(ArrayRef<StringTable::Offset> PrefixesTable) const {
@@ -150,16 +172,22 @@ public:
     }
   };
 
-  static_assert(sizeof(void *) != 8 || sizeof(Info) == 64,
-                "unexpected OptTable::Info layout");
+  static_assert(sizeof(SubCommand) == 12,
+                "unexpected OptTable::SubCommand layout");
+  static_assert(sizeof(HelpTextVariant) == 8,
+                "unexpected OptTable::HelpTextVariant layout");
+  static_assert(sizeof(StringTable::Offset) == 4,
+                "unexpected StringTable::Offset width");
+  static_assert(sizeof(Info) == 48, "unexpected OptTable::Info layout");
 
 public:
   bool isValidForSubCommand(const Info *CandidateInfo,
                             StringRef SubCommand) const {
     assert(!SubCommand.empty() &&
            "This helper is only for valid registered subcommands.");
-    auto SCIT = llvm::find_if(
-        SubCommands, [&](const auto &C) { return SubCommand == C.Name; });
+    auto SCIT = llvm::find_if(SubCommands, [&](const auto &C) {
+      return SubCommand == getSubCommandName(C);
+    });
     assert(SCIT != SubCommands.end() &&
            "This helper is only for valid registered subcommands.");
     auto SubCommandIDs = CandidateInfo->getSubCommandIDs(SubCommandIDsTable);
@@ -170,7 +198,7 @@ public:
 private:
   // A unified string table for these options. Individual strings are stored as
   // null terminated C-strings at offsets within this table.
-  const StringTable *StrTable;
+  StringTable StrTable;
 
   // A table of different sets of prefixes. Each set starts with the number of
   // prefixes in that set followed by that many offsets into the string table
@@ -181,6 +209,9 @@ private:
   /// The option information table.
   ArrayRef<Info> OptionInfos;
 
+  /// The visibility-specific help text table.
+  ArrayRef<HelpTextVariant> HelpTextVariants;
+
   bool IgnoreCase;
 
   /// The subcommand information table.
@@ -188,6 +219,10 @@ private:
 
   /// The subcommand IDs table.
   ArrayRef<unsigned> SubCommandIDsTable;
+
+  /// Resolves generated ValuesCode indices. This is stored once in the runtime
+  /// option table instead of once per generated option entry.
+  ValuesCodeResolver ResolveValuesCode;
 
   bool GroupedShortOptions = false;
   bool DashDashParsing = false;
@@ -218,6 +253,22 @@ private:
   std::unique_ptr<Arg> parseOneArgGrouped(InputArgList &Args,
                                           unsigned &Index) const;
 
+  const char *getStringOrNull(unsigned OneBasedOffset) const {
+    return OneBasedOffset
+               ? StrTable.getCString(StringTable::Offset(OneBasedOffset - 1))
+               : nullptr;
+  }
+
+  const char *getOptionValues(const Info &OptionInfo) const {
+    if (!OptionInfo.hasValues())
+      return nullptr;
+    if (!OptionInfo.hasValuesCode())
+      return StrTable.getCString(OptionInfo.getValuesOffset());
+    return ResolveValuesCode
+               ? ResolveValuesCode(OptionInfo.getValuesCodeIndex())
+               : nullptr;
+  }
+
 protected:
   /// Initialize OptTable using Tablegen'ed OptionInfos. Child class must
   /// manually call \c buildPrefixChars once they are fully constructed.
@@ -225,7 +276,9 @@ protected:
            ArrayRef<StringTable::Offset> PrefixesTable,
            ArrayRef<Info> OptionInfos, bool IgnoreCase = false,
            ArrayRef<SubCommand> SubCommands = {},
-           ArrayRef<unsigned> SubCommandIDsTable = {});
+           ArrayRef<unsigned> SubCommandIDsTable = {},
+           ArrayRef<HelpTextVariant> HelpTextVariants = {},
+           ValuesCodeResolver ResolveValuesCode = nullptr);
 
   /// Build (or rebuild) the PrefixChars member.
   void buildPrefixChars();
@@ -234,9 +287,21 @@ public:
   virtual ~OptTable();
 
   /// Return the string table used for option names.
-  const StringTable &getStrTable() const { return *StrTable; }
+  const StringTable &getStrTable() const { return StrTable; }
 
   ArrayRef<SubCommand> getSubCommands() const { return SubCommands; }
+
+  StringRef getSubCommandName(const SubCommand &Command) const {
+    return StrTable[Command.NameOffset];
+  }
+
+  StringRef getSubCommandHelpText(const SubCommand &Command) const {
+    return StrTable[Command.HelpTextOffset];
+  }
+
+  StringRef getSubCommandUsage(const SubCommand &Command) const {
+    return StrTable[Command.UsageOffset];
+  }
 
   /// Return the prefixes table used for option names.
   ArrayRef<StringTable::Offset> getPrefixesTable() const {
@@ -254,31 +319,29 @@ public:
 
   /// Lookup the name of the given option.
   StringRef getOptionName(OptSpecifier id) const {
-    return getInfo(id).getName(*StrTable, PrefixesTable);
+    return getInfo(id).getName(StrTable, PrefixesTable);
   }
 
   /// Lookup the prefix of the given option.
   StringRef getOptionPrefix(OptSpecifier id) const {
     const Info &I = getInfo(id);
     return I.hasNoPrefix() ? StringRef()
-                           : I.getPrefix(*StrTable, PrefixesTable, 0);
+                           : I.getPrefix(StrTable, PrefixesTable, 0);
   }
 
   void appendOptionPrefixes(OptSpecifier id,
                             SmallVectorImpl<StringRef> &Prefixes) const {
     const Info &I = getInfo(id);
-    I.appendPrefixes(*StrTable, PrefixesTable, Prefixes);
+    I.appendPrefixes(StrTable, PrefixesTable, Prefixes);
   }
 
   /// Lookup the prefixed name of the given option.
   StringRef getOptionPrefixedName(OptSpecifier id) const {
-    return getInfo(id).getPrefixedName(*StrTable);
+    return getInfo(id).getPrefixedName(StrTable);
   }
 
   /// Get the kind of the given option.
-  unsigned getOptionKind(OptSpecifier id) const {
-    return getInfo(id).Kind;
-  }
+  unsigned getOptionKind(OptSpecifier id) const { return getInfo(id).Kind; }
 
   /// Get the group id for the given option.
   unsigned getOptionGroupID(OptSpecifier id) const {
@@ -295,13 +358,18 @@ public:
   // visibility mask, use that text instead of the generic text.
   const char *getOptionHelpText(OptSpecifier id,
                                 Visibility VisibilityMask) const {
-    return getInfo(id).getHelpText(VisibilityMask);
+    return getStringOrNull(
+        getInfo(id).getHelpTextOffset(HelpTextVariants, VisibilityMask));
   }
 
   /// Get the meta-variable name to use when describing
   /// this options values in the help text.
   const char *getOptionMetaVar(OptSpecifier id) const {
-    return getInfo(id).MetaVar;
+    return getStringOrNull(getInfo(id).MetaVarOffset);
+  }
+
+  const char *getOptionAliasArgs(OptSpecifier id) const {
+    return getStringOrNull(getInfo(id).AliasArgsOffset);
   }
 
   /// Specify the environment variable where initial options should be read.
@@ -455,7 +523,7 @@ public:
   /// \param OS - The stream to write the help text to.
   /// \param Usage - USAGE: Usage
   /// \param Title - OVERVIEW: Title
-  /// \param VisibilityMask - Only in                 Visibility VisibilityMask,clude options with any of these
+  /// \param VisibilityMask - Only include options with any of these
   ///                         visibility flags set.
   /// \param ShowHidden     - If true, display options marked as HelpHidden
   /// \param ShowAllAliases - If true, display all options including aliases
@@ -486,7 +554,9 @@ protected:
                            ArrayRef<StringTable::Offset> PrefixesTable,
                            ArrayRef<Info> OptionInfos, bool IgnoreCase = false,
                            ArrayRef<SubCommand> SubCommands = {},
-                           ArrayRef<unsigned> SubCommandIDsTable = {});
+                           ArrayRef<unsigned> SubCommandIDsTable = {},
+                           ArrayRef<HelpTextVariant> HelpTextVariants = {},
+                           ValuesCodeResolver ResolveValuesCode = nullptr);
 };
 
 class PrecomputedOptTable : public OptTable {
@@ -497,9 +567,11 @@ protected:
                       ArrayRef<StringTable::Offset> PrefixesUnionOffsets,
                       bool IgnoreCase = false,
                       ArrayRef<SubCommand> SubCommands = {},
-                      ArrayRef<unsigned> SubCommandIDsTable = {})
+                      ArrayRef<unsigned> SubCommandIDsTable = {},
+                      ArrayRef<HelpTextVariant> HelpTextVariants = {},
+                      ValuesCodeResolver ResolveValuesCode = nullptr)
       : OptTable(StrTable, PrefixesTable, OptionInfos, IgnoreCase, SubCommands,
-                 SubCommandIDsTable) {
+                 SubCommandIDsTable, HelpTextVariants, ResolveValuesCode) {
     for (auto PrefixOffset : PrefixesUnionOffsets)
       PrefixesUnion.push_back(StrTable[PrefixOffset]);
     buildPrefixChars();
@@ -530,10 +602,10 @@ protected:
     ALIASARGS, FLAGS, VISIBILITY, PARAM, HELPTEXT, HELPTEXTSFORVARIANTS,       \
     METAVAR, VALUES, SUBCOMMANDIDS_OFFSET)                                     \
   llvm::opt::OptTable::Info {                                                  \
-    PREFIXES_OFFSET, PREFIXED_NAME_OFFSET, ID_PREFIX##ID, FLAGS, VISIBILITY,   \
-        SUBCOMMANDIDS_OFFSET, ID_PREFIX##GROUP, ID_PREFIX##ALIAS,              \
-        llvm::opt::Option::KIND##Class, PARAM, HELPTEXTSFORVARIANTS, HELPTEXT, \
-        METAVAR, ALIASARGS, VALUES                                             \
+    PREFIXES_OFFSET, PREFIXED_NAME_OFFSET, HELPTEXT, METAVAR, ALIASARGS,       \
+        VALUES, ID_PREFIX##ID, FLAGS, VISIBILITY, SUBCOMMANDIDS_OFFSET,        \
+        ID_PREFIX##GROUP, ID_PREFIX##ALIAS, HELPTEXTSFORVARIANTS,              \
+        llvm::opt::Option::KIND##Class, PARAM                                  \
   }
 
 #define LLVM_CONSTRUCT_OPT_INFO(                                               \

--- a/llvm/include/llvm/Option/OptTable.h
+++ b/llvm/include/llvm/Option/OptTable.h
@@ -60,36 +60,43 @@ public:
     const char *Usage;
   };
 
+  struct HelpTextVariants {
+    const char *Default;
+    const char *Text;
+    unsigned VisibilityMask;
+  };
+
   /// Entry for a single option instance in the option data table.
   struct Info {
     unsigned PrefixesOffset;
     StringTable::Offset PrefixedNameOffset;
-    const char *HelpText;
-    // Help text for specific visibilities. A list of pairs, where each pair
-    // is a list of visibilities and a specific help string for those
-    // visibilities. If no help text is found in this list for the visibility of
-    // the program, HelpText is used instead. This cannot use std::vector
-    // because OptTable is used in constexpr contexts. Increase the array sizes
-    // here if you need more entries and adjust the constants in
-    // OptionParserEmitter::EmitHelpTextsForVariants.
-    std::array<std::pair<std::array<unsigned int, 2 /*MaxVisibilityPerHelp*/>,
-                         const char *>,
-               1 /*MaxVisibilityHelp*/>
-        HelpTextsForVariants;
-    const char *MetaVar;
     unsigned ID;
-    unsigned char Kind;
-    unsigned char Param;
-    unsigned int Flags;
-    unsigned int Visibility;
-    unsigned short GroupID;
-    unsigned short AliasID;
-    const char *AliasArgs;
-    const char *Values;
+    unsigned Flags;
+    unsigned Visibility;
     // Offset into OptTable's SubCommandIDsTable.
     unsigned SubCommandIDsOffset;
+    unsigned short GroupID;
+    unsigned short AliasID;
+    unsigned char Kind;
+    unsigned char Param;
+    bool HasHelpTextVariants;
+    // Points to a C string unless HasHelpTextVariants is set, in which case it
+    // points to a HelpTextVariants descriptor.
+    const void *HelpText;
+    const char *MetaVar;
+    const char *AliasArgs;
+    const char *Values;
 
     bool hasNoPrefix() const { return PrefixesOffset == 0; }
+
+    const char *getHelpText(
+        llvm::opt::Visibility VisibilityMask = llvm::opt::Visibility(0)) const {
+      if (!HasHelpTextVariants)
+        return static_cast<const char *>(HelpText);
+      const auto *Variants = static_cast<const HelpTextVariants *>(HelpText);
+      return Variants->VisibilityMask & VisibilityMask ? Variants->Text
+                                                       : Variants->Default;
+    }
 
     unsigned getNumPrefixes(ArrayRef<StringTable::Offset> PrefixesTable) const {
       // We embed the number of prefixes in the value of the first offset.
@@ -142,6 +149,9 @@ public:
       return getPrefixedName(StrTable).drop_front(PrefixLength);
     }
   };
+
+  static_assert(sizeof(void *) != 8 || sizeof(Info) == 64,
+                "unexpected OptTable::Info layout");
 
 public:
   bool isValidForSubCommand(const Info *CandidateInfo,
@@ -285,12 +295,7 @@ public:
   // visibility mask, use that text instead of the generic text.
   const char *getOptionHelpText(OptSpecifier id,
                                 Visibility VisibilityMask) const {
-    auto Info = getInfo(id);
-    for (auto [Visibilities, Text] : Info.HelpTextsForVariants)
-      for (auto Visibility : Visibilities)
-        if (VisibilityMask & Visibility)
-          return Text;
-    return Info.HelpText;
+    return getInfo(id).getHelpText(VisibilityMask);
   }
 
   /// Get the meta-variable name to use when describing
@@ -525,10 +530,10 @@ protected:
     ALIASARGS, FLAGS, VISIBILITY, PARAM, HELPTEXT, HELPTEXTSFORVARIANTS,       \
     METAVAR, VALUES, SUBCOMMANDIDS_OFFSET)                                     \
   llvm::opt::OptTable::Info {                                                  \
-    PREFIXES_OFFSET, PREFIXED_NAME_OFFSET, HELPTEXT, HELPTEXTSFORVARIANTS,     \
-        METAVAR, ID_PREFIX##ID, llvm::opt::Option::KIND##Class, PARAM, FLAGS,  \
-        VISIBILITY, ID_PREFIX##GROUP, ID_PREFIX##ALIAS, ALIASARGS, VALUES,     \
-        SUBCOMMANDIDS_OFFSET                                                   \
+    PREFIXES_OFFSET, PREFIXED_NAME_OFFSET, ID_PREFIX##ID, FLAGS, VISIBILITY,   \
+        SUBCOMMANDIDS_OFFSET, ID_PREFIX##GROUP, ID_PREFIX##ALIAS,              \
+        llvm::opt::Option::KIND##Class, PARAM, HELPTEXTSFORVARIANTS, HELPTEXT, \
+        METAVAR, ALIASARGS, VALUES                                             \
   }
 
 #define LLVM_CONSTRUCT_OPT_INFO(                                               \

--- a/llvm/include/llvm/Option/Option.h
+++ b/llvm/include/llvm/Option/Option.h
@@ -144,7 +144,7 @@ public:
   /// Get the help text for this option.
   StringRef getHelpText() const {
     assert(Info && "Must have a valid info!");
-    return Info->HelpText;
+    return Info->getHelpText();
   }
 
   /// Get the meta-variable list for this option.

--- a/llvm/include/llvm/Option/Option.h
+++ b/llvm/include/llvm/Option/Option.h
@@ -121,10 +121,12 @@ public:
   /// E.g. ["foo", "bar"] would be returned as "foo\0bar\0".
   const char *getAliasArgs() const {
     assert(Info && "Must have a valid info!");
-    assert((!Info->AliasArgs || Info->AliasArgs[0] != 0) &&
+    assert(Owner && "Must have a valid owner!");
+    const char *AliasArgs = Owner->getOptionAliasArgs(Info->ID);
+    assert((!AliasArgs || AliasArgs[0] != 0) &&
            "AliasArgs should be either 0 or non-empty.");
 
-    return Info->AliasArgs;
+    return AliasArgs;
   }
 
   /// Get the default prefix for this option.
@@ -144,13 +146,15 @@ public:
   /// Get the help text for this option.
   StringRef getHelpText() const {
     assert(Info && "Must have a valid info!");
-    return Info->getHelpText();
+    assert(Owner && "Must have a valid owner!");
+    return Owner->getOptionHelpText(Info->ID);
   }
 
   /// Get the meta-variable list for this option.
   StringRef getMetaVar() const {
     assert(Info && "Must have a valid info!");
-    return Info->MetaVar;
+    assert(Owner && "Must have a valid owner!");
+    return Owner->getOptionMetaVar(Info->ID);
   }
 
   unsigned getNumArgs() const { return Info->Param; }

--- a/llvm/include/llvm/TableGen/StringToOffsetTable.h
+++ b/llvm/include/llvm/TableGen/StringToOffsetTable.h
@@ -67,8 +67,18 @@ public:
   // valid identifiers to declare.
   void EmitStringTableDef(raw_ostream &OS, const Twine &Name) const;
 
+  // Emit only the character storage for a string table with the provided name.
+  //
+  // This is useful when the generated code stores a StringTable in a runtime
+  // object and wants the static data to contain no address-bearing wrapper.
+  void EmitStringTableStorageDef(raw_ostream &OS, const Twine &Name) const;
+
   // Emit the string as one single string.
   void EmitString(raw_ostream &O) const;
+
+private:
+  void emitStringTableStorageDef(raw_ostream &OS, const Twine &Name,
+                                 bool IsStatic) const;
 };
 
 } // end namespace llvm

--- a/llvm/lib/Option/ArgList.cpp
+++ b/llvm/lib/Option/ArgList.cpp
@@ -204,7 +204,7 @@ LLVM_DUMP_METHOD void ArgList::dump() const { print(dbgs()); }
 #endif
 
 StringRef ArgList::getSubCommand(
-    ArrayRef<OptTable::SubCommand> AllSubCommands,
+    const OptTable &Options,
     std::function<void(ArrayRef<StringRef>)> HandleMultipleSubcommands,
     std::function<void(ArrayRef<StringRef>)> HandleOtherPositionals) const {
 
@@ -215,8 +215,8 @@ StringRef ArgList::getSubCommand(
       continue;
 
     size_t OldSize = SubCommands.size();
-    for (const OptTable::SubCommand &CMD : AllSubCommands) {
-      if (StringRef(CMD.Name) == A->getValue())
+    for (const OptTable::SubCommand &CMD : Options.getSubCommands()) {
+      if (Options.getSubCommandName(CMD) == A->getValue())
         SubCommands.push_back(A->getValue());
     }
 

--- a/llvm/lib/Option/OptTable.cpp
+++ b/llvm/lib/Option/OptTable.cpp
@@ -214,7 +214,8 @@ OptTable::findByPrefix(StringRef Cur, Visibility VisibilityMask,
   std::vector<std::string> Ret;
   for (size_t I = FirstSearchableIndex, E = OptionInfos.size(); I < E; I++) {
     const Info &In = OptionInfos[I];
-    if (In.hasNoPrefix() || (!In.HelpText && !In.GroupID))
+    const char *HelpText = In.getHelpText(VisibilityMask);
+    if (In.hasNoPrefix() || (!HelpText && !In.GroupID))
       continue;
     if (!(In.Visibility & VisibilityMask))
       continue;
@@ -225,8 +226,8 @@ OptTable::findByPrefix(StringRef Cur, Visibility VisibilityMask,
     for (auto PrefixOffset : In.getPrefixOffsets(PrefixesTable)) {
       StringRef Prefix = (*StrTable)[PrefixOffset];
       std::string S = (Twine(Prefix) + Name + "\t").str();
-      if (In.HelpText)
-        S += In.HelpText;
+      if (HelpText)
+        S += HelpText;
       if (StringRef(S).starts_with(Cur) && S != std::string(Cur) + "\t")
         Ret.push_back(S);
     }

--- a/llvm/lib/Option/OptTable.cpp
+++ b/llvm/lib/Option/OptTable.cpp
@@ -15,7 +15,6 @@
 #include "llvm/Option/Option.h"
 #include "llvm/Support/CommandLine.h" // for expandResponseFiles
 #include "llvm/Support/Compiler.h"
-#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/OptionStrCmp.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
@@ -80,22 +79,27 @@ OptTable::OptTable(const StringTable &StrTable,
                    ArrayRef<StringTable::Offset> PrefixesTable,
                    ArrayRef<Info> OptionInfos, bool IgnoreCase,
                    ArrayRef<SubCommand> SubCommands,
-                   ArrayRef<unsigned> SubCommandIDsTable)
-    : StrTable(&StrTable), PrefixesTable(PrefixesTable),
-      OptionInfos(OptionInfos), IgnoreCase(IgnoreCase),
-      SubCommands(SubCommands), SubCommandIDsTable(SubCommandIDsTable) {
+                   ArrayRef<unsigned> SubCommandIDsTable,
+                   ArrayRef<HelpTextVariant> HelpTextVariants,
+                   ValuesCodeResolver ResolveValuesCode)
+    : StrTable(StrTable), PrefixesTable(PrefixesTable),
+      OptionInfos(OptionInfos), HelpTextVariants(HelpTextVariants),
+      IgnoreCase(IgnoreCase), SubCommands(SubCommands),
+      SubCommandIDsTable(SubCommandIDsTable),
+      ResolveValuesCode(ResolveValuesCode) {
   // Explicitly zero initialize the error to work around a bug in array
   // value-initialization on MinGW with gcc 4.3.5.
 
   // Find start of normal options.
   for (unsigned i = 0, e = getNumOptions(); i != e; ++i) {
-    unsigned Kind = getInfo(i + 1).Kind;
+    const Info &OptionInfo = getInfo(i + 1);
+    unsigned Kind = OptionInfo.Kind;
     if (Kind == Option::InputClass) {
       assert(!InputOptionID && "Cannot have multiple input options!");
-      InputOptionID = getInfo(i + 1).ID;
+      InputOptionID = OptionInfo.ID;
     } else if (Kind == Option::UnknownClass) {
       assert(!UnknownOptionID && "Cannot have multiple unknown options!");
-      UnknownOptionID = getInfo(i + 1).ID;
+      UnknownOptionID = OptionInfo.ID;
     } else if (Kind != Option::GroupClass) {
       FirstSearchableIndex = i;
       break;
@@ -107,7 +111,12 @@ OptTable::OptTable(const StringTable &StrTable,
   // Check that everything after the first searchable option is a
   // regular option class.
   for (unsigned i = FirstSearchableIndex, e = getNumOptions(); i != e; ++i) {
-    Option::OptionClass Kind = (Option::OptionClass) getInfo(i + 1).Kind;
+    const Info &OptionInfo = getInfo(i + 1);
+    assert(OptionInfo.HelpTextVariantIndex <= HelpTextVariants.size() &&
+           "option table is missing visibility-specific help metadata");
+    assert((!OptionInfo.hasValuesCode() || ResolveValuesCode) &&
+           "option table is missing a ValuesCode resolver");
+    Option::OptionClass Kind = (Option::OptionClass)OptionInfo.Kind;
     assert((Kind != Option::InputClass && Kind != Option::UnknownClass &&
             Kind != Option::GroupClass) &&
            "Special options should be defined first!");
@@ -115,7 +124,8 @@ OptTable::OptTable(const StringTable &StrTable,
 
   // Check that options are in order.
   for (unsigned i = FirstSearchableIndex + 1, e = getNumOptions(); i != e; ++i){
-    if (!(OptNameLess(StrTable, PrefixesTable)(getInfo(i), getInfo(i + 1)))) {
+    if (!(OptNameLess(this->StrTable, PrefixesTable)(getInfo(i),
+                                                     getInfo(i + 1)))) {
       getOption(i).dump();
       getOption(i + 1).dump();
       llvm_unreachable("Options are not in order!");
@@ -193,11 +203,14 @@ OptTable::suggestValueCompletions(StringRef Option, StringRef Arg) const {
   // Search all options and return possible values.
   for (size_t I = FirstSearchableIndex, E = OptionInfos.size(); I < E; I++) {
     const Info &In = OptionInfos[I];
-    if (!In.Values || !optionMatches(*StrTable, PrefixesTable, In, Option))
+    if (!In.hasValues() || !optionMatches(StrTable, PrefixesTable, In, Option))
+      continue;
+    const char *Values = getOptionValues(In);
+    if (!Values)
       continue;
 
     SmallVector<StringRef, 8> Candidates;
-    StringRef(In.Values).split(Candidates, ",", -1, false);
+    StringRef(Values).split(Candidates, ",", -1, false);
 
     std::vector<std::string> Result;
     for (StringRef Val : Candidates)
@@ -214,7 +227,8 @@ OptTable::findByPrefix(StringRef Cur, Visibility VisibilityMask,
   std::vector<std::string> Ret;
   for (size_t I = FirstSearchableIndex, E = OptionInfos.size(); I < E; I++) {
     const Info &In = OptionInfos[I];
-    const char *HelpText = In.getHelpText(VisibilityMask);
+    const char *HelpText =
+        getStringOrNull(In.getHelpTextOffset(HelpTextVariants, VisibilityMask));
     if (In.hasNoPrefix() || (!HelpText && !In.GroupID))
       continue;
     if (!(In.Visibility & VisibilityMask))
@@ -222,9 +236,9 @@ OptTable::findByPrefix(StringRef Cur, Visibility VisibilityMask,
     if (In.Flags & DisableFlags)
       continue;
 
-    StringRef Name = In.getName(*StrTable, PrefixesTable);
+    StringRef Name = In.getName(StrTable, PrefixesTable);
     for (auto PrefixOffset : In.getPrefixOffsets(PrefixesTable)) {
-      StringRef Prefix = (*StrTable)[PrefixOffset];
+      StringRef Prefix = StrTable[PrefixOffset];
       std::string S = (Twine(Prefix) + Name + "\t").str();
       if (HelpText)
         S += HelpText;
@@ -274,7 +288,7 @@ unsigned OptTable::internalFindNearest(
 
   for (const Info &CandidateInfo :
        ArrayRef<Info>(OptionInfos).drop_front(FirstSearchableIndex)) {
-    StringRef CandidateName = CandidateInfo.getName(*StrTable, PrefixesTable);
+    StringRef CandidateName = CandidateInfo.getName(StrTable, PrefixesTable);
 
     // We can eliminate some option prefix/name pairs as candidates right away:
     // * Ignore option candidates with empty names, such as "--", or names
@@ -309,7 +323,7 @@ unsigned OptTable::internalFindNearest(
     // "--help" over "-help".
     for (auto CandidatePrefixOffset :
          CandidateInfo.getPrefixOffsets(PrefixesTable)) {
-      StringRef CandidatePrefix = (*StrTable)[CandidatePrefixOffset];
+      StringRef CandidatePrefix = StrTable[CandidatePrefixOffset];
       // If Candidate and NormalizedName have more than 'BestDistance'
       // characters of difference, no need to compute the edit distance, it's
       // going to be greater than BestDistance. Don't bother computing Candidate
@@ -362,14 +376,14 @@ std::unique_ptr<Arg> OptTable::parseOneArgGrouped(InputArgList &Args,
   StringRef Name = Str.ltrim(PrefixChars);
   const Info *Start =
       std::lower_bound(OptionInfos.data() + FirstSearchableIndex, End, Name,
-                       OptNameLess(*StrTable, PrefixesTable));
+                       OptNameLess(StrTable, PrefixesTable));
   const Info *Fallback = nullptr;
   unsigned Prev = Index;
 
   // Search for the option which matches Str.
   for (; Start != End; ++Start) {
     unsigned ArgSize =
-        matchOption(*StrTable, PrefixesTable, Start, Str, IgnoreCase);
+        matchOption(StrTable, PrefixesTable, Start, Str, IgnoreCase);
     if (!ArgSize)
       continue;
 
@@ -452,7 +466,7 @@ std::unique_ptr<Arg> OptTable::internalParseOneArg(
 
   // Search for the first next option which could be a prefix.
   Start =
-      std::lower_bound(Start, End, Name, OptNameLess(*StrTable, PrefixesTable));
+      std::lower_bound(Start, End, Name, OptNameLess(StrTable, PrefixesTable));
 
   // Options are stored in sorted order, with '\0' at the end of the
   // alphabet. Since the only options which can accept a string must
@@ -467,7 +481,7 @@ std::unique_ptr<Arg> OptTable::internalParseOneArg(
     // Scan for first option which is a proper prefix.
     for (; Start != End; ++Start)
       if ((ArgSize =
-               matchOption(*StrTable, PrefixesTable, Start, Str, IgnoreCase)))
+               matchOption(StrTable, PrefixesTable, Start, Str, IgnoreCase)))
         break;
     if (Start == End)
       break;
@@ -754,20 +768,21 @@ void OptTable::internalPrintHelp(
   // pairs.
   std::map<std::string, std::vector<OptionInfo>> GroupedOptionHelp;
 
-  auto ActiveSubCommand = llvm::find_if(
-      SubCommands, [&](const auto &C) { return SubCommand == C.Name; });
+  auto ActiveSubCommand = llvm::find_if(SubCommands, [&](const auto &C) {
+    return SubCommand == getSubCommandName(C);
+  });
   if (!SubCommand.empty()) {
     assert(ActiveSubCommand != SubCommands.end() &&
            "Not a valid registered subcommand.");
-    OS << ActiveSubCommand->HelpText << "\n\n";
-    if (!StringRef(ActiveSubCommand->Usage).empty())
-      OS << "USAGE: " << ActiveSubCommand->Usage << "\n\n";
+    OS << getSubCommandHelpText(*ActiveSubCommand) << "\n\n";
+    if (!getSubCommandUsage(*ActiveSubCommand).empty())
+      OS << "USAGE: " << getSubCommandUsage(*ActiveSubCommand) << "\n\n";
   } else {
     OS << "USAGE: " << Usage << "\n\n";
     if (SubCommands.size() > 1) {
       OS << "SUBCOMMANDS:\n\n";
       for (const auto &C : SubCommands)
-        OS << C.Name << " - " << C.HelpText << "\n";
+        OS << getSubCommandName(C) << " - " << getSubCommandHelpText(C) << "\n";
       OS << "\n";
     }
   }
@@ -842,9 +857,11 @@ GenericOptTable::GenericOptTable(const StringTable &StrTable,
                                  ArrayRef<StringTable::Offset> PrefixesTable,
                                  ArrayRef<Info> OptionInfos, bool IgnoreCase,
                                  ArrayRef<SubCommand> SubCommands,
-                                 ArrayRef<unsigned> SubCommandIDsTable)
+                                 ArrayRef<unsigned> SubCommandIDsTable,
+                                 ArrayRef<HelpTextVariant> HelpTextVariants,
+                                 ValuesCodeResolver ResolveValuesCode)
     : OptTable(StrTable, PrefixesTable, OptionInfos, IgnoreCase, SubCommands,
-               SubCommandIDsTable) {
+               SubCommandIDsTable, HelpTextVariants, ResolveValuesCode) {
 
   std::set<StringRef> TmpPrefixesUnion;
   for (auto const &Info : OptionInfos.drop_front(FirstSearchableIndex))

--- a/llvm/lib/TableGen/StringToOffsetTable.cpp
+++ b/llvm/lib/TableGen/StringToOffsetTable.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/TableGen/StringToOffsetTable.h"
+#include "llvm/Support/Format.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TableGen/Error.h"
@@ -26,10 +27,9 @@ unsigned StringToOffsetTable::GetOrAddStringOffset(StringRef Str) {
   return II->second;
 }
 
-void StringToOffsetTable::EmitStringTableDef(raw_ostream &OS,
-                                             const Twine &Name) const {
-  // This generates a `llvm::StringTable` which expects that entries are null
-  // terminated. So fail with an error if `AppendZero` is false.
+void StringToOffsetTable::emitStringTableStorageDef(raw_ostream &OS,
+                                                    const Twine &Name,
+                                                    bool IsStatic) const {
   if (!AppendZero)
     PrintFatalError("llvm::StringTable requires null terminated strings");
 
@@ -38,9 +38,8 @@ void StringToOffsetTable::EmitStringTableDef(raw_ostream &OS,
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Woverlength-strings"
 #endif
-{} constexpr char {}{}Storage[] =)",
-                ClassPrefix.empty() ? "static" : "",
-                UsePrefixForStorageMember ? ClassPrefix : "", Name);
+{}constexpr char {}[] =)",
+                IsStatic ? "static " : "", Name);
 
   // MSVC silently miscompiles string literals longer than 64k in some
   // circumstances. The build system sets EmitLongStrLiterals to false when it
@@ -70,20 +69,37 @@ void StringToOffsetTable::EmitStringTableDef(raw_ostream &OS,
     }
 
     ListSeparator CharSep(", ");
-    for (char C : Str) {
-      OS << CharSep << "'";
-      OS.write_escaped(StringRef(&C, 1));
-      OS << "'";
-    }
+    for (unsigned char C : Str)
+      OS << CharSep << "'\\x" << format_hex_no_prefix(C, 2) << "'";
     OS << CharSep << "'\\0'";
   }
   OS << LineSep << (UseChars ? "};" : "  ;");
 
-  OS << formatv(R"(
+  OS << R"(
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif
+)";
+}
 
+void StringToOffsetTable::EmitStringTableStorageDef(raw_ostream &OS,
+                                                    const Twine &Name) const {
+  emitStringTableStorageDef(OS, Name, /*IsStatic=*/true);
+}
+
+void StringToOffsetTable::EmitStringTableDef(raw_ostream &OS,
+                                             const Twine &Name) const {
+  // This generates a `llvm::StringTable` which expects that entries are null
+  // terminated. So fail with an error if `AppendZero` is false.
+  SmallString<128> StorageName;
+  raw_svector_ostream StorageNameOS(StorageName);
+  if (UsePrefixForStorageMember)
+    StorageNameOS << ClassPrefix;
+  StorageNameOS << Name << "Storage";
+  emitStringTableStorageDef(OS, StorageName,
+                            /*IsStatic=*/ClassPrefix.empty());
+
+  OS << formatv(R"(
 {1} llvm::StringTable
 {2}{0} = {0}Storage;
 )",

--- a/llvm/test/TableGen/option-parser-help-variants.td
+++ b/llvm/test/TableGen/option-parser-help-variants.td
@@ -1,0 +1,29 @@
+// RUN: not llvm-tblgen -gen-opt-parser-defs -I %p/../../include \
+// RUN:   -DTOO_MANY_VARIANTS %s 2>&1 | FileCheck %s --check-prefix=VARIANTS
+// RUN: not llvm-tblgen -gen-opt-parser-defs -I %p/../../include \
+// RUN:   -DTOO_MANY_VISIBILITIES %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefix=VISIBILITIES
+
+include "llvm/Option/OptParser.td"
+
+def V1 : OptionVisibility;
+def V2 : OptionVisibility;
+def V3 : OptionVisibility;
+
+#ifdef TOO_MANY_VARIANTS
+def bad_variants : Flag<["--"], "bad-variants"> {
+  let HelpTextsForVariants = [
+    HelpTextVariant<[V1], "one">,
+    HelpTextVariant<[V2], "two">
+  ];
+}
+
+// VARIANTS: error: at most one HelpTextForVariants entry is supported
+#endif
+
+#ifdef TOO_MANY_VISIBILITIES
+def bad_visibilities : Flag<["--"], "bad-visibilities">,
+  HelpTextForVariants<[V1, V2, V3], "bad help">;
+
+// VISIBILITIES: error: at most two visibilities are supported per HelpTextForVariants entry
+#endif

--- a/llvm/test/TableGen/option-parser-offset-metadata.td
+++ b/llvm/test/TableGen/option-parser-offset-metadata.td
@@ -1,0 +1,44 @@
+// RUN: llvm-tblgen -gen-opt-parser-defs -I %p/../../include %s | FileCheck %s
+
+include "llvm/Option/OptParser.td"
+
+def ToolVis : OptionVisibility;
+def sub : SubCommand<"sub", "Subcommand help", "tool sub [options]">;
+
+def target : Joined<["--"], "target=", [sub]>,
+             HelpText<"Select the target */ safely">,
+             HelpTextForVariants<[ToolVis], "Select the tool target">,
+             MetaVarName<"<triple>">,
+             Values<"alpha,beta">;
+def target_alias : Flag<["--"], "target-host">,
+                   Alias<target>,
+                   AliasArgs<["host", "default"]>;
+def computed : Joined<["--"], "computed=">, ValuesCode<[{
+  static constexpr char VALUES_CODE[] = "gamma,delta";
+}]>;
+
+// CHECK-LABEL: #ifdef OPTTABLE_STR_TABLE_CODE
+// CHECK: static constexpr char OptionStrTable[] =
+// CHECK-NOT: llvm::StringTable
+
+// CHECK-LABEL: #ifdef OPTTABLE_OPTION_STR_TABLE_CODE
+// CHECK: static constexpr char OptionNameStrTable[] =
+// CHECK-NOT: Select the target
+
+// CHECK-LABEL: #ifdef OPTTABLE_PREFIXES_TABLE_CODE
+// CHECK: static constexpr llvm::opt::OptTable::HelpTextVariant OptionHelpTextVariants[] = {
+// CHECK: {[[#]] /* Select the tool target */, ToolVis}, // target
+
+// CHECK-LABEL: #ifdef OPTTABLE_VALUES_CODE
+// CHECK: static const char *getGeneratedOptionValues(unsigned Index) {
+// CHECK: case 0: return computed_Values;
+
+// CHECK-LABEL: // Options
+// CHECK: OPTION(1, 22 /* --computed= */, computed, Joined, INVALID, INVALID, 0, 0, DefaultVis, 0, 0, 0, 0, llvm::opt::OptTable::ValuesCodeFlag | 0, 0)
+// CHECK: OPTION(1, 34 /* --target-host */, target_alias, Flag, INVALID, target, {{[0-9]+}}, 0, DefaultVis, 0, 0, 0, 0, 0, 0)
+// CHECK: OPTION(1, 48 /* --target= */, target, Joined, INVALID, INVALID, 0, 0, DefaultVis, 0,
+// CHECK-NEXT: {{[0-9]+}} /* Select the target * / safely */, 1, {{[0-9]+}} /* <triple> */, {{[0-9]+}} /* alpha,beta */, 1)
+
+// CHECK-LABEL: #ifdef OPTTABLE_SUBCOMMANDS_CODE
+// CHECK: static constexpr llvm::opt::OptTable::SubCommand OptionSubCommands[] = {
+// CHECK-NEXT: { {{[0-9]+}} /* sub */, {{[0-9]+}} /* Subcommand help */, {{[0-9]+}} /* tool sub [options] */ },

--- a/llvm/unittests/Option/OptionMarshallingTest.cpp
+++ b/llvm/unittests/Option/OptionMarshallingTest.cpp
@@ -21,7 +21,7 @@ struct OptionWithMarshallingInfo {
   const char *ImpliedValue;
 
   llvm::StringRef getPrefixedName() const {
-    return OptionStrTable[PrefixedNameOffset];
+    return llvm::StringTable(OptionStrTable)[PrefixedNameOffset];
   }
 };
 

--- a/llvm/unittests/Option/OptionParsingTest.cpp
+++ b/llvm/unittests/Option/OptionParsingTest.cpp
@@ -24,6 +24,10 @@ using namespace llvm::opt;
 #include "Opts.inc"
 #undef OPTTABLE_STR_TABLE_CODE
 
+#define OPTTABLE_VALUES_CODE
+#include "Opts.inc"
+#undef OPTTABLE_VALUES_CODE
+
 enum ID {
   OPT_INVALID = 0, // This is not an option ID.
 #define OPTION(...) LLVM_MAKE_OPT_ID(__VA_ARGS__),
@@ -62,14 +66,19 @@ class TestOptTable : public GenericOptTable {
 public:
   TestOptTable(bool IgnoreCase = false)
       : GenericOptTable(OptionStrTable, OptionPrefixesTable, InfoTable,
-                        IgnoreCase) {}
+                        IgnoreCase, /*SubCommands=*/{},
+                        /*SubCommandIDsTable=*/{}, OptionHelpTextVariants,
+                        getGeneratedOptionValues) {}
 };
 
 class TestPrecomputedOptTable : public PrecomputedOptTable {
 public:
   TestPrecomputedOptTable(bool IgnoreCase = false)
       : PrecomputedOptTable(OptionStrTable, OptionPrefixesTable, InfoTable,
-                            OptionPrefixesUnion, IgnoreCase) {}
+                            OptionPrefixesUnion, IgnoreCase,
+                            /*SubCommands=*/{},
+                            /*SubCommandIDsTable=*/{}, OptionHelpTextVariants,
+                            getGeneratedOptionValues) {}
 };
 }
 
@@ -232,6 +241,28 @@ TYPED_TEST(OptTableTest, HelpTextForVisibilityVariants) {
               /*ShowAllAliases=*/false, Visibility(SubtoolVis));
   EXPECT_NE(std::string::npos, Help.find("The subtool variant-help text"));
   EXPECT_EQ(std::string::npos, Help.find("The default variant-help text"));
+}
+
+TYPED_TEST(OptTableTest, ValueCompletionsFromStringsAndCode) {
+  TypeParam T;
+
+  EXPECT_EQ((std::vector<std::string>{"alpha"}),
+            T.suggestValueCompletions("--values=", "a"));
+  EXPECT_EQ((std::vector<std::string>{"gamma"}),
+            T.suggestValueCompletions("--values-code=", "g"));
+}
+
+TYPED_TEST(OptTableTest, EmptyOptionalStringsArePresent) {
+  TypeParam T;
+
+  ASSERT_NE(nullptr, T.getOptionHelpText(OPT_empty_strings));
+  EXPECT_STREQ("", T.getOptionHelpText(OPT_empty_strings));
+  ASSERT_NE(nullptr, T.getOptionMetaVar(OPT_empty_strings));
+  EXPECT_STREQ("", T.getOptionMetaVar(OPT_empty_strings));
+  ASSERT_NE(nullptr,
+            T.getOptionHelpText(OPT_empty_variant, Visibility(SubtoolVis)));
+  EXPECT_STREQ("",
+               T.getOptionHelpText(OPT_empty_variant, Visibility(SubtoolVis)));
 }
 
 TYPED_TEST(OptTableTest, ParseAliasInGroup) {

--- a/llvm/unittests/Option/OptionParsingTest.cpp
+++ b/llvm/unittests/Option/OptionParsingTest.cpp
@@ -32,6 +32,11 @@ enum ID {
 #undef OPTION
 };
 
+enum OptionVisibility {
+  SubtoolVis = (1 << 2),
+  MultiLineVis = (1 << 3),
+};
+
 #define OPTTABLE_PREFIXES_TABLE_CODE
 #include "Opts.inc"
 #undef OPTTABLE_PREFIXES_TABLE_CODE
@@ -44,11 +49,6 @@ enum OptionFlags {
   OptFlag1 = (1 << 4),
   OptFlag2 = (1 << 5),
   OptFlag3 = (1 << 6)
-};
-
-enum OptionVisibility {
-  SubtoolVis = (1 << 2),
-  MultiLineVis = (1 << 3),
 };
 
 static constexpr OptTable::Info InfoTable[] = {
@@ -207,6 +207,31 @@ TYPED_TEST(OptTableTest, ParseWithVisibility) {
   EXPECT_TRUE(AL.hasArg(OPT_A));
   EXPECT_TRUE(AL.hasArg(OPT_Q));
   EXPECT_TRUE(AL.hasArg(OPT_R));
+}
+
+TYPED_TEST(OptTableTest, HelpTextForVisibilityVariants) {
+  TypeParam T;
+
+  EXPECT_STREQ("The default variant-help text",
+               T.getOptionHelpText(OPT_variant_help, Visibility(DefaultVis)));
+  EXPECT_STREQ("The subtool variant-help text",
+               T.getOptionHelpText(OPT_variant_help, Visibility(SubtoolVis)));
+  EXPECT_STREQ("The subtool variant-help text",
+               T.getOptionHelpText(OPT_variant_help, Visibility(MultiLineVis)));
+  EXPECT_EQ(StringRef("The default variant-help text"),
+            T.getOption(OPT_variant_help).getHelpText());
+
+  std::vector<std::string> Completions =
+      T.findByPrefix("--variant", Visibility(SubtoolVis), 0);
+  ASSERT_EQ(1u, Completions.size());
+  EXPECT_EQ("--variant-help\tThe subtool variant-help text", Completions[0]);
+
+  std::string Help;
+  raw_string_ostream OS(Help);
+  T.printHelp(OS, "test", "title", /*ShowHidden=*/false,
+              /*ShowAllAliases=*/false, Visibility(SubtoolVis));
+  EXPECT_NE(std::string::npos, Help.find("The subtool variant-help text"));
+  EXPECT_EQ(std::string::npos, Help.find("The default variant-help text"));
 }
 
 TYPED_TEST(OptTableTest, ParseAliasInGroup) {

--- a/llvm/unittests/Option/OptionSubCommandsTest.cpp
+++ b/llvm/unittests/Option/OptionSubCommandsTest.cpp
@@ -95,8 +95,8 @@ TYPED_TEST(OptSubCommandTableTest, SubCommandParsing) {
     const char *Args[] = {"-version"};
     InputArgList AL = T.ParseArgs(Args, MAI, MAC);
     EXPECT_TRUE(AL.hasArg(OPT_version));
-    StringRef SC = AL.getSubCommand(
-        T.getSubCommands(), HandleMultipleSubcommands, HandleOtherPositionals);
+    StringRef SC =
+        AL.getSubCommand(T, HandleMultipleSubcommands, HandleOtherPositionals);
     EXPECT_TRUE(SC.empty());
     EXPECT_FALSE(AL.hasArg(OPT_uppercase));
     EXPECT_FALSE(AL.hasArg(OPT_lowercase));
@@ -106,8 +106,8 @@ TYPED_TEST(OptSubCommandTableTest, SubCommandParsing) {
     // Test case 2: Subcommand 'foo' with its valid options
     const char *Args[] = {"foo", "-uppercase"};
     InputArgList AL = T.ParseArgs(Args, MAI, MAC);
-    StringRef SC = AL.getSubCommand(
-        T.getSubCommands(), HandleMultipleSubcommands, HandleOtherPositionals);
+    StringRef SC =
+        AL.getSubCommand(T, HandleMultipleSubcommands, HandleOtherPositionals);
     EXPECT_EQ(SC, "foo");
     EXPECT_TRUE(AL.hasArg(OPT_uppercase));
     EXPECT_FALSE(AL.hasArg(OPT_lowercase));
@@ -123,8 +123,8 @@ TYPED_TEST(OptSubCommandTableTest, SubCommandParsing) {
     // subcommand option.
     const char *Args[] = {"-uppercase", "foo"};
     InputArgList AL = T.ParseArgs(Args, MAI, MAC);
-    StringRef SC = AL.getSubCommand(
-        T.getSubCommands(), HandleMultipleSubcommands, HandleOtherPositionals);
+    StringRef SC =
+        AL.getSubCommand(T, HandleMultipleSubcommands, HandleOtherPositionals);
     EXPECT_EQ(SC, "foo");
     EXPECT_TRUE(AL.hasArg(OPT_uppercase));
     EXPECT_FALSE(AL.hasArg(OPT_lowercase));
@@ -139,8 +139,8 @@ TYPED_TEST(OptSubCommandTableTest, SubCommandParsing) {
     // Test case 4: Check invalid use of passing multiple subcommands.
     const char *Args[] = {"-uppercase", "foo", "bar"};
     InputArgList AL = T.ParseArgs(Args, MAI, MAC);
-    StringRef SC = AL.getSubCommand(
-        T.getSubCommands(), HandleMultipleSubcommands, HandleOtherPositionals);
+    StringRef SC =
+        AL.getSubCommand(T, HandleMultipleSubcommands, HandleOtherPositionals);
     // No valid subcommand should be returned as this is an invalid invocation.
     EXPECT_TRUE(SC.empty());
     // Expect the multiple subcommands error message.
@@ -155,8 +155,8 @@ TYPED_TEST(OptSubCommandTableTest, SubCommandParsing) {
     // Test case 5: Check invalid use of passing unregistered subcommands.
     const char *Args[] = {"foobar"};
     InputArgList AL = T.ParseArgs(Args, MAI, MAC);
-    StringRef SC = AL.getSubCommand(
-        T.getSubCommands(), HandleMultipleSubcommands, HandleOtherPositionals);
+    StringRef SC =
+        AL.getSubCommand(T, HandleMultipleSubcommands, HandleOtherPositionals);
     // No valid subcommand should be returned as this is an invalid invocation.
     EXPECT_TRUE(SC.empty());
     // Expect the unregistered subcommands error message.
@@ -171,8 +171,8 @@ TYPED_TEST(OptSubCommandTableTest, SubCommandParsing) {
     // subcommand.
     const char *Args[] = {"-lowercase", "bar"};
     InputArgList AL = T.ParseArgs(Args, MAI, MAC);
-    StringRef SC = AL.getSubCommand(
-        T.getSubCommands(), HandleMultipleSubcommands, HandleOtherPositionals);
+    StringRef SC =
+        AL.getSubCommand(T, HandleMultipleSubcommands, HandleOtherPositionals);
     auto HandleSubCommandArg = [&](ID OptionType) {
       if (!AL.hasArg(OptionType))
         return false;
@@ -198,8 +198,8 @@ TYPED_TEST(OptSubCommandTableTest, SubCommandParsing) {
     // positional arguments.
     const char *Args[] = {"bar", "input"};
     InputArgList AL = T.ParseArgs(Args, MAI, MAC);
-    StringRef SC = AL.getSubCommand(
-        T.getSubCommands(), HandleMultipleSubcommands, HandleOtherPositionals);
+    StringRef SC =
+        AL.getSubCommand(T, HandleMultipleSubcommands, HandleOtherPositionals);
     EXPECT_EQ(SC, "bar"); // valid subcommand
     EXPECT_NE(std::string::npos,
               ErrMsg.find("Unregistered positionals passed"));

--- a/llvm/unittests/Option/Opts.td
+++ b/llvm/unittests/Option/Opts.td
@@ -40,6 +40,11 @@ def Doopf1 : Flag<["-"], "doopf1">, HelpText<"The doopf1 option">, Flags<[OptFla
 def Doopf2 : Flag<["-"], "doopf2">, HelpText<"The doopf2 option">, Flags<[OptFlag2]>;
 def Xyzzy1 : Flag<["-"], "xyzzy1">, HelpText<"The xyzzy1 option">, Visibility<[SubtoolVis]>;
 def Xyzzy2 : Flag<["-"], "xyzzy2">, HelpText<"The xyzzy2 option">, Visibility<[DefaultVis]>;
+def variant_help : Flag<["--"], "variant-help">,
+  HelpText<"The default variant-help text">,
+  HelpTextForVariants<[SubtoolVis, MultiLineVis],
+                      "The subtool variant-help text">,
+  Visibility<[DefaultVis, SubtoolVis]>;
 def Ermgh : Joined<["--"], "ermgh">, HelpText<"The ermgh option">, MetaVarName<"ERMGH">, Flags<[OptFlag1]>;
 def Fjormp : Flag<["--"], "fjormp">, HelpText<"The fjormp option">, Flags<[OptFlag1]>;
 

--- a/llvm/unittests/Option/Opts.td
+++ b/llvm/unittests/Option/Opts.td
@@ -56,6 +56,18 @@ def Blurmpq_eq : Flag<["--"], "blurmp=">;
 def Q : Flag<["-"], "Q">, Visibility<[SubtoolVis]>;
 def R : Flag<["-"], "R">, Visibility<[DefaultVis, SubtoolVis]>;
 
+def values : Joined<["--"], "values=">, Values<"alpha,beta">;
+def values_code : Joined<["--"], "values-code=">, ValuesCode<[{
+  static constexpr const char VALUES_CODE[] = "gamma,delta";
+}]>;
+def empty_strings : Joined<["--"], "empty-strings=">,
+                    HelpText<"">,
+                    MetaVarName<"">,
+                    Values<"">;
+def empty_variant : Flag<["--"], "empty-variant">,
+                    HelpText<"default help">,
+                    HelpTextForVariants<[SubtoolVis], "">;
+
 def multiline_help : Flag<["-"], "multiline-help">, HelpText<"This a help text that has\nmultiple lines in it">, Visibility<[MultiLineVis]>;
 
 def multiline_help_long :

--- a/llvm/unittests/TableGen/CMakeLists.txt
+++ b/llvm/unittests/TableGen/CMakeLists.txt
@@ -13,6 +13,7 @@ add_llvm_unittest(TableGenTests
   AutomataTest.cpp
   CodeExpanderTest.cpp
   ParserEntryPointTest.cpp
+  StringToOffsetTableTest.cpp
 
   DISABLE_LLVM_LINK_LLVM_DYLIB
   )

--- a/llvm/unittests/TableGen/StringToOffsetTableTest.cpp
+++ b/llvm/unittests/TableGen/StringToOffsetTableTest.cpp
@@ -1,0 +1,33 @@
+//===- StringToOffsetTableTest.cpp ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/TableGen/StringToOffsetTable.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/TableGen/Main.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+
+namespace {
+
+TEST(StringToOffsetTableTest, EscapesCharactersInLongTables) {
+  StringToOffsetTable Table;
+  Table.GetOrAddStringOffset(std::string(64 * 1024, '\''));
+
+  bool Previous = EmitLongStrLiterals;
+  EmitLongStrLiterals = false;
+  std::string Output;
+  raw_string_ostream OS(Output);
+  Table.EmitStringTableStorageDef(OS, "Strings");
+  EmitLongStrLiterals = Previous;
+
+  EXPECT_NE(Output.find("'\\x27'"), std::string::npos);
+  EXPECT_EQ(Output.find("'''"), std::string::npos);
+}
+
+} // namespace

--- a/llvm/utils/TableGen/OptionParserEmitter.cpp
+++ b/llvm/utils/TableGen/OptionParserEmitter.cpp
@@ -13,8 +13,8 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Option/OptTable.h"
-#include "llvm/Support/InterleavedRange.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/TableGen/Error.h"
 #include "llvm/TableGen/Record.h"
 #include "llvm/TableGen/StringToOffsetTable.h"
 #include "llvm/TableGen/TableGenBackend.h"
@@ -204,50 +204,68 @@ static MarshallingInfo createMarshallingInfo(const Record &R) {
   return Ret;
 }
 
-static void emitHelpTextsForVariants(
-    raw_ostream &OS, std::vector<std::pair<std::vector<std::string>, StringRef>>
-                         HelpTextsForVariants) {
-  // OptTable must be constexpr so it uses std::arrays with these capacities.
+struct HelpTextVariant {
+  std::vector<std::string> Visibilities;
+  StringRef Text;
+};
+
+static std::optional<HelpTextVariant> getHelpTextVariant(const Record &R) {
   const unsigned MaxVisibilityPerHelp = 2;
   const unsigned MaxVisibilityHelp = 1;
 
-  assert(HelpTextsForVariants.size() <= MaxVisibilityHelp &&
-         "Too many help text variants to store in "
-         "OptTable::HelpTextsForVariants");
+  std::vector<const Record *> Variants =
+      R.getValueAsListOfDefs("HelpTextsForVariants");
+  if (Variants.size() > MaxVisibilityHelp)
+    PrintFatalError(R.getLoc(),
+                    "at most one HelpTextForVariants entry is supported");
+  if (Variants.empty())
+    return std::nullopt;
 
-  // This function must initialise any unused elements of those arrays.
-  for (auto [Visibilities, _] : HelpTextsForVariants)
-    while (Visibilities.size() < MaxVisibilityPerHelp)
-      Visibilities.push_back("0");
+  const Record &Variant = *Variants.front();
+  ArrayRef<const Init *> VisibilityInits =
+      Variant.getValueAsListInit("Visibilities")->getElements();
+  if (VisibilityInits.size() > MaxVisibilityPerHelp)
+    PrintFatalError(
+        Variant.getLoc(),
+        "at most two visibilities are supported per HelpTextForVariants entry");
 
-  while (HelpTextsForVariants.size() < MaxVisibilityHelp)
-    HelpTextsForVariants.push_back(
-        {std::vector<std::string>(MaxVisibilityPerHelp, "0"), ""});
+  HelpTextVariant Result;
+  for (const Init *Visibility : VisibilityInits)
+    Result.Visibilities.push_back(Visibility->getAsUnquotedString());
+  Result.Text = Variant.getValueAsString("Text");
+  return Result;
+}
 
-  OS << ", (std::array<std::pair<std::array<unsigned, " << MaxVisibilityPerHelp
-     << ">, const char*>, " << MaxVisibilityHelp << ">{{ ";
+struct IndexedHelpTextVariant {
+  const Record *Option;
+  HelpTextVariant Variant;
+};
 
-  auto VisibilityHelpEnd = HelpTextsForVariants.cend();
-  for (auto VisibilityHelp = HelpTextsForVariants.cbegin();
-       VisibilityHelp != VisibilityHelpEnd; ++VisibilityHelp) {
-    auto [Visibilities, Help] = *VisibilityHelp;
+static void
+emitHelpTextVariants(raw_ostream &OS,
+                     ArrayRef<IndexedHelpTextVariant> HelpTextVariants) {
+  if (HelpTextVariants.empty())
+    return;
 
-    assert(Visibilities.size() <= MaxVisibilityPerHelp &&
-           "Too many visibilities to store in an "
-           "OptTable::HelpTextsForVariants entry");
-    OS << "{std::array<unsigned, " << MaxVisibilityPerHelp << ">{{"
-       << llvm::interleaved(Visibilities) << "}}, ";
-
-    if (Help.size())
-      writeCstring(OS, Help);
+  OS << "\nstatic constexpr llvm::opt::OptTable::HelpTextVariants "
+        "OptionHelpTextVariants[] = {\n";
+  for (const IndexedHelpTextVariant &Entry : HelpTextVariants) {
+    OS << "  {";
+    if (!isa<UnsetInit>(Entry.Option->getValueInit("HelpText")))
+      writeCstring(OS, Entry.Option->getValueAsString("HelpText"));
     else
       OS << "nullptr";
-    OS << "}";
-
-    if (std::next(VisibilityHelp) != VisibilityHelpEnd)
-      OS << ", ";
+    OS << ", ";
+    writeCstring(OS, Entry.Variant.Text);
+    OS << ", ";
+    llvm::ListSeparator Sep(" | ");
+    for (const std::string &Visibility : Entry.Variant.Visibilities)
+      OS << Sep << Visibility;
+    if (Entry.Variant.Visibilities.empty())
+      OS << "0";
+    OS << "}, // " << getOptionName(*Entry.Option) << "\n";
   }
-  OS << " }})";
+  OS << "};\n";
 }
 
 /// OptionParserEmitter - This tablegen backend takes an input .td file
@@ -259,6 +277,15 @@ static void emitOptionParser(const RecordKeeper &Records, raw_ostream &OS) {
       Records.getAllDerivedDefinitions("OptionGroup");
   std::vector<const Record *> Opts = Records.getAllDerivedDefinitions("Option");
   llvm::sort(Opts, IsOptionRecordsLess);
+
+  std::map<const Record *, unsigned> HelpTextVariantIndices;
+  std::vector<IndexedHelpTextVariant> HelpTextVariants;
+  for (const Record &R : llvm::make_pointee_range(Opts)) {
+    if (std::optional<HelpTextVariant> Variant = getHelpTextVariant(R)) {
+      HelpTextVariantIndices.try_emplace(&R, HelpTextVariants.size());
+      HelpTextVariants.push_back({&R, std::move(*Variant)});
+    }
+  }
 
   std::vector<const Record *> SubCommands =
       Records.getAllDerivedDefinitions("SubCommand");
@@ -355,6 +382,7 @@ static void emitOptionParser(const RecordKeeper &Records, raw_ostream &OS) {
     }
   }
   OS << "\n};\n";
+  emitHelpTextVariants(OS, HelpTextVariants);
   OS << "#endif // OPTTABLE_PREFIXES_TABLE_CODE\n\n";
 
   // Dump subcommand IDs.
@@ -461,8 +489,8 @@ static void emitOptionParser(const RecordKeeper &Records, raw_ostream &OS) {
       OS << ", nullptr";
     }
 
-    // Not using Visibility specific text for group help.
-    emitHelpTextsForVariants(OS, {});
+    // Groups do not use visibility-specific help text.
+    OS << ", false";
 
     // The option meta-variable name (unused).
     OS << ", nullptr";
@@ -560,30 +588,20 @@ static void emitOptionParser(const RecordKeeper &Records, raw_ostream &OS) {
     // The option parameter field.
     OS << ", " << R.getValueAsInt("NumArgs");
 
-    // The option help text.
-    if (!isa<UnsetInit>(R.getValueInit("HelpText"))) {
+    // The option help text. Options with visibility-specific help point to a
+    // sparse descriptor emitted next to the option prefix table.
+    auto HelpTextVariant = HelpTextVariantIndices.find(&R);
+    if (HelpTextVariant != HelpTextVariantIndices.end()) {
+      OS << ",\n       &OptionHelpTextVariants[" << HelpTextVariant->second
+         << "]";
+    } else if (!isa<UnsetInit>(R.getValueInit("HelpText"))) {
       OS << ",\n";
       OS << "       ";
       writeCstring(OS, R.getValueAsString("HelpText"));
     } else {
       OS << ", nullptr";
     }
-
-    std::vector<std::pair<std::vector<std::string>, StringRef>>
-        HelpTextsForVariants;
-    for (const Record *VisibilityHelp :
-         R.getValueAsListOfDefs("HelpTextsForVariants")) {
-      ArrayRef<const Init *> Visibilities =
-          VisibilityHelp->getValueAsListInit("Visibilities")->getElements();
-
-      std::vector<std::string> VisibilityNames;
-      for (const Init *Visibility : Visibilities)
-        VisibilityNames.push_back(Visibility->getAsUnquotedString());
-
-      HelpTextsForVariants.emplace_back(
-          VisibilityNames, VisibilityHelp->getValueAsString("Text"));
-    }
-    emitHelpTextsForVariants(OS, std::move(HelpTextsForVariants));
+    OS << ", " << (HelpTextVariant != HelpTextVariantIndices.end());
 
     // The option meta-variable name.
     OS << ", ";

--- a/llvm/utils/TableGen/OptionParserEmitter.cpp
+++ b/llvm/utils/TableGen/OptionParserEmitter.cpp
@@ -19,6 +19,7 @@
 #include "llvm/TableGen/StringToOffsetTable.h"
 #include "llvm/TableGen/TableGenBackend.h"
 #include <cstring>
+#include <limits>
 #include <map>
 
 using namespace llvm;
@@ -31,11 +32,31 @@ static std::string getOptionName(const Record &R) {
   return R.getValueAsString("EnumName").str();
 }
 
+static void writeCommentText(raw_ostream &OS, StringRef Str) {
+  for (size_t I = 0; I < Str.size(); ++I) {
+    if (I + 1 < Str.size() && Str[I] == '*' && Str[I + 1] == '/') {
+      OS << "* /";
+      ++I;
+      continue;
+    }
+    OS.write_escaped(Str.substr(I, 1));
+  }
+}
+
 static raw_ostream &writeStrTableOffset(raw_ostream &OS,
                                         const StringToOffsetTable &Table,
                                         llvm::StringRef Str) {
   OS << Table.GetStringOffset(Str) << " /* ";
-  OS.write_escaped(Str);
+  writeCommentText(OS, Str);
+  OS << " */";
+  return OS;
+}
+
+static raw_ostream &
+writeOptionalStrTableOffset(raw_ostream &OS, const StringToOffsetTable &Table,
+                            llvm::StringRef Str) {
+  OS << *Table.GetStringOffset(Str) + 1 << " /* ";
+  writeCommentText(OS, Str);
   OS << " */";
   return OS;
 }
@@ -55,6 +76,15 @@ static std::string getOptionPrefixedName(const Record &R) {
     return Name.str();
 
   return (Prefixes[0] + Twine(Name)).str();
+}
+
+static std::string getAliasArgs(const Record &R) {
+  std::string Result;
+  for (StringRef AliasArg : R.getValueAsListOfStrings("AliasArgs")) {
+    Result.append(AliasArg);
+    Result.push_back('\0');
+  }
+  return Result;
 }
 
 class MarshallingInfo {
@@ -243,20 +273,16 @@ struct IndexedHelpTextVariant {
 
 static void
 emitHelpTextVariants(raw_ostream &OS,
-                     ArrayRef<IndexedHelpTextVariant> HelpTextVariants) {
+                     ArrayRef<IndexedHelpTextVariant> HelpTextVariants,
+                     const StringToOffsetTable &Table) {
   if (HelpTextVariants.empty())
     return;
 
-  OS << "\nstatic constexpr llvm::opt::OptTable::HelpTextVariants "
+  OS << "\nstatic constexpr llvm::opt::OptTable::HelpTextVariant "
         "OptionHelpTextVariants[] = {\n";
   for (const IndexedHelpTextVariant &Entry : HelpTextVariants) {
     OS << "  {";
-    if (!isa<UnsetInit>(Entry.Option->getValueInit("HelpText")))
-      writeCstring(OS, Entry.Option->getValueAsString("HelpText"));
-    else
-      OS << "nullptr";
-    OS << ", ";
-    writeCstring(OS, Entry.Variant.Text);
+    writeOptionalStrTableOffset(OS, Table, Entry.Variant.Text);
     OS << ", ";
     llvm::ListSeparator Sep(" | ");
     for (const std::string &Visibility : Entry.Variant.Visibilities)
@@ -266,6 +292,8 @@ emitHelpTextVariants(raw_ostream &OS,
     OS << "}, // " << getOptionName(*Entry.Option) << "\n";
   }
   OS << "};\n";
+  OS << "static_assert(sizeof(OptionHelpTextVariants) / "
+        "sizeof(OptionHelpTextVariants[0]) <= 65535);\n";
 }
 
 /// OptionParserEmitter - This tablegen backend takes an input .td file
@@ -280,12 +308,22 @@ static void emitOptionParser(const RecordKeeper &Records, raw_ostream &OS) {
 
   std::map<const Record *, unsigned> HelpTextVariantIndices;
   std::vector<IndexedHelpTextVariant> HelpTextVariants;
+  std::map<const Record *, unsigned> ValuesCodeIndices;
+  std::vector<const Record *> ValuesCodeOptions;
   for (const Record &R : llvm::make_pointee_range(Opts)) {
     if (std::optional<HelpTextVariant> Variant = getHelpTextVariant(R)) {
       HelpTextVariantIndices.try_emplace(&R, HelpTextVariants.size());
       HelpTextVariants.push_back({&R, std::move(*Variant)});
     }
+    if (!isa<UnsetInit>(R.getValueInit("ValuesCode"))) {
+      ValuesCodeIndices.try_emplace(&R, ValuesCodeIndices.size());
+      ValuesCodeOptions.push_back(&R);
+    }
   }
+  if (HelpTextVariants.size() > std::numeric_limits<uint16_t>::max())
+    PrintFatalError("too many visibility-specific help text entries");
+  if (ValuesCodeIndices.size() >= llvm::opt::OptTable::ValuesCodeFlag)
+    PrintFatalError("too many ValuesCode entries");
 
   std::vector<const Record *> SubCommands =
       Records.getAllDerivedDefinitions("SubCommand");
@@ -339,21 +377,60 @@ static void emitOptionParser(const RecordKeeper &Records, raw_ostream &OS) {
                                        PrefixesUnionSet.end());
   array_pod_sort(PrefixesUnion.begin(), PrefixesUnion.end());
 
+  llvm::StringToOffsetTable NameTable;
   llvm::StringToOffsetTable Table;
-  // We can add all the prefixes via the union.
+  std::map<const Record *, unsigned> AliasArgsOffsets;
+  auto AddName = [&](StringRef Name) {
+    [[maybe_unused]] unsigned NameOffset = NameTable.GetOrAddStringOffset(Name);
+    [[maybe_unused]] unsigned TableOffset = Table.GetOrAddStringOffset(Name);
+    assert(NameOffset == TableOffset &&
+           "option name offsets must match the full string table");
+  };
+
+  // Keep every string referenced by PREFIXED_NAME_OFFSET in a compact prefix
+  // of the full table. Some generated-code consumers only need these names.
   for (const auto &Prefix : PrefixesUnion)
-    Table.GetOrAddStringOffset(Prefix);
+    AddName(Prefix);
   for (const Record &R : llvm::make_pointee_range(Groups))
-    Table.GetOrAddStringOffset(R.getValueAsString("Name"));
+    AddName(R.getValueAsString("Name"));
   for (const Record &R : llvm::make_pointee_range(Opts))
-    Table.GetOrAddStringOffset(getOptionPrefixedName(R));
+    AddName(getOptionPrefixedName(R));
+
+  for (const Record &R : llvm::make_pointee_range(Groups)) {
+    if (!isa<UnsetInit>(R.getValueInit("HelpText")))
+      Table.GetOrAddStringOffset(R.getValueAsString("HelpText"));
+  }
+  for (const Record &R : llvm::make_pointee_range(Opts)) {
+    if (!isa<UnsetInit>(R.getValueInit("HelpText")))
+      Table.GetOrAddStringOffset(R.getValueAsString("HelpText"));
+    if (!isa<UnsetInit>(R.getValueInit("MetaVarName")))
+      Table.GetOrAddStringOffset(R.getValueAsString("MetaVarName"));
+    if (!isa<UnsetInit>(R.getValueInit("Values")))
+      Table.GetOrAddStringOffset(R.getValueAsString("Values"));
+    std::string AliasArgs = getAliasArgs(R);
+    if (!AliasArgs.empty())
+      AliasArgsOffsets.try_emplace(&R, Table.GetOrAddStringOffset(AliasArgs));
+  }
+  for (const IndexedHelpTextVariant &Entry : HelpTextVariants)
+    Table.GetOrAddStringOffset(Entry.Variant.Text);
+  for (const Record *SubCommand : SubCommands) {
+    Table.GetOrAddStringOffset(SubCommand->getValueAsString("Name"));
+    Table.GetOrAddStringOffset(SubCommand->getValueAsString("HelpText"));
+    Table.GetOrAddStringOffset(SubCommand->getValueAsString("Usage"));
+  }
+  if (Table.size() + 1 >= llvm::opt::OptTable::ValuesCodeFlag)
+    PrintFatalError("option string table exceeds the ValuesCode encoding");
 
   // Dump string table.
   OS << "/////////\n";
   OS << "// String table\n\n";
   OS << "#ifdef OPTTABLE_STR_TABLE_CODE\n";
-  Table.EmitStringTableDef(OS, "OptionStrTable");
+  Table.EmitStringTableStorageDef(OS, "OptionStrTable");
+  OS << "static_assert(sizeof(OptionStrTable) < (1U << 31));\n";
   OS << "#endif // OPTTABLE_STR_TABLE_CODE\n\n";
+  OS << "#ifdef OPTTABLE_OPTION_STR_TABLE_CODE\n";
+  NameTable.EmitStringTableStorageDef(OS, "OptionNameStrTable");
+  OS << "#endif // OPTTABLE_OPTION_STR_TABLE_CODE\n\n";
 
   // Dump prefixes.
   OS << "/////////\n";
@@ -382,7 +459,7 @@ static void emitOptionParser(const RecordKeeper &Records, raw_ostream &OS) {
     }
   }
   OS << "\n};\n";
-  emitHelpTextVariants(OS, HelpTextVariants);
+  emitHelpTextVariants(OS, HelpTextVariants, Table);
   OS << "#endif // OPTTABLE_PREFIXES_TABLE_CODE\n\n";
 
   // Dump subcommand IDs.
@@ -448,6 +525,18 @@ static void emitOptionParser(const RecordKeeper &Records, raw_ostream &OS) {
       OS << "#undef VALUES_CODE\n";
     }
   }
+  if (!ValuesCodeIndices.empty()) {
+    OS << "static_assert(" << ValuesCodeIndices.size()
+       << " <= llvm::opt::OptTable::ValuesCodeFlag);\n";
+    OS << "static const char *getGeneratedOptionValues(unsigned Index) {\n"
+          "  switch (Index) {\n";
+    for (auto [Index, Option] : llvm::enumerate(ValuesCodeOptions))
+      OS << "  case " << Index << ": return " << getOptionName(*Option)
+         << "_Values;\n";
+    OS << "  default: return nullptr;\n"
+          "  }\n"
+          "}\n";
+  }
   OS << "#endif\n";
 
   OS << "/////////\n";
@@ -478,25 +567,25 @@ static void emitOptionParser(const RecordKeeper &Records, raw_ostream &OS) {
       OS << "INVALID";
 
     // The other option arguments (unused for groups).
-    OS << ", INVALID, nullptr, 0, 0, 0";
+    OS << ", INVALID, 0, 0, 0, 0";
 
     // The option help text.
     if (!isa<UnsetInit>(R.getValueInit("HelpText"))) {
       OS << ",\n";
       OS << "       ";
-      writeCstring(OS, R.getValueAsString("HelpText"));
+      writeOptionalStrTableOffset(OS, Table, R.getValueAsString("HelpText"));
     } else {
-      OS << ", nullptr";
+      OS << ", 0";
     }
 
     // Groups do not use visibility-specific help text.
-    OS << ", false";
+    OS << ", 0";
 
     // The option meta-variable name (unused).
-    OS << ", nullptr";
+    OS << ", 0";
 
     // The option Values (unused for groups).
-    OS << ", nullptr";
+    OS << ", 0";
 
     // The option SubCommandIDsOffset.
     OS << ", ";
@@ -541,20 +630,11 @@ static void emitOptionParser(const RecordKeeper &Records, raw_ostream &OS) {
     else
       OS << "INVALID";
 
-    // The option alias arguments (if any).
-    // Emitted as a \0 separated list in a string, e.g. ["foo", "bar"]
-    // would become "foo\0bar\0". Note that the compiler adds an implicit
-    // terminating \0 at the end.
+    // The option alias arguments (if any), encoded as a \0 separated list in
+    // the string table.
     OS << ", ";
-    std::vector<StringRef> AliasArgs = R.getValueAsListOfStrings("AliasArgs");
-    if (AliasArgs.size() == 0) {
-      OS << "nullptr";
-    } else {
-      OS << "\"";
-      for (StringRef AliasArg : AliasArgs)
-        OS << AliasArg << "\\0";
-      OS << "\"";
-    }
+    auto AliasArgs = AliasArgsOffsets.find(&R);
+    OS << (AliasArgs == AliasArgsOffsets.end() ? 0 : AliasArgs->second + 1);
 
     // "Flags" for the option, such as HelpHidden and Render*
     OS << ", ";
@@ -588,36 +668,38 @@ static void emitOptionParser(const RecordKeeper &Records, raw_ostream &OS) {
     // The option parameter field.
     OS << ", " << R.getValueAsInt("NumArgs");
 
-    // The option help text. Options with visibility-specific help point to a
-    // sparse descriptor emitted next to the option prefix table.
-    auto HelpTextVariant = HelpTextVariantIndices.find(&R);
-    if (HelpTextVariant != HelpTextVariantIndices.end()) {
-      OS << ",\n       &OptionHelpTextVariants[" << HelpTextVariant->second
-         << "]";
-    } else if (!isa<UnsetInit>(R.getValueInit("HelpText"))) {
+    // The option help text.
+    if (!isa<UnsetInit>(R.getValueInit("HelpText"))) {
       OS << ",\n";
       OS << "       ";
-      writeCstring(OS, R.getValueAsString("HelpText"));
+      writeOptionalStrTableOffset(OS, Table, R.getValueAsString("HelpText"));
     } else {
-      OS << ", nullptr";
+      OS << ", 0";
     }
-    OS << ", " << (HelpTextVariant != HelpTextVariantIndices.end());
+
+    // The one-based visibility-specific help descriptor index.
+    auto HelpTextVariant = HelpTextVariantIndices.find(&R);
+    OS << ", "
+       << (HelpTextVariant == HelpTextVariantIndices.end()
+               ? 0
+               : HelpTextVariant->second + 1);
 
     // The option meta-variable name.
     OS << ", ";
     if (!isa<UnsetInit>(R.getValueInit("MetaVarName")))
-      writeCstring(OS, R.getValueAsString("MetaVarName"));
+      writeOptionalStrTableOffset(OS, Table, R.getValueAsString("MetaVarName"));
     else
-      OS << "nullptr";
+      OS << "0";
 
     // The option Values. Used for shell autocompletion.
     OS << ", ";
     if (!isa<UnsetInit>(R.getValueInit("Values")))
-      writeCstring(OS, R.getValueAsString("Values"));
-    else if (!isa<UnsetInit>(R.getValueInit("ValuesCode")))
-      OS << getOptionName(R) << "_Values";
+      writeOptionalStrTableOffset(OS, Table, R.getValueAsString("Values"));
+    else if (auto ValuesCode = ValuesCodeIndices.find(&R);
+             ValuesCode != ValuesCodeIndices.end())
+      OS << "llvm::opt::OptTable::ValuesCodeFlag | " << ValuesCode->second;
     else
-      OS << "nullptr";
+      OS << "0";
 
     // The option SubCommandIDsOffset.
     OS << ", ";
@@ -697,9 +779,13 @@ static void emitOptionParser(const RecordKeeper &Records, raw_ostream &OS) {
         "= "
         "{\n";
   for (const Record *SubCommand : SubCommands) {
-    OS << "  { \"" << SubCommand->getValueAsString("Name") << "\", ";
-    OS << "\"" << SubCommand->getValueAsString("HelpText") << "\", ";
-    OS << "\"" << SubCommand->getValueAsString("Usage") << "\" },\n";
+    OS << "  { ";
+    writeStrTableOffset(OS, Table, SubCommand->getValueAsString("Name"));
+    OS << ", ";
+    writeStrTableOffset(OS, Table, SubCommand->getValueAsString("HelpText"));
+    OS << ", ";
+    writeStrTableOffset(OS, Table, SubCommand->getValueAsString("Usage"));
+    OS << " },\n";
   }
   OS << "};\n";
   OS << "#endif // OPTTABLE_SUBCOMMANDS_CODE\n\n";


### PR DESCRIPTION
This is stacked on #202653. It replaces the remaining pointer-bearing generated option metadata with scalar offsets into one byte string table, encodes `ValuesCode` as a tagged index resolved once by `OptTable`, and adds compile-time layout and range assertions.

In an arm64 Release build, the incremental change reduces `DriverOptions.cpp.o` by 144,632 bytes and a linked option-completion benchmark by 49,488 bytes; object relocations fall from 2,758 to 94 and linked dyld fixups from 2,891 to 211. The benchmark is 148,536 bytes smaller than main before both stacked changes.

Validated with 55 Option tests, the StringToOffsetTable unit test, two focused TableGen tests, the full 421-test TableGen suite, representative option-table consumers, and hot/cold completion benchmarks with no performance regression.

Work towards #202616

AI tool disclosure: Co-authored with OpenAI Codex.
