### PR TITLE
[flang-rt][cmake] Fix Windows build with CMAKE_Fortran_SIMULATE_ID

### DIFF
--- a/runtimes/cmake/config-Fortran.cmake
+++ b/runtimes/cmake/config-Fortran.cmake
@@ -91,13 +91,12 @@ if (CMAKE_Fortran_COMPILER)
     # Force the compiler ID so CMake does not try to run the compiler for
     # identification. In a bootstrapping build the Flang binary may not be
     # built yet at configure time (only CMAKE_Fortran_COMPILER_WORKS is set).
-    # FIXME: flang has has not equivalent to clang-cl, so
+    # FIXME: flang has no equivalent to clang-cl, so
     # CMAKE_Fortran_SIMULATE_ID=GNU should be the only correct value. CMake may
     # imply that supports different toolchains for each language but in
     # practice is doesn't. In particular, the last enabled
     # language will overwrite global variables such as CMAKE_LINK_LIBRARY_FLAG
     # depending on CMAKE_<lang>_SIMULATE_ID, i.e. they cannot be different.
-    # Fortunately, "MSVC" still works for Flang.
     set(CMAKE_Fortran_COMPILER_ID "LLVMFlang")
     set(CMAKE_Fortran_COMPILER_ID_RUN TRUE)
     set(CMAKE_Fortran_COMPILER_FORCED TRUE)

--- a/runtimes/cmake/config-Fortran.cmake
+++ b/runtimes/cmake/config-Fortran.cmake
@@ -91,11 +91,21 @@ if (CMAKE_Fortran_COMPILER)
     # Force the compiler ID so CMake does not try to run the compiler for
     # identification. In a bootstrapping build the Flang binary may not be
     # built yet at configure time (only CMAKE_Fortran_COMPILER_WORKS is set).
+    # FIXME: flang has has not equivalent to clang-cl, so
+    # CMAKE_Fortran_SIMULATE_ID=GNU should be the only correct value. CMake may
+    # imply that supports different toolchains for each language but in
+    # practice is doesn't. In particular, the last enabled
+    # language will overwrite global variables such as CMAKE_LINK_LIBRARY_FLAG
+    # depending on CMAKE_<lang>_SIMULATE_ID, i.e. they cannot be different.
+    # Fortunately, "MSVC" still works for Flang.
     set(CMAKE_Fortran_COMPILER_ID "LLVMFlang")
     set(CMAKE_Fortran_COMPILER_ID_RUN TRUE)
     set(CMAKE_Fortran_COMPILER_FORCED TRUE)
-    set(CMAKE_Fortran_COMPILER_VERSION "${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}")
-    set(CMAKE_Fortran_SIMULATE_ID "GNU")
+    set(CMAKE_Fortran_COMPILER_VERSION "${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}")
+    set(CMAKE_Fortran_SIMULATE_ID "${CMAKE_CXX_SIMULATE_ID}")
+    set(CMAKE_Fortran_SIMULATE_VERSION "${CMAKE_CXX_SIMULATE_VERSION}")
+    set(CMAKE_Fortran_COMPILER_SUPPORTS_F90 1)
+    set(CMAKE_Fortran_PLATFORM_ID "${CMAKE_CXX_PLATFORM_ID}")
 
     # CMake 3.24 is the first version of CMake that directly recognizes Flang.
     # LLVM's requirement is only CMake 3.20, teach CMake 3.20-3.23 how to use Flang, if used.


