### PR TITLE
[flang][semantics] Clean up -frelaxed-c-loc-checks warning flag handling

### DIFF
--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -567,6 +567,8 @@ end program
   unexpected behavior. This is for compatibility with
   legacy code; legacy code should be updated to be correct.
   This could be removed at any time.
+  Use `-Wrelaxed-c-loc-checks` (alongside `-frelaxed-c-loc-checks`) to
+  enable a diagnostic warning for affected call sites.
   [-frelaxed-c-loc-checks]
 
 ### Extensions and legacy features deliberately not supported

--- a/flang/include/flang/Support/Fortran-features.h
+++ b/flang/include/flang/Support/Fortran-features.h
@@ -59,7 +59,7 @@ ENUM_CLASS(LanguageFeature, BackslashEscapes, OldDebugLines,
     PointerPassObject, MultipleIdenticalDATA,
     DefaultStructConstructorNullPointer, AssumedRankIoItem,
     MultipleProgramUnitsOnSameLine, AllocatedForAssociated,
-    OpenMPThreadprivateEquivalence, RelaxedCLoc, CudaPinned,
+    OpenMPThreadprivateEquivalence, RelaxedCLocChecks, CudaPinned,
     OpenAccDefaultNoneScalarsStrict, OpenACCMultipleNamesInRoutine)
 
 // Portability and suspicious usage warnings
@@ -86,7 +86,7 @@ ENUM_CLASS(UsageWarning, Portability, PointerToUndefinable,
     RealConstantWidening, VolatileOrAsynchronousTemporary, UnusedVariable,
     UsedUndefinedVariable, BadValueInDeadCode, AssumedTypeSizeDummy,
     MisplacedIgnoreTKR, NamelistParameter, ImpureFinalInPure,
-    IgnoredNoReallocateLHS, CLoc, ExperimentalOption)
+    IgnoredNoReallocateLHS, ExperimentalOption)
 
 using LanguageFeatures = EnumSet<LanguageFeature, LanguageFeature_enumSize>;
 using UsageWarnings = EnumSet<UsageWarning, UsageWarning_enumSize>;

