### PR TITLE
[SPIR-V] Lower freeze instructions with aggregate operands

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -1581,9 +1581,9 @@ void SPIRVEmitIntrinsics::replaceMemInstrUses(Instruction *Old,
       // the i32 value-id type up front in runOnFunction, so only the operand
       // needs replacing here; their extractvalue users are lowered to
       // spv_extractv by visitExtractValueInst.
-      assert(
-          U->getType() == New->getType() &&
-          "aggregate PHI/select/freeze should have been mutated to value-id type");
+      assert(U->getType() == New->getType() &&
+             "aggregate PHI/select/freeze should have been mutated to value-id "
+             "type");
       U->replaceUsesOfWith(Old, New);
     } else {
       llvm_unreachable("illegal aggregate intrinsic user");

--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -1576,13 +1576,14 @@ void SPIRVEmitIntrinsics::replaceMemInstrUses(Instruction *Old,
           CI->setCalledFunction(NewF);
         }
       }
-    } else if (isa<PHINode>(U) || isa<SelectInst>(U)) {
-      // Aggregate-typed PHIs and selects have already been mutated to the
-      // i32 value-id type up front in runOnFunction, so only the operand
+    } else if (isa<PHINode>(U) || isa<SelectInst>(U) || isa<FreezeInst>(U)) {
+      // Aggregate-typed PHIs, selects and freezes have already been mutated to
+      // the i32 value-id type up front in runOnFunction, so only the operand
       // needs replacing here; their extractvalue users are lowered to
       // spv_extractv by visitExtractValueInst.
-      assert(U->getType() == New->getType() &&
-             "aggregate PHI/select should have been mutated to value-id type");
+      assert(
+          U->getType() == New->getType() &&
+          "aggregate PHI/select/freeze should have been mutated to value-id type");
       U->replaceUsesOfWith(Old, New);
     } else {
       llvm_unreachable("illegal aggregate intrinsic user");
@@ -3514,15 +3515,15 @@ bool SPIRVEmitIntrinsics::runOnFunction(Function &Func) {
   simplifyNullAddrSpaceCasts();
   preprocessCompositeConstants(B);
 
-  // A PHINode or SelectInst takes its result type from its operands. Aggregate
-  // arms are lowered to i32 value-ids (composite constants here, loads and
-  // other producers during the visitor pass below), so mutate an aggregate PHI
-  // or select to match. The original type is tracked in AggrConstTypes (used to
-  // assign the SPIR-V type) and its extractvalue users are lowered to
-  // spv_extractv.
+  // A PHINode, SelectInst or FreezeInst takes its result type from its
+  // operands. Aggregate arms are lowered to i32 value-ids (composite constants
+  // here, loads and other producers during the visitor pass below), so mutate
+  // an aggregate PHI, select or freeze to match. The original type is tracked
+  // in AggrConstTypes (used to assign the SPIR-V type) and its extractvalue
+  // users are lowered to spv_extractv.
   Type *I32Ty = B.getInt32Ty();
   for (Instruction &I : instructions(Func)) {
-    if (!isa<PHINode>(I) && !isa<SelectInst>(I))
+    if (!isa<PHINode>(I) && !isa<SelectInst>(I) && !isa<FreezeInst>(I))
       continue;
     if (!I.getType()->isAggregateType())
       continue;

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_poison_freeze/freeze-aggregate.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_poison_freeze/freeze-aggregate.ll
@@ -1,0 +1,47 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_KHR_poison_freeze %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_KHR_poison_freeze %s -o - -filetype=obj | spirv-val %}
+
+; An aggregate freeze takes its result type from its operand and is lowered like
+; aggregate PHIs and selects. With SPV_KHR_poison_freeze it becomes an
+; OpFreezeKHR over the composite type.
+
+; CHECK-DAG: OpCapability PoisonFreezeKHR
+; CHECK-DAG: OpExtension "SPV_KHR_poison_freeze"
+
+; CHECK-DAG: %[[#Float:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#Int:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#Two:]] = OpConstant %[[#Int]] 2
+; CHECK-DAG: %[[#Array:]] = OpTypeArray %[[#Float]] %[[#Two]]
+; CHECK-DAG: %[[#Struct:]] = OpTypeStruct %[[#Float]] %[[#Float]]
+
+; CHECK: %[[#L:]] = OpLoad %[[#Array]]
+; CHECK: %[[#FL:]] = OpFreezeKHR %[[#Array]] %[[#L]]
+; CHECK: OpCompositeExtract %[[#Float]] %[[#FL]] 0
+define spir_kernel void @freeze_loaded(ptr addrspace(1) %out, ptr addrspace(1) %pa) {
+  %a = load [2 x float], ptr addrspace(1) %pa
+  %v = freeze [2 x float] %a
+  %e0 = extractvalue [2 x float] %v, 0
+  store float %e0, ptr addrspace(1) %out
+  ret void
+}
+
+; CHECK: %[[#Ins:]] = OpCompositeInsert %[[#Struct]] %[[#]] %[[#]] 1
+; CHECK: %[[#FI:]] = OpFreezeKHR %[[#Struct]] %[[#Ins]]
+; CHECK: OpCompositeExtract %[[#Float]] %[[#FI]] 1
+define spir_kernel void @freeze_insertvalue(ptr addrspace(1) %out, float %x) {
+  %ins = insertvalue { float, float } zeroinitializer, float %x, 1
+  %v = freeze { float, float } %ins
+  %e1 = extractvalue { float, float } %v, 1
+  store float %e1, ptr addrspace(1) %out
+  ret void
+}
+
+; CHECK: %[[#S:]] = OpLoad %[[#Array]]
+; CHECK: %[[#FS:]] = OpFreezeKHR %[[#Array]] %[[#S]]
+; CHECK: OpStore %[[#]] %[[#FS]]
+define spir_kernel void @freeze_store_direct(ptr addrspace(1) %out, ptr addrspace(1) %pa) {
+  %a = load [2 x float], ptr addrspace(1) %pa
+  %v = freeze [2 x float] %a
+  store [2 x float] %v, ptr addrspace(1) %out
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/freeze-aggregate.ll
+++ b/llvm/test/CodeGen/SPIRV/freeze-aggregate.ll
@@ -1,0 +1,40 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; An aggregate freeze takes its result type from its operand and must be lowered
+; like aggregate PHIs and selects.
+
+; CHECK-DAG: %[[#Float:]] = OpTypeFloat 32
+; CHECK-DAG: %[[#Int:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#Two:]] = OpConstant %[[#Int]] 2
+; CHECK-DAG: %[[#Array:]] = OpTypeArray %[[#Float]] %[[#Two]]
+; CHECK-DAG: %[[#Struct:]] = OpTypeStruct %[[#Float]] %[[#Float]]
+
+; CHECK: %[[#L:]] = OpLoad %[[#Array]]
+; CHECK: OpCompositeExtract %[[#Float]] %[[#L]] 0
+define spir_kernel void @freeze_loaded(ptr addrspace(1) %out, ptr addrspace(1) %pa) {
+  %a = load [2 x float], ptr addrspace(1) %pa
+  %v = freeze [2 x float] %a
+  %e0 = extractvalue [2 x float] %v, 0
+  store float %e0, ptr addrspace(1) %out
+  ret void
+}
+
+; CHECK: %[[#Ins:]] = OpCompositeInsert %[[#Struct]] %[[#]] %[[#]] 1
+; CHECK: OpCompositeExtract %[[#Float]] %[[#Ins]] 1
+define spir_kernel void @freeze_insertvalue(ptr addrspace(1) %out, float %x) {
+  %ins = insertvalue { float, float } zeroinitializer, float %x, 1
+  %v = freeze { float, float } %ins
+  %e1 = extractvalue { float, float } %v, 1
+  store float %e1, ptr addrspace(1) %out
+  ret void
+}
+
+; CHECK: %[[#S:]] = OpLoad %[[#Array]]
+; CHECK: OpStore %[[#]] %[[#S]]
+define spir_kernel void @freeze_store_direct(ptr addrspace(1) %out, ptr addrspace(1) %pa) {
+  %a = load [2 x float], ptr addrspace(1) %pa
+  %v = freeze [2 x float] %a
+  store [2 x float] %v, ptr addrspace(1) %out
+  ret void
+}


### PR DESCRIPTION
An aggregate freeze takes its result type from its operand, like a PHI or select, but was handled by neither the up-front value-id mutation nor replaceMemInstrUses, so the pass aborted with "illegal aggregate intrinsic user". Mutate aggregate freezes to the i32 value-id type and replace their operands alongside PHIs and selects.