### PR TITLE
Add the ability to look up persistent types and variables defined in the expression parser through the SB API's.

### DIFF
--- a/lldb/bindings/interface/SBTargetDocstrings.i
+++ b/lldb/bindings/interface/SBTargetDocstrings.i
@@ -308,6 +308,40 @@ produces: ::
 ) lldb::SBTarget::ResolveFileAddress;
 
 %feature("docstring", "
+    Look up a persistent type defined using the expression parser.
+
+    @param[in] type_name
+         The base name of the persistent type you defined.
+
+    @param[in] language
+         A member of the enum lldb::LanguageType giving the
+         language of the Expression parser you used to define
+         the persistent type.
+
+    @param[out] error
+         If there are errors fetching the type, they will be 
+         returned here.
+
+    @return
+        An SBType representing the persistent type you defined."
+) lldb::SBTarget::FindExpressionTypeForLanguage;
+
+%feature("docstring", "
+    Look up a persistent variable defined using the expression parser.
+
+    @param[in] variable_name
+         The name of the persistent variable you defined.
+
+    @param[in] language
+	 A member of the enum lldb::LanguageType giving	the
+	 language of the Expression parser you used to define
+	 the persistent type.
+
+    @return
+        An SBValue representing the persistent variable you defined."
+) lldb::SBTarget::FindExpressionVariableForLanguage;
+
+%feature("docstring", "
     Read target memory. If a target process is running then memory
     is read from here. Otherwise the memory is read from the object
     files. For a target whose bytes are sized as a multiple of host

--- a/lldb/include/lldb/API/SBTarget.h
+++ b/lldb/include/lldb/API/SBTarget.h
@@ -923,6 +923,13 @@ public:
 
   lldb::SBType GetBasicType(lldb::BasicType type);
 
+  lldb::SBType FindExpressionTypeForLanguage(const char *typename_cstr,
+                                             lldb::LanguageType lang,
+                                             SBError &error);
+
+  lldb::SBValue FindExpressionVariableForLanguage(const char *varname_cstr,
+                                                  lldb::LanguageType lang);
+
   lldb::SBValue CreateValueFromAddress(const char *name, lldb::SBAddress addr,
                                        lldb::SBType type);
 

--- a/lldb/include/lldb/Target/Language.h
+++ b/lldb/include/lldb/Target/Language.h
@@ -24,6 +24,8 @@
 #include "lldb/Symbol/TypeSystem.h"
 #include "lldb/lldb-private.h"
 #include "lldb/lldb-public.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/FormatVariadic.h"
 
 namespace lldb_private {
 
@@ -518,5 +520,12 @@ private:
 };
 
 } // namespace lldb_private
+
+namespace llvm {
+template <> struct format_provider<lldb::LanguageType> {
+  static void format(const lldb::LanguageType &language, llvm::raw_ostream &OS,
+                     llvm::StringRef Options);
+};
+} // namespace llvm
 
 #endif // LLDB_TARGET_LANGUAGE_H

--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -40,6 +40,7 @@
 #include "lldb/Core/SearchFilter.h"
 #include "lldb/Core/Section.h"
 #include "lldb/Core/StructuredDataImpl.h"
+#include "lldb/Expression/ExpressionVariable.h"
 #include "lldb/Host/Host.h"
 #include "lldb/Interpreter/Interfaces/ScriptedBreakpointInterface.h"
 #include "lldb/Interpreter/Interfaces/ScriptedFrameProviderInterface.h"
@@ -1876,6 +1877,96 @@ lldb::SBSymbolContextList SBTarget::FindGlobalFunctions(const char *name,
     }
   }
   return sb_sc_list;
