### PR TITLE
[x64][win] Windows x64 unwind v3: Use tail-relative epilog offsets and add size-based splitting

### DIFF
--- a/llvm/lib/MC/MCWin64EH.cpp
+++ b/llvm/lib/MC/MCWin64EH.cpp
@@ -66,6 +66,49 @@ public:
     return UnwindV2Start->getFragment();
   }
 };
+
+/// MCExpr representing a V3 epilog's tail-relative EpilogOffset field. The
+/// first epilog descriptor is encoded relative to the fragment end, and each
+/// subsequent descriptor relative to the previous epilog's start. The fragment
+/// end may not have a symbol yet when the unwind info is emitted (e.g. via
+/// .seh_handlerdata), so the value is resolved lazily through the FrameInfo
+/// reference.
+class MCUnwindV3EpilogOffsetTargetExpr final : public MCTargetExpr {
+  const WinEH::FrameInfo &FrameInfo;
+  const MCSymbol *EpilogStart;
+  const MCSymbol *PrevEpilogStart;
+  SMLoc Loc;
+
+  MCUnwindV3EpilogOffsetTargetExpr(const WinEH::FrameInfo &FrameInfo,
+                                   const MCSymbol *EpilogStart,
+                                   const MCSymbol *PrevEpilogStart, SMLoc Loc)
+      : FrameInfo(FrameInfo), EpilogStart(EpilogStart),
+        PrevEpilogStart(PrevEpilogStart), Loc(Loc) {}
+
+public:
+  static MCUnwindV3EpilogOffsetTargetExpr *
+  create(const WinEH::FrameInfo &FrameInfo, const MCSymbol *EpilogStart,
+         const MCSymbol *PrevEpilogStart, SMLoc Loc, MCContext &Ctx) {
+    return new (Ctx) MCUnwindV3EpilogOffsetTargetExpr(FrameInfo, EpilogStart,
+                                                      PrevEpilogStart, Loc);
+  }
+
+  void printImpl(raw_ostream &OS, const MCAsmInfo *MAI) const override {
+    OS << ":epilogoffset:";
+    EpilogStart->print(OS, MAI);
+  }
+
+  bool evaluateAsRelocatableImpl(MCValue &Res,
+                                 const MCAssembler *Asm) const override;
+
+  void visitUsedExpr(MCStreamer &Streamer) const override {
+    // Contains no sub-expressions.
+  }
+
+  MCFragment *findAssociatedFragment() const override {
+    return EpilogStart->getFragment();
+  }
+};
 } // namespace
 
 // NOTE: All relocations generated here are 4-byte image-relative.
@@ -578,6 +621,15 @@ static void EmitUnwindInfoV3(MCStreamer &Streamer, WinEH::FrameInfo *Info) {
                           " This function has " +
                           Twine(EpilogInfos.size()));
 
+  // V3 epilog offsets are always encoded tail-relative: the first descriptor
+  // holds a negative byte offset from the fragment end, and each subsequent
+  // descriptor a (negative) delta from the previous epilog's start. The spec
+  // requires every descriptor in a fragment to use the same sign, so the
+  // descriptors must be listed in descending address order ("descending from
+  // tail"). EpilogMap is in ascending address order, so reverse it here before
+  // computing inheritance and emitting descriptors.
+  std::reverse(EpilogInfos.begin(), EpilogInfos.end());
+
   // --- Inheritance decisions ---
   // Per the V3 spec, an epilog descriptor with NumberOfOps == 0 inherits its
   // effective NumberOfOps, FirstOp, IpOffsetOfLastInstruction, and IP offset
