### PR TITLE
[clang][bytecode] Rename checkReturnValue to checkDynamicAllocations

### DIFF
--- a/clang/lib/AST/ByteCode/EvalEmitter.cpp
+++ b/clang/lib/AST/ByteCode/EvalEmitter.cpp
@@ -232,7 +232,7 @@ template <> bool EvalEmitter::emitRet<PT_Ptr>(SourceInfo Info) {
   if (this->PtrCB)
     return (*this->PtrCB)(Ptr);
 
-  if (!EvalResult.checkReturnValue(S, Ctx, Ptr, Info))
+  if (!EvalResult.checkDynamicAllocations(S, Ctx, Ptr, Info))
     return false;
   if (CheckFullyInitialized && !EvalResult.checkFullyInitialized(S, Ptr))
     return false;
@@ -292,7 +292,7 @@ bool EvalEmitter::emitRetVoid(SourceInfo Info) {
 bool EvalEmitter::emitRetValue(SourceInfo Info) {
   const auto &Ptr = S.Stk.pop<Pointer>();
 
-  if (!EvalResult.checkReturnValue(S, Ctx, Ptr, Info))
+  if (!EvalResult.checkDynamicAllocations(S, Ctx, Ptr, Info))
     return false;
   if (CheckFullyInitialized && !EvalResult.checkFullyInitialized(S, Ptr))
     return false;

--- a/clang/lib/AST/ByteCode/EvaluationResult.cpp
+++ b/clang/lib/AST/ByteCode/EvaluationResult.cpp
@@ -198,9 +198,10 @@ static void collectBlocks(PtrView Ptr, llvm::SetVector<const Block *> &Blocks) {
   }
 }
 
-bool EvaluationResult::checkReturnValue(InterpState &S, const Context &Ctx,
-                                        const Pointer &Ptr,
-                                        const SourceInfo &Info) {
+bool EvaluationResult::checkDynamicAllocations(InterpState &S,
+                                               const Context &Ctx,
+                                               const Pointer &Ptr,
+                                               SourceInfo Info) {
   if (!Ptr.isBlockPointer())
     return true;
   // Collect all blocks that this pointer (transitively) points to and

--- a/clang/lib/AST/ByteCode/EvaluationResult.h
+++ b/clang/lib/AST/ByteCode/EvaluationResult.h
@@ -85,8 +85,8 @@ public:
   bool checkFullyInitialized(InterpState &S, const Pointer &Ptr) const;
   /// Check that none of the blocks the given pointer (transitively) points
   /// to are dynamically allocated.
-  bool checkReturnValue(InterpState &S, const Context &Ctx, const Pointer &Ptr,
-                        const SourceInfo &Info);
+  bool checkDynamicAllocations(InterpState &S, const Context &Ctx,
+                               const Pointer &Ptr, SourceInfo Info);
 
   QualType getSourceType() const {
     if (const auto *D =


### PR DESCRIPTION
This is part of https://github.com/llvm/llvm-project/pull/186045, but makes sense independently.