### PR TITLE
[llvm] Fix most LLVM_ABI annotations in Frontend

### DIFF
--- a/llvm/include/llvm/Frontend/HLSL/CBuffer.h
+++ b/llvm/include/llvm/Frontend/HLSL/CBuffer.h
@@ -46,14 +46,14 @@ class CBufferMetadata {
   CBufferMetadata(NamedMDNode *MD) : MD(MD) {}
 
 public:
-  static std::optional<CBufferMetadata>
+  LLVM_ABI static std::optional<CBufferMetadata>
   get(Module &M, llvm::function_ref<bool(Type *)> IsPadding);
 
   using iterator = SmallVector<CBufferMapping>::iterator;
   iterator begin() { return Mappings.begin(); }
   iterator end() { return Mappings.end(); }
 
-  void eraseFromModule();
+  LLVM_ABI void eraseFromModule();
 };
 
 } // namespace hlsl

--- a/llvm/include/llvm/Frontend/HLSL/HLSLBinding.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLBinding.h
@@ -174,7 +174,7 @@ public:
         [&HasOverlap](auto, auto) { HasOverlap = true; });
   }
 
-  LLVM_ABI BoundRegs takeBoundRegs() {
+  BoundRegs takeBoundRegs() {
     assert(std::is_sorted(Bindings.begin(), Bindings.end()) &&
            "takeBoundRegs should only be called after calculateBindingInfo");
     return BoundRegs(std::move(Bindings));

--- a/llvm/include/llvm/Frontend/HLSL/RootSignatureMetadata.h
+++ b/llvm/include/llvm/Frontend/HLSL/RootSignatureMetadata.h
@@ -30,7 +30,7 @@ namespace rootsig {
 class RootSignatureValidationError
     : public ErrorInfo<RootSignatureValidationError> {
 public:
-  static char ID;
+  LLVM_ABI static char ID;
   std::string Msg;
 
   RootSignatureValidationError(const Twine &Msg) : Msg(Msg.str()) {}

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.h
@@ -101,7 +101,7 @@ LLVM_ABI ArrayRef<unsigned> getOpenMPVersions();
 
 /// Can directive D, under some circumstances, create a private copy
 /// of a variable in given OpenMP version?
-bool isPrivatizingConstruct(Directive D, unsigned Version);
+LLVM_ABI bool isPrivatizingConstruct(Directive D, unsigned Version);
 
 /// Create a nicer version of a function name for humans to look at.
 LLVM_ABI std::string prettifyFunctionName(StringRef FunctionName);

--- a/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPIRBuilder.h
@@ -594,12 +594,13 @@ public:
     /// The basic block to which control should be transferred to
     /// implement the FiniCB. Memoized to avoid generating finalization
     /// multiple times.
-    Expected<BasicBlock *> getFiniBB(IRBuilderBase &Builder);
+    LLVM_ABI Expected<BasicBlock *> getFiniBB(IRBuilderBase &Builder);
 
     /// For cases where there is an unavoidable existing finalization block
     /// (e.g. loop finialization after omp sections). The existing finalization
     /// block must not contain any non-finalization code.
-    Error mergeFiniBB(IRBuilderBase &Builder, BasicBlock *ExistingFiniBB);
+    LLVM_ABI Error mergeFiniBB(IRBuilderBase &Builder,
+                               BasicBlock *ExistingFiniBB);
 
   private:
     /// Access via getFiniBB.
@@ -2431,9 +2432,9 @@ public:
 
   LLVM_ABI Function *getOrCreateRuntimeFunctionPtr(omp::RuntimeFunction FnID);
 
-  CallInst *createRuntimeFunctionCall(FunctionCallee Callee,
-                                      ArrayRef<Value *> Args,
-                                      StringRef Name = "");
+  LLVM_ABI CallInst *createRuntimeFunctionCall(FunctionCallee Callee,
+                                               ArrayRef<Value *> Args,
+                                               StringRef Name = "");
 
   /// Return the (LLVM-IR) string describing the source location \p LocStr.
   LLVM_ABI Constant *getOrCreateSrcLocStr(StringRef LocStr,
@@ -2560,7 +2561,7 @@ public:
 
   /// Helper that contains information about regions we need to outline
   /// during finalization.
-  struct OutlineInfo {
+  struct LLVM_ABI OutlineInfo {
     using PostOutlineCBTy = std::function<void(Function &)>;
     PostOutlineCBTy PostOutlineCB;
     BasicBlock *EntryBB, *ExitBB, *OuterAllocBB;
@@ -2570,18 +2571,18 @@ public:
     // TODO: this should be safe to enable by default
     bool FixUpNonEntryAllocas = false;
 
-    LLVM_ABI virtual ~OutlineInfo() = default;
+    virtual ~OutlineInfo() = default;
 
     /// Collect all blocks in between EntryBB and ExitBB in both the given
     /// vector and set.
-    LLVM_ABI void collectBlocks(SmallPtrSetImpl<BasicBlock *> &BlockSet,
-                                SmallVectorImpl<BasicBlock *> &BlockVector);
+    void collectBlocks(SmallPtrSetImpl<BasicBlock *> &BlockSet,
+                       SmallVectorImpl<BasicBlock *> &BlockVector);
 
     /// Create a CodeExtractor instance based on the information stored in this
     /// structure, the list of collected blocks from a previous call to
     /// \c collectBlocks and a flag stating whether arguments must be passed in
     /// address space 0.
-    LLVM_ABI virtual std::unique_ptr<CodeExtractor>
+    virtual std::unique_ptr<CodeExtractor>
     createCodeExtractor(ArrayRef<BasicBlock *> Blocks,
                         bool ArgsInZeroAddressSpace, Twine Suffix = Twine(""));
 


### PR DESCRIPTION
This updates most LLVM_ABI annotations in the Frontend headers to match expected usage:
* All public APIs should be properly annotated.
* Inlined functions should not be annotated.

These changes were done by a script fixing annotations on LLVM public headers and manually checked.

This effort is tracked in #109483.