### PR TITLE
[AMDGPU] Add flag to control VGPR pressure limits

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -200,13 +200,13 @@ void GCNSchedStrategy::initialize(ScheduleDAGMI *DAG) {
                       << " -> " << VGPRCriticalLimit << "\n");
   } else {
     VGPRExcessLimit -= std::min(VGPRLimitBias + ErrorMargin, VGPRExcessLimit);
+    VGPRCriticalLimit -=
+        std::min(VGPRLimitBias + ErrorMargin, VGPRCriticalLimit);
   }
 
   // Subtract error margin and bias from register limits and avoid overflow.
   SGPRCriticalLimit -= std::min(SGPRLimitBias + ErrorMargin, SGPRCriticalLimit);
-  VGPRCriticalLimit -= std::min(VGPRLimitBias + ErrorMargin, VGPRCriticalLimit);
   SGPRExcessLimit -= std::min(SGPRLimitBias + ErrorMargin, SGPRExcessLimit);
-  VGPRExcessLimit -= std::min(VGPRLimitBias + ErrorMargin, VGPRExcessLimit);
   LLVM_DEBUG(dbgs() << "VGPRCriticalLimit = " << VGPRCriticalLimit
                     << ", VGPRExcessLimit = " << VGPRExcessLimit
                     << ", SGPRCriticalLimit = " << SGPRCriticalLimit

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -121,16 +121,14 @@ struct VGPRThresholdParser : public cl::parser<unsigned> {
 
 } // end anonymous namespace
 
-static cl::opt<unsigned, false, VGPRThresholdParser>
-    VGPRThresholdPercentOpt(
-        "amdgpu-vgpr-threshold-percent", cl::Hidden,
-        cl::desc(
-            "Percent of VGPR limits that we should use as RP threshold "
-            "during scheduling. We have two limits relevant to scheduling: "
-            "Critical (avoid decreasing occupancy), Excess (avoid spilling). "
-            "This flag scales both limits back by an equal percent: (0 = use "
-            " default calculation, 1-100 = use percentage), default: 0"),
-        cl::init(0));
+static cl::opt<unsigned, false, VGPRThresholdParser> VGPRThresholdPercentOpt(
+    "amdgpu-vgpr-threshold-percent", cl::Hidden,
+    cl::desc("Percent of VGPR limits that we should use as RP threshold "
+             "during scheduling. We have two limits relevant to scheduling: "
+             "Critical (avoid decreasing occupancy), Excess (avoid spilling). "
+             "This flag scales both limits back by an equal percent: (0 = use "
+             " default calculation, 1-100 = use percentage), default: 0"),
+    cl::init(0));
 
 const unsigned ScheduleMetrics::ScaleFactor = 100;
 
@@ -187,8 +185,7 @@ void GCNSchedStrategy::initialize(ScheduleDAGMI *DAG) {
   if (VGPRThresholdPercentOpt > 0) {
     [[maybe_unused]] unsigned OriginalVGPRExcessLimit = VGPRExcessLimit;
     [[maybe_unused]] unsigned OriginalVGPRCriticalLimit = VGPRCriticalLimit;
-    VGPRExcessLimit =
-        (VGPRThresholdPercentOpt * VGPRExcessLimit + 99) / 100;
+    VGPRExcessLimit = (VGPRThresholdPercentOpt * VGPRExcessLimit + 99) / 100;
     VGPRCriticalLimit =
         (VGPRThresholdPercentOpt * VGPRCriticalLimit + 99) / 100;
     LLVM_DEBUG(dbgs() << "Applied VGPR excess threshold "

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -122,13 +122,14 @@ struct VGPRThresholdParser : public cl::parser<unsigned> {
 } // end anonymous namespace
 
 static cl::opt<unsigned, false, VGPRThresholdParser>
-    VGPRExcessThresholdPercentOpt(
-        "amdgpu-vgpr-excess-threshold-percent", cl::Hidden,
+    VGPRThresholdPercentOpt(
+        "amdgpu-vgpr-threshold-percent", cl::Hidden,
         cl::desc(
-            "Percent of maximum available VGPRs to use as excess RP threshold "
-            "during  scheduling (0 = use default calculation, 1-100 = use "
-            "percentage), "
-            "default: 0"),
+            "Percent of VGPR limits that we should use as RP threshold "
+            "during scheduling. We have two limits relevant to scheduling: "
+            "Critical (avoid decreasing occupancy), Excess (avoid spilling). "
+            "This flag scales both limits back by an equal percent: (0 = use "
+            " default calculation, 1-100 = use percentage), default: 0"),
         cl::init(0));
 
 const unsigned ScheduleMetrics::ScaleFactor = 100;
@@ -183,21 +184,18 @@ void GCNSchedStrategy::initialize(ScheduleDAGMI *DAG) {
     VGPRCriticalLimit = std::min(VGPRBudget, VGPRExcessLimit);
   }
   // Apply VGPR excess threshold percentage if specified.
-  if (VGPRExcessThresholdPercentOpt > 0) {
+  if (VGPRThresholdPercentOpt > 0) {
     [[maybe_unused]] unsigned OriginalVGPRExcessLimit = VGPRExcessLimit;
     [[maybe_unused]] unsigned OriginalVGPRCriticalLimit = VGPRCriticalLimit;
     VGPRExcessLimit =
-        (VGPRExcessThresholdPercentOpt * VGPRExcessLimit + 99) / 100;
-    // If the new excess limit would be below the critical limit, adjust the
-    // critical limit as well to maintain the invariant that
-    // VGPRCriticalLimit <= VGPRExcessLimit.
-    if (VGPRExcessLimit < VGPRCriticalLimit)
-      VGPRCriticalLimit = VGPRExcessLimit;
+        (VGPRThresholdPercentOpt * VGPRExcessLimit + 99) / 100;
+    VGPRCriticalLimit =
+        (VGPRThresholdPercentOpt * VGPRCriticalLimit + 99) / 100;
     LLVM_DEBUG(dbgs() << "Applied VGPR excess threshold "
-                      << VGPRExcessThresholdPercentOpt << "%, VGPRExcessLimit: "
+                      << VGPRThresholdPercentOpt << "%, VGPRExcessLimit: "
                       << OriginalVGPRExcessLimit << " -> " << VGPRExcessLimit
-                      << "%, VGPRCriticalLimit: " << OriginalVGPRCriticalLimit
-                      << " -> " << VGPRCriticalLimit << "\n");
+                      << ". VGPRCriticalLimit: " << OriginalVGPRCriticalLimit
+                      << " -> " << VGPRCriticalLimit << '\n');
   } else {
     VGPRExcessLimit -= std::min(VGPRLimitBias + ErrorMargin, VGPRExcessLimit);
     VGPRCriticalLimit -=

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -103,6 +103,34 @@ static cl::opt<bool> DisableRewriteMFMAFormSchedStage(
     "amdgpu-disable-rewrite-mfma-form-sched-stage", cl::Hidden,
     cl::desc("Disable rewrite mfma rewrite scheduling stage"), cl::init(true));
 
+namespace {
+
+struct VGPRThresholdParser : public cl::parser<unsigned> {
+  VGPRThresholdParser(cl::Option &O) : cl::parser<unsigned>(O) {}
+
+  bool parse(cl::Option &O, StringRef ArgName, StringRef Arg, unsigned &Value) {
+    if (Arg.getAsInteger(0, Value))
+      return O.error("'" + Arg + "' value invalid for uint argument!");
+
+    if (Value > 100)
+      return O.error("'" + Arg + "' value must be in the range [0, 100]!");
+
+    return false;
+  }
+};
+
+} // end anonymous namespace
+
+static cl::opt<unsigned, false, VGPRThresholdParser>
+    VGPRExcessThresholdPercentOpt(
+        "amdgpu-vgpr-excess-threshold-percent", cl::Hidden,
+        cl::desc(
+            "Percent of maximum available VGPRs to use as excess RP threshold "
+            "during  scheduling (0 = use default calculation, 1-100 = use "
+            "percentage), "
+            "default: 0"),
+        cl::init(0));
+
 const unsigned ScheduleMetrics::ScaleFactor = 100;
 
 GCNSchedStrategy::GCNSchedStrategy(const MachineSchedContext *C)
@@ -153,6 +181,25 @@ void GCNSchedStrategy::initialize(ScheduleDAGMI *DAG) {
     unsigned VGPRBudget = alignDown(Addressable / TargetOccupancy, Granule);
     VGPRBudget = std::max(VGPRBudget, Granule);
     VGPRCriticalLimit = std::min(VGPRBudget, VGPRExcessLimit);
+  }
+  // Apply VGPR excess threshold percentage if specified.
+  if (VGPRExcessThresholdPercentOpt > 0) {
+    [[maybe_unused]] unsigned OriginalVGPRExcessLimit = VGPRExcessLimit;
+    [[maybe_unused]] unsigned OriginalVGPRCriticalLimit = VGPRCriticalLimit;
+    VGPRExcessLimit =
+        (VGPRExcessThresholdPercentOpt * VGPRExcessLimit + 99) / 100;
+    // If the new excess limit would be below the critical limit, adjust the
+    // critical limit as well to maintain the invariant that
+    // VGPRCriticalLimit <= VGPRExcessLimit.
+    if (VGPRExcessLimit < VGPRCriticalLimit)
+      VGPRCriticalLimit = VGPRExcessLimit;
+    LLVM_DEBUG(dbgs() << "Applied VGPR excess threshold "
+                      << VGPRExcessThresholdPercentOpt << "%, VGPRExcessLimit: "
+                      << OriginalVGPRExcessLimit << " -> " << VGPRExcessLimit
+                      << "%, VGPRCriticalLimit: " << OriginalVGPRCriticalLimit
+                      << " -> " << VGPRCriticalLimit << "\n");
+  } else {
+    VGPRExcessLimit -= std::min(VGPRLimitBias + ErrorMargin, VGPRExcessLimit);
   }
 
   // Subtract error margin and bias from register limits and avoid overflow.

--- a/llvm/test/CodeGen/AMDGPU/vgpr-excess-threshold-percent-invalid.ll
+++ b/llvm/test/CodeGen/AMDGPU/vgpr-excess-threshold-percent-invalid.ll
@@ -1,0 +1,13 @@
+; Test that invalid values for -amdgpu-vgpr-excess-threshold-percent are rejected.
+
+; RUN: not llc -mtriple=amdgcn -mcpu=gfx942 -amdgpu-vgpr-excess-threshold-percent=-20 -o /dev/null %s 2>&1 | FileCheck -check-prefix=NEGATIVE %s
+; RUN: not llc -mtriple=amdgcn -mcpu=gfx942 -amdgpu-vgpr-excess-threshold-percent=140 -o /dev/null %s 2>&1 | FileCheck -check-prefix=OVER100 %s
+
+; NEGATIVE: llc: for the --amdgpu-vgpr-excess-threshold-percent option: '-20' value invalid for uint argument!
+; OVER100: llc: for the --amdgpu-vgpr-excess-threshold-percent option: '140' value must be in the range [0, 100]!
+
+define amdgpu_kernel void @test(ptr addrspace(1) %out, ptr addrspace(1) %in) {
+  %val = load float, ptr addrspace(1) %in
+  store float %val, ptr addrspace(1) %out
+  ret void
+}

--- a/llvm/test/CodeGen/AMDGPU/vgpr-excess-threshold-percent-invalid.ll
+++ b/llvm/test/CodeGen/AMDGPU/vgpr-excess-threshold-percent-invalid.ll
@@ -3,8 +3,8 @@
 ; RUN: not llc -mtriple=amdgcn -mcpu=gfx942 -amdgpu-vgpr-threshold-percent=-20 -o /dev/null %s 2>&1 | FileCheck -check-prefix=NEGATIVE %s
 ; RUN: not llc -mtriple=amdgcn -mcpu=gfx942 -amdgpu-vgpr-threshold-percent=140 -o /dev/null %s 2>&1 | FileCheck -check-prefix=OVER100 %s
 
-; NEGATIVE: llc: for the --amdgpu-vgpr-threshold-percent option: '-20' value invalid for uint argument!
-; OVER100: llc: for the --amdgpu-vgpr-threshold-percent option: '140' value must be in the range [0, 100]!
+; NEGATIVE: for the --amdgpu-vgpr-threshold-percent option: '-20' value invalid for uint argument!
+; OVER100: for the --amdgpu-vgpr-threshold-percent option: '140' value must be in the range [0, 100]!
 
 define amdgpu_kernel void @test(ptr addrspace(1) %out, ptr addrspace(1) %in) {
   %val = load float, ptr addrspace(1) %in

--- a/llvm/test/CodeGen/AMDGPU/vgpr-excess-threshold-percent-invalid.ll
+++ b/llvm/test/CodeGen/AMDGPU/vgpr-excess-threshold-percent-invalid.ll
@@ -1,10 +1,10 @@
-; Test that invalid values for -amdgpu-vgpr-excess-threshold-percent are rejected.
+; Test that invalid values for -amdgpu-vgpr-threshold-percent are rejected.
 
-; RUN: not llc -mtriple=amdgcn -mcpu=gfx942 -amdgpu-vgpr-excess-threshold-percent=-20 -o /dev/null %s 2>&1 | FileCheck -check-prefix=NEGATIVE %s
-; RUN: not llc -mtriple=amdgcn -mcpu=gfx942 -amdgpu-vgpr-excess-threshold-percent=140 -o /dev/null %s 2>&1 | FileCheck -check-prefix=OVER100 %s
+; RUN: not llc -mtriple=amdgcn -mcpu=gfx942 -amdgpu-vgpr-threshold-percent=-20 -o /dev/null %s 2>&1 | FileCheck -check-prefix=NEGATIVE %s
+; RUN: not llc -mtriple=amdgcn -mcpu=gfx942 -amdgpu-vgpr-threshold-percent=140 -o /dev/null %s 2>&1 | FileCheck -check-prefix=OVER100 %s
 
-; NEGATIVE: llc: for the --amdgpu-vgpr-excess-threshold-percent option: '-20' value invalid for uint argument!
-; OVER100: llc: for the --amdgpu-vgpr-excess-threshold-percent option: '140' value must be in the range [0, 100]!
+; NEGATIVE: llc: for the --amdgpu-vgpr-threshold-percent option: '-20' value invalid for uint argument!
+; OVER100: llc: for the --amdgpu-vgpr-threshold-percent option: '140' value must be in the range [0, 100]!
 
 define amdgpu_kernel void @test(ptr addrspace(1) %out, ptr addrspace(1) %in) {
   %val = load float, ptr addrspace(1) %in

--- a/llvm/test/CodeGen/AMDGPU/vgpr-excess-threshold-percent.ll
+++ b/llvm/test/CodeGen/AMDGPU/vgpr-excess-threshold-percent.ll
@@ -1,38 +1,38 @@
 ; REQUIRES: asserts
 
 ; gfx942 tests with different threshold percentages
-; RUN: llc -mtriple=amdgcn -mcpu=gfx942 -amdgpu-vgpr-excess-threshold-percent=40  -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX942-40  %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx942 -amdgpu-vgpr-excess-threshold-percent=60  -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX942-60  %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx942 -amdgpu-vgpr-excess-threshold-percent=80  -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX942-80  %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx942 -amdgpu-vgpr-excess-threshold-percent=100 -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX942-100 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx942 -amdgpu-vgpr-threshold-percent=40  -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX942-40  %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx942 -amdgpu-vgpr-threshold-percent=60  -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX942-60  %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx942 -amdgpu-vgpr-threshold-percent=80  -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX942-80  %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx942 -amdgpu-vgpr-threshold-percent=100 -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX942-100 %s
 
 ; gfx1250 tests with coexec scheduling strategy and different threshold percentages
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1250 -mattr=+real-true16 --amdgpu-sched-strategy=coexec -amdgpu-vgpr-excess-threshold-percent=40  -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX1250-40  %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1250 -mattr=+real-true16 --amdgpu-sched-strategy=coexec -amdgpu-vgpr-excess-threshold-percent=60  -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX1250-60  %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1250 -mattr=+real-true16 --amdgpu-sched-strategy=coexec -amdgpu-vgpr-excess-threshold-percent=80  -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX1250-80  %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1250 -mattr=+real-true16 --amdgpu-sched-strategy=coexec -amdgpu-vgpr-excess-threshold-percent=100 -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX1250-100 %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1250 -mattr=+real-true16 --amdgpu-sched-strategy=coexec -amdgpu-vgpr-threshold-percent=40  -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX1250-40  %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1250 -mattr=+real-true16 --amdgpu-sched-strategy=coexec -amdgpu-vgpr-threshold-percent=60  -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX1250-60  %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1250 -mattr=+real-true16 --amdgpu-sched-strategy=coexec -amdgpu-vgpr-threshold-percent=80  -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX1250-80  %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1250 -mattr=+real-true16 --amdgpu-sched-strategy=coexec -amdgpu-vgpr-threshold-percent=100 -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX1250-100 %s
 
-; Test that -amdgpu-vgpr-excess-threshold-percent affects VGPRExcessLimit and VGPRCriticalLimit
+; Test that -amdgpu-vgpr-threshold-percent affects VGPRExcessLimit and VGPRCriticalLimit
 ; for functions with different waves-per-eu targets.
 
 ; waves-per-eu=4,4
 ; GFX942-40:  test_waves_4
-; GFX942-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 64 -> 26%, VGPRCriticalLimit: 64 -> 26
+; GFX942-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 64 -> 26. VGPRCriticalLimit: 64 -> 26
 ; GFX942-60:  test_waves_4
-; GFX942-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 64 -> 39%, VGPRCriticalLimit: 64 -> 39
+; GFX942-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 64 -> 39. VGPRCriticalLimit: 64 -> 39
 ; GFX942-80:  test_waves_4
-; GFX942-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 64 -> 52%, VGPRCriticalLimit: 64 -> 52
+; GFX942-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 64 -> 52. VGPRCriticalLimit: 64 -> 52
 ; GFX942-100: test_waves_4
-; GFX942-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 64 -> 64%, VGPRCriticalLimit: 64 -> 64
+; GFX942-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 64 -> 64. VGPRCriticalLimit: 64 -> 64
 
 ; GFX1250-40:  test_waves_4
-; GFX1250-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 256 -> 103%, VGPRCriticalLimit: 256 -> 103
+; GFX1250-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 256 -> 103. VGPRCriticalLimit: 256 -> 103
 ; GFX1250-60:  test_waves_4
-; GFX1250-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 256 -> 154%, VGPRCriticalLimit: 256 -> 154
+; GFX1250-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 256 -> 154. VGPRCriticalLimit: 256 -> 154
 ; GFX1250-80:  test_waves_4
-; GFX1250-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 256 -> 205%, VGPRCriticalLimit: 256 -> 205
+; GFX1250-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 256 -> 205. VGPRCriticalLimit: 256 -> 205
 ; GFX1250-100: test_waves_4
-; GFX1250-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 256 -> 256%, VGPRCriticalLimit: 256 -> 256
+; GFX1250-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 256 -> 256. VGPRCriticalLimit: 256 -> 256
 define amdgpu_kernel void @test_waves_4(ptr addrspace(1) %out, ptr addrspace(1) %in) #0 {
   %val = load float, ptr addrspace(1) %in
   store float %val, ptr addrspace(1) %out
@@ -41,22 +41,22 @@ define amdgpu_kernel void @test_waves_4(ptr addrspace(1) %out, ptr addrspace(1) 
 
 ; waves-per-eu=5,5
 ; GFX942-40:  test_waves_5
-; GFX942-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 48 -> 20%, VGPRCriticalLimit: 48 -> 20
+; GFX942-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 48 -> 20. VGPRCriticalLimit: 48 -> 20
 ; GFX942-60:  test_waves_5
-; GFX942-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 48 -> 29%, VGPRCriticalLimit: 48 -> 29
+; GFX942-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 48 -> 29. VGPRCriticalLimit: 48 -> 29
 ; GFX942-80:  test_waves_5
-; GFX942-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 48 -> 39%, VGPRCriticalLimit: 48 -> 39
+; GFX942-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 48 -> 39. VGPRCriticalLimit: 48 -> 39
 ; GFX942-100: test_waves_5
-; GFX942-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 48 -> 48%, VGPRCriticalLimit: 48 -> 48
+; GFX942-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 48 -> 48. VGPRCriticalLimit: 48 -> 48
 
 ; GFX1250-40:  test_waves_5
-; GFX1250-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 192 -> 77%, VGPRCriticalLimit: 192 -> 77
+; GFX1250-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 192 -> 77. VGPRCriticalLimit: 192 -> 77
 ; GFX1250-60:  test_waves_5
-; GFX1250-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 192 -> 116%, VGPRCriticalLimit: 192 -> 116
+; GFX1250-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 192 -> 116. VGPRCriticalLimit: 192 -> 116
 ; GFX1250-80:  test_waves_5
-; GFX1250-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 192 -> 154%, VGPRCriticalLimit: 192 -> 154
+; GFX1250-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 192 -> 154. VGPRCriticalLimit: 192 -> 154
 ; GFX1250-100: test_waves_5
-; GFX1250-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 192 -> 192%, VGPRCriticalLimit: 192 -> 192
+; GFX1250-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 192 -> 192. VGPRCriticalLimit: 192 -> 192
 define amdgpu_kernel void @test_waves_5(ptr addrspace(1) %out, ptr addrspace(1) %in) #1 {
   %val = load float, ptr addrspace(1) %in
   store float %val, ptr addrspace(1) %out
@@ -65,22 +65,22 @@ define amdgpu_kernel void @test_waves_5(ptr addrspace(1) %out, ptr addrspace(1) 
 
 ; waves-per-eu=6,6
 ; GFX942-40:  test_waves_6
-; GFX942-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 40 -> 16%, VGPRCriticalLimit: 40 -> 16
+; GFX942-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 40 -> 16. VGPRCriticalLimit: 40 -> 16
 ; GFX942-60:  test_waves_6
-; GFX942-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 40 -> 24%, VGPRCriticalLimit: 40 -> 24
+; GFX942-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 40 -> 24. VGPRCriticalLimit: 40 -> 24
 ; GFX942-80:  test_waves_6
-; GFX942-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 40 -> 32%, VGPRCriticalLimit: 40 -> 32
+; GFX942-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 40 -> 32. VGPRCriticalLimit: 40 -> 32
 ; GFX942-100: test_waves_6
-; GFX942-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 40 -> 40%, VGPRCriticalLimit: 40 -> 40
+; GFX942-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 40 -> 40. VGPRCriticalLimit: 40 -> 40
 
 ; GFX1250-40:  test_waves_6
-; GFX1250-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 160 -> 64%, VGPRCriticalLimit: 160 -> 64
+; GFX1250-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 160 -> 64. VGPRCriticalLimit: 160 -> 64
 ; GFX1250-60:  test_waves_6
-; GFX1250-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 160 -> 96%, VGPRCriticalLimit: 160 -> 96
+; GFX1250-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 160 -> 96. VGPRCriticalLimit: 160 -> 96
 ; GFX1250-80:  test_waves_6
-; GFX1250-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 160 -> 128%, VGPRCriticalLimit: 160 -> 128
+; GFX1250-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 160 -> 128. VGPRCriticalLimit: 160 -> 128
 ; GFX1250-100: test_waves_6
-; GFX1250-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 160 -> 160%, VGPRCriticalLimit: 160 -> 160
+; GFX1250-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 160 -> 160. VGPRCriticalLimit: 160 -> 160
 define amdgpu_kernel void @test_waves_6(ptr addrspace(1) %out, ptr addrspace(1) %in) #2 {
   %val = load float, ptr addrspace(1) %in
   store float %val, ptr addrspace(1) %out
@@ -89,22 +89,22 @@ define amdgpu_kernel void @test_waves_6(ptr addrspace(1) %out, ptr addrspace(1) 
 
 ; waves-per-eu=7,7
 ; GFX942-40:  test_waves_7
-; GFX942-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 36 -> 15%, VGPRCriticalLimit: 36 -> 15
+; GFX942-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 36 -> 15. VGPRCriticalLimit: 36 -> 15
 ; GFX942-60:  test_waves_7
-; GFX942-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 36 -> 22%, VGPRCriticalLimit: 36 -> 22
+; GFX942-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 36 -> 22. VGPRCriticalLimit: 36 -> 22
 ; GFX942-80:  test_waves_7
-; GFX942-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 36 -> 29%, VGPRCriticalLimit: 36 -> 29
+; GFX942-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 36 -> 29. VGPRCriticalLimit: 36 -> 29
 ; GFX942-100: test_waves_7
-; GFX942-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 36 -> 36%, VGPRCriticalLimit: 36 -> 36
+; GFX942-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 36 -> 36. VGPRCriticalLimit: 36 -> 36
 
 ; GFX1250-40:  test_waves_7
-; GFX1250-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 144 -> 58%, VGPRCriticalLimit: 144 -> 58
+; GFX1250-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 144 -> 58. VGPRCriticalLimit: 144 -> 58
 ; GFX1250-60:  test_waves_7
-; GFX1250-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 144 -> 87%, VGPRCriticalLimit: 144 -> 87
+; GFX1250-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 144 -> 87. VGPRCriticalLimit: 144 -> 87
 ; GFX1250-80:  test_waves_7
-; GFX1250-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 144 -> 116%, VGPRCriticalLimit: 144 -> 116
+; GFX1250-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 144 -> 116. VGPRCriticalLimit: 144 -> 116
 ; GFX1250-100: test_waves_7
-; GFX1250-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 144 -> 144%, VGPRCriticalLimit: 144 -> 144
+; GFX1250-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 144 -> 144. VGPRCriticalLimit: 144 -> 144
 define amdgpu_kernel void @test_waves_7(ptr addrspace(1) %out, ptr addrspace(1) %in) #3 {
   %val = load float, ptr addrspace(1) %in
   store float %val, ptr addrspace(1) %out
@@ -113,22 +113,22 @@ define amdgpu_kernel void @test_waves_7(ptr addrspace(1) %out, ptr addrspace(1) 
 
 ; waves-per-eu=8,8
 ; GFX942-40:  test_waves_8
-; GFX942-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 32 -> 13%, VGPRCriticalLimit: 32 -> 13
+; GFX942-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 32 -> 13. VGPRCriticalLimit: 32 -> 13
 ; GFX942-60:  test_waves_8
-; GFX942-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 32 -> 20%, VGPRCriticalLimit: 32 -> 20
+; GFX942-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 32 -> 20. VGPRCriticalLimit: 32 -> 20
 ; GFX942-80:  test_waves_8
-; GFX942-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 32 -> 26%, VGPRCriticalLimit: 32 -> 26
+; GFX942-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 32 -> 26. VGPRCriticalLimit: 32 -> 26
 ; GFX942-100: test_waves_8
-; GFX942-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 32 -> 32%, VGPRCriticalLimit: 32 -> 32
+; GFX942-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 32 -> 32. VGPRCriticalLimit: 32 -> 32
 
 ; GFX1250-40:  test_waves_8
-; GFX1250-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 128 -> 52%, VGPRCriticalLimit: 128 -> 52
+; GFX1250-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 128 -> 52. VGPRCriticalLimit: 128 -> 52
 ; GFX1250-60:  test_waves_8
-; GFX1250-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 128 -> 77%, VGPRCriticalLimit: 128 -> 77
+; GFX1250-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 128 -> 77. VGPRCriticalLimit: 128 -> 77
 ; GFX1250-80:  test_waves_8
-; GFX1250-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 128 -> 103%, VGPRCriticalLimit: 128 -> 103
+; GFX1250-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 128 -> 103. VGPRCriticalLimit: 128 -> 103
 ; GFX1250-100: test_waves_8
-; GFX1250-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 128 -> 128%, VGPRCriticalLimit: 128 -> 128
+; GFX1250-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 128 -> 128. VGPRCriticalLimit: 128 -> 128
 define amdgpu_kernel void @test_waves_8(ptr addrspace(1) %out, ptr addrspace(1) %in) #4 {
   %val = load float, ptr addrspace(1) %in
   store float %val, ptr addrspace(1) %out
@@ -136,24 +136,24 @@ define amdgpu_kernel void @test_waves_8(ptr addrspace(1) %out, ptr addrspace(1) 
 }
 
 ; waves-per-eu=9,9
-; gfx942 can only achieve max 8 waves (512 VGPRs / 64 per wave), so VGPRCriticalLimit stays at 64
+; gfx942 can only achieve max 8 waves (512 VGPRs / 64 per wave), so VGPRCriticalLimit is clamped
 ; GFX942-40:  test_waves_9
-; GFX942-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 256 -> 103%, VGPRCriticalLimit: 64 -> 64
+; GFX942-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 256 -> 103. VGPRCriticalLimit: 64 -> 26
 ; GFX942-60:  test_waves_9
-; GFX942-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 256 -> 154%, VGPRCriticalLimit: 64 -> 64
+; GFX942-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 256 -> 154. VGPRCriticalLimit: 64 -> 39
 ; GFX942-80:  test_waves_9
-; GFX942-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 256 -> 205%, VGPRCriticalLimit: 64 -> 64
+; GFX942-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 256 -> 205. VGPRCriticalLimit: 64 -> 52
 ; GFX942-100: test_waves_9
-; GFX942-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 256 -> 256%, VGPRCriticalLimit: 64 -> 64
+; GFX942-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 256 -> 256. VGPRCriticalLimit: 64 -> 64
 
 ; GFX1250-40:  test_waves_9
-; GFX1250-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 112 -> 45%, VGPRCriticalLimit: 112 -> 45
+; GFX1250-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 112 -> 45. VGPRCriticalLimit: 112 -> 45
 ; GFX1250-60:  test_waves_9
-; GFX1250-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 112 -> 68%, VGPRCriticalLimit: 112 -> 68
+; GFX1250-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 112 -> 68. VGPRCriticalLimit: 112 -> 68
 ; GFX1250-80:  test_waves_9
-; GFX1250-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 112 -> 90%, VGPRCriticalLimit: 112 -> 90
+; GFX1250-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 112 -> 90. VGPRCriticalLimit: 112 -> 90
 ; GFX1250-100: test_waves_9
-; GFX1250-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 112 -> 112%, VGPRCriticalLimit: 112 -> 112
+; GFX1250-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 112 -> 112. VGPRCriticalLimit: 112 -> 112
 define amdgpu_kernel void @test_waves_9(ptr addrspace(1) %out, ptr addrspace(1) %in) #5 {
   %val = load float, ptr addrspace(1) %in
   store float %val, ptr addrspace(1) %out
@@ -161,24 +161,24 @@ define amdgpu_kernel void @test_waves_9(ptr addrspace(1) %out, ptr addrspace(1) 
 }
 
 ; waves-per-eu=10,10
-; gfx942 can only achieve max 8 waves (512 VGPRs / 64 per wave), so VGPRCriticalLimit stays at 64
+; gfx942 can only achieve max 8 waves (512 VGPRs / 64 per wave), so VGPRCriticalLimit is clamped
 ; GFX942-40:  test_waves_10
-; GFX942-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 256 -> 103%, VGPRCriticalLimit: 64 -> 64
+; GFX942-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 256 -> 103. VGPRCriticalLimit: 64 -> 26
 ; GFX942-60:  test_waves_10
-; GFX942-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 256 -> 154%, VGPRCriticalLimit: 64 -> 64
+; GFX942-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 256 -> 154. VGPRCriticalLimit: 64 -> 39
 ; GFX942-80:  test_waves_10
-; GFX942-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 256 -> 205%, VGPRCriticalLimit: 64 -> 64
+; GFX942-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 256 -> 205. VGPRCriticalLimit: 64 -> 52
 ; GFX942-100: test_waves_10
-; GFX942-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 256 -> 256%, VGPRCriticalLimit: 64 -> 64
+; GFX942-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 256 -> 256. VGPRCriticalLimit: 64 -> 64
 
 ; GFX1250-40:  test_waves_10
-; GFX1250-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 96 -> 39%, VGPRCriticalLimit: 96 -> 39
+; GFX1250-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 96 -> 39. VGPRCriticalLimit: 96 -> 39
 ; GFX1250-60:  test_waves_10
-; GFX1250-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 96 -> 58%, VGPRCriticalLimit: 96 -> 58
+; GFX1250-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 96 -> 58. VGPRCriticalLimit: 96 -> 58
 ; GFX1250-80:  test_waves_10
-; GFX1250-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 96 -> 77%, VGPRCriticalLimit: 96 -> 77
+; GFX1250-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 96 -> 77. VGPRCriticalLimit: 96 -> 77
 ; GFX1250-100: test_waves_10
-; GFX1250-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 96 -> 96%, VGPRCriticalLimit: 96 -> 96
+; GFX1250-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 96 -> 96. VGPRCriticalLimit: 96 -> 96
 define amdgpu_kernel void @test_waves_10(ptr addrspace(1) %out, ptr addrspace(1) %in) #6 {
   %val = load float, ptr addrspace(1) %in
   store float %val, ptr addrspace(1) %out

--- a/llvm/test/CodeGen/AMDGPU/vgpr-excess-threshold-percent.ll
+++ b/llvm/test/CodeGen/AMDGPU/vgpr-excess-threshold-percent.ll
@@ -1,0 +1,194 @@
+; REQUIRES: asserts
+
+; gfx942 tests with different threshold percentages
+; RUN: llc -mtriple=amdgcn -mcpu=gfx942 -amdgpu-vgpr-excess-threshold-percent=40  -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX942-40  %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx942 -amdgpu-vgpr-excess-threshold-percent=60  -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX942-60  %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx942 -amdgpu-vgpr-excess-threshold-percent=80  -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX942-80  %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx942 -amdgpu-vgpr-excess-threshold-percent=100 -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX942-100 %s
+
+; gfx1250 tests with coexec scheduling strategy and different threshold percentages
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1250 -mattr=+real-true16 --amdgpu-sched-strategy=coexec -amdgpu-vgpr-excess-threshold-percent=40  -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX1250-40  %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1250 -mattr=+real-true16 --amdgpu-sched-strategy=coexec -amdgpu-vgpr-excess-threshold-percent=60  -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX1250-60  %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1250 -mattr=+real-true16 --amdgpu-sched-strategy=coexec -amdgpu-vgpr-excess-threshold-percent=80  -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX1250-80  %s
+; RUN: llc -mtriple=amdgcn -mcpu=gfx1250 -mattr=+real-true16 --amdgpu-sched-strategy=coexec -amdgpu-vgpr-excess-threshold-percent=100 -debug-only=machine-scheduler -o /dev/null %s 2>&1 | FileCheck -check-prefixes=GFX1250-100 %s
+
+; Test that -amdgpu-vgpr-excess-threshold-percent affects VGPRExcessLimit and VGPRCriticalLimit
+; for functions with different waves-per-eu targets.
+
+; waves-per-eu=4,4
+; GFX942-40:  test_waves_4
+; GFX942-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 64 -> 26%, VGPRCriticalLimit: 64 -> 26
+; GFX942-60:  test_waves_4
+; GFX942-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 64 -> 39%, VGPRCriticalLimit: 64 -> 39
+; GFX942-80:  test_waves_4
+; GFX942-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 64 -> 52%, VGPRCriticalLimit: 64 -> 52
+; GFX942-100: test_waves_4
+; GFX942-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 64 -> 64%, VGPRCriticalLimit: 64 -> 64
+
+; GFX1250-40:  test_waves_4
+; GFX1250-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 256 -> 103%, VGPRCriticalLimit: 256 -> 103
+; GFX1250-60:  test_waves_4
+; GFX1250-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 256 -> 154%, VGPRCriticalLimit: 256 -> 154
+; GFX1250-80:  test_waves_4
+; GFX1250-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 256 -> 205%, VGPRCriticalLimit: 256 -> 205
+; GFX1250-100: test_waves_4
+; GFX1250-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 256 -> 256%, VGPRCriticalLimit: 256 -> 256
+define amdgpu_kernel void @test_waves_4(ptr addrspace(1) %out, ptr addrspace(1) %in) #0 {
+  %val = load float, ptr addrspace(1) %in
+  store float %val, ptr addrspace(1) %out
+  ret void
+}
+
+; waves-per-eu=5,5
+; GFX942-40:  test_waves_5
+; GFX942-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 48 -> 20%, VGPRCriticalLimit: 48 -> 20
+; GFX942-60:  test_waves_5
+; GFX942-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 48 -> 29%, VGPRCriticalLimit: 48 -> 29
+; GFX942-80:  test_waves_5
+; GFX942-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 48 -> 39%, VGPRCriticalLimit: 48 -> 39
+; GFX942-100: test_waves_5
+; GFX942-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 48 -> 48%, VGPRCriticalLimit: 48 -> 48
+
+; GFX1250-40:  test_waves_5
+; GFX1250-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 192 -> 77%, VGPRCriticalLimit: 192 -> 77
+; GFX1250-60:  test_waves_5
+; GFX1250-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 192 -> 116%, VGPRCriticalLimit: 192 -> 116
+; GFX1250-80:  test_waves_5
+; GFX1250-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 192 -> 154%, VGPRCriticalLimit: 192 -> 154
+; GFX1250-100: test_waves_5
+; GFX1250-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 192 -> 192%, VGPRCriticalLimit: 192 -> 192
+define amdgpu_kernel void @test_waves_5(ptr addrspace(1) %out, ptr addrspace(1) %in) #1 {
+  %val = load float, ptr addrspace(1) %in
+  store float %val, ptr addrspace(1) %out
+  ret void
+}
+
+; waves-per-eu=6,6
+; GFX942-40:  test_waves_6
+; GFX942-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 40 -> 16%, VGPRCriticalLimit: 40 -> 16
+; GFX942-60:  test_waves_6
+; GFX942-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 40 -> 24%, VGPRCriticalLimit: 40 -> 24
+; GFX942-80:  test_waves_6
+; GFX942-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 40 -> 32%, VGPRCriticalLimit: 40 -> 32
+; GFX942-100: test_waves_6
+; GFX942-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 40 -> 40%, VGPRCriticalLimit: 40 -> 40
+
+; GFX1250-40:  test_waves_6
+; GFX1250-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 160 -> 64%, VGPRCriticalLimit: 160 -> 64
+; GFX1250-60:  test_waves_6
+; GFX1250-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 160 -> 96%, VGPRCriticalLimit: 160 -> 96
+; GFX1250-80:  test_waves_6
+; GFX1250-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 160 -> 128%, VGPRCriticalLimit: 160 -> 128
+; GFX1250-100: test_waves_6
+; GFX1250-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 160 -> 160%, VGPRCriticalLimit: 160 -> 160
+define amdgpu_kernel void @test_waves_6(ptr addrspace(1) %out, ptr addrspace(1) %in) #2 {
+  %val = load float, ptr addrspace(1) %in
+  store float %val, ptr addrspace(1) %out
+  ret void
+}
+
+; waves-per-eu=7,7
+; GFX942-40:  test_waves_7
+; GFX942-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 36 -> 15%, VGPRCriticalLimit: 36 -> 15
+; GFX942-60:  test_waves_7
+; GFX942-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 36 -> 22%, VGPRCriticalLimit: 36 -> 22
+; GFX942-80:  test_waves_7
+; GFX942-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 36 -> 29%, VGPRCriticalLimit: 36 -> 29
+; GFX942-100: test_waves_7
+; GFX942-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 36 -> 36%, VGPRCriticalLimit: 36 -> 36
+
+; GFX1250-40:  test_waves_7
+; GFX1250-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 144 -> 58%, VGPRCriticalLimit: 144 -> 58
+; GFX1250-60:  test_waves_7
+; GFX1250-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 144 -> 87%, VGPRCriticalLimit: 144 -> 87
+; GFX1250-80:  test_waves_7
+; GFX1250-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 144 -> 116%, VGPRCriticalLimit: 144 -> 116
+; GFX1250-100: test_waves_7
+; GFX1250-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 144 -> 144%, VGPRCriticalLimit: 144 -> 144
+define amdgpu_kernel void @test_waves_7(ptr addrspace(1) %out, ptr addrspace(1) %in) #3 {
+  %val = load float, ptr addrspace(1) %in
+  store float %val, ptr addrspace(1) %out
+  ret void
+}
+
+; waves-per-eu=8,8
+; GFX942-40:  test_waves_8
+; GFX942-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 32 -> 13%, VGPRCriticalLimit: 32 -> 13
+; GFX942-60:  test_waves_8
+; GFX942-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 32 -> 20%, VGPRCriticalLimit: 32 -> 20
+; GFX942-80:  test_waves_8
+; GFX942-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 32 -> 26%, VGPRCriticalLimit: 32 -> 26
+; GFX942-100: test_waves_8
+; GFX942-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 32 -> 32%, VGPRCriticalLimit: 32 -> 32
+
+; GFX1250-40:  test_waves_8
+; GFX1250-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 128 -> 52%, VGPRCriticalLimit: 128 -> 52
+; GFX1250-60:  test_waves_8
+; GFX1250-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 128 -> 77%, VGPRCriticalLimit: 128 -> 77
+; GFX1250-80:  test_waves_8
+; GFX1250-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 128 -> 103%, VGPRCriticalLimit: 128 -> 103
+; GFX1250-100: test_waves_8
+; GFX1250-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 128 -> 128%, VGPRCriticalLimit: 128 -> 128
+define amdgpu_kernel void @test_waves_8(ptr addrspace(1) %out, ptr addrspace(1) %in) #4 {
+  %val = load float, ptr addrspace(1) %in
+  store float %val, ptr addrspace(1) %out
+  ret void
+}
+
+; waves-per-eu=9,9
+; gfx942 can only achieve max 8 waves (512 VGPRs / 64 per wave), so VGPRCriticalLimit stays at 64
+; GFX942-40:  test_waves_9
+; GFX942-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 256 -> 103%, VGPRCriticalLimit: 64 -> 64
+; GFX942-60:  test_waves_9
+; GFX942-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 256 -> 154%, VGPRCriticalLimit: 64 -> 64
+; GFX942-80:  test_waves_9
+; GFX942-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 256 -> 205%, VGPRCriticalLimit: 64 -> 64
+; GFX942-100: test_waves_9
+; GFX942-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 256 -> 256%, VGPRCriticalLimit: 64 -> 64
+
+; GFX1250-40:  test_waves_9
+; GFX1250-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 112 -> 45%, VGPRCriticalLimit: 112 -> 45
+; GFX1250-60:  test_waves_9
+; GFX1250-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 112 -> 68%, VGPRCriticalLimit: 112 -> 68
+; GFX1250-80:  test_waves_9
+; GFX1250-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 112 -> 90%, VGPRCriticalLimit: 112 -> 90
+; GFX1250-100: test_waves_9
+; GFX1250-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 112 -> 112%, VGPRCriticalLimit: 112 -> 112
+define amdgpu_kernel void @test_waves_9(ptr addrspace(1) %out, ptr addrspace(1) %in) #5 {
+  %val = load float, ptr addrspace(1) %in
+  store float %val, ptr addrspace(1) %out
+  ret void
+}
+
+; waves-per-eu=10,10
+; gfx942 can only achieve max 8 waves (512 VGPRs / 64 per wave), so VGPRCriticalLimit stays at 64
+; GFX942-40:  test_waves_10
+; GFX942-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 256 -> 103%, VGPRCriticalLimit: 64 -> 64
+; GFX942-60:  test_waves_10
+; GFX942-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 256 -> 154%, VGPRCriticalLimit: 64 -> 64
+; GFX942-80:  test_waves_10
+; GFX942-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 256 -> 205%, VGPRCriticalLimit: 64 -> 64
+; GFX942-100: test_waves_10
+; GFX942-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 256 -> 256%, VGPRCriticalLimit: 64 -> 64
+
+; GFX1250-40:  test_waves_10
+; GFX1250-40:  Applied VGPR excess threshold 40%, VGPRExcessLimit: 96 -> 39%, VGPRCriticalLimit: 96 -> 39
+; GFX1250-60:  test_waves_10
+; GFX1250-60:  Applied VGPR excess threshold 60%, VGPRExcessLimit: 96 -> 58%, VGPRCriticalLimit: 96 -> 58
+; GFX1250-80:  test_waves_10
+; GFX1250-80:  Applied VGPR excess threshold 80%, VGPRExcessLimit: 96 -> 77%, VGPRCriticalLimit: 96 -> 77
+; GFX1250-100: test_waves_10
+; GFX1250-100: Applied VGPR excess threshold 100%, VGPRExcessLimit: 96 -> 96%, VGPRCriticalLimit: 96 -> 96
+define amdgpu_kernel void @test_waves_10(ptr addrspace(1) %out, ptr addrspace(1) %in) #6 {
+  %val = load float, ptr addrspace(1) %in
+  store float %val, ptr addrspace(1) %out
+  ret void
+}
+
+attributes #0 = { "amdgpu-waves-per-eu"="4,4" "amdgpu-flat-work-group-size"="1,128" }
+attributes #1 = { "amdgpu-waves-per-eu"="5,5" "amdgpu-flat-work-group-size"="1,128" }
+attributes #2 = { "amdgpu-waves-per-eu"="6,6" "amdgpu-flat-work-group-size"="1,128" }
+attributes #3 = { "amdgpu-waves-per-eu"="7,7" "amdgpu-flat-work-group-size"="1,128" }
+attributes #4 = { "amdgpu-waves-per-eu"="8,8" "amdgpu-flat-work-group-size"="1,128" }
+attributes #5 = { "amdgpu-waves-per-eu"="9,9" "amdgpu-flat-work-group-size"="1,128" }
+attributes #6 = { "amdgpu-waves-per-eu"="10,10" "amdgpu-flat-work-group-size"="1,128" }


### PR DESCRIPTION
The RP trackers don't accurately measure the RA problem, and can underestimate the number of registers required. Currently, for VGPR pressure, we account for these inaccuracies using VGPRLimitBias, and ErrorMargin. These are used to reduce the VGPRCriticalLimit / VGPRExcessLimit . During scheduling, we check RP against these limits, and if we start to see RP exceeding these limits, we will trigger RP reduction heuristics (when deciding which instructions to schedule next). Thus VGPRLimitBias + ErrorMargin effectively reduce the amount of allowable RP during scheduling, as a means to compensate for RP tracker inaccuracies. Currently, ErrorMargin is set to 3, and VGPRLimitBias is set to 0. 

However, the degree of inaccuracy tends to scale with the number of registers we have available for allocation. In other words, the RP trackers inaccuracy is better expressed as a percent of the register budget, rather than some literal value. This PR adds some functionality to express this inaccuracy compensation is a percent - and exposes a flag which is useful for debug purposes.  This correction only effects the Excess/Critical limit and does not adjust things like MinOCcupancy, or our spill estimates -- it only effects the guiding heuristics used during scheduling instead of also impacting the meta heuristics used when evaluating schedules. I can make arguments that it should also impact meta heuristics, but that would be changing the current semantics of the limit correction mechanisms. I thought it best to leave that as a separate PR if we want to go that route.