### PR TITLE
[BOLT] Fix heatmap with external addresses

### DIFF
--- a/bolt/lib/Profile/Heatmap.cpp
+++ b/bolt/lib/Profile/Heatmap.cpp
@@ -116,7 +116,7 @@ void Heatmap::print(raw_ostream &OS) const {
 
     changeColor(DefaultColor);
     finishLine(Start);
-    Start = alignTo(Start, BytesPerLine);
+    Start = alignTo(Start + BucketSize, BytesPerLine);
 
     uint64_t NumEmptyLines = (End - Start) / BytesPerLine;
 
@@ -216,6 +216,7 @@ void Heatmap::print(raw_ostream &OS) const {
 
   auto SectionStart = TextSections.begin();
   uint64_t PrevAddress = 0;
+  bool IsFirst = true;
   for (auto MI = Map.begin(), ME = Map.end(); MI != ME; ++MI) {
     const std::pair<const uint64_t, uint64_t> &Entry = *MI;
     uint64_t Address = Entry.first * BucketSize;
@@ -233,17 +234,18 @@ void Heatmap::print(raw_ostream &OS) const {
       Character = 'a' + ((Section - TextSections.begin()) % 26);
     }
 
-    if (PrevAddress)
-      fillRange(PrevAddress, Address);
-    else
+    if (IsFirst)
       startLine(Address);
+    else
+      fillRange(PrevAddress, Address);
 
     printValue(Entry.second, Character, /*ResetColor=*/false);
 
     PrevAddress = Address;
+    IsFirst = false;
   }
 
-  if (PrevAddress) {
+  if (!IsFirst) {
     changeColor(DefaultColor);
     finishLine(PrevAddress);
   }

--- a/bolt/test/X86/heatmap-preagg.test
+++ b/bolt/test/X86/heatmap-preagg.test
@@ -11,6 +11,11 @@ RUN: FileCheck %s --check-prefix CHECK-HM-64 --input-file %t
 RUN: FileCheck %s --check-prefix CHECK-HM-128 --input-file %t-128
 RUN: FileCheck %s --check-prefix CHECK-HM-1024 --input-file %t-1024
 
+RUN: split-file %s %t.inputs
+RUN: llvm-bolt-heatmap %t.exe -o %t.ext --pa \
+RUN:   -p %t.inputs/external.preagg --block-size=4096 --line-size=64
+RUN: FileCheck %s --check-prefix CHECK-HM-EXTERNAL --input-file %t.ext
+
 ## BOLTed input binary
 RUN: llvm-bolt %t.exe -o %t.out --pa -p %p/Inputs/blarge_new.preagg.txt \
 RUN:   --reorder-blocks=ext-tsp --split-functions --split-strategy=cdsplit \
@@ -68,6 +73,10 @@ CHECK-HM-1024-NEXT: 048c048c048c048c048c048c048c048c048c048c048c048c048c048c048c
 CHECK-HM-1024-NEXT: 0
 CHECK-HM-1024-NEXT: 0
 
+CHECK-HM-EXTERNAL: 0x00000000: o...............................................................
+CHECK-HM-EXTERNAL-NOT: 0x00000000:
+CHECK-HM-EXTERNAL: 0x00400000: .
+
 CHECK-BAT-HM-64: (349, 1126]
 CHECK-BAT-HM-4K: (605, 2182]
 
@@ -89,3 +98,7 @@ CHECK-SEC-HOT-BAT-NEXT: .text.cold, 0x800300, 0x800415, 0.0000, 0.0000, 0.0000
 CHECK-SEC-HOT-BAT-NEXT: [hot text], 0x800000, 0x8002cc, 38.7595, 91.6667, 0.3553
 CHECK-HOT-SYMS: 800000 W __hot_start
 CHECK-HOT-SYMS: 8002cc W __hot_end
+
+#--- external.preagg
+S X:0 1
+S 401000 6


### PR DESCRIPTION
External samples (X:0) were breaking heatmap printing, e.g.
```
  0x00000000: O0x00000000: ........
```
Explicitly track `IsFirst` instead of relying on zero.

Test Plan:
updated heatmap-preagg.test
