### PR TITLE
[NFC][AMDGPU][InsertWaitCnts] Move some simple functions into Utils

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUWaitcntUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaitcntUtils.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "AMDGPUWaitcntUtils.h"
+#include "MCTargetDesc/AMDGPUMCTargetDesc.h"
 #include "Utils/AMDGPUBaseInfo.h"
 
 namespace llvm::AMDGPU {
@@ -45,6 +46,53 @@ StringLiteral getInstCounterName(InstCounterType T) {
     return "NUM_INST_CNTS";
   }
   llvm_unreachable("Unhandled InstCounterType");
+}
+
+HardwareLimits::HardwareLimits(const IsaVersion &IV) {
+  bool HasExtendedWaitCounts = IV.Major >= 12;
+  if (HasExtendedWaitCounts) {
+    LoadcntMax = getLoadcntBitMask(IV);
+    DscntMax = getDscntBitMask(IV);
+  } else {
+    LoadcntMax = getVmcntBitMask(IV);
+    DscntMax = getLgkmcntBitMask(IV);
+  }
+  ExpcntMax = getExpcntBitMask(IV);
+  StorecntMax = getStorecntBitMask(IV);
+  SamplecntMax = getSamplecntBitMask(IV);
+  BvhcntMax = getBvhcntBitMask(IV);
+  KmcntMax = getKmcntBitMask(IV);
+  XcntMax = getXcntBitMask(IV);
+  AsyncMax = getAsynccntBitMask(IV);
+  VaVdstMax = DepCtr::getVaVdstBitMask();
+  VmVsrcMax = DepCtr::getVmVsrcBitMask();
+}
+
+unsigned HardwareLimits::get(InstCounterType T) const {
+  switch (T) {
+  case AMDGPU::LOAD_CNT:
+    return LoadcntMax;
+  case AMDGPU::DS_CNT:
+    return DscntMax;
+  case AMDGPU::EXP_CNT:
+    return ExpcntMax;
+  case AMDGPU::STORE_CNT:
+    return StorecntMax;
+  case AMDGPU::SAMPLE_CNT:
+    return SamplecntMax;
+  case AMDGPU::BVH_CNT:
+    return BvhcntMax;
+  case AMDGPU::KM_CNT:
+    return KmcntMax;
+  case AMDGPU::X_CNT:
+    return XcntMax;
+  case AMDGPU::VA_VDST:
+    return VaVdstMax;
+  case AMDGPU::VM_VSRC:
+    return VmVsrcMax;
+  default:
+    return 0;
+  }
 }
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
@@ -87,6 +135,33 @@ unsigned encodeStorecntDscnt(const IsaVersion &Version,
                              const Waitcnt &Decoded) {
   return encodeStorecntDscnt(Version, Decoded.get(STORE_CNT),
                              Decoded.get(DS_CNT));
+}
+
+std::optional<AMDGPU::InstCounterType> counterTypeForInstr(unsigned Opcode) {
+  switch (Opcode) {
+  case AMDGPU::S_WAIT_LOADCNT:
+    return AMDGPU::LOAD_CNT;
+  case AMDGPU::S_WAIT_EXPCNT:
+    return AMDGPU::EXP_CNT;
+  case AMDGPU::S_WAIT_STORECNT:
+    return AMDGPU::STORE_CNT;
+  case AMDGPU::S_WAIT_SAMPLECNT:
+    return AMDGPU::SAMPLE_CNT;
+  case AMDGPU::S_WAIT_BVHCNT:
+    return AMDGPU::BVH_CNT;
+  case AMDGPU::S_WAIT_DSCNT:
+    return AMDGPU::DS_CNT;
+  case AMDGPU::S_WAIT_KMCNT:
+    return AMDGPU::KM_CNT;
+  case AMDGPU::S_WAIT_XCNT:
+    return AMDGPU::X_CNT;
+  case AMDGPU::S_WAIT_ASYNCCNT:
+    return AMDGPU::ASYNC_CNT;
+  case AMDGPU::S_WAIT_TENSORCNT:
+    return AMDGPU::TENSOR_CNT;
+  default:
+    return {};
+  }
 }
 
 } // namespace llvm::AMDGPU

--- a/llvm/lib/Target/AMDGPU/AMDGPUWaitcntUtils.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaitcntUtils.h
@@ -46,6 +46,28 @@ StringLiteral getInstCounterName(InstCounterType T);
 iota_range<InstCounterType>
 inst_counter_types(InstCounterType MaxCounter = NUM_INST_CNTS);
 
