### PR TITLE
[AMDGPU] Support Wave Reduction intrinsics for half types

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
@@ -8234,10 +8234,14 @@ bool AMDGPULegalizerInfo::legalizeIntrinsic(LegalizerHelper &Helper,
   }
   case Intrinsic::amdgcn_wave_reduce_min:
   case Intrinsic::amdgcn_wave_reduce_umin:
+  case Intrinsic::amdgcn_wave_reduce_fmin:
   case Intrinsic::amdgcn_wave_reduce_max:
   case Intrinsic::amdgcn_wave_reduce_umax:
+  case Intrinsic::amdgcn_wave_reduce_fmax:
   case Intrinsic::amdgcn_wave_reduce_add:
+  case Intrinsic::amdgcn_wave_reduce_fadd:
   case Intrinsic::amdgcn_wave_reduce_sub:
+  case Intrinsic::amdgcn_wave_reduce_fsub:
   case Intrinsic::amdgcn_wave_reduce_and:
   case Intrinsic::amdgcn_wave_reduce_or:
   case Intrinsic::amdgcn_wave_reduce_xor: {
@@ -8245,18 +8249,26 @@ bool AMDGPULegalizerInfo::legalizeIntrinsic(LegalizerHelper &Helper,
     if (MRI.getType(SrcReg) != LLT::scalar(16))
       return true;
     Register DstReg = MI.getOperand(0).getReg();
+    bool IsFPOp = IntrID == Intrinsic::amdgcn_wave_reduce_fmin ||
+                  IntrID == Intrinsic::amdgcn_wave_reduce_fmax ||
+                  IntrID == Intrinsic::amdgcn_wave_reduce_fadd ||
+                  IntrID == Intrinsic::amdgcn_wave_reduce_fsub;
     bool NeedsSignExt = IntrID == Intrinsic::amdgcn_wave_reduce_min ||
                         IntrID == Intrinsic::amdgcn_wave_reduce_max ||
                         IntrID == Intrinsic::amdgcn_wave_reduce_add ||
                         IntrID == Intrinsic::amdgcn_wave_reduce_sub;
-    auto Ext = NeedsSignExt ? B.buildSExt(LLT::scalar(32), SrcReg)
-                            : B.buildZExt(LLT::scalar(32), SrcReg);
+    auto Ext = IsFPOp         ? B.buildFPExt(LLT::scalar(32), SrcReg)
+               : NeedsSignExt ? B.buildSExt(LLT::scalar(32), SrcReg)
+                              : B.buildZExt(LLT::scalar(32), SrcReg);
     auto NewDst = MRI.createGenericVirtualRegister(LLT::scalar(32));
     B.buildIntrinsic(IntrID, ArrayRef<Register>{NewDst},
                      /*hasSideEffects=*/false, /*isConvergent=*/true)
         .addUse(Ext.getReg(0))
         .addImm(MI.getOperand(3).getImm()); // strategy
-    B.buildTrunc(DstReg, NewDst);
+    if (IsFPOp)
+      B.buildFPTrunc(DstReg, NewDst);
+    else
+      B.buildTrunc(DstReg, NewDst);
     MI.eraseFromParent();
     return true;
   }

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -10822,7 +10822,7 @@ SDValue SITargetLowering::LowerINTRINSIC_WO_CHAIN(SDValue Op,
   case Intrinsic::amdgcn_wave_reduce_or:
   case Intrinsic::amdgcn_wave_reduce_xor: {
     EVT SrcVT = Op.getOperand(1).getValueType();
-    if (SrcVT.getFixedSizeInBits() == 0x10) {
+    if (SrcVT.getFixedSizeInBits() == 16) {
       bool IsFPOp = SrcVT.isFloatingPoint();
       bool NeedsSignExt = IntrinsicID == Intrinsic::amdgcn_wave_reduce_min ||
                           IntrinsicID == Intrinsic::amdgcn_wave_reduce_max ||

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -10810,25 +10810,38 @@ SDValue SITargetLowering::LowerINTRINSIC_WO_CHAIN(SDValue Op,
   switch (IntrinsicID) {
   case Intrinsic::amdgcn_wave_reduce_min:
   case Intrinsic::amdgcn_wave_reduce_umin:
+  case Intrinsic::amdgcn_wave_reduce_fmin:
   case Intrinsic::amdgcn_wave_reduce_max:
   case Intrinsic::amdgcn_wave_reduce_umax:
+  case Intrinsic::amdgcn_wave_reduce_fmax:
   case Intrinsic::amdgcn_wave_reduce_add:
+  case Intrinsic::amdgcn_wave_reduce_fadd:
   case Intrinsic::amdgcn_wave_reduce_sub:
+  case Intrinsic::amdgcn_wave_reduce_fsub:
   case Intrinsic::amdgcn_wave_reduce_and:
   case Intrinsic::amdgcn_wave_reduce_or:
   case Intrinsic::amdgcn_wave_reduce_xor: {
     EVT SrcVT = Op.getOperand(1).getValueType();
-    if (SrcVT == MVT::i16) {
+    if (SrcVT.getFixedSizeInBits() == 0x10) {
+      bool IsFPOp = SrcVT.isFloatingPoint();
       bool NeedsSignExt = IntrinsicID == Intrinsic::amdgcn_wave_reduce_min ||
                           IntrinsicID == Intrinsic::amdgcn_wave_reduce_max ||
                           IntrinsicID == Intrinsic::amdgcn_wave_reduce_add ||
                           IntrinsicID == Intrinsic::amdgcn_wave_reduce_sub;
-      unsigned ExtOpc = NeedsSignExt ? ISD::SIGN_EXTEND : ISD::ZERO_EXTEND;
-      SDValue ExtendedSrc = DAG.getNode(ExtOpc, DL, MVT::i32, Op.getOperand(1));
+      unsigned ExtOpc = IsFPOp         ? ISD::FP_EXTEND
+                        : NeedsSignExt ? ISD::SIGN_EXTEND
+                                       : ISD::ZERO_EXTEND;
+      auto SrcType = IsFPOp ? MVT::f16 : MVT::i16;
+      auto ExtType = IsFPOp ? MVT::f32 : MVT::i32;
+      SDValue ExtendedSrc = DAG.getNode(ExtOpc, DL, ExtType, Op.getOperand(1));
       SDValue Strategy = Op.getOperand(2);
-      SDValue Result = DAG.getNode(ISD::INTRINSIC_WO_CHAIN, DL, MVT::i32,
+      SDValue Result = DAG.getNode(ISD::INTRINSIC_WO_CHAIN, DL, ExtType,
                                    Op.getOperand(0), ExtendedSrc, Strategy);
-      return DAG.getNode(ISD::TRUNCATE, DL, MVT::i16, Result);
+      if (IsFPOp)
+        return DAG.getNode(ISD::FP_ROUND, DL, SrcType, Result,
+                           DAG.getTargetConstant(1, DL, MVT::i32));
+      else
+        return DAG.getNode(ISD::TRUNCATE, DL, SrcType, Result);
     }
     return SDValue();
   }

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.fadd.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.fadd.ll
@@ -7,12 +7,751 @@
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -global-isel=1 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1064GISEL %s
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -global-isel=0 < %s | FileCheck -check-prefixes=GFX1032DAGISEL %s
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -global-isel=1 < %s | FileCheck -check-prefixes=GFX1032GISEL %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -global-isel=0 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164DAGISEL %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -global-isel=1 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164GISEL %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -global-isel=0 < %s | FileCheck -check-prefixes=GFX1132DAGISEL %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -global-isel=1 < %s | FileCheck -check-prefixes=GFX1132GISEL %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=-real-true16 -global-isel=0 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164DAGISEL,GFX1164DAGISEL-FAKE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=-real-true16 -global-isel=1 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164GISEL,GFX1164GISEL-FAKE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=-real-true16 -global-isel=0 < %s | FileCheck -check-prefixes=GFX1132DAGISEL,GFX1132DAGISEL-FAKE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=-real-true16 -global-isel=1 < %s | FileCheck -check-prefixes=GFX1132GISEL,GFX1132GISEL-FAKE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+real-true16 -global-isel=0 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164DAGISEL,GFX1164DAGISEL-TRUE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+real-true16 -global-isel=1 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164GISEL,GFX1164GISEL-TRUE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+real-true16 -global-isel=0 < %s | FileCheck -check-prefixes=GFX1132DAGISEL,GFX1132DAGISEL-TRUE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+real-true16 -global-isel=1 < %s | FileCheck -check-prefixes=GFX1132GISEL,GFX1132GISEL-TRUE16 %s
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx1200 -global-isel=0 < %s | FileCheck -check-prefixes=GFX12DAGISEL %s
 
+define amdgpu_kernel void @uniform_value_half(ptr addrspace(1) %out, half %in) {
+; GFX8DAGISEL-LABEL: uniform_value_half:
+; GFX8DAGISEL:       ; %bb.0: ; %entry
+; GFX8DAGISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX8DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX8DAGISEL-NEXT:    s_brev_b32 s4, 1
+; GFX8DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX8DAGISEL-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX8DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
+; GFX8DAGISEL-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s5, s[2:3]
+; GFX8DAGISEL-NEXT:    v_readlane_b32 s6, v0, s5
+; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v1, s6
+; GFX8DAGISEL-NEXT:    s_bitset0_b64 s[2:3], s5
+; GFX8DAGISEL-NEXT:    v_add_f32_e32 v1, s4, v1
+; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[2:3], 0
+; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s4, v1
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX8DAGISEL-NEXT:  ; %bb.2:
+; GFX8DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2, s4
+; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v0, s0
+; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v1, s1
+; GFX8DAGISEL-NEXT:    flat_store_short v[0:1], v2
+; GFX8DAGISEL-NEXT:    s_endpgm
+;
+; GFX8GISEL-LABEL: uniform_value_half:
+; GFX8GISEL:       ; %bb.0: ; %entry
+; GFX8GISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX8GISEL-NEXT:    s_mov_b64 s[0:1], exec
+; GFX8GISEL-NEXT:    s_bcnt1_i32_b64 s0, s[0:1]
+; GFX8GISEL-NEXT:    v_cvt_f32_i32_e32 v1, s0
+; GFX8GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX8GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX8GISEL-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX8GISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX8GISEL-NEXT:    v_mul_f32_e32 v0, s2, v1
+; GFX8GISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX8GISEL-NEXT:    v_cvt_f16_f32_e32 v2, s2
+; GFX8GISEL-NEXT:    v_mov_b32_e32 v0, s0
+; GFX8GISEL-NEXT:    v_mov_b32_e32 v1, s1
+; GFX8GISEL-NEXT:    flat_store_short v[0:1], v2
+; GFX8GISEL-NEXT:    s_endpgm
+;
+; GFX9DAGISEL-LABEL: uniform_value_half:
+; GFX9DAGISEL:       ; %bb.0: ; %entry
+; GFX9DAGISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX9DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX9DAGISEL-NEXT:    s_brev_b32 s4, 1
+; GFX9DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX9DAGISEL-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX9DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
+; GFX9DAGISEL-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s5, s[2:3]
+; GFX9DAGISEL-NEXT:    v_readlane_b32 s6, v1, s5
+; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9DAGISEL-NEXT:    s_bitset0_b64 s[2:3], s5
+; GFX9DAGISEL-NEXT:    v_add_f32_e32 v2, s4, v2
+; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[2:3], 0
+; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s4, v2
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX9DAGISEL-NEXT:  ; %bb.2:
+; GFX9DAGISEL-NEXT:    v_cvt_f16_f32_e32 v1, s4
+; GFX9DAGISEL-NEXT:    global_store_short v0, v1, s[0:1]
+; GFX9DAGISEL-NEXT:    s_endpgm
+;
+; GFX9GISEL-LABEL: uniform_value_half:
+; GFX9GISEL:       ; %bb.0: ; %entry
+; GFX9GISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX9GISEL-NEXT:    s_mov_b64 s[0:1], exec
+; GFX9GISEL-NEXT:    s_bcnt1_i32_b64 s0, s[0:1]
+; GFX9GISEL-NEXT:    v_cvt_f32_i32_e32 v1, s0
+; GFX9GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX9GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX9GISEL-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX9GISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX9GISEL-NEXT:    v_mul_f32_e32 v0, s2, v1
+; GFX9GISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX9GISEL-NEXT:    v_cvt_f16_f32_e32 v0, s2
+; GFX9GISEL-NEXT:    v_mov_b32_e32 v1, 0
+; GFX9GISEL-NEXT:    global_store_short v1, v0, s[0:1]
+; GFX9GISEL-NEXT:    s_endpgm
+;
+; GFX1064DAGISEL-LABEL: uniform_value_half:
+; GFX1064DAGISEL:       ; %bb.0: ; %entry
+; GFX1064DAGISEL-NEXT:    s_clause 0x1
+; GFX1064DAGISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX1064DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1064DAGISEL-NEXT:    s_brev_b32 s4, 1
+; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1064DAGISEL-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1064DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
+; GFX1064DAGISEL-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s5, s[2:3]
+; GFX1064DAGISEL-NEXT:    v_readlane_b32 s6, v1, s5
+; GFX1064DAGISEL-NEXT:    s_bitset0_b64 s[2:3], s5
+; GFX1064DAGISEL-NEXT:    s_cmp_lg_u64 s[2:3], 0
+; GFX1064DAGISEL-NEXT:    v_add_f32_e64 v2, s4, s6
+; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s4, v2
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1064DAGISEL-NEXT:  ; %bb.2:
+; GFX1064DAGISEL-NEXT:    v_cvt_f16_f32_e32 v1, s4
+; GFX1064DAGISEL-NEXT:    global_store_short v0, v1, s[0:1]
+; GFX1064DAGISEL-NEXT:    s_endpgm
+;
+; GFX1064GISEL-LABEL: uniform_value_half:
+; GFX1064GISEL:       ; %bb.0: ; %entry
+; GFX1064GISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX1064GISEL-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1064GISEL-NEXT:    s_bcnt1_i32_b64 s0, s[0:1]
+; GFX1064GISEL-NEXT:    v_cvt_f32_i32_e32 v1, s0
+; GFX1064GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1064GISEL-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1064GISEL-NEXT:    v_mul_f32_e32 v0, s2, v1
+; GFX1064GISEL-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1064GISEL-NEXT:    v_cvt_f16_f32_e32 v0, s2
+; GFX1064GISEL-NEXT:    global_store_short v1, v0, s[0:1]
+; GFX1064GISEL-NEXT:    s_endpgm
+;
+; GFX1032DAGISEL-LABEL: uniform_value_half:
+; GFX1032DAGISEL:       ; %bb.0: ; %entry
+; GFX1032DAGISEL-NEXT:    s_clause 0x1
+; GFX1032DAGISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX1032DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1032DAGISEL-NEXT:    s_brev_b32 s3, 1
+; GFX1032DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1032DAGISEL-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1032DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
+; GFX1032DAGISEL-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s4, s2
+; GFX1032DAGISEL-NEXT:    v_readlane_b32 s5, v1, s4
+; GFX1032DAGISEL-NEXT:    s_bitset0_b32 s2, s4
+; GFX1032DAGISEL-NEXT:    s_cmp_lg_u32 s2, 0
+; GFX1032DAGISEL-NEXT:    v_add_f32_e64 v2, s3, s5
+; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s3, v2
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1032DAGISEL-NEXT:  ; %bb.2:
+; GFX1032DAGISEL-NEXT:    v_cvt_f16_f32_e32 v1, s3
+; GFX1032DAGISEL-NEXT:    global_store_short v0, v1, s[0:1]
+; GFX1032DAGISEL-NEXT:    s_endpgm
+;
+; GFX1032GISEL-LABEL: uniform_value_half:
+; GFX1032GISEL:       ; %bb.0: ; %entry
+; GFX1032GISEL-NEXT:    s_load_dword s0, s[4:5], 0x2c
+; GFX1032GISEL-NEXT:    s_mov_b32 s1, exec_lo
+; GFX1032GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1032GISEL-NEXT:    v_cvt_f32_f16_e32 v0, s0
+; GFX1032GISEL-NEXT:    s_bcnt1_i32_b32 s0, s1
+; GFX1032GISEL-NEXT:    v_cvt_f32_i32_e32 v1, s0
+; GFX1032GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1032GISEL-NEXT:    v_mul_f32_e32 v0, s2, v1
+; GFX1032GISEL-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1032GISEL-NEXT:    v_cvt_f16_f32_e32 v0, s2
+; GFX1032GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1032GISEL-NEXT:    global_store_short v1, v0, s[0:1]
+; GFX1032GISEL-NEXT:    s_endpgm
+;
+; GFX1164DAGISEL-FAKE16-LABEL: uniform_value_half:
+; GFX1164DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1164DAGISEL-FAKE16-NEXT:    s_brev_b32 s4, 1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mov_b64 s[2:3], exec
+; GFX1164DAGISEL-FAKE16-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_ctz_i32_b64 s5, s[2:3]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_readlane_b32 s6, v1, s5
+; GFX1164DAGISEL-FAKE16-NEXT:    s_bitset0_b64 s[2:3], s5
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cmp_lg_u64 s[2:3], 0
+; GFX1164DAGISEL-FAKE16-NEXT:    v_add_f32_e64 v2, s4, s6
+; GFX1164DAGISEL-FAKE16-NEXT:    v_readfirstlane_b32 s4, v2
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1164DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v1, s4
+; GFX1164DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_endpgm
+;
+; GFX1164GISEL-FAKE16-LABEL: uniform_value_half:
+; GFX1164GISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164GISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164GISEL-FAKE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164GISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1164GISEL-FAKE16-NEXT:    s_bcnt1_i32_b64 s0, s[0:1]
+; GFX1164GISEL-FAKE16-NEXT:    v_cvt_f32_i32_e32 v1, s0
+; GFX1164GISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164GISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164GISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX1164GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1164GISEL-FAKE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1164GISEL-FAKE16-NEXT:    v_mul_f32_e32 v0, s2, v1
+; GFX1164GISEL-FAKE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1164GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1164GISEL-FAKE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1164GISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v0, s2
+; GFX1164GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1164GISEL-FAKE16-NEXT:    s_endpgm
+;
+; GFX1132DAGISEL-FAKE16-LABEL: uniform_value_half:
+; GFX1132DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1132DAGISEL-FAKE16-NEXT:    s_brev_b32 s3, 1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mov_b32 s2, exec_lo
+; GFX1132DAGISEL-FAKE16-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_ctz_i32_b32 s4, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_readlane_b32 s5, v1, s4
+; GFX1132DAGISEL-FAKE16-NEXT:    s_bitset0_b32 s2, s4
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cmp_lg_u32 s2, 0
+; GFX1132DAGISEL-FAKE16-NEXT:    v_add_f32_e64 v2, s3, s5
+; GFX1132DAGISEL-FAKE16-NEXT:    v_readfirstlane_b32 s3, v2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1132DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v1, s3
+; GFX1132DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1132DAGISEL-FAKE16-NEXT:    s_endpgm
+;
+; GFX1132GISEL-FAKE16-LABEL: uniform_value_half:
+; GFX1132GISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132GISEL-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x2c
+; GFX1132GISEL-FAKE16-NEXT:    s_mov_b32 s1, exec_lo
+; GFX1132GISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132GISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, s0
+; GFX1132GISEL-FAKE16-NEXT:    s_bcnt1_i32_b32 s0, s1
+; GFX1132GISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1132GISEL-FAKE16-NEXT:    v_cvt_f32_i32_e32 v1, s0
+; GFX1132GISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132GISEL-FAKE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1132GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1132GISEL-FAKE16-NEXT:    v_dual_mul_f32 v0, s2, v1 :: v_dual_mov_b32 v1, 0
+; GFX1132GISEL-FAKE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1132GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1132GISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v0, s2
+; GFX1132GISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1132GISEL-FAKE16-NEXT:    s_endpgm
+;
+; GFX1164DAGISEL-TRUE16-LABEL: uniform_value_half:
+; GFX1164DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1164DAGISEL-TRUE16-NEXT:    s_brev_b32 s4, 1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b64 s[2:3], exec
+; GFX1164DAGISEL-TRUE16-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_ctz_i32_b64 s5, s[2:3]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_readlane_b32 s6, v1, s5
+; GFX1164DAGISEL-TRUE16-NEXT:    s_bitset0_b64 s[2:3], s5
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cmp_lg_u64 s[2:3], 0
+; GFX1164DAGISEL-TRUE16-NEXT:    v_add_f32_e64 v2, s4, s6
+; GFX1164DAGISEL-TRUE16-NEXT:    v_readfirstlane_b32 s4, v2
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1164DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.l, s4
+; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX1164GISEL-TRUE16-LABEL: uniform_value_half:
+; GFX1164GISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164GISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164GISEL-TRUE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164GISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1164GISEL-TRUE16-NEXT:    s_bcnt1_i32_b64 s0, s[0:1]
+; GFX1164GISEL-TRUE16-NEXT:    v_cvt_f32_i32_e32 v1, s0
+; GFX1164GISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164GISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX1164GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1164GISEL-TRUE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1164GISEL-TRUE16-NEXT:    v_mul_f32_e32 v0, s2, v1
+; GFX1164GISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1164GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1164GISEL-TRUE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1164GISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, s2
+; GFX1164GISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1164GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX1132DAGISEL-TRUE16-LABEL: uniform_value_half:
+; GFX1132DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    s_brev_b32 s3, 1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s2, exec_lo
+; GFX1132DAGISEL-TRUE16-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_ctz_i32_b32 s4, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_readlane_b32 s5, v1, s4
+; GFX1132DAGISEL-TRUE16-NEXT:    s_bitset0_b32 s2, s4
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cmp_lg_u32 s2, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    v_add_f32_e64 v2, s3, s5
+; GFX1132DAGISEL-TRUE16-NEXT:    v_readfirstlane_b32 s3, v2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1132DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.l, s3
+; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1132DAGISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX1132GISEL-TRUE16-LABEL: uniform_value_half:
+; GFX1132GISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132GISEL-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x2c
+; GFX1132GISEL-TRUE16-NEXT:    s_mov_b32 s1, exec_lo
+; GFX1132GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132GISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, s0
+; GFX1132GISEL-TRUE16-NEXT:    s_bcnt1_i32_b32 s0, s1
+; GFX1132GISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1132GISEL-TRUE16-NEXT:    v_cvt_f32_i32_e32 v1, s0
+; GFX1132GISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132GISEL-TRUE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1132GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1132GISEL-TRUE16-NEXT:    v_dual_mul_f32 v0, s2, v1 :: v_dual_mov_b32 v1, 0
+; GFX1132GISEL-TRUE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1132GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1132GISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, s2
+; GFX1132GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132GISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1132GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX12DAGISEL-LABEL: uniform_value_half:
+; GFX12DAGISEL:       ; %bb.0: ; %entry
+; GFX12DAGISEL-NEXT:    s_load_b96 s[0:2], s[4:5], 0x24
+; GFX12DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
+; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v1, 0
+; GFX12DAGISEL-NEXT:    s_bcnt1_i32_b32 s3, s3
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX12DAGISEL-NEXT:    v_cvt_f32_i32_e32 v0, s3
+; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12DAGISEL-NEXT:    s_cvt_f32_f16 s2, s2
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_2)
+; GFX12DAGISEL-NEXT:    v_mul_f32_e32 v0, s2, v0
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(SALU_CYCLE_2)
+; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX12DAGISEL-NEXT:    s_cvt_f16_f32 s2, s2
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX12DAGISEL-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX12DAGISEL-NEXT:    s_endpgm
+  entry:
+  %result = call half @llvm.amdgcn.wave.reduce.fadd(half %in, i32 1)
+  store half %result, ptr addrspace(1) %out
+  ret void
+}
+
+define void @divergent_value_half(ptr addrspace(1) %out, half %in) {
+; GFX8DAGISEL-LABEL: divergent_value_half:
+; GFX8DAGISEL:       ; %bb.0: ; %entry
+; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8DAGISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX8DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX8DAGISEL-NEXT:    s_brev_b32 s6, 1
+; GFX8DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX8DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s8
+; GFX8DAGISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX8DAGISEL-NEXT:    v_add_f32_e32 v3, s6, v3
+; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX8DAGISEL-NEXT:  ; %bb.2:
+; GFX8DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX8DAGISEL-NEXT:    flat_store_short v[0:1], v2
+; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX8DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8GISEL-LABEL: divergent_value_half:
+; GFX8GISEL:       ; %bb.0: ; %entry
+; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8GISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX8GISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX8GISEL-NEXT:    s_brev_b32 s6, 1
+; GFX8GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX8GISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s8
+; GFX8GISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX8GISEL-NEXT:    v_add_f32_e32 v3, s6, v3
+; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX8GISEL-NEXT:  ; %bb.2:
+; GFX8GISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX8GISEL-NEXT:    flat_store_short v[0:1], v2
+; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX8GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9DAGISEL-LABEL: divergent_value_half:
+; GFX9DAGISEL:       ; %bb.0: ; %entry
+; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9DAGISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX9DAGISEL-NEXT:    s_brev_b32 s6, 1
+; GFX9DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX9DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v3, s8
+; GFX9DAGISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX9DAGISEL-NEXT:    v_add_f32_e32 v3, s6, v3
+; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX9DAGISEL-NEXT:  ; %bb.2:
+; GFX9DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX9DAGISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX9DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9GISEL-LABEL: divergent_value_half:
+; GFX9GISEL:       ; %bb.0: ; %entry
+; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9GISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX9GISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX9GISEL-NEXT:    s_brev_b32 s6, 1
+; GFX9GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX9GISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX9GISEL-NEXT:    v_mov_b32_e32 v3, s8
+; GFX9GISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX9GISEL-NEXT:    v_add_f32_e32 v3, s6, v3
+; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX9GISEL-NEXT:  ; %bb.2:
+; GFX9GISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX9GISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX9GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1064DAGISEL-LABEL: divergent_value_half:
+; GFX1064DAGISEL:       ; %bb.0: ; %entry
+; GFX1064DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1064DAGISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1064DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX1064DAGISEL-NEXT:    s_brev_b32 s6, 1
+; GFX1064DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX1064DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX1064DAGISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX1064DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX1064DAGISEL-NEXT:    v_add_f32_e64 v3, s6, s8
+; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1064DAGISEL-NEXT:  ; %bb.2:
+; GFX1064DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX1064DAGISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX1064DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1064GISEL-LABEL: divergent_value_half:
+; GFX1064GISEL:       ; %bb.0: ; %entry
+; GFX1064GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1064GISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1064GISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX1064GISEL-NEXT:    s_brev_b32 s6, 1
+; GFX1064GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX1064GISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX1064GISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX1064GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX1064GISEL-NEXT:    v_add_f32_e64 v3, s6, s8
+; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1064GISEL-NEXT:  ; %bb.2:
+; GFX1064GISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX1064GISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX1064GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1032DAGISEL-LABEL: divergent_value_half:
+; GFX1032DAGISEL:       ; %bb.0: ; %entry
+; GFX1032DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1032DAGISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, exec_lo
+; GFX1032DAGISEL-NEXT:    s_brev_b32 s5, 1
+; GFX1032DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s6, s4
+; GFX1032DAGISEL-NEXT:    v_readlane_b32 s7, v2, s6
+; GFX1032DAGISEL-NEXT:    s_bitset0_b32 s4, s6
+; GFX1032DAGISEL-NEXT:    s_cmp_lg_u32 s4, 0
+; GFX1032DAGISEL-NEXT:    v_add_f32_e64 v3, s5, s7
+; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v3
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1032DAGISEL-NEXT:  ; %bb.2:
+; GFX1032DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2, s5
+; GFX1032DAGISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX1032DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1032GISEL-LABEL: divergent_value_half:
+; GFX1032GISEL:       ; %bb.0: ; %entry
+; GFX1032GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1032GISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1032GISEL-NEXT:    s_mov_b32 s4, exec_lo
+; GFX1032GISEL-NEXT:    s_brev_b32 s5, 1
+; GFX1032GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s6, s4
+; GFX1032GISEL-NEXT:    v_readlane_b32 s7, v2, s6
+; GFX1032GISEL-NEXT:    s_bitset0_b32 s4, s6
+; GFX1032GISEL-NEXT:    s_cmp_lg_u32 s4, 0
+; GFX1032GISEL-NEXT:    v_add_f32_e64 v3, s5, s7
+; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v3
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1032GISEL-NEXT:  ; %bb.2:
+; GFX1032GISEL-NEXT:    v_cvt_f16_f32_e32 v2, s5
+; GFX1032GISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX1032GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164DAGISEL-FAKE16-LABEL: divergent_value_half:
+; GFX1164DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164DAGISEL-FAKE16-NEXT:    s_brev_b32 s2, 1
+; GFX1164DAGISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164DAGISEL-FAKE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164DAGISEL-FAKE16-NEXT:    v_add_f32_e64 v3, s2, s4
+; GFX1164DAGISEL-FAKE16-NEXT:    v_readfirstlane_b32 s2, v3
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v2, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164DAGISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164GISEL-FAKE16-LABEL: divergent_value_half:
+; GFX1164GISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164GISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164GISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1164GISEL-FAKE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164GISEL-FAKE16-NEXT:    s_brev_b32 s2, 1
+; GFX1164GISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-FAKE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164GISEL-FAKE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164GISEL-FAKE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164GISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164GISEL-FAKE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164GISEL-FAKE16-NEXT:    v_add_f32_e64 v3, s2, s4
+; GFX1164GISEL-FAKE16-NEXT:    v_readfirstlane_b32 s2, v3
+; GFX1164GISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164GISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1164GISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v2, s2
+; GFX1164GISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164GISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132DAGISEL-FAKE16-LABEL: divergent_value_half:
+; GFX1132DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mov_b32 s0, exec_lo
+; GFX1132DAGISEL-FAKE16-NEXT:    s_brev_b32 s1, 1
+; GFX1132DAGISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_ctz_i32_b32 s2, s0
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_bitset0_b32 s0, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cmp_lg_u32 s0, 0
+; GFX1132DAGISEL-FAKE16-NEXT:    v_add_f32_e64 v3, s1, s3
+; GFX1132DAGISEL-FAKE16-NEXT:    v_readfirstlane_b32 s1, v3
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v2, s1
+; GFX1132DAGISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132DAGISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132GISEL-FAKE16-LABEL: divergent_value_half:
+; GFX1132GISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132GISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132GISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1132GISEL-FAKE16-NEXT:    s_mov_b32 s0, exec_lo
+; GFX1132GISEL-FAKE16-NEXT:    s_brev_b32 s1, 1
+; GFX1132GISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-FAKE16-NEXT:    s_ctz_i32_b32 s2, s0
+; GFX1132GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132GISEL-FAKE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132GISEL-FAKE16-NEXT:    s_bitset0_b32 s0, s2
+; GFX1132GISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132GISEL-FAKE16-NEXT:    s_cmp_lg_u32 s0, 0
+; GFX1132GISEL-FAKE16-NEXT:    v_add_f32_e64 v3, s1, s3
+; GFX1132GISEL-FAKE16-NEXT:    v_readfirstlane_b32 s1, v3
+; GFX1132GISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132GISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1132GISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v2, s1
+; GFX1132GISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132GISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164DAGISEL-TRUE16-LABEL: divergent_value_half:
+; GFX1164DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164DAGISEL-TRUE16-NEXT:    s_brev_b32 s2, 1
+; GFX1164DAGISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164DAGISEL-TRUE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164DAGISEL-TRUE16-NEXT:    v_add_f32_e64 v3, s2, s4
+; GFX1164DAGISEL-TRUE16-NEXT:    v_readfirstlane_b32 s2, v3
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v2.l, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164GISEL-TRUE16-LABEL: divergent_value_half:
+; GFX1164GISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164GISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164GISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
+; GFX1164GISEL-TRUE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164GISEL-TRUE16-NEXT:    s_brev_b32 s2, 1
+; GFX1164GISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-TRUE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164GISEL-TRUE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164GISEL-TRUE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164GISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164GISEL-TRUE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164GISEL-TRUE16-NEXT:    v_add_f32_e64 v3, s2, s4
+; GFX1164GISEL-TRUE16-NEXT:    v_readfirstlane_b32 s2, v3
+; GFX1164GISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164GISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1164GISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v2.l, s2
+; GFX1164GISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164GISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132DAGISEL-TRUE16-LABEL: divergent_value_half:
+; GFX1132DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s0, exec_lo
+; GFX1132DAGISEL-TRUE16-NEXT:    s_brev_b32 s1, 1
+; GFX1132DAGISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_ctz_i32_b32 s2, s0
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_bitset0_b32 s0, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cmp_lg_u32 s0, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    v_add_f32_e64 v3, s1, s3
+; GFX1132DAGISEL-TRUE16-NEXT:    v_readfirstlane_b32 s1, v3
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v2.l, s1
+; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132GISEL-TRUE16-LABEL: divergent_value_half:
+; GFX1132GISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132GISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132GISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
+; GFX1132GISEL-TRUE16-NEXT:    s_mov_b32 s0, exec_lo
+; GFX1132GISEL-TRUE16-NEXT:    s_brev_b32 s1, 1
+; GFX1132GISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-TRUE16-NEXT:    s_ctz_i32_b32 s2, s0
+; GFX1132GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132GISEL-TRUE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132GISEL-TRUE16-NEXT:    s_bitset0_b32 s0, s2
+; GFX1132GISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132GISEL-TRUE16-NEXT:    s_cmp_lg_u32 s0, 0
+; GFX1132GISEL-TRUE16-NEXT:    v_add_f32_e64 v3, s1, s3
+; GFX1132GISEL-TRUE16-NEXT:    v_readfirstlane_b32 s1, v3
+; GFX1132GISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132GISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1132GISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v2.l, s1
+; GFX1132GISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132GISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12DAGISEL-LABEL: divergent_value_half:
+; GFX12DAGISEL:       ; %bb.0: ; %entry
+; GFX12DAGISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12DAGISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
+; GFX12DAGISEL-NEXT:    s_mov_b32 s0, exec_lo
+; GFX12DAGISEL-NEXT:    s_brev_b32 s1, 1
+; GFX12DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s2, s0
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX12DAGISEL-NEXT:    s_bitset0_b32 s0, s2
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    s_cmp_lg_u32 s0, 0
+; GFX12DAGISEL-NEXT:    v_add_f32_e64 v3, s1, s3
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v3
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX12DAGISEL-NEXT:  ; %bb.2:
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX12DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2.l, s1
+; GFX12DAGISEL-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX12DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+  entry:
+  %result = call half @llvm.amdgcn.wave.reduce.fadd(half %in, i32 1)
+  store half %result, ptr addrspace(1) %out
+  ret void
+}
 
 define amdgpu_kernel void @uniform_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX8DAGISEL-LABEL: uniform_value_float:
@@ -232,7 +971,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX8DAGISEL-NEXT:    s_brev_b32 s6, 1
-; GFX8DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s8
@@ -240,7 +979,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX8DAGISEL-NEXT:    v_add_f32_e32 v3, s6, v3
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX8DAGISEL-NEXT:  ; %bb.2:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8DAGISEL-NEXT:    flat_store_dword v[0:1], v2
@@ -252,7 +991,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8GISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX8GISEL-NEXT:    s_brev_b32 s6, 1
-; GFX8GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX8GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s8
@@ -260,7 +999,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX8GISEL-NEXT:    v_add_f32_e32 v3, s6, v3
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX8GISEL-NEXT:  ; %bb.2:
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8GISEL-NEXT:    flat_store_dword v[0:1], v2
@@ -272,7 +1011,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX9DAGISEL-NEXT:    s_brev_b32 s6, 1
-; GFX9DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v3, s8
@@ -280,7 +1019,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX9DAGISEL-NEXT:    v_add_f32_e32 v3, s6, v3
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX9DAGISEL-NEXT:  ; %bb.2:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -292,7 +1031,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9GISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX9GISEL-NEXT:    s_brev_b32 s6, 1
-; GFX9GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX9GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v3, s8
@@ -300,7 +1039,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX9GISEL-NEXT:    v_add_f32_e32 v3, s6, v3
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX9GISEL-NEXT:  ; %bb.2:
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9GISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -312,14 +1051,14 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1064DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX1064DAGISEL-NEXT:    s_brev_b32 s6, 1
-; GFX1064DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1064DAGISEL-NEXT:    s_bitset0_b64 s[4:5], s7
 ; GFX1064DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX1064DAGISEL-NEXT:    v_add_f32_e64 v3, s6, s8
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1064DAGISEL-NEXT:  ; %bb.2:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -330,14 +1069,14 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1064GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX1064GISEL-NEXT:    s_brev_b32 s6, 1
-; GFX1064GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1064GISEL-NEXT:    s_bitset0_b64 s[4:5], s7
 ; GFX1064GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX1064GISEL-NEXT:    v_add_f32_e64 v3, s6, s8
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1064GISEL-NEXT:  ; %bb.2:
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064GISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -348,14 +1087,14 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1032DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_brev_b32 s5, 1
-; GFX1032DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s6, s4
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s7, v2, s6
 ; GFX1032DAGISEL-NEXT:    s_bitset0_b32 s4, s6
 ; GFX1032DAGISEL-NEXT:    s_cmp_lg_u32 s4, 0
 ; GFX1032DAGISEL-NEXT:    v_add_f32_e64 v3, s5, s7
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1032DAGISEL-NEXT:  ; %bb.2:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v2, s5
 ; GFX1032DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -366,14 +1105,14 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1032GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1032GISEL-NEXT:    s_mov_b32 s4, exec_lo
 ; GFX1032GISEL-NEXT:    s_brev_b32 s5, 1
-; GFX1032GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s6, s4
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s7, v2, s6
 ; GFX1032GISEL-NEXT:    s_bitset0_b32 s4, s6
 ; GFX1032GISEL-NEXT:    s_cmp_lg_u32 s4, 0
 ; GFX1032GISEL-NEXT:    v_add_f32_e64 v3, s5, s7
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1032GISEL-NEXT:  ; %bb.2:
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v2, s5
 ; GFX1032GISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -384,7 +1123,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1164DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[0:1], exec
 ; GFX1164DAGISEL-NEXT:    s_brev_b32 s2, 1
-; GFX1164DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s3, s[0:1]
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -393,7 +1132,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1164DAGISEL-NEXT:    v_add_f32_e64 v3, s2, s4
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s2, v3
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1164DAGISEL-NEXT:  ; %bb.2:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164DAGISEL-NEXT:    global_store_b32 v[0:1], v2, off
@@ -404,7 +1143,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1164GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[0:1], exec
 ; GFX1164GISEL-NEXT:    s_brev_b32 s2, 1
-; GFX1164GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s3, s[0:1]
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -413,7 +1152,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1164GISEL-NEXT:    v_add_f32_e64 v3, s2, s4
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s2, v3
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1164GISEL-NEXT:  ; %bb.2:
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164GISEL-NEXT:    global_store_b32 v[0:1], v2, off
@@ -424,7 +1163,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1132DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s0, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_brev_b32 s1, 1
-; GFX1132DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s2, s0
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s3, v2, s2
@@ -433,7 +1172,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1132DAGISEL-NEXT:    v_add_f32_e64 v3, s1, s3
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1132DAGISEL-NEXT:  ; %bb.2:
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v2, s1
 ; GFX1132DAGISEL-NEXT:    global_store_b32 v[0:1], v2, off
@@ -444,7 +1183,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1132GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1132GISEL-NEXT:    s_mov_b32 s0, exec_lo
 ; GFX1132GISEL-NEXT:    s_brev_b32 s1, 1
-; GFX1132GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s2, s0
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s3, v2, s2
@@ -453,7 +1192,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1132GISEL-NEXT:    v_add_f32_e64 v3, s1, s3
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1132GISEL-NEXT:  ; %bb.2:
 ; GFX1132GISEL-NEXT:    v_mov_b32_e32 v2, s1
 ; GFX1132GISEL-NEXT:    global_store_b32 v[0:1], v2, off
@@ -468,7 +1207,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s0, exec_lo
 ; GFX12DAGISEL-NEXT:    s_brev_b32 s1, 1
-; GFX12DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s2, s0
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -479,7 +1218,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX12DAGISEL-NEXT:    v_add_f32_e64 v3, s1, s3
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX12DAGISEL-NEXT:  ; %bb.2:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v2, s1
@@ -1836,7 +2575,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX8DAGISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX8DAGISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX8DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -1844,11 +2583,11 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8DAGISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX8DAGISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX8DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX8DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX8DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX8DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -1857,7 +2596,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8DAGISEL-NEXT:    v_mul_f32_e32 v0, s1, v0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX8DAGISEL-NEXT:  .LBB4_4: ; %endif
+; GFX8DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX8DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX8DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -1874,7 +2613,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8GISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX8GISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX8GISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX8GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -1882,11 +2621,11 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8GISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX8GISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX8GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX8GISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX8GISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX8GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -1895,7 +2634,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8GISEL-NEXT:    v_mul_f32_e32 v0, s1, v0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX8GISEL-NEXT:  .LBB4_4: ; %endif
+; GFX8GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX8GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX8GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -1912,7 +2651,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX9DAGISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX9DAGISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX9DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9DAGISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -1920,11 +2659,11 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9DAGISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9DAGISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX9DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX9DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX9DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX9DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -1933,7 +2672,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9DAGISEL-NEXT:    v_mul_f32_e32 v0, s1, v0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX9DAGISEL-NEXT:  .LBB4_4: ; %endif
+; GFX9DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX9DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX9DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -1949,7 +2688,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9GISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX9GISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX9GISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX9GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -1957,11 +2696,11 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9GISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9GISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX9GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX9GISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX9GISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX9GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -1970,7 +2709,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9GISEL-NEXT:    v_mul_f32_e32 v0, s1, v0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX9GISEL-NEXT:  .LBB4_4: ; %endif
+; GFX9GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX9GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX9GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -1986,7 +2725,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX1064DAGISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1064DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064DAGISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -1994,11 +2733,11 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064DAGISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX1064DAGISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX1064DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1064DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1064DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -2007,7 +2746,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064DAGISEL-NEXT:    v_mul_f32_e32 v0, s1, v0
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1064DAGISEL-NEXT:  .LBB4_4: ; %endif
+; GFX1064DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1064DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -2023,7 +2762,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064GISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX1064GISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX1064GISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1064GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -2031,11 +2770,11 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064GISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX1064GISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX1064GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1064GISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX1064GISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1064GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -2044,7 +2783,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064GISEL-NEXT:    v_mul_f32_e32 v0, s1, v0
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1064GISEL-NEXT:  .LBB4_4: ; %endif
+; GFX1064GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1064GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -2060,7 +2799,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $sgpr3
 ; GFX1032DAGISEL-NEXT:    s_and_saveexec_b32 s2, vcc_lo
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 s2, exec_lo, s2
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1032DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_bcnt1_i32_b32 s3, s3
@@ -2068,12 +2807,12 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1032DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032DAGISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s3, v0
-; GFX1032DAGISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX1032DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1032DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032DAGISEL-NEXT:    s_or_saveexec_b32 s0, s2
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v0, s3
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s0
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1032DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_bcnt1_i32_b32 s2, s2
@@ -2081,7 +2820,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1032DAGISEL-NEXT:    v_mul_f32_e32 v0, s1, v0
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s1, v0
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v0, s1
-; GFX1032DAGISEL-NEXT:  .LBB4_4: ; %endif
+; GFX1032DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1032DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX1032DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v1, 0
@@ -2096,7 +2835,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1032GISEL-NEXT:    ; implicit-def: $sgpr3
 ; GFX1032GISEL-NEXT:    s_and_saveexec_b32 s2, vcc_lo
 ; GFX1032GISEL-NEXT:    s_xor_b32 s2, exec_lo, s2
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1032GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032GISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1032GISEL-NEXT:    s_bcnt1_i32_b32 s3, s3
@@ -2104,12 +2843,12 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1032GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032GISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s3, v0
-; GFX1032GISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX1032GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1032GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032GISEL-NEXT:    s_or_saveexec_b32 s0, s2
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v0, s3
 ; GFX1032GISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s0
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1032GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1032GISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1032GISEL-NEXT:    s_bcnt1_i32_b32 s2, s2
@@ -2117,7 +2856,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1032GISEL-NEXT:    v_mul_f32_e32 v0, s1, v0
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s1, v0
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v0, s1
-; GFX1032GISEL-NEXT:  .LBB4_4: ; %endif
+; GFX1032GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1032GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX1032GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v1, 0
@@ -2134,7 +2873,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1164DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -2144,12 +2883,12 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX1164DAGISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX1164DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1164DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1164DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -2160,7 +2899,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1164DAGISEL-NEXT:  .LBB4_4: ; %endif
+; GFX1164DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1164DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1164DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
@@ -2178,7 +2917,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_cmpx_le_u32_e32 16, v0
 ; GFX1164GISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1164GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -2188,12 +2927,12 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX1164GISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX1164GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1164GISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX1164GISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1164GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -2204,7 +2943,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1164GISEL-NEXT:  .LBB4_4: ; %endif
+; GFX1164GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1164GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1164GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1164GISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
@@ -2222,7 +2961,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 s2, exec_lo, s2
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1132DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -2232,13 +2971,13 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s3, v0
-; GFX1132DAGISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX1132DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1132DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1132DAGISEL-NEXT:    s_or_saveexec_b32 s0, s2
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v0, s3
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s0
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1132DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -2249,7 +2988,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v0
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v0, s1
-; GFX1132DAGISEL-NEXT:  .LBB4_4: ; %endif
+; GFX1132DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1132DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX1132DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v1, 0
@@ -2266,7 +3005,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_cmpx_le_u32_e32 16, v0
 ; GFX1132GISEL-NEXT:    s_xor_b32 s2, exec_lo, s2
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1132GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132GISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -2276,13 +3015,13 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s3, v0
-; GFX1132GISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX1132GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1132GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1132GISEL-NEXT:    s_or_saveexec_b32 s0, s2
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_mov_b32_e32 v0, s3
 ; GFX1132GISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s0
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1132GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1132GISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -2293,7 +3032,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s1, v0
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_mov_b32_e32 v0, s1
-; GFX1132GISEL-NEXT:  .LBB4_4: ; %endif
+; GFX1132GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1132GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX1132GISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
 ; GFX1132GISEL-NEXT:    v_mov_b32_e32 v1, 0
@@ -2310,7 +3049,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX12DAGISEL-NEXT:    s_xor_b32 s2, exec_lo, s2
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX12DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -2320,14 +3059,14 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_mul_f32_e32 v0, s0, v0
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s3, v0
-; GFX12DAGISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX12DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12DAGISEL-NEXT:    s_or_saveexec_b32 s0, s2
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v0, s3
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s0
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX12DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -2340,7 +3079,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v0, s1
-; GFX12DAGISEL-NEXT:  .LBB4_4: ; %endif
+; GFX12DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX12DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX12DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v1, 0
@@ -2602,7 +3341,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX8DAGISEL-NEXT:    s_brev_b32 s7, 1
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX8DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -2613,7 +3352,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX8DAGISEL-NEXT:  ; %bb.2:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2627,7 +3366,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX8GISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX8GISEL-NEXT:    s_brev_b32 s7, 1
 ; GFX8GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX8GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX8GISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -2638,7 +3377,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX8GISEL-NEXT:  ; %bb.2:
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2652,7 +3391,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX9DAGISEL-NEXT:    s_brev_b32 s7, 1
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX9DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -2663,7 +3402,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX9DAGISEL-NEXT:  ; %bb.2:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2677,7 +3416,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX9GISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX9GISEL-NEXT:    s_brev_b32 s7, 1
 ; GFX9GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX9GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX9GISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -2688,7 +3427,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX9GISEL-NEXT:  ; %bb.2:
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2702,7 +3441,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX1064DAGISEL-NEXT:    s_brev_b32 s7, 1
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX1064DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -2711,7 +3450,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1064DAGISEL-NEXT:    v_add_f64 v[4:5], s[8:9], s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1064DAGISEL-NEXT:  ; %bb.2:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2724,7 +3463,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1064GISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX1064GISEL-NEXT:    s_brev_b32 s7, 1
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX1064GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -2733,7 +3472,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1064GISEL-NEXT:    v_add_f64 v[4:5], s[8:9], s[6:7]
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1064GISEL-NEXT:  ; %bb.2:
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2746,7 +3485,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032DAGISEL-NEXT:    s_brev_b32 s5, 1
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s6, exec_lo
-; GFX1032DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s7, s6
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s9, v3, s7
@@ -2755,7 +3494,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1032DAGISEL-NEXT:    v_add_f64 v[4:5], s[8:9], s[4:5]
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1032DAGISEL-NEXT:  ; %bb.2:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -2768,7 +3507,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1032GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032GISEL-NEXT:    s_brev_b32 s5, 1
 ; GFX1032GISEL-NEXT:    s_mov_b32 s6, exec_lo
-; GFX1032GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s7, s6
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s9, v3, s7
@@ -2777,7 +3516,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1032GISEL-NEXT:    v_add_f64 v[4:5], s[8:9], s[4:5]
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1032GISEL-NEXT:  ; %bb.2:
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -2790,7 +3529,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s2, 0
 ; GFX1164DAGISEL-NEXT:    s_brev_b32 s3, 1
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s6, s[0:1]
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -2802,7 +3541,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s2, v4
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s3, v5
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1164DAGISEL-NEXT:  ; %bb.2:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v3, s3
@@ -2815,7 +3554,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1164GISEL-NEXT:    s_mov_b32 s2, 0
 ; GFX1164GISEL-NEXT:    s_brev_b32 s3, 1
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s6, s[0:1]
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -2827,7 +3566,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s2, v4
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s3, v5
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1164GISEL-NEXT:  ; %bb.2:
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v3, s3
@@ -2840,7 +3579,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132DAGISEL-NEXT:    s_brev_b32 s1, 1
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX1132DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -2852,7 +3591,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1132DAGISEL-NEXT:  ; %bb.2:
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
 ; GFX1132DAGISEL-NEXT:    global_store_b64 v[0:1], v[2:3], off
@@ -2864,7 +3603,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1132GISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132GISEL-NEXT:    s_brev_b32 s1, 1
 ; GFX1132GISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX1132GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -2876,7 +3615,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1132GISEL-NEXT:  ; %bb.2:
 ; GFX1132GISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
 ; GFX1132GISEL-NEXT:    global_store_b64 v[0:1], v[2:3], off
@@ -2892,7 +3631,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX12DAGISEL-NEXT:    s_brev_b32 s1, 1
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX12DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -2905,7 +3644,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX12DAGISEL-NEXT:  ; %bb.2:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
@@ -2926,7 +3665,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $sgpr6_sgpr7
 ; GFX8DAGISEL-NEXT:    s_and_saveexec_b64 s[8:9], vcc
 ; GFX8DAGISEL-NEXT:    s_xor_b64 s[8:9], exec, s[8:9]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX8DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -2935,13 +3674,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8DAGISEL-NEXT:    v_mul_f64 v[0:1], s[2:3], v[0:1]
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX8DAGISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX8DAGISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX8DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[8:9]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v1, s7
 ; GFX8DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX8DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -2951,7 +3690,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX8DAGISEL-NEXT:  .LBB7_4: ; %endif
+; GFX8DAGISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX8DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s0
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s1
@@ -2965,7 +3704,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8GISEL-NEXT:    ; implicit-def: $sgpr6_sgpr7
 ; GFX8GISEL-NEXT:    s_and_saveexec_b64 s[8:9], vcc
 ; GFX8GISEL-NEXT:    s_xor_b64 s[8:9], exec, s[8:9]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX8GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -2974,13 +3713,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8GISEL-NEXT:    v_mul_f64 v[0:1], s[2:3], v[0:1]
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX8GISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX8GISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX8GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8GISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[8:9]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v1, s7
 ; GFX8GISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX8GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_load_dwordx2 s[4:5], s[4:5], 0x34
@@ -2992,7 +3731,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX8GISEL-NEXT:  .LBB7_4: ; %endif
+; GFX8GISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX8GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s1
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s0
@@ -3007,7 +3746,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GFX9DAGISEL-NEXT:    s_and_saveexec_b64 s[8:9], vcc
 ; GFX9DAGISEL-NEXT:    s_xor_b64 s[8:9], exec, s[8:9]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX9DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX9DAGISEL-NEXT:    s_bcnt1_i32_b64 s4, s[4:5]
@@ -3016,13 +3755,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9DAGISEL-NEXT:    v_mul_f64 v[0:1], s[2:3], v[0:1]
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s4, v0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX9DAGISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX9DAGISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX9DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[8:9]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
 ; GFX9DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX9DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX9DAGISEL-NEXT:    s_bcnt1_i32_b64 s4, s[4:5]
@@ -3032,7 +3771,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9DAGISEL-NEXT:  .LBB7_4: ; %endif
+; GFX9DAGISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX9DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX9DAGISEL-NEXT:    global_store_dwordx2 v2, v[0:1], s[0:1]
@@ -3045,7 +3784,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9GISEL-NEXT:    ; implicit-def: $sgpr6_sgpr7
 ; GFX9GISEL-NEXT:    s_and_saveexec_b64 s[8:9], vcc
 ; GFX9GISEL-NEXT:    s_xor_b64 s[8:9], exec, s[8:9]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX9GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -3054,13 +3793,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9GISEL-NEXT:    v_mul_f64 v[0:1], s[2:3], v[0:1]
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9GISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX9GISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX9GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9GISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[8:9]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v1, s7
 ; GFX9GISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX9GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX9GISEL-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x34
 ; GFX9GISEL-NEXT:    s_mov_b64 s[4:5], exec
@@ -3072,7 +3811,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9GISEL-NEXT:  .LBB7_4: ; %endif
+; GFX9GISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX9GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX9GISEL-NEXT:    global_store_dwordx2 v2, v[0:1], s[0:1]
@@ -3087,7 +3826,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $sgpr8_sgpr9
 ; GFX1064DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX1064DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[8:9], exec
 ; GFX1064DAGISEL-NEXT:    s_bcnt1_i32_b64 s8, s[8:9]
@@ -3096,13 +3835,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064DAGISEL-NEXT:    v_mul_f64 v[0:1], s[2:3], v[0:1]
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s8, v0
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s9, v1
-; GFX1064DAGISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX1064DAGISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[4:5]
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v0, s8
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v1, s9
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1064DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX1064DAGISEL-NEXT:    s_bcnt1_i32_b64 s4, s[4:5]
@@ -3112,7 +3851,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX1064DAGISEL-NEXT:  .LBB7_4: ; %endif
+; GFX1064DAGISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX1064DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1064DAGISEL-NEXT:    global_store_dwordx2 v2, v[0:1], s[0:1]
@@ -3125,7 +3864,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064GISEL-NEXT:    ; implicit-def: $sgpr8_sgpr9
 ; GFX1064GISEL-NEXT:    s_and_saveexec_b64 s[6:7], vcc
 ; GFX1064GISEL-NEXT:    s_xor_b64 s[6:7], exec, s[6:7]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX1064GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[8:9], exec
 ; GFX1064GISEL-NEXT:    s_bcnt1_i32_b64 s8, s[8:9]
@@ -3134,13 +3873,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064GISEL-NEXT:    v_mul_f64 v[0:1], s[2:3], v[0:1]
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s8, v0
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s9, v1
-; GFX1064GISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX1064GISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064GISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[6:7]
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v0, s8
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v1, s9
 ; GFX1064GISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1064GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -3152,7 +3891,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX1064GISEL-NEXT:  .LBB7_4: ; %endif
+; GFX1064GISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX1064GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1064GISEL-NEXT:    global_store_dwordx2 v2, v[0:1], s[0:1]
@@ -3167,7 +3906,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GFX1032DAGISEL-NEXT:    s_and_saveexec_b32 s8, vcc_lo
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 s8, exec_lo, s8
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX1032DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_bcnt1_i32_b32 s4, s4
@@ -3176,13 +3915,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032DAGISEL-NEXT:    v_mul_f64 v[0:1], s[2:3], v[0:1]
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s4, v0
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX1032DAGISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX1032DAGISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX1032DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032DAGISEL-NEXT:    s_or_saveexec_b32 s2, s8
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s2
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1032DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_bcnt1_i32_b32 s3, s3
@@ -3192,7 +3931,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX1032DAGISEL-NEXT:  .LBB7_4: ; %endif
+; GFX1032DAGISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX1032DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1032DAGISEL-NEXT:    global_store_dwordx2 v2, v[0:1], s[0:1]
@@ -3205,7 +3944,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032GISEL-NEXT:    ; implicit-def: $sgpr6_sgpr7
 ; GFX1032GISEL-NEXT:    s_and_saveexec_b32 s8, vcc_lo
 ; GFX1032GISEL-NEXT:    s_xor_b32 s8, exec_lo, s8
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX1032GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032GISEL-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX1032GISEL-NEXT:    s_bcnt1_i32_b32 s6, s6
@@ -3214,13 +3953,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032GISEL-NEXT:    v_mul_f64 v[0:1], s[2:3], v[0:1]
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1032GISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX1032GISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX1032GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032GISEL-NEXT:    s_or_saveexec_b32 s2, s8
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v1, s7
 ; GFX1032GISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s2
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1032GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1032GISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1032GISEL-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x34
@@ -3232,7 +3971,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX1032GISEL-NEXT:  .LBB7_4: ; %endif
+; GFX1032GISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX1032GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1032GISEL-NEXT:    global_store_dwordx2 v2, v[0:1], s[0:1]
@@ -3249,7 +3988,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 s[6:7], exec, s[6:7]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX1164DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[8:9], exec
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -3261,14 +4000,14 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s8, v0
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s9, v1
-; GFX1164DAGISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX1164DAGISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1164DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[6:7]
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, s8
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v1, s9
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1164DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -3282,7 +4021,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX1164DAGISEL-NEXT:  .LBB7_4: ; %endif
+; GFX1164DAGISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX1164DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1164DAGISEL-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
@@ -3297,7 +4036,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_cmpx_le_u32_e32 16, v0
 ; GFX1164GISEL-NEXT:    s_xor_b64 s[6:7], exec, s[6:7]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX1164GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[8:9], exec
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -3309,14 +4048,14 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s8, v0
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s9, v1
-; GFX1164GISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX1164GISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX1164GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1164GISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[6:7]
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v0, s8
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v1, s9
 ; GFX1164GISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1164GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164GISEL-NEXT:    s_load_b64 s[4:5], s[4:5], 0x34
@@ -3331,7 +4070,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX1164GISEL-NEXT:  .LBB7_4: ; %endif
+; GFX1164GISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX1164GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1164GISEL-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
@@ -3348,7 +4087,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 s8, exec_lo, s8
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX1132DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -3360,13 +4099,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1132DAGISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX1132DAGISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX1132DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1132DAGISEL-NEXT:    s_or_saveexec_b32 s2, s8
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v0, s6 :: v_dual_mov_b32 v1, s7
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s2
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1132DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -3378,7 +4117,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v1, s5
-; GFX1132DAGISEL-NEXT:  .LBB7_4: ; %endif
+; GFX1132DAGISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX1132DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1132DAGISEL-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
@@ -3393,7 +4132,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_cmpx_le_u32_e32 16, v0
 ; GFX1132GISEL-NEXT:    s_xor_b32 s8, exec_lo, s8
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX1132GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132GISEL-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -3405,13 +4144,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1132GISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX1132GISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX1132GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1132GISEL-NEXT:    s_or_saveexec_b32 s2, s8
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_dual_mov_b32 v0, s6 :: v_dual_mov_b32 v1, s7
 ; GFX1132GISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s2
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1132GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1132GISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1132GISEL-NEXT:    s_load_b64 s[4:5], s[4:5], 0x34
@@ -3425,7 +4164,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v1, s5
-; GFX1132GISEL-NEXT:  .LBB7_4: ; %endif
+; GFX1132GISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX1132GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1132GISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1132GISEL-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
@@ -3442,7 +4181,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX12DAGISEL-NEXT:    s_xor_b32 s8, exec_lo, s8
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX12DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -3454,7 +4193,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX12DAGISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX12DAGISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12DAGISEL-NEXT:    s_or_saveexec_b32 s2, s8
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
@@ -3462,7 +4201,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v0, s6 :: v_dual_mov_b32 v1, s7
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s2
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX12DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -3476,7 +4215,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v1, s5
-; GFX12DAGISEL-NEXT:  .LBB7_4: ; %endif
+; GFX12DAGISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX12DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX12DAGISEL-NEXT:    global_store_b64 v2, v[0:1], s[0:1]

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.fmax.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.fmax.ll
@@ -7,11 +7,688 @@
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -global-isel=1 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX10GISEL,GFX1064GISEL %s
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -global-isel=0 < %s | FileCheck -check-prefixes=GFX10DAGISEL,GFX1032DAGISEL %s
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -global-isel=1 < %s | FileCheck -check-prefixes=GFX10GISEL,GFX1032GISEL %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -global-isel=0 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164DAGISEL %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -global-isel=1 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164GISEL %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -global-isel=0 < %s | FileCheck -check-prefixes=GFX1132DAGISEL %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -global-isel=1 < %s | FileCheck -check-prefixes=GFX1132GISEL %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=-real-true16 -global-isel=0 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164DAGISEL,GFX1164DAGISEL-FAKE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=-real-true16 -global-isel=1 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164GISEL,GFX1164GISEL-FAKE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=-real-true16 -global-isel=0 < %s | FileCheck -check-prefixes=GFX1132DAGISEL,GFX1132DAGISEL-FAKE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=-real-true16 -global-isel=1 < %s | FileCheck -check-prefixes=GFX1132GISEL,GFX1132GISEL-FAKE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+real-true16 -global-isel=0 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164DAGISEL,GFX1164DAGISEL-TRUE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+real-true16 -global-isel=1 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164GISEL,GFX1164GISEL-TRUE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+real-true16 -global-isel=0 < %s | FileCheck -check-prefixes=GFX1132DAGISEL,GFX1132DAGISEL-TRUE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+real-true16 -global-isel=1 < %s | FileCheck -check-prefixes=GFX1132GISEL,GFX1132GISEL-TRUE16 %s
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx1200 -global-isel=0 < %s | FileCheck -check-prefixes=GFX12DAGISEL %s
+
+define amdgpu_kernel void @uniform_value_half(ptr addrspace(1) %out, half %in) {
+; GFX8DAGISEL-LABEL: uniform_value_half:
+; GFX8DAGISEL:       ; %bb.0: ; %entry
+; GFX8DAGISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX8DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX8DAGISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
+; GFX8DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX8DAGISEL-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX8DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
+; GFX8DAGISEL-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s5, s[2:3]
+; GFX8DAGISEL-NEXT:    v_readlane_b32 s6, v0, s5
+; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v1, s6
+; GFX8DAGISEL-NEXT:    s_bitset0_b64 s[2:3], s5
+; GFX8DAGISEL-NEXT:    v_max_f32_e32 v1, s4, v1
+; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[2:3], 0
+; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s4, v1
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX8DAGISEL-NEXT:  ; %bb.2:
+; GFX8DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2, s4
+; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v0, s0
+; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v1, s1
+; GFX8DAGISEL-NEXT:    flat_store_short v[0:1], v2
+; GFX8DAGISEL-NEXT:    s_endpgm
+;
+; GFX8GISEL-LABEL: uniform_value_half:
+; GFX8GISEL:       ; %bb.0: ; %entry
+; GFX8GISEL-NEXT:    s_load_dword s0, s[4:5], 0x2c
+; GFX8GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX8GISEL-NEXT:    v_cvt_f32_f16_e32 v0, s0
+; GFX8GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX8GISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX8GISEL-NEXT:    v_cvt_f16_f32_e32 v2, s2
+; GFX8GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX8GISEL-NEXT:    v_mov_b32_e32 v0, s0
+; GFX8GISEL-NEXT:    v_mov_b32_e32 v1, s1
+; GFX8GISEL-NEXT:    flat_store_short v[0:1], v2
+; GFX8GISEL-NEXT:    s_endpgm
+;
+; GFX9DAGISEL-LABEL: uniform_value_half:
+; GFX9DAGISEL:       ; %bb.0: ; %entry
+; GFX9DAGISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX9DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX9DAGISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
+; GFX9DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX9DAGISEL-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX9DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
+; GFX9DAGISEL-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s5, s[2:3]
+; GFX9DAGISEL-NEXT:    v_readlane_b32 s6, v1, s5
+; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9DAGISEL-NEXT:    s_bitset0_b64 s[2:3], s5
+; GFX9DAGISEL-NEXT:    v_max_f32_e32 v2, s4, v2
+; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[2:3], 0
+; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s4, v2
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX9DAGISEL-NEXT:  ; %bb.2:
+; GFX9DAGISEL-NEXT:    v_cvt_f16_f32_e32 v1, s4
+; GFX9DAGISEL-NEXT:    global_store_short v0, v1, s[0:1]
+; GFX9DAGISEL-NEXT:    s_endpgm
+;
+; GFX9GISEL-LABEL: uniform_value_half:
+; GFX9GISEL:       ; %bb.0: ; %entry
+; GFX9GISEL-NEXT:    s_load_dword s0, s[4:5], 0x2c
+; GFX9GISEL-NEXT:    v_mov_b32_e32 v1, 0
+; GFX9GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX9GISEL-NEXT:    v_cvt_f32_f16_e32 v0, s0
+; GFX9GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX9GISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX9GISEL-NEXT:    v_cvt_f16_f32_e32 v0, s2
+; GFX9GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX9GISEL-NEXT:    global_store_short v1, v0, s[0:1]
+; GFX9GISEL-NEXT:    s_endpgm
+;
+; GFX1064DAGISEL-LABEL: uniform_value_half:
+; GFX1064DAGISEL:       ; %bb.0: ; %entry
+; GFX1064DAGISEL-NEXT:    s_clause 0x1
+; GFX1064DAGISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX1064DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1064DAGISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
+; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1064DAGISEL-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1064DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
+; GFX1064DAGISEL-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s5, s[2:3]
+; GFX1064DAGISEL-NEXT:    v_readlane_b32 s6, v1, s5
+; GFX1064DAGISEL-NEXT:    s_bitset0_b64 s[2:3], s5
+; GFX1064DAGISEL-NEXT:    s_cmp_lg_u64 s[2:3], 0
+; GFX1064DAGISEL-NEXT:    v_max_f32_e64 v2, s4, s6
+; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s4, v2
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1064DAGISEL-NEXT:  ; %bb.2:
+; GFX1064DAGISEL-NEXT:    v_cvt_f16_f32_e32 v1, s4
+; GFX1064DAGISEL-NEXT:    global_store_short v0, v1, s[0:1]
+; GFX1064DAGISEL-NEXT:    s_endpgm
+;
+; GFX10GISEL-LABEL: uniform_value_half:
+; GFX10GISEL:       ; %bb.0: ; %entry
+; GFX10GISEL-NEXT:    s_clause 0x1
+; GFX10GISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX10GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX10GISEL-NEXT:    v_mov_b32_e32 v1, 0
+; GFX10GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX10GISEL-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX10GISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX10GISEL-NEXT:    v_cvt_f16_f32_e32 v0, s2
+; GFX10GISEL-NEXT:    global_store_short v1, v0, s[0:1]
+; GFX10GISEL-NEXT:    s_endpgm
+;
+; GFX1032DAGISEL-LABEL: uniform_value_half:
+; GFX1032DAGISEL:       ; %bb.0: ; %entry
+; GFX1032DAGISEL-NEXT:    s_clause 0x1
+; GFX1032DAGISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX1032DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1032DAGISEL-NEXT:    s_mov_b32 s3, 0x7fc00000
+; GFX1032DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1032DAGISEL-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1032DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
+; GFX1032DAGISEL-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s4, s2
+; GFX1032DAGISEL-NEXT:    v_readlane_b32 s5, v1, s4
+; GFX1032DAGISEL-NEXT:    s_bitset0_b32 s2, s4
+; GFX1032DAGISEL-NEXT:    s_cmp_lg_u32 s2, 0
+; GFX1032DAGISEL-NEXT:    v_max_f32_e64 v2, s3, s5
+; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s3, v2
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1032DAGISEL-NEXT:  ; %bb.2:
+; GFX1032DAGISEL-NEXT:    v_cvt_f16_f32_e32 v1, s3
+; GFX1032DAGISEL-NEXT:    global_store_short v0, v1, s[0:1]
+; GFX1032DAGISEL-NEXT:    s_endpgm
+;
+; GFX1164DAGISEL-FAKE16-LABEL: uniform_value_half:
+; GFX1164DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mov_b32 s4, 0x7fc00000
+; GFX1164DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mov_b64 s[2:3], exec
+; GFX1164DAGISEL-FAKE16-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_ctz_i32_b64 s5, s[2:3]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_readlane_b32 s6, v1, s5
+; GFX1164DAGISEL-FAKE16-NEXT:    s_bitset0_b64 s[2:3], s5
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cmp_lg_u64 s[2:3], 0
+; GFX1164DAGISEL-FAKE16-NEXT:    v_max_f32_e64 v2, s4, s6
+; GFX1164DAGISEL-FAKE16-NEXT:    v_readfirstlane_b32 s4, v2
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1164DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v1, s4
+; GFX1164DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_endpgm
+;
+; GFX1164GISEL-FAKE16-LABEL: uniform_value_half:
+; GFX1164GISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164GISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1164GISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164GISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164GISEL-FAKE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1164GISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164GISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX1164GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1164GISEL-FAKE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1164GISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v0, s2
+; GFX1164GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1164GISEL-FAKE16-NEXT:    s_endpgm
+;
+; GFX1132DAGISEL-FAKE16-LABEL: uniform_value_half:
+; GFX1132DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mov_b32 s3, 0x7fc00000
+; GFX1132DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mov_b32 s2, exec_lo
+; GFX1132DAGISEL-FAKE16-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_ctz_i32_b32 s4, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_readlane_b32 s5, v1, s4
+; GFX1132DAGISEL-FAKE16-NEXT:    s_bitset0_b32 s2, s4
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cmp_lg_u32 s2, 0
+; GFX1132DAGISEL-FAKE16-NEXT:    v_max_f32_e64 v2, s3, s5
+; GFX1132DAGISEL-FAKE16-NEXT:    v_readfirstlane_b32 s3, v2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1132DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v1, s3
+; GFX1132DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1132DAGISEL-FAKE16-NEXT:    s_endpgm
+;
+; GFX1132GISEL-FAKE16-LABEL: uniform_value_half:
+; GFX1132GISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132GISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1132GISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132GISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132GISEL-FAKE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1132GISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132GISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX1132GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1132GISEL-FAKE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1132GISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v0, s2
+; GFX1132GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1132GISEL-FAKE16-NEXT:    s_endpgm
+;
+; GFX1164DAGISEL-TRUE16-LABEL: uniform_value_half:
+; GFX1164DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b32 s4, 0x7fc00000
+; GFX1164DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b64 s[2:3], exec
+; GFX1164DAGISEL-TRUE16-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_ctz_i32_b64 s5, s[2:3]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_readlane_b32 s6, v1, s5
+; GFX1164DAGISEL-TRUE16-NEXT:    s_bitset0_b64 s[2:3], s5
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cmp_lg_u64 s[2:3], 0
+; GFX1164DAGISEL-TRUE16-NEXT:    v_max_f32_e64 v2, s4, s6
+; GFX1164DAGISEL-TRUE16-NEXT:    v_readfirstlane_b32 s4, v2
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1164DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.l, s4
+; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX1164GISEL-TRUE16-LABEL: uniform_value_half:
+; GFX1164GISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164GISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1164GISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164GISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164GISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1164GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164GISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX1164GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1164GISEL-TRUE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1164GISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, s2
+; GFX1164GISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1164GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX1132DAGISEL-TRUE16-LABEL: uniform_value_half:
+; GFX1132DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s3, 0x7fc00000
+; GFX1132DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s2, exec_lo
+; GFX1132DAGISEL-TRUE16-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_ctz_i32_b32 s4, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_readlane_b32 s5, v1, s4
+; GFX1132DAGISEL-TRUE16-NEXT:    s_bitset0_b32 s2, s4
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cmp_lg_u32 s2, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    v_max_f32_e64 v2, s3, s5
+; GFX1132DAGISEL-TRUE16-NEXT:    v_readfirstlane_b32 s3, v2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1132DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.l, s3
+; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1132DAGISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX1132GISEL-TRUE16-LABEL: uniform_value_half:
+; GFX1132GISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132GISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1132GISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132GISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132GISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1132GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132GISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX1132GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1132GISEL-TRUE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1132GISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, s2
+; GFX1132GISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1132GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX12DAGISEL-LABEL: uniform_value_half:
+; GFX12DAGISEL:       ; %bb.0: ; %entry
+; GFX12DAGISEL-NEXT:    s_load_b96 s[0:2], s[4:5], 0x24
+; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v1, 0
+; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12DAGISEL-NEXT:    s_cvt_f32_f16 s2, s2
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_3) | instskip(NEXT) | instid1(SALU_CYCLE_3)
+; GFX12DAGISEL-NEXT:    s_cvt_f16_f32 s2, s2
+; GFX12DAGISEL-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX12DAGISEL-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX12DAGISEL-NEXT:    s_endpgm
+  entry:
+  %result = call half @llvm.amdgcn.wave.reduce.fmax(half %in, i32 1)
+  store half %result, ptr addrspace(1) %out
+  ret void
+}
+
+define void @divergent_value_half(ptr addrspace(1) %out, half %in) {
+; GFX8DAGISEL-LABEL: divergent_value_half:
+; GFX8DAGISEL:       ; %bb.0: ; %entry
+; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8DAGISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX8DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX8DAGISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
+; GFX8DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX8DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s8
+; GFX8DAGISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX8DAGISEL-NEXT:    v_max_f32_e32 v3, s6, v3
+; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX8DAGISEL-NEXT:  ; %bb.2:
+; GFX8DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX8DAGISEL-NEXT:    flat_store_short v[0:1], v2
+; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX8DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8GISEL-LABEL: divergent_value_half:
+; GFX8GISEL:       ; %bb.0: ; %entry
+; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8GISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX8GISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX8GISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
+; GFX8GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX8GISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s8
+; GFX8GISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX8GISEL-NEXT:    v_max_f32_e32 v3, s6, v3
+; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX8GISEL-NEXT:  ; %bb.2:
+; GFX8GISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX8GISEL-NEXT:    flat_store_short v[0:1], v2
+; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX8GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9DAGISEL-LABEL: divergent_value_half:
+; GFX9DAGISEL:       ; %bb.0: ; %entry
+; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9DAGISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX9DAGISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
+; GFX9DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX9DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v3, s8
+; GFX9DAGISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX9DAGISEL-NEXT:    v_max_f32_e32 v3, s6, v3
+; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX9DAGISEL-NEXT:  ; %bb.2:
+; GFX9DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX9DAGISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX9DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9GISEL-LABEL: divergent_value_half:
+; GFX9GISEL:       ; %bb.0: ; %entry
+; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9GISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX9GISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX9GISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
+; GFX9GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX9GISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX9GISEL-NEXT:    v_mov_b32_e32 v3, s8
+; GFX9GISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX9GISEL-NEXT:    v_max_f32_e32 v3, s6, v3
+; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX9GISEL-NEXT:  ; %bb.2:
+; GFX9GISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX9GISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX9GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1064DAGISEL-LABEL: divergent_value_half:
+; GFX1064DAGISEL:       ; %bb.0: ; %entry
+; GFX1064DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1064DAGISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1064DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX1064DAGISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
+; GFX1064DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX1064DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX1064DAGISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX1064DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX1064DAGISEL-NEXT:    v_max_f32_e64 v3, s6, s8
+; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1064DAGISEL-NEXT:  ; %bb.2:
+; GFX1064DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX1064DAGISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX1064DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1064GISEL-LABEL: divergent_value_half:
+; GFX1064GISEL:       ; %bb.0: ; %entry
+; GFX1064GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1064GISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1064GISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX1064GISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
+; GFX1064GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX1064GISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX1064GISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX1064GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX1064GISEL-NEXT:    v_max_f32_e64 v3, s6, s8
+; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1064GISEL-NEXT:  ; %bb.2:
+; GFX1064GISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX1064GISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX1064GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1032DAGISEL-LABEL: divergent_value_half:
+; GFX1032DAGISEL:       ; %bb.0: ; %entry
+; GFX1032DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1032DAGISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, exec_lo
+; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, 0x7fc00000
+; GFX1032DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s6, s4
+; GFX1032DAGISEL-NEXT:    v_readlane_b32 s7, v2, s6
+; GFX1032DAGISEL-NEXT:    s_bitset0_b32 s4, s6
+; GFX1032DAGISEL-NEXT:    s_cmp_lg_u32 s4, 0
+; GFX1032DAGISEL-NEXT:    v_max_f32_e64 v3, s5, s7
+; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v3
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1032DAGISEL-NEXT:  ; %bb.2:
+; GFX1032DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2, s5
+; GFX1032DAGISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX1032DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1032GISEL-LABEL: divergent_value_half:
+; GFX1032GISEL:       ; %bb.0: ; %entry
+; GFX1032GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1032GISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1032GISEL-NEXT:    s_mov_b32 s4, exec_lo
+; GFX1032GISEL-NEXT:    s_mov_b32 s5, 0x7fc00000
+; GFX1032GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s6, s4
+; GFX1032GISEL-NEXT:    v_readlane_b32 s7, v2, s6
+; GFX1032GISEL-NEXT:    s_bitset0_b32 s4, s6
+; GFX1032GISEL-NEXT:    s_cmp_lg_u32 s4, 0
+; GFX1032GISEL-NEXT:    v_max_f32_e64 v3, s5, s7
+; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v3
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1032GISEL-NEXT:  ; %bb.2:
+; GFX1032GISEL-NEXT:    v_cvt_f16_f32_e32 v2, s5
+; GFX1032GISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX1032GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164DAGISEL-FAKE16-LABEL: divergent_value_half:
+; GFX1164DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mov_b32 s2, 0x7fc00000
+; GFX1164DAGISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164DAGISEL-FAKE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164DAGISEL-FAKE16-NEXT:    v_max_f32_e64 v3, s2, s4
+; GFX1164DAGISEL-FAKE16-NEXT:    v_readfirstlane_b32 s2, v3
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v2, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164DAGISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164GISEL-FAKE16-LABEL: divergent_value_half:
+; GFX1164GISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164GISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164GISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1164GISEL-FAKE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164GISEL-FAKE16-NEXT:    s_mov_b32 s2, 0x7fc00000
+; GFX1164GISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-FAKE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164GISEL-FAKE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164GISEL-FAKE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164GISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164GISEL-FAKE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164GISEL-FAKE16-NEXT:    v_max_f32_e64 v3, s2, s4
+; GFX1164GISEL-FAKE16-NEXT:    v_readfirstlane_b32 s2, v3
+; GFX1164GISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164GISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1164GISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v2, s2
+; GFX1164GISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164GISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132DAGISEL-FAKE16-LABEL: divergent_value_half:
+; GFX1132DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mov_b32 s0, exec_lo
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mov_b32 s1, 0x7fc00000
+; GFX1132DAGISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_ctz_i32_b32 s2, s0
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_bitset0_b32 s0, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cmp_lg_u32 s0, 0
+; GFX1132DAGISEL-FAKE16-NEXT:    v_max_f32_e64 v3, s1, s3
+; GFX1132DAGISEL-FAKE16-NEXT:    v_readfirstlane_b32 s1, v3
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v2, s1
+; GFX1132DAGISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132DAGISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132GISEL-FAKE16-LABEL: divergent_value_half:
+; GFX1132GISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132GISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132GISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1132GISEL-FAKE16-NEXT:    s_mov_b32 s0, exec_lo
+; GFX1132GISEL-FAKE16-NEXT:    s_mov_b32 s1, 0x7fc00000
+; GFX1132GISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-FAKE16-NEXT:    s_ctz_i32_b32 s2, s0
+; GFX1132GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132GISEL-FAKE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132GISEL-FAKE16-NEXT:    s_bitset0_b32 s0, s2
+; GFX1132GISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132GISEL-FAKE16-NEXT:    s_cmp_lg_u32 s0, 0
+; GFX1132GISEL-FAKE16-NEXT:    v_max_f32_e64 v3, s1, s3
+; GFX1132GISEL-FAKE16-NEXT:    v_readfirstlane_b32 s1, v3
+; GFX1132GISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132GISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1132GISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v2, s1
+; GFX1132GISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132GISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164DAGISEL-TRUE16-LABEL: divergent_value_half:
+; GFX1164DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b32 s2, 0x7fc00000
+; GFX1164DAGISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164DAGISEL-TRUE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164DAGISEL-TRUE16-NEXT:    v_max_f32_e64 v3, s2, s4
+; GFX1164DAGISEL-TRUE16-NEXT:    v_readfirstlane_b32 s2, v3
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v2.l, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164GISEL-TRUE16-LABEL: divergent_value_half:
+; GFX1164GISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164GISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164GISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
+; GFX1164GISEL-TRUE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164GISEL-TRUE16-NEXT:    s_mov_b32 s2, 0x7fc00000
+; GFX1164GISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-TRUE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164GISEL-TRUE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164GISEL-TRUE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164GISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164GISEL-TRUE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164GISEL-TRUE16-NEXT:    v_max_f32_e64 v3, s2, s4
+; GFX1164GISEL-TRUE16-NEXT:    v_readfirstlane_b32 s2, v3
+; GFX1164GISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164GISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1164GISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v2.l, s2
+; GFX1164GISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164GISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132DAGISEL-TRUE16-LABEL: divergent_value_half:
+; GFX1132DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s0, exec_lo
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s1, 0x7fc00000
+; GFX1132DAGISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_ctz_i32_b32 s2, s0
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_bitset0_b32 s0, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cmp_lg_u32 s0, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    v_max_f32_e64 v3, s1, s3
+; GFX1132DAGISEL-TRUE16-NEXT:    v_readfirstlane_b32 s1, v3
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v2.l, s1
+; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132GISEL-TRUE16-LABEL: divergent_value_half:
+; GFX1132GISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132GISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132GISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
+; GFX1132GISEL-TRUE16-NEXT:    s_mov_b32 s0, exec_lo
+; GFX1132GISEL-TRUE16-NEXT:    s_mov_b32 s1, 0x7fc00000
+; GFX1132GISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-TRUE16-NEXT:    s_ctz_i32_b32 s2, s0
+; GFX1132GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132GISEL-TRUE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132GISEL-TRUE16-NEXT:    s_bitset0_b32 s0, s2
+; GFX1132GISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132GISEL-TRUE16-NEXT:    s_cmp_lg_u32 s0, 0
+; GFX1132GISEL-TRUE16-NEXT:    v_max_f32_e64 v3, s1, s3
+; GFX1132GISEL-TRUE16-NEXT:    v_readfirstlane_b32 s1, v3
+; GFX1132GISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132GISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1132GISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v2.l, s1
+; GFX1132GISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132GISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12DAGISEL-LABEL: divergent_value_half:
+; GFX12DAGISEL:       ; %bb.0: ; %entry
+; GFX12DAGISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12DAGISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
+; GFX12DAGISEL-NEXT:    s_mov_b32 s0, exec_lo
+; GFX12DAGISEL-NEXT:    s_mov_b32 s1, 0x7fc00000
+; GFX12DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s2, s0
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX12DAGISEL-NEXT:    s_bitset0_b32 s0, s2
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    s_cmp_lg_u32 s0, 0
+; GFX12DAGISEL-NEXT:    v_max_num_f32_e64 v3, s1, s3
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v3
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX12DAGISEL-NEXT:  ; %bb.2:
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX12DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2.l, s1
+; GFX12DAGISEL-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX12DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+  entry:
+  %result = call half @llvm.amdgcn.wave.reduce.fmax(half %in, i32 1)
+  store half %result, ptr addrspace(1) %out
+  ret void
+}
 
 
 define amdgpu_kernel void @uniform_value_float(ptr addrspace(1) %out, float %in) #0 {
@@ -140,7 +817,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX8DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s8
@@ -148,7 +825,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX8DAGISEL-NEXT:    v_max_f32_e32 v3, s6, v3
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX8DAGISEL-NEXT:  ; %bb.2:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8DAGISEL-NEXT:    flat_store_dword v[0:1], v2
@@ -160,7 +837,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8GISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX8GISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX8GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX8GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s8
@@ -168,7 +845,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX8GISEL-NEXT:    v_max_f32_e32 v3, s6, v3
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX8GISEL-NEXT:  ; %bb.2:
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8GISEL-NEXT:    flat_store_dword v[0:1], v2
@@ -180,7 +857,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX9DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v3, s8
@@ -188,7 +865,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX9DAGISEL-NEXT:    v_max_f32_e32 v3, s6, v3
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX9DAGISEL-NEXT:  ; %bb.2:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -200,7 +877,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9GISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX9GISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX9GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX9GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v3, s8
@@ -208,7 +885,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX9GISEL-NEXT:    v_max_f32_e32 v3, s6, v3
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX9GISEL-NEXT:  ; %bb.2:
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9GISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -220,14 +897,14 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1064DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX1064DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1064DAGISEL-NEXT:    s_bitset0_b64 s[4:5], s7
 ; GFX1064DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX1064DAGISEL-NEXT:    v_max_f32_e64 v3, s6, s8
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1064DAGISEL-NEXT:  ; %bb.2:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -238,14 +915,14 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1064GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX1064GISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX1064GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1064GISEL-NEXT:    s_bitset0_b64 s[4:5], s7
 ; GFX1064GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX1064GISEL-NEXT:    v_max_f32_e64 v3, s6, s8
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1064GISEL-NEXT:  ; %bb.2:
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064GISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -256,14 +933,14 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1032DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, 0x7fc00000
-; GFX1032DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s6, s4
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s7, v2, s6
 ; GFX1032DAGISEL-NEXT:    s_bitset0_b32 s4, s6
 ; GFX1032DAGISEL-NEXT:    s_cmp_lg_u32 s4, 0
 ; GFX1032DAGISEL-NEXT:    v_max_f32_e64 v3, s5, s7
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1032DAGISEL-NEXT:  ; %bb.2:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v2, s5
 ; GFX1032DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -274,14 +951,14 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1032GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1032GISEL-NEXT:    s_mov_b32 s4, exec_lo
 ; GFX1032GISEL-NEXT:    s_mov_b32 s5, 0x7fc00000
-; GFX1032GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s6, s4
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s7, v2, s6
 ; GFX1032GISEL-NEXT:    s_bitset0_b32 s4, s6
 ; GFX1032GISEL-NEXT:    s_cmp_lg_u32 s4, 0
 ; GFX1032GISEL-NEXT:    v_max_f32_e64 v3, s5, s7
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1032GISEL-NEXT:  ; %bb.2:
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v2, s5
 ; GFX1032GISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -292,7 +969,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1164DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[0:1], exec
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX1164DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s3, s[0:1]
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -301,7 +978,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1164DAGISEL-NEXT:    v_max_f32_e64 v3, s2, s4
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s2, v3
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1164DAGISEL-NEXT:  ; %bb.2:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164DAGISEL-NEXT:    global_store_b32 v[0:1], v2, off
@@ -312,7 +989,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1164GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[0:1], exec
 ; GFX1164GISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX1164GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s3, s[0:1]
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -321,7 +998,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1164GISEL-NEXT:    v_max_f32_e64 v3, s2, s4
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s2, v3
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1164GISEL-NEXT:  ; %bb.2:
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164GISEL-NEXT:    global_store_b32 v[0:1], v2, off
@@ -332,7 +1009,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1132DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s0, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, 0x7fc00000
-; GFX1132DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s2, s0
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s3, v2, s2
@@ -341,7 +1018,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1132DAGISEL-NEXT:    v_max_f32_e64 v3, s1, s3
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1132DAGISEL-NEXT:  ; %bb.2:
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v2, s1
 ; GFX1132DAGISEL-NEXT:    global_store_b32 v[0:1], v2, off
@@ -352,7 +1029,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1132GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1132GISEL-NEXT:    s_mov_b32 s0, exec_lo
 ; GFX1132GISEL-NEXT:    s_mov_b32 s1, 0x7fc00000
-; GFX1132GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s2, s0
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s3, v2, s2
@@ -361,7 +1038,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1132GISEL-NEXT:    v_max_f32_e64 v3, s1, s3
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1132GISEL-NEXT:  ; %bb.2:
 ; GFX1132GISEL-NEXT:    v_mov_b32_e32 v2, s1
 ; GFX1132GISEL-NEXT:    global_store_b32 v[0:1], v2, off
@@ -376,7 +1053,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s0, exec_lo
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s1, 0x7fc00000
-; GFX12DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s2, s0
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -387,7 +1064,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX12DAGISEL-NEXT:    v_max_num_f32_e64 v3, s1, s3
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX12DAGISEL-NEXT:  ; %bb.2:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v2, s1
@@ -1745,11 +2422,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX8DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX8DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX8DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX8DAGISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s10
@@ -1757,17 +2434,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX8DAGISEL-NEXT:    v_max_f32_e32 v3, s8, v3
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s8, v3
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX8DAGISEL-NEXT:  ; %bb.3:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX8DAGISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX8DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX8DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX8DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX8DAGISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s10
@@ -1775,10 +2452,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX8DAGISEL-NEXT:    v_max_f32_e32 v2, s8, v2
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX8DAGISEL-NEXT:  ; %bb.7:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
-; GFX8DAGISEL-NEXT:  .LBB4_8: ; %endif
+; GFX8DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX8DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX8DAGISEL-NEXT:    flat_store_dword v[0:1], v4
 ; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -1792,11 +2469,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX8GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX8GISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX8GISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX8GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX8GISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX8GISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s10
@@ -1804,17 +2481,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX8GISEL-NEXT:    v_max_f32_e32 v3, s8, v3
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s8, v3
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX8GISEL-NEXT:  ; %bb.3:
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX8GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX8GISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX8GISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX8GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX8GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX8GISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX8GISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s10
@@ -1822,10 +2499,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX8GISEL-NEXT:    v_max_f32_e32 v2, s8, v2
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX8GISEL-NEXT:  ; %bb.7:
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v4, s8
-; GFX8GISEL-NEXT:  .LBB4_8: ; %endif
+; GFX8GISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX8GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX8GISEL-NEXT:    flat_store_dword v[0:1], v4
 ; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -1839,11 +2516,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX9DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX9DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX9DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX9DAGISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v3, s10
@@ -1851,17 +2528,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX9DAGISEL-NEXT:    v_max_f32_e32 v3, s8, v3
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s8, v3
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX9DAGISEL-NEXT:  ; %bb.3:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX9DAGISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX9DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX9DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX9DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX9DAGISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s10
@@ -1869,10 +2546,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX9DAGISEL-NEXT:    v_max_f32_e32 v2, s8, v2
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX9DAGISEL-NEXT:  ; %bb.7:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
-; GFX9DAGISEL-NEXT:  .LBB4_8: ; %endif
+; GFX9DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX9DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX9DAGISEL-NEXT:    global_store_dword v[0:1], v4, off
 ; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -1886,11 +2563,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX9GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX9GISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX9GISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX9GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX9GISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX9GISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v3, s10
@@ -1898,17 +2575,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX9GISEL-NEXT:    v_max_f32_e32 v3, s8, v3
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s8, v3
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX9GISEL-NEXT:  ; %bb.3:
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX9GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX9GISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX9GISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX9GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX9GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX9GISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX9GISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s10
@@ -1916,10 +2593,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX9GISEL-NEXT:    v_max_f32_e32 v2, s8, v2
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX9GISEL-NEXT:  ; %bb.7:
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v4, s8
-; GFX9GISEL-NEXT:  .LBB4_8: ; %endif
+; GFX9GISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX9GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX9GISEL-NEXT:    global_store_dword v[0:1], v4, off
 ; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -1933,38 +2610,38 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1064DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1064DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX1064DAGISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX1064DAGISEL-NEXT:    s_bitset0_b64 s[6:7], s9
 ; GFX1064DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX1064DAGISEL-NEXT:    v_max_f32_e64 v3, s8, s10
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s8, v3
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1064DAGISEL-NEXT:  ; %bb.3:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1064DAGISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX1064DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1064DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1064DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX1064DAGISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX1064DAGISEL-NEXT:    s_bitset0_b64 s[6:7], s9
 ; GFX1064DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX1064DAGISEL-NEXT:    v_max_f32_e64 v2, s8, s10
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1064DAGISEL-NEXT:  ; %bb.7:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
-; GFX1064DAGISEL-NEXT:  .LBB4_8: ; %endif
+; GFX1064DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1064DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX1064DAGISEL-NEXT:    global_store_dword v[0:1], v4, off
 ; GFX1064DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -1977,38 +2654,38 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1064GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1064GISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX1064GISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1064GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX1064GISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX1064GISEL-NEXT:    s_bitset0_b64 s[6:7], s9
 ; GFX1064GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX1064GISEL-NEXT:    v_max_f32_e64 v3, s8, s10
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s8, v3
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1064GISEL-NEXT:  ; %bb.3:
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX1064GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1064GISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX1064GISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1064GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1064GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX1064GISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX1064GISEL-NEXT:    s_bitset0_b64 s[6:7], s9
 ; GFX1064GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX1064GISEL-NEXT:    v_max_f32_e64 v2, s8, s10
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1064GISEL-NEXT:  ; %bb.7:
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v4, s8
-; GFX1064GISEL-NEXT:  .LBB4_8: ; %endif
+; GFX1064GISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1064GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX1064GISEL-NEXT:    global_store_dword v[0:1], v4, off
 ; GFX1064GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -2021,38 +2698,38 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1032DAGISEL-NEXT:    s_and_saveexec_b32 s4, vcc_lo
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 s4, exec_lo, s4
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1032DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX1032DAGISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s7, s5
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032DAGISEL-NEXT:    s_bitset0_b32 s5, s7
 ; GFX1032DAGISEL-NEXT:    s_cmp_lg_u32 s5, 0
 ; GFX1032DAGISEL-NEXT:    v_max_f32_e64 v3, s6, s8
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1032DAGISEL-NEXT:  ; %bb.3:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1032DAGISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX1032DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1032DAGISEL-NEXT:    s_andn2_saveexec_b32 s4, s4
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1032DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX1032DAGISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s7, s5
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v3, s7
 ; GFX1032DAGISEL-NEXT:    s_bitset0_b32 s5, s7
 ; GFX1032DAGISEL-NEXT:    s_cmp_lg_u32 s5, 0
 ; GFX1032DAGISEL-NEXT:    v_max_f32_e64 v2, s6, s8
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1032DAGISEL-NEXT:  ; %bb.7:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
-; GFX1032DAGISEL-NEXT:  .LBB4_8: ; %endif
+; GFX1032DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1032DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s4
 ; GFX1032DAGISEL-NEXT:    global_store_dword v[0:1], v4, off
 ; GFX1032DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -2065,38 +2742,38 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1032GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1032GISEL-NEXT:    s_and_saveexec_b32 s4, vcc_lo
 ; GFX1032GISEL-NEXT:    s_xor_b32 s4, exec_lo, s4
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1032GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032GISEL-NEXT:    s_mov_b32 s5, exec_lo
 ; GFX1032GISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX1032GISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s7, s5
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032GISEL-NEXT:    s_bitset0_b32 s5, s7
 ; GFX1032GISEL-NEXT:    s_cmp_lg_u32 s5, 0
 ; GFX1032GISEL-NEXT:    v_max_f32_e64 v3, s6, s8
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1032GISEL-NEXT:  ; %bb.3:
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX1032GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1032GISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX1032GISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1032GISEL-NEXT:    s_andn2_saveexec_b32 s4, s4
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1032GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1032GISEL-NEXT:    s_mov_b32 s5, exec_lo
 ; GFX1032GISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX1032GISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s7, s5
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v3, s7
 ; GFX1032GISEL-NEXT:    s_bitset0_b32 s5, s7
 ; GFX1032GISEL-NEXT:    s_cmp_lg_u32 s5, 0
 ; GFX1032GISEL-NEXT:    v_max_f32_e64 v2, s6, s8
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1032GISEL-NEXT:  ; %bb.7:
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v4, s6
-; GFX1032GISEL-NEXT:  .LBB4_8: ; %endif
+; GFX1032GISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1032GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s4
 ; GFX1032GISEL-NEXT:    global_store_dword v[0:1], v4, off
 ; GFX1032GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -2110,11 +2787,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1164DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1164DAGISEL-NEXT:    s_and_saveexec_b64 s[0:1], vcc
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 s[0:1], exec, s[0:1]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1164DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
-; GFX1164DAGISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s5, s[2:3]
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s6, v2, s5
@@ -2123,17 +2800,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1164DAGISEL-NEXT:    v_max_f32_e64 v3, s4, s6
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s4, v3
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1164DAGISEL-NEXT:  ; %bb.3:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v4, s4
 ; GFX1164DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1164DAGISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX1164DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1164DAGISEL-NEXT:    s_and_not1_saveexec_b64 s[0:1], s[0:1]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1164DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
-; GFX1164DAGISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s5, s[2:3]
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s6, v3, s5
@@ -2142,10 +2819,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1164DAGISEL-NEXT:    v_max_f32_e64 v2, s4, s6
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s4, v2
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1164DAGISEL-NEXT:  ; %bb.7:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v4, s4
-; GFX1164DAGISEL-NEXT:  .LBB4_8: ; %endif
+; GFX1164DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1164DAGISEL-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX1164DAGISEL-NEXT:    global_store_b32 v[0:1], v4, off
 ; GFX1164DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -2159,11 +2836,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1164GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1164GISEL-NEXT:    s_and_saveexec_b64 s[0:1], vcc
 ; GFX1164GISEL-NEXT:    s_xor_b64 s[0:1], exec, s[0:1]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1164GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[2:3], exec
 ; GFX1164GISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
-; GFX1164GISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s5, s[2:3]
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s6, v2, s5
@@ -2172,17 +2849,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1164GISEL-NEXT:    v_max_f32_e64 v3, s4, s6
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s4, v3
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1164GISEL-NEXT:  ; %bb.3:
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v4, s4
 ; GFX1164GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1164GISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX1164GISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1164GISEL-NEXT:    s_and_not1_saveexec_b64 s[0:1], s[0:1]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1164GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[2:3], exec
 ; GFX1164GISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
-; GFX1164GISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s5, s[2:3]
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s6, v3, s5
@@ -2191,10 +2868,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1164GISEL-NEXT:    v_max_f32_e64 v2, s4, s6
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s4, v2
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1164GISEL-NEXT:  ; %bb.7:
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v4, s4
-; GFX1164GISEL-NEXT:  .LBB4_8: ; %endif
+; GFX1164GISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1164GISEL-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX1164GISEL-NEXT:    global_store_b32 v[0:1], v4, off
 ; GFX1164GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -2208,11 +2885,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1132DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1132DAGISEL-NEXT:    s_and_saveexec_b32 s0, vcc_lo
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 s0, exec_lo, s0
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1132DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX1132DAGISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s3, s1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -2221,17 +2898,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1132DAGISEL-NEXT:    v_max_f32_e64 v3, s2, s4
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s2, v3
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1132DAGISEL-NEXT:  ; %bb.3:
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v4, s2
 ; GFX1132DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1132DAGISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX1132DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1132DAGISEL-NEXT:    s_and_not1_saveexec_b32 s0, s0
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1132DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX1132DAGISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s3, s1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v3, s3
@@ -2240,10 +2917,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1132DAGISEL-NEXT:    v_max_f32_e64 v2, s2, s4
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s2, v2
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1132DAGISEL-NEXT:  ; %bb.7:
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v4, s2
-; GFX1132DAGISEL-NEXT:  .LBB4_8: ; %endif
+; GFX1132DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1132DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX1132DAGISEL-NEXT:    global_store_b32 v[0:1], v4, off
 ; GFX1132DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -2257,11 +2934,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1132GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1132GISEL-NEXT:    s_and_saveexec_b32 s0, vcc_lo
 ; GFX1132GISEL-NEXT:    s_xor_b32 s0, exec_lo, s0
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1132GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132GISEL-NEXT:    s_mov_b32 s1, exec_lo
 ; GFX1132GISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX1132GISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s3, s1
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -2270,17 +2947,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1132GISEL-NEXT:    v_max_f32_e64 v3, s2, s4
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s2, v3
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1132GISEL-NEXT:  ; %bb.3:
 ; GFX1132GISEL-NEXT:    v_mov_b32_e32 v4, s2
 ; GFX1132GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1132GISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX1132GISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1132GISEL-NEXT:    s_and_not1_saveexec_b32 s0, s0
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1132GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1132GISEL-NEXT:    s_mov_b32 s1, exec_lo
 ; GFX1132GISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX1132GISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s3, s1
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v3, s3
@@ -2289,10 +2966,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1132GISEL-NEXT:    v_max_f32_e64 v2, s2, s4
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s2, v2
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1132GISEL-NEXT:  ; %bb.7:
 ; GFX1132GISEL-NEXT:    v_mov_b32_e32 v4, s2
-; GFX1132GISEL-NEXT:  .LBB4_8: ; %endif
+; GFX1132GISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1132GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX1132GISEL-NEXT:    global_store_b32 v[0:1], v4, off
 ; GFX1132GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -2311,11 +2988,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX12DAGISEL-NEXT:    s_and_saveexec_b32 s0, vcc_lo
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_xor_b32 s0, exec_lo, s0
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX12DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s1, exec_lo
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX12DAGISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s3, s1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -2326,19 +3003,19 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX12DAGISEL-NEXT:    v_max_num_f32_e64 v3, s2, s4
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s2, v3
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX12DAGISEL-NEXT:  ; %bb.3:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v4, s2
 ; GFX12DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX12DAGISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX12DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_and_not1_saveexec_b32 s0, s0
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX12DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s1, exec_lo
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX12DAGISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s3, s1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -2349,11 +3026,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX12DAGISEL-NEXT:    v_max_num_f32_e64 v2, s2, s4
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s2, v2
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX12DAGISEL-NEXT:  ; %bb.7:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v4, s2
-; GFX12DAGISEL-NEXT:  .LBB4_8: ; %endif
+; GFX12DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX12DAGISEL-NEXT:    global_store_b32 v[0:1], v4, off
@@ -2499,7 +3176,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX8DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -2510,7 +3187,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX8DAGISEL-NEXT:  ; %bb.2:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2524,7 +3201,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX8GISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX8GISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX8GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX8GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX8GISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -2535,7 +3212,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX8GISEL-NEXT:  ; %bb.2:
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2549,7 +3226,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX9DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -2560,7 +3237,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX9DAGISEL-NEXT:  ; %bb.2:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2574,7 +3251,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX9GISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX9GISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX9GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX9GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX9GISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -2585,7 +3262,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX9GISEL-NEXT:  ; %bb.2:
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2599,7 +3276,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX1064DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -2608,7 +3285,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1064DAGISEL-NEXT:    v_max_f64 v[4:5], s[8:9], s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1064DAGISEL-NEXT:  ; %bb.2:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2621,7 +3298,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1064GISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX1064GISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX1064GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -2630,7 +3307,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1064GISEL-NEXT:    v_max_f64 v[4:5], s[8:9], s[6:7]
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1064GISEL-NEXT:  ; %bb.2:
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2643,7 +3320,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s6, exec_lo
-; GFX1032DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s7, s6
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s9, v3, s7
@@ -2652,7 +3329,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1032DAGISEL-NEXT:    v_max_f64 v[4:5], s[8:9], s[4:5]
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1032DAGISEL-NEXT:  ; %bb.2:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -2665,7 +3342,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1032GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032GISEL-NEXT:    s_mov_b32 s6, exec_lo
-; GFX1032GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s7, s6
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s9, v3, s7
@@ -2674,7 +3351,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1032GISEL-NEXT:    v_max_f64 v[4:5], s[8:9], s[4:5]
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1032GISEL-NEXT:  ; %bb.2:
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -2687,7 +3364,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s2, 0
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s3, 0x7ff80000
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s6, s[0:1]
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -2699,7 +3376,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s2, v4
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s3, v5
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1164DAGISEL-NEXT:  ; %bb.2:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v3, s3
@@ -2712,7 +3389,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1164GISEL-NEXT:    s_mov_b32 s2, 0
 ; GFX1164GISEL-NEXT:    s_mov_b32 s3, 0x7ff80000
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s6, s[0:1]
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -2724,7 +3401,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s2, v4
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s3, v5
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1164GISEL-NEXT:  ; %bb.2:
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v3, s3
@@ -2737,7 +3414,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX1132DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -2749,7 +3426,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1132DAGISEL-NEXT:  ; %bb.2:
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
 ; GFX1132DAGISEL-NEXT:    global_store_b64 v[0:1], v[2:3], off
@@ -2761,7 +3438,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1132GISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132GISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132GISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX1132GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -2773,7 +3450,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1132GISEL-NEXT:  ; %bb.2:
 ; GFX1132GISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
 ; GFX1132GISEL-NEXT:    global_store_b64 v[0:1], v[2:3], off
@@ -2789,7 +3466,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX12DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -2802,7 +3479,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX12DAGISEL-NEXT:  ; %bb.2:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
@@ -2823,12 +3500,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX8DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX8DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX8DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX8DAGISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s10, v2, s12
@@ -2839,20 +3516,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s8, v4
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX8DAGISEL-NEXT:  ; %bb.3:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX8DAGISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX8DAGISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX8DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX8DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX8DAGISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s8
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s10, v4, s12
@@ -2863,11 +3540,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX8DAGISEL-NEXT:  ; %bb.7:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
-; GFX8DAGISEL-NEXT:  .LBB7_8: ; %endif
+; GFX8DAGISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX8DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX8DAGISEL-NEXT:    flat_store_dwordx2 v[0:1], v[6:7]
 ; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -2881,12 +3558,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8GISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX8GISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX8GISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX8GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8GISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX8GISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX8GISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX8GISEL-NEXT:    v_readlane_b32 s10, v2, s12
@@ -2897,20 +3574,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s8, v4
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX8GISEL-NEXT:  ; %bb.3:
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v7, s9
 ; GFX8GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX8GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX8GISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX8GISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX8GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX8GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX8GISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX8GISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX8GISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s8
 ; GFX8GISEL-NEXT:    v_readlane_b32 s10, v4, s12
@@ -2921,11 +3598,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s8, v2
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX8GISEL-NEXT:  ; %bb.7:
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v7, s9
-; GFX8GISEL-NEXT:  .LBB7_8: ; %endif
+; GFX8GISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX8GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX8GISEL-NEXT:    flat_store_dwordx2 v[0:1], v[6:7]
 ; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -2939,12 +3616,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX9DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX9DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX9DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX9DAGISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s10, v2, s12
@@ -2955,20 +3632,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s8, v4
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX9DAGISEL-NEXT:  ; %bb.3:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX9DAGISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX9DAGISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX9DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX9DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX9DAGISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s8
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s10, v4, s12
@@ -2979,11 +3656,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX9DAGISEL-NEXT:  ; %bb.7:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
-; GFX9DAGISEL-NEXT:  .LBB7_8: ; %endif
+; GFX9DAGISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX9DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX9DAGISEL-NEXT:    global_store_dwordx2 v[0:1], v[6:7], off
 ; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -2997,12 +3674,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9GISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX9GISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX9GISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX9GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9GISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX9GISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX9GISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX9GISEL-NEXT:    v_readlane_b32 s10, v2, s12
@@ -3013,20 +3690,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s8, v4
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX9GISEL-NEXT:  ; %bb.3:
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v7, s9
 ; GFX9GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX9GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX9GISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX9GISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX9GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX9GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX9GISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX9GISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX9GISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s8
 ; GFX9GISEL-NEXT:    v_readlane_b32 s10, v4, s12
@@ -3037,11 +3714,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s8, v2
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX9GISEL-NEXT:  ; %bb.7:
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v7, s9
-; GFX9GISEL-NEXT:  .LBB7_8: ; %endif
+; GFX9GISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX9GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX9GISEL-NEXT:    global_store_dwordx2 v[0:1], v[6:7], off
 ; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -3055,12 +3732,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1064DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1064DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX1064DAGISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s10, v2, s12
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s11, v3, s12
@@ -3069,20 +3746,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064DAGISEL-NEXT:    v_max_f64 v[4:5], s[10:11], s[8:9]
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s8, v4
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX1064DAGISEL-NEXT:  ; %bb.3:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1064DAGISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX1064DAGISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX1064DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX1064DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX1064DAGISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s10, v4, s12
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s11, v5, s12
@@ -3091,11 +3768,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064DAGISEL-NEXT:    v_max_f64 v[2:3], s[10:11], s[8:9]
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX1064DAGISEL-NEXT:  ; %bb.7:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
-; GFX1064DAGISEL-NEXT:  .LBB7_8: ; %endif
+; GFX1064DAGISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX1064DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX1064DAGISEL-NEXT:    global_store_dwordx2 v[0:1], v[6:7], off
 ; GFX1064DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -3108,12 +3785,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064GISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1064GISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX1064GISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1064GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064GISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX1064GISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX1064GISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s10, v2, s12
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s11, v3, s12
@@ -3122,20 +3799,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064GISEL-NEXT:    v_max_f64 v[4:5], s[10:11], s[8:9]
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s8, v4
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX1064GISEL-NEXT:  ; %bb.3:
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v7, s9
 ; GFX1064GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1064GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1064GISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX1064GISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX1064GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX1064GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1064GISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX1064GISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX1064GISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s10, v4, s12
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s11, v5, s12
@@ -3144,11 +3821,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064GISEL-NEXT:    v_max_f64 v[2:3], s[10:11], s[8:9]
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s8, v2
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX1064GISEL-NEXT:  ; %bb.7:
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v7, s9
-; GFX1064GISEL-NEXT:  .LBB7_8: ; %endif
+; GFX1064GISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX1064GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX1064GISEL-NEXT:    global_store_dwordx2 v[0:1], v[6:7], off
 ; GFX1064GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -3161,12 +3838,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1032DAGISEL-NEXT:    s_and_saveexec_b32 s4, vcc_lo
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 s6, exec_lo, s4
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1032DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s7, exec_lo
-; GFX1032DAGISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s10, s7
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -3175,20 +3852,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032DAGISEL-NEXT:    v_max_f64 v[4:5], s[8:9], s[4:5]
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX1032DAGISEL-NEXT:  ; %bb.3:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v6, s4
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1032DAGISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX1032DAGISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX1032DAGISEL-NEXT:    s_andn2_saveexec_b32 s6, s6
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX1032DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s7, exec_lo
-; GFX1032DAGISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s10, s7
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v4, s10
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s9, v5, s10
@@ -3197,11 +3874,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032DAGISEL-NEXT:    v_max_f64 v[2:3], s[8:9], s[4:5]
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s4, v2
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX1032DAGISEL-NEXT:  ; %bb.7:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v6, s4
-; GFX1032DAGISEL-NEXT:  .LBB7_8: ; %endif
+; GFX1032DAGISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX1032DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s6
 ; GFX1032DAGISEL-NEXT:    global_store_dwordx2 v[0:1], v[6:7], off
 ; GFX1032DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -3214,12 +3891,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032GISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1032GISEL-NEXT:    s_and_saveexec_b32 s4, vcc_lo
 ; GFX1032GISEL-NEXT:    s_xor_b32 s6, exec_lo, s4
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1032GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032GISEL-NEXT:    s_mov_b32 s7, exec_lo
-; GFX1032GISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s10, s7
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -3228,20 +3905,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032GISEL-NEXT:    v_max_f64 v[4:5], s[8:9], s[4:5]
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX1032GISEL-NEXT:  ; %bb.3:
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v6, s4
 ; GFX1032GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1032GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1032GISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX1032GISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX1032GISEL-NEXT:    s_andn2_saveexec_b32 s6, s6
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX1032GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1032GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032GISEL-NEXT:    s_mov_b32 s7, exec_lo
-; GFX1032GISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s10, s7
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v4, s10
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s9, v5, s10
@@ -3250,11 +3927,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032GISEL-NEXT:    v_max_f64 v[2:3], s[8:9], s[4:5]
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s4, v2
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX1032GISEL-NEXT:  ; %bb.7:
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v6, s4
-; GFX1032GISEL-NEXT:  .LBB7_8: ; %endif
+; GFX1032GISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX1032GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s6
 ; GFX1032GISEL-NEXT:    global_store_dwordx2 v[0:1], v[6:7], off
 ; GFX1032GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -3268,12 +3945,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1164DAGISEL-NEXT:    s_and_saveexec_b64 s[0:1], vcc
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 s[0:1], exec, s[0:1]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1164DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
-; GFX1164DAGISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s8, s[2:3]
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s6, v2, s8
@@ -3285,20 +3962,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX1164DAGISEL-NEXT:  ; %bb.3:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v6, s4
 ; GFX1164DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1164DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1164DAGISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX1164DAGISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX1164DAGISEL-NEXT:    s_and_not1_saveexec_b64 s[0:1], s[0:1]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX1164DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
-; GFX1164DAGISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s8, s[2:3]
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s6, v4, s8
@@ -3310,11 +3987,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s4, v2
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX1164DAGISEL-NEXT:  ; %bb.7:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v6, s4
-; GFX1164DAGISEL-NEXT:  .LBB7_8: ; %endif
+; GFX1164DAGISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX1164DAGISEL-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX1164DAGISEL-NEXT:    global_store_b64 v[0:1], v[6:7], off
 ; GFX1164DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -3328,12 +4005,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164GISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1164GISEL-NEXT:    s_and_saveexec_b64 s[0:1], vcc
 ; GFX1164GISEL-NEXT:    s_xor_b64 s[0:1], exec, s[0:1]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1164GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1164GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[2:3], exec
-; GFX1164GISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s8, s[2:3]
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s6, v2, s8
@@ -3345,20 +4022,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX1164GISEL-NEXT:  ; %bb.3:
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v6, s4
 ; GFX1164GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1164GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1164GISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX1164GISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX1164GISEL-NEXT:    s_and_not1_saveexec_b64 s[0:1], s[0:1]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX1164GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1164GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1164GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[2:3], exec
-; GFX1164GISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s8, s[2:3]
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s6, v4, s8
@@ -3370,11 +4047,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s4, v2
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX1164GISEL-NEXT:  ; %bb.7:
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v6, s4
-; GFX1164GISEL-NEXT:  .LBB7_8: ; %endif
+; GFX1164GISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX1164GISEL-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX1164GISEL-NEXT:    global_store_b64 v[0:1], v[6:7], off
 ; GFX1164GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -3388,12 +4065,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1132DAGISEL-NEXT:    s_and_saveexec_b32 s0, vcc_lo
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 s2, exec_lo, s0
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1132DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX1132DAGISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -3405,19 +4082,19 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX1132DAGISEL-NEXT:  ; %bb.3:
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v7, s1 :: v_dual_mov_b32 v6, s0
 ; GFX1132DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1132DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1132DAGISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX1132DAGISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX1132DAGISEL-NEXT:    s_and_not1_saveexec_b32 s2, s2
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX1132DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX1132DAGISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v4, s6
@@ -3429,10 +4106,10 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s0, v2
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX1132DAGISEL-NEXT:  ; %bb.7:
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v7, s1 :: v_dual_mov_b32 v6, s0
-; GFX1132DAGISEL-NEXT:  .LBB7_8: ; %endif
+; GFX1132DAGISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX1132DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1132DAGISEL-NEXT:    global_store_b64 v[0:1], v[6:7], off
 ; GFX1132DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -3446,12 +4123,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132GISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1132GISEL-NEXT:    s_and_saveexec_b32 s0, vcc_lo
 ; GFX1132GISEL-NEXT:    s_xor_b32 s2, exec_lo, s0
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1132GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132GISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132GISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132GISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX1132GISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -3463,19 +4140,19 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX1132GISEL-NEXT:  ; %bb.3:
 ; GFX1132GISEL-NEXT:    v_dual_mov_b32 v7, s1 :: v_dual_mov_b32 v6, s0
 ; GFX1132GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1132GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1132GISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX1132GISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX1132GISEL-NEXT:    s_and_not1_saveexec_b32 s2, s2
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX1132GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1132GISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132GISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132GISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX1132GISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v4, s6
@@ -3487,10 +4164,10 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s0, v2
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX1132GISEL-NEXT:  ; %bb.7:
 ; GFX1132GISEL-NEXT:    v_dual_mov_b32 v7, s1 :: v_dual_mov_b32 v6, s0
-; GFX1132GISEL-NEXT:  .LBB7_8: ; %endif
+; GFX1132GISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX1132GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1132GISEL-NEXT:    global_store_b64 v[0:1], v[6:7], off
 ; GFX1132GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -3509,12 +4186,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX12DAGISEL-NEXT:    s_and_saveexec_b32 s0, vcc_lo
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_xor_b32 s2, exec_lo, s0
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX12DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX12DAGISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -3527,21 +4204,21 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX12DAGISEL-NEXT:  ; %bb.3:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v7, s1 :: v_dual_mov_b32 v6, s0
 ; GFX12DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX12DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX12DAGISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX12DAGISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_and_not1_saveexec_b32 s2, s2
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX12DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX12DAGISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -3554,11 +4231,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s0, v2
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX12DAGISEL-NEXT:  ; %bb.7:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v7, s1 :: v_dual_mov_b32 v6, s0
-; GFX12DAGISEL-NEXT:  .LBB7_8: ; %endif
+; GFX12DAGISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX12DAGISEL-NEXT:    global_store_b64 v[0:1], v[6:7], off

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.fmin.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.fmin.ll
@@ -7,11 +7,688 @@
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -global-isel=1 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX10GISEL,GFX1064GISEL %s
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -global-isel=0 < %s | FileCheck -check-prefixes=GFX10DAGISEL,GFX1032DAGISEL %s
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -global-isel=1 < %s | FileCheck -check-prefixes=GFX10GISEL,GFX1032GISEL %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -global-isel=0 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164DAGISEL %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -global-isel=1 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164GISEL %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -global-isel=0 < %s | FileCheck -check-prefixes=GFX1132DAGISEL %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -global-isel=1 < %s | FileCheck -check-prefixes=GFX1132GISEL %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=-real-true16 -global-isel=0 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164DAGISEL,GFX1164DAGISEL-FAKE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=-real-true16 -global-isel=1 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164GISEL,GFX1164GISEL-FAKE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=-real-true16 -global-isel=0 < %s | FileCheck -check-prefixes=GFX1132DAGISEL,GFX1132DAGISEL-FAKE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=-real-true16 -global-isel=1 < %s | FileCheck -check-prefixes=GFX1132GISEL,GFX1132GISEL-FAKE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+real-true16 -global-isel=0 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164DAGISEL,GFX1164DAGISEL-TRUE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+real-true16 -global-isel=1 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164GISEL,GFX1164GISEL-TRUE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+real-true16 -global-isel=0 < %s | FileCheck -check-prefixes=GFX1132DAGISEL,GFX1132DAGISEL-TRUE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+real-true16 -global-isel=1 < %s | FileCheck -check-prefixes=GFX1132GISEL,GFX1132GISEL-TRUE16 %s
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx1200 -global-isel=0 < %s | FileCheck -check-prefixes=GFX12DAGISEL %s
+
+define amdgpu_kernel void @uniform_value_half(ptr addrspace(1) %out, half %in) {
+; GFX8DAGISEL-LABEL: uniform_value_half:
+; GFX8DAGISEL:       ; %bb.0: ; %entry
+; GFX8DAGISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX8DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX8DAGISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
+; GFX8DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX8DAGISEL-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX8DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
+; GFX8DAGISEL-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s5, s[2:3]
+; GFX8DAGISEL-NEXT:    v_readlane_b32 s6, v0, s5
+; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v1, s6
+; GFX8DAGISEL-NEXT:    s_bitset0_b64 s[2:3], s5
+; GFX8DAGISEL-NEXT:    v_min_f32_e32 v1, s4, v1
+; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[2:3], 0
+; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s4, v1
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX8DAGISEL-NEXT:  ; %bb.2:
+; GFX8DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2, s4
+; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v0, s0
+; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v1, s1
+; GFX8DAGISEL-NEXT:    flat_store_short v[0:1], v2
+; GFX8DAGISEL-NEXT:    s_endpgm
+;
+; GFX8GISEL-LABEL: uniform_value_half:
+; GFX8GISEL:       ; %bb.0: ; %entry
+; GFX8GISEL-NEXT:    s_load_dword s0, s[4:5], 0x2c
+; GFX8GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX8GISEL-NEXT:    v_cvt_f32_f16_e32 v0, s0
+; GFX8GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX8GISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX8GISEL-NEXT:    v_cvt_f16_f32_e32 v2, s2
+; GFX8GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX8GISEL-NEXT:    v_mov_b32_e32 v0, s0
+; GFX8GISEL-NEXT:    v_mov_b32_e32 v1, s1
+; GFX8GISEL-NEXT:    flat_store_short v[0:1], v2
+; GFX8GISEL-NEXT:    s_endpgm
+;
+; GFX9DAGISEL-LABEL: uniform_value_half:
+; GFX9DAGISEL:       ; %bb.0: ; %entry
+; GFX9DAGISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX9DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX9DAGISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
+; GFX9DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX9DAGISEL-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX9DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
+; GFX9DAGISEL-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s5, s[2:3]
+; GFX9DAGISEL-NEXT:    v_readlane_b32 s6, v1, s5
+; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9DAGISEL-NEXT:    s_bitset0_b64 s[2:3], s5
+; GFX9DAGISEL-NEXT:    v_min_f32_e32 v2, s4, v2
+; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[2:3], 0
+; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s4, v2
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX9DAGISEL-NEXT:  ; %bb.2:
+; GFX9DAGISEL-NEXT:    v_cvt_f16_f32_e32 v1, s4
+; GFX9DAGISEL-NEXT:    global_store_short v0, v1, s[0:1]
+; GFX9DAGISEL-NEXT:    s_endpgm
+;
+; GFX9GISEL-LABEL: uniform_value_half:
+; GFX9GISEL:       ; %bb.0: ; %entry
+; GFX9GISEL-NEXT:    s_load_dword s0, s[4:5], 0x2c
+; GFX9GISEL-NEXT:    v_mov_b32_e32 v1, 0
+; GFX9GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX9GISEL-NEXT:    v_cvt_f32_f16_e32 v0, s0
+; GFX9GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX9GISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX9GISEL-NEXT:    v_cvt_f16_f32_e32 v0, s2
+; GFX9GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX9GISEL-NEXT:    global_store_short v1, v0, s[0:1]
+; GFX9GISEL-NEXT:    s_endpgm
+;
+; GFX1064DAGISEL-LABEL: uniform_value_half:
+; GFX1064DAGISEL:       ; %bb.0: ; %entry
+; GFX1064DAGISEL-NEXT:    s_clause 0x1
+; GFX1064DAGISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX1064DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1064DAGISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
+; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1064DAGISEL-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1064DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
+; GFX1064DAGISEL-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s5, s[2:3]
+; GFX1064DAGISEL-NEXT:    v_readlane_b32 s6, v1, s5
+; GFX1064DAGISEL-NEXT:    s_bitset0_b64 s[2:3], s5
+; GFX1064DAGISEL-NEXT:    s_cmp_lg_u64 s[2:3], 0
+; GFX1064DAGISEL-NEXT:    v_min_f32_e64 v2, s4, s6
+; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s4, v2
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1064DAGISEL-NEXT:  ; %bb.2:
+; GFX1064DAGISEL-NEXT:    v_cvt_f16_f32_e32 v1, s4
+; GFX1064DAGISEL-NEXT:    global_store_short v0, v1, s[0:1]
+; GFX1064DAGISEL-NEXT:    s_endpgm
+;
+; GFX10GISEL-LABEL: uniform_value_half:
+; GFX10GISEL:       ; %bb.0: ; %entry
+; GFX10GISEL-NEXT:    s_clause 0x1
+; GFX10GISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX10GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX10GISEL-NEXT:    v_mov_b32_e32 v1, 0
+; GFX10GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX10GISEL-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX10GISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX10GISEL-NEXT:    v_cvt_f16_f32_e32 v0, s2
+; GFX10GISEL-NEXT:    global_store_short v1, v0, s[0:1]
+; GFX10GISEL-NEXT:    s_endpgm
+;
+; GFX1032DAGISEL-LABEL: uniform_value_half:
+; GFX1032DAGISEL:       ; %bb.0: ; %entry
+; GFX1032DAGISEL-NEXT:    s_clause 0x1
+; GFX1032DAGISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX1032DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1032DAGISEL-NEXT:    s_mov_b32 s3, 0x7fc00000
+; GFX1032DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1032DAGISEL-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1032DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
+; GFX1032DAGISEL-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s4, s2
+; GFX1032DAGISEL-NEXT:    v_readlane_b32 s5, v1, s4
+; GFX1032DAGISEL-NEXT:    s_bitset0_b32 s2, s4
+; GFX1032DAGISEL-NEXT:    s_cmp_lg_u32 s2, 0
+; GFX1032DAGISEL-NEXT:    v_min_f32_e64 v2, s3, s5
+; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s3, v2
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1032DAGISEL-NEXT:  ; %bb.2:
+; GFX1032DAGISEL-NEXT:    v_cvt_f16_f32_e32 v1, s3
+; GFX1032DAGISEL-NEXT:    global_store_short v0, v1, s[0:1]
+; GFX1032DAGISEL-NEXT:    s_endpgm
+;
+; GFX1164DAGISEL-FAKE16-LABEL: uniform_value_half:
+; GFX1164DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mov_b32 s4, 0x7fc00000
+; GFX1164DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mov_b64 s[2:3], exec
+; GFX1164DAGISEL-FAKE16-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_ctz_i32_b64 s5, s[2:3]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_readlane_b32 s6, v1, s5
+; GFX1164DAGISEL-FAKE16-NEXT:    s_bitset0_b64 s[2:3], s5
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cmp_lg_u64 s[2:3], 0
+; GFX1164DAGISEL-FAKE16-NEXT:    v_min_f32_e64 v2, s4, s6
+; GFX1164DAGISEL-FAKE16-NEXT:    v_readfirstlane_b32 s4, v2
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1164DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v1, s4
+; GFX1164DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_endpgm
+;
+; GFX1164GISEL-FAKE16-LABEL: uniform_value_half:
+; GFX1164GISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164GISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1164GISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164GISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164GISEL-FAKE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1164GISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164GISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX1164GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1164GISEL-FAKE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1164GISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v0, s2
+; GFX1164GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1164GISEL-FAKE16-NEXT:    s_endpgm
+;
+; GFX1132DAGISEL-FAKE16-LABEL: uniform_value_half:
+; GFX1132DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mov_b32 s3, 0x7fc00000
+; GFX1132DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mov_b32 s2, exec_lo
+; GFX1132DAGISEL-FAKE16-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_ctz_i32_b32 s4, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_readlane_b32 s5, v1, s4
+; GFX1132DAGISEL-FAKE16-NEXT:    s_bitset0_b32 s2, s4
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cmp_lg_u32 s2, 0
+; GFX1132DAGISEL-FAKE16-NEXT:    v_min_f32_e64 v2, s3, s5
+; GFX1132DAGISEL-FAKE16-NEXT:    v_readfirstlane_b32 s3, v2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1132DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v1, s3
+; GFX1132DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1132DAGISEL-FAKE16-NEXT:    s_endpgm
+;
+; GFX1132GISEL-FAKE16-LABEL: uniform_value_half:
+; GFX1132GISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132GISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1132GISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132GISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132GISEL-FAKE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1132GISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132GISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX1132GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1132GISEL-FAKE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1132GISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v0, s2
+; GFX1132GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1132GISEL-FAKE16-NEXT:    s_endpgm
+;
+; GFX1164DAGISEL-TRUE16-LABEL: uniform_value_half:
+; GFX1164DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b32 s4, 0x7fc00000
+; GFX1164DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b64 s[2:3], exec
+; GFX1164DAGISEL-TRUE16-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_ctz_i32_b64 s5, s[2:3]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_readlane_b32 s6, v1, s5
+; GFX1164DAGISEL-TRUE16-NEXT:    s_bitset0_b64 s[2:3], s5
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cmp_lg_u64 s[2:3], 0
+; GFX1164DAGISEL-TRUE16-NEXT:    v_min_f32_e64 v2, s4, s6
+; GFX1164DAGISEL-TRUE16-NEXT:    v_readfirstlane_b32 s4, v2
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1164DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.l, s4
+; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX1164GISEL-TRUE16-LABEL: uniform_value_half:
+; GFX1164GISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164GISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1164GISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164GISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164GISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1164GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164GISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX1164GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1164GISEL-TRUE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1164GISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, s2
+; GFX1164GISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1164GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX1132DAGISEL-TRUE16-LABEL: uniform_value_half:
+; GFX1132DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s3, 0x7fc00000
+; GFX1132DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s2, exec_lo
+; GFX1132DAGISEL-TRUE16-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_ctz_i32_b32 s4, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_readlane_b32 s5, v1, s4
+; GFX1132DAGISEL-TRUE16-NEXT:    s_bitset0_b32 s2, s4
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cmp_lg_u32 s2, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    v_min_f32_e64 v2, s3, s5
+; GFX1132DAGISEL-TRUE16-NEXT:    v_readfirstlane_b32 s3, v2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1132DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.l, s3
+; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1132DAGISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX1132GISEL-TRUE16-LABEL: uniform_value_half:
+; GFX1132GISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132GISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1132GISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132GISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132GISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1132GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132GISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX1132GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1132GISEL-TRUE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1132GISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, s2
+; GFX1132GISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1132GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX12DAGISEL-LABEL: uniform_value_half:
+; GFX12DAGISEL:       ; %bb.0: ; %entry
+; GFX12DAGISEL-NEXT:    s_load_b96 s[0:2], s[4:5], 0x24
+; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v1, 0
+; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12DAGISEL-NEXT:    s_cvt_f32_f16 s2, s2
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_3) | instskip(NEXT) | instid1(SALU_CYCLE_3)
+; GFX12DAGISEL-NEXT:    s_cvt_f16_f32 s2, s2
+; GFX12DAGISEL-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX12DAGISEL-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX12DAGISEL-NEXT:    s_endpgm
+  entry:
+  %result = call half @llvm.amdgcn.wave.reduce.fmin(half %in, i32 1)
+  store half %result, ptr addrspace(1) %out
+  ret void
+}
+
+define void @divergent_value_half(ptr addrspace(1) %out, half %in) {
+; GFX8DAGISEL-LABEL: divergent_value_half:
+; GFX8DAGISEL:       ; %bb.0: ; %entry
+; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8DAGISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX8DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX8DAGISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
+; GFX8DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX8DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s8
+; GFX8DAGISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX8DAGISEL-NEXT:    v_min_f32_e32 v3, s6, v3
+; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX8DAGISEL-NEXT:  ; %bb.2:
+; GFX8DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX8DAGISEL-NEXT:    flat_store_short v[0:1], v2
+; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX8DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8GISEL-LABEL: divergent_value_half:
+; GFX8GISEL:       ; %bb.0: ; %entry
+; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8GISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX8GISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX8GISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
+; GFX8GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX8GISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s8
+; GFX8GISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX8GISEL-NEXT:    v_min_f32_e32 v3, s6, v3
+; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX8GISEL-NEXT:  ; %bb.2:
+; GFX8GISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX8GISEL-NEXT:    flat_store_short v[0:1], v2
+; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX8GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9DAGISEL-LABEL: divergent_value_half:
+; GFX9DAGISEL:       ; %bb.0: ; %entry
+; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9DAGISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX9DAGISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
+; GFX9DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX9DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v3, s8
+; GFX9DAGISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX9DAGISEL-NEXT:    v_min_f32_e32 v3, s6, v3
+; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX9DAGISEL-NEXT:  ; %bb.2:
+; GFX9DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX9DAGISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX9DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9GISEL-LABEL: divergent_value_half:
+; GFX9GISEL:       ; %bb.0: ; %entry
+; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9GISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX9GISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX9GISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
+; GFX9GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX9GISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX9GISEL-NEXT:    v_mov_b32_e32 v3, s8
+; GFX9GISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX9GISEL-NEXT:    v_min_f32_e32 v3, s6, v3
+; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX9GISEL-NEXT:  ; %bb.2:
+; GFX9GISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX9GISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX9GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1064DAGISEL-LABEL: divergent_value_half:
+; GFX1064DAGISEL:       ; %bb.0: ; %entry
+; GFX1064DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1064DAGISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1064DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX1064DAGISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
+; GFX1064DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX1064DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX1064DAGISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX1064DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX1064DAGISEL-NEXT:    v_min_f32_e64 v3, s6, s8
+; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1064DAGISEL-NEXT:  ; %bb.2:
+; GFX1064DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX1064DAGISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX1064DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1064GISEL-LABEL: divergent_value_half:
+; GFX1064GISEL:       ; %bb.0: ; %entry
+; GFX1064GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1064GISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1064GISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX1064GISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
+; GFX1064GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX1064GISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX1064GISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX1064GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX1064GISEL-NEXT:    v_min_f32_e64 v3, s6, s8
+; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1064GISEL-NEXT:  ; %bb.2:
+; GFX1064GISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX1064GISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX1064GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1032DAGISEL-LABEL: divergent_value_half:
+; GFX1032DAGISEL:       ; %bb.0: ; %entry
+; GFX1032DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1032DAGISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, exec_lo
+; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, 0x7fc00000
+; GFX1032DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s6, s4
+; GFX1032DAGISEL-NEXT:    v_readlane_b32 s7, v2, s6
+; GFX1032DAGISEL-NEXT:    s_bitset0_b32 s4, s6
+; GFX1032DAGISEL-NEXT:    s_cmp_lg_u32 s4, 0
+; GFX1032DAGISEL-NEXT:    v_min_f32_e64 v3, s5, s7
+; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v3
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1032DAGISEL-NEXT:  ; %bb.2:
+; GFX1032DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2, s5
+; GFX1032DAGISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX1032DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1032GISEL-LABEL: divergent_value_half:
+; GFX1032GISEL:       ; %bb.0: ; %entry
+; GFX1032GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1032GISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1032GISEL-NEXT:    s_mov_b32 s4, exec_lo
+; GFX1032GISEL-NEXT:    s_mov_b32 s5, 0x7fc00000
+; GFX1032GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s6, s4
+; GFX1032GISEL-NEXT:    v_readlane_b32 s7, v2, s6
+; GFX1032GISEL-NEXT:    s_bitset0_b32 s4, s6
+; GFX1032GISEL-NEXT:    s_cmp_lg_u32 s4, 0
+; GFX1032GISEL-NEXT:    v_min_f32_e64 v3, s5, s7
+; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v3
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1032GISEL-NEXT:  ; %bb.2:
+; GFX1032GISEL-NEXT:    v_cvt_f16_f32_e32 v2, s5
+; GFX1032GISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX1032GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164DAGISEL-FAKE16-LABEL: divergent_value_half:
+; GFX1164DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mov_b32 s2, 0x7fc00000
+; GFX1164DAGISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164DAGISEL-FAKE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164DAGISEL-FAKE16-NEXT:    v_min_f32_e64 v3, s2, s4
+; GFX1164DAGISEL-FAKE16-NEXT:    v_readfirstlane_b32 s2, v3
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v2, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164DAGISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164GISEL-FAKE16-LABEL: divergent_value_half:
+; GFX1164GISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164GISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164GISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1164GISEL-FAKE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164GISEL-FAKE16-NEXT:    s_mov_b32 s2, 0x7fc00000
+; GFX1164GISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-FAKE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164GISEL-FAKE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164GISEL-FAKE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164GISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164GISEL-FAKE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164GISEL-FAKE16-NEXT:    v_min_f32_e64 v3, s2, s4
+; GFX1164GISEL-FAKE16-NEXT:    v_readfirstlane_b32 s2, v3
+; GFX1164GISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164GISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1164GISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v2, s2
+; GFX1164GISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164GISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132DAGISEL-FAKE16-LABEL: divergent_value_half:
+; GFX1132DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mov_b32 s0, exec_lo
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mov_b32 s1, 0x7fc00000
+; GFX1132DAGISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_ctz_i32_b32 s2, s0
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_bitset0_b32 s0, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cmp_lg_u32 s0, 0
+; GFX1132DAGISEL-FAKE16-NEXT:    v_min_f32_e64 v3, s1, s3
+; GFX1132DAGISEL-FAKE16-NEXT:    v_readfirstlane_b32 s1, v3
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v2, s1
+; GFX1132DAGISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132DAGISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132GISEL-FAKE16-LABEL: divergent_value_half:
+; GFX1132GISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132GISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132GISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1132GISEL-FAKE16-NEXT:    s_mov_b32 s0, exec_lo
+; GFX1132GISEL-FAKE16-NEXT:    s_mov_b32 s1, 0x7fc00000
+; GFX1132GISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-FAKE16-NEXT:    s_ctz_i32_b32 s2, s0
+; GFX1132GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132GISEL-FAKE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132GISEL-FAKE16-NEXT:    s_bitset0_b32 s0, s2
+; GFX1132GISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132GISEL-FAKE16-NEXT:    s_cmp_lg_u32 s0, 0
+; GFX1132GISEL-FAKE16-NEXT:    v_min_f32_e64 v3, s1, s3
+; GFX1132GISEL-FAKE16-NEXT:    v_readfirstlane_b32 s1, v3
+; GFX1132GISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132GISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1132GISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v2, s1
+; GFX1132GISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132GISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164DAGISEL-TRUE16-LABEL: divergent_value_half:
+; GFX1164DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b32 s2, 0x7fc00000
+; GFX1164DAGISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164DAGISEL-TRUE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164DAGISEL-TRUE16-NEXT:    v_min_f32_e64 v3, s2, s4
+; GFX1164DAGISEL-TRUE16-NEXT:    v_readfirstlane_b32 s2, v3
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v2.l, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164GISEL-TRUE16-LABEL: divergent_value_half:
+; GFX1164GISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164GISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164GISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
+; GFX1164GISEL-TRUE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164GISEL-TRUE16-NEXT:    s_mov_b32 s2, 0x7fc00000
+; GFX1164GISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-TRUE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164GISEL-TRUE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164GISEL-TRUE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164GISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164GISEL-TRUE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164GISEL-TRUE16-NEXT:    v_min_f32_e64 v3, s2, s4
+; GFX1164GISEL-TRUE16-NEXT:    v_readfirstlane_b32 s2, v3
+; GFX1164GISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164GISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1164GISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v2.l, s2
+; GFX1164GISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164GISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132DAGISEL-TRUE16-LABEL: divergent_value_half:
+; GFX1132DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s0, exec_lo
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s1, 0x7fc00000
+; GFX1132DAGISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_ctz_i32_b32 s2, s0
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_bitset0_b32 s0, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cmp_lg_u32 s0, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    v_min_f32_e64 v3, s1, s3
+; GFX1132DAGISEL-TRUE16-NEXT:    v_readfirstlane_b32 s1, v3
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v2.l, s1
+; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132GISEL-TRUE16-LABEL: divergent_value_half:
+; GFX1132GISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132GISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132GISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
+; GFX1132GISEL-TRUE16-NEXT:    s_mov_b32 s0, exec_lo
+; GFX1132GISEL-TRUE16-NEXT:    s_mov_b32 s1, 0x7fc00000
+; GFX1132GISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-TRUE16-NEXT:    s_ctz_i32_b32 s2, s0
+; GFX1132GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132GISEL-TRUE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132GISEL-TRUE16-NEXT:    s_bitset0_b32 s0, s2
+; GFX1132GISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132GISEL-TRUE16-NEXT:    s_cmp_lg_u32 s0, 0
+; GFX1132GISEL-TRUE16-NEXT:    v_min_f32_e64 v3, s1, s3
+; GFX1132GISEL-TRUE16-NEXT:    v_readfirstlane_b32 s1, v3
+; GFX1132GISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132GISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1132GISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v2.l, s1
+; GFX1132GISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132GISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12DAGISEL-LABEL: divergent_value_half:
+; GFX12DAGISEL:       ; %bb.0: ; %entry
+; GFX12DAGISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12DAGISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
+; GFX12DAGISEL-NEXT:    s_mov_b32 s0, exec_lo
+; GFX12DAGISEL-NEXT:    s_mov_b32 s1, 0x7fc00000
+; GFX12DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s2, s0
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX12DAGISEL-NEXT:    s_bitset0_b32 s0, s2
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    s_cmp_lg_u32 s0, 0
+; GFX12DAGISEL-NEXT:    v_min_num_f32_e64 v3, s1, s3
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v3
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX12DAGISEL-NEXT:  ; %bb.2:
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX12DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2.l, s1
+; GFX12DAGISEL-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX12DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+  entry:
+  %result = call half @llvm.amdgcn.wave.reduce.fmin(half %in, i32 1)
+  store half %result, ptr addrspace(1) %out
+  ret void
+}
 
 
 define amdgpu_kernel void @uniform_value_float(ptr addrspace(1) %out, float %in) #0 {
@@ -140,7 +817,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX8DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s8
@@ -148,7 +825,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX8DAGISEL-NEXT:    v_min_f32_e32 v3, s6, v3
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX8DAGISEL-NEXT:  ; %bb.2:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8DAGISEL-NEXT:    flat_store_dword v[0:1], v2
@@ -160,7 +837,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8GISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX8GISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX8GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX8GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s8
@@ -168,7 +845,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX8GISEL-NEXT:    v_min_f32_e32 v3, s6, v3
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX8GISEL-NEXT:  ; %bb.2:
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8GISEL-NEXT:    flat_store_dword v[0:1], v2
@@ -180,7 +857,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX9DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v3, s8
@@ -188,7 +865,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX9DAGISEL-NEXT:    v_min_f32_e32 v3, s6, v3
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX9DAGISEL-NEXT:  ; %bb.2:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -200,7 +877,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9GISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX9GISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX9GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX9GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v3, s8
@@ -208,7 +885,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX9GISEL-NEXT:    v_min_f32_e32 v3, s6, v3
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX9GISEL-NEXT:  ; %bb.2:
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9GISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -220,14 +897,14 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1064DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX1064DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1064DAGISEL-NEXT:    s_bitset0_b64 s[4:5], s7
 ; GFX1064DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX1064DAGISEL-NEXT:    v_min_f32_e64 v3, s6, s8
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1064DAGISEL-NEXT:  ; %bb.2:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -238,14 +915,14 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1064GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX1064GISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX1064GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1064GISEL-NEXT:    s_bitset0_b64 s[4:5], s7
 ; GFX1064GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX1064GISEL-NEXT:    v_min_f32_e64 v3, s6, s8
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1064GISEL-NEXT:  ; %bb.2:
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064GISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -256,14 +933,14 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1032DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, 0x7fc00000
-; GFX1032DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s6, s4
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s7, v2, s6
 ; GFX1032DAGISEL-NEXT:    s_bitset0_b32 s4, s6
 ; GFX1032DAGISEL-NEXT:    s_cmp_lg_u32 s4, 0
 ; GFX1032DAGISEL-NEXT:    v_min_f32_e64 v3, s5, s7
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1032DAGISEL-NEXT:  ; %bb.2:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v2, s5
 ; GFX1032DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -274,14 +951,14 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1032GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1032GISEL-NEXT:    s_mov_b32 s4, exec_lo
 ; GFX1032GISEL-NEXT:    s_mov_b32 s5, 0x7fc00000
-; GFX1032GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s6, s4
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s7, v2, s6
 ; GFX1032GISEL-NEXT:    s_bitset0_b32 s4, s6
 ; GFX1032GISEL-NEXT:    s_cmp_lg_u32 s4, 0
 ; GFX1032GISEL-NEXT:    v_min_f32_e64 v3, s5, s7
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1032GISEL-NEXT:  ; %bb.2:
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v2, s5
 ; GFX1032GISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -292,7 +969,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1164DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[0:1], exec
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX1164DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s3, s[0:1]
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -301,7 +978,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1164DAGISEL-NEXT:    v_min_f32_e64 v3, s2, s4
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s2, v3
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1164DAGISEL-NEXT:  ; %bb.2:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164DAGISEL-NEXT:    global_store_b32 v[0:1], v2, off
@@ -312,7 +989,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1164GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[0:1], exec
 ; GFX1164GISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX1164GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s3, s[0:1]
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -321,7 +998,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1164GISEL-NEXT:    v_min_f32_e64 v3, s2, s4
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s2, v3
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1164GISEL-NEXT:  ; %bb.2:
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164GISEL-NEXT:    global_store_b32 v[0:1], v2, off
@@ -332,7 +1009,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1132DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s0, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, 0x7fc00000
-; GFX1132DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s2, s0
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s3, v2, s2
@@ -341,7 +1018,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1132DAGISEL-NEXT:    v_min_f32_e64 v3, s1, s3
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1132DAGISEL-NEXT:  ; %bb.2:
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v2, s1
 ; GFX1132DAGISEL-NEXT:    global_store_b32 v[0:1], v2, off
@@ -352,7 +1029,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1132GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1132GISEL-NEXT:    s_mov_b32 s0, exec_lo
 ; GFX1132GISEL-NEXT:    s_mov_b32 s1, 0x7fc00000
-; GFX1132GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s2, s0
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s3, v2, s2
@@ -361,7 +1038,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX1132GISEL-NEXT:    v_min_f32_e64 v3, s1, s3
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1132GISEL-NEXT:  ; %bb.2:
 ; GFX1132GISEL-NEXT:    v_mov_b32_e32 v2, s1
 ; GFX1132GISEL-NEXT:    global_store_b32 v[0:1], v2, off
@@ -376,7 +1053,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s0, exec_lo
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s1, 0x7fc00000
-; GFX12DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s2, s0
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -387,7 +1064,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %in) #0 {
 ; GFX12DAGISEL-NEXT:    v_min_num_f32_e64 v3, s1, s3
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX12DAGISEL-NEXT:  ; %bb.2:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v2, s1
@@ -1745,11 +2422,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX8DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX8DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX8DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX8DAGISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s10
@@ -1757,17 +2434,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX8DAGISEL-NEXT:    v_min_f32_e32 v3, s8, v3
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s8, v3
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX8DAGISEL-NEXT:  ; %bb.3:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX8DAGISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX8DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX8DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX8DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX8DAGISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s10
@@ -1775,10 +2452,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX8DAGISEL-NEXT:    v_min_f32_e32 v2, s8, v2
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX8DAGISEL-NEXT:  ; %bb.7:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
-; GFX8DAGISEL-NEXT:  .LBB4_8: ; %endif
+; GFX8DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX8DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX8DAGISEL-NEXT:    flat_store_dword v[0:1], v4
 ; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -1792,11 +2469,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX8GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX8GISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX8GISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX8GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX8GISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX8GISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s10
@@ -1804,17 +2481,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX8GISEL-NEXT:    v_min_f32_e32 v3, s8, v3
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s8, v3
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX8GISEL-NEXT:  ; %bb.3:
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX8GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX8GISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX8GISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX8GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX8GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX8GISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX8GISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s10
@@ -1822,10 +2499,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX8GISEL-NEXT:    v_min_f32_e32 v2, s8, v2
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX8GISEL-NEXT:  ; %bb.7:
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v4, s8
-; GFX8GISEL-NEXT:  .LBB4_8: ; %endif
+; GFX8GISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX8GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX8GISEL-NEXT:    flat_store_dword v[0:1], v4
 ; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -1839,11 +2516,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX9DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX9DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX9DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX9DAGISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v3, s10
@@ -1851,17 +2528,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX9DAGISEL-NEXT:    v_min_f32_e32 v3, s8, v3
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s8, v3
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX9DAGISEL-NEXT:  ; %bb.3:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX9DAGISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX9DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX9DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX9DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX9DAGISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s10
@@ -1869,10 +2546,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX9DAGISEL-NEXT:    v_min_f32_e32 v2, s8, v2
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX9DAGISEL-NEXT:  ; %bb.7:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
-; GFX9DAGISEL-NEXT:  .LBB4_8: ; %endif
+; GFX9DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX9DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX9DAGISEL-NEXT:    global_store_dword v[0:1], v4, off
 ; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -1886,11 +2563,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX9GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX9GISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX9GISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX9GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX9GISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX9GISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v3, s10
@@ -1898,17 +2575,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX9GISEL-NEXT:    v_min_f32_e32 v3, s8, v3
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s8, v3
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX9GISEL-NEXT:  ; %bb.3:
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX9GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX9GISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX9GISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX9GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX9GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX9GISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX9GISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s10
@@ -1916,10 +2593,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX9GISEL-NEXT:    v_min_f32_e32 v2, s8, v2
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX9GISEL-NEXT:  ; %bb.7:
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v4, s8
-; GFX9GISEL-NEXT:  .LBB4_8: ; %endif
+; GFX9GISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX9GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX9GISEL-NEXT:    global_store_dword v[0:1], v4, off
 ; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -1933,38 +2610,38 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1064DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1064DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX1064DAGISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX1064DAGISEL-NEXT:    s_bitset0_b64 s[6:7], s9
 ; GFX1064DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX1064DAGISEL-NEXT:    v_min_f32_e64 v3, s8, s10
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s8, v3
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1064DAGISEL-NEXT:  ; %bb.3:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1064DAGISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX1064DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1064DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1064DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX1064DAGISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX1064DAGISEL-NEXT:    s_bitset0_b64 s[6:7], s9
 ; GFX1064DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX1064DAGISEL-NEXT:    v_min_f32_e64 v2, s8, s10
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1064DAGISEL-NEXT:  ; %bb.7:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
-; GFX1064DAGISEL-NEXT:  .LBB4_8: ; %endif
+; GFX1064DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1064DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX1064DAGISEL-NEXT:    global_store_dword v[0:1], v4, off
 ; GFX1064DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -1977,38 +2654,38 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1064GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1064GISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX1064GISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1064GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX1064GISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s10, v2, s9
 ; GFX1064GISEL-NEXT:    s_bitset0_b64 s[6:7], s9
 ; GFX1064GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX1064GISEL-NEXT:    v_min_f32_e64 v3, s8, s10
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s8, v3
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1064GISEL-NEXT:  ; %bb.3:
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX1064GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1064GISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX1064GISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1064GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1064GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064GISEL-NEXT:    s_mov_b32 s8, 0x7fc00000
-; GFX1064GISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s9, s[6:7]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s10, v3, s9
 ; GFX1064GISEL-NEXT:    s_bitset0_b64 s[6:7], s9
 ; GFX1064GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX1064GISEL-NEXT:    v_min_f32_e64 v2, s8, s10
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s8, v2
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1064GISEL-NEXT:  ; %bb.7:
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v4, s8
-; GFX1064GISEL-NEXT:  .LBB4_8: ; %endif
+; GFX1064GISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1064GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX1064GISEL-NEXT:    global_store_dword v[0:1], v4, off
 ; GFX1064GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -2021,38 +2698,38 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1032DAGISEL-NEXT:    s_and_saveexec_b32 s4, vcc_lo
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 s4, exec_lo, s4
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1032DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX1032DAGISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s7, s5
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032DAGISEL-NEXT:    s_bitset0_b32 s5, s7
 ; GFX1032DAGISEL-NEXT:    s_cmp_lg_u32 s5, 0
 ; GFX1032DAGISEL-NEXT:    v_min_f32_e64 v3, s6, s8
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1032DAGISEL-NEXT:  ; %bb.3:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1032DAGISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX1032DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1032DAGISEL-NEXT:    s_andn2_saveexec_b32 s4, s4
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1032DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX1032DAGISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s7, s5
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v3, s7
 ; GFX1032DAGISEL-NEXT:    s_bitset0_b32 s5, s7
 ; GFX1032DAGISEL-NEXT:    s_cmp_lg_u32 s5, 0
 ; GFX1032DAGISEL-NEXT:    v_min_f32_e64 v2, s6, s8
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1032DAGISEL-NEXT:  ; %bb.7:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
-; GFX1032DAGISEL-NEXT:  .LBB4_8: ; %endif
+; GFX1032DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1032DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s4
 ; GFX1032DAGISEL-NEXT:    global_store_dword v[0:1], v4, off
 ; GFX1032DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -2065,38 +2742,38 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1032GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1032GISEL-NEXT:    s_and_saveexec_b32 s4, vcc_lo
 ; GFX1032GISEL-NEXT:    s_xor_b32 s4, exec_lo, s4
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1032GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032GISEL-NEXT:    s_mov_b32 s5, exec_lo
 ; GFX1032GISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX1032GISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s7, s5
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032GISEL-NEXT:    s_bitset0_b32 s5, s7
 ; GFX1032GISEL-NEXT:    s_cmp_lg_u32 s5, 0
 ; GFX1032GISEL-NEXT:    v_min_f32_e64 v3, s6, s8
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1032GISEL-NEXT:  ; %bb.3:
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX1032GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1032GISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX1032GISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1032GISEL-NEXT:    s_andn2_saveexec_b32 s4, s4
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1032GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1032GISEL-NEXT:    s_mov_b32 s5, exec_lo
 ; GFX1032GISEL-NEXT:    s_mov_b32 s6, 0x7fc00000
-; GFX1032GISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s7, s5
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v3, s7
 ; GFX1032GISEL-NEXT:    s_bitset0_b32 s5, s7
 ; GFX1032GISEL-NEXT:    s_cmp_lg_u32 s5, 0
 ; GFX1032GISEL-NEXT:    v_min_f32_e64 v2, s6, s8
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1032GISEL-NEXT:  ; %bb.7:
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v4, s6
-; GFX1032GISEL-NEXT:  .LBB4_8: ; %endif
+; GFX1032GISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1032GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s4
 ; GFX1032GISEL-NEXT:    global_store_dword v[0:1], v4, off
 ; GFX1032GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -2110,11 +2787,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1164DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1164DAGISEL-NEXT:    s_and_saveexec_b64 s[0:1], vcc
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 s[0:1], exec, s[0:1]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1164DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
-; GFX1164DAGISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s5, s[2:3]
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s6, v2, s5
@@ -2123,17 +2800,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1164DAGISEL-NEXT:    v_min_f32_e64 v3, s4, s6
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s4, v3
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1164DAGISEL-NEXT:  ; %bb.3:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v4, s4
 ; GFX1164DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1164DAGISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX1164DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1164DAGISEL-NEXT:    s_and_not1_saveexec_b64 s[0:1], s[0:1]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1164DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
-; GFX1164DAGISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s5, s[2:3]
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s6, v3, s5
@@ -2142,10 +2819,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1164DAGISEL-NEXT:    v_min_f32_e64 v2, s4, s6
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s4, v2
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1164DAGISEL-NEXT:  ; %bb.7:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v4, s4
-; GFX1164DAGISEL-NEXT:  .LBB4_8: ; %endif
+; GFX1164DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1164DAGISEL-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX1164DAGISEL-NEXT:    global_store_b32 v[0:1], v4, off
 ; GFX1164DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -2159,11 +2836,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1164GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1164GISEL-NEXT:    s_and_saveexec_b64 s[0:1], vcc
 ; GFX1164GISEL-NEXT:    s_xor_b64 s[0:1], exec, s[0:1]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1164GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[2:3], exec
 ; GFX1164GISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
-; GFX1164GISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s5, s[2:3]
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s6, v2, s5
@@ -2172,17 +2849,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1164GISEL-NEXT:    v_min_f32_e64 v3, s4, s6
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s4, v3
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1164GISEL-NEXT:  ; %bb.3:
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v4, s4
 ; GFX1164GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1164GISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX1164GISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1164GISEL-NEXT:    s_and_not1_saveexec_b64 s[0:1], s[0:1]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1164GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[2:3], exec
 ; GFX1164GISEL-NEXT:    s_mov_b32 s4, 0x7fc00000
-; GFX1164GISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s5, s[2:3]
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s6, v3, s5
@@ -2191,10 +2868,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1164GISEL-NEXT:    v_min_f32_e64 v2, s4, s6
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s4, v2
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1164GISEL-NEXT:  ; %bb.7:
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v4, s4
-; GFX1164GISEL-NEXT:  .LBB4_8: ; %endif
+; GFX1164GISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1164GISEL-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX1164GISEL-NEXT:    global_store_b32 v[0:1], v4, off
 ; GFX1164GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -2208,11 +2885,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1132DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1132DAGISEL-NEXT:    s_and_saveexec_b32 s0, vcc_lo
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 s0, exec_lo, s0
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1132DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX1132DAGISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s3, s1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -2221,17 +2898,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1132DAGISEL-NEXT:    v_min_f32_e64 v3, s2, s4
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s2, v3
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1132DAGISEL-NEXT:  ; %bb.3:
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v4, s2
 ; GFX1132DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1132DAGISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX1132DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1132DAGISEL-NEXT:    s_and_not1_saveexec_b32 s0, s0
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1132DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX1132DAGISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s3, s1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v3, s3
@@ -2240,10 +2917,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1132DAGISEL-NEXT:    v_min_f32_e64 v2, s2, s4
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s2, v2
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1132DAGISEL-NEXT:  ; %bb.7:
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v4, s2
-; GFX1132DAGISEL-NEXT:  .LBB4_8: ; %endif
+; GFX1132DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1132DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX1132DAGISEL-NEXT:    global_store_b32 v[0:1], v4, off
 ; GFX1132DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -2257,11 +2934,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1132GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1132GISEL-NEXT:    s_and_saveexec_b32 s0, vcc_lo
 ; GFX1132GISEL-NEXT:    s_xor_b32 s0, exec_lo, s0
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1132GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132GISEL-NEXT:    s_mov_b32 s1, exec_lo
 ; GFX1132GISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX1132GISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s3, s1
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -2270,17 +2947,17 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1132GISEL-NEXT:    v_min_f32_e64 v3, s2, s4
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s2, v3
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX1132GISEL-NEXT:  ; %bb.3:
 ; GFX1132GISEL-NEXT:    v_mov_b32_e32 v4, s2
 ; GFX1132GISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX1132GISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX1132GISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX1132GISEL-NEXT:    s_and_not1_saveexec_b32 s0, s0
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX1132GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1132GISEL-NEXT:    s_mov_b32 s1, exec_lo
 ; GFX1132GISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX1132GISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s3, s1
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v3, s3
@@ -2289,10 +2966,10 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX1132GISEL-NEXT:    v_min_f32_e64 v2, s2, s4
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s2, v2
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX1132GISEL-NEXT:  ; %bb.7:
 ; GFX1132GISEL-NEXT:    v_mov_b32_e32 v4, s2
-; GFX1132GISEL-NEXT:  .LBB4_8: ; %endif
+; GFX1132GISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX1132GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX1132GISEL-NEXT:    global_store_b32 v[0:1], v4, off
 ; GFX1132GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -2311,11 +2988,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX12DAGISEL-NEXT:    s_and_saveexec_b32 s0, vcc_lo
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_xor_b32 s0, exec_lo, s0
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX12DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s1, exec_lo
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX12DAGISEL-NEXT:  .LBB4_2: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB6_2: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s3, s1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -2326,19 +3003,19 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX12DAGISEL-NEXT:    v_min_num_f32_e64 v3, s2, s4
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s2, v3
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_2
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_2
 ; GFX12DAGISEL-NEXT:  ; %bb.3:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v4, s2
 ; GFX12DAGISEL-NEXT:    ; implicit-def: $vgpr3
-; GFX12DAGISEL-NEXT:  .LBB4_4: ; %Flow
+; GFX12DAGISEL-NEXT:  .LBB6_4: ; %Flow
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_and_not1_saveexec_b32 s0, s0
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB4_8
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB6_8
 ; GFX12DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s1, exec_lo
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s2, 0x7fc00000
-; GFX12DAGISEL-NEXT:  .LBB4_6: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB6_6: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s3, s1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -2349,11 +3026,11 @@ define void @divergent_cfg_float(ptr addrspace(1) %out, float %in, float %in2) #
 ; GFX12DAGISEL-NEXT:    v_min_num_f32_e64 v2, s2, s4
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s2, v2
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB4_6
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_6
 ; GFX12DAGISEL-NEXT:  ; %bb.7:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v4, s2
-; GFX12DAGISEL-NEXT:  .LBB4_8: ; %endif
+; GFX12DAGISEL-NEXT:  .LBB6_8: ; %endif
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX12DAGISEL-NEXT:    global_store_b32 v[0:1], v4, off
@@ -2499,7 +3176,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX8DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -2510,7 +3187,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX8DAGISEL-NEXT:  ; %bb.2:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2524,7 +3201,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX8GISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX8GISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX8GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX8GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX8GISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -2535,7 +3212,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX8GISEL-NEXT:  ; %bb.2:
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2549,7 +3226,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX9DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -2560,7 +3237,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX9DAGISEL-NEXT:  ; %bb.2:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2574,7 +3251,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX9GISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX9GISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX9GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX9GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX9GISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -2585,7 +3262,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX9GISEL-NEXT:  ; %bb.2:
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2599,7 +3276,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX1064DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -2608,7 +3285,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1064DAGISEL-NEXT:    v_min_f64 v[4:5], s[8:9], s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1064DAGISEL-NEXT:  ; %bb.2:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2621,7 +3298,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1064GISEL-NEXT:    s_mov_b32 s6, 0
 ; GFX1064GISEL-NEXT:    s_mov_b32 s7, 0x7ff80000
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX1064GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -2630,7 +3307,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1064GISEL-NEXT:    v_min_f64 v[4:5], s[8:9], s[6:7]
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1064GISEL-NEXT:  ; %bb.2:
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2643,7 +3320,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s6, exec_lo
-; GFX1032DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s7, s6
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s9, v3, s7
@@ -2652,7 +3329,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1032DAGISEL-NEXT:    v_min_f64 v[4:5], s[8:9], s[4:5]
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1032DAGISEL-NEXT:  ; %bb.2:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -2665,7 +3342,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1032GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032GISEL-NEXT:    s_mov_b32 s6, exec_lo
-; GFX1032GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s7, s6
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s9, v3, s7
@@ -2674,7 +3351,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1032GISEL-NEXT:    v_min_f64 v[4:5], s[8:9], s[4:5]
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1032GISEL-NEXT:  ; %bb.2:
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -2687,7 +3364,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s2, 0
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s3, 0x7ff80000
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s6, s[0:1]
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -2699,7 +3376,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s2, v4
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s3, v5
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1164DAGISEL-NEXT:  ; %bb.2:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v3, s3
@@ -2712,7 +3389,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1164GISEL-NEXT:    s_mov_b32 s2, 0
 ; GFX1164GISEL-NEXT:    s_mov_b32 s3, 0x7ff80000
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s6, s[0:1]
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -2724,7 +3401,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s2, v4
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s3, v5
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1164GISEL-NEXT:  ; %bb.2:
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v3, s3
@@ -2737,7 +3414,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX1132DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -2749,7 +3426,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1132DAGISEL-NEXT:  ; %bb.2:
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
 ; GFX1132DAGISEL-NEXT:    global_store_b64 v[0:1], v[2:3], off
@@ -2761,7 +3438,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1132GISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132GISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132GISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX1132GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -2773,7 +3450,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1132GISEL-NEXT:  ; %bb.2:
 ; GFX1132GISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
 ; GFX1132GISEL-NEXT:    global_store_b64 v[0:1], v[2:3], off
@@ -2789,7 +3466,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX12DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -2802,7 +3479,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %in) #0 {
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX12DAGISEL-NEXT:  ; %bb.2:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
@@ -2823,12 +3500,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX8DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX8DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX8DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX8DAGISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s10, v2, s12
@@ -2839,20 +3516,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s8, v4
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX8DAGISEL-NEXT:  ; %bb.3:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX8DAGISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX8DAGISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX8DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX8DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX8DAGISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s8
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s10, v4, s12
@@ -2863,11 +3540,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX8DAGISEL-NEXT:  ; %bb.7:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
-; GFX8DAGISEL-NEXT:  .LBB7_8: ; %endif
+; GFX8DAGISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX8DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX8DAGISEL-NEXT:    flat_store_dwordx2 v[0:1], v[6:7]
 ; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -2881,12 +3558,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8GISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX8GISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX8GISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX8GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8GISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX8GISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX8GISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX8GISEL-NEXT:    v_readlane_b32 s10, v2, s12
@@ -2897,20 +3574,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s8, v4
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX8GISEL-NEXT:  ; %bb.3:
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v7, s9
 ; GFX8GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX8GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX8GISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX8GISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX8GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX8GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX8GISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX8GISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX8GISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s8
 ; GFX8GISEL-NEXT:    v_readlane_b32 s10, v4, s12
@@ -2921,11 +3598,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s8, v2
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX8GISEL-NEXT:  ; %bb.7:
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v7, s9
-; GFX8GISEL-NEXT:  .LBB7_8: ; %endif
+; GFX8GISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX8GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX8GISEL-NEXT:    flat_store_dwordx2 v[0:1], v[6:7]
 ; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -2939,12 +3616,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX9DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX9DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX9DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX9DAGISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s10, v2, s12
@@ -2955,20 +3632,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s8, v4
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX9DAGISEL-NEXT:  ; %bb.3:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX9DAGISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX9DAGISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX9DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX9DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX9DAGISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s8
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s10, v4, s12
@@ -2979,11 +3656,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX9DAGISEL-NEXT:  ; %bb.7:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
-; GFX9DAGISEL-NEXT:  .LBB7_8: ; %endif
+; GFX9DAGISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX9DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX9DAGISEL-NEXT:    global_store_dwordx2 v[0:1], v[6:7], off
 ; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -2997,12 +3674,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9GISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX9GISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX9GISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX9GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9GISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX9GISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX9GISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v4, s8
 ; GFX9GISEL-NEXT:    v_readlane_b32 s10, v2, s12
@@ -3013,20 +3690,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s8, v4
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX9GISEL-NEXT:  ; %bb.3:
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v7, s9
 ; GFX9GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX9GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX9GISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX9GISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX9GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX9GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX9GISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX9GISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX9GISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s8
 ; GFX9GISEL-NEXT:    v_readlane_b32 s10, v4, s12
@@ -3037,11 +3714,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[6:7], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s8, v2
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX9GISEL-NEXT:  ; %bb.7:
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v7, s9
-; GFX9GISEL-NEXT:  .LBB7_8: ; %endif
+; GFX9GISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX9GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX9GISEL-NEXT:    global_store_dwordx2 v[0:1], v[6:7], off
 ; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0)
@@ -3055,12 +3732,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1064DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1064DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX1064DAGISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s10, v2, s12
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s11, v3, s12
@@ -3069,20 +3746,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064DAGISEL-NEXT:    v_min_f64 v[4:5], s[10:11], s[8:9]
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s8, v4
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX1064DAGISEL-NEXT:  ; %bb.3:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1064DAGISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX1064DAGISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX1064DAGISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX1064DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX1064DAGISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s10, v4, s12
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s11, v5, s12
@@ -3091,11 +3768,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064DAGISEL-NEXT:    v_min_f64 v[2:3], s[10:11], s[8:9]
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s8, v2
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX1064DAGISEL-NEXT:  ; %bb.7:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v7, s9
-; GFX1064DAGISEL-NEXT:  .LBB7_8: ; %endif
+; GFX1064DAGISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX1064DAGISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX1064DAGISEL-NEXT:    global_store_dwordx2 v[0:1], v[6:7], off
 ; GFX1064DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -3108,12 +3785,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064GISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1064GISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX1064GISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1064GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064GISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX1064GISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX1064GISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s10, v2, s12
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s11, v3, s12
@@ -3122,20 +3799,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064GISEL-NEXT:    v_min_f64 v[4:5], s[10:11], s[8:9]
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s8, v4
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s9, v5
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX1064GISEL-NEXT:  ; %bb.3:
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v7, s9
 ; GFX1064GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1064GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1064GISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX1064GISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX1064GISEL-NEXT:    s_andn2_saveexec_b64 s[4:5], s[4:5]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX1064GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1064GISEL-NEXT:    s_mov_b32 s8, 0
 ; GFX1064GISEL-NEXT:    s_mov_b32 s9, 0x7ff80000
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
-; GFX1064GISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s12, s[6:7]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s10, v4, s12
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s11, v5, s12
@@ -3144,11 +3821,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1064GISEL-NEXT:    v_min_f64 v[2:3], s[10:11], s[8:9]
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s8, v2
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s9, v3
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX1064GISEL-NEXT:  ; %bb.7:
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v6, s8
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v7, s9
-; GFX1064GISEL-NEXT:  .LBB7_8: ; %endif
+; GFX1064GISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX1064GISEL-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX1064GISEL-NEXT:    global_store_dwordx2 v[0:1], v[6:7], off
 ; GFX1064GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -3161,12 +3838,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1032DAGISEL-NEXT:    s_and_saveexec_b32 s4, vcc_lo
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 s6, exec_lo, s4
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1032DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s7, exec_lo
-; GFX1032DAGISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s10, s7
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -3175,20 +3852,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032DAGISEL-NEXT:    v_min_f64 v[4:5], s[8:9], s[4:5]
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX1032DAGISEL-NEXT:  ; %bb.3:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v6, s4
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1032DAGISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX1032DAGISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX1032DAGISEL-NEXT:    s_andn2_saveexec_b32 s6, s6
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX1032DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s7, exec_lo
-; GFX1032DAGISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s10, s7
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v4, s10
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s9, v5, s10
@@ -3197,11 +3874,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032DAGISEL-NEXT:    v_min_f64 v[2:3], s[8:9], s[4:5]
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s4, v2
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX1032DAGISEL-NEXT:  ; %bb.7:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v6, s4
-; GFX1032DAGISEL-NEXT:  .LBB7_8: ; %endif
+; GFX1032DAGISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX1032DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s6
 ; GFX1032DAGISEL-NEXT:    global_store_dwordx2 v[0:1], v[6:7], off
 ; GFX1032DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -3214,12 +3891,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032GISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1032GISEL-NEXT:    s_and_saveexec_b32 s4, vcc_lo
 ; GFX1032GISEL-NEXT:    s_xor_b32 s6, exec_lo, s4
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1032GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032GISEL-NEXT:    s_mov_b32 s7, exec_lo
-; GFX1032GISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s10, s7
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -3228,20 +3905,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032GISEL-NEXT:    v_min_f64 v[4:5], s[8:9], s[4:5]
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX1032GISEL-NEXT:  ; %bb.3:
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v6, s4
 ; GFX1032GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1032GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1032GISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX1032GISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX1032GISEL-NEXT:    s_andn2_saveexec_b32 s6, s6
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX1032GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1032GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1032GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1032GISEL-NEXT:    s_mov_b32 s7, exec_lo
-; GFX1032GISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s10, s7
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v4, s10
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s9, v5, s10
@@ -3250,11 +3927,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1032GISEL-NEXT:    v_min_f64 v[2:3], s[8:9], s[4:5]
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s4, v2
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX1032GISEL-NEXT:  ; %bb.7:
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v6, s4
-; GFX1032GISEL-NEXT:  .LBB7_8: ; %endif
+; GFX1032GISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX1032GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s6
 ; GFX1032GISEL-NEXT:    global_store_dwordx2 v[0:1], v[6:7], off
 ; GFX1032GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -3268,12 +3945,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1164DAGISEL-NEXT:    s_and_saveexec_b64 s[0:1], vcc
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 s[0:1], exec, s[0:1]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1164DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
-; GFX1164DAGISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s8, s[2:3]
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s6, v2, s8
@@ -3285,20 +3962,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX1164DAGISEL-NEXT:  ; %bb.3:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v6, s4
 ; GFX1164DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1164DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1164DAGISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX1164DAGISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX1164DAGISEL-NEXT:    s_and_not1_saveexec_b64 s[0:1], s[0:1]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX1164DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
-; GFX1164DAGISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s8, s[2:3]
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s6, v4, s8
@@ -3310,11 +3987,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s4, v2
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX1164DAGISEL-NEXT:  ; %bb.7:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v6, s4
-; GFX1164DAGISEL-NEXT:  .LBB7_8: ; %endif
+; GFX1164DAGISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX1164DAGISEL-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX1164DAGISEL-NEXT:    global_store_b64 v[0:1], v[6:7], off
 ; GFX1164DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -3328,12 +4005,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164GISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1164GISEL-NEXT:    s_and_saveexec_b64 s[0:1], vcc
 ; GFX1164GISEL-NEXT:    s_xor_b64 s[0:1], exec, s[0:1]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1164GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1164GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[2:3], exec
-; GFX1164GISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s8, s[2:3]
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s6, v2, s8
@@ -3345,20 +4022,20 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX1164GISEL-NEXT:  ; %bb.3:
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v6, s4
 ; GFX1164GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1164GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1164GISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX1164GISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX1164GISEL-NEXT:    s_and_not1_saveexec_b64 s[0:1], s[0:1]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX1164GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1164GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX1164GISEL-NEXT:    s_mov_b32 s5, 0x7ff80000
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[2:3], exec
-; GFX1164GISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s8, s[2:3]
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s6, v4, s8
@@ -3370,11 +4047,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s4, v2
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX1164GISEL-NEXT:  ; %bb.7:
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v7, s5
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v6, s4
-; GFX1164GISEL-NEXT:  .LBB7_8: ; %endif
+; GFX1164GISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX1164GISEL-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX1164GISEL-NEXT:    global_store_b64 v[0:1], v[6:7], off
 ; GFX1164GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -3388,12 +4065,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132DAGISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1132DAGISEL-NEXT:    s_and_saveexec_b32 s0, vcc_lo
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 s2, exec_lo, s0
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1132DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX1132DAGISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -3405,19 +4082,19 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX1132DAGISEL-NEXT:  ; %bb.3:
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v7, s1 :: v_dual_mov_b32 v6, s0
 ; GFX1132DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1132DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1132DAGISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX1132DAGISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX1132DAGISEL-NEXT:    s_and_not1_saveexec_b32 s2, s2
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX1132DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX1132DAGISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v4, s6
@@ -3429,10 +4106,10 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s0, v2
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX1132DAGISEL-NEXT:  ; %bb.7:
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v7, s1 :: v_dual_mov_b32 v6, s0
-; GFX1132DAGISEL-NEXT:  .LBB7_8: ; %endif
+; GFX1132DAGISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX1132DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1132DAGISEL-NEXT:    global_store_b64 v[0:1], v[6:7], off
 ; GFX1132DAGISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -3446,12 +4123,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132GISEL-NEXT:    ; implicit-def: $vgpr6_vgpr7
 ; GFX1132GISEL-NEXT:    s_and_saveexec_b32 s0, vcc_lo
 ; GFX1132GISEL-NEXT:    s_xor_b32 s2, exec_lo, s0
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1132GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132GISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132GISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132GISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX1132GISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -3463,19 +4140,19 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX1132GISEL-NEXT:  ; %bb.3:
 ; GFX1132GISEL-NEXT:    v_dual_mov_b32 v7, s1 :: v_dual_mov_b32 v6, s0
 ; GFX1132GISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX1132GISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX1132GISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX1132GISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX1132GISEL-NEXT:    s_and_not1_saveexec_b32 s2, s2
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX1132GISEL-NEXT:  ; %bb.5: ; %if
 ; GFX1132GISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX1132GISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX1132GISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX1132GISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v4, s6
@@ -3487,10 +4164,10 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s0, v2
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX1132GISEL-NEXT:  ; %bb.7:
 ; GFX1132GISEL-NEXT:    v_dual_mov_b32 v7, s1 :: v_dual_mov_b32 v6, s0
-; GFX1132GISEL-NEXT:  .LBB7_8: ; %endif
+; GFX1132GISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX1132GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1132GISEL-NEXT:    global_store_b64 v[0:1], v[6:7], off
 ; GFX1132GISEL-NEXT:    s_setpc_b64 s[30:31]
@@ -3509,12 +4186,12 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX12DAGISEL-NEXT:    s_and_saveexec_b32 s0, vcc_lo
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_xor_b32 s2, exec_lo, s0
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX12DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX12DAGISEL-NEXT:  .LBB7_2: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB9_2: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -3527,21 +4204,21 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_2
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_2
 ; GFX12DAGISEL-NEXT:  ; %bb.3:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v7, s1 :: v_dual_mov_b32 v6, s0
 ; GFX12DAGISEL-NEXT:    ; implicit-def: $vgpr4
 ; GFX12DAGISEL-NEXT:    ; implicit-def: $vgpr5
-; GFX12DAGISEL-NEXT:  .LBB7_4: ; %Flow
+; GFX12DAGISEL-NEXT:  .LBB9_4: ; %Flow
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_and_not1_saveexec_b32 s2, s2
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB7_8
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB9_8
 ; GFX12DAGISEL-NEXT:  ; %bb.5: ; %if
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s0, 0
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s1, 0x7ff80000
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
-; GFX12DAGISEL-NEXT:  .LBB7_6: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB9_6: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s6, s3
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -3554,11 +4231,11 @@ define void @divergent_cfg_double(ptr addrspace(1) %out, double %in, double %in2
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s0, v2
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB7_6
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB9_6
 ; GFX12DAGISEL-NEXT:  ; %bb.7:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v7, s1 :: v_dual_mov_b32 v6, s0
-; GFX12DAGISEL-NEXT:  .LBB7_8: ; %endif
+; GFX12DAGISEL-NEXT:  .LBB9_8: ; %endif
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX12DAGISEL-NEXT:    global_store_b64 v[0:1], v[6:7], off

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.fsub.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.reduce.fsub.ll
@@ -7,11 +7,753 @@
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -global-isel=1 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1064GISEL %s
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -global-isel=0 < %s | FileCheck -check-prefixes=GFX1032DAGISEL %s
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -global-isel=1 < %s | FileCheck -check-prefixes=GFX1032GISEL %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -global-isel=0 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164DAGISEL %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -global-isel=1 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164GISEL %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -global-isel=0 < %s | FileCheck -check-prefixes=GFX1132DAGISEL %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -global-isel=1 < %s | FileCheck -check-prefixes=GFX1132GISEL %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=-real-true16 -global-isel=0 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164DAGISEL,GFX1164DAGISEL-FAKE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=-real-true16 -global-isel=1 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164GISEL,GFX1164GISEL-FAKE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=-real-true16 -global-isel=0 < %s | FileCheck -check-prefixes=GFX1132DAGISEL,GFX1132DAGISEL-FAKE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=-real-true16 -global-isel=1 < %s | FileCheck -check-prefixes=GFX1132GISEL,GFX1132GISEL-FAKE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+real-true16 -global-isel=0 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164DAGISEL,GFX1164DAGISEL-TRUE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+real-true16 -global-isel=1 -mattr=+wavefrontsize64 < %s | FileCheck -check-prefixes=GFX1164GISEL,GFX1164GISEL-TRUE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+real-true16 -global-isel=0 < %s | FileCheck -check-prefixes=GFX1132DAGISEL,GFX1132DAGISEL-TRUE16 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -mattr=+real-true16 -global-isel=1 < %s | FileCheck -check-prefixes=GFX1132GISEL,GFX1132GISEL-TRUE16 %s
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx1200 -global-isel=0 < %s | FileCheck -check-prefixes=GFX12DAGISEL %s
+
+define amdgpu_kernel void @uniform_value_half(ptr addrspace(1) %out, half %in) {
+; GFX8DAGISEL-LABEL: uniform_value_half:
+; GFX8DAGISEL:       ; %bb.0: ; %entry
+; GFX8DAGISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX8DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX8DAGISEL-NEXT:    s_mov_b32 s4, 0
+; GFX8DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX8DAGISEL-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX8DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
+; GFX8DAGISEL-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s5, s[2:3]
+; GFX8DAGISEL-NEXT:    v_readlane_b32 s6, v0, s5
+; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v1, s6
+; GFX8DAGISEL-NEXT:    s_bitset0_b64 s[2:3], s5
+; GFX8DAGISEL-NEXT:    v_sub_f32_e32 v1, s4, v1
+; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[2:3], 0
+; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s4, v1
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX8DAGISEL-NEXT:  ; %bb.2:
+; GFX8DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2, s4
+; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v0, s0
+; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v1, s1
+; GFX8DAGISEL-NEXT:    flat_store_short v[0:1], v2
+; GFX8DAGISEL-NEXT:    s_endpgm
+;
+; GFX8GISEL-LABEL: uniform_value_half:
+; GFX8GISEL:       ; %bb.0: ; %entry
+; GFX8GISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX8GISEL-NEXT:    s_mov_b64 s[0:1], exec
+; GFX8GISEL-NEXT:    s_bcnt1_i32_b64 s0, s[0:1]
+; GFX8GISEL-NEXT:    v_cvt_f32_i32_e32 v1, s0
+; GFX8GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX8GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX8GISEL-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX8GISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX8GISEL-NEXT:    v_mul_f32_e64 v0, -s2, v1
+; GFX8GISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX8GISEL-NEXT:    v_cvt_f16_f32_e32 v2, s2
+; GFX8GISEL-NEXT:    v_mov_b32_e32 v0, s0
+; GFX8GISEL-NEXT:    v_mov_b32_e32 v1, s1
+; GFX8GISEL-NEXT:    flat_store_short v[0:1], v2
+; GFX8GISEL-NEXT:    s_endpgm
+;
+; GFX9DAGISEL-LABEL: uniform_value_half:
+; GFX9DAGISEL:       ; %bb.0: ; %entry
+; GFX9DAGISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX9DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX9DAGISEL-NEXT:    s_mov_b32 s4, 0
+; GFX9DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX9DAGISEL-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX9DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
+; GFX9DAGISEL-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s5, s[2:3]
+; GFX9DAGISEL-NEXT:    v_readlane_b32 s6, v1, s5
+; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
+; GFX9DAGISEL-NEXT:    s_bitset0_b64 s[2:3], s5
+; GFX9DAGISEL-NEXT:    v_sub_f32_e32 v2, s4, v2
+; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[2:3], 0
+; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s4, v2
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX9DAGISEL-NEXT:  ; %bb.2:
+; GFX9DAGISEL-NEXT:    v_cvt_f16_f32_e32 v1, s4
+; GFX9DAGISEL-NEXT:    global_store_short v0, v1, s[0:1]
+; GFX9DAGISEL-NEXT:    s_endpgm
+;
+; GFX9GISEL-LABEL: uniform_value_half:
+; GFX9GISEL:       ; %bb.0: ; %entry
+; GFX9GISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX9GISEL-NEXT:    s_mov_b64 s[0:1], exec
+; GFX9GISEL-NEXT:    s_bcnt1_i32_b64 s0, s[0:1]
+; GFX9GISEL-NEXT:    v_cvt_f32_i32_e32 v1, s0
+; GFX9GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX9GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX9GISEL-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX9GISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX9GISEL-NEXT:    v_mul_f32_e64 v0, -s2, v1
+; GFX9GISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX9GISEL-NEXT:    v_cvt_f16_f32_e32 v0, s2
+; GFX9GISEL-NEXT:    v_mov_b32_e32 v1, 0
+; GFX9GISEL-NEXT:    global_store_short v1, v0, s[0:1]
+; GFX9GISEL-NEXT:    s_endpgm
+;
+; GFX1064DAGISEL-LABEL: uniform_value_half:
+; GFX1064DAGISEL:       ; %bb.0: ; %entry
+; GFX1064DAGISEL-NEXT:    s_clause 0x1
+; GFX1064DAGISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX1064DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1064DAGISEL-NEXT:    s_mov_b32 s4, 0
+; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1064DAGISEL-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1064DAGISEL-NEXT:    s_mov_b64 s[2:3], exec
+; GFX1064DAGISEL-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s5, s[2:3]
+; GFX1064DAGISEL-NEXT:    v_readlane_b32 s6, v1, s5
+; GFX1064DAGISEL-NEXT:    s_bitset0_b64 s[2:3], s5
+; GFX1064DAGISEL-NEXT:    s_cmp_lg_u64 s[2:3], 0
+; GFX1064DAGISEL-NEXT:    v_sub_f32_e64 v2, s4, s6
+; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s4, v2
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1064DAGISEL-NEXT:  ; %bb.2:
+; GFX1064DAGISEL-NEXT:    v_cvt_f16_f32_e32 v1, s4
+; GFX1064DAGISEL-NEXT:    global_store_short v0, v1, s[0:1]
+; GFX1064DAGISEL-NEXT:    s_endpgm
+;
+; GFX1064GISEL-LABEL: uniform_value_half:
+; GFX1064GISEL:       ; %bb.0: ; %entry
+; GFX1064GISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX1064GISEL-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1064GISEL-NEXT:    s_bcnt1_i32_b64 s0, s[0:1]
+; GFX1064GISEL-NEXT:    v_cvt_f32_i32_e32 v1, s0
+; GFX1064GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1064GISEL-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1064GISEL-NEXT:    v_mul_f32_e64 v0, -s2, v1
+; GFX1064GISEL-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1064GISEL-NEXT:    v_cvt_f16_f32_e32 v0, s2
+; GFX1064GISEL-NEXT:    global_store_short v1, v0, s[0:1]
+; GFX1064GISEL-NEXT:    s_endpgm
+;
+; GFX1032DAGISEL-LABEL: uniform_value_half:
+; GFX1032DAGISEL:       ; %bb.0: ; %entry
+; GFX1032DAGISEL-NEXT:    s_clause 0x1
+; GFX1032DAGISEL-NEXT:    s_load_dword s2, s[4:5], 0x2c
+; GFX1032DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1032DAGISEL-NEXT:    s_mov_b32 s3, 0
+; GFX1032DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1032DAGISEL-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1032DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
+; GFX1032DAGISEL-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s4, s2
+; GFX1032DAGISEL-NEXT:    v_readlane_b32 s5, v1, s4
+; GFX1032DAGISEL-NEXT:    s_bitset0_b32 s2, s4
+; GFX1032DAGISEL-NEXT:    s_cmp_lg_u32 s2, 0
+; GFX1032DAGISEL-NEXT:    v_sub_f32_e64 v2, s3, s5
+; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s3, v2
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1032DAGISEL-NEXT:  ; %bb.2:
+; GFX1032DAGISEL-NEXT:    v_cvt_f16_f32_e32 v1, s3
+; GFX1032DAGISEL-NEXT:    global_store_short v0, v1, s[0:1]
+; GFX1032DAGISEL-NEXT:    s_endpgm
+;
+; GFX1032GISEL-LABEL: uniform_value_half:
+; GFX1032GISEL:       ; %bb.0: ; %entry
+; GFX1032GISEL-NEXT:    s_load_dword s0, s[4:5], 0x2c
+; GFX1032GISEL-NEXT:    s_mov_b32 s1, exec_lo
+; GFX1032GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1032GISEL-NEXT:    v_cvt_f32_f16_e32 v0, s0
+; GFX1032GISEL-NEXT:    s_bcnt1_i32_b32 s0, s1
+; GFX1032GISEL-NEXT:    v_cvt_f32_i32_e32 v1, s0
+; GFX1032GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1032GISEL-NEXT:    v_mul_f32_e64 v0, -s2, v1
+; GFX1032GISEL-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1032GISEL-NEXT:    v_cvt_f16_f32_e32 v0, s2
+; GFX1032GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1032GISEL-NEXT:    global_store_short v1, v0, s[0:1]
+; GFX1032GISEL-NEXT:    s_endpgm
+;
+; GFX1164DAGISEL-FAKE16-LABEL: uniform_value_half:
+; GFX1164DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mov_b32 s4, 0
+; GFX1164DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mov_b64 s[2:3], exec
+; GFX1164DAGISEL-FAKE16-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_ctz_i32_b64 s5, s[2:3]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_readlane_b32 s6, v1, s5
+; GFX1164DAGISEL-FAKE16-NEXT:    s_bitset0_b64 s[2:3], s5
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cmp_lg_u64 s[2:3], 0
+; GFX1164DAGISEL-FAKE16-NEXT:    v_sub_f32_e64 v2, s4, s6
+; GFX1164DAGISEL-FAKE16-NEXT:    v_readfirstlane_b32 s4, v2
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1164DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v1, s4
+; GFX1164DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_endpgm
+;
+; GFX1164GISEL-FAKE16-LABEL: uniform_value_half:
+; GFX1164GISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164GISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164GISEL-FAKE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164GISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1164GISEL-FAKE16-NEXT:    s_bcnt1_i32_b64 s0, s[0:1]
+; GFX1164GISEL-FAKE16-NEXT:    v_cvt_f32_i32_e32 v1, s0
+; GFX1164GISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164GISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164GISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX1164GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1164GISEL-FAKE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1164GISEL-FAKE16-NEXT:    v_mul_f32_e64 v0, -s2, v1
+; GFX1164GISEL-FAKE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1164GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1164GISEL-FAKE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1164GISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v0, s2
+; GFX1164GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1164GISEL-FAKE16-NEXT:    s_endpgm
+;
+; GFX1132DAGISEL-FAKE16-LABEL: uniform_value_half:
+; GFX1132DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-FAKE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mov_b32 s3, 0
+; GFX1132DAGISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mov_b32 s2, exec_lo
+; GFX1132DAGISEL-FAKE16-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_ctz_i32_b32 s4, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_readlane_b32 s5, v1, s4
+; GFX1132DAGISEL-FAKE16-NEXT:    s_bitset0_b32 s2, s4
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cmp_lg_u32 s2, 0
+; GFX1132DAGISEL-FAKE16-NEXT:    v_sub_f32_e64 v2, s3, s5
+; GFX1132DAGISEL-FAKE16-NEXT:    v_readfirstlane_b32 s3, v2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1132DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v1, s3
+; GFX1132DAGISEL-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1132DAGISEL-FAKE16-NEXT:    s_endpgm
+;
+; GFX1132GISEL-FAKE16-LABEL: uniform_value_half:
+; GFX1132GISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132GISEL-FAKE16-NEXT:    s_load_b32 s0, s[4:5], 0x2c
+; GFX1132GISEL-FAKE16-NEXT:    s_mov_b32 s1, exec_lo
+; GFX1132GISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132GISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v0, s0
+; GFX1132GISEL-FAKE16-NEXT:    s_bcnt1_i32_b32 s0, s1
+; GFX1132GISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1132GISEL-FAKE16-NEXT:    v_cvt_f32_i32_e32 v1, s0
+; GFX1132GISEL-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132GISEL-FAKE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1132GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1132GISEL-FAKE16-NEXT:    v_mul_f32_e64 v0, -s2, v1
+; GFX1132GISEL-FAKE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1132GISEL-FAKE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1132GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1132GISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v0, s2
+; GFX1132GISEL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1132GISEL-FAKE16-NEXT:    s_endpgm
+;
+; GFX1164DAGISEL-TRUE16-LABEL: uniform_value_half:
+; GFX1164DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b32 s4, 0
+; GFX1164DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b64 s[2:3], exec
+; GFX1164DAGISEL-TRUE16-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_ctz_i32_b64 s5, s[2:3]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_readlane_b32 s6, v1, s5
+; GFX1164DAGISEL-TRUE16-NEXT:    s_bitset0_b64 s[2:3], s5
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cmp_lg_u64 s[2:3], 0
+; GFX1164DAGISEL-TRUE16-NEXT:    v_sub_f32_e64 v2, s4, s6
+; GFX1164DAGISEL-TRUE16-NEXT:    v_readfirstlane_b32 s4, v2
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1164DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.l, s4
+; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX1164GISEL-TRUE16-LABEL: uniform_value_half:
+; GFX1164GISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164GISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1164GISEL-TRUE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164GISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
+; GFX1164GISEL-TRUE16-NEXT:    s_bcnt1_i32_b64 s0, s[0:1]
+; GFX1164GISEL-TRUE16-NEXT:    v_cvt_f32_i32_e32 v1, s0
+; GFX1164GISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1164GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1164GISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, s2
+; GFX1164GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1164GISEL-TRUE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1164GISEL-TRUE16-NEXT:    v_mul_f32_e64 v0, -s2, v1
+; GFX1164GISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1164GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX1164GISEL-TRUE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1164GISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, s2
+; GFX1164GISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1164GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX1132DAGISEL-TRUE16-LABEL: uniform_value_half:
+; GFX1132DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-TRUE16-NEXT:    s_clause 0x1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x2c
+; GFX1132DAGISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132DAGISEL-TRUE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s3, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v1, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s2, exec_lo
+; GFX1132DAGISEL-TRUE16-NEXT:  .LBB0_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_ctz_i32_b32 s4, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_readlane_b32 s5, v1, s4
+; GFX1132DAGISEL-TRUE16-NEXT:    s_bitset0_b32 s2, s4
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cmp_lg_u32 s2, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    v_sub_f32_e64 v2, s3, s5
+; GFX1132DAGISEL-TRUE16-NEXT:    v_readfirstlane_b32 s3, v2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB0_1
+; GFX1132DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v1.l, s3
+; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; GFX1132DAGISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX1132GISEL-TRUE16-LABEL: uniform_value_half:
+; GFX1132GISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132GISEL-TRUE16-NEXT:    s_load_b32 s0, s[4:5], 0x2c
+; GFX1132GISEL-TRUE16-NEXT:    s_mov_b32 s1, exec_lo
+; GFX1132GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132GISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v0, s0
+; GFX1132GISEL-TRUE16-NEXT:    s_bcnt1_i32_b32 s0, s1
+; GFX1132GISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1132GISEL-TRUE16-NEXT:    v_cvt_f32_i32_e32 v1, s0
+; GFX1132GISEL-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX1132GISEL-TRUE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1132GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1132GISEL-TRUE16-NEXT:    v_mul_f32_e64 v0, -s2, v1
+; GFX1132GISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX1132GISEL-TRUE16-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX1132GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1132GISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v0.l, s2
+; GFX1132GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX1132GISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX1132GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GFX12DAGISEL-LABEL: uniform_value_half:
+; GFX12DAGISEL:       ; %bb.0: ; %entry
+; GFX12DAGISEL-NEXT:    s_load_b96 s[0:2], s[4:5], 0x24
+; GFX12DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
+; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v1, 0
+; GFX12DAGISEL-NEXT:    s_bcnt1_i32_b32 s3, s3
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX12DAGISEL-NEXT:    v_cvt_f32_i32_e32 v0, s3
+; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12DAGISEL-NEXT:    s_cvt_f32_f16 s2, s2
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_2)
+; GFX12DAGISEL-NEXT:    v_mul_f32_e64 v0, -s2, v0
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(SALU_CYCLE_2)
+; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s2, v0
+; GFX12DAGISEL-NEXT:    s_cvt_f16_f32 s2, s2
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    v_mov_b16_e32 v0.l, s2
+; GFX12DAGISEL-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GFX12DAGISEL-NEXT:    s_endpgm
+  entry:
+  %result = call half @llvm.amdgcn.wave.reduce.fsub(half %in, i32 1)
+  store half %result, ptr addrspace(1) %out
+  ret void
+}
+
+define void @divergent_value_half(ptr addrspace(1) %out, half %in) {
+; GFX8DAGISEL-LABEL: divergent_value_half:
+; GFX8DAGISEL:       ; %bb.0: ; %entry
+; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8DAGISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX8DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX8DAGISEL-NEXT:    s_mov_b32 s6, 0
+; GFX8DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX8DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s8
+; GFX8DAGISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX8DAGISEL-NEXT:    v_sub_f32_e32 v3, s6, v3
+; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX8DAGISEL-NEXT:  ; %bb.2:
+; GFX8DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX8DAGISEL-NEXT:    flat_store_short v[0:1], v2
+; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX8DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX8GISEL-LABEL: divergent_value_half:
+; GFX8GISEL:       ; %bb.0: ; %entry
+; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX8GISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX8GISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX8GISEL-NEXT:    s_mov_b32 s6, 0
+; GFX8GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX8GISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s8
+; GFX8GISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX8GISEL-NEXT:    v_sub_f32_e32 v3, s6, v3
+; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX8GISEL-NEXT:  ; %bb.2:
+; GFX8GISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX8GISEL-NEXT:    flat_store_short v[0:1], v2
+; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX8GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9DAGISEL-LABEL: divergent_value_half:
+; GFX9DAGISEL:       ; %bb.0: ; %entry
+; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9DAGISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX9DAGISEL-NEXT:    s_mov_b32 s6, 0
+; GFX9DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX9DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v3, s8
+; GFX9DAGISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX9DAGISEL-NEXT:    v_sub_f32_e32 v3, s6, v3
+; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX9DAGISEL-NEXT:  ; %bb.2:
+; GFX9DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX9DAGISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX9DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX9GISEL-LABEL: divergent_value_half:
+; GFX9GISEL:       ; %bb.0: ; %entry
+; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX9GISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX9GISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX9GISEL-NEXT:    s_mov_b32 s6, 0
+; GFX9GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX9GISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX9GISEL-NEXT:    v_mov_b32_e32 v3, s8
+; GFX9GISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX9GISEL-NEXT:    v_sub_f32_e32 v3, s6, v3
+; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX9GISEL-NEXT:  ; %bb.2:
+; GFX9GISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX9GISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0)
+; GFX9GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1064DAGISEL-LABEL: divergent_value_half:
+; GFX1064DAGISEL:       ; %bb.0: ; %entry
+; GFX1064DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1064DAGISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1064DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX1064DAGISEL-NEXT:    s_mov_b32 s6, 0
+; GFX1064DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX1064DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX1064DAGISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX1064DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX1064DAGISEL-NEXT:    v_sub_f32_e64 v3, s6, s8
+; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1064DAGISEL-NEXT:  ; %bb.2:
+; GFX1064DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX1064DAGISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX1064DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1064GISEL-LABEL: divergent_value_half:
+; GFX1064GISEL:       ; %bb.0: ; %entry
+; GFX1064GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1064GISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1064GISEL-NEXT:    s_mov_b64 s[4:5], exec
+; GFX1064GISEL-NEXT:    s_mov_b32 s6, 0
+; GFX1064GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
+; GFX1064GISEL-NEXT:    v_readlane_b32 s8, v2, s7
+; GFX1064GISEL-NEXT:    s_bitset0_b64 s[4:5], s7
+; GFX1064GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
+; GFX1064GISEL-NEXT:    v_sub_f32_e64 v3, s6, s8
+; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v3
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1064GISEL-NEXT:  ; %bb.2:
+; GFX1064GISEL-NEXT:    v_cvt_f16_f32_e32 v2, s6
+; GFX1064GISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX1064GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1032DAGISEL-LABEL: divergent_value_half:
+; GFX1032DAGISEL:       ; %bb.0: ; %entry
+; GFX1032DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1032DAGISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, exec_lo
+; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, 0
+; GFX1032DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s6, s4
+; GFX1032DAGISEL-NEXT:    v_readlane_b32 s7, v2, s6
+; GFX1032DAGISEL-NEXT:    s_bitset0_b32 s4, s6
+; GFX1032DAGISEL-NEXT:    s_cmp_lg_u32 s4, 0
+; GFX1032DAGISEL-NEXT:    v_sub_f32_e64 v3, s5, s7
+; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v3
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1032DAGISEL-NEXT:  ; %bb.2:
+; GFX1032DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2, s5
+; GFX1032DAGISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX1032DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1032GISEL-LABEL: divergent_value_half:
+; GFX1032GISEL:       ; %bb.0: ; %entry
+; GFX1032GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1032GISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1032GISEL-NEXT:    s_mov_b32 s4, exec_lo
+; GFX1032GISEL-NEXT:    s_mov_b32 s5, 0
+; GFX1032GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s6, s4
+; GFX1032GISEL-NEXT:    v_readlane_b32 s7, v2, s6
+; GFX1032GISEL-NEXT:    s_bitset0_b32 s4, s6
+; GFX1032GISEL-NEXT:    s_cmp_lg_u32 s4, 0
+; GFX1032GISEL-NEXT:    v_sub_f32_e64 v3, s5, s7
+; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v3
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1032GISEL-NEXT:  ; %bb.2:
+; GFX1032GISEL-NEXT:    v_cvt_f16_f32_e32 v2, s5
+; GFX1032GISEL-NEXT:    global_store_short v[0:1], v2, off
+; GFX1032GISEL-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164DAGISEL-FAKE16-LABEL: divergent_value_half:
+; GFX1164DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164DAGISEL-FAKE16-NEXT:    s_mov_b32 s2, 0
+; GFX1164DAGISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-FAKE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164DAGISEL-FAKE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164DAGISEL-FAKE16-NEXT:    v_sub_f32_e64 v3, s2, s4
+; GFX1164DAGISEL-FAKE16-NEXT:    v_readfirstlane_b32 s2, v3
+; GFX1164DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v2, s2
+; GFX1164DAGISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164DAGISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164GISEL-FAKE16-LABEL: divergent_value_half:
+; GFX1164GISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1164GISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164GISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1164GISEL-FAKE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164GISEL-FAKE16-NEXT:    s_mov_b32 s2, 0
+; GFX1164GISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-FAKE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164GISEL-FAKE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164GISEL-FAKE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164GISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164GISEL-FAKE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164GISEL-FAKE16-NEXT:    v_sub_f32_e64 v3, s2, s4
+; GFX1164GISEL-FAKE16-NEXT:    v_readfirstlane_b32 s2, v3
+; GFX1164GISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164GISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1164GISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v2, s2
+; GFX1164GISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164GISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132DAGISEL-FAKE16-LABEL: divergent_value_half:
+; GFX1132DAGISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mov_b32 s0, exec_lo
+; GFX1132DAGISEL-FAKE16-NEXT:    s_mov_b32 s1, 0
+; GFX1132DAGISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-FAKE16-NEXT:    s_ctz_i32_b32 s2, s0
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_bitset0_b32 s0, s2
+; GFX1132DAGISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cmp_lg_u32 s0, 0
+; GFX1132DAGISEL-FAKE16-NEXT:    v_sub_f32_e64 v3, s1, s3
+; GFX1132DAGISEL-FAKE16-NEXT:    v_readfirstlane_b32 s1, v3
+; GFX1132DAGISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132DAGISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v2, s1
+; GFX1132DAGISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132DAGISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132GISEL-FAKE16-LABEL: divergent_value_half:
+; GFX1132GISEL-FAKE16:       ; %bb.0: ; %entry
+; GFX1132GISEL-FAKE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132GISEL-FAKE16-NEXT:    v_cvt_f32_f16_e32 v2, v2
+; GFX1132GISEL-FAKE16-NEXT:    s_mov_b32 s0, exec_lo
+; GFX1132GISEL-FAKE16-NEXT:    s_mov_b32 s1, 0
+; GFX1132GISEL-FAKE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-FAKE16-NEXT:    s_ctz_i32_b32 s2, s0
+; GFX1132GISEL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132GISEL-FAKE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132GISEL-FAKE16-NEXT:    s_bitset0_b32 s0, s2
+; GFX1132GISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132GISEL-FAKE16-NEXT:    s_cmp_lg_u32 s0, 0
+; GFX1132GISEL-FAKE16-NEXT:    v_sub_f32_e64 v3, s1, s3
+; GFX1132GISEL-FAKE16-NEXT:    v_readfirstlane_b32 s1, v3
+; GFX1132GISEL-FAKE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132GISEL-FAKE16-NEXT:  ; %bb.2:
+; GFX1132GISEL-FAKE16-NEXT:    v_cvt_f16_f32_e32 v2, s1
+; GFX1132GISEL-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132GISEL-FAKE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164DAGISEL-TRUE16-LABEL: divergent_value_half:
+; GFX1164DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164DAGISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164DAGISEL-TRUE16-NEXT:    s_mov_b32 s2, 0
+; GFX1164DAGISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-TRUE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164DAGISEL-TRUE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164DAGISEL-TRUE16-NEXT:    v_sub_f32_e64 v3, s2, s4
+; GFX1164DAGISEL-TRUE16-NEXT:    v_readfirstlane_b32 s2, v3
+; GFX1164DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1164DAGISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v2.l, s2
+; GFX1164DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1164GISEL-TRUE16-LABEL: divergent_value_half:
+; GFX1164GISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1164GISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1164GISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
+; GFX1164GISEL-TRUE16-NEXT:    s_mov_b64 s[0:1], exec
+; GFX1164GISEL-TRUE16-NEXT:    s_mov_b32 s2, 0
+; GFX1164GISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-TRUE16-NEXT:    s_ctz_i32_b64 s3, s[0:1]
+; GFX1164GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1164GISEL-TRUE16-NEXT:    v_readlane_b32 s4, v2, s3
+; GFX1164GISEL-TRUE16-NEXT:    s_bitset0_b64 s[0:1], s3
+; GFX1164GISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1164GISEL-TRUE16-NEXT:    s_cmp_lg_u64 s[0:1], 0
+; GFX1164GISEL-TRUE16-NEXT:    v_sub_f32_e64 v3, s2, s4
+; GFX1164GISEL-TRUE16-NEXT:    v_readfirstlane_b32 s2, v3
+; GFX1164GISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164GISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1164GISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v2.l, s2
+; GFX1164GISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1164GISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132DAGISEL-TRUE16-LABEL: divergent_value_half:
+; GFX1132DAGISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132DAGISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s0, exec_lo
+; GFX1132DAGISEL-TRUE16-NEXT:    s_mov_b32 s1, 0
+; GFX1132DAGISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-TRUE16-NEXT:    s_ctz_i32_b32 s2, s0
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_bitset0_b32 s0, s2
+; GFX1132DAGISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cmp_lg_u32 s0, 0
+; GFX1132DAGISEL-TRUE16-NEXT:    v_sub_f32_e64 v3, s1, s3
+; GFX1132DAGISEL-TRUE16-NEXT:    v_readfirstlane_b32 s1, v3
+; GFX1132DAGISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132DAGISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1132DAGISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v2.l, s1
+; GFX1132DAGISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132DAGISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX1132GISEL-TRUE16-LABEL: divergent_value_half:
+; GFX1132GISEL-TRUE16:       ; %bb.0: ; %entry
+; GFX1132GISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; GFX1132GISEL-TRUE16-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
+; GFX1132GISEL-TRUE16-NEXT:    s_mov_b32 s0, exec_lo
+; GFX1132GISEL-TRUE16-NEXT:    s_mov_b32 s1, 0
+; GFX1132GISEL-TRUE16-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-TRUE16-NEXT:    s_ctz_i32_b32 s2, s0
+; GFX1132GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
+; GFX1132GISEL-TRUE16-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX1132GISEL-TRUE16-NEXT:    s_bitset0_b32 s0, s2
+; GFX1132GISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1132GISEL-TRUE16-NEXT:    s_cmp_lg_u32 s0, 0
+; GFX1132GISEL-TRUE16-NEXT:    v_sub_f32_e64 v3, s1, s3
+; GFX1132GISEL-TRUE16-NEXT:    v_readfirstlane_b32 s1, v3
+; GFX1132GISEL-TRUE16-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132GISEL-TRUE16-NEXT:  ; %bb.2:
+; GFX1132GISEL-TRUE16-NEXT:    v_cvt_f16_f32_e32 v2.l, s1
+; GFX1132GISEL-TRUE16-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX1132GISEL-TRUE16-NEXT:    s_setpc_b64 s[30:31]
+;
+; GFX12DAGISEL-LABEL: divergent_value_half:
+; GFX12DAGISEL:       ; %bb.0: ; %entry
+; GFX12DAGISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_expcnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_samplecnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_bvhcnt 0x0
+; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12DAGISEL-NEXT:    v_cvt_f32_f16_e32 v2, v2.l
+; GFX12DAGISEL-NEXT:    s_mov_b32 s0, exec_lo
+; GFX12DAGISEL-NEXT:    s_mov_b32 s1, 0
+; GFX12DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s2, s0
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    v_readlane_b32 s3, v2, s2
+; GFX12DAGISEL-NEXT:    s_bitset0_b32 s0, s2
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12DAGISEL-NEXT:    s_cmp_lg_u32 s0, 0
+; GFX12DAGISEL-NEXT:    v_sub_f32_e64 v3, s1, s3
+; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v3
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX12DAGISEL-NEXT:  ; %bb.2:
+; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX12DAGISEL-NEXT:    v_cvt_f16_f32_e32 v2.l, s1
+; GFX12DAGISEL-NEXT:    global_store_b16 v[0:1], v2, off
+; GFX12DAGISEL-NEXT:    s_setpc_b64 s[30:31]
+  entry:
+  %result = call half @llvm.amdgcn.wave.reduce.fsub(half %in, i32 1)
+  store half %result, ptr addrspace(1) %out
+  ret void
+}
 
 
 define amdgpu_kernel void @uniform_value_float(ptr addrspace(1) %out, float %in) #0 {
@@ -232,7 +974,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX8DAGISEL-NEXT:    s_mov_b32 s6, 0
-; GFX8DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s8
@@ -240,7 +982,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX8DAGISEL-NEXT:    v_sub_f32_e32 v3, s6, v3
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX8DAGISEL-NEXT:  ; %bb.2:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8DAGISEL-NEXT:    flat_store_dword v[0:1], v2
@@ -252,7 +994,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8GISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX8GISEL-NEXT:    s_mov_b32 s6, 0
-; GFX8GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX8GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s8
@@ -260,7 +1002,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX8GISEL-NEXT:    v_sub_f32_e32 v3, s6, v3
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX8GISEL-NEXT:  ; %bb.2:
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8GISEL-NEXT:    flat_store_dword v[0:1], v2
@@ -272,7 +1014,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX9DAGISEL-NEXT:    s_mov_b32 s6, 0
-; GFX9DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v3, s8
@@ -280,7 +1022,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX9DAGISEL-NEXT:    v_sub_f32_e32 v3, s6, v3
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX9DAGISEL-NEXT:  ; %bb.2:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -292,7 +1034,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9GISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX9GISEL-NEXT:    s_mov_b32 s6, 0
-; GFX9GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX9GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v3, s8
@@ -300,7 +1042,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX9GISEL-NEXT:    v_sub_f32_e32 v3, s6, v3
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX9GISEL-NEXT:  ; %bb.2:
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9GISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -312,14 +1054,14 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1064DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX1064DAGISEL-NEXT:    s_mov_b32 s6, 0
-; GFX1064DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1064DAGISEL-NEXT:    s_bitset0_b64 s[4:5], s7
 ; GFX1064DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX1064DAGISEL-NEXT:    v_sub_f32_e64 v3, s6, s8
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1064DAGISEL-NEXT:  ; %bb.2:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -330,14 +1072,14 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1064GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX1064GISEL-NEXT:    s_mov_b32 s6, 0
-; GFX1064GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s7, s[4:5]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1064GISEL-NEXT:    s_bitset0_b64 s[4:5], s7
 ; GFX1064GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX1064GISEL-NEXT:    v_sub_f32_e64 v3, s6, s8
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v3
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1064GISEL-NEXT:  ; %bb.2:
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064GISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -348,14 +1090,14 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1032DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s5, 0
-; GFX1032DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s6, s4
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s7, v2, s6
 ; GFX1032DAGISEL-NEXT:    s_bitset0_b32 s4, s6
 ; GFX1032DAGISEL-NEXT:    s_cmp_lg_u32 s4, 0
 ; GFX1032DAGISEL-NEXT:    v_sub_f32_e64 v3, s5, s7
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1032DAGISEL-NEXT:  ; %bb.2:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v2, s5
 ; GFX1032DAGISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -366,14 +1108,14 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1032GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1032GISEL-NEXT:    s_mov_b32 s4, exec_lo
 ; GFX1032GISEL-NEXT:    s_mov_b32 s5, 0
-; GFX1032GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s6, s4
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s7, v2, s6
 ; GFX1032GISEL-NEXT:    s_bitset0_b32 s4, s6
 ; GFX1032GISEL-NEXT:    s_cmp_lg_u32 s4, 0
 ; GFX1032GISEL-NEXT:    v_sub_f32_e64 v3, s5, s7
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v3
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1032GISEL-NEXT:  ; %bb.2:
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v2, s5
 ; GFX1032GISEL-NEXT:    global_store_dword v[0:1], v2, off
@@ -384,7 +1126,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1164DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[0:1], exec
 ; GFX1164DAGISEL-NEXT:    s_mov_b32 s2, 0
-; GFX1164DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s3, s[0:1]
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -393,7 +1135,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1164DAGISEL-NEXT:    v_sub_f32_e64 v3, s2, s4
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s2, v3
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1164DAGISEL-NEXT:  ; %bb.2:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164DAGISEL-NEXT:    global_store_b32 v[0:1], v2, off
@@ -404,7 +1146,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1164GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[0:1], exec
 ; GFX1164GISEL-NEXT:    s_mov_b32 s2, 0
-; GFX1164GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s3, s[0:1]
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -413,7 +1155,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1164GISEL-NEXT:    v_sub_f32_e64 v3, s2, s4
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s2, v3
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1164GISEL-NEXT:  ; %bb.2:
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164GISEL-NEXT:    global_store_b32 v[0:1], v2, off
@@ -424,7 +1166,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1132DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s0, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s1, 0
-; GFX1132DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s2, s0
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s3, v2, s2
@@ -433,7 +1175,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1132DAGISEL-NEXT:    v_sub_f32_e64 v3, s1, s3
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1132DAGISEL-NEXT:  ; %bb.2:
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v2, s1
 ; GFX1132DAGISEL-NEXT:    global_store_b32 v[0:1], v2, off
@@ -444,7 +1186,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1132GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1132GISEL-NEXT:    s_mov_b32 s0, exec_lo
 ; GFX1132GISEL-NEXT:    s_mov_b32 s1, 0
-; GFX1132GISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s2, s0
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s3, v2, s2
@@ -453,7 +1195,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX1132GISEL-NEXT:    v_sub_f32_e64 v3, s1, s3
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX1132GISEL-NEXT:  ; %bb.2:
 ; GFX1132GISEL-NEXT:    v_mov_b32_e32 v2, s1
 ; GFX1132GISEL-NEXT:    global_store_b32 v[0:1], v2, off
@@ -468,7 +1210,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s0, exec_lo
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s1, 0
-; GFX12DAGISEL-NEXT:  .LBB1_1: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB3_1: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s2, s0
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -479,7 +1221,7 @@ define void @divergent_value_float(ptr addrspace(1) %out, float %id.x) #0 {
 ; GFX12DAGISEL-NEXT:    v_sub_f32_e64 v3, s1, s3
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v3
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB1_1
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB3_1
 ; GFX12DAGISEL-NEXT:  ; %bb.2:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v2, s1
@@ -1869,7 +2611,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX8DAGISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX8DAGISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX8DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -1877,11 +2619,11 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8DAGISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX8DAGISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX8DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX8DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX8DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX8DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -1890,7 +2632,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8DAGISEL-NEXT:    v_mul_f32_e64 v0, -s1, v0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX8DAGISEL-NEXT:  .LBB4_4: ; %endif
+; GFX8DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX8DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX8DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -1907,7 +2649,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8GISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX8GISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX8GISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX8GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -1915,11 +2657,11 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8GISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX8GISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX8GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX8GISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX8GISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX8GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -1928,7 +2670,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX8GISEL-NEXT:    v_mul_f32_e64 v0, -s1, v0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX8GISEL-NEXT:  .LBB4_4: ; %endif
+; GFX8GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX8GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX8GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -1945,7 +2687,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX9DAGISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX9DAGISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX9DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9DAGISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -1953,11 +2695,11 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9DAGISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9DAGISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX9DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX9DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX9DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX9DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -1966,7 +2708,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9DAGISEL-NEXT:    v_mul_f32_e64 v0, -s1, v0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX9DAGISEL-NEXT:  .LBB4_4: ; %endif
+; GFX9DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX9DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX9DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -1982,7 +2724,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9GISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX9GISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX9GISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX9GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -1990,11 +2732,11 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9GISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX9GISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX9GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX9GISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX9GISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX9GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -2003,7 +2745,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX9GISEL-NEXT:    v_mul_f32_e64 v0, -s1, v0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX9GISEL-NEXT:  .LBB4_4: ; %endif
+; GFX9GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX9GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX9GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -2019,7 +2761,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX1064DAGISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1064DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064DAGISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -2027,11 +2769,11 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064DAGISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX1064DAGISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX1064DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1064DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1064DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -2040,7 +2782,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064DAGISEL-NEXT:    v_mul_f32_e64 v0, -s1, v0
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1064DAGISEL-NEXT:  .LBB4_4: ; %endif
+; GFX1064DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1064DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -2056,7 +2798,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064GISEL-NEXT:    ; implicit-def: $sgpr6
 ; GFX1064GISEL-NEXT:    s_and_saveexec_b64 s[2:3], vcc
 ; GFX1064GISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1064GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -2064,11 +2806,11 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064GISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX1064GISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX1064GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1064GISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX1064GISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1064GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -2077,7 +2819,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1064GISEL-NEXT:    v_mul_f32_e64 v0, -s1, v0
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1064GISEL-NEXT:  .LBB4_4: ; %endif
+; GFX1064GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1064GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
@@ -2093,7 +2835,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $sgpr3
 ; GFX1032DAGISEL-NEXT:    s_and_saveexec_b32 s2, vcc_lo
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 s2, exec_lo, s2
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1032DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_bcnt1_i32_b32 s3, s3
@@ -2101,12 +2843,12 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1032DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032DAGISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s3, v0
-; GFX1032DAGISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX1032DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1032DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032DAGISEL-NEXT:    s_or_saveexec_b32 s0, s2
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v0, s3
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s0
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1032DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_bcnt1_i32_b32 s2, s2
@@ -2114,7 +2856,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1032DAGISEL-NEXT:    v_mul_f32_e64 v0, -s1, v0
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s1, v0
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v0, s1
-; GFX1032DAGISEL-NEXT:  .LBB4_4: ; %endif
+; GFX1032DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1032DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX1032DAGISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v1, 0
@@ -2129,7 +2871,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1032GISEL-NEXT:    ; implicit-def: $sgpr3
 ; GFX1032GISEL-NEXT:    s_and_saveexec_b32 s2, vcc_lo
 ; GFX1032GISEL-NEXT:    s_xor_b32 s2, exec_lo, s2
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1032GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032GISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1032GISEL-NEXT:    s_bcnt1_i32_b32 s3, s3
@@ -2137,12 +2879,12 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1032GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032GISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s3, v0
-; GFX1032GISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX1032GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1032GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032GISEL-NEXT:    s_or_saveexec_b32 s0, s2
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v0, s3
 ; GFX1032GISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s0
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1032GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1032GISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1032GISEL-NEXT:    s_bcnt1_i32_b32 s2, s2
@@ -2150,7 +2892,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1032GISEL-NEXT:    v_mul_f32_e64 v0, -s1, v0
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s1, v0
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v0, s1
-; GFX1032GISEL-NEXT:  .LBB4_4: ; %endif
+; GFX1032GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1032GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX1032GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v1, 0
@@ -2167,7 +2909,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1164DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -2177,12 +2919,12 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX1164DAGISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX1164DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1164DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1164DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -2193,7 +2935,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1164DAGISEL-NEXT:  .LBB4_4: ; %endif
+; GFX1164DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1164DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1164DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
@@ -2211,7 +2953,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_cmpx_le_u32_e32 16, v0
 ; GFX1164GISEL-NEXT:    s_xor_b64 s[2:3], exec, s[2:3]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1164GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -2221,12 +2963,12 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s6, v0
-; GFX1164GISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX1164GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1164GISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[2:3]
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX1164GISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1164GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -2237,7 +2979,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s0, v0
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX1164GISEL-NEXT:  .LBB4_4: ; %endif
+; GFX1164GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1164GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1164GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1164GISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
@@ -2255,7 +2997,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 s2, exec_lo, s2
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1132DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -2265,13 +3007,13 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s3, v0
-; GFX1132DAGISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX1132DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1132DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1132DAGISEL-NEXT:    s_or_saveexec_b32 s0, s2
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v0, s3
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s0
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1132DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -2282,7 +3024,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v0
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v0, s1
-; GFX1132DAGISEL-NEXT:  .LBB4_4: ; %endif
+; GFX1132DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1132DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX1132DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v1, 0
@@ -2299,7 +3041,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_cmpx_le_u32_e32 16, v0
 ; GFX1132GISEL-NEXT:    s_xor_b32 s2, exec_lo, s2
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX1132GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132GISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -2309,13 +3051,13 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s3, v0
-; GFX1132GISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX1132GISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX1132GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1132GISEL-NEXT:    s_or_saveexec_b32 s0, s2
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_mov_b32_e32 v0, s3
 ; GFX1132GISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s0
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX1132GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1132GISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -2326,7 +3068,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s1, v0
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_mov_b32_e32 v0, s1
-; GFX1132GISEL-NEXT:  .LBB4_4: ; %endif
+; GFX1132GISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX1132GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX1132GISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
 ; GFX1132GISEL-NEXT:    v_mov_b32_e32 v1, 0
@@ -2343,7 +3085,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX12DAGISEL-NEXT:    s_xor_b32 s2, exec_lo, s2
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB4_2
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB6_2
 ; GFX12DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -2353,14 +3095,14 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_mul_f32_e64 v0, -s0, v0
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s3, v0
-; GFX12DAGISEL-NEXT:  .LBB4_2: ; %Flow
+; GFX12DAGISEL-NEXT:  .LBB6_2: ; %Flow
 ; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12DAGISEL-NEXT:    s_or_saveexec_b32 s0, s2
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v0, s3
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s0
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB4_4
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB6_4
 ; GFX12DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -2373,7 +3115,7 @@ define amdgpu_kernel void @divergent_cfg_float(ptr addrspace(1) %out, float %in,
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v0, s1
-; GFX12DAGISEL-NEXT:  .LBB4_4: ; %endif
+; GFX12DAGISEL-NEXT:  .LBB6_4: ; %endif
 ; GFX12DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX12DAGISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v1, 0
@@ -2634,7 +3376,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX8DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], 0
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX8DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX8DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX8DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -2645,7 +3387,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX8DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX8DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX8DAGISEL-NEXT:  ; %bb.2:
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2658,7 +3400,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX8GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], 0
 ; GFX8GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX8GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX8GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX8GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX8GISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -2669,7 +3411,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX8GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX8GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX8GISEL-NEXT:  ; %bb.2:
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2682,7 +3424,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX9DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[6:7], 0
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX9DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX9DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX9DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -2693,7 +3435,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX9DAGISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX9DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX9DAGISEL-NEXT:  ; %bb.2:
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2706,7 +3448,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX9GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], 0
 ; GFX9GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX9GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX9GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX9GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v4, s6
 ; GFX9GISEL-NEXT:    v_readlane_b32 s8, v2, s10
