### PR TITLE
Fix DebugInfo unittests shared library build

### DIFF
--- a/llvm/unittests/DebugInfo/PDB/CMakeLists.txt
+++ b/llvm/unittests/DebugInfo/PDB/CMakeLists.txt
@@ -2,6 +2,7 @@ set(LLVM_LINK_COMPONENTS
   DebugInfoCodeView
   DebugInfoMSF
   DebugInfoPDB
+  Object
   )
 
 add_llvm_unittest_with_input_files(DebugInfoPDBTests


### PR DESCRIPTION
Fixes: `PublicsStreamTest.cpp.o: undefined reference to symbol '_ZN4llvm6object18GenericBinaryErrorC1ERKNS_5TwineENS0_12object_errorE'` under `BUILD_SHARED_LIBS=1`.