### PR TITLE
[lldb][NFC] Remove FileSpec::GetPathAsConstString

### DIFF
--- a/lldb/include/lldb/Utility/FileSpec.h
+++ b/lldb/include/lldb/Utility/FileSpec.h
@@ -318,14 +318,6 @@ public:
   ///     concatenated.
   std::string GetPath(bool denormalize = true) const;
 
-  /// Get the full path as a ConstString.
-  ///
-  /// This method should only be used when you need a ConstString or the
-  /// const char * from a ConstString to ensure permanent lifetime of C string.
-  /// Anyone needing the path temporarily should use the GetPath() method that
-  /// returns a std:string.
-  ConstString GetPathAsConstString(bool denormalize = true) const;
-
   /// Extract the full path to the file.
   ///
   /// Extract the directory and path into an llvm::SmallVectorImpl<>

--- a/lldb/source/API/SBFileSpec.cpp
+++ b/lldb/source/API/SBFileSpec.cpp
@@ -116,7 +116,7 @@ const char *SBFileSpec::GetDirectory() const {
 
   FileSpec directory{*m_opaque_up};
   directory.ClearFilename();
-  return directory.GetPathAsConstString().GetCString();
+  return ConstString(directory.GetPath()).GetCString();
 }
 
 void SBFileSpec::SetFilename(const char *filename) {

--- a/lldb/source/API/SBLaunchInfo.cpp
+++ b/lldb/source/API/SBLaunchInfo.cpp
@@ -210,8 +210,8 @@ void SBLaunchInfo::Clear() {
 const char *SBLaunchInfo::GetWorkingDirectory() const {
   LLDB_INSTRUMENT_VA(this);
 
-  return m_opaque_sp->GetWorkingDirectory().GetPathAsConstString().AsCString(
-      nullptr);
+  return ConstString(m_opaque_sp->GetWorkingDirectory().GetPath())
+      .AsCString(nullptr);
 }
 
 void SBLaunchInfo::SetWorkingDirectory(const char *working_dir) {

--- a/lldb/source/API/SBPlatform.cpp
+++ b/lldb/source/API/SBPlatform.cpp
@@ -362,8 +362,8 @@ const char *SBPlatform::GetWorkingDirectory() {
 
   PlatformSP platform_sp(GetSP());
   if (platform_sp)
-    return platform_sp->GetWorkingDirectory().GetPathAsConstString().AsCString(
-        nullptr);
+    return ConstString(platform_sp->GetWorkingDirectory().GetPath())
+        .AsCString(nullptr);
   return nullptr;
 }
 

--- a/lldb/source/Host/common/HostInfoBase.cpp
+++ b/lldb/source/Host/common/HostInfoBase.cpp
@@ -320,7 +320,7 @@ bool HostInfoBase::ComputeProcessTempFileDirectory(FileSpec &file_spec) {
   if (llvm::sys::fs::create_directory(temp_file_spec.GetPath()))
     return false;
 
-  file_spec.SetDirectory(temp_file_spec.GetPathAsConstString());
+  file_spec.SetDirectory(temp_file_spec.GetPath());
   return true;
 }
 
@@ -343,7 +343,7 @@ bool HostInfoBase::ComputeGlobalTempFileDirectory(FileSpec &file_spec) {
   if (llvm::sys::fs::create_directory(temp_file_spec.GetPath()))
     return false;
 
-  file_spec.SetDirectory(temp_file_spec.GetPathAsConstString());
+  file_spec.SetDirectory(temp_file_spec.GetPath());
   return true;
 }
 
@@ -362,14 +362,14 @@ bool HostInfoBase::ComputeSystemPluginsDirectory(FileSpec &file_spec) {
 bool HostInfoBase::ComputeUserHomeDirectory(FileSpec &file_spec) {
   FileSpec temp_file("~");
   FileSystem::Instance().Resolve(temp_file);
-  file_spec.SetDirectory(temp_file.GetPathAsConstString());
+  file_spec.SetDirectory(temp_file.GetPath());
   return true;
 }
 
 bool HostInfoBase::ComputeUserLLDBHomeDirectory(FileSpec &file_spec) {
   FileSpec home_dir_spec = GetUserHomeDir();
   home_dir_spec.AppendPathComponent(".lldb");
-  file_spec.SetDirectory(home_dir_spec.GetPathAsConstString());
+  file_spec.SetDirectory(home_dir_spec.GetPath());
   return true;
 }
 

--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -237,7 +237,7 @@ bool HostInfoMacOSX::ComputeSystemPluginsDirectory(FileSpec &file_spec) {
 bool HostInfoMacOSX::ComputeUserPluginsDirectory(FileSpec &file_spec) {
   FileSpec home_dir_spec = GetUserHomeDir();
   home_dir_spec.AppendPathComponent("Library/Application Support/LLDB/PlugIns");
-  file_spec.SetDirectory(home_dir_spec.GetPathAsConstString());
+  file_spec.SetDirectory(home_dir_spec.GetPath());
   return true;
 }
 

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -154,11 +154,11 @@ ModuleSP DynamicLoaderDarwin::FindTargetModuleForImageInfo(
 
       else
         image_info = HostInfo::GetSharedCacheImageInfo(
-            module_spec.GetFileSpec().GetPathAsConstString(), sc_uuid, sc_mode);
+            ConstString(module_spec.GetFileSpec().GetPath()), sc_uuid, sc_mode);
     } else {
       // Fall back to looking lldb's own shared cache by filename
       image_info = HostInfo::GetSharedCacheImageInfo(
-          module_spec.GetFileSpec().GetPathAsConstString(), sc_mode);
+          ConstString(module_spec.GetFileSpec().GetPath()), sc_mode);
     }
 
     // If we found it and it has the correct UUID, let's proceed with

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -150,8 +150,7 @@ lldb::SectionSP MergeSections(lldb::SectionSP lhs, lldb::SectionSP rhs) {
         "mismatch addresses for section {0} when "
         "merging with {1}, expected: {2:x}, "
         "actual: {3:x}",
-        lhs->GetTypeAsCString(),
-        rhs_module_parent->GetFileSpec().GetPathAsConstString().GetCString(),
+        lhs->GetTypeAsCString(), rhs_module_parent->GetFileSpec().GetPath(),
         lhs->GetFileAddress(), rhs->GetFileAddress());
 
   // We want to take the greater of two sections. If LHS and RHS are both

--- a/lldb/source/Plugins/Platform/Android/PlatformAndroid.cpp
+++ b/lldb/source/Plugins/Platform/Android/PlatformAndroid.cpp
@@ -211,7 +211,7 @@ Status PlatformAndroid::GetFile(const FileSpec &source,
   FileSpec source_spec(source.GetPath(false), FileSpec::Style::posix);
   if (source_spec.IsRelative())
     source_spec = GetRemoteWorkingDirectory().CopyByAppendingPathComponent(
-        source_spec.GetPathAsConstString(false).GetStringRef());
+        source_spec.GetPath(false));
 
   Status error;
   auto sync_service = GetSyncService(error);

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -446,13 +446,13 @@ Status PlatformDarwin::GetModuleFromSharedCaches(
                                                        sc_uuid, sc_mode);
       else
         image_info = HostInfo::GetSharedCacheImageInfo(
-            module_spec.GetFileSpec().GetPathAsConstString(), sc_uuid, sc_mode);
+            ConstString(module_spec.GetFileSpec().GetPath()), sc_uuid, sc_mode);
     }
   }
   // Fall back to looking for the file in lldb's own shared cache.
   if (!image_info.GetUUID())
     image_info = HostInfo::GetSharedCacheImageInfo(
-        module_spec.GetFileSpec().GetPathAsConstString(), sc_mode);
+        ConstString(module_spec.GetFileSpec().GetPath()), sc_mode);
 
   // If we found it and it has the correct UUID, let's proceed with
   // creating a module from the memory contents.
