### PR TITLE
[lldb][Windows] Fix ECHO_TO_FILE/ECHO_APPEND_FILE

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -47,8 +47,8 @@ ifeq "$(OS)" "Windows_NT"
 	RM_RF = rd /s /q $(subst /,\,$(1))
 	LN_SF = mklink /D "$(subst /,\,$(2))" "$(subst /,\,$(1))"
 	ECHO = echo $(1);
-	ECHO_TO_FILE = printf "%s\n" $(1) > "$(subst /,\,$(2))"
-	ECHO_APPEND_FILE = printf "%s\n" $(1) >> "$(subst /,\,$(2))"
+	ECHO_TO_FILE = echo $(subst ',,$(1))> "$(subst /,\,$(2))"
+	ECHO_APPEND_FILE = echo $(subst ',,$(1))>> "$(subst /,\,$(2))"
 else
 	MKDIR_P = mkdir -p $(1)
 	CP = cp $(1) $(2)


### PR DESCRIPTION
The Windows recipes for these macros were printf "%s\n" $(1). The callers wrap content in single quotes (for the POSIX printf), but the test recipes run under cmd.exe on Windows, which keeps the single quotes literal and word-splits on spaces, and the bundled printf additionally mangles backslashes and spaces. The result is garbage generated files (e.g. a modulemap whose first line is 'module, or a truncated SDK path from a "Program Files" directory).

Write the file with cmd's echo after stripping the callers' single quotes. echo runs in the recipe shell, so unlike GNU make's $(file ...) it still works after a preceding MKDIR_P in the same recipe.

This is a reland of https://github.com/llvm/llvm-project/pull/202612 which add the changes in the wrong if/else branch.

rdar://179218545