### PR TITLE
[X86][APX] Enable PP2/PPX generation on Windows

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -7326,8 +7326,12 @@ def mapx_features_EQ : CommaJoined<["-"], "mapx-features=">, Group<m_x86_Feature
     HelpText<"Enable features of APX">, Values<"egpr,push2pop2,ppx,ndd,ccmp,nf,cf,zu,jmpabs">,  Visibility<[ClangOption, CLOption, FlangOption]>;
 def mno_apx_features_EQ : CommaJoined<["-"], "mno-apx-features=">, Group<m_x86_Features_Group>,
     HelpText<"Disable features of APX">, Values<"egpr,push2pop2,ppx,ndd,ccmp,nf,cf,zu,jmpabs">, Visibility<[ClangOption, CLOption, FlangOption]>;
-def mapxf : Flag<["-"], "mapxf">, Group<m_x86_Features_Group>;
-def mno_apxf : Flag<["-"], "mno-apxf">, Group<m_x86_Features_Group>;
+def mapxf : Flag<["-"], "mapxf">, Alias<mapx_features_EQ>,
+            AliasArgs<["egpr","push2pop2","ppx","ndd","ccmp","nf","zu","jmpabs"]>,
+            Group<m_x86_Features_Group>;
+def mno_apxf : Flag<["-"], "mno-apxf">, Alias<mno_apx_features_EQ>,
+               AliasArgs<["egpr","push2pop2","ppx","ndd","ccmp","nf","zu","jmpabs"]>,
+               Group<m_x86_Features_Group>;
 def mapx_inline_asm_use_gpr32 : Flag<["-"], "mapx-inline-asm-use-gpr32">, Group<m_Group>,
                                 HelpText<"Enable use of GPR32 in inline assembly for APX">;
 def ffixed_edi : Flag<["-"], "ffixed-edi">, Group<m_Group>,

