### PR TITLE
[clang][ThreadSafety] Add requires_negative_capability attribute

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -454,6 +454,11 @@ Attribute Changes in Clang
   Only plain function pointers are supported; pointers-to-member functions,
   blocks, or wrappers (e.g. ``std::function``) are not yet supported.
 
+- Added the :doc:`ThreadSafetyAnalysis` attribute
+  ``requires_negative_capability``. It expresses a negative capability
+  requirement without requiring ``!capability`` to be a well-formed C++
+  expression.
+
 - The ``[[clang::unsafe_buffer_usage]]`` attribute is now supported in API
   notes. For example:
   

--- a/clang/docs/ThreadSafetyAnalysis.rst
+++ b/clang/docs/ThreadSafetyAnalysis.rst
@@ -654,19 +654,24 @@ As a result, ``EXCLUDES`` can easily produce false negatives:
 
 
 Negative requirements are an alternative to ``EXCLUDES`` that provide
-a stronger safety guarantee.  A negative requirement uses the  ``REQUIRES``
-attribute, in conjunction with the ``!`` operator, to indicate that a capability
-should *not* be held.
+a stronger safety guarantee.  A negative requirement uses either
+``REQUIRES_NEGATIVE`` or the ``REQUIRES`` attribute in conjunction with the
+``!`` operator to indicate that a capability should *not* be held.
+``REQUIRES_NEGATIVE(mu)`` does not require ``!mu`` to be a well-formed
+expression. More generally, its argument is interpreted the same way as a
+``REQUIRES`` argument, and then the capability requirement is inverted. For
+example, if ``!mu`` is well-formed, ``REQUIRES_NEGATIVE(!mu)`` is equivalent
+to ``REQUIRES(mu)``.
 
-For example, using ``REQUIRES(!mu)`` instead of ``EXCLUDES(mu)`` will produce
-the appropriate warnings:
+For example, using ``REQUIRES_NEGATIVE(mu)`` instead of ``EXCLUDES(mu)`` will
+produce the appropriate warnings:
 
 .. code-block:: c++
 
   class FooNeg {
     Mutex mu;
 
-    void foo() REQUIRES(!mu) {   // foo() now requires !mu.
+    void foo() REQUIRES_NEGATIVE(mu) {  // foo() now requires !mu.
       mu.Lock();
       bar();
       baz();
@@ -674,16 +679,16 @@ the appropriate warnings:
     }
 
     void bar() {
-      mu.Lock();       // WARNING!  Missing REQUIRES(!mu).
+      mu.Lock();       // WARNING!  Missing REQUIRES_NEGATIVE(mu).
       // ...
       mu.Unlock();
     }
 
     void baz() {
-      bif();           // WARNING!  Missing REQUIRES(!mu).
+      bif();           // WARNING!  Missing REQUIRES_NEGATIVE(mu).
     }
 
-    void bif() REQUIRES(!mu);
+    void bif() REQUIRES_NEGATIVE(mu);
   };
 
 
@@ -936,6 +941,9 @@ implementation.
 
   #define REQUIRES_SHARED(...) \
     THREAD_ANNOTATION_ATTRIBUTE__(requires_shared_capability(__VA_ARGS__))
+
+  #define REQUIRES_NEGATIVE(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(requires_negative_capability(__VA_ARGS__))
 
   #define ACQUIRE(...) \
     THREAD_ANNOTATION_ATTRIBUTE__(acquire_capability(__VA_ARGS__))

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -4179,7 +4179,8 @@ def RequiresCapability : InheritableAttr {
   let Spellings = [Clang<"requires_capability", 0>,
                    Clang<"exclusive_locks_required", 0>,
                    Clang<"requires_shared_capability", 0>,
-                   Clang<"shared_locks_required", 0>];
+                   Clang<"shared_locks_required", 0>,
+                   Clang<"requires_negative_capability", 0>];
   let Args = [VariadicExprArgument<"Args">];
   let AcceptsExprPack = 1;
   let LateParsed = LateAttrParseStandard;
@@ -4189,7 +4190,9 @@ def RequiresCapability : InheritableAttr {
   let ParseArgsInFunctionScope = 1;
   let Subjects = SubjectList<[Function, Var, Field]>;
   let Accessors = [Accessor<"isShared", [Clang<"requires_shared_capability", 0>,
-                                         Clang<"shared_locks_required", 0>]>];
+                                         Clang<"shared_locks_required", 0>]>,
+                   Accessor<"isNegative",
+                     [Clang<"requires_negative_capability", 0>]>];
   let Documentation = [Undocumented];
 }
 

