### PR TITLE
[clang] Warn on signed char array constant conversion

### DIFF
--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -326,8 +326,7 @@ features cannot lower the translation-unit ABI level;
   in more diagnostics.
 
 - Fixed a missing `-Wconstant-conversion` diagnostic for `signed char` array
-  initialization.
-
+  initialization. (#GH181730)
 
 ### Improvements to Clang's time-trace
 

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -325,6 +325,9 @@ features cannot lower the translation-unit ABI level;
 - Clang now attempts to print enumerator names rather than C-style cast expressions
   in more diagnostics.
 
+- Fixed a missing `-Wconstant-conversion` diagnostic for `signed char` array
+  initialization.
+
 
 ### Improvements to Clang's time-trace
 

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -470,8 +470,7 @@ features cannot lower the translation-unit ABI level;
   `int vla[n][0]`. (#GH28328)
 
 - Fixed a missing `-Wconstant-conversion` diagnostic for `signed char` array
-  initialization.
-
+  initialization. (#GH181730)
 
 ### Improvements to Clang's time-trace
 

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -469,6 +469,10 @@ features cannot lower the translation-unit ABI level;
   dimension that is a zero integer constant, as in `struct Empty vla[n]` or
   `int vla[n][0]`. (#GH28328)
 
+- Fixed a missing `-Wconstant-conversion` diagnostic for `signed char` array
+  initialization.
+
+
 ### Improvements to Clang's time-trace
 
 ### Improvements to Coverage Mapping

--- a/clang/docs/ReleaseNotes.md
+++ b/clang/docs/ReleaseNotes.md
@@ -469,8 +469,8 @@ features cannot lower the translation-unit ABI level;
   dimension that is a zero integer constant, as in `struct Empty vla[n]` or
   `int vla[n][0]`. (#GH28328)
 
-- Fixed a missing `-Wconstant-conversion` diagnostic for `signed char` array
-  initialization. (#GH181730)
+- Fixed a missing `-Wconstant-conversion` diagnostic for signed `char` arrays.
+  (#GH181730)
 
 ### Improvements to Clang's time-trace
 

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -13251,7 +13251,7 @@ static void DiagnoseNullConversion(Sema &S, Expr *E, QualType T,
 }
 
 // Helper function to filter out cases for constant width constant conversion.
-// Don't warn on char / unsigned char array initialization or for non-decimal
+// Don't warn on unsigned character array initialization or for non-decimal
 // values.
 static bool isSameWidthConstantConversion(Sema &S, Expr *E, QualType T,
                                           SourceLocation CC) {
@@ -13265,16 +13265,12 @@ static bool isSameWidthConstantConversion(Sema &S, Expr *E, QualType T,
       return false;
   }
 
-  // If the CC location points to a '{', and the destination type is char or
-  // unsigned char, then assume this is an array initialization. Keep warning
-  // for signed char arrays, where values such as 255 change sign.
-  if (CC.isValid() && T->isCharType()) {
-    const auto *BT =
-        dyn_cast<BuiltinType>(S.Context.getCanonicalType(T).getTypePtr());
+  // If the CC location points to a '{' and the type is an unsigned character
+  // type, assume it is an array initialization.
+  if (T->isCharType() && !T->isSignedIntegerType() && CC.isValid()) {
     const char FirstContextCharacter =
         S.getSourceManager().getCharacterData(CC)[0];
-    if (BT && BT->getKind() != BuiltinType::SChar &&
-        FirstContextCharacter == '{')
+    if (FirstContextCharacter == '{')
       return false;
   }
 

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -13251,7 +13251,8 @@ static void DiagnoseNullConversion(Sema &S, Expr *E, QualType T,
 }
 
 // Helper function to filter out cases for constant width constant conversion.
-// Don't warn on char array initialization or for non-decimal values.
+// Don't warn on char / unsigned char array initialization or for non-decimal
+// values.
 static bool isSameWidthConstantConversion(Sema &S, Expr *E, QualType T,
                                           SourceLocation CC) {
   // If initializing from a constant, and the constant starts with '0',
@@ -13264,12 +13265,16 @@ static bool isSameWidthConstantConversion(Sema &S, Expr *E, QualType T,
       return false;
   }
 
-  // If the CC location points to a '{', and the type is char, then assume
-  // assume it is an array initialization.
+  // If the CC location points to a '{', and the destination type is char or
+  // unsigned char, then assume this is an array initialization. Keep warning
+  // for signed char arrays, where values such as 255 change sign.
   if (CC.isValid() && T->isCharType()) {
+    const auto *BT =
+        dyn_cast<BuiltinType>(S.Context.getCanonicalType(T).getTypePtr());
     const char FirstContextCharacter =
         S.getSourceManager().getCharacterData(CC)[0];
-    if (FirstContextCharacter == '{')
+    if (BT && BT->getKind() != BuiltinType::SChar &&
+        FirstContextCharacter == '{')
       return false;
   }
 

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -13266,7 +13266,8 @@ static void DiagnoseNullConversion(Sema &S, Expr *E, QualType T,
 }
 
 // Helper function to filter out cases for constant width constant conversion.
-// Don't warn on char array initialization or for non-decimal values.
+// Don't warn on char / unsigned char array initialization or for non-decimal
+// values.
 static bool isSameWidthConstantConversion(Sema &S, Expr *E, QualType T,
                                           SourceLocation CC) {
   // If initializing from a constant, and the constant starts with '0',
@@ -13279,12 +13280,16 @@ static bool isSameWidthConstantConversion(Sema &S, Expr *E, QualType T,
       return false;
   }
 
-  // If the CC location points to a '{', and the type is char, then assume
-  // assume it is an array initialization.
+  // If the CC location points to a '{', and the destination type is char or
+  // unsigned char, then assume this is an array initialization. Keep warning
+  // for signed char arrays, where values such as 255 change sign.
   if (CC.isValid() && T->isCharType()) {
+    const auto *BT =
+        dyn_cast<BuiltinType>(S.Context.getCanonicalType(T).getTypePtr());
     const char FirstContextCharacter =
         S.getSourceManager().getCharacterData(CC)[0];
-    if (FirstContextCharacter == '{')
+    if (BT && BT->getKind() != BuiltinType::SChar &&
+        FirstContextCharacter == '{')
       return false;
   }
 

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -13266,7 +13266,7 @@ static void DiagnoseNullConversion(Sema &S, Expr *E, QualType T,
 }
 
 // Helper function to filter out cases for constant width constant conversion.
-// Don't warn on char / unsigned char array initialization or for non-decimal
+// Don't warn on unsigned character array initialization or for non-decimal
 // values.
 static bool isSameWidthConstantConversion(Sema &S, Expr *E, QualType T,
                                           SourceLocation CC) {
@@ -13280,16 +13280,12 @@ static bool isSameWidthConstantConversion(Sema &S, Expr *E, QualType T,
       return false;
   }
 
-  // If the CC location points to a '{', and the destination type is char or
-  // unsigned char, then assume this is an array initialization. Keep warning
-  // for signed char arrays, where values such as 255 change sign.
-  if (CC.isValid() && T->isCharType()) {
-    const auto *BT =
-        dyn_cast<BuiltinType>(S.Context.getCanonicalType(T).getTypePtr());
+  // If the CC location points to a '{' and the type is an unsigned character
+  // type, assume it is an array initialization.
+  if (T->isCharType() && !T->isSignedIntegerType() && CC.isValid()) {
     const char FirstContextCharacter =
         S.getSourceManager().getCharacterData(CC)[0];
-    if (BT && BT->getKind() != BuiltinType::SChar &&
-        FirstContextCharacter == '{')
+    if (FirstContextCharacter == '{')
       return false;
   }
 

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -13266,7 +13266,7 @@ static void DiagnoseNullConversion(Sema &S, Expr *E, QualType T,
 }
 
 // Helper function to filter out cases for constant width constant conversion.
-// Don't warn on unsigned character array initialization or for non-decimal
+// Don't warn on unsigned char array initialization or for non-decimal
 // values.
 static bool isSameWidthConstantConversion(Sema &S, Expr *E, QualType T,
                                           SourceLocation CC) {
@@ -13280,7 +13280,7 @@ static bool isSameWidthConstantConversion(Sema &S, Expr *E, QualType T,
       return false;
   }
 
-  // If the CC location points to a '{' and the type is an unsigned character
+  // If the CC location points to a '{' and the type is an unsigned char
   // type, assume it is an array initialization.
   if (T->isCharType() && !T->isSignedIntegerType() && CC.isValid()) {
     const char FirstContextCharacter =

--- a/clang/test/Sema/constant-conversion.c
+++ b/clang/test/Sema/constant-conversion.c
@@ -125,6 +125,16 @@ void test9(void) {
   char macro_char_dec = CHAR_MACRO_DEC;  // expected-warning {{implicit conversion from 'int' to 'char' changes value from 255 to -1}}
 
   char array_init[] = { 255, 127, 128, 129, 0 };
+  unsigned char unsigned_array_init[] = { 255 };
+  unsigned char unsigned_array_init_multi[] = { 255, 127, 128, 129, 0 };
+  signed char signed_array_init[] = { 255 }; // expected-warning {{implicit conversion from 'int' to 'signed char' changes value from 255 to -1}}
+  signed char signed_array_init_multi[] = {
+    255, // expected-warning {{implicit conversion from 'int' to 'signed char' changes value from 255 to -1}}
+    127,
+    128, // expected-warning {{implicit conversion from 'int' to 'signed char' changes value from 128 to -128}}
+    129, // expected-warning {{implicit conversion from 'int' to 'signed char' changes value from 129 to -127}}
+    0
+  };
 }
 
 #define A 1

--- a/clang/test/Sema/constant-conversion.c
+++ b/clang/test/Sema/constant-conversion.c
@@ -1,5 +1,6 @@
-// RUN: %clang_cc1 -fsyntax-only -ffreestanding -verify=expected,one-bit -triple x86_64-apple-darwin %s
-// RUN: %clang_cc1 -fsyntax-only -ffreestanding -Wno-single-bit-bitfield-constant-conversion -verify -triple x86_64-apple-darwin %s
+// RUN: %clang_cc1 -fsyntax-only -ffreestanding -verify=expected,signed-plain-char,one-bit -triple x86_64-apple-darwin %s
+// RUN: %clang_cc1 -fsyntax-only -ffreestanding -Wno-single-bit-bitfield-constant-conversion -verify=expected,signed-plain-char -triple x86_64-apple-darwin %s
+// RUN: %clang_cc1 -fsyntax-only -ffreestanding -Wno-single-bit-bitfield-constant-conversion -verify -triple x86_64-apple-darwin -fno-signed-char %s
 
 #include <stdbool.h>
 
@@ -103,7 +104,7 @@ void test9(void) {
   const int max_short_plus_one = (int)max_short + 1;
   const long max_int_plus_one = (long)max_int + 1;
 
-  char new_char = max_char_plus_one;  // expected-warning {{implicit conversion from 'const short' to 'char' changes value from 128 to -128}}
+  char new_char = max_char_plus_one;  // signed-plain-char-warning {{implicit conversion from 'const short' to 'char' changes value from 128 to -128}}
   short new_short = max_short_plus_one;  // expected-warning {{implicit conversion from 'const int' to 'short' changes value from 32768 to -32768}}
   int new_int = max_int_plus_one;  // expected-warning {{implicit conversion from 'const long' to 'int' changes value from 2147483648 to -2147483648}}
 
@@ -122,9 +123,9 @@ void test9(void) {
 #define CHAR_MACRO_HEX 0xff
   char macro_char_hex = CHAR_MACRO_HEX;
 #define CHAR_MACRO_DEC 255
-  char macro_char_dec = CHAR_MACRO_DEC;  // expected-warning {{implicit conversion from 'int' to 'char' changes value from 255 to -1}}
+  char macro_char_dec = CHAR_MACRO_DEC;  // signed-plain-char-warning {{implicit conversion from 'int' to 'char' changes value from 255 to -1}}
 
-  char array_init[] = { 255, 127, 128, 129, 0 };
+  char array_init[] = { 255 }; // signed-plain-char-warning {{implicit conversion from 'int' to 'char' changes value from 255 to -1}}
   unsigned char unsigned_array_init[] = { 255 };
   unsigned char unsigned_array_init_multi[] = { 255, 127, 128, 129, 0 };
   signed char signed_array_init[] = { 255 }; // expected-warning {{implicit conversion from 'int' to 'signed char' changes value from 255 to -1}}


### PR DESCRIPTION
This resolves #181730: fixes a missing `-Wconstant-conversion`
diagnostic for `signed char` array initialization.

Before this change, Clang warned for `signed char foo = 255;` but did not
warn for `signed char bar[] = {255};`.

The warning suppression helper did not distinguish between `char`,
`unsigned char`, and `signed char` in brace-initialized arrays. Now it does.
