### PR TITLE
[test][Support] Disable CFI-icall for DynamicLibrary Overload test (#202446) (#202684)

### DIFF
--- a/llvm/unittests/Support/DynamicLibrary/DynamicLibraryTest.cpp
+++ b/llvm/unittests/Support/DynamicLibrary/DynamicLibraryTest.cpp
@@ -59,7 +59,11 @@ static const char *OverloadTestA() { return "OverloadCall"; }
 
 std::string StdString(const char *Ptr) { return Ptr ? Ptr : ""; }
 
-TEST(DynamicLibrary, Overload) {
+TEST(DynamicLibrary, Overload)
+#ifdef __clang__
+LLVM_NO_SANITIZE("cfi-icall")
+#endif
+{
   {
     std::string Err;
     DynamicLibrary DL =


### PR DESCRIPTION
The test performs manual symbol lookup and calls, which triggers
Control Flow Integrity indirect call checks.

Reland of #202446 and #202684 reverted with #202550 #202446.

Here we are going to use LLVM_NO_SANITIZE and check `__clang__`.
