### PR TITLE
[StringMap] Replace tombstone deletion with TAOCP 6.4 Algorithm R ()

### DIFF
--- a/llvm/docs/ProgrammersManual.rst
+++ b/llvm/docs/ProgrammersManual.rst
@@ -2375,7 +2375,7 @@ long, expensive to copy, etc.  ``StringMap`` is a specialized container designed
 cope with these issues.  It supports mapping an arbitrary range of bytes to an
 arbitrary other object.
 
-The ``StringMap`` implementation uses a quadratically-probed hash table, where the
+The ``StringMap`` implementation uses a linear-probed hash table, where the
 buckets store a pointer to the heap allocated entries (and some other stuff).
 The entries in the map must be heap allocated because the strings are variable
 length.  The string data (key) and the element object (value) are stored in the
@@ -2383,7 +2383,7 @@ same allocation with the string data immediately after the element object.
 This container guarantees the "``(char*)(&Value+1)``" points to the key string
 for a value.
 
-The ``StringMap`` is very fast for several reasons: quadratic probing is very cache
+The ``StringMap`` is very fast for several reasons: linear probing is very cache
 efficient for lookups, the hash value of strings in buckets is not recomputed
 when looking up an element, ``StringMap`` rarely has to touch the memory for
 unrelated objects when looking up a value (even when hash collisions happen),

--- a/llvm/include/llvm/ADT/StringMap.h
+++ b/llvm/include/llvm/ADT/StringMap.h
@@ -39,19 +39,16 @@ protected:
   StringMapEntryBase **TheTable = nullptr;
   unsigned NumBuckets = 0;
   unsigned NumItems = 0;
-  unsigned NumTombstones = 0;
   unsigned ItemSize;
 
 protected:
   explicit StringMapImpl(unsigned itemSize) : ItemSize(itemSize) {}
   StringMapImpl(StringMapImpl &&RHS)
       : TheTable(RHS.TheTable), NumBuckets(RHS.NumBuckets),
-        NumItems(RHS.NumItems), NumTombstones(RHS.NumTombstones),
-        ItemSize(RHS.ItemSize) {
+        NumItems(RHS.NumItems), ItemSize(RHS.ItemSize) {
     RHS.TheTable = nullptr;
     RHS.NumBuckets = 0;
     RHS.NumItems = 0;
-    RHS.NumTombstones = 0;
   }
 
   LLVM_ABI StringMapImpl(unsigned InitSize, unsigned ItemSize);
@@ -86,6 +83,10 @@ protected:
   /// table, returning it.  If the key is not in the table, this returns null.
   LLVM_ABI StringMapEntryBase *RemoveKey(StringRef Key);
 
+  /// Remove the entry pointer at the given (live) bucket without destroying
+  /// the entry, and close the hole via Algorithm R backward shifting.
+  LLVM_ABI void removeBucket(unsigned Bucket);
+
   /// Allocate the table with the specified number of buckets and otherwise
   /// setup the map as empty.
   LLVM_ABI void init(unsigned Size);
@@ -95,14 +96,6 @@ protected:
   }
 
 public:
-  static constexpr uintptr_t TombstoneIntVal =
-      static_cast<uintptr_t>(-1)
-      << PointerLikeTypeTraits<StringMapEntryBase *>::NumLowBitsAvailable;
-
-  static StringMapEntryBase *getTombstoneVal() {
-    return reinterpret_cast<StringMapEntryBase *>(TombstoneIntVal);
-  }
-
   [[nodiscard]] unsigned getNumBuckets() const { return NumBuckets; }
   [[nodiscard]] unsigned getNumItems() const { return NumItems; }
 
@@ -122,7 +115,6 @@ public:
     std::swap(TheTable, Other.TheTable);
     std::swap(NumBuckets, Other.NumBuckets);
     std::swap(NumItems, Other.NumItems);
-    std::swap(NumTombstones, Other.NumTombstones);
   }
 };
 
@@ -172,26 +164,18 @@ public:
              *RHSHashTable = (unsigned *)(RHS.TheTable + NumBuckets + 1);
 
     NumItems = RHS.NumItems;
-    NumTombstones = RHS.NumTombstones;
+    // Copy the bucket layout verbatim.  Preserving each entry's slot keeps
+    // the probe-sequence invariant intact without re-probing.
     for (unsigned I = 0, E = NumBuckets; I != E; ++I) {
       StringMapEntryBase *Bucket = RHS.TheTable[I];
-      if (!Bucket || Bucket == getTombstoneVal()) {
-        TheTable[I] = Bucket;
+      if (!Bucket)
         continue;
-      }
 
       TheTable[I] = MapEntryTy::create(
           static_cast<MapEntryTy *>(Bucket)->getKey(), getAllocator(),
           static_cast<MapEntryTy *>(Bucket)->getValue());
       HashTable[I] = RHSHashTable[I];
     }
