### PR TITLE
[CodeGen] Split determineCalleeSaves into smaller functions.

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetFrameLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetFrameLowering.h
@@ -368,6 +368,19 @@ public:
   virtual StackOffset getFrameIndexReferenceFromSP(const MachineFunction &MF,
                                                    int FI) const;
 
+  /// Return the list of registers which must be preserved by the function: the
+  /// value on exit must be the same as the value on entry. A register from this
+  /// list does may not need to be saved / reloaded if the function did not use
+  /// it.
+  const MCPhysReg *getMustPreserveRegisters(const MachineFunction &MF) const;
+
+  /// This method determines which of the registers reported by
+  /// getMustPreserveRegisters() must be saved in prolog and reloaded in epilog
+  /// regardless of whether or not they were modified by the function.
+  void determineUncondPrologCalleeSaves(MachineFunction &MF,
+                                        const MCPhysReg *CSRegs,
+                                        BitVector &UncondPrologCSRs) const;
+
   /// Returns the callee-saved registers as computed by determineCalleeSaves
   /// in the BitVector \p SavedRegs.
   virtual void getCalleeSaves(const MachineFunction &MF,

--- a/llvm/lib/CodeGen/TargetFrameLoweringImpl.cpp
+++ b/llvm/lib/CodeGen/TargetFrameLoweringImpl.cpp
@@ -93,15 +93,9 @@ void TargetFrameLowering::getCalleeSaves(const MachineFunction &MF,
     CalleeSaves.set(Info.getReg());
 }
 
-void TargetFrameLowering::determineCalleeSaves(MachineFunction &MF,
-                                               BitVector &SavedRegs,
-                                               RegScavenger *RS) const {
+const MCPhysReg *
+TargetFrameLowering::getMustPreserveRegisters(const MachineFunction &MF) const {
   const TargetRegisterInfo &TRI = *MF.getSubtarget().getRegisterInfo();
-
-  // Resize before the early returns. Some backends expect that
-  // SavedRegs.size() == TRI.getNumRegs() after this call even if there are no
-  // saved registers.
-  SavedRegs.resize(TRI.getNumRegs());
 
   // Get the callee saved register list...
   const MCPhysReg *CSRegs = nullptr;
@@ -118,11 +112,11 @@ void TargetFrameLowering::determineCalleeSaves(MachineFunction &MF,
 
   // Early exit if there are no callee saved registers.
   if (!CSRegs || CSRegs[0] == 0)
-    return;
+    return nullptr;
 
   // In Naked functions we aren't going to save any registers.
   if (MF.getFunction().hasFnAttribute(Attribute::Naked))
-    return;
+    return nullptr;
 
   // Noreturn+nounwind functions never restore CSR, so no saves are needed.
   // Purely noreturn functions may still return through throws, so those must
@@ -135,15 +129,45 @@ void TargetFrameLowering::determineCalleeSaves(MachineFunction &MF,
         MF.getFunction().hasFnAttribute(Attribute::NoUnwind) &&
         !MF.getFunction().hasFnAttribute(Attribute::UWTable) &&
         enableCalleeSaveSkip(MF))
+    return nullptr;
+
+  return CSRegs;
+}
+
+void TargetFrameLowering::determineUncondPrologCalleeSaves(
+    MachineFunction &MF, const MCPhysReg *CSRegs, BitVector &SavedRegs) const {
+  // Functions which call __builtin_unwind_init get all their registers saved.
+  if (!MF.callsUnwindInit())
+    return;
+  for (unsigned i = 0; CSRegs[i]; ++i) {
+    unsigned Reg = CSRegs[i];
+    SavedRegs.set(Reg);
+  }
+}
+
+void TargetFrameLowering::determineCalleeSaves(MachineFunction &MF,
+                                               BitVector &PrologCSRs,
+                                               RegScavenger *RS) const {
+  const TargetRegisterInfo &TRI = *MF.getSubtarget().getRegisterInfo();
+
+  // Resize before the early returns. Some backends expect that
+  // SavedRegs.size() == TRI.getNumRegs() after this call even if there are no
+  // saved registers.
+  PrologCSRs.resize(TRI.getNumRegs());
+
+  // Get the callee saved register list...
+  const MCPhysReg *CSRegs = getMustPreserveRegisters(MF);
+  // Early exit if there are no callee saved registers.
+  if (!CSRegs || CSRegs[0] == 0)
     return;
 
-  // Functions which call __builtin_unwind_init get all their registers saved.
-  bool CallsUnwindInit = MF.callsUnwindInit();
+  determineUncondPrologCalleeSaves(MF, CSRegs, PrologCSRs);
+
   const MachineRegisterInfo &MRI = MF.getRegInfo();
   for (unsigned i = 0; CSRegs[i]; ++i) {
     unsigned Reg = CSRegs[i];
-    if (CallsUnwindInit || MRI.isPhysRegModified(Reg))
-      SavedRegs.set(Reg);
+    if (MRI.isPhysRegModified(Reg))
+      PrologCSRs.set(Reg);
   }
 }
 


### PR DESCRIPTION
The function `getMustPreserveRegisters` - returns the list of registers that must be preserved by the function.

The function `determineUncondPrologCalleeSaves` - determines which of the registers reported by `getMustPreserveRegisters` must be saved in prolog and reloaded in epilog regardless of whether or not they were modified by the function.