### PR TITLE
[AMDGPU] Remove unnecessary and broken sign/zero-extension

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUCodeGenPrepare.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCodeGenPrepare.cpp
@@ -1085,7 +1085,7 @@ Value *AMDGPUCodeGenPrepareImpl::expandDivRemToFloatImpl(
   // Thus, we conservatively restrict expandDivRemToFloatImpl to
   // [-0x40000,0x3FFFFF] for IsSigned
   // [0x000000,0x3FFFFF] for !IsSigned.
-  assert(DivBits <= (IsSigned ? 23 : 22) &&
+  assert(0 < DivBits && DivBits <= (IsSigned ? 23 : 22) &&
          "abs(Num) must be <= than 0x40000 for expandDivRemToFloatImpl to work "
          "correctly");
 
@@ -1166,20 +1166,6 @@ Value *AMDGPUCodeGenPrepareImpl::expandDivRemToFloatImpl(
     // Rem needs compensation, it's easier to recompute it
     Value *Rem = Builder.CreateMul(Div, Den);
     Res = Builder.CreateSub(Num, Rem);
-  }
-
-  if (DivBits != 0 && DivBits < 32) {
-    // Extend in register from the number of bits this divide really is.
-    if (IsSigned) {
-      int InRegBits = 32 - DivBits;
-
-      Res = Builder.CreateShl(Res, InRegBits);
-      Res = Builder.CreateAShr(Res, InRegBits);
-    } else {
-      ConstantInt *TruncMask
-        = Builder.getInt32((UINT64_C(1) << DivBits) - 1);
-      Res = Builder.CreateAnd(Res, TruncMask);
-    }
   }
 
   return Res;

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-codegenprepare-idiv.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-codegenprepare-idiv.ll
@@ -442,8 +442,7 @@ define amdgpu_kernel void @udiv_i16(ptr addrspace(1) %out, i16 %x, i16 %y) {
 ; CHECK-NEXT:    [[TMP13:%.*]] = fcmp fast oge float [[TMP11]], [[TMP12]]
 ; CHECK-NEXT:    [[TMP14:%.*]] = select i1 [[TMP13]], i32 1, i32 0
 ; CHECK-NEXT:    [[TMP15:%.*]] = add i32 [[TMP10]], [[TMP14]]
-; CHECK-NEXT:    [[TMP16:%.*]] = and i32 [[TMP15]], 65535
-; CHECK-NEXT:    [[TMP17:%.*]] = trunc i32 [[TMP16]] to i16
+; CHECK-NEXT:    [[TMP17:%.*]] = trunc i32 [[TMP15]] to i16
 ; CHECK-NEXT:    store i16 [[TMP17]], ptr addrspace(1) [[OUT]], align 2
 ; CHECK-NEXT:    ret void
 ;
@@ -513,8 +512,7 @@ define amdgpu_kernel void @urem_i16(ptr addrspace(1) %out, i16 %x, i16 %y) {
 ; CHECK-NEXT:    [[TMP15:%.*]] = add i32 [[TMP10]], [[TMP14]]
 ; CHECK-NEXT:    [[TMP16:%.*]] = mul i32 [[TMP15]], [[TMP2]]
 ; CHECK-NEXT:    [[TMP17:%.*]] = sub i32 [[TMP1]], [[TMP16]]
-; CHECK-NEXT:    [[TMP18:%.*]] = and i32 [[TMP17]], 65535
-; CHECK-NEXT:    [[TMP19:%.*]] = trunc i32 [[TMP18]] to i16
+; CHECK-NEXT:    [[TMP19:%.*]] = trunc i32 [[TMP17]] to i16
 ; CHECK-NEXT:    store i16 [[TMP19]], ptr addrspace(1) [[OUT]], align 2
 ; CHECK-NEXT:    ret void
 ;
@@ -589,9 +587,7 @@ define amdgpu_kernel void @sdiv_i16(ptr addrspace(1) %out, i16 %x, i16 %y) {
 ; CHECK-NEXT:    [[TMP16:%.*]] = fcmp fast oge float [[TMP14]], [[TMP15]]
 ; CHECK-NEXT:    [[TMP17:%.*]] = select i1 [[TMP16]], i32 [[TMP5]], i32 0
 ; CHECK-NEXT:    [[TMP18:%.*]] = add i32 [[TMP13]], [[TMP17]]
-; CHECK-NEXT:    [[TMP19:%.*]] = shl i32 [[TMP18]], 16
-; CHECK-NEXT:    [[TMP20:%.*]] = ashr i32 [[TMP19]], 16
-; CHECK-NEXT:    [[TMP21:%.*]] = trunc i32 [[TMP20]] to i16
+; CHECK-NEXT:    [[TMP21:%.*]] = trunc i32 [[TMP18]] to i16
 ; CHECK-NEXT:    store i16 [[TMP21]], ptr addrspace(1) [[OUT]], align 2
 ; CHECK-NEXT:    ret void
 ;
@@ -672,9 +668,7 @@ define amdgpu_kernel void @srem_i16(ptr addrspace(1) %out, i16 %x, i16 %y) {
 ; CHECK-NEXT:    [[TMP18:%.*]] = add i32 [[TMP13]], [[TMP17]]
 ; CHECK-NEXT:    [[TMP19:%.*]] = mul i32 [[TMP18]], [[TMP2]]
 ; CHECK-NEXT:    [[TMP20:%.*]] = sub i32 [[TMP1]], [[TMP19]]
-; CHECK-NEXT:    [[TMP21:%.*]] = shl i32 [[TMP20]], 16
-; CHECK-NEXT:    [[TMP22:%.*]] = ashr i32 [[TMP21]], 16
-; CHECK-NEXT:    [[TMP23:%.*]] = trunc i32 [[TMP22]] to i16
+; CHECK-NEXT:    [[TMP23:%.*]] = trunc i32 [[TMP20]] to i16
 ; CHECK-NEXT:    store i16 [[TMP23]], ptr addrspace(1) [[OUT]], align 2
 ; CHECK-NEXT:    ret void
 ;
@@ -754,8 +748,7 @@ define amdgpu_kernel void @udiv_i8(ptr addrspace(1) %out, i8 %x, i8 %y) {
 ; CHECK-NEXT:    [[TMP13:%.*]] = fcmp fast oge float [[TMP11]], [[TMP12]]
 ; CHECK-NEXT:    [[TMP14:%.*]] = select i1 [[TMP13]], i32 1, i32 0
 ; CHECK-NEXT:    [[TMP15:%.*]] = add i32 [[TMP10]], [[TMP14]]
-; CHECK-NEXT:    [[TMP16:%.*]] = and i32 [[TMP15]], 255
-; CHECK-NEXT:    [[TMP17:%.*]] = trunc i32 [[TMP16]] to i8
+; CHECK-NEXT:    [[TMP17:%.*]] = trunc i32 [[TMP15]] to i8
 ; CHECK-NEXT:    store i8 [[TMP17]], ptr addrspace(1) [[OUT]], align 1
 ; CHECK-NEXT:    ret void
 ;
@@ -819,8 +812,7 @@ define amdgpu_kernel void @urem_i8(ptr addrspace(1) %out, i8 %x, i8 %y) {
 ; CHECK-NEXT:    [[TMP15:%.*]] = add i32 [[TMP10]], [[TMP14]]
 ; CHECK-NEXT:    [[TMP16:%.*]] = mul i32 [[TMP15]], [[TMP2]]
 ; CHECK-NEXT:    [[TMP17:%.*]] = sub i32 [[TMP1]], [[TMP16]]
-; CHECK-NEXT:    [[TMP18:%.*]] = and i32 [[TMP17]], 255
-; CHECK-NEXT:    [[TMP19:%.*]] = trunc i32 [[TMP18]] to i8
+; CHECK-NEXT:    [[TMP19:%.*]] = trunc i32 [[TMP17]] to i8
 ; CHECK-NEXT:    store i8 [[TMP19]], ptr addrspace(1) [[OUT]], align 1
 ; CHECK-NEXT:    ret void
 ;
@@ -891,9 +883,7 @@ define amdgpu_kernel void @sdiv_i8(ptr addrspace(1) %out, i8 %x, i8 %y) {
 ; CHECK-NEXT:    [[TMP16:%.*]] = fcmp fast oge float [[TMP14]], [[TMP15]]
 ; CHECK-NEXT:    [[TMP17:%.*]] = select i1 [[TMP16]], i32 [[TMP5]], i32 0
 ; CHECK-NEXT:    [[TMP18:%.*]] = add i32 [[TMP13]], [[TMP17]]
-; CHECK-NEXT:    [[TMP19:%.*]] = shl i32 [[TMP18]], 24
-; CHECK-NEXT:    [[TMP20:%.*]] = ashr i32 [[TMP19]], 24
-; CHECK-NEXT:    [[TMP21:%.*]] = trunc i32 [[TMP20]] to i8
+; CHECK-NEXT:    [[TMP21:%.*]] = trunc i32 [[TMP18]] to i8
 ; CHECK-NEXT:    store i8 [[TMP21]], ptr addrspace(1) [[OUT]], align 1
 ; CHECK-NEXT:    ret void
 ;
@@ -974,9 +964,7 @@ define amdgpu_kernel void @srem_i8(ptr addrspace(1) %out, i8 %x, i8 %y) {
 ; CHECK-NEXT:    [[TMP18:%.*]] = add i32 [[TMP13]], [[TMP17]]
 ; CHECK-NEXT:    [[TMP19:%.*]] = mul i32 [[TMP18]], [[TMP2]]
 ; CHECK-NEXT:    [[TMP20:%.*]] = sub i32 [[TMP1]], [[TMP19]]
-; CHECK-NEXT:    [[TMP21:%.*]] = shl i32 [[TMP20]], 24
-; CHECK-NEXT:    [[TMP22:%.*]] = ashr i32 [[TMP21]], 24
-; CHECK-NEXT:    [[TMP23:%.*]] = trunc i32 [[TMP22]] to i8
+; CHECK-NEXT:    [[TMP23:%.*]] = trunc i32 [[TMP20]] to i8
 ; CHECK-NEXT:    store i8 [[TMP23]], ptr addrspace(1) [[OUT]], align 1
 ; CHECK-NEXT:    ret void
 ;
@@ -2476,8 +2464,7 @@ define amdgpu_kernel void @udiv_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP15:%.*]] = fcmp fast oge float [[TMP13]], [[TMP14]]
 ; CHECK-NEXT:    [[TMP16:%.*]] = select i1 [[TMP15]], i32 1, i32 0
 ; CHECK-NEXT:    [[TMP17:%.*]] = add i32 [[TMP12]], [[TMP16]]
-; CHECK-NEXT:    [[TMP18:%.*]] = and i32 [[TMP17]], 65535
-; CHECK-NEXT:    [[TMP19:%.*]] = trunc i32 [[TMP18]] to i16
+; CHECK-NEXT:    [[TMP19:%.*]] = trunc i32 [[TMP17]] to i16
 ; CHECK-NEXT:    [[TMP20:%.*]] = insertelement <4 x i16> poison, i16 [[TMP19]], i64 0
 ; CHECK-NEXT:    [[TMP21:%.*]] = extractelement <4 x i16> [[X]], i64 1
 ; CHECK-NEXT:    [[TMP22:%.*]] = extractelement <4 x i16> [[Y]], i64 1
@@ -2496,8 +2483,7 @@ define amdgpu_kernel void @udiv_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP35:%.*]] = fcmp fast oge float [[TMP33]], [[TMP34]]
 ; CHECK-NEXT:    [[TMP36:%.*]] = select i1 [[TMP35]], i32 1, i32 0
 ; CHECK-NEXT:    [[TMP37:%.*]] = add i32 [[TMP32]], [[TMP36]]
-; CHECK-NEXT:    [[TMP38:%.*]] = and i32 [[TMP37]], 65535
-; CHECK-NEXT:    [[TMP39:%.*]] = trunc i32 [[TMP38]] to i16
+; CHECK-NEXT:    [[TMP39:%.*]] = trunc i32 [[TMP37]] to i16
 ; CHECK-NEXT:    [[TMP40:%.*]] = insertelement <4 x i16> [[TMP20]], i16 [[TMP39]], i64 1
 ; CHECK-NEXT:    [[TMP41:%.*]] = extractelement <4 x i16> [[X]], i64 2
 ; CHECK-NEXT:    [[TMP42:%.*]] = extractelement <4 x i16> [[Y]], i64 2
@@ -2516,8 +2502,7 @@ define amdgpu_kernel void @udiv_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP55:%.*]] = fcmp fast oge float [[TMP53]], [[TMP54]]
 ; CHECK-NEXT:    [[TMP56:%.*]] = select i1 [[TMP55]], i32 1, i32 0
 ; CHECK-NEXT:    [[TMP57:%.*]] = add i32 [[TMP52]], [[TMP56]]
-; CHECK-NEXT:    [[TMP58:%.*]] = and i32 [[TMP57]], 65535
-; CHECK-NEXT:    [[TMP59:%.*]] = trunc i32 [[TMP58]] to i16
+; CHECK-NEXT:    [[TMP59:%.*]] = trunc i32 [[TMP57]] to i16
 ; CHECK-NEXT:    [[TMP60:%.*]] = insertelement <4 x i16> [[TMP40]], i16 [[TMP59]], i64 2
 ; CHECK-NEXT:    [[TMP61:%.*]] = extractelement <4 x i16> [[X]], i64 3
 ; CHECK-NEXT:    [[TMP62:%.*]] = extractelement <4 x i16> [[Y]], i64 3
@@ -2536,8 +2521,7 @@ define amdgpu_kernel void @udiv_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP75:%.*]] = fcmp fast oge float [[TMP73]], [[TMP74]]
 ; CHECK-NEXT:    [[TMP76:%.*]] = select i1 [[TMP75]], i32 1, i32 0
 ; CHECK-NEXT:    [[TMP77:%.*]] = add i32 [[TMP72]], [[TMP76]]
-; CHECK-NEXT:    [[TMP78:%.*]] = and i32 [[TMP77]], 65535
-; CHECK-NEXT:    [[TMP79:%.*]] = trunc i32 [[TMP78]] to i16
+; CHECK-NEXT:    [[TMP79:%.*]] = trunc i32 [[TMP77]] to i16
 ; CHECK-NEXT:    [[TMP80:%.*]] = insertelement <4 x i16> [[TMP60]], i16 [[TMP79]], i64 3
 ; CHECK-NEXT:    store <4 x i16> [[TMP80]], ptr addrspace(1) [[OUT]], align 8
 ; CHECK-NEXT:    ret void
@@ -2685,8 +2669,7 @@ define amdgpu_kernel void @urem_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP17:%.*]] = add i32 [[TMP12]], [[TMP16]]
 ; CHECK-NEXT:    [[TMP18:%.*]] = mul i32 [[TMP17]], [[TMP4]]
 ; CHECK-NEXT:    [[TMP19:%.*]] = sub i32 [[TMP3]], [[TMP18]]
