### PR TITLE
[VPlan] Recalculate VPDT in handleUncountableExitsWithSideEffects

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -4250,6 +4250,8 @@ static bool handleUncountableExitsWithSideEffects(
     VPBlockUtils::disconnectBlocks(Exit.EarlyExitingVPBB, Exit.EarlyExitVPBB);
   }
 
+  VPDT.recalculate(Plan);
+
   // We can abandon a VPlan entirely if we return false here, so we shouldn't
   // crash if some earlier assumptions on scalar IR don't hold for the vplan
   // version of the loop.


### PR DESCRIPTION
In the loop before we're modifying the CFG, but this invalidates the
dominator tree. We need to recalculate since we query it later on. I
can't really think of a test case for this, if anything using the
stale dominator tree with the extra branch will make the dominance
queries more conservative. But it's probably something we should fix.
