### PR TITLE
[lldb] Remove several system header includes from tests

### DIFF
--- a/lldb/test/API/api/listeners/main.c
+++ b/lldb/test/API/api/listeners/main.c
@@ -1,7 +1,1 @@
-#include <stdio.h>
-
-int
-main()
-{
-    printf ("Hello there.\n");
-}
+int main() {}

--- a/lldb/test/API/commands/expression/ir-interpreter/main.c
+++ b/lldb/test/API/commands/expression/ir-interpreter/main.c
@@ -1,7 +1,4 @@
-#include <stdio.h>
-
 int main()
 {
-    printf("This is a dummy\n"); // Set breakpoint here   
-    return 0;
+  return 0; // Set breakpoint here
 }

--- a/lldb/test/API/commands/expression/radar_9673664/main.c
+++ b/lldb/test/API/commands/expression/radar_9673664/main.c
@@ -1,8 +1,6 @@
-#include <stdio.h>
-
 int main (int argc, char const *argv[])
 {
-    printf("Hello, world.\n"); // Set breakpoint here.
-    
-    return 0;
+  return 0; // Set breakpoint here.
+
+  return 0;
 }

--- a/lldb/test/API/commands/expression/top-level/dummy.cpp
+++ b/lldb/test/API/commands/expression/top-level/dummy.cpp
@@ -1,5 +1,3 @@
-#include <stdio.h>
-
 // These are needed to make sure that the linker does not strip the parts of the
 // C++ abi library that are necessary to execute the expressions in the
 // debugger. It would be great if we did not need to do this, but the fact that
@@ -10,6 +8,6 @@ struct DummyB : public virtual DummyA {};
 
 int main() {
   DummyB b;
-  printf("This is a dummy\n"); // Set breakpoint here
+  (void)b; // Set breakpoint here
   return 0;
 }

--- a/lldb/test/API/commands/expression/weak_symbols/main.c
+++ b/lldb/test/API/commands/expression/weak_symbols/main.c
@@ -1,19 +1,20 @@
 #include "dylib.h"
-#include <stdio.h>
+
+int sink;
+void *sinkPtr;
 
 int
 doSomething()
 {
   // Set a breakpoint here.
-  if (&absent_weak_int != NULL)
-    printf("In absent_weak_int: %d\n", absent_weak_int);
-  if (absent_weak_function != NULL)
-    printf("In absent_weak_func: %p\n", absent_weak_function);
-  if (&present_weak_int != NULL)
-    printf("In present_weak_int: %d\n", present_weak_int);
-  if (present_weak_function != NULL)
-    printf("In present_weak_func: %p\n", present_weak_function);
-
+  if (absent_weak_int)
+    sink = absent_weak_int;
+  if (absent_weak_function)
+    sinkPtr = absent_weak_function;
+  if (present_weak_int)
+    sink = present_weak_int;
+  if (present_weak_function)
+    sinkPtr = present_weak_function;
 }
 
 int

--- a/lldb/test/API/functionalities/asan/main.c
+++ b/lldb/test/API/functionalities/asan/main.c
@@ -1,4 +1,3 @@
-#include <stdio.h>
 #include <stdlib.h>
 
 char *pointer;
@@ -18,7 +17,7 @@ int main (int argc, char const *argv[])
     f1();
     f2();
 
-    printf("Hello world!\n"); // break line
+    int bp = 0; // break line
 
     pointer[0] = 'A'; // BOOM line
 

