### PR TITLE
[Support] Add a parser for cl::opt<ElementCount>

### DIFF
--- a/llvm/include/llvm/Support/CommandLine.h
+++ b/llvm/include/llvm/Support/CommandLine.h
@@ -46,6 +46,7 @@ class FileSystem;
 }
 
 class StringSaver;
+class ElementCount;
 
 /// This namespace contains all of the command line option processing machinery.
 /// It is intentionally a short name to make qualified usage concise.
@@ -1228,6 +1229,28 @@ public:
   StringRef getValueName() const override { return "char"; }
 
   void printOptionDiff(const Option &O, char V, OptVal Default,
+                       size_t GlobalWidth) const;
+
+  // An out-of-line virtual method to provide a 'home' for this class.
+  void anchor() override;
+};
+
+//--------------------------------------------------
+
+extern template class LLVM_TEMPLATE_ABI basic_parser<ElementCount>;
+
+template <>
+class LLVM_ABI parser<ElementCount> : public basic_parser<ElementCount> {
+public:
+  parser(Option &O) : basic_parser(O) {}
+
+  // Return true on error.
+  bool parse(Option &O, StringRef ArgName, StringRef Arg, ElementCount &Value);
+
+  // Overload in subclass to provide a better default value.
+  StringRef getValueName() const override { return "ElementCount"; }
+
+  void printOptionDiff(const Option &O, ElementCount V, OptVal Default,
                        size_t GlobalWidth) const;
 
   // An out-of-line virtual method to provide a 'home' for this class.

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -40,6 +40,7 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/StringSaver.h"
+#include "llvm/Support/TypeSize.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cstdlib>
@@ -67,6 +68,7 @@ template class LLVM_EXPORT_TEMPLATE basic_parser<double>;
 template class LLVM_EXPORT_TEMPLATE basic_parser<float>;
 template class LLVM_EXPORT_TEMPLATE basic_parser<std::string>;
 template class LLVM_EXPORT_TEMPLATE basic_parser<char>;
+template class LLVM_EXPORT_TEMPLATE basic_parser<ElementCount>;
 
 #if !(defined(LLVM_ENABLE_LLVM_EXPORT_ANNOTATIONS) && defined(_MSC_VER))
 // Only instantiate opt<std::string> when not building a Windows DLL. When
@@ -103,6 +105,7 @@ void parser<float>::anchor() {}
 void parser<std::string>::anchor() {}
 void parser<std::optional<std::string>>::anchor() {}
 void parser<char>::anchor() {}
+void parser<ElementCount>::anchor() {}
 
 // These anchor functions instantiate opt<T> and reference its virtual
 // destructor to ensure MSVC exports the corresponding vtable and typeinfo when
@@ -2014,6 +2017,41 @@ bool parser<boolOrDefault>::parse(Option &O, StringRef ArgName, StringRef Arg,
   return parseBool<boolOrDefault, BOU_TRUE, BOU_FALSE>(O, ArgName, Arg, Value);
 }
 
+// parser<FixedOrScalableQuantity> implementation
+//
+template <typename FixedOrScalableQuantityT>
+static bool parseFixedOrScalableQuantity(Option &O, StringRef Arg,
+                                         StringRef ValueKind,
+                                         FixedOrScalableQuantityT &Value) {
+  using ScalarTy = typename FixedOrScalableQuantityT::ScalarTy;
+
+  Arg = Arg.trim();
+
+  ScalarTy MinValue;
+  if (!Arg.getAsInteger(0, MinValue)) {
+    Value = FixedOrScalableQuantityT::getFixed(MinValue);
+    return false;
+  }
+
+  StringRef Remainder = Arg;
+  if (!Remainder.consume_front("vscale"))
+    return O.error("'" + Arg + "' value invalid for " + ValueKind +
+                   " argument!");
+
+  Remainder = Remainder.ltrim();
+  if (!Remainder.consume_front('x'))
+    return O.error("'" + Arg + "' value invalid for " + ValueKind +
+                   " argument!");
+
+  Remainder = Remainder.ltrim();
+  if (Remainder.getAsInteger(0, MinValue))
+    return O.error("'" + Arg + "' value invalid for " + ValueKind +
+                   " argument!");
+
+  Value = FixedOrScalableQuantityT::getScalable(MinValue);
+  return false;
+}
+
 // parser<int> implementation
 //
 bool parser<int>::parse(Option &O, StringRef ArgName, StringRef Arg,
@@ -2070,6 +2108,13 @@ bool parser<unsigned long long>::parse(Option &O, StringRef ArgName,
   if (Arg.getAsInteger(0, Value))
     return O.error("'" + Arg + "' value invalid for ullong argument!");
   return false;
+}
+
+// parser<ElementCount> implementation
+//
+bool parser<ElementCount>::parse(Option &O, StringRef ArgName, StringRef Arg,
+                                 ElementCount &Value) {
+  return parseFixedOrScalableQuantity(O, Arg, getValueName(), Value);
 }
 
 // parser<double>/parser<float> implementation
@@ -2260,6 +2305,7 @@ PRINT_OPT_DIFF(unsigned long long)
 PRINT_OPT_DIFF(double)
 PRINT_OPT_DIFF(float)
 PRINT_OPT_DIFF(char)
+PRINT_OPT_DIFF(ElementCount)
 
 void parser<std::string>::printOptionDiff(const Option &O, StringRef V,
                                           const OptionValue<std::string> &D,

--- a/llvm/unittests/Support/CommandLineTest.cpp
+++ b/llvm/unittests/Support/CommandLineTest.cpp
@@ -18,6 +18,7 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Program.h"
 #include "llvm/Support/StringSaver.h"
+#include "llvm/Support/TypeSize.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Host.h"
@@ -2200,6 +2201,80 @@ TEST(CommandLineTest, ConsumeOptionalString) {
   ASSERT_TRUE(Input.has_value());
   EXPECT_EQ("\"value\"", *Input);
   EXPECT_TRUE(Errs.empty());
+}
+
+TEST(CommandLineTest, ParseElementCount) {
+  cl::ResetCommandLineParser();
+
+  StackOption<ElementCount> Count("count", cl::init(ElementCount::getFixed(1)));
+
+  std::string Errs;
+  raw_string_ostream OS(Errs);
+
+  const char *FixedArgs[] = {"prog", "--count=4"};
+  ASSERT_TRUE(cl::ParseCommandLineOptions(std::size(FixedArgs), FixedArgs,
+                                          StringRef(), &OS));
+  EXPECT_EQ(Count, ElementCount::getFixed(4));
+  EXPECT_TRUE(Errs.empty());
+
+  Errs.clear();
+  cl::ResetAllOptionOccurrences();
+
+  const char *SpacedScalableArgs[] = {"prog", "--count=vscale x 8"};
+  ASSERT_TRUE(cl::ParseCommandLineOptions(
+      std::size(SpacedScalableArgs), SpacedScalableArgs, StringRef(), &OS));
+  EXPECT_EQ(Count, ElementCount::getScalable(8));
+  EXPECT_TRUE(Errs.empty());
+
+  Errs.clear();
+  cl::ResetAllOptionOccurrences();
+
+  const char *FlexibleWhitespaceArgs[] = {"prog", "--count=\tvscale\t x\t12  "};
+  ASSERT_TRUE(cl::ParseCommandLineOptions(std::size(FlexibleWhitespaceArgs),
+                                          FlexibleWhitespaceArgs, StringRef(),
+                                          &OS));
+  EXPECT_EQ(Count, ElementCount::getScalable(12));
+  EXPECT_TRUE(Errs.empty());
+
+  Errs.clear();
+  cl::ResetAllOptionOccurrences();
+
+  const char *CompactScalableArgs[] = {"prog", "--count=vscalex4"};
+  ASSERT_TRUE(cl::ParseCommandLineOptions(
+      std::size(CompactScalableArgs), CompactScalableArgs, StringRef(), &OS));
+  EXPECT_EQ(Count, ElementCount::getScalable(4));
+  EXPECT_TRUE(Errs.empty());
+}
+
+TEST(CommandLineTest, RejectInvalidElementCount) {
+  cl::ResetCommandLineParser();
+
+  StackOption<ElementCount> Count("count");
+
+  std::string Errs;
+  raw_string_ostream OS(Errs);
+
+  const char *MissingMultiplierArgs[] = {"prog", "--count=vscale"};
+  testing::internal::CaptureStderr();
+  EXPECT_FALSE(cl::ParseCommandLineOptions(std::size(MissingMultiplierArgs),
+                                           MissingMultiplierArgs, StringRef(),
+                                           &OS));
+  std::string ErrorOutput = testing::internal::GetCapturedStderr();
+  EXPECT_NE(
+      ErrorOutput.find("'vscale' value invalid for ElementCount argument!"),
+      std::string::npos);
+
+  Errs.clear();
+  cl::ResetAllOptionOccurrences();
+
+  const char *TrailingJunkArgs[] = {"prog", "--count=vscale x 8x"};
+  testing::internal::CaptureStderr();
+  EXPECT_FALSE(cl::ParseCommandLineOptions(std::size(TrailingJunkArgs),
+                                           TrailingJunkArgs, StringRef(), &OS));
+  ErrorOutput = testing::internal::GetCapturedStderr();
+  EXPECT_NE(ErrorOutput.find(
+                "'vscale x 8x' value invalid for ElementCount argument!"),
+            std::string::npos);
 }
 
 TEST(CommandLineTest, ResetAllOptionOccurrences) {

--- a/llvm/unittests/Support/CommandLineTest.cpp
+++ b/llvm/unittests/Support/CommandLineTest.cpp
@@ -2275,6 +2275,16 @@ TEST(CommandLineTest, RejectInvalidElementCount) {
   EXPECT_NE(ErrorOutput.find(
                 "'vscale x 8x' value invalid for ElementCount argument!"),
             std::string::npos);
+
+  const char *TrailingJunkFixedArgs[] = {"prog", "--count=4adsf"};
+  testing::internal::CaptureStderr();
+  EXPECT_FALSE(cl::ParseCommandLineOptions(std::size(TrailingJunkFixedArgs),
+                                           TrailingJunkFixedArgs, StringRef(),
+                                           &OS));
+  ErrorOutput = testing::internal::GetCapturedStderr();
+  EXPECT_NE(
+      ErrorOutput.find("'4adsf' value invalid for ElementCount argument!"),
+      std::string::npos);
 }
 
 TEST(CommandLineTest, ResetAllOptionOccurrences) {


### PR DESCRIPTION
This adds command-line option parsing support for ElementCount.

This allows the following syntax:
```
  --my-option=4 ; Maps to ElementCount::getFixed(4)
  --my-option="vscale x 8" ; Maps to ElementCount::getScalable(8)
```
This is intended to unify fixed/scalable option handling in the loop vectorizer. Currently, we have options like '`EpilogueVectorizationForceVF`' defined as `cl::opt<unsigned>` which do not allow specifying scalable VFs.

Assisted-by: Codex