### PR TITLE
[clang][CMake][Darwin] Make HOST_LINK_VERSION a CACHE option on Darwin 

### DIFF
--- a/clang/CMakeLists.txt
+++ b/clang/CMakeLists.txt
@@ -407,9 +407,12 @@ if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
 endif ()
 
 # Determine HOST_LINK_VERSION on Darwin.
-set(HOST_LINK_VERSION)
-if (APPLE AND NOT CMAKE_LINKER MATCHES ".*lld.*")
+set(HOST_LINK_VERSION "" CACHE STRING "Host linker version on Darwin")
+if (APPLE AND NOT HOST_LINK_VERSION AND NOT CMAKE_LINKER MATCHES ".*lld.*")
   get_darwin_linker_version(HOST_LINK_VERSION)
+  set(HOST_LINK_VERSION "${HOST_LINK_VERSION}" CACHE STRING "Host linker version on Darwin" FORCE)
+endif()
+if (HOST_LINK_VERSION)
   message(STATUS "Host linker version: ${HOST_LINK_VERSION}")
 endif()
 


### PR DESCRIPTION
This allows specifying a fixed host linker version during Clang configuration (e.g. -DHOST_LINK_VERSION=1249), bypassing the default auto-detection. This is useful for hermetic packaging scripts where the auto-detected host linker might differ from the intended target linker, and we do not want certain features to be enabled that depends on the host linker version -- e.g. https://github.com/llvm/llvm-project/issues/203385