@@ -2717,7 +3459,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX9GISEL-NEXT:    s_cmp_lg_u64 s[4:5], 0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX9GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX9GISEL-NEXT:  ; %bb.2:
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2730,7 +3472,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1064DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[6:7], 0
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX1064DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064DAGISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1064DAGISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -2739,7 +3481,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1064DAGISEL-NEXT:    v_add_f64 v[4:5], -s[8:9], s[6:7]
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1064DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1064DAGISEL-NEXT:  ; %bb.2:
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2751,7 +3493,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1064GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], 0
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[4:5], exec
-; GFX1064GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1064GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1064GISEL-NEXT:    s_ff1_i32_b64 s10, s[4:5]
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s8, v2, s10
 ; GFX1064GISEL-NEXT:    v_readlane_b32 s9, v3, s10
@@ -2760,7 +3502,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1064GISEL-NEXT:    v_add_f64 v[4:5], -s[8:9], s[6:7]
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s6, v4
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s7, v5
-; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1064GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1064GISEL-NEXT:  ; %bb.2:
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v3, s7
@@ -2772,7 +3514,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1032DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1032DAGISEL-NEXT:    s_mov_b64 s[4:5], 0
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s6, exec_lo
-; GFX1032DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032DAGISEL-NEXT:    s_ff1_i32_b32 s7, s6
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032DAGISEL-NEXT:    v_readlane_b32 s9, v3, s7
@@ -2781,7 +3523,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1032DAGISEL-NEXT:    v_add_f64 v[4:5], -s[8:9], s[4:5]
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1032DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1032DAGISEL-NEXT:  ; %bb.2:
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -2793,7 +3535,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1032GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1032GISEL-NEXT:    s_mov_b64 s[4:5], 0
 ; GFX1032GISEL-NEXT:    s_mov_b32 s6, exec_lo
