### PR TITLE
[clang][bytecode] Check CarrayOutPtr in subcl more thorougly

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -984,7 +984,7 @@ static bool interp__builtin_carryop(InterpState &S, CodePtr OpPC,
   if (!popToAPSInt(S.Stk, LHST, LHS))
     return false;
 
-  if (CarryOutPtr.isDummy() || !CarryOutPtr.isBlockPointer())
+  if (!isReadable(CarryOutPtr))
     return false;
 
   APSInt CarryOut;

--- a/clang/test/AST/ByteCode/builtins.c
+++ b/clang/test/AST/ByteCode/builtins.c
@@ -37,3 +37,7 @@ const int compared = strcmp(_str, (const char *)_str2); // both-error {{initiali
 
 int ptrint = __builtin_bswap64("") == 0x1234 ? 1 : 0; // both-error {{incompatible pointer to integer conversion}} \
                                                       // both-error {{initializer element is not a compile-time constant}}
+
+void subclNonReadable() {
+  if(__builtin_subcl(0, 0, 0, &(*({ struct {} x; &x; }))) != 0) {} // both-error {{incompatible pointer types}}
+}


### PR DESCRIPTION
Use the local `isReadable` check.