### PR TITLE
Fix -Wunused-template in assorted LLVM library helpers (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/GenericUniformityImpl.h
+++ b/llvm/include/llvm/ADT/GenericUniformityImpl.h
@@ -970,8 +970,7 @@ void GenericUniformityAnalysisImpl<ContextT>::taintAndPushPhiNodes(
 ///
 /// \return true iff \p Candidate was added to \p Cycles.
 template <typename CycleT>
-static bool insertIfNotContained(SmallVector<CycleT *> &Cycles,
-                                 CycleT *Candidate) {
+bool insertIfNotContained(SmallVector<CycleT *> &Cycles, CycleT *Candidate) {
   if (llvm::any_of(Cycles,
                    [Candidate](CycleT *C) { return C->contains(Candidate); }))
     return false;
@@ -985,9 +984,8 @@ static bool insertIfNotContained(SmallVector<CycleT *> &Cycles,
 /// inside that cycle, then that whole cycle is assumed to be
 /// divergent. This does not apply if the cycle is reducible.
 template <typename CycleT, typename BlockT>
-static const CycleT *getExtDivCycle(const CycleT *Cycle,
-                                    const BlockT *DivTermBlock,
-                                    const BlockT *JoinBlock) {
+const CycleT *getExtDivCycle(const CycleT *Cycle, const BlockT *DivTermBlock,
+                             const BlockT *JoinBlock) {
   assert(Cycle);
   assert(Cycle->contains(JoinBlock));
 
@@ -1022,10 +1020,9 @@ static const CycleT *getExtDivCycle(const CycleT *Cycle,
 /// docs/ConvergenceAnalysis.html.
 template <typename ContextT, typename CycleT, typename BlockT,
           typename DominatorTreeT>
-static const CycleT *
-getIntDivCycle(const CycleT *Cycle, const BlockT *DivTermBlock,
-               const BlockT *JoinBlock, const DominatorTreeT &DT,
-               ContextT &Context) {
+const CycleT *getIntDivCycle(const CycleT *Cycle, const BlockT *DivTermBlock,
+                             const BlockT *JoinBlock, const DominatorTreeT &DT,
+                             ContextT &Context) {
   LLVM_DEBUG(dbgs() << "examine join " << Context.print(JoinBlock)
                     << " for internal branch " << Context.print(DivTermBlock)
                     << "\n");
@@ -1060,7 +1057,7 @@ getIntDivCycle(const CycleT *Cycle, const BlockT *DivTermBlock,
 
 template <typename ContextT, typename CycleT, typename BlockT,
           typename DominatorTreeT>
-static const CycleT *
+const CycleT *
 getOutermostDivergentCycle(const CycleT *Cycle, const BlockT *DivTermBlock,
                            const BlockT *JoinBlock, const DominatorTreeT &DT,
                            ContextT &Context) {

--- a/llvm/include/llvm/Bitcode/BitcodeConvenience.h
+++ b/llvm/include/llvm/Bitcode/BitcodeConvenience.h
@@ -163,7 +163,7 @@ namespace detail {
 /// This is the base case for \c emitOps.
 ///
 /// \sa BCRecordLayout::emitAbbrev
-template <typename FieldTy> static void emitOps(llvm::BitCodeAbbrev &abbrev) {
+template <typename FieldTy> void emitOps(llvm::BitCodeAbbrev &abbrev) {
   FieldTy::emitOp(abbrev);
 }
 
@@ -173,7 +173,7 @@ template <typename FieldTy> static void emitOps(llvm::BitCodeAbbrev &abbrev) {
 ///
 /// \sa BCRecordLayout::emitAbbrev
 template <typename FieldTy, typename Next, typename... Rest>
-static void emitOps(llvm::BitCodeAbbrev &abbrev) {
+void emitOps(llvm::BitCodeAbbrev &abbrev) {
   static_assert(!FieldTy::IsCompound,
                 "arrays and blobs may not appear in the middle of a record");
   FieldTy::emitOp(abbrev);

--- a/llvm/include/llvm/ProfileData/Coverage/MCDCTypes.h
+++ b/llvm/include/llvm/ProfileData/Coverage/MCDCTypes.h
@@ -61,7 +61,7 @@ using Parameters =
 /// \tparam MaybeConstMCDCParameters Expected inferred. May be const.
 /// \param MCDCParams May be const.
 template <class MaybeConstInnerParameters, class MaybeConstMCDCParameters>
-static auto &getParams(MaybeConstMCDCParameters &MCDCParams) {
+auto &getParams(MaybeConstMCDCParameters &MCDCParams) {
   using InnerParameters =
       typename std::remove_const<MaybeConstInnerParameters>::type;
   MaybeConstInnerParameters *Params = std::get_if<InnerParameters>(&MCDCParams);

--- a/llvm/include/llvm/Support/CheckedArithmetic.h
+++ b/llvm/include/llvm/Support/CheckedArithmetic.h
@@ -19,7 +19,8 @@
 #include <optional>
 #include <type_traits>
 
-namespace {
+namespace llvm {
+namespace detail {
 
 /// Utility function to apply a given method of \c APInt \p F to \p LHS and
 /// \p RHS.
@@ -35,7 +36,8 @@ checkedOp(T LHS, T RHS, F Op, bool Signed = true) {
     return std::nullopt;
   return Signed ? Out.getSExtValue() : Out.getZExtValue();
 }
-}
+} // namespace detail
+} // namespace llvm
 
 namespace llvm {
 
@@ -45,7 +47,7 @@ namespace llvm {
 template <typename T>
 std::enable_if_t<std::is_signed_v<T>, std::optional<T>> checkedAdd(T LHS,
                                                                    T RHS) {
-  return checkedOp(LHS, RHS, &llvm::APInt::sadd_ov);
+  return detail::checkedOp(LHS, RHS, &llvm::APInt::sadd_ov);
 }
 
 /// Subtract two signed integers \p LHS and \p RHS.
@@ -54,7 +56,7 @@ std::enable_if_t<std::is_signed_v<T>, std::optional<T>> checkedAdd(T LHS,
 template <typename T>
 std::enable_if_t<std::is_signed_v<T>, std::optional<T>> checkedSub(T LHS,
                                                                    T RHS) {
-  return checkedOp(LHS, RHS, &llvm::APInt::ssub_ov);
+  return detail::checkedOp(LHS, RHS, &llvm::APInt::ssub_ov);
 }
 
 /// Multiply two signed integers \p LHS and \p RHS.
@@ -63,7 +65,7 @@ std::enable_if_t<std::is_signed_v<T>, std::optional<T>> checkedSub(T LHS,
 template <typename T>
 std::enable_if_t<std::is_signed_v<T>, std::optional<T>> checkedMul(T LHS,
                                                                    T RHS) {
-  return checkedOp(LHS, RHS, &llvm::APInt::smul_ov);
+  return detail::checkedOp(LHS, RHS, &llvm::APInt::smul_ov);
 }
 
 /// Multiply A and B, and add C to the resulting product.
@@ -83,7 +85,7 @@ std::enable_if_t<std::is_signed_v<T>, std::optional<T>> checkedMulAdd(T A, T B,
 template <typename T>
 std::enable_if_t<std::is_unsigned_v<T>, std::optional<T>>
 checkedAddUnsigned(T LHS, T RHS) {
-  return checkedOp(LHS, RHS, &llvm::APInt::uadd_ov, /*Signed=*/false);
+  return detail::checkedOp(LHS, RHS, &llvm::APInt::uadd_ov, /*Signed=*/false);
 }
 
 /// Multiply two unsigned integers \p LHS and \p RHS.
@@ -92,7 +94,7 @@ checkedAddUnsigned(T LHS, T RHS) {
 template <typename T>
 std::enable_if_t<std::is_unsigned_v<T>, std::optional<T>>
 checkedMulUnsigned(T LHS, T RHS) {
-  return checkedOp(LHS, RHS, &llvm::APInt::umul_ov, /*Signed=*/false);
+  return detail::checkedOp(LHS, RHS, &llvm::APInt::umul_ov, /*Signed=*/false);
 }
 
 /// Multiply unsigned integers A and B, and add C to the resulting product.

--- a/llvm/lib/MC/MCParser/GOFFAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/GOFFAsmParser.cpp
@@ -13,14 +13,6 @@ using namespace llvm;
 namespace {
 
 class GOFFAsmParser : public MCAsmParserExtension {
-  template <bool (GOFFAsmParser::*HandlerMethod)(StringRef, SMLoc)>
-  void addDirectiveHandler(StringRef Directive) {
-    MCAsmParser::ExtensionDirectiveHandler Handler =
-        std::make_pair(this, HandleDirective<GOFFAsmParser, HandlerMethod>);
-
-    getParser().addDirectiveHandler(Directive, Handler);
-  }
-
 public:
   GOFFAsmParser() = default;
 

--- a/llvm/lib/ProfileData/ItaniumManglingCanonicalizer.cpp
+++ b/llvm/lib/ProfileData/ItaniumManglingCanonicalizer.cpp
@@ -122,11 +122,6 @@ public:
     return {Result, true};
   }
 
-  template<typename T, typename... Args>
-  Node *makeNode(Args &&...As) {
-    return getOrCreateNode<T>(true, std::forward<Args>(As)...).first;
-  }
-
   void *allocateNodeArray(size_t sz) {
     return RawAlloc.Allocate(sizeof(Node *) * sz, alignof(Node *));
   }

--- a/llvm/tools/llvm-rc/ResourceFileWriter.cpp
+++ b/llvm/tools/llvm-rc/ResourceFileWriter.cpp
@@ -1492,15 +1492,6 @@ Error ResourceFileWriter::writeVersionInfoValue(const VersionInfoValue &Val) {
   return Error::success();
 }
 
-template <typename Ty>
-static Ty getWithDefault(const StringMap<Ty> &Map, StringRef Key,
-                         const Ty &Default) {
-  auto Iter = Map.find(Key);
-  if (Iter != Map.end())
-    return Iter->getValue();
-  return Default;
-}
-
 Error ResourceFileWriter::writeVersionInfoBody(const RCResource *Base) {
   auto *Res = cast<VersionInfoResource>(Base);
 


### PR DESCRIPTION
Function templates across a few low-level LLVM libraries trip `-Wunused-template`. Two kinds of fix here:

- Header templates with internal linkage. `CheckedArithmetic.h`: move `checkedOp` out of the anonymous namespace into `llvm::detail` and update its callers. `BitcodeConvenience.h`: drop `static` on `emitOps`. `MCDCTypes.h`: drop `static` on `getParams`. Templates are implicitly inline, so this is a linkage-only change.
- Dead code with no callers, removed: `makeNode` in `ItaniumManglingCanonicalizer.cpp` (a base-class helper shadowed by the derived class), `addDirectiveHandler` in `GOFFAsmParser.cpp`, and `getWithDefault` in `ResourceFileWriter.cpp`.

NFC.

Part of #202945.