### PR TITLE
[clang][Darwin] Disable ObjC class selector stubs when using LLD

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -3517,13 +3517,17 @@ void Darwin::addClangTargetOptions(
       (getLinkerVersion(DriverArgs) >= VersionTuple(811, 2)))
     CC1Args.push_back("-fobjc-msgsend-selector-stubs");
 
+  bool LinkerIsLLD = false;
+  GetLinkerPath(&LinkerIsLLD);
+
   // Enable objc_msgSend class selector stubs by default if the linker supports
   // it. ld64-1250+ does, for arm64, arm64e, and arm64_32.
+  // FIXME(#203385): LLD doesn't support ObjC class selector stubs yet.
   if (!DriverArgs.hasArgNoClaim(
           options::OPT_fobjc_msgsend_class_selector_stubs,
           options::OPT_fno_objc_msgsend_class_selector_stubs) &&
       getTriple().isAArch64() &&
-      (getLinkerVersion(DriverArgs) >= VersionTuple(1250, 0)))
+      (getLinkerVersion(DriverArgs) >= VersionTuple(1250, 0)) && !LinkerIsLLD)
     CC1Args.push_back("-fobjc-msgsend-class-selector-stubs");
 
   // Pass "-fno-sized-deallocation" only when the user hasn't manually enabled

--- a/clang/test/Driver/darwin-objc-selector-stubs.m
+++ b/clang/test/Driver/darwin-objc-selector-stubs.m
@@ -24,7 +24,8 @@
 // RUN: %clang -target arm64_32-apple-watchos8      -mlinker-version=1249  -### %s 2>&1 | FileCheck %s --check-prefix=INST_STUB_ONLY
 // RUN: %clang -target arm64_32-apple-watchos8      -mlinker-version=811.2 -### %s 2>&1 | FileCheck %s --check-prefix=INST_STUB_ONLY
 // RUN: %clang -target arm64_32-apple-watchos8      -mlinker-version=811   -### %s 2>&1 | FileCheck %s --check-prefix=NOSTUBS
-
+// FIXME(#203385): LLD does not support ObjC class selector stubs yet.
+// RUN: %clang -target arm64-apple-macos12 -fuse-ld=lld -B%S/Inputs/lld -mlinker-version=1250 -### %s 2>&1 | FileCheck %s --check-prefix=INST_STUB_ONLY
 
 // Disabled elsewhere, e.g. x86_64.
 // RUN: %clang -target x86_64-apple-macos12         -mlinker-version=1250  -### %s 2>&1 | FileCheck %s --check-prefix=NOSTUBS


### PR DESCRIPTION
LLD does not support ObjC class selector stubs yet (which requires synthesizing                                                                                                                                               `objc_msgSendClass$...` stubs). This change disables                                                                                                                                                                          `-fobjc-msgsend-class-selector-stubs` by default when the linker is LLD.                                                                                                                                                       
                                                                                                                                                                                                                             
Ref: https://github.com/llvm/llvm-project/issues/203385