### PR TITLE
[orc-rt] Add ORC_RT_C_NOTHROW and apply it to the Error C API.

### DIFF
--- a/orc-rt/include/orc-rt-c/Compiler.h
+++ b/orc-rt/include/orc-rt-c/Compiler.h
@@ -48,4 +48,13 @@
 #define ORC_RT_C_ABI
 #endif
 
+/* ORC_RT_C_NOTHROW indicates that a function won't throw a C++ exception. */
+#if defined(__cplusplus)
+#define ORC_RT_C_NOTHROW noexcept
+#elif defined(__GNUC__) || defined(__clang__)
+#define ORC_RT_C_NOTHROW __attribute__((nothrow))
+#else
+#define ORC_RT_C_NOTHROW
+#endif
+
 #endif /* ORC_RT_C_COMPILER_H */

--- a/orc-rt/include/orc-rt-c/Error.h
+++ b/orc-rt/include/orc-rt-c/Error.h
@@ -32,7 +32,8 @@ typedef const void *orc_rt_Error_TypeId;
  * Returns the type id for the given error instance, which must be a failure
  * value (i.e. non-null).
  */
-ORC_RT_C_ABI orc_rt_Error_TypeId orc_rt_Error_getTypeId(orc_rt_ErrorRef Err);
+ORC_RT_C_ABI orc_rt_Error_TypeId orc_rt_Error_getTypeId(orc_rt_ErrorRef Err)
+    ORC_RT_C_NOTHROW;
 
 /**
  * Dispose of the given error without handling it. This operation consumes the
@@ -41,7 +42,7 @@ ORC_RT_C_ABI orc_rt_Error_TypeId orc_rt_Error_getTypeId(orc_rt_ErrorRef Err);
  * Note: This method *only* needs to be called if the error is not being passed
  * to some other consuming operation, e.g. LLVMGetErrorMessage.
  */
-ORC_RT_C_ABI void orc_rt_Error_consume(orc_rt_ErrorRef Err);
+ORC_RT_C_ABI void orc_rt_Error_consume(orc_rt_ErrorRef Err) ORC_RT_C_NOTHROW;
 
 /**
  * Report a fatal error if Err is a failure value.
@@ -49,7 +50,7 @@ ORC_RT_C_ABI void orc_rt_Error_consume(orc_rt_ErrorRef Err);
  * This function can be used to wrap calls to fallible functions ONLY when it is
  * known that the Error will always be a success value.
  */
-ORC_RT_C_ABI void orc_rt_Error_cantFail(orc_rt_ErrorRef Err);
+ORC_RT_C_ABI void orc_rt_Error_cantFail(orc_rt_ErrorRef Err) ORC_RT_C_NOTHROW;
 
 /**
  * Returns the given string's error message. This operation consumes the error,
@@ -57,22 +58,24 @@ ORC_RT_C_ABI void orc_rt_Error_cantFail(orc_rt_ErrorRef Err);
  * The caller is responsible for disposing of the string by calling
  * LLVMDisposeErrorMessage.
  */
-ORC_RT_C_ABI char *orc_rt_Error_toString(orc_rt_ErrorRef Err);
+ORC_RT_C_ABI char *orc_rt_Error_toString(orc_rt_ErrorRef Err) ORC_RT_C_NOTHROW;
 
 /**
  * Dispose of the given error message.
  */
-ORC_RT_C_ABI void orc_rt_Error_freeErrorMessage(char *ErrMsg);
+ORC_RT_C_ABI void orc_rt_Error_freeErrorMessage(char *ErrMsg) ORC_RT_C_NOTHROW;
 
 /**
  * Returns the type id for llvm StringError.
  */
-ORC_RT_C_ABI orc_rt_Error_TypeId orc_rt_StringError_getTypeId(void);
+ORC_RT_C_ABI orc_rt_Error_TypeId orc_rt_StringError_getTypeId(void)
+    ORC_RT_C_NOTHROW;
 
 /**
  * Create a StringError.
  */
-ORC_RT_C_ABI orc_rt_ErrorRef orc_rt_StringError_create(const char *ErrMsg);
+ORC_RT_C_ABI orc_rt_ErrorRef orc_rt_StringError_create(const char *ErrMsg)
+    ORC_RT_C_NOTHROW;
 
 ORC_RT_C_EXTERN_C_END
 

--- a/orc-rt/lib/executor/Error.cpp
+++ b/orc-rt/lib/executor/Error.cpp
@@ -48,30 +48,34 @@ std::string ExceptionError::toString() const noexcept {
 
 #endif // ORC_RT_ENABLE_EXCEPTIONS
 
-extern "C" orc_rt_Error_TypeId orc_rt_Error_getTypeId(orc_rt_ErrorRef Err) {
+extern "C" orc_rt_Error_TypeId
+orc_rt_Error_getTypeId(orc_rt_ErrorRef Err) noexcept {
   assert(Err && "Err must not be null");
   return reinterpret_cast<ErrorInfoBase *>(Err)->dynamicClassID();
 }
 
-extern "C" void orc_rt_Error_consume(orc_rt_ErrorRef Err) {
+extern "C" void orc_rt_Error_consume(orc_rt_ErrorRef Err) noexcept {
   consumeError(unwrap(Err));
 }
 
-extern "C" void orc_rt_Error_cantFail(orc_rt_ErrorRef Err) {
+extern "C" void orc_rt_Error_cantFail(orc_rt_ErrorRef Err) noexcept {
   cantFail(unwrap(Err));
 }
 
-extern "C" char *orc_rt_Error_toString(orc_rt_ErrorRef Err) {
+extern "C" char *orc_rt_Error_toString(orc_rt_ErrorRef Err) noexcept {
   return strdup(toString(unwrap(Err)).c_str());
 }
 
-extern "C" void orc_rt_Error_freeErrorMessage(char *ErrMsg) { free(ErrMsg); }
+extern "C" void orc_rt_Error_freeErrorMessage(char *ErrMsg) noexcept {
+  free(ErrMsg);
+}
 
-extern "C" orc_rt_Error_TypeId orc_rt_StringError_getTypeId(void) {
+extern "C" orc_rt_Error_TypeId orc_rt_StringError_getTypeId(void) noexcept {
   return StringError::classID();
 }
 
-extern "C" orc_rt_ErrorRef orc_rt_StringError_create(const char *ErrMsg) {
+extern "C" orc_rt_ErrorRef
+orc_rt_StringError_create(const char *ErrMsg) noexcept {
   return wrap(make_error<StringError>(ErrMsg));
 }
 


### PR DESCRIPTION
Adds an ORC_RT_C_NOTHROW macro that expands to `noexcept` in C++ mode, and `__attribute__((nothrow))` where that attribute is supported.

Also applies the new ORC_RT_C_NOTHROW macro to orc-rt-c/Error.h (and adds `noexcept` to the corresponding C++ implementation in lib/executor/Error.cpp).