### PR TITLE
[LangRef] allow omitting `va_end`

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -14535,6 +14535,9 @@ does not define what this type is, so all transformations should be
 prepared to handle these functions regardless of the type used. The intrinsics
 are overloaded, and can be used for pointers to different address spaces.
 
+The underlying argument list is destroyed when a function returns, so
+a ``va_list`` must not outlive the function that created it.
+
 This example shows how the :ref:`va_arg <i_va_arg>` instruction and the
 variable argument handling intrinsic functions are used.
 
@@ -14673,6 +14676,10 @@ available in C. In a target-dependent way, it copies the source
 ``va_list`` element into the destination ``va_list`` element. This
 intrinsic is necessary because the ``llvm.va_start`` intrinsic may be
 arbitrarily complex and require, for example, memory allocation.
+
+On targets where ``va_list`` is trivially copyable, ``memcpy`` can be
+used instead to duplicate a ``va_list``. The ``va_list`` type is
+trivially copyable on all currently supported targets.
 
 Accurate Garbage Collection Intrinsics
 --------------------------------------

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -14631,10 +14631,13 @@ Semantics:
 
 The '``llvm.va_end``' intrinsic works just like the ``va_end`` macro
 available in C. In a target-dependent way, it destroys the ``va_list``
-element to which the argument points. Calls to
+element to which the argument points. Calls to ``llvm.va_end`` can be
+omitted when they are a no-op for the given target. ``llvm.va_end``
+is a no-op for all currently supported targets.
+
+When used, calls to ``llvm.va_end`` must be matched exactly with calls to
 :ref:`llvm.va_start <int_va_start>` and
-:ref:`llvm.va_copy <int_va_copy>` must be matched exactly with calls to
-``llvm.va_end``.
+:ref:`llvm.va_copy <int_va_copy>`.
 
 .. _int_va_copy:
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -14677,9 +14677,9 @@ available in C. In a target-dependent way, it copies the source
 intrinsic is necessary because the ``llvm.va_start`` intrinsic may be
 arbitrarily complex and require, for example, memory allocation.
 
-On targets where ``va_list`` is trivially copyable, ``memcpy`` can be
-used instead to duplicate a ``va_list``. The ``va_list`` type is
-trivially copyable on all currently supported targets.
+On targets where ``llvm.va_copy`` is equivalent to ``memcpy``, ``memcpy``
+can be used instead to duplicate a ``va_list``. ``llvm.va_copy`` is
+equivalent to ``memcpy`` on all currently supported targets implement
 
 Accurate Garbage Collection Intrinsics
 --------------------------------------

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -14679,7 +14679,7 @@ arbitrarily complex and require, for example, memory allocation.
 
 On targets where ``llvm.va_copy`` is equivalent to ``memcpy``, ``memcpy``
 can be used instead to duplicate a ``va_list``. ``llvm.va_copy`` is
-equivalent to ``memcpy`` on all currently supported targets implement
+equivalent to ``memcpy`` on all currently supported targets.
 
 Accurate Garbage Collection Intrinsics
 --------------------------------------


### PR DESCRIPTION
In Rust we'd like to be able to omit `va_end`: it is a no-op on all currently supported targets, and the requirement that it is paired exactly with `va_start` and `va_copy` (in the same frame) cannot be unified with a language with move semantics.

cc https://github.com/rust-lang/rust/pull/157627 https://github.com/rust-lang/rust/pull/155697