### PR TITLE
[clang][bytecode] Use `isSignedType()` in `pushInteger`

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -113,7 +113,7 @@ static void pushInteger(InterpState &S, const APSInt &Val, QualType QT) {
     return;
   }
 
-  if (QT->isSignedIntegerOrEnumerationType()) {
+  if (isSignedType(*T)) {
     int64_t V = Val.getSExtValue();
     INT_TYPE_SWITCH(*T, { S.Stk.push<T>(T::from(V)); });
   } else {


### PR DESCRIPTION
We need to classify here anyway, so use the information from the primtype.