### PR TITLE
[clang][ssaf] Add --ssaf-compilation-unit-id= flag

### DIFF
--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -429,6 +429,11 @@ def warn_ssaf_write_tu_summary_failed :
   Warning<"failed to write TU summary to '%0': %1">,
   InGroup<ScalableStaticAnalysisFramework>, DefaultError;
 
+def warn_ssaf_tu_summary_requires_compilation_unit_id :
+  Warning<"option '--ssaf-tu-summary-file=' requires "
+          "'--ssaf-compilation-unit-id=' to be set">,
+  InGroup<ScalableStaticAnalysisFramework>, DefaultError;
+
 def err_extract_api_ignores_file_not_found :
   Error<"file '%0' specified by '--extract-api-ignores=' not found">, DefaultFatal;
 

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -550,6 +550,12 @@ public:
   /// format.
   std::string SSAFTUSummaryFile;
 
+  /// Stable identifier for this translation unit, used as the name of the
+  /// `CompilationUnit` `BuildNamespace` of every produced TU summary. The
+  /// caller (typically the build system) supplies a value that is constant
+  /// across stages of the SSAF pipeline.
+  std::string SSAFCompilationUnitId;
+
   /// Show available SSAF summary extractors.
   LLVM_PREFERRED_TYPE(bool)
   unsigned SSAFShowExtractors : 1;

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -969,6 +969,16 @@ def _ssaf_list_formats :
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Display the list of available SSAF serialization formats">,
   MarshallingInfoFlag<FrontendOpts<"SSAFShowFormats">>;
+def _ssaf_compilation_unit_id :
+  Joined<["--"], "ssaf-compilation-unit-id=">,
+  MetaVarName<"<id>">,
+  Group<SSAF_Group>,
+  Visibility<[ClangOption, CC1Option]>,
+  HelpText<
+    "Stable identifier used as the CompilationUnit namespace name of every "
+    "produced SSAF TU summary. Required when '--ssaf-tu-summary-file=' is "
+    "set.">,
+  MarshallingInfoString<FrontendOpts<"SSAFCompilationUnitId">>;
 def Xarch__
     : JoinedAndSeparate<["-"], "Xarch_">,
       Flags<[NoXarchOption]>,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7913,6 +7913,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   Args.AddLastArg(CmdArgs, options::OPT__ssaf_extract_summaries);
   Args.AddLastArg(CmdArgs, options::OPT__ssaf_tu_summary_file);
