### PR TITLE
[llvm] Fix most LLVM_ABI annotations in CAS

### DIFF
--- a/llvm/include/llvm/CAS/ActionCache.h
+++ b/llvm/include/llvm/CAS/ActionCache.h
@@ -35,7 +35,7 @@ public:
 
   LLVM_ABI CacheKey(const CASID &ID);
   LLVM_ABI_FOR_TEST CacheKey(const ObjectProxy &Proxy);
-  CacheKey(const ObjectStore &CAS, const ObjectRef &Ref);
+  LLVM_ABI CacheKey(const ObjectStore &CAS, const ObjectRef &Ref);
 
 private:
   std::string Key;
@@ -46,7 +46,7 @@ private:
 ///
 /// Actions are expected to be pure. Storing mappings from one action to
 /// multiple results will result in error (cache poisoning).
-class ActionCache {
+class LLVM_ABI ActionCache {
   virtual void anchor();
 
 public:

--- a/llvm/include/llvm/CAS/BuiltinCASContext.h
+++ b/llvm/include/llvm/CAS/BuiltinCASContext.h
@@ -55,7 +55,7 @@ using HasherT = BLAKE3;
 using HashType = decltype(HasherT::hash(std::declval<ArrayRef<uint8_t> &>()));
 
 /// CASContext for LLVM builtin CAS using BLAKE3 hash type.
-class BuiltinCASContext : public CASContext {
+class LLVM_ABI BuiltinCASContext : public CASContext {
   void printIDImpl(raw_ostream &OS, const CASID &ID) const final;
   void anchor() override;
 

--- a/llvm/include/llvm/CAS/CASID.h
+++ b/llvm/include/llvm/CAS/CASID.h
@@ -25,7 +25,7 @@ namespace cas {
 class CASID;
 
 /// Context for CAS identifiers.
-class CASContext {
+class LLVM_ABI CASContext {
   virtual void anchor();
 
 public:
@@ -57,7 +57,7 @@ protected:
 /// compared by hash, in which case the result of \a getHash() is compared.
 class CASID {
 public:
-  void dump() const;
+  LLVM_ABI void dump() const;
 
   friend raw_ostream &operator<<(raw_ostream &OS, const CASID &ID) {
     ID.print(OS);

--- a/llvm/include/llvm/CAS/ObjectStore.h
+++ b/llvm/include/llvm/CAS/ObjectStore.h
@@ -87,7 +87,7 @@ class ObjectProxy;
 ///   long as \a ObjectStore.
 /// - \a readRef() and \a forEachRef() iterate through the references in an
 ///   object. There is no lifetime assumption.
-class ObjectStore {
+class LLVM_ABI ObjectStore {
   friend class ObjectProxy;
   void anchor();
 
@@ -200,8 +200,7 @@ protected:
 
 public:
   /// Helper functions to store object and returns a ObjectProxy.
-  LLVM_ABI_FOR_TEST Expected<ObjectProxy> createProxy(ArrayRef<ObjectRef> Refs,
-                                                      StringRef Data);
+  Expected<ObjectProxy> createProxy(ArrayRef<ObjectRef> Refs, StringRef Data);
 
   /// Store object from StringRef.
   Expected<ObjectRef> storeFromString(ArrayRef<ObjectRef> Refs,
@@ -227,10 +226,10 @@ public:
   static Error createUnknownObjectError(const CASID &ID);
 
   /// Create ObjectProxy from CASID. If the object doesn't exist, get an error.
-  LLVM_ABI Expected<ObjectProxy> getProxy(const CASID &ID);
+  Expected<ObjectProxy> getProxy(const CASID &ID);
   /// Create ObjectProxy from ObjectRef. If the object can't be loaded, get an
   /// error.
-  LLVM_ABI Expected<ObjectProxy> getProxy(ObjectRef Ref);
+  Expected<ObjectProxy> getProxy(ObjectRef Ref);
 
   /// \returns \c std::nullopt if the object is missing from the CAS.
   Expected<std::optional<ObjectProxy>> getProxyIfExists(ObjectRef Ref);
@@ -272,8 +271,7 @@ public:
 
   /// Import object from another CAS. This will import the full tree from the
   /// other CAS.
-  LLVM_ABI Expected<ObjectRef> importObject(ObjectStore &Upstream,
-                                            ObjectRef Other);
+  Expected<ObjectRef> importObject(ObjectStore &Upstream, ObjectRef Other);
 
   /// Print the ObjectStore internals for debugging purpose.
   virtual void print(raw_ostream &) const {}
@@ -315,7 +313,7 @@ public:
     return CAS->forEachRef(H, Callback);
   }
 
-  std::unique_ptr<MemoryBuffer>
+  LLVM_ABI std::unique_ptr<MemoryBuffer>
   getMemoryBuffer(StringRef Name = "",
                   bool RequiresNullTerminator = true) const;
 
@@ -360,7 +358,7 @@ private:
 LLVM_ABI std::unique_ptr<ObjectStore> createInMemoryCAS();
 
 /// \returns true if \c LLVM_ENABLE_ONDISK_CAS configuration was enabled.
-bool isOnDiskCASEnabled();
+LLVM_ABI bool isOnDiskCASEnabled();
 
 /// Create a persistent on-disk path at \p Path.
 LLVM_ABI Expected<std::unique_ptr<ObjectStore>>

--- a/llvm/include/llvm/CAS/OnDiskDataAllocator.h
+++ b/llvm/include/llvm/CAS/OnDiskDataAllocator.h
@@ -66,7 +66,7 @@ public:
 
   /// \returns the buffer that was allocated at \p create time, with size
   /// \p UserHeaderSize.
-  MutableArrayRef<uint8_t> getUserHeader() const;
+  LLVM_ABI MutableArrayRef<uint8_t> getUserHeader() const;
 
   LLVM_ABI_FOR_TEST size_t size() const;
   LLVM_ABI_FOR_TEST size_t capacity() const;

--- a/llvm/include/llvm/CAS/OnDiskGraphDB.h
+++ b/llvm/include/llvm/CAS/OnDiskGraphDB.h
@@ -202,8 +202,8 @@ public:
   explicit ObjectHandle(uint64_t Opaque) : Opaque(Opaque) {}
   uint64_t getOpaqueData() const { return Opaque; }
 
-  static ObjectHandle fromFileOffset(FileOffset Offset);
-  static ObjectHandle fromMemory(uintptr_t Ptr);
+  LLVM_ABI static ObjectHandle fromFileOffset(FileOffset Offset);
+  LLVM_ABI static ObjectHandle fromMemory(uintptr_t Ptr);
 
   friend bool operator==(const ObjectHandle &LHS, const ObjectHandle &RHS) {
     return LHS.Opaque == RHS.Opaque;
@@ -298,7 +298,7 @@ public:
 
   /// Check whether the object associated with \p Ref is stored in the CAS.
   /// Note that this function will fault-in according to the policy.
-  Expected<bool> isMaterialized(ObjectID Ref);
+  LLVM_ABI Expected<bool> isMaterialized(ObjectID Ref);
 
   /// Check whether the object associated with \p Ref is stored in the CAS.
   /// Note that this function does not fault-in.
@@ -351,7 +351,8 @@ public:
   /// loading the data in memory and then writing it to a file, the client could
   /// clone the underlying file directly. The client *must not* write to or
   /// delete the underlying file, the path is provided only for reading/copying.
-  FileBackedData getInternalFileBackedObjectData(ObjectHandle Node) const;
+  LLVM_ABI FileBackedData
+  getInternalFileBackedObjectData(ObjectHandle Node) const;
 
   /// \returns Total size of stored objects.
   ///
@@ -362,9 +363,9 @@ public:
   /// \returns The precentage of space utilization of hard space limits.
   ///
   /// Return value is an integer between 0 and 100 for percentage.
-  unsigned getHardStorageLimitUtilization() const;
+  LLVM_ABI unsigned getHardStorageLimitUtilization() const;
 
-  void print(raw_ostream &OS) const;
+  LLVM_ABI void print(raw_ostream &OS) const;
 
   /// Hashing function type for validation.
   using HashingFuncT = function_ref<void(
@@ -376,7 +377,7 @@ public:
   /// corruption in stored objects, otherwise just validate the structure of
   /// CAS database.
   /// \param Hasher is the hashing function used for objects inside CAS.
-  Error validate(bool Deep, HashingFuncT Hasher) const;
+  LLVM_ABI Error validate(bool Deep, HashingFuncT Hasher) const;
 
   /// Checks that \p ID exists in the index. It is allowed to not have data
   /// associated with it.

--- a/llvm/include/llvm/CAS/OnDiskTrieRawHashMap.h
+++ b/llvm/include/llvm/CAS/OnDiskTrieRawHashMap.h
@@ -53,8 +53,8 @@ class OnDiskCASLogger;
 ///   are only appropriate for local storage.
 class OnDiskTrieRawHashMap {
 public:
-  LLVM_DUMP_METHOD void dump() const;
-  void
+  LLVM_DUMP_METHOD LLVM_ABI void dump() const;
+  LLVM_ABI void
   print(raw_ostream &OS,
         function_ref<void(ArrayRef<char>)> PrintRecordData = nullptr) const;
 

--- a/llvm/include/llvm/CAS/UnifiedOnDiskCache.h
+++ b/llvm/include/llvm/CAS/UnifiedOnDiskCache.h
@@ -93,7 +93,7 @@ public:
   /// was invalid but has been cleared, \c Skipped if validation is not needed,
   /// or an \c Error if validation cannot be performed or if the data is left
   /// in an invalid state because \p AllowRecovery is false.
-  static Expected<ValidationResult>
+  LLVM_ABI static Expected<ValidationResult>
   validateIfNeeded(StringRef Path, StringRef HashName, unsigned HashByteSize,
                    bool CheckHash, OnDiskGraphDB::HashingFuncT HashFn,
                    bool AllowRecovery, bool ForceValidation,
@@ -141,7 +141,7 @@ public:
   collectGarbage(StringRef Path, ondisk::OnDiskCASLogger *Logger = nullptr);
 
   /// Remove unused data from the current UnifiedOnDiskCache.
-  Error collectGarbage();
+  LLVM_ABI Error collectGarbage();
 
   /// Helper function to convert the value stored in KeyValueDB and ObjectID.
   LLVM_ABI_FOR_TEST static ObjectID getObjectIDFromValue(ArrayRef<char> Value);


### PR DESCRIPTION
This updates most LLVM_ABI annotations in the CAS headers to match expected usage:
* All public APIs should be properly annotated.
* Inlined functions should not be annotated.

These changes were done by a script fixing annotations on LLVM public headers and manually checked.

This effort is tracked in #109483.