### PR TITLE
[mlir][linalg] Add inverse triag, log  to elementwise ops

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgEnums.td
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgEnums.td
@@ -32,7 +32,16 @@ def UnaryFn : I32EnumAttr<"UnaryFn", "", [
   I32EnumAttrCase<"erf", 12>,
   I32EnumAttrCase<"sin", 13>,
   I32EnumAttrCase<"cos", 14>,
-  I32EnumAttrCase<"tan", 15>
+  I32EnumAttrCase<"tan", 15>,
+  I32EnumAttrCase<"acos", 16>,
+  I32EnumAttrCase<"acosh", 17>,
+  I32EnumAttrCase<"asin", 18>,
+  I32EnumAttrCase<"asinh", 19>,
+  I32EnumAttrCase<"atan", 20>,
+  I32EnumAttrCase<"atanh", 21>,
+  I32EnumAttrCase<"log10", 22>,
+  I32EnumAttrCase<"log1p", 23>,
+  I32EnumAttrCase<"log2", 24>
 ]> {
   let genSpecializedAttr = 0;
   let cppNamespace = "::mlir::linalg";

--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -509,6 +509,24 @@ public:
       return math::CosOp::create(builder, arg.getLoc(), arg);
     case UnaryFn::tan:
       return math::TanOp::create(builder, arg.getLoc(), arg);
+    case UnaryFn::acos:
+      return math::AcosOp::create(builder, arg.getLoc(), arg);
+    case UnaryFn::acosh:
+      return math::AcoshOp::create(builder, arg.getLoc(), arg);
+    case UnaryFn::asin:
+      return math::AsinOp::create(builder, arg.getLoc(), arg);
+    case UnaryFn::asinh:
+      return math::AsinhOp::create(builder, arg.getLoc(), arg);
+    case UnaryFn::atan:
+      return math::AtanOp::create(builder, arg.getLoc(), arg);
+    case UnaryFn::atanh:
+      return math::AtanhOp::create(builder, arg.getLoc(), arg);
+    case UnaryFn::log10:
+      return math::Log10Op::create(builder, arg.getLoc(), arg);
+    case UnaryFn::log1p:
+      return math::Log1pOp::create(builder, arg.getLoc(), arg);
+    case UnaryFn::log2:
+      return math::Log2Op::create(builder, arg.getLoc(), arg);
     }
     if (emitError) {
       emitError() << "unsupported unary function";

--- a/mlir/lib/Dialect/Linalg/Transforms/Specialize.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Specialize.cpp
@@ -224,7 +224,7 @@ static FailureOr<LinalgOp> specializeLinalgElementwise(RewriterBase &rewriter,
     if (isa<math::ErfOp>(op))
       return replaceOp(ErfOp{}, ElementwiseKind::erf);
 
-    // sin, cos, tan only have the category (elementwise) form, but no
+    // The following ops only have the category (elementwise) form, but no
     // linalg.* named op equivalent.
     if (emitCategoryOp) {
       if (isa<math::SinOp>(op))
@@ -233,6 +233,24 @@ static FailureOr<LinalgOp> specializeLinalgElementwise(RewriterBase &rewriter,
         return replaceOp(nullptr, ElementwiseKind::cos);
       if (isa<math::TanOp>(op))
         return replaceOp(nullptr, ElementwiseKind::tan);
+      if (isa<math::AcosOp>(op))
+        return replaceOp(nullptr, ElementwiseKind::acos);
+      if (isa<math::AcoshOp>(op))
+        return replaceOp(nullptr, ElementwiseKind::acosh);
+      if (isa<math::AsinOp>(op))
+        return replaceOp(nullptr, ElementwiseKind::asin);
+      if (isa<math::AsinhOp>(op))
+        return replaceOp(nullptr, ElementwiseKind::asinh);
+      if (isa<math::AtanOp>(op))
+        return replaceOp(nullptr, ElementwiseKind::atan);
+      if (isa<math::AtanhOp>(op))
+        return replaceOp(nullptr, ElementwiseKind::atanh);
+      if (isa<math::Log10Op>(op))
+        return replaceOp(nullptr, ElementwiseKind::log10);
+      if (isa<math::Log1pOp>(op))
+        return replaceOp(nullptr, ElementwiseKind::log1p);
+      if (isa<math::Log2Op>(op))
+        return replaceOp(nullptr, ElementwiseKind::log2);
     }
 
     // At this point, we exhaustively checked the available unary named ops. The

--- a/mlir/test/Dialect/Linalg/roundtrip-morphism-linalg-category-ops.mlir
+++ b/mlir/test/Dialect/Linalg/roundtrip-morphism-linalg-category-ops.mlir
@@ -38,6 +38,24 @@ func.func @unary_ops(%A: memref<7x14x21xf32>, %Out: memref<7x14x21xf32>) {
     ins(%A : memref<7x14x21xf32>) outs(%Out : memref<7x14x21xf32>)
   linalg.elementwise kind=#linalg.elementwise_kind<tan>
     ins(%A : memref<7x14x21xf32>) outs(%Out : memref<7x14x21xf32>)
+  linalg.elementwise kind=#linalg.elementwise_kind<acos>
+    ins(%A : memref<7x14x21xf32>) outs(%Out : memref<7x14x21xf32>)
+  linalg.elementwise kind=#linalg.elementwise_kind<acosh>
+    ins(%A : memref<7x14x21xf32>) outs(%Out : memref<7x14x21xf32>)
+  linalg.elementwise kind=#linalg.elementwise_kind<asin>
+    ins(%A : memref<7x14x21xf32>) outs(%Out : memref<7x14x21xf32>)
+  linalg.elementwise kind=#linalg.elementwise_kind<asinh>
+    ins(%A : memref<7x14x21xf32>) outs(%Out : memref<7x14x21xf32>)
+  linalg.elementwise kind=#linalg.elementwise_kind<atan>
+    ins(%A : memref<7x14x21xf32>) outs(%Out : memref<7x14x21xf32>)
+  linalg.elementwise kind=#linalg.elementwise_kind<atanh>
+    ins(%A : memref<7x14x21xf32>) outs(%Out : memref<7x14x21xf32>)
+  linalg.elementwise kind=#linalg.elementwise_kind<log10>
+    ins(%A : memref<7x14x21xf32>) outs(%Out : memref<7x14x21xf32>)
+  linalg.elementwise kind=#linalg.elementwise_kind<log1p>
+    ins(%A : memref<7x14x21xf32>) outs(%Out : memref<7x14x21xf32>)
+  linalg.elementwise kind=#linalg.elementwise_kind<log2>
+    ins(%A : memref<7x14x21xf32>) outs(%Out : memref<7x14x21xf32>)
   return
 }
 
@@ -90,6 +108,33 @@ func.func @unary_ops(%A: memref<7x14x21xf32>, %Out: memref<7x14x21xf32>) {
 // CHECK-SAME: ins(%[[A]] : memref<7x14x21xf32>)
 // CHECK-SAME: outs(%[[OUT]] : memref<7x14x21xf32>)
 // CHECK: linalg.elementwise kind=#linalg.elementwise_kind<tan>
+// CHECK-SAME: ins(%[[A]] : memref<7x14x21xf32>)
+// CHECK-SAME: outs(%[[OUT]] : memref<7x14x21xf32>)
+// CHECK: linalg.elementwise kind=#linalg.elementwise_kind<acos>
+// CHECK-SAME: ins(%[[A]] : memref<7x14x21xf32>)
+// CHECK-SAME: outs(%[[OUT]] : memref<7x14x21xf32>)
+// CHECK: linalg.elementwise kind=#linalg.elementwise_kind<acosh>
+// CHECK-SAME: ins(%[[A]] : memref<7x14x21xf32>)
+// CHECK-SAME: outs(%[[OUT]] : memref<7x14x21xf32>)
+// CHECK: linalg.elementwise kind=#linalg.elementwise_kind<asin>
+// CHECK-SAME: ins(%[[A]] : memref<7x14x21xf32>)
+// CHECK-SAME: outs(%[[OUT]] : memref<7x14x21xf32>)
+// CHECK: linalg.elementwise kind=#linalg.elementwise_kind<asinh>
+// CHECK-SAME: ins(%[[A]] : memref<7x14x21xf32>)
+// CHECK-SAME: outs(%[[OUT]] : memref<7x14x21xf32>)
+// CHECK: linalg.elementwise kind=#linalg.elementwise_kind<atan>
+// CHECK-SAME: ins(%[[A]] : memref<7x14x21xf32>)
+// CHECK-SAME: outs(%[[OUT]] : memref<7x14x21xf32>)
+// CHECK: linalg.elementwise kind=#linalg.elementwise_kind<atanh>
+// CHECK-SAME: ins(%[[A]] : memref<7x14x21xf32>)
+// CHECK-SAME: outs(%[[OUT]] : memref<7x14x21xf32>)
+// CHECK: linalg.elementwise kind=#linalg.elementwise_kind<log10>
+// CHECK-SAME: ins(%[[A]] : memref<7x14x21xf32>)
+// CHECK-SAME: outs(%[[OUT]] : memref<7x14x21xf32>)
+// CHECK: linalg.elementwise kind=#linalg.elementwise_kind<log1p>
+// CHECK-SAME: ins(%[[A]] : memref<7x14x21xf32>)
+// CHECK-SAME: outs(%[[OUT]] : memref<7x14x21xf32>)
+// CHECK: linalg.elementwise kind=#linalg.elementwise_kind<log2>
 // CHECK-SAME: ins(%[[A]] : memref<7x14x21xf32>)
 // CHECK-SAME: outs(%[[OUT]] : memref<7x14x21xf32>)
 

--- a/mlir/test/Dialect/Linalg/specialize-generic-ops.mlir
+++ b/mlir/test/Dialect/Linalg/specialize-generic-ops.mlir
@@ -121,7 +121,70 @@ func.func @unary_ops(%A: tensor<?x?x?xf32>, %Out: tensor<?x?x?xf32>) -> tensor<?
     %v = math.tan %in : f32
     linalg.yield %v : f32
   } -> tensor<?x?x?xf32>
-  return %15 : tensor<?x?x?xf32>
+  %16 = linalg.generic
+          {indexing_maps = [#umap, #umap], iterator_types = ["parallel", "parallel","parallel"]}
+          ins(%15 : tensor<?x?x?xf32>) outs(%Out : tensor<?x?x?xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %v = math.acos %in : f32
+    linalg.yield %v : f32
+  } -> tensor<?x?x?xf32>
+  %17 = linalg.generic
+          {indexing_maps = [#umap, #umap], iterator_types = ["parallel", "parallel","parallel"]}
+          ins(%16 : tensor<?x?x?xf32>) outs(%Out : tensor<?x?x?xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %v = math.acosh %in : f32
+    linalg.yield %v : f32
+  } -> tensor<?x?x?xf32>
+  %18 = linalg.generic
+          {indexing_maps = [#umap, #umap], iterator_types = ["parallel", "parallel","parallel"]}
+          ins(%17 : tensor<?x?x?xf32>) outs(%Out : tensor<?x?x?xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %v = math.asin %in : f32
+    linalg.yield %v : f32
+  } -> tensor<?x?x?xf32>
+  %19 = linalg.generic
+          {indexing_maps = [#umap, #umap], iterator_types = ["parallel", "parallel","parallel"]}
+          ins(%18 : tensor<?x?x?xf32>) outs(%Out : tensor<?x?x?xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %v = math.asinh %in : f32
+    linalg.yield %v : f32
+  } -> tensor<?x?x?xf32>
+  %20 = linalg.generic
+          {indexing_maps = [#umap, #umap], iterator_types = ["parallel", "parallel","parallel"]}
+          ins(%19 : tensor<?x?x?xf32>) outs(%Out : tensor<?x?x?xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %v = math.atan %in : f32
+    linalg.yield %v : f32
+  } -> tensor<?x?x?xf32>
+  %21 = linalg.generic
+          {indexing_maps = [#umap, #umap], iterator_types = ["parallel", "parallel","parallel"]}
+          ins(%20 : tensor<?x?x?xf32>) outs(%Out : tensor<?x?x?xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %v = math.atanh %in : f32
+    linalg.yield %v : f32
+  } -> tensor<?x?x?xf32>
+  %22 = linalg.generic
+          {indexing_maps = [#umap, #umap], iterator_types = ["parallel", "parallel","parallel"]}
+          ins(%21 : tensor<?x?x?xf32>) outs(%Out : tensor<?x?x?xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %v = math.log10 %in : f32
+    linalg.yield %v : f32
+  } -> tensor<?x?x?xf32>
+  %23 = linalg.generic
+          {indexing_maps = [#umap, #umap], iterator_types = ["parallel", "parallel","parallel"]}
+          ins(%22 : tensor<?x?x?xf32>) outs(%Out : tensor<?x?x?xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %v = math.log1p %in : f32
+    linalg.yield %v : f32
+  } -> tensor<?x?x?xf32>
+  %24 = linalg.generic
+          {indexing_maps = [#umap, #umap], iterator_types = ["parallel", "parallel","parallel"]}
+          ins(%23 : tensor<?x?x?xf32>) outs(%Out : tensor<?x?x?xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %v = math.log2 %in : f32
+    linalg.yield %v : f32
+  } -> tensor<?x?x?xf32>
+  return %24 : tensor<?x?x?xf32>
 }
 
 // ALL-LABEL: unary_ops
@@ -215,6 +278,33 @@ func.func @unary_ops(%A: tensor<?x?x?xf32>, %Out: tensor<?x?x?xf32>) -> tensor<?
 // CATEGORY-SAME: outs(%[[OUT]] : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
 // CATEGORY: %[[RES15:.+]] = linalg.elementwise kind=#linalg.elementwise_kind<tan>
 // CATEGORY-SAME: ins(%[[RES14]] : tensor<?x?x?xf32>)
+// CATEGORY-SAME: outs(%[[OUT]] : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+// CATEGORY: %[[RES16:.+]] = linalg.elementwise kind=#linalg.elementwise_kind<acos>
+// CATEGORY-SAME: ins(%[[RES15]] : tensor<?x?x?xf32>)
+// CATEGORY-SAME: outs(%[[OUT]] : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+// CATEGORY: %[[RES17:.+]] = linalg.elementwise kind=#linalg.elementwise_kind<acosh>
+// CATEGORY-SAME: ins(%[[RES16]] : tensor<?x?x?xf32>)
+// CATEGORY-SAME: outs(%[[OUT]] : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+// CATEGORY: %[[RES18:.+]] = linalg.elementwise kind=#linalg.elementwise_kind<asin>
+// CATEGORY-SAME: ins(%[[RES17]] : tensor<?x?x?xf32>)
+// CATEGORY-SAME: outs(%[[OUT]] : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+// CATEGORY: %[[RES19:.+]] = linalg.elementwise kind=#linalg.elementwise_kind<asinh>
+// CATEGORY-SAME: ins(%[[RES18]] : tensor<?x?x?xf32>)
+// CATEGORY-SAME: outs(%[[OUT]] : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+// CATEGORY: %[[RES20:.+]] = linalg.elementwise kind=#linalg.elementwise_kind<atan>
+// CATEGORY-SAME: ins(%[[RES19]] : tensor<?x?x?xf32>)
+// CATEGORY-SAME: outs(%[[OUT]] : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+// CATEGORY: %[[RES21:.+]] = linalg.elementwise kind=#linalg.elementwise_kind<atanh>
+// CATEGORY-SAME: ins(%[[RES20]] : tensor<?x?x?xf32>)
+// CATEGORY-SAME: outs(%[[OUT]] : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+// CATEGORY: %[[RES22:.+]] = linalg.elementwise kind=#linalg.elementwise_kind<log10>
+// CATEGORY-SAME: ins(%[[RES21]] : tensor<?x?x?xf32>)
+// CATEGORY-SAME: outs(%[[OUT]] : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+// CATEGORY: %[[RES23:.+]] = linalg.elementwise kind=#linalg.elementwise_kind<log1p>
+// CATEGORY-SAME: ins(%[[RES22]] : tensor<?x?x?xf32>)
+// CATEGORY-SAME: outs(%[[OUT]] : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+// CATEGORY: %[[RES24:.+]] = linalg.elementwise kind=#linalg.elementwise_kind<log2>
+// CATEGORY-SAME: ins(%[[RES23]] : tensor<?x?x?xf32>)
 // CATEGORY-SAME: outs(%[[OUT]] : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
 
 // -----


### PR DESCRIPTION
Follow up to #200950

Add acos, acosh, asin, asinh, atan, atanh, log10, log1p, log2 to elementwise ops

These math operations are added as UnaryFn enum cases and supported through linalg.elementwise only, with no named op definitions. The specialize pass converts linalg.generic containing these math ops to linalg.elementwise when emitting category ops