### PR TITLE
[CIR] Use the AST result type for sizeof/alignof constants

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -2766,16 +2766,18 @@ mlir::Value ScalarExprEmitter::VisitUnaryExprOrTypeTraitExpr(
           e->getSourceRange(),
           "VisitUnaryExprOrTypeTraitExpr: sizeOf scalable vector");
       return builder.getConstant(
-          loc, cir::IntAttr::get(cgf.cgm.uInt64Ty,
+          loc, cir::IntAttr::get(cgf.cgm.sizeTy,
                                  e->EvaluateKnownConstInt(cgf.getContext())));
     }
 
     return builder.getConstant(
-        loc, cir::IntAttr::get(cgf.cgm.uInt64Ty, vecTy.getSize()));
+        loc, cir::IntAttr::get(cgf.cgm.sizeTy, vecTy.getSize()));
   }
 
+  // The result type is size_t (target-dependent width); use it so the IntAttr
+  // width matches the APInt from EvaluateKnownConstInt.
   return builder.getConstant(
-      loc, cir::IntAttr::get(cgf.cgm.uInt64Ty,
+      loc, cir::IntAttr::get(cgf.cgm.sizeTy,
                              e->EvaluateKnownConstInt(cgf.getContext())));
 }
 

--- a/clang/test/CIR/CodeGen/unary-expr-or-type-trait-32bit.cpp
+++ b/clang/test/CIR/CodeGen/unary-expr-or-type-trait-32bit.cpp
@@ -1,0 +1,47 @@
+// RUN: %clang_cc1 -std=c++20 -triple i686-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+// RUN: %clang_cc1 -std=c++20 -triple i686-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s --check-prefix=LLVM
+// RUN: %clang_cc1 -std=c++20 -triple i686-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s --check-prefix=OGCG
+
+// The result of sizeof/alignof/__builtin_vectorelements is size_t, which is
+// 32 bits wide on this target. The emitted constants must use that width
+// rather than a hardcoded 64-bit type.
+
+using size_t = decltype(sizeof(int));
+
+size_t size_of_int() { return sizeof(int); }
+
+// CIR-LABEL: cir.func {{.*}}@_Z11size_of_intv() -> !u32i
+// CIR:         cir.const #cir.int<4> : !u32i
+
+// LLVM-LABEL: define {{.*}}i32 @_Z11size_of_intv()
+// LLVM:         store i32 4, ptr
+
+// OGCG-LABEL: define {{.*}}i32 @_Z11size_of_intv()
+// OGCG:         ret i32 4
+
+size_t align_of_double() { return alignof(double); }
+
+// CIR-LABEL: cir.func {{.*}}@_Z15align_of_doublev() -> !u32i
+// CIR:         cir.const #cir.int<4> : !u32i
+
+// LLVM-LABEL: define {{.*}}i32 @_Z15align_of_doublev()
+// LLVM:         store i32 4, ptr
+
+// OGCG-LABEL: define {{.*}}i32 @_Z15align_of_doublev()
+// OGCG:         ret i32 4
+
+typedef int vi4 __attribute__((vector_size(16)));
+
+size_t vector_elements(vi4 v) { return __builtin_vectorelements(v); }
+
+// CIR-LABEL: cir.func {{.*}}@_Z15vector_elementsDv4_i({{.*}}) -> !u32i
+// CIR:         cir.const #cir.int<4> : !u32i
+
+// LLVM-LABEL: define {{.*}}i32 @_Z15vector_elementsDv4_i
+// LLVM:         store i32 4, ptr
+
+// OGCG-LABEL: define {{.*}}i32 @_Z15vector_elementsDv4_i
+// OGCG:         ret i32 4

--- a/clang/test/CIR/CodeGen/unary-expr-or-type-trait-32bit.cpp
+++ b/clang/test/CIR/CodeGen/unary-expr-or-type-trait-32bit.cpp
@@ -3,7 +3,7 @@
 // RUN: %clang_cc1 -std=c++20 -triple i686-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --input-file=%t-cir.ll %s --check-prefix=LLVM
 // RUN: %clang_cc1 -std=c++20 -triple i686-unknown-linux-gnu -emit-llvm %s -o %t.ll
