### PR TITLE
[MC][AsmParser] Check .lto_discard before parsing the assignment

### DIFF
--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -2886,6 +2886,13 @@ void AsmParser::handleMacroExit() {
 }
 
 bool AsmParser::parseAssignment(StringRef Name, AssignmentKind Kind) {
+  // If the LTO library has asked us to discard this symbol, skip the
+  // assignment without ever calling parseAssignmentExpression.
+  if (discardLTOSymbol(Name)) {
+    eatToEndOfStatement();
+    return false;
+  }
+
   MCSymbol *Sym;
   const MCExpr *Value;
   SMLoc ExprLoc = getTok().getLoc();
@@ -2901,9 +2908,6 @@ bool AsmParser::parseAssignment(StringRef Name, AssignmentKind Kind) {
     // should just return out.
     return false;
   }
-
-  if (discardLTOSymbol(Name))
-    return false;
 
   // Do the assignment.
   switch (Kind) {

--- a/llvm/test/MC/ELF/lto-discard.s
+++ b/llvm/test/MC/ELF/lto-discard.s
@@ -2,6 +2,15 @@
 // for the specified symbols.
 // RUN: llvm-mc -triple x86_64-pc-linux-gnu < %s | FileCheck %s
 
+// Also check directly via the integrated assembler that a symbol defined
+// before ".lto_discard SYM" survives into the object file even when
+// ".lto_discard SYM" is followed by another set of attribute/assignment
+// directives for SYM. The latter pattern is what the LLVM LTO library
+// emits when multiple bitcode inputs each carry the same weak symbol
+// definition through file-scope inline asm.
+// RUN: llvm-mc -filetype=obj -triple x86_64-pc-linux-gnu %s -o %t.o
+// RUN: llvm-readelf --syms %t.o | FileCheck %s --check-prefix=OBJ
+
 // Check that ".lto_discard" only accepts identifiers.
 // RUN: not llvm-mc -filetype=obj -triple x86_64-pc-linux-gnu --defsym ERR=1 %s 2>&1 |\
 // RUN:         FileCheck %s --check-prefix=ERR
@@ -21,6 +30,23 @@ foo:
 .weak bar
 bar:
     .byte 2
+
+// "Preserve first, discard later" pattern: ".weak baz; .set baz, V" is
+// followed by ".lto_discard baz; .weak baz; .set baz, V". The trailing
+// pair must be ignored without disturbing the preserved first definition.
+// OBJ:      WEAK   {{.*}} ABS    baz
+.weak baz
+.set baz, 0xCAFEC0DE
+.lto_discard baz
+.weak baz
+.set baz, 0xCAFEC0DE
+
+// A ".set" that follows a ".lto_discard SYM" for a previously-undefined
+// SYM must not give SYM a value; SYM should stay an undef weak reference.
+// OBJ:      WEAK   {{.*}} UND    qux
+.weak qux
+.lto_discard qux
+.set qux, 0xDEADBEEF
 
 
 .ifdef ERR


### PR DESCRIPTION
I was deeply stumped, so I asked an LLM to help me track down this Linux kernel build failure:
https://lore.kernel.org/all/202606122021.pA9TozrA-lkp@intel.com/

The bug only surfaced for Full LTO with 2+ TUs because that is when the LTO merger emits ".lto_discard SYM" between two duplicated module-asm blocks; ThinLTO compiles each module separately so the merged-asm pattern does not arise, and a single TU has nothing to discard. Hit in practice by the Linux kernel via -fsanitize=kcfi: every TU that address-takes an externally-defined function emits the same ".weak X; .set X, HASH" pair via module asm, so any >1-TU kcfi build with Full LTO failed to link with "undefined symbol" against the kcfi type id.

parseAssignment checked discardLTOSymbol after parseAssignmentExpression, which is too late for the common "preserve first, discard later" pattern that the LLVM LTO library emits when multiple bitcode inputs each carry the same weak symbol definition through file-scope inline asm. For that pattern, the first ".set SYM, V" makes SYM a redefinable variable; when the second (post-".lto_discard SYM") ".set SYM, V" reaches parseAssignmentExpression, it sees an existing redefinable symbol, calls cloneSymbol, and marks the original SYM as temporary -- which excludes it from the emitted symbol table. The subsequent discardLTOSymbol check then returns true and skips the assignment, leaving the symbol table pointing at an empty unassigned clone while the value we were supposed to preserve has just been dropped.

Move the discardLTOSymbol check to the top of parseAssignment so a discarded assignment never reaches parseAssignmentExpression; just consume tokens to end-of-statement and return.

Extend llvm/test/MC/ELF/lto-discard.s with a second RUN line that drives the integrated assembler directly (-filetype=obj) and inspects the ELF symbol table via llvm-readelf, covering the "preserve first, discard later" pattern that the existing text-only RUN line did not exercise.

Assisted-by: Claude Opus 4.7 (1M context)

@samitolvanen @JustinStitt @bwendling @teresajohnson 