-; CHECK-NEXT:    [[TMP20:%.*]] = and i32 [[TMP19]], 65535
-; CHECK-NEXT:    [[TMP21:%.*]] = trunc i32 [[TMP20]] to i16
+; CHECK-NEXT:    [[TMP21:%.*]] = trunc i32 [[TMP19]] to i16
 ; CHECK-NEXT:    [[TMP22:%.*]] = insertelement <4 x i16> poison, i16 [[TMP21]], i64 0
 ; CHECK-NEXT:    [[TMP23:%.*]] = extractelement <4 x i16> [[X]], i64 1
 ; CHECK-NEXT:    [[TMP24:%.*]] = extractelement <4 x i16> [[Y]], i64 1
@@ -2707,8 +2690,7 @@ define amdgpu_kernel void @urem_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP39:%.*]] = add i32 [[TMP34]], [[TMP38]]
 ; CHECK-NEXT:    [[TMP40:%.*]] = mul i32 [[TMP39]], [[TMP26]]
 ; CHECK-NEXT:    [[TMP41:%.*]] = sub i32 [[TMP25]], [[TMP40]]
-; CHECK-NEXT:    [[TMP42:%.*]] = and i32 [[TMP41]], 65535
-; CHECK-NEXT:    [[TMP43:%.*]] = trunc i32 [[TMP42]] to i16
+; CHECK-NEXT:    [[TMP43:%.*]] = trunc i32 [[TMP41]] to i16
 ; CHECK-NEXT:    [[TMP44:%.*]] = insertelement <4 x i16> [[TMP22]], i16 [[TMP43]], i64 1
 ; CHECK-NEXT:    [[TMP45:%.*]] = extractelement <4 x i16> [[X]], i64 2
 ; CHECK-NEXT:    [[TMP46:%.*]] = extractelement <4 x i16> [[Y]], i64 2
@@ -2729,8 +2711,7 @@ define amdgpu_kernel void @urem_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP61:%.*]] = add i32 [[TMP56]], [[TMP60]]
 ; CHECK-NEXT:    [[TMP62:%.*]] = mul i32 [[TMP61]], [[TMP48]]
 ; CHECK-NEXT:    [[TMP63:%.*]] = sub i32 [[TMP47]], [[TMP62]]
-; CHECK-NEXT:    [[TMP64:%.*]] = and i32 [[TMP63]], 65535
-; CHECK-NEXT:    [[TMP65:%.*]] = trunc i32 [[TMP64]] to i16
+; CHECK-NEXT:    [[TMP65:%.*]] = trunc i32 [[TMP63]] to i16
 ; CHECK-NEXT:    [[TMP66:%.*]] = insertelement <4 x i16> [[TMP44]], i16 [[TMP65]], i64 2
 ; CHECK-NEXT:    [[TMP67:%.*]] = extractelement <4 x i16> [[X]], i64 3
 ; CHECK-NEXT:    [[TMP68:%.*]] = extractelement <4 x i16> [[Y]], i64 3
@@ -2751,8 +2732,7 @@ define amdgpu_kernel void @urem_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP83:%.*]] = add i32 [[TMP78]], [[TMP82]]
 ; CHECK-NEXT:    [[TMP84:%.*]] = mul i32 [[TMP83]], [[TMP70]]
 ; CHECK-NEXT:    [[TMP85:%.*]] = sub i32 [[TMP69]], [[TMP84]]
-; CHECK-NEXT:    [[TMP86:%.*]] = and i32 [[TMP85]], 65535
-; CHECK-NEXT:    [[TMP87:%.*]] = trunc i32 [[TMP86]] to i16
+; CHECK-NEXT:    [[TMP87:%.*]] = trunc i32 [[TMP85]] to i16
 ; CHECK-NEXT:    [[TMP88:%.*]] = insertelement <4 x i16> [[TMP66]], i16 [[TMP87]], i64 3
 ; CHECK-NEXT:    store <4 x i16> [[TMP88]], ptr addrspace(1) [[OUT]], align 8
 ; CHECK-NEXT:    ret void
@@ -2916,9 +2896,7 @@ define amdgpu_kernel void @sdiv_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP18:%.*]] = fcmp fast oge float [[TMP16]], [[TMP17]]
 ; CHECK-NEXT:    [[TMP19:%.*]] = select i1 [[TMP18]], i32 [[TMP7]], i32 0
 ; CHECK-NEXT:    [[TMP20:%.*]] = add i32 [[TMP15]], [[TMP19]]
-; CHECK-NEXT:    [[TMP21:%.*]] = shl i32 [[TMP20]], 16
-; CHECK-NEXT:    [[TMP22:%.*]] = ashr i32 [[TMP21]], 16
-; CHECK-NEXT:    [[TMP23:%.*]] = trunc i32 [[TMP22]] to i16
+; CHECK-NEXT:    [[TMP23:%.*]] = trunc i32 [[TMP20]] to i16
 ; CHECK-NEXT:    [[TMP24:%.*]] = insertelement <4 x i16> poison, i16 [[TMP23]], i64 0
 ; CHECK-NEXT:    [[TMP25:%.*]] = extractelement <4 x i16> [[X]], i64 1
 ; CHECK-NEXT:    [[TMP26:%.*]] = extractelement <4 x i16> [[Y]], i64 1
@@ -2940,9 +2918,7 @@ define amdgpu_kernel void @sdiv_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP42:%.*]] = fcmp fast oge float [[TMP40]], [[TMP41]]
 ; CHECK-NEXT:    [[TMP43:%.*]] = select i1 [[TMP42]], i32 [[TMP31]], i32 0
 ; CHECK-NEXT:    [[TMP44:%.*]] = add i32 [[TMP39]], [[TMP43]]
