### PR TITLE
[lldb][Windows] Fix "Invalid register name" for eax on x86_64 attach

### DIFF
--- a/lldb/source/Plugins/ABI/X86/ABIX86.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABIX86.cpp
@@ -205,11 +205,10 @@ void ABIX86::AugmentRegisterInfo(
   if (!process_sp)
     return;
 
-  uint32_t gpr_base_size =
-      process_sp->GetTarget().GetArchitecture().GetAddressByteSize();
+  uint32_t gpr_base_size = Is64Bit() ? 8 : 4;
 
   // primary map from a base register to its subregisters
-  BaseRegToRegsMap base_reg_map = makeBaseRegMap(gpr_base_size == 8);
+  BaseRegToRegsMap base_reg_map = makeBaseRegMap(Is64Bit());
   // set used for fast matching of register names to subregisters
   llvm::SmallDenseSet<llvm::StringRef, 64> subreg_name_set;
   // convenience array providing access to all subregisters of given kind,

--- a/lldb/source/Plugins/ABI/X86/ABIX86.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABIX86.cpp
@@ -207,14 +207,9 @@ void ABIX86::AugmentRegisterInfo(
 
   uint32_t gpr_base_size =
       process_sp->GetTarget().GetArchitecture().GetAddressByteSize();
-  // Determine the GPR base size. Prefer the target architecture, but fall
-  // back to the register list itself when the target arch isn't set yet
-  bool is64bit = gpr_base_size == 8 || (gpr_base_size == 0 && Is64Bit());
-  if (gpr_base_size == 0)
-    gpr_base_size = is64bit ? 8 : 4;
 
   // primary map from a base register to its subregisters
-  BaseRegToRegsMap base_reg_map = makeBaseRegMap(is64bit);
+  BaseRegToRegsMap base_reg_map = makeBaseRegMap(gpr_base_size == 8);
   // set used for fast matching of register names to subregisters
   llvm::SmallDenseSet<llvm::StringRef, 64> subreg_name_set;
   // convenience array providing access to all subregisters of given kind,

--- a/lldb/source/Plugins/ABI/X86/ABIX86.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABIX86.cpp
@@ -209,21 +209,12 @@ void ABIX86::AugmentRegisterInfo(
       process_sp->GetTarget().GetArchitecture().GetAddressByteSize();
   // Determine the GPR base size. Prefer the target architecture, but fall
   // back to the register list itself when the target arch isn't set yet
-  if (gpr_base_size == 0) {
-    for (const auto &reg : regs) {
-      if (reg.name == "rax" || reg.name == "rsp" || reg.name == "rip") {
-        gpr_base_size = 8;
-        break;
-      }
-      if (reg.name == "eax" || reg.name == "esp" || reg.name == "eip") {
-        gpr_base_size = 4;
-        break;
-      }
-    }
-  }
+  bool is64bit = gpr_base_size == 8 || (gpr_base_size == 0 && Is64Bit());
+  if (gpr_base_size == 0)
+    gpr_base_size = is64bit ? 8 : 4;
 
   // primary map from a base register to its subregisters
-  BaseRegToRegsMap base_reg_map = makeBaseRegMap(gpr_base_size == 8);
+  BaseRegToRegsMap base_reg_map = makeBaseRegMap(is64bit);
   // set used for fast matching of register names to subregisters
   llvm::SmallDenseSet<llvm::StringRef, 64> subreg_name_set;
   // convenience array providing access to all subregisters of given kind,

--- a/lldb/source/Plugins/ABI/X86/ABIX86.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABIX86.cpp
@@ -207,6 +207,20 @@ void ABIX86::AugmentRegisterInfo(
 
   uint32_t gpr_base_size =
       process_sp->GetTarget().GetArchitecture().GetAddressByteSize();
+  // Determine the GPR base size. Prefer the target architecture, but fall
+  // back to the register list itself when the target arch isn't set yet
+  if (gpr_base_size == 0) {
+    for (const auto &reg : regs) {
+      if (reg.name == "rax" || reg.name == "rsp" || reg.name == "rip") {
+        gpr_base_size = 8;
+        break;
+      }
+      if (reg.name == "eax" || reg.name == "esp" || reg.name == "eip") {
+        gpr_base_size = 4;
+        break;
+      }
+    }
+  }
 
   // primary map from a base register to its subregisters
   BaseRegToRegsMap base_reg_map = makeBaseRegMap(gpr_base_size == 8);

--- a/lldb/source/Plugins/ABI/X86/ABIX86.h
+++ b/lldb/source/Plugins/ABI/X86/ABIX86.h
@@ -21,6 +21,8 @@ protected:
   void AugmentRegisterInfo(
       std::vector<lldb_private::DynamicRegisterInfo::Register> &regs) override;
 
+  virtual bool Is64Bit() const = 0;
+
 private:
   using lldb_private::MCBasedABI::MCBasedABI;
 };

--- a/lldb/source/Plugins/ABI/X86/ABIX86.h
+++ b/lldb/source/Plugins/ABI/X86/ABIX86.h
@@ -21,8 +21,6 @@ protected:
   void AugmentRegisterInfo(
       std::vector<lldb_private::DynamicRegisterInfo::Register> &regs) override;
 
-  virtual bool Is64Bit() const = 0;
-
 private:
   using lldb_private::MCBasedABI::MCBasedABI;
 };

--- a/lldb/source/Plugins/ABI/X86/ABIX86_64.h
+++ b/lldb/source/Plugins/ABI/X86/ABIX86_64.h
@@ -18,6 +18,8 @@ protected:
     return name;
   }
 
+  bool Is64Bit() const override { return true; }
+
 private:
   using ABIX86::ABIX86;
 };

