### PR TITLE
[libc++][filesystem] Fix truncation in vformat_string dynamic fallback

### DIFF
--- a/libcxx/src/filesystem/format_string.h
+++ b/libcxx/src/filesystem/format_string.h
@@ -31,7 +31,7 @@ _LIBCPP_BEGIN_NAMESPACE_FILESYSTEM
 namespace detail {
 
 inline _LIBCPP_ATTRIBUTE_FORMAT(__printf__, 1, 0) string vformat_string(const char* msg, va_list ap) {
-  array<char, 256> buf;
+  array<char, 1024> buf;
 
   va_list apcopy;
   va_copy(apcopy, ap);

--- a/libcxx/src/filesystem/format_string.h
+++ b/libcxx/src/filesystem/format_string.h
@@ -31,7 +31,7 @@ _LIBCPP_BEGIN_NAMESPACE_FILESYSTEM
 namespace detail {
 
 inline _LIBCPP_ATTRIBUTE_FORMAT(__printf__, 1, 0) string vformat_string(const char* msg, va_list ap) {
-  array<char, 1024> buf;
+  array<char, 256> buf;
 
   va_list apcopy;
   va_copy(apcopy, ap);
@@ -44,8 +44,10 @@ inline _LIBCPP_ATTRIBUTE_FORMAT(__printf__, 1, 0) string vformat_string(const ch
   } else {
     // we did not provide a long enough buffer on our first attempt. The
     // return value is the number of bytes (excluding the null byte) that are
-    // needed for formatting.
-    result.resize_and_overwrite(size, [&](char* res, size_t n) { return ::vsnprintf(res, n, msg, ap); });
+    // needed for formatting. We pass size+1 so that vsnprintf has room to
+    // write all 'size' characters plus the null terminator. ap is still
+    // valid here since only apcopy (not ap) was passed to vsnprintf above.
+    result.resize_and_overwrite(size + 1, [&](char* res, size_t n) { return ::vsnprintf(res, n, msg, ap); });
     _LIBCPP_ASSERT_INTERNAL(static_cast<size_t>(size) == result.size(),
                             "vsnprintf did not result in the same number of characters as the first attempt?");
   }


### PR DESCRIPTION
The `vformat_string` fallback path (used when the message exceeds the
stack buffer) had two bugs that caused the last character to be silently
dropped:

1. **Off-by-one in `resize_and_overwrite`**: `vsnprintf` returns the
   number of bytes needed *excluding* the null terminator. The fallback
   called `resize_and_overwrite(size, ...)`, which passed `n == size`
   to `vsnprintf`. Since `vsnprintf` needs `n+1` bytes to write `n`
   characters plus the null terminator, it truncated the output by one
   character. Fixed by passing `size + 1`.

2. **`ap` was never the problem**: Because the first `vsnprintf` call
   uses `apcopy` (not `ap`), `ap` remains valid for use in the
   fallback. The fallback correctly uses `ap` directly.

These bugs caused test failures in `copy_file.pass.cpp` on z/OS when the
`--execdir` path was long enough that the formatted error message
(which includes paths twice) exceeded 256 characters. The symptom was:

```
Expected message length: 263 characters
Actual message length: 262 characters (missing final ']')
```

With the fallback now working correctly, the stack buffer stays at its
original 256 bytes — no workaround inflation needed.