### PR TITLE
lsan: Document that ptrace_scope needs to be disabled.

### DIFF
--- a/compiler-rt/lib/lsan/lsan_common.cpp
+++ b/compiler-rt/lib/lsan/lsan_common.cpp
@@ -897,6 +897,9 @@ static bool CheckForLeaksOnce() {
       Report(
           "HINT: LeakSanitizer does not work under ptrace (strace, gdb, "
           "etc)\n");
+      Report(
+          "HINT: LeakSanitizer requires ptrace_scope to be disabled (e.g. echo "
+          "0 > /proc/sys/kernel/yama/ptrace_scope)\n");
       Die();
     }
     LeakReport leak_report;


### PR DESCRIPTION
As far as I'm aware, this is the reason why
http://45.33.8.238/linux/201640/step_9.txt is failing.
