### PR TITLE
[lldb][NFC] Return unique_ptr in AppleObjCRuntimeV2::TaggedPointerVendorLegacy::GetClassDescriptor

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -3091,16 +3091,16 @@ bool AppleObjCRuntimeV2::TaggedPointerVendorLegacy::IsPossibleTaggedPointer(
   return (ptr & 1);
 }
 
-ObjCLanguageRuntime::ClassDescriptorSP
+std::unique_ptr<ObjCLanguageRuntime::ClassDescriptor>
 AppleObjCRuntimeV2::TaggedPointerVendorLegacy::GetClassDescriptor(
     lldb::addr_t ptr) {
   if (!IsPossibleTaggedPointer(ptr))
-    return ObjCLanguageRuntime::ClassDescriptorSP();
+    return nullptr;
 
   uint32_t foundation_version = m_runtime.GetFoundationVersion();
 
   if (foundation_version == LLDB_INVALID_MODULE_VERSION)
-    return ObjCLanguageRuntime::ClassDescriptorSP();
+    return nullptr;
 
   uint64_t class_bits = (ptr & 0xE) >> 1;
   ConstString name;
@@ -3129,7 +3129,7 @@ AppleObjCRuntimeV2::TaggedPointerVendorLegacy::GetClassDescriptor(
       name = g_NSDate;
       break;
     default:
-      return ObjCLanguageRuntime::ClassDescriptorSP();
+      return nullptr;
     }
   } else {
     switch (class_bits) {
@@ -3146,12 +3146,12 @@ AppleObjCRuntimeV2::TaggedPointerVendorLegacy::GetClassDescriptor(
       name = g_NSDateTS;
       break;
     default:
-      return ObjCLanguageRuntime::ClassDescriptorSP();
+      return nullptr;
     }
   }
 
   lldb::addr_t unobfuscated = ptr ^ m_runtime.GetTaggedPointerObfuscator();
-  return ClassDescriptorSP(new ClassDescriptorV2Tagged(name, unobfuscated));
+  return std::make_unique<ClassDescriptorV2Tagged>(name, unobfuscated);
 }
 
 AppleObjCRuntimeV2::TaggedPointerVendorRuntimeAssisted::
@@ -3178,14 +3178,14 @@ bool AppleObjCRuntimeV2::TaggedPointerVendorRuntimeAssisted::
   return (ptr & m_objc_debug_taggedpointer_mask) != 0;
 }
 
-ObjCLanguageRuntime::ClassDescriptorSP
+std::unique_ptr<ObjCLanguageRuntime::ClassDescriptor>
 AppleObjCRuntimeV2::TaggedPointerVendorRuntimeAssisted::GetClassDescriptor(
     lldb::addr_t ptr) {
   ClassDescriptorSP actual_class_descriptor_sp;
   uint64_t unobfuscated = (ptr) ^ m_runtime.GetTaggedPointerObfuscator();
 
   if (!IsPossibleTaggedPointer(unobfuscated))
-    return ObjCLanguageRuntime::ClassDescriptorSP();
+    return nullptr;
 
   uintptr_t slot = (ptr >> m_objc_debug_taggedpointer_slot_shift) &
                    m_objc_debug_taggedpointer_slot_mask;
@@ -3212,7 +3212,7 @@ AppleObjCRuntimeV2::TaggedPointerVendorRuntimeAssisted::GetClassDescriptor(
       }
     }
     if (!actual_class_descriptor_sp)
-      return ObjCLanguageRuntime::ClassDescriptorSP();
+      return nullptr;
     m_cache[slot] = actual_class_descriptor_sp;
   }
 
