### PR TITLE
[XeGPU] Handle scf.while result types from scf.condition

### DIFF
--- a/mlir/lib/Dialect/XeGPU/Utils/XeGPUUtils.cpp
+++ b/mlir/lib/Dialect/XeGPU/Utils/XeGPUUtils.cpp
@@ -526,9 +526,28 @@ void xegpu::doSCFStructuralTypeConversionWithTensorType(
       return WalkResult::advance();
     });
 
+    // For scf.while, the parent op results correspond to scf.condition
+    // operands, not to the after-region scf.yield operands.
+    op->walk([](scf::ConditionOp conditionOp) {
+      auto whileOp = dyn_cast<scf::WhileOp>(conditionOp->getParentOp());
+      if (!whileOp)
+        return;
+
+      ValueRange args = conditionOp.getArgs();
+      for (OpResult r : whileOp->getOpResults()) {
+        unsigned idx = r.getResultNumber();
+        Type resultTy = r.getType();
+        Type conditionTy = args[idx].getType();
+        if (isa<RankedTensorType>(resultTy) && conditionTy != resultTy)
+          r.setType(conditionTy);
+      }
+    });
+
     // using yieldOp as anchor to update the result type of its ParentOp
     op->walk([](scf::YieldOp yieldOp) {
       Operation *parentOp = yieldOp->getParentOp();
+      if (isa<scf::WhileOp>(parentOp))
+        return;
       for (OpResult r : parentOp->getOpResults()) {
         unsigned idx = r.getResultNumber();
         Type resultTy = r.getType();

--- a/mlir/lib/Dialect/XeGPU/Utils/XeGPUUtils.cpp
+++ b/mlir/lib/Dialect/XeGPU/Utils/XeGPUUtils.cpp
@@ -526,35 +526,28 @@ void xegpu::doSCFStructuralTypeConversionWithTensorType(
       return WalkResult::advance();
     });
 
-    // For scf.while, the parent op results correspond to scf.condition
-    // operands, not to the after-region scf.yield operands.
-    op->walk([](scf::ConditionOp conditionOp) {
-      auto whileOp = dyn_cast<scf::WhileOp>(conditionOp->getParentOp());
-      if (!whileOp)
-        return;
-
-      ValueRange args = conditionOp.getArgs();
-      for (OpResult r : whileOp->getOpResults()) {
-        unsigned idx = r.getResultNumber();
-        Type resultTy = r.getType();
-        Type conditionTy = args[idx].getType();
-        if (isa<RankedTensorType>(resultTy) && conditionTy != resultTy)
-          r.setType(conditionTy);
+    auto updateTensorResultTypes = [](ResultRange results, ValueRange values) {
+      for (auto [result, value] : llvm::zip_equal(results, values)) {
+        Type resultTy = result.getType();
+        Type valueTy = value.getType();
+        if (isa<RankedTensorType>(resultTy) && valueTy != resultTy)
+          result.setType(valueTy);
       }
+    };
+
+    // For scf.while, parent op results correspond to scf.condition operands,
+    // not to the after-region scf.yield operands.
+    op->walk([&](scf::ConditionOp conditionOp) {
+      auto whileOp = cast<scf::WhileOp>(conditionOp->getParentOp());
+      updateTensorResultTypes(whileOp->getOpResults(), conditionOp.getArgs());
     });
 
     // using yieldOp as anchor to update the result type of its ParentOp
-    op->walk([](scf::YieldOp yieldOp) {
+    op->walk([&](scf::YieldOp yieldOp) {
       Operation *parentOp = yieldOp->getParentOp();
       if (isa<scf::WhileOp>(parentOp))
         return;
-      for (OpResult r : parentOp->getOpResults()) {
-        unsigned idx = r.getResultNumber();
-        Type resultTy = r.getType();
-        Type yieldTy = yieldOp.getResults()[idx].getType();
-        if (isa<RankedTensorType>(resultTy) && yieldTy != resultTy)
-          r.setType(yieldTy);
-      }
+      updateTensorResultTypes(parentOp->getOpResults(), yieldOp.getResults());
     });
   }
 

--- a/mlir/test/Dialect/XeGPU/xegpu-blocking.mlir
+++ b/mlir/test/Dialect/XeGPU/xegpu-blocking.mlir
@@ -1,5 +1,21 @@
 // RUN: mlir-opt --xegpu-blocking -split-input-file %s | FileCheck %s
 
+// CHECK-LABEL: func.func @while_results_without_iter_args
+func.func @while_results_without_iter_args() -> i32 {
+  %c0_i32 = arith.constant 0 : i32
+  %c0_i64 = arith.constant 0 : i64
+  %true = arith.constant true
+  %0:2 = scf.while : () -> (i32, i64) {
+    scf.condition(%true) %c0_i32, %c0_i64 : i32, i64
+  } do {
+  ^bb0(%arg0: i32, %arg1: i64):
+    scf.yield
+  }
+  return %0#0 : i32
+}
+
+// -----
+
 #a = #xegpu.layout<inst_data = [8, 16], lane_layout = [1, 16], lane_data = [8, 1]>
 #b = #xegpu.layout<inst_data = [16, 16], lane_layout = [1, 16], lane_data = [16, 1]>
 #c = #xegpu.layout<inst_data = [8, 16], lane_layout = [1, 16], lane_data = [8, 1]>


### PR DESCRIPTION
This PR resolves https://github.com/llvm/llvm-project/issues/202797. The existing code used scf.yield operands as the source for parent op result types, which is not valid for scf.while. So add codes to skip this situation and update result type from `scf::ConditionOp` op. 

Assisted-by: OpenAI Codex gpt-5.5 medium