### PR TITLE
[AMDGPU] Refine i8 extractelement cost model

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
@@ -1026,16 +1026,16 @@ InstructionCost GCNTTIImpl::getVectorInstrCost(
     if (EltSize < 32) {
       if (EltSize == 16 && Index == 0 && ST->has16BitInsts())
         return 0;
-      // Some i8 inserts and extracts are free so we want to reduce the
-      // cost to avoid scalarization. We limit the zero cost cases to avoid
-      // adversely impacting all i8 vectorizing.
-      if (EltSize == 8) {
-        unsigned NumElts = cast<FixedVectorType>(ValTy)->getNumElements();
-        if (NumElts >= 4 && isPowerOf2_32(NumElts)) {
-          // Extracts at indices aligned to 32-bit boundaries (0, 4, 8, 12 for
-          // v16i8) are free as they access the low byte of each VGPR. Other
-          // indices require bit manipulation (shifts/byte selects) and cost 1.
-          return Index % 4 == 0 ? 0 : 1;
+      // Extract element sequences of consecutive i8 values that match a
+      // register size are free most likely. It is not possible to know
+      // if this extract is part of a consecutive sequence so this may
+      // apply more generally.
+      if (Opcode == Instruction::ExtractElement && EltSize == 8) {
+        if (auto *FVTy = dyn_cast<FixedVectorType>(ValTy)) {
+          unsigned NumElts = FVTy->getNumElements();
+          if (NumElts >= 4 && isPowerOf2_32(NumElts)) {
+            return 0;
+          }
         }
       }
       return BaseT::getVectorInstrCost(Opcode, ValTy, CostKind, Index, Op0, Op1,

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
@@ -1033,9 +1033,8 @@ InstructionCost GCNTTIImpl::getVectorInstrCost(
       if (Opcode == Instruction::ExtractElement && EltSize == 8) {
         if (auto *FVTy = dyn_cast<FixedVectorType>(ValTy)) {
           unsigned NumElts = FVTy->getNumElements();
-          if (NumElts >= 4 && isPowerOf2_32(NumElts)) {
+          if (NumElts >= 4 && isPowerOf2_32(NumElts))
             return 0;
-          }
         }
       }
       return BaseT::getVectorInstrCost(Opcode, ValTy, CostKind, Index, Op0, Op1,

--- a/llvm/test/Analysis/CostModel/AMDGPU/div.ll
+++ b/llvm/test/Analysis/CostModel/AMDGPU/div.ll
@@ -44,9 +44,9 @@ define i32 @sdiv() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i16 = sdiv <16 x i16> poison, poison
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i16 = sdiv <32 x i16> poison, poison
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %I8 = sdiv i8 poison, poison
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 28 for instruction: %V16i8 = sdiv <16 x i8> poison, poison
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 56 for instruction: %V32i8 = sdiv <32 x i8> poison, poison
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V64i8 = sdiv <64 x i8> poison, poison
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i8 = sdiv <16 x i8> poison, poison
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i8 = sdiv <32 x i8> poison, poison
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V64i8 = sdiv <64 x i8> poison, poison
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'sdiv'
@@ -125,9 +125,9 @@ define i32 @udiv() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i16 = udiv <16 x i16> poison, poison
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i16 = udiv <32 x i16> poison, poison
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %I8 = udiv i8 poison, poison
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 28 for instruction: %V16i8 = udiv <16 x i8> poison, poison
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 56 for instruction: %V32i8 = udiv <32 x i8> poison, poison
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V64i8 = udiv <64 x i8> poison, poison
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i8 = udiv <16 x i8> poison, poison
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i8 = udiv <32 x i8> poison, poison
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V64i8 = udiv <64 x i8> poison, poison
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'udiv'
@@ -206,9 +206,9 @@ define i32 @sdiv_const() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i16 = sdiv <16 x i16> poison, <i16 4, i16 5, i16 6, i16 7, i16 8, i16 9, i16 10, i16 11, i16 12, i16 13, i16 14, i16 15, i16 16, i16 17, i16 18, i16 19>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i16 = sdiv <32 x i16> poison, <i16 4, i16 5, i16 6, i16 7, i16 8, i16 9, i16 10, i16 11, i16 12, i16 13, i16 14, i16 15, i16 16, i16 17, i16 18, i16 19, i16 4, i16 5, i16 6, i16 7, i16 8, i16 9, i16 10, i16 11, i16 12, i16 13, i16 14, i16 15, i16 16, i16 17, i16 18, i16 19>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %I8 = sdiv i8 poison, 7
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 28 for instruction: %V16i8 = sdiv <16 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 56 for instruction: %V32i8 = sdiv <32 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V64i8 = sdiv <64 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i8 = sdiv <16 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i8 = sdiv <32 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V64i8 = sdiv <64 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'sdiv_const'
@@ -287,9 +287,9 @@ define i32 @udiv_const() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i16 = udiv <16 x i16> poison, <i16 4, i16 5, i16 6, i16 7, i16 8, i16 9, i16 10, i16 11, i16 12, i16 13, i16 14, i16 15, i16 16, i16 17, i16 18, i16 19>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i16 = udiv <32 x i16> poison, <i16 4, i16 5, i16 6, i16 7, i16 8, i16 9, i16 10, i16 11, i16 12, i16 13, i16 14, i16 15, i16 16, i16 17, i16 18, i16 19, i16 4, i16 5, i16 6, i16 7, i16 8, i16 9, i16 10, i16 11, i16 12, i16 13, i16 14, i16 15, i16 16, i16 17, i16 18, i16 19>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %I8 = udiv i8 poison, 7
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 28 for instruction: %V16i8 = udiv <16 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 56 for instruction: %V32i8 = udiv <32 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V64i8 = udiv <64 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i8 = udiv <16 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i8 = udiv <32 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V64i8 = udiv <64 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'udiv_const'
@@ -368,9 +368,9 @@ define i32 @sdiv_uniformconst() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i16 = sdiv <16 x i16> poison, splat (i16 7)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i16 = sdiv <32 x i16> poison, splat (i16 7)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %I8 = sdiv i8 poison, 7
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 28 for instruction: %V16i8 = sdiv <16 x i8> poison, splat (i8 7)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 56 for instruction: %V32i8 = sdiv <32 x i8> poison, splat (i8 7)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V64i8 = sdiv <64 x i8> poison, splat (i8 7)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i8 = sdiv <16 x i8> poison, splat (i8 7)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i8 = sdiv <32 x i8> poison, splat (i8 7)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V64i8 = sdiv <64 x i8> poison, splat (i8 7)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'sdiv_uniformconst'
@@ -449,9 +449,9 @@ define i32 @udiv_uniformconst() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i16 = udiv <16 x i16> poison, splat (i16 7)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i16 = udiv <32 x i16> poison, splat (i16 7)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %I8 = udiv i8 poison, 7
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 28 for instruction: %V16i8 = udiv <16 x i8> poison, splat (i8 7)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 56 for instruction: %V32i8 = udiv <32 x i8> poison, splat (i8 7)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V64i8 = udiv <64 x i8> poison, splat (i8 7)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i8 = udiv <16 x i8> poison, splat (i8 7)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i8 = udiv <32 x i8> poison, splat (i8 7)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V64i8 = udiv <64 x i8> poison, splat (i8 7)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'udiv_uniformconst'
@@ -530,9 +530,9 @@ define i32 @sdiv_constpow2() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i16 = sdiv <16 x i16> poison, <i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256, i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i16 = sdiv <32 x i16> poison, <i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256, i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256, i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256, i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %I8 = sdiv i8 poison, 16
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 28 for instruction: %V16i8 = sdiv <16 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 56 for instruction: %V32i8 = sdiv <32 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V64i8 = sdiv <64 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i8 = sdiv <16 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i8 = sdiv <32 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V64i8 = sdiv <64 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'sdiv_constpow2'
@@ -611,9 +611,9 @@ define i32 @udiv_constpow2() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i16 = udiv <16 x i16> poison, <i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256, i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i16 = udiv <32 x i16> poison, <i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256, i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256, i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256, i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %I8 = udiv i8 poison, 16
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 28 for instruction: %V16i8 = udiv <16 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 56 for instruction: %V32i8 = udiv <32 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V64i8 = udiv <64 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i8 = udiv <16 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i8 = udiv <32 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V64i8 = udiv <64 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'udiv_constpow2'
@@ -692,9 +692,9 @@ define i32 @sdiv_uniformconstpow2() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i16 = sdiv <16 x i16> poison, splat (i16 16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i16 = sdiv <32 x i16> poison, splat (i16 16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %I8 = sdiv i8 poison, 16
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 28 for instruction: %V16i8 = sdiv <16 x i8> poison, splat (i8 16)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 56 for instruction: %V32i8 = sdiv <32 x i8> poison, splat (i8 16)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V64i8 = sdiv <64 x i8> poison, splat (i8 16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i8 = sdiv <16 x i8> poison, splat (i8 16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i8 = sdiv <32 x i8> poison, splat (i8 16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V64i8 = sdiv <64 x i8> poison, splat (i8 16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'sdiv_uniformconstpow2'
@@ -773,9 +773,9 @@ define i32 @udiv_uniformconstpow2() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i16 = udiv <16 x i16> poison, splat (i16 16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i16 = udiv <32 x i16> poison, splat (i16 16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %I8 = udiv i8 poison, 16
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 28 for instruction: %V16i8 = udiv <16 x i8> poison, splat (i8 16)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 56 for instruction: %V32i8 = udiv <32 x i8> poison, splat (i8 16)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V64i8 = udiv <64 x i8> poison, splat (i8 16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i8 = udiv <16 x i8> poison, splat (i8 16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i8 = udiv <32 x i8> poison, splat (i8 16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V64i8 = udiv <64 x i8> poison, splat (i8 16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'udiv_uniformconstpow2'
@@ -854,9 +854,9 @@ define i32 @sdiv_constnegpow2() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i16 = sdiv <16 x i16> poison, <i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256, i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i16 = sdiv <32 x i16> poison, <i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256, i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256, i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256, i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %I8 = sdiv i8 poison, -16
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 28 for instruction: %V16i8 = sdiv <16 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 56 for instruction: %V32i8 = sdiv <32 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V64i8 = sdiv <64 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i8 = sdiv <16 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i8 = sdiv <32 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V64i8 = sdiv <64 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'sdiv_constnegpow2'
@@ -935,9 +935,9 @@ define i32 @udiv_constnegpow2() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i16 = udiv <16 x i16> poison, <i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256, i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i16 = udiv <32 x i16> poison, <i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256, i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256, i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256, i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %I8 = udiv i8 poison, -16
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 28 for instruction: %V16i8 = udiv <16 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 56 for instruction: %V32i8 = udiv <32 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V64i8 = udiv <64 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i8 = udiv <16 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i8 = udiv <32 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V64i8 = udiv <64 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'udiv_constnegpow2'
@@ -1016,9 +1016,9 @@ define i32 @sdiv_uniformconstnegpow2() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i16 = sdiv <16 x i16> poison, splat (i16 -16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i16 = sdiv <32 x i16> poison, splat (i16 -16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %I8 = sdiv i8 poison, -16
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 28 for instruction: %V16i8 = sdiv <16 x i8> poison, splat (i8 -16)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 56 for instruction: %V32i8 = sdiv <32 x i8> poison, splat (i8 -16)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V64i8 = sdiv <64 x i8> poison, splat (i8 -16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i8 = sdiv <16 x i8> poison, splat (i8 -16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i8 = sdiv <32 x i8> poison, splat (i8 -16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V64i8 = sdiv <64 x i8> poison, splat (i8 -16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'sdiv_uniformconstnegpow2'
@@ -1097,9 +1097,9 @@ define i32 @udiv_uniformconstnegpow2() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i16 = udiv <16 x i16> poison, splat (i16 -16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i16 = udiv <32 x i16> poison, splat (i16 -16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %I8 = udiv i8 poison, -16
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 28 for instruction: %V16i8 = udiv <16 x i8> poison, splat (i8 -16)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 56 for instruction: %V32i8 = udiv <32 x i8> poison, splat (i8 -16)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V64i8 = udiv <64 x i8> poison, splat (i8 -16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 32 for instruction: %V16i8 = udiv <16 x i8> poison, splat (i8 -16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 64 for instruction: %V32i8 = udiv <32 x i8> poison, splat (i8 -16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V64i8 = udiv <64 x i8> poison, splat (i8 -16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'udiv_uniformconstnegpow2'

--- a/llvm/test/Analysis/CostModel/AMDGPU/extractelement.ll
+++ b/llvm/test/Analysis/CostModel/AMDGPU/extractelement.ll
@@ -176,23 +176,23 @@ define amdgpu_kernel void @extractelement_8(i32 %arg) {
 ; GCN-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v8i8_0 = extractelement <8 x i8> poison, i32 0
 ; GCN-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v2i8_1 = extractelement <2 x i8> poison, i32 1
 ; GCN-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v3i8_1 = extractelement <3 x i8> poison, i32 1
-; GCN-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v4i8_1 = extractelement <4 x i8> poison, i32 1
+; GCN-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v4i8_1 = extractelement <4 x i8> poison, i32 1
 ; GCN-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v5i8_1 = extractelement <5 x i8> poison, i32 1
-; GCN-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v8i8_1 = extractelement <8 x i8> poison, i32 1
+; GCN-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v8i8_1 = extractelement <8 x i8> poison, i32 1
 ; GCN-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v3i8_2 = extractelement <3 x i8> poison, i32 2
-; GCN-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v4i8_2 = extractelement <4 x i8> poison, i32 2
+; GCN-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v4i8_2 = extractelement <4 x i8> poison, i32 2
 ; GCN-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v5i8_2 = extractelement <5 x i8> poison, i32 2
-; GCN-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v8i8_2 = extractelement <8 x i8> poison, i32 2
-; GCN-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v4i8_3 = extractelement <4 x i8> poison, i32 3
+; GCN-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v8i8_2 = extractelement <8 x i8> poison, i32 2
+; GCN-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v4i8_3 = extractelement <4 x i8> poison, i32 3
 ; GCN-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v5i8_3 = extractelement <5 x i8> poison, i32 3
-; GCN-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v8i8_3 = extractelement <8 x i8> poison, i32 3
+; GCN-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v8i8_3 = extractelement <8 x i8> poison, i32 3
 ; GCN-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %v2i8_a = extractelement <2 x i8> poison, i32 %arg
 ; GCN-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %v4i8_a = extractelement <4 x i8> poison, i32 %arg
 ; GCN-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %v8i8_a = extractelement <8 x i8> poison, i32 %arg
 ; GCN-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v16i8_0 = extractelement <16 x i8> poison, i32 0
-; GCN-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v16i8_1 = extractelement <16 x i8> poison, i32 1
+; GCN-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v16i8_1 = extractelement <16 x i8> poison, i32 1
 ; GCN-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v16i8_8 = extractelement <16 x i8> poison, i32 8
-; GCN-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v16i8_15 = extractelement <16 x i8> poison, i32 15
+; GCN-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v16i8_15 = extractelement <16 x i8> poison, i32 15
 ; GCN-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %v16i8_a = extractelement <16 x i8> poison, i32 %arg
 ; GCN-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret void
 ;
@@ -204,23 +204,23 @@ define amdgpu_kernel void @extractelement_8(i32 %arg) {
 ; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v8i8_0 = extractelement <8 x i8> poison, i32 0
 ; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v2i8_1 = extractelement <2 x i8> poison, i32 1
 ; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v3i8_1 = extractelement <3 x i8> poison, i32 1
-; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v4i8_1 = extractelement <4 x i8> poison, i32 1
+; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v4i8_1 = extractelement <4 x i8> poison, i32 1
 ; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v5i8_1 = extractelement <5 x i8> poison, i32 1
-; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v8i8_1 = extractelement <8 x i8> poison, i32 1
+; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v8i8_1 = extractelement <8 x i8> poison, i32 1
 ; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v3i8_2 = extractelement <3 x i8> poison, i32 2
-; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v4i8_2 = extractelement <4 x i8> poison, i32 2
+; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v4i8_2 = extractelement <4 x i8> poison, i32 2
 ; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v5i8_2 = extractelement <5 x i8> poison, i32 2
-; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v8i8_2 = extractelement <8 x i8> poison, i32 2
-; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v4i8_3 = extractelement <4 x i8> poison, i32 3
+; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v8i8_2 = extractelement <8 x i8> poison, i32 2
+; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v4i8_3 = extractelement <4 x i8> poison, i32 3
 ; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v5i8_3 = extractelement <5 x i8> poison, i32 3
-; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v8i8_3 = extractelement <8 x i8> poison, i32 3
+; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v8i8_3 = extractelement <8 x i8> poison, i32 3
 ; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %v2i8_a = extractelement <2 x i8> poison, i32 %arg
 ; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %v4i8_a = extractelement <4 x i8> poison, i32 %arg
 ; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %v8i8_a = extractelement <8 x i8> poison, i32 %arg
 ; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v16i8_0 = extractelement <16 x i8> poison, i32 0
-; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v16i8_1 = extractelement <16 x i8> poison, i32 1
+; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v16i8_1 = extractelement <16 x i8> poison, i32 1
 ; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v16i8_8 = extractelement <16 x i8> poison, i32 8
-; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v16i8_15 = extractelement <16 x i8> poison, i32 15
+; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v16i8_15 = extractelement <16 x i8> poison, i32 15
 ; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %v16i8_a = extractelement <16 x i8> poison, i32 %arg
 ; GCN-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret void
 ;

--- a/llvm/test/Analysis/CostModel/AMDGPU/insertelement.ll
+++ b/llvm/test/Analysis/CostModel/AMDGPU/insertelement.ll
@@ -11,7 +11,7 @@ define amdgpu_kernel void @insertelement_i8(i32 %arg) {
 ; ALL-LABEL: 'insertelement_i8'
 ; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v2i8_0 = insertelement <2 x i8> poison, i8 42, i32 0
 ; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v3i8_0 = insertelement <3 x i8> poison, i8 42, i32 0
-; ALL-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v4i8_0 = insertelement <4 x i8> poison, i8 42, i32 0
+; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v4i8_0 = insertelement <4 x i8> poison, i8 42, i32 0
 ; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v5i8_0 = insertelement <5 x i8> poison, i8 42, i32 0
 ; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v2i8_1 = insertelement <2 x i8> poison, i8 42, i32 1
 ; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v3i8_1 = insertelement <3 x i8> poison, i8 42, i32 1
@@ -26,7 +26,7 @@ define amdgpu_kernel void @insertelement_i8(i32 %arg) {
 ; ALL-SIZE-LABEL: 'insertelement_i8'
 ; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v2i8_0 = insertelement <2 x i8> poison, i8 42, i32 0
 ; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v3i8_0 = insertelement <3 x i8> poison, i8 42, i32 0
-; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v4i8_0 = insertelement <4 x i8> poison, i8 42, i32 0
+; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v4i8_0 = insertelement <4 x i8> poison, i8 42, i32 0
 ; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v5i8_0 = insertelement <5 x i8> poison, i8 42, i32 0
 ; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v2i8_1 = insertelement <2 x i8> poison, i8 42, i32 1
 ; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v3i8_1 = insertelement <3 x i8> poison, i8 42, i32 1
@@ -574,31 +574,31 @@ define i32 @insert_i8_poison(i32 %arg) {
 ; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v2i8_0 = insertelement <2 x i8> poison, i8 poison, i32 0
 ; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v2i8_3 = insertelement <2 x i8> poison, i8 poison, i32 1
 ; ALL-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %v4i8_a = insertelement <4 x i8> poison, i8 poison, i32 %arg
-; ALL-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v4i8_0 = insertelement <4 x i8> poison, i8 poison, i32 0
+; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v4i8_0 = insertelement <4 x i8> poison, i8 poison, i32 0
 ; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v4i8_3 = insertelement <4 x i8> poison, i8 poison, i32 3
 ; ALL-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %v8i8_a = insertelement <8 x i8> poison, i8 poison, i32 %arg
-; ALL-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v8i8_0 = insertelement <8 x i8> poison, i8 poison, i32 0
+; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v8i8_0 = insertelement <8 x i8> poison, i8 poison, i32 0
 ; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v8i8_7 = insertelement <8 x i8> poison, i8 poison, i32 7
 ; ALL-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %v16i8_a = insertelement <16 x i8> poison, i8 poison, i32 %arg
-; ALL-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v16i8_0 = insertelement <16 x i8> poison, i8 poison, i32 0
-; ALL-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v16i8_8 = insertelement <16 x i8> poison, i8 poison, i32 8
+; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v16i8_0 = insertelement <16 x i8> poison, i8 poison, i32 0
+; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v16i8_8 = insertelement <16 x i8> poison, i8 poison, i32 8
 ; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v16i8_15 = insertelement <16 x i8> poison, i8 poison, i32 15
 ; ALL-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %v32i8_a = insertelement <32 x i8> poison, i8 poison, i32 %arg
-; ALL-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v32i8_0 = insertelement <32 x i8> poison, i8 poison, i32 0
+; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v32i8_0 = insertelement <32 x i8> poison, i8 poison, i32 0
 ; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v32i8_7 = insertelement <32 x i8> poison, i8 poison, i32 7
-; ALL-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v32i8_8 = insertelement <32 x i8> poison, i8 poison, i32 8
+; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v32i8_8 = insertelement <32 x i8> poison, i8 poison, i32 8
 ; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v32i8_15 = insertelement <32 x i8> poison, i8 poison, i32 15
-; ALL-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v32i8_24 = insertelement <32 x i8> poison, i8 poison, i32 24
+; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v32i8_24 = insertelement <32 x i8> poison, i8 poison, i32 24
 ; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v32i8_31 = insertelement <32 x i8> poison, i8 poison, i32 31
 ; ALL-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %v64i8_a = insertelement <64 x i8> poison, i8 poison, i32 %arg
-; ALL-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v64i8_0 = insertelement <64 x i8> poison, i8 poison, i32 0
+; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v64i8_0 = insertelement <64 x i8> poison, i8 poison, i32 0
 ; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v64i8_7 = insertelement <64 x i8> poison, i8 poison, i32 7
-; ALL-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v64i8_8 = insertelement <64 x i8> poison, i8 poison, i32 8
+; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v64i8_8 = insertelement <64 x i8> poison, i8 poison, i32 8
 ; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v64i8_15 = insertelement <64 x i8> poison, i8 poison, i32 15
-; ALL-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v64i8_24 = insertelement <64 x i8> poison, i8 poison, i32 24
+; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v64i8_24 = insertelement <64 x i8> poison, i8 poison, i32 24
 ; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v64i8_31 = insertelement <64 x i8> poison, i8 poison, i32 31
-; ALL-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v64i8_32 = insertelement <64 x i8> poison, i8 poison, i32 32
-; ALL-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v64i8_48 = insertelement <64 x i8> poison, i8 poison, i32 48
+; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v64i8_32 = insertelement <64 x i8> poison, i8 poison, i32 32
+; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v64i8_48 = insertelement <64 x i8> poison, i8 poison, i32 48
 ; ALL-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v64i8_63 = insertelement <64 x i8> poison, i8 poison, i32 63
 ; ALL-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
@@ -607,31 +607,31 @@ define i32 @insert_i8_poison(i32 %arg) {
 ; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v2i8_0 = insertelement <2 x i8> poison, i8 poison, i32 0
 ; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v2i8_3 = insertelement <2 x i8> poison, i8 poison, i32 1
 ; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %v4i8_a = insertelement <4 x i8> poison, i8 poison, i32 %arg
-; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v4i8_0 = insertelement <4 x i8> poison, i8 poison, i32 0
+; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v4i8_0 = insertelement <4 x i8> poison, i8 poison, i32 0
 ; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v4i8_3 = insertelement <4 x i8> poison, i8 poison, i32 3
 ; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %v8i8_a = insertelement <8 x i8> poison, i8 poison, i32 %arg
-; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v8i8_0 = insertelement <8 x i8> poison, i8 poison, i32 0
+; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v8i8_0 = insertelement <8 x i8> poison, i8 poison, i32 0
 ; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v8i8_7 = insertelement <8 x i8> poison, i8 poison, i32 7
 ; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %v16i8_a = insertelement <16 x i8> poison, i8 poison, i32 %arg
-; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v16i8_0 = insertelement <16 x i8> poison, i8 poison, i32 0
-; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v16i8_8 = insertelement <16 x i8> poison, i8 poison, i32 8
+; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v16i8_0 = insertelement <16 x i8> poison, i8 poison, i32 0
+; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v16i8_8 = insertelement <16 x i8> poison, i8 poison, i32 8
 ; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v16i8_15 = insertelement <16 x i8> poison, i8 poison, i32 15
 ; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %v32i8_a = insertelement <32 x i8> poison, i8 poison, i32 %arg
-; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v32i8_0 = insertelement <32 x i8> poison, i8 poison, i32 0
+; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v32i8_0 = insertelement <32 x i8> poison, i8 poison, i32 0
 ; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v32i8_7 = insertelement <32 x i8> poison, i8 poison, i32 7
-; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v32i8_8 = insertelement <32 x i8> poison, i8 poison, i32 8
+; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v32i8_8 = insertelement <32 x i8> poison, i8 poison, i32 8
 ; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v32i8_15 = insertelement <32 x i8> poison, i8 poison, i32 15
-; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v32i8_24 = insertelement <32 x i8> poison, i8 poison, i32 24
+; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v32i8_24 = insertelement <32 x i8> poison, i8 poison, i32 24
 ; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v32i8_31 = insertelement <32 x i8> poison, i8 poison, i32 31
 ; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 2 for instruction: %v64i8_a = insertelement <64 x i8> poison, i8 poison, i32 %arg
-; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v64i8_0 = insertelement <64 x i8> poison, i8 poison, i32 0
+; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v64i8_0 = insertelement <64 x i8> poison, i8 poison, i32 0
 ; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v64i8_7 = insertelement <64 x i8> poison, i8 poison, i32 7
-; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v64i8_8 = insertelement <64 x i8> poison, i8 poison, i32 8
+; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v64i8_8 = insertelement <64 x i8> poison, i8 poison, i32 8
 ; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v64i8_15 = insertelement <64 x i8> poison, i8 poison, i32 15
-; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v64i8_24 = insertelement <64 x i8> poison, i8 poison, i32 24
+; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v64i8_24 = insertelement <64 x i8> poison, i8 poison, i32 24
 ; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v64i8_31 = insertelement <64 x i8> poison, i8 poison, i32 31
-; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v64i8_32 = insertelement <64 x i8> poison, i8 poison, i32 32
-; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 0 for instruction: %v64i8_48 = insertelement <64 x i8> poison, i8 poison, i32 48
+; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v64i8_32 = insertelement <64 x i8> poison, i8 poison, i32 32
+; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v64i8_48 = insertelement <64 x i8> poison, i8 poison, i32 48
 ; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: %v64i8_63 = insertelement <64 x i8> poison, i8 poison, i32 63
 ; ALL-SIZE-NEXT:  Cost Model: Found an estimated cost of 1 for instruction: ret i32 poison
 ;

--- a/llvm/test/Analysis/CostModel/AMDGPU/rem.ll
+++ b/llvm/test/Analysis/CostModel/AMDGPU/rem.ll
@@ -44,9 +44,9 @@ define i32 @srem() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V16i16 = srem <16 x i16> poison, poison
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 266 for instruction: %V32i16 = srem <32 x i16> poison, poison
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 6 for instruction: %I8 = srem i8 poison, poison
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 120 for instruction: %V16i8 = srem <16 x i8> poison, poison
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 240 for instruction: %V32i8 = srem <32 x i8> poison, poison
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 490 for instruction: %V64i8 = srem <64 x i8> poison, poison
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V16i8 = srem <16 x i8> poison, poison
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 224 for instruction: %V32i8 = srem <32 x i8> poison, poison
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 458 for instruction: %V64i8 = srem <64 x i8> poison, poison
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'srem'
@@ -125,9 +125,9 @@ define i32 @urem() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V16i16 = urem <16 x i16> poison, poison
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 266 for instruction: %V32i16 = urem <32 x i16> poison, poison
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 6 for instruction: %I8 = urem i8 poison, poison
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 120 for instruction: %V16i8 = urem <16 x i8> poison, poison
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 240 for instruction: %V32i8 = urem <32 x i8> poison, poison
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 490 for instruction: %V64i8 = urem <64 x i8> poison, poison
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V16i8 = urem <16 x i8> poison, poison
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 224 for instruction: %V32i8 = urem <32 x i8> poison, poison
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 458 for instruction: %V64i8 = urem <64 x i8> poison, poison
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'urem'
@@ -206,9 +206,9 @@ define i32 @srem_const() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V16i16 = srem <16 x i16> poison, <i16 4, i16 5, i16 6, i16 7, i16 8, i16 9, i16 10, i16 11, i16 12, i16 13, i16 14, i16 15, i16 16, i16 17, i16 18, i16 19>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 266 for instruction: %V32i16 = srem <32 x i16> poison, <i16 4, i16 5, i16 6, i16 7, i16 8, i16 9, i16 10, i16 11, i16 12, i16 13, i16 14, i16 15, i16 16, i16 17, i16 18, i16 19, i16 4, i16 5, i16 6, i16 7, i16 8, i16 9, i16 10, i16 11, i16 12, i16 13, i16 14, i16 15, i16 16, i16 17, i16 18, i16 19>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 6 for instruction: %I8 = srem i8 poison, 7
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 120 for instruction: %V16i8 = srem <16 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 240 for instruction: %V32i8 = srem <32 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 490 for instruction: %V64i8 = srem <64 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V16i8 = srem <16 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 224 for instruction: %V32i8 = srem <32 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 458 for instruction: %V64i8 = srem <64 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'srem_const'
@@ -287,9 +287,9 @@ define i32 @urem_const() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V16i16 = urem <16 x i16> poison, <i16 4, i16 5, i16 6, i16 7, i16 8, i16 9, i16 10, i16 11, i16 12, i16 13, i16 14, i16 15, i16 16, i16 17, i16 18, i16 19>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 266 for instruction: %V32i16 = urem <32 x i16> poison, <i16 4, i16 5, i16 6, i16 7, i16 8, i16 9, i16 10, i16 11, i16 12, i16 13, i16 14, i16 15, i16 16, i16 17, i16 18, i16 19, i16 4, i16 5, i16 6, i16 7, i16 8, i16 9, i16 10, i16 11, i16 12, i16 13, i16 14, i16 15, i16 16, i16 17, i16 18, i16 19>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 6 for instruction: %I8 = urem i8 poison, 7
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 120 for instruction: %V16i8 = urem <16 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 240 for instruction: %V32i8 = urem <32 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 490 for instruction: %V64i8 = urem <64 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V16i8 = urem <16 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 224 for instruction: %V32i8 = urem <32 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 458 for instruction: %V64i8 = urem <64 x i8> poison, <i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19, i8 4, i8 5, i8 6, i8 7, i8 8, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 15, i8 16, i8 17, i8 18, i8 19>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'urem_const'
@@ -368,9 +368,9 @@ define i32 @srem_uniformconst() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V16i16 = srem <16 x i16> poison, splat (i16 7)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 266 for instruction: %V32i16 = srem <32 x i16> poison, splat (i16 7)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 6 for instruction: %I8 = srem i8 poison, 7
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 120 for instruction: %V16i8 = srem <16 x i8> poison, splat (i8 7)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 240 for instruction: %V32i8 = srem <32 x i8> poison, splat (i8 7)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 490 for instruction: %V64i8 = srem <64 x i8> poison, splat (i8 7)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V16i8 = srem <16 x i8> poison, splat (i8 7)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 224 for instruction: %V32i8 = srem <32 x i8> poison, splat (i8 7)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 458 for instruction: %V64i8 = srem <64 x i8> poison, splat (i8 7)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'srem_uniformconst'
@@ -449,9 +449,9 @@ define i32 @urem_uniformconst() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V16i16 = urem <16 x i16> poison, splat (i16 7)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 266 for instruction: %V32i16 = urem <32 x i16> poison, splat (i16 7)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 6 for instruction: %I8 = urem i8 poison, 7
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 120 for instruction: %V16i8 = urem <16 x i8> poison, splat (i8 7)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 240 for instruction: %V32i8 = urem <32 x i8> poison, splat (i8 7)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 490 for instruction: %V64i8 = urem <64 x i8> poison, splat (i8 7)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V16i8 = urem <16 x i8> poison, splat (i8 7)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 224 for instruction: %V32i8 = urem <32 x i8> poison, splat (i8 7)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 458 for instruction: %V64i8 = urem <64 x i8> poison, splat (i8 7)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'urem_uniformconst'
@@ -530,9 +530,9 @@ define i32 @srem_constpow2() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V16i16 = srem <16 x i16> poison, <i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256, i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 266 for instruction: %V32i16 = srem <32 x i16> poison, <i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256, i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256, i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256, i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 6 for instruction: %I8 = srem i8 poison, 16
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 120 for instruction: %V16i8 = srem <16 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 240 for instruction: %V32i8 = srem <32 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 490 for instruction: %V64i8 = srem <64 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V16i8 = srem <16 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 224 for instruction: %V32i8 = srem <32 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 458 for instruction: %V64i8 = srem <64 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'srem_constpow2'
@@ -611,9 +611,9 @@ define i32 @urem_constpow2() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V16i16 = urem <16 x i16> poison, <i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256, i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 266 for instruction: %V32i16 = urem <32 x i16> poison, <i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256, i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256, i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256, i16 2, i16 4, i16 8, i16 16, i16 32, i16 64, i16 128, i16 256>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 6 for instruction: %I8 = urem i8 poison, 16
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 120 for instruction: %V16i8 = urem <16 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 240 for instruction: %V32i8 = urem <32 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 490 for instruction: %V64i8 = urem <64 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V16i8 = urem <16 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 224 for instruction: %V32i8 = urem <32 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 458 for instruction: %V64i8 = urem <64 x i8> poison, <i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16, i8 2, i8 4, i8 8, i8 16>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'urem_constpow2'
@@ -692,9 +692,9 @@ define i32 @srem_uniformconstpow2() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V16i16 = srem <16 x i16> poison, splat (i16 16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 266 for instruction: %V32i16 = srem <32 x i16> poison, splat (i16 16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 6 for instruction: %I8 = srem i8 poison, 16
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 120 for instruction: %V16i8 = srem <16 x i8> poison, splat (i8 16)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 240 for instruction: %V32i8 = srem <32 x i8> poison, splat (i8 16)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 490 for instruction: %V64i8 = srem <64 x i8> poison, splat (i8 16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V16i8 = srem <16 x i8> poison, splat (i8 16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 224 for instruction: %V32i8 = srem <32 x i8> poison, splat (i8 16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 458 for instruction: %V64i8 = srem <64 x i8> poison, splat (i8 16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'srem_uniformconstpow2'
@@ -773,9 +773,9 @@ define i32 @urem_uniformconstpow2() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V16i16 = urem <16 x i16> poison, splat (i16 16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 266 for instruction: %V32i16 = urem <32 x i16> poison, splat (i16 16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 6 for instruction: %I8 = urem i8 poison, 16
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 120 for instruction: %V16i8 = urem <16 x i8> poison, splat (i8 16)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 240 for instruction: %V32i8 = urem <32 x i8> poison, splat (i8 16)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 490 for instruction: %V64i8 = urem <64 x i8> poison, splat (i8 16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V16i8 = urem <16 x i8> poison, splat (i8 16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 224 for instruction: %V32i8 = urem <32 x i8> poison, splat (i8 16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 458 for instruction: %V64i8 = urem <64 x i8> poison, splat (i8 16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'urem_uniformconstpow2'
@@ -854,9 +854,9 @@ define i32 @srem_constnegpow2() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V16i16 = srem <16 x i16> poison, <i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256, i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 266 for instruction: %V32i16 = srem <32 x i16> poison, <i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256, i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256, i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256, i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 6 for instruction: %I8 = srem i8 poison, -16
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 120 for instruction: %V16i8 = srem <16 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 240 for instruction: %V32i8 = srem <32 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 490 for instruction: %V64i8 = srem <64 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V16i8 = srem <16 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 224 for instruction: %V32i8 = srem <32 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 458 for instruction: %V64i8 = srem <64 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'srem_constnegpow2'
@@ -935,9 +935,9 @@ define i32 @urem_constnegpow2() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V16i16 = urem <16 x i16> poison, <i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256, i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 266 for instruction: %V32i16 = urem <32 x i16> poison, <i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256, i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256, i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256, i16 -2, i16 -4, i16 -8, i16 -16, i16 -32, i16 -64, i16 -128, i16 -256>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 6 for instruction: %I8 = urem i8 poison, -16
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 120 for instruction: %V16i8 = urem <16 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 240 for instruction: %V32i8 = urem <32 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 490 for instruction: %V64i8 = urem <64 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V16i8 = urem <16 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 224 for instruction: %V32i8 = urem <32 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 458 for instruction: %V64i8 = urem <64 x i8> poison, <i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16, i8 -2, i8 -4, i8 -8, i8 -16>
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'urem_constnegpow2'
@@ -1016,9 +1016,9 @@ define i32 @srem_uniformconstnegpow2() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V16i16 = srem <16 x i16> poison, splat (i16 -16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 266 for instruction: %V32i16 = srem <32 x i16> poison, splat (i16 -16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 6 for instruction: %I8 = srem i8 poison, -16
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 120 for instruction: %V16i8 = srem <16 x i8> poison, splat (i8 -16)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 240 for instruction: %V32i8 = srem <32 x i8> poison, splat (i8 -16)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 490 for instruction: %V64i8 = srem <64 x i8> poison, splat (i8 -16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V16i8 = srem <16 x i8> poison, splat (i8 -16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 224 for instruction: %V32i8 = srem <32 x i8> poison, splat (i8 -16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 458 for instruction: %V64i8 = srem <64 x i8> poison, splat (i8 -16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'srem_uniformconstnegpow2'
@@ -1097,9 +1097,9 @@ define i32 @urem_uniformconstnegpow2() {
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 128 for instruction: %V16i16 = urem <16 x i16> poison, splat (i16 -16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 266 for instruction: %V32i16 = urem <32 x i16> poison, splat (i16 -16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 6 for instruction: %I8 = urem i8 poison, -16
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 120 for instruction: %V16i8 = urem <16 x i8> poison, splat (i8 -16)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 240 for instruction: %V32i8 = urem <32 x i8> poison, splat (i8 -16)
-; SLOW-NEXT:  Cost Model: Found an estimated cost of 490 for instruction: %V64i8 = urem <64 x i8> poison, splat (i8 -16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 112 for instruction: %V16i8 = urem <16 x i8> poison, splat (i8 -16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 224 for instruction: %V32i8 = urem <32 x i8> poison, splat (i8 -16)
+; SLOW-NEXT:  Cost Model: Found an estimated cost of 458 for instruction: %V64i8 = urem <64 x i8> poison, splat (i8 -16)
 ; SLOW-NEXT:  Cost Model: Found an estimated cost of 10 for instruction: ret i32 poison
 ;
 ; ALL-SIZE-LABEL: 'urem_uniformconstnegpow2'

--- a/llvm/test/Transforms/SLPVectorizer/AMDGPU/vectorize-i8.ll
+++ b/llvm/test/Transforms/SLPVectorizer/AMDGPU/vectorize-i8.ll
@@ -73,30 +73,28 @@ define protected amdgpu_kernel void @arith_3(<16 x i8> %invec, ptr %out, i32 %fl
 ; GFX8-LABEL: define protected amdgpu_kernel void @arith_3(
 ; GFX8-SAME: <16 x i8> [[INVEC:%.*]], ptr [[OUT:%.*]], i32 [[FLAG:%.*]]) #[[ATTR0]] {
 ; GFX8-NEXT:  [[ENTRY:.*:]]
-; GFX8-NEXT:    [[EL0:%.*]] = extractelement <16 x i8> [[INVEC]], i64 0
+; GFX8-NEXT:    [[EL0:%.*]] = extractelement <16 x i8> [[INVEC]], i64 2
 ; GFX8-NEXT:    [[MUL2:%.*]] = mul i8 [[EL0]], 1
-; GFX8-NEXT:    [[ADD2:%.*]] = add i8 [[MUL2]], 1
-; GFX8-NEXT:    [[TMP0:%.*]] = shufflevector <16 x i8> [[INVEC]], <16 x i8> poison, <2 x i32> <i32 1, i32 2>
+; GFX8-NEXT:    [[TMP0:%.*]] = shufflevector <16 x i8> [[INVEC]], <16 x i8> poison, <2 x i32> <i32 0, i32 1>
 ; GFX8-NEXT:    [[TMP1:%.*]] = mul <2 x i8> [[TMP0]], splat (i8 1)
 ; GFX8-NEXT:    [[TMP2:%.*]] = add <2 x i8> [[TMP1]], splat (i8 1)
-; GFX8-NEXT:    [[VECINS0:%.*]] = insertelement <16 x i8> poison, i8 [[ADD2]], i64 0
+; GFX8-NEXT:    [[ADD2:%.*]] = add i8 [[MUL2]], 1
 ; GFX8-NEXT:    [[TMP3:%.*]] = shufflevector <2 x i8> [[TMP2]], <2 x i8> poison, <16 x i32> <i32 0, i32 1, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-; GFX8-NEXT:    [[VECINS2:%.*]] = shufflevector <16 x i8> [[VECINS0]], <16 x i8> [[TMP3]], <16 x i32> <i32 0, i32 16, i32 17, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+; GFX8-NEXT:    [[VECINS2:%.*]] = insertelement <16 x i8> [[TMP3]], i8 [[ADD2]], i64 2
 ; GFX8-NEXT:    store <16 x i8> [[VECINS2]], ptr [[OUT]], align 16
 ; GFX8-NEXT:    ret void
 ;
 ; GFX9-LABEL: define protected amdgpu_kernel void @arith_3(
 ; GFX9-SAME: <16 x i8> [[INVEC:%.*]], ptr [[OUT:%.*]], i32 [[FLAG:%.*]]) #[[ATTR0]] {
 ; GFX9-NEXT:  [[ENTRY:.*:]]
-; GFX9-NEXT:    [[EL0:%.*]] = extractelement <16 x i8> [[INVEC]], i64 0
+; GFX9-NEXT:    [[EL0:%.*]] = extractelement <16 x i8> [[INVEC]], i64 2
 ; GFX9-NEXT:    [[MUL2:%.*]] = mul i8 [[EL0]], 1
-; GFX9-NEXT:    [[ADD2:%.*]] = add i8 [[MUL2]], 1
-; GFX9-NEXT:    [[TMP0:%.*]] = shufflevector <16 x i8> [[INVEC]], <16 x i8> poison, <2 x i32> <i32 1, i32 2>
+; GFX9-NEXT:    [[TMP0:%.*]] = shufflevector <16 x i8> [[INVEC]], <16 x i8> poison, <2 x i32> <i32 0, i32 1>
 ; GFX9-NEXT:    [[TMP1:%.*]] = mul <2 x i8> [[TMP0]], splat (i8 1)
 ; GFX9-NEXT:    [[TMP2:%.*]] = add <2 x i8> [[TMP1]], splat (i8 1)
-; GFX9-NEXT:    [[VECINS0:%.*]] = insertelement <16 x i8> poison, i8 [[ADD2]], i64 0
+; GFX9-NEXT:    [[ADD2:%.*]] = add i8 [[MUL2]], 1
 ; GFX9-NEXT:    [[TMP3:%.*]] = shufflevector <2 x i8> [[TMP2]], <2 x i8> poison, <16 x i32> <i32 0, i32 1, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-; GFX9-NEXT:    [[VECINS2:%.*]] = shufflevector <16 x i8> [[VECINS0]], <16 x i8> [[TMP3]], <16 x i32> <i32 0, i32 16, i32 17, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+; GFX9-NEXT:    [[VECINS2:%.*]] = insertelement <16 x i8> [[TMP3]], i8 [[ADD2]], i64 2
 ; GFX9-NEXT:    store <16 x i8> [[VECINS2]], ptr [[OUT]], align 16
 ; GFX9-NEXT:    ret void
 ;

--- a/llvm/test/Transforms/VectorCombine/AMDGPU/extract-insert-chain-to-shuffles.ll
+++ b/llvm/test/Transforms/VectorCombine/AMDGPU/extract-insert-chain-to-shuffles.ll
@@ -8,16 +8,7 @@ define amdgpu_kernel void @extract_insert_chain_to_shuffles(<16 x i8> %in, <16 x
 ; OPT-LABEL: define amdgpu_kernel void @extract_insert_chain_to_shuffles(
 ; OPT-SAME: <16 x i8> [[IN:%.*]], <16 x i8> [[ADD:%.*]], ptr addrspace(3) [[OUT:%.*]]) #[[ATTR0:[0-9]+]] {
 ; OPT-NEXT:  [[ENTRY:.*:]]
-; OPT-NEXT:    [[I168:%.*]] = extractelement <16 x i8> [[IN]], i64 4
-; OPT-NEXT:    [[I176:%.*]] = extractelement <16 x i8> [[IN]], i64 8
-; OPT-NEXT:    [[I184:%.*]] = extractelement <16 x i8> [[IN]], i64 12
-; OPT-NEXT:    [[I260:%.*]] = insertelement <16 x i8> [[IN]], i8 [[I168]], i64 4
-; OPT-NEXT:    [[I263:%.*]] = shufflevector <16 x i8> [[I260]], <16 x i8> [[IN]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 21, i32 22, i32 23, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-; OPT-NEXT:    [[I264:%.*]] = insertelement <16 x i8> [[I263]], i8 [[I176]], i64 8
-; OPT-NEXT:    [[I267:%.*]] = shufflevector <16 x i8> [[I264]], <16 x i8> [[IN]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 25, i32 26, i32 27, i32 12, i32 13, i32 14, i32 15>
-; OPT-NEXT:    [[I268:%.*]] = insertelement <16 x i8> [[I267]], i8 [[I184]], i64 12
-; OPT-NEXT:    [[I271:%.*]] = shufflevector <16 x i8> [[I268]], <16 x i8> [[IN]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 29, i32 30, i32 31>
-; OPT-NEXT:    [[SUM:%.*]] = add <16 x i8> [[I271]], [[ADD]]
+; OPT-NEXT:    [[SUM:%.*]] = add <16 x i8> [[IN]], [[ADD]]
 ; OPT-NEXT:    store <16 x i8> [[SUM]], ptr addrspace(3) [[OUT]], align 16
 ; OPT-NEXT:    ret void
 ;

--- a/llvm/test/Transforms/VectorCombine/AMDGPU/extract-insert-i8.ll
+++ b/llvm/test/Transforms/VectorCombine/AMDGPU/extract-insert-i8.ll
@@ -5,38 +5,11 @@ define <32 x i8> @extract_insert_chain(<8 x i8> %in0, <8 x i8> %in1, <8 x i8> %i
 ; OPT-LABEL: define <32 x i8> @extract_insert_chain(
 ; OPT-SAME: <8 x i8> [[IN0:%.*]], <8 x i8> [[IN1:%.*]], <8 x i8> [[IN2:%.*]], <8 x i8> [[IN3:%.*]]) #[[ATTR0:[0-9]+]] {
 ; OPT-NEXT:  [[ENTRY:.*:]]
-; OPT-NEXT:    [[I_0_0:%.*]] = extractelement <8 x i8> [[IN0]], i64 0
-; OPT-NEXT:    [[I_0_4:%.*]] = extractelement <8 x i8> [[IN0]], i64 4
-; OPT-NEXT:    [[I_1_0:%.*]] = extractelement <8 x i8> [[IN1]], i64 0
-; OPT-NEXT:    [[I_1_4:%.*]] = extractelement <8 x i8> [[IN1]], i64 4
-; OPT-NEXT:    [[I_2_0:%.*]] = extractelement <8 x i8> [[IN2]], i64 0
-; OPT-NEXT:    [[I_2_4:%.*]] = extractelement <8 x i8> [[IN2]], i64 4
-; OPT-NEXT:    [[I_3_0:%.*]] = extractelement <8 x i8> [[IN3]], i64 0
-; OPT-NEXT:    [[I_3_4:%.*]] = extractelement <8 x i8> [[IN3]], i64 4
-; OPT-NEXT:    [[O_0_0:%.*]] = insertelement <32 x i8> poison, i8 [[I_0_0]], i32 0
-; OPT-NEXT:    [[TMP0:%.*]] = shufflevector <8 x i8> [[IN0]], <8 x i8> poison, <32 x i32> <i32 poison, i32 1, i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-; OPT-NEXT:    [[O_0_3:%.*]] = shufflevector <32 x i8> [[O_0_0]], <32 x i8> [[TMP0]], <32 x i32> <i32 0, i32 33, i32 34, i32 35, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-; OPT-NEXT:    [[O_0_4:%.*]] = insertelement <32 x i8> [[O_0_3]], i8 [[I_0_4]], i32 4
-; OPT-NEXT:    [[TMP1:%.*]] = shufflevector <8 x i8> [[IN0]], <8 x i8> poison, <32 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-; OPT-NEXT:    [[O_0_7:%.*]] = shufflevector <32 x i8> [[O_0_4]], <32 x i8> [[TMP1]], <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 37, i32 38, i32 39, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-; OPT-NEXT:    [[O_1_0:%.*]] = insertelement <32 x i8> [[O_0_7]], i8 [[I_1_0]], i32 8
-; OPT-NEXT:    [[TMP2:%.*]] = shufflevector <8 x i8> [[IN1]], <8 x i8> poison, <32 x i32> <i32 poison, i32 1, i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-; OPT-NEXT:    [[O_1_3:%.*]] = shufflevector <32 x i8> [[O_1_0]], <32 x i8> [[TMP2]], <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 33, i32 34, i32 35, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-; OPT-NEXT:    [[O_1_4:%.*]] = insertelement <32 x i8> [[O_1_3]], i8 [[I_1_4]], i32 12
-; OPT-NEXT:    [[TMP3:%.*]] = shufflevector <8 x i8> [[IN1]], <8 x i8> poison, <32 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-; OPT-NEXT:    [[O_1_7:%.*]] = shufflevector <32 x i8> [[O_1_4]], <32 x i8> [[TMP3]], <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 37, i32 38, i32 39, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-; OPT-NEXT:    [[O_2_0:%.*]] = insertelement <32 x i8> [[O_1_7]], i8 [[I_2_0]], i32 16
-; OPT-NEXT:    [[TMP4:%.*]] = shufflevector <8 x i8> [[IN2]], <8 x i8> poison, <32 x i32> <i32 poison, i32 1, i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-; OPT-NEXT:    [[O_2_3:%.*]] = shufflevector <32 x i8> [[O_2_0]], <32 x i8> [[TMP4]], <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 33, i32 34, i32 35, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-; OPT-NEXT:    [[O_2_4:%.*]] = insertelement <32 x i8> [[O_2_3]], i8 [[I_2_4]], i32 20
-; OPT-NEXT:    [[TMP5:%.*]] = shufflevector <8 x i8> [[IN2]], <8 x i8> poison, <32 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-; OPT-NEXT:    [[O_2_7:%.*]] = shufflevector <32 x i8> [[O_2_4]], <32 x i8> [[TMP5]], <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 37, i32 38, i32 39, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-; OPT-NEXT:    [[O_3_0:%.*]] = insertelement <32 x i8> [[O_2_7]], i8 [[I_3_0]], i32 24
-; OPT-NEXT:    [[TMP6:%.*]] = shufflevector <8 x i8> [[IN3]], <8 x i8> poison, <32 x i32> <i32 poison, i32 1, i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-; OPT-NEXT:    [[O_3_3:%.*]] = shufflevector <32 x i8> [[O_3_0]], <32 x i8> [[TMP6]], <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 33, i32 34, i32 35, i32 28, i32 29, i32 30, i32 31>
-; OPT-NEXT:    [[O_3_4:%.*]] = insertelement <32 x i8> [[O_3_3]], i8 [[I_3_4]], i32 28
-; OPT-NEXT:    [[TMP7:%.*]] = shufflevector <8 x i8> [[IN3]], <8 x i8> poison, <32 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-; OPT-NEXT:    [[O_3_7:%.*]] = shufflevector <32 x i8> [[O_3_4]], <32 x i8> [[TMP7]], <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 37, i32 38, i32 39>
+; OPT-NEXT:    [[O_1_7:%.*]] = shufflevector <8 x i8> [[IN0]], <8 x i8> [[IN1]], <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+; OPT-NEXT:    [[TMP0:%.*]] = shufflevector <8 x i8> [[IN2]], <8 x i8> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+; OPT-NEXT:    [[O_2_7:%.*]] = shufflevector <32 x i8> [[O_1_7]], <32 x i8> [[TMP0]], <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+; OPT-NEXT:    [[TMP1:%.*]] = shufflevector <8 x i8> [[IN3]], <8 x i8> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+; OPT-NEXT:    [[O_3_7:%.*]] = shufflevector <32 x i8> [[O_2_7]], <32 x i8> [[TMP1]], <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39>
 ; OPT-NEXT:    ret <32 x i8> [[O_3_7]]
 ;
 entry:
@@ -115,14 +88,7 @@ entry:
 define <8 x i8> @extract_insert_chain_shortening(<32 x i8> %in) {
 ; OPT-LABEL: define <8 x i8> @extract_insert_chain_shortening(
 ; OPT-SAME: <32 x i8> [[IN:%.*]]) #[[ATTR0]] {
-; OPT-NEXT:    [[I_0:%.*]] = extractelement <32 x i8> [[IN]], i64 16
-; OPT-NEXT:    [[I_4:%.*]] = extractelement <32 x i8> [[IN]], i64 20
-; OPT-NEXT:    [[O_0:%.*]] = insertelement <8 x i8> poison, i8 [[I_0]], i32 0
-; OPT-NEXT:    [[TMP3:%.*]] = shufflevector <32 x i8> [[IN]], <32 x i8> poison, <8 x i32> <i32 poison, i32 17, i32 18, i32 19, i32 poison, i32 poison, i32 poison, i32 poison>
-; OPT-NEXT:    [[O_3:%.*]] = shufflevector <8 x i8> [[O_0]], <8 x i8> [[TMP3]], <8 x i32> <i32 0, i32 9, i32 10, i32 11, i32 4, i32 5, i32 6, i32 7>
-; OPT-NEXT:    [[O_4:%.*]] = insertelement <8 x i8> [[O_3]], i8 [[I_4]], i32 4
-; OPT-NEXT:    [[TMP2:%.*]] = shufflevector <32 x i8> [[IN]], <32 x i8> poison, <8 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 21, i32 22, i32 23>
-; OPT-NEXT:    [[TMP1:%.*]] = shufflevector <8 x i8> [[O_4]], <8 x i8> [[TMP2]], <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 13, i32 14, i32 15>
+; OPT-NEXT:    [[TMP1:%.*]] = shufflevector <32 x i8> [[IN]], <32 x i8> poison, <8 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23>
 ; OPT-NEXT:    ret <8 x i8> [[TMP1]]
 ;
   %i.0 = extractelement <32 x i8> %in, i64 16

--- a/llvm/test/Transforms/VectorCombine/AMDGPU/no-scalarize-vector-extract.ll
+++ b/llvm/test/Transforms/VectorCombine/AMDGPU/no-scalarize-vector-extract.ll
@@ -65,12 +65,10 @@ define void @test_v16i8_load_with_extracts_no_scalarize(ptr addrspace(1) %out) {
 define void @test_v16i8_load_with_extracts_scalarize(ptr addrspace(1) %out) {
 ; GFX9-LABEL: @test_v16i8_load_with_extracts_scalarize(
 ; GFX9-NEXT:    [[PTR:%.*]] = getelementptr inbounds i8, ptr addrspace(3) @lds, i32 0
-; GFX9-NEXT:    [[TMP1:%.*]] = getelementptr inbounds <16 x i8>, ptr addrspace(3) [[PTR]], i32 0, i64 1
-; GFX9-NEXT:    [[E1:%.*]] = load i8, ptr addrspace(3) [[TMP1]], align 1
-; GFX9-NEXT:    [[TMP2:%.*]] = getelementptr inbounds <16 x i8>, ptr addrspace(3) [[PTR]], i32 0, i64 3
-; GFX9-NEXT:    [[E3:%.*]] = load i8, ptr addrspace(3) [[TMP2]], align 1
-; GFX9-NEXT:    [[TMP3:%.*]] = getelementptr inbounds <16 x i8>, ptr addrspace(3) [[PTR]], i32 0, i64 5
-; GFX9-NEXT:    [[E5:%.*]] = load i8, ptr addrspace(3) [[TMP3]], align 1
+; GFX9-NEXT:    [[VAL:%.*]] = load <16 x i8>, ptr addrspace(3) [[PTR]], align 16
+; GFX9-NEXT:    [[E1:%.*]] = extractelement <16 x i8> [[VAL]], i64 1
+; GFX9-NEXT:    [[E3:%.*]] = extractelement <16 x i8> [[VAL]], i64 3
+; GFX9-NEXT:    [[E5:%.*]] = extractelement <16 x i8> [[VAL]], i64 5
 ; GFX9-NEXT:    [[P4:%.*]] = getelementptr inbounds i8, ptr addrspace(1) [[OUT:%.*]], i64 3
 ; GFX9-NEXT:    store i8 [[E1]], ptr addrspace(1) [[P4]], align 1
 ; GFX9-NEXT:    [[P8:%.*]] = getelementptr inbounds i8, ptr addrspace(1) [[OUT]], i64 8
@@ -81,12 +79,10 @@ define void @test_v16i8_load_with_extracts_scalarize(ptr addrspace(1) %out) {
 ;
 ; GFX12-LABEL: @test_v16i8_load_with_extracts_scalarize(
 ; GFX12-NEXT:    [[PTR:%.*]] = getelementptr inbounds i8, ptr addrspace(3) @lds, i32 0
-; GFX12-NEXT:    [[TMP1:%.*]] = getelementptr inbounds <16 x i8>, ptr addrspace(3) [[PTR]], i32 0, i64 1
-; GFX12-NEXT:    [[E1:%.*]] = load i8, ptr addrspace(3) [[TMP1]], align 1
-; GFX12-NEXT:    [[TMP2:%.*]] = getelementptr inbounds <16 x i8>, ptr addrspace(3) [[PTR]], i32 0, i64 3
-; GFX12-NEXT:    [[E3:%.*]] = load i8, ptr addrspace(3) [[TMP2]], align 1
-; GFX12-NEXT:    [[TMP3:%.*]] = getelementptr inbounds <16 x i8>, ptr addrspace(3) [[PTR]], i32 0, i64 5
-; GFX12-NEXT:    [[E5:%.*]] = load i8, ptr addrspace(3) [[TMP3]], align 1
+; GFX12-NEXT:    [[VAL:%.*]] = load <16 x i8>, ptr addrspace(3) [[PTR]], align 16
+; GFX12-NEXT:    [[E1:%.*]] = extractelement <16 x i8> [[VAL]], i64 1
+; GFX12-NEXT:    [[E3:%.*]] = extractelement <16 x i8> [[VAL]], i64 3
+; GFX12-NEXT:    [[E5:%.*]] = extractelement <16 x i8> [[VAL]], i64 5
 ; GFX12-NEXT:    [[P4:%.*]] = getelementptr inbounds i8, ptr addrspace(1) [[OUT:%.*]], i64 3
 ; GFX12-NEXT:    store i8 [[E1]], ptr addrspace(1) [[P4]], align 1
 ; GFX12-NEXT:    [[P8:%.*]] = getelementptr inbounds i8, ptr addrspace(1) [[OUT]], i64 8
@@ -218,10 +214,9 @@ define void @test_v8i8_load_with_extracts_no_scalarize(ptr addrspace(1) %out) {
 define void @test_v4i8_load_with_extracts_no_scalarize(ptr addrspace(1) %out) {
 ; GFX9-LABEL: @test_v4i8_load_with_extracts_no_scalarize(
 ; GFX9-NEXT:    [[PTR:%.*]] = getelementptr inbounds i8, ptr addrspace(3) @lds, i32 0
-; GFX9-NEXT:    [[TMP1:%.*]] = getelementptr inbounds <4 x i8>, ptr addrspace(3) [[PTR]], i32 0, i64 1
-; GFX9-NEXT:    [[E0:%.*]] = load i8, ptr addrspace(3) [[TMP1]], align 1
-; GFX9-NEXT:    [[TMP2:%.*]] = getelementptr inbounds <4 x i8>, ptr addrspace(3) [[PTR]], i32 0, i64 3
-; GFX9-NEXT:    [[E3:%.*]] = load i8, ptr addrspace(3) [[TMP2]], align 1
+; GFX9-NEXT:    [[VAL:%.*]] = load <4 x i8>, ptr addrspace(3) [[PTR]], align 16
+; GFX9-NEXT:    [[E0:%.*]] = extractelement <4 x i8> [[VAL]], i64 1
+; GFX9-NEXT:    [[E3:%.*]] = extractelement <4 x i8> [[VAL]], i64 3
 ; GFX9-NEXT:    [[P0:%.*]] = getelementptr inbounds i8, ptr addrspace(1) [[OUT:%.*]], i64 0
 ; GFX9-NEXT:    store i8 [[E0]], ptr addrspace(1) [[P0]], align 1
 ; GFX9-NEXT:    [[P4:%.*]] = getelementptr inbounds i8, ptr addrspace(1) [[OUT]], i64 2
@@ -230,10 +225,9 @@ define void @test_v4i8_load_with_extracts_no_scalarize(ptr addrspace(1) %out) {
 ;
 ; GFX12-LABEL: @test_v4i8_load_with_extracts_no_scalarize(
 ; GFX12-NEXT:    [[PTR:%.*]] = getelementptr inbounds i8, ptr addrspace(3) @lds, i32 0
-; GFX12-NEXT:    [[TMP1:%.*]] = getelementptr inbounds <4 x i8>, ptr addrspace(3) [[PTR]], i32 0, i64 1
-; GFX12-NEXT:    [[E0:%.*]] = load i8, ptr addrspace(3) [[TMP1]], align 1
-; GFX12-NEXT:    [[TMP2:%.*]] = getelementptr inbounds <4 x i8>, ptr addrspace(3) [[PTR]], i32 0, i64 3
-; GFX12-NEXT:    [[E3:%.*]] = load i8, ptr addrspace(3) [[TMP2]], align 1
+; GFX12-NEXT:    [[VAL:%.*]] = load <4 x i8>, ptr addrspace(3) [[PTR]], align 16
+; GFX12-NEXT:    [[E0:%.*]] = extractelement <4 x i8> [[VAL]], i64 1
+; GFX12-NEXT:    [[E3:%.*]] = extractelement <4 x i8> [[VAL]], i64 3
 ; GFX12-NEXT:    [[P0:%.*]] = getelementptr inbounds i8, ptr addrspace(1) [[OUT:%.*]], i64 0
 ; GFX12-NEXT:    store i8 [[E0]], ptr addrspace(1) [[P0]], align 1
 ; GFX12-NEXT:    [[P4:%.*]] = getelementptr inbounds i8, ptr addrspace(1) [[OUT]], i64 2


### PR DESCRIPTION
Expand the cases when i8 extract elements are free. The extract elements should be free when they are part of a sequence that extract multiple consecutive elements the size of a register. This change enables the SLPVectorizer to keep extract elements over more costly shufflevectors.

This PR also undoes a previous change that made insert element free, but those require sequences of shift/or instructions so shouldn't be free.