### PR TITLE
[flang][acc] Add tests for implicit `acc declare` of type descriptors

### DIFF
--- a/flang/test/Transforms/OpenACC/acc-implicit-declare-type-descriptor-alloca.F90
+++ b/flang/test/Transforms/OpenACC/acc-implicit-declare-type-descriptor-alloca.F90
@@ -1,4 +1,4 @@
-!RUN: %bbc -emit-fir -fopenacc %s -o - | fir-opt --pass-pipeline="builtin.module(acc-initialize-fir-analyses,acc-implicit-declare)" | FileCheck %s
+!RUN: bbc -emit-fir -fopenacc %s -o - | fir-opt --pass-pipeline="builtin.module(acc-initialize-fir-analyses,acc-implicit-declare)" | FileCheck %s
 ! Test block construct with local struct to exercise fir.alloca with type descriptors
 
 module mm

--- a/flang/test/Transforms/OpenACC/acc-implicit-declare-type-descriptor-alloca.F90
+++ b/flang/test/Transforms/OpenACC/acc-implicit-declare-type-descriptor-alloca.F90
@@ -1,0 +1,27 @@
+!RUN: %bbc -emit-fir -fopenacc %s -o - | fir-opt --pass-pipeline="builtin.module(acc-initialize-fir-analyses,acc-implicit-declare)" | FileCheck %s
+! Test block construct with local struct to exercise fir.alloca with type descriptors
+
+module mm
+  type struct
+    real :: member
+  end type
+end module
+
+program main
+  use mm
+
+  ! Test block with local struct to test local creation via `fir.alloca`
+  !$acc kernels
+  block
+    type(struct) :: local_struct
+    local_struct%member = 3.0
+  end block
+  !$acc end kernels
+
+end program
+
+! CHECK-DAG: fir.alloca !fir.type<_QMmmTstruct{member:f32}>
+! CHECK-DAG: @_QMmmE{{.+}}n{{.+}}member {acc.declare
+! CHECK-DAG: @_QMmmE{{.+}}n{{.+}}struct {acc.declare
+! CHECK-DAG: @_QMmmE{{.+}}c{{.+}}struct {acc.declare
+! CHECK-DAG: @_QMmmE{{.+}}dt{{.+}}struct {acc.declare

--- a/flang/test/Transforms/OpenACC/acc-implicit-declare-type-descriptor-embox.F90
+++ b/flang/test/Transforms/OpenACC/acc-implicit-declare-type-descriptor-embox.F90
@@ -1,0 +1,26 @@
+!RUN: %bbc -emit-fir -fopenacc %s -o - | fir-opt --pass-pipeline="builtin.module(acc-initialize-fir-analyses,acc-implicit-declare)" | FileCheck %s
+! Test pointer association to exercise fir.embox with type descriptors
+
+module mm
+  type struct
+    real :: member
+  end type
+end module
+
+program main
+  use mm
+  type(struct), target :: static_struct
+  type(struct), pointer :: struct_pointer
+
+  ! Test pointer association (to test `fir.embox`)
+  !$acc serial
+  struct_pointer => static_struct
+  !$acc end serial
+
+end program
+
+! CHECK-DAG: fir.embox
+! CHECK-DAG: @_QMmmE{{.+}}n{{.+}}member {acc.declare
+! CHECK-DAG: @_QMmmE{{.+}}n{{.+}}struct {acc.declare
+! CHECK-DAG: @_QMmmE{{.+}}c{{.+}}struct {acc.declare
+! CHECK-DAG: @_QMmmE{{.+}}dt{{.+}}struct {acc.declare

--- a/flang/test/Transforms/OpenACC/acc-implicit-declare-type-descriptor-embox.F90
+++ b/flang/test/Transforms/OpenACC/acc-implicit-declare-type-descriptor-embox.F90
@@ -1,4 +1,4 @@
-!RUN: %bbc -emit-fir -fopenacc %s -o - | fir-opt --pass-pipeline="builtin.module(acc-initialize-fir-analyses,acc-implicit-declare)" | FileCheck %s
+!RUN: bbc -emit-fir -fopenacc %s -o - | fir-opt --pass-pipeline="builtin.module(acc-initialize-fir-analyses,acc-implicit-declare)" | FileCheck %s
 ! Test pointer association to exercise fir.embox with type descriptors
 
 module mm

--- a/flang/test/Transforms/OpenACC/acc-implicit-declare-type-descriptor-rebox.F90
+++ b/flang/test/Transforms/OpenACC/acc-implicit-declare-type-descriptor-rebox.F90
@@ -1,0 +1,21 @@
+!RUN: %bbc -emit-fir -fopenacc %s -o - | fir-opt --pass-pipeline="builtin.module(acc-initialize-fir-analyses,acc-implicit-declare)" | FileCheck %s
+! Test assumed-shape arguments to exercise fir.rebox with type descriptors
+
+module mm
+  type struct
+    real :: member
+  end type
+contains
+  subroutine acc_rout(struct_pointer_arr)
+    !$acc routine
+    ! Tests assumed-shape with dimensions changing (aka `fir.rebox`)
+    type(struct), dimension(0:) :: struct_pointer_arr
+    struct_pointer_arr(0)%member = 1.0
+  end subroutine
+end module
+
+! CHECK-DAG: fir.rebox
+! CHECK-DAG: @_QMmmE{{.+}}n{{.+}}member {acc.declare
+! CHECK-DAG: @_QMmmE{{.+}}n{{.+}}struct {acc.declare
+! CHECK-DAG: @_QMmmE{{.+}}c{{.+}}struct {acc.declare
+! CHECK-DAG: @_QMmmE{{.+}}dt{{.+}}struct {acc.declare

--- a/flang/test/Transforms/OpenACC/acc-implicit-declare-type-descriptor-rebox.F90
+++ b/flang/test/Transforms/OpenACC/acc-implicit-declare-type-descriptor-rebox.F90
@@ -1,4 +1,4 @@
-!RUN: %bbc -emit-fir -fopenacc %s -o - | fir-opt --pass-pipeline="builtin.module(acc-initialize-fir-analyses,acc-implicit-declare)" | FileCheck %s
+!RUN: bbc -emit-fir -fopenacc %s -o - | fir-opt --pass-pipeline="builtin.module(acc-initialize-fir-analyses,acc-implicit-declare)" | FileCheck %s
 ! Test assumed-shape arguments to exercise fir.rebox with type descriptors
 
 module mm

--- a/flang/test/Transforms/OpenACC/acc-implicit-declare-type-descriptor-type_desc.F90
+++ b/flang/test/Transforms/OpenACC/acc-implicit-declare-type-descriptor-type_desc.F90
@@ -1,0 +1,29 @@
+!RUN: %bbc -emit-fir -fopenacc %s -o - | fir-opt --pass-pipeline="builtin.module(acc-initialize-fir-analyses,acc-implicit-declare)" | FileCheck %s
+! Test nullify to exercise fir.type_desc with type descriptors
+
+module mm
+  type p1
+    real :: field
+  end type
+
+  type struct
+    class(p1), pointer :: member
+  end type
+end module
+
+program main
+  use mm
+  class(struct), pointer :: struct_pointer
+
+  ! Test extracting type descriptor to pass to runtime `fir.type_desc`
+  !$acc serial
+  nullify(struct_pointer%member)
+  !$acc end serial
+
+end program
+
+! CHECK-DAG: fir.type_desc
+! CHECK-DAG: @_QMmmE{{.+}}n{{.+}}field {acc.declare
+! CHECK-DAG: @_QMmmE{{.+}}n{{.+}}p1
+! CHECK-DAG: @_QMmmE{{.+}}c{{.+}}p1 {acc.declare
+! CHECK-DAG: @_QMmmE{{.+}}dt{{.+}}p1 {acc.declare

--- a/flang/test/Transforms/OpenACC/acc-implicit-declare-type-descriptor-type_desc.F90
+++ b/flang/test/Transforms/OpenACC/acc-implicit-declare-type-descriptor-type_desc.F90
@@ -1,4 +1,4 @@
-!RUN: %bbc -emit-fir -fopenacc %s -o - | fir-opt --pass-pipeline="builtin.module(acc-initialize-fir-analyses,acc-implicit-declare)" | FileCheck %s
+!RUN: bbc -emit-fir -fopenacc %s -o - | fir-opt --pass-pipeline="builtin.module(acc-initialize-fir-analyses,acc-implicit-declare)" | FileCheck %s
 ! Test nullify to exercise fir.type_desc with type descriptors
 
 module mm


### PR DESCRIPTION
Adds 4 tests to cover different cases which requires implicit `acc declare` for type descriptors.