### PR TITLE
[Clang][RISCV] packed comparison intrinsics

### DIFF
--- a/clang/lib/Headers/riscv_packed_simd.h
+++ b/clang/lib/Headers/riscv_packed_simd.h
@@ -86,6 +86,12 @@ typedef uint32_t uint32x2_t __attribute__((__vector_size__(8)));
         __builtin_elementwise_add_sat(__rs1, __rs1), __rs2);                   \
   }
 
+#define __packed_cmp(name, ty, rty, op)                                        \
+  static __inline__ rty __DEFAULT_FN_ATTRS __riscv_##name(ty __rs1,            \
+                                                          ty __rs2) {          \
+    return (rty)(__rs1 op __rs2);                                              \
+  }
+
 // clang-format off: macro call sites have no trailing semicolons, which
 // confuses clang-format into a deeply nested expression.
 
@@ -213,6 +219,70 @@ __packed_binary_builtin(pmaxu_u8x8, uint8x8_t, __builtin_elementwise_max)
 __packed_binary_builtin(pmaxu_u16x4, uint16x4_t, __builtin_elementwise_max)
 __packed_binary_builtin(pmaxu_u32x2, uint32x2_t, __builtin_elementwise_max)
 
+/* Packed Comparison (32-bit) */
+__packed_cmp(pmseq_i8x4_u8x4, int8x4_t, uint8x4_t, ==)
+__packed_cmp(pmseq_u8x4_u8x4, uint8x4_t, uint8x4_t, ==)
+__packed_cmp(pmsne_i8x4_u8x4, int8x4_t, uint8x4_t, !=)
+__packed_cmp(pmsne_u8x4_u8x4, uint8x4_t, uint8x4_t, !=)
+__packed_cmp(pmslt_u8x4, int8x4_t, uint8x4_t, <)
+__packed_cmp(pmsltu_u8x4, uint8x4_t, uint8x4_t, <)
+__packed_cmp(pmsgt_u8x4, int8x4_t, uint8x4_t, >)
+__packed_cmp(pmsgtu_u8x4, uint8x4_t, uint8x4_t, >)
+__packed_cmp(pmsge_u8x4, int8x4_t, uint8x4_t, >=)
+__packed_cmp(pmsgeu_u8x4, uint8x4_t, uint8x4_t, >=)
+__packed_cmp(pmsle_u8x4, int8x4_t, uint8x4_t, <=)
+__packed_cmp(pmsleu_u8x4, uint8x4_t, uint8x4_t, <=)
+__packed_cmp(pmseq_i16x2_u16x2, int16x2_t, uint16x2_t, ==)
+__packed_cmp(pmseq_u16x2_u16x2, uint16x2_t, uint16x2_t, ==)
+__packed_cmp(pmsne_i16x2_u16x2, int16x2_t, uint16x2_t, !=)
+__packed_cmp(pmsne_u16x2_u16x2, uint16x2_t, uint16x2_t, !=)
+__packed_cmp(pmslt_u16x2, int16x2_t, uint16x2_t, <)
+__packed_cmp(pmsltu_u16x2, uint16x2_t, uint16x2_t, <)
+__packed_cmp(pmsgt_u16x2, int16x2_t, uint16x2_t, >)
+__packed_cmp(pmsgtu_u16x2, uint16x2_t, uint16x2_t, >)
+__packed_cmp(pmsge_u16x2, int16x2_t, uint16x2_t, >=)
+__packed_cmp(pmsgeu_u16x2, uint16x2_t, uint16x2_t, >=)
+__packed_cmp(pmsle_u16x2, int16x2_t, uint16x2_t, <=)
+__packed_cmp(pmsleu_u16x2, uint16x2_t, uint16x2_t, <=)
+
+/* Packed Comparison (64-bit) */
+__packed_cmp(pmseq_i8x8_u8x8, int8x8_t, uint8x8_t, ==)
+__packed_cmp(pmseq_u8x8_u8x8, uint8x8_t, uint8x8_t, ==)
+__packed_cmp(pmsne_i8x8_u8x8, int8x8_t, uint8x8_t, !=)
+__packed_cmp(pmsne_u8x8_u8x8, uint8x8_t, uint8x8_t, !=)
+__packed_cmp(pmslt_u8x8, int8x8_t, uint8x8_t, <)
+__packed_cmp(pmsltu_u8x8, uint8x8_t, uint8x8_t, <)
+__packed_cmp(pmsgt_u8x8, int8x8_t, uint8x8_t, >)
+__packed_cmp(pmsgtu_u8x8, uint8x8_t, uint8x8_t, >)
+__packed_cmp(pmsge_u8x8, int8x8_t, uint8x8_t, >=)
+__packed_cmp(pmsgeu_u8x8, uint8x8_t, uint8x8_t, >=)
+__packed_cmp(pmsle_u8x8, int8x8_t, uint8x8_t, <=)
+__packed_cmp(pmsleu_u8x8, uint8x8_t, uint8x8_t, <=)
+__packed_cmp(pmseq_i16x4_u16x4, int16x4_t, uint16x4_t, ==)
+__packed_cmp(pmseq_u16x4_u16x4, uint16x4_t, uint16x4_t, ==)
+__packed_cmp(pmsne_i16x4_u16x4, int16x4_t, uint16x4_t, !=)
+__packed_cmp(pmsne_u16x4_u16x4, uint16x4_t, uint16x4_t, !=)
+__packed_cmp(pmslt_u16x4, int16x4_t, uint16x4_t, <)
+__packed_cmp(pmsltu_u16x4, uint16x4_t, uint16x4_t, <)
+__packed_cmp(pmsgt_u16x4, int16x4_t, uint16x4_t, >)
+__packed_cmp(pmsgtu_u16x4, uint16x4_t, uint16x4_t, >)
+__packed_cmp(pmsge_u16x4, int16x4_t, uint16x4_t, >=)
+__packed_cmp(pmsgeu_u16x4, uint16x4_t, uint16x4_t, >=)
+__packed_cmp(pmsle_u16x4, int16x4_t, uint16x4_t, <=)
+__packed_cmp(pmsleu_u16x4, uint16x4_t, uint16x4_t, <=)
+__packed_cmp(pmseq_i32x2_u32x2, int32x2_t, uint32x2_t, ==)
+__packed_cmp(pmseq_u32x2_u32x2, uint32x2_t, uint32x2_t, ==)
+__packed_cmp(pmsne_i32x2_u32x2, int32x2_t, uint32x2_t, !=)
+__packed_cmp(pmsne_u32x2_u32x2, uint32x2_t, uint32x2_t, !=)
+__packed_cmp(pmslt_u32x2, int32x2_t, uint32x2_t, <)
+__packed_cmp(pmsltu_u32x2, uint32x2_t, uint32x2_t, <)
+__packed_cmp(pmsgt_u32x2, int32x2_t, uint32x2_t, >)
+__packed_cmp(pmsgtu_u32x2, uint32x2_t, uint32x2_t, >)
+__packed_cmp(pmsge_u32x2, int32x2_t, uint32x2_t, >=)
+__packed_cmp(pmsgeu_u32x2, uint32x2_t, uint32x2_t, >=)
+__packed_cmp(pmsle_u32x2, int32x2_t, uint32x2_t, <=)
+__packed_cmp(pmsleu_u32x2, uint32x2_t, uint32x2_t, <=)
+
 /* Packed Shifts (32-bit) */
 __packed_shift8(psll_s_u8x4, uint8x4_t, <<)
 __packed_shift8(psll_s_i8x4, int8x4_t, <<)
