### PR TITLE
[OFFLOAD][L0] Add control for Copy Offload Hint

### DIFF
--- a/offload/plugins-nextgen/level_zero/include/L0Options.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Options.h
@@ -63,8 +63,9 @@ public:
 /// L0 Plugin flags.
 struct L0OptionFlagsTy {
   uint64_t UseMemoryPool : 1;
-  uint64_t Reserved : 63;
-  L0OptionFlagsTy() : UseMemoryPool(1), Reserved(0) {}
+  uint64_t UseCopyOffloadHint : 1;
+  uint64_t Reserved : 62;
+  L0OptionFlagsTy() : UseMemoryPool(1), UseCopyOffloadHint(0), Reserved(0) {}
 };
 
 struct L0OptionsTy {

--- a/offload/plugins-nextgen/level_zero/include/L0Options.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Options.h
@@ -65,7 +65,7 @@ struct L0OptionFlagsTy {
   uint64_t UseMemoryPool : 1;
   uint64_t UseCopyOffloadHint : 1;
   uint64_t Reserved : 62;
-  L0OptionFlagsTy() : UseMemoryPool(1), UseCopyOffloadHint(0), Reserved(0) {}
+  L0OptionFlagsTy() : UseMemoryPool(1), UseCopyOffloadHint(1), Reserved(0) {}
 };
 
 struct L0OptionsTy {

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -714,11 +714,14 @@ Error L0DeviceTy::makeMemoryResident(void *Mem, size_t Size) {
 Expected<ze_command_list_handle_t>
 L0DeviceTy::createImmCmdList(uint32_t Ordinal, uint32_t Index, bool InOrder) {
   ze_command_queue_flags_t Flags = InOrder ? ZE_COMMAND_QUEUE_FLAG_IN_ORDER : 0;
+  if (getPlugin().getOptions().Flags.UseCopyOffloadHint)
+    Flags |= ZE_COMMAND_QUEUE_FLAG_COPY_OFFLOAD_HINT;
+
   ze_command_queue_desc_t Desc{ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC,
                                nullptr,
                                Ordinal,
                                Index,
-                               Flags | ZE_COMMAND_QUEUE_FLAG_COPY_OFFLOAD_HINT,
+                               Flags,
                                ZE_COMMAND_QUEUE_MODE_ASYNCHRONOUS,
                                ZE_COMMAND_QUEUE_PRIORITY_NORMAL};
   ze_command_list_handle_t CmdList = nullptr;

--- a/offload/plugins-nextgen/level_zero/src/L0Options.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Options.cpp
@@ -25,6 +25,8 @@ void L0OptionsTy::processEnvironmentVars() {
       std::string(" ") +
       StringEnvar("LIBOMPTARGET_LEVEL_ZERO_COMPILATION_OPTIONS", "").get();
 
+  Flags.UseCopyOffloadHint = BoolEnvar("LIBOFFLOAD_LEVEL_ZERO_USE_COPY_OFFLOAD_HINT", true);
+
   // Memory pool syntax:
   // LIBOMPTARGET_LEVEL_ZERO_MEMORY_POOL=<Option>
   //  <Option>       := 0 | <PoolInfoList>

--- a/offload/plugins-nextgen/level_zero/src/L0Options.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Options.cpp
@@ -25,7 +25,8 @@ void L0OptionsTy::processEnvironmentVars() {
       std::string(" ") +
       StringEnvar("LIBOMPTARGET_LEVEL_ZERO_COMPILATION_OPTIONS", "").get();
 
-  Flags.UseCopyOffloadHint = BoolEnvar("LIBOFFLOAD_LEVEL_ZERO_USE_COPY_OFFLOAD_HINT", true);
+  Flags.UseCopyOffloadHint =
+      BoolEnvar("LIBOFFLOAD_LEVEL_ZERO_USE_COPY_OFFLOAD_HINT", true);
 
   // Memory pool syntax:
   // LIBOMPTARGET_LEVEL_ZERO_MEMORY_POOL=<Option>


### PR DESCRIPTION
In some cases setting ZE_COMMAND_QUEUE_FLAG_COPY_OFFLOAD_HINT reduces performance. Here we introduce LIBOFFLOAD_LEVEL_ZERO_USE_COPY_OFFLOAD_HINT env var to allow users to control the hint (which continues to be on by default).