### PR TITLE
[DirectX][NFC] Use addSection to create SRCI in DXContainerGlobals

### DIFF
--- a/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
+++ b/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
@@ -365,9 +365,7 @@ void DXContainerGlobals::addSourceInfo(Module &M,
   SmallString<256> Data;
   raw_svector_ostream OS(Data);
   MMI.SourceInfo->write(OS);
-  Constant *Constant =
-      ConstantDataArray::getString(M.getContext(), Data, /*AddNull*/ false);
-  Globals.emplace_back(buildContainerGlobal(M, Constant, "dx.srci", "SRCI"));
+  addSection(M, Globals, Data, "dx.srci", "SRCI");
 }
 
 char DXContainerGlobals::ID = 0;


### PR DESCRIPTION
A tiny follow-up for #202761.
Use `addSection()` helper function to create a global for SRCI part.