### PR TITLE
[clang] `this` getter missed in ConstructAttributeList

### DIFF
--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -2922,20 +2922,18 @@ void CodeGenModule::ConstructAttributeList(StringRef Name,
     llvm::AttrBuilder &Attrs = ArgAttrs[IRArgs.first];
 
     QualType ThisTy = FI.arg_begin()->type.getTypePtr()->getPointeeType();
+    int64_t ThisSz = getMinimumObjectSize(ThisTy).getQuantity();
 
     if (!CodeGenOpts.NullPointerIsValid &&
         getTypes().getTargetAddressSpace(FI.arg_begin()->type) == 0) {
       Attrs.addAttribute(llvm::Attribute::NonNull);
-      Attrs.addDereferenceableAttr(getMinimumObjectSize(ThisTy).getQuantity());
+      Attrs.addDereferenceableAttr(ThisSz);
     } else {
       // FIXME dereferenceable should be correct here, regardless of
       // NullPointerIsValid. However, dereferenceable currently does not always
       // respect NullPointerIsValid and may imply nonnull and break the program.
       // See https://reviews.llvm.org/D66618 for discussions.
-      Attrs.addDereferenceableOrNullAttr(
-          getMinimumObjectSize(
-              FI.arg_begin()->type.castAs<PointerType>()->getPointeeType())
-              .getQuantity());
+      Attrs.addDereferenceableOrNullAttr(ThisSz);
     }
 
     llvm::Align Alignment =


### PR DESCRIPTION
In https://reviews.llvm.org/D159247
(400d3261a0da56554aee8e5a2fbc27eade9d05db) it looks intended to update all of these calls, but missed this. The effect is that a reference to `this` in a non-zero addrspace would crash here (because it asserts that `this` is a pointer). DRY the code since this branch looks like it kept getting copied more incorrectly over time. I don't have an actual use or test for this, I just noticed it while I was trying to break other things in fuzzing.