### PR TITLE
[InstCombine] Sink IDiv to Select's arm when another is 1

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
@@ -1508,6 +1508,39 @@ Instruction *InstCombinerImpl::commonIDivTransforms(BinaryOperator &I) {
     }
   }
 
+  // X / (select Cond, 1, Y) --> select Cond, X, (X / Y)
+  // X / (select Cond, Y, 1) --> select Cond, (X / Y), X
+  // Division by 1 is a no-op, so we sink the division into the non-1 arm.
+  // For sdiv, limit Y to constant to avoid signed overflow concern.
+  {
+    Value *Cond, *DivY;
+    const APInt *C;
+    if (match(Op1, m_OneUse(m_Select(m_Value(Cond), m_One(), m_Value(DivY))))) {
+      bool Ok = IsSigned ? (match(DivY, m_APInt(C)) && !C->isZero() &&
+                            !C->isAllOnes())
+                         : isKnownNonZero(DivY, SQ.getWithInstruction(&I));
+      if (Ok) {
+        Value *Divisor = IsSigned ? ConstantInt::get(Ty, *C) : DivY;
+        Value *NewDiv = Builder.CreateBinOp(I.getOpcode(), Op0, Divisor);
+        if (auto *NewDivInst = dyn_cast<BinaryOperator>(NewDiv))
+          NewDivInst->setIsExact(I.isExact());
+        return createSelectInstWithUnknownProfile(Cond, Op0, NewDiv);
+      }
+    }
+    if (match(Op1, m_OneUse(m_Select(m_Value(Cond), m_Value(DivY), m_One())))) {
+      bool Ok = IsSigned ? (match(DivY, m_APInt(C)) && !C->isZero() &&
+                            !C->isAllOnes())
+                         : isKnownNonZero(DivY, SQ.getWithInstruction(&I));
+      if (Ok) {
+        Value *Divisor = IsSigned ? ConstantInt::get(Ty, *C) : DivY;
+        Value *NewDiv = Builder.CreateBinOp(I.getOpcode(), Op0, Divisor);
+        if (auto *NewDivInst = dyn_cast<BinaryOperator>(NewDiv))
+          NewDivInst->setIsExact(I.isExact());
+        return createSelectInstWithUnknownProfile(Cond, NewDiv, Op0);
+      }
+    }
+  }
+
   // (X * Y) / (X * Z) --> Y / Z (and commuted variants)
   if (match(Op0, m_Mul(m_Value(X), m_Value(Y)))) {
     auto OB0HasNSW = cast<OverflowingBinaryOperator>(Op0)->hasNoSignedWrap();

--- a/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
@@ -1521,21 +1521,19 @@ Instruction *InstCombinerImpl::commonIDivTransforms(BinaryOperator &I) {
       return isKnownNonZero(V, SQ.getWithInstruction(&I)) &&
              isGuaranteedNotToBePoison(V, SQ.AC, &I, SQ.DT);
     };
-    if (match(Op1, m_OneUse(m_Select(m_Value(Cond), m_One(), m_Value(DivY))))) {
-      if (IsSafeDivisor(DivY)) {
-        Value *NewDiv =
-            Builder.CreateExactBinOp(I.getOpcode(), Op0, DivY, I.isExact());
-        return SelectInst::Create(Cond, Op0, NewDiv, "", nullptr,
-                                  cast<SelectInst>(Op1));
-      }
+    if (match(Op1, m_OneUse(m_Select(m_Value(Cond), m_One(), m_Value(DivY)))) &&
+        IsSafeDivisor(DivY)) {
+      Value *NewDiv =
+          Builder.CreateExactBinOp(I.getOpcode(), Op0, DivY, I.isExact());
+      return SelectInst::Create(Cond, Op0, NewDiv, "", nullptr,
+                                cast<SelectInst>(Op1));
     }
-    if (match(Op1, m_OneUse(m_Select(m_Value(Cond), m_Value(DivY), m_One())))) {
-      if (IsSafeDivisor(DivY)) {
-        Value *NewDiv =
-            Builder.CreateExactBinOp(I.getOpcode(), Op0, DivY, I.isExact());
-        return SelectInst::Create(Cond, NewDiv, Op0, "", nullptr,
-                                  cast<SelectInst>(Op1));
-      }
+    if (match(Op1, m_OneUse(m_Select(m_Value(Cond), m_Value(DivY), m_One()))) &&
+        IsSafeDivisor(DivY)) {
+      Value *NewDiv =
+          Builder.CreateExactBinOp(I.getOpcode(), Op0, DivY, I.isExact());
+      return SelectInst::Create(Cond, NewDiv, Op0, "", nullptr,
+                                cast<SelectInst>(Op1));
     }
   }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
@@ -1515,28 +1515,26 @@ Instruction *InstCombinerImpl::commonIDivTransforms(BinaryOperator &I) {
   {
     Value *Cond, *DivY;
     const APInt *C;
+    auto IsSafeDivisor = [&](Value *V) {
+      if (IsSigned)
+        return match(V, m_APInt(C)) && !C->isZero() && !C->isAllOnes();
+      return isKnownNonZero(V, SQ.getWithInstruction(&I)) &&
+             isGuaranteedNotToBePoison(V, SQ.AC, &I, SQ.DT);
+    };
     if (match(Op1, m_OneUse(m_Select(m_Value(Cond), m_One(), m_Value(DivY))))) {
-      bool Ok = IsSigned ? (match(DivY, m_APInt(C)) && !C->isZero() &&
-                            !C->isAllOnes())
-                         : isKnownNonZero(DivY, SQ.getWithInstruction(&I));
-      if (Ok) {
+      if (IsSafeDivisor(DivY)) {
         Value *NewDiv =
             Builder.CreateExactBinOp(I.getOpcode(), Op0, DivY, I.isExact());
-        SelectInst *SI =
-            ProfcheckDisableMetadataFixes ? nullptr : cast<SelectInst>(Op1);
-        return SelectInst::Create(Cond, Op0, NewDiv, "", nullptr, SI);
+        return SelectInst::Create(Cond, Op0, NewDiv, "", nullptr,
+                                  cast<SelectInst>(Op1));
       }
     }
     if (match(Op1, m_OneUse(m_Select(m_Value(Cond), m_Value(DivY), m_One())))) {
-      bool Ok = IsSigned ? (match(DivY, m_APInt(C)) && !C->isZero() &&
-                            !C->isAllOnes())
-                         : isKnownNonZero(DivY, SQ.getWithInstruction(&I));
-      if (Ok) {
+      if (IsSafeDivisor(DivY)) {
         Value *NewDiv =
             Builder.CreateExactBinOp(I.getOpcode(), Op0, DivY, I.isExact());
-        SelectInst *SI =
-            ProfcheckDisableMetadataFixes ? nullptr : cast<SelectInst>(Op1);
-        return SelectInst::Create(Cond, NewDiv, Op0, "", nullptr, SI);
+        return SelectInst::Create(Cond, NewDiv, Op0, "", nullptr,
+                                  cast<SelectInst>(Op1));
       }
     }
   }

--- a/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
@@ -1520,11 +1520,11 @@ Instruction *InstCombinerImpl::commonIDivTransforms(BinaryOperator &I) {
                             !C->isAllOnes())
                          : isKnownNonZero(DivY, SQ.getWithInstruction(&I));
       if (Ok) {
-        Value *Divisor = IsSigned ? ConstantInt::get(Ty, *C) : DivY;
-        Value *NewDiv = Builder.CreateBinOp(I.getOpcode(), Op0, Divisor);
-        if (auto *NewDivInst = dyn_cast<BinaryOperator>(NewDiv))
-          NewDivInst->setIsExact(I.isExact());
-        return createSelectInstWithUnknownProfile(Cond, Op0, NewDiv);
+        Value *NewDiv =
+            Builder.CreateExactBinOp(I.getOpcode(), Op0, DivY, I.isExact());
+        SelectInst *SI =
+            ProfcheckDisableMetadataFixes ? nullptr : cast<SelectInst>(Op1);
+        return SelectInst::Create(Cond, Op0, NewDiv, "", nullptr, SI);
       }
     }
     if (match(Op1, m_OneUse(m_Select(m_Value(Cond), m_Value(DivY), m_One())))) {
@@ -1532,11 +1532,11 @@ Instruction *InstCombinerImpl::commonIDivTransforms(BinaryOperator &I) {
                             !C->isAllOnes())
                          : isKnownNonZero(DivY, SQ.getWithInstruction(&I));
       if (Ok) {
-        Value *Divisor = IsSigned ? ConstantInt::get(Ty, *C) : DivY;
-        Value *NewDiv = Builder.CreateBinOp(I.getOpcode(), Op0, Divisor);
-        if (auto *NewDivInst = dyn_cast<BinaryOperator>(NewDiv))
-          NewDivInst->setIsExact(I.isExact());
-        return createSelectInstWithUnknownProfile(Cond, NewDiv, Op0);
+        Value *NewDiv =
+            Builder.CreateExactBinOp(I.getOpcode(), Op0, DivY, I.isExact());
+        SelectInst *SI =
+            ProfcheckDisableMetadataFixes ? nullptr : cast<SelectInst>(Op1);
+        return SelectInst::Create(Cond, NewDiv, Op0, "", nullptr, SI);
       }
     }
   }

--- a/llvm/test/Transforms/InstCombine/div.ll
+++ b/llvm/test/Transforms/InstCombine/div.ll
@@ -1869,6 +1869,101 @@ define i32 @udiv_and_shl(i32 %a, i32 %b, i32 %c) {
   ret i32 %div
 }
 
+; sdiv X, (select Cond, 1, C) --> select Cond, X, (sdiv X, C)
+
+define i32 @sdiv_select_one_false(i32 %a, i1 %b) {
+; CHECK-LABEL: @sdiv_select_one_false(
+; CHECK-NEXT:    [[TMP1:%.*]] = sdiv i32 [[A:%.*]], 2
+; CHECK-NEXT:    [[DIV:%.*]] = select i1 [[B:%.*]], i32 [[A]], i32 [[TMP1]]
+; CHECK-NEXT:    ret i32 [[DIV]]
+;
+  %sub = select i1 %b, i32 1, i32 2
+  %div = sdiv i32 %a, %sub
+  ret i32 %div
+}
+
+; sdiv X, (select Cond, C, 1) --> select Cond, (sdiv X, C), X
+
+define i32 @sdiv_select_one_true(i32 %a, i1 %b) {
+; CHECK-LABEL: @sdiv_select_one_true(
+; CHECK-NEXT:    [[TMP1:%.*]] = sdiv i32 [[A:%.*]], 2
+; CHECK-NEXT:    [[DIV:%.*]] = select i1 [[B:%.*]], i32 [[TMP1]], i32 [[A]]
+; CHECK-NEXT:    ret i32 [[DIV]]
+;
+  %sub = select i1 %b, i32 2, i32 1
+  %div = sdiv i32 %a, %sub
+  ret i32 %div
+}
+
+; udiv X, (select Cond, 1, C) --> select Cond, X, (udiv X, C)
+
+define i32 @udiv_select_one_false(i32 %a, i1 %b) {
+; CHECK-LABEL: @udiv_select_one_false(
+; CHECK-NEXT:    [[TMP1:%.*]] = udiv i32 [[A:%.*]], 3
+; CHECK-NEXT:    [[DIV:%.*]] = select i1 [[B:%.*]], i32 [[A]], i32 [[TMP1]]
+; CHECK-NEXT:    ret i32 [[DIV]]
+;
+  %sub = select i1 %b, i32 1, i32 3
+  %div = udiv i32 %a, %sub
+  ret i32 %div
+}
+
+; udiv X, (select Cond, 1, Y) --> select Cond, X, (udiv X, Y) for known-non-zero variable
+
+define i32 @udiv_select_one_false_nonnull_var(i32 %a, i1 %b, i32 %y) {
+; CHECK-LABEL: @udiv_select_one_false_nonnull_var(
+; CHECK-NEXT:    [[YNZ:%.*]] = add nuw i32 [[Y:%.*]], 1
+; CHECK-NEXT:    [[TMP1:%.*]] = udiv i32 [[A:%.*]], [[YNZ]]
+; CHECK-NEXT:    [[DIV:%.*]] = select i1 [[B:%.*]], i32 [[A]], i32 [[TMP1]]
+; CHECK-NEXT:    ret i32 [[DIV]]
+;
+  %ynz = add nuw i32 %y, 1
+  %sub = select i1 %b, i32 1, i32 %ynz
+  %div = udiv i32 %a, %sub
+  ret i32 %div
+}
+
+; negative test - select has multiple uses, not profitable to duplicate div
+
+define i32 @sdiv_select_one_multiuse(i32 %a, i1 %b) {
+; CHECK-LABEL: @sdiv_select_one_multiuse(
+; CHECK-NEXT:    [[SUB:%.*]] = select i1 [[B:%.*]], i32 1, i32 2
+; CHECK-NEXT:    call void @use(i32 [[SUB]])
+; CHECK-NEXT:    [[DIV:%.*]] = sdiv i32 [[A:%.*]], [[SUB]]
+; CHECK-NEXT:    ret i32 [[DIV]]
+;
+  %sub = select i1 %b, i32 1, i32 2
+  call void @use(i32 %sub)
+  %div = sdiv i32 %a, %sub
+  ret i32 %div
+}
+
+; negative test - variable divisor (not a constant), does not apply
+
+define i32 @sdiv_select_one_false_var(i32 %a, i1 %b, i32 %y) {
+; CHECK-LABEL: @sdiv_select_one_false_var(
+; CHECK-NEXT:    [[SUB:%.*]] = select i1 [[B:%.*]], i32 1, i32 [[Y:%.*]]
+; CHECK-NEXT:    [[DIV:%.*]] = sdiv i32 [[A:%.*]], [[SUB]]
+; CHECK-NEXT:    ret i32 [[DIV]]
+;
+  %sub = select i1 %b, i32 1, i32 %y
+  %div = sdiv i32 %a, %sub
+  ret i32 %div
+}
+
+; negative test - divisor is -1: sdiv INT_MIN, -1 is UB, must not hoist
+
+define i32 @sdiv_select_one_false_neg1(i32 %a, i1 %b) {
+; CHECK-LABEL: @sdiv_select_one_false_neg1(
+; CHECK-NEXT:    [[SUB:%.*]] = select i1 [[B:%.*]], i32 1, i32 -1
+; CHECK-NEXT:    [[DIV:%.*]] = sdiv i32 [[A:%.*]], [[SUB]]
+; CHECK-NEXT:    ret i32 [[DIV]]
+;
+  %sub = select i1 %b, i32 1, i32 -1
+  %div = sdiv i32 %a, %sub
+  ret i32 %div
+}
+
 !0 = !{!"function_entry_count", i64 1000}
 ;.
 ; CHECK: [[META0:![0-9]+]] = !{!"function_entry_count", i64 1000}

--- a/llvm/test/Transforms/InstCombine/div.ll
+++ b/llvm/test/Transforms/InstCombine/div.ll
@@ -1908,17 +1908,17 @@ define i32 @udiv_select_one_false(i32 %a, i1 %b) {
   ret i32 %div
 }
 
-; udiv X, (select Cond, 1, Y) --> select Cond, X, (udiv X, Y) for known-non-zero variable
+; udiv X, (select Cond, 1, Y) --> select Cond, X, (udiv X, Y) for known-non-zero, non-poison variable
 
-define i32 @udiv_select_one_false_nonnull_var(i32 %a, i1 %b, i32 %y) {
+define i32 @udiv_select_one_false_nonnull_var(i32 %a, i1 %b, i32 noundef %y) {
 ; CHECK-LABEL: @udiv_select_one_false_nonnull_var(
-; CHECK-NEXT:    [[YNZ:%.*]] = add nuw i32 [[Y:%.*]], 1
-; CHECK-NEXT:    [[TMP1:%.*]] = udiv i32 [[A:%.*]], [[YNZ]]
+; CHECK-NEXT:    [[YOR1:%.*]] = or i32 [[Y:%.*]], 1
+; CHECK-NEXT:    [[TMP1:%.*]] = udiv i32 [[A:%.*]], [[YOR1]]
 ; CHECK-NEXT:    [[DIV:%.*]] = select i1 [[B:%.*]], i32 [[A]], i32 [[TMP1]]
 ; CHECK-NEXT:    ret i32 [[DIV]]
 ;
-  %ynz = add nuw i32 %y, 1
-  %sub = select i1 %b, i32 1, i32 %ynz
+  %yor1 = or i32 %y, 1
+  %sub = select i1 %b, i32 1, i32 %yor1
   %div = udiv i32 %a, %sub
   ret i32 %div
 }
@@ -1990,17 +1990,17 @@ define <2 x i32> @sdiv_select_one_true_vec(<2 x i32> %a, i1 %b) {
   ret <2 x i32> %div
 }
 
-; udiv X, (select Cond, 1, Y) --> select Cond, X, (udiv X, Y) for known-non-zero variable -- vector splat
+; udiv X, (select Cond, 1, Y) --> select Cond, X, (udiv X, Y) for known-non-zero, non-poison variable -- vector splat
 
-define <2 x i32> @udiv_select_one_false_nonnull_var_vec(<2 x i32> %a, i1 %b, <2 x i32> %y) {
+define <2 x i32> @udiv_select_one_false_nonnull_var_vec(<2 x i32> %a, i1 %b, <2 x i32> noundef %y) {
 ; CHECK-LABEL: @udiv_select_one_false_nonnull_var_vec(
-; CHECK-NEXT:    [[YNZ:%.*]] = add nuw <2 x i32> [[Y:%.*]], splat (i32 1)
-; CHECK-NEXT:    [[TMP1:%.*]] = udiv <2 x i32> [[A:%.*]], [[YNZ]]
+; CHECK-NEXT:    [[YOR1:%.*]] = or <2 x i32> [[Y:%.*]], splat (i32 1)
+; CHECK-NEXT:    [[TMP1:%.*]] = udiv <2 x i32> [[A:%.*]], [[YOR1]]
 ; CHECK-NEXT:    [[DIV:%.*]] = select i1 [[B:%.*]], <2 x i32> [[A]], <2 x i32> [[TMP1]]
 ; CHECK-NEXT:    ret <2 x i32> [[DIV]]
 ;
-  %ynz = add nuw <2 x i32> %y, <i32 1, i32 1>
-  %sub = select i1 %b, <2 x i32> <i32 1, i32 1>, <2 x i32> %ynz
+  %yor1 = or <2 x i32> %y, <i32 1, i32 1>
+  %sub = select i1 %b, <2 x i32> <i32 1, i32 1>, <2 x i32> %yor1
   %div = udiv <2 x i32> %a, %sub
   ret <2 x i32> %div
 }

--- a/llvm/test/Transforms/InstCombine/div.ll
+++ b/llvm/test/Transforms/InstCombine/div.ll
@@ -1912,13 +1912,28 @@ define i32 @udiv_select_one_false(i32 %a, i1 %b) {
 
 define i32 @udiv_select_one_false_nonnull_var(i32 %a, i1 %b, i32 noundef %y) {
 ; CHECK-LABEL: @udiv_select_one_false_nonnull_var(
-; CHECK-NEXT:    [[YOR1:%.*]] = or i32 [[Y:%.*]], 1
-; CHECK-NEXT:    [[TMP1:%.*]] = udiv i32 [[A:%.*]], [[YOR1]]
+; CHECK-NEXT:    [[YNZ:%.*]] = or i32 [[Y:%.*]], 1
+; CHECK-NEXT:    [[TMP1:%.*]] = udiv i32 [[A:%.*]], [[YNZ]]
 ; CHECK-NEXT:    [[DIV:%.*]] = select i1 [[B:%.*]], i32 [[A]], i32 [[TMP1]]
 ; CHECK-NEXT:    ret i32 [[DIV]]
 ;
   %yor1 = or i32 %y, 1
   %sub = select i1 %b, i32 1, i32 %yor1
+  %div = udiv i32 %a, %sub
+  ret i32 %div
+}
+
+; negative test - divisor is known-non-zero but maybe poison
+
+define i32 @udiv_select_one_false_nonnull_poison_var(i32 %a, i1 %b, i32 %y) {
+; CHECK-LABEL: @udiv_select_one_false_nonnull_poison_var(
+; CHECK-NEXT:    [[YNZ:%.*]] = add nuw i32 [[Y:%.*]], 1
+; CHECK-NEXT:    [[SUB:%.*]] = select i1 [[B:%.*]], i32 1, i32 [[YNZ]]
+; CHECK-NEXT:    [[DIV:%.*]] = udiv i32 [[A:%.*]], [[SUB]]
+; CHECK-NEXT:    ret i32 [[DIV]]
+;
+  %ynz = add nuw i32 %y, 1
+  %sub = select i1 %b, i32 1, i32 %ynz
   %div = udiv i32 %a, %sub
   ret i32 %div
 }
@@ -2002,6 +2017,19 @@ define <2 x i32> @udiv_select_one_false_nonnull_var_vec(<2 x i32> %a, i1 %b, <2 
   %yor1 = or <2 x i32> %y, <i32 1, i32 1>
   %sub = select i1 %b, <2 x i32> <i32 1, i32 1>, <2 x i32> %yor1
   %div = udiv <2 x i32> %a, %sub
+  ret <2 x i32> %div
+}
+
+; negative test - divisor has poison
+
+define <2 x i32> @sdiv_select_one_false_poison_vec(<2 x i32> %a, i1 %b) {
+; CHECK-LABEL: @sdiv_select_one_false_poison_vec(
+; CHECK-NEXT:    [[SUB:%.*]] = select i1 [[B:%.*]], <2 x i32> splat (i32 1), <2 x i32> <i32 2, i32 poison>
+; CHECK-NEXT:    [[DIV:%.*]] = sdiv <2 x i32> [[A:%.*]], [[SUB]]
+; CHECK-NEXT:    ret <2 x i32> [[DIV]]
+;
+  %sub = select i1 %b, <2 x i32> <i32 1, i32 1>, <2 x i32> <i32 2, i32 poison>
+  %div = sdiv <2 x i32> %a, %sub
   ret <2 x i32> %div
 }
 

--- a/llvm/test/Transforms/InstCombine/div.ll
+++ b/llvm/test/Transforms/InstCombine/div.ll
@@ -1964,6 +1964,47 @@ define i32 @sdiv_select_one_false_neg1(i32 %a, i1 %b) {
   ret i32 %div
 }
 
+; sdiv X, (select Cond, 1, C) --> select Cond, X, (sdiv X, C) -- vector splat
+
+define <2 x i32> @sdiv_select_one_false_vec(<2 x i32> %a, i1 %b) {
+; CHECK-LABEL: @sdiv_select_one_false_vec(
+; CHECK-NEXT:    [[TMP1:%.*]] = sdiv <2 x i32> [[A:%.*]], splat (i32 2)
+; CHECK-NEXT:    [[DIV:%.*]] = select i1 [[B:%.*]], <2 x i32> [[A]], <2 x i32> [[TMP1]]
+; CHECK-NEXT:    ret <2 x i32> [[DIV]]
+;
+  %sub = select i1 %b, <2 x i32> <i32 1, i32 1>, <2 x i32> <i32 2, i32 2>
+  %div = sdiv <2 x i32> %a, %sub
+  ret <2 x i32> %div
+}
+
+; sdiv X, (select Cond, C, 1) --> select Cond, (sdiv X, C), X -- vector splat
+
+define <2 x i32> @sdiv_select_one_true_vec(<2 x i32> %a, i1 %b) {
+; CHECK-LABEL: @sdiv_select_one_true_vec(
+; CHECK-NEXT:    [[TMP1:%.*]] = sdiv <2 x i32> [[A:%.*]], splat (i32 2)
+; CHECK-NEXT:    [[DIV:%.*]] = select i1 [[B:%.*]], <2 x i32> [[TMP1]], <2 x i32> [[A]]
+; CHECK-NEXT:    ret <2 x i32> [[DIV]]
+;
+  %sub = select i1 %b, <2 x i32> <i32 2, i32 2>, <2 x i32> <i32 1, i32 1>
+  %div = sdiv <2 x i32> %a, %sub
+  ret <2 x i32> %div
+}
+
+; udiv X, (select Cond, 1, Y) --> select Cond, X, (udiv X, Y) for known-non-zero variable -- vector splat
+
+define <2 x i32> @udiv_select_one_false_nonnull_var_vec(<2 x i32> %a, i1 %b, <2 x i32> %y) {
+; CHECK-LABEL: @udiv_select_one_false_nonnull_var_vec(
+; CHECK-NEXT:    [[YNZ:%.*]] = add nuw <2 x i32> [[Y:%.*]], splat (i32 1)
+; CHECK-NEXT:    [[TMP1:%.*]] = udiv <2 x i32> [[A:%.*]], [[YNZ]]
+; CHECK-NEXT:    [[DIV:%.*]] = select i1 [[B:%.*]], <2 x i32> [[A]], <2 x i32> [[TMP1]]
+; CHECK-NEXT:    ret <2 x i32> [[DIV]]
+;
+  %ynz = add nuw <2 x i32> %y, <i32 1, i32 1>
+  %sub = select i1 %b, <2 x i32> <i32 1, i32 1>, <2 x i32> %ynz
+  %div = udiv <2 x i32> %a, %sub
+  ret <2 x i32> %div
+}
+
 !0 = !{!"function_entry_count", i64 1000}
 ;.
 ; CHECK: [[META0:![0-9]+]] = !{!"function_entry_count", i64 1000}


### PR DESCRIPTION
And the divisor is neither 0 nor poison. For sdiv, limit divisor to constant to avoid signed overflow concern.

Verified by alive tool: https://alive2.llvm.org/ce/z/ao3ffi

Assisted-by: Claude Sonnet 4.6