### PR TITLE
[lldb][Windows] Make RM_RF a no-op on an empty argument and swallow errors

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -44,7 +44,7 @@ ifeq "$(OS)" "Windows_NT"
 	CP_R = xcopy $(subst /,\,$(1)) $(subst /,\,$(2)) /s /e /y
 	RM = del $(subst /,\,$(1)) > nul 2>&1 || (exit 0)
 	RM_F = del /f /q $(subst /,\,$(1))
-	RM_RF = rd /s /q $(subst /,\,$(1))
+	RM_RF = $(if $(strip $(1)),rd /s /q $(subst /,\,$(1)) > nul 2>&1 || (exit 0))
 	LN_SF = mklink /D "$(subst /,\,$(2))" "$(subst /,\,$(1))"
 	ECHO = echo $(1);
 	ECHO_TO_FILE = printf "%s\n" $(1) > "$(subst /,\,$(2))"


### PR DESCRIPTION
This patch makes the Windows `RM_RF` a no-op on an empty argument and swallow errors, matching Unix `rm -rf`. This fixes issues in swiftlang on fresh builds.

This is needed for https://github.com/swiftlang/llvm-project/pull/13180