### PR TITLE
[clang][bytecode] Add more checks around _Complex values

### DIFF
--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -909,7 +909,7 @@ std::optional<APValue> Pointer::toRValue(const Context &Ctx,
     if (Ty->isAnyComplexType()) {
       const Descriptor *Desc = Ptr.getFieldDesc();
       // Can happen via C casts.
-      if (!Desc->isPrimitiveArray())
+      if (!Desc->getType()->isAnyComplexType())
         return false;
 
       PrimType ElemT = Desc->getPrimType();

--- a/clang/lib/AST/ByteCode/Pointer.h
+++ b/clang/lib/AST/ByteCode/Pointer.h
@@ -671,7 +671,11 @@ public:
   bool isTypeidPointer() const { return StorageKind == Storage::Typeid; }
 
   /// Returns the record descriptor of a class.
-  const Record *getRecord() const { return view().getRecord(); }
+  const Record *getRecord() const {
+    if (!isBlockPointer())
+      return nullptr;
+    return view().getRecord();
+  }
   /// Returns the element record type, if this is a non-primive array.
   const Record *getElemRecord() const { return view().getElemRecord(); }
   /// Returns the field information.

--- a/clang/test/AST/ByteCode/complex.cpp
+++ b/clang/test/AST/ByteCode/complex.cpp
@@ -477,3 +477,10 @@ namespace MemcpyOp {
     z = *(_Complex double *)&x;
   };
 }
+
+namespace LessThanTwoElements {
+  void foo()  { _Complex float z = *(_Complex double *)&(int[]){0};    } // both-error {{taking the address of a temporary object of type 'int[1]'}}
+  void foo2() { _Complex float z = *(_Complex double *)&(int[]){0, 0}; } // both-error {{taking the address of a temporary object of type 'int[2]'}}
+
+  double _Complex z = *(double _Complex *)&(*(int *)0x1234);
+}


### PR DESCRIPTION
Check the actual source type when converting a pointer to an rvalue. We otherwise allow converting form a two-element primitive array.