### PR TITLE
[RISCV] Add PseudoClearGPR to the special cases in RISCVInstrInfo::getInstSizeInBytes.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -2007,6 +2007,7 @@ unsigned RISCVInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
   switch (Opcode) {
   case RISCV::PseudoMV_FPR16INX:
   case RISCV::PseudoMV_FPR32INX:
+  case RISCV::PseudoClearGPR:
     // MV is always compressible to either c.mv or c.li rd, 0.
     return STI.hasStdExtZca() ? 2 : 4;
   // Below cases are for short forward branch pseudos

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -2162,8 +2162,7 @@ def SetFCSRImm : SetSysRegImm<SysRegFCSR, [FRM, FFLAGS]>;
 /// Other pseudo-instructions
 
 // Used by -fzero-call-used-regs to zero out registers.
-let hasSideEffects = 0, mayLoad = 0, mayStore = 0, Size = 8,
-    isCodeGenOnly = true in
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 def PseudoClearGPR : Pseudo<(outs GPR:$rd), (ins), []>,
                      PseudoInstExpansion<(ADDI GPR:$rd, X0, 0)>;
 


### PR DESCRIPTION
This instruction is expanded to an ADDI with immediate of 0 and should then be compressed to c.li with Zca. The compression code doesn't know this so manually give a size of 2 for Zca.