-
-    // Note that here we've copied everything from the RHS into this object,
-    // tombstones included. We could, instead, have re-probed for each key to
-    // instantiate this new object without any tombstone buckets. The
-    // assumption here is that items are rarely deleted from most StringMaps,
-    // and so tombstones are rare, so the cost of re-probing for all inputs is
-    // not worthwhile.
   }
 
   StringMap &operator=(StringMap RHS) {
@@ -206,7 +190,7 @@ public:
     // work not required in the destructor.
     if (!empty()) {
       for (StringMapEntryBase *Bucket : buckets()) {
-        if (Bucket && Bucket != getTombstoneVal()) {
+        if (Bucket) {
           static_cast<MapEntryTy *>(Bucket)->Destroy(getAllocator());
         }
       }
@@ -326,15 +310,13 @@ public:
   bool insert(MapEntryTy *KeyValue) {
     unsigned BucketNo = LookupBucketFor(KeyValue->getKey());
     StringMapEntryBase *&Bucket = TheTable[BucketNo];
-    if (Bucket && Bucket != getTombstoneVal())
+    if (Bucket)
       return false; // Already exists in map.
 
     incrementEpoch();
-    if (Bucket == getTombstoneVal())
-      --NumTombstones;
     Bucket = KeyValue;
     ++NumItems;
-    assert(NumItems + NumTombstones <= NumBuckets);
+    assert(NumItems <= NumBuckets);
 
     RehashTable();
     return true;
@@ -394,16 +376,14 @@ public:
                                                   ArgsTy &&...Args) {
     unsigned BucketNo = LookupBucketFor(Key, FullHashValue);
     StringMapEntryBase *&Bucket = TheTable[BucketNo];
-    if (Bucket && Bucket != getTombstoneVal())
+    if (Bucket)
       return {iterator(this, TheTable + BucketNo), false}; // Already in map.
 
     incrementEpoch();
-    if (Bucket == getTombstoneVal())
-      --NumTombstones;
     Bucket =
         MapEntryTy::create(Key, getAllocator(), std::forward<ArgsTy>(Args)...);
     ++NumItems;
-    assert(NumItems + NumTombstones <= NumBuckets);
+    assert(NumItems <= NumBuckets);
 
     BucketNo = RehashTable(BucketNo);
     return {iterator(this, TheTable + BucketNo), true};
@@ -415,17 +395,16 @@ public:
     if (empty())
       return;
 
-    // Zap all values, resetting the keys back to non-present (not tombstone),
-    // which is safe because we're removing all elements.
+    // Zap all values, resetting the keys back to non-present, which is safe
+    // because we're removing all elements.
     for (StringMapEntryBase *&Bucket : buckets()) {
-      if (Bucket && Bucket != getTombstoneVal()) {
+      if (Bucket) {
         static_cast<MapEntryTy *>(Bucket)->Destroy(getAllocator());
       }
       Bucket = nullptr;
     }
 
     NumItems = 0;
-    NumTombstones = 0;
   }
 
   /// remove - Remove the specified key/value pair from the map, but do not
@@ -457,17 +436,22 @@ public:
   /// into the map are invalidated.
   template <typename Predicate> bool remove_if(Predicate Pred) {
     bool Removed = false;
-    for (StringMapEntryBase *&Bucket : buckets()) {
-      if (!Bucket || Bucket == getTombstoneVal())
+    for (unsigned I = 0; I != NumBuckets;) {
+      StringMapEntryBase *Bucket = TheTable[I];
+      if (!Bucket) {
+        ++I;
         continue;
-      auto *Entry = static_cast<MapEntryTy *>(Bucket);
-      if (Pred(*Entry)) {
-        Entry->Destroy(getAllocator());
-        Bucket = getTombstoneVal();
-        --NumItems;
-        ++NumTombstones;
-        Removed = true;
       }
+      auto *Entry = static_cast<MapEntryTy *>(Bucket);
+      if (!Pred(*Entry)) {
+        ++I;
+        continue;
+      }
+      Entry->Destroy(getAllocator());
+      // This may relocate a following entry into this slot to close the hole,
+      // so re-examine the same index rather than advancing past it.
+      removeBucket(I);
+      Removed = true;
     }
     if (Removed)
       incrementEpoch();
@@ -544,7 +528,7 @@ public:
 
 private:
   void AdvancePastEmptyBuckets() {
-    while (*Ptr == nullptr || *Ptr == StringMapImpl::getTombstoneVal())
+    while (*Ptr == nullptr)
       ++Ptr;
   }
 };

--- a/llvm/lib/Support/StringMap.cpp
+++ b/llvm/lib/Support/StringMap.cpp
@@ -62,7 +62,6 @@ void StringMapImpl::init(unsigned InitSize) {
 
   unsigned NewNumBuckets = InitSize ? InitSize : 16;
   NumItems = 0;
-  NumTombstones = 0;
 
   TheTable = createTable(NewNumBuckets);
 
@@ -88,28 +87,15 @@ unsigned StringMapImpl::LookupBucketFor(StringRef Name,
   unsigned BucketNo = FullHashValue & (NumBuckets - 1);
   unsigned *HashTable = getHashTable(TheTable, NumBuckets);
 
-  unsigned ProbeAmt = 1;
-  int FirstTombstone = -1;
   while (true) {
     StringMapEntryBase *BucketItem = TheTable[BucketNo];
     // If we found an empty bucket, this key isn't in the table yet, return it.
     if (LLVM_LIKELY(!BucketItem)) {
-      // If we found a tombstone, we want to reuse the tombstone instead of an
-      // empty bucket.  This reduces probing.
-      if (FirstTombstone != -1) {
-        HashTable[FirstTombstone] = FullHashValue;
-        return FirstTombstone;
-      }
-
       HashTable[BucketNo] = FullHashValue;
       return BucketNo;
     }
 
-    if (BucketItem == getTombstoneVal()) {
-      // Skip over tombstones.  However, remember the first one we see.
-      if (FirstTombstone == -1)
-        FirstTombstone = BucketNo;
-    } else if (LLVM_LIKELY(HashTable[BucketNo] == FullHashValue)) {
+    if (LLVM_LIKELY(HashTable[BucketNo] == FullHashValue)) {
       // If the full hash value matches, check deeply for a match.  The common
       // case here is that we are only looking at the buckets (for item info
       // being non-null and for the full hash value) not at the items.  This
@@ -125,11 +111,7 @@ unsigned StringMapImpl::LookupBucketFor(StringRef Name,
     }
 
     // Okay, we didn't find the item.  Probe to the next bucket.
-    BucketNo = (BucketNo + ProbeAmt) & (NumBuckets - 1);
-
-    // Use quadratic probing, it has fewer clumping artifacts than linear
-    // probing and has good cache behavior in the common case.
-    ++ProbeAmt;
+    BucketNo = (BucketNo + 1) & (NumBuckets - 1);
   }
 }
 
@@ -147,16 +129,13 @@ int StringMapImpl::FindKey(StringRef Key, uint32_t FullHashValue) const {
   unsigned BucketNo = FullHashValue & (NumBuckets - 1);
   unsigned *HashTable = getHashTable(TheTable, NumBuckets);
 
-  unsigned ProbeAmt = 1;
   while (true) {
     StringMapEntryBase *BucketItem = TheTable[BucketNo];
     // If we found an empty bucket, this key isn't in the table yet, return.
     if (LLVM_LIKELY(!BucketItem))
       return -1;
 
-    if (BucketItem == getTombstoneVal()) {
-      // Ignore tombstones.
-    } else if (LLVM_LIKELY(HashTable[BucketNo] == FullHashValue)) {
+    if (LLVM_LIKELY(HashTable[BucketNo] == FullHashValue)) {
       // If the full hash value matches, check deeply for a match.  The common
       // case here is that we are only looking at the buckets (for item info
       // being non-null and for the full hash value) not at the items.  This
@@ -172,11 +151,7 @@ int StringMapImpl::FindKey(StringRef Key, uint32_t FullHashValue) const {
     }
 
     // Okay, we didn't find the item.  Probe to the next bucket.
-    BucketNo = (BucketNo + ProbeAmt) & (NumBuckets - 1);
-
-    // Use quadratic probing, it has fewer clumping artifacts than linear
-    // probing and has good cache behavior in the common case.
-    ++ProbeAmt;
+    BucketNo = (BucketNo + 1) & (NumBuckets - 1);
   }
 }
 
@@ -189,19 +164,31 @@ void StringMapImpl::RemoveKey(StringMapEntryBase *V) {
   assert(V == V2 && "Didn't find key?");
 }
 
-/// RemoveKey - Remove the StringMapEntry for the specified key from the
-/// table, returning it.  If the key is not in the table, this returns null.
+// Knuth TAOCP 6.4 Algorithm R: walk forward sliding each following entry
+// whose probe path crosses the hole.
+void StringMapImpl::removeBucket(unsigned Bucket) {
+  unsigned *HashTable = getHashTable(TheTable, NumBuckets);
+  unsigned Mask = NumBuckets - 1;
+  unsigned I = Bucket, J = I;
+  while ((J = (J + 1) & Mask), TheTable[J]) {
+    unsigned Ideal = HashTable[J];
+    if (((I - Ideal) & Mask) < ((J - Ideal) & Mask)) {
+      TheTable[I] = TheTable[J];
+      HashTable[I] = HashTable[J];
+      I = J;
+    }
+  }
+  TheTable[I] = nullptr;
+  --NumItems;
+}
+
 StringMapEntryBase *StringMapImpl::RemoveKey(StringRef Key) {
   int Bucket = FindKey(Key);
   if (Bucket == -1)
     return nullptr;
 
   StringMapEntryBase *Result = TheTable[Bucket];
-  TheTable[Bucket] = getTombstoneVal();
-  --NumItems;
-  ++NumTombstones;
-  assert(NumItems + NumTombstones <= NumBuckets);
-
+  removeBucket(Bucket);
   return Result;
 }
 
@@ -209,14 +196,9 @@ StringMapEntryBase *StringMapImpl::RemoveKey(StringRef Key) {
 /// the appropriate mod-of-hashtable-size.
 unsigned StringMapImpl::RehashTable(unsigned BucketNo) {
   unsigned NewSize;
-  // If the hash table is now more than 3/4 full, or if fewer than 1/8 of
-  // the buckets are empty (meaning that many are filled with tombstones),
-  // grow/rehash the table.
+  // If the hash table is now more than 3/4 full, grow the table.
   if (LLVM_UNLIKELY(NumItems * 4 > NumBuckets * 3)) {
     NewSize = NumBuckets * 2;
-  } else if (LLVM_UNLIKELY(NumBuckets - (NumItems + NumTombstones) <=
-                           NumBuckets / 8)) {
-    NewSize = NumBuckets;
   } else {
     return BucketNo;
   }
@@ -230,16 +212,12 @@ unsigned StringMapImpl::RehashTable(unsigned BucketNo) {
   // the hash values available, so we don't have to rehash any strings.
   for (unsigned I = 0, E = NumBuckets; I != E; ++I) {
     StringMapEntryBase *Bucket = TheTable[I];
-    if (Bucket && Bucket != getTombstoneVal()) {
+    if (Bucket) {
       // If the bucket is not available, probe for a spot.
       unsigned FullHash = HashTable[I];
       unsigned NewBucket = FullHash & (NewSize - 1);
-      if (NewTableArray[NewBucket]) {
-        unsigned ProbeSize = 1;
-        do {
-          NewBucket = (NewBucket + ProbeSize++) & (NewSize - 1);
-        } while (NewTableArray[NewBucket]);
-      }
+      while (NewTableArray[NewBucket])
+        NewBucket = (NewBucket + 1) & (NewSize - 1);
 
       // Finally found a slot.  Fill it in.
       NewTableArray[NewBucket] = Bucket;
@@ -253,6 +231,5 @@ unsigned StringMapImpl::RehashTable(unsigned BucketNo) {
 
   TheTable = NewTableArray;
   NumBuckets = NewSize;
-  NumTombstones = 0;
   return NewBucketNo;
 }

--- a/llvm/unittests/ADT/StringMapTest.cpp
+++ b/llvm/unittests/ADT/StringMapTest.cpp
@@ -12,6 +12,7 @@
 #include "llvm/Support/DataTypes.h"
 #include "gtest/gtest.h"
 #include <limits>
+#include <map>
 #include <tuple>
 using namespace llvm;
 
@@ -178,6 +179,42 @@ TEST_F(StringMapTest, SmallFullMapTest) {
   EXPECT_EQ(0, Map.lookup("drei"));
   EXPECT_EQ(4, Map.lookup("veir"));
   EXPECT_EQ(5, Map.lookup("funf"));
+}
+
+// Stress test erase. Interleave inserts and erases so that probe clusters form,
+// shrink, and straddle the wrap-around, then verify every surviving key is
+// still findable and every erased key is gone.
+TEST_F(StringMapTest, EraseStressTest) {
+  llvm::StringMap<unsigned> Map;
+  std::map<std::string, unsigned> Ref;
+  // 64-bit Linear Congruential Generator.
+  uint64_t State = 1;
+  auto Next = [&] {
+    return (State = State * 6364136223846793005ULL + 1) >> 33;
+  };
+  for (unsigned I = 0; I != 4000; ++I) {
+    std::string Key = Twine(Next() % 100).str();
+    if (Next() & 1) {
+      Map[Key] = I;
+      Ref[Key] = I;
+    } else {
+      EXPECT_EQ(Map.erase(Key), Ref.erase(Key) != 0);
+    }
+
+    // Periodically cross-check the whole map against the reference.
+    if (I % 200 == 0) {
+      EXPECT_EQ(Map.size(), Ref.size());
+      for (const auto &KV : Ref) {
+        auto It = Map.find(KV.first);
+        ASSERT_NE(It, Map.end()) << "missing key " << KV.first;
+        EXPECT_EQ(It->second, KV.second);
+      }
+    }
+  }
+
+  EXPECT_EQ(Map.size(), Ref.size());
+  for (const auto &KV : Ref)
+    EXPECT_EQ(Map.lookup(KV.first), KV.second);
 }
 
 TEST_F(StringMapTest, CopyCtorTest) {
@@ -765,6 +802,46 @@ TEST(StringMapCustomTest, RemoveIf) {
   EXPECT_FALSE(Map.remove_if(
       [](const StringMapEntry<int> &E) { return E.getValue() > 100; }));
   EXPECT_EQ(2u, Map.size());
+}
+
+// Stress remove_if: it deletes in place using Algorithm R backward shifting and
+// re-examines each slot after a removal, which is subtle around probe clusters
+// that wrap past the end of the table. Remove a subset from a large map and
+// verify the survivors exactly match the reference.
+TEST(StringMapCustomTest, RemoveIfStress) {
+  llvm::StringMap<unsigned> Map;
+  std::map<std::string, unsigned> Ref;
+
+  // Deterministic LCG so the sequence is reproducible across platforms.
+  uint64_t State = 0x9e3779b9;
+  auto Next = [&] {
+    return (State = State * 6364136223846793005ULL + 1) >> 33;
+  };
+
+  for (unsigned I = 0; I != 4000; ++I) {
+    std::string Key = Twine(Next() % 1500).str();
+    Map[Key] = I;
+    Ref[Key] = I;
+  }
+
+  auto IsEven = [](unsigned V) { return V % 2 == 0; };
+  Map.remove_if(
+      [&](const StringMapEntry<unsigned> &E) { return IsEven(E.getValue()); });
+  for (auto It = Ref.begin(); It != Ref.end();) {
+    if (IsEven(It->second))
+      It = Ref.erase(It);
+    else
+      ++It;
+  }
+
+  EXPECT_EQ(Map.size(), Ref.size());
+  for (const auto &KV : Ref) {
+    auto It = Map.find(KV.first);
+    ASSERT_NE(It, Map.end()) << "missing key " << KV.first;
+    EXPECT_EQ(It->second, KV.second);
+  }
+  for (const auto &E : Map)
+    EXPECT_FALSE(IsEven(E.getValue())) << "stale key " << E.getKey();
 }
 
 #if LLVM_ENABLE_ABI_BREAKING_CHECKS

--- a/llvm/utils/gdb-scripts/prettyprinters.py
+++ b/llvm/utils/gdb-scripts/prettyprinters.py
@@ -209,11 +209,10 @@ class StringMapPrinter:
         end = it + self.val["NumBuckets"]
         value_ty = self.val.type.template_argument(0)
         entry_base_ty = gdb.lookup_type("llvm::StringMapEntryBase")
-        tombstone = gdb.parse_and_eval("llvm::StringMapImpl::TombstoneIntVal")
 
         while it != end:
             it_deref = it.dereference()
-            if it_deref == 0 or it_deref == tombstone:
+            if it_deref == 0:
                 it = it + 1
                 continue
 


### PR DESCRIPTION
Reland #202103 after relanding "[StringMap] Invalidate iterators in remove()" (#203249)

StringMap uses quadratic probing with lazy deletion: an erased entry
becomes a tombstone, a third bucket state alongside empty and live that
every find/insert must inspect.

Switch to linear probing with Knuth TAOCP 6.4 Algorithm R deletion,
similar to DenseMap #200595.

erase now relocates the following entries to close the hole. StringMap
buckets are pointers to heap-allocated entries, so only the pointers
(and the parallel hash array) move. References and pointers to entries
remain valid, but iterators are invalidated.

Depends on #202237 and #202520
Aided by Claude Opus 4.8