-; GFX1032GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1032GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1032GISEL-NEXT:    s_ff1_i32_b32 s7, s6
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s8, v2, s7
 ; GFX1032GISEL-NEXT:    v_readlane_b32 s9, v3, s7
@@ -2802,7 +3544,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1032GISEL-NEXT:    v_add_f64 v[4:5], -s[8:9], s[4:5]
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s4, v4
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v5
-; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1032GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1032GISEL-NEXT:  ; %bb.2:
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v2, s4
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v3, s5
@@ -2814,7 +3556,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1164DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[2:3], 0
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164DAGISEL-NEXT:    s_ctz_i32_b64 s6, s[0:1]
 ; GFX1164DAGISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -2826,7 +3568,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s2, v4
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s3, v5
-; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1164DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1164DAGISEL-NEXT:  ; %bb.2:
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v3, s3
@@ -2838,7 +3580,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1164GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[2:3], 0
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1164GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1164GISEL-NEXT:    s_ctz_i32_b64 s6, s[0:1]
 ; GFX1164GISEL-NEXT:    v_readlane_b32 s4, v2, s6
@@ -2850,7 +3592,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s2, v4
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s3, v5
-; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1164GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1164GISEL-NEXT:  ; %bb.2:
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v3, s3
@@ -2862,7 +3604,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1132DAGISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1132DAGISEL-NEXT:    s_mov_b64 s[0:1], 0
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX1132DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132DAGISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX1132DAGISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -2874,7 +3616,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1132DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1132DAGISEL-NEXT:  ; %bb.2:
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
 ; GFX1132DAGISEL-NEXT:    global_store_b64 v[0:1], v[2:3], off
