### PR TITLE
[lldb][test] Fix various bogus assertTrue calls in tests

### DIFF
--- a/lldb/test/API/commands/process/attach/TestProcessAttach.py
+++ b/lldb/test/API/commands/process/attach/TestProcessAttach.py
@@ -54,7 +54,7 @@ class ProcessAttachTestCase(TestBase):
 
         process = target.GetProcess()
         self.assertTrue(process, PROCESS_IS_VALID)
-        self.assertTrue(process.GetState(), lldb.eStateRunning)
+        self.assertEqual(process.GetState(), lldb.eStateRunning)
 
     @skipIfWindows  # This is flakey on Windows AND when it fails, it hangs: llvm.org/pr48806
     def test_attach_to_process_from_different_dir_by_id(self):

--- a/lldb/test/API/functionalities/postmortem/minidump-new/TestMiniDumpNew.py
+++ b/lldb/test/API/functionalities/postmortem/minidump-new/TestMiniDumpNew.py
@@ -503,13 +503,13 @@ class MiniDumpNewTestCase(TestBase):
         region = lldb.SBMemoryRegionInfo()
         self.assertTrue(region_info_list.GetMemoryRegionAtIndex(0, region))
         self.assertEqual(region.GetRegionBase(), 0x7FFF12A84030)
-        self.assertTrue(region.GetRegionEnd(), 0x7FFF12A84030 + 0x2FD0)
+        self.assertEqual(region.GetRegionEnd(), 0x7FFF12A84030 + 0x2FD0)
         self.assertTrue(region_info_list.GetMemoryRegionAtIndex(1, region))
         self.assertEqual(region.GetRegionBase(), 0x00007FFF12A87000)
-        self.assertTrue(region.GetRegionEnd(), 0x00007FFF12A87000 + 0x00000018)
+        self.assertEqual(region.GetRegionEnd(), 0x00007FFF12A87000 + 0x00000018)
         self.assertTrue(region_info_list.GetMemoryRegionAtIndex(2, region))
         self.assertEqual(region.GetRegionBase(), 0x00007FFF12A87018)
-        self.assertTrue(region.GetRegionEnd(), 0x00007FFF12A87018 + 0x00000400)
+        self.assertEqual(region.GetRegionEnd(), 0x00007FFF12A87018 + 0x00000400)
 
     def test_multiple_exceptions_or_signals(self):
         """Test that lldb can read the exception information from the Minidump."""

--- a/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump.py
+++ b/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump.py
@@ -29,7 +29,7 @@ class ProcessSaveCoreMinidumpTestCase(TestBase):
         self.assertTrue(process.GetProcessInfo().IsValid())
         self.assertEqual(process.GetProcessInfo().GetProcessID(), expected_pid)
         self.assertNotEqual(target.GetTriple().find("linux"), -1)
-        self.assertTrue(target.GetNumModules(), len(expected_modules))
+        self.assertEqual(target.GetNumModules(), len(expected_modules))
         self.assertEqual(process.GetNumThreads(), len(expected_threads))
 
         for module, expected in zip(target.modules, expected_modules):

--- a/lldb/test/API/functionalities/scripted_process/TestStackCoreScriptedProcess.py
+++ b/lldb/test/API/functionalities/scripted_process/TestStackCoreScriptedProcess.py
@@ -127,13 +127,13 @@ class StackCoreScriptedProcesTestCase(TestBase):
         # that triggers the breakpoint in the LC_NOTES of the corefile, so they
         # can be reloaded with the corefile on the next debug session.
         if arch in "arm64e":
-            self.assertTrue(thread.GetStopReason(), lldb.eStopReasonException)
+            self.assertEqual(thread.GetStopReason(), lldb.eStopReasonException)
         # However, it's architecture specific, and corefiles made from intel
         # process don't save any metadata to retrieve to stop reason.
         # To mitigate this, the StackCoreScriptedProcess will report a
         # eStopReasonSignal with a SIGTRAP, mimicking what debugserver does.
         else:
-            self.assertTrue(thread.GetStopReason(), lldb.eStopReasonSignal)
+            self.assertEqual(thread.GetStopReason(), lldb.eStopReasonSignal)
 
         self.assertEqual(thread.GetNumFrames(), 5)
         frame = thread.GetSelectedFrame()

