### PR TITLE
[flang][acc][lowering] Declare undeclared acc routine bind(name) targets

### DIFF
--- a/flang/include/flang/Lower/OpenACC.h
+++ b/flang/include/flang/Lower/OpenACC.h
@@ -89,6 +89,14 @@ void genOpenACCRoutineConstruct(
 void declareExternalAccModuleDeclareActionRecipes(
     AbstractConverter &, fir::FirOpBuilder &,
     const Fortran::semantics::Symbol &);
+
+/// Declare a private func.func for every `acc routine` bind(name) target not
+/// otherwise declared in this program unit, cloning the function type of the
+/// decorated routine. Walks the module's acc.routine ops, so an existing
+/// declaration (e.g. an in-TU bind target) is left untouched. Run after primary
+/// translation, once all acc.routine ops have been emitted.
+void materializeOpenACCRoutineBindTargets(AbstractConverter &);
+
 void attachDeclarePostAllocAction(AbstractConverter &, fir::FirOpBuilder &,
                                   const Fortran::semantics::Symbol &);
 void attachDeclarePreDeallocAction(AbstractConverter &, fir::FirOpBuilder &,

--- a/flang/include/flang/Lower/OpenACC.h
+++ b/flang/include/flang/Lower/OpenACC.h
@@ -90,12 +90,10 @@ void declareExternalAccModuleDeclareActionRecipes(
     AbstractConverter &, fir::FirOpBuilder &,
     const Fortran::semantics::Symbol &);
 
-/// Declare a private func.func for every `acc routine` bind(name) target not
-/// otherwise declared in this program unit, cloning the function type of the
-/// decorated routine. Walks the module's acc.routine ops, so an existing
-/// declaration (e.g. an in-TU bind target) is left untouched. Run after primary
-/// translation, once all acc.routine ops have been emitted.
-void materializeOpenACCRoutineBindTargets(AbstractConverter &);
+/// Declare a private func.func for each acc.routine bind(name) target in \p
+/// module (and its submodules) not already declared, cloning the decorated
+/// routine's type. Run after primary translation.
+void materializeOpenACCRoutineBindTargets(AbstractConverter &, mlir::ModuleOp);
 
 void attachDeclarePostAllocAction(AbstractConverter &, fir::FirOpBuilder &,
                                   const Fortran::semantics::Symbol &);

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -597,6 +597,15 @@ public:
           u);
     }
 
+    // Declare any `acc routine` bind(name) targets not otherwise declared, so a
+    // live symbol exists for later passes. No-op for targets already lowered in
+    // this unit.
+    if (getFoldingContext().languageFeatures().IsEnabled(
+            Fortran::common::LanguageFeature::OpenACC))
+      createBuilderOutsideOfFuncOpAndDo([&]() {
+        Fortran::lower::materializeOpenACCRoutineBindTargets(*this);
+      });
+
     // Once all the code has been translated, create global runtime type info
     // data structures for the derived types that have been processed, as well
     // as fir.type_info operations for the dispatch tables.

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -603,7 +603,8 @@ public:
     if (getFoldingContext().languageFeatures().IsEnabled(
             Fortran::common::LanguageFeature::OpenACC))
       createBuilderOutsideOfFuncOpAndDo([&]() {
-        Fortran::lower::materializeOpenACCRoutineBindTargets(*this);
+        Fortran::lower::materializeOpenACCRoutineBindTargets(*this,
+                                                             getModuleOp());
       });
 
     // Once all the code has been translated, create global runtime type info

