### PR TITLE
[Flang][OpenMP] remove enable-delayed-privatization-staging to suppor…

### DIFF
--- a/flang/include/flang/Support/Flags.h
+++ b/flang/include/flang/Support/Flags.h
@@ -12,6 +12,5 @@
 #include "llvm/Support/CommandLine.h"
 
 extern llvm::cl::opt<bool> enableDelayedPrivatization;
-extern llvm::cl::opt<bool> enableDelayedPrivatizationStaging;
 
 #endif // FORTRAN_SUPPORT_FLAGS_H_

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -1899,11 +1899,6 @@ genTargetClauses(lower::AbstractConverter &converter,
   cp.processThreadLimit(stmtCtx, clauseOps);
   cp.processTODO<clause::Allocate, clause::InReduction, clause::UsesAllocators>(
       loc, llvm::omp::Directive::OMPD_target);
-
-  // `target private(..)` is only supported in delayed privatization mode.
-  if (!enableDelayedPrivatizationStaging)
-    cp.processTODO<clause::Firstprivate, clause::Private>(
-        loc, llvm::omp::Directive::OMPD_target);
 }
 
 static void genTargetDataClauses(

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -25,7 +25,6 @@
 #include "flang/Semantics/openmp-utils.h"
 #include "flang/Semantics/symbol.h"
 #include "flang/Semantics/tools.h"
-#include "flang/Support/Flags.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Frontend/OpenMP/OMP.h.inc"
@@ -2698,8 +2697,7 @@ void OmpAttributeVisitor::CreateImplicitSymbols(
       // 4) not mapped target variable  -> firstprivate
       //    - i.e. implicit, but meets OpenMP specification rules for
       //    firstprivate "promotion"
-      if (enableDelayedPrivatizationStaging &&
-          IsTargetCaptureImplicitlyFirstprivatizeable(*symbol, prevDSA,
+      if (IsTargetCaptureImplicitlyFirstprivatizeable(*symbol, prevDSA,
               dataSharingAttributeFlags, dataMappingAttributeFlags,
               dirContext.defaultMap)) {
         prevDSA.set(Symbol::Flag::OmpImplicit);

--- a/flang/lib/Support/Flags.cpp
+++ b/flang/lib/Support/Flags.cpp
@@ -12,9 +12,3 @@ llvm::cl::opt<bool> enableDelayedPrivatization("enable-delayed-privatization",
     llvm::cl::desc(
         "Emit private/local variables as clauses/specifiers on MLIR ops."),
     llvm::cl::init(true));
-
-llvm::cl::opt<bool> enableDelayedPrivatizationStaging(
-    "enable-delayed-privatization-staging",
-    llvm::cl::desc("For partially supported constructs, emit private/local "
-                   "variables as clauses/specifiers on MLIR ops."),
-    llvm::cl::init(false));

--- a/flang/test/Integration/OpenMP/map-types-and-sizes.f90
+++ b/flang/test/Integration/OpenMP/map-types-and-sizes.f90
@@ -6,8 +6,7 @@
 ! added to this directory and sub-directories.
 !===----------------------------------------------------------------------===!
 
-!RUN: %flang_fc1 -emit-llvm -fopenmp -mmlir --enable-delayed-privatization-staging=false -fopenmp-version=51 -fopenmp-targets=amdgcn-amd-amdhsa %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-NO-FPRIV
-!RUN: %flang_fc1 -emit-llvm -fopenmp -mmlir --enable-delayed-privatization-staging=true -fopenmp-version=51 -fopenmp-targets=amdgcn-amd-amdhsa %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-FPRIV
+!RUN: %flang_fc1 -emit-llvm -fopenmp -fopenmp-version=51 -fopenmp-targets=amdgcn-amd-amdhsa %s -o - | FileCheck %s
 
 
 !===============================================================================
@@ -15,8 +14,7 @@
 !===============================================================================
 
 !CHECK: @.offload_sizes = private unnamed_addr constant [2 x i64] [i64 4, i64 0]
-!CHECK-FPRIV: @.offload_maptypes = private unnamed_addr constant [2 x i64] [i64 289, i64 288]
-!CHECK-NO-FPRIV: @.offload_maptypes = private unnamed_addr constant [2 x i64] [i64 800, i64 288]
+!CHECK: @.offload_maptypes = private unnamed_addr constant [2 x i64] [i64 289, i64 288]
 subroutine mapType_scalar
   integer :: a
   !$omp target
@@ -384,8 +382,7 @@ allocate(alloca_dtype%vertexes(2)%vertexy(10))
 end subroutine
 
 !CHECK: @.offload_sizes{{.*}} = private unnamed_addr constant [3 x i64] [i64 8, i64 4, i64 0]
-!CHECK-FPRIV: @.offload_maptypes{{.*}} = private unnamed_addr constant [3 x i64] [i64 544, i64 289, i64 288]
-!CHECK-NO-FPRIV: @.offload_maptypes{{.*}} = private unnamed_addr constant [3 x i64] [i64 544, i64 800, i64 288]
+!CHECK: @.offload_maptypes{{.*}} = private unnamed_addr constant [3 x i64] [i64 544, i64 289, i64 288]
 subroutine mapType_c_ptr
   use iso_c_binding, only : c_ptr, c_loc
   type(c_ptr) :: a
@@ -396,8 +393,7 @@ subroutine mapType_c_ptr
 end subroutine mapType_c_ptr
 
 !CHECK: @.offload_sizes{{.*}} = private unnamed_addr constant [2 x i64] [i64 1, i64 0]
-!CHECK-FPRIV: @.offload_maptypes{{.*}} = private unnamed_addr constant [2 x i64] [i64 289, i64 288]
-!CHECK-NO-FPRIV: @.offload_maptypes{{.*}} = private unnamed_addr constant [2 x i64] [i64 800, i64 288]
+!CHECK: @.offload_maptypes{{.*}} = private unnamed_addr constant [2 x i64] [i64 289, i64 288]
 subroutine mapType_char
   character :: a
   !$omp target

--- a/flang/test/Lower/OpenMP/DelayedPrivatization/distribute-standalone-private.f90
+++ b/flang/test/Lower/OpenMP/DelayedPrivatization/distribute-standalone-private.f90
@@ -1,7 +1,5 @@
-! RUN: %flang_fc1 -emit-hlfir -fopenmp -mmlir --enable-delayed-privatization-staging \
-! RUN:   -o - %s 2>&1 | FileCheck %s
-! RUN: bbc -emit-hlfir -fopenmp --enable-delayed-privatization-staging -o - %s 2>&1 \
-! RUN:   | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck %s
+! RUN: bbc -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck %s
 
 subroutine standalone_distribute
     implicit none

--- a/flang/test/Lower/OpenMP/DelayedPrivatization/target-firstprivate.f90
+++ b/flang/test/Lower/OpenMP/DelayedPrivatization/target-firstprivate.f90
@@ -1,0 +1,33 @@
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck %s
+! RUN: bbc -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck %s
+
+subroutine target_firstprivate_scalar
+  implicit none
+  integer :: x
+
+  x = 42
+  !$omp target firstprivate(x)
+    x = x + 1
+  !$omp end target
+end subroutine target_firstprivate_scalar
+
+! CHECK-LABEL: omp.private {type = firstprivate}
+! CHECK-SAME:              @[[VAR_PRIVATIZER_SYM:.*]] : i32 copy {
+! CHECK:         ^bb0(%[[ORIG:.*]]: !fir.ref<i32>, %[[PRIV:.*]]: !fir.ref<i32>):
+! CHECK:           %[[VAL:.*]] = fir.load %[[ORIG]]
+! CHECK:           hlfir.assign %[[VAL]] to %[[PRIV]]
+! CHECK:           omp.yield(%[[PRIV]] : !fir.ref<i32>)
+! CHECK:         }
+
+! CHECK-LABEL: func.func @_QPtarget_firstprivate_scalar()
+! CHECK:         %[[X_ALLOC:.*]] = fir.alloca i32 {bindc_name = "x", {{.*}}}
+! CHECK:         %[[X_DECL:.*]]:2 = hlfir.declare %[[X_ALLOC]]
+
+! CHECK:         omp.target {{.*}} private(
+! CHECK-SAME:      @[[VAR_PRIVATIZER_SYM]] %[[X_DECL]]#0 -> %[[PRIV_ARG:.*]] [map_idx=0] : !fir.ref<i32>) {
+! CHECK:           %[[PRIV_DECL:.*]]:2 = hlfir.declare %[[PRIV_ARG]]
+! CHECK:           omp.terminator
+! CHECK:         }
+
+! CHECK:         return
+! CHECK:       }

--- a/flang/test/Lower/OpenMP/DelayedPrivatization/target-private-adjustable-array.f90
+++ b/flang/test/Lower/OpenMP/DelayedPrivatization/target-private-adjustable-array.f90
@@ -1,13 +1,12 @@
 ! Tests delayed privatization for `targets ... private(..)` for adjustable arrays.
 ! Tests different allocation 
 
-! RUN: %flang_fc1 -emit-hlfir -fopenmp -mmlir --enable-delayed-privatization-staging \
+! RUN: %flang_fc1 -emit-hlfir -fopenmp \
 ! RUN: -mmlir --enable-gpu-heap-alloc  -o - %s 2>&1 | FileCheck %s --check-prefix=CPU
 
 ! RUN: %if amdgpu-registered-target %{ \
 ! RUN:   %flang_fc1 -triple amdgcn-amd-amdhsa -emit-hlfir  \
 ! RUN:     -fopenmp -fopenmp-is-target-device \
-! RUN:     -mmlir --enable-delayed-privatization-staging \
 ! RUN:     -mmlir --enable-gpu-heap-alloc \
 ! RUN:     -o - %s 2>&1 | \
 ! RUN:   FileCheck %s --check-prefix=GPU-HEAP \
@@ -16,7 +15,6 @@
 ! RUN: %if amdgpu-registered-target %{ \
 ! RUN:   %flang_fc1 -triple amdgcn-amd-amdhsa -emit-hlfir  \
 ! RUN:     -fopenmp -fopenmp-is-target-device \
-! RUN:     -mmlir --enable-delayed-privatization-staging \
 ! RUN:     -o - %s 2>&1 | \
 ! RUN:   FileCheck %s --check-prefix=GPU-STACK  \
 ! RUN: %}

--- a/flang/test/Lower/OpenMP/DelayedPrivatization/target-private-allocatable.f90
+++ b/flang/test/Lower/OpenMP/DelayedPrivatization/target-private-allocatable.f90
@@ -1,20 +1,17 @@
 ! Tests delayed privatization for `targets ... private(..)` for allocatables.
 
-! RUN: %flang_fc1 -emit-hlfir -fopenmp -mmlir --enable-delayed-privatization-staging \
-! RUN:   -o - %s 2>&1 | FileCheck %s --check-prefix=CPU
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck %s --check-prefix=CPU
 
-! RUN: bbc -emit-hlfir -fopenmp --enable-delayed-privatization-staging -o - %s 2>&1 \
-! RUN:   | FileCheck %s --check-prefix=CPU
+! RUN: bbc -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck %s --check-prefix=CPU
 
 ! RUN: %if amdgpu-registered-target %{ \
 ! RUN:   %flang_fc1 -triple amdgcn-amd-amdhsa -emit-hlfir  \
 ! RUN:     -fopenmp -fopenmp-is-target-device \
-! RUN:     -mmlir --enable-delayed-privatization-staging \
 ! RUN:     -o - %s 2>&1 | \
 ! RUN:   FileCheck %s --check-prefix=GPU  \
 ! RUN: %}
 
-! RUN: bbc -emit-hlfir -fopenmp --enable-delayed-privatization-staging \
+! RUN: bbc -emit-hlfir -fopenmp \
 ! RUN:    -fopenmp-is-target-device -fopenmp-is-gpu -o - %s 2>&1 \
 ! RUN:   | FileCheck %s --check-prefix=GPU
 

--- a/flang/test/Lower/OpenMP/DelayedPrivatization/target-private-implicit-scalar-map-2.f90
+++ b/flang/test/Lower/OpenMP/DelayedPrivatization/target-private-implicit-scalar-map-2.f90
@@ -2,8 +2,8 @@
 ! module boundaries.
 
 ! RUN: split-file %s %t
-! RUN: bbc -emit-hlfir -fopenmp --enable-delayed-privatization-staging -fopenmp-version=50 %t/imp_scalar_map_module.f90 -o - | FileCheck %s --check-prefix=CHECK-MOD
-! RUN: bbc -emit-hlfir -fopenmp --enable-delayed-privatization-staging -fopenmp-version=50 %t/imp_scalar_map_target.f90 -o - | FileCheck %s --check-prefix=CHECK-PROG
+! RUN: bbc -emit-hlfir -fopenmp -fopenmp-version=50 %t/imp_scalar_map_module.f90 -o - | FileCheck %s --check-prefix=CHECK-MOD
+! RUN: bbc -emit-hlfir -fopenmp -fopenmp-version=50 %t/imp_scalar_map_target.f90 -o - | FileCheck %s --check-prefix=CHECK-PROG
 
 !--- imp_scalar_map_module.f90
 module test_data

--- a/flang/test/Lower/OpenMP/DelayedPrivatization/target-private-implicit-scalar-map.f90
+++ b/flang/test/Lower/OpenMP/DelayedPrivatization/target-private-implicit-scalar-map.f90
@@ -1,7 +1,7 @@
 ! Tests delayed privatization works for implicit capture of scalars similarly to
 ! the way it works for explicitly firstprivitized scalars.
 
-! RUN: %flang_fc1 -emit-mlir -fopenmp -mmlir --enable-delayed-privatization-staging \
+! RUN: %flang_fc1 -emit-mlir -fopenmp \
 ! RUN:   -o - %s 2>&1 | FileCheck %s
 
 ! CHECK-LABEL:   omp.private {type = firstprivate} @_QFExdgfx_firstprivate_i32 : i32 copy {

--- a/flang/test/Lower/OpenMP/DelayedPrivatization/target-private-multiple-variables.f90
+++ b/flang/test/Lower/OpenMP/DelayedPrivatization/target-private-multiple-variables.f90
@@ -1,9 +1,7 @@
 ! Tests delayed privatization for `targets ... private(..)` for allocatables.
 
-! RUN: %flang_fc1 -emit-hlfir -fopenmp -mmlir --enable-delayed-privatization-staging \
-! RUN:   -o - %s 2>&1 | FileCheck %s
-! RUN: bbc -emit-hlfir -fopenmp --enable-delayed-privatization-staging -o - %s 2>&1 \
-! RUN:   | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck %s
+! RUN: bbc -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck %s
 
 subroutine target_allocatable(lb, ub, l)
   implicit none

--- a/flang/test/Lower/OpenMP/DelayedPrivatization/target-private-simple.f90
+++ b/flang/test/Lower/OpenMP/DelayedPrivatization/target-private-simple.f90
@@ -1,9 +1,7 @@
 ! Tests delayed privatization for `targets ... private(..)` for simple variables.
 
-! RUN: %flang_fc1 -emit-hlfir -fopenmp -mmlir --enable-delayed-privatization-staging \
-! RUN:   -o - %s 2>&1 | FileCheck %s
-! RUN: bbc -emit-hlfir -fopenmp --enable-delayed-privatization-staging -o - %s 2>&1 \
-! RUN:   | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck %s
+! RUN: bbc -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck %s
 
 subroutine target_simple
   implicit none

--- a/flang/test/Lower/OpenMP/DelayedPrivatization/target-teams-distribute-parallel-do-simd-private-adjustable-array.f90
+++ b/flang/test/Lower/OpenMP/DelayedPrivatization/target-teams-distribute-parallel-do-simd-private-adjustable-array.f90
@@ -4,7 +4,6 @@
 ! RUN: %if amdgpu-registered-target %{ \
 ! RUN:   %flang_fc1 -triple amdgcn-amd-amdhsa -emit-hlfir \
 ! RUN:     -fopenmp -fopenmp-is-target-device \
-! RUN:     -mmlir --enable-delayed-privatization-staging \
 ! RUN:     -o - %s 2>&1 | FileCheck %s \
 ! RUN: %}
 

--- a/flang/test/Lower/OpenMP/DelayedPrivatization/target-teams-distribute-private-adjustable-array.f90
+++ b/flang/test/Lower/OpenMP/DelayedPrivatization/target-teams-distribute-private-adjustable-array.f90
@@ -4,7 +4,6 @@
 ! RUN: %if amdgpu-registered-target %{ \
 ! RUN:   %flang_fc1 -triple amdgcn-amd-amdhsa -emit-hlfir \
 ! RUN:     -fopenmp -fopenmp-is-target-device \
-! RUN:     -mmlir --enable-delayed-privatization-staging \
 ! RUN:     -o - %s 2>&1 | FileCheck %s \
 ! RUN: %}
 

--- a/flang/test/Lower/OpenMP/DelayedPrivatization/target-teams-nested-distribute-private-adjustable-array.f90
+++ b/flang/test/Lower/OpenMP/DelayedPrivatization/target-teams-nested-distribute-private-adjustable-array.f90
@@ -4,7 +4,6 @@
 ! RUN: %if amdgpu-registered-target %{ \
 ! RUN:   %flang_fc1 -triple amdgcn-amd-amdhsa -emit-hlfir \
 ! RUN:     -fopenmp -fopenmp-is-target-device \
-! RUN:     -mmlir --enable-delayed-privatization-staging \
 ! RUN:     -o - %s 2>&1 | FileCheck %s \
 ! RUN: %}
 

--- a/flang/test/Lower/OpenMP/DelayedPrivatization/target-teams-private-implicit-scalar-map.f90
+++ b/flang/test/Lower/OpenMP/DelayedPrivatization/target-teams-private-implicit-scalar-map.f90
@@ -1,7 +1,7 @@
 ! Tests delayed privatization works for implicit capture of scalars similarly to
 ! the way it works for explicitly firstprivitized scalars.
 
-! RUN: %flang_fc1 -emit-mlir -fopenmp -mmlir --enable-delayed-privatization-staging \
+! RUN: %flang_fc1 -emit-mlir -fopenmp \
 ! RUN:   -o - %s 2>&1 | FileCheck %s
 
 !CHECK:   omp.private {type = private} @[[SYM_K:.*]] : i32

--- a/flang/test/Lower/OpenMP/Todo/firstprivate-target.f90
+++ b/flang/test/Lower/OpenMP/Todo/firstprivate-target.f90
@@ -1,9 +1,0 @@
-! RUN: %not_todo_cmd bbc -emit-fir -fopenmp -o - %s 2>&1 | FileCheck %s
-! RUN: %not_todo_cmd %flang_fc1 -emit-fir -fopenmp -o - %s 2>&1 | FileCheck %s
-
-integer :: i
-! CHECK: not yet implemented: Unhandled clause FIRSTPRIVATE in TARGET construct
-!$omp target firstprivate(i) nowait
-!$omp end target
-
-end program

--- a/flang/test/Lower/OpenMP/defaultmap.f90
+++ b/flang/test/Lower/OpenMP/defaultmap.f90
@@ -1,5 +1,4 @@
-!RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=52 -mmlir --enable-delayed-privatization-staging=false %s -o - | FileCheck %s  --check-prefixes=CHECK,CHECK-NO-FPRIV
-!RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=52 -mmlir --enable-delayed-privatization-staging=true %s -o - | FileCheck %s  --check-prefixes=CHECK,CHECK-FPRIV
+!RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=52 %s -o - | FileCheck %s  --check-prefixes=CHECK,CHECK-FPRIV
 
 subroutine defaultmap_allocatable_present()
     implicit none
@@ -50,11 +49,9 @@ subroutine defaultmap_pointer_to()
     integer, dimension(:), pointer :: arr_ptr(:)
     integer :: scalar_int
 
-! CHECK-NO-FPRIV: %[[MAP_1:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>, !fir.box<!fir.ptr<!fir.array<?xi32>>>) map_clauses(implicit, to) capture(ByRef) var_ptr_ptr({{.*}}) bounds({{.*}}) -> !fir.llvm_ptr<!fir.ref<!fir.array<?xi32>>> {name = ""}
 ! CHECK-FPRIV: %[[MAP_1:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>, !fir.box<!fir.ptr<!fir.array<?xi32>>>) map_clauses(implicit, to) capture(ByRef) var_ptr_ptr({{.*}}) bounds({{.*}}) -> !fir.llvm_ptr<!fir.ref<!fir.array<?xi32>>> {name = ""}
 ! CHECK: %[[MAP_2:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>, !fir.box<!fir.ptr<!fir.array<?xi32>>>) map_clauses(always, implicit, to) capture(ByRef) members({{.*}}) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>> {name = "arr_ptr"}
 ! CHECK-FPRIV: %[[MAP_3:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<i32>, i32) map_clauses(to) capture(ByCopy) -> !fir.ref<i32>
-! CHECK-NO-FPRIV: %[[MAP_3:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<i32>, i32) map_clauses(implicit) capture(ByCopy) -> !fir.ref<i32> {name = "scalar_int"}
     !$omp target defaultmap(to: pointer)
         arr_ptr(1) = scalar_int + 20
     !$omp end target

--- a/flang/test/Lower/OpenMP/different_vars_lastprivate_barrier.f90
+++ b/flang/test/Lower/OpenMP/different_vars_lastprivate_barrier.f90
@@ -1,4 +1,4 @@
-! RUN: %flang_fc1 -fopenmp -mmlir --enable-delayed-privatization-staging=true -emit-hlfir %s -o - | FileCheck %s
+! RUN: %flang_fc1 -fopenmp -emit-hlfir %s -o - | FileCheck %s
 
 subroutine first_and_lastprivate(var)
   integer i

--- a/flang/test/Lower/OpenMP/optional-argument-map-2.f90
+++ b/flang/test/Lower/OpenMP/optional-argument-map-2.f90
@@ -1,5 +1,4 @@
-!RUN: %flang_fc1 -emit-hlfir -fopenmp -mmlir --enable-delayed-privatization-staging=false %s -o - | FileCheck %s  --check-prefixes=CHECK,CHECK-NO-FPRIV
-!RUN: %flang_fc1 -emit-hlfir -fopenmp -mmlir --enable-delayed-privatization-staging=true %s -o - | FileCheck %s  --check-prefixes=CHECK,CHECK-FPRIV
+!RUN: %flang_fc1 -emit-hlfir -fopenmp %s -o - | FileCheck %s  --check-prefixes=CHECK,CHECK-FPRIV
 
 module mod
   implicit none
@@ -83,36 +82,3 @@ end module mod
 ! CHECK-FPRIV:         hlfir.assign %[[VAL_28]]#0 to %[[VAL_26]]#0 : !fir.boxchar<1>, !fir.ref<!fir.char<1,4>>
 ! CHECK-FPRIV:       return
 ! CHECK-FPRIV:     }
-! CHECK-NO-FPRIV:  %[[VAL_8:.*]] = fir.is_present %[[VAL_3]]#1 : (!fir.ref<!fir.char<1,?>>) -> i1
-! CHECK-NO-FPRIV:  %[[VAL_9:.*]] = arith.constant 0 : index
-! CHECK-NO-FPRIV:  %[[VAL_10:.*]] = arith.constant 1 : index
-! CHECK-NO-FPRIV:  %[[VAL_11:.*]]:2 = fir.if %[[VAL_8]] -> (index, index) {
-! CHECK-NO-FPRIV:    %[[VAL_12:.*]]:2 = fir.unboxchar %[[VAL_3]]#0 : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
-! CHECK-NO-FPRIV:       fir.result %[[VAL_12]]#1, %[[VAL_10]] : index, index
-! CHECK-NO-FPRIV:     } else {
-! CHECK-NO-FPRIV:       fir.result %[[VAL_9]], %[[VAL_9]] : index, index
-! CHECK-NO-FPRIV:     }
-! CHECK-NO-FPRIV:  %[[VAL_13:.*]] = arith.subi %[[VAL_14:.*]]#0, %[[VAL_10]] : index
-! CHECK-NO-FPRIV:  %[[VAL_15:.*]] = omp.map.bounds lower_bound(%[[VAL_9]] : index) upper_bound(%[[VAL_13]] : index) extent(%[[VAL_14]]#0 : index) stride(%[[VAL_14]]#1 : index) start_idx(%[[VAL_9]] : index) {stride_in_bytes = true}
-! CHECK-NO-FPRIV:  %[[VAL_16:.*]] = omp.map.info var_ptr(%[[VAL_3]]#1 : !fir.ref<!fir.char<1,?>>, !fir.char<1,?>) map_clauses(implicit) capture(ByCopy) bounds(%[[VAL_15]]) -> !fir.ref<!fir.char<1,?>> {name = "a"}
-! CHECK-NO-FPRIV:  fir.store %[[ARG0]] to %[[VAL_0]] : !fir.ref<!fir.boxchar<1>>
-! CHECK-NO-FPRIV:  %[[VAL_17:.*]] = arith.constant 0 : index
-! CHECK-NO-FPRIV:  %[[VAL_18:.*]] = arith.constant 1 : index
-! CHECK-NO-FPRIV:           %[[VAL_19:.*]]:2 = fir.unboxchar %[[ARG0]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
-! CHECK-NO-FPRIV:           %[[VAL_20:.*]] = arith.subi %[[VAL_19]]#1, %[[VAL_18]] : index
-! CHECK-NO-FPRIV:           %[[VAL_21:.*]] = omp.map.bounds lower_bound(%[[VAL_17]] : index) upper_bound(%[[VAL_20]] : index) extent(%[[VAL_19]]#1 : index) stride(%[[VAL_18]] : index) start_idx(%[[VAL_17]] : index) {stride_in_bytes = true}
-! CHECK-NO-FPRIV:           %[[VAL_22:.*]] = fir.box_offset %[[VAL_0]] base_addr : (!fir.ref<!fir.boxchar<1>>) -> !fir.llvm_ptr<!fir.ref<!fir.char<1,?>>>
-! CHECK-NO-FPRIV:           %[[VAL_23:.*]] = omp.map.info var_ptr(%[[VAL_0]] : !fir.ref<!fir.boxchar<1>>, !fir.boxchar<1>) map_clauses(implicit, to) capture(ByRef) var_ptr_ptr(%[[VAL_22]] : !fir.llvm_ptr<!fir.ref<!fir.char<1,?>>>, !fir.char<1,?>) bounds(%14) -> !fir.llvm_ptr<!fir.ref<!fir.char<1,?>>> {name = ""}
-! CHECK-NO-FPRIV:           %[[VAL_24:.*]] = omp.map.info var_ptr(%[[VAL_0]] : !fir.ref<!fir.boxchar<1>>, !fir.boxchar<1>) map_clauses(always, implicit, to) capture(ByRef) members(%[[VAL_23]] : [0] : !fir.llvm_ptr<!fir.ref<!fir.char<1,?>>>) -> !fir.ref<!fir.boxchar<1>> {name = ""}
-! CHECK-NO-FPRIV:           %[[VAL_26:.*]] = omp.map.info var_ptr(%[[VAL_0]] : !fir.ref<!fir.boxchar<1>>, !fir.boxchar<1>) map_clauses(attach, ref_ptr, ref_ptee) capture(ByRef) var_ptr_ptr(%[[VAL_22]] : !fir.llvm_ptr<!fir.ref<!fir.char<1,?>>>, !fir.char<1,?>) bounds(%[[VAL_21]]) -> !fir.ref<!fir.boxchar<1>>
-! CHECK-NO-FPRIV:  omp.target map_entries(%[[VAL_7]] -> %[[VAL_27:.*]], %[[VAL_16]] -> %[[VAL_28:.*]], %[[VAL_24]] -> %[[VAL_29:.*]], %[[VAL_26]] -> %[[VAL_30:.*]], %[[VAL_23]] -> %[[VAL_30:.*]] : !fir.ref<!fir.char<1,4>>, !fir.ref<!fir.char<1,?>>, !fir.ref<!fir.boxchar<1>>, !fir.ref<!fir.boxchar<1>>, !fir.llvm_ptr<!fir.ref<!fir.char<1,?>>>) {
-! CHECK-NO-FPRIV:    %[[VAL_31:.*]] = fir.load %[[VAL_29]] : !fir.ref<!fir.boxchar<1>>
-! CHECK-NO-FPRIV:    %[[VAL_32:.*]]:2 = fir.unboxchar %[[VAL_31]] : (!fir.boxchar<1>) -> (!fir.ref<!fir.char<1,?>>, index)
-! CHECK-NO-FPRIV:    %[[VAL_33:.*]] = arith.constant 4 : index
-! CHECK-NO-FPRIV:    %[[VAL_34:.*]]:2 = hlfir.declare %[[VAL_27]] typeparams %[[VAL_33]] {uniq_name = "_QMmodFroutine_boxcharEb"} : (!fir.ref<!fir.char<1,4>>, index) -> (!fir.ref<!fir.char<1,4>>, !fir.ref<!fir.char<1,4>>)
-! CHECK-NO-FPRIV:    %[[VAL_35:.*]]:2 = hlfir.declare %[[VAL_28]] typeparams %[[VAL_32]]#1 {fortran_attrs = #fir.var_attrs<intent_in, optional>, uniq_name = "_QMmodFroutine_boxcharEa"} : (!fir.ref<!fir.char<1,?>>, index) -> (!fir.boxchar<1>, !fir.ref<!fir.char<1,?>>)
-! CHECK-NO-FPRIV:    hlfir.assign %[[VAL_35]]#0 to %[[VAL_34]]#0 : !fir.boxchar<1>, !fir.ref<!fir.char<1,4>>
-! CHECK-NO-FPRIV:    omp.terminator
-! CHECK-NO-FPRIV:  }
-! CHECK-NO-FPRIV:  return
-! CHECK-NO-FPRIV:}

--- a/flang/test/Lower/OpenMP/private-derived-type.f90
+++ b/flang/test/Lower/OpenMP/private-derived-type.f90
@@ -1,5 +1,5 @@
-! RUN: %flang_fc1 -emit-hlfir -fopenmp -mmlir --enable-delayed-privatization-staging=true -o - %s | FileCheck %s
-! RUN: bbc -emit-hlfir -fopenmp --enable-delayed-privatization-staging=true -o - %s | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -o - %s | FileCheck %s
+! RUN: bbc -emit-hlfir -fopenmp -o - %s | FileCheck %s
 
 subroutine s4
   type y3

--- a/flang/test/Lower/OpenMP/same_var_first_lastprivate.f90
+++ b/flang/test/Lower/OpenMP/same_var_first_lastprivate.f90
@@ -1,4 +1,4 @@
-! RUN: %flang_fc1 -fopenmp -mmlir --enable-delayed-privatization-staging=true -emit-hlfir %s -o - | FileCheck %s
+! RUN: %flang_fc1 -fopenmp -emit-hlfir %s -o - | FileCheck %s
 
 subroutine first_and_lastprivate
   integer i

--- a/flang/test/Lower/OpenMP/target-map-complex.f90
+++ b/flang/test/Lower/OpenMP/target-map-complex.f90
@@ -1,21 +1,17 @@
-!RUN: %flang_fc1 -emit-hlfir -fopenmp -mmlir --enable-delayed-privatization-staging=false %s -o - | FileCheck %s  --check-prefixes=CHECK,CHECK-NO-FPRIV
-!RUN: %flang_fc1 -emit-hlfir -fopenmp -mmlir --enable-delayed-privatization-staging=true %s -o - | FileCheck %s  --check-prefixes=CHECK,CHECK-FPRIV
+!RUN: %flang_fc1 -emit-hlfir -fopenmp %s -o - | FileCheck %s
 
 ! Check that the complex*4 is passed by value. but complex*8 is passed by
 ! reference
 
-!CHECK-FPRIV: omp.private {type = firstprivate} @[[PRIV_64:.*]] : complex<f64> copy {
-!CHECK-FPRIV: omp.private {type = firstprivate} @[[PRIV_32:.*]] : complex<f32> copy {
+!CHECK: omp.private {type = firstprivate} @[[PRIV_64:.*]] : complex<f64> copy {
+!CHECK: omp.private {type = firstprivate} @[[PRIV_32:.*]] : complex<f32> copy {
 
 !CHECK-LABEL: func.func @_QMmPbar()
 !CHECK:  %[[V1:[0-9]+]]:2 = hlfir.declare {{.*}} (!fir.ref<complex<f32>>) -> (!fir.ref<complex<f32>>, !fir.ref<complex<f32>>)
 !CHECK:  %[[V0:[0-9]+]]:2 = hlfir.declare {{.*}} (!fir.ref<complex<f64>>) -> (!fir.ref<complex<f64>>, !fir.ref<complex<f64>>)
-!CHECK-FPRIV:  %[[V2:[0-9]+]] = omp.map.info var_ptr(%[[V1]]#0 : !fir.ref<complex<f32>>, complex<f32>) {{.*}} capture(ByCopy)
-!CHECK-FPRIV:  %[[V3:[0-9]+]] = omp.map.info var_ptr(%[[V0]]#0 : !fir.ref<complex<f64>>, complex<f64>) {{.*}} capture(ByRef)
-!CHECK-FPRIV:  omp.target map_entries(%[[V2]] -> {{.*}}, %[[V3]] -> {{.*}} : !fir.ref<complex<f32>>, !fir.ref<complex<f64>>) private(@[[PRIV_32]] %[[V1]]#0 -> %{{.*}} [map_idx=0], @[[PRIV_64]] %[[V0]]#0 -> %{{.*}} [map_idx=1] : !fir.ref<complex<f32>>, !fir.ref<complex<f64>>) {
-!CHECK-NO-FPRIV:  %[[V2:[0-9]+]] = omp.map.info var_ptr(%[[V1]]#1 : !fir.ref<complex<f32>>, complex<f32>) {{.*}} capture(ByCopy)
-!CHECK-NO-FPRIV:  %[[V3:[0-9]+]] = omp.map.info var_ptr(%[[V0]]#1 : !fir.ref<complex<f64>>, complex<f64>) {{.*}} capture(ByRef)
-!CHECK-NO-PRIV:  omp.target map_entries(%[[V2]] -> {{.*}}, %[[V3]] -> {{.*}} : !fir.ref<complex<f32>>, !fir.ref<complex<f64>>)
+!CHECK:  %[[V2:[0-9]+]] = omp.map.info var_ptr(%[[V1]]#0 : !fir.ref<complex<f32>>, complex<f32>) {{.*}} capture(ByCopy)
+!CHECK:  %[[V3:[0-9]+]] = omp.map.info var_ptr(%[[V0]]#0 : !fir.ref<complex<f64>>, complex<f64>) {{.*}} capture(ByRef)
+!CHECK:  omp.target map_entries(%[[V2]] -> {{.*}}, %[[V3]] -> {{.*}} : !fir.ref<complex<f32>>, !fir.ref<complex<f64>>) private(@[[PRIV_32]] %[[V1]]#0 -> %{{.*}} [map_idx=0], @[[PRIV_64]] %[[V0]]#0 -> %{{.*}} [map_idx=1] : !fir.ref<complex<f32>>, !fir.ref<complex<f64>>) {
 
 module m
   implicit none

--- a/flang/test/Lower/OpenMP/target-scope.f90
+++ b/flang/test/Lower/OpenMP/target-scope.f90
@@ -28,7 +28,7 @@ subroutine target_scope_basic()
 
   !$omp target
     ! CHECK: omp.map.info var_ptr(%{{.*}} : !fir.ref<i32>, i32)
-    ! CHECK: omp.target map_entries(%{{.*}} -> %[[XARG:.*]] : !fir.ref<i32>) {
+    ! CHECK: omp.target map_entries(%{{.*}} -> %{{.*}} : !fir.ref<i32>) private({{.*}} -> %[[XARG:.*]] [map_idx=0] : !fir.ref<i32>) {
     ! CHECK:   hlfir.declare %[[XARG]] {uniq_name = "_QFtarget_scope_basicEx"}
     ! CHECK:   omp.scope {
     !$omp scope
@@ -45,7 +45,7 @@ subroutine target_scope_nowait()
   x = 10
 
   !$omp target
-    ! CHECK: omp.target map_entries(%{{.*}} -> %[[XARG:.*]] : !fir.ref<i32>) {
+    ! CHECK: omp.target map_entries(%{{.*}} -> %{{.*}} : !fir.ref<i32>) private({{.*}} -> %[[XARG:.*]] [map_idx=0] : !fir.ref<i32>) {
     ! CHECK:   hlfir.declare %[[XARG]] {uniq_name = "_QFtarget_scope_nowaitEx"}
     ! CHECK:   omp.scope nowait {
     !$omp scope

--- a/flang/test/Lower/OpenMP/target.f90
+++ b/flang/test/Lower/OpenMP/target.f90
@@ -1,6 +1,5 @@
 ! The "thread_limit" clause was added to the "target" construct in OpenMP 5.1.
-!RUN: %flang_fc1 -emit-hlfir -fopenmp -mmlir --enable-delayed-privatization-staging=false -fopenmp-version=51 %s -o - | FileCheck %s  --check-prefixes=CHECK,CHECK-NO-FPRIV
-!RUN: %flang_fc1 -emit-hlfir -fopenmp -mmlir --enable-delayed-privatization-staging=true -fopenmp-version=51 %s -o - | FileCheck %s  --check-prefixes=CHECK,CHECK-FPRIV
+!RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=51 %s -o - | FileCheck %s  --check-prefixes=CHECK,CHECK-FPRIV
 
 !===============================================================================
 ! Target_Enter Simple
@@ -434,11 +433,8 @@ end subroutine omp_target_implicit
 subroutine omp_target_implicit_nested
    integer::a, b
 
-   !CHECK-NO-FPRIV: omp.target   map_entries(%{{.*}} -> %[[ARG0:.*]], %{{.*}} -> %[[ARG1:.*]] : !fir.ref<i32>, !fir.ref<i32>) {
    !CHECK-FPRIV: omp.target   map_entries(%{{.*}} -> %[[ARG0:.*]], %{{.*}} -> %[[ARG1:.*]] : !fir.ref<i32>, !fir.ref<i32>) private(@{{.*}} %{{.*}} -> %[[ARG2:.*]] [map_idx=0], @{{.*}} %{{.*}} -> %[[ARG3:.*]] [map_idx=1] : !fir.ref<i32>, !fir.ref<i32>) {
    !$omp target
-      !CHECK-NO-FPRIV: %[[VAL_8:.*]]:2 = hlfir.declare %[[ARG0]] {uniq_name = "_QFomp_target_implicit_nestedEa"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-      !CHECK-NO-FPRIV: %[[VAL_9:.*]]:2 = hlfir.declare %[[ARG1]] {uniq_name = "_QFomp_target_implicit_nestedEb"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
       !CHECK-FPRIV: %[[VAL_8:.*]]:2 = hlfir.declare %[[ARG2]] {uniq_name = "_QFomp_target_implicit_nestedEa"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
       !CHECK-FPRIV: %[[VAL_9:.*]]:2 = hlfir.declare %[[ARG3]] {uniq_name = "_QFomp_target_implicit_nestedEb"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 
@@ -674,17 +670,12 @@ subroutine target_unstructured
    integer :: i = 1
    !CHECK: %[[VAL_3:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFtarget_unstructuredEj"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
    integer :: j = 11
-   !CHECK-NO-FPRIV: %[[VAL_4:.*]] = omp.map.info var_ptr(%[[VAL_1]]#1 : !fir.ref<i32>, i32) map_clauses(implicit) capture(ByCopy) -> !fir.ref<i32> {name = "i"}
-   !CHECK-NO-FPRIV: %[[VAL_5:.*]] = omp.map.info var_ptr(%[[VAL_3]]#1 : !fir.ref<i32>, i32) map_clauses(implicit) capture(ByCopy) -> !fir.ref<i32> {name = "j"}
-   !CHECK-NO-FPRIV: omp.target map_entries(%[[VAL_4]] -> %[[VAL_6:.*]], %[[VAL_5]] -> %[[VAL_7:.*]] : !fir.ref<i32>, !fir.ref<i32>) {
    !CHECK-FPRIV: %[[VAL_4:.*]] = omp.map.info var_ptr(%[[VAL_1]]#0 : !fir.ref<i32>, i32) map_clauses(to) capture(ByCopy) -> !fir.ref<i32>
    !CHECK-FPRIV: %[[VAL_5:.*]] = omp.map.info var_ptr(%[[VAL_3]]#0 : !fir.ref<i32>, i32) map_clauses(to) capture(ByCopy) -> !fir.ref<i32>
    !CHECK-FPRIV: omp.target map_entries(%[[VAL_4]] -> %[[ARG_0:.*]], %[[VAL_5]] -> %[[ARG_1:.*]] : !fir.ref<i32>, !fir.ref<i32>) private(@{{.*}} %[[VAL_1]]#0 -> %[[ARG_2:.*]] [map_idx=0], @{{.*}} %[[VAL_3]]#0 -> %[[ARG_3:.*]] [map_idx=1] : !fir.ref<i32>, !fir.ref<i32>) {
    !$omp target
       !CHECK-FPRIV: %[[VAL_8:.*]]:2 = hlfir.declare %[[ARG_2]] {uniq_name = "_QFtarget_unstructuredEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
       !CHECK-FPRIV: %[[VAL_9:.*]]:2 = hlfir.declare %[[ARG_3]] {uniq_name = "_QFtarget_unstructuredEj"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-      !CHECK-NO-FPRIV: %[[VAL_8:.*]]:2 = hlfir.declare %[[VAL_6]] {uniq_name = "_QFtarget_unstructuredEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-      !CHECK-NO-FPRIV: %[[VAL_9:.*]]:2 = hlfir.declare %[[VAL_7]] {uniq_name = "_QFtarget_unstructuredEj"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 
       !CHECK: ^bb1:
       do while (i <= j)

--- a/flang/test/Lower/do_concurrent_delayed_locality.f90
+++ b/flang/test/Lower/do_concurrent_delayed_locality.f90
@@ -1,4 +1,4 @@
-! RUN: %flang_fc1 -emit-hlfir -mmlir --enable-delayed-privatization-staging=true -o - %s | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir -o - %s | FileCheck %s
 
 subroutine do_concurrent_with_locality_specs
   implicit none

--- a/flang/test/Lower/do_concurrent_local_assoc_entity.f90
+++ b/flang/test/Lower/do_concurrent_local_assoc_entity.f90
@@ -1,4 +1,4 @@
-! RUN: %flang_fc1 -emit-hlfir -mmlir --enable-delayed-privatization-staging=true -o - %s | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir -o - %s | FileCheck %s
 
 subroutine local_assoc
   implicit none

--- a/flang/test/Lower/do_concurrent_local_default_init.f90
+++ b/flang/test/Lower/do_concurrent_local_default_init.f90
@@ -1,5 +1,5 @@
 ! Test default initialization of DO CONCURRENT LOCAL() entities.
-! RUN: bbc -emit-hlfir --enable-delayed-privatization-staging=true -I nowhere -o - %s | FileCheck %s
+! RUN: bbc -emit-hlfir -I nowhere -o - %s | FileCheck %s
 
 subroutine test_ptr(p)
   interface

--- a/flang/test/Lower/do_concurrent_loop_in_nested_block.f90
+++ b/flang/test/Lower/do_concurrent_loop_in_nested_block.f90
@@ -1,4 +1,4 @@
-! RUN: %flang_fc1 -emit-hlfir -mmlir --enable-delayed-privatization-staging=true -o - %s | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir -o - %s | FileCheck %s
 
 subroutine loop_in_nested_block
   implicit none

--- a/flang/test/Lower/do_concurrent_reduce.f90
+++ b/flang/test/Lower/do_concurrent_reduce.f90
@@ -1,4 +1,4 @@
-! RUN: %flang_fc1 -emit-hlfir -mmlir --enable-delayed-privatization-staging=true -o - %s | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir -o - %s | FileCheck %s
 
 subroutine do_concurrent_reduce
   implicit none

--- a/flang/test/Semantics/OpenMP/symbol08.f90
+++ b/flang/test/Semantics/OpenMP/symbol08.f90
@@ -133,8 +133,8 @@ subroutine dotprod (b, c, n, block_size, num_teams, block_threads)
 !$omp teams num_teams(num_teams) thread_limit(block_threads) reduction(+: sum)
 !$omp distribute
  !DEF: /dotprod/OtherConstruct1/OtherConstruct1/OtherConstruct1/i0 (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
- !REF: /dotprod/n
- !REF: /dotprod/block_size
+ !DEF: /dotprod/OtherConstruct1/OtherConstruct1/OtherConstruct1/n HostAssoc INTEGER(4)
+ !DEF: /dotprod/OtherConstruct1/OtherConstruct1/OtherConstruct1/block_size HostAssoc INTEGER(4)
  do i0=1,n,block_size
 !$omp parallel do  reduction(+: sum)
   !DEF: /dotprod/OtherConstruct1/OtherConstruct1/OtherConstruct1/OtherConstruct1/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)

--- a/offload/test/offloading/fortran/target-firstprivate.f90
+++ b/offload/test/offloading/fortran/target-firstprivate.f90
@@ -1,0 +1,52 @@
+! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! REQUIRES: flang, amdgpu
+
+
+program main
+  implicit none
+  integer, parameter :: nnn = 1000
+  integer :: aaa(nnn), bbb
+  integer :: x, y, got
+  integer :: i
+
+  x = 42
+  got = -1
+  !$omp target firstprivate(x) map(from:got)
+    got = x + 1
+  !$omp end target
+
+  if (got .ne. 43) then
+    print *, "FAIL target firstprivate"
+    stop 1
+  end if
+  ! CHECK: PASS target firstprivate
+  print *, "PASS target firstprivate"
+
+  y = 10
+  got = -1
+  !$omp target firstprivate(y) nowait map(from:got)
+    got = y + 1
+  !$omp end target
+  !$omp taskwait
+
+  if (got .ne. 11) then
+    print *, "FAIL target firstprivate nowait"
+    stop 1
+  end if
+  ! CHECK: PASS target firstprivate nowait
+  print *, "PASS target firstprivate nowait"
+
+  aaa = 0
+  bbb = 1
+  !$omp target teams distribute parallel do firstprivate(bbb)
+  do i = 1, nnn
+    aaa(i) = bbb
+  end do
+
+  if (sum(abs(aaa)) .ne. nnn * bbb .or. any(aaa .ne. 1)) then
+    print *, "FAIL target teams distribute parallel do firstprivate"
+    stop 1
+  end if
+  ! CHECK: PASS target teams distribute parallel do firstprivate
+  print *, "PASS target teams distribute parallel do firstprivate"
+end program main


### PR DESCRIPTION
…t target first private default

This is a re push of https://github.com/llvm/llvm-project/pull/200952, `offload/test/offloading/fortran/target-firstprivate.f90` was failing in x86 and intel gpu tests as I did not add `! REQUIRES: flang, amdgpu` the only difference in this commit and the reverted one is the mentioned lined added to the failing test