### PR TITLE
[X86] Enable passing x86_fp80 arguments in x87 registers for the regcall calling convention

### DIFF
--- a/llvm/lib/Target/X86/X86CallingConv.td
+++ b/llvm/lib/Target/X86/X86CallingConv.td
@@ -41,7 +41,7 @@ class RC_X86_RegCall {
   list<Register> GPR_16 = [];
   list<Register> GPR_32 = [];
   list<Register> GPR_64 = [];
-  list<Register> FP_CALL = [FP0];
+  list<Register> FP_CALL = [FP0, FP1, FP2, FP3, FP4, FP5, FP6];
   list<Register> FP_RET = [FP0, FP1];
   list<Register> XMM = [];
   list<Register> YMM = [];

--- a/llvm/lib/Target/X86/X86FloatingPoint.cpp
+++ b/llvm/lib/Target/X86/X86FloatingPoint.cpp
@@ -327,6 +327,10 @@ static unsigned getFPReg(const MachineOperand &MO) {
   return Reg - X86::FP0;
 }
 
+static bool isFPPhysReg(Register Reg) {
+  return Reg >= X86::FP0 && Reg <= X86::FP6;
+}
+
 bool FPS::shouldRun(MachineFunction &MF) {
   // We only need to run this pass if there are any FP registers used in this
   // function.  If it is all integer, there is nothing for us to do!
@@ -361,21 +365,21 @@ bool FPS::run(MachineFunction &MF, EdgeBundles *FunctionBundles) {
   LiveBundle &Bundle =
       LiveBundles[Bundles->getBundle(Entry->getNumber(), false)];
 
-  // In regcall convention, some FP registers may not be passed through
-  // the stack, so they will need to be assigned to the stack first
+  // In regcall convention, FP arguments may be passed in x87 registers
+  // rather than on the memory stack, so they need to be assigned to the
+  // x87 stack before processing the entry block.
   if ((Entry->getParent()->getFunction().getCallingConv() ==
        CallingConv::X86_RegCall) &&
       (Bundle.Mask && !Bundle.FixCount)) {
-    // In the register calling convention, up to one FP argument could be
-    // saved in the first FP register.
     // If bundle.mask is non-zero and Bundle.FixCount is zero, it means
-    // that the FP registers contain arguments.
-    // The actual value is passed in FP0.
-    // Here we fix the stack and mark FP0 as pre-assigned register.
-    assert((Bundle.Mask & 0xFE) == 0 &&
-           "Only FP0 could be passed as an argument");
-    Bundle.FixCount = 1;
-    Bundle.FixStack[0] = 0;
+    // that the FP registers contain arguments. Assign them to ST(0).. in
+    // increasing FP register order.
+    unsigned Idx = 0;
+    for (unsigned Reg = 0; Reg < 7; ++Reg) {
+      if (Bundle.Mask & (1u << Reg))
+        Bundle.FixStack[Idx++] = Reg;
+    }
+    Bundle.FixCount = Idx;
   }
 
   bool Changed = false;
@@ -508,7 +512,7 @@ bool FPS::processBasicBlock(MachineFunction &MF, MachineBasicBlock &BB) {
       // Check if Reg is live on the stack. An inline-asm register operand that
       // is in the clobber list and marked dead might not be live on the stack.
       static_assert(X86::FP7 - X86::FP0 == 7, "sequential FP regnumbers");
-      if (Reg >= X86::FP0 && Reg <= X86::FP6 && isLive(Reg - X86::FP0)) {
+      if (isFPPhysReg(Reg) && isLive(Reg - X86::FP0)) {
         LLVM_DEBUG(dbgs() << "Register FP#" << Reg - X86::FP0 << " is dead!\n");
         freeStackSlotAfter(I, Reg - X86::FP0);
       }
@@ -1056,7 +1060,7 @@ void FPS::handleCall(MachineBasicBlock::iterator &I) {
         ClobbersFPStack = true;
     }
 
-    if (!Op.isReg() || Op.getReg() < X86::FP0 || Op.getReg() > X86::FP6)
+    if (!Op.isReg() || !isFPPhysReg(Op.getReg()))
       continue;
 
     assert(Op.isImplicit() && "Expected implicit def/use");
@@ -1110,7 +1114,7 @@ void FPS::handleReturn(MachineBasicBlock::iterator &I) {
 
   for (unsigned i = 0, e = MI.getNumOperands(); i != e; ++i) {
     MachineOperand &Op = MI.getOperand(i);
-    if (!Op.isReg() || Op.getReg() < X86::FP0 || Op.getReg() > X86::FP6)
+    if (!Op.isReg() || !isFPPhysReg(Op.getReg()))
       continue;
     // FP Register uses must be kills unless there are two uses of the same
     // register, in which case only one will be a kill.
@@ -1695,7 +1699,7 @@ void FPS::handleSpecialFP(MachineBasicBlock::iterator &Inst) {
     // and "f") to kill afer the instruction.
     unsigned FPKills = ((1u << NumFPRegs) - 1) & ~0xff;
     for (const MachineOperand &Op : MI.operands()) {
-      if (!Op.isReg() || Op.getReg() < X86::FP0 || Op.getReg() > X86::FP6)
+      if (!Op.isReg() || !isFPPhysReg(Op.getReg()))
         continue;
       unsigned FPReg = getFPReg(Op);
 
@@ -1724,7 +1728,7 @@ void FPS::handleSpecialFP(MachineBasicBlock::iterator &Inst) {
     // With the stack layout fixed, rewrite the FP registers.
     for (unsigned i = 0, e = MI.getNumOperands(); i != e; ++i) {
       MachineOperand &Op = MI.getOperand(i);
-      if (!Op.isReg() || Op.getReg() < X86::FP0 || Op.getReg() > X86::FP6)
+      if (!Op.isReg() || !isFPPhysReg(Op.getReg()))
         continue;
 
       unsigned FPReg = getFPReg(Op);

--- a/llvm/test/CodeGen/X86/avx512-regcall-NoMask.ll
+++ b/llvm/test/CodeGen/X86/avx512-regcall-NoMask.ll
@@ -488,6 +488,27 @@ define dso_local x86_regcallcc x86_fp80 @test_argRetf80(x86_fp80 %a0) nounwind {
   ret x86_fp80 %r0
 }
 
+; Test regcall when receiving two long double arguments in x87 registers.
+define dso_local x86_regcallcc x86_fp80 @test_arg2f80(x86_fp80 %a0, x86_fp80 %a1) nounwind {
+; X32-LABEL: test_arg2f80:
+; X32:       # %bb.0:
+; X32-NEXT:    faddp
+; X32-NEXT:    retl
+;
+; WIN64-LABEL: test_arg2f80:
+; WIN64:       # %bb.0:
+; WIN64-NEXT:    faddp
+; WIN64-NEXT:    retq
+;
+; LINUXOSX64-LABEL: test_arg2f80:
+; LINUXOSX64:       # %bb.0:
+; LINUXOSX64-NEXT:    faddp
+; LINUXOSX64-NOT:    fldt
+; LINUXOSX64-NEXT:    retq
+  %r0 = fadd x86_fp80 %a0, %a1
+  ret x86_fp80 %r0
+}
+
 ; Test regcall when receiving/returning long double
 define dso_local x86_regcallcc double @test_argParamf80(x86_fp80 %a0) nounwind {
 ; X32-LABEL: test_argParamf80:


### PR DESCRIPTION
Intel's regcall calling convention dictates that as many arguments as possible should be passed in registers. Previously, x86_fp80 (long double) arguments were falling back to suboptimal memory passing because the x87 stack registers were not fully exposed to the regcall allocation list. Additionally, vectorcall needed explicit documentation for its handling of f80 under MSVC environments, where long double is treated as a 64-bit double.