### PR TITLE
[MLIR][LLVM] Add function metadata to LLVMFuncOp

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
@@ -1873,6 +1873,28 @@ def LLVM_MDNodeArrayAttr
     : TypedArrayAttrBase<LLVM_MDNodeAttr,
                          "array of #llvm.md_node attributes">;
 
+def LLVM_FunctionMetadataAttr
+    : LLVM_Attr<"FunctionMetadata", "func_metadata"> {
+  let summary = "LLVM function metadata attachment";
+  let description = [{
+    Models one LLVM IR function metadata attachment. LLVM IR allows several
+    attachments with the same metadata kind, so function metadata is represented
+    as an ordered list of these entries instead of a dictionary.
+
+    Example:
+    ```mlir
+    #llvm.func_metadata<"type", <#llvm.md_string<"id">>>
+    ```
+  }];
+  let parameters = (ins "StringAttr":$metadataName, "MDNodeAttr":$node);
+  let assemblyFormat = "`<` $metadataName `,` $node `>`";
+  let genVerifyDecl = 1;
+}
+
+def LLVM_FunctionMetadataArrayAttr
+    : TypedArrayAttrBase<LLVM_FunctionMetadataAttr,
+                         "array of #llvm.func_metadata attributes">;
+
 def LLVM_AnyMDAttr : AnyAttrOf<[
     LLVM_MDStringAttr, LLVM_MDConstantAttr, LLVM_MDGlobalValueAttr,
     LLVM_MDNullAttr, LLVM_MDAddrSpaceCastAttr, LLVM_MDNodeAttr],

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -2105,6 +2105,7 @@ def LLVM_LLVMFuncOp : LLVM_Op<"func", [
     OptionalAttr<DenseI32ArrayAttr>:$work_group_size_hint,
     OptionalAttr<DenseI32ArrayAttr>:$reqd_work_group_size,
     OptionalAttr<I32Attr>:$intel_reqd_sub_group_size,
+    OptionalAttr<LLVM_FunctionMetadataArrayAttr>:$function_metadata,
     OptionalAttr<UWTableKindAttr>:$uwtable_kind,
     OptionalAttr<BoolAttr>:$use_sample_profile
   );

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
@@ -17,9 +17,12 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/BinaryFormat/Dwarf.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/Support/ErrorHandling.h"
 
 using namespace mlir;
 using namespace mlir::LLVM;
