### PR TITLE
[lldb/test] Tolerate ENOENT when cleaning per-test build directory

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 # System modules
 import abc
+import errno
 from functools import wraps
 import gc
 import io
@@ -791,7 +792,21 @@ class Base(unittest.TestCase):
                 "MAX_PATH limit): {}".format(bdir)
             )
         if os.path.isdir(bdir) and not self.SHARED_BUILD_TESTCASE:
-            shutil.rmtree(bdir)
+            # Tolerate files vanishing mid-walk. Clang's implicit module
+            # build leaves behind `*.pcm.lock` lockfiles whose lifetime is
+            # tied to the holding process; a concurrent or just-exited
+            # clang can unlink one between rmtree's scandir and unlink,
+            # raising ENOENT. The dir is going away anyway, so treat
+            # already-gone entries as success.
+            def _ignore_enoent(func, path, exc_info):
+                if (
+                    isinstance(exc_info[1], OSError)
+                    and exc_info[1].errno == errno.ENOENT
+                ):
+                    return
+                raise exc_info[1]
+
+            shutil.rmtree(bdir, onerror=_ignore_enoent)
         lldbutil.mkdir_p(bdir)
 
     def getBuildArtifact(self, name="a.out"):


### PR DESCRIPTION
makeBuildDir() removes any leftover bdir from a prior run before the new test starts. shutil.rmtree() walks the tree via scandir+unlink, so if an entry vanishes between those two calls it raises FileNotFoundError and the test aborts in setUp.

We see this on bots when a previous test's implicit clang module build left a *.pcm.lock file behind. clang's LockFileManager ties the lock's lifetime to the holding process, so the file can disappear under us as soon as that process exits.

Pass an onerror handler that swallows ENOENT (the entry is already gone, which is what we wanted) and re-raises anything else.