### PR TITLE
[XRay][Hexagon] Make XRay sleds register-transparent

### DIFF
--- a/compiler-rt/lib/xray/xray_hexagon.cpp
+++ b/compiler-rt/lib/xray/xray_hexagon.cpp
@@ -34,8 +34,19 @@ enum PatchOpcodes : uint32_t {
                                 // ICLASS 0x7 - S2-type A-type
   PO_IMMEXT = 0x00000000,       // constant extender
   PO_ALLOCFRAME_0 = 0xa09dc000, // allocframe(#0)
+  PO_ALLOCFRAME_8 = 0xa09dc001, // allocframe(#8)
   PO_DEALLOCFRAME = 0x901ec01e, // deallocframe
+  PO_STORE_R7_SP0 = 0xa19dc700, // memw(r29+#0) = r7
+  PO_LOAD_R7_SP0 = 0x919dc007,  // r7 = memw(r29+#0)
+  PO_CALL = 0x5a00c000, // call #0 (J2_call, packet end); offset added in
 };
+
+// Encode a J2_call to a PC-relative byte offset.  The offset (divided by 4) is
+// a 22-bit signed value split across instruction bits [24:16] and [13:1].
+inline static uint32_t encodeCall(int32_t ByteOffset) XRAY_NEVER_INSTRUMENT {
+  const int32_t Imm = ByteOffset >> 2;
+  return PO_CALL | ((Imm & 0x1fff) << 1) | (((Imm >> 13) & 0x1ff) << 16);
+}
 
 enum PacketWordParseBits : uint32_t {
   PP_DUPLEX = 0x00 << 14,
@@ -108,18 +119,24 @@ inline static bool patchSled(const bool Enable, const uint32_t FuncId,
   // With the following runtime patch:
   //
   // <xray_sled_n>:
-  // { allocframe(#0) }
-  // { immext(#...) // upper 26-bits of func id
-  //   r7 = ##...   // lower  6-bits of func id
-  //   immext(#...) // upper 26-bits of trampoline
-  //   r6 = ##... } // lower  6-bits of trampoline
-  // { callr r6 }
+  // { allocframe(#8) }       // save r31:30, reserve an 8-byte spill slot
+  // { memw(sp+#0) = r7 }     // preserve r7 (the only reg this sled clobbers)
+  // { immext(#...)           // upper 26-bits of func id
+  //   r7 = ##... }           // lower  6-bits of func id
+  // { call ##trampoline }    // direct PC-relative call (does NOT clobber r6)
+  // { r7 = memw(sp+#0) }     // restore r7
   // { deallocframe }
   //
-  // allocframe(#0) saves the caller's r31:30 (LR:FP) before the callr
-  // clobbers r31, and deallocframe restores them afterward.  This ensures
-  // the instrumented function's allocframe later saves the correct return
-  // address.
+  // An XRay sled is inserted post-register-allocation and is treated by the
+  // compiler as clobbering nothing, yet a function-exit sled can land in the
+  // middle of a loop (a conditional early return) where r6/r7 hold live
+  // loop-carried values.  Earlier code loaded the trampoline address into r6
+  // and used `callr r6`, clobbering both r6 and r7 with no way to recover the
+  // originals (the clobber precedes the trampoline's register save).  Use a
+  // direct `call` so r6 is never touched (the trampoline preserves the rest of
+  // the caller-saved set, including r6), and have the sled itself spill/reload
+  // r7 around the funcid setup.  allocframe(#8)/deallocframe save the caller's
+  // r31:30 (LR:FP) and provide the spill slot.
   //
   // Replacement of the first 4-byte instruction should be the last and
   // atomic operation, so that user code reaching the sled concurrently
@@ -132,28 +149,28 @@ inline static bool patchSled(const bool Enable, const uint32_t FuncId,
   uint32_t *FirstAddress = reinterpret_cast<uint32_t *>(Sled.address());
   if (Enable) {
     uint32_t *CurAddress = FirstAddress + 1;
-    // Word 1: immext for r7 = FuncId
+    // Word 1: memw(sp+#0) = r7  -- spill r7 before clobbering it below.
+    *CurAddress = uint32_t(PO_STORE_R7_SP0);
+    CurAddress++;
+    // Word 2: immext for r7 = FuncId
     *CurAddress = encodeConstantExtender(FuncId);
     CurAddress++;
-    // Word 2: r7 = ##FuncId (low 6 bits)
-    *CurAddress = encodeExtendedTransferImmediate(FuncId, RN_R7);
+    // Word 3: r7 = ##FuncId (low 6 bits), packet end
+    *CurAddress = encodeExtendedTransferImmediate(FuncId, RN_R7, true);
     CurAddress++;
-    // Word 3: immext for r6 = TracingHook
-    *CurAddress =
-        encodeConstantExtender(reinterpret_cast<uint32_t>(TracingHook));
+    // Word 4: call ##TracingHook -- PC-relative from this instruction.
+    *CurAddress = encodeCall(
+        static_cast<int32_t>(reinterpret_cast<intptr_t>(TracingHook) -
+                             reinterpret_cast<intptr_t>(CurAddress)));
     CurAddress++;
-    // Word 4: r6 = ##TracingHook (low 6 bits), packet end
-    *CurAddress = encodeExtendedTransferImmediate(
-        reinterpret_cast<uint32_t>(TracingHook), RN_R6, true);
-    CurAddress++;
-    // Word 5: callr r6
-    *CurAddress = uint32_t(PO_CALLR_R6);
+    // Word 5: r7 = memw(sp+#0)  -- restore r7.
+    *CurAddress = uint32_t(PO_LOAD_R7_SP0);
     CurAddress++;
     // Word 6: deallocframe
     *CurAddress = uint32_t(PO_DEALLOCFRAME);
 
-    // Word 0 (written last, atomically): allocframe(#0) replaces jump
-    WriteInstFlushCache(FirstAddress, uint32_t(PO_ALLOCFRAME_0));
+    // Word 0 (written last, atomically): allocframe(#8) replaces jump
+    WriteInstFlushCache(FirstAddress, uint32_t(PO_ALLOCFRAME_8));
   } else {
     WriteInstFlushCache(FirstAddress, uint32_t(PO_JUMPI_1C));
   }

--- a/compiler-rt/lib/xray/xray_trampoline_hexagon.S
+++ b/compiler-rt/lib/xray/xray_trampoline_hexagon.S
@@ -17,41 +17,110 @@
 
 // The patched sled sets:
 //   r7 = function ID
-//   r6 = trampoline address (used by callr, then dead)
-//   r31 = return address back to sled (set by callr)
+//   r31 = return address back to the sled (set by the call)
 //
-// The sled wraps the callr with allocframe(#0)/deallocframe to preserve
-// the caller's original r31:30 across the trampoline call.
+// The sled wraps the call with allocframe(#8)/deallocframe: this preserves the
+// caller's original r31:30 (LR:FP) and provides an 8-byte slot in which the sled
+// spills and reloads r7 (the only register the sled itself clobbers).
+
+// 112-byte, 8-byte-aligned save area:
+//   sp+#0:  r1:0    sp+#8:  r3:2    sp+#16: r5:4    sp+#24: r7:6
+//   sp+#32: r9:8    sp+#40: r11:10  sp+#48: r13:12  sp+#56: r15:14
+//   sp+#64: r28     sp+#68: r31     sp+#72: p3:0    sp+#76: usr
+//   sp+#80: c1:0 (SA0,LC0)   sp+#88: c3:2 (SA1,LC1)   sp+#96: c7:6 (M0,M1)
+//   (sp+#104: pad)
+//
+// The trampoline must preserve every caller-saved register, not just the
+// argument registers: an XRay sled is inserted post-register-allocation and is
+// treated by the compiler as clobbering nothing, but a function-exit sled can
+// land in the middle of a loop (a conditional early return), where loop-carried
+// values live across it.  The C++ handler freely clobbers the whole caller-saved
+// set: GPRs r0-r15 and r28, predicates p0-p3, the hardware-loop registers
+// SA0/LC0/SA1/LC1, the modifier registers M0/M1, and USR.  In particular a
+// hardware loop (loop0/loop1) with an exit sled in its body needs SA0/LC0 (and
+// SA1/LC1 if nested) preserved or the loop's trip count is corrupted.  r16-r27
+// are callee-saved (preserved by the handler) and r29/r30 are managed by the
+// sled's allocframe/deallocframe.  (The sled spills/reloads r7 itself, since it
+// clobbers r7 with the funcid before this trampoline runs.)  GPRs are spilled as
+// pairs with memd, two memory ops per packet; r0/r1 are reused as scratch for
+// the control registers once their originals are on the stack.
 
 .macro SAVE_REGISTERS
-	// Allocate 32 bytes on the stack:
-	//   sp+#0:  r0     (parameter / return value)
-	//   sp+#4:  r1     (parameter / return value)
-	//   sp+#8:  r2     (parameter)
-	//   sp+#12: r3     (parameter)
-	//   sp+#16: r4     (parameter)
-	//   sp+#20: r5     (parameter)
-	//   sp+#24: r31    (return address back to sled's deallocframe)
-	//   sp+#28: (padding for 8-byte alignment)
-	sp = add(sp, #-32)
-	memw(sp+#0) = r0
-	memw(sp+#4) = r1
-	memw(sp+#8) = r2
-	memw(sp+#12) = r3
-	memw(sp+#16) = r4
-	memw(sp+#20) = r5
-	memw(sp+#24) = r31
+	// The paired memd reads the pre-packet r0/r1, so moving the predicates into
+	// r0 in this same packet is safe (r0's original value is already stored).
+	{
+		memd(sp+#-112) = r1:0
+		memd(sp+#-104) = r3:2
+		sp = add(sp, #-112)
+		r0 = p3:0
+	}
+	{
+		memd(sp+#16) = r5:4
+		memd(sp+#24) = r7:6
+	}
+	{
+		memd(sp+#32) = r9:8
+		memd(sp+#40) = r11:10
+	}
+	{
+		memd(sp+#48) = r13:12
+		memd(sp+#56) = r15:14
+	}
+	{
+		memw(sp+#64) = r28
+		memw(sp+#68) = r31
+	}
+	// Predicates (computed above) and the control registers.  r0/r1 are already
+	// saved, so they are free to use as scratch for the control-register reads.
+	// Each control-register transfer must be alone in its packet (slot 3 only).
+	memw(sp+#72) = r0
+	r1:0 = c1:0
+	memd(sp+#80) = r1:0
+	r1:0 = c3:2
+	memd(sp+#88) = r1:0
+	r1:0 = c7:6
+	memd(sp+#96) = r1:0
+	r0 = usr
+	memw(sp+#76) = r0
 .endm
 
 .macro RESTORE_REGISTERS
-	r0 = memw(sp+#0)
-	r1 = memw(sp+#4)
-	r2 = memw(sp+#8)
-	r3 = memw(sp+#12)
-	r4 = memw(sp+#16)
-	r5 = memw(sp+#20)
-	r31 = memw(sp+#24)
-	sp = add(sp, #32)
+	// Restore the control registers first (each transfer alone, slot 3 only),
+	// using r0/r1 as scratch before the real r0/r1 are reloaded below; then the
+	// predicates and GPRs.  All loads use the pre-update sp; sp is bumped last.
+	r0 = memw(sp+#76)
+	usr = r0
+	r1:0 = memd(sp+#96)
+	c7:6 = r1:0
+	r1:0 = memd(sp+#88)
+	c3:2 = r1:0
+	r1:0 = memd(sp+#80)
+	c1:0 = r1:0
+	{
+		r0 = memw(sp+#72)
+		r31 = memw(sp+#68)
+	}
+	{
+		p3:0 = r0
+		r1:0 = memd(sp+#0)
+		r3:2 = memd(sp+#8)
+	}
+	{
+		r5:4 = memd(sp+#16)
+		r7:6 = memd(sp+#24)
+	}
+	{
+		r9:8 = memd(sp+#32)
+		r11:10 = memd(sp+#40)
+	}
+	{
+		r13:12 = memd(sp+#48)
+		r15:14 = memd(sp+#56)
+	}
+	{
+		r28 = memw(sp+#64)
+		sp = add(sp, #112)
+	}
 .endm
 
 .macro CALL_PATCHED_FUNC entry_type


### PR DESCRIPTION
A sled is inserted post-register-allocation and is treated by the compiler as clobbering nothing, but the sled and trampoline together preserve too little. The sled uses r6/r7 as scratch (trampoline address and funcid) and the trampoline saves only r0-r5, r31 and p3:0.  A function-exit sled can land in the middle of a loop (a conditional early return), where loop-carried values occupy r6-r15 and, for a hardware loop, SA0/LC0.  The handler clobbers them, so most instrumented gcc-c-torture programs compute wrong results and abort().