### PR TITLE
[lldb][test] Skip watchpoint and expression tests on WebAssembly

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -918,6 +918,8 @@ def canRunWatchpointTests():
     from lldbsuite.test import lldbplatformutil
 
     platform = lldbplatformutil.getPlatform()
+    if platform.startswith("wasi"):
+        return False, "watchpoints are not supported on WebAssembly"
     if platform == "netbsd":
         if os.geteuid() == 0:
             return True, "root can always write dbregs"
@@ -960,6 +962,18 @@ def checkObjcSupport():
         if configuration.verbose:
             print("objc tests will be skipped because of unsupported platform")
         configuration.skip_categories.append("objc")
+
+
+def checkExpressionSupport():
+    from lldbsuite.test import lldbplatformutil
+
+    # WebAssembly targets cannot JIT or interpret expressions yet.
+    if lldbplatformutil.getPlatform().startswith("wasi"):
+        if "expression" in configuration.categories_list:
+            return  # explicitly requested, let it run.
+        if configuration.verbose:
+            print("expression tests will be skipped because of unsupported platform")
+        configuration.skip_categories.append("expression")
 
 
 def checkDebugInfoSupport():
@@ -1132,6 +1146,7 @@ def run_suite():
     checkDebugInfoSupport()
     checkDebugServerSupport()
     checkObjcSupport()
+    checkExpressionSupport()
     checkForkVForkSupport()
     checkPexpectSupport()
     checkDAPSupport()


### PR DESCRIPTION
WebAssembly has no watchpoint support (Process/wasm reports no watchpoints; the stop reason comes back as a plain signal) and cannot JIT or interpret expressions (ProcessWasm sets CanJIT to false). Teach the existing per-platform category checks about wasm so the whole "watchpoint" and "expression" categories are skipped, rather than decorating each test individually.