### PR TITLE
[flang][cuda] Fix host loads from CUDA constant globals

### DIFF
--- a/flang/lib/Optimizer/Transforms/CUDA/CUFOpConversion.cpp
+++ b/flang/lib/Optimizer/Transforms/CUDA/CUFOpConversion.cpp
@@ -72,6 +72,8 @@ static mlir::Value createConvertOp(mlir::PatternRewriter &rewriter,
   return val;
 }
 
+// Scalar CUDA constants have a host-visible global for host reads/writes and a
+// device constant symbol for kernels.
 static bool isScalarCudaConstantGlobal(fir::GlobalOp global) {
   return global && global.getDataAttr() &&
          *global.getDataAttr() == cuf::DataAttribute::Constant &&
@@ -288,6 +290,8 @@ struct CUFDataTransferOpConversion
 
       mlir::Value dst = op.getDst();
       mlir::Value src = op.getSrc();
+      // Host assignments to scalar CUDA constants update both the host-visible
+      // global and the device constant symbol.
       auto getAddrOf = [](mlir::Value val) -> fir::AddrOfOp {
         if (auto declareOp = val.getDefiningOp<fir::DeclareOp>())
           return declareOp.getMemref().getDefiningOp<fir::AddrOfOp>();

--- a/flang/lib/Optimizer/Transforms/CUDA/CUFOpConversion.cpp
+++ b/flang/lib/Optimizer/Transforms/CUDA/CUFOpConversion.cpp
@@ -72,6 +72,12 @@ static mlir::Value createConvertOp(mlir::PatternRewriter &rewriter,
   return val;
 }
 
+static bool isScalarCudaConstantGlobal(fir::GlobalOp global) {
+  return global && global.getDataAttr() &&
+         *global.getDataAttr() == cuf::DataAttribute::Constant &&
+         fir::isa_trivial(fir::unwrapRefType(global.getType()));
+}
+
 struct DeclareOpConversion : public mlir::OpRewritePattern<fir::DeclareOp> {
   using OpRewritePattern::OpRewritePattern;
 
@@ -90,6 +96,8 @@ struct DeclareOpConversion : public mlir::OpRewritePattern<fir::DeclareOp> {
       }
       if (auto global = symTab.lookup<fir::GlobalOp>(
               addrOfOp.getSymbol().getRootReference().getValue())) {
+        if (isScalarCudaConstantGlobal(global))
+          return failure();
         if (cuf::isRegisteredDeviceGlobal(global)) {
           rewriter.setInsertionPointAfter(addrOfOp);
           mlir::Value devAddr = cuf::DeviceAddressOp::create(
@@ -280,6 +288,28 @@ struct CUFDataTransferOpConversion
 
       mlir::Value dst = op.getDst();
       mlir::Value src = op.getSrc();
+      auto getAddrOf = [](mlir::Value val) -> fir::AddrOfOp {
+        if (auto declareOp = val.getDefiningOp<fir::DeclareOp>())
+          return declareOp.getMemref().getDefiningOp<fir::AddrOfOp>();
+        if (auto declareOp = val.getDefiningOp<hlfir::DeclareOp>())
+          return declareOp.getMemref().getDefiningOp<fir::AddrOfOp>();
+        return {};
+      };
+      if (op.getTransferKind() == cuf::DataTransferKind::HostDevice) {
+        if (fir::AddrOfOp addrOfOp = getAddrOf(dst)) {
+          auto global = symtab.lookup<fir::GlobalOp>(
+              addrOfOp.getSymbol().getRootReference().getValue());
+          if (isScalarCudaConstantGlobal(global)) {
+            mlir::Value hostValue = src;
+            if (fir::isa_ref_type(src.getType()))
+              hostValue = fir::LoadOp::create(builder, loc, src);
+            hostValue = createConvertOp(rewriter, loc, dstTy, hostValue);
+            fir::StoreOp::create(builder, loc, hostValue, addrOfOp);
+            dst = cuf::DeviceAddressOp::create(rewriter, loc, dst.getType(),
+                                               addrOfOp.getSymbol());
+          }
+        }
+      }
       // Materialize the src if constant.
       if (matchPattern(src.getDefiningOp(), mlir::m_Constant())) {
         mlir::Value temp = builder.createTemporary(loc, srcTy);
@@ -534,6 +564,8 @@ public:
         if (auto global = symtab.lookup<fir::GlobalOp>(
                 addrOfOp.getSymbol().getRootReference().getValue())) {
           if (mlir::isa<fir::BaseBoxType>(fir::unwrapRefType(global.getType())))
+            return true;
+          if (isScalarCudaConstantGlobal(global))
             return true;
           if (cuf::isRegisteredDeviceGlobal(global))
             return false;

--- a/flang/lib/Optimizer/Transforms/CUDA/CUFOpConversion.cpp
+++ b/flang/lib/Optimizer/Transforms/CUDA/CUFOpConversion.cpp
@@ -72,8 +72,8 @@ static mlir::Value createConvertOp(mlir::PatternRewriter &rewriter,
   return val;
 }
 
-// Scalar CUDA constants have a host-visible global for host reads/writes and a
-// device constant symbol for kernels.
+// Scalar CUDA constants use separate host-visible and device constant globals.
+// Host-to-device assignments keep them in sync.
 static bool isScalarCudaConstantGlobal(fir::GlobalOp global) {
   return global && global.getDataAttr() &&
          *global.getDataAttr() == cuf::DataAttribute::Constant &&

--- a/flang/test/Fir/CUDA/cuda-global-addr.mlir
+++ b/flang/test/Fir/CUDA/cuda-global-addr.mlir
@@ -137,3 +137,28 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<f80, dense<128> :
 // CHECK-LABEL:  func.func @_QQmain()
 // CHECK: fir.address_of(@_QMcon2Ezzz) : !fir.ref<i32>
 // CHECK-NOT: fir.call {{.*}}GetDeviceAddress
+
+// -----
+
+module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<f80, dense<128> : vector<2xi64>>, #dlti.dl_entry<i128, dense<128> : vector<2xi64>>, #dlti.dl_entry<i64, dense<64> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr<272>, dense<64> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<271>, dense<32> : vector<4xi64>>, #dlti.dl_entry<!llvm.ptr<270>, dense<32> : vector<4xi64>>, #dlti.dl_entry<f128, dense<128> : vector<2xi64>>, #dlti.dl_entry<f64, dense<64> : vector<2xi64>>, #dlti.dl_entry<f16, dense<16> : vector<2xi64>>, #dlti.dl_entry<i32, dense<32> : vector<2xi64>>, #dlti.dl_entry<i16, dense<16> : vector<2xi64>>, #dlti.dl_entry<i8, dense<8> : vector<2xi64>>, #dlti.dl_entry<i1, dense<8> : vector<2xi64>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi64>>, #dlti.dl_entry<"dlti.endianness", "little">, #dlti.dl_entry<"dlti.stack_alignment", 128 : i64>>} {
+  func.func @_QQconstant_scalar_host_load() attributes {fir.bindc_name = "T"} {
+    %c32_i32 = arith.constant 32 : i32
+    %0 = fir.address_of(@_QMcon3Ezzz) : !fir.ref<i32>
+    %1 = fir.declare %0 {data_attr = #cuf.cuda<constant>, uniq_name = "_QMcon3Ezzz"} : (!fir.ref<i32>) -> !fir.ref<i32>
+    %2 = fir.load %1 : !fir.ref<i32>
+    %3 = fir.convert %2 : (i32) -> index
+    cuf.data_transfer %c32_i32 to %1 {transfer_kind = #cuf.cuda_transfer<host_device>} : i32, !fir.ref<i32>
+    fir.call @_QPuse_index(%3) : (index) -> ()
+    return
+  }
+  func.func private @_QPuse_index(index)
+  fir.global @_QMcon3Ezzz {data_attr = #cuf.cuda<constant>} : i32
+}
+
+// CHECK-LABEL: func.func @_QQconstant_scalar_host_load()
+// CHECK: %[[ADDR:.*]] = fir.address_of(@_QMcon3Ezzz) : !fir.ref<i32>
+// CHECK: %[[DECL:.*]] = fir.declare %[[ADDR]] {data_attr = #cuf.cuda<constant>, uniq_name = "_QMcon3Ezzz"} : (!fir.ref<i32>) -> !fir.ref<i32>
+// CHECK: fir.load %[[DECL]] : !fir.ref<i32>
+// CHECK: fir.store %{{.*}} to %[[ADDR]] : !fir.ref<i32>
+// CHECK: fir.call @_FortranACUFGetDeviceAddress
+// CHECK-NOT: fir.load %{{.*}} : !fir.ref<i32>


### PR DESCRIPTION
This fixes CUDA Fortran lowering for scalar module variables with the constant attribute that are read from host code, such as launch configuration expressions or CUF kernel loop bounds.

Previously, host-side declarations for these globals could be rewritten to device constant-memory addresses, causing host loads to dereference the result of _FortranACUFGetDeviceAddress. The fix preserves host reads from the host-visible global while still using the device address for host-to-device assignment updates.

A FIR regression test covers host reads and assignment updates for scalar CUDA constant globals.