### PR TITLE
[clang][test] Fix cl-pathmap.c test failure on mac

### DIFF
--- a/clang/test/Preprocessor/cl-pathmap.c
+++ b/clang/test/Preprocessor/cl-pathmap.c
@@ -7,7 +7,7 @@
 // CHECK-REPRODUCABLE-NOT: filename:
 
 //NOTE: currently . and .\ just gets eliminated after mapping 
-// RUN: %clang_cl -E /pathmap:%p=. %s | FileCheck %s --check-prefix CHECK-SIMPLE
+// RUN: %clang_cl -E /pathmap:%p=. -- %s | FileCheck %s --check-prefix CHECK-SIMPLE
 // CHECK-SIMPLE: filename: "cl-pathmap.c"
 // CHECK-SIMPLE-NOT: filename:
 filename: __FILE__


### PR DESCRIPTION
Add '--' before '%s' in the preprocessor test to
prevent the path (which typically starts with '/Users' 
on macOS) from being interpreted as an option.