### PR TITLE
[Object][ELF] Remove internal linkage from header function templates (NFC)

### DIFF
--- a/llvm/include/llvm/Object/ELF.h
+++ b/llvm/include/llvm/Object/ELF.h
@@ -130,8 +130,8 @@ template <class T> struct DataRegion {
 };
 
 template <class ELFT>
-static std::string getSecIndexForError(const ELFFile<ELFT> &Obj,
-                                       const typename ELFT::Shdr &Sec) {
+std::string getSecIndexForError(const ELFFile<ELFT> &Obj,
+                                const typename ELFT::Shdr &Sec) {
   auto TableOrErr = Obj.sections();
   if (TableOrErr)
     return "[index " + std::to_string(&Sec - &TableOrErr->front()) + "]";
@@ -144,8 +144,7 @@ static std::string getSecIndexForError(const ELFFile<ELFT> &Obj,
 }
 
 template <class ELFT>
-static std::string describe(const ELFFile<ELFT> &Obj,
-                            const typename ELFT::Shdr &Sec) {
+std::string describe(const ELFFile<ELFT> &Obj, const typename ELFT::Shdr &Sec) {
   unsigned SecNdx = &Sec - &cantFail(Obj.sections()).front();
   return (object::getELFSectionTypeName(Obj.getHeader().e_machine,
                                         Sec.sh_type) +
@@ -154,8 +153,8 @@ static std::string describe(const ELFFile<ELFT> &Obj,
 }
 
 template <class ELFT>
-static std::string getPhdrIndexForError(const ELFFile<ELFT> &Obj,
-                                        const typename ELFT::Phdr &Phdr) {
+std::string getPhdrIndexForError(const ELFFile<ELFT> &Obj,
+                                 const typename ELFT::Phdr &Phdr) {
   auto Headers = Obj.program_headers();
   if (Headers)
     return ("[index " + Twine(&Phdr - &Headers->front()) + "]").str();
@@ -169,8 +168,8 @@ static inline Error defaultWarningHandler(const Twine &Msg) {
 }
 
 template <class ELFT>
-static bool checkSectionOffsets(const typename ELFT::Phdr &Phdr,
-                                const typename ELFT::Shdr &Sec) {
+bool checkSectionOffsets(const typename ELFT::Phdr &Phdr,
+                         const typename ELFT::Shdr &Sec) {
   // SHT_NOBITS sections don't need to have an offset inside the segment.
   if (Sec.sh_type == ELF::SHT_NOBITS)
     return true;
@@ -187,8 +186,8 @@ static bool checkSectionOffsets(const typename ELFT::Phdr &Phdr,
 // Check that an allocatable section belongs to a virtual address
 // space of a segment.
 template <class ELFT>
-static bool checkSectionVMA(const typename ELFT::Phdr &Phdr,
-                            const typename ELFT::Shdr &Sec) {
+bool checkSectionVMA(const typename ELFT::Phdr &Phdr,
+                     const typename ELFT::Shdr &Sec) {
   if (!(Sec.sh_flags & ELF::SHF_ALLOC))
     return true;
 
@@ -206,8 +205,8 @@ static bool checkSectionVMA(const typename ELFT::Phdr &Phdr,
 }
 
 template <class ELFT>
-static bool isSectionInSegment(const typename ELFT::Phdr &Phdr,
-                               const typename ELFT::Shdr &Sec) {
+bool isSectionInSegment(const typename ELFT::Phdr &Phdr,
+                        const typename ELFT::Shdr &Sec) {
   return checkSectionOffsets<ELFT>(Phdr, Sec) &&
          checkSectionVMA<ELFT>(Phdr, Sec);
 }
@@ -215,7 +214,7 @@ static bool isSectionInSegment(const typename ELFT::Phdr &Phdr,
 // HdrHandler is called once with the number of relocations and whether the
 // relocations have addends. EntryHandler is called once per decoded relocation.
 template <bool Is64>
-static Error decodeCrel(
+Error decodeCrel(
     ArrayRef<uint8_t> Content,
     function_ref<void(uint64_t /*relocation count*/, bool /*explicit addends*/)>
         HdrHandler,
@@ -861,7 +860,7 @@ ELFFile<ELFT>::getSectionStringTable(Elf_Shdr_Range Sections,
 ///
 /// @param Table The GNU hash table for .dynsym.
 template <class ELFT>
-static Expected<uint64_t>
+Expected<uint64_t>
 getDynSymtabSizeFromGnuHash(const typename ELFT::GnuHash &Table,
                             const void *BufEnd) {
   using Elf_Word = typename ELFT::Word;


### PR DESCRIPTION
These `static` function templates live in a header, so every translation unit that includes it gets its own internal-linkage copy. That's a latent ODR hazard, and it trips `-Wunused-template` in every TU that doesn't instantiate them. Dropping `static` gives them external linkage (templates are implicitly inline, so nothing else changes). This matches `getElfArchType` in the same file, which is already a plain `inline` helper.

NFC: linkage-only change.

Part of #202945 