### PR TITLE
[llvm] Fix most LLVM_ABI annotations in Support

### DIFF
--- a/llvm/include/llvm/Support/AArch64BuildAttributes.h
+++ b/llvm/include/llvm/Support/AArch64BuildAttributes.h
@@ -30,30 +30,30 @@ enum VendorID : unsigned {
   AEABI_PAUTHABI = 1,
   VENDOR_UNKNOWN = 404 // Treated as a private subsection name
 };
-StringRef getVendorName(unsigned const Vendor);
-VendorID getVendorID(StringRef const Vendor);
+LLVM_ABI StringRef getVendorName(unsigned const Vendor);
+LLVM_ABI VendorID getVendorID(StringRef const Vendor);
 
 enum SubsectionOptional : unsigned {
   REQUIRED = 0,
   OPTIONAL = 1,
   OPTIONAL_NOT_FOUND = 404
 };
-StringRef getOptionalStr(unsigned Optional);
-SubsectionOptional getOptionalID(StringRef Optional);
-StringRef getSubsectionOptionalUnknownError();
+LLVM_ABI StringRef getOptionalStr(unsigned Optional);
+LLVM_ABI SubsectionOptional getOptionalID(StringRef Optional);
+LLVM_ABI StringRef getSubsectionOptionalUnknownError();
 
 enum SubsectionType : unsigned { ULEB128 = 0, NTBS = 1, TYPE_NOT_FOUND = 404 };
-StringRef getTypeStr(unsigned Type);
-SubsectionType getTypeID(StringRef Type);
-StringRef getSubsectionTypeUnknownError();
+LLVM_ABI StringRef getTypeStr(unsigned Type);
+LLVM_ABI SubsectionType getTypeID(StringRef Type);
+LLVM_ABI StringRef getSubsectionTypeUnknownError();
 
 enum PauthABITags : unsigned {
   TAG_PAUTH_PLATFORM = 1,
   TAG_PAUTH_SCHEMA = 2,
   PAUTHABI_TAG_NOT_FOUND = 404
 };
-StringRef getPauthABITagsStr(unsigned PauthABITag);
-PauthABITags getPauthABITagsID(StringRef PauthABITag);
+LLVM_ABI StringRef getPauthABITagsStr(unsigned PauthABITag);
+LLVM_ABI PauthABITags getPauthABITagsID(StringRef PauthABITag);
 
 enum FeatureAndBitsTags : unsigned {
   TAG_FEATURE_BTI = 0,
@@ -61,8 +61,9 @@ enum FeatureAndBitsTags : unsigned {
   TAG_FEATURE_GCS = 2,
   FEATURE_AND_BITS_TAG_NOT_FOUND = 404
 };
-StringRef getFeatureAndBitsTagsStr(unsigned FeatureAndBitsTag);
-FeatureAndBitsTags getFeatureAndBitsTagsID(StringRef FeatureAndBitsTag);
+LLVM_ABI StringRef getFeatureAndBitsTagsStr(unsigned FeatureAndBitsTag);
+LLVM_ABI FeatureAndBitsTags
+getFeatureAndBitsTagsID(StringRef FeatureAndBitsTag);
 
 enum FeatureAndBitsFlag : unsigned {
   Feature_BTI_Flag = 1 << 0,

--- a/llvm/include/llvm/Support/CodeGenCoverage.h
+++ b/llvm/include/llvm/Support/CodeGenCoverage.h
@@ -23,15 +23,15 @@ protected:
 public:
   using const_covered_iterator = BitVector::const_set_bits_iterator;
 
-  CodeGenCoverage();
+  LLVM_ABI CodeGenCoverage();
 
-  void setCovered(uint64_t RuleID);
-  bool isCovered(uint64_t RuleID) const;
-  iterator_range<const_covered_iterator> covered() const;
+  LLVM_ABI void setCovered(uint64_t RuleID);
+  LLVM_ABI bool isCovered(uint64_t RuleID) const;
+  LLVM_ABI iterator_range<const_covered_iterator> covered() const;
 
-  bool parse(MemoryBuffer &Buffer, StringRef BackendName);
-  bool emit(StringRef FilePrefix, StringRef BackendName) const;
-  void reset();
+  LLVM_ABI bool parse(MemoryBuffer &Buffer, StringRef BackendName);
+  LLVM_ABI bool emit(StringRef FilePrefix, StringRef BackendName) const;
+  LLVM_ABI void reset();
 };
 } // namespace llvm
 

