### PR TITLE
[libc][getcwd] Refactor getcwd to use the syscall wrapper pattern

### DIFF
--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/CMakeLists.txt
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/CMakeLists.txt
@@ -543,6 +543,20 @@ add_header_library(
 )
 
 add_header_library(
+  getcwd
+  HDRS
+    getcwd.h
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.hdr.types.ssize_t
+    libc.include.sys_syscall
+    libc.src.__support.common
+    libc.src.__support.error_or
+    libc.src.__support.macros.config
+    libc.src.__support.OSUtil.osutil
+)
+
+add_header_library(
   link
   HDRS
     link.h

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/getcwd.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/getcwd.h
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Syscall wrapper for getcwd.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_GETCWD_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_GETCWD_H
+
+#include "hdr/errno_macros.h"
+#include "hdr/types/ssize_t.h"
+#include "src/__support/OSUtil/linux/syscall.h" // syscall_impl
+#include "src/__support/common.h"
+#include "src/__support/error_or.h"
+#include "src/__support/macros/config.h"
+
+#include <sys/syscall.h> // For syscall numbers
+
+namespace LIBC_NAMESPACE_DECL {
+namespace linux_syscalls {
+
+ErrorOr<ssize_t> getcwd(char *buf, size_t size) {
+  ssize_t ret = syscall_impl<ssize_t>(SYS_getcwd, buf, size);
+  if (ret < 0) {
+    return Error(static_cast<int>(-ret));
+  }
+
+  // Return ENOENT for unreachable paths. This can occur, for example,
+  // when getcwd is called in a directory after `chroot` has switched
+  // the filesystem root.
+  if (ret == 0 || buf[0] != '/') {
+    return Error(ENOENT);
+  }
+
+  return ret;
+}
+
+} // namespace linux_syscalls
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_SYSCALL_WRAPPERS_GETCWD_H

--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/getcwd.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/getcwd.h
@@ -26,7 +26,7 @@
 namespace LIBC_NAMESPACE_DECL {
 namespace linux_syscalls {
 
-ErrorOr<ssize_t> getcwd(char *buf, size_t size) {
+LIBC_INLINE ErrorOr<ssize_t> getcwd(char *buf, size_t size) {
   ssize_t ret = syscall_impl<ssize_t>(SYS_getcwd, buf, size);
   if (ret < 0) {
     return Error(static_cast<int>(-ret));

--- a/libc/src/unistd/linux/CMakeLists.txt
+++ b/libc/src/unistd/linux/CMakeLists.txt
@@ -224,12 +224,12 @@ add_entrypoint_object(
   DEPENDS
     libc.hdr.types.size_t
     libc.hdr.types.ssize_t
-    libc.include.sys_syscall
-    libc.include.unistd
+    libc.src.__support.common
     libc.src.__support.CPP.optional
+    libc.src.__support.macros.config
     libc.src.__support.OSUtil.linux.syscall_wrappers.getcwd
-    libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
+    libc.src.string.allocating_string_utils
 )
 
 add_entrypoint_object(

--- a/libc/src/unistd/linux/CMakeLists.txt
+++ b/libc/src/unistd/linux/CMakeLists.txt
@@ -223,9 +223,11 @@ add_entrypoint_object(
     ../getcwd.h
   DEPENDS
     libc.hdr.types.size_t
-    libc.hdr.fcntl_macros
-    libc.include.unistd
+    libc.hdr.types.ssize_t
     libc.include.sys_syscall
+    libc.include.unistd
+    libc.src.__support.CPP.optional
+    libc.src.__support.OSUtil.linux.syscall_wrappers.getcwd
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
 )

--- a/libc/src/unistd/linux/getcwd.cpp
+++ b/libc/src/unistd/linux/getcwd.cpp
@@ -12,14 +12,12 @@
 #include "hdr/types/ssize_t.h"
 #include "src/__support/CPP/optional.h"
 #include "src/__support/OSUtil/linux/syscall_wrappers/getcwd.h"
-#include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 #include "src/string/allocating_string_utils.h" // For strdup.
 
 #include <linux/limits.h> // This is safe to include without any name pollution.
-#include <sys/syscall.h>  // For syscall numbers.
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/linux/getcwd.cpp
+++ b/libc/src/unistd/linux/getcwd.cpp
@@ -8,32 +8,20 @@
 
 #include "src/unistd/getcwd.h"
 
+#include "hdr/types/size_t.h"
+#include "hdr/types/ssize_t.h"
+#include "src/__support/CPP/optional.h"
+#include "src/__support/OSUtil/linux/syscall_wrappers/getcwd.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 #include "src/string/allocating_string_utils.h" // For strdup.
 
-#include "src/__support/libc_errno.h"
 #include <linux/limits.h> // This is safe to include without any name pollution.
-#include <sys/syscall.h> // For syscall numbers.
+#include <sys/syscall.h>  // For syscall numbers.
 
 namespace LIBC_NAMESPACE_DECL {
-
-namespace {
-
-bool getcwd_syscall(char *buf, size_t size) {
-  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_getcwd, buf, size);
-  if (ret < 0) {
-    libc_errno = -ret;
-    return false;
-  } else if (ret == 0 || buf[0] != '/') {
-    libc_errno = ENOENT;
-    return false;
-  }
-  return true;
-}
-
-} // anonymous namespace
 
 LLVM_LIBC_FUNCTION(char *, getcwd, (char *buf, size_t size)) {
   if (buf == nullptr) {
@@ -42,24 +30,34 @@ LLVM_LIBC_FUNCTION(char *, getcwd, (char *buf, size_t size)) {
     // into it. This way, if the syscall fails, we avoid unnecessary malloc
     // and free.
     char pathbuf[PATH_MAX];
-    if (!getcwd_syscall(pathbuf, PATH_MAX))
+
+    ErrorOr<ssize_t> bytes_written = linux_syscalls::getcwd(pathbuf, PATH_MAX);
+    if (!bytes_written) {
+      libc_errno = bytes_written.error();
       return nullptr;
-    auto cwd = internal::strdup(pathbuf);
+    }
+
+    cpp::optional<char *> cwd = internal::strdup(pathbuf);
     if (!cwd) {
       libc_errno = ENOMEM;
       return nullptr;
     }
     return *cwd;
-  } else if (size == 0) {
+  }
+
+  if (size == 0) {
     libc_errno = EINVAL;
     return nullptr;
   }
 
   // TODO: When buf is not sufficient, evaluate the full cwd path using
   // alternate approaches.
-
-  if (!getcwd_syscall(buf, size))
+  ErrorOr<ssize_t> bytes_written = linux_syscalls::getcwd(buf, size);
+  if (!bytes_written) {
+    libc_errno = bytes_written.error();
     return nullptr;
+  }
+
   return buf;
 }
 


### PR DESCRIPTION
Allows for re-use by other entrypoints. This PR also moves error handling for unreachable paths in `syscall_wrappers::getcwd` since I imagine most usages of getcwd would rather error with `ENOENT` than receive `"(unreachable) /path/to/cwd"`.