### PR TITLE
[lldb] Add skipIfRemote to TestRV32MachOCorefile

### DIFF
--- a/lldb/test/API/macosx/riscv32-corefile/TestRV32MachOCorefile.py
+++ b/lldb/test/API/macosx/riscv32-corefile/TestRV32MachOCorefile.py
@@ -14,6 +14,7 @@ class TestRV32MachOCorefile(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @no_debug_info_test
+    @skipIfRemote
     def test_riscv32_gpr_corefile_registers(self):
         corefile = self.getBuildArtifact("core")
         self.yaml2macho_core("riscv32-registers.yaml", corefile)


### PR DESCRIPTION
I'm getting a failure on the lldb-remote-linux-ubuntu bot, but the ubuntu native bot works fine.  The failure is a little difficult to understand;
```
FAIL: LLDB (/home/buildbot/worker/as-builder-9/lldb-remote-linux-ubuntu/build/bin/clang-aarch64) :: test_riscv32_gpr_corefile_registers (TestRV32MachOCorefile.TestRV32MachOCorefile.test_riscv32_gpr_corefile_registers)
Log Files:
 - /home/buildbot/worker/as-builder-9/lldb-remote-linux-ubuntu/build/lldb-test-build.noindex/macosx/riscv32-corefile/TestRV32MachOCorefile/Failure_test_riscv32_gpr_corefile_registers.log
======================================================================
FAIL: test_riscv32_gpr_corefile_registers (TestRV32MachOCorefile.TestRV32MachOCorefile.test_riscv32_gpr_corefile_registers)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/buildbot/worker/as-builder-9/lldb-remote-linux-ubuntu/llvm-project/lldb/packages/Python/lldbsuite/test/decorators.py", line 544, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/buildbot/worker/as-builder-9/lldb-remote-linux-ubuntu/llvm-project/lldb/test/API/macosx/riscv32-corefile/TestRV32MachOCorefile.py", line 28, in test_riscv32_gpr_corefile_registers
    self.assertEqual(thread.GetNumFrames(), 2)
AssertionError: 1 != 2
```

So it's got _a_ corefile, is it possible a corefile from a previous run is still being used on the remote tester system, from when this corefile only had 1 frame?  I'm not sure.