### PR TITLE
[lldb] Remove incorrect eServerPacketType_notify

### DIFF
--- a/lldb/include/lldb/Utility/StringExtractorGDBRemote.h
+++ b/lldb/include/lldb/Utility/StringExtractorGDBRemote.h
@@ -166,7 +166,6 @@ public:
 
     eServerPacketType__M,
     eServerPacketType__m,
-    eServerPacketType_notify, // '%' notification
 
     eServerPacketType_jLLDBTraceSupported,
     eServerPacketType_jLLDBTraceStart,

--- a/lldb/source/Utility/StringExtractorGDBRemote.cpp
+++ b/lldb/source/Utility/StringExtractorGDBRemote.cpp
@@ -67,9 +67,6 @@ StringExtractorGDBRemote::GetServerPacketType() const {
   const char *packet_cstr = m_packet.c_str();
   switch (m_packet[0]) {
 
-  case '%':
-    return eServerPacketType_notify;
-
   case '\x03':
     if (packet_size == 1)
       return eServerPacketType_interrupt;


### PR DESCRIPTION
This enum is not correct. gdb-remote divides packets into normal packets and notifications:

* Normal: `$content#checksum`
* Notification: `%content#checksum`

The `StringExtractorGDBRemote` only receives the `content` part, which does not contain anything to indicate if the packet is a notification or not. That information is in the return code of `GDBRemoteCommunication::CheckForPacket` which is currently thrown away (so LLDB does not handle notifications correctly at the moment).

See [the specification](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Notification-Packets.html):

> A notification packet has the form ‘% data # checksum’, where data is the content of the notification, and checksum is a checksum of data, computed and formatted as for ordinary GDB packets. A notification’s data never contains ‘$’, ‘%’ or ‘#’ characters.