### PR TITLE
[ConstraintElim] Do not model negative nuw-only GEP offset as signed.

### DIFF
--- a/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
@@ -462,6 +462,12 @@ static Decomposition decomposeGEP(GEPOperator &GEP,
   if (!BasePtr || NW == GEPNoWrapFlags::none())
     return &GEP;
 
+  // For a nuw-only GEP (nuw without nusw/inbounds), the offset must be
+  // interpreted as unsigned.
+  if (NW.hasNoUnsignedWrap() && !NW.hasNoUnsignedSignedWrap() &&
+      ConstantOffset.isNegative())
+    return &GEP;
+
   Decomposition Result(ConstantOffset.getSExtValue(), DecompEntry(1, BasePtr));
   for (auto [Index, Scale] : VariableOffsets) {
     auto IdxResult = decompose(Index, Preconditions, IsSigned, DL);

--- a/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
@@ -464,8 +464,7 @@ static Decomposition decomposeGEP(GEPOperator &GEP,
 
   // For a nuw-only GEP (nuw without nusw/inbounds), the offset must be
   // interpreted as unsigned.
-  if (NW.hasNoUnsignedWrap() && !NW.hasNoUnsignedSignedWrap() &&
-      ConstantOffset.isNegative())
+  if (!NW.hasNoUnsignedSignedWrap() && ConstantOffset.isNegative())
     return &GEP;
 
   Decomposition Result(ConstantOffset.getSExtValue(), DecompEntry(1, BasePtr));

--- a/llvm/test/Transforms/ConstraintElimination/geps-unsigned-predicates.ll
+++ b/llvm/test/Transforms/ConstraintElimination/geps-unsigned-predicates.ll
@@ -650,11 +650,11 @@ trap:
 
 declare void @use(i1)
 
-; FIXME: Currently incorrectly simplified to true.
 define i1 @gep_nuw_negative_offset_unsigned(ptr %p) {
 ; CHECK-LABEL: @gep_nuw_negative_offset_unsigned(
 ; CHECK-NEXT:    [[P2:%.*]] = getelementptr nuw i8, ptr [[P:%.*]], i64 -100
-; CHECK-NEXT:    ret i1 true
+; CHECK-NEXT:    [[C:%.*]] = icmp ult ptr [[P2]], [[P]]
+; CHECK-NEXT:    ret i1 [[C]]
 ;
   %p2 = getelementptr nuw i8, ptr %p, i64 -100
   %c = icmp ult ptr %p2, %p


### PR DESCRIPTION
decomposeGEP added the GEP's constant offset to the unsigned decomposition using its signed value (getSExtValue()). For a GEP that only carries nuw (without nusw/inbounds), the indices must be interpreted as unsigned.

Alive2 Proof of mis-compile https://alive2.llvm.org/ce/z/7G8uE3