### PR TITLE
[RISCV] Make analyzeBranch bail for INLINEASM_BR

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -1372,8 +1372,13 @@ bool RISCVInstrInfo::analyzeBranch(MachineBasicBlock &MBB,
   TBB = FBB = nullptr;
   Cond.clear();
 
-  // If the block has no terminators, it just falls into the block after it.
   MachineBasicBlock::iterator I = MBB.getLastNonDebugInstr();
+  // If we end up with a INLINEASM_BR instruction, the actual branch
+  // information is opaque and thus unanalyzeable.
+  if (I != MBB.end() && I->getOpcode() == TargetOpcode::INLINEASM_BR)
+    return true;
+
+  // If the block has no terminators, it just falls into the block after it.
   if (I == MBB.end() || !isUnpredicatedTerminator(*I))
     return false;
 


### PR DESCRIPTION
When working on the CodeGen BranchFolding pass, I ran into a case where analyzeBranch on RISC-V was returning that a branch was analyzeable for an INLINEASM_BR instruction, which probably shouldn't be the case. This was because we were going through the no terminators path, even though we do have an (opaque) terminator instruction.

No tests because it didn't seem like there was a good way to test this.