### PR TITLE
[MC][TableGen] Store itinerary cycles as uint8_t

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetSubtargetInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetSubtargetInfo.h
@@ -72,7 +72,7 @@ protected: // Can only create subclasses...
                       const MCWriteProcResEntry *WPR,
                       const MCWriteLatencyEntry *WL,
                       const MCReadAdvanceEntry *RA, const InstrStage *IS,
-                      const unsigned *OC, const unsigned *FP);
+                      const uint8_t *OC, const uint8_t *FP);
 
 public:
   // AntiDepBreakMode - Type of anti-dependence breaking that should

--- a/llvm/include/llvm/MC/MCInstrItineraries.h
+++ b/llvm/include/llvm/MC/MCInstrItineraries.h
@@ -17,6 +17,7 @@
 
 #include "llvm/MC/MCSchedule.h"
 #include <algorithm>
+#include <cstdint>
 #include <optional>
 
 namespace llvm {
@@ -112,16 +113,16 @@ public:
   MCSchedModel SchedModel =
       MCSchedModel::Default;               ///< Basic machine properties.
   const InstrStage *Stages = nullptr;      ///< Array of stages selected
-  const unsigned *OperandCycles = nullptr; ///< Array of operand cycles selected
-  const unsigned *Forwardings = nullptr; ///< Array of pipeline forwarding paths
+  const uint8_t *OperandCycles = nullptr;  ///< Array of operand cycles selected
+  const uint8_t *Forwardings = nullptr; ///< Array of pipeline forwarding paths
   const InstrItinerary *Itineraries =
       nullptr; ///< Array of itineraries selected
 
   InstrItineraryData() = default;
   InstrItineraryData(const MCSchedModel &SM, const InstrStage *S,
-                     const unsigned *OS, const unsigned *F)
-    : SchedModel(SM), Stages(S), OperandCycles(OS), Forwardings(F),
-      Itineraries(SchedModel.InstrItineraries) {}
+                     const uint8_t *OS, const uint8_t *F)
+      : SchedModel(SM), Stages(S), OperandCycles(OS), Forwardings(F),
+        Itineraries(SchedModel.InstrItineraries) {}
 
   /// Returns true if there are no itineraries.
   bool isEmpty() const { return Itineraries == nullptr; }

--- a/llvm/include/llvm/MC/MCSubtargetInfo.h
+++ b/llvm/include/llvm/MC/MCSubtargetInfo.h
@@ -89,8 +89,8 @@ class LLVM_ABI MCSubtargetInfo {
   const MCSchedModel *CPUSchedModel;
 
   const InstrStage *Stages;            // Instruction itinerary stages
-  const unsigned *OperandCycles;       // Itinerary operand cycles
-  const unsigned *ForwardingPaths;
+  const uint8_t *OperandCycles;        // Itinerary operand cycles
+  const uint8_t *ForwardingPaths;
   FeatureBitset FeatureBits;           // Feature bits for current CPU + FS
   std::string FeatureString;           // Feature string
 
@@ -102,7 +102,7 @@ public:
                   ArrayRef<SubtargetSubTypeKV> PD,
                   const MCWriteProcResEntry *WPR, const MCWriteLatencyEntry *WL,
                   const MCReadAdvanceEntry *RA, const InstrStage *IS,
-                  const unsigned *OC, const unsigned *FP);
+                  const uint8_t *OC, const uint8_t *FP);
   MCSubtargetInfo() = delete;
   MCSubtargetInfo &operator=(const MCSubtargetInfo &) = delete;
   MCSubtargetInfo &operator=(MCSubtargetInfo &&) = delete;

--- a/llvm/include/llvm/Target/TargetItinerary.td
+++ b/llvm/include/llvm/Target/TargetItinerary.td
@@ -89,9 +89,10 @@ def NoItinerary : InstrItinClass;
 // global IssueWidth property, which constrains the number of microops
 // that can issue per cycle.
 //
