### PR TITLE
Revert "[lit] Deprecate execute_external=True in ShTest"

### DIFF
--- a/llvm/utils/lit/lit/formats/shtest.py
+++ b/llvm/utils/lit/lit/formats/shtest.py
@@ -17,19 +17,8 @@ class ShTest(FileBasedTest):
     """
 
     def __init__(
-        self,
-        execute_external=False,
-        extra_substitutions=[],
-        preamble_commands=[],
-        force_execute_external=False,
+        self, execute_external=False, extra_substitutions=[], preamble_commands=[]
     ):
-        if execute_external and not force_execute_external:
-            raise ValueError(
-                "execute_external=True is deprected as of LLVM-23 and the option will "
-                "be removed in LLVM-24. Please move to using the internal shell "
-                "(execute_external=False). If you still need to force external "
-                "execution to allow time for migration, set force_execute_external=True"
-            )
         self.execute_external = execute_external
         self.extra_substitutions = extra_substitutions
         self.preamble_commands = preamble_commands

--- a/llvm/utils/lit/tests/Inputs/per-test-coverage-by-lit-cfg/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/per-test-coverage-by-lit-cfg/lit.cfg
@@ -3,11 +3,9 @@ import os
 
 config.name = "per-test-coverage-by-lit-cfg"
 config.suffixes = [".py"]
-use_external_shell = eval(lit_config.params.get("execute_external"))
 config.test_format = lit.formats.ShTest(
-    execute_external=use_external_shell,
-    preamble_commands=["%{python} %s | FileCheck -DINDEX=0 %s"],
-    force_execute_external=use_external_shell
+    execute_external=eval(lit_config.params.get("execute_external")),
+    preamble_commands=["%{python} %s | FileCheck -DINDEX=0 %s"]
 )
 lit_config.per_test_coverage = True
 config.substitutions.append(("%{python}", '"%s"' % (sys.executable)))

--- a/llvm/utils/lit/tests/Inputs/per-test-coverage/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/per-test-coverage/lit.cfg
@@ -3,10 +3,8 @@ import os
 
 config.name = "per-test-coverage"
 config.suffixes = [".py"]
-use_external_shell = eval(lit_config.params.get("execute_external"))
 config.test_format = lit.formats.ShTest(
-    execute_external=use_external_shell,
-    preamble_commands=["%{python} %s | FileCheck -DINDEX=0 %s"],
-    force_execute_external=use_external_shell
+    execute_external=eval(lit_config.params.get("execute_external")),
+    preamble_commands=["%{python} %s | FileCheck -DINDEX=0 %s"]
 )
 config.substitutions.append(("%{python}", '"%s"' % (sys.executable)))

--- a/llvm/utils/lit/tests/Inputs/shtest-external-shell-kill/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/shtest-external-shell-kill/lit.cfg
@@ -1,6 +1,5 @@
 import lit.formats
 
-config.test_format = lit.formats.ShTest(execute_external=True,
-                                        force_execute_external=True)
+config.test_format = lit.formats.ShTest(execute_external=True)
 config.name = "shtest-external-shell-kill"
 config.suffixes = [".txt"]

--- a/llvm/utils/lit/tests/Inputs/shtest-format/external_shell/lit.local.cfg
+++ b/llvm/utils/lit/tests/Inputs/shtest-format/external_shell/lit.local.cfg
@@ -1,4 +1,3 @@
 import lit.formats
 
-config.test_format = lit.formats.ShTest(execute_external=True,
-                                        force_execute_external=True)
+config.test_format = lit.formats.ShTest(execute_external=True)

--- a/llvm/utils/lit/tests/Inputs/shtest-readfile/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/shtest-readfile/lit.cfg
@@ -7,8 +7,7 @@ config.name = "shtest-readfile"
 config.suffixes = [".txt"]
 lit_shell_env = os.environ.get("LIT_USE_INTERNAL_SHELL")
 use_lit_shell = lit.util.pythonize_bool(lit_shell_env)
-config.test_format = lit.formats.ShTest(execute_external=not use_lit_shell,
-                                        force_execute_external=not use_lit_shell)
+config.test_format = lit.formats.ShTest(execute_external=not use_lit_shell)
 config.test_source_root = None
 config.test_exec_root = None
 config.substitutions.append(("%{python}", '"%s"' % (sys.executable)))

--- a/llvm/utils/lit/tests/Inputs/shtest-run-at-line/external-shell/lit.local.cfg
+++ b/llvm/utils/lit/tests/Inputs/shtest-run-at-line/external-shell/lit.local.cfg
@@ -1,7 +1,6 @@
 import lit.formats
 
-config.test_format = lit.formats.ShTest(execute_external=True,
-                                        force_execute_external=True)
+config.test_format = lit.formats.ShTest(execute_external=True)
 config.substitutions.append(("%{cmds-with-newlines}", """
 echo abc |
 FileCheck %s &&

--- a/llvm/utils/lit/tests/Inputs/shtest-timeout/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/shtest-timeout/lit.cfg
@@ -21,8 +21,7 @@ if configSetTimeout != "0":
     # Try setting the max individual test time in the configuration
     config.maxIndividualTestTime = int(configSetTimeout)
 
-config.test_format = lit.formats.ShTest(execute_external=externalShell,
-                                        force_execute_external=externalShell)
+config.test_format = lit.formats.ShTest(execute_external=externalShell)
 config.suffixes = [".py"]
 
 config.test_source_root = os.path.dirname(__file__)


### PR DESCRIPTION
Reverts llvm/llvm-project#201732

Breaks fuzzer tests which need more investigation.