### PR TITLE
[libomp][AIX] Rename libatomic to libcompiler_rt

### DIFF
--- a/openmp/runtime/CMakeLists.txt
+++ b/openmp/runtime/CMakeLists.txt
@@ -139,8 +139,8 @@ if("${CMAKE_SYSTEM_NAME}" MATCHES "AIX")
   set(LIBOMP_LIBFLAGS "-lperfstat" CACHE STRING
     "Appended user specified linked libs flags. (e.g., -lm)")
   if("${LIBOMP_ARCH}" STREQUAL "ppc")
-    # PPC (32-bit) on AIX needs libatomic for __atomic_load_8, etc.
-    set(LIBOMP_LIBFLAGS "${LIBOMP_LIBFLAGS} -latomic")
+    # PPC (32-bit) on AIX needs libcompiler_rt for __atomic_load_8, etc.
+    set(LIBOMP_LIBFLAGS "${LIBOMP_LIBFLAGS} -lcompiler_rt")
   endif()
 else()
   set(LIBOMP_LIBFLAGS "" CACHE STRING


### PR DESCRIPTION
This change updates the reference from `libatomic` to `libcompiler_rt` to match the recent renaming on AIX.