@@ -2885,7 +3627,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1132GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX1132GISEL-NEXT:    s_mov_b64 s[0:1], 0
 ; GFX1132GISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX1132GISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX1132GISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
 ; GFX1132GISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX1132GISEL-NEXT:    v_readlane_b32 s4, v2, s3
@@ -2897,7 +3639,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX1132GISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX1132GISEL-NEXT:  ; %bb.2:
 ; GFX1132GISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
 ; GFX1132GISEL-NEXT:    global_store_b64 v[0:1], v[2:3], off
@@ -2912,7 +3654,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12DAGISEL-NEXT:    s_mov_b64 s[0:1], 0
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s2, exec_lo
-; GFX12DAGISEL-NEXT:  .LBB6_1: ; =>This Inner Loop Header: Depth=1
+; GFX12DAGISEL-NEXT:  .LBB8_1: ; =>This Inner Loop Header: Depth=1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_ctz_i32_b32 s3, s2
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -2925,7 +3667,7 @@ define void @divergent_value_double(ptr addrspace(1) %out, double %id.x) #0 {
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s0, v4
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s1, v5
-; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB6_1
+; GFX12DAGISEL-NEXT:    s_cbranch_scc1 .LBB8_1
 ; GFX12DAGISEL-NEXT:  ; %bb.2:
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v3, s1 :: v_dual_mov_b32 v2, s0
@@ -2946,7 +3688,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8DAGISEL-NEXT:    ; implicit-def: $sgpr6_sgpr7
 ; GFX8DAGISEL-NEXT:    s_and_saveexec_b64 s[8:9], vcc
 ; GFX8DAGISEL-NEXT:    s_xor_b64 s[8:9], exec, s[8:9]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX8DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -2955,13 +3697,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8DAGISEL-NEXT:    v_mul_f64 v[0:1], -s[2:3], v[0:1]
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX8DAGISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX8DAGISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX8DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[8:9]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v1, s7
 ; GFX8DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX8DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX8DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX8DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8DAGISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -2971,7 +3713,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX8DAGISEL-NEXT:  .LBB7_4: ; %endif
