### PR TITLE
[AMDGPU] Set WMMA source-operand reuse bits in SIPreEmitPeephole

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIPreEmitPeephole.cpp
+++ b/llvm/lib/Target/AMDGPU/SIPreEmitPeephole.cpp
@@ -28,9 +28,23 @@
 #include "llvm/CodeGen/MachinePostDominators.h"
 #include "llvm/CodeGen/TargetSchedule.h"
 #include "llvm/Support/BranchProbability.h"
+#include "llvm/Support/CommandLine.h"
 using namespace llvm;
 
 #define DEBUG_TYPE "si-pre-emit-peephole"
+
+static cl::opt<bool> EnableWMMAReuseBits(
+    "amdgpu-set-wmma-reuse-bits", cl::init(true), cl::ReallyHidden,
+    cl::desc("Set WMMA source-operand reuse bits when a nearby WMMA reuses the "
+             "same A or B source registers"));
+
+static cl::opt<unsigned> WMMAReuseLookahead(
+    "amdgpu-wmma-reuse-lookahead", cl::init(1), cl::ReallyHidden,
+    cl::desc("Number of subsequent WMMAs to consider when looking for a reuse "
+             "of a WMMA's A/B source registers. The source-operand cache is "
+             "only a few entries deep, so reuse beyond the very next WMMA "
+             "rarely survives; keeping this small avoids pinning more "
+             "high-temporality entries than the cache can hold."));
 
 namespace {
 
@@ -80,6 +94,9 @@ private:
   // appropriate source modifers and operands into the unpacked instructions.
   void addOperandAndMods(MachineInstrBuilder &NewMI, unsigned SrcMods,
                          bool IsHiBits, const MachineOperand &SrcMO);
+  // Set the matrix_a_reuse / matrix_b_reuse bits on the WMMA W1 if its A or B
+  // source registers are reused by one of the next few WMMAs.
+  bool setWMMAReuseBits(MachineInstr &W1) const;
 
 public:
   bool run(MachineFunction &MF, MachineLoopInfo *MLI);
@@ -778,6 +795,78 @@ llvm::SIPreEmitPeepholePass::run(MachineFunction &MF,
   return PreservedAnalyses::all();
 }
 
+bool SIPreEmitPeephole::setWMMAReuseBits(MachineInstr &W1) const {
+  unsigned Opc = W1.getOpcode();
+  if (!AMDGPU::hasNamedOperand(Opc, AMDGPU::OpName::matrix_a_reuse) &&
+      !AMDGPU::hasNamedOperand(Opc, AMDGPU::OpName::matrix_b_reuse))
+    return false;
+
+  // Returns true if WMMA MI reads Reg as its A (src0) or B (src1) source.
+  auto WMMAReadsAB = [&](MachineInstr &MI, Register Reg) {
+    for (AMDGPU::OpName Name : {AMDGPU::OpName::src0, AMDGPU::OpName::src1}) {
+      const MachineOperand *MO = TII->getNamedOperand(MI, Name);
+      if (MO && MO->isReg() && MO->getReg() == Reg)
+        return true;
+    }
+    return false;
+  };
+
+  // The A operand corresponds to src0 and the B operand to src1.
+  struct ReuseCand {
+    AMDGPU::OpName BitName;
+    AMDGPU::OpName SrcName;
+    const char *DebugName;
+  };
+  static constexpr ReuseCand Cands[] = {
+      {AMDGPU::OpName::matrix_a_reuse, AMDGPU::OpName::src0, "matrix_a_reuse"},
+      {AMDGPU::OpName::matrix_b_reuse, AMDGPU::OpName::src1, "matrix_b_reuse"}};
+
+  MachineBasicBlock &MBB = *W1.getParent();
+  bool Changed = false;
+  for (const ReuseCand &C : Cands) {
+    MachineOperand *Bit = TII->getNamedOperand(W1, C.BitName);
+    // Never clear a bit the frontend already requested; only set it.
+    if (Bit->getImm() != 0)
+      continue;
+    MachineOperand *Src = TII->getNamedOperand(W1, C.SrcName);
+    if (!Src->isReg())
+      continue;
+    Register Reg = Src->getReg();
+    if (!Reg.isValid())
+      continue;
+
+    // Scan forward for a WMMA that reuses Reg as an A or B source. The
+    // source-operand cache is only a few entries deep and a high-temporality
+    // entry survives only while few other entries are sticky.
+    unsigned WMMASeen = 0;
+    for (MachineBasicBlock::iterator
+             It = std::next(MachineBasicBlock::iterator(W1)),
+             End = MBB.end();
+         It != End; ++It) {
+      MachineInstr &MI = *It;
+      if (MI.isDebugInstr())
+        continue;
+      // Any redefinition of Reg before the reuse breaks the chain. A WMMA
+      // that reuses Reg as an A/B source does not modify it, so checking
+      // this first keeps the reuse test below simple.
+      if (MI.modifiesRegister(Reg, TRI))
+        break;
+      bool IsWMMA = SIInstrInfo::isWMMA(MI);
+      if (IsWMMA && WMMAReadsAB(MI, Reg)) {
+        LLVM_DEBUG(dbgs() << "Setting " << C.DebugName << " on " << W1
+                          << "  reused by " << MI);
+        Bit->setImm(1);
+        Changed = true;
+        break;
+      }
+      if (IsWMMA && ++WMMASeen >= WMMAReuseLookahead)
+        break;
+    }
+  }
+
+  return Changed;
+}
+
 bool SIPreEmitPeephole::run(MachineFunction &MF, MachineLoopInfo *LoopInfo) {
   const GCNSubtarget &ST = MF.getSubtarget<GCNSubtarget>();
   TII = ST.getInstrInfo();
@@ -786,6 +875,10 @@ bool SIPreEmitPeephole::run(MachineFunction &MF, MachineLoopInfo *LoopInfo) {
   bool Changed = false;
 
   MF.RenumberBlocks();
+
+  // WMMA source-operand reuse bits only exist on gfx1250.
+  bool DoWMMAReuse = EnableWMMAReuseBits && ST.hasGFX1250Insts();
+  bool HasVGPRIdxMode = ST.hasVGPRIndexMode();
 
   for (MachineBasicBlock &MBB : MF) {
     MachineBasicBlock::iterator TermI = MBB.getFirstTerminator();
@@ -803,7 +896,7 @@ bool SIPreEmitPeephole::run(MachineFunction &MF, MachineLoopInfo *LoopInfo) {
       }
     }
 
-    if (!ST.hasVGPRIndexMode())
+    if (!DoWMMAReuse && !HasVGPRIdxMode)
       continue;
 
     MachineInstr *SetGPRMI = nullptr;
@@ -814,7 +907,14 @@ bool SIPreEmitPeephole::run(MachineFunction &MF, MachineLoopInfo *LoopInfo) {
     // and limit the distance to 20 instructions for compile time purposes.
     // Note: this needs to work on bundles as S_SET_GPR_IDX* instructions
     // may be bundled with the instructions they modify.
+    // The same walk sets the WMMA source-operand reuse bits.
     for (auto &MI : make_early_inc_range(MBB.instrs())) {
+      if (DoWMMAReuse && SIInstrInfo::isWMMA(MI))
+        Changed |= setWMMAReuseBits(MI);
+
+      if (!HasVGPRIdxMode)
+        continue;
+
       if (Count == Threshold)
         SetGPRMI = nullptr;
       else

--- a/llvm/test/CodeGen/AMDGPU/wmma-set-reuse-bits.mir
+++ b/llvm/test/CodeGen/AMDGPU/wmma-set-reuse-bits.mir
@@ -1,0 +1,105 @@
+# RUN: llc -mtriple=amdgcn -mcpu=gfx1250 -run-pass=si-pre-emit-peephole -verify-machineinstrs %s -o - | FileCheck -check-prefix=GCN %s
+# RUN: llc -mtriple=amdgcn -mcpu=gfx1250 -run-pass=si-pre-emit-peephole -amdgpu-wmma-reuse-lookahead=2 %s -o - | FileCheck -check-prefix=LOOKAHEAD2 %s
+# RUN: llc -mtriple=amdgcn -mcpu=gfx1250 -run-pass=si-pre-emit-peephole -amdgpu-set-wmma-reuse-bits=false %s -o - | FileCheck -check-prefix=OFF %s
+
+# The next WMMA reuses the first one's A (src0) register: set matrix_a_reuse on
+# the earlier instruction. The last consumer is left unset so its read drops the
+# cache entry out of the high-temporality state.
+---
+name: reuse_a
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $vgpr0_vgpr1, $vgpr2_vgpr3, $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11, $vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19, $vgpr20_vgpr21
+    ; GCN-LABEL: name: reuse_a
+    ; GCN: early-clobber $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr0_vgpr1, $vgpr2_vgpr3, 8, $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11, 1, 0, 0, 0, implicit $exec
+    ;
+    ; OFF-LABEL: name: reuse_a
+    ; OFF: early-clobber $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr0_vgpr1, $vgpr2_vgpr3, 8, $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11, 0, 0, 0, 0, implicit $exec
+    early-clobber $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr0_vgpr1, $vgpr2_vgpr3, 8, $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11, 0, 0, 0, 0, implicit $exec
+    early-clobber $vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr0_vgpr1, $vgpr20_vgpr21, 8, $vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19, 0, 0, 0, 0, implicit $exec
+    S_ENDPGM 0
+...
+
+# The next WMMA reuses the first one's B (src1) register: set matrix_b_reuse.
+---
+name: reuse_b
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $vgpr0_vgpr1, $vgpr2_vgpr3, $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11, $vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19, $vgpr20_vgpr21
+    ; GCN-LABEL: name: reuse_b
+    ; GCN: early-clobber $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr0_vgpr1, $vgpr2_vgpr3, 8, $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11, 0, 1, 0, 0, implicit $exec
+    early-clobber $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr0_vgpr1, $vgpr2_vgpr3, 8, $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11, 0, 0, 0, 0, implicit $exec
+    early-clobber $vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr20_vgpr21, $vgpr2_vgpr3, 8, $vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19, 0, 0, 0, 0, implicit $exec
+    S_ENDPGM 0
+...
+
+# Chain of three WMMAs each sharing the A register with the next. The first two
+# each have the next WMMA reuse A and get the bit; the terminal one is left
+# unset.
+---
+name: reuse_chain
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $vgpr0_vgpr1, $vgpr2_vgpr3, $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11, $vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19, $vgpr20_vgpr21, $vgpr22_vgpr23, $vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31
+    ; GCN-LABEL: name: reuse_chain
+    ; GCN: early-clobber $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr0_vgpr1, $vgpr2_vgpr3, 8, $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11, 1, 0, 0, 0, implicit $exec
+    ; GCN-NEXT: early-clobber $vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr0_vgpr1, $vgpr20_vgpr21, 8, $vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19, 1, 0, 0, 0, implicit $exec
+    ; GCN-NEXT: early-clobber $vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr0_vgpr1, $vgpr22_vgpr23, 8, $vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31, 0, 0, 0, 0, implicit $exec
+    early-clobber $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr0_vgpr1, $vgpr2_vgpr3, 8, $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11, 0, 0, 0, 0, implicit $exec
+    early-clobber $vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr0_vgpr1, $vgpr20_vgpr21, 8, $vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19, 0, 0, 0, 0, implicit $exec
+    early-clobber $vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr0_vgpr1, $vgpr22_vgpr23, 8, $vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31, 0, 0, 0, 0, implicit $exec
+    S_ENDPGM 0
+...
+
+# The A register is redefined before the reusing WMMA, so the cached value would
+# differ: do not set the bit.
+---
+name: reuse_blocked_by_redef
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $vgpr0_vgpr1, $vgpr2_vgpr3, $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11, $vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19, $vgpr20_vgpr21
+    ; GCN-LABEL: name: reuse_blocked_by_redef
+    ; GCN: early-clobber $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr0_vgpr1, $vgpr2_vgpr3, 8, $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11, 0, 0, 0, 0, implicit $exec
+    early-clobber $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr0_vgpr1, $vgpr2_vgpr3, 8, $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11, 0, 0, 0, 0, implicit $exec
+    $vgpr0 = V_MOV_B32_e32 0, implicit $exec
+    early-clobber $vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr0_vgpr1, $vgpr20_vgpr21, 8, $vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19, 0, 0, 0, 0, implicit $exec
+    S_ENDPGM 0
+...
+
+# An intervening WMMA does not reuse the A register; the reuser is the WMMA
+# after that. With the default lookahead of 1 the bit is not set (only the next
+# WMMA is considered); with a lookahead of 2 it is.
+---
+name: reuse_beyond_lookahead
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $vgpr0_vgpr1, $vgpr2_vgpr3, $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11, $vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19, $vgpr20_vgpr21, $vgpr22_vgpr23, $vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31, $vgpr32_vgpr33
+    ; GCN-LABEL: name: reuse_beyond_lookahead
+    ; GCN: early-clobber $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr0_vgpr1, $vgpr2_vgpr3, 8, $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11, 0, 0, 0, 0, implicit $exec
+    ;
+    ; LOOKAHEAD2-LABEL: name: reuse_beyond_lookahead
+    ; LOOKAHEAD2: early-clobber $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr0_vgpr1, $vgpr2_vgpr3, 8, $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11, 1, 0, 0, 0, implicit $exec
+    early-clobber $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr0_vgpr1, $vgpr2_vgpr3, 8, $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11, 0, 0, 0, 0, implicit $exec
+    early-clobber $vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr20_vgpr21, $vgpr22_vgpr23, 8, $vgpr12_vgpr13_vgpr14_vgpr15_vgpr16_vgpr17_vgpr18_vgpr19, 0, 0, 0, 0, implicit $exec
+    early-clobber $vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr0_vgpr1, $vgpr32_vgpr33, 8, $vgpr24_vgpr25_vgpr26_vgpr27_vgpr28_vgpr29_vgpr30_vgpr31, 0, 0, 0, 0, implicit $exec
+    S_ENDPGM 0
+...
+
+# A bit already requested by the frontend is preserved even with no reuser (the
+# pass only ever sets bits, never clears them).
+---
+name: preserve_frontend_bit
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $vgpr0_vgpr1, $vgpr2_vgpr3, $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11
+    ; GCN-LABEL: name: preserve_frontend_bit
+    ; GCN: early-clobber $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr0_vgpr1, $vgpr2_vgpr3, 8, $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11, 1, 0, 0, 0, implicit $exec
+    early-clobber $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11 = V_WMMA_F32_16X16X4_F32_w32_twoaddr $vgpr0_vgpr1, $vgpr2_vgpr3, 8, $vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11, 1, 0, 0, 0, implicit $exec
+    S_ENDPGM 0
+...


### PR DESCRIPTION
gfx1250 WMMA instructions can set matrix_a_reuse / matrix_b_reuse bits that keep the A or B source operand in a high-temporality state in the VALU source-operand cache, so a later WMMA reusing the same registers hits in the cache instead of re-reading the register file.

Add a late, post-RA peephole in the existing pre-emit peephole pass that scans each basic block and, for every WMMA, sets the A/B reuse bit when one of the next few WMMAs reuses the same physical registers as its A or B operand and those registers are not redefined in between.

Stale sticky entries in the cache are cleared when a register is used in an instruction without a reuse bit being set. Therefore, the final WMMA use of the same source should not set the bit.