--- a/lldb/test/API/lang/cpp/inline-namespace-in-typename/TestInlineNamespaceInTypename.py
+++ b/lldb/test/API/lang/cpp/inline-namespace-in-typename/TestInlineNamespaceInTypename.py
@@ -14,17 +14,17 @@ class TestInlineNamespaceInTypename(TestBase):
         target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
 
         t1 = target.FindGlobalVariables("t1", 1)
-        self.assertTrue(len(t1), 1)
+        self.assertEqual(len(t1), 1)
         self.assertEqual(t1[0].GetDisplayTypeName(), "foo::Duplicate")
 
         # 'foo::Duplicate' would be an ambiguous reference, but we still
         # omit the inline namespace when displaying the type.
         t2 = target.FindGlobalVariables("t2", 1)
-        self.assertTrue(len(t2), 1)
+        self.assertEqual(len(t2), 1)
         self.assertEqual(t2[0].GetDisplayTypeName(), "foo::Duplicate")
         self.assertEqual(t2[0].GetTypeName(), "foo::bar::Duplicate")
 
         t3 = target.FindGlobalVariables("t3", 1)
-        self.assertTrue(len(t3), 1)
+        self.assertEqual(len(t3), 1)
         self.assertEqual(t3[0].GetDisplayTypeName(), "foo::Unique")
         self.assertEqual(t3[0].GetTypeName(), "foo::bar::Unique")

--- a/lldb/test/API/macosx/lc-note/addrable-bits/TestAddrableBitsCorefile.py
+++ b/lldb/test/API/macosx/lc-note/addrable-bits/TestAddrableBitsCorefile.py
@@ -40,13 +40,13 @@ class TestAddrableBitsCorefile(TestBase):
         cmdinterp = self.dbg.GetCommandInterpreter()
         res = lldb.SBCommandReturnObject()
         cmdinterp.HandleCommand("process save-core %s" % self.corefile, res)
-        self.assertTrue(res.Succeeded(), True)
+        self.assertTrue(res.Succeeded())
         process.Kill()
         self.dbg.DeleteTarget(target)
 
         target = self.dbg.CreateTarget("")
         process = target.LoadCore(self.corefile)
-        self.assertTrue(process.IsValid(), True)
+        self.assertTrue(process.IsValid())
         thread = process.GetSelectedThread()
 
         found_main = False

--- a/lldb/test/API/python_api/symbol-context/two-files/TestSymbolContextTwoFiles.py
+++ b/lldb/test/API/python_api/symbol-context/two-files/TestSymbolContextTwoFiles.py
@@ -22,7 +22,7 @@ class SymbolContextTwoFilesTestCase(TestBase):
         self.assertTrue(module.IsValid())
         for symbol_name in ["struct1::f()", "struct2::f()"]:
             sc_list = module.FindFunctions(symbol_name, lldb.eSymbolTypeCode)
-            self.assertTrue(1, sc_list.GetSize())
+            self.assertEqual(1, sc_list.GetSize())
             symbol_address = sc_list.GetContextAtIndex(0).GetSymbol().GetStartAddress()
             self.assertTrue(symbol_address.IsValid())
             sc_by_address = module.ResolveSymbolContextForAddress(

--- a/lldb/test/API/tools/lldb-dap/save-core/TestDAP_save_core.py
+++ b/lldb/test/API/tools/lldb-dap/save-core/TestDAP_save_core.py
@@ -69,5 +69,5 @@ class TestDAP_save_core(lldbdap_testcase.DAPTestCaseBase):
         self.assertTrue(process, PROCESS_IS_VALID)
         self.assertTrue(process.GetProcessInfo().IsValid())
         self.assertNotEqual(target.GetTriple().find("linux"), -1)
-        self.assertTrue(target.GetNumModules(), expected_module_count)
+        self.assertEqual(target.GetNumModules(), expected_module_count)
         self.assertEqual(process.GetNumThreads(), expected_thread_count)


### PR DESCRIPTION
Jim pointed out in #201530 a assertTrue call that always passes as it's written like an assertEquals. I did a search over the code base to find all similar instances and replaced them with the proper check.

assisted-by: claude