### PR TITLE
[llvm] Fix most LLVM_ABI annotations in DebugInfo

### DIFF
--- a/llvm/include/llvm/DebugInfo/CodeView/DebugSubsectionVisitor.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugSubsectionVisitor.h
@@ -60,9 +60,9 @@ public:
                                     const StringsAndChecksumsRef &State) = 0;
 };
 
-Error visitDebugSubsection(const DebugSubsectionRecord &R,
-                           DebugSubsectionVisitor &V,
-                           const StringsAndChecksumsRef &State);
+LLVM_ABI Error visitDebugSubsection(const DebugSubsectionRecord &R,
+                                    DebugSubsectionVisitor &V,
+                                    const StringsAndChecksumsRef &State);
 
 namespace detail {
 template <typename T>

--- a/llvm/include/llvm/DebugInfo/CodeView/DebugSymbolRVASubsection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugSymbolRVASubsection.h
@@ -27,7 +27,7 @@ class DebugSymbolRVASubsectionRef final : public DebugSubsectionRef {
 public:
   using ArrayType = FixedStreamArray<support::ulittle32_t>;
 
-  DebugSymbolRVASubsectionRef();
+  LLVM_ABI DebugSymbolRVASubsectionRef();
 
   static bool classof(const DebugSubsectionRef *S) {
     return S->kind() == DebugSubsectionKind::CoffSymbolRVA;
@@ -36,13 +36,13 @@ public:
   ArrayType::Iterator begin() const { return RVAs.begin(); }
   ArrayType::Iterator end() const { return RVAs.end(); }
 
-  Error initialize(BinaryStreamReader &Reader);
+  LLVM_ABI Error initialize(BinaryStreamReader &Reader);
 
 private:
   ArrayType RVAs;
 };
 
-class DebugSymbolRVASubsection final : public DebugSubsection {
+class LLVM_ABI DebugSymbolRVASubsection final : public DebugSubsection {
 public:
   DebugSymbolRVASubsection();
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugAddr.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugAddr.h
@@ -49,28 +49,30 @@ class DWARFDebugAddrTable {
 public:
 
   /// Extract the entire table, including all addresses.
-  Error extract(const DWARFDataExtractor &Data, uint64_t *OffsetPtr,
-                uint16_t CUVersion, uint8_t CUAddrSize,
-                std::function<void(Error)> WarnCallback);
+  LLVM_ABI Error extract(const DWARFDataExtractor &Data, uint64_t *OffsetPtr,
+                         uint16_t CUVersion, uint8_t CUAddrSize,
+                         std::function<void(Error)> WarnCallback);
 
   /// Extract a DWARFv5 address table.
-  Error extractV5(const DWARFDataExtractor &Data, uint64_t *OffsetPtr,
-                  uint8_t CUAddrSize, std::function<void(Error)> WarnCallback);
+  LLVM_ABI Error extractV5(const DWARFDataExtractor &Data, uint64_t *OffsetPtr,
+                           uint8_t CUAddrSize,
+                           std::function<void(Error)> WarnCallback);
 
   /// Extract a pre-DWARFv5 address table. Such tables do not have a header
   /// and consist only of a series of addresses.
   /// See https://gcc.gnu.org/wiki/DebugFission for details.
-  Error extractPreStandard(const DWARFDataExtractor &Data, uint64_t *OffsetPtr,
-                           uint16_t CUVersion, uint8_t CUAddrSize);
+  LLVM_ABI Error extractPreStandard(const DWARFDataExtractor &Data,
+                                    uint64_t *OffsetPtr, uint16_t CUVersion,
+                                    uint8_t CUAddrSize);
 
-  void dump(raw_ostream &OS, DIDumpOptions DumpOpts = {}) const;
+  LLVM_ABI void dump(raw_ostream &OS, DIDumpOptions DumpOpts = {}) const;
 
   /// Return the address based on a given index.
-  Expected<uint64_t> getAddrEntry(uint32_t Index) const;
+  LLVM_ABI Expected<uint64_t> getAddrEntry(uint32_t Index) const;
 
   /// Return the full length of this table, including the length field.
   /// Return std::nullopt if the length cannot be identified reliably.
-  std::optional<uint64_t> getFullLength() const;
+  LLVM_ABI std::optional<uint64_t> getFullLength() const;
 
   /// Return the DWARF format of this table.
   dwarf::DwarfFormat getFormat() const { return Format; }

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugAranges.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugAranges.h
@@ -22,8 +22,8 @@ class DWARFContext;
 
 class DWARFDebugAranges {
 public:
-  void generate(DWARFContext *CTX);
-  uint64_t findAddress(uint64_t Address) const;
+  LLVM_ABI void generate(DWARFContext *CTX);
+  LLVM_ABI uint64_t findAddress(uint64_t Address) const;
 
 private:
   void clear();

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugMacro.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugMacro.h
@@ -62,16 +62,16 @@ class DWARFDebugMacro {
     uint64_t DebugLineOffset;
 
     /// Print the macro header from the debug_macro section.
-    void dumpMacroHeader(raw_ostream &OS) const;
+    LLVM_ABI void dumpMacroHeader(raw_ostream &OS) const;
 
     /// Parse the debug_macro header.
-    Error parseMacroHeader(DWARFDataExtractor Data, uint64_t *Offset);
+    LLVM_ABI Error parseMacroHeader(DWARFDataExtractor Data, uint64_t *Offset);
 
     /// Get the DWARF format according to the flags.
-    dwarf::DwarfFormat getDwarfFormat() const;
+    LLVM_ABI dwarf::DwarfFormat getDwarfFormat() const;
 
     /// Get the size of a reference according to the DWARF format.
-    uint8_t getOffsetByteSize() const;
+    LLVM_ABI uint8_t getOffsetByteSize() const;
   };
 
   /// A single macro entry within a macro list.
@@ -116,7 +116,7 @@ public:
   DWARFDebugMacro() = default;
 
   /// Print the macro list found within the debug_macinfo/debug_macro section.
-  void dump(raw_ostream &OS) const;
+  LLVM_ABI void dump(raw_ostream &OS) const;
 
   Error parseMacro(DWARFUnitVector::compile_unit_range Units,
                    DataExtractor StringExtractor,
@@ -142,9 +142,10 @@ public:
 private:
   /// Parse the debug_macinfo/debug_macro section accessible via the 'MacroData'
   /// parameter.
-  Error parseImpl(std::optional<DWARFUnitVector::compile_unit_range> Units,
-                  std::optional<DataExtractor> StringExtractor,
-                  DWARFDataExtractor Data, bool IsMacro);
+  LLVM_ABI Error
+  parseImpl(std::optional<DWARFUnitVector::compile_unit_range> Units,
+            std::optional<DataExtractor> StringExtractor,
+            DWARFDataExtractor Data, bool IsMacro);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFGdbIndex.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFGdbIndex.h
@@ -70,8 +70,8 @@ class DWARFGdbIndex {
   bool parseImpl(DataExtractor Data);
 
 public:
-  void dump(raw_ostream &OS);
-  void parse(DataExtractor Data);
+  LLVM_ABI void dump(raw_ostream &OS);
+  LLVM_ABI void parse(DataExtractor Data);
 
   bool HasContent = false;
   bool HasError = false;

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFTypeUnit.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFTypeUnit.h
@@ -21,7 +21,7 @@ class DWARFDebugAbbrev;
 struct DWARFSection;
 class raw_ostream;
 
-class DWARFTypeUnit : public DWARFUnit {
+class LLVM_ABI DWARFTypeUnit : public DWARFUnit {
 public:
   DWARFTypeUnit(DWARFContext &Context, const DWARFSection &Section,
                 const DWARFUnitHeader &Header, const DWARFDebugAbbrev *DA,

--- a/llvm/include/llvm/DebugInfo/DWARF/LowLevel/DWARFDataExtractorSimple.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/LowLevel/DWARFDataExtractorSimple.h
@@ -228,9 +228,9 @@ class DWARFDataExtractorSimple
 public:
   using DWARFDataExtractorBase::DWARFDataExtractorBase;
 
-  LLVM_ABI uint64_t getRelocatedValueImpl(uint32_t Size, uint64_t *Off,
-                                          uint64_t *SectionIndex = nullptr,
-                                          Error *Err = nullptr) const {
+  uint64_t getRelocatedValueImpl(uint32_t Size, uint64_t *Off,
+                                 uint64_t *SectionIndex = nullptr,
+                                 Error *Err = nullptr) const {
     assert(SectionIndex == nullptr &&
            "DWARFDATAExtractorSimple cannot take section indices.");
     return getUnsigned(Off, Size, Err);

--- a/llvm/include/llvm/DebugInfo/GSYM/GsymContext.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/GsymContext.h
@@ -26,7 +26,7 @@ class GsymReader;
 /// interface to different symbolication formats (e.g. GSYM, PDB and DWARF).
 /// More control and power over the debug information access can be had by using
 /// the GSYM interfaces directly.
-class GsymContext : public DIContext {
+class LLVM_ABI GsymContext : public DIContext {
 public:
   GsymContext(std::unique_ptr<GsymReader> Reader);
   ~GsymContext() override;

--- a/llvm/include/llvm/DebugInfo/GSYM/GsymCreator.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/GsymCreator.h
@@ -155,20 +155,20 @@ protected:
   ///
   /// \returns The start address of the first FunctionInfo or std::nullopt if
   /// there are no function infos.
-  std::optional<uint64_t> getFirstFunctionAddress() const;
+  LLVM_ABI std::optional<uint64_t> getFirstFunctionAddress() const;
 
   /// Get the last function address.
   ///
   /// \returns The start address of the last FunctionInfo or std::nullopt if
   /// there are no function infos.
-  std::optional<uint64_t> getLastFunctionAddress() const;
+  LLVM_ABI std::optional<uint64_t> getLastFunctionAddress() const;
 
   /// Get the base address to use for this GSYM file.
   ///
   /// \returns The base address to put into the header and to use when creating
   ///          the address offset table or std::nullpt if there are no valid
   ///          function infos or if the base address wasn't specified.
-  std::optional<uint64_t> getBaseAddress() const;
+  LLVM_ABI std::optional<uint64_t> getBaseAddress() const;
 
   /// Get the size of an address offset in the address offset table.
   ///
@@ -178,7 +178,7 @@ protected:
   /// on the current contents of the GSYM file.
   ///
   /// \returns The size in byets of the address offsets.
-  uint8_t getAddressOffsetSize() const;
+  LLVM_ABI uint8_t getAddressOffsetSize() const;
 
   /// Get the maximum address offset for the current address offset size.
   ///
@@ -188,7 +188,7 @@ protected:
   ///
   /// \returns The maximum address offset value that will be encoded into a GSYM
   /// file.
-  uint64_t getMaxAddressOffset() const;
+  LLVM_ABI uint64_t getMaxAddressOffset() const;
 
   /// Calculate the byte size of the GSYM header and tables sizes.
   ///
@@ -209,7 +209,8 @@ protected:
   /// \returns The number of bytes it will take to encode the function info in
   /// this GsymCreator. This helps calculate the size of the current GSYM
   /// segment file.
-  uint64_t copyFunctionInfo(const GsymCreator &SrcGC, size_t FuncInfoIdx);
+  LLVM_ABI uint64_t copyFunctionInfo(const GsymCreator &SrcGC,
+                                     size_t FuncInfoIdx);
 
   /// Copy a string from \a SrcGC into this object.
   ///
@@ -221,7 +222,7 @@ protected:
   /// \param SrcGC The source gsym creator to copy from.
   /// \param StrOff The string table offset from \a SrcGC to copy.
   /// \returns The new string table offset of the string within this object.
-  gsym_strp_t copyString(const GsymCreator &SrcGC, gsym_strp_t StrOff);
+  LLVM_ABI gsym_strp_t copyString(const GsymCreator &SrcGC, gsym_strp_t StrOff);
 
   /// Copy a file from \a SrcGC into this object.
   ///
@@ -237,7 +238,7 @@ protected:
   /// file index of zero will always return zero as the zero is a reserved file
   /// index that means no file.
   /// \returns The new file index of the file within this object.
-  uint32_t copyFile(const GsymCreator &SrcGC, uint32_t FileIdx);
+  LLVM_ABI uint32_t copyFile(const GsymCreator &SrcGC, uint32_t FileIdx);
 
   /// Inserts a FileEntry into the file table.
   ///
@@ -245,7 +246,7 @@ protected:
   ///
   /// \param FE A file entry object that contains valid string table offsets
   /// from this object already.
-  uint32_t insertFileEntry(FileEntry FE);
+  LLVM_ABI uint32_t insertFileEntry(FileEntry FE);
 
   /// Fixup any string and file references by updating any file indexes and
   /// strings offsets in the InlineInfo parameter.
@@ -257,7 +258,7 @@ protected:
   /// \param II The inline info that contains file indexes and string offsets
   /// that come from \a SrcGC. The entries will be updated by coping any files
   /// and strings over into this object.
-  void fixupInlineInfo(const GsymCreator &SrcGC, InlineInfo &II);
+  LLVM_ABI void fixupInlineInfo(const GsymCreator &SrcGC, InlineInfo &II);
 
   /// Save this GSYM file into segments that are roughly \a SegmentSize in size.
   ///
@@ -273,8 +274,8 @@ protected:
   /// \param Path The path prefix to use when saving the GSYM files.
   /// \param ByteOrder The endianness to use when saving the file.
   /// \param SegmentSize The size in bytes to segment the GSYM file into.
-  llvm::Error saveSegments(StringRef Path, llvm::endianness ByteOrder,
-                           uint64_t SegmentSize) const;
+  LLVM_ABI llvm::Error saveSegments(StringRef Path, llvm::endianness ByteOrder,
+                                    uint64_t SegmentSize) const;
 
   /// Let this creator know that this is a segment of another GsymCreator.
   ///
@@ -292,21 +293,22 @@ protected:
   ///
   /// \param[out] BaseAddr Set to the base address on success.
   /// \returns An error if validation fails, or Error::success().
-  llvm::Error validateForEncoding(std::optional<uint64_t> &BaseAddr) const;
+  LLVM_ABI llvm::Error
+  validateForEncoding(std::optional<uint64_t> &BaseAddr) const;
 
   /// Write the address offsets table to the output stream.
   ///
   /// \param O The file writer to write to.
   /// \param AddrOffSize The byte width of each address offset.
   /// \param BaseAddr The base address to subtract from each function address.
-  void encodeAddrOffsets(FileWriter &O, uint8_t AddrOffSize,
-                         uint64_t BaseAddr) const;
+  LLVM_ABI void encodeAddrOffsets(FileWriter &O, uint8_t AddrOffSize,
+                                  uint64_t BaseAddr) const;
 
   /// Write the file table to the output stream.
   ///
   /// \param O The file writer to write to.
   /// \returns An error if the file table is too large, or Error::success().
-  llvm::Error encodeFileTable(FileWriter &O) const;
+  LLVM_ABI llvm::Error encodeFileTable(FileWriter &O) const;
 
   /// Create a new empty creator of the same version.
   ///

--- a/llvm/include/llvm/DebugInfo/GSYM/GsymCreatorV1.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/GsymCreatorV1.h
@@ -15,7 +15,7 @@
 namespace llvm {
 namespace gsym {
 
-class GsymCreatorV1 : public GsymCreator {
+class LLVM_ABI GsymCreatorV1 : public GsymCreator {
   uint64_t calculateHeaderAndTableSize() const override;
   std::unique_ptr<GsymCreator> createNew(bool Quiet) const override {
     return std::make_unique<GsymCreatorV1>(Quiet);
@@ -27,7 +27,7 @@ public:
   uint8_t getStringOffsetSize() const override {
     return Header::getStringOffsetSize();
   }
-  LLVM_ABI llvm::Error encode(FileWriter &O) const override;
+  llvm::Error encode(FileWriter &O) const override;
 };
 
 } // namespace gsym

--- a/llvm/include/llvm/DebugInfo/GSYM/GsymCreatorV2.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/GsymCreatorV2.h
@@ -16,7 +16,7 @@ namespace llvm {
 namespace gsym {
 
 /// GsymCreatorV2 emits GSYM V2 data with a GlobalData-based section layout.
-class GsymCreatorV2 : public GsymCreator {
+class LLVM_ABI GsymCreatorV2 : public GsymCreator {
   uint64_t calculateHeaderAndTableSize() const override;
   std::unique_ptr<GsymCreator> createNew(bool Quiet) const override {
     return std::make_unique<GsymCreatorV2>(Quiet);
@@ -28,7 +28,7 @@ public:
   uint8_t getStringOffsetSize() const override {
     return HeaderV2::getStringOffsetSize();
   }
-  LLVM_ABI llvm::Error encode(FileWriter &O) const override;
+  llvm::Error encode(FileWriter &O) const override;
 };
 
 } // namespace gsym

--- a/llvm/include/llvm/DebugInfo/GSYM/GsymReader.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/GsymReader.h
@@ -58,10 +58,11 @@ protected:
   GsymDataExtractor FileEntryData;
   StringTable StrTab;
 
-  GsymReader(std::unique_ptr<MemoryBuffer> Buffer, llvm::endianness Endian);
+  LLVM_ABI GsymReader(std::unique_ptr<MemoryBuffer> Buffer,
+                      llvm::endianness Endian);
 
 public:
-  LLVM_ABI GsymReader(GsymReader &&RHS) = default;
+  GsymReader(GsymReader &&RHS) = default;
   virtual ~GsymReader() = default;
 
   bool isLittleEndian() const { return Endian == llvm::endianness::little; }
@@ -364,31 +365,31 @@ protected:
   ///
   /// \param Offset The byte offset where GlobalData entries begin.
   /// \returns Error on failure.
-  llvm::Error parseGlobalDataEntries(uint64_t Offset);
+  LLVM_ABI llvm::Error parseGlobalDataEntries(uint64_t Offset);
 
   /// Parse address offsets section bytes into AddrOffsets.
   ///
   /// \param Bytes The raw section bytes.
   /// \returns Error on failure.
-  llvm::Error parseAddrOffsets(StringRef Bytes);
+  LLVM_ABI llvm::Error parseAddrOffsets(StringRef Bytes);
 
   /// Set address info offsets section bytes into AddrInfoOffsetsData.
   ///
   /// \param Bytes The raw section bytes.
   /// \returns Error on failure.
-  llvm::Error setAddrInfoOffsetsData(StringRef Bytes);
+  LLVM_ABI llvm::Error setAddrInfoOffsetsData(StringRef Bytes);
 
   /// Set string table section bytes into StrTab.
   ///
   /// \param Bytes The raw section bytes.
   /// \returns Error on failure.
-  llvm::Error setStringTableData(StringRef Bytes);
+  LLVM_ABI llvm::Error setStringTableData(StringRef Bytes);
 
   /// Set file table section bytes into FileEntryData.
   ///
   /// \param Bytes The raw section bytes.
   /// \returns Error on failure.
-  llvm::Error setFileTableData(StringRef Bytes);
+  LLVM_ABI llvm::Error setFileTableData(StringRef Bytes);
 
   /// Get an appropriate address info offsets array.
   ///

--- a/llvm/include/llvm/DebugInfo/GSYM/GsymReaderV1.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/GsymReaderV1.h
@@ -18,7 +18,7 @@ class MemoryBuffer;
 namespace gsym {
 
 /// GsymReaderV1 reads GSYM V1 data from a buffer.
-class GsymReaderV1 : public GsymReader {
+class LLVM_ABI GsymReaderV1 : public GsymReader {
   friend class GsymReader;
   const Header *Hdr = nullptr;
   std::unique_ptr<Header> SwappedHdr;
@@ -44,7 +44,7 @@ public:
   }
 
   using GsymReader::dump;
-  LLVM_ABI void dump(raw_ostream &OS) override;
+  void dump(raw_ostream &OS) override;
 };
 
 } // namespace gsym

--- a/llvm/include/llvm/DebugInfo/GSYM/GsymReaderV2.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/GsymReaderV2.h
@@ -18,7 +18,7 @@ class MemoryBuffer;
 namespace gsym {
 
 /// GsymReaderV2 reads GSYM V2 data from a buffer.
-class GsymReaderV2 : public GsymReader {
+class LLVM_ABI GsymReaderV2 : public GsymReader {
   friend class GsymReader;
   const HeaderV2 *Hdr = nullptr;
   std::unique_ptr<HeaderV2> SwappedHdr;
@@ -44,7 +44,7 @@ public:
   }
 
   using GsymReader::dump;
-  LLVM_ABI void dump(raw_ostream &OS) override;
+  void dump(raw_ostream &OS) override;
 };
 
 } // namespace gsym

--- a/llvm/include/llvm/DebugInfo/LogicalView/Readers/LVBinaryReader.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Readers/LVBinaryReader.h
@@ -54,17 +54,18 @@ class LVSymbolTable final {
 public:
   LVSymbolTable() = default;
 
-  void add(StringRef Name, LVScope *Function, LVSectionIndex SectionIndex = 0);
-  void add(StringRef Name, LVAddress Address, LVSectionIndex SectionIndex,
-           bool IsComdat);
-  LVSectionIndex update(LVScope *Function);
+  LLVM_ABI void add(StringRef Name, LVScope *Function,
+                    LVSectionIndex SectionIndex = 0);
+  LLVM_ABI void add(StringRef Name, LVAddress Address,
+                    LVSectionIndex SectionIndex, bool IsComdat);
+  LLVM_ABI LVSectionIndex update(LVScope *Function);
 
-  const LVSymbolTableEntry &getEntry(StringRef Name);
-  LVAddress getAddress(StringRef Name);
-  LVSectionIndex getIndex(StringRef Name);
-  bool getIsComdat(StringRef Name);
+  LLVM_ABI const LVSymbolTableEntry &getEntry(StringRef Name);
+  LLVM_ABI LVAddress getAddress(StringRef Name);
+  LLVM_ABI LVSectionIndex getIndex(StringRef Name);
+  LLVM_ABI bool getIsComdat(StringRef Name);
 
-  void print(raw_ostream &OS);
+  LLVM_ABI void print(raw_ostream &OS);
 };
 
 class LVBinaryReader : public LVReader {
@@ -161,8 +162,8 @@ protected:
   LVAddress WasmCodeSectionOffset = 0;
 
   // Loads all info for the architecture of the provided object file.
-  Error loadGenericTargetInfo(StringRef TheTriple, StringRef TheFeatures,
-                              StringRef TheCPU);
+  LLVM_ABI Error loadGenericTargetInfo(StringRef TheTriple,
+                                       StringRef TheFeatures, StringRef TheCPU);
 
   virtual void mapRangeAddress(const object::ObjectFile &Obj) {}
   virtual void mapRangeAddress(const object::ObjectFile &Obj,
@@ -170,22 +171,25 @@ protected:
                                bool IsComdat) {}
 
   // Create a mapping from virtual address to section.
-  void mapVirtualAddress(const object::ObjectFile &Obj);
-  void mapVirtualAddress(const object::COFFObjectFile &COFFObj);
+  LLVM_ABI void mapVirtualAddress(const object::ObjectFile &Obj);
+  LLVM_ABI void mapVirtualAddress(const object::COFFObjectFile &COFFObj);
 
-  Expected<std::pair<LVSectionIndex, object::SectionRef>>
+  LLVM_ABI Expected<std::pair<LVSectionIndex, object::SectionRef>>
   getSection(LVScope *Scope, LVAddress Address, LVSectionIndex SectionIndex);
 
-  void includeInlineeLines(LVSectionIndex SectionIndex, LVScope *Function);
+  LLVM_ABI void includeInlineeLines(LVSectionIndex SectionIndex,
+                                    LVScope *Function);
 
-  Error createInstructions();
-  Error createInstructions(LVScope *Function, LVSectionIndex SectionIndex);
-  Error createInstructions(LVScope *Function, LVSectionIndex SectionIndex,
-                           const LVNameInfo &NameInfo);
+  LLVM_ABI Error createInstructions();
+  LLVM_ABI Error createInstructions(LVScope *Function,
+                                    LVSectionIndex SectionIndex);
+  LLVM_ABI Error createInstructions(LVScope *Function,
+                                    LVSectionIndex SectionIndex,
+                                    const LVNameInfo &NameInfo);
 
-  void processLines(LVLines *DebugLines, LVSectionIndex SectionIndex);
-  void processLines(LVLines *DebugLines, LVSectionIndex SectionIndex,
-                    LVScope *Function);
+  LLVM_ABI void processLines(LVLines *DebugLines, LVSectionIndex SectionIndex);
+  LLVM_ABI void processLines(LVLines *DebugLines, LVSectionIndex SectionIndex,
+                             LVScope *Function);
 
 public:
   LVBinaryReader() = delete;
@@ -206,23 +210,23 @@ public:
     return ImageBaseAddress + (Segment * VirtualAddress) + Offset + Addendum;
   }
 
-  void addToSymbolTable(StringRef Name, LVScope *Function,
-                        LVSectionIndex SectionIndex = 0);
-  void addToSymbolTable(StringRef Name, LVAddress Address,
-                        LVSectionIndex SectionIndex, bool IsComdat);
-  LVSectionIndex updateSymbolTable(LVScope *Function);
+  LLVM_ABI void addToSymbolTable(StringRef Name, LVScope *Function,
+                                 LVSectionIndex SectionIndex = 0);
+  LLVM_ABI void addToSymbolTable(StringRef Name, LVAddress Address,
+                                 LVSectionIndex SectionIndex, bool IsComdat);
+  LLVM_ABI LVSectionIndex updateSymbolTable(LVScope *Function);
 
-  const LVSymbolTableEntry &getSymbolTableEntry(StringRef Name);
-  LVAddress getSymbolTableAddress(StringRef Name);
-  LVSectionIndex getSymbolTableIndex(StringRef Name);
-  bool getSymbolTableIsComdat(StringRef Name);
+  LLVM_ABI const LVSymbolTableEntry &getSymbolTableEntry(StringRef Name);
+  LLVM_ABI LVAddress getSymbolTableAddress(StringRef Name);
+  LLVM_ABI LVSectionIndex getSymbolTableIndex(StringRef Name);
+  LLVM_ABI bool getSymbolTableIsComdat(StringRef Name);
 
   LVSectionIndex getSectionIndex(LVScope *Scope) override {
     return Scope ? getSymbolTableIndex(Scope->getLinkageName())
                  : DotTextSectionIndex;
   }
 
-  void print(raw_ostream &OS) const;
+  LLVM_ABI void print(raw_ostream &OS) const;
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const { print(dbgs()); }

--- a/llvm/include/llvm/DebugInfo/LogicalView/Readers/LVCodeViewReader.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Readers/LVCodeViewReader.h
@@ -64,7 +64,7 @@ using LVNames = SmallVector<StringRef, 16>;
 // As the CodeView constants are different to the DWARF constants, the
 // CodeView reader will map them to the DWARF ones.
 
-class LVCodeViewReader final : public LVBinaryReader {
+class LLVM_ABI LVCodeViewReader final : public LVBinaryReader {
   friend class LVTypeVisitor;
   friend class LVSymbolVisitor;
   friend class LVSymbolVisitorDelegate;

--- a/llvm/include/llvm/DebugInfo/LogicalView/Readers/LVCodeViewVisitor.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Readers/LVCodeViewVisitor.h
@@ -36,7 +36,7 @@ class LVCodeViewReader;
 class LVLogicalVisitor;
 struct LVShared;
 
-class LVTypeVisitor final : public TypeVisitorCallbacks {
+class LLVM_ABI LVTypeVisitor final : public TypeVisitorCallbacks {
   ScopedPrinter &W;
   LVLogicalVisitor *LogicalVisitor;
   LazyRandomTypeCollection &Types;
@@ -82,7 +82,7 @@ public:
   Error visitUnknownType(CVType &Record) override;
 };
 
-class LVSymbolVisitorDelegate final : public SymbolVisitorDelegate {
+class LLVM_ABI LVSymbolVisitorDelegate final : public SymbolVisitorDelegate {
   LVCodeViewReader *Reader;
   const llvm::object::coff_section *CoffSection;
   StringRef SectionContents;
@@ -121,7 +121,7 @@ class LVSymbol;
 class LVType;
 
 // Visitor for CodeView symbol streams found in COFF object files and PDB files.
-class LVSymbolVisitor final : public SymbolVisitorCallbacks {
+class LLVM_ABI LVSymbolVisitor final : public SymbolVisitorCallbacks {
   LVCodeViewReader *Reader;
   ScopedPrinter &W;
   LVLogicalVisitor *LogicalVisitor;
@@ -287,8 +287,8 @@ class LVLogicalVisitor final {
   void createParents(StringRef ScopedName, LVElement *Element);
 
 public:
-  LVLogicalVisitor(LVCodeViewReader *Reader, ScopedPrinter &W,
-                   llvm::pdb::InputFile &Input);
+  LLVM_ABI LVLogicalVisitor(LVCodeViewReader *Reader, ScopedPrinter &W,
+                            llvm::pdb::InputFile &Input);
 
   // Current elements during the processing of a RecordType or RecordSymbol.
   // They are shared with the SymbolVisitor.
@@ -310,19 +310,20 @@ public:
                         std::forward_as_tuple(LineNumber, Filename));
   }
 
-  void printTypeIndex(StringRef FieldName, TypeIndex TI, uint32_t StreamIdx);
-  void printMemberAttributes(MemberAttributes Attrs);
-  void printMemberAttributes(MemberAccess Access, MethodKind Kind,
-                             MethodOptions Options);
+  LLVM_ABI void printTypeIndex(StringRef FieldName, TypeIndex TI,
+                               uint32_t StreamIdx);
+  LLVM_ABI void printMemberAttributes(MemberAttributes Attrs);
+  LLVM_ABI void printMemberAttributes(MemberAccess Access, MethodKind Kind,
+                                      MethodOptions Options);
 
-  LVElement *createElement(TypeLeafKind Kind);
-  LVElement *createElement(SymbolKind Kind);
-  LVElement *createElement(TypeIndex TI, TypeLeafKind Kind);
+  LLVM_ABI LVElement *createElement(TypeLeafKind Kind);
+  LLVM_ABI LVElement *createElement(SymbolKind Kind);
+  LLVM_ABI LVElement *createElement(TypeIndex TI, TypeLeafKind Kind);
 
   // Break down the annotation byte code and calculate code and line offsets.
-  Error inlineSiteAnnotation(LVScope *AbstractFunction,
-                             LVScope *InlinedFunction,
-                             InlineSiteSym &InlineSite);
+  LLVM_ABI Error inlineSiteAnnotation(LVScope *AbstractFunction,
+                                      LVScope *InlinedFunction,
+                                      InlineSiteSym &InlineSite);
 
   void pushScope(LVScope *Scope) {
     ScopeStack.push(ReaderParent);
@@ -342,110 +343,121 @@ public:
   }
   void setRoot(LVScope *Root) { ReaderScope = Root; }
 
-  void addElement(LVScope *Scope, bool IsCompileUnit);
-  void addElement(LVSymbol *Symbol);
-  void addElement(LVType *Type);
+  LLVM_ABI void addElement(LVScope *Scope, bool IsCompileUnit);
+  LLVM_ABI void addElement(LVSymbol *Symbol);
+  LLVM_ABI void addElement(LVType *Type);
 
   std::string getCompileUnitName() { return CompileUnitName; }
   void setCompileUnitName(std::string Name) {
     CompileUnitName = std::move(Name);
   }
 
-  LVElement *getElement(uint32_t StreamIdx, TypeIndex TI,
-                        LVScope *Parent = nullptr);
+  LLVM_ABI LVElement *getElement(uint32_t StreamIdx, TypeIndex TI,
+                                 LVScope *Parent = nullptr);
   LVShared *getShared() { return Shared.get(); }
 
   LVScope *getReaderScope() const { return ReaderScope; }
 
-  void printTypeBegin(CVType &Record, TypeIndex TI, LVElement *Element,
-                      uint32_t StreamIdx);
-  void printTypeEnd(CVType &Record);
-  void printMemberBegin(CVMemberRecord &Record, TypeIndex TI,
-                        LVElement *Element, uint32_t StreamIdx);
-  void printMemberEnd(CVMemberRecord &Record);
+  LLVM_ABI void printTypeBegin(CVType &Record, TypeIndex TI, LVElement *Element,
+                               uint32_t StreamIdx);
+  LLVM_ABI void printTypeEnd(CVType &Record);
+  LLVM_ABI void printMemberBegin(CVMemberRecord &Record, TypeIndex TI,
+                                 LVElement *Element, uint32_t StreamIdx);
+  LLVM_ABI void printMemberEnd(CVMemberRecord &Record);
 
   void startProcessArgumentList() { ProcessArgumentList = true; }
   void stopProcessArgumentList() { ProcessArgumentList = false; }
 
-  void processFiles();
-  void processLines();
-  void processNamespaces();
+  LLVM_ABI void processFiles();
+  LLVM_ABI void processLines();
+  LLVM_ABI void processNamespaces();
 
-  void printRecords(raw_ostream &OS) const;
+  LLVM_ABI void printRecords(raw_ostream &OS) const;
 
-  Error visitUnknownType(CVType &Record, TypeIndex TI);
-  Error visitKnownRecord(CVType &Record, ArgListRecord &Args, TypeIndex TI,
-                         LVElement *Element);
-  Error visitKnownRecord(CVType &Record, ArrayRecord &AT, TypeIndex TI,
-                         LVElement *Element);
-  Error visitKnownRecord(CVType &Record, BitFieldRecord &BF, TypeIndex TI,
-                         LVElement *Element);
-  Error visitKnownRecord(CVType &Record, BuildInfoRecord &BI, TypeIndex TI,
-                         LVElement *Element);
-  Error visitKnownRecord(CVType &Record, ClassRecord &Class, TypeIndex TI,
-                         LVElement *Element);
-  Error visitKnownRecord(CVType &Record, EnumRecord &Enum, TypeIndex TI,
-                         LVElement *Element);
-  Error visitKnownRecord(CVType &Record, FieldListRecord &FieldList,
-                         TypeIndex TI, LVElement *Element);
-  Error visitKnownRecord(CVType &Record, FuncIdRecord &Func, TypeIndex TI,
-                         LVElement *Element);
-  Error visitKnownRecord(CVType &Record, LabelRecord &LR, TypeIndex TI,
-                         LVElement *Element);
-  Error visitKnownRecord(CVType &Record, ModifierRecord &Mod, TypeIndex TI,
-                         LVElement *Element);
-  Error visitKnownRecord(CVType &Record, MemberFuncIdRecord &Id, TypeIndex TI,
-                         LVElement *Element);
-  Error visitKnownRecord(CVType &Record, MemberFunctionRecord &MF, TypeIndex TI,
-                         LVElement *Element);
-  Error visitKnownRecord(CVType &Record, MethodOverloadListRecord &Overloads,
-                         TypeIndex TI, LVElement *Element);
-  Error visitKnownRecord(CVType &Record, PointerRecord &Ptr, TypeIndex TI,
-                         LVElement *Element);
-  Error visitKnownRecord(CVType &Record, ProcedureRecord &Proc, TypeIndex TI,
-                         LVElement *Element);
-  Error visitKnownRecord(CVType &Record, UnionRecord &Union, TypeIndex TI,
-                         LVElement *Element);
-  Error visitKnownRecord(CVType &Record, TypeServer2Record &TS, TypeIndex TI,
-                         LVElement *Element);
-  Error visitKnownRecord(CVType &Record, VFTableRecord &VFT, TypeIndex TI,
-                         LVElement *Element);
-  Error visitKnownRecord(CVType &Record, VFTableShapeRecord &Shape,
-                         TypeIndex TI, LVElement *Element);
-  Error visitKnownRecord(CVType &Record, StringListRecord &Strings,
-                         TypeIndex TI, LVElement *Element);
-  Error visitKnownRecord(CVType &Record, StringIdRecord &String, TypeIndex TI,
-                         LVElement *Element);
-  Error visitKnownRecord(CVType &Record, UdtSourceLineRecord &SourceLine,
-                         TypeIndex TI, LVElement *Element);
-  Error visitKnownRecord(CVType &Record, UdtModSourceLineRecord &ModSourceLine,
-                         TypeIndex TI, LVElement *Element);
-  Error visitKnownRecord(CVType &Record, PrecompRecord &Precomp, TypeIndex TI,
-                         LVElement *Element);
-  Error visitKnownRecord(CVType &Record, EndPrecompRecord &EndPrecomp,
-                         TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitUnknownType(CVType &Record, TypeIndex TI);
+  LLVM_ABI Error visitKnownRecord(CVType &Record, ArgListRecord &Args,
+                                  TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record, ArrayRecord &AT, TypeIndex TI,
+                                  LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record, BitFieldRecord &BF,
+                                  TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record, BuildInfoRecord &BI,
+                                  TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record, ClassRecord &Class,
+                                  TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record, EnumRecord &Enum,
+                                  TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record, FieldListRecord &FieldList,
+                                  TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record, FuncIdRecord &Func,
+                                  TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record, LabelRecord &LR, TypeIndex TI,
+                                  LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record, ModifierRecord &Mod,
+                                  TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record, MemberFuncIdRecord &Id,
+                                  TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record, MemberFunctionRecord &MF,
+                                  TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record,
+                                  MethodOverloadListRecord &Overloads,
+                                  TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record, PointerRecord &Ptr,
+                                  TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record, ProcedureRecord &Proc,
+                                  TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record, UnionRecord &Union,
+                                  TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record, TypeServer2Record &TS,
+                                  TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record, VFTableRecord &VFT,
+                                  TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record, VFTableShapeRecord &Shape,
+                                  TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record, StringListRecord &Strings,
+                                  TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record, StringIdRecord &String,
+                                  TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record,
+                                  UdtSourceLineRecord &SourceLine, TypeIndex TI,
+                                  LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record,
+                                  UdtModSourceLineRecord &ModSourceLine,
+                                  TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record, PrecompRecord &Precomp,
+                                  TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitKnownRecord(CVType &Record, EndPrecompRecord &EndPrecomp,
+                                  TypeIndex TI, LVElement *Element);
 
-  Error visitUnknownMember(CVMemberRecord &Record, TypeIndex TI);
-  Error visitKnownMember(CVMemberRecord &Record, BaseClassRecord &Base,
-                         TypeIndex TI, LVElement *Element);
-  Error visitKnownMember(CVMemberRecord &Record, DataMemberRecord &Field,
-                         TypeIndex TI, LVElement *Element);
-  Error visitKnownMember(CVMemberRecord &Record, EnumeratorRecord &Enum,
-                         TypeIndex TI, LVElement *Element);
-  Error visitKnownMember(CVMemberRecord &Record, ListContinuationRecord &Cont,
-                         TypeIndex TI, LVElement *Element);
-  Error visitKnownMember(CVMemberRecord &Record, NestedTypeRecord &Nested,
-                         TypeIndex TI, LVElement *Element);
-  Error visitKnownMember(CVMemberRecord &Record, OneMethodRecord &Method,
-                         TypeIndex TI, LVElement *Element);
-  Error visitKnownMember(CVMemberRecord &Record, OverloadedMethodRecord &Method,
-                         TypeIndex TI, LVElement *Element);
-  Error visitKnownMember(CVMemberRecord &Record, StaticDataMemberRecord &Field,
-                         TypeIndex TI, LVElement *Element);
-  Error visitKnownMember(CVMemberRecord &Record, VFPtrRecord &VFTable,
-                         TypeIndex TI, LVElement *Element);
-  Error visitKnownMember(CVMemberRecord &Record, VirtualBaseClassRecord &Base,
-                         TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitUnknownMember(CVMemberRecord &Record, TypeIndex TI);
+  LLVM_ABI Error visitKnownMember(CVMemberRecord &Record, BaseClassRecord &Base,
+                                  TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitKnownMember(CVMemberRecord &Record,
+                                  DataMemberRecord &Field, TypeIndex TI,
+                                  LVElement *Element);
+  LLVM_ABI Error visitKnownMember(CVMemberRecord &Record,
+                                  EnumeratorRecord &Enum, TypeIndex TI,
+                                  LVElement *Element);
+  LLVM_ABI Error visitKnownMember(CVMemberRecord &Record,
+                                  ListContinuationRecord &Cont, TypeIndex TI,
+                                  LVElement *Element);
+  LLVM_ABI Error visitKnownMember(CVMemberRecord &Record,
+                                  NestedTypeRecord &Nested, TypeIndex TI,
+                                  LVElement *Element);
+  LLVM_ABI Error visitKnownMember(CVMemberRecord &Record,
+                                  OneMethodRecord &Method, TypeIndex TI,
+                                  LVElement *Element);
+  LLVM_ABI Error visitKnownMember(CVMemberRecord &Record,
+                                  OverloadedMethodRecord &Method, TypeIndex TI,
+                                  LVElement *Element);
+  LLVM_ABI Error visitKnownMember(CVMemberRecord &Record,
+                                  StaticDataMemberRecord &Field, TypeIndex TI,
+                                  LVElement *Element);
+  LLVM_ABI Error visitKnownMember(CVMemberRecord &Record, VFPtrRecord &VFTable,
+                                  TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitKnownMember(CVMemberRecord &Record,
+                                  VirtualBaseClassRecord &Base, TypeIndex TI,
+                                  LVElement *Element);
 
   template <typename T>
   Error visitKnownMember(CVMemberRecord &Record,
@@ -472,10 +484,11 @@ public:
     return Error::success();
   }
 
-  Error visitMemberRecord(CVMemberRecord &Record,
-                          TypeVisitorCallbacks &Callbacks, TypeIndex TI,
-                          LVElement *Element);
-  Error finishVisitation(CVType &Record, TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error visitMemberRecord(CVMemberRecord &Record,
+                                   TypeVisitorCallbacks &Callbacks,
+                                   TypeIndex TI, LVElement *Element);
+  LLVM_ABI Error finishVisitation(CVType &Record, TypeIndex TI,
+                                  LVElement *Element);
 };
 
 } // namespace logicalview

--- a/llvm/include/llvm/DebugInfo/LogicalView/Readers/LVDWARFReader.h
+++ b/llvm/include/llvm/DebugInfo/LogicalView/Readers/LVDWARFReader.h
@@ -30,7 +30,7 @@ class LVType;
 
 using AttributeSpec = DWARFAbbreviationDeclaration::AttributeSpec;
 
-class LVDWARFReader final : public LVBinaryReader {
+class LLVM_ABI LVDWARFReader final : public LVBinaryReader {
   object::ObjectFile &Obj;
 
   // Indicates if ranges data are available; in the case of split DWARF any

--- a/llvm/include/llvm/DebugInfo/PDB/IPDBDataStream.h
+++ b/llvm/include/llvm/DebugInfo/PDB/IPDBDataStream.h
@@ -20,7 +20,7 @@ namespace pdb {
 /// IPDBDataStream defines an interface used to represent a stream consisting
 /// of a name and a series of records whose formats depend on the particular
 /// stream type.
-class IPDBDataStream {
+class LLVM_ABI IPDBDataStream {
 public:
   using RecordType = SmallVector<uint8_t, 32>;
 

--- a/llvm/include/llvm/DebugInfo/PDB/IPDBSectionContrib.h
+++ b/llvm/include/llvm/DebugInfo/PDB/IPDBSectionContrib.h
@@ -16,7 +16,7 @@ namespace pdb {
 
 /// IPDBSectionContrib defines an interface used to represent section
 /// contributions whose information are stored in the PDB.
-class IPDBSectionContrib {
+class LLVM_ABI IPDBSectionContrib {
 public:
   virtual ~IPDBSectionContrib();
 

--- a/llvm/include/llvm/DebugInfo/PDB/IPDBTable.h
+++ b/llvm/include/llvm/DebugInfo/PDB/IPDBTable.h
@@ -13,7 +13,7 @@
 
 namespace llvm {
 namespace pdb {
-class IPDBTable {
+class LLVM_ABI IPDBTable {
 public:
   virtual ~IPDBTable();
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/EnumTables.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/EnumTables.h
@@ -14,7 +14,7 @@
 namespace llvm {
 template <typename T> struct EnumEntry;
 namespace pdb {
-ArrayRef<EnumEntry<uint16_t>> getOMFSegMapDescFlagNames();
+LLVM_ABI ArrayRef<EnumEntry<uint16_t>> getOMFSegMapDescFlagNames();
 }
 }
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/InjectedSourceStream.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/InjectedSourceStream.h
@@ -21,8 +21,8 @@ class PDBStringTable;
 
 class InjectedSourceStream {
 public:
-  InjectedSourceStream(std::unique_ptr<msf::MappedBlockStream> Stream);
-  Error reload(const PDBStringTable &Strings);
+  LLVM_ABI InjectedSourceStream(std::unique_ptr<msf::MappedBlockStream> Stream);
+  LLVM_ABI Error reload(const PDBStringTable &Strings);
 
   using const_iterator = HashTable<SrcHeaderBlockEntry>::const_iterator;
   const_iterator begin() const { return InjectedSourceTable.begin(); }

--- a/llvm/include/llvm/DebugInfo/PDB/Native/InputFile.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/InputFile.h
@@ -55,9 +55,9 @@ class InputFile {
   getOrCreateTypeCollection(TypeCollectionKind Kind);
 
 public:
-  InputFile(PDBFile *Pdb);
-  InputFile(object::COFFObjectFile *Obj);
-  InputFile(MemoryBuffer *Buffer);
+  LLVM_ABI InputFile(PDBFile *Pdb);
+  LLVM_ABI InputFile(object::COFFObjectFile *Obj);
+  LLVM_ABI InputFile(MemoryBuffer *Buffer);
   LLVM_ABI ~InputFile();
   InputFile(InputFile &&Other) = default;
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeCompilandSymbol.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeCompilandSymbol.h
@@ -15,7 +15,7 @@
 namespace llvm {
 namespace pdb {
 
-class NativeCompilandSymbol : public NativeRawSymbol {
+class LLVM_ABI NativeCompilandSymbol : public NativeRawSymbol {
 public:
   NativeCompilandSymbol(NativeSession &Session, SymIndexId SymbolId,
                         DbiModuleDescriptor MI);

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeEnumGlobals.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeEnumGlobals.h
@@ -20,7 +20,7 @@ namespace pdb {
 
 class NativeSession;
 
-class NativeEnumGlobals : public IPDBEnumChildren<PDBSymbol> {
+class LLVM_ABI NativeEnumGlobals : public IPDBEnumChildren<PDBSymbol> {
 public:
   NativeEnumGlobals(NativeSession &Session,
                     std::vector<codeview::SymbolKind> Kinds);

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeEnumInjectedSources.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeEnumInjectedSources.h
@@ -20,7 +20,8 @@ class InjectedSourceStream;
 class PDBFile;
 class PDBStringTable;
 
-class NativeEnumInjectedSources : public IPDBEnumChildren<IPDBInjectedSource> {
+class LLVM_ABI NativeEnumInjectedSources
+    : public IPDBEnumChildren<IPDBInjectedSource> {
 public:
   NativeEnumInjectedSources(PDBFile &File, const InjectedSourceStream &IJS,
                             const PDBStringTable &Strings);

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeEnumLineNumbers.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeEnumLineNumbers.h
@@ -17,9 +17,12 @@
 namespace llvm {
 namespace pdb {
 
-class NativeEnumLineNumbers : public IPDBEnumChildren<IPDBLineNumber> {
+class LLVM_ABI NativeEnumLineNumbers : public IPDBEnumChildren<IPDBLineNumber> {
 public:
   explicit NativeEnumLineNumbers(std::vector<NativeLineNumber> LineNums);
+
+  NativeEnumLineNumbers(const NativeEnumLineNumbers &) = delete;
+  NativeEnumLineNumbers &operator=(const NativeEnumLineNumbers &) = delete;
 
   uint32_t getChildCount() const override;
   ChildTypePtr getChildAtIndex(uint32_t Index) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeEnumModules.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeEnumModules.h
@@ -16,7 +16,7 @@ namespace pdb {
 
 class NativeSession;
 
-class NativeEnumModules : public IPDBEnumChildren<PDBSymbol> {
+class LLVM_ABI NativeEnumModules : public IPDBEnumChildren<PDBSymbol> {
 public:
   NativeEnumModules(NativeSession &Session, uint32_t Index = 0);
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeEnumSymbols.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeEnumSymbols.h
@@ -20,7 +20,7 @@ namespace pdb {
 
 class NativeSession;
 
-class NativeEnumSymbols : public IPDBEnumChildren<PDBSymbol> {
+class LLVM_ABI NativeEnumSymbols : public IPDBEnumChildren<PDBSymbol> {
 public:
   NativeEnumSymbols(NativeSession &Session, std::vector<SymIndexId> Symbols);
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeEnumTypes.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeEnumTypes.h
@@ -24,7 +24,7 @@ namespace pdb {
 
 class NativeSession;
 
-class NativeEnumTypes : public IPDBEnumChildren<PDBSymbol> {
+class LLVM_ABI NativeEnumTypes : public IPDBEnumChildren<PDBSymbol> {
 public:
   NativeEnumTypes(NativeSession &Session,
                   codeview::LazyRandomTypeCollection &TypeCollection,

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeExeSymbol.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeExeSymbol.h
@@ -20,7 +20,7 @@ class NativeSession;
 
 class DbiStream;
 
-class NativeExeSymbol : public NativeRawSymbol {
+class LLVM_ABI NativeExeSymbol : public NativeRawSymbol {
   // EXE symbol is the authority on the various symbol types.
   DbiStream *Dbi = nullptr;
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeFunctionSymbol.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeFunctionSymbol.h
@@ -20,7 +20,7 @@ namespace pdb {
 
 class NativeSession;
 
-class NativeFunctionSymbol : public NativeRawSymbol {
+class LLVM_ABI NativeFunctionSymbol : public NativeRawSymbol {
 public:
   NativeFunctionSymbol(NativeSession &Session, SymIndexId Id,
                        const codeview::ProcSym &Sym, uint32_t RecordOffset);

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeInlineSiteSymbol.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeInlineSiteSymbol.h
@@ -19,7 +19,7 @@ namespace pdb {
 
 class NativeSession;
 
-class NativeInlineSiteSymbol : public NativeRawSymbol {
+class LLVM_ABI NativeInlineSiteSymbol : public NativeRawSymbol {
 public:
   NativeInlineSiteSymbol(NativeSession &Session, SymIndexId Id,
                          const codeview::InlineSiteSym &Sym,

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeLineNumber.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeLineNumber.h
@@ -17,7 +17,7 @@ namespace pdb {
 
 class NativeSession;
 
-class NativeLineNumber : public IPDBLineNumber {
+class LLVM_ABI NativeLineNumber : public IPDBLineNumber {
 public:
   explicit NativeLineNumber(const NativeSession &Session,
                             const codeview::LineInfo Line,

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativePublicSymbol.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativePublicSymbol.h
@@ -18,7 +18,7 @@ class raw_ostream;
 namespace pdb {
 class NativeSession;
 
-class NativePublicSymbol : public NativeRawSymbol {
+class LLVM_ABI NativePublicSymbol : public NativeRawSymbol {
 public:
   NativePublicSymbol(NativeSession &Session, SymIndexId Id,
                      const codeview::PublicSym32 &Sym);

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeSymbolEnumerator.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeSymbolEnumerator.h
@@ -21,7 +21,7 @@ namespace pdb {
 class NativeSession;
 class NativeTypeEnum;
 
-class NativeSymbolEnumerator : public NativeRawSymbol {
+class LLVM_ABI NativeSymbolEnumerator : public NativeRawSymbol {
 public:
   NativeSymbolEnumerator(NativeSession &Session, SymIndexId Id,
                          const NativeTypeEnum &Parent,

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeTypeArray.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeTypeArray.h
@@ -19,7 +19,7 @@ namespace pdb {
 
 class NativeSession;
 
-class NativeTypeArray : public NativeRawSymbol {
+class LLVM_ABI NativeTypeArray : public NativeRawSymbol {
 public:
   NativeTypeArray(NativeSession &Session, SymIndexId Id, codeview::TypeIndex TI,
                   codeview::ArrayRecord Record);

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeTypeBuiltin.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeTypeBuiltin.h
@@ -18,7 +18,7 @@ namespace pdb {
 
 class NativeSession;
 
-class NativeTypeBuiltin : public NativeRawSymbol {
+class LLVM_ABI NativeTypeBuiltin : public NativeRawSymbol {
 public:
   NativeTypeBuiltin(NativeSession &PDBSession, SymIndexId Id,
                     codeview::ModifierOptions Mods, PDB_BuiltinType T,

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeTypeEnum.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeTypeEnum.h
@@ -21,7 +21,7 @@ namespace pdb {
 
 class NativeTypeBuiltin;
 
-class NativeTypeEnum : public NativeRawSymbol {
+class LLVM_ABI NativeTypeEnum : public NativeRawSymbol {
 public:
   NativeTypeEnum(NativeSession &Session, SymIndexId Id, codeview::TypeIndex TI,
                  codeview::EnumRecord Record);

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeTypeFunctionSig.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeTypeFunctionSig.h
@@ -18,7 +18,7 @@
 namespace llvm {
 namespace pdb {
 
-class NativeTypeFunctionSig : public NativeRawSymbol {
+class LLVM_ABI NativeTypeFunctionSig : public NativeRawSymbol {
 protected:
   void initialize() override;
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeTypePointer.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeTypePointer.h
@@ -18,7 +18,7 @@
 namespace llvm {
 namespace pdb {
 
-class NativeTypePointer : public NativeRawSymbol {
+class LLVM_ABI NativeTypePointer : public NativeRawSymbol {
 public:
   // Create a pointer record for a simple type.
   NativeTypePointer(NativeSession &Session, SymIndexId Id,

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeTypeTypedef.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeTypeTypedef.h
@@ -22,7 +22,7 @@ namespace pdb {
 
 class NativeSession;
 
-class NativeTypeTypedef : public NativeRawSymbol {
+class LLVM_ABI NativeTypeTypedef : public NativeRawSymbol {
 public:
   // Create a pointer record for a non-simple type.
   NativeTypeTypedef(NativeSession &Session, SymIndexId Id,

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeTypeUDT.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeTypeUDT.h
@@ -21,7 +21,7 @@ class raw_ostream;
 namespace pdb {
 class NativeSession;
 
-class NativeTypeUDT : public NativeRawSymbol {
+class LLVM_ABI NativeTypeUDT : public NativeRawSymbol {
 public:
   NativeTypeUDT(NativeSession &Session, SymIndexId Id, codeview::TypeIndex TI,
                 codeview::ClassRecord Class);

--- a/llvm/include/llvm/DebugInfo/PDB/Native/NativeTypeVTShape.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/NativeTypeVTShape.h
@@ -19,7 +19,7 @@ namespace llvm {
 namespace pdb {
 class NativeSession;
 
-class NativeTypeVTShape : public NativeRawSymbol {
+class LLVM_ABI NativeTypeVTShape : public NativeRawSymbol {
 public:
   // Create a pointer record for a non-simple type.
   NativeTypeVTShape(NativeSession &Session, SymIndexId Id,

--- a/llvm/include/llvm/DebugInfo/PDB/PDBContext.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBContext.h
@@ -29,38 +29,38 @@ namespace pdb {
   /// need for a transparent interface to different debug information formats
   /// (e.g. PDB and DWARF).  More control and power over the debug information
   /// access can be had by using the PDB interfaces directly.
-  class PDBContext : public DIContext {
-  public:
-    PDBContext(const object::COFFObjectFile &Object,
-               std::unique_ptr<IPDBSession> PDBSession);
-    PDBContext(PDBContext &) = delete;
-    PDBContext &operator=(PDBContext &) = delete;
+class LLVM_ABI PDBContext : public DIContext {
+public:
+  PDBContext(const object::COFFObjectFile &Object,
+             std::unique_ptr<IPDBSession> PDBSession);
+  PDBContext(PDBContext &) = delete;
+  PDBContext &operator=(PDBContext &) = delete;
 
-    static bool classof(const DIContext *DICtx) {
-      return DICtx->getKind() == CK_PDB;
-    }
+  static bool classof(const DIContext *DICtx) {
+    return DICtx->getKind() == CK_PDB;
+  }
 
-    void dump(raw_ostream &OS, DIDumpOptions DIDumpOpts) override;
+  void dump(raw_ostream &OS, DIDumpOptions DIDumpOpts) override;
 
-    std::optional<DILineInfo> getLineInfoForAddress(
-        object::SectionedAddress Address,
-        DILineInfoSpecifier Specifier = DILineInfoSpecifier()) override;
-    std::optional<DILineInfo>
-    getLineInfoForDataAddress(object::SectionedAddress Address) override;
-    DILineInfoTable getLineInfoForAddressRange(
-        object::SectionedAddress Address, uint64_t Size,
-        DILineInfoSpecifier Specifier = DILineInfoSpecifier()) override;
-    DIInliningInfo getInliningInfoForAddress(
-        object::SectionedAddress Address,
-        DILineInfoSpecifier Specifier = DILineInfoSpecifier()) override;
+  std::optional<DILineInfo> getLineInfoForAddress(
+      object::SectionedAddress Address,
+      DILineInfoSpecifier Specifier = DILineInfoSpecifier()) override;
+  std::optional<DILineInfo>
+  getLineInfoForDataAddress(object::SectionedAddress Address) override;
+  DILineInfoTable getLineInfoForAddressRange(
+      object::SectionedAddress Address, uint64_t Size,
+      DILineInfoSpecifier Specifier = DILineInfoSpecifier()) override;
+  DIInliningInfo getInliningInfoForAddress(
+      object::SectionedAddress Address,
+      DILineInfoSpecifier Specifier = DILineInfoSpecifier()) override;
 
-    std::vector<DILocal>
-    getLocalsForAddress(object::SectionedAddress Address) override;
+  std::vector<DILocal>
+  getLocalsForAddress(object::SectionedAddress Address) override;
 
-  private:
-    std::string getFunctionName(uint64_t Address, DINameKind NameKind) const;
-    std::unique_ptr<IPDBSession> Session;
-  };
+private:
+  std::string getFunctionName(uint64_t Address, DINameKind NameKind) const;
+  std::unique_ptr<IPDBSession> Session;
+};
 
 } // end namespace pdb
 

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolAnnotation.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolAnnotation.h
@@ -15,7 +15,7 @@ namespace llvm {
 
 namespace pdb {
 
-class PDBSymbolAnnotation : public PDBSymbol {
+class LLVM_ABI PDBSymbolAnnotation : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::Annotation)
 
 public:

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolBlock.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolBlock.h
@@ -15,7 +15,7 @@ namespace llvm {
 
 namespace pdb {
 
-class PDBSymbolBlock : public PDBSymbol {
+class LLVM_ABI PDBSymbolBlock : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::Block)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolCompilandDetails.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolCompilandDetails.h
@@ -16,7 +16,7 @@ namespace llvm {
 
 namespace pdb {
 
-class PDBSymbolCompilandDetails : public PDBSymbol {
+class LLVM_ABI PDBSymbolCompilandDetails : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::CompilandDetails)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolCompilandEnv.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolCompilandEnv.h
@@ -15,7 +15,7 @@
 namespace llvm {
 
 namespace pdb {
-class PDBSymbolCompilandEnv : public PDBSymbol {
+class LLVM_ABI PDBSymbolCompilandEnv : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::CompilandEnv)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolCustom.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolCustom.h
@@ -19,7 +19,7 @@ namespace pdb {
 /// PDBSymbolCustom represents symbols that are compiler-specific and do not
 /// fit anywhere else in the lexical hierarchy.
 /// https://msdn.microsoft.com/en-us/library/d88sf09h.aspx
-class PDBSymbolCustom : public PDBSymbol {
+class LLVM_ABI PDBSymbolCustom : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::Custom)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeCustom.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeCustom.h
@@ -16,7 +16,7 @@ namespace llvm {
 
 namespace pdb {
 
-class PDBSymbolTypeCustom : public PDBSymbol {
+class LLVM_ABI PDBSymbolTypeCustom : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::CustomType)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeDimension.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeDimension.h
@@ -16,7 +16,7 @@ namespace llvm {
 
 namespace pdb {
 
-class PDBSymbolTypeDimension : public PDBSymbol {
+class LLVM_ABI PDBSymbolTypeDimension : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::Dimension)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeFriend.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeFriend.h
@@ -16,7 +16,7 @@ namespace llvm {
 
 namespace pdb {
 
-class PDBSymbolTypeFriend : public PDBSymbol {
+class LLVM_ABI PDBSymbolTypeFriend : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::Friend)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeManaged.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBSymbolTypeManaged.h
@@ -16,7 +16,7 @@ namespace llvm {
 
 namespace pdb {
 
-class PDBSymbolTypeManaged : public PDBSymbol {
+class LLVM_ABI PDBSymbolTypeManaged : public PDBSymbol {
   DECLARE_PDB_SYMBOL_CONCRETE_TYPE(PDB_SymType::ManagedType)
 public:
   void dump(PDBSymDumper &Dumper) const override;

--- a/llvm/include/llvm/DebugInfo/Symbolize/SymbolizableObjectFile.h
+++ b/llvm/include/llvm/DebugInfo/Symbolize/SymbolizableObjectFile.h
@@ -28,7 +28,7 @@ class DataExtractor;
 
 namespace symbolize {
 
-class SymbolizableObjectFile : public SymbolizableModule {
+class LLVM_ABI SymbolizableObjectFile : public SymbolizableModule {
 public:
   static Expected<std::unique_ptr<SymbolizableObjectFile>>
   create(const object::ObjectFile *Obj, std::unique_ptr<DIContext> DICtx,


### PR DESCRIPTION
This updates most LLVM_ABI annotations in the DebugInfo headers to match expected usage:
* All public APIs should be properly annotated.
* Inlined functions should not be annotated.

These changes were done by a script fixing annotations on LLVM public headers and manually checked.

This effort is tracked in #109483.