--- a/llvm/include/llvm/Support/DebugCounter.h
+++ b/llvm/include/llvm/Support/DebugCounter.h
@@ -180,7 +180,7 @@ public:
 
 protected:
   void addCounter(CounterInfo *Info) { Counters[Info->Name] = Info; }
-  bool handleCounterIncrement(CounterInfo &Info);
+  LLVM_ABI bool handleCounterIncrement(CounterInfo &Info);
 
   MapVector<StringRef, CounterInfo *> Counters;
 

--- a/llvm/include/llvm/Support/JSON.h
+++ b/llvm/include/llvm/Support/JSON.h
@@ -897,12 +897,12 @@ private:
 /// to the original source).
 LLVM_ABI llvm::Expected<Value> parse(llvm::StringRef JSON);
 
-class ParseError : public llvm::ErrorInfo<ParseError> {
+class LLVM_ABI ParseError : public llvm::ErrorInfo<ParseError> {
   const char *Msg;
   unsigned Line, Column, Offset;
 
 public:
-  LLVM_ABI static char ID;
+  static char ID;
   ParseError(const char *Msg, unsigned Line, unsigned Column, unsigned Offset)
       : Msg(Msg), Line(Line), Column(Column), Offset(Offset) {}
   void log(llvm::raw_ostream &OS) const override;

--- a/llvm/include/llvm/Support/Jobserver.h
+++ b/llvm/include/llvm/Support/Jobserver.h
@@ -105,7 +105,7 @@ public:
 
   static JobSlot createImplicit() { return JobSlot(kImplicitValue); }
 
-  uint8_t getExplicitValue() const;
+  LLVM_ABI uint8_t getExplicitValue() const;
   bool isExplicit() const { return isValid() && !isImplicit(); }
 
 private:
@@ -130,7 +130,7 @@ private:
 
 /// The public interface for a jobserver client.
 /// This client is a lazy-initialized singleton that is created on first use.
-class JobserverClient {
+class LLVM_ABI JobserverClient {
 public:
   virtual ~JobserverClient();
 
@@ -149,10 +149,10 @@ public:
   /// Returns the singleton instance of the JobserverClient.
   /// The instance is created on the first call to this function.
   /// Returns a nullptr if no jobserver is configured or an error occurs.
-  LLVM_ABI_FOR_TEST static JobserverClient *getInstance();
+  static JobserverClient *getInstance();
 
   /// Resets the singleton instance. For testing purposes only.
-  LLVM_ABI_FOR_TEST static void resetForTesting();
+  static void resetForTesting();
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Support/LSP/Protocol.h
+++ b/llvm/include/llvm/Support/LSP/Protocol.h
@@ -104,12 +104,12 @@ public:
   URIForFile() = default;
 
   /// Try to build a URIForFile from the given URI string.
-  static llvm::Expected<URIForFile> fromURI(StringRef uri);
+  LLVM_ABI static llvm::Expected<URIForFile> fromURI(StringRef uri);
 
   /// Try to build a URIForFile from the given absolute file path and optional
   /// scheme.
-  static llvm::Expected<URIForFile> fromFile(StringRef absoluteFilepath,
-                                             StringRef scheme = "file");
+  LLVM_ABI static llvm::Expected<URIForFile>
+  fromFile(StringRef absoluteFilepath, StringRef scheme = "file");
 
   /// Returns the absolute path to the file.
   StringRef file() const { return filePath; }
@@ -118,7 +118,7 @@ public:
   StringRef uri() const { return uriStr; }
 
   /// Return the scheme of the uri.
-  StringRef scheme() const;
+  LLVM_ABI StringRef scheme() const;
 
   explicit operator bool() const { return !filePath.empty(); }
 
@@ -135,7 +135,7 @@ public:
   /// Register a supported URI scheme. The protocol supports `file` by default,
   /// so this is only necessary for any additional schemes that a server wants
   /// to support.
-  static void registerSupportedScheme(StringRef scheme);
+  LLVM_ABI static void registerSupportedScheme(StringRef scheme);
 
 private:
   explicit URIForFile(std::string &&filePath, std::string &&uriStr)
@@ -149,7 +149,7 @@ private:
 LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const URIForFile &value);
 LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
                                 URIForFile &result, llvm::json::Path path);
-raw_ostream &operator<<(raw_ostream &os, const URIForFile &value);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &os, const URIForFile &value);
 
 //===----------------------------------------------------------------------===//
 // ClientCapabilities
@@ -344,7 +344,7 @@ struct Position {
 LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
                                 Position &result, llvm::json::Path path);
 LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const Position &value);
