### PR TITLE
[libc] Refactor FreeTrie to support detached metadata and popmin

### DIFF
--- a/libc/src/__support/freestore.h
+++ b/libc/src/__support/freestore.h
@@ -31,7 +31,7 @@ public:
   /// Sets the range of possible block sizes. This can only be called when the
   /// trie is empty.
   LIBC_INLINE void set_range(FreeTrie::SizeRange range) {
-    large_trie.set_range(range);
+    large_trie_range = range;
   }
 
   /// Insert a free block. If the block is too small to be tracked, nothing
@@ -64,8 +64,13 @@ private:
   FreeList &small_list(BlockRef block);
   FreeList *find_best_small_fit(size_t size);
 
+  LIBC_INLINE FreeTrie large_trie() {
+    return FreeTrie(large_trie_root, large_trie_range);
+  }
+
   cpp::array<FreeList, NUM_SMALL_SIZES> small_lists;
-  FreeTrie large_trie;
+  FreeTrie::Node *large_trie_root = nullptr;
+  FreeTrie::SizeRange large_trie_range{0, 0};
 };
 
 LIBC_INLINE void FreeStore::insert(BlockRef block) {
@@ -74,7 +79,7 @@ LIBC_INLINE void FreeStore::insert(BlockRef block) {
   if (is_small(block))
     small_list(block).push(block);
   else
-    large_trie.push(block);
+    large_trie().push(block);
 }
 
 LIBC_INLINE void FreeStore::remove(BlockRef block) {
@@ -84,7 +89,8 @@ LIBC_INLINE void FreeStore::remove(BlockRef block) {
     small_list(block).remove(
         reinterpret_cast<FreeList::Node *>(block.usable_space()));
   } else {
-    large_trie.remove(reinterpret_cast<FreeTrie::Node *>(block.usable_space()));
+    large_trie().remove(
+        reinterpret_cast<FreeTrie::Node *>(block.usable_space()));
   }
 }
 
@@ -94,9 +100,10 @@ LIBC_INLINE BlockRef FreeStore::remove_best_fit(size_t size) {
     list->pop();
     return block;
   }
-  if (FreeTrie::Node *best_fit = large_trie.find_best_fit(size)) {
+  FreeTrie trie = large_trie();
+  if (FreeTrie::Node *best_fit = trie.find_best_fit(size)) {
     BlockRef block = best_fit->block();
-    large_trie.remove(best_fit);
+    trie.remove(best_fit);
     return block;
   }
   return BlockRef();

--- a/libc/src/__support/freetrie.h
+++ b/libc/src/__support/freetrie.h
@@ -87,15 +87,8 @@ public:
     }
   };
 
-  LIBC_INLINE constexpr FreeTrie() : FreeTrie(SizeRange{0, 0}) {}
-  LIBC_INLINE constexpr FreeTrie(SizeRange range) : range(range) {}
-
-  /// Sets the range of possible block sizes. This can only be called when the
-  /// trie is empty.
-  LIBC_INLINE void set_range(FreeTrie::SizeRange new_range) {
-    LIBC_ASSERT(empty() && "cannot change the range of a preexisting trie");
-    range = new_range;
-  }
+  LIBC_INLINE FreeTrie(Node *&root, SizeRange range)
+      : root(root), range(range) {}
 
   /// @returns Whether the trie contains any blocks.
   LIBC_INLINE bool empty() const { return !root; }
@@ -110,15 +103,24 @@ public:
   /// nullptr.
   Node *find_best_fit(size_t size);
 
+  /// @returns The node with the minimum size in the trie; otherwise nullptr.
+  LIBC_INLINE Node *find_min();
+
+  /// Removes and returns the node with the minimum size in the trie; otherwise
+  /// nullptr.
+  LIBC_INLINE Node *pop_min();
+
 private:
   /// @returns Whether a node is the head of its containing freelist.
-  bool is_head(Node *node) const { return node->parent || node == root; }
+  LIBC_INLINE bool is_head(Node *node) const {
+    return node->parent || node == root;
+  }
 
   /// Replaces references to one node with another (or nullptr) in all adjacent
   /// parent and child nodes.
   void replace_node(Node *node, Node *new_node);
 
-  Node *root = nullptr;
+  Node *&root;
   SizeRange range;
 };
 
@@ -235,6 +237,47 @@ LIBC_INLINE FreeTrie::Node *FreeTrie::find_best_fit(size_t size) {
       cur_range = cur_range.lower();
     }
   }
