### PR TITLE
[arm64e][cfi] .cfi_negate_ra_state is irrelevant for Mach-O platforms

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -728,9 +728,13 @@ void AArch64FrameLowering::resetCFIToInitialState(
   CFIBuilder.buildDefCFA(AArch64::SP, 0);
 
   // Flip the RA sign state.
-  if (MFI.shouldSignReturnAddress(MF))
-    MFI.branchProtectionPAuthLR() ? CFIBuilder.buildNegateRAStateWithPC()
-                                  : CFIBuilder.buildNegateRAState();
+  if (MFI.shouldSignReturnAddress(MF)) {
+    if (MFI.branchProtectionPAuthLR()) {
+      CFIBuilder.buildNegateRAStateWithPC();
+    } else if (!MF.getTarget().getTargetTriple().isOSBinFormatMachO()) {
+      CFIBuilder.buildNegateRAState();
+    }
+  }
 
   // Shadow call stack uses X18, reset it.
   if (MFI.needsShadowCallStackPrologueEpilogue(MF))

--- a/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
+++ b/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
@@ -82,8 +82,11 @@ static void emitPACCFI(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI,
   auto &MFnI = *MF.getInfo<AArch64FunctionInfo>();
 
   CFIInstBuilder CFIBuilder(MBB, MBBI, Flags);
-  MFnI.branchProtectionPAuthLR() ? CFIBuilder.buildNegateRAStateWithPC()
-                                 : CFIBuilder.buildNegateRAState();
+  if (MFnI.branchProtectionPAuthLR()) {
+    CFIBuilder.buildNegateRAStateWithPC();
+  } else if (!MF.getTarget().getTargetTriple().isOSBinFormatMachO()) {
+    CFIBuilder.buildNegateRAState();
+  }
 }
 
 void AArch64PointerAuthImpl::signLR(MachineFunction &MF,

--- a/llvm/test/CodeGen/AArch64/arm64e-tail-call-autib.ll
+++ b/llvm/test/CodeGen/AArch64/arm64e-tail-call-autib.ll
@@ -13,7 +13,6 @@ define swifttailcc void @test_async_tail_call(ptr swiftasync %ctx) "ptrauth-retu
 ; CHECK-LABEL: test_async_tail_call:
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    pacibsp
-; CHECK-NEXT:    .cfi_negate_ra_state
 ; CHECK-NEXT:    orr x29, x29, #0x1000000000000000
 ; CHECK-NEXT:    sub sp, sp, #48
 ; CHECK-NEXT:    stp x29, x30, [sp, #16] ; 16-byte Folded Spill
@@ -57,7 +56,6 @@ define swifttailcc void @test_no_fpdiff_tail_call(ptr swiftasync %ctx) "ptrauth-
 ; CHECK-LABEL: test_no_fpdiff_tail_call:
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    pacibsp
-; CHECK-NEXT:    .cfi_negate_ra_state
 ; CHECK-NEXT:    orr x29, x29, #0x1000000000000000
 ; CHECK-NEXT:    sub sp, sp, #32
 ; CHECK-NEXT:    stp x29, x30, [sp, #16] ; 16-byte Folded Spill


### PR DESCRIPTION
The arm64e unwinder on Mach-O platforms always assumes saved LR's have been signed with a pacibsp, and does not support mixed signed and un-signed frames. Since the unwinder behaves the same whether the directive is present, it is better to avoid emitting it in the first place. This aligns with the behavior of AppleClang.

rdar://178084701