### PR TITLE
[NPM] Make few more passes required

### DIFF
--- a/llvm/include/llvm/Analysis/ModuleSummaryAnalysis.h
+++ b/llvm/include/llvm/Analysis/ModuleSummaryAnalysis.h
@@ -92,6 +92,35 @@ public:
   void getAnalysisUsage(AnalysisUsage &AU) const override;
 };
 
+/// NPM analysis to provide an externally-built ModuleSummaryIndex (e.g. the
+/// combined index from LTO).
+class ImmutableModuleSummaryIndexAnalysis
+    : public AnalysisInfoMixin<ImmutableModuleSummaryIndexAnalysis> {
+  friend AnalysisInfoMixin<ImmutableModuleSummaryIndexAnalysis>;
+  LLVM_ABI static AnalysisKey Key;
+  const ModuleSummaryIndex *Index = nullptr;
+
+public:
+  class Result {
+    const ModuleSummaryIndex *Index;
+    Result(const ModuleSummaryIndex *Index) : Index(Index) {}
+    friend class ImmutableModuleSummaryIndexAnalysis;
+
+  public:
+    const ModuleSummaryIndex *getIndex() const { return Index; }
+    bool invalidate(Module &, const PreservedAnalyses &,
+                    ModuleAnalysisManager::Invalidator &) {
+      return false;
+    }
+  };
+
+  ImmutableModuleSummaryIndexAnalysis() = default;
+  ImmutableModuleSummaryIndexAnalysis(const ModuleSummaryIndex *Index)
+      : Index(Index) {}
+
+  Result run(Module &M, ModuleAnalysisManager &AM) { return Result(Index); }
+};
+
 //===--------------------------------------------------------------------===//
 //
 // ImmutableModuleSummaryIndexWrapperPass - This pass wrap provided

