### PR TITLE
[AMDGPU][NFC] Restore clamp modifiers in gfx11_asm_vop3_dpp16.s

### DIFF
--- a/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp16.s
+++ b/llvm/test/MC/AMDGPU/gfx11_asm_vop3_dpp16.s
@@ -7,36 +7,36 @@
 // RUN: not llvm-mc -triple=amdgcn -mcpu=gfx1100 -mattr=+wavefrontsize64,+real-true16 -filetype=null %s 2>&1 | FileCheck --check-prefixes=W64-ERR --implicit-check-not=error: %s
 
 //  INSTS=
-//      v_add3_u32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
+//      v_add3_u32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
 //      v_add_co_u32_e64_dpp <OPS-32-M64-32-32>
-//      v_add_lshl_u32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
+//      v_add_lshl_u32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
 //      v_add_nc_i16_e64_dpp <OPS-16-16-16>
 //      v_add_nc_i32_e64_dpp <OPS-32-32-32-XMOD-XMULDIV>
 //      v_add_nc_u16_e64_dpp <OPS-16-16-16>
 //      v_alignbit_b32_e64_dpp <OPS-32-32-32-16>
 //      v_alignbyte_b32_e64_dpp <OPS-32-32-32-16>
-//      v_and_b16_e64_dpp <OPS-16-16-16>
-//      v_and_or_b32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
-//      v_ashrrev_i16_e64_dpp <OPS-16-16-16>
-//      v_bcnt_u32_b32_e64_dpp <OPS-32-32-32-XMOD-XMULDIV>
-//      v_bfe_i32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
-//      v_bfe_u32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
-//      v_bfi_b32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
-//      v_bfm_b32_e64_dpp <OPS-32-32-32-XMOD-XMULDIV>
+//      v_and_b16_e64_dpp <OPS-16-16-16-XCLAMP>
+//      v_and_or_b32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
+//      v_ashrrev_i16_e64_dpp <OPS-16-16-16-XCLAMP>
+//      v_bcnt_u32_b32_e64_dpp <OPS-32-32-32-XMOD-XMULDIV-XCLAMP>
+//      v_bfe_i32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
+//      v_bfe_u32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
+//      v_bfi_b32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
+//      v_bfm_b32_e64_dpp <OPS-32-32-32-XMOD-XMULDIV-XCLAMP>
 //      v_cndmask_b16_e64_dpp <OPS-16-16-16-M64>
 //      v_cubeid_f32_e64_dpp <OPS-32-32-32-32>
 //      v_cubema_f32_e64_dpp <OPS-32-32-32-32>
 //      v_cubesc_f32_e64_dpp <OPS-32-32-32-32>
 //      v_cubetc_f32_e64_dpp <OPS-32-32-32-32>
-//      v_cvt_pk_i16_f32_e64_dpp <OPS-32-32-32-XMULDIV>
-//      v_cvt_pk_i16_i32_e64_dpp <OPS-32-32-32-XMOD-XMULDIV>
+//      v_cvt_pk_i16_f32_e64_dpp <OPS-32-32-32-XMULDIV-XCLAMP>
+//      v_cvt_pk_i16_i32_e64_dpp <OPS-32-32-32-XMOD-XMULDIV-XCLAMP>
 //      v_cvt_pk_norm_i16_f16_e64_dpp <OPS-32-16-16>
-//      v_cvt_pk_norm_i16_f32_e64_dpp <OPS-32-32-32-XMULDIV>
+//      v_cvt_pk_norm_i16_f32_e64_dpp <OPS-32-32-32-XMULDIV-XCLAMP>
 //      v_cvt_pk_norm_u16_f16_e64_dpp <OPS-32-16-16>
-//      v_cvt_pk_norm_u16_f32_e64_dpp <OPS-32-32-32-XMULDIV>
-//      v_cvt_pk_u16_f32_e64_dpp <OPS-32-32-32-XMULDIV>
-//      v_cvt_pk_u16_u32_e64_dpp <OPS-32-32-32-XMOD-XMULDIV>
-//      v_cvt_pk_u8_f32_e64_dpp <OPS-32-32-32-32-XMULDIV>
+//      v_cvt_pk_norm_u16_f32_e64_dpp <OPS-32-32-32-XMULDIV-XCLAMP>
+//      v_cvt_pk_u16_f32_e64_dpp <OPS-32-32-32-XMULDIV-XCLAMP>
+//      v_cvt_pk_u16_u32_e64_dpp <OPS-32-32-32-XMOD-XMULDIV-XCLAMP>
+//      v_cvt_pk_u8_f32_e64_dpp <OPS-32-32-32-32-XMULDIV-XCLAMP>
 //      v_div_fixup_f16_e64_dpp <OPS-16-16-16-16-XMULDIV>
 //      v_dot2_bf16_bf16_e64_dpp <OPS-16-32-32-16>
 //      v_dot2_f16_f16_e64_dpp <OPS-16-32-32-16>
@@ -45,11 +45,11 @@
 //      v_fma_f16_e64_dpp <OPS-16-16-16-16-XMULDIV>
 //      v_fma_f32_e64_dpp <OPS-32-32-32-32>
 //      v_ldexp_f32_e64_dpp <OPS-32-32-32>
