### PR TITLE
[RISC-V] Add --implicit-check-not="error:" to a few tests

### DIFF
--- a/llvm/test/MC/RISCV/rv32c-invalid.s
+++ b/llvm/test/MC/RISCV/rv32c-invalid.s
@@ -1,89 +1,144 @@
 # RUN: not llvm-mc -triple=riscv32 -mattr=+c < %s 2>&1 \
-# RUN:     | FileCheck %s
+# RUN:     | FileCheck %s --implicit-check-not="error:"
 # RUN: not llvm-mc -triple=riscv32 -mattr=+zca < %s 2>&1 \
-# RUN:     | FileCheck %s
+# RUN:     | FileCheck %s --implicit-check-not="error:"
 
 ## GPRC
 .LBB:
-c.lw  ra, 4(sp) # CHECK: :[[@LINE]]:7: error: invalid operand for instruction
-c.sw  sp, 4(sp) # CHECK: :[[@LINE]]:7: error: invalid operand for instruction
-c.beqz  t0, .LBB # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
-c.bnez  s8, .LBB # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
-c.addi4spn  s4, sp, 12 # CHECK: :[[@LINE]]:13: error: invalid operand for instruction
-c.srli  s7, 12 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
-c.srai  t0, 12 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
-c.andi  t1, 12 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
-c.and  t1, a0 # CHECK: :[[@LINE]]:8: error: invalid operand for instruction
-c.or   a0, s8 # CHECK: :[[@LINE]]:12: error: invalid operand for instruction
-c.xor  t2, a0 # CHECK: :[[@LINE]]:8: error: invalid operand for instruction
-c.sub  a0, s8 # CHECK: :[[@LINE]]:12: error: invalid operand for instruction
+c.lw  ra, 4(sp)
+# CHECK: :[[#@LINE-1]]:7: error: invalid operand for instruction
+c.sw  sp, 4(sp)
+# CHECK: :[[#@LINE-1]]:7: error: invalid operand for instruction
+c.beqz  t0, .LBB
+# CHECK: :[[#@LINE-1]]:9: error: invalid operand for instruction
+c.bnez  s8, .LBB
+# CHECK: :[[#@LINE-1]]:9: error: invalid operand for instruction
+c.addi4spn  s4, sp, 12
+# CHECK: :[[#@LINE-1]]:13: error: invalid operand for instruction
+c.srli  s7, 12
+# CHECK: :[[#@LINE-1]]:9: error: invalid operand for instruction
+c.srai  t0, 12
+# CHECK: :[[#@LINE-1]]:9: error: invalid operand for instruction
+c.andi  t1, 12
+# CHECK: :[[#@LINE-1]]:9: error: invalid operand for instruction
+c.and  t1, a0
+# CHECK: :[[#@LINE-1]]:8: error: invalid operand for instruction
+c.or   a0, s8
+# CHECK: :[[#@LINE-1]]:12: error: invalid operand for instruction
+c.xor  t2, a0
+# CHECK: :[[#@LINE-1]]:8: error: invalid operand for instruction
+c.sub  a0, s8
+# CHECK: :[[#@LINE-1]]:12: error: invalid operand for instruction
 
 ## GPRNoX0
-c.lwsp  x0, 4(sp) # CHECK: :[[@LINE]]:9: error: register must be a GPR excluding zero (x0)
-c.lwsp  zero, 4(sp) # CHECK: :[[@LINE]]:9: error: register must be a GPR excluding zero (x0)
-c.jr  x0 # CHECK: :[[@LINE]]:7: error: register must be a GPR excluding zero (x0)
-c.jalr  zero # CHECK: :[[@LINE]]:9: error: register must be a GPR excluding zero (x0)
-c.mv  ra, x0 # CHECK: :[[@LINE]]:11: error: register must be a GPR excluding zero (x0)
-c.add  ra, ra, x0 # CHECK: :[[@LINE]]:16: error: invalid operand for instruction
+c.lwsp  x0, 4(sp)
+# CHECK: :[[#@LINE-1]]:9: error: register must be a GPR excluding zero (x0)
+c.lwsp  zero, 4(sp)
+# CHECK: :[[#@LINE-1]]:9: error: register must be a GPR excluding zero (x0)
+c.jr  x0
+# CHECK: :[[#@LINE-1]]:7: error: register must be a GPR excluding zero (x0)
+c.jalr  zero
+# CHECK: :[[#@LINE-1]]:9: error: register must be a GPR excluding zero (x0)
+c.mv  ra, x0
+# CHECK: :[[#@LINE-1]]:11: error: register must be a GPR excluding zero (x0)
+c.add  ra, ra, x0
+# CHECK: :[[#@LINE-1]]:16: error: invalid operand for instruction
 
 ## GPRNoX2