@@ -139,6 +142,20 @@ bool AddressSpaceAttr::isValidPtrIntCast(
 // FunctionMetadataAttr
 //===----------------------------------------------------------------------===//
 
+static constexpr unsigned kReservedFunctionMetadataKinds[] = {
+    llvm::LLVMContext::MD_dbg, llvm::LLVMContext::MD_prof};
+
+static StringRef getFixedMetadataKindName(unsigned kind) {
+  switch (kind) {
+#define LLVM_FIXED_MD_KIND(EnumID, Name, Value)                                \
+  case llvm::LLVMContext::EnumID:                                              \
+    return Name;
+#include "llvm/IR/FixedMetadataKinds.def"
+#undef LLVM_FIXED_MD_KIND
+  }
+  llvm_unreachable("unknown fixed metadata kind");
+}
+
 LogicalResult
 FunctionMetadataAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                              StringAttr metadataName, MDNodeAttr node) {
@@ -146,11 +163,11 @@ FunctionMetadataAttr::verify(function_ref<InFlightDiagnostic()> emitError,
   StringRef name = metadataName.getValue();
   if (name.empty())
     return emitError() << "function_metadata entry name must not be empty";
-  // MDNodeAttr cannot represent the DISubprogram required for a function's
-  // !dbg attachment.
-  if (name == "dbg") {
+  if (llvm::any_of(kReservedFunctionMetadataKinds, [&](unsigned kind) {
+        return name == getFixedMetadataKindName(kind);
+      })) {
     return emitError() << "reserved function_metadata entry '" << name
-                       << "' must use a dedicated LLVM dialect representation";
+                       << "' is not supported by the generic carrier";
   }
   return success();
 }

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
@@ -136,6 +136,24 @@ bool AddressSpaceAttr::isValidPtrIntCast(
 }
 
 //===----------------------------------------------------------------------===//
+// FunctionMetadataAttr
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+FunctionMetadataAttr::verify(function_ref<InFlightDiagnostic()> emitError,
+                             StringAttr metadataName, MDNodeAttr node) {
+  (void)node;
+  StringRef name = metadataName.getValue();
+  if (name.empty())
+    return emitError() << "function_metadata entry name must not be empty";
+  if (name == "dbg" || name == "prof") {
+    return emitError() << "reserved function_metadata entry '" << name
+                       << "' must use a dedicated LLVM dialect representation";
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // AliasScopeAttr
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
@@ -146,7 +146,9 @@ FunctionMetadataAttr::verify(function_ref<InFlightDiagnostic()> emitError,
   StringRef name = metadataName.getValue();
   if (name.empty())
     return emitError() << "function_metadata entry name must not be empty";
-  if (name == "dbg" || name == "prof") {
+  // MDNodeAttr cannot represent the DISubprogram required for a function's
+  // !dbg attachment.
+  if (name == "dbg") {
     return emitError() << "reserved function_metadata entry '" << name
                        << "' must use a dedicated LLVM dialect representation";
   }

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -3325,22 +3325,6 @@ LogicalResult LLVMFuncOp::verify() {
   if (failed(verifyComdat(*this, getComdat())))
     return failure();
 
-  unsigned numProfileMetadata = 0;
-  if (ArrayAttr functionMetadata = getFunctionMetadataAttr()) {
-    for (auto entry : functionMetadata.getAsRange<FunctionMetadataAttr>()) {
-      if (entry.getMetadataName().getValue() == "prof")
-        ++numProfileMetadata;
-    }
-  }
-  if (numProfileMetadata > 1)
-    return emitOpError("expects at most one 'prof' function_metadata entry");
-  if (numProfileMetadata && isExternal())
-    return emitOpError("function declarations cannot have 'prof' metadata");
-  if (numProfileMetadata && getFunctionEntryCountAttr()) {
-    return emitOpError("cannot have both a 'prof' function_metadata entry and "
-                       "the 'function_entry_count' attribute");
-  }
-
   if (isExternal()) {
     if (getLinkage() != LLVM::Linkage::External &&
         getLinkage() != LLVM::Linkage::ExternWeak)

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -3325,6 +3325,22 @@ LogicalResult LLVMFuncOp::verify() {
   if (failed(verifyComdat(*this, getComdat())))
     return failure();
 
+  unsigned numProfileMetadata = 0;
+  if (ArrayAttr functionMetadata = getFunctionMetadataAttr()) {
+    for (auto entry : functionMetadata.getAsRange<FunctionMetadataAttr>()) {
+      if (entry.getMetadataName().getValue() == "prof")
+        ++numProfileMetadata;
+    }
+  }
+  if (numProfileMetadata > 1)
+    return emitOpError("expects at most one 'prof' function_metadata entry");
+  if (numProfileMetadata && isExternal())
+    return emitOpError("function declarations cannot have 'prof' metadata");
+  if (numProfileMetadata && getFunctionEntryCountAttr()) {
+    return emitOpError("cannot have both a 'prof' function_metadata entry and "
+                       "the 'function_entry_count' attribute");
+  }
+
   if (isExternal()) {
     if (getLinkage() != LLVM::Linkage::External &&
         getLinkage() != LLVM::Linkage::ExternWeak)

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -2076,6 +2076,9 @@ LogicalResult ModuleTranslation::convertFunctionSignatures() {
     llvmFunc->setLinkage(convertLinkageToLLVM(function.getLinkage()));
     llvmFunc->setCallingConv(convertCConvToLLVM(function.getCConv()));
     mapFunction(function.getName(), llvmFunc);
+    if (function.getFunctionMetadataAttr())
+      return function.emitError()
+             << "not yet implemented: translating function_metadata to LLVM IR";
     addRuntimePreemptionSpecifier(function.getDsoLocal(), llvmFunc);
 
     // Convert function attributes.

--- a/mlir/test/Dialect/LLVMIR/invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/invalid.mlir
@@ -1871,41 +1871,13 @@ llvm.func @empty_function_metadata_name() attributes {function_metadata = [#llvm
 
 // -----
 
-// expected-error@+1{{reserved function_metadata entry 'dbg' must use a dedicated LLVM dialect representation}}
+// expected-error@+1{{reserved function_metadata entry 'dbg' is not supported by the generic carrier}}
 llvm.func @reserved_dbg_function_metadata() attributes {function_metadata = [#llvm.func_metadata<"dbg", #llvm.md_node<#llvm.md_string<"x">>>]}
 
 // -----
 
-// expected-error@below{{function declarations cannot have 'prof' metadata}}
-llvm.func @profile_metadata_declaration() attributes {
-  function_metadata = [
-    #llvm.func_metadata<"prof", #llvm.md_node<#llvm.md_string<"unknown">, #llvm.md_string<"sample-pass">>>
-  ]
-}
-
-// -----
-
-// expected-error@below{{expects at most one 'prof' function_metadata entry}}
-llvm.func @repeated_profile_metadata() attributes {
-  function_metadata = [
-    #llvm.func_metadata<"prof", #llvm.md_node<#llvm.md_string<"unknown">, #llvm.md_string<"sample-pass-0">>>,
-    #llvm.func_metadata<"prof", #llvm.md_node<#llvm.md_string<"unknown">, #llvm.md_string<"sample-pass-1">>>
-  ]
-} {
-  llvm.return
-}
-
-// -----
-
-// expected-error@below{{cannot have both a 'prof' function_metadata entry and the 'function_entry_count' attribute}}
-llvm.func @conflicting_profile_metadata() attributes {
-  function_entry_count = #llvm.function_entry_count<entry_count = 1>,
-  function_metadata = [
-    #llvm.func_metadata<"prof", #llvm.md_node<#llvm.md_string<"unknown">, #llvm.md_string<"sample-pass">>>
-  ]
-} {
-  llvm.return
-}
+// expected-error@+1{{reserved function_metadata entry 'prof' is not supported by the generic carrier}}
+llvm.func @reserved_prof_function_metadata() attributes {function_metadata = [#llvm.func_metadata<"prof", #llvm.md_node<#llvm.md_string<"unknown">, #llvm.md_string<"sample-pass">>>]}
 
 // -----
 

--- a/mlir/test/Dialect/LLVMIR/invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/invalid.mlir
@@ -1876,8 +1876,36 @@ llvm.func @reserved_dbg_function_metadata() attributes {function_metadata = [#ll
 
 // -----
 
-// expected-error@+1{{reserved function_metadata entry 'prof' must use a dedicated LLVM dialect representation}}
-llvm.func @reserved_prof_function_metadata() attributes {function_metadata = [#llvm.func_metadata<"prof", #llvm.md_node<#llvm.md_string<"function_entry_count">, #llvm.md_const<1 : i64>>>]}
+// expected-error@below{{function declarations cannot have 'prof' metadata}}
+llvm.func @profile_metadata_declaration() attributes {
+  function_metadata = [
+    #llvm.func_metadata<"prof", #llvm.md_node<#llvm.md_string<"unknown">, #llvm.md_string<"sample-pass">>>
+  ]
+}
+
+// -----
+
+// expected-error@below{{expects at most one 'prof' function_metadata entry}}
+llvm.func @repeated_profile_metadata() attributes {
+  function_metadata = [
+    #llvm.func_metadata<"prof", #llvm.md_node<#llvm.md_string<"unknown">, #llvm.md_string<"sample-pass-0">>>,
+    #llvm.func_metadata<"prof", #llvm.md_node<#llvm.md_string<"unknown">, #llvm.md_string<"sample-pass-1">>>
+  ]
+} {
+  llvm.return
+}
+
+// -----
+
+// expected-error@below{{cannot have both a 'prof' function_metadata entry and the 'function_entry_count' attribute}}
+llvm.func @conflicting_profile_metadata() attributes {
+  function_entry_count = #llvm.function_entry_count<entry_count = 1>,
+  function_metadata = [
+    #llvm.func_metadata<"prof", #llvm.md_node<#llvm.md_string<"unknown">, #llvm.md_string<"sample-pass">>>
+  ]
+} {
+  llvm.return
+}
 
 // -----
 

--- a/mlir/test/Dialect/LLVMIR/invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/invalid.mlir
@@ -1861,6 +1861,26 @@ llvm.mlir.alias external @y5 : i32 {
 
 // -----
 
+// expected-error@+1{{attribute 'function_metadata' failed to satisfy constraint: array of #llvm.func_metadata attributes}}
+llvm.func @function_metadata_value() attributes {function_metadata = [#llvm.md_string<"int">]}
+
+// -----
+
+// expected-error@+1{{function_metadata entry name must not be empty}}
+llvm.func @empty_function_metadata_name() attributes {function_metadata = [#llvm.func_metadata<"", #llvm.md_node<#llvm.md_string<"x">>>]}
+
+// -----
+
+// expected-error@+1{{reserved function_metadata entry 'dbg' must use a dedicated LLVM dialect representation}}
+llvm.func @reserved_dbg_function_metadata() attributes {function_metadata = [#llvm.func_metadata<"dbg", #llvm.md_node<#llvm.md_string<"x">>>]}
+
+// -----
+
+// expected-error@+1{{reserved function_metadata entry 'prof' must use a dedicated LLVM dialect representation}}
+llvm.func @reserved_prof_function_metadata() attributes {function_metadata = [#llvm.func_metadata<"prof", #llvm.md_node<#llvm.md_string<"function_entry_count">, #llvm.md_const<1 : i64>>>]}
+
+// -----
+
 // expected-error@+1{{attribute 'nodes' failed to satisfy constraint: array of #llvm.md_node attributes}}
 llvm.named_metadata "not_node" [#llvm.md_string<"int">]
 

--- a/mlir/test/Dialect/LLVMIR/roundtrip.mlir
+++ b/mlir/test/Dialect/LLVMIR/roundtrip.mlir
@@ -1260,3 +1260,25 @@ llvm.named_metadata "foo.kernel" [
     >
   >
 ]
+
+// CHECK-LABEL: llvm.func @generic_function_metadata
+// CHECK-SAME: function_metadata
+// CHECK-SAME: #llvm.func_metadata<"annotation", <#llvm.md_string<"function annotation">>>
+// CHECK-SAME: #llvm.func_metadata<"type", <#llvm.md_const<0 : i64>, #llvm.md_string<"typeid">>>
+llvm.func @generic_function_metadata() attributes {
+  function_metadata = [
+    #llvm.func_metadata<"annotation", #llvm.md_node<#llvm.md_string<"function annotation">>>,
+    #llvm.func_metadata<"type", #llvm.md_node<#llvm.md_const<0 : i64>, #llvm.md_string<"typeid">>>
+  ]
+}
+
+// CHECK-LABEL: llvm.func @repeated_function_metadata
+// CHECK-SAME: function_metadata
+// CHECK-SAME: #llvm.func_metadata<"type", <#llvm.md_const<0 : i64>, #llvm.md_string<"typeid0">>>
+// CHECK-SAME: #llvm.func_metadata<"type", <#llvm.md_const<0 : i64>, #llvm.md_string<"typeid1">>>
+llvm.func @repeated_function_metadata() attributes {
+  function_metadata = [
+    #llvm.func_metadata<"type", #llvm.md_node<#llvm.md_const<0 : i64>, #llvm.md_string<"typeid0">>>,
+    #llvm.func_metadata<"type", #llvm.md_node<#llvm.md_const<0 : i64>, #llvm.md_string<"typeid1">>>
+  ]
+}

--- a/mlir/test/Dialect/LLVMIR/roundtrip.mlir
+++ b/mlir/test/Dialect/LLVMIR/roundtrip.mlir
@@ -1272,17 +1272,6 @@ llvm.func @generic_function_metadata() attributes {
   ]
 }
 
-// CHECK-LABEL: llvm.func @generic_profile_metadata
-// CHECK-SAME: function_metadata
-// CHECK-SAME: #llvm.func_metadata<"prof", <#llvm.md_string<"unknown">, #llvm.md_string<"sample-pass">>>
-llvm.func @generic_profile_metadata() attributes {
-  function_metadata = [
-    #llvm.func_metadata<"prof", #llvm.md_node<#llvm.md_string<"unknown">, #llvm.md_string<"sample-pass">>>
-  ]
-} {
-  llvm.return
-}
-
 // CHECK-LABEL: llvm.func @repeated_function_metadata
 // CHECK-SAME: function_metadata
 // CHECK-SAME: #llvm.func_metadata<"type", <#llvm.md_const<0 : i64>, #llvm.md_string<"typeid0">>>

--- a/mlir/test/Dialect/LLVMIR/roundtrip.mlir
+++ b/mlir/test/Dialect/LLVMIR/roundtrip.mlir
@@ -1272,6 +1272,17 @@ llvm.func @generic_function_metadata() attributes {
   ]
 }
 
+// CHECK-LABEL: llvm.func @generic_profile_metadata
+// CHECK-SAME: function_metadata
+// CHECK-SAME: #llvm.func_metadata<"prof", <#llvm.md_string<"unknown">, #llvm.md_string<"sample-pass">>>
+llvm.func @generic_profile_metadata() attributes {
+  function_metadata = [
+    #llvm.func_metadata<"prof", #llvm.md_node<#llvm.md_string<"unknown">, #llvm.md_string<"sample-pass">>>
+  ]
+} {
+  llvm.return
+}
+
 // CHECK-LABEL: llvm.func @repeated_function_metadata
 // CHECK-SAME: function_metadata
 // CHECK-SAME: #llvm.func_metadata<"type", <#llvm.md_const<0 : i64>, #llvm.md_string<"typeid0">>>


### PR DESCRIPTION
Add a generic LLVM dialect carrier for LLVM IR function metadata on LLVMFuncOp. Represent attachments as an ordered list so repeated metadata kinds, such as multiple type metadata attachments, can be preserved while keeping metadata names language-agnostic.