### PR TITLE
[clang] Handle constructor closures with consteval default args

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -514,6 +514,9 @@ class ASTContext : public RefCountedBase<ASTContext> {
   /// Declaration for the CUDA cudaLaunchDevice function.
   FunctionDecl *cudaLaunchDeviceDecl = nullptr;
 
+  llvm::DenseMap<const CXXConstructorDecl *, ArrayRef<CXXDefaultArgExpr *>>
+      CtorClosureDefaultArgs;
+
   /// Keeps track of all declaration attributes.
   ///
   /// Since so few decls have attrs, we keep them in a hash map instead of
@@ -1147,6 +1150,11 @@ public:
 
   /// Erase the attributes corresponding to the given declaration.
   void eraseDeclAttrs(const Decl *D);
+
+  ArrayRef<CXXDefaultArgExpr *>
+  getCtorClosureDefaultArgs(const CXXConstructorDecl *CD);
+  void setCtorClosureDefaultArgs(const CXXConstructorDecl *CD,
+                                 ArrayRef<CXXDefaultArgExpr *> Args);
 
   /// Get all ExplicitInstantiationDecls for a given specialization.
   ArrayRef<ExplicitInstantiationDecl *>

--- a/clang/include/clang/AST/DeclCXX.h
+++ b/clang/include/clang/AST/DeclCXX.h
@@ -2668,6 +2668,11 @@ public:
   friend class ASTDeclWriter;
   friend TrailingObjects;
 
+  // FIXME: Just hacking it in here for now.
+  Expr **CtorClosureArgs = nullptr;
+  Expr **ctorClosureArgs() const { return CtorClosureArgs; }
+  void setCtorClosureArgs(Expr **Args) { CtorClosureArgs = Args; }
+
   static CXXConstructorDecl *CreateDeserialized(ASTContext &C, GlobalDeclID ID,
                                                 uint64_t AllocKind);
   static CXXConstructorDecl *

--- a/clang/include/clang/AST/DeclCXX.h
+++ b/clang/include/clang/AST/DeclCXX.h
@@ -2670,8 +2670,8 @@ public:
 
   // FIXME: Just hacking it in here for now.
   Expr **CtorClosureArgs = nullptr;
-  Expr **ctorClosureArgs() const { return CtorClosureArgs; }
-  void setCtorClosureArgs(Expr **Args) { CtorClosureArgs = Args; }
+  Expr **ctorClosureArgs() const { return getCanonicalDecl()->CtorClosureArgs; }
+  void setCtorClosureArgs(Expr **Args) { getCanonicalDecl()->CtorClosureArgs = Args; }
 
   static CXXConstructorDecl *CreateDeserialized(ASTContext &C, GlobalDeclID ID,
                                                 uint64_t AllocKind);

--- a/clang/include/clang/AST/DeclCXX.h
+++ b/clang/include/clang/AST/DeclCXX.h
@@ -2864,8 +2864,8 @@ public:
     return const_cast<CXXConstructorDecl*>(this)->getCanonicalDecl();
   }
 
-  ArrayRef<CXXDefaultArgExpr*> getCtorClosureDefaultArgs() const;
-  void setCtorClosureDefaultArgs(ArrayRef<CXXDefaultArgExpr*> Args);
+  ArrayRef<CXXDefaultArgExpr *> getCtorClosureDefaultArgs() const;
+  void setCtorClosureDefaultArgs(ArrayRef<CXXDefaultArgExpr *> Args);
 
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) { return classofKind(D->getKind()); }

--- a/clang/include/clang/AST/DeclCXX.h
+++ b/clang/include/clang/AST/DeclCXX.h
@@ -2668,11 +2668,6 @@ public:
   friend class ASTDeclWriter;
   friend TrailingObjects;
 
-  // FIXME: Just hacking it in here for now.
-  Expr **CtorClosureArgs = nullptr;
-  Expr **ctorClosureArgs() const { return getCanonicalDecl()->CtorClosureArgs; }
-  void setCtorClosureArgs(Expr **Args) { getCanonicalDecl()->CtorClosureArgs = Args; }
-
   static CXXConstructorDecl *CreateDeserialized(ASTContext &C, GlobalDeclID ID,
                                                 uint64_t AllocKind);
   static CXXConstructorDecl *
@@ -2868,6 +2863,9 @@ public:
   const CXXConstructorDecl *getCanonicalDecl() const {
     return const_cast<CXXConstructorDecl*>(this)->getCanonicalDecl();
   }
+
+  ArrayRef<CXXDefaultArgExpr*> getCtorClosureDefaultArgs() const;
+  void setCtorClosureDefaultArgs(ArrayRef<CXXDefaultArgExpr*> Args);
 
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) { return classofKind(D->getKind()); }

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -14265,11 +14265,8 @@ public:
                           LateInstantiatedAttrVec *LateAttrs = nullptr,
                           LocalInstantiationScope *OuterMostScope = nullptr);
 
-  /// In the MS ABI, we need to instantiate default arguments of dllexported
-  /// default constructors along with the constructor definition. This allows IR
-  /// gen to emit a constructor closure which calls the default constructor with
-  /// its default arguments.
-  void InstantiateDefaultCtorDefaultArgs(CXXConstructorDecl *Ctor);
+  /// XXX: comment
+  void BuildDefaultArgsForCtorClosure(CXXConstructorDecl *Ctor);
 
   bool InstantiateDefaultArgument(SourceLocation CallLoc, FunctionDecl *FD,
                                   ParmVarDecl *Param);

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -14265,8 +14265,8 @@ public:
                           LateInstantiatedAttrVec *LateAttrs = nullptr,
                           LocalInstantiationScope *OuterMostScope = nullptr);
 
