### PR TITLE
[MLIR] Use internal shell for standalone tests

### DIFF
--- a/mlir/examples/standalone/test/lit.cfg.py
+++ b/mlir/examples/standalone/test/lit.cfg.py
@@ -18,7 +18,7 @@ from lit.llvm.subst import FindTool
 # name: The name of this test suite.
 config.name = "STANDALONE"
 
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest()
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = [".mlir"]


### PR DESCRIPTION
The external shell will be removed soon
(https://discourse.llvm.org/t/rfc-removal-of-the-lit-external-shell/90951), and this is one of the places where it hasn't been enabled by default. There are no test failures caused by this, so we can just turn it on by not explicitly setting execute_external as it defaults to False.