### PR TITLE
[llvm-offload-wrapper] Add SYCL wrapping to the standalone tool

### DIFF
--- a/llvm/test/tools/llvm-offload-wrapper/offload-wrapper.ll
+++ b/llvm/test/tools/llvm-offload-wrapper/offload-wrapper.ll
@@ -107,3 +107,27 @@
 ; CUDA-NEXT:   call void @__cudaUnregisterFatBinary(ptr %0)
 ; CUDA-NEXT:   ret void
 ; CUDA-NEXT: }
+
+; RUN: llvm-offload-wrapper --triple=x86_64-unknown-linux-gnu -kind=sycl %s -o %t.bc
+; RUN: llvm-dis %t.bc -o - | FileCheck %s --check-prefix=SYCL
+
+;      SYCL: @.sycl_offloading.binary = internal unnamed_addr constant [[[SIZE:[0-9]+]] x i8] c"{{.*}}", section ".llvm.offloading"
+; SYCL-NEXT: @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 1, ptr @sycl.descriptor_reg, ptr null }]
+; SYCL-NEXT: @llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 1, ptr @sycl.descriptor_unreg, ptr null }]
+
+;      SYCL: define internal void @sycl.descriptor_reg() section ".text.startup" {
+; SYCL-NEXT: entry:
+; SYCL-NEXT:   call void @__sycl_register_lib(ptr @.sycl_offloading.binary, i64 [[SIZE]])
+; SYCL-NEXT:   ret void
+; SYCL-NEXT: }
+
+;      SYCL: define internal void @sycl.descriptor_unreg() section ".text.startup" {
+; SYCL-NEXT: entry:
+; SYCL-NEXT:   call void @__sycl_unregister_lib(ptr @.sycl_offloading.binary, i64 [[SIZE]])
+; SYCL-NEXT:   ret void
+; SYCL-NEXT: }
+
+; RUN: llvm-offload-wrapper --triple=x86_64-unknown-linux-gnu -kind=openmp --relocatable %s -o %t.bc
+; RUN: llvm-dis %t.bc -o - | FileCheck %s --check-prefix=OMP-RELOCATABLE
+
+; OMP-RELOCATABLE: @.omp_offloading.device_image = internal unnamed_addr constant [{{[0-9]+}} x i8] c"{{.*}}", section ".llvm.offloading.relocatable", align 8

--- a/llvm/tools/llvm-offload-wrapper/llvm-offload-wrapper.cpp
+++ b/llvm/tools/llvm-offload-wrapper/llvm-offload-wrapper.cpp
@@ -40,7 +40,13 @@ static cl::opt<object::OffloadKind> Kind(
     cl::Required,
     cl::values(clEnumValN(object::OFK_OpenMP, "openmp", "Wrap OpenMP binaries"),
                clEnumValN(object::OFK_Cuda, "cuda", "Wrap CUDA binaries"),
-               clEnumValN(object::OFK_HIP, "hip", "Wrap HIP binaries")));
+               clEnumValN(object::OFK_HIP, "hip", "Wrap HIP binaries"),
+               clEnumValN(object::OFK_SYCL, "sycl", "Wrap SYCL binaries")));
+
+static cl::opt<bool> Relocatable(
+    "relocatable",
+    cl::desc("Wrap for a relocatable offloading application (OpenMP only)"),
+    cl::cat(OffloadWrapeprCategory));
 
 static cl::opt<std::string> OutputFile("o", cl::desc("Write output to <file>."),
                                        cl::value_desc("file"),
@@ -70,7 +76,7 @@ static Error wrapImages(ArrayRef<ArrayRef<char>> BuffersToWrap) {
   case llvm::object::OFK_OpenMP:
     if (Error Err = offloading::wrapOpenMPBinaries(
             M, BuffersToWrap, offloading::getOffloadEntryArray(M),
-            /*Suffix=*/"", /*Relocatable=*/false))
+            /*Suffix=*/"", /*Relocatable=*/Relocatable))
       return Err;
     break;
   case llvm::object::OFK_Cuda:


### PR DESCRIPTION
Summary:
This tool exists so people can generate the registration code in manual
toolchains. But it was never updated to add the SYCL handling. Fix that.
