### PR TITLE
[Clang] [C++29] Implement P3950R1 `return_value` & `return_void` are not mutually exclusive

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -193,6 +193,11 @@ C++ Language Changes
 - ``__is_trivially_equality_comparable`` no longer returns false for all enum types. (#GH132672)
 - ``auto`` parameters are now available in all C++ language modes as an extension.
 
+C++2d Feature Support
+^^^^^^^^^^^^^^^^^^^^^
+
+- Clang now supports `P3950R1 <https://wg21.link/p3950r1>`_ ``return_value`` & ``return_void`` are not mutually exclusive. This change is applied as a DR to all C++ language modes.
+
 C++2c Feature Support
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12983,8 +12983,6 @@ def err_coroutine_promise_type_incomplete : Error<
 def err_coroutine_type_missing_specialization : Error<
   "this function cannot be a coroutine: missing definition of "
   "specialization %0">;
-def err_coroutine_promise_incompatible_return_functions : Error<
-  "the coroutine promise type %0 declares both 'return_value' and 'return_void'">;
 def note_coroutine_promise_implicit_await_transform_required_here : Note<
   "call to 'await_transform' implicitly required by 'co_await' here">;
 def note_coroutine_promise_suspend_implicitly_required : Note<

--- a/clang/lib/Sema/SemaCoroutine.cpp
+++ b/clang/lib/Sema/SemaCoroutine.cpp
@@ -1715,12 +1715,14 @@ bool CoroutineStmtBuilder::makeOnFallthrough() {
          "cannot make statement while the promise type is dependent");
 
   // [dcl.fct.def.coroutine]/p6
-  // If searches for the names return_void and return_value in the scope of
-  // the promise type each find any declarations, the program is ill-formed.
   // [Note 1: If return_void is found, flowing off the end of a coroutine is
   // equivalent to a co_return with no operand. Otherwise, flowing off the end
   // of a coroutine results in undefined behavior ([stmt.return.coroutine]). —
   // end note]
+  //
+  // Note: A promise type declaring both return_void and return_value was
+  // previously ill-formed, but this is allowed since P3950 which was adopted
+  // into C++2d as a DR.
   bool HasRVoid, HasRValue;
   LookupResult LRVoid =
       lookupMember(S, "return_void", PromiseRecordDecl, Loc, HasRVoid);
@@ -1728,19 +1730,7 @@ bool CoroutineStmtBuilder::makeOnFallthrough() {
       lookupMember(S, "return_value", PromiseRecordDecl, Loc, HasRValue);
 
   StmtResult Fallthrough;
-  if (HasRVoid && HasRValue) {
-    // FIXME Improve this diagnostic
-    S.Diag(FD.getLocation(),
-           diag::err_coroutine_promise_incompatible_return_functions)
-        << PromiseRecordDecl;
-    S.Diag(LRVoid.getRepresentativeDecl()->getLocation(),
-           diag::note_member_first_declared_here)
-        << LRVoid.getLookupName();
-    S.Diag(LRValue.getRepresentativeDecl()->getLocation(),
-           diag::note_member_first_declared_here)
-        << LRValue.getLookupName();
-    return false;
-  } else if (!HasRVoid && !HasRValue) {
+  if (!HasRVoid && !HasRValue) {
     // We need to set 'Fallthrough'. Otherwise the other analysis part might
     // think the coroutine has defined a return_value method. So it might emit
     // **false** positive warning. e.g.,

--- a/clang/test/CodeGenCoroutines/coro-ret-both.cpp
+++ b/clang/test/CodeGenCoroutines/coro-ret-both.cpp
@@ -1,0 +1,51 @@
+// RUN: %clang_cc1 -std=c++20 -triple=x86_64-unknown-linux-gnu -emit-llvm %s -o - -disable-llvm-passes | FileCheck %s
+
+#include "Inputs/coroutine.h"
+
+struct coro1 {
+  struct promise_type {
+    coro1 get_return_object();
+    std::suspend_never initial_suspend();
+    std::suspend_never final_suspend() noexcept;
+    void return_void();
+    void return_value(int);
+    void unhandled_exception() noexcept;
+  };
+};
+
+// CHECK-LABEL: define {{.*}} void @_Z2f1v
+coro1 f1() {
+  // CHECK: call void @_ZN5coro112promise_type11return_voidEv
+  co_return;
+}
+
+// CHECK-LABEL: define {{.*}} void @_Z2f2v
+coro1 f2() {
+  // CHECK: call void @_ZN5coro112promise_type12return_valueEi({{.*}}, i32 {{.*}} 1)
+  co_return 1;
+}
+
+// CHECK-LABEL: define {{.*}} void @_Z2f3b
+coro1 f3(bool b) {
+  // CHECK: call void @_ZN5coro112promise_type11return_voidEv
+  // CHECK: call void @_ZN5coro112promise_type12return_valueEi({{.*}}, i32 {{.*}} 2)
+  if (b) co_return;
+  co_return 2;
+}
+
+// CHECK-LABEL: define {{.*}} void @_Z2f4b
+coro1 f4(bool b) {
+  // CHECK: call void @_ZN5coro112promise_type12return_valueEi({{.*}}, i32 {{.*}} 3)
+  // CHECK: call void @_ZN5coro112promise_type11return_voidEv
+  if (b) co_return 3;
+}
+
+void returns_void();
+
+// CHECK-LABEL: define {{.*}} void @_Z2f5v
+coro1 f5() {
+  // CHECK: call void @_Z12returns_voidv
+  // CHECK: call void @_ZN5coro112promise_type11return_voidEv
+  // CHECK-NOT: call void @_ZN5coro112promise_type12return_valueEi
+  co_return returns_void();
+}

--- a/clang/test/SemaCXX/coreturn.cpp
+++ b/clang/test/SemaCXX/coreturn.cpp
@@ -55,6 +55,17 @@ struct VoidTagReturnVoid {
   };
 };
 
+struct VoidTagReturnVoidAndReturnValue {
+  struct promise_type {
+    VoidTagReturnVoidAndReturnValue get_return_object();
+    suspend_always initial_suspend();
+    suspend_always final_suspend() noexcept;
+    void unhandled_exception();
+    void return_void();
+    void return_value(int);
+  };
+};
+
 struct promise_float {
   float get_return_object();
   suspend_always initial_suspend();
@@ -138,3 +149,23 @@ VoidTagReturnValue test11(bool b) {
   if (b)
     co_return 42;
 } // expected-warning {{non-void coroutine does not return a value in all control paths}}
+
+VoidTagReturnVoidAndReturnValue test12(bool a) {
+  if (a) co_return 42;
+  co_return;
+}
+
+VoidTagReturnVoidAndReturnValue test13(bool a) {
+  if (a) co_return;
+  co_return 42;
+}
+
+VoidTagReturnVoidAndReturnValue test14(bool a) {
+  if (a) co_return 42;
+  // Falling off here is ok since we have return_void().
+}
+
+void returns_void();
+VoidTagReturnVoidAndReturnValue test15() {
+  co_return returns_void();
+}

--- a/clang/test/SemaCXX/coroutines.cpp
+++ b/clang/test/SemaCXX/coroutines.cpp
@@ -699,19 +699,19 @@ struct bad_promise_6 {
   suspend_always initial_suspend();
   suspend_always final_suspend() noexcept;
   void unhandled_exception();
-  void return_void();           // expected-note 2 {{member 'return_void' first declared here}}
-  void return_value(int) const; // expected-note 2 {{member 'return_value' first declared here}}
+  void return_void();
+  void return_value(int) const;
   void return_value(int);
 };
-coro<bad_promise_6> bad_implicit_return() { // expected-error {{'bad_promise_6' declares both 'return_value' and 'return_void'}}
+coro<bad_promise_6> bad_implicit_return() {
   co_await a;
 }
 
 template <class T>
-coro<T> bad_implicit_return_dependent(T) { // expected-error {{'bad_promise_6' declares both 'return_value' and 'return_void'}}
+coro<T> bad_implicit_return_dependent(T) {
   co_await a;
 }
-template coro<bad_promise_6> bad_implicit_return_dependent(bad_promise_6); // expected-note {{in instantiation}}
+template coro<bad_promise_6> bad_implicit_return_dependent(bad_promise_6);
 
 struct bad_promise_7 { // expected-note 2 {{defined here}}
   coro<bad_promise_7> get_return_object();

--- a/clang/www/cxx_status.html
+++ b/clang/www/cxx_status.html
@@ -140,7 +140,7 @@ C++2c, informally referred to as C++2d.</p>
 <tr>
   <td><code>return_value</code> &amp; <code>return_void</code> are not mutually exclusive</td>
   <td><a href="https://wg21.link/P3950R1">P3950R1</a> <a href="#dr">(DR)</a></td>
-  <td class="none" align="center">No</td>
+  <td class="unreleased" align="center">Clang 23</td>
 </tr>
 <tr>
   <td>More named universal character escapes</td>


### PR DESCRIPTION
This is a very straight-forward change since we only have to remove the check that disallows promise types that declare both functions, and then everything else just works. This is a DR, so this change is backported to all language modes.