+; GFX8DAGISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX8DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v2, s0
 ; GFX8DAGISEL-NEXT:    v_mov_b32_e32 v3, s1
@@ -2985,7 +3727,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8GISEL-NEXT:    ; implicit-def: $sgpr6_sgpr7
 ; GFX8GISEL-NEXT:    s_and_saveexec_b64 s[8:9], vcc
 ; GFX8GISEL-NEXT:    s_xor_b64 s[8:9], exec, s[8:9]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX8GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -2994,13 +3736,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8GISEL-NEXT:    v_mul_f64 v[0:1], -s[2:3], v[0:1]
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX8GISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX8GISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX8GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8GISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[8:9]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v1, s7
 ; GFX8GISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX8GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX8GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX8GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX8GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX8GISEL-NEXT:    s_load_dwordx2 s[4:5], s[4:5], 0x34
@@ -3012,7 +3754,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX8GISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX8GISEL-NEXT:  .LBB7_4: ; %endif
+; GFX8GISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX8GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v3, s1
 ; GFX8GISEL-NEXT:    v_mov_b32_e32 v2, s0
@@ -3027,7 +3769,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9DAGISEL-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GFX9DAGISEL-NEXT:    s_and_saveexec_b64 s[8:9], vcc
 ; GFX9DAGISEL-NEXT:    s_xor_b64 s[8:9], exec, s[8:9]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX9DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX9DAGISEL-NEXT:    s_bcnt1_i32_b64 s4, s[4:5]
