### PR TITLE
[Clang] Register __has_extension(bit_int) and __has_feature(bit_int)

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -262,6 +262,14 @@ Objective-C Language Changes
 Non-comprehensive list of changes in this release
 -------------------------------------------------
 
+- ``__has_extension(bit_int)`` now returns ``1`` in every language mode,
+  matching the long-standing availability of ``_BitInt(N)`` as a Clang
+  extension in C and C++. ``__has_feature(bit_int)`` returns ``1`` in C23+,
+  where ``_BitInt`` is a standard feature. The identifier previously had no
+  entry in ``Features.def`` and both probes returned ``0``, causing user
+  code and libcxx tests that gated ``_BitInt`` blocks on the probe to
+  silently take the no-``_BitInt`` branch.
+
 - Added support for floating point and pointer values in most ``__atomic_``
   builtins.
 

--- a/clang/include/clang/Basic/Features.def
+++ b/clang/include/clang/Basic/Features.def
@@ -337,6 +337,8 @@ EXTENSION(c_thread_local, PP.getTargetInfo().isTLSSupported())
 // C23 features supported by other languages as extensions
 EXTENSION(c_attributes, true)
 EXTENSION(c_fixed_enum, true)
+FEATURE(bit_int, LangOpts.C23)
+EXTENSION(bit_int, true)
 // C2y features supported by other languages as extensions
 EXTENSION(c_countof, !LangOpts.C2y && !LangOpts.CPlusPlus)
 // C++11 features supported by other languages as extensions.

--- a/clang/test/Preprocessor/has_extension_bit_int.c
+++ b/clang/test/Preprocessor/has_extension_bit_int.c
@@ -1,0 +1,30 @@
+// RUN: %clang_cc1 %s -verify
+// RUN: %clang_cc1 %s -verify -x c++
+// RUN: %clang_cc1 %s -verify -std=c17 -DC17
+// RUN: %clang_cc1 %s -verify -std=c23 -DC23
+// RUN: %clang_cc1 %s -verify -x c++ -std=c++26
+
+// _BitInt is a Clang extension in C and C++ everywhere, and a standard
+// feature in C23+. __has_extension(bit_int) is always 1; __has_feature
+// is 1 only in C23+.
+
+// expected-no-diagnostics
+
+#if !__has_extension(bit_int)
+#error "__has_extension(bit_int) should be true in every language mode"
+#endif
+
+#ifdef C23
+#  if !__has_feature(bit_int)
+#    error "__has_feature(bit_int) should be true in C23"
+#  endif
+#endif
+
+#ifdef C17
+#  if __has_feature(bit_int)
+#    error "__has_feature(bit_int) should be false in pre-C23"
+#  endif
+#endif
+
+_BitInt(13) bi;
+unsigned _BitInt(48) ubi;


### PR DESCRIPTION
`__has_extension(bit_int)` and `__has_feature(bit_int)` currently return `0` in every language mode because the identifier has no entry in `clang/include/clang/Basic/Features.def`. User code and libcxx tests that gated `_BitInt` blocks on the probe silently take the no-`_BitInt` branch. The libcxx `<bit>` test family (popcount, byteswap, rotl/rotr, etc.) has been compiling its `_BitInt` blocks as dead code for as long as the probe has existed.

Register both:

- `EXTENSION(bit_int, true)` so `__has_extension(bit_int)` returns `1` in every mode, matching the long-standing availability of `_BitInt(N)` as a Clang extension in C and C++.
- `FEATURE(bit_int, LangOpts.C23)` so `__has_feature(bit_int)` returns `1` in C23+, where `_BitInt` is a standard feature.

C++29 (P3666R4 was LEWG-approved at Brno 2026-06) can extend the `FEATURE` predicate with `|| LangOpts.CPlusPlus29` once the corresponding LangOpts entry lands.

Add a preprocessor test under `clang/test/Preprocessor/` covering C default, C++ default, C17 (no `__has_feature`), C23 (yes), and C++26 (extension only).

Assisted-by: Claude (Anthropic)