### PR TITLE
[SPIR-V] Return false after non-constant offset error in generateSampleImage

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -5671,6 +5671,7 @@ bool SPIRVInstructionSelector::generateSampleImage(
     else {
       Pos.emitGenericError(
           "Non-constant offsets are not supported in sample instructions.");
+      return false;
     }
   }
   if (ImOps.MinLod)

--- a/llvm/test/CodeGen/SPIRV/hlsl-resources/SampleErrors.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-resources/SampleErrors.ll
@@ -1,4 +1,4 @@
-; RUN: not llc -O0 -mtriple=spirv-vulkan-compute %s -o /dev/null 2>&1 | FileCheck %s
+; RUN: not llc -O0 -mtriple=spirv-vulkan-compute %s -o - 2>&1 | FileCheck %s
 
 ; CHECK: error: {{.*}} Non-constant offsets are not supported in sample instructions.
 


### PR DESCRIPTION
generateSampleImage emitted the diagnostic but kept building the instruction, producing a malformed OpImageSample with the offset silently dropped