+/// Represents the hardware counter limits for different wait count types.
+struct HardwareLimits {
+  unsigned LoadcntMax; // Corresponds to Vmcnt prior to gfx12.
+  unsigned ExpcntMax;
+  unsigned DscntMax;     // Corresponds to LGKMcnt prior to gfx12.
+  unsigned StorecntMax;  // Corresponds to VScnt in gfx10/gfx11.
+  unsigned SamplecntMax; // gfx12+ only.
+  unsigned BvhcntMax;    // gfx12+ only.
+  unsigned KmcntMax;     // gfx12+ only.
+  unsigned XcntMax;      // gfx1250.
+  unsigned AsyncMax;     // gfx1250.
+  unsigned VaVdstMax;    // gfx12+ expert mode only.
+  unsigned VmVsrcMax;    // gfx12+ expert mode only.
+
+  HardwareLimits() = default;
+
+  /// Initializes hardware limits from ISA version.
+  HardwareLimits(const IsaVersion &IV);
+
+  unsigned get(InstCounterType T) const;
+};
+
 } // namespace AMDGPU
 
 template <> struct enum_iteration_traits<AMDGPU::InstCounterType> {
@@ -109,6 +131,12 @@ public:
     return false;
   }
 
+  void add(AMDGPU::InstCounterType T, unsigned Count) {
+    set(T, std::min(get(T), Count));
+  }
+
+  void clear(AMDGPU::InstCounterType T) { set(T, ~0u); }
+
   bool hasWaitStoreCnt() const { return Cnt[STORE_CNT] != ~0u; }
 
   bool hasWaitDepctr() const {
@@ -167,6 +195,10 @@ unsigned encodeLoadcntDscnt(const IsaVersion &Version, const Waitcnt &Decoded);
 /// immediate that can be used with S_WAIT_STORECNT_DSCNT for given isa
 /// \p Version.
 unsigned encodeStorecntDscnt(const IsaVersion &Version, const Waitcnt &Decoded);
+
+/// Determine if \p MI is a gfx12+ single-counter S_WAIT_*CNT instruction,
+/// and if so, which counter it is waiting on.
+std::optional<AMDGPU::InstCounterType> counterTypeForInstr(unsigned Opcode);
 
 } // namespace AMDGPU
 

--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -74,34 +74,6 @@ static cl::opt<bool> ExpertSchedulingModeFlag(
     cl::init(false), cl::Hidden);
 
 namespace {
-// Get the maximum wait count value for a given counter type.
-static unsigned getWaitCountMax(const AMDGPU::HardwareLimits &Limits,
-                                AMDGPU::InstCounterType T) {
-  switch (T) {
-  case AMDGPU::LOAD_CNT:
-    return Limits.LoadcntMax;
-  case AMDGPU::DS_CNT:
-    return Limits.DscntMax;
-  case AMDGPU::EXP_CNT:
-    return Limits.ExpcntMax;
-  case AMDGPU::STORE_CNT:
-    return Limits.StorecntMax;
-  case AMDGPU::SAMPLE_CNT:
-    return Limits.SamplecntMax;
-  case AMDGPU::BVH_CNT:
-    return Limits.BvhcntMax;
-  case AMDGPU::KM_CNT:
-    return Limits.KmcntMax;
-  case AMDGPU::X_CNT:
-    return Limits.XcntMax;
-  case AMDGPU::VA_VDST:
-    return Limits.VaVdstMax;
-  case AMDGPU::VM_VSRC:
-    return Limits.VmVsrcMax;
-  default:
-    return 0;
-  }
-}
 
 template <typename EmitWaitcntFn>
 static void EmitExpandedWaitcnt(unsigned Outstanding, unsigned Target,
@@ -220,13 +192,6 @@ VmemType getVmemType(const MachineInstr &Inst) {
   return VMEM_NOSAMPLER;
 }
 
-void addWait(AMDGPU::Waitcnt &Wait, AMDGPU::InstCounterType T, unsigned Count) {
-  Wait.set(T, std::min(Wait.get(T), Count));
-}
-
-void setNoWait(AMDGPU::Waitcnt &Wait, AMDGPU::InstCounterType T) {
-  Wait.set(T, ~0u);
-}
 class WaitcntBrackets;
 
 // This abstracts the logic for generating and updating S_WAIT* instructions
@@ -710,7 +675,7 @@ public:
 
   unsigned getPendingGDSWait() const {
     return std::min(getScoreUB(AMDGPU::DS_CNT) - LastGDS,
-                    getWaitCountMax(Context->getLimits(), AMDGPU::DS_CNT) - 1);
+                    Context->getLimits().get(AMDGPU::DS_CNT) - 1);
   }
 
   void setPendingGDS() { LastGDS = ScoreUBs[AMDGPU::DS_CNT]; }
@@ -739,7 +704,7 @@ public:
   void setStateOnFunctionEntryOrReturn() {
     setScoreUB(AMDGPU::STORE_CNT,
                getScoreUB(AMDGPU::STORE_CNT) +
-                   getWaitCountMax(Context->getLimits(), AMDGPU::STORE_CNT));
+                   Context->getLimits().get(AMDGPU::STORE_CNT));
     PendingEvents |= Context->getWaitEvents(AMDGPU::STORE_CNT);
   }
 
