### PR TITLE
[clangd] fix preprocessor caching-lexer state tracking

### DIFF
--- a/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
+++ b/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
@@ -1918,6 +1918,23 @@ TEST(SignatureHelpTest, StalePreamble) {
   EXPECT_EQ(0, Results.activeParameter);
 }
 
+TEST(SignatureHelpTest, EOFInSkippedFunctionBody) {
+  Annotations Test(R"cpp(
+#ifdef IS_HEADER
+void frameSizeBlocksWarning() {
+  auto fn = []() {
+  };
+  fn();
+}
+#else
+#define IS_HEADER
+#include __FILE__
+#^endif
+)cpp");
+  auto Results = signatures(Test.code(), Test.point());
+  EXPECT_THAT(Results.signatures, IsEmpty());
+}
+
 class IndexRequestCollector : public SymbolIndex {
 public:
   IndexRequestCollector(std::vector<Symbol> Syms = {}) : Symbols(Syms) {}

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -721,6 +721,9 @@ Bug Fixes in This Version
 - Fixed a potential stack-use-after-return issue in Clang when copy-initializing
   an array via an element-at-a-time copy loop (#GH192026)
 - Fixed an issue where certain designated initializers would be rejected for constexpr variables. (#GH193373)
+- Fixed ``clang::Preprocessor::recomputeCurLexerKind`` to avoid default fallback to ``CurLexerCallback = CLK_CachingLexer;``. This prevents code-completion
+  EOF handling from accidentally restoring CLK_CachingLexer while a tentative parse is still active, which could trigger a caching lexer re-entry assertion
+  in clangd signature help. (#GH200677)
 - Fixed a crash when ``#embed`` is used with C++ modules (#GH195350)
 - Fixed a bug where ``-x cuda`` caused clang to immediately resolve templates that should not be. (#GH200545)
 - Fixed an issue where ``__typeof_unqual`` and ``__typeof_unqual__`` were rejected as a declaration specifier in block scope in C++.

--- a/clang/include/clang/Lex/Preprocessor.h
+++ b/clang/include/clang/Lex/Preprocessor.h
@@ -1190,6 +1190,9 @@ private:
   /// Lex() should be invoked.
   CachedTokensTy::size_type CachedLexPos = 0;
 
+  /// True when the caching lexer is installed as the active lexer layer.
+  bool IsCachingLexMode = false;
+
   /// Stack of backtrack positions, allowing nested backtracks.
   ///
   /// The EnableBacktrackAtThisPos() method pushes a position to
@@ -2583,7 +2586,7 @@ private:
   friend void TokenLexer::ExpandFunctionArguments();
 
   void PushIncludeMacroStack() {
-    assert(CurLexerCallback != CLK_CachingLexer &&
+    assert(!IsCachingLexMode && CurLexerCallback != CLK_CachingLexer &&
            "cannot push a caching lexer");
     IncludeMacroStack.emplace_back(CurLexerCallback, CurLexerSubmodule,
                                    std::move(CurLexer), CurPPLexer,
@@ -2592,6 +2595,7 @@ private:
   }
 
   void PopIncludeMacroStack() {
+    IsCachingLexMode = false;
     if (CurLexer)
       PendingDestroyLexers.push_back(std::move(CurLexer));
     CurLexer = std::move(IncludeMacroStack.back().TheLexer);
@@ -2819,18 +2823,16 @@ private:
   // Caching stuff.
   void CachingLex(Token &Result);
 
-  bool InCachingLexMode() const {
-    // If the Lexer pointers are 0 and IncludeMacroStack is empty, it means
-    // that we are past EOF, not that we are in CachingLex mode.
-    return !CurPPLexer && !CurTokenLexer && !IncludeMacroStack.empty();
-  }
+  bool InCachingLexMode() const { return IsCachingLexMode; }
 
   void EnterCachingLexMode();
   void EnterCachingLexModeUnchecked();
 
   void ExitCachingLexMode() {
-    if (InCachingLexMode())
+    if (InCachingLexMode()) {
+      IsCachingLexMode = false;
       RemoveTopOfLexerStack();
+    }
   }
 
   const Token &PeekAhead(unsigned N);

--- a/clang/include/clang/Lex/Preprocessor.h
+++ b/clang/include/clang/Lex/Preprocessor.h
@@ -1190,9 +1190,6 @@ private:
   /// Lex() should be invoked.
   CachedTokensTy::size_type CachedLexPos = 0;
 
-  /// True when the caching lexer is installed as the active lexer layer.
-  bool IsCachingLexMode = false;
-
   /// Stack of backtrack positions, allowing nested backtracks.
   ///
   /// The EnableBacktrackAtThisPos() method pushes a position to
@@ -2586,7 +2583,7 @@ private:
   friend void TokenLexer::ExpandFunctionArguments();
 
   void PushIncludeMacroStack() {
-    assert(!IsCachingLexMode && CurLexerCallback != CLK_CachingLexer &&
+    assert(CurLexerCallback != CLK_CachingLexer &&
            "cannot push a caching lexer");
     IncludeMacroStack.emplace_back(CurLexerCallback, CurLexerSubmodule,
                                    std::move(CurLexer), CurPPLexer,
@@ -2595,7 +2592,6 @@ private:
   }
 
   void PopIncludeMacroStack() {
-    IsCachingLexMode = false;
     if (CurLexer)
       PendingDestroyLexers.push_back(std::move(CurLexer));
     CurLexer = std::move(IncludeMacroStack.back().TheLexer);
@@ -2823,16 +2819,14 @@ private:
   // Caching stuff.
   void CachingLex(Token &Result);
 
-  bool InCachingLexMode() const { return IsCachingLexMode; }
+  bool InCachingLexMode() const { return CurLexerCallback == CLK_CachingLexer; }
 
   void EnterCachingLexMode();
   void EnterCachingLexModeUnchecked();
 
   void ExitCachingLexMode() {
-    if (InCachingLexMode()) {
-      IsCachingLexMode = false;
+    if (InCachingLexMode())
       RemoveTopOfLexerStack();
-    }
   }
 
   const Token &PeekAhead(unsigned N);

--- a/clang/lib/Lex/PPCaching.cpp
+++ b/clang/lib/Lex/PPCaching.cpp
@@ -126,10 +126,8 @@ void Preprocessor::EnterCachingLexMode() {
 }
 
 void Preprocessor::EnterCachingLexModeUnchecked() {
-  assert(!InCachingLexMode() && CurLexerCallback != CLK_CachingLexer &&
-         "already in caching lex mode");
+  assert(!InCachingLexMode() && "already in caching lex mode");
   PushIncludeMacroStack();
-  IsCachingLexMode = true;
   CurLexerCallback = CLK_CachingLexer;
 }
 

--- a/clang/lib/Lex/PPCaching.cpp
+++ b/clang/lib/Lex/PPCaching.cpp
@@ -117,10 +117,8 @@ void Preprocessor::EnterCachingLexMode() {
   assert(LexLevel == 0 &&
          "entered caching lex mode while lexing something else");
 
-  if (InCachingLexMode()) {
-    assert(CurLexerCallback == CLK_CachingLexer && "Unexpected lexer kind");
+  if (InCachingLexMode())
     return;
-  }
 
   EnterCachingLexModeUnchecked();
 }

--- a/clang/lib/Lex/PPCaching.cpp
+++ b/clang/lib/Lex/PPCaching.cpp
@@ -126,8 +126,10 @@ void Preprocessor::EnterCachingLexMode() {
 }
 
 void Preprocessor::EnterCachingLexModeUnchecked() {
-  assert(CurLexerCallback != CLK_CachingLexer && "already in caching lex mode");
+  assert(!InCachingLexMode() && CurLexerCallback != CLK_CachingLexer &&
+         "already in caching lex mode");
   PushIncludeMacroStack();
+  IsCachingLexMode = true;
   CurLexerCallback = CLK_CachingLexer;
 }
 

--- a/clang/lib/Lex/PPLexerChange.cpp
+++ b/clang/lib/Lex/PPLexerChange.cpp
@@ -106,6 +106,9 @@ bool Preprocessor::EnterSourceFile(FileID FID, ConstSearchDirIterator CurDir,
 ///  and start lexing tokens from it instead of the current buffer.
 void Preprocessor::EnterSourceFileWithLexer(std::unique_ptr<Lexer> TheLexer,
                                             ConstSearchDirIterator CurDir) {
+  if (InCachingLexMode())
+    ExitCachingLexMode();
+
   PreprocessorLexer *PrevPPLexer = CurPPLexer;
 
   // Add the current lexer to the include stack.
@@ -172,7 +175,8 @@ void Preprocessor::EnterMacro(Token &Tok, SourceLocation ILEnd,
 void Preprocessor::EnterTokenStream(const Token *Toks, unsigned NumToks,
                                     bool DisableMacroExpansion, bool OwnsTokens,
                                     bool IsReinject) {
-  if (CurLexerCallback == CLK_CachingLexer) {
+  if (InCachingLexMode()) {
+    assert(CurLexerCallback == CLK_CachingLexer && "Unexpected lexer kind");
     if (CachedLexPos < CachedTokens.size()) {
       assert(IsReinject && "new tokens in the middle of cached stream");
       // We're entering tokens into the middle of our cached token stream. We

--- a/clang/lib/Lex/PPLexerChange.cpp
+++ b/clang/lib/Lex/PPLexerChange.cpp
@@ -173,7 +173,6 @@ void Preprocessor::EnterTokenStream(const Token *Toks, unsigned NumToks,
                                     bool DisableMacroExpansion, bool OwnsTokens,
                                     bool IsReinject) {
   if (InCachingLexMode()) {
-    assert(CurLexerCallback == CLK_CachingLexer && "Unexpected lexer kind");
     if (CachedLexPos < CachedTokens.size()) {
       assert(IsReinject && "new tokens in the middle of cached stream");
       // We're entering tokens into the middle of our cached token stream. We

--- a/clang/lib/Lex/PPLexerChange.cpp
+++ b/clang/lib/Lex/PPLexerChange.cpp
@@ -106,9 +106,6 @@ bool Preprocessor::EnterSourceFile(FileID FID, ConstSearchDirIterator CurDir,
 ///  and start lexing tokens from it instead of the current buffer.
 void Preprocessor::EnterSourceFileWithLexer(std::unique_ptr<Lexer> TheLexer,
                                             ConstSearchDirIterator CurDir) {
-  if (InCachingLexMode())
-    ExitCachingLexMode();
-
   PreprocessorLexer *PrevPPLexer = CurPPLexer;
 
   // Add the current lexer to the include stack.

--- a/clang/lib/Lex/Preprocessor.cpp
+++ b/clang/lib/Lex/Preprocessor.cpp
@@ -417,14 +417,16 @@ StringRef Preprocessor::getLastMacroWithSpelling(
 }
 
 void Preprocessor::recomputeCurLexerKind() {
-  if (CurLexer)
+  if (InCachingLexMode())
+    CurLexerCallback = CLK_CachingLexer;
+  else if (CurLexer)
     CurLexerCallback = CurLexer->isDependencyDirectivesLexer()
                            ? CLK_DependencyDirectivesLexer
                            : CLK_Lexer;
   else if (CurTokenLexer)
     CurLexerCallback = CLK_TokenLexer;
   else
-    CurLexerCallback = CLK_CachingLexer;
+    CurLexerCallback = CLK_Lexer;
 }
 
 bool Preprocessor::SetCodeCompletionPoint(FileEntryRef File,

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -2496,7 +2496,6 @@ bool Parser::trySkippingFunctionBody() {
 
   // We're in code-completion mode. Skip parsing for all function bodies unless
   // the body contains the code-completion point.
-
   TentativeParsingAction PA(*this);
   bool IsTryCatch = Tok.is(tok::kw_try);
   CachedTokens Toks;

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -2496,8 +2496,10 @@ bool Parser::trySkippingFunctionBody() {
 
   // We're in code-completion mode. Skip parsing for all function bodies unless
   // the body contains the code-completion point.
+  if (Tok.is(tok::kw_try))
+    return false;
+
   TentativeParsingAction PA(*this);
-  bool IsTryCatch = Tok.is(tok::kw_try);
   CachedTokens Toks;
   bool ErrorInPrologue = ConsumeAndStoreFunctionPrologue(Toks);
   if (llvm::any_of(Toks, [](const Token &Tok) {
@@ -2511,18 +2513,12 @@ bool Parser::trySkippingFunctionBody() {
     SkipMalformedDecl();
     return true;
   }
-  if (!SkipUntil(tok::r_brace, StopAtCodeCompletion)) {
+  if (!SkipUntil(tok::r_brace, StopAtCodeCompletion | StopBeforeMatch)) {
     PA.Revert();
     return false;
   }
-  while (IsTryCatch && Tok.is(tok::kw_catch)) {
-    if (!SkipUntil(tok::l_brace, StopAtCodeCompletion) ||
-        !SkipUntil(tok::r_brace, StopAtCodeCompletion)) {
-      PA.Revert();
-      return false;
-    }
-  }
   PA.Commit();
+  ConsumeBrace();
   return true;
 }
 

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -2496,10 +2496,9 @@ bool Parser::trySkippingFunctionBody() {
 
   // We're in code-completion mode. Skip parsing for all function bodies unless
   // the body contains the code-completion point.
-  if (Tok.is(tok::kw_try))
-    return false;
 
   TentativeParsingAction PA(*this);
+  bool IsTryCatch = Tok.is(tok::kw_try);
   CachedTokens Toks;
   bool ErrorInPrologue = ConsumeAndStoreFunctionPrologue(Toks);
   if (llvm::any_of(Toks, [](const Token &Tok) {
@@ -2513,12 +2512,18 @@ bool Parser::trySkippingFunctionBody() {
     SkipMalformedDecl();
     return true;
   }
-  if (!SkipUntil(tok::r_brace, StopAtCodeCompletion | StopBeforeMatch)) {
+  if (!SkipUntil(tok::r_brace, StopAtCodeCompletion)) {
     PA.Revert();
     return false;
   }
+  while (IsTryCatch && Tok.is(tok::kw_catch)) {
+    if (!SkipUntil(tok::l_brace, StopAtCodeCompletion) ||
+        !SkipUntil(tok::r_brace, StopAtCodeCompletion)) {
+      PA.Revert();
+      return false;
+    }
+  }
   PA.Commit();
-  ConsumeBrace();
   return true;
 }
 


### PR DESCRIPTION
Fix `recomputeCurLexerKind` to avoid default fallback to `CurLexerCallback = CLK_CachingLexer;`.

This prevents code-completion EOF handling from accidentally restoring CLK_CachingLexer while a tentative parse is still active, which could trigger a caching lexer re-entry assertion in clangd signature help.

Fixes https://github.com/llvm/llvm-project/issues/200677