### PR TITLE
[AArch64] Fix swapped operands in tryFoldCselToFMaxMin

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelDAGToDAG.cpp
@@ -8120,15 +8120,11 @@ SDValue AArch64DAGToDAGISel::tryFoldCselToFMaxMin(SDNode &N) {
   if (CondCode == AArch64CC::GT || CondCode == AArch64CC::GE) {
     if (TVal == CmpLHS && FVal == CmpRHS)
       isMax = true;
-    else if (TVal == CmpRHS && FVal == CmpLHS)
-      isMax = false;
     else
       return SDValue();
   } else if (CondCode == AArch64CC::MI || CondCode == AArch64CC::LS) {
     if (TVal == CmpLHS && FVal == CmpRHS)
       isMax = false;
-    else if (TVal == CmpRHS && FVal == CmpLHS)
-      isMax = true;
     else
       return SDValue();
   } else {

--- a/llvm/test/CodeGen/AArch64/fmaximumnum-fminimumnum-select.ll
+++ b/llvm/test/CodeGen/AArch64/fmaximumnum-fminimumnum-select.ll
@@ -169,3 +169,33 @@ entry:
   %min = select i1 %cmp, float %mul, float 1.000000e+00
   ret float %min
 }
+
+define float @max_oge_swapped(float %a, float %b) {
+; CHECK-LABEL: max_oge_swapped:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fmul s0, s0, s1
+; CHECK-NEXT:    fmov s1, #1.00000000
+; CHECK-NEXT:    fcmp s0, s1
+; CHECK-NEXT:    fcsel s0, s1, s0, ge
+; CHECK-NEXT:    ret
+entry:
+  %mul = fmul float %a, %b
+  %cmp = fcmp nsz oge float %mul, 1.000000e+00
+  %max = select i1 %cmp, float 1.000000e+00, float %mul
+  ret float %max
+}
+
+define float @min_ole_swapped(float %a, float %b) {
+; CHECK-LABEL: min_ole_swapped:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fmul s0, s0, s1
+; CHECK-NEXT:    fmov s1, #1.00000000
+; CHECK-NEXT:    fcmp s0, s1
+; CHECK-NEXT:    fcsel s0, s1, s0, ls
+; CHECK-NEXT:    ret
+entry:
+  %mul = fmul float %a, %b
+  %cmp = fcmp nsz ole float %mul, 1.000000e+00
+  %min = select i1 %cmp, float 1.000000e+00, float %mul
+  ret float %min
+}


### PR DESCRIPTION
These swapped operands will treat nan the wrong way, make sure we only use the matching direction when converting to fminnm/fmaxnm.