-//      v_lerp_u8_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
-//      v_lshl_add_u32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
-//      v_lshl_or_b32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
-//      v_lshlrev_b16_e64_dpp <OPS-16-16-16>
-//      v_lshrrev_b16_e64_dpp <OPS-16-16-16>
+//      v_lerp_u8_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
+//      v_lshl_add_u32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
+//      v_lshl_or_b32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
+//      v_lshlrev_b16_e64_dpp <OPS-16-16-16-XCLAMP>
+//      v_lshrrev_b16_e64_dpp <OPS-16-16-16-XCLAMP>
 //      v_mad_i16_e64_dpp <OPS-16-16-16-16-XMOD-XMULDIV>
 //      v_mad_i32_i16_e64_dpp <OPS-32-16-16-32>
 //      v_mad_i32_i24_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
@@ -58,43 +58,43 @@
 //      v_mad_u32_u24_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
 //      v_max3_f16_e64_dpp <OPS-16-16-16-16>
 //      v_max3_f32_e64_dpp <OPS-32-32-32-32>
-//      v_max3_i16_e64_dpp <OPS-16-16-16-16-XMOD-XMULDIV>
-//      v_max3_i32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
-//      v_max3_u16_e64_dpp <OPS-16-16-16-16-XMOD-XMULDIV>
-//      v_max3_u32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
-//      v_max_i16_e64_dpp <OPS-16-16-16>
-//      v_max_u16_e64_dpp <OPS-16-16-16>
+//      v_max3_i16_e64_dpp <OPS-16-16-16-16-XMOD-XMULDIV-XCLAMP>
+//      v_max3_i32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
+//      v_max3_u16_e64_dpp <OPS-16-16-16-16-XMOD-XMULDIV-XCLAMP>
+//      v_max3_u32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
+//      v_max_i16_e64_dpp <OPS-16-16-16-XCLAMP>
+//      v_max_u16_e64_dpp <OPS-16-16-16-XCLAMP>
 //      v_maxmin_f16_e64_dpp <OPS-16-16-16-16>
 //      v_maxmin_f32_e64_dpp <OPS-32-32-32-32>
-//      v_maxmin_i32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
-//      v_maxmin_u32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
-//      v_mbcnt_hi_u32_b32_e64_dpp <OPS-32-32-32-XMOD-XMULDIV>
-//      v_mbcnt_lo_u32_b32_e64_dpp <OPS-32-32-32-XMOD-XMULDIV>
+//      v_maxmin_i32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
+//      v_maxmin_u32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
+//      v_mbcnt_hi_u32_b32_e64_dpp <OPS-32-32-32-XMOD-XMULDIV-XCLAMP>
+//      v_mbcnt_lo_u32_b32_e64_dpp <OPS-32-32-32-XMOD-XMULDIV-XCLAMP>
 //      v_med3_f16_e64_dpp <OPS-16-16-16-16>
 //      v_med3_f32_e64_dpp <OPS-32-32-32-32>
-//      v_med3_i16_e64_dpp <OPS-16-16-16-16-XMOD-XMULDIV>
-//      v_med3_i32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
-//      v_med3_u16_e64_dpp <OPS-16-16-16-16-XMOD-XMULDIV>
-//      v_med3_u32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
+//      v_med3_i16_e64_dpp <OPS-16-16-16-16-XMOD-XMULDIV-XCLAMP>
+//      v_med3_i32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
+//      v_med3_u16_e64_dpp <OPS-16-16-16-16-XMOD-XMULDIV-XCLAMP>
+//      v_med3_u32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
 //      v_min3_f16_e64_dpp <OPS-16-16-16-16>
 //      v_min3_f32_e64_dpp <OPS-32-32-32-32>
-//      v_min3_i16_e64_dpp <OPS-16-16-16-16-XMOD-XMULDIV>
-//      v_min3_i32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
+//      v_min3_i16_e64_dpp <OPS-16-16-16-16-XMOD-XMULDIV-XCLAMP>
+//      v_min3_i32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
 //      v_min3_u16_e64_dpp <OPS-16-16-16-16-XMOD-XMULDIV>
-//      v_min3_u32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
-//      v_min_i16_e64_dpp <OPS-16-16-16>
-//      v_min_u16_e64_dpp <OPS-16-16-16>
+//      v_min3_u32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
+//      v_min_i16_e64_dpp <OPS-16-16-16-XCLAMP>
+//      v_min_u16_e64_dpp <OPS-16-16-16-XCLAMP>
 //      v_minmax_f16_e64_dpp <OPS-16-16-16-16>
 //      v_minmax_f32_e64_dpp <OPS-32-32-32-32>
-//      v_minmax_i32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
-//      v_minmax_u32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
+//      v_minmax_i32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
+//      v_minmax_u32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
 //      v_msad_u8_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
-//      v_mul_lo_u16_e64_dpp <OPS-16-16-16>
+//      v_mul_lo_u16_e64_dpp <OPS-16-16-16-XCLAMP>
 //      v_mullit_f32_e64_dpp <OPS-32-32-32-32>
-//      v_or3_b32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
-//      v_or_b16_e64_dpp <OPS-16-16-16>
+//      v_or3_b32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
+//      v_or_b16_e64_dpp <OPS-16-16-16-XCLAMP>
 //      v_pack_b32_f16_e64_dpp <OPS-32-16-16>
-//      v_perm_b32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
+//      v_perm_b32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
 //      v_sad_hi_u8_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
 //      v_sad_u16_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
 //      v_sad_u32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
@@ -104,9 +104,9 @@
 //      v_sub_nc_i32_e64_dpp <OPS-32-32-32-XMOD-XMULDIV>
 //      v_sub_nc_u16_e64_dpp <OPS-16-16-16>
 //      v_subrev_co_u32_e64_dpp <OPS-32-M64-32-32>
