### PR TITLE
[DTLTO] Added missing timetrace "Check cache for DTLTO" message.

### DIFF
--- a/llvm/lib/DTLTO/DTLTO.cpp
+++ b/llvm/lib/DTLTO/DTLTO.cpp
@@ -104,6 +104,8 @@ Error lto::DTLTO::checkCacheHit(Job &J) {
   if (!Cache.isValid())
     return Error::success();
 
+  TimeTraceScope TimeScope("Check cache for DTLTO", J.SummaryIndexPath);
+
   auto CacheAddStreamExp = Cache(J.Task, J.CacheKey, J.ModuleID);
   if (Error Err = CacheAddStreamExp.takeError())
     return Err;

--- a/llvm/test/ThinLTO/X86/dtlto/timetrace.ll
+++ b/llvm/test/ThinLTO/X86/dtlto/timetrace.ll
@@ -9,7 +9,7 @@ RUN: opt -thinlto-bc t2.ll -o t2.bc
 ; Generate fake object files for mock.py to return.
 RUN: touch t1.o t2.o
 
-RUN: rm -rf %t.cache && mkdir -p %t.cache
+RUN: mkdir cache
 
 ; Perform DTLTO and generate a time trace. mock.py does not do any compilation,
 ; instead it simply writes the contents of the object files supplied on the
@@ -17,7 +17,7 @@ RUN: rm -rf %t.cache && mkdir -p %t.cache
 RUN: llvm-lto2 run t1.bc t2.bc -o t.o \
 RUN:   -dtlto-distributor=%python \
 RUN:   -dtlto-distributor-arg=%llvm_src_root/utils/dtlto/mock.py,t1.o,t2.o \
-RUN:   --cache-dir=%t.cache \
+RUN:   --cache-dir=cache \
 RUN:   --time-trace --time-trace-granularity=0 --time-trace-file=%t.json \
 RUN:   -r=t1.bc,t1,px \
 RUN:   -r=t2.bc,t2,px

--- a/llvm/test/ThinLTO/X86/dtlto/timetrace.ll
+++ b/llvm/test/ThinLTO/X86/dtlto/timetrace.ll
@@ -9,12 +9,15 @@ RUN: opt -thinlto-bc t2.ll -o t2.bc
 ; Generate fake object files for mock.py to return.
 RUN: touch t1.o t2.o
 
+RUN: rm -rf %t.cache && mkdir -p %t.cache
+
 ; Perform DTLTO and generate a time trace. mock.py does not do any compilation,
 ; instead it simply writes the contents of the object files supplied on the
 ; command line into the output object files in job order.
 RUN: llvm-lto2 run t1.bc t2.bc -o t.o \
 RUN:   -dtlto-distributor=%python \
 RUN:   -dtlto-distributor-arg=%llvm_src_root/utils/dtlto/mock.py,t1.o,t2.o \
+RUN:   --cache-dir=%t.cache \
 RUN:   --time-trace --time-trace-granularity=0 --time-trace-file=%t.json \
 RUN:   -r=t1.bc,t1,px \
 RUN:   -r=t2.bc,t2,px
@@ -28,6 +31,10 @@ CHECK-NEXT: "name": "Add input for DTLTO"
 CHECK-SAME:   "pid": [[#PID:]],
 CHECK-NEXT: "name": "Add input for DTLTO"
 CHECK-SAME:   "pid": [[#PID:]],
+CHECK-NEXT: "name": "Check cache for DTLTO"
+CHECK-SAME:   "pid": [[#PID:]],
+CHECK-NEXT: "name": "Check cache for DTLTO"
+CHECK-SAME:   "pid": [[#PID:]],
 CHECK-NEXT: "name": "Emit DTLTO JSON"
 CHECK-NEXT: "name": "Emit individual index for DTLTO"
 CHECK-SAME:   t1.1.[[#PID]].native.o.thinlto.bc"
@@ -38,6 +45,8 @@ CHECK-NEXT: "name": "Remove DTLTO temporary files"
 CHECK-NEXT: "name": "Total Add DTLTO files to the link"
 CHECK-SAME:   "count": 1,
 CHECK-NEXT: "name": "Total Add input for DTLTO"
+CHECK-SAME:   "count": 2,
+CHECK-NEXT: "name": "Total Check cache for DTLTO"
 CHECK-SAME:   "count": 2,
 CHECK-NEXT: "name": "Total Emit DTLTO JSON"
 CHECK-SAME:   "count": 1,


### PR DESCRIPTION
After the DTLTO refactor commit, the time trace "Chack cache for DTLTO" message was unintentionally omitted. This patch corrects this omission.   