### PR TITLE
[1/3][AMDGPU][NFC] Add virtual prefix to GCN trackers

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUNextUseAnalysis.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUNextUseAnalysis.cpp
@@ -2458,7 +2458,7 @@ void printNextUseDistancesAsJson(json::OStream &J, const MachineFunction &MF,
       UseDistancePair Furthest;
       UseDistancePair FurthestSubreg;
       RelevantUses.clear();
-      NUA.getNextUseDistances(RPTracker.getLiveRegs(), MI, Furthest,
+      NUA.getNextUseDistances(RPTracker.getVirtLiveRegs(), MI, Furthest,
                               &FurthestSubreg, &RelevantUses);
 
       J.objectBegin();

--- a/llvm/lib/Target/AMDGPU/GCNIterativeScheduler.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNIterativeScheduler.cpp
@@ -80,12 +80,12 @@ static void printLivenessInfo(raw_ostream &OS,
   auto *const BB = Begin->getParent();
   const auto &MRI = BB->getParent()->getRegInfo();
 
-  const auto LiveIns = getLiveRegsBefore(*Begin, *LIS);
-  OS << "LIn RP: " << print(getRegPressure(MRI, LiveIns));
+  const auto LiveIns = getVirtLiveRegsBefore(*Begin, *LIS);
+  OS << "LIn RP: " << print(getVirtRegPressure(MRI, LiveIns));
 
   const auto BottomMI = End == BB->end() ? std::prev(End) : End;
-  const auto LiveOuts = getLiveRegsAfter(*BottomMI, *LIS);
-  OS << "LOt RP: " << print(getRegPressure(MRI, LiveOuts));
+  const auto LiveOuts = getVirtLiveRegsAfter(*BottomMI, *LIS);
+  OS << "LOt RP: " << print(getVirtRegPressure(MRI, LiveOuts));
 }
 
 LLVM_DUMP_METHOD

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
@@ -559,7 +559,7 @@ void GCNRPTracker::reset(const MachineRegisterInfo &MRI, SlotIndex SI) {
   this->MRI = &MRI;
   LastTrackedMI = nullptr;
   VirtLiveRegs = llvm::getLiveRegs(SI, LIS, MRI);
-  MaxVirtPressure = CurVirtPressure = getRegPressure(MRI, VirtLiveRegs);
+  MaxPressure = CurPressure = getRegPressure(MRI, VirtLiveRegs);
 }
 
 void GCNRPTracker::reset(const MachineRegisterInfo &MRI,
@@ -568,7 +568,7 @@ void GCNRPTracker::reset(const MachineRegisterInfo &MRI,
   LastTrackedMI = nullptr;
   if (&this->VirtLiveRegs != &VirtLiveRegs)
     this->VirtLiveRegs = VirtLiveRegs;
-  MaxVirtPressure = CurVirtPressure = getRegPressure(MRI, VirtLiveRegs);
+  MaxPressure = CurPressure = getRegPressure(MRI, VirtLiveRegs);
 }
 
 /// Mostly copy/paste from CodeGen/RegisterPressure.cpp
@@ -616,16 +616,16 @@ void GCNUpwardRPTracker::recede(const MachineInstr &MI) {
     LaneBitmask &LiveMask = I->second;
     LaneBitmask PrevMask = LiveMask;
     LiveMask &= ~DefMask;
-    CurVirtPressure.inc(Reg, PrevMask, LiveMask, *MRI);
+    CurPressure.inc(Reg, PrevMask, LiveMask, *MRI);
     if (LiveMask.none())
       VirtLiveRegs.erase(I);
   }
 
-  // Update MaxVirtPressure with defs pressure.
-  DefPressure += CurVirtPressure;
+  // Update MaxPressure with defs pressure.
+  DefPressure += CurPressure;
   if (HasECDefs)
     DefPressure += ECDefPressure;
-  MaxVirtPressure = max(DefPressure, MaxVirtPressure);
+  MaxPressure = max(DefPressure, MaxPressure);
 
   // Make uses alive.
   SmallVector<VRegMaskOrUnit, 8> RegUses;
@@ -634,15 +634,14 @@ void GCNUpwardRPTracker::recede(const MachineInstr &MI) {
     LaneBitmask &LiveMask = VirtLiveRegs[U.VRegOrUnit.asVirtualReg()];
     LaneBitmask PrevMask = LiveMask;
     LiveMask |= U.LaneMask;
-    CurVirtPressure.inc(U.VRegOrUnit.asVirtualReg(), PrevMask, LiveMask, *MRI);
+    CurPressure.inc(U.VRegOrUnit.asVirtualReg(), PrevMask, LiveMask, *MRI);
   }
 
-  // Update MaxVirtPressure with uses plus early-clobber defs pressure.
-  MaxVirtPressure = HasECDefs
-                        ? max(CurVirtPressure + ECDefPressure, MaxVirtPressure)
-                        : max(CurVirtPressure, MaxVirtPressure);
+  // Update MaxPressure with uses plus early-clobber defs pressure.
+  MaxPressure = HasECDefs ? max(CurPressure + ECDefPressure, MaxPressure)
+                          : max(CurPressure, MaxPressure);
 
-  assert(CurVirtPressure == getRegPressure(*MRI, VirtLiveRegs));
+  assert(CurPressure == getRegPressure(*MRI, VirtLiveRegs));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -715,7 +714,7 @@ bool GCNDownwardRPTracker::advanceBeforeNext(MachineInstr *MI,
           }
           auto PrevMask = It->second;
           It->second &= ~S.LaneMask;
-          CurVirtPressure.inc(MO.getReg(), PrevMask, It->second, *MRI);
+          CurPressure.inc(MO.getReg(), PrevMask, It->second, *MRI);
         }
       }
       if (It != VirtLiveRegs.end() && It->second.none())
@@ -724,13 +723,12 @@ bool GCNDownwardRPTracker::advanceBeforeNext(MachineInstr *MI,
       auto It = VirtLiveRegs.find(MO.getReg());
       if (It == VirtLiveRegs.end())
         llvm_unreachable("register isn't live");
-      CurVirtPressure.inc(MO.getReg(), It->second, LaneBitmask::getNone(),
-                          *MRI);
+      CurPressure.inc(MO.getReg(), It->second, LaneBitmask::getNone(), *MRI);
       VirtLiveRegs.erase(It);
     }
   }
 
-  MaxVirtPressure = max(MaxVirtPressure, CurVirtPressure);
+  MaxPressure = max(MaxPressure, CurPressure);
 
   LastTrackedMI = nullptr;
 
@@ -756,10 +754,10 @@ void GCNDownwardRPTracker::advanceToNext(MachineInstr *MI,
     auto &LiveMask = VirtLiveRegs[Reg];
     auto PrevMask = LiveMask;
     LiveMask |= getDefRegMask(MO, *MRI);
-    CurVirtPressure.inc(Reg, PrevMask, LiveMask, *MRI);
+    CurPressure.inc(Reg, PrevMask, LiveMask, *MRI);
   }
 