@@ -796,10 +761,9 @@ private:
       return;
 
     if (getScoreRange(AMDGPU::EXP_CNT) >
-        getWaitCountMax(Context->getLimits(), AMDGPU::EXP_CNT))
+        Context->getLimits().get(AMDGPU::EXP_CNT))
       ScoreLBs[AMDGPU::EXP_CNT] =
-          ScoreUBs[AMDGPU::EXP_CNT] -
-          getWaitCountMax(Context->getLimits(), AMDGPU::EXP_CNT);
+          ScoreUBs[AMDGPU::EXP_CNT] - Context->getLimits().get(AMDGPU::EXP_CNT);
   }
 
   void setRegScore(MCPhysReg Reg, AMDGPU::InstCounterType T, unsigned Val) {
@@ -1432,18 +1396,18 @@ void WaitcntBrackets::determineWaitForScore(AMDGPU::InstCounterType T,
       // If there is a pending FLAT operation, and this is a VMem or LGKM
       // waitcnt and the target can report early completion, then we need
       // to force a waitcnt 0.
-      addWait(Wait, T, 0);
+      Wait.add(T, 0);
     } else if (counterOutOfOrder(T)) {
       // Counter can get decremented out-of-order when there
       // are multiple types event in the bracket. Also emit an s_wait counter
       // with a conservative value of 0 for the counter.
-      addWait(Wait, T, 0);
+      Wait.add(T, 0);
     } else {
       // If a counter has been maxed out avoid overflow by waiting for
       // MAX(CounterType) - 1 instead.
-      unsigned NeededWait = std::min(
-          UB - ScoreToWait, getWaitCountMax(Context->getLimits(), T) - 1);
-      addWait(Wait, T, NeededWait);
+      unsigned NeededWait =
+          std::min(UB - ScoreToWait, Context->getLimits().get(T) - 1);
+      Wait.add(T, NeededWait);
     }
   }
 }
@@ -1671,36 +1635,6 @@ static bool updateOperandIfDifferent(MachineInstr &MI, AMDGPU::OpName OpName,
   return true;
 }
 
