### PR TITLE
[clang][bytecode] Not all bases compare equal

### DIFF
--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -392,8 +392,7 @@ Pointer::computeOffsetForComparison(const ASTContext &ASTCtx) const {
     }
 
     if (P.isBaseClass()) {
-      if (P.getRecord()->getNumVirtualBases() > 0)
-        Result += P.getInlineDesc()->Offset;
+      Result += P.getInlineDesc()->Offset - sizeof(InlineDescriptor);
       P = P.getBase();
       continue;
     }

--- a/clang/test/AST/ByteCode/cxx11.cpp
+++ b/clang/test/AST/ByteCode/cxx11.cpp
@@ -469,8 +469,8 @@ namespace SubobjectCompare {
   constexpr Z z{};
   static_assert(&z.x < &z.y, ""); // both-error {{not an integral constant expression}} \
                                   // both-note {{comparison of addresses of subobjects of different base classes has unspecified value}}
-  static_assert(&z.x != &z.y, ""); // expected-error {{failed}} FIXME
+  static_assert(&z.x != &z.y, "");
   static_assert((void*)(X*)&z < (void*)(Y*)&z, ""); // both-error {{not an integral constant expression}} \
                                                     // both-note {{comparison of addresses of subobjects of different base classes has unspecified value}}
-  static_assert((void*)(X*)&z != (void*)(Y*)&z, ""); // expected-error {{failed}} FIXME
+  static_assert((void*)(X*)&z != (void*)(Y*)&z, "");
 }


### PR DESCRIPTION
Add the base class offset so they don't all compare equal.