### PR TITLE
[clangd] Add missing direct includes for bit.h. NFC

### DIFF
--- a/clang-tools-extra/clangd/index/SymbolID.h
+++ b/clang-tools-extra/clangd/index/SymbolID.h
@@ -11,6 +11,7 @@
 
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/bit.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
 #include <array>


### PR DESCRIPTION
This currently compile only because llvm/ADT/Hashing.h transitively
pulls in llvm/Support/SwapByteOrder.h (which includes llvm/ADT/bit.h).