### PR TITLE
[clang][bytecode][NFC] Fix Pointer::operator<< for non-block pointers

### DIFF
--- a/clang/lib/AST/ByteCode/Pointer.h
+++ b/clang/lib/AST/ByteCode/Pointer.h
@@ -1099,14 +1099,14 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const Pointer &P) {
       std::reverse(Indices.begin(), Indices.end());
       OS << Indices;
     }
-  } else if (P.isArrayRoot())
+  } else if (P.isBlockPointer() && P.isArrayRoot())
     OS << " arrayroot";
 
   if (P.isBlockPointer() && P.block() && P.block()->isDummy())
     OS << " dummy";
   if (!P.isLive())
     OS << " dead";
-  if (P.isBaseClass())
+  if (P.isBlockPointer() && P.isBaseClass())
     OS << " base-class";
   return OS;
 }


### PR DESCRIPTION
Some of those functions can only be called on block pointers.