-; CHECK-NEXT:    [[TMP45:%.*]] = shl i32 [[TMP44]], 16
-; CHECK-NEXT:    [[TMP46:%.*]] = ashr i32 [[TMP45]], 16
-; CHECK-NEXT:    [[TMP47:%.*]] = trunc i32 [[TMP46]] to i16
+; CHECK-NEXT:    [[TMP47:%.*]] = trunc i32 [[TMP44]] to i16
 ; CHECK-NEXT:    [[TMP48:%.*]] = insertelement <4 x i16> [[TMP24]], i16 [[TMP47]], i64 1
 ; CHECK-NEXT:    [[TMP49:%.*]] = extractelement <4 x i16> [[X]], i64 2
 ; CHECK-NEXT:    [[TMP50:%.*]] = extractelement <4 x i16> [[Y]], i64 2
@@ -2964,9 +2940,7 @@ define amdgpu_kernel void @sdiv_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP66:%.*]] = fcmp fast oge float [[TMP64]], [[TMP65]]
 ; CHECK-NEXT:    [[TMP67:%.*]] = select i1 [[TMP66]], i32 [[TMP55]], i32 0
 ; CHECK-NEXT:    [[TMP68:%.*]] = add i32 [[TMP63]], [[TMP67]]
-; CHECK-NEXT:    [[TMP69:%.*]] = shl i32 [[TMP68]], 16
-; CHECK-NEXT:    [[TMP70:%.*]] = ashr i32 [[TMP69]], 16
-; CHECK-NEXT:    [[TMP71:%.*]] = trunc i32 [[TMP70]] to i16
+; CHECK-NEXT:    [[TMP71:%.*]] = trunc i32 [[TMP68]] to i16
 ; CHECK-NEXT:    [[TMP72:%.*]] = insertelement <4 x i16> [[TMP48]], i16 [[TMP71]], i64 2
 ; CHECK-NEXT:    [[TMP73:%.*]] = extractelement <4 x i16> [[X]], i64 3
 ; CHECK-NEXT:    [[TMP74:%.*]] = extractelement <4 x i16> [[Y]], i64 3
@@ -2988,9 +2962,7 @@ define amdgpu_kernel void @sdiv_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP90:%.*]] = fcmp fast oge float [[TMP88]], [[TMP89]]
 ; CHECK-NEXT:    [[TMP91:%.*]] = select i1 [[TMP90]], i32 [[TMP79]], i32 0
 ; CHECK-NEXT:    [[TMP92:%.*]] = add i32 [[TMP87]], [[TMP91]]
-; CHECK-NEXT:    [[TMP93:%.*]] = shl i32 [[TMP92]], 16
-; CHECK-NEXT:    [[TMP94:%.*]] = ashr i32 [[TMP93]], 16
-; CHECK-NEXT:    [[TMP95:%.*]] = trunc i32 [[TMP94]] to i16
+; CHECK-NEXT:    [[TMP95:%.*]] = trunc i32 [[TMP92]] to i16
 ; CHECK-NEXT:    [[TMP96:%.*]] = insertelement <4 x i16> [[TMP72]], i16 [[TMP95]], i64 3
 ; CHECK-NEXT:    store <4 x i16> [[TMP96]], ptr addrspace(1) [[OUT]], align 8
 ; CHECK-NEXT:    ret void
@@ -3180,9 +3152,7 @@ define amdgpu_kernel void @srem_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP20:%.*]] = add i32 [[TMP15]], [[TMP19]]
 ; CHECK-NEXT:    [[TMP21:%.*]] = mul i32 [[TMP20]], [[TMP4]]
 ; CHECK-NEXT:    [[TMP22:%.*]] = sub i32 [[TMP3]], [[TMP21]]
-; CHECK-NEXT:    [[TMP23:%.*]] = shl i32 [[TMP22]], 16
-; CHECK-NEXT:    [[TMP24:%.*]] = ashr i32 [[TMP23]], 16
-; CHECK-NEXT:    [[TMP25:%.*]] = trunc i32 [[TMP24]] to i16
+; CHECK-NEXT:    [[TMP25:%.*]] = trunc i32 [[TMP22]] to i16
 ; CHECK-NEXT:    [[TMP26:%.*]] = insertelement <4 x i16> poison, i16 [[TMP25]], i64 0
 ; CHECK-NEXT:    [[TMP27:%.*]] = extractelement <4 x i16> [[X]], i64 1
 ; CHECK-NEXT:    [[TMP28:%.*]] = extractelement <4 x i16> [[Y]], i64 1
@@ -3206,9 +3176,7 @@ define amdgpu_kernel void @srem_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP46:%.*]] = add i32 [[TMP41]], [[TMP45]]
 ; CHECK-NEXT:    [[TMP47:%.*]] = mul i32 [[TMP46]], [[TMP30]]
 ; CHECK-NEXT:    [[TMP48:%.*]] = sub i32 [[TMP29]], [[TMP47]]
-; CHECK-NEXT:    [[TMP49:%.*]] = shl i32 [[TMP48]], 16
-; CHECK-NEXT:    [[TMP50:%.*]] = ashr i32 [[TMP49]], 16
-; CHECK-NEXT:    [[TMP51:%.*]] = trunc i32 [[TMP50]] to i16
+; CHECK-NEXT:    [[TMP51:%.*]] = trunc i32 [[TMP48]] to i16
 ; CHECK-NEXT:    [[TMP52:%.*]] = insertelement <4 x i16> [[TMP26]], i16 [[TMP51]], i64 1
 ; CHECK-NEXT:    [[TMP53:%.*]] = extractelement <4 x i16> [[X]], i64 2
 ; CHECK-NEXT:    [[TMP54:%.*]] = extractelement <4 x i16> [[Y]], i64 2
@@ -3232,9 +3200,7 @@ define amdgpu_kernel void @srem_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP72:%.*]] = add i32 [[TMP67]], [[TMP71]]
 ; CHECK-NEXT:    [[TMP73:%.*]] = mul i32 [[TMP72]], [[TMP56]]
 ; CHECK-NEXT:    [[TMP74:%.*]] = sub i32 [[TMP55]], [[TMP73]]
-; CHECK-NEXT:    [[TMP75:%.*]] = shl i32 [[TMP74]], 16
-; CHECK-NEXT:    [[TMP76:%.*]] = ashr i32 [[TMP75]], 16
-; CHECK-NEXT:    [[TMP77:%.*]] = trunc i32 [[TMP76]] to i16
+; CHECK-NEXT:    [[TMP77:%.*]] = trunc i32 [[TMP74]] to i16
 ; CHECK-NEXT:    [[TMP78:%.*]] = insertelement <4 x i16> [[TMP52]], i16 [[TMP77]], i64 2
 ; CHECK-NEXT:    [[TMP79:%.*]] = extractelement <4 x i16> [[X]], i64 3
 ; CHECK-NEXT:    [[TMP80:%.*]] = extractelement <4 x i16> [[Y]], i64 3
@@ -3258,9 +3224,7 @@ define amdgpu_kernel void @srem_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP98:%.*]] = add i32 [[TMP93]], [[TMP97]]
 ; CHECK-NEXT:    [[TMP99:%.*]] = mul i32 [[TMP98]], [[TMP82]]
 ; CHECK-NEXT:    [[TMP100:%.*]] = sub i32 [[TMP81]], [[TMP99]]
-; CHECK-NEXT:    [[TMP101:%.*]] = shl i32 [[TMP100]], 16
-; CHECK-NEXT:    [[TMP102:%.*]] = ashr i32 [[TMP101]], 16
-; CHECK-NEXT:    [[TMP103:%.*]] = trunc i32 [[TMP102]] to i16
+; CHECK-NEXT:    [[TMP103:%.*]] = trunc i32 [[TMP100]] to i16
 ; CHECK-NEXT:    [[TMP104:%.*]] = insertelement <4 x i16> [[TMP78]], i16 [[TMP103]], i64 3
 ; CHECK-NEXT:    store <4 x i16> [[TMP104]], ptr addrspace(1) [[OUT]], align 8
 ; CHECK-NEXT:    ret void
