### PR TITLE
[clang][lit] set spirv-tools feature when tools are available

### DIFF
--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -285,6 +285,10 @@ if config.clang_enable_cir:
 if lit.util.which("spirv-val", config.llvm_tools_dir):
     config.available_features.add("spirv-val")
 
+# SPIRV-Tools availability (e.g. built with -DLLVM_INCLUDE_SPIRV_TOOLS_TESTS)
+if config.spirv_tools_tests:
+    config.available_features.add("spirv-tools")
+
 llvm_config.add_tool_substitutions(tools, tool_dirs)
 
 config.substitutions.append(


### PR DESCRIPTION
When the spirv tools are available (e.g. built with -DLLVM_INCLUDE_SPIRV_TOOLS_TESTS) register the spirv-tools lit feature in clang/test/lit.cfg.py.
This can then be used to skip tests that are not applicable when these tools are available.

Fixes: #203049