### PR TITLE
[Offload] Pass `-nostdlibinc` to the device unit test files

### DIFF
--- a/offload/unittests/CMakeLists.txt
+++ b/offload/unittests/CMakeLists.txt
@@ -23,6 +23,7 @@ function(add_offload_test_device_code test_filename test_name)
 
   set(SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${test_filename})
   set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+  set(compile_flags -nostdlibinc -nogpulib)
 
   # Try to build with support for NVPTX devices.
   if("cuda" IN_LIST LIBOMPTARGET_PLUGINS_TO_BUILD)
@@ -40,7 +41,7 @@ function(add_offload_test_device_code test_filename test_name)
     endif()
 
     if(nvptx_arch AND CUDAToolkit_FOUND)
-      set(nvptx_compile_flags ${OFFLOAD_TESTS_UNPARSED_ARGUMENTS})
+      set(nvptx_compile_flags ${compile_flags} ${OFFLOAD_TESTS_UNPARSED_ARGUMENTS})
 
       if(OFFLOAD_TESTS_WITH_DEVICE_MATH_LIBS)
         file(GLOB libdevice_paths "${CUDAToolkit_LIBRARY_ROOT}/nvvm/libdevice/libdevice.*.bc")
@@ -58,7 +59,7 @@ function(add_offload_test_device_code test_filename test_name)
         COMMAND ${CMAKE_CXX_COMPILER}
         -I${OFFLOAD_UNITTESTS_DIR}
         --target=nvptx64-nvidia-cuda -march=${nvptx_arch}
-        -nogpulib --cuda-path=${cuda_path} -flto ${nvptx_compile_flags}
+        --cuda-path=${cuda_path} -flto ${nvptx_compile_flags}
         ${SRC_PATH} -o ${output_file}
         DEPENDS ${SRC_PATH}
       )
@@ -77,7 +78,7 @@ function(add_offload_test_device_code test_filename test_name)
     endif()
 
     if(amdgpu_arch)
-      set(amdgpu_compile_flags ${OFFLOAD_TESTS_UNPARSED_ARGUMENTS})
+      set(amdgpu_compile_flags ${compile_flags} ${OFFLOAD_TESTS_UNPARSED_ARGUMENTS})
 
       if(OFFLOAD_TESTS_WITH_DEVICE_MATH_LIBS)
         find_package(AMDDeviceLibs QUIET HINTS ${CMAKE_INSTALL_PREFIX} PATHS /opt/rocm)
@@ -95,7 +96,7 @@ function(add_offload_test_device_code test_filename test_name)
         COMMAND ${CMAKE_CXX_COMPILER}
         -I${OFFLOAD_UNITTESTS_DIR}
         --target=amdgcn-amd-amdhsa -mcpu=${amdgpu_arch}
-        -nogpulib -flto ${amdgpu_compile_flags} ${SRC_PATH} -o ${output_file}
+        -flto ${amdgpu_compile_flags} ${SRC_PATH} -o ${output_file}
         DEPENDS ${SRC_PATH}
       )
       add_custom_target(${test_name}.amdgpu DEPENDS ${output_file})
@@ -104,7 +105,7 @@ function(add_offload_test_device_code test_filename test_name)
 
   # Try to build with support for Level Zero SPIRV devices.
   if("level_zero" IN_LIST LIBOMPTARGET_PLUGINS_TO_BUILD)
-    set(spirv_compile_flags ${OFFLOAD_TESTS_UNPARSED_ARGUMENTS})
+    set(spirv_compile_flags ${compile_flags} ${OFFLOAD_TESTS_UNPARSED_ARGUMENTS})
     set(output_file "${CMAKE_CURRENT_BINARY_DIR}/${test_name}.spirv64.bin")
     # TODO: Building for specific devices is not implemented yet.
     # TODO: Remove the -ffreestanding flag once libc can be built for spirv64.
@@ -114,7 +115,7 @@ function(add_offload_test_device_code test_filename test_name)
       -I${OFFLOAD_UNITTESTS_DIR}
       --target=spirv64-intel
       -ffreestanding
-      -nogpulib -flto ${spirv_compile_flags} ${SRC_PATH} -o ${output_file}
+      -flto ${spirv_compile_flags} ${SRC_PATH} -o ${output_file}
       DEPENDS ${SRC_PATH}
     )
     add_custom_target(${test_name}.spirv64 DEPENDS ${output_file})


### PR DESCRIPTION
Summary:
We need this flag so we can include `stdint.h` without potentially going
through to the system interface. this flag removes all default include
paths excepts the resource directory, which is the intention here.
