### PR TITLE
[LLVM][InstSimplify][SVE] Only transform sve.eorv(all_active, A)->0 when A is the result of a splat.

### DIFF
--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -6831,7 +6831,8 @@ static Value *simplifySVEIntReduction(Intrinsic::ID IID, Type *ReturnType,
   case Intrinsic::aarch64_sve_eorv:
     // sve_reduce_xor(all, splat(X)) ==> 0
     if (C0 && C0->isAllOnesValue())
-      return ConstantInt::get(ReturnType, 0);
+      if (getSplatValue(Op1))
+        return ConstantInt::get(ReturnType, 0);
     break;
   }
 

--- a/llvm/test/Transforms/InstSimplify/AArch64/aarch64-sve-reductions.ll
+++ b/llvm/test/Transforms/InstSimplify/AArch64/aarch64-sve-reductions.ll
@@ -146,6 +146,15 @@ define i8 @eorv_i8_all_active_splat(i8 %a) #0 {
   ret i8 %out
 }
 
+define i8 @eorv_i8_all_active_non_splat(<vscale x 16 x i8> %a) #0 {
+; CHECK-LABEL: define i8 @eorv_i8_all_active_non_splat(
+; CHECK-SAME: <vscale x 16 x i8> [[A:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    ret i8 0
+;
+  %out = call i8 @llvm.aarch64.sve.eorv.nxv16i8(<vscale x 16 x i1> splat (i1 true), <vscale x 16 x i8> %a)
+  ret i8 %out
+}
+
 define i16 @eorv_i16_splat_neutral_val(<vscale x 8 x i1> %pg) #0 {
 ; CHECK-LABEL: define i16 @eorv_i16_splat_neutral_val(
 ; CHECK-SAME: <vscale x 8 x i1> [[PG:%.*]]) #[[ATTR0]] {

--- a/llvm/test/Transforms/InstSimplify/AArch64/aarch64-sve-reductions.ll
+++ b/llvm/test/Transforms/InstSimplify/AArch64/aarch64-sve-reductions.ll
@@ -149,7 +149,8 @@ define i8 @eorv_i8_all_active_splat(i8 %a) #0 {
 define i8 @eorv_i8_all_active_non_splat(<vscale x 16 x i8> %a) #0 {
 ; CHECK-LABEL: define i8 @eorv_i8_all_active_non_splat(
 ; CHECK-SAME: <vscale x 16 x i8> [[A:%.*]]) #[[ATTR0]] {
-; CHECK-NEXT:    ret i8 0
+; CHECK-NEXT:    [[OUT:%.*]] = call i8 @llvm.aarch64.sve.eorv.nxv16i8(<vscale x 16 x i1> splat (i1 true), <vscale x 16 x i8> [[A]])
+; CHECK-NEXT:    ret i8 [[OUT]]
 ;
   %out = call i8 @llvm.aarch64.sve.eorv.nxv16i8(<vscale x 16 x i1> splat (i1 true), <vscale x 16 x i8> %a)
   ret i8 %out


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/203921