### PR TITLE
[mlir] Use explicit op targets for region successors

### DIFF
--- a/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
+++ b/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
@@ -147,11 +147,11 @@ static fir::AliasAnalysis::Source getSourceForACCMappedValue(
 /// Predecessor SSA values that may define a result of \p branch when control
 /// continues in the parent region (same mapping as
 /// `LocalAliasAnalysis::collectUnderlyingAddressValues2` for
-/// `RegionSuccessor::parent()`).
+/// `RegionSuccessor(branch.getOperation())`).
 static void getRegionBranchPredecessorValuesForParentResult(
     mlir::RegionBranchOpInterface branch, mlir::OpResult result,
     llvm::SmallVectorImpl<mlir::Value> &out) {
-  mlir::RegionSuccessor parentSucc = mlir::RegionSuccessor::parent();
+  mlir::RegionSuccessor parentSucc(branch.getOperation());
   mlir::Value inputValue = result;
   unsigned inputIndex = result.getResultNumber();
   mlir::ValueRange inputs = branch.getSuccessorInputs(parentSucc);

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -3980,7 +3980,7 @@ void fir::DoLoopOp::getSuccessorRegions(
   // Loop-back (body → body): another iteration follows.
   regions.push_back(mlir::RegionSuccessor(&getRegion()));
   // Exit (body → parent): last iteration completes.
-  regions.push_back(mlir::RegionSuccessor::parent());
+  regions.push_back(mlir::RegionSuccessor(getOperation()));
 }
 
 // Note: when finalValue is set, result[0] tracks the IV's final value.
@@ -4003,7 +4003,7 @@ fir::DoLoopOp::getSuccessorInputs(mlir::RegionSuccessor successor) {
   //
   // %r#0 (finalValue IV) is excluded: it has no symmetric iter-arg slot in
   // the body, so it cannot participate in the 4-edge count check.
-  if (successor.isParent())
+  if (successor.isOperation())
     return getResults().drop_front(getFinalValue() ? 1 : 0);
   return getRegionIterArgs();
 }
@@ -5541,7 +5541,7 @@ void fir::IfOp::getSuccessorRegions(
     llvm::SmallVectorImpl<mlir::RegionSuccessor> &regions) {
   // The `then` and the `else` region branch back to the parent operation.
   if (!point.isParent()) {
-    regions.push_back(mlir::RegionSuccessor::parent());
+    regions.push_back(mlir::RegionSuccessor(getOperation()));
     return;
   }
 
@@ -5551,14 +5551,14 @@ void fir::IfOp::getSuccessorRegions(
   // Don't consider the else region if it is empty.
   mlir::Region *elseRegion = &this->getElseRegion();
   if (elseRegion->empty())
-    regions.push_back(mlir::RegionSuccessor::parent());
+    regions.push_back(mlir::RegionSuccessor(getOperation()));
   else
     regions.push_back(mlir::RegionSuccessor(elseRegion));
 }
 
 mlir::ValueRange
 fir::IfOp::getSuccessorInputs(mlir::RegionSuccessor successor) {
-  if (successor.isParent())
+  if (successor.isOperation())
     return getOperation()->getResults();
   return mlir::ValueRange();
 }
@@ -5577,7 +5577,7 @@ void fir::IfOp::getEntrySuccessorRegions(
     if (!getElseRegion().empty())
       regions.emplace_back(&getElseRegion());
     else
-      regions.push_back(mlir::RegionSuccessor::parent());
+      regions.push_back(mlir::RegionSuccessor(getOperation()));
   }
 }
 

--- a/flang/lib/Optimizer/OpenACC/Support/FIROpenACCOpsInterfaces.cpp
+++ b/flang/lib/Optimizer/OpenACC/Support/FIROpenACCOpsInterfaces.cpp
@@ -39,7 +39,7 @@ AccFortranObjectViewModel<mlir::acc::ReductionInitOp>::getViewSource(
   detail::verifyFortranObjectViewResult(op, resultView);
   auto iface = mlir::cast<mlir::RegionBranchOpInterface>(op);
   llvm::SmallVector<mlir::Value, 1> resultValues;
-  iface.getPredecessorValues(mlir::RegionSuccessor::parent(), /*index=*/0,
+  iface.getPredecessorValues(mlir::RegionSuccessor(op), /*index=*/0,
                              resultValues);
   assert(!resultValues.empty() &&
          "acc.reduction_init's result must have at least one possible value");

--- a/mlir/include/mlir/Interfaces/ControlFlowInterfaces.h
+++ b/mlir/include/mlir/Interfaces/ControlFlowInterfaces.h
@@ -193,9 +193,9 @@ using RegionBranchInverseSuccessorMapping =
     DenseMap<Value, SmallVector<OpOperand *>>;
 
 /// This class represents a successor of a region. A region successor can either
-/// be another region, or the parent operation (i.e., the operation that
-/// implements the `RegionBranchOpInterface`). In the latter case, the control
-/// flow branches after/out of the region branch operation.
+/// target another region or target an ancestor operation (at the moment,
+/// limited to the immediate parent operation). In the latter case, the control
+/// flow branches after/out of the target operation.
 class RegionSuccessor {
 public:
   /// Initialize a successor that branches to a region of the parent operation.
@@ -203,31 +203,47 @@ public:
     assert(region && "Region must not be null");
   }
 
-  /// Initialize a successor that branches after/out of the parent operation.
-  static RegionSuccessor parent() { return RegionSuccessor(); }
+  /// Initialize a successor that branches after/out of an operation.
+  RegionSuccessor(Operation *operation) : successor(operation) {
+    assert(operation && "Operation must not be null");
+  }
 
-  /// Return the given region successor. Returns nullptr if the successor is the
-  /// parent operation.
-  Region *getSuccessor() const { return successor; }
+  /// Return the given region successor. Returns nullptr if the successor is an
+  /// operation.
+  Region *getSuccessor() const {
+    return dyn_cast_if_present<Region *>(successor);
+  }
 
-  /// Return true if the successor is the parent operation.
-  bool isParent() const { return successor == nullptr; }
+  /// Return the given operation successor. Returns nullptr if the successor is
+  /// a region.
+  Operation *getSuccessorOp() const {
+    return dyn_cast_if_present<Operation *>(successor);
+  }
+
+  /// Return true if the successor is a region.
+  bool isRegion() const { return isa<Region *>(successor); }
+
+  /// Return true if the successor is an operation.
+  bool isOperation() const { return isa<Operation *>(successor); }
 
   bool operator==(RegionSuccessor rhs) const {
     return successor == rhs.successor;
   }
 
-  bool operator==(const Region *region) const { return successor == region; }
+  bool operator==(const Region *region) const {
+    return getSuccessor() == region;
+  }
+
+  bool operator==(const Operation *operation) const {
+    return getSuccessorOp() == operation;
+  }
 
   friend bool operator!=(RegionSuccessor lhs, RegionSuccessor rhs) {
     return !(lhs == rhs);
   }
 
 private:
-  /// Private constructor to encourage the use of `RegionSuccessor::parent`.
-  RegionSuccessor() : successor(nullptr) {}
-
-  Region *successor = nullptr;
+  llvm::PointerUnion<Region *, Operation *> successor;
 };
 
 /// This class represents a point being branched from in the methods of the
@@ -423,9 +439,11 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                                      RegionSuccessor successor) {
-  if (successor.isParent())
-    return os << "<to parent>";
-  return os << "<to region #" << successor.getSuccessor()->getRegionNumber()
+  if (Region *region = successor.getSuccessor())
+    return os << "<to region #" << region->getRegionNumber() << ">";
+  return os << "<to operation "
+            << OpWithFlags(successor.getSuccessorOp(),
+                           OpPrintingFlags().skipRegions())
             << ">";
 }
 } // namespace mlir

--- a/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
+++ b/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
@@ -140,7 +140,7 @@ def RegionBranchOpInterface : OpInterface<"RegionBranchOpInterface"> {
 
     A "region successor" indicates the target of a branch. It can indicate:
     1. A region of this op.
-    2. `RegionSuccessor::parent()`, i.e., the control flow leaves this op.
+    2. A parent operation, i.e., the control flow leaves/resumes after that op.
 
     The SSA values to which successor operands are forwarded are called
     "successor inputs".
@@ -171,8 +171,8 @@ def RegionBranchOpInterface : OpInterface<"RegionBranchOpInterface"> {
 
     `scf.for` has one region. There are two region branch points with two
     identical region successors:
-    * parent => parent(%r), region0(%a)
-    * `scf.yield` => parent(%r), region0(%a)
+    * parent => op(%r), region0(%a)
+    * `scf.yield` => op(%r), region0(%a)
 
     `%a` and %r are successor inputs. `%b` is an entry successor operand. `%c`
     is a successor operand.
@@ -265,7 +265,7 @@ def RegionBranchOpInterface : OpInterface<"RegionBranchOpInterface"> {
     InterfaceMethod<[{
         Return all successor inputs for the given region successor. If the
         given region successor is a region, then the returned values are block
-        arguments. Otherwise, if the given region successor is the "parent",
+        arguments. Otherwise, if the given region successor is an operation,
         the returned values are op results.
       }],
       "::mlir::ValueRange", "getSuccessorInputs",
@@ -289,9 +289,8 @@ def RegionBranchOpInterface : OpInterface<"RegionBranchOpInterface"> {
           ::llvm::SmallVector<::mlir::RegionSuccessor> successors;
           op.getSuccessorRegions(point, successors);
           bool isPred = llvm::any_of(successors, [&] (const auto &succ) {
-            return succ.getSuccessor() == successor.getSuccessor() ||
-                   (succ.isParent() && successor.isParent());
-            });
+            return succ == successor;
+          });
           if (isPred)
             predecessors.push_back(point);
         }

--- a/mlir/lib/Analysis/AliasAnalysis/LocalAliasAnalysis.cpp
+++ b/mlir/lib/Analysis/AliasAnalysis/LocalAliasAnalysis.cpp
@@ -108,9 +108,9 @@ static void collectUnderlyingAddressValues(OpResult result, unsigned maxDepth,
   // Check to see if we can reason about the control flow of this op.
   if (auto branch = dyn_cast<RegionBranchOpInterface>(op)) {
     LDBG() << "  Processing region branch operation";
-    return collectUnderlyingAddressValues2(branch, RegionSuccessor::parent(),
-                                           result, result.getResultNumber(),
-                                           maxDepth, visited, output);
+    return collectUnderlyingAddressValues2(
+        branch, RegionSuccessor(branch.getOperation()), result,
+        result.getResultNumber(), maxDepth, visited, output);
   }
 
   LDBG() << "  Adding result to output: " << result;

--- a/mlir/lib/Analysis/DataFlow/DeadCodeAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/DeadCodeAnalysis.cpp
@@ -521,13 +521,14 @@ void DeadCodeAnalysis::visitRegionBranchEdges(
     RegionBranchOpInterface regionBranchOp, Operation *predecessorOp,
     const SmallVector<RegionSuccessor> &successors) {
   for (const RegionSuccessor &successor : successors) {
-    // The successor can be either an entry block or the parent operation.
+    // The successor can be either an entry block or an operation to resume
+    // after.
     // Skip empty regions — they have no entry block to mark executable.
-    if (!successor.isParent() && successor.getSuccessor()->empty())
+    if (successor.isRegion() && successor.getSuccessor()->empty())
       continue;
     ProgramPoint *point =
-        successor.isParent()
-            ? getProgramPointAfter(regionBranchOp)
+        successor.isOperation()
+            ? getProgramPointAfter(successor.getSuccessorOp())
             : getProgramPointBefore(&successor.getSuccessor()->front());
 
     // Mark the entry block as executable.
@@ -535,7 +536,7 @@ void DeadCodeAnalysis::visitRegionBranchEdges(
     propagateIfChanged(state, state->setToLive());
     LDBG() << "Marked region successor live: " << *point;
 
-    // Add the parent op as a predecessor.
+    // Add the region branch predecessor.
     auto *predecessors = getOrCreate<PredecessorState>(point);
     propagateIfChanged(
         predecessors,

--- a/mlir/lib/Analysis/DataFlow/DenseAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/DenseAnalysis.cpp
@@ -637,8 +637,12 @@ void AbstractDenseBackwardDataFlowAnalysis::visitRegionBranchOperation(
   LDBG() << "  Processing " << successors.size() << " successor regions";
   for (const RegionSuccessor &successor : successors) {
     const AbstractDenseLattice *after;
-    if (successor.isParent() || successor.getSuccessor()->empty()) {
-      LDBG() << "    Successor is parent or empty region";
+    if (successor.isOperation()) {
+      LDBG() << "    Successor is operation";
+      after = getLatticeFor(point,
+                            getProgramPointAfter(successor.getSuccessorOp()));
+    } else if (successor.getSuccessor()->empty()) {
+      LDBG() << "    Successor is empty region";
       after = getLatticeFor(point, getProgramPointAfter(branch));
     } else {
       Region *successorRegion = successor.getSuccessor();

--- a/mlir/lib/Analysis/DataFlow/LivenessAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/LivenessAnalysis.cpp
@@ -173,6 +173,7 @@ void LivenessAnalysis::visitCallOperand(OpOperand &operand) {
 
 void LivenessAnalysis::visitNonControlFlowArguments(
     RegionSuccessor &successor, ArrayRef<BlockArgument> arguments) {
+  assert(successor.isRegion() && "expected a region successor");
   Operation *parentOp = successor.getSuccessor()->getParentOp();
   LDBG() << "visitNonControlFlowArguments visit the region: #"
          << successor.getSuccessor()->getRegionNumber() << " of "

--- a/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
@@ -134,7 +134,8 @@ AbstractSparseForwardDataFlowAnalysis::visitOperation(Operation *op) {
   // The results of a region branch operation are determined by control-flow.
   if (auto branch = dyn_cast<RegionBranchOpInterface>(op)) {
     visitRegionSuccessors(getProgramPointAfter(branch), branch,
-                          RegionSuccessor::parent(), resultLattices);
+                          RegionSuccessor(branch.getOperation()),
+                          resultLattices);
     return success();
   }
 
@@ -316,11 +317,10 @@ void AbstractSparseForwardDataFlowAnalysis::visitRegionSuccessors(
         if (!inputs.empty())
           firstIndex = cast<OpResult>(inputs.front()).getResultNumber();
         SmallVector<Value> nonSuccessorInputs =
-            branch.getNonSuccessorInputs(RegionSuccessor::parent());
+            branch.getNonSuccessorInputs(successor);
         SmallVector<AbstractSparseLattice *> nonSuccessorInputLattices =
             llvm::map_to_vector(nonSuccessorInputs, valueToLattices);
-        visitNonControlFlowArgumentsImpl(branch, RegionSuccessor::parent(),
-                                         nonSuccessorInputs,
+        visitNonControlFlowArgumentsImpl(branch, successor, nonSuccessorInputs,
                                          nonSuccessorInputLattices);
       } else {
         if (!inputs.empty())
@@ -619,7 +619,7 @@ void AbstractSparseBackwardDataFlowAnalysis::visitRegionSuccessors(
   SmallVector<Attribute> operands(op->getNumOperands(), nullptr);
   branch.getEntrySuccessorRegions(operands, successors);
   for (RegionSuccessor &successor : successors) {
-    if (successor.isParent())
+    if (successor.isOperation())
       continue;
     auto valueToArgument = [](Value value) {
       return cast<BlockArgument>(value);

--- a/mlir/lib/Analysis/SliceWalk.cpp
+++ b/mlir/lib/Analysis/SliceWalk.cpp
@@ -68,7 +68,7 @@ mlir::getControlFlowPredecessors(Value value) {
     if (!regionOp)
       return std::nullopt;
     // Add the control flow predecessor operands to the work list.
-    RegionSuccessor region = RegionSuccessor::parent();
+    RegionSuccessor region = RegionSuccessor(regionOp.getOperation());
     SmallVector<Value> predecessorOperands;
     // TODO (#175168): This assumes that there are no non-successor-inputs
     // in front of the op result.

--- a/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
+++ b/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
@@ -2677,8 +2677,9 @@ LogicalResult AffineForOp::fold(FoldAdaptor adaptor,
 }
 
 OperandRange AffineForOp::getEntrySuccessorOperands(RegionSuccessor successor) {
-  assert((successor.isParent() || successor.getSuccessor() == &getRegion()) &&
-         "invalid region point");
+  assert(
+      (successor.isOperation() || successor.getSuccessor() == &getRegion()) &&
+      "invalid region point");
 
   // The initial operands map to the loop arguments after the induction
   // variable or are forwarded to the results when the trip count is zero.
@@ -2701,7 +2702,7 @@ void AffineForOp::getSuccessorRegions(
       // From the loop body, if the trip count is one, we can only branch back
       // to the parent.
       if (tripCount == 1) {
-        regions.push_back(RegionSuccessor::parent());
+        regions.push_back(RegionSuccessor(getOperation()));
         return;
       }
       if (tripCount == 0)
@@ -2712,7 +2713,7 @@ void AffineForOp::getSuccessorRegions(
         return;
       }
       if (tripCount.value() == 0) {
-        regions.push_back(RegionSuccessor::parent());
+        regions.push_back(RegionSuccessor(getOperation()));
         return;
       }
     }
@@ -2721,11 +2722,11 @@ void AffineForOp::getSuccessorRegions(
   // In all other cases, the loop may branch back to itself or the parent
   // operation.
   regions.push_back(RegionSuccessor(&getRegion()));
-  regions.push_back(RegionSuccessor::parent());
+  regions.push_back(RegionSuccessor(getOperation()));
 }
 
 ValueRange AffineForOp::getSuccessorInputs(RegionSuccessor successor) {
-  if (successor.isParent())
+  if (successor.isOperation())
     return getResults();
   return getRegionIterArgs();
 }
@@ -3115,7 +3116,7 @@ void AffineIfOp::getSuccessorRegions(
     regions.push_back(RegionSuccessor(&getThenRegion()));
     // If the "else" region is empty, branch bach into parent.
     if (getElseRegion().empty()) {
-      regions.push_back(RegionSuccessor::parent());
+      regions.push_back(RegionSuccessor(getOperation()));
     } else {
       regions.push_back(RegionSuccessor(&getElseRegion()));
     }
@@ -3124,11 +3125,11 @@ void AffineIfOp::getSuccessorRegions(
 
   // If the predecessor is the `else`/`then` region, then branching into parent
   // op is valid.
-  regions.push_back(RegionSuccessor::parent());
+  regions.push_back(RegionSuccessor(getOperation()));
 }
 
 ValueRange AffineIfOp::getSuccessorInputs(RegionSuccessor successor) {
-  if (successor.isParent())
+  if (successor.isOperation())
     return getResults();
   if (successor == &getThenRegion())
     return getThenRegion().getArguments();

--- a/mlir/lib/Dialect/Async/IR/Async.cpp
+++ b/mlir/lib/Dialect/Async/IR/Async.cpp
@@ -55,7 +55,7 @@ void ExecuteOp::getSuccessorRegions(RegionBranchPoint point,
   if (!point.isParent() &&
       point.getTerminatorPredecessorOrNull()->getParentRegion() ==
           &getBodyRegion()) {
-    regions.push_back(RegionSuccessor::parent());
+    regions.push_back(RegionSuccessor(getOperation()));
     return;
   }
 
@@ -64,8 +64,8 @@ void ExecuteOp::getSuccessorRegions(RegionBranchPoint point,
 }
 
 ValueRange ExecuteOp::getSuccessorInputs(RegionSuccessor successor) {
-  return successor.isParent() ? ValueRange(getBodyResults())
-                              : ValueRange(getBodyRegion().getArguments());
+  return successor.isOperation() ? ValueRange(getBodyResults())
+                                 : ValueRange(getBodyRegion().getArguments());
 }
 
 void ExecuteOp::build(OpBuilder &builder, OperationState &result,

--- a/mlir/lib/Dialect/Bufferization/Transforms/OwnershipBasedBufferDeallocation.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/OwnershipBasedBufferDeallocation.cpp
@@ -563,7 +563,7 @@ BufferDeallocation::updateFunctionSignature(FunctionOpInterface op) {
   SmallVector<TypeRange> returnOperandTypes(llvm::map_range(
       op.getFunctionBody().getOps<RegionBranchTerminatorOpInterface>(),
       [&](RegionBranchTerminatorOpInterface branchOp) {
-        return branchOp.getSuccessorOperands(RegionSuccessor::parent())
+        return branchOp.getSuccessorOperands(RegionSuccessor(op.getOperation()))
             .getTypes();
       }));
   if (!llvm::all_equal(returnOperandTypes))
@@ -955,7 +955,7 @@ BufferDeallocation::handleInterface(RegionBranchTerminatorOpInterface op) {
   // which condition they are taken, etc.
 
   MutableOperandRange operands =
-      op.getMutableSuccessorOperands(RegionSuccessor::parent());
+      op.getMutableSuccessorOperands(RegionSuccessor(op->getParentOp()));
 
   SmallVector<Value> updatedOwnerships;
   auto result = deallocation_impl::insertDeallocOpForReturnLike(

--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -994,7 +994,7 @@ void IfOp::getSuccessorRegions(RegionBranchPoint point,
                                SmallVectorImpl<RegionSuccessor> &regions) {
   // The `then` and the `else` region branch back to the parent operation.
   if (!point.isParent()) {
-    regions.push_back(RegionSuccessor::parent());
+    regions.push_back(RegionSuccessor(getOperation()));
     return;
   }
 
@@ -1003,14 +1003,14 @@ void IfOp::getSuccessorRegions(RegionBranchPoint point,
   // Don't consider the else region if it is empty.
   Region *elseRegion = &this->getElseRegion();
   if (elseRegion->empty())
-    regions.push_back(RegionSuccessor::parent());
+    regions.push_back(RegionSuccessor(getOperation()));
   else
     regions.push_back(RegionSuccessor(elseRegion));
 }
 
 ValueRange IfOp::getSuccessorInputs(RegionSuccessor successor) {
-  return successor.isParent() ? ValueRange(getOperation()->getResults())
-                              : ValueRange();
+  return successor.isOperation() ? ValueRange(getOperation()->getResults())
+                                 : ValueRange();
 }
 
 void IfOp::getEntrySuccessorRegions(ArrayRef<Attribute> operands,
@@ -1025,7 +1025,7 @@ void IfOp::getEntrySuccessorRegions(ArrayRef<Attribute> operands,
     if (!getElseRegion().empty())
       regions.emplace_back(&getElseRegion());
     else
-      regions.emplace_back(RegionSuccessor::parent());
+      regions.emplace_back(RegionSuccessor(getOperation()));
   }
 }
 

--- a/mlir/lib/Dialect/Func/IR/FuncOps.cpp
+++ b/mlir/lib/Dialect/Func/IR/FuncOps.cpp
@@ -299,7 +299,7 @@ LogicalResult FuncOp::verifyRegions() {
     if (!returnOp)
       continue;
     auto operands =
-        returnOp.getMutableSuccessorOperands(RegionSuccessor::parent());
+        returnOp.getMutableSuccessorOperands(RegionSuccessor(getOperation()));
     if (operands.size() != resultTypes.size())
       return returnOp->emitOpError("has ")
              << operands.size() << " operands, but enclosing function (@"

--- a/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
+++ b/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
@@ -2521,7 +2521,7 @@ ParseResult WarpExecuteOnLane0Op::parse(OpAsmParser &parser,
 void WarpExecuteOnLane0Op::getSuccessorRegions(
     RegionBranchPoint point, SmallVectorImpl<RegionSuccessor> &regions) {
   if (!point.isParent()) {
-    regions.push_back(RegionSuccessor::parent());
+    regions.push_back(RegionSuccessor(getOperation()));
     return;
   }
 
@@ -2530,7 +2530,7 @@ void WarpExecuteOnLane0Op::getSuccessorRegions(
 }
 
 ValueRange WarpExecuteOnLane0Op::getSuccessorInputs(RegionSuccessor successor) {
-  return successor.isParent() ? ValueRange(getResults()) : ValueRange();
+  return successor.isOperation() ? ValueRange(getResults()) : ValueRange();
 }
 void WarpExecuteOnLane0Op::build(OpBuilder &builder, OperationState &result,
                                  TypeRange resultTypes, Value laneId,

--- a/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
+++ b/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
@@ -405,7 +405,7 @@ ParseResult AllocaScopeOp::parse(OpAsmParser &parser, OperationState &result) {
 void AllocaScopeOp::getSuccessorRegions(
     RegionBranchPoint point, SmallVectorImpl<RegionSuccessor> &regions) {
   if (!point.isParent()) {
-    regions.push_back(RegionSuccessor::parent());
+    regions.push_back(RegionSuccessor(getOperation()));
     return;
   }
 
@@ -413,7 +413,7 @@ void AllocaScopeOp::getSuccessorRegions(
 }
 
 ValueRange AllocaScopeOp::getSuccessorInputs(RegionSuccessor successor) {
-  return successor.isParent() ? ValueRange(getResults()) : ValueRange();
+  return successor.isOperation() ? ValueRange(getResults()) : ValueRange();
 }
 
 /// Given an operation, return whether this op is guaranteed to

--- a/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
@@ -506,7 +506,7 @@ void OpenACCDialect::initialize() {
 //===----------------------------------------------------------------------===//
 
 /// Generic helper for single-region OpenACC ops that execute their body once
-/// and then return to the parent operation with their results (if any).
+/// and then continue after the operation with their results (if any).
 static void
 getSingleRegionOpSuccessorRegions(Operation *op, Region &region,
                                   RegionBranchPoint point,
@@ -516,12 +516,12 @@ getSingleRegionOpSuccessorRegions(Operation *op, Region &region,
     return;
   }
 
-  regions.push_back(RegionSuccessor::parent());
+  regions.push_back(RegionSuccessor(op));
 }
 
 static ValueRange getSingleRegionSuccessorInputs(Operation *op,
                                                  RegionSuccessor successor) {
-  return successor.isParent() ? ValueRange(op->getResults()) : ValueRange();
+  return successor.isOperation() ? ValueRange(op->getResults()) : ValueRange();
 }
 
 void KernelsOp::getSuccessorRegions(RegionBranchPoint point,
@@ -584,13 +584,13 @@ void LoopOp::getSuccessorRegions(RegionBranchPoint point,
       regions.push_back(RegionSuccessor(&getRegion()));
       return;
     }
-    regions.push_back(RegionSuccessor::parent());
+    regions.push_back(RegionSuccessor(getOperation()));
     return;
   }
 
   // Structured loops: model a loop-shaped region graph similar to scf.for.
   regions.push_back(RegionSuccessor(&getRegion()));
-  regions.push_back(RegionSuccessor::parent());
+  regions.push_back(RegionSuccessor(getOperation()));
 }
 
 ValueRange LoopOp::getSuccessorInputs(RegionSuccessor successor) {

--- a/mlir/lib/Dialect/OpenACC/IR/OpenACCCG.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACCCG.cpp
@@ -33,7 +33,7 @@ using namespace acc;
 namespace {
 
 /// Generic helper for single-region OpenACC ops that execute their body once
-/// and then return to the parent operation with their results (if any).
+/// and then continue after the operation with their results (if any).
 static void
 getSingleRegionOpSuccessorRegions(Operation *op, Region &region,
                                   RegionBranchPoint point,
@@ -42,12 +42,12 @@ getSingleRegionOpSuccessorRegions(Operation *op, Region &region,
     regions.push_back(RegionSuccessor(&region));
     return;
   }
-  regions.push_back(RegionSuccessor::parent());
+  regions.push_back(RegionSuccessor(op));
 }
 
 static ValueRange getSingleRegionSuccessorInputs(Operation *op,
                                                  RegionSuccessor successor) {
-  return successor.isParent() ? ValueRange(op->getResults()) : ValueRange();
+  return successor.isOperation() ? ValueRange(op->getResults()) : ValueRange();
 }
 
 /// Remove empty acc.kernel_environment operations. If the operation has wait

--- a/mlir/lib/Dialect/SCF/IR/SCF.cpp
+++ b/mlir/lib/Dialect/SCF/IR/SCF.cpp
@@ -274,12 +274,12 @@ void ExecuteRegionOp::getSuccessorRegions(
   }
 
   // Otherwise, the region branches back to the parent operation.
-  regions.push_back(RegionSuccessor::parent());
+  regions.push_back(RegionSuccessor(getOperation()));
 }
 
 ValueRange ExecuteRegionOp::getSuccessorInputs(RegionSuccessor successor) {
-  return successor.isParent() ? ValueRange(getOperation()->getResults())
-                              : ValueRange();
+  return successor.isOperation() ? ValueRange(getOperation()->getResults())
+                                 : ValueRange();
 }
 
 //===----------------------------------------------------------------------===//
@@ -288,10 +288,10 @@ ValueRange ExecuteRegionOp::getSuccessorInputs(RegionSuccessor successor) {
 
 MutableOperandRange
 ConditionOp::getMutableSuccessorOperands(RegionSuccessor point) {
-  assert(
-      (point.isParent() || point.getSuccessor() == &getParentOp().getAfter()) &&
-      "condition op can only exit the loop or branch to the after"
-      "region");
+  assert((point.isOperation() ||
+          point.getSuccessor() == &getParentOp().getAfter()) &&
+         "condition op can only exit the loop or branch to the after"
+         "region");
   // Pass all operands except the condition to the successor region.
   return getArgsMutable();
 }
@@ -308,7 +308,7 @@ void ConditionOp::getSuccessorRegions(
   if (!boolAttr || boolAttr.getValue())
     regions.emplace_back(&whileOp.getAfter());
   if (!boolAttr || !boolAttr.getValue())
-    regions.push_back(RegionSuccessor::parent());
+    regions.push_back(RegionSuccessor(whileOp.getOperation()));
 }
 
 //===----------------------------------------------------------------------===//
@@ -693,7 +693,7 @@ void ForOp::getSuccessorRegions(RegionBranchPoint point,
       if (*tripCount == 0) {
         // The loop has zero iterations. It branches directly back to the
         // parent.
-        regions.push_back(RegionSuccessor::parent());
+        regions.push_back(RegionSuccessor(getOperation()));
       } else {
         // The loop has at least one iteration. It branches into the body.
         regions.push_back(RegionSuccessor(&getRegion()));
@@ -702,7 +702,7 @@ void ForOp::getSuccessorRegions(RegionBranchPoint point,
     } else if (*tripCount == 1) {
       // The loop has exactly 1 iteration. Therefore, it branches from the
       // region to the parent. (No further iteration.)
-      regions.push_back(RegionSuccessor::parent());
+      regions.push_back(RegionSuccessor(getOperation()));
       return;
     }
   }
@@ -711,12 +711,12 @@ void ForOp::getSuccessorRegions(RegionBranchPoint point,
   // back into the operation itself. It is possible for loop not to enter the
   // body.
   regions.push_back(RegionSuccessor(&getRegion()));
-  regions.push_back(RegionSuccessor::parent());
+  regions.push_back(RegionSuccessor(getOperation()));
 }
 
 ValueRange ForOp::getSuccessorInputs(RegionSuccessor successor) {
-  return successor.isParent() ? ValueRange(getResults())
-                              : ValueRange(getRegionIterArgs());
+  return successor.isOperation() ? ValueRange(getResults())
+                                 : ValueRange(getRegionIterArgs());
 }
 
 SmallVector<Region *> ForallOp::getLoopRegions() { return {&getRegion()}; }
@@ -1814,12 +1814,12 @@ void ForallOp::getSuccessorRegions(RegionBranchPoint point,
     regions.push_back(RegionSuccessor(&getRegion()));
     // However, when there are 0 threads, the control flow may branch back to
     // the parent immediately.
-    regions.push_back(RegionSuccessor::parent());
+    regions.push_back(RegionSuccessor(getOperation()));
   } else {
     // In accordance with the semantics of forall, its body is executed in
     // parallel by multiple threads. We should not expect to branch back into
     // the forall body after the region's execution is complete.
-    regions.push_back(RegionSuccessor::parent());
+    regions.push_back(RegionSuccessor(getOperation()));
   }
 }
 
@@ -2101,7 +2101,7 @@ void IfOp::getSuccessorRegions(RegionBranchPoint point,
   // The `then` and the `else` region branch back to the parent operation or one
   // of the recursive parent operations (early exit case).
   if (!point.isParent()) {
-    regions.push_back(RegionSuccessor::parent());
+    regions.push_back(RegionSuccessor(getOperation()));
     return;
   }
 
@@ -2110,14 +2110,14 @@ void IfOp::getSuccessorRegions(RegionBranchPoint point,
   // Don't consider the else region if it is empty.
   Region *elseRegion = &this->getElseRegion();
   if (elseRegion->empty())
-    regions.push_back(RegionSuccessor::parent());
+    regions.push_back(RegionSuccessor(getOperation()));
   else
     regions.push_back(RegionSuccessor(elseRegion));
 }
 
 ValueRange IfOp::getSuccessorInputs(RegionSuccessor successor) {
-  return successor.isParent() ? ValueRange(getOperation()->getResults())
-                              : ValueRange();
+  return successor.isOperation() ? ValueRange(getOperation()->getResults())
+                                 : ValueRange();
 }
 
 void IfOp::getEntrySuccessorRegions(ArrayRef<Attribute> operands,
@@ -2132,7 +2132,7 @@ void IfOp::getEntrySuccessorRegions(ArrayRef<Attribute> operands,
     if (!getElseRegion().empty())
       regions.emplace_back(&getElseRegion());
     else
-      regions.emplace_back(RegionSuccessor::parent());
+      regions.emplace_back(RegionSuccessor(getOperation()));
   }
 }
 
@@ -3128,7 +3128,7 @@ void ParallelOp::getSuccessorRegions(
   // back into the operation itself. It is possible for loop not to enter the
   // body.
   regions.push_back(RegionSuccessor(&getRegion()));
-  regions.push_back(RegionSuccessor::parent());
+  regions.push_back(RegionSuccessor(getOperation()));
 }
 
 //===----------------------------------------------------------------------===//
@@ -3287,12 +3287,12 @@ void WhileOp::getSuccessorRegions(RegionBranchPoint point,
     return;
   }
 
-  regions.push_back(RegionSuccessor::parent());
+  regions.push_back(RegionSuccessor(getOperation()));
   regions.emplace_back(&getAfter());
 }
 
 ValueRange WhileOp::getSuccessorInputs(RegionSuccessor successor) {
-  if (successor.isParent())
+  if (successor.isOperation())
     return getOperation()->getResults();
   if (successor == &getBefore())
     return getBefore().getArguments();
@@ -3830,7 +3830,7 @@ void IndexSwitchOp::getSuccessorRegions(
     RegionBranchPoint point, SmallVectorImpl<RegionSuccessor> &successors) {
   // All regions branch back to the parent op.
   if (!point.isParent()) {
-    successors.push_back(RegionSuccessor::parent());
+    successors.push_back(RegionSuccessor(getOperation()));
     return;
   }
 
@@ -3838,8 +3838,8 @@ void IndexSwitchOp::getSuccessorRegions(
 }
 
 ValueRange IndexSwitchOp::getSuccessorInputs(RegionSuccessor successor) {
-  return successor.isParent() ? ValueRange(getOperation()->getResults())
-                              : ValueRange();
+  return successor.isOperation() ? ValueRange(getOperation()->getResults())
+                                 : ValueRange();
 }
 
 void IndexSwitchOp::getEntrySuccessorRegions(

--- a/mlir/lib/Dialect/Shape/IR/Shape.cpp
+++ b/mlir/lib/Dialect/Shape/IR/Shape.cpp
@@ -346,7 +346,7 @@ void AssumingOp::getSuccessorRegions(
   // parent, so return the correct RegionSuccessor purely based on the index
   // being None or 0.
   if (!point.isParent()) {
-    regions.push_back(RegionSuccessor::parent());
+    regions.push_back(RegionSuccessor(getOperation()));
     return;
   }
 
@@ -354,7 +354,7 @@ void AssumingOp::getSuccessorRegions(
 }
 
 ValueRange AssumingOp::getSuccessorInputs(RegionSuccessor successor) {
-  return successor.isParent() ? ValueRange(getResults()) : ValueRange();
+  return successor.isOperation() ? ValueRange(getResults()) : ValueRange();
 }
 
 void AssumingOp::inlineRegionIntoParent(AssumingOp &op,

--- a/mlir/lib/Dialect/SparseTensor/IR/SparseTensorDialect.cpp
+++ b/mlir/lib/Dialect/SparseTensor/IR/SparseTensorDialect.cpp
@@ -2633,12 +2633,12 @@ void IterateOp::getSuccessorRegions(RegionBranchPoint point,
   // or back into the operation itself.
   regions.push_back(RegionSuccessor(&getRegion()));
   // It is possible for loop not to enter the body.
-  regions.push_back(RegionSuccessor::parent());
+  regions.push_back(RegionSuccessor(getOperation()));
 }
 
 ValueRange IterateOp::getSuccessorInputs(RegionSuccessor successor) {
-  return successor.isParent() ? ValueRange(getResults())
-                              : ValueRange(getRegionIterArgs());
+  return successor.isOperation() ? ValueRange(getResults())
+                                 : ValueRange(getRegionIterArgs());
 }
 
 void CoIterateOp::build(OpBuilder &builder, OperationState &odsState,

--- a/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
+++ b/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
@@ -100,7 +100,7 @@ ensurePayloadIsSeparateFromTransform(transform::TransformOpInterface transform,
 
 OperandRange transform::AlternativesOp::getEntrySuccessorOperands(
     RegionSuccessor successor) {
-  if (!successor.isParent() && getOperation()->getNumOperands() == 1)
+  if (!successor.isOperation() && getOperation()->getNumOperands() == 1)
     return getOperation()->getOperands();
   return OperandRange(getOperation()->operand_end(),
                       getOperation()->operand_end());
@@ -118,12 +118,12 @@ void transform::AlternativesOp::getSuccessorRegions(
     regions.emplace_back(&alternative);
   }
   if (!point.isParent())
-    regions.push_back(RegionSuccessor::parent());
+    regions.push_back(RegionSuccessor(getOperation()));
 }
 
 ValueRange
 transform::AlternativesOp::getSuccessorInputs(RegionSuccessor successor) {
-  if (successor.isParent())
+  if (successor.isOperation())
     return getOperation()->getResults();
   return successor.getSuccessor()->getArguments();
 }
@@ -1711,12 +1711,12 @@ void transform::ForeachOp::getSuccessorRegions(
              &getBody() &&
          "unexpected region index");
   regions.emplace_back(bodyRegion);
-  regions.push_back(RegionSuccessor::parent());
+  regions.push_back(RegionSuccessor(getOperation()));
 }
 
 ValueRange transform::ForeachOp::getSuccessorInputs(RegionSuccessor successor) {
-  return successor.isParent() ? ValueRange(getResults())
-                              : ValueRange(getBody().getArguments());
+  return successor.isOperation() ? ValueRange(getResults())
+                                 : ValueRange(getBody().getArguments());
 }
 
 OperandRange
@@ -2966,14 +2966,14 @@ void transform::SequenceOp::getSuccessorRegions(
   assert(point.getTerminatorPredecessorOrNull()->getParentRegion() ==
              &getBody() &&
          "unexpected region index");
-  regions.push_back(RegionSuccessor::parent());
+  regions.push_back(RegionSuccessor(getOperation()));
 }
 
 ValueRange
 transform::SequenceOp::getSuccessorInputs(RegionSuccessor successor) {
   if (getNumOperands() == 0)
     return ValueRange();
-  if (successor.isParent())
+  if (successor.isOperation())
     return getResults();
   return getBody().getArguments();
 }

--- a/mlir/lib/Dialect/Transform/TuneExtension/TuneExtensionOps.cpp
+++ b/mlir/lib/Dialect/Transform/TuneExtension/TuneExtensionOps.cpp
@@ -128,13 +128,13 @@ void transform::tune::AlternativesOp::getSuccessorRegions(
       for (Region &alternative : getAlternatives())
         regions.emplace_back(&alternative);
   else
-    regions.push_back(RegionSuccessor::parent());
+    regions.push_back(RegionSuccessor(getOperation()));
 }
 
 ValueRange
 transform::tune::AlternativesOp::getSuccessorInputs(RegionSuccessor successor) {
-  return successor.isParent() ? ValueRange(getOperation()->getResults())
-                              : ValueRange();
+  return successor.isOperation() ? ValueRange(getOperation()->getResults())
+                                 : ValueRange();
 }
 
 void transform::tune::AlternativesOp::getRegionInvocationBounds(

--- a/mlir/lib/Dialect/XeGPU/Transforms/XeGPULayoutImpl.cpp
+++ b/mlir/lib/Dialect/XeGPU/Transforms/XeGPULayoutImpl.cpp
@@ -206,7 +206,7 @@ static void propagateRegionResultsToYieldOperands(
 
     for (unsigned i = 0; i < count; ++i) {
       xegpu::DistributeLayoutAttr layout;
-      if (successor.isParent()) {
+      if (successor.isOperation()) {
         // For parent successor, get layout from external use points of the
         // parent op's results.
         auto regionResult = regionBranchOp->getResult(i);

--- a/mlir/lib/Interfaces/ControlFlowInterfaces.cpp
+++ b/mlir/lib/Interfaces/ControlFlowInterfaces.cpp
@@ -187,7 +187,7 @@ LogicalResult detail::verifyRegionBranchOpInterface(Operation *op) {
         if (Region *region = successor.getSuccessor()) {
           diag << "Region #" << region->getRegionNumber();
         } else {
-          diag << "parent";
+          diag << "Operation " << successor.getSuccessorOp()->getName();
         }
         return diag;
       };
@@ -260,13 +260,13 @@ static bool traverseRegionGraph(Region *begin,
       LDBG() << "Found " << successors.size()
              << " successors from terminator in block";
       for (RegionSuccessor successor : successors) {
-        if (!successor.isParent()) {
+        if (successor.isRegion()) {
           worklist.push_back(successor.getSuccessor());
           LDBG() << "Added region #"
                  << successor.getSuccessor()->getRegionNumber()
                  << " to worklist";
         } else {
-          LDBG() << "Skipping parent successor";
+          LDBG() << "Skipping operation successor";
         }
       }
     }
@@ -410,7 +410,7 @@ bool RegionBranchOpInterface::hasLoop() {
   LDBG() << "Found " << entryRegions.size() << " entry regions";
 
   for (RegionSuccessor successor : entryRegions) {
-    if (!successor.isParent()) {
+    if (successor.isRegion()) {
       LDBG() << "Checking entry region #"
              << successor.getSuccessor()->getRegionNumber() << " for loops";
 
@@ -428,7 +428,7 @@ bool RegionBranchOpInterface::hasLoop() {
         return true;
       }
     } else {
-      LDBG() << "Skipping parent successor";
+      LDBG() << "Skipping operation successor";
     }
   }
 
@@ -447,13 +447,13 @@ RegionBranchOpInterface::getSuccessorOperands(RegionBranchPoint src,
 SmallVector<Value>
 RegionBranchOpInterface::getNonSuccessorInputs(RegionSuccessor successor) {
   SmallVector<Value> results = llvm::to_vector(
-      successor.isParent()
-          ? ValueRange(getOperation()->getResults())
+      successor.isOperation()
+          ? ValueRange(successor.getSuccessorOp()->getResults())
           : ValueRange(successor.getSuccessor()->getArguments()));
   ValueRange successorInputs = getSuccessorInputs(successor);
   if (!successorInputs.empty()) {
     unsigned inputBegin =
-        successor.isParent()
+        successor.isOperation()
             ? cast<OpResult>(successorInputs.front()).getResultNumber()
             : cast<BlockArgument>(successorInputs.front()).getArgNumber();
     results.erase(results.begin() + inputBegin,
@@ -1103,19 +1103,20 @@ getSuccessorRegionsWithAttrs(RegionBranchOpInterface op,
 /// Find the single acyclic path through the given region branch op. Return an
 /// empty vector if no such path or multiple such paths exist.
 ///
-/// Example: "scf.if %true" has a single path: parent => then_region => parent
+/// Example: "scf.if %true" has a single path:
+///          parent => then_region => op
 ///
-/// Example: "scf.if ???" has multiple paths:
-///          (1) parent => then_region => parent
-///          (2) parent => else_region => parent
+/// Example: "scf.if %cond" has multiple paths:
+///          (1) parent => then_region => ancestor op
+///          (2) parent => else_region => ancestor op
 ///
 /// Example: "scf.while with scf.condition(%false)" has a single path:
-///          parent => before_region => parent
+///          parent => before_region => ancestor op
 ///
-/// Example: "scf.for with 0 iterations" has a single path: parent => parent
+/// Example: "scf.for with 0 iterations" has a single path: parent => op
 ///
-/// Note: Each path starts and ends with "parent". The "parent" at the beginning
-/// of the path is omitted from the result.
+/// Note: Each path starts from the op. The initial parent branch point is
+/// omitted from the result.
 ///
 /// Note: This function also returns an "empty" path when a region with multiple
 /// blocks was found.
@@ -1135,8 +1136,8 @@ computeSingleAcyclicRegionBranchPath(RegionBranchOpInterface op) {
       return {};
     }
     path.push_back(successors.front());
-    if (successors.front().isParent()) {
-      // Found path that ends with "parent".
+    if (successors.front().isOperation()) {
+      // Found path that ends after an operation.
       return path;
     }
     Region *region = successors.front().getSuccessor();
@@ -1238,20 +1239,20 @@ struct InlineRegionBranchOp : public RewritePattern {
       unsigned firstSuccessorInputIdx = 0;
       if (!successorInputs.empty())
         firstSuccessorInputIdx =
-            nextSuccessor.isParent()
+            nextSuccessor.isOperation()
                 ? cast<OpResult>(successorInputs.front()).getResultNumber()
                 : cast<BlockArgument>(successorInputs.front()).getArgNumber();
       // Query the total number of block arguments / op results.
       unsigned numValues =
-          nextSuccessor.isParent()
-              ? op->getNumResults()
+          nextSuccessor.isOperation()
+              ? nextSuccessor.getSuccessorOp()->getNumResults()
               : nextSuccessor.getSuccessor()->getNumArguments();
       // Compute replacement values for all block arguments / op results.
       SmallVector<Value> replacements;
       // Helper function to get the i-th block argument / op result.
       auto getValue = [&](unsigned idx) {
-        return nextSuccessor.isParent()
-                   ? Value(op->getResult(idx))
+        return nextSuccessor.isOperation()
+                   ? Value(nextSuccessor.getSuccessorOp()->getResult(idx))
                    : Value(nextSuccessor.getSuccessor()->getArgument(idx));
       };
       // Compute replacement values for all non-successor-input values that
@@ -1267,9 +1268,12 @@ struct InlineRegionBranchOp : public RewritePattern {
       for (unsigned i = replacements.size(); i < numValues; ++i)
         replacements.push_back(
             replBuilderFn(rewriter, op->getLoc(), getValue(i)));
-      if (nextSuccessor.isParent()) {
-        // The path ends with "parent". Replace the region branch op with the
+      if (nextSuccessor.isOperation()) {
+        // The path ends after the region branch op. Replace it with the
         // computed replacement values.
+        if (nextSuccessor.getSuccessorOp() != op)
+          return rewriter.notifyMatchFailure(
+              op, "path ends after a different operation");
         assert(remainingPath.empty() && "expected that the path ended");
         rewriter.replaceOp(op, replacements);
         return success();
@@ -1287,7 +1291,7 @@ struct InlineRegionBranchOp : public RewritePattern {
       rewriter.eraseOp(terminator);
     }
 
-    llvm_unreachable("expected that paths ends with parent");
+    llvm_unreachable("expected that path ends with an operation");
   }
 
   NonSuccessorInputReplacementBuilderFn replBuilderFn;

--- a/mlir/test/Dialect/SCF/invalid.mlir
+++ b/mlir/test/Dialect/SCF/invalid.mlir
@@ -98,7 +98,7 @@ func.func @not_enough_loop_results(%arg0: index, %init: f32) {
 // -----
 
 func.func @scf_for_incorrect_result_type(%arg0: index, %init: f32) {
-  // expected-error @below{{along control flow edge from parent to parent: successor operand type #0 'f32' should match successor input type #0 'f64'}}
+  // expected-error @below{{along control flow edge from parent to Operation scf.for: successor operand type #0 'f32' should match successor input type #0 'f64'}}
   // expected-note @below{{region branch point}}
   "scf.for"(%arg0, %arg0, %arg0, %init) (
     {
@@ -418,7 +418,7 @@ func.func @reduceReturn_not_inside_reduce(%arg0 : f32) {
 
 func.func @std_if_incorrect_yield(%arg0: i1, %arg1: f32)
 {
-  // expected-error@+1 {{along control flow edge from Operation scf.yield to parent: region branch point has 1 operands, but region successor needs 2 inputs}}
+  // expected-error@+1 {{along control flow edge from Operation scf.yield to Operation scf.if: region branch point has 1 operands, but region successor needs 2 inputs}}
   %x, %y = scf.if %arg0 -> (f32, f32) {
     %0 = arith.addf %arg1, %arg1 : f32
     // expected-note@+1 {{region branch point}}
@@ -619,7 +619,7 @@ func.func @while_cross_region_type_mismatch() {
 
 func.func @while_result_type_mismatch() {
   %true = arith.constant true
-  // expected-error@+1 {{along control flow edge from Operation scf.condition to parent: region branch point has 1 operands, but region successor needs 0 inputs}}
+  // expected-error@+1 {{along control flow edge from Operation scf.condition to Operation scf.while: region branch point has 1 operands, but region successor needs 0 inputs}}
   scf.while : () -> () {
     // expected-note@+1 {{region branch point}}
     scf.condition(%true) %true : i1

--- a/mlir/test/lib/Analysis/DataFlow/TestDenseBackwardDataFlowAnalysis.cpp
+++ b/mlir/test/lib/Analysis/DataFlow/TestDenseBackwardDataFlowAnalysis.cpp
@@ -246,15 +246,15 @@ void NextAccessAnalysis::visitRegionBranchControlFlowTransfer(
   LDBG() << "visitRegionBranchControlFlowTransfer: "
          << OpWithFlags(branch.getOperation(), OpPrintingFlags().skipRegions());
   LDBG() << "  regionFrom: " << (regionFrom.isParent() ? "parent" : "region");
-  LDBG() << "  regionTo: " << (regionTo.isParent() ? "parent" : "region");
+  LDBG() << "  regionTo: " << (regionTo.isOperation() ? "operation" : "region");
 
   auto testStoreWithARegion =
       dyn_cast<::test::TestStoreWithARegion>(branch.getOperation());
 
-  if (testStoreWithARegion &&
-      ((regionTo.isParent() && !testStoreWithARegion.getStoreBeforeRegion()) ||
-       (regionFrom.isParent() &&
-        testStoreWithARegion.getStoreBeforeRegion()))) {
+  if (testStoreWithARegion && ((regionTo.isOperation() &&
+                                !testStoreWithARegion.getStoreBeforeRegion()) ||
+                               (regionFrom.isParent() &&
+                                testStoreWithARegion.getStoreBeforeRegion()))) {
     LDBG() << "  Handling TestStoreWithARegion with special logic";
     (void)visitOperation(branch, static_cast<const NextAccess &>(after),
                          static_cast<NextAccess *>(before));
@@ -375,7 +375,7 @@ struct TestNextAccessPass
       SmallVector<RegionSuccessor> regionSuccessors;
       iface.getSuccessorRegions(RegionBranchPoint::parent(), regionSuccessors);
       for (const RegionSuccessor &successor : regionSuccessors) {
-        if (successor.isParent() || successor.getSuccessor()->empty())
+        if (successor.isOperation() || successor.getSuccessor()->empty())
           continue;
         Block &successorBlock = successor.getSuccessor()->front();
         ProgramPoint *successorPoint =

--- a/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
+++ b/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
@@ -775,7 +775,7 @@ void RegionIfOp::getSuccessorRegions(
         &getJoinRegion())
       regions.push_back(RegionSuccessor(&getJoinRegion()));
     else
-      regions.push_back(RegionSuccessor::parent());
+      regions.push_back(RegionSuccessor(getOperation()));
     return;
   }
 
@@ -785,7 +785,7 @@ void RegionIfOp::getSuccessorRegions(
 }
 
 ValueRange RegionIfOp::getSuccessorInputs(RegionSuccessor successor) {
-  if (successor.isParent())
+  if (successor.isOperation())
     return getResults();
   if (successor == &getThenRegion())
     return getThenArgs();
@@ -814,11 +814,11 @@ void AnyCondOp::getSuccessorRegions(RegionBranchPoint point,
   if (point.isParent())
     regions.emplace_back(&getRegion());
   else
-    regions.push_back(RegionSuccessor::parent());
+    regions.push_back(RegionSuccessor(getOperation()));
 }
 
 ValueRange AnyCondOp::getSuccessorInputs(RegionSuccessor successor) {
-  return successor.isParent() ? ValueRange(getResults()) : ValueRange();
+  return successor.isOperation() ? ValueRange(getResults()) : ValueRange();
 }
 
 void AnyCondOp::getRegionInvocationBounds(
@@ -1309,12 +1309,12 @@ void LoopBlockOp::getSuccessorRegions(
   if (point.isParent())
     return;
 
-  regions.push_back(RegionSuccessor::parent());
+  regions.push_back(RegionSuccessor(getOperation()));
 }
 
 ValueRange LoopBlockOp::getSuccessorInputs(RegionSuccessor successor) {
-  return successor.isParent() ? ValueRange(getOperation()->getResults())
-                              : ValueRange(getBody().getArguments());
+  return successor.isOperation() ? ValueRange(getOperation()->getResults())
+                                 : ValueRange(getBody().getArguments());
 }
 
 OperandRange LoopBlockOp::getEntrySuccessorOperands(RegionSuccessor successor) {
@@ -1328,7 +1328,7 @@ OperandRange LoopBlockOp::getEntrySuccessorOperands(RegionSuccessor successor) {
 
 MutableOperandRange
 LoopBlockTerminatorOp::getMutableSuccessorOperands(RegionSuccessor successor) {
-  if (successor.isParent())
+  if (successor.isOperation())
     return getExitArgMutable();
   return getNextIterArgMutable();
 }
@@ -1447,12 +1447,12 @@ void TestStoreWithARegion::getSuccessorRegions(
   if (point.isParent())
     regions.emplace_back(&getBody());
   else
-    regions.push_back(RegionSuccessor::parent());
+    regions.push_back(RegionSuccessor(getOperation()));
 }
 
 ValueRange TestStoreWithARegion::getSuccessorInputs(RegionSuccessor successor) {
-  return successor.isParent() ? ValueRange(getOperation()->getResults())
-                              : ValueRange(getBody().front().getArguments());
+  return successor.isOperation() ? ValueRange(getOperation()->getResults())
+                                 : ValueRange(getBody().front().getArguments());
 }
 
 //===----------------------------------------------------------------------===//
@@ -1465,13 +1465,13 @@ void TestStoreWithALoopRegion::getSuccessorRegions(
   // back into the operation itself. It is possible for the operation not to
   // enter the body.
   regions.emplace_back(&getBody());
-  regions.push_back(RegionSuccessor::parent());
+  regions.push_back(RegionSuccessor(getOperation()));
 }
 
 ValueRange
 TestStoreWithALoopRegion::getSuccessorInputs(RegionSuccessor successor) {
-  return successor.isParent() ? ValueRange(getOperation()->getResults())
-                              : ValueRange(getBody().front().getArguments());
+  return successor.isOperation() ? ValueRange(getOperation()->getResults())
+                                 : ValueRange(getBody().front().getArguments());
 }
 
 //===----------------------------------------------------------------------===//
@@ -1483,7 +1483,7 @@ void TestRegionTypesCompatOp::getSuccessorRegions(
   if (point.isParent())
     regions.emplace_back(&getBody());
   else
-    regions.push_back(RegionSuccessor::parent());
+    regions.push_back(RegionSuccessor(getOperation()));
 }
 
 OperandRange
@@ -1493,7 +1493,7 @@ TestRegionTypesCompatOp::getEntrySuccessorOperands(RegionSuccessor) {
 
 ValueRange
 TestRegionTypesCompatOp::getSuccessorInputs(RegionSuccessor successor) {
-  if (successor.isParent())
+  if (successor.isOperation())
     return getResults();
   return getBody().getArguments();
 }
@@ -1510,7 +1510,7 @@ void TestLoopTypesCompatOp::getSuccessorRegions(
     RegionBranchPoint point, SmallVectorImpl<RegionSuccessor> &regions) {
   regions.emplace_back(&getBody());
   if (!point.isParent())
-    regions.push_back(RegionSuccessor::parent());
+    regions.push_back(RegionSuccessor(getOperation()));
 }
 
 OperandRange TestLoopTypesCompatOp::getEntrySuccessorOperands(RegionSuccessor) {
@@ -1519,7 +1519,7 @@ OperandRange TestLoopTypesCompatOp::getEntrySuccessorOperands(RegionSuccessor) {
 
 ValueRange
 TestLoopTypesCompatOp::getSuccessorInputs(RegionSuccessor successor) {
-  if (successor.isParent())
+  if (successor.isOperation())
     return getResults();
   return getBody().getArguments();
 }
@@ -1555,7 +1555,7 @@ void TestRegionTypeChangerOp::getSuccessorRegions(
   if (point.isParent())
     regions.emplace_back(&getBody());
   else
-    regions.push_back(RegionSuccessor::parent());
+    regions.push_back(RegionSuccessor(getOperation()));
 }
 
 OperandRange
@@ -1565,7 +1565,7 @@ TestRegionTypeChangerOp::getEntrySuccessorOperands(RegionSuccessor) {
 
 ValueRange
 TestRegionTypeChangerOp::getSuccessorInputs(RegionSuccessor successor) {
-  if (successor.isParent())
+  if (successor.isOperation())
     return getResults();
   return getBody().getArguments();
 }

--- a/mlir/unittests/Interfaces/ControlFlowInterfacesTest.cpp
+++ b/mlir/unittests/Interfaces/ControlFlowInterfacesTest.cpp
@@ -66,15 +66,15 @@ struct LoopRegionsOp
       Region *region =
           point.getTerminatorPredecessorOrNull()->getParentRegion();
       if (region == &(*this)->getRegion(1))
-        // This region also branches back to the parent.
-        regions.push_back(RegionSuccessor::parent());
+        // This region also branches back to this operation.
+        regions.push_back(RegionSuccessor(getOperation()));
       regions.push_back(RegionSuccessor(region));
     }
   }
 
   ValueRange getSuccessorInputs(RegionSuccessor successor) {
-    return successor.isParent() ? ValueRange(getOperation()->getResults())
-                                : ValueRange();
+    return successor.isOperation() ? ValueRange(getOperation()->getResults())
+                                   : ValueRange();
   }
 
   using RegionBranchOpInterface::Trait<LoopRegionsOp>::getSuccessorRegions;
@@ -96,14 +96,14 @@ struct DoubleLoopRegionsOp
     if (point.getTerminatorPredecessorOrNull()) {
       Region *region =
           point.getTerminatorPredecessorOrNull()->getParentRegion();
-      regions.push_back(RegionSuccessor::parent());
+      regions.push_back(RegionSuccessor(getOperation()));
       regions.push_back(RegionSuccessor(region));
     }
   }
 
   ValueRange getSuccessorInputs(RegionSuccessor successor) {
-    return successor.isParent() ? ValueRange(getOperation()->getResults())
-                                : ValueRange();
+    return successor.isOperation() ? ValueRange(getOperation()->getResults())
+                                   : ValueRange();
   }
 
   using RegionBranchOpInterface::Trait<


### PR DESCRIPTION
Replace the RegionSuccessor parent sentinel with an explicit Operation * target. Operation successors now model continuing after that operation, while region successors continue to point at Region.

Update RegionBranchOpInterface helpers, analyses, and dialect implementations to use operation successors. This removes the ambiguity of interpreting parent relative to whichever operation produced the successor when introducing early-exits.

For downstream integration for this API change:

- `successor.isParent()` -> `successor.isOperation()`
- `RegionSuccessor::parent()` -> RegionSuccessor(op)` ; that means that you need to have access to the target op. In general it is either `getOperation()` or `getParentOp()` (depending if you're updating a method on the `RegionBranchOpInterface` operation or on the terminator.

Assisted-by: Codex