### PR TITLE
[clang][bytecode] Add an `ExplicitThisParam` flag to `Function`

### DIFF
--- a/clang/lib/AST/ByteCode/Function.cpp
+++ b/clang/lib/AST/ByteCode/Function.cpp
@@ -29,12 +29,15 @@ Function::Function(Program &P, FunctionDeclTy Source, unsigned ArgSize,
     Constexpr = F->isConstexpr();
     if (const auto *CD = dyn_cast<CXXConstructorDecl>(F)) {
       Virtual = CD->isVirtual();
+      ExplicitThisPointer = CD->isExplicitObjectMemberFunction();
       Kind = CD->isCopyOrMoveConstructor() ? FunctionKind::CopyOrMoveCtor
                                            : FunctionKind::Ctor;
     } else if (const auto *CD = dyn_cast<CXXDestructorDecl>(F)) {
+      ExplicitThisPointer = CD->isExplicitObjectMemberFunction();
       Virtual = CD->isVirtual();
       Kind = FunctionKind::Dtor;
     } else if (const auto *MD = dyn_cast<CXXMethodDecl>(F)) {
+      ExplicitThisPointer = MD->isExplicitObjectMemberFunction();
       Virtual = MD->isVirtual();
       if (IsLambdaStaticInvoker)
         Kind = FunctionKind::LambdaStaticInvoker;
@@ -43,9 +46,11 @@ Function::Function(Program &P, FunctionDeclTy Source, unsigned ArgSize,
       else if (MD->isCopyAssignmentOperator() || MD->isMoveAssignmentOperator())
         Kind = FunctionKind::CopyOrMoveOperator;
     } else {
+      ExplicitThisPointer = false;
       Virtual = false;
     }
   } else {
+    ExplicitThisPointer = false;
     Variadic = false;
     Virtual = false;
     Immediate = false;

--- a/clang/lib/AST/ByteCode/Function.h
+++ b/clang/lib/AST/ByteCode/Function.h
@@ -224,6 +224,10 @@ public:
   bool isFullyCompiled() const { return IsFullyCompiled; }
 
   bool hasThisPointer() const { return HasThisPointer; }
+  bool isThisPointerExplicit() const { return ExplicitThisPointer; }
+  bool hasImplicitThisParam() const {
+    return hasThisPointer() && !ExplicitThisPointer;
+  }
 
   /// Checks if the function already has a body attached.
   bool hasBody() const { return HasBody; }
@@ -232,7 +236,6 @@ public:
   bool isDefined() const { return Defined; }
 
   bool isVariadic() const { return Variadic; }
-
   unsigned getNumParams() const {
     return ParamDescriptors.size() + hasThisPointer() + hasRVO();
   }
@@ -245,17 +248,6 @@ public:
   }
   unsigned getWrittenArgSize() const {
     return ArgSize - (align(primSize(PT_Ptr)) * (hasThisPointer() + hasRVO()));
-  }
-
-  bool isThisPointerExplicit() const {
-    if (const auto *MD = dyn_cast_if_present<CXXMethodDecl>(
-            dyn_cast<const FunctionDecl *>(Source)))
-      return MD->isExplicitObjectMemberFunction();
-    return false;
-  }
-
-  bool hasImplicitThisParam() const {
-    return hasThisPointer() && !isThisPointerExplicit();
   }
 
 private:
@@ -315,6 +307,8 @@ private:
   /// as the first implicit argument
   LLVM_PREFERRED_TYPE(bool)
   unsigned HasThisPointer : 1;
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned ExplicitThisPointer : 1;
   /// Whether this function has Return Value Optimization, i.e.
   /// the return value is constructed in the caller's stack frame.
   /// This is done for functions that return non-primive values.


### PR DESCRIPTION
We unfortunately have to check this for every function call, so don't consult the decl every time here.