### PR TITLE
[flang][acc] Add PointerLikeType API for MemRef type conversion

### DIFF
--- a/flang/include/flang/Optimizer/OpenACC/Support/FIROpenACCTypeInterfaces.h
+++ b/flang/include/flang/Optimizer/OpenACC/Support/FIROpenACCTypeInterfaces.h
@@ -57,6 +57,9 @@ struct OpenACCPointerLikeModel
                       mlir::Location loc, mlir::Value value,
                       mlir::Type resultType) const;
 
+  mlir::MemRefType getAsMemRefType(mlir::Type pointer,
+                                   mlir::ModuleOp module) const;
+
   bool isDeviceData(mlir::Type pointer, mlir::Value var) const;
 };
 

--- a/flang/lib/Optimizer/OpenACC/Support/CMakeLists.txt
+++ b/flang/lib/Optimizer/OpenACC/Support/CMakeLists.txt
@@ -24,7 +24,6 @@ add_flang_library(FIROpenACCSupport
   FIRDialect
   FIRDialectSupport
   FIRSupport
-  FIRTransforms
   HLFIRDialect
 
   MLIR_DEPS

--- a/flang/lib/Optimizer/OpenACC/Support/CMakeLists.txt
+++ b/flang/lib/Optimizer/OpenACC/Support/CMakeLists.txt
@@ -24,6 +24,7 @@ add_flang_library(FIROpenACCSupport
   FIRDialect
   FIRDialectSupport
   FIRSupport
+  FIRTransforms
   HLFIRDialect
 
   MLIR_DEPS

--- a/flang/lib/Optimizer/OpenACC/Support/FIROpenACCTypeInterfaces.cpp
+++ b/flang/lib/Optimizer/OpenACC/Support/FIROpenACCTypeInterfaces.cpp
@@ -1605,8 +1605,9 @@ template bool OpenACCPointerLikeModel<fir::LLVMPointerType>::genStore(
     mlir::TypedValue<mlir::acc::PointerLikeType> destPtr) const;
 
 template <typename Ty>
-mlir::MemRefType OpenACCPointerLikeModel<Ty>::getAsMemRefType(
-    mlir::Type pointer, mlir::ModuleOp module) const {
+mlir::MemRefType
+OpenACCPointerLikeModel<Ty>::getAsMemRefType(mlir::Type pointer,
+                                             mlir::ModuleOp module) const {
   if (auto memrefTy = mlir::dyn_cast<mlir::MemRefType>(pointer))
     return memrefTy;
   fir::FIRToMemRefTypeConverter converter(module);
@@ -1616,17 +1617,21 @@ mlir::MemRefType OpenACCPointerLikeModel<Ty>::getAsMemRefType(
   return converter.convertMemrefType(pointer);
 }
 
-template mlir::MemRefType OpenACCPointerLikeModel<fir::ReferenceType>::
-    getAsMemRefType(mlir::Type pointer, mlir::ModuleOp module) const;
-
-template mlir::MemRefType OpenACCPointerLikeModel<fir::PointerType>::
-    getAsMemRefType(mlir::Type pointer, mlir::ModuleOp module) const;
-
-template mlir::MemRefType OpenACCPointerLikeModel<fir::HeapType>::getAsMemRefType(
+template mlir::MemRefType
+OpenACCPointerLikeModel<fir::ReferenceType>::getAsMemRefType(
     mlir::Type pointer, mlir::ModuleOp module) const;
 
-template mlir::MemRefType OpenACCPointerLikeModel<fir::LLVMPointerType>::
-    getAsMemRefType(mlir::Type pointer, mlir::ModuleOp module) const;
+template mlir::MemRefType
+OpenACCPointerLikeModel<fir::PointerType>::getAsMemRefType(
+    mlir::Type pointer, mlir::ModuleOp module) const;
+
+template mlir::MemRefType
+OpenACCPointerLikeModel<fir::HeapType>::getAsMemRefType(
+    mlir::Type pointer, mlir::ModuleOp module) const;
+
+template mlir::MemRefType
+OpenACCPointerLikeModel<fir::LLVMPointerType>::getAsMemRefType(
+    mlir::Type pointer, mlir::ModuleOp module) const;
 
 template <typename Ty>
 mlir::Value OpenACCPointerLikeModel<Ty>::genCast(mlir::Type pointer,

--- a/flang/lib/Optimizer/OpenACC/Support/FIROpenACCTypeInterfaces.cpp
+++ b/flang/lib/Optimizer/OpenACC/Support/FIROpenACCTypeInterfaces.cpp
@@ -25,6 +25,7 @@
 #include "flang/Optimizer/Dialect/Support/KindMapping.h"
 #include "flang/Optimizer/OpenACC/Support/FIROpenACCUtils.h"
 #include "flang/Optimizer/Support/Utils.h"
+#include "flang/Optimizer/Transforms/FIRToMemRefTypeConverter.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/OpenACC/OpenACC.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -1602,6 +1603,30 @@ template bool OpenACCPointerLikeModel<fir::LLVMPointerType>::genStore(
     mlir::Type pointer, mlir::OpBuilder &builder, mlir::Location loc,
     mlir::Value valueToStore,
     mlir::TypedValue<mlir::acc::PointerLikeType> destPtr) const;
+
+template <typename Ty>
+mlir::MemRefType OpenACCPointerLikeModel<Ty>::getAsMemRefType(
+    mlir::Type pointer, mlir::ModuleOp module) const {
+  if (auto memrefTy = mlir::dyn_cast<mlir::MemRefType>(pointer))
+    return memrefTy;
+  fir::FIRToMemRefTypeConverter converter(module);
+  converter.setConvertComplexTypes(true);
+  if (!converter.convertibleMemrefType(pointer))
+    return {};
+  return converter.convertMemrefType(pointer);
+}
+
+template mlir::MemRefType OpenACCPointerLikeModel<fir::ReferenceType>::
+    getAsMemRefType(mlir::Type pointer, mlir::ModuleOp module) const;
+
+template mlir::MemRefType OpenACCPointerLikeModel<fir::PointerType>::
+    getAsMemRefType(mlir::Type pointer, mlir::ModuleOp module) const;
+
+template mlir::MemRefType OpenACCPointerLikeModel<fir::HeapType>::getAsMemRefType(
+    mlir::Type pointer, mlir::ModuleOp module) const;
+
+template mlir::MemRefType OpenACCPointerLikeModel<fir::LLVMPointerType>::
+    getAsMemRefType(mlir::Type pointer, mlir::ModuleOp module) const;
 
 template <typename Ty>
 mlir::Value OpenACCPointerLikeModel<Ty>::genCast(mlir::Type pointer,

--- a/flang/unittests/Optimizer/CMakeLists.txt
+++ b/flang/unittests/Optimizer/CMakeLists.txt
@@ -36,9 +36,9 @@ add_flang_unittest(FlangOptimizerTests
   Builder/Runtime/ReductionTest.cpp
   Builder/Runtime/StopTest.cpp
   Builder/Runtime/TransformationalTest.cpp
+  OpenACC/FIROpenACCPointerLikeTypeInterfaceTest.cpp
   FIRCallInterfaceTest.cpp
   FIRContextTest.cpp
-  OpenACC/FIROpenACCPointerLikeTypeInterfaceTest.cpp
   FIRTypesTest.cpp
   FortranVariableTest.cpp
   InternalNamesTest.cpp

--- a/flang/unittests/Optimizer/CMakeLists.txt
+++ b/flang/unittests/Optimizer/CMakeLists.txt
@@ -12,7 +12,9 @@ set(LIBS
   FIRCodeGenDialect
   FIRDialect
   FIRDialectSupport
+  FIROpenACCSupport
   FIRSupport
+  FIRTransforms
   HLFIRDialect
   MIFDialect
 )
@@ -36,6 +38,7 @@ add_flang_unittest(FlangOptimizerTests
   Builder/Runtime/TransformationalTest.cpp
   FIRCallInterfaceTest.cpp
   FIRContextTest.cpp
+  OpenACC/FIROpenACCPointerLikeTypeInterfaceTest.cpp
   FIRTypesTest.cpp
   FortranVariableTest.cpp
   InternalNamesTest.cpp
@@ -60,4 +63,5 @@ mlir_target_link_libraries(FlangOptimizerTests
   PRIVATE
   ${dialect_libs}
   ${extension_libs}
+  MLIROpenACCDialect
   )

--- a/flang/unittests/Optimizer/OpenACC/FIROpenACCPointerLikeTypeInterfaceTest.cpp
+++ b/flang/unittests/Optimizer/OpenACC/FIROpenACCPointerLikeTypeInterfaceTest.cpp
@@ -1,0 +1,123 @@
+//===- FIROpenACCPointerLikeTypeInterfaceTest.cpp -------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "gtest/gtest.h"
+#include "mlir/Dialect/OpenACC/OpenACC.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "flang/Optimizer/Dialect/FIRType.h"
+#include "flang/Optimizer/Dialect/Support/FIRContext.h"
+#include "flang/Optimizer/Dialect/Support/KindMapping.h"
+#include "flang/Optimizer/Support/InitFIR.h"
+
+using namespace mlir;
+
+namespace {
+
+struct FIROpenACCPointerLikeTypeInterfaceTest : public testing::Test {
+  void SetUp() override {
+    mlir::DialectRegistry registry;
+    fir::support::addFIRExtensions(registry);
+    context.appendDialectRegistry(registry);
+    fir::support::loadDialects(context);
+    kindMap = std::make_unique<fir::KindMapping>(&context);
+    module = ModuleOp::create(UnknownLoc::get(&context));
+    fir::setKindMapping(module, *kindMap);
+  }
+
+  MLIRContext context;
+  std::unique_ptr<fir::KindMapping> kindMap;
+  ModuleOp module;
+};
+
+TEST_F(FIROpenACCPointerLikeTypeInterfaceTest,
+    GetAsMemRefTypeFromFirRefStaticArray) {
+  Type f32 = Float32Type::get(&context);
+  Type seq = fir::SequenceType::get({10}, f32);
+  Type refTy = fir::ReferenceType::get(seq);
+  auto ptrLike = cast<acc::PointerLikeType>(refTy);
+
+  MemRefType memrefTy = ptrLike.getAsMemRefType(module);
+  ASSERT_TRUE(memrefTy);
+  EXPECT_EQ(memrefTy.getRank(), 1);
+  EXPECT_EQ(memrefTy.getDimSize(0), 10);
+  EXPECT_TRUE(isa<Float32Type>(memrefTy.getElementType()));
+}
+
+TEST_F(FIROpenACCPointerLikeTypeInterfaceTest,
+    GetAsMemRefTypeFromFirRefMultiDimArray) {
+  Type i32 = IntegerType::get(&context, 32);
+  Type seq = fir::SequenceType::get({2, 3}, i32);
+  Type refTy = fir::ReferenceType::get(seq);
+  auto ptrLike = cast<acc::PointerLikeType>(refTy);
+
+  MemRefType memrefTy = ptrLike.getAsMemRefType(module);
+  ASSERT_TRUE(memrefTy);
+  EXPECT_EQ(memrefTy.getRank(), 2);
+  // MemRef layout is in reversed order:
+  EXPECT_EQ(memrefTy.getDimSize(0), 3);
+  EXPECT_EQ(memrefTy.getDimSize(1), 2);
+  EXPECT_TRUE(isa<IntegerType>(memrefTy.getElementType()));
+  EXPECT_EQ(cast<IntegerType>(memrefTy.getElementType()).getWidth(), 32u);
+}
+
+TEST_F(FIROpenACCPointerLikeTypeInterfaceTest,
+    GetAsMemRefTypeFromFirHeapDynamicArray) {
+  Type f64 = Float64Type::get(&context);
+  Type seq = fir::SequenceType::get({ShapedType::kDynamic}, f64);
+  Type heapTy = fir::HeapType::get(seq);
+  auto ptrLike = cast<acc::PointerLikeType>(heapTy);
+
+  MemRefType memrefTy = ptrLike.getAsMemRefType(module);
+  ASSERT_TRUE(memrefTy);
+  EXPECT_EQ(memrefTy.getRank(), 1);
+  EXPECT_EQ(memrefTy.getDimSize(0), ShapedType::kDynamic);
+  EXPECT_TRUE(isa<Float64Type>(memrefTy.getElementType()));
+}
+
+TEST_F(FIROpenACCPointerLikeTypeInterfaceTest,
+    GetAsMemRefTypeFromFirPointerStaticArray) {
+  Type f32 = Float32Type::get(&context);
+  Type seq = fir::SequenceType::get({4}, f32);
+  Type ptrTy = fir::PointerType::get(seq);
+  auto ptrLike = cast<acc::PointerLikeType>(ptrTy);
+
+  MemRefType memrefTy = ptrLike.getAsMemRefType(module);
+  ASSERT_TRUE(memrefTy);
+  EXPECT_EQ(memrefTy.getRank(), 1);
+  EXPECT_EQ(memrefTy.getDimSize(0), 4);
+}
+
+TEST_F(FIROpenACCPointerLikeTypeInterfaceTest,
+    GetAsMemRefTypeFromFirRefScalarInteger) {
+  Type i32 = IntegerType::get(&context, 32);
+  Type refTy = fir::ReferenceType::get(i32);
+  auto ptrLike = cast<acc::PointerLikeType>(refTy);
+
+  MemRefType memrefTy = ptrLike.getAsMemRefType(module);
+  ASSERT_TRUE(memrefTy);
+  EXPECT_EQ(memrefTy.getRank(), 0);
+  EXPECT_TRUE(isa<IntegerType>(memrefTy.getElementType()));
+  EXPECT_EQ(cast<IntegerType>(memrefTy.getElementType()).getWidth(), 32u);
+}
+
+TEST_F(FIROpenACCPointerLikeTypeInterfaceTest,
+    GetAsMemRefTypeFromFirRefScalarLogical) {
+  constexpr unsigned logicalKind = 4;
+  Type logicalTy = fir::LogicalType::get(&context, logicalKind);
+  Type refTy = fir::ReferenceType::get(logicalTy);
+  auto ptrLike = cast<acc::PointerLikeType>(refTy);
+
+  MemRefType memrefTy = ptrLike.getAsMemRefType(module);
+  ASSERT_TRUE(memrefTy);
+  EXPECT_EQ(memrefTy.getRank(), 0);
+  auto elTy = dyn_cast<IntegerType>(memrefTy.getElementType());
+  ASSERT_TRUE(elTy);
+  EXPECT_EQ(elTy.getWidth(), kindMap->getLogicalBitsize(logicalKind));
+}
+
+} // namespace

--- a/flang/unittests/Optimizer/OpenACC/FIROpenACCPointerLikeTypeInterfaceTest.cpp
+++ b/flang/unittests/Optimizer/OpenACC/FIROpenACCPointerLikeTypeInterfaceTest.cpp
@@ -12,6 +12,7 @@
 #include "flang/Optimizer/Dialect/FIRType.h"
 #include "flang/Optimizer/Dialect/Support/FIRContext.h"
 #include "flang/Optimizer/Dialect/Support/KindMapping.h"
+#include "flang/Optimizer/OpenACC/Support/RegisterOpenACCExtensions.h"
 #include "flang/Optimizer/Support/InitFIR.h"
 
 using namespace mlir;
@@ -21,7 +22,7 @@ namespace {
 struct FIROpenACCPointerLikeTypeInterfaceTest : public testing::Test {
   void SetUp() override {
     mlir::DialectRegistry registry;
-    fir::support::addFIRExtensions(registry);
+    fir::acc::registerOpenACCExtensions(registry);
     context.appendDialectRegistry(registry);
     fir::support::loadDialects(context);
     kindMap = std::make_unique<fir::KindMapping>(&context);

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCTypeInterfaces.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCTypeInterfaces.td
@@ -250,6 +250,18 @@ def OpenACC_PointerLikeTypeInterface : TypeInterface<"PointerLikeType"> {
     >,
     InterfaceMethod<
       /*description=*/[{
+        Return this type as an equivalent MemRef type when convertible.
+      }],
+      /*retTy=*/"::mlir::MemRefType",
+      /*methodName=*/"getAsMemRefType",
+      /*args=*/(ins "::mlir::ModuleOp":$module),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return {};
+      }]
+    >,
+    InterfaceMethod<
+      /*description=*/[{
         Returns true if the pointer points to device data.
       }],
       /*retTy=*/"bool",

--- a/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
@@ -283,6 +283,11 @@ struct MemRefPointerLikeModel
     Attribute memSpace = memrefTy.getMemorySpace();
     return isa_and_nonnull<gpu::AddressSpaceAttr>(memSpace);
   }
+
+  MemRefType getAsMemRefType(Type pointer, ModuleOp module) const {
+    (void)module;
+    return dyn_cast<MemRefType>(pointer);
+  }
 };
 
 struct LLVMPointerPointerLikeModel
@@ -360,6 +365,15 @@ struct PrivateTypePointerLikeModel
     if (!isa<PointerLikeType>(resultType))
       return {};
     return UnwrapPrivateOp::create(builder, loc, resultType, value).getResult();
+  }
+
+  MemRefType getAsMemRefType(Type type, ModuleOp module) const {
+    Type baseTy = cast<PrivateType>(type).getBaseTy();
+    if (auto memrefTy = dyn_cast<MemRefType>(baseTy))
+      return memrefTy;
+    if (auto ptrLikeTy = dyn_cast<PointerLikeType>(baseTy))
+      return ptrLikeTy.getAsMemRefType(module);
+    return {};
   }
 };
 

--- a/mlir/unittests/Dialect/OpenACC/OpenACCTypeInterfacesTest.cpp
+++ b/mlir/unittests/Dialect/OpenACC/OpenACCTypeInterfacesTest.cpp
@@ -301,7 +301,8 @@ TEST_F(OpenACCTypeInterfacesTest, PointerLikeGetAsMemRefTypeUnrankedMemref) {
   EXPECT_FALSE(ptrLike.getAsMemRefType(*module));
 }
 
-TEST_F(OpenACCTypeInterfacesTest, PointerLikeGetAsMemRefTypePrivateTypeMemrefBase) {
+TEST_F(OpenACCTypeInterfacesTest,
+       PointerLikeGetAsMemRefTypePrivateTypeMemrefBase) {
   Location loc = UnknownLoc::get(&context);
   OwningOpRef<ModuleOp> module = ModuleOp::create(loc);
 

--- a/mlir/unittests/Dialect/OpenACC/OpenACCTypeInterfacesTest.cpp
+++ b/mlir/unittests/Dialect/OpenACC/OpenACCTypeInterfacesTest.cpp
@@ -277,3 +277,46 @@ TEST_F(OpenACCTypeInterfacesTest, PointerLikeGenCastPrivateTypeToMemref) {
   ASSERT_TRUE(unwrap);
   EXPECT_EQ(unwrap.getHandle(), handle);
 }
+
+//===----------------------------------------------------------------------===//
+// PointerLikeType::getAsMemRefType tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(OpenACCTypeInterfacesTest, PointerLikeGetAsMemRefTypeRankedMemref) {
+  Location loc = UnknownLoc::get(&context);
+  OwningOpRef<ModuleOp> module = ModuleOp::create(loc);
+
+  auto memTy = MemRefType::get({4, 8}, Float32Type::get(&context));
+  auto ptrLike = cast<PointerLikeType>(memTy);
+  EXPECT_EQ(ptrLike.getAsMemRefType(*module), memTy);
+}
+
+TEST_F(OpenACCTypeInterfacesTest, PointerLikeGetAsMemRefTypeUnrankedMemref) {
+  Location loc = UnknownLoc::get(&context);
+  OwningOpRef<ModuleOp> module = ModuleOp::create(loc);
+
+  auto unrankedTy =
+      UnrankedMemRefType::get(Float32Type::get(&context), /*memorySpace=*/0);
+  auto ptrLike = cast<PointerLikeType>(unrankedTy);
+  EXPECT_FALSE(ptrLike.getAsMemRefType(*module));
+}
+
+TEST_F(OpenACCTypeInterfacesTest, PointerLikeGetAsMemRefTypePrivateTypeMemrefBase) {
+  Location loc = UnknownLoc::get(&context);
+  OwningOpRef<ModuleOp> module = ModuleOp::create(loc);
+
+  Type memrefTy = MemRefType::get({10}, IntegerType::get(&context, 64));
+  Type privateTy = PrivateType::get(&context, memrefTy);
+  auto ptrLike = cast<PointerLikeType>(privateTy);
+  EXPECT_EQ(ptrLike.getAsMemRefType(*module), memrefTy);
+}
+
+TEST_F(OpenACCTypeInterfacesTest,
+       PointerLikeGetAsMemRefTypePrivateTypeNonMemrefBase) {
+  Location loc = UnknownLoc::get(&context);
+  OwningOpRef<ModuleOp> module = ModuleOp::create(loc);
+
+  Type privateTy = PrivateType::get(&context, IntegerType::get(&context, 8));
+  auto ptrLike = cast<PointerLikeType>(privateTy);
+  EXPECT_FALSE(ptrLike.getAsMemRefType(*module));
+}


### PR DESCRIPTION
This PR adds a PointerLikeType API named `getAsMemRefType` whose intent is to establish equivalent MemRefType - the first use case for this will be privatization and shared memory handling to be done in a dialect-independent way. The Flang implementation uses FIRToMemRefTypeConverter to do so.