@@ -3036,13 +3778,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9DAGISEL-NEXT:    v_mul_f64 v[0:1], -s[2:3], v[0:1]
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s4, v0
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX9DAGISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX9DAGISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX9DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[8:9]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
 ; GFX9DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX9DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX9DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX9DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX9DAGISEL-NEXT:    s_bcnt1_i32_b64 s4, s[4:5]
@@ -3052,7 +3794,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9DAGISEL-NEXT:  .LBB7_4: ; %endif
+; GFX9DAGISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX9DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX9DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX9DAGISEL-NEXT:    global_store_dwordx2 v2, v[0:1], s[0:1]
@@ -3065,7 +3807,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9GISEL-NEXT:    ; implicit-def: $sgpr6_sgpr7
 ; GFX9GISEL-NEXT:    s_and_saveexec_b64 s[8:9], vcc
 ; GFX9GISEL-NEXT:    s_xor_b64 s[8:9], exec, s[8:9]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX9GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX9GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX9GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -3074,13 +3816,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9GISEL-NEXT:    v_mul_f64 v[0:1], -s[2:3], v[0:1]
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX9GISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX9GISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX9GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9GISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[8:9]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v1, s7
 ; GFX9GISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX9GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX9GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX9GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX9GISEL-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x34
 ; GFX9GISEL-NEXT:    s_mov_b64 s[4:5], exec
