### PR TITLE
[Triple] Add libc-less `x32` environment

### DIFF
--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -282,6 +282,7 @@ public:
     CODE16,
     EABI,
     EABIHF,
+    X32,
     Android,
     Musl,
     MuslABIN32,
@@ -1144,7 +1145,8 @@ public:
   /// Tests whether the target is X32.
   bool isX32() const {
     EnvironmentType Env = getEnvironment();
-    return Env == Triple::GNUX32 || Env == Triple::MuslX32;
+    return Env == Triple::X32 || Env == Triple::GNUX32 ||
+           Env == Triple::MuslX32;
   }
 
   /// Tests whether the target is eBPF.

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -518,6 +518,8 @@ StringRef Triple::getEnvironmentTypeName(EnvironmentType Kind) {
     return "eabi";
   case EABIHF:
     return "eabihf";
+  case X32:
+    return "x32";
   case GNU:
     return "gnu";
   case GNUT64:
@@ -975,6 +977,7 @@ static Triple::EnvironmentType parseEnvironment(StringRef EnvironmentName) {
   return StringSwitch<Triple::EnvironmentType>(EnvironmentName)
       .StartsWith("eabihf", Triple::EABIHF)
       .StartsWith("eabi", Triple::EABI)
+      .StartsWith("x32", Triple::X32)
       .StartsWith("gnuabin32", Triple::GNUABIN32)
       .StartsWith("gnuabi64", Triple::GNUABI64)
       .StartsWith("gnueabihft64", Triple::GNUEABIHFT64)

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -121,6 +121,12 @@ TEST(TripleTest, ParsedIDs) {
   EXPECT_EQ(Triple::Linux, T.getOS());
   EXPECT_EQ(Triple::MuslX32, T.getEnvironment());
 
+  T = Triple("x86_64-pc-linux-x32");
+  EXPECT_EQ(Triple::x86_64, T.getArch());
+  EXPECT_EQ(Triple::PC, T.getVendor());
+  EXPECT_EQ(Triple::Linux, T.getOS());
+  EXPECT_EQ(Triple::X32, T.getEnvironment());
+
   T = Triple("x86_64-pc-hurd-gnu");
   EXPECT_EQ(Triple::x86_64, T.getArch());
   EXPECT_EQ(Triple::PC, T.getVendor());


### PR DESCRIPTION
The x86 backend checks `Triple::isX32()` in multiple places, so frontends that have first-class support for building libc-less programs need a way for those checks to work without falsely claiming to be using glibc or musl.