### PR TITLE
[Dexter][NFC] Fixup test line numbers

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/nested_wheres.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/nested_wheres.cpp
@@ -23,16 +23,16 @@ int main() { return fib(4); }
 ---
 !where {function: main}:
     !where {function: fib}:
-        !and {lines: 8}:
+        !and {lines: 9}:
             !value n: 4
         !where {function: fib}:
-            !and {lines: 8}:
+            !and {lines: 9}:
                 !value n: [2, 3]
             !where {function: fib}:
-                !and {lines: 8}:
+                !and {lines: 9}:
                     !value n: [0, 1, 1, 2]
                 !where {function: fib}:
-                    !and {lines: 8}:
+                    !and {lines: 9}:
                         !value n: [0, 1]
 ...
 */


### PR DESCRIPTION
A previous commit (78ae864) added a test that contained off-by-1 errors in the line numbers used in the Dexter script; this patch adjusts these to the correct line number.