### PR TITLE
[OpenCL] Warn if filter_mode is linear in read_image{i|ui}

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11834,6 +11834,8 @@ def err_sampler_initializer_not_integer : Error<
   "sampler_t initialization requires 32-bit integer, not %0">;
 def warn_sampler_initializer_invalid_bits : Warning<
   "sampler initializer has invalid %0 bits">, InGroup<SpirCompat>, DefaultIgnore;
+def warn_sampler_argument_invalid_filter : Warning<
+  "'%0' sampler must use CLK_FILTER_NEAREST">, InGroup<SpirCompat>;
 def err_sampler_argument_required : Error<
   "sampler_t variable required - got %0">;
 def err_wrong_sampler_addressspace: Error<

--- a/clang/include/clang/Sema/SemaOpenCL.h
+++ b/clang/include/clang/Sema/SemaOpenCL.h
@@ -100,6 +100,8 @@ public:
   bool checkBuiltinKernelWorkGroupSize(CallExpr *TheCall);
 
   bool checkBuiltinNDRangeAndBlock(CallExpr *TheCall);
+
+  void checkBuiltinReadImage(FunctionDecl *FDecl, CallExpr *Call);
 };
 
 } // namespace clang

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -59,6 +59,7 @@
 #include "clang/Sema/SemaFixItUtils.h"
 #include "clang/Sema/SemaHLSL.h"
 #include "clang/Sema/SemaObjC.h"
+#include "clang/Sema/SemaOpenCL.h"
 #include "clang/Sema/SemaOpenMP.h"
 #include "clang/Sema/SemaPseudoObject.h"
 #include "clang/Sema/Template.h"
@@ -7281,6 +7282,12 @@ ExprResult Sema::BuildResolvedCallExpr(Expr *Fn, NamedDecl *NDecl,
                               diag::err_wasm_table_as_function_parameter));
       }
     }
+  }
+
+  // Check read_image{i|ui} sampler argument before ConvertArgumentsForCall
+  // replaces sampler DeclRefExprs with their integer initializers.
+  if (getLangOpts().OpenCL && FDecl) {
+    OpenCL().checkBuiltinReadImage(FDecl, TheCall);
   }
 
   if (Proto) {

--- a/clang/lib/Sema/SemaOpenCL.cpp
+++ b/clang/lib/Sema/SemaOpenCL.cpp
@@ -12,7 +12,9 @@
 
 #include "clang/Sema/SemaOpenCL.h"
 #include "clang/AST/Attr.h"
+#include "clang/AST/Decl.h"
 #include "clang/AST/DeclBase.h"
+#include "clang/AST/Expr.h"
 #include "clang/Basic/DiagnosticSema.h"
 #include "clang/Sema/ParsedAttr.h"
 #include "clang/Sema/Sema.h"
@@ -574,6 +576,53 @@ bool SemaOpenCL::checkBuiltinToAddr(unsigned BuiltinID, CallExpr *Call) {
       getASTContext().getQualifiedType(RT.getUnqualifiedType(), Qual)));
 
   return false;
