### PR TITLE
[bazel][libc] Allow passing additional sources to libc_release_library

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
@@ -169,6 +169,7 @@ def libc_release_library(
         name,
         libc_functions,
         weak_symbols = [],
+        srcs = [],
         **kwargs):
     """Create the release version of a libc library.
 
@@ -177,6 +178,7 @@ def libc_release_library(
         libc_functions: List of functions to include in the library. They should be
             created by libc_function macro.
         weak_symbols: List of function names that should be marked as weak symbols.
+        srcs: Additional sources for the cc_library.
         **kwargs: Other arguments relevant to cc_library.
     """
 
@@ -200,7 +202,7 @@ def libc_release_library(
     ]
     cc_library(
         name = name,
-        srcs = [":" + name + "_srcs"],
+        srcs = [":" + name + "_srcs"] + srcs,
         copts = libc_common_copts() + libc_release_copts(),
         local_defines = weak_attributes + LIBC_CONFIGURE_OPTIONS,
         deps = [


### PR DESCRIPTION
This rule currently only accepts dependencies created by `libc_function`, which are then traversed via `_get_libc_info_aspect` to gather all transitive C++ sources/headers. Processing all the `libc_function` dependencies for all LLVM-libc functions ends up costing a non-trivial amount of Bazel analysis memory. This PR allows callers to directly provide sources to bypass this if passing sources than needn't be in a `libc_function`.