### PR TITLE
[AMDGPU] Fix fmul/fma legacy sign-of-zero miscompile

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUInstCombineIntrinsic.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstCombineIntrinsic.cpp
@@ -429,14 +429,16 @@ bool GCNTTIImpl::canSimplifyLegacyMulToMul(const Instruction &I,
   // infinity, gives +0.0. If we can prove we don't have one of the special
   // cases then we can use a normal multiply instead.
   SimplifyQuery SQ = IC.getSimplifyQuery().getWithInstruction(&I);
-  KnownFPClass Known0 = computeKnownFPClass(Op0, fcZero | fcInf | fcNan, SQ);
+  KnownFPClass Known0 =
+      computeKnownFPClass(Op0, fcZero | fcSubnormal | fcInf | fcNan, SQ);
   DenormalMode Mode = I.getFunction()->getDenormalMode(APFloat::IEEEsingle());
 
   // Bail early if Op0 may be zero and nsz is not set -- Op1 cannot help.
   if (!Known0.isKnownNeverLogicalZero(Mode) && !I.hasNoSignedZeros())
     return false;
 
-  KnownFPClass Known1 = computeKnownFPClass(Op1, fcZero | fcInf | fcNan, SQ);
+  KnownFPClass Known1 =
+      computeKnownFPClass(Op1, fcZero | fcSubnormal | fcInf | fcNan, SQ);
 
   // Simplify if both operands are known non-zero.
   if (Known0.isKnownNeverLogicalZero(Mode) &&

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstCombineIntrinsic.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstCombineIntrinsic.cpp
@@ -428,19 +428,32 @@ bool GCNTTIImpl::canSimplifyLegacyMulToMul(const Instruction &I,
   // The legacy behaviour is that multiplying +/-0.0 by anything, even NaN or
   // infinity, gives +0.0. If we can prove we don't have one of the special
   // cases then we can use a normal multiply instead.
-  // TODO: Create and use isKnownFiniteNonZero instead of just matching
-  // constants here.
-  if (match(Op0, PatternMatch::m_FiniteNonZero()) ||
-      match(Op1, PatternMatch::m_FiniteNonZero())) {
-    // One operand is not zero or infinity or NaN.
-    return true;
-  }
-
   SimplifyQuery SQ = IC.getSimplifyQuery().getWithInstruction(&I);
-  if (isKnownNeverInfOrNaN(Op0, SQ) && isKnownNeverInfOrNaN(Op1, SQ)) {
-    // Neither operand is infinity or NaN.
+  KnownFPClass Known0 = computeKnownFPClass(Op0, fcZero | fcInf | fcNan, SQ);
+  DenormalMode Mode = I.getFunction()->getDenormalMode(APFloat::IEEEsingle());
+
+  // Bail early if Op0 may be zero and nsz is not set -- Op1 cannot help.
+  if (!Known0.isKnownNeverLogicalZero(Mode) && !I.hasNoSignedZeros())
+    return false;
+
+  KnownFPClass Known1 = computeKnownFPClass(Op1, fcZero | fcInf | fcNan, SQ);
+
+  // Simplify if both operands are known non-zero.
+  if (Known0.isKnownNeverLogicalZero(Mode) &&
+      Known1.isKnownNeverLogicalZero(Mode))
     return true;
-  }
+
+  // With nsz, two additional cases allow simplification:
+  // 1. One operand is not zero or infinity or NaN:
+  //    Op0 NeverLogicalZero && NeverInfOrNaN, or symmetric for Op1.
+  // 2. Neither operand is infinity or NaN:
+  //    Op0 NeverInfOrNaN && Op1 NeverInfOrNaN.
+  // The following condition captures both cases.
+  if (I.hasNoSignedZeros() &&
+      (Known0.isKnownNeverLogicalZero(Mode) || Known1.isKnownNeverInfOrNaN()) &&
+      (Known1.isKnownNeverLogicalZero(Mode) || Known0.isKnownNeverInfOrNaN()))
+    return true;
+
   return false;
 }
 

--- a/llvm/test/Transforms/InstCombine/AMDGPU/fma_legacy.ll
+++ b/llvm/test/Transforms/InstCombine/AMDGPU/fma_legacy.ll
@@ -49,32 +49,44 @@ define float @test_negzero_nsz(float %y, float %z) {
   ret float %call
 }
 
-; Combine to fma because the constant is finite and non-zero.
+; Combine to fma with nsz: sign-of-zero is don't-care so the +0 vs +-0
+; difference between legacy and IEEE does not matter.
+define float @test_const_nsz(float %x, float %z) {
+; CHECK-LABEL: @test_const_nsz(
+; CHECK-NEXT:    [[CALL:%.*]] = call nsz float @llvm.fma.f32(float [[X:%.*]], float 9.950000e+01, float [[Z:%.*]])
+; CHECK-NEXT:    ret float [[CALL]]
+;
+  %call = call nsz float @llvm.amdgcn.fma.legacy(float %x, float 99.5, float %z)
+  ret float %call
+}
+
+; Do NOT combine: one operand is finite-nonzero but the other may be +-0 at
+; runtime. Legacy mul returns +0; IEEE fmul returns -0. Sign-of-zero mismatch.
 define float @test_const(float %x, float %z) {
 ; CHECK-LABEL: @test_const(
-; CHECK-NEXT:    [[CALL:%.*]] = call float @llvm.fma.f32(float [[X:%.*]], float 9.950000e+01, float [[Z:%.*]])
+; CHECK-NEXT:    [[CALL:%.*]] = call float @llvm.amdgcn.fma.legacy(float [[X:%.*]], float 9.950000e+01, float [[Z:%.*]])
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
   %call = call float @llvm.amdgcn.fma.legacy(float %x, float 99.5, float %z)
   ret float %call
 }
 
-; Combine to fma because the constant is finite and non-zero, preserving fmf.
+; Do NOT combine: contract does not imply nsz, sign-of-zero still matters.
 define float @test_const_fmf(float %x, float %z) {
 ; CHECK-LABEL: @test_const_fmf(
-; CHECK-NEXT:    [[CALL:%.*]] = call contract float @llvm.fma.f32(float [[X:%.*]], float 9.950000e+01, float [[Z:%.*]])
+; CHECK-NEXT:    [[CALL:%.*]] = call contract float @llvm.amdgcn.fma.legacy(float [[X:%.*]], float 9.950000e+01, float [[Z:%.*]])
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
   %call = call contract float @llvm.amdgcn.fma.legacy(float %x, float 99.5, float %z)
   ret float %call
 }
 
-; Combine to fma because neither argument can be infinity or NaN.
+; Do NOT combine: sitofp is finite but may be zero, sign-of-zero can diverge.
 define float @test_finite(i32 %x, i32 %y, float %z) {
 ; CHECK-LABEL: @test_finite(
 ; CHECK-NEXT:    [[XF:%.*]] = sitofp i32 [[X:%.*]] to float
 ; CHECK-NEXT:    [[YF:%.*]] = sitofp i32 [[Y:%.*]] to float
-; CHECK-NEXT:    [[CALL:%.*]] = call float @llvm.fma.f32(float [[XF]], float [[YF]], float [[Z:%.*]])
+; CHECK-NEXT:    [[CALL:%.*]] = call float @llvm.amdgcn.fma.legacy(float [[XF]], float [[YF]], float [[Z:%.*]])
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
   %xf = sitofp i32 %x to float
@@ -83,7 +95,30 @@ define float @test_finite(i32 %x, i32 %y, float %z) {
   ret float %call
 }
 
-; Combine to fma because neither argument can be infinity or NaN based on assumptions
+; Combine to fma with nsz: neither mul operand can be Inf/NaN (via assumes)
+; and nsz permits ignoring the +-0 sign difference from the legacy zero clause.
+define float @test_finite_assumed_nsz(float %x, float %y, float %z) {
+; CHECK-LABEL: @test_finite_assumed_nsz(
+; CHECK-NEXT:    [[FABS_X:%.*]] = call float @llvm.fabs.f32(float [[X:%.*]])
+; CHECK-NEXT:    [[IS_FINITE_X:%.*]] = fcmp one float [[FABS_X]], +inf
+; CHECK-NEXT:    [[FABS_Y:%.*]] = call float @llvm.fabs.f32(float [[Y:%.*]])
+; CHECK-NEXT:    [[IS_FINITE_Y:%.*]] = fcmp one float [[FABS_Y]], +inf
+; CHECK-NEXT:    call void @llvm.assume(i1 [[IS_FINITE_X]])
+; CHECK-NEXT:    call void @llvm.assume(i1 [[IS_FINITE_Y]])
+; CHECK-NEXT:    [[CALL:%.*]] = call nsz float @llvm.fma.f32(float [[X]], float [[Y]], float [[Z:%.*]])
+; CHECK-NEXT:    ret float [[CALL]]
+;
+  %fabs.x = call float @llvm.fabs.f32(float %x)
+  %is.finite.x = fcmp one float %fabs.x, 0x7FF0000000000000
+  %fabs.y = call float @llvm.fabs.f32(float %y)
+  %is.finite.y = fcmp one float %fabs.y, 0x7FF0000000000000
+  call void @llvm.assume(i1 %is.finite.x)
+  call void @llvm.assume(i1 %is.finite.y)
+  %call = call nsz float @llvm.amdgcn.fma.legacy(float %x, float %y, float %z)
+  ret float %call
+}
+
+; Do NOT combine: finite assumptions don't exclude zero, sign-of-zero unsafe.
 define float @test_finite_assumed(float %x, float %y, float %z) {
 ; CHECK-LABEL: @test_finite_assumed(
 ; CHECK-NEXT:    [[FABS_X:%.*]] = call float @llvm.fabs.f32(float [[X:%.*]])
@@ -92,7 +127,7 @@ define float @test_finite_assumed(float %x, float %y, float %z) {
 ; CHECK-NEXT:    [[IS_FINITE_Y:%.*]] = fcmp one float [[FABS_Y]], +inf
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[IS_FINITE_X]])
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[IS_FINITE_Y]])
-; CHECK-NEXT:    [[CALL:%.*]] = call float @llvm.fma.f32(float [[X]], float [[Y]], float [[Z:%.*]])
+; CHECK-NEXT:    [[CALL:%.*]] = call float @llvm.amdgcn.fma.legacy(float [[X]], float [[Y]], float [[Z:%.*]])
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
   %fabs.x = call float @llvm.fabs.f32(float %x)
@@ -102,6 +137,38 @@ define float @test_finite_assumed(float %x, float %y, float %z) {
   call void @llvm.assume(i1 %is.finite.x)
   call void @llvm.assume(i1 %is.finite.y)
   %call = call float @llvm.amdgcn.fma.legacy(float %x, float %y, float %z)
+  ret float %call
+}
+
+; Combine without nsz: both mul operands are finite non-zero constants so the
+; legacy zero clause can never fire and sign-of-zero cannot diverge.
+define float @test_both_const_nonzero(float %z) {
+; CHECK-LABEL: @test_both_const_nonzero(
+; CHECK-NEXT:    [[CALL:%.*]] = call float @llvm.fma.f32(float -2.000000e+00, float 9.950000e+01, float [[Z:%.*]])
+; CHECK-NEXT:    ret float [[CALL]]
+;
+  %call = call float @llvm.amdgcn.fma.legacy(float -2.0, float 99.5, float %z)
+  ret float %call
+}
+
+; Combine without nsz: qNaN and finite non-zero, neither can be zero.
+; Result constant-folds to +qnan.
+define float @test_nan_const_nonzero(float %z) {
+; CHECK-LABEL: @test_nan_const_nonzero(
+; CHECK-NEXT:    ret float +qnan
+;
+  %call = call float @llvm.amdgcn.fma.legacy(float 0x7FF8000000000000, float -2.0, float %z)
+  ret float %call
+}
+
+; Combine without nsz: +inf and finite non-zero, neither can be zero.
+; Folds to llvm.fma.f32 (not constant-folded since %z is a runtime value).
+define float @test_inf_const_nonzero(float %z) {
+; CHECK-LABEL: @test_inf_const_nonzero(
+; CHECK-NEXT:    [[CALL:%.*]] = call float @llvm.fma.f32(float +inf, float -2.000000e+00, float [[Z:%.*]])
+; CHECK-NEXT:    ret float [[CALL]]
+;
+  %call = call float @llvm.amdgcn.fma.legacy(float 0x7FF0000000000000, float -2.0, float %z)
   ret float %call
 }
 

--- a/llvm/test/Transforms/InstCombine/AMDGPU/fma_legacy.ll
+++ b/llvm/test/Transforms/InstCombine/AMDGPU/fma_legacy.ll
@@ -143,7 +143,7 @@ define float @test_finite_assumed(float %x, float %y, float %z) {
 ; In IEEE mode subnormals are not logical zeros. A value known to be strictly
 ; positive (greater than 0.0) may be subnormal but is not a logical zero, so
 ; the fold fires.
-define float @test_subnormal_ieee_allows_fold(float %x, float %y, float %z) #0 {
+define float @test_subnormal_ieee_allows_fold(float %x, float %y, float %z) {
 ; CHECK-LABEL: @test_subnormal_ieee_allows_fold(
 ; CHECK-NEXT:    [[IS_POS_X:%.*]] = fcmp ogt float [[X:%.*]], 0.000000e+00
 ; CHECK-NEXT:    [[IS_POS_Y:%.*]] = fcmp ogt float [[Y:%.*]], 0.000000e+00
@@ -163,7 +163,7 @@ define float @test_subnormal_ieee_allows_fold(float %x, float %y, float %z) #0 {
 ; In preserve-sign mode, a value known to be strictly positive may still be
 ; subnormal, which is treated as a logical zero. The fold is blocked because
 ; the legacy zero clause could fire when subnormals are flushed to zero.
-define float @test_subnormal_flush_blocks_fold(float %x, float %y, float %z) #1 {
+define float @test_subnormal_flush_blocks_fold(float %x, float %y, float %z) #0 {
 ; CHECK-LABEL: @test_subnormal_flush_blocks_fold(
 ; CHECK-NEXT:    [[IS_POS_X:%.*]] = fcmp ogt float [[X:%.*]], 0.000000e+00
 ; CHECK-NEXT:    [[IS_POS_Y:%.*]] = fcmp ogt float [[Y:%.*]], 0.000000e+00
@@ -208,5 +208,4 @@ declare float @llvm.amdgcn.fma.legacy(float, float, float)
 declare float @llvm.fabs.f32(float)
 declare void @llvm.assume(i1 noundef)
 
-attributes #0 = { denormal_fpenv(float: ieee) }
-attributes #1 = { denormal_fpenv(float: preservesign) }
+attributes #0 = { denormal_fpenv(float: preservesign) }

--- a/llvm/test/Transforms/InstCombine/AMDGPU/fma_legacy.ll
+++ b/llvm/test/Transforms/InstCombine/AMDGPU/fma_legacy.ll
@@ -140,38 +140,6 @@ define float @test_finite_assumed(float %x, float %y, float %z) {
   ret float %call
 }
 
-; Combine without nsz: both mul operands are finite non-zero constants so the
-; legacy zero clause can never fire and sign-of-zero cannot diverge.
-define float @test_both_const_nonzero(float %z) {
-; CHECK-LABEL: @test_both_const_nonzero(
-; CHECK-NEXT:    [[CALL:%.*]] = call float @llvm.fma.f32(float -2.000000e+00, float 9.950000e+01, float [[Z:%.*]])
-; CHECK-NEXT:    ret float [[CALL]]
-;
-  %call = call float @llvm.amdgcn.fma.legacy(float -2.0, float 99.5, float %z)
-  ret float %call
-}
-
-; Combine without nsz: qNaN and finite non-zero, neither can be zero.
-; Result constant-folds to +qnan.
-define float @test_nan_const_nonzero(float %z) {
-; CHECK-LABEL: @test_nan_const_nonzero(
-; CHECK-NEXT:    ret float +qnan
-;
-  %call = call float @llvm.amdgcn.fma.legacy(float 0x7FF8000000000000, float -2.0, float %z)
-  ret float %call
-}
-
-; Combine without nsz: +inf and finite non-zero, neither can be zero.
-; Folds to llvm.fma.f32 (not constant-folded since %z is a runtime value).
-define float @test_inf_const_nonzero(float %z) {
-; CHECK-LABEL: @test_inf_const_nonzero(
-; CHECK-NEXT:    [[CALL:%.*]] = call float @llvm.fma.f32(float +inf, float -2.000000e+00, float [[Z:%.*]])
-; CHECK-NEXT:    ret float [[CALL]]
-;
-  %call = call float @llvm.amdgcn.fma.legacy(float 0x7FF0000000000000, float -2.0, float %z)
-  ret float %call
-}
-
 define float @test_poison_x_y(float %x, float %y) {
 ; CHECK-LABEL: @test_poison_x_y(
 ; CHECK-NEXT:    ret float poison

--- a/llvm/test/Transforms/InstCombine/AMDGPU/fma_legacy.ll
+++ b/llvm/test/Transforms/InstCombine/AMDGPU/fma_legacy.ll
@@ -140,6 +140,46 @@ define float @test_finite_assumed(float %x, float %y, float %z) {
   ret float %call
 }
 
+; In IEEE mode subnormals are not logical zeros. A value known to be strictly
+; positive (greater than 0.0) may be subnormal but is not a logical zero, so
+; the fold fires.
+define float @test_subnormal_ieee_allows_fold(float %x, float %y, float %z) #0 {
+; CHECK-LABEL: @test_subnormal_ieee_allows_fold(
+; CHECK-NEXT:    [[IS_POS_X:%.*]] = fcmp ogt float [[X:%.*]], 0.000000e+00
+; CHECK-NEXT:    [[IS_POS_Y:%.*]] = fcmp ogt float [[Y:%.*]], 0.000000e+00
+; CHECK-NEXT:    call void @llvm.assume(i1 [[IS_POS_X]])
+; CHECK-NEXT:    call void @llvm.assume(i1 [[IS_POS_Y]])
+; CHECK-NEXT:    [[CALL:%.*]] = call float @llvm.fma.f32(float [[X]], float [[Y]], float [[Z:%.*]])
+; CHECK-NEXT:    ret float [[CALL]]
+;
+  %is.pos.x = fcmp ogt float %x, 0.0
+  %is.pos.y = fcmp ogt float %y, 0.0
+  call void @llvm.assume(i1 %is.pos.x)
+  call void @llvm.assume(i1 %is.pos.y)
+  %call = call float @llvm.amdgcn.fma.legacy(float %x, float %y, float %z)
+  ret float %call
+}
+
+; In preserve-sign mode, a value known to be strictly positive may still be
+; subnormal, which is treated as a logical zero. The fold is blocked because
+; the legacy zero clause could fire when subnormals are flushed to zero.
+define float @test_subnormal_flush_blocks_fold(float %x, float %y, float %z) #1 {
+; CHECK-LABEL: @test_subnormal_flush_blocks_fold(
+; CHECK-NEXT:    [[IS_POS_X:%.*]] = fcmp ogt float [[X:%.*]], 0.000000e+00
+; CHECK-NEXT:    [[IS_POS_Y:%.*]] = fcmp ogt float [[Y:%.*]], 0.000000e+00
+; CHECK-NEXT:    call void @llvm.assume(i1 [[IS_POS_X]])
+; CHECK-NEXT:    call void @llvm.assume(i1 [[IS_POS_Y]])
+; CHECK-NEXT:    [[CALL:%.*]] = call float @llvm.amdgcn.fma.legacy(float [[X]], float [[Y]], float [[Z:%.*]])
+; CHECK-NEXT:    ret float [[CALL]]
+;
+  %is.pos.x = fcmp ogt float %x, 0.0
+  %is.pos.y = fcmp ogt float %y, 0.0
+  call void @llvm.assume(i1 %is.pos.x)
+  call void @llvm.assume(i1 %is.pos.y)
+  %call = call float @llvm.amdgcn.fma.legacy(float %x, float %y, float %z)
+  ret float %call
+}
+
 define float @test_poison_x_y(float %x, float %y) {
 ; CHECK-LABEL: @test_poison_x_y(
 ; CHECK-NEXT:    ret float poison
@@ -167,3 +207,6 @@ define float @test_x_y_poison_y(float %x, float %y) {
 declare float @llvm.amdgcn.fma.legacy(float, float, float)
 declare float @llvm.fabs.f32(float)
 declare void @llvm.assume(i1 noundef)
+
+attributes #0 = { denormal_fpenv(float: ieee) }
+attributes #1 = { denormal_fpenv(float: preservesign) }

--- a/llvm/test/Transforms/InstCombine/AMDGPU/fmul_legacy.ll
+++ b/llvm/test/Transforms/InstCombine/AMDGPU/fmul_legacy.ll
@@ -19,32 +19,43 @@ define float @test_negzero(float %y) {
   ret float %call
 }
 
-; Combine to fmul because the constant is finite and non-zero.
+; Combine to fmul because the constant is finite and non-zero with nsz flag.
+define float @test_const_nsz(float %x) {
+; CHECK-LABEL: @test_const_nsz(
+; CHECK-NEXT:    [[CALL:%.*]] = fmul nsz float [[X:%.*]], 9.950000e+01
+; CHECK-NEXT:    ret float [[CALL]]
+;
+  %call = call nsz float @llvm.amdgcn.fmul.legacy(float %x, float 99.5)
+  ret float %call
+}
+
+; Do NOT combine: one operand is finite-nonzero but the other may be +-0 at
+; runtime. Legacy returns +0; IEEE fmul returns -0. Sign-of-zero mismatch.
 define float @test_const(float %x) {
 ; CHECK-LABEL: @test_const(
-; CHECK-NEXT:    [[CALL:%.*]] = fmul float [[X:%.*]], 9.950000e+01
+; CHECK-NEXT:    [[CALL:%.*]] = call float @llvm.amdgcn.fmul.legacy(float [[X:%.*]], float 9.950000e+01)
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
   %call = call float @llvm.amdgcn.fmul.legacy(float %x, float 99.5)
   ret float %call
 }
 
-; Combine to fmul because the constant is finite and non-zero, preserving fmf.
+; Do NOT combine: contract does not imply nsz, sign-of-zero still matters.
 define float @test_const_fmf(float %x) {
 ; CHECK-LABEL: @test_const_fmf(
-; CHECK-NEXT:    [[CALL:%.*]] = fmul contract float [[X:%.*]], 9.950000e+01
+; CHECK-NEXT:    [[CALL:%.*]] = call contract float @llvm.amdgcn.fmul.legacy(float [[X:%.*]], float 9.950000e+01)
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
   %call = call contract float @llvm.amdgcn.fmul.legacy(float %x, float 99.5)
   ret float %call
 }
 
-; Combine to fmul because neither argument can be infinity or NaN.
+; Do NOT combine: sitofp is finite but may be zero, sign-of-zero can diverge.
 define float @test_finite(i32 %x, i32 %y) {
 ; CHECK-LABEL: @test_finite(
 ; CHECK-NEXT:    [[XF:%.*]] = sitofp i32 [[X:%.*]] to float
 ; CHECK-NEXT:    [[YF:%.*]] = sitofp i32 [[Y:%.*]] to float
-; CHECK-NEXT:    [[CALL:%.*]] = fmul nnan float [[XF]], [[YF]]
+; CHECK-NEXT:    [[CALL:%.*]] = call float @llvm.amdgcn.fmul.legacy(float [[XF]], float [[YF]])
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
   %xf = sitofp i32 %x to float
@@ -53,7 +64,29 @@ define float @test_finite(i32 %x, i32 %y) {
   ret float %call
 }
 
-; Combine to fmul because neither argument can be infinity or NaN based on assumptions
+; Combine to fmul because neither argument can be infinity or NaN with nsz based on assumptions
+define float @test_finite_assumed_nsz(float %x, float %y) {
+; CHECK-LABEL: @test_finite_assumed_nsz(
+; CHECK-NEXT:    [[FABS_X:%.*]] = call float @llvm.fabs.f32(float [[X:%.*]])
+; CHECK-NEXT:    [[IS_FINITE_X:%.*]] = fcmp one float [[FABS_X]], +inf
+; CHECK-NEXT:    [[FABS_Y:%.*]] = call float @llvm.fabs.f32(float [[Y:%.*]])
+; CHECK-NEXT:    [[IS_FINITE_Y:%.*]] = fcmp one float [[FABS_Y]], +inf
+; CHECK-NEXT:    call void @llvm.assume(i1 [[IS_FINITE_X]])
+; CHECK-NEXT:    call void @llvm.assume(i1 [[IS_FINITE_Y]])
+; CHECK-NEXT:    [[CALL:%.*]] = fmul nnan nsz float [[X]], [[Y]]
+; CHECK-NEXT:    ret float [[CALL]]
+;
+  %fabs.x = call float @llvm.fabs.f32(float %x)
+  %is.finite.x = fcmp one float %fabs.x, 0x7FF0000000000000
+  %fabs.y = call float @llvm.fabs.f32(float %y)
+  %is.finite.y = fcmp one float %fabs.y, 0x7FF0000000000000
+  call void @llvm.assume(i1 %is.finite.x)
+  call void @llvm.assume(i1 %is.finite.y)
+  %call = call nsz float @llvm.amdgcn.fmul.legacy(float %x, float %y)
+  ret float %call
+}
+
+; Do NOT combine: finite assumptions don't exclude zero, sign-of-zero unsafe.
 define float @test_finite_assumed(float %x, float %y) {
 ; CHECK-LABEL: @test_finite_assumed(
 ; CHECK-NEXT:    [[FABS_X:%.*]] = call float @llvm.fabs.f32(float [[X:%.*]])
@@ -62,7 +95,7 @@ define float @test_finite_assumed(float %x, float %y) {
 ; CHECK-NEXT:    [[IS_FINITE_Y:%.*]] = fcmp one float [[FABS_Y]], +inf
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[IS_FINITE_X]])
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[IS_FINITE_Y]])
-; CHECK-NEXT:    [[CALL:%.*]] = fmul nnan float [[X]], [[Y]]
+; CHECK-NEXT:    [[CALL:%.*]] = call float @llvm.amdgcn.fmul.legacy(float [[X]], float [[Y]])
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
   %fabs.x = call float @llvm.fabs.f32(float %x)
@@ -72,6 +105,37 @@ define float @test_finite_assumed(float %x, float %y) {
   call void @llvm.assume(i1 %is.finite.x)
   call void @llvm.assume(i1 %is.finite.y)
   %call = call float @llvm.amdgcn.fmul.legacy(float %x, float %y)
+  ret float %call
+}
+
+; Combine to fmul without nsz: both operands are finite non-zero constants so
+; the legacy zero clause can never fire (neither operand is zero) and there is
+; no sign-of-zero divergence. The result is further constant-folded to -199.0.
+define float @test_both_const_nonzero() {
+; CHECK-LABEL: @test_both_const_nonzero(
+; CHECK-NEXT:    ret float -1.990000e+02
+;
+  %call = call float @llvm.amdgcn.fmul.legacy(float -2.0, float 99.5)
+  ret float %call
+}
+
+; Combine to fmul without nsz: qNaN and finite non-zero, neither can be zero.
+; Result constant-folds to +qnan.
+define float @test_nan_const_nonzero() {
+; CHECK-LABEL: @test_nan_const_nonzero(
+; CHECK-NEXT:    ret float +qnan
+;
+  %call = call float @llvm.amdgcn.fmul.legacy(float 0x7FF8000000000000, float -2.0)
+  ret float %call
+}
+
+; Combine to fmul without nsz: +inf and finite non-zero, neither can be zero.
+; Result constant-folds to -inf.
+define float @test_inf_const_nonzero() {
+; CHECK-LABEL: @test_inf_const_nonzero(
+; CHECK-NEXT:    ret float -inf
+;
+  %call = call float @llvm.amdgcn.fmul.legacy(float 0x7FF0000000000000, float -2.0)
   ret float %call
 }
 

--- a/llvm/test/Transforms/InstCombine/AMDGPU/fmul_legacy.ll
+++ b/llvm/test/Transforms/InstCombine/AMDGPU/fmul_legacy.ll
@@ -111,7 +111,7 @@ define float @test_finite_assumed(float %x, float %y) {
 ; In IEEE mode subnormals are not logical zeros. A value known to be strictly
 ; positive (greater than 0.0) may be subnormal but is not a logical zero, so
 ; the fold fires.
-define float @test_subnormal_ieee_allows_fold(float %x, float %y) #0 {
+define float @test_subnormal_ieee_allows_fold(float %x, float %y) {
 ; CHECK-LABEL: @test_subnormal_ieee_allows_fold(
 ; CHECK-NEXT:    [[IS_POS_X:%.*]] = fcmp ogt float [[X:%.*]], 0.000000e+00
 ; CHECK-NEXT:    [[IS_POS_Y:%.*]] = fcmp ogt float [[Y:%.*]], 0.000000e+00
@@ -131,7 +131,7 @@ define float @test_subnormal_ieee_allows_fold(float %x, float %y) #0 {
 ; In preserve-sign mode, a value known to be strictly positive may still be
 ; subnormal, which is treated as a logical zero. The fold is blocked because
 ; the legacy zero clause could fire when subnormals are flushed to zero.
-define float @test_subnormal_flush_blocks_fold(float %x, float %y) #1 {
+define float @test_subnormal_flush_blocks_fold(float %x, float %y) #0 {
 ; CHECK-LABEL: @test_subnormal_flush_blocks_fold(
 ; CHECK-NEXT:    [[IS_POS_X:%.*]] = fcmp ogt float [[X:%.*]], 0.000000e+00
 ; CHECK-NEXT:    [[IS_POS_Y:%.*]] = fcmp ogt float [[Y:%.*]], 0.000000e+00
@@ -168,5 +168,4 @@ declare float @llvm.amdgcn.fmul.legacy(float, float)
 declare float @llvm.fabs.f32(float)
 declare void @llvm.assume(i1 noundef)
 
-attributes #0 = { denormal_fpenv(float: ieee) }
-attributes #1 = { denormal_fpenv(float: preservesign) }
+attributes #0 = { denormal_fpenv(float: preservesign) }

--- a/llvm/test/Transforms/InstCombine/AMDGPU/fmul_legacy.ll
+++ b/llvm/test/Transforms/InstCombine/AMDGPU/fmul_legacy.ll
@@ -108,37 +108,6 @@ define float @test_finite_assumed(float %x, float %y) {
   ret float %call
 }
 
-; Combine to fmul without nsz: both operands are finite non-zero constants so
-; the legacy zero clause can never fire (neither operand is zero) and there is
-; no sign-of-zero divergence. The result is further constant-folded to -199.0.
-define float @test_both_const_nonzero() {
-; CHECK-LABEL: @test_both_const_nonzero(
-; CHECK-NEXT:    ret float -1.990000e+02
-;
-  %call = call float @llvm.amdgcn.fmul.legacy(float -2.0, float 99.5)
-  ret float %call
-}
-
-; Combine to fmul without nsz: qNaN and finite non-zero, neither can be zero.
-; Result constant-folds to +qnan.
-define float @test_nan_const_nonzero() {
-; CHECK-LABEL: @test_nan_const_nonzero(
-; CHECK-NEXT:    ret float +qnan
-;
-  %call = call float @llvm.amdgcn.fmul.legacy(float 0x7FF8000000000000, float -2.0)
-  ret float %call
-}
-
-; Combine to fmul without nsz: +inf and finite non-zero, neither can be zero.
-; Result constant-folds to -inf.
-define float @test_inf_const_nonzero() {
-; CHECK-LABEL: @test_inf_const_nonzero(
-; CHECK-NEXT:    ret float -inf
-;
-  %call = call float @llvm.amdgcn.fmul.legacy(float 0x7FF0000000000000, float -2.0)
-  ret float %call
-}
-
 define float @test_poison_var(float %x) {
 ; CHECK-LABEL: @test_poison_var(
 ; CHECK-NEXT:    ret float poison

--- a/llvm/test/Transforms/InstCombine/AMDGPU/fmul_legacy.ll
+++ b/llvm/test/Transforms/InstCombine/AMDGPU/fmul_legacy.ll
@@ -108,6 +108,46 @@ define float @test_finite_assumed(float %x, float %y) {
   ret float %call
 }
 
+; In IEEE mode subnormals are not logical zeros. A value known to be strictly
+; positive (greater than 0.0) may be subnormal but is not a logical zero, so
+; the fold fires.
+define float @test_subnormal_ieee_allows_fold(float %x, float %y) #0 {
+; CHECK-LABEL: @test_subnormal_ieee_allows_fold(
+; CHECK-NEXT:    [[IS_POS_X:%.*]] = fcmp ogt float [[X:%.*]], 0.000000e+00
+; CHECK-NEXT:    [[IS_POS_Y:%.*]] = fcmp ogt float [[Y:%.*]], 0.000000e+00
+; CHECK-NEXT:    call void @llvm.assume(i1 [[IS_POS_X]])
+; CHECK-NEXT:    call void @llvm.assume(i1 [[IS_POS_Y]])
+; CHECK-NEXT:    [[CALL:%.*]] = fmul nnan float [[X]], [[Y]]
+; CHECK-NEXT:    ret float [[CALL]]
+;
+  %is.pos.x = fcmp ogt float %x, 0.0
+  %is.pos.y = fcmp ogt float %y, 0.0
+  call void @llvm.assume(i1 %is.pos.x)
+  call void @llvm.assume(i1 %is.pos.y)
+  %call = call float @llvm.amdgcn.fmul.legacy(float %x, float %y)
+  ret float %call
+}
+
+; In preserve-sign mode, a value known to be strictly positive may still be
+; subnormal, which is treated as a logical zero. The fold is blocked because
+; the legacy zero clause could fire when subnormals are flushed to zero.
+define float @test_subnormal_flush_blocks_fold(float %x, float %y) #1 {
+; CHECK-LABEL: @test_subnormal_flush_blocks_fold(
+; CHECK-NEXT:    [[IS_POS_X:%.*]] = fcmp ogt float [[X:%.*]], 0.000000e+00
+; CHECK-NEXT:    [[IS_POS_Y:%.*]] = fcmp ogt float [[Y:%.*]], 0.000000e+00
+; CHECK-NEXT:    call void @llvm.assume(i1 [[IS_POS_X]])
+; CHECK-NEXT:    call void @llvm.assume(i1 [[IS_POS_Y]])
+; CHECK-NEXT:    [[CALL:%.*]] = call float @llvm.amdgcn.fmul.legacy(float [[X]], float [[Y]])
+; CHECK-NEXT:    ret float [[CALL]]
+;
+  %is.pos.x = fcmp ogt float %x, 0.0
+  %is.pos.y = fcmp ogt float %y, 0.0
+  call void @llvm.assume(i1 %is.pos.x)
+  call void @llvm.assume(i1 %is.pos.y)
+  %call = call float @llvm.amdgcn.fmul.legacy(float %x, float %y)
+  ret float %call
+}
+
 define float @test_poison_var(float %x) {
 ; CHECK-LABEL: @test_poison_var(
 ; CHECK-NEXT:    ret float poison
@@ -127,3 +167,6 @@ define float @test_var_poison(float %x) {
 declare float @llvm.amdgcn.fmul.legacy(float, float)
 declare float @llvm.fabs.f32(float)
 declare void @llvm.assume(i1 noundef)
+
+attributes #0 = { denormal_fpenv(float: ieee) }
+attributes #1 = { denormal_fpenv(float: preservesign) }


### PR DESCRIPTION
V_MUL_LEGACY_F32 always returns +0.0 when either operand is ±0.0 or a
denormal treated as zero, while IEEE fmul XORs operand signs. This makes
results observably different when one operand is a runtime ±0.0:

  fmul.legacy(-2.0, +0.0) = +0.0  (legacy zero clause forces +0.0)
  fmul       (-2.0, +0.0) = -0.0  (IEEE sign XOR: - * + = -)

The previous code folded whenever one operand matched m_FiniteNonZero()
or both were known never Inf/NaN, without accounting for sign-of-zero
divergence on the other operand.

Restructure the guard:

- Always safe: both operands are known never zero (legacy zero clause
  cannot fire). Uses isKnownNeverLogicalZero to correctly account for
  denormals flushed to zero under the function's f32 denormal mode.

- With nsz (sign-of-zero is don't-care), two additional cases apply:
  1. One operand is not zero or infinity or NaN: zero clause cannot fire
     on that side, and 0*Inf/0*NaN (where legacy returns +0.0 but IEEE
     returns NaN) is excluded.
  2. Neither operand is infinity or NaN: 0*Inf and 0*NaN cases excluded,
     nsz covers any sign-of-zero difference from the zero clause.
  A single condition captures both cases.

- Compute Known1 lazily: bail before the second computeKnownFPClass call
  if Op0 may be zero and nsz is not set, since Op1 cannot help.

Update fmul_legacy.ll and fma_legacy.ll to reflect the corrected
behavior: cases that previously folded without nsz now require it or
require both operands to be provably non-zero.