### PR TITLE
clang/AMDGPU: Split out target ID flags in TranslateArgs.

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -5862,6 +5862,10 @@ defm cumode : SimpleMFlag<"cumode",
   " execution mode (AMDGPU only)", m_amdgpu_Features_Group>;
 defm tgsplit : SimpleMFlag<"tgsplit", "Enable", "Disable",
   " threadgroup split execution mode (AMDGPU only)", m_amdgpu_Features_Group>;
+defm xnack : SimpleMFlag<"xnack", "Enable", "Disable",
+  " XNACK (AMDGPU only)", m_amdgpu_Features_Group>;
+defm sramecc : SimpleMFlag<"sramecc", "Enable", "Disable",
+  " SRAMECC (AMDGPU only)", m_amdgpu_Features_Group>;
 defm wavefrontsize64 : SimpleMFlag<"wavefrontsize64",
   "Specify wavefront size 64", "Specify wavefront size 32",
   " mode (AMDGPU only)">;

--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -658,28 +658,6 @@ void amdgpu::getAMDGPUTargetFeatures(const Driver &D,
                                      const llvm::Triple &Triple,
                                      const llvm::opt::ArgList &Args,
                                      std::vector<StringRef> &Features) {
-  // Add target ID features to -target-feature options. No diagnostics should
-  // be emitted here since invalid target ID is diagnosed at other places.
-  StringRef TargetID = Args.getLastArgValue(options::OPT_mcpu_EQ);
-  if (!TargetID.empty()) {
-    llvm::StringMap<bool> FeatureMap;
-    auto OptionalGpuArch = parseTargetID(Triple, TargetID, &FeatureMap);
-    if (OptionalGpuArch) {
-      StringRef GpuArch = *OptionalGpuArch;
-      // Iterate through all possible target ID features for the given GPU.
-      // If it is mapped to true, add +feature.
-      // If it is mapped to false, add -feature.
-      // If it is not in the map (default), do not add it
-      for (auto &&Feature : getAllPossibleTargetIDFeatures(Triple, GpuArch)) {
-        auto Pos = FeatureMap.find(Feature);
-        if (Pos == FeatureMap.end())
-          continue;
-        Features.push_back(Args.MakeArgStringRef(
-            (Twine(Pos->second ? "+" : "-") + Feature).str()));
-      }
-    }
-  }
-
   if (Args.hasFlag(options::OPT_mwavefrontsize64,
                    options::OPT_mno_wavefrontsize64, false))
     Features.push_back("+wavefrontsize64");
@@ -755,9 +733,27 @@ AMDGPUToolChain::TranslateArgs(const DerivedArgList &Args, StringRef BoundArch,
   if (!BoundArch.empty()) {
     DAL->eraseArg(options::OPT_mcpu_EQ);
     DAL->AddJoinedArg(nullptr, Opts.getOption(options::OPT_mcpu_EQ), BoundArch);
-    checkTargetID(*DAL);
-  } else if (DeviceOffloadKind == Action::OFK_None) {
-    checkTargetID(*DAL);
+  }
+
+  AMDGPUToolChain::ParsedTargetIDType PTID = checkTargetID(*DAL);
+
+  // Synthesize feature flags for target ID modifiers (xnack, sramecc).
+  if (PTID.OptionalFeatureMap) {
+    const llvm::StringMap<bool> &FeatureMap = *PTID.OptionalFeatureMap;
+
+    auto XnackIt = FeatureMap.find("xnack");
+    if (XnackIt != FeatureMap.end()) {
+      DAL->AddFlagArg(nullptr,
+                      Opts.getOption(XnackIt->second ? options::OPT_mxnack
+                                                     : options::OPT_mno_xnack));
+    }
+
+    auto SrameccIt = FeatureMap.find("sramecc");
+    if (SrameccIt != FeatureMap.end()) {
+      DAL->AddFlagArg(nullptr, Opts.getOption(SrameccIt->second
+                                                  ? options::OPT_msramecc
+                                                  : options::OPT_mno_sramecc));
+    }
   }
 
   if (Args.getLastArgValue(options::OPT_x) != "cl")
@@ -947,13 +943,14 @@ AMDGPUToolChain::getParsedTargetID(const llvm::opt::ArgList &DriverArgs) const {
   return {TargetID.str(), OptionalGpuArch->str(), FeatureMap};
 }
 
-void AMDGPUToolChain::checkTargetID(
-    const llvm::opt::ArgList &DriverArgs) const {
+AMDGPUToolChain::ParsedTargetIDType
+AMDGPUToolChain::checkTargetID(const llvm::opt::ArgList &DriverArgs) const {
   auto PTID = getParsedTargetID(DriverArgs);
   if (PTID.OptionalTargetID && !PTID.OptionalGPUArch) {
     getDriver().Diag(clang::diag::err_drv_bad_target_id)
         << *PTID.OptionalTargetID;
   }
+  return PTID;
 }
 
 Expected<SmallVector<std::string>>

--- a/clang/lib/Driver/ToolChains/AMDGPU.h
+++ b/clang/lib/Driver/ToolChains/AMDGPU.h
@@ -110,15 +110,17 @@ public:
   getSystemGPUArchs(const llvm::opt::ArgList &Args) const override;
 
 protected:
-  /// Check and diagnose invalid target ID specified by -mcpu.
-  virtual void checkTargetID(const llvm::opt::ArgList &DriverArgs) const;
-
   /// The struct type returned by getParsedTargetID.
   struct ParsedTargetIDType {
     std::optional<std::string> OptionalTargetID;
     std::optional<std::string> OptionalGPUArch;
-    std::optional<llvm::StringMap<bool>> OptionalFeatures;
+    std::optional<llvm::StringMap<bool>> OptionalFeatureMap;
   };
+
+  /// Check and diagnose invalid target ID specified by -mcpu.
+  /// Returns the parsed target ID.
+  virtual ParsedTargetIDType
+  checkTargetID(const llvm::opt::ArgList &DriverArgs) const;
 
   /// Get target ID, GPU arch, and target ID features if the target ID is
   /// specified and valid.

--- a/clang/lib/Driver/ToolChains/HIPAMD.cpp
+++ b/clang/lib/Driver/ToolChains/HIPAMD.cpp
@@ -409,13 +409,14 @@ HIPAMDToolChain::getDeviceLibs(const llvm::opt::ArgList &DriverArgs,
   return BCLibs;
 }
 
-void HIPAMDToolChain::checkTargetID(
-    const llvm::opt::ArgList &DriverArgs) const {
+HIPAMDToolChain::ParsedTargetIDType
+HIPAMDToolChain::checkTargetID(const llvm::opt::ArgList &DriverArgs) const {
   auto PTID = getParsedTargetID(DriverArgs);
   if (PTID.OptionalTargetID && !PTID.OptionalGPUArch &&
       PTID.OptionalTargetID != "amdgcnspirv")
     getDriver().Diag(clang::diag::err_drv_bad_target_id)
         << *PTID.OptionalTargetID;
+  return PTID;
 }
 
 SPIRVAMDToolChain::SPIRVAMDToolChain(const Driver &D,

--- a/clang/lib/Driver/ToolChains/HIPAMD.h
+++ b/clang/lib/Driver/ToolChains/HIPAMD.h
@@ -95,7 +95,8 @@ public:
   LTOKind getDefaultLTOMode() const override { return LTOK_Full; }
 
   const ToolChain &HostTC;
-  void checkTargetID(const llvm::opt::ArgList &DriverArgs) const override;
+  ParsedTargetIDType
+  checkTargetID(const llvm::opt::ArgList &DriverArgs) const override;
 
 protected:
   Tool *buildLinker() const override;

--- a/clang/test/Driver/amdgpu-openmp-toolchain.c
+++ b/clang/test/Driver/amdgpu-openmp-toolchain.c
@@ -63,7 +63,7 @@
 
 // RUN: %clang -### -target x86_64-pc-linux-gnu -fopenmp --offload-arch=gfx90a:sramecc-:xnack+ \
 // RUN:   -nogpulib %s 2>&1 | FileCheck %s --check-prefix=CHECK-TARGET-ID
-// CHECK-TARGET-ID: "-cc1" "-triple" "amdgcn-amd-amdhsa" {{.*}} "-target-cpu" "gfx90a" "-target-feature" "-sramecc" "-target-feature" "+xnack"
+// CHECK-TARGET-ID: "-cc1" "-triple" "amdgcn-amd-amdhsa" {{.*}} "-target-cpu" "gfx90a" "-target-feature" "+xnack" "-target-feature" "-sramecc"
 // CHECK-TARGET-ID: llvm-offload-binary{{.*}}arch=gfx90a:sramecc-:xnack+,kind=openmp
 
 // RUN: not %clang -### -target x86_64-pc-linux-gnu -fopenmp --offload-arch=gfx90a,gfx90a:xnack+ \

--- a/clang/test/Driver/amdgpu-toolchain.c
+++ b/clang/test/Driver/amdgpu-toolchain.c
@@ -25,11 +25,11 @@
 // RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx90a:xnack+:sramecc- -nogpulib \
 // RUN:   -L. -flto -fconvergent-functions %s 2>&1 | FileCheck -check-prefix=LTO %s
 // LTO: clang{{.*}}"-flto=full"{{.*}}"-fconvergent-functions"
-// LTO: ld.lld{{.*}}"-plugin-opt=mcpu=gfx90a"{{.*}}"-plugin-opt=-mattr=-sramecc,+xnack"{{.*}}
+// LTO: ld.lld{{.*}}"-plugin-opt=mcpu=gfx90a"{{.*}}"-plugin-opt=-mattr=+xnack,-sramecc"{{.*}}
 
 // RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx90a:xnack+:sramecc- -nogpulib \
 // RUN:   -L. -fconvergent-functions %s 2>&1 | FileCheck -check-prefix=MCPU %s
-// MCPU: ld.lld{{.*}}"-plugin-opt=mcpu=gfx90a"{{.*}}"-plugin-opt=-mattr=-sramecc,+xnack"{{.*}}
+// MCPU: ld.lld{{.*}}"-plugin-opt=mcpu=gfx90a"{{.*}}"-plugin-opt=-mattr=+xnack,-sramecc"{{.*}}
 
 // RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx906 -nogpulib \
 // RUN:   -fuse-ld=ld %s 2>&1 | FileCheck -check-prefixes=LD %s

--- a/clang/test/Driver/amdgpu-xnack-sramecc-flags.c
+++ b/clang/test/Driver/amdgpu-xnack-sramecc-flags.c
@@ -1,0 +1,149 @@
+// Test for -mxnack/-mno-xnack and -msramecc/-mno-sramecc flags
+
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx90a -mxnack %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=XNACK-ON %s
+// XNACK-ON: "-target-feature" "+xnack"
+
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx90a -mno-xnack %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=XNACK-OFF %s
+// XNACK-OFF: "-target-feature" "-xnack"
+
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx90a -msramecc %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=SRAMECC-ON %s
+// SRAMECC-ON: "-target-feature" "+sramecc"
+
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx90a -mno-sramecc %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=SRAMECC-OFF %s
+// SRAMECC-OFF: "-target-feature" "-sramecc"
+
+// Test that target ID takes precedence over explicit flags
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx90a:xnack+ -mno-xnack %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=TARGETID-OVERRIDES-XNACK %s
+// TARGETID-OVERRIDES-XNACK: "-target-feature" "+xnack"
+
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx90a:xnack- -mxnack %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=TARGETID-OVERRIDES-XNACK-OFF %s
+// TARGETID-OVERRIDES-XNACK-OFF: "-target-feature" "-xnack"
+
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx90a:sramecc+ -mno-sramecc %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=TARGETID-OVERRIDES-SRAMECC %s
+// TARGETID-OVERRIDES-SRAMECC: "-target-feature" "+sramecc"
+
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx90a:sramecc- -msramecc %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=TARGETID-OVERRIDES-SRAMECC-OFF %s
+// TARGETID-OVERRIDES-SRAMECC-OFF: "-target-feature" "-sramecc"
+
+// Test combining both flags
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx90a -mxnack -msramecc %s 2>&1 | \
+// RUN:   FileCheck -check-prefixes=BOTH-ON %s
+// BOTH-ON: "-target-feature" "+xnack"
+// BOTH-ON-SAME: "-target-feature" "+sramecc"
+
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx90a -mno-xnack -mno-sramecc %s 2>&1 | \
+// RUN:   FileCheck -check-prefixes=BOTH-OFF %s
+// BOTH-OFF: "-target-feature" "-xnack"
+// BOTH-OFF-SAME: "-target-feature" "-sramecc"
+
+// Test that target ID without explicit features doesn't synthesize flags
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx90a %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=NO-FEATURES %s
+// NO-FEATURES-NOT: "-target-feature" "{{[+-]}}xnack"
+// NO-FEATURES-NOT: "-target-feature" "{{[+-]}}sramecc"
+
+// Test target ID features are synthesized
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx90a:xnack+ %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=TARGETID-XNACK %s
+// TARGETID-XNACK: "-target-feature" "+xnack"
+
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx90a:sramecc+ %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=TARGETID-SRAMECC %s
+// TARGETID-SRAMECC: "-target-feature" "+sramecc"
+
+// RUN: %clang -### --target=amdgcn-amd-amdhsa -mcpu=gfx90a:xnack+:sramecc+ %s 2>&1 | \
+// RUN:   FileCheck -check-prefixes=TARGETID-BOTH %s
+// TARGETID-BOTH: "-target-feature" "+xnack"
+// TARGETID-BOTH-SAME: "-target-feature" "+sramecc"
+
+//
+// Offload tests
+//
+
+// Test offload with target ID features synthesized from --offload-arch
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fopenmp --offload-arch=gfx90a:xnack+:sramecc- \
+// RUN:   -nogpulib %s 2>&1 | FileCheck -check-prefix=OMP-TARGETID %s
+// OMP-TARGETID: "-cc1" "-triple" "amdgcn-amd-amdhsa" {{.*}} "-target-cpu" "gfx90a"
+// OMP-TARGETID-SAME: "-target-feature" "+xnack"
+// OMP-TARGETID-SAME: "-target-feature" "-sramecc"
+
+// Test offload using -fopenmp-targets with target ID
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx908:xnack-:sramecc+ \
+// RUN:   -nogpulib %s 2>&1 | FileCheck -check-prefix=OMP-MARCH %s
+// OMP-MARCH: "-cc1" "-triple" "amdgcn-amd-amdhsa" {{.*}} "-target-cpu" "gfx908"
+// OMP-MARCH-SAME: "-target-feature" "-xnack"
+// OMP-MARCH-SAME: "-target-feature" "+sramecc"
+
+// Test offload with explicit device flags using -Xopenmp-target
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -mxnack \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -mno-sramecc \
+// RUN:   -nogpulib %s 2>&1 | FileCheck -check-prefix=OMP-FLAGS %s
+// OMP-FLAGS: "-cc1" "-triple" "amdgcn-amd-amdhsa" {{.*}} "-target-cpu" "gfx90a"
+// OMP-FLAGS-SAME: "-target-feature" "+xnack"
+// OMP-FLAGS-SAME: "-target-feature" "-sramecc"
+
+// Test offload with target ID taking precedence over explicit flags
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a:xnack- \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -mxnack \
+// RUN:   -nogpulib %s 2>&1 | FileCheck -check-prefix=OMP-TARGETID-WINS %s
+// OMP-TARGETID-WINS: "-cc1" "-triple" "amdgcn-amd-amdhsa" {{.*}} "-target-cpu" "gfx90a"
+// OMP-TARGETID-WINS-SAME: "-target-feature" "-xnack"
+
+// Test offload using base architecture gfx90a with -mxnack flag for xnack+
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fopenmp \
+// RUN:   --offload-arch=gfx90a \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -mxnack \
+// RUN:   -nogpulib %s 2>&1 | FileCheck -check-prefix=OMP-GFX90A-XNACK-ON %s
+// OMP-GFX90A-XNACK-ON: "-cc1" "-triple" "amdgcn-amd-amdhsa" {{.*}} "-target-cpu" "gfx90a"
+// OMP-GFX90A-XNACK-ON-SAME: "-target-feature" "+xnack"
+
+// Test offload using base architecture gfx90a with -mno-xnack flag for xnack-
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fopenmp \
+// RUN:   --offload-arch=gfx90a \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -mno-xnack \
+// RUN:   -nogpulib %s 2>&1 | FileCheck -check-prefix=OMP-GFX90A-XNACK-OFF %s
+// OMP-GFX90A-XNACK-OFF: "-cc1" "-triple" "amdgcn-amd-amdhsa" {{.*}} "-target-cpu" "gfx90a"
+// OMP-GFX90A-XNACK-OFF-SAME: "-target-feature" "-xnack"
+
+// Test offload with multiple device compilations for same base architecture.
+// To get both xnack+ and xnack- for gfx90a in the same invocation, you must use
+// target ID syntax in --offload-arch.
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fopenmp \
+// RUN:   --offload-arch=gfx90a:xnack+ --offload-arch=gfx90a:xnack- -mxnack \
+// RUN:   -nogpulib %s 2>&1 | FileCheck -check-prefix=OMP-MULTI-XNACK %s
+// OMP-MULTI-XNACK: "-cc1" "-triple" "amdgcn-amd-amdhsa" {{.*}} "-target-cpu" "gfx90a"
+// OMP-MULTI-XNACK-SAME: "-target-feature" "+xnack"
+// OMP-MULTI-XNACK: "-cc1" "-triple" "amdgcn-amd-amdhsa" {{.*}} "-target-cpu" "gfx90a"
+// OMP-MULTI-XNACK-SAME: "-target-feature" "-xnack"
+
+// Test that -Xopenmp-target flags apply to all targets with matching triple.
+// When compiling for multiple different base architectures (gfx906, gfx90a),
+// -Xopenmp-target=amdgcn-amd-amdhsa applies the flag to all of them.
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fopenmp \
+// RUN:   --offload-arch=gfx906 --offload-arch=gfx90a \
+// RUN:   -Xopenmp-target=amdgcn-amd-amdhsa -mxnack \
+// RUN:   -nogpulib %s 2>&1 | FileCheck -check-prefix=OMP-MULTI-ARCH %s
+// OMP-MULTI-ARCH: "-cc1" "-triple" "amdgcn-amd-amdhsa" {{.*}} "-target-cpu" "gfx906"
+// OMP-MULTI-ARCH-SAME: "-target-feature" "+xnack"
+// OMP-MULTI-ARCH: "-cc1" "-triple" "amdgcn-amd-amdhsa" {{.*}} "-target-cpu" "gfx90a"
+// OMP-MULTI-ARCH-SAME: "-target-feature" "+xnack"
+
+// Test that top-level -mxnack flags (not specified to the device are ignored).
+// TODO: Should this be forwarded?
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fopenmp \
+// RUN:   --offload-arch=gfx90a -mxnack -mno-sramecc \
+// RUN:   -nogpulib %s 2>&1 | FileCheck -check-prefix=GENERIC-ARG %s
+// GENERIC-ARG: warning: argument unused during compilation: '-mxnack'
+// GENERIC-ARG: warning: argument unused during compilation: '-mno-sramecc'

--- a/clang/test/Driver/hip-target-id.hip
+++ b/clang/test/Driver/hip-target-id.hip
@@ -23,19 +23,24 @@
 
 // CHECK: [[CLANG:"[^"]*clang[^"]*"]] "-cc1" "-triple" "amdgcn-amd-amdhsa"
 // CHECK-SAME: "-target-cpu" "gfx908"
-// CHECK-SAME: "-target-feature" "+sramecc"
 // CHECK-SAME: "-target-feature" "+xnack"
+// CHECK-SAME: "-target-feature" "+sramecc"
+
+// TMP: [[CLANG:"[^"]*clang[^"]*"]] "-cc1as" "-triple" "amdgcn-amd-amdhsa"
+// TMP-SAME: "-target-cpu" "gfx908"
+// TMP-SAME: "-target-feature" "+xnack"
+// TMP-SAME: "-target-feature" "+sramecc"
 
 // CHECK: [[LLD:"[^"]*lld[^"]*"]] {{.*}} "-plugin-opt=mcpu=gfx908"
-// CHECK-SAME: "-plugin-opt=-mattr=+sramecc,+xnack"
+// CHECK-SAME: "-plugin-opt=-mattr=+xnack,+sramecc"
 
 // CHECK: [[CLANG]] "-cc1" "-triple" "amdgcn-amd-amdhsa"
 // CHECK-SAME: "-target-cpu" "gfx908"
-// CHECK-SAME: "-target-feature" "-sramecc"
 // CHECK-SAME: "-target-feature" "+xnack"
+// CHECK-SAME: "-target-feature" "-sramecc"
 
 // CHECK: [[LLD]] {{.*}} "-plugin-opt=mcpu=gfx908"
-// CHECK-SAME: "-plugin-opt=-mattr=-sramecc,+xnack"
+// CHECK-SAME: "-plugin-opt=-mattr=+xnack,-sramecc"
 
 // CHECK: {{"[^"]*clang-offload-bundler[^"]*"}}
 // CHECK-SAME: "-targets=host-x86_64-unknown-linux-gnu,hipv4-amdgcn-amd-amdhsa--gfx908:sramecc+:xnack+,hipv4-amdgcn-amd-amdhsa--gfx908:sramecc-:xnack+"

--- a/clang/test/Driver/hip-toolchain-features.hip
+++ b/clang/test/Driver/hip-toolchain-features.hip
@@ -41,8 +41,8 @@
 // RUN:   -nogpuinc --offload-arch=gfx908:xnack-:sramecc- --no-offload-new-driver %s \
 // RUN:   2>&1 | FileCheck %s -check-prefix=NOALL3
 
-// ALL3: {{.*}}clang{{.*}}"-target-feature" "+sramecc" "-target-feature" "+xnack"
-// NOALL3: {{.*}}clang{{.*}}"-target-feature" "-sramecc" "-target-feature" "-xnack"
+// ALL3: {{.*}}clang{{.*}}"-target-feature" "+xnack" "-target-feature" "+sramecc"
+// NOALL3: {{.*}}clang{{.*}}"-target-feature" "-xnack" "-target-feature" "-sramecc"
 
 // RUN: %clang -### --target=x86_64-linux-gnu -fgpu-rdc -nogpulib \
 // RUN:   -nogpuinc --offload-arch=gfx1010 --no-offload-new-driver %s \

--- a/clang/test/Driver/target-id.cl
+++ b/clang/test/Driver/target-id.cl
@@ -22,8 +22,8 @@
 // RUN:   -nostdlib %s 2>&1 | FileCheck -check-prefix=NONE %s
 
 // CHECK: "-target-cpu" "gfx908"
-// CHECK-SAME: "-target-feature" "-sramecc"
 // CHECK-SAME: "-target-feature" "+xnack"
+// CHECK-SAME: "-target-feature" "-sramecc"
 
 // NONE-NOT: "-target-cpu"
 // NONE-NOT: "-target-feature"


### PR DESCRIPTION
Change how xnack and sramecc are processed. Introduce
-mxnack/-mno-xnack and -msramecc/-mno-sramecc flags.
When the target is first parsed in TranslateArgs, synthesize
the appropriate flag for the toolchain. This avoids
special case feature string fixups in getAMDGPUTargetFeatures,
and also avoids an extra parse of the target ID.

In the future this will also simplify tracking these ABI
modifiers in a module flag.

As a side-effect, you can use these flags to override the
no specifier case with the flags. These do not fully replace
the target ID syntax, as there's no way to represent compiling
both modes for the same subtarget.

I didn't bother trying to forward these flags on the main command
line without being specified to the offload device, but I suppose
that would be possible.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>