### PR TITLE
[z/OS][Clang] Raise minimum supported z/OS target level to 3.1

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -552,9 +552,7 @@ static void setZosTargetVersion(const Driver &D, llvm::Triple &Target,
                                 StringRef ArgTarget) {
 
   static bool BeSilent = false;
-  auto IsTooOldToBeSupported = [](int v, int r) -> bool {
-    return v < 3;
-  };
+  auto IsTooOldToBeSupported = [](int v, int r) -> bool { return v < 3; };
 
   /* expect CURRENT, zOSVnRn, or 0xnnnnnnnn */
   if (ArgTarget.equals_insensitive("CURRENT")) {

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -553,7 +553,7 @@ static void setZosTargetVersion(const Driver &D, llvm::Triple &Target,
 
   static bool BeSilent = false;
   auto IsTooOldToBeSupported = [](int v, int r) -> bool {
-    return ((v < 3) || ((v == 3) && (r < 1)));
+    return v < 3;
   };
 
   /* expect CURRENT, zOSVnRn, or 0xnnnnnnnn */

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -553,10 +553,10 @@ static void setZosTargetVersion(const Driver &D, llvm::Triple &Target,
 
   static bool BeSilent = false;
   auto IsTooOldToBeSupported = [](int v, int r) -> bool {
-    return ((v < 2) || ((v == 2) && (r < 4)));
+    return ((v < 3) || ((v == 3) && (r < 1)));
   };
 
-  /* expect CURRENT, zOSV2R[45], or 0xnnnnnnnn */
+  /* expect CURRENT, zOSVnRn, or 0xnnnnnnnn */
   if (ArgTarget.equals_insensitive("CURRENT")) {
     /* If the user gives CURRENT, then we rely on the LE to set   */
     /* __TARGET_LIB__.  There's nothing more we need to do.       */

--- a/clang/test/Preprocessor/zos-target.c
+++ b/clang/test/Preprocessor/zos-target.c
@@ -5,14 +5,14 @@
 // RUN: %clang -mzos-target=current -dM -E %s | FileCheck --check-prefix=CURRENT %s
 // CURRENT-NOT: #define __TARGET_LIB__
 
-// RUN: %clang -mzos-target=zosv2r5 -dM -E %s | FileCheck --check-prefix=ZOSVR %s
-// ZOSVR: #define __TARGET_LIB__ 0x42050000
+// RUN: %clang -mzos-target=zosv3r1 -dM -E %s | FileCheck --check-prefix=ZOSVR %s
+// ZOSVR: #define __TARGET_LIB__ 0x43010000
 
-// RUN: %clang -mzos-target=0x4204001f  -dM -E %s | FileCheck --check-prefix=HEX %s
-// HEX: #define __TARGET_LIB__ 0x4204001F
+// RUN: %clang -mzos-target=0x4301001f  -dM -E %s | FileCheck --check-prefix=HEX %s
+// HEX: #define __TARGET_LIB__ 0x4301001F
 
-// RUN: not %clang -mzos-target=0x42010000 -dM -E %s 2>&1 | FileCheck --check-prefix=ERR-DISCONTINUED %s
-// ERR-DISCONTINUED: z/OS target level "0x42010000" is discontinued. Unexpected behavior might occur if an out-of-support target level is specified. Use z/OS target level "zosv2r4", or later instead
+// RUN: not %clang -mzos-target=0x43000000 -dM -E %s 2>&1 | FileCheck --check-prefix=ERR-DISCONTINUED %s
+// ERR-DISCONTINUED: z/OS target level "0x43000000" is discontinued
 
 // RUN: not %clang -mzos-target=Rubbish -dM -E %s 2>&1 | FileCheck --check-prefix=ERR-INVALID-ARG   %s
-// ERR-INVALID-ARG: "Rubbish" is not recognized as a valid z/OS target level. The z/OS target level must be "current", or of the form "zosvVrR", where "V" is the version and "R" is the release, or given as a "0x"-prefixed eight digit hexadecimal value
+// ERR-INVALID-ARG: z/OS target level "Rubbish" is invalid

--- a/clang/test/Preprocessor/zos-target.c
+++ b/clang/test/Preprocessor/zos-target.c
@@ -11,8 +11,8 @@
 // RUN: %clang -mzos-target=0x4301001f  -dM -E %s | FileCheck --check-prefix=HEX %s
 // HEX: #define __TARGET_LIB__ 0x4301001F
 
-// RUN: not %clang -mzos-target=0x43000000 -dM -E %s 2>&1 | FileCheck --check-prefix=ERR-DISCONTINUED %s
-// ERR-DISCONTINUED: z/OS target level "0x43000000" is discontinued
+// RUN: not %clang -mzos-target=0x42010000 -dM -E %s 2>&1 | FileCheck --check-prefix=ERR-DISCONTINUED %s
+// ERR-DISCONTINUED: z/OS target level "0x42010000" is discontinued
 
 // RUN: not %clang -mzos-target=Rubbish -dM -E %s 2>&1 | FileCheck --check-prefix=ERR-INVALID-ARG   %s
 // ERR-INVALID-ARG: z/OS target level "Rubbish" is invalid


### PR DESCRIPTION
Update z/OS target validation and tests to reject targets older than z/OS 3.1