@@ -3092,7 +3834,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX9GISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX9GISEL-NEXT:  .LBB7_4: ; %endif
+; GFX9GISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX9GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX9GISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX9GISEL-NEXT:    global_store_dwordx2 v2, v[0:1], s[0:1]
@@ -3107,7 +3849,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064DAGISEL-NEXT:    ; implicit-def: $sgpr8_sgpr9
 ; GFX1064DAGISEL-NEXT:    s_and_saveexec_b64 s[4:5], vcc
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 s[4:5], exec, s[4:5]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX1064DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[8:9], exec
 ; GFX1064DAGISEL-NEXT:    s_bcnt1_i32_b64 s8, s[8:9]
@@ -3116,13 +3858,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064DAGISEL-NEXT:    v_mul_f64 v[0:1], -s[2:3], v[0:1]
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s8, v0
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s9, v1
-; GFX1064DAGISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX1064DAGISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX1064DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[4:5]
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v0, s8
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v1, s9
 ; GFX1064DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1064DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1064DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1064DAGISEL-NEXT:    s_mov_b64 s[4:5], exec
 ; GFX1064DAGISEL-NEXT:    s_bcnt1_i32_b64 s4, s[4:5]
@@ -3132,7 +3874,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX1064DAGISEL-NEXT:  .LBB7_4: ; %endif
+; GFX1064DAGISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX1064DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1064DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1064DAGISEL-NEXT:    global_store_dwordx2 v2, v[0:1], s[0:1]
@@ -3145,7 +3887,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064GISEL-NEXT:    ; implicit-def: $sgpr8_sgpr9
 ; GFX1064GISEL-NEXT:    s_and_saveexec_b64 s[6:7], vcc
 ; GFX1064GISEL-NEXT:    s_xor_b64 s[6:7], exec, s[6:7]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX1064GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[8:9], exec
 ; GFX1064GISEL-NEXT:    s_bcnt1_i32_b64 s8, s[8:9]
