### PR TITLE
[DirectX][ObjectYAML][NFC] Remove unused function

### DIFF
--- a/llvm/include/llvm/BinaryFormat/DXContainer.h
+++ b/llvm/include/llvm/BinaryFormat/DXContainer.h
@@ -897,11 +897,6 @@ struct SectionHeader {
     sys::swapByteOrder(Flags);
     sys::swapByteOrder(Type);
   }
-
-  void updateSize(uint32_t ContentSize) {
-    AlignedSizeInBytes =
-        alignTo(sizeof(*this) + ContentSize, DXCONTAINER_STRUCT_ALIGNMENT);
-  }
 };
 
 static_assert(sizeof(SectionHeader) == 8,


### PR DESCRIPTION
A small follow-up for #202761.
`updateSize()` function added there is a rebase artifact. It is never actually used. This change removes it.