### PR TITLE
[lldb] Drop prefix & offset arguments in ParseTrieEntries

### DIFF
--- a/lldb/source/Plugins/ObjectFile/Mach-O/MachOTrie.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/MachOTrie.cpp
@@ -136,10 +136,11 @@ bool ParseTrieEntriesImpl(DataExtractor &data, lldb::offset_t offset,
 } // namespace
 
 bool lldb_private::ParseTrieEntries(
-    DataExtractor &data, lldb::offset_t offset, const bool is_arm,
-    lldb::addr_t text_seg_base_addr, std::set<lldb::addr_t> &resolver_addresses,
+    DataExtractor &data, const bool is_arm, lldb::addr_t text_seg_base_addr,
+    std::set<lldb::addr_t> &resolver_addresses,
     std::vector<TrieEntryWithOffset> &reexports,
     std::vector<TrieEntryWithOffset> &ext_symbols) {
+  lldb::offset_t offset = 0;
   std::set<lldb::offset_t> visited_nodes;
   std::string prefix;
   return ParseTrieEntriesImpl(data, offset, is_arm, text_seg_base_addr, prefix,

--- a/lldb/source/Plugins/ObjectFile/Mach-O/MachOTrie.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/MachOTrie.cpp
@@ -137,11 +137,11 @@ bool ParseTrieEntriesImpl(DataExtractor &data, lldb::offset_t offset,
 
 bool lldb_private::ParseTrieEntries(
     DataExtractor &data, lldb::offset_t offset, const bool is_arm,
-    lldb::addr_t text_seg_base_addr, std::string &prefix,
-    std::set<lldb::addr_t> &resolver_addresses,
+    lldb::addr_t text_seg_base_addr, std::set<lldb::addr_t> &resolver_addresses,
     std::vector<TrieEntryWithOffset> &reexports,
     std::vector<TrieEntryWithOffset> &ext_symbols) {
   std::set<lldb::offset_t> visited_nodes;
+  std::string prefix;
   return ParseTrieEntriesImpl(data, offset, is_arm, text_seg_base_addr, prefix,
                               resolver_addresses, reexports, ext_symbols,
                               visited_nodes);

--- a/lldb/source/Plugins/ObjectFile/Mach-O/MachOTrie.h
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/MachOTrie.h
@@ -66,8 +66,6 @@ struct TrieEntryWithOffset {
 /// handling.
 /// \param[in] text_seg_base_addr The __TEXT segment file address added to each
 ///     symbol address, or LLDB_INVALID_ADDRESS to leave addresses unbiased.
-/// \param[in,out] prefix The accumulated symbol-name prefix; pass an empty
-///     string for the root call.
 /// \param[out] resolver_addresses Stub-and-resolver addresses encountered.
 /// \param[out] reexports Re-export entries with a valid import name.
 /// \param[out] ext_symbols Externally visible (non-re-export) entries.
@@ -75,7 +73,6 @@ struct TrieEntryWithOffset {
 /// \return false if the trie is detectably corrupt, true otherwise.
 bool ParseTrieEntries(DataExtractor &data, lldb::offset_t offset,
                       const bool is_arm, lldb::addr_t text_seg_base_addr,
-                      std::string &prefix,
                       std::set<lldb::addr_t> &resolver_addresses,
                       std::vector<TrieEntryWithOffset> &reexports,
                       std::vector<TrieEntryWithOffset> &ext_symbols);

--- a/lldb/source/Plugins/ObjectFile/Mach-O/MachOTrie.h
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/MachOTrie.h
@@ -61,7 +61,6 @@ struct TrieEntryWithOffset {
 /// and re-exported symbols and any stub resolver addresses.
 ///
 /// \param[in] data The buffer holding the raw export trie.
-/// \param[in] offset The node offset to start parsing from (0 for the root).
 /// \param[in] is_arm Whether the image is ARM, which governs Thumb-bit
 /// handling.
 /// \param[in] text_seg_base_addr The __TEXT segment file address added to each
@@ -71,8 +70,8 @@ struct TrieEntryWithOffset {
 /// \param[out] ext_symbols Externally visible (non-re-export) entries.
 ///
 /// \return false if the trie is detectably corrupt, true otherwise.
-bool ParseTrieEntries(DataExtractor &data, lldb::offset_t offset,
-                      const bool is_arm, lldb::addr_t text_seg_base_addr,
+bool ParseTrieEntries(DataExtractor &data, const bool is_arm,
+                      lldb::addr_t text_seg_base_addr,
                       std::set<lldb::addr_t> &resolver_addresses,
                       std::vector<TrieEntryWithOffset> &reexports,
                       std::vector<TrieEntryWithOffset> &ext_symbols);

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -2528,8 +2528,7 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
     lldb::addr_t text_segment_file_addr = LLDB_INVALID_ADDRESS;
     if (text_segment_sp)
       text_segment_file_addr = text_segment_sp->GetFileAddress();
-    std::string prefix;
-    ParseTrieEntries(dyld_trie_data, 0, is_arm, text_segment_file_addr, prefix,
+    ParseTrieEntries(dyld_trie_data, 0, is_arm, text_segment_file_addr,
                      resolver_addresses, reexport_trie_entries,
                      external_sym_trie_entries);
   }

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -2528,7 +2528,7 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
     lldb::addr_t text_segment_file_addr = LLDB_INVALID_ADDRESS;
     if (text_segment_sp)
       text_segment_file_addr = text_segment_sp->GetFileAddress();
-    ParseTrieEntries(dyld_trie_data, 0, is_arm, text_segment_file_addr,
+    ParseTrieEntries(dyld_trie_data, is_arm, text_segment_file_addr,
                      resolver_addresses, reexport_trie_entries,
                      external_sym_trie_entries);
   }

--- a/lldb/unittests/ObjectFile/MachO/MachOTrieTest.cpp
+++ b/lldb/unittests/ObjectFile/MachO/MachOTrieTest.cpp
@@ -191,11 +191,10 @@ ParseResult Parse(llvm::ArrayRef<uint8_t> bytes, bool is_arm = false,
                   lldb::addr_t text_seg_base_addr = LLDB_INVALID_ADDRESS) {
   DataExtractor data(bytes.data(), bytes.size(), lldb::eByteOrderLittle,
                      /*addr_size=*/8);
-  std::string prefix;
   ParseResult result;
   result.ok = ParseTrieEntries(data, /*offset=*/0, is_arm, text_seg_base_addr,
-                               prefix, result.resolver_addresses,
-                               result.reexports, result.ext_symbols);
+                               result.resolver_addresses, result.reexports,
+                               result.ext_symbols);
   return result;
 }
 

--- a/lldb/unittests/ObjectFile/MachO/MachOTrieTest.cpp
+++ b/lldb/unittests/ObjectFile/MachO/MachOTrieTest.cpp
@@ -192,7 +192,7 @@ ParseResult Parse(llvm::ArrayRef<uint8_t> bytes, bool is_arm = false,
   DataExtractor data(bytes.data(), bytes.size(), lldb::eByteOrderLittle,
                      /*addr_size=*/8);
   ParseResult result;
-  result.ok = ParseTrieEntries(data, /*offset=*/0, is_arm, text_seg_base_addr,
+  result.ok = ParseTrieEntries(data, is_arm, text_seg_base_addr,
                                result.resolver_addresses, result.reexports,
                                result.ext_symbols);
   return result;


### PR DESCRIPTION
I addressed Dave's review feedback locally but forgot to push the fix to the PR branch.