### PR TITLE
[mlir][EmitC] Make `GlobalOps` `FieldOps` in wrap-emitc-func-in-class pass

### DIFF
--- a/mlir/include/mlir/Dialect/EmitC/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/EmitC/Transforms/Passes.td
@@ -20,7 +20,7 @@ def FormExpressionsPass : Pass<"form-expressions"> {
   let dependentDialects = ["emitc::EmitCDialect"];
 }
 
-def WrapFuncInClassPass : Pass<"wrap-emitc-func-in-class"> {
+def WrapFuncInClassPass : Pass<"wrap-emitc-func-in-class", "ModuleOp"> {
   let summary = "Wrap functions in classes, using arguments as fields.";
   let description = [{
     This pass transforms `emitc.func` operations into `emitc.class` operations.

--- a/mlir/include/mlir/Dialect/EmitC/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/EmitC/Transforms/Transforms.h
@@ -32,7 +32,8 @@ void populateExpressionPatterns(RewritePatternSet &patterns);
 // The WrapFuncInClass pass.
 //===----------------------------------------------------------------------===//
 
-void populateWrapFuncInClass(RewritePatternSet &patterns, StringRef fName);
+void populateWrapFuncInClass(RewritePatternSet &patterns, StringRef funcName,
+                             llvm::SmallVector<emitc::GlobalOp> &globalsToMove);
 
 } // namespace emitc
 } // namespace mlir

--- a/mlir/include/mlir/Dialect/EmitC/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/EmitC/Transforms/Transforms.h
@@ -32,8 +32,9 @@ void populateExpressionPatterns(RewritePatternSet &patterns);
 // The WrapFuncInClass pass.
 //===----------------------------------------------------------------------===//
 
-void populateWrapFuncInClass(RewritePatternSet &patterns, StringRef funcName,
-                             llvm::SmallVector<emitc::GlobalOp> &globalsToMove);
+void populateWrapFuncInClass(
+    RewritePatternSet &patterns, StringRef funcName,
+    std::map<FuncOp, llvm::DenseSet<GlobalOp>> &globalsToMove);
 
 } // namespace emitc
 } // namespace mlir

--- a/mlir/include/mlir/Dialect/EmitC/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/EmitC/Transforms/Transforms.h
@@ -11,6 +11,7 @@
 
 #include "mlir/Dialect/EmitC/IR/EmitC.h"
 #include "mlir/IR/PatternMatch.h"
+#include "llvm/ADT/DenseMap.h"
 
 namespace mlir {
 namespace emitc {
@@ -34,7 +35,7 @@ void populateExpressionPatterns(RewritePatternSet &patterns);
 
 void populateWrapFuncInClass(
     RewritePatternSet &patterns, StringRef funcName,
-    std::map<FuncOp, llvm::DenseSet<GlobalOp>> &globalsToMove);
+    DenseMap<FuncOp, llvm::DenseSet<GlobalOp>> &globalsToMove);
 
 } // namespace emitc
 } // namespace mlir

--- a/mlir/lib/Dialect/EmitC/Transforms/WrapFuncInClass.cpp
+++ b/mlir/lib/Dialect/EmitC/Transforms/WrapFuncInClass.cpp
@@ -28,12 +28,21 @@ struct WrapFuncInClassPass
     : public impl::WrapFuncInClassPassBase<WrapFuncInClassPass> {
   using WrapFuncInClassPassBase::WrapFuncInClassPassBase;
   void runOnOperation() override {
-    Operation *rootOp = getOperation();
+    mlir::ModuleOp moduleOp = getOperation();
+
+    llvm::SmallVector<emitc::GlobalOp> globalsToMove;
+    moduleOp.walk(
+        [&](mlir::emitc::GlobalOp op) { globalsToMove.push_back(op); });
 
     RewritePatternSet patterns(&getContext());
-    populateWrapFuncInClass(patterns, funcName);
+    populateWrapFuncInClass(patterns, funcName, globalsToMove);
 
-    walkAndApplyPatterns(rootOp, std::move(patterns));
+    walkAndApplyPatterns(moduleOp, std::move(patterns));
+
+    for (GlobalOp globalOp : globalsToMove) {
+      if (globalOp)
+        globalOp.erase();
+    }
   }
 };
 
