### PR TITLE
[Mips] Remove unused function templates (NFC)

### DIFF
--- a/llvm/lib/Target/Mips/Disassembler/MipsDisassembler.cpp
+++ b/llvm/lib/Target/Mips/Disassembler/MipsDisassembler.cpp
@@ -339,21 +339,6 @@ static DecodeStatus DecodeINSVE_DF(MCInst &MI, InsnType insn, uint64_t Address,
 }
 
 template <typename InsnType>
-static DecodeStatus DecodeDAHIDATIMMR6(MCInst &MI, InsnType insn,
-                                       uint64_t Address,
-                                       const MCDisassembler *Decoder) {
-  InsnType Rs = fieldFromInstruction(insn, 16, 5);
-  InsnType Imm = fieldFromInstruction(insn, 0, 16);
-  MI.addOperand(MCOperand::createReg(getReg(Decoder, Mips::GPR64RegClassID,
-                                       Rs)));
-  MI.addOperand(MCOperand::createReg(getReg(Decoder, Mips::GPR64RegClassID,
-                                       Rs)));
-  MI.addOperand(MCOperand::createImm(Imm));
-
-  return MCDisassembler::Success;
-}
-
-template <typename InsnType>
 static DecodeStatus DecodeDAHIDATI(MCInst &MI, InsnType insn, uint64_t Address,
                                    const MCDisassembler *Decoder) {
   InsnType Rs = fieldFromInstruction(insn, 21, 5);

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsELFObjectWriter.cpp
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsELFObjectWriter.cpp
@@ -54,62 +54,7 @@ public:
   void sortRelocs(std::vector<ELFRelocationEntry> &Relocs) override;
 };
 
-/// The possible results of the Predicate function used by find_best.
-enum FindBestPredicateResult {
-  FindBest_NoMatch = 0,  ///< The current element is not a match.
-  FindBest_Match,        ///< The current element is a match but better ones are
-                         ///  possible.
-  FindBest_PerfectMatch, ///< The current element is an unbeatable match.
-};
-
 } // end anonymous namespace
-
-/// Copy elements in the range [First, Last) to d1 when the predicate is true or
-/// d2 when the predicate is false. This is essentially both std::copy_if and
-/// std::remove_copy_if combined into a single pass.
-template <class InputIt, class OutputIt1, class OutputIt2, class UnaryPredicate>
-static std::pair<OutputIt1, OutputIt2> copy_if_else(InputIt First, InputIt Last,
-                                                    OutputIt1 d1, OutputIt2 d2,
-                                                    UnaryPredicate Predicate) {
-  for (InputIt I = First; I != Last; ++I) {
-    if (Predicate(*I)) {
-      *d1 = *I;
-      d1++;
-    } else {
-      *d2 = *I;
-      d2++;
-    }
-  }
-
-  return std::make_pair(d1, d2);
-}
-
-/// Find the best match in the range [First, Last).
-///
-/// An element matches when Predicate(X) returns FindBest_Match or
-/// FindBest_PerfectMatch. A value of FindBest_PerfectMatch also terminates
-/// the search. BetterThan(A, B) is a comparator that returns true when A is a
-/// better match than B. The return value is the position of the best match.
-///
-/// This is similar to std::find_if but finds the best of multiple possible
-/// matches.
-template <class InputIt, class UnaryPredicate, class Comparator>
-static InputIt find_best(InputIt First, InputIt Last, UnaryPredicate Predicate,
-                         Comparator BetterThan) {
-  InputIt Best = Last;
-
-  for (InputIt I = First; I != Last; ++I) {
-    unsigned Matched = Predicate(*I);
-    if (Matched != FindBest_NoMatch) {
-      if (Best == Last || BetterThan(*I, *Best))
-        Best = I;
-    }
-    if (Matched == FindBest_PerfectMatch)
-      break;
-  }
-
-  return Best;
-}
 
 /// Determine the low relocation that matches the given relocation.
 /// If the relocation does not need a low relocation then the return value


### PR DESCRIPTION
A few function templates in the Mips MC layer have no callers anywhere, so they never get instantiated and trip `-Wunused-template`. They all live in `.cpp` files, so this is plain dead-code removal.

`MipsELFObjectWriter.cpp`: `copy_if_else` and `find_best` lost their only user when `sortRelocs` was rewritten in #104723. The `FindBestPredicateResult` enum existed only for `find_best`, so it goes too.

`MipsDisassembler.cpp`: `DecodeDAHIDATIMMR6` isn't referenced by any `DecoderMethod`. The r6 DAHI/DATI instructions decode through its sibling `DecodeDAHIDATI`, which is what the generated tables actually call.

NFC: removes uninstantiated templates only.

Part of #202945.