### PR TITLE
fix(clang): Fix miscompile for string literals.

### DIFF
--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1917,11 +1917,9 @@ TemplateInstantiator::TransformPredefinedExpr(PredefinedExpr *E) {
   return getSema().BuildPredefinedExpr(E->getLocation(), E->getIdentKind());
 }
 
-ExprResult
-TemplateInstantiator::TransformStringLiteral(StringLiteral *E) {
+ExprResult TemplateInstantiator::TransformStringLiteral(StringLiteral *E) {
   return StringLiteral::Create(
-      SemaRef.Context, E->getBytes(), E->getKind(), E->isPascal(),
-      E->getType(),
+      SemaRef.Context, E->getBytes(), E->getKind(), E->isPascal(), E->getType(),
       llvm::ArrayRef<SourceLocation>(E->tokloc_begin(), E->tokloc_end()));
 }
 

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1340,6 +1340,7 @@ namespace {
     ExprResult TransformPredefinedExpr(PredefinedExpr *E);
     ExprResult TransformDeclRefExpr(DeclRefExpr *E);
     ExprResult TransformCXXDefaultArgExpr(CXXDefaultArgExpr *E);
+    ExprResult TransformStringLiteral(StringLiteral *E);
 
     ExprResult TransformTemplateParmRefExpr(DeclRefExpr *E,
                                             NonTypeTemplateParmDecl *D);
@@ -1914,6 +1915,14 @@ TemplateInstantiator::TransformPredefinedExpr(PredefinedExpr *E) {
     return E;
 
   return getSema().BuildPredefinedExpr(E->getLocation(), E->getIdentKind());
+}
+
+ExprResult
+TemplateInstantiator::TransformStringLiteral(StringLiteral *E) {
+  return StringLiteral::Create(
+      SemaRef.Context, E->getBytes(), E->getKind(), E->isPascal(),
+      E->getType(),
+      llvm::ArrayRef<SourceLocation>(E->tokloc_begin(), E->tokloc_end()));
 }
 
 ExprResult

--- a/clang/test/SemaTemplate/instantiate-init.cpp
+++ b/clang/test/SemaTemplate/instantiate-init.cpp
@@ -178,3 +178,13 @@ namespace RebuildStdInitList {
   template<typename U> void f() { PES({1, 2, 3}); }
   void g() { f<int>(); }
 }
+
+namespace StringLiteralDefaultInit {
+  template <unsigned L> struct V {
+    char rest[L] = "at least 18 bytes";
+  };
+  void test() {
+    V<100> v1;
+    V<18> v2;
+  }
+}


### PR DESCRIPTION
When a string-literal is used to initialize a sized char array, the template instantiation code always returned a reference to the string literal AST node. Therefore modifications to the array bounds applied to all instantiantions.

This change copies the AST node for each template instantiation, so each template instantiation gets its own string-literal.

After this change, the compilation behavior matches `g++`:
*   When the array bounds depend on the template parameter, multiple
    copies of the string literal are present in the final binary, even
    with `-O3`
*   When the array bounds do not depend on the template parameter, only
    one copy of the string literal is present in the final binary with
    `-O3`.

Separate AST nodes for each template instantiation are always constructed; they are deduped during code generation when identical. That occurs in GetAddrOfConstantStringFromLiteral, when two constant arrays have identical content, types, and sizes. See https://github.com/llvm/llvm-project/blob/fb2d6709f289525497cdf731bf32085401c6b962/clang/lib/CodeGen/CodeGenModule.cpp#L7476.

Fixes #72738