-//      v_xad_u32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
-//      v_xor3_b32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV>
-//      v_xor_b16_e64_dpp <OPS-16-16-16>
+//      v_xad_u32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
+//      v_xor3_b32_e64_dpp <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
+//      v_xor_b16_e64_dpp <OPS-16-16-16-XCLAMP>
 //
 //  <SREG-M64>=
 //      s6
@@ -206,7 +206,7 @@
 //      row_mask:0x3 bank_mask:0x0
 //      row_mask:0xf bank_mask:0xf
 //
-//  <OPS-16-16-16>=
+//  <OPS-16-16-16-XCLAMP>=
 //      v5.l, v1.l, v2.l quad_perm:[3,2,1,0]
 //      v255.l, v255.l, v255.l quad_perm:[3,2,1,0]
 //      v5.l, v1.h, v2.l op_sel:[1,0,0] quad_perm:[3,2,1,0]
@@ -215,6 +215,10 @@
 //      v5.l, v1.l, v2.l <DPP>
 //      v5.l, v1.l, v2.l quad_perm:[3,2,1,0] <FI>
 //      v5.l, v1.l, v2.l quad_perm:[3,2,1,0] <ROWBANK>
+//
+//  <OPS-16-16-16>=
+//      <OPS-16-16-16-XCLAMP>
+//      v5.l, v1.l, v2.l clamp quad_perm:[3,2,1,0]
 //
 //  <OPS-16-16-16-16>=
 //      v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0]
@@ -230,8 +234,9 @@
 //      v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] <FI>
 //      v5.l, v1.l, v2.l, v3.l <MULDIV> quad_perm:[3,2,1,0]
 //      v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] <ROWBANK>
+//      v5.l, v1.l, v2.l, v3.l clamp quad_perm:[3,2,1,0]
 //
-//  <OPS-16-16-16-16-XMOD-XMULDIV>=
+//  <OPS-16-16-16-16-XMOD-XMULDIV-XCLAMP>=
 //      v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0]
 //      v255.l, v255.l, v255.l, v255.l quad_perm:[3,2,1,0]
 //      v5.l, v1.l, v2.l, <SRC16-XMOD> quad_perm:[3,2,1,0]
@@ -242,6 +247,10 @@
 //      v5.l, v1.l, v2.l, v3.l <DPP>
 //      v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] <FI>
 //      v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] <ROWBANK>
+//
+//  <OPS-16-16-16-16-XMOD-XMULDIV>=
+//      <OPS-16-16-16-16-XMOD-XMULDIV-XCLAMP>
+//      v5.l, v1.l, v2.l, v3.l clamp quad_perm:[3,2,1,0]
 //
 //  <OPS-16-16-16-16-XMULDIV>=
 //      v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0]
@@ -256,6 +265,7 @@
 //      v5.l, v1.l, v2.l, v3.l <DPP>
 //      v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] <FI>
 //      v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] <ROWBANK>
+//      v5.l, v1.l, v2.l, v3.l clamp quad_perm:[3,2,1,0]
 //
 //  <OPS-16-16-16-M64>=
 //      v5.l, v1.l, v2.l, s3 quad_perm:[3,2,1,0]
@@ -291,6 +301,7 @@
 //      v5, v1.l, v2.l <DPP>
 //      v5, v1.l, v2.l quad_perm:[3,2,1,0] <FI>
 //      v5, v1.l, v2.l quad_perm:[3,2,1,0] <ROWBANK>
+//      v5, v1.l, v2.l clamp quad_perm:[3,2,1,0]
 //
 //  <OPS-32-16-16-32>=
 //      v5, v1.l, v2.l, v3 quad_perm:[3,2,1,0]
@@ -302,6 +313,7 @@
 //      v5, v1.l, v2.l, v3 <DPP>
 //      v5, v1.l, v2.l, v3 quad_perm:[3,2,1,0] <FI>
 //      v5, v1.l, v2.l, v3 quad_perm:[3,2,1,0] <ROWBANK>
+//      v5, v1.l, v2.l, v3 clamp quad_perm:[3,2,1,0]
 //
 //  <OPS-32-32-32>=
 //      v5, v1, v2 quad_perm:[3,2,1,0]
@@ -312,6 +324,7 @@
 //      v5, v1, v2 quad_perm:[3,2,1,0] <FI>
 //      v5, v1, v2 <MULDIV> quad_perm:[3,2,1,0]
 //      v5, v1, v2 quad_perm:[3,2,1,0] <ROWBANK>
+//      v5, v1, v2 clamp quad_perm:[3,2,1,0]
 //
 //  <OPS-32-32-32-16>=
 //      v5, v1, v2, v3.l quad_perm:[3,2,1,0]
@@ -322,6 +335,7 @@
 //      v5, v1, v2, v3.l <DPP>
 //      v5, v1, v2, v3.l quad_perm:[3,2,1,0] <FI>
 //      v5, v1, v2, v3.l quad_perm:[3,2,1,0] <ROWBANK>
+//      v5, v1, v2, v3.l clamp quad_perm:[3,2,1,0]
 //
 //  <OPS-32-32-32-32>=
 //      v5, v1, v2, v3 quad_perm:[3,2,1,0]
@@ -334,8 +348,9 @@
 //      v5, v1, v2, v3 quad_perm:[3,2,1,0] <FI>
 //      v5, v1, v2, v3 <MULDIV> quad_perm:[3,2,1,0]
 //      v5, v1, v2, v3 quad_perm:[3,2,1,0] <ROWBANK>
+//      v5, v1, v2, v3 clamp quad_perm:[3,2,1,0]
 //
