### PR TITLE
[Support] Compile out unused dominator DFS sorting

### DIFF
--- a/llvm/include/llvm/Support/GenericDomTreeConstruction.h
+++ b/llvm/include/llvm/Support/GenericDomTreeConstruction.h
@@ -189,13 +189,16 @@ template <typename DomTreeT> struct SemiNCAInfo {
   // relative to IsPostDom -- using reverse edges for dominators and forward
   // edges for postdominators.
   //
-  // If SuccOrder is specified then in this order the DFS traverses the children
+  // If UseSuccOrder is set then the DFS traverses children in SuccOrder;
   // otherwise the order is implied by the results of getChildren().
-  template <bool IsReverse = false, typename DescendCondition>
+  template <bool IsReverse = false, bool UseSuccOrder = false,
+            typename DescendCondition>
   unsigned runDFS(NodePtr V, unsigned LastNum, DescendCondition Condition,
                   unsigned AttachToNum,
                   const NodeOrderMap *SuccOrder = nullptr) {
     assert(V);
+    assert((!UseSuccOrder || SuccOrder) &&
+           "Ordered DFS requires a successor order");
     SmallVector<std::pair<NodePtr, unsigned>, 64> WorkList = {{V, AttachToNum}};
     getNodeInfo(V).Parent = AttachToNum;
 
@@ -213,11 +216,12 @@ template <typename DomTreeT> struct SemiNCAInfo {
 
       constexpr bool Direction = IsReverse != IsPostDom; // XOR.
       auto Successors = getChildren<Direction>(BB, BatchUpdates);
-      if (SuccOrder && Successors.size() > 1)
-        llvm::sort(
-            Successors.begin(), Successors.end(), [=](NodePtr A, NodePtr B) {
-              return SuccOrder->find(A)->second < SuccOrder->find(B)->second;
-            });
+      if constexpr (UseSuccOrder)
+        if (Successors.size() > 1)
+          llvm::sort(
+              Successors.begin(), Successors.end(), [=](NodePtr A, NodePtr B) {
+                return SuccOrder->find(A)->second < SuccOrder->find(B)->second;
+              });
 
       for (const NodePtr Succ : Successors) {
         if (!Condition(BB, Succ))
@@ -456,7 +460,7 @@ template <typename DomTreeT> struct SemiNCAInfo {
           assert(SuccOrder);
 
           const unsigned NewNum =
-              SNCA.runDFS<true>(I, Num, AlwaysDescend, Num, &*SuccOrder);
+              SNCA.runDFS<true, true>(I, Num, AlwaysDescend, Num, &*SuccOrder);
           const NodePtr FurthestAway = SNCA.NumToNode[NewNum];
           LLVM_DEBUG(dbgs() << "\t\t\tFound a new furthest away node "
                             << "(non-trivial root): "


### PR DESCRIPTION
`SemiNCAInfo::runDFS` accepts an optional successor order, but its runtime null
check causes every instantiation to retain sorting code. Make ordered traversal
a compile-time choice and enable it only for non-trivial post-dominator root
discovery, the sole caller that supplies an order.

On Darwin arm64 Release with assertions disabled:

- `Dominators.cpp.o`: 416,808 -> 219,216 bytes (-197,592)
- `MachineDominators.cpp.o`: 230,784 -> 121,872 bytes (-108,912)
- `MachinePostDominators.cpp.o`: 226,120 -> 136,464 bytes (-89,656)
- `opt`: 55,630,352 -> 55,261,184 bytes (-369,168)

Work towards #202616

AI tool disclosure: Co-authored with OpenAI Codex.
