### PR TITLE
[flang][OpenACC] Support COLLAPSE on DO CONCURRENT

### DIFF
--- a/flang/docs/OpenACC-extensions.md
+++ b/flang/docs/OpenACC-extensions.md
@@ -43,6 +43,12 @@ These extensions require no flag.
   or module, but Flang permits it with a warning when the same clause is used.
 * The REDUCTION clause accepts a MINUS "-" operator which is not permitted in
   the OpenACC specification. A warning is issued for this use. 
+* The `collapse` clause may be applied to a `DO CONCURRENT` loop, which the
+  OpenACC specification does not permit. The collapse value must equal the
+  number of `DO CONCURRENT` controls; the construct then lowers like the
+  equivalent perfectly-nested `DO` loops. A portability warning is issued for
+  this use (`-Wportability`, also enabled by `-pedantic`; suppress with
+  `-Wno-portability`).
 
 ## Extensions enabled by default
 

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -3689,11 +3689,15 @@ private:
 
       if (curEval->lowerAsStructured()) {
         curEval = &curEval->getFirstNestedEvaluation();
-        for (uint64_t i = 1; i < loopCount; i++) {
-          if (!curEval->hasNestedEvaluations())
-            break;
-          curEval = &*std::next(curEval->getNestedEvaluations().begin());
-        }
+        // A DO CONCURRENT holds all controls in one construct; the per-level
+        // descent would overshoot into its body and drop it.
+        const auto *outerDo = curEval->getIf<Fortran::parser::DoConstruct>();
+        if (!(outerDo && outerDo->IsDoConcurrent()))
+          for (uint64_t i = 1; i < loopCount; i++) {
+            if (!curEval->hasNestedEvaluations())
+              break;
+            curEval = &*std::next(curEval->getNestedEvaluations().begin());
+          }
       }
     }
 

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -3661,6 +3661,13 @@ private:
     const Fortran::parser::OpenACCCombinedConstruct *accCombined =
         std::get_if<Fortran::parser::OpenACCCombinedConstruct>(&acc.u);
 
+    // TODO: Determining curEval here re-walks the nested evaluations to the
+    // collapse/DO CONCURRENT depth that the construct absorbs, mirroring the
+    // descent genOpenACCConstruct already performs (visitLoopControl in
+    // OpenACC.cpp). That duplication is fragile and couples this code to
+    // genOpenACCConstruct's internals. Move the responsibility for determining
+    // curEval into genOpenACCConstruct -- where the absorbed evaluations are
+    // actually decided -- and return it from there.
     Fortran::lower::pft::Evaluation *curEval = &getEval();
     // Determine collapse depth/force and loopCount
     bool collapseForce = false;