-// OperandCycles are optional "cycle counts". They specify the cycle after
-// instruction issue the values which correspond to specific operand indices
-// are defined or read. Bypasses are optional "pipeline forwarding paths", if
+// OperandCycles are optional "cycle counts" between 0 and 255. They specify
+// the cycle after instruction issue the values which correspond to specific
+// operand indices are defined or read. Bypasses are optional "pipeline
+// forwarding paths". ProcessorItineraries supports at most eight Bypasses. If
 // a def by an instruction is available on a specific bypass and the use can
 // read from the same bypass, then the operand use latency is reduced by one.
 //
@@ -159,4 +160,3 @@ class ComboFuncData<FuncUnit ComboFunc, list<FuncUnit> funclist> {
 class ComboFuncUnits<list<ComboFuncData> cfd> {
   list<ComboFuncData> CFD = cfd;
 }
-

--- a/llvm/lib/CodeGen/TargetSubtargetInfo.cpp
+++ b/llvm/lib/CodeGen/TargetSubtargetInfo.cpp
@@ -19,7 +19,7 @@ TargetSubtargetInfo::TargetSubtargetInfo(
     ArrayRef<StringRef> PN, ArrayRef<SubtargetFeatureKV> PF,
     ArrayRef<SubtargetSubTypeKV> PD, const MCWriteProcResEntry *WPR,
     const MCWriteLatencyEntry *WL, const MCReadAdvanceEntry *RA,
-    const InstrStage *IS, const unsigned *OC, const unsigned *FP)
+    const InstrStage *IS, const uint8_t *OC, const uint8_t *FP)
     : MCSubtargetInfo(TT, CPU, TuneCPU, FS, PN, PF, PD, WPR, WL, RA, IS, OC,
                       FP) {}
 

--- a/llvm/lib/MC/MCSubtargetInfo.cpp
+++ b/llvm/lib/MC/MCSubtargetInfo.cpp
@@ -259,7 +259,7 @@ MCSubtargetInfo::MCSubtargetInfo(
     ArrayRef<StringRef> PN, ArrayRef<SubtargetFeatureKV> PF,
     ArrayRef<SubtargetSubTypeKV> PD, const MCWriteProcResEntry *WPR,
     const MCWriteLatencyEntry *WL, const MCReadAdvanceEntry *RA,
-    const InstrStage *IS, const unsigned *OC, const unsigned *FP)
+    const InstrStage *IS, const uint8_t *OC, const uint8_t *FP)
     : TargetTriple(TT), CPU(std::string(C)), TuneCPU(std::string(TC)),
       ProcNames(PN), ProcFeatures(PF), ProcDesc(PD), WriteProcResTable(WPR),
       WriteLatencyTable(WL), ReadAdvanceTable(RA), Stages(IS),

