### PR TITLE
[lldb][Windows] Relax dependent-modules-nodupe-windows OS-DLL ordering

### DIFF
--- a/lldb/test/Shell/Target/dependent-modules-nodupe-windows.test
+++ b/lldb/test/Shell/Target/dependent-modules-nodupe-windows.test
@@ -18,8 +18,8 @@
 
 # CHECK-LABEL: #after
 # CHECK-NEXT: target modules list
-# CHECK-NEXT: .main.exe
-# CHECK-NEXT: ntdll.dll
-# CHECK-NEXT: kernel32.dll
-# CHECK:      .shlib.dll
+# CHECK-DAG: .main.exe
+# CHECK-DAG: ntdll.dll
+# CHECK-DAG: kernel32.dll
+# CHECK-DAG: .shlib.dll
 # CHECK-NOT:  .shlib.dll


### PR DESCRIPTION
The post-run "target modules list" output orders the OS DLLs (ntdll, kernel32, ...) by load address, which differs between the in-process debugger and the lldb-server-on-Windows path. The exact order is not what this test cares about. The goal is to verify that preloaded dependent modules are not duplicated once the inferior actually loads the DLL.

This patch replaces `CHECK-NEXT/CHECK` lines with `CHECK-DAG`, keeping the trailing `CHECK-NOT` to enforce no duplicate `shlib.dll` entry.

rdar://179367320