### PR TITLE
[RISCV] Fix ensureDominates with successive defs

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVVectorPeephole.cpp
+++ b/llvm/lib/Target/RISCV/RISCVVectorPeephole.cpp
@@ -448,9 +448,11 @@ bool RISCVVectorPeephole::convertToUnmasked(MachineInstr &MI) const {
 }
 
 /// Given A and B are in the same MBB, returns true if A comes before B.
-static bool dominates(MachineBasicBlock::const_iterator A,
-                      MachineBasicBlock::const_iterator B) {
+static bool strictlyDominates(MachineBasicBlock::const_iterator A,
+                              MachineBasicBlock::const_iterator B) {
   assert(A->getParent() == B->getParent());
+  if (A == B)
+    return false;
   const MachineBasicBlock *MBB = A->getParent();
   auto MBBEnd = MBB->end();
   if (B == MBBEnd)
@@ -476,7 +478,8 @@ bool RISCVVectorPeephole::ensureDominates(ArrayRef<const MachineOperand *> Defs,
       continue;
 
     MachineInstr *Def = MRI->getVRegDef(MO->getReg());
-    if (Def->getParent() == Dest->getParent() && !dominates(Def, *Dest)) {
+    if (Def->getParent() == Dest->getParent() &&
+        !strictlyDominates(Def, *Dest)) {
       if (!RISCVInstrInfo::isSafeToMove(*Dest, *Def->getNextNode()))
         return false;
       Dest = Def->getNextNode();

--- a/llvm/test/CodeGen/RISCV/rvv/rvv-peephole-vmerge-vops.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/rvv-peephole-vmerge-vops.ll
@@ -1193,3 +1193,49 @@ entry:
   %7 = extractelement <vscale x 16 x i32> %4, i64 %6
   ret i32 %7
 }
+
+; Test case for https://github.com/llvm/llvm-project/issues/202894
+define i32 @pr202894(<vscale x 16 x i32> %0, <vscale x 16 x i1> %1, i32 %2, <vscale x 16 x ptr> %p) {
+; CHECK-LABEL: pr202894:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vsetivli zero, 1, e8, m1, ta, ma
+; CHECK-NEXT:    vmv1r.v v7, v0
+; CHECK-NEXT:    vl8re64.v v24, (a1)
+; CHECK-NEXT:    csrr a1, vlenb
+; CHECK-NEXT:    li a2, 1
+; CHECK-NEXT:    mv a3, a1
+; CHECK-NEXT:    bltu a1, a2, .LBB88_2
+; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    li a3, 1
+; CHECK-NEXT:  .LBB88_2:
+; CHECK-NEXT:    vsetvli a4, zero, e8, m1, ta, ma
+; CHECK-NEXT:    vmv.v.i v6, 0
+; CHECK-NEXT:    vmv1r.v v0, v7
+; CHECK-NEXT:    vsetvli zero, a3, e8, m1, ta, ma
+; CHECK-NEXT:    vsoxei64.v v6, (zero), v16, v0.t
+; CHECK-NEXT:    srli a3, a1, 3
+; CHECK-NEXT:    vsetvli a4, zero, e8, mf4, ta, ma
+; CHECK-NEXT:    vslidedown.vx v0, v7, a3
+; CHECK-NEXT:    sub a2, a2, a1
+; CHECK-NEXT:    sltiu a1, a2, 2
+; CHECK-NEXT:    neg a1, a1
+; CHECK-NEXT:    and a1, a1, a2
+; CHECK-NEXT:    vsetvli zero, a1, e8, m1, ta, ma
+; CHECK-NEXT:    vsoxei64.v v6, (zero), v24, v0.t
+; CHECK-NEXT:    vmv1r.v v0, v7
+; CHECK-NEXT:    sext.w a0, a0
+; CHECK-NEXT:    vsetvli zero, a0, e32, m8, ta, mu
+; CHECK-NEXT:    vadd.vv v8, v8, v8, v0.t
+; CHECK-NEXT:    addi a0, a0, -1
+; CHECK-NEXT:    vsetivli zero, 1, e32, m8, ta, ma
+; CHECK-NEXT:    vslidedown.vx v8, v8, a0
+; CHECK-NEXT:    vmv.x.s a0, v8
+; CHECK-NEXT:    ret
+  call void @llvm.vp.scatter(<vscale x 16 x i8> zeroinitializer, <vscale x 16 x ptr> %p, <vscale x 16 x i1> %1, i32 1)
+  %4 = zext <vscale x 16 x i1> %1 to <vscale x 16 x i32>
+  %5 = shl <vscale x 16 x i32> %0, %4
+  %6 = zext nneg i32 %2 to i64
+  %7 = add i64 %6, -1
+  %8 = extractelement <vscale x 16 x i32> %5, i64 %7
+  ret i32 %8
+}

--- a/llvm/test/CodeGen/RISCV/rvv/vmerge-peephole.mir
+++ b/llvm/test/CodeGen/RISCV/rvv/vmerge-peephole.mir
@@ -276,8 +276,8 @@ body: |
     ; CHECK-LABEL: name: sink_past_avl_mask_false
     ; CHECK: %false:vrnov0 = PseudoVADD_VV_M1 $noreg, $noreg, $noreg, -1 /* vl=VLMAX */, 5 /* e32 */, 3 /* ta, ma */
     ; CHECK-NEXT: %mask:vmv0 = COPY $v0
-    ; CHECK-NEXT: %z:vrnov0 = PseudoVADD_VV_M1_MASK %false, $noreg, $noreg, %mask, %avl /* vl */, 5 /* e32 */, 1 /* ta, mu */
     ; CHECK-NEXT: %avl:gprnox0 = ADDI $noreg, 1
+    ; CHECK-NEXT: %z:vrnov0 = PseudoVADD_VV_M1_MASK %false, $noreg, $noreg, %mask, %avl /* vl */, 5 /* e32 */, 1 /* ta, mu */
     %x:vrnov0 = PseudoVADD_VV_M1 $noreg, $noreg, $noreg, -1, 5, 3
     %false:vrnov0 = PseudoVADD_VV_M1 $noreg, $noreg, $noreg, -1, 5, 3
     %mask:vmv0 = COPY $v0

--- a/llvm/test/CodeGen/RISCV/rvv/vmerge-peephole.mir
+++ b/llvm/test/CodeGen/RISCV/rvv/vmerge-peephole.mir
@@ -269,3 +269,18 @@ body: |
     %avl:gprnox0 = ADDI $noreg, 1
     %z:vrnov0 = PseudoVMERGE_VVM_M1 $noreg, $noreg, %x:vrnov0, %mask, %avl, 5
 ...
+---
+name: sink_past_avl_mask_false
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: sink_past_avl_mask_false
+    ; CHECK: %false:vrnov0 = PseudoVADD_VV_M1 $noreg, $noreg, $noreg, -1 /* vl=VLMAX */, 5 /* e32 */, 3 /* ta, ma */
+    ; CHECK-NEXT: %mask:vmv0 = COPY $v0
+    ; CHECK-NEXT: %z:vrnov0 = PseudoVADD_VV_M1_MASK %false, $noreg, $noreg, %mask, %avl /* vl */, 5 /* e32 */, 1 /* ta, mu */
+    ; CHECK-NEXT: %avl:gprnox0 = ADDI $noreg, 1
+    %x:vrnov0 = PseudoVADD_VV_M1 $noreg, $noreg, $noreg, -1, 5, 3
+    %false:vrnov0 = PseudoVADD_VV_M1 $noreg, $noreg, $noreg, -1, 5, 3
+    %mask:vmv0 = COPY $v0
+    %avl:gprnox0 = ADDI $noreg, 1
+    %z:vrnov0 = PseudoVMERGE_VVM_M1 $noreg, %false:vrnov0, %x:vrnov0, %mask, %avl, 5
+...


### PR DESCRIPTION
In RISCVVectorPeephole when we want to sink a use so that it's below multiple defs, if the defs are beside each other then we will end up checking if !dominates(Dest, Dest). This should be !strictlyDominates(Dest, Dest), otherwise we don't sink the use far enough.

Fixes #202894

Co-authored-by: Pengcheng Wang <wangpengcheng.pp@bytedance.com>
