### PR TITLE
[DebugInfo] Avoid std::function in DWARF verifier internals

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFVerifier.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFVerifier.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_DEBUGINFO_DWARF_DWARFVERIFIER_H
 #define LLVM_DEBUGINFO_DWARF_DWARFVERIFIER_H
 
+#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/DebugInfo/DIContext.h"
 #include "llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h"
@@ -51,15 +52,13 @@ public:
       : IncludeDetail(includeDetail) {}
   void ShowDetail(bool showDetail) { IncludeDetail = showDetail; }
   size_t GetNumCategories() const { return Aggregation.size(); }
-  LLVM_ABI void Report(StringRef category,
-                       std::function<void()> detailCallback);
+  LLVM_ABI void Report(StringRef category, function_ref<void()> detailCallback);
   LLVM_ABI void Report(StringRef category, StringRef sub_category,
-                       std::function<void()> detailCallback);
+                       function_ref<void()> detailCallback);
   LLVM_ABI void
-  EnumerateResults(std::function<void(StringRef, unsigned)> handleCounts);
+  EnumerateResults(function_ref<void(StringRef, unsigned)> handleCounts);
   LLVM_ABI void EnumerateDetailedResultsFor(
-      StringRef category,
-      std::function<void(StringRef, unsigned)> handleCounts);
+      StringRef category, function_ref<void(StringRef, unsigned)> handleCounts);
   /// Return the number of errors that have been reported.
   uint64_t GetNumErrors() const { return NumErrors; }
 };

--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -2343,20 +2343,19 @@ bool DWARFVerifier::verifyDebugStrOffsets(
     std::string Msg = toString(std::move(E));
     ErrorCategory.Report("String offset error", [&]() {
       error() << formatv("{0}: {1}\n", SectionName, Msg);
-      return false;
     });
   }
   return Success;
 }
 
-void OutputCategoryAggregator::Report(
-    StringRef s, std::function<void(void)> detailCallback) {
-  this->Report(s, "", detailCallback);
+void OutputCategoryAggregator::Report(StringRef s,
+                                      function_ref<void(void)> detailCallback) {
+  Report(s, "", detailCallback);
 }
 
-void OutputCategoryAggregator::Report(
-    StringRef category, StringRef sub_category,
-    std::function<void(void)> detailCallback) {
+void OutputCategoryAggregator::Report(StringRef category,
+                                      StringRef sub_category,
+                                      function_ref<void(void)> detailCallback) {
   std::lock_guard<std::mutex> Lock(WriteMutex);
   ++NumErrors;
   std::string category_str = std::string(category);
@@ -2370,13 +2369,13 @@ void OutputCategoryAggregator::Report(
 }
 
 void OutputCategoryAggregator::EnumerateResults(
-    std::function<void(StringRef, unsigned)> handleCounts) {
+    function_ref<void(StringRef, unsigned)> handleCounts) {
   for (const auto &[name, aggData] : Aggregation) {
     handleCounts(name, aggData.OverallCount);
   }
 }
 void OutputCategoryAggregator::EnumerateDetailedResultsFor(
-    StringRef category, std::function<void(StringRef, unsigned)> handleCounts) {
+    StringRef category, function_ref<void(StringRef, unsigned)> handleCounts) {
   const auto Agg = Aggregation.find(category);
   if (Agg != Aggregation.end()) {
     for (const auto &[name, aggData] : Agg->second.DetailedCounts) {


### PR DESCRIPTION
This changes `OutputCategoryAggregator`'s synchronous callback parameters from `std::function` to `function_ref`, avoiding type-erased callback construction at 75 `DWARFVerifier` diagnostic sites.

On an arm64 Release build, standalone llvm-dwarfdump decreases by 133,680 bytes raw and 17,040 bytes stripped, `DWARFVerifier.cpp.o` decreases by 174,464 bytes, and linked fixups decrease by 546.

Work towards #202616

AI tool disclosure: Co-authored with OpenAI Codex.
