### PR TITLE
[AMDGPU] Add AMDGPUAlignVALURuns pass to fix gfx9 instruction fetch stalls

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPU.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.h
@@ -238,6 +238,9 @@ extern char &SILowerControlFlowLegacyID;
 void initializeSIPreEmitPeepholeLegacyPass(PassRegistry &);
 extern char &SIPreEmitPeepholeID;
 
+void initializeAMDGPUAlignVALURunsLegacyPass(PassRegistry &);
+extern char &AMDGPUAlignVALURunsLegacyID;
+
 void initializeSILateBranchLoweringLegacyPass(PassRegistry &);
 extern char &SILateBranchLoweringPassID;
 
@@ -462,6 +465,13 @@ public:
 
 class SIPreEmitPeepholePass
     : public RequiredPassInfoMixin<SIPreEmitPeepholePass> {
+public:
+  PreservedAnalyses run(MachineFunction &MF,
+                        MachineFunctionAnalysisManager &MFAM);
+};
+
+class AMDGPUAlignVALURunsPass
+    : public OptionalPassInfoMixin<AMDGPUAlignVALURunsPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);

--- a/llvm/lib/Target/AMDGPU/AMDGPUAlignVALURuns.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAlignVALURuns.cpp
@@ -1,0 +1,206 @@
+//===-- AMDGPUAlignVALURuns.cpp ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+/// \file
+/// On gfx9, the instruction fetch unit delivers 32-byte aligned windows into a
+/// per-wave instruction buffer (IB). When a contiguous run of 8-byte VALU
+/// instructions starts at an odd-dword (4-byte-misaligned) boundary, every 4th
+/// instruction straddles a fetch-window boundary, stalling the wave for ~1 quad
+/// (4 cycles) each time.
+///
+/// This pass detects such runs in loops and inserts a single `s_nop 0` (4
+/// bytes) before the run to shift it to an even-dword boundary, eliminating all
+/// straddle stalls.
+///
+/// Runs after BranchRelaxation so that byte offsets are final.
+//
+//===----------------------------------------------------------------------===//
+
+#include "AMDGPU.h"
+#include "GCNSubtarget.h"
+#include "SIInstrInfo.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineLoopInfo.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/Support/CommandLine.h"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "amdgpu-align-valu-runs"
+
+static cl::opt<unsigned> AlignThreshold(
+    "amdgpu-valu-run-align-threshold",
+    cl::desc("Minimum run length (in instructions) to trigger alignment"),
+    cl::init(8), cl::Hidden);
+
+static cl::opt<bool>
+    DisableAlignVALURuns("amdgpu-disable-valu-run-align",
+                         cl::desc("Disable the VALU run alignment pass"),
+                         cl::init(false), cl::Hidden);
+
+namespace {
+
+class AMDGPUAlignVALURuns {
+  const SIInstrInfo *TII = nullptr;
+
+  bool isQualifyingVALU(const MachineInstr &MI) const {
+    if (MI.isMetaInstruction() || MI.isDebugInstr())
+      return false;
+    if (!SIInstrInfo::isVALU(MI))
+      return false;
+    if (SIInstrInfo::isMFMA(MI))
+      return false;
+    return TII->getInstSizeInBytes(MI) == 8;
+  }
+
+  bool isRunBreaker(const MachineInstr &MI, bool PrevWasVALU) const {
+    if (MI.isMetaInstruction() || MI.isDebugInstr())
+      return false;
+
+    unsigned Opc = MI.getOpcode();
+    if (SIInstrInfo::isWaitcnt(Opc))
+      return true;
+
+    if (SIInstrInfo::isMFMA(MI))
+      return true;
+
+    if (PrevWasVALU && (SIInstrInfo::isVMEM(MI) || SIInstrInfo::isSMRD(MI) ||
+                        SIInstrInfo::isDS(MI) || SIInstrInfo::isFLAT(MI)))
+      return true;
+
+    return false;
+  }
+
+public:
+  bool run(MachineFunction &MF, MachineLoopInfo *MLI);
+};
+
+class AMDGPUAlignVALURunsLegacy : public MachineFunctionPass {
+public:
+  static char ID;
+
+  AMDGPUAlignVALURunsLegacy() : MachineFunctionPass(ID) {}
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.addRequired<MachineLoopInfoWrapperPass>();
+    AU.addPreserved<MachineLoopInfoWrapperPass>();
+    MachineFunctionPass::getAnalysisUsage(AU);
+  }
+
+  bool runOnMachineFunction(MachineFunction &MF) override {
+    MachineLoopInfo &MLI = getAnalysis<MachineLoopInfoWrapperPass>().getLI();
+    return AMDGPUAlignVALURuns().run(MF, &MLI);
+  }
+};
+
+} // end anonymous namespace
+
+INITIALIZE_PASS_BEGIN(AMDGPUAlignVALURunsLegacy, DEBUG_TYPE,
+                      "AMDGPU Align VALU Runs", false, false)
+INITIALIZE_PASS_DEPENDENCY(MachineLoopInfoWrapperPass)
+INITIALIZE_PASS_END(AMDGPUAlignVALURunsLegacy, DEBUG_TYPE,
+                    "AMDGPU Align VALU Runs", false, false)
+
+char AMDGPUAlignVALURunsLegacy::ID = 0;
+
+char &llvm::AMDGPUAlignVALURunsLegacyID = AMDGPUAlignVALURunsLegacy::ID;
+
+PreservedAnalyses
+AMDGPUAlignVALURunsPass::run(MachineFunction &MF,
+                             MachineFunctionAnalysisManager &MFAM) {
+  auto &MLI = MFAM.getResult<MachineLoopAnalysis>(MF);
+  if (!AMDGPUAlignVALURuns().run(MF, &MLI))
+    return PreservedAnalyses::all();
+  auto PA = getMachineFunctionPassPreservedAnalyses();
+  PA.preserveSet<CFGAnalyses>();
+  return PA;
+}
+
+bool AMDGPUAlignVALURuns::run(MachineFunction &MF, MachineLoopInfo *MLI) {
+  if (DisableAlignVALURuns)
+    return false;
+
+  const GCNSubtarget &ST = MF.getSubtarget<GCNSubtarget>();
+  if (ST.getGeneration() != AMDGPUSubtarget::GFX9)
+    return false;
+
+  TII = ST.getInstrInfo();
+  bool Changed = false;
+
+  // Accumulate byte offset from function start as we walk MBBs in layout order.
+  uint64_t Offset = 0;
+
+  for (MachineBasicBlock &MBB : MF) {
+    bool InLoop = MLI && MLI->getLoopFor(&MBB);
+
+    // Track state for run detection within this block.
+    MachineInstr *RunStart = nullptr;
+    uint64_t RunStartOffset = 0;
+    unsigned RunLength = 0;
+    bool PrevWasVALU = false;
+
+    auto evaluateRun = [&]() {
+      if (RunLength >= AlignThreshold && (RunStartOffset % 8 != 0)) {
+        assert(RunStart && "RunStart must be set when RunLength > 0");
+        BuildMI(MBB, RunStart, DebugLoc(), TII->get(AMDGPU::S_NOP)).addImm(0);
+        // Shift all subsequent offsets.
+        Offset += 4;
+        Changed = true;
+      }
+      RunStart = nullptr;
+      RunLength = 0;
+    };
+
+    for (MachineInstr &MI : MBB) {
+      if (MI.isMetaInstruction() || MI.isDebugInstr())
+        continue;
+
+      unsigned InstSize = TII->getInstSizeInBytes(MI);
+
+      if (InLoop && isQualifyingVALU(MI)) {
+        if (RunLength == 0) {
+          RunStart = &MI;
+          RunStartOffset = Offset;
+        }
+        RunLength++;
+        PrevWasVALU = true;
+      } else if (isRunBreaker(MI, PrevWasVALU)) {
+        if (InLoop)
+          evaluateRun();
+        else {
+          RunStart = nullptr;
+          RunLength = 0;
+        }
+        PrevWasVALU = false;
+      } else {
+        // Non-qualifying, non-breaking instruction (e.g. 4-byte SALU).
+        // A non-8-byte instruction changes dword parity, so end the run.
+        if (InstSize != 8) {
+          if (InLoop)
+            evaluateRun();
+          else {
+            RunStart = nullptr;
+            RunLength = 0;
+          }
+        }
+        PrevWasVALU = SIInstrInfo::isVALU(MI);
+      }
+
+      Offset += InstSize;
+    }
+
+    // End-of-block: evaluate any open run.
+    if (InLoop)
+      evaluateRun();
+  }
+
+  if (Changed)
+    MF.setAlignment(Align(8));
+
+  return Changed;
+}

