### PR TITLE
[DirectX] Replace unrepresentable debug info with i1 undef

### DIFF
--- a/llvm/lib/Target/DirectX/DirectXIRPasses/DXILDebugInfo.cpp
+++ b/llvm/lib/Target/DirectX/DirectXIRPasses/DXILDebugInfo.cpp
@@ -123,6 +123,27 @@ DXILDebugInfoMap DXILDebugInfoPass::run(Module &M) {
             // a variable.
             DILocalVariable *V = DV->getVariable();
             DIExpression *E = DV->getExpression();
+            // If this is already an llvm.dbg.value instruction that we can
+            // keep, just do that, otherwise convert it.
+            auto *Val = cast<MetadataAsValue>(DV->getArgOperand(0));
+            auto *Var = cast<MetadataAsValue>(DV->getArgOperand(1));
+            auto *Expr = cast<MetadataAsValue>(DV->getArgOperand(2));
+            bool Replace = DV->getIntrinsicID() != Intrinsic::dbg_value;
+            if (!isa<ValueAsMetadata>(Val->getMetadata())) {
+              // This may be a DIArgList which is not supported in LLVM 3.7. If
+              // it is, we cannot record the new value, but we still need to
+              // kill any old value. Do this by poison. We do not know the
+              // correct type to use here and arbitrarily use i1.
+              // This should never be anything other than ValueAsMetadata or
+              // DIArgList, but in manually constructed LLVM IR, it can be.
+              // Handle this gracefully by also replacing it with poison.
+              Val = MetadataAsValue::get(
+                  M.getContext(), ConstantAsMetadata::get(PoisonValue::get(
+                                      Type::getInt1Ty(M.getContext()))));
+              E = DIExpression::get(M.getContext(), {});
+              Expr = MetadataAsValue::get(M.getContext(), E);
+              Replace = true;
+            }
             std::pair<Instruction *, DbgValueInst *> &DbgValue = DbgValues[V];
             std::pair<Instruction *, DbgValueInst *> &DbgValueFragment =
                 DbgValueFragments[{V, E}];
@@ -143,12 +164,8 @@ DXILDebugInfoMap DXILDebugInfoPass::run(Module &M) {
                 DbgValue.second->eraseFromParent();
               }
             }
-            // If this is already an llvm.dbg.value instruction, just keep it,
-            // otherwise convert it.
             DbgValueInst *NewDV;
