### PR TITLE
clang-format/test: Anchor the empty .clang-format-ignore to test_exec_root

### DIFF
--- a/clang/test/Format/lit.local.cfg
+++ b/clang/test/Format/lit.local.cfg
@@ -29,7 +29,7 @@ config.suffixes = [
 if platform.system() == "AIX":
     config.test_format = lit.formats.ShTest()
 
-# Create an empty .clang-format-ignore file so that tests don't get messed
-# up if one exists higher in the tree
-with open(".clang-format-ignore", "w"):
+# Create an empty .clang-format-ignore file in the test execution root so that
+# tests don't get messed up if one exists higher in the tree.
+with open(os.path.join(config.test_exec_root, ".clang-format-ignore"), "w"):
     pass


### PR DESCRIPTION
The test suite's lit.local.cfg creates an empty .clang-format-ignore at
config discovery time to protect the multiple-inputs[-inplace].cpp tests
that work on files in temporary locations.

This file should be written to where the tests execute instead of the
CWD during config discovery. The CWD might not even be an ancestor of
where the tests execute, and it might be the repository root which does
have a .clang-format-ignore that is incorrectly clobbered without this
change.

An alternative would be to just fix the tests that need to be protected,
but having a blanket guard like this does seem like a reasonable thing
to do.

Fixes: 915de1a5889c ("Generate empty .clang-format-ignore before running tests (#136154)")