### PR DESCRIPTION
The PR #198205 sets CMAKE_Fortran_SIMULATE_ID to "GNU", since Flang has no alternative driver such as an equivalent to clang-cl. But it breaks the Windows build with
```
C:\WINDOWS\system32\cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_exe --msvc-ver=1951 --intdir=flang-rt\unittests\Evaluate\CMakeFiles\reshape.test.dir --rc=C:\Users\meinersbur\src\llvm\main\release_vs18\.\bin\llvm-rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100261~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MICROS~2\18\COMMUN~1\VC\Tools\MSVC\1451~1.362\bin\Hostx64\x64\link.exe /nologo flang-rt/unittests/Evaluate/CMakeFiles/reshape.test.dir/reshape.cpp.obj  /out:flang-rt\unittests\Evaluate\reshape.test.exe /implib:flang-rt\unittests\Evaluate\libreshape.test.dll.a /pdb:flang-rt\unittests\Evaluate\reshape.test.pdb /version:0.0 /machine:x64 /Brepro /INCREMENTAL:NO /subsystem:console /STACK:10000000  flang-rt/lib/Testing/libNonGTestTesting.a  C:/Users/meinersbur/src/llvm/main/release_vs18/lib/clang/23/lib/x86_64-pc-windows-msvc/libflang_rt.runtime.dynamic.a  C:/Users/meinersbur/src/llvm/main/release_vs18/lib/LLVMSupport.lib  -lpsapi  -lshell32  -lole32  -luuid  -ladvapi32  -lws2_32  -lntdll  -ldelayimp  -delayload:shell32.dll  -delayload:ole32.dll  C:/Users/meinersbur/src/llvm/main/release_vs18/lib/LLVMDemangle.lib  kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib && cd ."
LINK: command "C:\PROGRA~1\MICROS~2\18\COMMUN~1\VC\Tools\MSVC\1451~1.362\bin\Hostx64\x64\link.exe /nologo flang-rt/unittests/Evaluate/CMakeFiles/reshape.test.dir/reshape.cpp.obj /out:flang-rt\unittests\Evaluate\reshape.test.exe /implib:flang-rt\unittests\Evaluate\libreshape.test.dll.a /pdb:flang-rt\unittests\Evaluate\reshape.test.pdb /version:0.0 /machine:x64 /Brepro /INCREMENTAL:NO /subsystem:console /STACK:10000000 flang-rt/lib/Testing/libNonGTestTesting.a C:/Users/meinersbur/src/llvm/main/release_vs18/lib/clang/23/lib/x86_64-pc-windows-msvc/libflang_rt.runtime.dynamic.a C:/Users/meinersbur/src/llvm/main/release_vs18/lib/LLVMSupport.lib -lpsapi -lshell32 -lole32 -luuid -ladvapi32 -lws2_32 -lntdll -ldelayimp -delayload:shell32.dll -delayload:ole32.dll C:/Users/meinersbur/src/llvm/main/release_vs18/lib/LLVMDemangle.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST:EMBED,ID=1" failed (exit code 1120) with the following output:
LINK : warning LNK4044: unrecognized option '/lpsapi'; ignored
LINK : warning LNK4044: unrecognized option '/lshell32'; ignored
LINK : warning LNK4044: unrecognized option '/lole32'; ignored
LINK : warning LNK4044: unrecognized option '/luuid'; ignored
LINK : warning LNK4044: unrecognized option '/ladvapi32'; ignored
LINK : warning LNK4044: unrecognized option '/lws2_32'; ignored
LINK : warning LNK4044: unrecognized option '/lntdll'; ignored
LINK : warning LNK4044: unrecognized option '/ldelayimp'; ignored
```

The reason is interesting. With CMAKE_Fortran_SIMULATE_ID=GNU, CMake will [include the Windows-GNU.cmake](https://github.com/Kitware/CMake/blob/3e8ea99e79ddea098765b98f1802c8decd070504/Modules/Platform/Windows-LLVMFlang-Fortran.cmake#L2) platform file. That file [overwrites CMAKE_LINK_LIBRARY_FLAG with `-l`](https://github.com/Kitware/CMake/blob/3e8ea99e79ddea098765b98f1802c8decd070504/Modules/Platform/Windows-GNU.cmake#L52) which is GNU convention for the linker flag. But since CMAKE_LINK_LIBRARY_FLAG is global (in contrast to a per-language setting), it changes the flags for link.exe/lld-link.exe even when compiling C/C++ applications. CMake internally converts `-l` to `/l` for convenience.

Set CMAKE_Fortran_SIMULATE_ID to the same as CMAKE_CXX_SIMULATE_ID as originally proposed in #198205. While flang.exe is a GNU-style driver, setting it to "MSVC" still works, probably because there is no alternative set of flags for Flang. Also define some additional variables that CMake stores in `CMakeFortranCompiler.cmake` in the build directory when CMake is allowed to introspect the Flang driver itself.

Should fix the buildbots [flang-arm64-windows-msvc-testsuite](https://lab.llvm.org/buildbot/#/builders/222), [flang-arm64-windows-msvc](https://lab.llvm.org/buildbot/#/builders/207), [flang-x86_64-windows](https://lab.llvm.org/buildbot/#/builders/166)