### PR TITLE
[lldb] Strip code pointers in lldb-server test binary on arm64e

### DIFF
--- a/lldb/test/API/tools/lldb-server/main.cpp
+++ b/lldb/test/API/tools/lldb-server/main.cpp
@@ -330,6 +330,9 @@ int main(int argc, char **argv) {
         func_p = swap_chars;
 
       std::lock_guard<std::mutex> lock(g_print_mutex);
+#if defined(__arm64e__)
+      func_p = __builtin_ptrauth_strip(func_p, /*ptrauth_key_asib*/ 1);
+#endif
       printf("code address: %p\n", func_p);
     } else if (consume_front(arg, "call-function:")) {
       void (*func_p)() = nullptr;


### PR DESCRIPTION
Otherwise an unstripped pointer will be sent to debugserver. LLDB strips pointers before sending them to debugserver, so debugserver does not know how to handle it.

This fixes TestGdbRemoteSingleStep.py, TestGdbRemote_qMemoryRegion.py, and TestGdbRemote_vCont.py on arm64e.