### PR TITLE
[LoopUnroll] Remove `Count` from `UnrollingPreferences` (NFC)

### DIFF
--- a/llvm/include/llvm/Analysis/TargetTransformInfo.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfo.h
@@ -686,11 +686,6 @@ public:
     /// OptSizeThreshold, but used for partial/runtime unrolling (set to
     /// UINT_MAX to disable).
     unsigned PartialOptSizeThreshold;
-    /// A forced unrolling factor (the number of concatenated bodies of the
-    /// original loop in the unrolled loop body). When set to 0, the unrolling
-    /// transformation will select an unrolling factor based on the current cost
-    /// threshold and other factors.
-    unsigned Count;
     /// Default unroll count for loops with run-time trip count.
     unsigned DefaultUnrollRuntimeCount;
     // Set the maximum unrolling factor. The unrolling factor may be selected

--- a/llvm/include/llvm/Transforms/Scalar.h
+++ b/llvm/include/llvm/Transforms/Scalar.h
@@ -75,9 +75,9 @@ LLVM_ABI Pass *createLoopTermFoldPass();
 LLVM_ABI Pass *createLoopUnrollPass(int OptLevel = 2,
                                     bool OnlyWhenForced = false,
                                     bool ForgetAllSCEV = false,
-                                    int Threshold = -1, int Count = -1,
-                                    int AllowPartial = -1, int Runtime = -1,
-                                    int UpperBound = -1, int AllowPeeling = -1);
+                                    int Threshold = -1, int AllowPartial = -1,
+                                    int Runtime = -1, int UpperBound = -1,
+                                    int AllowPeeling = -1);
 
 //===----------------------------------------------------------------------===//
 //

--- a/llvm/include/llvm/Transforms/Utils/UnrollLoop.h
+++ b/llvm/include/llvm/Transforms/Utils/UnrollLoop.h
@@ -139,9 +139,8 @@ LLVM_ABI TargetTransformInfo::UnrollingPreferences gatherUnrollingPreferences(
     Loop *L, ScalarEvolution &SE, const TargetTransformInfo &TTI,
     BlockFrequencyInfo *BFI, ProfileSummaryInfo *PSI,
     llvm::OptimizationRemarkEmitter &ORE, int OptLevel,
-    std::optional<unsigned> UserThreshold, std::optional<unsigned> UserCount,
-    std::optional<bool> UserAllowPartial, std::optional<bool> UserRuntime,
-    std::optional<bool> UserUpperBound,
+    std::optional<unsigned> UserThreshold, std::optional<bool> UserAllowPartial,
+    std::optional<bool> UserRuntime, std::optional<bool> UserUpperBound,
     std::optional<unsigned> UserFullUnrollMaxCount);
 
 /// Produce an estimate of the unrolled cost of the specified loop.  This
@@ -174,14 +173,14 @@ public:
 
   uint64_t getRolledLoopSize() const { return LoopSize.getValue(); }
 
-  /// Returns loop size estimation for unrolled loop, given the unrolling
-  /// configuration specified by UP.
+  /// Returns loop size estimation for an unrolled loop with the given unroll
+  /// count and the unrolling configuration specified by UP.
   LLVM_ABI uint64_t
   getUnrolledLoopSize(const TargetTransformInfo::UnrollingPreferences &UP,
-                      unsigned CountOverwrite = 0) const;
+                      unsigned Count) const;
 };
 
