### PR TITLE
[libcxx] Do not mark mkstemp tests xfail for libc

### DIFF
--- a/libcxx/test/std/containers/container.adaptors/container.adaptors.format/format.functions.format.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/container.adaptors.format/format.functions.format.pass.cpp
@@ -12,9 +12,6 @@
 
 // XFAIL: availability-fp_to_chars-missing
 
-// Missing mkstemp
-// XFAIL: LLVM-LIBC-FIXME
-
 // [container.adaptors.format]
 // For each of queue, priority_queue, and stack, the library provides the
 // following formatter specialization where adaptor-type is the name of the

--- a/libcxx/test/std/containers/container.adaptors/container.adaptors.format/format.functions.vformat.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/container.adaptors.format/format.functions.vformat.pass.cpp
@@ -12,9 +12,6 @@
 
 // XFAIL: availability-fp_to_chars-missing
 
-// Missing mkstemp
-// XFAIL: LLVM-LIBC-FIXME
-
 // [container.adaptors.format]
 // For each of queue, priority_queue, and stack, the library provides the
 // following formatter specialization where adaptor-type is the name of the

--- a/libcxx/test/std/utilities/format/format.range/format.range.fmtmap/format.functions.format.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.range/format.range.fmtmap/format.functions.format.pass.cpp
@@ -12,9 +12,6 @@
 
 // XFAIL: availability-fp_to_chars-missing
 
-// Missing mkstemp
-// XFAIL: LLVM-LIBC-FIXME
-
 // <format>
 
 // template<ranges::input_range R, class charT>

--- a/libcxx/test/std/utilities/format/format.range/format.range.fmtmap/format.functions.vformat.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.range/format.range.fmtmap/format.functions.vformat.pass.cpp
@@ -12,9 +12,6 @@
 
 // XFAIL: availability-fp_to_chars-missing
 
-// Missing mkstemp
-// XFAIL: LLVM-LIBC-FIXME
-
 // <format>
 
 // template<ranges::input_range R, class charT>

--- a/libcxx/test/std/utilities/format/format.range/format.range.fmtset/format.functions.format.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.range/format.range.fmtset/format.functions.format.pass.cpp
@@ -12,9 +12,6 @@
 
 // XFAIL: availability-fp_to_chars-missing
 
-// Missing mkstemp
-// XFAIL: LLVM-LIBC-FIXME
-
 // <format>
 
 // template<ranges::input_range R, class charT>

--- a/libcxx/test/std/utilities/format/format.range/format.range.fmtset/format.functions.vformat.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.range/format.range.fmtset/format.functions.vformat.pass.cpp
@@ -12,9 +12,6 @@
 
 // XFAIL: availability-fp_to_chars-missing
 
-// Missing mkstemp
-// XFAIL: LLVM-LIBC-FIXME
-
 // <format>
 
 // template<ranges::input_range R, class charT>

--- a/libcxx/test/std/utilities/format/format.range/format.range.fmtstr/format.functions.format.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.range/format.range.fmtstr/format.functions.format.pass.cpp
@@ -12,9 +12,6 @@
 
 // XFAIL: availability-fp_to_chars-missing
 
-// Missing mkstemp
-// XFAIL: LLVM-LIBC-FIXME
-
 // <format>
 
 // template<ranges::input_range R, class charT>

--- a/libcxx/test/std/utilities/format/format.range/format.range.fmtstr/format.functions.vformat.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.range/format.range.fmtstr/format.functions.vformat.pass.cpp
@@ -12,9 +12,6 @@
 
 // XFAIL: availability-fp_to_chars-missing
 
-// Missing mkstemp
-// XFAIL: LLVM-LIBC-FIXME
-
 // <format>
 
 // template<ranges::input_range R, class charT>

--- a/libcxx/test/std/utilities/format/format.range/format.range.fmtstr/format.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.range/format.range.fmtstr/format.pass.cpp
@@ -8,9 +8,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
-// Missing mkstemp
-// XFAIL: LLVM-LIBC-FIXME
-
 // <format>
 
 // template<ranges::input_range R, class charT>

--- a/libcxx/test/std/utilities/format/format.range/format.range.fmtstr/parse.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.range/format.range.fmtstr/parse.pass.cpp
@@ -8,9 +8,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
-// Missing mkstemp
-// XFAIL: LLVM-LIBC-FIXME
-
 // <format>
 
 // template<ranges::input_range R, class charT>

--- a/libcxx/test/std/utilities/format/format.range/format.range.formatter/format.functions.format.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.range/format.range.formatter/format.functions.format.pass.cpp
@@ -12,9 +12,6 @@
 
 // XFAIL: availability-fp_to_chars-missing
 
-// Missing mkstemp
-// XFAIL: LLVM-LIBC-FIXME
-
 // <format>
 
 //  template<class T, class charT = char>

--- a/libcxx/test/std/utilities/format/format.range/format.range.formatter/format.functions.vformat.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.range/format.range.formatter/format.functions.vformat.pass.cpp
@@ -12,9 +12,6 @@
 
 // XFAIL: availability-fp_to_chars-missing
 
-// Missing mkstemp
-// XFAIL: LLVM-LIBC-FIXME
-
 // <format>
 
 //  template<class T, class charT = char>


### PR DESCRIPTION
mkstemp was recently implemented in
c9b25a6437fd97fdb1e55ab6661c0cccce98913e, so these tests now pass.