### PR TITLE
[clang][bytecode] Override constant context state in CallVar

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1774,9 +1774,7 @@ bool CallVar(InterpState &S, CodePtr OpPC, const Function *Func,
   InterpFrame *FrameBefore = S.Current;
   S.Current = NewFrame;
 
-  // Note that we cannot assert(CallResult.hasValue()) here since
-  // Ret() above only sets the APValue if the curent frame doesn't
-  // have a caller set.
+  InterpStateCCOverride CCOverride(S, Func->isImmediate());
   if (Interpret(S)) {
     assert(S.Current == FrameBefore);
     return true;
@@ -1868,9 +1866,6 @@ bool Call(InterpState &S, CodePtr OpPC, const Function *Func,
   S.Current = NewFrame;
 
   InterpStateCCOverride CCOverride(S, Func->isImmediate());
-  // Note that we cannot assert(CallResult.hasValue()) here since
-  // Ret() above only sets the APValue if the curent frame doesn't
-  // have a caller set.
   bool Success = Interpret(S);
   // Remove initializing  block again.
   if (Func->isConstructor() || Func->isDestructor())

--- a/clang/test/AST/ByteCode/codegen-cxx2a.cpp
+++ b/clang/test/AST/ByteCode/codegen-cxx2a.cpp
@@ -1,0 +1,26 @@
+// RUN: %clang_cc1 -emit-llvm %s -std=c++2a -triple x86_64-unknown-linux-gnu -fexperimental-new-constant-interpreter -o - | FileCheck %s
+// RUN: %clang_cc1 -emit-llvm %s -std=c++2a -triple x86_64-unknown-linux-gnu                                         -o - | FileCheck %s
+
+
+struct Agg {
+  int a;
+  long b;
+};
+consteval Agg is_const(...) {
+  return {5, 19 * __builtin_is_constant_evaluated()};
+}
+// CHECK-LABEL: @_Z13test_is_constv(
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[B:%.*]] = alloca i64, align 8
+// CHECK-NEXT:    [[REF_TMP:%.*]] = alloca [[STRUCT_AGG:%.*]], align 8
+// CHECK-NEXT:    [[TMP0:%.*]] = getelementptr inbounds nuw [[STRUCT_AGG]], ptr [[REF_TMP]], i32 0, i32 0
+// CHECK-NEXT:    store i32 5, ptr [[TMP0]], align 8
+// CHECK-NEXT:    [[TMP1:%.*]] = getelementptr inbounds nuw [[STRUCT_AGG]], ptr [[REF_TMP]], i32 0, i32 1
+// CHECK-NEXT:    store i64 19, ptr [[TMP1]], align 8
+// CHECK-NEXT:    store i64 19, ptr [[B]], align 8
+// CHECK-NEXT:    [[TMP2:%.*]] = load i64, ptr [[B]], align 8
+// CHECK-NEXT:    ret i64 [[TMP2]]
+long test_is_const() {
+  long b = is_const().b;
+  return b;
+}


### PR DESCRIPTION
We do this for regular calls, so do it for variable calls as well. Also remove two comments that don't have any meaning today anymore.