### PR TITLE
[libc] Add Endian::from_{big,little}_endian

### DIFF
--- a/libc/src/__support/endian_internal.h
+++ b/libc/src/__support/endian_internal.h
@@ -41,6 +41,16 @@ template <unsigned ORDER> struct Endian {
   static constexpr const bool IS_BIG = ORDER == __ORDER_BIG_ENDIAN__;
   template <typename T> LIBC_INLINE static T to_big_endian(T value);
   template <typename T> LIBC_INLINE static T to_little_endian(T value);
+
+  // Converting "to" and "from" a given endianness is actually the same
+  // operation, but we provide dedicated functions to let the user express their
+  // intent clearly.
+  template <typename T> LIBC_INLINE static T from_big_endian(T value) {
+    return to_big_endian(value);
+  }
+  template <typename T> LIBC_INLINE static T from_little_endian(T value) {
+    return to_little_endian(value);
+  }
 };
 
 // Little Endian specializations

--- a/libc/src/arpa/inet/ntohl.cpp
+++ b/libc/src/arpa/inet/ntohl.cpp
@@ -14,10 +14,7 @@
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(uint32_t, ntohl, (uint32_t netlong)) {
-  if constexpr (Endian::IS_LITTLE)
-    return __builtin_bswap32(netlong);
-  else
-    return netlong;
+  return Endian::from_big_endian(netlong);
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/arpa/inet/ntohs.cpp
+++ b/libc/src/arpa/inet/ntohs.cpp
@@ -14,10 +14,7 @@
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(uint16_t, ntohs, (uint16_t netshort)) {
-  if constexpr (Endian::IS_LITTLE)
-    return __builtin_bswap16(netshort);
-  else
-    return netshort;
+  return Endian::from_big_endian(netshort);
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/test/src/__support/endian_internal_test.cpp
+++ b/libc/test/src/__support/endian_internal_test.cpp
@@ -16,11 +16,15 @@ struct LlvmLibcEndian : testing::Test {
   template <typename T> void check(const T original, const T swapped) {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     EXPECT_EQ(Endian::to_little_endian(original), original);
+    EXPECT_EQ(Endian::from_little_endian(original), original);
     EXPECT_EQ(Endian::to_big_endian(original), swapped);
+    EXPECT_EQ(Endian::from_big_endian(swapped), original);
 #endif
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
     EXPECT_EQ(Endian::to_big_endian(original), original);
+    EXPECT_EQ(Endian::from_big_endian(original), original);
     EXPECT_EQ(Endian::to_little_endian(original), swapped);
+    EXPECT_EQ(Endian::from_little_endian(swapped), original);
 #endif
   }
 };


### PR DESCRIPTION
This is actually the same function as its to_ counterpart, but it lets us correctly express the intent.

The functions are already useful for implementing ntoh?, but I'll add other uses of them soon.