### PR TITLE
[SystemZ] Add serialization strings for some MO target flags.

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
@@ -2426,6 +2426,9 @@ SystemZInstrInfo::getSerializableDirectMachineOperandTargetFlags() const {
   using namespace SystemZII;
 
   static const std::pair<unsigned, const char *> TargetFlags[] = {
+      {MO_SYMBOL_MODIFIER, "systemz-symbol-modifier"},
+      {MO_GOT, "systemz-got"},
+      {MO_INDNTPOFF, "systemz-indntpoff"},
       {MO_ADA_DATA_SYMBOL_ADDR, "systemz-ada-datasymboladdr"},
       {MO_ADA_INDIRECT_FUNC_DESC, "systemz-ada-indirectfuncdesc"},
       {MO_ADA_DIRECT_FUNC_DESC, "systemz-ada-directfuncdesc"}};

--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
@@ -2426,7 +2426,6 @@ SystemZInstrInfo::getSerializableDirectMachineOperandTargetFlags() const {
   using namespace SystemZII;
 
   static const std::pair<unsigned, const char *> TargetFlags[] = {
-      {MO_SYMBOL_MODIFIER, "systemz-symbol-modifier"},
       {MO_GOT, "systemz-got"},
       {MO_INDNTPOFF, "systemz-indntpoff"},
       {MO_ADA_DATA_SYMBOL_ADDR, "systemz-ada-datasymboladdr"},

--- a/llvm/test/CodeGen/SystemZ/target-flags.ll
+++ b/llvm/test/CodeGen/SystemZ/target-flags.ll
@@ -1,0 +1,10 @@
+; RUN: llc -mtriple=s390x-linux-gnu -stop-after=systemz-isel --simplify-mir < %s | FileCheck %s
+
+@G = external global i64
+
+define i64 @fun() {
+entry:
+; CHECK:    %{{.*}}:addr64bit = LGRL target-flags(systemz-got) @G
+  %Res = load i64, ptr @G
+  ret i64 %Res
+}

--- a/llvm/test/CodeGen/SystemZ/target-flags.ll
+++ b/llvm/test/CodeGen/SystemZ/target-flags.ll
@@ -1,10 +1,14 @@
 ; RUN: llc -mtriple=s390x-linux-gnu -stop-after=systemz-isel --simplify-mir < %s | FileCheck %s
 
 @G = external global i64
-
-define i64 @fun() {
-entry:
+define i64 @fun0() {
 ; CHECK:    %{{.*}}:addr64bit = LGRL target-flags(systemz-got) @G
   %Res = load i64, ptr @G
   ret i64 %Res
+}
+
+@x = thread_local(initialexec) global i32 0
+define ptr@fun1() {
+; CHECK:    %{{.*}}:addr64bit = LARL target-flags(systemz-indntpoff) @x
+  ret ptr@x
 }


### PR DESCRIPTION
These strings are needed for MIR textual representation, if it is missing it doesn't work to do "-stop-before=XXX and then -start-before=XXX".

Unfortunately I found three strings missing, but could only find a case for one of them (the one I ran into).

