### PR TITLE
[ids-check] Re-enable the workflow

### DIFF
--- a/.github/workflows/ids-check.yml
+++ b/.github/workflows/ids-check.yml
@@ -1,10 +1,7 @@
 name: "Check LLVM ABI annotations"
 
-# TODO(https://github.com/llvm/llvm-project/issues/109483): Re-enable on pull
-# requests once the workflow is less diruptive.
 on:
-  # pull_request:
-  workflow_dispatch:
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
Following earlier changes, the workflow should now only affect modified headers.

The effort to build LLVM as a shared library is tracked in #109483.