### PR TITLE
[doxygen] try again to handle doxygen everywhere

### DIFF
--- a/bolt/docs/CMakeLists.txt
+++ b/bolt/docs/CMakeLists.txt
@@ -1,5 +1,3 @@
-
-find_package(Doxygen)
 if (DOXYGEN_FOUND)
 if (LLVM_ENABLE_DOXYGEN)
   set(abs_top_srcdir ${CMAKE_CURRENT_SOURCE_DIR})
@@ -48,7 +46,6 @@ if (LLVM_ENABLE_DOXYGEN)
     set(bolt_doxygen_qhp_cust_filter_attrs "")
   endif()
 
-  include(HandleDoxygen)
   llvm_configure_doxygen()
 
   set(abs_top_srcdir)

--- a/clang-tools-extra/docs/CMakeLists.txt
+++ b/clang-tools-extra/docs/CMakeLists.txt
@@ -46,7 +46,6 @@ if (DOXYGEN_FOUND)
       set(clang_tools_doxygen_qhp_cust_filter_attrs "")
     endif()
 
-    include(HandleDoxygen)
     llvm_configure_doxygen()
 
     set(abs_top_srcdir)

--- a/clang/docs/CMakeLists.txt
+++ b/clang/docs/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 if (DOXYGEN_FOUND)
 if (LLVM_ENABLE_DOXYGEN)
   set(abs_srcdir ${CMAKE_CURRENT_SOURCE_DIR})
@@ -47,7 +46,6 @@ if (LLVM_ENABLE_DOXYGEN)
     set(clang_doxygen_qhp_cust_filter_attrs "")
   endif()
 
-  include(HandleDoxygen)
   llvm_configure_doxygen()
 
   set(abs_top_srcdir)

--- a/cmake/Modules/HandleDoxygen.cmake
+++ b/cmake/Modules/HandleDoxygen.cmake
@@ -20,6 +20,11 @@ if (LLVM_ENABLE_DOXYGEN)
   llvm_find_program(dot)
   find_package(Doxygen REQUIRED)
   message(STATUS "Doxygen enabled (${DOXYGEN_VERSION}).")
+  # Create a global aggregate doxygen target for generating llvm and any/all
+  # subprojects doxygen documentation.
+  if (LLVM_BUILD_DOCS)
+    add_custom_target(doxygen ALL)
+  endif()
 
   if (DOXYGEN_FOUND)
     option(LLVM_DOXYGEN_EXTERNAL_SEARCH "Enable doxygen external search." OFF)

--- a/flang/CMakeLists.txt
+++ b/flang/CMakeLists.txt
@@ -241,9 +241,6 @@ if (FLANG_STANDALONE_BUILD)
   else()
     add_custom_target(check-all DEPENDS check-flang )
   endif()