-            if (DV->getIntrinsicID() == Intrinsic::dbg_value) {
-              NewDV = DV;
-            } else {
+            if (Replace) {
               if (!DVDecl) {
                 DVDecl =
                     Intrinsic::getOrInsertDeclaration(&M, Intrinsic::dbg_value);
@@ -161,13 +178,13 @@ DXILDebugInfoMap DXILDebugInfoPass::run(Module &M) {
                 DVDecl->removeFnAttrs(AM);
               }
               NewDV = cast<DbgValueInst>(
-                  CallInst::Create(DVDecl,
-                                   {DV->getArgOperand(0), DV->getArgOperand(1),
-                                    DV->getArgOperand(2)},
-                                   {}, "", std::next(DV->getIterator())));
+                  CallInst::Create(DVDecl, {Val, Var, Expr}, {}, "",
+                                   std::next(DV->getIterator())));
               NewDV->setTailCall();
               NewDV->setDebugLoc(DV->getDebugLoc());
               DV->eraseFromParent();
+            } else {
+              NewDV = DV;
             }
             DbgValue = DbgValueFragment = {NextNonDebugInst, NewDV};
             continue;

--- a/llvm/test/CodeGen/DirectX/DebugInfo/dbg-value-arglist.ll
+++ b/llvm/test/CodeGen/DirectX/DebugInfo/dbg-value-arglist.ll
@@ -1,41 +1,42 @@
-; RUN: llc %s -o - | FileCheck %s
+;; RUN: llc -o - %s | FileCheck %s
 
-target triple = "dxil-unknown-shadermodel6.3-library"
+target triple = "dxil-pc-shadermodel6.3-library"
 
-; CHECK-NOT: call void @llvm.dbg.value(
+;; CHECK: define i32 @dbgassign(i32 %a, i32 %b) !dbg [[SP:![0-9]+]] {
+;; CHECK-NEXT: entry:
+;; CHECK-NEXT:   ; DXIL: to be replaced with: tail call addrspace(0) void @llvm.dbg.value(metadata i32 0, i64 0, metadata [[LV:![0-9]+]], metadata !DIExpression())
+;; CHECK-NEXT:   tail call void @llvm.dbg.value(metadata i32 0, metadata [[LV:![0-9]+]], metadata !DIExpression())
+;; CHECK-NEXT:   %add = add nsw i32 %a, %b
+;; CHECK-NEXT:   ; DXIL: to be replaced with: tail call addrspace(0) void @llvm.dbg.value(metadata i1 poison, i64 0, metadata [[LV]], metadata !DIExpression())
+;; CHECK-NEXT:   tail call void @llvm.dbg.value(metadata i1 poison, metadata [[LV]], metadata !DIExpression()
+;; CHECK-NEXT:   ret i32 %add
+;; CHECK-NEXT: }
 
-define void @fn() !dbg !17 {
+define i32 @dbgassign(i32 %a, i32 %b) !dbg !5 {
 entry:
-    #dbg_value(!DIArgList(ptr poison, i32 poison), !21, !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_LLVM_arg, 1, DW_OP_LLVM_convert, 32, DW_ATE_signed, DW_OP_LLVM_convert, 64, DW_ATE_signed, DW_OP_constu, 4, DW_OP_mul, DW_OP_plus, DW_OP_stack_value), !23)
-  ret void, !dbg !23
+    #dbg_assign(i1 poison, !10, !DIExpression(), !11, ptr poison, !DIExpression(), !12)
+    #dbg_assign(i32 0, !10, !DIExpression(), !13, ptr poison, !DIExpression(), !12)
+  %add = add nsw i32 %a, %b, !dbg !14
+    #dbg_assign(!DIArgList(ptr poison, i32 poison), !10, !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_LLVM_arg, 1, DW_OP_LLVM_convert, 32, DW_ATE_signed, DW_OP_LLVM_convert, 64, DW_ATE_signed, DW_OP_constu, 4, DW_OP_mul, DW_OP_plus, DW_OP_stack_value), !15, ptr poison, !DIExpression(), !12)
+  ret i32 %add
 }
 
-attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) }
-
 !llvm.dbg.cu = !{!0}
-!llvm.module.flags = !{!15, !16}
+!llvm.module.flags = !{!2, !3, !4}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, splitDebugInlining: false, nameTableKind: None)
-!1 = !DIFile(filename: "foo.c", directory: "/")
-!2 = !{}
-!3 = !{!4, !13}
-!4 = !DIGlobalVariableExpression(var: !5, expr: !DIExpression())
-!5 = distinct !DIGlobalVariable(name: "s", scope: !0, file: !1, line: 1, type: !6, isLocal: true, isDefinition: true)
-!6 = !DICompositeType(tag: DW_TAG_array_type, baseType: !7, size: 32, elements: !11)
-!7 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "S", file: !1, line: 1, size: 32, elements: !8)
-!8 = !{!9}
-!9 = !DIDerivedType(tag: DW_TAG_member, name: "data", scope: !7, file: !1, line: 1, baseType: !10, size: 32)
-!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-!11 = !{!12}
-!12 = !DISubrange(count: 1)
-!13 = !DIGlobalVariableExpression(var: !14, expr: !DIExpression())
-!14 = distinct !DIGlobalVariable(name: "idx", scope: !0, file: !1, line: 2, type: !10, isLocal: false, isDefinition: true)
-!15 = !{i32 7, !"Dwarf Version", i32 4}
-!16 = !{i32 2, !"Debug Info Version", i32 3}
-!17 = distinct !DISubprogram(name: "fn", scope: !1, file: !1, line: 4, type: !18, scopeLine: 4, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !20)
-!18 = !DISubroutineType(types: !19)
-!19 = !{null}
-!20 = !{!21}
-!21 = !DILocalVariable(name: "local", scope: !17, file: !1, line: 5, type: !22)
-!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
-!23 = !DILocation(line: 5, scope: !17)
+!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "dbgassign.c", directory: "")
+!2 = !{i32 7, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 7, !"debug-info-assignment-tracking", i1 true}
+!5 = distinct !DISubprogram(name: "dbgassign", scope: !1, file: !1, line: 2, type: !6, scopeLine: 2, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !9, keyInstructions: true)
+!6 = !DISubroutineType(types: !7)
+!7 = !{!8, !8, !8}
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DILocalVariable(name: "result", scope: !5, file: !1, line: 3, type: !8)
+!11 = distinct !DIAssignID()
+!12 = !DILocation(line: 0, scope: !5)
+!13 = distinct !DIAssignID()
+!14 = !DILocation(line: 7, column: 10, scope: !5, atomGroup: 3, atomRank: 2)
+!15 = distinct !DIAssignID()

--- a/llvm/test/tools/dxil-dis/dbg-value-arglist.ll
+++ b/llvm/test/tools/dxil-dis/dbg-value-arglist.ll
@@ -2,42 +2,41 @@
 ; RUN: llvm-objcopy --dump-section=ILDB=%t.bc %t.dxbc
 ; RUN: dxil-dis %t.bc -o - | FileCheck %s
 
-target triple = "dxil-unknown-shadermodel6.3-library"
+target triple = "dxil-pc-shadermodel6.3-library"
 
