### PR TITLE
[clang] Use ClassifyInternal in binary op value kind classification when the binary op is type dependent

### DIFF
--- a/clang/lib/AST/ExprClassification.cpp
+++ b/clang/lib/AST/ExprClassification.cpp
@@ -622,7 +622,7 @@ static Cl::Kinds ClassifyBinaryOp(ASTContext &Ctx, const BinaryOperator *E) {
   // expressions can be either lvalues or prvalues depending on whether they
   // might resolve to an overloaded operator.
   if (E->getType() == Ctx.DependentTy)
-    return ClassifyExprValueKind(Ctx.getLangOpts(), E, E->getValueKind());
+    return ClassifyInternal(Ctx, E);
 
   // C++ [expr.ass]p1: All [...] return an lvalue referring to the left operand.
   // Except we override this for writes to ObjC properties.


### PR DESCRIPTION
This is a follow up PR for https://github.com/llvm/llvm-project/pull/202696. 

In 202693, we use `ClassifyExprValueKind`,  this PR changed to use `ClassifyInternal`, which is what seems to be used everywhere else.