### PR TITLE
[HIP] Remove default `-flto-partitions=8` in the HIP toolchain

### DIFF
--- a/clang/lib/Driver/ToolChains/HIPAMD.cpp
+++ b/clang/lib/Driver/ToolChains/HIPAMD.cpp
@@ -294,12 +294,6 @@ HIPAMDToolChain::TranslateArgs(const llvm::opt::DerivedArgList &Args,
   llvm::opt::DerivedArgList *DAL =
       ROCMToolChain::TranslateArgs(Args, BoundArch, DeviceOffloadKind);
 
-  if (!Args.hasArg(options::OPT_flto_partitions_EQ)) {
-    const OptTable &Opts = getDriver().getOpts();
-    DAL->AddJoinedArg(nullptr, Opts.getOption(options::OPT_flto_partitions_EQ),
-                      "8");
-  }
-
   return DAL;
 }
 

--- a/clang/test/Driver/hip-toolchain-rdc-static-lib.hip
+++ b/clang/test/Driver/hip-toolchain-rdc-static-lib.hip
@@ -2,6 +2,7 @@
 // RUN:   -x hip --cuda-gpu-arch=gfx803 --cuda-gpu-arch=gfx900 \
 // RUN:   --no-offload-new-driver --emit-static-lib -nogpulib \
 // RUN:   -fuse-ld=lld -B%S/Inputs/lld -fgpu-rdc -nogpuinc \
+// RUN:   -flto-partitions=8 \
 // RUN:   %S/Inputs/hip_multiple_inputs/a.cu \
 // RUN:   %S/Inputs/hip_multiple_inputs/b.hip \
 // RUN: 2>&1 | FileCheck %s

--- a/clang/test/Driver/hip-toolchain-rdc.hip
+++ b/clang/test/Driver/hip-toolchain-rdc.hip
@@ -5,6 +5,7 @@
 // RUN:   --hip-device-lib-path=%S/Inputs/hip_multiple_inputs/lib2 \
 // RUN:   -fuse-ld=lld -B%S/Inputs/lld -fgpu-rdc -nogpuinc \
 // RUN:   --no-offload-new-driver -fhip-dump-offload-linker-script \
+// RUN:   -flto-partitions=8 \
 // RUN:   %S/Inputs/hip_multiple_inputs/a.cu \
 // RUN:   %S/Inputs/hip_multiple_inputs/b.hip \
 // RUN: 2>&1 | FileCheck -check-prefixes=CHECK,LNX %s
@@ -16,6 +17,7 @@
 // RUN:   --hip-device-lib-path=%S/Inputs/hip_multiple_inputs/lib2 \
 // RUN:   -fuse-ld=lld -B%S/Inputs/lld -fgpu-rdc -nogpuinc \
 // RUN:   --no-offload-new-driver -fhip-dump-offload-linker-script \
+// RUN:   -flto-partitions=8 \
 // RUN:   %S/Inputs/hip_multiple_inputs/a.cu \
 // RUN:   %S/Inputs/hip_multiple_inputs/b.hip \
 // RUN: 2>&1 | FileCheck -check-prefixes=CHECK,MSVC %s
@@ -170,11 +172,13 @@
 
 // RUN: %clang -### -fgpu-rdc --offload-arch=gfx90a -nogpulib -nogpuinc --no-offload-new-driver \
 // RUN:   -L. -foffload-lto %s 2>&1 | FileCheck -check-prefix=LTO_DEFAULT %s
-// LTO_DEFAULT: lld{{.*}}"--lto-partitions=8"
+// LTO_DEFAULT: lld
+// LTO_DEFAULT-NOT: "--lto-partitions=
 
 // RUN: %clang -### -fgpu-rdc --offload-arch=gfx90a -nogpulib -nogpuinc --offload-new-driver \
 // RUN:   -L. -foffload-lto %s 2>&1 | FileCheck -check-prefix=LTO_DEFAULT_NEW %s
-// LTO_DEFAULT_NEW: clang-linker-wrapper{{.*}}"--device-compiler=amdgcn-amd-amdhsa=-flto-partitions=8"
+// LTO_DEFAULT_NEW: clang-linker-wrapper
+// LTO_DEFAULT_NEW-NOT: "--device-compiler=amdgcn-amd-amdhsa=-flto-partitions=
 
 // RUN: %clang -### -fgpu-rdc --offload-arch=gfx90a -nogpulib -nogpuinc --no-offload-new-driver \
 // RUN:   -L. -foffload-lto -flto-partitions=42 %s 2>&1 | FileCheck -check-prefix=LTO_PARTS %s


### PR DESCRIPTION
Summary:
This was added and made it into a release, but it never should've been a
default argument. Partitioning the LTO is a fundamentally different
compilation model and has real impacts on the generated code. Right now
it is added silently, which breaks non-Hostcall printf and degreades
performance due to split uselists.

This is a contract that should not be made default. "Compile times" is
not a justification to silently change compilation semantics, that is
the user's build system's job. Parititioning to a magic number is not an
appropriate solution when passing -flto-partitions=8 or `-Xarch_device
-flto-partitions=8` is perfectly viable and not hidden from the user.

This resolves the 12% performance regression observed when switching to
the LTO toolchain in HIP for dcsrgemm.
