### PR TITLE
[Transforms] Skip FailedRequestedVectorization warning for OpenMP parallel loops

### DIFF
--- a/llvm/lib/Transforms/Scalar/WarnMissedTransforms.cpp
+++ b/llvm/lib/Transforms/Scalar/WarnMissedTransforms.cpp
@@ -46,28 +46,36 @@ static void warnAboutLeftoverTransformations(Loop *L,
   }
 
   if (hasVectorizeTransformation(L) == TM_ForcedByUser) {
-    LLVM_DEBUG(dbgs() << "Leftover vectorization transformation\n");
-    std::optional<ElementCount> VectorizeWidth =
-        getOptionalElementCountLoopAttribute(L);
-    std::optional<int> InterleaveCount =
-        getOptionalIntLoopAttribute(L, "llvm.loop.interleave.count");
+    // OpenMP SIMD loops are represented as annotated parallel loops.  They can
+    // still legally execute without loop-vectorization, so avoid turning these
+    // cases into transform-warning diagnostics that are commonly promoted to
+    // hard errors by -Werror builds.
+    if (!L->isAnnotatedParallel()) {
+      LLVM_DEBUG(dbgs() << "Leftover vectorization transformation\n");
+      std::optional<ElementCount> VectorizeWidth =
+          getOptionalElementCountLoopAttribute(L);
+      std::optional<int> InterleaveCount =
+          getOptionalIntLoopAttribute(L, "llvm.loop.interleave.count");
 
-    if (!VectorizeWidth || VectorizeWidth->isVector())
-      ORE->emit(
-          DiagnosticInfoOptimizationFailure(DEBUG_TYPE,
-                                            "FailedRequestedVectorization",
-                                            L->getStartLoc(), L->getHeader())
-          << "loop not vectorized: the optimizer was unable to perform the "
-             "requested transformation; the transformation might be disabled "
-             "or specified as part of an unsupported transformation ordering");
-    else if (InterleaveCount.value_or(0) != 1)
-      ORE->emit(
-          DiagnosticInfoOptimizationFailure(DEBUG_TYPE,
-                                            "FailedRequestedInterleaving",
-                                            L->getStartLoc(), L->getHeader())
-          << "loop not interleaved: the optimizer was unable to perform the "
-             "requested transformation; the transformation might be disabled "
-             "or specified as part of an unsupported transformation ordering");
+      if (!VectorizeWidth || VectorizeWidth->isVector())
+        ORE->emit(
+            DiagnosticInfoOptimizationFailure(DEBUG_TYPE,
+                                              "FailedRequestedVectorization",
+                                              L->getStartLoc(), L->getHeader())
+            << "loop not vectorized: the optimizer was unable to perform the "
+               "requested transformation; the transformation might be disabled "
+               "or specified as part of an unsupported transformation "
+               "ordering");
+      else if (InterleaveCount.value_or(0) != 1)
+        ORE->emit(
+            DiagnosticInfoOptimizationFailure(DEBUG_TYPE,
+                                              "FailedRequestedInterleaving",
+                                              L->getStartLoc(), L->getHeader())
+            << "loop not interleaved: the optimizer was unable to perform the "
+               "requested transformation; the transformation might be disabled "
+               "or specified as part of an unsupported transformation "
+               "ordering");
+    }
   }
 
   if (hasDistributeTransformation(L) == TM_ForcedByUser) {

--- a/llvm/test/Transforms/LoopTransformWarning/omp-simd-vectorization-remarks-suppressed.ll
+++ b/llvm/test/Transforms/LoopTransformWarning/omp-simd-vectorization-remarks-suppressed.ll
@@ -1,0 +1,30 @@
+; RUN: opt -passes=transform-warning -disable-output -pass-remarks-missed=transform-warning -pass-remarks-analysis=transform-warning < %s 2>&1 | FileCheck -allow-empty %s
+;
+; OpenMP SIMD loops are represented as annotated parallel loops. Keep
+; transform-warning from emitting FailedRequestedVectorization for these loops.
+;
+; CHECK-NOT: FailedRequestedVectorization
+; CHECK-NOT: loop not vectorized
+
+define void @test(ptr %x, ptr %c) {
+entry:
+  br label %loop
+
+loop:
+  %i = phi i64 [ 0, %entry ], [ %next, %loop ]
+  %src.ptr = getelementptr inbounds double, ptr %c, i64 %i
+  %v = load double, ptr %src.ptr, align 8, !llvm.access.group !1
+  %dst.ptr = getelementptr inbounds double, ptr %x, i64 %i
+  store double %v, ptr %dst.ptr, align 8, !llvm.access.group !1
+  %next = add nuw nsw i64 %i, 1
+  %done = icmp eq i64 %next, 64
+  br i1 %done, label %exit, label %loop, !llvm.loop !0
+
+exit:
+  ret void
+}
+
+!0 = distinct !{!0, !2, !3}
+!1 = distinct !{}
+!2 = !{!"llvm.loop.vectorize.enable", i1 true}
+!3 = !{!"llvm.loop.parallel_accesses", !1}


### PR DESCRIPTION
OpenMP SIMD loops are represented as `!llvm.loop.parallel_accesses` annotated
parallel loops in IR.  When vectorization fails for these loops, the existing
code emits a FailedRequestedVectorization diagnostic, which -Werror promotes
to a hard error and breaks valid OpenMP programs.  Fix by skipping the warning
when the loop is annotated parallel.

Link to 1/3: #193881 
Link to 2/3: #193884 