### PR TITLE
[LifetimeSafety] Add additional test for buildOriginFlowChain

### DIFF
--- a/clang/test/Sema/LifetimeSafety/safety.cpp
+++ b/clang/test/Sema/LifetimeSafety/safety.cpp
@@ -1250,6 +1250,8 @@ void conditional_operator_lifetimebound_nested_deep(bool cond) {
   (void)*p;  // expected-note 4 {{later used here}}
 }
 
+// FIXME: Ignore ParenExpr and treat it as `p = b`.
+// So that we can see {{local variable 'p' aliases the storage of local variable 'b'}}
 void simpleparen() {
   MyObj* p;
   {

--- a/clang/test/Sema/LifetimeSafety/safety.cpp
+++ b/clang/test/Sema/LifetimeSafety/safety.cpp
@@ -1250,6 +1250,16 @@ void conditional_operator_lifetimebound_nested_deep(bool cond) {
   (void)*p;  // expected-note 4 {{later used here}}
 }
 
+void simpleparen() {
+  MyObj* p;
+  {
+    MyObj a;
+    MyObj* b = &a;  // expected-warning {{local variable 'a' does not live long enough}}
+    p = (((b)));
+  }                 // expected-note {{destroyed here}}
+  (void)*p;         // expected-note {{later used here}}
+}
+
 void parentheses(bool cond) {
   MyObj* p;
   {

--- a/clang/test/Sema/LifetimeSafety/safety.cpp
+++ b/clang/test/Sema/LifetimeSafety/safety.cpp
@@ -1250,8 +1250,8 @@ void conditional_operator_lifetimebound_nested_deep(bool cond) {
   (void)*p;  // expected-note 4 {{later used here}}
 }
 
-// FIXME: Ignore ParenExpr and treat it as `p = b`.
-// So that we can see {{local variable 'p' aliases the storage of local variable 'b'}}
+// FIXME: Diagnostic output does not handle ParenExpr correctly, causing alias
+// information to be missed (local variable 'p' aliases the storage of local variable 'b').
 void simpleparen() {
   MyObj* p;
   {

--- a/clang/unittests/Analysis/LifetimeSafetyTest.cpp
+++ b/clang/unittests/Analysis/LifetimeSafetyTest.cpp
@@ -213,7 +213,7 @@ public:
     std::vector<LoanID> EndLoanIDs = getLoansForVar(EndLoanVar);
 
     for (LoanID LID : EndLoanIDs) {
-      const llvm::SmallVector<OriginID> OriginFlowChain =
+      llvm::SmallVector<OriginID> OriginFlowChain =
           Runner.getAnalysis().getLoanPropagation().buildOriginFlowChain(
               getProgramPoint(Annotation), *StartOriginID, LID);
       if (!OriginFlowChain.empty())
@@ -2025,6 +2025,8 @@ TEST_F(LifetimeAnalysisTest, BuildOriginFlowChainWithMultiAssignInSameStmt) {
       Helper->buildOriginFlowChainInOneBlock("s", "tgt", "after_use");
 
   EXPECT_THAT(OriginFlowChain, Contains(*Helper->getOriginForDecl("a")));
+  EXPECT_THAT(OriginFlowChain, Contains(*Helper->getOriginForDecl("b")));
+  EXPECT_THAT(OriginFlowChain, Contains(*Helper->getOriginForDecl("c")));
 }
 
 TEST_F(LifetimeAnalysisTest, BuildOriginFlowChainWithOverwritingAssignments) {
@@ -2044,6 +2046,8 @@ TEST_F(LifetimeAnalysisTest, BuildOriginFlowChainWithOverwritingAssignments) {
       Helper->buildOriginFlowChainInOneBlock("s", "tgt1", "after_use");
 
   EXPECT_THAT(OriginFlowChain, Contains(*Helper->getOriginForDecl("a")));
+  EXPECT_THAT(OriginFlowChain, Contains(*Helper->getOriginForDecl("b")));
+  EXPECT_THAT(OriginFlowChain, Contains(*Helper->getOriginForDecl("c")));
 }
 
 TEST_F(LifetimeAnalysisTest, BuildOriginFlowChainWithLifetimeBound) {


### PR DESCRIPTION
These are test case improvements suggested in previous PRs.

The `simpleparen` case originates from https://github.com/llvm/llvm-project/pull/199345#discussion_r3343186258.

Additional unit test improvements were suggested in https://github.com/llvm/llvm-project/pull/196075#discussion_r3274899024.