-c.lui x2, 4 # CHECK: :[[@LINE]]:7: error: register must be a GPR excluding sp (x2){{$}}
+c.lui x2, 4
+# CHECK: :[[#@LINE-1]]:7: error: register must be a GPR excluding sp (x2){{$}}
 
 ## SP
-c.addi4spn  a0, a0, 12 # CHECK: :[[@LINE]]:17: error: register must be sp (x2)
-c.addi16sp  t0, 16 # CHECK: :[[@LINE]]:13: error: register must be sp (x2)
+c.addi4spn  a0, a0, 12
+# CHECK: :[[#@LINE-1]]:17: error: register must be sp (x2)
+c.addi16sp  t0, 16
+# CHECK: :[[#@LINE-1]]:13: error: register must be sp (x2)
 
 # Out of range immediates
 
 ## uimmlog2xlenn
-c.slli t0, 64 # CHECK: :[[@LINE]]:12: error: immediate must be an integer in the range [0, 31]
-c.srli a0, 32 # CHECK: :[[@LINE]]:12: error: immediate must be an integer in the range [0, 31]
+c.slli t0, 64
+# CHECK: :[[#@LINE-1]]:12: error: immediate must be an integer in the range [0, 31]
+c.srli a0, 32
+# CHECK: :[[#@LINE-1]]:12: error: immediate must be an integer in the range [0, 31]
 
 ## simm6
-c.li t0, 128 # CHECK: :[[@LINE]]:10: error: immediate must be an integer in the range [-32, 31]
-c.li t0, foo # CHECK: :[[@LINE]]:10: error: immediate must be an integer in the range [-32, 31]
-c.li t0, %lo(foo) # CHECK: :[[@LINE]]:10: error: immediate must be an integer in the range [-32, 31]
-c.li t0, %hi(foo) # CHECK: :[[@LINE]]:10: error: immediate must be an integer in the range [-32, 31]
-c.andi a0, -33 # CHECK: :[[@LINE]]:12: error: immediate must be an integer in the range [-32, 31]
-c.andi a0, foo # CHECK: :[[@LINE]]:12: error: immediate must be an integer in the range [-32, 31]
-c.andi a0, %lo(foo) # CHECK: :[[@LINE]]:12: error: immediate must be an integer in the range [-32, 31]
-c.andi a0, %hi(foo) # CHECK: :[[@LINE]]:12: error: immediate must be an integer in the range [-32, 31]
-c.addi t0, -33 # CHECK: :[[@LINE]]:12: error: immediate must be an integer in the range [-32, 31]
-c.addi t0, 32 # CHECK: :[[@LINE]]:12: error: immediate must be an integer in the range [-32, 31]
-c.addi t0, foo # CHECK: :[[@LINE]]:12: error: immediate must be an integer in the range [-32, 31]
-c.addi t0, %lo(foo) # CHECK: :[[@LINE]]:12: error: immediate must be an integer in the range [-32, 31]
-c.addi t0, %hi(foo) # CHECK: :[[@LINE]]:12: error: immediate must be an integer in the range [-32, 31]
+c.li t0, 128
+# CHECK: :[[#@LINE-1]]:10: error: immediate must be an integer in the range [-32, 31]
+c.li t0, foo
+# CHECK: :[[#@LINE-1]]:10: error: immediate must be an integer in the range [-32, 31]
+c.li t0, %lo(foo)
+# CHECK: :[[#@LINE-1]]:10: error: immediate must be an integer in the range [-32, 31]
+c.li t0, %hi(foo)
+# CHECK: :[[#@LINE-1]]:10: error: immediate must be an integer in the range [-32, 31]
+c.andi a0, -33
+# CHECK: :[[#@LINE-1]]:12: error: immediate must be an integer in the range [-32, 31]
+c.andi a0, foo
+# CHECK: :[[#@LINE-1]]:12: error: immediate must be an integer in the range [-32, 31]
+c.andi a0, %lo(foo)
+# CHECK: :[[#@LINE-1]]:12: error: immediate must be an integer in the range [-32, 31]
+c.andi a0, %hi(foo)
+# CHECK: :[[#@LINE-1]]:12: error: immediate must be an integer in the range [-32, 31]
+c.addi t0, -33
+# CHECK: :[[#@LINE-1]]:12: error: immediate must be an integer in the range [-32, 31]
+c.addi t0, 32
+# CHECK: :[[#@LINE-1]]:12: error: immediate must be an integer in the range [-32, 31]
+c.addi t0, foo
+# CHECK: :[[#@LINE-1]]:12: error: immediate must be an integer in the range [-32, 31]
+c.addi t0, %lo(foo)
+# CHECK: :[[#@LINE-1]]:12: error: immediate must be an integer in the range [-32, 31]
+c.addi t0, %hi(foo)
+# CHECK: :[[#@LINE-1]]:12: error: immediate must be an integer in the range [-32, 31]
 
 ## simm6nonzero
