### PR TITLE
[LLVM] Fix vprintf modular format with constant format string

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -4451,7 +4451,8 @@ static Bitset<256> parseFormatStringSpecifiers(StringRef FormatStr) {
   return Specifiers;
 }
 
-static bool isAspectNeeded(StringRef Aspect, CallInst *CI, unsigned FirstArgIdx,
+static bool isAspectNeeded(StringRef Aspect, CallInst *CI,
+                           std::optional<unsigned> FirstArgIdx,
                            const std::optional<Bitset<256>> &Specifiers) {
   if (Aspect == "float") {
     if (Specifiers) {
@@ -4460,8 +4461,10 @@ static bool isAspectNeeded(StringRef Aspect, CallInst *CI, unsigned FirstArgIdx,
       return (*Specifiers & FloatSpecifiers).any();
     }
     // Fallback to type-based check for dynamic format string.
+    if (!FirstArgIdx)
+      return true;
     return llvm::any_of(
-        llvm::make_range(std::next(CI->arg_begin(), FirstArgIdx),
+        llvm::make_range(std::next(CI->arg_begin(), *FirstArgIdx),
                          CI->arg_end()),
         [](Value *V) { return V->getType()->isFloatingPointTy(); });
   }
@@ -4505,17 +4508,19 @@ static Value *optimizeModularFormat(CallInst *CI, IRBuilderBase &B) {
   ArrayRef<StringRef> AllAspects = ArrayRef<StringRef>(Args).drop_front(5);
 
   unsigned FormatIdx;
-  unsigned FirstArgIdx;
+  std::optional<unsigned> FirstArgIdx;
   [[maybe_unused]] bool Error;
   Error = FormatIdxStr.getAsInteger(10, FormatIdx);
   assert(!Error && "invalid format arg index");
   --FormatIdx; // 1-based to 0-based
 
-  Error = FirstArgIdxStr.getAsInteger(10, FirstArgIdx);
+  FirstArgIdx.emplace();
+  Error = FirstArgIdxStr.getAsInteger(10, *FirstArgIdx);
   assert(!Error && "invalid first arg index");
-  if (FirstArgIdx == 0)
-    return nullptr;
-  --FirstArgIdx; // 1-based to 0-based
+  if (*FirstArgIdx > 0)
+    --*FirstArgIdx; // 1-based to 0-based
+  else
+    FirstArgIdx.reset();
 
   if (AllAspects.empty())
     return nullptr;

--- a/llvm/test/Transforms/InstCombine/modular-format.ll
+++ b/llvm/test/Transforms/InstCombine/modular-format.ll
@@ -109,6 +109,18 @@ define void @test_zero_first_arg(ptr %ap) {
   ret void
 }
 
+;; The first argument index is 0, and the format string is constant and doesn't
+;; contain a float specifier. The "float" aspect is optimized away, and it is
+;; transformed to call the modular implementation.
+define void @test_zero_first_arg_optimized(ptr %ap) {
+; CHECK-LABEL: @test_zero_first_arg_optimized(
+; CHECK-NEXT:    call void @zero_first_arg_mod(ptr nonnull @.str.int, ptr [[AP:%.*]])
+; CHECK-NEXT:    ret void
+;
+  call void @zero_first_arg(ptr @.str.int, ptr %ap)
+  ret void
+}
+
 declare void @zero_first_arg(ptr, ptr) #5
 
 @.str.fixed = constant [3 x i8] c"%r\00"


### PR DESCRIPTION
The vprintf family of functions cannot readily have their arguments scanned for type, but this isn't an obstacle when the format string is a known constant. This change only requires argument examination as a fallback when the format string is unknown.

Generated by Gemini; edited and reviewed by hand.