-//  <OPS-32-32-32-32-XMOD-XMULDIV>=
+//  <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>=
 //      v5, v1, v2, v3 quad_perm:[3,2,1,0]
 //      v255, v255, v255, v255 quad_perm:[3,2,1,0]
 //      v5, v1, v2, <SRC32-XMOD> quad_perm:[3,2,1,0]
@@ -344,7 +359,11 @@
 //      v5, v1, v2, v3 quad_perm:[3,2,1,0] <FI>
 //      v5, v1, v2, v3 quad_perm:[3,2,1,0] <ROWBANK>
 //
-//  <OPS-32-32-32-32-XMULDIV>=
+//  <OPS-32-32-32-32-XMOD-XMULDIV>=
+//      <OPS-32-32-32-32-XMOD-XMULDIV-XCLAMP>
+//      v5, v1, v2, v3 clamp quad_perm:[3,2,1,0]
+//
+//  <OPS-32-32-32-32-XMULDIV-XCLAMP>=
 //      v5, v1, v2, v3 quad_perm:[3,2,1,0]
 //      v255, v255, v255, v255 quad_perm:[3,2,1,0]
 //      v5, <SRC32-XIMM>, v2, v3 quad_perm:[3,2,1,0]
@@ -354,7 +373,7 @@
 //      v5, v1, v2, v3 quad_perm:[3,2,1,0] <FI>
 //      v5, v1, v2, v3 quad_perm:[3,2,1,0] <ROWBANK>
 //
-//  <OPS-32-32-32-XMOD-XMULDIV>=
+//  <OPS-32-32-32-XMOD-XMULDIV-XCLAMP>=
 //      v5, v1, v2 quad_perm:[3,2,1,0]
 //      v255, v255, v255 quad_perm:[3,2,1,0]
 //      v5, v1, v2 quad_perm:[3,2,1,0] <BOUND-CTRL>
@@ -362,7 +381,11 @@
 //      v5, v1, v2 quad_perm:[3,2,1,0] <FI>
 //      v5, v1, v2 quad_perm:[3,2,1,0] <ROWBANK>
 //
-//  <OPS-32-32-32-XMULDIV>=
+//  <OPS-32-32-32-XMOD-XMULDIV>=
+//      <OPS-32-32-32-XMOD-XMULDIV-XCLAMP>
+//      v5, v1, v2 clamp quad_perm:[3,2,1,0]
+//
+//  <OPS-32-32-32-XMULDIV-XCLAMP>=
 //      v5, v1, v2 quad_perm:[3,2,1,0]
 //      v255, v255, v255 quad_perm:[3,2,1,0]
 //      v5, <SRC32-XIMM>, v2 quad_perm:[3,2,1,0]
@@ -380,6 +403,7 @@
 //      v5, s6, v1, v2 <DPP>
 //      v5, s6, v1, v2 quad_perm:[3,2,1,0] <FI>
 //      v5, s6, v1, v2 quad_perm:[3,2,1,0] <ROWBANK>
+//      v5, s6, v1, v2 clamp quad_perm:[3,2,1,0]
 
 v_add3_u32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX11: v_add3_u32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x55,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
@@ -608,6 +632,10 @@ v_add_co_u32_e64_dpp v5, s6, v1, v2 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0
 // W32: v_add_co_u32_e64_dpp v5, s6, v1, v2 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x06,0x00,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
 // W64-ERR: :[[@LINE-2]]:26: error: invalid operand for instruction
 
+v_add_co_u32_e64_dpp v5, s6, v1, v2 clamp quad_perm:[3,2,1,0]
+// W32: v_add_co_u32_e64_dpp v5, s6, v1, v2 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x86,0x00,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
+// W64-ERR: :[[@LINE-2]]:26: error: invalid operand for instruction
+
 v_add_lshl_u32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX11: v_add_lshl_u32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x47,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
@@ -785,6 +813,9 @@ v_add_nc_i16_e64_dpp v5.l, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0x3 bank_mask
 v_add_nc_i16_e64_dpp v5.l, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_add_nc_i16_e64_dpp v5.l, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x0d,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
 
+v_add_nc_i16_e64_dpp v5.l, v1.l, v2.l clamp quad_perm:[3,2,1,0]
+// GFX11: v_add_nc_i16_e64_dpp v5.l, v1.l, v2.l clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x0d,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
+
 v_add_nc_i32_e64_dpp v5, v1, v2 quad_perm:[3,2,1,0]
 // GFX11: v_add_nc_i32_e64_dpp v5, v1, v2 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x26,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
 
@@ -850,6 +881,9 @@ v_add_nc_i32_e64_dpp v5, v1, v2 quad_perm:[3,2,1,0] row_mask:0x3 bank_mask:0x0
 
 v_add_nc_i32_e64_dpp v5, v1, v2 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_add_nc_i32_e64_dpp v5, v1, v2 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x26,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
+
+v_add_nc_i32_e64_dpp v5, v1, v2 clamp quad_perm:[3,2,1,0]
+// GFX11: v_add_nc_i32_e64_dpp v5, v1, v2 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x26,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
 
 v_add_nc_u16_e64_dpp v5.l, v1.l, v2.l quad_perm:[3,2,1,0]
 // GFX11: v_add_nc_u16_e64_dpp v5.l, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x03,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
@@ -922,6 +956,9 @@ v_add_nc_u16_e64_dpp v5.l, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0x3 bank_mask
 
 v_add_nc_u16_e64_dpp v5.l, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_add_nc_u16_e64_dpp v5.l, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x03,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
