### PR TITLE
[SimplifyLibCalls] Use context instruction strcmp->memcmp transform

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
@@ -264,11 +264,11 @@ static bool isOnlyUsedInComparisonWithZero(Value *V) {
 }
 
 static bool canTransformToMemCmp(CallInst *CI, Value *Str, uint64_t Len,
-                                 const DataLayout &DL) {
+                                 const SimplifyQuery &SQ) {
   if (!isOnlyUsedInComparisonWithZero(CI))
     return false;
 
-  if (!isDereferenceableAndAlignedPointer(Str, Align(1), APInt(64, Len), DL))
+  if (!isDereferenceableAndAlignedPointer(Str, Align(1), APInt(64, Len), SQ))
     return false;
 
   if (CI->getFunction()->hasFnAttribute(Attribute::SanitizeMemory))
@@ -608,13 +608,14 @@ Value *LibCallSimplifier::optimizeStrCmp(CallInst *CI, IRBuilderBase &B) {
   }
 
   // strcmp to memcmp
+  SimplifyQuery SQ(DL, TLI, DT, AC, CI);
   if (!HasStr1 && HasStr2) {
-    if (canTransformToMemCmp(CI, Str1P, Len2, DL))
+    if (canTransformToMemCmp(CI, Str1P, Len2, SQ))
       return copyFlags(*CI, emitMemCmp(Str1P, Str2P,
                                        TLI->getAsSizeT(Len2, *CI->getModule()),
                                        B, DL, TLI));
   } else if (HasStr1 && !HasStr2) {
-    if (canTransformToMemCmp(CI, Str2P, Len1, DL))
+    if (canTransformToMemCmp(CI, Str2P, Len1, SQ))
       return copyFlags(*CI, emitMemCmp(Str1P, Str2P,
                                        TLI->getAsSizeT(Len1, *CI->getModule()),
                                        B, DL, TLI));

--- a/llvm/test/Transforms/InstCombine/strcmp-memcmp.ll
+++ b/llvm/test/Transforms/InstCombine/strcmp-memcmp.ll
@@ -489,4 +489,34 @@ define i32 @strcmp_memcmp_msan(ptr dereferenceable (12) %buf) sanitize_memory {
   ret i32 %conv
 }
 
+define i32 @strcmp_memcmp_assume(ptr %buf) {
+; CHECK-LABEL: @strcmp_memcmp_assume(
+; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "dereferenceable"(ptr [[BUF:%.*]], i64 4) ]
+; CHECK-NEXT:    [[CALL:%.*]] = call i32 @memcmp(ptr noundef nonnull dereferenceable(4) [[BUF]], ptr noundef nonnull dereferenceable(4) @key, i64 4)
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[CALL]], 0
+; CHECK-NEXT:    [[CONV:%.*]] = zext i1 [[CMP]] to i32
+; CHECK-NEXT:    ret i32 [[CONV]]
+;
+  call void @llvm.assume(i1 true) ["dereferenceable"(ptr %buf, i64 4)]
+  %call = call i32 @strcmp(ptr nonnull %buf, ptr @key)
+  %cmp = icmp eq i32 %call, 0
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
+define i32 @strcmp_memcmp_assume_insufficient(ptr %buf) {
+; CHECK-LABEL: @strcmp_memcmp_assume_insufficient(
+; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "dereferenceable"(ptr [[BUF:%.*]], i64 3) ]
+; CHECK-NEXT:    [[CALL:%.*]] = call i32 @strcmp(ptr noundef nonnull dereferenceable(1) [[BUF]], ptr noundef nonnull dereferenceable(4) @key)
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[CALL]], 0
+; CHECK-NEXT:    [[CONV:%.*]] = zext i1 [[CMP]] to i32
+; CHECK-NEXT:    ret i32 [[CONV]]
+;
+  call void @llvm.assume(i1 true) ["dereferenceable"(ptr %buf, i64 3)]
+  %call = call i32 @strcmp(ptr nonnull %buf, ptr @key)
+  %cmp = icmp eq i32 %call, 0
+  %conv = zext i1 %cmp to i32
+  ret i32 %conv
+}
+
 declare i32 @memcmp(ptr nocapture, ptr nocapture, i64)


### PR DESCRIPTION
Pass the context instruction when checking for dereferenceability.