### PR TITLE
[AArch64] Add scalable i128 costmodel test coverage. NFC

### DIFF
--- a/llvm/test/Analysis/CostModel/AArch64/sve-arith.ll
+++ b/llvm/test/Analysis/CostModel/AArch64/sve-arith.ll
@@ -3,74 +3,103 @@
 
 target triple = "aarch64-unknown-linux-gnu"
 
-define void @scalable_sdiv() #0 {
-; CHECK-LABEL: 'scalable_sdiv'
-; CHECK-NEXT:  Cost Model: Found costs of RThru:16 CodeSize:4 Lat:4 SizeLat:4 for: %sdiv_nxv16i8 = sdiv <vscale x 16 x i8> undef, undef
-; CHECK-NEXT:  Cost Model: Found costs of RThru:8 CodeSize:4 Lat:4 SizeLat:4 for: %sdiv_nxv8i16 = sdiv <vscale x 8 x i16> undef, undef
-; CHECK-NEXT:  Cost Model: Found costs of RThru:2 CodeSize:4 Lat:4 SizeLat:4 for: %sdiv_nxv4i32 = sdiv <vscale x 4 x i32> undef, undef
-; CHECK-NEXT:  Cost Model: Found costs of RThru:2 CodeSize:4 Lat:4 SizeLat:4 for: %sdiv_nxv2i64 = sdiv <vscale x 2 x i64> undef, undef
+define void @scalable_add() #0 {
+; CHECK-LABEL: 'scalable_add'
+; CHECK-NEXT:  Cost Model: Found costs of 1 for: %nxv16i8 = add <vscale x 16 x i8> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of 1 for: %nxv8i16 = add <vscale x 8 x i16> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of 1 for: %nxv4i32 = add <vscale x 4 x i32> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of 1 for: %nxv2i64 = add <vscale x 2 x i64> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of Invalid for: %nxv1i64 = add <vscale x 1 x i64> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of RThru:Invalid CodeSize:1 Lat:1 SizeLat:1 for: %nxv2i128 = add <vscale x 2 x i128> undef, undef
 ; CHECK-NEXT:  Cost Model: Found costs of RThru:0 CodeSize:1 Lat:1 SizeLat:1 for: ret void
 ;
 entry:
-  %sdiv_nxv16i8 = sdiv <vscale x 16 x i8> undef, undef
-  %sdiv_nxv8i16 = sdiv <vscale x 8 x i16> undef, undef
-  %sdiv_nxv4i32 = sdiv <vscale x 4 x i32> undef, undef
-  %sdiv_nxv2i64 = sdiv <vscale x 2 x i64> undef, undef
+  %nxv16i8 = add <vscale x 16 x i8> undef, undef
+  %nxv8i16 = add <vscale x 8 x i16> undef, undef
+  %nxv4i32 = add <vscale x 4 x i32> undef, undef
+  %nxv2i64 = add <vscale x 2 x i64> undef, undef
+  %nxv1i64 = add <vscale x 1 x i64> undef, undef
+  %nxv2i128 = add <vscale x 2 x i128> undef, undef
 
   ret void
 }
 
-define void @scalable_udiv() #0 {
-; CHECK-LABEL: 'scalable_udiv'
-; CHECK-NEXT:  Cost Model: Found costs of RThru:16 CodeSize:4 Lat:4 SizeLat:4 for: %udiv_nxv16i8 = udiv <vscale x 16 x i8> undef, undef
-; CHECK-NEXT:  Cost Model: Found costs of RThru:8 CodeSize:4 Lat:4 SizeLat:4 for: %udiv_nxv8i16 = udiv <vscale x 8 x i16> undef, undef
-; CHECK-NEXT:  Cost Model: Found costs of RThru:2 CodeSize:4 Lat:4 SizeLat:4 for: %udiv_nxv4i32 = udiv <vscale x 4 x i32> undef, undef
-; CHECK-NEXT:  Cost Model: Found costs of RThru:2 CodeSize:4 Lat:4 SizeLat:4 for: %udiv_nxv2i64 = udiv <vscale x 2 x i64> undef, undef
+define void @scalable_sub() #0 {
+; CHECK-LABEL: 'scalable_sub'
+; CHECK-NEXT:  Cost Model: Found costs of 1 for: %nxv16i8 = sub <vscale x 16 x i8> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of 1 for: %nxv8i16 = sub <vscale x 8 x i16> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of 1 for: %nxv4i32 = sub <vscale x 4 x i32> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of 1 for: %nxv2i64 = sub <vscale x 2 x i64> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of Invalid for: %nxv1i64 = sub <vscale x 1 x i64> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of RThru:Invalid CodeSize:1 Lat:1 SizeLat:1 for: %nxv2i128 = sub <vscale x 2 x i128> undef, undef
 ; CHECK-NEXT:  Cost Model: Found costs of RThru:0 CodeSize:1 Lat:1 SizeLat:1 for: ret void
 ;
 entry:
