### PR TITLE
[Flang][OpenMP] Fix crash when common block name is used in LINEAR clause

### DIFF
--- a/flang/lib/Semantics/check-omp-loop.cpp
+++ b/flang/lib/Semantics/check-omp-loop.cpp
@@ -724,15 +724,6 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Linear &x) {
   auto &objects{std::get<parser::OmpObjectList>(x.v.t)};
   CheckVarIsNotPartOfAnotherVar(GetContext().clauseSource, objects, "LINEAR");
   CheckCrayPointee(objects, "LINEAR", false);
-  for (const auto &ompObject : objects.v) {
-    if (const auto *name{std::get_if<parser::Name>(&ompObject.u)}) {
-      if (name->symbol && name->symbol->has<CommonBlockDetails>()) {
-        context_.Say(name->source,
-            "'%s' is a common block name and must not appear in a LINEAR clause"_err_en_US,
-            name->symbol->name());
-      }
-    }
-  }
   GetSymbolsInObjectList(objects, symbols);
 
   auto CheckIntegerNoRef{[&](const Symbol *symbol, parser::CharBlock source) {

--- a/flang/lib/Semantics/check-omp-loop.cpp
+++ b/flang/lib/Semantics/check-omp-loop.cpp
@@ -724,6 +724,15 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Linear &x) {
   auto &objects{std::get<parser::OmpObjectList>(x.v.t)};
   CheckVarIsNotPartOfAnotherVar(GetContext().clauseSource, objects, "LINEAR");
   CheckCrayPointee(objects, "LINEAR", false);
+  for (const auto &ompObject : objects.v) {
+    if (const auto *name{std::get_if<parser::Name>(&ompObject.u)}) {
+      if (name->symbol && name->symbol->has<CommonBlockDetails>()) {
+        context_.Say(name->source,
+            "'%s' is a common block name and must not appear in a LINEAR clause"_err_en_US,
+            name->symbol->name());
+      }
+    }
+  }
   GetSymbolsInObjectList(objects, symbols);
 
   auto CheckIntegerNoRef{[&](const Symbol *symbol, parser::CharBlock source) {

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -693,10 +693,14 @@ void OmpStructureChecker::CheckArgumentObjectKind(const parser::OmpClause &x) {
   // clauses. Assumed-size arrays are allowed on "map", "shared", and
   // "use_device_addr". The check for this happens a few lines below.
   bool AssumedSizeArrayAllowed{false};
+  bool CommonBlockAllowed{true};
   bool NamedConstantAllowed{false};
   switch (clauseId) {
   case llvm::omp::Clause::OMPC_firstprivate:
     NamedConstantAllowed = true;
+    break;
+  case llvm::omp::Clause::OMPC_linear:
+    CommonBlockAllowed = false;
     break;
   case llvm::omp::Clause::OMPC_map:
     AssumedSizeArrayAllowed = true;
@@ -728,6 +732,12 @@ void OmpStructureChecker::CheckArgumentObjectKind(const parser::OmpClause &x) {
       context_.Say(source,
           "A whole assumed-size array is not allowed as a list item on %s clause"_err_en_US,
           parser::omp::GetUpperName(clauseId, version));
+      continue;
+    }
+    if (!CommonBlockAllowed && IsCommonBlock(*symbol)) {
+      context_.Say(source,
+          "'%s' is a common block name and must not appear in a %s clause"_err_en_US,
+          symbol->name(), parser::omp::GetUpperName(clauseId, version));
       continue;
     }
     // Emit a more user-friendly diagnostic than "'kind' must be a variable

--- a/flang/test/Semantics/OpenMP/linear-clause01.f90
+++ b/flang/test/Semantics/OpenMP/linear-clause01.f90
@@ -46,6 +46,20 @@ subroutine linear_clause_03(arg)
     !ERROR: The list item `i` must be a dummy argument
     !$omp declare simd linear(i)
 
+    !ERROR: 'cc' is a common block name and must not appear in a LINEAR clause
     !ERROR: The list item `i` must be a dummy argument
     !$omp declare simd linear(/cc/)
 end subroutine linear_clause_03
+
+! Case 4
+subroutine linear_clause_04(x)
+    real :: x(10)
+    integer :: b
+    common /c/ b
+    !ERROR: 'c' is a common block name and must not appear in a LINEAR clause
+    !$omp simd linear(/c/)
+      do i = 1, 10
+        x(i) = x(i) * 2
+      end do
+    !$omp end simd
+end subroutine linear_clause_04


### PR DESCRIPTION
[Flang][OpenMP] Fix crash when common block name is used in LINEAR clause

  Using a common block name in a LINEAR clause (e.g. linear(/c/))
  caused
  a symbol-must-have-a-type crash during lowering. The semantic checker
  was not emitting an error because GetSymbolsInObjectList expands /c/
  to its member variables before the check runs, so the
  symbol->has<CommonBlockDetails>() guard was never reached.

  Fix by checking for common block names directly on the OmpObjectList
  before the expansion, where the Name variant of OmpObject still holds
  the common block symbol.

  Fixes #202329