### PR TITLE
[flang][NFC] remove libFortranEvaluate from Optimizer libraries

### DIFF
--- a/flang/include/flang/Lower/CustomIntrinsicCall.h
+++ b/flang/include/flang/Lower/CustomIntrinsicCall.h
@@ -38,6 +38,9 @@ struct SpecificIntrinsic;
 
 namespace lower {
 
+/// Build intrinsic lowering options from the converter state.
+fir::IntrinsicLoweringOptions getIntrinsicLoweringOptions(AbstractConverter &);
+
 /// Does the call \p procRef to \p intrinsic need to be handle via this custom
 /// framework due to optional arguments. Otherwise, the tools from
 /// IntrinsicCall.cpp should be used directly.

--- a/flang/include/flang/Optimizer/Builder/IntrinsicCall.h
+++ b/flang/include/flang/Optimizer/Builder/IntrinsicCall.h
@@ -21,19 +21,18 @@
 #include "mlir/Dialect/Math/IR/Math.h"
 #include <optional>
 
-namespace Fortran {
-namespace lower {
-// TODO: remove the usage of AbstractConverter to avoid making IntrinsicCall.cpp
-// depend upon Lower/Evaluate and use a data structure to pass options to
-// IntrinsicLibrary.
-class AbstractConverter;
-} // namespace lower
-} // namespace Fortran
-
 namespace fir {
 
 class StatementContext;
 struct IntrinsicHandlerEntry;
+
+/// Options controlling intrinsic lowering that depend on front-end state.
+struct IntrinsicLoweringOptions {
+  /// Whether multi-image (coarray) features are enabled (e.g. via -fcoarray).
+  bool coarrayEnabled = false;
+  /// Whether to avoid using the native vector element order on PPC targets.
+  bool noPPCNativeVecElemOrder = false;
+};
 
 /// Lower an intrinsic call given the intrinsic \p name, its \p resultType (that
 /// must be std::nullopt if and only if this is a subroutine call), and its
@@ -44,7 +43,7 @@ std::pair<fir::ExtendedValue, bool>
 genIntrinsicCall(fir::FirOpBuilder &, mlir::Location, llvm::StringRef name,
                  std::optional<mlir::Type> resultType,
                  llvm::ArrayRef<fir::ExtendedValue> args,
-                 Fortran::lower::AbstractConverter *converter = nullptr);
+                 IntrinsicLoweringOptions options = {});
 
 /// Same as the entry above except that instead of an intrinsic name it takes an
 /// IntrinsicHandlerEntry obtained by a previous lookup for a handler to lower
@@ -54,7 +53,7 @@ genIntrinsicCall(fir::FirOpBuilder &, mlir::Location,
                  const IntrinsicHandlerEntry &,
                  std::optional<mlir::Type> resultType,
                  llvm::ArrayRef<fir::ExtendedValue> args,
-                 Fortran::lower::AbstractConverter *converter = nullptr);
+                 IntrinsicLoweringOptions options = {});
 
 /// Enum specifying how intrinsic argument evaluate::Expr should be
 /// lowered to fir::ExtendedValue to be passed to genIntrinsicCall.