--- a/llvm/include/llvm/Analysis/ModuleSummaryAnalysis.h
+++ b/llvm/include/llvm/Analysis/ModuleSummaryAnalysis.h
@@ -102,7 +102,7 @@ class ImmutableModuleSummaryIndexAnalysis
 
 public:
   class Result {
-    const ModuleSummaryIndex *Index;
+    const ModuleSummaryIndex *Index = nullptr;
     Result(const ModuleSummaryIndex *Index) : Index(Index) {}
     friend class ImmutableModuleSummaryIndexAnalysis;
 

--- a/llvm/include/llvm/CodeGen/MachineBlockPlacement.h
+++ b/llvm/include/llvm/CodeGen/MachineBlockPlacement.h
@@ -14,7 +14,7 @@
 namespace llvm {
 
 class MachineBlockPlacementPass
-    : public RequiredPassInfoMixin<MachineBlockPlacementPass> {
+    : public OptionalPassInfoMixin<MachineBlockPlacementPass> {
 
   bool AllowTailMerge = true;
 

--- a/llvm/include/llvm/CodeGen/RegisterCoalescerPass.h
+++ b/llvm/include/llvm/CodeGen/RegisterCoalescerPass.h
@@ -13,7 +13,7 @@
 
 namespace llvm {
 class RegisterCoalescerPass
-    : public OptionalPassInfoMixin<RegisterCoalescerPass> {
+    : public RequiredPassInfoMixin<RegisterCoalescerPass> {
 public:
   LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
                                  MachineFunctionAnalysisManager &MFAM);

--- a/llvm/include/llvm/CodeGen/RenameIndependentSubregs.h
+++ b/llvm/include/llvm/CodeGen/RenameIndependentSubregs.h
@@ -14,7 +14,7 @@
 namespace llvm {
 
 class RenameIndependentSubregsPass
-    : public OptionalPassInfoMixin<RenameIndependentSubregsPass> {
+    : public RequiredPassInfoMixin<RenameIndependentSubregsPass> {
 public:
   LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
                                  MachineFunctionAnalysisManager &MFAM);

--- a/llvm/include/llvm/CodeGen/TwoAddressInstructionPass.h
+++ b/llvm/include/llvm/CodeGen/TwoAddressInstructionPass.h
@@ -14,7 +14,7 @@
 namespace llvm {
 
 class TwoAddressInstructionPass
-    : public OptionalPassInfoMixin<TwoAddressInstructionPass> {
+    : public RequiredPassInfoMixin<TwoAddressInstructionPass> {
 public:
   LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
                                  MachineFunctionAnalysisManager &MFAM);

--- a/llvm/include/llvm/CodeGen/UnreachableBlockElim.h
+++ b/llvm/include/llvm/CodeGen/UnreachableBlockElim.h
@@ -28,13 +28,13 @@
 namespace llvm {
 
 class UnreachableBlockElimPass
-    : public OptionalPassInfoMixin<UnreachableBlockElimPass> {
+    : public RequiredPassInfoMixin<UnreachableBlockElimPass> {
 public:
   LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 class UnreachableMachineBlockElimPass
-    : public OptionalPassInfoMixin<UnreachableMachineBlockElimPass> {
+    : public RequiredPassInfoMixin<UnreachableMachineBlockElimPass> {
 public:
   LLVM_ABI PreservedAnalyses run(MachineFunction &F,
                                  MachineFunctionAnalysisManager &AM);

--- a/llvm/include/llvm/Transforms/Scalar/StructurizeCFG.h
+++ b/llvm/include/llvm/Transforms/Scalar/StructurizeCFG.h
@@ -12,7 +12,7 @@
 #include "llvm/IR/PassManager.h"
 
 namespace llvm {
-struct StructurizeCFGPass : OptionalPassInfoMixin<StructurizeCFGPass> {
+struct StructurizeCFGPass : RequiredPassInfoMixin<StructurizeCFGPass> {
 private:
   bool SkipUniformRegions;
 

--- a/llvm/include/llvm/Transforms/Utils/UnifyLoopExits.h
+++ b/llvm/include/llvm/Transforms/Utils/UnifyLoopExits.h
@@ -13,7 +13,7 @@
 
 namespace llvm {
 
-class UnifyLoopExitsPass : public OptionalPassInfoMixin<UnifyLoopExitsPass> {
+class UnifyLoopExitsPass : public RequiredPassInfoMixin<UnifyLoopExitsPass> {
 public:
   LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };

--- a/llvm/lib/Analysis/ModuleSummaryAnalysis.cpp
+++ b/llvm/lib/Analysis/ModuleSummaryAnalysis.cpp
@@ -1175,6 +1175,7 @@ ModuleSummaryIndex llvm::buildModuleSummaryIndex(
 }
 
 AnalysisKey ModuleSummaryIndexAnalysis::Key;
+AnalysisKey ImmutableModuleSummaryIndexAnalysis::Key;
 
 ModuleSummaryIndex
 ModuleSummaryIndexAnalysis::run(Module &M, ModuleAnalysisManager &AM) {

--- a/llvm/lib/Analysis/StackSafetyAnalysis.cpp
+++ b/llvm/lib/Analysis/StackSafetyAnalysis.cpp
@@ -1068,14 +1068,17 @@ AnalysisKey StackSafetyGlobalAnalysis::Key;
 
 StackSafetyGlobalInfo
 StackSafetyGlobalAnalysis::run(Module &M, ModuleAnalysisManager &AM) {
-  // FIXME: Lookup Module Summary.
   FunctionAnalysisManager &FAM =
       AM.getResult<FunctionAnalysisManagerModuleProxy>(M).getManager();
+  const ModuleSummaryIndex *Index = nullptr;
+  if (auto *IndexPass =
+          AM.getCachedResult<ImmutableModuleSummaryIndexAnalysis>(M))
+    Index = IndexPass->getIndex();
   return {&M,
           [&FAM](Function &F) -> const StackSafetyInfo & {
             return FAM.getResult<StackSafetyAnalysis>(F);
           },
-          nullptr};
+          Index};
 }
 
 PreservedAnalyses StackSafetyGlobalPrinterPass::run(Module &M,

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -31,6 +31,8 @@ MODULE_ANALYSIS("ir-similarity", IRSimilarityAnalysis())
 MODULE_ANALYSIS("last-run-tracking", LastRunTrackingAnalysis())
 MODULE_ANALYSIS("lcg", LazyCallGraphAnalysis())
 MODULE_ANALYSIS("libcall-lowering-info", LibcallLoweringModuleAnalysis())
+MODULE_ANALYSIS("immutable-module-summary",
+                ImmutableModuleSummaryIndexAnalysis())
 MODULE_ANALYSIS("module-summary", ModuleSummaryIndexAnalysis())
 MODULE_ANALYSIS("no-op-module", NoOpModuleAnalysis())
 MODULE_ANALYSIS("pass-instrumentation", PassInstrumentationAnalysis(PIC))

--- a/llvm/lib/Target/AMDGPU/AMDGPU.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.h
@@ -92,7 +92,7 @@ struct AMDGPUUseNativeCallsPass
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
-class SILowerI1CopiesPass : public OptionalPassInfoMixin<SILowerI1CopiesPass> {
+class SILowerI1CopiesPass : public RequiredPassInfoMixin<SILowerI1CopiesPass> {
 public:
   SILowerI1CopiesPass() = default;
   PreservedAnalyses run(MachineFunction &MF,
@@ -354,7 +354,7 @@ public:
 };
 
 class AMDGPULowerKernelArgumentsPass
-    : public OptionalPassInfoMixin<AMDGPULowerKernelArgumentsPass> {
+    : public RequiredPassInfoMixin<AMDGPULowerKernelArgumentsPass> {
 private:
   TargetMachine &TM;
 
@@ -411,7 +411,7 @@ public:
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
-class SIModeRegisterPass : public OptionalPassInfoMixin<SIModeRegisterPass> {
+class SIModeRegisterPass : public RequiredPassInfoMixin<SIModeRegisterPass> {
 public:
   SIModeRegisterPass() = default;
   PreservedAnalyses run(MachineFunction &F, MachineFunctionAnalysisManager &AM);
@@ -516,7 +516,7 @@ public:
 };
 
 class SIAnnotateControlFlowPass
-    : public OptionalPassInfoMixin<SIAnnotateControlFlowPass> {
+    : public RequiredPassInfoMixin<SIAnnotateControlFlowPass> {
 private:
   const AMDGPUTargetMachine &TM;
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUUnifyDivergentExitNodes.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUUnifyDivergentExitNodes.h
@@ -26,7 +26,7 @@
 
 namespace llvm {
 class AMDGPUUnifyDivergentExitNodesPass
-    : public OptionalPassInfoMixin<AMDGPUUnifyDivergentExitNodesPass> {
+    : public RequiredPassInfoMixin<AMDGPUUnifyDivergentExitNodesPass> {
 public:
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };

--- a/llvm/lib/Target/AMDGPU/AMDGPUWaitSGPRHazards.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaitSGPRHazards.h
@@ -14,7 +14,7 @@
 namespace llvm {
 
 class AMDGPUWaitSGPRHazardsPass
-    : public OptionalPassInfoMixin<AMDGPUWaitSGPRHazardsPass> {
+    : public RequiredPassInfoMixin<AMDGPUWaitSGPRHazardsPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);

--- a/llvm/lib/Target/AMDGPU/GCNNSAReassign.h
+++ b/llvm/lib/Target/AMDGPU/GCNNSAReassign.h
@@ -12,7 +12,7 @@
 #include "llvm/CodeGen/MachinePassManager.h"
 
 namespace llvm {
-class GCNNSAReassignPass : public OptionalPassInfoMixin<GCNNSAReassignPass> {
+class GCNNSAReassignPass : public RequiredPassInfoMixin<GCNNSAReassignPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);

--- a/llvm/lib/Target/AMDGPU/GCNPreRALongBranchReg.h
+++ b/llvm/lib/Target/AMDGPU/GCNPreRALongBranchReg.h
@@ -13,7 +13,7 @@
 
 namespace llvm {
 class GCNPreRALongBranchRegPass
-    : public OptionalPassInfoMixin<GCNPreRALongBranchRegPass> {
+    : public RequiredPassInfoMixin<GCNPreRALongBranchRegPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);

--- a/llvm/lib/Target/AMDGPU/GCNRewritePartialRegUses.h
+++ b/llvm/lib/Target/AMDGPU/GCNRewritePartialRegUses.h
@@ -13,7 +13,7 @@
 
 namespace llvm {
 class GCNRewritePartialRegUsesPass
-    : public OptionalPassInfoMixin<GCNRewritePartialRegUsesPass> {
+    : public RequiredPassInfoMixin<GCNRewritePartialRegUsesPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);

--- a/llvm/lib/Target/AMDGPU/SIFixSGPRCopies.h
+++ b/llvm/lib/Target/AMDGPU/SIFixSGPRCopies.h
@@ -13,7 +13,7 @@
 
 namespace llvm {
 
-class SIFixSGPRCopiesPass : public OptionalPassInfoMixin<SIFixSGPRCopiesPass> {
+class SIFixSGPRCopiesPass : public RequiredPassInfoMixin<SIFixSGPRCopiesPass> {
 public:
   SIFixSGPRCopiesPass() = default;
   PreservedAnalyses run(MachineFunction &MF,

--- a/llvm/lib/Target/AMDGPU/SIFixVGPRCopies.h
+++ b/llvm/lib/Target/AMDGPU/SIFixVGPRCopies.h
@@ -12,7 +12,7 @@
 #include "llvm/CodeGen/MachinePassManager.h"
 
 namespace llvm {
-class SIFixVGPRCopiesPass : public OptionalPassInfoMixin<SIFixVGPRCopiesPass> {
+class SIFixVGPRCopiesPass : public RequiredPassInfoMixin<SIFixVGPRCopiesPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);

--- a/llvm/lib/Target/AMDGPU/SILowerControlFlow.h
+++ b/llvm/lib/Target/AMDGPU/SILowerControlFlow.h
@@ -13,7 +13,7 @@
 
 namespace llvm {
 class SILowerControlFlowPass
-    : public OptionalPassInfoMixin<SILowerControlFlowPass> {
+    : public RequiredPassInfoMixin<SILowerControlFlowPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);

--- a/llvm/lib/Target/AMDGPU/SILowerSGPRSpills.h
+++ b/llvm/lib/Target/AMDGPU/SILowerSGPRSpills.h
@@ -13,7 +13,7 @@
 
 namespace llvm {
 class SILowerSGPRSpillsPass
-    : public OptionalPassInfoMixin<SILowerSGPRSpillsPass> {
+    : public RequiredPassInfoMixin<SILowerSGPRSpillsPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);

--- a/llvm/lib/Target/AMDGPU/SILowerWWMCopies.h
+++ b/llvm/lib/Target/AMDGPU/SILowerWWMCopies.h
@@ -13,7 +13,7 @@
 
 namespace llvm {
 class SILowerWWMCopiesPass
-    : public OptionalPassInfoMixin<SILowerWWMCopiesPass> {
+    : public RequiredPassInfoMixin<SILowerWWMCopiesPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);

--- a/llvm/lib/Target/AMDGPU/SIPreAllocateWWMRegs.h
+++ b/llvm/lib/Target/AMDGPU/SIPreAllocateWWMRegs.h
@@ -14,7 +14,7 @@
 namespace llvm {
 
 class SIPreAllocateWWMRegsPass
-    : public OptionalPassInfoMixin<SIPreAllocateWWMRegsPass> {
+    : public RequiredPassInfoMixin<SIPreAllocateWWMRegsPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);

--- a/llvm/lib/Target/AMDGPU/SIWholeQuadMode.h
+++ b/llvm/lib/Target/AMDGPU/SIWholeQuadMode.h
@@ -12,7 +12,7 @@
 #include "llvm/CodeGen/MachinePassManager.h"
 
 namespace llvm {
-class SIWholeQuadModePass : public OptionalPassInfoMixin<SIWholeQuadModePass> {
+class SIWholeQuadModePass : public RequiredPassInfoMixin<SIWholeQuadModePass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);


### PR DESCRIPTION
essentially a port of https://github.com/llvm/llvm-project/pull/148115. matches legacy behaviour. MachineBlockPlacement is made optional since it is optional in legacy as well. not sure if there was any reason to make it required in NPM.