-raw_ostream &operator<<(raw_ostream &os, const Position &value);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &os, const Position &value);
 
 //===----------------------------------------------------------------------===//
 // Range
@@ -397,7 +397,7 @@ struct Range {
 LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value, Range &result,
                                 llvm::json::Path path);
 LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const Range &value);
-raw_ostream &operator<<(raw_ostream &os, const Range &value);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &os, const Range &value);
 
 //===----------------------------------------------------------------------===//
 // Location
@@ -432,7 +432,7 @@ struct Location {
 LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
                                 Location &result, llvm::json::Path path);
 LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const Location &value);
-raw_ostream &operator<<(raw_ostream &os, const Location &value);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &os, const Location &value);
 
 //===----------------------------------------------------------------------===//
 // TextDocumentPositionParams
@@ -519,10 +519,11 @@ LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &,
 
 struct TextDocumentContentChangeEvent {
   /// Try to apply this change to the given contents string.
-  LogicalResult applyTo(std::string &contents) const;
+  LLVM_ABI LogicalResult applyTo(std::string &contents) const;
   /// Try to apply a set of changes to the given contents string.
-  static LogicalResult applyTo(ArrayRef<TextDocumentContentChangeEvent> changes,
-                               std::string &contents);
+  LLVM_ABI static LogicalResult
+  applyTo(ArrayRef<TextDocumentContentChangeEvent> changes,
+          std::string &contents);
 
   /// The range of the document that changed.
   std::optional<Range> range;
@@ -562,7 +563,7 @@ enum class MarkupKind {
   PlainText,
   Markdown,
 };
-raw_ostream &operator<<(raw_ostream &os, MarkupKind kind);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &os, MarkupKind kind);
 
 struct MarkupContent {
   MarkupKind kind = MarkupKind::PlainText;
@@ -804,7 +805,7 @@ inline bool operator==(const TextEdit &lhs, const TextEdit &rhs) {
 LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
                                 TextEdit &result, llvm::json::Path path);
 LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const TextEdit &value);
-raw_ostream &operator<<(raw_ostream &os, const TextEdit &value);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &os, const TextEdit &value);
 
 //===----------------------------------------------------------------------===//
 // CompletionItemKind
@@ -852,7 +853,7 @@ LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
                                 CompletionItemKindBitset &result,
                                 llvm::json::Path path);
 
-CompletionItemKind
+LLVM_ABI CompletionItemKind
 adjustKindToCapability(CompletionItemKind kind,
                        CompletionItemKindBitset &supportedCompletionItemKinds);
 
@@ -934,8 +935,8 @@ struct CompletionItem {
 
 /// Add support for JSON serialization.
 LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const CompletionItem &value);
-raw_ostream &operator<<(raw_ostream &os, const CompletionItem &value);
-bool operator<(const CompletionItem &lhs, const CompletionItem &rhs);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &os, const CompletionItem &value);
+LLVM_ABI bool operator<(const CompletionItem &lhs, const CompletionItem &rhs);
 
 //===----------------------------------------------------------------------===//
 // CompletionList
@@ -1036,7 +1037,8 @@ struct SignatureInformation {
 
 /// Add support for JSON serialization.
 LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const SignatureInformation &value);
-raw_ostream &operator<<(raw_ostream &os, const SignatureInformation &value);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &os,
+                                 const SignatureInformation &value);
 
 //===----------------------------------------------------------------------===//
 // SignatureHelp
@@ -1185,9 +1187,10 @@ struct InlayHint {
 
 /// Add support for JSON serialization.
 LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const InlayHint &);
-bool operator==(const InlayHint &lhs, const InlayHint &rhs);
-bool operator<(const InlayHint &lhs, const InlayHint &rhs);
-llvm::raw_ostream &operator<<(llvm::raw_ostream &os, InlayHintKind value);
+LLVM_ABI bool operator==(const InlayHint &lhs, const InlayHint &rhs);
+LLVM_ABI bool operator<(const InlayHint &lhs, const InlayHint &rhs);
+LLVM_ABI llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                       InlayHintKind value);
 
 //===----------------------------------------------------------------------===//
 // CodeActionContext
