### PR TITLE
[Fuzzer] Bump max RSS in fork tests

### DIFF
--- a/compiler-rt/test/fuzzer/fork.test
+++ b/compiler-rt/test/fuzzer/fork.test
@@ -22,4 +22,4 @@ RUN: FileCheck %s --check-prefix=CRASH --input-file=%t-ShallowOOMDeepCrash.log
 
 MAX_TOTAL_TIME: INFO: fuzzed for {{.*}} seconds, wrapping up soon
 MAX_TOTAL_TIME: INFO: exiting: {{.*}} time:
-RUN: not %run %t-ShallowOOMDeepCrash -fork=1 -rss_limit_mb=128 -ignore_crashes=1 -max_total_time=30 2>&1 | FileCheck %s  --check-prefix=MAX_TOTAL_TIME
+RUN: not %run %t-ShallowOOMDeepCrash -fork=1 -rss_limit_mb=256 -ignore_crashes=1 -max_total_time=30 2>&1 | FileCheck %s  --check-prefix=MAX_TOTAL_TIME

--- a/compiler-rt/test/fuzzer/fork_corpus_groups.test
+++ b/compiler-rt/test/fuzzer/fork_corpus_groups.test
@@ -22,4 +22,4 @@ RUN: FileCheck %s --check-prefix=CRASH --input-file=%t-ShallowOOMDeepCrash.log
 
 MAX_TOTAL_TIME: INFO: fuzzed for {{.*}} seconds, wrapping up soon
 MAX_TOTAL_TIME: INFO: exiting: {{.*}} time:
-RUN: not %run %t-ShallowOOMDeepCrash -fork=1 -fork_corpus_groups=1 -rss_limit_mb=128 -ignore_crashes=1 -max_total_time=30 2>&1 | FileCheck %s  --check-prefix=MAX_TOTAL_TIME
+RUN: not %run %t-ShallowOOMDeepCrash -fork=1 -fork_corpus_groups=1 -rss_limit_mb=256 -ignore_crashes=1 -max_total_time=30 2>&1 | FileCheck %s  --check-prefix=MAX_TOTAL_TIME


### PR DESCRIPTION
These became flaky on at least one buildbot after enabling the internal shell by default:
1. https://lab.llvm.org/buildbot/#/builders/174/builds/36874
2. https://lab.llvm.org/buildbot/#/builders/174/builds/36876

Try bumping the max RSS to see if that helps.