### PR TITLE
[llvm-diff] Respect AllowAssumptions in diffCallSites

### DIFF
--- a/llvm/test/tools/llvm-diff/callsite-assumption-passing.ll
+++ b/llvm/test/tools/llvm-diff/callsite-assumption-passing.ll
@@ -1,0 +1,33 @@
+; RUN: split-file %s %t
+; RUN: not llvm-diff %t/a.ll %t/b.ll 2>&1 | FileCheck %s
+
+; Regression test for https://github.com/llvm/llvm-project/issues/184133
+
+; CHECK:      in function func:
+; CHECK-NEXT:   in block %0 / %0:
+; CHECK-NEXT:    >   %c = call double @h()
+; CHECK-NEXT:    >   %b = call double @g(double %c)
+; CHECK-NEXT:    >   ret double %b
+; CHECK-NEXT:    <   %b = call double @g(double %a)
+; CHECK-NEXT:    <   ret double %b
+; CHECK-NOT: second time around
+
+;--- a.ll
+define double @func() {
+  %a = call double @f()
+  %b = call double @g(double %a)
+  ret double %b
+}
+declare double @f()
+declare double @g(double)
+
+;--- b.ll
+define double @func() {
+  %a = call double @f()
+  %c = call double @h()
+  %b = call double @g(double %c)
+  ret double %b
+}
+declare double @f()
+declare double @h()
+declare double @g(double)

--- a/llvm/tools/llvm-diff/lib/DifferenceEngine.cpp
+++ b/llvm/tools/llvm-diff/lib/DifferenceEngine.cpp
@@ -339,11 +339,10 @@ class FunctionDifferenceEngine {
   void runBlockDiff(BasicBlock::const_iterator LI,
                     BasicBlock::const_iterator RI);
 
-  bool diffCallSites(const CallBase &L, const CallBase &R, bool Complain) {
+  bool diffCallSites(const CallBase &L, const CallBase &R, bool Complain,
+                     const AssumptionContext *AC) {
     // FIXME: call attributes
-    AssumptionContext AC = {L.getParent(), R.getParent()};
-    if (!equivalentAsOperands(L.getCalledOperand(), R.getCalledOperand(),
-                              &AC)) {
+    if (!equivalentAsOperands(L.getCalledOperand(), R.getCalledOperand(), AC)) {
       if (Complain) Engine.log("called functions differ");
       return true;
     }
@@ -352,7 +351,7 @@ class FunctionDifferenceEngine {
       return true;
     }
     for (unsigned I = 0, E = L.arg_size(); I != E; ++I)
-      if (!equivalentAsOperands(L.getArgOperand(I), R.getArgOperand(I), &AC)) {
+      if (!equivalentAsOperands(L.getArgOperand(I), R.getArgOperand(I), AC)) {
         if (Complain)
           Engine.logf("arguments %l and %r differ")
               << L.getArgOperand(I) << R.getArgOperand(I);
@@ -384,7 +383,8 @@ class FunctionDifferenceEngine {
         return true;
       }
     } else if (isa<CallInst>(L)) {
-      return diffCallSites(cast<CallInst>(*L), cast<CallInst>(*R), Complain);
+      return diffCallSites(cast<CallInst>(*L), cast<CallInst>(*R), Complain,
+                           AC);
     } else if (isa<PHINode>(L)) {
       const PHINode &LI = cast<PHINode>(*L);
       const PHINode &RI = cast<PHINode>(*R);
@@ -421,7 +421,7 @@ class FunctionDifferenceEngine {
     } else if (isa<InvokeInst>(L)) {
       const InvokeInst &LI = cast<InvokeInst>(*L);
       const InvokeInst &RI = cast<InvokeInst>(*R);
-      if (diffCallSites(LI, RI, Complain))
+      if (diffCallSites(LI, RI, Complain, AC))
         return true;
 
       if (TryUnify) {
@@ -444,7 +444,7 @@ class FunctionDifferenceEngine {
       for (unsigned I = 0; I < LI.getNumIndirectDests(); I++)
         tryUnify(LI.getIndirectDest(I), RI.getIndirectDest(I));
 
-      if (diffCallSites(LI, RI, Complain))
+      if (diffCallSites(LI, RI, Complain, AC))
         return true;
 
       if (TryUnify)


### PR DESCRIPTION
diffCallSites always built an AssumptionContext, so call sites made optimistic equivalence assumptions even when the caller disabled them. This made matchForBlockDiff over-match, and the re-check in unify() then hit the "structural differences second time around?" assertion.

Thread the caller's AssumptionContext into diffCallSites so call sites honor the no-assumptions request like every other instruction kind.

Fixes #184133