### PR TITLE
[Driver] Re-enable -fobjc-constant-literals by default

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4318,7 +4318,7 @@ static void RenderObjCOptions(const ToolChain &TC, const Driver &D,
     bool EnableConstantLiterals =
         Args.hasFlag(options::OPT_fobjc_constant_literals,
                      options::OPT_fno_objc_constant_literals,
-                     /*default=*/false) &&
+                     /*default=*/true) &&
         Runtime.hasConstantLiteralClasses();
     if (EnableConstantLiterals)
       CmdArgs.push_back("-fobjc-constant-literals");

--- a/clang/test/Driver/objc-constant-literals.m
+++ b/clang/test/Driver/objc-constant-literals.m
@@ -5,10 +5,10 @@
 // RUN: %clang -### -target arm64-apple-macosx11 -fno-objc-constant-literals -c %s 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=DISABLED
 
-// DEFAULT-NOT: -fobjc-constant-literals
-// DEFAULT-NOT: -fconstant-nsnumber-literals
-// DEFAULT-NOT: -fconstant-nsarray-literals
-// DEFAULT-NOT: -fconstant-nsdictionary-literals
+// DEFAULT: -fobjc-constant-literals
+// DEFAULT: -fconstant-nsnumber-literals
+// DEFAULT: -fconstant-nsarray-literals
+// DEFAULT: -fconstant-nsdictionary-literals
 
 // ENABLED: -fobjc-constant-literals
 // ENABLED: -fconstant-nsnumber-literals


### PR DESCRIPTION
This reverts 4d154f6ea5eb ([Driver] Disable -fobjc-constant-literals by default (#195000)), which was a temporary measure to unblock a project that the original constant-literal change (#185130) broke.

For background on the feature and the discussion that led to disabling and then re-enabling it, see
https://github.com/llvm/llvm-project/pull/185130.

rdar://179823193