@@ -1310,7 +1310,7 @@ lldb_private::FileSpec PlatformDarwin::LocateExecutable(const char *basename) {
       xcode_lldb_resources.AppendPathComponent("Resources");
       if (FileSystem::Instance().Exists(xcode_lldb_resources)) {
         FileSpec dir;
-        dir.SetDirectory(xcode_lldb_resources.GetPathAsConstString());
+        dir.SetDirectory(xcode_lldb_resources.GetPath());
         g_executable_dirs.push_back(dir);
       }
     }
@@ -1323,7 +1323,7 @@ lldb_private::FileSpec PlatformDarwin::LocateExecutable(const char *basename) {
       cmd_line_lldb_resources.AppendPathComponent("Resources");
       if (FileSystem::Instance().Exists(cmd_line_lldb_resources)) {
         FileSpec dir;
-        dir.SetDirectory(cmd_line_lldb_resources.GetPathAsConstString());
+        dir.SetDirectory(cmd_line_lldb_resources.GetPath());
         g_executable_dirs.push_back(dir);
       }
     }

--- a/lldb/source/Plugins/SymbolLocator/DebugSymbols/SymbolLocatorDebugSymbols.cpp
+++ b/lldb/source/Plugins/SymbolLocator/DebugSymbols/SymbolLocatorDebugSymbols.cpp
@@ -207,7 +207,7 @@ std::optional<ModuleSpec> SymbolLocatorDebugSymbols::LocateExecutableObjectFile(
                 ModuleList::GetGlobalModuleListProperties()
                     .GetSharedCacheBinaryLoading();
             SharedCacheImageInfo image_info = HostInfo::GetSharedCacheImageInfo(
-                module_spec.GetFileSpec().GetPathAsConstString(), sc_mode);
+                ConstString(module_spec.GetFileSpec().GetPath()), sc_mode);
 
             // If we found it and it has the correct UUID, let's proceed with
             // creating a module from the memory contents.