+}
+
+void SemaOpenCL::checkBuiltinReadImage(FunctionDecl *FDecl, CallExpr *Call) {
+  IdentifierInfo *II = FDecl->getIdentifier();
+  if (!II)
+    return;
+  StringRef Name = II->getName();
+  if (Name != "read_imagei" && Name != "read_imageui")
+    return;
+
+  // read_image{i|ui} take (image, sampler, coord); sampler is arg[1].
+  if (Call->getNumArgs() < 2)
+    return;
+  Expr *SamplerArg = Call->getArg(1);
+  QualType ArgTy = SamplerArg->getType().getCanonicalType();
+  if (!ArgTy->isSamplerT() && !ArgTy->isIntegerType())
+    return;
+
+  Expr *IntExpr = nullptr;
+  Expr *Inner = SamplerArg->IgnoreParenCasts();
+
+  if (auto *DRE = dyn_cast<DeclRefExpr>(Inner)) {
+    if (auto *Var = dyn_cast<VarDecl>(DRE->getDecl())) {
+      if (const Expr *Init = Var->getAnyInitializer()) {
+        Init = Init->IgnoreParenImpCasts();
+        if (Init->getType()->isIntegerType())
+          IntExpr = const_cast<Expr *>(Init);
+      }
+    }
+  } else if (Inner->getType()->isIntegerType()) {
+    IntExpr = Inner;
+  }
+
+  if (!IntExpr)
+    return;
+
+  Expr::EvalResult EVResult;
+  if (!IntExpr->EvaluateAsInt(EVResult, getASTContext()))
+    return;
+
+  uint64_t SamplerValue = EVResult.Val.getInt().getLimitedValue();
+  // Bit layout: |...|FilterMode[5:4]|AddressMode[3:1]|NormalizedCoords[0]|
+  // CLK_FILTER_LINEAR = 0x20 => FilterMode bits = 2
+  if (((SamplerValue & 0x30u) >> 4) == 2)
+    Diag(SamplerArg->getExprLoc(),
+         diag::warn_sampler_argument_invalid_filter)
+        << Name << SamplerArg->getSourceRange();
 }
 
 } // namespace clang

--- a/clang/lib/Sema/SemaOpenCL.cpp
+++ b/clang/lib/Sema/SemaOpenCL.cpp
@@ -620,8 +620,7 @@ void SemaOpenCL::checkBuiltinReadImage(FunctionDecl *FDecl, CallExpr *Call) {
   // Bit layout: |...|FilterMode[5:4]|AddressMode[3:1]|NormalizedCoords[0]|
   // CLK_FILTER_LINEAR = 0x20 => FilterMode bits = 2
   if (((SamplerValue & 0x30u) >> 4) == 2)
-    Diag(SamplerArg->getExprLoc(),
-         diag::warn_sampler_argument_invalid_filter)
+    Diag(SamplerArg->getExprLoc(), diag::warn_sampler_argument_invalid_filter)
         << Name << SamplerArg->getSourceRange();
 }
 

