### PR TITLE
[libc] [math] Fix build bot failure introduced by unit test in PR #201154

### DIFF
--- a/libc/test/src/math/RoundToIntegerTest.h
+++ b/libc/test/src/math/RoundToIntegerTest.h
@@ -10,7 +10,6 @@
 #define LLVM_LIBC_TEST_SRC_MATH_ROUNDTOINTEGERTEST_H
 
 #include "test/UnitTest/RoundingModeUtils.h"
-#include <cfenv>
 #undef LIBC_MATH_USE_SYSTEM_FENV
 
 #include "src/__support/CPP/algorithm.h"


### PR DESCRIPTION
The root cause is that the unit test `libc/test/src/math/RoundToIntegerTest.h` `#include <cfenv>` which requires the macro `__GLIBC_PREREQ` to be defined. But in that riscv32 runtime, seems like it's not defined.

Removing the include works fine, and at the same time, would resolve the failure.