### PR TITLE
[Flang][Driver] Support for -fsplit-lto-unit option in flang driver

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -4814,9 +4814,9 @@ defm whole_program_vtables : BoolFOption<"whole-program-vtables",
   NegFlag<SetFalse>, BothFlags<[], [ClangOption, CLOption]>>;
 defm split_lto_unit : BoolFOption<"split-lto-unit",
   CodeGenOpts<"EnableSplitLTOUnit">, DefaultFalse,
-  PosFlag<SetTrue, [], [ClangOption, CC1Option],
+  PosFlag<SetTrue, [], [ClangOption, CC1Option, FlangOption, FC1Option],
           "Enables splitting of the LTO unit">,
-  NegFlag<SetFalse>, BothFlags<[], [ClangOption, CLOption]>>;
+  NegFlag<SetFalse>, BothFlags<[], [ClangOption, CLOption, FlangOption, FC1Option]>>;
 defm force_emit_vtables : BoolFOption<"force-emit-vtables",
   CodeGenOpts<"ForceEmitVTables">, DefaultFalse,
   PosFlag<SetTrue, [], [ClangOption, CC1Option],

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -282,6 +282,11 @@ void Flang::addLTOOptions(const ArgList &Args, ArgStringList &CmdArgs) const {
     CmdArgs.push_back("-flto=full");
   else if (LTOMode == LTOK_Thin)
     CmdArgs.push_back("-flto=thin");
+
+  if (Args.hasFlag(options::OPT_fsplit_lto_unit,
+                   options::OPT_fno_split_lto_unit, /*Default=*/false))
+    CmdArgs.push_back("-fsplit-lto-unit");
+
   Args.addAllArgs(CmdArgs, {options::OPT_ffat_lto_objects,
                             options::OPT_fno_fat_lto_objects});
 }

--- a/flang/include/flang/Frontend/CodeGenOptions.def
+++ b/flang/include/flang/Frontend/CodeGenOptions.def
@@ -45,6 +45,7 @@ CODEGENOPT(PrepareForFullLTO , 1, 0) ///< Set when -flto is enabled on the
                                      ///< compile step.
 CODEGENOPT(PrepareForThinLTO , 1, 0) ///< Set when -flto=thin is enabled on the
                                      ///< compile step.
+CODEGENOPT(EnableSplitLTOUnit, 1, 0) ///< Set when -fsplit-lto-unit is enabled.
 CODEGENOPT(ProtectParens, 1, 1) ///< -fprotect-parens (enable parenthesis protection)
 CODEGENOPT(StackArrays, 1, 0) ///< -fstack-arrays (enable the stack-arrays pass)
 CODEGENOPT(EnableSafeTrampoline, 1, 0) ///< -fsafe-trampoline (W^X compliant trampoline pool)

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -1551,6 +1551,10 @@ static bool parseLinkerOptionsArgs(CompilerInvocation &invoc,
       opts.PrepareForThinLTO = true;
   }
 