-LLVM_ABI void
+LLVM_ABI unsigned
 computeUnrollCount(Loop *L, const TargetTransformInfo &TTI, DominatorTree &DT,
                    LoopInfo *LI, AssumptionCache *AC, ScalarEvolution &SE,
                    const SmallPtrSetImpl<const Value *> &EphValues,

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -7569,7 +7569,6 @@ static int32_t computeHeuristicUnrollFactor(CanonicalLoopInfo *CLI) {
       /*BlockFrequencyInfo=*/nullptr,
       /*ProfileSummaryInfo=*/nullptr, ORE, static_cast<int>(OptLevel),
       /*UserThreshold=*/std::nullopt,
-      /*UserCount=*/std::nullopt,
       /*UserAllowPartial=*/true,
       /*UserAllowRuntime=*/true,
       /*UserUpperBound=*/std::nullopt,
@@ -7644,9 +7643,9 @@ static int32_t computeHeuristicUnrollFactor(CanonicalLoopInfo *CLI) {
   bool MaxOrZero = false;
   unsigned TripMultiple = 0;
 
-  computeUnrollCount(L, TTI, DT, &LI, &AC, SE, EphValues, &ORE, TripCount,
-                     MaxTripCount, MaxOrZero, TripMultiple, UCE, UP, PP);
-  unsigned Factor = UP.Count;
+  unsigned Factor =
+      computeUnrollCount(L, TTI, DT, &LI, &AC, SE, EphValues, &ORE, TripCount,
+                         MaxTripCount, MaxOrZero, TripMultiple, UCE, UP, PP);
   LLVM_DEBUG(dbgs() << "Suggesting unroll factor of " << Factor << "\n");
 
   // This function returns 1 to signal to not unroll a loop.

--- a/llvm/lib/Transforms/Scalar/LoopUnrollAndJamPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollAndJamPass.cpp
@@ -128,57 +128,65 @@ static unsigned unrollAndJamCountPragmaValue(const Loop *L) {
   return 0;
 }
 
-// Returns loop size estimation for unrolled loop.
+// Returns loop size estimation for an unrolled-and-jammed loop with the given
+// unroll count.
 static uint64_t
 getUnrollAndJammedLoopSize(unsigned LoopSize,
-                           TargetTransformInfo::UnrollingPreferences &UP) {
+                           const TargetTransformInfo::UnrollingPreferences &UP,
+                           unsigned Count) {
   assert(LoopSize >= UP.BEInsns && "LoopSize should not be less than BEInsns!");
-  return static_cast<uint64_t>(LoopSize - UP.BEInsns) * UP.Count + UP.BEInsns;
+  return static_cast<uint64_t>(LoopSize - UP.BEInsns) * Count + UP.BEInsns;
 }
 
-// Calculates unroll and jam count and writes it to UP.Count. Returns true if
-// unroll count was set explicitly.
-static bool computeUnrollAndJamCount(
+// Calculates unroll and jam count.
+static unsigned computeUnrollAndJamCount(
     Loop *L, Loop *SubLoop, const TargetTransformInfo &TTI, DominatorTree &DT,
     LoopInfo *LI, AssumptionCache *AC, ScalarEvolution &SE,
     const SmallPtrSetImpl<const Value *> &EphValues,
     OptimizationRemarkEmitter *ORE, unsigned OuterTripCount,
     unsigned OuterTripMultiple, const UnrollCostEstimator &OuterUCE,
     unsigned InnerTripCount, unsigned InnerLoopSize,
-    TargetTransformInfo::UnrollingPreferences &UP,
+    bool &IsExplicitUnrollAndJam, TargetTransformInfo::UnrollingPreferences &UP,
     TargetTransformInfo::PeelingPreferences &PP) {
   unsigned OuterLoopSize = OuterUCE.getRolledLoopSize();
+  IsExplicitUnrollAndJam = false;
+
   // Use computeUnrollCount from the loop unroller to get a count for
   // unrolling the outer loop. This uses UP.Threshold / UP.PartialThreshold /
   // UP.MaxCount to come up with sensible loop values.
   // We have already checked that the loop has no unroll.* pragmas.
-  computeUnrollCount(L, TTI, DT, LI, AC, SE, EphValues, ORE, OuterTripCount,
-                     /*MaxTripCount*/ 0, /*MaxOrZero*/ false, OuterTripMultiple,
-                     OuterUCE, UP, PP);
+  unsigned Count =
+      computeUnrollCount(L, TTI, DT, LI, AC, SE, EphValues, ORE, OuterTripCount,
+                         /*MaxTripCount*/ 0, /*MaxOrZero*/ false,
+                         OuterTripMultiple, OuterUCE, UP, PP);
 
-  // Override with any explicit Count from the "unroll-and-jam-count" option.
+  // Override with any explicit count from the "unroll-and-jam-count" option.
   bool UserUnrollCount = UnrollAndJamCount.getNumOccurrences() > 0;
   if (UserUnrollCount) {
-    UP.Count = UnrollAndJamCount;
+    Count = UnrollAndJamCount;
     UP.Force = true;
     if (UP.AllowRemainder &&
-        getUnrollAndJammedLoopSize(OuterLoopSize, UP) < UP.Threshold &&
-        getUnrollAndJammedLoopSize(InnerLoopSize, UP) <
-            UP.UnrollAndJamInnerLoopThreshold)
-      return true;
+        getUnrollAndJammedLoopSize(OuterLoopSize, UP, Count) < UP.Threshold &&
+        getUnrollAndJammedLoopSize(InnerLoopSize, UP, Count) <
+            UP.UnrollAndJamInnerLoopThreshold) {
+      IsExplicitUnrollAndJam = true;
+      return Count;
+    }
   }
 
   // Check for unroll_and_jam pragmas
   unsigned PragmaCount = unrollAndJamCountPragmaValue(L);
   if (PragmaCount > 0) {
-    UP.Count = PragmaCount;
+    Count = PragmaCount;
     UP.Runtime = true;
     UP.Force = true;
     if ((UP.AllowRemainder || (OuterTripMultiple % PragmaCount == 0)) &&
-        getUnrollAndJammedLoopSize(OuterLoopSize, UP) < UP.Threshold &&
-        getUnrollAndJammedLoopSize(InnerLoopSize, UP) <
-            UP.UnrollAndJamInnerLoopThreshold)
-      return true;
+        getUnrollAndJammedLoopSize(OuterLoopSize, UP, Count) < UP.Threshold &&
+        getUnrollAndJammedLoopSize(InnerLoopSize, UP, Count) <
+            UP.UnrollAndJamInnerLoopThreshold) {
+      IsExplicitUnrollAndJam = true;
+      return Count;
+    }
   }
 
   bool PragmaEnableUnroll = hasUnrollAndJamEnablePragma(L);
@@ -190,35 +198,36 @@ static bool computeUnrollAndJamCount(
   if (ExplicitUnrollAndJam)
     UP.UnrollAndJamInnerLoopThreshold = PragmaUnrollAndJamThreshold;
 
-  if (!UP.AllowRemainder && getUnrollAndJammedLoopSize(InnerLoopSize, UP) >=
-                                UP.UnrollAndJamInnerLoopThreshold) {
+  if (!UP.AllowRemainder &&
+      getUnrollAndJammedLoopSize(InnerLoopSize, UP, Count) >=
+          UP.UnrollAndJamInnerLoopThreshold) {
     LLVM_DEBUG(dbgs() << "Won't unroll-and-jam; can't create remainder and "
                          "inner loop too large\n");
-    UP.Count = 0;
-    return false;
+    return 0;
   }
 
   // We have a sensible limit for the outer loop, now adjust it for the inner
   // loop and UP.UnrollAndJamInnerLoopThreshold. If the outer limit was set
   // explicitly, we want to stick to it.
   if (!ExplicitUnrollAndJamCount && UP.AllowRemainder) {
-    while (UP.Count != 0 && getUnrollAndJammedLoopSize(InnerLoopSize, UP) >=
-                                UP.UnrollAndJamInnerLoopThreshold)
-      UP.Count--;
+    while (Count != 0 && getUnrollAndJammedLoopSize(InnerLoopSize, UP, Count) >=
+                             UP.UnrollAndJamInnerLoopThreshold)
+      Count--;
   }
 
   // If we are explicitly unroll and jamming, we are done. Otherwise there are a
   // number of extra performance heuristics to check.
-  if (ExplicitUnrollAndJam)
-    return true;
+  if (ExplicitUnrollAndJam) {
+    IsExplicitUnrollAndJam = true;
+    return Count;
+  }
 
   // If the inner loop count is known and small, leave the entire loop nest to
   // be the unroller
   if (InnerTripCount && InnerLoopSize * InnerTripCount < UP.Threshold) {
     LLVM_DEBUG(dbgs() << "Won't unroll-and-jam; small inner loop count is "
                          "being left for the unroller\n");
-    UP.Count = 0;
-    return false;
+    return 0;
   }
 
   // Check for situations where UnJ is likely to be unprofitable. Including
@@ -226,8 +235,7 @@ static bool computeUnrollAndJamCount(
   if (SubLoop->getBlocks().size() != 1) {
     LLVM_DEBUG(
         dbgs() << "Won't unroll-and-jam; More than one inner loop block\n");
-    UP.Count = 0;
-    return false;
+    return 0;
   }
 
   // Limit to loops where there is something to gain from unrolling and
@@ -246,11 +254,10 @@ static bool computeUnrollAndJamCount(
   }
   if (NumInvariant == 0) {
     LLVM_DEBUG(dbgs() << "Won't unroll-and-jam; No loop invariant loads\n");
-    UP.Count = 0;
-    return false;
+    return 0;
   }
 
-  return false;
+  return Count;
 }
 
 static LoopUnrollResult
@@ -260,7 +267,7 @@ tryToUnrollAndJamLoop(Loop *L, DominatorTree &DT, LoopInfo *LI,
                       OptimizationRemarkEmitter &ORE, int OptLevel) {
   TargetTransformInfo::UnrollingPreferences UP = gatherUnrollingPreferences(
       L, SE, TTI, nullptr, nullptr, ORE, OptLevel, std::nullopt, std::nullopt,
-      std::nullopt, std::nullopt, std::nullopt, std::nullopt);
+      std::nullopt, std::nullopt, std::nullopt);
   TargetTransformInfo::PeelingPreferences PP =
       gatherPeelingPreferences(L, SE, TTI, std::nullopt, std::nullopt);
 
@@ -348,19 +355,21 @@ tryToUnrollAndJamLoop(Loop *L, DominatorTree &DT, LoopInfo *LI,
   unsigned InnerTripCount = SE.getSmallConstantTripCount(SubLoop, SubLoopLatch);
 
   // Decide if, and by how much, to unroll
-  bool IsCountSetExplicitly = computeUnrollAndJamCount(
-    L, SubLoop, TTI, DT, LI, &AC, SE, EphValues, &ORE, OuterTripCount,
-      OuterTripMultiple, OuterUCE, InnerTripCount, InnerLoopSize, UP, PP);
-  if (UP.Count <= 1)
+  bool IsExplicitUnrollAndJam = false;
+  unsigned Count = computeUnrollAndJamCount(
+      L, SubLoop, TTI, DT, LI, &AC, SE, EphValues, &ORE, OuterTripCount,
+      OuterTripMultiple, OuterUCE, InnerTripCount, InnerLoopSize,
+      IsExplicitUnrollAndJam, UP, PP);
+  if (Count <= 1)
     return LoopUnrollResult::Unmodified;
   // Unroll factor (Count) must be less or equal to TripCount.
-  if (OuterTripCount && UP.Count > OuterTripCount)
-    UP.Count = OuterTripCount;
+  if (OuterTripCount && Count > OuterTripCount)
+    Count = OuterTripCount;
 
   Loop *EpilogueOuterLoop = nullptr;
   LoopUnrollResult UnrollResult = UnrollAndJamLoop(
-      L, UP.Count, OuterTripCount, OuterTripMultiple, UP.UnrollRemainder, LI,
-      &SE, &DT, &AC, &TTI, &ORE, &EpilogueOuterLoop);
+      L, Count, OuterTripCount, OuterTripMultiple, UP.UnrollRemainder, LI, &SE,
+      &DT, &AC, &TTI, &ORE, &EpilogueOuterLoop);
 
   // Assign new loop attributes.
   if (EpilogueOuterLoop) {
@@ -391,9 +400,9 @@ tryToUnrollAndJamLoop(Loop *L, DominatorTree &DT, LoopInfo *LI,
     }
   }
 
-  // If loop has an unroll count pragma or unrolled by explicitly set count
-  // mark loop as unrolled to prevent unrolling beyond that requested.
-  if (UnrollResult != LoopUnrollResult::FullyUnrolled && IsCountSetExplicitly)
+  // If unroll-and-jam was explicitly requested, mark the loop as already
+  // unrolled to prevent unrolling beyond that request.
+  if (UnrollResult != LoopUnrollResult::FullyUnrolled && IsExplicitUnrollAndJam)
     L->setLoopAlreadyUnrolled();
 
   return UnrollResult;

--- a/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
@@ -190,9 +190,8 @@ TargetTransformInfo::UnrollingPreferences llvm::gatherUnrollingPreferences(
     Loop *L, ScalarEvolution &SE, const TargetTransformInfo &TTI,
     BlockFrequencyInfo *BFI, ProfileSummaryInfo *PSI,
     OptimizationRemarkEmitter &ORE, int OptLevel,
-    std::optional<unsigned> UserThreshold, std::optional<unsigned> UserCount,
-    std::optional<bool> UserAllowPartial, std::optional<bool> UserRuntime,
-    std::optional<bool> UserUpperBound,
+    std::optional<unsigned> UserThreshold, std::optional<bool> UserAllowPartial,
+    std::optional<bool> UserRuntime, std::optional<bool> UserUpperBound,
     std::optional<unsigned> UserFullUnrollMaxCount) {
   TargetTransformInfo::UnrollingPreferences UP;
 
@@ -203,7 +202,6 @@ TargetTransformInfo::UnrollingPreferences llvm::gatherUnrollingPreferences(
   UP.OptSizeThreshold = UnrollOptSizeThreshold;
   UP.PartialThreshold = 150;
   UP.PartialOptSizeThreshold = UnrollOptSizeThreshold;
-  UP.Count = 0;
   UP.DefaultUnrollRuntimeCount = 8;
   UP.MaxCount = std::numeric_limits<unsigned>::max();
   UP.MaxUpperBound = UnrollMaxUpperBound;
@@ -269,8 +267,6 @@ TargetTransformInfo::UnrollingPreferences llvm::gatherUnrollingPreferences(
     UP.Threshold = *UserThreshold;
     UP.PartialThreshold = *UserThreshold;
   }
-  if (UserCount)
-    UP.Count = *UserCount;
   if (UserAllowPartial)
     UP.Partial = *UserAllowPartial;
   if (UserRuntime)
@@ -736,14 +732,10 @@ bool UnrollCostEstimator::canUnroll(OptimizationRemarkEmitter *ORE,
 }
 
 uint64_t UnrollCostEstimator::getUnrolledLoopSize(
-    const TargetTransformInfo::UnrollingPreferences &UP,
-    unsigned CountOverwrite) const {
+    const TargetTransformInfo::UnrollingPreferences &UP, unsigned Count) const {
   unsigned LS = LoopSize.getValue();
   assert(LS >= UP.BEInsns && "LoopSize should not be less than BEInsns!");
-  if (CountOverwrite)
-    return static_cast<uint64_t>(LS - UP.BEInsns) * CountOverwrite + UP.BEInsns;
-  else
-    return static_cast<uint64_t>(LS - UP.BEInsns) * UP.Count + UP.BEInsns;
+  return static_cast<uint64_t>(LS - UP.BEInsns) * Count + UP.BEInsns;
 }
 
 // Returns true if the loop has an unroll(full) pragma.
@@ -971,70 +963,65 @@ shouldPartialUnroll(const unsigned LoopSize, const unsigned TripCount,
                                 << "-unroll-allow-partial not given\n");
     return 0;
   }
-  unsigned count = UP.Count;
-  if (count == 0)
-    count = TripCount;
+  unsigned Count = TripCount;
   if (UP.PartialThreshold != NoThreshold) {
     // Reduce unroll count to be modulo of TripCount for partial unrolling.
-    if (UCE.getUnrolledLoopSize(UP, count) > UP.PartialThreshold) {
+    if (UCE.getUnrolledLoopSize(UP, Count) > UP.PartialThreshold) {
       unsigned NewCount =
           (std::max(UP.PartialThreshold, UP.BEInsns + 1) - UP.BEInsns) /
           (LoopSize - UP.BEInsns);
       LLVM_DEBUG(dbgs().indent(2)
                  << "Unrolled size exceeds threshold; reducing count "
-                 << "from " << count << " to " << NewCount << ".\n");
-      count = NewCount;
+                 << "from " << Count << " to " << NewCount << ".\n");
+      Count = NewCount;
     }
-    if (count > UP.MaxCount)
-      count = UP.MaxCount;
-    while (count != 0 && TripCount % count != 0)
-      count--;
-    if (UP.AllowRemainder && count <= 1) {
+    if (Count > UP.MaxCount)
+      Count = UP.MaxCount;
+    while (Count != 0 && TripCount % Count != 0)
+      Count--;
+    if (UP.AllowRemainder && Count <= 1) {
       // If there is no Count that is modulo of TripCount, set Count to
       // largest power-of-two factor that satisfies the threshold limit.
       // As we'll create fixup loop, do the type of unrolling only if
       // remainder loop is allowed.
       // Note: DefaultUnrollRuntimeCount is used as a reasonable starting point
       // even though this is partial unrolling (not runtime unrolling).
-      count = UP.DefaultUnrollRuntimeCount;
-      while (count != 0 &&
-             UCE.getUnrolledLoopSize(UP, count) > UP.PartialThreshold)
-        count >>= 1;
+      Count = UP.DefaultUnrollRuntimeCount;
+      while (Count != 0 &&
+             UCE.getUnrolledLoopSize(UP, Count) > UP.PartialThreshold)
+        Count >>= 1;
     }
-    if (count < 2) {
+    if (Count < 2) {
       LLVM_DEBUG(dbgs().indent(2)
                  << "Will not partially unroll: no profitable count.\n");
-      count = 0;
+      Count = 0;
     }
   } else {
-    count = TripCount;
+    Count = TripCount;
   }
-  if (count > UP.MaxCount)
-    count = UP.MaxCount;
+  if (Count > UP.MaxCount)
+    Count = UP.MaxCount;
 
   LLVM_DEBUG(dbgs().indent(2)
-             << "Partially unrolling with count: " << count << "\n");
+             << "Partially unrolling with count: " << Count << "\n");
 
-  return count;
+  return Count;
 }
-// Calculates unroll count and writes it to UP.Count.
-// Unless IgnoreUser is true, will also use metadata and command-line options
-// that are specific to the LoopUnroll pass (which, for instance, are
+// Calculates and returns the unroll count, using metadata and command-line
+// options that are specific to the LoopUnroll pass (which, for instance, are
 // irrelevant for the LoopUnrollAndJam pass).
 // FIXME: This function is used by LoopUnroll and LoopUnrollAndJam, but consumes
 // many LoopUnroll-specific options. The shared functionality should be
 // refactored into it own function.
-void llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
-                              DominatorTree &DT, LoopInfo *LI,
-                              AssumptionCache *AC, ScalarEvolution &SE,
-                              const SmallPtrSetImpl<const Value *> &EphValues,
-                              OptimizationRemarkEmitter *ORE,
-                              const unsigned TripCount,
-                              const unsigned MaxTripCount, const bool MaxOrZero,
-                              const unsigned TripMultiple,
-                              const UnrollCostEstimator &UCE,
-                              TargetTransformInfo::UnrollingPreferences &UP,
-                              TargetTransformInfo::PeelingPreferences &PP) {
+unsigned llvm::computeUnrollCount(
+    Loop *L, const TargetTransformInfo &TTI, DominatorTree &DT, LoopInfo *LI,
+    AssumptionCache *AC, ScalarEvolution &SE,
+    const SmallPtrSetImpl<const Value *> &EphValues,
+    OptimizationRemarkEmitter *ORE, const unsigned TripCount,
+    const unsigned MaxTripCount, const bool MaxOrZero,
+    const unsigned TripMultiple, const UnrollCostEstimator &UCE,
+    TargetTransformInfo::UnrollingPreferences &UP,
+    TargetTransformInfo::PeelingPreferences &PP) {
 
   unsigned LoopSize = UCE.getRolledLoopSize();
 
@@ -1068,9 +1055,8 @@ void llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
     }
     LLVM_DEBUG(dbgs().indent(2)
                << "Using explicit peel count: " << PP.PeelCount << ".\n");
-    UP.Count = 1;
     UP.Runtime = false;
-    return;
+    return 1;
   }
 
   // If a user provided an explicit unroll pragma (with or without count),
@@ -1080,19 +1066,17 @@ void llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
     UP.Runtime = true;
   }
 
-  // Check for explicit Count.
+  // Check for an explicit unroll count.
   // 1st priority is unroll count set by "unroll-count" option.
   // 2nd priority is unroll count set by pragma.
   LLVM_DEBUG(dbgs().indent(1) << "Trying pragma unroll...\n");
   if (auto UnrollFactor = shouldPragmaUnroll(L, PInfo, TripMultiple, TripCount,
                                              MaxTripCount, UCE, UP, ORE)) {
-    UP.Count = *UnrollFactor;
-
     if (PInfo.UserUnrollCount || (PInfo.PragmaCount > 0)) {
       UP.AllowExpensiveTripCount = true;
       UP.Force = true;
     }
-    return;
+    return *UnrollFactor;
   } else {
     if (PInfo.ExplicitUnroll && TripCount != 0) {
       // If the loop has an unrolling pragma, we want to be more aggressive with
@@ -1107,13 +1091,10 @@ void llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
   // 3rd priority is exact full unrolling.  This will eliminate all copies
   // of some exit test.
   LLVM_DEBUG(dbgs().indent(1) << "Trying full unroll...\n");
-  assert(UP.Count == 0);
   if (TripCount) {
-    if (auto UnrollFactor = shouldFullUnroll(L, TTI, DT, SE, EphValues,
-                                             TripCount, UCE, UP)) {
-      UP.Count = *UnrollFactor;
-      return;
-    }
+    if (auto UnrollFactor =
+            shouldFullUnroll(L, TTI, DT, SE, EphValues, TripCount, UCE, UP))
+      return *UnrollFactor;
   }
 
   // 4th priority is bounded unrolling.
@@ -1131,11 +1112,9 @@ void llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
   LLVM_DEBUG(dbgs().indent(1) << "Trying upper-bound unroll...\n");
   if (!TripCount && MaxTripCount && (UP.UpperBound || MaxOrZero) &&
       MaxTripCount <= UP.MaxUpperBound) {
-    if (auto UnrollFactor = shouldFullUnroll(L, TTI, DT, SE, EphValues,
-                                             MaxTripCount, UCE, UP)) {
-      UP.Count = *UnrollFactor;
-      return;
-    }
+    if (auto UnrollFactor =
+            shouldFullUnroll(L, TTI, DT, SE, EphValues, MaxTripCount, UCE, UP))
+      return *UnrollFactor;
   }
 
   // 5th priority is loop peeling.
@@ -1145,22 +1124,19 @@ void llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
     LLVM_DEBUG(dbgs().indent(2)
                << "Peeling with count: " << PP.PeelCount << ".\n");
     UP.Runtime = false;
-    UP.Count = 1;
-    return;
+    return 1;
   }
 
-  // Before starting partial unrolling, set up.partial to true,
-  // if user explicitly asked  for unrolling
+  // Before starting partial unrolling, set UP.Partial to true,
+  // if user explicitly asked for unrolling.
   if (TripCount)
     UP.Partial |= PInfo.ExplicitUnroll;
 
   // 6th priority is partial unrolling.
   // Try partial unroll only when TripCount could be statically calculated.
   LLVM_DEBUG(dbgs().indent(1) << "Trying partial unroll...\n");
-  if (auto UnrollFactor = shouldPartialUnroll(LoopSize, TripCount, UCE, UP)) {
-    UP.Count = *UnrollFactor;
-    return;
-  }
+  if (auto UnrollFactor = shouldPartialUnroll(LoopSize, TripCount, UCE, UP))
+    return *UnrollFactor;
   assert(TripCount == 0 &&
          "All cases when TripCount is constant should be covered here.");
 
@@ -1170,7 +1146,7 @@ void llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
   if (PInfo.PragmaRuntimeUnrollDisable) {
     LLVM_DEBUG(dbgs().indent(2)
                << "Not runtime unrolling: disabled by pragma.\n");
-    return;
+    return 0;
   }
 
   // Don't unroll a small upper bound loop unless user or TTI asked to do so.
@@ -1178,14 +1154,14 @@ void llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
     LLVM_DEBUG(dbgs().indent(2) << "Not runtime unrolling: max trip count "
                                 << MaxTripCount << " is small (<= "
                                 << UP.MaxUpperBound << ") and not forced.\n");
-    return;
+    return 0;
   }
 
   // Check if the runtime trip count is too small when profile is available.
   if (L->getHeader()->getParent()->hasProfileData()) {
     if (auto ProfileTripCount = getLoopEstimatedTripCount(L)) {
       if (*ProfileTripCount < FlatLoopTripCountThreshold)
-        return;
+        return 0;
       else
         UP.AllowExpensiveTripCount = true;
     }
@@ -1194,46 +1170,44 @@ void llvm::computeUnrollCount(Loop *L, const TargetTransformInfo &TTI,
     LLVM_DEBUG(dbgs().indent(2)
                << "Will not try to unroll loop with runtime trip count "
                << "because -unroll-runtime not given\n");
-    return;
+    return 0;
   }
 
-  assert(UP.Count == 0);
-  UP.Count = UP.DefaultUnrollRuntimeCount;
+  unsigned Count = UP.DefaultUnrollRuntimeCount;
 
   // Reduce unroll count to be the largest power-of-two factor of
   // the original count which satisfies the threshold limit.
-  while (UP.Count != 0 &&
-         UCE.getUnrolledLoopSize(UP) > UP.PartialThreshold)
-    UP.Count >>= 1;
+  while (Count != 0 && UCE.getUnrolledLoopSize(UP, Count) > UP.PartialThreshold)
+    Count >>= 1;
 
 #ifndef NDEBUG
-  unsigned OrigCount = UP.Count;
+  unsigned OrigCount = Count;
 #endif
 
-  if (!UP.AllowRemainder && UP.Count != 0 && (TripMultiple % UP.Count) != 0) {
-    while (UP.Count != 0 && TripMultiple % UP.Count != 0)
-      UP.Count >>= 1;
+  if (!UP.AllowRemainder && Count != 0 && (TripMultiple % Count) != 0) {
+    while (Count != 0 && TripMultiple % Count != 0)
+      Count >>= 1;
     LLVM_DEBUG(dbgs().indent(2)
                << "Remainder loop is restricted (that could be architecture "
                   "specific or because the loop contains a convergent "
                   "instruction), so unroll count must divide the trip "
                   "multiple, "
                << TripMultiple << ".  Reducing unroll count from " << OrigCount
-               << " to " << UP.Count << ".\n");
+               << " to " << Count << ".\n");
   }
 
-  if (UP.Count > UP.MaxCount)
-    UP.Count = UP.MaxCount;
+  if (Count > UP.MaxCount)
+    Count = UP.MaxCount;
 
-  if (MaxTripCount && UP.Count > MaxTripCount)
-    UP.Count = MaxTripCount;
+  if (MaxTripCount && Count > MaxTripCount)
+    Count = MaxTripCount;
 
-  if (UP.Count < 2)
-    UP.Count = 0;
+  if (Count < 2)
+    Count = 0;
   else
     LLVM_DEBUG(dbgs().indent(2)
-               << "Runtime unrolling with count: " << UP.Count << "\n");
-  return;
+               << "Runtime unrolling with count: " << Count << "\n");
+  return Count;
 }
 
 static LoopUnrollResult
@@ -1242,8 +1216,7 @@ tryToUnrollLoop(Loop *L, DominatorTree &DT, LoopInfo *LI, ScalarEvolution &SE,
                 OptimizationRemarkEmitter &ORE, BlockFrequencyInfo *BFI,
                 ProfileSummaryInfo *PSI, bool PreserveLCSSA, int OptLevel,
                 bool OnlyFullUnroll, bool OnlyWhenForced, bool ForgetAllSCEV,
-                bool PrepareForLTO, std::optional<unsigned> ProvidedCount,
-                std::optional<unsigned> ProvidedThreshold,
+                bool PrepareForLTO, std::optional<unsigned> ProvidedThreshold,
                 std::optional<bool> ProvidedAllowPartial,
                 std::optional<bool> ProvidedRuntime,
                 std::optional<bool> ProvidedUpperBound,
@@ -1311,7 +1284,7 @@ tryToUnrollLoop(Loop *L, DominatorTree &DT, LoopInfo *LI, ScalarEvolution &SE,
 
   bool OptForSize = L->getHeader()->getParent()->hasOptSize();
   TargetTransformInfo::UnrollingPreferences UP = gatherUnrollingPreferences(
-      L, SE, TTI, BFI, PSI, ORE, OptLevel, ProvidedThreshold, ProvidedCount,
+      L, SE, TTI, BFI, PSI, ORE, OptLevel, ProvidedThreshold,
       ProvidedAllowPartial, ProvidedRuntime, ProvidedUpperBound,
       ProvidedFullUnrollMaxCount);
   TargetTransformInfo::PeelingPreferences PP = gatherPeelingPreferences(
@@ -1409,9 +1382,10 @@ tryToUnrollLoop(Loop *L, DominatorTree &DT, LoopInfo *LI, ScalarEvolution &SE,
 
   // computeUnrollCount() decides whether it is beneficial to use upper bound to
   // fully unroll the loop.
-  computeUnrollCount(L, TTI, DT, LI, &AC, SE, EphValues, &ORE, TripCount,
-                     MaxTripCount, MaxOrZero, TripMultiple, UCE, UP, PP);
-  if (!UP.Count) {
+  unsigned Count =
+      computeUnrollCount(L, TTI, DT, LI, &AC, SE, EphValues, &ORE, TripCount,
+                         MaxTripCount, MaxOrZero, TripMultiple, UCE, UP, PP);
+  if (!Count) {
     LLVM_DEBUG(dbgs().indent(1)
                << "Not unrolling: no viable strategy found.\n");
     if (TM & TM_ForcedByUser) {
@@ -1427,7 +1401,7 @@ tryToUnrollLoop(Loop *L, DominatorTree &DT, LoopInfo *LI, ScalarEvolution &SE,
   UP.Runtime &= UCE.ConvergenceAllowsRuntime;
 
   if (PP.PeelCount) {
-    assert(UP.Count == 1 && "Cannot perform peel and unroll in the same step");
+    assert(Count == 1 && "Cannot perform peel and unroll in the same step");
     LLVM_DEBUG(dbgs() << "PEELING loop %" << L->getHeader()->getName()
                       << " with iteration count " << PP.PeelCount << "!\n");
     ORE.emit([&]() {
@@ -1450,8 +1424,8 @@ tryToUnrollLoop(Loop *L, DominatorTree &DT, LoopInfo *LI, ScalarEvolution &SE,
   }
 
   // Do not attempt partial/runtime unrolling in FullLoopUnrolling
-  if (OnlyFullUnroll && ((!TripCount && !MaxTripCount) ||
-                         UP.Count < TripCount || UP.Count < MaxTripCount)) {
+  if (OnlyFullUnroll && ((!TripCount && !MaxTripCount) || Count < TripCount ||
+                         Count < MaxTripCount)) {
     LLVM_DEBUG(dbgs().indent(1)
                << "Not attempting partial/runtime unroll in FullLoopUnroll.\n");
     return LoopUnrollResult::Unmodified;
@@ -1462,7 +1436,7 @@ tryToUnrollLoop(Loop *L, DominatorTree &DT, LoopInfo *LI, ScalarEvolution &SE,
   // count and the unroll count doesn't divide the known trip multiple.
   // TODO: This decision should probably be pushed up into
   // computeUnrollCount().
-  UP.Runtime &= TripCount == 0 && TripMultiple % UP.Count != 0;
+  UP.Runtime &= TripCount == 0 && TripMultiple % Count != 0;
 
   // Save loop properties before it is transformed.
   MDNode *OrigLoopID = L->getLoopID();
@@ -1473,7 +1447,7 @@ tryToUnrollLoop(Loop *L, DominatorTree &DT, LoopInfo *LI, ScalarEvolution &SE,
   // Unroll the loop.
   Loop *RemainderLoop = nullptr;
   UnrollLoopOptions ULO;
-  ULO.Count = UP.Count;
+  ULO.Count = Count;
   ULO.Force = UP.Force;
   ULO.AllowExpensiveTripCount = UP.AllowExpensiveTripCount;
   ULO.UnrollRemainder = UP.UnrollRemainder;
@@ -1563,7 +1537,6 @@ public:
   /// Otherwise, forgetAllLoops and rebuild when needed next.
   bool ForgetAllSCEV;
 
-  std::optional<unsigned> ProvidedCount;
   std::optional<unsigned> ProvidedThreshold;
   std::optional<bool> ProvidedAllowPartial;
   std::optional<bool> ProvidedRuntime;
@@ -1575,7 +1548,6 @@ public:
   LoopUnroll(int OptLevel = 2, bool OnlyWhenForced = false,
              bool ForgetAllSCEV = false,
              std::optional<unsigned> Threshold = std::nullopt,
-             std::optional<unsigned> Count = std::nullopt,
              std::optional<bool> AllowPartial = std::nullopt,
              std::optional<bool> Runtime = std::nullopt,
              std::optional<bool> UpperBound = std::nullopt,
@@ -1583,10 +1555,9 @@ public:
              std::optional<bool> AllowProfileBasedPeeling = std::nullopt,
              std::optional<unsigned> ProvidedFullUnrollMaxCount = std::nullopt)
       : LoopPass(ID), OptLevel(OptLevel), OnlyWhenForced(OnlyWhenForced),
-        ForgetAllSCEV(ForgetAllSCEV), ProvidedCount(std::move(Count)),
-        ProvidedThreshold(Threshold), ProvidedAllowPartial(AllowPartial),
-        ProvidedRuntime(Runtime), ProvidedUpperBound(UpperBound),
-        ProvidedAllowPeeling(AllowPeeling),
+        ForgetAllSCEV(ForgetAllSCEV), ProvidedThreshold(Threshold),
+        ProvidedAllowPartial(AllowPartial), ProvidedRuntime(Runtime),
+        ProvidedUpperBound(UpperBound), ProvidedAllowPeeling(AllowPeeling),
         ProvidedAllowProfileBasedPeeling(AllowProfileBasedPeeling),
         ProvidedFullUnrollMaxCount(ProvidedFullUnrollMaxCount) {
     initializeLoopUnrollPass(*PassRegistry::getPassRegistry());
@@ -1617,10 +1588,9 @@ public:
     LoopUnrollResult Result = tryToUnrollLoop(
         L, DT, LI, SE, TTI, AC, ORE, nullptr, nullptr, PreserveLCSSA, OptLevel,
         /*OnlyFullUnroll*/ false, OnlyWhenForced, ForgetAllSCEV,
-        /*PrepareForLTO*/ false, ProvidedCount, ProvidedThreshold,
-        ProvidedAllowPartial, ProvidedRuntime, ProvidedUpperBound,
-        ProvidedAllowPeeling, ProvidedAllowProfileBasedPeeling,
-        ProvidedFullUnrollMaxCount, UI);
+        /*PrepareForLTO*/ false, ProvidedThreshold, ProvidedAllowPartial,
+        ProvidedRuntime, ProvidedUpperBound, ProvidedAllowPeeling,
+        ProvidedAllowProfileBasedPeeling, ProvidedFullUnrollMaxCount, UI);
 
     if (Result == LoopUnrollResult::FullyUnrolled)
       LPM.markLoopAsDeleted(*L);
@@ -1652,7 +1622,7 @@ INITIALIZE_PASS_DEPENDENCY(UniformityInfoWrapperPass)
 INITIALIZE_PASS_END(LoopUnroll, "loop-unroll", "Unroll loops", false, false)
 
 Pass *llvm::createLoopUnrollPass(int OptLevel, bool OnlyWhenForced,
-                                 bool ForgetAllSCEV, int Threshold, int Count,
+                                 bool ForgetAllSCEV, int Threshold,
                                  int AllowPartial, int Runtime, int UpperBound,
                                  int AllowPeeling) {
   // TODO: It would make more sense for this function to take the optionals
@@ -1661,7 +1631,6 @@ Pass *llvm::createLoopUnrollPass(int OptLevel, bool OnlyWhenForced,
   return new LoopUnroll(
       OptLevel, OnlyWhenForced, ForgetAllSCEV,
       Threshold == -1 ? std::nullopt : std::optional<unsigned>(Threshold),
-      Count == -1 ? std::nullopt : std::optional<unsigned>(Count),
       AllowPartial == -1 ? std::nullopt : std::optional<bool>(AllowPartial),
       Runtime == -1 ? std::nullopt : std::optional<bool>(Runtime),
       UpperBound == -1 ? std::nullopt : std::optional<bool>(UpperBound),
@@ -1692,7 +1661,6 @@ PreservedAnalyses LoopFullUnrollPass::run(Loop &L, LoopAnalysisManager &AM,
                       /*BFI*/ nullptr, /*PSI*/ nullptr,
                       /*PreserveLCSSA*/ true, OptLevel, /*OnlyFullUnroll*/ true,
                       OnlyWhenForced, ForgetSCEV, PrepareForLTO,
-                      /*Count*/ std::nullopt,
                       /*Threshold*/ std::nullopt, /*AllowPartial*/ false,
                       /*Runtime*/ false, /*UpperBound*/ false,
                       /*AllowPeeling*/ true,
@@ -1820,15 +1788,15 @@ PreservedAnalyses LoopUnrollPass::run(Function &F,
     std::string LoopName = std::string(L.getName());
     // The API here is quite complex to call and we allow to select some
     // flavors of unrolling during construction time (by setting UnrollOpts).
-    LoopUnrollResult Result = tryToUnrollLoop(
-        &L, DT, &LI, SE, TTI, AC, ORE, BFI, PSI,
-        /*PreserveLCSSA*/ true, UnrollOpts.OptLevel, /*OnlyFullUnroll*/ false,
-        UnrollOpts.OnlyWhenForced, UnrollOpts.ForgetSCEV,
-        UnrollOpts.PrepareForLTO, /*Count*/ std::nullopt,
-        /*Threshold*/ std::nullopt, UnrollOpts.AllowPartial,
-        UnrollOpts.AllowRuntime, UnrollOpts.AllowUpperBound, LocalAllowPeeling,
-        UnrollOpts.AllowProfileBasedPeeling, UnrollOpts.FullUnrollMaxCount, UI,
-        &AA);
+    LoopUnrollResult Result =
+        tryToUnrollLoop(&L, DT, &LI, SE, TTI, AC, ORE, BFI, PSI,
+                        /*PreserveLCSSA*/ true, UnrollOpts.OptLevel,
+                        /*OnlyFullUnroll*/ false, UnrollOpts.OnlyWhenForced,
+                        UnrollOpts.ForgetSCEV, UnrollOpts.PrepareForLTO,
+                        /*Threshold*/ std::nullopt, UnrollOpts.AllowPartial,
+                        UnrollOpts.AllowRuntime, UnrollOpts.AllowUpperBound,
+                        LocalAllowPeeling, UnrollOpts.AllowProfileBasedPeeling,
+                        UnrollOpts.FullUnrollMaxCount, UI, &AA);
     Changed |= Result != LoopUnrollResult::Unmodified;
 
     // The parent must not be damaged by unrolling!

--- a/llvm/test/Transforms/LoopUnroll/RISCV/runtime-unroll-max-trip-count.ll
+++ b/llvm/test/Transforms/LoopUnroll/RISCV/runtime-unroll-max-trip-count.ll
@@ -3,9 +3,10 @@
 
 ; Regression test: when a loop has a small MaxTripCount and falls through to
 ; runtime unrolling, the unroll count should be based on DefaultUnrollRuntimeCount
-; (not MaxTripCount). Previously, a quirk would set UP.Count = MaxTripCount (5)
-; before the power-of-two reduction, yielding count 2 (5 >> 1). Now the count
-; starts at DefaultUnrollRuntimeCount (8) and reduces to 4 (8 >> 1).
+; (not MaxTripCount). Previously, a quirk would seed the selected count with
+; MaxTripCount (5) before the power-of-two reduction, yielding count 2 (5 >> 1).
+; Now the count starts at DefaultUnrollRuntimeCount (8) and reduces to 4
+; (8 >> 1).
 ;
 ; This test uses RISC-V because we need a target that sets UP.Force = true
 ; (via RISCVTTIImpl::getUnrollingPreferences) to trigger the bug.


### PR DESCRIPTION
`UnrollingPreferences` is a way for targets to specify their preferences to the unroller. The unroller uses `UnrollingPreferences` to guide what kinds of unrolling to consider while also co-opting it to encode the specific kind of unrolling it's chosen to attempt. 

One preference targets can set is the `Count`, or the number of times the loop in question will be unrolled:
```
    /// A forced unrolling factor (the number of concatenated bodies of the
    /// original loop in the unrolled loop body). When set to 0, the unrolling
    /// transformation will select an unrolling factor based on the current cost
    /// threshold and other factors.
    unsigned Count;
```
However, there are no in-tree uses of this functionality, and it does not work. [Loop peeling](https://github.com/llvm/llvm-project/blob/112fb2f79d7983be203957cad6b148865182ed47/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp#L1072) ([2](https://github.com/llvm/llvm-project/blob/112fb2f79d7983be203957cad6b148865182ed47/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp#L1149)), [pragma unrolling](https://github.com/llvm/llvm-project/blob/112fb2f79d7983be203957cad6b148865182ed47/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp#L1090), [full unrolling](https://github.com/llvm/llvm-project/blob/112fb2f79d7983be203957cad6b148865182ed47/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp#L1115), [upper-bound unrolling](https://github.com/llvm/llvm-project/blob/112fb2f79d7983be203957cad6b148865182ed47/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp#L1137), [partial unrolling](https://github.com/llvm/llvm-project/blob/112fb2f79d7983be203957cad6b148865182ed47/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp#L1162), and [runtime unrolling](https://github.com/llvm/llvm-project/blob/112fb2f79d7983be203957cad6b148865182ed47/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp#L1202) all override the value of `UP.Count` that targets would've set. This appears to have been broken since LLVM 3.9 days as a result of ea2aef4a1d4beded20033fa4fc223936c7ffe5d8. 

This PR removes `Count` from `UnrollingPreferences` and instead encodes it as a return value of the `computeUnrollCount()` family of functions. 

If [out-of-tree targets want to begin setting `Count`](https://github.com/llvm/llvm-project/pull/185979#discussion_r3022857799), their best bet is likely to use [`llvm.loop.unroll.count`](https://llvm.org/docs/LangRef.html#llvm-loop-unroll-count-metadata).