### PR TITLE
[clang][Driver] Pass --cstdlib through to multilibs

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -492,11 +492,9 @@ ToolChain::getMultilibFlags(const llvm::opt::ArgList &Args) const {
 
   processMultilibCustomFlags(Result, Args);
 
-  if (Arg *CStdLibArg = Args.getLastArg(options::OPT_cstdlib_EQ)) {
+  if (Arg *CStdLibArg = Args.getLastArg(options::OPT_cstdlib_EQ))
     Result.push_back(std::string(CStdLibArg->getOption().getPrefixedName()) +
                      CStdLibArg->getValue());
-    CStdLibArg->claim();
-  }
 
   // Include fno-exceptions and fno-rtti
   // to improve multilib selection

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -492,6 +492,12 @@ ToolChain::getMultilibFlags(const llvm::opt::ArgList &Args) const {
 
   processMultilibCustomFlags(Result, Args);
 
+  if (Arg *CStdLibArg = Args.getLastArg(options::OPT_cstdlib_EQ)) {
+    Result.push_back(std::string(CStdLibArg->getOption().getPrefixedName()) +
+                     CStdLibArg->getValue());
+    CStdLibArg->claim();
+  }
+
   // Include fno-exceptions and fno-rtti
   // to improve multilib selection
   if (getRTTIMode() == ToolChain::RTTIMode::RM_Disabled)

--- a/clang/test/Driver/baremetal-multilib.yaml
+++ b/clang/test/Driver/baremetal-multilib.yaml
@@ -14,6 +14,14 @@
 # CHECK-SAME: "-lc"
 # CHECK-SAME: "-o" "{{.*}}.tmp.out"
 
+# RUN: %clang --multi-lib-config=%s -no-canonical-prefixes -x c++ %s -### -Werror -o %t.out 2>&1 \
+# RUN:     --target=thumbv8m.main-none-eabihf --cstdlib=picolibc --sysroot= \
+# RUN:   | FileCheck --check-prefix=CHECK-CSTDLIB %s
+# CHECK-CSTDLIB:      "-cc1" "-triple" "thumbv8m.main-unknown-none-eabihf"
+# CHECK-CSTDLIB-SAME: "-internal-isystem" "[[SYSROOT:[^"]*]]/bin/../lib/clang-runtimes/arm-none-eabi/thumb/v8-m.main/fp/picolibc/include/c++/v1"
+# CHECK-CSTDLIB-NEXT: ld{{(.exe)?}}" "-Bstatic"
+# CHECK-CSTDLIB-SAME: "-L[[SYSROOT]]/bin/../lib/clang-runtimes/arm-none-eabi/thumb/v8-m.main/fp/picolibc/lib"
+
 # RUN: %clang --multi-lib-config=%s -no-canonical-prefixes -x c++ %s -### -o %t.out 2>&1 \
 # RUN:     --target=thumbv7em-none-eabi -mfpu=fpv4-sp-d16 --sysroot= \
 # RUN:   | FileCheck --check-prefix=CHECK-NO-MATCH %s
@@ -105,6 +113,9 @@ Variants:
 
 - Dir: arm-none-eabi/thumb/v8-m.main/fp
   Flags: [--target=thumbv8m.main-unknown-none-eabihf, -mfpu=fpv5-d16]
+
+- Dir: arm-none-eabi/thumb/v8-m.main/fp/picolibc
+  Flags: [--target=thumbv8m.main-unknown-none-eabihf, --cstdlib=picolibc, -mfpu=fpv5-d16]
 
 - Dir: arm-none-eabi/thumb/v8.1-m.main/fp
   Flags: [--target=thumbv8.1m.main-unknown-none-eabihf, -mfpu=fp-armv8-fullfp16-sp-d16]

--- a/clang/test/Driver/print-multi-selection-flags.c
+++ b/clang/test/Driver/print-multi-selection-flags.c
@@ -71,6 +71,10 @@
 // RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=aarch64-none-elf -mbranch-protection=standard | FileCheck --check-prefix=CHECK-BRANCH-PROTECTION %s
 // CHECK-BRANCH-PROTECTION: -mbranch-protection=standard
 
+// RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=arm-none-eabi --cstdlib=picolibc | FileCheck --check-prefix=CHECK-CSTDLIB %s
+// RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=arm-none-eabi --cstdlib picolibc | FileCheck --check-prefix=CHECK-CSTDLIB %s
+// CHECK-CSTDLIB: --cstdlib=picolibc
+
 // RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=arm-none-eabi -mno-unaligned-access | FileCheck --check-prefix=CHECK-NO-UNALIGNED-ACCESS %s
 // RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=arm-none-eabi -mstrict-align | FileCheck --check-prefix=CHECK-NO-UNALIGNED-ACCESS %s
 // RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=arm-none-eabi | FileCheck --check-prefix=CHECK-NO-UNALIGNED-ACCESS %s


### PR DESCRIPTION
Pass the --cstdlib through to the multilibs backend so that the value specified on the command line can be used inside the multilibs YAML file.

Assisted-by: codex, reviewed and tested by me.