+  // -fsplit-lto-unit option
+  if (args.hasArg(clang::options::OPT_fsplit_lto_unit))
+    opts.EnableSplitLTOUnit = true;
+
   // -ffat-lto-objects
   if (const llvm::opt::Arg *arg =
           args.getLastArg(clang::options::OPT_ffat_lto_objects,

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -1059,10 +1059,17 @@ void CodeGenAction::runOptimizationPipeline(llvm::raw_pwrite_stream &os) {
 
   if (action == BackendActionTy::Backend_EmitBC ||
       action == BackendActionTy::Backend_EmitLL || opts.PrepareForFatLTO) {
-    // If it is not ThinLTO, emits the module flag and sets it to be off.
-    if (!opts.PrepareForThinLTO && emitSummary &&
-        !llvmModule->getModuleFlag("ThinLTO")) {
-      llvmModule->addModuleFlag(llvm::Module::Error, "ThinLTO", uint32_t(0));
+    if (opts.PrepareForThinLTO) {
+      if (!llvmModule->getModuleFlag("EnableSplitLTOUnit"))
+        llvmModule->addModuleFlag(llvm::Module::Error, "EnableSplitLTOUnit",
+                                  opts.EnableSplitLTOUnit);
+    } else if (emitSummary && opts.PrepareForFullLTO) {
+      // If it is not ThinLTO, emits the module flag and sets it to be off.
+      if (!llvmModule->getModuleFlag("ThinLTO"))
+        llvmModule->addModuleFlag(llvm::Module::Error, "ThinLTO", uint32_t(0));
+      if (!llvmModule->getModuleFlag("EnableSplitLTOUnit"))
+        llvmModule->addModuleFlag(llvm::Module::Error, "EnableSplitLTOUnit",
+                                  uint32_t(1));
     }
 
     if (action == BackendActionTy::Backend_EmitBC) {

--- a/flang/test/Driver/split-lto-unit.f90
+++ b/flang/test/Driver/split-lto-unit.f90
@@ -1,0 +1,23 @@
+! Check that -fsplit-lto-unit is passed to fc1 by the driver with -fsplit-lto-unit
+! RUN: %flang -c -### -fsplit-lto-unit %s 2>&1 | FileCheck %s --check-prefix=SPLIT
+
+! Check that -fsplit-lto-unit is passed to fc1 by the driver with -fsplit-lto-unit
+! RUN: %flang -c -### -fno-split-lto-unit -fsplit-lto-unit %s 2>&1 | FileCheck %s  --check-prefix=SPLIT
+
+! Check that -fsplit-lto-unit is not passed to fc1 by the driver with -fno-split-lto-unit
+! RUN: %flang -c -### -fno-split-lto-unit %s 2>&1 | FileCheck %s  --check-prefix=NO-SPLIT
+
+! Check that -fsplit-lto-unit is not passed to fc1 by the driver with -fno-split-lto-unit
+! RUN: %flang -c -### -fsplit-lto-unit -fno-split-lto-unit %s 2>&1 | FileCheck %s  --check-prefix=NO-SPLIT
+
+! Check that the driver does not pass -fsplit-lto-unit to fc1 by default
+! RUN: %flang -c -### %s 2>&1 | FileCheck %s  --check-prefix=NO-SPLIT
+! RUN: %flang -c -### -flto %s 2>&1 | FileCheck %s  --check-prefix=NO-SPLIT
+! RUN: %flang -c -### -flto=thin %s 2>&1 | FileCheck %s  --check-prefix=NO-SPLIT
+
+! SPLIT: "-fc1"
+! SPLIT-SAME: "-fsplit-lto-unit"
+! NO-SPLIT-NOT: "-fsplit-lto-unit"
+
+program main
+end program main

--- a/flang/test/Integration/split-lto-unit-2.f90
+++ b/flang/test/Integration/split-lto-unit-2.f90
@@ -1,0 +1,23 @@
+! Check that -flto=thin without -fsplit-lto-unit has EnableSplitLTOUnit = 0
+! RUN: %flang -flto=thin  -S -o - %s |  FileCheck %s --check-prefix=SPLIT0
+! RUN: %flang -flto=thin --target=x86_64-linux-gnu -S -o - %s |  FileCheck %s --check-prefix=SPLIT0
+! RUN: %flang -flto=thin --target=x86_64-apple-macosx -S -o - %s | FileCheck %s --check-prefix=SPLIT0
+
+! Check that -flto=thin with -fsplit-lto-unit has EnableSplitLTOUnit = 1
+! RUN: %flang -flto=thin -fsplit-lto-unit -S -o - %s | FileCheck %s --check-prefix=SPLIT1
+! RUN: %flang -flto=thin --target=x86_64-linux-gnu -fsplit-lto-unit -S -o - %s | FileCheck %s --check-prefix=SPLIT1
+! RUN: %flang -flto=thin --target=x86_64-apple-macosx -fsplit-lto-unit -S -o - %s | FileCheck %s --check-prefix=SPLIT1
+
+! Check that regular LTO has EnableSplitLTOUnit = 1 
+! RUN: %flang -flto -S -o - %s | FileCheck %s --implicit-check-not="EnableSplitLTOUnit" --check-prefix=SPLIT1
+! RUN: %flang -flto --target=x86_64-linux-gnu -S -o - %s |  FileCheck %s --check-prefix=SPLIT1
+
+! Check that regular LTO has no EnableSplitLTOUnit for apple targets
+! RUN: %flang -flto --target=x86_64-apple-macosx -S -o - %s | FileCheck %s --check-prefix=NOSPLIT
+
+! SPLIT0: !{i32 1, !"EnableSplitLTOUnit", i32 0}
+! SPLIT1: !{i32 1, !"EnableSplitLTOUnit", i32 1}
+! NOSPLIT-NOT: "EnableSplitLTOUnit"
+
+program main
+end program main


### PR DESCRIPTION

When mixing Fortran objects from Flang with C/C++ objects compiled by Clang during a combined LTO build, it is necessary to ensure that all files use the same setting for split-lto-unit. This requires the support for -fsplit-lto-unit option in the flang driver. This support is added as part of this commit.