-  /// XXX: comment
-  bool BuildDefaultArgsForCtorClosure(SourceLocation Loc, CXXConstructorDecl *Ctor, bool IsCopy = false);
+  bool BuildCtorClosureDefaultArgs(SourceLocation Loc, CXXConstructorDecl *Ctor,
+                                   bool IsCopy = false);
 
   bool InstantiateDefaultArgument(SourceLocation CallLoc, FunctionDecl *FD,
                                   ParmVarDecl *Param);

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -14266,7 +14266,7 @@ public:
                           LocalInstantiationScope *OuterMostScope = nullptr);
 
   /// XXX: comment
-  void BuildDefaultArgsForCtorClosure(CXXConstructorDecl *Ctor);
+  bool BuildDefaultArgsForCtorClosure(SourceLocation Loc, CXXConstructorDecl *Ctor, bool IsCopy = false);
 
   bool InstantiateDefaultArgument(SourceLocation CallLoc, FunctionDecl *FD,
                                   ParmVarDecl *Param);

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -989,6 +989,8 @@ void ASTContext::cleanup() {
     A->second->~AttrVec();
   DeclAttrs.clear();
 
+  CtorClosureDefaultArgs.clear();
+
   for (const auto &Value : ModuleInitializers)
     Value.second->~PerModuleInitializers();
   ModuleInitializers.clear();
@@ -1545,6 +1547,17 @@ void ASTContext::eraseDeclAttrs(const Decl *D) {
     Pos->second->~AttrVec();
     DeclAttrs.erase(Pos);
   }
+}
+
+ArrayRef<CXXDefaultArgExpr *>
+ASTContext::getCtorClosureDefaultArgs(const CXXConstructorDecl *CD) {
+  return CtorClosureDefaultArgs.lookup(CD);
+}
+
+void ASTContext::setCtorClosureDefaultArgs(const CXXConstructorDecl *CD,
+                                           ArrayRef<CXXDefaultArgExpr *> Args) {
+  assert(!CtorClosureDefaultArgs.contains(CD));
+  CtorClosureDefaultArgs[CD] = Args;
 }
 
 ArrayRef<ExplicitInstantiationDecl *>

--- a/clang/lib/AST/DeclCXX.cpp
+++ b/clang/lib/AST/DeclCXX.cpp
@@ -3132,6 +3132,16 @@ bool CXXConstructorDecl::isSpecializationCopyingObject() const {
   return ParamType == ClassTy;
 }
 
