### PR TITLE
[AArch64][llvm] Define APAS, BRB and TRCIT as SYS aliases

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -1848,12 +1848,6 @@ class RegInputSystemI<bits<4> CRm, bits<3> Op2, string asm,
   let Inst{7-5} = Op2;
 }
 
-class APASI : SimpleSystemI<0, (ins GPR64:$Xt), "apas", "\t$Xt">, Sched<[]> {
-  bits<5> Xt;
-  let Inst{20-5} = 0b0111001110000000;
-  let Inst{4-0} = Xt;
-}
-
 // Hint instructions that take both a CRm and a 3-bit immediate.
 // NOTE: ideally, this would have mayStore = 0, mayLoad = 0, but we cannot
 // model patterns with sufficiently fine granularity
@@ -13095,19 +13089,6 @@ class LRCPC3NEONLdStSingle<bit L, dag oops, dag iops, string asm, string cst>
   let mayLoad = L;
   let mayStore = !not(L);
   let hasSideEffects = 1;
-}
-
-//---
-// Instrumentation Extension (FEAT_ITE)
-//---
-
-let Predicates = [HasITE] in
-def TRCIT : RtSystemI<0b0, (outs), (ins GPR64:$Rt), "trcit", "\t$Rt"> {
-  let Inst{20-19} = 0b01;
-  let Inst{18-16} = 0b011;
-  let Inst{15-12} = 0b0111;
-  let Inst{11-8}  = 0b0010;
-  let Inst{7-5}   = 0b111;
 }
 
 // * RCWCAS family

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -1614,16 +1614,6 @@ def WFET : RegInputSystemI<0b0000, 0b000, "wfet">;
 def WFIT : RegInputSystemI<0b0000, 0b001, "wfit">;
 }
 
-// Branch Record Buffer two-word mnemonic instructions
-class BRBEI<bits<3> op2, string keyword>
-    : SimpleSystemI<0, (ins), "brb", keyword>, Sched<[WriteSys]> {
-  let Inst{31-8} = 0b110101010000100101110010;
-  let Inst{7-5} = op2;
-  let Predicates = [HasBRBE];
-}
-def BRB_IALL: BRBEI<0b100, "\tiall">;
-def BRB_INJ:  BRBEI<0b101, "\tinj">;
-
 }
 
 // Allow uppercase and lowercase keyword arguments for BRB IALL and BRB INJ
@@ -2552,6 +2542,14 @@ def SYSLxt : SystemLXtI<1, "sysl">;
 def : InstAlias<"sys $op1, $Cn, $Cm, $op2",
                 (SYSxt timm32_0_7:$op1, sys_cr_op:$Cn,
                  sys_cr_op:$Cm, timm32_0_7:$op2, XZR)>;
+def : InstAlias<"apas $Xt",
+                (SYSxt 6, 7, 0, 0, GPR64:$Xt), 2>;
+def : InstAlias<"brb\tiall",
+                (SYSxt 1, 7, 2, 4, XZR), 2>, Requires<[HasBRBE]>;
+def : InstAlias<"brb\tinj",
+                (SYSxt 1, 7, 2, 5, XZR), 2>, Requires<[HasBRBE]>;
+def : InstAlias<"trcit $Rt",
+                (SYSxt 3, 7, 2, 7, GPR64:$Rt), 2>, Requires<[HasITE]>;
 
 
 //===----------------------------------------------------------------------===//
@@ -3080,9 +3078,6 @@ let Predicates = [HasLSUI] in {
   defm : STOPregisterLSUI<"sttclr","LDTCLR">; // STTCLRx
   defm : STOPregisterLSUI<"sttset","LDTSET">; // STTSETx
 }
-
-// v9.6-a FEAT_RME_GPC3
-def APAS : APASI;
 
 // v8.1 atomic LD<OP>(register). Performs load and then ST<OP>(register)
 defm LDADD   : LDOPregister<0b000, "add", 0, 0, "">;

--- a/llvm/test/MC/AArch64/arm64-aliases.s
+++ b/llvm/test/MC/AArch64/arm64-aliases.s
@@ -1,4 +1,9 @@
 ; RUN: llvm-mc -triple arm64-apple-darwin -mattr=neon -output-asm-variant=1 -show-encoding -print-imm-hex < %s | FileCheck %s
+; RUN: llvm-mc -triple arm64-apple-darwin -mattr=neon,+ite -filetype=obj < %s | llvm-objdump -d --mattr=+ite --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-ITE
+; RUN: llvm-mc -triple arm64-apple-darwin -mattr=neon,+ite -filetype=obj < %s | llvm-objdump -d --mattr=-ite --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-NO-ITE
+; RUN: llvm-mc -triple arm64-apple-darwin -mattr=neon,+brbe -filetype=obj < %s | llvm-objdump -d --mattr=+brbe --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-BRBE
+; RUN: llvm-mc -triple arm64-apple-darwin -mattr=neon,+brbe -filetype=obj < %s | llvm-objdump -d --mattr=-brbe --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-NO-BRBE
+; RUN: llvm-mc -triple arm64-apple-darwin -mattr=neon -filetype=obj < %s | llvm-objdump -d --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-RME
 
 foo:
 ;-----------------------------------------------------------------------------
@@ -525,6 +530,28 @@ foo:
 ; CHECK: sys #0x4, c8, c7, #0x6, x30
   sys #4, c8, c7, #6, x31
 ; CHECK: tlbi vmalls12e1
+
+  sys #3, c7, c2, #7, x2
+; CHECK-ITE: trcit x2
+; CHECK-NO-ITE: sys #3, c7, c2, #7, x2
+  sys #3, c7, c2, #7
+; CHECK-ITE: trcit xzr
+; CHECK-NO-ITE: sys #3, c7, c2, #7
+
+  sys #1, c7, c2, #4, x30
+; CHECK-BRBE: sys #1, c7, c2, #4, x30
+; CHECK-NO-BRBE: sys #1, c7, c2, #4, x30
+  sys #1, c7, c2, #4
+; CHECK-BRBE: brb iall
+; CHECK-NO-BRBE: sys #1, c7, c2, #4
+  sys #1, c7, c2, #5
+; CHECK-BRBE: brb inj
+; CHECK-NO-BRBE: sys #1, c7, c2, #5
+
+  sys #6, c7, c0, #0, x3
+; CHECK-RME: apas x3
+  sys #6, c7, c0, #0
+; CHECK-RME: apas xzr
 
   ic ialluis
 ; CHECK: ic ialluis                 ; encoding: [0x1f,0x71,0x08,0xd5]

--- a/llvm/test/MC/AArch64/brbe.s
+++ b/llvm/test/MC/AArch64/brbe.s
@@ -147,3 +147,7 @@ brb INJ
 // CHECK: brb inj   // encoding: [0xbf,0x72,0x09,0xd5]
 // ERROR-NO-BRBE: [[@LINE-4]]:1: error: instruction requires: brbe
 // ERROR-NO-BRBE: [[@LINE-4]]:1: error: instruction requires: brbe
+
+brb iall, x30
+// ERROR: [[@LINE-1]]:11: error: invalid operand for instruction
+// ERROR-NO-BRBE: [[@LINE-2]]:11: error: invalid operand for instruction


### PR DESCRIPTION
`APAS`, `BRB IALL/INJ` and `TRCIT` use `SYS` encodings, so define them
as aliases of `SYSxt` instead of separate instructions.

Check that the preferred architectural aliases are printed when their
features are enabled and that disassembly falls back to the generic `SYS`
spelling when not enabled.