### PR TITLE
[CodeGen] Migrate report_fatal_error from CodeGen headers

### DIFF
--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -657,7 +657,7 @@ public:
   }
 
   virtual const MCExpr *lowerConstantPtrAuth(const ConstantPtrAuth &CPA) {
-    report_fatal_error("ptrauth constant lowering not implemented");
+    reportFatalUsageError("ptrauth constant lowering not implemented");
   }
 
   /// Lower the specified BlockAddress to an MCExpr.

--- a/llvm/include/llvm/CodeGen/GlobalISel/IRTranslator.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/IRTranslator.h
@@ -802,7 +802,7 @@ public:
   //     getMBB(bb)
   //     for each inst in bb
   //       if (!translate(MIRBuilder, inst, ValToVReg, ConstantToSequence))
-  //         report_fatal_error("Don't know how to translate input");
+  //         reportFatalUsageError("Don't know how to translate input");
   //   finalize()
   bool runOnMachineFunction(MachineFunction &MF) override;
 };

--- a/llvm/include/llvm/CodeGen/MachinePassManager.h
+++ b/llvm/include/llvm/CodeGen/MachinePassManager.h
@@ -53,7 +53,7 @@ public:
         errs() << "\nCurrent properties: ";
         MFProps.print(errs());
         errs() << '\n';
-        report_fatal_error("MachineFunctionProperties check failed");
+        reportFatalUsageError("MachineFunctionProperties check failed");
       }
     }
 #endif // NDEBUG

--- a/llvm/include/llvm/CodeGen/TargetFrameLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetFrameLowering.h
@@ -17,6 +17,7 @@
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineOptimizationRemarkEmitter.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/TypeSize.h"
 #include <vector>
 
@@ -402,7 +403,7 @@ public:
                                             RegScavenger *RS = nullptr) const {}
 
   virtual unsigned getWinEHParentFrameOffset(const MachineFunction &MF) const {
-    report_fatal_error("WinEH not implemented for this target");
+    reportFatalUsageError("WinEH not implemented for this target");
   }
 
   /// This method is called during prolog/epilog code insertion to eliminate

--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -2138,7 +2138,7 @@ public:
   }
 
   virtual bool needsFixedCatchObjects() const {
-    report_fatal_error("Funclet EH is not implemented for this target");
+    reportFatalUsageError("Funclet EH is not implemented for this target");
   }
 
   /// Return the minimum stack alignment of an argument.
@@ -5147,7 +5147,7 @@ public:
   /// so the default action is to bail.
   virtual Register getRegisterByName(const char* RegName, LLT Ty,
                                      const MachineFunction &MF) const {
-    report_fatal_error("Named registers not implemented for this target");
+    reportFatalUsageError("Named registers not implemented for this target");
   }
 
   /// Return the type that should be used to zero or sign extend a

--- a/llvm/lib/CodeGen/MachineFunctionPass.cpp
+++ b/llvm/lib/CodeGen/MachineFunctionPass.cpp
@@ -32,6 +32,7 @@
 #include "llvm/IR/Dominators.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Support/ErrorHandling.h"
 
 using namespace llvm;
 using namespace ore;
@@ -66,7 +67,7 @@ bool MachineFunctionPass::runOnFunction(Function &F) {
     errs() << "\nCurrent properties: ";
     MFProps.print(errs());
     errs() << "\n";
-    llvm_unreachable("MachineFunctionProperties check failed");
+    reportFatalUsageError("MachineFunctionProperties check failed");
   }
 #endif
   // Collect the MI count of the function before the pass.

--- a/llvm/test/CodeGen/AMDGPU/branch-folder-requires-no-phis.mir
+++ b/llvm/test/CodeGen/AMDGPU/branch-folder-requires-no-phis.mir
@@ -1,6 +1,6 @@
 # REQUIRES: asserts
 # RUN: not --crash llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -run-pass=branch-folder -filetype=null %s 2>&1 | FileCheck %s --check-prefixes=LEGACY-CHECK,CHECK
-# RUN: not --crash llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -passes="require<profile-summary>,function(machine-function(branch-folder<enable-tail-merge>))" -filetype=null %s 2>&1 | FileCheck %s --check-prefixes=NPM-CHECK,CHECK
+# RUN: not llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -passes="require<profile-summary>,function(machine-function(branch-folder<enable-tail-merge>))" -filetype=null %s 2>&1 | FileCheck %s --check-prefixes=NPM-CHECK,CHECK
 
 # BranchFolding breaks this function due to phis
 

--- a/llvm/test/CodeGen/AMDGPU/branch-folder-requires-no-phis.mir
+++ b/llvm/test/CodeGen/AMDGPU/branch-folder-requires-no-phis.mir
@@ -1,5 +1,5 @@
 # REQUIRES: asserts
-# RUN: not --crash llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -run-pass=branch-folder -filetype=null %s 2>&1 | FileCheck %s --check-prefixes=LEGACY-CHECK,CHECK
+# RUN: not llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -run-pass=branch-folder -filetype=null %s 2>&1 | FileCheck %s --check-prefixes=LEGACY-CHECK,CHECK
 # RUN: not llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -passes="require<profile-summary>,function(machine-function(branch-folder<enable-tail-merge>))" -filetype=null %s 2>&1 | FileCheck %s --check-prefixes=NPM-CHECK,CHECK
 
 # BranchFolding breaks this function due to phis

--- a/llvm/test/CodeGen/AMDGPU/machine-cse-ssa.mir
+++ b/llvm/test/CodeGen/AMDGPU/machine-cse-ssa.mir
@@ -1,6 +1,6 @@
 # REQUIRES: asserts
 # RUN: not --crash llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -run-pass=machine-cse -filetype=null %s 2>&1 | FileCheck -check-prefixes=ERR,ERR-LEGACY %s
