### PR TITLE
[llvm] Fix most LLVM_ABI annotations in TableGen

### DIFF
--- a/llvm/include/llvm/TableGen/Error.h
+++ b/llvm/include/llvm/TableGen/Error.h
@@ -22,38 +22,44 @@ class Record;
 class RecordVal;
 class Init;
 
-void PrintNote(const Twine &Msg);
-void PrintNote(function_ref<void(raw_ostream &OS)> PrintMsg);
-void PrintNote(ArrayRef<SMLoc> NoteLoc, const Twine &Msg);
+LLVM_ABI void PrintNote(const Twine &Msg);
+LLVM_ABI void PrintNote(function_ref<void(raw_ostream &OS)> PrintMsg);
+LLVM_ABI void PrintNote(ArrayRef<SMLoc> NoteLoc, const Twine &Msg);
 
-[[noreturn]] void PrintFatalNote(const Twine &Msg);
-[[noreturn]] void PrintFatalNote(ArrayRef<SMLoc> ErrorLoc, const Twine &Msg);
-[[noreturn]] void PrintFatalNote(const Record *Rec, const Twine &Msg);
-[[noreturn]] void PrintFatalNote(const RecordVal *RecVal, const Twine &Msg);
+[[noreturn]] LLVM_ABI void PrintFatalNote(const Twine &Msg);
+[[noreturn]] LLVM_ABI void PrintFatalNote(ArrayRef<SMLoc> ErrorLoc,
+                                          const Twine &Msg);
+[[noreturn]] LLVM_ABI void PrintFatalNote(const Record *Rec, const Twine &Msg);
+[[noreturn]] LLVM_ABI void PrintFatalNote(const RecordVal *RecVal,
+                                          const Twine &Msg);
 
-void PrintWarning(const Twine &Msg);
-void PrintWarning(ArrayRef<SMLoc> WarningLoc, const Twine &Msg);
-void PrintWarning(const char *Loc, const Twine &Msg);
+LLVM_ABI void PrintWarning(const Twine &Msg);
+LLVM_ABI void PrintWarning(ArrayRef<SMLoc> WarningLoc, const Twine &Msg);
+LLVM_ABI void PrintWarning(const char *Loc, const Twine &Msg);
 
-void PrintError(const Twine &Msg);
-void PrintError(function_ref<void(raw_ostream &OS)> PrintMsg);
-void PrintError(ArrayRef<SMLoc> ErrorLoc, const Twine &Msg);
-void PrintError(const char *Loc, const Twine &Msg);
-void PrintError(const Record *Rec, const Twine &Msg);
-void PrintError(const RecordVal *RecVal, const Twine &Msg);
+LLVM_ABI void PrintError(const Twine &Msg);
+LLVM_ABI void PrintError(function_ref<void(raw_ostream &OS)> PrintMsg);
+LLVM_ABI void PrintError(ArrayRef<SMLoc> ErrorLoc, const Twine &Msg);
+LLVM_ABI void PrintError(const char *Loc, const Twine &Msg);
+LLVM_ABI void PrintError(const Record *Rec, const Twine &Msg);
+LLVM_ABI void PrintError(const RecordVal *RecVal, const Twine &Msg);
 
-[[noreturn]] void PrintFatalError(const Twine &Msg);
-[[noreturn]] void PrintFatalError(ArrayRef<SMLoc> ErrorLoc, const Twine &Msg);
-[[noreturn]] void PrintFatalError(const Record *Rec, const Twine &Msg);
-[[noreturn]] void PrintFatalError(const RecordVal *RecVal, const Twine &Msg);
-[[noreturn]] void PrintFatalError(function_ref<void(raw_ostream &OS)> PrintMsg);
+[[noreturn]] LLVM_ABI void PrintFatalError(const Twine &Msg);
+[[noreturn]] LLVM_ABI void PrintFatalError(ArrayRef<SMLoc> ErrorLoc,
+                                           const Twine &Msg);
+[[noreturn]] LLVM_ABI void PrintFatalError(const Record *Rec, const Twine &Msg);
+[[noreturn]] LLVM_ABI void PrintFatalError(const RecordVal *RecVal,
+                                           const Twine &Msg);
+[[noreturn]] LLVM_ABI void
+PrintFatalError(function_ref<void(raw_ostream &OS)> PrintMsg);
 
 // Returns true if the assert failed.
-bool CheckAssert(SMLoc Loc, const Init *Condition, const Init *Message);
-void dumpMessage(SMLoc Loc, const Init *Message);
+LLVM_ABI bool CheckAssert(SMLoc Loc, const Init *Condition,
+                          const Init *Message);
+LLVM_ABI void dumpMessage(SMLoc Loc, const Init *Message);
 
