### PR TITLE
[llvm] Fix unused function warning in Parallel

### DIFF
--- a/llvm/lib/Support/Parallel.cpp
+++ b/llvm/lib/Support/Parallel.cpp
@@ -227,14 +227,6 @@ size_t parallel::getThreadCount() {
 }
 #endif
 
-static bool isNested() {
-#if LLVM_ENABLE_THREADS
-  return threadIndex != UINT_MAX;
-#else
-  return false;
-#endif
-}
-
 TaskGroup::TaskGroup()
     : Parallel(
 #if LLVM_ENABLE_THREADS
@@ -248,7 +240,8 @@ TaskGroup::TaskGroup()
 TaskGroup::~TaskGroup() {
 #if LLVM_ENABLE_THREADS
   // In a nested TaskGroup (threadIndex != -1u), actively help drain the queue.
-  if (Parallel && isNested())
+  bool IsNested = threadIndex != UINT_MAX;
+  if (Parallel && IsNested)
     getDefaultExecutor()->helpSync(L);
 #endif
   L.sync();


### PR DESCRIPTION
When llvm is built without threading support:
<...>/llvm-project/llvm/lib/Support/Parallel.cpp:230:13: warning: unused function 'isNested' [-Wunused-function]
  230 | static bool isNested() {
      |             ^~~~~~~~

The function is only used once, so I've put the code into the caller, which is itself guarded with `#if LLVM_ENABLE_THREADS`.

Function added in 8daaa26efdda3802f73367d844b267bda3f84cbe / #189293.