-// RUN: FileCheck --input-file=%t.ll %s --check-prefix=OGCG
+// RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM
 
 // The result of sizeof/alignof/__builtin_vectorelements is size_t, which is
 // 32 bits wide on this target. The emitted constants must use that width
@@ -13,35 +13,26 @@ using size_t = decltype(sizeof(int));
 
 size_t size_of_int() { return sizeof(int); }
 
-// CIR-LABEL: cir.func {{.*}}@_Z11size_of_intv() -> !u32i
+// CIR-LABEL: cir.func {{.*}}@_Z11size_of_intv() -> {{.*}}!u32i
 // CIR:         cir.const #cir.int<4> : !u32i
 
 // LLVM-LABEL: define {{.*}}i32 @_Z11size_of_intv()
-// LLVM:         store i32 4, ptr
-
-// OGCG-LABEL: define {{.*}}i32 @_Z11size_of_intv()
-// OGCG:         ret i32 4
+// LLVM:         {{.*}}i32 4
 
 size_t align_of_double() { return alignof(double); }
 
-// CIR-LABEL: cir.func {{.*}}@_Z15align_of_doublev() -> !u32i
+// CIR-LABEL: cir.func {{.*}}@_Z15align_of_doublev() -> {{.*}}!u32i
 // CIR:         cir.const #cir.int<4> : !u32i
 
 // LLVM-LABEL: define {{.*}}i32 @_Z15align_of_doublev()
-// LLVM:         store i32 4, ptr
-
-// OGCG-LABEL: define {{.*}}i32 @_Z15align_of_doublev()
-// OGCG:         ret i32 4
+// LLVM:         {{.*}}i32 4
 
 typedef int vi4 __attribute__((vector_size(16)));
 
 size_t vector_elements(vi4 v) { return __builtin_vectorelements(v); }
 
-// CIR-LABEL: cir.func {{.*}}@_Z15vector_elementsDv4_i({{.*}}) -> !u32i
+// CIR-LABEL: cir.func {{.*}}@_Z15vector_elementsDv4_i({{.*}}) -> {{.*}}!u32i
 // CIR:         cir.const #cir.int<4> : !u32i
 
 // LLVM-LABEL: define {{.*}}i32 @_Z15vector_elementsDv4_i
-// LLVM:         store i32 4, ptr
-
-// OGCG-LABEL: define {{.*}}i32 @_Z15vector_elementsDv4_i
-// OGCG:         ret i32 4
+// LLVM:         {{.*}}i32 4


### PR DESCRIPTION
On targets where `size_t` is narrower than 64 bits (e.g. `i686`), CIR codegen for `sizeof`/`alignof`/`__builtin_vectorelements` crashes with a type/value bitwidth mismatch.

  The result of these expressions is `size_t`, but the emitted integer constant was built with a hardcoded 64-bit type. `EvaluateKnownConstInt` returns an `APSInt` with the width of the AST result type (32 bits on this target), so it no longer matches the `IntAttr`'s type and trips the `IntAttr` verifier.

  ### How to Reproduce
  ```c++
  using size_t = decltype(sizeof(int));
  size_t size_of_int() { return sizeof(int); }

  clang -cc1 -std=c++20 -triple i686-unknown-linux-gnu -fclangir \
    -emit-cir test.cpp -o test.cir

  error: type and value bitwidth mismatch: 64 != 32
  clang: mlir/include/mlir/IR/StorageUniquerSupport.h:180:
    ... Assertion `succeeded(ConcreteT::verifyInvariants(...))' failed.
   #11 cir::IntAttr::get(mlir::Type, llvm::APInt const&)
   #12 ScalarExprEmitter::VisitUnaryExprOrTypeTraitExpr(...)
   #13 CIRGenFunction::emitScalarExpr(...)
```
### Fix
Form the IntAttr using the converted AST result type (convertType(e->getType())) instead of a hardcoded 64-bit type, matching classic codegen. The same path covers the fixed-vector __builtin_vectorelements case.