### PR TITLE
[tools] Register analyses correctly

### DIFF
--- a/llvm/tools/llc/NewPMDriver.cpp
+++ b/llvm/tools/llc/NewPMDriver.cpp
@@ -128,14 +128,6 @@ int llvm::compileModuleWithNewPM(
   FunctionAnalysisManager FAM;
   CGSCCAnalysisManager CGAM;
   ModuleAnalysisManager MAM;
-  PassBuilder PB(Target.get(), PipelineTuningOptions(), std::nullopt, &PIC);
-  PB.registerModuleAnalyses(MAM);
-  PB.registerCGSCCAnalyses(CGAM);
-  PB.registerFunctionAnalyses(FAM);
-  PB.registerLoopAnalyses(LAM);
-  PB.registerMachineFunctionAnalyses(MFAM);
-  PB.crossRegisterProxies(LAM, FAM, CGAM, MAM, &MFAM);
-  SI.registerCallbacks(PIC, &MAM);
 
   FAM.registerPass([&] { return TargetLibraryAnalysis(TLII); });
 
@@ -146,9 +138,17 @@ int llvm::compileModuleWithNewPM(
         Target->Options.FloatABIType, Target->Options.EABIVersion,
         Options.MCOptions.ABIName, Target->Options.VecLib);
   });
-  MAM.registerPass([&] { return LibcallLoweringModuleAnalysis(); });
 
   MAM.registerPass([&] { return MachineModuleAnalysis(MMI); });
+
+  PassBuilder PB(Target.get(), PipelineTuningOptions(), std::nullopt, &PIC);
+  PB.registerModuleAnalyses(MAM);
+  PB.registerCGSCCAnalyses(CGAM);
+  PB.registerFunctionAnalyses(FAM);
+  PB.registerLoopAnalyses(LAM);
+  PB.registerMachineFunctionAnalyses(MFAM);
+  PB.crossRegisterProxies(LAM, FAM, CGAM, MAM, &MFAM);
+  SI.registerCallbacks(PIC, &MAM);
 
   ModulePassManager MPM;
   FunctionPassManager FPM;

--- a/llvm/tools/opt/NewPMDriver.cpp
+++ b/llvm/tools/opt/NewPMDriver.cpp
@@ -426,8 +426,6 @@ bool llvm::runPassPipeline(
                                     Options.FloatABIType, Options.EABIVersion,
                                     Options.MCOptions.ABIName, Options.VecLib);
     });
-
-    MAM.registerPass([&] { return LibcallLoweringModuleAnalysis(); });
   }
 
   PassInstrumentationCallbacks PIC;


### PR DESCRIPTION
-  Analyses with custom parameter must be registered before register*Analyses, otherwise it will be skipped.
- Remove redundant LibcallLoweringModuleAnalysis, pass builder will register it automatically.