@@ -647,7 +647,7 @@ static int LocateMacOSXFilesUsingDebugSymbols(const ModuleSpec &module_spec,
                 ModuleList::GetGlobalModuleListProperties()
                     .GetSharedCacheBinaryLoading();
             SharedCacheImageInfo image_info = HostInfo::GetSharedCacheImageInfo(
-                module_spec.GetFileSpec().GetPathAsConstString(), sc_mode);
+                ConstString(module_spec.GetFileSpec().GetPath()), sc_mode);
 
             // If we found it and it has the correct UUID, let's proceed with
             // creating a module from the memory contents.

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -506,7 +506,7 @@ RecurseCopy_Callback(void *baton, llvm::sys::fs::file_type ft,
     // Make a filespec that only fills in the directory of a FileSpec so when
     // we enumerate we can quickly fill in the filename for dst copies
     FileSpec recurse_dst;
-    recurse_dst.SetDirectory(dst_dir.GetPathAsConstString());
+    recurse_dst.SetDirectory(dst_dir.GetPath());
     RecurseCopyBaton rc_baton2 = {recurse_dst, rc_baton->platform_ptr,
                                   Status()};
     FileSystem::Instance().EnumerateDirectory(src_dir_path, true, true, true,
@@ -599,7 +599,7 @@ Status Platform::Install(const FileSpec &src, const FileSpec &dst) {
       }
     } else {
       if (working_dir) {
-        fixed_dst.SetDirectory(working_dir.GetPathAsConstString());
+        fixed_dst.SetDirectory(working_dir.GetPath());
       } else {
         error = Status::FromErrorStringWithFormat(
             "platform working directory must be valid for relative path '%s'",
@@ -609,7 +609,7 @@ Status Platform::Install(const FileSpec &src, const FileSpec &dst) {
     }
   } else {
     if (working_dir) {
-      fixed_dst.SetDirectory(working_dir.GetPathAsConstString());
+      fixed_dst.SetDirectory(working_dir.GetPath());
     } else {
       error =
           Status::FromErrorString("platform working directory must be valid "
@@ -637,7 +637,7 @@ Status Platform::Install(const FileSpec &src, const FileSpec &dst) {
         // Make a filespec that only fills in the directory of a FileSpec so
         // when we enumerate we can quickly fill in the filename for dst copies
         FileSpec recurse_dst;
-        recurse_dst.SetDirectory(fixed_dst.GetPathAsConstString());
+        recurse_dst.SetDirectory(fixed_dst.GetPath());
         std::string src_dir_path(src.GetPath());
         RecurseCopyBaton baton = {recurse_dst, this, Status()};
         FileSystem::Instance().EnumerateDirectory(

--- a/lldb/source/Utility/FileSpec.cpp
+++ b/lldb/source/Utility/FileSpec.cpp
@@ -387,10 +387,6 @@ std::string FileSpec::GetPath(bool denormalize) const {
   return static_cast<std::string>(result);
 }
 
-ConstString FileSpec::GetPathAsConstString(bool denormalize) const {
-  return ConstString{GetPath(denormalize)};
-}
-
 void FileSpec::GetPath(llvm::SmallVectorImpl<char> &path,
                        bool denormalize) const {
   path.append(m_directory.GetStringRef().begin(),


### PR DESCRIPTION
I'm trying to clean up the FileSpec API. Even if it is currently implemented as a pair of ConstStrings, I think it would be better if FileSpec users only created new ConstStrings as necessary.