### PR TITLE
[Clang][HIP] Fix math header conflict with MSVC v145

### DIFF
--- a/clang/lib/Headers/__clang_cuda_math_forward_declares.h
+++ b/clang/lib/Headers/__clang_cuda_math_forward_declares.h
@@ -94,21 +94,25 @@ __DEVICE__ bool isfinite(long double);
 #endif
 __DEVICE__ bool isfinite(double);
 __DEVICE__ bool isfinite(float);
+#if !defined(_MSC_VER) || _MSC_VER < 1451
 __DEVICE__ bool isgreater(double, double);
 __DEVICE__ bool isgreaterequal(double, double);
 __DEVICE__ bool isgreaterequal(float, float);
 __DEVICE__ bool isgreater(float, float);
+#endif
 #ifdef _MSC_VER
 __DEVICE__ bool isinf(long double);
 #endif
 __DEVICE__ bool isinf(double);
 __DEVICE__ bool isinf(float);
+#if !defined(_MSC_VER) || _MSC_VER < 1451
 __DEVICE__ bool isless(double, double);
 __DEVICE__ bool islessequal(double, double);
 __DEVICE__ bool islessequal(float, float);
 __DEVICE__ bool isless(float, float);
 __DEVICE__ bool islessgreater(double, double);
 __DEVICE__ bool islessgreater(float, float);
+#endif
 #ifdef _MSC_VER
 __DEVICE__ bool isnan(long double);
 #endif
@@ -116,8 +120,10 @@ __DEVICE__ bool isnan(double);
 __DEVICE__ bool isnan(float);
 __DEVICE__ bool isnormal(double);
 __DEVICE__ bool isnormal(float);
+#if !defined(_MSC_VER) || _MSC_VER < 1451
 __DEVICE__ bool isunordered(double, double);
 __DEVICE__ bool isunordered(float, float);
+#endif
 __DEVICE__ long labs(long);
 __DEVICE__ double ldexp(double, int);
 __DEVICE__ float ldexp(float, int);

--- a/clang/lib/Headers/__clang_hip_cmath.h
+++ b/clang/lib/Headers/__clang_hip_cmath.h
@@ -104,6 +104,7 @@ __DEVICE__ __CONSTEXPR__ bool isnan(double __x) { return ::__isnan(__x); }
 #pragma omp end declare variant
 #endif // defined(__OPENMP_AMDGCN__)
 
+#if !defined(_MSC_VER) || _MSC_VER < 1451
 __DEVICE__ __CONSTEXPR__ bool isgreater(float __x, float __y) {
   return __builtin_isgreater(__x, __y);
 }
@@ -134,18 +135,21 @@ __DEVICE__ __CONSTEXPR__ bool islessgreater(float __x, float __y) {
 __DEVICE__ __CONSTEXPR__ bool islessgreater(double __x, double __y) {
   return __builtin_islessgreater(__x, __y);
 }
+#endif // !defined(_MSC_VER) || _MSC_VER < 1451
 __DEVICE__ __CONSTEXPR__ bool isnormal(float __x) {
   return __builtin_isnormal(__x);
 }
 __DEVICE__ __CONSTEXPR__ bool isnormal(double __x) {
   return __builtin_isnormal(__x);
 }
+#if !defined(_MSC_VER) || _MSC_VER < 1451
 __DEVICE__ __CONSTEXPR__ bool isunordered(float __x, float __y) {
   return __builtin_isunordered(__x, __y);
 }
 __DEVICE__ __CONSTEXPR__ bool isunordered(double __x, double __y) {
   return __builtin_isunordered(__x, __y);
 }
+#endif // !defined(_MSC_VER) || _MSC_VER < 1451
 __DEVICE__ __CONSTEXPR__ float modf(float __x, float *__iptr) {
   return ::modff(__x, __iptr);
 }


### PR DESCRIPTION
 MSVC v145 added `__host__ __device__` attributes to math comparison functions **(isgreater, isgreaterequal, isless, islessequal, islessgreater, isunordered)** in `<cmath>`, causing overload conflicts with Clang's `__device__` only declarations in HIP headers.

Guard these declarations when MSVC v145+ is detected since MSVC provides its own `__host__ __device__` implementations via `_CLANG_BUILTIN2` macros.

Fixes https://github.com/ROCm/llvm-project/issues/2669
