### PR TITLE
[AMDGPU] NFC: Drop constexpr from getFlavor*Name functions

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h
@@ -39,7 +39,7 @@ enum class InstructionFlavor : uint8_t {
   NUM_FLAVORS
 };
 
-constexpr StringRef getFlavorName(InstructionFlavor F) {
+inline StringRef getFlavorName(InstructionFlavor F) {
   switch (F) {
   case InstructionFlavor::WMMA:
     return "WMMA";
@@ -67,7 +67,7 @@ constexpr StringRef getFlavorName(InstructionFlavor F) {
   llvm_unreachable("Unknown InstructionFlavor");
 }
 
-constexpr StringRef getFlavorShortName(InstructionFlavor F) {
+inline StringRef getFlavorShortName(InstructionFlavor F) {
   switch (F) {
   case InstructionFlavor::WMMA:
     return "W";

--- a/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h
@@ -128,7 +128,7 @@ enum class AMDGPUSchedReason : uint8_t {
   NUM_REASONS
 };
 
-constexpr StringRef getReasonName(AMDGPUSchedReason R) {
+inline StringRef getReasonName(AMDGPUSchedReason R) {
   switch (R) {
   case AMDGPUSchedReason::None:
     return "None";


### PR DESCRIPTION
It seems specifying these as constexpr was causing some buildbot failures due to llvm_unreachable --

```
[1/123] Building CXX object lib/Target/AMDGPU/CMakeFiles/LLVMAMDGPUCodeGen.dir/AMDGPUCoExecSchedStrategy.cpp.o
FAILED: lib/Target/AMDGPU/CMakeFiles/LLVMAMDGPUCodeGen.dir/AMDGPUCoExecSchedStrategy.cpp.o 
/usr/bin/c++ -DLLVM_EXPORTS -D_DEBUG -D_GLIBCXX_ASSERTIONS -D_GLIBCXX_USE_CXX11_ABI=1 -D_GNU_SOURCE -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/path/to/build.AArch64.Release.main/lib/Target/AMDGPU -I/path/to/llvm-project/llvm/lib/Target/AMDGPU -I/path/to/build.AArch64.Release.main/include -I/path/to/llvm-project/llvm/include -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -pedantic -Wno-long-long -Wimplicit-fallthrough -Wno-uninitialized -Wno-nonnull -Wno-class-memaccess -Wno-array-bounds -Wno-noexcept-type -Wdelete-non-virtual-dtor -Wno-comment -Wno-misleading-indentation -fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG -std=c++17 -fvisibility=hidden -UNDEBUG -fno-exceptions -funwind-tables -fno-rtti -MD -MT lib/Target/AMDGPU/CMakeFiles/LLVMAMDGPUCodeGen.dir/AMDGPUCoExecSchedStrategy.cpp.o -MF lib/Target/AMDGPU/CMakeFiles/LLVMAMDGPUCodeGen.dir/AMDGPUCoExecSchedStrategy.cpp.o.d -o lib/Target/AMDGPU/CMakeFiles/LLVMAMDGPUCodeGen.dir/AMDGPUCoExecSchedStrategy.cpp.o -c /path/to/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.cpp
In file included from /path/to/llvm-project/llvm/include/llvm/ADT/Hashing.h:49,
                 from /path/to/llvm-project/llvm/include/llvm/ADT/ArrayRef.h:12,
                 from /path/to/llvm-project/llvm/include/llvm/CodeGen/GlobalISel/CallLowering.h:17,
                 from /path/to/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUCallLowering.h:17,
                 from /path/to/llvm-project/llvm/lib/Target/AMDGPU/GCNSubtarget.h:17,
                 from /path/to/llvm-project/llvm/lib/Target/AMDGPU/GCNRegPressure.h:20,
                 from /path/to/llvm-project/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h:16,
                 from /path/to/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h:17,
                 from /path/to/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.cpp:14:
/path/to/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h: In function 'constexpr llvm::StringRef llvm::AMDGPU::getFlavorName(llvm::AMDGPU::InstructionFlavor)':
/path/to/llvm-project/llvm/include/llvm/Support/ErrorHandling.h:165:36: error: call to non-'constexpr' function 'void llvm::llvm_unreachable_internal(const char*, const char*, unsigned int)'
   ::llvm::llvm_unreachable_internal(msg, __FILE__, __LINE__)
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h:67: note: in expansion of macro 'llvm_unreachable'
   llvm_unreachable("Unknown InstructionFlavor");
 
/path/to/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h: In function 'constexpr llvm::StringRef llvm::AMDGPU::getFlavorShortName(llvm::AMDGPU::InstructionFlavor)':
/path/to/llvm-project/llvm/include/llvm/Support/ErrorHandling.h:165:36: error: call to non-'constexpr' function 'void llvm::llvm_unreachable_internal(const char*, const char*, unsigned int)'
   ::llvm::llvm_unreachable_internal(msg, __FILE__, __LINE__)
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h:95: note: in expansion of macro 'llvm_unreachable'
   llvm_unreachable("Unknown InstructionFlavor");
 
/path/to/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h: In function 'constexpr llvm::StringRef llvm::AMDGPU::getReasonName(llvm::AMDGPU::AMDGPUSchedReason)':
/path/to/llvm-project/llvm/include/llvm/Support/ErrorHandling.h:165:36: error: call to non-'constexpr' function 'void llvm::llvm_unreachable_internal(const char*, const char*, unsigned int)'
   ::llvm::llvm_unreachable_internal(msg, __FILE__, __LINE__)
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h:142: note: in expansion of macro 'llvm_unreachable'
   llvm_unreachable("Unknown AMDGPUSchedReason");
 
[2/123] Building CXX object lib/Target/AMDGPU/CMakeFiles/LLVMAMDGPUCodeGen.dir/AMDGPUTargetMachine.cpp.o
FAILED: lib/Target/AMDGPU/CMakeFiles/LLVMAMDGPUCodeGen.dir/AMDGPUTargetMachine.cpp.o 
/usr/bin/c++ -DLLVM_EXPORTS -D_DEBUG -D_GLIBCXX_ASSERTIONS -D_GLIBCXX_USE_CXX11_ABI=1 -D_GNU_SOURCE -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/path/to/build.AArch64.Release.main/lib/Target/AMDGPU -I/path/to/llvm-project/llvm/lib/Target/AMDGPU -I/path/to/build.AArch64.Release.main/include -I/path/to/llvm-project/llvm/include -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -pedantic -Wno-long-long -Wimplicit-fallthrough -Wno-uninitialized -Wno-nonnull -Wno-class-memaccess -Wno-array-bounds -Wno-noexcept-type -Wdelete-non-virtual-dtor -Wno-comment -Wno-misleading-indentation -fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG -std=c++17 -fvisibility=hidden -UNDEBUG -fno-exceptions -funwind-tables -fno-rtti -MD -MT lib/Target/AMDGPU/CMakeFiles/LLVMAMDGPUCodeGen.dir/AMDGPUTargetMachine.cpp.o -MF lib/Target/AMDGPU/CMakeFiles/LLVMAMDGPUCodeGen.dir/AMDGPUTargetMachine.cpp.o.d -o lib/Target/AMDGPU/CMakeFiles/LLVMAMDGPUCodeGen.dir/AMDGPUTargetMachine.cpp.o -c /path/to/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
In file included from /path/to/llvm-project/llvm/include/llvm/ADT/Hashing.h:49,
                 from /path/to/llvm-project/llvm/include/llvm/ADT/ArrayRef.h:12,
                 from /path/to/llvm-project/llvm/include/llvm/CodeGen/GlobalISel/CallLowering.h:17,
                 from /path/to/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUCallLowering.h:17,
                 from /path/to/llvm-project/llvm/lib/Target/AMDGPU/GCNSubtarget.h:17,
                 from /path/to/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.h:17,
                 from /path/to/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp:17:
/path/to/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h: In function 'constexpr llvm::StringRef llvm::AMDGPU::getFlavorName(llvm::AMDGPU::InstructionFlavor)':
/path/to/llvm-project/llvm/include/llvm/Support/ErrorHandling.h:165:36: error: call to non-'constexpr' function 'void llvm::llvm_unreachable_internal(const char*, const char*, unsigned int)'
   ::llvm::llvm_unreachable_internal(msg, __FILE__, __LINE__)
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h:67: note: in expansion of macro 'llvm_unreachable'
   llvm_unreachable("Unknown InstructionFlavor");
 
/path/to/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h: In function 'constexpr llvm::StringRef llvm::AMDGPU::getFlavorShortName(llvm::AMDGPU::InstructionFlavor)':
/path/to/llvm-project/llvm/include/llvm/Support/ErrorHandling.h:165:36: error: call to non-'constexpr' function 'void llvm::llvm_unreachable_internal(const char*, const char*, unsigned int)'
   ::llvm::llvm_unreachable_internal(msg, __FILE__, __LINE__)
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h:95: note: in expansion of macro 'llvm_unreachable'
   llvm_unreachable("Unknown InstructionFlavor");
 
/path/to/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h: In function 'constexpr llvm::StringRef llvm::AMDGPU::getReasonName(llvm::AMDGPU::AMDGPUSchedReason)':
/path/to/llvm-project/llvm/include/llvm/Support/ErrorHandling.h:165:36: error: call to non-'constexpr' function 'void llvm::llvm_unreachable_internal(const char*, const char*, unsigned int)'
   ::llvm::llvm_unreachable_internal(msg, __FILE__, __LINE__)
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/llvm-project/llvm/lib/Target/AMDGPU/AMDGPUCoExecSchedStrategy.h:142: note: in expansion of macro 'llvm_unreachable'
   llvm_unreachable("Unknown AMDGPUSchedReason");
 
ninja: build stopped: subcommand failed.
```

See alo
(https://github.com/llvm/llvm-project/pull/192322#issuecomment-4672427400)