### PR TITLE
[lld][MachO] Add --lto-obj-path for distributed ThinLTO

### DIFF
--- a/lld/MachO/Config.h
+++ b/lld/MachO/Config.h
@@ -170,6 +170,7 @@ struct Configuration {
   llvm::StringRef mapFile;
   llvm::StringRef ltoNewPmPasses;
   llvm::StringRef ltoObjPath;
+  bool ltoObjPathIsFile = false;
   llvm::StringRef thinLTOJobs;
   llvm::StringRef umbrella;
   uint32_t ltoo = 2;

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -1973,7 +1973,11 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
       warn("-umbrella used, but not creating dylib");
     config->umbrella = arg->getValue();
   }
-  config->ltoObjPath = args.getLastArgValue(OPT_object_path_lto);
+  if (const Arg *arg =
+          args.getLastArg(OPT_object_path_lto, OPT_lto_obj_path_eq)) {
+    config->ltoObjPath = arg->getValue();
+    config->ltoObjPathIsFile = arg->getOption().matches(OPT_lto_obj_path_eq);
+  }
   config->ltoNewPmPasses = args.getLastArgValue(OPT_lto_newpm_passes);
   config->thinLTOCacheDir = args.getLastArgValue(OPT_cache_path_lto);
   config->thinLTOCachePolicy = getLTOCachePolicy(args);

--- a/lld/MachO/LTO.cpp
+++ b/lld/MachO/LTO.cpp
@@ -244,15 +244,15 @@ std::vector<ObjFile *> BitcodeCompiler::compile() {
     thinLTOCreateEmptyIndexFiles();
 
   // In ThinLTO mode, Clang passes a temporary directory in -object_path_lto,
-  // while the argument is a single file in FullLTO mode.
-  bool objPathIsDir = true;
-  if (!config->ltoObjPath.empty()) {
+  // while -object_path_lto specifies a single file in FullLTO mode.
+  // --lto-obj-path always specifies a file.
+  bool objPathIsDir = !config->ltoObjPathIsFile;
+  if (!config->ltoObjPath.empty() && objPathIsDir) {
     if (std::error_code ec = fs::create_directories(config->ltoObjPath))
       fatal("cannot create LTO object path " + config->ltoObjPath + ": " +
             ec.message());
-
-    if (!fs::is_directory(config->ltoObjPath)) {
-      objPathIsDir = false;
+    objPathIsDir = fs::is_directory(config->ltoObjPath);
+    if (!objPathIsDir) {
       unsigned objCount =
           count_if(buf, [](const SmallString<0> &b) { return !b.empty(); });
       if (objCount > 1)
@@ -268,6 +268,8 @@ std::vector<ObjFile *> BitcodeCompiler::compile() {
         path::append(filePath, Twine(i) + "." +
                                    getArchitectureName(config->arch()) +
                                    ".lto.o");
+      else if (config->ltoObjPathIsFile && i != 0)
+        filePath += Twine(i).str();
     }
     return filePath;
   };

--- a/lld/MachO/Options.td
+++ b/lld/MachO/Options.td
@@ -41,6 +41,9 @@ def thinlto_index_only: Flag<["--"], "thinlto-index-only">,
     Group<grp_lld>;
 def thinlto_index_only_eq: Joined<["--"], "thinlto-index-only=">,
     Group<grp_lld>;
+def lto_obj_path_eq: Joined<["--"], "lto-obj-path=">,
+    HelpText<"Write the regular LTO object to <path>">,
+    Group<grp_lld>;
 def thinlto_jobs_eq : Joined<["--"], "thinlto-jobs=">,
     HelpText<"Number of ThinLTO jobs. Default to --threads=">,
     Group<grp_lld>;

--- a/lld/test/MachO/thinlto-obj-path.ll
+++ b/lld/test/MachO/thinlto-obj-path.ll
@@ -11,6 +11,18 @@
 ; RUN: llvm-nm %t4/0.x86_64.lto.o 2>&1 | FileCheck --check-prefix=NM %s
 ; RUN: llvm-readobj -h %t4/0.x86_64.lto.o | FileCheck %s
 
+;; --lto-obj-path writes the regular LTO object to an exact file path.
+; RUN: rm -f %t-exact.o*
+; RUN: %lld --thinlto-index-only=%t/linked-objects.txt \
+; RUN:     --lto-obj-path=%t-exact.o \
+; RUN:     -dylib %t1.o %t2.o -o /dev/null
+; RUN: llvm-readobj -h %t-exact.o | FileCheck %s
+; RUN: llvm-nm %t-exact.o 2>&1 | FileCheck --check-prefix=NM %s
+
+;; Additional native objects use numeric suffixes, as in ELF and WebAssembly.
+; RUN: %lld --lto-obj-path=%t-exact.o -dylib %t1.o %t2.o -o %t-exact
+; RUN: ls %t-exact.o %t-exact.o1 %t-exact.o2
+
 ;; Ensure lld emits empty combined module if specific obj-path.
 ; RUN: rm -fr %t.dir/objpath && mkdir -p %t.dir/objpath
 ; RUN: %lld -object_path_lto %t4.o -dylib %t1.o %t2.o -o %t.dir/objpath/a.out -save-temps


### PR DESCRIPTION
Mach-O LLD supports distributed ThinLTO, but unlike ELF LLD, wasm-ld, and lld-link, it does not provide an option that writes the regular LTO object to an exact path. This adds the LLD-specific `--lto-obj-path=<path>` option and gives additional native objects the numeric suffixes used by ELF LLD and wasm-ld.

The existing ld64-compatible `-object_path_lto` option is not sufficient for this use case. Clang passes a directory in `-object_path_lto` for ThinLTO, and Mach-O LLD generates a child such as `0.<arch>.lto.o`. Distributed build systems declare action outputs before execution; consuming that child requires reproducing Mach-O LLD's generated filename and architecture spelling. `--lto-obj-path` provides the same exact-file contract as the other LLD ports while preserving all existing `-object_path_lto` behavior.

Validation: `llvm-check-pr-format`; end-to-end Bazel builds of the macOS x86-64 and arm64 LLVM prebuilt targets with remote distributed ThinLTO indexing and backend compilation.

AI tool disclosure: Co-authored with OpenAI Codex.
