### PR TITLE
[Support] Remove incorrect LLVM_ABI annotation

### DIFF
--- a/llvm/include/llvm/Support/CommandLine.h
+++ b/llvm/include/llvm/Support/CommandLine.h
@@ -333,8 +333,8 @@ public:
   void addSubCommand(SubCommand &S) { Subs.insert(&S); }
 
 protected:
-  LLVM_ABI explicit Option(enum NumOccurrencesFlag OccurrencesFlag,
-                           enum OptionHidden Hidden);
+  explicit Option(enum NumOccurrencesFlag OccurrencesFlag,
+                  enum OptionHidden Hidden);
 
   inline void setNumAdditionalVals(unsigned n) { AdditionalVals = n; }
 


### PR DESCRIPTION
This was mistakenly added in #202847. The `Option` class is annotated with `LLVM_ABI`. The effort to build LLVM as a dynamic library is tracked in #109483.