### PR TITLE
[CIR] Fix inline asm operand-attr indexing

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenAsm.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenAsm.cpp
@@ -560,10 +560,9 @@ mlir::LogicalResult CIRGenFunction::emitAsmStmt(const AsmStmt &s) {
 
     llvm::SmallVector<mlir::Attribute> operandAttrs;
 
-    int i = 0;
-    for (auto typ : argElemTypes) {
+    for (auto [idx, typ] : llvm::enumerate(argElemTypes)) {
       if (typ) {
-        [[maybe_unused]] mlir::Value op = args[i++];
+        [[maybe_unused]] mlir::Value op = args[idx];
         assert(mlir::isa<cir::PointerType>(op.getType()) &&
                "pointer type expected");
         assert(cast<cir::PointerType>(op.getType()).getPointee() == typ &&

--- a/clang/test/CIR/CodeGen/inline-asm.c
+++ b/clang/test/CIR/CodeGen/inline-asm.c
@@ -903,3 +903,23 @@ void *t33(void *ptr)
 void t34(void) {
   __asm__ volatile("T34 CC NAMED MODIFIER: %cc[input]" :: [input] "i" (4));
 }
+
+// Register input (null element type) before a memory input: keep elementtype.
+//      CIR: cir.func{{.*}}@t35
+//      CIR: %[[I:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init]
+//      CIR: %[[G:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["g"]
+//      CIR: %[[I_LOAD:.*]] = cir.load align(4) %[[I]] : !cir.ptr<!s32i>, !s32i
+//      CIR: cir.asm(x86_att,
+// CIR-NEXT:   out = [],
+// CIR-NEXT:   in = [%[[I_LOAD]] : !s32i, %[[G]] : !cir.ptr<!s32i> (maybe_memory)],
+// CIR-NEXT:   in_out = [],
+// CIR-NEXT:   {"" "r,*m,~{dirflag},~{fpsr},~{flags}"}) side_effects
+// LLVM: define{{.*}}@t35
+// LLVM: %[[I:.*]] = alloca i32
+// LLVM: %[[G:.*]] = alloca i32
+// LLVM: %[[I_LOAD:.*]] = load i32, ptr %[[I]]
+// LLVM: call void asm sideeffect "", "r,*m,~{dirflag},~{fpsr},~{flags}"(i32 %[[I_LOAD]], ptr elementtype(i32) %[[G]])
+void t35(int i) {
+  int g;
+  __asm__ volatile("" :: "r"(i), "m"(g));
+}


### PR DESCRIPTION
Inline asm with a register operand ordered before a memory operand, e.g. `asm("" :: "r"(i), "m"(g))`, crashes CIRGen at the `"pointer type expected"` / `"element type differs from pointee type"` assertions in `emitAsmStmt`.

The element-type-attribute loop walks `argElemTypes` with a counter that only advances on entries that have an element type, but uses that counter to index the parallel `args` array. The two arrays are the same length (every operand pushes to both, and `assert(args.size() == operandAttrs.size())` enforces it), so the matching value for `argElemTypes[k]` is `args[k]`. As soon as a register operand (null element type) precedes a memory operand (non-null), the counter desyncs and reads the wrong operand — a non-pointer, or a pointer with the wrong pointee.

The fix indexes `args` positionally with `llvm::enumerate`, matching classic CodeGen in `CGStmt.cpp`, which iterates `llvm::enumerate(ArgElemTypes)` and attaches the element-type attribute at `Pair.index()`. New `t35` in `inline-asm.c` covers the register-before-memory ordering and checks the lowered IR against classic codegen.