-  MaxVirtPressure = max(MaxVirtPressure, CurVirtPressure);
+  MaxPressure = max(MaxPressure, CurPressure);
 }
 
 bool GCNDownwardRPTracker::advance(MachineInstr *MI, bool UseInternalIterator) {
@@ -845,7 +843,7 @@ GCNDownwardRPTracker::bumpDownwardPressure(const MachineInstr *MI,
   RegisterOperands RegOpers;
   RegOpers.collect(*MI, *TRI, *MRI, true, /*IgnoreDead=*/false);
   RegOpers.adjustLaneLiveness(LIS, *MRI, SlotIdx);
-  GCNRegPressure TempPressure = CurVirtPressure;
+  GCNRegPressure TempPressure = CurPressure;
   // Tracks the live mask reported by the use loop for redefined registers.
   SmallDenseMap<Register, LaneBitmask, 8> PostUseMask;
 
@@ -909,9 +907,9 @@ bool GCNUpwardRPTracker::isValid() const {
   }
 
   auto LISPressure = getRegPressure(*MRI, LISLR);
-  if (LISPressure != CurVirtPressure) {
+  if (LISPressure != CurPressure) {
     dbgs() << "GCNUpwardRPTracker error: Pressure sets different\nTracked: "
-           << print(CurVirtPressure) << "LIS rpt: " << print(LISPressure);
+           << print(CurPressure) << "LIS rpt: " << print(LISPressure);
     return false;
   }
   return true;
@@ -1104,7 +1102,7 @@ LLVM_DUMP_METHOD void llvm::dumpMaxRegPressure(MachineFunction &MF,
   const char *RegName = GCNRegPressure::getName(Kind);
 
   unsigned MaxNumRegs = 0;
-  const MachineInstr *MaxVirtPressureMI = nullptr;
+  const MachineInstr *MaxPressureMI = nullptr;
   GCNUpwardRPTracker RPT(LIS);
   for (const MachineBasicBlock &MBB : MF) {
     RPT.reset(MRI, LIS.getSlotIndexes()->getMBBEndIdx(&MBB).getPrevSlot());
@@ -1113,12 +1111,12 @@ LLVM_DUMP_METHOD void llvm::dumpMaxRegPressure(MachineFunction &MF,
       unsigned NumRegs = RPT.getMaxPressure().getNumRegs(Kind);
       if (NumRegs > MaxNumRegs) {
         MaxNumRegs = NumRegs;
-        MaxVirtPressureMI = &MI;
+        MaxPressureMI = &MI;
       }
     }
   }
 
-  SlotIndex MISlot = LIS.getInstructionIndex(*MaxVirtPressureMI);
+  SlotIndex MISlot = LIS.getInstructionIndex(*MaxPressureMI);
 
   // Max pressure can occur at either the early-clobber or register slot.
   // Choose the maximum liveset between both slots. This is ugly but this is
@@ -1131,7 +1129,7 @@ LLVM_DUMP_METHOD void llvm::dumpMaxRegPressure(MachineFunction &MF,
   unsigned RNumRegs = getRegPressure(MRI, RLiveSet).getNumRegs(Kind);
   GCNRPTracker::LiveRegSet *LiveSet =
       ECNumRegs > RNumRegs ? &ECLiveSet : &RLiveSet;
-  SlotIndex MaxVirtPressureSlot = ECNumRegs > RNumRegs ? ECSlot : RSlot;
+  SlotIndex MaxPressureSlot = ECNumRegs > RNumRegs ? ECSlot : RSlot;
   assert(getRegPressure(MRI, *LiveSet).getNumRegs(Kind) == MaxNumRegs);
 
   // Split live registers into single-def and multi-def sets.
@@ -1193,8 +1191,8 @@ LLVM_DUMP_METHOD void llvm::dumpMaxRegPressure(MachineFunction &MF,
   OS << "\n*** Register pressure info (" << RegName << "s) for " << MF.getName()
      << " ***\n";
   OS << "Max pressure is " << MaxNumRegs << ' ' << RegName << "s at "
-     << printLoc(MaxVirtPressureMI->getParent(), MaxVirtPressureSlot) << ": "
-     << *MaxVirtPressureMI;
+     << printLoc(MaxPressureMI->getParent(), MaxPressureSlot) << ": "
+     << *MaxPressureMI;
 
   OS << "\nLive registers with single definition (" << SDefNumRegs << ' '
      << RegName << "s):\n";

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
@@ -502,10 +502,10 @@ LaneBitmask llvm::getLiveLaneMask(const LiveInterval &LI, SlotIndex SI,
   return LiveMask;
 }
 
-GCNRPTracker::LiveRegSet llvm::getLiveRegs(SlotIndex SI,
-                                           const LiveIntervals &LIS,
-                                           const MachineRegisterInfo &MRI,
-                                           GCNRegPressure::RegKind RegKind) {
+GCNRPTracker::LiveRegSet
+llvm::getVirtLiveRegs(SlotIndex SI, const LiveIntervals &LIS,
+                      const MachineRegisterInfo &MRI,
+                      GCNRegPressure::RegKind RegKind) {
   GCNRPTracker::LiveRegSet VirtLiveRegs;
   for (unsigned I = 0, E = MRI.getNumVirtRegs(); I != E; ++I) {
     auto Reg = Register::index2VirtReg(I);
@@ -558,8 +558,8 @@ void GCNRPTracker::reset(const MachineBasicBlock &MBB, bool End) {
 void GCNRPTracker::reset(const MachineRegisterInfo &MRI, SlotIndex SI) {
   this->MRI = &MRI;
   LastTrackedMI = nullptr;
-  VirtLiveRegs = llvm::getLiveRegs(SI, LIS, MRI);
-  MaxPressure = CurPressure = getRegPressure(MRI, VirtLiveRegs);
+  VirtLiveRegs = llvm::getVirtLiveRegs(SI, LIS, MRI);
+  MaxPressure = CurPressure = getVirtRegPressure(MRI, VirtLiveRegs);
 }
 
 void GCNRPTracker::reset(const MachineRegisterInfo &MRI,
@@ -568,7 +568,7 @@ void GCNRPTracker::reset(const MachineRegisterInfo &MRI,
   LastTrackedMI = nullptr;
   if (&this->VirtLiveRegs != &VirtLiveRegs)
     this->VirtLiveRegs = VirtLiveRegs;
-  MaxPressure = CurPressure = getRegPressure(MRI, VirtLiveRegs);
+  MaxPressure = CurPressure = getVirtRegPressure(MRI, VirtLiveRegs);
 }
 
 /// Mostly copy/paste from CodeGen/RegisterPressure.cpp
@@ -641,7 +641,7 @@ void GCNUpwardRPTracker::recede(const MachineInstr &MI) {
   MaxPressure = HasECDefs ? max(CurPressure + ECDefPressure, MaxPressure)
                           : max(CurPressure, MaxPressure);
 
-  assert(CurPressure == getRegPressure(*MRI, VirtLiveRegs));
+  assert(CurPressure == getVirtRegPressure(*MRI, VirtLiveRegs));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -895,7 +895,7 @@ GCNDownwardRPTracker::bumpDownwardPressure(const MachineInstr *MI,
 
 bool GCNUpwardRPTracker::isValid() const {
   const auto &SI = LIS.getInstructionIndex(*LastTrackedMI).getBaseIndex();
-  const auto LISLR = llvm::getLiveRegs(SI, LIS, *MRI);
+  const auto LISLR = llvm::getVirtLiveRegs(SI, LIS, *MRI);
   const auto &TrackedLR = VirtLiveRegs;
 
   if (!isEqual(LISLR, TrackedLR)) {
@@ -906,7 +906,7 @@ bool GCNUpwardRPTracker::isValid() const {
     return false;
   }
 
-  auto LISPressure = getRegPressure(*MRI, LISLR);
+  auto LISPressure = getVirtRegPressure(*MRI, LISLR);
   if (LISPressure != CurPressure) {
     dbgs() << "GCNUpwardRPTracker error: Pressure sets different\nTracked: "
            << print(CurPressure) << "LIS rpt: " << print(LISPressure);
@@ -1010,18 +1010,18 @@ bool GCNRegPressurePrinter::runOnMachineFunction(MachineFunction &MF) {
     SlotIndex MBBStartSlot = LIS.getSlotIndexes()->getMBBStartIdx(&MBB);
     SlotIndex MBBLastSlot = LIS.getSlotIndexes()->getMBBLastIdx(&MBB);
 
-    GCNRPTracker::LiveRegSet LiveIn, LiveOut;
+    GCNRPTracker::LiveRegSet VirtLiveIn, VirtLiveOut;
     GCNRegPressure RPAtMBBEnd;
 
     if (UseDownwardTracker) {
       if (MBB.empty()) {
-        LiveIn = LiveOut = getLiveRegs(MBBStartSlot, LIS, MRI);
-        RPAtMBBEnd = getRegPressure(MRI, LiveIn);
+        VirtLiveIn = VirtLiveOut = getVirtLiveRegs(MBBStartSlot, LIS, MRI);
+        RPAtMBBEnd = getVirtRegPressure(MRI, VirtLiveIn);
       } else {
         GCNDownwardRPTracker RPT(LIS);
         RPT.reset(MBB.front(), MBB.end());
 
-        LiveIn = RPT.getLiveRegs();
+        VirtLiveIn = RPT.getVirtLiveRegs();
 
         while (!RPT.advanceBeforeNext()) {
           GCNRegPressure RPBeforeMI = RPT.getPressure();
@@ -1029,14 +1029,14 @@ bool GCNRegPressurePrinter::runOnMachineFunction(MachineFunction &MF) {
           RP.emplace_back(RPBeforeMI, RPT.getPressure());
         }
 
-        LiveOut = RPT.getLiveRegs();
+        VirtLiveOut = RPT.getVirtLiveRegs();
         RPAtMBBEnd = RPT.getPressure();
       }
     } else {
       GCNUpwardRPTracker RPT(LIS);
       RPT.reset(MRI, MBBLastSlot);
 
-      LiveOut = RPT.getLiveRegs();
+      VirtLiveOut = RPT.getVirtLiveRegs();
       RPAtMBBEnd = RPT.getPressure();
 
       for (auto &MI : reverse(MBB)) {
@@ -1046,12 +1046,13 @@ bool GCNRegPressurePrinter::runOnMachineFunction(MachineFunction &MF) {
           RP.emplace_back(RPT.getPressure(), RPT.getMaxPressure());
       }
 
-      LiveIn = RPT.getLiveRegs();
+      VirtLiveIn = RPT.getVirtLiveRegs();
     }
 
-    OS << PFX "  Live-in: " << llvm::print(LiveIn, MRI);
+    OS << PFX "  Live-in: " << llvm::print(VirtLiveIn, MRI);
     if (!UseDownwardTracker)
-      ReportLISMismatchIfAny(LiveIn, getLiveRegs(MBBStartSlot, LIS, MRI));
+      ReportLISMismatchIfAny(VirtLiveIn,
+                             getVirtLiveRegs(MBBStartSlot, LIS, MRI));
 
     OS << PFX "  SGPR  VGPR\n";
     int I = 0;
@@ -1067,13 +1068,14 @@ bool GCNRegPressurePrinter::runOnMachineFunction(MachineFunction &MF) {
     }
     OS << printRP(RPAtMBBEnd) << '\n';
 
-    OS << PFX "  Live-out:" << llvm::print(LiveOut, MRI);
+    OS << PFX "  Live-out:" << llvm::print(VirtLiveOut, MRI);
     if (UseDownwardTracker)
-      ReportLISMismatchIfAny(LiveOut, getLiveRegs(MBBLastSlot, LIS, MRI));
+      ReportLISMismatchIfAny(VirtLiveOut,
+                             getVirtLiveRegs(MBBLastSlot, LIS, MRI));
 
     GCNRPTracker::LiveRegSet LiveThrough;
-    for (auto [Reg, Mask] : LiveIn) {
-      LaneBitmask MaskIntersection = Mask & LiveOut.lookup(Reg);
+    for (auto [Reg, Mask] : VirtLiveIn) {
+      LaneBitmask MaskIntersection = Mask & VirtLiveOut.lookup(Reg);
       if (MaskIntersection.any()) {
         LaneBitmask LTMask = getRegLiveThroughMask(
             MRI, LIS, Reg, MBBStartSlot, MBBLastSlot, MaskIntersection);
@@ -1082,7 +1084,7 @@ bool GCNRegPressurePrinter::runOnMachineFunction(MachineFunction &MF) {
       }
     }
     OS << PFX "  Live-thr:" << llvm::print(LiveThrough, MRI);
-    OS << printRP(getRegPressure(MRI, LiveThrough)) << '\n';
+    OS << printRP(getVirtRegPressure(MRI, LiveThrough)) << '\n';
   }
   OS << "...\n";
   return false;
@@ -1123,14 +1125,14 @@ LLVM_DUMP_METHOD void llvm::dumpMaxRegPressure(MachineFunction &MF,
   // diagnostic code.
   SlotIndex ECSlot = MISlot.getRegSlot(true);
   SlotIndex RSlot = MISlot.getRegSlot(false);
-  GCNRPTracker::LiveRegSet ECLiveSet = getLiveRegs(ECSlot, LIS, MRI, Kind);
-  GCNRPTracker::LiveRegSet RLiveSet = getLiveRegs(RSlot, LIS, MRI, Kind);
-  unsigned ECNumRegs = getRegPressure(MRI, ECLiveSet).getNumRegs(Kind);
-  unsigned RNumRegs = getRegPressure(MRI, RLiveSet).getNumRegs(Kind);
+  GCNRPTracker::LiveRegSet ECLiveSet = getVirtLiveRegs(ECSlot, LIS, MRI, Kind);
+  GCNRPTracker::LiveRegSet RLiveSet = getVirtLiveRegs(RSlot, LIS, MRI, Kind);
+  unsigned ECNumRegs = getVirtRegPressure(MRI, ECLiveSet).getNumRegs(Kind);
+  unsigned RNumRegs = getVirtRegPressure(MRI, RLiveSet).getNumRegs(Kind);
   GCNRPTracker::LiveRegSet *LiveSet =
       ECNumRegs > RNumRegs ? &ECLiveSet : &RLiveSet;
   SlotIndex MaxPressureSlot = ECNumRegs > RNumRegs ? ECSlot : RSlot;
-  assert(getRegPressure(MRI, *LiveSet).getNumRegs(Kind) == MaxNumRegs);
+  assert(getVirtRegPressure(MRI, *LiveSet).getNumRegs(Kind) == MaxNumRegs);
 
   // Split live registers into single-def and multi-def sets.
   GCNRegPressure SDefPressure, MDefPressure;

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
@@ -506,7 +506,7 @@ GCNRPTracker::LiveRegSet llvm::getLiveRegs(SlotIndex SI,
                                            const LiveIntervals &LIS,
                                            const MachineRegisterInfo &MRI,
                                            GCNRegPressure::RegKind RegKind) {
-  GCNRPTracker::LiveRegSet LiveRegs;
+  GCNRPTracker::LiveRegSet VirtLiveRegs;
   for (unsigned I = 0, E = MRI.getNumVirtRegs(); I != E; ++I) {
     auto Reg = Register::index2VirtReg(I);
     if (RegKind != GCNRegPressure::TOTAL_KINDS &&
@@ -516,9 +516,9 @@ GCNRPTracker::LiveRegSet llvm::getLiveRegs(SlotIndex SI,
       continue;
     auto LiveMask = getLiveLaneMask(Reg, SI, LIS, MRI);
     if (LiveMask.any())
-      LiveRegs[Reg] = LiveMask;
+      VirtLiveRegs[Reg] = LiveMask;
   }
-  return LiveRegs;
+  return VirtLiveRegs;
 }
 
 void GCNRPTracker::reset(const MachineInstr &MI, bool After) {
@@ -558,17 +558,17 @@ void GCNRPTracker::reset(const MachineBasicBlock &MBB, bool End) {
 void GCNRPTracker::reset(const MachineRegisterInfo &MRI, SlotIndex SI) {
   this->MRI = &MRI;
   LastTrackedMI = nullptr;
-  LiveRegs = llvm::getLiveRegs(SI, LIS, MRI);
-  MaxPressure = CurPressure = getRegPressure(MRI, LiveRegs);
+  VirtLiveRegs = llvm::getLiveRegs(SI, LIS, MRI);
+  MaxVirtPressure = CurVirtPressure = getRegPressure(MRI, VirtLiveRegs);
 }
 
 void GCNRPTracker::reset(const MachineRegisterInfo &MRI,
-                         const LiveRegSet &LiveRegs) {
+                         const LiveRegSet &VirtLiveRegs) {
   this->MRI = &MRI;
   LastTrackedMI = nullptr;
-  if (&this->LiveRegs != &LiveRegs)
-    this->LiveRegs = LiveRegs;
-  MaxPressure = CurPressure = getRegPressure(MRI, LiveRegs);
+  if (&this->VirtLiveRegs != &VirtLiveRegs)
+    this->VirtLiveRegs = VirtLiveRegs;
+  MaxVirtPressure = CurVirtPressure = getRegPressure(MRI, VirtLiveRegs);
 }
 
 /// Mostly copy/paste from CodeGen/RegisterPressure.cpp
@@ -609,39 +609,40 @@ void GCNUpwardRPTracker::recede(const MachineInstr &MI) {
     } else
       DefPressure.inc(Reg, LaneBitmask::getNone(), DefMask, *MRI);
 
-    auto I = LiveRegs.find(Reg);
-    if (I == LiveRegs.end())
+    auto I = VirtLiveRegs.find(Reg);
+    if (I == VirtLiveRegs.end())
       continue;
 
     LaneBitmask &LiveMask = I->second;
     LaneBitmask PrevMask = LiveMask;
     LiveMask &= ~DefMask;
-    CurPressure.inc(Reg, PrevMask, LiveMask, *MRI);
+    CurVirtPressure.inc(Reg, PrevMask, LiveMask, *MRI);
     if (LiveMask.none())
-      LiveRegs.erase(I);
+      VirtLiveRegs.erase(I);
   }
 
-  // Update MaxPressure with defs pressure.
-  DefPressure += CurPressure;
+  // Update MaxVirtPressure with defs pressure.
+  DefPressure += CurVirtPressure;
   if (HasECDefs)
     DefPressure += ECDefPressure;
-  MaxPressure = max(DefPressure, MaxPressure);
+  MaxVirtPressure = max(DefPressure, MaxVirtPressure);
 
   // Make uses alive.
   SmallVector<VRegMaskOrUnit, 8> RegUses;
   collectVirtualRegUses(RegUses, MI, LIS, *MRI);
   for (const VRegMaskOrUnit &U : RegUses) {
-    LaneBitmask &LiveMask = LiveRegs[U.VRegOrUnit.asVirtualReg()];
+    LaneBitmask &LiveMask = VirtLiveRegs[U.VRegOrUnit.asVirtualReg()];
     LaneBitmask PrevMask = LiveMask;
     LiveMask |= U.LaneMask;
-    CurPressure.inc(U.VRegOrUnit.asVirtualReg(), PrevMask, LiveMask, *MRI);
+    CurVirtPressure.inc(U.VRegOrUnit.asVirtualReg(), PrevMask, LiveMask, *MRI);
   }
 
-  // Update MaxPressure with uses plus early-clobber defs pressure.
-  MaxPressure = HasECDefs ? max(CurPressure + ECDefPressure, MaxPressure)
-                          : max(CurPressure, MaxPressure);
+  // Update MaxVirtPressure with uses plus early-clobber defs pressure.
+  MaxVirtPressure = HasECDefs
+                        ? max(CurVirtPressure + ECDefPressure, MaxVirtPressure)
+                        : max(CurVirtPressure, MaxVirtPressure);
 
-  assert(CurPressure == getRegPressure(*MRI, LiveRegs));
+  assert(CurVirtPressure == getRegPressure(*MRI, VirtLiveRegs));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -649,7 +650,7 @@ void GCNUpwardRPTracker::recede(const MachineInstr &MI) {
 
 bool GCNDownwardRPTracker::reset(const MachineInstr &MI,
                                  MachineBasicBlock::const_iterator End,
-                                 const LiveRegSet *LiveRegsCopy) {
+                                 const LiveRegSet *VirtLiveRegsCopy) {
   MBBEnd = MI.getParent()->end();
   assert(End == MBBEnd ||
          End->getParent()->end() == MBBEnd && "end unrelated to MI block");
@@ -660,8 +661,8 @@ bool GCNDownwardRPTracker::reset(const MachineInstr &MI,
   // Otherwise the first non-debug instruction after the provided one (or the
   // end of the block, if no such instruction exists) serves as the basis to
   // compute a live register set.
-  if (LiveRegsCopy)
-    GCNRPTracker::reset(MI.getMF()->getRegInfo(), *LiveRegsCopy);
+  if (VirtLiveRegsCopy)
+    GCNRPTracker::reset(MI.getMF()->getRegInfo(), *VirtLiveRegsCopy);
   else if (NextMI != MBBEnd)
     GCNRPTracker::reset(*NextMI, /*After=*/false);
   else
@@ -704,31 +705,32 @@ bool GCNDownwardRPTracker::advanceBeforeNext(MachineInstr *MI,
       continue;
     const LiveInterval &LI = LIS.getInterval(MO.getReg());
     if (LI.hasSubRanges()) {
-      auto It = LiveRegs.end();
+      auto It = VirtLiveRegs.end();
       for (const auto &S : LI.subranges()) {
         if (!S.liveAt(SI)) {
-          if (It == LiveRegs.end()) {
-            It = LiveRegs.find(MO.getReg());
-            if (It == LiveRegs.end())
+          if (It == VirtLiveRegs.end()) {
+            It = VirtLiveRegs.find(MO.getReg());
+            if (It == VirtLiveRegs.end())
               llvm_unreachable("register isn't live");
           }
           auto PrevMask = It->second;
           It->second &= ~S.LaneMask;
-          CurPressure.inc(MO.getReg(), PrevMask, It->second, *MRI);
+          CurVirtPressure.inc(MO.getReg(), PrevMask, It->second, *MRI);
         }
       }
-      if (It != LiveRegs.end() && It->second.none())
-        LiveRegs.erase(It);
+      if (It != VirtLiveRegs.end() && It->second.none())
+        VirtLiveRegs.erase(It);
     } else if (!LI.liveAt(SI)) {
-      auto It = LiveRegs.find(MO.getReg());
-      if (It == LiveRegs.end())
+      auto It = VirtLiveRegs.find(MO.getReg());
+      if (It == VirtLiveRegs.end())
         llvm_unreachable("register isn't live");
-      CurPressure.inc(MO.getReg(), It->second, LaneBitmask::getNone(), *MRI);
-      LiveRegs.erase(It);
+      CurVirtPressure.inc(MO.getReg(), It->second, LaneBitmask::getNone(),
+                          *MRI);
+      VirtLiveRegs.erase(It);
     }
   }
 
-  MaxPressure = max(MaxPressure, CurPressure);
+  MaxVirtPressure = max(MaxVirtPressure, CurVirtPressure);
 
   LastTrackedMI = nullptr;
 
@@ -751,13 +753,13 @@ void GCNDownwardRPTracker::advanceToNext(MachineInstr *MI,
     Register Reg = MO.getReg();
     if (!Reg.isVirtual())
       continue;
-    auto &LiveMask = LiveRegs[Reg];
+    auto &LiveMask = VirtLiveRegs[Reg];
     auto PrevMask = LiveMask;
     LiveMask |= getDefRegMask(MO, *MRI);
-    CurPressure.inc(Reg, PrevMask, LiveMask, *MRI);
+    CurVirtPressure.inc(Reg, PrevMask, LiveMask, *MRI);
   }
 
-  MaxPressure = max(MaxPressure, CurPressure);
+  MaxVirtPressure = max(MaxVirtPressure, CurVirtPressure);
 }
 
 bool GCNDownwardRPTracker::advance(MachineInstr *MI, bool UseInternalIterator) {
@@ -788,8 +790,8 @@ bool GCNDownwardRPTracker::advance(MachineBasicBlock::const_iterator End) {
 
 bool GCNDownwardRPTracker::advance(MachineBasicBlock::const_iterator Begin,
                                    MachineBasicBlock::const_iterator End,
-                                   const LiveRegSet *LiveRegsCopy) {
-  if (!reset(*Begin, End, LiveRegsCopy))
+                                   const LiveRegSet *VirtLiveRegsCopy) {
+  if (!reset(*Begin, End, VirtLiveRegsCopy))
     return false;
   return advance(End);
 }
@@ -843,7 +845,7 @@ GCNDownwardRPTracker::bumpDownwardPressure(const MachineInstr *MI,
   RegisterOperands RegOpers;
   RegOpers.collect(*MI, *TRI, *MRI, true, /*IgnoreDead=*/false);
   RegOpers.adjustLaneLiveness(LIS, *MRI, SlotIdx);
-  GCNRegPressure TempPressure = CurPressure;
+  GCNRegPressure TempPressure = CurVirtPressure;
   // Tracks the live mask reported by the use loop for redefined registers.
   SmallDenseMap<Register, LaneBitmask, 8> PostUseMask;
 
@@ -864,8 +866,9 @@ GCNDownwardRPTracker::bumpDownwardPressure(const MachineInstr *MI,
     if (LastUseMask.none())
       continue;
 
-    auto It = LiveRegs.find(Reg);
-    LaneBitmask LiveMask = It != LiveRegs.end() ? It->second : LaneBitmask(0);
+    auto It = VirtLiveRegs.find(Reg);
+    LaneBitmask LiveMask =
+        It != VirtLiveRegs.end() ? It->second : LaneBitmask(0);
     LaneBitmask NewMask = LiveMask & ~LastUseMask;
     PostUseMask[Reg] = NewMask;
     TempPressure.inc(Reg, LiveMask, NewMask, *MRI);
@@ -881,8 +884,8 @@ GCNDownwardRPTracker::bumpDownwardPressure(const MachineInstr *MI,
     if (PostIt != PostUseMask.end()) {
       LiveMask = PostIt->second;
     } else {
-      auto It = LiveRegs.find(Reg);
-      LiveMask = It != LiveRegs.end() ? It->second : LaneBitmask(0);
+      auto It = VirtLiveRegs.find(Reg);
+      LiveMask = It != VirtLiveRegs.end() ? It->second : LaneBitmask(0);
     }
 
     LaneBitmask NewMask = LiveMask | Def.LaneMask;
@@ -895,7 +898,7 @@ GCNDownwardRPTracker::bumpDownwardPressure(const MachineInstr *MI,
 bool GCNUpwardRPTracker::isValid() const {
   const auto &SI = LIS.getInstructionIndex(*LastTrackedMI).getBaseIndex();
   const auto LISLR = llvm::getLiveRegs(SI, LIS, *MRI);
-  const auto &TrackedLR = LiveRegs;
+  const auto &TrackedLR = VirtLiveRegs;
 
   if (!isEqual(LISLR, TrackedLR)) {
     dbgs() << "\nGCNUpwardRPTracker error: Tracked and"
@@ -906,22 +909,22 @@ bool GCNUpwardRPTracker::isValid() const {
   }
 
   auto LISPressure = getRegPressure(*MRI, LISLR);
-  if (LISPressure != CurPressure) {
+  if (LISPressure != CurVirtPressure) {
     dbgs() << "GCNUpwardRPTracker error: Pressure sets different\nTracked: "
-           << print(CurPressure) << "LIS rpt: " << print(LISPressure);
+           << print(CurVirtPressure) << "LIS rpt: " << print(LISPressure);
     return false;
   }
   return true;
 }
 
-Printable llvm::print(const GCNRPTracker::LiveRegSet &LiveRegs,
+Printable llvm::print(const GCNRPTracker::LiveRegSet &VirtLiveRegs,
                       const MachineRegisterInfo &MRI) {
-  return Printable([&LiveRegs, &MRI](raw_ostream &OS) {
+  return Printable([&VirtLiveRegs, &MRI](raw_ostream &OS) {
     const TargetRegisterInfo *TRI = MRI.getTargetRegisterInfo();
     for (unsigned I = 0, E = MRI.getNumVirtRegs(); I != E; ++I) {
       Register Reg = Register::index2VirtReg(I);
-      auto It = LiveRegs.find(Reg);
-      if (It != LiveRegs.end() && It->second.any())
+      auto It = VirtLiveRegs.find(Reg);
+      if (It != VirtLiveRegs.end() && It->second.any())
         OS << ' ' << printReg(Reg, TRI) << ':' << PrintLaneMask(It->second);
     }
     OS << '\n';
@@ -1101,7 +1104,7 @@ LLVM_DUMP_METHOD void llvm::dumpMaxRegPressure(MachineFunction &MF,
   const char *RegName = GCNRegPressure::getName(Kind);
 
   unsigned MaxNumRegs = 0;
-  const MachineInstr *MaxPressureMI = nullptr;
+  const MachineInstr *MaxVirtPressureMI = nullptr;
   GCNUpwardRPTracker RPT(LIS);
   for (const MachineBasicBlock &MBB : MF) {
     RPT.reset(MRI, LIS.getSlotIndexes()->getMBBEndIdx(&MBB).getPrevSlot());
@@ -1110,12 +1113,12 @@ LLVM_DUMP_METHOD void llvm::dumpMaxRegPressure(MachineFunction &MF,
       unsigned NumRegs = RPT.getMaxPressure().getNumRegs(Kind);
       if (NumRegs > MaxNumRegs) {
         MaxNumRegs = NumRegs;
-        MaxPressureMI = &MI;
+        MaxVirtPressureMI = &MI;
       }
     }
   }
 
-  SlotIndex MISlot = LIS.getInstructionIndex(*MaxPressureMI);
+  SlotIndex MISlot = LIS.getInstructionIndex(*MaxVirtPressureMI);
 
   // Max pressure can occur at either the early-clobber or register slot.
   // Choose the maximum liveset between both slots. This is ugly but this is
@@ -1128,7 +1131,7 @@ LLVM_DUMP_METHOD void llvm::dumpMaxRegPressure(MachineFunction &MF,
   unsigned RNumRegs = getRegPressure(MRI, RLiveSet).getNumRegs(Kind);
   GCNRPTracker::LiveRegSet *LiveSet =
       ECNumRegs > RNumRegs ? &ECLiveSet : &RLiveSet;
-  SlotIndex MaxPressureSlot = ECNumRegs > RNumRegs ? ECSlot : RSlot;
+  SlotIndex MaxVirtPressureSlot = ECNumRegs > RNumRegs ? ECSlot : RSlot;
   assert(getRegPressure(MRI, *LiveSet).getNumRegs(Kind) == MaxNumRegs);
 
   // Split live registers into single-def and multi-def sets.
@@ -1190,8 +1193,8 @@ LLVM_DUMP_METHOD void llvm::dumpMaxRegPressure(MachineFunction &MF,
   OS << "\n*** Register pressure info (" << RegName << "s) for " << MF.getName()
      << " ***\n";
   OS << "Max pressure is " << MaxNumRegs << ' ' << RegName << "s at "
-     << printLoc(MaxPressureMI->getParent(), MaxPressureSlot) << ": "
-     << *MaxPressureMI;
+     << printLoc(MaxVirtPressureMI->getParent(), MaxVirtPressureSlot) << ": "
+     << *MaxVirtPressureMI;
 
   OS << "\nLive registers with single definition (" << SDefNumRegs << ' '
      << RegName << "s):\n";

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.h
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.h
@@ -325,7 +325,7 @@ public:
 protected:
   const LiveIntervals &LIS;
   LiveRegSet VirtLiveRegs;
-  GCNRegPressure CurVirtPressure, MaxVirtPressure;
+  GCNRegPressure CurPressure, MaxPressure;
   const MachineInstr *LastTrackedMI = nullptr;
   mutable const MachineRegisterInfo *MRI = nullptr;
 
@@ -354,9 +354,9 @@ public:
   const decltype(VirtLiveRegs) &getLiveRegs() const { return VirtLiveRegs; }
   const MachineInstr *getLastTrackedMI() const { return LastTrackedMI; }
 
-  void clearMaxPressure() { MaxVirtPressure.clear(); }
+  void clearMaxPressure() { MaxPressure.clear(); }
 
-  GCNRegPressure getPressure() const { return CurVirtPressure; }
+  GCNRegPressure getPressure() const { return CurPressure; }
 
   decltype(VirtLiveRegs) moveLiveRegs() { return std::move(VirtLiveRegs); }
 };
@@ -388,12 +388,12 @@ public:
   /// to reported by LIS.
   bool isValid() const;
 
-  const GCNRegPressure &getMaxPressure() const { return MaxVirtPressure; }
+  const GCNRegPressure &getMaxPressure() const { return MaxPressure; }
 
-  void resetMaxPressure() { MaxVirtPressure = CurVirtPressure; }
+  void resetMaxPressure() { MaxPressure = CurPressure; }
 
   GCNRegPressure getMaxPressureAndReset() {
-    GCNRegPressure RP = MaxVirtPressure;
+    GCNRegPressure RP = MaxPressure;
     resetMaxPressure();
     return RP;
   }
@@ -417,8 +417,8 @@ public:
 
   /// \p return MaxPressure and clear it.
   GCNRegPressure moveMaxPressure() {
-    auto Res = MaxVirtPressure;
-    MaxVirtPressure.clear();
+    auto Res = MaxPressure;
+    MaxPressure.clear();
     return Res;
   }
 
@@ -472,7 +472,7 @@ public:
                const LiveRegSet *VirtLiveRegsCopy = nullptr);
 
   /// Mostly copy/paste from CodeGen/RegisterPressure.cpp
-  /// Calculate the impact \p MI will have on CurVirtPressure and \return the
+  /// Calculate the impact \p MI will have on CurPressure and \return the
   /// speculated pressure. In order to support RP Speculation, this does not
   /// rely on the implicit program ordering in the LiveIntervals.
   GCNRegPressure bumpDownwardPressure(const MachineInstr *MI,

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.h
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.h
@@ -351,20 +351,20 @@ public:
   void reset(const MachineRegisterInfo &MRI, const LiveRegSet &VirtLiveRegs);
 
   // live regs for the current state
-  const decltype(VirtLiveRegs) &getLiveRegs() const { return VirtLiveRegs; }
+  const decltype(VirtLiveRegs) &getVirtLiveRegs() const { return VirtLiveRegs; }
   const MachineInstr *getLastTrackedMI() const { return LastTrackedMI; }
 
   void clearMaxPressure() { MaxPressure.clear(); }
 
   GCNRegPressure getPressure() const { return CurPressure; }
 
-  decltype(VirtLiveRegs) moveLiveRegs() { return std::move(VirtLiveRegs); }
+  decltype(VirtLiveRegs) moveVirtLiveRegs() { return std::move(VirtLiveRegs); }
 };
 
 GCNRPTracker::LiveRegSet
-getLiveRegs(SlotIndex SI, const LiveIntervals &LIS,
-            const MachineRegisterInfo &MRI,
-            GCNRegPressure::RegKind RegKind = GCNRegPressure::TOTAL_KINDS);
+getVirtLiveRegs(SlotIndex SI, const LiveIntervals &LIS,
+                const MachineRegisterInfo &MRI,
+                GCNRegPressure::RegKind RegKind = GCNRegPressure::TOTAL_KINDS);
 
 ////////////////////////////////////////////////////////////////////////////////
 // GCNUpwardRPTracker
@@ -498,8 +498,8 @@ LaneBitmask getLiveLaneMask(const LiveInterval &LI, SlotIndex SI,
 /// Note: there is no entry in the map for instructions with empty live reg set
 /// Complexity = O(NumVirtRegs * averageLiveRangeSegmentsPerReg * lg(R))
 template <typename Range>
-DenseMap<MachineInstr*, GCNRPTracker::LiveRegSet>
-getLiveRegMap(Range &&R, bool After, LiveIntervals &LIS) {
+DenseMap<MachineInstr *, GCNRPTracker::LiveRegSet>
+getVirtLiveRegMap(Range &&R, bool After, LiveIntervals &LIS) {
   std::vector<SlotIndex> Indexes;
   Indexes.reserve(llvm::size(R));
   auto &SII = *LIS.getSlotIndexes();
@@ -536,21 +536,21 @@ getLiveRegMap(Range &&R, bool After, LiveIntervals &LIS) {
   return LiveRegMap;
 }
 
-inline GCNRPTracker::LiveRegSet getLiveRegsAfter(const MachineInstr &MI,
-                                                 const LiveIntervals &LIS) {
-  return getLiveRegs(LIS.getInstructionIndex(MI).getDeadSlot(), LIS,
-                     MI.getMF()->getRegInfo());
+inline GCNRPTracker::LiveRegSet getVirtLiveRegsAfter(const MachineInstr &MI,
+                                                     const LiveIntervals &LIS) {
+  return getVirtLiveRegs(LIS.getInstructionIndex(MI).getDeadSlot(), LIS,
+                         MI.getMF()->getRegInfo());
 }
 
-inline GCNRPTracker::LiveRegSet getLiveRegsBefore(const MachineInstr &MI,
-                                                  const LiveIntervals &LIS) {
-  return getLiveRegs(LIS.getInstructionIndex(MI).getBaseIndex(), LIS,
-                     MI.getMF()->getRegInfo());
+inline GCNRPTracker::LiveRegSet
+getVirtLiveRegsBefore(const MachineInstr &MI, const LiveIntervals &LIS) {
+  return getVirtLiveRegs(LIS.getInstructionIndex(MI).getBaseIndex(), LIS,
+                         MI.getMF()->getRegInfo());
 }
 
 template <typename Range>
-GCNRegPressure getRegPressure(const MachineRegisterInfo &MRI,
-                              Range &&LiveRegs) {
+GCNRegPressure getVirtRegPressure(const MachineRegisterInfo &MRI,
+                                  Range &&LiveRegs) {
   GCNRegPressure Res;
   for (const auto &RM : LiveRegs)
     Res.inc(RM.first, LaneBitmask::getNone(), RM.second, MRI);

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.h
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.h
@@ -324,8 +324,8 @@ public:
 
 protected:
   const LiveIntervals &LIS;
-  LiveRegSet LiveRegs;
-  GCNRegPressure CurPressure, MaxPressure;
+  LiveRegSet VirtLiveRegs;
+  GCNRegPressure CurVirtPressure, MaxVirtPressure;
   const MachineInstr *LastTrackedMI = nullptr;
   mutable const MachineRegisterInfo *MRI = nullptr;
 
@@ -347,20 +347,18 @@ protected:
   LaneBitmask getLastUsedLanes(Register Reg, SlotIndex Pos) const;
 
 public:
-  /// Resets tracker with the provided \p LiveRegs.
-  void reset(const MachineRegisterInfo &MRI, const LiveRegSet &LiveRegs);
+  /// Resets tracker with the provided \p VirtLiveRegs.
+  void reset(const MachineRegisterInfo &MRI, const LiveRegSet &VirtLiveRegs);
 
   // live regs for the current state
-  const decltype(LiveRegs) &getLiveRegs() const { return LiveRegs; }
+  const decltype(VirtLiveRegs) &getLiveRegs() const { return VirtLiveRegs; }
   const MachineInstr *getLastTrackedMI() const { return LastTrackedMI; }
 
-  void clearMaxPressure() { MaxPressure.clear(); }
+  void clearMaxPressure() { MaxVirtPressure.clear(); }
 
-  GCNRegPressure getPressure() const { return CurPressure; }
+  GCNRegPressure getPressure() const { return CurVirtPressure; }
 
-  decltype(LiveRegs) moveLiveRegs() {
-    return std::move(LiveRegs);
-  }
+  decltype(VirtLiveRegs) moveLiveRegs() { return std::move(VirtLiveRegs); }
 };
 
 GCNRPTracker::LiveRegSet
@@ -373,7 +371,7 @@ getLiveRegs(SlotIndex SI, const LiveIntervals &LIS,
 
 class GCNUpwardRPTracker : public GCNRPTracker {
 public:
-  GCNUpwardRPTracker(const LiveIntervals &LIS_) : GCNRPTracker(LIS_) {}
+  GCNUpwardRPTracker(const LiveIntervals &LIS) : GCNRPTracker(LIS) {}
 
   using GCNRPTracker::reset;
 
@@ -390,12 +388,12 @@ public:
   /// to reported by LIS.
   bool isValid() const;
 
-  const GCNRegPressure &getMaxPressure() const { return MaxPressure; }
+  const GCNRegPressure &getMaxPressure() const { return MaxVirtPressure; }
 
-  void resetMaxPressure() { MaxPressure = CurPressure; }
+  void resetMaxPressure() { MaxVirtPressure = CurVirtPressure; }
 
   GCNRegPressure getMaxPressureAndReset() {
-    GCNRegPressure RP = MaxPressure;
+    GCNRegPressure RP = MaxVirtPressure;
     resetMaxPressure();
     return RP;
   }
@@ -419,17 +417,17 @@ public:
 
   /// \p return MaxPressure and clear it.
   GCNRegPressure moveMaxPressure() {
-    auto Res = MaxPressure;
-    MaxPressure.clear();
+    auto Res = MaxVirtPressure;
+    MaxVirtPressure.clear();
     return Res;
   }
 
-  /// Reset tracker to the point before the \p MI filling \p LiveRegs upon this
-  /// point using LIS. \p End must be between the MI and the end of its parent
-  /// block (inclusive). \p returns false if the range [MI, End) is empty except
-  /// debug values.
+  /// Reset tracker to the point before the \p MI filling \p VirtLiveRegs upon
+  /// this point using LIS. \p End must be between the MI and the end of its
+  /// parent block (inclusive). \p returns false if the range [MI, End) is empty
+  /// except debug values.
   bool reset(const MachineInstr &MI, MachineBasicBlock::const_iterator End,
-             const LiveRegSet *LiveRegs = nullptr);
+             const LiveRegSet *VirtLiveRegs = nullptr);
 
   /// Move to the state right before the next MI or after the end of MBB.
   /// \p returns false if reached end of the block.
@@ -471,10 +469,10 @@ public:
   /// empty except debug values.
   bool advance(MachineBasicBlock::const_iterator Begin,
                MachineBasicBlock::const_iterator End,
-               const LiveRegSet *LiveRegsCopy = nullptr);
+               const LiveRegSet *VirtLiveRegsCopy = nullptr);
 
   /// Mostly copy/paste from CodeGen/RegisterPressure.cpp
-  /// Calculate the impact \p MI will have on CurPressure and \return the
+  /// Calculate the impact \p MI will have on CurVirtPressure and \return the
   /// speculated pressure. In order to support RP Speculation, this does not
   /// rely on the implicit program ordering in the LiveIntervals.
   GCNRegPressure bumpDownwardPressure(const MachineInstr *MI,
@@ -565,7 +563,7 @@ bool isEqual(const GCNRPTracker::LiveRegSet &S1,
 Printable print(const GCNRegPressure &RP, const GCNSubtarget *ST = nullptr,
                 unsigned DynamicVGPRBlockSize = 0);
 
-Printable print(const GCNRPTracker::LiveRegSet &LiveRegs,
+Printable print(const GCNRPTracker::LiveRegSet &VirtLiveRegs,
                 const MachineRegisterInfo &MRI);
 
 Printable reportMismatch(const GCNRPTracker::LiveRegSet &LISLR,

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -3203,10 +3203,10 @@ void PreRARematStage::finalizeGCNSchedStage() {
     return;
 
   // Revert re-scheduling in all affected regions.
-  for (const auto &[RegionIdx, OrigMIOrder, MaxVirtPressure] : RegionReverts) {
+  for (const auto &[RegionIdx, OrigMIOrder, MaxPressure] : RegionReverts) {
     REMAT_DEBUG(dbgs() << "Reverting re-scheduling in region " << RegionIdx
                        << '\n');
-    DAG.Pressure[RegionIdx] = MaxVirtPressure;
+    DAG.Pressure[RegionIdx] = MaxPressure;
     modifyRegionSchedule(RegionIdx, OrigMIOrder);
   }
 

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -3203,10 +3203,10 @@ void PreRARematStage::finalizeGCNSchedStage() {
     return;
 
   // Revert re-scheduling in all affected regions.
-  for (const auto &[RegionIdx, OrigMIOrder, MaxPressure] : RegionReverts) {
+  for (const auto &[RegionIdx, OrigMIOrder, MaxVirtPressure] : RegionReverts) {
     REMAT_DEBUG(dbgs() << "Reverting re-scheduling in region " << RegionIdx
                        << '\n');
-    DAG.Pressure[RegionIdx] = MaxPressure;
+    DAG.Pressure[RegionIdx] = MaxVirtPressure;
     modifyRegionSchedule(RegionIdx, OrigMIOrder);
   }
 

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -1022,7 +1022,7 @@ GCNScheduleDAGMILive::GCNScheduleDAGMILive(
     : ScheduleDAGMILive(C, std::move(S)), ST(MF.getSubtarget<GCNSubtarget>()),
       MFI(*MF.getInfo<SIMachineFunctionInfo>()),
       StartingOccupancy(MFI.getOccupancy()), MinOccupancy(StartingOccupancy),
-      RegionLiveOuts(this, /*IsLiveOut=*/true) {
+      RegionVirtLiveOuts(this, /*IsLiveOut=*/true) {
 
   // We want regions with a single MI to be scheduled so that we can reason
   // about them correctly during scheduling stages that move MIs between regions
@@ -1069,10 +1069,10 @@ void GCNScheduleDAGMILive::schedule() {
 GCNRegPressure
 GCNScheduleDAGMILive::getRealRegPressure(unsigned RegionIdx) const {
   if (Regions[RegionIdx].first == Regions[RegionIdx].second)
-    return llvm::getRegPressure(MRI, LiveIns[RegionIdx]);
+    return llvm::getVirtRegPressure(MRI, VirtLiveIns[RegionIdx]);
   GCNDownwardRPTracker RPTracker(*LIS);
   RPTracker.advance(Regions[RegionIdx].first, Regions[RegionIdx].second,
-                    &LiveIns[RegionIdx]);
+                    &VirtLiveIns[RegionIdx]);
   return RPTracker.moveMaxPressure();
 }
 
@@ -1112,27 +1112,27 @@ void GCNScheduleDAGMILive::computeBlockPressure(unsigned RegionIdx,
   --CurRegion;
 
   auto I = MBB->begin();
-  auto LiveInIt = MBBLiveIns.find(MBB);
+  auto VirtLiveInIt = MBBVirtLiveIns.find(MBB);
   auto &Rgn = Regions[CurRegion];
   auto *NonDbgMI = &*skipDebugInstructionsForward(Rgn.first, Rgn.second);
-  if (LiveInIt != MBBLiveIns.end()) {
-    auto LiveIn = std::move(LiveInIt->second);
-    RPTracker.reset(*MBB->begin(), MBB->end(), &LiveIn);
-    MBBLiveIns.erase(LiveInIt);
+  if (VirtLiveInIt != MBBVirtLiveIns.end()) {
+    auto VirtLiveIn = std::move(VirtLiveInIt->second);
+    RPTracker.reset(*MBB->begin(), MBB->end(), &VirtLiveIn);
+    MBBVirtLiveIns.erase(VirtLiveInIt);
   } else {
     I = Rgn.first;
-    auto LRS = BBLiveInMap.lookup(NonDbgMI);
+    auto VirtLiveInSet = BBVirtLiveInMap.lookup(NonDbgMI);
 #ifdef EXPENSIVE_CHECKS
-    assert(isEqual(getLiveRegsBefore(*NonDbgMI, *LIS), LRS));
+    assert(isEqual(getVirtLiveRegsBefore(*NonDbgMI, *LIS), VirtLiveInSet));
 #endif
-    RPTracker.reset(*I, I->getParent()->end(), &LRS);
+    RPTracker.reset(*I, I->getParent()->end(), &VirtLiveInSet);
   }
 
   for (;;) {
     I = RPTracker.getNext();
 
     if (Regions[CurRegion].first == I || NonDbgMI == I) {
-      LiveIns[CurRegion] = RPTracker.getLiveRegs();
+      VirtLiveIns[CurRegion] = RPTracker.getVirtLiveRegs();
       RPTracker.clearMaxPressure();
     }
 
@@ -1153,12 +1153,12 @@ void GCNScheduleDAGMILive::computeBlockPressure(unsigned RegionIdx,
       RPTracker.advanceToNext();
       RPTracker.advance(MBB->end());
     }
-    MBBLiveIns[OnlySucc] = RPTracker.moveLiveRegs();
+    MBBVirtLiveIns[OnlySucc] = RPTracker.moveVirtLiveRegs();
   }
 }
 
 DenseMap<MachineInstr *, GCNRPTracker::LiveRegSet>
-GCNScheduleDAGMILive::getRegionLiveInMap() const {
+GCNScheduleDAGMILive::getRegionVirtLiveInMap() const {
   assert(!Regions.empty());
   std::vector<MachineInstr *> RegionFirstMIs;
   RegionFirstMIs.reserve(Regions.size());
@@ -1166,11 +1166,11 @@ GCNScheduleDAGMILive::getRegionLiveInMap() const {
     RegionFirstMIs.push_back(
         &*skipDebugInstructionsForward(RegionBegin, RegionEnd));
 
-  return getLiveRegMap(RegionFirstMIs, /*After=*/false, *LIS);
+  return getVirtLiveRegMap(RegionFirstMIs, /*After=*/false, *LIS);
 }
 
 DenseMap<MachineInstr *, GCNRPTracker::LiveRegSet>
-GCNScheduleDAGMILive::getRegionLiveOutMap() const {
+GCNScheduleDAGMILive::getRegionVirtLiveOutMap() const {
   assert(!Regions.empty());
   std::vector<MachineInstr *> RegionLastMIs;
   RegionLastMIs.reserve(Regions.size());
@@ -1180,14 +1180,14 @@ GCNScheduleDAGMILive::getRegionLiveOutMap() const {
       continue;
     RegionLastMIs.push_back(getLastMIForRegion(RegionBegin, RegionEnd));
   }
-  return getLiveRegMap(RegionLastMIs, /*After=*/true, *LIS);
+  return getVirtLiveRegMap(RegionLastMIs, /*After=*/true, *LIS);
 }
 
-void RegionPressureMap::buildLiveRegMap() {
+void RegionPressureMap::buildVirtLiveRegMap() {
   IdxToInstruction.clear();
 
-  RegionLiveRegMap =
-      IsLiveOut ? DAG->getRegionLiveOutMap() : DAG->getRegionLiveInMap();
+  RegionVirtLiveRegMap = IsLiveOut ? DAG->getRegionVirtLiveOutMap()
+                                   : DAG->getRegionVirtLiveInMap();
   for (unsigned I = 0; I < DAG->Regions.size(); I++) {
     auto &[RegionBegin, RegionEnd] = DAG->Regions[I];
     // Skip empty regions.
@@ -1203,7 +1203,7 @@ void GCNScheduleDAGMILive::finalizeSchedule() {
   // Start actual scheduling here. This function is called by the base
   // MachineScheduler after all regions have been recorded by
   // GCNScheduleDAGMILive::schedule().
-  LiveIns.resize(Regions.size());
+  VirtLiveIns.resize(Regions.size());
   Pressure.resize(Regions.size());
   RegionsWithHighRP.resize(Regions.size());
   RegionsWithExcessRP.resize(Regions.size());
@@ -1220,9 +1220,9 @@ void GCNScheduleDAGMILive::runSchedStages() {
 
   GCNSchedStrategy &S = static_cast<GCNSchedStrategy &>(*SchedImpl);
   if (!Regions.empty()) {
-    BBLiveInMap = getRegionLiveInMap();
+    BBVirtLiveInMap = getRegionVirtLiveInMap();
     if (S.useGCNTrackers())
-      RegionLiveOuts.buildLiveRegMap();
+      RegionVirtLiveOuts.buildVirtLiveRegMap();
   }
 
 #ifdef DUMP_MAX_REG_PRESSURE
@@ -1250,9 +1250,9 @@ void GCNScheduleDAGMILive::runSchedStages() {
 
       if (S.useGCNTrackers()) {
         const unsigned RegionIdx = Stage->getRegionIdx();
-        S.getDownwardTracker()->reset(MRI, LiveIns[RegionIdx]);
+        S.getDownwardTracker()->reset(MRI, VirtLiveIns[RegionIdx]);
         S.getUpwardTracker()->reset(
-            MRI, RegionLiveOuts.getLiveRegsForRegionIdx(RegionIdx));
+            MRI, RegionVirtLiveOuts.getVirtLiveRegsForRegionIdx(RegionIdx));
       }
 
       ScheduleDAGMILive::schedule();
@@ -1481,9 +1481,9 @@ Printable PreRARematStage::ScoredRemat::print() const {
 #endif
 
 bool PreRARematStage::initGCNSchedStage() {
-  // FIXME: This pass will invalidate cached BBLiveInMap and MBBLiveIns for
-  // regions inbetween the defs and region we sinked the def to. Will need to be
-  // fixed if there is another pass after this pass.
+  // FIXME: This pass will invalidate cached BBVirtLiveInMap and MBBVirtLiveIns
+  // for regions inbetween the defs and region we sinked the def to. Will need
+  // to be fixed if there is another pass after this pass.
   assert(!S.hasNextStage());
 
   if (!GCNSchedStage::initGCNSchedStage() || DAG.Regions.size() <= 1)
@@ -1524,7 +1524,7 @@ bool PreRARematStage::initGCNSchedStage() {
 
   // We need up-to-date live-out info. to query live-out register masks in
   // regions containing rematerializable instructions.
-  DAG.RegionLiveOuts.buildLiveRegMap();
+  DAG.RegionVirtLiveOuts.buildVirtLiveRegMap();
 
   if (!Remater.analyze()) {
     REMAT_DEBUG(dbgs() << "No rematerializable registers\n");
@@ -1675,7 +1675,7 @@ bool PreRARematStage::initGCNSchedStage() {
             LM = DAG.TRI->getSubRegIndexLaneMask(MO.getSubReg());
 
           const unsigned UseRegion = Reg.Uses.begin()->first;
-          LaneBitmask LiveInMask = DAG.LiveIns[UseRegion].at(UseReg);
+          LaneBitmask LiveInMask = DAG.VirtLiveIns[UseRegion].at(UseReg);
           LaneBitmask UncoveredLanes = LM & ~(LiveInMask & LM);
           // If this register has lanes not covered by the LiveIns, be sure they
           // do not map to any subrange. ref:
@@ -1833,12 +1833,12 @@ bool GCNSchedStage::initGCNRegion() {
 
   PressureBefore = DAG.Pressure[RegionIdx];
 
-  LLVM_DEBUG(
-      dbgs() << "Pressure before scheduling:\nRegion live-ins:"
-             << print(DAG.LiveIns[RegionIdx], DAG.MRI)
-             << "Region live-in pressure:  "
-             << print(llvm::getRegPressure(DAG.MRI, DAG.LiveIns[RegionIdx]))
-             << "Region register pressure: " << print(PressureBefore));
+  LLVM_DEBUG(dbgs() << "Pressure before scheduling:\nRegion live-ins:"
+                    << print(DAG.VirtLiveIns[RegionIdx], DAG.MRI)
+                    << "Region live-in pressure:  "
+                    << print(llvm::getVirtRegPressure(
+                           DAG.MRI, DAG.VirtLiveIns[RegionIdx]))
+                    << "Region register pressure: " << print(PressureBefore));
 
   S.HasHighPressure = false;
   S.KnownExcessRP = isRegionWithExcessRP();
@@ -2962,11 +2962,12 @@ bool RewriteMFMAFormStage::rewrite(
   // Bulk update the LIS.
   DAG.LIS->reanalyze(DAG.MF);
   // Liveins may have been modified for cross RC copies
-  RegionPressureMap LiveInUpdater(&DAG, false);
-  LiveInUpdater.buildLiveRegMap();
+  RegionPressureMap VirtLiveInUpdater(&DAG, false);
+  VirtLiveInUpdater.buildVirtLiveRegMap();
 
   for (unsigned Region = 0; Region < DAG.Regions.size(); Region++)
-    DAG.LiveIns[Region] = LiveInUpdater.getLiveRegsForRegionIdx(Region);
+    DAG.VirtLiveIns[Region] =
+        VirtLiveInUpdater.getVirtLiveRegsForRegionIdx(Region);
 
   DAG.Pressure[RegionIdx] = DAG.getRealRegPressure(RegionIdx);
 
@@ -3072,9 +3073,9 @@ void PreRARematStage::ScoredRemat::init(RegisterIdx RegIdx,
 
   // Mark regions in which the rematerializable register is live.
   for (unsigned I = 0, E = NumRegions; I != E; ++I) {
-    if (DAG.LiveIns[I].contains(DefReg))
+    if (DAG.VirtLiveIns[I].contains(DefReg))
       LiveIn.set(I);
-    if (DAG.RegionLiveOuts.getLiveRegsForRegionIdx(I).contains(DefReg))
+    if (DAG.RegionVirtLiveOuts.getVirtLiveRegsForRegionIdx(I).contains(DefReg))
       LiveOut.set(I);
 
     // If the register is both unused and live-through in the region, the
@@ -3173,9 +3174,9 @@ void PreRARematStage::removeFromLiveMaps(Register Reg, const BitVector &LiveIn,
   assert(LiveIn.size() == DAG.Regions.size() &&
          LiveOut.size() == DAG.Regions.size() && "region num mismatch");
   for (unsigned I : LiveIn.set_bits())
-    DAG.LiveIns[I].erase(Reg);
+    DAG.VirtLiveIns[I].erase(Reg);
   for (unsigned I : LiveOut.set_bits())
-    DAG.RegionLiveOuts.getLiveRegsForRegionIdx(I).erase(Reg);
+    DAG.RegionVirtLiveOuts.getVirtLiveRegsForRegionIdx(I).erase(Reg);
 }
 
 void PreRARematStage::addToLiveMaps(Register Reg, LaneBitmask Mask,
@@ -3185,9 +3186,9 @@ void PreRARematStage::addToLiveMaps(Register Reg, LaneBitmask Mask,
          LiveOut.size() == DAG.Regions.size() && "region num mismatch");
   std::pair<Register, LaneBitmask> LiveReg(Reg, Mask);
   for (unsigned I : LiveIn.set_bits())
-    DAG.LiveIns[I].insert(LiveReg);
+    DAG.VirtLiveIns[I].insert(LiveReg);
   for (unsigned I : LiveOut.set_bits())
-    DAG.RegionLiveOuts.getLiveRegsForRegionIdx(I).insert(LiveReg);
+    DAG.RegionVirtLiveOuts.getVirtLiveRegsForRegionIdx(I).insert(LiveReg);
 }
 
 void PreRARematStage::finalizeGCNSchedStage() {

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
@@ -716,12 +716,12 @@ private:
     /// Original instruction order (both debug and non-debug MIs).
     std::vector<MachineInstr *> OrigMIOrder;
     /// Maximum pressure recorded in the region.
-    GCNRegPressure MaxVirtPressure;
+    GCNRegPressure MaxPressure;
 
     RegionSchedRevert(unsigned RegionIdx, ArrayRef<MachineInstr *> OrigMIOrder,
-                      const GCNRegPressure &MaxVirtPressure)
+                      const GCNRegPressure &MaxPressure)
         : RegionIdx(RegionIdx), OrigMIOrder(OrigMIOrder),
-          MaxVirtPressure(MaxVirtPressure) {}
+          MaxPressure(MaxPressure) {}
   };
   /// After re-scheduling, contains pre-re-scheduling data for all re-scheduled
   /// regions.

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
@@ -716,12 +716,12 @@ private:
     /// Original instruction order (both debug and non-debug MIs).
     std::vector<MachineInstr *> OrigMIOrder;
     /// Maximum pressure recorded in the region.
-    GCNRegPressure MaxPressure;
+    GCNRegPressure MaxVirtPressure;
 
     RegionSchedRevert(unsigned RegionIdx, ArrayRef<MachineInstr *> OrigMIOrder,
-                      const GCNRegPressure &MaxPressure)
+                      const GCNRegPressure &MaxVirtPressure)
         : RegionIdx(RegionIdx), OrigMIOrder(OrigMIOrder),
-          MaxPressure(MaxPressure) {}
+          MaxVirtPressure(MaxVirtPressure) {}
   };
   /// After re-scheduling, contains pre-re-scheduling data for all re-scheduled
   /// regions.

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
@@ -231,7 +231,7 @@ class RegionPressureMap {
   GCNScheduleDAGMILive *DAG;
   // The live in/out pressure as indexed by the first or last MI in the region
   // before scheduling.
-  DenseMap<MachineInstr *, GCNRPTracker::LiveRegSet> RegionLiveRegMap;
+  DenseMap<MachineInstr *, GCNRPTracker::LiveRegSet> RegionVirtLiveRegMap;
   // The mapping of RegionIDx to key instruction
   DenseMap<unsigned, MachineInstr *> IdxToInstruction;
   // Whether we are calculating LiveOuts or LiveIns
@@ -242,13 +242,13 @@ public:
   RegionPressureMap(GCNScheduleDAGMILive *GCNDAG, bool LiveOut)
       : DAG(GCNDAG), IsLiveOut(LiveOut) {}
   // Build the Instr->LiveReg and RegionIdx->Instr maps
-  void buildLiveRegMap();
+  void buildVirtLiveRegMap();
 
   // Retrieve the LiveReg for a given RegionIdx
-  GCNRPTracker::LiveRegSet &getLiveRegsForRegionIdx(unsigned RegionIdx) {
+  GCNRPTracker::LiveRegSet &getVirtLiveRegsForRegionIdx(unsigned RegionIdx) {
     assert(IdxToInstruction.contains(RegionIdx));
     MachineInstr *Key = IdxToInstruction[RegionIdx];
-    return RegionLiveRegMap[Key];
+    return RegionVirtLiveRegMap[Key];
   }
 };
 
@@ -291,30 +291,31 @@ class GCNScheduleDAGMILive final : public ScheduleDAGMILive {
   BitVector RegionsWithIGLPInstrs;
 
   // Region live-in cache.
-  SmallVector<GCNRPTracker::LiveRegSet, 32> LiveIns;
+  SmallVector<GCNRPTracker::LiveRegSet, 32> VirtLiveIns;
 
   // Region pressure cache.
   SmallVector<GCNRegPressure, 32> Pressure;
 
   // Temporary basic block live-in cache.
-  DenseMap<const MachineBasicBlock *, GCNRPTracker::LiveRegSet> MBBLiveIns;
+  DenseMap<const MachineBasicBlock *, GCNRPTracker::LiveRegSet> MBBVirtLiveIns;
 
   // The map of the initial first region instruction to region live in registers
-  DenseMap<MachineInstr *, GCNRPTracker::LiveRegSet> BBLiveInMap;
+  DenseMap<MachineInstr *, GCNRPTracker::LiveRegSet> BBVirtLiveInMap;
 
   // Calculate the map of the initial first region instruction to region live in
   // registers
-  DenseMap<MachineInstr *, GCNRPTracker::LiveRegSet> getRegionLiveInMap() const;
+  DenseMap<MachineInstr *, GCNRPTracker::LiveRegSet>
+  getRegionVirtLiveInMap() const;
 
   // Calculate the map of the initial last region instruction to region live out
   // registers
   DenseMap<MachineInstr *, GCNRPTracker::LiveRegSet>
-  getRegionLiveOutMap() const;
+  getRegionVirtLiveOutMap() const;
 
   // The live out registers per region. These are internally stored as a map of
   // the initial last region instruction to region live out registers, but can
-  // be retreived with the regionIdx by calls to getLiveRegsForRegionIdx.
-  RegionPressureMap RegionLiveOuts;
+  // be retreived with the regionIdx by calls to getVirtLiveRegsForRegionIdx.
+  RegionPressureMap RegionVirtLiveOuts;
 
   // Return current region pressure.
   GCNRegPressure getRealRegPressure(unsigned RegionIdx) const;

--- a/llvm/lib/Target/AMDGPU/SIFormMemoryClauses.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFormMemoryClauses.cpp
@@ -296,7 +296,7 @@ bool SIFormMemoryClausesImpl::run(MachineFunction &MF) {
         RPT.advanceBeforeNext();
       }
 
-      const GCNRPTracker::LiveRegSet LiveRegsCopy(RPT.getLiveRegs());
+      const GCNRPTracker::LiveRegSet LiveRegsCopy(RPT.getVirtLiveRegs());
       RegUse Defs, Uses;
       if (!processRegUses(MI, Defs, Uses, RPT)) {
         RPT.reset(MI, MBB.end(), &LiveRegsCopy);

--- a/llvm/unittests/Target/AMDGPU/GCNRegPressureTest.cpp
+++ b/llvm/unittests/Target/AMDGPU/GCNRegPressureTest.cpp
@@ -56,8 +56,8 @@ body:             |
   MachineBasicBlock &MBB0 = *MF.getBlockNumbered(0);
   MachineBasicBlock &MBB1 = *MF.getBlockNumbered(1);
   GCNRPTracker::LiveRegSet MBB1LiveIns =
-      getLiveRegs(LIS.getInstructionIndex(*MBB0.rbegin()).getDeadSlot(), LIS,
-                  MF.getRegInfo());
+      getVirtLiveRegs(LIS.getInstructionIndex(*MBB0.rbegin()).getDeadSlot(),
+                      LIS, MF.getRegInfo());
 
   // Track pressure across MBB1.
   {
@@ -124,8 +124,8 @@ body:             |
   // MBB1 live-in pressure is equivalent to MBB0 live-out pressure.
   MachineBasicBlock &MBB0 = *MF.getBlockNumbered(0);
   GCNRPTracker::LiveRegSet MBB1LiveIns =
-      getLiveRegs(LIS.getInstructionIndex(*MBB0.rbegin()).getDeadSlot(), LIS,
-                  MF.getRegInfo());
+      getVirtLiveRegs(LIS.getInstructionIndex(*MBB0.rbegin()).getDeadSlot(),
+                      LIS, MF.getRegInfo());
 
   MachineBasicBlock &MBB1 = *MF.getBlockNumbered(1);
   GCNDownwardRPTracker RPTracker(LIS), RPTrackerNoLiveIns(LIS);


### PR DESCRIPTION
The renames are to clarify that these fields capture virtual register attributes and are in preparation for physical register support.

Replaces https://github.com/llvm/llvm-project/pull/183673.