### PR TITLE
[flang][OpenMP][NFC] Extract enclosing-construct trait collection helper

### DIFF
--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -4667,21 +4667,6 @@ struct MetadirectiveCandidate {
 };
 } // namespace
 
-static void appendConstructTraits(
-    mlir::Operation *op,
-    llvm::SmallVectorImpl<llvm::omp::TraitProperty> &constructTraits) {
-  if (mlir::isa<mlir::omp::WsloopOp>(op))
-    constructTraits.push_back(llvm::omp::TraitProperty::construct_for_for);
-  if (mlir::isa<mlir::omp::ParallelOp>(op))
-    constructTraits.push_back(
-        llvm::omp::TraitProperty::construct_parallel_parallel);
-  if (mlir::isa<mlir::omp::TeamsOp>(op))
-    constructTraits.push_back(llvm::omp::TraitProperty::construct_teams_teams);
-  if (mlir::isa<mlir::omp::TargetOp>(op))
-    constructTraits.push_back(
-        llvm::omp::TraitProperty::construct_target_target);
-}
-
 static void genMetadirective(lower::AbstractConverter &converter,
                              lower::SymMap &symTable,
                              semantics::SemanticsContext &semaCtx,
@@ -4690,15 +4675,7 @@ static void genMetadirective(lower::AbstractConverter &converter,
   fir::FirOpBuilder &builder = converter.getFirOpBuilder();
 
   llvm::SmallVector<llvm::omp::TraitProperty, 8> constructTraits;
-  // Collect enclosing OpenMP operations so variants chosen by an outer
-  // metadirective are part of this metadirective's context. For example, an
-  // inner metadirective inside `target` and an outer-selected `parallel` must
-  // be able to match construct={target, parallel}.
-  for (mlir::Operation *op = builder.getInsertionBlock()->getParentOp(); op;
-       op = op->getParentOp())
-    appendConstructTraits(op, constructTraits);
-
-  std::reverse(constructTraits.begin(), constructTraits.end());
+  collectEnclosingConstructTraits(builder, constructTraits);
   FlangOMPContext ompCtx(builder.getModule(), constructTraits);
 
   llvm::SmallVector<MetadirectiveCandidate, 4> candidates;

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -4675,7 +4675,8 @@ static void genMetadirective(lower::AbstractConverter &converter,
   fir::FirOpBuilder &builder = converter.getFirOpBuilder();
 
   llvm::SmallVector<llvm::omp::TraitProperty, 8> constructTraits;
-  collectEnclosingConstructTraits(builder, constructTraits);
+  collectEnclosingConstructTraits(builder.getInsertionBlock()->getParentOp(),
+                                  constructTraits);
   FlangOMPContext ompCtx(builder.getModule(), constructTraits);
 
   llvm::SmallVector<MetadirectiveCandidate, 4> candidates;

--- a/flang/lib/Lower/OpenMP/Utils.cpp
+++ b/flang/lib/Lower/OpenMP/Utils.cpp
@@ -1438,15 +1438,14 @@ bool FlangOMPContext::matchesISATrait(llvm::StringRef rawString) const {
 }
 
 void collectEnclosingConstructTraits(
-    fir::FirOpBuilder &builder,
+    mlir::Operation *op,
     llvm::SmallVectorImpl<llvm::omp::TraitProperty> &constructTraits) {
   // Collect enclosing OpenMP operations so variants chosen by an outer
   // metadirective are part of this metadirective's context. For example, an
   // inner metadirective inside `target` and an outer-selected `parallel` must
   // be able to match construct={target, parallel}. The final reverse yields
   // outermost-to-innermost order as required by OMPContext.
-  for (mlir::Operation *op = builder.getInsertionBlock()->getParentOp(); op;
-       op = op->getParentOp()) {
+  for (; op; op = op->getParentOp()) {
     if (mlir::isa<mlir::omp::WsloopOp>(op))
       constructTraits.push_back(llvm::omp::TraitProperty::construct_for_for);
     if (mlir::isa<mlir::omp::ParallelOp>(op))

--- a/flang/lib/Lower/OpenMP/Utils.cpp
+++ b/flang/lib/Lower/OpenMP/Utils.cpp
@@ -1437,6 +1437,31 @@ bool FlangOMPContext::matchesISATrait(llvm::StringRef rawString) const {
   return targetFeatures.contains(("+" + rawString).str());
 }
 
+void collectEnclosingConstructTraits(
+    fir::FirOpBuilder &builder,
+    llvm::SmallVectorImpl<llvm::omp::TraitProperty> &constructTraits) {
+  // Collect enclosing OpenMP operations so variants chosen by an outer
+  // metadirective are part of this metadirective's context. For example, an
+  // inner metadirective inside `target` and an outer-selected `parallel` must
+  // be able to match construct={target, parallel}. The final reverse yields
+  // outermost-to-innermost order as required by OMPContext.
+  for (mlir::Operation *op = builder.getInsertionBlock()->getParentOp(); op;
+       op = op->getParentOp()) {
+    if (mlir::isa<mlir::omp::WsloopOp>(op))
+      constructTraits.push_back(llvm::omp::TraitProperty::construct_for_for);
+    if (mlir::isa<mlir::omp::ParallelOp>(op))
+      constructTraits.push_back(
+          llvm::omp::TraitProperty::construct_parallel_parallel);
+    if (mlir::isa<mlir::omp::TeamsOp>(op))
+      constructTraits.push_back(
+          llvm::omp::TraitProperty::construct_teams_teams);
+    if (mlir::isa<mlir::omp::TargetOp>(op))
+      constructTraits.push_back(
+          llvm::omp::TraitProperty::construct_target_target);
+  }
+  std::reverse(constructTraits.begin(), constructTraits.end());
+}
+
 } // namespace omp
 } // namespace lower
 } // namespace Fortran

--- a/flang/lib/Lower/OpenMP/Utils.h
+++ b/flang/lib/Lower/OpenMP/Utils.h
@@ -256,6 +256,14 @@ std::optional<llvm::SmallVector<mlir::Value>> getIteratorElementIndices(
     Fortran::lower::AbstractConverter &converter, const omp::Object &object,
     Fortran::lower::StatementContext &stmtCtx, mlir::Location loc);
 
+/// Walk the already-emitted MLIR parent operations from the current insertion
+/// point and collect the implied OpenMP construct traits in
+/// outermost-to-innermost order. Used by metadirective lowering to build the
+/// `ConstructTraits` of an `OMPContext`.
+void collectEnclosingConstructTraits(
+    fir::FirOpBuilder &builder,
+    llvm::SmallVectorImpl<llvm::omp::TraitProperty> &constructTraits);
+
 /// Non-constant user condition expression and source for runtime lowering.
 struct DynamicUserCondition {
   const parser::ScalarExpr *expr;

--- a/flang/lib/Lower/OpenMP/Utils.h
+++ b/flang/lib/Lower/OpenMP/Utils.h
@@ -256,12 +256,12 @@ std::optional<llvm::SmallVector<mlir::Value>> getIteratorElementIndices(
     Fortran::lower::AbstractConverter &converter, const omp::Object &object,
     Fortran::lower::StatementContext &stmtCtx, mlir::Location loc);
 
-/// Walk the already-emitted MLIR parent operations from the current insertion
-/// point and collect the implied OpenMP construct traits in
-/// outermost-to-innermost order. Used by metadirective lowering to build the
-/// `ConstructTraits` of an `OMPContext`.
+/// Walk the already-emitted MLIR parent operations starting from \p op and
+/// collect the implied OpenMP construct traits in outermost-to-innermost
+/// order. Used by metadirective lowering to build the `ConstructTraits` of an
+/// `OMPContext`.
 void collectEnclosingConstructTraits(
-    fir::FirOpBuilder &builder,
+    mlir::Operation *op,
     llvm::SmallVectorImpl<llvm::omp::TraitProperty> &constructTraits);
 
 /// Non-constant user condition expression and source for runtime lowering.


### PR DESCRIPTION
Move the inline MLIR-parent walk in genMetadirective that maps enclosing OpenMP operations to construct trait properties into a reusable collectEnclosingConstructTraits helper. No functional change to metadirective matching; this prepares the helper for reuse by DECLARE VARIANT call-site resolution.