### PR TITLE
[AtomicExpand][NFC] Rename AtomicExpansionKind::Expand to AtomicExpansionKind::Xchg

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -267,7 +267,7 @@ public:
                        // operations; used by X86.
     CmpArithIntrinsic, // Use a target-specific intrinsic for special compare
                        // operations; used by X86.
-    Expand,            // Generic expansion in terms of other atomic operations.
+    Xchg,              // Expand a store into an atomicrmw xchg.
     CustomExpand,      // Custom target-specific expansion using TLI hooks.
 
     // Rewrite to a non-atomic form for use in a known non-preemptible
@@ -2461,8 +2461,8 @@ public:
   }
 
   /// Returns how the given (atomic) store should be expanded by the IR-level
-  /// AtomicExpand pass into. For instance AtomicExpansionKind::CustomExpand
-  /// will try to use an atomicrmw xchg.
+  /// AtomicExpand pass. For instance, AtomicExpansionKind::Xchg expands the
+  /// store to an atomicrmw xchg.
   virtual AtomicExpansionKind shouldExpandAtomicStoreInIR(StoreInst *SI) const {
     return AtomicExpansionKind::None;
   }

--- a/llvm/lib/CodeGen/AtomicExpandPass.cpp
+++ b/llvm/lib/CodeGen/AtomicExpandPass.cpp
@@ -638,7 +638,7 @@ bool AtomicExpandImpl::tryExpandAtomicStore(StoreInst *SI) {
   case TargetLoweringBase::AtomicExpansionKind::CustomExpand:
     TLI->emitExpandAtomicStore(SI);
     return true;
-  case TargetLoweringBase::AtomicExpansionKind::Expand:
+  case TargetLoweringBase::AtomicExpansionKind::Xchg:
     expandAtomicStoreToXChg(SI);
     return true;
   case TargetLoweringBase::AtomicExpansionKind::NotAtomic:

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -31151,10 +31151,10 @@ AArch64TargetLowering::shouldExpandAtomicStoreInIR(StoreInst *SI) const {
   if (isOpSuitableForRCPC3(SI))
     return AtomicExpansionKind::None;
   if (isOpSuitableForLSE128(SI))
-    return AtomicExpansionKind::Expand;
+    return AtomicExpansionKind::Xchg;
   if (isOpSuitableForLDPSTP(SI))
     return AtomicExpansionKind::None;
-  return AtomicExpansionKind::Expand;
+  return AtomicExpansionKind::Xchg;
 }
 
 // Loads and stores less than 128-bits are already atomic; ones above that

--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -21471,7 +21471,7 @@ ARMTargetLowering::shouldExpandAtomicStoreInIR(StoreInst *SI) const {
     has64BitAtomicStore = Subtarget->hasV6Ops();
 
   unsigned Size = SI->getValueOperand()->getType()->getPrimitiveSizeInBits();
-  return Size == 64 && has64BitAtomicStore ? AtomicExpansionKind::Expand
+  return Size == 64 && has64BitAtomicStore ? AtomicExpansionKind::Xchg
                                            : AtomicExpansionKind::None;
 }
 

--- a/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
@@ -3947,7 +3947,7 @@ TargetLowering::AtomicExpansionKind
 HexagonTargetLowering::shouldExpandAtomicStoreInIR(StoreInst *SI) const {
   // Do not expand loads and stores that don't exceed 64 bits.
   return SI->getValueOperand()->getType()->getPrimitiveSizeInBits() > 64
-             ? AtomicExpansionKind::Expand
+             ? AtomicExpansionKind::Xchg
              : AtomicExpansionKind::None;
 }
 

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -32581,7 +32581,7 @@ X86TargetLowering::shouldExpandAtomicStoreInIR(StoreInst *SI) const {
       return AtomicExpansionKind::None;
   }
 
-  return needsCmpXchgNb(MemType) ? AtomicExpansionKind::Expand
+  return needsCmpXchgNb(MemType) ? AtomicExpansionKind::Xchg
                                  : AtomicExpansionKind::None;
 }
 


### PR DESCRIPTION
`AtomicExpansionKind::Expand` is labeled as a "generic expansion in terms of other atomic operations." I think this was meant to be a catch-all for smaller expansions, but it would be weird for a target to specify `AtomicExpansionKind::Expand` and for `AtomicExpandPass` to expand in two completely different ways for different operations. Every `ExpansionKind` should specify a unique type of expansion. We already have `AtomicExpansionKind::CustomExpand` for targets who want to implement their own unique expansion.

`AtomicExpansionKind::Expand` is currently only expanding `atomic store` to `atomicrmw xchg`, so rename it to `AtomicExpansionKind::Xchg`.