+
+v_add_nc_u16_e64_dpp v5.l, v1.l, v2.l clamp quad_perm:[3,2,1,0]
+// GFX11: v_add_nc_u16_e64_dpp v5.l, v1.l, v2.l clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x03,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
 
 v_alignbit_b32_e64_dpp v5, v1, v2, v3.l quad_perm:[3,2,1,0]
 // GFX11: v_alignbit_b32_e64_dpp v5, v1, v2, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x16,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
@@ -1037,6 +1074,9 @@ v_alignbit_b32_e64_dpp v5, v1, v2, v3.l quad_perm:[3,2,1,0] row_mask:0x3 bank_ma
 v_alignbit_b32_e64_dpp v5, v1, v2, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_alignbit_b32_e64_dpp v5, v1, v2, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x16,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
+v_alignbit_b32_e64_dpp v5, v1, v2, v3.l clamp quad_perm:[3,2,1,0]
+// GFX11: v_alignbit_b32_e64_dpp v5, v1, v2, v3.l clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x16,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
 v_alignbyte_b32_e64_dpp v5, v1, v2, v3.l quad_perm:[3,2,1,0]
 // GFX11: v_alignbyte_b32_e64_dpp v5, v1, v2, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x17,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
@@ -1150,6 +1190,9 @@ v_alignbyte_b32_e64_dpp v5, v1, v2, v3.l quad_perm:[3,2,1,0] row_mask:0x3 bank_m
 
 v_alignbyte_b32_e64_dpp v5, v1, v2, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_alignbyte_b32_e64_dpp v5, v1, v2, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x17,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
+v_alignbyte_b32_e64_dpp v5, v1, v2, v3.l clamp quad_perm:[3,2,1,0]
+// GFX11: v_alignbyte_b32_e64_dpp v5, v1, v2, v3.l clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x17,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
 v_and_b16_e64_dpp v5.l, v1.l, v2.l quad_perm:[3,2,1,0]
 // GFX11: v_and_b16_e64_dpp v5.l, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x62,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
@@ -2132,6 +2175,9 @@ v_cubeid_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0x3 bank_mask:0
 v_cubeid_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_cubeid_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x0c,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
+v_cubeid_f32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0]
+// GFX11: v_cubeid_f32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x0c,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
 v_cubema_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX11: v_cubema_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x0f,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
@@ -2266,6 +2312,9 @@ v_cubema_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0x3 bank_mask:0
 
 v_cubema_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_cubema_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x0f,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
+v_cubema_f32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0]
+// GFX11: v_cubema_f32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x0f,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
 v_cubesc_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX11: v_cubesc_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x0d,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
@@ -2402,6 +2451,9 @@ v_cubesc_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0x3 bank_mask:0
 v_cubesc_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_cubesc_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x0d,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
+v_cubesc_f32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0]
+// GFX11: v_cubesc_f32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x0d,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
 v_cubetc_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX11: v_cubetc_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x0e,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
@@ -2536,6 +2588,9 @@ v_cubetc_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0x3 bank_mask:0
 
 v_cubetc_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_cubetc_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x0e,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
+v_cubetc_f32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0]
+// GFX11: v_cubetc_f32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x0e,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
 v_cvt_pk_i16_f32_e64_dpp v5, v1, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cvt_pk_i16_f32_e64_dpp v5, v1, v2 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x06,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
@@ -2777,6 +2832,9 @@ v_cvt_pk_norm_i16_f16_e64_dpp v5, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0x3 ba
 v_cvt_pk_norm_i16_f16_e64_dpp v5, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_cvt_pk_norm_i16_f16_e64_dpp v5, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x12,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
 
+v_cvt_pk_norm_i16_f16_e64_dpp v5, v1.l, v2.l clamp quad_perm:[3,2,1,0]
+// GFX11: v_cvt_pk_norm_i16_f16_e64_dpp v5, v1.l, v2.l clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x12,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
+
 v_cvt_pk_norm_i16_f32_e64_dpp v5, v1, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cvt_pk_norm_i16_f32_e64_dpp v5, v1, v2 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x21,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
 
@@ -2950,6 +3008,9 @@ v_cvt_pk_norm_u16_f16_e64_dpp v5, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0x3 ba
 
 v_cvt_pk_norm_u16_f16_e64_dpp v5, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_cvt_pk_norm_u16_f16_e64_dpp v5, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x13,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
+
+v_cvt_pk_norm_u16_f16_e64_dpp v5, v1.l, v2.l clamp quad_perm:[3,2,1,0]
+// GFX11: v_cvt_pk_norm_u16_f16_e64_dpp v5, v1.l, v2.l clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x13,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
 
 v_cvt_pk_norm_u16_f32_e64_dpp v5, v1, v2 quad_perm:[3,2,1,0]
 // GFX11: v_cvt_pk_norm_u16_f32_e64_dpp v5, v1, v2 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x22,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
@@ -3440,6 +3501,9 @@ v_div_fixup_f16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0x3 
 v_div_fixup_f16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_div_fixup_f16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x54,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
+v_div_fixup_f16_e64_dpp v5.l, v1.l, v2.l, v3.l clamp quad_perm:[3,2,1,0]
+// GFX11: v_div_fixup_f16_e64_dpp v5.l, v1.l, v2.l, v3.l clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x54,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
 v_dot2_bf16_bf16_e64_dpp v0.l, v1, v2, v3.l quad_perm:[0,1,2,3]
 // GFX11: v_dot2_bf16_bf16_e64_dpp v0.l, v1, v2, v3.l quad_perm:[0,1,2,3] row_mask:0xf bank_mask:0xf ; encoding: [0x00,0x00,0x67,0xd6,0xfa,0x04,0x0e,0x04,0x01,0xe4,0x00,0xff]
 