@@ -3463,8 +3427,7 @@ define amdgpu_kernel void @udiv_i3(ptr addrspace(1) %out, i3 %x, i3 %y) {
 ; CHECK-NEXT:    [[TMP13:%.*]] = fcmp fast oge float [[TMP11]], [[TMP12]]
 ; CHECK-NEXT:    [[TMP14:%.*]] = select i1 [[TMP13]], i32 1, i32 0
 ; CHECK-NEXT:    [[TMP15:%.*]] = add i32 [[TMP10]], [[TMP14]]
-; CHECK-NEXT:    [[TMP16:%.*]] = and i32 [[TMP15]], 7
-; CHECK-NEXT:    [[TMP17:%.*]] = trunc i32 [[TMP16]] to i3
+; CHECK-NEXT:    [[TMP17:%.*]] = trunc i32 [[TMP15]] to i3
 ; CHECK-NEXT:    store i3 [[TMP17]], ptr addrspace(1) [[OUT]], align 1
 ; CHECK-NEXT:    ret void
 ;
@@ -3534,8 +3497,7 @@ define amdgpu_kernel void @urem_i3(ptr addrspace(1) %out, i3 %x, i3 %y) {
 ; CHECK-NEXT:    [[TMP15:%.*]] = add i32 [[TMP10]], [[TMP14]]
 ; CHECK-NEXT:    [[TMP16:%.*]] = mul i32 [[TMP15]], [[TMP2]]
 ; CHECK-NEXT:    [[TMP17:%.*]] = sub i32 [[TMP1]], [[TMP16]]
-; CHECK-NEXT:    [[TMP18:%.*]] = and i32 [[TMP17]], 7
-; CHECK-NEXT:    [[TMP19:%.*]] = trunc i32 [[TMP18]] to i3
+; CHECK-NEXT:    [[TMP19:%.*]] = trunc i32 [[TMP17]] to i3
 ; CHECK-NEXT:    store i3 [[TMP19]], ptr addrspace(1) [[OUT]], align 1
 ; CHECK-NEXT:    ret void
 ;
@@ -3613,9 +3575,7 @@ define amdgpu_kernel void @sdiv_i3(ptr addrspace(1) %out, i3 %x, i3 %y) {
 ; CHECK-NEXT:    [[TMP16:%.*]] = fcmp fast oge float [[TMP14]], [[TMP15]]
 ; CHECK-NEXT:    [[TMP17:%.*]] = select i1 [[TMP16]], i32 [[TMP5]], i32 0
 ; CHECK-NEXT:    [[TMP18:%.*]] = add i32 [[TMP13]], [[TMP17]]
-; CHECK-NEXT:    [[TMP19:%.*]] = shl i32 [[TMP18]], 29
-; CHECK-NEXT:    [[TMP20:%.*]] = ashr i32 [[TMP19]], 29
-; CHECK-NEXT:    [[TMP21:%.*]] = trunc i32 [[TMP20]] to i3
+; CHECK-NEXT:    [[TMP21:%.*]] = trunc i32 [[TMP18]] to i3
 ; CHECK-NEXT:    store i3 [[TMP21]], ptr addrspace(1) [[OUT]], align 1
 ; CHECK-NEXT:    ret void
 ;
@@ -3698,9 +3658,7 @@ define amdgpu_kernel void @srem_i3(ptr addrspace(1) %out, i3 %x, i3 %y) {
 ; CHECK-NEXT:    [[TMP18:%.*]] = add i32 [[TMP13]], [[TMP17]]
 ; CHECK-NEXT:    [[TMP19:%.*]] = mul i32 [[TMP18]], [[TMP2]]
 ; CHECK-NEXT:    [[TMP20:%.*]] = sub i32 [[TMP1]], [[TMP19]]
-; CHECK-NEXT:    [[TMP21:%.*]] = shl i32 [[TMP20]], 29
-; CHECK-NEXT:    [[TMP22:%.*]] = ashr i32 [[TMP21]], 29
-; CHECK-NEXT:    [[TMP23:%.*]] = trunc i32 [[TMP22]] to i3
+; CHECK-NEXT:    [[TMP23:%.*]] = trunc i32 [[TMP20]] to i3
 ; CHECK-NEXT:    store i3 [[TMP23]], ptr addrspace(1) [[OUT]], align 1
 ; CHECK-NEXT:    ret void
 ;
@@ -3787,8 +3745,7 @@ define amdgpu_kernel void @udiv_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP15:%.*]] = fcmp fast oge float [[TMP13]], [[TMP14]]
 ; CHECK-NEXT:    [[TMP16:%.*]] = select i1 [[TMP15]], i32 1, i32 0
 ; CHECK-NEXT:    [[TMP17:%.*]] = add i32 [[TMP12]], [[TMP16]]
-; CHECK-NEXT:    [[TMP18:%.*]] = and i32 [[TMP17]], 65535
-; CHECK-NEXT:    [[TMP19:%.*]] = trunc i32 [[TMP18]] to i16
+; CHECK-NEXT:    [[TMP19:%.*]] = trunc i32 [[TMP17]] to i16
 ; CHECK-NEXT:    [[TMP20:%.*]] = insertelement <3 x i16> poison, i16 [[TMP19]], i64 0
 ; CHECK-NEXT:    [[TMP21:%.*]] = extractelement <3 x i16> [[X]], i64 1
 ; CHECK-NEXT:    [[TMP22:%.*]] = extractelement <3 x i16> [[Y]], i64 1
@@ -3807,8 +3764,7 @@ define amdgpu_kernel void @udiv_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP35:%.*]] = fcmp fast oge float [[TMP33]], [[TMP34]]
 ; CHECK-NEXT:    [[TMP36:%.*]] = select i1 [[TMP35]], i32 1, i32 0
 ; CHECK-NEXT:    [[TMP37:%.*]] = add i32 [[TMP32]], [[TMP36]]
-; CHECK-NEXT:    [[TMP38:%.*]] = and i32 [[TMP37]], 65535
-; CHECK-NEXT:    [[TMP39:%.*]] = trunc i32 [[TMP38]] to i16
+; CHECK-NEXT:    [[TMP39:%.*]] = trunc i32 [[TMP37]] to i16
 ; CHECK-NEXT:    [[TMP40:%.*]] = insertelement <3 x i16> [[TMP20]], i16 [[TMP39]], i64 1
 ; CHECK-NEXT:    [[TMP41:%.*]] = extractelement <3 x i16> [[X]], i64 2
 ; CHECK-NEXT:    [[TMP42:%.*]] = extractelement <3 x i16> [[Y]], i64 2
@@ -3827,8 +3783,7 @@ define amdgpu_kernel void @udiv_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP55:%.*]] = fcmp fast oge float [[TMP53]], [[TMP54]]
 ; CHECK-NEXT:    [[TMP56:%.*]] = select i1 [[TMP55]], i32 1, i32 0
 ; CHECK-NEXT:    [[TMP57:%.*]] = add i32 [[TMP52]], [[TMP56]]
-; CHECK-NEXT:    [[TMP58:%.*]] = and i32 [[TMP57]], 65535
-; CHECK-NEXT:    [[TMP59:%.*]] = trunc i32 [[TMP58]] to i16
+; CHECK-NEXT:    [[TMP59:%.*]] = trunc i32 [[TMP57]] to i16
 ; CHECK-NEXT:    [[TMP60:%.*]] = insertelement <3 x i16> [[TMP40]], i16 [[TMP59]], i64 2
 ; CHECK-NEXT:    store <3 x i16> [[TMP60]], ptr addrspace(1) [[OUT]], align 8
 ; CHECK-NEXT:    ret void
@@ -3951,8 +3906,7 @@ define amdgpu_kernel void @urem_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP17:%.*]] = add i32 [[TMP12]], [[TMP16]]
 ; CHECK-NEXT:    [[TMP18:%.*]] = mul i32 [[TMP17]], [[TMP4]]
 ; CHECK-NEXT:    [[TMP19:%.*]] = sub i32 [[TMP3]], [[TMP18]]
-; CHECK-NEXT:    [[TMP20:%.*]] = and i32 [[TMP19]], 65535
-; CHECK-NEXT:    [[TMP21:%.*]] = trunc i32 [[TMP20]] to i16
+; CHECK-NEXT:    [[TMP21:%.*]] = trunc i32 [[TMP19]] to i16
 ; CHECK-NEXT:    [[TMP22:%.*]] = insertelement <3 x i16> poison, i16 [[TMP21]], i64 0
 ; CHECK-NEXT:    [[TMP23:%.*]] = extractelement <3 x i16> [[X]], i64 1
 ; CHECK-NEXT:    [[TMP24:%.*]] = extractelement <3 x i16> [[Y]], i64 1
@@ -3973,8 +3927,7 @@ define amdgpu_kernel void @urem_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP39:%.*]] = add i32 [[TMP34]], [[TMP38]]
 ; CHECK-NEXT:    [[TMP40:%.*]] = mul i32 [[TMP39]], [[TMP26]]
 ; CHECK-NEXT:    [[TMP41:%.*]] = sub i32 [[TMP25]], [[TMP40]]
-; CHECK-NEXT:    [[TMP42:%.*]] = and i32 [[TMP41]], 65535
-; CHECK-NEXT:    [[TMP43:%.*]] = trunc i32 [[TMP42]] to i16
+; CHECK-NEXT:    [[TMP43:%.*]] = trunc i32 [[TMP41]] to i16
 ; CHECK-NEXT:    [[TMP44:%.*]] = insertelement <3 x i16> [[TMP22]], i16 [[TMP43]], i64 1
 ; CHECK-NEXT:    [[TMP45:%.*]] = extractelement <3 x i16> [[X]], i64 2
 ; CHECK-NEXT:    [[TMP46:%.*]] = extractelement <3 x i16> [[Y]], i64 2
@@ -3995,8 +3948,7 @@ define amdgpu_kernel void @urem_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP61:%.*]] = add i32 [[TMP56]], [[TMP60]]
 ; CHECK-NEXT:    [[TMP62:%.*]] = mul i32 [[TMP61]], [[TMP48]]
 ; CHECK-NEXT:    [[TMP63:%.*]] = sub i32 [[TMP47]], [[TMP62]]
-; CHECK-NEXT:    [[TMP64:%.*]] = and i32 [[TMP63]], 65535
-; CHECK-NEXT:    [[TMP65:%.*]] = trunc i32 [[TMP64]] to i16
+; CHECK-NEXT:    [[TMP65:%.*]] = trunc i32 [[TMP63]] to i16
 ; CHECK-NEXT:    [[TMP66:%.*]] = insertelement <3 x i16> [[TMP44]], i16 [[TMP65]], i64 2
 ; CHECK-NEXT:    store <3 x i16> [[TMP66]], ptr addrspace(1) [[OUT]], align 8
 ; CHECK-NEXT:    ret void
@@ -4131,9 +4083,7 @@ define amdgpu_kernel void @sdiv_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP18:%.*]] = fcmp fast oge float [[TMP16]], [[TMP17]]
 ; CHECK-NEXT:    [[TMP19:%.*]] = select i1 [[TMP18]], i32 [[TMP7]], i32 0
 ; CHECK-NEXT:    [[TMP20:%.*]] = add i32 [[TMP15]], [[TMP19]]
-; CHECK-NEXT:    [[TMP21:%.*]] = shl i32 [[TMP20]], 16
-; CHECK-NEXT:    [[TMP22:%.*]] = ashr i32 [[TMP21]], 16
-; CHECK-NEXT:    [[TMP23:%.*]] = trunc i32 [[TMP22]] to i16
+; CHECK-NEXT:    [[TMP23:%.*]] = trunc i32 [[TMP20]] to i16
 ; CHECK-NEXT:    [[TMP24:%.*]] = insertelement <3 x i16> poison, i16 [[TMP23]], i64 0
 ; CHECK-NEXT:    [[TMP25:%.*]] = extractelement <3 x i16> [[X]], i64 1
 ; CHECK-NEXT:    [[TMP26:%.*]] = extractelement <3 x i16> [[Y]], i64 1