-c.nop 32 # CHECK: :[[@LINE]]:7: error: immediate must be non-zero in the range [-32, 31]
+c.nop 32
+# CHECK: :[[#@LINE-1]]:7: error: immediate must be non-zero in the range [-32, 31]
 
 ## c_lui_imm
-c.lui t0, 0 # CHECK: :[[@LINE]]:11: error: immediate must be in [0xfffe0, 0xfffff] or [1, 31]
-c.lui t0, 32 # CHECK: :[[@LINE]]:11: error: immediate must be in [0xfffe0, 0xfffff] or [1, 31]
-c.lui t0, 0xffffdf # CHECK: :[[@LINE]]:11: error: immediate must be in [0xfffe0, 0xfffff] or [1, 31]
-c.lui t0, 0x1000000 # CHECK: :[[@LINE]]:11: error: immediate must be in [0xfffe0, 0xfffff] or [1, 31]
-c.lui t0, foo # CHECK: [[@LINE]]:11: error: immediate must be in [0xfffe0, 0xfffff] or [1, 31]
+c.lui t0, 0
+# CHECK: :[[#@LINE-1]]:11: error: immediate must be in [0xfffe0, 0xfffff] or [1, 31]
+c.lui t0, 32
+# CHECK: :[[#@LINE-1]]:11: error: immediate must be in [0xfffe0, 0xfffff] or [1, 31]
+c.lui t0, 0xffffdf
+# CHECK: :[[#@LINE-1]]:11: error: immediate must be in [0xfffe0, 0xfffff] or [1, 31]
+c.lui t0, 0x1000000
+# CHECK: :[[#@LINE-1]]:11: error: immediate must be in [0xfffe0, 0xfffff] or [1, 31]
+c.lui t0, foo
+# CHECK: [[#@LINE-1]]:11: error: immediate must be in [0xfffe0, 0xfffff] or [1, 31]
 
 ## uimm8_lsb00
-c.lwsp  ra, 256(sp) # CHECK: :[[@LINE]]:13: error: immediate must be a multiple of 4 bytes in the range [0, 252]
-c.swsp  ra, -4(sp) # CHECK: :[[@LINE]]:13: error: immediate must be a multiple of 4 bytes in the range [0, 252]
+c.lwsp  ra, 256(sp)
+# CHECK: :[[#@LINE-1]]:13: error: immediate must be a multiple of 4 bytes in the range [0, 252]
+c.swsp  ra, -4(sp)
+# CHECK: :[[#@LINE-1]]:13: error: immediate must be a multiple of 4 bytes in the range [0, 252]
 ## uimm7_lsb00
-c.lw  s0, -4(sp) # CHECK: :[[@LINE]]:11: error: immediate must be a multiple of 4 bytes in the range [0, 124]
-c.sw  s0, 128(sp) # CHECK: :[[@LINE]]:11: error: immediate must be a multiple of 4 bytes in the range [0, 124]
+c.lw  s0, -4(sp)
+# CHECK: :[[#@LINE-1]]:11: error: immediate must be a multiple of 4 bytes in the range [0, 124]
+c.sw  s0, 128(sp)
+# CHECK: :[[#@LINE-1]]:11: error: immediate must be a multiple of 4 bytes in the range [0, 124]
 
 ## simm9_lsb0
-c.bnez  s1, -258 # CHECK: :[[@LINE]]:13: error: immediate must be a multiple of 2 bytes in the range [-256, 254]
-c.beqz  a0, 256 # CHECK: :[[@LINE]]:13: error: immediate must be a multiple of 2 bytes in the range [-256, 254]
+c.bnez  s1, -258
+# CHECK: :[[#@LINE-1]]:13: error: immediate must be a multiple of 2 bytes in the range [-256, 254]
+c.beqz  a0, 256
+# CHECK: :[[#@LINE-1]]:13: error: immediate must be a multiple of 2 bytes in the range [-256, 254]
 
 ## simm12_lsb0
