### PR TITLE
[MLIR][EmitC] Allow lvalue operands in (member_)call_opaque arg_operands

### DIFF
--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -302,7 +302,7 @@ def EmitC_CallOpaqueOp : EmitC_Op<"call_opaque", [CExpressionInterface]> {
     Arg<StrAttr, "the C++ function to call">:$callee,
     Arg<OptionalAttr<ArrayAttr>, "the order of operands and further attributes">:$args,
     Arg<OptionalAttr<ArrayAttr>, "template arguments">:$template_args,
-    Variadic<EmitCType>:$arg_operands
+    Variadic<AnyTypeOf<[EmitCType, EmitC_LValueType]>>:$arg_operands
   );
   let results = (outs Variadic<EmitCType>);
   let builders = [
@@ -347,7 +347,7 @@ def EmitC_MemberCallOpaqueOp : EmitC_Op<"member_call_opaque", [CExpressionInterf
     StrAttr:$callee,
     OptionalAttr<ArrayAttr>:$args,
     OptionalAttr<ArrayAttr>:$template_args,
-    Variadic<EmitCType>:$arg_operands
+    Variadic<AnyTypeOf<[EmitCType, EmitC_LValueType]>>:$arg_operands
   );
   let results = (outs Variadic<EmitCType>);
 

--- a/mlir/test/Dialect/EmitC/member_call_opaque.mlir
+++ b/mlir/test/Dialect/EmitC/member_call_opaque.mlir
@@ -27,3 +27,10 @@ func.func @member_call_reorder(%arg0 : !emitc.opaque<"MyClass">, %arg1 : i32, %a
 }
 // CHECK-LABEL: func @member_call_reorder
 // CHECK: emitc.member_call_opaque %arg0 "method"(%arg1, %arg2) <{args = [1 : index, 0 : index]}> : !emitc.opaque<"MyClass">, (i32, i32) -> i32
+
+func.func @member_call_lvalue_arg(%arg0 : !emitc.opaque<"MyClass">, %arg1 : !emitc.lvalue<i32>) {
+  %0 = emitc.member_call_opaque %arg0 "method" (%arg1) : !emitc.opaque<"MyClass">, (!emitc.lvalue<i32>) -> i32
+  return
+}
+// CHECK-LABEL: func @member_call_lvalue_arg
+// CHECK: emitc.member_call_opaque %arg0 "method"(%arg1) : !emitc.opaque<"MyClass">, (!emitc.lvalue<i32>) -> i32

--- a/mlir/test/Target/Cpp/call.mlir
+++ b/mlir/test/Target/Cpp/call.mlir
@@ -35,6 +35,15 @@ func.func @emitc_call_opaque_two_results() {
 // CPP-DECLTOP-NEXT: [[V1]] = 0;
 // CPP-DECLTOP-NEXT: std::tie([[V2]], [[V3]]) = two_results();
 
+func.func @emitc_call_opaque_lvalue_arg() {
+  %0 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
+  emitc.call_opaque "func_out" (%0) : (!emitc.lvalue<i32>) -> ()
+  return
+}
+// CPP-DEFAULT: void emitc_call_opaque_lvalue_arg() {
+// CPP-DEFAULT-NEXT: int32_t [[V0:[^ ]*]];
+// CPP-DEFAULT-NEXT: func_out([[V0]]);
+
 func.func @emitc_member_call(%arg0 : !emitc.opaque<"MyClass">, %arg1 : !emitc.ptr<!emitc.opaque<"MyClass">> ) {
   %0 = emitc.member_call_opaque %arg0 "method" () : !emitc.opaque<"MyClass">, () -> i32
   %1 = emitc.member_call_opaque %arg1 "ptr_method" () : !emitc.ptr<!emitc.opaque<"MyClass">>, () -> i32
@@ -64,3 +73,12 @@ func.func @emitc_member_call_template_args(%arg0 : !emitc.opaque<"MyClass">) {
 }
 // CPP-DEFAULT: void emitc_member_call_template_args(MyClass [[V0:[^ ]*]]) {
 // CPP-DEFAULT-NEXT: int32_t [[V1:[^ ]*]] = [[V0]].method<int32_t>();
+
+func.func @emitc_member_call_lvalue_arg(%arg0 : !emitc.opaque<"MyClass">) {
+  %0 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
+  emitc.member_call_opaque %arg0 "method" (%0) : !emitc.opaque<"MyClass">, (!emitc.lvalue<i32>) -> ()
+  return
+}
+// CPP-DEFAULT: void emitc_member_call_lvalue_arg(MyClass [[V0:[^ ]*]]) {
+// CPP-DEFAULT-NEXT: int32_t [[V1:[^ ]*]];
+// CPP-DEFAULT-NEXT: [[V0]].method([[V1]]);


### PR DESCRIPTION
 Widen the `arg_operands` of `emitc.call_opaque` and
`emitc.member_call_opaque` from `Variadic<EmitCType>` to `Variadic<AnyTypeOf<[EmitCType, EmitC_LValueType]>>` to support taking arguments by reference (e.g., out-parameters in destination-passing style, or move-only types that cannot be copied into the call).

No translation/emitter codegen changes are needed, the generated C++ for `arg_operands` also works with reference parameters.