### PR TITLE
Revert "[lldb][test] Increase polling in TestInterruptThreadNames.py (#201554)"

### DIFF
--- a/lldb/test/API/macosx/thread-names/TestInterruptThreadNames.py
+++ b/lldb/test/API/macosx/thread-names/TestInterruptThreadNames.py
@@ -65,9 +65,16 @@ class TestInterruptThreadNames(TestBase):
     # check to see if the global has that value, and continue if it does not.
     def wait_until_program_setup_complete(self, process, listener):
         inferior_set_up = lldb.SBValue()
-        retry = 50
+        retry = 5
         while retry > 0:
-            time.sleep(0.1)
+            arch = self.getArchitecture()
+            # when running the testsuite against a remote arm device, it may take
+            # a little longer for the process to start up.  Use a "can't possibly take
+            # longer than this" value.
+            if arch == "arm64" or arch == "armv7":
+                time.sleep(10)
+            else:
+                time.sleep(1)
             process.SendAsyncInterrupt()
             self.assertTrue(
                 self.wait_for_stop(process, listener), "Check that process is paused"


### PR DESCRIPTION
This reverts commit fdfd1c1344187d64b63504ea8e3662ae4936503a.

The Intel mac CI bot is timing out often with these new timeouts and we're getting failing runs.  Raphael will adjust and re-land.