### PR TITLE
[Fuzzer] Make signal tests work with internal shell

### DIFF
--- a/compiler-rt/test/fuzzer/fork-sigusr.test
+++ b/compiler-rt/test/fuzzer/fork-sigusr.test
@@ -5,9 +5,9 @@ RUN: rm -rf %t
 RUN: mkdir -p %t
 RUN: %cpp_compiler %S/SleepOneSecondTest.cpp -o %t/ForkSIGUSR
 
-RUN: %run %t/ForkSIGUSR -fork=3 -ignore_crashes=1 2>%t/log & export PID=$!
-RUN: sleep 3
-RUN: kill -SIGUSR2 $PID
+RUN: bash -c "%run %t/ForkSIGUSR -fork=3 -ignore_crashes=1 > /dev/null 2>%t/log & export PID=\$!; \
+RUN: sleep 3; \
+RUN: kill -SIGUSR2 \$PID"
 RUN: sleep 6
 RUN: cat %t/log | FileCheck %s --dump-input=fail
 

--- a/compiler-rt/test/fuzzer/merge-sigusr.test
+++ b/compiler-rt/test/fuzzer/merge-sigusr.test
@@ -24,10 +24,10 @@ RUN: echo n > %t/C2/g
 RUN: echo o > %t/C2/g
 
 # Run in new session so we can easily kill child processes all at once.
-RUN: setsid %run %t/LFSIGUSR -merge=1 -merge_control_file=%t/MCF %t/C1 %t/C2 2>%t/log & export PID=$!
-RUN: sleep 3
-RUN: kill -SIGUSR2 -$(ps -o sess= $PID | grep -o '[0-9]*')
-RUN: wait $PID || true
+RUN: bash -c "setsid %run %t/LFSIGUSR -merge=1 -merge_control_file=%t/MCF %t/C1 %t/C2 > /dev/null 2>%t/log & export PID=\$!; \
+RUN: sleep 3; \
+RUN: kill -SIGUSR2 -\$(ps -o sess= \$PID | grep -o '[0-9]*'); \
+RUN: wait \$PID || true"
 RUN: sleep 3
 RUN: cat %t/log | FileCheck %s --dump-input=fail
 RUN: grep C2/g %t/MCF

--- a/compiler-rt/test/fuzzer/sigint.test
+++ b/compiler-rt/test/fuzzer/sigint.test
@@ -6,9 +6,9 @@ RUN: rm -rf %t
 RUN: mkdir -p %t
 RUN: %msan_compiler %S/SleepOneSecondTest.cpp -o %t/LFSIGINT
 
-RUN: %run %t/LFSIGINT 2> %t/log & export PID=$!
-RUN: sleep 2
-RUN: kill -SIGINT $PID
+RUN: bash -c "%run %t/LFSIGINT > /dev/null 2> %t/log & export PID=\$!; \
+RUN: sleep 2; \
+RUN: kill -SIGINT \$PID"
 RUN: sleep 3
 RUN: cat %t/log | FileCheck %s
 

--- a/compiler-rt/test/fuzzer/sigusr.test
+++ b/compiler-rt/test/fuzzer/sigusr.test
@@ -6,9 +6,9 @@ RUN: rm -rf %t
 RUN: mkdir -p %t
 RUN: %cpp_compiler %S/SleepOneSecondTest.cpp -o %t/LFSIGUSR
 
-RUN: %run %t/LFSIGUSR 2> %t/log & export PID=$!
-RUN: sleep 2
-RUN: kill -SIGUSR1 $PID
+RUN: bash -c "%run %t/LFSIGUSR > /dev/null 2> %t/log & export PID=\$!; \
+RUN: sleep 2; \
+RUN: kill -SIGUSR1 \$PID"
 RUN: sleep 3
 RUN: cat %t/log | FileCheck %s
 


### PR DESCRIPTION
Wrap some commands in bash as it seemed like the least bad option. The alternative is to use setsid and run the other commands in the internal shell, but them it's impossible to use wait and we run into reliability issues because of that.