### PR TITLE
[clang][PS5] Clang driver PS5 - pass the target CPU to lld.

### DIFF
--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "PS4CPU.h"
+#include "Arch/X86.h"
 #include "clang/Config/config.h"
 #include "clang/Driver/CommonArgs.h"
 #include "clang/Driver/Compilation.h"
@@ -177,6 +178,9 @@ void tools::PS4cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 
   if (StringRef Threads = getLTOParallelism(Args, D); !Threads.empty())
     AddLTOFlag(Twine("-threads=") + Threads);
+
+  std::string CPU = tools::x86::getX86TargetCPU(D, Args, TC.getTriple());
+  AddLTOFlag(Twine("mcpu=" + CPU));
 
   if (*LTOArgs)
     CmdArgs.push_back(

--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -179,9 +179,6 @@ void tools::PS4cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   if (StringRef Threads = getLTOParallelism(Args, D); !Threads.empty())
     AddLTOFlag(Twine("-threads=") + Threads);
 
-  std::string CPU = tools::x86::getX86TargetCPU(D, Args, TC.getTriple());
-  AddLTOFlag(Twine("mcpu=" + CPU));
-
   if (*LTOArgs)
     CmdArgs.push_back(
         Args.MakeArgString(Twine("-lto-debug-options=") + LTOArgs));
@@ -373,6 +370,9 @@ void tools::PS5cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 
   if (StringRef Jobs = getLTOParallelism(Args, D); !Jobs.empty())
     AddLTOFlag(Twine("jobs=") + Jobs);
+
+  std::string CPU = tools::x86::getX86TargetCPU(D, Args, TC.getTriple());
+  AddLTOFlag(Twine("mcpu=" + CPU));
 
   Args.AddAllArgs(CmdArgs, options::OPT_L);
   TC.AddFilePathLibArgs(Args, CmdArgs);

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -220,3 +220,9 @@
 // CHECK-NO-FAT-LTO: {{ld(\.exe)?}}"
 // CHECK-NO-FAT-LTO-NOT: "--fat-lto-objects"
 // CHECK-NO-FAT-LTO-SAME: {{$}}
+
+// Check -plugin-opt=mcpu=znver2s is passed to prospero-lld.
+// RUN: %clang --target=x86_64-sie-ps5 %s -### 2>&1 | FileCheck --check-prefixes=CHECK-CLANG-TARGET-CPU %s
+
+// CHECK-CLANG-TARGET-CPU: {{ld(\.exe)?}}"
+// CHECK-CLANG-TARGET-CPU: "-plugin-opt=mcpu=znver2s"

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -221,7 +221,7 @@
 // CHECK-NO-FAT-LTO-NOT: "--fat-lto-objects"
 // CHECK-NO-FAT-LTO-SAME: {{$}}
 
-// Check -plugin-opt=mcpu=znver2s is passed to prospero-lld.
+// Check -plugin-opt=mcpu=znver2 is passed to prospero-lld.
 // RUN: %clang --target=x86_64-sie-ps5 %s -### 2>&1 | FileCheck --check-prefixes=CHECK-CLANG-TARGET-CPU %s
 
 // CHECK-CLANG-TARGET-CPU: {{ld(\.exe)?}}"

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -225,4 +225,4 @@
 // RUN: %clang --target=x86_64-sie-ps5 %s -### 2>&1 | FileCheck --check-prefixes=CHECK-CLANG-TARGET-CPU %s
 
 // CHECK-CLANG-TARGET-CPU: {{ld(\.exe)?}}"
-// CHECK-CLANG-TARGET-CPU: "-plugin-opt=mcpu=znver2s"
+// CHECK-CLANG-TARGET-CPU: "-plugin-opt=mcpu=znver2"


### PR DESCRIPTION
Forward the PS5 target CPU from the clang driver to lld as `-plugin-opt=mcpu=znver2`, matching behavior of other platforms. 