### PR TITLE
[ConstraintElim] Add test with negative offset and NUW only GEP (NFC)

### DIFF
--- a/llvm/test/Transforms/ConstraintElimination/geps-unsigned-predicates.ll
+++ b/llvm/test/Transforms/ConstraintElimination/geps-unsigned-predicates.ll
@@ -649,3 +649,14 @@ trap:
 }
 
 declare void @use(i1)
+
+; FIXME: Currently incorrectly simplified to true.
+define i1 @gep_nuw_negative_offset_unsigned(ptr %p) {
+; CHECK-LABEL: @gep_nuw_negative_offset_unsigned(
+; CHECK-NEXT:    [[P2:%.*]] = getelementptr nuw i8, ptr [[P:%.*]], i64 -100
+; CHECK-NEXT:    ret i1 true
+;
+  %p2 = getelementptr nuw i8, ptr %p, i64 -100
+  %c = icmp ult ptr %p2, %p
+  ret i1 %c
+}


### PR DESCRIPTION
Add test currently mis-compiled with NUW only GEP.

https://alive2.llvm.org/ce/z/7G8uE3