--- a/flang/lib/Evaluate/intrinsics.cpp
+++ b/flang/lib/Evaluate/intrinsics.cpp
@@ -3515,8 +3515,8 @@ std::optional<SpecificCall> IntrinsicProcTable::Implementation::HandleC_Loc(
         !(IsObjectPointer(*expr) ||
             (IsVariable(*expr) && GetLastTarget(GetSymbolVector(*expr))))) {
       if (context.languageFeatures().IsEnabled(
-              common::LanguageFeature::RelaxedCLoc)) {
-        context.Warn(common::UsageWarning::CLoc, arguments[0]->sourceLocation(),
+              common::LanguageFeature::RelaxedCLocChecks)) {
+        context.Warn(common::LanguageFeature::RelaxedCLocChecks, arguments[0]->sourceLocation(),
             "C_LOC() argument should be a data pointer or target"_warn_en_US);
       } else {
         context.messages().Say(arguments[0]->sourceLocation(),
@@ -3566,7 +3566,7 @@ std::optional<SpecificCall> IntrinsicProcTable::Implementation::HandleC_Loc(
       specificCall.arguments.emplace_back(std::move(arguments[0]));
       return specificCall;
     } else if (context.languageFeatures().IsEnabled(
-                   common::LanguageFeature::RelaxedCLoc)) {
+                   common::LanguageFeature::RelaxedCLocChecks)) {
       if (!expr || !IsProcedurePointer(*expr)) {
         // There are more specific errors as to why the expression doesn't exist
         // or isn't characterizable as a data object or procedure.

--- a/flang/lib/Evaluate/intrinsics.cpp
+++ b/flang/lib/Evaluate/intrinsics.cpp
@@ -3516,7 +3516,8 @@ std::optional<SpecificCall> IntrinsicProcTable::Implementation::HandleC_Loc(
             (IsVariable(*expr) && GetLastTarget(GetSymbolVector(*expr))))) {
       if (context.languageFeatures().IsEnabled(
               common::LanguageFeature::RelaxedCLocChecks)) {
-        context.Warn(common::LanguageFeature::RelaxedCLocChecks, arguments[0]->sourceLocation(),
+        context.Warn(common::LanguageFeature::RelaxedCLocChecks,
+            arguments[0]->sourceLocation(),
             "C_LOC() argument should be a data pointer or target"_warn_en_US);
       } else {
         context.messages().Say(arguments[0]->sourceLocation(),

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -878,7 +878,7 @@ static bool parseFrontendArgs(FrontendOptions &opts, llvm::opt::ArgList &args,
 
   // -frelaxed-c-loc-checks
   if (args.hasArg(clang::options::OPT_relaxed_c_loc)) {
-    opts.features.Enable(Fortran::common::LanguageFeature::RelaxedCLoc);
+    opts.features.Enable(Fortran::common::LanguageFeature::RelaxedCLocChecks);
   }
 
   // -f{no-}openacc-default-none-scalars-strict

--- a/flang/lib/Support/Fortran-features.cpp
+++ b/flang/lib/Support/Fortran-features.cpp
@@ -140,7 +140,7 @@ LanguageFeatureControl::LanguageFeatureControl() {
   disable_.set(LanguageFeature::ImplicitNoneExternal);
   disable_.set(LanguageFeature::DefaultSave);
   disable_.set(LanguageFeature::SaveMainProgram);
-  disable_.set(LanguageFeature::RelaxedCLoc);
+  disable_.set(LanguageFeature::RelaxedCLocChecks);
   // These features, if enabled, conflict with valid standard usage,
   // so there are disabled here by default.
   disable_.set(LanguageFeature::BackslashEscapes);
@@ -215,7 +215,6 @@ LanguageFeatureControl::LanguageFeatureControl() {
   warnUsage_.set(UsageWarning::MisplacedIgnoreTKR);
   warnUsage_.set(UsageWarning::ImpureFinalInPure);
   warnUsage_.set(UsageWarning::IgnoredNoReallocateLHS);
-  warnUsage_.set(UsageWarning::CLoc);
   warnLanguage_.set(LanguageFeature::OpenMPThreadprivateEquivalence);
   warnLanguage_.set(LanguageFeature::OpenACCMultipleNamesInRoutine);
 }

--- a/flang/test/Semantics/c_loc01-relaxed.f90
+++ b/flang/test/Semantics/c_loc01-relaxed.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1 -frelaxed-c-loc-checks
+! RUN: %python %S/test_errors.py %s %flang_fc1 -frelaxed-c-loc-checks -Wrelaxed-c-loc-checks
 module m
   use iso_c_binding
   type haslen(L)
@@ -25,9 +25,9 @@ module m
     real :: arr2(purefun2(c_funloc(subr))) ! ok
     character(:), allocatable, target :: deferred
     character(n), pointer :: p2ch
-    !WARNING: C_LOC() argument should be a data pointer or target [-Wc-loc]
+    !WARNING: C_LOC() argument should be a data pointer or target [-Wrelaxed-c-loc-checks]
     cp = c_loc(notATarget)
-    !WARNING: C_LOC() argument should be a data pointer or target [-Wc-loc]
+    !WARNING: C_LOC() argument should be a data pointer or target [-Wrelaxed-c-loc-checks]
     cp = c_loc(pptr)
     !ERROR: C_LOC() argument must be contiguous
     cp = c_loc(arr(1:3:2))
@@ -91,9 +91,9 @@ module m3
     procedure(helper), pointer :: pptr
     cp = c_loc(modtarg)    ! ok
     cp = c_loc(localtarg)  ! ok
-    !WARNING: C_LOC() argument should be a data pointer or target [-Wc-loc]
+    !WARNING: C_LOC() argument should be a data pointer or target [-Wrelaxed-c-loc-checks]
     cp = c_loc(notATarget)
-    !WARNING: C_LOC() argument should be a data pointer or target [-Wc-loc]
+    !WARNING: C_LOC() argument should be a data pointer or target [-Wrelaxed-c-loc-checks]
     cp = c_loc(pptr)
   end subroutine
 end module


### PR DESCRIPTION
When I originally implemented this I was confused about how LanguageFeature warning flags work. Drop the separate UsageWarning::CLoc in favour of using LanguageFeature::RelaxedCLocChecks (renamed from RelaxedCLoc to match the feature flag) as the warning flag directly. The warning is off by default since the user has already opted into this extension using the feature flag; use -Wrelaxed-c-loc-checks alongside -frelaxed-c-loc-checks to opt in. Update the test and docs accordingly.