### PR TITLE
[libc++] Diagnose unused variables of container types

### DIFF
--- a/libcxx/docs/ReleaseNotes/24.rst
+++ b/libcxx/docs/ReleaseNotes/24.rst
@@ -49,7 +49,6 @@ Implemented Papers
 Improvements and New Features
 -----------------------------
 
-
 Deprecations and Removals
 -------------------------
 
@@ -62,6 +61,9 @@ Potentially breaking changes
 - In LLVM 23, libc++ dropped a lot of transitive includes in all language modes. This improves compile time significantly,
   but causes programs which rely on these includes to not compile anymore. The ``_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23``
   macro that was provided in LLVM 23 to ease the transition has been removed in this release.
+
+- Unused objects of containers are now diagnosed. To ease the transition ``_LIBCPP_DISABLE_UNUSED_STRUCT_WARNINGS`` can
+  be defined as an escape hatch. This escape hatch will be removed in LLVM 24.
 
 Announcements About Future Releases
 -----------------------------------

--- a/libcxx/include/__bit_reference
+++ b/libcxx/include/__bit_reference
@@ -274,7 +274,7 @@ struct __bit_array {
 };
 
 template <class _Cp, bool _IsConst, typename _Cp::__storage_type>
-class __bit_iterator {
+class _LIBCPP_WARN_UNUSED __bit_iterator {
 public:
   using difference_type = typename __size_difference_type_traits<_Cp>::difference_type;
   using value_type      = bool;

--- a/libcxx/include/__configuration/attributes.h
+++ b/libcxx/include/__configuration/attributes.h
@@ -473,4 +473,11 @@
 #  define _LIBCPP_DISABLE_POINTER_FIELD_PROTECTION
 #endif
 
+// TODO(LLVM 25): Remove this escape hatch
+#ifndef _LIBCPP_DISABLE_UNUSED_STRUCT_WARNINGS
+#  define _LIBCPP_WARN_UNUSED [[__gnu__::__warn_unused__]]
+#else
+#  define _LIBCPP_WARN_UNUSED
+#endif
+
 #endif // _LIBCPP___CONFIGURATION_ATTRIBUTES_H

--- a/libcxx/include/__hash_table
+++ b/libcxx/include/__hash_table
@@ -289,7 +289,7 @@ private:
 };
 
 template <class _NodePtr>
-class __hash_const_iterator {
+class _LIBCPP_WARN_UNUSED __hash_const_iterator {
   static_assert(!is_const<typename pointer_traits<_NodePtr>::element_type>::value, "");
   typedef __hash_node_types<_NodePtr> _NodeTypes;
   typedef _NodePtr __node_pointer;

--- a/libcxx/include/__iterator/wrap_iter.h
+++ b/libcxx/include/__iterator/wrap_iter.h
@@ -31,7 +31,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Iter>
-class __wrap_iter {
+class _LIBCPP_WARN_UNUSED __wrap_iter {
 public:
   typedef typename iterator_traits<_Iter>::value_type value_type;
   typedef typename iterator_traits<_Iter>::difference_type difference_type;

--- a/libcxx/include/__tree
+++ b/libcxx/include/__tree
@@ -802,7 +802,7 @@ struct __specialized_algorithm<
 #endif
 
 template <class _Tp, class _NodePtr, class _DiffType>
-class __tree_const_iterator {
+class _LIBCPP_WARN_UNUSED __tree_const_iterator {
   using _NodeTypes _LIBCPP_NODEBUG = __tree_node_types<_NodePtr>;
   // NOLINTNEXTLINE(libcpp-nodebug-on-aliases) lldb relies on this alias for pretty printing
   using __node_pointer                      = _NodePtr;

--- a/libcxx/include/__vector/vector.h
+++ b/libcxx/include/__vector/vector.h
@@ -86,7 +86,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, class _Allocator /* = allocator<_Tp> */>
-class vector {
+class _LIBCPP_WARN_UNUSED vector {
   using __base_type _LIBCPP_NODEBUG  = __vector_layout<_Tp, _Allocator>;
   using __bound_type _LIBCPP_NODEBUG = typename __base_type::__bound_type;
   using _SplitBuffer _LIBCPP_NODEBUG = typename __base_type::_SplitBuffer;

--- a/libcxx/include/__vector/vector_bool.h
+++ b/libcxx/include/__vector/vector_bool.h
@@ -77,7 +77,7 @@ struct __has_storage_type<vector<bool, _Allocator> > {
 };
 
 template <class _Allocator>
-class vector<bool, _Allocator> {
+class _LIBCPP_WARN_UNUSED vector<bool, _Allocator> {
 public:
   using __self _LIBCPP_NODEBUG         = vector;
   using value_type                     = bool;

--- a/libcxx/include/deque
+++ b/libcxx/include/deque
@@ -289,7 +289,7 @@ template <class _ValueType,
               __deque_block_size<_ValueType, _DiffType>::value
 #  endif
           >
-class __deque_iterator {
+class _LIBCPP_WARN_UNUSED __deque_iterator {
   using __map_iterator _LIBCPP_NODEBUG = __rebind_pointer_t<_Pointer, const __rebind_pointer_t<_Pointer, _ValueType> >;
 
 // TODO(LLVM 25): Remove this check
@@ -502,7 +502,7 @@ const _DiffType __deque_iterator<_ValueType, _Pointer, _Reference, _MapPointer, 
     __deque_block_size<_ValueType, _DiffType>::value;
 
 template <class _Tp, class _Allocator /*= allocator<_Tp>*/>
-class deque {
+class _LIBCPP_WARN_UNUSED deque {
   template <class _Up, class _Alloc>
   using __split_buffer _LIBCPP_NODEBUG = std::__split_buffer<_Up, _Alloc, __split_buffer_pointer_layout>;
 

--- a/libcxx/include/forward_list
+++ b/libcxx/include/forward_list
@@ -336,7 +336,7 @@ template <class _NodeConstPtr>
 class __forward_list_const_iterator;
 
 template <class _NodePtr>
-class __forward_list_iterator {
+class _LIBCPP_WARN_UNUSED __forward_list_iterator {
   typedef __forward_node_traits<_NodePtr> __traits;
   typedef typename __traits::__node_type __node_type;
   typedef typename __traits::__begin_node __begin_node_type;
@@ -396,7 +396,7 @@ public:
 };
 
 template <class _NodeConstPtr>
-class __forward_list_const_iterator {
+class _LIBCPP_WARN_UNUSED __forward_list_const_iterator {
   static_assert(!is_const<typename pointer_traits<_NodeConstPtr>::element_type>::value, "");
   typedef _NodeConstPtr _NodePtr;
 
@@ -625,7 +625,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX26 void __forward_list_base<_Tp, _Alloc>::clear() _NO
 }
 
 template <class _Tp, class _Alloc /*= allocator<_Tp>*/>
-class forward_list : private __forward_list_base<_Tp, _Alloc> {
+class _LIBCPP_WARN_UNUSED forward_list : private __forward_list_base<_Tp, _Alloc> {
   typedef __forward_list_base<_Tp, _Alloc> __base;
   typedef typename __base::__node_allocator __node_allocator;
   typedef typename __base::__node_type __node_type;

--- a/libcxx/include/list
+++ b/libcxx/include/list
@@ -344,7 +344,7 @@ template <class _Tp, class _VoidPtr>
 class __list_const_iterator;
 
 template <class _Tp, class _VoidPtr>
-class __list_iterator {
+class _LIBCPP_WARN_UNUSED __list_iterator {
   typedef __list_node_pointer_traits<_Tp, _VoidPtr> _NodeTraits;
   typedef typename _NodeTraits::__base_pointer __base_pointer;
 
@@ -407,7 +407,7 @@ public:
 };
 
 template <class _Tp, class _VoidPtr>
-class __list_const_iterator {
+class _LIBCPP_WARN_UNUSED __list_const_iterator {
   typedef __list_node_pointer_traits<_Tp, _VoidPtr> _NodeTraits;
   typedef typename _NodeTraits::__base_pointer __base_pointer;
 
@@ -672,7 +672,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX26 void __list_imp<_Tp, _Alloc>::swap(__list_imp& __c
 }
 
 template <class _Tp, class _Alloc /*= allocator<_Tp>*/>
-class list : private __list_imp<_Tp, _Alloc> {
+class _LIBCPP_WARN_UNUSED list : private __list_imp<_Tp, _Alloc> {
   typedef __list_imp<_Tp, _Alloc> __base;
   typedef typename __base::__node_type __node_type;
   typedef typename __base::__node_allocator __node_allocator;

--- a/libcxx/include/map
+++ b/libcxx/include/map
@@ -776,7 +776,7 @@ template <class _Key, class _Tp>
 struct __value_type;
 
 template <class _TreeIterator>
-class __map_iterator {
+class _LIBCPP_WARN_UNUSED __map_iterator {
   _TreeIterator __i_;
 
 public:
@@ -853,7 +853,7 @@ struct __specialized_algorithm<_Alg, __iterator_pair<__map_iterator<_TreeIterato
 #  endif
 
 template <class _TreeIterator>
-class __map_const_iterator {
+class _LIBCPP_WARN_UNUSED __map_const_iterator {
   _TreeIterator __i_;
 
 public:
@@ -937,7 +937,7 @@ template <class _Key, class _Tp, class _Compare = less<_Key>, class _Allocator =
 class multimap;
 
 template <class _Key, class _Tp, class _Compare = less<_Key>, class _Allocator = allocator<pair<const _Key, _Tp> > >
-class map {
+class _LIBCPP_WARN_UNUSED map {
 public:
   // types:
   typedef _Key key_type;
@@ -1716,7 +1716,7 @@ struct __container_traits<map<_Key, _Tp, _Compare, _Allocator> > {
 };
 
 template <class _Key, class _Tp, class _Compare, class _Allocator>
-class multimap {
+class _LIBCPP_WARN_UNUSED multimap {
 public:
   // types:
   typedef _Key key_type;

--- a/libcxx/include/set
+++ b/libcxx/include/set
@@ -573,7 +573,7 @@ template <class _Key, class _Compare = less<_Key>, class _Allocator = allocator<
 class multiset;
 
 template <class _Key, class _Compare = less<_Key>, class _Allocator = allocator<_Key> >
-class set {
+class _LIBCPP_WARN_UNUSED set {
 public:
   // types:
   typedef _Key key_type;
@@ -1130,7 +1130,7 @@ struct __container_traits<set<_Key, _Compare, _Allocator> > {
 };
 
 template <class _Key, class _Compare, class _Allocator>
-class multiset {
+class _LIBCPP_WARN_UNUSED multiset {
 public:
   // types:
   typedef _Key key_type;

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -732,7 +732,7 @@ template <>
 struct __padding<0> {};
 
 template <class _CharT, class _Traits, class _Allocator>
-class basic_string {
+class _LIBCPP_WARN_UNUSED basic_string {
 public:
   using __self _LIBCPP_NODEBUG         = basic_string;
   using __self_view _LIBCPP_NODEBUG    = basic_string_view<_CharT, _Traits>;

--- a/libcxx/include/unordered_map
+++ b/libcxx/include/unordered_map
@@ -769,7 +769,7 @@ template <class _Key, class _Tp>
 struct __hash_value_type;
 
 template <class _HashIterator>
-class __hash_map_iterator {
+class _LIBCPP_WARN_UNUSED __hash_map_iterator {
   _HashIterator __i_;
 
   typedef __hash_node_types_from_iterator<_HashIterator> _NodeTypes;
@@ -820,7 +820,7 @@ public:
 };
 
 template <class _HashIterator>
-class __hash_map_const_iterator {
+class _LIBCPP_WARN_UNUSED __hash_map_const_iterator {
   _HashIterator __i_;
 
   typedef __hash_node_types_from_iterator<_HashIterator> _NodeTypes;
@@ -881,7 +881,7 @@ template <class _Key,
           class _Hash  = hash<_Key>,
           class _Pred  = equal_to<_Key>,
           class _Alloc = allocator<pair<const _Key, _Tp> > >
-class unordered_map {
+class _LIBCPP_WARN_UNUSED unordered_map {
 public:
   // types
   typedef _Key key_type;
@@ -1678,7 +1678,7 @@ template <class _Key,
           class _Hash  = hash<_Key>,
           class _Pred  = equal_to<_Key>,
           class _Alloc = allocator<pair<const _Key, _Tp> > >
-class unordered_multimap {
+class _LIBCPP_WARN_UNUSED unordered_multimap {
 public:
   // types
   typedef _Key key_type;

--- a/libcxx/include/unordered_set
+++ b/libcxx/include/unordered_set
@@ -591,7 +591,7 @@ template <class _Value, class _Hash, class _Pred, class _Alloc>
 class unordered_multiset;
 
 template <class _Value, class _Hash = hash<_Value>, class _Pred = equal_to<_Value>, class _Alloc = allocator<_Value> >
-class unordered_set {
+class _LIBCPP_WARN_UNUSED unordered_set {
 public:
   // types
   typedef _Value key_type;
@@ -1201,7 +1201,7 @@ struct __container_traits<unordered_set<_Value, _Hash, _Pred, _Alloc> > {
 };
 
 template <class _Value, class _Hash = hash<_Value>, class _Pred = equal_to<_Value>, class _Alloc = allocator<_Value> >
-class unordered_multiset {
+class _LIBCPP_WARN_UNUSED unordered_multiset {
 public:
   // types
   typedef _Value key_type;

--- a/libcxx/test/benchmarks/containers/sequence/sequence_container_benchmarks.h
+++ b/libcxx/test/benchmarks/containers/sequence/sequence_container_benchmarks.h
@@ -333,7 +333,6 @@ void sequence_container_benchmarks(std::string container) {
           };
 
           std::vector<Container> c(BatchSize, at_capacity(Container(in.begin(), in.end())));
-          std::vector<Container> const original = c;
 
           while (st.KeepRunningBatch(BatchSize)) {
             for (std::size_t i = 0; i != BatchSize; ++i) {

--- a/libcxx/test/libcxx/containers/associative/non_const_comparator.incomplete.verify.cpp
+++ b/libcxx/test/libcxx/containers/associative/non_const_comparator.incomplete.verify.cpp
@@ -33,6 +33,7 @@ void test_set() {
   struct KeyDerived : KeyBase {};
 
   C c; // ODR use it, which should be OK
+  (void)c;
 }
 
 template <template <typename...> class Container>
@@ -45,6 +46,7 @@ void test_map() {
   (void)dummy;
   struct KeyDerived : KeyBase {};
   C c;
+  (void)c;
 }
 
 void f() {

--- a/libcxx/test/libcxx/containers/associative/non_const_comparator.verify.cpp
+++ b/libcxx/test/libcxx/containers/associative/non_const_comparator.verify.cpp
@@ -32,17 +32,21 @@ void f() {
   {
     using C = std::set<int, BadCompare>;
     C s;
+    (void)s;
   }
   {
     using C = std::multiset<long, BadCompare>;
     C s;
+    (void)s;
   }
   {
     using C = std::map<int, int, BadCompare>;
     C s;
+    (void)s;
   }
   {
     using C = std::multimap<long, int, BadCompare>;
     C s;
+    (void)s;
   }
 }

--- a/libcxx/test/libcxx/containers/sequences/vector/robust_against_adl.pass.cpp
+++ b/libcxx/test/libcxx/containers/sequences/vector/robust_against_adl.pass.cpp
@@ -34,6 +34,7 @@ struct MyAlloc {
 
 int main(int, char**) {
   std::vector<bool, MyAlloc<bool>> vb;
+  (void)vb;
   // std::fill_n triggers ADL because __bit_iterator has the container type as a template argument
   // std::vector<bool, MyAlloc<bool>> wb(100);
 

--- a/libcxx/test/libcxx/containers/unord/non_const_comparator.incomplete.verify.cpp
+++ b/libcxx/test/libcxx/containers/unord/non_const_comparator.incomplete.verify.cpp
@@ -35,6 +35,7 @@ void test_set() {
   struct KeyDerived : KeyBase {};
 
   C c; // ODR use it, which should be OK
+  (void)c;
 }
 
 template <template <typename...> class Container>
@@ -47,6 +48,7 @@ void test_map() {
   (void)dummy;
   struct KeyDerived : KeyBase {};
   C c;
+  (void)c;
 }
 
 void f() {

--- a/libcxx/test/libcxx/containers/unord/non_const_comparator.verify.cpp
+++ b/libcxx/test/libcxx/containers/unord/non_const_comparator.verify.cpp
@@ -42,17 +42,21 @@ void f() {
   {
     using C = std::unordered_set<int, BadHash, BadEqual>;
     C s;
+    (void)s;
   }
   {
     using C = std::unordered_multiset<long, BadHash, BadEqual>;
     C s;
+    (void)s;
   }
   {
     using C = std::unordered_map<int, int, BadHash, BadEqual>;
     C s;
+    (void)s;
   }
   {
     using C = std::unordered_multimap<long, int, BadHash, BadEqual>;
     C s;
+    (void)s;
   }
 }

--- a/libcxx/test/libcxx/containers/unord/unord.set/missing_hash_specialization.verify.cpp
+++ b/libcxx/test/libcxx/containers/unord/unord.set/missing_hash_specialization.verify.cpp
@@ -47,6 +47,7 @@ int main(int, char**) {
   {
     using Set = std::unordered_set<VT>;
     Set s; // expected-error@__hash_table:* {{the specified hash does not meet the Hash requirements}}
+    (void)s;
 
     // FIXME: It would be great to suppress the below diagnostic all together.
     //        but for now it's sufficient that it appears last. However there is
@@ -56,14 +57,17 @@ int main(int, char**) {
   {
     using Set = std::unordered_set<int, BadHashNoCopy>;
     Set s; // expected-error@__hash_table:* {{the specified hash does not meet the Hash requirements}}
+    (void)s;
   }
   {
     using Set = std::unordered_set<int, BadHashNoCall>;
     Set s; // expected-error@__hash_table:* {{the specified hash does not meet the Hash requirements}}
+    (void)s;
   }
   {
     using Set = std::unordered_set<int, GoodHashNoDefault>;
     Set s(/*bucketcount*/ 42, GoodHashNoDefault(nullptr));
+    (void)s;
   }
 
   return 0;

--- a/libcxx/test/libcxx/diagnostics/unused_variables.compile.pass.cpp
+++ b/libcxx/test/libcxx/diagnostics/unused_variables.compile.pass.cpp
@@ -1,0 +1,87 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Make sure that we don't introduce new warnings on unused variables of libc++ classes if
+// _LIBCPP_DISABLE_UNUSED_STRUCT_WARNINGS is set.
+
+// ADDITIONAL_COMPILE_FLAGS: -D_LIBCPP_DISABLE_UNUSED_STRUCT_WARNINGS
+
+#include <deque>
+#include <forward_list>
+#include <list>
+#include <map>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "test_macros.h"
+
+void containers() {
+  std::deque<int> a;
+  std::forward_list<int> b;
+  std::list<int> c;
+  std::map<int, int> d;
+  std::multimap<int, int> e;
+  std::set<int> f;
+  std::multiset<int> g;
+  std::unordered_map<int, int> h;
+  std::unordered_multimap<int, int> i;
+  std::unordered_set<int> j;
+  std::unordered_multiset<int> k;
+  std::string l;
+  std::vector<int> m;
+  std::vector<bool> n;
+}
+
+void container_iterators() {
+  std::deque<int>::iterator a;
+#if TEST_STD_VER <= 23
+  std::forward_list<int>::iterator b;
+  std::list<int>::iterator c;
+  std::map<int, int>::iterator d;
+  std::multimap<int, int>::iterator e;
+  std::set<int>::iterator f;
+  std::multiset<int>::iterator g;
+#endif
+  std::unordered_map<int, int>::iterator h;
+  std::unordered_multimap<int, int>::iterator i;
+  std::unordered_set<int>::iterator j;
+  std::unordered_multiset<int>::iterator k;
+#if TEST_STD_VER <= 11
+  std::string::iterator l;
+  std::vector<int>::iterator m;
+#endif
+#if TEST_STD_VER <= 17
+  std::vector<bool>::iterator n;
+#endif
+}
+
+void container_const_iterators() {
+  std::deque<int>::const_iterator a;
+#if TEST_STD_VER <= 23
+  std::forward_list<int>::const_iterator b;
+  std::list<int>::const_iterator c;
+  std::map<int, int>::const_iterator d;
+  std::multimap<int, int>::const_iterator e;
+  std::set<int>::const_iterator f;
+  std::multiset<int>::const_iterator g;
+#endif
+  std::unordered_map<int, int>::const_iterator h;
+  std::unordered_multimap<int, int>::const_iterator i;
+  std::unordered_set<int>::const_iterator j;
+  std::unordered_multiset<int>::const_iterator k;
+#if TEST_STD_VER <= 11
+  std::string::const_iterator l;
+  std::vector<int>::const_iterator m;
+#endif
+#if TEST_STD_VER <= 17
+  std::vector<bool>::const_iterator n;
+#endif
+}

--- a/libcxx/test/libcxx/diagnostics/unused_variables.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/unused_variables.verify.cpp
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Make sure that we warn on unused variables of libc++ classes which behave like value types.
+
+#include <deque>
+#include <forward_list>
+#include <list>
+#include <map>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+void containers() {
+  std::deque<int> a;                   // expected-warning {{unused variable}}
+  std::forward_list<int> b;            // expected-warning {{unused variable}}
+  std::list<int> c;                    // expected-warning {{unused variable}}
+  std::map<int, int> d;                // expected-warning {{unused variable}}
+  std::multimap<int, int> e;           // expected-warning {{unused variable}}
+  std::set<int> f;                     // expected-warning {{unused variable}}
+  std::multiset<int> g;                // expected-warning {{unused variable}}
+  std::unordered_map<int, int> h;      // expected-warning {{unused variable}}
+  std::unordered_multimap<int, int> i; // expected-warning {{unused variable}}
+  std::unordered_set<int> j;           // expected-warning {{unused variable}}
+  std::unordered_multiset<int> k;      // expected-warning {{unused variable}}
+  std::string l;                       // expected-warning {{unused variable}}
+  std::vector<int> m;                  // expected-warning {{unused variable}}
+  std::vector<bool> n;                 // expected-warning {{unused variable}}
+}
+
+void container_iterators() {
+  std::deque<int>::iterator a;                   // expected-warning {{unused variable}}
+  std::forward_list<int>::iterator b;            // expected-warning {{unused variable}}
+  std::list<int>::iterator c;                    // expected-warning {{unused variable}}
+  std::map<int, int>::iterator d;                // expected-warning {{unused variable}}
+  std::multimap<int, int>::iterator e;           // expected-warning {{unused variable}}
+  std::set<int>::iterator f;                     // expected-warning {{unused variable}}
+  std::multiset<int>::iterator g;                // expected-warning {{unused variable}}
+  std::unordered_map<int, int>::iterator h;      // expected-warning {{unused variable}}
+  std::unordered_multimap<int, int>::iterator i; // expected-warning {{unused variable}}
+  std::unordered_set<int>::iterator j;           // expected-warning {{unused variable}}
+  std::unordered_multiset<int>::iterator k;      // expected-warning {{unused variable}}
+  std::string::iterator l;                       // expected-warning {{unused variable}}
+  std::vector<int>::iterator m;                  // expected-warning {{unused variable}}
+  std::vector<bool>::iterator n;                 // expected-warning {{unused variable}}
+}
+
+void container_const_iterators() {
+  std::deque<int>::const_iterator a;                   // expected-warning {{unused variable}}
+  std::forward_list<int>::const_iterator b;            // expected-warning {{unused variable}}
+  std::list<int>::const_iterator c;                    // expected-warning {{unused variable}}
+  std::map<int, int>::const_iterator d;                // expected-warning {{unused variable}}
+  std::multimap<int, int>::const_iterator e;           // expected-warning {{unused variable}}
+  std::set<int>::const_iterator f;                     // expected-warning {{unused variable}}
+  std::multiset<int>::const_iterator g;                // expected-warning {{unused variable}}
+  std::unordered_map<int, int>::const_iterator h;      // expected-warning {{unused variable}}
+  std::unordered_multimap<int, int>::const_iterator i; // expected-warning {{unused variable}}
+  std::unordered_set<int>::const_iterator j;           // expected-warning {{unused variable}}
+  std::unordered_multiset<int>::const_iterator k;      // expected-warning {{unused variable}}
+  std::string::const_iterator l;                       // expected-warning {{unused variable}}
+  std::vector<int>::const_iterator m;                  // expected-warning {{unused variable}}
+  std::vector<bool>::const_iterator n;                 // expected-warning {{unused variable}}
+}

--- a/libcxx/test/libcxx/input.output/filesystems/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/input.output/filesystems/nodiscard.verify.cpp
@@ -290,7 +290,6 @@ void test() {
 
   {
     std::filesystem::path p;
-    const std::string src;
 
     // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
     p.native();

--- a/libcxx/test/libcxx/iterators/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/iterators/nodiscard.verify.cpp
@@ -22,8 +22,8 @@
 void test() {
   int cArr[] = {94, 82, 49};
   std::vector<int> cont;
-  const std::vector<int> cCont;
 #if TEST_STD_VER >= 11
+  const std::vector<int> cCont;
   std::initializer_list<int> il;
 #endif
 #if !defined(TEST_HAS_NO_LOCALIZATION)

--- a/libcxx/test/libcxx/strings/basic.string/nonnull.verify.cpp
+++ b/libcxx/test/libcxx/strings/basic.string/nonnull.verify.cpp
@@ -23,8 +23,8 @@ void func() {
   const char* const np = nullptr;
   std::string str1(np);                         // expected-warning {{null passed}}
   std::string str2(np, std::allocator<char>{}); // expected-warning {{null passed}}
-  str2 = np;                                    // expected-warning {{null passed}}
-  str2 += np;                                   // expected-warning {{null passed}}
+  str1 = np;                                    // expected-warning {{null passed}}
+  str1 += np;                                   // expected-warning {{null passed}}
   str2.assign(np, 1);                           // expected-warning {{null passed}}
   str2.assign(np);                              // expected-warning {{null passed}}
   str2.assign(np, 0, 1);                        // expected-warning {{null passed}}
@@ -55,7 +55,7 @@ void func() {
   // These diagnostics are issued via diagnose_if, so we want to check the full description
   std::string str3(nullptr, 1); // expected-warning {{null passed to callee that requires a non-null argument if n is not zero}}
   std::string str4(nullptr, 1, std::allocator<char>{}); // expected-warning {{null passed to callee that requires a non-null argument if n is not zero}}
-  str4.find(nullptr, 0, 1); // expected-warning {{null passed to callee that requires a non-null argument if n is not zero}}
+  str3.find(nullptr, 0, 1); // expected-warning {{null passed to callee that requires a non-null argument if n is not zero}}
   str4.rfind(nullptr, 0, 1); // expected-warning {{null passed to callee that requires a non-null argument if n is not zero}}
   str4.find_first_of(nullptr, 0, 1); // expected-warning {{null passed to callee that requires a non-null argument if n is not zero}}
   str4.find_last_of(nullptr, 0, 1); // expected-warning {{null passed to callee that requires a non-null argument if n is not zero}}

--- a/libcxx/test/libcxx/strings/basic.string/string.cons/constinit_sso_string.compile.pass.cpp
+++ b/libcxx/test/libcxx/strings/basic.string/string.cons/constinit_sso_string.compile.pass.cpp
@@ -22,4 +22,4 @@
 #endif
 
 constinit std::string g_str = LONGEST_STR;
-void fn() { constexpr std::string l_str = LONGEST_STR; }
+void fn() { [[maybe_unused]] constexpr std::string l_str = LONGEST_STR; }

--- a/libcxx/test/std/containers/associative/from_range_associative_containers.h
+++ b/libcxx/test/std/containers/associative/from_range_associative_containers.h
@@ -260,6 +260,7 @@ TEST_CONSTEXPR_CXX26 void test_set_exception_safety_throwing_copy() {
 
   try {
     Container<T> c(std::from_range, in);
+    (void)c;
     assert(false); // The constructor call above should throw.
 
   } catch (int) {
@@ -279,6 +280,7 @@ TEST_CONSTEXPR_CXX26 void test_set_exception_safety_throwing_allocator() {
 
     globalMemCounter.reset();
     Container<T, test_less<T>, ThrowingAllocator<T>> c(std::from_range, in, alloc);
+    (void)c;
     assert(false); // The constructor call above should throw.
 
   } catch (int) {

--- a/libcxx/test/std/containers/associative/map/incomplete_type.pass.cpp
+++ b/libcxx/test/std/containers/associative/map/incomplete_type.pass.cpp
@@ -33,6 +33,7 @@ TEST_CONSTEXPR_CXX26 bool test() {
 
   // Make sure that the allocator isn't rebound to and incomplete type
   std::map<int, int, std::less<int>, complete_type_allocator<std::pair<const int, int> > > m;
+  (void)m;
 
   return true;
 }

--- a/libcxx/test/std/containers/associative/map/map.cons/copy_assign.addressof.compile.pass.cpp
+++ b/libcxx/test/std/containers/associative/map/map.cons/copy_assign.addressof.compile.pass.cpp
@@ -24,10 +24,12 @@ void test() {
     std::map<int, operator_hijacker> mo;
     std::map<int, operator_hijacker> m;
     m = mo;
+    (void)m;
   }
   {
     std::map<operator_hijacker, int> mo;
     std::map<operator_hijacker, int> m;
     m = mo;
+    (void)m;
   }
 }

--- a/libcxx/test/std/containers/associative/multimap/incomplete_type.pass.cpp
+++ b/libcxx/test/std/containers/associative/multimap/incomplete_type.pass.cpp
@@ -33,6 +33,7 @@ bool test() {
 
   // Make sure that the allocator isn't rebound to and incomplete type
   std::multimap<int, int, std::less<int>, complete_type_allocator<std::pair<const int, int> > > m;
+  (void)m;
 
   return true;
 }

--- a/libcxx/test/std/containers/associative/multimap/multimap.cons/copy_assign.addressof.compile.pass.cpp
+++ b/libcxx/test/std/containers/associative/multimap/multimap.cons/copy_assign.addressof.compile.pass.cpp
@@ -24,10 +24,12 @@ void test() {
     std::multimap<int, operator_hijacker> mo;
     std::multimap<int, operator_hijacker> m;
     m = mo;
+    (void)m;
   }
   {
     std::multimap<operator_hijacker, int> mo;
     std::multimap<operator_hijacker, int> m;
     m = mo;
+    (void)m;
   }
 }

--- a/libcxx/test/std/containers/associative/multiset/multiset.cons/copy_assign.addressof.compile.pass.cpp
+++ b/libcxx/test/std/containers/associative/multiset/multiset.cons/copy_assign.addressof.compile.pass.cpp
@@ -23,4 +23,5 @@ void test() {
   std::multiset<operator_hijacker> so;
   std::multiset<operator_hijacker> s;
   s = so;
+  (void)s;
 }

--- a/libcxx/test/std/containers/associative/set/set.cons/copy_assign.addressof.compile.pass.cpp
+++ b/libcxx/test/std/containers/associative/set/set.cons/copy_assign.addressof.compile.pass.cpp
@@ -23,4 +23,5 @@ void test() {
   std::set<operator_hijacker> so;
   std::set<operator_hijacker> s;
   s = so;
+  (void)s;
 }

--- a/libcxx/test/std/containers/sequences/deque/deque.cons/move_assign.addressof.compile.pass.cpp
+++ b/libcxx/test/std/containers/sequences/deque/deque.cons/move_assign.addressof.compile.pass.cpp
@@ -21,4 +21,5 @@ void test() {
   std::deque<operator_hijacker> dqo;
   std::deque<operator_hijacker> dq;
   dq = dqo;
+  (void)dq;
 }

--- a/libcxx/test/std/containers/sequences/forwardlist/exception_safety.pass.cpp
+++ b/libcxx/test/std/containers/sequences/forwardlist/exception_safety.pass.cpp
@@ -214,12 +214,14 @@ int main(int, char**) {
     test_exception_safety_throwing_copy_container<C, ThrowOn, Size>([](C&& in) {
       std::forward_list<T> c;
       c = in;
+      (void)c;
     });
 
     // forward_list& operator=(initializer_list<value_type> il);
     test_exception_safety_throwing_copy<ThrowOn, Size>([&il](T*, T*) {
       std::forward_list<T> c;
       c = il;
+      (void)c;
     });
 
     // template <class InputIterator>

--- a/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/assign_copy.addressof.compile.pass.cpp
+++ b/libcxx/test/std/containers/sequences/forwardlist/forwardlist.cons/assign_copy.addressof.compile.pass.cpp
@@ -21,4 +21,5 @@ void test() {
   std::forward_list<operator_hijacker> lo;
   std::forward_list<operator_hijacker> l;
   l = lo;
+  (void)l;
 }

--- a/libcxx/test/std/containers/sequences/from_range_sequence_containers.h
+++ b/libcxx/test/std/containers/sequences/from_range_sequence_containers.h
@@ -136,6 +136,7 @@ void test_exception_safety_throwing_allocator() {
 
     globalMemCounter.reset();
     Container<T, ThrowingAllocator<T>> c(std::from_range, in, alloc);
+    (void)c;
     assert(false); // The constructor call above should throw.
 
   } catch (int) {

--- a/libcxx/test/std/containers/sequences/list/exception_safety.pass.cpp
+++ b/libcxx/test/std/containers/sequences/list/exception_safety.pass.cpp
@@ -151,6 +151,7 @@ int main(int, char**) {
     test_exception_safety_throwing_copy_container<C, ThrowOn, Size>([](C&& in) {
       std::list<T> c;
       c = in;
+      (void)c;
     });
 
     // template <class InputIterator>

--- a/libcxx/test/std/containers/sequences/list/list.cons/assign_copy.addressof.compile.pass.cpp
+++ b/libcxx/test/std/containers/sequences/list/list.cons/assign_copy.addressof.compile.pass.cpp
@@ -21,4 +21,5 @@ void test() {
   std::list<operator_hijacker> lo;
   std::list<operator_hijacker> l;
   l = lo;
+  (void)l;
 }

--- a/libcxx/test/std/containers/sequences/list/list.cons/assign_move.addressof.compile.pass.cpp
+++ b/libcxx/test/std/containers/sequences/list/list.cons/assign_move.addressof.compile.pass.cpp
@@ -23,4 +23,5 @@ void test() {
   std::list<operator_hijacker> lo;
   std::list<operator_hijacker> l;
   l = std::move(lo);
+  (void)l;
 }

--- a/libcxx/test/std/containers/sequences/list/list.cons/input_iterator.pass.cpp
+++ b/libcxx/test/std/containers/sequences/list/list.cons/input_iterator.pass.cpp
@@ -184,10 +184,12 @@ void test_ctor_under_alloc() {
     {
       ExpectConstructGuard<int&> G(1);
       C v(It(arr1), It(std::end(arr1)));
+      (void)v;
     }
     {
       ExpectConstructGuard<int&> G(3);
       C v(It(arr2), It(std::end(arr2)));
+      (void)v;
     }
   }
   {
@@ -196,10 +198,12 @@ void test_ctor_under_alloc() {
     {
       ExpectConstructGuard<int&> G(1);
       C v(It(arr1), It(std::end(arr1)));
+      (void)v;
     }
     {
       ExpectConstructGuard<int&> G(3);
       C v(It(arr2), It(std::end(arr2)));
+      (void)v;
     }
   }
 #endif
@@ -217,10 +221,12 @@ void test_ctor_under_alloc_with_alloc() {
     {
       ExpectConstructGuard<int&> G(1);
       C v(It(arr1), It(std::end(arr1)), a);
+      (void)v;
     }
     {
       ExpectConstructGuard<int&> G(3);
       C v(It(arr2), It(std::end(arr2)), a);
+      (void)v;
     }
   }
   {
@@ -231,10 +237,12 @@ void test_ctor_under_alloc_with_alloc() {
     {
       ExpectConstructGuard<int&> G(1);
       C v(It(arr1), It(std::end(arr1)), a);
+      (void)v;
     }
     {
       ExpectConstructGuard<int&> G(3);
       C v(It(arr2), It(std::end(arr2)), a);
+      (void)v;
     }
   }
 #endif

--- a/libcxx/test/std/containers/sequences/vector.bool/ctor_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/ctor_exceptions.pass.cpp
@@ -25,6 +25,7 @@ int main(int, char**) {
 
   try { // Throw in vector() from allocator
     AllocVec vec;
+    (void)vec;
   } catch (int) {
   }
   check_new_delete_called();
@@ -33,6 +34,7 @@ int main(int, char**) {
   try { // Throw in vector(size_type, const allocator_type&) from allocator
     throwing_allocator<bool> alloc(/*throw_on_ctor = */ false, /*throw_on_copy = */ true);
     AllocVec get_alloc(0, alloc);
+    (void)get_alloc;
   } catch (int) {
   }
   check_new_delete_called();
@@ -41,6 +43,7 @@ int main(int, char**) {
   try { // Throw in vector(size_type, const value_type&, const allocator_type&) from allocator
     throwing_allocator<bool> alloc(/*throw_on_ctor = */ false, /*throw_on_copy = */ true);
     AllocVec get_alloc(0, true, alloc);
+    (void)get_alloc;
   } catch (int) {
   }
   check_new_delete_called();
@@ -48,6 +51,7 @@ int main(int, char**) {
   try { // Throw in vector(InputIterator, InputIterator) from input iterator
     std::vector<bool> vec(
         throwing_iterator<bool, std::input_iterator_tag>(), throwing_iterator<bool, std::input_iterator_tag>(2));
+    (void)vec;
   } catch (int) {
   }
   check_new_delete_called();
@@ -55,6 +59,7 @@ int main(int, char**) {
   try { // Throw in vector(InputIterator, InputIterator) from forward iterator
     std::vector<bool> vec(
         throwing_iterator<bool, std::forward_iterator_tag>(), throwing_iterator<bool, std::forward_iterator_tag>(2));
+    (void)vec;
   } catch (int) {
   }
   check_new_delete_called();
@@ -62,6 +67,7 @@ int main(int, char**) {
   try { // Throw in vector(InputIterator, InputIterator) from allocator
     bool a[] = {true, true};
     AllocVec vec(cpp17_input_iterator<bool*>(a), cpp17_input_iterator<bool*>(a + 2));
+    (void)vec;
   } catch (int) {
   }
   check_new_delete_called();
@@ -70,6 +76,7 @@ int main(int, char**) {
     std::allocator<bool> alloc;
     std::vector<bool> vec(
         throwing_iterator<bool, std::input_iterator_tag>(), throwing_iterator<bool, std::input_iterator_tag>(2), alloc);
+    (void)vec;
   } catch (int) {
   }
   check_new_delete_called();
@@ -79,6 +86,7 @@ int main(int, char**) {
     std::vector<bool> vec(throwing_iterator<bool, std::forward_iterator_tag>(),
                           throwing_iterator<bool, std::forward_iterator_tag>(2),
                           alloc);
+    (void)vec;
   } catch (int) {
   }
   check_new_delete_called();
@@ -87,6 +95,7 @@ int main(int, char**) {
     bool a[] = {true, false};
     throwing_allocator<bool> alloc(/*throw_on_ctor = */ false, /*throw_on_copy = */ true);
     AllocVec vec(cpp17_input_iterator<bool*>(a), cpp17_input_iterator<bool*>(a + 2), alloc);
+    (void)vec;
   } catch (int) {
   }
   check_new_delete_called();
@@ -95,6 +104,7 @@ int main(int, char**) {
     bool a[] = {true, false};
     throwing_allocator<bool> alloc(/*throw_on_ctor = */ false, /*throw_on_copy = */ true);
     AllocVec vec(forward_iterator<bool*>(a), forward_iterator<bool*>(a + 2), alloc);
+    (void)vec;
   } catch (int) {
   }
   check_new_delete_called();
@@ -106,6 +116,7 @@ int main(int, char**) {
     vec.push_back(true);
     alloc.throw_on_copy_ = true;
     AllocVec vec2(vec, alloc);
+    (void)vec2;
   } catch (int) {
   }
   check_new_delete_called();
@@ -116,6 +127,7 @@ int main(int, char**) {
     vec.push_back(true);
     alloc.throw_on_copy_ = true;
     AllocVec vec2(std::move(vec), alloc);
+    (void)vec2;
   } catch (int) {
   }
   check_new_delete_called();
@@ -123,6 +135,7 @@ int main(int, char**) {
   try { // Throw in vector(initializer_list<value_type>, const allocator_type&) constructor from allocator
     throwing_allocator<bool> alloc(/*throw_on_ctor = */ false, /*throw_on_copy = */ true);
     AllocVec vec({true, true}, alloc);
+    (void)vec;
   } catch (int) {
   }
   check_new_delete_called();

--- a/libcxx/test/std/containers/sequences/vector/addressof.compile.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/addressof.compile.pass.cpp
@@ -41,9 +41,11 @@ void test(
   // construction
   {
     Vector v2(std::move(v));
+    (void)v2;
   }
   {
     Vector v2(std::move(v), std::allocator<operator_hijacker>());
+    (void)v2;
   }
 
   // swap

--- a/libcxx/test/std/containers/sequences/vector/vector.cons/construct_iter_iter.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.cons/construct_iter_iter.pass.cpp
@@ -83,7 +83,9 @@ TEST_CONSTEXPR_CXX20 void basic_test_cases() {
   // Regression test for https://llvm.org/PR47497
   {
     std::vector<int> v1({}, forward_iterator<const int*>{});
+    (void)v1;
     std::vector<int> v2(forward_iterator<const int*>{}, {});
+    (void)v2;
   }
 #endif
 }
@@ -137,10 +139,12 @@ void test_ctor_under_alloc() {
     {
       ExpectConstructGuard<int&> G(1);
       C v(It(arr1), It(std::end(arr1)));
+      (void)v;
     }
     {
       ExpectConstructGuard<int&> G(3);
       C v(It(arr2), It(std::end(arr2)));
+      (void)v;
     }
   }
   {
@@ -149,6 +153,7 @@ void test_ctor_under_alloc() {
     {
       ExpectConstructGuard<int&> G(1);
       C v(It(arr1), It(std::end(arr1)));
+      (void)v;
     }
     {
       //ExpectConstructGuard<int&> G(3);
@@ -163,11 +168,13 @@ void test_ctor_under_alloc() {
     {
       Alloc::construct_called = false;
       C v(arr1, arr1 + 1);
+      (void)v;
       assert(Alloc::construct_called);
     }
     {
       Alloc::construct_called = false;
       C v(arr2, arr2 + 3);
+      (void)v;
       assert(Alloc::construct_called);
     }
   }
@@ -177,11 +184,13 @@ void test_ctor_under_alloc() {
     {
       Alloc::construct_called = false;
       C v(arr1, arr1 + 1);
+      (void)v;
       assert(Alloc::construct_called);
     }
     {
       Alloc::construct_called = false;
       C v(arr2, arr2 + 3);
+      (void)v;
       assert(Alloc::construct_called);
     }
   }

--- a/libcxx/test/std/containers/sequences/vector/vector.cons/construct_iter_iter_alloc.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.cons/construct_iter_iter_alloc.pass.cpp
@@ -94,7 +94,9 @@ TEST_CONSTEXPR_CXX20 void basic_tests() {
   {
     min_allocator<int> alloc;
     std::vector<int, min_allocator<int> > v1({}, forward_iterator<const int*>{}, alloc);
+    (void)v1;
     std::vector<int, min_allocator<int> > v2(forward_iterator<const int*>{}, {}, alloc);
+    (void)v2;
   }
 #endif
 }
@@ -152,10 +154,12 @@ void test_ctor_under_alloc() {
     {
       ExpectConstructGuard<int&> G(1);
       C v(It(arr1), It(std::end(arr1)), a);
+      (void)v;
     }
     {
       ExpectConstructGuard<int&> G(3);
       C v(It(arr2), It(std::end(arr2)), a);
+      (void)v;
     }
   }
   {
@@ -166,6 +170,7 @@ void test_ctor_under_alloc() {
     {
       ExpectConstructGuard<int&> G(1);
       C v(It(arr1), It(std::end(arr1)), a);
+      (void)v;
     }
     {
       //ExpectConstructGuard<int&> G(3);
@@ -181,11 +186,13 @@ void test_ctor_under_alloc() {
     {
       Alloc::construct_called = false;
       C v(arr1, arr1 + 1, a);
+      (void)v;
       assert(Alloc::construct_called);
     }
     {
       Alloc::construct_called = false;
       C v(arr2, arr2 + 3, a);
+      (void)v;
       assert(Alloc::construct_called);
     }
   }
@@ -196,11 +203,13 @@ void test_ctor_under_alloc() {
     {
       Alloc::construct_called = false;
       C v(arr1, arr1 + 1, a);
+      (void)v;
       assert(Alloc::construct_called);
     }
     {
       Alloc::construct_called = false;
       C v(arr2, arr2 + 3, a);
+      (void)v;
       assert(Alloc::construct_called);
     }
   }

--- a/libcxx/test/std/containers/sequences/vector/vector.cons/copy.move_only.verify.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.cons/copy.move_only.verify.cpp
@@ -18,4 +18,5 @@ void f() {
   std::vector<MoveOnly> v;
   std::vector<MoveOnly> copy =
       v; // expected-error-re@* {{{{(no matching function for call to '__construct_at')|(call to deleted constructor of 'MoveOnly')}}}}
+  (void)copy;
 }

--- a/libcxx/test/std/containers/sequences/vector/vector.cons/exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.cons/exceptions.pass.cpp
@@ -25,12 +25,14 @@ int main(int, char**) {
   using AllocVec = std::vector<int, throwing_allocator<int> >;
   try { // vector()
     AllocVec vec;
+    (void)vec;
   } catch (int) {
   }
   check_new_delete_called();
 
   try { // Throw in vector(size_type) from type
     std::vector<throwing_t> get_alloc(1);
+    (void)get_alloc;
   } catch (int) {
   }
   check_new_delete_called();
@@ -40,6 +42,7 @@ int main(int, char**) {
     int throw_after = 1;
     throwing_t v(throw_after);
     std::vector<throwing_t> get_alloc(1, v);
+    (void)get_alloc;
   } catch (int) {
   }
   check_new_delete_called();
@@ -47,12 +50,14 @@ int main(int, char**) {
   try { // Throw in vector(size_type, const allocator_type&) from allocator
     throwing_allocator<int> alloc(/*throw_on_ctor = */ false, /*throw_on_copy = */ true);
     AllocVec get_alloc(0, alloc);
+    (void)get_alloc;
   } catch (int) {
   }
   check_new_delete_called();
 
   try { // Throw in vector(size_type, const allocator_type&) from the type
     std::vector<throwing_t> vec(1, std::allocator<throwing_t>());
+    (void)vec;
   } catch (int) {
   }
   check_new_delete_called();
@@ -62,6 +67,7 @@ int main(int, char**) {
     int throw_after = 1;
     throwing_t v(throw_after);
     std::vector<throwing_t> vec(1, v, std::allocator<throwing_t>());
+    (void)vec;
   } catch (int) {
   }
   check_new_delete_called();
@@ -69,6 +75,7 @@ int main(int, char**) {
   try { // Throw in vector(InputIterator, InputIterator) from input iterator
     std::vector<int> vec(
         (throwing_iterator<int, std::input_iterator_tag>()), throwing_iterator<int, std::input_iterator_tag>(2));
+    (void)vec;
   } catch (int) {
   }
   check_new_delete_called();
@@ -76,6 +83,7 @@ int main(int, char**) {
   try { // Throw in vector(InputIterator, InputIterator) from forward iterator
     std::vector<int> vec(
         (throwing_iterator<int, std::forward_iterator_tag>()), throwing_iterator<int, std::forward_iterator_tag>(2));
+    (void)vec;
   } catch (int) {
   }
   check_new_delete_called();
@@ -83,6 +91,7 @@ int main(int, char**) {
   try { // Throw in vector(InputIterator, InputIterator) from allocator
     int a[] = {1, 2};
     AllocVec vec(cpp17_input_iterator<int*>(a), cpp17_input_iterator<int*>(a + 2));
+    (void)vec;
   } catch (int) {
   }
   check_new_delete_called();
@@ -91,6 +100,7 @@ int main(int, char**) {
     std::allocator<int> alloc;
     std::vector<int> vec(
         throwing_iterator<int, std::input_iterator_tag>(), throwing_iterator<int, std::input_iterator_tag>(2), alloc);
+    (void)vec;
   } catch (int) {
   }
   check_new_delete_called();
@@ -100,6 +110,7 @@ int main(int, char**) {
     std::vector<int> vec(throwing_iterator<int, std::forward_iterator_tag>(),
                          throwing_iterator<int, std::forward_iterator_tag>(2),
                          alloc);
+    (void)vec;
   } catch (int) {
   }
   check_new_delete_called();
@@ -108,6 +119,7 @@ int main(int, char**) {
     int a[] = {1, 2};
     throwing_allocator<int> alloc(/*throw_on_ctor = */ false, /*throw_on_copy = */ true);
     AllocVec vec(cpp17_input_iterator<int*>(a), cpp17_input_iterator<int*>(a + 2), alloc);
+    (void)vec;
   } catch (int) {
   }
   check_new_delete_called();
@@ -116,6 +128,7 @@ int main(int, char**) {
     int a[] = {1, 2};
     throwing_allocator<int> alloc(/*throw_on_ctor = */ false, /*throw_on_copy = */ true);
     AllocVec vec(forward_iterator<int*>(a), forward_iterator<int*>(a + 2), alloc);
+    (void)vec;
   } catch (int) {
   }
   check_new_delete_called();
@@ -125,6 +138,7 @@ int main(int, char**) {
     int throw_after = 1;
     vec.emplace_back(throw_after);
     auto vec2 = vec;
+    (void)vec2;
   } catch (int) {
   }
   check_new_delete_called();
@@ -134,6 +148,7 @@ int main(int, char**) {
     int throw_after = 1;
     vec.emplace_back(throw_after);
     std::vector<throwing_t> vec2(vec, std::allocator<int>());
+    (void)vec2;
   } catch (int) {
   }
   check_new_delete_called();
@@ -144,6 +159,7 @@ int main(int, char**) {
     throwing_t v(throw_after);
     vec.insert(vec.end(), 6, v);
     std::vector<throwing_t, test_allocator<throwing_t> > vec2(std::move(vec), test_allocator<throwing_t>(2));
+    (void)vec2;
   } catch (int) {
   }
   check_new_delete_called();
@@ -152,6 +168,7 @@ int main(int, char**) {
   try { // Throw in vector(initializer_list<value_type>) from type
     int throw_after = 1;
     std::vector<throwing_t> vec({throwing_t(throw_after)});
+    (void)vec;
   } catch (int) {
   }
   check_new_delete_called();
@@ -159,6 +176,7 @@ int main(int, char**) {
   try { // Throw in vector(initializer_list<value_type>, const allocator_type&) constructor from type
     int throw_after = 1;
     std::vector<throwing_t> vec({throwing_t(throw_after)}, std::allocator<throwing_t>());
+    (void)vec;
   } catch (int) {
   }
   check_new_delete_called();

--- a/libcxx/test/std/containers/unord/from_range_unordered_containers.h
+++ b/libcxx/test/std/containers/unord/from_range_unordered_containers.h
@@ -225,6 +225,7 @@ void test_map_exception_safety_throwing_copy() {
 
   try {
     Container<K, V> c(std::from_range, in);
+    (void)c;
     assert(false); // The constructor call above should throw.
 
   } catch (int) {
@@ -246,6 +247,7 @@ void test_map_exception_safety_throwing_allocator() {
     globalMemCounter.reset();
     Container<K, V, test_hash<K>, test_equal_to<K>, ThrowingAllocator<ValueType>> c(
         std::from_range, in, /*n=*/0, alloc);
+    (void)c;
     assert(false); // The constructor call should throw.
 
   } catch (int) {
@@ -417,6 +419,7 @@ void test_set_exception_safety_throwing_copy() {
 
   try {
     Container<T, test_hash<T>> c(std::from_range, in);
+    (void)c;
     assert(false); // The constructor call above should throw.
 
   } catch (int) {
@@ -436,6 +439,7 @@ void test_set_exception_safety_throwing_allocator() {
 
     globalMemCounter.reset();
     Container<T, test_hash<T>, test_equal_to<T>, ThrowingAllocator<T>> c(std::from_range, in, /*n=*/0, alloc);
+    (void)c;
     assert(false); // The constructor call should throw.
 
   } catch (int) {

--- a/libcxx/test/std/containers/unord/unord.map/incomplete_type.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.map/incomplete_type.pass.cpp
@@ -40,6 +40,7 @@ int main(int, char**) {
   // Make sure that the allocator isn't rebound to an incomplete type
   std::unordered_map<int, int, std::hash<int>, std::equal_to<int>, complete_type_allocator<std::pair<const int, int> > >
       m;
+  (void)m;
 
   return 0;
 }

--- a/libcxx/test/std/containers/unord/unord.map/iterators.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.map/iterators.pass.cpp
@@ -45,6 +45,7 @@ int main(int, char**) {
     assert(static_cast<std::size_t>(std::distance(c.begin(), c.end())) == c.size());
     assert(static_cast<std::size_t>(std::distance(c.cbegin(), c.cend())) == c.size());
     C::iterator i;
+    (void)i;
   }
   {
     typedef std::unordered_map<int, std::string> C;
@@ -63,6 +64,7 @@ int main(int, char**) {
     assert(static_cast<std::size_t>(std::distance(c.begin(), c.end())) == c.size());
     assert(static_cast<std::size_t>(std::distance(c.cbegin(), c.cend())) == c.size());
     C::const_iterator i;
+    (void)i;
   }
 #if TEST_STD_VER >= 11
   {
@@ -87,6 +89,7 @@ int main(int, char**) {
     assert(static_cast<std::size_t>(std::distance(c.begin(), c.end())) == c.size());
     assert(static_cast<std::size_t>(std::distance(c.cbegin(), c.cend())) == c.size());
     C::iterator i;
+    (void)i;
   }
   {
     typedef std::unordered_map<int,
@@ -110,6 +113,7 @@ int main(int, char**) {
     assert(static_cast<std::size_t>(std::distance(c.begin(), c.end())) == c.size());
     assert(static_cast<std::size_t>(std::distance(c.cbegin(), c.cend())) == c.size());
     C::const_iterator i;
+    (void)i;
   }
 #endif
 #if TEST_STD_VER > 11

--- a/libcxx/test/std/containers/unord/unord.map/unord.map.cnstr/assign_copy.addressof.compile.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.map/unord.map.cnstr/assign_copy.addressof.compile.pass.cpp
@@ -26,10 +26,12 @@ void test() {
     std::unordered_map<int, operator_hijacker> mo;
     std::unordered_map<int, operator_hijacker> m;
     m = mo;
+    (void)m;
   }
   {
     std::unordered_map<operator_hijacker, int> mo;
     std::unordered_map<operator_hijacker, int> m;
     m = mo;
+    (void)m;
   }
 }

--- a/libcxx/test/std/containers/unord/unord.map/unord.map.cnstr/assign_move.addressof.compile.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.map/unord.map.cnstr/assign_move.addressof.compile.pass.cpp
@@ -33,10 +33,12 @@ void test() {
     std::unordered_map<int, operator_hijacker> mo;
     std::unordered_map<int, operator_hijacker> m;
     m = std::move(mo);
+    (void)m;
   }
   {
     std::unordered_map<operator_hijacker, int> mo;
     std::unordered_map<operator_hijacker, int> m;
     m = std::move(mo);
+    (void)m;
   }
 }

--- a/libcxx/test/std/containers/unord/unord.map/unord.map.cnstr/move.addressof.compile.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.map/unord.map.cnstr/move.addressof.compile.pass.cpp
@@ -30,4 +30,5 @@
 void test() {
   std::unordered_map<operator_hijacker, operator_hijacker> mo;
   std::unordered_map<operator_hijacker, operator_hijacker> m(std::move(mo));
+  (void)m;
 }

--- a/libcxx/test/std/containers/unord/unord.map/unord.map.cnstr/move_alloc.addressof.compile.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.map/unord.map.cnstr/move_alloc.addressof.compile.pass.cpp
@@ -37,4 +37,5 @@ void test() {
 
   C mo;
   C m(std::move(mo), A());
+  (void)m;
 }

--- a/libcxx/test/std/containers/unord/unord.multimap/incomplete.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multimap/incomplete.pass.cpp
@@ -44,6 +44,7 @@ int main(int, char**) {
                           std::equal_to<int>,
                           complete_type_allocator<std::pair<const int, int> > >
       m;
+  (void)m;
 
   return 0;
 }

--- a/libcxx/test/std/containers/unord/unord.multimap/iterators.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multimap/iterators.pass.cpp
@@ -66,6 +66,7 @@ int main(int, char**) {
     assert(static_cast<std::size_t>(std::distance(c.begin(), c.end())) == c.size());
     assert(static_cast<std::size_t>(std::distance(c.cbegin(), c.cend())) == c.size());
     C::const_iterator i;
+    (void)i;
   }
 #if TEST_STD_VER >= 11
   {
@@ -116,6 +117,7 @@ int main(int, char**) {
     assert(static_cast<std::size_t>(std::distance(c.begin(), c.end())) == c.size());
     assert(static_cast<std::size_t>(std::distance(c.cbegin(), c.cend())) == c.size());
     C::const_iterator i;
+    (void)i;
   }
 #endif
 #if TEST_STD_VER > 11

--- a/libcxx/test/std/containers/unord/unord.multimap/unord.multimap.cnstr/assign_copy.addressof.compile.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multimap/unord.multimap.cnstr/assign_copy.addressof.compile.pass.cpp
@@ -26,10 +26,12 @@ void test() {
     std::unordered_multimap<int, operator_hijacker> mo;
     std::unordered_multimap<int, operator_hijacker> m;
     m = mo;
+    (void)m;
   }
   {
     std::unordered_multimap<operator_hijacker, int> mo;
     std::unordered_multimap<operator_hijacker, int> m;
     m = mo;
+    (void)m;
   }
 }

--- a/libcxx/test/std/containers/unord/unord.multimap/unord.multimap.cnstr/move.addressof.compile.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multimap/unord.multimap.cnstr/move.addressof.compile.pass.cpp
@@ -30,4 +30,5 @@
 void test() {
   std::unordered_multimap<operator_hijacker, operator_hijacker> mo;
   std::unordered_multimap<operator_hijacker, operator_hijacker> m(std::move(mo));
+  (void)m;
 }

--- a/libcxx/test/std/containers/unord/unord.multimap/unord.multimap.cnstr/move_alloc.addressof.compile.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multimap/unord.multimap.cnstr/move_alloc.addressof.compile.pass.cpp
@@ -37,4 +37,5 @@ void test() {
 
   C mo;
   C m(std::move(mo), A());
+  (void)m;
 }

--- a/libcxx/test/std/containers/unord/unord.multiset/iterators.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multiset/iterators.pass.cpp
@@ -37,6 +37,7 @@ int main(int, char**) {
     assert(static_cast<std::size_t>(std::distance(c.begin(), c.end())) == c.size());
     assert(static_cast<std::size_t>(std::distance(c.cbegin(), c.cend())) == c.size());
     C::iterator i;
+    (void)i;
   }
   {
     typedef std::unordered_multiset<int> C;
@@ -48,6 +49,7 @@ int main(int, char**) {
     assert(static_cast<std::size_t>(std::distance(c.begin(), c.end())) == c.size());
     assert(static_cast<std::size_t>(std::distance(c.cbegin(), c.cend())) == c.size());
     C::const_iterator i;
+    (void)i;
   }
 #if TEST_STD_VER >= 11
   {
@@ -60,6 +62,7 @@ int main(int, char**) {
     assert(static_cast<std::size_t>(std::distance(c.begin(), c.end())) == c.size());
     assert(static_cast<std::size_t>(std::distance(c.cbegin(), c.cend())) == c.size());
     C::iterator i;
+    (void)i;
   }
   {
     typedef std::unordered_multiset<int, std::hash<int>, std::equal_to<int>, min_allocator<int>> C;
@@ -71,6 +74,7 @@ int main(int, char**) {
     assert(static_cast<std::size_t>(std::distance(c.begin(), c.end())) == c.size());
     assert(static_cast<std::size_t>(std::distance(c.cbegin(), c.cend())) == c.size());
     C::const_iterator i;
+    (void)i;
   }
 #endif
 #if TEST_STD_VER > 11

--- a/libcxx/test/std/containers/unord/unord.multiset/unord.multiset.cnstr/assign_copy.addressof.compile.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multiset/unord.multiset.cnstr/assign_copy.addressof.compile.pass.cpp
@@ -25,4 +25,5 @@ void test() {
   std::unordered_multiset<operator_hijacker> so;
   std::unordered_multiset<operator_hijacker> s;
   s = so;
+  (void)s;
 }

--- a/libcxx/test/std/containers/unord/unord.multiset/unord.multiset.cnstr/move.addressof.compile.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multiset/unord.multiset.cnstr/move.addressof.compile.pass.cpp
@@ -26,4 +26,5 @@
 void test() {
   std::unordered_multiset<operator_hijacker> so;
   std::unordered_multiset<operator_hijacker> s(std::move(so));
+  (void)s;
 }

--- a/libcxx/test/std/containers/unord/unord.multiset/unord.multiset.cnstr/move_alloc.addressof.compile.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multiset/unord.multiset.cnstr/move_alloc.addressof.compile.pass.cpp
@@ -30,4 +30,5 @@ void test() {
   const A a;
   std::unordered_multiset<operator_hijacker, H, P, A> so;
   std::unordered_multiset<operator_hijacker, H, P, A> s(std::move(so), a);
+  (void)s;
 }

--- a/libcxx/test/std/containers/unord/unord.set/iterators.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.set/iterators.pass.cpp
@@ -37,6 +37,7 @@ int main(int, char**) {
     assert(static_cast<std::size_t>(std::distance(c.begin(), c.end())) == c.size());
     assert(static_cast<std::size_t>(std::distance(c.cbegin(), c.cend())) == c.size());
     C::iterator i;
+    (void)i;
   }
   {
     typedef std::unordered_set<int> C;
@@ -48,6 +49,7 @@ int main(int, char**) {
     assert(static_cast<std::size_t>(std::distance(c.begin(), c.end())) == c.size());
     assert(static_cast<std::size_t>(std::distance(c.cbegin(), c.cend())) == c.size());
     C::const_iterator i;
+    (void)i;
   }
 #if TEST_STD_VER >= 11
   {
@@ -60,6 +62,7 @@ int main(int, char**) {
     assert(static_cast<std::size_t>(std::distance(c.begin(), c.end())) == c.size());
     assert(static_cast<std::size_t>(std::distance(c.cbegin(), c.cend())) == c.size());
     C::iterator i;
+    (void)i;
   }
   {
     typedef std::unordered_set<int, std::hash<int>, std::equal_to<int>, min_allocator<int>> C;
@@ -71,6 +74,7 @@ int main(int, char**) {
     assert(static_cast<std::size_t>(std::distance(c.begin(), c.end())) == c.size());
     assert(static_cast<std::size_t>(std::distance(c.cbegin(), c.cend())) == c.size());
     C::const_iterator i;
+    (void)i;
   }
 #endif
 #if TEST_STD_VER > 11

--- a/libcxx/test/std/containers/unord/unord.set/unord.set.cnstr/assign_copy.addressof.compile.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.set/unord.set.cnstr/assign_copy.addressof.compile.pass.cpp
@@ -25,4 +25,5 @@ void test() {
   std::unordered_set<operator_hijacker> so;
   std::unordered_set<operator_hijacker> s;
   s = so;
+  (void)s;
 }

--- a/libcxx/test/std/containers/unord/unord.set/unord.set.cnstr/move.addressof.compile.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.set/unord.set.cnstr/move.addressof.compile.pass.cpp
@@ -26,4 +26,5 @@
 void test() {
   std::unordered_set<operator_hijacker> so;
   std::unordered_set<operator_hijacker> s(std::move(so));
+  (void)s;
 }

--- a/libcxx/test/std/containers/unord/unord.set/unord.set.cnstr/move_alloc.addressof.compile.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.set/unord.set.cnstr/move_alloc.addressof.compile.pass.cpp
@@ -32,4 +32,5 @@ void test() {
   const A a;
   std::unordered_set<operator_hijacker, H, P, A> so;
   std::unordered_set<operator_hijacker, H, P, A> s(std::move(so), a);
+  (void)s;
 }

--- a/libcxx/test/std/localization/locale.categories/category.ctype/facet.ctype.special/facet.ctype.char.members/scan_is.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/facet.ctype.special/facet.ctype.char.members/scan_is.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <locale>
 #include <string>
-#include <vector>
 #include <cassert>
 
 #include <stdio.h>
@@ -28,7 +27,6 @@ int main(int, char**)
         typedef std::ctype<char> F;
         const F& f = std::use_facet<F>(l);
         const std::string in(" A\x07.a1");
-        std::vector<F::mask> m(in.size());
         assert(f.scan_is(F::space, in.data(), in.data() + in.size()) - in.data() == 0);
         assert(f.scan_is(F::print, in.data(), in.data() + in.size()) - in.data() == 0);
         assert(f.scan_is(F::cntrl, in.data(), in.data() + in.size()) - in.data() == 2);

--- a/libcxx/test/std/localization/locale.categories/category.ctype/facet.ctype.special/facet.ctype.char.members/scan_not.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/facet.ctype.special/facet.ctype.char.members/scan_not.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <locale>
 #include <string>
-#include <vector>
 #include <cassert>
 
 #include <stdio.h>
@@ -28,7 +27,6 @@ int main(int, char**)
         typedef std::ctype<char> F;
         const F& f = std::use_facet<F>(l);
         const std::string in(" A\x07.a1");
-        std::vector<F::mask> m(in.size());
         assert(f.scan_not(F::space, in.data(), in.data() + in.size()) - in.data() == 1);
         assert(f.scan_not(F::print, in.data(), in.data() + in.size()) - in.data() == 2);
         assert(f.scan_not(F::cntrl, in.data(), in.data() + in.size()) - in.data() == 0);

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.ctype.byname/scan_is.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.ctype.byname/scan_is.pass.cpp
@@ -20,7 +20,6 @@
 
 #include <locale>
 #include <string>
-#include <vector>
 #include <cassert>
 
 #include <stdio.h>
@@ -36,7 +35,6 @@ int main(int, char**)
             typedef std::ctype<wchar_t> F;
             const F& f = std::use_facet<F>(l);
             const std::wstring in(L"\x00DA A\x07.a1");
-            std::vector<F::mask> m(in.size());
             assert(f.scan_is(F::space, in.data(), in.data() + in.size()) - in.data() == 1);
             assert(f.scan_is(F::print, in.data(), in.data() + in.size()) - in.data() == 0);
             assert(f.scan_is(F::cntrl, in.data(), in.data() + in.size()) - in.data() == 3);
@@ -57,7 +55,6 @@ int main(int, char**)
             typedef std::ctype<wchar_t> F;
             const F& f = std::use_facet<F>(l);
             const std::wstring in(L"\x00DA A\x07.a1");
-            std::vector<F::mask> m(in.size());
             assert(f.scan_is(F::space, in.data(), in.data() + in.size()) - in.data() == 1);
             assert(f.scan_is(F::cntrl, in.data(), in.data() + in.size()) - in.data() == 3);
             assert(f.scan_is(F::lower, in.data(), in.data() + in.size()) - in.data() == 5);

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.ctype.byname/scan_not.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.ctype.byname/scan_not.pass.cpp
@@ -20,7 +20,6 @@
 
 #include <locale>
 #include <string>
-#include <vector>
 #include <cassert>
 
 #include <stdio.h>
@@ -36,7 +35,6 @@ int main(int, char**)
             typedef std::ctype<wchar_t> F;
             const F& f = std::use_facet<F>(l);
             const std::wstring in(L"\x00DA A\x07.a1");
-            std::vector<F::mask> m(in.size());
             assert(f.scan_not(F::space, in.data(), in.data() + in.size()) - in.data() == 0);
             assert(f.scan_not(F::print, in.data(), in.data() + in.size()) - in.data() == 3);
             assert(f.scan_not(F::cntrl, in.data(), in.data() + in.size()) - in.data() == 0);
@@ -57,7 +55,6 @@ int main(int, char**)
             typedef std::ctype<wchar_t> F;
             const F& f = std::use_facet<F>(l);
             const std::wstring in(L"\x00DA A\x07.a1");
-            std::vector<F::mask> m(in.size());
             assert(f.scan_not(F::space, in.data(), in.data() + in.size()) - in.data() == 0);
             assert(f.scan_not(F::cntrl, in.data(), in.data() + in.size()) - in.data() == 0);
             assert(f.scan_not(F::lower, in.data(), in.data() + in.size()) - in.data() == 0);

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.ctype/locale.ctype.members/scan_is.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.ctype/locale.ctype.members/scan_is.pass.cpp
@@ -30,7 +30,6 @@ int main(int, char**)
         typedef std::ctype<wchar_t> F;
         const F& f = std::use_facet<F>(l);
         const std::wstring in(L" A\x07.a1");
-        std::vector<F::mask> m(in.size());
         assert(f.scan_is(F::space, in.data(), in.data() + in.size()) - in.data() == 0);
         assert(f.scan_is(F::print, in.data(), in.data() + in.size()) - in.data() == 0);
         assert(f.scan_is(F::cntrl, in.data(), in.data() + in.size()) - in.data() == 2);

--- a/libcxx/test/std/localization/locale.categories/category.ctype/locale.ctype/locale.ctype.members/scan_not.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.ctype/locale.ctype/locale.ctype.members/scan_not.pass.cpp
@@ -16,7 +16,6 @@
 
 #include <locale>
 #include <string>
-#include <vector>
 #include <cassert>
 
 #include <stdio.h>
@@ -30,7 +29,6 @@ int main(int, char**)
         typedef std::ctype<wchar_t> F;
         const F& f = std::use_facet<F>(l);
         const std::wstring in(L" A\x07.a1");
-        std::vector<F::mask> m(in.size());
         assert(f.scan_not(F::space, in.data(), in.data() + in.size()) - in.data() == 1);
         assert(f.scan_not(F::print, in.data(), in.data() + in.size()) - in.data() == 2);
         assert(f.scan_not(F::cntrl, in.data(), in.data() + in.size()) - in.data() == 0);

--- a/libcxx/test/std/localization/locale.categories/category.time/locale.time.put/locale.time.put.members/put2.pass.cpp
+++ b/libcxx/test/std/localization/locale.categories/category.time/locale.time.put/locale.time.put.members/put2.pass.cpp
@@ -314,11 +314,13 @@ int main(int, char**)
     {
         cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', &t, 'Z');
         std::string ex(str, base(iter));
+        (void)ex;
 //        assert(ex == "EDT");  depends on time zone
     }
     {
         cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', &t, 'z');
         std::string ex(str, base(iter));
+        (void)ex;
 //        assert(ex == "-0400");  depends on time zone
     }
 #ifndef _WIN32
@@ -327,6 +329,7 @@ int main(int, char**)
     {
         cpp17_output_iterator<char*> iter = f.put(cpp17_output_iterator<char*>(str), ios, '*', &t, '+');
         std::string ex(str, base(iter));
+        (void)ex;
 //        assert(ex == "Sat May  2 13:03:06 EDT 2009");  depends on time zone
     }
 #endif

--- a/libcxx/test/std/localization/locales/locale.convenience/conversions/conversions.string/converted.pass.cpp
+++ b/libcxx/test/std/localization/locales/locale.convenience/conversions/conversions.string/converted.pass.cpp
@@ -41,11 +41,11 @@ void TestHelper<CharT, 2>::test() {
     typedef std::wstring_convert<Codecvt> Myconv;
     Myconv myconv;
     assert(myconv.converted() == 0);
-    std::string bs = myconv.to_bytes(L"\u1005");
+    (void)myconv.to_bytes(L"\u1005");
     assert(myconv.converted() == 1);
-    bs = myconv.to_bytes(L"\u1005e");
+    (void)myconv.to_bytes(L"\u1005e");
     assert(myconv.converted() == 2);
-    std::wstring ws = myconv.from_bytes("\xE1\x80\x85");
+    (void)myconv.from_bytes("\xE1\x80\x85");
     assert(myconv.converted() == 3);
   }
 }
@@ -58,11 +58,11 @@ void TestHelper<CharT, 4>::test() {
     typedef std::wstring_convert<Codecvt> Myconv;
     Myconv myconv;
     assert(myconv.converted() == 0);
-    std::string bs = myconv.to_bytes(L"\U00040003");
+    (void)myconv.to_bytes(L"\U00040003");
     assert(myconv.converted() == 1);
-    bs = myconv.to_bytes(L"\U00040003e");
+    (void)myconv.to_bytes(L"\U00040003e");
     assert(myconv.converted() == 2);
-    std::wstring ws = myconv.from_bytes("\xF1\x80\x80\x83");
+    (void)myconv.from_bytes("\xF1\x80\x80\x83");
     assert(myconv.converted() == 4);
   }
 }

--- a/libcxx/test/std/ranges/range.adaptors/range.lazy.split/general.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.lazy.split/general.pass.cpp
@@ -256,9 +256,6 @@ bool test_nontrivial_characters() {
     {"hijk", 5},
   };
 
-  Vec expected1 = {m1, m2};
-  Vec expected2 = {m3};
-
   std::ranges::lazy_split_view v(Vec{m1, m2, sep, m3}, sep);
 
   // Segment 1: {m1, m2}

--- a/libcxx/test/std/ranges/range.adaptors/range.split/general.pass.cpp
+++ b/libcxx/test/std/ranges/range.adaptors/range.split/general.pass.cpp
@@ -204,9 +204,6 @@ bool test_nontrivial_characters() {
       {"hijk", 5},
   };
 
-  Vec expected1 = {m1, m2};
-  Vec expected2 = {m3};
-
   std::ranges::split_view v(Vec{m1, m2, sep, m3}, sep);
 
   // Segment 1: {m1, m2}

--- a/libcxx/test/std/ranges/range.utility/range.utility.conv/to_std_containers.pass.cpp
+++ b/libcxx/test/std/ranges/range.utility/range.utility.conv/to_std_containers.pass.cpp
@@ -62,7 +62,7 @@ template <class From, class To>
 void test_is_permutation(std::vector<std::vector<typename From::value_type>> inputs) {
   for (const auto& in : inputs) {
     From from(in.begin(), in.end());
-    std::same_as<To> decltype(auto) result = std::ranges::to<To>(in);
+    std::same_as<To> decltype(auto) result = std::ranges::to<To>(from);
     assert(std::ranges::is_permutation(in, result));
   }
 }

--- a/libcxx/test/std/re/re.regex/re.regex.construct/il_flg.pass.cpp
+++ b/libcxx/test/std/re/re.regex/re.regex.construct/il_flg.pass.cpp
@@ -31,11 +31,6 @@ test(std::initializer_list<char> il, std::regex_constants::syntax_option_type f,
 
 int main(int, char**)
 {
-    std::string s1("\\(a\\)");
-    std::string s2("\\(a[bc]\\)");
-    std::string s3("\\(a\\([bc]\\)\\)");
-    std::string s4("(a([bc]))");
-
     test({'\\', '(', 'a', '\\', ')'}, std::regex_constants::basic, 1);
     test({'\\', '(', 'a', '[', 'b', 'c', ']', '\\', ')'}, std::regex_constants::basic, 1);
     test({'\\', '(', 'a', '\\', '(', '[', 'b', 'c', ']', '\\', ')', '\\', ')'}, std::regex_constants::basic, 2);

--- a/libcxx/test/std/strings/basic.string/string.cons/T_size_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/T_size_size.pass.cpp
@@ -45,6 +45,7 @@ TEST_CONSTEXPR_CXX20 void test(SV sv, std::size_t pos, std::size_t n) {
   else if (!TEST_IS_CONSTANT_EVALUATED) {
     try {
       S s2(sv, static_cast<Size>(pos), static_cast<Size>(n));
+      (void)s2;
       assert(false);
     } catch (std::out_of_range&) {
       assert(pos > sv.size());
@@ -71,6 +72,7 @@ TEST_CONSTEXPR_CXX20 void test(SV sv, std::size_t pos, std::size_t n, const type
   else if (!TEST_IS_CONSTANT_EVALUATED) {
     try {
       S s2(sv, static_cast<Size>(pos), static_cast<Size>(n), a);
+      (void)s2;
       assert(false);
     } catch (std::out_of_range&) {
       assert(pos > sv.size());

--- a/libcxx/test/std/strings/basic.string/string.cons/dtor.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/dtor.pass.cpp
@@ -45,6 +45,7 @@ TEST_CONSTEXPR_CXX20 bool test() {
   {
     std::basic_string<char, std::char_traits<char>, test_allocator<char>> str2((test_allocator<char>(&alloc_stats)));
     str2 = "long long string so no SSO";
+    (void)str2;
     assert(alloc_stats.alloc_count > 0);
     LIBCPP_ASSERT(alloc_stats.alloc_count == 1);
   }

--- a/libcxx/test/std/strings/basic.string/string.cons/from_range.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/from_range.pass.cpp
@@ -99,7 +99,7 @@ void test_string_exception_safety_throwing_allocator() {
 
     globalMemCounter.reset();
     // Note: the input string must be long enough to prevent SSO, otherwise the allocator won't be used.
-    std::basic_string<char, std::char_traits<char>, ThrowingAllocator<char>> c(
+    [[maybe_unused]] std::basic_string<char, std::char_traits<char>, ThrowingAllocator<char>> c(
         std::from_range, std::vector<char>(64, 'A'), alloc);
     assert(false); // The constructor call should throw.
 

--- a/libcxx/test/std/strings/basic.string/string.cons/move_alloc.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/move_alloc.pass.cpp
@@ -61,6 +61,7 @@ TEST_CONSTEXPR_CXX20 bool test() {
 #endif
     S s1("Twas brillig, and the slivy toves did gyre and gymbal in the wabe", A(&alloc_stats));
     S s2(std::move(s1), A(1, &alloc_stats));
+    (void)s2;
   }
   assert(alloc_stats.alloc_count == alloc_count);
   {

--- a/libcxx/test/std/strings/basic.string/string.cons/substr.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.cons/substr.pass.cpp
@@ -47,6 +47,7 @@ TEST_CONSTEXPR_CXX20 void test(S str, unsigned pos) {
   else if (!TEST_IS_CONSTANT_EVALUATED) {
     try {
       S s2(str, pos);
+      (void)s2;
       assert(false);
     } catch (std::out_of_range&) {
       assert(pos > str.size());
@@ -73,6 +74,7 @@ TEST_CONSTEXPR_CXX20 void test(S str, unsigned pos, unsigned n) {
   else if (!TEST_IS_CONSTANT_EVALUATED) {
     try {
       S s2(str, pos, n);
+      (void)s2;
       assert(false);
     } catch (std::out_of_range&) {
       assert(pos > str.size());
@@ -99,6 +101,7 @@ TEST_CONSTEXPR_CXX20 void test(S str, unsigned pos, unsigned n, const typename S
   else if (!TEST_IS_CONSTANT_EVALUATED) {
     try {
       S s2(str, pos, n, a);
+      (void)s2;
       assert(false);
     } catch (std::out_of_range&) {
       assert(pos > str.size());

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_erase/size_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_erase/size_size.pass.cpp
@@ -22,7 +22,6 @@
 template <class S>
 TEST_CONSTEXPR_CXX20 void test(S s, typename S::size_type pos, typename S::size_type n, S expected) {
   const typename S::size_type old_size = s.size();
-  S s0                                 = s;
   if (pos <= old_size) {
     s.erase(pos, n);
     LIBCPP_ASSERT(s.__invariants());
@@ -32,6 +31,7 @@ TEST_CONSTEXPR_CXX20 void test(S s, typename S::size_type pos, typename S::size_
   }
 #ifndef TEST_HAS_NO_EXCEPTIONS
   else if (!TEST_IS_CONSTANT_EVALUATED) {
+    S s0 = s;
     try {
       s.erase(pos, n);
       assert(false);
@@ -46,7 +46,6 @@ TEST_CONSTEXPR_CXX20 void test(S s, typename S::size_type pos, typename S::size_
 template <class S>
 TEST_CONSTEXPR_CXX20 void test(S s, typename S::size_type pos, S expected) {
   const typename S::size_type old_size = s.size();
-  S s0                                 = s;
   if (pos <= old_size) {
     s.erase(pos);
     LIBCPP_ASSERT(s.__invariants());
@@ -55,6 +54,7 @@ TEST_CONSTEXPR_CXX20 void test(S s, typename S::size_type pos, S expected) {
   }
 #ifndef TEST_HAS_NO_EXCEPTIONS
   else if (!TEST_IS_CONSTANT_EVALUATED) {
+    S s0 = s;
     try {
       s.erase(pos);
       assert(false);

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_insert/size_T_size_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_insert/size_T_size_size.pass.cpp
@@ -25,7 +25,6 @@ TEST_CONSTEXPR_CXX20 void
 test(S s, typename S::size_type pos1, SV sv, typename S::size_type pos2, typename S::size_type n, S expected) {
   static_assert((!std::is_same<S, SV>::value), "");
   const typename S::size_type old_size = s.size();
-  S s0                                 = s;
   if (pos1 <= old_size && pos2 <= sv.size()) {
     s.insert(pos1, sv, pos2, n);
     LIBCPP_ASSERT(s.__invariants());
@@ -33,6 +32,7 @@ test(S s, typename S::size_type pos1, SV sv, typename S::size_type pos2, typenam
   }
 #ifndef TEST_HAS_NO_EXCEPTIONS
   else if (!TEST_IS_CONSTANT_EVALUATED) {
+    S s0 = s;
     try {
       s.insert(pos1, sv, pos2, n);
       assert(false);
@@ -48,7 +48,6 @@ template <class S, class SV>
 TEST_CONSTEXPR_CXX20 void test_npos(S s, typename S::size_type pos1, SV sv, typename S::size_type pos2, S expected) {
   static_assert((!std::is_same<S, SV>::value), "");
   const typename S::size_type old_size = s.size();
-  S s0                                 = s;
   if (pos1 <= old_size && pos2 <= sv.size()) {
     s.insert(pos1, sv, pos2);
     LIBCPP_ASSERT(s.__invariants());
@@ -56,6 +55,7 @@ TEST_CONSTEXPR_CXX20 void test_npos(S s, typename S::size_type pos1, SV sv, type
   }
 #ifndef TEST_HAS_NO_EXCEPTIONS
   else if (!TEST_IS_CONSTANT_EVALUATED) {
+    S s0 = s;
     try {
       s.insert(pos1, sv, pos2);
       assert(false);

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_insert/size_pointer.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_insert/size_pointer.pass.cpp
@@ -22,7 +22,6 @@
 template <class S>
 TEST_CONSTEXPR_CXX20 void test(S s, typename S::size_type pos, const typename S::value_type* str, S expected) {
   const typename S::size_type old_size = s.size();
-  S s0                                 = s;
   if (pos <= old_size) {
     s.insert(pos, str);
     LIBCPP_ASSERT(s.__invariants());
@@ -31,6 +30,7 @@ TEST_CONSTEXPR_CXX20 void test(S s, typename S::size_type pos, const typename S:
   }
 #ifndef TEST_HAS_NO_EXCEPTIONS
   else if (!TEST_IS_CONSTANT_EVALUATED) {
+    S s0 = s;
     try {
       s.insert(pos, str);
       assert(false);

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_insert/size_pointer_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_insert/size_pointer_size.pass.cpp
@@ -23,7 +23,6 @@ template <class S>
 TEST_CONSTEXPR_CXX20 void
 test(S s, typename S::size_type pos, const typename S::value_type* str, typename S::size_type n, S expected) {
   const typename S::size_type old_size = s.size();
-  S s0                                 = s;
   if (pos <= old_size) {
     s.insert(pos, str, n);
     LIBCPP_ASSERT(s.__invariants());
@@ -32,6 +31,7 @@ test(S s, typename S::size_type pos, const typename S::value_type* str, typename
   }
 #ifndef TEST_HAS_NO_EXCEPTIONS
   else if (!TEST_IS_CONSTANT_EVALUATED) {
+    S s0 = s;
     try {
       s.insert(pos, str, n);
       assert(false);

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_insert/size_size_char.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_insert/size_size_char.pass.cpp
@@ -23,7 +23,6 @@ template <class S>
 TEST_CONSTEXPR_CXX20 void
 test(S s, typename S::size_type pos, typename S::size_type n, typename S::value_type str, S expected) {
   const typename S::size_type old_size = s.size();
-  S s0                                 = s;
   if (pos <= old_size) {
     s.insert(pos, n, str);
     LIBCPP_ASSERT(s.__invariants());
@@ -32,6 +31,7 @@ test(S s, typename S::size_type pos, typename S::size_type n, typename S::value_
   }
 #ifndef TEST_HAS_NO_EXCEPTIONS
   else if (!TEST_IS_CONSTANT_EVALUATED) {
+    S s0 = s;
     try {
       s.insert(pos, n, str);
       assert(false);

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_insert/size_string.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_insert/size_string.pass.cpp
@@ -22,7 +22,6 @@
 template <class S>
 TEST_CONSTEXPR_CXX20 void test(S s, typename S::size_type pos, S str, S expected) {
   const typename S::size_type old_size = s.size();
-  S s0                                 = s;
   if (pos <= old_size) {
     s.insert(pos, str);
     LIBCPP_ASSERT(s.__invariants());
@@ -31,6 +30,7 @@ TEST_CONSTEXPR_CXX20 void test(S s, typename S::size_type pos, S str, S expected
   }
 #ifndef TEST_HAS_NO_EXCEPTIONS
   else if (!TEST_IS_CONSTANT_EVALUATED) {
+    S s0 = s;
     try {
       s.insert(pos, str);
       assert(false);

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_insert/size_string_size_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_insert/size_string_size_size.pass.cpp
@@ -25,7 +25,6 @@ template <class S>
 TEST_CONSTEXPR_CXX20 void
 test(S s, typename S::size_type pos1, S str, typename S::size_type pos2, typename S::size_type n, S expected) {
   const typename S::size_type old_size = s.size();
-  S s0                                 = s;
   if (pos1 <= old_size && pos2 <= str.size()) {
     s.insert(pos1, str, pos2, n);
     LIBCPP_ASSERT(s.__invariants());
@@ -34,6 +33,7 @@ test(S s, typename S::size_type pos1, S str, typename S::size_type pos2, typenam
   }
 #ifndef TEST_HAS_NO_EXCEPTIONS
   else if (!TEST_IS_CONSTANT_EVALUATED) {
+    S s0 = s;
     try {
       s.insert(pos1, str, pos2, n);
       assert(false);
@@ -48,7 +48,6 @@ test(S s, typename S::size_type pos1, S str, typename S::size_type pos2, typenam
 template <class S>
 TEST_CONSTEXPR_CXX20 void test_npos(S s, typename S::size_type pos1, S str, typename S::size_type pos2, S expected) {
   const typename S::size_type old_size = s.size();
-  S s0                                 = s;
   if (pos1 <= old_size && pos2 <= str.size()) {
     s.insert(pos1, str, pos2);
     LIBCPP_ASSERT(s.__invariants());
@@ -56,6 +55,7 @@ TEST_CONSTEXPR_CXX20 void test_npos(S s, typename S::size_type pos1, S str, type
   }
 #ifndef TEST_HAS_NO_EXCEPTIONS
   else if (!TEST_IS_CONSTANT_EVALUATED) {
+    S s0 = s;
     try {
       s.insert(pos1, str, pos2);
       assert(false);

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_insert/string_view.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_insert/string_view.pass.cpp
@@ -21,7 +21,6 @@
 template <class S, class SV>
 TEST_CONSTEXPR_CXX20 void test(S s, typename S::size_type pos, SV sv, S expected) {
   const typename S::size_type old_size = s.size();
-  S s0                                 = s;
   if (pos <= old_size) {
     s.insert(pos, sv);
     LIBCPP_ASSERT(s.__invariants());
@@ -29,6 +28,7 @@ TEST_CONSTEXPR_CXX20 void test(S s, typename S::size_type pos, SV sv, S expected
   }
 #ifndef TEST_HAS_NO_EXCEPTIONS
   else if (!TEST_IS_CONSTANT_EVALUATED) {
+    S s0 = s;
     try {
       s.insert(pos, sv);
       assert(false);

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_replace/size_size_T_size_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_replace/size_size_T_size_size.pass.cpp
@@ -42,7 +42,6 @@ test(S s,
   static_assert(sizeof(SizeT) == sizeof(typename SV::size_type), "");
 
   const SizeT old_size = s.size();
-  S s0                 = s;
   if (pos1 <= old_size && pos2 <= sv.size()) {
     s.replace(pos1, n1, sv, pos2, n2);
     LIBCPP_ASSERT(s.__invariants());
@@ -54,6 +53,7 @@ test(S s,
   }
 #ifndef TEST_HAS_NO_EXCEPTIONS
   else if (!TEST_IS_CONSTANT_EVALUATED) {
+    S s0 = s;
     try {
       s.replace(pos1, n1, sv, pos2, n2);
       assert(false);
@@ -71,7 +71,6 @@ test_npos(S s, typename S::size_type pos1, typename S::size_type n1, SV sv, type
   typedef typename S::size_type SizeT;
   static_assert((!std::is_same<S, SV>::value), "");
   const SizeT old_size = s.size();
-  S s0                 = s;
   if (pos1 <= old_size && pos2 <= sv.size()) {
     s.replace(pos1, n1, sv, pos2);
     LIBCPP_ASSERT(s.__invariants());
@@ -82,6 +81,7 @@ test_npos(S s, typename S::size_type pos1, typename S::size_type n1, SV sv, type
   }
 #ifndef TEST_HAS_NO_EXCEPTIONS
   else if (!TEST_IS_CONSTANT_EVALUATED) {
+    S s0 = s;
     try {
       s.replace(pos1, n1, sv, pos2);
       assert(false);

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_replace/size_size_pointer.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_replace/size_size_pointer.pass.cpp
@@ -24,7 +24,6 @@ template <class S>
 TEST_CONSTEXPR_CXX20 void
 test(S s, typename S::size_type pos, typename S::size_type n1, const typename S::value_type* str, S expected) {
   const typename S::size_type old_size = s.size();
-  S s0                                 = s;
   if (pos <= old_size) {
     s.replace(pos, n1, str);
     LIBCPP_ASSERT(s.__invariants());
@@ -36,6 +35,7 @@ test(S s, typename S::size_type pos, typename S::size_type n1, const typename S:
   }
 #ifndef TEST_HAS_NO_EXCEPTIONS
   else if (!TEST_IS_CONSTANT_EVALUATED) {
+    S s0 = s;
     try {
       s.replace(pos, n1, str);
       assert(false);

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_replace/size_size_pointer_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_replace/size_size_pointer_size.pass.cpp
@@ -29,7 +29,6 @@ test(S s,
      typename S::size_type n2,
      S expected) {
   const typename S::size_type old_size = s.size();
-  S s0                                 = s;
   if (pos <= old_size) {
     s.replace(pos, n1, str, n2);
     LIBCPP_ASSERT(s.__invariants());
@@ -41,6 +40,7 @@ test(S s,
   }
 #ifndef TEST_HAS_NO_EXCEPTIONS
   else if (!TEST_IS_CONSTANT_EVALUATED) {
+    S s0 = s;
     try {
       s.replace(pos, n1, str, n2);
       assert(false);

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_replace/size_size_size_char.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_replace/size_size_size_char.pass.cpp
@@ -29,7 +29,6 @@ test(S s,
      typename S::value_type c,
      S expected) {
   const typename S::size_type old_size = s.size();
-  S s0                                 = s;
   if (pos <= old_size) {
     s.replace(pos, n1, n2, c);
     LIBCPP_ASSERT(s.__invariants());
@@ -41,6 +40,7 @@ test(S s,
   }
 #ifndef TEST_HAS_NO_EXCEPTIONS
   else if (!TEST_IS_CONSTANT_EVALUATED) {
+    S s0 = s;
     try {
       s.replace(pos, n1, n2, c);
       assert(false);

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_replace/size_size_string.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_replace/size_size_string.pass.cpp
@@ -23,7 +23,6 @@
 template <class S>
 TEST_CONSTEXPR_CXX20 void test(S s, typename S::size_type pos1, typename S::size_type n1, S str, S expected) {
   const typename S::size_type old_size = s.size();
-  S s0                                 = s;
   if (pos1 <= old_size) {
     s.replace(pos1, n1, str);
     LIBCPP_ASSERT(s.__invariants());
@@ -35,6 +34,7 @@ TEST_CONSTEXPR_CXX20 void test(S s, typename S::size_type pos1, typename S::size
   }
 #ifndef TEST_HAS_NO_EXCEPTIONS
   else if (!TEST_IS_CONSTANT_EVALUATED) {
+    S s0 = s;
     try {
       s.replace(pos1, n1, str);
       assert(false);

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_replace/size_size_string_size_size.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_replace/size_size_string_size_size.pass.cpp
@@ -34,7 +34,6 @@ test(S s,
      typename S::size_type n2,
      S expected) {
   const typename S::size_type old_size = s.size();
-  S s0                                 = s;
   if (pos1 <= old_size && pos2 <= str.size()) {
     s.replace(pos1, n1, str, pos2, n2);
     LIBCPP_ASSERT(s.__invariants());
@@ -46,6 +45,7 @@ test(S s,
   }
 #ifndef TEST_HAS_NO_EXCEPTIONS
   else if (!TEST_IS_CONSTANT_EVALUATED) {
+    S s0 = s;
     try {
       s.replace(pos1, n1, str, pos2, n2);
       assert(false);
@@ -61,7 +61,6 @@ template <class S>
 TEST_CONSTEXPR_CXX20 void
 test_npos(S s, typename S::size_type pos1, typename S::size_type n1, S str, typename S::size_type pos2, S expected) {
   const typename S::size_type old_size = s.size();
-  S s0                                 = s;
   if (pos1 <= old_size && pos2 <= str.size()) {
     s.replace(pos1, n1, str, pos2);
     LIBCPP_ASSERT(s.__invariants());
@@ -72,6 +71,7 @@ test_npos(S s, typename S::size_type pos1, typename S::size_type n1, S str, type
   }
 #ifndef TEST_HAS_NO_EXCEPTIONS
   else if (!TEST_IS_CONSTANT_EVALUATED) {
+    S s0 = s;
     try {
       s.replace(pos1, n1, str, pos2);
       assert(false);

--- a/libcxx/test/std/strings/basic.string/string.modifiers/string_replace/size_size_string_view.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.modifiers/string_replace/size_size_string_view.pass.cpp
@@ -23,7 +23,6 @@
 template <class S, class SV>
 TEST_CONSTEXPR_CXX20 void test(S s, typename S::size_type pos1, typename S::size_type n1, SV sv, S expected) {
   const typename S::size_type old_size = s.size();
-  S s0                                 = s;
   if (pos1 <= old_size) {
     s.replace(pos1, n1, sv);
     LIBCPP_ASSERT(s.__invariants());
@@ -35,6 +34,7 @@ TEST_CONSTEXPR_CXX20 void test(S s, typename S::size_type pos1, typename S::size
   }
 #ifndef TEST_HAS_NO_EXCEPTIONS
   else if (!TEST_IS_CONSTANT_EVALUATED) {
+    S s0 = s;
     try {
       s.replace(pos1, n1, sv);
       assert(false);

--- a/libcxx/test/std/strings/basic.string/string.ops/string_substr/substr.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.ops/string_substr/substr.pass.cpp
@@ -37,6 +37,7 @@ TEST_CONSTEXPR_CXX20 void test(const S& s, typename S::size_type pos, typename S
   else if (!TEST_IS_CONSTANT_EVALUATED) {
     try {
       S str = s.substr(pos, n);
+      (void)str;
       assert(false);
     } catch (std::out_of_range&) {
       assert(pos > s.size());

--- a/libcxx/test/std/strings/basic.string/string.ops/string_substr/substr_rvalue.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.ops/string_substr/substr_rvalue.pass.cpp
@@ -43,6 +43,7 @@ constexpr void test(S orig, typename S::size_type pos, typename S::size_type n, 
   if (!std::is_constant_evaluated()) {
     try {
       S str = std::move(orig).substr(pos, n);
+      (void)str;
       assert(false);
     } catch (const std::out_of_range&) {
     }

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_deque_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_deque_synop2.pass.cpp
@@ -23,7 +23,7 @@
 int main(int, char**) {
   {
     // Check that std::pmr::deque is usable without <memory_resource>.
-    std::pmr::deque<int> d;
+    [[maybe_unused]] std::pmr::deque<int> d;
   }
 
   return 0;

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_list_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_list_synop2.pass.cpp
@@ -23,7 +23,7 @@
 int main(int, char**) {
   {
     // Check that std::pmr::list is usable without <memory_resource>.
-    std::pmr::list<int> l;
+    [[maybe_unused]] std::pmr::list<int> l;
   }
 
   return 0;

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_map_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_map_synop2.pass.cpp
@@ -23,8 +23,8 @@
 int main(int, char**) {
   {
     // Check that std::pmr::map is usable without <memory_resource>.
-    std::pmr::map<int, int> m;
-    std::pmr::multimap<int, int> mm;
+    [[maybe_unused]] std::pmr::map<int, int> m;
+    [[maybe_unused]] std::pmr::multimap<int, int> mm;
   }
 
   return 0;

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_set_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_set_synop2.pass.cpp
@@ -23,8 +23,8 @@
 int main(int, char**) {
   {
     // Check that std::pmr::set is usable without <memory_resource>.
-    std::pmr::set<int> s;
-    std::pmr::multiset<int> ms;
+    [[maybe_unused]] std::pmr::set<int> s;
+    [[maybe_unused]] std::pmr::multiset<int> ms;
   }
 
   return 0;

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_string_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_string_synop2.pass.cpp
@@ -28,12 +28,12 @@
 int main(int, char**) {
   {
     // Check that std::pmr::string is usable without <memory_resource>.
-    std::pmr::string s;
+    [[maybe_unused]] std::pmr::string s;
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
-    std::pmr::wstring ws;
+    [[maybe_unused]] std::pmr::wstring ws;
 #endif
-    std::pmr::u16string u16s;
-    std::pmr::u32string u32s;
+    [[maybe_unused]] std::pmr::u16string u16s;
+    [[maybe_unused]] std::pmr::u32string u32s;
   }
 
   return 0;

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_unordered_map_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_unordered_map_synop2.pass.cpp
@@ -23,8 +23,8 @@
 int main(int, char**) {
   {
     // Check that std::pmr::unordered_map is usable without <memory_resource>.
-    std::pmr::unordered_map<int, int> m;
-    std::pmr::unordered_multimap<int, int> mm;
+    [[maybe_unused]] std::pmr::unordered_map<int, int> m;
+    [[maybe_unused]] std::pmr::unordered_multimap<int, int> mm;
   }
 
   return 0;

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_unordered_set_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_unordered_set_synop2.pass.cpp
@@ -23,8 +23,8 @@
 int main(int, char**) {
   {
     // Check that std::pmr::unordered_set is usable without <memory_resource>.
-    std::pmr::unordered_set<int> s;
-    std::pmr::unordered_multiset<int> ms;
+    [[maybe_unused]] std::pmr::unordered_set<int> s;
+    [[maybe_unused]] std::pmr::unordered_multiset<int> ms;
   }
 
   return 0;

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_vector_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_vector_synop2.pass.cpp
@@ -23,7 +23,7 @@
 int main(int, char**) {
   {
     // Check that std::pmr::vector is usable without <memory_resource>.
-    std::pmr::vector<int> l;
+    [[maybe_unused]] std::pmr::vector<int> l;
   }
 
   return 0;


### PR DESCRIPTION
This adds `[[gnu::warn_unused]]` to all container types currently implemented. In the future new containers should be added to the list, as well as other value types in the library.

Clang has `-Wunused`, which is a suite of warnings about unused variables. However, that doesn't warn for a lot of class types, especially non-trivial ones. That is done to avoid false-positives for RAII-style types like `lock_guard`. `[[gnu::warn_unused]]` exists to tell Clang that a given class is a value type.