### PR TITLE
[NFC][Support] Add test for inverted slash-agnostic matching

### DIFF
--- a/llvm/unittests/Support/GlobPatternTest.cpp
+++ b/llvm/unittests/Support/GlobPatternTest.cpp
@@ -471,4 +471,18 @@ TEST_F(GlobPatternTest, SlashAgnosticMatchInverted) {
   EXPECT_FALSE(Pat->match("foo/barb"));
   EXPECT_TRUE(Pat->match("foo/bar1"));
 }
+
+TEST_F(GlobPatternTest, SlashAgnosticInvertedSlash) {
+  auto Pat1 = GlobPattern::create("foo[^/]", 1024, /*SlashAgnostic=*/true);
+  ASSERT_TRUE((bool)Pat1);
+  EXPECT_FALSE(Pat1->match("foo/"));
+  EXPECT_FALSE(Pat1->match("foo\\"));
+  EXPECT_TRUE(Pat1->match("fooa"));
+
+  auto Pat2 = GlobPattern::create("foo[^\\]", 1024, /*SlashAgnostic=*/true);
+  ASSERT_TRUE((bool)Pat2);
+  EXPECT_FALSE(Pat2->match("foo/"));
+  EXPECT_FALSE(Pat2->match("foo\\"));
+  EXPECT_TRUE(Pat2->match("fooa"));
+}
 }


### PR DESCRIPTION
Add a test case to GlobPatternTest to verify that inverted character
classes containing slashes (e.g. [^/] or [^\\]) behave correctly
under SlashAgnostic mode (i.e. they do not match either slash).

Assisted-by: Gemini
