### PR TITLE
[SPIR-V] Lower nested aggregate insertvalue operands

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -2464,6 +2464,17 @@ SPIRVEmitIntrinsicsImpl::visitExtractValueInst(ExtractValueInst &I) {
     Args.push_back(B.getInt32(Op));
   Instruction *NewI = B.CreateIntrinsicWithoutFolding(Intrinsic::spv_extractv,
                                                       {I.getType()}, {Args});
+  // If this aggregate extract feeds another insertvalue, the extracted
+  // composite is used as a SPIR-V value-id by llvm.spv.insertv. Keep the real
+  // aggregate type in metadata, but expose the value itself as i32 so the
+  // intrinsic signature remains valid.
+  if (NewI->getType()->isAggregateType() &&
+      any_of(I.users(), [](User *U) { return isa<InsertValueInst>(U); })) {
+    AggrConstTypes[NewI] = I.getType();
+    NewI->mutateType(B.getInt32Ty());
+    replaceMemInstrUses(&I, NewI, B);
+    return NewI;
+  }
   replaceAllUsesWithAndErase(B, &I, NewI);
   // If the aggregate result feeds a return or callsite whose type was rewritten
   // to an i32 value-id by SPIRVPrepareFunctions, mutate it to match.

--- a/llvm/test/CodeGen/SPIRV/instructions/insertvalue-nested-extractvalue.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/insertvalue-nested-extractvalue.ll
@@ -1,0 +1,25 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; A nested aggregate extractvalue can produce an aggregate that is then used as
+; the base of another insertvalue. The intermediate aggregate must be lowered as
+; an i32 SPIR-V value-id before it is passed to llvm.spv.insertv.
+
+; CHECK-DAG: %[[#I64:]] = OpTypeInt 64
+; CHECK-DAG: %[[#ONE:]] = OpConstant %[[#]] 1
+; CHECK-DAG: %[[#INNER:]] = OpTypeArray %[[#I64]] %[[#ONE]]
+; CHECK-DAG: %[[#OUTER:]] = OpTypeArray %[[#INNER]] %[[#ONE]]
+
+; CHECK: OpFunction
+; CHECK: %[[#A:]] = OpFunctionParameter %[[#OUTER]]
+; CHECK: %[[#X:]] = OpFunctionParameter %[[#I64]]
+; CHECK: %[[#E:]] = OpCompositeExtract %[[#INNER]] %[[#A]] 0
+; CHECK: %[[#I:]] = OpCompositeInsert %[[#INNER]] %[[#X]] %[[#E]] 0
+; CHECK: %[[#R:]] = OpCompositeInsert %[[#OUTER]] %[[#I]] %[[#A]] 0
+; CHECK: OpReturnValue %[[#R]]
+define spir_func [1 x [1 x i64]] @f([1 x [1 x i64]] %a, i64 %x) {
+  %e = extractvalue [1 x [1 x i64]] %a, 0
+  %i = insertvalue [1 x i64] %e, i64 %x, 0
+  %r = insertvalue [1 x [1 x i64]] %a, [1 x i64] %i, 0
+  ret [1 x [1 x i64]] %r
+}


### PR DESCRIPTION
Fix a crash in the SPIR-V backend when an aggregate `extractvalue` result is used as the base of a later `insertvalue`.

The failing pattern is:

```llvm
%e = extractvalue [1 x [1 x i64]] %a, 0
%i = insertvalue [1 x i64] %e, i64 %x, 0
%r = insertvalue [1 x [1 x i64]] %a, [1 x i64] %i, 0
```

`SPIRVPrepareFunctions` rewrites aggregate function arguments and returns to `i32` SPIR-V value IDs. The `llvm.spv.insertv` intrinsic also models its composite operand as an `i32` value ID. However, an intermediate aggregate `extractvalue` could still be rewritten to `llvm.spv.extractv` with an LLVM aggregate result type. Passing that aggregate-typed value to `llvm.spv.insertv` made `IRBuilder::CreateIntrinsic` create a call with a mismatched signature and assert.

This patch mutates aggregate-result `llvm.spv.extractv` values that feed `insertvalue` to `i32`, while preserving the original aggregate type in the existing aggregate type metadata path. Selection then emits the expected SPIR-V:

```spirv
%inner = OpCompositeExtract %Inner %outer 0
%new_inner = OpCompositeInsert %Inner %x %inner 0
%new_outer = OpCompositeInsert %Outer %new_inner %outer 0
```