### PR TITLE
[llvm] Fix most LLVM_ABI annotations in MC/MCA

### DIFF
--- a/llvm/include/llvm/MC/ConstantPools.h
+++ b/llvm/include/llvm/MC/ConstantPools.h
@@ -60,16 +60,16 @@ public:
   // \param Size is the size in bytes of the entry
   //
   // \returns a MCExpr that references the newly inserted value
-  const MCExpr *addEntry(const MCExpr *Value, MCContext &Context,
-                         unsigned Size, SMLoc Loc);
+  LLVM_ABI const MCExpr *addEntry(const MCExpr *Value, MCContext &Context,
+                                  unsigned Size, SMLoc Loc);
 
   // Emit the contents of the constant pool using the provided streamer.
-  void emitEntries(MCStreamer &Streamer);
+  LLVM_ABI void emitEntries(MCStreamer &Streamer);
 
   // Return true if the constant pool is empty
-  bool empty();
+  LLVM_ABI bool empty();
 
-  void clearCache();
+  LLVM_ABI void clearCache();
 };
 
 class AssemblerConstantPools {
@@ -91,11 +91,11 @@ class AssemblerConstantPools {
   ConstantPoolMapTy ConstantPools;
 
 public:
-  void emitAll(MCStreamer &Streamer);
-  void emitForCurrentSection(MCStreamer &Streamer);
-  void clearCacheForCurrentSection(MCStreamer &Streamer);
-  const MCExpr *addEntry(MCStreamer &Streamer, const MCExpr *Expr,
-                         unsigned Size, SMLoc Loc);
+  LLVM_ABI void emitAll(MCStreamer &Streamer);
+  LLVM_ABI void emitForCurrentSection(MCStreamer &Streamer);
+  LLVM_ABI void clearCacheForCurrentSection(MCStreamer &Streamer);
+  LLVM_ABI const MCExpr *addEntry(MCStreamer &Streamer, const MCExpr *Expr,
+                                  unsigned Size, SMLoc Loc);
 
 private:
   ConstantPool *getConstantPool(MCSection *Section);

--- a/llvm/include/llvm/MC/DXContainerPSVInfo.h
+++ b/llvm/include/llvm/MC/DXContainerPSVInfo.h
@@ -73,11 +73,13 @@ struct PSVRuntimeInfo {
   // Serialize PSVInfo into the provided raw_ostream. The version field
   // specifies the data version to encode, the default value specifies encoding
   // the highest supported version.
-  void write(raw_ostream &OS,
-             uint32_t Version = std::numeric_limits<uint32_t>::max()) const;
+  LLVM_ABI void
+  write(raw_ostream &OS,
+        uint32_t Version = std::numeric_limits<uint32_t>::max()) const;
 
-  void finalize(Triple::EnvironmentType Stage,
-                uint32_t Version = std::numeric_limits<uint32_t>::max());
+  LLVM_ABI void
+  finalize(Triple::EnvironmentType Stage,
+           uint32_t Version = std::numeric_limits<uint32_t>::max());
 
 private:
   SmallVector<uint32_t, 64> IndexBuffer;
@@ -110,7 +112,7 @@ public:
                                Register, Mask, ExclusiveMask, MinPrecision});
   }
 
-  void write(raw_ostream &OS);
+  LLVM_ABI void write(raw_ostream &OS);
 };
 
 } // namespace mcdxbc

