### PR TITLE
[cross-project-tests] Use lit internal shell

### DIFF
--- a/cross-project-tests/lit.cfg.py
+++ b/cross-project-tests/lit.cfg.py
@@ -16,7 +16,7 @@ from lit.llvm.subst import ToolSubst
 config.name = "cross-project-tests"
 
 # testFormat: The test format to use to interpret tests.
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest()
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = [".c", ".cl", ".cpp", ".m", ".test"]


### PR DESCRIPTION
The external shell will be going away soon and this doesn't cause any test failures, so we should just switch over to it. Not doing this also blocks deprecation of the external shell.