### PR TITLE
[lldb] Decouple LLDB_EXPORT_ALL_SYMBOLS from dynamic interpreters

### DIFF
--- a/lldb/cmake/modules/AddLLDB.cmake
+++ b/lldb/cmake/modules/AddLLDB.cmake
@@ -347,10 +347,12 @@ function(add_lldb_library name)
     set_target_properties(${name} PROPERTIES FOLDER "LLDB/Libraries")
   endif()
 
-  # If we want to export all lldb symbols (i.e LLDB_EXPORT_ALL_SYMBOLS=ON), we
-  # need to use default visibility for all LLDB libraries even if a global
-  # `CMAKE_CXX_VISIBILITY_PRESET=hidden`is present.
-  if (LLDB_EXPORT_ALL_SYMBOLS)
+  # When liblldb re-exports private symbols (due to LLDB_EXPORT_ALL_SYMBOLS
+  # and/or LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS) those symbols must keep
+  # default visibility in the contributing libraries, even if a global
+  # `CMAKE_CXX_VISIBILITY_PRESET=hidden` is present. A linker version script
+  # cannot re-export a symbol that was hidden at compile time.
+  if (LLDB_EXPORT_ALL_SYMBOLS OR LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS)
     set_target_properties(${name} PROPERTIES CXX_VISIBILITY_PRESET default)
   endif()
 endfunction(add_lldb_library)

--- a/lldb/cmake/modules/LLDBConfig.cmake
+++ b/lldb/cmake/modules/LLDBConfig.cmake
@@ -131,12 +131,8 @@ if(APPLE AND CMAKE_GENERATOR STREQUAL Xcode)
   endif()
 endif()
 
-set(LLDB_EXPORT_ALL_SYMBOLS ${LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS} CACHE BOOL
-  "Causes lldb to export some private symbols when building liblldb. See lldb/source/API/liblldb-private.exports for the full list of symbols that get exported.")
-
-if (LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS AND NOT LLDB_EXPORT_ALL_SYMBOLS)
-  message(FATAL_ERROR "LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS requires LLDB_EXPORT_ALL_SYMBOLS")
-endif()
+set(LLDB_EXPORT_ALL_SYMBOLS OFF CACHE BOOL
+  "Causes lldb to export all private symbols when building liblldb. See lldb/source/API/liblldb-private.exports for the full list of symbols that get exported.")
 
 set(LLDB_EXPORT_ALL_SYMBOLS_EXPORTS_FILE "" CACHE PATH
   "When `LLDB_EXPORT_ALL_SYMBOLS` is enabled, this specifies the exports file to use when building liblldb.")

--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -159,7 +159,20 @@ set_target_properties(liblldb
 
 target_compile_definitions(liblldb PRIVATE LLDB_IN_LIBLLDB)
 if (NOT CMAKE_SYSTEM_NAME MATCHES "Windows")
-  if (LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS AND NOT LLDB_EXPORT_ALL_SYMBOLS_EXPORTS_FILE)
+  if (LLDB_EXPORT_ALL_SYMBOLS)
+    if (LLDB_EXPORT_ALL_SYMBOLS_EXPORTS_FILE)
+      message(STATUS "Symbols (liblldb): exporting all symbols specified in the exports "
+              " file '${LLDB_EXPORT_ALL_SYMBOLS_EXPORTS_FILE}'")
+      message(WARNING "Private LLDB symbols frequently change and no API stability is guaranteed. "
+                      "Only the SB API is guaranteed to be stable.")
+      add_llvm_symbol_exports(liblldb "${LLDB_EXPORT_ALL_SYMBOLS_EXPORTS_FILE}")
+    else ()
+      message(STATUS "Symbols (liblldb): exporting all symbols from the lldb and lldb_private namespaces")
+      message(WARNING "Private LLDB symbols frequently change and no API stability is guaranteed. "
+                      "Only the SB API is guaranteed to be stable.")
+      add_llvm_symbol_exports(liblldb ${CMAKE_CURRENT_SOURCE_DIR}/liblldb-private.exports)
+    endif()
+  elseif (LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS)
     # Each script interpreter plugin contributes a list of its undefined
     # LLDB symbols. Concatenating those with liblldb.exports yields the
     # smallest export set that satisfies dynamically loaded plugins.
@@ -186,28 +199,18 @@ if (NOT CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(STATUS "Symbols (liblldb): exporting the lldb namespace plus "
                    "script interpreter dependencies")
     lldb_apply_exports_file(liblldb ${generated_exports_file})
-  elseif (NOT LLDB_EXPORT_ALL_SYMBOLS)
+  else ()
     # If we're not exporting all symbols, we'll want to explicitly set
     # the exported symbols here.  This prevents 'log enable --stack ...'
     # from working on some systems but limits the liblldb size.
     message(STATUS "Symbols (liblldb): exporting all symbols from the lldb namespace")
     add_llvm_symbol_exports(liblldb ${CMAKE_CURRENT_SOURCE_DIR}/liblldb.exports)
-  elseif (NOT LLDB_EXPORT_ALL_SYMBOLS_EXPORTS_FILE)
-    # Don't use an explicit export. Instead, tell the linker to export all symbols.
-    message(STATUS "Symbols (liblldb): exporting all symbols from the lldb and lldb_private namespaces")
-    message(WARNING "Private LLDB symbols frequently change and no API stability is guaranteed. "
-                    "Only the SB API is guaranteed to be stable.")
-    add_llvm_symbol_exports(liblldb ${CMAKE_CURRENT_SOURCE_DIR}/liblldb-private.exports)
-  else ()
-    message(STATUS "Symbols (liblldb): exporting all symbols specified in the exports "
-            " file '${LLDB_EXPORT_ALL_SYMBOLS_EXPORTS_FILE}'")
-    message(WARNING "Private LLDB symbols frequently change and no API stability is guaranteed. "
-                    "Only the SB API is guaranteed to be stable.")
-    add_llvm_symbol_exports(liblldb "${LLDB_EXPORT_ALL_SYMBOLS_EXPORTS_FILE}")
   endif()
-elseif (LLDB_EXPORT_ALL_SYMBOLS)
+elseif (LLDB_EXPORT_ALL_SYMBOLS OR LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS)
+  # On Windows there is no per-plugin symbol extraction, so dynamically loaded
+  # script interpreter plugins resolve their imports against the full set of
+  # private symbols, same as LLDB_EXPORT_ALL_SYMBOLS.
   message(STATUS "Symbols (liblldb): exporting all symbols from the lldb and lldb_private namespaces")
-
   # Pull out the various lldb libraries linked into liblldb, these will be used
   # when looking for symbols to extract. We ignore most plugin libraries here,
   # because we may expose more symbols than the DLL limit and these symbols


### PR DESCRIPTION
With #201392, we  generate a minimal export list when LLDB_ENABLE_ DYNAMIC_SCRIPTINTERPRETERS is set. We therefore no longer need to force LLDB_EXPORT_ALL_SYMBOLS.

This PR makes the two options independent again. LLDB_EXPORT_ALL_SYMBOLS now defaults to OFF and, when set, is honored regardless of whether the script interpreters are built as static or dynamic libraries. otherwise, when disabled, liblldb exports the generated subset if dynamic interpreters are enabled, otherwise only the public lldb namespace.