### PR TITLE
[AMDGPU] Track LDS DMA VGPR source reads in expert scheduling

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -2778,6 +2778,7 @@ bool SIInsertWaitcnts::generateWaitcntInstBefore(
   // waits on VA_VDST if the instruction it would precede is not a VALU
   // instruction, since hardware handles VALU->VGPR->VALU hazards in
   // expert scheduling mode.
+  // TODO: LDSDMA are marked as VALU but we need to treat them as vmem
   if (TII.isVALU(MI) && !SIInstrInfo::isLDSDMA(MI))
     Wait.set(AMDGPU::VA_VDST, ~0u);
 
@@ -2858,6 +2859,7 @@ bool SIInsertWaitcnts::generateWaitcnt(AMDGPU::Waitcnt Wait,
 
 std::optional<WaitEventType>
 SIInsertWaitcnts::getExpertSchedulingEventType(const MachineInstr &Inst) const {
+  // TODO: LDSDMA are marked as VALU but we need to treat them as vmem
   if (TII.isVALU(Inst) && !SIInstrInfo::isLDSDMA(Inst)) {
     // Core/Side-, DP-, XDL- and TRANS-MACC VALU instructions complete
     // out-of-order with respect to each other, so each of these classes

--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -2778,7 +2778,7 @@ bool SIInsertWaitcnts::generateWaitcntInstBefore(
   // waits on VA_VDST if the instruction it would precede is not a VALU
   // instruction, since hardware handles VALU->VGPR->VALU hazards in
   // expert scheduling mode.
-  if (TII.isVALU(MI))
+  if (TII.isVALU(MI) && !SIInstrInfo::isLDSDMA(MI))
     Wait.set(AMDGPU::VA_VDST, ~0u);
 
   // Since the translation for VMEM addresses occur in-order, we can apply the

--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -2858,7 +2858,7 @@ bool SIInsertWaitcnts::generateWaitcnt(AMDGPU::Waitcnt Wait,
 
 std::optional<WaitEventType>
 SIInsertWaitcnts::getExpertSchedulingEventType(const MachineInstr &Inst) const {
-  if (TII.isVALU(Inst)) {
+  if (TII.isVALU(Inst) && !SIInstrInfo::isLDSDMA(Inst)) {
     // Core/Side-, DP-, XDL- and TRANS-MACC VALU instructions complete
     // out-of-order with respect to each other, so each of these classes
     // has its own event.

--- a/llvm/test/CodeGen/AMDGPU/expert_scheduling_gfx1250.mir
+++ b/llvm/test/CodeGen/AMDGPU/expert_scheduling_gfx1250.mir
@@ -29,6 +29,25 @@ body: |
 ...
 
 ---
+name: async_global_to_lds_vaddr_raw
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $vgpr1, $vgpr2
+    ; CHECK-LABEL: name: async_global_to_lds_vaddr_raw
+    ; CHECK: liveins: $vgpr1, $vgpr2
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
+    ; CHECK-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
+    ; CHECK-NEXT: S_WAIT_KMCNT 0
+    ; CHECK-NEXT: $vgpr0 = V_MOV_B32_e32 1, implicit $exec
+    ; CHECK-NEXT: S_WAITCNT_DEPCTR .VaVdst_0
+    ; CHECK-NEXT: GLOBAL_LOAD_ASYNC_TO_LDS_B32 $vgpr2, $vgpr0_vgpr1, 0, 0, implicit-def $asynccnt, implicit $exec, implicit $asynccnt :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+    $vgpr0 = V_MOV_B32_e32 1, implicit $exec
+    GLOBAL_LOAD_ASYNC_TO_LDS_B32 $vgpr2, $vgpr0_vgpr1, 0, 0, implicit-def $asynccnt, implicit $exec, implicit $asynccnt :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+...
+
+---
 name: async_global_to_lds_vaddr_vsrc_war
 tracksRegLiveness: true
 machineFunctionInfo:

--- a/llvm/test/CodeGen/AMDGPU/expert_scheduling_gfx1250.mir
+++ b/llvm/test/CodeGen/AMDGPU/expert_scheduling_gfx1250.mir
@@ -27,3 +27,79 @@ body: |
     $vgpr64 = GLOBAL_LOAD_DWORD $vgpr16_vgpr17, 0, 0, implicit $exec
     $vgpr64 = GLOBAL_LOAD_DWORD $vgpr40_vgpr41, 0, 0, implicit $exec
 ...
+
+---
+name: async_global_to_lds_vaddr_vsrc_war
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+body: |
+  bb.0:
+    liveins: $vgpr0, $vgpr1, $vgpr2
+    ; CHECK-LABEL: name: async_global_to_lds_vaddr_vsrc_war
+    ; CHECK: liveins: $vgpr0, $vgpr1, $vgpr2
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
+    ; CHECK-NEXT: GLOBAL_LOAD_ASYNC_TO_LDS_B32 $vgpr2, $vgpr0_vgpr1, 0, 0, implicit-def $asynccnt, implicit $exec, implicit $asynccnt :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+    ; CHECK-NEXT: $vgpr0 = V_MOV_B32_e32 1, implicit $exec
+    GLOBAL_LOAD_ASYNC_TO_LDS_B32 $vgpr2, $vgpr0_vgpr1, 0, 0, implicit-def $asynccnt, implicit $exec, implicit $asynccnt :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+    $vgpr0 = V_MOV_B32_e32 1, implicit $exec
+...
+
+---
+name: async_global_to_lds_vdst_vsrc_war
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+body: |
+  bb.0:
+    liveins: $vgpr0, $vgpr1, $vgpr2
+    ; CHECK-LABEL: name: async_global_to_lds_vdst_vsrc_war
+    ; CHECK: liveins: $vgpr0, $vgpr1, $vgpr2
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
+    ; CHECK-NEXT: GLOBAL_LOAD_ASYNC_TO_LDS_B32 $vgpr2, $vgpr0_vgpr1, 0, 0, implicit-def $asynccnt, implicit $exec, implicit $asynccnt :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+    ; CHECK-NEXT: $vgpr2 = V_MOV_B32_e32 1, implicit $exec
+    GLOBAL_LOAD_ASYNC_TO_LDS_B32 $vgpr2, $vgpr0_vgpr1, 0, 0, implicit-def $asynccnt, implicit $exec, implicit $asynccnt :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+    $vgpr2 = V_MOV_B32_e32 1, implicit $exec
+...
+
+---
+name: global_load_vsrc_war
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+body: |
+  bb.0:
+    liveins: $vgpr0, $vgpr1
+    ; CHECK-LABEL: name: global_load_vsrc_war
+    ; CHECK: liveins: $vgpr0, $vgpr1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
+    ; CHECK-NEXT: $vgpr2 = GLOBAL_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec :: (load (s32), addrspace 1)
+    ; CHECK-NEXT: S_WAIT_XCNT 0
+    ; CHECK-NEXT: S_WAITCNT_DEPCTR .VmVsrc_0
+    ; CHECK-NEXT: $vgpr0 = V_MOV_B32_e32 1, implicit $exec
+    $vgpr2 = GLOBAL_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec :: (load (s32), addrspace 1)
+    $vgpr0 = V_MOV_B32_e32 1, implicit $exec
+...
+
+---
+name: buffer_load_vsrc_war
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+body: |
+  bb.0:
+    liveins: $vgpr0, $vgpr1, $sgpr0_sgpr1_sgpr2_sgpr3
+    ; CHECK-LABEL: name: buffer_load_vsrc_war
+    ; CHECK: liveins: $vgpr0, $vgpr1, $sgpr0_sgpr1_sgpr2_sgpr3
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
+    ; CHECK-NEXT: $vgpr2 = BUFFER_LOAD_DWORD_ADDR64 $vgpr0_vgpr1, $sgpr0_sgpr1_sgpr2_sgpr3, 0, 0, 0, 0, implicit $exec
+    ; CHECK-NEXT: S_WAIT_XCNT 0
+    ; CHECK-NEXT: S_WAITCNT_DEPCTR .VmVsrc_0
+    ; CHECK-NEXT: $vgpr0 = V_MOV_B32_e32 1, implicit $exec
+    $vgpr2 = BUFFER_LOAD_DWORD_ADDR64 $vgpr0_vgpr1, $sgpr0_sgpr1_sgpr2_sgpr3, 0, 0, 0, 0, implicit $exec
+    $vgpr0 = V_MOV_B32_e32 1, implicit $exec
+...

--- a/llvm/test/CodeGen/AMDGPU/expert_scheduling_gfx1250.mir
+++ b/llvm/test/CodeGen/AMDGPU/expert_scheduling_gfx1250.mir
@@ -50,44 +50,50 @@ body: |
 ---
 name: async_global_to_lds_vaddr_vsrc_war
 tracksRegLiveness: true
-machineFunctionInfo:
-  isEntryFunction: true
 body: |
   bb.0:
-    liveins: $vgpr0, $vgpr1, $vgpr2
+    liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr4, $vgpr5
     ; CHECK-LABEL: name: async_global_to_lds_vaddr_vsrc_war
-    ; CHECK: liveins: $vgpr0, $vgpr1, $vgpr2
+    ; CHECK: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr4, $vgpr5
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
+    ; CHECK-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
+    ; CHECK-NEXT: S_WAIT_KMCNT 0
     ; CHECK-NEXT: GLOBAL_LOAD_ASYNC_TO_LDS_B32 $vgpr2, $vgpr0_vgpr1, 0, 0, implicit-def $asynccnt, implicit $exec, implicit $asynccnt :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+    ; CHECK-NEXT: S_WAITCNT_DEPCTR .VmVsrc_0
     ; CHECK-NEXT: $vgpr0 = V_MOV_B32_e32 1, implicit $exec
+    ; CHECK-NEXT: S_WAITCNT_DEPCTR .VaVdst_0
+    ; CHECK-NEXT: GLOBAL_STORE_DWORD $vgpr4_vgpr5, $vgpr0, 0, 0, implicit $exec :: (store (s32), addrspace 1)
     GLOBAL_LOAD_ASYNC_TO_LDS_B32 $vgpr2, $vgpr0_vgpr1, 0, 0, implicit-def $asynccnt, implicit $exec, implicit $asynccnt :: (load (s32), addrspace 1), (store (s32), addrspace 3)
     $vgpr0 = V_MOV_B32_e32 1, implicit $exec
+    GLOBAL_STORE_DWORD $vgpr4_vgpr5, $vgpr0, 0, 0, implicit $exec :: (store (s32), addrspace 1)
 ...
 
 ---
 name: async_global_to_lds_vdst_vsrc_war
 tracksRegLiveness: true
-machineFunctionInfo:
-  isEntryFunction: true
 body: |
   bb.0:
-    liveins: $vgpr0, $vgpr1, $vgpr2
+    liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr4, $vgpr5
     ; CHECK-LABEL: name: async_global_to_lds_vdst_vsrc_war
-    ; CHECK: liveins: $vgpr0, $vgpr1, $vgpr2
+    ; CHECK: liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr4, $vgpr5
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
+    ; CHECK-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
+    ; CHECK-NEXT: S_WAIT_KMCNT 0
     ; CHECK-NEXT: GLOBAL_LOAD_ASYNC_TO_LDS_B32 $vgpr2, $vgpr0_vgpr1, 0, 0, implicit-def $asynccnt, implicit $exec, implicit $asynccnt :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+    ; CHECK-NEXT: S_WAITCNT_DEPCTR .VmVsrc_0
     ; CHECK-NEXT: $vgpr2 = V_MOV_B32_e32 1, implicit $exec
+    ; CHECK-NEXT: S_WAITCNT_DEPCTR .VaVdst_0
+    ; CHECK-NEXT: GLOBAL_STORE_DWORD $vgpr4_vgpr5, $vgpr2, 0, 0, implicit $exec :: (store (s32), addrspace 1)
     GLOBAL_LOAD_ASYNC_TO_LDS_B32 $vgpr2, $vgpr0_vgpr1, 0, 0, implicit-def $asynccnt, implicit $exec, implicit $asynccnt :: (load (s32), addrspace 1), (store (s32), addrspace 3)
     $vgpr2 = V_MOV_B32_e32 1, implicit $exec
+    GLOBAL_STORE_DWORD $vgpr4_vgpr5, $vgpr2, 0, 0, implicit $exec :: (store (s32), addrspace 1)
 ...
 
 ---
 name: global_load_vsrc_war
 tracksRegLiveness: true
-machineFunctionInfo:
-  isEntryFunction: true
 body: |
   bb.0:
     liveins: $vgpr0, $vgpr1
@@ -95,6 +101,8 @@ body: |
     ; CHECK: liveins: $vgpr0, $vgpr1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
+    ; CHECK-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
+    ; CHECK-NEXT: S_WAIT_KMCNT 0
     ; CHECK-NEXT: $vgpr2 = GLOBAL_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec :: (load (s32), addrspace 1)
     ; CHECK-NEXT: S_WAIT_XCNT 0
     ; CHECK-NEXT: S_WAITCNT_DEPCTR .VmVsrc_0
@@ -106,8 +114,6 @@ body: |
 ---
 name: buffer_load_vsrc_war
 tracksRegLiveness: true
-machineFunctionInfo:
-  isEntryFunction: true
 body: |
   bb.0:
     liveins: $vgpr0, $vgpr1, $sgpr0_sgpr1_sgpr2_sgpr3
@@ -115,6 +121,8 @@ body: |
     ; CHECK: liveins: $vgpr0, $vgpr1, $sgpr0_sgpr1_sgpr2_sgpr3
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: S_SETREG_IMM32_B32 2, 2074, implicit-def $mode, implicit $mode
+    ; CHECK-NEXT: S_WAIT_LOADCNT_DSCNT .Loadcnt_0_Dscnt_0
+    ; CHECK-NEXT: S_WAIT_KMCNT 0
     ; CHECK-NEXT: $vgpr2 = BUFFER_LOAD_DWORD_ADDR64 $vgpr0_vgpr1, $sgpr0_sgpr1_sgpr2_sgpr3, 0, 0, 0, 0, implicit $exec
     ; CHECK-NEXT: S_WAIT_XCNT 0
     ; CHECK-NEXT: S_WAITCNT_DEPCTR .VmVsrc_0


### PR DESCRIPTION
LDS DMA instructions are marked as VALU but we need to treat them as FLAT instructions for expert mode waitcnt insertion. This meant we were missing a `vm_vsrc` wait for WAR and RAW on input registers of the LDS DMA instruction.

I added lit tests for other memory ops as well to catch future regressions.