### PR TITLE
[NFC][clang][Serialization] Batch serialized LangOptions values

### DIFF
--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -1608,14 +1608,15 @@ void ASTWriter::WriteControlBlock(Preprocessor &PP, StringRef isysroot) {
   // Language options.
   Record.clear();
   const LangOptions &LangOpts = PP.getLangOpts();
-#define LANGOPT(Name, Bits, Default, Compatibility, Description)               \
-  Record.push_back(LangOpts.Name);
+  const uint64_t LanguageOptionValues[] = {
+#define LANGOPT(Name, Bits, Default, Compatibility, Description) LangOpts.Name,
 #define ENUM_LANGOPT(Name, Type, Bits, Default, Compatibility, Description)    \
-  Record.push_back(static_cast<unsigned>(LangOpts.get##Name()));
+  static_cast<unsigned>(LangOpts.get##Name()),
 #include "clang/Basic/LangOptions.def"
-#define SANITIZER(NAME, ID)                                                    \
-  Record.push_back(LangOpts.Sanitize.has(SanitizerKind::ID));
+#define SANITIZER(NAME, ID) LangOpts.Sanitize.has(SanitizerKind::ID),
 #include "clang/Basic/Sanitizers.def"
+  };
+  llvm::append_range(Record, LanguageOptionValues);
 
   Record.push_back(LangOpts.ModuleFeatures.size());
   for (StringRef Feature : LangOpts.ModuleFeatures)


### PR DESCRIPTION
Collect fixed language-option and sanitizer values in a `uint64_t` local array and append the array to the control-block record once. Generated values retain their serialized order.

Linked `clang` and `clangd` shrink by 91,584 and 91,520 bytes respectively; `ASTWriter.cpp.o` shrinks by 25,128 bytes with 396 fewer relocations, while linked fixups are unchanged.

Work towards #202616

AI tool disclosure: Co-authored with OpenAI Codex.
