### PR TITLE
[clang] Share MultiOnDiskHashTable table visitation

### DIFF
--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -147,6 +147,13 @@ using namespace clang::serialization;
 using namespace clang::serialization::reader;
 using llvm::BitstreamCursor;
 
+void clang::serialization::visitMultiOnDiskHashTables(
+    void *const *Begin, void *const *End, void *Context,
+    MultiOnDiskHashTableVisitor Visitor) {
+  for (; Begin != End; ++Begin)
+    Visitor(*Begin, Context);
+}
+
 //===----------------------------------------------------------------------===//
 // ChainedASTReaderListener implementation
 //===----------------------------------------------------------------------===//

--- a/clang/lib/Serialization/MultiOnDiskHashTable.h
+++ b/clang/lib/Serialization/MultiOnDiskHashTable.h
@@ -36,8 +36,13 @@
 namespace clang {
 namespace serialization {
 
+using MultiOnDiskHashTableVisitor = void (*)(void *, void *);
+void visitMultiOnDiskHashTables(void *const *Begin, void *const *End,
+                                void *Context,
+                                MultiOnDiskHashTableVisitor Visitor);
+
 /// A collection of on-disk hash tables, merged when relevant for performance.
-template<typename Info> class MultiOnDiskHashTable {
+template <typename Info> class MultiOnDiskHashTable {
 public:
   /// A handle to a file, used when overriding tables.
   using file_type = typename Info::file_type;
@@ -140,6 +145,43 @@ private:
     PendingOverrides.clear();
   }
 
+  static void mergeTable(void *OpaqueTable, void *OpaqueMerged) {
+    auto *ODT =
+        llvm::cast<OnDiskTable *>(Table::getFromOpaqueValue(OpaqueTable));
+    auto *Merged = static_cast<MergedTable *>(OpaqueMerged);
+    auto &HT = ODT->Table;
+    Info &InfoObj = HT.getInfoObj();
+
+    for (auto I = HT.data_begin(), E = HT.data_end(); I != E; ++I) {
+      auto *LocalPtr = I.getItem();
+
+      // FIXME: Don't rely on the OnDiskHashTable format here.
+      auto L = InfoObj.ReadKeyDataLength(LocalPtr);
+      const internal_key_type &Key = InfoObj.ReadKey(LocalPtr, L.first);
+      data_type_builder ValueBuilder(Merged->Data[Key]);
+      InfoObj.ReadDataInto(Key, LocalPtr + L.first, L.second, ValueBuilder);
+    }
+
+    Merged->Files.push_back(ODT->File);
+    delete ODT;
+  }
+
+  static void readAllFromTable(void *OpaqueTable, void *OpaqueResultBuilder) {
+    auto *ODT =
+        llvm::cast<OnDiskTable *>(Table::getFromOpaqueValue(OpaqueTable));
+    auto *ResultBuilder = static_cast<data_type_builder *>(OpaqueResultBuilder);
+    auto &HT = ODT->Table;
+    Info &InfoObj = HT.getInfoObj();
+    for (auto I = HT.data_begin(), E = HT.data_end(); I != E; ++I) {
+      auto *LocalPtr = I.getItem();
+
+      // FIXME: Don't rely on the OnDiskHashTable format here.
+      auto L = InfoObj.ReadKeyDataLength(LocalPtr);
+      const internal_key_type &Key = InfoObj.ReadKey(LocalPtr, L.first);
+      InfoObj.ReadDataInto(Key, LocalPtr + L.first, L.second, *ResultBuilder);
+    }
+  }
+
   void condense() {
     MergedTable *Merged = getMergedTable();
     if (!Merged)
@@ -147,24 +189,8 @@ private:
 
     // Read in all the tables and merge them together.
     // FIXME: Be smarter about which tables we merge.
-    for (auto *ODT : tables()) {
-      auto &HT = ODT->Table;
-      Info &InfoObj = HT.getInfoObj();
-
-      for (auto I = HT.data_begin(), E = HT.data_end(); I != E; ++I) {
-        auto *LocalPtr = I.getItem();
-
-        // FIXME: Don't rely on the OnDiskHashTable format here.
-        auto L = InfoObj.ReadKeyDataLength(LocalPtr);
-        const internal_key_type &Key = InfoObj.ReadKey(LocalPtr, L.first);
-        data_type_builder ValueBuilder(Merged->Data[Key]);
-        InfoObj.ReadDataInto(Key, LocalPtr + L.first, L.second,
-                             ValueBuilder);
-      }
-
-      Merged->Files.push_back(ODT->File);
-      delete ODT;
-    }
+    visitMultiOnDiskHashTables(tables().begin().getCurrent(), Tables.end(),
+                               Merged, mergeTable);
 
     Tables.clear();
     Tables.push_back(Table(Merged).getOpaqueValue());
@@ -269,18 +295,8 @@ public:
         Info::MergeDataInto(KV.second, ResultBuilder);
     }
 
-    for (auto *ODT : tables()) {
-      auto &HT = ODT->Table;
-      Info &InfoObj = HT.getInfoObj();
-      for (auto I = HT.data_begin(), E = HT.data_end(); I != E; ++I) {
-        auto *LocalPtr = I.getItem();
-
-        // FIXME: Don't rely on the OnDiskHashTable format here.
-        auto L = InfoObj.ReadKeyDataLength(LocalPtr);
-        const internal_key_type &Key = InfoObj.ReadKey(LocalPtr, L.first);
-        InfoObj.ReadDataInto(Key, LocalPtr + L.first, L.second, ResultBuilder);
-      }
-    }
+    visitMultiOnDiskHashTables(tables().begin().getCurrent(), Tables.end(),
+                               &ResultBuilder, readAllFromTable);
 
     return Result;
   }


### PR DESCRIPTION
Outline iteration over `MultiOnDiskHashTable` tables while retaining the typed hash-entry loops in each specialization. The shared loop makes one indirect call per table; hashing, probing, key decoding, result conversion, and the on-disk format remain unchanged.

Linked `clang` and `clangd` shrink by 6,288 and 6,024 bytes respectively; `ASTReader.cpp.o` shrinks by 26,264 bytes with 553 fewer relocations, while linked fixups are unchanged.

Work towards #202616

AI tool disclosure: Co-authored with OpenAI Codex.