+}
+
+lldb::SBType SBTarget::FindExpressionTypeForLanguage(
+    const char *typename_cstr, lldb::LanguageType language, SBError &sb_error) {
+  LLDB_INSTRUMENT_VA(this, typename_cstr, language, sb_error);
+  sb_error.Clear();
+
+  TargetSP target_sp = GetSP();
+  if (!target_sp) {
+    sb_error.SetErrorString("no target.");
+    return {};
+  }
+
+  if (!typename_cstr || !typename_cstr[0]) {
+    sb_error.SetErrorString("empty type name for search.");
+    return {};
+  }
+
+  if (language == eLanguageTypeUnknown) {
+    sb_error.SetErrorString("eLanguageTypeUnknown can't define expression "
+                            "types.");
+    return {};
+  }
+
+  PersistentExpressionState *persistent =
+      target_sp->GetPersistentExpressionStateForLanguage(language);
+
+  if (!persistent) {
+    sb_error.SetErrorString(
+        llvm::formatv("language {0} does not support expression defined types",
+                      language)
+            .str()
+            .c_str());
+    return {};
+  }
+
+  ConstString const_typename(typename_cstr);
+  std::optional<CompilerType> type_op =
+      persistent->GetCompilerTypeFromPersistentDecl(const_typename);
+  if (type_op && (*type_op)) {
+    return SBType(*type_op);
+  }
+  sb_error.SetErrorString(
+      llvm::formatv("no type {0} found in expression types for language {1}",
+                    typename_cstr, language)
+          .str()
+          .c_str());
+  return {};
+}
+
+lldb::SBValue
+SBTarget::FindExpressionVariableForLanguage(const char *varname_cstr,
+                                            lldb::LanguageType language) {
+  LLDB_INSTRUMENT_VA(this, varname_cstr, language);
+  TargetSP target_sp = GetSP();
+  if (!target_sp)
+    return ValueObjectConstResult::Create(
+        nullptr,
+        Status::FromErrorStringWithFormatv(
+            "no variable {0} found for language {1}", varname_cstr, language));
+
+  if (!varname_cstr || !varname_cstr[0])
+    return ValueObjectConstResult::Create(
+        target_sp.get(),
+        Status::FromErrorString("empty variable name for search."));
+
+  if (language == eLanguageTypeUnknown)
+    return ValueObjectConstResult::Create(
+        nullptr, Status::FromErrorString("eLanguageTypeUnknown doesn't support "
+                                         "expression variables."));
+
+  PersistentExpressionState *persistent =
+      target_sp->GetPersistentExpressionStateForLanguage(language);
+  if (!persistent) {
+    return ValueObjectConstResult::Create(
+        target_sp.get(),
+        Status::FromErrorStringWithFormatv(
+            "language: {0} doesn't support expression variables.", language));
+  }
+
+  ConstString const_varname(varname_cstr);
+  lldb::ExpressionVariableSP expr_var_sp =
+      persistent->GetVariable(const_varname);
+  if (expr_var_sp)
+    return expr_var_sp->GetValueObject();
+
+  return ValueObjectConstResult::Create(
+      target_sp.get(),
+      Status::FromErrorStringWithFormatv(
+          "no variable {0} found for language {1}", varname_cstr, language));
 }
 
 lldb::SBType SBTarget::FindFirstType(const char *typename_cstr) {

--- a/lldb/source/Target/Language.cpp
+++ b/lldb/source/Target/Language.cpp
@@ -631,3 +631,9 @@ bool SourceLanguage::IsObjC() const {
 bool SourceLanguage::IsCPlusPlus() const {
   return name == llvm::dwarf::DW_LNAME_C_plus_plus;
 }
+
+void llvm::format_provider<lldb::LanguageType>::format(
+    const lldb::LanguageType &language, llvm::raw_ostream &OS,
+    llvm::StringRef Options) {
+  OS << Language::GetNameForLanguageType(language);
+}

--- a/lldb/test/API/python_api/persistent_decls/Makefile
+++ b/lldb/test/API/python_api/persistent_decls/Makefile
@@ -1,0 +1,4 @@
+C_SOURCES := main.c
+CFLAGS_EXTRAS := -std=c99
+
+include Makefile.rules

--- a/lldb/test/API/python_api/persistent_decls/TestPersistentDecls.py
+++ b/lldb/test/API/python_api/persistent_decls/TestPersistentDecls.py
@@ -1,0 +1,121 @@
+"""
+Test the SBTarget API's to retrieve persistent types
+and values.
+"""
+
+
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import *
+
+
+class TestPersistentDecls(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_persistent_types(self):
+        """Define some types in the expression evaluator and find them."""
+        self.build()
+        self.main_source_file = lldb.SBFileSpec("main.c")
+        self.types_test()
+
+    def test_persistent_values(self):
+        """Define some values in the expression evaluator and find them."""
+        self.build()
+        self.main_source_file = lldb.SBFileSpec("main.c")
+        self.values_test()
+
+    def types_test(self):
+        (target, _, _, _) = lldbutil.run_to_source_breakpoint(
+            self, "Set a breakpoint here", self.main_source_file
+        )
+
+        # Make some types so we aren't succeeding in gettting the only one.
+
+        typename = "$firstStruct"
+
+        self.expect(f"expr struct $SomeType {{ int b; int a; int c;}}")
+        self.expect(f"expr struct {typename} {{ int a; int b; char *c;}}")
+        self.expect(f"expr struct $AnotherType {{ int a; char *b; int c;}}")
+        self.expect(f"expr struct $YetAnotherType {{ char *a; int b; int c;}}")
+
+        language = lldb.eLanguageTypeC_plus_plus
+        error = lldb.SBError()
+        type = target.FindExpressionTypeForLanguage(typename, language, error)
+        self.assertSuccess(error, "Got the right error")
+        self.assertTrue(type.IsValid(), "Got a valid type")
+
+        # Make sure we got the type we expected:
+        self.assertEqual(type.name, typename, "Got the right type.")
+        # Now check that the fields are right:
+        self.assertEqual(type.num_fields, 3, "Right number of fields")
+
+        ivar_a = type.fields[0]
+        self.assertEqual(ivar_a.name, "a", "a name is right")
+        self.assertEqual(ivar_a.type.name, "int", "Right type")
+
+        ivar_b = type.fields[1]
+        self.assertEqual(ivar_b.name, "b", "b name is right")
+        self.assertEqual(ivar_b.type.name, "int", "Right type")
+
+        ivar_c = type.fields[2]
+        self.assertEqual(ivar_c.name, "c", "c name is right")
+        self.assertEqual(ivar_c.type.name, "char *", "Right type")
+
+        # Also test the error returns:
+        type = target.FindExpressionTypeForLanguage(
+            typename, lldb.eLanguageTypeUnknown, error
+        )
+        self.assertFalse(error.Success(), "unknown doesn't support expression types")
+        self.assertFalse(type.IsValid(), "Type is also invalid.")
+
+        type = target.FindExpressionTypeForLanguage("", language, error)
+        self.assertFalse(error.Success(), "empty type name for search.")
+        self.assertFalse(type.IsValid(), "Type is also invalid.")
+        type = target.FindExpressionTypeForLanguage(
+            "doesnt_start_with_dollar", language, error
+        )
+        self.assertFalse(error.Success(), "Can't find names that don't exist.")
+        self.assertFalse(type.IsValid(), "Type is also invalid.")
+
+    def values_test(self):
+        (target, _, _, _) = lldbutil.run_to_source_breakpoint(
+            self, "Set a breakpoint here", self.main_source_file
+        )
+
+        type_name = "struct $MyStruct"
+        value_name = "$my_struct"
+        self.expect("expr int $my_int = 100")
+        self.expect('expr char *$my_char_ptr = "Some char pointer."')
+        self.expect(
+            f"expr {type_name} {{int a; int b;}}; {type_name} {value_name} = {{10, 20}}"
+        )
+
+        # Now try to find one:
+        language = lldb.eLanguageTypeC_plus_plus
+
+        value = target.FindExpressionVariableForLanguage(value_name, language)
+
+        self.assertTrue(value.IsValid(), "Got a valid SBValue")
+        self.assertSuccess(value.GetError(), "Got no errors")
+
+        value_checker = ValueCheck(
+            name=value_name,
+            type=type_name,
+            children=[
+                ValueCheck(name="a", type="int", value="10"),
+                ValueCheck(name="b", type="int", value="20"),
+            ],
+        )
+        value_checker.check_value(self, value, "Found the right value")
+
+        # Also test that errors are set correctly:
+        value = target.FindExpressionVariableForLanguage(
+            value_name, lldb.eLanguageTypeUnknown
+        )
+        self.assertFalse(value.error.Success(), "unknown can't compile expressions")
+        value = target.FindExpressionVariableForLanguage(None, language)
+        self.assertFalse(value.error.Success(), "reject empty expression variable name")
+        value = target.FindExpressionVariableForLanguage(
+            "doesnt_start_with_dollar", language
+        )
+        self.assertFalse(value.error.Success(), "error on unknown variable name")

--- a/lldb/test/API/python_api/persistent_decls/main.c
+++ b/lldb/test/API/python_api/persistent_decls/main.c
@@ -1,0 +1,4 @@
+int main() {
+  int test_var = 10; // Set a breakpoint here
+  return test_var;
+}


### PR DESCRIPTION
In responding to the question here:

https://discourse.llvm.org/t/creating-nested-synthetic-children/90997/3

it became clear that getting the persistent variable/type results from the expression parser was much harder than it needed to be.  I filed a couple issues for this:

https://github.com/llvm/llvm-project/issues/201952
https://github.com/llvm/llvm-project/issues/201949

though after thinking about this a bit more, I decided to go with dedicated API for getting Persistent Expression variables & types.  We don't allow redefinitions of persistent variables and types within the same Target, so a "FirstType" API didn't make sense, nor did one returning a list of types or values.  

Plus, this will be easier to discover.