### PR TITLE
[MLIR][XeGPU] Fix issue with expandDim

### DIFF
--- a/mlir/lib/Dialect/XeGPU/IR/XeGPUDialect.cpp
+++ b/mlir/lib/Dialect/XeGPU/IR/XeGPUDialect.cpp
@@ -660,14 +660,9 @@ DistributeLayoutAttr LayoutAttr::collapseDims(SmallVector<int64_t> dimGroup) {
 //   - sg_layout / lane_layout: spread outer-to-inner; each dim takes
 //     min(remaining, targetShape[i]); leftover spills into the next inner
 //     dim.
-//   - sg_data: fill innermost-first, capped per dim by targetShape[i] (the
-//     full extent of the expanded dim). Capping by the full extent (rather
-//     than the per-sg share targetShape[i] / sgLayout[i]) keeps the inverse of
-//     collapseDims well-defined for replicated/broadcast layouts, where a dim
-//     is shared across subgroups so sg_layout[dim] * sg_data[dim] > extent and
-//     sg_data can be as large as the full extent. For evenly-distributed
-//     layouts the inner-first fill still lands on the per-sg share, so the
-//     result is unchanged.
+//   - sg_data: fill innermost-first, capped per dim by
+//     targetShape[i] / sgLayout[i] (the per-sg share of the extent),
+//     or targetShape[i] (if sg_data is replicated across all subgroups).
 //   - lane_data: fill innermost-first, capped per dim by
 //     (targetShape[i] / sgLayout[i]) / laneLayout[i] (the per-lane share of
 //     the per-sg extent).

--- a/mlir/lib/Dialect/XeGPU/IR/XeGPUDialect.cpp
+++ b/mlir/lib/Dialect/XeGPU/IR/XeGPUDialect.cpp
@@ -660,8 +660,14 @@ DistributeLayoutAttr LayoutAttr::collapseDims(SmallVector<int64_t> dimGroup) {
 //   - sg_layout / lane_layout: spread outer-to-inner; each dim takes
 //     min(remaining, targetShape[i]); leftover spills into the next inner
 //     dim.
-//   - sg_data: fill innermost-first, capped per dim by
-//     targetShape[i] / sgLayout[i] (the per-sg share of the extent).
+//   - sg_data: fill innermost-first, capped per dim by targetShape[i] (the
+//     full extent of the expanded dim). Capping by the full extent (rather
+//     than the per-sg share targetShape[i] / sgLayout[i]) keeps the inverse of
+//     collapseDims well-defined for replicated/broadcast layouts, where a dim
+//     is shared across subgroups so sg_layout[dim] * sg_data[dim] > extent and
+//     sg_data can be as large as the full extent. For evenly-distributed
+//     layouts the inner-first fill still lands on the per-sg share, so the
+//     result is unchanged.
 //   - lane_data: fill innermost-first, capped per dim by
 //     (targetShape[i] / sgLayout[i]) / laneLayout[i] (the per-lane share of
 //     the per-sg extent).
@@ -752,10 +758,13 @@ DistributeLayoutAttr LayoutAttr::expandDim(int64_t dim,
     splice(sgLayout, expSgLayout);
   }
   if (hasSgData) {
+    // Cap by the full extent targetShape[i], not the per-sg share
+    // targetShape[i] / sgLayout[i]: a replicated dim (sg_layout[dim] *
+    // sg_data[dim] > extent) has sg_data up to the full extent, which would not
+    // fit within the per-sg share. For evenly-distributed layouts the
+    // inner-first fill lands on the per-sg share regardless, so this is
+    // equivalent.
     SmallVector<int64_t> dimSizeCap(targetShape.begin(), targetShape.end());
-    if (hasSgLayout)
-      for (int64_t i = 0; i < expCount; ++i)
-        dimSizeCap[i] /= expSgLayout[i];
     SmallVector<int64_t> expSgData =
         spread(origSgDataDim, dimSizeCap, /*outerToInner=*/false);
     splice(sgData, expSgData);

--- a/mlir/lib/Dialect/XeGPU/IR/XeGPUDialect.cpp
+++ b/mlir/lib/Dialect/XeGPU/IR/XeGPUDialect.cpp
@@ -757,14 +757,13 @@ DistributeLayoutAttr LayoutAttr::expandDim(int64_t dim,
     expSgLayout = spread(origSgLayoutDim, targetShape, /*outerToInner=*/true);
     splice(sgLayout, expSgLayout);
   }
+  bool sgDataReplicated =
+      hasSgData && origSgDataDim == computeProduct(targetShape);
   if (hasSgData) {
-    // Cap by the full extent targetShape[i], not the per-sg share
-    // targetShape[i] / sgLayout[i]: a replicated dim (sg_layout[dim] *
-    // sg_data[dim] > extent) has sg_data up to the full extent, which would not
-    // fit within the per-sg share. For evenly-distributed layouts the
-    // inner-first fill lands on the per-sg share regardless, so this is
-    // equivalent.
     SmallVector<int64_t> dimSizeCap(targetShape.begin(), targetShape.end());
+    if (hasSgLayout && !sgDataReplicated)
+      for (int64_t i = 0; i < expCount; ++i)
+        dimSizeCap[i] /= expSgLayout[i];
     SmallVector<int64_t> expSgData =
         spread(origSgDataDim, dimSizeCap, /*outerToInner=*/false);
     splice(sgData, expSgData);
@@ -774,7 +773,7 @@ DistributeLayoutAttr LayoutAttr::expandDim(int64_t dim,
   // targetShape[i] / sg_layout[i] when sg_layout is present, else
   // targetShape itself.
   SmallVector<int64_t> perSgShape(targetShape.begin(), targetShape.end());
-  if (hasSgLayout)
+  if (hasSgLayout && !sgDataReplicated)
     for (int64_t i = 0; i < expCount; ++i)
       perSgShape[i] /= expSgLayout[i];
 

--- a/mlir/test/Dialect/XeGPU/propagate-layout-subgroup.mlir
+++ b/mlir/test/Dialect/XeGPU/propagate-layout-subgroup.mlir
@@ -577,19 +577,6 @@ gpu.module @test {
 }
 
 // -----
-// shape_cast collapse where the collapsed dst dim is replicated across
-// subgroups: sg_layout[1] * sg_data[1] = 2 * 64 = 128 > extent 64, i.e. the
-// two subgroups along dim1 hold the same data (broadcast). This is the layout
-// shape produced by WG-level mxfp GEMM operands, where the per-block scale
-// spans the full K extent shared across the N-parallel subgroups.
-// srcShape=[16, 8, 8], resShape=[16, 64], consumer sg_layout=[2, 2],
-// sg_data=[8, 64]
-//  - dst[1]=64 collapses src[1, 2]: sg_layout outer-to-inner: dim1 take=
-//      min(2, 8)=2 (rem=1) -> [_, 2, 1]; sg_data innermost-first capped by the
-//      full extent (not the per-sg share): dim2 take=min(64, 8)=8 (rem=8);
-//      dim1 take=min(8, 8)=8 (rem=1) -> [_, 8, 8]. The replicated sg_data 64
-//      would not fit the per-sg share cap 64/2=32 on dim1, so the full extent
-//      is used.
 gpu.module @test {
 // CHECK-LABEL: gpu.func @shape_cast_collapse_replicated(
 // CHECK: %[[CST:.*]] = arith.constant {layout_result_0 = #xegpu.layout<sg_layout = [2, 2, 1], sg_data = [8, 8, 8]>} dense<0.000000e+00> : vector<16x8x8xf16>

--- a/mlir/test/Dialect/XeGPU/propagate-layout-subgroup.mlir
+++ b/mlir/test/Dialect/XeGPU/propagate-layout-subgroup.mlir
@@ -575,3 +575,30 @@ gpu.module @test {
     gpu.return
   }
 }
+
+// -----
+// shape_cast collapse where the collapsed dst dim is replicated across
+// subgroups: sg_layout[1] * sg_data[1] = 2 * 64 = 128 > extent 64, i.e. the
+// two subgroups along dim1 hold the same data (broadcast). This is the layout
+// shape produced by WG-level mxfp GEMM operands, where the per-block scale
+// spans the full K extent shared across the N-parallel subgroups.
+// srcShape=[16, 8, 8], resShape=[16, 64], consumer sg_layout=[2, 2],
+// sg_data=[8, 64]
+//  - dst[1]=64 collapses src[1, 2]: sg_layout outer-to-inner: dim1 take=
+//      min(2, 8)=2 (rem=1) -> [_, 2, 1]; sg_data innermost-first capped by the
+//      full extent (not the per-sg share): dim2 take=min(64, 8)=8 (rem=8);
+//      dim1 take=min(8, 8)=8 (rem=1) -> [_, 8, 8]. The replicated sg_data 64
+//      would not fit the per-sg share cap 64/2=32 on dim1, so the full extent
+//      is used.
+gpu.module @test {
+// CHECK-LABEL: gpu.func @shape_cast_collapse_replicated(
+// CHECK: %[[CST:.*]] = arith.constant {layout_result_0 = #xegpu.layout<sg_layout = [2, 2, 1], sg_data = [8, 8, 8]>} dense<0.000000e+00> : vector<16x8x8xf16>
+// CHECK: %[[CAST:.*]] = vector.shape_cast %[[CST]] {layout_result_0 = #xegpu.layout<sg_layout = [2, 2], sg_data = [8, 64]>} : vector<16x8x8xf16> to vector<16x64xf16>
+  gpu.func @shape_cast_collapse_replicated(%dst: memref<16x64xf16>) kernel {
+    %cst = arith.constant dense<0.000000e+00> : vector<16x8x8xf16>
+    %0 = vector.shape_cast %cst : vector<16x8x8xf16> to vector<16x64xf16>
+    %tdesc = xegpu.create_nd_tdesc %dst : memref<16x64xf16> -> !xegpu.tensor_desc<16x64xf16>
+    xegpu.store_nd %0, %tdesc[0, 0] <{layout = #xegpu.layout<sg_layout = [2, 2], sg_data = [8, 64]>}> : vector<16x64xf16>, !xegpu.tensor_desc<16x64xf16>
+    gpu.return
+  }
+}


### PR DESCRIPTION
In case, sgData is replicated or
bool sgDataReplicated = hasSgData && origSgDataDim == computeProduct(targetShape);
sgDataReplicate is evaluated to "true"
dimSizeCap and perSgShape shouldn't be divided by expSgLayout

Add a regression test (shape_cast_collapse_replicated) covering the replicated sg_data collapse.