### PR TITLE
[RISC-V][MC] Improve the diagnostic for invalid compressed register number

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
@@ -372,6 +372,7 @@ def GPRJALRNonX7 : GPRRegisterClass<(sub GPRJALR, X7)>;
 def GPRC : GPRRegisterClass<(add (sequence "X%u", 10, 15),
                                  (sequence "X%u", 8, 9))> {
   let DecoderMethod = "DecodeSimpleRegisterClass<RISCV::X8, 8>";
+  let DiagnosticString = "register must be a GPR from x8 to x15";
 }
 
 // For indirect tail calls, we can't use callee-saved registers, as they are

--- a/llvm/test/MC/RISCV/rv32c-invalid.s
+++ b/llvm/test/MC/RISCV/rv32c-invalid.s
@@ -6,29 +6,29 @@
 ## GPRC
 .LBB:
 c.lw  ra, 4(sp)
-# CHECK: :[[#@LINE-1]]:7: error: invalid operand for instruction
+# CHECK: :[[#@LINE-1]]:7: error: register must be a GPR from x8 to x15
 c.sw  sp, 4(sp)
-# CHECK: :[[#@LINE-1]]:7: error: invalid operand for instruction
+# CHECK: :[[#@LINE-1]]:7: error: register must be a GPR from x8 to x15
 c.beqz  t0, .LBB
-# CHECK: :[[#@LINE-1]]:9: error: invalid operand for instruction
+# CHECK: :[[#@LINE-1]]:9: error: register must be a GPR from x8 to x15
 c.bnez  s8, .LBB
-# CHECK: :[[#@LINE-1]]:9: error: invalid operand for instruction
+# CHECK: :[[#@LINE-1]]:9: error: register must be a GPR from x8 to x15
 c.addi4spn  s4, sp, 12
-# CHECK: :[[#@LINE-1]]:13: error: invalid operand for instruction
+# CHECK: :[[#@LINE-1]]:13: error: register must be a GPR from x8 to x15
 c.srli  s7, 12
-# CHECK: :[[#@LINE-1]]:9: error: invalid operand for instruction
+# CHECK: :[[#@LINE-1]]:9: error: register must be a GPR from x8 to x15
 c.srai  t0, 12
-# CHECK: :[[#@LINE-1]]:9: error: invalid operand for instruction
+# CHECK: :[[#@LINE-1]]:9: error: register must be a GPR from x8 to x15
 c.andi  t1, 12
-# CHECK: :[[#@LINE-1]]:9: error: invalid operand for instruction
+# CHECK: :[[#@LINE-1]]:9: error: register must be a GPR from x8 to x15
 c.and  t1, a0
-# CHECK: :[[#@LINE-1]]:8: error: invalid operand for instruction
+# CHECK: :[[#@LINE-1]]:8: error: register must be a GPR from x8 to x15
 c.or   a0, s8
-# CHECK: :[[#@LINE-1]]:12: error: invalid operand for instruction
+# CHECK: :[[#@LINE-1]]:12: error: register must be a GPR from x8 to x15
 c.xor  t2, a0
-# CHECK: :[[#@LINE-1]]:8: error: invalid operand for instruction
+# CHECK: :[[#@LINE-1]]:8: error: register must be a GPR from x8 to x15
 c.sub  a0, s8
-# CHECK: :[[#@LINE-1]]:12: error: invalid operand for instruction
+# CHECK: :[[#@LINE-1]]:12: error: register must be a GPR from x8 to x15
 
 ## GPRNoX0
 c.lwsp  x0, 4(sp)

--- a/llvm/test/MC/RISCV/rv64c-invalid.s
+++ b/llvm/test/MC/RISCV/rv64c-invalid.s
@@ -3,13 +3,13 @@
 
 ## GPRC
 c.ld ra, 4(sp)
-# CHECK: :[[#@LINE-1]]:6: error: invalid operand for instruction
+# CHECK: :[[#@LINE-1]]:6: error: register must be a GPR from x8 to x15
 c.sd sp, 4(sp)
-# CHECK: :[[#@LINE-1]]:6: error: invalid operand for instruction
+# CHECK: :[[#@LINE-1]]:6: error: register must be a GPR from x8 to x15
 c.addw   a0, a7
-# CHECK: :[[#@LINE-1]]:14: error: invalid operand for instruction
+# CHECK: :[[#@LINE-1]]:14: error: register must be a GPR from x8 to x15
 c.subw   a0, a6
-# CHECK: :[[#@LINE-1]]:14: error: invalid operand for instruction
+# CHECK: :[[#@LINE-1]]:14: error: register must be a GPR from x8 to x15
 
 ## GPRNoX0
 c.ldsp  x0, 4(sp)

--- a/llvm/test/MC/RISCV/rvc-hints-invalid.s
+++ b/llvm/test/MC/RISCV/rvc-hints-invalid.s
@@ -25,7 +25,7 @@ c.slli x0, 32
 # CHECK-RV32: :[[#@LINE-1]]:12: error: immediate must be an integer in the range [0, 31]
 
 c.srli64 x30
-# CHECK: :[[#@LINE-1]]:10: error: invalid operand for instruction
+# CHECK: :[[#@LINE-1]]:10: error: register must be a GPR from x8 to x15
 
 c.srai64 x31
-# CHECK: :[[#@LINE-1]]:10: error: invalid operand for instruction
+# CHECK: :[[#@LINE-1]]:10: error: register must be a GPR from x8 to x15

--- a/llvm/test/MC/RISCV/xqcibm-invalid.s
+++ b/llvm/test/MC/RISCV/xqcibm-invalid.s
@@ -541,7 +541,7 @@ qc.extdprh x6, x24, x0
 qc.extdprh x6, x24, x25
 
 
-# CHECK-PLUS: :[[@LINE+2]]:12: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:12: error: register must be a GPR from x8 to x15
 # CHECK-MINUS: :[[@LINE+1]]:12: error: invalid operand for instruction
 qc.c.bexti x1, 8
 
@@ -556,7 +556,7 @@ qc.c.bexti x15, 43
 qc.c.bexti x9, 8
 
 
-# CHECK-PLUS: :[[@LINE+2]]:12: error: invalid operand for instruction
+# CHECK-PLUS: :[[@LINE+2]]:12: error: register must be a GPR from x8 to x15
 # CHECK-MINUS: :[[@LINE+1]]:12: error: invalid operand for instruction
 qc.c.bseti x2, 10
 


### PR DESCRIPTION
Instead of a generic `invalid operand for instruction`, print
`register must be a GPR from x8 to x15` instead.
