### PR TITLE
AMDGPU: Remove AMDGPUbfm

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUInstrInfo.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstrInfo.td
@@ -315,9 +315,6 @@ def AMDGPUbfe_i32_impl : SDNode<"AMDGPUISD::BFE_I32", AMDGPUDTIntTernaryOp>;
 // (src0 & src1) | (~src0 & src2)
 def AMDGPUbfi : SDNode<"AMDGPUISD::BFI", AMDGPUDTIntTernaryOp>;
 
-// Insert a range of bits into a 32-bit word.
-def AMDGPUbfm : SDNode<"AMDGPUISD::BFM", SDTIntBinOp>;
-
 // ctlz with -1 if input is zero.
 def AMDGPUffbh_u32_impl : SDNode<"AMDGPUISD::FFBH_U32", SDTIntBitCountUnaryOp>;
 

--- a/llvm/lib/Target/AMDGPU/EvergreenInstructions.td
+++ b/llvm/lib/Target/AMDGPU/EvergreenInstructions.td
@@ -489,10 +489,7 @@ def : AMDGPUPat <
                 $src1), sub1)
 >;
 
-def BFM_INT_eg : R600_2OP <0xA0, "BFM_INT",
-  [(set i32:$dst, (AMDGPUbfm i32:$src0, i32:$src1))],
-  VecALU
->;
+def BFM_INT_eg : R600_2OP <0xA0, "BFM_INT", [], VecALU>;
 
 def MULADD_UINT24_eg : R600_3OP <0x10, "MULADD_UINT24",
   [(set i32:$dst, (AMDGPUmad_u24 i32:$src0, i32:$src1, i32:$src2))], VecALU

--- a/llvm/lib/Target/AMDGPU/SOPInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SOPInstructions.td
@@ -855,8 +855,7 @@ def S_ASHR_I64 : SOP2_64_32 <"s_ashr_i64",
 } // End Defs = [SCC]
 
 let isReMaterializable = 1 in {
-def S_BFM_B32 : SOP2_32 <"s_bfm_b32",
-  [(set i32:$sdst, (UniformBinFrag<AMDGPUbfm> i32:$src0, i32:$src1))]>;
+def S_BFM_B32 : SOP2_32 <"s_bfm_b32">;
 def S_BFM_B64 : SOP2_64_32_32 <"s_bfm_b64">;
 
 def S_MUL_I32 : SOP2_32 <"s_mul_i32",


### PR DESCRIPTION
It wasn't actually used. We select [SV]_BFM_B32 by directly matching
shift-based patterns.