### PR TITLE
[RISCV] Mark HW shadow stack ops as frame setup/destroy

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
@@ -132,9 +132,13 @@ static void emitSCSPrologue(MachineFunction &MF, MachineBasicBlock &MBB,
   if (HasHWShadowStack) {
     if (STI.hasStdExtZcmop()) {
       static_assert(RAReg == RISCV::X1, "C.SSPUSH only accepts X1");
-      BuildMI(MBB, MI, DL, TII->get(RISCV::C_SSPUSH)).addReg(RAReg);
+      BuildMI(MBB, MI, DL, TII->get(RISCV::C_SSPUSH))
+          .addReg(RAReg)
+          .setMIFlag(MachineInstr::FrameSetup);
     } else {
-      BuildMI(MBB, MI, DL, TII->get(RISCV::SSPUSH)).addReg(RAReg);
+      BuildMI(MBB, MI, DL, TII->get(RISCV::SSPUSH))
+          .addReg(RAReg)
+          .setMIFlag(MachineInstr::FrameSetup);
     }
     return;
   }
@@ -197,7 +201,9 @@ static void emitSCSEpilogue(MachineFunction &MF, MachineBasicBlock &MBB,
 
   const RISCVInstrInfo *TII = STI.getInstrInfo();
   if (HasHWShadowStack) {
-    BuildMI(MBB, MI, DL, TII->get(RISCV::SSPOPCHK)).addReg(RAReg);
+    BuildMI(MBB, MI, DL, TII->get(RISCV::SSPOPCHK))
+        .addReg(RAReg)
+        .setMIFlag(MachineInstr::FrameDestroy);
     return;
   }
 

--- a/llvm/test/CodeGen/RISCV/shadowcallstack-frame-flags.ll
+++ b/llvm/test/CodeGen/RISCV/shadowcallstack-frame-flags.ll
@@ -1,0 +1,21 @@
+; RUN: llc < %s -mtriple=riscv32 -mattr=+experimental-zicfiss \
+; RUN:   -verify-machineinstrs -stop-after=prologepilog \
+; RUN:   | FileCheck %s --check-prefix=RV32
+; RUN: llc < %s -mtriple=riscv64 -mattr=+experimental-zicfiss \
+; RUN:   -verify-machineinstrs -stop-after=prologepilog \
+; RUN:   | FileCheck %s --check-prefix=RV64
+
+declare i32 @bar()
+
+define i32 @f() "hw-shadow-stack" {
+; RV32-LABEL: name: f
+; RV32: frame-setup SSPUSH
+; RV32: frame-destroy SSPOPCHK
+;
+; RV64-LABEL: name: f
+; RV64: frame-setup SSPUSH
+; RV64: frame-destroy SSPOPCHK
+  %res = call i32 @bar()
+  %res1 = add i32 %res, 1
+  ret i32 %res
+}


### PR DESCRIPTION
This change follows up on PR #200182 and addresses the issue in the [related comment](https://github.com/llvm/llvm-project/pull/200182#discussion_r3329197379).  

It sets `FrameSetup` on SSPUSH/C_SSPUSH and `FrameDestroy` on SSPOPCHK instructions emitted by RISCVFrameLowering for the HW shadow stack path.  
The test was written manually (instead of using `utils/update_mir_test_checks.py`) to keep it simple and avoid unnecessary fragility.