### PR TITLE
[clang] Fix -Wunused-template in AST and analysis helpers (NFC)

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Utils.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Utils.h
@@ -36,9 +36,8 @@ template <typename Tag> struct ID {
 
 /// Computes the union of two ImmutableSets.
 template <typename T>
-static llvm::ImmutableSet<T> join(llvm::ImmutableSet<T> A,
-                                  llvm::ImmutableSet<T> B,
-                                  typename llvm::ImmutableSet<T>::Factory &F) {
+llvm::ImmutableSet<T> join(llvm::ImmutableSet<T> A, llvm::ImmutableSet<T> B,
+                           typename llvm::ImmutableSet<T>::Factory &F) {
   if (A.getHeight() < B.getHeight())
     std::swap(A, B);
   for (const T &E : B)
@@ -67,10 +66,10 @@ enum class JoinKind {
 // efficient merge could be implemented using a Patricia Trie or HAMT
 // instead of the current AVL-tree-based ImmutableMap.
 template <typename K, typename V, typename Joiner>
-static llvm::ImmutableMap<K, V>
-join(const llvm::ImmutableMap<K, V> &A, const llvm::ImmutableMap<K, V> &B,
-     typename llvm::ImmutableMap<K, V>::Factory &F, Joiner JoinValues,
-     JoinKind Kind) {
+llvm::ImmutableMap<K, V> join(const llvm::ImmutableMap<K, V> &A,
+                              const llvm::ImmutableMap<K, V> &B,
+                              typename llvm::ImmutableMap<K, V>::Factory &F,
+                              Joiner JoinValues, JoinKind Kind) {
   if (A.getHeight() < B.getHeight())
     return join(B, A, F, JoinValues, Kind);
 

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -9678,10 +9678,6 @@ class AttrImporter {
 public:
   AttrImporter(ASTImporter &I) : Importer(I), NImporter(I) {}
 
-  // Useful for accessing the imported attribute.
-  template <typename T> T *castAttrAs() { return cast<T>(ToAttr); }
-  template <typename T> const T *castAttrAs() const { return cast<T>(ToAttr); }
-
   // Create an "importer" for an attribute parameter.
   // Result of the 'value()' of that object is to be passed to the function
   // 'importAttr', in the order that is expected by the attribute class.

--- a/clang/lib/AST/ByteCode/InterpHelpers.h
+++ b/clang/lib/AST/ByteCode/InterpHelpers.h
@@ -70,7 +70,7 @@ UnsignedOrNone evaluateBuiltinObjectSize(const ASTContext &ASTCtx,
                                          unsigned Kind, Pointer &Ptr);
 
 template <typename T>
-static bool handleOverflow(InterpState &S, CodePtr OpPC, const T &SrcValue) {
+bool handleOverflow(InterpState &S, CodePtr OpPC, const T &SrcValue) {
   const Expr *E = S.Current->getExpr(OpPC);
   S.CCEDiag(E, diag::note_constexpr_overflow) << SrcValue << E->getType();
   return S.noteUndefinedBehavior();

--- a/clang/lib/ASTMatchers/Dynamic/Marshallers.h
+++ b/clang/lib/ASTMatchers/Dynamic/Marshallers.h
@@ -422,13 +422,13 @@ private:
 /// Helper methods to extract and merge all possible typed matchers
 /// out of the polymorphic object.
 template <class PolyMatcher>
-static void mergePolyMatchers(const PolyMatcher &Poly,
-                              std::vector<DynTypedMatcher> &Out,
-                              ast_matchers::internal::EmptyTypeList) {}
+void mergePolyMatchers(const PolyMatcher &Poly,
+                       std::vector<DynTypedMatcher> &Out,
+                       ast_matchers::internal::EmptyTypeList) {}
 
 template <class PolyMatcher, class TypeList>
-static void mergePolyMatchers(const PolyMatcher &Poly,
-                              std::vector<DynTypedMatcher> &Out, TypeList) {
+void mergePolyMatchers(const PolyMatcher &Poly,
+                       std::vector<DynTypedMatcher> &Out, TypeList) {
   Out.push_back(ast_matchers::internal::Matcher<typename TypeList::head>(Poly));
   mergePolyMatchers(Poly, Out, typename TypeList::tail());
 }
@@ -444,9 +444,8 @@ inline VariantMatcher outvalueToVariantMatcher(const DynTypedMatcher &Matcher) {
 }
 
 template <typename T>
-static VariantMatcher outvalueToVariantMatcher(const T &PolyMatcher,
-                                               typename T::ReturnTypes * =
-                                                   nullptr) {
+VariantMatcher outvalueToVariantMatcher(const T &PolyMatcher,
+                                        typename T::ReturnTypes * = nullptr) {
   std::vector<DynTypedMatcher> Matchers;
   mergePolyMatchers(PolyMatcher, Matchers, typename T::ReturnTypes());
   VariantMatcher Out = VariantMatcher::PolymorphicMatcher(std::move(Matchers));
@@ -649,10 +648,9 @@ private:
 
 /// 0-arg marshaller function.
 template <typename ReturnType>
-static VariantMatcher matcherMarshall0(void (*Func)(), StringRef MatcherName,
-                                       SourceRange NameRange,
-                                       ArrayRef<ParserValue> Args,
-                                       Diagnostics *Error) {
+VariantMatcher
+matcherMarshall0(void (*Func)(), StringRef MatcherName, SourceRange NameRange,
+                 ArrayRef<ParserValue> Args, Diagnostics *Error) {
   using FuncType = ReturnType (*)();
   CHECK_ARG_COUNT(0);
   return outvalueToVariantMatcher(reinterpret_cast<FuncType>(Func)());
@@ -660,10 +658,9 @@ static VariantMatcher matcherMarshall0(void (*Func)(), StringRef MatcherName,
 
 /// 1-arg marshaller function.
 template <typename ReturnType, typename ArgType1>
-static VariantMatcher matcherMarshall1(void (*Func)(), StringRef MatcherName,
-                                       SourceRange NameRange,
-                                       ArrayRef<ParserValue> Args,
-                                       Diagnostics *Error) {
+VariantMatcher
+matcherMarshall1(void (*Func)(), StringRef MatcherName, SourceRange NameRange,
+                 ArrayRef<ParserValue> Args, Diagnostics *Error) {
   using FuncType = ReturnType (*)(ArgType1);
   CHECK_ARG_COUNT(1);
   CHECK_ARG_TYPE(0, ArgType1);
@@ -673,10 +670,9 @@ static VariantMatcher matcherMarshall1(void (*Func)(), StringRef MatcherName,
 
 /// 2-arg marshaller function.
 template <typename ReturnType, typename ArgType1, typename ArgType2>
-static VariantMatcher matcherMarshall2(void (*Func)(), StringRef MatcherName,
-                                       SourceRange NameRange,
-                                       ArrayRef<ParserValue> Args,
-                                       Diagnostics *Error) {
+VariantMatcher
+matcherMarshall2(void (*Func)(), StringRef MatcherName, SourceRange NameRange,
+                 ArrayRef<ParserValue> Args, Diagnostics *Error) {
   using FuncType = ReturnType (*)(ArgType1, ArgType2);
   CHECK_ARG_COUNT(2);
   CHECK_ARG_TYPE(0, ArgType1);

--- a/clang/lib/Analysis/FlowSensitive/DataflowAnalysisContext.cpp
+++ b/clang/lib/Analysis/FlowSensitive/DataflowAnalysisContext.cpp
@@ -96,7 +96,8 @@ StorageLocation &DataflowAnalysisContext::createStorageLocation(QualType Type) {
 // Returns the keys for a given `StringMap`.
 // Can't use `StringSet` as the return type as it doesn't support `operator==`.
 template <typename T>
-static llvm::DenseSet<llvm::StringRef> getKeys(const llvm::StringMap<T> &Map) {
+[[maybe_unused]] static llvm::DenseSet<llvm::StringRef>
+getKeys(const llvm::StringMap<T> &Map) {
   return llvm::DenseSet<llvm::StringRef>(llvm::from_range, Map.keys());
 }
 

--- a/clang/lib/CrossTU/CrossTranslationUnit.cpp
+++ b/clang/lib/CrossTU/CrossTranslationUnit.cpp
@@ -257,7 +257,7 @@ static bool hasBodyOrInit(const FunctionDecl *D, const FunctionDecl *&DefD) {
 static bool hasBodyOrInit(const VarDecl *D, const VarDecl *&DefD) {
   return D->getAnyInitializer(DefD);
 }
-template <typename T> static bool hasBodyOrInit(const T *D) {
+template <typename T> [[maybe_unused]] static bool hasBodyOrInit(const T *D) {
   const T *Unused;
   return hasBodyOrInit(D, Unused);
 }


### PR DESCRIPTION
Several function templates across clang's AST and analysis code trip `-Wunused-template`. Three kinds of fix here:

- Header templates with internal linkage (`static`), which gives each TU its own copy and a latent ODR hazard. Drop `static` in `InterpHelpers.h` (`handleOverflow`), `Marshallers.h` (the `matcherMarshall*`, `mergePolyMatchers`, and `outvalueToVariantMatcher` helpers), and `LifetimeSafety/Utils.h` (`join`). Templates are implicitly inline, so nothing else changes.
- Dead code: `castAttrAs` in `ASTImporter.cpp` has no callers, so it's removed.
- Assert-only helpers compiled out in release builds, marked `[[maybe_unused]]`: `getKeys` in `DataflowAnalysisContext.cpp` and the `hasBodyOrInit` template in `CrossTranslationUnit.cpp`.

NFC.

Part of #202945.