### PR TITLE
[libc][math][c23] Switch `static_cast` to `fputil::cast` in `cbrtf16`

### DIFF
--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -765,6 +765,7 @@ add_header_library(
   HDRS
     cbrtf16.h
   DEPENDS
+    libc.src.__support.FPUtil.cast
     libc.src.__support.FPUtil.fenv_impl
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.FPUtil.multiply_add

--- a/libc/src/__support/math/cbrtf16.h
+++ b/libc/src/__support/math/cbrtf16.h
@@ -15,6 +15,7 @@
 
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "src/__support/FPUtil/FPBits.h"
+#include "src/__support/FPUtil/cast.h"
 #include "src/__support/FPUtil/multiply_add.h"
 #include "src/__support/FPUtil/rounding_mode.h"
 #include "src/__support/macros/config.h"
@@ -174,7 +175,7 @@ LIBC_INLINE constexpr float16 cbrtf16(float16 x) {
 
   uint32_t r_bits = r_m | (static_cast<uint32_t>(out_e | sign_bit)
                            << FloatBits::FRACTION_LEN);
-  return static_cast<float16>(FloatBits(r_bits).get_val());
+  return fputil::cast<float16>(FloatBits(r_bits).get_val());
 }
 
 } // namespace math

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -4646,6 +4646,7 @@ libc_support_library(
     name = "__support_math_cbrtf16",
     hdrs = ["src/__support/math/cbrtf16.h"],
     deps = [
+        ":__support_fputil_cast",
         ":__support_fputil_fenv_impl",
         ":__support_fputil_fp_bits",
         ":__support_fputil_multiply_add",


### PR DESCRIPTION
This avoids some failures w/ the compilers runtime