### PR TITLE
[MLIR][NVVM] Fix valid range of ord in tensormap.replace op

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -6898,7 +6898,7 @@ def NVVM_TensormapReplaceOp : NVVM_VoidIntrinsicOp<"tensormap.replace",
     TensormapFieldAttr:$field,
     AnyTypeOf<[LLVM_PointerGlobal, LLVM_PointerShared]>:$addr,
     Optional<AnyTypeOf<[I64, I32]>>:$new_value,
-    OptionalAttr<ConfinedAttr<I32Attr, [IntMinValue<1>, IntMaxValue<5>]>>:$ord,
+    OptionalAttr<ConfinedAttr<I32Attr, [IntMinValue<0>, IntMaxValue<4>]>>:$ord,
     OptionalAttr<TensormapFieldValueAttr>:$new_value_attr
   );
 

--- a/mlir/test/Target/LLVMIR/nvvm/tensormap_replace_invalid.mlir
+++ b/mlir/test/Target/LLVMIR/nvvm/tensormap_replace_invalid.mlir
@@ -27,7 +27,7 @@ llvm.func @tensormap_replace_invalid_ordinal(%addr : !llvm.ptr<1>, %new_val : i3
 // -----
 
 llvm.func @tensormap_replace_ordinal_out_of_range(%addr : !llvm.ptr<1>, %new_val : i32) {
-  // expected-error @+1 {{attribute 'ord' failed to satisfy constraint: 32-bit signless integer attribute whose minimum value is 1 whose maximum value is 5}}
+  // expected-error @+1 {{attribute 'ord' failed to satisfy constraint: 32-bit signless integer attribute whose minimum value is 0 whose maximum value is 4}}
   nvvm.tensormap.replace field = box_dim[6], new_value = %new_val in %addr : !llvm.ptr<1>, i32
   llvm.return
 }


### PR DESCRIPTION
Fixes the valid range of the `ord` attribute in the NVVM dialect `tensormap.replace` op to be `0-4` as indicated in the PTX ISA.

PTX ISA Reference: https://docs.nvidia.com/cuda/parallel-thread-execution/#data-movement-and-conversion-instructions-tensormap-replace