--- a/llvm/include/llvm/MC/MCAsmInfoCOFF.h
+++ b/llvm/include/llvm/MC/MCAsmInfoCOFF.h
@@ -13,7 +13,7 @@
 
 namespace llvm {
 
-class MCAsmInfoCOFF : public MCAsmInfo {
+class LLVM_ABI MCAsmInfoCOFF : public MCAsmInfo {
   virtual void anchor();
   void printSwitchToSection(const MCSection &, uint32_t, const Triple &,
                             raw_ostream &) const final;
@@ -23,14 +23,14 @@ protected:
   explicit MCAsmInfoCOFF(const MCTargetOptions &Options);
 };
 
-class MCAsmInfoMicrosoft : public MCAsmInfoCOFF {
+class LLVM_ABI MCAsmInfoMicrosoft : public MCAsmInfoCOFF {
   void anchor() override;
 
 protected:
   explicit MCAsmInfoMicrosoft(const MCTargetOptions &Options);
 };
 
-class MCAsmInfoGNUCOFF : public MCAsmInfoCOFF {
+class LLVM_ABI MCAsmInfoGNUCOFF : public MCAsmInfoCOFF {
   void anchor() override;
 
 protected:

--- a/llvm/include/llvm/MC/MCAsmInfoDarwin.h
+++ b/llvm/include/llvm/MC/MCAsmInfoDarwin.h
@@ -18,7 +18,7 @@
 
 namespace llvm {
 
-class MCAsmInfoDarwin : public MCAsmInfo {
+class LLVM_ABI MCAsmInfoDarwin : public MCAsmInfo {
 public:
   explicit MCAsmInfoDarwin(const MCTargetOptions &Options);
   void printSwitchToSection(const MCSection &, uint32_t, const Triple &,

--- a/llvm/include/llvm/MC/MCAsmInfoELF.h
+++ b/llvm/include/llvm/MC/MCAsmInfoELF.h
@@ -13,7 +13,7 @@
 
 namespace llvm {
 
-class MCAsmInfoELF : public MCAsmInfo {
+class LLVM_ABI MCAsmInfoELF : public MCAsmInfo {
   virtual void anchor();
   MCSection *getStackSection(MCContext &Ctx, bool Exec) const override;
   void printSwitchToSection(const MCSection &, uint32_t, const Triple &,

--- a/llvm/include/llvm/MC/MCAsmInfoGOFF.h
+++ b/llvm/include/llvm/MC/MCAsmInfoGOFF.h
@@ -18,7 +18,7 @@
 #include "llvm/MC/MCAsmInfo.h"
 
 namespace llvm {
-class MCAsmInfoGOFF : public MCAsmInfo {
+class LLVM_ABI MCAsmInfoGOFF : public MCAsmInfo {
   void printSwitchToSection(const MCSection &, uint32_t, const Triple &,
                             raw_ostream &) const final;
 

--- a/llvm/include/llvm/MC/MCAsmInfoWasm.h
+++ b/llvm/include/llvm/MC/MCAsmInfoWasm.h
@@ -12,7 +12,7 @@
 #include "llvm/MC/MCAsmInfo.h"
 
 namespace llvm {
-class MCAsmInfoWasm : public MCAsmInfo {
+class LLVM_ABI MCAsmInfoWasm : public MCAsmInfo {
   void printSwitchToSection(const MCSection &, uint32_t, const Triple &,
                             raw_ostream &) const final;
 

--- a/llvm/include/llvm/MC/MCAsmInfoXCOFF.h
+++ b/llvm/include/llvm/MC/MCAsmInfoXCOFF.h
@@ -13,7 +13,7 @@
 
 namespace llvm {
 
-class MCAsmInfoXCOFF : public MCAsmInfo {
+class LLVM_ABI MCAsmInfoXCOFF : public MCAsmInfo {
 protected:
   MCAsmInfoXCOFF(const MCTargetOptions &Options);
   void printSwitchToSection(const MCSection &, uint32_t, const Triple &,

--- a/llvm/include/llvm/MC/MCCodeView.h
+++ b/llvm/include/llvm/MC/MCCodeView.h
@@ -148,80 +148,81 @@ public:
   CodeViewContext &operator=(const CodeViewContext &other) = delete;
   CodeViewContext(const CodeViewContext &other) = delete;
 
-  void finish();
+  LLVM_ABI void finish();
 
-  bool isValidFileNumber(unsigned FileNumber) const;
-  bool addFile(MCStreamer &OS, unsigned FileNumber, StringRef Filename,
-               ArrayRef<uint8_t> ChecksumBytes, uint8_t ChecksumKind);
+  LLVM_ABI bool isValidFileNumber(unsigned FileNumber) const;
+  LLVM_ABI bool addFile(MCStreamer &OS, unsigned FileNumber, StringRef Filename,
+                        ArrayRef<uint8_t> ChecksumBytes, uint8_t ChecksumKind);
 
   /// Records the function id of a normal function. Returns false if the
   /// function id has already been used, and true otherwise.
-  bool recordFunctionId(unsigned FuncId);
+  LLVM_ABI bool recordFunctionId(unsigned FuncId);
 
   /// Records the function id of an inlined call site. Records the "inlined at"
   /// location info of the call site, including what function or inlined call
   /// site it was inlined into. Returns false if the function id has already
   /// been used, and true otherwise.
-  bool recordInlinedCallSiteId(unsigned FuncId, unsigned IAFunc,
-                               unsigned IAFile, unsigned IALine,
-                               unsigned IACol);
+  LLVM_ABI bool recordInlinedCallSiteId(unsigned FuncId, unsigned IAFunc,
+                                        unsigned IAFile, unsigned IALine,
+                                        unsigned IACol);
 
   /// Retreive the function info if this is a valid function id, or nullptr.
-  MCCVFunctionInfo *getCVFunctionInfo(unsigned FuncId);
+  LLVM_ABI MCCVFunctionInfo *getCVFunctionInfo(unsigned FuncId);
 
   /// Saves the information from the currently parsed .cv_loc directive
   /// and sets CVLocSeen.  When the next instruction is assembled an entry
   /// in the line number table with this information and the address of the
   /// instruction will be created.
-  void recordCVLoc(MCContext &Ctx, const MCSymbol *Label, unsigned FunctionId,
-                   unsigned FileNo, unsigned Line, unsigned Column,
-                   bool PrologueEnd, bool IsStmt);
+  LLVM_ABI void recordCVLoc(MCContext &Ctx, const MCSymbol *Label,
+                            unsigned FunctionId, unsigned FileNo, unsigned Line,
+                            unsigned Column, bool PrologueEnd, bool IsStmt);
 
   /// Add a line entry.
-  void addLineEntry(const MCCVLoc &LineEntry);
+  LLVM_ABI void addLineEntry(const MCCVLoc &LineEntry);
 
-  std::vector<MCCVLoc> getFunctionLineEntries(unsigned FuncId);
+  LLVM_ABI std::vector<MCCVLoc> getFunctionLineEntries(unsigned FuncId);
 
-  std::pair<size_t, size_t> getLineExtent(unsigned FuncId);
-  std::pair<size_t, size_t> getLineExtentIncludingInlinees(unsigned FuncId);
+  LLVM_ABI std::pair<size_t, size_t> getLineExtent(unsigned FuncId);
+  LLVM_ABI std::pair<size_t, size_t>
+  getLineExtentIncludingInlinees(unsigned FuncId);
 
-  ArrayRef<MCCVLoc> getLinesForExtent(size_t L, size_t R);
+  LLVM_ABI ArrayRef<MCCVLoc> getLinesForExtent(size_t L, size_t R);
 
   /// Emits a line table substream.
-  void emitLineTableForFunction(MCObjectStreamer &OS, unsigned FuncId,
-                                const MCSymbol *FuncBegin,
-                                const MCSymbol *FuncEnd);
+  LLVM_ABI void emitLineTableForFunction(MCObjectStreamer &OS, unsigned FuncId,
+                                         const MCSymbol *FuncBegin,
+                                         const MCSymbol *FuncEnd);
 
-  void emitInlineLineTableForFunction(MCObjectStreamer &OS,
-                                      unsigned PrimaryFunctionId,
-                                      unsigned SourceFileId,
-                                      unsigned SourceLineNum,
-                                      const MCSymbol *FnStartSym,
-                                      const MCSymbol *FnEndSym);
+  LLVM_ABI void emitInlineLineTableForFunction(MCObjectStreamer &OS,
+                                               unsigned PrimaryFunctionId,
+                                               unsigned SourceFileId,
+                                               unsigned SourceLineNum,
+                                               const MCSymbol *FnStartSym,
+                                               const MCSymbol *FnEndSym);
 
   /// Encodes the binary annotations once we have a layout.
-  void encodeInlineLineTable(const MCAssembler &Asm,
-                             MCCVInlineLineTableFragment &F);
+  LLVM_ABI void encodeInlineLineTable(const MCAssembler &Asm,
+                                      MCCVInlineLineTableFragment &F);
 
-  void
+  LLVM_ABI void
   emitDefRange(MCObjectStreamer &OS,
                ArrayRef<std::pair<const MCSymbol *, const MCSymbol *>> Ranges,
                StringRef FixedSizePortion);
 
-  void encodeDefRange(const MCAssembler &Asm, MCCVDefRangeFragment &F);
+  LLVM_ABI void encodeDefRange(const MCAssembler &Asm, MCCVDefRangeFragment &F);
 
   /// Emits the string table substream.
-  void emitStringTable(MCObjectStreamer &OS);
+  LLVM_ABI void emitStringTable(MCObjectStreamer &OS);
 
   /// Emits the file checksum substream.
-  void emitFileChecksums(MCObjectStreamer &OS);
+  LLVM_ABI void emitFileChecksums(MCObjectStreamer &OS);
 
   /// Emits the offset into the checksum table of the given file number.
-  void emitFileChecksumOffset(MCObjectStreamer &OS, unsigned FileNo);
+  LLVM_ABI void emitFileChecksumOffset(MCObjectStreamer &OS, unsigned FileNo);
 
   /// Add something to the string table.  Returns the final string as well as
   /// offset into the string table.
-  std::pair<StringRef, unsigned> addToStringTable(StringRef S);
+  LLVM_ABI std::pair<StringRef, unsigned> addToStringTable(StringRef S);
 
 private:
   MCContext *MCCtx;

--- a/llvm/include/llvm/MC/MCDXContainerWriter.h
+++ b/llvm/include/llvm/MC/MCDXContainerWriter.h
@@ -18,7 +18,7 @@ namespace llvm {
 
 class raw_pwrite_stream;
 
-class MCDXContainerTargetWriter : public MCObjectTargetWriter {
+class LLVM_ABI MCDXContainerTargetWriter : public MCObjectTargetWriter {
 protected:
   MCDXContainerTargetWriter() {}
 
@@ -33,7 +33,7 @@ public:
   }
 };
 
-class DXContainerObjectWriter final : public MCObjectWriter {
+class LLVM_ABI DXContainerObjectWriter final : public MCObjectWriter {
   support::endian::Writer W;
   std::unique_ptr<MCDXContainerTargetWriter> TargetObjectWriter;
 

--- a/llvm/include/llvm/MC/MCDisassembler/MCExternalSymbolizer.h
+++ b/llvm/include/llvm/MC/MCDisassembler/MCExternalSymbolizer.h
@@ -24,7 +24,7 @@ namespace llvm {
 /// Symbolize using user-provided, C API, callbacks.
 ///
 /// See llvm-c/Disassembler.h.
-class MCExternalSymbolizer : public MCSymbolizer {
+class LLVM_ABI MCExternalSymbolizer : public MCSymbolizer {
 protected:
   /// \name Hooks for symbolic disassembly via the public 'C' interface.
   /// @{
@@ -52,7 +52,6 @@ public:
                                        int64_t Value,
                                        uint64_t Address) override;
 };
-
 }
 
 #endif

--- a/llvm/include/llvm/MC/MCELFObjectWriter.h
+++ b/llvm/include/llvm/MC/MCELFObjectWriter.h
@@ -50,7 +50,7 @@ struct ELFRelocationEntry {
   LLVM_DUMP_METHOD void dump() const { print(errs()); }
 };
 
-class MCELFObjectTargetWriter : public MCObjectTargetWriter {
+class LLVM_ABI MCELFObjectTargetWriter : public MCObjectTargetWriter {
   const uint8_t OSABI;
   const uint8_t ABIVersion;
   const uint16_t EMachine;
@@ -139,7 +139,7 @@ public:
   }
 };
 
-class ELFObjectWriter final : public MCObjectWriter {
+class LLVM_ABI ELFObjectWriter final : public MCObjectWriter {
   unsigned ELFHeaderEFlags = 0;
 
 public:

--- a/llvm/include/llvm/MC/MCELFStreamer.h
+++ b/llvm/include/llvm/MC/MCELFStreamer.h
@@ -28,7 +28,7 @@ class MCCodeEmitter;
 class MCExpr;
 class MCInst;
 
-class MCELFStreamer : public MCObjectStreamer {
+class LLVM_ABI MCELFStreamer : public MCObjectStreamer {
 public:
   MCELFStreamer(MCContext &Context, std::unique_ptr<MCAsmBackend> TAB,
                 std::unique_ptr<MCObjectWriter> OW,
@@ -148,11 +148,11 @@ private:
   bool SeenIdent = false;
 };
 
-MCELFStreamer *createARMELFStreamer(MCContext &Context,
-                                    std::unique_ptr<MCAsmBackend> TAB,
-                                    std::unique_ptr<MCObjectWriter> OW,
-                                    std::unique_ptr<MCCodeEmitter> Emitter,
-                                    bool IsThumb, bool IsAndroid);
+LLVM_ABI MCELFStreamer *
+createARMELFStreamer(MCContext &Context, std::unique_ptr<MCAsmBackend> TAB,
+                     std::unique_ptr<MCObjectWriter> OW,
+                     std::unique_ptr<MCCodeEmitter> Emitter, bool IsThumb,
+                     bool IsAndroid);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/MC/MCGOFFObjectWriter.h
+++ b/llvm/include/llvm/MC/MCGOFFObjectWriter.h
@@ -73,7 +73,7 @@ struct GOFFRelocationEntry {
         Action(Action), FetchStore(FetchStore) {}
 };
 
-class GOFFObjectWriter : public MCObjectWriter {
+class LLVM_ABI GOFFObjectWriter : public MCObjectWriter {
   // The target specific GOFF writer instance.
   std::unique_ptr<MCGOFFObjectTargetWriter> TargetObjectWriter;
 
@@ -107,7 +107,7 @@ public:
 /// \param MOTW - The target-specific GOFF writer subclass.
 /// \param OS - The stream to write to.
 /// \returns The constructed object writer.
-std::unique_ptr<MCObjectWriter>
+LLVM_ABI std::unique_ptr<MCObjectWriter>
 createGOFFObjectWriter(std::unique_ptr<MCGOFFObjectTargetWriter> MOTW,
                        raw_pwrite_stream &OS);
 } // namespace llvm

--- a/llvm/include/llvm/MC/MCLabel.h
+++ b/llvm/include/llvm/MC/MCLabel.h
@@ -13,6 +13,8 @@
 #ifndef LLVM_MC_MCLABEL_H
 #define LLVM_MC_MCLABEL_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 
 class raw_ostream;
@@ -40,10 +42,10 @@ public:
   unsigned incInstance() { return ++Instance; }
 
   /// Print the value to the stream \p OS.
-  void print(raw_ostream &OS) const;
+  LLVM_ABI void print(raw_ostream &OS) const;
 
   /// Print the value to stderr.
-  void dump() const;
+  LLVM_ABI void dump() const;
 };
 
 inline raw_ostream &operator<<(raw_ostream &OS, const MCLabel &Label) {

--- a/llvm/include/llvm/MC/MCParser/MCAsmParserUtils.h
+++ b/llvm/include/llvm/MC/MCParser/MCAsmParserUtils.h
@@ -9,6 +9,8 @@
 #ifndef LLVM_MC_MCPARSER_MCASMPARSERUTILS_H
 #define LLVM_MC_MCPARSER_MCASMPARSERUTILS_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 
 class MCAsmParser;
@@ -22,9 +24,9 @@ namespace MCParserUtils {
 /// with the given name.
 ///
 /// On success, returns false and sets the Symbol and Value output parameters.
-bool parseAssignmentExpression(StringRef Name, bool allow_redef,
-                               MCAsmParser &Parser, MCSymbol *&Symbol,
-                               const MCExpr *&Value);
+LLVM_ABI bool parseAssignmentExpression(StringRef Name, bool allow_redef,
+                                        MCAsmParser &Parser, MCSymbol *&Symbol,
+                                        const MCExpr *&Value);
 
 } // namespace MCParserUtils
 

--- a/llvm/include/llvm/MC/MCSFrame.h
+++ b/llvm/include/llvm/MC/MCSFrame.h
@@ -30,7 +30,7 @@ public:
   // Emit the sframe section.
   //
   // \param Streamer - Emit into this stream.
-  static void emit(MCObjectStreamer &Streamer);
+  LLVM_ABI static void emit(MCObjectStreamer &Streamer);
 
   // Encode the FRE's function offset.
   //
@@ -38,8 +38,9 @@ public:
   // \param Offset - Offset to encode.
   // \param Out - Destination of the encoding.
   // \param FDEFrag - Frag that specifies the encoding format.
-  static void encodeFuncOffset(MCContext &C, uint64_t Offset,
-                               SmallVectorImpl<char> &Out, MCFragment *FDEFrag);
+  LLVM_ABI static void encodeFuncOffset(MCContext &C, uint64_t Offset,
+                                        SmallVectorImpl<char> &Out,
+                                        MCFragment *FDEFrag);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/MC/MCSPIRVObjectWriter.h
+++ b/llvm/include/llvm/MC/MCSPIRVObjectWriter.h
@@ -25,7 +25,7 @@ public:
   }
 };
 
-class SPIRVObjectWriter final : public MCObjectWriter {
+class LLVM_ABI SPIRVObjectWriter final : public MCObjectWriter {
   support::endian::Writer W;
   std::unique_ptr<MCSPIRVObjectTargetWriter> TargetObjectWriter;
 
@@ -52,7 +52,7 @@ private:
 /// \param MOTW - The target specific SPIR-V writer subclass.
 /// \param OS - The stream to write to.
 /// \returns The constructed object writer.
-std::unique_ptr<MCObjectWriter>
+LLVM_ABI std::unique_ptr<MCObjectWriter>
 createSPIRVObjectWriter(std::unique_ptr<MCSPIRVObjectTargetWriter> MOTW,
                         raw_pwrite_stream &OS);
 

--- a/llvm/include/llvm/MC/MCSectionCOFF.h
+++ b/llvm/include/llvm/MC/MCSectionCOFF.h
@@ -68,13 +68,13 @@ private:
 public:
   /// Decides whether a '.section' directive should be printed before the
   /// section name
-  bool shouldOmitSectionDirective(StringRef Name) const;
+  LLVM_ABI bool shouldOmitSectionDirective(StringRef Name) const;
 
   unsigned getCharacteristics() const { return Characteristics; }
   MCSymbol *getCOMDATSymbol() const { return COMDATSymbol; }
   int getSelection() const { return Selection; }
 
-  void setSelection(int Selection) const;
+  LLVM_ABI void setSelection(int Selection) const;
 
   bool isUnique() const { return UniqueID != NonUniqueID; }
   unsigned getUniqueID() const { return UniqueID; }

--- a/llvm/include/llvm/MC/MCSectionXCOFF.h
+++ b/llvm/include/llvm/MC/MCSectionXCOFF.h
@@ -94,7 +94,7 @@ class MCSectionXCOFF final : public MCSection {
   void printCsectDirective(raw_ostream &OS) const;
 
 public:
-  ~MCSectionXCOFF();
+  LLVM_ABI ~MCSectionXCOFF();
 
   XCOFF::StorageMappingClass getMappingClass() const {
     assert(isCsect() && "Only csect section has mapping class property!");

--- a/llvm/include/llvm/MC/MCSymbol.h
+++ b/llvm/include/llvm/MC/MCSymbol.h
@@ -383,7 +383,7 @@ inline raw_ostream &operator<<(raw_ostream &OS, const MCSymbol &Sym) {
   return OS;
 }
 
-bool isRangeRelaxable(const MCSymbol *Begin, const MCSymbol *End);
+LLVM_ABI bool isRangeRelaxable(const MCSymbol *Begin, const MCSymbol *End);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/MC/MCSymbolELF.h
+++ b/llvm/include/llvm/MC/MCSymbolELF.h
@@ -25,28 +25,28 @@ public:
 
   const MCExpr *getSize() const { return SymbolSize; }
 
-  void setVisibility(unsigned Visibility);
-  unsigned getVisibility() const;
+  LLVM_ABI void setVisibility(unsigned Visibility);
+  LLVM_ABI unsigned getVisibility() const;
 
-  void setOther(unsigned Other);
-  unsigned getOther() const;
+  LLVM_ABI void setOther(unsigned Other);
+  LLVM_ABI unsigned getOther() const;
 
-  void setType(unsigned Type) const;
-  unsigned getType() const;
+  LLVM_ABI void setType(unsigned Type) const;
+  LLVM_ABI unsigned getType() const;
 
-  void setBinding(unsigned Binding) const;
-  unsigned getBinding() const;
+  LLVM_ABI void setBinding(unsigned Binding) const;
+  LLVM_ABI unsigned getBinding() const;
 
-  bool isBindingSet() const;
+  LLVM_ABI bool isBindingSet() const;
 
-  void setIsWeakref() const;
-  bool isWeakref() const;
+  LLVM_ABI void setIsWeakref() const;
+  LLVM_ABI bool isWeakref() const;
 
-  void setIsSignature() const;
-  bool isSignature() const;
+  LLVM_ABI void setIsSignature() const;
+  LLVM_ABI bool isSignature() const;
 
-  void setMemtag(bool Tagged);
-  bool isMemtag() const;
+  LLVM_ABI void setMemtag(bool Tagged);
+  LLVM_ABI bool isMemtag() const;
 
 private:
   void setIsBindingSet() const;

--- a/llvm/include/llvm/MC/MCSymbolGOFF.h
+++ b/llvm/include/llvm/MC/MCSymbolGOFF.h
@@ -90,7 +90,7 @@ public:
                     : GOFF::ESDBindingStrength::ESD_BST_Strong;
   }
 
-  bool setSymbolAttribute(MCSymbolAttr Attribute);
+  LLVM_ABI bool setSymbolAttribute(MCSymbolAttr Attribute);
 
   bool isInEDSection() const {
     return isInSection() && static_cast<MCSectionGOFF &>(getSection()).isED();

--- a/llvm/include/llvm/MC/MCSymbolXCOFF.h
+++ b/llvm/include/llvm/MC/MCSymbolXCOFF.h
@@ -50,9 +50,9 @@ public:
 
   StringRef getUnqualifiedName() const { return getUnqualifiedName(getName()); }
 
-  MCSectionXCOFF *getRepresentedCsect() const;
+  LLVM_ABI MCSectionXCOFF *getRepresentedCsect() const;
 
-  void setRepresentedCsect(MCSectionXCOFF *C);
+  LLVM_ABI void setRepresentedCsect(MCSectionXCOFF *C);
 
   void setVisibilityType(XCOFF::VisibilityType SVT) { VisibilityType = SVT; };
 

--- a/llvm/include/llvm/MC/MCWasmObjectWriter.h
+++ b/llvm/include/llvm/MC/MCWasmObjectWriter.h
@@ -19,7 +19,7 @@ class MCSectionWasm;
 class MCValue;
 class raw_pwrite_stream;
 
-class MCWasmObjectTargetWriter : public MCObjectTargetWriter {
+class LLVM_ABI MCWasmObjectTargetWriter : public MCObjectTargetWriter {
   const unsigned Is64Bit : 1;
   const unsigned IsEmscripten : 1;
 
@@ -50,11 +50,11 @@ public:
 /// \param MOTW - The target specific Wasm writer subclass.
 /// \param OS - The stream to write to.
 /// \returns The constructed object writer.
-std::unique_ptr<MCObjectWriter>
+LLVM_ABI std::unique_ptr<MCObjectWriter>
 createWasmObjectWriter(std::unique_ptr<MCWasmObjectTargetWriter> MOTW,
                        raw_pwrite_stream &OS);
 
-std::unique_ptr<MCObjectWriter>
+LLVM_ABI std::unique_ptr<MCObjectWriter>
 createWasmDwoObjectWriter(std::unique_ptr<MCWasmObjectTargetWriter> MOTW,
                           raw_pwrite_stream &OS, raw_pwrite_stream &DwoOS);
 

--- a/llvm/include/llvm/MC/MCWasmStreamer.h
+++ b/llvm/include/llvm/MC/MCWasmStreamer.h
@@ -20,7 +20,7 @@ namespace llvm {
 class MCExpr;
 class MCInst;
 
-class MCWasmStreamer : public MCObjectStreamer {
+class LLVM_ABI MCWasmStreamer : public MCObjectStreamer {
 public:
   MCWasmStreamer(MCContext &Context, std::unique_ptr<MCAsmBackend> TAB,
                  std::unique_ptr<MCObjectWriter> OW,

--- a/llvm/include/llvm/MC/MCWin64EH.h
+++ b/llvm/include/llvm/MC/MCWin64EH.h
@@ -50,21 +50,21 @@ struct Instruction {
   }
 };
 
-class UnwindEmitter : public WinEH::UnwindEmitter {
+class LLVM_ABI UnwindEmitter : public WinEH::UnwindEmitter {
 public:
   void Emit(MCStreamer &Streamer) const override;
   void EmitUnwindInfo(MCStreamer &Streamer, WinEH::FrameInfo *FI,
                       bool HandlerData) const override;
 };
 
-class ARMUnwindEmitter : public WinEH::UnwindEmitter {
+class LLVM_ABI ARMUnwindEmitter : public WinEH::UnwindEmitter {
 public:
   void Emit(MCStreamer &Streamer) const override;
   void EmitUnwindInfo(MCStreamer &Streamer, WinEH::FrameInfo *FI,
                       bool HandlerData) const override;
 };
 
-class ARM64UnwindEmitter : public WinEH::UnwindEmitter {
+class LLVM_ABI ARM64UnwindEmitter : public WinEH::UnwindEmitter {
 public:
   void Emit(MCStreamer &Streamer) const override;
   void EmitUnwindInfo(MCStreamer &Streamer, WinEH::FrameInfo *FI,

--- a/llvm/include/llvm/MC/MCWinCOFFObjectWriter.h
+++ b/llvm/include/llvm/MC/MCWinCOFFObjectWriter.h
@@ -79,11 +79,11 @@ public:
 /// \param MOTW - The target specific WinCOFF writer subclass.
 /// \param OS - The stream to write to.
 /// \returns The constructed object writer.
-std::unique_ptr<MCObjectWriter>
+LLVM_ABI std::unique_ptr<MCObjectWriter>
 createWinCOFFObjectWriter(std::unique_ptr<MCWinCOFFObjectTargetWriter> MOTW,
                           raw_pwrite_stream &OS);
 
-std::unique_ptr<MCObjectWriter>
+LLVM_ABI std::unique_ptr<MCObjectWriter>
 createWinCOFFDwoObjectWriter(std::unique_ptr<MCWinCOFFObjectTargetWriter> MOTW,
                              raw_pwrite_stream &OS, raw_pwrite_stream &DwoOS);
 } // end namespace llvm

--- a/llvm/include/llvm/MC/MCWinCOFFStreamer.h
+++ b/llvm/include/llvm/MC/MCWinCOFFStreamer.h
@@ -25,7 +25,7 @@ class StringRef;
 class WinCOFFObjectWriter;
 class raw_pwrite_stream;
 
-class MCWinCOFFStreamer : public MCObjectStreamer {
+class LLVM_ABI MCWinCOFFStreamer : public MCObjectStreamer {
 public:
   MCWinCOFFStreamer(MCContext &Context, std::unique_ptr<MCAsmBackend> MAB,
                     std::unique_ptr<MCCodeEmitter> CE,

--- a/llvm/include/llvm/MC/MCXCOFFObjectWriter.h
+++ b/llvm/include/llvm/MC/MCXCOFFObjectWriter.h
@@ -15,7 +15,7 @@ namespace llvm {
 
 class raw_pwrite_stream;
 
-class MCXCOFFObjectTargetWriter : public MCObjectTargetWriter {
+class LLVM_ABI MCXCOFFObjectTargetWriter : public MCObjectTargetWriter {
 protected:
   MCXCOFFObjectTargetWriter(bool Is64Bit);
 
@@ -52,7 +52,7 @@ public:
   void setCPU(StringRef TargetCPU) { CPUType = TargetCPU; }
 };
 
-std::unique_ptr<MCObjectWriter>
+LLVM_ABI std::unique_ptr<MCObjectWriter>
 createXCOFFObjectWriter(std::unique_ptr<MCXCOFFObjectTargetWriter> MOTW,
                         raw_pwrite_stream &OS);
 

--- a/llvm/include/llvm/MC/MCXCOFFStreamer.h
+++ b/llvm/include/llvm/MC/MCXCOFFStreamer.h
@@ -14,7 +14,7 @@
 namespace llvm {
 class XCOFFObjectWriter;
 
-class MCXCOFFStreamer : public MCObjectStreamer {
+class LLVM_ABI MCXCOFFStreamer : public MCObjectStreamer {
 public:
   MCXCOFFStreamer(MCContext &Context, std::unique_ptr<MCAsmBackend> MAB,
                   std::unique_ptr<MCObjectWriter> OW,

--- a/llvm/include/llvm/MC/TargetRegistry.h
+++ b/llvm/include/llvm/MC/TargetRegistry.h
@@ -662,7 +662,7 @@ public:
   /// For example feature string "+a,+m,c" is accepted, and results in feature
   /// list {"+a", "+m", "c"}. Later in ApplyFeatureFlag, it asserts
   /// that all features must start with '+' or '-' and assert is failed.
-  static bool isValidFeatureListFormat(StringRef FeaturesString);
+  LLVM_ABI static bool isValidFeatureListFormat(StringRef FeaturesString);
 
   /// @}
 };

--- a/llvm/include/llvm/MCA/CustomBehaviour.h
+++ b/llvm/include/llvm/MCA/CustomBehaviour.h
@@ -137,7 +137,7 @@ class LatencyInstrument : public Instrument {
   std::optional<unsigned> Latency;
 
 public:
-  static const StringRef DESC_NAME;
+  LLVM_ABI static const StringRef DESC_NAME;
   LatencyInstrument(StringRef Data) : Instrument(DESC_NAME, Data) {
     // Skip spaces and tabs.
     Data = Data.trim();

--- a/llvm/include/llvm/MCA/HardwareUnits/RegisterFile.h
+++ b/llvm/include/llvm/MCA/HardwareUnits/RegisterFile.h
@@ -42,27 +42,27 @@ class WriteRef {
   MCPhysReg RegisterID;
   WriteState *Write;
 
-  static const unsigned INVALID_IID;
+  LLVM_ABI static const unsigned INVALID_IID;
 
 public:
   WriteRef()
       : IID(INVALID_IID), WriteBackCycle(), WriteResID(), RegisterID(),
         Write() {}
-  WriteRef(unsigned SourceIndex, WriteState *WS);
+  LLVM_ABI WriteRef(unsigned SourceIndex, WriteState *WS);
 
   unsigned getSourceIndex() const { return IID; }
-  unsigned getWriteBackCycle() const;
+  LLVM_ABI unsigned getWriteBackCycle() const;
 
   const WriteState *getWriteState() const { return Write; }
   WriteState *getWriteState() { return Write; }
-  unsigned getWriteResourceID() const;
-  MCPhysReg getRegisterID() const;
+  LLVM_ABI unsigned getWriteResourceID() const;
+  LLVM_ABI MCPhysReg getRegisterID() const;
 
-  void commit();
-  void notifyExecuted(unsigned Cycle);
+  LLVM_ABI void commit();
+  LLVM_ABI void notifyExecuted(unsigned Cycle);
 
-  bool hasKnownWriteBackCycle() const;
-  bool isWriteZero() const;
+  LLVM_ABI bool hasKnownWriteBackCycle() const;
+  LLVM_ABI bool isWriteZero() const;
   bool isValid() const { return getSourceIndex() != INVALID_IID; }
 
   /// Returns true if this register write has been executed, and the new
@@ -229,13 +229,13 @@ class RegisterFile : public HardwareUnit {
   void initialize(const MCSchedModel &SM, unsigned NumRegs);
 
 public:
-  RegisterFile(const MCSchedModel &SM, const MCRegisterInfo &mri,
-               unsigned NumRegs = 0);
+  LLVM_ABI RegisterFile(const MCSchedModel &SM, const MCRegisterInfo &mri,
+                        unsigned NumRegs = 0);
 
   // Collects writes that are in a RAW dependency with RS.
-  void collectWrites(const MCSubtargetInfo &STI, const ReadState &RS,
-                     SmallVectorImpl<WriteRef> &Writes,
-                     SmallVectorImpl<WriteRef> &CommittedWrites) const;
+  LLVM_ABI void collectWrites(const MCSubtargetInfo &STI, const ReadState &RS,
+                              SmallVectorImpl<WriteRef> &Writes,
+                              SmallVectorImpl<WriteRef> &CommittedWrites) const;
   struct RAWHazard {
     MCPhysReg RegisterID = 0;
     int CyclesLeft = 0;
@@ -245,29 +245,31 @@ public:
     bool hasUnknownCycles() const { return CyclesLeft < 0; }
   };
 
-  RAWHazard checkRAWHazards(const MCSubtargetInfo &STI,
-                            const ReadState &RS) const;
+  LLVM_ABI RAWHazard checkRAWHazards(const MCSubtargetInfo &STI,
+                                     const ReadState &RS) const;
 
   // This method updates the register mappings inserting a new register
   // definition. This method is also responsible for updating the number of
   // allocated physical registers in each register file modified by the write.
   // No physical regiser is allocated if this write is from a zero-idiom.
-  void addRegisterWrite(WriteRef Write, MutableArrayRef<unsigned> UsedPhysRegs);
+  LLVM_ABI void addRegisterWrite(WriteRef Write,
+                                 MutableArrayRef<unsigned> UsedPhysRegs);
 
   // Collect writes that are in a data dependency with RS, and update RS
   // internal state.
-  void addRegisterRead(ReadState &RS, const MCSubtargetInfo &STI) const;
+  LLVM_ABI void addRegisterRead(ReadState &RS,
+                                const MCSubtargetInfo &STI) const;
 
   // Removes write \param WS from the register mappings.
   // Physical registers may be released to reflect this update.
   // No registers are released if this write is from a zero-idiom.
-  void removeRegisterWrite(const WriteState &WS,
-                           MutableArrayRef<unsigned> FreedPhysRegs);
+  LLVM_ABI void removeRegisterWrite(const WriteState &WS,
+                                    MutableArrayRef<unsigned> FreedPhysRegs);
 
   // Returns true if the PRF at index `PRFIndex` can eliminate a move from RS to
   // WS.
-  bool canEliminateMove(const WriteState &WS, const ReadState &RS,
-                        unsigned PRFIndex) const;
+  LLVM_ABI bool canEliminateMove(const WriteState &WS, const ReadState &RS,
+                                 unsigned PRFIndex) const;
 
   // Returns true if this instruction can be fully eliminated at register
   // renaming stage. On success, this method updates the internal state of each
@@ -275,8 +277,8 @@ public:
   // flag for known zero registers. It internally uses `canEliminateMove` to
   // determine if a read/write pair can be eliminated. By default, it assumes a
   // register swap if there is more than one register definition.
-  bool tryEliminateMoveOrSwap(MutableArrayRef<WriteState> Writes,
-                              MutableArrayRef<ReadState> Reads);
+  LLVM_ABI bool tryEliminateMoveOrSwap(MutableArrayRef<WriteState> Writes,
+                                       MutableArrayRef<ReadState> Reads);
 
   // Checks if there are enough physical registers in the register files.
   // Returns a "response mask" where each bit represents the response from a
@@ -287,17 +289,17 @@ public:
   //
   // Current implementation can simulate up to 32 register files (including the
   // special register file at index #0).
-  unsigned isAvailable(ArrayRef<MCPhysReg> Regs) const;
+  LLVM_ABI unsigned isAvailable(ArrayRef<MCPhysReg> Regs) const;
 
   // Returns the number of PRFs implemented by this processor.
   unsigned getNumRegisterFiles() const { return RegisterFiles.size(); }
 
-  unsigned getElapsedCyclesFromWriteBack(const WriteRef &WR) const;
+  LLVM_ABI unsigned getElapsedCyclesFromWriteBack(const WriteRef &WR) const;
 
-  void onInstructionExecuted(Instruction *IS);
+  LLVM_ABI void onInstructionExecuted(Instruction *IS);
 
   // Notify each PRF that a new cycle just started.
-  void cycleStart();
+  LLVM_ABI void cycleStart();
 
   void cycleEnd() { ++CurrentCycle; }
 

--- a/llvm/include/llvm/MCA/HardwareUnits/RetireControlUnit.h
+++ b/llvm/include/llvm/MCA/HardwareUnits/RetireControlUnit.h
@@ -77,7 +77,7 @@ private:
   unsigned computeNextSlotIdx() const;
 
 public:
-  RetireControlUnit(const MCSchedModel &SM);
+  LLVM_ABI RetireControlUnit(const MCSchedModel &SM);
 
   bool isEmpty() const { return AvailableEntries == NumROBEntries; }
 
@@ -88,18 +88,18 @@ public:
   unsigned getMaxRetirePerCycle() const { return MaxRetirePerCycle; }
 
   // Reserves a number of slots, and returns a new token reference.
-  unsigned dispatch(const InstRef &IS);
+  LLVM_ABI unsigned dispatch(const InstRef &IS);
 
   // Return the current token from the RCU's circular token queue.
-  const RUToken &getCurrentToken() const;
+  LLVM_ABI const RUToken &getCurrentToken() const;
 
-  const RUToken &peekNextToken() const;
+  LLVM_ABI const RUToken &peekNextToken() const;
 
   // Advance the pointer to the next token in the circular token queue.
-  void consumeCurrentToken();
+  LLVM_ABI void consumeCurrentToken();
 
   // Update the RCU token to represent the executed state.
-  void onInstructionExecuted(unsigned TokenID);
+  LLVM_ABI void onInstructionExecuted(unsigned TokenID);
 
 #ifndef NDEBUG
   void dump() const;

--- a/llvm/include/llvm/MCA/Stages/DispatchStage.h
+++ b/llvm/include/llvm/MCA/Stages/DispatchStage.h
@@ -46,7 +46,7 @@ namespace mca {
 //
 // If the number of micro opcodes exceedes DispatchWidth, then the instruction
 // is dispatched in multiple cycles.
-class DispatchStage final : public Stage {
+class LLVM_ABI DispatchStage final : public Stage {
   unsigned DispatchWidth;
   unsigned AvailableEntries;
   unsigned CarryOver;

--- a/llvm/include/llvm/MCA/Stages/ExecuteStage.h
+++ b/llvm/include/llvm/MCA/Stages/ExecuteStage.h
@@ -25,7 +25,7 @@
 namespace llvm {
 namespace mca {
 
-class ExecuteStage final : public Stage {
+class LLVM_ABI ExecuteStage final : public Stage {
   Scheduler &HWS;
 
   unsigned NumDispatchedOpcodes;

--- a/llvm/include/llvm/MCA/Stages/InOrderIssueStage.h
+++ b/llvm/include/llvm/MCA/Stages/InOrderIssueStage.h
@@ -46,12 +46,12 @@ struct StallInfo {
   InstRef &getInstruction() { return IR; }
 
   bool isValid() const { return (bool)IR; }
-  void clear();
-  void update(const InstRef &Inst, unsigned Cycles, StallKind SK);
-  void cycleEnd();
+  LLVM_ABI void clear();
+  LLVM_ABI void update(const InstRef &Inst, unsigned Cycles, StallKind SK);
+  LLVM_ABI void cycleEnd();
 };
 
-class InOrderIssueStage final : public Stage {
+class LLVM_ABI InOrderIssueStage final : public Stage {
   const MCSubtargetInfo &STI;
   RegisterFile &PRF;
   ResourceManager RM;

--- a/llvm/include/llvm/MCA/Stages/MicroOpQueueStage.h
+++ b/llvm/include/llvm/MCA/Stages/MicroOpQueueStage.h
@@ -23,7 +23,7 @@ namespace llvm {
 namespace mca {
 
 /// A stage that simulates a queue of instruction opcodes.
-class MicroOpQueueStage : public Stage {
+class LLVM_ABI MicroOpQueueStage : public Stage {
   SmallVector<InstRef, 8> Buffer;
   unsigned NextAvailableSlotIdx;
   unsigned CurrentInstructionSlotIdx;

--- a/llvm/include/llvm/MCA/Stages/RetireStage.h
+++ b/llvm/include/llvm/MCA/Stages/RetireStage.h
@@ -25,7 +25,7 @@
 namespace llvm {
 namespace mca {
 
-class RetireStage final : public Stage {
+class LLVM_ABI RetireStage final : public Stage {
   // Owner will go away when we move listeners/eventing to the stages.
   RetireControlUnit &RCU;
   RegisterFile &PRF;


### PR DESCRIPTION
This updates most LLVM_ABI annotations in the MC/MCA headers to match expected usage:
* All public APIs should be properly annotated.
* Inlined functions should not be annotated.

These changes were done by a script fixing annotations on LLVM public headers and manually checked.

This effort is tracked in #109483.