@@ -738,24 +790,19 @@ static void EmitUnwindInfoV3(MCStreamer &Streamer, WinEH::FrameInfo *Info) {
     uint8_t EpiNumOps = EI.Inherited ? 0 : EI.NumberOfOps;
     Streamer.emitInt8((EpiNumOps << 3) | EpiFlags);
 
-    // EpilogOffset: signed 16-bit.
-    // For the first epilog: byte offset from fragment start to epilog start.
-    // For subsequent epilogs: delta from the previous epilog's start position.
-    // Emit as a fixup since we may not know the exact distance yet.
+    // EpilogOffset: signed 16-bit, always tail-relative.
+    // The first epilog descriptor (closest to the fragment tail) holds the
+    // negative byte offset from the fragment end to the epilog start; each
+    // subsequent descriptor holds the delta from the previous epilog's start.
+    // Because descriptors are emitted in descending address order, every offset
+    // is non-positive, satisfying the V3 "all epilogs use the same sign" rule.
+    // Measuring from the tail keeps the magnitude small (epilogs sit near the
+    // end of the function), avoiding overflow of the signed 16-bit field for
+    // large functions. The fragment end may not have a symbol yet (e.g. when
+    // emitted via .seh_handlerdata), so the value is resolved lazily.
     {
-      const MCSymbol *Base = PrevEpilogStart ? PrevEpilogStart : Info->Begin;
-      const MCExpr *EpilogOffsetExpr = MCBinaryExpr::createSub(
-          MCSymbolRefExpr::create(Epilog.Start, Context),
-          MCSymbolRefExpr::create(Base, Context), Context);
-      // Validate the epilog offset fits in a signed 16-bit field if we can
-      // evaluate it now.
-      int64_t OffsetValue;
-      if (EpilogOffsetExpr->evaluateAsAbsolute(OffsetValue,
-                                               OS->getAssembler())) {
-        if (OffsetValue < INT16_MIN || OffsetValue > INT16_MAX)
-          reportFatalUsageError(
-              "Epilog offset out of signed 16-bit range for V3 encoding");
-      }
+      const MCExpr *EpilogOffsetExpr = MCUnwindV3EpilogOffsetTargetExpr::create(
+          *Info, Epilog.Start, PrevEpilogStart, Epilog.Loc, Context);
       OS->ensureHeadroom(2);
       OS->addFixup(EpilogOffsetExpr, FK_Data_2);
       OS->appendContents(2, 0);
@@ -1044,6 +1091,38 @@ bool MCUnwindV2EpilogTargetExpr::evaluateAsRelocatableImpl(
   auto HighBits = *Offset >> 8;
   Res = MCValue::get((HighBits << 12) | (Win64EH::UOP_Epilog << 8) |
                      (*Offset & 0xFF));
+  return true;
+}
+
+bool MCUnwindV3EpilogOffsetTargetExpr::evaluateAsRelocatableImpl(
+    MCValue &Res, const MCAssembler *Asm) const {
+  // The first epilog descriptor is encoded relative to the fragment tail (the
+  // first byte past the end of the fragment); subsequent descriptors are
+  // encoded relative to the previous epilog's start. Both bases yield a
+  // non-positive offset, as required by the V3 "same sign" rule.
+  const MCSymbol *Base = PrevEpilogStart ? PrevEpilogStart : FrameInfo.End;
+  if (!Base) {
+    Asm->getContext().reportError(
+        Loc, "Missing fragment end for V3 epilog offset in " +
+                 FrameInfo.Function->getName());
+    return false;
+  }
+
+  auto Offset = GetOptionalAbsDifference(*Asm, EpilogStart, Base);
+  if (!Offset) {
+    Asm->getContext().reportError(
+        Loc, "Failed to evaluate epilog offset for V3 unwind info in " +
+                 FrameInfo.Function->getName());
+    return false;
+  }
+  if (*Offset < INT16_MIN || *Offset > INT16_MAX) {
+    Asm->getContext().reportError(
+        Loc, "Epilog offset out of signed 16-bit range for V3 encoding in " +
+                 FrameInfo.Function->getName());
+    return false;
+  }
+
+  Res = MCValue::get(*Offset);
   return true;
 }
 

--- a/llvm/lib/MC/MCWin64EH.cpp
+++ b/llvm/lib/MC/MCWin64EH.cpp
@@ -69,10 +69,12 @@ public:
 
 /// MCExpr representing a V3 epilog's tail-relative EpilogOffset field. The
 /// first epilog descriptor is encoded relative to the fragment end, and each
-/// subsequent descriptor relative to the previous epilog's start. The fragment
-/// end may not have a symbol yet when the unwind info is emitted (e.g. via
-/// .seh_handlerdata), so the value is resolved lazily through the FrameInfo
-/// reference.
+/// subsequent descriptor relative to the previous epilog's start. Measuring
+/// from the tail keeps the magnitude small (epilogs sit near the end of the
+/// function), avoiding overflow of the signed 16-bit field for large
+/// functions. The fragment end may not have a symbol yet when the unwind info
+/// is emitted (e.g. via .seh_handlerdata), so the value is resolved lazily
+/// through the FrameInfo reference.
 class MCUnwindV3EpilogOffsetTargetExpr final : public MCTargetExpr {
   const WinEH::FrameInfo &FrameInfo;
   const MCSymbol *EpilogStart;
@@ -790,16 +792,12 @@ static void EmitUnwindInfoV3(MCStreamer &Streamer, WinEH::FrameInfo *Info) {
     uint8_t EpiNumOps = EI.Inherited ? 0 : EI.NumberOfOps;
     Streamer.emitInt8((EpiNumOps << 3) | EpiFlags);
 
-    // EpilogOffset: signed 16-bit, always tail-relative.
-    // The first epilog descriptor (closest to the fragment tail) holds the
-    // negative byte offset from the fragment end to the epilog start; each
-    // subsequent descriptor holds the delta from the previous epilog's start.
-    // Because descriptors are emitted in descending address order, every offset
-    // is non-positive, satisfying the V3 "all epilogs use the same sign" rule.
-    // Measuring from the tail keeps the magnitude small (epilogs sit near the
-    // end of the function), avoiding overflow of the signed 16-bit field for
-    // large functions. The fragment end may not have a symbol yet (e.g. when
-    // emitted via .seh_handlerdata), so the value is resolved lazily.
+    // EpilogOffset: signed 16-bit, always tail-relative (see
+    // MCUnwindV3EpilogOffsetTargetExpr). The first descriptor holds the
+    // negative byte offset from the fragment end; each subsequent descriptor
+    // holds the delta from the previous epilog's start. Emitted in descending
+    // address order, every offset is non-positive, satisfying the V3
+    // "all epilogs use the same sign" rule.
     {
       const MCExpr *EpilogOffsetExpr = MCUnwindV3EpilogOffsetTargetExpr::create(
           *Info, Epilog.Start, PrevEpilogStart, Epilog.Loc, Context);

--- a/llvm/lib/MC/MCWin64EH.cpp
+++ b/llvm/lib/MC/MCWin64EH.cpp
@@ -1115,7 +1115,8 @@ bool MCUnwindV3EpilogOffsetTargetExpr::evaluateAsRelocatableImpl(
   }
   if (*Offset < INT16_MIN || *Offset > INT16_MAX) {
     Asm->getContext().reportError(
-        Loc, "Epilog offset out of signed 16-bit range for V3 encoding in " +
+        Loc, "Epilog offset " + Twine(*Offset) +
+                 " out of signed 16-bit range for V3 encoding in " +
                  FrameInfo.Function->getName());
     return false;
   }

--- a/llvm/lib/Target/X86/X86WinEHUnwindV3.cpp
+++ b/llvm/lib/Target/X86/X86WinEHUnwindV3.cpp
@@ -32,6 +32,7 @@
 #include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Support/CommandLine.h"
 
 using namespace llvm;
 
@@ -46,6 +47,20 @@ STATISTIC(SubFragmentSplits,
 static constexpr unsigned MaxV3PrologOps = 31;
 static constexpr unsigned MaxV3Epilogs = 7;
 static constexpr unsigned MaxV3EpilogOps = 31;
+
+/// Approximate-instruction-count distance between an epilog and its fragment
+/// tail beyond which the funclet is split into a new chained sub-fragment.
+/// The V3 EpilogOffset field is a signed 16-bit byte offset measured from the
+/// fragment tail, so each fragment must span less than 32 KiB of code. The
+/// exact byte offsets aren't known until MC layout, so (like the V2 pass) the
+/// approximate instruction count is used as a proxy, with margin for the
+/// average emitted instruction size.
+static cl::opt<unsigned> EpilogDistanceThreshold(
+    "x86-wineh-unwindv3-epilog-distance-threshold", cl::Hidden,
+    cl::desc("Maximum approximate instruction distance between an epilog and "
+             "its fragment tail before splitting into a new chained unwind "
+             "info for Unwind v3."),
+    cl::init(4000));
 
 /// After reporting a recoverable error for `MF`, erase all SEH pseudo-
 /// instructions and clear the WinCFI flag so the AsmPrinter doesn't try to
@@ -81,13 +96,23 @@ static void suppressWinCFI(MachineFunction &MF) {
 
 namespace {
 
+/// A V3 epilog and the approximate instruction position where it begins, used
+/// as a candidate sub-fragment split point.
+struct EpilogSplitPoint {
+  MachineInstr *BeginEpilog;
+  unsigned ApproxInstrPos;
+};
+
 /// Per-funclet analysis results.
 struct FuncletInfo {
   unsigned PrologOpCount = 0;
-  unsigned EpilogCount = 0;
   unsigned MaxEpilogOpCount = 0;
-  /// SEH_BeginEpilogue instructions, used as insertion points for splitting.
-  SmallVector<MachineInstr *, 8> EpilogBegins;
+  /// Approximate instruction position at the end of the funclet, used as the
+  /// initial fragment tail reference for size-based splitting.
+  unsigned EndInstrPos = 0;
+  /// SEH_BeginEpilogue instructions (with approximate positions), used as
+  /// candidate insertion points for sub-fragment splitting.
+  SmallVector<EpilogSplitPoint, 8> Epilogs;
 };
 
 class X86WinEHUnwindV3 : public MachineFunctionPass {
@@ -105,9 +130,12 @@ public:
 private:
   /// Analyze one funclet (or the main function body) starting at Iter.
   /// Advances Iter past the analyzed region, stopping at the next funclet
-  /// entry or the end of the function.
+  /// entry or the end of the function. ApproxInstrPos is a running count of
+  /// emitted instructions across the whole function, used to estimate the
+  /// byte distance between epilogs and their fragment tail.
   static FuncletInfo analyzeFunclet(MachineFunction &MF,
-                                    MachineFunction::iterator &Iter);
+                                    MachineFunction::iterator &Iter,
+                                    unsigned &ApproxInstrPos);
 };
 
 } // end anonymous namespace
@@ -123,7 +151,8 @@ FunctionPass *llvm::createX86WinEHUnwindV3Pass() {
 }
 
 FuncletInfo X86WinEHUnwindV3::analyzeFunclet(MachineFunction &MF,
-                                             MachineFunction::iterator &Iter) {
+                                             MachineFunction::iterator &Iter,
+                                             unsigned &ApproxInstrPos) {
   FuncletInfo Info;
   bool InEpilog = false;
   bool SeenProlog = false;
@@ -138,6 +167,12 @@ FuncletInfo X86WinEHUnwindV3::analyzeFunclet(MachineFunction &MF,
       break;
 
     for (MachineInstr &MI : MBB) {
+      // Approximate the number of emitted instructions, mirroring the V2 pass.
+      // This estimates how far each epilog sits from its fragment tail; the
+      // exact byte offsets aren't available until MC layout.
+      if (!MI.isPseudo() && !MI.isMetaInstruction())
+        ApproxInstrPos++;
+
       switch (MI.getOpcode()) {
       case X86::SEH_PushReg:
       case X86::SEH_Push2Regs:
@@ -157,8 +192,7 @@ FuncletInfo X86WinEHUnwindV3::analyzeFunclet(MachineFunction &MF,
       case X86::SEH_BeginEpilogue:
         InEpilog = true;
         CurrentEpilogOpCount = 0;
-        Info.EpilogCount++;
-        Info.EpilogBegins.push_back(&MI);
+        Info.Epilogs.push_back({&MI, ApproxInstrPos});
         break;
       case X86::SEH_EndEpilogue:
         InEpilog = false;
@@ -171,6 +205,7 @@ FuncletInfo X86WinEHUnwindV3::analyzeFunclet(MachineFunction &MF,
     }
   }
 
+  Info.EndInstrPos = ApproxInstrPos;
   return Info;
 }
 
@@ -201,12 +236,13 @@ bool X86WinEHUnwindV3::runOnMachineFunction(MachineFunction &MF) {
   }
 
   bool Changed = false;
+  unsigned ApproxInstrPos = 0;
   MachineFunction::iterator Iter = MF.begin();
 
   // Process each funclet (and the main function body) independently.
   // Each funclet gets its own UNWIND_INFO, so V3 limits apply per funclet.
   while (Iter != MF.end()) {
-    FuncletInfo Info = analyzeFunclet(MF, Iter);
+    FuncletInfo Info = analyzeFunclet(MF, Iter, ApproxInstrPos);
 
     if (Info.PrologOpCount > MaxV3PrologOps) {
       Ctx.diagnose(DiagnosticInfoResourceLimit(
@@ -232,23 +268,54 @@ bool X86WinEHUnwindV3::runOnMachineFunction(MachineFunction &MF) {
       return true;
     }
 
-    if (Info.EpilogCount > MaxV3Epilogs) {
-      const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
-      unsigned Count = 0;
-      for (MachineInstr *BeginEpilog : Info.EpilogBegins) {
-        Count++;
-        if (Count > MaxV3Epilogs) {
-          MachineBasicBlock *MBB = BeginEpilog->getParent();
-          BuildMI(*MBB, BeginEpilog, BeginEpilog->getDebugLoc(),
-                  TII->get(X86::SEH_SplitChained));
-          BuildMI(*MBB, BeginEpilog, BeginEpilog->getDebugLoc(),
-                  TII->get(X86::SEH_EndPrologue));
-          SubFragmentSplits++;
-          Count = 1;
-        }
-      }
+    // Split the funclet into chained sub-fragments so that each fragment's
+    // UNWIND_INFO stays within the V3 capacity limits:
+    //   * at most 7 epilogs per fragment, and
+    //   * every epilog close enough to its fragment tail that the tail-relative
+    //     EpilogOffset fits in the signed 16-bit field.
+    // The exact byte offsets aren't known until MC layout, so (like the V2
+    // pass) the distance bound uses an approximate instruction count as a
+    // proxy. A SEH_SplitChainedAtEndOfBlock is inserted at the start of an
+    // epilog's block; the AsmPrinter emits the actual .seh_splitchained at the
+    // *end* of that block, so the epilog becomes the last epilog of the
+    // earlier fragment, immediately followed by the new chained fragment. This
+    // keeps every epilog close to its tail even when a single epilog is
+    // followed by a large amount of code (a long "tail" after the last
+    // epilog is pushed into its own epilog-free chained fragment).
+    const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
+    auto SplitAfter = [&](const EpilogSplitPoint &Epilog) {
+      MachineBasicBlock *MBB = Epilog.BeginEpilog->getParent();
+      BuildMI(*MBB, MBB->begin(), Epilog.BeginEpilog->getDebugLoc(),
+              TII->get(X86::SEH_SplitChainedAtEndOfBlock));
+      SubFragmentSplits++;
       Changed = true;
+    };
+
+    unsigned FragmentFirstPos = 0;
+    unsigned EpilogsInFragment = 0;
+    const EpilogSplitPoint *LastEpilog = nullptr;
+    for (const EpilogSplitPoint &Epilog : Info.Epilogs) {
+      // If adding this epilog would exceed a fragment limit, end the current
+      // fragment after the previous epilog and start a new one here.
+      if (EpilogsInFragment > 0 && (EpilogsInFragment >= MaxV3Epilogs ||
+                                    Epilog.ApproxInstrPos - FragmentFirstPos >=
+                                        EpilogDistanceThreshold)) {
+        SplitAfter(*LastEpilog);
+        EpilogsInFragment = 0;
+      }
+      if (EpilogsInFragment == 0)
+        FragmentFirstPos = Epilog.ApproxInstrPos;
+      EpilogsInFragment++;
+      LastEpilog = &Epilog;
     }
+
+    // If the last fragment's first epilog is too far from the funclet end,
+    // split after the last epilog so the trailing code becomes its own
+    // epilog-free chained fragment, keeping the last fragment's epilogs close
+    // to their tail.
+    if (LastEpilog &&
+        Info.EndInstrPos - FragmentFirstPos >= EpilogDistanceThreshold)
+      SplitAfter(*LastEpilog);
   }
 
   if (Changed)

--- a/llvm/lib/Target/X86/X86WinEHUnwindV3.cpp
+++ b/llvm/lib/Target/X86/X86WinEHUnwindV3.cpp
@@ -48,18 +48,20 @@ static constexpr unsigned MaxV3PrologOps = 31;
 static constexpr unsigned MaxV3Epilogs = 7;
 static constexpr unsigned MaxV3EpilogOps = 31;
 
-/// Approximate-instruction-count distance between an epilog and its fragment
-/// tail beyond which the funclet is split into a new chained sub-fragment.
-/// The V3 EpilogOffset field is a signed 16-bit byte offset measured from the
-/// fragment tail, so each fragment must span less than 32 KiB of code. The
-/// exact byte offsets aren't known until MC layout, so the approximate
-/// instruction count is used as a proxy, with margin for the average emitted
-/// instruction size.
+/// Maximum approximate instruction distance allowed between two adjacent
+/// epilogs, and between the last epilog and the funclet end, before the
+/// funclet is split into a new chained sub-fragment. V3 encodes each epilog's
+/// position as a signed 16-bit EpilogOffset: a delta from the previous epilog,
+/// with the tail-closest epilog encoded relative to the fragment end. The exact
+/// byte offsets aren't known until MC layout, so the approximate instruction
+/// count is used as a proxy, with margin for the average emitted instruction
+/// size.
 static cl::opt<unsigned> EpilogDistanceThreshold(
     "x86-wineh-unwindv3-epilog-distance-threshold", cl::Hidden,
-    cl::desc("Maximum approximate instruction distance between an epilog and "
-             "its fragment tail before splitting into a new chained unwind "
-             "info for Unwind v3."),
+    cl::desc(
+        "Maximum approximate instruction distance between adjacent epilogs "
+        "(or between the last epilog and the funclet end) before "
+        "splitting into a new chained unwind info for Unwind v3."),
     cl::init(3000));
 
 /// After reporting a recoverable error for `MF`, erase all SEH pseudo-
@@ -278,8 +280,9 @@ bool X86WinEHUnwindV3::runOnMachineFunction(MachineFunction &MF) {
 
     // Split the funclet into chained sub-fragments so that each fragment's
     // UNWIND_INFO stays within the V3 capacity limits: at most 7 epilogs per
-    // fragment, and every epilog close enough to its fragment tail that the
-    // tail-relative EpilogOffset fits in the signed 16-bit field.
+    // fragment, and each adjacent-epilog gap (plus the gap from the last epilog
+    // to the fragment tail) small enough that the corresponding signed-16-bit
+    // EpilogOffset delta fits.
     //
     // A SEH_SplitChainedAtEndOfBlock inserted at the start of an epilog's
     // block makes the AsmPrinter emit the actual .seh_splitchained at the
@@ -296,18 +299,18 @@ bool X86WinEHUnwindV3::runOnMachineFunction(MachineFunction &MF) {
       Changed = true;
     };
 
-    unsigned FragmentFirstPos = 0;
     unsigned EpilogsInFragment = 0;
     const EpilogSplitPoint *LastEpilog = nullptr;
     unsigned LastEpilogIdx = 0;
     for (unsigned Idx = 0; Idx < Info.Epilogs.size(); ++Idx) {
       const EpilogSplitPoint &Epilog = Info.Epilogs[Idx];
-      // If adding this epilog would exceed a fragment limit, end the current
-      // fragment after the previous epilog and start a new one here.
+      // If adding this epilog would exceed a fragment limit or is too far, end
+      // the current fragment after the previous epilog and start a new one.
       if (EpilogsInFragment > 0) {
         bool ExceedsEpilogCount = EpilogsInFragment >= MaxV3Epilogs;
         bool ExceedsDistance =
-            Epilog.ApproxInstrPos - FragmentFirstPos >= EpilogDistanceThreshold;
+            Epilog.ApproxInstrPos - LastEpilog->ApproxInstrPos >=
+            EpilogDistanceThreshold;
         if (ExceedsEpilogCount || ExceedsDistance) {
           LLVM_DEBUG({
             dbgs() << "  splitting after epilog " << LastEpilogIdx
@@ -315,31 +318,28 @@ bool X86WinEHUnwindV3::runOnMachineFunction(MachineFunction &MF) {
             if (ExceedsEpilogCount)
               dbgs() << "7-epilog-per-fragment limit\n";
             else
-              dbgs() << "fragment distance threshold (epilog at "
-                     << Epilog.ApproxInstrPos << " vs fragment start "
-                     << FragmentFirstPos << ")\n";
+              dbgs() << "epilog distance threshold (gap from previous epilog "
+                        "at "
+                     << LastEpilog->ApproxInstrPos << " to epilog at "
+                     << Epilog.ApproxInstrPos << ")\n";
           });
           SplitAfter(*LastEpilog);
           EpilogsInFragment = 0;
         }
       }
-      if (EpilogsInFragment == 0)
-        FragmentFirstPos = Epilog.ApproxInstrPos;
       EpilogsInFragment++;
       LastEpilog = &Epilog;
       LastEpilogIdx = Idx;
     }
 
-    // If the last fragment's first epilog is too far from the funclet end,
-    // split after the last epilog so the trailing code becomes its own
-    // epilog-free chained fragment, keeping the last fragment's epilogs close
-    // to their tail.
-    if (LastEpilog &&
-        Info.EndInstrPos - FragmentFirstPos >= EpilogDistanceThreshold) {
+    // If the last epilog is too far from the funclet end, split after it so the
+    // trailing code becomes its own epilog-free chained fragment.
+    if (LastEpilog && Info.EndInstrPos - LastEpilog->ApproxInstrPos >=
+                          EpilogDistanceThreshold) {
       LLVM_DEBUG(dbgs() << "  splitting after last epilog " << LastEpilogIdx
-                        << " to isolate the trailing tail (funclet end "
-                        << Info.EndInstrPos << " vs fragment start "
-                        << FragmentFirstPos << ")\n");
+                        << " to isolate the trailing tail (gap from epilog at "
+                        << LastEpilog->ApproxInstrPos << " to funclet end "
+                        << Info.EndInstrPos << ")\n");
       SplitAfter(*LastEpilog);
     }
   }

--- a/llvm/lib/Target/X86/X86WinEHUnwindV3.cpp
+++ b/llvm/lib/Target/X86/X86WinEHUnwindV3.cpp
@@ -7,9 +7,8 @@
 //===----------------------------------------------------------------------===//
 ///
 /// Implements the capacity-checking and sub-fragment splitting pass for
-/// Unwind v3 information. Unlike the V2 pass, V3 does not need to validate
-/// epilog structure (V3 can encode any prolog/epilog pattern). This pass
-/// only needs to:
+/// Unwind v3 information. V3 can encode any prolog/epilog pattern, so this
+/// pass does not validate epilog structure; it only needs to:
 ///   1. Count prolog/epilog operations and epilogs.
 ///   2. Check V3 capacity limits (<=31 prolog/epilog ops, <=7 epilogs).
 ///   3. Insert sub-fragment split points if limits are exceeded.
@@ -52,9 +51,9 @@ static constexpr unsigned MaxV3EpilogOps = 31;
 /// tail beyond which the funclet is split into a new chained sub-fragment.
 /// The V3 EpilogOffset field is a signed 16-bit byte offset measured from the
 /// fragment tail, so each fragment must span less than 32 KiB of code. The
-/// exact byte offsets aren't known until MC layout, so (like the V2 pass) the
-/// approximate instruction count is used as a proxy, with margin for the
-/// average emitted instruction size.
+/// exact byte offsets aren't known until MC layout, so the approximate
+/// instruction count is used as a proxy, with margin for the average emitted
+/// instruction size.
 static cl::opt<unsigned> EpilogDistanceThreshold(
     "x86-wineh-unwindv3-epilog-distance-threshold", cl::Hidden,
     cl::desc("Maximum approximate instruction distance between an epilog and "
@@ -167,9 +166,9 @@ FuncletInfo X86WinEHUnwindV3::analyzeFunclet(MachineFunction &MF,
       break;
 
     for (MachineInstr &MI : MBB) {
-      // Approximate the number of emitted instructions, mirroring the V2 pass.
-      // This estimates how far each epilog sits from its fragment tail; the
-      // exact byte offsets aren't available until MC layout.
+      // Approximate the number of emitted instructions. This estimates how
+      // far each epilog sits from its fragment tail; the exact byte offsets
+      // aren't available until MC layout.
       if (!MI.isPseudo() && !MI.isMetaInstruction())
         ApproxInstrPos++;
 
@@ -269,19 +268,16 @@ bool X86WinEHUnwindV3::runOnMachineFunction(MachineFunction &MF) {
     }
 
     // Split the funclet into chained sub-fragments so that each fragment's
-    // UNWIND_INFO stays within the V3 capacity limits:
-    //   * at most 7 epilogs per fragment, and
-    //   * every epilog close enough to its fragment tail that the tail-relative
-    //     EpilogOffset fits in the signed 16-bit field.
-    // The exact byte offsets aren't known until MC layout, so (like the V2
-    // pass) the distance bound uses an approximate instruction count as a
-    // proxy. A SEH_SplitChainedAtEndOfBlock is inserted at the start of an
-    // epilog's block; the AsmPrinter emits the actual .seh_splitchained at the
+    // UNWIND_INFO stays within the V3 capacity limits: at most 7 epilogs per
+    // fragment, and every epilog close enough to its fragment tail that the
+    // tail-relative EpilogOffset fits in the signed 16-bit field.
+    //
+    // A SEH_SplitChainedAtEndOfBlock inserted at the start of an epilog's
+    // block makes the AsmPrinter emit the actual .seh_splitchained at the
     // *end* of that block, so the epilog becomes the last epilog of the
-    // earlier fragment, immediately followed by the new chained fragment. This
-    // keeps every epilog close to its tail even when a single epilog is
-    // followed by a large amount of code (a long "tail" after the last
-    // epilog is pushed into its own epilog-free chained fragment).
+    // earlier fragment, immediately followed by the new chained fragment. A
+    // long tail after the last epilog is pushed into its own epilog-free
+    // chained fragment.
     const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
     auto SplitAfter = [&](const EpilogSplitPoint &Epilog) {
       MachineBasicBlock *MBB = Epilog.BeginEpilog->getParent();

--- a/llvm/lib/Target/X86/X86WinEHUnwindV3.cpp
+++ b/llvm/lib/Target/X86/X86WinEHUnwindV3.cpp
@@ -32,6 +32,7 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
 
 using namespace llvm;
 
@@ -191,6 +192,9 @@ FuncletInfo X86WinEHUnwindV3::analyzeFunclet(MachineFunction &MF,
       case X86::SEH_BeginEpilogue:
         InEpilog = true;
         CurrentEpilogOpCount = 0;
+        LLVM_DEBUG(dbgs() << "  epilog " << Info.Epilogs.size()
+                          << " begins at approx instruction position "
+                          << ApproxInstrPos << "\n");
         Info.Epilogs.push_back({&MI, ApproxInstrPos});
         break;
       case X86::SEH_EndEpilogue:
@@ -205,6 +209,9 @@ FuncletInfo X86WinEHUnwindV3::analyzeFunclet(MachineFunction &MF,
   }
 
   Info.EndInstrPos = ApproxInstrPos;
+  LLVM_DEBUG(dbgs() << "  funclet has " << Info.Epilogs.size()
+                    << " epilog(s); ends at approx instruction position "
+                    << ApproxInstrPos << "\n");
   return Info;
 }
 
@@ -237,6 +244,8 @@ bool X86WinEHUnwindV3::runOnMachineFunction(MachineFunction &MF) {
   bool Changed = false;
   unsigned ApproxInstrPos = 0;
   MachineFunction::iterator Iter = MF.begin();
+
+  LLVM_DEBUG(dbgs() << "X86WinEHUnwindV3: processing " << MF.getName() << "\n");
 
   // Process each funclet (and the main function body) independently.
   // Each funclet gets its own UNWIND_INFO, so V3 limits apply per funclet.
@@ -290,19 +299,35 @@ bool X86WinEHUnwindV3::runOnMachineFunction(MachineFunction &MF) {
     unsigned FragmentFirstPos = 0;
     unsigned EpilogsInFragment = 0;
     const EpilogSplitPoint *LastEpilog = nullptr;
-    for (const EpilogSplitPoint &Epilog : Info.Epilogs) {
+    unsigned LastEpilogIdx = 0;
+    for (unsigned Idx = 0; Idx < Info.Epilogs.size(); ++Idx) {
+      const EpilogSplitPoint &Epilog = Info.Epilogs[Idx];
       // If adding this epilog would exceed a fragment limit, end the current
       // fragment after the previous epilog and start a new one here.
-      if (EpilogsInFragment > 0 && (EpilogsInFragment >= MaxV3Epilogs ||
-                                    Epilog.ApproxInstrPos - FragmentFirstPos >=
-                                        EpilogDistanceThreshold)) {
-        SplitAfter(*LastEpilog);
-        EpilogsInFragment = 0;
+      if (EpilogsInFragment > 0) {
+        bool ExceedsEpilogCount = EpilogsInFragment >= MaxV3Epilogs;
+        bool ExceedsDistance =
+            Epilog.ApproxInstrPos - FragmentFirstPos >= EpilogDistanceThreshold;
+        if (ExceedsEpilogCount || ExceedsDistance) {
+          LLVM_DEBUG({
+            dbgs() << "  splitting after epilog " << LastEpilogIdx
+                   << " because adding epilog " << Idx << " would exceed the ";
+            if (ExceedsEpilogCount)
+              dbgs() << "7-epilog-per-fragment limit\n";
+            else
+              dbgs() << "fragment distance threshold (epilog at "
+                     << Epilog.ApproxInstrPos << " vs fragment start "
+                     << FragmentFirstPos << ")\n";
+          });
+          SplitAfter(*LastEpilog);
+          EpilogsInFragment = 0;
+        }
       }
       if (EpilogsInFragment == 0)
         FragmentFirstPos = Epilog.ApproxInstrPos;
       EpilogsInFragment++;
       LastEpilog = &Epilog;
+      LastEpilogIdx = Idx;
     }
 
     // If the last fragment's first epilog is too far from the funclet end,
@@ -310,8 +335,13 @@ bool X86WinEHUnwindV3::runOnMachineFunction(MachineFunction &MF) {
     // epilog-free chained fragment, keeping the last fragment's epilogs close
     // to their tail.
     if (LastEpilog &&
-        Info.EndInstrPos - FragmentFirstPos >= EpilogDistanceThreshold)
+        Info.EndInstrPos - FragmentFirstPos >= EpilogDistanceThreshold) {
+      LLVM_DEBUG(dbgs() << "  splitting after last epilog " << LastEpilogIdx
+                        << " to isolate the trailing tail (funclet end "
+                        << Info.EndInstrPos << " vs fragment start "
+                        << FragmentFirstPos << ")\n");
       SplitAfter(*LastEpilog);
+    }
   }
 
   if (Changed)

--- a/llvm/lib/Target/X86/X86WinEHUnwindV3.cpp
+++ b/llvm/lib/Target/X86/X86WinEHUnwindV3.cpp
@@ -60,7 +60,7 @@ static cl::opt<unsigned> EpilogDistanceThreshold(
     cl::desc("Maximum approximate instruction distance between an epilog and "
              "its fragment tail before splitting into a new chained unwind "
              "info for Unwind v3."),
-    cl::init(4000));
+    cl::init(3000));
 
 /// After reporting a recoverable error for `MF`, erase all SEH pseudo-
 /// instructions and clear the WinCFI flag so the AsmPrinter doesn't try to

--- a/llvm/test/CodeGen/X86/win64-eh-unwindv3-split-large.ll
+++ b/llvm/test/CodeGen/X86/win64-eh-unwindv3-split-large.ll
@@ -1,0 +1,62 @@
+; RUN: llc -mtriple=x86_64-unknown-windows-msvc \
+; RUN:   -x86-wineh-unwindv3-epilog-distance-threshold=1 -o - %s | FileCheck %s
+; RUN: llc -mtriple=x86_64-unknown-windows-msvc \
+; RUN:   -x86-wineh-unwindv3-epilog-distance-threshold=1 -filetype=obj %s -o - \
+; RUN:   | llvm-readobj --unwind - | FileCheck %s --check-prefix=OBJ
+
+; Test V3 *size-based* sub-fragment splitting (the "Unwind v2 style" heuristic).
+; With a very small distance threshold, every epilog is forced into its own
+; chained sub-fragment, even though the function has far fewer than 8 epilogs.
+; This exercises the path that keeps each tail-relative EpilogOffset within the
+; signed 16-bit field for large functions.
+
+declare i32 @c(i32) local_unnamed_addr
+
+; CHECK-LABEL: three_epilogs:
+; CHECK:         .seh_endprologue
+; First epilog stays in the main fragment.
+; CHECK:         .seh_startepilogue
+; CHECK:         .seh_endepilogue
+; A size-based split is inserted after each epilog.
+; CHECK:         .seh_splitchained
+; CHECK-NEXT:    .seh_endprologue
+; CHECK:         .seh_startepilogue
+; CHECK:         .seh_endepilogue
+; CHECK:         .seh_splitchained
+; CHECK-NEXT:    .seh_endprologue
+; CHECK:         .seh_startepilogue
+; CHECK:         .seh_endepilogue
+; CHECK:         .seh_endproc
+
+; Each fragment carries a single epilog with a small, in-range, tail-relative
+; (negative) EpilogOffset, and every chained fragment is marked CHAININFO.
+; OBJ:        Version: 3
+; OBJ:        NumberOfEpilogs: 1
+; OBJ:          EpilogOffset: -0x5
+; OBJ:      RuntimeFunction {
+; OBJ:        Version: 3
+; OBJ:          ChainInfo (0x4)
+; OBJ:        NumberOfEpilogs: 1
+; OBJ:          EpilogOffset: -0x5
+
+define dso_local i32 @three_epilogs(i32 %x) #0 {
+entry:
+  switch i32 %x, label %sw.default [
+    i32 0, label %sw.0
+    i32 1, label %sw.1
+  ]
+sw.0:
+  %r0 = call i32 @c(i32 0)
+  ret i32 %r0
+sw.1:
+  %r1 = call i32 @c(i32 1)
+  ret i32 %r1
+sw.default:
+  %rd = call i32 @c(i32 7)
+  ret i32 %rd
+}
+
+attributes #0 = { optnone noinline }
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"winx64-eh-unwind", i32 3}

--- a/llvm/test/CodeGen/X86/win64-eh-unwindv3-split-large.ll
+++ b/llvm/test/CodeGen/X86/win64-eh-unwindv3-split-large.ll
@@ -10,7 +10,7 @@
 ; This exercises the path that keeps each tail-relative EpilogOffset within the
 ; signed 16-bit field for large functions.
 
-declare i32 @c(i32) local_unnamed_addr
+declare i32 @c(i32)
 
 ; CHECK-LABEL: three_epilogs:
 ; CHECK:         .seh_endprologue
@@ -28,18 +28,69 @@ declare i32 @c(i32) local_unnamed_addr
 ; CHECK:         .seh_endepilogue
 ; CHECK:         .seh_endproc
 
-; Each fragment carries a single epilog with a small, in-range, tail-relative
-; (negative) EpilogOffset, and every chained fragment is marked CHAININFO.
-; OBJ:        Version: 3
-; OBJ:        NumberOfEpilogs: 1
-; OBJ:          EpilogOffset: -0x5
-; OBJ:      RuntimeFunction {
-; OBJ:        Version: 3
-; OBJ:          ChainInfo (0x4)
-; OBJ:        NumberOfEpilogs: 1
-; OBJ:          EpilogOffset: -0x5
+; Each epilog ends up in its own fragment with a small, in-range, tail-relative
+; (negative) EpilogOffset. The main fragment holds the prolog; each subsequent
+; fragment is an epilog-only chained fragment, and the trailing code after the
+; last epilog becomes a final epilog-free chained fragment.
+; OBJ:      UnwindInformation [
+; Main fragment: holds the prolog and the first epilog.
+; OBJ:        RuntimeFunction {
+; OBJ:          UnwindInfo {
+; OBJ-NEXT:       Version: 3
+; OBJ-NEXT:       Flags [ (0x0)
+; OBJ-NEXT:       ]
+; OBJ:            NumberOfOps: 1
+; OBJ-NEXT:       NumberOfEpilogs: 1
+; OBJ-NEXT:       Prolog [1 ops]:
+; OBJ-NEXT:         [0] IP +0x0000: ALLOC_SMALL Size=0x28
+; OBJ-NEXT:       Epilog [0] {
+; OBJ:              EpilogOffset: -0x5
+; OBJ-NEXT:         NumberOfOps: 1
+; OBJ-NEXT:         FirstOp: 0x0
+; OBJ-NEXT:         IpOffsetOfLastInstruction: 0x4
+; OBJ-NEXT:         [0] IP +0x0000: ALLOC_SMALL Size=0x28
+; OBJ-NEXT:       }
+; Second epilog: its own chained fragment (inherits the prolog from the parent).
+; OBJ:        RuntimeFunction {
+; OBJ:          UnwindInfo {
+; OBJ-NEXT:       Version: 3
+; OBJ-NEXT:       Flags [ (0x4)
+; OBJ-NEXT:         ChainInfo (0x4)
+; OBJ-NEXT:       ]
+; OBJ:            NumberOfOps: 0
+; OBJ-NEXT:       NumberOfEpilogs: 1
+; OBJ-NEXT:       Prolog [0 ops]:
+; OBJ-NEXT:       Epilog [0] {
+; OBJ:              EpilogOffset: -0x5
+; OBJ-NEXT:         NumberOfOps: 1
+; OBJ-NEXT:         FirstOp: 0x0
+; OBJ-NEXT:         IpOffsetOfLastInstruction: 0x4
+; OBJ-NEXT:         [0] IP +0x0000: ALLOC_SMALL Size=0x28
+; OBJ-NEXT:       }
+; OBJ:            Chained {
+; Third epilog: another chained fragment.
+; OBJ:        RuntimeFunction {
+; OBJ:          UnwindInfo {
+; OBJ-NEXT:       Version: 3
+; OBJ-NEXT:       Flags [ (0x4)
+; OBJ-NEXT:         ChainInfo (0x4)
+; OBJ-NEXT:       ]
+; OBJ:            NumberOfEpilogs: 1
+; OBJ:              EpilogOffset: -0x5
+; OBJ:            Chained {
+; Trailing code after the last epilog: an epilog-free chained fragment.
+; OBJ:        RuntimeFunction {
+; OBJ:          UnwindInfo {
+; OBJ-NEXT:       Version: 3
+; OBJ-NEXT:       Flags [ (0x4)
+; OBJ-NEXT:         ChainInfo (0x4)
+; OBJ-NEXT:       ]
+; OBJ:            NumberOfOps: 0
+; OBJ-NEXT:       NumberOfEpilogs: 0
+; OBJ-NEXT:       Prolog [0 ops]:
+; OBJ-NEXT:       Chained {
 
-define dso_local i32 @three_epilogs(i32 %x) #0 {
+define i32 @three_epilogs(i32 %x) #0 {
 entry:
   switch i32 %x, label %sw.default [
     i32 0, label %sw.0

--- a/llvm/test/MC/COFF/seh-unwindv3-inheritance.s
+++ b/llvm/test/MC/COFF/seh-unwindv3-inheritance.s
@@ -38,18 +38,35 @@ same_ops_inherit:
     retq
     .seh_endproc
 // CHECK-LABEL:  StartAddress: same_ops_inherit
-// CHECK:        NumberOfOps: 2
-// CHECK:        NumberOfEpilogs: 2
-// CHECK:        Epilog [0] {
-// CHECK:          NumberOfOps: 2
-// CHECK:          FirstOp: 0x0
-// CHECK:          ALLOC_SMALL Size=0x20
-// CHECK:          PUSH Reg=RBX
-// CHECK:        }
-// Epilog 1 inherits (same FirstOp, same NumberOfOps, same IP offsets)
-// CHECK:        Epilog [1] {
-// CHECK:          NumberOfOps: 0
-// CHECK:          (inherits
+// CHECK:        UnwindInfo {
+// CHECK-NEXT:     Version: 3
+// CHECK-NEXT:     Flags [ (0x0)
+// CHECK-NEXT:     ]
+// CHECK-NEXT:     SizeOfProlog: 0x5
+// CHECK-NEXT:     PayloadWords: 8
+// CHECK-NEXT:     NumberOfOps: 2
+// CHECK-NEXT:     NumberOfEpilogs: 2
+// CHECK-NEXT:     Prolog [2 ops]:
+// CHECK-NEXT:       [0] IP +0x0001: ALLOC_SMALL Size=0x20
+// CHECK-NEXT:       [1] IP +0x0000: PUSH Reg=RBX
+// CHECK-NEXT:     Epilog [0] {
+// CHECK-NEXT:       Flags [ (0x0)
+// CHECK-NEXT:       ]
+// CHECK-NEXT:       EpilogOffset: -0x6
+// CHECK-NEXT:       NumberOfOps: 2
+// CHECK-NEXT:       FirstOp: 0x0
+// CHECK-NEXT:       IpOffsetOfLastInstruction: 0x5
+// CHECK-NEXT:       [0] IP +0x0000: ALLOC_SMALL Size=0x20
+// CHECK-NEXT:       [1] IP +0x0004: PUSH Reg=RBX
+// CHECK-NEXT:     }
+// Epilog 1 inherits (same FirstOp, same NumberOfOps, same IP offsets).
+// CHECK-NEXT:     Epilog [1] {
+// CHECK-NEXT:       Flags [ (0x0)
+// CHECK-NEXT:       ]
+// CHECK-NEXT:       EpilogOffset: -0xC
+// CHECK-NEXT:       NumberOfOps: 0
+// CHECK-NEXT:       (inherits from base epilog: FirstOp=0x0, IpOffsetOfLastInstruction=0x5, 2 ops)
+// CHECK-NEXT:     }
 
 // --- Test 2: two epilogs, different NumberOfOps -> no inheritance ---
 // Epilog 0: mirror (2 ops), Epilog 1: partial (1 op)
@@ -81,20 +98,39 @@ different_numops:
     jmp     b
     .seh_endproc
 // CHECK-LABEL:  StartAddress: different_numops
-// CHECK:        NumberOfOps: 2
-// CHECK:        NumberOfEpilogs: 2
+// CHECK:        UnwindInfo {
+// CHECK-NEXT:     Version: 3
+// CHECK-NEXT:     Flags [ (0x0)
+// CHECK-NEXT:     ]
+// CHECK-NEXT:     SizeOfProlog: 0x5
+// CHECK-NEXT:     PayloadWords: 10
+// CHECK-NEXT:     NumberOfOps: 2
+// CHECK-NEXT:     NumberOfEpilogs: 2
+// CHECK-NEXT:     Prolog [2 ops]:
+// CHECK-NEXT:       [0] IP +0x0001: ALLOC_SMALL Size=0x20
+// CHECK-NEXT:       [1] IP +0x0000: PUSH Reg=RBX
 // V3 emits epilog descriptors in descending address order (tail-relative
 // offsets), so the later partial (1-op) epilog is Epilog [0].
-// CHECK:        Epilog [0] {
-// CHECK:          NumberOfOps: 1
-// CHECK:          FirstOp: 0x0
-// CHECK:          ALLOC_SMALL Size=0x20
-// CHECK:        }
-// Epilog 1: different NumberOfOps -> gets its own full descriptor, not inherited
-// CHECK:        Epilog [1] {
-// CHECK:          NumberOfOps: 2
-// CHECK:          FirstOp: 0x0
-// CHECK:          ALLOC_SMALL Size=0x20
+// CHECK-NEXT:     Epilog [0] {
+// CHECK-NEXT:       Flags [ (0x0)
+// CHECK-NEXT:       ]
+// CHECK-NEXT:       EpilogOffset: -0x9
+// CHECK-NEXT:       NumberOfOps: 1
+// CHECK-NEXT:       FirstOp: 0x0
+// CHECK-NEXT:       IpOffsetOfLastInstruction: 0x4
+// CHECK-NEXT:       [0] IP +0x0000: ALLOC_SMALL Size=0x20
+// CHECK-NEXT:     }
+// Epilog 1: different NumberOfOps -> gets its own full descriptor, not inherited.
+// CHECK-NEXT:     Epilog [1] {
+// CHECK-NEXT:       Flags [ (0x0)
+// CHECK-NEXT:       ]
+// CHECK-NEXT:       EpilogOffset: -0xF
+// CHECK-NEXT:       NumberOfOps: 2
+// CHECK-NEXT:       FirstOp: 0x0
+// CHECK-NEXT:       IpOffsetOfLastInstruction: 0x5
+// CHECK-NEXT:       [0] IP +0x0000: ALLOC_SMALL Size=0x20
+// CHECK-NEXT:       [1] IP +0x0004: PUSH Reg=RBX
+// CHECK-NEXT:     }
 
 // --- Test 3: two epilogs, same NumberOfOps but different WODs -> no inheritance ---
 // Epilog 0: pop rdi, Epilog 1: pop rbx (different register in single-op epilog)
@@ -126,19 +162,39 @@ different_wods:
     jmp     b
     .seh_endproc
 // CHECK-LABEL:  StartAddress: different_wods
-// CHECK:        NumberOfOps: 3
-// CHECK:        NumberOfEpilogs: 2
+// CHECK:        UnwindInfo {
+// CHECK-NEXT:     Version: 3
+// CHECK-NEXT:     Flags [ (0x0)
+// CHECK-NEXT:     ]
+// CHECK-NEXT:     SizeOfProlog: 0x6
+// CHECK-NEXT:     PayloadWords: 10
+// CHECK-NEXT:     NumberOfOps: 3
+// CHECK-NEXT:     NumberOfEpilogs: 2
+// CHECK-NEXT:     Prolog [3 ops]:
+// CHECK-NEXT:       [0] IP +0x0002: ALLOC_SMALL Size=0x20
+// CHECK-NEXT:       [1] IP +0x0001: PUSH Reg=RDI
+// CHECK-NEXT:       [2] IP +0x0000: PUSH Reg=RBX
 // Descriptors are in descending address order, so the later epilog
-// (PUSH RBX) is Epilog [0].
-// CHECK:        Epilog [0] {
-// CHECK:          NumberOfOps: 1
-// CHECK:          PUSH Reg=RBX
-// CHECK:        }
-// Epilog 1: PUSH RDI -> different FirstOp, so NOT inherited
-// CHECK:        Epilog [1] {
-// CHECK:          NumberOfOps: 1
-// CHECK:          PUSH Reg=RDI
-// CHECK:        }
+// (PUSH RBX) is Epilog [0]; it shares the prolog's RBX WOD (FirstOp=0x2).
+// CHECK-NEXT:     Epilog [0] {
+// CHECK-NEXT:       Flags [ (0x0)
+// CHECK-NEXT:       ]
+// CHECK-NEXT:       EpilogOffset: -0x6
+// CHECK-NEXT:       NumberOfOps: 1
+// CHECK-NEXT:       FirstOp: 0x2
+// CHECK-NEXT:       IpOffsetOfLastInstruction: 0x1
+// CHECK-NEXT:       [0] IP +0x0000: PUSH Reg=RBX
+// CHECK-NEXT:     }
+// Epilog 1: PUSH RDI -> different FirstOp (0x1), so NOT inherited.
+// CHECK-NEXT:     Epilog [1] {
+// CHECK-NEXT:       Flags [ (0x0)
+// CHECK-NEXT:       ]
+// CHECK-NEXT:       EpilogOffset: -0xC
+// CHECK-NEXT:       NumberOfOps: 1
+// CHECK-NEXT:       FirstOp: 0x1
+// CHECK-NEXT:       IpOffsetOfLastInstruction: 0x1
+// CHECK-NEXT:       [0] IP +0x0000: PUSH Reg=RDI
+// CHECK-NEXT:     }
 
 // --- Test 4: two identical LARGE mirror epilogs -> second inherits ---
 // Each epilog has 260 NOPs between its two unwind ops, pushing the IP
@@ -183,18 +239,34 @@ large_inherit:
     retq
     .seh_endproc
 // CHECK-LABEL:  StartAddress: large_inherit
-// CHECK:        NumberOfEpilogs: 2
-// CHECK:        Epilog [0] {
-// CHECK:          Flags [ (0x2)
-// CHECK-NEXT:       Large (0x2)
+// CHECK:        UnwindInfo {
+// CHECK-NEXT:     Version: 3
+// CHECK-NEXT:     Flags [ (0x0)
 // CHECK-NEXT:     ]
-// CHECK:          NumberOfOps: 2
-// CHECK:        }
+// CHECK-NEXT:     SizeOfProlog: 0x5
+// CHECK-NEXT:     PayloadWords: 9
+// CHECK-NEXT:     NumberOfOps: 2
+// CHECK-NEXT:     NumberOfEpilogs: 2
+// CHECK-NEXT:     Prolog [2 ops]:
+// CHECK-NEXT:       [0] IP +0x0001: ALLOC_SMALL Size=0x20
+// CHECK-NEXT:       [1] IP +0x0000: PUSH Reg=RBX
+// CHECK-NEXT:     Epilog [0] {
+// CHECK-NEXT:       Flags [ (0x2)
+// CHECK-NEXT:         Large (0x2)
+// CHECK-NEXT:       ]
+// CHECK-NEXT:       EpilogOffset: -0x10A
+// CHECK-NEXT:       NumberOfOps: 2
+// CHECK-NEXT:       FirstOp: 0x0
+// CHECK-NEXT:       IpOffsetOfLastInstruction: 0x109
+// CHECK-NEXT:       [0] IP +0x0000: ALLOC_SMALL Size=0x20
+// CHECK-NEXT:       [1] IP +0x0108: PUSH Reg=RBX
+// CHECK-NEXT:     }
 // Epilog 1 inherits, but must still carry the Large flag in its own byte.
-// CHECK:        Epilog [1] {
-// CHECK:          Flags [ (0x2)
-// CHECK-NEXT:       Large (0x2)
-// CHECK-NEXT:     ]
-// CHECK:          NumberOfOps: 0
-// CHECK:          (inherits
-// CHECK:       ]
+// CHECK-NEXT:     Epilog [1] {
+// CHECK-NEXT:       Flags [ (0x2)
+// CHECK-NEXT:         Large (0x2)
+// CHECK-NEXT:       ]
+// CHECK-NEXT:       EpilogOffset: -0x214
+// CHECK-NEXT:       NumberOfOps: 0
+// CHECK-NEXT:       (inherits from base epilog: FirstOp=0x0, IpOffsetOfLastInstruction=0x109, 2 ops)
+// CHECK-NEXT:     }

--- a/llvm/test/MC/COFF/seh-unwindv3-inheritance.s
+++ b/llvm/test/MC/COFF/seh-unwindv3-inheritance.s
@@ -83,13 +83,16 @@ different_numops:
 // CHECK-LABEL:  StartAddress: different_numops
 // CHECK:        NumberOfOps: 2
 // CHECK:        NumberOfEpilogs: 2
+// V3 emits epilog descriptors in descending address order (tail-relative
+// offsets), so the later partial (1-op) epilog is Epilog [0].
 // CHECK:        Epilog [0] {
-// CHECK:          NumberOfOps: 2
+// CHECK:          NumberOfOps: 1
 // CHECK:          FirstOp: 0x0
+// CHECK:          ALLOC_SMALL Size=0x20
 // CHECK:        }
 // Epilog 1: different NumberOfOps -> gets its own full descriptor, not inherited
 // CHECK:        Epilog [1] {
-// CHECK:          NumberOfOps: 1
+// CHECK:          NumberOfOps: 2
 // CHECK:          FirstOp: 0x0
 // CHECK:          ALLOC_SMALL Size=0x20
 
@@ -125,15 +128,16 @@ different_wods:
 // CHECK-LABEL:  StartAddress: different_wods
 // CHECK:        NumberOfOps: 3
 // CHECK:        NumberOfEpilogs: 2
-// Epilog 0: PUSH RDI, found in prolog pool
+// Descriptors are in descending address order, so the later epilog
+// (PUSH RBX) is Epilog [0].
 // CHECK:        Epilog [0] {
 // CHECK:          NumberOfOps: 1
-// CHECK:          PUSH Reg=RDI
+// CHECK:          PUSH Reg=RBX
 // CHECK:        }
-// Epilog 1: PUSH RBX -> different FirstOp, so NOT inherited
+// Epilog 1: PUSH RDI -> different FirstOp, so NOT inherited
 // CHECK:        Epilog [1] {
 // CHECK:          NumberOfOps: 1
-// CHECK:          PUSH Reg=RBX
+// CHECK:          PUSH Reg=RDI
 // CHECK:        }
 
 // --- Test 4: two identical LARGE mirror epilogs -> second inherits ---

--- a/llvm/test/MC/COFF/seh-unwindv3-large.s
+++ b/llvm/test/MC/COFF/seh-unwindv3-large.s
@@ -45,7 +45,7 @@ large_prolog_known:
 // CHECK-NEXT:       [0] IP +0x0105: ALLOC_SMALL Size=0x20
 // CHECK-NEXT:       [1] IP +0x0000: PUSH Reg=RBX
 // CHECK:          Epilog [0] {
-// CHECK:            EpilogOffset: +0x10A
+// CHECK:            EpilogOffset: -0x6
 // CHECK-NEXT:       NumberOfOps: 2
 // CHECK-NEXT:       FirstOp: 0x0
 // CHECK-NEXT:       IpOffsetOfLastInstruction: 0x5
@@ -93,7 +93,7 @@ large_prolog_unevaluatable:
 // CHECK-NEXT:       [0] IP +0x00F0: ALLOC_SMALL Size=0x20
 // CHECK-NEXT:       [1] IP +0x0000: PUSH Reg=RBX
 // CHECK:          Epilog [0] {
-// CHECK:            EpilogOffset: +0xF5
+// CHECK:            EpilogOffset: -0x6
 // CHECK-NEXT:       NumberOfOps: 2
 // CHECK-NEXT:       FirstOp: 0x0
 // CHECK-NEXT:       IpOffsetOfLastInstruction: 0x5
@@ -143,7 +143,7 @@ large_epilog_known:
 // CHECK-NEXT:       Flags [ (0x2)
 // CHECK-NEXT:         Large (0x2)
 // CHECK-NEXT:       ]
-// CHECK-NEXT:       EpilogOffset: +0x6
+// CHECK-NEXT:       EpilogOffset: -0x10A
 // CHECK-NEXT:       NumberOfOps: 2
 // CHECK-NEXT:       FirstOp: 0x0
 // CHECK-NEXT:       IpOffsetOfLastInstruction: 0x109
@@ -189,7 +189,7 @@ large_epilog_unevaluatable:
 // CHECK-NEXT:       Flags [ (0x2)
 // CHECK-NEXT:         Large (0x2)
 // CHECK-NEXT:       ]
-// CHECK-NEXT:       EpilogOffset: +0x6
+// CHECK-NEXT:       EpilogOffset: -0xE1
 // CHECK-NEXT:       NumberOfOps: 2
 // CHECK-NEXT:       FirstOp: 0x0
 // CHECK-NEXT:       IpOffsetOfLastInstruction: 0xE0

--- a/llvm/test/MC/COFF/seh-unwindv3-nonmirror.s
+++ b/llvm/test/MC/COFF/seh-unwindv3-nonmirror.s
@@ -143,19 +143,20 @@ mixed_epilogs:
 // CHECK:            ALLOC_SMALL Size=0x20
 // CHECK:            PUSH Reg=RDI
 // CHECK:            PUSH Reg=RBX
-// Mirror epilog (FirstOp=0, NumberOfOps=3)
+// V3 emits epilog descriptors in descending address order (tail-relative
+// offsets), so the later partial epilog (2 ops) is Epilog [0].
 // CHECK:          Epilog [0] {
+// CHECK:            NumberOfOps: 2
+// CHECK:            FirstOp: 0x0
+// CHECK:            ALLOC_SMALL Size=0x20
+// CHECK:            PUSH Reg=RDI
+// Mirror epilog (FirstOp=0, NumberOfOps=3).
+// CHECK:          Epilog [1] {
 // CHECK:            NumberOfOps: 3
 // CHECK:            FirstOp: 0x0
 // CHECK:            ALLOC_SMALL Size=0x20
 // CHECK:            PUSH Reg=RDI
 // CHECK:            PUSH Reg=RBX
-// Partial epilog — different NumberOfOps, so NOT inherited.
-// CHECK:          Epilog [1] {
-// CHECK:            NumberOfOps: 2
-// CHECK:            FirstOp: 0x0
-// CHECK:            ALLOC_SMALL Size=0x20
-// CHECK:            PUSH Reg=RDI
 
 // --- Test 4: reordered epilog ---
 // Prolog: push rbx, push rdi, sub rsp, 32


### PR DESCRIPTION
Win64 Unwind v3 encodes each epilog's EpilogOffset as a signed 16-bit field. The encoder previously measured the first epilog offset from the fragment start, which overflowed for large functions and produced a cryptic "<unknown>:0: value too large for field" error (and, on the early .seh_handlerdata path, an assertion failure).

Two changes:

- MCWin64EH.cpp: Always emit epilog offsets tail-relative. The first epilog descriptor is measured from the fragment end and subsequent ones as deltas from the previous epilog, so descriptors are emitted in descending address order (all non-positive, per spec). A new lazy MCUnwindV3EpilogOffsetTargetExpr resolves the fragment-end-relative value at layout time (it may not have a symbol yet when emitted via .seh_handlerdata) and reports a clean, function-named diagnostic on genuine overflow.

- X86WinEHUnwindV3.cpp: Add Unwind-v2-style size-based sub-fragment splitting. In addition to the existing >7-epilog split, the pass now splits a funclet into chained fragments when an epilog is too far from its fragment tail (using the V2 approximate-instruction-count heuristic, tunable via -x86-wineh-unwindv3-epilog-distance-threshold). Splits use SEH_SplitChainedAtEndOfBlock so the split lands after the epilog, keeping every epilog close to its tail; a long trailing region becomes its own epilog-free chained fragment.

Updates seh-unwindv3-large.s expectations to the new tail-relative values and adds win64-eh-unwindv3-split-large.ll covering size-based splitting.