### PR TITLE
[lldb][unittests] Add LLDB_UNITTEST_STRIP_DEBUG_INFO to cut unittest link time

### DIFF
--- a/lldb/unittests/CMakeLists.txt
+++ b/lldb/unittests/CMakeLists.txt
@@ -10,6 +10,11 @@ if (CXX_SUPPORTS_SUGGEST_OVERRIDE_FLAG)
   add_compile_options("-Wno-suggest-override")
 endif()
 
+option(LLDB_UNITTEST_STRIP_DEBUG_INFO
+  "Strip debug info from lldb unit-test binaries to cut link time and disk \
+usage. On MSVC this also adds /OPT:REF /OPT:ICF /INCREMENTAL:NO. Turn OFF \
+when you need to debug a unittest binary." OFF)
+
 function(add_lldb_unittest test_name)
   cmake_parse_arguments(ARG
     "SBAPITEST"
@@ -41,6 +46,23 @@ function(add_lldb_unittest test_name)
     COMMAND "${CMAKE_COMMAND}" -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/Inputs)
 
   target_link_libraries(${test_name} PRIVATE ${ARG_LINK_LIBS})
+
+  if (LLDB_UNITTEST_STRIP_DEBUG_INFO)
+    if (MSVC)
+      target_link_options(${test_name} PRIVATE
+        "LINKER:/DEBUG:NONE"
+        "LINKER:/INCREMENTAL:NO"
+        "LINKER:/OPT:REF"
+        "LINKER:/OPT:ICF")
+    else()
+      target_compile_options(${test_name} PRIVATE -g0)
+      if (APPLE)
+        target_link_options(${test_name} PRIVATE "LINKER:-S")
+      else()
+        target_link_options(${test_name} PRIVATE "LINKER:--strip-debug")
+      endif()
+    endif()
+  endif()
 endfunction()
 
 function(add_unittest_inputs test_name inputs)

--- a/lldb/unittests/CMakeLists.txt
+++ b/lldb/unittests/CMakeLists.txt
@@ -10,10 +10,11 @@ if (CXX_SUPPORTS_SUGGEST_OVERRIDE_FLAG)
   add_compile_options("-Wno-suggest-override")
 endif()
 
-option(LLDB_UNITTEST_STRIP_DEBUG_INFO
-  "Strip debug info from lldb unit-test binaries to cut link time and disk \
-usage. On MSVC this also adds /OPT:REF /OPT:ICF /INCREMENTAL:NO. Turn OFF \
-when you need to debug a unittest binary." OFF)
+if (MSVC)
+  option(LLDB_UNITTEST_STRIP_DEBUG_INFO
+    "Strip debug info from lldb unit-test binaries to cut link time and disk \
+  usage when building with MSVC. Turn OFF when you need to debug a unittest binary." OFF)
+endif()
 
 function(add_lldb_unittest test_name)
   cmake_parse_arguments(ARG
@@ -47,20 +48,13 @@ function(add_lldb_unittest test_name)
 
   target_link_libraries(${test_name} PRIVATE ${ARG_LINK_LIBS})
 
-  if (LLDB_UNITTEST_STRIP_DEBUG_INFO)
-    if (MSVC)
+  if (MSVC)
+    if (LLDB_UNITTEST_STRIP_DEBUG_INFO)
       target_link_options(${test_name} PRIVATE
         "LINKER:/DEBUG:NONE"
         "LINKER:/INCREMENTAL:NO"
         "LINKER:/OPT:REF"
         "LINKER:/OPT:ICF")
-    else()
-      target_compile_options(${test_name} PRIVATE -g0)
-      if (APPLE)
-        target_link_options(${test_name} PRIVATE "LINKER:-S")
-      else()
-        target_link_options(${test_name} PRIVATE "LINKER:--strip-debug")
-      endif()
     endif()
   endif()
 endfunction()


### PR DESCRIPTION
Add an opt-in cache option (default OFF). When ON, every target declared via `add_lldb_unittest` links without per-target debug info and dead-strips: 
- **MSVC**: `/DEBUG:NONE + /INCREMENTAL:NO + /OPT:REF + /OPT:ICF`
- **clang/gcc**: `-g0 + LINKER:--strip-debug` (or `LINKER:-S` on macOS).

This drastically speeds up linking the unittests executable when building with debug info on Windows.