@@ -3902,6 +3966,9 @@ v_fma_f16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0x3 bank_m
 v_fma_f16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_fma_f16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x48,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
+v_fma_f16_e64_dpp v5.l, v1.l, v2.l, v3.l clamp quad_perm:[3,2,1,0]
+// GFX11: v_fma_f16_e64_dpp v5.l, v1.l, v2.l, v3.l clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x48,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
 v_fma_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX11: v_fma_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x13,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
@@ -4037,6 +4104,9 @@ v_fma_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0x3 bank_mask:0x0
 v_fma_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_fma_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x13,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
+v_fma_f32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0]
+// GFX11: v_fma_f32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x13,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
 v_ldexp_f32_e64_dpp v5, v1, v2 quad_perm:[3,2,1,0]
 // GFX11: v_ldexp_f32_e64_dpp v5, v1, v2 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x1c,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
 
@@ -4120,6 +4190,9 @@ v_ldexp_f32_e64_dpp v5, v1, v2 quad_perm:[3,2,1,0] row_mask:0x3 bank_mask:0x0
 
 v_ldexp_f32_e64_dpp v5, v1, v2 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_ldexp_f32_e64_dpp v5, v1, v2 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x1c,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
+
+v_ldexp_f32_e64_dpp v5, v1, v2 clamp quad_perm:[3,2,1,0]
+// GFX11: v_ldexp_f32_e64_dpp v5, v1, v2 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x1c,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
 
 v_lerp_u8_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX11: v_lerp_u8_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x15,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
@@ -4700,6 +4773,9 @@ v_mad_i16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0x3 bank_m
 v_mad_i16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_mad_i16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x53,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
+v_mad_i16_e64_dpp v5.l, v1.l, v2.l, v3.l clamp quad_perm:[3,2,1,0]
+// GFX11: v_mad_i16_e64_dpp v5.l, v1.l, v2.l, v3.l clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x53,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
 v_mad_i32_i16_e64_dpp v5, v1.l, v2.l, v3 quad_perm:[3,2,1,0]
 // GFX11: v_mad_i32_i16_e64_dpp v5, v1.l, v2.l, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x5a,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
@@ -4811,6 +4887,9 @@ v_mad_i32_i16_e64_dpp v5, v1.l, v2.l, v3 quad_perm:[3,2,1,0] row_mask:0x3 bank_m
 v_mad_i32_i16_e64_dpp v5, v1.l, v2.l, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_mad_i32_i16_e64_dpp v5, v1.l, v2.l, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x5a,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
+v_mad_i32_i16_e64_dpp v5, v1.l, v2.l, v3 clamp quad_perm:[3,2,1,0]
+// GFX11: v_mad_i32_i16_e64_dpp v5, v1.l, v2.l, v3 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x5a,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
 v_mad_i32_i24_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX11: v_mad_i32_i24_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x0a,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
@@ -4915,6 +4994,9 @@ v_mad_i32_i24_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0x3 bank_mask:
 
 v_mad_i32_i24_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_mad_i32_i24_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x0a,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
+v_mad_i32_i24_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0]
+// GFX11: v_mad_i32_i24_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x0a,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
 v_mad_u16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0]
 // GFX11: v_mad_u16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x41,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
@@ -5036,6 +5118,9 @@ v_mad_u16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0x3 bank_m
 v_mad_u16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_mad_u16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x41,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
+v_mad_u16_e64_dpp v5.l, v1.l, v2.l, v3.l clamp quad_perm:[3,2,1,0]
+// GFX11: v_mad_u16_e64_dpp v5.l, v1.l, v2.l, v3.l clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x41,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
 v_mad_u32_u16_e64_dpp v5, v1.l, v2.l, v3 quad_perm:[3,2,1,0]
 // GFX11: v_mad_u32_u16_e64_dpp v5, v1.l, v2.l, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x59,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
@@ -5147,6 +5232,9 @@ v_mad_u32_u16_e64_dpp v5, v1.l, v2.l, v3 quad_perm:[3,2,1,0] row_mask:0x3 bank_m
 v_mad_u32_u16_e64_dpp v5, v1.l, v2.l, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_mad_u32_u16_e64_dpp v5, v1.l, v2.l, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x59,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
+v_mad_u32_u16_e64_dpp v5, v1.l, v2.l, v3 clamp quad_perm:[3,2,1,0]
+// GFX11: v_mad_u32_u16_e64_dpp v5, v1.l, v2.l, v3 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x59,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
 v_mad_u32_u24_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX11: v_mad_u32_u24_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x0b,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
@@ -5251,6 +5339,9 @@ v_mad_u32_u24_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0x3 bank_mask:
 
 v_mad_u32_u24_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_mad_u32_u24_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x0b,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
+v_mad_u32_u24_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0]
+// GFX11: v_mad_u32_u24_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x0b,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
 v_max3_f16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0]
 // GFX11: v_max3_f16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x4c,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
@@ -5402,6 +5493,9 @@ v_max3_f16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0x3 bank_
 v_max3_f16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_max3_f16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x4c,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
+v_max3_f16_e64_dpp v5.l, v1.l, v2.l, v3.l clamp quad_perm:[3,2,1,0]
+// GFX11: v_max3_f16_e64_dpp v5.l, v1.l, v2.l, v3.l clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x4c,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
 v_max3_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX11: v_max3_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x1c,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
@@ -5536,6 +5630,9 @@ v_max3_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0x3 bank_mask:0x0
 
 v_max3_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_max3_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x1c,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
