### PR TITLE
[LoongArch] Propagate demanded bits for CRC[C].W.{B,H}.W

### DIFF
--- a/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
+++ b/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
@@ -7641,9 +7641,9 @@ static SDValue performMOVFR2GR_SCombine(SDNode *N, SelectionDAG &DAG,
   return SDValue();
 }
 
-static SDValue performVMSKLTZCombine(SDNode *N, SelectionDAG &DAG,
-                                     TargetLowering::DAGCombinerInfo &DCI,
-                                     const LoongArchSubtarget &Subtarget) {
+static SDValue
+performDemandedBitsCombine(SDNode *N, SelectionDAG &DAG,
+                           TargetLowering::DAGCombinerInfo &DCI) {
   MVT VT = N->getSimpleValueType(0);
   unsigned NumBits = VT.getScalarSizeInBits();
 
@@ -8086,9 +8086,13 @@ SDValue LoongArchTargetLowering::PerformDAGCombine(SDNode *N,
     return performMOVGR2FR_WCombine(N, DAG, DCI, Subtarget);
   case LoongArchISD::MOVFR2GR_S_LA64:
     return performMOVFR2GR_SCombine(N, DAG, DCI, Subtarget);
+  case LoongArchISD::CRC_W_B_W:
+  case LoongArchISD::CRC_W_H_W:
+  case LoongArchISD::CRCC_W_B_W:
+  case LoongArchISD::CRCC_W_H_W:
   case LoongArchISD::VMSKLTZ:
   case LoongArchISD::XVMSKLTZ:
-    return performVMSKLTZCombine(N, DAG, DCI, Subtarget);
+    return performDemandedBitsCombine(N, DAG, DCI);
   case LoongArchISD::SPLIT_PAIR_F64:
     return performSPLIT_PAIR_F64Combine(N, DAG, DCI, Subtarget);
   case LoongArchISD::VANDN:
@@ -11082,6 +11086,19 @@ bool LoongArchTargetLowering::SimplifyDemandedBitsForTargetNode(
   switch (Opc) {
   default:
     break;
+  case LoongArchISD::CRC_W_B_W:
+  case LoongArchISD::CRC_W_H_W:
+  case LoongArchISD::CRCC_W_B_W:
+  case LoongArchISD::CRCC_W_H_W: {
+    KnownBits KnownSrc;
+    APInt DemandedSrcBits =
+        APInt::getLowBitsSet(BitWidth, (Opc == LoongArchISD::CRC_W_B_W ||
+                                        Opc == LoongArchISD::CRCC_W_B_W)
+                                           ? 8
+                                           : 16);
+    return SimplifyDemandedBits(Op.getOperand(1), DemandedSrcBits,
+                                OriginalDemandedElts, KnownSrc, TLO, Depth + 1);
+  }
   case LoongArchISD::VMSKLTZ:
   case LoongArchISD::XVMSKLTZ: {
     SDValue Src = Op.getOperand(0);

--- a/llvm/test/CodeGen/LoongArch/crc.ll
+++ b/llvm/test/CodeGen/LoongArch/crc.ll
@@ -4,7 +4,6 @@
 define i32 @crc_w_b_w(i8 signext %a, i32 signext %b) nounwind {
 ; CHECK-LABEL: crc_w_b_w:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    andi $a0, $a0, 255
 ; CHECK-NEXT:    crc.w.b.w $a0, $a0, $a1
 ; CHECK-NEXT:    ret
 entry:
@@ -16,7 +15,6 @@ entry:
 define i32 @crc_w_h_w(i16 signext %a, i32 signext %b) nounwind {
 ; CHECK-LABEL: crc_w_h_w:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    bstrpick.d $a0, $a0, 15, 0
 ; CHECK-NEXT:    crc.w.h.w $a0, $a0, $a1
 ; CHECK-NEXT:    ret
 entry:
@@ -28,7 +26,6 @@ entry:
 define i32 @crcc_w_b_w(i8 signext %a, i32 signext %b) nounwind {
 ; CHECK-LABEL: crcc_w_b_w:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    andi $a0, $a0, 255
 ; CHECK-NEXT:    crcc.w.b.w $a0, $a0, $a1
 ; CHECK-NEXT:    ret
 entry:
@@ -40,7 +37,6 @@ entry:
 define i32 @crcc_w_h_w(i16 signext %a, i32 signext %b) nounwind {
 ; CHECK-LABEL: crcc_w_h_w:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    bstrpick.d $a0, $a0, 15, 0
 ; CHECK-NEXT:    crcc.w.h.w $a0, $a0, $a1
 ; CHECK-NEXT:    ret
 entry:


### PR DESCRIPTION
CRC byte and halfword instructions only use the low 8 or 16 bits of their data operand. Propagate these demanded-bit requirements through SimplifyDemandedBitsForTargetNode() so redundant masking operations can be removed during DAG combining.