### PR TITLE
Mark BaseEpiFlags as maybe unused

### DIFF
--- a/llvm/lib/MC/MCWin64EH.cpp
+++ b/llvm/lib/MC/MCWin64EH.cpp
@@ -714,7 +714,7 @@ static void EmitUnwindInfoV3(MCStreamer &Streamer, WinEH::FrameInfo *Info) {
 
   // --- Emit epilog descriptors ---
   const MCSymbol *PrevEpilogStart = nullptr;
-  uint8_t BaseEpiFlags = 0;
+  [[maybe_unused]] uint8_t BaseEpiFlags = 0;
   for (const auto &EI : EpilogInfos) {
     const auto &Epilog = *EI.Epilog;
 


### PR DESCRIPTION
After #202778 was merged in, the `release-noassertions-warnings` build was failing because the new `BaseEpiFlags` is always set but only read in an assert.