+v_max3_f32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0]
+// GFX11: v_max3_f32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x1c,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
 v_max3_i16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0]
 // GFX11: v_max3_i16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x4d,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
@@ -6281,6 +6378,9 @@ v_maxmin_f16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0x3 ban
 v_maxmin_f16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_maxmin_f16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x60,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
+v_maxmin_f16_e64_dpp v5.l, v1.l, v2.l, v3.l clamp quad_perm:[3,2,1,0]
+// GFX11: v_maxmin_f16_e64_dpp v5.l, v1.l, v2.l, v3.l clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x60,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
 v_maxmin_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX11: v_maxmin_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x5e,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
@@ -6415,6 +6515,9 @@ v_maxmin_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0x3 bank_mask:0
 
 v_maxmin_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_maxmin_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x5e,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
+v_maxmin_f32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0]
+// GFX11: v_maxmin_f32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x5e,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
 v_maxmin_i32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX11: v_maxmin_i32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x64,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
@@ -6908,6 +7011,9 @@ v_med3_f16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0x3 bank_
 v_med3_f16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_med3_f16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x4f,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
+v_med3_f16_e64_dpp v5.l, v1.l, v2.l, v3.l clamp quad_perm:[3,2,1,0]
+// GFX11: v_med3_f16_e64_dpp v5.l, v1.l, v2.l, v3.l clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x4f,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
 v_med3_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX11: v_med3_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x1f,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
@@ -7042,6 +7148,9 @@ v_med3_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0x3 bank_mask:0x0
 
 v_med3_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_med3_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x1f,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
+v_med3_f32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0]
+// GFX11: v_med3_f32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x1f,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
 v_med3_i16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0]
 // GFX11: v_med3_i16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x50,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
@@ -7643,6 +7752,9 @@ v_min3_f16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0x3 bank_
 v_min3_f16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_min3_f16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x49,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
+v_min3_f16_e64_dpp v5.l, v1.l, v2.l, v3.l clamp quad_perm:[3,2,1,0]
+// GFX11: v_min3_f16_e64_dpp v5.l, v1.l, v2.l, v3.l clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x49,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
 v_min3_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX11: v_min3_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x19,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
@@ -7777,6 +7889,9 @@ v_min3_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0x3 bank_mask:0x0
 
 v_min3_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_min3_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x19,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
+v_min3_f32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0]
+// GFX11: v_min3_f32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x19,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
 v_min3_i16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0]
 // GFX11: v_min3_i16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x4a,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
@@ -8122,6 +8237,9 @@ v_min3_u16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0x3 bank_
 
 v_min3_u16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_min3_u16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x4b,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
+v_min3_u16_e64_dpp v5.l, v1.l, v2.l, v3.l clamp quad_perm:[3,2,1,0]
+// GFX11: v_min3_u16_e64_dpp v5.l, v1.l, v2.l, v3.l clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x4b,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
 v_min3_u32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX11: v_min3_u32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x1b,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
@@ -8522,6 +8640,9 @@ v_minmax_f16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0x3 ban
 v_minmax_f16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_minmax_f16_e64_dpp v5.l, v1.l, v2.l, v3.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x61,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
+v_minmax_f16_e64_dpp v5.l, v1.l, v2.l, v3.l clamp quad_perm:[3,2,1,0]
+// GFX11: v_minmax_f16_e64_dpp v5.l, v1.l, v2.l, v3.l clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x61,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
 v_minmax_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX11: v_minmax_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x5f,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
@@ -8656,6 +8777,9 @@ v_minmax_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0x3 bank_mask:0
 
 v_minmax_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_minmax_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x5f,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
+v_minmax_f32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0]
+// GFX11: v_minmax_f32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x5f,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
 v_minmax_i32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX11: v_minmax_i32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x65,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
@@ -8972,6 +9096,9 @@ v_msad_u8_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0x3 bank_mask:0x0
 v_msad_u8_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_msad_u8_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x39,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
+v_msad_u8_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0]
+// GFX11: v_msad_u8_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x39,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
 v_mul_lo_u16_e64_dpp v5.l, v1.l, v2.l quad_perm:[3,2,1,0]
 // GFX11: v_mul_lo_u16_e64_dpp v5.l, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x05,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
 
@@ -9178,6 +9305,9 @@ v_mullit_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0x3 bank_mask:0
 
 v_mullit_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_mullit_f32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x18,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
+v_mullit_f32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0]
+// GFX11: v_mullit_f32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x18,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
 v_or3_b32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX11: v_or3_b32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x58,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
@@ -9446,6 +9576,9 @@ v_pack_b32_f16_e64_dpp v5, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0x3 bank_mask
 v_pack_b32_f16_e64_dpp v5, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_pack_b32_f16_e64_dpp v5, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x11,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
 
+v_pack_b32_f16_e64_dpp v5, v1.l, v2.l clamp quad_perm:[3,2,1,0]
+// GFX11: v_pack_b32_f16_e64_dpp v5, v1.l, v2.l clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x11,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
+
 v_perm_b32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX11: v_perm_b32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x44,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
@@ -9656,6 +9789,9 @@ v_sad_hi_u8_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0x3 bank_mask:0x
 v_sad_hi_u8_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_sad_hi_u8_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x23,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
+v_sad_hi_u8_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0]
+// GFX11: v_sad_hi_u8_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x23,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
 v_sad_u16_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX11: v_sad_u16_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x24,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
@@ -9760,6 +9896,9 @@ v_sad_u16_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0x3 bank_mask:0x0
 
 v_sad_u16_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_sad_u16_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x24,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
