### PR TITLE
[lldb][NFC] Use unique ptr in AppleObjCRuntime::GetMetaclass

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
@@ -588,7 +588,7 @@ bool ClassDescriptorV2::Describe(
   }
 
   if (class_method_func) {
-    AppleObjCRuntime::ClassDescriptorSP metaclass(GetMetaclass());
+    std::unique_ptr<ClassDescriptor> metaclass = GetMetaclass();
 
     // We don't care about the metaclass's superclass, or its class methods.
     // Its instance methods are our class methods.
@@ -670,21 +670,22 @@ ObjCLanguageRuntime::ClassDescriptorSP ClassDescriptorV2::GetSuperclass() {
       objc_class->m_superclass);
 }
 
-ObjCLanguageRuntime::ClassDescriptorSP ClassDescriptorV2::GetMetaclass() const {
+std::unique_ptr<ObjCLanguageRuntime::ClassDescriptor>
+ClassDescriptorV2::GetMetaclass() const {
   lldb_private::Process *process = m_runtime.GetProcess();
 
   if (!process)
-    return ObjCLanguageRuntime::ClassDescriptorSP();
+    return nullptr;
 
   auto objc_class = objc_class_t::Read(process, m_objc_class_ptr);
   if (!objc_class) {
     LLDB_LOG_ERROR(GetLog(LLDBLog::Types), objc_class.takeError(), "{0}");
-    return ObjCLanguageRuntime::ClassDescriptorSP();
+    return nullptr;
   }
 
   lldb::addr_t candidate_isa = m_runtime.GetPointerISA(objc_class->m_isa);
 
-  return ObjCLanguageRuntime::ClassDescriptorSP(
+  return std::unique_ptr<ClassDescriptor>(
       new ClassDescriptorV2(m_runtime, candidate_isa, nullptr));
 }
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.h
@@ -29,7 +29,7 @@ public:
 
   ObjCLanguageRuntime::ClassDescriptorSP GetSuperclass() override;
 
-  ObjCLanguageRuntime::ClassDescriptorSP GetMetaclass() const override;
+  std::unique_ptr<ClassDescriptor> GetMetaclass() const override;
 
   bool IsValid() override {
     return true; // any Objective-C v2 runtime class descriptor we vend is valid
@@ -322,8 +322,8 @@ public:
     return ObjCLanguageRuntime::ClassDescriptorSP();
   }
 
-  ObjCLanguageRuntime::ClassDescriptorSP GetMetaclass() const override {
-    return ObjCLanguageRuntime::ClassDescriptorSP();
+  std::unique_ptr<ClassDescriptor> GetMetaclass() const override {
+    return nullptr;
   }
 
   bool IsValid() override { return m_valid; }

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.cpp
@@ -259,9 +259,9 @@ AppleObjCRuntimeV1::ClassDescriptorV1::GetSuperclass() {
       new AppleObjCRuntimeV1::ClassDescriptorV1(m_parent_isa, process_sp));
 }
 
-AppleObjCRuntime::ClassDescriptorSP
+std::unique_ptr<AppleObjCRuntime::ClassDescriptor>
 AppleObjCRuntimeV1::ClassDescriptorV1::GetMetaclass() const {
-  return ClassDescriptorSP();
+  return nullptr;
 }
 
 bool AppleObjCRuntimeV1::ClassDescriptorV1::Describe(

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.h
@@ -53,7 +53,7 @@ public:
 
     ClassDescriptorSP GetSuperclass() override;
 
-    ClassDescriptorSP GetMetaclass() const override;
+    std::unique_ptr<ClassDescriptor> GetMetaclass() const override;
 
     bool IsValid() override { return m_valid; }
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
@@ -63,7 +63,7 @@ public:
 
     virtual ClassDescriptorSP GetSuperclass() = 0;
 
-    virtual ClassDescriptorSP GetMetaclass() const = 0;
+    virtual std::unique_ptr<ClassDescriptor> GetMetaclass() const = 0;
 
     // virtual if any implementation has some other version-specific rules but
     // for the known v1/v2 this is all that needs to be done


### PR DESCRIPTION
These methods have no reason to return a shared pointer.