### PR TITLE
[NFC][DirectX][SPIRV] Remove helper from HLSLFrontend

### DIFF
--- a/llvm/include/llvm/Frontend/HLSL/CBuffer.h
+++ b/llvm/include/llvm/Frontend/HLSL/CBuffer.h
@@ -53,7 +53,6 @@ public:
   iterator begin() { return Mappings.begin(); }
   iterator end() { return Mappings.end(); }
 
-  LLVM_ABI void removeCBufferGlobalsFromUseList(Module &M);
   LLVM_ABI void eraseFromModule();
 };
 

--- a/llvm/lib/Frontend/HLSL/CBuffer.cpp
+++ b/llvm/lib/Frontend/HLSL/CBuffer.cpp
@@ -71,54 +71,6 @@ CBufferMetadata::get(Module &M, llvm::function_ref<bool(Type *)> IsPadding) {
   return Result;
 }
 
-// Removes the provided global variables from the compiler used list.
-// This needs to be implemented here because using the llvm::removeFromUsedList
-// function from LLVMTransformUtils would create a cyclic dependency.
-static void
-removeFromCompilerUsedList(Module &M,
-                           SmallPtrSet<GlobalVariable *, 8> &GlobalToRemove) {
-  GlobalVariable *UsedListGV = M.getNamedGlobal("llvm.compiler.used");
-  if (!UsedListGV || !UsedListGV->hasInitializer())
-    return;
-
-  auto *CA = cast<ConstantArray>(UsedListGV->getInitializer());
-  SmallVector<Constant *, 16> NewInit;
-  for (Use &Op : CA->operands()) {
-    if (auto *GV = dyn_cast<GlobalVariable>(Op->stripPointerCasts())) {
-      if (!GlobalToRemove.contains(GV))
-        NewInit.push_back(GV);
-    }
-  }
-
-  if (!NewInit.empty()) {
-    Type *ArrayEltTy =
-        cast<ArrayType>(UsedListGV->getValueType())->getElementType();
-    ArrayType *ATy = ArrayType::get(ArrayEltTy, NewInit.size());
-    GlobalVariable *NewUsedListGV = new GlobalVariable(
-        M, ATy, false, GlobalValue::AppendingLinkage,
-        ConstantArray::get(ATy, NewInit), "", UsedListGV,
-        UsedListGV->getThreadLocalMode(), UsedListGV->getAddressSpace());
-    NewUsedListGV->setSection(UsedListGV->getSection());
-    NewUsedListGV->takeName(UsedListGV);
-  }
-
-  UsedListGV->eraseFromParent();
-}
-
-void CBufferMetadata::removeCBufferGlobalsFromUseList(Module &M) {
-  if (Mappings.empty())
-    return;
-
-  SmallPtrSet<GlobalVariable *, 8> CBGlobals;
-  for (const hlsl::CBufferMapping &Mapping : Mappings)
-    CBGlobals.insert(Mapping.Handle);
-
-  removeFromCompilerUsedList(M, CBGlobals);
-
-  for (GlobalVariable *HandleGV : CBGlobals)
-    HandleGV->removeDeadConstantUsers();
-}
-
 void CBufferMetadata::eraseFromModule() {
   // Remove the cbs named metadata
   MD->eraseFromParent();

--- a/llvm/lib/Target/DirectX/DXILCBufferAccess.cpp
+++ b/llvm/lib/Target/DirectX/DXILCBufferAccess.cpp
@@ -19,6 +19,7 @@
 #include "llvm/Pass.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Transforms/Utils/Local.h"
+#include "llvm/Transforms/Utils/ModuleUtils.h"
 
 #define DEBUG_TYPE "dxil-cbuffer-access"
 using namespace llvm;
@@ -50,16 +51,26 @@ static bool replaceCBufferAccesses(Module &M) {
     return false;
 
   SmallVector<Constant *> CBufferGlobals;
-  for (const hlsl::CBufferMapping &Mapping : *CBufMD)
+  SmallPtrSet<GlobalVariable *, 8> CBufferHandles;
+  for (const hlsl::CBufferMapping &Mapping : *CBufMD) {
+    CBufferHandles.insert(Mapping.Handle);
     for (const hlsl::CBufferMember &Member : Mapping.Members)
       CBufferGlobals.push_back(Member.GV);
+  }
   convertUsersOfConstantsToInstructions(CBufferGlobals);
 
   for (const hlsl::CBufferMapping &Mapping : *CBufMD)
     for (const hlsl::CBufferMember &Member : Mapping.Members)
       replaceUsersOfGlobal(Member.GV, Mapping.Handle, Member.Offset);
 
-  CBufMD->removeCBufferGlobalsFromUseList(M);
+  // Remove cbuffer handle globals from @llvm.compiler.used list.
+  llvm::removeFromUsedLists(M, [&](Constant *C) -> bool {
+    auto *GV = dyn_cast<GlobalVariable>(C);
+    return GV && CBufferHandles.contains(GV);
+  });
+  for (GlobalVariable *HandleGV : CBufferHandles)
+    HandleGV->removeDeadConstantUsers();
+
   CBufMD->eraseFromModule();
   return true;
 }

--- a/llvm/lib/Target/SPIRV/SPIRVCBufferAccess.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCBufferAccess.cpp
@@ -36,6 +36,7 @@
 #include "llvm/IR/IntrinsicsSPIRV.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/ReplaceConstant.h"
+#include "llvm/Transforms/Utils/ModuleUtils.h"
 
 #define DEBUG_TYPE "spirv-cbuffer-access"
 using namespace llvm;
@@ -63,10 +64,13 @@ static bool replaceCBufferAccesses(Module &M) {
   if (!CBufMD)
     return false;
 
+  SmallPtrSet<GlobalVariable *, 8> CBufferHandles;
   SmallVector<Constant *> CBufferGlobals;
-  for (const hlsl::CBufferMapping &Mapping : *CBufMD)
+  for (const hlsl::CBufferMapping &Mapping : *CBufMD) {
+    CBufferHandles.insert(Mapping.Handle);
     for (const hlsl::CBufferMember &Member : Mapping.Members)
       CBufferGlobals.push_back(Member.GV);
+  }
   convertUsersOfConstantsToInstructions(CBufferGlobals);
 
   for (const hlsl::CBufferMapping &Mapping : *CBufMD) {
@@ -101,7 +105,13 @@ static bool replaceCBufferAccesses(Module &M) {
     }
   }
 
-  CBufMD->removeCBufferGlobalsFromUseList(M);
+  // Remove cbuffer handle globals from @llvm.compiler.used list.
+  llvm::removeFromUsedLists(M, [&](Constant *C) -> bool {
+    auto *GV = dyn_cast<GlobalVariable>(C);
+    return GV && CBufferHandles.contains(GV);
+  });
+  for (GlobalVariable *HandleGV : CBufferHandles)
+    HandleGV->removeDeadConstantUsers();
 
   // Now that all uses are replaced, clean up the globals and metadata.
   for (const hlsl::CBufferMapping &Mapping : *CBufMD) {


### PR DESCRIPTION
Remove helper function `removeCBufferGlobalsFromUseList` which basically implements existing `llvm::removeFromUsedLists`. Modify the passes that use it to call `llvm::removeFromUsedLists`.

Follow-up on https://github.com/llvm/llvm-project/pull/202745#discussion_r3398119720