### PR TITLE
[Sema] Fix assertion in TreeTransform when rebuilding CXXParenListInitExpr

### DIFF
--- a/clang/include/clang/AST/ExprCXX.h
+++ b/clang/include/clang/AST/ExprCXX.h
@@ -5184,6 +5184,10 @@ public:
 
   ArrayRef<Expr *> getInitExprs() const { return getTrailingObjects(NumExprs); }
 
+  MutableArrayRef<Expr *> getUserSpecifiedInitExprs() {
+    return getTrailingObjects(NumUserSpecifiedExprs);
+  }
+
   ArrayRef<Expr *> getUserSpecifiedInitExprs() const {
     return getTrailingObjects(NumUserSpecifiedExprs);
   }

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -3412,7 +3412,8 @@ public:
 
     if (auto *PLE = dyn_cast<CXXParenListInitExpr>(Sub))
       return getSema().BuildCXXTypeConstructExpr(
-          TInfo, LParenLoc, PLE->getInitExprs(), RParenLoc, ListInitialization);
+          TInfo, LParenLoc, PLE->getUserSpecifiedInitExprs(), RParenLoc,
+          ListInitialization);
 
     return getSema().BuildCXXTypeConstructExpr(TInfo, LParenLoc,
                                                MultiExprArg(&Sub, 1), RParenLoc,

--- a/clang/test/SemaTemplate/instantiate-member-initializers.cpp
+++ b/clang/test/SemaTemplate/instantiate-member-initializers.cpp
@@ -41,3 +41,16 @@ template<typename T> struct Array {
   Array() : a() {}
 };
 Array<int> s;
+
+namespace GH194986 {
+  struct S {};
+  template <typename T> struct SS { T t1; T t2; }; // expected-note {{candidate template ignored: could not match 'GH194986::SS<T>' against 'const char *'}} expected-note {{implicit deduction guide declared as 'template <typename T> SS(GH194986::SS<T>) -> GH194986::SS<T>'}} expected-note {{candidate function template not viable: requires 0 arguments, but 1 was provided}} expected-note {{implicit deduction guide declared as 'template <typename T> SS() -> GH194986::SS<T>'}}
+  template <class T, class... Args> T C(Args... args) { return SS("foo"); } // expected-error {{no viable constructor or deduction guide for deduction of template arguments of 'SS'}}
+  S s = C<S>();
+
+  template <class T> struct SS2 { T t1, t2; }; // expected-note {{candidate template ignored: could not match 'GH194986::SS2<T>' against 'const char *'}} expected-note {{implicit deduction guide declared as 'template <class T> SS2(GH194986::SS2<T>) -> GH194986::SS2<T>'}} expected-note {{candidate function template not viable: requires 0 arguments, but 1 was provided}} expected-note {{implicit deduction guide declared as 'template <class T> SS2() -> GH194986::SS2<T>'}}
+  template <class> void C2() {
+    SS2("foo"); // expected-error {{no viable constructor or deduction guide for deduction of template arguments of 'SS2'}}
+  }
+  template void C2<int>();
+};


### PR DESCRIPTION
When rebuilding a CXXFunctionalCastExpr during template instantiation, where the sub-expression is a CXXParenListInitExpr, we were passing all stored initializers to BuildCXXTypeConstructExpr — including the ones the compiler synthesized for uninitialized aggregate fields. Only the user-written initializers should be passed, otherwise we hit an assertion.

The test cases might be incomplete. I would like suggestions on what more type of testcases to be added.

Fixes #194986 