@@ -1267,9 +1270,9 @@ struct CodeAction {
   /// The kind of the code action.
   /// Used to filter code actions.
   std::optional<std::string> kind;
-  const static llvm::StringLiteral kQuickFix;
-  const static llvm::StringLiteral kRefactor;
-  const static llvm::StringLiteral kInfo;
+  LLVM_ABI const static llvm::StringLiteral kQuickFix;
+  LLVM_ABI const static llvm::StringLiteral kRefactor;
+  LLVM_ABI const static llvm::StringLiteral kInfo;
 
   /// The diagnostics that this code action resolves.
   std::optional<std::vector<Diagnostic>> diagnostics;
@@ -1310,10 +1313,10 @@ struct ShowMessageParams {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const MessageActionItem &Params);
+LLVM_ABI llvm::json::Value toJSON(const MessageActionItem &Params);
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const ShowMessageParams &Params);
+LLVM_ABI llvm::json::Value toJSON(const ShowMessageParams &Params);
 
 } // namespace lsp
 } // namespace llvm

--- a/llvm/include/llvm/Support/LSP/Transport.h
+++ b/llvm/include/llvm/Support/LSP/Transport.h
@@ -73,7 +73,7 @@ private:
 };
 
 /// Concrete implementation of the JSONTransportInput that reads from a file.
