### PR TITLE
[Dexter] Write expects for variables in Debugger scopes

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
@@ -555,15 +555,22 @@ class DAP(DebuggerBase, metaclass=abc.ABCMeta):
     # response when it arrives. An optional timeout for the response may be passed.
     # If allow_failure is passed, then the result may instead be a str containing the fail reason if the request failed.
     def _communicate_request(
-        self, command: str, arguments=None, timeout: float = 60.0, allow_failure=False
+        self, command: str, arguments=None, timeout: float = 60.0
+    ) -> Dict:
+        req_id = self.send_message(self.make_request(command, arguments))
+        response = self._await_response(req_id, timeout)
+        if not response["success"]:
+            raise DebuggerException(
+                f"received failure response for command {command}: {response['message']}"
+            )
+        return response["body"]
+
+    def _communicate_fallible_request(
+        self, command: str, arguments=None, timeout: float = 60.0
     ) -> Union[Dict, str]:
         req_id = self.send_message(self.make_request(command, arguments))
         response = self._await_response(req_id, timeout)
         if not response["success"]:
-            if not allow_failure:
-                raise DebuggerException(
-                    f"received failure response for command {command}"
-                )
             return response["message"]
         return response["body"]
 
@@ -1013,12 +1020,53 @@ class DAP(DebuggerBase, metaclass=abc.ABCMeta):
             stop_reason=reason,
         )
 
-    def collect_watches(self, step: StepIR, watches: List[str]):
+    def collect_watches(
+        self, step: StepIR, watches: List[str], scope_watches: List[str]
+    ):
         """Evaluates the provided watches and stores their evaluation results (ValueIR) in the provided step."""
         frame_idx = 0
-        if not watches:
+        if not watches and not scope_watches:
             return
         active_exprs = set(watches)
+        active_scopes = set(scope_watches)
+        frame_loc = step.frames[frame_idx].loc
+        frame_id = self._debugger_state.frame_map[frame_idx]
+        frame_scopes = self._communicate_request("scopes", {"frameId": frame_id})
+        for scope in frame_scopes["scopes"]:
+            scope_name = scope["name"]
+            if scope_name not in active_scopes:
+                continue
+            scope_vars_ref = scope["variablesReference"]
+            scope_vars = self._communicate_request(
+                "variables", {"variablesReference": scope_vars_ref}
+            )
+            assert isinstance(scope_vars, dict)
+            scope_var_values = {}
+            # Evaluate all scope variables.
+            for var in scope_vars["variables"]:
+                result = var["value"]
+                # Check to see whether this variable is in-scope yet.
+                # FIXME: This is just the best solution I can see right now, but we may want better in
+                # future (especially for languages with non-C-like declaration/scoping semantics).
+                if "declarationLocationReference" in var:
+                    declaration_loc = self._communicate_request(
+                        "locations",
+                        {"locationReference": var["declarationLocationReference"]},
+                    )
+                    if declaration_loc["line"] >= frame_loc.lineno:
+                        continue
+                value = self._evaluate_result_value(
+                    var["evaluateName"], result, var.get("type")
+                )
+                self._evaluate_subvariables(value, var["variablesReference"])
+                scope_var_values[value.expression] = value
+            step.scope_watches[scope_name] = list(scope_var_values.keys())
+            for var_name in sorted(step.scope_watches[scope_name]):
+                step.watches[var_name] = scope_var_values[var_name]
+            for expr in list(active_exprs):
+                if expr in scope_var_values:
+                    active_exprs.remove(expr)
+
         for expr in active_exprs:
             step.watches[expr] = self.evaluate_expression(expr, frame_idx)
 
@@ -1036,7 +1084,9 @@ class DAP(DebuggerBase, metaclass=abc.ABCMeta):
 
     @staticmethod
     @abc.abstractmethod
-    def _evaluate_result_value(expression: str, result_string: str) -> ValueIR:
+    def _evaluate_result_value(
+        expression: str, result_string: str, type_string: Optional[str]
+    ) -> ValueIR:
         """For the result of an "evaluate" message, return a ValueIR. Implementation must be debugger-specific."""
 
     # For the given `value` and associated `variables_reference`, recursively requests "variables" information for all

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DebuggerBase.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DebuggerBase.py
@@ -223,7 +223,9 @@ class DebuggerBase(object, metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def collect_watches(self, step: StepIR, watches: List[str]):
+    def collect_watches(
+        self, step: StepIR, watches: List[str], scope_watches: List[str]
+    ):
         pass
 
     @abc.abstractproperty

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DebuggerControllers/ScriptDebuggerController.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DebuggerControllers/ScriptDebuggerController.py
@@ -128,7 +128,13 @@ class ScriptDebuggerController(DebuggerControllerBase):
                 for expect in where_match.active_expects
                 if (watch := expect.get_watched_expr())
             ]
