### PR TITLE
[LLVM][Intrinsics] Add scalar-only and vector-only overload types

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -547,15 +547,32 @@ class LLVMVectorOfAnyPointersToElt<int oidx>
 
 def llvm_void_ty       : LLVMType<isVoid>;
 
+// Unconstrained overloaded type.
 def llvm_any_ty        : LLVMAnyType<Any,
                                      AnyKindVectorConstraint.None,
                                      AnyKindElementConstraint.None>;
+// Integer overloaded types.
 def llvm_anyint_ty     : LLVMAnyType<iAny,
                                      AnyKindVectorConstraint.None,
                                      AnyKindElementConstraint.Integer>;
+def llvm_any_vector_int_ty : LLVMAnyType<iAny,
+                                     AnyKindVectorConstraint.Vector,
+                                     AnyKindElementConstraint.Integer>;
+def llvm_any_scalar_int_ty : LLVMAnyType<iAny,
+                                     AnyKindVectorConstraint.Scalar,
+                                     AnyKindElementConstraint.Integer>;
+
+// FP overloaded types.
 def llvm_anyfloat_ty   : LLVMAnyType<fAny,
                                      AnyKindVectorConstraint.None,
                                      AnyKindElementConstraint.Float>;
+def llvm_any_vector_float_ty : LLVMAnyType<iAny,
+                                     AnyKindVectorConstraint.Vector,
+                                     AnyKindElementConstraint.Float>;
+def llvm_any_scalar_float_ty : LLVMAnyType<iAny,
+                                     AnyKindVectorConstraint.Scalar,
+                                     AnyKindElementConstraint.Float>;
+// Other overloaded types.
 def llvm_anyvector_ty  : LLVMAnyType<vAny,
                                      AnyKindVectorConstraint.Vector,
                                      AnyKindElementConstraint.None>;
