### PR TITLE
[lldb] Expose SBProcess::IsLiveDebugSession()

### DIFF
--- a/lldb/include/lldb/API/SBProcess.h
+++ b/lldb/include/lldb/API/SBProcess.h
@@ -424,6 +424,15 @@ public:
   ///     the process isn't loaded from a core file.
   lldb::SBFileSpec GetCoreFile();
 
+  /// Check whether this process is a live debug session, as opposed to a
+  /// post-mortem session such as a core file or minidump.
+  ///
+  /// \return
+  ///     \b true if the process represents a live debug session, \b false if it
+  ///     is a post-mortem session (e.g. a core file) or there is no underlying
+  ///     process.
+  bool IsLiveDebugSession() const;
+
   /// \{
   /// \group Mask Address Methods
   ///

--- a/lldb/source/API/SBProcess.cpp
+++ b/lldb/source/API/SBProcess.cpp
@@ -1354,6 +1354,15 @@ lldb::SBFileSpec SBProcess::GetCoreFile() {
   return SBFileSpec(core_file);
 }
 
+bool SBProcess::IsLiveDebugSession() const {
+  LLDB_INSTRUMENT_VA(this);
+
+  ProcessSP process_sp(GetSP());
+  if (!process_sp)
+    return false;
+  return process_sp->IsLiveDebugSession();
+}
+
 addr_t SBProcess::GetAddressMask(AddressMaskType type,
                                  AddressMaskRange addr_range) {
   LLDB_INSTRUMENT_VA(this, type, addr_range);

--- a/lldb/test/API/functionalities/postmortem/elf-core/TestLinuxCore.py
+++ b/lldb/test/API/functionalities/postmortem/elf-core/TestLinuxCore.py
@@ -224,6 +224,15 @@ class LinuxCoreTestCase(TestBase):
         self.dbg.DeleteTarget(target)
 
     @skipIfLLVMTargetMissing("X86")
+    def test_is_not_live_debug_session(self):
+        """Test that a process loaded from a core file is not a live session."""
+        target = self.dbg.CreateTarget("linux-x86_64.out")
+        process = target.LoadCore("linux-x86_64.core")
+        self.assertTrue(process, PROCESS_IS_VALID)
+        self.assertFalse(process.IsLiveDebugSession())
+        self.dbg.DeleteTarget(target)
+
+    @skipIfLLVMTargetMissing("X86")
     def test_write_register(self):
         """Test that writing to register results in an error and that error
         message is set."""

--- a/lldb/test/API/python_api/process/TestProcessAPI.py
+++ b/lldb/test/API/python_api/process/TestProcessAPI.py
@@ -29,6 +29,17 @@ class ProcessAPITestCase(TestBase):
         self.assertTrue(process, PROCESS_IS_VALID)
         self.assertEqual(process.GetScriptedImplementation(), None)
 
+    def test_is_live_debug_session(self):
+        """Test that a launched process reports as a live debug session."""
+        self.build()
+
+        (target, process, _, _) = lldbutil.run_to_source_breakpoint(
+            self, "Set break point", lldb.SBFileSpec("main.cpp")
+        )
+
+        self.assertTrue(process, PROCESS_IS_VALID)
+        self.assertTrue(process.IsLiveDebugSession())
+
     def test_read_memory(self):
         """Test Python SBProcess.ReadMemory() API."""
         self.build()

--- a/lldb/test/API/python_api/process/TestProcessAPI.py
+++ b/lldb/test/API/python_api/process/TestProcessAPI.py
@@ -40,6 +40,12 @@ class ProcessAPITestCase(TestBase):
         self.assertTrue(process, PROCESS_IS_VALID)
         self.assertTrue(process.IsLiveDebugSession())
 
+    def test_is_live_debug_session_invalid_process(self):
+        """Test that an invalid process is not reported as a live session."""
+        process = lldb.SBProcess()
+        self.assertFalse(process.IsValid())
+        self.assertFalse(process.IsLiveDebugSession())
+
     def test_read_memory(self):
         """Test Python SBProcess.ReadMemory() API."""
         self.build()


### PR DESCRIPTION
Expose the existing `Process::IsLiveDebugSession()` through the SB API as `SBProcess::IsLiveDebugSession()`, letting clients distinguish a live debuggee from a post-mortem session such as a core file or minidump. It returns `false` when there is no underlying process, consistent with other `SBProcess` query methods.