### PR TITLE
[lldb][test] Avoid namespace name colliding with dyld symbols in TestAbiTagLookup

### DIFF
--- a/lldb/test/API/lang/cpp/abi_tag_lookup/TestAbiTagLookup.py
+++ b/lldb/test/API/lang/cpp/abi_tag_lookup/TestAbiTagLookup.py
@@ -60,14 +60,18 @@ class AbiTagLookupTestCase(TestBase):
 
         # Inline namespaces with ABI tags
         self.expect_expr(
-            "v1::withImplicitTag(Simple{.mem = 6})", result_type="int", result_value="6"
+            "lldb_test_abi_tag_lookup_inline_ns::withImplicitTag(Simple{.mem = 6})",
+            result_type="int",
+            result_value="6",
         )
         self.expect_expr(
             "withImplicitTag(Simple{.mem = 6})", result_type="int", result_value="6"
         )
 
         self.expect_expr(
-            "v1::withImplicitTag(Tagged{.mem = 6})", result_type="int", result_value="6"
+            "lldb_test_abi_tag_lookup_inline_ns::withImplicitTag(Tagged{.mem = 6})",
+            result_type="int",
+            result_value="6",
         )
         self.expect_expr(
             "withImplicitTag(Tagged{.mem = 6})", result_type="int", result_value="6"

--- a/lldb/test/API/lang/cpp/abi_tag_lookup/main.cpp
+++ b/lldb/test/API/lang/cpp/abi_tag_lookup/main.cpp
@@ -49,7 +49,7 @@ template <typename T> struct [[gnu::abi_tag("Quux", "Quuux")]] TaggedTemplate {
 };
 
 // clang-format off
-inline namespace [[gnu::abi_tag("Inline", "NS")]] v1 {
+inline namespace [[gnu::abi_tag("Inline", "NS")]] lldb_test_abi_tag_lookup_inline_ns {
 template <typename T> int withImplicitTag(T const &t) { return t.mem; }
 } // namespace
 // clang-format on

--- a/lldb/test/API/lang/cpp/namespace_data_symbol_collision/Makefile
+++ b/lldb/test/API/lang/cpp/namespace_data_symbol_collision/Makefile
@@ -1,0 +1,10 @@
+CXX_SOURCES := main.cpp
+C_SOURCES := colliding_a.c colliding_b.c
+
+include Makefile.rules
+
+# The colliding_*.c files must be built WITHOUT debug info so that lldb sees
+# them only as bare symtab entries (eSymbolTypeData), the same situation as
+# the dyld globals that triggered the original failure.
+colliding_a.o: CFLAGS = $(CFLAGS_NO_DEBUG)
+colliding_b.o: CFLAGS = $(CFLAGS_NO_DEBUG)

--- a/lldb/test/API/lang/cpp/namespace_data_symbol_collision/TestNamespaceDataSymbolCollision.py
+++ b/lldb/test/API/lang/cpp/namespace_data_symbol_collision/TestNamespaceDataSymbolCollision.py
@@ -1,21 +1,10 @@
 """
-Standalone reproducer for the lookup failure originally seen in
-TestAbiTagLookup.py on Apple platforms, where the dyld shared cache
-happens to expose two internal data symbols literally named `v1`.
-
 This test plants two unrelated internal data symbols named
 `colliding_ns` in non-debug-info objects, then evaluates a qualified-id
 expression that uses `colliding_ns` as a (real) namespace prefix.
 
 Expected eventual behavior: the namespace resolution succeeds and the
 function call returns 6.
-
-Current behavior (XFAIL): ClangExpressionDeclMap falls through to
-SymbolContext::FindBestGlobalDataSymbol which sees two internal
-`colliding_ns` data symbols and raises
-  "error: Multiple internal symbols found for 'colliding_ns'"
-even though the name has already been resolved to a NamespaceDecl
-earlier in the same lookup.
 """
 
 import lldb
@@ -24,8 +13,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-class NamespaceDataSymbolCollisionTestCase(TestBase):
-    SHARED_BUILD_TESTCASE = False
+class TestCase(TestBase):
 
     @skipIfWindows
     @expectedFailureAll
@@ -39,7 +27,7 @@ class NamespaceDataSymbolCollisionTestCase(TestBase):
         # lldb's expression evaluator still runs FindBestGlobalDataSymbol on
         # the bare name, finds the two internal data symbols, and errors out.
         self.expect_expr(
-            "colliding_ns::do_thing(S{.mem = 6})",
+            "colliding_ns::do_thing(5)",
             result_type="int",
             result_value="6",
         )

--- a/lldb/test/API/lang/cpp/namespace_data_symbol_collision/TestNamespaceDataSymbolCollision.py
+++ b/lldb/test/API/lang/cpp/namespace_data_symbol_collision/TestNamespaceDataSymbolCollision.py
@@ -1,0 +1,45 @@
+"""
+Standalone reproducer for the lookup failure originally seen in
+TestAbiTagLookup.py on Apple platforms, where the dyld shared cache
+happens to expose two internal data symbols literally named `v1`.
+
+This test plants two unrelated internal data symbols named
+`colliding_ns` in non-debug-info objects, then evaluates a qualified-id
+expression that uses `colliding_ns` as a (real) namespace prefix.
+
+Expected eventual behavior: the namespace resolution succeeds and the
+function call returns 6.
+
+Current behavior (XFAIL): ClangExpressionDeclMap falls through to
+SymbolContext::FindBestGlobalDataSymbol which sees two internal
+`colliding_ns` data symbols and raises
+  "error: Multiple internal symbols found for 'colliding_ns'"
+even though the name has already been resolved to a NamespaceDecl
+earlier in the same lookup.
+"""
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class NamespaceDataSymbolCollisionTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
+    @skipIfWindows
+    @expectedFailureAll
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "Break here", lldb.SBFileSpec("main.cpp", False)
+        )
+
+        # The bug: even though `colliding_ns` is a namespace in the program,
+        # lldb's expression evaluator still runs FindBestGlobalDataSymbol on
+        # the bare name, finds the two internal data symbols, and errors out.
+        self.expect_expr(
+            "colliding_ns::do_thing(S{.mem = 6})",
+            result_type="int",
+            result_value="6",
+        )

--- a/lldb/test/API/lang/cpp/namespace_data_symbol_collision/TestNamespaceDataSymbolCollision.py
+++ b/lldb/test/API/lang/cpp/namespace_data_symbol_collision/TestNamespaceDataSymbolCollision.py
@@ -14,7 +14,6 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
-
     @skipIfWindows
     @expectedFailureAll
     def test(self):

--- a/lldb/test/API/lang/cpp/namespace_data_symbol_collision/colliding_a.c
+++ b/lldb/test/API/lang/cpp/namespace_data_symbol_collision/colliding_a.c
@@ -1,0 +1,6 @@
+// Internal (file-static) data symbol named `colliding_ns`. Built without
+// debug info, so lldb sees only the symtab entry, not a DWARF VarDecl.
+static const int colliding_ns __attribute__((used)) = 1;
+
+// Anchor referenced from main so the linker keeps the object alive.
+const int *colliding_a_anchor(void) { return &colliding_ns; }

--- a/lldb/test/API/lang/cpp/namespace_data_symbol_collision/colliding_b.c
+++ b/lldb/test/API/lang/cpp/namespace_data_symbol_collision/colliding_b.c
@@ -1,0 +1,7 @@
+// Second internal data symbol with the SAME name as the one in
+// colliding_a.c. Two such symbols in the target's symtab is what trips
+// SymbolContext::FindBestGlobalDataSymbol -> "Multiple internal symbols
+// found".
+static const int colliding_ns __attribute__((used)) = 2;
+
+const int *colliding_b_anchor(void) { return &colliding_ns; }

--- a/lldb/test/API/lang/cpp/namespace_data_symbol_collision/main.cpp
+++ b/lldb/test/API/lang/cpp/namespace_data_symbol_collision/main.cpp
@@ -1,0 +1,25 @@
+#include <cstdio>
+
+// `colliding_ns` is a real (inline) namespace in this translation unit.
+// Two unrelated internal data symbols of the same name live in
+// colliding_a.o / colliding_b.o (built without debug info).
+inline namespace colliding_ns {
+template <typename T> int do_thing(T const &t) { return t.mem; }
+} // namespace colliding_ns
+
+struct S {
+  int mem;
+};
+
+extern "C" const int *colliding_a_anchor(void);
+extern "C" const int *colliding_b_anchor(void);
+
+int main() {
+  // Force the linker to keep both internal `colliding_ns` data symbols.
+  (void)colliding_a_anchor();
+  (void)colliding_b_anchor();
+
+  int r = do_thing(S{.mem = 42});
+  std::puts("Break here");
+  return r;
+}

--- a/lldb/test/API/lang/cpp/namespace_data_symbol_collision/main.cpp
+++ b/lldb/test/API/lang/cpp/namespace_data_symbol_collision/main.cpp
@@ -1,15 +1,9 @@
-#include <cstdio>
-
 // `colliding_ns` is a real (inline) namespace in this translation unit.
 // Two unrelated internal data symbols of the same name live in
 // colliding_a.o / colliding_b.o (built without debug info).
 inline namespace colliding_ns {
-template <typename T> int do_thing(T const &t) { return t.mem; }
+int do_thing(int t) { return t + 1; }
 } // namespace colliding_ns
-
-struct S {
-  int mem;
-};
 
 extern "C" const int *colliding_a_anchor(void);
 extern "C" const int *colliding_b_anchor(void);
@@ -19,7 +13,6 @@ int main() {
   (void)colliding_a_anchor();
   (void)colliding_b_anchor();
 
-  int r = do_thing(S{.mem = 42});
-  std::puts("Break here");
-  return r;
+  int r = do_thing(5);
+  return r; // Break here
 }


### PR DESCRIPTION
TestAbiTagLookup.py used `v1` as the inline namespace name. On macOS the
dyld shared cache contains two unrelated internal data symbols named
`v1` (one in dyld, one in libdyld.dylib). When evaluating
`v1::withImplicitTag(...)`, `ClangExpressionDeclMap` resolves `v1` as a
namespace correctly, but then still falls through to
`SymbolContext::FindBestGlobalDataSymbol`, which finds the two dyld
symbols and raises "Multiple internal symbols found for 'v1'", failing
the test.

Rename the inline namespace to `lldb_test_abi_tag_lookup_inline_ns` so
the test no longer collides with anything in dyld.

Add a new XFAIL test, namespace_data_symbol_collision, that reproduces
the underlying bug deterministically (without depending on `dyld`) by
linking two non-debug-info objects that each define a static data
symbol whose name matches a real namespace in main.cpp.
