### PR TITLE
[FunctionAttrs] Remove unused legacy-PM runImpl template (NFC)

### DIFF
--- a/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
@@ -2319,16 +2319,6 @@ void PostOrderFunctionAttrsPass::printPipeline(
     OS << "<skip-non-recursive-function-attrs>";
 }
 
-template <typename AARGetterT>
-static bool runImpl(CallGraphSCC &SCC, AARGetterT AARGetter) {
-  SmallVector<Function *, 8> Functions;
-  for (CallGraphNode *I : SCC) {
-    Functions.push_back(I->getFunction());
-  }
-
-  return !deriveAttrsInPostOrder(Functions, AARGetter).empty();
-}
-
 static bool addNoRecurseAttrsTopDown(Function &F) {
   if (F.doesNotRecurse())
     return false;


### PR DESCRIPTION
`runImpl` here is a leftover from the legacy pass manager (it takes `CallGraphSCC`), with no callers since the legacy PM was removed. It never instantiates, so it trips `-Wunused-template`. Removing the dead template.

NFC.

Part of #202945.