### PR TITLE
[mlir][SPIR-V] Fix swapped GL/CL SAbs ops in arith.remsi lowering

### DIFF
--- a/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
+++ b/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
@@ -471,7 +471,7 @@ struct RemSIOpGLPattern final : public OpConversionPattern<arith::RemSIOp> {
   LogicalResult
   matchAndRewrite(arith::RemSIOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value result = emulateSignedRemainder<spirv::CLSAbsOp>(
+    Value result = emulateSignedRemainder<spirv::GLSAbsOp>(
         op.getLoc(), adaptor.getOperands()[0], adaptor.getOperands()[1],
         adaptor.getOperands()[0], rewriter);
     rewriter.replaceOp(op, result);
@@ -487,7 +487,7 @@ struct RemSIOpCLPattern final : public OpConversionPattern<arith::RemSIOp> {
   LogicalResult
   matchAndRewrite(arith::RemSIOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value result = emulateSignedRemainder<spirv::GLSAbsOp>(
+    Value result = emulateSignedRemainder<spirv::CLSAbsOp>(
         op.getLoc(), adaptor.getOperands()[0], adaptor.getOperands()[1],
         adaptor.getOperands()[0], rewriter);
     rewriter.replaceOp(op, result);


### PR DESCRIPTION
Could be treated as NFC:

The GL/CL template args were confused but in fact it did not affect the actual result, so no test modification is required. The reason is that driver legalizes ops by target env capabilities and rewriter that created the unsupported variant of the op is dropped and another one is picked