### PR TITLE
[libclc] Use __CLC_SCALAR instead of nonexistant __CLC_SCALAR1 for sin

### DIFF
--- a/libclc/clc/lib/generic/math/clc_sincos_helpers_fp64.inc
+++ b/libclc/clc/lib/generic/math/clc_sincos_helpers_fp64.inc
@@ -257,7 +257,7 @@ _CLC_DEF _CLC_OVERLOAD __CLC_INTN __clc_argReductionS(
     private __CLC_DOUBLEN *r_lo, private __CLC_DOUBLEN *r_hi, __CLC_DOUBLEN x) {
   __CLC_LONGN is_large = x >= (__CLC_DOUBLEN)0x1.0p+30;
 
-#ifdef __CLC_SCALAR1
+#ifdef __CLC_SCALAR
   if (is_large)
     return __clc_remainder_piby2_large(x, r_lo, r_hi);
   return __clc_remainder_piby2_small(x, r_lo, r_hi);


### PR DESCRIPTION
Summary:
This seems to be a typo? Every other case is guarded by `__CLC_SCALAR`
but this case had a `1` after it. Removing this improved performance on
sin/cos/tan to match the ROCm version.
