### PR TITLE
[lit] Avoid profraw filename collisions with --per-test-coverage

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1802,10 +1802,10 @@ def _runShTest(test, litConfig, useExternalSh, script, tmpBase) -> lit.Test.Resu
         scriptCopy = script[:]
         # Set unique LLVM_PROFILE_FILE for each run command
         if litConfig.per_test_coverage:
-            # Extract the test case name from the test object, and remove the
-            # file extension.
-            test_case_name = test.path_in_suite[-1]
-            test_case_name = test_case_name.rsplit(".", 1)[0]
+            # Use the test's full path in the suite, plus the %p (pid) and %m
+            # (binary signature) runtime placeholders, so that distinct tests,
+            # processes, and instrumented binaries don't share a profraw file.
+            test_case_name = "_".join(test.path_in_suite)
             coverage_index = 0  # Counter for coverage file index
             for i, ln in enumerate(scriptCopy):
                 match = re.fullmatch(kPdbgRegex, ln)
@@ -1814,7 +1814,7 @@ def _runShTest(test, litConfig, useExternalSh, script, tmpBase) -> lit.Test.Resu
                     command = match.group(2)
                 else:
                     command = ln
-                profile = f"{test_case_name}{coverage_index}.profraw"
+                profile = f"{test_case_name}-%p-%m{coverage_index}.profraw"
                 coverage_index += 1
                 command = f"export LLVM_PROFILE_FILE={profile}; {command}"
                 if match:

--- a/llvm/utils/lit/tests/Inputs/per-test-coverage-by-lit-cfg/name-collision/a/test.py
+++ b/llvm/utils/lit/tests/Inputs/per-test-coverage-by-lit-cfg/name-collision/a/test.py
@@ -1,0 +1,8 @@
+# RUN: %{python} %s | FileCheck -DINDEX=1 %s
+# RUN: %{python} %s | FileCheck -DINDEX=2 %s
+
+import os
+
+print(os.environ.get("LLVM_PROFILE_FILE"))
+
+# CHECK: name-collision_a_test.py-%p-%m[[INDEX]].profraw

--- a/llvm/utils/lit/tests/Inputs/per-test-coverage-by-lit-cfg/name-collision/b/test.py
+++ b/llvm/utils/lit/tests/Inputs/per-test-coverage-by-lit-cfg/name-collision/b/test.py
@@ -1,0 +1,8 @@
+# RUN: %{python} %s | FileCheck -DINDEX=1 %s
+# RUN: %{python} %s | FileCheck -DINDEX=2 %s
+
+import os
+
+print(os.environ.get("LLVM_PROFILE_FILE"))
+
+# CHECK: name-collision_b_test.py-%p-%m[[INDEX]].profraw

--- a/llvm/utils/lit/tests/Inputs/per-test-coverage-by-lit-cfg/per-test-coverage-by-lit-cfg.py
+++ b/llvm/utils/lit/tests/Inputs/per-test-coverage-by-lit-cfg/per-test-coverage-by-lit-cfg.py
@@ -9,4 +9,4 @@ import os
 llvm_profile_file = os.environ.get('LLVM_PROFILE_FILE')
 print(llvm_profile_file)
 
-# CHECK: per-test-coverage-by-lit-cfg[[INDEX]].profraw
+# CHECK: per-test-coverage-by-lit-cfg.py-%p-%m[[INDEX]].profraw

--- a/llvm/utils/lit/tests/Inputs/per-test-coverage/per-test-coverage.py
+++ b/llvm/utils/lit/tests/Inputs/per-test-coverage/per-test-coverage.py
@@ -9,4 +9,4 @@ import os
 llvm_profile_file = os.environ.get('LLVM_PROFILE_FILE')
 print(llvm_profile_file)
 
-# CHECK: per-test-coverage[[INDEX]].profraw
+# CHECK: per-test-coverage.py-%p-%m[[INDEX]].profraw

--- a/llvm/utils/lit/tests/per-test-coverage-by-lit-cfg.py
+++ b/llvm/utils/lit/tests/per-test-coverage-by-lit-cfg.py
@@ -12,13 +12,21 @@
 #      CHECK: Command Output ([[OUT]]):
 # CHECK-NEXT: --
 #      CHECK: export
-#      CHECK: LLVM_PROFILE_FILE=per-test-coverage-by-lit-cfg0.profraw
+#      CHECK: LLVM_PROFILE_FILE=per-test-coverage-by-lit-cfg.py-%p-%m0.profraw
 #      CHECK: per-test-coverage-by-lit-cfg.py
 #      CHECK: {{RUN}}: at line 2
 #      CHECK: export
-#      CHECK: LLVM_PROFILE_FILE=per-test-coverage-by-lit-cfg1.profraw
+#      CHECK: LLVM_PROFILE_FILE=per-test-coverage-by-lit-cfg.py-%p-%m1.profraw
 #      CHECK: per-test-coverage-by-lit-cfg.py
 #      CHECK: {{RUN}}: at line 3
 #      CHECK: export
-#      CHECK: LLVM_PROFILE_FILE=per-test-coverage-by-lit-cfg2.profraw
+#      CHECK: LLVM_PROFILE_FILE=per-test-coverage-by-lit-cfg.py-%p-%m2.profraw
 #      CHECK: per-test-coverage-by-lit-cfg.py
+
+# Sibling tests sharing a basename in different directories must get distinct profile filenames.
+# RUN: %{lit} -a -Dexecute_external=False \
+# RUN:     %{inputs}/per-test-coverage-by-lit-cfg/name-collision | \
+# RUN:   FileCheck -check-prefix=COLLISION %s
+
+# COLLISION-DAG: LLVM_PROFILE_FILE=name-collision_a_test.py-%p-%m0.profraw
+# COLLISION-DAG: LLVM_PROFILE_FILE=name-collision_b_test.py-%p-%m0.profraw

--- a/llvm/utils/lit/tests/per-test-coverage.py
+++ b/llvm/utils/lit/tests/per-test-coverage.py
@@ -12,13 +12,13 @@
 #      CHECK: Command Output ([[OUT]]):
 # CHECK-NEXT: --
 #      CHECK: export
-#      CHECK: LLVM_PROFILE_FILE=per-test-coverage0.profraw
+#      CHECK: LLVM_PROFILE_FILE=per-test-coverage.py-%p-%m0.profraw
 #      CHECK: per-test-coverage.py
 #      CHECK: {{RUN}}: at line 2
 #      CHECK: export
-#      CHECK: LLVM_PROFILE_FILE=per-test-coverage1.profraw
+#      CHECK: LLVM_PROFILE_FILE=per-test-coverage.py-%p-%m1.profraw
 #      CHECK: per-test-coverage.py
 #      CHECK: {{RUN}}: at line 3
 #      CHECK: export
-#      CHECK: LLVM_PROFILE_FILE=per-test-coverage2.profraw
+#      CHECK: LLVM_PROFILE_FILE=per-test-coverage.py-%p-%m2.profraw
 #      CHECK: per-test-coverage.py


### PR DESCRIPTION
Per-test-coverage derived the `LLVM_PROFILE_FILE` name from the test's basename with its extension removed, so siblings that share a basename but differ by directory or extension (e.g. foo.c and foo.cpp in one directory) wrote into the same profraw file and raced on it.

This PR builds the name from the full path in the suite and adds the `%p` and `%m` placeholders so a test that runs several instrumented binaries gets a distinct file per process and per binary, even across exec chains or recycled process ids.