@@ -4155,9 +4105,7 @@ define amdgpu_kernel void @sdiv_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP42:%.*]] = fcmp fast oge float [[TMP40]], [[TMP41]]
 ; CHECK-NEXT:    [[TMP43:%.*]] = select i1 [[TMP42]], i32 [[TMP31]], i32 0
 ; CHECK-NEXT:    [[TMP44:%.*]] = add i32 [[TMP39]], [[TMP43]]
-; CHECK-NEXT:    [[TMP45:%.*]] = shl i32 [[TMP44]], 16
-; CHECK-NEXT:    [[TMP46:%.*]] = ashr i32 [[TMP45]], 16
-; CHECK-NEXT:    [[TMP47:%.*]] = trunc i32 [[TMP46]] to i16
+; CHECK-NEXT:    [[TMP47:%.*]] = trunc i32 [[TMP44]] to i16
 ; CHECK-NEXT:    [[TMP48:%.*]] = insertelement <3 x i16> [[TMP24]], i16 [[TMP47]], i64 1
 ; CHECK-NEXT:    [[TMP49:%.*]] = extractelement <3 x i16> [[X]], i64 2
 ; CHECK-NEXT:    [[TMP50:%.*]] = extractelement <3 x i16> [[Y]], i64 2
@@ -4179,9 +4127,7 @@ define amdgpu_kernel void @sdiv_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP66:%.*]] = fcmp fast oge float [[TMP64]], [[TMP65]]
 ; CHECK-NEXT:    [[TMP67:%.*]] = select i1 [[TMP66]], i32 [[TMP55]], i32 0
 ; CHECK-NEXT:    [[TMP68:%.*]] = add i32 [[TMP63]], [[TMP67]]
-; CHECK-NEXT:    [[TMP69:%.*]] = shl i32 [[TMP68]], 16
-; CHECK-NEXT:    [[TMP70:%.*]] = ashr i32 [[TMP69]], 16
-; CHECK-NEXT:    [[TMP71:%.*]] = trunc i32 [[TMP70]] to i16
+; CHECK-NEXT:    [[TMP71:%.*]] = trunc i32 [[TMP68]] to i16
 ; CHECK-NEXT:    [[TMP72:%.*]] = insertelement <3 x i16> [[TMP48]], i16 [[TMP71]], i64 2
 ; CHECK-NEXT:    store <3 x i16> [[TMP72]], ptr addrspace(1) [[OUT]], align 8
 ; CHECK-NEXT:    ret void
@@ -4336,9 +4282,7 @@ define amdgpu_kernel void @srem_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP20:%.*]] = add i32 [[TMP15]], [[TMP19]]
 ; CHECK-NEXT:    [[TMP21:%.*]] = mul i32 [[TMP20]], [[TMP4]]
 ; CHECK-NEXT:    [[TMP22:%.*]] = sub i32 [[TMP3]], [[TMP21]]
-; CHECK-NEXT:    [[TMP23:%.*]] = shl i32 [[TMP22]], 16
-; CHECK-NEXT:    [[TMP24:%.*]] = ashr i32 [[TMP23]], 16
-; CHECK-NEXT:    [[TMP25:%.*]] = trunc i32 [[TMP24]] to i16
+; CHECK-NEXT:    [[TMP25:%.*]] = trunc i32 [[TMP22]] to i16
 ; CHECK-NEXT:    [[TMP26:%.*]] = insertelement <3 x i16> poison, i16 [[TMP25]], i64 0
 ; CHECK-NEXT:    [[TMP27:%.*]] = extractelement <3 x i16> [[X]], i64 1
 ; CHECK-NEXT:    [[TMP28:%.*]] = extractelement <3 x i16> [[Y]], i64 1
@@ -4362,9 +4306,7 @@ define amdgpu_kernel void @srem_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP46:%.*]] = add i32 [[TMP41]], [[TMP45]]
 ; CHECK-NEXT:    [[TMP47:%.*]] = mul i32 [[TMP46]], [[TMP30]]
 ; CHECK-NEXT:    [[TMP48:%.*]] = sub i32 [[TMP29]], [[TMP47]]
-; CHECK-NEXT:    [[TMP49:%.*]] = shl i32 [[TMP48]], 16
-; CHECK-NEXT:    [[TMP50:%.*]] = ashr i32 [[TMP49]], 16
-; CHECK-NEXT:    [[TMP51:%.*]] = trunc i32 [[TMP50]] to i16
+; CHECK-NEXT:    [[TMP51:%.*]] = trunc i32 [[TMP48]] to i16
 ; CHECK-NEXT:    [[TMP52:%.*]] = insertelement <3 x i16> [[TMP26]], i16 [[TMP51]], i64 1
 ; CHECK-NEXT:    [[TMP53:%.*]] = extractelement <3 x i16> [[X]], i64 2
 ; CHECK-NEXT:    [[TMP54:%.*]] = extractelement <3 x i16> [[Y]], i64 2
@@ -4388,9 +4330,7 @@ define amdgpu_kernel void @srem_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP72:%.*]] = add i32 [[TMP67]], [[TMP71]]
 ; CHECK-NEXT:    [[TMP73:%.*]] = mul i32 [[TMP72]], [[TMP56]]
 ; CHECK-NEXT:    [[TMP74:%.*]] = sub i32 [[TMP55]], [[TMP73]]
-; CHECK-NEXT:    [[TMP75:%.*]] = shl i32 [[TMP74]], 16
-; CHECK-NEXT:    [[TMP76:%.*]] = ashr i32 [[TMP75]], 16
-; CHECK-NEXT:    [[TMP77:%.*]] = trunc i32 [[TMP76]] to i16
+; CHECK-NEXT:    [[TMP77:%.*]] = trunc i32 [[TMP74]] to i16
 ; CHECK-NEXT:    [[TMP78:%.*]] = insertelement <3 x i16> [[TMP52]], i16 [[TMP77]], i64 2
 ; CHECK-NEXT:    store <3 x i16> [[TMP78]], ptr addrspace(1) [[OUT]], align 8
 ; CHECK-NEXT:    ret void
@@ -4554,8 +4494,7 @@ define amdgpu_kernel void @udiv_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP15:%.*]] = fcmp fast oge float [[TMP13]], [[TMP14]]
 ; CHECK-NEXT:    [[TMP16:%.*]] = select i1 [[TMP15]], i32 1, i32 0
 ; CHECK-NEXT:    [[TMP17:%.*]] = add i32 [[TMP12]], [[TMP16]]
-; CHECK-NEXT:    [[TMP18:%.*]] = and i32 [[TMP17]], 32767
-; CHECK-NEXT:    [[TMP19:%.*]] = trunc i32 [[TMP18]] to i15
+; CHECK-NEXT:    [[TMP19:%.*]] = trunc i32 [[TMP17]] to i15
 ; CHECK-NEXT:    [[TMP20:%.*]] = insertelement <3 x i15> poison, i15 [[TMP19]], i64 0
 ; CHECK-NEXT:    [[TMP21:%.*]] = extractelement <3 x i15> [[X]], i64 1
 ; CHECK-NEXT:    [[TMP22:%.*]] = extractelement <3 x i15> [[Y]], i64 1
@@ -4574,8 +4513,7 @@ define amdgpu_kernel void @udiv_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP35:%.*]] = fcmp fast oge float [[TMP33]], [[TMP34]]
 ; CHECK-NEXT:    [[TMP36:%.*]] = select i1 [[TMP35]], i32 1, i32 0
 ; CHECK-NEXT:    [[TMP37:%.*]] = add i32 [[TMP32]], [[TMP36]]
-; CHECK-NEXT:    [[TMP38:%.*]] = and i32 [[TMP37]], 32767
-; CHECK-NEXT:    [[TMP39:%.*]] = trunc i32 [[TMP38]] to i15
+; CHECK-NEXT:    [[TMP39:%.*]] = trunc i32 [[TMP37]] to i15
 ; CHECK-NEXT:    [[TMP40:%.*]] = insertelement <3 x i15> [[TMP20]], i15 [[TMP39]], i64 1
 ; CHECK-NEXT:    [[TMP41:%.*]] = extractelement <3 x i15> [[X]], i64 2
 ; CHECK-NEXT:    [[TMP42:%.*]] = extractelement <3 x i15> [[Y]], i64 2
@@ -4594,8 +4532,7 @@ define amdgpu_kernel void @udiv_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP55:%.*]] = fcmp fast oge float [[TMP53]], [[TMP54]]
 ; CHECK-NEXT:    [[TMP56:%.*]] = select i1 [[TMP55]], i32 1, i32 0
 ; CHECK-NEXT:    [[TMP57:%.*]] = add i32 [[TMP52]], [[TMP56]]
-; CHECK-NEXT:    [[TMP58:%.*]] = and i32 [[TMP57]], 32767
-; CHECK-NEXT:    [[TMP59:%.*]] = trunc i32 [[TMP58]] to i15
+; CHECK-NEXT:    [[TMP59:%.*]] = trunc i32 [[TMP57]] to i15
 ; CHECK-NEXT:    [[TMP60:%.*]] = insertelement <3 x i15> [[TMP40]], i15 [[TMP59]], i64 2
 ; CHECK-NEXT:    store <3 x i15> [[TMP60]], ptr addrspace(1) [[OUT]], align 8
 ; CHECK-NEXT:    ret void
@@ -4733,8 +4670,7 @@ define amdgpu_kernel void @urem_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP17:%.*]] = add i32 [[TMP12]], [[TMP16]]
 ; CHECK-NEXT:    [[TMP18:%.*]] = mul i32 [[TMP17]], [[TMP4]]
 ; CHECK-NEXT:    [[TMP19:%.*]] = sub i32 [[TMP3]], [[TMP18]]
-; CHECK-NEXT:    [[TMP20:%.*]] = and i32 [[TMP19]], 32767
-; CHECK-NEXT:    [[TMP21:%.*]] = trunc i32 [[TMP20]] to i15
+; CHECK-NEXT:    [[TMP21:%.*]] = trunc i32 [[TMP19]] to i15
 ; CHECK-NEXT:    [[TMP22:%.*]] = insertelement <3 x i15> poison, i15 [[TMP21]], i64 0
 ; CHECK-NEXT:    [[TMP23:%.*]] = extractelement <3 x i15> [[X]], i64 1
 ; CHECK-NEXT:    [[TMP24:%.*]] = extractelement <3 x i15> [[Y]], i64 1
