### PR TITLE
[llvm] Fix most LLVM_ABI annotations in Obj*

### DIFF
--- a/llvm/include/llvm/ObjCopy/DXContainer/DXContainerObjcopy.h
+++ b/llvm/include/llvm/ObjCopy/DXContainer/DXContainerObjcopy.h
@@ -9,6 +9,8 @@
 #ifndef LLVM_OBJCOPY_DXCONTAINER_DXCONTAINEROBJCOPY_H
 #define LLVM_OBJCOPY_DXCONTAINER_DXCONTAINEROBJCOPY_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 class Error;
 class raw_ostream;
@@ -25,10 +27,10 @@ namespace dxbc {
 /// Apply the transformations described by \p Config and \p DXContainerConfig
 /// to \p In and writes the result into \p Out.
 /// \returns any Error encountered whilst performing the operation.
-Error executeObjcopyOnBinary(const CommonConfig &Config,
-                             const DXContainerConfig &,
-                             object::DXContainerObjectFile &In,
-                             raw_ostream &Out);
+LLVM_ABI Error executeObjcopyOnBinary(const CommonConfig &Config,
+                                      const DXContainerConfig &,
+                                      object::DXContainerObjectFile &In,
+                                      raw_ostream &Out);
 } // end namespace dxbc
 } // end namespace objcopy
 } // end namespace llvm

--- a/llvm/include/llvm/ObjCopy/XCOFF/XCOFFObjcopy.h
+++ b/llvm/include/llvm/ObjCopy/XCOFF/XCOFFObjcopy.h
@@ -9,6 +9,8 @@
 #ifndef LLVM_OBJCOPY_XCOFF_XCOFFOBJCOPY_H
 #define LLVM_OBJCOPY_XCOFF_XCOFFOBJCOPY_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 class Error;
 class raw_ostream;
@@ -25,8 +27,10 @@ namespace xcoff {
 /// Apply the transformations described by \p Config and \p XCOFFConfig
 /// to \p In and writes the result into \p Out.
 /// \returns any Error encountered whilst performing the operation.
-Error executeObjcopyOnBinary(const CommonConfig &Config, const XCOFFConfig &,
-                             object::XCOFFObjectFile &In, raw_ostream &Out);
+LLVM_ABI Error executeObjcopyOnBinary(const CommonConfig &Config,
+                                      const XCOFFConfig &,
+                                      object::XCOFFObjectFile &In,
+                                      raw_ostream &Out);
 
 } // end namespace xcoff
 } // end namespace objcopy

--- a/llvm/include/llvm/Object/BBAddrMap.h
+++ b/llvm/include/llvm/Object/BBAddrMap.h
@@ -279,7 +279,7 @@ public:
 /// \p Extractor provides address extraction and the underlying DataExtractor.
 /// \p PGOAnalyses if non-null, receives the decoded PGO analysis data. On
 ///   error, \p PGOAnalyses may be partially populated.
-Expected<std::vector<BBAddrMap>>
+LLVM_ABI Expected<std::vector<BBAddrMap>>
 decodeBBAddrMapPayload(AddressExtractor &Extractor,
                        std::vector<PGOAnalysisMap> *PGOAnalyses = nullptr);
 

