### PR TITLE
[libc] Enable baremetal printf float320

### DIFF
--- a/libc/config/baremetal/config.json
+++ b/libc/config/baremetal/config.json
@@ -33,6 +33,9 @@
     },
     "LIBC_CONF_PRINTF_MODULAR": {
       "value": true
+    },
+    "LIBC_CONF_PRINTF_FLOAT_TO_STR_USE_DYADIC_FLOAT": {
+      "value": true
     }
   },
   "scanf": {

--- a/libc/config/baremetal/config.json
+++ b/libc/config/baremetal/config.json
@@ -34,7 +34,7 @@
     "LIBC_CONF_PRINTF_MODULAR": {
       "value": true
     },
-    "LIBC_CONF_PRINTF_FLOAT_TO_STR_USE_DYADIC_FLOAT": {
+    "LIBC_CONF_PRINTF_FLOAT_TO_STR_USE_FLOAT320": {
       "value": true
     }
   },


### PR DESCRIPTION
For memory constrained baremetal devices using float320 seems a
reasonable option by default.
