### PR TITLE
[mlir][ROCM] Disable integration tests on shared library builds

### DIFF
--- a/mlir/test/Integration/GPU/ROCM/lit.local.cfg
+++ b/mlir/test/Integration/GPU/ROCM/lit.local.cfg
@@ -1,4 +1,10 @@
 if not config.enable_rocm_runner or not config.rocm_test_chipset:
     config.unsupported = True
 
+# TODO: Re-enable these tests for shared-library builds. The ROCM runtime
+# library depends on ROCm's monolithic libLLVM.so through HIP/COMGR, which
+# collides with LLVM split shared libraries already loaded by mlir-runner.
+if config.llvm_shared_libs_build:
+    config.unsupported = True
+
 config.substitutions.append(("%chip", config.rocm_test_chipset))


### PR DESCRIPTION
Recent ROCm builds cause conflicts when loading the HIP library into mlir-rocm-runner when LLVM is built as a shared library (this manifests as duplicate command-line options).

Fixing this properly would require dlopen()-ing the HIP libraries or some other such workaround, which can be done later.

For now, disable these tests on such builds.