### PR TITLE
[OFFLOAD][L0] Switch to use inorder queues by default

### DIFF
--- a/offload/plugins-nextgen/level_zero/include/L0Options.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Options.h
@@ -129,9 +129,7 @@ struct L0OptionsTy {
   SpecConstantsTy CommonSpecConstants;
 
   /// Command execution mode.
-  /// Whether the runtime uses asynchronous mode or not depends on the type of
-  /// devices and whether immediate command list is fully enabled.
-  CommandModeTy CommandMode = CommandModeTy::Async;
+  CommandModeTy CommandMode = CommandModeTy::InOrder;
 
   /// Controls if we need to reduce available HW threads. We need this
   /// adjustment on XeHPG when Level Zero debug is enabled


### PR DESCRIPTION
Now that other pieces are in place we can switch to using Level Zero inorder queues by default.