--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -2385,9 +2385,32 @@ static mlir::acc::LoopOp createLoopOp(
   uint64_t loopsToProcess =
       Fortran::lower::getLoopCountForCollapseAndTile(accClauseList);
 
-  if (outerDoConstruct.IsDoConcurrent() &&
-      Fortran::lower::getCollapseSizeAndForce(accClauseList).first > 1)
-    TODO(currentLocation, "OpenACC LOOP COLLAPSE with DO CONCURRENT");
+  if (outerDoConstruct.IsDoConcurrent()) {
+    uint64_t collapseValue =
+        Fortran::lower::getCollapseSizeAndForce(accClauseList).first;
+    if (collapseValue > 1) {
+      // N>C reaches here only via mixed DO CONCURRENT + inner DO; semantics
+      // rejects the straight-line N>C case.
+      const Fortran::parser::LoopControl *loopControl =
+          &*outerDoConstruct.GetLoopControl();
+      const auto &concurrent =
+          std::get<Fortran::parser::LoopControl::Concurrent>(loopControl->u);
+      const auto &concurrentHeader =
+          std::get<Fortran::parser::ConcurrentHeader>(concurrent.t);
+      const auto &controls =
+          std::get<std::list<Fortran::parser::ConcurrentControl>>(
+              concurrentHeader.t);
+      uint64_t controlCount = controls.size();
+      if (collapseValue > controlCount)
+        TODO(currentLocation,
+             "OpenACC LOOP COLLAPSE greater than DO CONCURRENT control count");
+      if (collapseValue < controlCount)
+        TODO(currentLocation,
+             "OpenACC LOOP COLLAPSE less than DO CONCURRENT control count");
+      // N==C falls through; its body relies on Bridge.cpp not descending into
+      // the DO CONCURRENT.
+    }
+  }
 
   auto loopOp = buildACCLoopOp(
       converter, currentLocation, semanticsContext, stmtCtx, outerDoConstruct,

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1654,6 +1654,13 @@ void AccAttributeVisitor::CheckAssociatedLoop(
     return;
   }
 
+  // Non-standard extension; warn for collapse(N>1) on a DO CONCURRENT.
+  if (outerDoConstruct.IsDoConcurrent() && level > 1) {
+    context_.Warn(common::UsageWarning::Portability,
+        GetContext().directiveSource,
+        "COLLAPSE on DO CONCURRENT is non-standard"_warn_en_US);
+  }
+
   const auto getNextDoConstruct =
       [this, forceCollapsed](const parser::Block &block,
           std::int64_t &level) -> const parser::DoConstruct * {

--- a/flang/test/Lower/OpenACC/Todo/do-loops-to-acc-loops-todo.f90
+++ b/flang/test/Lower/OpenACC/Todo/do-loops-to-acc-loops-todo.f90
@@ -3,7 +3,8 @@
 ! RUN: %not_todo_cmd bbc -fopenacc -emit-hlfir %t/do_loop_with_cycle_goto.f90 -o - 2>&1 | FileCheck %s --check-prefix=CHECK2
 ! RUN: %not_todo_cmd bbc -fopenacc -emit-hlfir %t/nested_goto_loop.f90 -o - 2>&1 | FileCheck %s --check-prefix=CHECK3
 ! RUN: %not_todo_cmd bbc -fopenacc -emit-hlfir %t/nested_loop_with_inner_goto.f90 -o - 2>&1 | FileCheck %s --check-prefix=CHECK4
-! RUN: %not_todo_cmd bbc -fopenacc -emit-hlfir %t/collapse.f90 -o - 2>&1 | FileCheck %s --check-prefix=CHECK5
+! RUN: %not_todo_cmd bbc -fopenacc -emit-hlfir %t/collapse_lt.f90 -o - 2>&1 | FileCheck %s --check-prefix=CHECK7
+! RUN: %not_todo_cmd bbc -fopenacc -emit-hlfir %t/collapse_gt.f90 -o - 2>&1 | FileCheck %s --check-prefix=CHECK8
 ! RUN: %not_todo_cmd bbc -fopenacc -emit-hlfir %t/collapse_nested.f90 -o - 2>&1 | FileCheck %s --check-prefix=CHECK6
 
 //--- do_loop_with_stop.f90
@@ -92,19 +93,34 @@ subroutine nested_loop_with_inner_goto()
 
 end subroutine
 
-//--- collapse.f90
+//--- collapse_lt.f90
 
-! !$acc parallel loop collapse(N) over a do concurrent.
+! collapse(2) over a 3-control do concurrent: collapse < control count (N < C).
+subroutine combined(i, j, k)
+  integer :: i, j, k
+  integer :: a(i,j,k)
+  !$acc parallel loop collapse(2)
+  do concurrent (i=1:10, j=1:100, k=1:200)
+    a(i,j,k) = a(i,j,k) + 1
+  end do
+  ! CHECK7: not yet implemented: OpenACC LOOP COLLAPSE less than DO CONCURRENT control count
+end subroutine
+
+//--- collapse_gt.f90
+
+! collapse(3) over a 2-control do concurrent + inner regular do (N > C, mixed).
+! Semantics accepts it: the inner do supplies the extra level.
 subroutine combined(i, j, k)
   integer :: i, j, k
   integer :: a(i,j,k)
   !$acc parallel loop collapse(3)
-  do concurrent (i=1:10, j=1:100, k=1:200)
-    a(i,j,k) = a(i,j,k) + 1
+  do concurrent (i=1:10, j=1:100)
+    do k = 1, 200
+      a(i,j,k) = a(i,j,k) + 1
+    end do
   end do
-  ! CHECK5: not yet implemented: OpenACC LOOP COLLAPSE with DO CONCURRENT
+  ! CHECK8: not yet implemented: OpenACC LOOP COLLAPSE greater than DO CONCURRENT control count
 end subroutine
-
 
 //--- collapse_nested.f90
 

--- a/flang/test/Lower/OpenACC/do-concurrent-collapse.f90
+++ b/flang/test/Lower/OpenACC/do-concurrent-collapse.f90
@@ -1,0 +1,44 @@
+! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
+
+! COLLAPSE on a DO CONCURRENT with collapse value == control count (N==C).
+! NVHPC extension; lowers like the equivalent nested-DO collapse.
+
+subroutine dc_collapse_eq(a, n)
+  integer :: n
+  integer :: a(n,n,n)
+  integer :: i, j, k
+  !$acc parallel loop collapse(3)
+  do concurrent (i=1:10, j=1:100, k=1:200)
+    a(i,j,k) = a(i,j,k) + 1
+  end do
+end subroutine
+
+! CHECK-LABEL: func.func @_QPdc_collapse_eq(
+! CHECK: acc.parallel combined(loop)
+! CHECK: acc.loop combined(parallel)
+! CHECK-SAME: control(%{{[a-z_0-9]+}} : i32, %{{[a-z_0-9]+}} : i32, %{{[a-z_0-9]+}} : i32)
+! CHECK-SAME: to (%{{[a-z_0-9]+}}, %{{[a-z_0-9]+}}, %{{[a-z_0-9]+}} : i32, i32, i32)
+! Body must be lowered into the acc.loop region (regression: must not be dropped).
+! CHECK: hlfir.designate
+! CHECK: arith.addi %{{.*}}, %{{.*}} : i32
+! CHECK: hlfir.assign %{{.*}} to %{{.*}} : i32, !fir.ref<i32>
+! CHECK: collapse = [3]
+
+! collapse(force:N) on a DO CONCURRENT must lower the body too (force takes a
+! different path in Bridge.cpp).
+
+subroutine dc_collapse_force_eq(a, n)
+  integer :: n
+  integer :: a(n,n,n)
+  integer :: i, j, k
+  !$acc parallel loop collapse(force:3)
+  do concurrent (i=1:10, j=1:100, k=1:200)
+    a(i,j,k) = a(i,j,k) + 1
+  end do
+end subroutine
+
+! CHECK-LABEL: func.func @_QPdc_collapse_force_eq(
+! CHECK: acc.loop combined(parallel)
+! CHECK-SAME: control(%{{[a-z_0-9]+}} : i32, %{{[a-z_0-9]+}} : i32, %{{[a-z_0-9]+}} : i32)
+! CHECK: hlfir.assign %{{.*}} to %{{.*}} : i32, !fir.ref<i32>
+! CHECK: collapse = [3]

--- a/flang/test/Semantics/OpenACC/acc-collapse-do-concurrent.f90
+++ b/flang/test/Semantics/OpenACC/acc-collapse-do-concurrent.f90
@@ -1,0 +1,24 @@
+! RUN: %flang_fc1 -fopenacc -Wportability -fsyntax-only %s 2>&1 | FileCheck %s --implicit-check-not='COLLAPSE on DO CONCURRENT is non-standard'
+! RUN: %flang_fc1 -fopenacc -fsyntax-only %s 2>&1 | FileCheck %s --check-prefix=DEFAULT --allow-empty
+
+! Portability warning for COLLAPSE on a DO CONCURRENT: emitted under
+! -Wportability/-pedantic, silent by default. A bare DO CONCURRENT never warns.
+
+subroutine collapse_do_concurrent(a)
+  integer :: a(10,10,10)
+  integer :: i, j, k
+
+  ! CHECK: warning: COLLAPSE on DO CONCURRENT is non-standard [-Wportability]
+  !$acc parallel loop collapse(3)
+  do concurrent (i=1:10, j=1:10, k=1:10)
+    a(i,j,k) = 0
+  end do
+
+  !$acc parallel loop
+  do concurrent (i=1:10, j=1:10, k=1:10)
+    a(i,j,k) = 0
+  end do
+end subroutine
+
+! Default run: no warning.
+! DEFAULT-NOT: COLLAPSE on DO CONCURRENT is non-standard


### PR DESCRIPTION
Lower a COLLAPSE clause on a DO CONCURRENT when the collapse value equals the number of concurrent controls, matching the equivalent nested-DO collapse form, and route the loop body into the collapsed acc.loop. Emit specific not-yet-implemented diagnostics for the collapse-less-than and collapse-greater-than control-count cases, and a -Wportability warning for this non-standard extension.

Collapse of mismatched control cases will require a little more invasive change, so I will submit that as a follow up PR if it is okay, if desired I could fix the lowering for those two cases now.