-extern SourceMgr SrcMgr;
-extern unsigned ErrorsPrinted;
+extern LLVM_ABI SourceMgr SrcMgr;
+extern LLVM_ABI unsigned ErrorsPrinted;
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/TableGen/Main.h
+++ b/llvm/include/llvm/TableGen/Main.h
@@ -37,13 +37,14 @@ using TableGenMainFn =
 using MultiFileTableGenMainFn = function_ref<bool(TableGenOutputFiles &OutFiles,
                                                   const RecordKeeper &Records)>;
 
-int TableGenMain(const char *argv0, TableGenMainFn MainFn = nullptr);
+LLVM_ABI int TableGenMain(const char *argv0, TableGenMainFn MainFn = nullptr);
 
-int TableGenMain(const char *argv0, MultiFileTableGenMainFn MainFn = nullptr);
+LLVM_ABI int TableGenMain(const char *argv0,
+                          MultiFileTableGenMainFn MainFn = nullptr);
 
 /// Controls emitting large character arrays as strings or character arrays.
 /// Typically set to false when building with MSVC.
-extern cl::opt<bool> EmitLongStrLiterals;
+extern LLVM_ABI cl::opt<bool> EmitLongStrLiterals;
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/TableGen/Parser.h
+++ b/llvm/include/llvm/TableGen/Parser.h
@@ -13,6 +13,8 @@
 #ifndef LLVM_TABLEGEN_PARSER_H
 #define LLVM_TABLEGEN_PARSER_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 class RecordKeeper;
 class SourceMgr;
@@ -23,7 +25,7 @@ class SourceMgr;
 ///
 /// NOTE: TableGen currently relies on global state within a given parser
 ///       invocation, so this function is not thread-safe.
-bool TableGenParseFile(SourceMgr &InputSrcMgr, RecordKeeper &Records);
+LLVM_ABI bool TableGenParseFile(SourceMgr &InputSrcMgr, RecordKeeper &Records);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/TableGen/SetTheory.h
+++ b/llvm/include/llvm/TableGen/SetTheory.h
@@ -68,7 +68,7 @@ public:
   using RecSet = SmallSetVector<const Record *, 16>;
 
   /// Operator - A callback representing a DAG operator.
