### PR TITLE
[lld][MachO] Require LLVM_ENABLE_THREADS for new read workers tests

### DIFF
--- a/lld/test/MachO/read-workers-order-obj.s
+++ b/lld/test/MachO/read-workers-order-obj.s
@@ -1,4 +1,4 @@
-# REQUIRES: aarch64
+# REQUIRES: aarch64 && thread_support
 # RUN: rm -rf %t; split-file %s %t
 # RUN: llvm-mc -filetype=obj -triple=arm64-apple-macos11.0 %t/obj-rival.s -o %t/obj-rival.o
 # RUN: llvm-mc -filetype=obj -triple=arm64-apple-macos11.0 %t/dylib.s -o %t/dylib.o

--- a/lld/test/MachO/read-workers-order.s
+++ b/lld/test/MachO/read-workers-order.s
@@ -1,4 +1,4 @@
-# REQUIRES: aarch64
+# REQUIRES: aarch64 && thread_support
 # RUN: rm -rf %t; split-file %s %t
 # RUN: llvm-mc -filetype=obj -triple=arm64-apple-macos11.0 %t/archive.s -o %t/archive.o
 # RUN: llvm-mc -filetype=obj -triple=arm64-apple-macos11.0 %t/dylib.s -o %t/dylib.o


### PR DESCRIPTION
Added by b11e4fb50c0ff5dc87ab6113f4850af991750d66/#193239.

The option is not available when LLVM_ENABLE_THREADS is off.