### PR TITLE
[AssumeBundleQueries] Use correct default value for dereferenceable

### DIFF
--- a/llvm/lib/Analysis/AssumeBundleQueries.cpp
+++ b/llvm/lib/Analysis/AssumeBundleQueries.cpp
@@ -106,20 +106,34 @@ llvm::getKnowledgeFromBundle(AssumeInst &Assume,
   Result.AttrKind = Attribute::getAttrKindFromName(BOI.Tag->getKey());
   if (bundleHasArgument(BOI, ABA_WasOn))
     Result.WasOn = getValueFromBundleOpInfo(Assume, BOI, ABA_WasOn);
-  auto GetArgOr1 = [&](unsigned Idx) -> uint64_t {
+  auto GetArgOr = [&](unsigned Idx, uint64_t Default) -> uint64_t {
     if (auto *ConstInt = dyn_cast<ConstantInt>(
             getValueFromBundleOpInfo(Assume, BOI, ABA_Argument + Idx)))
       return ConstInt->getZExtValue();
-    return 1;
+    return Default;
   };
-  if (BOI.End - BOI.Begin > ABA_Argument)
-    Result.ArgValue = GetArgOr1(0);
+  if (BOI.End - BOI.Begin > ABA_Argument) {
+    switch (Result.AttrKind) {
+    case Attribute::Alignment:
+      Result.ArgValue = GetArgOr(0, 1);
+      break;
+    case Attribute::Dereferenceable:
+    case Attribute::DereferenceableOrNull:
+      Result.ArgValue = GetArgOr(0, 0);
+      break;
+    case Attribute::None:
+      Result.ArgValue = 0;
+      break;
+    default:
+      llvm_unreachable("Attribute kind does not support argument");
+    }
+  }
   Result.IRArgValue = bundleHasArgument(BOI, ABA_Argument)
                           ? getValueFromBundleOpInfo(Assume, BOI, ABA_Argument)
                           : nullptr;
   if (Result.AttrKind == Attribute::Alignment)
     if (BOI.End - BOI.Begin > ABA_Argument + 1)
-      Result.ArgValue = MinAlign(Result.ArgValue, GetArgOr1(1));
+      Result.ArgValue = MinAlign(Result.ArgValue, GetArgOr(1, 1));
   return Result;
 }
 

--- a/llvm/test/Transforms/SimplifyCFG/speculate-derefable-load.ll
+++ b/llvm/test/Transforms/SimplifyCFG/speculate-derefable-load.ll
@@ -153,10 +153,14 @@ exit:
 define i8 @align_deref_size_unknown(i1 %c, ptr %p, i64 %size) {
 ; CHECK-LABEL: define i8 @align_deref_size_unknown(
 ; CHECK-SAME: i1 [[C:%.*]], ptr [[P:%.*]], i64 [[SIZE:%.*]]) {
-; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:  [[ENTRY:.*]]:
 ; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "dereferenceable"(ptr [[P]], i64 [[SIZE]]) ]
+; CHECK-NEXT:    br i1 [[C]], label %[[IF:.*]], label %[[EXIT:.*]]
+; CHECK:       [[IF]]:
 ; CHECK-NEXT:    [[V:%.*]] = load i8, ptr [[P]], align 1
-; CHECK-NEXT:    [[SPEC_SELECT:%.*]] = select i1 [[C]], i8 [[V]], i8 0
+; CHECK-NEXT:    br label %[[EXIT]]
+; CHECK:       [[EXIT]]:
+; CHECK-NEXT:    [[SPEC_SELECT:%.*]] = phi i8 [ [[V]], %[[IF]] ], [ 0, %[[ENTRY]] ]
 ; CHECK-NEXT:    ret i8 [[SPEC_SELECT]]
 ;
 entry:

--- a/llvm/test/Transforms/SimplifyCFG/speculate-derefable-load.ll
+++ b/llvm/test/Transforms/SimplifyCFG/speculate-derefable-load.ll
@@ -128,6 +128,50 @@ exit:
   ret i64 %res
 }
 
+define i8 @align_deref_size_1(i1 %c, ptr %p) {
+; CHECK-LABEL: define i8 @align_deref_size_1(
+; CHECK-SAME: i1 [[C:%.*]], ptr [[P:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "dereferenceable"(ptr [[P]], i64 1) ]
+; CHECK-NEXT:    [[V:%.*]] = load i8, ptr [[P]], align 1
+; CHECK-NEXT:    [[SPEC_SELECT:%.*]] = select i1 [[C]], i8 [[V]], i8 0
+; CHECK-NEXT:    ret i8 [[SPEC_SELECT]]
+;
+entry:
+  call void @llvm.assume(i1 true) [ "dereferenceable"(ptr %p, i64 1) ]
+  br i1 %c, label %if, label %exit
+
+if:
+  %v = load i8, ptr %p
+  br label %exit
+
+exit:
+  %res = phi i8 [ %v, %if ], [ 0, %entry ]
+  ret i8 %res
+}
+
+define i8 @align_deref_size_unknown(i1 %c, ptr %p, i64 %size) {
+; CHECK-LABEL: define i8 @align_deref_size_unknown(
+; CHECK-SAME: i1 [[C:%.*]], ptr [[P:%.*]], i64 [[SIZE:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "dereferenceable"(ptr [[P]], i64 [[SIZE]]) ]
+; CHECK-NEXT:    [[V:%.*]] = load i8, ptr [[P]], align 1
+; CHECK-NEXT:    [[SPEC_SELECT:%.*]] = select i1 [[C]], i8 [[V]], i8 0
+; CHECK-NEXT:    ret i8 [[SPEC_SELECT]]
+;
+entry:
+  call void @llvm.assume(i1 true) [ "dereferenceable"(ptr %p, i64 %size) ]
+  br i1 %c, label %if, label %exit
+
+if:
+  %v = load i8, ptr %p
+  br label %exit
+
+exit:
+  %res = phi i8 [ %v, %if ], [ 0, %entry ]
+  ret i8 %res
+}
+
 define i64 @deref_no_hoist(i1 %c, ptr align 8 dereferenceable(8) %p1) {
 ; CHECK-LABEL: define i64 @deref_no_hoist(
 ; CHECK-SAME: i1 [[C:%.*]], ptr align 8 dereferenceable(8) [[P1:%.*]]) {


### PR DESCRIPTION
Dereferenceable with a non-constant argument should be treated like dereferenceable(0), not dereferenceable(1).