-  class Operator {
+  class LLVM_ABI Operator {
     virtual void anchor();
 
   public:
@@ -83,7 +83,7 @@ public:
   /// Expander - A callback function that can transform a Record representing a
   /// set into a fully expanded list of elements. Expanders provide a way for
   /// users to define named sets that can be used in DAG expressions.
-  class Expander {
+  class LLVM_ABI Expander {
     virtual void anchor();
 
   public:
@@ -106,10 +106,10 @@ private:
 
 public:
   /// Create a SetTheory instance with only the standard operators.
-  SetTheory();
+  LLVM_ABI SetTheory();
 
   /// addExpander - Add an expander for Records with the named super class.
-  void addExpander(StringRef ClassName, std::unique_ptr<Expander>);
+  LLVM_ABI void addExpander(StringRef ClassName, std::unique_ptr<Expander>);
 
   /// addFieldExpander - Add an expander for ClassName that simply evaluates
   /// FieldName in the Record to get the set elements. That is all that is
@@ -119,13 +119,13 @@ public:
   ///     dag Elts = d;
   ///   }
   ///
-  void addFieldExpander(StringRef ClassName, StringRef FieldName);
+  LLVM_ABI void addFieldExpander(StringRef ClassName, StringRef FieldName);
 
   /// addOperator - Add a DAG operator.
-  void addOperator(StringRef Name, std::unique_ptr<Operator>);
+  LLVM_ABI void addOperator(StringRef Name, std::unique_ptr<Operator>);
 
   /// evaluate - Evaluate Expr and append the resulting set to Elts.
-  void evaluate(const Init *Expr, RecSet &Elts, ArrayRef<SMLoc> Loc);
+  LLVM_ABI void evaluate(const Init *Expr, RecSet &Elts, ArrayRef<SMLoc> Loc);
 
   /// evaluate - Evaluate a sequence of Inits and append to Elts.
   template<typename Iter>
@@ -137,7 +137,7 @@ public:
   /// expand - Expand a record into a set of elements if possible. Return a
   /// pointer to the expanded elements, or NULL if Set cannot be expanded
   /// further.
-  const RecVec *expand(const Record *Set);
+  LLVM_ABI const RecVec *expand(const Record *Set);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/TableGen/StringMatcher.h
+++ b/llvm/include/llvm/TableGen/StringMatcher.h
@@ -41,7 +41,7 @@ public:
                 raw_ostream &OS)
       : StrVariableName(StrVariableName), Matches(Matches), OS(OS) {}
 
-  void Emit(unsigned Indent = 0, bool IgnoreDuplicates = false) const;
+  LLVM_ABI void Emit(unsigned Indent = 0, bool IgnoreDuplicates = false) const;
 
 private:
   bool EmitStringMatcherForChar(ArrayRef<const StringPair *> Matches,

--- a/llvm/include/llvm/TableGen/StringToOffsetTable.h
+++ b/llvm/include/llvm/TableGen/StringToOffsetTable.h
@@ -43,7 +43,7 @@ public:
   bool empty() const { return StringOffset.empty(); }
   size_t size() const { return AggregateString.size(); }
 
-  unsigned GetOrAddStringOffset(StringRef Str);
+  LLVM_ABI unsigned GetOrAddStringOffset(StringRef Str);
 
   // Returns the offset of `Str` in the table if its preset, else return
   // std::nullopt.
@@ -65,10 +65,10 @@ public:
   // The string table, and its input string contents, are always emitted as both
   // `static` and `constexpr`. Both `Name` and (`Name` + "Storage") must be
   // valid identifiers to declare.
-  void EmitStringTableDef(raw_ostream &OS, const Twine &Name) const;
+  LLVM_ABI void EmitStringTableDef(raw_ostream &OS, const Twine &Name) const;
 
   // Emit the string as one single string.
-  void EmitString(raw_ostream &O) const;
+  LLVM_ABI void EmitString(raw_ostream &O) const;
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/TableGen/TGTimer.h
+++ b/llvm/include/llvm/TableGen/TGTimer.h
@@ -38,17 +38,17 @@ public:
   }
 
   /// Start timing a phase. Automatically stops any previous phase timer.
-  void startTimer(StringRef Name);
+  LLVM_ABI void startTimer(StringRef Name);
 
   /// Stop timing a phase.
-  void stopTimer();
+  LLVM_ABI void stopTimer();
 
   /// Start timing the overall backend. If the backend itself starts a timer,
   /// then this timer is cleared.
-  void startBackendTimer(StringRef Name);
+  LLVM_ABI void startBackendTimer(StringRef Name);
 
   /// Stop timing the overall backend.
-  void stopBackendTimer();
+  LLVM_ABI void stopBackendTimer();
 
   /// Stop phase timing and print the report.
   void stopPhaseTiming() { TimingGroup.reset(); }

--- a/llvm/include/llvm/TableGen/TableGenBackend.h
+++ b/llvm/include/llvm/TableGen/TableGenBackend.h
@@ -51,7 +51,7 @@ struct FnT {
 /// \p ByDefault is true, then that callback is applied by default if no
 /// command line option was specified.
 struct Opt {
-  Opt(StringRef Name, FnT CB, StringRef Desc, bool ByDefault = false);
+  LLVM_ABI Opt(StringRef Name, FnT CB, StringRef Desc, bool ByDefault = false);
 };
 
 /// Convienence wrapper around `Opt` that registers `EmitterClass::run` as the
@@ -82,15 +82,16 @@ public:
 
 /// Apply callback for any command line option registered above. Returns false
 /// is no callback was applied.
-bool ApplyCallback(const RecordKeeper &Records, TableGenOutputFiles &OutFiles,
-                   StringRef FilenamePrefix);
+LLVM_ABI bool ApplyCallback(const RecordKeeper &Records,
+                            TableGenOutputFiles &OutFiles,
+                            StringRef FilenamePrefix);
 
 } // namespace TableGen::Emitter
 
 /// emitSourceFileHeader - Output an LLVM style file header to the specified
 /// raw_ostream.
-void emitSourceFileHeader(StringRef Desc, raw_ostream &OS,
-                          const RecordKeeper &Record = RecordKeeper());
+LLVM_ABI void emitSourceFileHeader(StringRef Desc, raw_ostream &OS,
+                                   const RecordKeeper &Record = RecordKeeper());
 
 } // namespace llvm
 


### PR DESCRIPTION
This updates most LLVM_ABI annotations in the TableGen headers to match expected usage:
* All public APIs should be properly annotated.
* Inlined functions should not be annotated.

These changes were done by a script fixing annotations on LLVM public headers and manually checked.

This effort is tracked in #109483.