### PR TITLE
[APFloat] Extend fltSemantics and drop special case E8M0 bit conversionJan/apfloat e8m0

### DIFF
--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -1023,6 +1023,11 @@ struct fltSemantics {
 
   /* Whether the sign bit of this semantics is the most significant bit */
   bool hasSignBitInMSB = true;
+
+  /* Whether the format supports IEEE754 denormal representation.
+     If both hasDenormals and hasZero are false exponent 0 is assumed to be a
+     regular exponent instead of being reserved. This changes the bias by +1. */
+  bool hasDenormals = true;
 };
 
 // This is a interface class that is currently forwarding functionalities from

--- a/llvm/lib/Support/APFloat.cpp
+++ b/llvm/lib/Support/APFloat.cpp
@@ -94,6 +94,7 @@ constexpr fltSemantics APFloatBase::semFloat8E8M0FNU = {
     fltNanEncoding::AllOnes,
     false,
     false,
+    false,
     false};
 
 constexpr fltSemantics APFloatBase::semFloat6E3M2FN = {
@@ -943,9 +944,10 @@ IEEEFloat &IEEEFloat::operator=(IEEEFloat &&rhs) {
 }
 
 bool IEEEFloat::isDenormal() const {
-  return isFiniteNonZero() && (exponent == semantics->minExponent) &&
-         (APInt::tcExtractBit(significandParts(),
-                              semantics->precision - 1) == 0);
+  return getSemantics().hasDenormals && isFiniteNonZero() &&
+         (exponent == semantics->minExponent) &&
+         (APInt::tcExtractBit(significandParts(), semantics->precision - 1) ==
+          0);
 }
 
 bool IEEEFloat::isSmallest() const {
@@ -3430,19 +3432,17 @@ APInt IEEEFloat::convertPPCDoubleDoubleLegacyAPFloatToAPInt() const {
 template <const fltSemantics &S>
 APInt IEEEFloat::convertIEEEFloatToAPInt() const {
   assert(semantics == &S);
-  const int bias = (semantics == &APFloatBase::semFloat8E8M0FNU)
-                       ? -S.minExponent
-                       : -(S.minExponent - 1);
   constexpr unsigned int trailing_significand_bits = S.precision - 1;
   constexpr int integer_bit_part = trailing_significand_bits / integerPartWidth;
   constexpr integerPart integer_bit =
       integerPart{1} << (trailing_significand_bits % integerPartWidth);
   constexpr uint64_t significand_mask = integer_bit - 1;
   constexpr unsigned int exponent_bits =
-      trailing_significand_bits ? (S.sizeInBits - 1 - trailing_significand_bits)
-                                : S.sizeInBits;
+      S.sizeInBits - (S.hasSignedRepr ? 1 : 0) - trailing_significand_bits;
   static_assert(exponent_bits < 64);
   constexpr uint64_t exponent_mask = (uint64_t{1} << exponent_bits) - 1;
+  constexpr bool is_zero_exp_reserved = S.hasDenormals || S.hasZero;
+  constexpr int bias = -(S.minExponent - (is_zero_exp_reserved ? 1 : 0));
 
   uint64_t myexponent;
   std::array<integerPart, partCountForBits(trailing_significand_bits)>
@@ -3737,55 +3737,40 @@ void IEEEFloat::initFromPPCDoubleDoubleLegacyAPInt(const APInt &api) {
 // NaN is represented by all 1's.
 // Bias is 127.
 void IEEEFloat::initFromFloat8E8M0FNUAPInt(const APInt &api) {
-  const uint64_t exponent_mask = 0xff;
-  uint64_t val = api.getRawData()[0];
-  uint64_t myexponent = val & exponent_mask;
-
-  initialize(&APFloatBase::semFloat8E8M0FNU);
-  assert(partCount() == 1);
-
-  // This format has unsigned representation only
-  sign = 0;
-
-  // Set the significand
-  // This format does not have any significand but the 'Pth' precision bit is
-  // always set to 1 for consistency in APFloat's internal representation.
-  uint64_t mysignificand = 1;
-  significandParts()[0] = mysignificand;
-
-  // This format can either have a NaN or fcNormal
-  // All 1's i.e. 255 is a NaN
-  if (val == exponent_mask) {
-    category = fcNaN;
-    exponent = exponentNaN();
-    return;
-  }
-  // Handle fcNormal...
-  category = fcNormal;
-  exponent = myexponent - 127; // 127 is bias
+  initFromIEEEAPInt<APFloatBase::semFloat8E8M0FNU>(api);
 }
 
 template <const fltSemantics &S>
 void IEEEFloat::initFromIEEEAPInt(const APInt &api) {
   assert(api.getBitWidth() == S.sizeInBits);
-  constexpr integerPart integer_bit = integerPart{1}
-                                      << ((S.precision - 1) % integerPartWidth);
-  constexpr uint64_t significand_mask = integer_bit - 1;
+
   constexpr unsigned int trailing_significand_bits = S.precision - 1;
+  constexpr integerPart integer_bit =
+      integerPart{1} << (trailing_significand_bits % integerPartWidth);
+  constexpr uint64_t significand_mask = integer_bit - 1;
+  constexpr unsigned int exponent_bits =
+      S.sizeInBits - (S.hasSignedRepr ? 1 : 0) - trailing_significand_bits;
   constexpr unsigned int stored_significand_parts =
       partCountForBits(trailing_significand_bits);
-  constexpr unsigned int exponent_bits =
-      S.sizeInBits - 1 - trailing_significand_bits;
   static_assert(exponent_bits < 64);
   constexpr uint64_t exponent_mask = (uint64_t{1} << exponent_bits) - 1;
-  constexpr int bias = -(S.minExponent - 1);
+  constexpr bool is_zero_exp_reserved = S.hasDenormals || S.hasZero;
+  constexpr int bias = -(S.minExponent - (is_zero_exp_reserved ? 1 : 0));
+  constexpr bool has_significand = trailing_significand_bits > 0;
 
   // Copy the bits of the significand. We need to clear out the exponent and
   // sign bit in the last word.
   std::array<integerPart, stored_significand_parts> mysignificand;
-  std::copy_n(api.getRawData(), mysignificand.size(), mysignificand.begin());
-  if constexpr (significand_mask != 0) {
-    mysignificand[mysignificand.size() - 1] &= significand_mask;
+  if constexpr (has_significand) {
+    std::copy_n(api.getRawData(), mysignificand.size(), mysignificand.begin());
+    if constexpr (significand_mask != 0) {
+      mysignificand[mysignificand.size() - 1] &= significand_mask;
+    }
+  } else {
+    std::fill_n(mysignificand.begin(), mysignificand.size(), 0);
+    // Always set integer bit to 1 for consistency in APFloat's internal
+    // representation.
+    mysignificand[0] = 1;
   }
 
   // We assume the last word holds the sign bit, the exponent, and potentially
@@ -3797,11 +3782,14 @@ void IEEEFloat::initFromIEEEAPInt(const APInt &api) {
   initialize(&S);
   assert(partCount() == mysignificand.size());
 
-  sign = static_cast<unsigned int>(last_word >> ((S.sizeInBits - 1) % 64));
+  sign = S.hasSignedRepr
+             ? static_cast<unsigned int>(last_word >> ((S.sizeInBits - 1) % 64))
+             : 0;
 
-  bool all_zero_significand = llvm::all_of(mysignificand, equal_to(0));
+  bool all_zero_significand =
+      has_significand && llvm::all_of(mysignificand, equal_to(0));
 
-  bool is_zero = myexponent == 0 && all_zero_significand;
+  bool is_zero = myexponent == 0 && all_zero_significand && S.hasZero;
 
   if constexpr (S.nonFiniteBehavior == fltNonfiniteBehavior::IEEE754) {
     if (myexponent - bias == ::exponentInf(S) && all_zero_significand) {
@@ -3841,7 +3829,7 @@ void IEEEFloat::initFromIEEEAPInt(const APInt &api) {
   category = fcNormal;
   exponent = myexponent - bias;
   std::copy_n(mysignificand.begin(), mysignificand.size(), significandParts());
-  if (myexponent == 0) // denormal
+  if (myexponent == 0 && S.hasDenormals) // denormal
     exponent = S.minExponent;
   else
     significandParts()[mysignificand.size()-1] |= integer_bit; // integer bit

--- a/llvm/unittests/ADT/APFloatTest.cpp
+++ b/llvm/unittests/ADT/APFloatTest.cpp
@@ -1027,6 +1027,13 @@ TEST(APFloatTest, Denormal) {
     EXPECT_TRUE(NegT.isDenormal());
     EXPECT_EQ(fcNegSubnormal, NegT.classify());
   }
+
+  // Test E8M0
+  {
+    APInt bits(8, 0);
+    APFloat minExp(APFloat::Float8E8M0FNU(), bits);
+    EXPECT_FALSE(minExp.isDenormal());
+  }
 }
 
 TEST(APFloatTest, IsSmallestNormalized) {
@@ -7374,6 +7381,70 @@ TEST(APFloatTest, x87Next) {
   APFloat F(APFloat::x87DoubleExtended(), "-1.0");
   F.next(false);
   EXPECT_TRUE(ilogb(F) == -1);
+}
+
+static bool isBitcastRoundtripSafe(APFloat value) {
+  APInt bits = value.bitcastToAPInt();
+  APFloat fromBits = APFloat(value.getSemantics(), bits);
+  return (value.isNaN() || value == fromBits) && value.bitwiseIsEqual(fromBits);
+}
+
+TEST(APFloatTest, bitcast) {
+  // 4, 6, and 8 bit types are handled in Float[468]ExhaustivePair below
+  for (APFloat::Semantics Sem : {
+           APFloat::S_IEEEhalf,
+           APFloat::S_BFloat,
+           APFloat::S_IEEEsingle,
+           APFloat::S_IEEEdouble,
+           APFloat::S_IEEEquad,
+           APFloat::S_PPCDoubleDouble,
+           APFloat::S_Float8E5M2,
+           APFloat::S_Float8E4M3,
+           APFloat::S_Float8E3M4,
+           APFloat::S_FloatTF32,
+           APFloat::S_x87DoubleExtended,
+       }) {
+    const fltSemantics &S = APFloatBase::EnumToSemantics(Sem);
+
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getZero(S, false)));
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getZero(S, true)));
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getOne(S, false)));
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getOne(S, true)));
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getLargest(S, false)));
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getLargest(S, true)));
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getSmallest(S, false)));
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getSmallest(S, true)));
+    EXPECT_TRUE(
+        isBitcastRoundtripSafe(APFloat::getSmallestNormalized(S, false)));
+    EXPECT_TRUE(
+        isBitcastRoundtripSafe(APFloat::getSmallestNormalized(S, true)));
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getInf(S, false)));
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getInf(S, true)));
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getQNaN(S, false)));
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getQNaN(S, true)));
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getSNaN(S, false)));
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getSNaN(S, true)));
+  }
+
+  {
+    // PPCDoubleDoubleLegacy format supports most but not all operations
+    const fltSemantics &S =
+        APFloatBase::EnumToSemantics(APFloat::S_PPCDoubleDoubleLegacy);
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getZero(S, false)));
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getZero(S, true)));
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getOne(S, false)));
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getOne(S, true)));
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getSmallest(S, false)));
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getSmallest(S, true)));
+    EXPECT_TRUE(
+        isBitcastRoundtripSafe(APFloat::getSmallestNormalized(S, false)));
+    EXPECT_TRUE(
+        isBitcastRoundtripSafe(APFloat::getSmallestNormalized(S, true)));
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getInf(S, false)));
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getInf(S, true)));
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getQNaN(S, false)));
+    EXPECT_TRUE(isBitcastRoundtripSafe(APFloat::getQNaN(S, true)));
+  }
 }
 
 TEST(APFloatTest, Float8ExhaustivePair) {


### PR DESCRIPTION
This is one step towards being able to make APFloat extensible with custom formats in the future.

fltSemantics gained a new flag to indicate lack of denormal support. Combined with hasZero = 0 it means exponent 0 does not have a special meaning. This makes it possible to remove the special case implementation for initFromFloat8E8M0FNUAPInt and handle it in the generic version.

The generic initFromIEEEAPInt function now also supports existing fltSemantics flags for hasZero, and hasSignedRepr which where only needed in the specialized initFromFloat8E8M0FNUAPInt.

Also adds new tests for bitcasting to and from APInt. There are several tests involving bitcastToAPInt together with convert functions but none explicitly verify the functionality of bitcastToAPInt.

The implementations of convertIEEEFloatToAPInt and initFromIEEEAPInt also diverged a bit in the past and have been synchronized, again. This is a separate commit as it is not strictly required and could be dropped if the risk is considered higher than it's benefit and so it can be tested independently.