### PR TITLE
[mlir] Check for argument uses in test-func-erase-arg pass

### DIFF
--- a/mlir/test/IR/test-func-erase-arg-error.mlir
+++ b/mlir/test/IR/test-func-erase-arg-error.mlir
@@ -1,0 +1,15 @@
+// RUN: mlir-opt %s -test-func-erase-arg -split-input-file -verify-diagnostics
+
+// Erasing arguments that still have uses must fail (see #203218).
+
+// expected-error @below {{cannot erase argument 0 which still has uses}}
+// expected-error @below {{cannot erase argument 1 which still has uses}}
+func.func @f(%arg0: f32 {test.erase_this_arg},
+             %arg1: f32 {test.erase_this_arg}) -> (f32, f32) {
+  return %arg0, %arg1 : f32, f32
+}
+
+// -----
+
+// An external function has no body, so erasure must succeed.
+func.func private @ext(f32 {test.erase_this_arg})

--- a/mlir/test/lib/IR/TestFunc.cpp
+++ b/mlir/test/lib/IR/TestFunc.cpp
@@ -106,9 +106,19 @@ struct TestFuncEraseArg
 
     for (auto func : module.getOps<FunctionOpInterface>()) {
       BitVector indicesToErase(func.getNumArguments());
-      for (auto argIndex : llvm::seq<int>(0, func.getNumArguments()))
-        if (func.getArgAttr(argIndex, "test.erase_this_arg"))
-          indicesToErase.set(argIndex);
+      bool hasUsedArg = false;
+      for (auto argIndex : llvm::seq<int>(0, func.getNumArguments())) {
+        if (!func.getArgAttr(argIndex, "test.erase_this_arg"))
+          continue;
+        indicesToErase.set(argIndex);
+        if (!func.isExternal() && !func.getArgument(argIndex).use_empty()) {
+          emitError(func->getLoc()) << "cannot erase argument " << argIndex
+                                    << " which still has uses";
+          hasUsedArg = true;
+        }
+      }
+      if (hasUsedArg)
+        return signalPassFailure();
       if (succeeded(func.eraseArguments(indicesToErase)))
         continue;
       emitError(func->getLoc()) << "failed to erase arguments";


### PR DESCRIPTION
The -test-func-erase-arg pass crashed when erasing arguments that still
had uses. Diagnose every such argument and fail the pass without erasing.

Fixes https://github.com/llvm/llvm-project/issues/203218

Assisted-by: Claude (Claude Code)