### PR TITLE
[Instrumentor] Move NumericFlags into InstrumentorRuntimeHelper.h

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/InstrumentorRuntimeHelper.h
+++ b/llvm/include/llvm/Transforms/IPO/InstrumentorRuntimeHelper.h
@@ -293,7 +293,7 @@ inline const T *getValueAs(const void *pack_ptr, uint32_t num_elements,
 /// Bitmask flags for different instrumentation opportunities.
 
 /// NumericIO flag bitmask values.
-enum NumericFlags {
+typedef enum NumericFlags {
   NUMERIC_FLAG_NONE = 0,
   NUMERIC_FLAG_NO_SIGNED_WRAP = 1 << 0,
   NUMERIC_FLAG_NO_UNSIGNED_WRAP = 1 << 1,
@@ -302,6 +302,6 @@ enum NumericFlags {
   NUMERIC_FLAG_HAS_NO_SIGNED_ZEROS = 1 << 4,
   NUMERIC_FLAG_IS_DISJOINT = 1 << 5,
   NUMERIC_FLAG_IS_EXACT = 1 << 6,
-};
+} NumericFlags;
 
 #endif // INSTRUMENTOR_RUNTIME_H

--- a/llvm/include/llvm/Transforms/IPO/InstrumentorRuntimeHelper.h
+++ b/llvm/include/llvm/Transforms/IPO/InstrumentorRuntimeHelper.h
@@ -290,4 +290,18 @@ inline const T *getValueAs(const void *pack_ptr, uint32_t num_elements,
 
 #endif // __cplusplus
 
+/// Bitmask flags for different instrumentation opportunities.
+
+/// NumericIO flag bitmask values.
+enum NumericFlags {
+  NUMERIC_FLAG_NONE = 0,
+  NUMERIC_FLAG_NO_SIGNED_WRAP = 1 << 0,
+  NUMERIC_FLAG_NO_UNSIGNED_WRAP = 1 << 1,
+  NUMERIC_FLAG_HAS_NO_NANS = 1 << 2,
+  NUMERIC_FLAG_HAS_NO_INFS = 1 << 3,
+  NUMERIC_FLAG_HAS_NO_SIGNED_ZEROS = 1 << 4,
+  NUMERIC_FLAG_IS_DISJOINT = 1 << 5,
+  NUMERIC_FLAG_IS_EXACT = 1 << 6,
+};
+
 #endif // INSTRUMENTOR_RUNTIME_H

--- a/llvm/lib/Transforms/IPO/Instrumentor.cpp
+++ b/llvm/lib/Transforms/IPO/Instrumentor.cpp
@@ -13,6 +13,7 @@
 
 #include "llvm/Transforms/IPO/Instrumentor.h"
 #include "llvm/Transforms/IPO/InstrumentorConfigFile.h"
+#include "llvm/Transforms/IPO/InstrumentorRuntimeHelper.h"
 #include "llvm/Transforms/IPO/InstrumentorStubPrinter.h"
 
 #include "llvm/ADT/PostOrderIterator.h"
@@ -1704,18 +1705,6 @@ Value *NumericIO::getRight(Value &V, Type &Ty, InstrumentationConfig &IConf,
   else
     return PoisonValue::get(&Ty);
 }
-
-// NumericIO flag bitmask values.
-enum NumericFlags : uint64_t {
-  NUMERIC_FLAG_NONE = 0,
-  NUMERIC_FLAG_NO_SIGNED_WRAP = 1 << 0,
-  NUMERIC_FLAG_NO_UNSIGNED_WRAP = 1 << 1,
-  NUMERIC_FLAG_HAS_NO_NANS = 1 << 2,
-  NUMERIC_FLAG_HAS_NO_INFS = 1 << 3,
-  NUMERIC_FLAG_HAS_NO_SIGNED_ZEROS = 1 << 4,
-  NUMERIC_FLAG_IS_DISJOINT = 1 << 5,
-  NUMERIC_FLAG_IS_EXACT = 1 << 6,
-};
 
 Value *NumericIO::getFlags(Value &V, Type &Ty, InstrumentationConfig &IConf,
                            InstrumentorIRBuilderTy &IIRB) {

--- a/llvm/test/Instrumentation/Instrumentor/default_rt.h
+++ b/llvm/test/Instrumentation/Instrumentor/default_rt.h
@@ -293,7 +293,7 @@ inline const T *getValueAs(const void *pack_ptr, uint32_t num_elements,
 /// Bitmask flags for different instrumentation opportunities.
 
 /// NumericIO flag bitmask values.
-enum NumericFlags {
+typedef enum NumericFlags {
   NUMERIC_FLAG_NONE = 0,
   NUMERIC_FLAG_NO_SIGNED_WRAP = 1 << 0,
   NUMERIC_FLAG_NO_UNSIGNED_WRAP = 1 << 1,
@@ -302,7 +302,7 @@ enum NumericFlags {
   NUMERIC_FLAG_HAS_NO_SIGNED_ZEROS = 1 << 4,
   NUMERIC_FLAG_IS_DISJOINT = 1 << 5,
   NUMERIC_FLAG_IS_EXACT = 1 << 6,
-};
+} NumericFlags;
 
 #endif // INSTRUMENTOR_RUNTIME_H
 

--- a/llvm/test/Instrumentation/Instrumentor/default_rt.h
+++ b/llvm/test/Instrumentation/Instrumentor/default_rt.h
@@ -290,6 +290,20 @@ inline const T *getValueAs(const void *pack_ptr, uint32_t num_elements,
 
 #endif // __cplusplus
 
+/// Bitmask flags for different instrumentation opportunities.
+
+/// NumericIO flag bitmask values.
+enum NumericFlags {
+  NUMERIC_FLAG_NONE = 0,
+  NUMERIC_FLAG_NO_SIGNED_WRAP = 1 << 0,
+  NUMERIC_FLAG_NO_UNSIGNED_WRAP = 1 << 1,
+  NUMERIC_FLAG_HAS_NO_NANS = 1 << 2,
+  NUMERIC_FLAG_HAS_NO_INFS = 1 << 3,
+  NUMERIC_FLAG_HAS_NO_SIGNED_ZEROS = 1 << 4,
+  NUMERIC_FLAG_IS_DISJOINT = 1 << 5,
+  NUMERIC_FLAG_IS_EXACT = 1 << 6,
+};
+
 #endif // INSTRUMENTOR_RUNTIME_H
 
 // Generated with runtime prefix: __instrumentor_


### PR DESCRIPTION
This patch makes the `NumericFlags` enum visible to the end user by moving it into `InstrumentorRuntimeHelper.h`.