### PR TITLE
[lit] Add support for %{s:stem} substitution.

### DIFF
--- a/llvm/docs/CommandGuide/lit.rst
+++ b/llvm/docs/CommandGuide/lit.rst
@@ -667,6 +667,7 @@ TestRunner.py:
  %/p                     %p but ``\`` is replaced by ``/``
  %/t                     %t but ``\`` is replaced by ``/``
  %{s:basename}           The last path component of %s
+ %{s:stem}               The last path component of %s but with the last extension removed.
  %{t:stem}               The last path component of %t but without the ``.tmp`` extension (alias for %basename_t)
  %{s:real}               %s after expanding all symbolic links and substitute drives
  %{S:real}               %S after expanding all symbolic links and substitute drives

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -992,11 +992,13 @@ def getDefaultSubstitutions(test, tmpDir, tmpBase, normalize_slashes=False):
     tmpName = tmpBase + ".tmp"
     tmpBaseName = os.path.basename(tmpBase)
     sourceBaseName = os.path.basename(sourcepath)
+    sourceStem = os.path.splitext(sourceBaseName)[0]
 
     substitutions.append(("%{pathsep}", os.pathsep))
     substitutions.append(("%basename_t", tmpBaseName))
 
     substitutions.append(("%{s:basename}", sourceBaseName))
+    substitutions.append(("%{s:stem}", sourceStem))
     substitutions.append(("%{t:stem}", tmpBaseName))
 
     fs_sep = os.path.sep

--- a/llvm/utils/lit/tests/substitutions.py
+++ b/llvm/utils/lit/tests/substitutions.py
@@ -1,7 +1,9 @@
 # Basic test for substitutions.
 #
 # RUN: echo %{s:basename} | FileCheck %s --check-prefix=BASENAME
+# RUN: echo %{s:stem} | FileCheck %s --check-prefix=STEM
 # RUN: echo %{t:stem} %basename_t | FileCheck %s --check-prefix=TMPBASENAME
 
 # BASENAME: substitutions.py
+# STEM: substitutions
 # TMPBASENAME: [[FIRST:[^[:space:]]+]] [[FIRST]]


### PR DESCRIPTION
It provides the source file name with the (last) extension removed.

This is to align with what is available for %t and actually needed downstream.
