### PR TITLE
[libc] fix EAGAIN being treated as timeout in mutex and rwlock

### DIFF
--- a/libc/src/__support/threads/linux/futex_utils.h
+++ b/libc/src/__support/threads/linux/futex_utils.h
@@ -66,6 +66,11 @@ public:
       if (ret == -EINTR)
         continue;
 
+      // EAGAIN and EWOULDBLOCK will be treated as a normal finish, as the value
+      // has changed.
+      if (ret == -EAGAIN || ret == -EWOULDBLOCK)
+        return 0;
+
       if (ret < 0)
         return cpp::unexpected(-ret);
       return ret;

--- a/libc/src/__support/threads/raw_mutex.h
+++ b/libc/src/__support/threads/raw_mutex.h
@@ -83,8 +83,8 @@ private:
           futex.exchange(IN_CONTENTION, cpp::MemoryOrder::ACQUIRE) == UNLOCKED)
         return true;
       // Contention persists. Park the thread and wait for further notification.
-      if (!futex.wait(IN_CONTENTION, timeout, is_pshared).has_value() &&
-          timeout.has_value())
+      if (ErrorOr<int> res = futex.wait(IN_CONTENTION, timeout, is_pshared);
+          !res.has_value() && res.error() == ETIMEDOUT)
         return false;
 
       // Continue to spin after waking up.

--- a/libc/src/__support/threads/raw_mutex.h
+++ b/libc/src/__support/threads/raw_mutex.h
@@ -83,8 +83,8 @@ private:
           futex.exchange(IN_CONTENTION, cpp::MemoryOrder::ACQUIRE) == UNLOCKED)
         return true;
       // Contention persists. Park the thread and wait for further notification.
-      if (ErrorOr<int> res = futex.wait(IN_CONTENTION, timeout, is_pshared);
-          !res.has_value() && res.error() == ETIMEDOUT)
+      ErrorOr<int> res = futex.wait(IN_CONTENTION, timeout, is_pshared);
+      if (!res.has_value() && res.error() == ETIMEDOUT)
         return false;
 
       // Continue to spin after waking up.

--- a/libc/src/__support/threads/raw_rwlock.h
+++ b/libc/src/__support/threads/raw_rwlock.h
@@ -400,8 +400,9 @@ private:
       // reached.
       bool timeout_flag = false;
       if (!old.can_acquire<role>(get_preference())) {
-        auto wait_result = queue.wait<role>(serial_number, timeout, is_pshared);
-        timeout_flag = (!wait_result.has_value() && timeout.has_value());
+        ErrorOr<int> wait_result = queue.wait<role>(serial_number, timeout, is_pshared);
+        timeout_flag =
+            (!wait_result.has_value() && wait_result.error() == ETIMEDOUT);
       }
 
       // Phase 7: unregister ourselves as a pending reader/writer.

--- a/libc/src/__support/threads/raw_rwlock.h
+++ b/libc/src/__support/threads/raw_rwlock.h
@@ -400,7 +400,8 @@ private:
       // reached.
       bool timeout_flag = false;
       if (!old.can_acquire<role>(get_preference())) {
-        ErrorOr<int> wait_result = queue.wait<role>(serial_number, timeout, is_pshared);
+        ErrorOr<int> wait_result =
+            queue.wait<role>(serial_number, timeout, is_pshared);
         timeout_flag =
             (!wait_result.has_value() && wait_result.error() == ETIMEDOUT);
       }

--- a/libc/test/integration/src/__support/threads/futex_requeue_test.cpp
+++ b/libc/test/integration/src/__support/threads/futex_requeue_test.cpp
@@ -29,7 +29,7 @@ struct SharedState {
 void wait_until_zero(LIBC_NAMESPACE::Futex &futex) {
   while (futex.load() != 0) {
     auto wait_result = futex.wait(1, LIBC_NAMESPACE::cpp::nullopt, false);
-    ASSERT_TRUE(wait_result.has_value() || wait_result.error() == EAGAIN);
+    ASSERT_TRUE(wait_result.has_value());
   }
 }
 


### PR DESCRIPTION
fix #203411. 

This PR addresses the problem that `EAGAIN` may be treated as timeout in mutex and rwlock. Two changes are applied: 

1. timeout sites always explicitly check for timeout now to make the logic more robust; 
2. the futex wait now discards the error of `EAGAIN/EWOULDBLOCK` and returns 0; 

We don't distinguish waking up from signal and waking up from mismatch for the following 3 reasons: 
- We have userspace guard to avoid futex syscall if we already know value would match, it seems awkward to make that check returns error, as we may wake up and loop back to the check, where signal is consumed but we still return error....; 
- futex syscall can spuriously wake up anyway, there is no way to tell whether the signal is "indeed" consumed; 
- other platforms like darwin does not distinguish these states either.

Assisted-by: Gemini powered automation tools (human-in-the-loop).


