### PR TITLE
[llvm] Replace unordered_map<std::string, T> with StringMap

### DIFF
--- a/llvm/lib/Support/Z3Solver.cpp
+++ b/llvm/lib/Support/Z3Solver.cpp
@@ -16,10 +16,10 @@ using namespace llvm;
 #if LLVM_WITH_Z3
 
 #include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/Twine.h"
 
 #include <set>
-#include <unordered_map>
 
 #include <z3.h>
 
@@ -938,19 +938,18 @@ public:
   };
 
   void print(raw_ostream &OS) const override {
-    for (auto const &[K, V] : UnsignedValues) {
-      OS << K << ": " << V << '\n';
-    }
-    for (auto const &[K, V] : DoubleValues) {
-      write_double(OS << K << ": ", V, FloatStyle::Fixed);
+    for (const auto &E : UnsignedValues)
+      OS << E.first() << ": " << E.second << '\n';
+    for (const auto &E : DoubleValues) {
+      write_double(OS << E.first() << ": ", E.second, FloatStyle::Fixed);
       OS << '\n';
     }
   }
 
 private:
   friend class Z3Solver;
-  std::unordered_map<std::string, unsigned> UnsignedValues;
-  std::unordered_map<std::string, double> DoubleValues;
+  StringMap<unsigned> UnsignedValues;
+  StringMap<double> DoubleValues;
 };
 
 std::unique_ptr<SMTSolverStatistics> Z3Solver::getStatistics() const {

--- a/llvm/lib/Target/AArch64/AArch64.h
+++ b/llvm/lib/Target/AArch64/AArch64.h
@@ -16,6 +16,7 @@
 
 #include "MCTargetDesc/AArch64MCTargetDesc.h"
 #include "Utils/AArch64BaseInfo.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineFunctionAnalysisManager.h"
 #include "llvm/CodeGen/SelectionDAGISel.h"
@@ -25,7 +26,6 @@
 #include "llvm/Target/TargetMachine.h"
 #include <map>
 #include <memory>
-#include <unordered_map>
 
 struct AArch64O0PreLegalizerCombinerImplRuleConfig;
 struct AArch64PreLegalizerCombinerImplRuleConfig;
@@ -302,7 +302,7 @@ public:
 class AArch64SIMDInstrOptPass
     : public OptionalPassInfoMixin<AArch64SIMDInstrOptPass> {
   std::map<std::pair<unsigned, std::string>, bool> SIMDInstrTable;
-  std::unordered_map<std::string, bool> InterlEarlyExit;
+  StringMap<bool> InterlEarlyExit;
 
 public:
   PreservedAnalyses run(MachineFunction &MF,

--- a/llvm/lib/Target/AArch64/AArch64SIMDInstrOpt.cpp
+++ b/llvm/lib/Target/AArch64/AArch64SIMDInstrOpt.cpp
@@ -36,6 +36,7 @@
 #include "AArch64Subtarget.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Statistic.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineFunction.h"
@@ -52,7 +53,6 @@
 #include "llvm/MC/MCSchedule.h"
 #include "llvm/Pass.h"
 #include <map>
-#include <unordered_map>
 
 using namespace llvm;
 
@@ -78,7 +78,7 @@ public:
 
   using SIMDInstrTableMap = std::map<std::pair<unsigned, std::string>, bool>;
 
-  using InterlEarlyExitMap = std::unordered_map<std::string, bool>;
+  using InterlEarlyExitMap = StringMap<bool>;
 
   // The two maps below are used to cache decisions instead of recomputing. Note
   // that we're only storing references, the data is scoped at the Pass level to

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCTargetDesc.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCTargetDesc.cpp
@@ -19,6 +19,7 @@
 #include "MCTargetDesc/HexagonMCInstrInfo.h"
 #include "TargetInfo/HexagonTargetInfo.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/MC/MCAsmBackend.h"
@@ -43,7 +44,6 @@
 #include <mutex>
 #include <new>
 #include <string>
-#include <unordered_map>
 
 using namespace llvm;
 
@@ -527,14 +527,13 @@ std::pair<std::string, std::string> selectCPUAndFS(StringRef CPU,
   return Result;
 }
 std::mutex ArchSubtargetMutex;
-std::unordered_map<std::string, std::unique_ptr<MCSubtargetInfo const>>
-    ArchSubtarget;
+StringMap<std::unique_ptr<MCSubtargetInfo const>> ArchSubtarget;
 } // namespace
 
 MCSubtargetInfo const *
 Hexagon_MC::getArchSubtarget(MCSubtargetInfo const *STI) {
   std::lock_guard<std::mutex> Lock(ArchSubtargetMutex);
-  auto Existing = ArchSubtarget.find(std::string(STI->getCPU()));
+  auto Existing = ArchSubtarget.find(STI->getCPU());
   if (Existing == ArchSubtarget.end())
     return nullptr;
   return Existing->second.get();
@@ -673,7 +672,7 @@ void Hexagon_MC::addArchSubtarget(MCSubtargetInfo const *STI, StringRef FS) {
     auto ArchSTI = createHexagonMCSubtargetInfo(STI->getTargetTriple(),
                                                 STI->getCPU().drop_back(), FS);
     std::lock_guard<std::mutex> Lock(ArchSubtargetMutex);
-    ArchSubtarget[std::string(STI->getCPU())] =
+    ArchSubtarget[STI->getCPU()] =
         std::unique_ptr<MCSubtargetInfo const>(ArchSTI);
   }
 }

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -14,6 +14,7 @@
 #define LLVM_LIB_TARGET_SPIRV_SPIRVUTILS_H
 
 #include "MCTargetDesc/SPIRVBaseInfo.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/Analysis/LoopInfo.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/IR/Dominators.h"
@@ -567,7 +568,7 @@ bool isNestedPointer(const Type *Ty);
 enum FPDecorationId { NONE, RTE, RTZ, RTP, RTN, SAT };
 
 inline FPDecorationId demangledPostfixToDecorationId(const std::string &S) {
-  static std::unordered_map<std::string, FPDecorationId> Mapping = {
+  static const StringMap<FPDecorationId> Mapping = {
       {"rte", FPDecorationId::RTE},
       {"rtz", FPDecorationId::RTZ},
       {"rtp", FPDecorationId::RTP},

--- a/llvm/tools/llvm-exegesis/lib/BenchmarkResult.h
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkResult.h
@@ -18,6 +18,7 @@
 #include "LlvmState.h"
 #include "RegisterValue.h"
 #include "ValidationEvent.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/MC/MCInst.h"
 #include "llvm/MC/MCInstBuilder.h"
@@ -25,7 +26,6 @@
 #include <limits>
 #include <set>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace llvm {
@@ -65,7 +65,7 @@ struct BenchmarkKey {
   std::vector<RegisterValue> RegisterInitialValues;
   // The memory values that can be mapped into the execution context of the
   // snippet.
-  std::unordered_map<std::string, MemoryValue> MemoryValues;
+  StringMap<MemoryValue> MemoryValues;
   // The memory mappings that the snippet can access.
   std::vector<MemoryMapping> MemoryMappings;
   // An opaque configuration, that can be used to separate several benchmarks of

--- a/llvm/tools/llvm-exegesis/lib/SnippetFile.cpp
+++ b/llvm/tools/llvm-exegesis/lib/SnippetFile.cpp
@@ -108,7 +108,7 @@ public:
       }
       MemVal.Value = APInt(HexValue.size() * 4, HexValue, 16);
       MemVal.Index = Result->Key.MemoryValues.size();
-      Result->Key.MemoryValues[Parts[0].trim().str()] = MemVal;
+      Result->Key.MemoryValues[Parts[0].trim()] = MemVal;
       return;
     }
     if (CommentText.consume_front("MEM-MAP")) {
@@ -139,7 +139,7 @@ public:
 
       // validate that the annotation refers to an already existing memory
       // definition
-      auto MemValIT = Result->Key.MemoryValues.find(Parts[0].trim().str());
+      auto MemValIT = Result->Key.MemoryValues.find(Parts[0].trim());
       if (MemValIT == Result->Key.MemoryValues.end()) {
         errs() << "invalid comment 'LLVM-EXEGESIS-MEM-MAP " << CommentText
                << "', expected <VALUE NAME> to contain the name of an already "

--- a/llvm/tools/llvm-exegesis/lib/SubprocessMemory.cpp
+++ b/llvm/tools/llvm-exegesis/lib/SubprocessMemory.cpp
@@ -68,10 +68,10 @@ Error SubprocessMemory::initializeSubprocessMemory(pid_t ProcessID) {
 }
 
 Error SubprocessMemory::addMemoryDefinition(
-    std::unordered_map<std::string, MemoryValue> MemoryDefinitions,
-    pid_t ProcessPID) {
+    StringMap<MemoryValue> MemoryDefinitions, pid_t ProcessPID) {
   SharedMemoryNames.reserve(MemoryDefinitions.size());
-  for (auto &[Name, MemVal] : MemoryDefinitions) {
+  for (const auto &E : MemoryDefinitions) {
+    const MemoryValue &MemVal = E.second;
     std::string SharedMemoryName =
         formatv("/{0}t{1}memdef{2}", ProcessPID, getCurrentTID(), MemVal.Index);
     SharedMemoryNames.push_back(SharedMemoryName);
@@ -112,8 +112,8 @@ Error SubprocessMemory::addMemoryDefinition(
 }
 
 Expected<int> SubprocessMemory::setupAuxiliaryMemoryInSubprocess(
-    std::unordered_map<std::string, MemoryValue> MemoryDefinitions,
-    pid_t ParentPID, long ParentTID, int CounterFileDescriptor) {
+    StringMap<MemoryValue> MemoryDefinitions, pid_t ParentPID, long ParentTID,
+    int CounterFileDescriptor) {
   std::string AuxiliaryMemoryName =
       formatv("/{0}auxmem{1}", ParentTID, ParentPID);
   int AuxiliaryMemoryFileDescriptor =
@@ -129,7 +129,8 @@ Expected<int> SubprocessMemory::setupAuxiliaryMemoryInSubprocess(
   if (reinterpret_cast<intptr_t>(AuxiliaryMemoryMapping) == -1)
     return make_error<Failure>("Mapping auxiliary memory failed");
   AuxiliaryMemoryMapping[0] = CounterFileDescriptor;
-  for (auto &[Name, MemVal] : MemoryDefinitions) {
+  for (const auto &E : MemoryDefinitions) {
+    const MemoryValue &MemVal = E.second;
     std::string MemoryValueName =
         formatv("/{0}t{1}memdef{2}", ParentPID, ParentTID, MemVal.Index);
     AuxiliaryMemoryMapping[AuxiliaryMemoryOffset + MemVal.Index] =
@@ -159,14 +160,13 @@ Error SubprocessMemory::initializeSubprocessMemory(pid_t ProcessPID) {
 }
 
 Error SubprocessMemory::addMemoryDefinition(
-    std::unordered_map<std::string, MemoryValue> MemoryDefinitions,
-    pid_t ProcessPID) {
+    StringMap<MemoryValue> MemoryDefinitions, pid_t ProcessPID) {
   return make_error<Failure>("addMemoryDefinitions is only supported on Linux");
 }
 
 Expected<int> SubprocessMemory::setupAuxiliaryMemoryInSubprocess(
-    std::unordered_map<std::string, MemoryValue> MemoryDefinitions,
-    pid_t ParentPID, long ParentTID, int CounterFileDescriptor) {
+    StringMap<MemoryValue> MemoryDefinitions, pid_t ParentPID, long ParentTID,
+    int CounterFileDescriptor) {
   return make_error<Failure>(
       "setupAuxiliaryMemoryInSubprocess is only supported on Linux");
 }

--- a/llvm/tools/llvm-exegesis/lib/SubprocessMemory.h
+++ b/llvm/tools/llvm-exegesis/lib/SubprocessMemory.h
@@ -16,8 +16,8 @@
 #define LLVM_TOOLS_LLVM_EXEGESIS_SUBPROCESSMEMORY_H
 
 #include "BenchmarkResult.h"
+#include "llvm/ADT/StringMap.h"
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #ifdef _MSC_VER
@@ -44,9 +44,8 @@ public:
   // memory objects for the definitions and fills them with the specified
   // values. Arguments: MemoryDefinitions - A map from memory value names to
   // MemoryValues, ProcessID - The ID of the current process.
-  Error addMemoryDefinition(
-      std::unordered_map<std::string, MemoryValue> MemoryDefinitions,
-      pid_t ProcessID);
+  Error addMemoryDefinition(StringMap<MemoryValue> MemoryDefinitions,
+                            pid_t ProcessID);
 
   // The following function sets up the auxiliary memory by opening shared
   // memory objects backing memory definitions and putting file descriptors
@@ -55,9 +54,10 @@ public:
   // setup the memory definitions, CounterFileDescriptor - The file descriptor
   // for the performance counter that will be placed in the auxiliary memory
   // section.
-  static Expected<int> setupAuxiliaryMemoryInSubprocess(
-      std::unordered_map<std::string, MemoryValue> MemoryDefinitions,
-      pid_t ParentPID, long ParentTID, int CounterFileDescriptor);
+  static Expected<int>
+  setupAuxiliaryMemoryInSubprocess(StringMap<MemoryValue> MemoryDefinitions,
+                                   pid_t ParentPID, long ParentTID,
+                                   int CounterFileDescriptor);
 
   ~SubprocessMemory();
 

--- a/llvm/tools/llvm-objdump/SourcePrinter.h
+++ b/llvm/tools/llvm-objdump/SourcePrinter.h
@@ -19,7 +19,6 @@
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/Support/FormattedStream.h"
 #include <set>
-#include <unordered_map>
 #include <vector>
 
 namespace llvm {
@@ -215,9 +214,9 @@ protected:
   const object::ObjectFile *Obj = nullptr;
   std::unique_ptr<symbolize::LLVMSymbolizer> Symbolizer;
   // File name to file contents of source.
-  std::unordered_map<std::string, std::unique_ptr<MemoryBuffer>> SourceCache;
+  StringMap<std::unique_ptr<MemoryBuffer>> SourceCache;
   // Mark the line endings of the cached source.
-  std::unordered_map<std::string, std::vector<StringRef>> LineCache;
+  StringMap<std::vector<StringRef>> LineCache;
   // Keep track of missing sources.
   StringSet<> MissingSources;
   // Only emit 'invalid debug info' warning once.

--- a/llvm/tools/llvm-profgen/ProfiledBinary.cpp
+++ b/llvm/tools/llvm-profgen/ProfiledBinary.cpp
@@ -218,7 +218,7 @@ void ProfiledBinary::warnNoFuncEntry() {
       NoFuncEntryNum++;
       if (ShowDetailedWarning)
         WithColor::warning()
-            << "Failed to determine function entry for " << F.first
+            << "Failed to determine function entry for " << F.first()
             << " due to inconsistent name from symbol table and dwarf info.\n";
     }
   }
@@ -953,10 +953,10 @@ void ProfiledBinary::loadSymbolsFromSymtab(const ObjectFile *Obj) {
       assert(findFuncRange(EndAddr - 1) == nullptr &&
              "Function range overlaps with existing functions.");
       // Function from symbol table not found previously in DWARF, store ranges.
-      auto Ret = BinaryFunctions.emplace(SymName, BinaryFunction());
+      auto Ret = BinaryFunctions.try_emplace(SymName);
       auto &Func = Ret.first->second;
       if (Ret.second) {
-        Func.FuncName = Ret.first->first;
+        Func.FuncName = Ret.first->first();
         HashBinaryFunctions[Function::getGUIDAssumingExternalLinkage(SymName)] =
             &Func;
       }
@@ -1030,10 +1030,10 @@ void ProfiledBinary::loadSymbolsFromDWARFUnit(DWARFUnit &CompilationUnit) {
 
     // Different DWARF symbols can have same function name, search or create
     // BinaryFunction indexed by the name.
-    auto Ret = BinaryFunctions.emplace(Name, BinaryFunction());
+    auto Ret = BinaryFunctions.try_emplace(Name);
     auto &Func = Ret.first->second;
     if (Ret.second)
-      Func.FuncName = Ret.first->first;
+      Func.FuncName = Ret.first->first();
 
     for (const auto &Range : Ranges) {
       uint64_t StartAddress = Range.LowPC;
@@ -1106,7 +1106,7 @@ void ProfiledBinary::loadSymbolsFromDWARF(ObjectFile &Obj) {
   // Populate the hash binary function map for MD5 function name lookup. This
   // is done after BinaryFunctions are finalized.
   for (auto &BinaryFunction : BinaryFunctions) {
-    HashBinaryFunctions[MD5Hash(StringRef(BinaryFunction.first))] =
+    HashBinaryFunctions[MD5Hash(BinaryFunction.first())] =
         &BinaryFunction.second;
   }
 

--- a/llvm/tools/llvm-profgen/ProfiledBinary.h
+++ b/llvm/tools/llvm-profgen/ProfiledBinary.h
@@ -236,7 +236,7 @@ class ProfiledBinary {
   std::set<std::pair<uint64_t, uint64_t>> TextSections;
 
   // A map of mapping function name to BinaryFunction info.
-  std::unordered_map<std::string, BinaryFunction> BinaryFunctions;
+  StringMap<BinaryFunction> BinaryFunctions;
 
   // Lookup BinaryFunctions using the function name's MD5 hash. Needed if the
   // profile is using MD5.
@@ -571,8 +571,7 @@ public:
     return FRange->Func->Ranges;
   }
 
-  const std::unordered_map<std::string, BinaryFunction> &
-  getAllBinaryFunctions() {
+  const StringMap<BinaryFunction> &getAllBinaryFunctions() {
     return BinaryFunctions;
   }
 
@@ -586,7 +585,7 @@ public:
 
   BinaryFunction *getBinaryFunction(FunctionId FName) {
     if (FName.isStringRef()) {
-      auto I = BinaryFunctions.find(FName.str());
+      auto I = BinaryFunctions.find(FName.stringRef());
       if (I == BinaryFunctions.end())
         return nullptr;
       return &I->second;

--- a/llvm/unittests/tools/llvm-exegesis/X86/SnippetFileTest.cpp
+++ b/llvm/unittests/tools/llvm-exegesis/X86/SnippetFileTest.cpp
@@ -67,11 +67,11 @@ MATCHER_P2(RegisterInitialValueIs, Reg, Val, "") {
 
 MATCHER_P3(MemoryDefinitionIs, Name, Value, Size, "") {
   if (arg.second.Value.getLimitedValue() == static_cast<uint64_t>(Value) &&
-      arg.second.SizeBytes == static_cast<size_t>(Size) && arg.first == Name)
+      arg.second.SizeBytes == static_cast<size_t>(Size) && arg.first() == Name)
     return true;
   *result_listener << "expected: {" << Name << ", " << Value << ", " << Size
                    << "} ";
-  *result_listener << "actual: {" << arg.first << ", "
+  *result_listener << "actual: {" << arg.first().str() << ", "
                    << arg.second.Value.getLimitedValue() << ", "
                    << arg.second.SizeBytes << "}";
   return false;

--- a/llvm/unittests/tools/llvm-exegesis/X86/SubprocessMemoryTest.cpp
+++ b/llvm/unittests/tools/llvm-exegesis/X86/SubprocessMemoryTest.cpp
@@ -11,7 +11,6 @@
 #include "X86/TestBase.h"
 #include "gtest/gtest.h"
 #include <string>
-#include <unordered_map>
 
 #ifdef __linux__
 #include <endian.h>
@@ -40,9 +39,8 @@ protected:
     return getpid() * TestCount + TestNumber;
   }
 
-  void
-  testCommon(std::unordered_map<std::string, MemoryValue> MemoryDefinitions,
-             const unsigned TestNumber) {
+  void testCommon(StringMap<MemoryValue> MemoryDefinitions,
+                  const unsigned TestNumber) {
     EXPECT_FALSE(
         SM.initializeSubprocessMemory(getSharedMemoryNumber(TestNumber)));
     EXPECT_FALSE(SM.addMemoryDefinition(MemoryDefinitions,

--- a/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
+++ b/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
@@ -18,6 +18,7 @@
 #include "Common/CodeGenTarget.h"
 #include "DFAEmitter.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TableGen/Record.h"
@@ -28,7 +29,6 @@
 #include <map>
 #include <set>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #define DEBUG_TYPE "dfa-emitter"
@@ -217,17 +217,16 @@ void DFAPacketizerEmitter::run(raw_ostream &OS) {
   CodeGenTarget CGT(Records);
   CodeGenSchedModels CGS(Records, CGT);
 
-  std::unordered_map<std::string, std::vector<const CodeGenProcModel *>>
-      ItinsByNamespace;
+  StringMap<std::vector<const CodeGenProcModel *>> ItinsByNamespace;
   for (const CodeGenProcModel &ProcModel : CGS.procModels()) {
     if (ProcModel.hasItineraries()) {
       auto NS = ProcModel.ItinsDef->getValueAsString("PacketizerNamespace");
-      ItinsByNamespace[NS.str()].push_back(&ProcModel);
+      ItinsByNamespace[NS].push_back(&ProcModel);
     }
   }
 
   for (auto &KV : ItinsByNamespace)
-    emitForItineraries(OS, KV.second, KV.first);
+    emitForItineraries(OS, KV.second, KV.first().str());
   OS << "} // end namespace llvm\n";
 }
 


### PR DESCRIPTION
Prefer StringMap to the slow unordered_map per ProgrammersManual.