-; CHECK-NOT: call void @llvm.dbg.value(
+;; CHECK: define i32 @dbgassign(i32 %a, i32 %b) {
+;; CHECK-NEXT: entry:
+;; CHECK-NEXT:   tail call void @llvm.dbg.value(metadata i32 0, i64 0, metadata [[LV:![0-9]+]], metadata [[E:![0-9]+]])
+;; CHECK-NEXT:   %add = add nsw i32 %a, %b
+;; CHECK-NEXT:   tail call void @llvm.dbg.value(metadata i1 undef, i64 0, metadata [[LV]], metadata [[E]])
+;; CHECK-NEXT:   ret i32 %add
+;; CHECK-NEXT: }
 
-define void @fn() !dbg !17 {
+define i32 @dbgassign(i32 %a, i32 %b) !dbg !5 {
 entry:
-    #dbg_value(!DIArgList(ptr poison, i32 poison), !21, !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_LLVM_arg, 1, DW_OP_LLVM_convert, 32, DW_ATE_signed, DW_OP_LLVM_convert, 64, DW_ATE_signed, DW_OP_constu, 4, DW_OP_mul, DW_OP_plus, DW_OP_stack_value), !23)
-  ret void, !dbg !23
+    #dbg_assign(i1 poison, !10, !DIExpression(), !11, ptr poison, !DIExpression(), !12)
+    #dbg_assign(i32 0, !10, !DIExpression(), !13, ptr poison, !DIExpression(), !12)
+  %add = add nsw i32 %a, %b, !dbg !14
+    #dbg_assign(!DIArgList(ptr poison, i32 poison), !10, !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_LLVM_arg, 1, DW_OP_LLVM_convert, 32, DW_ATE_signed, DW_OP_LLVM_convert, 64, DW_ATE_signed, DW_OP_constu, 4, DW_OP_mul, DW_OP_plus, DW_OP_stack_value), !15, ptr poison, !DIExpression(), !12)
+  ret i32 %add
 }
 
-attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) }
-
 !llvm.dbg.cu = !{!0}
-!llvm.module.flags = !{!15, !16}
+!llvm.module.flags = !{!2, !3, !4}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, splitDebugInlining: false, nameTableKind: None)
-!1 = !DIFile(filename: "foo.c", directory: "/")
-!2 = !{}
-!3 = !{!4, !13}
-!4 = !DIGlobalVariableExpression(var: !5, expr: !DIExpression())
-!5 = distinct !DIGlobalVariable(name: "s", scope: !0, file: !1, line: 1, type: !6, isLocal: true, isDefinition: true)
-!6 = !DICompositeType(tag: DW_TAG_array_type, baseType: !7, size: 32, elements: !11)
-!7 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "S", file: !1, line: 1, size: 32, elements: !8)
-!8 = !{!9}
-!9 = !DIDerivedType(tag: DW_TAG_member, name: "data", scope: !7, file: !1, line: 1, baseType: !10, size: 32)
-!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-!11 = !{!12}
-!12 = !DISubrange(count: 1)
-!13 = !DIGlobalVariableExpression(var: !14, expr: !DIExpression())
-!14 = distinct !DIGlobalVariable(name: "idx", scope: !0, file: !1, line: 2, type: !10, isLocal: false, isDefinition: true)
-!15 = !{i32 7, !"Dwarf Version", i32 4}
-!16 = !{i32 2, !"Debug Info Version", i32 3}
-!17 = distinct !DISubprogram(name: "fn", scope: !1, file: !1, line: 4, type: !18, scopeLine: 4, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !20)
-!18 = !DISubroutineType(types: !19)
-!19 = !{null}
-!20 = !{!21}
-!21 = !DILocalVariable(name: "local", scope: !17, file: !1, line: 5, type: !22)
-!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
-!23 = !DILocation(line: 5, scope: !17)
+!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "dbgassign.c", directory: "")
+!2 = !{i32 7, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 7, !"debug-info-assignment-tracking", i1 true}
+!5 = distinct !DISubprogram(name: "dbgassign", scope: !1, file: !1, line: 2, type: !6, scopeLine: 2, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !9, keyInstructions: true)
+!6 = !DISubroutineType(types: !7)
+!7 = !{!8, !8, !8}
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DILocalVariable(name: "result", scope: !5, file: !1, line: 3, type: !8)
+!11 = distinct !DIAssignID()
+!12 = !DILocation(line: 0, scope: !5)
+!13 = distinct !DIAssignID()
+!14 = !DILocation(line: 7, column: 10, scope: !5, atomGroup: 3, atomRank: 2)
+!15 = distinct !DIAssignID()


### PR DESCRIPTION
The i1 is arbitrary: we do not know the correct type to use and have no way of representing an untyped undef.