### PR TITLE
[flang] Improve error for data component definition after CONTAINS in derived type

### DIFF
--- a/flang/lib/Parser/Fortran-parsers.cpp
+++ b/flang/lib/Parser/Fortran-parsers.cpp
@@ -562,7 +562,10 @@ TYPE_CONTEXT_PARSER("type bound procedure binding"_en_US,
     recovery(
         first(construct<TypeBoundProcBinding>(Parser<TypeBoundProcedureStmt>{}),
             construct<TypeBoundProcBinding>(Parser<TypeBoundGenericStmt>{}),
-            construct<TypeBoundProcBinding>(Parser<FinalProcedureStmt>{})),
+            construct<TypeBoundProcBinding>(Parser<FinalProcedureStmt>{}),
+            Parser<DataComponentDefStmt>{} >>
+                fail<TypeBoundProcBinding>(
+                    "component definition must precede CONTAINS in a derived type"_err_en_US)),
         construct<TypeBoundProcBinding>(
             !"END"_tok >> SkipTo<'\n'>{} >> construct<ErrorRecovery>())))
 

--- a/flang/test/Parser/recovery09.f90
+++ b/flang/test/Parser/recovery09.f90
@@ -1,0 +1,27 @@
+! RUN: not %flang_fc1 -fsyntax-only %s 2>&1 | FileCheck %s
+
+! Verify that a data component definition appearing after CONTAINS in a
+! derived type gives a clear error instead of misleading
+! "expected 'FINAL'/'GENERIC'/'PROCEDURE'" messages.
+
+module m
+  implicit none
+
+  type, public :: t1
+     real :: x
+   contains
+     procedure, public :: init
+! CHECK: error: component definition must precede CONTAINS in a derived type
+     integer, public :: n(3) = 1
+! CHECK: error: component definition must precede CONTAINS in a derived type
+     real, pointer, dimension(:,:,:), public :: gpoint => null()
+! CHECK-NOT: expected 'FINAL'
+! CHECK-NOT: expected 'GENERIC'
+! CHECK-NOT: expected 'PROCEDURE'
+  end type t1
+
+contains
+  subroutine init(this)
+    class(t1), intent(inout) :: this
+  end subroutine init
+end module m

--- a/flang/test/Parser/recovery09.f90
+++ b/flang/test/Parser/recovery09.f90
@@ -12,8 +12,10 @@ module m
    contains
      procedure, public :: init
 ! CHECK: error: component definition must precede CONTAINS in a derived type
+! CHECK-NEXT: {{.*}}integer, public :: n(3) = 1
      integer, public :: n(3) = 1
 ! CHECK: error: component definition must precede CONTAINS in a derived type
+! CHECK-NEXT: {{.*}}real, pointer, dimension(:,:,:), public :: gpoint => null()
      real, pointer, dimension(:,:,:), public :: gpoint => null()
 ! CHECK-NOT: expected 'FINAL'
 ! CHECK-NOT: expected 'GENERIC'


### PR DESCRIPTION
  When a data component declaration appears after CONTAINS in a derived
  type definition, flang previously emitted confusing "expected 'FINAL'",
  "expected 'GENERIC'", and "expected 'PROCEDURE'" errors for each
  misplaced component.

   This patch adds a misplaced-component detector following the same
  pattern as `misplacedSpecificationStmt` in program-parsers.cpp.
  DataComponentDefStmt is tried as a last alternative in
  TypeBoundProcBinding's first(). When it matches, fail<>() fires
  with the message:

    error: component definition must precede CONTAINS in a derived type

  CombineFailedParses then replaces the three keyword-mismatch messages
  with this single targeted one, since the component parse advances
  further than the PROCEDURE/GENERIC/FINAL failures.

  Assisted-By: AI

