### PR TITLE
[RISCV] Lower the paadd/pasub intrinsics to existing ISD nodes. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -11736,6 +11736,29 @@ SDValue RISCVTargetLowering::LowerINTRINSIC_WO_CHAIN(SDValue Op,
     unsigned Opc = IntNo == Intrinsic::riscv_clmulh ? ISD::CLMULH : ISD::CLMULR;
     return DAG.getNode(Opc, DL, XLenVT, Op.getOperand(1), Op.getOperand(2));
   }
+  case Intrinsic::riscv_paadd:
+  case Intrinsic::riscv_paaddu:
+  case Intrinsic::riscv_pasub:
+  case Intrinsic::riscv_pasubu: {
+    unsigned Opc;
+    switch (IntNo) {
+    case Intrinsic::riscv_paadd:
+      Opc = ISD::AVGFLOORS;
+      break;
+    case Intrinsic::riscv_paaddu:
+      Opc = ISD::AVGFLOORU;
+      break;
+    case Intrinsic::riscv_pasub:
+      Opc = RISCVISD::ASUB;
+      break;
+    case Intrinsic::riscv_pasubu:
+      Opc = RISCVISD::ASUBU;
+      break;
+    }
+
+    return DAG.getNode(Opc, DL, Op.getValueType(), Op.getOperand(1),
+                       Op.getOperand(2));
+  }
   case Intrinsic::experimental_get_vector_length:
     return lowerGetVectorLength(Op.getNode(), DAG, Subtarget);
   case Intrinsic::riscv_vmv_x_s: {
@@ -15648,14 +15671,29 @@ void RISCVTargetLowering::ReplaceNodeResults(SDNode *N,
       if (!Subtarget.is64Bit() || (VT != MVT::v4i8 && VT != MVT::v2i16))
         return;
 
+      unsigned Opc;
+      switch (IntNo) {
+      case Intrinsic::riscv_paadd:
+        Opc = ISD::AVGFLOORS;
+        break;
+      case Intrinsic::riscv_paaddu:
+        Opc = ISD::AVGFLOORU;
+        break;
+      case Intrinsic::riscv_pasub:
+        Opc = RISCVISD::ASUB;
+        break;
+      case Intrinsic::riscv_pasubu:
+        Opc = RISCVISD::ASUBU;
+        break;
+      }
+
       EVT WideVT = VT == MVT::v4i8 ? MVT::v8i8 : MVT::v4i16;
       SDValue Undef = DAG.getUNDEF(VT);
       SDValue Op0 =
           DAG.getNode(ISD::CONCAT_VECTORS, DL, WideVT, N->getOperand(1), Undef);
       SDValue Op1 =
           DAG.getNode(ISD::CONCAT_VECTORS, DL, WideVT, N->getOperand(2), Undef);
-      SDValue Res = DAG.getNode(ISD::INTRINSIC_WO_CHAIN, DL, WideVT,
-                                N->getOperand(0), Op0, Op1);
+      SDValue Res = DAG.getNode(Opc, DL, WideVT, Op0, Op1);
       Results.push_back(DAG.getNode(ISD::EXTRACT_SUBVECTOR, DL, VT, Res,
                                     DAG.getVectorIdxConstant(0, DL)));
       return;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -1990,21 +1990,11 @@ let Predicates = [HasStdExtP] in {
   def : PatGprGpr<riscv_asub, PASUB_B, XLenVecI8VT>;
   def : PatGprGpr<riscv_asubu, PASUBU_B, XLenVecI8VT>;
 
-  def : PatGprGpr<int_riscv_paadd, PAADD_B, XLenVecI8VT>;
-  def : PatGprGpr<int_riscv_paaddu, PAADDU_B, XLenVecI8VT>;
-  def : PatGprGpr<int_riscv_pasub, PASUB_B, XLenVecI8VT>;
-  def : PatGprGpr<int_riscv_pasubu, PASUBU_B, XLenVecI8VT>;
-
   // 16-bit averaging patterns
   def : PatGprGpr<avgfloors, PAADD_H, XLenVecI16VT>;
   def : PatGprGpr<avgflooru, PAADDU_H, XLenVecI16VT>;
   def : PatGprGpr<riscv_asub, PASUB_H, XLenVecI16VT>;
   def : PatGprGpr<riscv_asubu, PASUBU_H, XLenVecI16VT>;
-
-  def : PatGprGpr<int_riscv_paadd, PAADD_H, XLenVecI16VT>;
-  def : PatGprGpr<int_riscv_paaddu, PAADDU_H, XLenVecI16VT>;
-  def : PatGprGpr<int_riscv_pasub, PASUB_H, XLenVecI16VT>;
-  def : PatGprGpr<int_riscv_pasubu, PASUBU_H, XLenVecI16VT>;
 
   // 8-bit absolute difference patterns
   def : Pat<(XLenVecI8VT (abs GPR:$rs1)), (PABD_B GPR:$rs1, (XLenVecI8VT X0))>;
@@ -2280,19 +2270,6 @@ let append Predicates = [IsRV32] in {
   def : PatGprPairGprPair<riscv_asub, PASUB_DW, v2i32>;
   def : PatGprPairGprPair<riscv_asubu, PASUBU_DW, v2i32>;
 
-  def : PatGprPairGprPair<int_riscv_paadd, PAADD_DB, v8i8>;
-  def : PatGprPairGprPair<int_riscv_paaddu, PAADDU_DB, v8i8>;
-  def : PatGprPairGprPair<int_riscv_pasub, PASUB_DB, v8i8>;
-  def : PatGprPairGprPair<int_riscv_pasubu, PASUBU_DB, v8i8>;
-  def : PatGprPairGprPair<int_riscv_paadd, PAADD_DH, v4i16>;
-  def : PatGprPairGprPair<int_riscv_paaddu, PAADDU_DH, v4i16>;
-  def : PatGprPairGprPair<int_riscv_pasub, PASUB_DH, v4i16>;
-  def : PatGprPairGprPair<int_riscv_pasubu, PASUBU_DH, v4i16>;
-  def : PatGprPairGprPair<int_riscv_paadd, PAADD_DW, v2i32>;
-  def : PatGprPairGprPair<int_riscv_paaddu, PAADDU_DW, v2i32>;
-  def : PatGprPairGprPair<int_riscv_pasub, PASUB_DW, v2i32>;
-  def : PatGprPairGprPair<int_riscv_pasubu, PASUBU_DW, v2i32>;
-
   // 8-bit absolute difference patterns
   def : Pat<(v8i8 (abs GPRPair:$rs1)), (PABD_DB GPRPair:$rs1, (v8i8 X0_Pair))>;
   def : PatGprPairGprPair<abds, PABD_DB, v8i8>;
@@ -2501,14 +2478,10 @@ let append Predicates = [IsRV64] in {
   // 32-bit averaging patterns
   def : PatGprGpr<avgfloors, PAADD_W, v2i32>;
   def : PatGprGpr<avgflooru, PAADDU_W, v2i32>;
-  def : PatGprGpr<int_riscv_paadd, PAADD_W, v2i32>;
-  def : PatGprGpr<int_riscv_paaddu, PAADDU_W, v2i32>;
 
   // 32-bit averaging-sub patterns
   def : PatGprGpr<riscv_asub, PASUB_W, v2i32>;
   def : PatGprGpr<riscv_asubu, PASUBU_W, v2i32>;
-  def : PatGprGpr<int_riscv_pasub, PASUB_W, v2i32>;
-  def : PatGprGpr<int_riscv_pasubu, PASUBU_W, v2i32>;
 
   // 32-bit multiply high patterns
   def : PatGprGpr<mulhs, PMULH_W, v2i32>;


### PR DESCRIPTION
This avoids having 2 different isel patterns for the same operation.