### PR TITLE
[llvm] Fix most LLVM_ABI annotations in ExecutionEngine

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/JITLink/COFF.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/COFF.h
@@ -23,7 +23,7 @@ namespace jitlink {
 /// Note: The graph does not take ownership of the underlying buffer, nor copy
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
-Expected<std::unique_ptr<LinkGraph>>
+LLVM_ABI Expected<std::unique_ptr<LinkGraph>>
 createLinkGraphFromCOFFObject(MemoryBufferRef ObjectBuffer,
                               std::shared_ptr<orc::SymbolStringPool> SSP);
 
@@ -31,8 +31,8 @@ createLinkGraphFromCOFFObject(MemoryBufferRef ObjectBuffer,
 ///
 /// Uses conservative defaults for GOT and stub handling based on the target
 /// platform.
-void link_COFF(std::unique_ptr<LinkGraph> G,
-               std::unique_ptr<JITLinkContext> Ctx);
+LLVM_ABI void link_COFF(std::unique_ptr<LinkGraph> G,
+                        std::unique_ptr<JITLinkContext> Ctx);
 
 /// GetImageBaseSymbol is a function object that finds the __ImageBase symbol
 /// in the given graph if one is present.
@@ -43,7 +43,7 @@ class GetImageBaseSymbol {
 public:
   GetImageBaseSymbol(StringRef ImageBaseName = "__ImageBase")
       : ImageBaseName(ImageBaseName) {}
-  Symbol *operator()(LinkGraph &G);
+  LLVM_ABI Symbol *operator()(LinkGraph &G);
   void reset(std::optional<Symbol *> CacheValue = std::nullopt) {
     ImageBase = CacheValue;
   }

--- a/llvm/include/llvm/ExecutionEngine/JITLink/COFF_x86_64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/COFF_x86_64.h
@@ -23,15 +23,16 @@ namespace jitlink {
 /// Note: The graph does not take ownership of the underlying buffer, nor copy
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
-Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromCOFFObject_x86_64(
+LLVM_ABI Expected<std::unique_ptr<LinkGraph>>
+createLinkGraphFromCOFFObject_x86_64(
     MemoryBufferRef ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// jit-link the given object buffer, which must be a COFF x86-64 object file.
-void link_COFF_x86_64(std::unique_ptr<LinkGraph> G,
-                      std::unique_ptr<JITLinkContext> Ctx);
+LLVM_ABI void link_COFF_x86_64(std::unique_ptr<LinkGraph> G,
+                               std::unique_ptr<JITLinkContext> Ctx);
 
 /// Return the string name of the given COFF x86-64 edge kind.
-const char *getCOFFX86RelocationKindName(Edge::Kind R);
+LLVM_ABI const char *getCOFFX86RelocationKindName(Edge::Kind R);
 } // end namespace jitlink
 } // end namespace llvm
 

--- a/llvm/include/llvm/ExecutionEngine/JITLink/DWARFRecordSectionSplitter.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/DWARFRecordSectionSplitter.h
@@ -20,8 +20,8 @@ namespace jitlink {
 /// without EHFrameEdgeFixer, which is responsible for adding FDE-to-CIE edges.
 class DWARFRecordSectionSplitter {
 public:
-  DWARFRecordSectionSplitter(StringRef SectionName);
-  Error operator()(LinkGraph &G);
+  LLVM_ABI DWARFRecordSectionSplitter(StringRef SectionName);
+  LLVM_ABI Error operator()(LinkGraph &G);
 
 private:
   Error processBlock(LinkGraph &G, Block &B, LinkGraph::SplitBlockCache &Cache);

--- a/llvm/include/llvm/ExecutionEngine/JITLink/ELF.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/ELF.h
@@ -23,7 +23,7 @@ namespace jitlink {
 /// Note: The graph does not take ownership of the underlying buffer, nor copy
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
-Expected<std::unique_ptr<LinkGraph>>
+LLVM_ABI Expected<std::unique_ptr<LinkGraph>>
 createLinkGraphFromELFObject(MemoryBufferRef ObjectBuffer,
                              std::shared_ptr<orc::SymbolStringPool> SSP);
 
@@ -31,8 +31,8 @@ createLinkGraphFromELFObject(MemoryBufferRef ObjectBuffer,
 ///
 /// Uses conservative defaults for GOT and stub handling based on the target
 /// platform.
-void link_ELF(std::unique_ptr<LinkGraph> G,
-              std::unique_ptr<JITLinkContext> Ctx);
+LLVM_ABI void link_ELF(std::unique_ptr<LinkGraph> G,
+                       std::unique_ptr<JITLinkContext> Ctx);
 
 } // end namespace jitlink
 } // end namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/JITLink/ELF_aarch32.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/ELF_aarch32.h
@@ -24,13 +24,14 @@ namespace jitlink {
 /// Note: The graph does not take ownership of the underlying buffer, nor copy
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
-Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromELFObject_aarch32(
+LLVM_ABI Expected<std::unique_ptr<LinkGraph>>
+createLinkGraphFromELFObject_aarch32(
     MemoryBufferRef ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// jit-link the given object buffer, which must be an ELF arm/thumb object
 /// file.
-void link_ELF_aarch32(std::unique_ptr<LinkGraph> G,
-                      std::unique_ptr<JITLinkContext> Ctx);
+LLVM_ABI void link_ELF_aarch32(std::unique_ptr<LinkGraph> G,
+                               std::unique_ptr<JITLinkContext> Ctx);
 
 } // end namespace jitlink
 } // end namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/JITLink/ELF_aarch64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/ELF_aarch64.h
@@ -25,13 +25,14 @@ namespace jitlink {
 /// Note: The graph does not take ownership of the underlying buffer, nor copy
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
-Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromELFObject_aarch64(
+LLVM_ABI Expected<std::unique_ptr<LinkGraph>>
+createLinkGraphFromELFObject_aarch64(
     MemoryBufferRef ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// jit-link the given object buffer, which must be a ELF aarch64 relocatable
 /// object file.
-void link_ELF_aarch64(std::unique_ptr<LinkGraph> G,
-                      std::unique_ptr<JITLinkContext> Ctx);
+LLVM_ABI void link_ELF_aarch64(std::unique_ptr<LinkGraph> G,
+                               std::unique_ptr<JITLinkContext> Ctx);
 
 } // end namespace jitlink
 } // end namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/JITLink/ELF_hexagon.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/ELF_hexagon.h
@@ -23,13 +23,14 @@ namespace jitlink {
 /// Note: The graph does not take ownership of the underlying buffer, nor copy
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
-Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromELFObject_hexagon(
+LLVM_ABI Expected<std::unique_ptr<LinkGraph>>
+createLinkGraphFromELFObject_hexagon(
     MemoryBufferRef ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// jit-link the given object buffer, which must be a ELF Hexagon relocatable
 /// object file.
-void link_ELF_hexagon(std::unique_ptr<LinkGraph> G,
-                      std::unique_ptr<JITLinkContext> Ctx);
+LLVM_ABI void link_ELF_hexagon(std::unique_ptr<LinkGraph> G,
+                               std::unique_ptr<JITLinkContext> Ctx);
 
 } // end namespace jitlink
 } // end namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/JITLink/ELF_loongarch.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/ELF_loongarch.h
@@ -25,17 +25,18 @@ namespace jitlink {
 /// Note: The graph does not take ownership of the underlying buffer, nor copy
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
-Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromELFObject_loongarch(
+LLVM_ABI Expected<std::unique_ptr<LinkGraph>>
+createLinkGraphFromELFObject_loongarch(
     MemoryBufferRef ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// jit-link the given object buffer, which must be an ELF loongarch object
 /// file.
-void link_ELF_loongarch(std::unique_ptr<LinkGraph> G,
-                        std::unique_ptr<JITLinkContext> Ctx);
+LLVM_ABI void link_ELF_loongarch(std::unique_ptr<LinkGraph> G,
+                                 std::unique_ptr<JITLinkContext> Ctx);
 
 /// Returns a pass that performs linker relaxation. Should be added to
 /// PostAllocationPasses.
-LinkGraphPassFunction createRelaxationPass_ELF_loongarch();
+LLVM_ABI LinkGraphPassFunction createRelaxationPass_ELF_loongarch();
 
 } // end namespace jitlink
 } // end namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/JITLink/ELF_ppc64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/ELF_ppc64.h
@@ -24,7 +24,7 @@ namespace llvm::jitlink {
 /// outlives the graph.
 ///
 /// WARNING: The big-endian backend has not been tested yet.
-Expected<std::unique_ptr<LinkGraph>>
+LLVM_ABI Expected<std::unique_ptr<LinkGraph>>
 createLinkGraphFromELFObject_ppc64(MemoryBufferRef ObjectBuffer,
                                    std::shared_ptr<orc::SymbolStringPool> SSP);
 
@@ -33,18 +33,19 @@ createLinkGraphFromELFObject_ppc64(MemoryBufferRef ObjectBuffer,
 /// Note: The graph does not take ownership of the underlying buffer, nor copy
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
-Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromELFObject_ppc64le(
+LLVM_ABI Expected<std::unique_ptr<LinkGraph>>
+createLinkGraphFromELFObject_ppc64le(
     MemoryBufferRef ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// jit-link the given object buffer, which must be a ELF ppc64le object file.
 ///
 /// WARNING: The big-endian backend has not been tested yet.
-void link_ELF_ppc64(std::unique_ptr<LinkGraph> G,
-                    std::unique_ptr<JITLinkContext> Ctx);
+LLVM_ABI void link_ELF_ppc64(std::unique_ptr<LinkGraph> G,
+                             std::unique_ptr<JITLinkContext> Ctx);
 
 /// jit-link the given object buffer, which must be a ELF ppc64le object file.
-void link_ELF_ppc64le(std::unique_ptr<LinkGraph> G,
-                      std::unique_ptr<JITLinkContext> Ctx);
+LLVM_ABI void link_ELF_ppc64le(std::unique_ptr<LinkGraph> G,
+                               std::unique_ptr<JITLinkContext> Ctx);
 
 } // end namespace llvm::jitlink
 

--- a/llvm/include/llvm/ExecutionEngine/JITLink/ELF_riscv.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/ELF_riscv.h
@@ -25,17 +25,17 @@ namespace jitlink {
 /// Note: The graph does not take ownership of the underlying buffer, nor copy
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
-Expected<std::unique_ptr<LinkGraph>>
+LLVM_ABI Expected<std::unique_ptr<LinkGraph>>
 createLinkGraphFromELFObject_riscv(MemoryBufferRef ObjectBuffer,
                                    std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// jit-link the given object buffer, which must be a ELF riscv object file.
-void link_ELF_riscv(std::unique_ptr<LinkGraph> G,
-                    std::unique_ptr<JITLinkContext> Ctx);
+LLVM_ABI void link_ELF_riscv(std::unique_ptr<LinkGraph> G,
+                             std::unique_ptr<JITLinkContext> Ctx);
 
 /// Returns a pass that performs linker relaxation. Should be added to
 /// PostAllocationPasses.
-LinkGraphPassFunction createRelaxationPass_ELF_riscv();
+LLVM_ABI LinkGraphPassFunction createRelaxationPass_ELF_riscv();
 
 } // end namespace jitlink
 } // end namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/JITLink/ELF_systemz.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/ELF_systemz.h
@@ -25,13 +25,14 @@ namespace jitlink {
 /// Note: The graph does not take ownership of the underlying buffer, nor copy
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
-Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromELFObject_systemz(
+LLVM_ABI Expected<std::unique_ptr<LinkGraph>>
+createLinkGraphFromELFObject_systemz(
     MemoryBufferRef ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// jit-link the given object buffer, which must be a ELF systemz relocatable
 /// object file.
-void link_ELF_systemz(std::unique_ptr<LinkGraph> G,
-                      std::unique_ptr<JITLinkContext> Ctx);
+LLVM_ABI void link_ELF_systemz(std::unique_ptr<LinkGraph> G,
+                               std::unique_ptr<JITLinkContext> Ctx);
 
 } // end namespace jitlink
 } // end namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/JITLink/ELF_x86.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/ELF_x86.h
@@ -25,14 +25,14 @@ namespace jitlink {
 /// Note: The graph does not take ownership of the underlying buffer, nor copy
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
-Expected<std::unique_ptr<LinkGraph>>
+LLVM_ABI Expected<std::unique_ptr<LinkGraph>>
 createLinkGraphFromELFObject_x86(MemoryBufferRef ObjectBuffer,
                                  std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// jit-link the given object buffer, which must be a ELF x86 relocatable
 /// object file.
-void link_ELF_x86(std::unique_ptr<LinkGraph> G,
-                  std::unique_ptr<JITLinkContext> Ctx);
+LLVM_ABI void link_ELF_x86(std::unique_ptr<LinkGraph> G,
+                           std::unique_ptr<JITLinkContext> Ctx);
 
 } // end namespace jitlink
 } // end namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/JITLink/ELF_x86_64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/ELF_x86_64.h
@@ -23,13 +23,13 @@ namespace jitlink {
 /// Note: The graph does not take ownership of the underlying buffer, nor copy
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
-Expected<std::unique_ptr<LinkGraph>>
+LLVM_ABI Expected<std::unique_ptr<LinkGraph>>
 createLinkGraphFromELFObject_x86_64(MemoryBufferRef ObjectBuffer,
                                     std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// jit-link the given object buffer, which must be a ELF x86-64 object file.
-void link_ELF_x86_64(std::unique_ptr<LinkGraph> G,
-                     std::unique_ptr<JITLinkContext> Ctx);
+LLVM_ABI void link_ELF_x86_64(std::unique_ptr<LinkGraph> G,
+                              std::unique_ptr<JITLinkContext> Ctx);
 
 } // end namespace jitlink
 } // end namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/JITLink/XCOFF.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/XCOFF.h
@@ -23,13 +23,13 @@ namespace jitlink {
 /// Note: The graph does not take ownership of the underlying buffer, nor copy
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
-Expected<std::unique_ptr<LinkGraph>>
+LLVM_ABI Expected<std::unique_ptr<LinkGraph>>
 createLinkGraphFromXCOFFObject(MemoryBufferRef ObjectBuffer,
                                std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// Link the given graph.
-void link_XCOFF(std::unique_ptr<LinkGraph> G,
-                std::unique_ptr<JITLinkContext> Ctx);
+LLVM_ABI void link_XCOFF(std::unique_ptr<LinkGraph> G,
+                         std::unique_ptr<JITLinkContext> Ctx);
 
 } // namespace jitlink
 } // namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/JITLink/XCOFF_ppc64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/XCOFF_ppc64.h
@@ -24,13 +24,14 @@ namespace llvm::jitlink {
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
 ///
-Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromXCOFFObject_ppc64(
+LLVM_ABI Expected<std::unique_ptr<LinkGraph>>
+createLinkGraphFromXCOFFObject_ppc64(
     MemoryBufferRef ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// jit-link the given object buffer, which must be a XCOFF ppc64 object file.
 ///
-void link_XCOFF_ppc64(std::unique_ptr<LinkGraph> G,
-                      std::unique_ptr<JITLinkContext> Ctx);
+LLVM_ABI void link_XCOFF_ppc64(std::unique_ptr<LinkGraph> G,
+                               std::unique_ptr<JITLinkContext> Ctx);
 
 } // end namespace llvm::jitlink
 

--- a/llvm/include/llvm/ExecutionEngine/JITLink/systemz.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/systemz.h
@@ -554,7 +554,7 @@ enum EdgeKind_systemz : Edge::Kind {
 
 /// Returns a string name for the given systemz edge. For debugging purposes
 /// only
-const char *getEdgeKindName(Edge::Kind K);
+LLVM_ABI const char *getEdgeKindName(Edge::Kind K);
 
 /// Apply fixup expression for edge to block content.
 inline Error applyFixup(LinkGraph &G, Block &B, const Edge &E,
@@ -764,7 +764,7 @@ inline Error applyFixup(LinkGraph &G, Block &B, const Edge &E,
 }
 
 /// SystemZ null pointer content.
-extern const char NullPointerContent[8];
+extern const LLVM_ABI char NullPointerContent[8];
 inline ArrayRef<char> getGOTEntryBlockContent(LinkGraph &G) {
   return {reinterpret_cast<const char *>(NullPointerContent),
           G.getPointerSize()};
@@ -777,7 +777,7 @@ inline ArrayRef<char> getGOTEntryBlockContent(LinkGraph &G) {
 ///   lgrl %r1, ptr
 ///   j    %r1
 constexpr size_t StubEntrySize = 8;
-extern const char Pointer64JumpStubContent[StubEntrySize];
+extern const LLVM_ABI char Pointer64JumpStubContent[StubEntrySize];
 inline ArrayRef<char> getStubBlockContent(LinkGraph &G) {
   auto StubContent = Pointer64JumpStubContent;
   return {reinterpret_cast<const char *>(StubContent), StubEntrySize};

--- a/llvm/include/llvm/ExecutionEngine/Orc/ExecutorResolutionGenerator.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ExecutorResolutionGenerator.h
@@ -22,7 +22,7 @@
 
 namespace llvm::orc {
 
-class ExecutorResolutionGenerator : public DefinitionGenerator {
+class LLVM_ABI ExecutorResolutionGenerator : public DefinitionGenerator {
 public:
   using SymbolPredicate = unique_function<bool(const SymbolStringPtr &)>;
   using AbsoluteSymbolsFn =

--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
@@ -77,7 +77,7 @@ struct SimpleExecutorMemoryManagerSymbolNames {
 
 /// Default symbol names for the ORC runtime's SimpleNativeMemoryMap SPS
 /// interface.
-extern const SimpleExecutorMemoryManagerSymbolNames
+extern const LLVM_ABI SimpleExecutorMemoryManagerSymbolNames
     orc_rt_SimpleNativeMemoryMapSPSSymbols;
 
 /// Symbol names for dylib management implementation.

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/ExecutorResolver.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/ExecutorResolver.h
@@ -32,7 +32,7 @@ public:
                             YieldResolveResultFn &&OnResolve) = 0;
 };
 
-class DylibSymbolResolver : public ExecutorResolver {
+class LLVM_ABI DylibSymbolResolver : public ExecutorResolver {
 public:
   DylibSymbolResolver(tpctypes::DylibHandle H) : Handle(H) {}
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/LibraryResolver.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/LibraryResolver.h
@@ -386,10 +386,11 @@ public:
 
     using OnEachSymbolFn = std::function<EnumerateResult(StringRef Sym)>;
 
-    static bool enumerateSymbols(object::ObjectFile *Obj, OnEachSymbolFn OnEach,
-                                 const SymbolEnumeratorOptions &Opts);
-    static bool enumerateSymbols(StringRef Path, OnEachSymbolFn OnEach,
-                                 const SymbolEnumeratorOptions &Opts);
+    LLVM_ABI static bool enumerateSymbols(object::ObjectFile *Obj,
+                                          OnEachSymbolFn OnEach,
+                                          const SymbolEnumeratorOptions &Opts);
+    LLVM_ABI static bool enumerateSymbols(StringRef Path, OnEachSymbolFn OnEach,
+                                          const SymbolEnumeratorOptions &Opts);
   };
 
   /// Tracks a set of symbols and the libraries where they are resolved.
@@ -515,7 +516,7 @@ public:
   };
 
   LibraryResolver() = delete;
-  explicit LibraryResolver(const Setup &S);
+  LLVM_ABI explicit LibraryResolver(const Setup &S);
   ~LibraryResolver() = default;
 
   using OnSearchComplete = unique_function<void(SymbolQuery &)>;
@@ -533,12 +534,13 @@ public:
     });
   }
 
-  void searchSymbolsInLibraries(ArrayRef<StringRef> SymList,
-                                OnSearchComplete OnComplete,
-                                const SearchConfig &Config = SearchConfig());
+  LLVM_ABI void
+  searchSymbolsInLibraries(ArrayRef<StringRef> SymList,
+                           OnSearchComplete OnComplete,
+                           const SearchConfig &Config = SearchConfig());
 
 private:
-  bool scanLibrariesIfNeeded(PathType K, size_t BatchSize = 0);
+  LLVM_ABI bool scanLibrariesIfNeeded(PathType K, size_t BatchSize = 0);
   bool scanForNewLibraries(PathType K, LibraryCursor &Cur);
   void resolveSymbolsInLibrary(LibraryInfo *Lib, SymbolQuery &Q,
                                const SymbolEnumeratorOptions &Opts);
@@ -558,12 +560,12 @@ using EnumerateResult = SymbolEnumerator::EnumerateResult;
 
 class LibraryResolutionDriver {
 public:
-  static std::unique_ptr<LibraryResolutionDriver>
+  LLVM_ABI static std::unique_ptr<LibraryResolutionDriver>
   create(const LibraryResolver::Setup &S);
 
-  void addScanPath(const std::string &Path, PathType Kind);
-  void markLibraryLoaded(StringRef Path);
-  void markLibraryUnLoaded(StringRef Path);
+  LLVM_ABI void addScanPath(const std::string &Path, PathType Kind);
+  LLVM_ABI void markLibraryLoaded(StringRef Path);
+  LLVM_ABI void markLibraryUnLoaded(StringRef Path);
   bool isLibraryLoaded(StringRef Path) const {
     return LR->LibMgr.isLoaded(Path);
   }
@@ -583,9 +585,9 @@ public:
     LR->scanLibrariesIfNeeded(PK, BatchSize);
   }
 
-  void resolveSymbols(ArrayRef<StringRef> Symbols,
-                      LibraryResolver::OnSearchComplete OnCompletion,
-                      const SearchConfig &Config = SearchConfig());
+  LLVM_ABI void resolveSymbols(ArrayRef<StringRef> Symbols,
+                               LibraryResolver::OnSearchComplete OnCompletion,
+                               const SearchConfig &Config = SearchConfig());
 
   ~LibraryResolutionDriver() = default;
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/LibraryScanner.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/LibraryScanner.h
@@ -155,10 +155,9 @@ public:
   mode_t lstatCached(StringRef Path);
   std::optional<std::string> readlinkCached(StringRef Path);
 #endif
-  std::optional<std::string> realpathCached(StringRef Path, std::error_code &ec,
-                                            StringRef base = "",
-                                            bool baseIsResolved = false,
-                                            long symloopLevel = 40);
+  LLVM_ABI std::optional<std::string>
+  realpathCached(StringRef Path, std::error_code &ec, StringRef base = "",
+                 bool baseIsResolved = false, long symloopLevel = 40);
 };
 
 /// Performs placeholder substitution in dynamic library paths.
@@ -167,7 +166,7 @@ public:
 /// in input paths with their resolved values.
 class DylibSubstitutor {
 public:
-  void configure(StringRef loaderPath);
+  LLVM_ABI void configure(StringRef loaderPath);
 
   std::string substitute(StringRef input) const {
     for (const auto &[ph, value] : Placeholders) {
@@ -219,14 +218,14 @@ public:
     return *Obj.getBinary();
   }
 
-  static bool isArchitectureCompatible(const object::ObjectFile &Obj);
+  LLVM_ABI static bool isArchitectureCompatible(const object::ObjectFile &Obj);
 
 private:
   object::OwningBinary<object::ObjectFile> Obj;
   Error Err = Error::success();
   bool ErrorTaken = false;
 
-  static Expected<object::OwningBinary<object::ObjectFile>>
+  LLVM_ABI static Expected<object::OwningBinary<object::ObjectFile>>
   loadObjectFileWithOwnership(StringRef FilePath);
 };
 
@@ -265,7 +264,7 @@ public:
                      ObjFileCache *ObjCache = nullptr)
       : LibPathResolver(PR), LibPathCache(LC), ObjCache(ObjCache) {}
 
-  bool isSharedLibrary(StringRef Path) const;
+  LLVM_ABI bool isSharedLibrary(StringRef Path) const;
   bool isSharedLibraryCached(StringRef Path) const {
     if (LibPathCache.hasSeen(Path))
       return true;
@@ -322,9 +321,9 @@ public:
       Paths.emplace_back(path.str());
   }
 
-  std::optional<std::string> resolve(StringRef libStem,
-                                     const DylibSubstitutor &Subst,
-                                     DylibPathValidator &Validator) const;
+  LLVM_ABI std::optional<std::string>
+  resolve(StringRef libStem, const DylibSubstitutor &Subst,
+          DylibPathValidator &Validator) const;
   SearchPathType searchPathType() const { return Kind; }
 
 private:
@@ -340,8 +339,8 @@ public:
       : Substitutor(std::move(Substitutor)), Validator(Validator),
         Resolvers(std::move(Resolvers)) {}
 
-  std::optional<std::string> resolve(StringRef Stem,
-                                     bool VariateLibStem = false) const;
+  LLVM_ABI std::optional<std::string>
+  resolve(StringRef Stem, bool VariateLibStem = false) const;
 
 private:
   std::optional<std::string> tryWithExtensions(StringRef libstem) const;
@@ -420,18 +419,18 @@ public:
       addBasePath(p);
   }
 
-  void
+  LLVM_ABI void
   addBasePath(const std::string &P,
               PathType Kind =
                   PathType::Unknown); // Add a canonical directory for scanning
 
-  void getNextBatch(PathType Kind, size_t batchSize,
-                    SmallVectorImpl<const LibrarySearchPath *> &Out);
+  LLVM_ABI void getNextBatch(PathType Kind, size_t batchSize,
+                             SmallVectorImpl<const LibrarySearchPath *> &Out);
 
-  bool leftToScan(PathType K) const;
-  void resetToScan();
+  LLVM_ABI bool leftToScan(PathType K) const;
+  LLVM_ABI void resetToScan();
 
-  bool isTrackedBasePath(StringRef P) const;
+  LLVM_ABI bool isTrackedBasePath(StringRef P) const;
   bool hasSearchPath() const { return !LibSearchPaths.empty(); }
 
   SmallVector<StringRef> getSearchPaths() const {
@@ -480,7 +479,7 @@ public:
                   &ObjCache),
         ShouldScanCall(std::move(ShouldScanCall)) {}
 
-  void scanNext(PathType Kind, size_t batchSize = 1);
+  LLVM_ABI void scanNext(PathType Kind, size_t batchSize = 1);
 
   /// Dependency info for a library.
   struct LibraryDepsInfo {

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderGDB.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderGDB.cpp
@@ -24,13 +24,12 @@ extern "C" {
 // We put information about the JITed function in this global, which the
 // debugger reads.  Make sure to specify the version statically, because the
 // debugger checks the version before we can set it during runtime.
-LLVM_ABI LLVM_ALWAYS_EXPORT struct jit_descriptor __jit_debug_descriptor = {
+LLVM_ALWAYS_EXPORT struct jit_descriptor __jit_debug_descriptor = {
     JitDescriptorVersion, 0, nullptr, nullptr};
 
 // Debuggers that implement the GDB JIT interface put a special breakpoint in
 // this function.
-LLVM_ABI LLVM_ALWAYS_EXPORT LLVM_ATTRIBUTE_NOINLINE void
-__jit_debug_register_code() {
+LLVM_ALWAYS_EXPORT LLVM_ATTRIBUTE_NOINLINE void __jit_debug_register_code() {
   // The noinline and the asm prevent calls to this function from being
   // optimized out.
 #if !defined(_MSC_VER)


### PR DESCRIPTION
This updates most LLVM_ABI annotations in the ExecutionEngine headers to match expected usage:
* All public APIs should be properly annotated.
* Inlined functions should not be annotated.

These changes were done by a script fixing annotations on LLVM public headers and manually checked.

This effort is tracked in #109483.