### PR TITLE
[bazel][llvm] Guard pthread_getname_np / posix_spawn for low-API Android

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/config.h
+++ b/utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/config.h
@@ -118,7 +118,11 @@
 #define HAVE_LIBPTHREAD 1
 
 /* Define to 1 if you have the `pthread_getname_np' function. */
+/* Android bionic added pthread_getname_np in API 26; guard so the Android
+   cross-build at lower API levels takes llvm's fallback path. */
+#if !defined(__ANDROID__) || __ANDROID_API__ >= 26
 #define HAVE_PTHREAD_GETNAME_NP 1
+#endif
 
 /* Define to 1 if you have the `pthread_setname_np' function. */
 #define HAVE_PTHREAD_SETNAME_NP 1
@@ -139,7 +143,11 @@
 /* HAVE_MALLOC_ZONE_STATISTICS defined in Bazel */
 
 /* Define to 1 if you have the `posix_spawn' function. */
+/* Android bionic added posix_spawn in API 28; guard so the Android cross-build at
+   lower API levels takes llvm's fork/exec fallback path. */
+#if !defined(__ANDROID__) || __ANDROID_API__ >= 28
 #define HAVE_POSIX_SPAWN 1
+#endif
 
 /* Define to 1 if you have the `pread' function. */
 #define HAVE_PREAD 1


### PR DESCRIPTION
bionic added pthread_getname_np in API 26 and posix_spawn in API 28. The bazel overlay's config.h hardcoded both to 1, breaking the Android cross-build at lower API levels. Guard each with an __ANDROID_API__ check so those builds take llvm's fallback paths.

Meta is working to build lldb-server internally with buck2 for Android.  The build bazel setup looks like it is missing any sort of setup for this.  Working backwards from good builds, it is found that depending on the API version of and android platform built against, compiler errors happen around this.  Leverage built in guards from compiler to disable features that won't work.  This is cleaner than trying to shoehorn a select around Android version.  It might work internally, but not a clue if bazel's select would support Android version (rather than just Android _platform_.