### PR TITLE
[libc] Add the htons function family to netinet/in.h

### DIFF
--- a/libc/include/arpa/inet.yaml
+++ b/libc/include/arpa/inet.yaml
@@ -1,6 +1,8 @@
 header: arpa/inet.h
 standards:
   - posix
+merge_yaml_files:
+  - ../htons-family.yaml
 macros:
   - macro_name: INET_ADDRSTRLEN
     macro_header: inet-address-macros.h
@@ -12,18 +14,6 @@ types:
 enums: []
 objects: []
 functions:
-  - name: htonl
-    standards:
-      - posix
-    return_type: uint32_t
-    arguments:
-      - type: uint32_t
-  - name: htons
-    standards:
-      - posix
-    return_type: uint16_t
-    arguments:
-      - type: uint16_t
   - name: inet_addr
     standards:
       - posix
@@ -37,15 +27,3 @@ functions:
     arguments:
       - type: const char *
       - type: struct in_addr *
-  - name: ntohl
-    standards:
-      - posix
-    return_type: uint32_t
-    arguments:
-      - type: uint32_t
-  - name: ntohs
-    standards:
-      - posix
-    return_type: uint16_t
-    arguments:
-      - type: uint16_t

--- a/libc/include/htons-family.yaml
+++ b/libc/include/htons-family.yaml
@@ -1,0 +1,25 @@
+functions:
+  - name: htonl
+    standards:
+      - posix
+    return_type: uint32_t
+    arguments:
+      - type: uint32_t
+  - name: htons
+    standards:
+      - posix
+    return_type: uint16_t
+    arguments:
+      - type: uint16_t
+  - name: ntohl
+    standards:
+      - posix
+    return_type: uint32_t
+    arguments:
+      - type: uint32_t
+  - name: ntohs
+    standards:
+      - posix
+    return_type: uint16_t
+    arguments:
+      - type: uint16_t

--- a/libc/include/netinet/in.yaml
+++ b/libc/include/netinet/in.yaml
@@ -1,6 +1,8 @@
 header: netinet/in.h
 standards:
   - posix
+merge_yaml_files:
+  - ../htons-family.yaml
 macros:
   - macro_name: IPPROTO_IP
     macro_header: netinet-in-macros.h

--- a/libc/utils/docgen/netinet/in.yaml
+++ b/libc/utils/docgen/netinet/in.yaml
@@ -59,3 +59,12 @@ macros:
     in-latest-posix: ''
   IN6_IS_ADDR_MC_GLOBAL:
     in-latest-posix: ''
+functions:
+  htonl:
+    in-latest-posix: ''
+  htons:
+    in-latest-posix: ''
+  ntohl:
+    in-latest-posix: ''
+  ntohs:
+    in-latest-posix: ''


### PR DESCRIPTION
As required by POSIX.

I've used the merge_yaml_files functionality to avoid duplication.

Assisted by Gemini.