### PR TITLE
[PowerPC] Fix crash when promoting smaller types to 64 bit ucmp

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -606,7 +606,7 @@ PPCTargetLowering::PPCTargetLowering(const PPCTargetMachine &TM,
   // Custom handling for PowerPC ucmp instruction
   if (isPPC64) {
     // UCMP involves using carries, which only works in 64-bit
-    setOperationAction(ISD::UCMP, MVT::i32, Promote);
+    setOperationPromotedToType(ISD::UCMP, MVT::i32, MVT::i64);
     setOperationAction(ISD::UCMP, MVT::i64, Custom);
   } else {
     setOperationAction(ISD::UCMP, MVT::i32, Custom);
@@ -12801,6 +12801,15 @@ SDValue PPCTargetLowering::LowerUCMP(SDValue Op, SelectionDAG &DAG) const {
   SDValue B = DAG.getFreeze(Op.getOperand(1));
   EVT OpVT = A.getValueType();
   EVT ResVT = Op.getValueType();
+
+  // On PPC64, carry ops use the full 64-bit register. UCMP i32 is promoted to
+  // i64 by the legalizer; this only runs for UCMP i64 with operands still
+  // narrower than i64 (e.g. i64 @llvm.ucmp(i8, i8)).
+  if (Subtarget.isPPC64() && OpVT != MVT::i64) {
+    A = DAG.getNode(ISD::ZERO_EXTEND, DL, MVT::i64, A);
+    B = DAG.getNode(ISD::ZERO_EXTEND, DL, MVT::i64, B);
+    OpVT = MVT::i64;
+  }
 
   // First compute diff = A - B.
   SDValue Diff = DAG.getNode(ISD::SUB, DL, OpVT, A, B);

--- a/llvm/test/CodeGen/PowerPC/ucmp.ll
+++ b/llvm/test/CodeGen/PowerPC/ucmp.ll
@@ -108,3 +108,30 @@ define i64 @ucmp_64_64(i64 %x, i64 %y) nounwind {
   %1 = call i64 @llvm.ucmp(i64 %x, i64 %y)
   ret i64 %1
 }
+
+define i64 @ucmp_64_8_zero(i8 %x) nounwind {
+; CHECK-LABEL: ucmp_64_8_zero:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    clrldi 3, 3, 56
+; CHECK-NEXT:    subfic 4, 3, 0
+; CHECK-NEXT:    li 4, 0
+; CHECK-NEXT:    subfe 4, 4, 3
+; CHECK-NEXT:    subfe 3, 4, 3
+; CHECK-NEXT:    blr
+  %1 = call i64 @llvm.ucmp(i8 %x, i8 0)
+  ret i64 %1
+}
+
+define i64 @ucmp_64_8(i8 %x, i8 %y) nounwind {
+; CHECK-LABEL: ucmp_64_8:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    clrldi 3, 3, 56
+; CHECK-NEXT:    clrldi 4, 4, 56
+; CHECK-NEXT:    sub 5, 3, 4
+; CHECK-NEXT:    subc 6, 4, 3
+; CHECK-NEXT:    subfe 3, 4, 3
+; CHECK-NEXT:    subfe 3, 3, 5
+; CHECK-NEXT:    blr
+  %1 = call i64 @llvm.ucmp(i8 %x, i8 %y)
+  ret i64 %1
+}


### PR DESCRIPTION
i64 @llvm.ucmp(i8, …) bypasses UCMP i32→i64 promotion; widen operands in LowerUCMP before carry lowering.