-c.j 2048 # CHECK: :[[@LINE]]:5: error: immediate must be a multiple of 2 bytes in the range [-2048, 2046]
-c.jal -2050 # CHECK: :[[@LINE]]:7: error: immediate must be a multiple of 2 bytes in the range [-2048, 2046]
+c.j 2048
+# CHECK: :[[#@LINE-1]]:5: error: immediate must be a multiple of 2 bytes in the range [-2048, 2046]
+c.jal -2050
+# CHECK: :[[#@LINE-1]]:7: error: immediate must be a multiple of 2 bytes in the range [-2048, 2046]
 
 ## uimm10_lsb00nonzero
-c.addi4spn  a0, sp, 0 # CHECK: :[[@LINE]]:21: error: immediate must be a multiple of 4 bytes in the range [4, 1020]
-c.addi4spn  a0, sp, 1024 # CHECK: :[[@LINE]]:21: error: immediate must be a multiple of 4 bytes in the range [4, 1020]
+c.addi4spn  a0, sp, 0
+# CHECK: :[[#@LINE-1]]:21: error: immediate must be a multiple of 4 bytes in the range [4, 1020]
+c.addi4spn  a0, sp, 1024
+# CHECK: :[[#@LINE-1]]:21: error: immediate must be a multiple of 4 bytes in the range [4, 1020]
 
 ## simm10_lsb0000nonzero
-c.addi16sp  sp, -528 # CHECK: :[[@LINE]]:17: error: immediate must be a multiple of 16 bytes and non-zero in the range [-512, 496]
-c.addi16sp  sp, 512 # CHECK: :[[@LINE]]:17: error: immediate must be a multiple of 16 bytes and non-zero in the range [-512, 496]
-c.addi16sp  sp, 0 # CHECK: :[[@LINE]]:17: error: immediate must be a multiple of 16 bytes and non-zero in the range [-512, 496]
+c.addi16sp  sp, -528
+# CHECK: :[[#@LINE-1]]:17: error: immediate must be a multiple of 16 bytes and non-zero in the range [-512, 496]
+c.addi16sp  sp, 512
+# CHECK: :[[#@LINE-1]]:17: error: immediate must be a multiple of 16 bytes and non-zero in the range [-512, 496]
+c.addi16sp  sp, 0
+# CHECK: :[[#@LINE-1]]:17: error: immediate must be a multiple of 16 bytes and non-zero in the range [-512, 496]

--- a/llvm/test/MC/RISCV/rv64c-invalid.s
+++ b/llvm/test/MC/RISCV/rv64c-invalid.s
@@ -1,32 +1,49 @@
-# RUN: not llvm-mc -triple=riscv64 -mattr=+c < %s 2>&1 | FileCheck %s
-# RUN: not llvm-mc -triple=riscv64 -mattr=+zca < %s 2>&1 | FileCheck %s
+# RUN: not llvm-mc -triple=riscv64 -mattr=+c < %s 2>&1 | FileCheck %s --implicit-check-not="error:"
+# RUN: not llvm-mc -triple=riscv64 -mattr=+zca < %s 2>&1 | FileCheck %s --implicit-check-not="error:"
 
 ## GPRC
-c.ld ra, 4(sp) # CHECK: :[[@LINE]]:6: error: invalid operand for instruction
-c.sd sp, 4(sp) # CHECK: :[[@LINE]]:6: error: invalid operand for instruction
-c.addw   a0, a7 # CHECK: :[[@LINE]]:14: error: invalid operand for instruction
-c.subw   a0, a6 # CHECK: :[[@LINE]]:14: error: invalid operand for instruction
+c.ld ra, 4(sp)
+# CHECK: :[[#@LINE-1]]:6: error: invalid operand for instruction
+c.sd sp, 4(sp)
+# CHECK: :[[#@LINE-1]]:6: error: invalid operand for instruction
+c.addw   a0, a7
+# CHECK: :[[#@LINE-1]]:14: error: invalid operand for instruction
+c.subw   a0, a6
+# CHECK: :[[#@LINE-1]]:14: error: invalid operand for instruction
 
 ## GPRNoX0
-c.ldsp  x0, 4(sp) # CHECK: :[[@LINE]]:9: error: register must be a GPR excluding zero (x0)
-c.ldsp  zero, 4(sp) # CHECK: :[[@LINE]]:9: error: register must be a GPR excluding zero (x0)
+c.ldsp  x0, 4(sp)
+# CHECK: :[[#@LINE-1]]:9: error: register must be a GPR excluding zero (x0)
+c.ldsp  zero, 4(sp)
+# CHECK: :[[#@LINE-1]]:9: error: register must be a GPR excluding zero (x0)
 
 # Out of range immediates
 
 ## uimmlog2xlen
