### PR TITLE
[Bitcode] Decode small byte constants as signed values

### DIFF
--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -3370,7 +3370,8 @@ Error BitcodeReader::parseConstants() {
     case bitc::CST_CODE_BYTE: // BYTE: [byteval]
       if (!CurTy->isByteOrByteVectorTy() || Record.empty())
         return error("Invalid byte const record");
-      V = ConstantByte::get(CurTy, decodeSignRotatedValue(Record[0]));
+      V = ConstantByte::get(CurTy, decodeSignRotatedValue(Record[0]),
+                            /*isSigned=*/true);
       break;
     case bitc::CST_CODE_WIDE_BYTE: { // WIDE_BYTE: [n x byteval]
       if (!CurTy->isByteOrByteVectorTy() || Record.empty())

--- a/llvm/test/Bitcode/byte-constants.ll
+++ b/llvm/test/Bitcode/byte-constants.ll
@@ -1,0 +1,7 @@
+; RUN: llvm-as < %s | llvm-dis | FileCheck %s
+
+; CHECK: @byte.highbit = constant b8 -1
+@byte.highbit = constant b8 255
+
+; CHECK: @byte.vector.highbit = constant <2 x b8> <b8 -128, b8 -1>
+@byte.vector.highbit = constant <2 x b8> <b8 128, b8 255>


### PR DESCRIPTION
Decode small byte constants the same way we encode them. The bitcode writer stores ConstantByte values as signed integers, so the reader must rebuild them using the signed ConstantByte::get path. This has high-bit values like b8 255 round-trip as their canonical signed form, b8 -1, instead of tripping the APInt width assertion. This matches current i8 behavior.

Before the fix, the new test crashes in llvm-dis with: "APInt.h: Assertion `llvm::isUIntN(BitWidth, val) && "Value is not an N-bit unsigned value"' failed."

Bug found while investigating this PR (https://github.com/llvm/llvm-project/pull/177908), which transitions the LSV to emitting the byte type. Fix assisted by AI.