### PR TITLE
[SPIRV] Fix structurizer merge dominance violation and switch case ordering

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
@@ -1209,9 +1209,9 @@ class SPIRVStructurizer : public FunctionPass {
       // Map from target block to its case index (first occurrence only, used
       // for fall-through detection).
       SmallDenseMap<BasicBlock *, unsigned, 8> BlockToCaseIdx;
-      for (unsigned i = 0; i < Cases.size(); i++) {
+      for (unsigned I = 0; I < Cases.size(); I++) {
         // Only record the first case targeting each block.
-        BlockToCaseIdx.try_emplace(Cases[i].second, i);
+        BlockToCaseIdx.try_emplace(Cases[I].second, I);
       }
 
       // Build fall-through edges among cases (excluding default).
@@ -1219,13 +1219,13 @@ class SPIRVStructurizer : public FunctionPass {
       // target block, so case i must immediately precede case j.
       SmallDenseMap<unsigned, unsigned, 8> FallThrough;
       SmallDenseMap<unsigned, unsigned, 8> IncomingCount;
-      for (unsigned i = 0; i < Cases.size(); i++) {
-        for (BasicBlock *Succ : successors(Cases[i].second)) {
+      for (unsigned I = 0; I < Cases.size(); I++) {
+        for (BasicBlock *Succ : successors(Cases[I].second)) {
           if (Succ == SI->getDefaultDest())
             continue; // Skip fall-throughs involving default.
           auto It = BlockToCaseIdx.find(Succ);
-          if (It != BlockToCaseIdx.end() && It->second != i) {
-            FallThrough[i] = It->second;
+          if (It != BlockToCaseIdx.end() && It->second != I) {
+            FallThrough[I] = It->second;
             IncomingCount[It->second]++;
             break;
           }
@@ -1246,11 +1246,11 @@ class SPIRVStructurizer : public FunctionPass {
       }
       if (!Unsatisfiable) {
         // Check for cycles by following chains.
-        for (unsigned i = 0; i < Cases.size() && !Unsatisfiable; i++) {
-          if (!FallThrough.count(i))
+        for (unsigned I = 0; I < Cases.size() && !Unsatisfiable; I++) {
+          if (!FallThrough.count(I))
             continue;
           SmallDenseSet<unsigned, 8> Visited;
-          unsigned Cur = i;
+          unsigned Cur = I;
           while (FallThrough.count(Cur)) {
             if (!Visited.insert(Cur).second) {
               Unsatisfiable = true;
@@ -1273,10 +1273,10 @@ class SPIRVStructurizer : public FunctionPass {
         HasIncoming.insert(To);
 
       // Start chains from cases that aren't landed on.
-      for (unsigned i = 0; i < Cases.size(); i++) {
-        if (HasIncoming.count(i))
+      for (unsigned I = 0; I < Cases.size(); I++) {
+        if (HasIncoming.count(I))
           continue;
-        unsigned Cur = i;
+        unsigned Cur = I;
         while (true) {
           if (Placed.contains(Cur))
             break;
@@ -1290,17 +1290,17 @@ class SPIRVStructurizer : public FunctionPass {
       }
 
       // Add any remaining cases not part of a chain.
-      for (unsigned i = 0; i < Cases.size(); i++) {
-        if (!Placed.contains(i)) {
-          Order.push_back(i);
-          Placed.insert(i);
+      for (unsigned I = 0; I < Cases.size(); I++) {
+        if (!Placed.contains(I)) {
+          Order.push_back(I);
+          Placed.insert(I);
         }
       }
 
       // Check if order actually changed.
       bool Changed = false;
-      for (unsigned i = 0; i < Order.size(); i++) {
-        if (Order[i] != i) {
+      for (unsigned I = 0; I < Order.size(); I++) {
+        if (Order[I] != I) {
           Changed = true;
           break;
         }

--- a/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
@@ -14,7 +14,6 @@
 #include "SPIRVSubtarget.h"
 #include "SPIRVUtils.h"
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Analysis/LoopInfo.h"
 #include "llvm/IR/CFG.h"
@@ -1028,15 +1027,13 @@ class SPIRVStructurizer : public FunctionPass {
           if (!Convergence || Convergence == &BB)
             continue;
 
-          if (DT.dominates(&BB, Convergence)) {
-            // Simple case: convergence is dominated. Use it as target.
-            Target = Convergence;
-          } else {
-            // Convergence not dominated by header (sibling paths also reach
-            // it). Insert a new merge before the convergence, redirecting
-            // only the edges from BB-dominated predecessors.
-            Target = Convergence;
-          }
+          // Target is not used directly as the merge. The downstream code
+          // creates a new intermediate block (NewMerge) intercepting only the
+          // header-dominated predecessors of Target. This works regardless of
+          // whether Header dominates Convergence: if it does, all predecessors
+          // get redirected; if not, only the dominated subset does, while
+          // sibling paths continue directly to Convergence.
+          Target = Convergence;
         }
 
         // Check 2 is intentionally omitted. Branching to a merge block of
@@ -1066,16 +1063,16 @@ class SPIRVStructurizer : public FunctionPass {
         // For each phi in Target, create a phi in NewMerge collecting the
         // values from redirected predecessors, then replace those incoming
         // entries in Target's phi with a single entry from NewMerge.
-        for (PHINode &Phi : make_early_inc_range(Target->phis())) {
+        for (PHINode &Phi : Target->phis()) {
           PHINode *NewPhi =
               PHINode::Create(Phi.getType(), RedirectedPreds.size(),
                               Phi.getName() + ".inner", NewMerge);
           for (BasicBlock *Pred : RedirectedPreds) {
             int Idx = Phi.getBasicBlockIndex(Pred);
-            if (Idx >= 0) {
-              NewPhi->addIncoming(Phi.getIncomingValue(Idx), Pred);
-              Phi.removeIncomingValue(Idx, /*DeletePHIIfEmpty=*/false);
-            }
+            assert(Idx >= 0 &&
+                   "redirected predecessor missing PHI incoming value");
+            NewPhi->addIncoming(Phi.getIncomingValue(Idx), Pred);
+            Phi.removeIncomingValue(Idx, /*DeletePHIIfEmpty=*/false);
           }
           Phi.addIncoming(NewPhi, NewMerge);
         }
@@ -1088,6 +1085,11 @@ class SPIRVStructurizer : public FunctionPass {
         for (BasicBlock *Pred : RedirectedPreds) {
           Pred->getTerminator()->replaceSuccessorWith(Target, NewMerge);
         }
+
+        // Verify the new merge is dominated by the header.
+        DT.recalculate(F);
+        assert(DT.dominates(&BB, NewMerge) &&
+               "new merge must be dominated by header");
 
         // Reassign merge.
         auto *NewMergeAddr = BlockAddress::get(NewMerge->getParent(), NewMerge);
@@ -1187,7 +1189,9 @@ class SPIRVStructurizer : public FunctionPass {
 
   // Fix switch case ordering for SPIR-V: if a case construct branches to
   // another case's target block, the branching case must immediately precede
-  // the target case in the OpSwitch target list.
+  // the target case in the OpSwitch target list. Only non-default cases
+  // participate in reordering (the default target is not part of the OpSwitch
+  // target list in SPIR-V).
   bool fixSwitchCaseOrder(Function &F) {
     bool Modified = false;
 
@@ -1196,24 +1200,33 @@ class SPIRVStructurizer : public FunctionPass {
       if (!SI || SI->getNumCases() < 2)
         continue;
 
-      // Collect all case targets (including default).
-      SmallVector<BasicBlock *, 8> Targets;
-      SmallDenseMap<BasicBlock *, unsigned, 8> TargetIndex;
-      Targets.push_back(SI->getDefaultDest());
-      TargetIndex[SI->getDefaultDest()] = 0;
-      for (auto &Case : SI->cases()) {
-        TargetIndex[Case.getCaseSuccessor()] = Targets.size();
-        Targets.push_back(Case.getCaseSuccessor());
+      // Collect non-default case targets. Use indices (not block pointers)
+      // to correctly handle multiple case values sharing the same target.
+      SmallVector<std::pair<ConstantInt *, BasicBlock *>, 8> Cases;
+      for (auto &Case : SI->cases())
+        Cases.push_back({Case.getCaseValue(), Case.getCaseSuccessor()});
+
+      // Map from target block to its case index (first occurrence only, used
+      // for fall-through detection).
+      SmallDenseMap<BasicBlock *, unsigned, 8> BlockToCaseIdx;
+      for (unsigned i = 0; i < Cases.size(); i++) {
+        // Only record the first case targeting each block.
+        BlockToCaseIdx.try_emplace(Cases[i].second, i);
       }
 
-      // Build fall-through edges: case A falls through to case B if A's
-      // block branches to B's block.
-      SmallDenseMap<unsigned, unsigned, 8> FallThrough; // from -> to
-      for (unsigned i = 0; i < Targets.size(); i++) {
-        for (BasicBlock *Succ : successors(Targets[i])) {
-          auto It = TargetIndex.find(Succ);
-          if (It != TargetIndex.end() && It->second != i) {
+      // Build fall-through edges among cases (excluding default).
+      // FallThrough[i] = j means case i's target block branches to case j's
+      // target block, so case i must immediately precede case j.
+      SmallDenseMap<unsigned, unsigned, 8> FallThrough;
+      SmallDenseMap<unsigned, unsigned, 8> IncomingCount;
+      for (unsigned i = 0; i < Cases.size(); i++) {
+        for (BasicBlock *Succ : successors(Cases[i].second)) {
+          if (Succ == SI->getDefaultDest())
+            continue; // Skip fall-throughs involving default.
+          auto It = BlockToCaseIdx.find(Succ);
+          if (It != BlockToCaseIdx.end() && It->second != i) {
             FallThrough[i] = It->second;
+            IncomingCount[It->second]++;
             break;
           }
         }
@@ -1222,27 +1235,53 @@ class SPIRVStructurizer : public FunctionPass {
       if (FallThrough.empty())
         continue;
 
-      // Topological sort: build a chain of cases respecting fall-through.
-      // A case with a fall-through edge must immediately precede its target.
-      SmallVector<unsigned, 8> Order;
-      SmallPtrSet<BasicBlock *, 8> Placed;
+      // Detect unsatisfiable constraints: cycles or multiple predecessors
+      // targeting the same case. Skip reordering if found.
+      bool Unsatisfiable = false;
+      for (auto &[Target, Count] : IncomingCount) {
+        if (Count > 1) {
+          Unsatisfiable = true;
+          break;
+        }
+      }
+      if (!Unsatisfiable) {
+        // Check for cycles by following chains.
+        for (unsigned i = 0; i < Cases.size() && !Unsatisfiable; i++) {
+          if (!FallThrough.count(i))
+            continue;
+          SmallDenseSet<unsigned, 8> Visited;
+          unsigned Cur = i;
+          while (FallThrough.count(Cur)) {
+            if (!Visited.insert(Cur).second) {
+              Unsatisfiable = true;
+              break;
+            }
+            Cur = FallThrough[Cur];
+          }
+        }
+      }
+      if (Unsatisfiable)
+        continue;
 
-      // Find which targets are "landed on" (have an incoming fall-through).
+      // Topological sort: build chains respecting fall-through adjacency.
+      SmallVector<unsigned, 8> Order;
+      SmallDenseSet<unsigned, 8> Placed;
+
+      // Find chain heads (cases with no incoming fall-through).
       SmallDenseSet<unsigned, 8> HasIncoming;
       for (auto &[From, To] : FallThrough)
         HasIncoming.insert(To);
 
       // Start chains from cases that aren't landed on.
-      for (unsigned i = 0; i < Targets.size(); i++) {
+      for (unsigned i = 0; i < Cases.size(); i++) {
         if (HasIncoming.count(i))
           continue;
-        // Follow the chain.
         unsigned Cur = i;
         while (true) {
-          if (Placed.contains(Targets[Cur]))
+          if (Placed.contains(Cur))
             break;
           Order.push_back(Cur);
-          Placed.insert(Targets[Cur]);
+          Placed.insert(Cur);
           auto It = FallThrough.find(Cur);
           if (It == FallThrough.end())
             break;
@@ -1250,15 +1289,15 @@ class SPIRVStructurizer : public FunctionPass {
         }
       }
 
-      // Add any remaining (shouldn't happen in well-formed input, but safe).
-      for (unsigned i = 0; i < Targets.size(); i++) {
-        if (!Placed.contains(Targets[i])) {
+      // Add any remaining cases not part of a chain.
+      for (unsigned i = 0; i < Cases.size(); i++) {
+        if (!Placed.contains(i)) {
           Order.push_back(i);
-          Placed.insert(Targets[i]);
+          Placed.insert(i);
         }
       }
 
-      // Check if order changed.
+      // Check if order actually changed.
       bool Changed = false;
       for (unsigned i = 0; i < Order.size(); i++) {
         if (Order[i] != i) {
@@ -1269,31 +1308,19 @@ class SPIRVStructurizer : public FunctionPass {
       if (!Changed)
         continue;
 
-      // Rebuild the switch with new case order. The default stays as-is in
-      // LLVM IR (it's separate from cases), but we reorder the cases.
-      // First, collect case values and targets in current order.
-      SmallVector<std::pair<ConstantInt *, BasicBlock *>, 8> Cases;
-      for (auto &Case : SI->cases())
-        Cases.push_back({Case.getCaseValue(), Case.getCaseSuccessor()});
-
-      // Map from old target index (1-based for cases) to new position.
-      // Order[j] gives the original index at new position j.
-      // We need cases in the order specified by Order, skipping index 0
-      // (default).
+      // Rebuild switch with reordered cases.
       SmallVector<std::pair<ConstantInt *, BasicBlock *>, 8> NewCases;
-      for (unsigned Idx : Order) {
-        if (Idx == 0)
-          continue; // default, handled separately
-        NewCases.push_back(Cases[Idx - 1]);
-      }
+      for (unsigned Idx : Order)
+        NewCases.push_back(Cases[Idx]);
 
-      // Rebuild switch.
       IRBuilder<> Builder(&BB);
       Builder.SetInsertPoint(SI);
       SwitchInst *NewSI = Builder.CreateSwitch(
           SI->getCondition(), SI->getDefaultDest(), NewCases.size());
       for (auto &[Val, Dest] : NewCases)
         NewSI->addCase(Val, Dest);
+      NewSI->copyMetadata(*SI);
+      NewSI->setDebugLoc(SI->getDebugLoc());
       SI->eraseFromParent();
       Modified = true;
     }

--- a/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
@@ -1014,7 +1014,7 @@ class SPIRVStructurizer : public FunctionPass {
         // Find the target block that needs a new intermediate merge.
         BasicBlock *Target = nullptr;
 
-        // Check 1: Header must dominate merge.
+        // Header must dominate its merge block.
         if (!DT.dominates(&BB, Merge)) {
           // Find the convergence point of all successors.
           BasicBlock *Convergence = nullptr;
@@ -1029,18 +1029,18 @@ class SPIRVStructurizer : public FunctionPass {
 
           // Target is not used directly as the merge. The downstream code
           // creates a new intermediate block (NewMerge) intercepting only the
-          // header-dominated predecessors of Target. This works regardless of
-          // whether Header dominates Convergence: if it does, all predecessors
+          // BB-dominated predecessors of Target. This works regardless of
+          // whether BB dominates Convergence: if it does, all predecessors
           // get redirected; if not, only the dominated subset does, while
           // sibling paths continue directly to Convergence.
           Target = Convergence;
         }
 
-        // Check 2 is intentionally omitted. Branching to a merge block of
-        // an enclosing construct (selection or loop) is a valid structured
-        // exit. The invalid patterns are caught by Check 1 on the deeper
-        // headers that lose dominance over their merge blocks after routing
-        // blocks are created.
+        // Note: We do NOT check whether a successor escapes this construct
+        // by branching to the merge of an enclosing selection/loop. That is a
+        // valid structured exit in SPIR-V. The actual invalid patterns are
+        // caught above (header not dominating merge) on the deeper headers
+        // that lose dominance after routing blocks are created.
 
         if (!Target)
           continue;
@@ -1215,8 +1215,8 @@ class SPIRVStructurizer : public FunctionPass {
       }
 
       // Build fall-through edges among cases (excluding default).
-      // FallThrough[i] = j means case i's target block branches to case j's
-      // target block, so case i must immediately precede case j.
+      // FallThrough[I] = J means case I's target block branches to case J's
+      // target block, so case I must immediately precede case J.
       SmallDenseMap<unsigned, unsigned, 8> FallThrough;
       SmallDenseMap<unsigned, unsigned, 8> IncomingCount;
       for (unsigned I = 0; I < Cases.size(); I++) {

--- a/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
@@ -14,6 +14,7 @@
 #include "SPIRVSubtarget.h"
 #include "SPIRVUtils.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Analysis/LoopInfo.h"
 #include "llvm/IR/CFG.h"
@@ -989,6 +990,114 @@ class SPIRVStructurizer : public FunctionPass {
     return ToRemove.size() != 0;
   }
 
+  // Fixes merge assignments where the header has a branch target that exits
+  // its own selection construct non-structurally. This happens when a header
+  // branches to a block that is outside [header, merge) — typically the merge
+  // of a parent construct. The fix inserts a new intermediate merge block that
+  // collects all edges from inside the construct that go to the exit target,
+  // and reassigns the header's merge to this new block.
+  bool fixInvalidMergeDominance(Function &F) {
+    DomTreeBuilder::BBDomTree DT;
+    DomTreeBuilder::BBPostDomTree PDT;
+    DT.recalculate(F);
+    PDT.recalculate(F);
+
+    for (BasicBlock &BB : F) {
+      auto MIS = getMergeInstructions(BB);
+      if (MIS.empty())
+        continue;
+
+      for (Instruction *MI : MIS) {
+        BasicBlock *Merge = getDesignatedMergeBlock(MI);
+        if (!Merge)
+          continue;
+
+        // Find the target block that needs a new intermediate merge.
+        BasicBlock *Target = nullptr;
+
+        // Check 1: Header must dominate merge.
+        if (!DT.dominates(&BB, Merge)) {
+          // Find the convergence point of all successors.
+          BasicBlock *Convergence = nullptr;
+          for (BasicBlock *Succ : successors(&BB)) {
+            if (!Convergence)
+              Convergence = Succ;
+            else
+              Convergence = PDT.findNearestCommonDominator(Convergence, Succ);
+          }
+          if (!Convergence || Convergence == &BB)
+            continue;
+
+          if (DT.dominates(&BB, Convergence)) {
+            // Simple case: convergence is dominated. Use it as target.
+            Target = Convergence;
+          } else {
+            // Convergence not dominated by header (sibling paths also reach
+            // it). Insert a new merge before the convergence, redirecting
+            // only the edges from BB-dominated predecessors.
+            Target = Convergence;
+          }
+        }
+
+        // Check 2 is intentionally omitted. Branching to a merge block of
+        // an enclosing construct (selection or loop) is a valid structured
+        // exit. The invalid patterns are caught by Check 1 on the deeper
+        // headers that lose dominance over their merge blocks after routing
+        // blocks are created.
+
+        if (!Target)
+          continue;
+
+        // Collect predecessors of Target that are dominated by BB (these
+        // are "inside" the construct and will be redirected).
+        SmallVector<BasicBlock *, 4> RedirectedPreds;
+        for (BasicBlock *Pred : predecessors(Target)) {
+          if (DT.dominates(&BB, Pred))
+            RedirectedPreds.push_back(Pred);
+        }
+
+        if (RedirectedPreds.empty())
+          continue;
+
+        // Create new merge block.
+        BasicBlock *NewMerge = BasicBlock::Create(
+            F.getContext(), Target->getName() + ".inner_merge", &F, Target);
+
+        // For each phi in Target, create a phi in NewMerge collecting the
+        // values from redirected predecessors, then replace those incoming
+        // entries in Target's phi with a single entry from NewMerge.
+        for (PHINode &Phi : make_early_inc_range(Target->phis())) {
+          PHINode *NewPhi =
+              PHINode::Create(Phi.getType(), RedirectedPreds.size(),
+                              Phi.getName() + ".inner", NewMerge);
+          for (BasicBlock *Pred : RedirectedPreds) {
+            int Idx = Phi.getBasicBlockIndex(Pred);
+            if (Idx >= 0) {
+              NewPhi->addIncoming(Phi.getIncomingValue(Idx), Pred);
+              Phi.removeIncomingValue(Idx, /*DeletePHIIfEmpty=*/false);
+            }
+          }
+          Phi.addIncoming(NewPhi, NewMerge);
+        }
+
+        // Add terminator (branch to Target).
+        IRBuilder<> Builder(NewMerge);
+        Builder.CreateBr(Target);
+
+        // Redirect edges.
+        for (BasicBlock *Pred : RedirectedPreds) {
+          Pred->getTerminator()->replaceSuccessorWith(Target, NewMerge);
+        }
+
+        // Reassign merge.
+        auto *NewMergeAddr = BlockAddress::get(NewMerge->getParent(), NewMerge);
+        MI->setOperand(0, NewMergeAddr);
+        return true;
+      }
+    }
+    return false;
+  }
+
   bool addHeaderToRemainingDivergentDAG(Function &F) {
     bool Modified = false;
 
@@ -1009,10 +1118,15 @@ class SPIRVStructurizer : public FunctionPass {
 
       size_t CandidateEdges = 0;
       for (BasicBlock *Successor : successors(&BB)) {
-        if (MergeBlocks.count(Successor) != 0 ||
-            ContinueBlocks.count(Successor) != 0)
+        if (ContinueBlocks.count(Successor) != 0)
           continue;
-        if (HeaderBlocks.count(Successor) != 0)
+        if (MergeBlocks.count(Successor) != 0)
+          continue;
+        // Filter header blocks that dominate us (we're inside their
+        // construct — branching to them is normal structured flow). But if
+        // a header does NOT dominate us, we're routing into it from outside
+        // and need our own selection merge.
+        if (HeaderBlocks.count(Successor) != 0 && DT.dominates(Successor, &BB))
           continue;
         CandidateEdges += 1;
       }
@@ -1053,17 +1167,135 @@ class SPIRVStructurizer : public FunctionPass {
         continue;
       }
 
-      Instruction *SplitInstruction = Merge->getTerminator();
-      if (isMergeInstruction(SplitInstruction->getPrevNode()))
-        SplitInstruction = SplitInstruction->getPrevNode();
-      BasicBlock *NewMerge =
-          Merge->splitBasicBlockBefore(SplitInstruction, "new.merge");
+      BasicBlock *NewMerge;
+      {
+        Instruction *SplitInstruction = Merge->getTerminator();
+        if (isMergeInstruction(SplitInstruction->getPrevNode()))
+          SplitInstruction = SplitInstruction->getPrevNode();
+        NewMerge = Merge->splitBasicBlockBefore(SplitInstruction, "new.merge");
+      }
 
       IRBuilder<> Builder(Header);
       Builder.SetInsertPoint(Header->getTerminator());
 
       auto MergeAddress = BlockAddress::get(NewMerge->getParent(), NewMerge);
       createOpSelectMerge(&Builder, MergeAddress);
+    }
+
+    return Modified;
+  }
+
+  // Fix switch case ordering for SPIR-V: if a case construct branches to
+  // another case's target block, the branching case must immediately precede
+  // the target case in the OpSwitch target list.
+  bool fixSwitchCaseOrder(Function &F) {
+    bool Modified = false;
+
+    for (BasicBlock &BB : F) {
+      auto *SI = dyn_cast<SwitchInst>(BB.getTerminator());
+      if (!SI || SI->getNumCases() < 2)
+        continue;
+
+      // Collect all case targets (including default).
+      SmallVector<BasicBlock *, 8> Targets;
+      SmallDenseMap<BasicBlock *, unsigned, 8> TargetIndex;
+      Targets.push_back(SI->getDefaultDest());
+      TargetIndex[SI->getDefaultDest()] = 0;
+      for (auto &Case : SI->cases()) {
+        TargetIndex[Case.getCaseSuccessor()] = Targets.size();
+        Targets.push_back(Case.getCaseSuccessor());
+      }
+
+      // Build fall-through edges: case A falls through to case B if A's
+      // block branches to B's block.
+      SmallDenseMap<unsigned, unsigned, 8> FallThrough; // from -> to
+      for (unsigned i = 0; i < Targets.size(); i++) {
+        for (BasicBlock *Succ : successors(Targets[i])) {
+          auto It = TargetIndex.find(Succ);
+          if (It != TargetIndex.end() && It->second != i) {
+            FallThrough[i] = It->second;
+            break;
+          }
+        }
+      }
+
+      if (FallThrough.empty())
+        continue;
+
+      // Topological sort: build a chain of cases respecting fall-through.
+      // A case with a fall-through edge must immediately precede its target.
+      SmallVector<unsigned, 8> Order;
+      SmallPtrSet<BasicBlock *, 8> Placed;
+
+      // Find which targets are "landed on" (have an incoming fall-through).
+      SmallDenseSet<unsigned, 8> HasIncoming;
+      for (auto &[From, To] : FallThrough)
+        HasIncoming.insert(To);
+
+      // Start chains from cases that aren't landed on.
+      for (unsigned i = 0; i < Targets.size(); i++) {
+        if (HasIncoming.count(i))
+          continue;
+        // Follow the chain.
+        unsigned Cur = i;
+        while (true) {
+          if (Placed.contains(Targets[Cur]))
+            break;
+          Order.push_back(Cur);
+          Placed.insert(Targets[Cur]);
+          auto It = FallThrough.find(Cur);
+          if (It == FallThrough.end())
+            break;
+          Cur = It->second;
+        }
+      }
+
+      // Add any remaining (shouldn't happen in well-formed input, but safe).
+      for (unsigned i = 0; i < Targets.size(); i++) {
+        if (!Placed.contains(Targets[i])) {
+          Order.push_back(i);
+          Placed.insert(Targets[i]);
+        }
+      }
+
+      // Check if order changed.
+      bool Changed = false;
+      for (unsigned i = 0; i < Order.size(); i++) {
+        if (Order[i] != i) {
+          Changed = true;
+          break;
+        }
+      }
+      if (!Changed)
+        continue;
+
+      // Rebuild the switch with new case order. The default stays as-is in
+      // LLVM IR (it's separate from cases), but we reorder the cases.
+      // First, collect case values and targets in current order.
+      SmallVector<std::pair<ConstantInt *, BasicBlock *>, 8> Cases;
+      for (auto &Case : SI->cases())
+        Cases.push_back({Case.getCaseValue(), Case.getCaseSuccessor()});
+
+      // Map from old target index (1-based for cases) to new position.
+      // Order[j] gives the original index at new position j.
+      // We need cases in the order specified by Order, skipping index 0
+      // (default).
+      SmallVector<std::pair<ConstantInt *, BasicBlock *>, 8> NewCases;
+      for (unsigned Idx : Order) {
+        if (Idx == 0)
+          continue; // default, handled separately
+        NewCases.push_back(Cases[Idx - 1]);
+      }
+
+      // Rebuild switch.
+      IRBuilder<> Builder(&BB);
+      Builder.SetInsertPoint(SI);
+      SwitchInst *NewSI = Builder.CreateSwitch(
+          SI->getCondition(), SI->getDefaultDest(), NewCases.size());
+      for (auto &[Val, Dest] : NewCases)
+        NewSI->addCase(Val, Dest);
+      SI->eraseFromParent();
+      Modified = true;
     }
 
     return Modified;
@@ -1132,7 +1364,31 @@ public:
     // STEP 8: Final fix-up steps: our tree boundaries are correct, but some
     // blocks are branching with no header. Those are often simple conditional
     // branches with 1 or 2 returning edges. Adding a header for those.
-    Modified |= addHeaderToRemainingDivergentDAG(F);
+    // Also fix any merge assignments where the header does not dominate its
+    // merge (caused by STEP 6 creating alternate paths). These two fixes
+    // interact: removing an invalid merge may expose a block that needs a new
+    // header, and adding headers may reveal new dominance violations. Run both
+    // in a loop until convergence.
+    {
+      bool Changed;
+      do {
+        Changed = false;
+        while (addHeaderToRemainingDivergentDAG(F)) {
+          Changed = true;
+          Modified = true;
+        }
+        while (fixInvalidMergeDominance(F)) {
+          Changed = true;
+          Modified = true;
+        }
+      } while (Changed);
+    }
+
+    // STEP 8b: Fix switch case ordering. SPIR-V requires that if one case
+    // construct falls through (branches) to another case construct, the
+    // falling-through case must immediately precede the target case in the
+    // OpSwitch target list.
+    Modified |= fixSwitchCaseOrder(F);
 
     // STEP 9: sort basic blocks to match both the LLVM & SPIR-V requirements.
     Modified |= sortBlocks(F);

--- a/llvm/test/CodeGen/SPIRV/structurizer/merge-dominance-nested-routing.ll
+++ b/llvm/test/CodeGen/SPIRV/structurizer/merge-dominance-nested-routing.ll
@@ -1,0 +1,56 @@
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+; RUN: llc -mtriple=spirv-unknown-vulkan-compute -O0 %s -o - | FileCheck %s
+
+; Test that the structurizer handles three nested convergent operations where
+; each level creates routing blocks. This exercises:
+; 1. fixInvalidMergeDominance iterating multiple times (one per nesting level)
+; 2. fixSwitchCaseOrder when case fall-through edges need reordering
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+target triple = "spirv-unknown-vulkan-compute"
+
+; CHECK: OpSelectionMerge
+; CHECK: OpBranchConditional
+
+define internal spir_func void @main() #0 {
+entry:
+  %0 = call token @llvm.experimental.convergence.entry()
+  %tid = call i32 @__hlsl_wave_get_lane_index() [ "convergencectrl"(token %0) ]
+  %cond1 = icmp ult i32 %tid, 16
+  br i1 %cond1, label %wave1, label %thread1
+
+wave1:
+  %r1 = call double @llvm.spv.wave.prefix.product.f64(double 1.0) [ "convergencectrl"(token %0) ]
+  %cond2 = icmp ult i32 %tid, 8
+  br i1 %cond2, label %wave2, label %thread2
+
+wave2:
+  %r2 = call double @llvm.spv.wave.prefix.product.f64(double 2.0) [ "convergencectrl"(token %0) ]
+  %cond3 = icmp ult i32 %tid, 4
+  br i1 %cond3, label %wave3, label %thread3
+
+wave3:
+  %r3 = call double @llvm.spv.wave.prefix.product.f64(double 3.0) [ "convergencectrl"(token %0) ]
+  br label %merge
+
+thread3:
+  br label %merge
+
+thread2:
+  br label %merge
+
+thread1:
+  br label %merge
+
+merge:
+  %result = phi double [ %r3, %wave3 ], [ 0.0, %thread3 ], [ 0.0, %thread2 ], [ 0.0, %thread1 ]
+  ret void
+}
+
+declare token @llvm.experimental.convergence.entry() #1
+declare i32 @__hlsl_wave_get_lane_index() #2
+declare double @llvm.spv.wave.prefix.product.f64(double) #2
+
+attributes #0 = { convergent noinline norecurse nounwind optnone "hlsl.numthreads"="32,1,1" "hlsl.shader"="compute" }
+attributes #1 = { convergent nocallback nofree nosync nounwind willreturn }
+attributes #2 = { convergent nounwind }

--- a/llvm/test/CodeGen/SPIRV/structurizer/merge-dominance-routing.ll
+++ b/llvm/test/CodeGen/SPIRV/structurizer/merge-dominance-routing.ll
@@ -1,0 +1,60 @@
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+; RUN: llc -mtriple=spirv-unknown-vulkan-compute -O0 %s -o - | FileCheck %s
+
+; Test that the structurizer correctly handles merge dominance when routing
+; blocks create alternate paths to merge points. This pattern occurs when
+; SPIRVMergeRegionExitTargets creates switch-based routing and the structurizer
+; creates conditional branches where a "thread" block (skipping a convergent
+; op) provides an alternate path to the merge, breaking header dominance.
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+target triple = "spirv-unknown-vulkan-compute"
+
+; Verify the output has proper nested selection constructs and valid structure.
+; The key check: selection merges are properly nested and all branches stay
+; within their constructs.
+; CHECK:       %[[#entry:]] = OpLabel
+; CHECK:                      OpSelectionMerge %[[#merge:]] None
+; CHECK:                      OpBranchConditional %[[#]] %[[#wave1:]] %[[#merge]]
+; CHECK:    %[[#wave1]] = OpLabel
+; CHECK:                      OpSelectionMerge %[[#merge2:]] None
+; CHECK:                      OpBranchConditional
+; CHECK:   %[[#merge2]] = OpLabel
+; CHECK:                      OpBranchConditional %[[#]] %[[#]] %[[#merge]]
+; CHECK:    %[[#merge]] = OpLabel
+; CHECK:                      OpReturn
+
+define internal spir_func void @main() #0 {
+entry:
+  %0 = call token @llvm.experimental.convergence.entry()
+  %tid = call i32 @__hlsl_wave_get_lane_index() [ "convergencectrl"(token %0) ]
+  %cond1 = icmp ult i32 %tid, 16
+  br i1 %cond1, label %wave1, label %thread1
+
+wave1:
+  %r1 = call double @llvm.spv.wave.prefix.product.f64(double 1.0) [ "convergencectrl"(token %0) ]
+  %cond2 = icmp ult i32 %tid, 8
+  br i1 %cond2, label %wave2, label %thread2
+
+wave2:
+  %r2 = call double @llvm.spv.wave.prefix.product.f64(double 2.0) [ "convergencectrl"(token %0) ]
+  br label %merge
+
+thread2:
+  br label %merge
+
+thread1:
+  br label %merge
+
+merge:
+  %result = phi double [ %r1, %thread2 ], [ %r2, %wave2 ], [ 0.0, %thread1 ]
+  ret void
+}
+
+declare token @llvm.experimental.convergence.entry() #1
+declare i32 @__hlsl_wave_get_lane_index() #2
+declare double @llvm.spv.wave.prefix.product.f64(double) #2
+
+attributes #0 = { convergent noinline norecurse nounwind optnone "hlsl.numthreads"="32,1,1" "hlsl.shader"="compute" }
+attributes #1 = { convergent nocallback nofree nosync nounwind willreturn }
+attributes #2 = { convergent nounwind }

--- a/llvm/test/CodeGen/SPIRV/structurizer/merge-dominance-vector-wave.ll
+++ b/llvm/test/CodeGen/SPIRV/structurizer/merge-dominance-vector-wave.ll
@@ -1,0 +1,83 @@
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+; RUN: llc -mtriple=spirv-unknown-vulkan-compute -O0 %s -o - | FileCheck %s
+
+; Regression test for the original bug: WavePrefixProduct on double4 triggers
+; the structurizer to create routing blocks that violate SPIR-V merge dominance
+; rules. This test exercises the full pattern with vector wave operations and
+; interleaved conditionals, matching the real-world pattern from HLSL's
+; WavePrefixProduct<double4>.
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+target triple = "spirv-unknown-vulkan-compute"
+
+; CHECK: OpSelectionMerge
+; CHECK: OpBranchConditional
+
+define internal spir_func void @main() #0 {
+entry:
+  %0 = call token @llvm.experimental.convergence.entry()
+  %tid = call i32 @__hlsl_wave_get_lane_index() [ "convergencectrl"(token %0) ]
+  %cond1 = icmp ult i32 %tid, 16
+  %cond2 = icmp ult i32 %tid, 8
+  %cond3 = icmp ult i32 %tid, 4
+  br i1 %cond1, label %scalar.wave, label %scalar.thread
+
+scalar.wave:
+  %s1 = call double @llvm.spv.wave.prefix.product.f64(double 1.0) [ "convergencectrl"(token %0) ]
+  br i1 %cond2, label %scalar.wave2, label %scalar.thread2
+
+scalar.wave2:
+  %s2 = call double @llvm.spv.wave.prefix.product.f64(double 2.0) [ "convergencectrl"(token %0) ]
+  br i1 %cond3, label %scalar.wave3, label %scalar.thread3
+
+scalar.wave3:
+  %s3 = call double @llvm.spv.wave.prefix.product.f64(double 3.0) [ "convergencectrl"(token %0) ]
+  br label %vec.entry
+
+scalar.thread3:
+  br label %vec.entry
+
+scalar.thread2:
+  br label %vec.entry
+
+scalar.thread:
+  br label %vec.entry
+
+vec.entry:
+  %sv = phi double [ %s3, %scalar.wave3 ], [ 0.0, %scalar.thread3 ], [ 0.0, %scalar.thread2 ], [ 0.0, %scalar.thread ]
+  br i1 %cond1, label %vec.wave, label %vec.thread
+
+vec.wave:
+  %v1 = call <2 x double> @llvm.spv.wave.prefix.product.v2f64(<2 x double> <double 1.0, double 1.0>) [ "convergencectrl"(token %0) ]
+  br i1 %cond2, label %vec.wave2, label %vec.thread2
+
+vec.wave2:
+  %v2 = call <2 x double> @llvm.spv.wave.prefix.product.v2f64(<2 x double> <double 2.0, double 2.0>) [ "convergencectrl"(token %0) ]
+  br i1 %cond3, label %vec.wave3, label %vec.thread3
+
+vec.wave3:
+  %v3 = call <2 x double> @llvm.spv.wave.prefix.product.v2f64(<2 x double> <double 3.0, double 3.0>) [ "convergencectrl"(token %0) ]
+  br label %final
+
+vec.thread3:
+  br label %final
+
+vec.thread2:
+  br label %final
+
+vec.thread:
+  br label %final
+
+final:
+  %vr = phi <2 x double> [ %v3, %vec.wave3 ], [ zeroinitializer, %vec.thread3 ], [ zeroinitializer, %vec.thread2 ], [ zeroinitializer, %vec.thread ]
+  ret void
+}
+
+declare token @llvm.experimental.convergence.entry() #1
+declare i32 @__hlsl_wave_get_lane_index() #2
+declare double @llvm.spv.wave.prefix.product.f64(double) #2
+declare <2 x double> @llvm.spv.wave.prefix.product.v2f64(<2 x double>) #2
+
+attributes #0 = { convergent noinline norecurse nounwind optnone "hlsl.numthreads"="32,1,1" "hlsl.shader"="compute" }
+attributes #1 = { convergent nocallback nofree nosync nounwind willreturn }
+attributes #2 = { convergent nounwind }

--- a/llvm/test/CodeGen/SPIRV/structurizer/merge-dominance-wave-prefix-product.ll
+++ b/llvm/test/CodeGen/SPIRV/structurizer/merge-dominance-wave-prefix-product.ll
@@ -1,0 +1,343 @@
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+;
+; Regression test for SPIR-V structurizer merge dominance bug.
+; WavePrefixProduct on double4 creates nested convergent operations that
+; trigger routing blocks with invalid merge assignments after structurization.
+; This test verifies the fix produces valid SPIR-V.
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+target triple = "spirv-unknown-vulkan-compute"
+
+@.str = private unnamed_addr constant [3 x i8] c"In\00", align 1
+@.str.2 = private unnamed_addr constant [5 x i8] c"Out1\00", align 1
+@.str.4 = private unnamed_addr constant [5 x i8] c"Out2\00", align 1
+@.str.6 = private unnamed_addr constant [5 x i8] c"Out3\00", align 1
+@.str.8 = private unnamed_addr constant [5 x i8] c"Out4\00", align 1
+@.str.10 = private unnamed_addr constant [5 x i8] c"Out5\00", align 1
+
+; Function Attrs: convergent mustprogress nocallback nofree nosync nounwind willreturn memory(none)
+declare token @llvm.experimental.convergence.entry() #0
+
+; Function Attrs: convergent mustprogress nofree noinline norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none, target_mem: none)
+define void @main() local_unnamed_addr #1 {
+entry:
+  %scalars.i = alloca [4 x double], align 8
+  %vec2s.i = alloca [4 x <2 x double>], align 8
+  %vec3s.i = alloca [4 x <3 x double>], align 8
+  %vec4s.i = alloca [4 x <4 x double>], align 8
+  %0 = tail call token @llvm.experimental.convergence.entry()
+  %1 = tail call target("spirv.VulkanBuffer", [0 x <4 x double>], 12, 0) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v4f64_12_0t(i32 0, i32 0, i32 1, i32 0, ptr nonnull @.str)
+  %2 = tail call i32 @llvm.spv.thread.id.in.group.i32(i32 0)
+  %3 = tail call noundef align 8 dereferenceable(32) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v4f64_12_0t.i32(target("spirv.VulkanBuffer", [0 x <4 x double>], 12, 0) %1, i32 0)
+  %4 = load <4 x double>, ptr addrspace(11) %3, align 8, !tbaa !6
+  %cmp.i = icmp eq i32 %2, 0
+  br i1 %cmp.i, label %cond.end.i.thread, label %cond.end.i
+
+cond.end.i.thread:                                ; preds = %entry
+  %5 = extractelement <4 x double> %4, i64 0
+  %hlsl.wave.prefix.product2.i = call reassoc nnan ninf nsz arcp afn double @llvm.spv.wave.prefix.product.f64(double %5) [ "convergencectrl"(token %0) ]
+  br label %cond.end7.i.thread
+
+cond.end.i:                                       ; preds = %entry
+  %cmp3.i = icmp eq i32 %2, 1
+  br i1 %cmp3.i, label %cond.end.i.cond.end7.i.thread_crit_edge, label %cond.end7.i
+
+cond.end.i.cond.end7.i.thread_crit_edge:          ; preds = %cond.end.i
+  %.pre = extractelement <4 x double> %4, i64 0
+  br label %cond.end7.i.thread
+
+cond.end7.i.thread:                               ; preds = %cond.end.i.cond.end7.i.thread_crit_edge, %cond.end.i.thread
+  %.pre-phi = phi double [ %.pre, %cond.end.i.cond.end7.i.thread_crit_edge ], [ %5, %cond.end.i.thread ]
+  %cond.i4 = phi double [ 0.000000e+00, %cond.end.i.cond.end7.i.thread_crit_edge ], [ %hlsl.wave.prefix.product2.i, %cond.end.i.thread ]
+  %hlsl.wave.prefix.product5.i = call reassoc nnan ninf nsz arcp afn double @llvm.spv.wave.prefix.product.f64(double %.pre-phi) [ "convergencectrl"(token %0) ]
+  br label %cond.end13.i.thread
+
+cond.end7.i:                                      ; preds = %cond.end.i
+  %cmp9.i = icmp ult i32 %2, 3
+  br i1 %cmp9.i, label %cond.end7.i.cond.end13.i.thread_crit_edge, label %cond.end13.i
+
+cond.end7.i.cond.end13.i.thread_crit_edge:        ; preds = %cond.end7.i
+  %.pre439 = extractelement <4 x double> %4, i64 0
+  br label %cond.end13.i.thread
+
+cond.end13.i.thread:                              ; preds = %cond.end7.i.cond.end13.i.thread_crit_edge, %cond.end7.i.thread
+  %.pre-phi440 = phi double [ %.pre439, %cond.end7.i.cond.end13.i.thread_crit_edge ], [ %.pre-phi, %cond.end7.i.thread ]
+  %cond8.i16 = phi double [ 0.000000e+00, %cond.end7.i.cond.end13.i.thread_crit_edge ], [ %hlsl.wave.prefix.product5.i, %cond.end7.i.thread ]
+  %cond.i314 = phi double [ 0.000000e+00, %cond.end7.i.cond.end13.i.thread_crit_edge ], [ %cond.i4, %cond.end7.i.thread ]
+  %cmp3.i512 = phi i1 [ false, %cond.end7.i.cond.end13.i.thread_crit_edge ], [ true, %cond.end7.i.thread ]
+  %hlsl.wave.prefix.product11.i = call reassoc nnan ninf nsz arcp afn double @llvm.spv.wave.prefix.product.f64(double %.pre-phi440) [ "convergencectrl"(token %0) ]
+  br label %cond.end19.i
+
+cond.end13.i:                                     ; preds = %cond.end7.i
+  %cmp15.i = icmp eq i32 %2, 3
+  br i1 %cmp15.i, label %cond.end13.i.cond.end19.i_crit_edge, label %_Z4mainDv3_j.exit
+
+cond.end13.i.cond.end19.i_crit_edge:              ; preds = %cond.end13.i
+  %.pre441 = extractelement <4 x double> %4, i64 0
+  br label %cond.end19.i
+
+cond.end19.i:                                     ; preds = %cond.end13.i.cond.end19.i_crit_edge, %cond.end13.i.thread
+  %.pre-phi442 = phi double [ %.pre441, %cond.end13.i.cond.end19.i_crit_edge ], [ %.pre-phi440, %cond.end13.i.thread ]
+  %cond14.i34 = phi double [ 0.000000e+00, %cond.end13.i.cond.end19.i_crit_edge ], [ %hlsl.wave.prefix.product11.i, %cond.end13.i.thread ]
+  %cmp3.i51132 = phi i1 [ false, %cond.end13.i.cond.end19.i_crit_edge ], [ %cmp3.i512, %cond.end13.i.thread ]
+  %cond.i31330 = phi double [ 0.000000e+00, %cond.end13.i.cond.end19.i_crit_edge ], [ %cond.i314, %cond.end13.i.thread ]
+  %cond8.i1528 = phi double [ 0.000000e+00, %cond.end13.i.cond.end19.i_crit_edge ], [ %cond8.i16, %cond.end13.i.thread ]
+  %cmp9.i1726 = phi i1 [ false, %cond.end13.i.cond.end19.i_crit_edge ], [ true, %cond.end13.i.thread ]
+  %hlsl.wave.prefix.product17.i = call reassoc nnan ninf nsz arcp afn double @llvm.spv.wave.prefix.product.f64(double %.pre-phi442) [ "convergencectrl"(token %0) ]
+  br i1 %cmp.i, label %cond.true22.i, label %cond.end25.i
+
+cond.true22.i:                                    ; preds = %cond.end19.i
+  %6 = shufflevector <4 x double> %4, <4 x double> poison, <2 x i32> <i32 0, i32 1>
+  %hlsl.wave.prefix.product23.i = call reassoc nnan ninf nsz arcp afn <2 x double> @llvm.spv.wave.prefix.product.v2f64(<2 x double> %6) [ "convergencectrl"(token %0) ]
+  br i1 %cmp3.i51132, label %cond.true28.i, label %cond.end31.i
+
+cond.end25.i:                                     ; preds = %cond.end19.i
+  br i1 %cmp3.i51132, label %cond.end25.i.cond.true28.i_crit_edge, label %cond.end31.i
+
+cond.end25.i.cond.true28.i_crit_edge:             ; preds = %cond.end25.i
+  %.pre443 = shufflevector <4 x double> %4, <4 x double> poison, <2 x i32> <i32 0, i32 1>
+  br label %cond.true28.i
+
+cond.true28.i:                                    ; preds = %cond.end25.i.cond.true28.i_crit_edge, %cond.true22.i
+  %.pre-phi444 = phi <2 x double> [ %.pre443, %cond.end25.i.cond.true28.i_crit_edge ], [ %6, %cond.true22.i ]
+  %cond26.i74 = phi <2 x double> [ zeroinitializer, %cond.end25.i.cond.true28.i_crit_edge ], [ %hlsl.wave.prefix.product23.i, %cond.true22.i ]
+  %hlsl.wave.prefix.product29.i = call reassoc nnan ninf nsz arcp afn <2 x double> @llvm.spv.wave.prefix.product.v2f64(<2 x double> %.pre-phi444) [ "convergencectrl"(token %0) ]
+  br i1 %cmp9.i1726, label %cond.true34.i, label %cond.true40.i
+
+cond.end31.i:                                     ; preds = %cond.true22.i, %cond.end25.i
+  %cond26.i66 = phi <2 x double> [ %hlsl.wave.prefix.product23.i, %cond.true22.i ], [ zeroinitializer, %cond.end25.i ]
+  %.pre445 = shufflevector <4 x double> %4, <4 x double> poison, <2 x i32> <i32 0, i32 1>
+  br i1 %cmp9.i1726, label %cond.true34.i, label %cond.true40.i
+
+cond.true34.i:                                    ; preds = %cond.end31.i, %cond.true28.i
+  %.pre-phi446 = phi <2 x double> [ %.pre-phi444, %cond.true28.i ], [ %.pre445, %cond.end31.i ]
+  %cond32.i101 = phi <2 x double> [ %hlsl.wave.prefix.product29.i, %cond.true28.i ], [ zeroinitializer, %cond.end31.i ]
+  %cmp3.i51131466396 = phi i1 [ true, %cond.true28.i ], [ false, %cond.end31.i ]
+  %cond26.i6693 = phi <2 x double> [ %cond26.i74, %cond.true28.i ], [ %cond26.i66, %cond.end31.i ]
+  %hlsl.wave.prefix.product35.i = call reassoc nnan ninf nsz arcp afn <2 x double> @llvm.spv.wave.prefix.product.v2f64(<2 x double> %.pre-phi446) [ "convergencectrl"(token %0) ]
+  br label %cond.true40.i
+
+cond.true40.i:                                    ; preds = %cond.end31.i, %cond.true28.i, %cond.true34.i
+  %.pre-phi448 = phi <2 x double> [ %.pre-phi446, %cond.true34.i ], [ %.pre-phi444, %cond.true28.i ], [ %.pre445, %cond.end31.i ]
+  %cond38.i131 = phi <2 x double> [ %hlsl.wave.prefix.product35.i, %cond.true34.i ], [ zeroinitializer, %cond.true28.i ], [ zeroinitializer, %cond.end31.i ]
+  %cond26.i6684130 = phi <2 x double> [ %cond26.i6693, %cond.true34.i ], [ %cond26.i74, %cond.true28.i ], [ %cond26.i66, %cond.end31.i ]
+  %cmp3.i51131466387127 = phi i1 [ %cmp3.i51131466396, %cond.true34.i ], [ true, %cond.true28.i ], [ false, %cond.end31.i ]
+  %cmp9.i1725496090124 = phi i1 [ true, %cond.true34.i ], [ false, %cond.true28.i ], [ false, %cond.end31.i ]
+  %cond32.i92122 = phi <2 x double> [ %cond32.i101, %cond.true34.i ], [ %hlsl.wave.prefix.product29.i, %cond.true28.i ], [ zeroinitializer, %cond.end31.i ]
+  %hlsl.wave.prefix.product41.i = call reassoc nnan ninf nsz arcp afn <2 x double> @llvm.spv.wave.prefix.product.v2f64(<2 x double> %.pre-phi448) [ "convergencectrl"(token %0) ]
+  br i1 %cmp.i, label %cond.true46.i, label %cond.end49.i
+
+cond.true46.i:                                    ; preds = %cond.true40.i
+  %7 = shufflevector <4 x double> %4, <4 x double> poison, <3 x i32> <i32 0, i32 1, i32 2>
+  %hlsl.wave.prefix.product47.i = call reassoc nnan ninf nsz arcp afn <3 x double> @llvm.spv.wave.prefix.product.v3f64(<3 x double> %7) [ "convergencectrl"(token %0) ]
+  br i1 %cmp3.i51131466387127, label %cond.true52.i, label %cond.end55.i
+
+cond.end49.i:                                     ; preds = %cond.true40.i
+  br i1 %cmp3.i51131466387127, label %cond.end49.i.cond.true52.i_crit_edge, label %cond.end55.i
+
+cond.end49.i.cond.true52.i_crit_edge:             ; preds = %cond.end49.i
+  %.pre449 = shufflevector <4 x double> %4, <4 x double> poison, <3 x i32> <i32 0, i32 1, i32 2>
+  br label %cond.true52.i
+
+cond.true52.i:                                    ; preds = %cond.end49.i.cond.true52.i_crit_edge, %cond.true46.i
+  %.pre-phi450 = phi <3 x double> [ %.pre449, %cond.end49.i.cond.true52.i_crit_edge ], [ %7, %cond.true46.i ]
+  %cond50.i189 = phi <3 x double> [ zeroinitializer, %cond.end49.i.cond.true52.i_crit_edge ], [ %hlsl.wave.prefix.product47.i, %cond.true46.i ]
+  %hlsl.wave.prefix.product53.i = call reassoc nnan ninf nsz arcp afn <3 x double> @llvm.spv.wave.prefix.product.v3f64(<3 x double> %.pre-phi450) [ "convergencectrl"(token %0) ]
+  br i1 %cmp9.i1725496090124, label %cond.true58.i, label %cond.true64.i
+
+cond.end55.i:                                     ; preds = %cond.true46.i, %cond.end49.i
+  %cond50.i177 = phi <3 x double> [ %hlsl.wave.prefix.product47.i, %cond.true46.i ], [ zeroinitializer, %cond.end49.i ]
+  %.pre451 = shufflevector <4 x double> %4, <4 x double> poison, <3 x i32> <i32 0, i32 1, i32 2>
+  br i1 %cmp9.i1725496090124, label %cond.true58.i, label %cond.true64.i
+
+cond.true58.i:                                    ; preds = %cond.end55.i, %cond.true52.i
+  %.pre-phi452 = phi <3 x double> [ %.pre-phi450, %cond.true52.i ], [ %.pre451, %cond.end55.i ]
+  %cond56.i228 = phi <3 x double> [ %hlsl.wave.prefix.product53.i, %cond.true52.i ], [ zeroinitializer, %cond.end55.i ]
+  %cmp3.i51131466387117147172221 = phi i1 [ true, %cond.true52.i ], [ false, %cond.end55.i ]
+  %cond50.i177216 = phi <3 x double> [ %cond50.i189, %cond.true52.i ], [ %cond50.i177, %cond.end55.i ]
+  %hlsl.wave.prefix.product59.i = call reassoc nnan ninf nsz arcp afn <3 x double> @llvm.spv.wave.prefix.product.v3f64(<3 x double> %.pre-phi452) [ "convergencectrl"(token %0) ]
+  br label %cond.true64.i
+
+cond.true64.i:                                    ; preds = %cond.end55.i, %cond.true52.i, %cond.true58.i
+  %.pre-phi454 = phi <3 x double> [ %.pre-phi452, %cond.true58.i ], [ %.pre-phi450, %cond.true52.i ], [ %.pre451, %cond.end55.i ]
+  %cond62.i270 = phi <3 x double> [ %hlsl.wave.prefix.product59.i, %cond.true58.i ], [ zeroinitializer, %cond.true52.i ], [ zeroinitializer, %cond.end55.i ]
+  %cond50.i177203269 = phi <3 x double> [ %cond50.i177216, %cond.true58.i ], [ %cond50.i189, %cond.true52.i ], [ %cond50.i177, %cond.end55.i ]
+  %cmp3.i51131466387117147172208264 = phi i1 [ %cmp3.i51131466387117147172221, %cond.true58.i ], [ true, %cond.true52.i ], [ false, %cond.end55.i ]
+  %cmp9.i1725496090114150169211261 = phi i1 [ true, %cond.true58.i ], [ false, %cond.true52.i ], [ false, %cond.end55.i ]
+  %cond56.i215257 = phi <3 x double> [ %cond56.i228, %cond.true58.i ], [ %hlsl.wave.prefix.product53.i, %cond.true52.i ], [ zeroinitializer, %cond.end55.i ]
+  %hlsl.wave.prefix.product65.i = call reassoc nnan ninf nsz arcp afn <3 x double> @llvm.spv.wave.prefix.product.v3f64(<3 x double> %.pre-phi454) [ "convergencectrl"(token %0) ]
+  br i1 %cmp.i, label %cond.true70.i, label %cond.end73.i
+
+cond.true70.i:                                    ; preds = %cond.true64.i
+  %hlsl.wave.prefix.product71.i = call reassoc nnan ninf nsz arcp afn <4 x double> @llvm.spv.wave.prefix.product.v4f64(<4 x double> %4) [ "convergencectrl"(token %0) ]
+  br i1 %cmp3.i51131466387117147172208264, label %cond.true76.i, label %cond.end79.i
+
+cond.end73.i:                                     ; preds = %cond.true64.i
+  br i1 %cmp3.i51131466387117147172208264, label %cond.true76.i, label %cond.end79.i
+
+cond.true76.i:                                    ; preds = %cond.true70.i, %cond.end73.i
+  %cond74.i346 = phi <4 x double> [ %hlsl.wave.prefix.product71.i, %cond.true70.i ], [ zeroinitializer, %cond.end73.i ]
+  %hlsl.wave.prefix.product77.i = call reassoc nnan ninf nsz arcp afn <4 x double> @llvm.spv.wave.prefix.product.v4f64(<4 x double> %4) [ "convergencectrl"(token %0) ]
+  br i1 %cmp9.i1725496090114150169211261, label %cond.true82.i, label %cond.true88.i
+
+cond.end79.i:                                     ; preds = %cond.true70.i, %cond.end73.i
+  %cond74.i331 = phi <4 x double> [ %hlsl.wave.prefix.product71.i, %cond.true70.i ], [ zeroinitializer, %cond.end73.i ]
+  br i1 %cmp9.i1725496090114150169211261, label %cond.true82.i, label %cond.true88.i
+
+cond.true82.i:                                    ; preds = %cond.true76.i, %cond.end79.i
+  %cond80.i392 = phi <4 x double> [ %hlsl.wave.prefix.product77.i, %cond.true76.i ], [ zeroinitializer, %cond.end79.i ]
+  %cond74.i331378 = phi <4 x double> [ %cond74.i346, %cond.true76.i ], [ %cond74.i331, %cond.end79.i ]
+  %hlsl.wave.prefix.product83.i = call reassoc nnan ninf nsz arcp afn <4 x double> @llvm.spv.wave.prefix.product.v4f64(<4 x double> %4) [ "convergencectrl"(token %0) ]
+  br label %cond.true88.i
+
+cond.true88.i:                                    ; preds = %cond.end79.i, %cond.true76.i, %cond.true82.i
+  %cond86.i438 = phi <4 x double> [ %hlsl.wave.prefix.product83.i, %cond.true82.i ], [ zeroinitializer, %cond.true76.i ], [ zeroinitializer, %cond.end79.i ]
+  %cond74.i331363437 = phi <4 x double> [ %cond74.i331378, %cond.true82.i ], [ %cond74.i346, %cond.true76.i ], [ %cond74.i331, %cond.end79.i ]
+  %cond80.i377424 = phi <4 x double> [ %cond80.i392, %cond.true82.i ], [ %hlsl.wave.prefix.product77.i, %cond.true76.i ], [ zeroinitializer, %cond.end79.i ]
+  %hlsl.wave.prefix.product89.i = call reassoc nnan ninf nsz arcp afn <4 x double> @llvm.spv.wave.prefix.product.v4f64(<4 x double> %4) [ "convergencectrl"(token %0) ]
+  br label %_Z4mainDv3_j.exit
+
+_Z4mainDv3_j.exit:                                ; preds = %cond.end13.i, %cond.true88.i
+  %cond86.i423 = phi <4 x double> [ %cond86.i438, %cond.true88.i ], [ zeroinitializer, %cond.end13.i ]
+  %cond74.i331363422 = phi <4 x double> [ %cond74.i331363437, %cond.true88.i ], [ zeroinitializer, %cond.end13.i ]
+  %cond62.i256286330364421 = phi <3 x double> [ %cond62.i270, %cond.true88.i ], [ zeroinitializer, %cond.end13.i ]
+  %cond50.i177203255287329365420 = phi <3 x double> [ %cond50.i177203269, %cond.true88.i ], [ zeroinitializer, %cond.end13.i ]
+  %cond38.i121143176204254288328366419 = phi <2 x double> [ %cond38.i131, %cond.true88.i ], [ zeroinitializer, %cond.end13.i ]
+  %cond26.i6684120144175205253289327367418 = phi <2 x double> [ %cond26.i6684130, %cond.true88.i ], [ zeroinitializer, %cond.end13.i ]
+  %cond14.i33456486118146173207251291325369417 = phi double [ %cond14.i34, %cond.true88.i ], [ 0.000000e+00, %cond.end13.i ]
+  %cond.i31329476288116148171209249293324370416 = phi double [ %cond.i31330, %cond.true88.i ], [ 0.000000e+00, %cond.end13.i ]
+  %cond8.i1527486189115149170210248294323371415 = phi double [ %cond8.i1528, %cond.true88.i ], [ 0.000000e+00, %cond.end13.i ]
+  %cond20.i505991113151168212246296321372414 = phi double [ %hlsl.wave.prefix.product17.i, %cond.true88.i ], [ 0.000000e+00, %cond.end13.i ]
+  %cond32.i92112152167213245297320373413 = phi <2 x double> [ %cond32.i92122, %cond.true88.i ], [ zeroinitializer, %cond.end13.i ]
+  %cond44.i153166214244298319374412 = phi <2 x double> [ %hlsl.wave.prefix.product41.i, %cond.true88.i ], [ zeroinitializer, %cond.end13.i ]
+  %cond56.i215243299318375411 = phi <3 x double> [ %cond56.i215257, %cond.true88.i ], [ zeroinitializer, %cond.end13.i ]
+  %cond68.i300317376410 = phi <3 x double> [ %hlsl.wave.prefix.product65.i, %cond.true88.i ], [ zeroinitializer, %cond.end13.i ]
+  %cond80.i377409 = phi <4 x double> [ %cond80.i377424, %cond.true88.i ], [ zeroinitializer, %cond.end13.i ]
+  %cond92.i = phi reassoc nnan ninf nsz arcp afn <4 x double> [ %hlsl.wave.prefix.product89.i, %cond.true88.i ], [ zeroinitializer, %cond.end13.i ]
+  %8 = tail call target("spirv.VulkanBuffer", [0 x <4 x double>], 12, 1) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v4f64_12_1t(i32 0, i32 5, i32 1, i32 0, ptr nonnull @.str.10)
+  %9 = tail call target("spirv.VulkanBuffer", [0 x <4 x double>], 12, 1) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v4f64_12_1t(i32 0, i32 4, i32 1, i32 0, ptr nonnull @.str.8)
+  %10 = tail call target("spirv.VulkanBuffer", [0 x <4 x double>], 12, 1) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v4f64_12_1t(i32 0, i32 3, i32 1, i32 0, ptr nonnull @.str.6)
+  %11 = tail call target("spirv.VulkanBuffer", [0 x <4 x double>], 12, 1) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v4f64_12_1t(i32 0, i32 2, i32 1, i32 0, ptr nonnull @.str.4)
+  %12 = tail call target("spirv.VulkanBuffer", [0 x <4 x double>], 12, 1) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v4f64_12_1t(i32 0, i32 1, i32 1, i32 0, ptr nonnull @.str.2)
+  call void @llvm.lifetime.start.p0(ptr nonnull %scalars.i) #5
+  store double %cond.i31329476288116148171209249293324370416, ptr %scalars.i, align 8, !tbaa !7
+  %arrayinit.element.i = getelementptr inbounds nuw i8, ptr %scalars.i, i64 8
+  store double %cond8.i1527486189115149170210248294323371415, ptr %arrayinit.element.i, align 8, !tbaa !7
+  %arrayinit.element93.i = getelementptr inbounds nuw i8, ptr %scalars.i, i64 16
+  store double %cond14.i33456486118146173207251291325369417, ptr %arrayinit.element93.i, align 8, !tbaa !7
+  %arrayinit.element94.i = getelementptr inbounds nuw i8, ptr %scalars.i, i64 24
+  store double %cond20.i505991113151168212246296321372414, ptr %arrayinit.element94.i, align 8, !tbaa !7
+  call void @llvm.lifetime.start.p0(ptr nonnull %vec2s.i) #5
+  store <2 x double> %cond26.i6684120144175205253289327367418, ptr %vec2s.i, align 8, !tbaa !6
+  %arrayinit.element97.i = getelementptr inbounds nuw i8, ptr %vec2s.i, i64 16
+  store <2 x double> %cond32.i92112152167213245297320373413, ptr %arrayinit.element97.i, align 8, !tbaa !6
+  %arrayinit.element102.i = getelementptr inbounds nuw i8, ptr %vec2s.i, i64 32
+  store <2 x double> %cond38.i121143176204254288328366419, ptr %arrayinit.element102.i, align 8, !tbaa !6
+  %arrayinit.element107.i = getelementptr inbounds nuw i8, ptr %vec2s.i, i64 48
+  store <2 x double> %cond44.i153166214244298319374412, ptr %arrayinit.element107.i, align 8, !tbaa !6
+  call void @llvm.lifetime.start.p0(ptr nonnull %vec3s.i) #5
+  store <3 x double> %cond50.i177203255287329365420, ptr %vec3s.i, align 8, !tbaa !6
+  %arrayinit.element118.i = getelementptr inbounds nuw i8, ptr %vec3s.i, i64 24
+  store <3 x double> %cond56.i215243299318375411, ptr %arrayinit.element118.i, align 8, !tbaa !6
+  %arrayinit.element125.i = getelementptr inbounds nuw i8, ptr %vec3s.i, i64 48
+  store <3 x double> %cond62.i256286330364421, ptr %arrayinit.element125.i, align 8, !tbaa !6
+  %arrayinit.element132.i = getelementptr inbounds nuw i8, ptr %vec3s.i, i64 72
+  store <3 x double> %cond68.i300317376410, ptr %arrayinit.element132.i, align 8, !tbaa !6
+  call void @llvm.lifetime.start.p0(ptr nonnull %vec4s.i) #5
+  store <4 x double> %cond74.i331363422, ptr %vec4s.i, align 8, !tbaa !6
+  %arrayinit.element147.i = getelementptr inbounds nuw i8, ptr %vec4s.i, i64 32
+  store <4 x double> %cond80.i377409, ptr %arrayinit.element147.i, align 8, !tbaa !6
+  %arrayinit.element156.i = getelementptr inbounds nuw i8, ptr %vec4s.i, i64 64
+  store <4 x double> %cond86.i423, ptr %arrayinit.element156.i, align 8, !tbaa !6
+  %arrayinit.element165.i = getelementptr inbounds nuw i8, ptr %vec4s.i, i64 96
+  store <4 x double> %cond92.i, ptr %arrayinit.element165.i, align 8, !tbaa !6
+  %idxprom.i = zext i32 %2 to i64
+  %arrayidx.i = getelementptr inbounds nuw [8 x i8], ptr %scalars.i, i64 %idxprom.i
+  %13 = load double, ptr %arrayidx.i, align 8, !tbaa !7
+  %14 = tail call noundef align 8 dereferenceable(32) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v4f64_12_1t.i32(target("spirv.VulkanBuffer", [0 x <4 x double>], 12, 1) %12, i32 %2)
+  store double %13, ptr addrspace(11) %14, align 8
+  %arrayidx176.i = getelementptr inbounds nuw [16 x i8], ptr %vec2s.i, i64 %idxprom.i
+  %15 = load <2 x double>, ptr %arrayidx176.i, align 8, !tbaa !6
+  %16 = tail call noundef align 8 dereferenceable(32) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v4f64_12_1t.i32(target("spirv.VulkanBuffer", [0 x <4 x double>], 12, 1) %11, i32 %2)
+  %17 = extractelement <2 x double> %15, i64 0
+  store double %17, ptr addrspace(11) %16, align 8
+  %18 = extractelement <2 x double> %15, i64 1
+  %19 = getelementptr inbounds nuw i8, ptr addrspace(11) %16, i64 8
+  store double %18, ptr addrspace(11) %19, align 8
+  %arrayidx179.i = getelementptr inbounds nuw [24 x i8], ptr %vec3s.i, i64 %idxprom.i
+  %20 = load <3 x double>, ptr %arrayidx179.i, align 8, !tbaa !6
+  %21 = tail call noundef align 8 dereferenceable(32) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v4f64_12_1t.i32(target("spirv.VulkanBuffer", [0 x <4 x double>], 12, 1) %10, i32 %2)
+  %22 = extractelement <3 x double> %20, i64 0
+  store double %22, ptr addrspace(11) %21, align 8
+  %23 = extractelement <3 x double> %20, i64 1
+  %24 = getelementptr inbounds nuw i8, ptr addrspace(11) %21, i64 8
+  store double %23, ptr addrspace(11) %24, align 8
+  %25 = extractelement <3 x double> %20, i64 2
+  %26 = getelementptr inbounds nuw i8, ptr addrspace(11) %21, i64 16
+  store double %25, ptr addrspace(11) %26, align 8
+  %arrayidx182.i = getelementptr inbounds nuw [32 x i8], ptr %vec4s.i, i64 %idxprom.i
+  %27 = load <4 x double>, ptr %arrayidx182.i, align 8, !tbaa !6
+  %28 = tail call noundef align 8 dereferenceable(32) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v4f64_12_1t.i32(target("spirv.VulkanBuffer", [0 x <4 x double>], 12, 1) %9, i32 %2)
+  store <4 x double> %27, ptr addrspace(11) %28, align 8, !tbaa !6
+  %hlsl.wave.prefix.product184.i = call reassoc nnan ninf nsz arcp afn <4 x double> @llvm.spv.wave.prefix.product.v4f64(<4 x double> <double 2.000000e+00, double 3.000000e+00, double 5.000000e+00, double 7.000000e+00>) [ "convergencectrl"(token %0) ]
+  %29 = tail call noundef align 8 dereferenceable(32) ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v4f64_12_1t.i32(target("spirv.VulkanBuffer", [0 x <4 x double>], 12, 1) %8, i32 %2)
+  store <4 x double> %hlsl.wave.prefix.product184.i, ptr addrspace(11) %29, align 8, !tbaa !6
+  call void @llvm.lifetime.end.p0(ptr nonnull %vec4s.i) #5
+  call void @llvm.lifetime.end.p0(ptr nonnull %vec3s.i) #5
+  call void @llvm.lifetime.end.p0(ptr nonnull %vec2s.i) #5
+  call void @llvm.lifetime.end.p0(ptr nonnull %scalars.i) #5
+  ret void
+}
+
+; Function Attrs: mustprogress nofree nosync nounwind willreturn memory(none)
+declare i32 @llvm.spv.thread.id.in.group.i32(i32) #2
+
+; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(ptr captures(none)) #3
+
+; Function Attrs: convergent mustprogress nocallback nofree nosync nounwind willreturn memory(none)
+declare double @llvm.spv.wave.prefix.product.f64(double) #0
+
+; Function Attrs: convergent mustprogress nocallback nofree nosync nounwind willreturn memory(none)
+declare <2 x double> @llvm.spv.wave.prefix.product.v2f64(<2 x double>) #0
+
+; Function Attrs: convergent mustprogress nocallback nofree nosync nounwind willreturn memory(none)
+declare <3 x double> @llvm.spv.wave.prefix.product.v3f64(<3 x double>) #0
+
+; Function Attrs: convergent mustprogress nocallback nofree nosync nounwind willreturn memory(none)
+declare <4 x double> @llvm.spv.wave.prefix.product.v4f64(<4 x double>) #0
+
+; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(ptr captures(none)) #3
+
+; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(none)
+declare target("spirv.VulkanBuffer", [0 x <4 x double>], 12, 0) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v4f64_12_0t(i32, i32, i32, i32, ptr) #4
+
+; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(none)
+declare target("spirv.VulkanBuffer", [0 x <4 x double>], 12, 1) @llvm.spv.resource.handlefrombinding.tspirv.VulkanBuffer_a0v4f64_12_1t(i32, i32, i32, i32, ptr) #4
+
+; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(none)
+declare ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v4f64_12_0t.i32(target("spirv.VulkanBuffer", [0 x <4 x double>], 12, 0), i32) #4
+
+; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(none)
+declare ptr addrspace(11) @llvm.spv.resource.getpointer.p11.tspirv.VulkanBuffer_a0v4f64_12_1t.i32(target("spirv.VulkanBuffer", [0 x <4 x double>], 12, 1), i32) #4
+
+attributes #0 = { convergent mustprogress nocallback nofree nosync nounwind willreturn memory(none) }
+attributes #1 = { convergent mustprogress nofree noinline norecurse nosync nounwind willreturn memory(readwrite, inaccessiblemem: none, target_mem: none) "frame-pointer"="all" "hlsl.numthreads"="4,1,1" "hlsl.shader"="compute" "no-signed-zeros-fp-math"="true" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+attributes #2 = { mustprogress nofree nosync nounwind willreturn memory(none) }
+attributes #3 = { mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #4 = { mustprogress nocallback nofree nosync nounwind willreturn memory(none) }
+attributes #5 = { nounwind }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+!llvm.errno.tbaa = !{!2}
+
+!0 = !{i32 7, !"frame-pointer", i32 2}
+!1 = !{!"clang version 23.0.0git (https://github.com/llvm/llvm-project.git dfab397600fb548e895d2c28832d5eaeea3f8bb1)"}
+!2 = !{!3, !3, i64 0}
+!3 = !{!"int", !4, i64 0}
+!4 = !{!"omnipotent char", !5, i64 0}
+!5 = !{!"Simple C++ TBAA"}
+!6 = !{!4, !4, i64 0}
+!7 = !{!8, !8, i64 0}
+!8 = !{!"double", !4, i64 0}

--- a/llvm/test/CodeGen/SPIRV/structurizer/switch-case-fallthrough-order.ll
+++ b/llvm/test/CodeGen/SPIRV/structurizer/switch-case-fallthrough-order.ll
@@ -1,0 +1,68 @@
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+; RUN: llc -mtriple=spirv-unknown-vulkan-compute -O0 %s -o - | FileCheck %s
+
+; Test that the structurizer correctly handles switch case fall-through ordering.
+; When SPIRVMergeRegionExitTargets creates switch-based routing with multiple
+; exit targets, and one case construct branches to another (fall-through), the
+; cases must be ordered so the falling-through case immediately precedes its
+; target in the OpSwitch target list.
+;
+; This pattern occurs with 4+ convergent operations in nested conditionals,
+; where the routing switch has cases that form a chain.
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+target triple = "spirv-unknown-vulkan-compute"
+
+; CHECK: OpSelectionMerge
+; CHECK: OpBranchConditional
+
+define internal spir_func void @main() #0 {
+entry:
+  %0 = call token @llvm.experimental.convergence.entry()
+  %tid = call i32 @__hlsl_wave_get_lane_index() [ "convergencectrl"(token %0) ]
+  %cond1 = icmp ult i32 %tid, 16
+  br i1 %cond1, label %wave1, label %thread1
+
+wave1:
+  %r1 = call double @llvm.spv.wave.prefix.product.f64(double 1.0) [ "convergencectrl"(token %0) ]
+  %cond2 = icmp ult i32 %tid, 8
+  br i1 %cond2, label %wave2, label %thread2
+
+wave2:
+  %r2 = call double @llvm.spv.wave.prefix.product.f64(double 2.0) [ "convergencectrl"(token %0) ]
+  %cond3 = icmp ult i32 %tid, 4
+  br i1 %cond3, label %wave3, label %thread3
+
+wave3:
+  %r3 = call double @llvm.spv.wave.prefix.product.f64(double 3.0) [ "convergencectrl"(token %0) ]
+  %cond4 = icmp ult i32 %tid, 2
+  br i1 %cond4, label %wave4, label %thread4
+
+wave4:
+  %r4 = call double @llvm.spv.wave.prefix.product.f64(double 4.0) [ "convergencectrl"(token %0) ]
+  br label %merge
+
+thread4:
+  br label %merge
+
+thread3:
+  br label %merge
+
+thread2:
+  br label %merge
+
+thread1:
+  br label %merge
+
+merge:
+  %result = phi double [ %r4, %wave4 ], [ 0.0, %thread4 ], [ 0.0, %thread3 ], [ 0.0, %thread2 ], [ 0.0, %thread1 ]
+  ret void
+}
+
+declare token @llvm.experimental.convergence.entry() #1
+declare i32 @__hlsl_wave_get_lane_index() #2
+declare double @llvm.spv.wave.prefix.product.f64(double) #2
+
+attributes #0 = { convergent noinline norecurse nounwind optnone "hlsl.numthreads"="32,1,1" "hlsl.shader"="compute" }
+attributes #1 = { convergent nocallback nofree nosync nounwind willreturn }
+attributes #2 = { convergent nounwind }


### PR DESCRIPTION
This PR is an attempt to address a SPIRV assertion failure, and is open for feedback.

**Problem**

When compiling HLSL shaders with nested convergent operations (e.g., WavePrefixProduct<double4>), the SPIR-V structurizer produces invalid structured control flow that fails spirv-val with:

``` error: block <ID> 17 branches to the selection construct, but not to the selection header <ID> 7```

**Root Cause**

SPIRVMergeRegionExitTargets creates switch-based routing blocks for convergence regions with multiple exits. Later, the structurizer's splitCriticalEdges (STEP 6) creates conditional routing blocks where one branch goes through a nested header and the other is a "thread" block that skips the convergent operation. Both paths converge at a single merge point, but the header no longer dominates that merge (the thread block provides an alternate path), making the merge assignment invalid per SPIR-V rules.

**Fix**

Three changes to SPIRVStructurizer.cpp:

 1. fixInvalidMergeDominance (new function): After structurization, detects headers that don't dominate their merge block. Inserts a new intermediate merge block, redirecting only the header-dominated predecessors through it, so the header properly dominates its merge while sibling paths continue to the original convergence point. Handles phi node splitting correctly.
 2. addHeaderToRemainingDivergentDAG candidate filtering: Only filters header-block successors that dominate the current block (normal structured flow). Headers that don't dominate us indicate routing into a construct from outside — these need their own selection merge.
 3. fixSwitchCaseOrder (new function): Reorders switch case targets so that when one case construct falls through to another, it immediately precedes the target in the OpSwitch target list (required by SPIR-V spec).

The fix runs addHeaderToRemainingDivergentDAG and fixInvalidMergeDominance in a convergence loop since each pass may expose issues for the other.

**Testing**

 - All 55 existing structurizer lit tests pass (no regressions)
 - Added 5 new tests:
      4 tests covering nested convergent operations with 2–4 levels of routing
      1 regression test from the exact IR that triggered the original bug

Assisted by Github Copilot
Addresses [#1083](https://github.com/llvm/llvm-project/issues/217826)