-class JSONTransportInputOverFile : public JSONTransportInput {
+class LLVM_ABI JSONTransportInputOverFile : public JSONTransportInput {
 public:
   explicit JSONTransportInputOverFile(
       std::FILE *In, JSONStreamStyle Style = JSONStreamStyle::Standard)
@@ -82,8 +82,8 @@ public:
   bool hasError() const final { return ferror(In); }
   bool isEndOfInput() const final { return feof(In); }
 
-  LLVM_ABI_FOR_TEST LogicalResult readDelimitedMessage(std::string &Json) final;
-  LLVM_ABI_FOR_TEST LogicalResult readStandardMessage(std::string &Json) final;
+  LogicalResult readDelimitedMessage(std::string &Json) final;
+  LogicalResult readStandardMessage(std::string &Json) final;
 
 private:
   std::FILE *In;
@@ -161,9 +161,11 @@ class MessageHandler {
 public:
   MessageHandler(JSONTransport &Transport) : Transport(Transport) {}
 
-  bool onNotify(StringRef Method, llvm::json::Value Value);
-  bool onCall(StringRef Method, llvm::json::Value Params, llvm::json::Value Id);
-  bool onReply(llvm::json::Value Id, llvm::Expected<llvm::json::Value> Result);
+  LLVM_ABI bool onNotify(StringRef Method, llvm::json::Value Value);
+  LLVM_ABI bool onCall(StringRef Method, llvm::json::Value Params,
+                       llvm::json::Value Id);
+  LLVM_ABI bool onReply(llvm::json::Value Id,
+                        llvm::Expected<llvm::json::Value> Result);
 
   template <typename T>
   static llvm::Expected<T> parse(const llvm::json::Value &Raw,

--- a/llvm/include/llvm/Support/MathExtras.h
+++ b/llvm/include/llvm/Support/MathExtras.h
@@ -787,7 +787,7 @@ using stack_float_t = float;
 #endif
 
 /// Returns the number of digits in the given integer.
-int NumDigitsBase10(uint64_t X);
+LLVM_ABI int NumDigitsBase10(uint64_t X);
 
 } // namespace llvm
 

--- a/llvm/include/llvm/Support/OptionStrCmp.h
+++ b/llvm/include/llvm/Support/OptionStrCmp.h
@@ -20,12 +20,12 @@ namespace llvm {
 // precede any other options which prefix them). Additionally, if two options
 // are identical ignoring case, they are ordered according to case sensitive
 // ordering if `FallbackCaseSensitive` is true.
-int StrCmpOptionName(StringRef A, StringRef B,
-                     bool FallbackCaseSensitive = true);
+LLVM_ABI int StrCmpOptionName(StringRef A, StringRef B,
+                              bool FallbackCaseSensitive = true);
 
 // Comparison function for Option prefixes.
-int StrCmpOptionPrefixes(ArrayRef<StringRef> APrefixes,
-                         ArrayRef<StringRef> BPrefixes);
+LLVM_ABI int StrCmpOptionPrefixes(ArrayRef<StringRef> APrefixes,
+                                  ArrayRef<StringRef> BPrefixes);
 
 } // namespace llvm
 

--- a/llvm/include/llvm/Support/VirtualOutputBackend.h
+++ b/llvm/include/llvm/Support/VirtualOutputBackend.h
@@ -31,8 +31,8 @@ namespace llvm::vfs {
 ///
 /// If virtual functions are added here, also add them to \a
 /// ProxyOutputBackend.
-class OutputBackend : public RefCountedBase<OutputBackend> {
-  LLVM_ABI virtual void anchor();
+class LLVM_ABI OutputBackend : public RefCountedBase<OutputBackend> {
+  virtual void anchor();
 
 public:
   /// Get a backend that points to the same destination as this one but that
@@ -47,7 +47,7 @@ public:
   /// have been customized).
   ///
   /// Thread-safe.
-  LLVM_ABI Expected<OutputFile>
+  Expected<OutputFile>
   createFile(const Twine &Path,
              std::optional<OutputConfig> Config = std::nullopt);
 

--- a/llvm/include/llvm/Support/VirtualOutputBackends.h
+++ b/llvm/include/llvm/Support/VirtualOutputBackends.h
@@ -47,8 +47,8 @@ makeMirroringOutputBackend(IntrusiveRefCntPtr<OutputBackend> Backend1,
 
 /// A helper class for proxying another backend, with the default
 /// implementation to forward to the underlying backend.
-class ProxyOutputBackend : public OutputBackend {
-  LLVM_ABI void anchor() override;
+class LLVM_ABI ProxyOutputBackend : public OutputBackend {
+  void anchor() override;
 
 protected:
   // Require subclass to implement cloneImpl().
@@ -76,15 +76,15 @@ private:
 };
 
 /// An output backend that creates files on disk, wrapping APIs in sys::fs.
-class OnDiskOutputBackend : public OutputBackend {
-  LLVM_ABI void anchor() override;
+class LLVM_ABI OnDiskOutputBackend : public OutputBackend {
+  void anchor() override;
 
 protected:
   IntrusiveRefCntPtr<OutputBackend> cloneImpl() const override {
     return clone();
   }
 
-  LLVM_ABI Expected<std::unique_ptr<OutputFileImpl>>
+  Expected<std::unique_ptr<OutputFileImpl>>
   createFileImpl(StringRef Path, std::optional<OutputConfig> Config) override;
 
 public:

--- a/llvm/include/llvm/Support/VirtualOutputConfig.h
+++ b/llvm/include/llvm/Support/VirtualOutputConfig.h
@@ -37,7 +37,7 @@ struct EmptyBaseClass {};
 struct OutputConfig : detail::EmptyBaseClass {
 public:
   LLVM_ABI_FOR_TEST void print(raw_ostream &OS) const;
-  void dump() const;
+  LLVM_ABI void dump() const;
 
 #define HANDLE_OUTPUT_CONFIG_FLAG(NAME, DEFAULT)                               \
   constexpr bool get##NAME() const { return NAME; }                            \

--- a/llvm/include/llvm/Support/VirtualOutputError.h
+++ b/llvm/include/llvm/Support/VirtualOutputError.h
@@ -19,7 +19,7 @@
 
 namespace llvm::vfs {
 
-const std::error_category &output_category();
+LLVM_ABI const std::error_category &output_category();
 
 enum class OutputErrorCode {
   // Error code 0 is absent. Use std::error_code() instead.
@@ -35,7 +35,7 @@ inline std::error_code make_error_code(OutputErrorCode EV) {
 
 /// Error related to an \a OutputFile. Derives from \a ECError and adds \a
 /// getOutputPath().
-class OutputError : public ErrorInfo<OutputError, ECError> {
+class LLVM_ABI OutputError : public ErrorInfo<OutputError, ECError> {
   void anchor() override;
 
 public:
@@ -43,7 +43,7 @@ public:
   void log(raw_ostream &OS) const override;
 
   // Used by ErrorInfo::classID.
-  LLVM_ABI static char ID;
+  static char ID;
 
   OutputError(const Twine &OutputPath, std::error_code EC)
       : ErrorInfo<OutputError, ECError>(EC), OutputPath(OutputPath.str()) {
@@ -70,7 +70,8 @@ inline Error convertToOutputError(const Twine &OutputPath, std::error_code EC) {
 
 /// Error related to an OutputConfig for an \a OutputFile. Derives from \a
 /// OutputError and adds \a getConfig().
-class OutputConfigError : public ErrorInfo<OutputConfigError, OutputError> {
+class LLVM_ABI OutputConfigError
+    : public ErrorInfo<OutputConfigError, OutputError> {
   void anchor() override;
 
 public:
@@ -91,7 +92,8 @@ private:
 
 /// Error related to a temporary file for an \a OutputFile. Derives from \a
 /// OutputError and adds \a getTempPath().
-class TempFileOutputError : public ErrorInfo<TempFileOutputError, OutputError> {
+class LLVM_ABI TempFileOutputError
+    : public ErrorInfo<TempFileOutputError, OutputError> {
   void anchor() override;
 
 public:
@@ -99,7 +101,7 @@ public:
   void log(raw_ostream &OS) const override;
 
   // Used by ErrorInfo::classID.
-  LLVM_ABI static char ID;
+  static char ID;
 
   TempFileOutputError(const Twine &TempPath, const Twine &OutputPath,
                       std::error_code EC)

--- a/llvm/include/llvm/Support/VirtualOutputFile.h
+++ b/llvm/include/llvm/Support/VirtualOutputFile.h
@@ -26,11 +26,11 @@
 
 namespace llvm::vfs {
 
-class OutputFileImpl : public RTTIExtends<OutputFileImpl, RTTIRoot> {
-  LLVM_ABI void anchor() override;
+class LLVM_ABI OutputFileImpl : public RTTIExtends<OutputFileImpl, RTTIRoot> {
+  void anchor() override;
 
 public:
-  LLVM_ABI static char ID;
+  static char ID;
   ~OutputFileImpl() override = default;
 
   virtual Error keep() = 0;
@@ -38,12 +38,12 @@ public:
   virtual raw_pwrite_stream &getOS() = 0;
 };
 
-class NullOutputFileImpl final
+class LLVM_ABI NullOutputFileImpl final
     : public RTTIExtends<NullOutputFileImpl, OutputFileImpl> {
-  LLVM_ABI void anchor() override;
+  void anchor() override;
 
 public:
-  LLVM_ABI static char ID;
+  static char ID;
   Error keep() final { return Error::success(); }
   Error discard() final { return Error::success(); }
   raw_pwrite_stream &getOS() final { return OS; }

--- a/llvm/include/llvm/Support/Watchdog.h
+++ b/llvm/include/llvm/Support/Watchdog.h
@@ -24,8 +24,9 @@ namespace llvm {
     /// to handle it are provided.
     class Watchdog {
     public:
-      Watchdog(unsigned int seconds);
-      ~Watchdog();
+      LLVM_ABI Watchdog(unsigned int seconds);
+      LLVM_ABI ~Watchdog();
+
     private:
       // Noncopyable.
       Watchdog(const Watchdog &other) = delete;

--- a/llvm/include/llvm/Support/circular_raw_ostream.h
+++ b/llvm/include/llvm/Support/circular_raw_ostream.h
@@ -21,138 +21,136 @@ namespace llvm {
   /// to a circular buffer, or can pass it through directly to an
   /// underlying stream if specified with a buffer of zero.
   ///
-  class circular_raw_ostream : public raw_ostream {
-  public:
-    /// TAKE_OWNERSHIP - Tell this stream that it owns the underlying
-    /// stream and is responsible for cleanup, memory management
-    /// issues, etc.
-    ///
-    static constexpr bool TAKE_OWNERSHIP = true;
+class LLVM_ABI circular_raw_ostream : public raw_ostream {
+public:
+  /// TAKE_OWNERSHIP - Tell this stream that it owns the underlying
+  /// stream and is responsible for cleanup, memory management
+  /// issues, etc.
+  ///
+  static constexpr bool TAKE_OWNERSHIP = true;
 
-    /// REFERENCE_ONLY - Tell this stream it should not manage the
-    /// held stream.
-    ///
-    static constexpr bool REFERENCE_ONLY = false;
+  /// REFERENCE_ONLY - Tell this stream it should not manage the
+  /// held stream.
+  ///
+  static constexpr bool REFERENCE_ONLY = false;
 
-  private:
-    /// TheStream - The real stream we output to. We set it to be
-    /// unbuffered, since we're already doing our own buffering.
-    ///
-    raw_ostream *TheStream = nullptr;
+private:
+  /// TheStream - The real stream we output to. We set it to be
+  /// unbuffered, since we're already doing our own buffering.
+  ///
+  raw_ostream *TheStream = nullptr;
 
-    /// OwnsStream - Are we responsible for managing the underlying
-    /// stream?
-    ///
-    bool OwnsStream;
+  /// OwnsStream - Are we responsible for managing the underlying
+  /// stream?
+  ///
+  bool OwnsStream;
 
-    /// BufferSize - The size of the buffer in bytes.
-    ///
-    size_t BufferSize;
+  /// BufferSize - The size of the buffer in bytes.
+  ///
+  size_t BufferSize;
 
-    /// BufferArray - The actual buffer storage.
-    ///
-    char *BufferArray = nullptr;
+  /// BufferArray - The actual buffer storage.
+  ///
+  char *BufferArray = nullptr;
 
-    /// Cur - Pointer to the current output point in BufferArray.
-    ///
-    char *Cur;
+  /// Cur - Pointer to the current output point in BufferArray.
+  ///
+  char *Cur;
 
-    /// Filled - Indicate whether the buffer has been completely
-    /// filled.  This helps avoid garbage output.
-    ///
-    bool Filled = false;
+  /// Filled - Indicate whether the buffer has been completely
+  /// filled.  This helps avoid garbage output.
+  ///
+  bool Filled = false;
 
-    /// Banner - A pointer to a banner to print before dumping the
-    /// log.
-    ///
-    const char *Banner;
+  /// Banner - A pointer to a banner to print before dumping the
+  /// log.
+  ///
+  const char *Banner;
 
-    /// flushBuffer - Dump the contents of the buffer to Stream.
-    ///
-    void flushBuffer() {
-      if (Filled)
-        // Write the older portion of the buffer.
-        TheStream->write(Cur, BufferArray + BufferSize - Cur);
-      // Write the newer portion of the buffer.
-      TheStream->write(BufferArray, Cur - BufferArray);
-      Cur = BufferArray;
-      Filled = false;
-    }
+  /// flushBuffer - Dump the contents of the buffer to Stream.
+  ///
+  void flushBuffer() {
+    if (Filled)
+      // Write the older portion of the buffer.
+      TheStream->write(Cur, BufferArray + BufferSize - Cur);
+    // Write the newer portion of the buffer.
+    TheStream->write(BufferArray, Cur - BufferArray);
+    Cur = BufferArray;
+    Filled = false;
+  }
 
-    void write_impl(const char *Ptr, size_t Size) override;
+  void write_impl(const char *Ptr, size_t Size) override;
 
-    /// current_pos - Return the current position within the stream,
-    /// not counting the bytes currently in the buffer.
-    ///
-    uint64_t current_pos() const override {
-      // This has the same effect as calling TheStream.current_pos(),
-      // but that interface is private.
-      return TheStream->tell() - TheStream->GetNumBytesInBuffer();
-    }
+  /// current_pos - Return the current position within the stream,
+  /// not counting the bytes currently in the buffer.
+  ///
+  uint64_t current_pos() const override {
+    // This has the same effect as calling TheStream.current_pos(),
+    // but that interface is private.
+    return TheStream->tell() - TheStream->GetNumBytesInBuffer();
+  }
 
-  public:
-    /// circular_raw_ostream - Construct an optionally
-    /// circular-buffered stream, handing it an underlying stream to
-    /// do the "real" output.
-    ///
-    /// As a side effect, if BuffSize is nonzero, the given Stream is
-    /// set to be Unbuffered.  This is because circular_raw_ostream
-    /// does its own buffering, so it doesn't want another layer of
-    /// buffering to be happening underneath it.
-    ///
-    /// "Owns" tells the circular_raw_ostream whether it is
-    /// responsible for managing the held stream, doing memory
-    /// management of it, etc.
-    ///
-    circular_raw_ostream(raw_ostream &Stream, const char *Header,
-                         size_t BuffSize = 0, bool Owns = REFERENCE_ONLY)
-        : raw_ostream(/*unbuffered*/ true), OwnsStream(Owns),
-          BufferSize(BuffSize), Banner(Header) {
-      if (BufferSize != 0)
-        BufferArray = new char[BufferSize];
-      Cur = BufferArray;
-      setStream(Stream, Owns);
-    }
+public:
+  /// circular_raw_ostream - Construct an optionally
+  /// circular-buffered stream, handing it an underlying stream to
+  /// do the "real" output.
+  ///
+  /// As a side effect, if BuffSize is nonzero, the given Stream is
+  /// set to be Unbuffered.  This is because circular_raw_ostream
+  /// does its own buffering, so it doesn't want another layer of
+  /// buffering to be happening underneath it.
+  ///
+  /// "Owns" tells the circular_raw_ostream whether it is
+  /// responsible for managing the held stream, doing memory
+  /// management of it, etc.
+  ///
+  circular_raw_ostream(raw_ostream &Stream, const char *Header,
+                       size_t BuffSize = 0, bool Owns = REFERENCE_ONLY)
+      : raw_ostream(/*unbuffered*/ true), OwnsStream(Owns),
+        BufferSize(BuffSize), Banner(Header) {
+    if (BufferSize != 0)
+      BufferArray = new char[BufferSize];
+    Cur = BufferArray;
+    setStream(Stream, Owns);
+  }
 
-    ~circular_raw_ostream() override {
-      flush();
-      flushBufferWithBanner();
-      releaseStream();
-      delete[] BufferArray;
-    }
+  ~circular_raw_ostream() override {
+    flush();
+    flushBufferWithBanner();
+    releaseStream();
+    delete[] BufferArray;
+  }
 
-    bool is_displayed() const override {
-      return TheStream->is_displayed();
-    }
+  bool is_displayed() const override { return TheStream->is_displayed(); }
 
-    /// setStream - Tell the circular_raw_ostream to output a
-    /// different stream.  "Owns" tells circular_raw_ostream whether
-    /// it should take responsibility for managing the underlying
-    /// stream.
-    ///
-    void setStream(raw_ostream &Stream, bool Owns = REFERENCE_ONLY) {
-      releaseStream();
-      TheStream = &Stream;
-      OwnsStream = Owns;
-    }
+  /// setStream - Tell the circular_raw_ostream to output a
+  /// different stream.  "Owns" tells circular_raw_ostream whether
+  /// it should take responsibility for managing the underlying
+  /// stream.
+  ///
+  void setStream(raw_ostream &Stream, bool Owns = REFERENCE_ONLY) {
+    releaseStream();
+    TheStream = &Stream;
+    OwnsStream = Owns;
+  }
 
-    /// flushBufferWithBanner - Force output of the buffer along with
-    /// a small header.
-    ///
-    void flushBufferWithBanner();
+  /// flushBufferWithBanner - Force output of the buffer along with
+  /// a small header.
+  ///
+  void flushBufferWithBanner();
 
-  private:
-    /// releaseStream - Delete the held stream if needed. Otherwise,
-    /// transfer the buffer settings from this circular_raw_ostream
-    /// back to the underlying stream.
-    ///
-    void releaseStream() {
-      if (!TheStream)
-        return;
-      if (OwnsStream)
-        delete TheStream;
-    }
-  };
+private:
+  /// releaseStream - Delete the held stream if needed. Otherwise,
+  /// transfer the buffer settings from this circular_raw_ostream
+  /// back to the underlying stream.
+  ///
+  void releaseStream() {
+    if (!TheStream)
+      return;
+    if (OwnsStream)
+      delete TheStream;
+  }
+};
 } // end llvm namespace
 
 #endif

--- a/llvm/include/llvm/Support/raw_ostream_proxy.h
+++ b/llvm/include/llvm/Support/raw_ostream_proxy.h
@@ -111,8 +111,8 @@ protected:
 
 /// Non-owning proxy for a \a raw_ostream. Enables passing a stream into an
 /// API that takes ownership.
-class raw_ostream_proxy : public raw_ostream_proxy_adaptor<> {
-  LLVM_ABI_FOR_TEST void anchor() override;
+class LLVM_ABI raw_ostream_proxy : public raw_ostream_proxy_adaptor<> {
+  void anchor() override;
 
 public:
   raw_ostream_proxy(raw_ostream &OS) : raw_ostream_proxy_adaptor<>(OS) {}
@@ -120,8 +120,9 @@ public:
 
 /// Non-owning proxy for a \a raw_pwrite_stream. Enables passing a stream
 /// into an API that takes ownership.
-class raw_pwrite_stream_proxy : public raw_pwrite_stream_proxy_adaptor<> {
-  LLVM_ABI_FOR_TEST void anchor() override;
+class LLVM_ABI raw_pwrite_stream_proxy
+    : public raw_pwrite_stream_proxy_adaptor<> {
+  void anchor() override;
 
 public:
   raw_pwrite_stream_proxy(raw_pwrite_stream &OS)


### PR DESCRIPTION
This updates most LLVM_ABI annotations in the Support headers to match expected usage:
* All public APIs should be properly annotated.
* Inlined functions should not be annotated.

These changes were done by a script fixing annotations on LLVM public headers and manually checked.

This effort is tracked in #109483.