### PR TITLE
CodeGenPassBuilder: Use cl::boolOrDefault directly in CGPassBuilderOption

### DIFF
--- a/llvm/include/llvm/Passes/CodeGenPassBuilder.h
+++ b/llvm/include/llvm/Passes/CodeGenPassBuilder.h
@@ -194,8 +194,9 @@ public:
     if (Opt.EnableGlobalISelAbort)
       TM.Options.GlobalISelAbort = *Opt.EnableGlobalISelAbort;
 
-    if (!Opt.OptimizeRegAlloc)
-      Opt.OptimizeRegAlloc = getOptLevel() != CodeGenOptLevel::None;
+    if (Opt.OptimizeRegAlloc == cl::BOU_UNSET)
+      Opt.OptimizeRegAlloc =
+          getOptLevel() != CodeGenOptLevel::None ? cl::BOU_TRUE : cl::BOU_FALSE;
   }
 
   Error buildPipeline(ModulePassManager &MPM, ModuleAnalysisManager &MAM,
@@ -875,19 +876,17 @@ template <typename Derived, typename TargetMachineT>
 Error CodeGenPassBuilder<Derived, TargetMachineT>::addCoreISelPasses(
     PassManagerWrapper &PMW) const {
   // Enable FastISel with -fast-isel, but allow that to be overridden.
-  TM.setO0WantsFastISel(Opt.EnableFastISelOption.value_or(true));
+  TM.setO0WantsFastISel(Opt.EnableFastISelOption != cl::BOU_FALSE);
 
   // Determine an instruction selector.
   enum class SelectorType { SelectionDAG, FastISel, GlobalISel };
   SelectorType Selector;
 
-  if (Opt.EnableFastISelOption && *Opt.EnableFastISelOption == true)
+  if (Opt.EnableFastISelOption == cl::BOU_TRUE)
     Selector = SelectorType::FastISel;
-  else if ((Opt.EnableGlobalISelOption &&
-            *Opt.EnableGlobalISelOption == true) ||
+  else if (Opt.EnableGlobalISelOption == cl::BOU_TRUE ||
            (TM.Options.EnableGlobalISel &&
-            (!Opt.EnableGlobalISelOption ||
-             *Opt.EnableGlobalISelOption == false)))
+            Opt.EnableGlobalISelOption != cl::BOU_FALSE))
     Selector = SelectorType::GlobalISel;
   else if (TM.getOptLevel() == CodeGenOptLevel::None && TM.getO0WantsFastISel())
     Selector = SelectorType::FastISel;
@@ -989,8 +988,9 @@ Error CodeGenPassBuilder<Derived, TargetMachineT>::addMachinePasses(
 
   // Run register allocation and passes that are tightly coupled with it,
   // including phi elimination and scheduling.
-  if (auto Err = *Opt.OptimizeRegAlloc ? derived().addOptimizedRegAlloc(PMW)
-                                       : derived().addFastRegAlloc(PMW))
+  if (auto Err = Opt.OptimizeRegAlloc == cl::BOU_TRUE
+                     ? derived().addOptimizedRegAlloc(PMW)
+                     : derived().addFastRegAlloc(PMW))
     return std::move(Err);
 
   // Run post-ra passes.

--- a/llvm/include/llvm/Target/CGPassBuilderOption.h
+++ b/llvm/include/llvm/Target/CGPassBuilderOption.h
@@ -48,7 +48,7 @@ public:
 // Not one-on-one but mostly corresponding to commandline options in
 // TargetPassConfig.cpp.
 struct CGPassBuilderOption {
-  std::optional<bool> OptimizeRegAlloc;
+  cl::boolOrDefault OptimizeRegAlloc = cl::BOU_UNSET;
   std::optional<bool> EnableIPRA;
   bool DebugPM = false;
   bool DisableVerify = false;
@@ -84,11 +84,11 @@ struct CGPassBuilderOption {
   std::string FSProfileFile;
   std::string FSRemappingFile;
 
-  std::optional<bool> VerifyMachineCode;
-  std::optional<bool> EnableFastISelOption;
-  std::optional<bool> EnableGlobalISelOption;
-  std::optional<bool> DebugifyAndStripAll;
-  std::optional<bool> DebugifyCheckAndStripAll;
+  cl::boolOrDefault VerifyMachineCode = cl::BOU_UNSET;
+  cl::boolOrDefault EnableFastISelOption = cl::BOU_UNSET;
+  cl::boolOrDefault EnableGlobalISelOption = cl::BOU_UNSET;
+  cl::boolOrDefault DebugifyAndStripAll = cl::BOU_UNSET;
+  cl::boolOrDefault DebugifyCheckAndStripAll = cl::BOU_UNSET;
 };
 
 LLVM_ABI CGPassBuilderOption getCGPassBuilderOption();

--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -499,42 +499,42 @@ void TargetPassConfig::setStartStopPasses() {
 CGPassBuilderOption llvm::getCGPassBuilderOption() {
   CGPassBuilderOption Opt;
 
-#define SET_OPTION(Option)                                                     \
+#define SET_OPTION_IF_PRESENT(Option)                                          \
   if (Option.getNumOccurrences())                                              \
     Opt.Option = Option;
 
-  SET_OPTION(EnableFastISelOption)
-  SET_OPTION(EnableGlobalISelAbort)
-  SET_OPTION(EnableGlobalISelOption)
-  SET_OPTION(EnableIPRA)
+  SET_OPTION_IF_PRESENT(EnableGlobalISelAbort)
+  SET_OPTION_IF_PRESENT(EnableIPRA)
+
+#define SET_OPTION(Option) Opt.Option = Option;
+
   SET_OPTION(OptimizeRegAlloc)
+  SET_OPTION(EnableFastISelOption)
+  SET_OPTION(EnableGlobalISelOption)
   SET_OPTION(VerifyMachineCode)
   SET_OPTION(DisableAtExitBasedGlobalDtorLowering)
   SET_OPTION(DisableExpandReductions)
   SET_OPTION(PrintAfterISel)
   SET_OPTION(FSProfileFile)
   SET_OPTION(EnableGCEmptyBlocks)
-
-#define SET_BOOLEAN_OPTION(Option) Opt.Option = Option;
-
-  SET_BOOLEAN_OPTION(EarlyLiveIntervals)
-  SET_BOOLEAN_OPTION(EnableBlockPlacementStats)
-  SET_BOOLEAN_OPTION(EnableGlobalMergeFunc)
-  SET_BOOLEAN_OPTION(EnableImplicitNullChecks)
-  SET_BOOLEAN_OPTION(EnableMachineOutliner)
-  SET_BOOLEAN_OPTION(MISchedPostRA)
-  SET_BOOLEAN_OPTION(DisableLSR)
-  SET_BOOLEAN_OPTION(DisableConstantHoisting)
-  SET_BOOLEAN_OPTION(DisableCGP)
-  SET_BOOLEAN_OPTION(DisablePartialLibcallInlining)
-  SET_BOOLEAN_OPTION(DisableSelectOptimize)
-  SET_BOOLEAN_OPTION(PrintISelInput)
-  SET_BOOLEAN_OPTION(PrintRegUsage)
-  SET_BOOLEAN_OPTION(DebugifyAndStripAll)
-  SET_BOOLEAN_OPTION(DebugifyCheckAndStripAll)
-  SET_BOOLEAN_OPTION(DisableRAFSProfileLoader)
-  SET_BOOLEAN_OPTION(DisableCFIFixup)
-  SET_BOOLEAN_OPTION(EnableMachineFunctionSplitter)
+  SET_OPTION(EarlyLiveIntervals)
+  SET_OPTION(EnableBlockPlacementStats)
+  SET_OPTION(EnableGlobalMergeFunc)
+  SET_OPTION(EnableImplicitNullChecks)
+  SET_OPTION(EnableMachineOutliner)
+  SET_OPTION(MISchedPostRA)
+  SET_OPTION(DisableLSR)
+  SET_OPTION(DisableConstantHoisting)
+  SET_OPTION(DisableCGP)
+  SET_OPTION(DisablePartialLibcallInlining)
+  SET_OPTION(DisableSelectOptimize)
+  SET_OPTION(PrintISelInput)
+  SET_OPTION(PrintRegUsage)
+  SET_OPTION(DebugifyAndStripAll)
+  SET_OPTION(DebugifyCheckAndStripAll)
+  SET_OPTION(DisableRAFSProfileLoader)
+  SET_OPTION(DisableCFIFixup)
+  SET_OPTION(EnableMachineFunctionSplitter)
 
   return Opt;
 }

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -285,7 +285,7 @@ LLVMInitializeAArch64Target() {
 
 bool AArch64TargetMachine::isGlobalISelOptNone() const {
   const bool GlobalISelFlag =
-      getCGPassBuilderOption().EnableGlobalISelOption.value_or(false);
+      getCGPassBuilderOption().EnableGlobalISelOption == cl::BOU_TRUE;
 
   return getOptLevel() == CodeGenOptLevel::None ||
          (static_cast<unsigned>(getOptLevel()) >
@@ -398,7 +398,7 @@ AArch64TargetMachine::AArch64TargetMachine(const Target &T, const Triple &TT,
       !(getCodeModel() == CodeModel::Large && TT.isOSBinFormatMachO());
 
   const bool GlobalISelFlag =
-      getCGPassBuilderOption().EnableGlobalISelOption.value_or(false);
+      getCGPassBuilderOption().EnableGlobalISelOption == cl::BOU_TRUE;
 
   // Enable GlobalISel at or below EnableGlobalISelAt0, unless this is
   // MachO/CodeModel::Large, which GlobalISel does not support.

--- a/llvm/lib/Target/AArch64/GISel/AArch64CallLowering.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64CallLowering.cpp
@@ -601,7 +601,7 @@ bool AArch64CallLowering::fallBackToDAGISel(const MachineFunction &MF) const {
 
   auto OptLevel = MF.getTarget().getOptLevel();
   bool IsGlobalISelPreferred =
-      getCGPassBuilderOption().EnableGlobalISelOption.value_or(false) ||
+      getCGPassBuilderOption().EnableGlobalISelOption == cl::BOU_TRUE ||
       static_cast<unsigned>(OptLevel) <= TM.getEnableGlobalISelAtO() ||
       F.hasOptNone();
   return !IsGlobalISelPreferred;

--- a/llvm/lib/Target/AMDGPU/AMDGPUCodeGenPrepare.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCodeGenPrepare.cpp
@@ -1896,7 +1896,8 @@ bool AMDGPUCodeGenPrepareImpl::visitPHINode(PHINode &I) {
   // operations with most elements being "undef". This inhibits a lot of
   // optimization opportunities and can result in unreasonably high register
   // pressure and the inevitable stack spilling.
-  if (!BreakLargePHIs || getCGPassBuilderOption().EnableGlobalISelOption)
+  if (!BreakLargePHIs ||
+      getCGPassBuilderOption().EnableGlobalISelOption == cl::BOU_TRUE)
     return false;
 
   FixedVectorType *FVT = dyn_cast<FixedVectorType>(I.getType());

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -1626,7 +1626,7 @@ bool GCNPassConfig::addPreISel() {
 
   // SDAG requires LCSSA, GlobalISel does not. Disable LCSSA for -global-isel
   // with -new-reg-bank-select and without any of the fallback options.
-  if (!getCGPassBuilderOption().EnableGlobalISelOption ||
+  if (getCGPassBuilderOption().EnableGlobalISelOption != cl::BOU_TRUE ||
       !isGlobalISelAbortEnabled() || !NewRegBankSelect)
     addPass(createLCSSAPass());
 
@@ -2390,7 +2390,7 @@ void AMDGPUCodeGenPassBuilder::addPreISel(PassManagerWrapper &PMW) const {
   // control flow modifications.
   addFunctionPass(AMDGPURewriteUndefForPHIPass(), PMW);
 
-  if (!getCGPassBuilderOption().EnableGlobalISelOption ||
+  if (getCGPassBuilderOption().EnableGlobalISelOption != cl::BOU_TRUE ||
       !isGlobalISelAbortEnabled() || !NewRegBankSelect)
     addFunctionPass(LCSSAPass(), PMW);
 


### PR DESCRIPTION
Current implementation that uses std::optional<bool> captures cl::BOU_FALSE,
for example -global-isel=0, as true. Explictly setting option to 0 should be
false, forced option not set.
This could be fixed but I find it cleaner to use boolOrDefault directly and
use same logic as in TargetPassConfig.
Options EnableIPRA and EnableGlobalISelAbort are left as optional since for
them it is explictly checked if they are set using getNumOccurrences.
boolOrDefault has encoded unset option.