### PR TITLE
[clang][bytecode] Add `Block::invokeCtorNoMemset()`

### DIFF
--- a/clang/lib/AST/ByteCode/DynamicAllocator.cpp
+++ b/clang/lib/AST/ByteCode/DynamicAllocator.cpp
@@ -76,7 +76,7 @@ Block *DynamicAllocator::allocate(const Descriptor *D, unsigned EvalID,
   auto Memory =
       std::make_unique<std::byte[]>(sizeof(Block) + D->getAllocSize());
   auto *B = new (Memory.get()) Block(EvalID, D, /*isStatic=*/false);
-  B->invokeCtor();
+  B->invokeCtorNoMemset();
 
   assert(D->getMetadataSize() == sizeof(InlineDescriptor));
   InlineDescriptor *ID = reinterpret_cast<InlineDescriptor *>(B->rawData());

--- a/clang/lib/AST/ByteCode/EvalEmitter.cpp
+++ b/clang/lib/AST/ByteCode/EvalEmitter.cpp
@@ -134,7 +134,7 @@ Scope::Local EvalEmitter::createLocal(Descriptor *D) {
   // Allocate memory for a local.
   auto Memory = std::make_unique<char[]>(sizeof(Block) + D->getAllocSize());
   auto *B = new (Memory.get()) Block(Ctx.getEvalID(), D, /*IsStatic=*/false);
-  B->invokeCtor();
+  B->invokeCtorNoMemset();
 
   // Initialize local variable inline descriptor.
   auto &Desc = B->getBlockDesc<InlineDescriptor>();

--- a/clang/lib/AST/ByteCode/InterpBlock.h
+++ b/clang/lib/AST/ByteCode/InterpBlock.h
@@ -136,11 +136,16 @@ public:
   void invokeCtor() {
     assert(!IsInitialized);
     std::memset(rawData(), 0, Desc->getAllocSize());
-    if (Desc->CtorFn) {
+    invokeCtorNoMemset();
+  }
+  /// The same, but won't memset() the memory first to zero.
+  void invokeCtorNoMemset() {
+    assert(!IsInitialized);
+    if (Desc->CtorFn)
       Desc->CtorFn(this, data(), Desc->IsConst, Desc->IsMutable,
                    Desc->IsVolatile,
                    /*isActive=*/true, /*InUnion=*/false, Desc);
-    }
+
     IsInitialized = true;
   }
 


### PR DESCRIPTION
`invokeCtor()` first memsets the memory to zero, then calls the descriptor ctor function. The memset is unnecessary if we're already working with zero-ed memory, like the one we get from `std::make_unique`.