### PR TITLE
[clang][bytecode] Allow downcasts of constexpr-unknown values

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -558,8 +558,15 @@ bool CheckDowncast(InterpState &S, CodePtr OpPC, const Pointer &Ptr,
     return true;
 
   const auto *E = cast<CastExpr>(S.Current->getExpr(OpPC));
-  QualType TargetQT = E->getType()->getPointeeType();
+  QualType ExprTy = E->getType();
+  if (ExprTy->isPointerOrReferenceType())
+    ExprTy = ExprTy->getPointeeType();
+
+  QualType TargetQT = ExprTy;
   QualType MostDerivedQT = Ptr.getDeclPtr().getType();
+
+  if (MostDerivedQT->isPointerOrReferenceType())
+    MostDerivedQT = MostDerivedQT->getPointeeType();
 
   S.CCEDiag(E, diag::note_constexpr_invalid_downcast)
       << MostDerivedQT << TargetQT;
@@ -1577,9 +1584,6 @@ bool GetPtrDerivedPop(InterpState &S, CodePtr OpPC, uint32_t Off, bool NullOK,
     S.Stk.push<Pointer>(Ptr);
     return true;
   }
-
-  if (isConstexprUnknown(Ptr))
-    return false;
 
   if (!Ptr.getFieldDesc()->isRecord()) {
     S.Stk.push<Pointer>(Ptr);

--- a/clang/test/SemaCXX/constant-expression-p2280r4.cpp
+++ b/clang/test/SemaCXX/constant-expression-p2280r4.cpp
@@ -296,14 +296,14 @@ namespace casting {
   struct B : A {};
   struct C : A {};
   extern A &a;
-  extern B &b; // nointerpreter-note {{declared here}}
+  extern B &b; // expected-note {{declared here}}
   constexpr B &t1 = (B&)a; // expected-error {{must be initialized by a constant expression}} \
-                           // nointerpreter-note {{cannot cast object of dynamic type 'A' to type 'B'}}
+                           // expected-note {{cannot cast object of dynamic type 'A' to type 'B'}}
   constexpr B &t2 = (B&)(A&)b; // expected-error {{must be initialized by a constant expression}} \
-                               // nointerpreter-note {{initializer of 'b' is not a constant expression}}
-  constexpr bool t3 = &b + 1 == &(B&)(A&)b; // interpreter-error {{constexpr variable 't3' must be initialized by a constant expression}}
+                               // expected-note {{initializer of 'b' is not a constant expression}}
+  constexpr bool t3 = &b + 1 == &(B&)(A&)b;
   constexpr C &t4 = (C&)(A&)b; // expected-error {{must be initialized by a constant expression}} \
-                               // nointerpreter-note {{cannot cast object of dynamic type 'B' to type 'C'}}
+                               // expected-note {{cannot cast object of dynamic type 'B' to type 'C'}}
 }
 
 namespace pointer_comparisons {


### PR DESCRIPTION
They might be diagnosed later.