### PR TITLE
[libc] EAGAIN and EWOULDBLOCK should be treated as success in futex wait

### DIFF
--- a/libc/src/__support/threads/linux/futex_utils.h
+++ b/libc/src/__support/threads/linux/futex_utils.h
@@ -66,6 +66,11 @@ public:
       if (ret == -EINTR)
         continue;
 
+      // the value pointed to by uaddr was not equal to the expected
+      // value val at the time of the call (EAGAIN or EWOULDBLOCK).
+      if (ret == -EAGAIN || ret == -EWOULDBLOCK)
+        return 0;
+
       if (ret < 0)
         return cpp::unexpected(-ret);
       return ret;


### PR DESCRIPTION
The `futex` wait function means waiting until a real change has been detected. We should not reject valid EAGAIN/EWOULDBLOCK kernel detection as failures.

Pure human code.