### PR TITLE
[clang][bytecode] Fix right shifts greater than bitwidth

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -3245,16 +3245,16 @@ inline bool DoShift(InterpState &S, CodePtr OpPC, LT &LHS, RT &RHS,
     return true;
   }
 
-    // Right shift.
-    if (Compare(RHS, RT::from(MaxShiftAmount, RHS.bitWidth())) ==
-        ComparisonCategoryResult::Greater) {
-      R = LT::AsUnsigned::from(-1);
-    } else {
-      // Do the shift on potentially signed LT, then convert to unsigned type.
-      LT A;
-      LT::shiftRight(LHS, LT::from(RHS, Bits), Bits, &A);
-      R = LT::AsUnsigned::from(A);
-    }
+  // Right shift.
+  if (Compare(RHS, RT::from(MaxShiftAmount, RHS.bitWidth())) ==
+      ComparisonCategoryResult::Greater) {
+    R = LT::AsUnsigned::from(0);
+  } else {
+    // Do the shift on potentially signed LT, then convert to unsigned type.
+    LT A;
+    LT::shiftRight(LHS, LT::from(RHS, Bits), Bits, &A);
+    R = LT::AsUnsigned::from(A);
+  }
 
   S.Stk.push<LT>(LT::from(R));
   return true;

--- a/clang/test/AST/ByteCode/codegen.c
+++ b/clang/test/AST/ByteCode/codegen.c
@@ -9,6 +9,9 @@ const intptr_t Z1 = (intptr_t)(((char*)-1LL) + 1);
 const intptr_t Z2 = (intptr_t)(((char*)1LL) - 1);
 // CHECK: @Z2 = constant i64 0
 
+const int Shift = 2 >> 32;
+// CHECK: @Shift = constant i32 0
+
 struct A {
   char num_fields;
 };


### PR DESCRIPTION
We're not erroring in C, but we did compute the wrong result.