### PR TITLE
[SystemZ][z/OS] Mark the -msoft-float option as unsupported on z/OS

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -2138,8 +2138,15 @@ void Clang::AddSystemZTargetArgs(const ArgList &Args,
   systemz::FloatABI FloatABI =
       systemz::getSystemZFloatABI(getToolChain().getDriver(), Args);
   bool HasSoftFloat = (FloatABI == systemz::FloatABI::Soft);
+
+  // Only hard float ABI (-mhard-float) is supported on z/OS.
+  const Driver &D = getToolChain().getDriver();
+  const llvm::Triple &Triple = getToolChain().getTriple();
+  if (HasSoftFloat && Triple.isOSzOS()) {
+    D.Diag(diag::err_drv_unsupported_opt_for_target)
+        << "-msoft-float" << Triple.str();
+  }
   if (HasBackchain && HasPackedStack && !HasSoftFloat) {
-    const Driver &D = getToolChain().getDriver();
     D.Diag(diag::err_drv_unsupported_opt)
       << "-mpacked-stack -mbackchain -mhard-float";
   }

--- a/clang/test/Driver/zos-err-options.c
+++ b/clang/test/Driver/zos-err-options.c
@@ -1,3 +1,3 @@
-// RUN: not %clang -msoft-float --target=s390x-unknown-zos 2>&1 %s | FileCheck %s
+// RUN: not %clang -msoft-float --target=s390x-none-zos 2>&1 %s | FileCheck %s
 
 // CHECK: error: unsupported option '-msoft-float' for target 's390x-unknown-zos'

--- a/clang/test/Driver/zos-err-options.c
+++ b/clang/test/Driver/zos-err-options.c
@@ -1,3 +1,3 @@
 // RUN: not %clang -msoft-float --target=s390x-none-zos 2>&1 %s | FileCheck %s
 
-// CHECK: error: unsupported option '-msoft-float' for target 's390x-unknown-zos'
+// CHECK: error: unsupported option '-msoft-float' for target 's390x-none-zos'

--- a/clang/test/Driver/zos-err-options.c
+++ b/clang/test/Driver/zos-err-options.c
@@ -1,0 +1,3 @@
+// RUN: not %clang -msoft-float --target=s390x-unknown-zos 2>&1 %s | FileCheck %s
+
+// CHECK: error: unsupported option '-msoft-float' for target 's390x-unknown-zos'


### PR DESCRIPTION
This patch unsupports the -msoft-float option for z/OS