### PR TITLE
[clang][test][darwin] Driver/clang-offload-bundler-multi-compress.c fails on macOS

### DIFF
--- a/clang/test/Driver/clang-offload-bundler-multi-compress.c
+++ b/clang/test/Driver/clang-offload-bundler-multi-compress.c
@@ -1,6 +1,6 @@
 // REQUIRES: x86-registered-target
 // REQUIRES: zlib || zstd
-// UNSUPPORTED: target={{.*}}-darwin{{.*}}, target={{.*}}-aix{{.*}}, target={{.*}}-zos{{.*}}
+// UNSUPPORTED: target={{.*}}-macosx{{.*}}, target={{.*}}-darwin{{.*}}, target={{.*}}-aix{{.*}}, target={{.*}}-zos{{.*}}
 
 // Tests that clang-offload-bundler --list correctly enumerates all bundle IDs
 // from multiple concatenated compressed (CCOB) fat binary blobs stored in the


### PR DESCRIPTION
Driver/clang-offload-bundler-multi-compress.c isn't supported on Darwin, but neglected to list the macosx target.