--- a/llvm/test/TableGen/SubtargetItineraryU8.td
+++ b/llvm/test/TableGen/SubtargetItineraryU8.td
@@ -1,0 +1,90 @@
+// RUN: llvm-tblgen -gen-subtarget -I %p/../../include %s -o - | FileCheck %s
+// RUN: not llvm-tblgen -gen-subtarget -I %p/../../include %s -DNEGATIVE_CYCLE -o - 2>&1 | FileCheck %s --check-prefix=INVALID-CYCLE
+// RUN: not llvm-tblgen -gen-subtarget -I %p/../../include %s -DLARGE_CYCLE -o - 2>&1 | FileCheck %s --check-prefix=INVALID-CYCLE
+// RUN: not llvm-tblgen -gen-subtarget -I %p/../../include %s -DTOO_MANY_BYPASSES -o - 2>&1 | FileCheck %s --check-prefix=TOO-MANY-BYPASSES
+// RUN: not llvm-tblgen -gen-subtarget -I %p/../../include %s -DTOO_MANY_BYPASSES_WITHOUT_FU -o - 2>&1 | FileCheck %s --check-prefix=TOO-MANY-BYPASSES
+
+include "llvm/Target/Target.td"
+
+def TestTarget : Target;
+
+def TestFU : FuncUnit;
+def TestItinClass : InstrItinClass;
+def TestInst : Instruction {
+  let OutOperandList = (outs);
+  let InOperandList = (ins);
+  let Itinerary = TestItinClass;
+}
+
+def TestBP0 : Bypass;
+def TestBP1 : Bypass;
+def TestBP2 : Bypass;
+def TestBP3 : Bypass;
+def TestBP4 : Bypass;
+def TestBP5 : Bypass;
+def TestBP6 : Bypass;
+def TestBP7 : Bypass;
+
+#ifdef TOO_MANY_BYPASSES
+def TestBP8 : Bypass;
+def TestItinData
+    : InstrItinData<TestItinClass, [InstrStage<1, [TestFU]>], [1],
+                    [TestBP8]>;
+def TestItineraries
+    : ProcessorItineraries<[TestFU],
+                           [TestBP0, TestBP1, TestBP2, TestBP3, TestBP4,
+                            TestBP5, TestBP6, TestBP7, TestBP8],
+                           [TestItinData]>;
+#else
+#ifdef TOO_MANY_BYPASSES_WITHOUT_FU
+def TestBP8 : Bypass;
+def TestItinData
+    : InstrItinData<TestItinClass, [InstrStage<1, [TestFU]>], [1],
+                    [TestBP8]>;
+def TestItineraries
+    : ProcessorItineraries<[],
+                           [TestBP0, TestBP1, TestBP2, TestBP3, TestBP4,
+                            TestBP5, TestBP6, TestBP7, TestBP8],
+                           [TestItinData]>;
+#else
+#ifdef NEGATIVE_CYCLE
+def TestItinData
+    : InstrItinData<TestItinClass, [InstrStage<1, [TestFU]>], [-1],
+                    [TestBP7]>;
+#else
+#ifdef LARGE_CYCLE
+def TestItinData
+    : InstrItinData<TestItinClass, [InstrStage<1, [TestFU]>], [4294967296],
+                    [TestBP7]>;
+#else
+def TestItinData
+    : InstrItinData<TestItinClass, [InstrStage<1, [TestFU]>], [255],
+                    [TestBP7]>;
+#endif
+#endif
+def TestItineraries
+    : ProcessorItineraries<[TestFU],
+                           [TestBP0, TestBP1, TestBP2, TestBP3, TestBP4,
+                            TestBP5, TestBP6, TestBP7],
+                           [TestItinData]>;
+#endif
+#endif
+
+def TestProcessor : Processor<"test", TestItineraries, []>;
+
+// CHECK: const uint8_t TestBP7 = 1 << 7;
+// CHECK: extern const uint8_t TestTargetOperandCycles[] = {
+// CHECK: 255,
+// CHECK: static_assert(sizeof(TestTargetOperandCycles) == 3);
+// CHECK: static_assert(255 <= static_cast<uint8_t>(-1));
+// CHECK: extern const uint8_t TestTargetForwardingPaths[] = {
+// CHECK: TestItinerariesBypass::TestBP7,
+// CHECK: static_assert(sizeof(TestTargetForwardingPaths) == 3);
+// CHECK: static_assert(sizeof(TestTargetForwardingPaths) == sizeof(TestTargetOperandCycles));
+// CHECK: static_assert((1U << 7) <= static_cast<uint8_t>(-1));
+// CHECK: const uint8_t *OC, const uint8_t *FP)
+// CHECK: extern const uint8_t TestTargetOperandCycles[];
+// CHECK: extern const uint8_t TestTargetForwardingPaths[];
+
+// INVALID-CYCLE: error: operand cycle must fit in a uint8_t
+// TOO-MANY-BYPASSES: error: at most eight itinerary bypasses are supported

