### PR TITLE
[lldb/test] Skip TestPlatformProcessLaunch on remote-darwin targets

### DIFF
--- a/lldb/test/API/commands/platform/process/launch/TestPlatformProcessLaunch.py
+++ b/lldb/test/API/commands/platform/process/launch/TestPlatformProcessLaunch.py
@@ -3,10 +3,12 @@ Test platform process launch.
 """
 
 from textwrap import dedent
-from lldbsuite.test import lldbutil
+from lldbsuite.test import lldbplatformutil, lldbutil
+from lldbsuite.test.decorators import skipIf
 from lldbsuite.test.lldbtest import TestBase
 
 
+@skipIf(remote=True, oslist=lldbplatformutil.getDarwinOSTriples())
 class ProcessLaunchTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 


### PR DESCRIPTION
The test exercises `platform process launch` to spawn an inferior under debugserver and read back its stdout. On a real remote-darwin target (e.g. iOS / tvOS / watchOS / visionOS device) debugserver-as-launcher needs entitlements / paths that platform-mode doesn't provide, so the launch itself doesn't succeed cleanly and the test fails before the read-back assertion is reached.

A previous fix (1a25b723628e, "Fixed the test TestPlatformProcessLaunch running on a remote target") plumbed the read-back path through remote_platform.Get, but it didn't address the launch side; the launch still fails with permission/path errors on a real device. The test asserts host-side `platform process launch` plumbing and adds nothing when run on a real remote-darwin target.

Skip on remote-darwin only -- remote-linux / remote-windows runs may still succeed since they don't have the same entitlement requirement.