### PR TITLE
[llvm] Replace unordered_{map,set} with Dense{Map,Set} in llvm tools

### DIFF
--- a/llvm/tools/llvm-exegesis/lib/Analysis.cpp
+++ b/llvm/tools/llvm-exegesis/lib/Analysis.cpp
@@ -196,7 +196,7 @@ std::vector<Analysis::ResolvedSchedClassAndPoints>
 Analysis::makePointsPerSchedClass() const {
   std::vector<ResolvedSchedClassAndPoints> Entries;
   // Maps SchedClassIds to index in result.
-  std::unordered_map<unsigned, size_t> SchedClassIdToIndex;
+  DenseMap<unsigned, size_t> SchedClassIdToIndex;
   const auto &Points = Clustering_.getPoints();
   for (size_t PointId = 0, E = Points.size(); PointId < E; ++PointId) {
     const Benchmark &Point = Points[PointId];
@@ -214,7 +214,7 @@ Analysis::makePointsPerSchedClass() const {
     const auto IndexIt = SchedClassIdToIndex.find(SchedClassId);
     if (IndexIt == SchedClassIdToIndex.end()) {
       // Create a new entry.
-      SchedClassIdToIndex.emplace(SchedClassId, Entries.size());
+      SchedClassIdToIndex.try_emplace(SchedClassId, Entries.size());
       ResolvedSchedClassAndPoints Entry(ResolvedSchedClass(
           State_.getSubtargetInfo(), SchedClassId, WasVariant));
       Entry.PointIds.push_back(PointId);

--- a/llvm/tools/llvm-exegesis/lib/MCInstrDescView.h
+++ b/llvm/tools/llvm-exegesis/lib/MCInstrDescView.h
@@ -20,10 +20,10 @@
 
 #include <memory>
 #include <random>
-#include <unordered_map>
 
 #include "RegisterAliasing.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/MC/MCInst.h"
 #include "llvm/MC/MCInstrDesc.h"
 #include "llvm/MC/MCInstrInfo.h"
@@ -197,8 +197,7 @@ private:
   const MCInstrInfo &InstrInfo;
   const RegisterAliasingTrackerCache &RATC;
   const MCSubtargetInfo *STI;
-  mutable std::unordered_map<unsigned, std::unique_ptr<Instruction>>
-      Instructions;
+  mutable DenseMap<unsigned, std::unique_ptr<Instruction>> Instructions;
   const BitVectorCache BVC;
 };
 

--- a/llvm/tools/llvm-exegesis/lib/RegisterAliasing.h
+++ b/llvm/tools/llvm-exegesis/lib/RegisterAliasing.h
@@ -15,9 +15,9 @@
 #define LLVM_TOOLS_LLVM_EXEGESIS_ALIASINGTRACKER_H
 
 #include <memory>
-#include <unordered_map>
 
 #include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/PackedVector.h"
 #include "llvm/MC/MCRegisterInfo.h"
 
@@ -97,9 +97,9 @@ private:
   const MCRegisterInfo &RegInfo;
   const BitVector ReservedReg;
   const BitVector EmptyRegisters;
-  mutable std::unordered_map<unsigned, std::unique_ptr<RegisterAliasingTracker>>
+  mutable DenseMap<unsigned, std::unique_ptr<RegisterAliasingTracker>>
       Registers;
-  mutable std::unordered_map<unsigned, std::unique_ptr<RegisterAliasingTracker>>
+  mutable DenseMap<unsigned, std::unique_ptr<RegisterAliasingTracker>>
       RegisterClasses;
 };
 

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -24,6 +24,7 @@
 #include "SourcePrinter.h"
 #include "WasmDump.h"
 #include "XCOFFDump.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetOperations.h"
 #include "llvm/ADT/StringExtras.h"
@@ -83,7 +84,6 @@
 #include <optional>
 #include <set>
 #include <system_error>
-#include <unordered_map>
 #include <utility>
 
 using namespace llvm;
@@ -262,8 +262,8 @@ public:
   void AddFunctionEntry(BBAddrMap AddrMap, PGOAnalysisMap PGOMap) {
     uint64_t FunctionAddr = AddrMap.getFunctionAddress();
     for (size_t I = 1; I < AddrMap.BBRanges.size(); ++I)
-      RangeBaseAddrToFunctionAddr.emplace(AddrMap.BBRanges[I].BaseAddress,
-                                          FunctionAddr);
+      RangeBaseAddrToFunctionAddr.try_emplace(AddrMap.BBRanges[I].BaseAddress,
+                                              FunctionAddr);
     [[maybe_unused]] auto R = FunctionAddrToMap.try_emplace(
         FunctionAddr, std::move(AddrMap), std::move(PGOMap));
     assert(R.second && "duplicate function address");
@@ -285,8 +285,8 @@ public:
   }
 
 private:
-  std::unordered_map<uint64_t, BBAddrMapFunctionEntry> FunctionAddrToMap;
-  std::unordered_map<uint64_t, uint64_t> RangeBaseAddrToFunctionAddr;
+  DenseMap<uint64_t, BBAddrMapFunctionEntry> FunctionAddrToMap;
+  DenseMap<uint64_t, uint64_t> RangeBaseAddrToFunctionAddr;
 };
 
 } // namespace