@@ -43,8 +52,10 @@ struct WrapFuncInClassPass
 
 class WrapFuncInClass : public OpRewritePattern<emitc::FuncOp> {
 public:
-  WrapFuncInClass(MLIRContext *context, StringRef funcName)
-      : OpRewritePattern<emitc::FuncOp>(context), funcName(funcName) {}
+  WrapFuncInClass(MLIRContext *context, StringRef funcName,
+                  llvm::SmallVector<emitc::GlobalOp> &globalsToMove)
+      : OpRewritePattern<emitc::FuncOp>(context), funcName(funcName),
+        globalsToMove(globalsToMove) {}
 
   LogicalResult matchAndRewrite(emitc::FuncOp funcOp,
                                 PatternRewriter &rewriter) const override {
@@ -70,6 +81,12 @@ public:
       if (argAttrs && idx < argAttrs->size()) {
         fieldop->setDiscardableAttrs(funcOp.getArgAttrDict(idx));
       }
+    }
+
+    for (GlobalOp globalOp : globalsToMove) {
+      emitc::FieldOp::create(rewriter, funcOp->getLoc(),
+                             globalOp.getSymNameAttr(), globalOp.getTypeAttr(),
+                             globalOp.getInitialValueAttr());
     }
 
     rewriter.setInsertionPointToEnd(&newClassOp.getBody().front());
@@ -99,6 +116,14 @@ public:
     if (failed(newFuncOp.eraseArguments(argsToErase)))
       newFuncOp->emitOpError("failed to erase all arguments using BitVector");
 
+    newFuncOp.walk([&](emitc::GetGlobalOp getGlobalOp) {
+      rewriter.setInsertionPoint(getGlobalOp);
+      emitc::GetFieldOp getFieldOp = emitc::GetFieldOp::create(
+          rewriter, getGlobalOp.getLoc(), getGlobalOp.getType(),
+          getGlobalOp.getNameAttr());
+      rewriter.replaceOp(getGlobalOp, getFieldOp);
+    });
+
     rewriter.replaceOp(funcOp, newClassOp);
     return success();
   }
@@ -107,9 +132,11 @@ private:
   /// Name of the newly generated member function with body matching the input
   /// function.
   std::string funcName;
+  llvm::SmallVector<emitc::GlobalOp> globalsToMove;
 };
 
