### PR TITLE
[Bitstream] Use reportFatalInternalError for invalid encoding

### DIFF
--- a/llvm/include/llvm/Bitstream/BitCodes.h
+++ b/llvm/include/llvm/Bitstream/BitCodes.h
@@ -81,7 +81,7 @@ public:
     case Blob:
       return false;
     }
-    report_fatal_error("Invalid encoding");
+    reportFatalInternalError("Invalid encoding");
   }
 
   /// isChar6 - Return true if this character is legal in the Char6 encoding.


### PR DESCRIPTION
Migrate one report_fatal_error call site to the non-deprecated internal-error API. The fallthrough in BitCodeAbbrevOp::hasEncodingData is only reachable for an invalid Encoding value, so it represents an internal invariant failure rather than a usage error.

Part of #138914.