-  %udiv_nxv16i8 = udiv <vscale x 16 x i8> undef, undef
-  %udiv_nxv8i16 = udiv <vscale x 8 x i16> undef, undef
-  %udiv_nxv4i32 = udiv <vscale x 4 x i32> undef, undef
-  %udiv_nxv2i64 = udiv <vscale x 2 x i64> undef, undef
+  %nxv16i8 = sub <vscale x 16 x i8> undef, undef
+  %nxv8i16 = sub <vscale x 8 x i16> undef, undef
+  %nxv4i32 = sub <vscale x 4 x i32> undef, undef
+  %nxv2i64 = sub <vscale x 2 x i64> undef, undef
+  %nxv1i64 = sub <vscale x 1 x i64> undef, undef
+  %nxv2i128 = sub <vscale x 2 x i128> undef, undef
 
   ret void
 }
 
 define void @scalable_mul() #0 {
 ; CHECK-LABEL: 'scalable_mul'
-; CHECK-NEXT:  Cost Model: Found costs of 1 for: %mul_nxv16i8 = mul <vscale x 16 x i8> undef, undef
-; CHECK-NEXT:  Cost Model: Found costs of 1 for: %mul_nxv8i16 = mul <vscale x 8 x i16> undef, undef
-; CHECK-NEXT:  Cost Model: Found costs of 1 for: %mul_nxv4i32 = mul <vscale x 4 x i32> undef, undef
-; CHECK-NEXT:  Cost Model: Found costs of 1 for: %mul_nxv2i64 = mul <vscale x 2 x i64> undef, undef
-; CHECK-NEXT:  Cost Model: Found costs of Invalid for: %mul_nxv1i64 = mul <vscale x 1 x i64> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of 1 for: %nxv16i8 = mul <vscale x 16 x i8> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of 1 for: %nxv8i16 = mul <vscale x 8 x i16> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of 1 for: %nxv4i32 = mul <vscale x 4 x i32> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of 1 for: %nxv2i64 = mul <vscale x 2 x i64> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of Invalid for: %nxv1i64 = mul <vscale x 1 x i64> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of RThru:Invalid CodeSize:1 Lat:1 SizeLat:1 for: %nxv2i128 = mul <vscale x 2 x i128> undef, undef
 ; CHECK-NEXT:  Cost Model: Found costs of RThru:0 CodeSize:1 Lat:1 SizeLat:1 for: ret void
 ;
 entry:
-  %mul_nxv16i8 = mul <vscale x 16 x i8> undef, undef
-  %mul_nxv8i16 = mul <vscale x 8 x i16> undef, undef
-  %mul_nxv4i32 = mul <vscale x 4 x i32> undef, undef
-  %mul_nxv2i64 = mul <vscale x 2 x i64> undef, undef
-  %mul_nxv1i64 = mul <vscale x 1 x i64> undef, undef
+  %nxv16i8 = mul <vscale x 16 x i8> undef, undef
+  %nxv8i16 = mul <vscale x 8 x i16> undef, undef
+  %nxv4i32 = mul <vscale x 4 x i32> undef, undef
+  %nxv2i64 = mul <vscale x 2 x i64> undef, undef
+  %nxv1i64 = mul <vscale x 1 x i64> undef, undef
+  %nxv2i128 = mul <vscale x 2 x i128> undef, undef
 
   ret void
 }
 
