### PR TITLE
[clang][bytecode] Remove InterpState::InitializingBlocks

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -580,7 +580,7 @@ bool CheckConst(InterpState &S, CodePtr OpPC, const Pointer &Ptr) {
 
   // The This pointer is writable in constructors and destructors,
   // even if isConst() returns true.
-  if (llvm::is_contained(S.InitializingBlocks, Ptr.block()))
+  if (S.initializingBlock(Ptr.block()))
     return true;
 
   if (!S.checkingPotentialConstantExpression()) {
@@ -619,7 +619,7 @@ static bool CheckVolatile(InterpState &S, CodePtr OpPC, const Pointer &Ptr,
     return Invalid(S, OpPC);
 
   // Volatile object can be written-to and read if they are being constructed.
-  if (llvm::is_contained(S.InitializingBlocks, Ptr.block()))
+  if (S.initializingBlock(Ptr.block()))
     return true;
 
   // The reason why Ptr is volatile might be further up the hierarchy.
@@ -1841,10 +1841,8 @@ bool Call(InterpState &S, CodePtr OpPC, const Function *Func,
     if (Func->isDestructor() && !CheckDestructor(S, OpPC, ThisPtr))
       return false;
 
-    if (Func->isConstructor() || Func->isDestructor()) {
+    if (Func->isConstructor() || Func->isDestructor())
       S.InitializingPtrs.push_back(ThisPtr.view());
-      S.InitializingBlocks.push_back(ThisPtr.block());
-    }
   }
 
   if (!Func->isFullyCompiled())
@@ -1870,10 +1868,8 @@ bool Call(InterpState &S, CodePtr OpPC, const Function *Func,
   InterpStateCCOverride CCOverride(S, Func->isImmediate());
   bool Success = Interpret(S);
   // Remove initializing  block again.
-  if (Func->isConstructor() || Func->isDestructor()) {
-    S.InitializingBlocks.pop_back();
+  if (Func->isConstructor() || Func->isDestructor())
     S.InitializingPtrs.pop_back();
-  }
 
   if (!Success) {
     InterpFrame::free(NewFrame);
@@ -2139,8 +2135,7 @@ bool CallVirt(InterpState &S, CodePtr OpPC, const Function *Func,
   const auto *InitialFunction = cast<CXXMethodDecl>(Callee);
   const CXXMethodDecl *Overrider;
 
-  if (StaticDecl != DynamicDecl &&
-      !llvm::is_contained(S.InitializingBlocks, ThisPtr.block())) {
+  if (StaticDecl != DynamicDecl && !S.initializingBlock(ThisPtr.block())) {
     if (!DynamicDecl->isDerivedFrom(StaticDecl))
       return false;
     Overrider = S.getContext().getOverridingFunction(DynamicDecl, StaticDecl,

--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -3665,12 +3665,12 @@ inline bool StartSpeculation(InterpState &S, CodePtr OpPC) {
 
 inline bool StartInit(InterpState &S, CodePtr OpPC) {
   const Pointer &Ptr = S.Stk.peek<Pointer>();
-  S.InitializingBlocks.push_back(Ptr.block());
+  S.InitializingPtrs.push_back(Ptr.view());
   return true;
 }
 
 inline bool EndInit(InterpState &S, CodePtr OpPC) {
-  S.InitializingBlocks.pop_back();
+  S.InitializingPtrs.pop_back();
   return true;
 }
 

--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -2580,7 +2580,7 @@ static bool interp__builtin_is_within_lifetime(InterpState &S, CodePtr OpPC,
   }
 
   // Check if we're currently running an initializer.
-  if (llvm::is_contained(S.InitializingBlocks, Ptr.block()))
+  if (S.initializingBlock(Ptr.block()))
     return Error(2);
   if (S.EvaluatingDecl && Ptr.getDeclDesc()->asVarDecl() == S.EvaluatingDecl)
     return Error(2);

--- a/clang/lib/AST/ByteCode/InterpState.h
+++ b/clang/lib/AST/ByteCode/InterpState.h
@@ -125,6 +125,13 @@ public:
   /// diagnoses and returns \c false.
   bool noteStep(CodePtr OpPC);
 
+  bool initializingBlock(const Block *B) const {
+    for (PtrView V : InitializingPtrs)
+      if (V.block() == B)
+        return true;
+    return false;
+  }
+
 private:
   friend class EvaluationResult;
   friend class InterpStateCCOverride;
@@ -174,8 +181,6 @@ public:
 
   /// List of blocks we're currently running either constructors or destructors
   /// for.
-  llvm::SmallVector<const Block *> InitializingBlocks;
-  // FIXME: We clearly dont' need two lists here, just one is enough.
   llvm::SmallVector<PtrView> InitializingPtrs;
 };
 


### PR DESCRIPTION
This was superseded by `InitializingPtrs` when implementing `dynamic_cast`, so we can now remove `InitializingBlocks`.