### PR TITLE
[lldb/test] Skip TestCancelAttach on remote targets

### DIFF
--- a/lldb/test/API/python_api/process/cancel_attach/TestCancelAttach.py
+++ b/lldb/test/API/python_api/process/cancel_attach/TestCancelAttach.py
@@ -14,8 +14,8 @@ import lldbsuite.test.lldbutil
 class AttachCancelTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipIfRemote
     @skipIf(
-        remote=True,
         hostoslist=["windows", "linux"],
         bugnumber="https://github.com/llvm/llvm-project/issues/115618",
     )


### PR DESCRIPTION
The existing decorator AND-combined three conditions:
```
  @skipIf(remote=True, hostoslist=["windows", "linux"], bugnumber=...)
 ```
which only skipped when the test was running remotely AND the host was windows or linux. On a remote-darwin run from a Mac host the host condition is false, so the AND is false, and the test runs.

The waitfor-attach cancel path doesn't reliably interrupt a wait forwarded on a remote target, so SendAsyncInterrupt() doesn't unblock the attach thread on the host; the attempt then hangs to the lit timeout (600s) instead of completing the assertion.

Split the decorator into two: @skipIfRemote unconditionally, plus the existing @skipIf(hostoslist=["windows", "linux"]) for the original windows/linux issue. Both apply independently.