-c.slli t0, 64 # CHECK: :[[@LINE]]:12: error: immediate must be an integer in the range [0, 63]
-c.srli a0, -1 # CHECK: :[[@LINE]]:12: error: immediate must be an integer in the range [0, 63]
+c.slli t0, 64
+# CHECK: :[[#@LINE-1]]:12: error: immediate must be an integer in the range [0, 63]
+c.srli a0, -1
+# CHECK: :[[#@LINE-1]]:12: error: immediate must be an integer in the range [0, 63]
 
 ## simm6
-c.addiw t0, -33 # CHECK: :[[@LINE]]:13: error: immediate must be an integer in the range [-32, 31]
-c.addiw t0, 32 # CHECK: :[[@LINE]]:13: error: immediate must be an integer in the range [-32, 31]
-c.addiw t0, foo # CHECK: :[[@LINE]]:13: error: immediate must be an integer in the range [-32, 31]
-c.addiw t0, %lo(foo) # CHECK: :[[@LINE]]:13: error: immediate must be an integer in the range [-32, 31]
-c.addiw t0, %hi(foo) # CHECK: :[[@LINE]]:13: error: immediate must be an integer in the range [-32, 31]
+c.addiw t0, -33
+# CHECK: :[[#@LINE-1]]:13: error: immediate must be an integer in the range [-32, 31]
+c.addiw t0, 32
+# CHECK: :[[#@LINE-1]]:13: error: immediate must be an integer in the range [-32, 31]
+c.addiw t0, foo
+# CHECK: :[[#@LINE-1]]:13: error: immediate must be an integer in the range [-32, 31]
+c.addiw t0, %lo(foo)
+# CHECK: :[[#@LINE-1]]:13: error: immediate must be an integer in the range [-32, 31]
+c.addiw t0, %hi(foo)
+# CHECK: :[[#@LINE-1]]:13: error: immediate must be an integer in the range [-32, 31]
 
 ## uimm9_lsb000
-c.ldsp  ra, 512(sp) # CHECK: :[[@LINE]]:13: error: immediate must be a multiple of 8 bytes in the range [0, 504]
-c.sdsp  ra, -8(sp) # CHECK: :[[@LINE]]:13: error: immediate must be a multiple of 8 bytes in the range [0, 504]
+c.ldsp  ra, 512(sp)
+# CHECK: :[[#@LINE-1]]:13: error: immediate must be a multiple of 8 bytes in the range [0, 504]
+c.sdsp  ra, -8(sp)
+# CHECK: :[[#@LINE-1]]:13: error: immediate must be a multiple of 8 bytes in the range [0, 504]
 ## uimm8_lsb000
-c.ld  s0, -8(sp) # CHECK: :[[@LINE]]:11: error: immediate must be a multiple of 8 bytes in the range [0, 248]
-c.sd  s0, 256(sp) # CHECK: :[[@LINE]]:11: error: immediate must be a multiple of 8 bytes in the range [0, 248]
+c.ld  s0, -8(sp)
+# CHECK: :[[#@LINE-1]]:11: error: immediate must be a multiple of 8 bytes in the range [0, 248]
+c.sd  s0, 256(sp)
+# CHECK: :[[#@LINE-1]]:11: error: immediate must be a multiple of 8 bytes in the range [0, 248]

--- a/llvm/test/MC/RISCV/rvc-hints-invalid.s
+++ b/llvm/test/MC/RISCV/rvc-hints-invalid.s
@@ -1,22 +1,31 @@
 # RUN: not llvm-mc -triple=riscv32 -mattr=+c < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-RV32 %s
+# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-RV32 %s --implicit-check-not="error:"
 # RUN: not llvm-mc -triple=riscv64 -mattr=+c < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK %s
+# RUN:     | FileCheck -check-prefixes=CHECK %s --implicit-check-not="error:"
 
-c.nop 0 # CHECK: :[[@LINE]]:7: error: immediate must be non-zero in the range [-32, 31]
+c.nop 0
+# CHECK: :[[#@LINE-1]]:7: error: immediate must be non-zero in the range [-32, 31]
 
-c.addi x0, 33 # CHECK: :[[@LINE]]:12: error: immediate must be an integer in the range [-32, 31]
+c.addi x0, 33
+# CHECK: :[[#@LINE-1]]:12: error: immediate must be an integer in the range [-32, 31]
 
