### PR TITLE
[LLDB] Restore LLDB_TEST_ARCH for building target tests for specific architecturesRestore lldb test arch

### DIFF
--- a/lldb/docs/resources/test.md
+++ b/lldb/docs/resources/test.md
@@ -587,6 +587,10 @@ $ ./tools/lldb/unittests/Host/HostTests --gtest_filter=SocketTest.DomainListenCo
    remote system. This is done with CMake options `LLDB_TEST_COMPILER` and
    `LLDB_TEST_TRIPLE`, or the `dotest.py` options `--compiler` and `--triple`.
 
+   Optionally, ``LLDB_TEST_ARCH`` (or ``--arch``) can be used to override just
+   the architecture component of the triple when needed (e.g. ``aarch64``).
+   ``LLDB_TEST_ARCH`` requires ``LLDB_TEST_TRIPLE`` to also be set.
+
    :::{note}
    Even in cases where the two systems are the same architecture and run the
    same operating system, there may be version differences between the two
@@ -597,12 +601,13 @@ $ ./tools/lldb/unittests/Host/HostTests --gtest_filter=SocketTest.DomainListenCo
    you might run:
 
    ```
-   ./bin/lldb-dotest --platform-name remote-linux --triple aarch64-unknown-linux-gnu --compiler aarch64-none-linux-gnu-gcc --platform-url connect://<remote-ip>:<port A> --platform-working-dir /tmp/test_lldb -p <test-name>.py
+   ./bin/lldb-dotest --platform-name remote-linux --triple aarch64-unknown-linux-gnu --arch aarch64 --compiler aarch64-none-linux-gnu-gcc --platform-url connect://<remote-ip>:<port A> --platform-working-dir /tmp/test_lldb -p <test-name>.py
    ```
 
    This is the equivalent of:
 
    > - `LLDB_TEST_TRIPLE` = `aarch64-unknown-linux-gnu`
+   > - `LLDB_TEST_ARCH` = `aarch64`
    > - `LLDB_TEST_COMPILER` = `aarch64-none-linux-gnu-gcc`
    > - `LLDB_TEST_PLATFORM_URL` = `connect://<remote-ip>:<port A>`
    > - `LLDB_TEST_PLATFORM_WORKING_DIR` = `/tmp/test_lldb`

--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -41,6 +41,17 @@ class Builder:
             return ["TRIPLE=" + triple]
         return []
 
+    def getArchSpec(self):
+        """
+        Helper function to return the key-value string to specify the architecture
+        used for the make system.
+        """
+        arch = self.getArchitecture()
+        triple = self.getTriple()
+        if arch and triple and arch != triple.split("-")[0]:
+            return ["ARCH=" + arch]
+        return []
+
     def getArchCFlags(self):
         """Returns the ARCH_CFLAGS for the make system."""
         return []
@@ -293,6 +304,7 @@ class Builder:
             make_targets,
             self.getArchCFlags(),
             self.getTripleSpec(),
+            self.getArchSpec(),
             self.getToolchainSpec(compiler),
             self.getExtraMakeArgs(),
             self.getSDKRootSpec(),

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -342,6 +342,9 @@ def parseOptionsAndInitTestdirs():
         configuration.triple.split("-")[0] if configuration.triple else platform_machine
     )
 
