### PR TITLE
[mlir][emitc] Remove deprecated apply op

### DIFF
--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -170,42 +170,6 @@ def EmitC_AddOp : EmitC_BinaryOp<"add", []> {
   let hasVerifier = 1;
 }
 
-def EmitC_ApplyOp : EmitC_Op<"apply", [CExpressionInterface]> {
-  let summary = "Deprecated (use address_of/dereference)";
-  let description = [{
-    With the `emitc.apply` operation the operators & (address of) and * (contents of)
-    can be applied to a single operand.
-
-    Example:
-
-    ```mlir
-    // Custom form of applying the & operator.
-    %0 = emitc.apply "&"(%arg0) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
-
-    // Generic form of the same operation.
-    %0 = "emitc.apply"(%arg0) {applicableOperator = "&"}
-        : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
-
-    ```
-  }];
-  let arguments = (ins
-    Arg<StrAttr, "the operator to apply">:$applicableOperator,
-    AnyTypeOf<[EmitCType, EmitC_LValueType]>:$operand
-  );
-  let results = (outs EmitCType:$result);
-  let assemblyFormat = [{
-    $applicableOperator `(` $operand `)` attr-dict `:` functional-type($operand, results)
-  }];
-
-  let extraClassDeclaration = [{
-    bool hasSideEffects() {
-      return getApplicableOperator() == "*";
-    }
-  }];
-
-  let hasVerifier = 1;
-}
-
 def EmitC_BitwiseAndOp : EmitC_BinaryOp<"bitwise_and", []> {
   let summary = "Bitwise and operation";
   let description = [{
@@ -1331,12 +1295,12 @@ def EmitC_VariableOp : EmitC_Op<"variable", []> {
 
     Since folding is not supported, it can be used with pointers.
     As an example, it is valid to create pointers to `variable` operations
-    by using `apply` operations and pass these to a `call` operation.
+    by using `address_of` operations and pass these to a `call` operation.
     ```mlir
     %0 = "emitc.variable"() {value = 0 : i32} : () -> !emitc.lvalue<i32>
     %1 = "emitc.variable"() {value = 0 : i32} : () -> !emitc.lvalue<i32>
-    %2 = emitc.apply "&"(%0) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
-    %3 = emitc.apply "&"(%1) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
+    %2 = emitc.address_of %0 : !emitc.lvalue<i32>
+    %3 = emitc.address_of %1 : !emitc.lvalue<i32>
     emitc.call_opaque "write"(%2, %3)
       : (!emitc.ptr<i32>, !emitc.ptr<i32>) -> ()
     ```

--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -263,36 +263,6 @@ LogicalResult AddOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// ApplyOp
-//===----------------------------------------------------------------------===//
-
-LogicalResult ApplyOp::verify() {
-  StringRef applicableOperatorStr = getApplicableOperator();
-
-  // Applicable operator must not be empty.
-  if (applicableOperatorStr.empty())
-    return emitOpError("applicable operator must not be empty");
-
-  // Only `*` and `&` are supported.
-  if (applicableOperatorStr != "&" && applicableOperatorStr != "*")
-    return emitOpError("applicable operator is illegal");
-
-  Type operandType = getOperand().getType();
-  Type resultType = getResult().getType();
-  if (applicableOperatorStr == "&") {
-    if (!llvm::isa<emitc::LValueType>(operandType))
-      return emitOpError("operand type must be an lvalue when applying `&`");
-    if (!llvm::isa<emitc::PointerType>(resultType))
-      return emitOpError("result type must be a pointer when applying `&`");
-  } else {
-    if (!llvm::isa<emitc::PointerType>(operandType))
-      return emitOpError("operand type must be a pointer when applying `*`");
-  }
-
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
 // AssignOp
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Dialect/EmitC/Transforms/Transforms.cpp
+++ b/mlir/lib/Dialect/EmitC/Transforms/Transforms.cpp
@@ -63,13 +63,7 @@ struct FoldExpressionOp : public OpRewritePattern<ExpressionOp> {
     ExpressionOp usedExpression;
     SetVector<Value> foldedOperands;
 
-    auto takesItsOperandsAddress = [](Operation *user) {
-      auto applyOp = dyn_cast<emitc::ApplyOp>(user);
-      return applyOp && applyOp.getApplicableOperator() == "&";
-    };
-
     // Select as expression to fold the first operand expression that
-    // - doesn't have its result value's address taken,
     // - has a single user: assume any re-materialization was done separately,
     // - has no side effects,
     // and save all other operands to be used later as operands in the folded
@@ -78,7 +72,6 @@ struct FoldExpressionOp : public OpRewritePattern<ExpressionOp> {
                                          expressionBody->getArguments())) {
       ExpressionOp operandExpression = operand.getDefiningOp<ExpressionOp>();
       if (usedExpression || !operandExpression ||
-          llvm::any_of(arg.getUsers(), takesItsOperandsAddress) ||
           !operandExpression.getResult().hasOneUse() ||
           operandExpression.hasSideEffects())
         foldedOperands.insert(operand);

--- a/mlir/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/mlir/lib/Target/Cpp/TranslateToCpp.cpp
@@ -74,7 +74,6 @@ static FailureOr<int> getOperatorPrecedence(Operation *operation) {
   return llvm::TypeSwitch<Operation *, FailureOr<int>>(operation)
       .Case([&](emitc::AddressOfOp op) { return 15; })
       .Case([&](emitc::AddOp op) { return 12; })
-      .Case([&](emitc::ApplyOp op) { return 15; })
       .Case([&](emitc::BitwiseAndOp op) { return 7; })
       .Case([&](emitc::BitwiseLeftShiftOp op) { return 11; })
       .Case([&](emitc::BitwiseNotOp op) { return 15; })
@@ -997,25 +996,6 @@ printOperation(CppEmitter &emitter,
 }
 
 static LogicalResult printOperation(CppEmitter &emitter,
-                                    emitc::ApplyOp applyOp) {
-  raw_ostream &os = emitter.ostream();
-  Operation &op = *applyOp.getOperation();
-
-  if (failed(emitter.emitAssignPrefix(op)))
-    return failure();
-
-  StringRef applicableOperator = applyOp.getApplicableOperator();
-  Value operand = applyOp.getOperand();
-
-  // Check if we're taking address of a const global.
-  if (applicableOperator == "&" && getConstGlobal(operand, &op))
-    return emitAddressOfWithConstCast(emitter, op, operand);
-
-  os << applicableOperator;
-  return emitter.emitOperand(operand);
-}
-
-static LogicalResult printOperation(CppEmitter &emitter,
                                     emitc::BitwiseAndOp bitwiseAndOp) {
   Operation *operation = bitwiseAndOp.getOperation();
   return printBinaryOperation(emitter, operation, "&");
@@ -1898,8 +1878,8 @@ LogicalResult CppEmitter::emitOperation(Operation &op, bool trailingSemicolon) {
           .Case<cf::BranchOp, cf::CondBranchOp>(
               [&](auto op) { return printOperation(*this, op); })
           // EmitC ops.
-          .Case<emitc::AddressOfOp, emitc::AddOp, emitc::ApplyOp,
-                emitc::AssignOp, emitc::BitwiseAndOp, emitc::BitwiseLeftShiftOp,
+          .Case<emitc::AddressOfOp, emitc::AddOp, emitc::AssignOp,
+                emitc::BitwiseAndOp, emitc::BitwiseLeftShiftOp,
                 emitc::BitwiseNotOp, emitc::BitwiseOrOp,
                 emitc::BitwiseRightShiftOp, emitc::BitwiseXorOp, emitc::CallOp,
                 emitc::CallOpaqueOp, emitc::CastOp, emitc::ClassOp,

--- a/mlir/test/Dialect/EmitC/form-expressions.mlir
+++ b/mlir/test/Dialect/EmitC/form-expressions.mlir
@@ -83,45 +83,6 @@ func.func @expression_with_call(%arg0: i32, %arg1: i32, %arg2: i32, %arg3: i32) 
   return %c : i1
 }
 
-// CHECK-LABEL: func.func @expression_with_dereference(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: !emitc.ptr<i32>) -> i1 {
-// CHECK:         %[[VAL_3:.*]] = emitc.expression %[[VAL_2]] : (!emitc.ptr<i32>) -> i32 {
-// CHECK:           %[[VAL_4:.*]] = apply "*"(%[[VAL_2]]) : (!emitc.ptr<i32>) -> i32
-// CHECK:           yield %[[VAL_4]] : i32
-// CHECK:         }
-// CHECK:         %[[VAL_5:.*]] = emitc.expression %[[VAL_3]], %[[VAL_0]], %[[VAL_1]] : (i32, i32, i32) -> i1 {
-// CHECK:           %[[VAL_6:.*]] = mul %[[VAL_0]], %[[VAL_1]] : (i32, i32) -> i32
-// CHECK:           %[[VAL_7:.*]] = cmp lt, %[[VAL_6]], %[[VAL_3]] : (i32, i32) -> i1
-// CHECK:         return %[[VAL_5]] : i1
-// CHECK:       }
-
-func.func @expression_with_dereference(%arg0: i32, %arg1: i32, %arg2: !emitc.ptr<i32>) -> i1 {
-  %a = emitc.mul %arg0, %arg1 : (i32, i32) -> i32
-  %b = emitc.apply "*"(%arg2) : (!emitc.ptr<i32>) -> (i32)
-  %c = emitc.cmp lt, %a, %b :(i32, i32) -> i1
-  return %c : i1
-}
-
-// CHECK-LABEL: func.func @expression_with_address_taken(
-// CHECK-SAME:      %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: !emitc.ptr<i32>) -> i1 {
-// CHECK:         %[[VAL_3:.*]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
-// CHECK:         %[[VAL_4:.*]] = emitc.expression %[[VAL_2]], %[[VAL_1]], %[[VAL_3]] : (!emitc.ptr<i32>, i32, !emitc.lvalue<i32>) -> i1 {
-// CHECK:           %[[VAL_5:.*]] = apply "&"(%[[VAL_3]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
-// CHECK:           %[[VAL_6:.*]] = add %[[VAL_5]], %[[VAL_1]] : (!emitc.ptr<i32>, i32) -> !emitc.ptr<i32>
-// CHECK:           %[[VAL_7:.*]] = cmp lt, %[[VAL_6]], %[[VAL_2]] : (!emitc.ptr<i32>, !emitc.ptr<i32>) -> i1
-// CHECK:           yield %[[VAL_7]] : i1
-// CHECK:         }
-// CHECK:         return %[[VAL_4]] : i1
-// CHECK:       }
-
-func.func @expression_with_address_taken(%arg0: i32, %arg1: i32, %arg2: !emitc.ptr<i32>) -> i1 {
-  %0 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
-  %a = emitc.apply "&"(%0) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
-  %b = emitc.add %a, %arg1 : (!emitc.ptr<i32>, i32) -> !emitc.ptr<i32>
-  %c = emitc.cmp lt, %b, %arg2 :(!emitc.ptr<i32>, !emitc.ptr<i32>) -> i1
-  return %c : i1
-}
-
 // CHECK-LABEL: func.func @no_nested_expression(
 // CHECK-SAME:      %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32) -> i1 {
 // CHECK:         %[[VAL_2:.*]] = emitc.expression %[[VAL_0]], %[[VAL_1]] : (i32, i32) -> i1 {

--- a/mlir/test/Dialect/EmitC/invalid_ops.mlir
+++ b/mlir/test/Dialect/EmitC/invalid_ops.mlir
@@ -128,24 +128,6 @@ func.func @member_call_dense_template_argument(%arg0 : !emitc.opaque<"MyClass">)
 
 // -----
 
-func.func @empty_operator() {
-    %0 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
-    // expected-error @+1 {{'emitc.apply' op applicable operator must not be empty}}
-    %1 = emitc.apply ""(%0) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
-    return
-}
-
-// -----
-
-func.func @illegal_operator() {
-    %0 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
-    // expected-error @+1 {{'emitc.apply' op applicable operator is illegal}}
-    %1 = emitc.apply "+"(%0) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
-    return
-}
-
-// -----
-
 func.func @var_attribute_return_type_1() {
     // expected-error @+1 {{'emitc.variable' op requires attribute to either be an #emitc.opaque attribute or it's type ('i64') to match the op's result type ('i32')}}
     %c0 = "emitc.variable"(){value = 42: i64} : () -> !emitc.lvalue<i32>

--- a/mlir/test/Dialect/EmitC/ops.mlir
+++ b/mlir/test/Dialect/EmitC/ops.mlir
@@ -52,14 +52,6 @@ func.func @c() {
   return
 }
 
-func.func @a() {
-  %0 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
-  %1 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
-  %2 = "emitc.apply"(%0) {applicableOperator = "&"} : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
-  %3 = emitc.apply "&"(%1) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
-  return
-}
-
 func.func @add_int(%arg0: i32, %arg1: i32) {
   %1 = "emitc.add" (%arg0, %arg1) : (i32, i32) -> i32
   return

--- a/mlir/test/Target/Cpp/common-cpp.mlir
+++ b/mlir/test/Target/Cpp/common-cpp.mlir
@@ -89,23 +89,6 @@ func.func @opaque_types(%arg0: !emitc.opaque<"bool">, %arg1: !emitc.opaque<"char
   return %2 : !emitc.opaque<"status_t">
 }
 
-// CHECK-LABEL: int32_t* apply() {
-func.func @apply() -> !emitc.ptr<i32> {
-  // CHECK-NEXT: int32_t [[V1:[^ ]*]];
-  %0 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
-  // CHECK-NEXT: int32_t* [[V2:[^ ]*]] = &[[V1]];
-  %1 = emitc.apply "&"(%0) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
-  // CHECK-NEXT: int32_t [[V3:[^ ]*]];
-  %2 = "emitc.variable"() {value = #emitc.opaque<"">} : () -> !emitc.lvalue<i32>
-  // CHECK-NEXT: int32_t [[V4:[^ ]*]] = *[[V2]];
-  %3 = emitc.apply "*"(%1) : (!emitc.ptr<i32>) -> i32
-  // CHECK-NEXT: [[V3]] = [[V4]];
-  emitc.assign %3 : i32 to %2 : !emitc.lvalue<i32>
-  // CHECK-NEXT: return [[V2]];
-  return %1 : !emitc.ptr<i32>
-}
-
-
 // CHECK-LABEL: void address_of() {
 func.func @address_of() {
   // CHECK-NEXT: int32_t [[V1:[^ ]*]];

--- a/mlir/test/Target/Cpp/expressions.mlir
+++ b/mlir/test/Target/Cpp/expressions.mlir
@@ -314,44 +314,6 @@ func.func @different_expressions(%arg0: i32, %arg1: i32, %arg2: i32, %arg3: i32)
   return %v_load : i32
 }
 
-// CPP-DEFAULT:      int32_t expression_with_dereference_apply(int32_t [[VAL_1:v[0-9]+]], int32_t* [[VAL_2]]) {
-// CPP-DEFAULT-NEXT:   return *([[VAL_2]] - [[VAL_1]]);
-// CPP-DEFAULT-NEXT: }
-
-// CPP-DECLTOP:      int32_t expression_with_dereference_apply(int32_t [[VAL_1:v[0-9]+]], int32_t* [[VAL_2]]) {
-// CPP-DECLTOP-NEXT:   return *([[VAL_2]] - [[VAL_1]]);
-// CPP-DECLTOP-NEXT: }
-emitc.func @expression_with_dereference_apply(%arg1: i32, %arg2: !emitc.ptr<i32>) -> i32 {
-  %c = emitc.expression %arg1, %arg2 : (i32, !emitc.ptr<i32>) -> i32 {
-    %e = emitc.sub %arg2, %arg1 : (!emitc.ptr<i32>, i32) -> !emitc.ptr<i32>
-    %d = emitc.apply "*"(%e) : (!emitc.ptr<i32>) -> i32
-    emitc.yield %d : i32
-  }
-  return %c : i32
-}
-
-// CPP-DEFAULT:      bool expression_with_address_taken_apply(int32_t [[VAL_1:v[0-9]+]], int32_t [[VAL_2:v[0-9]+]], int32_t* [[VAL_3]]) {
-// CPP-DEFAULT-NEXT:   int32_t [[VAL_4:v[0-9]+]] = 42;
-// CPP-DEFAULT-NEXT:   return &[[VAL_4]] - [[VAL_2]] < [[VAL_3]];
-// CPP-DEFAULT-NEXT: }
-
-// CPP-DECLTOP:      bool expression_with_address_taken_apply(int32_t [[VAL_1:v[0-9]+]], int32_t [[VAL_2:v[0-9]+]], int32_t* [[VAL_3]]) {
-// CPP-DECLTOP-NEXT:   int32_t [[VAL_4:v[0-9]+]];
-// CPP-DECLTOP-NEXT:   [[VAL_4]] = 42;
-// CPP-DECLTOP-NEXT:   return &[[VAL_4]] - [[VAL_2]] < [[VAL_3]];
-// CPP-DECLTOP-NEXT: }
-
-func.func @expression_with_address_taken_apply(%arg0: i32, %arg1: i32, %arg2: !emitc.ptr<i32>) -> i1 {
-  %a = "emitc.variable"(){value = 42 : i32} : () -> !emitc.lvalue<i32>
-  %c = emitc.expression %arg1, %arg2, %a : (i32, !emitc.ptr<i32>, !emitc.lvalue<i32>) -> i1 {
-    %d = emitc.apply "&"(%a) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
-    %e = emitc.sub %d, %arg1 : (!emitc.ptr<i32>, i32) -> !emitc.ptr<i32>
-    %f = emitc.cmp lt, %e, %arg2 : (!emitc.ptr<i32>, !emitc.ptr<i32>) -> i1
-    emitc.yield %f : i1
-  }
-  return %c : i1
-}
-
 // CPP-DEFAULT:      bool expression_with_address_taken(int32_t [[VAL_1:v[0-9]+]], int32_t [[VAL_2:v[0-9]+]], int32_t* [[VAL_3]]) {
 // CPP-DEFAULT-NEXT:   int32_t [[VAL_4:v[0-9]+]] = 42;
 // CPP-DEFAULT-NEXT:   return &[[VAL_4]] - [[VAL_2]] < [[VAL_3]];

--- a/mlir/test/Target/Cpp/global.mlir
+++ b/mlir/test/Target/Cpp/global.mlir
@@ -103,56 +103,6 @@ func.func @use_global_array_write(%i: index, %val : f32) {
 // CPP-DECLTOP-NEXT: myglobal[[[V1]]] = [[V2]];
 // CPP-DECLTOP-NEXT: return;
 
-func.func @use_const_global_array_pointer(%i: index) -> !emitc.ptr<i16> {
-  %0 = emitc.get_global @myconstant : !emitc.array<2xi16>
-  %1 = emitc.subscript %0[%i] : (!emitc.array<2xi16>, index) -> !emitc.lvalue<i16>
-  %2 = emitc.apply "&"(%1) : (!emitc.lvalue<i16>) -> !emitc.ptr<i16>
-  return %2 : !emitc.ptr<i16>
-}
-// CPP-DEFAULT-LABEL: int16_t* use_const_global_array_pointer
-// CPP-DEFAULT-SAME: (size_t [[V1:.*]])
-// CPP-DEFAULT-NEXT: int16_t* [[V2:.*]] = (int16_t*)(&myconstant[[[V1]]]);
-// CPP-DEFAULT-NEXT: return [[V2]];
-
-// CPP-DECLTOP-LABEL: int16_t* use_const_global_array_pointer
-// CPP-DECLTOP-SAME: (size_t [[V1:.*]])
-// CPP-DECLTOP-NEXT: int16_t* [[V2:.*]];
-// CPP-DECLTOP-NEXT: [[V2]] = (int16_t*)(&myconstant[[[V1]]]);
-// CPP-DECLTOP-NEXT: return [[V2]];
-
-func.func @use_const_global_scalar_pointer() -> !emitc.ptr<f32> {
-  %0 = emitc.get_global @static_const : !emitc.lvalue<f32>
-  %1 = emitc.apply "&"(%0) : (!emitc.lvalue<f32>) -> !emitc.ptr<f32>
-  return %1 : !emitc.ptr<f32>
-}
-// CPP-DEFAULT-LABEL: float* use_const_global_scalar_pointer()
-// CPP-DEFAULT-NEXT: float* [[V1:.*]] = (float*)(&static_const);
-// CPP-DEFAULT-NEXT: return [[V1]];
-
-// CPP-DECLTOP-LABEL: float* use_const_global_scalar_pointer()
-// CPP-DECLTOP-NEXT: float* [[V1:.*]];
-// CPP-DECLTOP-NEXT: [[V1]] = (float*)(&static_const);
-// CPP-DECLTOP-NEXT: return [[V1]];
-
-func.func @use_const_global_2d_array_pointer(%i: index, %j: index) -> !emitc.ptr<i16> {
-  %0 = emitc.get_global @myconstant_2d : !emitc.array<2x3xi16>
-  %1 = emitc.subscript %0[%i, %j] : (!emitc.array<2x3xi16>, index, index) -> !emitc.lvalue<i16>
-  %2 = emitc.apply "&"(%1) : (!emitc.lvalue<i16>) -> !emitc.ptr<i16>
-  return %2 : !emitc.ptr<i16>
-}
-// CPP-DEFAULT-LABEL: int16_t* use_const_global_2d_array_pointer
-// CPP-DEFAULT-SAME: (size_t [[I:.*]], size_t [[J:.*]])
-// CPP-DEFAULT-NEXT: int16_t* [[V:.*]] = (int16_t*)(&myconstant_2d[[[I]]][[[J]]]);
-// CPP-DEFAULT-NEXT: return [[V]];
-
-// CPP-DECLTOP-LABEL: int16_t* use_const_global_2d_array_pointer
-// CPP-DECLTOP-SAME: (size_t [[I:.*]], size_t [[J:.*]])
-// CPP-DECLTOP-NEXT: int16_t* [[V:.*]];
-// CPP-DECLTOP-NEXT: [[V]] = (int16_t*)(&myconstant_2d[[[I]]][[[J]]]);
-// CPP-DECLTOP-NEXT: return [[V]];
-
-// Test emitc.address_of with const globals (same as emitc.apply "&" tests above)
-
 func.func @use_const_global_array_pointer_address_of(%i: index) -> !emitc.ptr<i16> {
   %0 = emitc.get_global @myconstant : !emitc.array<2xi16>
   %1 = emitc.subscript %0[%i] : (!emitc.array<2xi16>, index) -> !emitc.lvalue<i16>

--- a/mlir/test/Target/Cpp/lvalue.mlir
+++ b/mlir/test/Target/Cpp/lvalue.mlir
@@ -4,7 +4,7 @@ emitc.func @lvalue_variables(%v1: i32, %v2: i32) -> i32 {
   %val = emitc.mul %v1, %v2 : (i32, i32) -> i32
   %variable = "emitc.variable"() {value = #emitc.opaque<"">} : () -> !emitc.lvalue<i32> 
   emitc.assign %val : i32 to %variable : !emitc.lvalue<i32>
-  %addr = emitc.apply "&"(%variable) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
+  %addr = emitc.address_of %variable : !emitc.lvalue<i32>
   emitc.call @zero (%addr) : (!emitc.ptr<i32>) -> ()
   %updated_val = emitc.load %variable : !emitc.lvalue<i32>
   %neg_one = "emitc.constant"() {value = -1 : i32} : () -> i32


### PR DESCRIPTION
The `emitc.apply` op has been deprecated since it was replaced by 'emitc.address_of` and `emitc.dereference`. This patch removes this op from the dialect.

See PSA:
https://discourse.llvm.org/t/psa-emitc-replacing-the-emitc-apply-operation/89057