-c.li x0, 42 # CHECK: :[[@LINE]]:10: error: immediate must be an integer in the range [-32, 31]
+c.li x0, 42
+# CHECK: :[[#@LINE-1]]:10: error: immediate must be an integer in the range [-32, 31]
 
-c.lui x0, 0 # CHECK: :[[@LINE]]:11: error: immediate must be in [0xfffe0, 0xfffff] or [1, 31]
+c.lui x0, 0
+# CHECK: :[[#@LINE-1]]:11: error: immediate must be in [0xfffe0, 0xfffff] or [1, 31]
 
-c.mv x0, x0 # CHECK: :[[@LINE]]:10: error: register must be a GPR excluding zero (x0)
+c.mv x0, x0
+# CHECK: :[[#@LINE-1]]:10: error: register must be a GPR excluding zero (x0)
 
-c.add x0, x0 # CHECK: :[[@LINE]]:11: error: register must be a GPR excluding zero (x0)
+c.add x0, x0
+# CHECK: :[[#@LINE-1]]:11: error: register must be a GPR excluding zero (x0)
 
-c.slli x0, 32 # CHECK-RV32: :[[@LINE]]:12: error: immediate must be an integer in the range [0, 31]
+c.slli x0, 32
+# CHECK-RV32: :[[#@LINE-1]]:12: error: immediate must be an integer in the range [0, 31]
 
-c.srli64 x30 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
+c.srli64 x30
+# CHECK: :[[#@LINE-1]]:10: error: invalid operand for instruction
 
-c.srai64 x31 # CHECK: :[[@LINE]]:10: error: invalid operand for instruction
+c.srai64 x31
+# CHECK: :[[#@LINE-1]]:10: error: invalid operand for instruction

--- a/llvm/test/MC/RISCV/xqcibm-invalid.s
+++ b/llvm/test/MC/RISCV/xqcibm-invalid.s
@@ -1,8 +1,8 @@
 # Xqcibm - Qualcomm uC Bit Manipulation Extension
 # RUN: not llvm-mc -triple riscv32 -mattr=+xqcibm < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-PLUS %s
+# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-PLUS %s --implicit-check-not="error:"
 # RUN: not llvm-mc -triple riscv32 -mattr=-xqcibm < %s 2>&1 \
-# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-MINUS %s
+# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-MINUS %s --implicit-check-not="error:"
 
 # CHECK-PLUS: :[[@LINE+2]]:18: error: register must be a GPR excluding zero (x0)
 # CHECK-MINUS: :[[@LINE+1]]:18: error: invalid operand for instruction
@@ -152,7 +152,8 @@ qc.insbri x10, x0, -1024
 # CHECK: :[[@LINE+1]]:1: error: too few operands for instruction
 qc.insbri x10, x20
 
-# CHECK-PLUS: :[[@LINE+1]]:21: error: immediate must be an integer in the range [-1024, 1023]
+# CHECK-PLUS: :[[@LINE+2]]:21: error: immediate must be an integer in the range [-1024, 1023]
+# CHECK-MINUS: :[[@LINE+1]]:21: error: invalid operand for instruction
 qc.insbri x10, x20, -1027
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcibm' (Qualcomm uC Bit Manipulation Extension)
@@ -166,13 +167,16 @@ qc.insbi x0, -10, 12, 15
 # CHECK: :[[@LINE+1]]:1: error: too few operands for instruction
 qc.insbi x6, -10, 12
 
-# CHECK-PLUS: :[[@LINE+1]]:14: error: immediate must be an integer in the range [-16, 15]
+# CHECK-PLUS: :[[@LINE+2]]:14: error: immediate must be an integer in the range [-16, 15]
+# CHECK-MINUS: :[[@LINE+1]]:14: error: invalid operand for instruction
 qc.insbi x6, -17, 12, 15
 
-# CHECK-PLUS: :[[@LINE+1]]:19: error: immediate must be an integer in the range [1, 32]
+# CHECK-PLUS: :[[@LINE+2]]:19: error: immediate must be an integer in the range [1, 32]
+# CHECK-MINUS: :[[@LINE+1]]:19: error: invalid operand for instruction
 qc.insbi x6, -10, 45, 15
 
