### PR TITLE
[SLP][NFC] Fix compile-time hang in isMaskedLoadCompress

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -7424,6 +7424,14 @@ static bool isMaskedLoadCompress(
       }
     }
   }
+  // Estimating the compression shuffle cost below can be extremely expensive
+  // for a very wide LoadVecTy, which is split into a large number of vector
+  // registers (see processShuffleMasks). The shuffle cost is always
+  // non-negative, so if the load cost alone already reaches the gather cost the
+  // masked-load-compress cannot be profitable. Bail out before the costly
+  // shuffle cost estimation in that case.
+  if (VectorGEPCost + LoadCost >= GatherCost)
+    return false;
   InstructionCost CompressCost = ::getShuffleCost(
       TTI, TTI::SK_PermuteSingleSrc, LoadVecTy, CompressMask, CostKind);
   if (!Order.empty()) {


### PR DESCRIPTION
For a large gathered-load cluster LoadVecTy spans hundreds of vector
registers and the shuffle cost query blows up in processShuffleMasks.
The shuffle cost is non-negative, so bail out before computing it when
VectorGEPCost + LoadCost already reaches GatherCost (not profitable).

Fixes #204163