@@ -3222,8 +3222,8 @@ AppleObjCRuntimeV2::TaggedPointerVendorRuntimeAssisted::GetClassDescriptor(
   int64_t data_payload_signed =
       ((int64_t)(unobfuscated << m_objc_debug_taggedpointer_payload_lshift) >>
        m_objc_debug_taggedpointer_payload_rshift);
-  return ClassDescriptorSP(new ClassDescriptorV2Tagged(
-      actual_class_descriptor_sp, data_payload, data_payload_signed));
+  return std::make_unique<ClassDescriptorV2Tagged>(
+      actual_class_descriptor_sp, data_payload, data_payload_signed);
 }
 
 AppleObjCRuntimeV2::TaggedPointerVendorExtended::TaggedPointerVendorExtended(
@@ -3271,14 +3271,14 @@ bool AppleObjCRuntimeV2::TaggedPointerVendorExtended::
           m_objc_debug_taggedpointer_ext_mask);
 }
 
-ObjCLanguageRuntime::ClassDescriptorSP
+std::unique_ptr<ObjCLanguageRuntime::ClassDescriptor>
 AppleObjCRuntimeV2::TaggedPointerVendorExtended::GetClassDescriptor(
     lldb::addr_t ptr) {
   ClassDescriptorSP actual_class_descriptor_sp;
   uint64_t unobfuscated = (ptr) ^ m_runtime.GetTaggedPointerObfuscator();
 
   if (!IsPossibleTaggedPointer(unobfuscated))
-    return ObjCLanguageRuntime::ClassDescriptorSP();
+    return nullptr;
 
   if (!IsPossibleExtendedTaggedPointer(unobfuscated))
     return this->TaggedPointerVendorRuntimeAssisted::GetClassDescriptor(ptr);
@@ -3301,7 +3301,7 @@ AppleObjCRuntimeV2::TaggedPointerVendorExtended::GetClassDescriptor(
     actual_class_descriptor_sp =
         m_runtime.GetClassDescriptorFromISA((ObjCISA)slot_data);
     if (!actual_class_descriptor_sp)
-      return ObjCLanguageRuntime::ClassDescriptorSP();
+      return nullptr;
     m_ext_cache[slot] = actual_class_descriptor_sp;
   }
 
@@ -3313,8 +3313,8 @@ AppleObjCRuntimeV2::TaggedPointerVendorExtended::GetClassDescriptor(
                  << m_objc_debug_taggedpointer_ext_payload_lshift) >>
        m_objc_debug_taggedpointer_ext_payload_rshift);
 
-  return ClassDescriptorSP(new ClassDescriptorV2Tagged(
-      actual_class_descriptor_sp, data_payload, data_payload_signed));
+  return std::make_unique<ClassDescriptorV2Tagged>(
+      actual_class_descriptor_sp, data_payload, data_payload_signed);
 }
 
 AppleObjCRuntimeV2::NonPointerISACache::NonPointerISACache(

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.h
@@ -198,7 +198,7 @@ private:
   public:
     bool IsPossibleTaggedPointer(lldb::addr_t ptr) override;
 
-    ObjCLanguageRuntime::ClassDescriptorSP
+    std::unique_ptr<ObjCLanguageRuntime::ClassDescriptor>
     GetClassDescriptor(lldb::addr_t ptr) override;
 
   protected:
@@ -231,7 +231,7 @@ private:
   class TaggedPointerVendorExtended
       : public TaggedPointerVendorRuntimeAssisted {
   public:
-    ObjCLanguageRuntime::ClassDescriptorSP
+    std::unique_ptr<ObjCLanguageRuntime::ClassDescriptor>
     GetClassDescriptor(lldb::addr_t ptr) override;
 
   protected:
@@ -272,7 +272,7 @@ private:
   public:
     bool IsPossibleTaggedPointer(lldb::addr_t ptr) override;
 
-    ObjCLanguageRuntime::ClassDescriptorSP
+    std::unique_ptr<ObjCLanguageRuntime::ClassDescriptor>
     GetClassDescriptor(lldb::addr_t ptr) override;
 
   protected:

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
@@ -198,7 +198,7 @@ public:
 
     virtual bool IsPossibleTaggedPointer(lldb::addr_t ptr) = 0;
 
-    virtual ObjCLanguageRuntime::ClassDescriptorSP
+    virtual std::unique_ptr<ClassDescriptor>
     GetClassDescriptor(lldb::addr_t ptr) = 0;
 
   protected:


### PR DESCRIPTION

There is no reason to use a shared_pointer here.