### PR TITLE
[lldb] Reject a zero child offset in the Mach-O export trie

### DIFF
--- a/lldb/source/Plugins/ObjectFile/Mach-O/MachOTrie.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/MachOTrie.cpp
@@ -121,13 +121,12 @@ bool ParseTrieEntriesImpl(DataExtractor &data, lldb::offset_t offset,
     const size_t prevSize = prefix.size();
     prefix.append(cstr);
     lldb::offset_t childNodeOffset = data.GetULEB128(&children_offset);
-    if (childNodeOffset) {
-      if (!ParseTrieEntriesImpl(data, childNodeOffset, is_arm,
-                                text_seg_base_addr, prefix, resolver_addresses,
-                                reexports, ext_symbols, visited_nodes)) {
-        return false;
-      }
-    }
+    // A child offset of 0 points back at the root; like any other repeated
+    // offset it is a cycle, which ParseTrieEntriesImpl rejects as corrupt.
+    if (!ParseTrieEntriesImpl(data, childNodeOffset, is_arm, text_seg_base_addr,
+                              prefix, resolver_addresses, reexports,
+                              ext_symbols, visited_nodes))
+      return false;
     prefix.resize(prevSize);
   }
   return true;

--- a/lldb/unittests/ObjectFile/MachO/MachOTrieTest.cpp
+++ b/lldb/unittests/ObjectFile/MachO/MachOTrieTest.cpp
@@ -410,17 +410,16 @@ TEST(MachOTrieTest, MixedExportsAndReexports) {
   EXPECT_EQ(result.reexports[0].entry.import_name.GetStringRef(), "baz");
 }
 
-TEST(MachOTrieTest, ChildOffsetZeroSkipped) {
-  // A child whose node offset is zero is not followed (zero is the root).
+TEST(MachOTrieTest, MalformedChildOffsetZero) {
+  // A child offset of 0 points back at the root, which is a cycle.
   std::vector<uint8_t> t;
   AppendULEB128(t, 0); // terminalSize
   t.push_back(1);      // childrenCount
   AppendCStr(t, "_foo");
-  AppendOffset(t, 0); // childNodeOffset 0 -> not recursed
+  AppendOffset(t, 0); // childNodeOffset 0 -> points back at the root
 
   ParseResult result = Parse(t);
-  EXPECT_TRUE(result.ok);
-  EXPECT_TRUE(result.ext_symbols.empty());
+  EXPECT_FALSE(result.ok);
 }
 
 TEST(MachOTrieTest, MalformedSelfCycle) {
@@ -512,7 +511,7 @@ TEST(MachOTrieTest, MalformedExcessChildrenCount) {
   AppendULEB128(t, 0); // terminalSize
   t.push_back(5);      // claims five children
   AppendCStr(t, "a");
-  AppendOffset(t, 0); // childNodeOffset 0 -> not recursed
+  AppendOffset(t, 1000); // first child offset, out of range and tolerated
   // ...but no data for the remaining four claimed children.
 
   ParseResult result = Parse(t);


### PR DESCRIPTION
A child node offset of 0 points back at the root. ParseTrieEntries silently skipped such a child because of a leftover guard from before the walk tracked visited nodes, letting a malformed trie parse as valid.

Drop the guard so the visited-node set rejects it as the cycle it is, matching how LLVM's MachO export-trie reader treats a child pointing at an already-visited node.