### PR TITLE
[InstrProf] Bounds-check readAndDecodeStrings against malformed symtabs

### DIFF
--- a/llvm/lib/ProfileData/InstrProf.cpp
+++ b/llvm/lib/ProfileData/InstrProf.cpp
@@ -575,15 +575,23 @@ Error readAndDecodeStrings(StringRef NameStrings,
   const uint8_t *P = NameStrings.bytes_begin();
   const uint8_t *EndP = NameStrings.bytes_end();
   while (P < EndP) {
-    uint32_t N;
-    uint64_t UncompressedSize = decodeULEB128(P, &N);
+    unsigned N;
+    const char *ULEBError = nullptr;
+    uint64_t UncompressedSize = decodeULEB128(P, &N, EndP, &ULEBError);
+    if (ULEBError)
+      return make_error<InstrProfError>(instrprof_error::truncated);
     P += N;
-    uint64_t CompressedSize = decodeULEB128(P, &N);
+    uint64_t CompressedSize = decodeULEB128(P, &N, EndP, &ULEBError);
+    if (ULEBError)
+      return make_error<InstrProfError>(instrprof_error::truncated);
     P += N;
     const bool IsCompressed = (CompressedSize != 0);
     SmallVector<uint8_t, 128> UncompressedNameStrings;
     StringRef NameStrings;
     if (IsCompressed) {
+      if (CompressedSize > (uint64_t)(EndP - P))
+        return make_error<InstrProfError>(instrprof_error::truncated);
+
       if (!llvm::compression::zlib::isAvailable())
         return make_error<InstrProfError>(instrprof_error::zlib_unavailable);
 
@@ -596,6 +604,8 @@ Error readAndDecodeStrings(StringRef NameStrings,
       P += CompressedSize;
       NameStrings = toStringRef(UncompressedNameStrings);
     } else {
+      if (UncompressedSize > (uint64_t)(EndP - P))
+        return make_error<InstrProfError>(instrprof_error::truncated);
       NameStrings =
           StringRef(reinterpret_cast<const char *>(P), UncompressedSize);
       P += UncompressedSize;

--- a/llvm/unittests/ProfileData/InstrProfTest.cpp
+++ b/llvm/unittests/ProfileData/InstrProfTest.cpp
@@ -1660,6 +1660,36 @@ TEST(SymtabTest, instr_prof_bogus_symtab_empty_func_name) {
   EXPECT_TRUE(ErrorEquals(instrprof_error::malformed, Symtab.addFuncName("")));
 }
 
+// A malformed name-strings buffer must produce an error rather than reading
+// past the end of the buffer.
+TEST(SymtabTest, instr_prof_malformed_name_strings) {
+  auto NoopCallback = [](StringRef) { return Error::success(); };
+
+  // Truncated ULEB128 length: a lone continuation byte with nothing after it.
+  {
+    const char Data[] = {'\x80'};
+    EXPECT_TRUE(ErrorEquals(
+        instrprof_error::truncated,
+        readAndDecodeStrings(StringRef(Data, sizeof(Data)), NoopCallback)));
+  }
+
+  // Uncompressed size (100) larger than the remaining buffer.
+  {
+    const char Data[] = {'\x64', '\x00'};
+    EXPECT_TRUE(ErrorEquals(
+        instrprof_error::truncated,
+        readAndDecodeStrings(StringRef(Data, sizeof(Data)), NoopCallback)));
+  }
+
+  // Compressed size (100) larger than the remaining buffer.
+  {
+    const char Data[] = {'\x0a', '\x64'};
+    EXPECT_TRUE(ErrorEquals(
+        instrprof_error::truncated,
+        readAndDecodeStrings(StringRef(Data, sizeof(Data)), NoopCallback)));
+  }
+}
+
 // Testing symtab creator interface used by value profile transformer.
 TEST(SymtabTest, instr_prof_symtab_module_test) {
   LLVMContext Ctx;


### PR DESCRIPTION
`readAndDecodeStrings` decodes the name-strings symtab with the unchecked `decodeULEB128` overload and builds a `StringRef` from a length that could extend past the buffer, so a truncated or malformed profraw makes the following `split()` walk off the end of the buffer and crash. 

This PR uses the bounds-checked decoder and rejects sizes larger than the remaining buffer, returning `instrprof_error::truncated`.