### PR TITLE
[CodeGen] Gate rematerializer unit tests on AMDGPU target being enabled

### DIFF
--- a/llvm/unittests/CodeGen/RematerializerTest.cpp
+++ b/llvm/unittests/CodeGen/RematerializerTest.cpp
@@ -97,6 +97,8 @@ public:
     LLVMInitializeAMDGPUTargetInfo();
     LLVMInitializeAMDGPUTarget();
     LLVMInitializeAMDGPUTargetMC();
+#else
+    GTEST_SKIP();
 #endif
   }
 

--- a/llvm/unittests/CodeGen/RematerializerTest.cpp
+++ b/llvm/unittests/CodeGen/RematerializerTest.cpp
@@ -93,9 +93,11 @@ struct RematerializerWrapper {
 class RematerializerTest : public CodeGenTestBase {
 public:
   static void SetUpTestCase() {
+#if LLVM_HAS_AMDGPU_TARGET
     LLVMInitializeAMDGPUTargetInfo();
     LLVMInitializeAMDGPUTarget();
     LLVMInitializeAMDGPUTargetMC();
+#endif
   }
 
   void SetUp() override { setUpImpl("amdgcn--", "gfx950", ""); }


### PR DESCRIPTION
Issue introduced in #197575. Initialization functions for the AMDGPU target only work if the target is enabled.