### PR TITLE
[APINotes] Parse function-like Where.Parameters

### DIFF
--- a/clang/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/clang/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -338,8 +338,15 @@ template <> struct MappingTraits<Class> {
 } // namespace llvm
 
 namespace {
+typedef std::vector<StringRef> WhereParamsSeq;
+
+struct FunctionWhere {
+  std::optional<WhereParamsSeq> Parameters;
+};
+
 struct Function {
   StringRef Name;
+  std::optional<FunctionWhere> Where;
   ParamsSeq Params;
   NullabilitySeq Nullability;
   std::optional<NullabilityKind> NullabilityOfRet;
@@ -361,9 +368,16 @@ LLVM_YAML_IS_SEQUENCE_VECTOR(Function)
 
 namespace llvm {
 namespace yaml {
+template <> struct MappingTraits<FunctionWhere> {
+  static void mapping(IO &IO, FunctionWhere &W) {
+    IO.mapOptional("Parameters", W.Parameters);
+  }
+};
+
 template <> struct MappingTraits<Function> {
   static void mapping(IO &IO, Function &F) {
     IO.mapRequired("Name", F.Name);
+    IO.mapOptional("Where", F.Where);
     IO.mapOptional("Parameters", F.Params);
     IO.mapOptional("Nullability", F.Nullability);
     IO.mapOptional("NullabilityOfRet", F.NullabilityOfRet, std::nullopt);
@@ -1137,6 +1151,12 @@ public:
     }
 
     for (const auto &CXXMethod : T.Methods) {
+      if (CXXMethod.Where && CXXMethod.Where->Parameters) {
+        emitError(
+            "'Where.Parameters' is not supported by binary API notes yet");
+        continue;
+      }
+
       CXXMethodInfo MI;
       convertFunction(CXXMethod, MI);
       Writer.addCXXMethod(TagCtxID, CXXMethod.Name, MI, SwiftVersion);
@@ -1210,6 +1230,12 @@ public:
     // Write all global functions.
     llvm::StringSet<> KnownFunctions;
     for (const auto &Function : TLItems.Functions) {
+      if (Function.Where && Function.Where->Parameters) {
+        emitError(
+            "'Where.Parameters' is not supported by binary API notes yet");
+        continue;
+      }
+
       // Check for duplicate global functions.
       if (!KnownFunctions.insert(Function.Name).second) {
         emitError(llvm::Twine("multiple definitions of global function '") +

--- a/clang/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/clang/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -1151,9 +1151,8 @@ public:
     }
 
     for (const auto &CXXMethod : T.Methods) {
-      if (CXXMethod.Where && CXXMethod.Where->Parameters) {
-        emitError(
-            "'Where.Parameters' is not supported by binary API notes yet");
+      if (CXXMethod.Where) {
+        emitError("'Where' is not supported by binary API notes yet");
         continue;
       }
 
@@ -1230,9 +1229,8 @@ public:
     // Write all global functions.
     llvm::StringSet<> KnownFunctions;
     for (const auto &Function : TLItems.Functions) {
-      if (Function.Where && Function.Where->Parameters) {
-        emitError(
-            "'Where.Parameters' is not supported by binary API notes yet");
+      if (Function.Where) {
+        emitError("'Where' is not supported by binary API notes yet");
         continue;
       }
 

--- a/clang/test/APINotes/Inputs/Headers/WhereParametersMapElement.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/WhereParametersMapElement.apinotes
@@ -1,0 +1,8 @@
+---
+Name: WhereParametersMapElement
+Functions:
+- Name: makeWidget
+  Where:
+    Parameters:
+      - Type: int
+  SwiftName: makeWidget(_:)

--- a/clang/test/APINotes/Inputs/Headers/WhereParametersMethodWhereSequence.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/WhereParametersMethodWhereSequence.apinotes
@@ -1,0 +1,9 @@
+---
+Name: WhereParametersMethodWhereSequence
+Tags:
+- Name: Widget
+  Methods:
+  - Name: setValue
+    Where:
+      - Parameters:
+        - int

--- a/clang/test/APINotes/Inputs/Headers/WhereParametersMissingName.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/WhereParametersMissingName.apinotes
@@ -1,0 +1,7 @@
+---
+Name: WhereParametersMissingName
+Functions:
+- Where:
+    Parameters:
+      - int
+  SwiftName: makeWidget(_:)

--- a/clang/test/APINotes/Inputs/Headers/WhereParametersParser.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/WhereParametersParser.apinotes
@@ -1,0 +1,50 @@
+---
+Name: WhereParametersParser
+Functions:
+- Name: makeWidget
+  Where:
+    Parameters:
+      - int
+  SwiftName: makeWidget(_:)
+- Name: makeWidget
+  Where:
+    Parameters:
+      - double
+      - const char *
+  SwiftName: makeWidget(_:_:)
+- Name: currentWidget
+  Where:
+    Parameters: []
+  SwiftName: currentWidget()
+- Name: makeWidget
+  SwiftName: makeWidget(_:)
+- Name: functionWithParameterNotes
+  Parameters:
+  - Position: 0
+    Type: int
+  SwiftName: functionWithParameterNotes(_:)
+Tags:
+- Name: Widget
+  Methods:
+  - Name: setValue
+    Where:
+      Parameters:
+        - int
+    SwiftName: setIntValue(_:)
+  - Name: setValue
+    Where:
+      Parameters:
+        - double
+        - const char *
+    SwiftName: setValue(_:_:)
+  - Name: reset
+    Where:
+      Parameters: []
+    SwiftName: reset()
+  - Name: setValue
+    SwiftName: setValue(_:)
+  - Name: methodWithParameterNotes
+    Parameters:
+    - Position: 0
+      Type: int
+    SwiftName: methodWithParameterNotes(_:)

--- a/clang/test/APINotes/Inputs/Headers/WhereParametersScalar.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/WhereParametersScalar.apinotes
@@ -1,0 +1,7 @@
+---
+Name: WhereParametersScalar
+Functions:
+- Name: makeWidget
+  Where:
+    Parameters: int
+  SwiftName: makeWidget(_:)

--- a/clang/test/APINotes/Inputs/Headers/WhereParametersUnknownWhereKey.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/WhereParametersUnknownWhereKey.apinotes
@@ -1,0 +1,7 @@
+---
+Name: WhereParametersUnknownWhereKey
+Functions:
+- Name: makeWidget
+  Where:
+    ResultType: int
+  SwiftName: makeWidget(_:)

--- a/clang/test/APINotes/Inputs/Headers/WhereParametersWhereSequence.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/WhereParametersWhereSequence.apinotes
@@ -1,0 +1,8 @@
+---
+Name: WhereParametersWhereSequence
+Functions:
+- Name: makeWidget
+  Where:
+    - Parameters:
+        - int
+  SwiftName: makeWidget(_:)

--- a/clang/test/APINotes/Inputs/WhereParametersConvertDiag/APINotes.apinotes
+++ b/clang/test/APINotes/Inputs/WhereParametersConvertDiag/APINotes.apinotes
@@ -1,0 +1,8 @@
+---
+Name: WhereParametersConvertDiag
+Tags:
+- Name: Widget
+  Methods:
+  - Name: reset
+    Where: {}
+    SwiftName: reset()

--- a/clang/test/APINotes/Inputs/WhereParametersConvertDiag/WhereParametersConvertDiag.h
+++ b/clang/test/APINotes/Inputs/WhereParametersConvertDiag/WhereParametersConvertDiag.h
@@ -1,0 +1,8 @@
+#ifndef WHERE_PARAMETERS_CONVERT_DIAG_H
+#define WHERE_PARAMETERS_CONVERT_DIAG_H
+
+struct Widget {
+  void reset();
+};
+
+#endif // WHERE_PARAMETERS_CONVERT_DIAG_H

--- a/clang/test/APINotes/where-parameters-convert-diags.cpp
+++ b/clang/test/APINotes/where-parameters-convert-diags.cpp
@@ -1,0 +1,5 @@
+// RUN: not %clang_cc1 -fsyntax-only -fapinotes %s -I %S/Inputs/WhereParametersConvertDiag 2>&1 | FileCheck %s
+
+#include "WhereParametersConvertDiag.h"
+
+// CHECK: error: 'Where' is not supported by binary API notes yet

--- a/clang/test/APINotes/where-parameters-yaml.test
+++ b/clang/test/APINotes/where-parameters-yaml.test
@@ -1,0 +1,56 @@
+RUN: apinotes-test %S/Inputs/Headers/WhereParametersParser.apinotes | FileCheck %s
+RUN: apinotes-test %S/Inputs/Headers/WhereParametersMissingName.apinotes 2>&1 | FileCheck %s --check-prefix=MISSING-NAME
+RUN: apinotes-test %S/Inputs/Headers/WhereParametersWhereSequence.apinotes 2>&1 | FileCheck %s --check-prefix=WHERE-SEQUENCE
+RUN: apinotes-test %S/Inputs/Headers/WhereParametersScalar.apinotes 2>&1 | FileCheck %s --check-prefix=PARAMETERS-SCALAR
+RUN: apinotes-test %S/Inputs/Headers/WhereParametersMapElement.apinotes 2>&1 | FileCheck %s --check-prefix=PARAMETERS-MAP-ELEMENT
+RUN: apinotes-test %S/Inputs/Headers/WhereParametersUnknownWhereKey.apinotes 2>&1 | FileCheck %s --check-prefix=UNKNOWN-WHERE-KEY
+RUN: apinotes-test %S/Inputs/Headers/WhereParametersMethodWhereSequence.apinotes 2>&1 | FileCheck %s --check-prefix=METHOD-WHERE-SEQUENCE
+
+CHECK:      Name:            WhereParametersParser
+CHECK:      Functions:
+CHECK:      - Name:            makeWidget
+CHECK-NEXT:   Where:
+CHECK-NEXT:     Parameters:
+CHECK-NEXT:       - int
+CHECK:      - Name:            makeWidget
+CHECK-NEXT:   Where:
+CHECK-NEXT:     Parameters:
+CHECK-NEXT:       - double
+CHECK-NEXT:       - 'const char *'
+CHECK:      - Name:            currentWidget
+CHECK-NEXT:   Where:
+CHECK-NEXT:     Parameters:      []
+CHECK:      - Name:            makeWidget
+CHECK-NEXT:   SwiftName:       'makeWidget(_:)'
+CHECK:      - Name:            functionWithParameterNotes
+CHECK-NEXT:   Parameters:
+CHECK-NEXT:     - Position:        0
+CHECK-NEXT:       Type:            int
+CHECK:      Tags:
+CHECK:      - Name:            Widget
+CHECK:      Methods:
+CHECK:      - Name:            setValue
+CHECK-NEXT:   Where:
+CHECK-NEXT:     Parameters:
+CHECK-NEXT:       - int
+CHECK:      - Name:            setValue
+CHECK-NEXT:   Where:
+CHECK-NEXT:     Parameters:
+CHECK-NEXT:       - double
+CHECK-NEXT:       - 'const char *'
+CHECK:      - Name:            reset
+CHECK-NEXT:   Where:
+CHECK-NEXT:     Parameters:      []
+CHECK:      - Name:            setValue
+CHECK-NEXT:   SwiftName:       'setValue(_:)'
+CHECK:      - Name:            methodWithParameterNotes
+CHECK-NEXT:   Parameters:
+CHECK-NEXT:     - Position:        0
+CHECK-NEXT:       Type:            int
+
+MISSING-NAME: missing required key 'Name'
+WHERE-SEQUENCE: not a mapping
+PARAMETERS-SCALAR: not a sequence
+PARAMETERS-MAP-ELEMENT: unexpected scalar
+UNKNOWN-WHERE-KEY: unknown key 'ResultType'
+METHOD-WHERE-SEQUENCE: not a mapping


### PR DESCRIPTION
Add YAML parser/model support for `Where.Parameters` on function-like API notes entries. This keeps `Name` as the required entry key and allows top-level `Functions` and C++ `Tags` / `Methods` to parse and round-trip an optional ordered list of explicit parameter type spellings. 

Binary API notes serialization, lookup, and overload matching are intentionally left for follow-up patches. Notes using `Where.Parameters` are diagnosed during binary conversion for now.