@@ -4755,8 +4691,7 @@ define amdgpu_kernel void @urem_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP39:%.*]] = add i32 [[TMP34]], [[TMP38]]
 ; CHECK-NEXT:    [[TMP40:%.*]] = mul i32 [[TMP39]], [[TMP26]]
 ; CHECK-NEXT:    [[TMP41:%.*]] = sub i32 [[TMP25]], [[TMP40]]
-; CHECK-NEXT:    [[TMP42:%.*]] = and i32 [[TMP41]], 32767
-; CHECK-NEXT:    [[TMP43:%.*]] = trunc i32 [[TMP42]] to i15
+; CHECK-NEXT:    [[TMP43:%.*]] = trunc i32 [[TMP41]] to i15
 ; CHECK-NEXT:    [[TMP44:%.*]] = insertelement <3 x i15> [[TMP22]], i15 [[TMP43]], i64 1
 ; CHECK-NEXT:    [[TMP45:%.*]] = extractelement <3 x i15> [[X]], i64 2
 ; CHECK-NEXT:    [[TMP46:%.*]] = extractelement <3 x i15> [[Y]], i64 2
@@ -4777,8 +4712,7 @@ define amdgpu_kernel void @urem_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP61:%.*]] = add i32 [[TMP56]], [[TMP60]]
 ; CHECK-NEXT:    [[TMP62:%.*]] = mul i32 [[TMP61]], [[TMP48]]
 ; CHECK-NEXT:    [[TMP63:%.*]] = sub i32 [[TMP47]], [[TMP62]]
-; CHECK-NEXT:    [[TMP64:%.*]] = and i32 [[TMP63]], 32767
-; CHECK-NEXT:    [[TMP65:%.*]] = trunc i32 [[TMP64]] to i15
+; CHECK-NEXT:    [[TMP65:%.*]] = trunc i32 [[TMP63]] to i15
 ; CHECK-NEXT:    [[TMP66:%.*]] = insertelement <3 x i15> [[TMP44]], i15 [[TMP65]], i64 2
 ; CHECK-NEXT:    store <3 x i15> [[TMP66]], ptr addrspace(1) [[OUT]], align 8
 ; CHECK-NEXT:    ret void
@@ -4933,9 +4867,7 @@ define amdgpu_kernel void @sdiv_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP18:%.*]] = fcmp fast oge float [[TMP16]], [[TMP17]]
 ; CHECK-NEXT:    [[TMP19:%.*]] = select i1 [[TMP18]], i32 [[TMP7]], i32 0
 ; CHECK-NEXT:    [[TMP20:%.*]] = add i32 [[TMP15]], [[TMP19]]
-; CHECK-NEXT:    [[TMP21:%.*]] = shl i32 [[TMP20]], 17
-; CHECK-NEXT:    [[TMP22:%.*]] = ashr i32 [[TMP21]], 17
-; CHECK-NEXT:    [[TMP23:%.*]] = trunc i32 [[TMP22]] to i15
+; CHECK-NEXT:    [[TMP23:%.*]] = trunc i32 [[TMP20]] to i15
 ; CHECK-NEXT:    [[TMP24:%.*]] = insertelement <3 x i15> poison, i15 [[TMP23]], i64 0
 ; CHECK-NEXT:    [[TMP25:%.*]] = extractelement <3 x i15> [[X]], i64 1
 ; CHECK-NEXT:    [[TMP26:%.*]] = extractelement <3 x i15> [[Y]], i64 1
@@ -4957,9 +4889,7 @@ define amdgpu_kernel void @sdiv_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP42:%.*]] = fcmp fast oge float [[TMP40]], [[TMP41]]
 ; CHECK-NEXT:    [[TMP43:%.*]] = select i1 [[TMP42]], i32 [[TMP31]], i32 0
 ; CHECK-NEXT:    [[TMP44:%.*]] = add i32 [[TMP39]], [[TMP43]]
-; CHECK-NEXT:    [[TMP45:%.*]] = shl i32 [[TMP44]], 17
-; CHECK-NEXT:    [[TMP46:%.*]] = ashr i32 [[TMP45]], 17
-; CHECK-NEXT:    [[TMP47:%.*]] = trunc i32 [[TMP46]] to i15
+; CHECK-NEXT:    [[TMP47:%.*]] = trunc i32 [[TMP44]] to i15
 ; CHECK-NEXT:    [[TMP48:%.*]] = insertelement <3 x i15> [[TMP24]], i15 [[TMP47]], i64 1
 ; CHECK-NEXT:    [[TMP49:%.*]] = extractelement <3 x i15> [[X]], i64 2
 ; CHECK-NEXT:    [[TMP50:%.*]] = extractelement <3 x i15> [[Y]], i64 2
@@ -4981,9 +4911,7 @@ define amdgpu_kernel void @sdiv_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP66:%.*]] = fcmp fast oge float [[TMP64]], [[TMP65]]
 ; CHECK-NEXT:    [[TMP67:%.*]] = select i1 [[TMP66]], i32 [[TMP55]], i32 0
 ; CHECK-NEXT:    [[TMP68:%.*]] = add i32 [[TMP63]], [[TMP67]]
-; CHECK-NEXT:    [[TMP69:%.*]] = shl i32 [[TMP68]], 17
-; CHECK-NEXT:    [[TMP70:%.*]] = ashr i32 [[TMP69]], 17
-; CHECK-NEXT:    [[TMP71:%.*]] = trunc i32 [[TMP70]] to i15
+; CHECK-NEXT:    [[TMP71:%.*]] = trunc i32 [[TMP68]] to i15
 ; CHECK-NEXT:    [[TMP72:%.*]] = insertelement <3 x i15> [[TMP48]], i15 [[TMP71]], i64 2
 ; CHECK-NEXT:    store <3 x i15> [[TMP72]], ptr addrspace(1) [[OUT]], align 8
 ; CHECK-NEXT:    ret void
@@ -5154,9 +5082,7 @@ define amdgpu_kernel void @srem_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP20:%.*]] = add i32 [[TMP15]], [[TMP19]]
 ; CHECK-NEXT:    [[TMP21:%.*]] = mul i32 [[TMP20]], [[TMP4]]
 ; CHECK-NEXT:    [[TMP22:%.*]] = sub i32 [[TMP3]], [[TMP21]]
-; CHECK-NEXT:    [[TMP23:%.*]] = shl i32 [[TMP22]], 17
-; CHECK-NEXT:    [[TMP24:%.*]] = ashr i32 [[TMP23]], 17
-; CHECK-NEXT:    [[TMP25:%.*]] = trunc i32 [[TMP24]] to i15
+; CHECK-NEXT:    [[TMP25:%.*]] = trunc i32 [[TMP22]] to i15
 ; CHECK-NEXT:    [[TMP26:%.*]] = insertelement <3 x i15> poison, i15 [[TMP25]], i64 0
 ; CHECK-NEXT:    [[TMP27:%.*]] = extractelement <3 x i15> [[X]], i64 1
 ; CHECK-NEXT:    [[TMP28:%.*]] = extractelement <3 x i15> [[Y]], i64 1
@@ -5180,9 +5106,7 @@ define amdgpu_kernel void @srem_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP46:%.*]] = add i32 [[TMP41]], [[TMP45]]
 ; CHECK-NEXT:    [[TMP47:%.*]] = mul i32 [[TMP46]], [[TMP30]]
 ; CHECK-NEXT:    [[TMP48:%.*]] = sub i32 [[TMP29]], [[TMP47]]
-; CHECK-NEXT:    [[TMP49:%.*]] = shl i32 [[TMP48]], 17
-; CHECK-NEXT:    [[TMP50:%.*]] = ashr i32 [[TMP49]], 17
-; CHECK-NEXT:    [[TMP51:%.*]] = trunc i32 [[TMP50]] to i15
+; CHECK-NEXT:    [[TMP51:%.*]] = trunc i32 [[TMP48]] to i15
 ; CHECK-NEXT:    [[TMP52:%.*]] = insertelement <3 x i15> [[TMP26]], i15 [[TMP51]], i64 1
 ; CHECK-NEXT:    [[TMP53:%.*]] = extractelement <3 x i15> [[X]], i64 2
 ; CHECK-NEXT:    [[TMP54:%.*]] = extractelement <3 x i15> [[Y]], i64 2
@@ -5206,9 +5130,7 @@ define amdgpu_kernel void @srem_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP72:%.*]] = add i32 [[TMP67]], [[TMP71]]
 ; CHECK-NEXT:    [[TMP73:%.*]] = mul i32 [[TMP72]], [[TMP56]]
 ; CHECK-NEXT:    [[TMP74:%.*]] = sub i32 [[TMP55]], [[TMP73]]
-; CHECK-NEXT:    [[TMP75:%.*]] = shl i32 [[TMP74]], 17
-; CHECK-NEXT:    [[TMP76:%.*]] = ashr i32 [[TMP75]], 17
-; CHECK-NEXT:    [[TMP77:%.*]] = trunc i32 [[TMP76]] to i15
+; CHECK-NEXT:    [[TMP77:%.*]] = trunc i32 [[TMP74]] to i15
 ; CHECK-NEXT:    [[TMP78:%.*]] = insertelement <3 x i15> [[TMP52]], i15 [[TMP77]], i64 2
 ; CHECK-NEXT:    store <3 x i15> [[TMP78]], ptr addrspace(1) [[OUT]], align 8
 ; CHECK-NEXT:    ret void
