### PR TITLE
[AArch64] Minor rearrangement of cost instructions. NFC

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
@@ -4405,6 +4405,35 @@ InstructionCost AArch64TTIImpl::getArithmeticInstrCost(
   default:
     return BaseT::getArithmeticInstrCost(Opcode, Ty, CostKind, Op1Info,
                                          Op2Info);
+  case ISD::ADD:
+  case ISD::SUB:
+    return LT.first; // Also works for i128
+  case ISD::MUL:
+    if (LT.second == MVT::v2i64) {
+      // When SVE is available, then we can lower the v2i64 operation using
+      // the SVE mul instruction, which has a lower cost.
+      if (ST->hasSVE())
+        return LT.first;
+
+      // When SVE is not available, there is no MUL.2d instruction,
+      // which means mul <2 x i64> is expensive as elements are extracted
+      // from the vectors and the muls scalarized.
+      // As getScalarizationOverhead is a bit too pessimistic, we
+      // estimate the cost for a i64 vector directly here, which is:
+      // - four 2-cost i64 extracts,
+      // - two 2-cost i64 inserts, and
+      // - two 1-cost muls.
+      // So, for a v2i64 with LT.First = 1 the cost is 14, and for a v4i64 with
+      // LT.first = 2 the cost is 28.
+      return cast<VectorType>(Ty)->getElementCount().getKnownMinValue() *
+             (getArithmeticInstrCost(Opcode, Ty->getScalarType(), CostKind) +
+              getVectorInstrCost(Instruction::ExtractElement, Ty, CostKind, -1,
+                                 nullptr, nullptr) *
+                  2 +
+              getVectorInstrCost(Instruction::InsertElement, Ty, CostKind, -1,
+                                 nullptr, nullptr));
+    }
+    return LT.first;
   case ISD::SREM:
   case ISD::SDIV:
     /*
@@ -4619,33 +4648,6 @@ InstructionCost AArch64TTIImpl::getArithmeticInstrCost(
     }
     return Cost;
   }
-  case ISD::MUL:
-    // When SVE is available, then we can lower the v2i64 operation using
-    // the SVE mul instruction, which has a lower cost.
-    if (LT.second == MVT::v2i64 && ST->hasSVE())
-      return LT.first;
-
-    // When SVE is not available, there is no MUL.2d instruction,
-    // which means mul <2 x i64> is expensive as elements are extracted
-    // from the vectors and the muls scalarized.
-    // As getScalarizationOverhead is a bit too pessimistic, we
-    // estimate the cost for a i64 vector directly here, which is:
-    // - four 2-cost i64 extracts,
-    // - two 2-cost i64 inserts, and
-    // - two 1-cost muls.
-    // So, for a v2i64 with LT.First = 1 the cost is 14, and for a v4i64 with
-    // LT.first = 2 the cost is 28.
-    if (LT.second != MVT::v2i64)
-      return LT.first;
-    return cast<VectorType>(Ty)->getElementCount().getKnownMinValue() *
-           (getArithmeticInstrCost(Opcode, Ty->getScalarType(), CostKind) +
-            getVectorInstrCost(Instruction::ExtractElement, Ty, CostKind, -1,
-                               nullptr, nullptr) *
-                2 +
-            getVectorInstrCost(Instruction::InsertElement, Ty, CostKind, -1,
-                               nullptr, nullptr));
-  case ISD::ADD:
-  case ISD::SUB:
   case ISD::XOR:
   case ISD::OR:
   case ISD::AND:


### PR DESCRIPTION
This just moves the existing cost checks to a more standard order and cleans up
how v2i64 is processed.