### PR TITLE
[OpenACC] Fix scope setup for OpenACC directives without scope.

### DIFF
--- a/clang/lib/Parse/ParseOpenACC.cpp
+++ b/clang/lib/Parse/ParseOpenACC.cpp
@@ -1682,7 +1682,9 @@ StmtResult Parser::ParseOpenACCDirectiveStmt() {
         getActions().OpenACC(), DirInfo.DirKind, DirInfo.DirLoc, {},
         DirInfo.Clauses);
     ParsingOpenACCDirectiveRAII DirScope(*this, /*Value=*/false);
-    ParseScope ACCScope(this, getOpenACCScopeFlags(DirInfo.DirKind));
+
+    unsigned scopeFlags = getOpenACCScopeFlags(DirInfo.DirKind);
+    ParseScope ACCScope(this, scopeFlags, /*EnteredScope=*/scopeFlags != 0);
 
     AssocStmt = getActions().OpenACC().ActOnAssociatedStmt(
         DirInfo.StartLoc, DirInfo.DirKind, DirInfo.AtomicKind, DirInfo.Clauses,

--- a/clang/test/ParserOpenACC/directive-scope-setup.cpp
+++ b/clang/test/ParserOpenACC/directive-scope-setup.cpp
@@ -7,4 +7,6 @@ void func() {
   using j; // expected-error{{using declaration requires a qualified name}}
 #pragma acc parallel loop
   using k; // expected-error{{using declaration requires a qualified name}}
+#pragma acc data default(none)
+  using l; // expected-error{{using declaration requires a qualified name}}
 }


### PR DESCRIPTION
When implementing these, I intended to have the 'empty' parse scopes for most of the directives introduced for simplicity.  However some assertions show that this is not a valid use of this, as it doesn't tolerate 'empty' parse scopes. This patch stops introducing one.

Fixes: #203679