### PR TITLE
[llvm] Fix most LLVM_ABI annotations in SandboxIR

### DIFF
--- a/llvm/include/llvm/SandboxIR/Context.h
+++ b/llvm/include/llvm/SandboxIR/Context.h
@@ -30,7 +30,7 @@ class Region;
 class Value;
 class Use;
 
-class Context {
+class LLVM_ABI Context {
 public:
   // A EraseInstrCallback receives the instruction about to be erased.
   using EraseInstrCallback = std::function<void(Instruction *)>;
@@ -114,33 +114,32 @@ protected:
   CallbackID::ValTy NextCallbackID = 1;
 
   /// Remove \p V from the maps and returns the unique_ptr.
-  LLVM_ABI std::unique_ptr<Value> detachLLVMValue(llvm::Value *V);
+  std::unique_ptr<Value> detachLLVMValue(llvm::Value *V);
   /// Remove \p SBV from all SandboxIR maps and stop owning it. This effectively
   /// detaches \p V from the underlying IR.
-  LLVM_ABI std::unique_ptr<Value> detach(Value *V);
+  std::unique_ptr<Value> detach(Value *V);
   friend class Instruction; // For detach().
   /// Take ownership of VPtr and store it in `LLVMValueToValueMap`.
-  LLVM_ABI Value *registerValue(std::unique_ptr<Value> &&VPtr);
+  Value *registerValue(std::unique_ptr<Value> &&VPtr);
   friend class EraseFromParent; // For registerValue().
   /// This is the actual function that creates sandboxir values for \p V,
   /// and among others handles all instruction types.
-  LLVM_ABI Value *getOrCreateValueInternal(llvm::Value *V,
-                                           llvm::User *U = nullptr);
+  Value *getOrCreateValueInternal(llvm::Value *V, llvm::User *U = nullptr);
   /// Get or create a sandboxir::Argument for an existing LLVM IR \p LLVMArg.
-  LLVM_ABI Argument *getOrCreateArgument(llvm::Argument *LLVMArg);
+  Argument *getOrCreateArgument(llvm::Argument *LLVMArg);
   /// Get or create a sandboxir::Value for an existing LLVM IR \p LLVMV.
   Value *getOrCreateValue(llvm::Value *LLVMV) {
     return getOrCreateValueInternal(LLVMV, 0);
   }
   /// Get or create a sandboxir::Constant from an existing LLVM IR \p LLVMC.
-  LLVM_ABI Constant *getOrCreateConstant(llvm::Constant *LLVMC);
+  Constant *getOrCreateConstant(llvm::Constant *LLVMC);
   friend class ConstantDataSequential; // For getOrCreateConstant().
   friend class Utils; // For getMemoryBase
 
-  LLVM_ABI void runEraseInstrCallbacks(Instruction *I);
-  LLVM_ABI void runCreateInstrCallbacks(Instruction *I);
-  LLVM_ABI void runMoveInstrCallbacks(Instruction *I, const BBIterator &Where);
-  LLVM_ABI void runSetUseCallbacks(const Use &U, Value *NewSrc);
+  void runEraseInstrCallbacks(Instruction *I);
+  void runCreateInstrCallbacks(Instruction *I);
+  void runMoveInstrCallbacks(Instruction *I, const BBIterator &Where);
+  void runSetUseCallbacks(const Use &U, Value *NewSrc);
 
   friend class User;  // For runSetUseCallbacks().
   friend class Value; // For runSetUseCallbacks().
@@ -151,99 +150,92 @@ protected:
 
   /// Create a sandboxir::BasicBlock for an existing LLVM IR \p BB. This will
   /// also create all contents of the block.
-  LLVM_ABI BasicBlock *createBasicBlock(llvm::BasicBlock *BB);
+  BasicBlock *createBasicBlock(llvm::BasicBlock *BB);
   friend class BasicBlock; // For getOrCreateValue().
 
   IRBuilder<ConstantFolder> LLVMIRBuilder;
   auto &getLLVMIRBuilder() { return LLVMIRBuilder; }
 
-  LLVM_ABI VAArgInst *createVAArgInst(llvm::VAArgInst *SI);
+  VAArgInst *createVAArgInst(llvm::VAArgInst *SI);
   friend VAArgInst; // For createVAArgInst()
-  LLVM_ABI FreezeInst *createFreezeInst(llvm::FreezeInst *SI);
+  FreezeInst *createFreezeInst(llvm::FreezeInst *SI);
   friend FreezeInst; // For createFreezeInst()
-  LLVM_ABI FenceInst *createFenceInst(llvm::FenceInst *SI);
+  FenceInst *createFenceInst(llvm::FenceInst *SI);
   friend FenceInst; // For createFenceInst()
-  LLVM_ABI SelectInst *createSelectInst(llvm::SelectInst *SI);
+  SelectInst *createSelectInst(llvm::SelectInst *SI);
   friend SelectInst; // For createSelectInst()
-  LLVM_ABI InsertElementInst *
-  createInsertElementInst(llvm::InsertElementInst *IEI);
+  InsertElementInst *createInsertElementInst(llvm::InsertElementInst *IEI);
   friend InsertElementInst; // For createInsertElementInst()
-  LLVM_ABI ExtractElementInst *
-  createExtractElementInst(llvm::ExtractElementInst *EEI);
+  ExtractElementInst *createExtractElementInst(llvm::ExtractElementInst *EEI);
   friend ExtractElementInst; // For createExtractElementInst()
-  LLVM_ABI ShuffleVectorInst *
-  createShuffleVectorInst(llvm::ShuffleVectorInst *SVI);
+  ShuffleVectorInst *createShuffleVectorInst(llvm::ShuffleVectorInst *SVI);
   friend ShuffleVectorInst; // For createShuffleVectorInst()
-  LLVM_ABI ExtractValueInst *
-  createExtractValueInst(llvm::ExtractValueInst *IVI);
+  ExtractValueInst *createExtractValueInst(llvm::ExtractValueInst *IVI);
   friend ExtractValueInst; // For createExtractValueInst()
-  LLVM_ABI InsertValueInst *createInsertValueInst(llvm::InsertValueInst *IVI);
+  InsertValueInst *createInsertValueInst(llvm::InsertValueInst *IVI);
   friend InsertValueInst; // For createInsertValueInst()
-  LLVM_ABI UncondBrInst *createUncondBrInst(llvm::UncondBrInst *UBI);
+  UncondBrInst *createUncondBrInst(llvm::UncondBrInst *UBI);
   friend UncondBrInst; // For createUncondBrInst()
-  LLVM_ABI CondBrInst *createCondBrInst(llvm::CondBrInst *CBI);
+  CondBrInst *createCondBrInst(llvm::CondBrInst *CBI);
   friend CondBrInst; // For createCondBrInst()
-  LLVM_ABI LoadInst *createLoadInst(llvm::LoadInst *LI);
+  LoadInst *createLoadInst(llvm::LoadInst *LI);
   friend LoadInst; // For createLoadInst()
-  LLVM_ABI StoreInst *createStoreInst(llvm::StoreInst *SI);
+  StoreInst *createStoreInst(llvm::StoreInst *SI);
   friend StoreInst; // For createStoreInst()
-  LLVM_ABI ReturnInst *createReturnInst(llvm::ReturnInst *I);
+  ReturnInst *createReturnInst(llvm::ReturnInst *I);
   friend ReturnInst; // For createReturnInst()
-  LLVM_ABI CallInst *createCallInst(llvm::CallInst *I);
+  CallInst *createCallInst(llvm::CallInst *I);
   friend CallInst; // For createCallInst()
-  LLVM_ABI InvokeInst *createInvokeInst(llvm::InvokeInst *I);
+  InvokeInst *createInvokeInst(llvm::InvokeInst *I);
   friend InvokeInst; // For createInvokeInst()
-  LLVM_ABI CallBrInst *createCallBrInst(llvm::CallBrInst *I);
+  CallBrInst *createCallBrInst(llvm::CallBrInst *I);
   friend CallBrInst; // For createCallBrInst()
-  LLVM_ABI LandingPadInst *createLandingPadInst(llvm::LandingPadInst *I);
+  LandingPadInst *createLandingPadInst(llvm::LandingPadInst *I);
   friend LandingPadInst; // For createLandingPadInst()
-  LLVM_ABI CatchPadInst *createCatchPadInst(llvm::CatchPadInst *I);
+  CatchPadInst *createCatchPadInst(llvm::CatchPadInst *I);
   friend CatchPadInst; // For createCatchPadInst()
-  LLVM_ABI CleanupPadInst *createCleanupPadInst(llvm::CleanupPadInst *I);
+  CleanupPadInst *createCleanupPadInst(llvm::CleanupPadInst *I);
   friend CleanupPadInst; // For createCleanupPadInst()
-  LLVM_ABI CatchReturnInst *createCatchReturnInst(llvm::CatchReturnInst *I);
+  CatchReturnInst *createCatchReturnInst(llvm::CatchReturnInst *I);
   friend CatchReturnInst; // For createCatchReturnInst()
-  LLVM_ABI CleanupReturnInst *
-  createCleanupReturnInst(llvm::CleanupReturnInst *I);
+  CleanupReturnInst *createCleanupReturnInst(llvm::CleanupReturnInst *I);
   friend CleanupReturnInst; // For createCleanupReturnInst()
-  LLVM_ABI GetElementPtrInst *
-  createGetElementPtrInst(llvm::GetElementPtrInst *I);
+  GetElementPtrInst *createGetElementPtrInst(llvm::GetElementPtrInst *I);
   friend GetElementPtrInst; // For createGetElementPtrInst()
-  LLVM_ABI CatchSwitchInst *createCatchSwitchInst(llvm::CatchSwitchInst *I);
+  CatchSwitchInst *createCatchSwitchInst(llvm::CatchSwitchInst *I);
   friend CatchSwitchInst; // For createCatchSwitchInst()
-  LLVM_ABI ResumeInst *createResumeInst(llvm::ResumeInst *I);
+  ResumeInst *createResumeInst(llvm::ResumeInst *I);
   friend ResumeInst; // For createResumeInst()
-  LLVM_ABI SwitchInst *createSwitchInst(llvm::SwitchInst *I);
+  SwitchInst *createSwitchInst(llvm::SwitchInst *I);
   friend SwitchInst; // For createSwitchInst()
-  LLVM_ABI UnaryOperator *createUnaryOperator(llvm::UnaryOperator *I);
+  UnaryOperator *createUnaryOperator(llvm::UnaryOperator *I);
   friend UnaryOperator; // For createUnaryOperator()
-  LLVM_ABI BinaryOperator *createBinaryOperator(llvm::BinaryOperator *I);
+  BinaryOperator *createBinaryOperator(llvm::BinaryOperator *I);
   friend BinaryOperator; // For createBinaryOperator()
-  LLVM_ABI AtomicRMWInst *createAtomicRMWInst(llvm::AtomicRMWInst *I);
+  AtomicRMWInst *createAtomicRMWInst(llvm::AtomicRMWInst *I);
   friend AtomicRMWInst; // For createAtomicRMWInst()
-  LLVM_ABI AtomicCmpXchgInst *
-  createAtomicCmpXchgInst(llvm::AtomicCmpXchgInst *I);
+  AtomicCmpXchgInst *createAtomicCmpXchgInst(llvm::AtomicCmpXchgInst *I);
   friend AtomicCmpXchgInst; // For createAtomicCmpXchgInst()
-  LLVM_ABI AllocaInst *createAllocaInst(llvm::AllocaInst *I);
+  AllocaInst *createAllocaInst(llvm::AllocaInst *I);
   friend AllocaInst; // For createAllocaInst()
-  LLVM_ABI CastInst *createCastInst(llvm::CastInst *I);
+  CastInst *createCastInst(llvm::CastInst *I);
   friend CastInst; // For createCastInst()
-  LLVM_ABI PHINode *createPHINode(llvm::PHINode *I);
+  PHINode *createPHINode(llvm::PHINode *I);
   friend PHINode; // For createPHINode()
-  LLVM_ABI UnreachableInst *createUnreachableInst(llvm::UnreachableInst *UI);
+  UnreachableInst *createUnreachableInst(llvm::UnreachableInst *UI);
   friend UnreachableInst; // For createUnreachableInst()
-  LLVM_ABI CmpInst *createCmpInst(llvm::CmpInst *I);
+  CmpInst *createCmpInst(llvm::CmpInst *I);
   friend CmpInst; // For createCmpInst()
-  LLVM_ABI ICmpInst *createICmpInst(llvm::ICmpInst *I);
+  ICmpInst *createICmpInst(llvm::ICmpInst *I);
   friend ICmpInst; // For createICmpInst()
-  LLVM_ABI FCmpInst *createFCmpInst(llvm::FCmpInst *I);
+  FCmpInst *createFCmpInst(llvm::FCmpInst *I);
   friend FCmpInst; // For createFCmpInst()
 
 public:
-  LLVM_ABI Context(LLVMContext &LLVMCtx);
-  LLVM_ABI virtual ~Context();
+  Context(LLVMContext &LLVMCtx);
+  virtual ~Context();
   /// Clears function-level state.
-  LLVM_ABI void clear();
+  void clear();
 
   Tracker &getTracker() { return IRTracker; }
   /// Convenience function for `getTracker().save()`
@@ -253,14 +245,14 @@ public:
   /// Convenience function for `getTracker().accept()`
   void accept(bool AcceptAll = false) { IRTracker.accept(AcceptAll); }
 
-  LLVM_ABI sandboxir::Value *getValue(llvm::Value *V) const;
+  sandboxir::Value *getValue(llvm::Value *V) const;
   const sandboxir::Value *getValue(const llvm::Value *V) const {
     return getValue(const_cast<llvm::Value *>(V));
   }
 
-  LLVM_ABI Module *getModule(llvm::Module *LLVMM) const;
+  Module *getModule(llvm::Module *LLVMM) const;
 
-  LLVM_ABI Module *getOrCreateModule(llvm::Module *LLVMM);
+  Module *getOrCreateModule(llvm::Module *LLVMM);
 
   Type *getType(llvm::Type *LLVMTy) {
     if (LLVMTy == nullptr)
@@ -277,10 +269,10 @@ public:
   /// This is the main API function for creating Sandbox IR.
   /// Note: this will not fully populate its parent module. The only globals
   /// that will be available are those used within the function.
-  LLVM_ABI Function *createFunction(llvm::Function *F);
+  Function *createFunction(llvm::Function *F);
 
   /// Create a sandboxir::Module corresponding to \p LLVMM.
-  LLVM_ABI Module *createModule(llvm::Module *LLVMM);
+  Module *createModule(llvm::Module *LLVMM);
 
   /// \Returns the number of values registered with Context.
   size_t getNumValues() const { return LLVMValueToValueMap.size(); }
@@ -289,26 +281,26 @@ public:
   /// to be removed from its parent. Note that this will also be called when
   /// reverting the creation of an instruction.
   /// \Returns a callback ID for later deregistration.
-  LLVM_ABI CallbackID registerEraseInstrCallback(EraseInstrCallback CB);
-  LLVM_ABI void unregisterEraseInstrCallback(CallbackID ID);
+  CallbackID registerEraseInstrCallback(EraseInstrCallback CB);
+  void unregisterEraseInstrCallback(CallbackID ID);
 
   /// Register a callback that gets called right after a SandboxIR instruction
   /// is created. Note that this will also be called when reverting the removal
   /// of an instruction.
   /// \Returns a callback ID for later deregistration.
-  LLVM_ABI CallbackID registerCreateInstrCallback(CreateInstrCallback CB);
-  LLVM_ABI void unregisterCreateInstrCallback(CallbackID ID);
+  CallbackID registerCreateInstrCallback(CreateInstrCallback CB);
+  void unregisterCreateInstrCallback(CallbackID ID);
 
   /// Register a callback that gets called when a SandboxIR instruction is about
   /// to be moved. Note that this will also be called when reverting a move.
   /// \Returns a callback ID for later deregistration.
-  LLVM_ABI CallbackID registerMoveInstrCallback(MoveInstrCallback CB);
-  LLVM_ABI void unregisterMoveInstrCallback(CallbackID ID);
+  CallbackID registerMoveInstrCallback(MoveInstrCallback CB);
+  void unregisterMoveInstrCallback(CallbackID ID);
 
   /// Register a callback that gets called when a Use gets set.
   /// \Returns a callback ID for later deregistration.
-  LLVM_ABI CallbackID registerSetUseCallback(SetUseCallback CB);
-  LLVM_ABI void unregisterSetUseCallback(CallbackID ID);
+  CallbackID registerSetUseCallback(SetUseCallback CB);
+  void unregisterSetUseCallback(CallbackID ID);
 };
 
 } // namespace sandboxir

--- a/llvm/include/llvm/SandboxIR/Instruction.h
+++ b/llvm/include/llvm/SandboxIR/Instruction.h
@@ -117,7 +117,7 @@ protected:
   }
 
 public:
-  LLVM_ABI static const char *getOpcodeName(Opcode Opc) {
+  static const char *getOpcodeName(Opcode Opc) {
     switch (Opc) {
 #define OP(OPC)                                                                \
   case Opcode::OPC:                                                            \
@@ -1097,8 +1097,8 @@ class UncondBrInst : public SingleLLVMInstructionImpl<llvm::UncondBrInst>,
   friend Context; // for UncondBrInst()
 
 public:
-  static UncondBrInst *create(BasicBlock *Target, InsertPosition InsertBefore,
-                              Context &Ctx);
+  LLVM_ABI static UncondBrInst *
+  create(BasicBlock *Target, InsertPosition InsertBefore, Context &Ctx);
   LLVM_ABI BasicBlock *getSuccessor() const;
   LLVM_ABI void setSuccessor(BasicBlock *NewSucc);
   unsigned getNumSuccessors() const { return 1; }
@@ -1123,11 +1123,11 @@ class CondBrInst : public SingleLLVMInstructionImpl<llvm::CondBrInst>,
   friend Context; // for UcnondBrInst()
 
 public:
-  static CondBrInst *create(Value *Cond, BasicBlock *IfTrue,
-                            BasicBlock *IfFalse, InsertPosition InsertBefore,
-                            Context &Ctx);
+  LLVM_ABI static CondBrInst *create(Value *Cond, BasicBlock *IfTrue,
+                                     BasicBlock *IfFalse,
+                                     InsertPosition InsertBefore, Context &Ctx);
   LLVM_ABI Value *getCondition() const;
-  void setCondition(Value *V);
+  LLVM_ABI void setCondition(Value *V);
   LLVM_ABI BasicBlock *getSuccessor(unsigned SuccIdx) const;
   LLVM_ABI void setSuccessor(unsigned Idx, BasicBlock *NewSucc);
   unsigned getNumSuccessors() const { return 2; }

--- a/llvm/include/llvm/SandboxIR/Region.h
+++ b/llvm/include/llvm/SandboxIR/Region.h
@@ -63,7 +63,7 @@ enum RegionClassID {
   RegionWithScoreID,
 };
 
-class Region {
+class LLVM_ABI Region {
 protected:
   /// All the instructions in the Region. Only new instructions generated during
   /// vectorization are part of the Region.
@@ -103,7 +103,7 @@ protected:
   /// region.
   virtual void add(Instruction *I) { addRaw(I); }
   /// Removes I from the set.
-  LLVM_ABI virtual void remove(Instruction *I);
+  virtual void remove(Instruction *I);
   friend class Context; // The callbacks need to call add() and remove().
   friend class RegionInternalsAttorney; // For unit tests.
 
@@ -115,7 +115,7 @@ protected:
   /// Remove instruction \p I from Aux and drop metadata.
   void removeFromAux(Instruction *I);
 
-  LLVM_ABI Region(Context &Ctx, RegionClassID ID);
+  Region(Context &Ctx, RegionClassID ID);
 
   template <typename RegionT, typename RegionFactoryT>
   static SmallVector<std::unique_ptr<RegionT>>
@@ -159,8 +159,8 @@ protected:
   }
 
 public:
-  LLVM_ABI Region(Context &Ctx) : Region(Ctx, RegionClassID::RegionID) {}
-  LLVM_ABI virtual ~Region();
+  Region(Context &Ctx) : Region(Ctx, RegionClassID::RegionID) {}
+  virtual ~Region();
   // Disable copies to avoid unregistering the callback more than once.
   Region(const Region &) = delete;
   // Moves are allowed.
@@ -172,19 +172,18 @@ public:
   /// Returns true if the Region has no instructions.
   bool empty() const { return Insts.empty(); }
   /// Set the auxiliary vector.
-  LLVM_ABI void setAux(ArrayRef<Instruction *> Aux);
+  void setAux(ArrayRef<Instruction *> Aux);
   /// \Returns the auxiliary vector.
   const SmallVector<Instruction *> &getAux() const { return Aux; }
   /// Clears all auxiliary data.
-  LLVM_ABI void clearAux();
+  void clearAux();
 
   using iterator = decltype(Insts.begin());
   iterator begin() { return Insts.begin(); }
   iterator end() { return Insts.end(); }
   iterator_range<iterator> insts() { return make_range(begin(), end()); }
 
-  LLVM_ABI static SmallVector<std::unique_ptr<Region>>
-  createRegionsFromMD(Function &F);
+  static SmallVector<std::unique_ptr<Region>> createRegionsFromMD(Function &F);
 
   RegionClassID getSubclassID() const { return ID; }
 


### PR DESCRIPTION
This updates most LLVM_ABI annotations in the SandboxIR headers to match expected usage:
* All public APIs should be properly annotated.
* Inlined functions should not be annotated.

These changes were done by a script fixing annotations on LLVM public headers and manually checked.

This effort is tracked in #109483.