### PR TITLE
[lldb][gdb-remote] Send argv[0] in remote target's separator style on launch

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -871,8 +871,19 @@ Status ProcessGDBRemote::DoLaunch(lldb_private::Module *exe_module,
       // Since we can't send argv0 separate from the executable path, we need to
       // make sure to use the actual executable path found in the launch_info...
       Args args = launch_info.GetArguments();
-      if (FileSpec exe_file = launch_info.GetExecutableFile())
-        args.ReplaceArgumentAtIndex(0, exe_file.GetPath(/*denormalize=*/true));
+      if (FileSpec exe_file = launch_info.GetExecutableFile()) {
+        const llvm::Triple &remote_triple =
+            GetTarget().GetArchitecture().GetTriple();
+        if (remote_triple.getOS() != llvm::Triple::UnknownOS) {
+          FileSpec remote_exe_file(exe_file.GetPath(/*denormalize=*/false),
+                                   remote_triple);
+          args.ReplaceArgumentAtIndex(
+              0, remote_exe_file.GetPath(/*denormalize=*/true));
+        } else {
+          args.ReplaceArgumentAtIndex(0,
+                                      exe_file.GetPath(/*denormalize=*/true));
+        }
+      }
       if (llvm::Error err = m_gdb_comm.LaunchProcess(args)) {
         error = Status::FromErrorStringWithFormatv(
             "Cannot launch '{0}': {1}", args.GetArgumentAtIndex(0),


### PR DESCRIPTION
When lldb launches an inferior on a remote stub via the A or vRun packet, `ProcessGDBRemote::DoLaunch` currently sends the executable path through `FileSpec::GetPath(denormalize=true)`. That uses the FileSpec's `m_style`, which is the lldb client host's native style by default, not the remote target's. So a Windows lldb client launching on a POSIX remote sent the path with backslashes, so the remote tried to launch a file that didn't exist.

The fix re-normalizes the `FileSpec` with the target's triple before denormalizing, so path uses the remote's native separators. This is only done when the target's OS is actually known. When it isn't, we keep the historical host-native behavior, since tests and callers that only set arch (e.g. QLaunchArch:x86_64 with no qHostInfo OS) have always relied on the old default.

This fixes `TestNoLocalFile` on Windows with `LLDB_USE_LLDB_SERVER=1`.

rdar://179932755