### PR TITLE
[Demangle] Guard DEMANGLE_ABI and add missing annotation

### DIFF
--- a/libcxxabi/src/demangle/Utility.h
+++ b/libcxxabi/src/demangle/Utility.h
@@ -31,7 +31,7 @@ class Node;
 
 // Stream that AST nodes write their string representation into after the AST
 // has been parsed.
-class OutputBuffer {
+class DEMANGLE_ABI OutputBuffer {
   char *Buffer = nullptr;
   size_t CurrentPosition = 0;
   size_t BufferCapacity = 0;

--- a/llvm/include/llvm/Demangle/DemangleConfig.h
+++ b/llvm/include/llvm/Demangle/DemangleConfig.h
@@ -97,24 +97,36 @@
 #define DEMANGLE_NAMESPACE_BEGIN namespace llvm { namespace itanium_demangle {
 #define DEMANGLE_NAMESPACE_END } }
 
-/// DEMANGLE_ABI is the export/visibility macro used to mark symbols delcared in
+/// DEMANGLE_ABI is the export/visibility macro used to mark symbols declared in
 /// llvm/Demangle as exported when built as a shared library.
+#if !defined(DEMANGLE_ABI)
+
 #if defined(LLVM_BUILD_STATIC) || !defined(LLVM_ENABLE_LLVM_EXPORT_ANNOTATIONS)
+
 #define DEMANGLE_ABI
-#else
+
+#else // !(defined(LLVM_BUILD_STATIC) || [...])
+
 #if defined(_WIN32) && !defined(__MINGW32__)
+
 #if defined(LLVM_EXPORTS)
 #define DEMANGLE_ABI __declspec(dllexport)
-#else
+#else // !defined(LLVM_EXPORTS)
 #define DEMANGLE_ABI __declspec(dllimport)
-#endif
-#else
+#endif // defined(LLVM_EXPORTS)
+
+#else // !(defined(_WIN32) && !defined(__MINGW32__))
+
 #if __has_attribute(visibility)
 #define DEMANGLE_ABI __attribute__((__visibility__("default")))
-#else
+#else // !__has_attribute(visibility)
 #define DEMANGLE_ABI
-#endif
-#endif
-#endif
+#endif // __has_attribute(visibility)
+
+#endif // defined(_WIN32) && !defined(__MINGW32__)
+
+#endif // defined(LLVM_BUILD_STATIC) || [...]
+
+#endif // !defined(DEMANGLE_ABI)
 
 #endif

--- a/llvm/include/llvm/Demangle/DemangleConfig.h
+++ b/llvm/include/llvm/Demangle/DemangleConfig.h
@@ -99,34 +99,27 @@
 
 /// DEMANGLE_ABI is the export/visibility macro used to mark symbols declared in
 /// llvm/Demangle as exported when built as a shared library.
+// clang-format off
+// Autoformatting removes indentation, making this harder to read.
 #if !defined(DEMANGLE_ABI)
-
-#if defined(LLVM_BUILD_STATIC) || !defined(LLVM_ENABLE_LLVM_EXPORT_ANNOTATIONS)
-
-#define DEMANGLE_ABI
-
-#else // !(defined(LLVM_BUILD_STATIC) || [...])
-
-#if defined(_WIN32) && !defined(__MINGW32__)
-
-#if defined(LLVM_EXPORTS)
-#define DEMANGLE_ABI __declspec(dllexport)
-#else // !defined(LLVM_EXPORTS)
-#define DEMANGLE_ABI __declspec(dllimport)
-#endif // defined(LLVM_EXPORTS)
-
-#else // !(defined(_WIN32) && !defined(__MINGW32__))
-
-#if __has_attribute(visibility)
-#define DEMANGLE_ABI __attribute__((__visibility__("default")))
-#else // !__has_attribute(visibility)
-#define DEMANGLE_ABI
-#endif // __has_attribute(visibility)
-
-#endif // defined(_WIN32) && !defined(__MINGW32__)
-
-#endif // defined(LLVM_BUILD_STATIC) || [...]
-
-#endif // !defined(DEMANGLE_ABI)
+# if defined(LLVM_BUILD_STATIC) || !defined(LLVM_ENABLE_LLVM_EXPORT_ANNOTATIONS)
+#  define DEMANGLE_ABI
+# else
+#  if defined(_WIN32) && !defined(__MINGW32__)
+#   if defined(LLVM_EXPORTS)
+#    define DEMANGLE_ABI __declspec(dllexport)
+#   else
+#    define DEMANGLE_ABI __declspec(dllimport)
+#   endif
+#  else
+#   if __has_attribute(visibility)
+#    define DEMANGLE_ABI __attribute__((__visibility__("default")))
+#   else
+#    define DEMANGLE_ABI
+#   endif
+#  endif
+# endif
+#endif
+// clang-format on
 
 #endif

--- a/llvm/include/llvm/Demangle/Utility.h
+++ b/llvm/include/llvm/Demangle/Utility.h
@@ -31,7 +31,7 @@ class Node;
 
 // Stream that AST nodes write their string representation into after the AST
 // has been parsed.
-class OutputBuffer {
+class DEMANGLE_ABI OutputBuffer {
   char *Buffer = nullptr;
   size_t CurrentPosition = 0;
   size_t BufferCapacity = 0;


### PR DESCRIPTION
This updates the DEMANGLE_ABI annotation to only be defined if it is not already defined. This is required to parse the Demangle headers with the ids-check script.
In addition, this adds one missing DEMANGLE_ABI annotation.

This effort is tracked in #109483.