### PR TITLE
[1/4]: [docs] Add BOLTAArch64OptimizationStatus to toctree

### DIFF
--- a/bolt/docs/index.rst
+++ b/bolt/docs/index.rst
@@ -1,6 +1,11 @@
 BOLT
 ====
 
+.. toctree::
+   :hidden:
+
+   BOLTAArch64OptimizationStatus
+
 BOLT is a post-link optimizer developed to speed up large applications.
 It achieves the improvements by optimizing application’s code layout
 based on execution profile gathered by sampling profiler, such as Linux


### PR DESCRIPTION
Building docs-bolt-html fails with:

  Warning, treated as error:
  /home/slinder1/llvm-project/scratch/bolt/docs/BOLTAArch64OptimizationStatus.rst:document isn't included in any toctree

Just add the orphan document to the toctree in the index to silence
this. If there is a better parent it can be moved somewhere else in the
tree.

Change-Id: I1d26d96d5485d97d29231da89f8c8408b375c41f

---

**Stack**:
- #203967
- #203962
- #203963
- #203964⬅
- `main`

<sub>(Note: Closed and merged PRs may not be reflected here and PR numbering is not stable.)</sub>
