### PR TITLE
[clangd] fix wrong resouce-dir

### DIFF
--- a/clang-tools-extra/clangd/CompileCommands.cpp
+++ b/clang-tools-extra/clangd/CompileCommands.cpp
@@ -135,6 +135,28 @@ std::string detectStandardResourceDir() {
   return GetResourcesPath("clangd", (void *)&StaticForMainAddr);
 }
 
+std::optional<std::string>
+detectResourceDirWithClangPath(std::optional<std::string> ClangPath) {
+  std::string ResourceDir = detectStandardResourceDir();
+  if (llvm::sys::fs::exists(ResourceDir))
+    return ResourceDir;
+  vlog("Auto-detected standard resource directory '{0}' doesn't exist",
+       ResourceDir);
+
+  if (ClangPath) {
+    ResourceDir = GetResourcesPath(*ClangPath);
+    if (llvm::sys::fs::exists(ResourceDir))
+      return ResourceDir;
+    vlog("Auto-detected using clang path '{0}' "
+         "resource directory '{1}' doesn't exist",
+         *ClangPath, ResourceDir);
+  }
+
+  elog("Failed to auto-detect resource directory, "
+       "specify it manually via --resource-dir command line argument");
+  return std::nullopt;
+}
+
 // The path passed to argv[0] is important:
 //  - its parent directory is Driver::Dir, used for library discovery
 //  - its basename affects CLI parsing (clang-cl) and other settings
@@ -188,7 +210,7 @@ static std::string resolveDriver(llvm::StringRef Driver, bool FollowSymlink,
 CommandMangler CommandMangler::detect() {
   CommandMangler Result;
   Result.ClangPath = detectClangPath();
-  Result.ResourceDir = detectStandardResourceDir();
+  Result.ResourceDir = detectResourceDirWithClangPath(Result.ClangPath);
   Result.Sysroot = detectSysroot();
   return Result;
 }


### PR DESCRIPTION
clangd and LLVM are installed separately. When clangd and LLVM are installed under different install prefixes, clangd constructs a fake resource-dir based on its own installation directory and set it to the underlying Clang compilers.

Example:
````
clangd install prefix: /usr/local/
clangd detected resouce-dir : /usr/local/lib/clang/22

llvm install prefix: /usr/local/llvm22/
llvm real resource-dir:  /usr/local/llvm22/lib/clang/22
````

This change modifies the logic for guessing the resource-dir in clangd, instead of deriving it from clangd's own location, it now locates the resource-dir based on the discovered Clang binary or the compiler specified by the user.