### PR TITLE
[SPIR-V] Don't lower metadata-argument intrinsics to functions

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVPrepareFunctions.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPrepareFunctions.cpp
@@ -28,6 +28,7 @@
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/CodeGen/IntrinsicLowering.h"
+#include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/Instructions.h"
@@ -117,6 +118,23 @@ static bool lowerIntrinsicToFunction(IntrinsicInst *Intrinsic,
   if (auto *MSI = dyn_cast<MemSetInst>(Intrinsic))
     if (isa<Constant>(MSI->getValue()) && isa<ConstantInt>(MSI->getLength()))
       return false; // It is handled later using OpCopyMemorySized.
+
+  // An intrinsic with a metadata argument has no SPIR-V lowering and can't be
+  // turned into a function.
+  for (Value *Arg : Intrinsic->args())
+    if (isa<MetadataAsValue>(Arg)) {
+      const Function *F = Intrinsic->getFunction();
+      F->getContext().diagnose(DiagnosticInfoUnsupported(
+          *F,
+          "cannot lower the intrinsic '" +
+              Intrinsic->getCalledFunction()->getName() +
+              "' that takes a metadata argument",
+          Intrinsic->getDebugLoc()));
+      if (!Intrinsic->getType()->isVoidTy())
+        Intrinsic->replaceAllUsesWith(PoisonValue::get(Intrinsic->getType()));
+      Intrinsic->eraseFromParent();
+      return true;
+    }
 
   Module *M = Intrinsic->getModule();
   std::string FuncName = lowerLLVMIntrinsicName(Intrinsic);
@@ -499,6 +517,11 @@ bool SPIRVPrepareFunctionsImpl::substituteIntrinsicCalls(Function *F) {
       case Intrinsic::experimental_constrained_fcmps:
         lowerConstrainedFPCmpIntrinsic(dyn_cast<ConstrainedFPCmpIntrinsic>(II),
                                        EraseFromParent);
+        Changed = true;
+        break;
+      case Intrinsic::experimental_noalias_scope_decl:
+        // Drop as there is no SPIR-V representation.
+        II->eraseFromParent();
         Changed = true;
         break;
       default:

--- a/llvm/lib/Target/SPIRV/SPIRVPrepareFunctions.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPrepareFunctions.cpp
@@ -121,20 +121,19 @@ static bool lowerIntrinsicToFunction(IntrinsicInst *Intrinsic,
 
   // An intrinsic with a metadata argument has no SPIR-V lowering and can't be
   // turned into a function.
-  for (Value *Arg : Intrinsic->args())
-    if (isa<MetadataAsValue>(Arg)) {
-      const Function *F = Intrinsic->getFunction();
-      F->getContext().diagnose(DiagnosticInfoUnsupported(
-          *F,
-          "cannot lower the intrinsic '" +
-              Intrinsic->getCalledFunction()->getName() +
-              "' that takes a metadata argument",
-          Intrinsic->getDebugLoc()));
-      if (!Intrinsic->getType()->isVoidTy())
-        Intrinsic->replaceAllUsesWith(PoisonValue::get(Intrinsic->getType()));
-      Intrinsic->eraseFromParent();
-      return true;
-    }
+  if (any_of(Intrinsic->args(), IsaPred<MetadataAsValue>)) {
+    const Function *F = Intrinsic->getFunction();
+    F->getContext().diagnose(DiagnosticInfoUnsupported(
+        *F,
+        "cannot lower the intrinsic '" +
+            Intrinsic->getCalledFunction()->getName() +
+            "' that takes a metadata argument",
+        Intrinsic->getDebugLoc()));
+    if (!Intrinsic->getType()->isVoidTy())
+      Intrinsic->replaceAllUsesWith(PoisonValue::get(Intrinsic->getType()));
+    Intrinsic->eraseFromParent();
+    return true;
+  }
 
   Module *M = Intrinsic->getModule();
   std::string FuncName = lowerLLVMIntrinsicName(Intrinsic);
@@ -519,12 +518,15 @@ bool SPIRVPrepareFunctionsImpl::substituteIntrinsicCalls(Function *F) {
                                        EraseFromParent);
         Changed = true;
         break;
-      case Intrinsic::experimental_noalias_scope_decl:
-        // Drop as there is no SPIR-V representation.
-        II->eraseFromParent();
-        Changed = true;
-        break;
       default:
+        // Drop assume-like intrinsics that have no SPIR-V representation.
+        if (II->isAssumeLikeIntrinsic()) {
+          if (!II->getType()->isVoidTy())
+            II->replaceAllUsesWith(PoisonValue::get(II->getType()));
+          II->eraseFromParent();
+          Changed = true;
+          break;
+        }
         if (TM.getTargetTriple().getVendor() == Triple::AMD ||
             any_of(SPVAllowUnknownIntrinsics, [II](auto &&Prefix) {
               if (Prefix.empty())

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/metadata-argument-intrinsic.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/metadata-argument-intrinsic.ll
@@ -1,0 +1,14 @@
+; RUN: not llc -O0 -mtriple=spirv64-unknown-unknown --spv-allow-unknown-intrinsics=llvm %s -o /dev/null 2>&1 | FileCheck %s
+; RUN: not llc -O0 -mtriple=spirv64-amd-amdhsa %s -o /dev/null 2>&1 | FileCheck %s
+
+; An intrinsic that takes a metadata argument has no SPIR-V representation and
+; can't be turned into a function call.
+
+; CHECK: cannot lower the intrinsic 'llvm.type.test' that takes a metadata argument
+
+define spir_func i1 @foo(ptr %p) {
+  %r = call i1 @llvm.type.test(ptr %p, metadata !"typeid")
+  ret i1 %r
+}
+
+declare i1 @llvm.type.test(ptr, metadata)

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/noalias-scope-decl.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/noalias-scope-decl.ll
@@ -1,0 +1,22 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown -verify-machineinstrs --spv-allow-unknown-intrinsics=llvm %s -o - | FileCheck %s
+; RUN: llc -O0 -mtriple=spirv64-amd-amdhsa -verify-machineinstrs %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; llvm.experimental.noalias.scope.decl carries a metadata argument and therefore
+; it can't be lowered to a function call. Check that it is dropped.
+
+; CHECK-NOT: OpFunctionCall
+; CHECK: OpStore
+
+define spir_kernel void @foo(ptr addrspace(4) %a) {
+entry:
+  call void @llvm.experimental.noalias.scope.decl(metadata !0)
+  store float 0.0, ptr addrspace(4) %a, align 4
+  ret void
+}
+
+declare void @llvm.experimental.noalias.scope.decl(metadata)
+
+!0 = !{!1}
+!1 = distinct !{!1, !2, !"foo: %a"}
+!2 = distinct !{!2, !"foo"}


### PR DESCRIPTION
llvm.experimental.noalias.scope.decl takes a metadata argument. When the SPIR-V backend lowered unknown intrinsics to functions (AMD vendor or --spv-allow-unknown-intrinsics), it emitted
@spirv.llvm_experimental_noalias_scope_decl(metadata ...), which fails the verifier: "Function has metadata parameter but isn't an intrinsic".

Therefore drop llvm.experimental.noalias.scope.decl, as it has no SPIR-V representation.