### PR TITLE
[llvm-objcopy][DirectX][NFC] Reuse isProgramPart() in DXContainerObjcopy

### DIFF
--- a/llvm/lib/ObjCopy/DXContainer/DXContainerObjcopy.cpp
+++ b/llvm/lib/ObjCopy/DXContainer/DXContainerObjcopy.cpp
@@ -64,7 +64,7 @@ static Error dumpPartToFile(StringRef PartName, StringRef Filename,
   // documentation on the DXContainer format can be found at
   // https://llvm.org/docs/DirectX/DXContainer.html.
 
-  if (PartName == "DXIL" || PartName == "ILDB" || PartName == "STAT")
+  if (llvm::dxbc::isProgramPart(PartName) || PartName == "STAT")
     Contents = Contents.drop_front(sizeof(llvm::dxbc::ProgramHeader));
   if (Contents.empty())
     return createFileError(Filename, object_error::parse_failed,


### PR DESCRIPTION
 #201423 introduced a helper function to determine if a given
 DXContainer part name is DXIL or ILDB (i.e. a program part).
 Reuse it everywhere.