-# CHECK-PLUS: :[[@LINE+1]]:23: error: immediate must be an integer in the range [0, 31]
+# CHECK-PLUS: :[[@LINE+2]]:23: error: immediate must be an integer in the range [0, 31]
+# CHECK-MINUS: :[[@LINE+1]]:23: error: invalid operand for instruction
 qc.insbi x6, -10, 12, 65
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcibm' (Qualcomm uC Bit Manipulation Extension)
@@ -189,10 +193,12 @@ qc.insb x10, x7, 6
 # CHECK-MINUS: :[[@LINE+1]]:9: error: invalid operand for instruction
 qc.insb x0, x7, 6, 31
 
-# CHECK-PLUS: :[[@LINE+1]]:18: error: immediate must be an integer in the range [1, 32]
+# CHECK-PLUS: :[[@LINE+2]]:18: error: immediate must be an integer in the range [1, 32]
+# CHECK-MINUS: :[[@LINE+1]]:18: error: invalid operand for instruction
 qc.insb x10, x7, 46, 31
 
-# CHECK-PLUS: :[[@LINE+1]]:21: error: immediate must be an integer in the range [0, 31]
+# CHECK-PLUS: :[[@LINE+2]]:21: error: immediate must be an integer in the range [0, 31]
+# CHECK-MINUS: :[[@LINE+1]]:21: error: invalid operand for instruction
 qc.insb x10, x7, 6, 61
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcibm' (Qualcomm uC Bit Manipulation Extension)
@@ -209,10 +215,12 @@ qc.insbh x20, x12, 8
 # CHECK-MINUS: :[[@LINE+1]]:10: error: invalid operand for instruction
 qc.insbh x0, x12, 8, 12
 
-# CHECK-PLUS: :[[@LINE+1]]:20: error: immediate must be an integer in the range [1, 32]
+# CHECK-PLUS: :[[@LINE+2]]:20: error: immediate must be an integer in the range [1, 32]
+# CHECK-MINUS: :[[@LINE+1]]:20: error: invalid operand for instruction
 qc.insbh x20, x12, 48, 12
 
-# CHECK-PLUS: :[[@LINE+1]]:23: error: immediate must be an integer in the range [0, 31]
+# CHECK-PLUS: :[[@LINE+2]]:23: error: immediate must be an integer in the range [0, 31]
+# CHECK-MINUS: :[[@LINE+1]]:23: error: invalid operand for instruction
 qc.insbh x20, x12, 8, 72
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcibm' (Qualcomm uC Bit Manipulation Extension)
@@ -234,10 +242,12 @@ qc.extu x0, x12, 20, 20
 # CHECK-MINUS: :[[@LINE+1]]:14: error: invalid operand for instruction
 qc.extu x15, x0, 20, 20
 
-# CHECK-PLUS: :[[@LINE+1]]:19: error: immediate must be an integer in the range [1, 32]
+# CHECK-PLUS: :[[@LINE+2]]:19: error: immediate must be an integer in the range [1, 32]
+# CHECK-MINUS: :[[@LINE+1]]:19: error: invalid operand for instruction
 qc.extu x15, x12, 0, 20
 
-# CHECK-PLUS: :[[@LINE+1]]:23: error: immediate must be an integer in the range [0, 31]
+# CHECK-PLUS: :[[@LINE+2]]:23: error: immediate must be an integer in the range [0, 31]
+# CHECK-MINUS: :[[@LINE+1]]:23: error: invalid operand for instruction
 qc.extu x15, x12, 20, 60
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcibm' (Qualcomm uC Bit Manipulation Extension)
@@ -259,10 +269,12 @@ qc.ext x0, x6, 31, 1
 # CHECK-MINUS: :[[@LINE+1]]:13: error: invalid operand for instruction
 qc.ext x27, x0, 31, 1
 
-# CHECK-PLUS: :[[@LINE+1]]:17: error: immediate must be an integer in the range [1, 32]
+# CHECK-PLUS: :[[@LINE+2]]:17: error: immediate must be an integer in the range [1, 32]
+# CHECK-MINUS: :[[@LINE+1]]:17: error: invalid operand for instruction
 qc.ext x27, x6, 0, 1
 
-# CHECK-PLUS: :[[@LINE+1]]:21: error: immediate must be an integer in the range [0, 31]
+# CHECK-PLUS: :[[@LINE+2]]:21: error: immediate must be an integer in the range [0, 31]
+# CHECK-MINUS: :[[@LINE+1]]:21: error: invalid operand for instruction
 qc.ext x27, x6, 31, 41
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcibm' (Qualcomm uC Bit Manipulation Extension)
@@ -280,10 +292,12 @@ qc.extdu x1, x8, 8
 # CHECK-MINUS: :[[@LINE+1]]:10: error: invalid operand for instruction
 qc.extdu x0, x8, 8, 8
 