-define void @scalable_add() #0 {
-; CHECK-LABEL: 'scalable_add'
-; CHECK-NEXT:  Cost Model: Found costs of 1 for: %add_nxv16i8 = add <vscale x 16 x i8> undef, undef
-; CHECK-NEXT:  Cost Model: Found costs of 1 for: %add_nxv8i16 = add <vscale x 8 x i16> undef, undef
-; CHECK-NEXT:  Cost Model: Found costs of 1 for: %add_nxv4i32 = add <vscale x 4 x i32> undef, undef
-; CHECK-NEXT:  Cost Model: Found costs of 1 for: %add_nxv2i64 = add <vscale x 2 x i64> undef, undef
-; CHECK-NEXT:  Cost Model: Found costs of Invalid for: %add_nxv1i64 = add <vscale x 1 x i64> undef, undef
+define void @scalable_sdiv() #0 {
+; CHECK-LABEL: 'scalable_sdiv'
+; CHECK-NEXT:  Cost Model: Found costs of RThru:16 CodeSize:4 Lat:4 SizeLat:4 for: %nxv16i8 = sdiv <vscale x 16 x i8> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of RThru:8 CodeSize:4 Lat:4 SizeLat:4 for: %nxv8i16 = sdiv <vscale x 8 x i16> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of RThru:2 CodeSize:4 Lat:4 SizeLat:4 for: %nxv4i32 = sdiv <vscale x 4 x i32> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of RThru:2 CodeSize:4 Lat:4 SizeLat:4 for: %nxv2i64 = sdiv <vscale x 2 x i64> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of RThru:Invalid CodeSize:4 Lat:4 SizeLat:4 for: %nxv2i128 = sdiv <vscale x 2 x i128> undef, undef
 ; CHECK-NEXT:  Cost Model: Found costs of RThru:0 CodeSize:1 Lat:1 SizeLat:1 for: ret void
 ;
 entry:
-  %add_nxv16i8 = add <vscale x 16 x i8> undef, undef
-  %add_nxv8i16 = add <vscale x 8 x i16> undef, undef
-  %add_nxv4i32 = add <vscale x 4 x i32> undef, undef
-  %add_nxv2i64 = add <vscale x 2 x i64> undef, undef
-  %add_nxv1i64 = add <vscale x 1 x i64> undef, undef
+  %nxv16i8 = sdiv <vscale x 16 x i8> undef, undef
+  %nxv8i16 = sdiv <vscale x 8 x i16> undef, undef
+  %nxv4i32 = sdiv <vscale x 4 x i32> undef, undef
+  %nxv2i64 = sdiv <vscale x 2 x i64> undef, undef
+  %nxv2i128 = sdiv <vscale x 2 x i128> undef, undef
+
+  ret void
+}
+
+define void @scalable_udiv() #0 {
+; CHECK-LABEL: 'scalable_udiv'
+; CHECK-NEXT:  Cost Model: Found costs of RThru:16 CodeSize:4 Lat:4 SizeLat:4 for: %nxv16i8 = udiv <vscale x 16 x i8> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of RThru:8 CodeSize:4 Lat:4 SizeLat:4 for: %nxv8i16 = udiv <vscale x 8 x i16> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of RThru:2 CodeSize:4 Lat:4 SizeLat:4 for: %nxv4i32 = udiv <vscale x 4 x i32> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of RThru:2 CodeSize:4 Lat:4 SizeLat:4 for: %nxv2i64 = udiv <vscale x 2 x i64> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of RThru:Invalid CodeSize:4 Lat:4 SizeLat:4 for: %nxv2i128 = udiv <vscale x 2 x i128> undef, undef
+; CHECK-NEXT:  Cost Model: Found costs of RThru:0 CodeSize:1 Lat:1 SizeLat:1 for: ret void
+;
+entry:
+  %nxv16i8 = udiv <vscale x 16 x i8> undef, undef
+  %nxv8i16 = udiv <vscale x 8 x i16> undef, undef
+  %nxv4i32 = udiv <vscale x 4 x i32> undef, undef
+  %nxv2i64 = udiv <vscale x 2 x i64> undef, undef
+  %nxv2i128 = udiv <vscale x 2 x i128> undef, undef
 
   ret void
 }


### PR DESCRIPTION
This also adds some basic sub costs, similar to the others, and sorts the
operations into a more standard order.