### PR TITLE
Revert "[Compiler-rt][test] Fix circular link dependency between builtins and libc"

### DIFF
--- a/compiler-rt/test/builtins/Unit/lit.cfg.py
+++ b/compiler-rt/test/builtins/Unit/lit.cfg.py
@@ -107,9 +107,7 @@ else:
     if config.target_os == "Haiku":
         config.substitutions.append(("%librt ", base_lib + " -lroot "))
     else:
-        config.substitutions.append(
-            ("%librt ", "-lm -Wl,--start-group " + base_lib + " -lc -Wl,--end-group ")
-        )
+        config.substitutions.append(("%librt ", base_lib + " -lc -lm "))
 
 builtins_test_crt = get_required_attr(config, "builtins_test_crt")
 if builtins_test_crt:


### PR DESCRIPTION
Reverts llvm/llvm-project#199482  due to failures when it's used on platforms with non-ELF linkers. The patch needs additional guards, but it's not immediately clear which platform linkers support the required options.