--- a/lldb/test/API/functionalities/memory-region/main.cpp
+++ b/lldb/test/API/functionalities/memory-region/main.cpp
@@ -1,6 +1,3 @@
-#include <iostream>
-
-int main (int argc, char const **argv) {
-  std::cout << "Program with sections" << std::endl;
+int main(int argc, char const **argv) {
   return 0; // Run here before printing memory regions
 }

--- a/lldb/test/API/functionalities/object-file/bin/hello.c
+++ b/lldb/test/API/functionalities/object-file/bin/hello.c
@@ -1,8 +1,1 @@
-#include <stdio.h>
-
-int main(int argc, char **argv)
-{
-	printf("Hello, world\n");
-	return 0;
-}
-
+int main(int argc, char **argv) { return 0; }

--- a/lldb/test/API/functionalities/object-file/bin/hello.cpp
+++ b/lldb/test/API/functionalities/object-file/bin/hello.cpp
@@ -1,8 +1,1 @@
-#include <stdio.h>
-
-int main(int argc, char **argv)
-{
-	printf("Hello, world\n");
-	return 0;
-}
-
+int main(int argc, char **argv) { return 0; }

--- a/lldb/test/API/functionalities/process_save_core_minidump/main.cpp
+++ b/lldb/test/API/functionalities/process_save_core_minidump/main.cpp
@@ -1,5 +1,4 @@
 #include <cassert>
-#include <iostream>
 #include <thread>
 thread_local size_t lf = 42;
 
@@ -20,10 +19,8 @@ size_t h() {
 int main() {
   std::thread t1(f);
 
-  size_t x = h();
+  h();
 
   t1.join();
-
-  std::cout << "X is " << x << "\n";
   return 0;
 }

--- a/lldb/test/API/functionalities/step-vrs-interrupt/main.cpp
+++ b/lldb/test/API/functionalities/step-vrs-interrupt/main.cpp
@@ -1,11 +1,7 @@
-#include <stdio.h>
 #include <chrono>
 #include <thread>
 
-void call_me() {
-  printf("I was called");
-  std::this_thread::sleep_for(std::chrono::seconds(3));
-}
+void call_me() { std::this_thread::sleep_for(std::chrono::seconds(3)); }
 
 int
 main()

--- a/lldb/test/API/functionalities/thread/create_after_attach/main.cpp
+++ b/lldb/test/API/functionalities/thread/create_after_attach/main.cpp
@@ -1,6 +1,5 @@
 #include "attach.h"
 #include <chrono>
-#include <cstdio>
 #include <thread>
 
 using std::chrono::microseconds;
@@ -57,6 +56,4 @@ int main(int argc, char const *argv[])
     // Wait for the threads to finish.
     thread_1.join();
     thread_2.join();
-
-    printf("Exiting now\n");
 }

--- a/lldb/test/API/functionalities/tsan/thread_leak/main.c
+++ b/lldb/test/API/functionalities/tsan/thread_leak/main.c
@@ -1,11 +1,7 @@
 #include <pthread.h>
-#include <stdio.h>
 #include <stdlib.h>
 
-void *f1(void *p) {
-    printf("hello\n");
-    return NULL;
-}
+void *f1(void *p) { return NULL; }
 
 int main (int argc, char const *argv[])
 {

--- a/lldb/test/API/lang/c/const_variables/TestConstVariables.py
+++ b/lldb/test/API/lang/c/const_variables/TestConstVariables.py
@@ -36,7 +36,6 @@ class ConstVariableTestCase(TestBase):
         lldbutil.check_breakpoint(self, bpno=1, expected_hit_count=1)
 
         self.runCmd("next")
-        self.runCmd("next")
 
         # Try frame variable.
         self.expect(

--- a/lldb/test/API/lang/c/const_variables/main.c
+++ b/lldb/test/API/lang/c/const_variables/main.c
@@ -1,5 +1,4 @@
 #include <stdint.h>
-#include <stdio.h>
 
 extern int foo();
 extern int bar();
@@ -13,9 +12,7 @@ int main()
 
   index = 512;
 
-  if (bar())
-  {
-    printf("COMPILER PLEASE STOP HERE\n");
+  if (bar()) {
     index = 256;
   }
 

--- a/lldb/test/API/macosx/profile_vrs_detach/main.c
+++ b/lldb/test/API/macosx/profile_vrs_detach/main.c
@@ -1,4 +1,3 @@
-#include <stdio.h>
 #include <unistd.h>
 
 int
@@ -6,7 +5,6 @@ main()
 {
   while (1) {
     sleep(1); // Set a breakpoint here
-    printf("I slept\n");
   }
   return 0;
 }

--- a/lldb/test/API/python_api/breakpoint/main.c
+++ b/lldb/test/API/python_api/breakpoint/main.c
@@ -1,10 +1,4 @@
-#include <stdio.h>
-
-void
-AFunction()
-{
-  printf ("I am a function.\n");
-}
+void AFunction() {}
 
 int
 main ()

--- a/lldb/test/API/python_api/process/address-masks/main.c
+++ b/lldb/test/API/python_api/process/address-masks/main.c
@@ -1,5 +1,3 @@
-#include <stdio.h>
-
 int main(int argc, char const *argv[]) {
-  puts("Hello address masking world"); // break here
+  return 0; // break here
 }

--- a/lldb/test/API/python_api/unified_section_list/main.cpp
+++ b/lldb/test/API/python_api/unified_section_list/main.cpp
@@ -1,3 +1,1 @@
-#include <stdio.h>
-
-int main() { printf("Hello World\n"); }
+int main() {}

--- a/lldb/test/API/tools/lldb-dap/cancel/main.c
+++ b/lldb/test/API/tools/lldb-dap/cancel/main.c
@@ -1,6 +1,1 @@
-#include <stdio.h>
-
-int main(int argc, char const *argv[]) {
-  printf("Hello world!\n");
-  return 0;
-}
+int main(int argc, char const *argv[]) { return 0; }

--- a/lldb/test/API/tools/lldb-dap/eventStatistic/main.cpp
+++ b/lldb/test/API/tools/lldb-dap/eventStatistic/main.cpp
@@ -1,8 +1,6 @@
 #include "foo.h"
-#include <iostream>
 
 int main(int argc, char const *argv[]) {
-  std::cout << "Hello World!" << std::endl;
   foo();
   return 0;
 }

--- a/lldb/test/API/tools/lldb-dap/locations/main.cpp
+++ b/lldb/test/API/tools/lldb-dap/locations/main.cpp
@@ -1,6 +1,6 @@
-#include <cstdio>
+int g = 0;
 
-void greet() { printf("Hello"); }
+void greet() { g++; }
 
 struct Test {
   void foo() {}

--- a/lldb/test/API/tools/lldb-dap/restart/main.c
+++ b/lldb/test/API/tools/lldb-dap/restart/main.c
@@ -1,9 +1,6 @@
-#include <stdio.h>
-
 int main(int argc, char const *argv[], char const *envp[]) {
   int i = 0;
-  printf("Do something\n"); // breakpoint A
-  printf("Do something else\n");
+  (void)i; // breakpoint A
   i = 1234;
   return 0; // breakpoint B
 }

--- a/lldb/test/API/tools/lldb-dap/send-event/main.c
+++ b/lldb/test/API/tools/lldb-dap/send-event/main.c
@@ -1,6 +1,3 @@
-#include <stdio.h>
-
 int main(int argc, char const *argv[]) {
-  printf("example\n"); // breakpoint 1
-  return 0;
+  return 0; // breakpoint 1
 }

--- a/lldb/test/API/tools/lldb-dap/stackTrace/subtleFrames/main.cpp
+++ b/lldb/test/API/tools/lldb-dap/stackTrace/subtleFrames/main.cpp
@@ -1,9 +1,8 @@
 #include <functional>
-#include <iostream>
 
+int g = 0;
 void greet() {
-  // BREAK HERE
-  std::cout << "Hello\n";
+  g++; // BREAK HERE
 }
 
 int main() {

--- a/lldb/test/API/tools/lldb-dap/startDebugging/main.c
+++ b/lldb/test/API/tools/lldb-dap/startDebugging/main.c
@@ -1,6 +1,3 @@
-#include <stdio.h>
-
 int main(int argc, char const *argv[]) {
-  printf("example\n"); // breakpoint 1
-  return 0;
+  return 0; // breakpoint 1
 }

--- a/lldb/test/API/tools/lldb-dap/terminated-event/main.cpp
+++ b/lldb/test/API/tools/lldb-dap/terminated-event/main.cpp
@@ -1,8 +1,7 @@
 #include "foo.h"
-#include <iostream>
 
 int main(int argc, char const *argv[]) {
-  std::cout << "Hello World!" << std::endl; // main breakpoint 1
+  int bp = 0; // main breakpoint 1
   foo();
   return 0;
 }

--- a/lldb/test/API/tools/lldb-dap/unknown/main.c
+++ b/lldb/test/API/tools/lldb-dap/unknown/main.c
@@ -1,6 +1,1 @@
-#include <stdio.h>
-
-int main() {
-  printf("Hello, World!\n");
-  return 0;
-}
+int main() { return 0; }


### PR DESCRIPTION
System includes slow down test compilation and create unnecessary dependencies on system header code.

This patch removes system headers from tests that do not test their functionality. For the most part, this just removes the dummy 'printf' we had in many tests.