### PR TITLE
Add limited vtable address querying to `clang::CodeGenerator`

### DIFF
--- a/clang/include/clang/CodeGen/ModuleBuilder.h
+++ b/clang/include/clang/CodeGen/ModuleBuilder.h
@@ -32,16 +32,16 @@ namespace llvm {
 inline constexpr llvm::StringRef ClangTrapPrefix = "__clang_trap_msg";
 
 namespace clang {
-  class BaseSubobject;
-  class CodeGenOptions;
-  class CoverageSourceInfo;
-  class Decl;
-  class DiagnosticsEngine;
-  class GlobalDecl;
-  class HeaderSearchOptions;
-  class LangOptions;
-  class PreprocessorOptions;
-  class CompilerInstance;
+class BaseSubobject;
+class CodeGenOptions;
+class CoverageSourceInfo;
+class Decl;
+class DiagnosticsEngine;
+class GlobalDecl;
+class HeaderSearchOptions;
+class LangOptions;
+class PreprocessorOptions;
+class CompilerInstance;
 
 namespace CodeGen {
   class CodeGenModule;

--- a/clang/include/clang/CodeGen/ModuleBuilder.h
+++ b/clang/include/clang/CodeGen/ModuleBuilder.h
@@ -32,6 +32,7 @@ namespace llvm {
 inline constexpr llvm::StringRef ClangTrapPrefix = "__clang_trap_msg";
 
 namespace clang {
+  class BaseSubobject;
   class CodeGenOptions;
   class CoverageSourceInfo;
   class Decl;
@@ -104,6 +105,8 @@ public:
   ///   code generator will schedule the entity for emission if a
   ///   definition has been registered with this code generator.
   llvm::Constant *GetAddrOfGlobal(GlobalDecl decl, bool isForDefinition);
+
+  llvm::Constant *GetAddrOfVTable(BaseSubobject base, CXXRecordDecl *decl);
 
   /// Create a new \c llvm::Module after calling HandleTranslationUnit. This
   /// enable codegen in interactive processing environments.

--- a/clang/include/clang/CodeGen/ModuleBuilder.h
+++ b/clang/include/clang/CodeGen/ModuleBuilder.h
@@ -110,7 +110,8 @@ public:
   ///
   /// \param base The base subobject that owns the vptr to be initialized.
   /// \param decl The derived type being initialized, that contains `base`.
-  llvm::Constant *GetAddrOfVTable(BaseSubobject base, const CXXRecordDecl *decl);
+  llvm::Constant *GetAddrOfVTable(BaseSubobject base,
+                                  const CXXRecordDecl *decl);
 
   /// Create a new \c llvm::Module after calling HandleTranslationUnit. This
   /// enable codegen in interactive processing environments.

--- a/clang/include/clang/CodeGen/ModuleBuilder.h
+++ b/clang/include/clang/CodeGen/ModuleBuilder.h
@@ -106,7 +106,7 @@ public:
   ///   definition has been registered with this code generator.
   llvm::Constant *GetAddrOfGlobal(GlobalDecl decl, bool isForDefinition);
 
-  llvm::Constant *GetAddrOfVTable(BaseSubobject base, CXXRecordDecl *decl);
+  llvm::Constant *GetAddrOfVTable(BaseSubobject base, const CXXRecordDecl *decl);
 
   /// Create a new \c llvm::Module after calling HandleTranslationUnit. This
   /// enable codegen in interactive processing environments.

--- a/clang/include/clang/CodeGen/ModuleBuilder.h
+++ b/clang/include/clang/CodeGen/ModuleBuilder.h
@@ -106,6 +106,10 @@ public:
   ///   definition has been registered with this code generator.
   llvm::Constant *GetAddrOfGlobal(GlobalDecl decl, bool isForDefinition);
 
+  /// Return the LLVM address of the vtable for the given base subobject.
+  ///
+  /// \param base The base subobject that owns the vptr to be initialized.
+  /// \param decl The derived type being initialized, that contains `base`.
   llvm::Constant *GetAddrOfVTable(BaseSubobject base, const CXXRecordDecl *decl);
 
   /// Create a new \c llvm::Module after calling HandleTranslationUnit. This

--- a/clang/lib/CodeGen/ModuleBuilder.cpp
+++ b/clang/lib/CodeGen/ModuleBuilder.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/CodeGen/ModuleBuilder.h"
+#include "CGCXXABI.h"
 #include "CGDebugInfo.h"
 #include "CodeGenModule.h"
 #include "clang/AST/ASTContext.h"
@@ -129,6 +130,11 @@ namespace {
 
     llvm::Constant *GetAddrOfGlobal(GlobalDecl global, bool isForDefinition) {
       return Builder->GetAddrOfGlobal(global, ForDefinition_t(isForDefinition));
+    }
+
+    llvm::Constant *GetAddrOfVTable(BaseSubobject subobject,
+                                    CXXRecordDecl *decl) {
+      return Builder->getCXXABI().getVTableAddressPoint(subobject, decl);
     }
 
     llvm::Module *StartModule(llvm::StringRef ModuleName,
@@ -376,6 +382,11 @@ llvm::Constant *CodeGenerator::GetAddrOfGlobal(GlobalDecl global,
                                                bool isForDefinition) {
   return static_cast<CodeGeneratorImpl*>(this)
            ->GetAddrOfGlobal(global, isForDefinition);
+}
+
+llvm::Constant *CodeGenerator::GetAddrOfVTable(BaseSubobject base,
+                                               CXXRecordDecl *decl) {
+  return static_cast<CodeGeneratorImpl *>(this)->GetAddrOfVTable(base, decl);
 }
 
 llvm::Module *CodeGenerator::StartModule(llvm::StringRef ModuleName,

--- a/clang/lib/CodeGen/ModuleBuilder.cpp
+++ b/clang/lib/CodeGen/ModuleBuilder.cpp
@@ -385,7 +385,7 @@ llvm::Constant *CodeGenerator::GetAddrOfGlobal(GlobalDecl global,
 }
 
 llvm::Constant *CodeGenerator::GetAddrOfVTable(BaseSubobject base,
-                                               CXXRecordDecl *decl) {
+                                               const CXXRecordDecl *decl) {
   return static_cast<CodeGeneratorImpl *>(this)->GetAddrOfVTable(base, decl);
 }
 

--- a/clang/lib/CodeGen/ModuleBuilder.cpp
+++ b/clang/lib/CodeGen/ModuleBuilder.cpp
@@ -133,7 +133,7 @@ namespace {
     }
 
     llvm::Constant *GetAddrOfVTable(BaseSubobject subobject,
-                                    CXXRecordDecl *decl) {
+                                    const CXXRecordDecl *decl) {
       return Builder->getCXXABI().getVTableAddressPoint(subobject, decl);
     }
 

--- a/clang/unittests/CodeGen/CodeGenExternalTest.cpp
+++ b/clang/unittests/CodeGen/CodeGenExternalTest.cpp
@@ -271,7 +271,7 @@ static void test_codegen_fns(MyASTConsumer *my) {
         GEPOperator *gepOperator = dyn_cast<GEPOperator>(c);
         ASSERT_NE(gepOperator, nullptr);
         gepOperator->accumulateConstantOffset(dataLayout, offset);
-        // Itanium ABI has a couple of pointersi (offset to top, type info)
+        // Itanium ABI has a couple of pointers (offset to top, type info)
         // before the array of function pointers.
         ASSERT_EQ(offset, (pointerSizeInBits / 8) * 2);
       }

--- a/clang/unittests/CodeGen/CodeGenExternalTest.cpp
+++ b/clang/unittests/CodeGen/CodeGenExternalTest.cpp
@@ -195,7 +195,7 @@ static void test_codegen_fns(MyASTConsumer *my) {
           mytest_fn_ok = true;
         }
       }
-    } else if(CXXRecordDecl *rd = dyn_cast<CXXRecordDecl>(decl)) {
+    } else if (CXXRecordDecl *rd = dyn_cast<CXXRecordDecl>(decl)) {
       if (rd->getName() == "mytest_struct") {
         RecordDecl *def = rd->getDefinition();
         ASSERT_TRUE(def != NULL);
@@ -268,7 +268,7 @@ static void test_codegen_fns(MyASTConsumer *my) {
         unsigned pointerSizeInBits =
             dataLayout.getPointerTypeSizeInBits(c->getType());
         APInt offset(pointerSizeInBits, 0);
-        GEPOperator* gepOperator = dyn_cast<GEPOperator>(c);
+        GEPOperator *gepOperator = dyn_cast<GEPOperator>(c);
         ASSERT_NE(gepOperator, nullptr);
         gepOperator->accumulateConstantOffset(dataLayout, offset);
         // Itanium ABI has a couple of pointersi (offset to top, type info)

--- a/clang/unittests/CodeGen/CodeGenExternalTest.cpp
+++ b/clang/unittests/CodeGen/CodeGenExternalTest.cpp
@@ -10,6 +10,7 @@
 
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/BaseSubobject.h"
 #include "clang/AST/GlobalDecl.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Basic/TargetInfo.h"
@@ -21,6 +22,7 @@
 #include "clang/Sema/Sema.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Operator.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/TargetParser/Host.h"
@@ -163,7 +165,12 @@ bool MyASTConsumer::shouldSkipFunctionBody(Decl *D) {
 
 const char TestProgram[] =
     "struct mytest_struct { char x; short y; char p; long z; };\n"
-    "int mytest_fn(int x) { return x; }\n";
+    "int mytest_fn(int x) { return x; }\n"
+    "struct mytest_dynamic_struct {\n"
+    "  mytest_dynamic_struct();\n"
+    "  virtual void f1();\n"
+    "};\n"
+    "mytest_dynamic_struct::mytest_dynamic_struct() { }\n";
 
 // This function has the real test code here
 static void test_codegen_fns(MyASTConsumer *my) {
@@ -176,17 +183,19 @@ static void test_codegen_fns(MyASTConsumer *my) {
 
   for (auto decl : my->toplevel_decls ) {
     if (FunctionDecl *fd = dyn_cast<FunctionDecl>(decl)) {
-      if (fd->getName() == "mytest_fn") {
-        Constant *c = my->Builder->GetAddrOfGlobal(GlobalDecl(fd), false);
-        // Verify that we got a function.
-        ASSERT_TRUE(c != NULL);
-        if (DebugThisTest) {
-          c->print(dbgs(), true);
-          dbgs() << "\n";
+      if (fd->getDeclName().isIdentifier()) {
+        if (fd->getName() == "mytest_fn") {
+          Constant *c = my->Builder->GetAddrOfGlobal(GlobalDecl(fd), false);
+          // Verify that we got a function.
+          ASSERT_TRUE(c != NULL);
+          if (DebugThisTest) {
+            c->print(dbgs(), true);
+            dbgs() << "\n";
+          }
+          mytest_fn_ok = true;
         }
-        mytest_fn_ok = true;
       }
-    } else if(clang::RecordDecl *rd = dyn_cast<RecordDecl>(decl)) {
+    } else if(CXXRecordDecl *rd = dyn_cast<CXXRecordDecl>(decl)) {
       if (rd->getName() == "mytest_struct") {
         RecordDecl *def = rd->getDefinition();
         ASSERT_TRUE(def != NULL);
@@ -247,6 +256,24 @@ static void test_codegen_fns(MyASTConsumer *my) {
         ASSERT_GE(zTy->getPrimitiveSizeInBits(), 32u); // long is at least 32b
 
         mytest_struct_ok = true;
+      } else if (rd->getName() == "mytest_dynamic_struct") {
+        Constant *c = my->Builder->GetAddrOfVTable(
+            BaseSubobject(rd, CharUnits::fromQuantity(0)), rd);
+        ASSERT_NE(c, nullptr);
+        Value *vtableGlobal = c->getOperand(0);
+        ASSERT_NE(vtableGlobal, nullptr);
+        ASSERT_EQ(vtableGlobal->getName(), "_ZTV21mytest_dynamic_struct");
+        const DataLayout &dataLayout =
+            my->Builder->GetModule()->getDataLayout();
+        unsigned pointerSizeInBits =
+            dataLayout.getPointerTypeSizeInBits(c->getType());
+        APInt offset(pointerSizeInBits, 0);
+        GEPOperator* gepOperator = dyn_cast<GEPOperator>(c);
+        ASSERT_NE(gepOperator, nullptr);
+        gepOperator->accumulateConstantOffset(dataLayout, offset);
+        // Itanium ABI has a couple of pointersi (offset to top, type info)
+        // before the array of function pointers.
+        ASSERT_EQ(offset, (pointerSizeInBits / 8) * 2);
       }
     }
   }


### PR DESCRIPTION
This is being used in Carbon ( https://github.com/carbon-language/carbon-lang/pull/7323 ) to implement cross-language overriding.

I realize this isn't the fully general feature needed for virtual bases, etc - but this limited functionality is already wrapped up for, if I understand it correctly, constexpr use cases and some others. So hopefully it's still something folks feel is general enough to be worthwhile exporting. For now Carbon doesn't support deriving from a type with virtual bases, so the extra complexity isn't needed.