### PR TITLE
Turn signal handling on in LineEditor

### DIFF
--- a/llvm/lib/LineEditor/LineEditor.cpp
+++ b/llvm/lib/LineEditor/LineEditor.cpp
@@ -209,6 +209,7 @@ LineEditor::LineEditor(StringRef ProgName, StringRef HistoryPath, FILE *In,
 
   ::el_set(Data->EL, EL_PROMPT, ElGetPromptFn);
   ::el_set(Data->EL, EL_EDITOR, "emacs");
+  ::el_set(Data->EL, EL_SIGNAL, 1);
   ::el_set(Data->EL, EL_HIST, history, Data->Hist);
   ::el_set(Data->EL, EL_ADDFN, "tab_complete", "Tab completion function",
            ElCompletionFn);


### PR DESCRIPTION
This PR was created to address https://github.com/jank-lang/jank/issues/801.

Without signal handling, `CLRL+C` / `CTRL+Z` leaves the terminal in an awkward state, breaking other command line tasks and forcing the user to open a new/clean terminal window.

cc: @jeaye 

### Edit

#### AI

Per the contribution policies and review practices, AI was used to locate the root cause of the issue I was seeing. From there, I personally wrote the code and manually tested the build to verify that the change fixed the problem I was seeing.

#### Testing

Since there were no pre-existing unit tests for this module, no additional unit tests were added for this PR. I validated the existing build/tests locally and validated the change propagated through manually.