--- a/llvm/utils/TableGen/SubtargetEmitter.cpp
+++ b/llvm/utils/TableGen/SubtargetEmitter.cpp
@@ -36,6 +36,7 @@
 #include <cassert>
 #include <cstdint>
 #include <iterator>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -93,7 +94,8 @@ class SubtargetEmitter : TargetFeaturesEmitter {
                                 unsigned &NStages);
   void formItineraryOperandCycleString(const Record *ItinData,
                                        std::string &ItinString,
-                                       unsigned &NOperandCycles);
+                                       unsigned &NOperandCycles,
+                                       int64_t &MaxOperandCycle);
   void formItineraryBypassString(const std::string &Names,
                                  const Record *ItinData,
                                  std::string &ItinString,
@@ -390,7 +392,8 @@ void SubtargetEmitter::formItineraryStageString(const std::string &Name,
 // number of operands that has cycles specified.
 //
 void SubtargetEmitter::formItineraryOperandCycleString(
-    const Record *ItinData, std::string &ItinString, unsigned &NOperandCycles) {
+    const Record *ItinData, std::string &ItinString, unsigned &NOperandCycles,
+    int64_t &MaxOperandCycle) {
   // Get operand cycle list
   std::vector<int64_t> OperandCycleList =
       ItinData->getValueAsListOfInts("OperandCycles");
@@ -398,7 +401,11 @@ void SubtargetEmitter::formItineraryOperandCycleString(
   // For each operand cycle
   NOperandCycles = OperandCycleList.size();
   ListSeparator LS;
-  for (int OCycle : OperandCycleList) {
+  for (int64_t OCycle : OperandCycleList) {
+    if (OCycle < 0 || OCycle > std::numeric_limits<uint8_t>::max())
+      PrintFatalError(ItinData->getLoc(),
+                      "operand cycle must fit in a uint8_t");
+    MaxOperandCycle = std::max(MaxOperandCycle, OCycle);
     // Next operand cycle
     ItinString += LS;
     ItinString += "  " + itostr(OCycle);
@@ -433,10 +440,18 @@ void SubtargetEmitter::emitStageAndOperandCycleData(
   // Multiple processor models may share an itinerary record. Emit it once.
   SmallPtrSet<const Record *, 8> ItinsDefSet;
 
+  unsigned MaxBypasses = 0;
+
   // Emit functional units for all the itineraries.
   for (const CodeGenProcModel &ProcModel : SchedModels.procModels()) {
     if (!ItinsDefSet.insert(ProcModel.ItinsDef).second)
       continue;
+
+    ConstRecVec BPs = ProcModel.ItinsDef->getValueAsListOfDefs("BP");
+    if (BPs.size() > 8)
+      PrintFatalError(ProcModel.ItinsDef->getLoc(),
+                      "at most eight itinerary bypasses are supported");
+    MaxBypasses = std::max(MaxBypasses, static_cast<unsigned>(BPs.size()));
 
     ConstRecVec FUs = ProcModel.ItinsDef->getValueAsListOfDefs("FU");
     if (FUs.empty())
@@ -452,15 +467,14 @@ void SubtargetEmitter::emitStageAndOperandCycleData(
            << Idx << ";\n";
     }
 
-    ConstRecVec BPs = ProcModel.ItinsDef->getValueAsListOfDefs("BP");
     if (BPs.empty())
       continue;
     OS << "\n// Pipeline forwarding paths for itineraries \"" << Name << "\"\n";
     NamespaceEmitter BypassNamespace(OS, (Name + Twine("Bypass")).str());
 
-    OS << "  const unsigned NoBypass = 0;\n";
+    OS << "  const uint8_t NoBypass = 0;\n";
     for (const auto &[Idx, BP] : enumerate(BPs))
-      OS << "  const unsigned " << BP->getName() << " = 1 << " << Idx << ";\n";
+      OS << "  const uint8_t " << BP->getName() << " = 1 << " << Idx << ";\n";
   }
 
   // Begin stages table
@@ -470,18 +484,19 @@ void SubtargetEmitter::emitStageAndOperandCycleData(
 
   // Begin operand cycle table
   std::string OperandCycleTable =
-      "extern const unsigned " + Target + "OperandCycles[] = {\n";
+      "extern const uint8_t " + Target + "OperandCycles[] = {\n";
   OperandCycleTable += "  0, // No itinerary\n";
 
   // Begin pipeline bypass table
   std::string BypassTable =
-      "extern const unsigned " + Target + "ForwardingPaths[] = {\n";
+      "extern const uint8_t " + Target + "ForwardingPaths[] = {\n";
   BypassTable += " 0, // No itinerary\n";
 
   // For each Itinerary across all processors, add a unique entry to the stages,
   // operand cycles, and pipeline bypass tables. Then add the new Itinerary
   // object with computed offsets to the ProcItinLists result.
   unsigned StageCount = 1, OperandCycleCount = 1;
+  int64_t MaxOperandCycle = 0;
   StringMap<unsigned> ItinStageMap, ItinOperandMap;
   for (const CodeGenProcModel &ProcModel : SchedModels.procModels()) {
     // Add process itinerary to the list.
@@ -516,7 +531,7 @@ void SubtargetEmitter::emitStageAndOperandCycleData(
       std::string ItinBypassString;
       if (ItinData) {
         formItineraryOperandCycleString(ItinData, ItinOperandCycleString,
-                                        NOperandCycles);
+                                        NOperandCycles, MaxOperandCycle);
 
         formItineraryBypassString(Name.str(), ItinData, ItinBypassString,
                                   NOperandCycles);
@@ -583,9 +598,22 @@ void SubtargetEmitter::emitStageAndOperandCycleData(
   // Closing operand cycles
   OperandCycleTable += "  0 // End operand cycles\n";
   OperandCycleTable += "};\n";
+  OperandCycleTable += "static_assert(sizeof(" + Target +
+                       "OperandCycles) == " + itostr(OperandCycleCount + 1) +
+                       ");\n";
+  OperandCycleTable += "static_assert(" + itostr(MaxOperandCycle) +
+                       " <= static_cast<uint8_t>(-1));\n";
 
   BypassTable += " 0 // End bypass tables\n";
   BypassTable += "};\n";
+  BypassTable += "static_assert(sizeof(" + Target +
+                 "ForwardingPaths) == " + itostr(OperandCycleCount + 1) +
+                 ");\n";
+  BypassTable += "static_assert(sizeof(" + Target +
+                 "ForwardingPaths) == sizeof(" + Target + "OperandCycles));\n";
+  if (MaxBypasses != 0)
+    BypassTable += "static_assert((1U << " + itostr(MaxBypasses - 1) +
+                   ") <= static_cast<uint8_t>(-1));\n";
 
   // Emit tables.
   OS << StageTable;
@@ -2010,7 +2038,7 @@ void SubtargetEmitter::emitGenMCSubtargetInfo(raw_ostream &OS) {
      << "    const MCWriteProcResEntry *WPR,\n"
      << "    const MCWriteLatencyEntry *WL,\n"
      << "    const MCReadAdvanceEntry *RA, const InstrStage *IS,\n"
-     << "    const unsigned *OC, const unsigned *FP) :\n"
+     << "    const uint8_t *OC, const uint8_t *FP) :\n"
      << "      MCSubtargetInfo(TT, CPU, TuneCPU, FS, PN, PF, PD,\n"
      << "                      WPR, WL, RA, IS, OC, FP) { }\n\n"
      << "  unsigned resolveVariantSchedClass(unsigned SchedClass,\n"
@@ -2202,8 +2230,8 @@ void SubtargetEmitter::emitCtor(raw_ostream &OS, unsigned NumNames,
 
   if (SchedModels.hasItineraries()) {
     OS << "extern const llvm::InstrStage " << Target << "Stages[];\n";
-    OS << "extern const unsigned " << Target << "OperandCycles[];\n";
-    OS << "extern const unsigned " << Target << "ForwardingPaths[];\n";
+    OS << "extern const uint8_t " << Target << "OperandCycles[];\n";
+    OS << "extern const uint8_t " << Target << "ForwardingPaths[];\n";
   }
 
   std::string ClassName = Target + "GenSubtargetInfo";


### PR DESCRIPTION
Store generated `OperandCycles` and `ForwardingPaths` as `uint8_t` after rejecting values outside the representable ranges, update `MCSubtargetInfo`, `TargetSubtargetInfo`, and generated constructors, and emit generated size and range `static_assert`s.

In an AppleClang Release build, the five target table pairs shrink from 214,000 to 53,500 bytes, standalone stripped `llc` and `llvm-mca` each shrink 148,592 bytes, and the stripped `llvm` multicall binary shrinks 165,120 bytes; `__TEXT,__const` shrinks 160,496 bytes with unchanged data sections and fixup counts.

Validation includes the full AArch64, ARM, Hexagon, Lanai, PowerPC, and Sparc build, all 420 TableGen tests, byte-identical Cortex-A9 output, and a 16-pair Cortex-A9 benchmark result of +0.272% CPU with a 95% confidence interval of [-1.239%, +1.806%].

Work towards #202616

AI tool disclosure: Co-authored with OpenAI Codex.
