### PR TITLE
[MLIR][GPUToNVVM] Emit aligned nvvm.barrier for workgroup gpu.barrier

### DIFF
--- a/mlir/lib/Conversion/GPUToNVVM/LowerGpuOpsToNVVMOps.cpp
+++ b/mlir/lib/Conversion/GPUToNVVM/LowerGpuOpsToNVVMOps.cpp
@@ -433,7 +433,12 @@ struct GPUBarrierOpToNVVMLowering final
     gpu::BarrierScope scope = op.getScope();
     switch (scope) {
     case gpu::BarrierScope::Workgroup:
-      rewriter.replaceOpWithNewOp<NVVM::BarrierOp>(op);
+      // A workgroup barrier synchronizes the whole CTA: every thread is
+      // required to reach this same barrier instruction, so it is safe to emit
+      // the .aligned form of the barrier intrinsic.
+      rewriter.replaceOpWithNewOp<NVVM::BarrierOp>(op, /*barrierId=*/Value{},
+                                                   /*numberOfThreads=*/Value{},
+                                                   /*aligned=*/true);
       return success();
     case gpu::BarrierScope::Subgroup: {
       // Emit __syncwarp(0xFFFFFFFF) for full-warp sync.

--- a/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm.mlir
+++ b/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm.mlir
@@ -185,7 +185,7 @@ gpu.module @test_module_4 {
 gpu.module @test_module_5 {
   // CHECK-LABEL: func @gpu_sync()
   func.func @gpu_sync() {
-    // CHECK: nvvm.barrier
+    // CHECK: nvvm.barrier {aligned = true}
     gpu.barrier
     func.return
   }


### PR DESCRIPTION
The nvvm.barrier op defaults its aligned attribute to false, lowering to the non-aligned @llvm.nvvm.barrier.cta.* intrinsics. A workgroup gpu.barrier synchronizes the whole CTA, where every thread is required to reach the same barrier instruction, so it is safe to emit the .aligned form. Set aligned = true for the workgroup scope while leaving named (partial) barriers non-aligned.