### PR TITLE
[ADT][NFC] Fix documentation for arrayRefFromStringRef

### DIFF
--- a/llvm/include/llvm/ADT/StringExtras.h
+++ b/llvm/include/llvm/ADT/StringExtras.h
@@ -63,7 +63,7 @@ inline StringRef toStringRef(ArrayRef<char> Input) {
   return StringRef(Input.begin(), Input.size());
 }
 
-/// Construct a string ref from an array ref of unsigned chars.
+/// Construct an array ref of unsigned bytes from a string ref.
 template <class CharT = uint8_t>
 inline ArrayRef<CharT> arrayRefFromStringRef(StringRef Input) {
   static_assert(std::is_same<CharT, char>::value ||

--- a/llvm/include/llvm/ADT/StringExtras.h
+++ b/llvm/include/llvm/ADT/StringExtras.h
@@ -63,7 +63,7 @@ inline StringRef toStringRef(ArrayRef<char> Input) {
   return StringRef(Input.begin(), Input.size());
 }
 
-/// Construct an array ref of unsigned bytes from a string ref.
+/// Construct an array ref of bytes from a string ref.
 template <class CharT = uint8_t>
 inline ArrayRef<CharT> arrayRefFromStringRef(StringRef Input) {
   static_assert(std::is_same<CharT, char>::value ||


### PR DESCRIPTION
The documentation was describing the opposite behavior of what it does.