--- a/clang/lib/Basic/Targets/X86.cpp
+++ b/clang/lib/Basic/Targets/X86.cpp
@@ -164,11 +164,6 @@ bool X86TargetInfo::initFeatureMap(
   for (auto &F : CPUFeatures)
     setFeatureEnabled(Features, F, true);
 
-  if (Features.lookup("egpr") && getTriple().isOSWindows()) {
-    setFeatureEnabled(Features, "push2pop2", false);
-    setFeatureEnabled(Features, "ppx", false);
-  }
-
   std::vector<std::string> UpdatedFeaturesVec;
   for (const auto &Feature : FeaturesVec) {
     // Expand general-regs-only to -x86, -mmx and -sse
@@ -988,9 +983,9 @@ void X86TargetInfo::getTargetDefines(const LangOptions &Opts,
     Builder.defineMacro("__ZU__");
   if (HasJMPABS)
     Builder.defineMacro("__JMPABS__");
-  if (HasEGPR && HasNDD && HasCCMP && HasNF && HasZU && HasJMPABS)
-    if (getTriple().isOSWindows() || (HasPush2Pop2 && HasPPX))
-      Builder.defineMacro("__APX_F__");
+  if (HasEGPR && HasPush2Pop2 && HasPPX && HasNDD && HasCCMP && HasNF &&
+      HasZU && HasJMPABS)
+    Builder.defineMacro("__APX_F__");
   if (HasEGPR && HasInlineAsmUseGPR32)
     Builder.defineMacro("__APX_INLINE_ASM_USE_GPR32__");
 

--- a/clang/lib/Driver/ToolChains/Arch/X86.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/X86.cpp
@@ -264,17 +264,8 @@ void x86::getX86TargetFeatures(const Driver &D, const llvm::Triple &Triple,
         A->getOption().matches(options::OPT_mno_apxf)) {
       if (IsNegative) {
         EGPROpt = EGPRFeature::Disabled;
-        Features.insert(Features.end(),
-                        {"-egpr", "-ndd", "-ccmp", "-nf", "-zu", "-jmpabs"});
-        if (!Triple.isOSWindows())
-          Features.insert(Features.end(), {"-push2pop2", "-ppx"});
       } else {
         EGPROpt = EGPRFeature::Enabled;
-        Features.insert(Features.end(),
-                        {"+egpr", "+ndd", "+ccmp", "+nf", "+zu", "+jmpabs"});
-        if (!Triple.isOSWindows())
-          Features.insert(Features.end(), {"+push2pop2", "+ppx"});
-
         if (Not64Bit)
           D.Diag(diag::err_drv_unsupported_opt_for_target)
               << StringRef("-mapxf") << Triple.getTriple();

--- a/clang/test/Driver/cl-x86-flags.c
+++ b/clang/test/Driver/cl-x86-flags.c
@@ -215,16 +215,15 @@ void f(void) {
 }
 
 
-// RUN: not %clang_cl -### --target=i386-pc-windows -mapx-features=ndd -- 2>&1 %s | FileCheck --check-prefixes=NON-APX,NON-APXFS %s
-// RUN: not %clang_cl -### --target=i386-pc-windows -mapxf -- 2>&1 %s | FileCheck --check-prefixes=NON-APX,NON-APXF %s
+// RUN: not %clang_cl -### --target=i386-pc-windows -mapx-features=ndd -- 2>&1 %s | FileCheck --check-prefixes=NON-APX %s
+// RUN: not %clang_cl -### --target=i386-pc-windows -mapxf -- 2>&1 %s | FileCheck --check-prefixes=NON-APX %s
 // RUN: %clang_cl -### --target=i386-pc-windows -mno-apxf -- 2>&1 %s > /dev/null
-// NON-APXF:     error: unsupported option '-mapxf' for target 'i386-pc-windows{{.*}}'
-// NON-APXFS:    error: unsupported option '-mapx-features=' for target 'i386-pc-windows{{.*}}'
+// NON-APX:      error: unsupported option '-mapx-features=' for target 'i386-pc-windows{{.*}}'
 // NON-APX-NOT:  error: {{.*}} -mapx-features=
 
 // RUN: %clang_cl --target=x86_64-pc-windows -mapxf -### -- 2>&1 %s | FileCheck -check-prefix=APXF %s
 // RUN: %clang_cl --target=x86_64-pc-windows -mapxf -mno-apxf -### -- 2>&1 %s | FileCheck -check-prefix=NO-APXF %s
 // RUN: %clang_cl --target=x86_64-pc-windows -mapx-features=egpr,push2pop2,ppx,ndd,ccmp,nf,cf,zu,jmpabs -### -- 2>&1 %s | FileCheck -check-prefix=APXALL %s
-// APXF: "-target-feature" "+egpr" "-target-feature" "+ndd" "-target-feature" "+ccmp" "-target-feature" "+nf" "-target-feature" "+zu" "-target-feature" "+jmpabs"
-// NO-APXF: "-target-feature" "-egpr" "-target-feature" "-ndd" "-target-feature" "-ccmp" "-target-feature" "-nf" "-target-feature" "-zu" "-target-feature" "-jmpabs"
+// APXF: "-target-feature" "+egpr" "-target-feature" "+push2pop2" "-target-feature" "+ppx" "-target-feature" "+ndd" "-target-feature" "+ccmp" "-target-feature" "+nf" "-target-feature" "+zu" "-target-feature" "+jmpabs"
+// NO-APXF: "-target-feature" "-egpr" "-target-feature" "-push2pop2" "-target-feature" "-ppx" "-target-feature" "-ndd" "-target-feature" "-ccmp" "-target-feature" "-nf" "-target-feature" "-zu" "-target-feature" "-jmpabs"
 // APXALL: "-target-feature" "+egpr" "-target-feature" "+push2pop2" "-target-feature" "+ppx" "-target-feature" "+ndd" "-target-feature" "+ccmp" "-target-feature" "+nf" "-target-feature" "+cf" "-target-feature" "+zu" "-target-feature" "+jmpabs"

--- a/clang/test/Driver/x86-target-features.c
+++ b/clang/test/Driver/x86-target-features.c
@@ -417,12 +417,11 @@
 
 // RUN: not %clang -### --target=i386 -muintr %s 2>&1 | FileCheck --check-prefix=NON-UINTR %s
 // RUN: %clang -### --target=i386 -mno-uintr %s 2>&1 > /dev/null
-// RUN: not %clang -### --target=i386 -mapx-features=ndd %s 2>&1 | FileCheck --check-prefixes=NON-APX,NON-APXFS %s
-// RUN: not %clang -### --target=i386 -mapxf %s 2>&1 | FileCheck --check-prefixes=NON-APX,NON-APXF %s
+// RUN: not %clang -### --target=i386 -mapx-features=ndd %s 2>&1 | FileCheck --check-prefixes=NON-APX %s
+// RUN: not %clang -### --target=i386 -mapxf %s 2>&1 | FileCheck --check-prefixes=NON-APX %s
 // RUN: %clang -### --target=i386 -mno-apxf %s 2>&1 > /dev/null
 // NON-UINTR:    error: unsupported option '-muintr' for target 'i386'
-// NON-APXF:     error: unsupported option '-mapxf' for target 'i386'
-// NON-APXFS:    error: unsupported option '-mapx-features=' for target 'i386'
+// NON-APX:      error: unsupported option '-mapx-features=' for target 'i386'
 // NON-APX-NOT:  error: {{.*}} -mapx-features=
 
 // RUN: %clang --target=i386 -march=i386 -mharden-sls=return %s -### -o %t.o 2>&1 | FileCheck -check-prefixes=SLS-RET,NO-SLS %s
@@ -444,8 +443,8 @@
 // RUN: %clang --target=x86_64-unknown-linux-gnu -mno-apxf -mapxf %s -### -o %t.o 2>&1 | FileCheck -check-prefix=APXF %s
 // RUN: %clang --target=x86_64-unknown-linux-gnu -mapxf -mno-apxf %s -### -o %t.o 2>&1 | FileCheck -check-prefix=NO-APXF %s
 //
-// APXF: "-target-feature" "+egpr" "-target-feature" "+ndd" "-target-feature" "+ccmp" "-target-feature" "+nf" "-target-feature" "+zu"  "-target-feature" "+jmpabs" "-target-feature" "+push2pop2" "-target-feature" "+ppx"
-// NO-APXF: "-target-feature" "-egpr" "-target-feature" "-ndd" "-target-feature" "-ccmp" "-target-feature" "-nf" "-target-feature" "-zu" "-target-feature" "-jmpabs" "-target-feature" "-push2pop2" "-target-feature" "-ppx"
+// APXF: "-target-feature" "+egpr" "-target-feature" "+push2pop2" "-target-feature" "+ppx" "-target-feature" "+ndd" "-target-feature" "+ccmp" "-target-feature" "+nf" "-target-feature" "+zu" "-target-feature" "+jmpabs"
+// NO-APXF: "-target-feature" "-egpr" "-target-feature" "-push2pop2" "-target-feature" "-ppx" "-target-feature" "-ndd" "-target-feature" "-ccmp" "-target-feature" "-nf" "-target-feature" "-zu" "-target-feature" "-jmpabs"
 
 // RUN: %clang --target=x86_64-unknown-linux-gnu -mapx-features=egpr %s -### -o %t.o 2>&1 | FileCheck -check-prefix=EGPR %s
 // RUN: %clang --target=x86_64-unknown-linux-gnu -mapx-features=push2pop2 %s -### -o %t.o 2>&1 | FileCheck -check-prefix=PUSH2POP2 %s

--- a/llvm/lib/Target/X86/X86Subtarget.cpp
+++ b/llvm/lib/Target/X86/X86Subtarget.cpp
@@ -257,9 +257,6 @@ void X86Subtarget::initSubtargetFeatures(StringRef CPU, StringRef TuneCPU,
   std::string FullFS = X86_MC::ParseX86Triple(TargetTriple);
   assert(!FullFS.empty() && "Failed to parse X86 triple");
 
-  if (TargetTriple.isOSWindows())
-    FullFS += ",-push2pop2,-ppx";
-
   if (!FS.empty())
     FullFS = (Twine(FullFS) + "," + FS).str();
 

--- a/llvm/lib/TargetParser/Host.cpp
+++ b/llvm/lib/TargetParser/Host.cpp
@@ -2214,12 +2214,10 @@ StringMap<bool> sys::getHostCPUFeatures() {
   bool HasAVX10 = HasLeaf7Subleaf1 && ((EDX >> 19) & 1);
   bool HasAPXF = HasLeaf7Subleaf1 && ((EDX >> 21) & 1) && HasAPXSave;
   Features["egpr"] = HasAPXF;
-#ifndef _WIN32
   // TODO: We may need to check OS or MSVC version once unwinder opcodes
   // support PUSH2/POP2/PPX.
   Features["push2pop2"] = HasAPXF;
   Features["ppx"] = HasAPXF;
-#endif
   Features["ndd"] = HasAPXF;
   Features["ccmp"] = HasAPXF;
   Features["nf"] = HasAPXF;

--- a/llvm/test/CodeGen/X86/apx/push2-pop2-cfi-seh-v3.ll
+++ b/llvm/test/CodeGen/X86/apx/push2-pop2-cfi-seh-v3.ll
@@ -2,7 +2,7 @@
 ; RUN: llc < %s -mtriple=x86_64-windows-msvc | FileCheck %s --check-prefix=WIN-V3-REF
 ; RUN: llc < %s -mtriple=x86_64-windows-msvc -mattr=+push2pop2 | FileCheck %s --check-prefix=WIN-V3
 ; RUN: llc < %s -mtriple=x86_64-windows-msvc -mattr=+push2pop2,+ppx | FileCheck %s --check-prefix=WIN-V3-PPX
-; RUN: llc < %s -mtriple=x86_64-windows-msvc -mcpu=diamondrapids | FileCheck %s --check-prefix=WIN-V3-DR
+; RUN: llc < %s -mtriple=x86_64-windows-msvc -mcpu=diamondrapids | FileCheck %s --check-prefix=WIN-V3-PPX
 
 ; V3 unwind info is enabled module-wide here. diamondrapids (which enables
 ; EGPR) requires V3, but with V3 enabled the SEH prolog/epilogue ordering
@@ -115,47 +115,6 @@ define i32 @csr6_alloc16(ptr %argv) {
 ; WIN-V3-PPX-NEXT:    .seh_endepilogue
 ; WIN-V3-PPX-NEXT:    retq
 ; WIN-V3-PPX-NEXT:    .seh_endproc
-;
-; WIN-V3-DR-LABEL: csr6_alloc16:
-; WIN-V3-DR:       # %bb.0: # %entry
-; WIN-V3-DR-NEXT:    .seh_pushreg %r15
-; WIN-V3-DR-NEXT:    pushq %r15
-; WIN-V3-DR-NEXT:    .seh_pushreg %r14
-; WIN-V3-DR-NEXT:    pushq %r14
-; WIN-V3-DR-NEXT:    .seh_pushreg %r13
-; WIN-V3-DR-NEXT:    pushq %r13
-; WIN-V3-DR-NEXT:    .seh_pushreg %r12
-; WIN-V3-DR-NEXT:    pushq %r12
-; WIN-V3-DR-NEXT:    .seh_pushreg %rbp
-; WIN-V3-DR-NEXT:    pushq %rbp
-; WIN-V3-DR-NEXT:    .seh_pushreg %rbx
-; WIN-V3-DR-NEXT:    pushq %rbx
-; WIN-V3-DR-NEXT:    .seh_stackalloc 56
-; WIN-V3-DR-NEXT:    subq $56, %rsp
-; WIN-V3-DR-NEXT:    .seh_endprologue
-; WIN-V3-DR-NEXT:    #APP
-; WIN-V3-DR-NEXT:    #NO_APP
-; WIN-V3-DR-NEXT:    xorl %eax, %eax
-; WIN-V3-DR-NEXT:    callq *%rax
-; WIN-V3-DR-NEXT:    nop
-; WIN-V3-DR-NEXT:    .seh_startepilogue
-; WIN-V3-DR-NEXT:    .seh_stackalloc 56
-; WIN-V3-DR-NEXT:    addq $56, %rsp
-; WIN-V3-DR-NEXT:    .seh_pushreg %rbx
-; WIN-V3-DR-NEXT:    popq %rbx
-; WIN-V3-DR-NEXT:    .seh_pushreg %rbp
-; WIN-V3-DR-NEXT:    popq %rbp
-; WIN-V3-DR-NEXT:    .seh_pushreg %r12
-; WIN-V3-DR-NEXT:    popq %r12
-; WIN-V3-DR-NEXT:    .seh_pushreg %r13
-; WIN-V3-DR-NEXT:    popq %r13
-; WIN-V3-DR-NEXT:    .seh_pushreg %r14
-; WIN-V3-DR-NEXT:    popq %r14
-; WIN-V3-DR-NEXT:    .seh_pushreg %r15
-; WIN-V3-DR-NEXT:    popq %r15
-; WIN-V3-DR-NEXT:    .seh_endepilogue
-; WIN-V3-DR-NEXT:    retq
-; WIN-V3-DR-NEXT:    .seh_endproc
 entry:
   tail call void asm sideeffect "", "~{rbp},~{r15},~{r14},~{r13},~{r12},~{rbx},~{dirflag},~{fpsr},~{flags}"()
   %a = alloca [3 x ptr], align 8

--- a/llvm/test/CodeGen/X86/apx/push2-pop2-cfi-seh.ll
+++ b/llvm/test/CodeGen/X86/apx/push2-pop2-cfi-seh.ll
@@ -10,7 +10,7 @@
 ; EPGR normally required unwind v3 info, but that changes the SEH directives
 ; that get emitted, so disable epgr so that we can validate diamondrapids
 ; enables push2pop2
-; RUN: llc < %s -mtriple=x86_64-windows-msvc -mcpu=diamondrapids -mattr=-egpr | FileCheck %s --check-prefix=WIN-REF
+; RUN: llc < %s -mtriple=x86_64-windows-msvc -mcpu=diamondrapids -mattr=-egpr | FileCheck %s --check-prefix=WIN-PPX
 
 define i32 @csr6_alloc16(ptr %argv) {
 ; LIN-REF-LABEL: csr6_alloc16:


### PR DESCRIPTION
Revert restrictions from https://github.com/llvm/llvm-project/pull/178122 which disabled PUSH2/POP2/PPX on Windows due to missing unwinder opcodes. Now that unwinder support has landed, this is no longer needed.