### PR TITLE
[lldb] Adjust TestObjectFileMachO.cpp for macOS 27

### DIFF
--- a/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
+++ b/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
@@ -82,7 +82,7 @@ TEST_F(ObjectFileMachOTest, ModuleFromSharedCacheInfo) {
   };
 
   // Read a symbol from the __TEXT segment...
-  check_symbol("objc_msgSend");
+  check_symbol("objc_begin_catch");
   // ... and one from the __DATA segment
   check_symbol("OBJC_IVAR_$_NSObject.isa");
 }


### PR DESCRIPTION
In macOS 27 (and accompanying device OSes), objc_msgSend was moved out of the libobjc dylib into other system dylibs.

The simplest fix is to use a different symbol from libobjc.