--- a/clang/lib/Analysis/ThreadSafety.cpp
+++ b/clang/lib/Analysis/ThreadSafety.cpp
@@ -1278,7 +1278,8 @@ public:
   void warnIfMutexNotHeld(const FactSet &FSet, const NamedDecl *D,
                           const Expr *Exp, AccessKind AK, Expr *MutexExp,
                           ProtectedOperationKind POK, til::SExpr *Self,
-                          SourceLocation Loc);
+                          SourceLocation Loc,
+                          const bool NegateCapability = false);
   void warnIfAnyMutexNotHeldForRead(const FactSet &FSet, const NamedDecl *D,
                                     const Expr *Exp,
                                     llvm::ArrayRef<Expr *> Args,
@@ -1518,15 +1519,24 @@ void ThreadSafetyAnalyzer::removeLock(FactSet &FSet, const CapabilityExpr &Cp,
   LDat->handleUnlock(FSet, FactMan, Cp, UnlockLoc, FullyRemove, Handler);
 }
 
+static bool requiresNegativeCapability(const Attr *Attr) {
+  if (const auto *A = dyn_cast<RequiresCapabilityAttr>(Attr))
+    return A->isNegative();
+  return false;
+}
+
 /// Extract the list of mutexIDs from the attribute on an expression,
 /// and push them onto Mtxs, discarding any duplicates.
 template <typename AttrType>
 void ThreadSafetyAnalyzer::getMutexIDs(CapExprSet &Mtxs, AttrType *Attr,
                                        const Expr *Exp, const NamedDecl *D,
                                        til::SExpr *Self) {
+  const bool NegateCapability = requiresNegativeCapability(Attr);
   if (Attr->args_size() == 0) {
     // The mutex held is the "this" object.
     CapabilityExpr Cp = SxBuilder.translateAttrExpr(nullptr, D, Exp, Self);
+    if (NegateCapability)
+      Cp = !Cp;
     if (Cp.isInvalid()) {
       warnInvalidLock(Handler, nullptr, D, Exp, Cp.getKind());
       return;
@@ -1539,6 +1549,8 @@ void ThreadSafetyAnalyzer::getMutexIDs(CapExprSet &Mtxs, AttrType *Attr,
 
   for (const auto *Arg : Attr->args()) {
     CapabilityExpr Cp = SxBuilder.translateAttrExpr(Arg, D, Exp, Self);
+    if (NegateCapability)
+      Cp = !Cp;
     if (Cp.isInvalid()) {
       warnInvalidLock(Handler, nullptr, D, Exp, Cp.getKind());
       continue;
@@ -1798,9 +1810,11 @@ public:
 void ThreadSafetyAnalyzer::warnIfMutexNotHeld(
     const FactSet &FSet, const NamedDecl *D, const Expr *Exp, AccessKind AK,
     Expr *MutexExp, ProtectedOperationKind POK, til::SExpr *Self,
-    SourceLocation Loc) {
+    SourceLocation Loc, const bool NegateCapability) {
   LockKind LK = getLockKindFromAccessKind(AK);
   CapabilityExpr Cp = SxBuilder.translateAttrExpr(MutexExp, D, Exp, Self);
+  if (NegateCapability)
+    Cp = !Cp;
   if (Cp.isInvalid()) {
     warnInvalidLock(Handler, MutexExp, D, Exp, Cp.getKind());
     return;
@@ -2148,7 +2162,8 @@ void BuildLockset::handleCall(const Expr *Exp, const NamedDecl *D,
         for (auto *Arg : A->args()) {
           Analyzer->warnIfMutexNotHeld(FSet, D, Exp,
                                        A->isShared() ? AK_Read : AK_Written,
-                                       Arg, POK_FunctionCall, Self, Loc);
+                                       Arg, POK_FunctionCall, Self, Loc,
+                                       /*NegateCapability=*/A->isNegative());
           // use for adopting a lock
           if (!Scp.shouldIgnore())
             Analyzer->getMutexIDs(ScopedReqsAndExcludes, A, Exp, D, Self);
@@ -2214,7 +2229,8 @@ void BuildLockset::handleCall(const Expr *Exp, const NamedDecl *D,
           for (auto *Arg : A->args())
             Analyzer->warnIfMutexNotHeld(FSet, D, Exp,
                                          A->isShared() ? AK_Read : AK_Written,
-                                         Arg, POK_FunctionCall, Self, Loc);
+                                         Arg, POK_FunctionCall, Self, Loc,
+                                         /*NegateCapability=*/A->isNegative());
           Analyzer->getMutexIDs(DeclaredLocks, A, Exp, D, Self);
           break;
         }

--- a/clang/test/Sema/attr-capabilities.c
+++ b/clang/test/Sema/attr-capabilities.c
@@ -71,3 +71,10 @@ void Func30(void) __attribute__((requires_capability((Worker || Worker) && !GUI)
 
 int AlsoNotACapability;
 void Func31(void) __attribute__((requires_capability(GUI && AlsoNotACapability))); // expected-warning {{'requires_capability' attribute requires arguments whose type is annotated with 'capability' attribute; type here is 'int'}}
+
+void Func32(void) __attribute__((requires_negative_capability(GUI)));
+void Func33(void) __attribute__((requires_negative_capability)) {}
+// expected-error@-1 {{'requires_negative_capability' attribute takes at least 1 argument}}
+void Func34(void) __attribute__((requires_negative_capability(1))) {}
+// expected-warning@-1 {{requires arguments whose type is annotated with 'capability' attribute; type here is 'int'}}
+void Func35(void) __attribute__((requires_negative_capability(!GUI))) {}

--- a/clang/test/SemaCXX/thread-safety-annotations.h
+++ b/clang/test/SemaCXX/thread-safety-annotations.h
@@ -33,6 +33,7 @@
 #define SHARED_UNLOCK_FUNCTION(...)     __attribute__((release_shared_capability(__VA_ARGS__)))
 #define GUARDED_BY(...)                 __attribute__((guarded_by(__VA_ARGS__)))
 #define PT_GUARDED_BY(...)              __attribute__((pt_guarded_by(__VA_ARGS__)))
+#define REQUIRES_NEGATIVE(...)          __attribute__((requires_negative_capability(__VA_ARGS__)))
 
 // Common
 #define REENTRANT_CAPABILITY            __attribute__((reentrant_capability))

--- a/clang/test/SemaCXX/warn-thread-safety-negative.cpp
+++ b/clang/test/SemaCXX/warn-thread-safety-negative.cpp
@@ -6,6 +6,8 @@
 
 #include "thread-safety-annotations.h"
 
+namespace NegativeExclusiveLockFunctionTests {
+
 class LOCKABLE Mutex {
  public:
   void Lock() EXCLUSIVE_LOCK_FUNCTION();
@@ -128,7 +130,7 @@ Mutex globalMutex;
 namespace ScopeTest {
 
 void f() EXCLUSIVE_LOCKS_REQUIRED(!globalMutex);
-void fq() EXCLUSIVE_LOCKS_REQUIRED(!::globalMutex);
+void fq() EXCLUSIVE_LOCKS_REQUIRED(!::NegativeExclusiveLockFunctionTests::globalMutex);
 
 namespace ns {
   Mutex globalMutex;
@@ -195,3 +197,239 @@ class TemplateClass {
 void test() { TemplateClass<int> TC; }
 
 }  // end namespace DoubleAttribute
+
+} // end namespace NegativeExclusiveLockFunctionTests
+
+namespace RequiresNegativeCapabilityTests {
+
+class LOCKABLE Mutex {
+ public:
+  void Lock() EXCLUSIVE_LOCK_FUNCTION();
+  void ReaderLock() SHARED_LOCK_FUNCTION();
+  void Unlock() UNLOCK_FUNCTION();
+  bool TryLock() EXCLUSIVE_TRYLOCK_FUNCTION(true);
+  bool ReaderTryLock() SHARED_TRYLOCK_FUNCTION(true);
+  void AssertHeld()       ASSERT_EXCLUSIVE_LOCK();
+  void AssertReaderHeld() ASSERT_SHARED_LOCK();
+};
+
+class LOCKABLE MutexWithOperatorNot {
+public:
+  void Lock() EXCLUSIVE_LOCK_FUNCTION();
+  void ReaderLock() SHARED_LOCK_FUNCTION();
+  void Unlock() UNLOCK_FUNCTION();
+  bool TryLock() EXCLUSIVE_TRYLOCK_FUNCTION(true);
+  bool ReaderTryLock() SHARED_TRYLOCK_FUNCTION(true);
+
+  const MutexWithOperatorNot& operator!() const { return *this; }
+
+  void AssertHeld()       ASSERT_EXCLUSIVE_LOCK();
+  void AssertReaderHeld() ASSERT_SHARED_LOCK();
+};
+
+class LOCKABLE REENTRANT_CAPABILITY ReentrantMutex {
+public:
+  void Lock() EXCLUSIVE_LOCK_FUNCTION();
+  void Unlock() UNLOCK_FUNCTION();
+};
+
+class SCOPED_LOCKABLE MutexLock {
+public:
+  MutexLock(Mutex *mu) EXCLUSIVE_LOCK_FUNCTION(mu);
+  MutexLock(Mutex *mu, bool adopt) EXCLUSIVE_LOCKS_REQUIRED(mu);
+  ~MutexLock() UNLOCK_FUNCTION();
+};
+
+namespace SimpleTest {
+
+class Bar {
+  Mutex mu;
+  int a GUARDED_BY(mu);
+
+public:
+  void baz() REQUIRES_NEGATIVE(mu) {
+    mu.Lock();
+    a = 0;
+    mu.Unlock();
+  }
+};
+
+
+class Foo {
+  Mutex mu;
+  int a GUARDED_BY(mu);
+
+public:
+  void foo() {
+    mu.Lock();    // expected-warning {{acquiring mutex 'mu' requires negative capability '!mu'}}
+    baz();        // expected-warning {{cannot call function 'baz' while mutex 'mu' is held}}
+    bar();
+    mu.Unlock();
+  }
+
+  void bar() {
+    baz();        // expected-warning {{calling function 'baz' requires negative capability '!mu'}}
+  }
+
+  void baz() REQUIRES_NEGATIVE(mu) {
+    mu.Lock();
+    a = 0;
+    mu.Unlock();
+  }
+
+  void test() {
+    Bar b;
+    b.baz();     // no warning -- in different class.
+  }
+
+  void test2() {
+    mu.Lock();   // expected-warning {{acquiring mutex 'mu' requires negative capability '!mu'}}
+    a = 0;
+    mu.Unlock();
+    baz();       // no warning -- !mu in set.
+  }
+
+  void test3() REQUIRES_NEGATIVE(mu) {
+    mu.Lock();
+    a = 0;
+    mu.Unlock();
+    baz();       // no warning -- !mu in set.
+  }
+
+  void test4() {
+    MutexLock lock(&mu); // expected-warning {{acquiring mutex 'mu' requires negative capability '!mu'}}
+  }
+};
+
+class Reentrant {
+  ReentrantMutex mu;
+
+public:
+  void acquire() {
+    mu.Lock();   // no warning -- reentrant mutex
+    mu.Unlock();
+  }
+
+  void requireNegative() REQUIRES_NEGATIVE(mu) { // warning?
+    mu.Lock();
+    mu.Unlock();
+  }
+
+  void callRequireNegative() {
+    requireNegative(); // expected-warning{{calling function 'requireNegative' requires negative capability '!mu'}}
+  }
+
+  void callHaveNegative() REQUIRES_NEGATIVE(mu) {
+    requireNegative();
+  }
+};
+
+class DoubleNegativeTest {
+  MutexWithOperatorNot mu;
+  int a GUARDED_BY(mu);
+
+public:
+  void test1() {
+    mu.Lock(); // expected-warning {{acquiring mutex 'mu' requires negative capability '!mu'}}
+    baz();
+    bar();
+    mu.Unlock();
+  }
+
+  void bar() {
+    baz();     // expected-warning {{calling function 'baz' requires holding mutex 'mu' exclusively}}
+  }
+
+  void baz() REQUIRES_NEGATIVE(!mu) {
+    a = 0;
+  }
+
+  void test2() REQUIRES_NEGATIVE(mu) {
+    mu.Lock();
+    a = 0;
+    mu.Unlock();
+    baz();     // expected-warning {{calling function 'baz' requires holding mutex 'mu' exclusively}}
+  }
+
+  void test3() REQUIRES_NEGATIVE(!mu) {
+    a = 0;
+    baz();
+  }
+};
+
+}  // end namespace SimpleTest
+
+Mutex globalMutex;
+
+namespace ScopeTest {
+
+void f() REQUIRES_NEGATIVE(globalMutex);
+void fq() REQUIRES_NEGATIVE(::RequiresNegativeCapabilityTests::globalMutex);
+
+namespace ns {
+  Mutex globalMutex;
+  void f() REQUIRES_NEGATIVE(globalMutex);
+  void fq() REQUIRES_NEGATIVE(ns::globalMutex);
+}
+
+void testGlobals() REQUIRES_NEGATIVE(ns::globalMutex) {
+  f();     // expected-warning {{calling function 'f' requires negative capability '!globalMutex'}}
+  fq();    // expected-warning {{calling function 'fq' requires negative capability '!globalMutex'}}
+  ns::f();
+  ns::fq();
+}
+
+void testNamespaceGlobals() REQUIRES_NEGATIVE(globalMutex) {
+  f();
+  fq();
+  ns::f();  // expected-warning {{calling function 'f' requires negative capability '!globalMutex'}}
+  ns::fq(); // expected-warning {{calling function 'fq' requires negative capability '!globalMutex'}}
+}
+
+class StaticMembers {
+public:
+  void pub() REQUIRES_NEGATIVE(publicMutex);
+  void prot() REQUIRES_NEGATIVE(protectedMutex);
+  void priv() REQUIRES_NEGATIVE(privateMutex);
+  void test() {
+    pub();
+    prot();
+    priv();
+  }
+
+  static Mutex publicMutex;
+
+protected:
+  static Mutex protectedMutex;
+
+private:
+  static Mutex privateMutex;
+};
+
+void testStaticMembers() {
+  StaticMembers x;
+  x.pub();
+  x.prot();
+  x.priv();
+}
+
+}  // end namespace ScopeTest
+
+namespace DoubleAttribute {
+
+struct Foo {
+  Mutex &mutex();
+};
+
+template <typename A>
+class TemplateClass {
+  template <typename B>
+  static void Function(Foo *F)
+      EXCLUSIVE_LOCKS_REQUIRED(F->mutex()) UNLOCK_FUNCTION(F->mutex()) {}
+};
+
+void test() { TemplateClass<int> TC; }
+
+}  // end namespace DoubleAttribute
+
+} // end namespace RequiresNegativeCapabilityTests

--- a/clang/test/SemaCXX/warn-thread-safety-parsing.cpp
+++ b/clang/test/SemaCXX/warn-thread-safety-parsing.cpp
@@ -24,6 +24,7 @@
   __attribute__ ((exclusive_locks_required(__VA_ARGS__)))
 #define SHARED_LOCKS_REQUIRED(...) \
   __attribute__ ((shared_locks_required(__VA_ARGS__)))
+#define REQUIRES_NEGATIVE(...) __attribute__ ((requires_negative_capability(__VA_ARGS__)))
 #define NO_THREAD_SAFETY_ANALYSIS  __attribute__ ((no_thread_safety_analysis))
 
 
@@ -1301,6 +1302,89 @@ template int elr_variadic_template<Mutex, UnlockableMu>(Mutex&, UnlockableMu&);
 #endif
 
 
+//-----------------------------------------//
+//  Requires Negative Capability
+//-----------------------------------------//
+
+#if !__has_attribute(requires_negative_capability)
+#error "Should support requires_negative_capability attribute"
+#endif
+
+// takes one or more arguments, all locks (vars/fields)
+
+void rnc_function() __attribute__((requires_negative_capability)); // \
+  // expected-error {{'requires_negative_capability' attribute takes at least 1 argument}}
+
+void rnc_function_arg() REQUIRES_NEGATIVE(mu1);
+
+void rnc_function_args() REQUIRES_NEGATIVE(mu1, mu2);
+
+int rnc_testfn(int y) REQUIRES_NEGATIVE(mu1);
+
+int rnc_testfn(int y) {
+  int x REQUIRES_NEGATIVE(mu1) = y; // \
+    // expected-warning {{'requires_negative_capability' attribute on a variable requires the variable to be of function pointer type}}
+  return x;
+}
+
+int rnc_test_var REQUIRES_NEGATIVE(mu1); // \
+  // expected-warning {{'requires_negative_capability' attribute on a variable requires the variable to be of function pointer type}}
+
+void rnc_fun_params1(MutexLock& scope REQUIRES_NEGATIVE(mu1));
+void rnc_fun_params2(int lvar REQUIRES_NEGATIVE(mu1)); // \
+  // expected-warning {{'requires_negative_capability' attribute applies to function parameters only if their type is a reference to a 'scoped_lockable'-annotated type}}
+
+class RncFoo {
+ private:
+  int test_field REQUIRES_NEGATIVE(mu1); // \
+    // expected-warning {{'requires_negative_capability' attribute on a field requires the field to be of function pointer type}}
+  void test_method() REQUIRES_NEGATIVE(mu1);
+};
+
+class REQUIRES_NEGATIVE(mu1) RncTestClass { // \
+  // expected-warning {{'requires_negative_capability' attribute only applies to functions, variables, and non-static data members}}
+};
+
+// Check argument parsing.
+
+// legal attribute arguments
+int rnc_function_1() REQUIRES_NEGATIVE(muWrapper.mu);
+int rnc_function_2() REQUIRES_NEGATIVE(muDoubleWrapper.muWrapper->mu);
+int rnc_function_3() REQUIRES_NEGATIVE(muWrapper.getMu());
+int rnc_function_4() REQUIRES_NEGATIVE(*muWrapper.getMuPointer());
+int rnc_function_5() REQUIRES_NEGATIVE(&mu1);
+int rnc_function_6() REQUIRES_NEGATIVE(muRef);
+int rnc_function_7() REQUIRES_NEGATIVE(muDoubleWrapper.getWrapper()->getMu());
+int rnc_function_8() REQUIRES_NEGATIVE(muPointer);
+int rnc_function_9() REQUIRES_NEGATIVE(!&mu1);
+
+// illegal attribute arguments
+int rnc_function_bad_1() REQUIRES_NEGATIVE(1); // \
+  // expected-warning {{'requires_negative_capability' attribute requires arguments whose type is annotated with 'capability' attribute; type here is 'int'}}
+int rnc_function_bad_2() REQUIRES_NEGATIVE("mu"); // \
+  // expected-warning {{ignoring 'requires_negative_capability' attribute because its argument is invalid}}
+int rnc_function_bad_3() REQUIRES_NEGATIVE(muDoublePointer); // \
+  // expected-warning {{'requires_negative_capability' attribute requires arguments whose type is annotated with 'capability' attribute; type here is 'Mutex **'}}
+int rnc_function_bad_4() REQUIRES_NEGATIVE(umu); // \
+  // expected-warning {{'requires_negative_capability' attribute requires arguments whose type is annotated with 'capability' attribute}}
+
+template<typename Mu>
+int rnc_template(Mu& mu) REQUIRES_NEGATIVE(mu) {}
+
+template int rnc_template<Mutex>(Mutex&);
+// FIXME: warn on template instantiation.
+template int rnc_template<UnlockableMu>(UnlockableMu&);
+
+#if __cplusplus >= 201103
+
+template<typename... Mus>
+int rnc_variadic_template(Mus&... mus) REQUIRES_NEGATIVE(mus...) {}
+
+template int rnc_variadic_template<Mutex, Mutex>(Mutex&, Mutex&);
+// FIXME: warn on template instantiation.
+template int rnc_variadic_template<Mutex, UnlockableMu>(Mutex&, UnlockableMu&);
+
+#endif
 
 
 //-----------------------------------------//
@@ -1803,6 +1887,7 @@ void (*(&fp_ref_to_array)[4])(void) EXCLUSIVE_LOCK_FUNCTION(mu1) = fp_array; // 
 // C++11 spelling at the declaration prefix so attribute applies to variable.
 [[clang::acquire_capability(mu1)]] void (*fp_cxx11)(void);
 [[clang::requires_capability(mu1)]] void (*fp_cxx11_req)(void);
+[[clang::requires_negative_capability(mu1)]] void (*fp_cxx11_neg_req)(void);
 
 template <typename FuncPtr>
 struct DependentFPFields {

--- a/libcxx/.clang-format
+++ b/libcxx/.clang-format
@@ -46,6 +46,7 @@ AttributeMacros: [
                   '_LIBCPP_OVERRIDABLE_FUNC_VIS',
                   '_LIBCPP_RELEASE_CAPABILITY',
                   '_LIBCPP_REQUIRES_CAPABILITY',
+                  '_LIBCPP_REQUIRES_NEGATIVE_CAPABILITY',
                   '_LIBCPP_SCOPED_LOCKABLE',
                   '_LIBCPP_STANDALONE_DEBUG',
                   '_LIBCPP_TEMPLATE_DATA_VIS',

--- a/libcxx/include/__configuration/attributes.h
+++ b/libcxx/include/__configuration/attributes.h
@@ -351,6 +351,12 @@
 #  define _LIBCPP_REQUIRES_CAPABILITY(...)
 #endif
 
+#if __has_attribute(__requires_negative_capability__)
+#  define _LIBCPP_REQUIRES_NEGATIVE_CAPABILITY(...) __attribute__((__requires_negative_capability__(__VA_ARGS__)))
+#else
+#  define _LIBCPP_REQUIRES_NEGATIVE_CAPABILITY(...)
+#endif
+
 #if __has_cpp_attribute(_Clang::__no_thread_safety_analysis__)
 #  define _LIBCPP_NO_THREAD_SAFETY_ANALYSIS [[_Clang::__no_thread_safety_analysis__]]
 #else

--- a/libcxx/include/__cxx03/__config
+++ b/libcxx/include/__cxx03/__config
@@ -1090,6 +1090,12 @@ typedef __char32_t char32_t;
 #    define _LIBCPP_REQUIRES_CAPABILITY(...)
 #  endif
 
+#  if __has_attribute(__requires_negative_capability__)
+#    define _LIBCPP_REQUIRES_NEGATIVE_CAPABILITY(...) __attribute__((__requires_negative_capability__(__VA_ARGS__)))
+#  else
+#    define _LIBCPP_REQUIRES_NEGATIVE_CAPABILITY(...)
+#  endif
+
 #  if defined(_LIBCPP_ABI_MICROSOFT) && __has_declspec_attribute(empty_bases)
 #    define _LIBCPP_DECLSPEC_EMPTY_BASES __declspec(empty_bases)
 #  else

--- a/libcxx/test/extensions/clang/thread/thread.mutex/thread_safety_negative.pass.cpp
+++ b/libcxx/test/extensions/clang/thread/thread.mutex/thread_safety_negative.pass.cpp
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: no-threads
+
+// <mutex>
+
+// GCC doesn't have thread safety attributes
+// UNSUPPORTED: gcc
+
+// ADDITIONAL_COMPILE_FLAGS: -Wthread-safety -Wthread-safety-negative
+
+#include <mutex>
+
+#include "test_macros.h"
+
+std::mutex m;
+int foo __attribute__((guarded_by(m)));
+
+void increment() __attribute__((requires_negative_capability(m))) {
+  m.lock();
+  foo++;
+  m.unlock();
+}
+
+void test() __attribute__((requires_negative_capability(m))) {
+  increment();
+}
+
+int main(int, char**) {
+  return 0;
+}


### PR DESCRIPTION
Add a requires_negative_capability thread-safety attribute spelling for negative capability requirements. This allows users to express that a capability must not be held without requiring !capability to be a well-formed C++ expression.

The new spelling reuses the existing RequiresCapabilityAttr and CapabilityExpr negative-capability machinery. The argument is translated like requires_capability, then the resulting capability polarity is inverted.

Also add a libc++ helper macro and tests covering std::mutex use with -Wthread-safety-negative.

Fixes #157975.

--

This is my first LLVM patch so please let me know if there is anything I can do to improve my patch. Thank you!

AI disclosure: I used GPT 5.5 to come up with an initial patch. I iterated on it several times, improving the code by providing it alternative implementation directions, reviewing the production code manually, reviewing test cases manually, and reading through the release note changes.