### PR TITLE
[BOLT] Change DataAggregator error types

### DIFF
--- a/bolt/lib/Profile/DataAggregator.cpp
+++ b/bolt/lib/Profile/DataAggregator.cpp
@@ -643,7 +643,7 @@ Error DataAggregator::filterBinaryMMapInfo() {
       if (errs().has_colors())
         errs().resetColor();
 
-      return createStringError(inconvertibleErrorCode(),
+      return createStringError(std::errc::not_supported,
                                "could not find a profile matching PID");
     }
   }
@@ -766,7 +766,7 @@ Error DataAggregator::parsePerfData() {
       Regex NoData("Samples for '.*' event do not have ADDR attribute set. "
                    "Cannot print 'addr' field.");
       if (!NoData.match(ErrMsg))
-        return createStringError(inconvertibleErrorCode(), ErrMsg);
+        return E;
     }
     if (std::error_code EC = parseMemEvents())
       return errorCodeToError(EC);

--- a/bolt/test/perf2bolt/perf_test.test
+++ b/bolt/test/perf2bolt/perf_test.test
@@ -36,3 +36,7 @@ RUN:   --heatmap %t.hm2 2>&1 | FileCheck %s
 RUN: FileCheck %s --input-file %t.hm2-section-hotness.csv --check-prefix=CHECK-HM
 
 CHECK-HM: .text
+
+# Expect an error if the process did not match any PID in perf data
+RUN: not perf2bolt %t -p=%t2 -o %t.null --pid=99999 2>&1 | FileCheck %s --check-prefix=CHECK-PID
+CHECK-PID: PERF2BOLT-ERROR: could not find a profile matching PID "99999" for binary


### PR DESCRIPTION
1. In `filterBinaryMMapInfo`, replace `incovertibleErrorCode` with errc
   code as `parseMainEvents` converts returned Error to std::error_code.
2. In `parsePerfData`, pass through Error returned by `prepareToParse`
   for memory events.

Test Plan: updated perf_test.test
