### PR TITLE
Reland "[lldb][test] Add support for building Wasm test inferiors"

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -245,7 +245,14 @@ class Builder:
         return []
 
     def getLLDBObjRoot(self):
-        return ["LLDB_OBJ_ROOT={}".format(configuration.lldb_obj_root)]
+        if configuration.lldb_obj_root:
+            return [f"LLDB_OBJ_ROOT={configuration.lldb_obj_root}"]
+        return []
+
+    def getResourceDirArgs(self):
+        if configuration.resource_dir:
+            return [f"RESOURCE_DIR={configuration.resource_dir}"]
+        return []
 
     def _getDebugInfoArgs(self, debug_info):
         if debug_info is None:
@@ -299,6 +306,7 @@ class Builder:
             self.getModuleCacheSpec(),
             self.getLibCxxArgs(),
             self.getLLDBObjRoot(),
+            self.getResourceDirArgs(),
             self.getCmdLine(dictionary),
         ]
         command = list(itertools.chain(*command_parts))

--- a/lldb/packages/Python/lldbsuite/test/configuration.py
+++ b/lldb/packages/Python/lldbsuite/test/configuration.py
@@ -50,6 +50,9 @@ make_path = None
 # Allow specifying a triple for cross compilation.
 triple = None
 
+# Clang resource directory for cross compilation.
+resource_dir = None
+
 # The overriden dwarf verison.
 # Don't use this to test the current compiler's
 # DWARF version, as this won't be set if the

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -276,6 +276,8 @@ def parseOptionsAndInitTestdirs():
         configuration.dsymutil = seven.get_command_output(
             "xcrun -find -toolchain default dsymutil"
         )
+    if args.resource_dir:
+        configuration.resource_dir = args.resource_dir
     if args.llvm_tools_dir:
         configuration.llvm_tools_dir = args.llvm_tools_dir
         configuration.filecheck = shutil.which("FileCheck", path=args.llvm_tools_dir)

--- a/lldb/packages/Python/lldbsuite/test/dotest_args.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest_args.py
@@ -107,6 +107,15 @@ def create_parser():
         help=textwrap.dedent("Specify which dsymutil to use."),
     )
     group.add_argument(
+        "--resource-dir",
+        metavar="dir",
+        dest="resource_dir",
+        default="",
+        help=textwrap.dedent(
+            "Specify the clang resource directory for cross-compiling test inferiors."
+        ),
+    )
+    group.add_argument(
         "--llvm-tools-dir",
         metavar="dir",
         dest="llvm_tools_dir",

--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -124,6 +124,10 @@ ifeq "$(OS)" "Android"
 	include $(THIS_FILE_DIR)/Android.rules
 endif
 
+ifeq "$(OS)" "WASI"
+	include $(THIS_FILE_DIR)/WASI.rules
+endif
+
 ifeq "$(TRIPLE)" ""
   ifeq "$(ARCH)" ""
     # No triple, no arch: query the compiler for its default triple.
@@ -178,7 +182,11 @@ ifeq "$(OS)" "Darwin"
 else
     ifneq "$(SDKROOT)" ""
         SYSROOT_FLAGS := --sysroot "$(SDKROOT)"
-        GCC_TOOLCHAIN_FLAGS := --gcc-toolchain="$(SDKROOT)/usr"
+        ifeq "$(OS)" "WASI"
+            GCC_TOOLCHAIN_FLAGS :=
+        else
+            GCC_TOOLCHAIN_FLAGS := --gcc-toolchain="$(SDKROOT)/usr"
+        endif
     else
         # Do not set up these options if SDKROOT was not specified.
         # This is a regular build in that case (or Android).

--- a/lldb/packages/Python/lldbsuite/test/make/WASI.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/WASI.rules
@@ -1,0 +1,14 @@
+USE_SYSTEM_STDLIB = 1
+
+ifneq "$(RESOURCE_DIR)" ""
+  ARCH_CFLAGS += -resource-dir $(RESOURCE_DIR)
+endif
+
+ARCH_CXXFLAGS += \
+	-fno-exceptions
+
+ARCH_LDFLAGS += \
+	$(if $(RESOURCE_DIR),-resource-dir $(RESOURCE_DIR)) \
+	-Wl,--export-all \
+	-Wl,--no-entry \
+	-Wl,--allow-undefined

--- a/lldb/test/API/CMakeLists.txt
+++ b/lldb/test/API/CMakeLists.txt
@@ -92,6 +92,8 @@ set(LLDB_TEST_EXECUTABLE "${LLDB_DEFAULT_TEST_EXECUTABLE}" CACHE PATH "lldb exec
 set(LLDB_TEST_COMPILER "${LLDB_DEFAULT_TEST_COMPILER}" CACHE PATH "C Compiler to use for building LLDB test inferiors")
 set(LLDB_TEST_DSYMUTIL "${LLDB_DEFAULT_TEST_DSYMUTIL}" CACHE PATH "dsymutil used for generating dSYM bundles")
 set(LLDB_TEST_MAKE "${LLDB_DEFAULT_TEST_MAKE}" CACHE PATH "make tool used for building test executables")
+set(LLDB_TEST_RESOURCE_DIR "" CACHE PATH "Clang resource directory for cross-compiling test inferiors")
+set(LLDB_TEST_SYSROOT "" CACHE PATH "Sysroot for cross-compiling test inferiors")
 
 if ("${LLDB_TEST_COMPILER}" STREQUAL "")
   message(FATAL_ERROR "LLDB test compiler not specified. Tests will not run.")

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -346,6 +346,8 @@ if is_configured("lldb_platform_working_dir"):
     dotest_cmd += ["--platform-working-dir", config.lldb_platform_working_dir]
 if is_configured("cmake_sysroot"):
     dotest_cmd += ["--sysroot", config.cmake_sysroot]
+if is_configured("test_resource_dir"):
+    dotest_cmd += ["--resource-dir", config.test_resource_dir]
 
 if is_configured("dotest_user_args_str"):
     dotest_cmd.extend(config.dotest_user_args_str.split(";"))

--- a/lldb/test/API/lit.site.cfg.py.in
+++ b/lldb/test/API/lit.site.cfg.py.in
@@ -43,6 +43,7 @@ config.libcxx_libs_dir = "@LIBCXX_LIBRARY_DIR@"
 config.libcxx_include_dir = "@LIBCXX_GENERATED_INCLUDE_DIR@"
 config.libcxx_include_target_dir = "@LIBCXX_GENERATED_INCLUDE_TARGET_DIR@"
 config.lldb_launcher = "@LLDB_LAUNCHER@"
+config.test_resource_dir = "@LLDB_TEST_RESOURCE_DIR@"
 config.lldb_enable_mte = @LLDB_ENABLE_MTE@
 config.lldb_enable_arm64e_debugserver = @LLDB_USE_ARM64E_DEBUGSERVER@
 config.lldb_use_lldb_server = @LLDB_TEST_USE_LLDB_SERVER@


### PR DESCRIPTION
This relands #192872, reverted in #193493 for breaking the Windows LLDB bots.

The original PR changed finalize_build_dictionary to derive the inferior OS by parsing configuration.triple, which misfired on the Windows bots' x86_64-pc-windows-msvc. However, that's unnecessary when specifying the platform with --platform-name, in which case getPlatform return wasip1, correctly mapping to OS=WASI.