@@ -3154,13 +3896,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064GISEL-NEXT:    v_mul_f64 v[0:1], -s[2:3], v[0:1]
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s8, v0
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s9, v1
-; GFX1064GISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX1064GISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX1064GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1064GISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[6:7]
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v0, s8
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v1, s9
 ; GFX1064GISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1064GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1064GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1064GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1064GISEL-NEXT:    s_bcnt1_i32_b64 s6, s[6:7]
@@ -3172,7 +3914,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1064GISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX1064GISEL-NEXT:  .LBB7_4: ; %endif
+; GFX1064GISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX1064GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1064GISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1064GISEL-NEXT:    global_store_dwordx2 v2, v[0:1], s[0:1]
@@ -3187,7 +3929,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032DAGISEL-NEXT:    ; implicit-def: $sgpr4_sgpr5
 ; GFX1032DAGISEL-NEXT:    s_and_saveexec_b32 s8, vcc_lo
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 s8, exec_lo, s8
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX1032DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s4, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_bcnt1_i32_b32 s4, s4
@@ -3196,13 +3938,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032DAGISEL-NEXT:    v_mul_f64 v[0:1], -s[2:3], v[0:1]
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s4, v0
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
-; GFX1032DAGISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX1032DAGISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX1032DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032DAGISEL-NEXT:    s_or_saveexec_b32 s2, s8
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
 ; GFX1032DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s2
-; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1032DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1032DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1032DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1032DAGISEL-NEXT:    s_bcnt1_i32_b32 s3, s3
@@ -3212,7 +3954,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX1032DAGISEL-NEXT:  .LBB7_4: ; %endif
+; GFX1032DAGISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX1032DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1032DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1032DAGISEL-NEXT:    global_store_dwordx2 v2, v[0:1], s[0:1]
@@ -3225,7 +3967,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032GISEL-NEXT:    ; implicit-def: $sgpr6_sgpr7
 ; GFX1032GISEL-NEXT:    s_and_saveexec_b32 s8, vcc_lo
 ; GFX1032GISEL-NEXT:    s_xor_b32 s8, exec_lo, s8
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX1032GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1032GISEL-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX1032GISEL-NEXT:    s_bcnt1_i32_b32 s6, s6
@@ -3234,13 +3976,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032GISEL-NEXT:    v_mul_f64 v[0:1], -s[2:3], v[0:1]
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1032GISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX1032GISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX1032GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1032GISEL-NEXT:    s_or_saveexec_b32 s2, s8
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v1, s7
 ; GFX1032GISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s2
-; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1032GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1032GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1032GISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1032GISEL-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x34
@@ -3252,7 +3994,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1032GISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX1032GISEL-NEXT:  .LBB7_4: ; %endif
+; GFX1032GISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX1032GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1032GISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1032GISEL-NEXT:    global_store_dwordx2 v2, v[0:1], s[0:1]
@@ -3269,7 +4011,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 s[6:7], exec, s[6:7]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX1164DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[8:9], exec
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -3281,14 +4023,14 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s8, v0
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_readfirstlane_b32 s9, v1
-; GFX1164DAGISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX1164DAGISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX1164DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1164DAGISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[6:7]
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, s8
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v1, s9
 ; GFX1164DAGISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1164DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1164DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1164DAGISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -3302,7 +4044,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX1164DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX1164DAGISEL-NEXT:  .LBB7_4: ; %endif
+; GFX1164DAGISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX1164DAGISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1164DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1164DAGISEL-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
@@ -3317,7 +4059,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1164GISEL-NEXT:    v_cmpx_le_u32_e32 16, v0
 ; GFX1164GISEL-NEXT:    s_xor_b64 s[6:7], exec, s[6:7]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX1164GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[8:9], exec
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -3329,14 +4071,14 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s8, v0
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_readfirstlane_b32 s9, v1
-; GFX1164GISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX1164GISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX1164GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1164GISEL-NEXT:    s_or_saveexec_b64 s[2:3], s[6:7]
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v0, s8
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v1, s9
 ; GFX1164GISEL-NEXT:    s_xor_b64 exec, exec, s[2:3]
-; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1164GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1164GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1164GISEL-NEXT:    s_mov_b64 s[6:7], exec
 ; GFX1164GISEL-NEXT:    s_load_b64 s[4:5], s[4:5], 0x34
@@ -3351,7 +4093,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1164GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v1, s5
-; GFX1164GISEL-NEXT:  .LBB7_4: ; %endif
+; GFX1164GISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX1164GISEL-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; GFX1164GISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1164GISEL-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
@@ -3368,7 +4110,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 s8, exec_lo, s8
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX1132DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -3380,13 +4122,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1132DAGISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX1132DAGISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX1132DAGISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1132DAGISEL-NEXT:    s_or_saveexec_b32 s2, s8
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v0, s6 :: v_dual_mov_b32 v1, s7
 ; GFX1132DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s2
-; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1132DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1132DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1132DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -3398,7 +4140,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX1132DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX1132DAGISEL-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v1, s5
-; GFX1132DAGISEL-NEXT:  .LBB7_4: ; %endif
+; GFX1132DAGISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX1132DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1132DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1132DAGISEL-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
@@ -3413,7 +4155,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_cmpx_le_u32_e32 16, v0
 ; GFX1132GISEL-NEXT:    s_xor_b32 s8, exec_lo, s8
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX1132GISEL-NEXT:  ; %bb.1: ; %else
 ; GFX1132GISEL-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -3425,13 +4167,13 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX1132GISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX1132GISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX1132GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX1132GISEL-NEXT:    s_or_saveexec_b32 s2, s8
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_dual_mov_b32 v0, s6 :: v_dual_mov_b32 v1, s7
 ; GFX1132GISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s2
-; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX1132GISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX1132GISEL-NEXT:  ; %bb.3: ; %if
 ; GFX1132GISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX1132GISEL-NEXT:    s_load_b64 s[4:5], s[4:5], 0x34
@@ -3445,7 +4187,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX1132GISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX1132GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1132GISEL-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v1, s5
-; GFX1132GISEL-NEXT:  .LBB7_4: ; %endif
+; GFX1132GISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX1132GISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX1132GISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX1132GISEL-NEXT:    global_store_b64 v2, v[0:1], s[0:1]
@@ -3462,7 +4204,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12DAGISEL-NEXT:    v_cmpx_lt_u32_e32 15, v0
 ; GFX12DAGISEL-NEXT:    s_xor_b32 s8, exec_lo, s8
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB7_2
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB9_2
 ; GFX12DAGISEL-NEXT:  ; %bb.1: ; %else
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
@@ -3474,7 +4216,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; GFX12DAGISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s7, v1
-; GFX12DAGISEL-NEXT:  .LBB7_2: ; %Flow
+; GFX12DAGISEL-NEXT:  .LBB9_2: ; %Flow
 ; GFX12DAGISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12DAGISEL-NEXT:    s_or_saveexec_b32 s2, s8
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
@@ -3482,7 +4224,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v0, s6 :: v_dual_mov_b32 v1, s7
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12DAGISEL-NEXT:    s_xor_b32 exec_lo, exec_lo, s2
-; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB7_4
+; GFX12DAGISEL-NEXT:    s_cbranch_execz .LBB9_4
 ; GFX12DAGISEL-NEXT:  ; %bb.3: ; %if
 ; GFX12DAGISEL-NEXT:    s_mov_b32 s3, exec_lo
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
@@ -3496,7 +4238,7 @@ define amdgpu_kernel void @divergent_cfg_double(ptr addrspace(1) %out, double %i
 ; GFX12DAGISEL-NEXT:    v_readfirstlane_b32 s5, v1
 ; GFX12DAGISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12DAGISEL-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v1, s5
-; GFX12DAGISEL-NEXT:  .LBB7_4: ; %endif
+; GFX12DAGISEL-NEXT:  .LBB9_4: ; %endif
 ; GFX12DAGISEL-NEXT:    s_or_b32 exec_lo, exec_lo, s2
 ; GFX12DAGISEL-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX12DAGISEL-NEXT:    global_store_b64 v2, v[0:1], s[0:1]


### PR DESCRIPTION
Supported Ops: `fmin`, `fmax`, `fadd`, `fsub`.