### PR TITLE
Revert "Reland "[libc] Enable baremetal float printf using modular format""

### DIFF
--- a/libc/config/baremetal/config.json
+++ b/libc/config/baremetal/config.json
@@ -13,6 +13,9 @@
     "LIBC_CONF_PRINTF_DISABLE_FIXED_POINT": {
       "value": true
     },
+    "LIBC_CONF_PRINTF_DISABLE_FLOAT": {
+      "value": true
+    },
     "LIBC_CONF_PRINTF_DISABLE_INDEX_MODE": {
       "value": true
     },
@@ -29,9 +32,6 @@
       "value": true
     },
     "LIBC_COPT_PRINTF_DISABLE_BITINT": {
-      "value": true
-    },
-    "LIBC_CONF_PRINTF_MODULAR": {
       "value": true
     }
   },


### PR DESCRIPTION
Reverts llvm/llvm-project#199758

We are seeing float_impl.cpp.obj getting pulled into the final binary in our code where it wasn't before this change. While we investigate this, reverting to address the binary bloat issue.