@@ -1659,8 +1659,7 @@ static SymbolInfoTy createDummySymbolInfo(const ObjectFile &Obj,
 
 static void collectBBAddrMapLabels(
     const BBAddrMapInfo &FullAddrMap, uint64_t SectionAddr, uint64_t Start,
-    uint64_t End,
-    std::unordered_map<uint64_t, std::vector<BBAddrMapLabel>> &Labels) {
+    uint64_t End, DenseMap<uint64_t, std::vector<BBAddrMapLabel>> &Labels) {
   if (FullAddrMap.empty())
     return;
   Labels.clear();
@@ -1692,12 +1691,10 @@ static void collectBBAddrMapLabels(
   }
 }
 
-static void
-collectLocalBranchTargets(ArrayRef<uint8_t> Bytes, MCInstrAnalysis *MIA,
-                          MCDisassembler *DisAsm, MCInstPrinter *IP,
-                          const MCSubtargetInfo *STI, uint64_t SectionAddr,
-                          uint64_t Start, uint64_t End,
-                          std::unordered_map<uint64_t, std::string> &Labels) {
+static void collectLocalBranchTargets(
+    ArrayRef<uint8_t> Bytes, MCInstrAnalysis *MIA, MCDisassembler *DisAsm,
+    MCInstPrinter *IP, const MCSubtargetInfo *STI, uint64_t SectionAddr,
+    uint64_t Start, uint64_t End, DenseMap<uint64_t, std::string> &Labels) {
   // Supported by certain targets.
   const bool isPPC = STI->getTargetTriple().isPPC();
   const bool isX86 = STI->getTargetTriple().isX86();
@@ -2422,8 +2419,8 @@ disassembleObject(ObjectFile &Obj, const ObjectFile &DbgObj,
           Symbols[SI - 1].XCOFFSymInfo.StorageMappingClass &&
           (*Symbols[SI - 1].XCOFFSymInfo.StorageMappingClass == XCOFF::XMC_PR);
 
-      std::unordered_map<uint64_t, std::string> AllLabels;
-      std::unordered_map<uint64_t, std::vector<BBAddrMapLabel>> BBAddrMapLabels;
+      DenseMap<uint64_t, std::string> AllLabels;
+      DenseMap<uint64_t, std::vector<BBAddrMapLabel>> BBAddrMapLabels;
       if (SymbolizeOperands) {
         collectLocalBranchTargets(Bytes, DT->InstrAnalysis.get(),
                                   DT->DisAsm.get(), DT->InstPrinter.get(),

--- a/llvm/tools/llvm-profdata/llvm-profdata.cpp
+++ b/llvm/tools/llvm-profdata/llvm-profdata.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
@@ -2045,8 +2046,7 @@ public:
   /// Load profiles specified by BaseFilename and TestFilename.
   std::error_code loadProfiles();
 
-  using FuncSampleStatsMap =
-      std::unordered_map<SampleContext, FuncSampleStats, SampleContext::Hash>;
+  using FuncSampleStatsMap = DenseMap<SampleContext, FuncSampleStats>;
 
 private:
   SampleOverlapStats ProfOverlap;
@@ -2207,7 +2207,7 @@ void SampleOverlapAggregator::getHotFunctions(
     uint64_t HotThreshold) const {
   for (const auto &F : ProfStats) {
     if (isFunctionHot(F.second, HotThreshold))
-      HotFunc.emplace(F.first, F.second);
+      HotFunc.try_emplace(F.first, F.second);
   }
 }
 
@@ -2434,12 +2434,10 @@ double SampleOverlapAggregator::computeSampleFunctionOverlap(
 void SampleOverlapAggregator::computeSampleProfileOverlap(raw_fd_ostream &OS) {
   using namespace sampleprof;
 
-  std::unordered_map<SampleContext, const FunctionSamples *,
-                     SampleContext::Hash>
-      BaseFuncProf;
+  DenseMap<SampleContext, const FunctionSamples *> BaseFuncProf;
   const auto &BaseProfiles = BaseReader->getProfiles();
   for (const auto &BaseFunc : BaseProfiles) {
-    BaseFuncProf.emplace(BaseFunc.second.getContext(), &(BaseFunc.second));
+    BaseFuncProf.try_emplace(BaseFunc.second.getContext(), &(BaseFunc.second));
   }
   ProfOverlap.UnionCount = BaseFuncProf.size();
 
@@ -2557,7 +2555,7 @@ void SampleOverlapAggregator::initializeSampleProfileOverlap() {
     FuncSampleStats FuncStats;
     getFuncSampleStats(I.second, FuncStats, BaseHotThreshold);
     ProfOverlap.BaseSample += FuncStats.SampleSum;
-    BaseStats.emplace(I.second.getContext(), FuncStats);
+    BaseStats.try_emplace(I.second.getContext(), FuncStats);
   }
 
   const auto &TestProf = TestReader->getProfiles();
@@ -2566,7 +2564,7 @@ void SampleOverlapAggregator::initializeSampleProfileOverlap() {
     FuncSampleStats FuncStats;
     getFuncSampleStats(I.second, FuncStats, TestHotThreshold);
     ProfOverlap.TestSample += FuncStats.SampleSum;
-    TestStats.emplace(I.second.getContext(), FuncStats);
+    TestStats.try_emplace(I.second.getContext(), FuncStats);
   }
 
   ProfOverlap.BaseName = StringRef(BaseFilename);

--- a/llvm/tools/llvm-profgen/MissingFrameInferrer.cpp
+++ b/llvm/tools/llvm-profgen/MissingFrameInferrer.cpp
@@ -44,8 +44,8 @@ void MissingFrameInferrer::initialize(
     const ContextSampleCounterMap *SampleCounters) {
   // Refine call edges based on LBR samples.
   if (SampleCounters) {
-    std::unordered_map<uint64_t, std::unordered_set<uint64_t>> SampledCalls;
-    std::unordered_map<uint64_t, std::unordered_set<uint64_t>> SampledTailCalls;
+    DenseMap<uint64_t, DenseSet<uint64_t>> SampledCalls;
+    DenseMap<uint64_t, DenseSet<uint64_t>> SampledTailCalls;
 
     // Populate SampledCalls based on static call sites. Similarly to
     // SampledTailCalls.
@@ -72,8 +72,8 @@ void MissingFrameInferrer::initialize(
     }
 
     // Replace static edges with dynamic edges.
-    CallEdges = SampledCalls;
-    TailCallEdges = SampledTailCalls;
+    CallEdges = std::move(SampledCalls);
+    TailCallEdges = std::move(SampledTailCalls);
   }
 
   // Populate function-based edges. This is to speed up address to function
@@ -106,8 +106,7 @@ void MissingFrameInferrer::initialize(
 
 #ifndef NDEBUG
   auto PrintCallTargets =
-      [&](const std::unordered_map<uint64_t, std::unordered_set<uint64_t>>
-              &CallTargets,
+      [&](const DenseMap<uint64_t, DenseSet<uint64_t>> &CallTargets,
           bool IsTailCall) {
         for (const auto &Targets : CallTargets) {
           for (const auto &Target : Targets.second) {

--- a/llvm/tools/llvm-profgen/MissingFrameInferrer.h
+++ b/llvm/tools/llvm-profgen/MissingFrameInferrer.h
@@ -10,11 +10,11 @@
 #define LLVM_TOOLS_LLVM_PROFGEN_MISSINGFRAMEINFERRER_H
 
 #include "PerfReader.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Statistic.h"
-#include <unordered_map>
-#include <unordered_set>
 
 namespace llvm {
 namespace sampleprof {
@@ -66,39 +66,29 @@ private:
   // A map of call instructions to their target addresses. This is first
   // populated with static call edges but then trimmed down to dynamic call
   // edges based on LBR samples.
-  std::unordered_map<uint64_t, std::unordered_set<uint64_t>> CallEdges;
+  DenseMap<uint64_t, DenseSet<uint64_t>> CallEdges;
 
   // A map of tail call instructions to their target addresses. This is first
   // populated with static call edges but then trimmed down to dynamic call
   // edges based on LBR samples.
-  std::unordered_map<uint64_t, std::unordered_set<uint64_t>> TailCallEdges;
+  DenseMap<uint64_t, DenseSet<uint64_t>> TailCallEdges;
 
   // Dynamic call targets in terms of BinaryFunction for any calls.
-  std::unordered_map<uint64_t, std::unordered_set<BinaryFunction *>> CallEdgesF;
+  DenseMap<uint64_t, SmallPtrSet<BinaryFunction *, 0>> CallEdgesF;
 
   // Dynamic call targets in terms of BinaryFunction  for tail calls.
-  std::unordered_map<uint64_t, std::unordered_set<BinaryFunction *>>
-      TailCallEdgesF;
+  DenseMap<uint64_t, SmallPtrSet<BinaryFunction *, 0>> TailCallEdgesF;
 
   // Dynamic tail call targets of caller functions.
-  std::unordered_map<BinaryFunction *, std::vector<uint64_t>> FuncToTailCallMap;
+  DenseMap<BinaryFunction *, std::vector<uint64_t>> FuncToTailCallMap;
 
   // Functions that are reachable via tail calls.
   DenseSet<const BinaryFunction *> TailCallTargetFuncs;
 
-  struct PairHash {
-    std::size_t operator()(
-        const std::pair<BinaryFunction *, BinaryFunction *> &Pair) const {
-      return std::hash<BinaryFunction *>()(Pair.first) ^
-             std::hash<BinaryFunction *>()(Pair.second);
-    }
-  };
-
   // Cached results from a CallerCalleePair to a unique call path between them.
-  std::unordered_map<CallerCalleePair, std::vector<uint64_t>, PairHash>
-      UniquePaths;
+  DenseMap<CallerCalleePair, std::vector<uint64_t>> UniquePaths;
   // Cached results from CallerCalleePair to the number of available call paths.
-  std::unordered_map<CallerCalleePair, uint64_t, PairHash> NonUniquePaths;
+  DenseMap<CallerCalleePair, uint64_t> NonUniquePaths;
 
   DenseSet<BinaryFunction *> Visiting;
 

--- a/llvm/tools/llvm-profgen/PerfReader.cpp
+++ b/llvm/tools/llvm-profgen/PerfReader.cpp
@@ -218,7 +218,7 @@ void VirtualUnwinder::collectSamplesFromFrame(UnwindState::ProfiledFrame *Cur,
   std::shared_ptr<ContextKey> Key = Stack.getContextKey();
   if (Key == nullptr)
     return;
-  auto Ret = CtxCounterMap->emplace(Hashable<ContextKey>(Key), SampleCounter());
+  auto Ret = CtxCounterMap->try_emplace(Hashable<ContextKey>(Key));
   SampleCounter &SCounter = Ret.first->second;
   for (auto &I : Cur->RangeSamples)
     SCounter.recordRangeCount(std::get<0>(I), std::get<1>(I), std::get<2>(I));
@@ -486,12 +486,12 @@ PerfScriptReader::convertPerfDataToTrace(ProfiledBinary *Binary, bool SkipPID,
 
     // Collect the PIDs
     TraceStream TraceIt(PerfTraceFile);
-    std::unordered_set<int32_t> PIDSet;
+    DenseSet<int32_t> PIDSet;
     while (!TraceIt.isAtEoF()) {
       MMapEvent MMap;
       if (isMMapEvent(TraceIt.getCurrentLine()) &&
           extractMMapEventForBinary(Binary, TraceIt.getCurrentLine(), MMap)) {
-        auto It = PIDSet.emplace(MMap.PID);
+        auto It = PIDSet.insert(MMap.PID);
         if (It.second && (!PIDFilter || MMap.PID == *PIDFilter)) {
           if (!PIDs.empty()) {
             PIDs.append(",");
@@ -1000,8 +1000,7 @@ void UnsymbolizedProfileReader::readUnsymbolizedProfile(StringRef FileName) {
       SampleContext::createCtxVectorFromStr(I.first->getKey(), Key->Context);
       TraceIt.advance();
     }
-    auto Ret =
-        SampleCounters.emplace(Hashable<ContextKey>(Key), SampleCounter());
+    auto Ret = SampleCounters.try_emplace(Hashable<ContextKey>(Key));
     readSampleCounters(TraceIt, Ret.first->second);
   }
 }
@@ -1053,7 +1052,7 @@ void PerfScriptReader::generateUnsymbolizedProfile() {
          "Sample counter map should be empty before raw profile generation");
   std::shared_ptr<StringBasedCtxKey> Key =
       std::make_shared<StringBasedCtxKey>();
-  SampleCounters.emplace(Hashable<ContextKey>(Key), SampleCounter());
+  SampleCounters.try_emplace(Hashable<ContextKey>(Key));
   for (const auto &Item : AggregatedSamples) {
     const PerfSample *Sample = Item.first.getPtr();
     computeCounterFromLBR(Sample, Item.second);
@@ -1265,9 +1264,7 @@ void PerfScriptReader::warnTruncatedStack() {
 }
 
 void PerfScriptReader::warnInvalidRange() {
-  std::unordered_map<std::pair<uint64_t, uint64_t>, uint64_t,
-                     pair_hash<uint64_t, uint64_t>>
-      Ranges;
+  DenseMap<std::pair<uint64_t, uint64_t>, uint64_t> Ranges;
 
   for (const auto &Item : AggregatedSamples) {
     const PerfSample *Sample = Item.first.getPtr();
@@ -1466,7 +1463,7 @@ void ETMReader::parseETMTraces() {
   // Initialize the SampleCounters map with a single empty context key
   // to aggregate all instruction hits into a global bucket.
   auto Key = std::make_shared<StringBasedCtxKey>();
-  Counters.emplace(Hashable<ContextKey>(Key), SampleCounter());
+  Counters.try_emplace(Hashable<ContextKey>(Key));
 
   // The protocol utilizes a 0x80 byte as an initial synchronization header.
   // Perform a manual search for this sync point to discard any leading

--- a/llvm/tools/llvm-profgen/PerfReader.h
+++ b/llvm/tools/llvm-profgen/PerfReader.h
@@ -10,6 +10,7 @@
 #define LLVM_TOOLS_LLVM_PROFGEN_PERFREADER_H
 #include "ErrorHandling.h"
 #include "ProfiledBinary.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
@@ -125,26 +126,27 @@ public:
   std::shared_ptr<T> Data;
   Hashable(const std::shared_ptr<T> &D) : Data(D) {}
 
-  // Hash code generation
-  struct Hash {
-    uint64_t operator()(const Hashable<T> &Key) const {
-      // Don't make it virtual for getHashCode
-      uint64_t Hash = Key.Data->getHashCode();
-      assert(Hash && "Should generate HashCode for it!");
-      return Hash;
-    }
-  };
-
-  // Hash equal
-  struct Equal {
-    bool operator()(const Hashable<T> &LHS, const Hashable<T> &RHS) const {
-      // Precisely compare the data, vtable will have overhead.
-      return LHS.Data->isEqual(RHS.Data.get());
-    }
-  };
-
   T *getPtr() const { return Data.get(); }
 };
+
+} // end namespace sampleprof
+
+template <typename T> struct DenseMapInfo<sampleprof::Hashable<T>> {
+  static unsigned getHashValue(const sampleprof::Hashable<T> &Key) {
+    // Don't make it virtual for getHashCode
+    uint64_t Hash = Key.Data->getHashCode();
+    assert(Hash && "Should generate HashCode for it!");
+    return DenseMapInfo<uint64_t>::getHashValue(Hash);
+  }
+
+  static bool isEqual(const sampleprof::Hashable<T> &LHS,
+                      const sampleprof::Hashable<T> &RHS) {
+    // Precisely compare the data, vtable will have overhead.
+    return LHS.Data->isEqual(RHS.Data.get());
+  }
+};
+
+namespace sampleprof {
 
 struct PerfSample {
   // LBR stack recorded in FIFO order.
@@ -204,9 +206,7 @@ struct PerfSample {
 // After parsing the sample, we record the samples by aggregating them
 // into this counter. The key stores the sample data and the value is
 // the sample repeat times.
-using AggregatedCounter =
-    std::unordered_map<Hashable<PerfSample>, uint64_t,
-                       Hashable<PerfSample>::Hash, Hashable<PerfSample>::Equal>;
+using AggregatedCounter = DenseMap<Hashable<PerfSample>, uint64_t>;
 
 using SampleVector = SmallVector<std::tuple<uint64_t, uint64_t, uint64_t>, 16>;
 
@@ -233,15 +233,16 @@ struct UnwindState {
     ProfiledFrame *Parent;
     SampleVector RangeSamples;
     SampleVector BranchSamples;
-    std::unordered_map<uint64_t, std::unique_ptr<ProfiledFrame>> Children;
+    DenseMap<uint64_t, std::unique_ptr<ProfiledFrame>> Children;
 
     ProfiledFrame(uint64_t Addr = 0, ProfiledFrame *P = nullptr)
         : Address(Addr), Parent(P) {}
     ProfiledFrame *getOrCreateChildFrame(uint64_t Address) {
       assert(Address && "Address can't be zero!");
-      auto Ret = Children.emplace(
-          Address, std::make_unique<ProfiledFrame>(Address, this));
-      return Ret.first->second.get();
+      auto [It, Inserted] = Children.try_emplace(Address);
+      if (Inserted)
+        It->second = std::make_unique<ProfiledFrame>(Address, this);
+      return It->second.get();
     }
     void recordRangeCount(uint64_t Start, uint64_t End, uint64_t Count) {
       RangeSamples.emplace_back(std::make_tuple(Start, End, Count));
@@ -417,9 +418,7 @@ struct SampleCounter {
 };
 
 // Sample counter with context to support context-sensitive profile
-using ContextSampleCounterMap =
-    std::unordered_map<Hashable<ContextKey>, SampleCounter,
-                       Hashable<ContextKey>::Hash, Hashable<ContextKey>::Equal>;
+using ContextSampleCounterMap = DenseMap<Hashable<ContextKey>, SampleCounter>;
 
 struct FrameStack {
   SmallVector<uint64_t, 16> Stack;

--- a/llvm/tools/llvm-profgen/ProfileGenerator.cpp
+++ b/llvm/tools/llvm-profgen/ProfileGenerator.cpp
@@ -1296,8 +1296,7 @@ void CSProfileGenerator::populateBodySamplesWithProbes(
   // Extract the top frame probes by looking up each address among the range in
   // the Address2ProbeMap
   extractProbesFromRange(RangeCounter, ProbeCounter);
-  std::unordered_map<MCDecodedPseudoProbeInlineTree *,
-                     std::unordered_set<FunctionSamples *>>
+  DenseMap<MCDecodedPseudoProbeInlineTree *, SmallPtrSet<FunctionSamples *, 0>>
       FrameSamples;
   for (const auto &PI : ProbeCounter) {
     const MCDecodedPseudoProbe *Probe = PI.first;

--- a/llvm/tools/llvm-profgen/ProfileGenerator.h
+++ b/llvm/tools/llvm-profgen/ProfileGenerator.h
@@ -12,6 +12,7 @@
 #include "ErrorHandling.h"
 #include "PerfReader.h"
 #include "ProfiledBinary.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/ProfileData/SampleProfWriter.h"
@@ -21,8 +22,7 @@
 namespace llvm {
 namespace sampleprof {
 
-using ProbeCounterMap =
-    std::unordered_map<const MCDecodedPseudoProbe *, uint64_t>;
+using ProbeCounterMap = DenseMap<const MCDecodedPseudoProbe *, uint64_t>;
 
 // This base class for profile generation of sample-based PGO. We reuse all
 // structures relating to function profiles and profile writers as seen in
@@ -382,7 +382,9 @@ private:
   // The container for holding the FunctionSamples used by context trie.
   std::list<FunctionSamples> FSamplesList;
 
-  // Underlying context table serves for sample profile writer.
+  // Underlying context table serves for sample profile writer. SampleContexts
+  // in the output profile hold ArrayRefs into the stored vectors, so the
+  // elements' addresses must be stable: keep std::unordered_set.
   std::unordered_set<SampleContextFrameVector, SampleContextFrameHash> Contexts;
 
   SampleContextTracker ContextTracker;

--- a/llvm/tools/llvm-profgen/ProfiledBinary.cpp
+++ b/llvm/tools/llvm-profgen/ProfiledBinary.cpp
@@ -1248,7 +1248,7 @@ void ProfiledBinary::loadSymbolsFromPseudoProbe() {
                "Top level pseudo probe does not match function range");
 
         const auto *ProbeDesc = getFuncDescForGUID(InlineTreeNode->Guid);
-        auto Ret = PseudoProbeNames.emplace(Func, ProbeDesc->FuncName);
+        auto Ret = PseudoProbeNames.try_emplace(Func, ProbeDesc->FuncName);
         if (!Ret.second && Ret.first->second != ProbeDesc->FuncName &&
             ShowDetailedWarning)
           WithColor::warning()

--- a/llvm/tools/llvm-profgen/ProfiledBinary.h
+++ b/llvm/tools/llvm-profgen/ProfiledBinary.h
@@ -12,6 +12,7 @@
 #include "CallContext.h"
 #include "ErrorHandling.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
@@ -120,7 +121,7 @@ struct FuncRange {
 // we will switch to Dwarf CFI based tracker
 struct PrologEpilogTracker {
   // A set of prolog and epilog addresses. Used by virtual unwinding.
-  std::unordered_set<uint64_t> PrologEpilogSet;
+  DenseSet<uint64_t> PrologEpilogSet;
   ProfiledBinary *Binary;
   PrologEpilogTracker(ProfiledBinary *Bin) : Binary(Bin){};
 
@@ -137,7 +138,7 @@ struct PrologEpilogTracker {
   }
 
   // Take the last two addresses before the return address as epilog
-  void inferEpilogAddresses(std::unordered_set<uint64_t> &RetAddrs) {
+  void inferEpilogAddresses(DenseSet<uint64_t> &RetAddrs) {
     for (auto Addr : RetAddrs) {
       PrologEpilogSet.insert(Addr);
       InstructionPointer IP(Binary, Addr);
@@ -241,7 +242,7 @@ class ProfiledBinary {
 
   // Lookup BinaryFunctions using the function name's MD5 hash. Needed if the
   // profile is using MD5.
-  std::unordered_map<uint64_t, BinaryFunction *> HashBinaryFunctions;
+  DenseMap<uint64_t, BinaryFunction *> HashBinaryFunctions;
 
   // A list of binary functions that have samples.
   SmallPtrSet<const BinaryFunction *, 0> ProfiledFunctions;
@@ -255,7 +256,7 @@ class ProfiledBinary {
       AlternativeFunctionGUIDs;
 
   // Mapping of profiled binary function to its pseudo probe name
-  std::unordered_map<const BinaryFunction *, StringRef> PseudoProbeNames;
+  DenseMap<const BinaryFunction *, StringRef> PseudoProbeNames;
 
   // These maps are for temporary use of warning diagnosis.
   DenseSet<int64_t> AddrsWithMultipleSymbols;
@@ -270,26 +271,29 @@ class ProfiledBinary {
   std::map<uint64_t, FuncRange> StartAddrToFuncRangeMap;
 
   // Address to context location map. Used to expand the context.
+  // getCachedFrameLocationStack returns references to the mapped values while
+  // later queries insert, so the values' addresses must be stable: keep
+  // std::unordered_map.
   std::unordered_map<uint64_t, SampleContextFrameVector> AddressToLocStackMap;
 
   // Address to instruction size map. Also used for quick Address lookup.
-  std::unordered_map<uint64_t, uint64_t> AddressToInstSizeMap;
+  DenseMap<uint64_t, uint64_t> AddressToInstSizeMap;
 
   // An array of Addresses of all instructions sorted in increasing order. The
   // sorting is needed to fast advance to the next forward/backward instruction.
   std::vector<uint64_t> CodeAddressVec;
   // A set of call instruction addresses. Used by virtual unwinding.
-  std::unordered_set<uint64_t> CallAddressSet;
+  DenseSet<uint64_t> CallAddressSet;
   // A set of return instruction addresses. Used by virtual unwinding.
-  std::unordered_set<uint64_t> RetAddressSet;
+  DenseSet<uint64_t> RetAddressSet;
   // An ordered set of unconditional branch instruction addresses.
   std::set<uint64_t> UncondBranchAddrSet;
   // A set of branch instruction addresses.
-  std::unordered_set<uint64_t> BranchAddressSet;
+  DenseSet<uint64_t> BranchAddressSet;
   // A set of indirect branch instruction addresses.
-  std::unordered_set<uint64_t> IndirectBranchAddressSet;
+  DenseSet<uint64_t> IndirectBranchAddressSet;
   // A set of branch target addresses (destinations of branches/calls).
-  std::unordered_set<uint64_t> BranchTargetAddressSet;
+  DenseSet<uint64_t> BranchTargetAddressSet;
 
   // Estimate and track function prolog and epilog ranges.
   PrologEpilogTracker ProEpilogTracker;

--- a/llvm/tools/llvm-remarkutil/RemarkUtilRegistry.cpp
+++ b/llvm/tools/llvm-remarkutil/RemarkUtilRegistry.cpp
@@ -10,15 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 #include "RemarkUtilRegistry.h"
-#include <unordered_map>
+#include "llvm/ADT/DenseMap.h"
 
 namespace llvm {
 namespace remarkutil {
 
 using HandlerType = std::function<Error()>;
 
-static std::unordered_map<cl::SubCommand *, HandlerType> &getCommands() {
-  static std::unordered_map<cl::SubCommand *, HandlerType> Commands;
+static DenseMap<cl::SubCommand *, HandlerType> &getCommands() {
+  static DenseMap<cl::SubCommand *, HandlerType> Commands;
   return Commands;
 }
 

--- a/llvm/tools/llvm-xray/xray-registry.cpp
+++ b/llvm/tools/llvm-xray/xray-registry.cpp
@@ -11,15 +11,15 @@
 //===----------------------------------------------------------------------===//
 #include "xray-registry.h"
 
-#include <unordered_map>
+#include "llvm/ADT/DenseMap.h"
 
 using namespace llvm;
 using namespace xray;
 
 using HandlerType = std::function<Error()>;
 
-static std::unordered_map<cl::SubCommand *, HandlerType> &getCommands() {
-  static std::unordered_map<cl::SubCommand *, HandlerType> Commands;
+static DenseMap<cl::SubCommand *, HandlerType> &getCommands() {
+  static DenseMap<cl::SubCommand *, HandlerType> Commands;
   return Commands;
 }
 


### PR DESCRIPTION
std::unordered_map is slow. Switch the remaining local maps and sets in
the command-line tools (llvm-profgen, llvm-profdata, llvm-objdump,
llvm-exegesis, llvm-xray, llvm-remarkutil) to DenseMap/DenseSet.