@@ -297,6 +367,7 @@ __packed_unary_op(pnot_u32x2, uint32x2_t, ~)
 #undef __packed_binary_builtin
 #undef __packed_sh1add
 #undef __packed_sh1sadd
+#undef __packed_cmp
 #undef __DEFAULT_FN_ATTRS
 
 #if defined(__cplusplus)

--- a/clang/test/CodeGen/RISCV/rvp-intrinsics.c
+++ b/clang/test/CodeGen/RISCV/rvp-intrinsics.c
@@ -2107,6 +2107,1450 @@ uint16x4_t test_pmaxu_u16x4(uint16x4_t a, uint16x4_t b) {
 uint32x2_t test_pmaxu_u32x2(uint32x2_t a, uint32x2_t b) {
   return __riscv_pmaxu_u32x2(a, b);
 }
+/* Packed Comparison (32-bit) */
+
+// RV32-LABEL: define dso_local i32 @test_pmseq_i8x4_u8x4(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp eq <4 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmseq_i8x4_u8x4(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp eq <4 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint8x4_t test_pmseq_i8x4_u8x4(int8x4_t a, int8x4_t b) {
+  return __riscv_pmseq_i8x4_u8x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pmseq_u8x4_u8x4(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp eq <4 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmseq_u8x4_u8x4(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp eq <4 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint8x4_t test_pmseq_u8x4_u8x4(uint8x4_t a, uint8x4_t b) {
+  return __riscv_pmseq_u8x4_u8x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pmsne_i8x4_u8x4(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ne <4 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmsne_i8x4_u8x4(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ne <4 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint8x4_t test_pmsne_i8x4_u8x4(int8x4_t a, int8x4_t b) {
+  return __riscv_pmsne_i8x4_u8x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pmsne_u8x4_u8x4(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ne <4 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmsne_u8x4_u8x4(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ne <4 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint8x4_t test_pmsne_u8x4_u8x4(uint8x4_t a, uint8x4_t b) {
+  return __riscv_pmsne_u8x4_u8x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pmslt_u8x4(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp slt <4 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmslt_u8x4(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp slt <4 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint8x4_t test_pmslt_u8x4(int8x4_t a, int8x4_t b) {
+  return __riscv_pmslt_u8x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pmsltu_u8x4(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ult <4 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmsltu_u8x4(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ult <4 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint8x4_t test_pmsltu_u8x4(uint8x4_t a, uint8x4_t b) {
+  return __riscv_pmsltu_u8x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pmsgt_u8x4(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp sgt <4 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmsgt_u8x4(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp sgt <4 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint8x4_t test_pmsgt_u8x4(int8x4_t a, int8x4_t b) {
+  return __riscv_pmsgt_u8x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pmsgtu_u8x4(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ugt <4 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmsgtu_u8x4(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ugt <4 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint8x4_t test_pmsgtu_u8x4(uint8x4_t a, uint8x4_t b) {
+  return __riscv_pmsgtu_u8x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pmsge_u8x4(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp sge <4 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmsge_u8x4(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp sge <4 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint8x4_t test_pmsge_u8x4(int8x4_t a, int8x4_t b) {
+  return __riscv_pmsge_u8x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pmsgeu_u8x4(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp uge <4 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmsgeu_u8x4(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp uge <4 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint8x4_t test_pmsgeu_u8x4(uint8x4_t a, uint8x4_t b) {
+  return __riscv_pmsgeu_u8x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pmsle_u8x4(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp sle <4 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmsle_u8x4(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp sle <4 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint8x4_t test_pmsle_u8x4(int8x4_t a, int8x4_t b) {
+  return __riscv_pmsle_u8x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pmsleu_u8x4(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ule <4 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmsleu_u8x4(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <4 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ule <4 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i8> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint8x4_t test_pmsleu_u8x4(uint8x4_t a, uint8x4_t b) {
+  return __riscv_pmsleu_u8x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pmseq_i16x2_u16x2(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp eq <2 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmseq_i16x2_u16x2(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp eq <2 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint16x2_t test_pmseq_i16x2_u16x2(int16x2_t a, int16x2_t b) {
+  return __riscv_pmseq_i16x2_u16x2(a, b);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pmseq_u16x2_u16x2(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp eq <2 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmseq_u16x2_u16x2(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp eq <2 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint16x2_t test_pmseq_u16x2_u16x2(uint16x2_t a, uint16x2_t b) {
+  return __riscv_pmseq_u16x2_u16x2(a, b);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pmsne_i16x2_u16x2(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ne <2 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmsne_i16x2_u16x2(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ne <2 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint16x2_t test_pmsne_i16x2_u16x2(int16x2_t a, int16x2_t b) {
+  return __riscv_pmsne_i16x2_u16x2(a, b);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pmsne_u16x2_u16x2(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ne <2 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmsne_u16x2_u16x2(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ne <2 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint16x2_t test_pmsne_u16x2_u16x2(uint16x2_t a, uint16x2_t b) {
+  return __riscv_pmsne_u16x2_u16x2(a, b);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pmslt_u16x2(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp slt <2 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmslt_u16x2(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp slt <2 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint16x2_t test_pmslt_u16x2(int16x2_t a, int16x2_t b) {
+  return __riscv_pmslt_u16x2(a, b);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pmsltu_u16x2(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ult <2 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmsltu_u16x2(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ult <2 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint16x2_t test_pmsltu_u16x2(uint16x2_t a, uint16x2_t b) {
+  return __riscv_pmsltu_u16x2(a, b);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pmsgt_u16x2(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp sgt <2 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmsgt_u16x2(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp sgt <2 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint16x2_t test_pmsgt_u16x2(int16x2_t a, int16x2_t b) {
+  return __riscv_pmsgt_u16x2(a, b);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pmsgtu_u16x2(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ugt <2 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmsgtu_u16x2(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ugt <2 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint16x2_t test_pmsgtu_u16x2(uint16x2_t a, uint16x2_t b) {
+  return __riscv_pmsgtu_u16x2(a, b);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pmsge_u16x2(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp sge <2 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmsge_u16x2(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp sge <2 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint16x2_t test_pmsge_u16x2(int16x2_t a, int16x2_t b) {
+  return __riscv_pmsge_u16x2(a, b);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pmsgeu_u16x2(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp uge <2 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmsgeu_u16x2(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp uge <2 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint16x2_t test_pmsgeu_u16x2(uint16x2_t a, uint16x2_t b) {
+  return __riscv_pmsgeu_u16x2(a, b);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pmsle_u16x2(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp sle <2 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmsle_u16x2(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp sle <2 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint16x2_t test_pmsle_u16x2(int16x2_t a, int16x2_t b) {
+  return __riscv_pmsle_u16x2(a, b);
+}
+
+// RV32-LABEL: define dso_local i32 @test_pmsleu_u16x2(
+// RV32-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ule <2 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV32-NEXT:    ret i32 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i32 @test_pmsleu_u16x2(
+// RV64-SAME: i32 noundef [[A_COERCE:%.*]], i32 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i32 [[A_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i32 [[B_COERCE]] to <2 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ule <2 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i16> [[SEXT_I]] to i32
+// RV64-NEXT:    ret i32 [[TMP2]]
+//
+uint16x2_t test_pmsleu_u16x2(uint16x2_t a, uint16x2_t b) {
+  return __riscv_pmsleu_u16x2(a, b);
+}
+
+/* Packed Comparison (64-bit) */
+
+// RV32-LABEL: define dso_local i64 @test_pmseq_i8x8_u8x8(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp eq <8 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmseq_i8x8_u8x8(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp eq <8 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint8x8_t test_pmseq_i8x8_u8x8(int8x8_t a, int8x8_t b) {
+  return __riscv_pmseq_i8x8_u8x8(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmseq_u8x8_u8x8(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp eq <8 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmseq_u8x8_u8x8(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp eq <8 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint8x8_t test_pmseq_u8x8_u8x8(uint8x8_t a, uint8x8_t b) {
+  return __riscv_pmseq_u8x8_u8x8(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsne_i8x8_u8x8(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ne <8 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsne_i8x8_u8x8(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ne <8 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint8x8_t test_pmsne_i8x8_u8x8(int8x8_t a, int8x8_t b) {
+  return __riscv_pmsne_i8x8_u8x8(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsne_u8x8_u8x8(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ne <8 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsne_u8x8_u8x8(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ne <8 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint8x8_t test_pmsne_u8x8_u8x8(uint8x8_t a, uint8x8_t b) {
+  return __riscv_pmsne_u8x8_u8x8(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmslt_u8x8(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp slt <8 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmslt_u8x8(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp slt <8 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint8x8_t test_pmslt_u8x8(int8x8_t a, int8x8_t b) {
+  return __riscv_pmslt_u8x8(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsltu_u8x8(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ult <8 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsltu_u8x8(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ult <8 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint8x8_t test_pmsltu_u8x8(uint8x8_t a, uint8x8_t b) {
+  return __riscv_pmsltu_u8x8(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsgt_u8x8(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp sgt <8 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsgt_u8x8(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp sgt <8 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint8x8_t test_pmsgt_u8x8(int8x8_t a, int8x8_t b) {
+  return __riscv_pmsgt_u8x8(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsgtu_u8x8(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ugt <8 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsgtu_u8x8(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ugt <8 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint8x8_t test_pmsgtu_u8x8(uint8x8_t a, uint8x8_t b) {
+  return __riscv_pmsgtu_u8x8(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsge_u8x8(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp sge <8 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsge_u8x8(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp sge <8 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint8x8_t test_pmsge_u8x8(int8x8_t a, int8x8_t b) {
+  return __riscv_pmsge_u8x8(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsgeu_u8x8(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp uge <8 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsgeu_u8x8(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp uge <8 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint8x8_t test_pmsgeu_u8x8(uint8x8_t a, uint8x8_t b) {
+  return __riscv_pmsgeu_u8x8(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsle_u8x8(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp sle <8 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsle_u8x8(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp sle <8 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint8x8_t test_pmsle_u8x8(int8x8_t a, int8x8_t b) {
+  return __riscv_pmsle_u8x8(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsleu_u8x8(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ule <8 x i8> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsleu_u8x8(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <8 x i8>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ule <8 x i8> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <8 x i1> [[CMP_I]] to <8 x i8>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <8 x i8> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint8x8_t test_pmsleu_u8x8(uint8x8_t a, uint8x8_t b) {
+  return __riscv_pmsleu_u8x8(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmseq_i16x4_u16x4(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp eq <4 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmseq_i16x4_u16x4(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp eq <4 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint16x4_t test_pmseq_i16x4_u16x4(int16x4_t a, int16x4_t b) {
+  return __riscv_pmseq_i16x4_u16x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmseq_u16x4_u16x4(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp eq <4 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmseq_u16x4_u16x4(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp eq <4 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint16x4_t test_pmseq_u16x4_u16x4(uint16x4_t a, uint16x4_t b) {
+  return __riscv_pmseq_u16x4_u16x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsne_i16x4_u16x4(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ne <4 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsne_i16x4_u16x4(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ne <4 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint16x4_t test_pmsne_i16x4_u16x4(int16x4_t a, int16x4_t b) {
+  return __riscv_pmsne_i16x4_u16x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsne_u16x4_u16x4(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ne <4 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsne_u16x4_u16x4(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ne <4 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint16x4_t test_pmsne_u16x4_u16x4(uint16x4_t a, uint16x4_t b) {
+  return __riscv_pmsne_u16x4_u16x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmslt_u16x4(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp slt <4 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmslt_u16x4(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp slt <4 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint16x4_t test_pmslt_u16x4(int16x4_t a, int16x4_t b) {
+  return __riscv_pmslt_u16x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsltu_u16x4(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ult <4 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsltu_u16x4(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ult <4 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint16x4_t test_pmsltu_u16x4(uint16x4_t a, uint16x4_t b) {
+  return __riscv_pmsltu_u16x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsgt_u16x4(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp sgt <4 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsgt_u16x4(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp sgt <4 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint16x4_t test_pmsgt_u16x4(int16x4_t a, int16x4_t b) {
+  return __riscv_pmsgt_u16x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsgtu_u16x4(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ugt <4 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsgtu_u16x4(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ugt <4 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint16x4_t test_pmsgtu_u16x4(uint16x4_t a, uint16x4_t b) {
+  return __riscv_pmsgtu_u16x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsge_u16x4(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp sge <4 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsge_u16x4(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp sge <4 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint16x4_t test_pmsge_u16x4(int16x4_t a, int16x4_t b) {
+  return __riscv_pmsge_u16x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsgeu_u16x4(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp uge <4 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsgeu_u16x4(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp uge <4 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint16x4_t test_pmsgeu_u16x4(uint16x4_t a, uint16x4_t b) {
+  return __riscv_pmsgeu_u16x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsle_u16x4(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp sle <4 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsle_u16x4(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp sle <4 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint16x4_t test_pmsle_u16x4(int16x4_t a, int16x4_t b) {
+  return __riscv_pmsle_u16x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsleu_u16x4(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ule <4 x i16> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsleu_u16x4(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <4 x i16>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ule <4 x i16> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <4 x i1> [[CMP_I]] to <4 x i16>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <4 x i16> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint16x4_t test_pmsleu_u16x4(uint16x4_t a, uint16x4_t b) {
+  return __riscv_pmsleu_u16x4(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmseq_i32x2_u32x2(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp eq <2 x i32> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmseq_i32x2_u32x2(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp eq <2 x i32> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint32x2_t test_pmseq_i32x2_u32x2(int32x2_t a, int32x2_t b) {
+  return __riscv_pmseq_i32x2_u32x2(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmseq_u32x2_u32x2(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp eq <2 x i32> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmseq_u32x2_u32x2(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp eq <2 x i32> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint32x2_t test_pmseq_u32x2_u32x2(uint32x2_t a, uint32x2_t b) {
+  return __riscv_pmseq_u32x2_u32x2(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsne_i32x2_u32x2(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ne <2 x i32> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsne_i32x2_u32x2(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ne <2 x i32> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint32x2_t test_pmsne_i32x2_u32x2(int32x2_t a, int32x2_t b) {
+  return __riscv_pmsne_i32x2_u32x2(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsne_u32x2_u32x2(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ne <2 x i32> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsne_u32x2_u32x2(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ne <2 x i32> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint32x2_t test_pmsne_u32x2_u32x2(uint32x2_t a, uint32x2_t b) {
+  return __riscv_pmsne_u32x2_u32x2(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmslt_u32x2(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp slt <2 x i32> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmslt_u32x2(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp slt <2 x i32> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint32x2_t test_pmslt_u32x2(int32x2_t a, int32x2_t b) {
+  return __riscv_pmslt_u32x2(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsltu_u32x2(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ult <2 x i32> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsltu_u32x2(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ult <2 x i32> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint32x2_t test_pmsltu_u32x2(uint32x2_t a, uint32x2_t b) {
+  return __riscv_pmsltu_u32x2(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsgt_u32x2(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp sgt <2 x i32> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsgt_u32x2(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp sgt <2 x i32> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint32x2_t test_pmsgt_u32x2(int32x2_t a, int32x2_t b) {
+  return __riscv_pmsgt_u32x2(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsgtu_u32x2(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ugt <2 x i32> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsgtu_u32x2(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ugt <2 x i32> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint32x2_t test_pmsgtu_u32x2(uint32x2_t a, uint32x2_t b) {
+  return __riscv_pmsgtu_u32x2(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsge_u32x2(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp sge <2 x i32> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsge_u32x2(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp sge <2 x i32> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint32x2_t test_pmsge_u32x2(int32x2_t a, int32x2_t b) {
+  return __riscv_pmsge_u32x2(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsgeu_u32x2(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp uge <2 x i32> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsgeu_u32x2(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp uge <2 x i32> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint32x2_t test_pmsgeu_u32x2(uint32x2_t a, uint32x2_t b) {
+  return __riscv_pmsgeu_u32x2(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsle_u32x2(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp sle <2 x i32> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsle_u32x2(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp sle <2 x i32> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint32x2_t test_pmsle_u32x2(int32x2_t a, int32x2_t b) {
+  return __riscv_pmsle_u32x2(a, b);
+}
+
+// RV32-LABEL: define dso_local i64 @test_pmsleu_u32x2(
+// RV32-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV32-NEXT:  [[ENTRY:.*:]]
+// RV32-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV32-NEXT:    [[CMP_I:%.*]] = icmp ule <2 x i32> [[TMP0]], [[TMP1]]
+// RV32-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV32-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV32-NEXT:    ret i64 [[TMP2]]
+//
+// RV64-LABEL: define dso_local i64 @test_pmsleu_u32x2(
+// RV64-SAME: i64 noundef [[A_COERCE:%.*]], i64 noundef [[B_COERCE:%.*]]) #[[ATTR0]] {
+// RV64-NEXT:  [[ENTRY:.*:]]
+// RV64-NEXT:    [[TMP0:%.*]] = bitcast i64 [[A_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[TMP1:%.*]] = bitcast i64 [[B_COERCE]] to <2 x i32>
+// RV64-NEXT:    [[CMP_I:%.*]] = icmp ule <2 x i32> [[TMP0]], [[TMP1]]
+// RV64-NEXT:    [[SEXT_I:%.*]] = sext <2 x i1> [[CMP_I]] to <2 x i32>
+// RV64-NEXT:    [[TMP2:%.*]] = bitcast <2 x i32> [[SEXT_I]] to i64
+// RV64-NEXT:    ret i64 [[TMP2]]
+//
+uint32x2_t test_pmsleu_u32x2(uint32x2_t a, uint32x2_t b) {
+  return __riscv_pmsleu_u32x2(a, b);
+}
+
 
 /* Packed Shifts (32-bit) */
 

--- a/cross-project-tests/intrinsic-header-tests/riscv_packed_simd.c
+++ b/cross-project-tests/intrinsic-header-tests/riscv_packed_simd.c
@@ -1196,3 +1196,447 @@ int32x2_t test_pnot_i32x2(int32x2_t a) { return __riscv_pnot_i32x2(a); }
 // RV32-COUNT-2: not{{[[:space:]]}}
 // RV64:         not{{[[:space:]]}}
 uint32x2_t test_pnot_u32x2(uint32x2_t a) { return __riscv_pnot_u32x2(a); }
+
+// CHECK-LABEL: test_pmseq_i8x4_u8x4:
+// CHECK:       pmseq.b
+uint8x4_t test_pmseq_i8x4_u8x4(int8x4_t a, int8x4_t b) {
+  return __riscv_pmseq_i8x4_u8x4(a, b);
+}
+
+// CHECK-LABEL: test_pmseq_u8x4_u8x4:
+// CHECK:       pmseq.b
+uint8x4_t test_pmseq_u8x4_u8x4(uint8x4_t a, uint8x4_t b) {
+  return __riscv_pmseq_u8x4_u8x4(a, b);
+}
+
+// CHECK-LABEL: test_pmsne_i8x4_u8x4:
+// CHECK:       pmseq.b
+// CHECK:       not{{[[:space:]]}}
+uint8x4_t test_pmsne_i8x4_u8x4(int8x4_t a, int8x4_t b) {
+  return __riscv_pmsne_i8x4_u8x4(a, b);
+}
+
+// CHECK-LABEL: test_pmsne_u8x4_u8x4:
+// CHECK:       pmseq.b
+// CHECK:       not{{[[:space:]]}}
+uint8x4_t test_pmsne_u8x4_u8x4(uint8x4_t a, uint8x4_t b) {
+  return __riscv_pmsne_u8x4_u8x4(a, b);
+}
+
+// CHECK-LABEL: test_pmslt_u8x4:
+// CHECK:       pmslt.b
+uint8x4_t test_pmslt_u8x4(int8x4_t a, int8x4_t b) {
+  return __riscv_pmslt_u8x4(a, b);
+}
+
+// CHECK-LABEL: test_pmsltu_u8x4:
+// CHECK:       pmsltu.b
+uint8x4_t test_pmsltu_u8x4(uint8x4_t a, uint8x4_t b) {
+  return __riscv_pmsltu_u8x4(a, b);
+}
+
+// CHECK-LABEL: test_pmsgt_u8x4:
+// CHECK:       pmslt.b
+uint8x4_t test_pmsgt_u8x4(int8x4_t a, int8x4_t b) {
+  return __riscv_pmsgt_u8x4(a, b);
+}
+
+// CHECK-LABEL: test_pmsgtu_u8x4:
+// CHECK:       pmsltu.b
+uint8x4_t test_pmsgtu_u8x4(uint8x4_t a, uint8x4_t b) {
+  return __riscv_pmsgtu_u8x4(a, b);
+}
+
+// CHECK-LABEL: test_pmsge_u8x4:
+// CHECK:       pmslt.b
+// CHECK:       not{{[[:space:]]}}
+uint8x4_t test_pmsge_u8x4(int8x4_t a, int8x4_t b) {
+  return __riscv_pmsge_u8x4(a, b);
+}
+
+// CHECK-LABEL: test_pmsgeu_u8x4:
+// CHECK:       pmsltu.b
+// CHECK:       not{{[[:space:]]}}
+uint8x4_t test_pmsgeu_u8x4(uint8x4_t a, uint8x4_t b) {
+  return __riscv_pmsgeu_u8x4(a, b);
+}
+
+// CHECK-LABEL: test_pmsle_u8x4:
+// CHECK:       pmslt.b
+// CHECK:       not{{[[:space:]]}}
+uint8x4_t test_pmsle_u8x4(int8x4_t a, int8x4_t b) {
+  return __riscv_pmsle_u8x4(a, b);
+}
+
+// CHECK-LABEL: test_pmsleu_u8x4:
+// CHECK:       pmsltu.b
+// CHECK:       not{{[[:space:]]}}
+uint8x4_t test_pmsleu_u8x4(uint8x4_t a, uint8x4_t b) {
+  return __riscv_pmsleu_u8x4(a, b);
+}
+
+// CHECK-LABEL: test_pmseq_i16x2_u16x2:
+// CHECK:       pmseq.h
+uint16x2_t test_pmseq_i16x2_u16x2(int16x2_t a, int16x2_t b) {
+  return __riscv_pmseq_i16x2_u16x2(a, b);
+}
+
+// CHECK-LABEL: test_pmseq_u16x2_u16x2:
+// CHECK:       pmseq.h
+uint16x2_t test_pmseq_u16x2_u16x2(uint16x2_t a, uint16x2_t b) {
+  return __riscv_pmseq_u16x2_u16x2(a, b);
+}
+
+// CHECK-LABEL: test_pmsne_i16x2_u16x2:
+// CHECK:       pmseq.h
+// CHECK:       not{{[[:space:]]}}
+uint16x2_t test_pmsne_i16x2_u16x2(int16x2_t a, int16x2_t b) {
+  return __riscv_pmsne_i16x2_u16x2(a, b);
+}
+
+// CHECK-LABEL: test_pmsne_u16x2_u16x2:
+// CHECK:       pmseq.h
+// CHECK:       not{{[[:space:]]}}
+uint16x2_t test_pmsne_u16x2_u16x2(uint16x2_t a, uint16x2_t b) {
+  return __riscv_pmsne_u16x2_u16x2(a, b);
+}
+
+// CHECK-LABEL: test_pmslt_u16x2:
+// CHECK:       pmslt.h
+uint16x2_t test_pmslt_u16x2(int16x2_t a, int16x2_t b) {
+  return __riscv_pmslt_u16x2(a, b);
+}
+
+// CHECK-LABEL: test_pmsltu_u16x2:
+// CHECK:       pmsltu.h
+uint16x2_t test_pmsltu_u16x2(uint16x2_t a, uint16x2_t b) {
+  return __riscv_pmsltu_u16x2(a, b);
+}
+
+// CHECK-LABEL: test_pmsgt_u16x2:
+// CHECK:       pmslt.h
+uint16x2_t test_pmsgt_u16x2(int16x2_t a, int16x2_t b) {
+  return __riscv_pmsgt_u16x2(a, b);
+}
+
+// CHECK-LABEL: test_pmsgtu_u16x2:
+// CHECK:       pmsltu.h
+uint16x2_t test_pmsgtu_u16x2(uint16x2_t a, uint16x2_t b) {
+  return __riscv_pmsgtu_u16x2(a, b);
+}
+
+// CHECK-LABEL: test_pmsge_u16x2:
+// CHECK:       pmslt.h
+// CHECK:       not{{[[:space:]]}}
+uint16x2_t test_pmsge_u16x2(int16x2_t a, int16x2_t b) {
+  return __riscv_pmsge_u16x2(a, b);
+}
+
+// CHECK-LABEL: test_pmsgeu_u16x2:
+// CHECK:       pmsltu.h
+// CHECK:       not{{[[:space:]]}}
+uint16x2_t test_pmsgeu_u16x2(uint16x2_t a, uint16x2_t b) {
+  return __riscv_pmsgeu_u16x2(a, b);
+}
+
+// CHECK-LABEL: test_pmsle_u16x2:
+// CHECK:       pmslt.h
+// CHECK:       not{{[[:space:]]}}
+uint16x2_t test_pmsle_u16x2(int16x2_t a, int16x2_t b) {
+  return __riscv_pmsle_u16x2(a, b);
+}
+
+// CHECK-LABEL: test_pmsleu_u16x2:
+// CHECK:       pmsltu.h
+// CHECK:       not{{[[:space:]]}}
+uint16x2_t test_pmsleu_u16x2(uint16x2_t a, uint16x2_t b) {
+  return __riscv_pmsleu_u16x2(a, b);
+}
+
+// CHECK-LABEL: test_pmseq_i8x8_u8x8:
+// RV32:        pmseq.db
+// RV64:        pmseq.b
+uint8x8_t test_pmseq_i8x8_u8x8(int8x8_t a, int8x8_t b) {
+  return __riscv_pmseq_i8x8_u8x8(a, b);
+}
+
+// CHECK-LABEL: test_pmseq_u8x8_u8x8:
+// RV32:        pmseq.db
+// RV64:        pmseq.b
+uint8x8_t test_pmseq_u8x8_u8x8(uint8x8_t a, uint8x8_t b) {
+  return __riscv_pmseq_u8x8_u8x8(a, b);
+}
+
+// CHECK-LABEL: test_pmsne_i8x8_u8x8:
+// RV32:         pmseq.db
+// RV32-COUNT-2: not{{[[:space:]]}}
+// RV64:         pmseq.b
+// RV64:         not{{[[:space:]]}}
+uint8x8_t test_pmsne_i8x8_u8x8(int8x8_t a, int8x8_t b) {
+  return __riscv_pmsne_i8x8_u8x8(a, b);
+}
+
+// CHECK-LABEL: test_pmsne_u8x8_u8x8:
+// RV32:         pmseq.db
+// RV32-COUNT-2: not{{[[:space:]]}}
+// RV64:         pmseq.b
+// RV64:         not{{[[:space:]]}}
+uint8x8_t test_pmsne_u8x8_u8x8(uint8x8_t a, uint8x8_t b) {
+  return __riscv_pmsne_u8x8_u8x8(a, b);
+}
+
+// CHECK-LABEL: test_pmslt_u8x8:
+// RV32:        pmslt.db
+// RV64:        pmslt.b
+uint8x8_t test_pmslt_u8x8(int8x8_t a, int8x8_t b) {
+  return __riscv_pmslt_u8x8(a, b);
+}
+
+// CHECK-LABEL: test_pmsltu_u8x8:
+// RV32:        pmsltu.db
+// RV64:        pmsltu.b
+uint8x8_t test_pmsltu_u8x8(uint8x8_t a, uint8x8_t b) {
+  return __riscv_pmsltu_u8x8(a, b);
+}
+
+// CHECK-LABEL: test_pmsgt_u8x8:
+// RV32:        pmslt.db
+// RV64:        pmslt.b
+uint8x8_t test_pmsgt_u8x8(int8x8_t a, int8x8_t b) {
+  return __riscv_pmsgt_u8x8(a, b);
+}
+
+// CHECK-LABEL: test_pmsgtu_u8x8:
+// RV32:        pmsltu.db
+// RV64:        pmsltu.b
+uint8x8_t test_pmsgtu_u8x8(uint8x8_t a, uint8x8_t b) {
+  return __riscv_pmsgtu_u8x8(a, b);
+}
+
+// CHECK-LABEL: test_pmsge_u8x8:
+// RV32:         pmslt.db
+// RV32-COUNT-2: not{{[[:space:]]}}
+// RV64:         pmslt.b
+// RV64:         not{{[[:space:]]}}
+uint8x8_t test_pmsge_u8x8(int8x8_t a, int8x8_t b) {
+  return __riscv_pmsge_u8x8(a, b);
+}
+
+// CHECK-LABEL: test_pmsgeu_u8x8:
+// RV32:         pmsltu.db
+// RV32-COUNT-2: not{{[[:space:]]}}
+// RV64:         pmsltu.b
+// RV64:         not{{[[:space:]]}}
+uint8x8_t test_pmsgeu_u8x8(uint8x8_t a, uint8x8_t b) {
+  return __riscv_pmsgeu_u8x8(a, b);
+}
+
+// CHECK-LABEL: test_pmsle_u8x8:
+// RV32:         pmslt.db
+// RV32-COUNT-2: not{{[[:space:]]}}
+// RV64:         pmslt.b
+// RV64:         not{{[[:space:]]}}
+uint8x8_t test_pmsle_u8x8(int8x8_t a, int8x8_t b) {
+  return __riscv_pmsle_u8x8(a, b);
+}
+
+// CHECK-LABEL: test_pmsleu_u8x8:
+// RV32:         pmsltu.db
+// RV32-COUNT-2: not{{[[:space:]]}}
+// RV64:         pmsltu.b
+// RV64:         not{{[[:space:]]}}
+uint8x8_t test_pmsleu_u8x8(uint8x8_t a, uint8x8_t b) {
+  return __riscv_pmsleu_u8x8(a, b);
+}
+
+// CHECK-LABEL: test_pmseq_i16x4_u16x4:
+// RV32:        pmseq.dh
+// RV64:        pmseq.h
+uint16x4_t test_pmseq_i16x4_u16x4(int16x4_t a, int16x4_t b) {
+  return __riscv_pmseq_i16x4_u16x4(a, b);
+}
+
+// CHECK-LABEL: test_pmseq_u16x4_u16x4:
+// RV32:        pmseq.dh
+// RV64:        pmseq.h
+uint16x4_t test_pmseq_u16x4_u16x4(uint16x4_t a, uint16x4_t b) {
+  return __riscv_pmseq_u16x4_u16x4(a, b);
+}
+
+// CHECK-LABEL: test_pmsne_i16x4_u16x4:
+// RV32:         pmseq.dh
+// RV32-COUNT-2: not{{[[:space:]]}}
+// RV64:         pmseq.h
+// RV64:         not{{[[:space:]]}}
+uint16x4_t test_pmsne_i16x4_u16x4(int16x4_t a, int16x4_t b) {
+  return __riscv_pmsne_i16x4_u16x4(a, b);
+}
+
+// CHECK-LABEL: test_pmsne_u16x4_u16x4:
+// RV32:         pmseq.dh
+// RV32-COUNT-2: not{{[[:space:]]}}
+// RV64:         pmseq.h
+// RV64:         not{{[[:space:]]}}
+uint16x4_t test_pmsne_u16x4_u16x4(uint16x4_t a, uint16x4_t b) {
+  return __riscv_pmsne_u16x4_u16x4(a, b);
+}
+
+// CHECK-LABEL: test_pmslt_u16x4:
+// RV32:        pmslt.dh
+// RV64:        pmslt.h
+uint16x4_t test_pmslt_u16x4(int16x4_t a, int16x4_t b) {
+  return __riscv_pmslt_u16x4(a, b);
+}
+
+// CHECK-LABEL: test_pmsltu_u16x4:
+// RV32:        pmsltu.dh
+// RV64:        pmsltu.h
+uint16x4_t test_pmsltu_u16x4(uint16x4_t a, uint16x4_t b) {
+  return __riscv_pmsltu_u16x4(a, b);
+}
+
+// CHECK-LABEL: test_pmsgt_u16x4:
+// RV32:        pmslt.dh
+// RV64:        pmslt.h
+uint16x4_t test_pmsgt_u16x4(int16x4_t a, int16x4_t b) {
+  return __riscv_pmsgt_u16x4(a, b);
+}
+
+// CHECK-LABEL: test_pmsgtu_u16x4:
+// RV32:        pmsltu.dh
+// RV64:        pmsltu.h
+uint16x4_t test_pmsgtu_u16x4(uint16x4_t a, uint16x4_t b) {
+  return __riscv_pmsgtu_u16x4(a, b);
+}
+
+// CHECK-LABEL: test_pmsge_u16x4:
+// RV32:         pmslt.dh
+// RV32-COUNT-2: not{{[[:space:]]}}
+// RV64:         pmslt.h
+// RV64:         not{{[[:space:]]}}
+uint16x4_t test_pmsge_u16x4(int16x4_t a, int16x4_t b) {
+  return __riscv_pmsge_u16x4(a, b);
+}
+
+// CHECK-LABEL: test_pmsgeu_u16x4:
+// RV32:         pmsltu.dh
+// RV32-COUNT-2: not{{[[:space:]]}}
+// RV64:         pmsltu.h
+// RV64:         not{{[[:space:]]}}
+uint16x4_t test_pmsgeu_u16x4(uint16x4_t a, uint16x4_t b) {
+  return __riscv_pmsgeu_u16x4(a, b);
+}
+
+// CHECK-LABEL: test_pmsle_u16x4:
+// RV32:         pmslt.dh
+// RV32-COUNT-2: not{{[[:space:]]}}
+// RV64:         pmslt.h
+// RV64:         not{{[[:space:]]}}
+uint16x4_t test_pmsle_u16x4(int16x4_t a, int16x4_t b) {
+  return __riscv_pmsle_u16x4(a, b);
+}
+
+// CHECK-LABEL: test_pmsleu_u16x4:
+// RV32:         pmsltu.dh
+// RV32-COUNT-2: not{{[[:space:]]}}
+// RV64:         pmsltu.h
+// RV64:         not{{[[:space:]]}}
+uint16x4_t test_pmsleu_u16x4(uint16x4_t a, uint16x4_t b) {
+  return __riscv_pmsleu_u16x4(a, b);
+}
+
+// CHECK-LABEL: test_pmseq_i32x2_u32x2:
+// RV32:        pmseq.dw
+// RV64:        pmseq.w
+uint32x2_t test_pmseq_i32x2_u32x2(int32x2_t a, int32x2_t b) {
+  return __riscv_pmseq_i32x2_u32x2(a, b);
+}
+
+// CHECK-LABEL: test_pmseq_u32x2_u32x2:
+// RV32:        pmseq.dw
+// RV64:        pmseq.w
+uint32x2_t test_pmseq_u32x2_u32x2(uint32x2_t a, uint32x2_t b) {
+  return __riscv_pmseq_u32x2_u32x2(a, b);
+}
+
+// CHECK-LABEL: test_pmsne_i32x2_u32x2:
+// RV32:         pmseq.dw
+// RV32-COUNT-2: not{{[[:space:]]}}
+// RV64:         pmseq.w
+// RV64:         not{{[[:space:]]}}
+uint32x2_t test_pmsne_i32x2_u32x2(int32x2_t a, int32x2_t b) {
+  return __riscv_pmsne_i32x2_u32x2(a, b);
+}
+
+// CHECK-LABEL: test_pmsne_u32x2_u32x2:
+// RV32:         pmseq.dw
+// RV32-COUNT-2: not{{[[:space:]]}}
+// RV64:         pmseq.w
+// RV64:         not{{[[:space:]]}}
+uint32x2_t test_pmsne_u32x2_u32x2(uint32x2_t a, uint32x2_t b) {
+  return __riscv_pmsne_u32x2_u32x2(a, b);
+}
+
+// CHECK-LABEL: test_pmslt_u32x2:
+// RV32:        pmslt.dw
+// RV64:        pmslt.w
+uint32x2_t test_pmslt_u32x2(int32x2_t a, int32x2_t b) {
+  return __riscv_pmslt_u32x2(a, b);
+}
+
+// CHECK-LABEL: test_pmsltu_u32x2:
+// RV32:        pmsltu.dw
+// RV64:        pmsltu.w
+uint32x2_t test_pmsltu_u32x2(uint32x2_t a, uint32x2_t b) {
+  return __riscv_pmsltu_u32x2(a, b);
+}
+
+// CHECK-LABEL: test_pmsgt_u32x2:
+// RV32:        pmslt.dw
+// RV64:        pmslt.w
+uint32x2_t test_pmsgt_u32x2(int32x2_t a, int32x2_t b) {
+  return __riscv_pmsgt_u32x2(a, b);
+}
+
+// CHECK-LABEL: test_pmsgtu_u32x2:
+// RV32:        pmsltu.dw
+// RV64:        pmsltu.w
+uint32x2_t test_pmsgtu_u32x2(uint32x2_t a, uint32x2_t b) {
+  return __riscv_pmsgtu_u32x2(a, b);
+}
+
+// CHECK-LABEL: test_pmsge_u32x2:
+// RV32:         pmslt.dw
+// RV32-COUNT-2: not{{[[:space:]]}}
+// RV64:         pmslt.w
+// RV64:         not{{[[:space:]]}}
+uint32x2_t test_pmsge_u32x2(int32x2_t a, int32x2_t b) {
+  return __riscv_pmsge_u32x2(a, b);
+}
+
+// CHECK-LABEL: test_pmsgeu_u32x2:
+// RV32:         pmsltu.dw
+// RV32-COUNT-2: not{{[[:space:]]}}
+// RV64:         pmsltu.w
+// RV64:         not{{[[:space:]]}}
+uint32x2_t test_pmsgeu_u32x2(uint32x2_t a, uint32x2_t b) {
+  return __riscv_pmsgeu_u32x2(a, b);
+}
+
+// CHECK-LABEL: test_pmsle_u32x2:
+// RV32:         pmslt.dw
+// RV32-COUNT-2: not{{[[:space:]]}}
+// RV64:         pmslt.w
+// RV64:         not{{[[:space:]]}}
+uint32x2_t test_pmsle_u32x2(int32x2_t a, int32x2_t b) {
+  return __riscv_pmsle_u32x2(a, b);
+}
+
+// CHECK-LABEL: test_pmsleu_u32x2:
+// RV32:         pmsltu.dw
+// RV32-COUNT-2: not{{[[:space:]]}}
+// RV64:         pmsltu.w
+// RV64:         not{{[[:space:]]}}
+uint32x2_t test_pmsleu_u32x2(uint32x2_t a, uint32x2_t b) {
+  return __riscv_pmsleu_u32x2(a, b);
+}


### PR DESCRIPTION
Add header wrappers for pmseq/pmsne/pmslt[u]/pmsgt[u]/pmsge[u]/pmsle[u] as element-wise vector comparisons cast to the unsigned result type.