### PR TITLE
[MemorySSA] Fix memory SSA updater bug when adding new memory phi from an unreachable basic block

### DIFF
--- a/llvm/lib/Analysis/MemorySSAUpdater.cpp
+++ b/llvm/lib/Analysis/MemorySSAUpdater.cpp
@@ -984,6 +984,19 @@ void MemorySSAUpdater::applyInsertUpdates(ArrayRef<CFGUpdate> Updates,
       InsertedPhis.push_back(MSSA->createMemoryPhi(BB));
   }
 
+  // MemoryPhis updated for inserted edges from unreachable predecessors may
+  // not be revisited by the IDF-based update below. IDF is computed from the
+  // reachable dominator tree, so such predecessors do not contribute to IDF
+  // placement. Recompute these phis after the IDF update, because newly
+  // inserted IDF phis may invalidate the incoming values of these phis.
+  SmallVector<WeakVH, 8> PhisWithUnreachableIncoming;
+  SmallPtrSet<MemoryPhi *, 8> SeenPhisWithUnreachableIncoming;
+
+  auto RecordMemoryPhiWithUnreachableIncoming = [&](MemoryPhi *MPhi) {
+    if (SeenPhisWithUnreachableIncoming.insert(MPhi).second)
+      PhisWithUnreachableIncoming.push_back(MPhi);
+  };
+
   // Now we'll fill in the MemoryPhis with the right incoming values.
   for (auto &BBPredPair : PredMap) {
     auto *BB = BBPredPair.first;
@@ -1013,6 +1026,9 @@ void MemorySSAUpdater::applyInsertUpdates(ArrayRef<CFGUpdate> Updates,
         auto *LastDefForPred = LastDefAddedPred[Pred];
         for (int I = 0, E = EdgeCountMap[{Pred, BB}]; I < E; ++I)
           NewPhi->addIncoming(LastDefForPred, Pred);
+
+        if (!DT.getNode(Pred))
+          RecordMemoryPhiWithUnreachableIncoming(NewPhi);
       }
     } else {
       // Pick any existing predecessor and get its definition. All other
@@ -1044,6 +1060,9 @@ void MemorySSAUpdater::applyInsertUpdates(ArrayRef<CFGUpdate> Updates,
         auto *LastDefForPred = LastDefAddedPred[Pred];
         for (int I = 0, E = EdgeCountMap[{Pred, BB}]; I < E; ++I)
           NewPhi->addIncoming(LastDefForPred, Pred);
+
+        if (!DT.getNode(Pred))
+          RecordMemoryPhiWithUnreachableIncoming(NewPhi);
       }
       for (auto *Pred : PrevBlockSet)
         for (int I = 0, E = EdgeCountMap[{Pred, BB}]; I < E; ++I)
@@ -1102,6 +1121,13 @@ void MemorySSAUpdater::applyInsertUpdates(ArrayRef<CFGUpdate> Updates,
       }
     }
   }
+
+  // The IDF update above may have inserted new phis that should define the
+  // reachable incoming values of these phis.
+  for (auto &VH : PhisWithUnreachableIncoming)
+    if (auto *MPhi = cast_or_null<MemoryPhi>(VH))
+      for (unsigned I = 0, E = MPhi->getNumIncomingValues(); I < E; ++I)
+        MPhi->setIncomingValue(I, GetLastDef(MPhi->getIncomingBlock(I)));
 
   // Now for all defs in BlocksWithDefsToReplace, if there are uses they no
   // longer dominate, replace those with the closest dominating def.

--- a/llvm/test/Transforms/SimpleLoopUnswitch/memoryssa-unreachable-cloned-exit.ll
+++ b/llvm/test/Transforms/SimpleLoopUnswitch/memoryssa-unreachable-cloned-exit.ll
@@ -1,0 +1,33 @@
+; RUN: opt -passes='loop-mssa(simple-loop-unswitch<nontrivial;trivial>)' -verify-memoryssa -disable-output %s
+
+@a = global i16 0
+@buf = global i8 0
+
+define void @test(i16 %0) {
+entry:
+  store i16 0, ptr @a, align 2
+  br label %for.cond
+
+for.cond:                                         ; preds = %lor.end, %entry
+  br label %for.cond2.preheader
+
+for.cond2.preheader:                              ; preds = %lor.end, %for.cond
+  %arrayidx7 = getelementptr i8, ptr @buf, i64 0
+  br label %for.cond2
+
+for.cond2:                                        ; preds = %for.body4, %for.cond2.preheader
+  switch i16 %0, label %lor.end [
+    i16 -6, label %for.body4
+    i16 0, label %lor.rhs
+  ]
+
+for.body4:                                        ; preds = %for.cond2
+  %1 = load i8, ptr %arrayidx7, align 1
+  br label %for.cond2
+
+lor.rhs:                                          ; preds = %for.cond2
+  br label %lor.end
+
+lor.end:                                          ; preds = %lor.rhs, %for.cond2
+  br i1 false, label %for.cond, label %for.cond2.preheader
+}


### PR DESCRIPTION
Fix https://github.com/llvm/llvm-project/issues/179229.

### Summary 
The Memory SSA verifier may fail after `SimpleLoopUnswitch` updates the memory SSA for cloned loop exit blocks. 

The problem is in `MemorySSAUpdater::applyInsertUpdates`. During the update, a Memory Phi may be updated for an inserted edge whose predecessor is unreachable. The predecessor is still presented in the CFG, so the Memory Phi needs an incoming value from it. However, the predecessor is not presented in the dominator tree used by IDF computation, so that Memory Phi is not visited in later IDF-based update.

As a result, such Memory Phi node may still contain the stale incoming value after new Memory Phis are inserted in IDF blocks.

### Fix
Record all Memory Phis updated due to unreachable predecessors in `MemorySSAUpdater::applyInsertUpdates` and recompute their incoming values after creating and updating memory phis in the IDF blocks.

Add a new test case to verify the bug fix.

The fix does not introduce noticeable slowdown when running the LLVM test suite.