### PR TITLE
[BPF] Force incremental mandatory inlining for BPF target

### DIFF
--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -983,7 +983,11 @@ PassBuilder::buildInlinerPipeline(OptimizationLevel Level,
   if (PGOOpt)
     IP.EnableDeferral = EnablePGOInlineDeferral;
 
-  ModuleInlinerWrapperPass MIWP(IP, PerformMandatoryInliningsFirst,
+  bool MandatoryFirst = PerformMandatoryInliningsFirst;
+  if (TM && TM->getTargetTriple().isBPF())
+    MandatoryFirst = true;
+
+  ModuleInlinerWrapperPass MIWP(IP, MandatoryFirst,
                                 InlineContext{Phase, InlinePass::CGSCCInliner},
                                 UseInlineAdvisor, MaxDevirtIterations);
 
@@ -1316,7 +1320,8 @@ PassBuilder::buildModuleSimplificationPipeline(OptimizationLevel Level,
                  PGOOpt->Action == PGOOptions::SampleUse))
     MPM.addPass(PGOForceFunctionAttrsPass(PGOOpt->ColdOptType));
 
-  MPM.addPass(AlwaysInlinerPass(/*InsertLifetimeIntrinsics=*/true));
+  if (!(TM && TM->getTargetTriple().isBPF()))
+    MPM.addPass(AlwaysInlinerPass(/*InsertLifetimeIntrinsics=*/true));
 
   if (EnableModuleInliner)
     MPM.addPass(buildModuleInlinerPipeline(Level, Phase));


### PR DESCRIPTION
The standalone AlwaysInlinerPass (introduced in 7f886b137d) expands all __always_inline calls without intermediate simplification. For BPF, this produces bloated IR that can exceed the kernel verifier's 1-million instruction limit, causing programs to be rejected.

The CGSCC-based approach (PerformMandatoryInliningsFirst=true) performs inline-then-simplify incrementally, keeping IR compact at each step and producing smaller BPF bytecode that passes verification.

This patch forces PerformMandatoryInliningsFirst=true for BPF targets and skips the standalone AlwaysInlinerPass in the optimizing pipeline when targeting BPF, since mandatory inlining is already handled inside the CGSCC inliner. The -O0 pipeline is unaffected.