@@ -1471,12 +1488,12 @@ let IntrProperties = [IntrInaccessibleMemOnly, IntrStrictFP] in {
                                                          [ LLVMMatchType<0>,
                                                            llvm_metadata_ty,
                                                            llvm_metadata_ty ]>;
-  def int_experimental_constrained_lrint : DefaultAttrsIntrinsic<[ llvm_anyint_ty ],
-                                                     [ llvm_anyfloat_ty,
+  def int_experimental_constrained_lrint : DefaultAttrsIntrinsic<[ llvm_any_scalar_int_ty ],
+                                                     [ llvm_any_scalar_float_ty,
                                                        llvm_metadata_ty,
                                                        llvm_metadata_ty ]>;
-  def int_experimental_constrained_llrint : DefaultAttrsIntrinsic<[ llvm_anyint_ty ],
-                                                      [ llvm_anyfloat_ty,
+  def int_experimental_constrained_llrint : DefaultAttrsIntrinsic<[ llvm_any_scalar_int_ty ],
+                                                      [ llvm_any_scalar_float_ty,
                                                         llvm_metadata_ty,
                                                         llvm_metadata_ty ]>;
   def int_experimental_constrained_maxnum : DefaultAttrsIntrinsic<[ llvm_anyfloat_ty ],
@@ -1501,11 +1518,11 @@ let IntrProperties = [IntrInaccessibleMemOnly, IntrStrictFP] in {
   def int_experimental_constrained_floor : DefaultAttrsIntrinsic<[ llvm_anyfloat_ty ],
                                                      [ LLVMMatchType<0>,
                                                        llvm_metadata_ty ]>;
-  def int_experimental_constrained_lround : DefaultAttrsIntrinsic<[ llvm_anyint_ty ],
-                                                      [ llvm_anyfloat_ty,
+  def int_experimental_constrained_lround : DefaultAttrsIntrinsic<[ llvm_any_scalar_int_ty ],
+                                                      [ llvm_any_scalar_float_ty,
                                                         llvm_metadata_ty ]>;
-  def int_experimental_constrained_llround : DefaultAttrsIntrinsic<[ llvm_anyint_ty ],
-                                                       [ llvm_anyfloat_ty,
+  def int_experimental_constrained_llround : DefaultAttrsIntrinsic<[ llvm_any_scalar_int_ty ],
+                                                       [ llvm_any_scalar_float_ty,
                                                          llvm_metadata_ty ]>;
   def int_experimental_constrained_round : DefaultAttrsIntrinsic<[ llvm_anyfloat_ty ],
                                                      [ LLVMMatchType<0>,
@@ -2701,28 +2718,28 @@ def int_experimental_vector_compress:
               [IntrNoMem]>;
 
 def int_masked_udiv:
-  DefaultAttrsIntrinsic<[llvm_anyvector_ty],
+  DefaultAttrsIntrinsic<[llvm_any_vector_int_ty],
             [LLVMMatchType<0>,
              LLVMMatchType<0>,
              LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>],
             [IntrNoMem]>;
 
 def int_masked_sdiv:
-  DefaultAttrsIntrinsic<[llvm_anyvector_ty],
+  DefaultAttrsIntrinsic<[llvm_any_vector_int_ty],
             [LLVMMatchType<0>,
              LLVMMatchType<0>,
              LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>],
             [IntrNoMem]>;
 
 def int_masked_urem:
-  DefaultAttrsIntrinsic<[llvm_anyvector_ty],
+  DefaultAttrsIntrinsic<[llvm_any_vector_int_ty],
             [LLVMMatchType<0>,
              LLVMMatchType<0>,
              LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>],
             [IntrNoMem]>;
 
 def int_masked_srem:
-  DefaultAttrsIntrinsic<[llvm_anyvector_ty],
+  DefaultAttrsIntrinsic<[llvm_any_vector_int_ty],
             [LLVMMatchType<0>,
              LLVMMatchType<0>,
              LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>],
@@ -2847,38 +2864,38 @@ let IntrProperties = [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison]
 
   def int_vector_reduce_fadd : DefaultAttrsIntrinsic<[LLVMVectorElementType<0>],
                                          [LLVMVectorElementType<0>,
-                                          llvm_anyvector_ty]>;
+                                          llvm_any_vector_float_ty]>;
   def int_vector_reduce_fmul : DefaultAttrsIntrinsic<[LLVMVectorElementType<0>],
                                          [LLVMVectorElementType<0>,
-                                          llvm_anyvector_ty]>;
+                                          llvm_any_vector_float_ty]>;
   def int_vector_reduce_add : DefaultAttrsIntrinsic<[LLVMVectorElementType<0>],
-                                        [llvm_anyvector_ty]>;
+                                        [llvm_any_vector_int_ty]>;
   def int_vector_reduce_mul : DefaultAttrsIntrinsic<[LLVMVectorElementType<0>],
-                                        [llvm_anyvector_ty]>;
+                                        [llvm_any_vector_int_ty]>;
   def int_vector_reduce_and : DefaultAttrsIntrinsic<[LLVMVectorElementType<0>],
-                                        [llvm_anyvector_ty]>;
+                                        [llvm_any_vector_int_ty]>;
   def int_vector_reduce_or : DefaultAttrsIntrinsic<[LLVMVectorElementType<0>],
-                                       [llvm_anyvector_ty]>;
+                                       [llvm_any_vector_int_ty]>;
   def int_vector_reduce_xor : DefaultAttrsIntrinsic<[LLVMVectorElementType<0>],
-                                        [llvm_anyvector_ty]>;
+                                        [llvm_any_vector_int_ty]>;
   def int_vector_reduce_smax : DefaultAttrsIntrinsic<[LLVMVectorElementType<0>],
-                                         [llvm_anyvector_ty]>;
+                                         [llvm_any_vector_int_ty]>;
   def int_vector_reduce_smin : DefaultAttrsIntrinsic<[LLVMVectorElementType<0>],
-                                         [llvm_anyvector_ty]>;
+                                         [llvm_any_vector_int_ty]>;
   def int_vector_reduce_umax : DefaultAttrsIntrinsic<[LLVMVectorElementType<0>],
-                                         [llvm_anyvector_ty]>;
+                                         [llvm_any_vector_int_ty]>;
   def int_vector_reduce_umin : DefaultAttrsIntrinsic<[LLVMVectorElementType<0>],
-                                         [llvm_anyvector_ty]>;
+                                         [llvm_any_vector_int_ty]>;
   def int_vector_reduce_fmax : DefaultAttrsIntrinsic<[LLVMVectorElementType<0>],
-                                         [llvm_anyvector_ty]>;
+                                         [llvm_any_vector_float_ty]>;
   def int_vector_reduce_fmin : DefaultAttrsIntrinsic<[LLVMVectorElementType<0>],
-                                         [llvm_anyvector_ty]>;
+                                         [llvm_any_vector_float_ty]>;
   def int_vector_reduce_fminimum: DefaultAttrsIntrinsic<
                                          [LLVMVectorElementType<0>],
-                                         [llvm_anyvector_ty]>;
+                                         [llvm_any_vector_float_ty]>;
   def int_vector_reduce_fmaximum: DefaultAttrsIntrinsic<
                                          [LLVMVectorElementType<0>],
-                                         [llvm_anyvector_ty]>;
+                                         [llvm_any_vector_float_ty]>;
 }
 
 //===------ Matrix intrinsics ---------------------------------------------===//

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -6832,40 +6832,6 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
           Call);
     break;
   }
-  case Intrinsic::masked_udiv:
-  case Intrinsic::masked_sdiv:
-  case Intrinsic::masked_urem:
-  case Intrinsic::masked_srem:
-  case Intrinsic::vector_reduce_and:
-  case Intrinsic::vector_reduce_or:
-  case Intrinsic::vector_reduce_xor:
-  case Intrinsic::vector_reduce_add:
-  case Intrinsic::vector_reduce_mul:
-  case Intrinsic::vector_reduce_smax:
-  case Intrinsic::vector_reduce_smin:
-  case Intrinsic::vector_reduce_umax:
-  case Intrinsic::vector_reduce_umin: {
-    Type *ArgTy = Call.getArgOperand(0)->getType();
-    Check(ArgTy->isIntOrIntVectorTy() && ArgTy->isVectorTy(),
-          "intrinsic has incorrect argument type!");
-    break;
-  }
-  case Intrinsic::vector_reduce_fmax:
-  case Intrinsic::vector_reduce_fmin: {
-    Type *ArgTy = Call.getArgOperand(0)->getType();
-    Check(ArgTy->isFPOrFPVectorTy() && ArgTy->isVectorTy(),
-          "intrinsic has incorrect argument type!");
-    break;
-  }
-  case Intrinsic::vector_reduce_fadd:
-  case Intrinsic::vector_reduce_fmul: {
-    // Unlike the other reductions, the first argument is a start value. The
-    // second argument is the vector to be reduced.
-    Type *ArgTy = Call.getArgOperand(1)->getType();
-    Check(ArgTy->isFPOrFPVectorTy() && ArgTy->isVectorTy(),
-          "intrinsic has incorrect argument type!");
-    break;
-  }
   case Intrinsic::smul_fix:
   case Intrinsic::smul_fix_sat:
   case Intrinsic::umul_fix:
@@ -7873,24 +7839,6 @@ void Verifier::visitConstrainedFPIntrinsic(ConstrainedFPIntrinsic &FPI) {
         "invalid arguments for constrained FP intrinsic", &FPI);
 
   switch (FPI.getIntrinsicID()) {
-  case Intrinsic::experimental_constrained_lrint:
-  case Intrinsic::experimental_constrained_llrint: {
-    Type *ValTy = FPI.getArgOperand(0)->getType();
-    Type *ResultTy = FPI.getType();
-    Check(!ValTy->isVectorTy() && !ResultTy->isVectorTy(),
-          "Intrinsic does not support vectors", &FPI);
-    break;
-  }
-
-  case Intrinsic::experimental_constrained_lround:
-  case Intrinsic::experimental_constrained_llround: {
-    Type *ValTy = FPI.getArgOperand(0)->getType();
-    Type *ResultTy = FPI.getType();
-    Check(!ValTy->isVectorTy() && !ResultTy->isVectorTy(),
-          "Intrinsic does not support vectors", &FPI);
-    break;
-  }
-
   case Intrinsic::experimental_constrained_fcmp:
   case Intrinsic::experimental_constrained_fcmps: {
     auto Pred = cast<ConstrainedFPCmpIntrinsic>(&FPI)->getPredicate();

--- a/llvm/test/Verifier/masked-divrem.ll
+++ b/llvm/test/Verifier/masked-divrem.ll
@@ -2,26 +2,31 @@
 
 ; Reject llvm.masked.{u,s}{div,rem} with a non-integer argument.
 
+declare <4 x float> @llvm.masked.udiv.v4f32(<4 x float>, <4 x float>, <4 x i1>)
+declare <4 x float> @llvm.masked.sdiv.v4f32(<4 x float>, <4 x float>, <4 x i1>)
+declare <4 x float> @llvm.masked.urem.v4f32(<4 x float>, <4 x float>, <4 x i1>)
+declare <4 x float> @llvm.masked.srem.v4f32(<4 x float>, <4 x float>, <4 x i1>)
+
 define <4 x float> @udiv(<4 x float> %x, <4 x float> %y, <4 x i1> %m) {
-; CHECK: intrinsic has incorrect argument type!
-  %res = call <4 x float> @llvm.masked.udiv(<4 x float> %x, <4 x float> %y, <4 x i1> %m)
+; CHECK: intrinsic return type (overload type 0) expected any integer vector, but got <4 x float>
+  %res = call <4 x float> @llvm.masked.udiv.v4f32(<4 x float> %x, <4 x float> %y, <4 x i1> %m)
   ret <4 x float> %res
 }
 
 define <4 x float> @sdiv(<4 x float> %x, <4 x float> %y, <4 x i1> %m) {
-; CHECK: intrinsic has incorrect argument type!
-  %res = call <4 x float> @llvm.masked.sdiv(<4 x float> %x, <4 x float> %y, <4 x i1> %m)
+; CHECK: intrinsic return type (overload type 0) expected any integer vector, but got <4 x float>
+  %res = call <4 x float> @llvm.masked.sdiv.v4f32(<4 x float> %x, <4 x float> %y, <4 x i1> %m)
   ret <4 x float> %res
 }
 
 define <4 x float> @urem(<4 x float> %x, <4 x float> %y, <4 x i1> %m) {
-; CHECK: intrinsic has incorrect argument type!
-  %res = call <4 x float> @llvm.masked.urem(<4 x float> %x, <4 x float> %y, <4 x i1> %m)
+; CHECK: intrinsic return type (overload type 0) expected any integer vector, but got <4 x float>
+  %res = call <4 x float> @llvm.masked.urem.v4f32(<4 x float> %x, <4 x float> %y, <4 x i1> %m)
   ret <4 x float> %res
 }
 
 define <4 x float> @srem(<4 x float> %x, <4 x float> %y, <4 x i1> %m) {
-; CHECK: intrinsic has incorrect argument type!
-  %res = call <4 x float> @llvm.masked.srem(<4 x float> %x, <4 x float> %y, <4 x i1> %m)
+; CHECK: intrinsic return type (overload type 0) expected any integer vector, but got <4 x float>
+  %res = call <4 x float> @llvm.masked.srem.v4f32(<4 x float> %x, <4 x float> %y, <4 x i1> %m)
   ret <4 x float> %res
 }

--- a/llvm/test/Verifier/reduction-intrinsics.ll
+++ b/llvm/test/Verifier/reduction-intrinsics.ll
@@ -3,13 +3,13 @@
 ; Reject a vector reduction with a non-vector argument.
 
 define float @reduce_vector_not_vec_arg(float %x) {
-; CHECK: intrinsic argument 0 type (overload type 0) expected any vector type, but got float
+; CHECK: intrinsic argument 0 type (overload type 0) expected any fp vector, but got float
   %r0 = call float @llvm.vector.reduce.fmax.f32(float %x)
   ret float %r0
 }
 
 define i32 @reduce_vector_not_vec_arg2(i32 %x) {
-; CHECK: intrinsic argument 0 type (overload type 0) expected any vector type, but got i32
+; CHECK: intrinsic argument 0 type (overload type 0) expected any integer vector, but got i32
   %r0 = call i32 @llvm.vector.reduce.smax.i32(i32 %x)
   ret i32 %r0
 }
@@ -34,25 +34,25 @@ define i64 @result_too_wide(<4 x i32> %x) {
 ; for any vector reduction.
 
 define float @not_float_reduce(<4 x float> %x) {
-; CHECK: intrinsic has incorrect argument type!
+; CHECK: intrinsic argument 0 type (overload type 0) expected any integer vector, but got <4 x float>
   %r = call float @llvm.vector.reduce.umin.v4f32(<4 x float> %x)
   ret float %r
 }
 
 define ptr @not_pointer_reduce(<4 x ptr> %x) {
-; CHECK: intrinsic has incorrect argument type!
+; CHECK: intrinsic argument 0 type (overload type 0) expected any integer vector, but got <4 x ptr>
   %r = call ptr @llvm.vector.reduce.or.v4p0(<4 x ptr> %x)
   ret ptr %r
 }
 
 define i32 @not_integer_reduce(<4 x i32> %x) {
-; CHECK: intrinsic has incorrect argument type!
+; CHECK: intrinsic argument 1 type (overload type 0) expected any fp vector, but got <4 x i32>
   %r = call i32 @llvm.vector.reduce.fadd.v4i32(i32 0, <4 x i32> %x)
   ret i32 %r
 }
 
 define ptr @not_pointer_reduce2(<4 x ptr> %x) {
-; CHECK: intrinsic has incorrect argument type!
+; CHECK: intrinsic argument 0 type (overload type 0) expected any fp vector, but got <4 x ptr>
   %r = call ptr @llvm.vector.reduce.fmin.v4p0(<4 x ptr> %x)
   ret ptr %r
 }

--- a/llvm/unittests/Analysis/ValueTrackingTest.cpp
+++ b/llvm/unittests/Analysis/ValueTrackingTest.cpp
@@ -1274,7 +1274,7 @@ TEST_F(ValueTrackingTest, isGuaranteedNotToBeUndefOrPoison_assume) {
   EXPECT_TRUE(isGuaranteedNotToBeUndefOrPoison(A, &AC, CxtI3, &DT));
 }
 
-TEST(ValueTracking, canCreatePoisonOrUndef) {
+TEST_F(ValueTrackingTest, canCreatePoisonOrUndef) {
   std::string AsmHead =
       "@s = external dso_local global i32, align 1\n"
       "declare i32 @g(i32)\n"
@@ -1285,7 +1285,8 @@ TEST(ValueTracking, canCreatePoisonOrUndef) {
       "declare {i32, i1} @llvm.usub.with.overflow.i32(i32 %a, i32 %b)\n"
       "declare {i32, i1} @llvm.umul.with.overflow.i32(i32 %a, i32 %b)\n"
       "define void @f(i32 %x, i32 %y, float %fx, float %fy, i1 %cond, "
-      "<4 x i32> %vx, <4 x i32> %vx2, <vscale x 4 x i32> %svx, ptr %p) {\n";
+      "<4 x i32> %vx, <4 x i32> %vx2, <vscale x 4 x i32> %svx, ptr %p,"
+      "<4 x float> %vf) {\n";
   std::string AsmTail = "  ret void\n}";
   // (can create poison?, can create undef?, IR instruction)
   SmallVector<std::pair<std::pair<bool, bool>, std::string>, 32> Data = {
@@ -1369,26 +1370,24 @@ TEST(ValueTracking, canCreatePoisonOrUndef) {
       {{false, false},
        "call i32 @llvm.vector.reduce.umin.v4i32(<4 x i32> %vx)"},
       {{false, false},
-       "call i32 @llvm.vector.reduce.fmax.v4i32(<4 x i32> %vx)"},
+       "call float @llvm.vector.reduce.fmax.v4f32(<4 x float> %vf)"},
       {{false, false},
-       "call i32 @llvm.vector.reduce.fmin.v4i32(<4 x i32> %vx)"},
+       "call float @llvm.vector.reduce.fmin.v4f32(<4 x float> %vf)"},
       {{false, false},
-       "call i32 @llvm.vector.reduce.fmaximum.v4i32(<4 x i32> %vx)"},
+       "call float @llvm.vector.reduce.fmaximum.v4f32(<4 x float> %vf)"},
       {{false, false},
-       "call i32 @llvm.vector.reduce.fmaximum.v4i32(<4 x i32> %vx)"}};
+       "call float @llvm.vector.reduce.fmaximum.v4f32(<4 x float> %vf)"}};
 
   std::string AssemblyStr = AsmHead;
   for (auto &Itm : Data)
     AssemblyStr += Itm.second + "\n";
   AssemblyStr += AsmTail;
 
-  LLVMContext Context;
-  SMDiagnostic Error;
-  auto M = parseAssemblyString(AssemblyStr, Error, Context);
-  assert(M && "Bad assembly?");
+  auto M = parseModule(AssemblyStr);
+  ASSERT_TRUE(M) << "Bad assembly?";
 
-  auto *F = M->getFunction("f");
-  assert(F && "Bad assembly?");
+  Function *F = M->getFunction("f");
+  ASSERT_TRUE(F) << "Bad assembly?";
 
   auto &BB = F->getEntryBlock();
 


### PR DESCRIPTION
Add integer/fp overload types that allow only scalar or only vector types, and adopt them in some existing intrinsics.

Fixed ValueTracking unit test to not exercise invalid vp reduce intrinsics as they now fail to parse (as opposed to fail to validate).

See https://discourse.llvm.org/t/rfc-minor-change-in-overloaded-types-for-intrinsics/90880