-# CHECK-PLUS: :[[@LINE+1]]:18: error: immediate must be an integer in the range [1, 32]
+# CHECK-PLUS: :[[@LINE+2]]:18: error: immediate must be an integer in the range [1, 32]
+# CHECK-MINUS: :[[@LINE+1]]:18: error: invalid operand for instruction
 qc.extdu x1, x8, 48, 8
 
-# CHECK-PLUS: :[[@LINE+1]]:21: error: immediate must be an integer in the range [0, 31]
+# CHECK-PLUS: :[[@LINE+2]]:21: error: immediate must be an integer in the range [0, 31]
+# CHECK-MINUS: :[[@LINE+1]]:21: error: invalid operand for instruction
 qc.extdu x1, x8, 8, 78
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcibm' (Qualcomm uC Bit Manipulation Extension)
@@ -301,10 +315,12 @@ qc.extd x13, x21, 10
 # CHECK-MINUS: :[[@LINE+1]]:9: error: invalid operand for instruction
 qc.extd x0, x21, 10, 15
 
-# CHECK-PLUS: :[[@LINE+1]]:19: error: immediate must be an integer in the range [1, 32]
+# CHECK-PLUS: :[[@LINE+2]]:19: error: immediate must be an integer in the range [1, 32]
+# CHECK-MINUS: :[[@LINE+1]]:19: error: invalid operand for instruction
 qc.extd x13, x21, 60, 15
 
-# CHECK-PLUS: :[[@LINE+1]]:23: error: immediate must be an integer in the range [0, 31]
+# CHECK-PLUS: :[[@LINE+2]]:23: error: immediate must be an integer in the range [0, 31]
+# CHECK-MINUS: :[[@LINE+1]]:23: error: invalid operand for instruction
 qc.extd x13, x21, 10, 85
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcibm' (Qualcomm uC Bit Manipulation Extension)
@@ -525,26 +541,30 @@ qc.extdprh x6, x24, x0
 qc.extdprh x6, x24, x25
 
 
-# CHECK: :[[@LINE+1]]:12: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:12: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:12: error: invalid operand for instruction
 qc.c.bexti x1, 8
 
 # CHECK: :[[@LINE+1]]:1: error: too few operands for instruction
 qc.c.bexti x15
 
-# CHECK-PLUS: :[[@LINE+1]]:17: error: immediate must be an integer in the range [1, 31]
+# CHECK-PLUS: :[[@LINE+2]]:17: error: immediate must be an integer in the range [1, 31]
+# CHECK-MINUS: :[[@LINE+1]]:17: error: invalid operand for instruction
 qc.c.bexti x15, 43
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcibm' (Qualcomm uC Bit Manipulation Extension)
 qc.c.bexti x9, 8
 
 
-# CHECK: :[[@LINE+1]]:12: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:12: error: invalid operand for instruction
+# CHECK-MINUS: :[[@LINE+1]]:12: error: invalid operand for instruction
 qc.c.bseti x2, 10
 
 # CHECK: :[[@LINE+1]]:1: error: too few operands for instruction
 qc.c.bseti x12
 
-# CHECK-PLUS: :[[@LINE+1]]:17: error: immediate must be an integer in the range [1, 31]
+# CHECK-PLUS: :[[@LINE+2]]:17: error: immediate must be an integer in the range [1, 31]
+# CHECK-MINUS: :[[@LINE+1]]:17: error: invalid operand for instruction
 qc.c.bseti x12, -10
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcibm' (Qualcomm uC Bit Manipulation Extension)
@@ -558,7 +578,8 @@ qc.c.extu x0, 10
 # CHECK: :[[@LINE+1]]:1: error: too few operands for instruction
 qc.c.extu x5
 
-# CHECK-PLUS: :[[@LINE+1]]:16: error: immediate must be an integer in the range [6, 32]
+# CHECK-PLUS: :[[@LINE+2]]:16: error: immediate must be an integer in the range [6, 32]
+# CHECK-MINUS: :[[@LINE+1]]:16: error: invalid operand for instruction
 qc.c.extu x17, 3
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcibm' (Qualcomm uC Bit Manipulation Extension)


### PR DESCRIPTION
Ensures that the test checks for every error emitted by llvm-mc. To do this
we have to move the CHECK lines to the next line rather than the same line
since otherwise we get a false-positive match.

This adds a few missing CHECK line in the xqcibm-invalid test and is needed
to minimize the diff in one of my subsequent commit.