-            self.debugger.collect_watches(step_info, watches)
+            scope_watches = [
+                scope_watch
+                for where_match in active_where_matches.values()
+                for expect in where_match.active_expects
+                if (scope_watch := expect.get_watched_scope())
+            ]
+            self.debugger.collect_watches(step_info, watches, scope_watches)
 
             active_thens = [
                 then

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/dbgeng/dbgeng.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/dbgeng/dbgeng.py
@@ -171,7 +171,9 @@ class DbgEng(DebuggerBase):
     def get_stack_frames(self, step_index: int) -> StepIR:
         raise NotImplementedError("--use-script debugging not supported in dbgeng yet.")
 
-    def collect_watches(self, step: StepIR, watches: List[str]):
+    def collect_watches(
+        self, step: StepIR, watches: List[str], scope_watches: List[str]
+    ):
         raise NotImplementedError("--use-script debugging not supported in dbgeng yet.")
 
     @property

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
@@ -11,7 +11,7 @@ import os
 import shlex
 from subprocess import CalledProcessError, check_output, STDOUT
 import sys
-from typing import List
+from typing import List, Optional
 
 from dex.debugger.DebuggerBase import DebuggerBase, watch_is_active
 from dex.debugger.DAP import DAP
@@ -322,7 +322,9 @@ class LLDB(DebuggerBase):
     def get_stack_frames(self, step_index: int) -> StepIR:
         raise NotImplementedError("--use-script debugging not supported in lldb yet.")
 
-    def collect_watches(self, step: StepIR, watches: List[str]):
+    def collect_watches(
+        self, step: StepIR, watches: List[str], scope_watches: List[str]
+    ):
         raise NotImplementedError("--use-script debugging not supported in lldb yet.")
 
     @property
@@ -480,7 +482,7 @@ class LLDBDAP(DAP):
 
     @staticmethod
     def _evaluate_result_value(
-        expression: str, result_string: str, type_string
+        expression: str, result_string: str, type_string: Optional[str]
     ) -> ValueIR:
         could_evaluate = not any(
             s in result_string

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/visualstudio/VisualStudio.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/visualstudio/VisualStudio.py
@@ -398,7 +398,9 @@ class VisualStudio(
             "--use-script debugging not supported in visual studio yet."
         )
 
-    def collect_watches(self, step: StepIR, watches: List[str]):
+    def collect_watches(
+        self, step: StepIR, watches: List[str], scope_watches: List[str]
+    ):
         raise NotImplementedError(
             "--use-script debugging not supported in visual studio yet."
         )

--- a/cross-project-tests/debuginfo-tests/dexter/dex/dextIR/StepIR.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/dextIR/StepIR.py
@@ -9,7 +9,7 @@
 import json
 
 from collections import OrderedDict
-from typing import List
+from typing import Dict, List, Optional
 from enum import Enum
 from dex.dextIR.FrameIR import FrameIR
 from dex.dextIR.LocIR import LocIR
@@ -50,6 +50,7 @@ class StepIR:
         frames: List[FrameIR],
         step_kind: StepKind = None,
         watches: OrderedDict = None,
+        scope_watches: Optional[Dict[str, List[str]]] = None,
         program_state: ProgramState = None,
     ):
         self.step_index = step_index
@@ -64,6 +65,7 @@ class StepIR:
         if watches is None:
             watches = {}
         self.watches = watches
+        self.scope_watches = scope_watches or OrderedDict()
         self.hit_fn_bps: List[str] = []
 
     def __str__(self):
@@ -124,6 +126,13 @@ class StepIR:
             lines.append(f"    {fn_text}")
             lines.append(f"    {frame.loc}")
             lines.append(f"    $pc = {frame.instruction_addr}")
+
+        if self.scope_watches:
+            lines.append(f"Variable Scopes:")
+            for scope_name in sorted(self.scope_watches):
+                lines.append(
+                    f"  {scope_name}: [{', '.join(self.scope_watches[scope_name])}]"
+                )
 
         if self.watches:
             lines.append(f"Variables:")

--- a/cross-project-tests/debuginfo-tests/dexter/dex/evaluation/ExpectRewriter.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/evaluation/ExpectRewriter.py
@@ -227,7 +227,6 @@ class ScriptExpectRewriter:
             assert isinstance(expect, Value), "Non-Value expects currently unsupported"
             if expected_value is None:
                 self.unknown_expect_rewrites[expect] = []
-
         script.visit_script(visit_expect=collect_expects_to_rewrite)
 
         # If there are no expects to update, then there is no rewriting to be done - exit early.

--- a/cross-project-tests/debuginfo-tests/dexter/dex/evaluation/ExpectRewriter.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/evaluation/ExpectRewriter.py
@@ -6,16 +6,15 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Utilities for using debugger output to generate expected values that match that output."""
 
-from collections import Counter, OrderedDict, defaultdict
-from copy import deepcopy
-from enum import Enum, IntEnum
+from collections import defaultdict
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 from dex.dextIR import DextIR, StepIR, ValueIR
 from dex.evaluation.StateMatch import get_active_where_matches
-from dex.test_script.Nodes import Expect, Then, Value, Where
+from dex.test_script.Nodes import DexRange, Expect, Line, Then, Value, ValueAll, Where
 from dex.test_script.Script import DexterScript, Scope
 from dex.tools.Main import Context
+from dex.utils.Exceptions import Error
 
 
 class ExpectedValueRewriter:
@@ -69,6 +68,94 @@ def unique_expected_values(elements: List[ExpectedValueRewriter]):
     return result
 
 
+class ExpectedScopeRewriter:
+    """Given a list of ValueIRs for all variables in a scope, generates a set of expected values for each."""
+
+    def __init__(self, expect: Expect, step: StepIR, values: List[ValueIR]):
+        self.expect = expect
+        self.step = step
+        self.values = values
+        self.expected_values = [
+            ExpectedValueRewriter(expect, value) for value in values
+        ]
+
+
+# (StartLine, StopLine) -> [(Var, ExpectedValues)]
+ExpectedScopeRewrites = Dict[Optional[Tuple[int, int]], List[Tuple[str, Any]]]
+
+
+def collect_scope_values(
+    step_scope_values: List[ExpectedScopeRewriter],
+) -> ExpectedScopeRewrites:
+    if not step_scope_values:
+        return {}
+    assert all(
+        step_scope_values[0].step.current_location.path == sv.step.current_location.path
+        for sv in step_scope_values[1:]
+    ), "Dexter currently does not handle scope watches that span multiple files."
+    all_vars: Set[str] = set()
+    for step_scope_rewriter in step_scope_values:
+        all_vars.update(
+            ev_rewriter.root_value.expression
+            for ev_rewriter in step_scope_rewriter.expected_values
+        )
+    line_sorted_steps = sorted(
+        step_scope_values,
+        key=lambda step_scope_rewriter: step_scope_rewriter.step.current_location.lineno,
+    )
+
+    # Now we have a list of expected values for each variable sorted by the lines at which they appear; we use this to
+    # form blocks of continuous liveness. In general, for unoptimized code we expect variables to have a single
+    # continuous live range.
+    per_range_var_unique_expected_values: ExpectedScopeRewrites = defaultdict(list)
+    for var in sorted(all_vars):
+        # Now build a list of all continuous live ranges.
+        continuous_live_ranges: List[Tuple[int, int, List[ExpectedValueRewriter]]] = []
+        is_live = False
+        ever_dead = False
+        for step_scope_rewriter in line_sorted_steps:
+            line = step_scope_rewriter.step.current_location.lineno
+            var_ev_rewriter = next(
+                (
+                    ev_rewriter
+                    for ev_rewriter in step_scope_rewriter.expected_values
+                    if ev_rewriter.root_value.expression == var
+                ),
+                None,
+            )
+            if var_ev_rewriter is None or var_ev_rewriter.expected_value is None:
+                is_live = False
+                ever_dead = True
+                continue
+
+            if not is_live:
+                continuous_live_ranges.append((line, line, [var_ev_rewriter]))
+            else:
+                start, stop, range_evs = continuous_live_ranges[-1]
+                assert line >= stop
+                range_evs.append(var_ev_rewriter)
+                continuous_live_ranges[-1] = (start, line, range_evs)
+            is_live = True
+
+        if not continuous_live_ranges:
+            continue
+
+        if not ever_dead:
+            assert len(continuous_live_ranges) == 1
+            per_range_var_unique_expected_values[None].append(
+                (var, unique_expected_values(continuous_live_ranges[0][2]))
+            )
+            continue
+
+        # Finally, collect the results into the per_var map.
+        for start, stop, expected_values in continuous_live_ranges:
+            per_range_var_unique_expected_values[(start, stop)].append(
+                (var, unique_expected_values(expected_values))
+            )
+
+    return per_range_var_unique_expected_values
+
+
 class StepExpectRewriter:
     """Processes all active, unknown expects at a given debugger step and produces ExpectedValueRewriter results for
     each."""
@@ -82,13 +169,24 @@ class StepExpectRewriter:
             for where_match in self.state_match.values()
             for expect in where_match.active_expects
         }
-        self.expect_matches: Dict[Expect, ExpectedValueRewriter] = {}
+        self.expect_value_matches: Dict[Expect, ExpectedValueRewriter] = {}
+        self.expect_scope_matches: Dict[Expect, ExpectedScopeRewriter] = {}
 
         def add_expected_values(expect: Expect, expected_value: Any, scope: Scope):
-            assert isinstance(expect, Value), "Non-Value expects currently unsupported"
-            if expect in active_expects and expected_value is None:
-                self.expect_matches[expect] = ExpectedValueRewriter(
-                    expect, step.watches[expect.get_watched_expr()]
+            if expect not in active_expects or expected_value is not None:
+                return
+            if (expr := expect.get_watched_expr()) is not None:
+                self.expect_value_matches[expect] = ExpectedValueRewriter(
+                    expect, step.watches[expr]
+                )
+            elif (scope_name := expect.get_watched_scope()) is not None:
+                scope_vars = step.scope_watches.get(scope_name, [])
+                self.expect_scope_matches[expect] = ExpectedScopeRewriter(
+                    expect, step, [step.watches[var] for var in scope_vars]
+                )
+            else:
+                raise Error(
+                    f"Unexpected expect without watched expression or scope: {expect}"
                 )
 
         script.visit_script(visit_expect=add_expected_values)
@@ -104,8 +202,12 @@ class ScriptExpectRewriter:
         self.unknown_expect_rewrites: Dict[
             Expect, List[Tuple[int, ExpectedValueRewriter]]
         ] = {}
+        self.scope_expect_rewrites: Dict[
+            Expect, List[Tuple[int, ExpectedScopeRewriter]]
+        ] = {}
         self.new_script: Optional[DexterScript] = None
         self.new_expected_values: Dict[Expect, Any] = {}
+        self.new_expected_scopes: Dict[Expect, ExpectedScopeRewrites] = {}
         self.missing_expect_rewrites: List[Expect] = []
 
         script = dext_ir.script
@@ -115,15 +217,21 @@ class ScriptExpectRewriter:
 
         # Collect every Expect with an unknown value into the `unknown_expect_rewrites` dict. We expect all Expects in
         # this dict to have observed values, and don't expect to rewrite any Expects outside of this dict.
-        def collect_unknown_expects(expect: Expect, expected_value: Any, scope: Scope):
+        def collect_expects_to_rewrite(
+            expect: Expect, expected_value: Any, scope: Scope
+        ):
+            if isinstance(expect, ValueAll):
+                assert expected_value is None
+                self.scope_expect_rewrites[expect] = []
+                return
             assert isinstance(expect, Value), "Non-Value expects currently unsupported"
             if expected_value is None:
                 self.unknown_expect_rewrites[expect] = []
 
-        script.visit_script(visit_expect=collect_unknown_expects)
+        script.visit_script(visit_expect=collect_expects_to_rewrite)
 
         # If there are no expects to update, then there is no rewriting to be done - exit early.
-        if not self.unknown_expect_rewrites:
+        if not self.unknown_expect_rewrites and not self.scope_expect_rewrites:
             return
 
         # Populate the `unknown_expect_rewrites` dict, mapping each expect with an unknown value to its list of observed
@@ -133,9 +241,19 @@ class ScriptExpectRewriter:
         ]
         for step_rewriter in self.step_rewriters:
             step_idx = step_rewriter.step.step_index
-            for expect, expected_value_rewriter in step_rewriter.expect_matches.items():
+            for (
+                expect,
+                expected_value_rewriter,
+            ) in step_rewriter.expect_value_matches.items():
                 self.unknown_expect_rewrites[expect].append(
                     (step_idx, expected_value_rewriter)
+                )
+            for (
+                expect,
+                expected_scope_rewriter,
+            ) in step_rewriter.expect_scope_matches.items():
+                self.scope_expect_rewrites[expect].append(
+                    (step_idx, expected_scope_rewriter)
                 )
 
         # For each unknown expect, merge the observed values into a writable "expected values" entry, which may be a
@@ -150,9 +268,18 @@ class ScriptExpectRewriter:
             )
             is not None
         }
+        # Do the same for unknown scope expects.
+        self.new_expected_scopes = {
+            expect: collect_scope_values(
+                [rewriter for idx, rewriter in expect_rewriters]
+            )
+            for expect, expect_rewriters in self.scope_expect_rewrites.items()
+        }
 
         # Finally, use the new expected values to rewrite the script.
-        self.new_script = rewrite_script(script, self.new_expected_values)
+        self.new_script = rewrite_script(
+            script, self.new_expected_values, self.new_expected_scopes
+        )
         self.missing_expect_rewrites = [
             expect
             for expect in self.unknown_expect_rewrites
@@ -161,7 +288,10 @@ class ScriptExpectRewriter:
 
     @property
     def num_successful_rewrites(self):
-        return len(self.new_expected_values)
+        return len(self.new_expected_values) + sum(
+            sum(len(var_expects) for var_expects in new_expected_scope.values())
+            for new_expected_scope in self.new_expected_scopes.values()
+        )
 
     @property
     def num_unsuccessful_rewrites(self):
@@ -169,7 +299,9 @@ class ScriptExpectRewriter:
 
 
 def rewrite_script(
-    script: DexterScript, add_expected_values: Dict[Expect, Any]
+    script: DexterScript,
+    add_expected_values: Dict[Expect, Any],
+    expected_scope_rewrites: Dict[Expect, ExpectedScopeRewrites],
 ) -> DexterScript:
     """Given a set of updates to apply to a provided script, returns a copy of the script_obj with the updates
     applied.
@@ -194,12 +326,54 @@ def rewrite_script(
         new_node_child_map[scope.where] = then
 
     def replace_expect(expect: Expect, expected_value, scope: Scope):
-        new_expected_value = add_expected_values.get(expect) or expected_value
-        new_node_child_map[expect] = new_expected_value
         scope_where_children = new_node_child_map.setdefault(scope.where, [])
         assert isinstance(
             scope_where_children, list
         ), f"Unexpected child for state node {scope.where}: {scope_where_children}"
+        if isinstance(expect, ValueAll):
+            assert (
+                expect in expected_scope_rewrites
+            ), "Script-rewriter error: Dexter missed rewriting !expect/all node."
+            scope_rewrites = expected_scope_rewrites[expect]
+            for line_range in sorted(
+                scope_rewrites.keys(), key=lambda lines: lines or (0, 0)
+            ):
+                var_expected_values = scope_rewrites[line_range]
+                # First we determine which node will be the parent for the new expect nodes; then we can start appending
+                # new expects to that parent's child list.
+                if line_range is None:
+                    new_expect_sibling_list = scope_where_children
+                else:
+                    start, stop = line_range
+                    lines = (
+                        Line(start)
+                        if start == stop
+                        else DexRange(Line(start), Line(stop))
+                    )
+                    new_expect_parent = Where({"lines": lines}, is_and=True)
+                    # Reuse an existing !and node if one exists...
+                    try:
+                        existing_parent = next(
+                            node
+                            for node in scope_where_children
+                            if str(node) == str(new_expect_parent)
+                        )
+                        new_expect_sibling_list = new_node_child_map.setdefault(
+                            existing_parent, []
+                        )
+                    except StopIteration:
+                        scope_where_children.append(new_expect_parent)
+                        new_expect_sibling_list = new_node_child_map.setdefault(
+                            new_expect_parent, []
+                        )
+                for var, expected_values in var_expected_values:
+                    new_expect = Value(var)
+                    new_expect_sibling_list.append(new_expect)
+                    new_node_child_map[new_expect] = expected_values
+            return
+        assert isinstance(expect, Value)
+        new_expected_value = add_expected_values.get(expect) or expected_value
+        new_node_child_map[expect] = new_expected_value
         scope_where_children.append(expect)
 
     script.visit_script(

--- a/cross-project-tests/debuginfo-tests/dexter/dex/evaluation/ExpectRewriter.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/evaluation/ExpectRewriter.py
@@ -227,6 +227,7 @@ class ScriptExpectRewriter:
             assert isinstance(expect, Value), "Non-Value expects currently unsupported"
             if expected_value is None:
                 self.unknown_expect_rewrites[expect] = []
+
         script.visit_script(visit_expect=collect_expects_to_rewrite)
 
         # If there are no expects to update, then there is no rewriting to be done - exit early.

--- a/cross-project-tests/debuginfo-tests/dexter/dex/evaluation/StateMatch.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/evaluation/StateMatch.py
@@ -13,7 +13,7 @@ from typing import Dict, List, Optional, Tuple
 
 from dex.dextIR import FrameIR, StepIR
 from dex.test_script import DexterScript, Scope
-from dex.test_script.Nodes import Expect, FileLabels, Value, Where, Then
+from dex.test_script.Nodes import Expect, FileLabels, Where, Then
 
 
 def is_subpath(subpath: str, superpath: str) -> bool:
@@ -64,7 +64,7 @@ class WhereMatchResult:
     """
 
     frame_idx: int
-    active_expects: List[Value] = field(default_factory=list)
+    active_expects: List[Expect] = field(default_factory=list)
     active_thens: List[Then] = field(default_factory=list)
     pending_wheres: List[Where] = field(default_factory=list)
 
@@ -114,9 +114,6 @@ def get_active_where_matches(
     # As we visit the script nodes in pre-order traversal, we can always assume that an expect's parent !where
     # has already been visited, and thus should have an entry in active_where_expects if it is active.
     def get_active_expects(expect: Expect, expected_value, scope: Scope):
-        assert isinstance(
-            expect, Value
-        ), "Values should be the only type of expect possible!"
         if (
             scope.where in active_where_expects
             and active_where_expects[scope.where].frame_idx == 0

--- a/cross-project-tests/debuginfo-tests/dexter/dex/test_script/Nodes.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/test_script/Nodes.py
@@ -18,14 +18,7 @@ from dex.utils.Exceptions import Error
 
 
 def setup_yaml_parser(loader):
-    reg_classes = [
-        Where,
-        Value,
-        DexRange,
-        Label,
-        Then,
-        Address,
-    ]
+    reg_classes = [Where, Value, DexRange, Label, Then, Address, ValueAll]
     for c in reg_classes:
         c.register_yaml(loader)
 
@@ -156,9 +149,13 @@ class Expect:
         excluding any subvalues (i.e. struct members), or None if there is no valid result for this ValueIR.
         """
 
-    @abc.abstractmethod
-    def get_watched_expr(self) -> str:
-        """Returns the list of expressions that this Expect wants to evaluate."""
+    def get_watched_expr(self) -> Optional[str]:
+        """Returns the expression that this Expect wants to evaluate."""
+        return None
+
+    def get_watched_scope(self) -> Optional[str]:
+        """Returns the scope that this Expect wants to evaluate."""
+        return None
 
 
 class Value(Expect):
@@ -192,6 +189,34 @@ class Value(Expect):
     def register_yaml(loader):
         yaml.add_constructor("!value", Value.constructor, loader)
         yaml.add_representer(Value, Value.representer)
+
+
+class ValueAll(Expect):
+    def __init__(self, scope_name: str):
+        self.scope_name = scope_name
+
+    def __repr__(self):
+        return f"ValueAll({self.scope_name})"
+
+    @staticmethod
+    def get_variable_result(value: ValueIR) -> Optional[str]:
+        return Value.get_variable_result(value)
+
+    def get_watched_scope(self) -> Optional[str]:
+        return self.scope_name
+
+    @staticmethod
+    def constructor(loader, node):
+        return ValueAll(loader.construct_scalar(node))
+
+    @staticmethod
+    def representer(dumper, data):
+        return dumper.represent_scalar("!value/all", data.scope_name)
+
+    @staticmethod
+    def register_yaml(loader):
+        yaml.add_constructor("!value/all", ValueAll.constructor, loader)
+        yaml.add_representer(ValueAll, ValueAll.representer)
 
 
 ##############

--- a/cross-project-tests/debuginfo-tests/dexter/dex/test_script/Nodes.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/test_script/Nodes.py
@@ -192,6 +192,14 @@ class Value(Expect):
 
 
 class ValueAll(Expect):
+    """Expect node used to write values for all variables within a particular debugger scope, as defined by the DAP
+    specification; see: https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Scopes.
+
+    This node is not directly evaluated; it must have no expected values, and when Dexter rewrites the original script,
+    this node will be replaced with !value nodes for each variable that was seen in its scope inserted under !and nodes
+    that cover that variable's live range(s).
+    """
+
     def __init__(self, scope_name: str):
         self.scope_name = scope_name
 

--- a/cross-project-tests/debuginfo-tests/dexter/dex/test_script/Script.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/test_script/Script.py
@@ -21,6 +21,7 @@ from dex.test_script.Nodes import (
     FileLabels,
     Where,
     Then,
+    ValueAll,
     setup_yaml_parser,
 )
 
@@ -169,9 +170,18 @@ class DexterScript:
             if source_root_dir is not None
             else os.path.dirname(scope.file)
         )
+        self._validate()
+
+    def _validate(self):
+        def validate_expect(expect: Expect, expected_value, scope: Scope):
+            if isinstance(expect, ValueAll) and expected_value is not None:
+                raise DexterScriptError(
+                    f"!expect/all node {expect} should not have an expected value."
+                )
+
         # `visit_script` will validate the structure of the script, as it traverses the full script and raises an
         # exception if it sees anything unexpected.
-        self.visit_script()
+        self.visit_script(visit_expect=validate_expect)
 
     # If a truthy value is returned, abort further visiting and return that value.
     def _visit_script(

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/watch_scope.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/watch_scope.cpp
@@ -1,5 +1,6 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --skip-evaluate --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-script --skip-evaluate --binary %t \
+// RUN:   -- %s | FileCheck %s
 
 char There[] = "Here";
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/watch_scope.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/watch_scope.cpp
@@ -1,0 +1,47 @@
+// RUN: %dexter_regression_test_cxx_build %s -o %t
+// RUN: %dexter_regression_test_run --use-script --skip-evaluate --binary %t -- %s | FileCheck %s
+
+char There[] = "Here";
+
+int main() {
+  int One = 2;
+  char Red[] = "Blue";
+  return 0; // !dex_label ret
+}
+
+/// Test that we can use functions in !where nodes, and that Dexter steps
+/// through the entirety of those functions. We expect both calls to `assign` to
+/// be stepped through, but only the non-recursive call of `replace` should be
+/// stepped through, as the !where matches to the rootmost applicable frame.
+
+// CHECK:      Step 0
+// CHECK:          main
+// CHECK:      Variable Scopes:
+// CHECK-NEXT:   Globals: [::There]
+// CHECK-NEXT:   Locals: [One, Red]
+// CHECK-NEXT: Variables:
+// CHECK-NEXT:   "::There": (char[5]) "Here"
+// CHECK-NEXT:     "[0]": (char) 'H'
+// CHECK-NEXT:     "[1]": (char) 'e'
+// CHECK-NEXT:     "[2]": (char) 'r'
+// CHECK-NEXT:     "[3]": (char) 'e'
+// CHECK-NEXT:     "[4]": (char) '\0'
+// CHECK-NEXT:   "One": (int) 2
+// CHECK-NEXT:   "Red": (char[5]) "Blue"
+// CHECK-NEXT:     "[0]": (char) 'B'
+// CHECK-NEXT:     "[1]": (char) 'l'
+// CHECK-NEXT:     "[2]": (char) 'u'
+// CHECK-NEXT:     "[3]": (char) 'e'
+// CHECK-NEXT:     "[4]": (char) '\0'
+
+// CHECK-NOT: Step 1
+
+/*
+---
+!where {lines: !label ret}:
+    ? !value/all Locals
+    ? !value/all Globals
+    # Invalid scopes won't appear in the output.
+    ? !value/all NotARealScope
+...
+*/

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/parser/expect-all-with-value.test
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/parser/expect-all-with-value.test
@@ -1,0 +1,12 @@
+RUN: not %dexter_regression_test_run --binary %s --use-script --skip-run -- %s 2>&1 | FileCheck %s
+
+Tests that we reject !expect/all nodes with expected values.
+
+CHECK: No valid Dexter script found in file
+
+CHECK: Script starting line [[# @LINE + 2]]:
+CHECK: !expect/all node ValueAll(Locals) should not have an expected value.
+---
+!where {function: foo}:
+    !value/all Locals: "a real value"
+...

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/Inputs/rewrite_scopes_expected.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/Inputs/rewrite_scopes_expected.cpp
@@ -1,0 +1,49 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t/test
+// RUN: %dexter_regression_test_run --use-script --binary %t/test \
+// RUN:   --results-directory %t/results -- %s 2>&1 | FileCheck %s
+// RUN: diff %t/results/%{s:basename} \
+// RUN:   %S/Inputs/rewrite_scopes_expected.cpp
+
+/// Tests that we can collect the values of all available variables with
+/// !value/all and produce corresponding variable expects.
+
+/// NB: The exact contents of this file are compared against the expect file in
+///     the Inputs/ directory; any changes to this file, including comments,
+///     will require updating the corresponding expected file.
+
+char There[] = "Here";
+
+int main() {
+  int One = 2;
+  char Red[] = "Blue";
+  return 0; // !dex_label ret
+}
+
+// CHECK: total_watched_steps: 3
+// CHECK: correct_steps: 3
+// CHECK: incorrect_steps: 0
+// CHECK: missing_var_steps: 0
+// CHECK: unexpected_value_steps: 0
+// CHECK: seen_values: 11
+// CHECK: missing_values: 0
+
+/*
+---
+? !where {lines: !label 'ret'}
+: !value 'One': '2'
+  !value 'Red':
+    '[0]': '''B'''
+    '[1]': '''l'''
+    '[2]': '''u'''
+    '[3]': '''e'''
+    '[4]': '''\0'''
+  !value '::There':
+    '[0]': '''H'''
+    '[1]': '''e'''
+    '[2]': '''r'''
+    '[3]': '''e'''
+    '[4]': '''\0'''
+...
+*/

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/Inputs/rewrite_scopes_list_expected.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/Inputs/rewrite_scopes_list_expected.cpp
@@ -1,0 +1,71 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t/test
+// RUN: %dexter_regression_test_run --use-script --binary %t/test \
+// RUN:   --results-directory %t/results -- %s 2>&1 | FileCheck %s
+// RUN: diff %t/results/%{s:basename} \
+// RUN:   %S/Inputs/rewrite_scopes_list_expected.cpp
+
+/// Tests that !value/all creates appropriate state nodes for the different
+/// variables:
+/// - TopFloor is live for the entire scope of the !value/all, so appears
+///   directly under the root !where
+/// - Elevator is live at two disjoint positions, so appears under two different
+///   !and nodes.
+/// - Ground and Button become live at the same time after the !value/all
+///   becomes active and for the remainder of the program, so are both placed
+///   under a single shared !and.
+
+/// NB: The exact contents of this file are compared against the expect file in
+///     the Inputs/ directory; any changes to this file, including comments,
+///     will require updating the corresponding expected file.
+
+void ding() {}
+void swapPassengers() {}
+
+int main() {
+  int TopFloor = 10;
+  int Ground = 0, Button = 6; // !dex_label start
+  for (int Elevator = Ground; Elevator < Button; ++Elevator) {
+    ding();
+  }
+  swapPassengers();
+  for (int Elevator = Button; Elevator < TopFloor; ++Elevator) {
+    ding();
+  }
+  return 0; // !dex_label ret
+}
+
+// CHECK: Rewrote script to add 5 expected values.
+
+// CHECK: total_watched_steps: 83
+// CHECK: correct_steps: 83
+// CHECK: incorrect_steps: 0
+// CHECK: missing_var_steps: 0
+// CHECK: unexpected_value_steps: 0
+// CHECK: seen_values: 13
+// CHECK: missing_values: 0
+
+/*
+---
+? !where {lines: !range [!label 'start', !label 'ret']}
+: !value 'TopFloor': '10'
+  ? !and {lines: !range [29, 36]}
+  : !value 'Button': '6'
+    !value 'Ground': '0'
+  ? !and {lines: 30}
+  : !value 'Elevator':
+    - '0'
+    - '1'
+    - '2'
+    - '3'
+    - '4'
+    - '5'
+  ? !and {lines: 34}
+  : !value 'Elevator':
+    - '6'
+    - '7'
+    - '8'
+    - '9'
+...
+*/

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_scopes.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_scopes.cpp
@@ -1,0 +1,40 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t/test
+// RUN: %dexter_regression_test_run --use-script --binary %t/test \
+// RUN:   --results-directory %t/results -- %s 2>&1 | FileCheck %s
+// RUN: diff %t/results/%{s:basename} \
+// RUN:   %S/Inputs/rewrite_scopes_expected.cpp
+
+/// Tests that we can collect the values of all available variables with
+/// !value/all and produce corresponding variable expects.
+
+/// NB: The exact contents of this file are compared against the expect file in
+///     the Inputs/ directory; any changes to this file, including comments,
+///     will require updating the corresponding expected file.
+
+char There[] = "Here";
+
+int main() {
+  int One = 2;
+  char Red[] = "Blue";
+  return 0; // !dex_label ret
+}
+
+// CHECK: total_watched_steps: 3
+// CHECK: correct_steps: 3
+// CHECK: incorrect_steps: 0
+// CHECK: missing_var_steps: 0
+// CHECK: unexpected_value_steps: 0
+// CHECK: seen_values: 11
+// CHECK: missing_values: 0
+
+/*
+---
+!where {lines: !label ret}:
+    ? !value/all Locals
+    ? !value/all Globals
+    # Invalid scopes won't appear in the output.
+    ? !value/all NotARealScope
+...
+*/

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_scopes_list.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_scopes_list.cpp
@@ -1,0 +1,54 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: %dexter_regression_test_cxx_build %s -o %t/test
+// RUN: %dexter_regression_test_run --use-script --binary %t/test \
+// RUN:   --results-directory %t/results -- %s 2>&1 | FileCheck %s
+// RUN: diff %t/results/%{s:basename} \
+// RUN:   %S/Inputs/rewrite_scopes_list_expected.cpp
+
+/// Tests that !value/all creates appropriate state nodes for the different
+/// variables:
+/// - TopFloor is live for the entire scope of the !value/all, so appears
+///   directly under the root !where
+/// - Elevator is live at two disjoint positions, so appears under two different
+///   !and nodes.
+/// - Ground and Button become live at the same time after the !value/all
+///   becomes active and for the remainder of the program, so are both placed
+///   under a single shared !and.
+
+/// NB: The exact contents of this file are compared against the expect file in
+///     the Inputs/ directory; any changes to this file, including comments,
+///     will require updating the corresponding expected file.
+
+void ding() {}
+void swapPassengers() {}
+
+int main() {
+  int TopFloor = 10;
+  int Ground = 0, Button = 6; // !dex_label start
+  for (int Elevator = Ground; Elevator < Button; ++Elevator) {
+    ding();
+  }
+  swapPassengers();
+  for (int Elevator = Button; Elevator < TopFloor; ++Elevator) {
+    ding();
+  }
+  return 0; // !dex_label ret
+}
+
+// CHECK: Rewrote script to add 5 expected values.
+
+// CHECK: total_watched_steps: 83
+// CHECK: correct_steps: 83
+// CHECK: incorrect_steps: 0
+// CHECK: missing_var_steps: 0
+// CHECK: unexpected_value_steps: 0
+// CHECK: seen_values: 13
+// CHECK: missing_values: 0
+
+/*
+---
+!where {lines: !range [!label start, !label ret]}:
+    ? !value/all Locals
+...
+*/


### PR DESCRIPTION
Following on from the previous patch, this patch adds support for writing expects from !value/all nodes, generating separate expects for each variable in the requested debugger scope, for each continuous range of lines it is live for.

NB: As with the other patch that implements script-writing features, each test in this patch has a corresponding "expected" file, which is almost identical (including the `RUN` lines), and exists to be `diff`'d against the output of Dexter's script generation.