### PR TITLE
[clang][bytecode] Update what primtypes need a Descriptor ctor func

### DIFF
--- a/clang/lib/AST/ByteCode/Descriptor.cpp
+++ b/clang/lib/AST/ByteCode/Descriptor.cpp
@@ -31,7 +31,10 @@ template <typename T> static constexpr bool needsCtor() {
                 std::is_same_v<T, Integral<32, false>> ||
                 std::is_same_v<T, Integral<64, true>> ||
                 std::is_same_v<T, Integral<64, false>> ||
-                std::is_same_v<T, Boolean>)
+                std::is_same_v<T, Integral<64, false>> ||
+                std::is_same_v<T, IntegralAP<false>> ||
+                std::is_same_v<T, IntegralAP<true>> ||
+                std::is_same_v<T, Floating> || std::is_same_v<T, Boolean>)
     return false;
 
   return true;
@@ -243,12 +246,6 @@ static bool needsRecordDtor(const Record *R) {
 
 static BlockCtorFn getCtorPrim(PrimType T) {
   switch (T) {
-  case PT_Float:
-    return ctorTy<PrimConv<PT_Float>::T>;
-  case PT_IntAP:
-    return ctorTy<PrimConv<PT_IntAP>::T>;
-  case PT_IntAPS:
-    return ctorTy<PrimConv<PT_IntAPS>::T>;
   case PT_Ptr:
     return ctorTy<PrimConv<PT_Ptr>::T>;
   case PT_MemberPtr:
@@ -261,12 +258,6 @@ static BlockCtorFn getCtorPrim(PrimType T) {
 
 static BlockDtorFn getDtorPrim(PrimType T) {
   switch (T) {
-  case PT_Float:
-    return dtorTy<PrimConv<PT_Float>::T>;
-  case PT_IntAP:
-    return dtorTy<PrimConv<PT_IntAP>::T>;
-  case PT_IntAPS:
-    return dtorTy<PrimConv<PT_IntAPS>::T>;
   case PT_Ptr:
     return dtorTy<PrimConv<PT_Ptr>::T>;
   case PT_MemberPtr:
@@ -278,7 +269,8 @@ static BlockDtorFn getDtorPrim(PrimType T) {
 }
 
 static BlockCtorFn getCtorArrayPrim(PrimType Type) {
-  TYPE_SWITCH(Type, return ctorArrayTy<T>);
+  TYPE_SWITCH(Type, if constexpr (!needsCtor<T>()) return nullptr;
+              return ctorArrayTy<T>);
   llvm_unreachable("unknown Expr");
 }
 

--- a/clang/lib/AST/ByteCode/InitMap.h
+++ b/clang/lib/AST/ByteCode/InitMap.h
@@ -82,7 +82,7 @@ struct InitMapPtr final {
   /// V's value after the initmap has been destroyed because
   /// all its elements have already been initialized.
   static constexpr intptr_t AllInitializedValue = 1;
-  uintptr_t V = 0;
+  uintptr_t V = NoInitMapValue;
 
   explicit InitMapPtr() = default;
   bool hasInitMap() const {


### PR DESCRIPTION
Now that IntegralAP is allocated via InterpState/Program, we don't need to initialize it. The same is true for Floating.

And with the new `InitMapPtr` being zero by default as well, we don't need ctor funcs for primitive array types if the element type doesn't need one.