### PR TITLE
[CodeGen][NewPM] Port machine-region-info to new pass manager

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineRegionInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineRegionInfo.h
@@ -18,6 +18,7 @@
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachineLoopInfo.h"
+#include "llvm/CodeGen/MachinePassManager.h"
 #include <cassert>
 
 namespace llvm {
@@ -73,14 +74,53 @@ public:
 class LLVM_ABI MachineRegionInfo
     : public RegionInfoBase<RegionTraits<MachineFunction>> {
 public:
+  using Base = RegionInfoBase<RegionTraits<MachineFunction>>;
+
   explicit MachineRegionInfo();
   ~MachineRegionInfo() override;
+
+  MachineRegionInfo(MachineRegionInfo &&Arg)
+      : Base(std::move(static_cast<Base &>(Arg))) {
+    updateRegionTree(*this, TopLevelRegion);
+  }
+
+  MachineRegionInfo &operator=(MachineRegionInfo &&RHS) {
+    Base::operator=(std::move(static_cast<Base &>(RHS)));
+    updateRegionTree(*this, TopLevelRegion);
+    return *this;
+  }
+
+  /// Handle invalidation explicitly.
+  bool invalidate(MachineFunction &F, const PreservedAnalyses &PA,
+                  MachineFunctionAnalysisManager::Invalidator &);
 
   // updateStatistics - Update statistic about created regions.
   void updateStatistics(MachineRegion *R) final;
 
   void recalculate(MachineFunction &F, MachineDominatorTree *DT,
                    MachinePostDominatorTree *PDT, MachineDominanceFrontier *DF);
+};
+
+class LLVM_ABI MachineRegionInfoAnalysis
+    : public AnalysisInfoMixin<MachineRegionInfoAnalysis> {
+  friend AnalysisInfoMixin<MachineRegionInfoAnalysis>;
+
+  static AnalysisKey Key;
+
+public:
+  using Result = MachineRegionInfo;
+
+  Result run(MachineFunction &F, MachineFunctionAnalysisManager &AM);
+};
+
+class LLVM_ABI MachineRegionInfoPrinterPass
+    : public RequiredPassInfoMixin<MachineRegionInfoPrinterPass> {
+  raw_ostream &OS;
+
+public:
+  explicit MachineRegionInfoPrinterPass(raw_ostream &OS) : OS(OS) {}
+  PreservedAnalyses run(MachineFunction &MF,
+                        MachineFunctionAnalysisManager &MFAM);
 };
 
 class LLVM_ABI MachineRegionInfoPass : public MachineFunctionPass {

--- a/llvm/include/llvm/Passes/MachinePassRegistry.def
+++ b/llvm/include/llvm/Passes/MachinePassRegistry.def
@@ -46,6 +46,7 @@ MACHINE_FUNCTION_ANALYSIS("machine-opt-remark-emitter",
                           MachineOptimizationRemarkEmitterAnalysis())
 MACHINE_FUNCTION_ANALYSIS("machine-post-dom-tree",
                           MachinePostDominatorTreeAnalysis())
+MACHINE_FUNCTION_ANALYSIS("machine-regions", MachineRegionInfoAnalysis())
 MACHINE_FUNCTION_ANALYSIS("machine-trace-metrics", MachineTraceMetricsAnalysis())
 MACHINE_FUNCTION_ANALYSIS("machine-uniformity", MachineUniformityAnalysis())
 MACHINE_FUNCTION_ANALYSIS("pass-instrumentation", PassInstrumentationAnalysis(PIC))
@@ -55,8 +56,6 @@ MACHINE_FUNCTION_ANALYSIS("regalloc-priority", RegAllocPriorityAdvisorAnalysis()
 MACHINE_FUNCTION_ANALYSIS("slot-indexes", SlotIndexesAnalysis())
 MACHINE_FUNCTION_ANALYSIS("spill-code-placement", SpillPlacementAnalysis())
 MACHINE_FUNCTION_ANALYSIS("virtregmap", VirtRegMapAnalysis())
-// MACHINE_FUNCTION_ANALYSIS("machine-region-info",
-// MachineRegionInfoPassAnalysis())
 // MACHINE_FUNCTION_ANALYSIS("gc-analysis",
 // GCMachineCodeAnalysisPass())
 #undef MACHINE_FUNCTION_ANALYSIS
@@ -116,6 +115,8 @@ MACHINE_FUNCTION_PASS("print<machine-dom-tree>",
 MACHINE_FUNCTION_PASS("print<machine-loops>", MachineLoopPrinterPass(errs()))
 MACHINE_FUNCTION_PASS("print<machine-post-dom-tree>",
                       MachinePostDominatorTreePrinterPass(errs()))
+MACHINE_FUNCTION_PASS("print<machine-regions>",
+                      MachineRegionInfoPrinterPass(errs()))
 MACHINE_FUNCTION_PASS("print<machine-uniformity>",
                       MachineUniformityPrinterPass(errs()))
 MACHINE_FUNCTION_PASS("print<reaching-def>", ReachingDefPrinterPass(errs()))

--- a/llvm/lib/CodeGen/MachineRegionInfo.cpp
+++ b/llvm/lib/CodeGen/MachineRegionInfo.cpp
@@ -72,6 +72,39 @@ void MachineRegionInfo::recalculate(MachineFunction &F,
   calculate(F);
 }
 
+bool MachineRegionInfo::invalidate(
+    MachineFunction &F, const PreservedAnalyses &PA,
+    MachineFunctionAnalysisManager::Invalidator &) {
+  // Check whether the analysis, all analyses on functions, or the function's
+  // CFG has been preserved.
+  auto PAC = PA.getChecker<MachineRegionInfoAnalysis>();
+  return !(PAC.preserved() ||
+           PAC.preservedSet<AllAnalysesOn<MachineFunction>>() ||
+           PAC.preservedSet<CFGAnalyses>());
+}
+
+//===----------------------------------------------------------------------===//
+// MachineRegionAnalysis implementation
+//
+AnalysisKey MachineRegionInfoAnalysis::Key;
+MachineRegionInfo
+MachineRegionInfoAnalysis::run(MachineFunction &MF,
+                               MachineFunctionAnalysisManager &MFAM) {
+  MachineRegionInfo MRI;
+  MRI.recalculate(MF, &MFAM.getResult<MachineDominatorTreeAnalysis>(MF),
+                  &MFAM.getResult<MachinePostDominatorTreeAnalysis>(MF),
+                  &MFAM.getResult<MachineDominanceFrontierAnalysis>(MF));
+  return MRI;
+}
+
+PreservedAnalyses
+MachineRegionInfoPrinterPass::run(MachineFunction &MF,
+                                  MachineFunctionAnalysisManager &MFAM) {
+  MachineRegionInfo &MRI = MFAM.getResult<MachineRegionInfoAnalysis>(MF);
+  MRI.print(OS);
+  return PreservedAnalyses::all();
+}
+
 //===----------------------------------------------------------------------===//
 // MachineRegionInfoPass implementation
 //

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -138,6 +138,7 @@
 #include "llvm/CodeGen/MachineLateInstrsCleanup.h"
 #include "llvm/CodeGen/MachinePassManager.h"
 #include "llvm/CodeGen/MachinePostDominators.h"
+#include "llvm/CodeGen/MachineRegionInfo.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
 #include "llvm/CodeGen/MachineScheduler.h"
 #include "llvm/CodeGen/MachineSink.h"

--- a/llvm/test/CodeGen/X86/machine-region-info.mir
+++ b/llvm/test/CodeGen/X86/machine-region-info.mir
@@ -1,4 +1,5 @@
 # RUN: llc -mtriple=x86_64-- -run-pass=machine-region-info %s -debug-only=machine-region-info -o /dev/null 2>&1 | FileCheck %s
+# RUN: llc -mtriple=x86_64-- -p 'print<machine-regions>' %s -debug-only=machine-region-info -o /dev/null 2>&1 | FileCheck %s
 # REQUIRES: asserts
 ---
 name:            fun


### PR DESCRIPTION
- Make `MachineRegionInfo` movable, like `RegionInfo`.
- Add printer pass.