### PR TITLE
Patch 2: [LV][NFCI] Parameterize IAI instance for the Planner

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
@@ -834,9 +834,6 @@ class LoopVectorizationPlanner {
   /// VF selection state independent of cost-modeling decisions.
   VFSelectionContext &Config;
 
-  /// The interleaved access analysis.
-  InterleavedAccessInfo &IAI;
-
   PredicatedScalarEvolution &PSE;
 
   const LoopVectorizeHints &Hints;
@@ -872,11 +869,10 @@ public:
   LoopVectorizationPlanner(
       Loop *L, LoopInfo *LI, DominatorTree *DT, const TargetLibraryInfo *TLI,
       const TargetTransformInfo &TTI, LoopVectorizationLegality *Legal,
-      VFSelectionContext &Config, InterleavedAccessInfo &IAI,
-      PredicatedScalarEvolution &PSE, const LoopVectorizeHints &Hints,
-      OptimizationRemarkEmitter *ORE)
+      VFSelectionContext &Config, PredicatedScalarEvolution &PSE,
+      const LoopVectorizeHints &Hints, OptimizationRemarkEmitter *ORE)
       : OrigLoop(L), LI(LI), DT(DT), TLI(TLI), TTI(TTI), Legal(Legal),
-        Config(Config), IAI(IAI), PSE(PSE), Hints(Hints), ORE(ORE) {}
+        Config(Config), PSE(PSE), Hints(Hints), ORE(ORE) {}
 
   /// Build VPlans for the specified \p UserVF and \p UserIC if they are
   /// non-zero or all applicable candidate VFs otherwise. If vectorization and

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -6695,7 +6695,8 @@ LoopVectorizationPlanner::tryToBuildVPlan(VPlanPtr Plan, VFRange &Range,
   // Range, add it to the set of groups to be later applied to the VPlan and add
   // placeholders for its members' Recipes which we'll be replacing with a
   // single VPInterleaveRecipe.
-  for (InterleaveGroup<Instruction> *IG : IAI.getInterleaveGroups()) {
+  for (InterleaveGroup<Instruction> *IG :
+       CM.InterleaveInfo.getInterleaveGroups()) {
     auto ApplyIG = [IG, &CM](ElementCount VF) -> bool {
       bool Result = (VF.isVector() && // Query is illegal for VF == 1
                      CM.getWideningDecision(IG->getInsertPos(), VF) ==
@@ -8035,8 +8036,8 @@ bool LoopVectorizePass::processLoop(Loop *L) {
   LoopVectorizationCostModel CM(SEL, L, PSE, LI, &LVL, *TTI, TLI, AC, ORE,
                                 GetBFI, F, &Hints, IAI, Config);
   // Use the planner for vectorization.
-  LoopVectorizationPlanner LVP(L, LI, DT, TLI, *TTI, &LVL, Config, IAI, PSE,
-                               Hints, ORE);
+  LoopVectorizationPlanner LVP(L, LI, DT, TLI, *TTI, &LVL, Config, PSE, Hints,
+                               ORE);
 
   EpilogueLowering EpilogueTailLoweringStatus =
       getEpilogueTailLowering(CM, L, ORE);


### PR DESCRIPTION
Following Patch 1, this removes `InterleavedAccessInfo &IAI` as a stored member of `LoopVectorizationPlanner` and replaces all uses of `IAI` inside the planner with `CM.InterleaveInfo`, which holds the same object.   
The constructor no longer takes `IAI` as a separate argument.   
This is a pure cleanup enabled by Patch 1 — since `CM` is now a parameter, its `InterleaveInfo` field is already accessible wherever needed.