### PR TITLE
[libc][NFC] Migrate unistd entrypoints to syscall wrappers

### DIFF
--- a/libc/src/unistd/linux/CMakeLists.txt
+++ b/libc/src/unistd/linux/CMakeLists.txt
@@ -207,11 +207,7 @@ add_entrypoint_object(
     ../ftruncate.h
   DEPENDS
     libc.hdr.types.off_t
-    libc.hdr.fcntl_macros
-    libc.hdr.stdint_proxy
-    libc.include.unistd
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
+    libc.src.__support.OSUtil.linux.syscall_wrappers.ftruncate
     libc.src.errno.errno
 )
 
@@ -359,10 +355,7 @@ add_entrypoint_object(
   HDRS
     ../link.h
   DEPENDS
-    libc.hdr.fcntl_macros
-    libc.include.unistd
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
+    libc.src.__support.OSUtil.linux.syscall_wrappers.link
     libc.src.errno.errno
 )
 
@@ -666,7 +659,6 @@ add_entrypoint_object(
     libc.hdr.types.size_t
     libc.hdr.types.ssize_t
     libc.hdr.errno_macros
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
+    libc.src.__support.OSUtil.linux.syscall_wrappers.getrandom
     libc.src.errno.errno
 )

--- a/libc/src/unistd/linux/ftruncate.cpp
+++ b/libc/src/unistd/linux/ftruncate.cpp
@@ -8,31 +8,17 @@
 
 #include "src/unistd/ftruncate.h"
 
-#include "src/__support/OSUtil/syscall.h" // For internal syscall function.
+#include "src/__support/OSUtil/linux/syscall_wrappers/ftruncate.h"
 #include "src/__support/common.h"
-
-#include "hdr/stdint_proxy.h" // For uint64_t.
-#include "hdr/unistd_macros.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
-#include <sys/syscall.h> // For syscall numbers.
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, ftruncate, (int fd, off_t len)) {
-#ifdef SYS_ftruncate
-  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_ftruncate, fd, len);
-#elif defined(SYS_ftruncate64)
-  // Same as ftruncate but can handle large offsets
-  static_assert(sizeof(off_t) == 8);
-  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_ftruncate64, fd, (long)len,
-                                              (long)(((uint64_t)(len)) >> 32));
-#else
-#error "ftruncate and ftruncate64 syscalls not available."
-#endif
-
-  if (ret < 0) {
-    libc_errno = -ret;
+  auto result = linux_syscalls::ftruncate(fd, len);
+  if (!result) {
+    libc_errno = result.error();
     return -1;
   }
   return 0;

--- a/libc/src/unistd/linux/getentropy.cpp
+++ b/libc/src/unistd/linux/getentropy.cpp
@@ -8,11 +8,9 @@
 
 #include "src/unistd/getentropy.h"
 #include "hdr/errno_macros.h"
-#include "src/__support/OSUtil/syscall.h"
+#include "src/__support/OSUtil/linux/syscall_wrappers/getrandom.h"
 #include "src/__support/common.h"
 #include "src/__support/libc_errno.h"
-
-#include <sys/syscall.h> // For syscall numbers.
 
 namespace LIBC_NAMESPACE_DECL {
 LLVM_LIBC_FUNCTION(int, getentropy, (void *buffer, size_t length)) {
@@ -26,16 +24,16 @@ LLVM_LIBC_FUNCTION(int, getentropy, (void *buffer, size_t length)) {
   while (length != 0) {
     // 0 flag means urandom and blocking, which meets the assumption of
     // getentropy
-    auto ret = syscall_impl<long>(SYS_getrandom, cursor, length, 0);
+    auto result = linux_syscalls::getrandom(cursor, length, 0);
 
     // on success, advance the buffer pointer
-    if (ret >= 0) {
-      length -= static_cast<size_t>(ret);
-      cursor += ret;
+    if (result) {
+      length -= static_cast<size_t>(result.value());
+      cursor += result.value();
       continue;
     }
 
-    auto error = -static_cast<int>(ret);
+    auto error = result.error();
 
     // on EINTR, try again
     if (error == EINTR)

--- a/libc/src/unistd/linux/link.cpp
+++ b/libc/src/unistd/linux/link.cpp
@@ -8,30 +8,20 @@
 
 #include "src/unistd/link.h"
 
-#include "src/__support/OSUtil/syscall.h" // For internal syscall function.
+#include "src/__support/OSUtil/linux/syscall_wrappers/link.h"
 #include "src/__support/common.h"
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 
-#include "hdr/fcntl_macros.h"
-#include <sys/syscall.h> // For syscall numbers.
-
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, link, (const char *path1, const char *path2)) {
-#ifdef SYS_link
-  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_link, path1, path2);
-#elif defined(SYS_linkat)
-  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_linkat, AT_FDCWD, path1,
-                                              AT_FDCWD, path2, 0);
-#else
-#error "link or linkat syscalls not available."
-#endif
-  if (ret < 0) {
-    libc_errno = -ret;
+  auto result = linux_syscalls::link(path1, path2);
+  if (!result) {
+    libc_errno = result.error();
     return -1;
   }
-  return ret;
+  return result.value();
 }
 
 } // namespace LIBC_NAMESPACE_DECL


### PR DESCRIPTION
Migrated link, ftruncate, and getentropy entrypoints to use their
corresponding syscall wrappers instead of direct syscall_impl calls.
Updated CMake dependencies accordingly.

Assisted-by: Automated tooling, human reviewed.