--- a/clang/lib/Sema/SemaOpenCL.cpp
+++ b/clang/lib/Sema/SemaOpenCL.cpp
@@ -586,8 +586,9 @@ void SemaOpenCL::checkBuiltinReadImage(FunctionDecl *FDecl, CallExpr *Call) {
   if (Name != "read_imagei" && Name != "read_imageui")
     return;
 
-  // read_image{i|ui} take (image, sampler, coord); sampler is arg[1].
-  if (Call->getNumArgs() < 2)
+  // read_image{i|ui} with a sampler take (image, sampler, coord).
+  // Bail out samplerless overloads (image, coord) — 2 args.
+  if (Call->getNumArgs() < 3)
     return;
   Expr *SamplerArg = Call->getArg(1);
   QualType ArgTy = SamplerArg->getType().getCanonicalType();

--- a/clang/lib/Sema/SemaOpenCL.cpp
+++ b/clang/lib/Sema/SemaOpenCL.cpp
@@ -618,9 +618,10 @@ void SemaOpenCL::checkBuiltinReadImage(FunctionDecl *FDecl, CallExpr *Call) {
     return;
 
   uint64_t SamplerValue = EVResult.Val.getInt().getLimitedValue();
-  // Bit layout: |...|FilterMode[5:4]|AddressMode[3:1]|NormalizedCoords[0]|
-  // CLK_FILTER_LINEAR = 0x20 => FilterMode bits = 2
-  if (((SamplerValue & 0x30u) >> 4) == 2)
+  // Must stay in sync with CLK_FILTER_* defines in opencl-c-base.h.
+  constexpr unsigned FilterModeMask = 0x30u;
+  constexpr unsigned FilterModeLinear = 0x20u;
+  if ((SamplerValue & FilterModeMask) == FilterModeLinear)
     Diag(SamplerArg->getExprLoc(), diag::warn_sampler_argument_invalid_filter)
         << Name << SamplerArg->getSourceRange();
 }

--- a/clang/lib/Sema/SemaOpenCL.cpp
+++ b/clang/lib/Sema/SemaOpenCL.cpp
@@ -586,14 +586,12 @@ void SemaOpenCL::checkBuiltinReadImage(FunctionDecl *FDecl, CallExpr *Call) {
   if (Name != "read_imagei" && Name != "read_imageui")
     return;
 
-  // read_image{i|ui} with a sampler take (image, sampler, coord).
-  // Bail out samplerless overloads (image, coord) — 2 args.
-  if (Call->getNumArgs() < 3)
+  if (FDecl->getNumParams() < 2)
+    return;
+  QualType ParamTy = FDecl->getParamDecl(1)->getType().getCanonicalType();
+  if (!ParamTy->isSamplerT())
     return;
   Expr *SamplerArg = Call->getArg(1);
-  QualType ArgTy = SamplerArg->getType().getCanonicalType();
-  if (!ArgTy->isSamplerT() && !ArgTy->isIntegerType())
-    return;
 
   Expr *IntExpr = nullptr;
   Expr *Inner = SamplerArg->IgnoreParenCasts();

--- a/clang/test/SemaOpenCL/read-image-integer-linear-filter.cl
+++ b/clang/test/SemaOpenCL/read-image-integer-linear-filter.cl
@@ -66,3 +66,13 @@ kernel void test_read_imagef_linear(read_only image2d_t img, global float *out) 
   float2 coord = (float2)(0.5f, 0.5f);
   *out = read_imagef(img, glb_linear, coord).s0; // no warning
 }
+
+// Samplerless 1D image reads: integer coordinate must not be mistaken for a
+// sampler value even when it looks like CLK_FILTER_LINEAR (e.g. 0x20).
+kernel void test_read_imageui_samplerless(read_only image1d_t img, global uint *out) {
+  *out = read_imageui(img, 0x10).s0; // no warning
+  *out = read_imageui(img, 0x20).s0; // no warning
+  *out = read_imageui(img, 0x30).s0; // no warning
+  *out = read_imagei(img, 0x10).s0;  // no warning
+  *out = read_imagei(img, 0x20).s0;  // no warning
+}

--- a/clang/test/SemaOpenCL/read-image-integer-linear-filter.cl
+++ b/clang/test/SemaOpenCL/read-image-integer-linear-filter.cl
@@ -1,0 +1,68 @@
+// RUN: %clang_cc1 %s -verify -fsyntax-only -cl-std=CL2.0 -finclude-default-header
+
+// OpenCL spec: read_imagei and read_imageui support nearest filter only.
+// CLK_FILTER_LINEAR in the sampler results in undefined behavior; warn.
+
+// Program scope samplers.
+__constant sampler_t glb_linear =
+    CLK_NORMALIZED_COORDS_TRUE | CLK_FILTER_LINEAR | CLK_ADDRESS_MIRRORED_REPEAT;
+__constant sampler_t glb_nearest =
+    CLK_NORMALIZED_COORDS_TRUE | CLK_FILTER_NEAREST | CLK_ADDRESS_CLAMP_TO_EDGE;
+
+kernel void test_read_imageui_global_sampler(read_only image2d_t img, global uint *out) {
+  int2 coord = (int2)(0, 0);
+  *out = read_imageui(img, glb_linear, coord).s0; // expected-warning{{'read_imageui' sampler must use CLK_FILTER_NEAREST}}
+  *out = read_imageui(img, glb_nearest, coord).s0; // no warning
+}
+
+kernel void test_read_imagei_global_sampler(read_only image2d_t img, global int *out) {
+  int2 coord = (int2)(0, 0);
+  *out = read_imagei(img, glb_linear, coord).s0; // expected-warning{{'read_imagei' sampler must use CLK_FILTER_NEAREST}}
+}
+
+kernel void test_read_imageui_local_constant(read_only image2d_t img, global uint *out) {
+  __constant sampler_t s_linear =
+      CLK_NORMALIZED_COORDS_TRUE | CLK_FILTER_LINEAR | CLK_ADDRESS_CLAMP;
+  int2 coord = (int2)(0, 0);
+  *out = read_imageui(img, s_linear, coord).s0; // expected-warning{{'read_imageui' sampler must use CLK_FILTER_NEAREST}}
+}
+
+kernel void test_read_imageui_nearest_constant(read_only image2d_t img, global uint *out) {
+  __constant sampler_t s_nearest =
+      CLK_NORMALIZED_COORDS_FALSE | CLK_FILTER_NEAREST | CLK_ADDRESS_NONE;
+  int2 coord = (int2)(0, 0);
+  *out = read_imageui(img, s_nearest, coord).s0; // no warning
+}
+
+kernel void test_read_imageui_local(read_only image2d_t img, global uint *out) {
+  sampler_t s_linear =
+      CLK_NORMALIZED_COORDS_TRUE | CLK_FILTER_LINEAR | CLK_ADDRESS_CLAMP;
+  int2 coord = (int2)(0, 0);
+  *out = read_imageui(img, s_linear, coord).s0; // expected-warning{{'read_imageui' sampler must use CLK_FILTER_NEAREST}}
+}
+
+kernel void test_read_imageui_nearest(read_only image2d_t img, global uint *out) {
+  sampler_t s_nearest =
+      CLK_NORMALIZED_COORDS_FALSE | CLK_FILTER_NEAREST | CLK_ADDRESS_NONE;
+  int2 coord = (int2)(0, 0);
+  *out = read_imageui(img, s_nearest, coord).s0; // no warning
+}
+
+kernel void test_read_imageui_literal(read_only image2d_t img, global uint *out) {
+  int2 coord = (int2)(0, 0);
+  // CLK_NORMALIZED_COORDS_TRUE | CLK_FILTER_LINEAR | CLK_ADDRESS_CLAMP = 0x21
+  *out = read_imageui(img, CLK_NORMALIZED_COORDS_TRUE | CLK_FILTER_LINEAR | CLK_ADDRESS_CLAMP, coord).s0; // expected-warning{{'read_imageui' sampler must use CLK_FILTER_NEAREST}}
+  // CLK_NORMALIZED_COORDS_FALSE | CLK_FILTER_NEAREST | CLK_ADDRESS_NONE = 0x10
+  *out = read_imageui(img, CLK_NORMALIZED_COORDS_FALSE | CLK_FILTER_NEAREST | CLK_ADDRESS_NONE, coord).s0; // no warning
+}
+
+kernel void test_read_imageui_parameter(read_only image2d_t img, global uint *out, sampler_t smp) {
+  int2 coord = (int2)(0, 0);
+  *out = read_imageui(img, smp, coord).s0; // no warning
+}
+
+kernel void test_read_imagef_linear(read_only image2d_t img, global float *out) {
+  // read_imagef supports linear filtering: no warning.
+  float2 coord = (float2)(0.5f, 0.5f);
+  *out = read_imagef(img, glb_linear, coord).s0; // no warning
+}

--- a/clang/test/SemaOpenCL/read-image-integer-linear-filter.cl
+++ b/clang/test/SemaOpenCL/read-image-integer-linear-filter.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -verify -fsyntax-only -cl-std=CL2.0 -finclude-default-header
+// RUN: %clang_cc1 %s -verify -fsyntax-only -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header
 
 // OpenCL spec: read_imagei and read_imageui support nearest filter only.
 // CLK_FILTER_LINEAR in the sampler results in undefined behavior; warn.

--- a/clang/test/SemaOpenCL/read-image-integer-linear-filter.cl
+++ b/clang/test/SemaOpenCL/read-image-integer-linear-filter.cl
@@ -9,70 +9,70 @@ __constant sampler_t glb_linear =
 __constant sampler_t glb_nearest =
     CLK_NORMALIZED_COORDS_TRUE | CLK_FILTER_NEAREST | CLK_ADDRESS_CLAMP_TO_EDGE;
 
-kernel void test_read_imageui_global_sampler(read_only image2d_t img, global uint *out) {
+kernel void test_read_imageui_global_sampler(read_only image2d_t img) {
   int2 coord = (int2)(0, 0);
-  *out = read_imageui(img, glb_linear, coord).s0; // expected-warning{{'read_imageui' sampler must use CLK_FILTER_NEAREST}}
-  *out = read_imageui(img, glb_nearest, coord).s0; // no warning
+  uint4 u = read_imageui(img, glb_linear, coord); // expected-warning{{'read_imageui' sampler must use CLK_FILTER_NEAREST}}
+  u = read_imageui(img, glb_nearest, coord); // no warning
 }
 
-kernel void test_read_imagei_global_sampler(read_only image2d_t img, global int *out) {
+kernel void test_read_imagei_global_sampler(read_only image2d_t img) {
   int2 coord = (int2)(0, 0);
-  *out = read_imagei(img, glb_linear, coord).s0; // expected-warning{{'read_imagei' sampler must use CLK_FILTER_NEAREST}}
+  int4 i = read_imagei(img, glb_linear, coord); // expected-warning{{'read_imagei' sampler must use CLK_FILTER_NEAREST}}
 }
 
-kernel void test_read_imageui_local_constant(read_only image2d_t img, global uint *out) {
+kernel void test_read_imageui_local_constant(read_only image2d_t img) {
   __constant sampler_t s_linear =
       CLK_NORMALIZED_COORDS_TRUE | CLK_FILTER_LINEAR | CLK_ADDRESS_CLAMP;
   int2 coord = (int2)(0, 0);
-  *out = read_imageui(img, s_linear, coord).s0; // expected-warning{{'read_imageui' sampler must use CLK_FILTER_NEAREST}}
+  uint4 u = read_imageui(img, s_linear, coord); // expected-warning{{'read_imageui' sampler must use CLK_FILTER_NEAREST}}
 }
 
-kernel void test_read_imageui_nearest_constant(read_only image2d_t img, global uint *out) {
+kernel void test_read_imageui_nearest_constant(read_only image2d_t img) {
   __constant sampler_t s_nearest =
       CLK_NORMALIZED_COORDS_FALSE | CLK_FILTER_NEAREST | CLK_ADDRESS_NONE;
   int2 coord = (int2)(0, 0);
-  *out = read_imageui(img, s_nearest, coord).s0; // no warning
+  uint4 u = read_imageui(img, s_nearest, coord); // no warning
 }
 
-kernel void test_read_imageui_local(read_only image2d_t img, global uint *out) {
+kernel void test_read_imageui_local(read_only image2d_t img) {
   sampler_t s_linear =
       CLK_NORMALIZED_COORDS_TRUE | CLK_FILTER_LINEAR | CLK_ADDRESS_CLAMP;
   int2 coord = (int2)(0, 0);
-  *out = read_imageui(img, s_linear, coord).s0; // expected-warning{{'read_imageui' sampler must use CLK_FILTER_NEAREST}}
+  uint4 u = read_imageui(img, s_linear, coord); // expected-warning{{'read_imageui' sampler must use CLK_FILTER_NEAREST}}
 }
 
-kernel void test_read_imageui_nearest(read_only image2d_t img, global uint *out) {
+kernel void test_read_imageui_nearest(read_only image2d_t img) {
   sampler_t s_nearest =
       CLK_NORMALIZED_COORDS_FALSE | CLK_FILTER_NEAREST | CLK_ADDRESS_NONE;
   int2 coord = (int2)(0, 0);
-  *out = read_imageui(img, s_nearest, coord).s0; // no warning
+  uint4 u = read_imageui(img, s_nearest, coord); // no warning
 }
 
-kernel void test_read_imageui_literal(read_only image2d_t img, global uint *out) {
+kernel void test_read_imageui_literal(read_only image2d_t img) {
   int2 coord = (int2)(0, 0);
   // CLK_NORMALIZED_COORDS_TRUE | CLK_FILTER_LINEAR | CLK_ADDRESS_CLAMP = 0x21
-  *out = read_imageui(img, CLK_NORMALIZED_COORDS_TRUE | CLK_FILTER_LINEAR | CLK_ADDRESS_CLAMP, coord).s0; // expected-warning{{'read_imageui' sampler must use CLK_FILTER_NEAREST}}
+  uint4 u = read_imageui(img, CLK_NORMALIZED_COORDS_TRUE | CLK_FILTER_LINEAR | CLK_ADDRESS_CLAMP, coord); // expected-warning{{'read_imageui' sampler must use CLK_FILTER_NEAREST}}
   // CLK_NORMALIZED_COORDS_FALSE | CLK_FILTER_NEAREST | CLK_ADDRESS_NONE = 0x10
-  *out = read_imageui(img, CLK_NORMALIZED_COORDS_FALSE | CLK_FILTER_NEAREST | CLK_ADDRESS_NONE, coord).s0; // no warning
+  u = read_imageui(img, CLK_NORMALIZED_COORDS_FALSE | CLK_FILTER_NEAREST | CLK_ADDRESS_NONE, coord); // no warning
 }
 
-kernel void test_read_imageui_parameter(read_only image2d_t img, global uint *out, sampler_t smp) {
+kernel void test_read_imageui_parameter(read_only image2d_t img, sampler_t smp) {
   int2 coord = (int2)(0, 0);
-  *out = read_imageui(img, smp, coord).s0; // no warning
+  uint4 u = read_imageui(img, smp, coord); // no warning
 }
 
-kernel void test_read_imagef_linear(read_only image2d_t img, global float *out) {
+kernel void test_read_imagef_linear(read_only image2d_t img) {
   // read_imagef supports linear filtering: no warning.
   float2 coord = (float2)(0.5f, 0.5f);
-  *out = read_imagef(img, glb_linear, coord).s0; // no warning
+  float4 f = read_imagef(img, glb_linear, coord); // no warning
 }
 
 // Samplerless 1D image reads: integer coordinate must not be mistaken for a
 // sampler value even when it looks like CLK_FILTER_LINEAR (e.g. 0x20).
-kernel void test_read_imageui_samplerless(read_only image1d_t img, global uint *out) {
-  *out = read_imageui(img, 0x10).s0; // no warning
-  *out = read_imageui(img, 0x20).s0; // no warning
-  *out = read_imageui(img, 0x30).s0; // no warning
-  *out = read_imagei(img, 0x10).s0;  // no warning
-  *out = read_imagei(img, 0x20).s0;  // no warning
+kernel void test_read_imageui_samplerless(read_only image1d_t img) {
+  uint4 u = read_imageui(img, 0x10); // no warning
+  u = read_imageui(img, 0x20); // no warning
+  u = read_imageui(img, 0x30); // no warning
+  int4 i = read_imagei(img, 0x10); // no warning
+  i = read_imagei(img, 0x20); // no warning
 }

--- a/clang/test/SemaOpenCL/read-image-integer-linear-filter.cl
+++ b/clang/test/SemaOpenCL/read-image-integer-linear-filter.cl
@@ -1,4 +1,6 @@
 // RUN: %clang_cc1 %s -verify -fsyntax-only -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header
+// RUN: %clang_cc1 %s -verify=nowarn -fsyntax-only -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -Wno-spir-compat
+// nowarn-no-diagnostics
 
 // OpenCL spec: read_imagei and read_imageui support nearest filter only.
 // CLK_FILTER_LINEAR in the sampler results in undefined behavior; warn.


### PR DESCRIPTION
Per OpenCL spec:
The read_image{i|ui} calls support a nearest filter only. The filter_mode specified in sampler must be set to CLK_FILTER_NEAREST; otherwise the values returned are undefined.

Warn users when they apply a linear filter accidentally.
Address https://github.com/intel/compute-runtime/issues/379#issuecomment-4592083032

Assisted-by: Claude Sonnet 4.6