### PR TITLE
[tysan] Guard mallopt() use on SANITIZER_GLIBC instead of SANITIZER_LINUX

### DIFF
--- a/compiler-rt/lib/tysan/tysan_interceptors.cpp
+++ b/compiler-rt/lib/tysan/tysan_interceptors.cpp
@@ -22,7 +22,7 @@
 #define TYSAN_INTERCEPT___STRDUP 0
 #endif
 
-#if SANITIZER_LINUX
+#if SANITIZER_GLIBC
 extern "C" int mallopt(int param, int value);
 #endif
 
@@ -211,7 +211,7 @@ void InitializeInterceptors() {
   CHECK_EQ(inited, 0);
 
   // Instruct libc malloc to consume less memory.
-#if SANITIZER_LINUX
+#if SANITIZER_GLIBC
   mallopt(1, 0);          // M_MXFAST
   mallopt(-3, 32 * 1024); // M_MMAP_THRESHOLD
 #endif


### PR DESCRIPTION
mallopt() is a glibc extension, not provided by other Linux C libraries such as musl, but its declaration and its use in InitializeInterceptors() are gated on SANITIZER_LINUX.  Linking the TySan runtime for a musl target therefore fails:

  ld.lld: error: undefined symbol: mallopt
  >>> referenced by tysan_interceptors.cpp:215 in
  >>>   __tysan::InitializeInterceptors() in libclang_rt.tysan-hexagon.a