### PR TITLE
[DirectX] Fill CommitCount field of VERS part with LLVM_COMMIT_COUNT

### DIFF
--- a/llvm/cmake/modules/GenerateVersionFromVCS.cmake
+++ b/llvm/cmake/modules/GenerateVersionFromVCS.cmake
@@ -5,9 +5,9 @@
 #   <NAME>_SOURCE_DIR - A path to source directory for each name in NAMES.
 #   HEADER_FILE       - The header file to write
 #
-# The output header will contain macros <NAME>_REPOSITORY and <NAME>_REVISION,
-# where "<NAME>" is substituted with the names specified in the input variables,
-# for each of the <NAME>_SOURCE_DIR given.
+# The output header will contain macros <NAME>_REPOSITORY, <NAME>_REVISION,
+# and <NAME>_COMMIT_COUNT, where "<NAME>" is substituted with the names specified
+# in the input variables, for each of the <NAME>_SOURCE_DIR given.
 
 get_filename_component(LLVM_CMAKE_DIR "${CMAKE_SCRIPT_MODE_FILE}" PATH)
 
@@ -18,7 +18,7 @@ include(VersionFromVCS)
 # Handle strange terminals
 set(ENV{TERM} "dumb")
 
-function(append_info name revision repository)
+function(append_info name revision repository commit_count)
   if(revision)
     file(APPEND "${HEADER_FILE}.tmp"
       "#define ${name}_REVISION R\"(${revision})\"\n")
@@ -33,9 +33,17 @@ function(append_info name revision repository)
     file(APPEND "${HEADER_FILE}.tmp"
       "#undef ${name}_REPOSITORY\n")
   endif()
+  if(commit_count)
+    file(APPEND "${HEADER_FILE}.tmp"
+      "#define ${name}_COMMIT_COUNT ${commit_count}u\n")
+  else()
+    file(APPEND "${HEADER_FILE}.tmp"
+      "#undef ${name}_COMMIT_COUNT\n")
+  endif()
 endfunction()
 
 foreach(name IN LISTS NAMES)
+  set(commit_count "")
   if(LLVM_FORCE_VC_REVISION AND LLVM_FORCE_VC_REPOSITORY)
     set(revision ${LLVM_FORCE_VC_REVISION})
     set(repository ${LLVM_FORCE_VC_REPOSITORY})
@@ -48,12 +56,12 @@ foreach(name IN LISTS NAMES)
     set(repository ${${name}_VC_REPOSITORY})
   elseif(DEFINED ${name}_SOURCE_DIR)
     if (${name}_SOURCE_DIR)
-      get_source_info("${${name}_SOURCE_DIR}" revision repository)
+      get_source_info("${${name}_SOURCE_DIR}" revision repository commit_count)
     endif()
   else()
     message(FATAL_ERROR "${name}_SOURCE_DIR is not defined")
   endif()
-  append_info(${name} "${revision}" "${repository}")
+  append_info(${name} "${revision}" "${repository}" "${commit_count}")
 endforeach()
 
 # Copy the file only if it has changed.

--- a/llvm/cmake/modules/VersionFromVCS.cmake
+++ b/llvm/cmake/modules/VersionFromVCS.cmake
@@ -3,7 +3,7 @@
 # existence of certain subdirectories under SOURCE_DIR (if provided as an
 # extra argument, otherwise uses CMAKE_CURRENT_SOURCE_DIR).
 
-function(get_source_info path revision repository)
+function(get_source_info path revision repository commit_count)
   find_package(Git QUIET)
   if(GIT_FOUND)
     execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --git-dir
@@ -21,6 +21,15 @@ function(get_source_info path revision repository)
       if(git_result EQUAL 0)
         string(STRIP "${git_output}" git_output)
         set(${revision} ${git_output} PARENT_SCOPE)
