### PR TITLE
[XRay][Hexagon] Fix immext encoding of high bits in sled patcher

### DIFF
--- a/compiler-rt/lib/xray/xray_hexagon.cpp
+++ b/compiler-rt/lib/xray/xray_hexagon.cpp
@@ -76,7 +76,11 @@ encodeConstantExtender(uint32_t Imm) XRAY_NEVER_INSTRUMENT {
   // constant:
   Imm = Imm >> 6;
 
-  const uint32_t high = (Imm & IMM_MASK_HIGH) << 16;
+  // The high 12 bits sit at bit positions [25:14] of the shifted constant;
+  // they must land in instruction bits [27:16], i.e. shifted left by 2 (not
+  // 16, which would overflow the word and drop the high bits -- breaking any
+  // constant above ~2^20, e.g. trampoline addresses in a PIE executable).
+  const uint32_t high = (Imm & IMM_MASK_HIGH) << 2;
   const uint32_t low = Imm & IMM_MASK_LOW;
 
   return PO_IMMEXT | high | PP_NOT_END | low;


### PR DESCRIPTION
encodeConstantExtender() places the high 12 bits of the 26-bit extension at the wrong offset (<<16 instead of <<2), dropping them for any constant above ~2^20. The runtime sled patcher then encodes a corrupted trampoline address for PIE executables (load base 0x08000000+), so the first patched function call jumps to a bogus address and crashes.