### PR TITLE
[clang] Fix -Wunused-template in frontend helpers (NFC)

### DIFF
--- a/clang/lib/Frontend/ASTUnit.cpp
+++ b/clang/lib/Frontend/ASTUnit.cpp
@@ -142,14 +142,6 @@ static std::unique_ptr<T> valueOrNull(llvm::ErrorOr<std::unique_ptr<T>> Val) {
   return std::move(*Val);
 }
 
-template <class T>
-static bool moveOnNoError(llvm::ErrorOr<T> Val, T &Output) {
-  if (!Val)
-    return false;
-  Output = std::move(*Val);
-  return true;
-}
-
 /// Get a source buffer for \p MainFilePath, handling all file-to-file
 /// and file-to-buffer remappings inside \p Invocation.
 static std::unique_ptr<llvm::MemoryBuffer>

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -515,7 +515,8 @@ static T mergeForwardValue(T KeyPath, U Value) {
   return static_cast<T>(Value);
 }
 
-template <typename T, typename U> static T mergeMaskValue(T KeyPath, U Value) {
+template <typename T, typename U>
+[[maybe_unused]] static T mergeMaskValue(T KeyPath, U Value) {
   return KeyPath | Value;
 }
 
@@ -524,7 +525,7 @@ template <typename T> static T extractForwardValue(T KeyPath) {
 }
 
 template <typename T, typename U, U Value>
-static T extractMaskValue(T KeyPath) {
+[[maybe_unused]] static T extractMaskValue(T KeyPath) {
   return ((KeyPath & Value) == Value) ? static_cast<T>(Value) : T();
 }
 


### PR DESCRIPTION
Two frontend templates trip `-Wunused-template`.

In `ASTUnit.cpp`, `moveOnNoError` is an unused duplicate (the live copy lives in `PrecompiledPreamble.cpp`), so it's removed.

In `CompilerInvocation.cpp`, `mergeMaskValue` and `extractMaskValue` are the option-marshalling helpers that `OptParser.td` names for bitfield options. No option currently uses that kind, so they never instantiate. They're kept and marked `[[maybe_unused]]`, since deleting them would break any future bitfield option.

NFC.

Part of #202945.