--- a/llvm/lib/Target/AMDGPU/AMDGPUPassRegistry.def
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPassRegistry.def
@@ -150,6 +150,7 @@ MACHINE_FUNCTION_PASS("si-optimize-exec-masking-pre-ra", SIOptimizeExecMaskingPr
 MACHINE_FUNCTION_PASS("si-peephole-sdwa", SIPeepholeSDWAPass())
 MACHINE_FUNCTION_PASS("si-post-ra-bundler", SIPostRABundlerPass())
 MACHINE_FUNCTION_PASS("si-pre-allocate-wwm-regs", SIPreAllocateWWMRegsPass())
+MACHINE_FUNCTION_PASS("amdgpu-align-valu-runs", AMDGPUAlignVALURunsPass())
 MACHINE_FUNCTION_PASS("si-pre-emit-peephole", SIPreEmitPeepholePass())
 MACHINE_FUNCTION_PASS("si-shrink-instructions", SIShrinkInstructionsPass())
 MACHINE_FUNCTION_PASS("si-wqm", SIWholeQuadModePass())

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -715,6 +715,7 @@ extern "C" LLVM_ABI LLVM_EXTERNAL_VISIBILITY void LLVMInitializeAMDGPUTarget() {
   initializeSIWholeQuadModeLegacyPass(*PR);
   initializeSILowerControlFlowLegacyPass(*PR);
   initializeSIPreEmitPeepholeLegacyPass(*PR);
+  initializeAMDGPUAlignVALURunsLegacyPass(*PR);
   initializeSILateBranchLoweringLegacyPass(*PR);
   initializeSIMemoryLegalizerLegacyPass(*PR);
   initializeSIOptimizeExecMaskingLegacyPass(*PR);
@@ -1949,6 +1950,9 @@ void GCNPassConfig::addPreEmitPass() {
     addPass(&AMDGPUInsertDelayAluID);
 
   addPass(&BranchRelaxationPassID);
+
+  if (getOptLevel() > CodeGenOptLevel::None)
+    addPass(&AMDGPUAlignVALURunsLegacyID);
 }
 
 void GCNPassConfig::addPostBBSections() {
@@ -2662,6 +2666,9 @@ void AMDGPUCodeGenPassBuilder::addPreEmitPass(PassManagerWrapper &PMW) const {
   }
 
   addMachineFunctionPass(BranchRelaxationPass(), PMW);
+
+  if (TM.getOptLevel() > CodeGenOptLevel::None)
+    addMachineFunctionPass(AMDGPUAlignVALURunsPass(), PMW);
 }
 
 bool AMDGPUCodeGenPassBuilder::isPassEnabled(const cl::opt<bool> &Opt,

--- a/llvm/lib/Target/AMDGPU/CMakeLists.txt
+++ b/llvm/lib/Target/AMDGPU/CMakeLists.txt
@@ -42,6 +42,7 @@ add_public_tablegen_target(AMDGPUCommonTableGen)
 
 add_llvm_target(AMDGPUCodeGen
   AMDGPUAliasAnalysis.cpp
+  AMDGPUAlignVALURuns.cpp
   AMDGPUAlwaysInlinePass.cpp
   AMDGPUAnnotateUniformValues.cpp
   AMDGPUArgumentUsageInfo.cpp

--- a/llvm/test/CodeGen/AMDGPU/align-valu-runs.mir
+++ b/llvm/test/CodeGen/AMDGPU/align-valu-runs.mir
@@ -1,0 +1,224 @@
+# RUN: llc -mtriple=amdgcn -mcpu=gfx900 -run-pass=amdgpu-align-valu-runs -o - %s | FileCheck -check-prefix=GFX9 %s
+# RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -run-pass=amdgpu-align-valu-runs -o - %s | FileCheck -check-prefix=GFX10 %s
+
+# Test 1: Misaligned run in a loop — should insert S_NOP 0.
+# bb.0 is a 4-byte S_BRANCH, so bb.1 starts at offset 4 (misaligned).
+# bb.1 has 10 V_ADD_F32_e64 (8 bytes each) forming a qualifying run.
+# The pass should insert S_NOP 0 before the first V_ADD_F32_e64.
+
+# GFX9-LABEL: name: misaligned_run_in_loop
+# GFX9:      bb.1:
+# GFX9-NEXT:   successors:
+# GFX9-NEXT:   liveins:
+# GFX9:        S_NOP 0
+# GFX9-NEXT:   $vgpr0 = V_ADD_F32_e64
+
+# GFX10-LABEL: name: misaligned_run_in_loop
+# GFX10:      bb.1:
+# GFX10-NOT:   S_NOP 0
+# GFX10:       $vgpr0 = V_ADD_F32_e64
+---
+name: misaligned_run_in_loop
+tracksRegLiveness: true
+body: |
+  bb.0:
+    successors: %bb.1
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.1, %bb.2
+    liveins: $vgpr0, $vgpr1, $vgpr2, $vcc
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    S_CBRANCH_VCCNZ %bb.1, implicit $vcc
+    S_BRANCH %bb.2
+
+  bb.2:
+    S_ENDPGM 0
+...
+
+# Test 2: Aligned run in a loop — should NOT insert S_NOP.
+# bb.0 has S_NOP 0 + S_BRANCH = 8 bytes, so bb.1 starts at offset 8 (aligned).
+
+# GFX9-LABEL: name: aligned_run_in_loop
+# GFX9:      bb.1:
+# GFX9-NOT:   S_NOP
+# GFX9:       $vgpr0 = V_ADD_F32_e64
+---
+name: aligned_run_in_loop
+tracksRegLiveness: true
+body: |
+  bb.0:
+    successors: %bb.1
+    S_NOP 0
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.1, %bb.2
+    liveins: $vgpr0, $vgpr1, $vgpr2, $vcc
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    S_CBRANCH_VCCNZ %bb.1, implicit $vcc
+    S_BRANCH %bb.2
+
+  bb.2:
+    S_ENDPGM 0
+...
+
+# Test 3: Below threshold — run of 6, default threshold is 8, no S_NOP.
+
+# GFX9-LABEL: name: below_threshold
+# GFX9:      bb.1:
+# GFX9-NOT:   S_NOP
+# GFX9:       $vgpr0 = V_ADD_F32_e64
+---
+name: below_threshold
+tracksRegLiveness: true
+body: |
+  bb.0:
+    successors: %bb.1
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.1, %bb.2
+    liveins: $vgpr0, $vgpr1, $vgpr2, $vcc
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    S_CBRANCH_VCCNZ %bb.1, implicit $vcc
+    S_BRANCH %bb.2
+
+  bb.2:
+    S_ENDPGM 0
+...
+
+# Test 4: Not in a loop — even misaligned, no S_NOP should be inserted.
+
+# GFX9-LABEL: name: not_in_loop
+# GFX9:      bb.1:
+# GFX9-NOT:   S_NOP
+# GFX9:       $vgpr0 = V_ADD_F32_e64
+---
+name: not_in_loop
+tracksRegLiveness: true
+body: |
+  bb.0:
+    successors: %bb.1
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.2
+    liveins: $vgpr0, $vgpr1, $vgpr2
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    S_BRANCH %bb.2
+
+  bb.2:
+    S_ENDPGM 0
+...
+
+# Test 5: S_WAITCNT breaks run into two sub-runs, each below threshold.
+
+# GFX9-LABEL: name: waitcnt_breaks_run
+# GFX9:      bb.1:
+# GFX9-NOT:   S_NOP
+# GFX9:       $vgpr0 = V_ADD_F32_e64
+---
+name: waitcnt_breaks_run
+tracksRegLiveness: true
+body: |
+  bb.0:
+    successors: %bb.1
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.1, %bb.2
+    liveins: $vgpr0, $vgpr1, $vgpr2, $vcc
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    S_WAITCNT 0
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    S_CBRANCH_VCCNZ %bb.1, implicit $vcc
+    S_BRANCH %bb.2
+
+  bb.2:
+    S_ENDPGM 0
+...
+
+# Test 6: VALU→MEM transition breaks run. 5 VALU + VMEM + 5 VALU = two sub-runs.
+
+# GFX9-LABEL: name: valu_to_mem_breaks_run
+# GFX9:      bb.1:
+# GFX9-NOT:   S_NOP
+# GFX9:       $vgpr0 = V_ADD_F32_e64
+---
+name: valu_to_mem_breaks_run
+tracksRegLiveness: true
+body: |
+  bb.0:
+    successors: %bb.1
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.1, %bb.2
+    liveins: $vgpr0, $vgpr1, $vgpr2, $vgpr3, $vcc, $sgpr0_sgpr1
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr3 = BUFFER_LOAD_DWORD_OFFEN $vgpr1, $sgpr0_sgpr1_sgpr2_sgpr3, 0, 0, 0, 0, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr1, 0, 0, implicit $mode, implicit $exec
+    $vgpr0 = V_ADD_F32_e64 0, $vgpr0, 0, $vgpr2, 0, 0, implicit $mode, implicit $exec
+    S_CBRANCH_VCCNZ %bb.1, implicit $vcc
+    S_BRANCH %bb.2
+
+  bb.2:
+    S_ENDPGM 0
+...
+
+# Test 7: Disable flag prevents pass from running.
+
+# RUN: llc -mtriple=amdgcn -mcpu=gfx900 -amdgpu-disable-valu-run-align -run-pass=amdgpu-align-valu-runs -o - %s | FileCheck -check-prefix=DISABLED %s
+
+# DISABLED-LABEL: name: misaligned_run_in_loop
+# DISABLED:      bb.1:
+# DISABLED-NOT:   S_NOP
+# DISABLED:       $vgpr0 = V_ADD_F32_e64

--- a/llvm/test/CodeGen/AMDGPU/llc-pipeline-npm.ll
+++ b/llvm/test/CodeGen/AMDGPU/llc-pipeline-npm.ll
@@ -282,6 +282,7 @@
 ; GCN-O2-NEXT:       amdgpu-lower-vgpr-encoding
 ; GCN-O2-NEXT:       amdgpu-insert-delay-alu
 ; GCN-O2-NEXT:       branch-relaxation
+; GCN-O2-NEXT:       amdgpu-align-valu-runs
 ; GCN-O2-NEXT:       reg-usage-collector
 ; GCN-O2-NEXT:       remove-loads-into-fake-uses
 ; GCN-O2-NEXT:       live-debug-values
@@ -468,6 +469,7 @@
 ; GCN-O3-NEXT:       amdgpu-lower-vgpr-encoding
 ; GCN-O3-NEXT:       amdgpu-insert-delay-alu
 ; GCN-O3-NEXT:       branch-relaxation
+; GCN-O3-NEXT:       amdgpu-align-valu-runs
 ; GCN-O3-NEXT:       reg-usage-collector
 ; GCN-O3-NEXT:       remove-loads-into-fake-uses
 ; GCN-O3-NEXT:       live-debug-values

--- a/llvm/test/CodeGen/AMDGPU/llc-pipeline.ll
+++ b/llvm/test/CodeGen/AMDGPU/llc-pipeline.ll
@@ -441,6 +441,9 @@
 ; GCN-O1-NEXT:        AMDGPU Lower VGPR Encoding
 ; GCN-O1-NEXT:        AMDGPU Insert Delay ALU
 ; GCN-O1-NEXT:        Branch relaxation pass
+; GCN-O1-NEXT:        MachineDominator Tree Construction
+; GCN-O1-NEXT:        Machine Natural Loop Construction
+; GCN-O1-NEXT:        AMDGPU Align VALU Runs
 ; GCN-O1-NEXT:        Register Usage Information Collector Pass
 ; GCN-O1-NEXT:        Remove Loads Into Fake Uses
 ; GCN-O1-NEXT:        Live DEBUG_VALUE analysis
@@ -759,6 +762,9 @@
 ; GCN-O1-OPTS-NEXT:        AMDGPU Lower VGPR Encoding
 ; GCN-O1-OPTS-NEXT:        AMDGPU Insert Delay ALU
 ; GCN-O1-OPTS-NEXT:        Branch relaxation pass
+; GCN-O1-OPTS-NEXT:        MachineDominator Tree Construction
+; GCN-O1-OPTS-NEXT:        Machine Natural Loop Construction
+; GCN-O1-OPTS-NEXT:        AMDGPU Align VALU Runs
 ; GCN-O1-OPTS-NEXT:        Register Usage Information Collector Pass
 ; GCN-O1-OPTS-NEXT:        Remove Loads Into Fake Uses
 ; GCN-O1-OPTS-NEXT:        Live DEBUG_VALUE analysis
@@ -1082,6 +1088,9 @@
 ; GCN-O2-NEXT:        AMDGPU Lower VGPR Encoding
 ; GCN-O2-NEXT:        AMDGPU Insert Delay ALU
 ; GCN-O2-NEXT:        Branch relaxation pass
+; GCN-O2-NEXT:        MachineDominator Tree Construction
+; GCN-O2-NEXT:        Machine Natural Loop Construction
+; GCN-O2-NEXT:        AMDGPU Align VALU Runs
 ; GCN-O2-NEXT:        Register Usage Information Collector Pass
 ; GCN-O2-NEXT:        Remove Loads Into Fake Uses
 ; GCN-O2-NEXT:        Live DEBUG_VALUE analysis
@@ -1418,6 +1427,9 @@
 ; GCN-O3-NEXT:        AMDGPU Lower VGPR Encoding
 ; GCN-O3-NEXT:        AMDGPU Insert Delay ALU
 ; GCN-O3-NEXT:        Branch relaxation pass
+; GCN-O3-NEXT:        MachineDominator Tree Construction
+; GCN-O3-NEXT:        Machine Natural Loop Construction
+; GCN-O3-NEXT:        AMDGPU Align VALU Runs
 ; GCN-O3-NEXT:        Register Usage Information Collector Pass
 ; GCN-O3-NEXT:        Remove Loads Into Fake Uses
 ; GCN-O3-NEXT:        Live DEBUG_VALUE analysis


### PR DESCRIPTION
On gfx9, the SQC fetches instructions into per-wave instruction buffers in 32-byte aligned windows. When a contiguous run of 8-byte VALU instructions (VOP3/VOP3P) starts at a 4-byte-but-not-8-byte-aligned offset, every 4th instruction straddles a 32-byte fetch window boundary. Each straddle costs roughly one quad (4 cycles) of stall while the next window is fetched. At low occupancy where there aren't enough waves to hide this latency, the penalty compounds to around 14% on affected kernels — confirmed on both MI210 (gfx90a) and MI300 (gfx942).

This patch adds a late machine pass, AMDGPUAlignVALURuns, that runs after BranchRelaxation and only on gfx9. It walks loop bodies tracking byte offsets and detects runs of qualifying 8-byte VALU instructions. When a run of 8 or more such instructions starts at a misaligned offset, the pass inserts a single `s_nop 0` (4 bytes) before the run to shift it to 8-byte alignment. The pass also sets function alignment to 8 bytes when padding is inserted so the offset-from-zero model holds. Runs are broken by non-8-byte instructions, waitcnts, MFMA, and VALU-to-memory transitions. The pass is gated on -O1+ and can be disabled with `-amdgpu-disable-valu-run-align` or tuned with `-amdgpu-valu-run-align-threshold`.

Assisted-by: Claude Code