### PR TITLE
[SCEVDivision] Add assertion to check operand types match (NFCI)

### DIFF
--- a/llvm/lib/Analysis/ScalarEvolutionDivision.cpp
+++ b/llvm/lib/Analysis/ScalarEvolutionDivision.cpp
@@ -56,6 +56,8 @@ void SCEVDivision::divide(ScalarEvolution &SE, const SCEV *Numerator,
                           const SCEV *Denominator, const SCEV **Quotient,
                           const SCEV **Remainder) {
   assert(Numerator && Denominator && "Uninitialized SCEV");
+  assert(Numerator->getType() == Denominator->getType() &&
+         "Numerator and Denominator must have the same type");
 
   SCEVDivision D(SE, Numerator, Denominator);
 


### PR DESCRIPTION
In ScalarEvolutionDivision.h, the `SCEVDivision::divide` operation is defined as follows:

```
/// Computes the Quotient and Remainder of the division of Numerator by
/// Denominator. We are not actually performing the division here. Instead, we
/// are trying to find SCEV expressions Quotient and Remainder that satisfy:
///
/// Numerator = Denominator * Quotient + Remainder
```

Therefore, I believe it makes sense to enforce that the types of `Numerator` and `Denominator` are the same.

This patch adds an assertion to verify that restriction.