### PR TITLE
[AMDGPU] Guard against opsel selection in V_PK_*64

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
@@ -3610,6 +3610,14 @@ bool AMDGPUDAGToDAGISel::SelectVOP3PMods(SDValue In, SDValue &Src,
     Src = Src.getOperand(0);
   }
 
+  // 64-bit VOP3P instructions do not have OPSEL or ABS. Bail on v2f64 or v2i64.
+  // TODO: Select NEG_LO and NEG_HI modifiers from BUILD_VECTOR.
+  if (Src.getValueSizeInBits() == 128) {
+    Mods |= SISrcMods::OP_SEL_1; // Just the default, OPSEL unsupported.
+    SrcMods = CurDAG->getTargetConstant(Mods, SDLoc(In), MVT::i32);
+    return true;
+  }
+
   if (Src.getOpcode() == ISD::BUILD_VECTOR && Src.getNumOperands() == 2 &&
       (!IsDOT || !Subtarget->hasDOTOpSelHazard())) {
     unsigned VecMods = Mods;

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
@@ -5359,7 +5359,7 @@ std::pair<Register, unsigned> AMDGPUInstructionSelector::selectVOP3PModsImpl(
   else if (Stat.second == SrcStatus::IS_LO_NEG)
     Mods ^= SISrcMods::NEG;
 
-  // 64-bit VOP3P instructions do not have OPSEL or ABS.
+  // 64-bit VOP3P instructions do not have OPSEL or ABS. Bail on v2f64 or v2i64.
   // TODO: Select NEG_LO and NEG_HI modifiers from BUILD_VECTOR.
   if (MRI.getType(RootReg).getSizeInBits() == 128) {
     Mods |= SISrcMods::OP_SEL_1; // Just the default, OPSEL unsupported.


### PR DESCRIPTION
These instructions do not have OPSEL or ABS so bail on selection.
This does not affect any tests now because v2f64/v2i64 are not legal
for BUILD_VECTOR and alike, but if it is legal it will silently
produce incorrect code. GlobalISel already has this guard.
