### PR TITLE
[AArch64] Add missing arithmetic to arith+cb(n)z clustering

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64MacroFusion.cpp
+++ b/llvm/lib/Target/AArch64/AArch64MacroFusion.cpp
@@ -97,15 +97,25 @@ static bool isArithmeticCbzPair(const MachineInstr *FirstMI,
   case AArch64::ORRWrr:
   case AArch64::ORRXri:
   case AArch64::ORRXrr:
+  case AArch64::ORNWrr:
+  case AArch64::ORNXrr:
   case AArch64::SUBWri:
   case AArch64::SUBWrr:
   case AArch64::SUBXri:
   case AArch64::SUBXrr:
+  case AArch64::BICWrr:
+  case AArch64::BICXrr:
     return true;
   case AArch64::ADDWrs:
   case AArch64::ADDXrs:
   case AArch64::ANDWrs:
   case AArch64::ANDXrs:
+  case AArch64::EORWrs:
+  case AArch64::EORXrs:
+  case AArch64::ORNWrs:
+  case AArch64::ORNXrs:
+  case AArch64::ORRWrs:
+  case AArch64::ORRXrs:
   case AArch64::SUBWrs:
   case AArch64::SUBXrs:
   case AArch64::BICWrs:

--- a/llvm/test/CodeGen/AArch64/misched-fusion-arith-cbz.ll
+++ b/llvm/test/CodeGen/AArch64/misched-fusion-arith-cbz.ll
@@ -279,6 +279,78 @@ exit:
   ret void
 }
 