-void mlir::emitc::populateWrapFuncInClass(RewritePatternSet &patterns,
-                                          StringRef funcName) {
-  patterns.add<WrapFuncInClass>(patterns.getContext(), funcName);
+void mlir::emitc::populateWrapFuncInClass(
+    RewritePatternSet &patterns, StringRef funcName,
+    llvm::SmallVector<emitc::GlobalOp> &globalsToMove) {
+  patterns.add<WrapFuncInClass>(patterns.getContext(), funcName, globalsToMove);
 }

--- a/mlir/lib/Dialect/EmitC/Transforms/WrapFuncInClass.cpp
+++ b/mlir/lib/Dialect/EmitC/Transforms/WrapFuncInClass.cpp
@@ -15,6 +15,7 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Transforms/WalkPatternRewriteDriver.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 
 using namespace mlir;
@@ -32,17 +33,17 @@ struct WrapFuncInClassPass
   void runOnOperation() override {
     mlir::ModuleOp moduleOp = getOperation();
 
-    std::map<FuncOp, llvm::DenseSet<GlobalOp>> globalsUsedByFuncs;
+    DenseMap<FuncOp, llvm::DenseSet<GlobalOp>> globalsUsedByFuncs;
 
     SymbolTableCollection symbolTable;
     moduleOp.walk([&globalsUsedByFuncs, &symbolTable](FuncOp funcOp) {
-      funcOp.walk(
-          [&globalsUsedByFuncs, &symbolTable, funcOp](GetGlobalOp getGlobalOp) {
-            if (auto globalOp = symbolTable.lookupNearestSymbolFrom<GlobalOp>(
-                    getGlobalOp, getGlobalOp.getNameAttr())) {
-              globalsUsedByFuncs[funcOp].insert(globalOp);
-            }
-          });
+      funcOp.walk([&globalsUsedByFuncs, &symbolTable,
+                   &funcOp](GetGlobalOp getGlobalOp) {
+        if (auto globalOp = symbolTable.lookupNearestSymbolFrom<GlobalOp>(
+                getGlobalOp, getGlobalOp.getNameAttr())) {
+          globalsUsedByFuncs[funcOp].insert(globalOp);
+        }
+      });
     });
 
     RewritePatternSet patterns(&getContext());
@@ -51,8 +52,8 @@ struct WrapFuncInClassPass
     walkAndApplyPatterns(moduleOp, std::move(patterns));
 
     DenseSet<GlobalOp> globalsToErase;
-    for (auto &pair : globalsUsedByFuncs)
-      globalsToErase.insert(pair.second.begin(), pair.second.end());
+    for (auto &[_, globals] : globalsUsedByFuncs)
+      globalsToErase.insert_range(globals);
 
     for (GlobalOp globalOp : globalsToErase)
       globalOp.erase();
@@ -67,7 +68,7 @@ class WrapFuncInClass : public OpRewritePattern<FuncOp> {
 public:
   WrapFuncInClass(
       MLIRContext *context, StringRef funcName,
-      const std::map<FuncOp, llvm::DenseSet<GlobalOp>> &globalsToMove)
+      const DenseMap<FuncOp, llvm::DenseSet<GlobalOp>> &globalsToMove)
       : OpRewritePattern<FuncOp>(context), funcName(funcName),
         globalsToMove(globalsToMove) {}
 
@@ -150,11 +151,11 @@ private:
 
   /// Map of FuncOp and the GlobalOps it uses which need to be moved into the
   /// ClassOp wrapper.
-  std::map<FuncOp, llvm::DenseSet<GlobalOp>> globalsToMove;
+  DenseMap<FuncOp, llvm::DenseSet<GlobalOp>> globalsToMove;
 };
 
 void mlir::emitc::populateWrapFuncInClass(
     RewritePatternSet &patterns, StringRef funcName,
-    std::map<FuncOp, llvm::DenseSet<GlobalOp>> &globalsToMove) {
+    DenseMap<FuncOp, DenseSet<GlobalOp>> &globalsToMove) {
   patterns.add<WrapFuncInClass>(patterns.getContext(), funcName, globalsToMove);
 }

--- a/mlir/lib/Dialect/EmitC/Transforms/WrapFuncInClass.cpp
+++ b/mlir/lib/Dialect/EmitC/Transforms/WrapFuncInClass.cpp
@@ -13,7 +13,9 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/Transforms/WalkPatternRewriteDriver.h"
+#include "llvm/ADT/DenseSet.h"
 
 using namespace mlir;
 using namespace emitc;
@@ -30,19 +32,30 @@ struct WrapFuncInClassPass
   void runOnOperation() override {
     mlir::ModuleOp moduleOp = getOperation();
 
-    llvm::SmallVector<emitc::GlobalOp> globalsToMove;
-    moduleOp.walk(
-        [&](mlir::emitc::GlobalOp op) { globalsToMove.push_back(op); });
+    std::map<FuncOp, llvm::DenseSet<GlobalOp>> globalsUsedByFuncs;
+
+    SymbolTableCollection symbolTable;
+    moduleOp.walk([&globalsUsedByFuncs, &symbolTable](FuncOp funcOp) {
+      funcOp.walk(
+          [&globalsUsedByFuncs, &symbolTable, funcOp](GetGlobalOp getGlobalOp) {
+            if (auto globalOp = symbolTable.lookupNearestSymbolFrom<GlobalOp>(
+                    getGlobalOp, getGlobalOp.getNameAttr())) {
+              globalsUsedByFuncs[funcOp].insert(globalOp);
+            }
+          });
+    });
 
     RewritePatternSet patterns(&getContext());
-    populateWrapFuncInClass(patterns, funcName, globalsToMove);
+    populateWrapFuncInClass(patterns, funcName, globalsUsedByFuncs);
 
     walkAndApplyPatterns(moduleOp, std::move(patterns));
 
-    for (GlobalOp globalOp : globalsToMove) {
-      if (globalOp)
-        globalOp.erase();
-    }
+    DenseSet<GlobalOp> globalsToErase;
+    for (auto &pair : globalsUsedByFuncs)
+      globalsToErase.insert(pair.second.begin(), pair.second.end());
+
+    for (GlobalOp globalOp : globalsToErase)
+      globalOp.erase();
   }
 };
 