@@ -101,10 +100,9 @@ struct IntrinsicArgumentLoweringRules;
 struct IntrinsicLibrary {
 
   // Constructors.
-  explicit IntrinsicLibrary(
-      fir::FirOpBuilder &builder, mlir::Location loc,
-      Fortran::lower::AbstractConverter *converter = nullptr)
-      : builder{builder}, loc{loc}, converter{converter} {}
+  explicit IntrinsicLibrary(fir::FirOpBuilder &builder, mlir::Location loc,
+                            IntrinsicLoweringOptions options = {})
+      : builder{builder}, loc{loc}, options{options} {}
   IntrinsicLibrary() = delete;
   IntrinsicLibrary(const IntrinsicLibrary &) = delete;
 
@@ -526,7 +524,7 @@ struct IntrinsicLibrary {
   fir::FirOpBuilder &builder;
   mlir::Location loc;
   bool resultMustBeFreed = false;
-  Fortran::lower::AbstractConverter *converter = nullptr;
+  IntrinsicLoweringOptions options;
 };
 
 struct IntrinsicDummyArgument {

--- a/flang/include/flang/Optimizer/Builder/MIFCommon.h
+++ b/flang/include/flang/Optimizer/Builder/MIFCommon.h
@@ -9,7 +9,6 @@
 #ifndef FORTRAN_OPTIMIZER_TRANSFORMS_MIFCOMMON_H_
 #define FORTRAN_OPTIMIZER_TRANSFORMS_MIFCOMMON_H_
 
-#include "flang/Lower/AbstractConverter.h"
 #include "flang/Optimizer/Dialect/FIROps.h"
 #include "flang/Optimizer/Dialect/MIF/MIFOps.h"
 #include "mlir/IR/BuiltinOps.h"

--- a/flang/lib/Lower/ConvertCall.cpp
+++ b/flang/lib/Lower/ConvertCall.cpp
@@ -2299,8 +2299,9 @@ genIntrinsicRefCore(Fortran::lower::PreparedActualArguments &loweredActuals,
     scalarResultType = hlfir::getFortranElementType(*callContext.resultType);
   const std::string intrinsicName = callContext.getProcedureName();
   // Let the intrinsic library lower the intrinsic procedure call.
-  auto [resultExv, mustBeFreed] = genIntrinsicCall(
-      builder, loc, intrinsicEntry, scalarResultType, operands, &converter);
+  auto [resultExv, mustBeFreed] =
+      genIntrinsicCall(builder, loc, intrinsicEntry, scalarResultType, operands,
+                       Fortran::lower::getIntrinsicLoweringOptions(converter));
   for (const hlfir::CleanupFunction &fn : cleanupFns)
     fn();
   if (!fir::getBase(resultExv))

--- a/flang/lib/Lower/CustomIntrinsicCall.cpp
+++ b/flang/lib/Lower/CustomIntrinsicCall.cpp
@@ -18,6 +18,7 @@
 #include "flang/Optimizer/Builder/IntrinsicCall.h"
 #include "flang/Optimizer/Builder/Todo.h"
 #include "flang/Semantics/tools.h"
+#include "flang/Support/Fortran-features.h"
 #include <optional>
 
 /// Is this a call to MIN or MAX intrinsic with arguments that may be absent at
@@ -85,6 +86,17 @@ bool Fortran::lower::intrinsicRequiresCustomOptionalHandling(
          isAssociatedWithDynamicallyOptionalArg(name, procRef);
 }
 
+fir::IntrinsicLoweringOptions
+Fortran::lower::getIntrinsicLoweringOptions(AbstractConverter &converter) {
+  fir::IntrinsicLoweringOptions options;
+  options.coarrayEnabled =
+      converter.getFoldingContext().languageFeatures().IsEnabled(
+          Fortran::common::LanguageFeature::Coarray);
+  options.noPPCNativeVecElemOrder =
+      converter.getLoweringOptions().getNoPPCNativeVecElemOrder();
+  return options;
+}
+
 /// Generate the FIR+MLIR operations for the generic intrinsic \p name
 /// with arguments \p args and the expected result type \p resultType.
 /// Returned fir::ExtendedValue is the returned Fortran intrinsic value.
@@ -95,8 +107,11 @@ Fortran::lower::genIntrinsicCall(fir::FirOpBuilder &builder, mlir::Location loc,
                                  llvm::ArrayRef<fir::ExtendedValue> args,
                                  Fortran::lower::StatementContext &stmtCtx,
                                  Fortran::lower::AbstractConverter *converter) {
+  fir::IntrinsicLoweringOptions options;
+  if (converter)
+    options = getIntrinsicLoweringOptions(*converter);
   auto [result, mustBeFreed] =
-      fir::genIntrinsicCall(builder, loc, name, resultType, args, converter);
+      fir::genIntrinsicCall(builder, loc, name, resultType, args, options);
   if (mustBeFreed) {
     mlir::Value addr = fir::getBase(result);
     if (auto *box = result.getBoxOf<fir::BoxValue>())

--- a/flang/lib/Optimizer/Builder/CMakeLists.txt
+++ b/flang/lib/Optimizer/Builder/CMakeLists.txt
@@ -53,7 +53,6 @@ add_flang_library(FIRBuilder
   FIRDialect
   FIRDialectSupport
   FIRSupport
-  FortranEvaluate
   FortranSupport
   HLFIRDialect
   MIFDialect

--- a/flang/lib/Optimizer/Builder/CUDAIntrinsicCall.cpp
+++ b/flang/lib/Optimizer/Builder/CUDAIntrinsicCall.cpp
@@ -14,7 +14,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Optimizer/Builder/CUDAIntrinsicCall.h"
-#include "flang/Evaluate/common.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Builder/MutableBox.h"
 #include "flang/Optimizer/Dialect/CUF/CUFOps.h"

--- a/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
+++ b/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
@@ -15,7 +15,6 @@
 
 #include "flang/Optimizer/Builder/IntrinsicCall.h"
 #include "flang/Common/static-multimap-view.h"
-#include "flang/Lower/AbstractConverter.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
 #include "flang/Optimizer/Builder/CUDAIntrinsicCall.h"
 #include "flang/Optimizer/Builder/CUFCommon.h"
@@ -61,6 +60,16 @@
 #include <optional>
 
 #define DEBUG_TYPE "flang-lower-intrinsic"
+
+static void checkCoarrayEnabled(mlir::Location loc,
+                                const fir::IntrinsicLoweringOptions &options) {
+  if (!options.coarrayEnabled)
+    fir::emitFatalError(
+        loc,
+        "Not yet implemented: Multi-image features are experimental and are "
+        "disabled by default, use '-fcoarray' to enable.",
+        false);
+}
 
 /// This file implements lowering of Fortran intrinsic procedures and Fortran
 /// intrinsic module procedures.  A call may be inlined with a mix of FIR and
@@ -2113,8 +2122,8 @@ genIntrinsicCall(fir::FirOpBuilder &builder, mlir::Location loc,
                  const IntrinsicHandlerEntry &intrinsic,
                  std::optional<mlir::Type> resultType,
                  llvm::ArrayRef<fir::ExtendedValue> args,
-                 Fortran::lower::AbstractConverter *converter) {
-  IntrinsicLibrary library{builder, loc, converter};
+                 fir::IntrinsicLoweringOptions options) {
+  IntrinsicLibrary library{builder, loc, options};
   return std::visit(
       [&](auto handler) -> auto {
         return genIntrinsicCallHelper(handler, resultType, args, library);
@@ -3477,7 +3486,7 @@ mlir::Value IntrinsicLibrary::genCmplx(mlir::Type resultType,
 
 // CO_BROADCAST
 void IntrinsicLibrary::genCoBroadcast(llvm::ArrayRef<fir::ExtendedValue> args) {
-  converter->checkCoarrayEnabled();
+  checkCoarrayEnabled(loc, options);
   assert(args.size() == 4);
   mif::CoBroadcastOp::create(builder, loc, fir::getBase(args[0]),
                              /*sourceImage*/ fir::getBase(args[1]),
@@ -3487,7 +3496,7 @@ void IntrinsicLibrary::genCoBroadcast(llvm::ArrayRef<fir::ExtendedValue> args) {
 
 // CO_MAX
 void IntrinsicLibrary::genCoMax(llvm::ArrayRef<fir::ExtendedValue> args) {
-  converter->checkCoarrayEnabled();
+  checkCoarrayEnabled(loc, options);
   assert(args.size() == 4);
   mif::CoMaxOp::create(builder, loc, fir::getBase(args[0]),
                        /*resultImage*/ fir::getBase(args[1]),
@@ -3497,7 +3506,7 @@ void IntrinsicLibrary::genCoMax(llvm::ArrayRef<fir::ExtendedValue> args) {
 
 // CO_MIN
 void IntrinsicLibrary::genCoMin(llvm::ArrayRef<fir::ExtendedValue> args) {
-  converter->checkCoarrayEnabled();
+  checkCoarrayEnabled(loc, options);
   assert(args.size() == 4);
   mif::CoMinOp::create(builder, loc, fir::getBase(args[0]),
                        /*resultImage*/ fir::getBase(args[1]),
@@ -3507,7 +3516,7 @@ void IntrinsicLibrary::genCoMin(llvm::ArrayRef<fir::ExtendedValue> args) {
 
 // CO_SUM
 void IntrinsicLibrary::genCoSum(llvm::ArrayRef<fir::ExtendedValue> args) {
-  converter->checkCoarrayEnabled();
+  checkCoarrayEnabled(loc, options);
   assert(args.size() == 4);
   mif::CoSumOp::create(builder, loc, fir::getBase(args[0]),
                        /*resultImage*/ fir::getBase(args[1]),
@@ -4227,7 +4236,7 @@ IntrinsicLibrary::genFtell(std::optional<mlir::Type> resultType,
 // GET_TEAM
 mlir::Value IntrinsicLibrary::genGetTeam(mlir::Type resultType,
                                          llvm::ArrayRef<mlir::Value> args) {
-  converter->checkCoarrayEnabled();
+  checkCoarrayEnabled(loc, options);
   assert(args.size() == 1);
   return mif::GetTeamOp::create(builder, loc, fir::BoxType::get(resultType),
                                 /*level*/ args[0]);
@@ -7224,7 +7233,7 @@ IntrinsicLibrary::genNull(mlir::Type, llvm::ArrayRef<fir::ExtendedValue> args) {
 fir::ExtendedValue
 IntrinsicLibrary::genNumImages(mlir::Type resultType,
                                llvm::ArrayRef<fir::ExtendedValue> args) {
-  converter->checkCoarrayEnabled();
+  checkCoarrayEnabled(loc, options);
   assert(args.size() == 0 || args.size() == 1);
 
   if (args.size())
@@ -8273,7 +8282,7 @@ mlir::Value IntrinsicLibrary::genTanpi(mlir::Type resultType,
 fir::ExtendedValue
 IntrinsicLibrary::genTeamNumber(mlir::Type resultType,
                                 llvm::ArrayRef<fir::ExtendedValue> args) {
-  converter->checkCoarrayEnabled();
+  checkCoarrayEnabled(loc, options);
   assert(args.size() == 1);
 
   mlir::Value res = mif::TeamNumberOp::create(builder, loc,
@@ -8285,7 +8294,7 @@ IntrinsicLibrary::genTeamNumber(mlir::Type resultType,
 fir::ExtendedValue
 IntrinsicLibrary::genThisImage(mlir::Type resultType,
                                llvm::ArrayRef<fir::ExtendedValue> args) {
-  converter->checkCoarrayEnabled();
+  checkCoarrayEnabled(loc, options);
   assert(args.size() >= 1 && args.size() <= 3);
   const bool coarrayIsAbsent = args.size() == 1;
   mlir::Value team = fir::getBase(args[args.size() - 1]);
@@ -9280,8 +9289,8 @@ std::pair<fir::ExtendedValue, bool>
 genIntrinsicCall(fir::FirOpBuilder &builder, mlir::Location loc,
                  llvm::StringRef name, std::optional<mlir::Type> resultType,
                  llvm::ArrayRef<fir::ExtendedValue> args,
-                 Fortran::lower::AbstractConverter *converter) {
-  return IntrinsicLibrary{builder, loc, converter}.genIntrinsicCall(
+                 fir::IntrinsicLoweringOptions options) {
+  return IntrinsicLibrary{builder, loc, options}.genIntrinsicCall(
       name, resultType, args);
 }
 

--- a/flang/lib/Optimizer/Builder/PPCIntrinsicCall.cpp
+++ b/flang/lib/Optimizer/Builder/PPCIntrinsicCall.cpp
@@ -14,8 +14,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Optimizer/Builder/PPCIntrinsicCall.h"
-#include "flang/Evaluate/common.h"
-#include "flang/Lower/AbstractConverter.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Builder/MutableBox.h"
 #include "mlir/Dialect/Index/IR/IndexOps.h"
@@ -955,18 +953,15 @@ checkPPCMathOperationsRange(llvm::StringRef name) {
 // Helper functions for vector element ordering.
 bool PPCIntrinsicLibrary::isBEVecElemOrderOnLE() {
   const auto triple{fir::getTargetTriple(builder.getModule())};
-  return (triple.isLittleEndian() &&
-          converter->getLoweringOptions().getNoPPCNativeVecElemOrder());
+  return (triple.isLittleEndian() && options.noPPCNativeVecElemOrder);
 }
 bool PPCIntrinsicLibrary::isNativeVecElemOrderOnLE() {
   const auto triple{fir::getTargetTriple(builder.getModule())};
-  return (triple.isLittleEndian() &&
-          !converter->getLoweringOptions().getNoPPCNativeVecElemOrder());
+  return (triple.isLittleEndian() && !options.noPPCNativeVecElemOrder);
 }
 bool PPCIntrinsicLibrary::changeVecElemOrder() {
   const auto triple{fir::getTargetTriple(builder.getModule())};
-  return (triple.isLittleEndian() !=
-          converter->getLoweringOptions().getNoPPCNativeVecElemOrder());
+  return (triple.isLittleEndian() != options.noPPCNativeVecElemOrder);
 }
 
 static mlir::FunctionType genMmaVpFuncType(mlir::MLIRContext *context,

--- a/flang/lib/Optimizer/Builder/Runtime/Intrinsics.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Intrinsics.cpp
@@ -18,7 +18,6 @@
 #include "flang/Runtime/random.h"
 #include "flang/Runtime/stop.h"
 #include "flang/Runtime/time-intrinsic.h"
-#include "flang/Semantics/tools.h"
 #include "llvm/Support/Debug.h"
 #include <optional>
 #include <signal.h>

--- a/flang/lib/Optimizer/HLFIR/Transforms/CMakeLists.txt
+++ b/flang/lib/Optimizer/HLFIR/Transforms/CMakeLists.txt
@@ -29,7 +29,6 @@ add_flang_library(HLFIRTransforms
   FIRSupport
   FIRTransforms
   FlangOpenMPTransforms
-  FortranEvaluate
   FortranSupport
   HLFIRDialect
 

--- a/flang/lib/Optimizer/Transforms/MIFOpConversion.cpp
+++ b/flang/lib/Optimizer/Transforms/MIFOpConversion.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Optimizer/Transforms/MIFOpConversion.h"
-#include "flang/Lower/ConvertExpr.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
 #include "flang/Optimizer/Builder/Character.h"
 #include "flang/Optimizer/Builder/MIFCommon.h"


### PR DESCRIPTION
Replace usages of `AbstractConverter` inside IntrinsicCall.cpp by a structure that propagates the required option to avoid bringing libFortranEvaluate as a dependency of libFortranOptimizer while the Optimizer is not using evalute::Expr or other front-end data structure at all.

Also remove headers whose include have crept-in and that were never removed while not required.