+      endif()
+      execute_process(COMMAND ${GIT_EXECUTABLE} rev-list --count HEAD
+        WORKING_DIRECTORY ${path}
+        RESULT_VARIABLE git_result
+        OUTPUT_VARIABLE git_output
+        ERROR_QUIET)
+      if(git_result EQUAL 0)
+        string(STRIP "${git_output}" git_output)
+        set(${commit_count} ${git_output} PARENT_SCOPE)
       endif()
       execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref --symbolic-full-name @{upstream}
         WORKING_DIRECTORY ${path}

--- a/llvm/lib/MC/DXContainerInfo.cpp
+++ b/llvm/lib/MC/DXContainerInfo.cpp
@@ -63,7 +63,11 @@ CompilerVersion::CompilerVersion() {
 #ifndef NDEBUG
   Parameters.Flags |= dxbc::CompilerVersionFlags::Debug;
 #endif
+#ifdef LLVM_COMMIT_COUNT
+  Parameters.CommitCount = LLVM_COMMIT_COUNT;
+#else
   Parameters.CommitCount = 0;
+#endif
   Parameters.ContentSizeInBytes = 0;
 #ifdef LLVM_REVISION
   CommitSha = LLVM_REVISION;

--- a/llvm/unittests/ObjectYAML/DXContainerYAMLTest.cpp
+++ b/llvm/unittests/ObjectYAML/DXContainerYAMLTest.cpp
@@ -685,7 +685,11 @@ TEST(DXCFile, ComputeVERSPart) {
   EXPECT_FALSE(!!(Header.Flags & dxbc::CompilerVersionFlags::Debug));
 #endif
   EXPECT_FALSE(!!(Header.Flags & dxbc::CompilerVersionFlags::Internal));
+#ifdef LLVM_COMMIT_COUNT
+  EXPECT_EQ(Header.CommitCount, LLVM_COMMIT_COUNT);
+#else
   EXPECT_EQ(Header.CommitCount, 0u);
+#endif
 #ifdef LLVM_REVISION
   EXPECT_EQ(VERS->CommitSha, LLVM_REVISION);
 #else

--- a/llvm/utils/gn/build/write_vcsrevision.py
+++ b/llvm/utils/gn/build/write_vcsrevision.py
@@ -8,7 +8,6 @@ import subprocess
 import sys
 import shutil
 
-
 THIS_DIR = os.path.abspath(os.path.dirname(__file__))
 LLVM_DIR = os.path.dirname(os.path.dirname(os.path.dirname(THIS_DIR)))
 
@@ -67,13 +66,25 @@ def main():
             .decode()
             .strip()
         )
+        commit_count = (
+            subprocess.check_output(
+                [git, "rev-list", "--count", "HEAD"], cwd=git_dir, shell=use_shell
+            )
+            .decode()
+            .strip()
+        )
         for name in args.name:
             vcsrevision_contents += '#define %s_REVISION "%s"\n' % (name, rev)
             vcsrevision_contents += '#define %s_REPOSITORY "%s"\n' % (name, url)
+            vcsrevision_contents += "#define %s_COMMIT_COUNT %su\n" % (
+                name,
+                commit_count,
+            )
     else:
         for name in args.name:
             vcsrevision_contents += "#undef %s_REVISION\n" % name
             vcsrevision_contents += "#undef %s_REPOSITORY\n" % name
+            vcsrevision_contents += "#undef %s_COMMIT_COUNT\n" % name
 
     # If the output already exists and is identical to what we'd write,
     # return to not perturb the existing file's timestamp.

--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -291,6 +291,7 @@ write_file(
     content = [
         "#undef LLVM_REVISION",
         "#undef LLVM_REPOSITORY",
+        "#undef LLVM_COMMIT_COUNT",
     ],
 )
 


### PR DESCRIPTION
Microsoft's DirectXShaderCompiler fills `CommitCount` field of DXContainer VERS part with the output of `git rev-list --count HEAD` (the number of commits reachable from HEAD). This patch reimplements this behavior in llc and yaml2obj. 

LLVM_COMMIT_COUNT macro, which contains commit count of the branch used for building LLVM, is added to VCSRevision.h.