### PR TITLE
Fix contextual implicit conversions to int: with _Atomic

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -705,6 +705,7 @@ Bug Fixes in This Version
 - Fixed crash when checking for overflow for unary operator that can't overflow (#GH170072)
 - Clang no longer handles a `" q-char-sequence "` header name as a string literal (#GH132643).
 - Fixed an assertion when ``__attribute__((alloc_size))`` is used with an argument type wider than the target's pointer width. (#GH190445)
+- Fixed an assertion where we improperly handled implicit conversions to integral types from an atomic-type with a conversion function. (#GH201770)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -7036,7 +7036,6 @@ ExprResult Sema::PerformContextualImplicitConversion(
   if (Converter.match(T))
     return Converted;
 
-
   // FIXME: Check for missing '()' if T is a function type?
 
   // We can only perform contextual implicit conversions on objects of class

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -7031,9 +7031,11 @@ ExprResult Sema::PerformContextualImplicitConversion(
   // Try converting the expression to an Lvalue first, to get rid of qualifiers.
   ExprResult Converted = DefaultLvalueConversion(From);
   QualType T = Converted.isUsable() ? Converted.get()->getType() : QualType();
+  From = Converted.get();
   // If the expression already has a matching type, we're golden.
   if (Converter.match(T))
     return Converted;
+
 
   // FIXME: Check for missing '()' if T is a function type?
 

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -7031,7 +7031,7 @@ ExprResult Sema::PerformContextualImplicitConversion(
   // Try converting the expression to an Lvalue first, to get rid of qualifiers.
   ExprResult Converted = DefaultLvalueConversion(From);
   QualType T = Converted.isUsable() ? Converted.get()->getType() : QualType();
-  From = Converted.get();
+  From = Converted.isUsable() ? Converted.get() : nullptr;
   // If the expression already has a matching type, we're golden.
   if (Converter.match(T))
     return Converted;

--- a/clang/test/Sema/atomic-conversions-to-int.cpp
+++ b/clang/test/Sema/atomic-conversions-to-int.cpp
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -triple x86_64-linux -Wunused -verify %s
+
+struct Convert {
+  operator unsigned() const;
+};
+
+struct NoConvert {
+  operator float() const;
+};
+
+struct H {
+  static _Atomic Convert conv;
+  static _Atomic NoConvert noconv;
+};
+
+void foo() {
+    switch(H::conv){}
+    (void)__builtin_stdc_rotate_left(H::conv, H::conv);
+
+    // expected-error@+1{{statement requires expression of integer type ('NoConvert' invalid)}}
+    switch(H::noconv){}
+    // expected-error@+1{{1st argument must be a scalar unsigned integer type (was 'NoConvert')}}
+    (void)__builtin_stdc_rotate_left(H::noconv, H::noconv);
+}
+

--- a/clang/test/Sema/atomic-conversions-to-int.cpp
+++ b/clang/test/Sema/atomic-conversions-to-int.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-linux -Wunused -verify %s
+// RUN: %clang_cc1 -verify %s
 
 struct Convert {
   operator unsigned() const;


### PR DESCRIPTION
PerformContextualImplicitConversion was performing default-lvalue-conversions, then basing decisions on viable conversion functions on this type  However, when we then went to add the candidates we were using the 'old' value (pre-conversion) of the type, resulting in us regaining the lost 'atomic' from the default Lvalue conversion.

This patch updates the 'from' variable to be the converted value so all conversions are done post-conversion.

Fixes: #201770