### PR TITLE
[ACCRecipeMaterialization] add tests for private/firstprivate destroy

### DIFF
--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCRecipeMaterialization.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCRecipeMaterialization.cpp
@@ -120,9 +120,6 @@ static void cloneDestroy(RecipeOpTy recipe, mlir::Block *block,
                          const llvm::SmallVector<mlir::Value> &arguments) {
   IRMapping mapping{};
   Region &destroyRegion = recipe.getDestroyRegion();
-  llvm::dbgs() << "getNumArguments: "
-               << destroyRegion.getBlocks().front().getNumArguments() << "\n";
-  llvm::dbgs() << "arguments.size: " << arguments.size() << "\n";
   assert(destroyRegion.getBlocks().front().getNumArguments() ==
              arguments.size() &&
          "unexpected acc recipe destroy block arguments");

--- a/mlir/lib/Dialect/OpenACC/Transforms/ACCRecipeMaterialization.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/ACCRecipeMaterialization.cpp
@@ -120,6 +120,9 @@ static void cloneDestroy(RecipeOpTy recipe, mlir::Block *block,
                          const llvm::SmallVector<mlir::Value> &arguments) {
   IRMapping mapping{};
   Region &destroyRegion = recipe.getDestroyRegion();
+  llvm::dbgs() << "getNumArguments: "
+               << destroyRegion.getBlocks().front().getNumArguments() << "\n";
+  llvm::dbgs() << "arguments.size: " << arguments.size() << "\n";
   assert(destroyRegion.getBlocks().front().getNumArguments() ==
              arguments.size() &&
          "unexpected acc recipe destroy block arguments");
@@ -263,7 +266,7 @@ ACCRecipeMaterialization::materialize(OpTy op, RecipeOpTy recipe, AccOpTy accOp,
     if (!recipe.getDestroyRegion().empty()) {
       results.insert(results.begin(), origPtr);
       results.append(triples);
-      cloneDestroy(recipe, block, block->end(), results);
+      cloneDestroy(recipe, block, std::prev(block->end()), results);
     }
   } else if constexpr (std::is_same_v<OpTy, acc::FirstprivateOp>) {
     // Clone the init region for a firstprivate.
@@ -284,7 +287,7 @@ ACCRecipeMaterialization::materialize(OpTy op, RecipeOpTy recipe, AccOpTy accOp,
                             mapping, {});
     if (!recipe.getDestroyRegion().empty()) {
       // origPtr was already pushed.
-      cloneDestroy(recipe, block, block->end(), results);
+      cloneDestroy(recipe, block, std::prev(block->end()), results);
     }
   } else if constexpr (std::is_same_v<OpTy, acc::ReductionOp>) {
     auto cloneRegionIntoAccRegion = [&](Region *src, Region *dest,

--- a/mlir/test/Dialect/OpenACC/acc-recipe-materialization-firstprivate.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-recipe-materialization-firstprivate.mlir
@@ -9,6 +9,10 @@ acc.firstprivate.recipe @firstprivatization_memref_i32 : memref<i32> init {
   %0 = memref.load %arg0[] : memref<i32>
   memref.store %0, %arg1[] : memref<i32>
   acc.terminator
+} destroy {
+^bb0(%arg0: memref<i32>, %arg1: memref<i32>):
+  memref.dealloc %arg1 : memref<i32>  
+  acc.terminator
 }
 acc.private.recipe @privatization_memref_i32 : memref<i32> init {
 ^bb0(%arg0: memref<i32>):
@@ -27,6 +31,7 @@ acc.private.recipe @privatization_memref_i32 : memref<i32> init {
 // CHECK: %[[ALLOCALOAD:.*]] = memref.load %[[ALLOCA]][] : memref<i32>
 // CHECK: %[[ADDI:.*]] = arith.addi %[[ALLOCALOAD]], %c1{{.*}} : i32
 // CHECK: memref.store %[[ADDI]], %[[ALLOCA]][] : memref<i32>
+// CHECK: memref.dealloc %[[ALLOCA]] : memref<i32>
 
 func.func @firstpriv() {
   %c1336 = arith.constant 1336 : i32

--- a/mlir/test/Dialect/OpenACC/acc-recipe-materialization-private.mlir
+++ b/mlir/test/Dialect/OpenACC/acc-recipe-materialization-private.mlir
@@ -4,12 +4,17 @@ acc.private.recipe @privatization_memref_i64 : memref<i64> init {
 ^bb0(%arg0: memref<i64>):
   %0 = memref.alloca() : memref<i64>
   acc.yield %0 : memref<i64>
+} destroy {
+^bb0(%arg0: memref<i64>, %arg1: memref<i64>):
+  memref.dealloc %arg1 : memref<i64>
+  acc.terminator
 }
 
 // CHECK-LABEL: func.func @private_i64
 // CHECK: acc.loop control([[IV:%.+]] : index)
 // CHECK: [[ALLOC:%.+]] = memref.alloca() : memref<i64>
 // CHECK: memref.store {{.*}}, [[ALLOC]][]
+// CHECK: memref.dealloc [[ALLOC]] : memref<i64>
 
 func.func @private_i64(%arg0 : memref<i64>) {
   %c16 = arith.constant 16 : index


### PR DESCRIPTION
While working on #203935, I noticed that private and firstprivate recipes with destroy regions were not tested. Add these tests and fix a bug from the previous commit that would have been caught had these tests been fixed by generating the destroy region at the correct insertion point