+; CHECK-LABEL: ornwrr_cbz:
+; CHECK:      orn  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
+; CHECK-NEXT: cbz  [[R]], {{.?LBB[0-9_]+}}
+define void @ornwrr_cbz(i32 %a, i32 %b) {
+entry:
+  %n = xor i32 %b, -1
+  %v0 = or i32 %a, %n
+  %v1 = add i32 %a, 7
+  %cond = icmp ne i32 %v0, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
+; CHECK-LABEL: ornwrr_cbnz:
+; CHECK:      orn  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
+; CHECK-NEXT: cbnz [[R]], {{.?LBB[0-9_]+}}
+define void @ornwrr_cbnz(i32 %a, i32 %b) {
+entry:
+  %n = xor i32 %b, -1
+  %v0 = or i32 %a, %n
+  %v1 = add i32 %a, 7
+  %cond = icmp eq i32 %v0, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
+; CHECK-LABEL: bicwrr_cbz:
+; CHECK:      bic  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
+; CHECK-NEXT: cbz  [[R]], {{.?LBB[0-9_]+}}
+define void @bicwrr_cbz(i32 %a, i32 %b) {
+entry:
+  %n = xor i32 %b, -1
+  %v0 = and i32 %a, %n
+  %v1 = add i32 %a, 7
+  %cond = icmp ne i32 %v0, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
+; CHECK-LABEL: bicwrr_cbnz:
+; CHECK:      bic  [[R:w[0-9]+]], {{w[0-9]+}}, {{w[0-9]+}}
+; CHECK-NEXT: cbnz [[R]], {{.?LBB[0-9_]+}}
+define void @bicwrr_cbnz(i32 %a, i32 %b) {
+entry:
+  %n = xor i32 %b, -1
+  %v0 = and i32 %a, %n
+  %v1 = add i32 %a, 7
+  %cond = icmp eq i32 %v0, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi32(i32 %v1, i32 %v0)
+  br label %exit
+exit:
+  call void @fi32(i32 %v0, i32 %v1)
+  ret void
+}
+
 ; CHECK-LABEL: subwri_cbz:
 ; CHECK:      sub  [[R:w[0-9]+]], {{w[0-9]+}}, #13
 ; CHECK-NEXT: cbz  [[R]], {{.?LBB[0-9_]+}}
@@ -608,6 +680,78 @@ exit:
 define void @orrxrr_cbnz(i64 %a, i64 %b) {
 entry:
   %v0 = or i64 %a, %b
+  %v1 = add i64 %a, 7
+  %cond = icmp eq i64 %v0, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
+; CHECK-LABEL: ornxrr_cbz:
+; CHECK:      orn  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
+; CHECK-NEXT: cbz  [[R]], {{.?LBB[0-9_]+}}
+define void @ornxrr_cbz(i64 %a, i64 %b) {
+entry:
+  %n = xor i64 %b, -1
+  %v0 = or i64 %a, %n
+  %v1 = add i64 %a, 7
+  %cond = icmp ne i64 %v0, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
+; CHECK-LABEL: ornxrr_cbnz:
+; CHECK:      orn  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
+; CHECK-NEXT: cbnz [[R]], {{.?LBB[0-9_]+}}
+define void @ornxrr_cbnz(i64 %a, i64 %b) {
+entry:
+  %n = xor i64 %b, -1
+  %v0 = or i64 %a, %n
+  %v1 = add i64 %a, 7
+  %cond = icmp eq i64 %v0, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
+; CHECK-LABEL: bicxrr_cbz:
+; CHECK:      bic  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
+; CHECK-NEXT: cbz  [[R]], {{.?LBB[0-9_]+}}
+define void @bicxrr_cbz(i64 %a, i64 %b) {
+entry:
+  %n = xor i64 %b, -1
+  %v0 = and i64 %a, %n
+  %v1 = add i64 %a, 7
+  %cond = icmp ne i64 %v0, 0
+  br i1 %cond, label %if, label %exit
+if:
+  call void @fi64(i64 %v1, i64 %v0)
+  br label %exit
+exit:
+  call void @fi64(i64 %v0, i64 %v1)
+  ret void
+}
+
+; CHECK-LABEL: bicxrr_cbnz:
+; CHECK:      bic  [[R:x[0-9]+]], {{x[0-9]+}}, {{x[0-9]+}}
+; CHECK-NEXT: cbnz [[R]], {{.?LBB[0-9_]+}}
+define void @bicxrr_cbnz(i64 %a, i64 %b) {
+entry:
+  %n = xor i64 %b, -1
+  %v0 = and i64 %a, %n
   %v1 = add i64 %a, 7
   %cond = icmp eq i64 %v0, 0
   br i1 %cond, label %if, label %exit

--- a/llvm/test/CodeGen/AArch64/misched-fusion-arith-cbz.mir
+++ b/llvm/test/CodeGen/AArch64/misched-fusion-arith-cbz.mir
@@ -418,6 +418,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: eorwrs_cbz
+# CHECK: SU({{[0-9]+}}): $w0 = EORWrs $w0, $w1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: CBZW
+---
+name: eorwrs_cbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = EORWrs $w0, $w1, 0
+    $w3 = ORRWri $w2, 4096
+    CBZW $w0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: eorwrs_cbnz
+# CHECK: SU({{[0-9]+}}): $w0 = EORWrs $w0, $w1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: CBNZW
+---
+name: eorwrs_cbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = EORWrs $w0, $w1, 0
+    $w3 = ORRWri $w2, 4096
+    CBNZW $w0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: no_fuse_positive_shift_eorwrs
 # CHECK: SU({{[0-9]+}}): $w0 = EORWrs $w0, $w1, 12
 # CHECK: Successors:
@@ -433,6 +479,121 @@ body: |
     successors: %bb.1, %bb.2
     liveins: $w0, $w1, $w2
     $w0 = EORWrs $w0, $w1, 12
+    $w3 = ORRWri $w2, 4096
+    CBNZW $w0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: ornwrr_cbz
+# CHECK: SU({{[0-9]+}}): $w0 = ORNWrr $w0, $w1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: CBZW
+---
+name: ornwrr_cbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ORNWrr $w0, $w1
+    $w3 = ORRWri $w2, 4096
+    CBZW $w0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: ornwrr_cbnz
+# CHECK: SU({{[0-9]+}}): $w0 = ORNWrr $w0, $w1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: CBNZW
+---
+name: ornwrr_cbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ORNWrr $w0, $w1
+    $w3 = ORRWri $w2, 4096
+    CBNZW $w0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: ornwrs_cbz
+# CHECK: SU({{[0-9]+}}): $w0 = ORNWrs $w0, $w1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: CBZW
+---
+name: ornwrs_cbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ORNWrs $w0, $w1, 0
+    $w3 = ORRWri $w2, 4096
+    CBZW $w0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: ornwrs_cbnz
+# CHECK: SU({{[0-9]+}}): $w0 = ORNWrs $w0, $w1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: CBNZW
+---
+name: ornwrs_cbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ORNWrs $w0, $w1, 0
+    $w3 = ORRWri $w2, 4096
+    CBNZW $w0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: no_fuse_positive_shift_ornwrs
+# CHECK: SU({{[0-9]+}}): $w0 = ORNWrs $w0, $w1, 12
+# CHECK: Successors:
+# CHECK-NOT: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: CBNZW
+---
+name: no_fuse_positive_shift_ornwrs
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ORNWrs $w0, $w1, 12
     $w3 = ORRWri $w2, 4096
     CBNZW $w0, %bb.2
   bb.1:
@@ -525,6 +686,52 @@ body: |
     successors: %bb.1, %bb.2
     liveins: $w0, $w1, $w2
     $w0 = ORRWrr $w0, $w1
+    $w3 = ORRWri $w2, 4096
+    CBNZW $w0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: orrwrs_cbz
+# CHECK: SU({{[0-9]+}}): $w0 = ORRWrs $w0, $w1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: CBZW
+---
+name: orrwrs_cbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ORRWrs $w0, $w1, 0
+    $w3 = ORRWri $w2, 4096
+    CBZW $w0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: orrwrs_cbnz
+# CHECK: SU({{[0-9]+}}): $w0 = ORRWrs $w0, $w1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: CBNZW
+---
+name: orrwrs_cbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = ORRWrs $w0, $w1, 0
     $w3 = ORRWri $w2, 4096
     CBNZW $w0, %bb.2
   bb.1:
@@ -709,6 +916,52 @@ body: |
     successors: %bb.1, %bb.2
     liveins: $w0, $w1, $w2
     $w0 = SUBWrs $w0, $w1, 12
+    $w3 = ORRWri $w2, 4096
+    CBNZW $w0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: bicwrr_cbz
+# CHECK: SU({{[0-9]+}}): $w0 = BICWrr $w0, $w1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: CBZW
+---
+name: bicwrr_cbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = BICWrr $w0, $w1
+    $w3 = ORRWri $w2, 4096
+    CBZW $w0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: bicwrr_cbnz
+# CHECK: SU({{[0-9]+}}): $w0 = BICWrr $w0, $w1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: CBNZW
+---
+name: bicwrr_cbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $w0, $w1, $w2
+    $w0 = BICWrr $w0, $w1
     $w3 = ORRWri $w2, 4096
     CBNZW $w0, %bb.2
   bb.1:
@@ -1200,6 +1453,52 @@ body: |
     RET undef $lr
 ...
 
+# CHECK-LABEL: eorxrs_cbz
+# CHECK: SU({{[0-9]+}}): $x0 = EORXrs $x0, $x1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: CBZX
+---
+name: eorxrs_cbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = EORXrs $x0, $x1, 0
+    $x3 = ORRXri $x2, 8192
+    CBZX $x0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: eorxrs_cbnz
+# CHECK: SU({{[0-9]+}}): $x0 = EORXrs $x0, $x1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: CBNZX
+---
+name: eorxrs_cbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = EORXrs $x0, $x1, 0
+    $x3 = ORRXri $x2, 8192
+    CBNZX $x0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
 # CHECK-LABEL: no_fuse_positive_shift_eorxrs
 # CHECK: SU({{[0-9]+}}): $x0 = EORXrs $x0, $x1, 12
 # CHECK: Successors:
@@ -1215,6 +1514,121 @@ body: |
     successors: %bb.1, %bb.2
     liveins: $x0, $x1, $x2
     $x0 = EORXrs $x0, $x1, 12
+    $x3 = ORRXri $x2, 8192
+    CBNZX $x0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: ornxrr_cbz
+# CHECK: SU({{[0-9]+}}): $x0 = ORNXrr $x0, $x1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: CBZX
+---
+name: ornxrr_cbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ORNXrr $x0, $x1
+    $x3 = ORRXri $x2, 8192
+    CBZX $x0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: ornxrr_cbnz
+# CHECK: SU({{[0-9]+}}): $x0 = ORNXrr $x0, $x1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: CBNZX
+---
+name: ornxrr_cbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ORNXrr $x0, $x1
+    $x3 = ORRXri $x2, 8192
+    CBNZX $x0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: ornxrs_cbz
+# CHECK: SU({{[0-9]+}}): $x0 = ORNXrs $x0, $x1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: CBZX
+---
+name: ornxrs_cbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ORNXrs $x0, $x1, 0
+    $x3 = ORRXri $x2, 8192
+    CBZX $x0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: ornxrs_cbnz
+# CHECK: SU({{[0-9]+}}): $x0 = ORNXrs $x0, $x1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: CBNZX
+---
+name: ornxrs_cbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ORNXrs $x0, $x1, 0
+    $x3 = ORRXri $x2, 8192
+    CBNZX $x0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: no_fuse_positive_shift_ornxrs
+# CHECK: SU({{[0-9]+}}): $x0 = ORNXrs $x0, $x1, 12
+# CHECK: Successors:
+# CHECK-NOT: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: CBNZX
+---
+name: no_fuse_positive_shift_ornxrs
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ORNXrs $x0, $x1, 12
     $x3 = ORRXri $x2, 8192
     CBNZX $x0, %bb.2
   bb.1:
@@ -1307,6 +1721,52 @@ body: |
     successors: %bb.1, %bb.2
     liveins: $x0, $x1, $x2
     $x0 = ORRXrr $x0, $x1
+    $x3 = ORRXri $x2, 8192
+    CBNZX $x0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: orrxrs_cbz
+# CHECK: SU({{[0-9]+}}): $x0 = ORRXrs $x0, $x1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: CBZX
+---
+name: orrxrs_cbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ORRXrs $x0, $x1, 0
+    $x3 = ORRXri $x2, 8192
+    CBZX $x0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: orrxrs_cbnz
+# CHECK: SU({{[0-9]+}}): $x0 = ORRXrs $x0, $x1, 0
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: CBNZX
+---
+name: orrxrs_cbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = ORRXrs $x0, $x1, 0
     $x3 = ORRXri $x2, 8192
     CBNZX $x0, %bb.2
   bb.1:
@@ -1491,6 +1951,52 @@ body: |
     successors: %bb.1, %bb.2
     liveins: $x0, $x1, $x2
     $x0 = SUBXrs $x0, $x1, 12
+    $x3 = ORRXri $x2, 8192
+    CBNZX $x0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: bicxrr_cbz
+# CHECK: SU({{[0-9]+}}): $x0 = BICXrr $x0, $x1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: CBZX
+---
+name: bicxrr_cbz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = BICXrr $x0, $x1
+    $x3 = ORRXri $x2, 8192
+    CBZX $x0, %bb.2
+  bb.1:
+    RET undef $lr
+  bb.2:
+    RET undef $lr
+...
+
+# CHECK-LABEL: bicxrr_cbnz
+# CHECK: SU({{[0-9]+}}): $x0 = BICXrr $x0, $x1
+# CHECK: Successors:
+# CHECK: ExitSU: Ord  Latency={{[0-9]+}} Cluster
+# CHECK: ExitSU: CBNZX
+---
+name: bicxrr_cbnz
+tracksRegLiveness: true
+isSSA: false
+noVRegs: true
+body: |
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $x0, $x1, $x2
+    $x0 = BICXrr $x0, $x1
     $x3 = ORRXri $x2, 8192
     CBNZX $x0, %bb.2
   bb.1:


### PR DESCRIPTION
This patch adds a few missing opcodes for arithmetic+CB(N)Z clustering. Most of them complement an already existing rr/rs variant for pre/post-RA coverage. The only one which is completely new is ORN which I think can be reasonably expected to behave similarly on AArch64 targets.