@@ -10102,7 +10024,6 @@ define i64 @udiv_i64_9divbits(i8 %size) {
 ; GFX6-NEXT:    v_cmp_ge_f32_e64 vcc, |v0|, s4
 ; GFX6-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX6-NEXT:    v_addc_u32_e32 v0, vcc, 0, v2, vcc
-; GFX6-NEXT:    v_and_b32_e32 v0, 0x1ff, v0
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: udiv_i64_9divbits:
@@ -10119,7 +10040,6 @@ define i64 @udiv_i64_9divbits(i8 %size) {
 ; GFX9-NEXT:    v_cmp_ge_f32_e64 vcc, |v0|, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX9-NEXT:    v_addc_co_u32_e32 v0, vcc, 0, v2, vcc
-; GFX9-NEXT:    v_and_b32_e32 v0, 0x1ff, v0
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ; CHECK-LABEL: define i64 @udiv_i64_9divbits(
 ; CHECK-SAME: i8 [[SIZE:%.*]]) #[[ATTR0]] {
@@ -10140,9 +10060,8 @@ define i64 @udiv_i64_9divbits(i8 %size) {
 ; CHECK-NEXT:    [[TMP14:%.*]] = fcmp oge float [[TMP12]], [[TMP13]]
 ; CHECK-NEXT:    [[TMP15:%.*]] = select i1 [[TMP14]], i32 1, i32 0
 ; CHECK-NEXT:    [[TMP16:%.*]] = add i32 [[TMP11]], [[TMP15]]
-; CHECK-NEXT:    [[TMP17:%.*]] = and i32 [[TMP16]], 511
-; CHECK-NEXT:    [[TMP18:%.*]] = zext i32 [[TMP17]] to i64
-; CHECK-NEXT:    ret i64 [[TMP18]]
+; CHECK-NEXT:    [[TMP17:%.*]] = zext i32 [[TMP16]] to i64
+; CHECK-NEXT:    ret i64 [[TMP17]]
 ;
   %zextend = zext i8 %size to i64
   %num = add nuw nsw i64 1, %zextend
@@ -10246,10 +10165,8 @@ define amdgpu_kernel void @sdiv23(ptr addrspace(1) %out, i23 %x, i23 %y) {
 ; CHECK-NEXT:    [[TMP16:%.*]] = fcmp fast oge float [[TMP14]], [[TMP15]]
 ; CHECK-NEXT:    [[TMP17:%.*]] = select i1 [[TMP16]], i32 [[TMP5]], i32 0
 ; CHECK-NEXT:    [[TMP18:%.*]] = add i32 [[TMP13]], [[TMP17]]
-; CHECK-NEXT:    [[TMP19:%.*]] = shl i32 [[TMP18]], 9
-; CHECK-NEXT:    [[TMP20:%.*]] = ashr i32 [[TMP19]], 9
-; CHECK-NEXT:    [[TMP21:%.*]] = trunc i32 [[TMP20]] to i23
-; CHECK-NEXT:    store i23 [[TMP21]], ptr addrspace(1) [[OUT]], align 4
+; CHECK-NEXT:    [[TMP19:%.*]] = trunc i32 [[TMP18]] to i23
+; CHECK-NEXT:    store i23 [[TMP19]], ptr addrspace(1) [[OUT]], align 4
 ; CHECK-NEXT:    ret void
 ;
   %r = sdiv i23 %x, %y
@@ -10451,9 +10368,8 @@ define amdgpu_kernel void @udiv22(ptr addrspace(1) %out, i22 %x, i22 %y) {
 ; CHECK-NEXT:    [[TMP13:%.*]] = fcmp fast oge float [[TMP11]], [[TMP12]]
 ; CHECK-NEXT:    [[TMP14:%.*]] = select i1 [[TMP13]], i32 1, i32 0
 ; CHECK-NEXT:    [[TMP15:%.*]] = add i32 [[TMP10]], [[TMP14]]
-; CHECK-NEXT:    [[TMP16:%.*]] = and i32 [[TMP15]], 4194303
-; CHECK-NEXT:    [[TMP17:%.*]] = trunc i32 [[TMP16]] to i22
-; CHECK-NEXT:    store i22 [[TMP17]], ptr addrspace(1) [[OUT]], align 4
+; CHECK-NEXT:    [[TMP16:%.*]] = trunc i32 [[TMP15]] to i22
+; CHECK-NEXT:    store i22 [[TMP16]], ptr addrspace(1) [[OUT]], align 4
 ; CHECK-NEXT:    ret void
 ;
   %r = udiv i22 %x, %y

--- a/llvm/test/CodeGen/AMDGPU/divrem24-assume.ll
+++ b/llvm/test/CodeGen/AMDGPU/divrem24-assume.ll
@@ -20,8 +20,7 @@ define amdgpu_kernel void @divrem24_assume(ptr addrspace(1) %arg, i32 %arg1) {
 ; CHECK-NEXT:    [[TMP10:%.*]] = fcmp fast oge float [[TMP8]], [[TMP9]]
 ; CHECK-NEXT:    [[TMP11:%.*]] = select i1 [[TMP10]], i32 1, i32 0
 ; CHECK-NEXT:    [[TMP12:%.*]] = add i32 [[TMP7]], [[TMP11]]
-; CHECK-NEXT:    [[TMP13:%.*]] = and i32 [[TMP12]], 1023
-; CHECK-NEXT:    [[TMP4:%.*]] = zext i32 [[TMP13]] to i64
+; CHECK-NEXT:    [[TMP4:%.*]] = zext i32 [[TMP12]] to i64
 ; CHECK-NEXT:    [[TMP5:%.*]] = getelementptr inbounds i32, ptr addrspace(1) [[ARG:%.*]], i64 [[TMP4]]
 ; CHECK-NEXT:    store i32 0, ptr addrspace(1) [[TMP5]], align 4
 ; CHECK-NEXT:    ret void

--- a/llvm/test/CodeGen/AMDGPU/sdiv.ll
+++ b/llvm/test/CodeGen/AMDGPU/sdiv.ll
@@ -218,9 +218,8 @@ define amdgpu_kernel void @s_test_sdiv22_32(ptr addrspace(1) %out, i32 %x, i32 %
 ; GCN-NEXT:    v_cmp_ge_f32_e64 s[4:5], |v1|, |v0|
 ; GCN-NEXT:    s_and_b64 s[4:5], s[4:5], exec
 ; GCN-NEXT:    s_cselect_b32 s4, s6, 0
-; GCN-NEXT:    v_add_i32_e32 v0, vcc, s4, v2
 ; GCN-NEXT:    s_mov_b32 s2, -1
-; GCN-NEXT:    v_bfe_i32 v0, v0, 0, 22
+; GCN-NEXT:    v_add_i32_e32 v0, vcc, s4, v2
 ; GCN-NEXT:    buffer_store_dword v0, off, s[0:3], 0
 ; GCN-NEXT:    s_endpgm
 ;
@@ -245,9 +244,8 @@ define amdgpu_kernel void @s_test_sdiv22_32(ptr addrspace(1) %out, i32 %x, i32 %
 ; TONGA-NEXT:    v_cmp_ge_f32_e64 s[4:5], |v1|, |v0|
 ; TONGA-NEXT:    s_and_b64 s[4:5], s[4:5], exec
 ; TONGA-NEXT:    s_cselect_b32 s4, s6, 0
-; TONGA-NEXT:    v_add_u32_e32 v0, vcc, s4, v2
 ; TONGA-NEXT:    s_mov_b32 s2, -1
-; TONGA-NEXT:    v_bfe_i32 v0, v0, 0, 22
+; TONGA-NEXT:    v_add_u32_e32 v0, vcc, s4, v2
 ; TONGA-NEXT:    buffer_store_dword v0, off, s[0:3], 0
 ; TONGA-NEXT:    s_endpgm
 ;
@@ -272,9 +270,8 @@ define amdgpu_kernel void @s_test_sdiv22_32(ptr addrspace(1) %out, i32 %x, i32 %
 ; GFX9-NEXT:    v_cmp_ge_f32_e64 s[4:5], |v1|, |v0|
 ; GFX9-NEXT:    s_and_b64 s[4:5], s[4:5], exec
 ; GFX9-NEXT:    s_cselect_b32 s4, s6, 0
-; GFX9-NEXT:    v_add_u32_e32 v0, s4, v2
 ; GFX9-NEXT:    s_mov_b32 s2, -1
-; GFX9-NEXT:    v_bfe_i32 v0, v0, 0, 22
+; GFX9-NEXT:    v_add_u32_e32 v0, s4, v2
 ; GFX9-NEXT:    buffer_store_dword v0, off, s[0:3], 0
 ; GFX9-NEXT:    s_endpgm
 ;

--- a/llvm/test/CodeGen/AMDGPU/sdiv64.ll
+++ b/llvm/test/CodeGen/AMDGPU/sdiv64.ll
@@ -504,7 +504,6 @@ define amdgpu_kernel void @s_test_sdiv22_64(ptr addrspace(1) %out, i64 %x, i64 %
 ; GCN-NEXT:    s_and_b64 s[0:1], s[0:1], exec
 ; GCN-NEXT:    s_cselect_b32 s0, s2, 0
 ; GCN-NEXT:    v_add_i32_e32 v0, vcc, s0, v2
-; GCN-NEXT:    v_bfe_i32 v0, v0, 0, 22
 ; GCN-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
 ; GCN-NEXT:    buffer_store_dwordx2 v[0:1], off, s[4:7], 0
 ; GCN-NEXT:    s_endpgm
@@ -535,7 +534,6 @@ define amdgpu_kernel void @s_test_sdiv22_64(ptr addrspace(1) %out, i64 %x, i64 %
 ; GCN-IR-NEXT:    s_and_b64 s[0:1], s[0:1], exec
 ; GCN-IR-NEXT:    s_cselect_b32 s0, s2, 0
 ; GCN-IR-NEXT:    v_add_i32_e32 v0, vcc, s0, v2
-; GCN-IR-NEXT:    v_bfe_i32 v0, v0, 0, 22
 ; GCN-IR-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
 ; GCN-IR-NEXT:    buffer_store_dwordx2 v[0:1], off, s[4:7], 0
 ; GCN-IR-NEXT:    s_endpgm

--- a/llvm/test/CodeGen/AMDGPU/sdiv64.ll
+++ b/llvm/test/CodeGen/AMDGPU/sdiv64.ll
@@ -912,7 +912,6 @@ define amdgpu_kernel void @s_test_sdiv23_64(ptr addrspace(1) %out, i64 %x, i64 %
 ; GCN-NEXT:    s_and_b64 s[0:1], s[0:1], exec
 ; GCN-NEXT:    s_cselect_b32 s0, s2, 0
 ; GCN-NEXT:    v_add_i32_e32 v0, vcc, s0, v2
-; GCN-NEXT:    v_bfe_i32 v0, v0, 0, 23
 ; GCN-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
 ; GCN-NEXT:    buffer_store_dwordx2 v[0:1], off, s[4:7], 0
 ; GCN-NEXT:    s_endpgm
@@ -943,7 +942,6 @@ define amdgpu_kernel void @s_test_sdiv23_64(ptr addrspace(1) %out, i64 %x, i64 %
 ; GCN-IR-NEXT:    s_and_b64 s[0:1], s[0:1], exec
 ; GCN-IR-NEXT:    s_cselect_b32 s0, s2, 0
 ; GCN-IR-NEXT:    v_add_i32_e32 v0, vcc, s0, v2
-; GCN-IR-NEXT:    v_bfe_i32 v0, v0, 0, 23
 ; GCN-IR-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
 ; GCN-IR-NEXT:    buffer_store_dwordx2 v[0:1], off, s[4:7], 0
 ; GCN-IR-NEXT:    s_endpgm

--- a/llvm/test/CodeGen/AMDGPU/sdivrem24.ll
+++ b/llvm/test/CodeGen/AMDGPU/sdivrem24.ll
@@ -301,7 +301,6 @@ define amdgpu_kernel void @srem25_i11_i24_i32(ptr addrspace(1) %out, ptr addrspa
 ; FUNC-LABEL: {{^}}srem25_i17_i12_i32:
 ; SI: v_cvt_f32_i32
 ; SI: v_rcp_f32
-; SI: v_bfe_i32 v{{[0-9]+}}, v{{[0-9]+}}, 0, 17
 
 ; EG: INT_TO_FLT
 ; EG: RECIP_IEEE

--- a/llvm/test/CodeGen/AMDGPU/srem64.ll
+++ b/llvm/test/CodeGen/AMDGPU/srem64.ll
@@ -467,73 +467,63 @@ define i64 @v_test_srem(i64 %x, i64 %y) {
 define amdgpu_kernel void @s_test_srem23_64(ptr addrspace(1) %out, i64 %x, i64 %y) {
 ; GCN-LABEL: s_test_srem23_64:
 ; GCN:       ; %bb.0:
+; GCN-NEXT:    s_load_dword s6, s[4:5], 0xe
 ; GCN-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x9
-; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-NEXT:    s_load_dword s2, s[4:5], 0xe
 ; GCN-NEXT:    s_mov_b32 s7, 0xf000
-; GCN-NEXT:    s_mov_b32 s6, -1
-; GCN-NEXT:    s_ashr_i32 s3, s3, 9
 ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-NEXT:    s_ashr_i32 s2, s2, 9
-; GCN-NEXT:    v_cvt_f32_i32_e32 v0, s2
-; GCN-NEXT:    v_cvt_f32_i32_e32 v1, s3
-; GCN-NEXT:    s_mov_b32 s4, s0
-; GCN-NEXT:    s_xor_b32 s0, s3, s2
+; GCN-NEXT:    s_ashr_i32 s4, s6, 9
+; GCN-NEXT:    v_cvt_f32_i32_e32 v0, s4
+; GCN-NEXT:    s_ashr_i32 s8, s3, 9
+; GCN-NEXT:    v_cvt_f32_i32_e32 v1, s8
+; GCN-NEXT:    s_xor_b32 s2, s8, s4
 ; GCN-NEXT:    v_rcp_f32_e32 v2, v0
-; GCN-NEXT:    s_ashr_i32 s0, s0, 30
-; GCN-NEXT:    s_mov_b32 s5, s1
-; GCN-NEXT:    s_or_b32 s8, s0, 1
+; GCN-NEXT:    s_ashr_i32 s2, s2, 30
+; GCN-NEXT:    s_or_b32 s5, s2, 1
+; GCN-NEXT:    s_mov_b32 s6, -1
 ; GCN-NEXT:    v_mul_f32_e32 v2, v1, v2
 ; GCN-NEXT:    v_trunc_f32_e32 v2, v2
 ; GCN-NEXT:    v_mad_f32 v1, -v2, v0, v1
 ; GCN-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GCN-NEXT:    v_cmp_ge_f32_e64 s[0:1], |v1|, |v0|
-; GCN-NEXT:    s_and_b64 s[0:1], s[0:1], exec
-; GCN-NEXT:    s_cselect_b32 s0, s8, 0
-; GCN-NEXT:    v_readfirstlane_b32 s1, v2
-; GCN-NEXT:    s_add_i32 s0, s1, s0
-; GCN-NEXT:    s_mul_i32 s0, s0, s2
-; GCN-NEXT:    s_sub_i32 s0, s3, s0
-; GCN-NEXT:    s_bfe_i32 s0, s0, 0x170000
-; GCN-NEXT:    s_ashr_i32 s1, s0, 31
-; GCN-NEXT:    v_mov_b32_e32 v0, s0
-; GCN-NEXT:    v_mov_b32_e32 v1, s1
+; GCN-NEXT:    v_cmp_ge_f32_e64 s[2:3], |v1|, |v0|
+; GCN-NEXT:    s_and_b64 s[2:3], s[2:3], exec
+; GCN-NEXT:    s_cselect_b32 s2, s5, 0
+; GCN-NEXT:    v_add_i32_e32 v0, vcc, s2, v2
+; GCN-NEXT:    v_mul_lo_u32 v0, v0, s4
+; GCN-NEXT:    s_mov_b32 s4, s0
+; GCN-NEXT:    s_mov_b32 s5, s1
+; GCN-NEXT:    v_sub_i32_e32 v0, vcc, s8, v0
+; GCN-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
 ; GCN-NEXT:    buffer_store_dwordx2 v[0:1], off, s[4:7], 0
 ; GCN-NEXT:    s_endpgm
 ;
 ; GCN-IR-LABEL: s_test_srem23_64:
 ; GCN-IR:       ; %bb.0:
+; GCN-IR-NEXT:    s_load_dword s6, s[4:5], 0xe
 ; GCN-IR-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x9
-; GCN-IR-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-IR-NEXT:    s_load_dword s2, s[4:5], 0xe
 ; GCN-IR-NEXT:    s_mov_b32 s7, 0xf000
-; GCN-IR-NEXT:    s_mov_b32 s6, -1
-; GCN-IR-NEXT:    s_ashr_i32 s3, s3, 9
 ; GCN-IR-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-IR-NEXT:    s_ashr_i32 s2, s2, 9
-; GCN-IR-NEXT:    v_cvt_f32_i32_e32 v0, s2
-; GCN-IR-NEXT:    v_cvt_f32_i32_e32 v1, s3
-; GCN-IR-NEXT:    s_mov_b32 s4, s0
-; GCN-IR-NEXT:    s_xor_b32 s0, s3, s2
+; GCN-IR-NEXT:    s_ashr_i32 s4, s6, 9
+; GCN-IR-NEXT:    v_cvt_f32_i32_e32 v0, s4
+; GCN-IR-NEXT:    s_ashr_i32 s8, s3, 9
+; GCN-IR-NEXT:    v_cvt_f32_i32_e32 v1, s8
+; GCN-IR-NEXT:    s_xor_b32 s2, s8, s4
 ; GCN-IR-NEXT:    v_rcp_f32_e32 v2, v0
-; GCN-IR-NEXT:    s_ashr_i32 s0, s0, 30
-; GCN-IR-NEXT:    s_mov_b32 s5, s1
-; GCN-IR-NEXT:    s_or_b32 s8, s0, 1
+; GCN-IR-NEXT:    s_ashr_i32 s2, s2, 30
+; GCN-IR-NEXT:    s_or_b32 s5, s2, 1
+; GCN-IR-NEXT:    s_mov_b32 s6, -1
 ; GCN-IR-NEXT:    v_mul_f32_e32 v2, v1, v2
 ; GCN-IR-NEXT:    v_trunc_f32_e32 v2, v2
 ; GCN-IR-NEXT:    v_mad_f32 v1, -v2, v0, v1
 ; GCN-IR-NEXT:    v_cvt_i32_f32_e32 v2, v2
-; GCN-IR-NEXT:    v_cmp_ge_f32_e64 s[0:1], |v1|, |v0|
-; GCN-IR-NEXT:    s_and_b64 s[0:1], s[0:1], exec
-; GCN-IR-NEXT:    s_cselect_b32 s0, s8, 0
-; GCN-IR-NEXT:    v_readfirstlane_b32 s1, v2
-; GCN-IR-NEXT:    s_add_i32 s0, s1, s0
-; GCN-IR-NEXT:    s_mul_i32 s0, s0, s2
-; GCN-IR-NEXT:    s_sub_i32 s0, s3, s0
-; GCN-IR-NEXT:    s_bfe_i32 s0, s0, 0x170000
-; GCN-IR-NEXT:    s_ashr_i32 s1, s0, 31
-; GCN-IR-NEXT:    v_mov_b32_e32 v0, s0
-; GCN-IR-NEXT:    v_mov_b32_e32 v1, s1
+; GCN-IR-NEXT:    v_cmp_ge_f32_e64 s[2:3], |v1|, |v0|
+; GCN-IR-NEXT:    s_and_b64 s[2:3], s[2:3], exec
+; GCN-IR-NEXT:    s_cselect_b32 s2, s5, 0
+; GCN-IR-NEXT:    v_add_i32_e32 v0, vcc, s2, v2
+; GCN-IR-NEXT:    v_mul_lo_u32 v0, v0, s4
+; GCN-IR-NEXT:    s_mov_b32 s4, s0
+; GCN-IR-NEXT:    s_mov_b32 s5, s1
+; GCN-IR-NEXT:    v_sub_i32_e32 v0, vcc, s8, v0
+; GCN-IR-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
 ; GCN-IR-NEXT:    buffer_store_dwordx2 v[0:1], off, s[4:7], 0
 ; GCN-IR-NEXT:    s_endpgm
   %1 = ashr i64 %x, 41


### PR DESCRIPTION
When expanding div/rem by using floating-point operations, sign/zero-extending the result from the calculated DivBits input width to 32-bits is unnecessary.  CreateFPToSI or CreateFPToUI is called with a 32-bit int type so the conversion instruction will already produce a result with the desired width.

Also it is incorrect. For signed-division `DIVBITS_MAX_NEG/-1`,  the result should be      `-DIVBITS_MAX_NEG` a positive value.  Sign-extension will incorrectly return a negative result.  For example, for DivBits=4, `-8/-1 = 8`, but adding code to do a 28-bit sign-extension will incorrectly return `-8`.

Tested in https://github.com/llvm/llvm-test-suite/pull/423.