### PR TITLE
[ThinLTO] Correctly rename CFI function declarations

### DIFF
--- a/llvm/lib/Transforms/IPO/ThinLTOBitcodeWriter.cpp
+++ b/llvm/lib/Transforms/IPO/ThinLTOBitcodeWriter.cpp
@@ -53,9 +53,8 @@ void promoteInternals(Module &ExportM, Module &ImportM, StringRef ModuleId,
       continue;
 
     auto Name = ExportGV.getName();
-    GlobalValue *ImportGV = nullptr;
+    GlobalValue *ImportGV = ImportM.getNamedValue(Name);
     if (!PromoteExtra.count(&ExportGV)) {
-      ImportGV = ImportM.getNamedValue(Name);
       if (!ImportGV)
         continue;
       ImportGV->removeDeadConstantUsers();


### PR DESCRIPTION
During LTO unit splitting, vtables are moved to the regular LTO unit
while inline virtual functions (e.g., destructors in anonymous
namespaces) remain in the ThinLTO unit.

To support CFI, local functions are promoted to external linkage and
renamed with a Module ID suffix. However, the promotion logic skipped
looking up and renaming the corresponding declarations in the importing
regular LTO module if the symbol was a force-promoted CFI function.

This left vtables referencing the original, un-suffixed symbols while
the definitions were renamed, causing undefined symbol linker errors.

Fix this by always looking up and renaming the symbol in the importing
module if present.

Note: Commit message was generated using a LLM