--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -4536,65 +4536,41 @@ void Fortran::lower::genOpenACCRoutineConstruct(
 }
 
 void Fortran::lower::materializeOpenACCRoutineBindTargets(
-    Fortran::lower::AbstractConverter &converter) {
-  mlir::ModuleOp topModule = converter.getModuleOp();
+    Fortran::lower::AbstractConverter &converter, mlir::ModuleOp module) {
+  // There is only one module today; recurse in case submodules are added.
+  for (mlir::ModuleOp nested : module.getOps<mlir::ModuleOp>())
+    materializeOpenACCRoutineBindTargets(converter, nested);
+
   fir::FirOpBuilder &builder = converter.getFirOpBuilder();
+  // The converter's symbol table tracks only the top module.
+  mlir::SymbolTable *symbolTable =
+      module.getOperation() == converter.getModuleOp().getOperation()
+          ? converter.getMLIRSymbolTable()
+          : nullptr;
 
-  // The acc.routine ops are exactly the decorated routines (one per op), each
-  // created alongside its func.func, so processing them avoids a full
-  // symbol-table visit and inherently skips never-lowered routines (no op =>
-  // nothing to do). They normally live in the top-level module, but a routine
-  // in a nested module would be emitted there, so walk recursively. Collect
-  // first because declaring inserts func.func ops into the modules being
-  // walked.
-  llvm::SmallVector<mlir::acc::RoutineOp> routineOps;
-  topModule.walk(
-      [&](mlir::acc::RoutineOp routineOp) { routineOps.push_back(routineOp); });
-
-  for (mlir::acc::RoutineOp routineOp : routineOps) {
-    // Declare the bind target in the module that holds the acc.routine op, so
-    // the symbol resolves where the in-kernel call is. The converter's cached
-    // symbol table tracks only the top module, so pass it for that module and
-    // nullptr (forcing a direct module lookup) for any nested module.
-    mlir::ModuleOp module = routineOp->getParentOfType<mlir::ModuleOp>();
-    mlir::SymbolTable *symbolTable =
-        module.getOperation() == topModule.getOperation()
-            ? converter.getMLIRSymbolTable()
-            : nullptr;
-
-    // Clone the decorated routine's function type onto the bind target: bind
-    // renames the same callable, so this is the type the rewritten in-kernel
-    // call uses. Fall back to () -> () if the decorated func.func is absent.
+  for (mlir::acc::RoutineOp routineOp : module.getOps<mlir::acc::RoutineOp>()) {
+    // bind renames the same callable, so clone the decorated routine's type.
     mlir::func::FuncOp decorated = fir::FirOpBuilder::getNamedFunction(
         module, symbolTable, routineOp.getFuncName());
     mlir::FunctionType type =
         decorated ? decorated.getFunctionType()
                   : mlir::FunctionType::get(builder.getContext(), {}, {});
 
-    // Get-or-create a func.func named \p name in \p module. If one already
-    // exists (e.g. an in-TU bind target lowered as a real procedure), leave it
-    // untouched. Otherwise declare a body-less func.func with the cloned type
-    // so later passes (external-name-interop, nvhpc-acc-bind-routine) reference
-    // a live symbol.
-    auto declareBindTarget = [&](llvm::StringRef name) {
-      if (fir::FirOpBuilder::getNamedFunction(module, symbolTable, name))
-        return;
-      fir::FirOpBuilder::createFunction(builder.getUnknownLoc(), module, name,
-                                        type, symbolTable);
+    auto declare = [&](llvm::StringRef name) {
+      if (!fir::FirOpBuilder::getNamedFunction(module, symbolTable, name))
+        fir::FirOpBuilder::createFunction(builder.getUnknownLoc(), module, name,
+                                          type, symbolTable);
     };
 
-    // bind(identifier): mangled SymbolRefAttr, matching the bind reference
-    // (and honoring BIND(C) via the same mangling).
+    // bind(identifier) is mangled; bind("string") is a verbatim asm name.
     if (mlir::ArrayAttr binds = routineOp.getBindIdNameAttr())
       for (mlir::Attribute bind : binds)
         if (auto symRef = mlir::dyn_cast<mlir::SymbolRefAttr>(bind))
-          declareBindTarget(symRef.getLeafReference());
-
-    // bind("string"): the literal is its own external name, declared verbatim.
+          declare(symRef.getLeafReference());
     if (mlir::ArrayAttr binds = routineOp.getBindStrNameAttr())
       for (mlir::Attribute bind : binds)
         if (auto strAttr = mlir::dyn_cast<mlir::StringAttr>(bind))
-          declareBindTarget(strAttr.getValue());
+          declare(strAttr.getValue());
   }
 }
 

--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -4535,6 +4535,69 @@ void Fortran::lower::genOpenACCRoutineConstruct(
       workerDeviceTypes, vectorDeviceTypes);
 }
 
+void Fortran::lower::materializeOpenACCRoutineBindTargets(
+    Fortran::lower::AbstractConverter &converter) {
+  mlir::ModuleOp topModule = converter.getModuleOp();
+  fir::FirOpBuilder &builder = converter.getFirOpBuilder();
+
+  // The acc.routine ops are exactly the decorated routines (one per op), each
+  // created alongside its func.func, so processing them avoids a full
+  // symbol-table visit and inherently skips never-lowered routines (no op =>
+  // nothing to do). They normally live in the top-level module, but a routine
+  // in a nested module would be emitted there, so walk recursively. Collect
+  // first because declaring inserts func.func ops into the modules being
+  // walked.
+  llvm::SmallVector<mlir::acc::RoutineOp> routineOps;
+  topModule.walk(
+      [&](mlir::acc::RoutineOp routineOp) { routineOps.push_back(routineOp); });
+
+  for (mlir::acc::RoutineOp routineOp : routineOps) {
+    // Declare the bind target in the module that holds the acc.routine op, so
+    // the symbol resolves where the in-kernel call is. The converter's cached
+    // symbol table tracks only the top module, so pass it for that module and
+    // nullptr (forcing a direct module lookup) for any nested module.
+    mlir::ModuleOp module = routineOp->getParentOfType<mlir::ModuleOp>();
+    mlir::SymbolTable *symbolTable =
+        module.getOperation() == topModule.getOperation()
+            ? converter.getMLIRSymbolTable()
+            : nullptr;
+
+    // Clone the decorated routine's function type onto the bind target: bind
+    // renames the same callable, so this is the type the rewritten in-kernel
+    // call uses. Fall back to () -> () if the decorated func.func is absent.
+    mlir::func::FuncOp decorated = fir::FirOpBuilder::getNamedFunction(
+        module, symbolTable, routineOp.getFuncName());
+    mlir::FunctionType type =
+        decorated ? decorated.getFunctionType()
+                  : mlir::FunctionType::get(builder.getContext(), {}, {});
+
+    // Get-or-create a func.func named \p name in \p module. If one already
+    // exists (e.g. an in-TU bind target lowered as a real procedure), leave it
+    // untouched. Otherwise declare a body-less func.func with the cloned type
+    // so later passes (external-name-interop, nvhpc-acc-bind-routine) reference
+    // a live symbol.
+    auto declareBindTarget = [&](llvm::StringRef name) {
+      if (fir::FirOpBuilder::getNamedFunction(module, symbolTable, name))
+        return;
+      fir::FirOpBuilder::createFunction(builder.getUnknownLoc(), module, name,
+                                        type, symbolTable);
+    };
+
+    // bind(identifier): mangled SymbolRefAttr, matching the bind reference
+    // (and honoring BIND(C) via the same mangling).
+    if (mlir::ArrayAttr binds = routineOp.getBindIdNameAttr())
+      for (mlir::Attribute bind : binds)
+        if (auto symRef = mlir::dyn_cast<mlir::SymbolRefAttr>(bind))
+          declareBindTarget(symRef.getLeafReference());
+
+    // bind("string"): the literal is its own external name, declared verbatim.
+    if (mlir::ArrayAttr binds = routineOp.getBindStrNameAttr())
+      for (mlir::Attribute bind : binds)
+        if (auto strAttr = mlir::dyn_cast<mlir::StringAttr>(bind))
+          declareBindTarget(strAttr.getValue());
+  }
+}
+
 static void
 genACC(Fortran::lower::AbstractConverter &converter,
        Fortran::lower::pft::Evaluation &eval,

--- a/flang/test/Lower/OpenACC/acc-routine-bind-clone-signature.f90
+++ b/flang/test/Lower/OpenACC/acc-routine-bind-clone-signature.f90
@@ -1,0 +1,25 @@
+! A bind(name) target with no declaration of its own is declared by cloning the
+! decorated routine's function type (not () -> ()), since bind renames the same
+! callable. The cloned declaration carries the type only (no argument attributes).
+
+! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
+
+subroutine s_bind_clone(n, x)
+  integer :: n, i
+  real :: x(n)
+  interface
+    subroutine aclear(y)
+      real :: y(:)
+    end subroutine
+  end interface
+  !$acc routine(aclear) seq bind(aclear_seq)
+  !$acc parallel loop
+  do i = 1, n
+    call aclear(x(i:i))
+  end do
+end subroutine
+
+! The decorated routine's signature (assumed-shape array descriptor):
+! CHECK: func.func private @_QPaclear(!fir.box<!fir.array<?xf32>>
+! The bind target is declared with the same type, proving the clone:
+! CHECK: func.func private @_QPaclear_seq(!fir.box<!fir.array<?xf32>>)

--- a/flang/test/Lower/OpenACC/acc-routine-bind-devtype-undeclared.f90
+++ b/flang/test/Lower/OpenACC/acc-routine-bind-devtype-undeclared.f90
@@ -1,0 +1,17 @@
+! A device_type-specific bind to an undeclared target is also declared.
+
+! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
+
+subroutine s_bind_devtype(n, x)
+  integer :: n, i
+  real :: x(n)
+  !$acc routine(aclear) seq device_type(nvidia) bind(aclear_dev)
+  external :: aclear
+  !$acc parallel loop
+  do i = 1, n
+    call aclear(x(i))
+  end do
+end subroutine
+
+! CHECK: acc.routine @{{.*}} func(@_QPaclear){{.*}}@_QPaclear_dev
+! CHECK: func.func private @_QPaclear_dev

--- a/flang/test/Lower/OpenACC/acc-routine-bind-gate-skip.f90
+++ b/flang/test/Lower/OpenACC/acc-routine-bind-gate-skip.f90
@@ -1,0 +1,14 @@
+! A decorated acc routine bind(...) whose procedure is never lowered gets no
+! bind-target declaration and no acc.routine.
+
+! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
+
+subroutine s_gate_skip()
+  !$acc routine(unused_ext) seq bind(unused_ext_dev)
+  external :: unused_ext
+end subroutine
+
+! CHECK-LABEL: func.func @_QPs_gate_skip
+! CHECK-NOT: @_QPunused_ext_dev
+! CHECK-NOT: @_QPunused_ext
+! CHECK-NOT: acc.routine

--- a/flang/test/Lower/OpenACC/acc-routine-bind-string-undeclared.f90
+++ b/flang/test/Lower/OpenACC/acc-routine-bind-string-undeclared.f90
@@ -1,0 +1,18 @@
+! A bind("name") target is its own external name, declared verbatim (not
+! mangled), so later passes reference a live symbol.
+
+! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
+
+! CHECK: acc.routine @{{.*}} func(@_QPaclear) bind("aclear_dev") seq
+! CHECK: func.func private @aclear_dev
+
+subroutine s_bind_str_undeclared(n, x)
+  integer :: n, i
+  real :: x(n)
+  !$acc routine(aclear) seq bind("aclear_dev")
+  external :: aclear
+  !$acc parallel loop
+  do i = 1, n
+    call aclear(x(i))
+  end do
+end subroutine

--- a/flang/test/Lower/OpenACC/acc-routine-bind-undeclared.f90
+++ b/flang/test/Lower/OpenACC/acc-routine-bind-undeclared.f90
@@ -1,0 +1,17 @@
+! An otherwise-undeclared acc routine bind(name) target still gets a func.func.
+
+! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
+
+! CHECK: acc.routine @{{.*}} func(@_QPaclear) bind(@_QPaclear_seq) seq
+! CHECK: func.func private @_QPaclear_seq
+
+subroutine s_bind_undeclared(n, x)
+  integer :: n, i
+  real :: x(n)
+  !$acc routine(aclear) seq bind(aclear_seq)
+  external :: aclear
+  !$acc parallel loop
+  do i = 1, n
+    call aclear(x(i))
+  end do
+end subroutine

--- a/flang/test/Transforms/external-name-interop-acc-routine-bind.fir
+++ b/flang/test/Transforms/external-name-interop-acc-routine-bind.fir
@@ -1,0 +1,13 @@
+// Given a declared (otherwise-undeclared) bind target, external-name-interop
+// renames the func.func and the acc.routine bind reference together.
+
+// RUN: fir-opt %s --external-name-interop | FileCheck %s
+
+module {
+  acc.routine @acc_routine_0 func(@_QPaclear) bind(@_QPaclear_seq) seq
+  func.func private @_QPaclear(!fir.ref<f32>) attributes {acc.routine_info = #acc.routine_info<[@acc_routine_0]>}
+  func.func private @_QPaclear_seq()
+}
+
+// CHECK: acc.routine @acc_routine_0 func(@aclear_) bind(@aclear_seq_) seq
+// CHECK: func.func private @aclear_seq_() attributes {{{.*}}fir.internal_name = "_QPaclear_seq"{{.*}}}


### PR DESCRIPTION
An `!$acc routine ... bind(target)` can name a target with no func.func in the program unit. Lowering emits an acc.routine op referencing it, and external-name-interop / nvhpc-acc-bind-routine then reference an undeclared symbol, tripping the MLIR verifier ("does not reference a symbol in the current scope").

Materialize a private func.func for each otherwise-undeclared bind target after primary translation, gated on the decorated procedure having been lowered (so the declared set matches the acc.routine bind references actually emitted). bind(symbol) targets reuse getOrDeclareFunction (mangled, honoring BIND(C)); bind("string") targets use the new getOrDeclareNamedFunction (verbatim asm name, left untouched by external-name-interop).