### PR TITLE
[clang][deps] Strip `CodeGenOptions` command-line arguments

### DIFF
--- a/clang/lib/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/DependencyScanning/ModuleDepCollector.cpp
@@ -263,6 +263,12 @@ makeCommonInvocationForModuleBuild(CompilerInvocation CI) {
   resetBenignCodeGenOptions(frontend::GenerateModule, CI.getLangOpts(),
                             CI.getCodeGenOpts());
 
+  // Erase the command-line arguments. These don't make it into the final set of
+  // compilation arguments and will be re-populated during compilation itself.
+  // Keeping them around would make copies of the invocation expensive.
+  CI.getCodeGenOpts().Argv0 = nullptr;
+  CI.getCodeGenOpts().CommandLineArgs.clear();
+
   // Map output paths that affect behaviour to "-" so their existence is in the
   // context hash. The final path will be computed in addOutputPaths.
   if (!CI.getDiagnosticOpts().DiagnosticSerializationFile.empty())


### PR DESCRIPTION
This change speeds up dependency scanning for compilation caching with explicit modules by 1.34x (wall-time) and 1.51x (instructions). Performance of regular explicit module scans is not affected, because that mode already makes good use of the copy-on-write nature of `CowCompilerInvocation`.