### PR TITLE
[clangd] Store diagnostic names in a direct offset table

### DIFF
--- a/clang-tools-extra/clangd/DiagnosticNameKinds.inc
+++ b/clang-tools-extra/clangd/DiagnosticNameKinds.inc
@@ -1,0 +1,27 @@
+//===-- DiagnosticNameKinds.inc - clangd diagnostic names -------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Expands the diagnostic categories whose names clangd exposes as LSP
+// diagnostic codes.
+//
+// Diagnostics.cpp includes DiagnosticNameKinds.inc with different DIAG
+// definitions, so DiagnosticNameKinds.inc intentionally has no include guard.
+
+// clang-format off
+#include "clang/Basic/DiagnosticCommonKinds.inc"
+#include "clang/Basic/DiagnosticDriverKinds.inc"
+#include "clang/Basic/DiagnosticFrontendKinds.inc"
+#include "clang/Basic/DiagnosticSerializationKinds.inc"
+#include "clang/Basic/DiagnosticLexKinds.inc"
+#include "clang/Basic/DiagnosticParseKinds.inc"
+#include "clang/Basic/DiagnosticASTKinds.inc"
+#include "clang/Basic/DiagnosticCommentKinds.inc"
+#include "clang/Basic/DiagnosticSemaKinds.inc"
+#include "clang/Basic/DiagnosticAnalysisKinds.inc"
+#include "clang/Basic/DiagnosticRefactoringKinds.inc"
+// clang-format on

--- a/clang-tools-extra/clangd/Diagnostics.cpp
+++ b/clang-tools-extra/clangd/Diagnostics.cpp
@@ -39,7 +39,11 @@
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
+#include <array>
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
 #include <optional>
 #include <set>
 #include <string>
@@ -51,28 +55,47 @@ namespace clang {
 namespace clangd {
 namespace {
 
-const char *getDiagnosticCode(unsigned ID) {
-  switch (ID) {
+struct DiagnosticNameTable {
 #define DIAG(ENUM, CLASS, DEFAULT_MAPPING, DESC, GROPU, SFINAE, NOWERROR,      \
              SHOWINSYSHEADER, SHOWINSYSMACRO, DEFERRABLE, CATEGORY, STABLE_ID, \
              LEGACY_STABLE_IDS)                                                \
-  case clang::diag::ENUM:                                                      \
-    return #ENUM;
-#include "clang/Basic/DiagnosticASTKinds.inc"
-#include "clang/Basic/DiagnosticAnalysisKinds.inc"
-#include "clang/Basic/DiagnosticCommentKinds.inc"
-#include "clang/Basic/DiagnosticCommonKinds.inc"
-#include "clang/Basic/DiagnosticDriverKinds.inc"
-#include "clang/Basic/DiagnosticFrontendKinds.inc"
-#include "clang/Basic/DiagnosticLexKinds.inc"
-#include "clang/Basic/DiagnosticParseKinds.inc"
-#include "clang/Basic/DiagnosticRefactoringKinds.inc"
-#include "clang/Basic/DiagnosticSemaKinds.inc"
-#include "clang/Basic/DiagnosticSerializationKinds.inc"
+  char ENUM[sizeof(#ENUM)];
+#include "DiagnosticNameKinds.inc"
 #undef DIAG
-  default:
+};
+
+constexpr DiagnosticNameTable DiagnosticNames = {
+#define DIAG(ENUM, CLASS, DEFAULT_MAPPING, DESC, GROPU, SFINAE, NOWERROR,      \
+             SHOWINSYSHEADER, SHOWINSYSMACRO, DEFERRABLE, CATEGORY, STABLE_ID, \
+             LEGACY_STABLE_IDS)                                                \
+  #ENUM,
+#include "DiagnosticNameKinds.inc"
+#undef DIAG
+};
+
+constexpr std::array<uint32_t, clang::diag::DIAG_UPPER_LIMIT>
+makeDiagnosticNameOffsets() {
+  std::array<uint32_t, clang::diag::DIAG_UPPER_LIMIT> Offsets{};
+#define DIAG(ENUM, CLASS, DEFAULT_MAPPING, DESC, GROPU, SFINAE, NOWERROR,      \
+             SHOWINSYSHEADER, SHOWINSYSMACRO, DEFERRABLE, CATEGORY, STABLE_ID, \
+             LEGACY_STABLE_IDS)                                                \
+  Offsets[clang::diag::ENUM] = offsetof(DiagnosticNameTable, ENUM) + 1;
+#include "DiagnosticNameKinds.inc"
+#undef DIAG
+  return Offsets;
+}
+
+constexpr auto DiagnosticNameOffsets = makeDiagnosticNameOffsets();
+static_assert(sizeof(DiagnosticNames) < std::numeric_limits<uint32_t>::max());
+
+const char *getDiagnosticCode(unsigned ID) {
+  if (ID >= DiagnosticNameOffsets.size())
     return nullptr;
-  }
+  uint32_t Offset = DiagnosticNameOffsets[ID];
+  if (Offset == 0)
+    return nullptr;
+  const char *Names = reinterpret_cast<const char *>(&DiagnosticNames);
+  return Names + Offset - 1;
 }
 
 bool mentionsMainFile(const Diag &D) {


### PR DESCRIPTION
This replaces the generated `getDiagnosticCode` switch with one pointer-free character blob and a direct `uint32_t` offset table indexed by diagnostic ID; zero offsets preserve the existing `nullptr` result for unnamed diagnostic IDs.

On an arm64 Release build, standalone clangd decreases by 49,480 bytes raw and 49,560 bytes stripped with 7,251 fewer linked fixups.

Work towards #202616

AI tool disclosure: Co-authored with OpenAI Codex.
