### PR TITLE
[lldb] Reformat doxygen comments in lldb-enumerations.h (NFC)

### DIFF
--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -75,7 +75,7 @@ enum StateType {
   eStateInvalid = 0,
   eStateUnloaded,  ///< Process is object is valid, but not currently loaded
   eStateConnected, ///< Process is connected to remote debug services, but not
-                   /// launched or attached to anything yet
+                   ///< launched or attached to anything yet
   eStateAttaching, ///< Process is currently trying to attach
   eStateLaunching, ///< Process is in the process of launching
   // The state changes eStateAttaching and eStateLaunching are both sent while
@@ -85,7 +85,7 @@ enum StateType {
   eStateStopped,   ///< Process or thread is stopped and can be examined.
   eStateRunning,   ///< Process or thread is running and can't be examined.
   eStateStepping,  ///< Process or thread is in the process of stepping and can
-                   /// not be examined.
+                   ///< not be examined.
   eStateCrashed,   ///< Process or thread has crashed and can be examined.
   eStateDetached,  ///< Process has been detached and can't be examined.
   eStateExited,    ///< Process has exited and can't be examined.
@@ -99,13 +99,13 @@ enum StateType {
 FLAGS_ENUM(LaunchFlags){
     eLaunchFlagNone = 0u,
     eLaunchFlagExec = (1u << 0),  ///< Exec when launching and turn the calling
-                                  /// process into a new process
+                                  ///< process into a new process
     eLaunchFlagDebug = (1u << 1), ///< Stop as soon as the process launches to
-                                  /// allow the process to be debugged
+                                  ///< allow the process to be debugged
     eLaunchFlagStopAtEntry = (1u
                               << 2), ///< Stop at the program entry point
-                                     /// instead of auto-continuing when
-                                     /// launching or attaching at entry point
+                                     ///< instead of auto-continuing when
+                                     ///< launching or attaching at entry point
     eLaunchFlagDisableASLR =
         (1u << 3), ///< Disable Address Space Layout Randomization
     eLaunchFlagDisableSTDIO =
@@ -1321,10 +1321,10 @@ enum DWIMPrintVerbosity {
 
 enum WatchpointValueKind {
   eWatchPointValueKindInvalid = 0,
-  ///< Watchpoint was created watching a variable
+  /// Watchpoint was created watching a variable
   eWatchPointValueKindVariable = 1,
-  ///< Watchpoint was created watching the result of an expression that was
-  ///< evaluated at creation time.
+  /// Watchpoint was created watching the result of an expression that was
+  /// evaluated at creation time.
   eWatchPointValueKindExpression = 2,
 };
 

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -75,8 +75,8 @@ enum StateType {
   eStateInvalid = 0,
   /// Process is object is valid, but not currently loaded
   eStateUnloaded,
-  /// Process is connected to remote debug services, but not
-  /// launched or attached to anything yet
+  /// Process is connected to remote debug services, but not launched or
+  /// attached to anything yet
   eStateConnected,
   /// Process is currently trying to attach
   eStateAttaching,
@@ -90,8 +90,7 @@ enum StateType {
   eStateStopped,
   /// Process or thread is running and can't be examined.
   eStateRunning,
-  /// Process or thread is in the process of stepping and can
-  /// not be examined.
+  /// Process or thread is in the process of stepping and can not be examined.
   eStateStepping,
   /// Process or thread has crashed and can be examined.
   eStateCrashed,
@@ -99,9 +98,8 @@ enum StateType {
   eStateDetached,
   /// Process has exited and can't be examined.
   eStateExited,
-  /// Process or thread is in a suspended state as far
-  /// as the debugger is concerned while other processes
-  /// or threads get the chance to run.
+  /// Process or thread is in a suspended state as far as the debugger is
+  /// concerned while other processes or threads get the chance to run.
   eStateSuspended,
   kLastStateType = eStateSuspended
 };
@@ -125,8 +123,8 @@ FLAGS_ENUM(LaunchFlags){
     eLaunchFlagLaunchInTTY = (1u << 5),
     /// Launch the process inside a shell to get shell expansion.
     eLaunchFlagLaunchInShell = (1u << 6),
-    /// Launch the process in a separate process group. If you are going to
-    /// hand the process off (e.g. to debugserver).
+    /// Launch the process in a separate process group. If you are going to hand
+    /// the process off (e.g. to debugserver).
     eLaunchFlagLaunchInSeparateProcessGroup = (1u << 7),
     /// Set this flag so lldb & the handee don't race to set its exit status.
     eLaunchFlagDontSetExitStatus = (1u << 8),
@@ -197,8 +195,7 @@ enum Format {
   eFormatHexUppercase,
   eFormatFloat,
   eFormatOctal,
-  /// OS character codes encoded into an integer 'PICT' 'text'
-  /// etc...
+  /// OS character codes encoded into an integer 'PICT' 'text' etc...
   eFormatOSType,
   eFormatUnicode16,
   eFormatUnicode32,
@@ -219,12 +216,11 @@ enum Format {
   eFormatVectorOfUInt128,
   /// Integer complex type
   eFormatComplexInteger,
-  /// Print characters with no single quotes, used for
-  /// character arrays that can contain non printable
-  /// characters
+  /// Print characters with no single quotes, used for character arrays that can
+  /// contain non printable characters
   eFormatCharArray,
-  /// Describe what an address points to (func + offset
-  /// with file/line, symbol + offset, data, etc)
+  /// Describe what an address points to (func + offset with file/line, symbol +
+  /// offset, data, etc)
   eFormatAddressInfo,
   /// ISO C99 hex float string
   eFormatHexFloat,
@@ -233,10 +229,9 @@ enum Format {
   /// Do not print this
   eFormatVoid,
   eFormatUnicode8,
-  /// Disambiguate between 128-bit `long double` (which uses
-  /// `eFormatFloat`) and `__float128` (which uses
-  /// `eFormatFloat128`). If the value being formatted is not
-  /// 128 bits, then this is identical to `eFormatFloat`.
+  /// Disambiguate between 128-bit `long double` (which uses `eFormatFloat`) and
+  /// `__float128` (which uses `eFormatFloat128`). If the value being formatted
+  /// is not 128 bits, then this is identical to `eFormatFloat`.
   eFormatFloat128,
   kNumFormats
 };
@@ -268,11 +263,10 @@ enum RegisterKind {
   eRegisterKindEHFrame = 0,
   /// the register numbers seen DWARF
   eRegisterKindDWARF,
-  /// insn ptr reg, stack ptr reg, etc not specific to
-  /// any particular target
+  /// insn ptr reg, stack ptr reg, etc not specific to any particular target
   eRegisterKindGeneric,
-  /// num used by the process plugin - e.g. by the
-  /// remote gdb-protocol stub program
+  /// num used by the process plugin - e.g. by the remote gdb-protocol stub
+  /// program
   eRegisterKindProcessPlugin,
   /// lldb's internal register numbers
   eRegisterKindLLDB,
@@ -353,8 +347,7 @@ enum ConnectionStatus {
   eConnectionStatusTimedOut,
   /// No connection
   eConnectionStatusNoConnection,
-  /// Lost connection while connected to a
-  /// valid connection
+  /// Lost connection while connected to a valid connection
   eConnectionStatusLostConnection,
   /// Interrupted read
   eConnectionStatusInterrupted
@@ -414,44 +407,43 @@ enum InputReaderGranularity {
   eInputReaderGranularityAll
 };
 
-/// These mask bits allow a common interface for queries that can
-/// limit the amount of information that gets parsed to only the
-/// information that is requested. These bits also can indicate what
-/// actually did get resolved during query function calls.
+/// These mask bits allow a common interface for queries that can limit the
+/// amount of information that gets parsed to only the information that is
+/// requested. These bits also can indicate what actually did get resolved
+/// during query function calls.
 ///
-/// Each definition corresponds to a one of the member variables
-/// in this class, and requests that that item be resolved, or
-/// indicates that the member did get resolved.
+/// Each definition corresponds to a one of the member variables in this class,
+/// and requests that that item be resolved, or indicates that the member did
+/// get resolved.
 FLAGS_ENUM(SymbolContextItem){
-    /// Set when \a target is requested from a query, or was located
-    /// in query results
+    /// Set when \a target is requested from a query, or was located in query
+    /// results
     eSymbolContextTarget = (1u << 0),
-    /// Set when \a module is requested from a query, or was located
-    /// in query results
+    /// Set when \a module is requested from a query, or was located in query
+    /// results
     eSymbolContextModule = (1u << 1),
-    /// Set when \a comp_unit is requested from a query, or was
-    /// located in query results
+    /// Set when \a comp_unit is requested from a query, or was located in query
+    /// results
     eSymbolContextCompUnit = (1u << 2),
-    /// Set when \a function is requested from a query, or was located
-    /// in query results
+    /// Set when \a function is requested from a query, or was located in query
+    /// results
     eSymbolContextFunction = (1u << 3),
-    /// Set when the deepest \a block is requested from a query, or
-    /// was located in query results
-    eSymbolContextBlock = (1u << 4),
-    /// Set when \a line_entry is requested from a query, or was
-    /// located in query results
-    eSymbolContextLineEntry = (1u << 5),
-    /// Set when \a symbol is requested from a query, or was located
+    /// Set when the deepest \a block is requested from a query, or was located
     /// in query results
+    eSymbolContextBlock = (1u << 4),
+    /// Set when \a line_entry is requested from a query, or was located in
+    /// query results
+    eSymbolContextLineEntry = (1u << 5),
+    /// Set when \a symbol is requested from a query, or was located in query
+    /// results
     eSymbolContextSymbol = (1u << 6),
-    /// Indicates to try and lookup everything up during a routine
-    /// symbol context query.
+    /// Indicates to try and lookup everything up during a routine symbol
+    /// context query.
     eSymbolContextEverything = ((eSymbolContextSymbol << 1) - 1u),
-    /// Set when \a global or static variable is requested from a
-    /// query, or was located in query results.
-    /// eSymbolContextVariable is potentially expensive to lookup so
-    /// it isn't included in eSymbolContextEverything which stops it
-    /// from being used during frame PC lookups and many other
+    /// Set when \a global or static variable is requested from a query, or was
+    /// located in query results. eSymbolContextVariable is potentially
+    /// expensive to lookup so it isn't included in eSymbolContextEverything
+    /// which stops it from being used during frame PC lookups and many other
     /// potential address to symbol context lookups.
     eSymbolContextVariable = (1u << 7),
 
@@ -468,22 +460,17 @@ LLDB_MARK_AS_BITMASK_ENUM(Permissions)
 enum InputReaderAction {
   /// reader is newly pushed onto the reader stack
   eInputReaderActivate,
-  /// an async output event occurred;
-  /// the reader may want to do
-  /// something
+  /// an async output event occurred; the reader may want to do something
   eInputReaderAsynchronousOutputWritten,
-  /// reader is on top of the stack again after another
-  /// reader was popped off
+  /// reader is on top of the stack again after another reader was popped off
   eInputReaderReactivate,
   /// another reader was pushed on the stack
   eInputReaderDeactivate,
   /// reader got one of its tokens (granularity)
   eInputReaderGotToken,
-  /// reader received an interrupt signal (probably from
-  /// a control-c)
+  /// reader received an interrupt signal (probably from a control-c)
   eInputReaderInterrupt,
-  /// reader received an EOF char (probably from a
-  /// control-d)
+  /// reader received an EOF char (probably from a control-d)
   eInputReaderEndOfFile,
   /// reader was just popped off the stack and is done
   eInputReaderDone
@@ -493,9 +480,7 @@ FLAGS_ENUM(BreakpointEventType){
     eBreakpointEventTypeInvalidType = (1u << 0),
     eBreakpointEventTypeAdded = (1u << 1),
     eBreakpointEventTypeRemoved = (1u << 2),
-    /// Locations added doesn't
-    /// get sent when the
-    /// breakpoint is created
+    /// Locations added doesn't get sent when the breakpoint is created
     eBreakpointEventTypeLocationsAdded = (1u << 3),
     eBreakpointEventTypeLocationsRemoved = (1u << 4),
     eBreakpointEventTypeLocationsResolved = (1u << 5),
@@ -522,27 +507,26 @@ FLAGS_ENUM(WatchpointEventType){
 enum WatchpointWriteType {
   /// Don't stop when the watched memory region is written to.
   eWatchpointWriteTypeDisabled,
-  /// Stop on any write access to the memory region, even if
-  /// the value doesn't change.  On some architectures, a write
-  /// near the memory region may be falsely reported as a match,
-  /// and notify this spurious stop as a watchpoint trap.
+  /// Stop on any write access to the memory region, even if the value doesn't
+  /// change. On some architectures, a write near the memory region may be
+  /// falsely reported as a match, and notify this spurious stop as a watchpoint
+  /// trap.
   eWatchpointWriteTypeAlways,
-  /// Stop on a write to the memory region that changes its value.
-  /// This is most likely the behavior a user expects, and is the
-  /// behavior in gdb.  lldb can silently ignore writes near the
-  /// watched memory region that are reported as accesses to lldb.
+  /// Stop on a write to the memory region that changes its value. This is most
+  /// likely the behavior a user expects, and is the behavior in gdb. lldb can
+  /// silently ignore writes near the watched memory region that are reported as
+  /// accesses to lldb.
   eWatchpointWriteTypeOnModify
 };
 
 /// Programming language type.
 ///
 /// These enumerations use the same language enumerations as the DWARF
-/// specification for ease of use and consistency.
-/// The enum -> string code is in Language.cpp, don't change this
-/// table without updating that code as well.
+/// specification for ease of use and consistency. The enum -> string code is in
+/// Language.cpp, don't change this table without updating that code as well.
 ///
-/// This datatype is used in SBExpressionOptions::SetLanguage() which
-/// makes this type API. Do not change its underlying storage type!
+/// This datatype is used in SBExpressionOptions::SetLanguage() which makes this
+/// type API. Do not change its underlying storage type!
 enum LanguageType {
   /// Unknown or invalid language value.
   eLanguageTypeUnknown = 0x0000,
@@ -823,8 +807,7 @@ enum SymbolType {
   eSymbolTypeLineHeader,
   eSymbolTypeScopeBegin,
   eSymbolTypeScopeEnd,
-  /// When symbols take more than one entry, the extra
-  /// entries get this type
+  /// When symbols take more than one entry, the extra entries get this type
   eSymbolTypeAdditional,
   eSymbolTypeCompiler,
   eSymbolTypeInstrumentation,
@@ -855,8 +838,7 @@ enum SectionType {
   eSectionTypeZeroFill,
   /// Pointer to function pointer + selector
   eSectionTypeDataObjCMessageRefs,
-  /// Objective-C const CFString/NSString
-  /// objects
+  /// Objective-C const CFString/NSString objects
   eSectionTypeDataObjCCFStrings,
   eSectionTypeDWARFDebugAbbrev,
   eSectionTypeDWARFDebugAddr,
@@ -888,12 +870,10 @@ enum SectionType {
   eSectionTypeEHFrame,
   eSectionTypeARMexidx,
   eSectionTypeARMextab,
-  /// compact unwind section in Mach-O,
-  /// __TEXT,__unwind_info
+  /// compact unwind section in Mach-O, __TEXT,__unwind_info
   eSectionTypeCompactUnwind,
   eSectionTypeGoSymtab,
-  /// Dummy section for symbols with absolute
-  /// address
+  /// Dummy section for symbols with absolute address
   eSectionTypeAbsoluteAddress,
   eSectionTypeDWARFGNUDebugAltLink,
   /// DWARF .debug_types section
@@ -930,24 +910,23 @@ FLAGS_ENUM(EmulateInstructionOptions){
 
 FLAGS_ENUM(FunctionNameType){
     eFunctionNameTypeNone = 0u,
-    /// Automatically figure out which FunctionNameType bits to set based on
-    /// the function name.
+    /// Automatically figure out which FunctionNameType bits to set based on the
+    /// function name.
     eFunctionNameTypeAuto = (1u << 1),
     /// The function name. For C this is the same as just the name of the
     /// function. For C++ this is the mangled or demangled version of the
-    /// mangled name. For ObjC this is the full function signature with the +
-    /// or - and the square brackets and the class and selector.
+    /// mangled name. For ObjC this is the full function signature with the + or
+    /// - and the square brackets and the class and selector.
     eFunctionNameTypeFull = (1u << 2),
-    /// The function name only, no namespaces or arguments and no class
-    /// methods or selectors will be searched.
+    /// The function name only, no namespaces or arguments and no class methods
+    /// or selectors will be searched.
     eFunctionNameTypeBase = (1u << 3),
     /// Find function by method name (C++) with no namespace or arguments.
     eFunctionNameTypeMethod = (1u << 4),
     /// Find function by selector name (ObjC) names.
     eFunctionNameTypeSelector = (1u << 5),
     /// DEPRECATED: use eFunctionNameTypeAuto.
-    eFunctionNameTypeAny = eFunctionNameTypeAuto
-};
+    eFunctionNameTypeAny = eFunctionNameTypeAuto};
 LLDB_MARK_AS_BITMASK_ENUM(FunctionNameType)
 
 /// Basic types enumeration for the public API SBType::GetBasicType().
@@ -1051,8 +1030,8 @@ enum FormatterMatchType {
   eLastFormatterMatchType = eFormatterMatchCallback,
 };
 
-/// Options that can be set for a formatter to alter its behavior. Not
-/// all of these are applicable to all formatter types.
+/// Options that can be set for a formatter to alter its behavior. Not all of
+/// these are applicable to all formatter types.
 FLAGS_ENUM(TypeOptions){eTypeOptionNone = (0u),
                         eTypeOptionCascade = (1u << 0),
                         eTypeOptionSkipPointers = (1u << 1),
@@ -1066,26 +1045,24 @@ FLAGS_ENUM(TypeOptions){eTypeOptionNone = (0u),
                         eTypeOptionFrontEndWantsDereference = (1u << 9),
                         eTypeOptionCustomSubscripting = (1u << 10)};
 
-/// This is the return value for frame comparisons.  If you are comparing frame
-/// A to frame B the following cases arise:
+/// This is the return value for frame comparisons. If you are comparing frame A
+/// to frame B the following cases arise:
 ///
-///    1) When frame A pushes frame B (or a frame that ends up pushing
-///       B) A is Older than B.
+///    1) When frame A pushes frame B (or a frame that ends up pushing B) A is
+///    Older than B.
 ///
-///    2) When frame A pushed frame B (or if frameA is on the stack
-///       but B is not) A is Younger than B.
+///    2) When frame A pushed frame B (or if frameA is on the stack but B is
+///    not) A is Younger than B.
 ///
-///    3) When frame A and frame B have the same StackID, they are
-///       Equal.
+///    3) When frame A and frame B have the same StackID, they are Equal.
 ///
-///    4) When frame A and frame B have the same immediate parent
-///       frame, but are not equal, the comparison yields SameParent.
+///    4) When frame A and frame B have the same immediate parent frame, but are
+///    not equal, the comparison yields SameParent.
 ///
-///    5) If the two frames are on different threads or processes the
-///       comparison is Invalid.
+///    5) If the two frames are on different threads or processes the comparison
+///    is Invalid.
 ///
-///    6) If for some reason we can't figure out what went on, we
-///       return Unknown.
+///  6) If for some reason we can't figure out what went on, we return Unknown.
 enum FrameComparison {
   eFrameCompareInvalid,
   eFrameCompareUnknown,
@@ -1167,9 +1144,8 @@ enum QueueItemKind {
 
 /// Queue type.
 ///
-/// libdispatch aka Grand Central Dispatch (GCD) queues can be either
-/// serial (executing on one thread) or concurrent (executing on
-/// multiple threads).
+/// libdispatch aka Grand Central Dispatch (GCD) queues can be either serial
+/// (executing on one thread) or concurrent (executing on multiple threads).
 enum QueueKind {
   eQueueKindUnknown = 0,
   eQueueKindSerial,
@@ -1178,9 +1154,9 @@ enum QueueKind {
 
 /// Expression Evaluation Stages.
 ///
-/// These are the cancellable stages of expression evaluation, passed
-/// to the expression evaluation callback, so that you can interrupt
-/// expression evaluation at the various points in its lifecycle.
+/// These are the cancellable stages of expression evaluation, passed to the
+/// expression evaluation callback, so that you can interrupt expression
+/// evaluation at the various points in its lifecycle.
 enum ExpressionEvaluationPhase {
   eExpressionEvaluationParse = 0,
   eExpressionEvaluationIRGen,
@@ -1206,14 +1182,13 @@ enum InstructionControlFlowKind {
   eInstructionControlFlowKindJump,
   /// The instruction is a near conditional jump.
   eInstructionControlFlowKindCondJump,
-  /// The instruction is a call-like far transfer.
-  /// E.g. SYSCALL, SYSENTER, or FAR CALL.
+  /// The instruction is a call-like far transfer. E.g. SYSCALL, SYSENTER, or
+  /// FAR CALL.
   eInstructionControlFlowKindFarCall,
-  /// The instruction is a return-like far transfer.
-  /// E.g. SYSRET, SYSEXIT, IRET, or FAR RET.
+  /// The instruction is a return-like far transfer. E.g. SYSRET, SYSEXIT, IRET,
+  /// or FAR RET.
   eInstructionControlFlowKindFarReturn,
-  /// The instruction is a jump-like far transfer.
-  /// E.g. FAR JMP.
+  /// The instruction is a jump-like far transfer. E.g. FAR JMP.
   eInstructionControlFlowKindFarJump
 };
 
@@ -1234,14 +1209,13 @@ enum GdbSignal {
 };
 
 /// Used with SBHostOS::GetLLDBPath (lldb::PathType) to find files that are
-/// related to LLDB on the current host machine. Most files are
-/// relative to LLDB or are in known locations.
+/// related to LLDB on the current host machine. Most files are relative to LLDB
+/// or are in known locations.
 enum PathType {
-  /// The directory where the lldb.so (unix) or LLDB
-  /// mach-o file in LLDB.framework (MacOSX) exists
+  /// The directory where the lldb.so (unix) or LLDB mach-o file in
+  /// LLDB.framework (MacOSX) exists
   ePathTypeLLDBShlibDir,
-  /// Find LLDB support executable directory
-  /// (debugserver, etc)
+  /// Find LLDB support executable directory (debugserver, etc)
   ePathTypeSupportExecutableDir,
   /// Find LLDB header file directory
   ePathTypeHeaderDir,
@@ -1251,12 +1225,9 @@ enum PathType {
   ePathTypeLLDBSystemPlugins,
   /// User plug-ins directory
   ePathTypeLLDBUserPlugins,
-  /// The LLDB temp directory for this system that
-  /// will be cleaned up on exit
+  /// The LLDB temp directory for this system that will be cleaned up on exit
   ePathTypeLLDBTempSystemDir,
-  /// The LLDB temp directory for this
-  /// system, NOT cleaned up on a process
-  /// exit.
+  /// The LLDB temp directory for this system, NOT cleaned up on a process exit.
   ePathTypeGlobalLLDBTempSystemDir,
   /// Find path to Clang builtin headers
   ePathTypeClangDir
@@ -1270,14 +1241,11 @@ enum MemberFunctionKind {
   eMemberFunctionKindUnknown = 0,
   /// A function used to create instances
   eMemberFunctionKindConstructor,
-  /// A function used to tear down existing
-  /// instances
+  /// A function used to tear down existing instances
   eMemberFunctionKindDestructor,
-  /// A function that applies to a specific
-  /// instance
+  /// A function that applies to a specific instance
   eMemberFunctionKindInstanceMethod,
-  /// A function that applies to a type rather
-  /// than any instance
+  /// A function that applies to a type rather than any instance
   eMemberFunctionKindStaticMethod
 };
 
@@ -1387,11 +1355,10 @@ enum TypeSummaryCapping {
 enum CommandInterpreterResult {
   /// Command interpreter finished successfully.
   eCommandInterpreterResultSuccess,
-  /// Stopped because the corresponding option was set and the inferior
-  /// crashed.
+  /// Stopped because the corresponding option was set and the inferior crashed.
   eCommandInterpreterResultInferiorCrash,
-  /// Stopped because the corresponding option was set and a command returned
-  /// an error.
+  /// Stopped because the corresponding option was set and a command returned an
+  /// error.
   eCommandInterpreterResultCommandError,
   /// Stopped because quit was requested.
   eCommandInterpreterResultQuitRequested,
@@ -1429,8 +1396,7 @@ enum TraceItemKind {
   eTraceItemKindInstruction,
 };
 
-/// Enum to indicate the reference point when invoking
-/// \a TraceCursor::Seek().
+/// Enum to indicate the reference point when invoking \a TraceCursor::Seek().
 /// The following values are inspired by \a std::istream::seekg.
 enum TraceCursorSeekType {
   /// The beginning of the trace, i.e the oldest item.
@@ -1497,14 +1463,14 @@ enum CompletionType {
   eTerminatorCompletion = (1ul << 28)
 };
 
-/// Specifies if children need to be re-computed
-/// after a call to \ref SyntheticChildrenFrontEnd::Update.
+/// Specifies if children need to be re-computed after a call to \ref
+/// SyntheticChildrenFrontEnd::Update.
 enum ChildCacheState {
   /// Children need to be recomputed dynamically.
   eRefetch = 0,
 
-  /// Children did not change and don't need to be recomputed;
-  /// re-use what we computed the last time we called Update.
+  /// Children did not change and don't need to be recomputed; re-use what we
+  /// computed the last time we called Update.
   eReuse = 1,
 };
 
@@ -1590,25 +1556,21 @@ enum NameMatchStyle {
   eNameMatchStyleRegex = eFunctionNameTypeSelector << 1
 };
 
-/// Data Inspection Language (DIL) evaluation modes.
-/// DIL will only attempt evaluating expressions that contain tokens
-/// allowed by a selected mode.
+/// Data Inspection Language (DIL) evaluation modes. DIL will only attempt
+/// evaluating expressions that contain tokens allowed by a selected mode.
 enum DILMode {
   /// Allowed: identifiers, operators: '.'.
   eDILModeSimple,
   /// Allowed: identifiers, integers, operators: '.', '->', '*', '&', '[]'.
   eDILModeLegacy,
-  /// Allowed: everything supported by DIL.
-  /// \see lldb/docs/dil-expr-lang.ebnf
+  /// Allowed: everything supported by DIL. \see lldb/docs/dil-expr-lang.ebnf
   eDILModeFull
 };
 
-/// When the Process plugin can retrieve information
-/// about all binaries loaded in the target process,
-/// or given a list of binary load addresses, this
-/// enum specifies how much information needed from
-/// the Process plugin; there may be performance reasons
-/// to limit the amount of information returned.
+/// When the Process plugin can retrieve information about all binaries loaded
+/// in the target process, or given a list of binary load addresses, this enum
+/// specifies how much information needed from the Process plugin; there may be
+/// performance reasons to limit the amount of information returned.
 enum BinaryInformationLevel {
   eBinaryInformationLevelAddrOnly,
   eBinaryInformationLevelAddrName,

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -73,69 +73,79 @@ namespace lldb {
 /// Process and Thread States.
 enum StateType {
   eStateInvalid = 0,
-  eStateUnloaded,  ///< Process is object is valid, but not currently loaded
-  eStateConnected, ///< Process is connected to remote debug services, but not
-                   ///< launched or attached to anything yet
-  eStateAttaching, ///< Process is currently trying to attach
-  eStateLaunching, ///< Process is in the process of launching
+  /// Process is object is valid, but not currently loaded
+  eStateUnloaded,
+  /// Process is connected to remote debug services, but not
+  /// launched or attached to anything yet
+  eStateConnected,
+  /// Process is currently trying to attach
+  eStateAttaching,
+  /// Process is in the process of launching
+  eStateLaunching,
   // The state changes eStateAttaching and eStateLaunching are both sent while
   // the private state thread is either not yet started or paused. For that
   // reason, they should only be signaled as public state changes, and not
   // private state changes.
-  eStateStopped,   ///< Process or thread is stopped and can be examined.
-  eStateRunning,   ///< Process or thread is running and can't be examined.
-  eStateStepping,  ///< Process or thread is in the process of stepping and can
-                   ///< not be examined.
-  eStateCrashed,   ///< Process or thread has crashed and can be examined.
-  eStateDetached,  ///< Process has been detached and can't be examined.
-  eStateExited,    ///< Process has exited and can't be examined.
-  eStateSuspended, ///< Process or thread is in a suspended state as far
-                   ///< as the debugger is concerned while other processes
-                   ///< or threads get the chance to run.
+  /// Process or thread is stopped and can be examined.
+  eStateStopped,
+  /// Process or thread is running and can't be examined.
+  eStateRunning,
+  /// Process or thread is in the process of stepping and can
+  /// not be examined.
+  eStateStepping,
+  /// Process or thread has crashed and can be examined.
+  eStateCrashed,
+  /// Process has been detached and can't be examined.
+  eStateDetached,
+  /// Process has exited and can't be examined.
+  eStateExited,
+  /// Process or thread is in a suspended state as far
+  /// as the debugger is concerned while other processes
+  /// or threads get the chance to run.
+  eStateSuspended,
   kLastStateType = eStateSuspended
 };
 
 /// Launch Flags.
 FLAGS_ENUM(LaunchFlags){
     eLaunchFlagNone = 0u,
-    eLaunchFlagExec = (1u << 0),  ///< Exec when launching and turn the calling
-                                  ///< process into a new process
-    eLaunchFlagDebug = (1u << 1), ///< Stop as soon as the process launches to
-                                  ///< allow the process to be debugged
-    eLaunchFlagStopAtEntry = (1u
-                              << 2), ///< Stop at the program entry point
-                                     ///< instead of auto-continuing when
-                                     ///< launching or attaching at entry point
-    eLaunchFlagDisableASLR =
-        (1u << 3), ///< Disable Address Space Layout Randomization
-    eLaunchFlagDisableSTDIO =
-        (1u << 4), ///< Disable stdio for inferior process (e.g. for a GUI app)
-    eLaunchFlagLaunchInTTY =
-        (1u << 5), ///< Launch the process in a new TTY if supported by the host
-    eLaunchFlagLaunchInShell =
-        (1u << 6), ///< Launch the process inside a shell to get shell expansion
-    eLaunchFlagLaunchInSeparateProcessGroup =
-        (1u << 7), ///< Launch the process in a separate process group
-                   ///< If you are going to hand the process off (e.g. to
-                   ///< debugserver)
+    /// Exec when launching and turn the calling process into a new process.
+    eLaunchFlagExec = (1u << 0),
+    /// Stop as soon as the process launches to allow the process to be
+    /// debugged.
+    eLaunchFlagDebug = (1u << 1),
+    /// Stop at the program entry point instead of auto-continuing when
+    /// launching or attaching at entry point.
+    eLaunchFlagStopAtEntry = (1u << 2),
+    /// Disable Address Space Layout Randomization.
+    eLaunchFlagDisableASLR = (1u << 3),
+    /// Disable stdio for inferior process (e.g. for a GUI app).
+    eLaunchFlagDisableSTDIO = (1u << 4),
+    /// Launch the process in a new TTY if supported by the host.
+    eLaunchFlagLaunchInTTY = (1u << 5),
+    /// Launch the process inside a shell to get shell expansion.
+    eLaunchFlagLaunchInShell = (1u << 6),
+    /// Launch the process in a separate process group. If you are going to
+    /// hand the process off (e.g. to debugserver).
+    eLaunchFlagLaunchInSeparateProcessGroup = (1u << 7),
+    /// Set this flag so lldb & the handee don't race to set its exit status.
     eLaunchFlagDontSetExitStatus = (1u << 8),
-    ///< set this flag so lldb & the handee don't race to set its exit status.
-    eLaunchFlagDetachOnError = (1u << 9), ///< If set, then the client stub
-                                          ///< should detach rather than killing
-                                          ///< the debugee
-                                          ///< if it loses connection with lldb.
-    eLaunchFlagShellExpandArguments =
-        (1u << 10), ///< Perform shell-style argument expansion
-    eLaunchFlagCloseTTYOnExit = (1u << 11), ///< Close the open TTY on exit
-    eLaunchFlagInheritTCCFromParent =
-        (1u << 12), ///< Don't make the inferior responsible for its own TCC
-                    ///< permissions but instead inherit them from its parent.
-    eLaunchFlagMemoryTagging =
-        (1u << 13), ///< Launch process with memory tagging explicitly enabled.
-    eLaunchFlagUsePipes =
-        (1u << 14), ///< Use anonymous pipes for stdio instead of a ConPTY on
-                    ///< Windows. Useful when terminal emulation is not needed
-                    ///< (e.g. lldb-dap internalConsole mode).
+    /// If set, then the client stub should detach rather than killing the
+    /// debugee if it loses connection with lldb.
+    eLaunchFlagDetachOnError = (1u << 9),
+    /// Perform shell-style argument expansion.
+    eLaunchFlagShellExpandArguments = (1u << 10),
+    /// Close the open TTY on exit.
+    eLaunchFlagCloseTTYOnExit = (1u << 11),
+    /// Don't make the inferior responsible for its own TCC permissions but
+    /// instead inherit them from its parent.
+    eLaunchFlagInheritTCCFromParent = (1u << 12),
+    /// Launch process with memory tagging explicitly enabled.
+    eLaunchFlagMemoryTagging = (1u << 13),
+    /// Use anonymous pipes for stdio instead of a ConPTY on Windows. Useful
+    /// when terminal emulation is not needed (e.g. lldb-dap internalConsole
+    /// mode).
+    eLaunchFlagUsePipes = (1u << 14),
 };
 
 /// Thread Run Modes.
@@ -155,10 +165,14 @@ enum ByteOrder {
 /// Register encoding definitions.
 enum Encoding {
   eEncodingInvalid = 0,
-  eEncodingUint,    ///< unsigned integer
-  eEncodingSint,    ///< signed integer
-  eEncodingIEEE754, ///< float
-  eEncodingVector   ///< vector registers
+  /// unsigned integer
+  eEncodingUint,
+  /// signed integer
+  eEncodingSint,
+  /// float
+  eEncodingIEEE754,
+  /// vector registers
+  eEncodingVector
 };
 
 /// Display format definitions.
@@ -170,18 +184,22 @@ enum Format {
   eFormatBytes,
   eFormatBytesWithASCII,
   eFormatChar,
-  eFormatCharPrintable, ///< Only printable characters, '.' if not printable
-  eFormatComplex,       ///< Floating point complex type
+  /// Only printable characters, '.' if not printable
+  eFormatCharPrintable,
+  /// Floating point complex type
+  eFormatComplex,
   eFormatComplexFloat = eFormatComplex,
-  eFormatCString, ///< NULL terminated C strings
+  /// NULL terminated C strings
+  eFormatCString,
   eFormatDecimal,
   eFormatEnum,
   eFormatHex,
   eFormatHexUppercase,
   eFormatFloat,
   eFormatOctal,
-  eFormatOSType, ///< OS character codes encoded into an integer 'PICT' 'text'
-                 ///< etc...
+  /// OS character codes encoded into an integer 'PICT' 'text'
+  /// etc...
+  eFormatOSType,
   eFormatUnicode16,
   eFormatUnicode32,
   eFormatUnsigned,
@@ -199,20 +217,27 @@ enum Format {
   eFormatVectorOfFloat32,
   eFormatVectorOfFloat64,
   eFormatVectorOfUInt128,
-  eFormatComplexInteger, ///< Integer complex type
-  eFormatCharArray,      ///< Print characters with no single quotes, used for
-                         ///< character arrays that can contain non printable
-                         ///< characters
-  eFormatAddressInfo,    ///< Describe what an address points to (func + offset
-                         ///< with file/line, symbol + offset, data, etc)
-  eFormatHexFloat,       ///< ISO C99 hex float string
-  eFormatInstruction,    ///< Disassemble an opcode
-  eFormatVoid,           ///< Do not print this
+  /// Integer complex type
+  eFormatComplexInteger,
+  /// Print characters with no single quotes, used for
+  /// character arrays that can contain non printable
+  /// characters
+  eFormatCharArray,
+  /// Describe what an address points to (func + offset
+  /// with file/line, symbol + offset, data, etc)
+  eFormatAddressInfo,
+  /// ISO C99 hex float string
+  eFormatHexFloat,
+  /// Disassemble an opcode
+  eFormatInstruction,
+  /// Do not print this
+  eFormatVoid,
   eFormatUnicode8,
-  eFormatFloat128, ///< Disambiguate between 128-bit `long double` (which uses
-                   ///< `eFormatFloat`) and `__float128` (which uses
-                   ///< `eFormatFloat128`). If the value being formatted is not
-                   ///< 128 bits, then this is identical to `eFormatFloat`.
+  /// Disambiguate between 128-bit `long double` (which uses
+  /// `eFormatFloat`) and `__float128` (which uses
+  /// `eFormatFloat128`). If the value being formatted is not
+  /// 128 bits, then this is identical to `eFormatFloat`.
+  eFormatFloat128,
   kNumFormats
 };
 
@@ -239,13 +264,18 @@ enum ScriptLanguage {
 // See RegisterContext::ConvertRegisterKindToRegisterNumber to convert any of
 // these to the lldb internal register numbering scheme (eRegisterKindLLDB).
 enum RegisterKind {
-  eRegisterKindEHFrame = 0, ///< the register numbers seen in eh_frame
-  eRegisterKindDWARF,       ///< the register numbers seen DWARF
-  eRegisterKindGeneric, ///< insn ptr reg, stack ptr reg, etc not specific to
-                        ///< any particular target
-  eRegisterKindProcessPlugin, ///< num used by the process plugin - e.g. by the
-                              ///< remote gdb-protocol stub program
-  eRegisterKindLLDB,          ///< lldb's internal register numbers
+  /// the register numbers seen in eh_frame
+  eRegisterKindEHFrame = 0,
+  /// the register numbers seen DWARF
+  eRegisterKindDWARF,
+  /// insn ptr reg, stack ptr reg, etc not specific to
+  /// any particular target
+  eRegisterKindGeneric,
+  /// num used by the process plugin - e.g. by the
+  /// remote gdb-protocol stub program
+  eRegisterKindProcessPlugin,
+  /// lldb's internal register numbers
+  eRegisterKindLLDB,
   kNumRegisterKinds
 };
 
@@ -258,7 +288,8 @@ enum StopReason {
   eStopReasonWatchpoint,
   eStopReasonSignal,
   eStopReasonException,
-  eStopReasonExec, ///< Program was re-exec'ed
+  /// Program was re-exec'ed
+  eStopReasonExec,
   eStopReasonPlanComplete,
   eStopReasonThreadExiting,
   eStopReasonInstrumentation,
@@ -266,7 +297,8 @@ enum StopReason {
   eStopReasonFork,
   eStopReasonVFork,
   eStopReasonVForkDone,
-  eStopReasonInterrupt, ///< Thread requested interrupt
+  /// Thread requested interrupt
+  eStopReasonInterrupt,
   // Indicates that execution stopped because the debugger backend relies
   // on recorded data and we reached the end of that data.
   eStopReasonHistoryBoundary,
@@ -311,37 +343,59 @@ enum SearchDepth {
 
 /// Connection Status Types.
 enum ConnectionStatus {
-  eConnectionStatusSuccess,        ///< Success
-  eConnectionStatusEndOfFile,      ///< End-of-file encountered
-  eConnectionStatusError,          ///< Check GetError() for details
-  eConnectionStatusTimedOut,       ///< Request timed out
-  eConnectionStatusNoConnection,   ///< No connection
-  eConnectionStatusLostConnection, ///< Lost connection while connected to a
-                                   ///< valid connection
-  eConnectionStatusInterrupted ///< Interrupted read
+  /// Success
+  eConnectionStatusSuccess,
+  /// End-of-file encountered
+  eConnectionStatusEndOfFile,
+  /// Check GetError() for details
+  eConnectionStatusError,
+  /// Request timed out
+  eConnectionStatusTimedOut,
+  /// No connection
+  eConnectionStatusNoConnection,
+  /// Lost connection while connected to a
+  /// valid connection
+  eConnectionStatusLostConnection,
+  /// Interrupted read
+  eConnectionStatusInterrupted
 };
 
 enum ErrorType {
   eErrorTypeInvalid,
-  eErrorTypeGeneric,    ///< Generic errors that can be any value.
-  eErrorTypeMachKernel, ///< Mach kernel error codes.
-  eErrorTypePOSIX,      ///< POSIX error codes.
-  eErrorTypeExpression, ///< These are from the ExpressionResults enum.
-  eErrorTypeWin32       ///< Standard Win32 error codes.
+  /// Generic errors that can be any value.
+  eErrorTypeGeneric,
+  /// Mach kernel error codes.
+  eErrorTypeMachKernel,
+  /// POSIX error codes.
+  eErrorTypePOSIX,
+  /// These are from the ExpressionResults enum.
+  eErrorTypeExpression,
+  /// Standard Win32 error codes.
+  eErrorTypeWin32
 };
 
 enum ValueType : uint32_t {
   eValueTypeInvalid = 0,
-  eValueTypeVariableGlobal = 1,   ///< globals variable
-  eValueTypeVariableStatic = 2,   ///< static variable
-  eValueTypeVariableArgument = 3, ///< function argument variables
-  eValueTypeVariableLocal = 4,    ///< function local variables
-  eValueTypeRegister = 5,         ///< stack frame register value
-  eValueTypeRegisterSet = 6, ///< A collection of stack frame register values
-  eValueTypeConstResult = 7, ///< constant result variables
-  eValueTypeVariableThreadLocal = 8, ///< thread local storage variable
-  eValueTypeVTable = 9,              ///< virtual function table
-  eValueTypeVTableEntry = 10, ///< function pointer in virtual function table
+  /// globals variable
+  eValueTypeVariableGlobal = 1,
+  /// static variable
+  eValueTypeVariableStatic = 2,
+  /// function argument variables
+  eValueTypeVariableArgument = 3,
+  /// function local variables
+  eValueTypeVariableLocal = 4,
+  /// stack frame register value
+  eValueTypeRegister = 5,
+  /// A collection of stack frame register values
+  eValueTypeRegisterSet = 6,
+  /// constant result variables
+  eValueTypeConstResult = 7,
+  /// thread local storage variable
+  eValueTypeVariableThreadLocal = 8,
+  /// virtual function table
+  eValueTypeVTable = 9,
+  /// function pointer in virtual function table
+  eValueTypeVTableEntry = 10,
 };
 
 /// A mask that we can use to check if the value type is synthetic or not.
@@ -412,28 +466,37 @@ FLAGS_ENUM(Permissions){ePermissionsWritable = (1u << 0),
 LLDB_MARK_AS_BITMASK_ENUM(Permissions)
 
 enum InputReaderAction {
-  eInputReaderActivate, ///< reader is newly pushed onto the reader stack
-  eInputReaderAsynchronousOutputWritten, ///< an async output event occurred;
-                                         ///< the reader may want to do
-                                         ///< something
-  eInputReaderReactivate, ///< reader is on top of the stack again after another
-                          ///< reader was popped off
-  eInputReaderDeactivate, ///< another reader was pushed on the stack
-  eInputReaderGotToken,   ///< reader got one of its tokens (granularity)
-  eInputReaderInterrupt, ///< reader received an interrupt signal (probably from
-                         ///< a control-c)
-  eInputReaderEndOfFile, ///< reader received an EOF char (probably from a
-                         ///< control-d)
-  eInputReaderDone       ///< reader was just popped off the stack and is done
+  /// reader is newly pushed onto the reader stack
+  eInputReaderActivate,
+  /// an async output event occurred;
+  /// the reader may want to do
+  /// something
+  eInputReaderAsynchronousOutputWritten,
+  /// reader is on top of the stack again after another
+  /// reader was popped off
+  eInputReaderReactivate,
+  /// another reader was pushed on the stack
+  eInputReaderDeactivate,
+  /// reader got one of its tokens (granularity)
+  eInputReaderGotToken,
+  /// reader received an interrupt signal (probably from
+  /// a control-c)
+  eInputReaderInterrupt,
+  /// reader received an EOF char (probably from a
+  /// control-d)
+  eInputReaderEndOfFile,
+  /// reader was just popped off the stack and is done
+  eInputReaderDone
 };
 
 FLAGS_ENUM(BreakpointEventType){
     eBreakpointEventTypeInvalidType = (1u << 0),
     eBreakpointEventTypeAdded = (1u << 1),
     eBreakpointEventTypeRemoved = (1u << 2),
-    eBreakpointEventTypeLocationsAdded = (1u << 3), ///< Locations added doesn't
-                                                    ///< get sent when the
-                                                    ///< breakpoint is created
+    /// Locations added doesn't
+    /// get sent when the
+    /// breakpoint is created
+    eBreakpointEventTypeLocationsAdded = (1u << 3),
     eBreakpointEventTypeLocationsRemoved = (1u << 4),
     eBreakpointEventTypeLocationsResolved = (1u << 5),
     eBreakpointEventTypeEnabled = (1u << 6),
@@ -481,51 +544,89 @@ enum WatchpointWriteType {
 /// This datatype is used in SBExpressionOptions::SetLanguage() which
 /// makes this type API. Do not change its underlying storage type!
 enum LanguageType {
-  eLanguageTypeUnknown = 0x0000,        ///< Unknown or invalid language value.
-  eLanguageTypeC89 = 0x0001,            ///< ISO C:1989.
-  eLanguageTypeC = 0x0002,              ///< Non-standardized C, such as K&R.
-  eLanguageTypeAda83 = 0x0003,          ///< ISO Ada:1983.
-  eLanguageTypeC_plus_plus = 0x0004,    ///< ISO C++:1998.
-  eLanguageTypeCobol74 = 0x0005,        ///< ISO Cobol:1974.
-  eLanguageTypeCobol85 = 0x0006,        ///< ISO Cobol:1985.
-  eLanguageTypeFortran77 = 0x0007,      ///< ISO Fortran 77.
-  eLanguageTypeFortran90 = 0x0008,      ///< ISO Fortran 90.
-  eLanguageTypePascal83 = 0x0009,       ///< ISO Pascal:1983.
-  eLanguageTypeModula2 = 0x000a,        ///< ISO Modula-2:1996.
-  eLanguageTypeJava = 0x000b,           ///< Java.
-  eLanguageTypeC99 = 0x000c,            ///< ISO C:1999.
-  eLanguageTypeAda95 = 0x000d,          ///< ISO Ada:1995.
-  eLanguageTypeFortran95 = 0x000e,      ///< ISO Fortran 95.
-  eLanguageTypePLI = 0x000f,            ///< ANSI PL/I:1976.
-  eLanguageTypeObjC = 0x0010,           ///< Objective-C.
-  eLanguageTypeObjC_plus_plus = 0x0011, ///< Objective-C++.
-  eLanguageTypeUPC = 0x0012,            ///< Unified Parallel C.
-  eLanguageTypeD = 0x0013,              ///< D.
-  eLanguageTypePython = 0x0014,         ///< Python.
+  /// Unknown or invalid language value.
+  eLanguageTypeUnknown = 0x0000,
+  /// ISO C:1989.
+  eLanguageTypeC89 = 0x0001,
+  /// Non-standardized C, such as K&R.
+  eLanguageTypeC = 0x0002,
+  /// ISO Ada:1983.
+  eLanguageTypeAda83 = 0x0003,
+  /// ISO C++:1998.
+  eLanguageTypeC_plus_plus = 0x0004,
+  /// ISO Cobol:1974.
+  eLanguageTypeCobol74 = 0x0005,
+  /// ISO Cobol:1985.
+  eLanguageTypeCobol85 = 0x0006,
+  /// ISO Fortran 77.
+  eLanguageTypeFortran77 = 0x0007,
+  /// ISO Fortran 90.
+  eLanguageTypeFortran90 = 0x0008,
+  /// ISO Pascal:1983.
+  eLanguageTypePascal83 = 0x0009,
+  /// ISO Modula-2:1996.
+  eLanguageTypeModula2 = 0x000a,
+  /// Java.
+  eLanguageTypeJava = 0x000b,
+  /// ISO C:1999.
+  eLanguageTypeC99 = 0x000c,
+  /// ISO Ada:1995.
+  eLanguageTypeAda95 = 0x000d,
+  /// ISO Fortran 95.
+  eLanguageTypeFortran95 = 0x000e,
+  /// ANSI PL/I:1976.
+  eLanguageTypePLI = 0x000f,
+  /// Objective-C.
+  eLanguageTypeObjC = 0x0010,
+  /// Objective-C++.
+  eLanguageTypeObjC_plus_plus = 0x0011,
+  /// Unified Parallel C.
+  eLanguageTypeUPC = 0x0012,
+  /// D.
+  eLanguageTypeD = 0x0013,
+  /// Python.
+  eLanguageTypePython = 0x0014,
   // NOTE: The below are DWARF5 constants, subject to change upon
   // completion of the DWARF5 specification
-  eLanguageTypeOpenCL = 0x0015,         ///< OpenCL.
-  eLanguageTypeGo = 0x0016,             ///< Go.
-  eLanguageTypeModula3 = 0x0017,        ///< Modula 3.
-  eLanguageTypeHaskell = 0x0018,        ///< Haskell.
-  eLanguageTypeC_plus_plus_03 = 0x0019, ///< ISO C++:2003.
-  eLanguageTypeC_plus_plus_11 = 0x001a, ///< ISO C++:2011.
-  eLanguageTypeOCaml = 0x001b,          ///< OCaml.
-  eLanguageTypeRust = 0x001c,           ///< Rust.
-  eLanguageTypeC11 = 0x001d,            ///< ISO C:2011.
-  eLanguageTypeSwift = 0x001e,          ///< Swift.
-  eLanguageTypeJulia = 0x001f,          ///< Julia.
-  eLanguageTypeDylan = 0x0020,          ///< Dylan.
-  eLanguageTypeC_plus_plus_14 = 0x0021, ///< ISO C++:2014.
-  eLanguageTypeFortran03 = 0x0022,      ///< ISO Fortran 2003.
-  eLanguageTypeFortran08 = 0x0023,      ///< ISO Fortran 2008.
+  /// OpenCL.
+  eLanguageTypeOpenCL = 0x0015,
+  /// Go.
+  eLanguageTypeGo = 0x0016,
+  /// Modula 3.
+  eLanguageTypeModula3 = 0x0017,
+  /// Haskell.
+  eLanguageTypeHaskell = 0x0018,
+  /// ISO C++:2003.
+  eLanguageTypeC_plus_plus_03 = 0x0019,
+  /// ISO C++:2011.
+  eLanguageTypeC_plus_plus_11 = 0x001a,
+  /// OCaml.
+  eLanguageTypeOCaml = 0x001b,
+  /// Rust.
+  eLanguageTypeRust = 0x001c,
+  /// ISO C:2011.
+  eLanguageTypeC11 = 0x001d,
+  /// Swift.
+  eLanguageTypeSwift = 0x001e,
+  /// Julia.
+  eLanguageTypeJulia = 0x001f,
+  /// Dylan.
+  eLanguageTypeDylan = 0x0020,
+  /// ISO C++:2014.
+  eLanguageTypeC_plus_plus_14 = 0x0021,
+  /// ISO Fortran 2003.
+  eLanguageTypeFortran03 = 0x0022,
+  /// ISO Fortran 2008.
+  eLanguageTypeFortran08 = 0x0023,
   eLanguageTypeRenderScript = 0x0024,
   eLanguageTypeBLISS = 0x0025,
   eLanguageTypeKotlin = 0x0026,
   eLanguageTypeZig = 0x0027,
   eLanguageTypeCrystal = 0x0028,
-  eLanguageTypeC_plus_plus_17 = 0x002a, ///< ISO C++:2017.
-  eLanguageTypeC_plus_plus_20 = 0x002b, ///< ISO C++:2020.
+  /// ISO C++:2017.
+  eLanguageTypeC_plus_plus_17 = 0x002a,
+  /// ISO C++:2020.
+  eLanguageTypeC_plus_plus_20 = 0x002b,
   eLanguageTypeC17 = 0x002c,
   eLanguageTypeFortran18 = 0x002d,
   eLanguageTypeAda2005 = 0x002e,
@@ -541,7 +642,8 @@ enum LanguageType {
   // assumes these can be used as indexes into array language_names, and
   // Language::SetLanguageFromCString and Language::AsCString assume these can
   // be used as indexes into array g_languages.
-  eLanguageTypeMipsAssembler, ///< Mips_Assembler.
+  /// Mips_Assembler.
+  eLanguageTypeMipsAssembler,
   eNumLanguageTypes
 };
 
@@ -721,8 +823,9 @@ enum SymbolType {
   eSymbolTypeLineHeader,
   eSymbolTypeScopeBegin,
   eSymbolTypeScopeEnd,
-  eSymbolTypeAdditional, ///< When symbols take more than one entry, the extra
-                         ///< entries get this type
+  /// When symbols take more than one entry, the extra
+  /// entries get this type
+  eSymbolTypeAdditional,
   eSymbolTypeCompiler,
   eSymbolTypeInstrumentation,
   eSymbolTypeUndefined,
@@ -735,20 +838,26 @@ enum SymbolType {
 enum SectionType {
   eSectionTypeInvalid,
   eSectionTypeCode,
-  eSectionTypeContainer, ///< The section contains child sections
+  /// The section contains child sections
+  eSectionTypeContainer,
   eSectionTypeData,
-  eSectionTypeDataCString,         ///< Inlined C string data
-  eSectionTypeDataCStringPointers, ///< Pointers to C string data
-  eSectionTypeDataSymbolAddress,   ///< Address of a symbol in the symbol table
+  /// Inlined C string data
+  eSectionTypeDataCString,
+  /// Pointers to C string data
+  eSectionTypeDataCStringPointers,
+  /// Address of a symbol in the symbol table
+  eSectionTypeDataSymbolAddress,
   eSectionTypeData4,
   eSectionTypeData8,
   eSectionTypeData16,
   eSectionTypeDataPointers,
   eSectionTypeDebug,
   eSectionTypeZeroFill,
-  eSectionTypeDataObjCMessageRefs, ///< Pointer to function pointer + selector
-  eSectionTypeDataObjCCFStrings,   ///< Objective-C const CFString/NSString
-                                   ///< objects
+  /// Pointer to function pointer + selector
+  eSectionTypeDataObjCMessageRefs,
+  /// Objective-C const CFString/NSString
+  /// objects
+  eSectionTypeDataObjCCFStrings,
   eSectionTypeDWARFDebugAbbrev,
   eSectionTypeDWARFDebugAddr,
   eSectionTypeDWARFDebugAranges,
@@ -768,25 +877,36 @@ enum SectionType {
   eSectionTypeDWARFAppleTypes,
   eSectionTypeDWARFAppleNamespaces,
   eSectionTypeDWARFAppleObjC,
-  eSectionTypeELFSymbolTable,       ///< Elf SHT_SYMTAB section
-  eSectionTypeELFDynamicSymbols,    ///< Elf SHT_DYNSYM section
-  eSectionTypeELFRelocationEntries, ///< Elf SHT_REL or SHT_REL section
-  eSectionTypeELFDynamicLinkInfo,   ///< Elf SHT_DYNAMIC section
+  /// Elf SHT_SYMTAB section
+  eSectionTypeELFSymbolTable,
+  /// Elf SHT_DYNSYM section
+  eSectionTypeELFDynamicSymbols,
+  /// Elf SHT_REL or SHT_REL section
+  eSectionTypeELFRelocationEntries,
+  /// Elf SHT_DYNAMIC section
+  eSectionTypeELFDynamicLinkInfo,
   eSectionTypeEHFrame,
   eSectionTypeARMexidx,
   eSectionTypeARMextab,
-  eSectionTypeCompactUnwind, ///< compact unwind section in Mach-O,
-                             ///< __TEXT,__unwind_info
+  /// compact unwind section in Mach-O,
+  /// __TEXT,__unwind_info
+  eSectionTypeCompactUnwind,
   eSectionTypeGoSymtab,
-  eSectionTypeAbsoluteAddress, ///< Dummy section for symbols with absolute
-                               ///< address
+  /// Dummy section for symbols with absolute
+  /// address
+  eSectionTypeAbsoluteAddress,
   eSectionTypeDWARFGNUDebugAltLink,
-  eSectionTypeDWARFDebugTypes, ///< DWARF .debug_types section
-  eSectionTypeDWARFDebugNames, ///< DWARF v5 .debug_names
+  /// DWARF .debug_types section
+  eSectionTypeDWARFDebugTypes,
+  /// DWARF v5 .debug_names
+  eSectionTypeDWARFDebugNames,
   eSectionTypeOther,
-  eSectionTypeDWARFDebugLineStr,  ///< DWARF v5 .debug_line_str
-  eSectionTypeDWARFDebugRngLists, ///< DWARF v5 .debug_rnglists
-  eSectionTypeDWARFDebugLocLists, ///< DWARF v5 .debug_loclists
+  /// DWARF v5 .debug_line_str
+  eSectionTypeDWARFDebugLineStr,
+  /// DWARF v5 .debug_rnglists
+  eSectionTypeDWARFDebugRngLists,
+  /// DWARF v5 .debug_loclists
+  eSectionTypeDWARFDebugLocLists,
   eSectionTypeDWARFDebugAbbrevDwo,
   eSectionTypeDWARFDebugInfoDwo,
   eSectionTypeDWARFDebugStrDwo,
@@ -810,24 +930,23 @@ FLAGS_ENUM(EmulateInstructionOptions){
 
 FLAGS_ENUM(FunctionNameType){
     eFunctionNameTypeNone = 0u,
-    eFunctionNameTypeAuto =
-        (1u << 1), ///< Automatically figure out which FunctionNameType
-                   ///< bits to set based on the function name.
-    eFunctionNameTypeFull = (1u << 2), ///< The function name.
-    ///< For C this is the same as just the name of the function For C++ this is
-    ///< the mangled or demangled version of the mangled name. For ObjC this is
-    ///< the full function signature with the + or - and the square brackets and
-    ///< the class and selector
-    eFunctionNameTypeBase = (1u
-                             << 3), ///< The function name only, no namespaces
-                                    ///< or arguments and no class
-                                    ///< methods or selectors will be searched.
-    eFunctionNameTypeMethod = (1u << 4), ///< Find function by method name (C++)
-                                         ///< with no namespace or arguments
-    eFunctionNameTypeSelector =
-        (1u << 5), ///< Find function by selector name (ObjC) names
-    eFunctionNameTypeAny =
-        eFunctionNameTypeAuto ///< DEPRECATED: use eFunctionNameTypeAuto
+    /// Automatically figure out which FunctionNameType bits to set based on
+    /// the function name.
+    eFunctionNameTypeAuto = (1u << 1),
+    /// The function name. For C this is the same as just the name of the
+    /// function. For C++ this is the mangled or demangled version of the
+    /// mangled name. For ObjC this is the full function signature with the +
+    /// or - and the square brackets and the class and selector.
+    eFunctionNameTypeFull = (1u << 2),
+    /// The function name only, no namespaces or arguments and no class
+    /// methods or selectors will be searched.
+    eFunctionNameTypeBase = (1u << 3),
+    /// Find function by method name (C++) with no namespace or arguments.
+    eFunctionNameTypeMethod = (1u << 4),
+    /// Find function by selector name (ObjC) names.
+    eFunctionNameTypeSelector = (1u << 5),
+    /// DEPRECATED: use eFunctionNameTypeAuto.
+    eFunctionNameTypeAny = eFunctionNameTypeAuto
 };
 LLDB_MARK_AS_BITMASK_ENUM(FunctionNameType)
 
@@ -1118,34 +1237,48 @@ enum GdbSignal {
 /// related to LLDB on the current host machine. Most files are
 /// relative to LLDB or are in known locations.
 enum PathType {
-  ePathTypeLLDBShlibDir, ///< The directory where the lldb.so (unix) or LLDB
-                         ///< mach-o file in LLDB.framework (MacOSX) exists
-  ePathTypeSupportExecutableDir, ///< Find LLDB support executable directory
-                                 ///< (debugserver, etc)
-  ePathTypeHeaderDir,            ///< Find LLDB header file directory
-  ePathTypePythonDir,            ///< Find Python modules (PYTHONPATH) directory
-  ePathTypeLLDBSystemPlugins,    ///< System plug-ins directory
-  ePathTypeLLDBUserPlugins,      ///< User plug-ins directory
-  ePathTypeLLDBTempSystemDir, ///< The LLDB temp directory for this system that
-                              ///< will be cleaned up on exit
-  ePathTypeGlobalLLDBTempSystemDir, ///< The LLDB temp directory for this
-                                    ///< system, NOT cleaned up on a process
-                                    ///< exit.
-  ePathTypeClangDir ///< Find path to Clang builtin headers
+  /// The directory where the lldb.so (unix) or LLDB
+  /// mach-o file in LLDB.framework (MacOSX) exists
+  ePathTypeLLDBShlibDir,
+  /// Find LLDB support executable directory
+  /// (debugserver, etc)
+  ePathTypeSupportExecutableDir,
+  /// Find LLDB header file directory
+  ePathTypeHeaderDir,
+  /// Find Python modules (PYTHONPATH) directory
+  ePathTypePythonDir,
+  /// System plug-ins directory
+  ePathTypeLLDBSystemPlugins,
+  /// User plug-ins directory
+  ePathTypeLLDBUserPlugins,
+  /// The LLDB temp directory for this system that
+  /// will be cleaned up on exit
+  ePathTypeLLDBTempSystemDir,
+  /// The LLDB temp directory for this
+  /// system, NOT cleaned up on a process
+  /// exit.
+  ePathTypeGlobalLLDBTempSystemDir,
+  /// Find path to Clang builtin headers
+  ePathTypeClangDir
 };
 
 /// Kind of member function.
 ///
 /// Used by the type system.
 enum MemberFunctionKind {
-  eMemberFunctionKindUnknown = 0,    ///< Not sure what the type of this is
-  eMemberFunctionKindConstructor,    ///< A function used to create instances
-  eMemberFunctionKindDestructor,     ///< A function used to tear down existing
-                                     ///< instances
-  eMemberFunctionKindInstanceMethod, ///< A function that applies to a specific
-                                     ///< instance
-  eMemberFunctionKindStaticMethod ///< A function that applies to a type rather
-                                  ///< than any instance
+  /// Not sure what the type of this is
+  eMemberFunctionKindUnknown = 0,
+  /// A function used to create instances
+  eMemberFunctionKindConstructor,
+  /// A function used to tear down existing
+  /// instances
+  eMemberFunctionKindDestructor,
+  /// A function that applies to a specific
+  /// instance
+  eMemberFunctionKindInstanceMethod,
+  /// A function that applies to a type rather
+  /// than any instance
+  eMemberFunctionKindStaticMethod
 };
 
 /// String matching algorithm used by SBTarget.
@@ -1367,10 +1500,12 @@ enum CompletionType {
 /// Specifies if children need to be re-computed
 /// after a call to \ref SyntheticChildrenFrontEnd::Update.
 enum ChildCacheState {
-  eRefetch = 0, ///< Children need to be recomputed dynamically.
+  /// Children need to be recomputed dynamically.
+  eRefetch = 0,
 
-  eReuse = 1, ///< Children did not change and don't need to be recomputed;
-              ///< re-use what we computed the last time we called Update.
+  /// Children did not change and don't need to be recomputed;
+  /// re-use what we computed the last time we called Update.
+  eReuse = 1,
 };
 
 enum SymbolDownload {
@@ -1408,9 +1543,11 @@ enum DebuggerBroadcastBit {
   eBroadcastBitWarning = (1 << 1),
   eBroadcastBitError = (1 << 2),
   eBroadcastSymbolChange = (1 << 3),
-  eBroadcastBitProgressCategory = (1 << 4), ///< Deprecated
+  /// Deprecated
+  eBroadcastBitProgressCategory = (1 << 4),
   eBroadcastBitExternalProgress = (1 << 5),
-  eBroadcastBitExternalProgressCategory = (1 << 6), ///< Deprecated
+  /// Deprecated
+  eBroadcastBitExternalProgressCategory = (1 << 6),
 };
 
 /// Used for expressing severity in logs and diagnostics.


### PR DESCRIPTION
Convert doxygen comments to precede the enumerator to which they apply (using `///`). This placement of documentation is more consistent with how functions and classes are documented. Additionally, with the column limit, the documentation was quite crammed as it was. Lastly, comments have been reflowed, so that make full use of horizontal space.

Assisted-by: claude