### PR TITLE
[Passes] Invoke CGSCCOptimizerLateEP callbacks in LTO pipeline

### DIFF
--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -2212,6 +2212,7 @@ PassBuilder::buildLTODefaultPipeline(OptimizationLevel Level,
   CGPM.addPass(ArgumentPromotionPass());
   CGPM.addPass(CoroSplitPass(Level != OptimizationLevel::O0));
   CGPM.addPass(CoroAnnotationElidePass());
+  invokeCGSCCOptimizerLateEPCallbacks(CGPM, Level);
   MPM.addPass(createModuleToPostOrderCGSCCPassAdaptor(std::move(CGPM)));
 
   FunctionPassManager FPM;

--- a/llvm/test/Other/new-pm-lto-defaults.ll
+++ b/llvm/test/Other/new-pm-lto-defaults.ll
@@ -26,6 +26,9 @@
 ; RUN: opt -disable-verify -verify-analysis-invalidation=0 -eagerly-invalidate-analyses=0 -debug-pass-manager \
 ; RUN:     -passes='lto<O3>' -S  %s -passes-ep-peephole='no-op-function' 2>&1 \
 ; RUN:     | FileCheck %s --check-prefixes=CHECK-O,CHECK-O23,CHECK-EP-PEEPHOLE
+; RUN: opt -disable-verify -verify-analysis-invalidation=0 -eagerly-invalidate-analyses=0 -debug-pass-manager \
+; RUN:     -passes='lto<O3>' -S  %s -passes-ep-cgscc-optimizer-late='no-op-cgscc' 2>&1 \
+; RUN:     | FileCheck %s --check-prefixes=CHECK-O,CHECK-O23,CHECK-EP-CGSCC-LATE
 
 ; CHECK-EP: Running pass: NoOpModulePass
 ; CHECK-O: Running pass: CrossDSOCFIPass
@@ -84,6 +87,7 @@
 ; CHECK-O23-NEXT: Running pass: ArgumentPromotionPass on (foo)
 ; CHECK-O23-NEXT: CoroSplitPass on (foo)
 ; CHECK-O23-NEXT: CoroAnnotationElidePass on (foo)
+; CHECK-EP-CGSCC-LATE-NEXT: Running pass: NoOpCGSCCPass on (foo)
 ; CHECK-O23-NEXT: Running pass: InstCombinePass
 ; CHECK-EP-PEEPHOLE-NEXT: Running pass: NoOpFunctionPass
 ; CHECK-O23-NEXT: Running pass: ConstraintEliminationPass


### PR DESCRIPTION
The CGSCCOptimizerLateEP extension point was not being invoked in the
LTO pipeline. Right now only AMDGPU registers any passes during this
callback, but it was a real source of delta between the LTO and default
pipelines when targeting AMDGPU. This doesn't seem to be an intentional
omission given that it is instantiated in thinLTO as well. Just add it.
