### PR TITLE
[X86] Fold cross-block constants into address mode displacement 

### DIFF
--- a/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
@@ -2896,6 +2896,29 @@ bool X86DAGToDAGISel::matchAddressRecursively(SDValue N, X86ISelAddressMode &AM,
 
     break;
   }
+  case ISD::AssertZext:
+  case ISD::AssertSext:
+    // Peek through assert extension nodes - the underlying value is
+    // unchanged, so we can continue matching the operand directly.
+    return matchAddressRecursively(N.getOperand(0), AM, Depth + 1);
+
+  case ISD::CopyFromReg: {
+    // If this is a copy from a virtual register that was defined as a
+    // constant, try to fold the constant value into the displacement field.
+    Register Reg = cast<RegisterSDNode>(N.getOperand(1))->getReg();
+    if (Reg.isVirtual()) {
+      MachineRegisterInfo &MRI = CurDAG->getMachineFunction().getRegInfo();
+      MachineInstr *DefMI = MRI.getVRegDef(Reg);
+      if (DefMI) {
+        int64_t ImmVal;
+        if (Subtarget->getInstrInfo()->getConstValDefinedInReg(*DefMI, Reg,
+                                                               ImmVal) &&
+            !foldOffsetIntoAddress(ImmVal, AM))
+          return false;
+      }
+    }
+    break;
+  }
   }
 
   return matchAddressBase(N, AM);

--- a/llvm/test/CodeGen/X86/x86-64-disp.ll
+++ b/llvm/test/CodeGen/X86/x86-64-disp.ll
@@ -18,3 +18,62 @@ define fastcc void @foo() nounwind {
 	store i8 1, ptr %t, align 1
 	ret void
 }
+
+; A compile-time constant used as a base address in a loop was not being
+; folded into the x86 displacement field, causing a redundant MOV
+;LLVM Issue- 198228
+
+@g_align = dso_local global i64 16, align 8
+@g_idx = dso_local global i64 5, align 8
+@g_out = dso_local global i64 0, align 8
+
+
+define dso_local void @const_disp_fold()  {
+; CHECK-LABEL: const_disp_fold:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    movq g_align(%rip), %rax
+; CHECK-NEXT:    decq %rax
+; CHECK-NEXT:    movq g_idx(%rip), %rcx
+; CHECK-NEXT:    movzwl 536875250(%rcx,%rcx), %ecx
+; CHECK-NEXT:    testl %eax, 536888780(,%rcx,4)
+; CHECK-NEXT:    je .LBB1_3
+; CHECK-NEXT:  # %bb.1: # %do.body.preheader
+; CHECK-NEXT:    movl $536875250, %edx # imm = 0x200010F2
+; CHECK-NEXT:    .p2align 4
+; CHECK-NEXT:  .LBB1_2: # %do.body
+; CHECK-NEXT:    # =>This Inner Loop Header: Depth=1
+; CHECK-NEXT:    testl %eax, 13534(%rdx,%rcx,4)
+; CHECK-NEXT:    leaq 1(%rcx), %rcx
+; CHECK-NEXT:    jne .LBB1_2
+; CHECK-NEXT:  .LBB1_3: # %if.end
+; CHECK-NEXT:    movq %rcx, g_out(%rip)
+; CHECK-NEXT:    retq
+entry:
+  %0 = load volatile i64, ptr @g_align, align 8
+  %sub = add i64 %0, -1
+  %1 = load volatile i64, ptr @g_idx, align 8
+  %arrayidx = getelementptr inbounds nuw [2 x i8], ptr inttoptr (i64 536875250 to ptr), i64 %1
+  %2 = load i16, ptr %arrayidx, align 2
+  %conv = zext i16 %2 to i64
+  %arrayidx1 = getelementptr inbounds nuw [4 x i8], ptr inttoptr (i64 536888780 to ptr), i64 %conv
+  %3 = load i32, ptr %arrayidx1, align 4
+  %conv2 = zext i32 %3 to i64
+  %and = and i64 %sub, %conv2
+  %tobool.not = icmp eq i64 %and, 0
+  br i1 %tobool.not, label %if.end, label %do.body
+
+do.body:                                          ; preds = %entry, %do.body
+  %size_class.0 = phi i64 [ %inc, %do.body ], [ %conv, %entry ]
+  %inc = add i64 %size_class.0, 1
+  %arrayidx4 = getelementptr inbounds nuw [4 x i8], ptr inttoptr (i64 536888780 to ptr), i64 %inc
+  %4 = load i32, ptr %arrayidx4, align 4
+  %conv5 = zext i32 %4 to i64
+  %and6 = and i64 %sub, %conv5
+  %tobool8.not = icmp eq i64 %and6, 0
+  br i1 %tobool8.not, label %if.end, label %do.body
+
+if.end:                                           ; preds = %do.body, %entry
+  %size_class.1 = phi i64 [ %conv, %entry ], [ %inc, %do.body ]
+  store volatile i64 %size_class.1, ptr @g_out, align 8
+  ret void
+}

--- a/llvm/test/CodeGen/X86/x86-64-disp.ll
+++ b/llvm/test/CodeGen/X86/x86-64-disp.ll
@@ -36,16 +36,14 @@ define dso_local void @const_disp_fold()  {
 ; CHECK-NEXT:    movq g_idx(%rip), %rcx
 ; CHECK-NEXT:    movzwl 536875250(%rcx,%rcx), %ecx
 ; CHECK-NEXT:    testl %eax, 536888780(,%rcx,4)
-; CHECK-NEXT:    je .LBB1_3
-; CHECK-NEXT:  # %bb.1: # %do.body.preheader
-; CHECK-NEXT:    movl $536875250, %edx # imm = 0x200010F2
+; CHECK-NEXT:    je .LBB1_2
 ; CHECK-NEXT:    .p2align 4
-; CHECK-NEXT:  .LBB1_2: # %do.body
+; CHECK-NEXT:  .LBB1_1: # %do.body
 ; CHECK-NEXT:    # =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    testl %eax, 13534(%rdx,%rcx,4)
+; CHECK-NEXT:    testl %eax, 536888784(,%rcx,4)
 ; CHECK-NEXT:    leaq 1(%rcx), %rcx
-; CHECK-NEXT:    jne .LBB1_2
-; CHECK-NEXT:  .LBB1_3: # %if.end
+; CHECK-NEXT:    jne .LBB1_1
+; CHECK-NEXT:  .LBB1_2: # %if.end
 ; CHECK-NEXT:    movq %rcx, g_out(%rip)
 ; CHECK-NEXT:    retq
 entry:


### PR DESCRIPTION
Fixes #198228 

matchAddressRecursively did not handle cases for AssertZext, AssertSext, or 
CopyFromReg nodes, which are produced when SelectionDAGBuilder exports a 
compile-time constant across basic block boundaries via a virtual register.
Add cases for these nodes to recover the underlying constant and fold it into 
the memory displacement, eliminating a redundant MOV.  