### PR TITLE
[AMDGPU][GISel] Add dst_lo_hi_sel operands to register bank legalize rules for amdgcn_cvt_scalef32_f16_(fp8,bf8)

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeRules.cpp
@@ -2088,8 +2088,8 @@ RegBankLegalizeRules::RegBankLegalizeRules(const GCNSubtarget &_ST,
 
   addRulesForIOpcs({amdgcn_cvt_scalef32_f16_fp8, amdgcn_cvt_scalef32_f16_bf8},
                    Standard)
-      .Div(V2S16, {{VgprV2S16}, {IntrId, VgprV2S16, Vgpr32, Vgpr32}})
-      .Uni(V2S16, {{UniInVgprV2S16}, {IntrId, VgprV2S16, Vgpr32, Vgpr32}});
+      .Div(V2S16, {{VgprV2S16}, {IntrId, VgprV2S16, Vgpr32, Vgpr32, Imm}})
+      .Uni(V2S16, {{UniInVgprV2S16}, {IntrId, VgprV2S16, Vgpr32, Vgpr32, Imm}});
 
   addRulesForIOpcs({amdgcn_cvt_scalef32_f32_fp8, amdgcn_cvt_scalef32_f32_bf8},
                    Standard)


### PR DESCRIPTION
As discussed on https://github.com/llvm/llvm-project/pull/203253 (and already present for amdgcn_cvt_sr_(f16,bf16)_f32, amdgcn_cvt_scalef32_pk_(fp8,bf8)_f32, and amdgcn_cvt_scalef32_pk_(fp8,bf8)_f16).