@@ -50,14 +63,15 @@ struct WrapFuncInClassPass
 } // namespace emitc
 } // namespace mlir
 
-class WrapFuncInClass : public OpRewritePattern<emitc::FuncOp> {
+class WrapFuncInClass : public OpRewritePattern<FuncOp> {
 public:
-  WrapFuncInClass(MLIRContext *context, StringRef funcName,
-                  llvm::SmallVector<emitc::GlobalOp> &globalsToMove)
-      : OpRewritePattern<emitc::FuncOp>(context), funcName(funcName),
+  WrapFuncInClass(
+      MLIRContext *context, StringRef funcName,
+      const std::map<FuncOp, llvm::DenseSet<GlobalOp>> &globalsToMove)
+      : OpRewritePattern<FuncOp>(context), funcName(funcName),
         globalsToMove(globalsToMove) {}
 
-  LogicalResult matchAndRewrite(emitc::FuncOp funcOp,
+  LogicalResult matchAndRewrite(FuncOp funcOp,
                                 PatternRewriter &rewriter) const override {
 
     auto className = funcOp.getSymNameAttr().str() + "Class";
@@ -75,25 +89,26 @@ public:
       TypeAttr typeAttr = TypeAttr::get(val.getType());
       fields.push_back({fieldName, typeAttr});
 
-      FieldOp fieldop = emitc::FieldOp::create(rewriter, funcOp->getLoc(),
-                                               fieldName, typeAttr, nullptr);
+      FieldOp fieldop = FieldOp::create(rewriter, funcOp->getLoc(), fieldName,
+                                        typeAttr, nullptr);
 
       if (argAttrs && idx < argAttrs->size()) {
         fieldop->setDiscardableAttrs(funcOp.getArgAttrDict(idx));
       }
     }
 
-    for (GlobalOp globalOp : globalsToMove) {
-      emitc::FieldOp::create(rewriter, funcOp->getLoc(),
-                             globalOp.getSymNameAttr(), globalOp.getTypeAttr(),
-                             globalOp.getInitialValueAttr());
+    auto globalsIt = globalsToMove.find(funcOp);
+    if (globalsIt != globalsToMove.end()) {
+      for (auto global : globalsIt->second) {
+        FieldOp::create(rewriter, funcOp->getLoc(), global.getSymNameAttr(),
+                        global.getTypeAttr(), global.getInitialValueAttr());
+      }
     }
 
     rewriter.setInsertionPointToEnd(&newClassOp.getBody().front());
     FunctionType funcType = funcOp.getFunctionType();
     Location loc = funcOp.getLoc();
-    FuncOp newFuncOp =
-        emitc::FuncOp::create(rewriter, loc, (funcName), funcType);
+    FuncOp newFuncOp = FuncOp::create(rewriter, loc, (funcName), funcType);
 
     rewriter.createBlock(&newFuncOp.getBody());
     newFuncOp.getBody().takeBody(funcOp.getBody());
@@ -103,7 +118,7 @@ public:
     newArguments.reserve(fields.size());
     for (auto &[fieldName, attr] : fields) {
       GetFieldOp arg =
-          emitc::GetFieldOp::create(rewriter, loc, attr.getValue(), fieldName);
+          GetFieldOp::create(rewriter, loc, attr.getValue(), fieldName);
       newArguments.push_back(arg);
     }
 
@@ -116,11 +131,11 @@ public:
     if (failed(newFuncOp.eraseArguments(argsToErase)))
       newFuncOp->emitOpError("failed to erase all arguments using BitVector");
 
-    newFuncOp.walk([&](emitc::GetGlobalOp getGlobalOp) {
+    newFuncOp.walk([&](GetGlobalOp getGlobalOp) {
       rewriter.setInsertionPoint(getGlobalOp);
-      emitc::GetFieldOp getFieldOp = emitc::GetFieldOp::create(
-          rewriter, getGlobalOp.getLoc(), getGlobalOp.getType(),
-          getGlobalOp.getNameAttr());
+      GetFieldOp getFieldOp =
+          GetFieldOp::create(rewriter, getGlobalOp.getLoc(),
+                             getGlobalOp.getType(), getGlobalOp.getNameAttr());
       rewriter.replaceOp(getGlobalOp, getFieldOp);
     });
 
@@ -132,11 +147,14 @@ private:
   /// Name of the newly generated member function with body matching the input
   /// function.
   std::string funcName;
-  llvm::SmallVector<emitc::GlobalOp> globalsToMove;
+
+  /// Map of FuncOp and the GlobalOps it uses which need to be moved into the
+  /// ClassOp wrapper.
+  std::map<FuncOp, llvm::DenseSet<GlobalOp>> globalsToMove;
 };
 
 void mlir::emitc::populateWrapFuncInClass(
     RewritePatternSet &patterns, StringRef funcName,
-    llvm::SmallVector<emitc::GlobalOp> &globalsToMove) {
+    std::map<FuncOp, llvm::DenseSet<GlobalOp>> &globalsToMove) {
   patterns.add<WrapFuncInClass>(patterns.getContext(), funcName, globalsToMove);
 }

--- a/mlir/test/Dialect/EmitC/wrap-func-in-class.mlir
+++ b/mlir/test/Dialect/EmitC/wrap-func-in-class.mlir
@@ -60,6 +60,7 @@ module attributes { } {
 // EXECUTE: execute()
 
 // -----
+// Tests that GlobalOps are moved into the ClassOp wrapper correctly as fields
 
 module attributes { } {
   emitc.global static const @global_arr : !emitc.array<1xi8> = dense<0>
@@ -76,6 +77,134 @@ module attributes { } {
 // CHECK:       return
 // CHECK:     }
 // CHECK:   }
+
+// EXECUTE-NOT: operator
+// EXECUTE: execute()
+
+// -----
+// Tests that only GlobalOps that are used within a function are moved into the
+// ClassOp wrapper as fields
+
+module attributes { } {
+  emitc.global static const @global_arr : !emitc.array<1xi8> = dense<0>
+  emitc.global static const @global_arr2 : !emitc.array<1xi8> = dense<0>
+  emitc.func @foo() {
+    %0 = emitc.get_global @global_arr : !emitc.array<1xi8>
+    emitc.return
+  }
+}
+
+// CHECK:   module {
+// CHECK-NEXT:     emitc.global static const @global_arr2 : !emitc.array<1xi8> = dense<0>
+// CHECK-NEXT:     emitc.class @fooClass {
+// CHECK-NEXT:       emitc.field @global_arr : !emitc.array<1xi8> = dense<0>
+// CHECK-NEXT:       emitc.func @"operator()"() {
+// CHECK-NEXT:         %0 = get_field @global_arr : !emitc.array<1xi8>
+// CHECK-NEXT:         return
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+
+// EXECUTE-NOT: operator
+// EXECUTE: execute()
+
+// -----
+// Tests that when multiple functions use different globals, only the used globals
+// are moved into their respective ClassOp wrappers as fields.
+
+module attributes { } {
+  emitc.global static const @global_arr1 : !emitc.array<1xi8> = dense<0>
+  emitc.global static const @global_arr2 : !emitc.array<1xi8> = dense<0>
+  emitc.global static const @global_arr3 : !emitc.array<1xi8> = dense<0>
+  emitc.func @foo() {
+    %0 = emitc.get_global @global_arr1 : !emitc.array<1xi8>
+    emitc.return
+  }
+  emitc.func @bar() {
+    %0 = emitc.get_global @global_arr2 : !emitc.array<1xi8>
+    emitc.return
+  }
+}
+
+// CHECK:   module {
+// CHECK-NEXT:     emitc.global static const @global_arr3 : !emitc.array<1xi8> = dense<0>
+// CHECK-NEXT:     emitc.class @fooClass {
+// CHECK-NEXT:       emitc.field @global_arr1 : !emitc.array<1xi8> = dense<0>
+// CHECK-NEXT:       emitc.func @"operator()"() {
+// CHECK-NEXT:         %0 = get_field @global_arr1 : !emitc.array<1xi8>
+// CHECK-NEXT:         return
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     emitc.class @barClass {
+// CHECK-NEXT:       emitc.field @global_arr2 : !emitc.array<1xi8> = dense<0>
+// CHECK-NEXT:       emitc.func @"operator()"() {
+// CHECK-NEXT:         %0 = get_field @global_arr2 : !emitc.array<1xi8>
+// CHECK-NEXT:         return
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+
+// EXECUTE-NOT: operator
+// EXECUTE: execute()
+
+// -----
+// Tests that when multiple functions use the same global, the global is moved
+// into each ClassOp wrapper as a field and erased from the module.
+
+module attributes { } {
+  emitc.global static const @global_arr : !emitc.array<1xi8> = dense<0>
+  emitc.func @foo() {
+    %0 = emitc.get_global @global_arr : !emitc.array<1xi8>
+    emitc.return
+  }
+  emitc.func @bar() {
+    %0 = emitc.get_global @global_arr : !emitc.array<1xi8>
+    emitc.return
+  }
+}
+
+// CHECK:   module {
+// CHECK-NEXT:     emitc.class @fooClass {
+// CHECK-NEXT:       emitc.field @global_arr : !emitc.array<1xi8> = dense<0>
+// CHECK-NEXT:       emitc.func @"operator()"() {
+// CHECK-NEXT:         %0 = get_field @global_arr : !emitc.array<1xi8>
+// CHECK-NEXT:         return
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     emitc.class @barClass {
+// CHECK-NEXT:       emitc.field @global_arr : !emitc.array<1xi8> = dense<0>
+// CHECK-NEXT:       emitc.func @"operator()"() {
+// CHECK-NEXT:         %0 = get_field @global_arr : !emitc.array<1xi8>
+// CHECK-NEXT:         return
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+
+// EXECUTE-NOT: operator
+// EXECUTE: execute()
+
+// -----
+// Tests that multiple uses of the same global in a function result in a single field.
+
+module attributes { } {
+  emitc.global static const @global_arr : !emitc.array<1xi8> = dense<0>
+  emitc.func @foo() {
+    %0 = emitc.get_global @global_arr : !emitc.array<1xi8>
+    %1 = emitc.get_global @global_arr : !emitc.array<1xi8>
+    emitc.return
+  }
+}
+
+// CHECK:   module {
+// CHECK-NEXT:     emitc.class @fooClass {
+// CHECK-NEXT:       emitc.field @global_arr : !emitc.array<1xi8> = dense<0>
+// CHECK-NEXT:       emitc.func @"operator()"() {
+// CHECK-NEXT:         %0 = get_field @global_arr : !emitc.array<1xi8>
+// CHECK-NEXT:         %1 = get_field @global_arr : !emitc.array<1xi8>
+// CHECK-NEXT:         return
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
 
 // EXECUTE-NOT: operator
 // EXECUTE: execute()

--- a/mlir/test/Dialect/EmitC/wrap-func-in-class.mlir
+++ b/mlir/test/Dialect/EmitC/wrap-func-in-class.mlir
@@ -1,5 +1,6 @@
 // RUN: mlir-opt %s -wrap-emitc-func-in-class -split-input-file | FileCheck %s
 // RUN: mlir-opt %s -wrap-emitc-func-in-class=func-name=execute -split-input-file | FileCheck %s --check-prefixes=EXECUTE
+// RUN: mlir-opt %s -wrap-emitc-func-in-class -split-input-file | FileCheck %s
 
 emitc.func @foo(%arg0 : !emitc.array<1xf32>) {
   emitc.call_opaque "bar" (%arg0) : (!emitc.array<1xf32>) -> ()
@@ -52,6 +53,27 @@ module attributes { } {
 // CHECK:       add {{.*}}, {{.*}} : (f32, f32) -> f32
 // CHECK:       subscript {{.*}}[{{.*}}] : (!emitc.array<1xf32>, !emitc.size_t) -> !emitc.lvalue<f32>
 // CHECK:       assign {{.*}} : f32 to {{.*}} : <f32>
+// CHECK:       return
+// CHECK:     }
+// CHECK:   }
+
+// EXECUTE-NOT: operator
+// EXECUTE: execute()
+
+// -----
+
+module attributes { } {
+  emitc.global static const @global_arr : !emitc.array<1xi8> = dense<0>
+  emitc.func @foo() {
+    %0 = emitc.get_global @global_arr : !emitc.array<1xi8>
+    emitc.return
+  }
+}
+
+// CHECK:   emitc.class @fooClass {
+// CHECK:     emitc.field @global_arr : !emitc.array<1xi8> = dense<0>
+// CHECK:     emitc.func @"operator()"() {
+// CHECK:       %0 = get_field @global_arr : !emitc.array<1xi8>
 // CHECK:       return
 // CHECK:     }
 // CHECK:   }

--- a/mlir/test/Dialect/EmitC/wrap-func-in-class.mlir
+++ b/mlir/test/Dialect/EmitC/wrap-func-in-class.mlir
@@ -1,6 +1,5 @@
 // RUN: mlir-opt %s -wrap-emitc-func-in-class -split-input-file | FileCheck %s
 // RUN: mlir-opt %s -wrap-emitc-func-in-class=func-name=execute -split-input-file | FileCheck %s --check-prefixes=EXECUTE
-// RUN: mlir-opt %s -wrap-emitc-func-in-class -split-input-file | FileCheck %s
 
 emitc.func @foo(%arg0 : !emitc.array<1xf32>) {
   emitc.call_opaque "bar" (%arg0) : (!emitc.array<1xf32>) -> ()


### PR DESCRIPTION
Update the `WrapFuncInClassPass` pass so that `GlobalOp`s are moved into the `ClassOp` as `FieldOps`. This respects MLIR's behavior of resolving references to the closest parent operation that defines a symbol table which is the `ClassOp` that we are creating in this pass.

Without this change, references to a `GlobalOp` in `GetGlobalOp` are failing to resolve.

Details:
- Identify `GlobalOp`s
- Create a `FieldOp` within the `ClassOp` for each `GlobalOp`
- Delete the `GlobalOp`s after all functions have been wrapped in a class. Doing this after every function can cause an error when multiple functions refer to the same `GlobalOp`(s) which would be deleted after the first function is wrapped in a class.

Also renamed `fName` parameter in `populateWrapFuncInClass` to `funcName` to match naming in `WrapFuncInClass`.

Based on PR #153452. Key differences:
- No size is set for the `globalsToMove` `SmallVector` type because I'm not sure if the number of global variables is consistent across different models.
- `GlobalOp`s are deleted after all functions have been processed.
- Instead of directly cloning the `GlobalOp`, an equivalent `FieldOp` is created
- `GetGlobalOp`s are translated to `GetFieldOp`s

Co-authored-by: [Jaddyen](https://github.com/Jaddyen)