-/// Determine if \p MI is a gfx12+ single-counter S_WAIT_*CNT instruction,
-/// and if so, which counter it is waiting on.
-static std::optional<AMDGPU::InstCounterType>
-counterTypeForInstr(unsigned Opcode) {
-  switch (Opcode) {
-  case AMDGPU::S_WAIT_LOADCNT:
-    return AMDGPU::LOAD_CNT;
-  case AMDGPU::S_WAIT_EXPCNT:
-    return AMDGPU::EXP_CNT;
-  case AMDGPU::S_WAIT_STORECNT:
-    return AMDGPU::STORE_CNT;
-  case AMDGPU::S_WAIT_SAMPLECNT:
-    return AMDGPU::SAMPLE_CNT;
-  case AMDGPU::S_WAIT_BVHCNT:
-    return AMDGPU::BVH_CNT;
-  case AMDGPU::S_WAIT_DSCNT:
-    return AMDGPU::DS_CNT;
-  case AMDGPU::S_WAIT_KMCNT:
-    return AMDGPU::KM_CNT;
-  case AMDGPU::S_WAIT_XCNT:
-    return AMDGPU::X_CNT;
-  case AMDGPU::S_WAIT_ASYNCCNT:
-    return AMDGPU::ASYNC_CNT;
-  case AMDGPU::S_WAIT_TENSORCNT:
-    return AMDGPU::TENSOR_CNT;
-  default:
-    return {};
-  }
-}
-
 bool WaitcntGenerator::promoteSoftWaitCnt(MachineInstr *Waitcnt) const {
   unsigned Opcode = SIInstrInfo::getNonSoftWaitcntOpcode(Waitcnt->getOpcode());
   if (Opcode == Waitcnt->getOpcode())
@@ -1878,7 +1812,7 @@ bool WaitcntGeneratorPreGFX12::createNewWaitcnt(
             continue;
 
           unsigned Outstanding = std::min(ScoreBrackets.getOutstanding(CT),
-                                          getWaitCountMax(getLimits(), CT) - 1);
+                                          getLimits().get(CT) - 1);
           EmitExpandedWaitcnt(Outstanding, WaitCnt, [&](unsigned Count) {
             AMDGPU::Waitcnt W;
             W.set(CT, Count);
@@ -1909,7 +1843,7 @@ bool WaitcntGeneratorPreGFX12::createNewWaitcnt(
       // Only expand if counter is not out-of-order
       unsigned Outstanding =
           std::min(ScoreBrackets.getOutstanding(AMDGPU::STORE_CNT),
-                   getWaitCountMax(getLimits(), AMDGPU::STORE_CNT) - 1);
+                   getLimits().get(AMDGPU::STORE_CNT) - 1);
       EmitExpandedWaitcnt(
           Outstanding, Wait.get(AMDGPU::STORE_CNT), [&](unsigned Count) {
             BuildMI(Block, It, DL, TII.get(AMDGPU::S_WAITCNT_VSCNT))
@@ -2064,14 +1998,15 @@ bool WaitcntGeneratorGFX12Plus::applyPreexistingWaitcnt(
       AMDGPU::Waitcnt OldWait = ScoreBrackets.determineAsyncWait(N);
       Wait = Wait.combined(OldWait);
     } else {
-      std::optional<AMDGPU::InstCounterType> CT = counterTypeForInstr(Opcode);
+      std::optional<AMDGPU::InstCounterType> CT =
+          AMDGPU::counterTypeForInstr(Opcode);
       assert(CT.has_value());
       unsigned OldCnt =
           TII.getNamedOperand(II, AMDGPU::OpName::simm16)->getImm();
       if (TrySimplify)
-        addWait(Wait, CT.value(), OldCnt);
+        Wait.add(CT.value(), OldCnt);
       else
-        addWait(RequiredWait, CT.value(), OldCnt);
+        RequiredWait.add(CT.value(), OldCnt);
       // Keep the first wait of its kind, erase the rest.
       if (WaitInstrs[CT.value()] == nullptr) {
         WaitInstrs[CT.value()] = &II;
@@ -2188,7 +2123,7 @@ bool WaitcntGeneratorGFX12Plus::applyPreexistingWaitcnt(
       Modified |= promoteSoftWaitCnt(WaitInstrs[CT]);
 
       ScoreBrackets.applyWaitcnt(CT, NewCnt);
-      setNoWait(Wait, CT);
+      Wait.clear(CT);
 
       LLVM_DEBUG(It.isEnd()
                      ? dbgs() << "applied pre-existing waitcnt\n"
@@ -2263,8 +2198,8 @@ bool WaitcntGeneratorGFX12Plus::createNewWaitcnt(
         continue;
       }
 
-      unsigned Outstanding = std::min(ScoreBrackets.getOutstanding(CT),
-                                      getWaitCountMax(getLimits(), CT) - 1);
+      unsigned Outstanding =
+          std::min(ScoreBrackets.getOutstanding(CT), getLimits().get(CT) - 1);
       EmitExpandedWaitcnt(Outstanding, Count, [&](unsigned Val) {
         BuildMI(Block, It, DL, TII.get(instrsForExtendedCounterTypes[CT]))
             .addImm(Val);
@@ -2447,7 +2382,7 @@ bool SIInsertWaitcnts::generateWaitcntInstBefore(
     // Wait for any pending GDS instruction to complete before any
     // "Always GDS" instruction.
     if (TII.isAlwaysGDS(Opc) && ScoreBrackets.hasPendingGDS())
-      addWait(Wait, AMDGPU::DS_CNT, ScoreBrackets.getPendingGDSWait());
+      Wait.add(AMDGPU::DS_CNT, ScoreBrackets.getPendingGDSWait());
 
     if (MI.isCall()) {
       // The function is going to insert a wait on everything in its prolog.
@@ -2488,7 +2423,7 @@ bool SIInsertWaitcnts::generateWaitcntInstBefore(
         const Value *Ptr = Memop->getValue();
         if (Memop->isStore()) {
           if (auto It = SLoadAddresses.find(Ptr); It != SLoadAddresses.end()) {
-            addWait(Wait, SmemAccessCounter, 0);
+            Wait.add(SmemAccessCounter, 0);
             if (PDT.dominates(MI.getParent(), It->second))
               SLoadAddresses.erase(It);
           }
@@ -2985,7 +2920,7 @@ static bool isWaitInstr(MachineInstr &Inst) {
          Opcode == AMDGPU::S_WAIT_STORECNT_DSCNT ||
          Opcode == AMDGPU::S_WAITCNT_lds_direct ||
          Opcode == AMDGPU::WAIT_ASYNCMARK ||
-         counterTypeForInstr(Opcode).has_value();
+         AMDGPU::counterTypeForInstr(Opcode).has_value();
 }
 
 void SIInsertWaitcnts::setSchedulingMode(MachineBasicBlock &MBB,

--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -675,7 +675,7 @@ public:
 
   unsigned getPendingGDSWait() const {
     return std::min(getScoreUB(AMDGPU::DS_CNT) - LastGDS,
-                    Context->getLimits().get(AMDGPU::DS_CNT) - 1);
+                    getLimit(AMDGPU::DS_CNT) - 1);
   }
 
   void setPendingGDS() { LastGDS = ScoreUBs[AMDGPU::DS_CNT]; }
@@ -703,8 +703,7 @@ public:
 
   void setStateOnFunctionEntryOrReturn() {
     setScoreUB(AMDGPU::STORE_CNT,
-               getScoreUB(AMDGPU::STORE_CNT) +
-                   Context->getLimits().get(AMDGPU::STORE_CNT));
+               getScoreUB(AMDGPU::STORE_CNT) + getLimit(AMDGPU::STORE_CNT));
     PendingEvents |= Context->getWaitEvents(AMDGPU::STORE_CNT);
   }
 
@@ -724,6 +723,10 @@ public:
   void purgeEmptyTrackingData();
 
 private:
+  unsigned getLimit(AMDGPU::InstCounterType T) const {
+    return Context->getLimits().get(T);
+  }
+
   struct MergeInfo {
     unsigned OldLB;
     unsigned OtherLB;
@@ -760,10 +763,9 @@ private:
     if (T != AMDGPU::EXP_CNT)
       return;
 
-    if (getScoreRange(AMDGPU::EXP_CNT) >
-        Context->getLimits().get(AMDGPU::EXP_CNT))
+    if (getScoreRange(AMDGPU::EXP_CNT) > getLimit(AMDGPU::EXP_CNT))
       ScoreLBs[AMDGPU::EXP_CNT] =
-          ScoreUBs[AMDGPU::EXP_CNT] - Context->getLimits().get(AMDGPU::EXP_CNT);
+          ScoreUBs[AMDGPU::EXP_CNT] - getLimit(AMDGPU::EXP_CNT);
   }
 
   void setRegScore(MCPhysReg Reg, AMDGPU::InstCounterType T, unsigned Val) {
@@ -1405,8 +1407,7 @@ void WaitcntBrackets::determineWaitForScore(AMDGPU::InstCounterType T,
     } else {
       // If a counter has been maxed out avoid overflow by waiting for
       // MAX(CounterType) - 1 instead.
-      unsigned NeededWait =
-          std::min(UB - ScoreToWait, Context->getLimits().get(T) - 1);
+      unsigned NeededWait = std::min(UB - ScoreToWait, getLimit(T) - 1);
       Wait.add(T, NeededWait);
     }
   }

--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -228,7 +228,7 @@ public:
   // optimization.
   bool isOptNone() const { return OptNone; }
 
-  const AMDGPU::HardwareLimits &getLimits() const { return Limits; }
+  unsigned getLimit(AMDGPU::InstCounterType E) const { return Limits.get(E); }
 
   // Edits an existing sequence of wait count instructions according
   // to an incoming Waitcnt value, which is itself updated to reflect
@@ -1812,8 +1812,8 @@ bool WaitcntGeneratorPreGFX12::createNewWaitcnt(
           if (WaitCnt == ~0u)
             continue;
 
-          unsigned Outstanding = std::min(ScoreBrackets.getOutstanding(CT),
-                                          getLimits().get(CT) - 1);
+          unsigned Outstanding =
+              std::min(ScoreBrackets.getOutstanding(CT), getLimit(CT) - 1);
           EmitExpandedWaitcnt(Outstanding, WaitCnt, [&](unsigned Count) {
             AMDGPU::Waitcnt W;
             W.set(CT, Count);
@@ -1844,7 +1844,7 @@ bool WaitcntGeneratorPreGFX12::createNewWaitcnt(
       // Only expand if counter is not out-of-order
       unsigned Outstanding =
           std::min(ScoreBrackets.getOutstanding(AMDGPU::STORE_CNT),
-                   getLimits().get(AMDGPU::STORE_CNT) - 1);
+                   getLimit(AMDGPU::STORE_CNT) - 1);
       EmitExpandedWaitcnt(
           Outstanding, Wait.get(AMDGPU::STORE_CNT), [&](unsigned Count) {
             BuildMI(Block, It, DL, TII.get(AMDGPU::S_WAITCNT_VSCNT))
@@ -2200,7 +2200,7 @@ bool WaitcntGeneratorGFX12Plus::createNewWaitcnt(
       }
 
       unsigned Outstanding =
-          std::min(ScoreBrackets.getOutstanding(CT), getLimits().get(CT) - 1);
+          std::min(ScoreBrackets.getOutstanding(CT), getLimit(CT) - 1);
       EmitExpandedWaitcnt(Outstanding, Count, [&](unsigned Val) {
         BuildMI(Block, It, DL, TII.get(instrsForExtendedCounterTypes[CT]))
             .addImm(Val);

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -1866,26 +1866,6 @@ unsigned getStorecntBitMask(const IsaVersion &Version) {
   return (1 << getStorecntBitWidth(Version.Major)) - 1;
 }
 
-HardwareLimits::HardwareLimits(const IsaVersion &IV) {
-  bool HasExtendedWaitCounts = IV.Major >= 12;
-  if (HasExtendedWaitCounts) {
-    LoadcntMax = getLoadcntBitMask(IV);
-    DscntMax = getDscntBitMask(IV);
-  } else {
-    LoadcntMax = getVmcntBitMask(IV);
-    DscntMax = getLgkmcntBitMask(IV);
-  }
-  ExpcntMax = getExpcntBitMask(IV);
-  StorecntMax = getStorecntBitMask(IV);
-  SamplecntMax = getSamplecntBitMask(IV);
-  BvhcntMax = getBvhcntBitMask(IV);
-  KmcntMax = getKmcntBitMask(IV);
-  XcntMax = getXcntBitMask(IV);
-  AsyncMax = getAsynccntBitMask(IV);
-  VaVdstMax = DepCtr::getVaVdstBitMask();
-  VmVsrcMax = DepCtr::getVmVsrcBitMask();
-}
-
 unsigned getWaitcntBitMask(const IsaVersion &Version) {
   unsigned VmcntLo = getBitMask(getVmcntBitShiftLo(Version.Major),
                                 getVmcntBitWidthLo(Version.Major));

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h
@@ -1106,26 +1106,6 @@ getIntegerVecAttribute(const Function &F, StringRef Name, unsigned Size);
 /// Checks if \p Val is inside \p MD, a !range-like metadata.
 bool hasValueInRangeLikeMetadata(const MDNode &MD, int64_t Val);
 
-/// Represents the hardware counter limits for different wait count types.
-struct HardwareLimits {
-  unsigned LoadcntMax; // Corresponds to Vmcnt prior to gfx12.
-  unsigned ExpcntMax;
-  unsigned DscntMax;     // Corresponds to LGKMcnt prior to gfx12.
-  unsigned StorecntMax;  // Corresponds to VScnt in gfx10/gfx11.
-  unsigned SamplecntMax; // gfx12+ only.
-  unsigned BvhcntMax;    // gfx12+ only.
-  unsigned KmcntMax;     // gfx12+ only.
-  unsigned XcntMax;      // gfx1250.
-  unsigned AsyncMax;     // gfx1250.
-  unsigned VaVdstMax;    // gfx12+ expert mode only.
-  unsigned VmVsrcMax;    // gfx12+ expert mode only.
-
-  HardwareLimits() = default;
-
-  /// Initializes hardware limits from ISA version.
-  HardwareLimits(const IsaVersion &IV);
-};
-
 // The following methods are only meaningful on targets that support
 // S_WAITCNT.
 


### PR DESCRIPTION
Move really trivial functions into helpers to declutter InsertWaitCnt a bit more.
I had to move HardwareLimits into a different header but it's only used in InsertWaitCnt so it doesn't matter.