--- a/lldb/source/Plugins/ABI/X86/ABIX86_64.h
+++ b/lldb/source/Plugins/ABI/X86/ABIX86_64.h
@@ -18,8 +18,6 @@ protected:
     return name;
   }
 
-  bool Is64Bit() const override { return true; }
-
 private:
   using ABIX86::ABIX86;
 };

--- a/lldb/source/Plugins/ABI/X86/ABIX86_i386.h
+++ b/lldb/source/Plugins/ABI/X86/ABIX86_i386.h
@@ -15,6 +15,9 @@ class ABIX86_i386 : public ABIX86 {
 public:
   uint32_t GetGenericNum(llvm::StringRef name) override;
 
+protected:
+  bool Is64Bit() const override { return false; }
+
 private:
   using ABIX86::ABIX86;
 };

--- a/lldb/source/Plugins/ABI/X86/ABIX86_i386.h
+++ b/lldb/source/Plugins/ABI/X86/ABIX86_i386.h
@@ -15,9 +15,6 @@ class ABIX86_i386 : public ABIX86 {
 public:
   uint32_t GetGenericNum(llvm::StringRef name) override;
 
-protected:
-  bool Is64Bit() const override { return false; }
-
 private:
   using ABIX86::ABIX86;
 };

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -5505,6 +5505,9 @@ void ProcessGDBRemote::AddRemoteRegisters(
                     remote_reg_info.invalidate_regs.begin(), proc_to_lldb);
   }
 
+  if (!GetTarget().GetArchitecture().IsValid() && arch_to_use.IsValid())
+    GetTarget().SetArchitecture(arch_to_use);
+
   // Don't use Process::GetABI, this code gets called from DidAttach, and
   // in that context we haven't set the Target's architecture yet, so the
   // ABI is also potentially incorrect.

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -1002,7 +1002,6 @@ Status ProcessGDBRemote::ConnectToDebugserver(llvm::StringRef connect_url) {
 
 void ProcessGDBRemote::DidLaunchOrAttach(ArchSpec &process_arch) {
   Log *log = GetLog(GDBRLog::Process);
-  BuildDynamicRegisterInfo(false);
 
   // See if the GDB server supports qHostInfo or qProcessInfo packets. Prefer
   // qProcessInfo as it will be more specific to our process.
@@ -1080,6 +1079,8 @@ void ProcessGDBRemote::DidLaunchOrAttach(ArchSpec &process_arch) {
       GetTarget().SetArchitecture(process_arch);
     }
   }
+
+  BuildDynamicRegisterInfo(false);
 
   // Target and Process are reasonably initailized;
   // load any binaries we have metadata for / set load address.
@@ -5504,9 +5505,6 @@ void ProcessGDBRemote::AddRemoteRegisters(
     llvm::transform(remote_reg_info.invalidate_regs,
                     remote_reg_info.invalidate_regs.begin(), proc_to_lldb);
   }
-
-  if (!GetTarget().GetArchitecture().IsValid() && arch_to_use.IsValid())
-    GetTarget().SetArchitecture(arch_to_use);
 
   // Don't use Process::GetABI, this code gets called from DidAttach, and
   // in that context we haven't set the Target's architecture yet, so the

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -1002,6 +1002,7 @@ Status ProcessGDBRemote::ConnectToDebugserver(llvm::StringRef connect_url) {
 
 void ProcessGDBRemote::DidLaunchOrAttach(ArchSpec &process_arch) {
   Log *log = GetLog(GDBRLog::Process);
+  BuildDynamicRegisterInfo(false);
 
   // See if the GDB server supports qHostInfo or qProcessInfo packets. Prefer
   // qProcessInfo as it will be more specific to our process.
@@ -1079,8 +1080,6 @@ void ProcessGDBRemote::DidLaunchOrAttach(ArchSpec &process_arch) {
       GetTarget().SetArchitecture(process_arch);
     }
   }
-
-  BuildDynamicRegisterInfo(false);
 
   // Target and Process are reasonably initailized;
   // load any binaries we have metadata for / set load address.


### PR DESCRIPTION
On Windows, when attaching to a process with no pre-existing target, lldb reports "Invalid register name" for sub-registers like eax.

This is due to a bug in `ABIX86::AugmentRegisterInfo`, which determines the GPR base size by reading `Target::GetArchitecture().GetAddressByteSize()`. During attach, the target's architecture has not yet been set when `AugmentRegisterInfo` runs, so the lookup returns 0, the process is treated as 32-bit, and the x86_64 sub-registers are never added.

This patch removes the dependency on the target's architecture: the X86 ABI plugins already know their own bitness, so `ABIX86_64` and `ABIX86_i386` now report it directly via a new `Is64Bit()` virtual.

This patch fixes `TestRegisters::test_convenience_registers_with_process_attach` and `TestRegisters::test_convenience_registers_16bit_with_process_attach` on Windows using `LLDB_USE_LLDB_SERVER=1`.

rdar://180307995