### PR TITLE
[APINotes] Skip per-decl ProcessAPINotes work when no API notes are active

### DIFF
--- a/clang/include/clang/APINotes/APINotesManager.h
+++ b/clang/include/clang/APINotes/APINotesManager.h
@@ -50,6 +50,11 @@ class APINotesManager {
   /// source file from which an entity was declared.
   bool ImplicitAPINotes;
 
+  /// Cached value of hasAPINotes() true once any current-module reader has
+  /// been loaded, or if implicit API notes lookup is enabled. Monotonic within
+  /// a compilation, so it can be tested per-declaration without recomputing.
+  bool HasAPINotes;
+
   /// Whether to apply all APINotes as optionally-applied versioned
   /// entities. This means that when building a Clang module,
   /// we capture every note on a given decl wrapped in a SwiftVersionedAttr
@@ -171,6 +176,8 @@ public:
       return {};
     return ArrayRef(CurrentModuleReaders).slice(0, HasPrivate ? 2 : 1);
   }
+
+  bool hasAPINotes() const { return HasAPINotes; }
 
   /// Find the API notes readers that correspond to the given source location.
   llvm::SmallVector<APINotesReader *, 2> findAPINotes(SourceLocation Loc);

--- a/clang/lib/APINotes/APINotesManager.cpp
+++ b/clang/lib/APINotes/APINotesManager.cpp
@@ -50,6 +50,7 @@ public:
 
 APINotesManager::APINotesManager(SourceManager &SM, const LangOptions &LangOpts)
     : SM(SM), ImplicitAPINotes(LangOpts.APINotes),
+      HasAPINotes(LangOpts.APINotes),
       VersionIndependentSwift(LangOpts.SwiftVersionIndependentAPINotes) {}
 
 APINotesManager::~APINotesManager() {
@@ -319,6 +320,8 @@ bool APINotesManager::loadCurrentModuleAPINotes(
       M->APINotesFile = File.getName().str();
   }
 
+  if (NumReaders > 0)
+    HasAPINotes = true;
   return NumReaders > 0;
 }
 
@@ -331,6 +334,8 @@ bool APINotesManager::loadCurrentModuleAPINotesFromBuffer(
 
     CurrentModuleReaders[NumReader++] = Reader.release();
   }
+  if (NumReader > 0)
+    HasAPINotes = true;
   return NumReader;
 }
 

--- a/clang/lib/Sema/SemaAPINotes.cpp
+++ b/clang/lib/Sema/SemaAPINotes.cpp
@@ -998,6 +998,8 @@ UnwindTagContext(TagDecl *DC, api_notes::APINotesManager &APINotes) {
 void Sema::ProcessAPINotes(Decl *D) {
   if (!D)
     return;
+  if (!APINotes.hasAPINotes())
+    return;
   auto Readers = APINotes.findAPINotes(D->getLocation());
   if (Readers.empty())
     return;


### PR DESCRIPTION
Cache "any API notes active" and skip per-decl lookups.

| function                 | before #202727    | trunk (parent)    | this PR             |
| ------------------------ | ----------------- | ----------------- | ------------------- |
| `Sema::ProcessAPINotes`  | 2,385,852 (0.21%) | 1,028,280 (0.09%) | **365,310 (0.03%)** |
| `UnwindNamespaceContext` | 349,244           | gone              | gone                |
| `findAPINotes`           | 448,140           | 473,550           | **gone**            |


cc @egorzhdan @Xazax-hun @compnerd