+}
+LIBC_INLINE FreeTrie::Node *FreeTrie::find_min() {
+  if (empty())
+    return nullptr;
+
+  Node *cur = root;
+  SizeRange cur_range = range;
+  Node *best_min = nullptr;
+
+  while (cur) {
+    if (cur->lower) {
+      if (cur_range.lower().contains(cur->size())) {
+        if (!best_min || cur->size() < best_min->size()) {
+          best_min = cur;
+        }
+      }
+      cur = cur->lower;
+      cur_range = cur_range.lower();
+    } else {
+      if (cur_range.lower().contains(cur->size())) {
+        if (!best_min || cur->size() < best_min->size()) {
+          best_min = cur;
+        }
+        break;
+      } else {
+        if (!best_min || cur->size() < best_min->size()) {
+          best_min = cur;
+        }
+        cur = cur->upper;
+        cur_range = cur_range.upper();
+      }
+    }
+  }
+  return best_min;
+}
+
+LIBC_INLINE FreeTrie::Node *FreeTrie::pop_min() {
+  Node *min_node = find_min();
+  if (min_node)
+    remove(min_node);
+  return min_node;
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/test/src/__support/freetrie_test.cpp
+++ b/libc/test/src/__support/freetrie_test.cpp
@@ -22,7 +22,9 @@ using LIBC_NAMESPACE::cpp::byte;
 using LIBC_NAMESPACE::cpp::optional;
 
 TEST(LlvmLibcFreeTrie, FindBestFitRoot) {
-  FreeTrie trie({0, 4096});
+  FreeTrie::Node *root = nullptr;
+  FreeTrie::SizeRange range{0, 4096};
+  FreeTrie trie(root, range);
   EXPECT_EQ(trie.find_best_fit(123), static_cast<FreeTrie::Node *>(nullptr));
 
   byte mem[1024];
@@ -31,10 +33,10 @@ TEST(LlvmLibcFreeTrie, FindBestFitRoot) {
   BlockRef block = *maybeBlock;
   trie.push(block);
 
-  FreeTrie::Node *root = trie.find_best_fit(0);
-  ASSERT_EQ(root->block().addr(), block.addr());
-  EXPECT_EQ(trie.find_best_fit(block.inner_size() - 1), root);
-  EXPECT_EQ(trie.find_best_fit(block.inner_size()), root);
+  FreeTrie::Node *found = trie.find_best_fit(0);
+  ASSERT_EQ(found->block().addr(), block.addr());
+  EXPECT_EQ(trie.find_best_fit(block.inner_size() - 1), found);
+  EXPECT_EQ(trie.find_best_fit(block.inner_size()), found);
   EXPECT_EQ(trie.find_best_fit(block.inner_size() + 1),
             static_cast<FreeTrie::Node *>(nullptr));
   EXPECT_EQ(trie.find_best_fit(4095), static_cast<FreeTrie::Node *>(nullptr));
@@ -47,10 +49,12 @@ TEST(LlvmLibcFreeTrie, FindBestFitLower) {
   BlockRef lower = *maybeBlock;
   maybeBlock = lower.split(512);
   ASSERT_TRUE(maybeBlock.has_value());
-  BlockRef root = *maybeBlock;
+  BlockRef root_block = *maybeBlock;
 
-  FreeTrie trie({0, 4096});
-  trie.push(root);
+  FreeTrie::Node *root = nullptr;
+  FreeTrie::SizeRange range{0, 4096};
+  FreeTrie trie(root, range);
+  trie.push(root_block);
   trie.push(lower);
 
   EXPECT_EQ(trie.find_best_fit(0)->block().addr(), lower.addr());
@@ -60,36 +64,40 @@ TEST(LlvmLibcFreeTrie, FindBestFitUpper) {
   byte mem[4096];
   optional<BlockRef> maybeBlock = BlockRef::init(mem);
   ASSERT_TRUE(maybeBlock.has_value());
-  BlockRef root = *maybeBlock;
-  maybeBlock = root.split(512);
+  BlockRef root_block = *maybeBlock;
+  maybeBlock = root_block.split(512);
   ASSERT_TRUE(maybeBlock.has_value());
   BlockRef upper = *maybeBlock;
 
-  FreeTrie trie({0, 4096});
-  trie.push(root);
+  FreeTrie::Node *root = nullptr;
+  FreeTrie::SizeRange range{0, 4096};
+  FreeTrie trie(root, range);
+  trie.push(root_block);
   trie.push(upper);
 
-  EXPECT_EQ(trie.find_best_fit(root.inner_size() + 1)->block().addr(),
+  EXPECT_EQ(trie.find_best_fit(root_block.inner_size() + 1)->block().addr(),
             upper.addr());
   // The upper subtrie should be skipped if it could not contain a better fit.
-  EXPECT_EQ(trie.find_best_fit(root.inner_size() - 1)->block().addr(),
-            root.addr());
+  EXPECT_EQ(trie.find_best_fit(root_block.inner_size() - 1)->block().addr(),
+            root_block.addr());
 }
 
 TEST(LlvmLibcFreeTrie, FindBestFitLowerAndUpper) {
   byte mem[4096];
   optional<BlockRef> maybeBlock = BlockRef::init(mem);
   ASSERT_TRUE(maybeBlock.has_value());
-  BlockRef root = *maybeBlock;
-  maybeBlock = root.split(1024);
+  BlockRef root_block = *maybeBlock;
+  maybeBlock = root_block.split(1024);
   ASSERT_TRUE(maybeBlock.has_value());
   BlockRef lower = *maybeBlock;
   maybeBlock = lower.split(128);
   ASSERT_TRUE(maybeBlock.has_value());
   BlockRef upper = *maybeBlock;
 
-  FreeTrie trie({0, 4096});
-  trie.push(root);
+  FreeTrie::Node *root = nullptr;
+  FreeTrie::SizeRange range{0, 4096};
+  FreeTrie trie(root, range);
+  trie.push(root_block);
   trie.push(lower);
   trie.push(upper);
 
@@ -114,7 +122,9 @@ TEST(LlvmLibcFreeTrie, Remove) {
   BlockRef large = *maybeBlock;
 
   // Removing the root empties the trie.
-  FreeTrie trie({0, 4096});
+  FreeTrie::Node *root = nullptr;
+  FreeTrie::SizeRange range{0, 4096};
+  FreeTrie trie(root, range);
   trie.push(large);
   FreeTrie::Node *large_node = trie.find_best_fit(0);
   ASSERT_EQ(large_node->block().addr(), large.addr());
@@ -131,4 +141,47 @@ TEST(LlvmLibcFreeTrie, Remove) {
   trie.remove(trie.find_best_fit(small1.inner_size()));
   EXPECT_EQ(trie.find_best_fit(large.inner_size())->block().addr(),
             large.addr());
+}
+
+TEST(LlvmLibcFreeTrie, PopMin) {
+  alignas(BlockRef::MIN_ALIGN) byte mem[4096];
+  optional<BlockRef> maybe_block = BlockRef::init(mem);
+  ASSERT_TRUE(maybe_block.has_value());
+  BlockRef root_block = *maybe_block;
+  maybe_block = root_block.split(1024);
+  ASSERT_TRUE(maybe_block.has_value());
+  BlockRef lower = *maybe_block;
+  maybe_block = lower.split(128);
+  ASSERT_TRUE(maybe_block.has_value());
+  BlockRef upper = *maybe_block;
+
+  FreeTrie::Node *root = nullptr;
+  FreeTrie::SizeRange range{0, 4096};
+  FreeTrie trie(root, range);
+
+  // Empty pop
+  EXPECT_EQ(trie.pop_min(), static_cast<FreeTrie::Node *>(nullptr));
+
+  trie.push(root_block);
+  trie.push(lower);
+  trie.push(upper);
+
+  // Min should be lower (~128)
+  FreeTrie::Node *min1 = trie.pop_min();
+  ASSERT_NE(min1, static_cast<FreeTrie::Node *>(nullptr));
+  EXPECT_EQ(min1->block().addr(), lower.addr());
+
+  // Next min should be root_block (~1024)
+  FreeTrie::Node *min2 = trie.pop_min();
+  ASSERT_NE(min2, static_cast<FreeTrie::Node *>(nullptr));
+  EXPECT_EQ(min2->block().addr(), root_block.addr());
+
+  // Next min should be upper (~2944)
+  FreeTrie::Node *min3 = trie.pop_min();
+  ASSERT_NE(min3, static_cast<FreeTrie::Node *>(nullptr));
+  EXPECT_EQ(min3->block().addr(), upper.addr());
+
+  // Now empty
+  EXPECT_EQ(trie.pop_min(), static_cast<FreeTrie::Node *>(nullptr));
+  EXPECT_TRUE(trie.empty());
 }


### PR DESCRIPTION
Factoring out range and add pop_min; in this way, we allow detached metadata from the trie for interaction with TLSF.

Benchmark shows that pure freetrie implementation still has 5% better heap efficiency in random actions. Although it suffers from a large latency that may undermine the heap efficiency gain, we still think this is desirable because when FreeTrie is used as the fallback data structure, the bounded time requirement can be fulfilled even in fallback search mode when heap is near to its full utilization. 

Assisted-by: Gemini powered AI tools (human-in-the-loop)