### PR TITLE
[BPF] Consider alignment when selecting memcpy/memmove/memset op type

### DIFF
--- a/llvm/lib/Target/BPF/BPFISelLowering.h
+++ b/llvm/lib/Target/BPF/BPFISelLowering.h
@@ -118,14 +118,6 @@ private:
   void ReplaceNodeResults(SDNode *N, SmallVectorImpl<SDValue> &Results,
                           SelectionDAG &DAG) const override;
 
-  EVT getOptimalMemOpType(LLVMContext &Context, const MemOp &Op,
-                          const AttributeList &FuncAttributes) const override {
-    // Defer to the target-independent heuristic, which picks the largest
-    // integer type whose alignment constraints are satisfied (clamped to the
-    // largest legal integer type, i.e. i64 for BPF).
-    return MVT::Other;
-  }
-
   bool isIntDivCheap(EVT VT, AttributeList Attr) const override {
     return false;
   }

--- a/llvm/lib/Target/BPF/BPFISelLowering.h
+++ b/llvm/lib/Target/BPF/BPFISelLowering.h
@@ -120,7 +120,10 @@ private:
 
   EVT getOptimalMemOpType(LLVMContext &Context, const MemOp &Op,
                           const AttributeList &FuncAttributes) const override {
-    return Op.size() >= 8 ? MVT::i64 : MVT::i32;
+    // Defer to the target-independent heuristic, which picks the largest
+    // integer type whose alignment constraints are satisfied (clamped to the
+    // largest legal integer type, i.e. i64 for BPF).
+    return MVT::Other;
   }
 
   bool isIntDivCheap(EVT VT, AttributeList Attr) const override {

--- a/llvm/test/CodeGen/BPF/memcpy-align.ll
+++ b/llvm/test/CodeGen/BPF/memcpy-align.ll
@@ -1,0 +1,56 @@
+; RUN: llc < %s -mtriple=bpfel -mcpu=v3 -verify-machineinstrs | FileCheck %s
+;
+; Mismatched alignment (dst 8, src 1): expect plain byte copies, no shifts/ORs
+; and no wide (u64) access.
+define void @memcpy_dst8_src1(ptr align 8 %a, ptr align 1 %b) {
+; CHECK-LABEL: memcpy_dst8_src1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    w3 = *(u8 *)(r2 + 7)
+; CHECK-NEXT:    *(u8 *)(r1 + 7) = w3
+; CHECK-NEXT:    w3 = *(u8 *)(r2 + 6)
+; CHECK-NEXT:    *(u8 *)(r1 + 6) = w3
+; CHECK-NEXT:    w3 = *(u8 *)(r2 + 5)
+; CHECK-NEXT:    *(u8 *)(r1 + 5) = w3
+; CHECK-NEXT:    w3 = *(u8 *)(r2 + 4)
+; CHECK-NEXT:    *(u8 *)(r1 + 4) = w3
+; CHECK-NEXT:    w3 = *(u8 *)(r2 + 3)
+; CHECK-NEXT:    *(u8 *)(r1 + 3) = w3
+; CHECK-NEXT:    w3 = *(u8 *)(r2 + 2)
+; CHECK-NEXT:    *(u8 *)(r1 + 2) = w3
+; CHECK-NEXT:    w3 = *(u8 *)(r2 + 1)
+; CHECK-NEXT:    *(u8 *)(r1 + 1) = w3
+; CHECK-NEXT:    w2 = *(u8 *)(r2 + 0)
+; CHECK-NEXT:    *(u8 *)(r1 + 0) = w2
+; CHECK-NEXT:    exit
+entry:
+  tail call void @llvm.memcpy.p0.p0.i64(ptr align 8 %a, ptr align 1 %b, i64 8, i1 false)
+  ret void
+}
+
+define void @memmove_dst8_src1(ptr align 8 %a, ptr align 1 %b) {
+; CHECK-LABEL: memmove_dst8_src1:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    w3 = *(u8 *)(r2 + 0)
+; CHECK-NEXT:    w4 = *(u8 *)(r2 + 1)
+; CHECK-NEXT:    w5 = *(u8 *)(r2 + 2)
+; CHECK-NEXT:    w0 = *(u8 *)(r2 + 3)
+; CHECK-NEXT:    w6 = *(u8 *)(r2 + 4)
+; CHECK-NEXT:    w7 = *(u8 *)(r2 + 5)
+; CHECK-NEXT:    w8 = *(u8 *)(r2 + 6)
+; CHECK-NEXT:    w2 = *(u8 *)(r2 + 7)
+; CHECK-NEXT:    *(u8 *)(r1 + 7) = w2
+; CHECK-NEXT:    *(u8 *)(r1 + 6) = w8
+; CHECK-NEXT:    *(u8 *)(r1 + 5) = w7
+; CHECK-NEXT:    *(u8 *)(r1 + 4) = w6
+; CHECK-NEXT:    *(u8 *)(r1 + 3) = w0
+; CHECK-NEXT:    *(u8 *)(r1 + 2) = w5
+; CHECK-NEXT:    *(u8 *)(r1 + 1) = w4
+; CHECK-NEXT:    *(u8 *)(r1 + 0) = w3
+; CHECK-NEXT:    exit
+entry:
+  tail call void @llvm.memmove.p0.p0.i64(ptr align 8 %a, ptr align 1 %b, i64 8, i1 false)
+  ret void
+}
+
+declare void @llvm.memcpy.p0.p0.i64(ptr nocapture writeonly, ptr nocapture readonly, i64, i1)
+declare void @llvm.memmove.p0.p0.i64(ptr nocapture writeonly, ptr nocapture readonly, i64, i1)

--- a/llvm/test/CodeGen/BPF/rodata_1.ll
+++ b/llvm/test/CodeGen/BPF/rodata_1.ll
@@ -36,12 +36,13 @@ entry:
     tail call void @llvm.memcpy.p0.p0.i64(ptr @g1, ptr @test.t1, i64 3, i1 false)
     tail call void @llvm.memcpy.p0.p0.i64(ptr align 4 @g2, ptr align 4 @test.t2, i64 20, i1 false)
 ; CHECK:  r1 = g1
-; CHECK:  r2 = 0
-; CHECK:  *(u8 *)(r1 + 1) = r2
-; CHECK:  r3 = 1
-; CHECK:  *(u8 *)(r1 + 2) = r3
+; CHECK:  r2 = 1
+; CHECK:  *(u8 *)(r1 + 2) = r2
+; CHECK:  r3 = 0
+; CHECK:  *(u8 *)(r1 + 1) = r3
+; CHECK:  *(u8 *)(r1 + 0) = r3
 ; CHECK:  r1 = g2
-; CHECK:  *(u32 *)(r1 + 8) = r3
+; CHECK:  *(u32 *)(r1 + 8) = r2
     ret i32 0
 }
 ; CHECK: .section  .rodata,"a",@progbits


### PR DESCRIPTION
Currently getOptimalMemOpType() forces i64 for size >= 8 and i32 otherwise without considering the operation alignment. In [1], memcpy and memmove destination and source alignments are passed separately instead of being collapsed to their minimum. As a result, poor code may be generated for a copy with a well aligned destination but a poorly aligned source: a wide store ends up fed by a wide load that the legalizer has to synthesize from byte loads via a chain of shifts and ORs.

The target independent getOptimalMemOpType() returns MVT::Other which is exactly we want as MVT::Other allows target independent to check/set proper type and alignment.

Newly added memcpy-align.ll uses u8 type for load and stores. Without BPFISelLowering.h change, a chain of shifts and ORs will happen.

The rodata_1.ll change is only instruction scheduling / register allocation churn
caused by the different but equivalent lowering.

  [1] https://github.com/llvm/llvm-project/pull/201119