### PR TITLE
[CIR] Add constrained FP binary operations

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2706,6 +2706,130 @@ def CIR_FRemOp : CIR_FPBinaryOp<"frem"> {
 }
 
 //===----------------------------------------------------------------------===//
+// Constrained floating-point binary operations
+//===----------------------------------------------------------------------===//
+
+def CIR_RoundingMode : CIR_I32EnumAttr<"RoundingMode",
+    "floating-point rounding mode for constrained operations", [
+  I32EnumAttrCase<"NearestTiesToEven", 0, "tonearest">,
+  I32EnumAttrCase<"Downward", 1, "downward">,
+  I32EnumAttrCase<"Upward", 2, "upward">,
+  I32EnumAttrCase<"TowardZero", 3, "towardzero">,
+  I32EnumAttrCase<"Dynamic", 4, "dynamic">,
+  I32EnumAttrCase<"NearestTiesToAway", 5, "tonearestaway">
+]>;
+
+def CIR_FPExceptionBehavior : CIR_I32EnumAttr<"FPExceptionBehavior",
+    "floating-point exception behavior for constrained operations", [
+  I32EnumAttrCase<"Ignore", 0, "ignore">,
+  I32EnumAttrCase<"MayTrap", 1, "maytrap">,
+  I32EnumAttrCase<"Strict", 2, "strict">
+]>;
+
+// Base class for constrained floating-point binary arithmetic operations.
+// These model the LLVM `llvm.experimental.constrained.*` intrinsics: they
+// read and write the floating-point environment (per their rounding mode and
+// exception behavior), so they are deliberately NOT `Pure` -- they must not be
+// speculated, CSE'd, hoisted, or constant-folded across an `fesetround` /
+// `feclearexcept`.
+class CIR_ConstrainedFPBinaryOp<string mnemonic, list<Trait> traits = []>
+    : CIR_Op<mnemonic, !listconcat([SameOperandsAndResultType], traits)> {
+  let arguments = (ins
+    CIR_AnyFloatOrVecOfFloatType:$lhs,
+    CIR_AnyFloatOrVecOfFloatType:$rhs,
+    CIR_RoundingMode:$rounding,
+    CIR_FPExceptionBehavior:$exception_behavior
+  );
+  let results = (outs CIR_AnyFloatOrVecOfFloatType:$result);
+  let assemblyFormat = [{
+    $lhs `,` $rhs `rounding` `(` $rounding `)` `except`
+    `(` $exception_behavior `)` `:` type($result) attr-dict
+  }];
+}
+
+def CIR_ConstrainedFAddOp : CIR_ConstrainedFPBinaryOp<"constrained_fadd"> {
+  let summary = "Constrained floating-point addition";
+  let description = [{
+    The `cir.constrained_fadd` operation performs floating-point addition under
+    an explicit rounding mode and exception behavior, modeling
+    `llvm.experimental.constrained.fadd`.  Emitted for code compiled with
+    `#pragma STDC FENV_ACCESS ON`, `-frounding-math`, or
+    `-ffp-exception-behavior=strict`.
+
+    Example:
+
+    ```
+    %0 = cir.constrained_fadd %a, %b rounding(dynamic) except(strict)
+        : !cir.float
+    ```
+  }];
+}
+
+def CIR_ConstrainedFSubOp : CIR_ConstrainedFPBinaryOp<"constrained_fsub"> {
+  let summary = "Constrained floating-point subtraction";
+  let description = [{
+    The `cir.constrained_fsub` operation performs floating-point subtraction
+    under an explicit rounding mode and exception behavior, modeling
+    `llvm.experimental.constrained.fsub`.
+
+    Example:
+
+    ```
+    %0 = cir.constrained_fsub %a, %b rounding(dynamic) except(strict)
+        : !cir.float
+    ```
+  }];
+}
+
+def CIR_ConstrainedFMulOp : CIR_ConstrainedFPBinaryOp<"constrained_fmul"> {
+  let summary = "Constrained floating-point multiplication";
+  let description = [{
+    The `cir.constrained_fmul` operation performs floating-point multiplication
+    under an explicit rounding mode and exception behavior, modeling
+    `llvm.experimental.constrained.fmul`.
+
+    Example:
+
+    ```
+    %0 = cir.constrained_fmul %a, %b rounding(dynamic) except(strict)
+        : !cir.float
+    ```
+  }];
+}
+
+def CIR_ConstrainedFDivOp : CIR_ConstrainedFPBinaryOp<"constrained_fdiv"> {
+  let summary = "Constrained floating-point division";
+  let description = [{
+    The `cir.constrained_fdiv` operation performs floating-point division under
+    an explicit rounding mode and exception behavior, modeling
+    `llvm.experimental.constrained.fdiv`.
+
+    Example:
+
+    ```
+    %0 = cir.constrained_fdiv %a, %b rounding(dynamic) except(strict)
+        : !cir.float
+    ```
+  }];
+}
+
+def CIR_ConstrainedFRemOp : CIR_ConstrainedFPBinaryOp<"constrained_frem"> {
+  let summary = "Constrained floating-point remainder";
+  let description = [{
+    The `cir.constrained_frem` operation computes the floating-point remainder
+    under an explicit rounding mode and exception behavior, modeling
+    `llvm.experimental.constrained.frem`.
+
+    Example:
+
+    ```
+    %0 = cir.constrained_frem %a, %b rounding(dynamic) except(strict)
+        : !cir.float
+    ```
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // AndOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2834,6 +2834,99 @@ convertCmpKindToFCmpPredicate(cir::CmpOpKind kind) {
   llvm_unreachable("Unknown CmpOpKind");
 }
 
+static mlir::LLVM::RoundingMode convertCIRRoundingMode(cir::RoundingMode mode) {
+  switch (mode) {
+  case cir::RoundingMode::NearestTiesToEven:
+    return mlir::LLVM::RoundingMode::NearestTiesToEven;
+  case cir::RoundingMode::Downward:
+    return mlir::LLVM::RoundingMode::TowardNegative;
+  case cir::RoundingMode::Upward:
+    return mlir::LLVM::RoundingMode::TowardPositive;
+  case cir::RoundingMode::TowardZero:
+    return mlir::LLVM::RoundingMode::TowardZero;
+  case cir::RoundingMode::Dynamic:
+    return mlir::LLVM::RoundingMode::Dynamic;
+  case cir::RoundingMode::NearestTiesToAway:
+    return mlir::LLVM::RoundingMode::NearestTiesToAway;
+  }
+  llvm_unreachable("unknown CIR rounding mode");
+}
+
+static mlir::LLVM::FPExceptionBehavior
+convertCIRFPExceptionBehavior(cir::FPExceptionBehavior eb) {
+  switch (eb) {
+  case cir::FPExceptionBehavior::Ignore:
+    return mlir::LLVM::FPExceptionBehavior::Ignore;
+  case cir::FPExceptionBehavior::MayTrap:
+    return mlir::LLVM::FPExceptionBehavior::MayTrap;
+  case cir::FPExceptionBehavior::Strict:
+    return mlir::LLVM::FPExceptionBehavior::Strict;
+  }
+  llvm_unreachable("unknown CIR FP exception behavior");
+}
+
+// Lower a constrained FP binary op (cir.constrained_f{add,sub,mul,div,rem})
+// to its LLVM `llvm.experimental.constrained.*` intrinsic counterpart,
+// threading the rounding mode and exception behavior through.
+template <typename CIROpTy, typename LLVMOpTy, typename AdaptorTy>
+static mlir::LogicalResult
+lowerConstrainedFPBinOp(CIROpTy op, AdaptorTy adaptor,
+                        mlir::ConversionPatternRewriter &rewriter,
+                        const mlir::TypeConverter *typeConverter) {
+  mlir::Type llvmResTy = typeConverter->convertType(op.getType());
+  if (!llvmResTy)
+    return op.emitError() << "unsupported result type for constrained FP op";
+  auto roundingAttr = mlir::LLVM::RoundingModeAttr::get(
+      op.getContext(), convertCIRRoundingMode(op.getRounding()));
+  auto exceptAttr = mlir::LLVM::FPExceptionBehaviorAttr::get(
+      op.getContext(),
+      convertCIRFPExceptionBehavior(op.getExceptionBehavior()));
+  rewriter.replaceOpWithNewOp<LLVMOpTy>(op, llvmResTy, adaptor.getLhs(),
+                                        adaptor.getRhs(), roundingAttr,
+                                        exceptAttr);
+  return mlir::success();
+}
+
+mlir::LogicalResult CIRToLLVMConstrainedFAddOpLowering::matchAndRewrite(
+    cir::ConstrainedFAddOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  return lowerConstrainedFPBinOp<cir::ConstrainedFAddOp,
+                                 mlir::LLVM::ConstrainedFAddIntr>(
+      op, adaptor, rewriter, getTypeConverter());
+}
+
+mlir::LogicalResult CIRToLLVMConstrainedFSubOpLowering::matchAndRewrite(
+    cir::ConstrainedFSubOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  return lowerConstrainedFPBinOp<cir::ConstrainedFSubOp,
+                                 mlir::LLVM::ConstrainedFSubIntr>(
+      op, adaptor, rewriter, getTypeConverter());
+}
+
+mlir::LogicalResult CIRToLLVMConstrainedFMulOpLowering::matchAndRewrite(
+    cir::ConstrainedFMulOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  return lowerConstrainedFPBinOp<cir::ConstrainedFMulOp,
+                                 mlir::LLVM::ConstrainedFMulIntr>(
+      op, adaptor, rewriter, getTypeConverter());
+}
+
+mlir::LogicalResult CIRToLLVMConstrainedFDivOpLowering::matchAndRewrite(
+    cir::ConstrainedFDivOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  return lowerConstrainedFPBinOp<cir::ConstrainedFDivOp,
+                                 mlir::LLVM::ConstrainedFDivIntr>(
+      op, adaptor, rewriter, getTypeConverter());
+}
+
+mlir::LogicalResult CIRToLLVMConstrainedFRemOpLowering::matchAndRewrite(
+    cir::ConstrainedFRemOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  return lowerConstrainedFPBinOp<cir::ConstrainedFRemOp,
+                                 mlir::LLVM::ConstrainedFRemIntr>(
+      op, adaptor, rewriter, getTypeConverter());
+}
+
 mlir::LogicalResult CIRToLLVMCmpOpLowering::matchAndRewrite(
     cir::CmpOp cmpOp, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {

--- a/clang/test/CIR/IR/constrained-fp.cir
+++ b/clang/test/CIR/IR/constrained-fp.cir
@@ -1,0 +1,39 @@
+// RUN: cir-opt %s --verify-roundtrip | FileCheck %s
+// RUN: cir-opt %s --cse | FileCheck %s --check-prefix=CSE
+
+module {
+  // CHECK-LABEL: cir.func @constrained_binops
+  cir.func @constrained_binops(%a: !cir.float, %b: !cir.float) -> !cir.float {
+    // CHECK: cir.constrained_fadd %{{.+}}, %{{.+}} rounding(dynamic) except(strict) : !cir.float
+    %0 = cir.constrained_fadd %a, %b rounding(dynamic) except(strict) : !cir.float
+    // CHECK: cir.constrained_fsub %{{.+}}, %{{.+}} rounding(tonearest) except(maytrap) : !cir.float
+    %1 = cir.constrained_fsub %0, %b rounding(tonearest) except(maytrap) : !cir.float
+    // CHECK: cir.constrained_fmul %{{.+}}, %{{.+}} rounding(towardzero) except(ignore) : !cir.float
+    %2 = cir.constrained_fmul %1, %a rounding(towardzero) except(ignore) : !cir.float
+    // CHECK: cir.constrained_fdiv %{{.+}}, %{{.+}} rounding(upward) except(strict) : !cir.float
+    %3 = cir.constrained_fdiv %2, %b rounding(upward) except(strict) : !cir.float
+    // CHECK: cir.constrained_frem %{{.+}}, %{{.+}} rounding(downward) except(strict) : !cir.float
+    %4 = cir.constrained_frem %3, %a rounding(downward) except(strict) : !cir.float
+    cir.return %4 : !cir.float
+  }
+
+  // Constrained FP ops read/write the floating-point environment, so they are
+  // not Pure: two identical ops must NOT be merged by CSE.
+  // CSE-LABEL: cir.func @no_cse
+  cir.func @no_cse(%a: !cir.float, %b: !cir.float) -> !cir.float {
+    // CSE: cir.constrained_fadd
+    %0 = cir.constrained_fadd %a, %b rounding(dynamic) except(strict) : !cir.float
+    // CSE: cir.constrained_fadd
+    %1 = cir.constrained_fadd %a, %b rounding(dynamic) except(strict) : !cir.float
+    %2 = cir.fadd %0, %1 : !cir.float
+    cir.return %2 : !cir.float
+  }
+
+  // Covers the tonearestaway rounding mode and a wider (double) element type.
+  // CHECK-LABEL: cir.func @constrained_double
+  cir.func @constrained_double(%a: !cir.double, %b: !cir.double) -> !cir.double {
+    // CHECK: cir.constrained_fadd %{{.+}}, %{{.+}} rounding(tonearestaway) except(strict) : !cir.double
+    %0 = cir.constrained_fadd %a, %b rounding(tonearestaway) except(strict) : !cir.double
+    cir.return %0 : !cir.double
+  }
+}

--- a/clang/test/CIR/IR/invalid-constrained-fp.cir
+++ b/clang/test/CIR/IR/invalid-constrained-fp.cir
@@ -1,0 +1,9 @@
+// RUN: cir-opt %s -verify-diagnostics -split-input-file
+
+!s32i = !cir.int<s, 32>
+
+cir.func @nonfp_operand(%a: !s32i, %b: !s32i) -> !s32i {
+  // expected-error@+1 {{operand #0 must be floating point or vector of floating point type}}
+  %0 = cir.constrained_fadd %a, %b rounding(dynamic) except(strict) : !s32i
+  cir.return %0 : !s32i
+}

--- a/clang/test/CIR/Lowering/constrained-fp.cir
+++ b/clang/test/CIR/Lowering/constrained-fp.cir
@@ -1,0 +1,38 @@
+// RUN: cir-opt %s -cir-to-llvm -o %t.mlir
+// RUN: FileCheck --input-file=%t.mlir %s
+
+module {
+  // CHECK-LABEL: llvm.func @constrained_binops
+  cir.func @constrained_binops(%a: !cir.float, %b: !cir.float) -> !cir.float {
+    // CHECK: llvm.intr.experimental.constrained.fadd %{{.+}}, %{{.+}} dynamic strict : f32
+    %0 = cir.constrained_fadd %a, %b rounding(dynamic) except(strict) : !cir.float
+    // CHECK: llvm.intr.experimental.constrained.fsub %{{.+}}, %{{.+}} tonearest maytrap : f32
+    %1 = cir.constrained_fsub %0, %b rounding(tonearest) except(maytrap) : !cir.float
+    // CHECK: llvm.intr.experimental.constrained.fmul %{{.+}}, %{{.+}} towardzero ignore : f32
+    %2 = cir.constrained_fmul %1, %a rounding(towardzero) except(ignore) : !cir.float
+    // CHECK: llvm.intr.experimental.constrained.fdiv %{{.+}}, %{{.+}} upward strict : f32
+    %3 = cir.constrained_fdiv %2, %b rounding(upward) except(strict) : !cir.float
+    // CHECK: llvm.intr.experimental.constrained.frem %{{.+}}, %{{.+}} downward strict : f32
+    %4 = cir.constrained_frem %3, %a rounding(downward) except(strict) : !cir.float
+    cir.return %4 : !cir.float
+  }
+
+  // A constrained op on a vector-of-float operates element-wise.
+  // CHECK-LABEL: llvm.func @constrained_vec
+  cir.func @constrained_vec(%a: !cir.vector<4 x !cir.float>,
+                            %b: !cir.vector<4 x !cir.float>)
+      -> !cir.vector<4 x !cir.float> {
+    // CHECK: llvm.intr.experimental.constrained.fadd %{{.+}}, %{{.+}} dynamic strict : vector<4xf32>
+    %0 = cir.constrained_fadd %a, %b rounding(dynamic) except(strict)
+        : !cir.vector<4 x !cir.float>
+    cir.return %0 : !cir.vector<4 x !cir.float>
+  }
+
+  // Covers the tonearestaway rounding mode and a wider (double) element type.
+  // CHECK-LABEL: llvm.func @constrained_double
+  cir.func @constrained_double(%a: !cir.double, %b: !cir.double) -> !cir.double {
+    // CHECK: llvm.intr.experimental.constrained.fadd %{{.+}}, %{{.+}} tonearestaway strict : f64
+    %0 = cir.constrained_fadd %a, %b rounding(tonearestaway) except(strict) : !cir.double
+    cir.return %0 : !cir.double
+  }
+}


### PR DESCRIPTION
ClangIR cannot yet compile a function that uses a non-default floating-point environment (`#pragma STDC FENV_ACCESS ON`, `-frounding-math`, or `-ffp-exception-behavior=strict`): CIRGen hits `errorNYI("STDC FENV_ACCESS")` right after the prologue. This is the first step toward fixing that.

It adds rounding-mode and exception-behavior enum attributes and five constrained binary ops, `cir.constrained_fadd`, `fsub`, `fmul`, `fdiv`, and `frem`, and lowers each to the matching `LLVM::ConstrainedF*Intr` (`llvm.experimental.constrained.*`). There is no CIRGen emitter yet; that is deferred to a follow-up.

One design choice I'd like your read on: I modeled these as separate ops rather than optional rounding/exception attributes on the existing `cir.fadd`. A constrained op reads and writes the FP environment, so it must not be speculated, CSE'd, hoisted, or folded, but `cir.fadd` is `Pure` and MLIR op traits are static, so an optional attribute cannot make it conditionally impure without dropping `Pure` from the common path and re-expressing effects dynamically (`MemoryEffectOpInterface` plus `ConditionallySpeculatable`). Separate ops mirror how the LLVM dialect models this (`LLVM_ConstrainedFAddIntr` is likewise non-`Pure`) and leave the hot `cir.fadd` untouched. Attributes on `cir.fadd` are a reasonable alternative if you prefer that direction.

This lands standalone as the base of a stack. The follow-ups wire CIRGen (the function-level strict state and per-expression FP options), then constrained casts and compares, call-site `strictfp` propagation, and the constrained math intrinsics; paths not yet handled report `errorNYI` in strict mode rather than silently emitting unconstrained IR. The MultiSource `UnitTests/Float/rounding` test is the end-to-end target. Fast-math flags are a separate, orthogonal feature and out of scope.
