### PR TITLE
[lldb] Add static asserts on Symbol size to DataFileCache

### DIFF
--- a/lldb/source/Symbol/Symbol.cpp
+++ b/lldb/source/Symbol/Symbol.cpp
@@ -646,6 +646,16 @@ bool Symbol::Decode(const DataExtractor &data, lldb::offset_t *offset_ptr,
   return true;
 }
 
+// If the size of Symbol has changed, the Encode and
+// Decode methods also likely need to be updated and
+// the DataFileCache version number in Symtab::Encode
+// will need to be incremented as well.
+#if __SIZEOF_POINTER__ == 8
+static_assert(sizeof(lldb_private::Symbol) == 80,
+              "Symbol size has changed, Symbol::Encode and Decode likely need "
+              "to be updated");
+#endif
+
 /// The encoding format for the symbol is as follows:
 ///
 /// uint32_t m_uid;

--- a/lldb/source/Symbol/Symtab.cpp
+++ b/lldb/source/Symbol/Symtab.cpp
@@ -1229,6 +1229,15 @@ bool DecodeCStrMap(const DataExtractor &data, lldb::offset_t *offset_ptr,
 constexpr llvm::StringLiteral kIdentifierSymbolTable("SYMB");
 constexpr uint32_t CURRENT_CACHE_VERSION = 1;
 
+// If the size of the Symbol object changes, the serialized
+// format likely also needs to change so the
+// CURRENT_CACHE_VERSION number will need to be incremented.
+#if __SIZEOF_POINTER__ == 8
+static_assert(
+    sizeof(lldb_private::Symbol) == 80,
+    "Symbol size has changed, DataFileCache version likely needs updating");
+#endif
+
 /// The encoding format for the symbol table is as follows:
 ///
 /// Signature signature;


### PR DESCRIPTION
DataFileCache is a serialization to disk of a Symtab - the symbol names and array of Symbol objects - so if the contents of the Symbol object change, the serialization may need to change as well, and we need to bump the DataFileCache version number to avoid misparsing an older format.

It's also a little too easy to change Symbol and not notice that Symbol::Encode/Decode and Symtab::Encode/Decode need to be updated.

static_asserting the size of Symbol isn't perfect, but as long as we're doing it in Symbol.h already to warn anyone increasing the size of this object, I want to use the same technique to make sure people look at these other sites that are tied to the contents.