+ArrayRef<CXXDefaultArgExpr *>
+CXXConstructorDecl::getCtorClosureDefaultArgs() const {
+  return getASTContext().getCtorClosureDefaultArgs(getCanonicalDecl());
+}
+
+void CXXConstructorDecl::setCtorClosureDefaultArgs(
+    ArrayRef<CXXDefaultArgExpr *> Args) {
+  getASTContext().setCtorClosureDefaultArgs(getCanonicalDecl(), Args);
+}
+
 void CXXDestructorDecl::anchor() {}
 
 CXXDestructorDecl *CXXDestructorDecl::CreateDeserialized(ASTContext &C,

--- a/clang/lib/CodeGen/MicrosoftCXXABI.cpp
+++ b/clang/lib/CodeGen/MicrosoftCXXABI.cpp
@@ -4207,18 +4207,19 @@ MicrosoftCXXABI::getAddrOfCXXCtorClosure(const CXXConstructorDecl *CD,
   if (SrcVal)
     Args.add(RValue::get(SrcVal), SrcParam->getType());
 
+
   // Add the rest of the default arguments.
   SmallVector<const Stmt *, 4> ArgVec;
-  ArrayRef<ParmVarDecl *> params = CD->parameters().drop_front(IsCopy ? 1 : 0);
-  for (const ParmVarDecl *PD : params) {
-    assert(PD->hasDefaultArg() && "ctor closure lacks default args");
-    ArgVec.push_back(PD->getDefaultArg());
+  for (unsigned I = IsCopy ? 1 : 0, N = CD->getNumParams(); I != N; ++I) {
+    assert(CD->getParamDecl(I)->hasDefaultArg() && "ctor closure lacks default args");
+    assert(CD->ctorClosureArgs());
+    ArgVec.push_back(CD->ctorClosureArgs()[I]);
   }
 
   CodeGenFunction::RunCleanupsScope Cleanups(CGF);
 
   const auto *FPT = CD->getType()->castAs<FunctionProtoType>();
-  CGF.EmitCallArgs(Args, FPT, llvm::ArrayRef(ArgVec), CD, IsCopy ? 1 : 0);
+  CGF.EmitCallArgs(Args, FPT, ArrayRef(ArgVec), CD, IsCopy ? 1 : 0);
 
   // Insert any ABI-specific implicit constructor arguments.
   AddedStructorArgCounts ExtraArgs =

--- a/clang/lib/CodeGen/MicrosoftCXXABI.cpp
+++ b/clang/lib/CodeGen/MicrosoftCXXABI.cpp
@@ -4209,7 +4209,8 @@ MicrosoftCXXABI::getAddrOfCXXCtorClosure(const CXXConstructorDecl *CD,
 
   // Get the rest of the default arguments.
   SmallVector<const Stmt *, 4> ArgVec;
-  for (const CXXDefaultArgExpr *Expr : CD->getCtorClosureDefaultArgs())
+  for (const CXXDefaultArgExpr *Expr :
+       CD->getCtorClosureDefaultArgs().drop_front(IsCopy ? 1 : 0))
     ArgVec.push_back(Expr);
   assert(ArgVec.size() == CD->getNumParams() - IsCopy);
 

--- a/clang/lib/CodeGen/MicrosoftCXXABI.cpp
+++ b/clang/lib/CodeGen/MicrosoftCXXABI.cpp
@@ -4214,7 +4214,6 @@ MicrosoftCXXABI::getAddrOfCXXCtorClosure(const CXXConstructorDecl *CD,
     ArgVec.push_back(Expr);
   assert(ArgVec.size() == CD->getNumParams() - IsCopy);
 
-
   CodeGenFunction::RunCleanupsScope Cleanups(CGF);
 
   const auto *FPT = CD->getType()->castAs<FunctionProtoType>();

--- a/clang/lib/CodeGen/MicrosoftCXXABI.cpp
+++ b/clang/lib/CodeGen/MicrosoftCXXABI.cpp
@@ -4207,14 +4207,12 @@ MicrosoftCXXABI::getAddrOfCXXCtorClosure(const CXXConstructorDecl *CD,
   if (SrcVal)
     Args.add(RValue::get(SrcVal), SrcParam->getType());
 
-
-  // Add the rest of the default arguments.
+  // Get the rest of the default arguments.
   SmallVector<const Stmt *, 4> ArgVec;
-  for (unsigned I = IsCopy ? 1 : 0, N = CD->getNumParams(); I != N; ++I) {
-    assert(CD->getParamDecl(I)->hasDefaultArg() && "ctor closure lacks default args");
-    assert(CD->ctorClosureArgs());
-    ArgVec.push_back(CD->ctorClosureArgs()[I]);
-  }
+  for (const CXXDefaultArgExpr *Expr : CD->getCtorClosureDefaultArgs())
+    ArgVec.push_back(Expr);
+  assert(ArgVec.size() == CD->getNumParams() - IsCopy);
+
 
   CodeGenFunction::RunCleanupsScope Cleanups(CGF);
 

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -16307,7 +16307,7 @@ Decl *Sema::ActOnStartOfFunctionDef(Scope *FnBodyScope, Decl *D,
       // If this is an MS ABI dllexport default constructor, instantiate any
       // default arguments.
       if (DLLExportAttr *Attr = Ctor->getAttr<DLLExportAttr>())
-        BuildDefaultArgsForCtorClosure(Attr->getLocation(), Ctor);
+        BuildCtorClosureDefaultArgs(Attr->getLocation(), Ctor);
     }
   }
 

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -16306,7 +16306,8 @@ Decl *Sema::ActOnStartOfFunctionDef(Scope *FnBodyScope, Decl *D,
         Context.getTargetInfo().getCXXABI().isMicrosoft()) {
       // If this is an MS ABI dllexport default constructor, instantiate any
       // default arguments.
-      BuildDefaultArgsForCtorClosure(Ctor);
+      if (DLLExportAttr *Attr = Ctor->getAttr<DLLExportAttr>())
+        BuildDefaultArgsForCtorClosure(Attr->getLocation(), Ctor);
     }
   }
 

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -16306,7 +16306,7 @@ Decl *Sema::ActOnStartOfFunctionDef(Scope *FnBodyScope, Decl *D,
         Context.getTargetInfo().getCXXABI().isMicrosoft()) {
       // If this is an MS ABI dllexport default constructor, instantiate any
       // default arguments.
-      InstantiateDefaultCtorDefaultArgs(Ctor);
+      BuildDefaultArgsForCtorClosure(Ctor);
     }
   }
 

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -19826,8 +19826,9 @@ bool Sema::BuildCtorClosureDefaultArgs(SourceLocation Loc,
     Args[0] = nullptr; // Copy ctor closure will provide the first argument.
 
   for (unsigned I = IsCopy ? 1 : 0; I != NumParams; ++I) {
+    EnterExpressionEvaluationContext EvalContext(
+        *this, ExpressionEvaluationContext::Unevaluated);
     ExprResult R = BuildCXXDefaultArgExpr(Loc, Ctor, Ctor->getParamDecl(I));
-    CleanupVarDeclMarking();
     if (R.isInvalid())
       return true;
     Args[I] = cast<CXXDefaultArgExpr>(R.get());

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -6339,7 +6339,7 @@ static void ReferenceDllExportedMembers(Sema &S, CXXRecordDecl *Class) {
       if (S.Context.getTargetInfo().getCXXABI().isMicrosoft()) {
         auto *CD = dyn_cast<CXXConstructorDecl>(MD);
         if (CD && CD->isDefaultConstructor() && TSK == TSK_Undeclared) {
-          S.BuildDefaultArgsForCtorClosure(CD);
+          S.BuildDefaultArgsForCtorClosure(CD->getAttr<DLLExportAttr>()->getLocation(), CD);
         }
       }
 
@@ -19805,19 +19805,19 @@ void Sema::ActOnFinishFunctionDeclarationDeclarator(Declarator &Declarator) {
   InventedParameterInfos.pop_back();
 }
 
-void Sema::BuildDefaultArgsForCtorClosure(CXXConstructorDecl *Ctor) {
-  assert(Context.getTargetInfo().getCXXABI().isMicrosoft() &&
-         Ctor->isDefaultConstructor());
+bool Sema::BuildDefaultArgsForCtorClosure(SourceLocation Loc, CXXConstructorDecl *Ctor, bool IsCopy) {
+  assert(Context.getTargetInfo().getCXXABI().isMicrosoft());
+
   unsigned NumParams = Ctor->getNumParams();
   if (NumParams == 0)
-    return;
-  DLLExportAttr *Attr = Ctor->getAttr<DLLExportAttr>();
-  if (!Attr)
-    return;
-  for (unsigned I = 0; I != NumParams; ++I) {
-    (void)CheckCXXDefaultArgExpr(Attr->getLocation(), Ctor,
-                                   Ctor->getParamDecl(I));
-    CleanupVarDeclMarking();
+    return false;
+
+  unsigned FirstParam = IsCopy ? 1 : 0;
+  for (unsigned I = FirstParam; I != NumParams; ++I) {
+    if (CheckCXXDefaultArgExpr(Loc, Ctor, Ctor->getParamDecl(I)))
+      return true;
+    CleanupVarDeclMarking(); // XXX: still not sure what this does.
   }
 
+  return false;
 }

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -6392,10 +6392,8 @@ static void checkForMultipleExportedDefaultConstructors(Sema &S,
     // If the class is non-dependent, mark the default arguments as ODR-used so
     // that we can properly codegen the constructor closure.
     if (!Class->isDependentContext()) {
-      for (ParmVarDecl *PD : CD->parameters()) {
-        (void)S.CheckCXXDefaultArgExpr(Attr->getLocation(), CD, PD);
-        S.DiscardCleanupsInEvaluationContext();
-      }
+      S.BuildDefaultArgsForCtorClosure(Attr->getLocation(), CD);
+      S.DiscardCleanupsInEvaluationContext();
     }
 
     if (LastExportedDefaultCtor) {
@@ -19814,9 +19812,11 @@ bool Sema::BuildDefaultArgsForCtorClosure(SourceLocation Loc, CXXConstructorDecl
 
   unsigned FirstParam = IsCopy ? 1 : 0;
   for (unsigned I = FirstParam; I != NumParams; ++I) {
-    if (CheckCXXDefaultArgExpr(Loc, Ctor, Ctor->getParamDecl(I)))
+    ExprResult R = BuildCXXDefaultArgExpr(Loc, Ctor, Ctor->getParamDecl(I));
+    if (R.isInvalid())
       return true;
-    CleanupVarDeclMarking(); // XXX: still not sure what this does.
+
+    CleanupVarDeclMarking();
   }
 
   return false;

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -19808,25 +19808,31 @@ bool Sema::BuildCtorClosureDefaultArgs(SourceLocation Loc,
                                        CXXConstructorDecl *Ctor, bool IsCopy) {
   assert(Context.getTargetInfo().getCXXABI().isMicrosoft());
 
-  if (!Ctor->getCtorClosureDefaultArgs().empty())
+  if (!Ctor->getCtorClosureDefaultArgs().empty()) {
+    // If we build args for default constructor closures, those will have
+    // been generated *before* building args for any copy constructor closures.
+    assert(IsCopy || Ctor->getCtorClosureDefaultArgs()[0] != nullptr);
     return false;
+  }
 
   unsigned NumParams = Ctor->getNumParams();
   if (NumParams == 0)
     return false;
-  unsigned FirstParam = IsCopy ? 1 : 0;
 
   CXXDefaultArgExpr **Args =
-      new (getASTContext()) CXXDefaultArgExpr *[NumParams - FirstParam];
+      new (getASTContext()) CXXDefaultArgExpr *[NumParams];
 
-  for (unsigned I = FirstParam; I != NumParams; ++I) {
+  if (IsCopy)
+    Args[0] = nullptr; // Copy ctor closure will provide the first argument.
+
+  for (unsigned I = IsCopy ? 1 : 0; I != NumParams; ++I) {
     ExprResult R = BuildCXXDefaultArgExpr(Loc, Ctor, Ctor->getParamDecl(I));
     CleanupVarDeclMarking();
     if (R.isInvalid())
       return true;
-    Args[I - FirstParam] = cast<CXXDefaultArgExpr>(R.get());
+    Args[I] = cast<CXXDefaultArgExpr>(R.get());
   }
 
-  Ctor->setCtorClosureDefaultArgs(ArrayRef(Args, NumParams - FirstParam));
+  Ctor->setCtorClosureDefaultArgs(ArrayRef(Args, NumParams));
   return false;
 }

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -6339,7 +6339,8 @@ static void ReferenceDllExportedMembers(Sema &S, CXXRecordDecl *Class) {
       if (S.Context.getTargetInfo().getCXXABI().isMicrosoft()) {
         auto *CD = dyn_cast<CXXConstructorDecl>(MD);
         if (CD && CD->isDefaultConstructor() && TSK == TSK_Undeclared) {
-          S.BuildDefaultArgsForCtorClosure(CD->getAttr<DLLExportAttr>()->getLocation(), CD);
+          S.BuildCtorClosureDefaultArgs(
+              CD->getAttr<DLLExportAttr>()->getLocation(), CD);
         }
       }
 
@@ -6392,7 +6393,7 @@ static void checkForMultipleExportedDefaultConstructors(Sema &S,
     // If the class is non-dependent, mark the default arguments as ODR-used so
     // that we can properly codegen the constructor closure.
     if (!Class->isDependentContext()) {
-      S.BuildDefaultArgsForCtorClosure(Attr->getLocation(), CD);
+      S.BuildCtorClosureDefaultArgs(Attr->getLocation(), CD);
       S.DiscardCleanupsInEvaluationContext();
     }
 
@@ -19803,9 +19804,8 @@ void Sema::ActOnFinishFunctionDeclarationDeclarator(Declarator &Declarator) {
   InventedParameterInfos.pop_back();
 }
 
-bool Sema::BuildDefaultArgsForCtorClosure(SourceLocation Loc,
-                                          CXXConstructorDecl *Ctor,
-                                          bool IsCopy) {
+bool Sema::BuildCtorClosureDefaultArgs(SourceLocation Loc,
+                                       CXXConstructorDecl *Ctor, bool IsCopy) {
   assert(Context.getTargetInfo().getCXXABI().isMicrosoft());
 
   if (!Ctor->getCtorClosureDefaultArgs().empty())

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -19803,10 +19803,12 @@ void Sema::ActOnFinishFunctionDeclarationDeclarator(Declarator &Declarator) {
   InventedParameterInfos.pop_back();
 }
 
-bool Sema::BuildDefaultArgsForCtorClosure(SourceLocation Loc, CXXConstructorDecl *Ctor, bool IsCopy) {
+bool Sema::BuildDefaultArgsForCtorClosure(SourceLocation Loc,
+                                          CXXConstructorDecl *Ctor,
+                                          bool IsCopy) {
   assert(Context.getTargetInfo().getCXXABI().isMicrosoft());
 
-  if (Ctor->ctorClosureArgs())
+  if (!Ctor->getCtorClosureDefaultArgs().empty())
     return false;
 
   unsigned NumParams = Ctor->getNumParams();
@@ -19814,17 +19816,17 @@ bool Sema::BuildDefaultArgsForCtorClosure(SourceLocation Loc, CXXConstructorDecl
     return false;
   unsigned FirstParam = IsCopy ? 1 : 0;
 
-  Expr **Args = new (getASTContext()) Expr*[NumParams];
-  Args[0] = nullptr;
+  CXXDefaultArgExpr **Args =
+      new (getASTContext()) CXXDefaultArgExpr *[NumParams - FirstParam];
 
   for (unsigned I = FirstParam; I != NumParams; ++I) {
     ExprResult R = BuildCXXDefaultArgExpr(Loc, Ctor, Ctor->getParamDecl(I));
     CleanupVarDeclMarking();
     if (R.isInvalid())
       return true;
-    Args[I] = R.get();
+    Args[I - FirstParam] = cast<CXXDefaultArgExpr>(R.get());
   }
-  Ctor->setCtorClosureArgs(Args);
 
+  Ctor->setCtorClosureDefaultArgs(ArrayRef(Args, NumParams - FirstParam));
   return false;
 }

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -19806,18 +19806,24 @@ void Sema::ActOnFinishFunctionDeclarationDeclarator(Declarator &Declarator) {
 bool Sema::BuildDefaultArgsForCtorClosure(SourceLocation Loc, CXXConstructorDecl *Ctor, bool IsCopy) {
   assert(Context.getTargetInfo().getCXXABI().isMicrosoft());
 
+  if (Ctor->ctorClosureArgs())
+    return false;
+
   unsigned NumParams = Ctor->getNumParams();
   if (NumParams == 0)
     return false;
-
   unsigned FirstParam = IsCopy ? 1 : 0;
+
+  Expr **Args = new (getASTContext()) Expr*[NumParams - FirstParam];
+
   for (unsigned I = FirstParam; I != NumParams; ++I) {
     ExprResult R = BuildCXXDefaultArgExpr(Loc, Ctor, Ctor->getParamDecl(I));
+    CleanupVarDeclMarking();
     if (R.isInvalid())
       return true;
-
-    CleanupVarDeclMarking();
+    Args[I - FirstParam] = R.get();
   }
+  Ctor->setCtorClosureArgs(Args);
 
   return false;
 }

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -19826,9 +19826,8 @@ bool Sema::BuildCtorClosureDefaultArgs(SourceLocation Loc,
     Args[0] = nullptr; // Copy ctor closure will provide the first argument.
 
   for (unsigned I = IsCopy ? 1 : 0; I != NumParams; ++I) {
-    EnterExpressionEvaluationContext EvalContext(
-        *this, ExpressionEvaluationContext::Unevaluated);
     ExprResult R = BuildCXXDefaultArgExpr(Loc, Ctor, Ctor->getParamDecl(I));
+    CleanupVarDeclMarking();
     if (R.isInvalid())
       return true;
     Args[I] = cast<CXXDefaultArgExpr>(R.get());

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -19814,14 +19814,15 @@ bool Sema::BuildDefaultArgsForCtorClosure(SourceLocation Loc, CXXConstructorDecl
     return false;
   unsigned FirstParam = IsCopy ? 1 : 0;
 
-  Expr **Args = new (getASTContext()) Expr*[NumParams - FirstParam];
+  Expr **Args = new (getASTContext()) Expr*[NumParams];
+  Args[0] = nullptr;
 
   for (unsigned I = FirstParam; I != NumParams; ++I) {
     ExprResult R = BuildCXXDefaultArgExpr(Loc, Ctor, Ctor->getParamDecl(I));
     CleanupVarDeclMarking();
     if (R.isInvalid())
       return true;
-    Args[I - FirstParam] = R.get();
+    Args[I] = R.get();
   }
   Ctor->setCtorClosureArgs(Args);
 

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -6339,7 +6339,7 @@ static void ReferenceDllExportedMembers(Sema &S, CXXRecordDecl *Class) {
       if (S.Context.getTargetInfo().getCXXABI().isMicrosoft()) {
         auto *CD = dyn_cast<CXXConstructorDecl>(MD);
         if (CD && CD->isDefaultConstructor() && TSK == TSK_Undeclared) {
-          S.InstantiateDefaultCtorDefaultArgs(CD);
+          S.BuildDefaultArgsForCtorClosure(CD);
         }
       }
 
@@ -19803,4 +19803,21 @@ void Sema::ActOnFinishFunctionDeclarationDeclarator(Declarator &Declarator) {
     }
   }
   InventedParameterInfos.pop_back();
+}
+
+void Sema::BuildDefaultArgsForCtorClosure(CXXConstructorDecl *Ctor) {
+  assert(Context.getTargetInfo().getCXXABI().isMicrosoft() &&
+         Ctor->isDefaultConstructor());
+  unsigned NumParams = Ctor->getNumParams();
+  if (NumParams == 0)
+    return;
+  DLLExportAttr *Attr = Ctor->getAttr<DLLExportAttr>();
+  if (!Attr)
+    return;
+  for (unsigned I = 0; I != NumParams; ++I) {
+    (void)CheckCXXDefaultArgExpr(Attr->getLocation(), Ctor,
+                                   Ctor->getParamDecl(I));
+    CleanupVarDeclMarking();
+  }
+
 }

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -1070,10 +1070,9 @@ bool Sema::CheckCXXThrowOperand(SourceLocation ThrowLoc,
 
       // We don't keep the instantiated default argument expressions around so
       // we must rebuild them here.
-      for (unsigned I = 1, E = CD->getNumParams(); I != E; ++I) {
-        if (CheckCXXDefaultArgExpr(ThrowLoc, CD, CD->getParamDecl(I)))
-          return true;
-      }
+      // XXX: surprisingly, CD->isCopyConstructor() is not necessarily true here!
+      if (BuildDefaultArgsForCtorClosure(ThrowLoc, CD, /*IsCopy=*/true))
+        return true;
     }
   }
 

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -1070,8 +1070,7 @@ bool Sema::CheckCXXThrowOperand(SourceLocation ThrowLoc,
 
       // We don't keep the instantiated default argument expressions around so
       // we must rebuild them here.
-      // XXX: surprisingly, CD->isCopyConstructor() is not necessarily true here!
-      if (BuildDefaultArgsForCtorClosure(ThrowLoc, CD, /*IsCopy=*/true))
+      if (BuildCtorClosureDefaultArgs(ThrowLoc, CD, /*IsCopy=*/true))
         return true;
     }
   }

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -1078,22 +1078,6 @@ void Sema::updateAttrsForLateParsedTemplate(const Decl *Pattern, Decl *Inst) {
   }
 }
 
-void Sema::InstantiateDefaultCtorDefaultArgs(CXXConstructorDecl *Ctor) {
-  assert(Context.getTargetInfo().getCXXABI().isMicrosoft() &&
-         Ctor->isDefaultConstructor());
-  unsigned NumParams = Ctor->getNumParams();
-  if (NumParams == 0)
-    return;
-  DLLExportAttr *Attr = Ctor->getAttr<DLLExportAttr>();
-  if (!Attr)
-    return;
-  for (unsigned I = 0; I != NumParams; ++I) {
-    (void)CheckCXXDefaultArgExpr(Attr->getLocation(), Ctor,
-                                   Ctor->getParamDecl(I));
-    CleanupVarDeclMarking();
-  }
-}
-
 /// Get the previous declaration of a declaration for the purposes of template
 /// instantiation. If this finds a previous declaration, then the previous
 /// declaration of the instantiation of D should be an instantiation of the
@@ -5961,7 +5945,7 @@ void Sema::InstantiateFunctionDefinition(SourceLocation PointOfInstantiation,
         // default arguments.
         if (Context.getTargetInfo().getCXXABI().isMicrosoft() &&
             Ctor->isDefaultConstructor()) {
-          InstantiateDefaultCtorDefaultArgs(Ctor);
+          BuildDefaultArgsForCtorClosure(Ctor);
         }
       }
 

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -5946,7 +5946,7 @@ void Sema::InstantiateFunctionDefinition(SourceLocation PointOfInstantiation,
         if (Context.getTargetInfo().getCXXABI().isMicrosoft() &&
             Ctor->isDefaultConstructor()) {
           if (DLLExportAttr *Attr = Ctor->getAttr<DLLExportAttr>())
-            BuildDefaultArgsForCtorClosure(Attr->getLocation(), Ctor);
+            BuildCtorClosureDefaultArgs(Attr->getLocation(), Ctor);
         }
       }
 

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -5945,7 +5945,8 @@ void Sema::InstantiateFunctionDefinition(SourceLocation PointOfInstantiation,
         // default arguments.
         if (Context.getTargetInfo().getCXXABI().isMicrosoft() &&
             Ctor->isDefaultConstructor()) {
-          BuildDefaultArgsForCtorClosure(Ctor);
+          if (DLLExportAttr *Attr = Ctor->getAttr<DLLExportAttr>())
+            BuildDefaultArgsForCtorClosure(Attr->getLocation(), Ctor);
         }
       }
 

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -2333,6 +2333,12 @@ void ASTDeclReader::VisitCXXConstructorDecl(CXXConstructorDecl *D) {
     *D->getTrailingObjects<InheritedConstructor>() =
         InheritedConstructor(Shadow, Ctor);
   }
+  if (int NumCtorClosureArgs = Record.readInt()) {
+    Expr **Args = new (Reader.getContext()) Expr*[NumCtorClosureArgs];
+    for (int I = 0; I != NumCtorClosureArgs; I++)
+      Args[I] = cast<Expr>(Record.readStmt());
+    D->setCtorClosureArgs(Args);
+  }
 
   VisitCXXMethodDecl(D);
 }

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -2333,11 +2333,13 @@ void ASTDeclReader::VisitCXXConstructorDecl(CXXConstructorDecl *D) {
     *D->getTrailingObjects<InheritedConstructor>() =
         InheritedConstructor(Shadow, Ctor);
   }
-  if (int NumCtorClosureArgs = Record.readInt()) {
-    Expr **Args = new (Reader.getContext()) Expr*[NumCtorClosureArgs];
-    for (int I = 0; I != NumCtorClosureArgs; I++)
-      Args[I] = cast<Expr>(Record.readStmt());
-    D->setCtorClosureArgs(Args);
+
+  if (unsigned NumArgs = Record.readUInt32()) {
+    CXXDefaultArgExpr **Args =
+        new (Reader.getContext()) CXXDefaultArgExpr *[NumArgs];
+    for (unsigned I = 0; I != NumArgs; I++)
+      Args[I] = cast<CXXDefaultArgExpr>(Record.readStmt());
+    D->setCtorClosureDefaultArgs(ArrayRef(Args, NumArgs));
   }
 
   VisitCXXMethodDecl(D);

--- a/clang/lib/Serialization/ASTWriterDecl.cpp
+++ b/clang/lib/Serialization/ASTWriterDecl.cpp
@@ -1774,6 +1774,14 @@ void ASTDeclWriter::VisitCXXConstructorDecl(CXXConstructorDecl *D) {
     Record.AddDeclRef(Inherited.getConstructor());
   }
 
+  if (Expr **CtorClosureArgs = D->ctorClosureArgs()) {
+    Record.push_back(D->getNumParams());
+    for (unsigned I = 0, N = D->getNumParams(); I != N; ++I)
+      Record.AddStmt(CtorClosureArgs[I]);
+  } else {
+    Record.push_back(0);
+  }
+
   VisitCXXMethodDecl(D);
   Code = serialization::DECL_CXX_CONSTRUCTOR;
 }

--- a/clang/lib/Serialization/ASTWriterDecl.cpp
+++ b/clang/lib/Serialization/ASTWriterDecl.cpp
@@ -1774,13 +1774,11 @@ void ASTDeclWriter::VisitCXXConstructorDecl(CXXConstructorDecl *D) {
     Record.AddDeclRef(Inherited.getConstructor());
   }
 
-  if (Expr **CtorClosureArgs = D->ctorClosureArgs()) {
-    Record.push_back(D->getNumParams());
-    for (unsigned I = 0, N = D->getNumParams(); I != N; ++I)
-      Record.AddStmt(CtorClosureArgs[I]);
-  } else {
-    Record.push_back(0);
-  }
+  ArrayRef<CXXDefaultArgExpr *> CtorClosureDefaultArgs =
+      D->getCtorClosureDefaultArgs();
+  Record.push_back((unsigned)CtorClosureDefaultArgs.size());
+  for (CXXDefaultArgExpr *Arg : CtorClosureDefaultArgs)
+    Record.writeStmtRef(Arg);
 
   VisitCXXMethodDecl(D);
   Code = serialization::DECL_CXX_CONSTRUCTOR;

--- a/clang/test/CodeGenCXX/dllexport-ctor-closure.cpp
+++ b/clang/test/CodeGenCXX/dllexport-ctor-closure.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple i686-windows-msvc -emit-llvm -std=c++14 \
+// RUN: %clang_cc1 -triple i686-windows-msvc -emit-llvm -std=c++20 \
 // RUN:    -fno-threadsafe-statics -fms-extensions -O1 -mconstructor-aliases \
 // RUN:    -disable-llvm-passes -o - %s -w -fms-compatibility-version=19.00 | \
 // RUN:    FileCheck %s
@@ -95,3 +95,10 @@ struct __declspec(dllexport) ConstexprDefaultArg {
   ConstexprDefaultArg(SomeStruct = kConstexprStruct) {}
 };
 // CHECK-LABEL: define weak_odr dso_local dllexport x86_thiscallcc void @"??_FConstexprDefaultArg@@QAEXXZ"
+
+consteval int constEvalFunc() { return 42; }
+struct ConstEvalDefaultArg {
+  __declspec(dllexport) ConstEvalDefaultArg(int n = constEvalFunc()) {}
+};
+// CHECK-LABEL: define weak_odr dso_local dllexport x86_thiscallcc void @"??_FConstEvalDefaultArg@@QAEXXZ"
+// CHECK: call {{.*}} @"??0ConstEvalDefaultArg@@QAE@H@Z"({{.*}}, i32 noundef 42)

--- a/clang/test/CodeGenCXX/microsoft-abi-throw.cpp
+++ b/clang/test/CodeGenCXX/microsoft-abi-throw.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -emit-llvm -o - -triple=i386-pc-win32 -std=c++11 %s -fcxx-exceptions -fms-extensions | FileCheck %s
+// RUN: %clang_cc1 -emit-llvm -o - -triple=i386-pc-win32 -std=c++20 %s -fcxx-exceptions -fms-extensions | FileCheck %s
 
 // CHECK-DAG: @"??_R0?AUY@@@8" = linkonce_odr global %rtti.TypeDescriptor7 { ptr @"??_7type_info@@6B@", ptr null, [8 x i8] c".?AUY@@\00" }, comdat
 // CHECK-DAG: @"_CT??_R0?AUY@@@8??0Y@@QAE@ABU0@@Z8" = linkonce_odr unnamed_addr constant %eh.CatchableType { i32 4, ptr @"??_R0?AUY@@@8", i32 0, i32 -1, i32 0, i32 8, ptr @"??0Y@@QAE@ABU0@@Z" }, section ".xdata", comdat
@@ -68,6 +68,17 @@ struct Default {
 // CHECK: ret void
 
 void h(Default &d) {
+  throw d;
+}
+
+consteval int constEvalFunc() { return 123; }
+struct DefaultConstEval {
+  DefaultConstEval(DefaultConstEval&, int = constEvalFunc());
+};
+// CHECK-LABEL: @"??_ODefaultConstEval@@QAEXAAU0@@Z"
+// CHECK: call x86_thiscallcc {{.*}} @"??0DefaultConstEval@@QAE@AAU0@H@Z"({{.*}} %[[this]], {{.*}} %[[src]], i32 noundef 123)
+
+void h2(DefaultConstEval &d) {
   throw d;
 }
 

--- a/clang/test/CodeGenCXX/microsoft-abi-throw.cpp
+++ b/clang/test/CodeGenCXX/microsoft-abi-throw.cpp
@@ -86,11 +86,16 @@ void h2(DefaultConstEval &d) {
 struct DefaultCtorIsCopyCtor;
 const DefaultCtorIsCopyCtor& foo();
 struct DefaultCtorIsCopyCtor {
-  __declspec(dllexport) DefaultCtorIsCopyCtor(const DefaultCtorIsCopyCtor& = foo(), int = 42) {}
+  __declspec(dllexport) DefaultCtorIsCopyCtor(const DefaultCtorIsCopyCtor& = foo(), int = 456) {}
 };
 void h3(DefaultCtorIsCopyCtor &d) {
   throw d;
 }
+// CHECK-LABEL: @"??_FDefaultCtorIsCopyCtor@@QAEXXZ"
+// CHECK: %[[foo:.*]] = call {{.*}} @"?foo@@YAABUDefaultCtorIsCopyCtor@@XZ"
+// CHECK: call {{.*}} @"??0DefaultCtorIsCopyCtor@@QAE@ABU0@H@Z"({{.*}} %[[foo]], i32 noundef 456)
+// CHECK-LABEL: @"??_ODefaultCtorIsCopyCtor@@QAEXABU0@@Z"
+// CHECK: call {{.*}} @"??0DefaultCtorIsCopyCtor@@QAE@ABU0@H@Z"({{.*}} i32 noundef 456)
 
 struct DeletedCopy {
   DeletedCopy();

--- a/clang/test/CodeGenCXX/microsoft-abi-throw.cpp
+++ b/clang/test/CodeGenCXX/microsoft-abi-throw.cpp
@@ -82,6 +82,16 @@ void h2(DefaultConstEval &d) {
   throw d;
 }
 
+// This will generate both the default constructor closure and the copy constructor closure -- for the same constructor.
+struct DefaultCtorIsCopyCtor;
+const DefaultCtorIsCopyCtor& foo();
+struct DefaultCtorIsCopyCtor {
+  __declspec(dllexport) DefaultCtorIsCopyCtor(const DefaultCtorIsCopyCtor& = foo(), int = 42) {}
+};
+void h3(DefaultCtorIsCopyCtor &d) {
+  throw d;
+}
+
 struct DeletedCopy {
   DeletedCopy();
   DeletedCopy(DeletedCopy &&);

--- a/clang/test/SemaCXX/ms-ctor-closure.cpp
+++ b/clang/test/SemaCXX/ms-ctor-closure.cpp
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 %s -triple=i386-pc-win32 -std=c++23 -fms-extensions -verify
+
+consteval int bad(int x) { return 42 / x; } // expected-note{{division by zero}}
+
+struct ExportedDefaultArgClosure {
+  __declspec(dllexport)                 // expected-note{{in the default initializer of 'x'}}
+  ExportedDefaultArgClosure(int x       // expected-note{{declared here}}
+                            = bad(0)) { // expected-error{{call to consteval function 'bad' is not a constant expression}} expected-note{{in call to 'bad(0)'}}
+  }
+};


### PR DESCRIPTION
This is for https://github.com/llvm/llvm-project/issues/201320

Just grabbing the default argument with `getDefaultArg()` during codegen doesn't work if the expression requires evaluating a consteval expression (see bug). Instead, we must properly BuildCXXDefaultArgExpr it during Sema, store it in the AST (including serializatin/deserialization) and then use that during codegen.