### PR TITLE
[LoopFusion][NFC] Avoid copying fusion candidates per pair

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopFuse.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopFuse.cpp
@@ -746,8 +746,8 @@ private:
       for (auto It = CandidateList.begin(), NextIt = std::next(It);
            NextIt != CandidateList.end(); It = NextIt, NextIt = std::next(It)) {
 
-        auto FC0 = *It;
-        auto FC1 = *NextIt;
+        const FusionCandidate &FC0 = *It;
+        const FusionCandidate &FC1 = *NextIt;
 
         assert(!LDT.isRemovedLoop(FC0.L) &&
                "Should not have removed loops in CandidateList!");


### PR DESCRIPTION
`fuseCandidates()` copied both candidates (each holding two `SmallVector<Instruction *, 16>`) for every adjacent pair examined, even pairs rejected by an early continue. Bind them by const reference; they are only read before being erased from the list, and performFusion runs before the erases.