-# RUN: not --crash llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -passes=machine-cse -filetype=null %s 2>&1 | FileCheck -check-prefixes=ERR,ERR-NPM %s
+# RUN: not llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -passes=machine-cse -filetype=null %s 2>&1 | FileCheck -check-prefixes=ERR,ERR-NPM %s
 
 # ERR-LEGACY: MachineFunctionProperties required by Machine Common Subexpression Elimination pass are not met by function not_ssa.
 # ERR-NPM: MachineFunctionProperties required by MachineCSEPass pass are not met by function not_ssa.

--- a/llvm/test/CodeGen/AMDGPU/machine-cse-ssa.mir
+++ b/llvm/test/CodeGen/AMDGPU/machine-cse-ssa.mir
@@ -1,5 +1,5 @@
 # REQUIRES: asserts
-# RUN: not --crash llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -run-pass=machine-cse -filetype=null %s 2>&1 | FileCheck -check-prefixes=ERR,ERR-LEGACY %s
+# RUN: not llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -run-pass=machine-cse -filetype=null %s 2>&1 | FileCheck -check-prefixes=ERR,ERR-LEGACY %s
 # RUN: not llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -passes=machine-cse -filetype=null %s 2>&1 | FileCheck -check-prefixes=ERR,ERR-NPM %s
 
 # ERR-LEGACY: MachineFunctionProperties required by Machine Common Subexpression Elimination pass are not met by function not_ssa.

--- a/llvm/test/CodeGen/AMDGPU/si-fold-operands-requires-ssa.mir
+++ b/llvm/test/CodeGen/AMDGPU/si-fold-operands-requires-ssa.mir
@@ -1,5 +1,5 @@
 # REQUIRES: asserts
-# RUN: not --crash llc -mtriple=amdgcn -mcpu=gfx900 -run-pass=si-fold-operands -filetype=null %s 2>&1 | FileCheck -check-prefixes=ERR-LEGACY,ERR %s
+# RUN: not llc -mtriple=amdgcn -mcpu=gfx900 -run-pass=si-fold-operands -filetype=null %s 2>&1 | FileCheck -check-prefixes=ERR-LEGACY,ERR %s
 # RUN: not llc -mtriple=amdgcn -mcpu=gfx900 -passes=si-fold-operands -filetype=null %s 2>&1 | FileCheck -check-prefixes=ERR-NPM,ERR %s
 
 # ERR-LEGACY: MachineFunctionProperties required by SI Fold Operands pass are not met by function not_ssa.

--- a/llvm/test/CodeGen/AMDGPU/si-fold-operands-requires-ssa.mir
+++ b/llvm/test/CodeGen/AMDGPU/si-fold-operands-requires-ssa.mir
@@ -1,6 +1,6 @@
 # REQUIRES: asserts
 # RUN: not --crash llc -mtriple=amdgcn -mcpu=gfx900 -run-pass=si-fold-operands -filetype=null %s 2>&1 | FileCheck -check-prefixes=ERR-LEGACY,ERR %s
-# RUN: not --crash llc -mtriple=amdgcn -mcpu=gfx900 -passes=si-fold-operands -filetype=null %s 2>&1 | FileCheck -check-prefixes=ERR-NPM,ERR %s
+# RUN: not llc -mtriple=amdgcn -mcpu=gfx900 -passes=si-fold-operands -filetype=null %s 2>&1 | FileCheck -check-prefixes=ERR-NPM,ERR %s
 
 # ERR-LEGACY: MachineFunctionProperties required by SI Fold Operands pass are not met by function not_ssa.
 # ERR-NPM: MachineFunctionProperties required by SIFoldOperandsPass pass are not met by function not_ssa.

--- a/llvm/test/CodeGen/MIR/AMDGPU/subreg-def-is-not-ssa.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/subreg-def-is-not-ssa.mir
@@ -1,5 +1,5 @@
 # REQUIRES: asserts
-# RUN: not --crash llc -mtriple=amdgcn -mcpu=gfx900 -run-pass=instruction-select -verify-machineinstrs -filetype=null %s 2>&1 | FileCheck %s
+# RUN: not llc -mtriple=amdgcn -mcpu=gfx900 -run-pass=instruction-select -verify-machineinstrs -filetype=null %s 2>&1 | FileCheck %s
 
 # CHECK: MachineFunctionProperties required by InstructionSelect pass are not met by function subreg_def_is_not_ssa.
 # CHECK-NEXT: Required properties: IsSSA

--- a/llvm/test/tools/llc/new-pm/machine-function-properties.mir
+++ b/llvm/test/tools/llc/new-pm/machine-function-properties.mir
@@ -1,5 +1,5 @@
 # REQUIRES: asserts
-# RUN: not --crash llc -mtriple=x86_64-pc-linux-gnu -passes=require-all-machine-function-properties -filetype=null %s 2>&1 | FileCheck %s
+# RUN: not llc -mtriple=x86_64-pc-linux-gnu -passes=require-all-machine-function-properties -filetype=null %s 2>&1 | FileCheck %s
 
 # CHECK: MachineFunctionProperties required by RequireAllMachineFunctionPropertiesPass pass are not met by function f.
 


### PR DESCRIPTION
Replace deprecated report_fatal_error references in llvm/include/llvm/CodeGen with reportFatalInternalError or reportFatalUsageError based on the failure category.

MachineFunctionProperties verification failures indicate an internal codegen pipeline invariant failure. Default target hooks for unsupported functionality use reportFatalUsageError. Also update stale pseudocode in IRTranslator.h.

Part of #138914.