### PR TITLE
clang: Remove BoundArch assert in AMDGPUToolChain::addClangTargetOptions

### DIFF
--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -841,9 +841,6 @@ ROCMToolChain::ROCMToolChain(const Driver &D, const llvm::Triple &Triple,
 void AMDGPUToolChain::addClangTargetOptions(
     const llvm::opt::ArgList &DriverArgs, llvm::opt::ArgStringList &CC1Args,
     llvm::StringRef BoundArch, Action::OffloadKind DeviceOffloadingKind) const {
-  assert(DeviceOffloadingKind == Action::OFK_None && BoundArch.empty() &&
-         "this toolchain is for non-offloading cases");
-
   // Default to "hidden" visibility, as object level linking will not be
   // supported for the foreseeable future.
   // TODO: remove the SPIR-V bypass once it can encode (hidden) visibility.


### PR DESCRIPTION
This was assuming that the offload languages use a subclass, and
only OpenCL hits the AMDGPUToolChain base class. Flang violates this,
and passes in the wrong values. Delete the assert for now.