### PR TITLE
[Fuzzer] Make two tests compatible with the internal shell.

### DIFF
--- a/compiler-rt/test/fuzzer/features_dir.test
+++ b/compiler-rt/test/fuzzer/features_dir.test
@@ -4,4 +4,4 @@ RUN: %cpp_compiler %S/SimpleTest.cpp -o %t-SimpleTest
 RUN: rm -rf %t-C %t-F
 RUN: mkdir %t-C %t-F
 RUN: not %run %t-SimpleTest %t-C -features_dir=%t-F
-RUN: for c in %t-C/*; do f=%t-F/$(basename $c); echo looking for $f; [ -a $f ]; done
+RUN: %python -c "import glob; import os; assert all([os.path.exists(f'%t-F/{os.path.basename(file_path)}') for file_path in list(glob.glob('%t-C/*'))])"

--- a/compiler-rt/test/fuzzer/merge-posix.test
+++ b/compiler-rt/test/fuzzer/merge-posix.test
@@ -18,9 +18,9 @@ RUN: echo ....E. > %tmp/T2/5
 RUN: %python -c "print('.....R' + 'X' * 4096, end='')" > %tmp/T2/6
 
 # Check that we can report an error if file size exceeded
-RUN: (ulimit -f 4; not %run %t-FullCoverageSetTest -merge=1 %tmp/T1 %tmp/T2 2>&1 | FileCheck %s --check-prefix=SIGXFSZ)
+RUN: ulimit -f 4; not %run %t-FullCoverageSetTest -merge=1 %tmp/T1 %tmp/T2 2>&1 | FileCheck %s --check-prefix=SIGXFSZ
 SIGXFSZ: ERROR: libFuzzer: file size exceeded
 
 # Check that we honor TMPDIR
-RUN: TMPDIR=DIR_DOES_NOT_EXIST not %run %t-FullCoverageSetTest -merge=1 %tmp/T1 %tmp/T2 2>&1 | FileCheck %s --check-prefix=TMPDIR
+RUN: env TMPDIR=DIR_DOES_NOT_EXIST not %run %t-FullCoverageSetTest -merge=1 %tmp/T1 %tmp/T2 2>&1 | FileCheck %s --check-prefix=TMPDIR
 TMPDIR: MERGE-OUTER: failed to write to the control file: DIR_DOES_NOT_EXIST/libFuzzerTemp


### PR DESCRIPTION
1. Remove redundant parntheses that broke the internal shell's parsing logic.
2. Use env when specifying environment variables.
3. Rewrite a bash one-line loop in python.