--- a/llvm/include/llvm/Object/GOFF.h
+++ b/llvm/include/llvm/Object/GOFF.h
@@ -30,8 +30,9 @@ namespace object {
 /// be called from deriving classes to change values as that record specifies.
 class Record {
 public:
-  static Error getContinuousData(const uint8_t *Record, uint16_t DataLength,
-                                 int DataIndex, SmallString<256> &CompleteData);
+  LLVM_ABI static Error getContinuousData(const uint8_t *Record,
+                                          uint16_t DataLength, int DataIndex,
+                                          SmallString<256> &CompleteData);
 
   static bool isContinued(const uint8_t *Record) {
     uint8_t IsContinued;
@@ -78,7 +79,8 @@ public:
   /// \brief Maximum length of data; any more must go in continuation.
   static const uint8_t TXTMaxDataLength = 56;
 
-  static Error getData(const uint8_t *Record, SmallString<256> &CompleteData);
+  LLVM_ABI static Error getData(const uint8_t *Record,
+                                SmallString<256> &CompleteData);
 
   static void getElementEsdId(const uint8_t *Record, uint32_t &EsdId) {
     get<uint32_t>(Record, 4, EsdId);
@@ -95,7 +97,8 @@ public:
 
 class HDRRecord : public Record {
 public:
-  static Error getData(const uint8_t *Record, SmallString<256> &CompleteData);
+  LLVM_ABI static Error getData(const uint8_t *Record,
+                                SmallString<256> &CompleteData);
 
   static uint16_t getPropertyModuleLength(const uint8_t *Record) {
     uint16_t Length;
@@ -118,7 +121,8 @@ public:
   static const uint16_t MaxNameLength = 32 * 1024;
 
 public:
-  static Error getData(const uint8_t *Record, SmallString<256> &CompleteData);
+  LLVM_ABI static Error getData(const uint8_t *Record,
+                                SmallString<256> &CompleteData);
 
   // ESD Get routines.
   static void getSymbolType(const uint8_t *Record,
@@ -288,7 +292,8 @@ public:
 
 class ENDRecord : public Record {
 public:
-  static Error getData(const uint8_t *Record, SmallString<256> &CompleteData);
+  LLVM_ABI static Error getData(const uint8_t *Record,
+                                SmallString<256> &CompleteData);
 
   static uint16_t getNameLength(const uint8_t *Record) {
     uint16_t Length;

--- a/llvm/include/llvm/Object/OffloadBundle.h
+++ b/llvm/include/llvm/Object/OffloadBundle.h
@@ -56,15 +56,16 @@ public:
     size_t UncompressedFileSize;
     uint64_t Hash;
 
-    static llvm::Expected<CompressedBundleHeader> tryParse(llvm::StringRef);
+    LLVM_ABI static llvm::Expected<CompressedBundleHeader>
+        tryParse(llvm::StringRef);
   };
 
   static inline const uint16_t DefaultVersion = 3;
 
-  static llvm::Expected<std::unique_ptr<llvm::MemoryBuffer>>
+  LLVM_ABI static llvm::Expected<std::unique_ptr<llvm::MemoryBuffer>>
   compress(llvm::compression::Params P, const llvm::MemoryBuffer &Input,
            uint16_t Version, raw_ostream *VerboseStream = nullptr);
-  static llvm::Expected<std::unique_ptr<llvm::MemoryBuffer>>
+  LLVM_ABI static llvm::Expected<std::unique_ptr<llvm::MemoryBuffer>>
   decompress(const llvm::MemoryBuffer &Input,
              raw_ostream *VerboseStream = nullptr);
 };

--- a/llvm/include/llvm/ObjectYAML/ArchiveYAML.h
+++ b/llvm/include/llvm/ObjectYAML/ArchiveYAML.h
@@ -63,13 +63,13 @@ namespace llvm {
 namespace yaml {
 
 template <> struct MappingTraits<ArchYAML::Archive> {
-  static void mapping(IO &IO, ArchYAML::Archive &A);
-  static std::string validate(IO &, ArchYAML::Archive &A);
+  LLVM_ABI static void mapping(IO &IO, ArchYAML::Archive &A);
+  LLVM_ABI static std::string validate(IO &, ArchYAML::Archive &A);
 };
 
 template <> struct MappingTraits<ArchYAML::Archive::Child> {
-  static void mapping(IO &IO, ArchYAML::Archive::Child &C);
-  static std::string validate(IO &, ArchYAML::Archive::Child &C);
+  LLVM_ABI static void mapping(IO &IO, ArchYAML::Archive::Child &C);
+  LLVM_ABI static std::string validate(IO &, ArchYAML::Archive::Child &C);
 };
 
 } // end namespace yaml

--- a/llvm/include/llvm/ObjectYAML/COFFYAML.h
+++ b/llvm/include/llvm/ObjectYAML/COFFYAML.h
@@ -73,8 +73,8 @@ struct SectionDataEntry {
   std::optional<object::coff_load_configuration32> LoadConfig32;
   std::optional<object::coff_load_configuration64> LoadConfig64;
 
-  size_t size() const;
-  void writeAsBinary(raw_ostream &OS) const;
+  LLVM_ABI size_t size() const;
+  LLVM_ABI void writeAsBinary(raw_ostream &OS) const;
 };
 
 struct Section {
@@ -89,7 +89,7 @@ struct Section {
   std::vector<Relocation> Relocations;
   StringRef Name;
 
-  Section();
+  LLVM_ABI Section();
 };
 
 struct Symbol {
@@ -104,7 +104,7 @@ struct Symbol {
   std::optional<COFF::AuxiliaryCLRToken> CLRToken;
   StringRef Name;
 
-  Symbol();
+  LLVM_ABI Symbol();
 };
 
 struct PEHeader {
@@ -119,7 +119,7 @@ struct Object {
   std::vector<Section> Sections;
   std::vector<Symbol> Symbols;
 
-  Object();
+  LLVM_ABI Object();
 };
 
 } // end namespace COFFYAML
@@ -136,152 +136,154 @@ namespace yaml {
 
 template <>
 struct ScalarEnumerationTraits<COFFYAML::WeakExternalCharacteristics> {
-  static void enumeration(IO &IO, COFFYAML::WeakExternalCharacteristics &Value);
+  LLVM_ABI static void
+  enumeration(IO &IO, COFFYAML::WeakExternalCharacteristics &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<COFFYAML::AuxSymbolType> {
-  static void enumeration(IO &IO, COFFYAML::AuxSymbolType &Value);
+  LLVM_ABI static void enumeration(IO &IO, COFFYAML::AuxSymbolType &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<COFFYAML::COMDATType> {
-  static void enumeration(IO &IO, COFFYAML::COMDATType &Value);
+  LLVM_ABI static void enumeration(IO &IO, COFFYAML::COMDATType &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<COFF::MachineTypes> {
-  static void enumeration(IO &IO, COFF::MachineTypes &Value);
+  LLVM_ABI static void enumeration(IO &IO, COFF::MachineTypes &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<COFF::SymbolBaseType> {
-  static void enumeration(IO &IO, COFF::SymbolBaseType &Value);
+  LLVM_ABI static void enumeration(IO &IO, COFF::SymbolBaseType &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<COFF::SymbolStorageClass> {
-  static void enumeration(IO &IO, COFF::SymbolStorageClass &Value);
+  LLVM_ABI static void enumeration(IO &IO, COFF::SymbolStorageClass &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<COFF::SymbolComplexType> {
-  static void enumeration(IO &IO, COFF::SymbolComplexType &Value);
+  LLVM_ABI static void enumeration(IO &IO, COFF::SymbolComplexType &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<COFF::RelocationTypeI386> {
-  static void enumeration(IO &IO, COFF::RelocationTypeI386 &Value);
+  LLVM_ABI static void enumeration(IO &IO, COFF::RelocationTypeI386 &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<COFF::RelocationTypeAMD64> {
-  static void enumeration(IO &IO, COFF::RelocationTypeAMD64 &Value);
+  LLVM_ABI static void enumeration(IO &IO, COFF::RelocationTypeAMD64 &Value);
 };
 
 template <> struct ScalarEnumerationTraits<COFF::RelocationTypesMips> {
-  static void enumeration(IO &IO, COFF::RelocationTypesMips &Value);
+  LLVM_ABI static void enumeration(IO &IO, COFF::RelocationTypesMips &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<COFF::RelocationTypesARM> {
-  static void enumeration(IO &IO, COFF::RelocationTypesARM &Value);
+  LLVM_ABI static void enumeration(IO &IO, COFF::RelocationTypesARM &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<COFF::RelocationTypesARM64> {
-  static void enumeration(IO &IO, COFF::RelocationTypesARM64 &Value);
+  LLVM_ABI static void enumeration(IO &IO, COFF::RelocationTypesARM64 &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<COFF::WindowsSubsystem> {
-  static void enumeration(IO &IO, COFF::WindowsSubsystem &Value);
+  LLVM_ABI static void enumeration(IO &IO, COFF::WindowsSubsystem &Value);
 };
 
 template <>
 struct ScalarBitSetTraits<COFF::Characteristics> {
-  static void bitset(IO &IO, COFF::Characteristics &Value);
+  LLVM_ABI static void bitset(IO &IO, COFF::Characteristics &Value);
 };
 
 template <>
 struct ScalarBitSetTraits<COFF::SectionCharacteristics> {
-  static void bitset(IO &IO, COFF::SectionCharacteristics &Value);
+  LLVM_ABI static void bitset(IO &IO, COFF::SectionCharacteristics &Value);
 };
 
 template <>
 struct ScalarBitSetTraits<COFF::DLLCharacteristics> {
-  static void bitset(IO &IO, COFF::DLLCharacteristics &Value);
+  LLVM_ABI static void bitset(IO &IO, COFF::DLLCharacteristics &Value);
 };
 
 template <>
 struct MappingTraits<COFFYAML::Relocation> {
-  static void mapping(IO &IO, COFFYAML::Relocation &Rel);
+  LLVM_ABI static void mapping(IO &IO, COFFYAML::Relocation &Rel);
 };
 
 template <>
 struct MappingTraits<COFFYAML::PEHeader> {
-  static void mapping(IO &IO, COFFYAML::PEHeader &PH);
+  LLVM_ABI static void mapping(IO &IO, COFFYAML::PEHeader &PH);
 };
 
 template <>
 struct MappingTraits<COFF::DataDirectory> {
-  static void mapping(IO &IO, COFF::DataDirectory &DD);
+  LLVM_ABI static void mapping(IO &IO, COFF::DataDirectory &DD);
 };
 
 template <>
 struct MappingTraits<COFF::header> {
-  static void mapping(IO &IO, COFF::header &H);
+  LLVM_ABI static void mapping(IO &IO, COFF::header &H);
 };
 
 template <> struct MappingTraits<COFF::AuxiliaryFunctionDefinition> {
-  static void mapping(IO &IO, COFF::AuxiliaryFunctionDefinition &AFD);
+  LLVM_ABI static void mapping(IO &IO, COFF::AuxiliaryFunctionDefinition &AFD);
 };
 
 template <> struct MappingTraits<COFF::AuxiliarybfAndefSymbol> {
-  static void mapping(IO &IO, COFF::AuxiliarybfAndefSymbol &AAS);
+  LLVM_ABI static void mapping(IO &IO, COFF::AuxiliarybfAndefSymbol &AAS);
 };
 
 template <> struct MappingTraits<COFF::AuxiliaryWeakExternal> {
-  static void mapping(IO &IO, COFF::AuxiliaryWeakExternal &AWE);
+  LLVM_ABI static void mapping(IO &IO, COFF::AuxiliaryWeakExternal &AWE);
 };
 
 template <> struct MappingTraits<COFF::AuxiliarySectionDefinition> {
-  static void mapping(IO &IO, COFF::AuxiliarySectionDefinition &ASD);
+  LLVM_ABI static void mapping(IO &IO, COFF::AuxiliarySectionDefinition &ASD);
 };
 
 template <> struct MappingTraits<COFF::AuxiliaryCLRToken> {
-  static void mapping(IO &IO, COFF::AuxiliaryCLRToken &ACT);
+  LLVM_ABI static void mapping(IO &IO, COFF::AuxiliaryCLRToken &ACT);
 };
 
 template <> struct MappingTraits<object::coff_load_configuration32> {
-  static void mapping(IO &IO, object::coff_load_configuration32 &ACT);
+  LLVM_ABI static void mapping(IO &IO, object::coff_load_configuration32 &ACT);
 };
 
 template <> struct MappingTraits<object::coff_load_configuration64> {
-  static void mapping(IO &IO, object::coff_load_configuration64 &ACT);
+  LLVM_ABI static void mapping(IO &IO, object::coff_load_configuration64 &ACT);
 };
 
 template <> struct MappingTraits<object::coff_load_config_code_integrity> {
-  static void mapping(IO &IO, object::coff_load_config_code_integrity &ACT);
+  LLVM_ABI static void mapping(IO &IO,
+                               object::coff_load_config_code_integrity &ACT);
 };
 
 template <>
 struct MappingTraits<COFFYAML::Symbol> {
-  static void mapping(IO &IO, COFFYAML::Symbol &S);
+  LLVM_ABI static void mapping(IO &IO, COFFYAML::Symbol &S);
 };
 
 template <> struct MappingTraits<COFFYAML::SectionDataEntry> {
-  static void mapping(IO &IO, COFFYAML::SectionDataEntry &Sec);
+  LLVM_ABI static void mapping(IO &IO, COFFYAML::SectionDataEntry &Sec);
 };
 
 template <>
 struct MappingTraits<COFFYAML::Section> {
-  static void mapping(IO &IO, COFFYAML::Section &Sec);
+  LLVM_ABI static void mapping(IO &IO, COFFYAML::Section &Sec);
 };
 
 template <>
 struct MappingTraits<COFFYAML::Object> {
-  static void mapping(IO &IO, COFFYAML::Object &Obj);
+  LLVM_ABI static void mapping(IO &IO, COFFYAML::Object &Obj);
 };
 
 } // end namespace yaml

--- a/llvm/include/llvm/ObjectYAML/CodeViewYAMLTypeHashing.h
+++ b/llvm/include/llvm/ObjectYAML/CodeViewYAMLTypeHashing.h
@@ -45,9 +45,9 @@ struct DebugHSection {
   std::vector<GlobalHash> Hashes;
 };
 
-DebugHSection fromDebugH(ArrayRef<uint8_t> DebugH);
-ArrayRef<uint8_t> toDebugH(const DebugHSection &DebugH,
-                           BumpPtrAllocator &Alloc);
+LLVM_ABI DebugHSection fromDebugH(ArrayRef<uint8_t> DebugH);
+LLVM_ABI ArrayRef<uint8_t> toDebugH(const DebugHSection &DebugH,
+                                    BumpPtrAllocator &Alloc);
 
 } // end namespace CodeViewYAML
 

--- a/llvm/include/llvm/ObjectYAML/DXContainerYAML.h
+++ b/llvm/include/llvm/ObjectYAML/DXContainerYAML.h
@@ -508,7 +508,7 @@ template <> struct MappingTraits<DXContainerYAML::SignatureElement> {
 };
 
 template <> struct MappingTraits<DXContainerYAML::StringTableEntry> {
-  static void mapping(IO &IO, DXContainerYAML::StringTableEntry &E);
+  LLVM_ABI static void mapping(IO &IO, DXContainerYAML::StringTableEntry &E);
 };
 
 template <> struct MappingTraits<DXContainerYAML::SignatureParameter> {

--- a/llvm/include/llvm/ObjectYAML/ELFYAML.h
+++ b/llvm/include/llvm/ObjectYAML/ELFYAML.h
@@ -30,8 +30,8 @@
 namespace llvm {
 namespace ELFYAML {
 
-StringRef dropUniqueSuffix(StringRef S);
-std::string appendUniqueSuffix(StringRef Name, const Twine& Msg);
+LLVM_ABI StringRef dropUniqueSuffix(StringRef S);
+LLVM_ABI std::string appendUniqueSuffix(StringRef Name, const Twine &Msg);
 
 // These types are invariant across 32/64-bit ELF, so for simplicity just
 // directly give them their exact sizes. We don't need to worry about
@@ -168,7 +168,7 @@ struct NoteEntry {
   ELF_NT Type;
 };
 
-struct Chunk {
+struct LLVM_ABI Chunk {
   enum class ChunkKind {
     Dynamic,
     Group,
@@ -713,12 +713,12 @@ struct Object {
     llvm_unreachable("the section header table chunk must always be present");
   }
 
-  ELF_ELFOSABI getOSAbi() const;
-  unsigned getMachine() const;
+  LLVM_ABI ELF_ELFOSABI getOSAbi() const;
+  LLVM_ABI unsigned getMachine() const;
 };
 
-bool shouldAllocateFileSpace(ArrayRef<ProgramHeader> Phdrs,
-                             const NoBitsSection &S);
+LLVM_ABI bool shouldAllocateFileSpace(ArrayRef<ProgramHeader> Phdrs,
+                                      const NoBitsSection &S);
 
 } // end namespace ELFYAML
 } // end namespace llvm
@@ -743,199 +743,200 @@ namespace llvm {
 namespace yaml {
 
 template <> struct ScalarTraits<ELFYAML::YAMLIntUInt> {
-  static void output(const ELFYAML::YAMLIntUInt &Val, void *Ctx,
-                     raw_ostream &Out);
-  static StringRef input(StringRef Scalar, void *Ctx,
-                         ELFYAML::YAMLIntUInt &Val);
+  LLVM_ABI static void output(const ELFYAML::YAMLIntUInt &Val, void *Ctx,
+                              raw_ostream &Out);
+  LLVM_ABI static StringRef input(StringRef Scalar, void *Ctx,
+                                  ELFYAML::YAMLIntUInt &Val);
   static QuotingType mustQuote(StringRef) { return QuotingType::None; }
 };
 
 template <>
 struct ScalarEnumerationTraits<ELFYAML::ELF_ET> {
-  static void enumeration(IO &IO, ELFYAML::ELF_ET &Value);
+  LLVM_ABI static void enumeration(IO &IO, ELFYAML::ELF_ET &Value);
 };
 
 template <> struct ScalarEnumerationTraits<ELFYAML::ELF_PT> {
-  static void enumeration(IO &IO, ELFYAML::ELF_PT &Value);
+  LLVM_ABI static void enumeration(IO &IO, ELFYAML::ELF_PT &Value);
 };
 
 template <> struct ScalarEnumerationTraits<ELFYAML::ELF_NT> {
-  static void enumeration(IO &IO, ELFYAML::ELF_NT &Value);
+  LLVM_ABI static void enumeration(IO &IO, ELFYAML::ELF_NT &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<ELFYAML::ELF_EM> {
-  static void enumeration(IO &IO, ELFYAML::ELF_EM &Value);
+  LLVM_ABI static void enumeration(IO &IO, ELFYAML::ELF_EM &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<ELFYAML::ELF_ELFCLASS> {
-  static void enumeration(IO &IO, ELFYAML::ELF_ELFCLASS &Value);
+  LLVM_ABI static void enumeration(IO &IO, ELFYAML::ELF_ELFCLASS &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<ELFYAML::ELF_ELFDATA> {
-  static void enumeration(IO &IO, ELFYAML::ELF_ELFDATA &Value);
+  LLVM_ABI static void enumeration(IO &IO, ELFYAML::ELF_ELFDATA &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<ELFYAML::ELF_ELFOSABI> {
-  static void enumeration(IO &IO, ELFYAML::ELF_ELFOSABI &Value);
+  LLVM_ABI static void enumeration(IO &IO, ELFYAML::ELF_ELFOSABI &Value);
 };
 
 template <>
 struct ScalarBitSetTraits<ELFYAML::ELF_EF> {
-  static void bitset(IO &IO, ELFYAML::ELF_EF &Value);
+  LLVM_ABI static void bitset(IO &IO, ELFYAML::ELF_EF &Value);
 };
 
 template <> struct ScalarBitSetTraits<ELFYAML::ELF_PF> {
-  static void bitset(IO &IO, ELFYAML::ELF_PF &Value);
+  LLVM_ABI static void bitset(IO &IO, ELFYAML::ELF_PF &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<ELFYAML::ELF_SHT> {
-  static void enumeration(IO &IO, ELFYAML::ELF_SHT &Value);
+  LLVM_ABI static void enumeration(IO &IO, ELFYAML::ELF_SHT &Value);
 };
 
 template <>
 struct ScalarBitSetTraits<ELFYAML::ELF_SHF> {
-  static void bitset(IO &IO, ELFYAML::ELF_SHF &Value);
+  LLVM_ABI static void bitset(IO &IO, ELFYAML::ELF_SHF &Value);
 };
 
 template <> struct ScalarEnumerationTraits<ELFYAML::ELF_SHN> {
-  static void enumeration(IO &IO, ELFYAML::ELF_SHN &Value);
+  LLVM_ABI static void enumeration(IO &IO, ELFYAML::ELF_SHN &Value);
 };
 
 template <> struct ScalarEnumerationTraits<ELFYAML::ELF_STB> {
-  static void enumeration(IO &IO, ELFYAML::ELF_STB &Value);
+  LLVM_ABI static void enumeration(IO &IO, ELFYAML::ELF_STB &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<ELFYAML::ELF_STT> {
-  static void enumeration(IO &IO, ELFYAML::ELF_STT &Value);
+  LLVM_ABI static void enumeration(IO &IO, ELFYAML::ELF_STT &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<ELFYAML::ELF_REL> {
-  static void enumeration(IO &IO, ELFYAML::ELF_REL &Value);
+  LLVM_ABI static void enumeration(IO &IO, ELFYAML::ELF_REL &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<ELFYAML::ELF_DYNTAG> {
-  static void enumeration(IO &IO, ELFYAML::ELF_DYNTAG &Value);
+  LLVM_ABI static void enumeration(IO &IO, ELFYAML::ELF_DYNTAG &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<ELFYAML::ELF_RSS> {
-  static void enumeration(IO &IO, ELFYAML::ELF_RSS &Value);
+  LLVM_ABI static void enumeration(IO &IO, ELFYAML::ELF_RSS &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<ELFYAML::MIPS_AFL_REG> {
-  static void enumeration(IO &IO, ELFYAML::MIPS_AFL_REG &Value);
+  LLVM_ABI static void enumeration(IO &IO, ELFYAML::MIPS_AFL_REG &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<ELFYAML::MIPS_ABI_FP> {
-  static void enumeration(IO &IO, ELFYAML::MIPS_ABI_FP &Value);
+  LLVM_ABI static void enumeration(IO &IO, ELFYAML::MIPS_ABI_FP &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<ELFYAML::MIPS_AFL_EXT> {
-  static void enumeration(IO &IO, ELFYAML::MIPS_AFL_EXT &Value);
+  LLVM_ABI static void enumeration(IO &IO, ELFYAML::MIPS_AFL_EXT &Value);
 };
 
 template <>
 struct ScalarEnumerationTraits<ELFYAML::MIPS_ISA> {
-  static void enumeration(IO &IO, ELFYAML::MIPS_ISA &Value);
+  LLVM_ABI static void enumeration(IO &IO, ELFYAML::MIPS_ISA &Value);
 };
 
 template <>
 struct ScalarBitSetTraits<ELFYAML::MIPS_AFL_ASE> {
-  static void bitset(IO &IO, ELFYAML::MIPS_AFL_ASE &Value);
+  LLVM_ABI static void bitset(IO &IO, ELFYAML::MIPS_AFL_ASE &Value);
 };
 
 template <>
 struct ScalarBitSetTraits<ELFYAML::MIPS_AFL_FLAGS1> {
-  static void bitset(IO &IO, ELFYAML::MIPS_AFL_FLAGS1 &Value);
+  LLVM_ABI static void bitset(IO &IO, ELFYAML::MIPS_AFL_FLAGS1 &Value);
 };
 
 template <>
 struct MappingTraits<ELFYAML::FileHeader> {
-  static void mapping(IO &IO, ELFYAML::FileHeader &FileHdr);
+  LLVM_ABI static void mapping(IO &IO, ELFYAML::FileHeader &FileHdr);
 };
 
 template <> struct MappingTraits<ELFYAML::SectionHeader> {
-  static void mapping(IO &IO, ELFYAML::SectionHeader &SHdr);
+  LLVM_ABI static void mapping(IO &IO, ELFYAML::SectionHeader &SHdr);
 };
 
 template <> struct MappingTraits<ELFYAML::ProgramHeader> {
-  static void mapping(IO &IO, ELFYAML::ProgramHeader &FileHdr);
-  static std::string validate(IO &IO, ELFYAML::ProgramHeader &FileHdr);
+  LLVM_ABI static void mapping(IO &IO, ELFYAML::ProgramHeader &FileHdr);
+  LLVM_ABI static std::string validate(IO &IO, ELFYAML::ProgramHeader &FileHdr);
 };
 
 template <>
 struct MappingTraits<ELFYAML::Symbol> {
-  static void mapping(IO &IO, ELFYAML::Symbol &Symbol);
-  static std::string validate(IO &IO, ELFYAML::Symbol &Symbol);
+  LLVM_ABI static void mapping(IO &IO, ELFYAML::Symbol &Symbol);
+  LLVM_ABI static std::string validate(IO &IO, ELFYAML::Symbol &Symbol);
 };
 
 template <> struct MappingTraits<ELFYAML::StackSizeEntry> {
-  static void mapping(IO &IO, ELFYAML::StackSizeEntry &Rel);
+  LLVM_ABI static void mapping(IO &IO, ELFYAML::StackSizeEntry &Rel);
 };
 
 template <> struct MappingTraits<ELFYAML::GnuHashHeader> {
-  static void mapping(IO &IO, ELFYAML::GnuHashHeader &Rel);
+  LLVM_ABI static void mapping(IO &IO, ELFYAML::GnuHashHeader &Rel);
 };
 
 template <> struct MappingTraits<ELFYAML::DynamicEntry> {
-  static void mapping(IO &IO, ELFYAML::DynamicEntry &Rel);
+  LLVM_ABI static void mapping(IO &IO, ELFYAML::DynamicEntry &Rel);
 };
 
 template <> struct MappingTraits<ELFYAML::NoteEntry> {
-  static void mapping(IO &IO, ELFYAML::NoteEntry &N);
+  LLVM_ABI static void mapping(IO &IO, ELFYAML::NoteEntry &N);
 };
 
 template <> struct MappingTraits<ELFYAML::VerdefEntry> {
-  static void mapping(IO &IO, ELFYAML::VerdefEntry &E);
+  LLVM_ABI static void mapping(IO &IO, ELFYAML::VerdefEntry &E);
 };
 
 template <> struct MappingTraits<ELFYAML::VerneedEntry> {
-  static void mapping(IO &IO, ELFYAML::VerneedEntry &E);
+  LLVM_ABI static void mapping(IO &IO, ELFYAML::VerneedEntry &E);
 };
 
 template <> struct MappingTraits<ELFYAML::VernauxEntry> {
-  static void mapping(IO &IO, ELFYAML::VernauxEntry &E);
+  LLVM_ABI static void mapping(IO &IO, ELFYAML::VernauxEntry &E);
 };
 
 template <> struct MappingTraits<ELFYAML::LinkerOption> {
-  static void mapping(IO &IO, ELFYAML::LinkerOption &Sym);
+  LLVM_ABI static void mapping(IO &IO, ELFYAML::LinkerOption &Sym);
 };
 
 template <> struct MappingTraits<ELFYAML::CallGraphEntryWeight> {
-  static void mapping(IO &IO, ELFYAML::CallGraphEntryWeight &E);
+  LLVM_ABI static void mapping(IO &IO, ELFYAML::CallGraphEntryWeight &E);
 };
 
 template <> struct MappingTraits<ELFYAML::Relocation> {
-  static void mapping(IO &IO, ELFYAML::Relocation &Rel);
+  LLVM_ABI static void mapping(IO &IO, ELFYAML::Relocation &Rel);
 };
 
 template <> struct MappingTraits<ELFYAML::ARMIndexTableEntry> {
-  static void mapping(IO &IO, ELFYAML::ARMIndexTableEntry &E);
+  LLVM_ABI static void mapping(IO &IO, ELFYAML::ARMIndexTableEntry &E);
 };
 
 template <> struct MappingTraits<std::unique_ptr<ELFYAML::Chunk>> {
-  static void mapping(IO &IO, std::unique_ptr<ELFYAML::Chunk> &C);
-  static std::string validate(IO &io, std::unique_ptr<ELFYAML::Chunk> &C);
+  LLVM_ABI static void mapping(IO &IO, std::unique_ptr<ELFYAML::Chunk> &C);
+  LLVM_ABI static std::string validate(IO &io,
+                                       std::unique_ptr<ELFYAML::Chunk> &C);
 };
 
 template <>
 struct MappingTraits<ELFYAML::Object> {
-  static void mapping(IO &IO, ELFYAML::Object &Object);
+  LLVM_ABI static void mapping(IO &IO, ELFYAML::Object &Object);
 };
 
 template <> struct MappingTraits<ELFYAML::SectionOrType> {
-  static void mapping(IO &IO, ELFYAML::SectionOrType &sectionOrType);
+  LLVM_ABI static void mapping(IO &IO, ELFYAML::SectionOrType &sectionOrType);
 };
 
 } // end namespace yaml

--- a/llvm/include/llvm/ObjectYAML/GOFFYAML.h
+++ b/llvm/include/llvm/ObjectYAML/GOFFYAML.h
@@ -37,7 +37,7 @@ struct FileHeader {
 
 struct Object {
   FileHeader Header;
-  Object();
+  LLVM_ABI Object();
 };
 } // end namespace GOFFYAML
 } // end namespace llvm

--- a/llvm/include/llvm/ObjectYAML/MachOYAML.h
+++ b/llvm/include/llvm/ObjectYAML/MachOYAML.h
@@ -70,7 +70,7 @@ struct FileHeader {
   llvm::yaml::Hex32 reserved;
 };
 
-struct LoadCommand {
+struct LLVM_ABI LoadCommand {
   virtual ~LoadCommand();
 
   llvm::MachO::macho_load_command Data;
@@ -133,7 +133,7 @@ struct LinkEditData {
   std::vector<DataInCodeEntry> DataInCode;
   std::vector<yaml::Hex8> ChainedFixups;
 
-  bool isEmpty() const;
+  LLVM_ABI bool isEmpty() const;
 };
 
 struct Object {
@@ -188,64 +188,66 @@ class raw_ostream;
 namespace yaml {
 
 template <> struct MappingTraits<MachOYAML::FileHeader> {
-  static void mapping(IO &IO, MachOYAML::FileHeader &FileHeader);
+  LLVM_ABI static void mapping(IO &IO, MachOYAML::FileHeader &FileHeader);
 };
 
 template <> struct MappingTraits<MachOYAML::Object> {
-  static void mapping(IO &IO, MachOYAML::Object &Object);
+  LLVM_ABI static void mapping(IO &IO, MachOYAML::Object &Object);
 };
 
 template <> struct MappingTraits<MachOYAML::FatHeader> {
-  static void mapping(IO &IO, MachOYAML::FatHeader &FatHeader);
+  LLVM_ABI static void mapping(IO &IO, MachOYAML::FatHeader &FatHeader);
 };
 
 template <> struct MappingTraits<MachOYAML::FatArch> {
-  static void mapping(IO &IO, MachOYAML::FatArch &FatArch);
+  LLVM_ABI static void mapping(IO &IO, MachOYAML::FatArch &FatArch);
 };
 
 template <> struct MappingTraits<MachOYAML::UniversalBinary> {
-  static void mapping(IO &IO, MachOYAML::UniversalBinary &UniversalBinary);
+  LLVM_ABI static void mapping(IO &IO,
+                               MachOYAML::UniversalBinary &UniversalBinary);
 };
 
 template <> struct MappingTraits<MachOYAML::LoadCommand> {
-  static void mapping(IO &IO, MachOYAML::LoadCommand &LoadCommand);
+  LLVM_ABI static void mapping(IO &IO, MachOYAML::LoadCommand &LoadCommand);
 };
 
 template <> struct MappingTraits<MachOYAML::LinkEditData> {
-  static void mapping(IO &IO, MachOYAML::LinkEditData &LinkEditData);
+  LLVM_ABI static void mapping(IO &IO, MachOYAML::LinkEditData &LinkEditData);
 };
 
 template <> struct MappingTraits<MachOYAML::RebaseOpcode> {
-  static void mapping(IO &IO, MachOYAML::RebaseOpcode &RebaseOpcode);
+  LLVM_ABI static void mapping(IO &IO, MachOYAML::RebaseOpcode &RebaseOpcode);
 };
 
 template <> struct MappingTraits<MachOYAML::BindOpcode> {
-  static void mapping(IO &IO, MachOYAML::BindOpcode &BindOpcode);
+  LLVM_ABI static void mapping(IO &IO, MachOYAML::BindOpcode &BindOpcode);
 };
 
 template <> struct MappingTraits<MachOYAML::ExportEntry> {
-  static void mapping(IO &IO, MachOYAML::ExportEntry &ExportEntry);
+  LLVM_ABI static void mapping(IO &IO, MachOYAML::ExportEntry &ExportEntry);
 };
 
 template <> struct MappingTraits<MachOYAML::Relocation> {
-  static void mapping(IO &IO, MachOYAML::Relocation &R);
+  LLVM_ABI static void mapping(IO &IO, MachOYAML::Relocation &R);
 };
 
 template <> struct MappingTraits<MachOYAML::Section> {
-  static void mapping(IO &IO, MachOYAML::Section &Section);
-  static std::string validate(IO &io, MachOYAML::Section &Section);
+  LLVM_ABI static void mapping(IO &IO, MachOYAML::Section &Section);
+  LLVM_ABI static std::string validate(IO &io, MachOYAML::Section &Section);
 };
 
 template <> struct MappingTraits<MachOYAML::NListEntry> {
-  static void mapping(IO &IO, MachOYAML::NListEntry &NListEntry);
+  LLVM_ABI static void mapping(IO &IO, MachOYAML::NListEntry &NListEntry);
 };
 
 template <> struct MappingTraits<MachO::build_tool_version> {
-  static void mapping(IO &IO, MachO::build_tool_version &tool);
+  LLVM_ABI static void mapping(IO &IO, MachO::build_tool_version &tool);
 };
 
 template <> struct MappingTraits<MachOYAML::DataInCodeEntry> {
-  static void mapping(IO &IO, MachOYAML::DataInCodeEntry &DataInCodeEntry);
+  LLVM_ABI static void mapping(IO &IO,
+                               MachOYAML::DataInCodeEntry &DataInCodeEntry);
 };
 
 #define HANDLE_LOAD_COMMAND(LCName, LCValue, LCStruct)                         \
@@ -298,9 +300,9 @@ template <> struct ScalarEnumerationTraits<MachO::BindOpcode> {
 using char_16 = char[16];
 
 template <> struct ScalarTraits<char_16> {
-  static void output(const char_16 &Val, void *, raw_ostream &Out);
-  static StringRef input(StringRef Scalar, void *, char_16 &Val);
-  static QuotingType mustQuote(StringRef S);
+  LLVM_ABI static void output(const char_16 &Val, void *, raw_ostream &Out);
+  LLVM_ABI static StringRef input(StringRef Scalar, void *, char_16 &Val);
+  LLVM_ABI static QuotingType mustQuote(StringRef S);
 };
 
 // This trait is used for UUIDs. It reads and writes them matching otool's
@@ -308,9 +310,9 @@ template <> struct ScalarTraits<char_16> {
 using uuid_t = raw_ostream::uuid_t;
 
 template <> struct ScalarTraits<uuid_t> {
-  static void output(const uuid_t &Val, void *, raw_ostream &Out);
-  static StringRef input(StringRef Scalar, void *, uuid_t &Val);
-  static QuotingType mustQuote(StringRef S);
+  LLVM_ABI static void output(const uuid_t &Val, void *, raw_ostream &Out);
+  LLVM_ABI static StringRef input(StringRef Scalar, void *, uuid_t &Val);
+  LLVM_ABI static QuotingType mustQuote(StringRef S);
 };
 
 // Load Command struct mapping traits
@@ -324,19 +326,19 @@ template <> struct ScalarTraits<uuid_t> {
 
 // Extra structures used by load commands
 template <> struct MappingTraits<MachO::dylib> {
-  static void mapping(IO &IO, MachO::dylib &LoadCommand);
+  LLVM_ABI static void mapping(IO &IO, MachO::dylib &LoadCommand);
 };
 
 template <> struct MappingTraits<MachO::fvmlib> {
-  static void mapping(IO &IO, MachO::fvmlib &LoadCommand);
+  LLVM_ABI static void mapping(IO &IO, MachO::fvmlib &LoadCommand);
 };
 
 template <> struct MappingTraits<MachO::section> {
-  static void mapping(IO &IO, MachO::section &LoadCommand);
+  LLVM_ABI static void mapping(IO &IO, MachO::section &LoadCommand);
 };
 
 template <> struct MappingTraits<MachO::section_64> {
-  static void mapping(IO &IO, MachO::section_64 &LoadCommand);
+  LLVM_ABI static void mapping(IO &IO, MachO::section_64 &LoadCommand);
 };
 
 } // end namespace yaml

--- a/llvm/include/llvm/ObjectYAML/MinidumpYAML.h
+++ b/llvm/include/llvm/ObjectYAML/MinidumpYAML.h
@@ -24,7 +24,7 @@ namespace MinidumpYAML {
 /// one stream Kind can be used to represent multiple stream Types (e.g. any
 /// unrecognised stream Type will be handled via RawContentStream). The mapping
 /// from Types to Kinds is fixed and given by the static getKind function.
-struct Stream {
+struct LLVM_ABI Stream {
   enum class StreamKind {
     Exception,
     MemoryInfoList,
@@ -234,7 +234,7 @@ struct Object {
   /// The list of streams in this minidump object.
   std::vector<std::unique_ptr<Stream>> Streams;
 
-  static Expected<Object> create(const object::MinidumpFile &File);
+  LLVM_ABI static Expected<Object> create(const object::MinidumpFile &File);
 };
 
 } // namespace MinidumpYAML
@@ -254,19 +254,21 @@ template <> struct BlockScalarTraits<MinidumpYAML::BlockStringRef> {
 };
 
 template <> struct MappingTraits<std::unique_ptr<MinidumpYAML::Stream>> {
-  static void mapping(IO &IO, std::unique_ptr<MinidumpYAML::Stream> &S);
-  static std::string validate(IO &IO, std::unique_ptr<MinidumpYAML::Stream> &S);
+  LLVM_ABI static void mapping(IO &IO,
+                               std::unique_ptr<MinidumpYAML::Stream> &S);
+  LLVM_ABI static std::string
+  validate(IO &IO, std::unique_ptr<MinidumpYAML::Stream> &S);
 };
 
 template <> struct MappingContextTraits<minidump::MemoryDescriptor, BinaryRef> {
-  static void mapping(IO &IO, minidump::MemoryDescriptor &Memory,
-                      BinaryRef &Content);
+  LLVM_ABI static void mapping(IO &IO, minidump::MemoryDescriptor &Memory,
+                               BinaryRef &Content);
 };
 
 template <>
 struct MappingContextTraits<minidump::MemoryDescriptor_64, BinaryRef> {
-  static void mapping(IO &IO, minidump::MemoryDescriptor_64 &Memory,
-                      BinaryRef &Content);
+  LLVM_ABI static void mapping(IO &IO, minidump::MemoryDescriptor_64 &Memory,
+                               BinaryRef &Content);
 };
 
 } // namespace yaml

--- a/llvm/include/llvm/ObjectYAML/ObjectYAML.h
+++ b/llvm/include/llvm/ObjectYAML/ObjectYAML.h
@@ -42,7 +42,7 @@ struct YamlObjectFile {
 };
 
 template <> struct MappingTraits<YamlObjectFile> {
-  static void mapping(IO &IO, YamlObjectFile &ObjectFile);
+  LLVM_ABI static void mapping(IO &IO, YamlObjectFile &ObjectFile);
 };
 
 } // end namespace yaml

--- a/llvm/include/llvm/ObjectYAML/OffloadYAML.h
+++ b/llvm/include/llvm/ObjectYAML/OffloadYAML.h
@@ -54,23 +54,23 @@ namespace llvm {
 namespace yaml {
 
 template <> struct ScalarEnumerationTraits<object::ImageKind> {
-  static void enumeration(IO &IO, object::ImageKind &Value);
+  LLVM_ABI static void enumeration(IO &IO, object::ImageKind &Value);
 };
 
 template <> struct ScalarEnumerationTraits<object::OffloadKind> {
-  static void enumeration(IO &IO, object::OffloadKind &Value);
+  LLVM_ABI static void enumeration(IO &IO, object::OffloadKind &Value);
 };
 
 template <> struct MappingTraits<OffloadYAML::Binary> {
-  static void mapping(IO &IO, OffloadYAML::Binary &O);
+  LLVM_ABI static void mapping(IO &IO, OffloadYAML::Binary &O);
 };
 
 template <> struct MappingTraits<OffloadYAML::Binary::StringEntry> {
-  static void mapping(IO &IO, OffloadYAML::Binary::StringEntry &M);
+  LLVM_ABI static void mapping(IO &IO, OffloadYAML::Binary::StringEntry &M);
 };
 
 template <> struct MappingTraits<OffloadYAML::Binary::Member> {
-  static void mapping(IO &IO, OffloadYAML::Binary::Member &M);
+  LLVM_ABI static void mapping(IO &IO, OffloadYAML::Binary::Member &M);
 };
 
 } // end namespace yaml

--- a/llvm/include/llvm/ObjectYAML/WasmYAML.h
+++ b/llvm/include/llvm/ObjectYAML/WasmYAML.h
@@ -184,7 +184,7 @@ struct Comdat {
   std::vector<ComdatEntry> Entries;
 };
 
-struct Section {
+struct LLVM_ABI Section {
   explicit Section(SectionType SecType) : Type(SecType) {}
   virtual ~Section();
 
@@ -452,151 +452,153 @@ namespace llvm {
 namespace yaml {
 
 template <> struct MappingTraits<WasmYAML::FileHeader> {
-  static void mapping(IO &IO, WasmYAML::FileHeader &FileHdr);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::FileHeader &FileHdr);
 };
 
 template <> struct MappingTraits<std::unique_ptr<WasmYAML::Section>> {
-  static void mapping(IO &IO, std::unique_ptr<WasmYAML::Section> &Section);
+  LLVM_ABI static void mapping(IO &IO,
+                               std::unique_ptr<WasmYAML::Section> &Section);
 };
 
 template <> struct MappingTraits<WasmYAML::Object> {
-  static void mapping(IO &IO, WasmYAML::Object &Object);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::Object &Object);
 };
 
 template <> struct MappingTraits<WasmYAML::Import> {
-  static void mapping(IO &IO, WasmYAML::Import &Import);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::Import &Import);
 };
 
 template <> struct MappingTraits<WasmYAML::Export> {
-  static void mapping(IO &IO, WasmYAML::Export &Export);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::Export &Export);
 };
 
 template <> struct MappingTraits<WasmYAML::Global> {
-  static void mapping(IO &IO, WasmYAML::Global &Global);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::Global &Global);
 };
 
 template <> struct ScalarBitSetTraits<WasmYAML::LimitFlags> {
-  static void bitset(IO &IO, WasmYAML::LimitFlags &Value);
+  LLVM_ABI static void bitset(IO &IO, WasmYAML::LimitFlags &Value);
 };
 
 template <> struct ScalarBitSetTraits<WasmYAML::SymbolFlags> {
-  static void bitset(IO &IO, WasmYAML::SymbolFlags &Value);
+  LLVM_ABI static void bitset(IO &IO, WasmYAML::SymbolFlags &Value);
 };
 
 template <> struct ScalarEnumerationTraits<WasmYAML::SymbolKind> {
-  static void enumeration(IO &IO, WasmYAML::SymbolKind &Kind);
+  LLVM_ABI static void enumeration(IO &IO, WasmYAML::SymbolKind &Kind);
 };
 
 template <> struct ScalarBitSetTraits<WasmYAML::SegmentFlags> {
-  static void bitset(IO &IO, WasmYAML::SegmentFlags &Value);
+  LLVM_ABI static void bitset(IO &IO, WasmYAML::SegmentFlags &Value);
 };
 
 template <> struct ScalarEnumerationTraits<WasmYAML::SectionType> {
-  static void enumeration(IO &IO, WasmYAML::SectionType &Type);
+  LLVM_ABI static void enumeration(IO &IO, WasmYAML::SectionType &Type);
 };
 
 template <> struct MappingTraits<WasmYAML::Signature> {
-  static void mapping(IO &IO, WasmYAML::Signature &Signature);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::Signature &Signature);
 };
 
 template <> struct MappingTraits<WasmYAML::Table> {
-  static void mapping(IO &IO, WasmYAML::Table &Table);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::Table &Table);
 };
 
 template <> struct MappingTraits<WasmYAML::Limits> {
-  static void mapping(IO &IO, WasmYAML::Limits &Limits);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::Limits &Limits);
 };
 
 template <> struct MappingTraits<WasmYAML::Function> {
-  static void mapping(IO &IO, WasmYAML::Function &Function);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::Function &Function);
 };
 
 template <> struct MappingTraits<WasmYAML::Relocation> {
-  static void mapping(IO &IO, WasmYAML::Relocation &Relocation);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::Relocation &Relocation);
 };
 
 template <> struct MappingTraits<WasmYAML::NameEntry> {
-  static void mapping(IO &IO, WasmYAML::NameEntry &NameEntry);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::NameEntry &NameEntry);
 };
 
 template <> struct MappingTraits<WasmYAML::ProducerEntry> {
-  static void mapping(IO &IO, WasmYAML::ProducerEntry &ProducerEntry);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::ProducerEntry &ProducerEntry);
 };
 
 template <> struct ScalarEnumerationTraits<WasmYAML::FeaturePolicyPrefix> {
-  static void enumeration(IO &IO, WasmYAML::FeaturePolicyPrefix &Prefix);
+  LLVM_ABI static void enumeration(IO &IO,
+                                   WasmYAML::FeaturePolicyPrefix &Prefix);
 };
 
 template <> struct MappingTraits<WasmYAML::FeatureEntry> {
-  static void mapping(IO &IO, WasmYAML::FeatureEntry &FeatureEntry);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::FeatureEntry &FeatureEntry);
 };
 
 template <> struct MappingTraits<WasmYAML::SegmentInfo> {
-  static void mapping(IO &IO, WasmYAML::SegmentInfo &SegmentInfo);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::SegmentInfo &SegmentInfo);
 };
 
 template <> struct MappingTraits<WasmYAML::LocalDecl> {
-  static void mapping(IO &IO, WasmYAML::LocalDecl &LocalDecl);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::LocalDecl &LocalDecl);
 };
 
 template <> struct MappingTraits<WasmYAML::InitExpr> {
-  static void mapping(IO &IO, WasmYAML::InitExpr &Expr);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::InitExpr &Expr);
 };
 
 template <> struct MappingTraits<WasmYAML::DataSegment> {
-  static void mapping(IO &IO, WasmYAML::DataSegment &Segment);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::DataSegment &Segment);
 };
 
 template <> struct MappingTraits<WasmYAML::ElemSegment> {
-  static void mapping(IO &IO, WasmYAML::ElemSegment &Segment);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::ElemSegment &Segment);
 };
 
 template <> struct MappingTraits<WasmYAML::SymbolInfo> {
-  static void mapping(IO &IO, WasmYAML::SymbolInfo &Info);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::SymbolInfo &Info);
 };
 
 template <> struct MappingTraits<WasmYAML::InitFunction> {
-  static void mapping(IO &IO, WasmYAML::InitFunction &Init);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::InitFunction &Init);
 };
 
 template <> struct ScalarEnumerationTraits<WasmYAML::ComdatKind> {
-  static void enumeration(IO &IO, WasmYAML::ComdatKind &Kind);
+  LLVM_ABI static void enumeration(IO &IO, WasmYAML::ComdatKind &Kind);
 };
 
 template <> struct MappingTraits<WasmYAML::ComdatEntry> {
-  static void mapping(IO &IO, WasmYAML::ComdatEntry &ComdatEntry);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::ComdatEntry &ComdatEntry);
 };
 
 template <> struct MappingTraits<WasmYAML::Comdat> {
-  static void mapping(IO &IO, WasmYAML::Comdat &Comdat);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::Comdat &Comdat);
 };
 
 template <> struct ScalarEnumerationTraits<WasmYAML::ValueType> {
-  static void enumeration(IO &IO, WasmYAML::ValueType &Type);
+  LLVM_ABI static void enumeration(IO &IO, WasmYAML::ValueType &Type);
 };
 
 template <> struct ScalarEnumerationTraits<WasmYAML::ExportKind> {
-  static void enumeration(IO &IO, WasmYAML::ExportKind &Kind);
+  LLVM_ABI static void enumeration(IO &IO, WasmYAML::ExportKind &Kind);
 };
 
 template <> struct ScalarEnumerationTraits<WasmYAML::TableType> {
-  static void enumeration(IO &IO, WasmYAML::TableType &Type);
+  LLVM_ABI static void enumeration(IO &IO, WasmYAML::TableType &Type);
 };
 
 template <> struct ScalarEnumerationTraits<WasmYAML::Opcode> {
-  static void enumeration(IO &IO, WasmYAML::Opcode &Opcode);
+  LLVM_ABI static void enumeration(IO &IO, WasmYAML::Opcode &Opcode);
 };
 
 template <> struct ScalarEnumerationTraits<WasmYAML::RelocType> {
-  static void enumeration(IO &IO, WasmYAML::RelocType &Kind);
+  LLVM_ABI static void enumeration(IO &IO, WasmYAML::RelocType &Kind);
 };
 
 template <> struct MappingTraits<WasmYAML::DylinkImportInfo> {
-  static void mapping(IO &IO, WasmYAML::DylinkImportInfo &Info);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::DylinkImportInfo &Info);
 };
 
 template <> struct MappingTraits<WasmYAML::DylinkExportInfo> {
-  static void mapping(IO &IO, WasmYAML::DylinkExportInfo &Info);
+  LLVM_ABI static void mapping(IO &IO, WasmYAML::DylinkExportInfo &Info);
 };
 
 } // end namespace yaml

--- a/llvm/include/llvm/ObjectYAML/XCOFFYAML.h
+++ b/llvm/include/llvm/ObjectYAML/XCOFFYAML.h
@@ -94,7 +94,7 @@ enum AuxSymbolType : uint8_t {
   AUX_STAT = 249
 };
 
-struct AuxSymbolEnt {
+struct LLVM_ABI AuxSymbolEnt {
   AuxSymbolType Type;
 
   explicit AuxSymbolEnt(AuxSymbolType T) : Type(T) {}
@@ -216,7 +216,7 @@ struct Object {
   std::vector<Section> Sections;
   std::vector<Symbol> Symbols;
   StringTable StrTbl;
-  Object();
+  LLVM_ABI Object();
 };
 } // namespace XCOFFYAML
 } // namespace llvm
@@ -230,63 +230,65 @@ namespace llvm {
 namespace yaml {
 
 template <> struct ScalarBitSetTraits<XCOFF::SectionTypeFlags> {
-  static void bitset(IO &IO, XCOFF::SectionTypeFlags &Value);
+  LLVM_ABI static void bitset(IO &IO, XCOFF::SectionTypeFlags &Value);
 };
 
 template <> struct ScalarEnumerationTraits<XCOFF::DwarfSectionSubtypeFlags> {
-  static void enumeration(IO &IO, XCOFF::DwarfSectionSubtypeFlags &Value);
+  LLVM_ABI static void enumeration(IO &IO,
+                                   XCOFF::DwarfSectionSubtypeFlags &Value);
 };
 
 template <> struct ScalarEnumerationTraits<XCOFF::StorageClass> {
-  static void enumeration(IO &IO, XCOFF::StorageClass &Value);
+  LLVM_ABI static void enumeration(IO &IO, XCOFF::StorageClass &Value);
 };
 
 template <> struct ScalarEnumerationTraits<XCOFF::StorageMappingClass> {
-  static void enumeration(IO &IO, XCOFF::StorageMappingClass &Value);
+  LLVM_ABI static void enumeration(IO &IO, XCOFF::StorageMappingClass &Value);
 };
 
 template <> struct ScalarEnumerationTraits<XCOFF::SymbolType> {
-  static void enumeration(IO &IO, XCOFF::SymbolType &Value);
+  LLVM_ABI static void enumeration(IO &IO, XCOFF::SymbolType &Value);
 };
 
 template <> struct ScalarEnumerationTraits<XCOFF::CFileStringType> {
-  static void enumeration(IO &IO, XCOFF::CFileStringType &Type);
+  LLVM_ABI static void enumeration(IO &IO, XCOFF::CFileStringType &Type);
 };
 
 template <> struct ScalarEnumerationTraits<XCOFFYAML::AuxSymbolType> {
-  static void enumeration(IO &IO, XCOFFYAML::AuxSymbolType &Type);
+  LLVM_ABI static void enumeration(IO &IO, XCOFFYAML::AuxSymbolType &Type);
 };
 
 template <> struct MappingTraits<XCOFFYAML::FileHeader> {
-  static void mapping(IO &IO, XCOFFYAML::FileHeader &H);
+  LLVM_ABI static void mapping(IO &IO, XCOFFYAML::FileHeader &H);
 };
 
 template <> struct MappingTraits<XCOFFYAML::AuxiliaryHeader> {
-  static void mapping(IO &IO, XCOFFYAML::AuxiliaryHeader &AuxHdr);
+  LLVM_ABI static void mapping(IO &IO, XCOFFYAML::AuxiliaryHeader &AuxHdr);
 };
 
 template <> struct MappingTraits<std::unique_ptr<XCOFFYAML::AuxSymbolEnt>> {
-  static void mapping(IO &IO, std::unique_ptr<XCOFFYAML::AuxSymbolEnt> &AuxSym);
+  LLVM_ABI static void
+  mapping(IO &IO, std::unique_ptr<XCOFFYAML::AuxSymbolEnt> &AuxSym);
 };
 
 template <> struct MappingTraits<XCOFFYAML::Symbol> {
-  static void mapping(IO &IO, XCOFFYAML::Symbol &S);
+  LLVM_ABI static void mapping(IO &IO, XCOFFYAML::Symbol &S);
 };
 
 template <> struct MappingTraits<XCOFFYAML::Relocation> {
-  static void mapping(IO &IO, XCOFFYAML::Relocation &R);
+  LLVM_ABI static void mapping(IO &IO, XCOFFYAML::Relocation &R);
 };
 
 template <> struct MappingTraits<XCOFFYAML::Section> {
-  static void mapping(IO &IO, XCOFFYAML::Section &Sec);
+  LLVM_ABI static void mapping(IO &IO, XCOFFYAML::Section &Sec);
 };
 
 template <> struct MappingTraits<XCOFFYAML::StringTable> {
-  static void mapping(IO &IO, XCOFFYAML::StringTable &Str);
+  LLVM_ABI static void mapping(IO &IO, XCOFFYAML::StringTable &Str);
 };
 
 template <> struct MappingTraits<XCOFFYAML::Object> {
-  static void mapping(IO &IO, XCOFFYAML::Object &Obj);
+  LLVM_ABI static void mapping(IO &IO, XCOFFYAML::Object &Obj);
 };
 
 } // namespace yaml


### PR DESCRIPTION
This updates most LLVM_ABI annotations in the Obj* headers to match expected usage:
* All public APIs should be properly annotated.
* Inlined functions should not be annotated.

These changes were done by a script fixing annotations on LLVM public headers and manually checked.

This effort is tracked in #109483.