### PR TITLE
[lldb/test] Skip TestBranchIslands on remote targets

### DIFF
--- a/lldb/test/API/macosx/branch-islands/TestBranchIslands.py
+++ b/lldb/test/API/macosx/branch-islands/TestBranchIslands.py
@@ -13,6 +13,7 @@ class TestBranchIslandStepping(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @skipUnlessAppleSilicon
+    @skipIfRemote
     def test_step_in_branch_island(self):
         """Make sure we can step in across a branch island"""
         self.build()


### PR DESCRIPTION
The test builds four 120 MB padding object files and links them into a.out specifically to force the linker to emit an arm64 branch island between main() and foo(). On a remote target the resulting ~480 MB binary has to be uploaded byte-by-byte over gdb-remote vFile:write, which on its own consumes the bulk of the lit timeout budget before any debugging work happens; the test then times out at 600s.

The test verifies a host-toolchain artifact (the linker's branch island generation), not anything about the runtime; running it on-device adds nothing. Skip on remote.