+    if args.arch:
+        configuration.arch = args.arch
+
     if args.categories_list:
         configuration.categories_list = set(
             test_categories.validate(args.categories_list, False)

--- a/lldb/packages/Python/lldbsuite/test/dotest_args.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest_args.py
@@ -40,6 +40,15 @@ def create_parser():
         ),
     )
     group.add_argument(
+        "-A",
+        "--arch",
+        metavar="arch",
+        dest="arch",
+        help=textwrap.dedent(
+            """Specify the architecture(s) to test. This option can be specified more than once"""
+        ),
+    )
+    group.add_argument(
         "-C",
         "--compiler",
         metavar="compiler",

--- a/lldb/test/API/CMakeLists.txt
+++ b/lldb/test/API/CMakeLists.txt
@@ -31,6 +31,20 @@ set(LLDB_TEST_TRIPLE
   ${default_lldb_test_triple}
   CACHE STRING "The target triple used to build test inferiors.")
 
+# Some cases may require an explicit architcture selection, so
+# LLDB_TEST_ARCH is allowed to override the default architecture only when
+# LLDB_TEST_TRIPLE is also set.
+if(DEFINED LLDB_TEST_ARCH AND NOT "${LLDB_TEST_ARCH}" STREQUAL "")
+  if("${LLDB_TEST_TRIPLE}" STREQUAL "${default_lldb_test_triple}")
+    message(FATAL_ERROR
+      "LLDB_TEST_ARCH may only be set when LLDB_TEST_TRIPLE is also explicitly set.")
+  endif()
+endif()
+
+set(LLDB_TEST_ARCH
+  ""
+  CACHE STRING "Specify the architecture to run LLDB tests as (x86|x64).  Determines whether tests are compiled with -m32 or -m64")
+
 # Users can override LLDB_TEST_USER_ARGS to specify arbitrary arguments to pass to the script
 set(LLDB_TEST_USER_ARGS
   ""

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -246,6 +246,9 @@ for env_var in ("ASAN_OPTIONS", "DYLD_INSERT_LIBRARIES"):
 if is_configured("test_triple"):
     dotest_cmd += ["--triple", config.test_triple]
 
+if is_configured("test_arch") and config.test_arch:
+    dotest_cmd += ["--arch", config.test_arch]
+
 if is_configured("lldb_build_directory"):
     dotest_cmd += ["--build-dir", config.lldb_build_directory]
 

--- a/lldb/test/API/lit.site.cfg.py.in
+++ b/lldb/test/API/lit.site.cfg.py.in
@@ -35,6 +35,7 @@ config.dotest_lit_args_str = None
 config.enabled_plugins = []
 config.lldb_executable = lit_config.substitute('@LLDB_TEST_EXECUTABLE@')
 config.test_triple = '@LLDB_TEST_TRIPLE@'
+config.test_arch = '@LLDB_TEST_ARCH@'
 config.test_compiler = lit_config.substitute('@LLDB_TEST_COMPILER@')
 config.dsymutil = lit_config.substitute('@LLDB_TEST_DSYMUTIL@')
 config.make = lit_config.substitute('@LLDB_TEST_MAKE@')

--- a/lldb/utils/lldb-dotest/lldb-dotest.in
+++ b/lldb/utils/lldb-dotest/lldb-dotest.in
@@ -7,6 +7,7 @@ dotest_path = '@LLDB_SOURCE_DIR_CONFIGURED@/test/API/dotest.py'
 dotest_common_args_str = '@LLDB_TEST_COMMON_ARGS_CONFIGURED@'
 dotest_user_args_str = '@LLDB_TEST_USER_ARGS_CONFIGURED@'
 triple = '@LLDB_TEST_TRIPLE@'
+arch = '@LLDB_TEST_ARCH@'
 executable = '@LLDB_TEST_EXECUTABLE_CONFIGURED@'
 compiler = '@LLDB_TEST_COMPILER_CONFIGURED@'
 dsymutil = '@LLDB_TEST_DSYMUTIL_CONFIGURED@'
@@ -38,6 +39,8 @@ if __name__ == '__main__':
     # Build dotest.py command.
     cmd = [sys.executable, dotest_path]
     cmd.extend(['--triple', triple])
+    if arch:
+        cmd.extend(['--arch', arch])
     cmd.extend(dotest_args)
     cmd.extend(['--build-dir', lldb_build_dir])
     cmd.extend(['--executable', executable])


### PR DESCRIPTION
Upstream replaced LLDB_TEST_ARCH with LLDB_TEST_TRIPLE as the standard way to way to define the test target.
While this works for most cases, it is not sufficient for some dowsnstream use cases that require targeting a
specific architecture configuration(e.g v1, v2 ... etc).

As a result, certain architecture dependent test may not be built or executed correctly.

Proposed Solution:
Restored support for the LLDB_TEST_ARCH configuration, which has been removed/replaced previously.
PR's https://github.com/llvm/llvm-project/pull/192818 and https://github.com/llvm/llvm-project/pull/191204
Added logic to enforce that LLDB_TEST_ARCH is only valid when LLDB_TEST_TRIPLE is defined.