### PR TITLE
[lldb][Windows] Use uint64 for GetExceptionArguments

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/ExceptionRecord.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ExceptionRecord.cpp
@@ -56,7 +56,7 @@ void lldb_private::ExceptionRecord::Dump(llvm::raw_ostream &stream) const {
 
   const int addr_min_width = 2 + 8; // "0x" + 4 address bytes
 
-  const llvm::ArrayRef<unsigned long long> args = GetExceptionArguments();
+  const llvm::ArrayRef<uint64_t> args = GetExceptionArguments();
   switch (GetExceptionValue()) {
   case EXCEPTION_ACCESS_VIOLATION: {
     if (args.size() < 2)

--- a/lldb/source/Plugins/Process/Windows/Common/ExceptionRecord.h
+++ b/lldb/source/Plugins/Process/Windows/Common/ExceptionRecord.h
@@ -44,9 +44,7 @@ public:
 
   lldb::tid_t GetThreadID() const { return m_thread_id; }
 
-  llvm::ArrayRef<unsigned long long> GetExceptionArguments() const {
-    return m_arguments;
-  }
+  llvm::ArrayRef<uint64_t> GetExceptionArguments() const { return m_arguments; }
 
   void Dump(llvm::raw_ostream &stream) const;
 
@@ -55,7 +53,7 @@ private:
   bool m_continuable;
   lldb::addr_t m_exception_addr;
   lldb::tid_t m_thread_id;
-  std::vector<unsigned long long> m_arguments;
+  std::vector<uint64_t> m_arguments;
 };
 }
 

--- a/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.cpp
@@ -538,7 +538,7 @@ NativeProcessWindows::HandleBreakpointException(const ExceptionRecord &record) {
     // This block of code will only be entered in case of a hardware
     // watchpoint or breakpoint hit on AArch64. However, we only handle
     // hardware watchpoints below as breakpoints are not yet supported.
-    const std::vector<ULONG_PTR> &args = record.GetExceptionArguments();
+    const ArrayRef<uint64_t> args = record.GetExceptionArguments();
     // Check that the ExceptionInformation array of EXCEPTION_RECORD
     // contains at least two elements: the first is a read-write flag
     // indicating the type of data access operation (read or write) while


### PR DESCRIPTION
Intended to fix the build failure mentioned in https://github.com/llvm/llvm-project/pull/203301#issuecomment-4688315446.

Makes sure we always use a 64 bit int, as the minidump exception record specifies the arguments to be 64 bit. `unsigned long long` is also 64 bit on Windows, but I think `uint64_t` conveys that we actually want a 64bit int.
Then updates uses of the return value to use `uint64_t` over `ULONG_PTR`.