### PR TITLE
[Support][ScopedPrinter] Remove unused printVersion

### DIFF
--- a/llvm/include/llvm/Support/ScopedPrinter.h
+++ b/llvm/include/llvm/Support/ScopedPrinter.h
@@ -284,14 +284,6 @@ public:
     startLine() << Label << ": " << (Value ? "Yes" : "No") << '\n';
   }
 
-  template <typename T, typename... TArgs>
-  void printVersion(StringRef Label, T MajorVersion, TArgs... MinorVersions) {
-    startLine() << Label << ": ";
-    getOStream() << MajorVersion;
-    ((getOStream() << '.' << MinorVersions), ...);
-    getOStream() << "\n";
-  }
-
   template <typename T>
   void printList(StringRef Label, const ArrayRef<T> List) {
     SmallVector<std::string, 10> StringList;

--- a/llvm/unittests/Support/ScopedPrinterTest.cpp
+++ b/llvm/unittests/Support/ScopedPrinterTest.cpp
@@ -731,15 +731,6 @@ False: No
   verifyAll(ExpectedOut, JSONExpectedOut, PrintFunc);
 }
 
-TEST_F(ScopedPrinterTest, PrintVersion) {
-  auto PrintFunc = [](ScopedPrinter &W) {
-    W.printVersion("Version", "123", "456", "789");
-  };
-  const char *ExpectedOut = R"(Version: 123.456.789
-)";
-  verifyScopedPrinter(ExpectedOut, PrintFunc);
-}
-
 TEST_F(ScopedPrinterTest, PrintList) {
   auto PrintFunc = [](ScopedPrinter &W) {
     const std::vector<uint64_t> EmptyList;


### PR DESCRIPTION
While I was working on #200069, I found that `ScopedPrinter::printVersion` is also broken for JSON output, as it does not have or use `JSONScopedPrinter` override. 

Luckily, this function has no real caller, so it might as well just be removed. 

A bit of history: 
- `printVersion` was added in  https://github.com/llvm/llvm-project/commit/cdd313ca1980 ("Use ScopedPrinter in llvm-pdbdump") to print PDB header versions. 
- Its only callers were removed in https://github.com/llvm/llvm-project/commit/b560fdf3b84e ([llvm-pdbutil] rewrite the "raw" output style), and it has had no users since except for its own unit test. 