### PR TITLE
[LoopInterchange] Mark getAddRecCoefficient with static

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
@@ -1666,8 +1666,8 @@ const DenseMap<const Loop *, unsigned> &CacheCostManager::getCostMap() {
 /// the addrec for \p L in \S.
 /// TODO: Handle more complex cases. Maybe using SCEVTraversal is a good way to
 /// do that.
-std::optional<const SCEV *> getAddRecCoefficient(ScalarEvolution &SE,
-                                                 const SCEV *S, const Loop *L) {
+static std::optional<const SCEV *>
+getAddRecCoefficient(ScalarEvolution &SE, const SCEV *S, const Loop *L) {
   const SCEVAddRecExpr *AR = dyn_cast<SCEVAddRecExpr>(S);
   if (!AR) {
     if (SE.isLoopInvariant(S, L))


### PR DESCRIPTION
As this function is a file-scope non-member function, it's better to mark it with static.