### PR TITLE
[flang][cuda] Fix device reduction intrinsics shadowed by gpu_reductions

### DIFF
--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -3054,6 +3054,20 @@ const Symbol *ExpressionAnalyzer::ResolveForward(const Symbol &symbol) {
 
 // Resolve a call to a generic procedure with given actual arguments.
 // adjustActuals is called on procedure bindings to handle pass arg.
+static bool IsCudaDeviceIntrinsicShadowedByGpuReductions(
+    const parser::CharBlock &callSite, semantics::SemanticsContext &context,
+    const Symbol *resolution) {
+  if (!resolution || !semantics::FindCUDADeviceContext(
+                         &context.FindScope(callSite))) {
+    return false;
+  }
+  const Symbol &ultimate{resolution->GetUltimate()};
+  const semantics::Scope &owner{ultimate.owner()};
+  return owner.IsModule() && owner.GetName() &&
+      parser::ToLowerCaseLetters(owner.GetName()->ToString()) ==
+      "gpu_reductions";
+}
+
 auto ExpressionAnalyzer::ResolveGeneric(const Symbol &symbol,
     const ActualArguments &actuals, const AdjustActuals &adjustActuals,
     bool isSubroutine, SymbolVector &&tried, bool mightBeStructureConstructor)
@@ -3307,6 +3321,18 @@ auto ExpressionAnalyzer::GetCalleeAndArguments(const parser::Name &name,
     resolution = result.specific;
     dueToAmbiguity = result.failedDueToAmbiguity;
     tried = std::move(result.tried);
+    if (IsCudaDeviceIntrinsicShadowedByGpuReductions(
+            name.source, context_, resolution)) {
+      ActualArguments localArguments{arguments};
+      if (std::optional<SpecificCall> specificCall{context_.intrinsics().Probe(
+              CallCharacteristics{ultimate.name().ToString(), isSubroutine},
+              localArguments, GetFoldingContext())}) {
+        CheckBadExplicitType(*specificCall, *symbol);
+        return CalleeAndArguments{
+            ProcedureDesignator{std::move(specificCall->specificIntrinsic)},
+            std::move(specificCall->arguments)};
+      }
+    }
     if (resolution) {
       if (context_.GetPPCBuiltinsScope() &&
           resolution->name().ToString().rfind("__ppc_", 0) == 0) {

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -3065,8 +3065,8 @@ static bool IsCudaGpuReductionsModule(const semantics::Scope &scope) {
 static bool IsCudaDeviceIntrinsicShadowedByGpuReductions(
     const parser::CharBlock &callSite, semantics::SemanticsContext &context,
     const Symbol *resolution) {
-  if (!resolution || !semantics::FindCUDADeviceContext(
-                         &context.FindScope(callSite))) {
+  if (!resolution ||
+      !semantics::FindCUDADeviceContext(&context.FindScope(callSite))) {
     return false;
   }
   const Symbol &ultimate{resolution->GetUltimate()};

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -3054,6 +3054,14 @@ const Symbol *ExpressionAnalyzer::ResolveForward(const Symbol &symbol) {
 
 // Resolve a call to a generic procedure with given actual arguments.
 // adjustActuals is called on procedure bindings to handle pass arg.
+static bool IsCudaGpuReductionsModule(const semantics::Scope &scope) {
+  // gpu_reductions is the CUDA runtime module whose host-side wrappers share
+  // names with reduction intrinsics.
+  return scope.IsModule() && scope.GetName() &&
+      parser::ToLowerCaseLetters(scope.GetName()->ToString()) ==
+      "gpu_reductions";
+}
+
 static bool IsCudaDeviceIntrinsicShadowedByGpuReductions(
     const parser::CharBlock &callSite, semantics::SemanticsContext &context,
     const Symbol *resolution) {
@@ -3063,9 +3071,7 @@ static bool IsCudaDeviceIntrinsicShadowedByGpuReductions(
   }
   const Symbol &ultimate{resolution->GetUltimate()};
   const semantics::Scope &owner{ultimate.owner()};
-  return owner.IsModule() && owner.GetName() &&
-      parser::ToLowerCaseLetters(owner.GetName()->ToString()) ==
-      "gpu_reductions";
+  return IsCudaGpuReductionsModule(owner);
 }
 
 auto ExpressionAnalyzer::ResolveGeneric(const Symbol &symbol,

--- a/flang/test/Semantics/cuf28.cuf
+++ b/flang/test/Semantics/cuf28.cuf
@@ -1,0 +1,69 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+
+! CUDA Fortran exposes host-side reduction wrappers through cudafor's
+! gpu_reductions use association. In device code, the intrinsic lowering path
+! must still win so these calls do not become calls to host wrappers.
+module gpu_reductions
+  interface sum
+    function fake_sum(array_d) result(res)
+      real(8), device :: array_d(:)
+      real(8) :: res
+    end function
+  end interface
+  interface maxval
+    function fake_maxval(array_d) result(res)
+      real(8), device :: array_d(:)
+      real(8) :: res
+    end function
+  end interface
+  interface minval
+    function fake_minval(array_d) result(res)
+      real(8), device :: array_d(:)
+      real(8) :: res
+    end function
+  end interface
+  interface maxloc
+    function fake_maxloc(array_d, dim) result(res)
+      real(8), device :: array_d(:)
+      integer :: dim
+      integer :: res
+    end function
+  end interface
+  interface minloc
+    function fake_minloc(array_d, dim) result(res)
+      real(8), device :: array_d(:)
+      integer :: dim
+      integer :: res
+    end function
+  end interface
+  interface host_wrapper
+    function fake_host_wrapper(array_d) result(res)
+      real(8), device :: array_d(:)
+      real(8) :: res
+    end function
+  end interface
+end module
+
+module cudafor
+  use gpu_reductions
+end module
+
+module test
+  use cudafor
+contains
+  attributes(global) subroutine reduction_intrinsics(a, locs, vals)
+    real(8), intent(in) :: a(3)
+    integer, intent(out) :: locs(2)
+    real(8), intent(out) :: vals(3)
+    real(8) :: local(3)
+
+    local = a
+    locs(1) = maxloc(local, 1)
+    locs(2) = minloc(local, 1)
+    vals(1) = sum(local)
+    vals(2) = maxval(local)
+    vals(3) = minval(local)
+    !ERROR: 'fake_host_wrapper' may not be called in device code
+    vals(1) = host_wrapper(local)
+  end subroutine
+end module


### PR DESCRIPTION
In CUDA device code, `use cudafor` can make reduction intrinsics such as maxloc and minloc resolve to host-side gpu_reductions wrappers, which are then rejected as non-device-callable. Prefer intrinsic resolution when a gpu_reductions specific shadows a valid intrinsic in device context, while preserving normal host-side wrapper resolution.