### PR TITLE
[JITLink][ORC] Clean up unused and assert-only function templates (NFC)

### DIFF
--- a/llvm/lib/ExecutionEngine/JITLink/aarch32.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/aarch32.cpp
@@ -341,32 +341,16 @@ const FixupInfoBase *FixupInfoBase::getDynFixupInfo(Edge::Kind K) {
 }
 
 template <EdgeKind_aarch32 Kind>
-bool checkRegister(const ThumbRelocation &R, HalfWords Reg) {
+[[maybe_unused]] bool checkRegister(const ThumbRelocation &R, HalfWords Reg) {
   uint16_t Hi = R.Hi & FixupInfo<Kind>::RegMask.Hi;
   uint16_t Lo = R.Lo & FixupInfo<Kind>::RegMask.Lo;
   return Hi == Reg.Hi && Lo == Reg.Lo;
 }
 
 template <EdgeKind_aarch32 Kind>
-bool checkRegister(const ArmRelocation &R, uint32_t Reg) {
+[[maybe_unused]] bool checkRegister(const ArmRelocation &R, uint32_t Reg) {
   uint32_t Wd = R.Wd & FixupInfo<Kind>::RegMask;
   return Wd == Reg;
-}
-
-template <EdgeKind_aarch32 Kind>
-void writeRegister(WritableThumbRelocation &R, HalfWords Reg) {
-  static constexpr HalfWords Mask = FixupInfo<Kind>::RegMask;
-  assert((Mask.Hi & Reg.Hi) == Reg.Hi && (Mask.Lo & Reg.Lo) == Reg.Lo &&
-         "Value bits exceed bit range of given mask");
-  R.Hi = (R.Hi & ~Mask.Hi) | Reg.Hi;
-  R.Lo = (R.Lo & ~Mask.Lo) | Reg.Lo;
-}
-
-template <EdgeKind_aarch32 Kind>
-void writeRegister(WritableArmRelocation &R, uint32_t Reg) {
-  static constexpr uint32_t Mask = FixupInfo<Kind>::RegMask;
-  assert((Mask & Reg) == Reg && "Value bits exceed bit range of given mask");
-  R.Wd = (R.Wd & ~Mask) | Reg;
 }
 
 template <EdgeKind_aarch32 Kind>

--- a/llvm/lib/ExecutionEngine/Orc/OrcABISupport.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/OrcABISupport.cpp
@@ -16,9 +16,9 @@ using namespace llvm;
 using namespace llvm::orc;
 
 template <typename ORCABI>
-static bool stubAndPointerRangesOk(ExecutorAddr StubBlockAddr,
-                                   ExecutorAddr PointerBlockAddr,
-                                   unsigned NumStubs) {
+[[maybe_unused]] static bool
+stubAndPointerRangesOk(ExecutorAddr StubBlockAddr,
+                       ExecutorAddr PointerBlockAddr, unsigned NumStubs) {
   constexpr unsigned MaxDisp = ORCABI::StubToPointerMaxDisplacement;
   ExecutorAddr FirstStub = StubBlockAddr;
   ExecutorAddr LastStub = FirstStub + ((NumStubs - 1) * ORCABI::StubSize);


### PR DESCRIPTION
These function templates trip `-Wunused-template`.

In `aarch32.cpp`, `writeRegister` has no callers, so it's removed. `checkRegister` is only used inside `assert`, so it gets compiled out in release builds (`-DNDEBUG`) and never instantiates; it's marked `[[maybe_unused]]`. Same story for `stubAndPointerRangesOk` in `OrcABISupport.cpp`, which is only used in asserts.

NFC.

Part of #202945.