+  Args.AddLastArg(CmdArgs, options::OPT__ssaf_compilation_unit_id);
 
   // Handle serialized diagnostics.
   if (Arg *A = Args.getLastArg(options::OPT__serialize_diags)) {

--- a/clang/lib/ScalableStaticAnalysisFramework/Frontend/TUSummaryExtractorFrontendAction.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Frontend/TUSummaryExtractorFrontendAction.cpp
@@ -93,11 +93,10 @@ namespace {
 /// automatically forwarded to each extractor.
 class TUSummaryRunner final : public MultiplexConsumer {
 public:
-  static std::unique_ptr<TUSummaryRunner> create(CompilerInstance &CI,
-                                                 StringRef InFile);
+  static std::unique_ptr<TUSummaryRunner> create(CompilerInstance &CI);
 
 private:
-  TUSummaryRunner(StringRef InFile, std::unique_ptr<SerializationFormat> Format,
+  TUSummaryRunner(std::unique_ptr<SerializationFormat> Format,
                   const FrontendOptions &Opts);
 
   void HandleTranslationUnit(ASTContext &Ctx) override;
@@ -109,10 +108,14 @@ private:
 };
 } // namespace
 
-std::unique_ptr<TUSummaryRunner> TUSummaryRunner::create(CompilerInstance &CI,
-                                                         StringRef InFile) {
+std::unique_ptr<TUSummaryRunner> TUSummaryRunner::create(CompilerInstance &CI) {
   const FrontendOptions &Opts = CI.getFrontendOpts();
   DiagnosticsEngine &Diags = CI.getDiagnostics();
+
+  if (Opts.SSAFCompilationUnitId.empty()) {
+    Diags.Report(diag::warn_ssaf_tu_summary_requires_compilation_unit_id);
+    return nullptr;
+  }
 
   auto MaybePair =
       parseOutputFileFormatAndPathOrReportError(Diags, Opts.SSAFTUSummaryFile);
@@ -124,16 +127,17 @@ std::unique_ptr<TUSummaryRunner> TUSummaryRunner::create(CompilerInstance &CI,
     return nullptr;
 
   return std::unique_ptr<TUSummaryRunner>{
-      new TUSummaryRunner{InFile, makeFormat(FormatName), Opts}};
+      new TUSummaryRunner{makeFormat(FormatName), Opts}};
 }
 
-TUSummaryRunner::TUSummaryRunner(StringRef InFile,
-                                 std::unique_ptr<SerializationFormat> Format,
+TUSummaryRunner::TUSummaryRunner(std::unique_ptr<SerializationFormat> Format,
                                  const FrontendOptions &Opts)
     : MultiplexConsumer(std::vector<std::unique_ptr<ASTConsumer>>{}),
-      Summary(BuildNamespace(BuildNamespaceKind::CompilationUnit, InFile)),
+      Summary(BuildNamespace(BuildNamespaceKind::CompilationUnit,
+                             Opts.SSAFCompilationUnitId)),
       Format(std::move(Format)), Opts(Opts) {
   assert(this->Format);
+  assert(!Opts.SSAFCompilationUnitId.empty());
 
   // Now the Summary and the builders are constructed, we can also construct the
   // extractors.
@@ -174,7 +178,7 @@ TUSummaryExtractorFrontendAction::CreateASTConsumer(CompilerInstance &CI,
   if (!WrappedConsumer)
     return nullptr;
 
-  if (auto Runner = TUSummaryRunner::create(CI, InFile)) {
+  if (auto Runner = TUSummaryRunner::create(CI)) {
     CI.getCodeGenOpts().ClearASTBeforeBackend = false;
     std::vector<std::unique_ptr<ASTConsumer>> Consumers;
     Consumers.reserve(2);

--- a/clang/test/Analysis/Scalable/PointerFlow/external-inline-function-in-multi-tu.test
+++ b/clang/test/Analysis/Scalable/PointerFlow/external-inline-function-in-multi-tu.test
@@ -11,8 +11,8 @@
 // RUN: split-file %s %t
 
 // Extract per-TU PointerFlow + UnsafeBufferUsage summaries.
-// RUN: %{extract} %t/tu1.cpp --ssaf-tu-summary-file=%t/tu1.summary.json
-// RUN: %{extract} %t/tu2.cpp --ssaf-tu-summary-file=%t/tu2.summary.json
+// RUN: %{extract} %t/tu1.cpp --ssaf-compilation-unit-id=cu_1 --ssaf-tu-summary-file=%t/tu1.summary.json
+// RUN: %{extract} %t/tu2.cpp --ssaf-compilation-unit-id=cu_2 --ssaf-tu-summary-file=%t/tu2.summary.json
 
 // Link the two TU summaries into a single LU summary.
 // RUN: clang-ssaf-linker %t/tu1.summary.json %t/tu2.summary.json \
@@ -26,7 +26,7 @@
 
 //--- shared.h
 inline int shared_inline(int *p) {
-  int * l = p;      
+  int * l = p;
   return l[5];
 }
 
@@ -55,5 +55,3 @@ int g(int *y) {
 
 // Confirm UnsafeBufferReachableAnalysisResult is present in the output.
 // CHECK: "analysis_name": "UnsafeBufferReachableAnalysisResult"
-
-

--- a/clang/test/Analysis/Scalable/call-graph.cpp
+++ b/clang/test/Analysis/Scalable/call-graph.cpp
@@ -4,11 +4,13 @@
 
 // RUN: %clang_cc1 -fsyntax-only %t/caller.cpp \
 // RUN:   --ssaf-extract-summaries=CallGraph \
+// RUN:   --ssaf-compilation-unit-id=test-cu-caller \
 // RUN:   --ssaf-tu-summary-file=%t/caller.summary.json
 // RUN: FileCheck --match-full-lines --check-prefix=CALLER %t/caller.cpp --input-file=%t/caller.summary.json
 
 // RUN: %clang_cc1 -fsyntax-only %t/polymorphic.cpp \
 // RUN:   --ssaf-extract-summaries=CallGraph \
+// RUN:   --ssaf-compilation-unit-id=test-cu-polymorphic \
 // RUN:   --ssaf-tu-summary-file=%t/polymorphic.summary.json
 // RUN: FileCheck --match-full-lines --check-prefix=POLYMORPHIC %t/polymorphic.cpp --input-file=%t/polymorphic.summary.json
 

--- a/clang/test/Analysis/Scalable/cli-errors-compilation-unit-id.cpp
+++ b/clang/test/Analysis/Scalable/cli-errors-compilation-unit-id.cpp
@@ -1,0 +1,51 @@
+// CLI errors: missing or empty --ssaf-compilation-unit-id= when
+// --ssaf-tu-summary-file= is set. Both forms emit the same default-error
+// diagnostic and skip TU-summary writing while leaving the rest of the
+// compile pipeline alone.
+
+// DEFINE: %{filecheck} = FileCheck %s --match-full-lines --check-prefix
+
+// =============================================================================
+// 1. Missing --ssaf-compilation-unit-id= entirely.
+// =============================================================================
+
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: not %clang     -c %s -o %t/test.o --ssaf-extract-summaries=CallGraph --ssaf-tu-summary-file=%t/tu-absent.json 2>&1 | %{filecheck}=MISSING
+// RUN: not %clang_cc1    %s              --ssaf-extract-summaries=CallGraph --ssaf-tu-summary-file=%t/tu-absent.json 2>&1 | %{filecheck}=MISSING
+// MISSING: error: option '--ssaf-tu-summary-file=' requires '--ssaf-compilation-unit-id=' to be set [-Wscalable-static-analysis-framework]
+// RUN: not test -e %t/tu-absent.json
+
+// =============================================================================
+// 2. --ssaf-compilation-unit-id= present with empty value.
+// =============================================================================
+
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: not %clang     -c %s -o %t/test.o --ssaf-extract-summaries=CallGraph --ssaf-compilation-unit-id= --ssaf-tu-summary-file=%t/tu-empty.json 2>&1 | %{filecheck}=MISSING
+// RUN: not %clang_cc1    %s              --ssaf-extract-summaries=CallGraph --ssaf-compilation-unit-id= --ssaf-tu-summary-file=%t/tu-empty.json 2>&1 | %{filecheck}=MISSING
+// RUN: not test -e %t/tu-empty.json
+
+// =============================================================================
+// 3. The diagnostic is downgradable; under -Wno-error= the compile still
+//    produces its normal object output and no TU summary file.
+// =============================================================================
+
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %clang -c %s -o %t/test.o -Wno-error=scalable-static-analysis-framework --ssaf-extract-summaries=CallGraph --ssaf-tu-summary-file=%t/tu-warn.json 2>&1 | %{filecheck}=WARNING
+// WARNING: warning: option '--ssaf-tu-summary-file=' requires '--ssaf-compilation-unit-id=' to be set [-Wscalable-static-analysis-framework]
+// RUN: test -e %t/test.o
+// RUN: not test -e %t/tu-warn.json
+
+// And it can be silenced entirely with -Wno-.
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %clang -c %s -o %t/test.o -Wno-scalable-static-analysis-framework --ssaf-extract-summaries=CallGraph --ssaf-tu-summary-file=%t/tu-silent.json 2>&1 | count 0
+// RUN: test -e %t/test.o
+// RUN: not test -e %t/tu-silent.json
+
+// =============================================================================
+// 4. --ssaf-compilation-unit-id= alone is a no-op (no other --ssaf-* flag).
+// =============================================================================
+
+// RUN: %clang     -fsyntax-only %s --ssaf-compilation-unit-id=cu-X 2>&1 | count 0
+// RUN: %clang_cc1 -fsyntax-only %s --ssaf-compilation-unit-id=cu-X 2>&1 | count 0
+
+void foo() {}

--- a/clang/test/Analysis/Scalable/command-line-interface.cpp
+++ b/clang/test/Analysis/Scalable/command-line-interface.cpp
@@ -2,16 +2,16 @@
 
 // The flags should behave the same way on the clang driver and also on CC1.
 
-// RUN: not %clang     -fsyntax-only %s --ssaf-tu-summary-file=foobar             2>&1 | %{filecheck}=NOT-MATCHING-THE-PATTERN
-// RUN: not %clang_cc1 -fsyntax-only %s --ssaf-tu-summary-file=foobar             2>&1 | %{filecheck}=NOT-MATCHING-THE-PATTERN
-// RUN: not %clang     -fsyntax-only %s --ssaf-tu-summary-file=%t.ssaf.unknownfmt 2>&1 | %{filecheck}=UNKNOWN-FILE-FORMAT
-// RUN: not %clang_cc1 -fsyntax-only %s --ssaf-tu-summary-file=%t.ssaf.unknownfmt 2>&1 | %{filecheck}=UNKNOWN-FILE-FORMAT
-// RUN: not %clang     -fsyntax-only %s --ssaf-tu-summary-file=%t.ssaf.json       2>&1 | %{filecheck}=NO-EXTRACTORS-ENABLED
-// RUN: not %clang_cc1 -fsyntax-only %s --ssaf-tu-summary-file=%t.ssaf.json       2>&1 | %{filecheck}=NO-EXTRACTORS-ENABLED
-// RUN: not %clang     -fsyntax-only %s --ssaf-tu-summary-file=%t.ssaf.json --ssaf-extract-summaries=extractor1            2>&1 | %{filecheck}=NO-EXTRACTOR-WITH-NAME
-// RUN: not %clang_cc1 -fsyntax-only %s --ssaf-tu-summary-file=%t.ssaf.json --ssaf-extract-summaries=extractor1            2>&1 | %{filecheck}=NO-EXTRACTOR-WITH-NAME
-// RUN: not %clang     -fsyntax-only %s --ssaf-tu-summary-file=%t.ssaf.json --ssaf-extract-summaries=extractor1,extractor2 2>&1 | %{filecheck}=NO-EXTRACTORS-WITH-NAME
-// RUN: not %clang_cc1 -fsyntax-only %s --ssaf-tu-summary-file=%t.ssaf.json --ssaf-extract-summaries=extractor1,extractor2 2>&1 | %{filecheck}=NO-EXTRACTORS-WITH-NAME
+// RUN: not %clang     -fsyntax-only %s --ssaf-tu-summary-file=foobar             --ssaf-compilation-unit-id=test-cu 2>&1 | %{filecheck}=NOT-MATCHING-THE-PATTERN
+// RUN: not %clang_cc1 -fsyntax-only %s --ssaf-tu-summary-file=foobar             --ssaf-compilation-unit-id=test-cu 2>&1 | %{filecheck}=NOT-MATCHING-THE-PATTERN
+// RUN: not %clang     -fsyntax-only %s --ssaf-tu-summary-file=%t.ssaf.unknownfmt --ssaf-compilation-unit-id=test-cu 2>&1 | %{filecheck}=UNKNOWN-FILE-FORMAT
+// RUN: not %clang_cc1 -fsyntax-only %s --ssaf-tu-summary-file=%t.ssaf.unknownfmt --ssaf-compilation-unit-id=test-cu 2>&1 | %{filecheck}=UNKNOWN-FILE-FORMAT
+// RUN: not %clang     -fsyntax-only %s --ssaf-tu-summary-file=%t.ssaf.json       --ssaf-compilation-unit-id=test-cu 2>&1 | %{filecheck}=NO-EXTRACTORS-ENABLED
+// RUN: not %clang_cc1 -fsyntax-only %s --ssaf-tu-summary-file=%t.ssaf.json       --ssaf-compilation-unit-id=test-cu 2>&1 | %{filecheck}=NO-EXTRACTORS-ENABLED
+// RUN: not %clang     -fsyntax-only %s --ssaf-tu-summary-file=%t.ssaf.json --ssaf-compilation-unit-id=test-cu --ssaf-extract-summaries=extractor1            2>&1 | %{filecheck}=NO-EXTRACTOR-WITH-NAME
+// RUN: not %clang_cc1 -fsyntax-only %s --ssaf-tu-summary-file=%t.ssaf.json --ssaf-compilation-unit-id=test-cu --ssaf-extract-summaries=extractor1            2>&1 | %{filecheck}=NO-EXTRACTOR-WITH-NAME
+// RUN: not %clang     -fsyntax-only %s --ssaf-tu-summary-file=%t.ssaf.json --ssaf-compilation-unit-id=test-cu --ssaf-extract-summaries=extractor1,extractor2 2>&1 | %{filecheck}=NO-EXTRACTORS-WITH-NAME
+// RUN: not %clang_cc1 -fsyntax-only %s --ssaf-tu-summary-file=%t.ssaf.json --ssaf-compilation-unit-id=test-cu --ssaf-extract-summaries=extractor1,extractor2 2>&1 | %{filecheck}=NO-EXTRACTORS-WITH-NAME
 
 void empty() {}
 

--- a/clang/test/Analysis/Scalable/downgradable-errors.cpp
+++ b/clang/test/Analysis/Scalable/downgradable-errors.cpp
@@ -1,8 +1,8 @@
 // DEFINE: %{filecheck} = FileCheck %s --match-full-lines --check-prefix
 
-// RUN: not %clang -fsyntax-only %s --ssaf-tu-summary-file=foobar 2>&1 | %{filecheck}=DEFAULT-ERROR
-// RUN:     %clang -fsyntax-only %s --ssaf-tu-summary-file=foobar -Wno-error=scalable-static-analysis-framework 2>&1 | %{filecheck}=DEMOTED-TO-WARNING
-// RUN:     %clang -fsyntax-only %s --ssaf-tu-summary-file=foobar -Wno-scalable-static-analysis-framework 2>&1 | count 0
+// RUN: not %clang -fsyntax-only %s --ssaf-tu-summary-file=foobar --ssaf-compilation-unit-id=test-cu 2>&1 | %{filecheck}=DEFAULT-ERROR
+// RUN:     %clang -fsyntax-only %s --ssaf-tu-summary-file=foobar --ssaf-compilation-unit-id=test-cu -Wno-error=scalable-static-analysis-framework 2>&1 | %{filecheck}=DEMOTED-TO-WARNING
+// RUN:     %clang -fsyntax-only %s --ssaf-tu-summary-file=foobar --ssaf-compilation-unit-id=test-cu -Wno-scalable-static-analysis-framework 2>&1 | count 0
 
 // This test demonstrates that the "scalable-static-analysis-framework" diagnostics can be downgraded or completely silenced with the right flags.
 

--- a/clang/test/Analysis/Scalable/extraction-works-alongside-compilation.cpp
+++ b/clang/test/Analysis/Scalable/extraction-works-alongside-compilation.cpp
@@ -11,6 +11,7 @@
 // RUN: rm -rf %t.o %t.json
 // RUN: %{codegen} \
 // RUN:   --ssaf-extract-summaries=CallGraph \
+// RUN:   --ssaf-compilation-unit-id=test-cu \
 // RUN:   --ssaf-tu-summary-file=%t.json \
 // RUN: | not grep "Clearing AST"
 

--- a/clang/test/Analysis/Scalable/help.cpp
+++ b/clang/test/Analysis/Scalable/help.cpp
@@ -3,7 +3,9 @@
 // RUN: %clang     --help 2>&1 | %{filecheck}=HELP
 // RUN: %clang_cc1 --help 2>&1 | %{filecheck}=HELP
 
-// HELP:       --ssaf-extract-summaries=<summary-names>
+// HELP:       --ssaf-compilation-unit-id=<id>
+// HELP-NEXT:    Stable identifier used as the CompilationUnit namespace name of every produced SSAF TU summary. Required when '--ssaf-tu-summary-file=' is set.
+// HELP-NEXT:  --ssaf-extract-summaries=<summary-names>
 // HELP-NEXT:    Comma-separated list of summary names to extract
 // HELP-NEXT:  --ssaf-list-extractors  Display the list of available SSAF summary extractors
 // HELP-NEXT:  --ssaf-list-formats     Display the list of available SSAF serialization formats

--- a/clang/unittests/ScalableStaticAnalysisFramework/Frontend/TUSummaryExtractorFrontendActionTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/Frontend/TUSummaryExtractorFrontendActionTest.cpp
@@ -117,6 +117,66 @@ static SerializationFormatRegistry::Add<FailingSerializationFormat>
         "FailingSerializationFormat",
         "A serialization format that fails on every possible operation.");
 
+namespace {
+/// Records the \c CompilationUnit namespace name of the most recently written
+/// \c TUSummary into a static, so tests can assert that the runner threads
+/// the configured CU name verbatim into the produced summary.
+class CapturingSerializationFormat final : public SerializationFormat {
+public:
+  static std::string &lastCapturedName() {
+    static std::string Name;
+    return Name;
+  }
+
+  static void resetCapturedName() { lastCapturedName().clear(); }
+
+  llvm::Expected<TUSummary> readTUSummary(llvm::StringRef) override {
+    return llvm::createStringError("not implemented");
+  }
+  llvm::Error writeTUSummary(const TUSummary &Summary,
+                             llvm::StringRef) override {
+    lastCapturedName() = getName(getTUNamespace(Summary));
+    return llvm::Error::success();
+  }
+  llvm::Expected<TUSummaryEncoding>
+  readTUSummaryEncoding(llvm::StringRef) override {
+    return llvm::createStringError("not implemented");
+  }
+  llvm::Error writeTUSummaryEncoding(const TUSummaryEncoding &,
+                                     llvm::StringRef) override {
+    return llvm::Error::success();
+  }
+  llvm::Expected<LUSummary> readLUSummary(llvm::StringRef) override {
+    return llvm::createStringError("not implemented");
+  }
+  llvm::Error writeLUSummary(const LUSummary &, llvm::StringRef) override {
+    return llvm::Error::success();
+  }
+  llvm::Expected<LUSummaryEncoding>
+  readLUSummaryEncoding(llvm::StringRef) override {
+    return llvm::createStringError("not implemented");
+  }
+  llvm::Error writeLUSummaryEncoding(const LUSummaryEncoding &,
+                                     llvm::StringRef) override {
+    return llvm::Error::success();
+  }
+  llvm::Expected<WPASuite> readWPASuite(llvm::StringRef) override {
+    return llvm::createStringError("not implemented");
+  }
+  llvm::Error writeWPASuite(const WPASuite &, llvm::StringRef) override {
+    return llvm::Error::success();
+  }
+  void forEachRegisteredAnalysis(
+      llvm::function_ref<void(llvm::StringRef, llvm::StringRef)>)
+      const override {}
+};
+} // namespace
+
+static SerializationFormatRegistry::Add<CapturingSerializationFormat>
+    RegisterCapturingFormat(
+        "CapturingSerializationFormat",
+        "A serialization format that captures the CU namespace name.");
+
 using EventLog = std::vector<std::string>;
 
 namespace {
@@ -209,6 +269,7 @@ TEST_F(TUSummaryExtractorFrontendActionTest,
   std::string Output = makePath("output.MockSerializationFormat");
   Compiler->getFrontendOpts().SSAFTUSummaryFile = Output;
   Compiler->getFrontendOpts().SSAFExtractSummaries = {"NoOpExtractor"};
+  Compiler->getFrontendOpts().SSAFCompilationUnitId = "test-cu";
 
   TUSummaryExtractorFrontendAction ExtractorAction(
       std::make_unique<FailingAction>());
@@ -224,6 +285,7 @@ TEST_F(TUSummaryExtractorFrontendActionTest,
   std::string Output = makePath("output.xyz");
   Compiler->getFrontendOpts().SSAFTUSummaryFile = Output;
   Compiler->getFrontendOpts().SSAFExtractSummaries = {"NoOpExtractor"};
+  Compiler->getFrontendOpts().SSAFCompilationUnitId = "test-cu";
 
   auto Wrapped = std::make_unique<RecordingAction>();
   const EventLog &Log = Wrapped->getLog();
@@ -253,6 +315,7 @@ TEST_F(TUSummaryExtractorFrontendActionTest,
   std::string Output = makePath("output.MockSerializationFormat");
   Compiler->getFrontendOpts().SSAFTUSummaryFile = Output;
   Compiler->getFrontendOpts().SSAFExtractSummaries = {"NonExistentExtractor"};
+  Compiler->getFrontendOpts().SSAFCompilationUnitId = "test-cu";
 
   auto Wrapped = std::make_unique<RecordingAction>();
   const EventLog &Log = Wrapped->getLog();
@@ -277,6 +340,7 @@ TEST_F(TUSummaryExtractorFrontendActionTest,
   std::string Output = makePath("output.MockSerializationFormat");
   Compiler->getFrontendOpts().SSAFTUSummaryFile = Output;
   Compiler->getFrontendOpts().SSAFExtractSummaries = {"NoOpExtractor"};
+  Compiler->getFrontendOpts().SSAFCompilationUnitId = "test-cu";
 
   auto Wrapped = std::make_unique<RecordingAction>();
   const EventLog &Log = Wrapped->getLog();
@@ -331,6 +395,7 @@ TEST_F(TUSummaryExtractorFrontendActionTest,
   std::string Output = makePath("output.MockSerializationFormat");
   Compiler->getFrontendOpts().SSAFTUSummaryFile = Output;
   Compiler->getFrontendOpts().SSAFExtractSummaries = {"NoOpExtractor"};
+  Compiler->getFrontendOpts().SSAFCompilationUnitId = "test-cu";
 
   auto Wrapped = std::make_unique<OrderCheckingAction>();
   Wrapped->OutputPath = Output;
@@ -352,6 +417,7 @@ TEST_F(TUSummaryExtractorFrontendActionTest, RunnerFailsToWrite) {
   std::string Output = makePath("output.FailingSerializationFormat");
   Compiler->getFrontendOpts().SSAFTUSummaryFile = Output;
   Compiler->getFrontendOpts().SSAFExtractSummaries = {"NoOpExtractor"};
+  Compiler->getFrontendOpts().SSAFCompilationUnitId = "test-cu";
 
   TUSummaryExtractorFrontendAction Action(std::make_unique<RecordingAction>());
 
@@ -366,6 +432,71 @@ TEST_F(TUSummaryExtractorFrontendActionTest, RunnerFailsToWrite) {
 
   // No output should have been created due to the failure.
   EXPECT_FALSE(llvm::sys::fs::exists(Output));
+}
+
+TEST_F(TUSummaryExtractorFrontendActionTest,
+       MissingCompilationUnitIdDiagnoses) {
+  std::string Output = makePath("output.MockSerializationFormat");
+  Compiler->getFrontendOpts().SSAFTUSummaryFile = Output;
+  Compiler->getFrontendOpts().SSAFExtractSummaries = {"NoOpExtractor"};
+  // SSAFCompilationUnitId left empty.
+
+  auto Wrapped = std::make_unique<RecordingAction>();
+  const EventLog &Log = Wrapped->getLog();
+  TUSummaryExtractorFrontendAction ExtractorAction(std::move(Wrapped));
+
+  EXPECT_FALSE(Compiler->ExecuteAction(ExtractorAction));
+
+  EXPECT_THAT(Log, Contains("Wrapped::Initialize"));
+  EXPECT_THAT(Log, Contains("Wrapped::HandleTranslationUnit"));
+
+  EXPECT_THAT(
+      errorsMsgsOf(DiagBuf),
+      UnorderedElementsAre("option '--ssaf-tu-summary-file=' requires "
+                           "'--ssaf-compilation-unit-id=' to be set"));
+
+  EXPECT_FALSE(llvm::sys::fs::exists(Output));
+}
+
+TEST_F(TUSummaryExtractorFrontendActionTest,
+       EmptyCompilationUnitIdDiagnoses) {
+  std::string Output = makePath("output.MockSerializationFormat");
+  Compiler->getFrontendOpts().SSAFTUSummaryFile = Output;
+  Compiler->getFrontendOpts().SSAFExtractSummaries = {"NoOpExtractor"};
+  Compiler->getFrontendOpts().SSAFCompilationUnitId = "";
+
+  auto Wrapped = std::make_unique<RecordingAction>();
+  const EventLog &Log = Wrapped->getLog();
+  TUSummaryExtractorFrontendAction ExtractorAction(std::move(Wrapped));
+
+  EXPECT_FALSE(Compiler->ExecuteAction(ExtractorAction));
+
+  EXPECT_THAT(Log, Contains("Wrapped::Initialize"));
+  EXPECT_THAT(Log, Contains("Wrapped::HandleTranslationUnit"));
+
+  EXPECT_THAT(
+      errorsMsgsOf(DiagBuf),
+      UnorderedElementsAre("option '--ssaf-tu-summary-file=' requires "
+                           "'--ssaf-compilation-unit-id=' to be set"));
+
+  EXPECT_FALSE(llvm::sys::fs::exists(Output));
+}
+
+TEST_F(TUSummaryExtractorFrontendActionTest,
+       CompilationUnitIdThreadsToSummary) {
+  CapturingSerializationFormat::resetCapturedName();
+
+  const std::string CUId = "cu-X-test";
+  std::string Output = makePath("output.CapturingSerializationFormat");
+  Compiler->getFrontendOpts().SSAFTUSummaryFile = Output;
+  Compiler->getFrontendOpts().SSAFExtractSummaries = {"NoOpExtractor"};
+  Compiler->getFrontendOpts().SSAFCompilationUnitId = CUId;
+
+  TUSummaryExtractorFrontendAction Action(std::make_unique<RecordingAction>());
+  EXPECT_TRUE(Compiler->ExecuteAction(Action));
+  EXPECT_EQ(DiagBuf.getNumErrors(), 0U);
+
+  EXPECT_EQ(CapturingSerializationFormat::lastCapturedName(), CUId);
 }
 
 } // namespace


### PR DESCRIPTION
The TU summary extractor previously sourced the CompilationUnit namespace name from clang's `InFile` argument, which made the identity of a TU summary depend on the file path the build system passed to clang. Have the build system pass the identifier directly:

- New driver/cc1 option `--ssaf-compilation-unit-id=<id>`, marshalled into `FrontendOptions::SSAFCompilationUnitId`.
- `TUSummaryRunner` builds its `BuildNamespace(CompilationUnit, ...)` from the new option's value; `InFile` is no longer threaded into the runner.
- New diagnostic `warn_ssaf_tu_summary_requires_compilation_unit_id` (under `-Wscalable-static-analysis-framework`, `DefaultError`) fires when `--ssaf-tu-summary-file=` is set without a non-empty `--ssaf-compilation-unit-id=`. The runner falls back to the wrapped consumer alone in that case, matching the existing setup-time SSAF diagnostics.

Assisted-By: Claude Opus 4.7