### PR TITLE
[docs] Remove myself from security response

### DIFF
--- a/llvm/docs/Security.rst
+++ b/llvm/docs/Security.rst
@@ -43,7 +43,6 @@ username for an individual isn't available, the brackets will be empty.
 * Dimitry Andric (individual; FreeBSD) [@DimitryAndric]
 * Ed Maste (individual; FreeBSD) [@emaste]
 * George Burgess IV (Google) [@gburgessiv]
-* Josh Stone (Red Hat; Rust) [@cuviper]
 * Kristof Beyls (ARM) [@kbeyls]
 * Mario Cupelli (HighTec EDV Systeme) [@mariocup]
 * Matthew Riley (Google) [@mmdriley]


### PR DESCRIPTION
I haven't really been active in this group, so I think it's best for me
to voluntarily leave. My affiliations are still covered by others, and
anyway I think cross-cutting issues (e.g. with Rust) should pull in
those orgs rather than relying on direct membership.
