### PR TITLE
[BOLT] Delay indirect call pointer setup

### DIFF
--- a/bolt/runtime/instr.cpp
+++ b/bolt/runtime/instr.cpp
@@ -1659,8 +1659,6 @@ extern "C" void __bolt_instr_indirect_tailcall();
 
 /// Initialization code
 extern "C" void __attribute((force_align_arg_pointer)) __bolt_instr_setup() {
-  __bolt_ind_call_counter_func_pointer = __bolt_instr_indirect_call;
-  __bolt_ind_tailcall_counter_func_pointer = __bolt_instr_indirect_tailcall;
   TextBaseAddress = getTextBaseAddress();
 
   const uint64_t CountersStart =
@@ -1694,6 +1692,12 @@ extern "C" void __attribute((force_align_arg_pointer)) __bolt_instr_setup() {
   if (__bolt_instr_num_ind_calls > 0)
     GlobalIndCallCounters =
         new (*GlobalAlloc, 0) IndirectCallHashTable[__bolt_instr_num_ind_calls];
+
+  // Set these up after initializing indirect call counters. Otherwise,
+  // background threads spawned through global constructors might try to access
+  // uninitialized counters.
+  __bolt_ind_call_counter_func_pointer = __bolt_instr_indirect_call;
+  __bolt_ind_tailcall_counter_func_pointer = __bolt_instr_indirect_tailcall;
 
   if (__bolt_instr_sleep_time != 0) {
     // Separate instrumented process to the own process group

--- a/bolt/test/runtime/setup-race.cpp
+++ b/bolt/test/runtime/setup-race.cpp
@@ -1,0 +1,45 @@
+// Test that indirect call instrumentation works if background threads are
+// spawned early during application startup. This can be the case with jemalloc,
+// when libstdcxx.so invokes global constructors that call malloc.
+
+// REQUIRES: system-linux
+// RUN: %clangxx %cxxflags -Wl,-q %s -o %t.exe -D_GNU_SOURCE -g
+// RUN: llvm-bolt -instrument %t.exe -o %t.bolt.exe
+// RUN: %t.bolt.exe
+
+#include <atomic>
+#include <dlfcn.h>
+#include <pthread.h>
+
+static pthread_mutex_t M = PTHREAD_MUTEX_INITIALIZER;
+static std::atomic_bool Init;
+static void *(*MallocFn)(size_t);
+static pthread_t Thread;
+
+static void target() {}
+static void (*IndTarget)() = target;
+
+static void *threadFun(void *) {
+  for (int I = 0; I < 1000; ++I)
+    IndTarget();
+  return nullptr;
+}
+
+extern "C" void *malloc(size_t Size) {
+  if (!Init) {
+    pthread_mutex_lock(&M);
+    if (!Init) {
+      MallocFn =
+          reinterpret_cast<decltype(MallocFn)>(dlsym(RTLD_NEXT, "malloc"));
+      Init = true;
+      pthread_create(&Thread, nullptr, threadFun, nullptr);
+    }
+    pthread_mutex_unlock(&M);
+  }
+  return MallocFn(Size);
+}
+
+int main() {
+  pthread_join(Thread, nullptr);
+  return 0;
+}


### PR DESCRIPTION
There is a race in the instrumentation runtime during setup. The setup initializes the function pointers for indirect call instrumentation before the indirect call counters array. If the application spawns a background thread through a constructor (as does jemalloc), the background thread has a chance to derefence that uninitialized array pointer. Defer initialization of these function pointers to prevent this race.

Fixes #198181.