### PR TITLE
[clang][ExprConst] Don't pass invalid decls to ASTRecordLayout

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltinBitCast.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltinBitCast.cpp
@@ -131,6 +131,8 @@ static Result enumerateData(PtrView P, const Context &Ctx, Bits Offset,
   // Records.
   if (FieldDesc->isRecord()) {
     const Record *R = FieldDesc->ElemRecord;
+    if (R->getDecl()->isInvalidDecl())
+      return Result::Failure;
     const ASTRecordLayout &Layout =
         Ctx.getASTContext().getASTRecordLayout(R->getDecl());
     bool Ok = true;

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -8060,6 +8060,8 @@ class BufferToAPValueConverter {
 
   std::optional<APValue> visit(const RecordType *RTy, CharUnits Offset) {
     const RecordDecl *RD = RTy->getAsRecordDecl();
+    if (RD->isInvalidDecl())
+      return std::nullopt;
     const ASTRecordLayout &Layout = Info.Ctx.getASTRecordLayout(RD);
 
     unsigned NumBases = 0;

--- a/clang/test/AST/ByteCode/builtin-bit-cast.cpp
+++ b/clang/test/AST/ByteCode/builtin-bit-cast.cpp
@@ -599,3 +599,11 @@ namespace NonNumbers {
   static_assert(fn() == 1); // both-error {{not an integral constant expression}} \
                             // ref-note {{in call to}}
 }
+
+namespace InvalidRecordDecl {
+ struct a :; // both-error {{expected class name}} \
+             // both-error {{expected '{' after base class list}}
+  constexpr struct {
+  } b;
+  a c = __builtin_bit_cast(a, b);
+}


### PR DESCRIPTION
It will assert.

Fixes https://github.com/llvm/llvm-project/issues/203755