+v_sad_u16_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0]
+// GFX11: v_sad_u16_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x24,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
 v_sad_u32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX11: v_sad_u32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x25,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
@@ -9866,6 +10005,9 @@ v_sad_u32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0x3 bank_mask:0x0
 v_sad_u32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_sad_u32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x25,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
+v_sad_u32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0]
+// GFX11: v_sad_u32_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x25,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
 v_sad_u8_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]
 // GFX11: v_sad_u8_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x22,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
@@ -9970,6 +10112,9 @@ v_sad_u8_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0x3 bank_mask:0x0
 
 v_sad_u8_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_sad_u8_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x22,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
+
+v_sad_u8_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0]
+// GFX11: v_sad_u8_e64_dpp v5, v1, v2, v3 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x22,0xd6,0xfa,0x04,0x0e,0x04,0x01,0x1b,0x00,0xff]
 
 v_sub_co_u32_e64_dpp v5, s6, v1, v2 quad_perm:[3,2,1,0]
 // W32: v_sub_co_u32_e64_dpp v5, s6, v1, v2 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x06,0x01,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
@@ -10093,6 +10238,10 @@ v_sub_co_u32_e64_dpp v5, s6, v1, v2 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0
 // W32: v_sub_co_u32_e64_dpp v5, s6, v1, v2 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x06,0x01,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
 // W64-ERR: :[[@LINE-2]]:26: error: invalid operand for instruction
 
+v_sub_co_u32_e64_dpp v5, s6, v1, v2 clamp quad_perm:[3,2,1,0]
+// W32: v_sub_co_u32_e64_dpp v5, s6, v1, v2 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x86,0x01,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
+// W64-ERR: :[[@LINE-2]]:26: error: invalid operand for instruction
+
 v_sub_nc_i16_e64_dpp v5.l, v1.l, v2.l quad_perm:[3,2,1,0]
 // GFX11: v_sub_nc_i16_e64_dpp v5.l, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x0e,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
 
@@ -10165,6 +10314,9 @@ v_sub_nc_i16_e64_dpp v5.l, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0x3 bank_mask
 v_sub_nc_i16_e64_dpp v5.l, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_sub_nc_i16_e64_dpp v5.l, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x0e,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
 
+v_sub_nc_i16_e64_dpp v5.l, v1.l, v2.l clamp quad_perm:[3,2,1,0]
+// GFX11: v_sub_nc_i16_e64_dpp v5.l, v1.l, v2.l clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x0e,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
+
 v_sub_nc_i32_e64_dpp v5, v1, v2 quad_perm:[3,2,1,0]
 // GFX11: v_sub_nc_i32_e64_dpp v5, v1, v2 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x25,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
 
@@ -10230,6 +10382,9 @@ v_sub_nc_i32_e64_dpp v5, v1, v2 quad_perm:[3,2,1,0] row_mask:0x3 bank_mask:0x0
 
 v_sub_nc_i32_e64_dpp v5, v1, v2 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_sub_nc_i32_e64_dpp v5, v1, v2 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x25,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
+
+v_sub_nc_i32_e64_dpp v5, v1, v2 clamp quad_perm:[3,2,1,0]
+// GFX11: v_sub_nc_i32_e64_dpp v5, v1, v2 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x25,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
 
 v_sub_nc_u16_e64_dpp v5.l, v1.l, v2.l quad_perm:[3,2,1,0]
 // GFX11: v_sub_nc_u16_e64_dpp v5.l, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x04,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
@@ -10302,6 +10457,9 @@ v_sub_nc_u16_e64_dpp v5.l, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0x3 bank_mask
 
 v_sub_nc_u16_e64_dpp v5.l, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // GFX11: v_sub_nc_u16_e64_dpp v5.l, v1.l, v2.l quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x00,0x04,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
+
+v_sub_nc_u16_e64_dpp v5.l, v1.l, v2.l clamp quad_perm:[3,2,1,0]
+// GFX11: v_sub_nc_u16_e64_dpp v5.l, v1.l, v2.l clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x80,0x04,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
 
 v_subrev_co_u32_e64_dpp v5, s6, v1, v2 quad_perm:[3,2,1,0]
 // W32: v_subrev_co_u32_e64_dpp v5, s6, v1, v2 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x06,0x02,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
@@ -10423,6 +10581,10 @@ v_subrev_co_u32_e64_dpp v5, s6, v1, v2 quad_perm:[3,2,1,0] row_mask:0x3 bank_mas
 
 v_subrev_co_u32_e64_dpp v5, s6, v1, v2 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf
 // W32: v_subrev_co_u32_e64_dpp v5, s6, v1, v2 quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x06,0x02,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
+// W64-ERR: :[[@LINE-2]]:29: error: invalid operand for instruction
+
+v_subrev_co_u32_e64_dpp v5, s6, v1, v2 clamp quad_perm:[3,2,1,0]
+// W32: v_subrev_co_u32_e64_dpp v5, s6, v1, v2 clamp quad_perm:[3,2,1,0] row_mask:0xf bank_mask:0xf ; encoding: [0x05,0x86,0x02,0xd7,0xfa,0x04,0x02,0x00,0x01,0x1b,0x00,0xff]
 // W64-ERR: :[[@LINE-2]]:29: error: invalid operand for instruction
 
 v_xad_u32_e64_dpp v5, v1, v2, v3 quad_perm:[3,2,1,0]


### PR DESCRIPTION
Were dropped by mistake in https://github.com/llvm/llvm-project/pull/202721.