-  if (LLVM_BUILD_DOCS)
-    add_custom_target(doxygen-flang ALL)
-  endif()
 
 else()
   option(FLANG_INCLUDE_TESTS
@@ -305,6 +302,7 @@ list(INSERT CMAKE_MODULE_PATH 0
   "${FLANG_SOURCE_DIR}/cmake/modules"
   "${LLVM_COMMON_CMAKE_UTILS}/Modules"
   )
+
 include(AddFlang)
 
 if (NOT DEFAULT_SYSROOT)
@@ -516,6 +514,9 @@ endif()
 
 option(FLANG_INCLUDE_DOCS "Generate build targets for the Flang docs."
        ${LLVM_INCLUDE_DOCS})
+if(FLANG_STANDALONE_BUILD)
+  include(HandleDoxygen)
+endif()
 if (FLANG_INCLUDE_DOCS)
   add_subdirectory(docs)
 endif()

--- a/flang/docs/CMakeLists.txt
+++ b/flang/docs/CMakeLists.txt
@@ -1,5 +1,3 @@
-
-find_package(Doxygen)
 if (DOXYGEN_FOUND)
 if (LLVM_ENABLE_DOXYGEN)
   set(abs_top_srcdir ${CMAKE_CURRENT_SOURCE_DIR})
@@ -48,7 +46,6 @@ if (LLVM_ENABLE_DOXYGEN)
     set(flang_doxygen_qhp_cust_filter_attrs "")
   endif()
 
-  include(HandleDoxygen)
   llvm_configure_doxygen()
 
   set(abs_top_srcdir)

--- a/lldb/CMakeLists.txt
+++ b/lldb/CMakeLists.txt
@@ -34,6 +34,7 @@ if(LLDB_BUILT_STANDALONE)
   set(CMAKE_CXX_EXTENSIONS NO)
 
   include(LLDBStandalone)
+  include(HandleDoxygen)
 endif()
 
 include(LLDBConfig)

--- a/lldb/docs/CMakeLists.txt
+++ b/lldb/docs/CMakeLists.txt
@@ -1,11 +1,8 @@
-include(FindDoxygen)
-
 if(DOXYGEN_FOUND)
   set(abs_top_srcdir ${CMAKE_CURRENT_SOURCE_DIR}/..)
   set(DOT dot)
   set(PACKAGE_VERSION mainline)
   set(abs_top_builddir ..)
-  include(HandleDoxygen)
   llvm_configure_doxygen()
 
   add_custom_target(lldb-cpp-doc

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -927,17 +927,6 @@ option (LLVM_ENABLE_BINDINGS "Build bindings." ON)
 option (LLVM_ENABLE_TELEMETRY "Enable the telemetry library. If set to OFF, library cannot be enabled after build (eg., at runtime)" ON)
 
 include(HandleDoxygen)
-if (LLVM_ENABLE_DOXYGEN)
-  if (DOXYGEN_FOUND)
-    # If we find doxygen and we want to enable doxygen by default create a
-    # global aggregate doxygen target for generating llvm and any/all
-    # subprojects doxygen documentation.
-    if (LLVM_BUILD_DOCS)
-      add_custom_target(doxygen ALL)
-    endif()
-  endif()
-endif()
-
 
 set(LLVM_INSTALL_DOXYGEN_HTML_DIR "${CMAKE_INSTALL_DOCDIR}/llvm/doxygen-html"
     CACHE STRING "Doxygen-generated HTML documentation install directory")

--- a/llvm/docs/CMakeLists.txt
+++ b/llvm/docs/CMakeLists.txt
@@ -56,7 +56,6 @@ if (LLVM_ENABLE_DOXYGEN)
     set(llvm_doxygen_qhp_cust_filter_attrs "")
   endif()
 
-  include(HandleDoxygen)
   llvm_configure_doxygen()
 
   set(abs_top_srcdir)

--- a/mlir/docs/CMakeLists.txt
+++ b/mlir/docs/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 if (DOXYGEN_FOUND)
 if (LLVM_ENABLE_DOXYGEN)
   set(abs_top_srcdir ${CMAKE_CURRENT_SOURCE_DIR})
@@ -47,7 +46,6 @@ if (LLVM_ENABLE_DOXYGEN)
     set(mlir_doxygen_qhp_cust_filter_attrs "")
   endif()
 
-  include(HandleDoxygen)
   llvm_configure_doxygen()
 
   set(abs_top_srcdir)

--- a/openmp/docs/CMakeLists.txt
+++ b/openmp/docs/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 if (DOXYGEN_FOUND)
 if (LLVM_ENABLE_DOXYGEN)
   set(abs_srcdir ${CMAKE_CURRENT_SOURCE_DIR})
@@ -47,7 +46,6 @@ if (LLVM_ENABLE_DOXYGEN)
     set(openmp_doxygen_qhp_cust_filter_attrs "")
   endif()
 
-  include(HandleDoxygen)
   llvm_configure_doxygen()
 
   set(abs_top_srcdir)

--- a/polly/docs/CMakeLists.txt
+++ b/polly/docs/CMakeLists.txt
@@ -46,7 +46,6 @@ if (LLVM_ENABLE_DOXYGEN)
     set(polly_doxygen_qhp_cust_filter_attrs "")
   endif()
 
-  include(HandleDoxygen)
   llvm_configure_doxygen()
 
   set(abs_top_srcdir)

--- a/runtimes/CMakeLists.txt
+++ b/runtimes/CMakeLists.txt
@@ -296,7 +296,9 @@ option(LLVM_INCLUDE_DOCS "Generate build targets for the runtimes documentation.
 option(LLVM_ENABLE_SPHINX "Use Sphinx to generate the runtimes documentation." OFF)
 option(RUNTIMES_EXECUTE_ONLY_CODE "Compile runtime libraries as execute-only." OFF)
 
-include(HandleDoxygen)
+if(NOT HAVE_LLVM_LIT)
+  include(HandleDoxygen)
+endif()
 
 if (RUNTIMES_EXECUTE_ONLY_CODE)
   # If a target doesn't support or recognise -mexecute-only, Clang will simply ignore the flag.


### PR DESCRIPTION
I hate dealing with cmake configuration. The previous attempt (b7da9565017e32c18b927a7637714d1b660b558d) still broke standalone builds. Now I have locally tested standalone flang, runtimes (with openmp), lldb, combined builds, and the utils script. Hopefully that covers everything this time, and gets everything into a more consistent state (always using the HandleDoxygen script in the same way, included exactly once as required by the cmake design).

c.f. https://lab.llvm.org/buildbot/#/builders/111/builds/3679/steps/9/logs/stdio