### PR TITLE
Fix "not all control paths return" warnings; NFC

### DIFF
--- a/llvm/lib/IR/BundleAttributes.cpp
+++ b/llvm/lib/IR/BundleAttributes.cpp
@@ -22,6 +22,7 @@ StringRef llvm::getNameFromBundleAttr(BundleAttr BA) {
   case BundleAttr::None:
     return "none";
   }
+  llvm_unreachable("unknonwn bundle attribute");
 }
 
 BundleAttr llvm::getBundleAttrFromString(StringRef Str) {

--- a/llvm/lib/Object/DXContainer.cpp
+++ b/llvm/lib/Object/DXContainer.cpp
@@ -361,6 +361,7 @@ parseContentsEntries(StringRef Entries,
     return Contents.Parameters.EntriesSizeInBytes;
   }
   }
+  llvm_unreachable("unhandled compression type");
 }
 
 static Expected<size_t>


### PR DESCRIPTION
In both cases, the switches are fully covered but MSVC still diagnoses.