### PR TITLE
[clang][Frontend] Table-drive compiler option dumping

### DIFF
--- a/clang/lib/Frontend/FrontendActions.cpp
+++ b/clang/lib/Frontend/FrontendActions.cpp
@@ -1165,6 +1165,23 @@ void PrintPreambleAction::ExecuteAction() {
   }
 }
 
+static void writeCompilerOptionValues(raw_ostream &OS,
+                                      StringRef CompilerOptionNames,
+                                      ArrayRef<bool> CompilerOptionValues) {
+  bool FirstValue = true;
+  for (bool CompilerOptionValue : CompilerOptionValues) {
+    auto [CompilerOptionName, RemainingCompilerOptionNames] =
+        CompilerOptionNames.split('\0');
+    CompilerOptionNames = RemainingCompilerOptionNames;
+    if (!FirstValue)
+      OS << ",\n";
+    FirstValue = false;
+    OS << "\t{\"" << CompilerOptionName
+       << "\" : " << (CompilerOptionValue ? "true" : "false") << "}";
+  }
+  assert(CompilerOptionNames.empty() && "compiler option name count mismatch");
+}
+
 void DumpCompilerOptionsAction::ExecuteAction() {
   CompilerInstance &CI = getCompilerInstance();
   std::unique_ptr<raw_ostream> OSP =
@@ -1184,29 +1201,32 @@ void DumpCompilerOptionsAction::ExecuteAction() {
   OS << "{\n";
   OS << "\n\"features\" : [\n";
   {
-    llvm::SmallString<128> Str;
-#define FEATURE(Name, Predicate)                                               \
-  ("\t{\"" #Name "\" : " + llvm::Twine(Predicate ? "true" : "false") + "},\n") \
-      .toVector(Str);
+    static constexpr char FeatureNames[] = {
+#define FEATURE(Name, Predicate) #Name "\0"
 #include "clang/Basic/Features.def"
-#undef FEATURE
-    // Remove the newline and comma from the last entry to ensure this remains
-    // valid JSON.
-    OS << Str.substr(0, Str.size() - 2);
+    };
+    const bool FeatureValues[] = {
+#define FEATURE(Name, Predicate) static_cast<bool>(Predicate),
+#include "clang/Basic/Features.def"
+    };
+    writeCompilerOptionValues(
+        OS, StringRef(FeatureNames, sizeof(FeatureNames) - 1), FeatureValues);
   }
   OS << "\n],\n";
 
   OS << "\n\"extensions\" : [\n";
   {
-    llvm::SmallString<128> Str;
-#define EXTENSION(Name, Predicate)                                             \
-  ("\t{\"" #Name "\" : " + llvm::Twine(Predicate ? "true" : "false") + "},\n") \
-      .toVector(Str);
+    static constexpr char ExtensionNames[] = {
+#define EXTENSION(Name, Predicate) #Name "\0"
 #include "clang/Basic/Features.def"
-#undef EXTENSION
-    // Remove the newline and comma from the last entry to ensure this remains
-    // valid JSON.
-    OS << Str.substr(0, Str.size() - 2);
+    };
+    const bool ExtensionValues[] = {
+#define EXTENSION(Name, Predicate) static_cast<bool>(Predicate),
+#include "clang/Basic/Features.def"
+    };
+    writeCompilerOptionValues(
+        OS, StringRef(ExtensionNames, sizeof(ExtensionNames) - 1),
+        ExtensionValues);
   }
   OS << "\n]\n";
 

--- a/clang/test/Frontend/compiler-options-dump.cpp
+++ b/clang/test/Frontend/compiler-options-dump.cpp
@@ -1,6 +1,7 @@
 // RUN: %clang_cc1 -compiler-options-dump -std=c++03 %s -o - | FileCheck %s --check-prefix=CXX03
 // RUN: %clang_cc1 -compiler-options-dump -std=c++17 %s -o - | FileCheck %s --check-prefix=CXX17
 // RUN: %clang_cc1 -compiler-options-dump -std=c99 -x c %s -o - | FileCheck %s --check-prefix=C99
+// RUN: %clang_cc1 -compiler-options-dump -std=c++17 %s -o - | %python -c 'import json, sys; json.load(sys.stdin)'
 
 // CXX03: "features"
 // CXX03: "cxx_auto_type" : false


### PR DESCRIPTION
`Features.def` currently expands 228 feature formatting expressions and 49 extension formatting expressions in `DumpCompilerOptionsAction::ExecuteAction`. This stores the names in NUL-separated character blobs, evaluates the predicates into local `bool` arrays, and formats both arrays with `writeCompilerOptionValues`.

In a Release arm64 build, standalone clang decreases by 49,256 bytes unstripped and 49,520 bytes stripped, while the LLVM multicall binary decreases by 49,264 bytes unstripped and 49,528 bytes stripped; linked `__text` decreases by 52,696 bytes and linked fixups decrease by 7.

Work towards #202616

AI tool disclosure: Co-authored with OpenAI Codex.
