### PR TITLE
[libc] Fix remaining 32-bit time syscalls on 32-bit platforms

### DIFF
--- a/libc/cmake/modules/LLVMLibCTestRules.cmake
+++ b/libc/cmake/modules/LLVMLibCTestRules.cmake
@@ -259,9 +259,11 @@ function(create_libc_unittest fq_target_name)
   get_fq_deps_list(fq_deps_list ${LIBC_UNITTEST_DEPENDS})
   if(NOT LIBC_UNITTEST_C_TEST)
     list(APPEND fq_deps_list libc.src.__support.StringUtil.error_to_string
-                             libc.test.UnitTest.ErrnoSetterMatcher)
+                             libc.test.UnitTest.ErrnoSetterMatcher
+                             libc.src.__support.CPP.new)
   endif()
   list(REMOVE_DUPLICATES fq_deps_list)
+
 
   _get_common_test_compile_options(compile_options "${LIBC_UNITTEST_C_TEST}"
                                    "${LIBC_UNITTEST_FLAGS}")

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/utimensat.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/utimensat.h
@@ -15,15 +15,37 @@
 #include "src/__support/macros/config.h"
 
 #include "hdr/types/struct_timespec.h"
-#include <sys/syscall.h> // For syscall numbers
+#include <sys/syscall.h>
+#if defined(SYS_utimensat_time64)
+#include <linux/time_types.h>
+#endif
 
 namespace LIBC_NAMESPACE_DECL {
 namespace linux_syscalls {
 
 LIBC_INLINE ErrorOr<int> utimensat(int dirfd, const char *path,
-                                   const struct timespec times[2], int flags) {
+                                   const timespec times[2], int flags) {
 #if defined(SYS_utimensat_time64)
-  int ret = syscall_impl<int>(SYS_utimensat_time64, dirfd, path, times, flags);
+  int ret;
+  // In overlay mode on 32-bit platforms, the system timespec (which we use)
+  // may be 32-bit (8 bytes), while the kernel's __kernel_timespec (used by
+  // _time64 syscalls) is 64-bit (16 bytes). If they match, we can pass the
+  // pointer directly. Otherwise, we must convert to avoid stack corruption.
+  if constexpr (sizeof(timespec) == sizeof(__kernel_timespec)) {
+    ret = syscall_impl<int>(SYS_utimensat_time64, dirfd, path, times, flags);
+  } else {
+    if (times != nullptr) {
+      __kernel_timespec ts64[2];
+      ts64[0].tv_sec = times[0].tv_sec;
+      ts64[0].tv_nsec = times[0].tv_nsec;
+      ts64[1].tv_sec = times[1].tv_sec;
+      ts64[1].tv_nsec = times[1].tv_nsec;
+      ret = syscall_impl<int>(SYS_utimensat_time64, dirfd, path, ts64, flags);
+    } else {
+      ret =
+          syscall_impl<int>(SYS_utimensat_time64, dirfd, path, nullptr, flags);
+    }
+  }
 #elif defined(SYS_utimensat)
   static_assert(
       sizeof(timespec::tv_nsec) == sizeof(long),

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/utimensat.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/utimensat.h
@@ -15,6 +15,7 @@
 #include "src/__support/macros/config.h"
 
 #include "hdr/types/struct_timespec.h"
+#include "src/__support/time/linux/kernel_timespec.h"
 #include <sys/syscall.h>
 #if defined(SYS_utimensat_time64)
 #include <linux/time_types.h>
@@ -35,11 +36,8 @@ LIBC_INLINE ErrorOr<int> utimensat(int dirfd, const char *path,
     ret = syscall_impl<int>(SYS_utimensat_time64, dirfd, path, times, flags);
   } else {
     if (times != nullptr) {
-      __kernel_timespec ts64[2];
-      ts64[0].tv_sec = times[0].tv_sec;
-      ts64[0].tv_nsec = times[0].tv_nsec;
-      ts64[1].tv_sec = times[1].tv_sec;
-      ts64[1].tv_nsec = times[1].tv_nsec;
+      __kernel_timespec ts64[2]{to_kernel_timespec(times[0]),
+                                to_kernel_timespec(times[1])};
       ret = syscall_impl<int>(SYS_utimensat_time64, dirfd, path, ts64, flags);
     } else {
       ret =

--- a/libc/src/__support/threads/linux/futex_utils.h
+++ b/libc/src/__support/threads/linux/futex_utils.h
@@ -20,6 +20,9 @@
 #include "src/__support/time/abs_timeout.h"
 #include <linux/errno.h>
 #include <linux/futex.h>
+#if defined(SYS_futex_time64)
+#include <linux/time_types.h>
+#endif
 
 namespace LIBC_NAMESPACE_DECL {
 
@@ -52,12 +55,34 @@ public:
       if (this->load(cpp::MemoryOrder::RELAXED) != expected)
         return 0;
 
+#if defined(SYS_futex_time64)
+      __kernel_timespec ts64{};
+      void *timeout_arg = nullptr;
+      if (timeout) {
+        // In overlay mode on 32-bit platforms, the system timespec (which we
+        // use) may be 32-bit (8 bytes), while the kernel's __kernel_timespec
+        // (used by _time64 syscalls) is 64-bit (16 bytes). If they match, we
+        // can pass the pointer directly. Otherwise, we must convert to avoid
+        // stack corruption.
+        if constexpr (sizeof(timespec) == sizeof(__kernel_timespec)) {
+          timeout_arg = const_cast<timespec *>(&timeout->get_timespec());
+        } else {
+          ts64.tv_sec = timeout->get_timespec().tv_sec;
+          ts64.tv_nsec = timeout->get_timespec().tv_nsec;
+          timeout_arg = &ts64;
+        }
+      }
+#else
+      void *timeout_arg =
+          timeout ? const_cast<timespec *>(&timeout->get_timespec()) : nullptr;
+#endif
+
       int ret = syscall_impl<int>(
           /*syscall_number=*/FUTEX_SYSCALL_ID,
           /*futex_addr=*/this,
           /*op=*/op,
           /*expected=*/expected,
-          /*timeout=*/timeout ? &timeout->get_timespec() : nullptr,
+          /*timeout=*/timeout_arg,
           /*ignored=*/nullptr,
           /*bitset=*/FUTEX_BITSET_MATCH_ANY);
 

--- a/libc/src/__support/threads/linux/futex_utils.h
+++ b/libc/src/__support/threads/linux/futex_utils.h
@@ -18,6 +18,7 @@
 #include "src/__support/macros/config.h"
 #include "src/__support/threads/linux/futex_word.h"
 #include "src/__support/time/abs_timeout.h"
+#include "src/__support/time/linux/kernel_timespec.h"
 #include <linux/errno.h>
 #include <linux/futex.h>
 #if defined(SYS_futex_time64)
@@ -67,8 +68,7 @@ public:
         if constexpr (sizeof(timespec) == sizeof(__kernel_timespec)) {
           timeout_arg = const_cast<timespec *>(&timeout->get_timespec());
         } else {
-          ts64.tv_sec = timeout->get_timespec().tv_sec;
-          ts64.tv_nsec = timeout->get_timespec().tv_nsec;
+          ts64 = to_kernel_timespec(timeout->get_timespec());
           timeout_arg = &ts64;
         }
       }

--- a/libc/src/__support/time/linux/CMakeLists.txt
+++ b/libc/src/__support/time/linux/CMakeLists.txt
@@ -1,3 +1,11 @@
+add_header_library(
+  kernel_timespec
+  HDRS
+    kernel_timespec.h
+  DEPENDS
+    libc.hdr.types.struct_timespec
+)
+
 add_object_library(
   clock_gettime
   HDRS
@@ -12,6 +20,7 @@ add_object_library(
     libc.src.__support.error_or
     libc.src.__support.OSUtil.osutil
     libc.src.__support.OSUtil.linux.vdso
+    .kernel_timespec
 )
 
 add_object_library(
@@ -27,4 +36,5 @@ add_object_library(
     libc.src.__support.common
     libc.src.__support.error_or
     libc.src.__support.OSUtil.osutil
+    .kernel_timespec
 )

--- a/libc/src/__support/time/linux/clock_gettime.cpp
+++ b/libc/src/__support/time/linux/clock_gettime.cpp
@@ -14,8 +14,8 @@
 #include "src/__support/common.h"
 #include "src/__support/error_or.h"
 #include "src/__support/macros/config.h"
+#include "src/__support/time/linux/kernel_timespec.h"
 #include <sys/syscall.h>
-
 #if defined(SYS_clock_gettime64)
 #include <linux/time_types.h>
 #endif
@@ -36,9 +36,7 @@ ErrorOr<int> clock_gettime(clockid_t clockid, timespec *ts) {
                                               reinterpret_cast<long>(ts));
   } else {
     __kernel_timespec ts64{};
-    __kernel_timespec *ts64_ptr = nullptr;
-    if (ts != nullptr)
-      ts64_ptr = &ts64;
+    __kernel_timespec *ts64_ptr = ts ? &ts64 : nullptr;
     if (ts64_ptr != nullptr && LIBC_LIKELY(clock_gettime64 != nullptr)) {
       ret = clock_gettime64(clockid, ts64_ptr);
     } else {
@@ -47,8 +45,7 @@ ErrorOr<int> clock_gettime(clockid_t clockid, timespec *ts) {
                                               reinterpret_cast<long>(ts64_ptr));
     }
     if (ret == 0 && ts != nullptr) {
-      ts->tv_sec = static_cast<decltype(ts->tv_sec)>(ts64.tv_sec);
-      ts->tv_nsec = static_cast<decltype(ts->tv_nsec)>(ts64.tv_nsec);
+      *ts = to_timespec(ts64);
     }
   }
 #elif defined(SYS_clock_gettime)

--- a/libc/src/__support/time/linux/clock_settime.cpp
+++ b/libc/src/__support/time/linux/clock_settime.cpp
@@ -24,9 +24,26 @@ namespace internal {
 ErrorOr<int> clock_settime(clockid_t clockid, const timespec *ts) {
   int ret;
 #if defined(SYS_clock_settime64)
-  ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_clock_settime64,
-                                          static_cast<long>(clockid),
-                                          reinterpret_cast<long>(ts));
+  // In overlay mode on 32-bit platforms, the system timespec (which we use)
+  // may be 32-bit (8 bytes), while the kernel's __kernel_timespec (used by
+  // _time64 syscalls) is 64-bit (16 bytes). If they match, we can pass the
+  // pointer directly. Otherwise, we must convert to avoid stack corruption.
+  if constexpr (sizeof(timespec) == sizeof(__kernel_timespec)) {
+    ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_clock_settime64,
+                                            static_cast<long>(clockid),
+                                            reinterpret_cast<long>(ts));
+  } else {
+    __kernel_timespec ts64{};
+    __kernel_timespec *ts64_ptr = nullptr;
+    if (ts != nullptr) {
+      ts64.tv_sec = ts->tv_sec;
+      ts64.tv_nsec = ts->tv_nsec;
+      ts64_ptr = &ts64;
+    }
+    ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_clock_settime64,
+                                            static_cast<long>(clockid),
+                                            reinterpret_cast<long>(ts64_ptr));
+  }
 #elif defined(SYS_clock_settime)
   static_assert(
       sizeof(timespec::tv_nsec) == sizeof(long),

--- a/libc/src/__support/time/linux/clock_settime.cpp
+++ b/libc/src/__support/time/linux/clock_settime.cpp
@@ -13,8 +13,8 @@
 #include "src/__support/common.h"
 #include "src/__support/error_or.h"
 #include "src/__support/macros/config.h"
+#include "src/__support/time/linux/kernel_timespec.h"
 #include <sys/syscall.h>
-
 #if defined(SYS_clock_settime64)
 #include <linux/time_types.h>
 #endif
@@ -36,8 +36,7 @@ ErrorOr<int> clock_settime(clockid_t clockid, const timespec *ts) {
     __kernel_timespec ts64{};
     __kernel_timespec *ts64_ptr = nullptr;
     if (ts != nullptr) {
-      ts64.tv_sec = ts->tv_sec;
-      ts64.tv_nsec = ts->tv_nsec;
+      ts64 = to_kernel_timespec(*ts);
       ts64_ptr = &ts64;
     }
     ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_clock_settime64,

--- a/libc/src/__support/time/linux/kernel_timespec.h
+++ b/libc/src/__support/time/linux/kernel_timespec.h
@@ -1,0 +1,34 @@
+//===--- Conversion helpers for __kernel_timespec ---------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_TIME_LINUX_KERNEL_TIMESPEC_H
+#define LLVM_LIBC_SRC___SUPPORT_TIME_LINUX_KERNEL_TIMESPEC_H
+
+#include "hdr/types/struct_timespec.h"
+#include "src/__support/macros/config.h"
+#include <linux/time_types.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+// Convert from timespec to __kernel_timespec
+LIBC_INLINE constexpr __kernel_timespec to_kernel_timespec(const timespec &ts) {
+  return __kernel_timespec{
+      static_cast<decltype(__kernel_timespec::tv_sec)>(ts.tv_sec),
+      static_cast<decltype(__kernel_timespec::tv_nsec)>(ts.tv_nsec)};
+}
+
+// Convert from __kernel_timespec to timespec
+LIBC_INLINE constexpr timespec to_timespec(const __kernel_timespec &ts64) {
+  return timespec{
+      static_cast<decltype(timespec::tv_sec)>(ts64.tv_sec),
+      static_cast<decltype(timespec::tv_nsec)>(ts64.tv_nsec)};
+}
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_TIME_LINUX_KERNEL_TIMESPEC_H

--- a/libc/src/sys/select/linux/select.cpp
+++ b/libc/src/sys/select/linux/select.cpp
@@ -17,6 +17,7 @@
 #include "src/__support/macros/config.h"
 
 #include "hdr/types/size_t.h"
+#include "src/__support/time/linux/kernel_timespec.h"
 #include <sys/syscall.h>
 #if defined(SYS_pselect6_time64)
 #include <linux/time_types.h>
@@ -71,8 +72,7 @@ LLVM_LIBC_FUNCTION(int, select,
     __kernel_timespec ts64{};
     __kernel_timespec *ts_ptr = nullptr;
     if (timeout != nullptr) {
-      ts64.tv_sec = ts.tv_sec;
-      ts64.tv_nsec = ts.tv_nsec;
+      ts64 = to_kernel_timespec(ts);
       ts_ptr = &ts64;
     }
     ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_pselect6_time64, nfds, read_set,

--- a/libc/src/sys/select/linux/select.cpp
+++ b/libc/src/sys/select/linux/select.cpp
@@ -17,7 +17,10 @@
 #include "src/__support/macros/config.h"
 
 #include "hdr/types/size_t.h"
-#include <sys/syscall.h> // For syscall numbers.
+#include <sys/syscall.h>
+#if defined(SYS_pselect6_time64)
+#include <linux/time_types.h>
+#endif
 
 namespace LIBC_NAMESPACE_DECL {
 
@@ -55,8 +58,26 @@ LLVM_LIBC_FUNCTION(int, select,
   }
   pselect6_sigset_t pss{nullptr, sizeof(sigset_t)};
 #if defined(SYS_pselect6_time64)
-  int ret = LIBC_NAMESPACE::syscall_impl<int>(
-      SYS_pselect6_time64, nfds, read_set, write_set, error_set, &ts, &pss);
+  int ret;
+  // In overlay mode on 32-bit platforms, the system timespec (which we use)
+  // may be 32-bit (8 bytes), while the kernel's __kernel_timespec (used by
+  // _time64 syscalls) is 64-bit (16 bytes). If they match, we can pass the
+  // pointer directly. Otherwise, we must convert to avoid stack corruption.
+  if constexpr (sizeof(timespec) == sizeof(__kernel_timespec)) {
+    ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_pselect6_time64, nfds, read_set,
+                                            write_set, error_set,
+                                            timeout ? &ts : nullptr, &pss);
+  } else {
+    __kernel_timespec ts64{};
+    __kernel_timespec *ts_ptr = nullptr;
+    if (timeout != nullptr) {
+      ts64.tv_sec = ts.tv_sec;
+      ts64.tv_nsec = ts.tv_nsec;
+      ts_ptr = &ts64;
+    }
+    ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_pselect6_time64, nfds, read_set,
+                                            write_set, error_set, ts_ptr, &pss);
+  }
 #elif defined(SYS_pselect6)
   static_assert(
       sizeof(timespec::tv_nsec) == sizeof(long),
@@ -64,7 +85,8 @@ LLVM_LIBC_FUNCTION(int, select,
       "matches the register size (long). It is unsafe on 32-bit platforms "
       "with 64-bit tv_nsec.");
   int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_pselect6, nfds, read_set,
-                                              write_set, error_set, &ts, &pss);
+                                              write_set, error_set,
+                                              timeout ? &ts : nullptr, &pss);
 #else
 #error "SYS_pselect6 and SYS_pselect6_time64 syscalls not available."
 #endif

--- a/libc/src/time/linux/nanosleep.cpp
+++ b/libc/src/time/linux/nanosleep.cpp
@@ -13,15 +13,43 @@
 #include "src/__support/common.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
+#include "src/__support/macros/null_check.h"
 
-#include <sys/syscall.h> // For syscall numbers.
+#include <sys/syscall.h>
+#if defined(SYS_clock_nanosleep_time64)
+#include <linux/time_types.h>
+#endif
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, nanosleep, (const timespec *req, timespec *rem)) {
+  LIBC_CRASH_ON_NULLPTR(req);
 #if defined(SYS_clock_nanosleep_time64)
-  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_clock_nanosleep_time64,
-                                              CLOCK_REALTIME, 0, req, rem);
+  int ret;
+  // In overlay mode on 32-bit platforms, the system timespec (which we use)
+  // may be 32-bit (8 bytes), while the kernel's __kernel_timespec (used by
+  // _time64 syscalls) is 64-bit (16 bytes). If they match, we can pass the
+  // pointer directly. Otherwise, we must convert to avoid stack corruption.
+  if constexpr (sizeof(timespec) == sizeof(__kernel_timespec)) {
+    ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_clock_nanosleep_time64,
+                                            CLOCK_REALTIME, 0, req, rem);
+  } else {
+    __kernel_timespec ts64_req{};
+    __kernel_timespec *req_ptr = nullptr;
+    if (req != nullptr) {
+      ts64_req.tv_sec = req->tv_sec;
+      ts64_req.tv_nsec = req->tv_nsec;
+      req_ptr = &ts64_req;
+    }
+    __kernel_timespec ts64_rem{};
+    __kernel_timespec *rem_ptr = rem ? &ts64_rem : nullptr;
+    ret = LIBC_NAMESPACE::syscall_impl<int>(
+        SYS_clock_nanosleep_time64, CLOCK_REALTIME, 0, req_ptr, rem_ptr);
+    if (ret == -EINTR && rem != nullptr) {
+      rem->tv_sec = static_cast<decltype(rem->tv_sec)>(ts64_rem.tv_sec);
+      rem->tv_nsec = static_cast<decltype(rem->tv_nsec)>(ts64_rem.tv_nsec);
+    }
+  }
 #elif defined(SYS_nanosleep)
   static_assert(
       sizeof(timespec::tv_nsec) == sizeof(long),

--- a/libc/src/time/linux/nanosleep.cpp
+++ b/libc/src/time/linux/nanosleep.cpp
@@ -15,6 +15,7 @@
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/null_check.h"
 
+#include "src/__support/time/linux/kernel_timespec.h"
 #include <sys/syscall.h>
 #if defined(SYS_clock_nanosleep_time64)
 #include <linux/time_types.h>
@@ -37,8 +38,7 @@ LLVM_LIBC_FUNCTION(int, nanosleep, (const timespec *req, timespec *rem)) {
     __kernel_timespec ts64_req{};
     __kernel_timespec *req_ptr = nullptr;
     if (req != nullptr) {
-      ts64_req.tv_sec = req->tv_sec;
-      ts64_req.tv_nsec = req->tv_nsec;
+      ts64_req = to_kernel_timespec(*req);
       req_ptr = &ts64_req;
     }
     __kernel_timespec ts64_rem{};
@@ -46,8 +46,7 @@ LLVM_LIBC_FUNCTION(int, nanosleep, (const timespec *req, timespec *rem)) {
     ret = LIBC_NAMESPACE::syscall_impl<int>(
         SYS_clock_nanosleep_time64, CLOCK_REALTIME, 0, req_ptr, rem_ptr);
     if (ret == -EINTR && rem != nullptr) {
-      rem->tv_sec = static_cast<decltype(rem->tv_sec)>(ts64_rem.tv_sec);
-      rem->tv_nsec = static_cast<decltype(rem->tv_nsec)>(ts64_rem.tv_nsec);
+      *rem = to_timespec(ts64_rem);
     }
   }
 #elif defined(SYS_nanosleep)

--- a/libc/test/UnitTest/LibcTest.cpp
+++ b/libc/test/UnitTest/LibcTest.cpp
@@ -299,3 +299,8 @@ bool Test::testMatch(bool MatchResult, MatcherBase &Matcher, const char *LHSStr,
 
 } // namespace testing
 } // namespace LIBC_NAMESPACE_DECL
+
+extern "C" void __cxa_pure_virtual() {
+  __builtin_trap();
+}
+

--- a/libc/test/UnitTest/LibcTest.h
+++ b/libc/test/UnitTest/LibcTest.h
@@ -29,7 +29,9 @@
 #include "src/__support/CPP/string.h"
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/CPP/type_traits.h"
+#include "src/__support/CPP/new.h"
 #include "src/__support/c_string.h"
+
 #include "src/__support/macros/properties/compiler.h"
 #include "test/UnitTest/ExecuteFunction.h"
 #include "test/UnitTest/TestLogger.h"


### PR DESCRIPTION
After removing 32-bit time_t support, some time-related syscall wrappers were still passing 32-bit timespec structures directly to 64-bit time syscalls (like SYS_clock_nanosleep_time64, SYS_pselect6_time64, etc.). This caused stack corruption and invalid arguments on 32-bit platforms.

Commit 961d5b8ac7de fixed this for clock_gettime. This commit applies similar fixes to:
- clock_settime
- nanosleep (including correct handling of remaining time)
- select (pselect6)
- utimensat
- futex (wait timeout)

Also fixes a bug in select where a null timeout would incorrectly result in passing a zero timeout (polling) instead of blocking.