### PR TITLE
[AMDGPU] Fix copy-paste in hasNon16BitAccesses OpIs16Bit check

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -15070,7 +15070,7 @@ static bool hasNon16BitAccesses(uint64_t PermMask, SDValue &Op,
   auto TempOtherOp = peekThroughBitcasts(OtherOp);
 
   auto OpIs16Bit =
-      TempOtherOp.getValueSizeInBits() == 16 || isExtendedFrom16Bits(TempOp);
+      TempOp.getValueSizeInBits() == 16 || isExtendedFrom16Bits(TempOp);
   if (!OpIs16Bit)
     return true;
 


### PR DESCRIPTION
OpIs16Bit tested TempOtherOp width instead of TempOp, mismatching symmetric OtherOpIs16Bit clause

No observed miscompiles or direct issues to due to that so far