### PR TITLE
[lldb][Windows][NFC] Clean up ConnectionConPTYWindows

### DIFF
--- a/lldb/source/Host/windows/ConnectionConPTYWindows.cpp
+++ b/lldb/source/Host/windows/ConnectionConPTYWindows.cpp
@@ -10,8 +10,6 @@
 #include "lldb/Utility/Status.h"
 #include "lldb/Utility/Timeout.h"
 
-#include <cstring>
-
 using namespace lldb;
 using namespace lldb_private;
 


### PR DESCRIPTION
Remove unused `<cstring>` include (no string/mem APIs used in the file).