### PR TITLE
[IR] Remove unused and mark debug-only verifier templates (NFC)

### DIFF
--- a/llvm/lib/IR/SafepointIRVerifier.cpp
+++ b/llvm/lib/IR/SafepointIRVerifier.cpp
@@ -267,6 +267,8 @@ static bool containsGCPtrType(Type *Ty) {
 }
 
 // Debugging aid -- prints a [Begin, End) range of values.
+// Only used inside LLVM_DEBUG below, so it has no instantiations in release
+// builds (NDEBUG); [[maybe_unused]] avoids -Wunused-template in that case.
 template <typename IteratorTy>
 [[maybe_unused]] static void PrintValueSet(raw_ostream &OS, IteratorTy Begin,
                                            IteratorTy End) {

--- a/llvm/lib/IR/SafepointIRVerifier.cpp
+++ b/llvm/lib/IR/SafepointIRVerifier.cpp
@@ -267,8 +267,9 @@ static bool containsGCPtrType(Type *Ty) {
 }
 
 // Debugging aid -- prints a [Begin, End) range of values.
-template<typename IteratorTy>
-static void PrintValueSet(raw_ostream &OS, IteratorTy Begin, IteratorTy End) {
+template <typename IteratorTy>
+[[maybe_unused]] static void PrintValueSet(raw_ostream &OS, IteratorTy Begin,
+                                           IteratorTy End) {
   OS << "[ ";
   while (Begin != End) {
     OS << **Begin << " ";

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -555,7 +555,6 @@ private:
   void visitInlineHistoryMetadata(Instruction &I, MDNode *MD);
   void visitMemCacheHintMetadata(Instruction &I, MDNode *MD);
 
-  template <class Ty> bool isValidMetadataArray(const MDTuple &N);
 #define HANDLE_SPECIALIZED_MDNODE_LEAF(CLASS) void visit##CLASS(const CLASS &N);
 #include "llvm/IR/Metadata.def"
   void visitDIType(const DIType &N);


### PR DESCRIPTION
Two verifier templates trip `-Wunused-template`.

In `Verifier.cpp`, `isValidMetadataArray` is a leftover declaration with no definition and no callers, so it's removed. In `SafepointIRVerifier.cpp`, `PrintValueSet` is only used inside `LLVM_DEBUG`, so it gets compiled out in release builds and never instantiates; it's marked `[[maybe_unused]]`.

NFC.

Part of #202945.