### PR TITLE
[RISC-V] Rename GPRCMem operand to BasePtrC. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -238,7 +238,7 @@ def BasePtr : MemOperand<GPR>;
 
 def SPMem : MemOperand<SP>;
 
-def GPRCMem : MemOperand<GPRC>;
+def BasePtrC : MemOperand<GPRC>;
 
 class SImmAsmOperand<int width, string suffix = "">
     : ImmAsmOperand<"S", width, suffix> {

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoC.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoC.td
@@ -218,13 +218,13 @@ class CStackStore<bits<3> funct3, string OpcodeStr,
 let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 class CLoad_ri<bits<3> funct3, string OpcodeStr,
                DAGOperand cls, DAGOperand opnd>
-    : RVInst16CL<funct3, OPC_C0, (outs cls:$rd), (ins GPRCMem:$rs1, opnd:$imm),
+    : RVInst16CL<funct3, OPC_C0, (outs cls:$rd), (ins BasePtrC:$rs1, opnd:$imm),
                  OpcodeStr, "$rd, ${imm}(${rs1})">;
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 class CStore_rri<bits<3> funct3, string OpcodeStr,
                  DAGOperand cls, DAGOperand opnd>
-    : RVInst16CS<funct3, OPC_C0, (outs), (ins cls:$rs2,GPRCMem:$rs1, opnd:$imm),
+    : RVInst16CS<funct3, OPC_C0, (outs), (ins cls:$rs2,BasePtrC:$rs1, opnd:$imm),
                  OpcodeStr, "$rs2, ${imm}(${rs1})">;
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
@@ -606,29 +606,29 @@ def : InstAlias<"c.ntl.all", (C_ADD X0, X5)>;
 
 let EmitPriority = 0 in {
 let Predicates = [HasStdExtZca] in {
-def : InstAlias<"c.lw $rd, (${rs1})", (C_LW GPRC:$rd, GPRCMem:$rs1, 0)>;
-def : InstAlias<"c.sw $rs2, (${rs1})", (C_SW GPRC:$rs2, GPRCMem:$rs1, 0)>;
+def : InstAlias<"c.lw $rd, (${rs1})", (C_LW GPRC:$rd, BasePtrC:$rs1, 0)>;
+def : InstAlias<"c.sw $rs2, (${rs1})", (C_SW GPRC:$rs2, BasePtrC:$rs1, 0)>;
 def : InstAlias<"c.lwsp $rd, (${rs1})", (C_LWSP GPRNoX0:$rd, SPMem:$rs1, 0)>;
 def : InstAlias<"c.swsp $rs2, (${rs1})", (C_SWSP GPR:$rs2, SPMem:$rs1, 0)>;
 }
 
 let Predicates = [HasStdExtZca, IsRV64] in {
-def : InstAlias<"c.ld $rd, (${rs1})", (C_LD GPRC:$rd, GPRCMem:$rs1, 0)>;
-def : InstAlias<"c.sd $rs2, (${rs1})", (C_SD GPRC:$rs2, GPRCMem:$rs1, 0)>;
+def : InstAlias<"c.ld $rd, (${rs1})", (C_LD GPRC:$rd, BasePtrC:$rs1, 0)>;
+def : InstAlias<"c.sd $rs2, (${rs1})", (C_SD GPRC:$rs2, BasePtrC:$rs1, 0)>;
 def : InstAlias<"c.ldsp $rd, (${rs1})", (C_LDSP GPRNoX0:$rd, SPMem:$rs1, 0)>;
 def : InstAlias<"c.sdsp $rs2, (${rs1})", (C_SDSP GPR:$rs2, SPMem:$rs1, 0)>;
 }
 
 let Predicates = [HasStdExtZcf, IsRV32] in {
-def : InstAlias<"c.flw $rd, (${rs1})", (C_FLW FPR32C:$rd, GPRCMem:$rs1, 0)>;
-def : InstAlias<"c.fsw $rs2, (${rs1})", (C_FSW FPR32C:$rs2, GPRCMem:$rs1, 0)>;
+def : InstAlias<"c.flw $rd, (${rs1})", (C_FLW FPR32C:$rd, BasePtrC:$rs1, 0)>;
+def : InstAlias<"c.fsw $rs2, (${rs1})", (C_FSW FPR32C:$rs2, BasePtrC:$rs1, 0)>;
 def : InstAlias<"c.flwsp $rd, (${rs1})", (C_FLWSP FPR32:$rd, SPMem:$rs1, 0)>;
 def : InstAlias<"c.fswsp $rs2, (${rs1})", (C_FSWSP FPR32:$rs2, SPMem:$rs1, 0)>;
 }
 
 let Predicates = [HasStdExtZcd] in {
-def : InstAlias<"c.fld $rd, (${rs1})", (C_FLD FPR64C:$rd, GPRCMem:$rs1, 0)>;
-def : InstAlias<"c.fsd $rs2, (${rs1})", (C_FSD FPR64C:$rs2, GPRCMem:$rs1, 0)>;
+def : InstAlias<"c.fld $rd, (${rs1})", (C_FLD FPR64C:$rd, BasePtrC:$rs1, 0)>;
+def : InstAlias<"c.fsd $rs2, (${rs1})", (C_FSD FPR64C:$rs2, BasePtrC:$rs1, 0)>;
 def : InstAlias<"c.fldsp $rd, (${rs1})", (C_FLDSP FPR64:$rd, SPMem:$rs1, 0)>;
 def : InstAlias<"c.fsdsp $rs2, (${rs1})", (C_FSDSP FPR64:$rs2, SPMem:$rs1, 0)>;
 }
@@ -748,28 +748,28 @@ let Predicates = [HasStdExtZca] in {
 def : CompressPat<(ADDI GPRC:$rd, SP:$rs1, uimm10_lsb00nonzero:$imm),
                   (C_ADDI4SPN GPRC:$rd, SP:$rs1, uimm10_lsb00nonzero:$imm)>;
 
-def : CompressPat<(LW GPRC:$rd, GPRCMem:$rs1, uimm7_lsb00:$imm),
-                  (C_LW GPRC:$rd, GPRCMem:$rs1, uimm7_lsb00:$imm)>;
+def : CompressPat<(LW GPRC:$rd, BasePtrC:$rs1, uimm7_lsb00:$imm),
+                  (C_LW GPRC:$rd, BasePtrC:$rs1, uimm7_lsb00:$imm)>;
 
 let isCompressOnly = true in
-def : CompressPat<(LW_INX GPRF32C:$rd, GPRCMem:$rs1, uimm7_lsb00:$imm),
-                  (C_LW_INX GPRF32C:$rd, GPRCMem:$rs1, uimm7_lsb00:$imm)>;
+def : CompressPat<(LW_INX GPRF32C:$rd, BasePtrC:$rs1, uimm7_lsb00:$imm),
+                  (C_LW_INX GPRF32C:$rd, BasePtrC:$rs1, uimm7_lsb00:$imm)>;
 
 let append Predicates = [IsRV64] in {
-def : CompressPat<(LD GPRC:$rd, GPRCMem:$rs1, uimm8_lsb000:$imm),
-                  (C_LD GPRC:$rd, GPRCMem:$rs1, uimm8_lsb000:$imm)>;
+def : CompressPat<(LD GPRC:$rd, BasePtrC:$rs1, uimm8_lsb000:$imm),
+                  (C_LD GPRC:$rd, BasePtrC:$rs1, uimm8_lsb000:$imm)>;
 } // append Predicates = [IsRV64]
 
-def : CompressPat<(SW GPRC:$rs2, GPRCMem:$rs1, uimm7_lsb00:$imm),
-                  (C_SW GPRC:$rs2, GPRCMem:$rs1, uimm7_lsb00:$imm)>;
+def : CompressPat<(SW GPRC:$rs2, BasePtrC:$rs1, uimm7_lsb00:$imm),
+                  (C_SW GPRC:$rs2, BasePtrC:$rs1, uimm7_lsb00:$imm)>;
 
 let isCompressOnly = true in
-def : CompressPat<(SW_INX GPRF32C:$rs2, GPRCMem:$rs1, uimm7_lsb00:$imm),
-                  (C_SW_INX GPRF32C:$rs2, GPRCMem:$rs1, uimm7_lsb00:$imm)>;
+def : CompressPat<(SW_INX GPRF32C:$rs2, BasePtrC:$rs1, uimm7_lsb00:$imm),
+                  (C_SW_INX GPRF32C:$rs2, BasePtrC:$rs1, uimm7_lsb00:$imm)>;
 
 let append Predicates = [IsRV64] in {
-def : CompressPat<(SD GPRC:$rs2, GPRCMem:$rs1, uimm8_lsb000:$imm),
-                  (C_SD GPRC:$rs2, GPRCMem:$rs1, uimm8_lsb000:$imm)>;
+def : CompressPat<(SD GPRC:$rs2, BasePtrC:$rs1, uimm8_lsb000:$imm),
+                  (C_SD GPRC:$rs2, BasePtrC:$rs1, uimm8_lsb000:$imm)>;
 } // append Predicates = [IsRV64]
 } // Predicates = [HasStdExtZca]
 
@@ -899,10 +899,10 @@ def : CompressPat<(SD GPR:$rs2, SPMem:$rs1, uimm9_lsb000:$imm),
 // Zcf Instructions
 let Predicates = [HasStdExtZcf, IsRV32] in {
   // Quadrant 0
-  def : CompressPat<(FLW FPR32C:$rd, GPRCMem:$rs1, uimm7_lsb00:$imm),
-                    (C_FLW FPR32C:$rd, GPRCMem:$rs1, uimm7_lsb00:$imm)>;
-  def : CompressPat<(FSW FPR32C:$rs2, GPRCMem:$rs1, uimm7_lsb00:$imm),
-                    (C_FSW FPR32C:$rs2, GPRCMem:$rs1, uimm7_lsb00:$imm)>;
+  def : CompressPat<(FLW FPR32C:$rd, BasePtrC:$rs1, uimm7_lsb00:$imm),
+                    (C_FLW FPR32C:$rd, BasePtrC:$rs1, uimm7_lsb00:$imm)>;
+  def : CompressPat<(FSW FPR32C:$rs2, BasePtrC:$rs1, uimm7_lsb00:$imm),
+                    (C_FSW FPR32C:$rs2, BasePtrC:$rs1, uimm7_lsb00:$imm)>;
 
   // Quadrant 2
   def : CompressPat<(FLW FPR32:$rd, SPMem:$rs1, uimm8_lsb00:$imm),
@@ -914,10 +914,10 @@ let Predicates = [HasStdExtZcf, IsRV32] in {
 // Zcd Instructions
 let Predicates = [HasStdExtZcd] in {
   // Quadrant 0
-  def : CompressPat<(FLD FPR64C:$rd, GPRCMem:$rs1, uimm8_lsb000:$imm),
-                    (C_FLD FPR64C:$rd, GPRCMem:$rs1, uimm8_lsb000:$imm)>;
-  def : CompressPat<(FSD FPR64C:$rs2, GPRCMem:$rs1, uimm8_lsb000:$imm),
-                    (C_FSD FPR64C:$rs2, GPRCMem:$rs1, uimm8_lsb000:$imm)>;
+  def : CompressPat<(FLD FPR64C:$rd, BasePtrC:$rs1, uimm8_lsb000:$imm),
+                    (C_FLD FPR64C:$rd, BasePtrC:$rs1, uimm8_lsb000:$imm)>;
+  def : CompressPat<(FSD FPR64C:$rs2, BasePtrC:$rs1, uimm8_lsb000:$imm),
+                    (C_FSD FPR64C:$rs2, BasePtrC:$rs1, uimm8_lsb000:$imm)>;
 
   // Quadrant 2
   def : CompressPat<(FLD FPR64:$rd, SPMem:$rs1, uimm9_lsb000:$imm),

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoC.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoC.td
@@ -224,7 +224,7 @@ class CLoad_ri<bits<3> funct3, string OpcodeStr,
 let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 class CStore_rri<bits<3> funct3, string OpcodeStr,
                  DAGOperand cls, DAGOperand opnd>
-    : RVInst16CS<funct3, OPC_C0, (outs), (ins cls:$rs2,BasePtrC:$rs1, opnd:$imm),
+    : RVInst16CS<funct3, OPC_C0, (outs), (ins cls:$rs2, BasePtrC:$rs1, opnd:$imm),
                  OpcodeStr, "$rs2, ${imm}(${rs1})">;
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
@@ -1437,26 +1437,26 @@ let hasSideEffects = false, mayLoad = true, mayStore = false, Size = 2,
     isCodeGenOnly = false in
 class PseudoQCAccessCLoad_ri<string opcodestr, DAGOperand immop>
   : Pseudo<(outs GPRC:$rd),
-           (ins GPRCMem:$rs1, immop:$imm, qc_access_symbol:$expr),
+           (ins BasePtrC:$rs1, immop:$imm, qc_access_symbol:$expr),
            [], opcodestr, "$rd, ${imm}(${rs1}), $expr">;
 
 let hasSideEffects = false, mayLoad = false, mayStore = true, Size = 2,
     isCodeGenOnly = false in
 class PseudoQCAccessCStore_rri<string opcodestr, DAGOperand immop>
   : Pseudo<(outs),
-           (ins GPRC:$rs2, GPRCMem:$rs1, immop:$imm, qc_access_symbol:$expr),
+           (ins GPRC:$rs2, BasePtrC:$rs1, immop:$imm, qc_access_symbol:$expr),
            [], opcodestr, "$rs2, ${imm}(${rs1}), $expr">;
 
 let Predicates = [IsRV32, HasStdExtZca] in {
 def PseudoQCAccessC_LW : PseudoQCAccessCLoad_ri<"c.lw", uimm7_lsb00>;
 let EmitPriority = 0 in
 def : InstAlias<"c.lw $rd, (${rs1}), $expr",
-                (PseudoQCAccessC_LW GPRC:$rd, GPRCMem:$rs1, 0, qc_access_symbol:$expr)>;
+                (PseudoQCAccessC_LW GPRC:$rd, BasePtrC:$rs1, 0, qc_access_symbol:$expr)>;
 
 def PseudoQCAccessC_SW : PseudoQCAccessCStore_rri<"c.sw", uimm7_lsb00>;
 let EmitPriority = 0 in
 def : InstAlias<"c.sw $rs2, (${rs1}), $expr",
-               (PseudoQCAccessC_SW GPRC:$rs2, GPRCMem:$rs1, 0, qc_access_symbol:$expr)>;
+               (PseudoQCAccessC_SW GPRC:$rs2, BasePtrC:$rs1, 0, qc_access_symbol:$expr)>;
 }
 
 let Predicates = [IsRV32, HasStdExtZcb] in {
@@ -1468,11 +1468,11 @@ def PseudoQCAccessC_LHU : PseudoQCAccessCLoad_ri<"c.lhu", uimm2_lsb0>;
 let EmitPriority = 0 in {
 // No c.lb so no alias
 def : InstAlias<"c.lbu $rd, (${rs1}), $expr",
-                (PseudoQCAccessC_LBU GPRC:$rd, GPRCMem:$rs1, 0, qc_access_symbol:$expr)>;
+                (PseudoQCAccessC_LBU GPRC:$rd, BasePtrC:$rs1, 0, qc_access_symbol:$expr)>;
 def : InstAlias<"c.lh $rd, (${rs1}), $expr",
-                (PseudoQCAccessC_LH GPRC:$rd, GPRCMem:$rs1, 0, qc_access_symbol:$expr)>;
+                (PseudoQCAccessC_LH GPRC:$rd, BasePtrC:$rs1, 0, qc_access_symbol:$expr)>;
 def : InstAlias<"c.lhu $rd, (${rs1}), $expr",
-                (PseudoQCAccessC_LHU GPRC:$rd, GPRCMem:$rs1, 0, qc_access_symbol:$expr)>;
+                (PseudoQCAccessC_LHU GPRC:$rd, BasePtrC:$rs1, 0, qc_access_symbol:$expr)>;
 }
 
 def PseudoQCAccessC_SB : PseudoQCAccessCStore_rri<"c.sb", uimm2>;
@@ -1480,16 +1480,16 @@ def PseudoQCAccessC_SH : PseudoQCAccessCStore_rri<"c.sh", uimm2_lsb0>;
 
 let EmitPriority = 0 in {
 def : InstAlias<"c.sb $rs2, (${rs1}), $expr",
-                (PseudoQCAccessC_SB GPRC:$rs2, GPRCMem:$rs1, 0, qc_access_symbol:$expr)>;
+                (PseudoQCAccessC_SB GPRC:$rs2, BasePtrC:$rs1, 0, qc_access_symbol:$expr)>;
 def : InstAlias<"c.sh $rs2, (${rs1}), $expr",
-                (PseudoQCAccessC_SH GPRC:$rs2, GPRCMem:$rs1, 0, qc_access_symbol:$expr)>;
+                (PseudoQCAccessC_SH GPRC:$rs2, BasePtrC:$rs1, 0, qc_access_symbol:$expr)>;
 }
 }
 
 // FIXME: We would like to add these but they are not supported by CompressPat.
 // let Predicates = [HasVendorXqcili, HasStdExtZca] in {
-// def : CompressPat<(PseudoQCAccessLW GPRC:$rd, GPRCMem:$rs1, uimm7_lsb00:$imm, qc_access_symbol:$expr),
-//                   (PseudoQCAccessC_LW GPRC:$rd, GPRCMem:$rs1, uimm7_lsb00:$imm, qc_access_symbol:$expr)>;
+// def : CompressPat<(PseudoQCAccessLW GPRC:$rd, BasePtrC:$rs1, uimm7_lsb00:$imm, qc_access_symbol:$expr),
+//                   (PseudoQCAccessC_LW GPRC:$rd, BasePtrC:$rs1, uimm7_lsb00:$imm, qc_access_symbol:$expr)>;
 // }
 
 
@@ -1896,20 +1896,20 @@ def : CompressPat<(QC_SYNCWF uimm5slist:$imm5), (QC_C_SYNCWF uimm5slist:$imm5)>;
 
 let isCompressOnly = true, Predicates = [HasVendorXqcilo, IsRV32] in {
 let append Predicates = [HasStdExtZcb] in {
-def : CompressPat<(QC_E_LBU GPRC:$rd, GPRCMem:$rs1, uimm2:$imm),
-                  (C_LBU GPRC:$rd, GPRCMem:$rs1, uimm2:$imm)>;
-def : CompressPat<(QC_E_LHU GPRC:$rd, GPRCMem:$rs1, uimm2_lsb0:$imm),
-                  (C_LHU GPRC:$rd, GPRCMem:$rs1, uimm2_lsb0:$imm)>;
-def : CompressPat<(QC_E_LH GPRC:$rd, GPRCMem:$rs1, uimm2_lsb0:$imm),
-                  (C_LH GPRC:$rd, GPRCMem:$rs1, uimm2_lsb0:$imm)>;
-def : CompressPat<(QC_E_SB GPRC:$rs2, GPRCMem:$rs1, uimm2:$imm),
-                  (C_SB GPRC:$rs2, GPRCMem:$rs1, uimm2:$imm)>;
-def : CompressPat<(QC_E_SH GPRC:$rs2, GPRCMem:$rs1, uimm2_lsb0:$imm),
-                  (C_SH GPRC:$rs2, GPRCMem:$rs1, uimm2_lsb0:$imm)>;
+def : CompressPat<(QC_E_LBU GPRC:$rd, BasePtrC:$rs1, uimm2:$imm),
+                  (C_LBU GPRC:$rd, BasePtrC:$rs1, uimm2:$imm)>;
+def : CompressPat<(QC_E_LHU GPRC:$rd, BasePtrC:$rs1, uimm2_lsb0:$imm),
+                  (C_LHU GPRC:$rd, BasePtrC:$rs1, uimm2_lsb0:$imm)>;
+def : CompressPat<(QC_E_LH GPRC:$rd, BasePtrC:$rs1, uimm2_lsb0:$imm),
+                  (C_LH GPRC:$rd, BasePtrC:$rs1, uimm2_lsb0:$imm)>;
+def : CompressPat<(QC_E_SB GPRC:$rs2, BasePtrC:$rs1, uimm2:$imm),
+                  (C_SB GPRC:$rs2, BasePtrC:$rs1, uimm2:$imm)>;
+def : CompressPat<(QC_E_SH GPRC:$rs2, BasePtrC:$rs1, uimm2_lsb0:$imm),
+                  (C_SH GPRC:$rs2, BasePtrC:$rs1, uimm2_lsb0:$imm)>;
 } // append Predicates = [HasStdExtZcb]
 
-def : CompressPat<(QC_E_LW GPRC:$rd, GPRCMem:$rs1, uimm7_lsb00:$imm),
-                  (C_LW GPRC:$rd, GPRCMem:$rs1, uimm7_lsb00:$imm)>;
+def : CompressPat<(QC_E_LW GPRC:$rd, BasePtrC:$rs1, uimm7_lsb00:$imm),
+                  (C_LW GPRC:$rd, BasePtrC:$rs1, uimm7_lsb00:$imm)>;
 def : CompressPat<(QC_E_LW GPRNoX0:$rd, SPMem:$rs1,  uimm8_lsb00:$imm),
                   (C_LWSP GPRNoX0:$rd, SPMem:$rs1, uimm8_lsb00:$imm)>;
 def : CompressPat<(QC_E_LB GPR:$rd, BasePtr:$rs1, simm12_lo:$imm12),
@@ -1923,8 +1923,8 @@ def : CompressPat<(QC_E_LHU GPR:$rd, BasePtr:$rs1, simm12_lo:$imm12),
 def : CompressPat<(QC_E_LW GPR:$rd, BasePtr:$rs1, simm12_lo:$imm12),
                   (LW GPR:$rd, BasePtr:$rs1, simm12_lo:$imm12)>;
 
-def : CompressPat<(QC_E_SW GPRC:$rs2, GPRCMem:$rs1, uimm7_lsb00:$imm),
-                  (C_SW GPRC:$rs2, GPRCMem:$rs1, uimm7_lsb00:$imm)>;
+def : CompressPat<(QC_E_SW GPRC:$rs2, BasePtrC:$rs1, uimm7_lsb00:$imm),
+                  (C_SW GPRC:$rs2, BasePtrC:$rs1, uimm7_lsb00:$imm)>;
 def : CompressPat<(QC_E_SW GPR:$rs2, SPMem:$rs1, uimm8_lsb00:$imm),
                   (C_SWSP GPR:$rs2, SPMem:$rs1, uimm8_lsb00:$imm)>;
 def : CompressPat<(QC_E_SB GPR:$rs2, BasePtr:$rs1, simm12_lo:$imm12),

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXwch.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXwch.td
@@ -38,7 +38,7 @@ let Predicates = [HasVendorXwchc], DecoderNamespace = "Xwchc" in {
 
 let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 def QK_C_LBU : RVInst16CL<0b001, OPC_C0, (outs GPRC:$rd),
-                          (ins GPRCMem:$rs1, uimm5:$imm),
+                          (ins BasePtrC:$rs1, uimm5:$imm),
                           "qk.c.lbu", "$rd, ${imm}(${rs1})">,
                Sched<[WriteLDB, ReadMemBase]> {
   bits<5> imm;
@@ -48,7 +48,7 @@ def QK_C_LBU : RVInst16CL<0b001, OPC_C0, (outs GPRC:$rd),
 }
 let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 def QK_C_SB : RVInst16CS<0b101, OPC_C0, (outs),
-                         (ins GPRC:$rs2, GPRCMem:$rs1,
+                         (ins GPRC:$rs2, BasePtrC:$rs1,
                               uimm5:$imm),
                          "qk.c.sb", "$rs2, ${imm}(${rs1})">,
               Sched<[WriteSTB, ReadStoreData, ReadMemBase]> {
@@ -60,7 +60,7 @@ def QK_C_SB : RVInst16CS<0b101, OPC_C0, (outs),
 
 let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 def QK_C_LHU : RVInst16CL<0b001, OPC_C2, (outs GPRC:$rd),
-                          (ins GPRCMem:$rs1, uimm6_lsb0:$imm),
+                          (ins BasePtrC:$rs1, uimm6_lsb0:$imm),
                           "qk.c.lhu", "$rd, ${imm}(${rs1})">,
                Sched<[WriteLDH, ReadMemBase]> {
   bits<6> imm;
@@ -69,7 +69,7 @@ def QK_C_LHU : RVInst16CL<0b001, OPC_C2, (outs GPRC:$rd),
 }
 let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 def QK_C_SH : RVInst16CS<0b101, OPC_C2, (outs),
-                         (ins GPRC:$rs2, GPRCMem:$rs1, uimm6_lsb0:$imm),
+                         (ins GPRC:$rs2, BasePtrC:$rs1, uimm6_lsb0:$imm),
                          "qk.c.sh", "$rs2, ${imm}(${rs1})">,
               Sched<[WriteSTH, ReadStoreData, ReadMemBase]> {
   bits<6> imm;
@@ -126,10 +126,10 @@ def QK_C_SHSP : QKStackInst<0b11, (outs),
 
 let EmitPriority = 0 in {
 let Predicates = [HasVendorXwchc] in {
-def : InstAlias<"qk.c.lbu $rd, (${rs1})", (QK_C_LBU GPRC:$rd, GPRCMem:$rs1, 0)>;
-def : InstAlias<"qk.c.sb $rs2, (${rs1})", (QK_C_SB GPRC:$rs2, GPRCMem:$rs1, 0)>;
-def : InstAlias<"qk.c.lhu $rd, (${rs1})", (QK_C_LHU GPRC:$rd, GPRCMem:$rs1, 0)>;
-def : InstAlias<"qk.c.sh $rs2, (${rs1})", (QK_C_SH GPRC:$rs2, GPRCMem:$rs1, 0)>;
+def : InstAlias<"qk.c.lbu $rd, (${rs1})", (QK_C_LBU GPRC:$rd, BasePtrC:$rs1, 0)>;
+def : InstAlias<"qk.c.sb $rs2, (${rs1})", (QK_C_SB GPRC:$rs2, BasePtrC:$rs1, 0)>;
+def : InstAlias<"qk.c.lhu $rd, (${rs1})", (QK_C_LHU GPRC:$rd, BasePtrC:$rs1, 0)>;
+def : InstAlias<"qk.c.sh $rs2, (${rs1})", (QK_C_SH GPRC:$rs2, BasePtrC:$rs1, 0)>;
 def : InstAlias<"qk.c.lbusp $rd, (${rs1})", (QK_C_LBUSP GPRC:$rd, SPMem:$rs1, 0)>;
 def : InstAlias<"qk.c.sbsp $rs2, (${rs1})", (QK_C_SBSP GPRC:$rs2, SPMem:$rs1, 0)>;
 def : InstAlias<"qk.c.lhusp $rd, (${rs1})", (QK_C_LHUSP GPRC:$rd, SPMem:$rs1, 0)>;
@@ -142,14 +142,14 @@ def : InstAlias<"qk.c.shsp $rs2, (${rs1})", (QK_C_SHSP GPRC:$rs2, SPMem:$rs1, 0)
 //===----------------------------------------------------------------------===//
 
 let Predicates = [HasVendorXwchc] in {
-def : CompressPat<(LBU GPRC:$rd, GPRCMem:$rs1, uimm5:$imm),
-                  (QK_C_LBU GPRC:$rd, GPRCMem:$rs1, uimm5:$imm)>;
-def : CompressPat<(SB GPRC:$rs2, GPRCMem:$rs1, uimm5:$imm),
-                  (QK_C_SB GPRC:$rs2, GPRCMem:$rs1, uimm5:$imm)>;
-def : CompressPat<(LHU GPRC:$rd, GPRCMem:$rs1, uimm6_lsb0:$imm),
-                  (QK_C_LHU GPRC:$rd, GPRCMem:$rs1, uimm6_lsb0:$imm)>;
-def : CompressPat<(SH GPRC:$rs2, GPRCMem:$rs1, uimm6_lsb0:$imm),
-                  (QK_C_SH GPRC:$rs2, GPRCMem:$rs1, uimm6_lsb0:$imm)>;
+def : CompressPat<(LBU GPRC:$rd, BasePtrC:$rs1, uimm5:$imm),
+                  (QK_C_LBU GPRC:$rd, BasePtrC:$rs1, uimm5:$imm)>;
+def : CompressPat<(SB GPRC:$rs2, BasePtrC:$rs1, uimm5:$imm),
+                  (QK_C_SB GPRC:$rs2, BasePtrC:$rs1, uimm5:$imm)>;
+def : CompressPat<(LHU GPRC:$rd, BasePtrC:$rs1, uimm6_lsb0:$imm),
+                  (QK_C_LHU GPRC:$rd, BasePtrC:$rs1, uimm6_lsb0:$imm)>;
+def : CompressPat<(SH GPRC:$rs2, BasePtrC:$rs1, uimm6_lsb0:$imm),
+                  (QK_C_SH GPRC:$rs2, BasePtrC:$rs1, uimm6_lsb0:$imm)>;
 def : CompressPat<(LBU GPRC:$rd, SPMem:$rs1,   uimm4:$imm),
                   (QK_C_LBUSP GPRC:$rd, SPMem:$rs1, uimm4:$imm)>;
 def : CompressPat<(SB GPRC:$rs2, SPMem:$rs1,   uimm4:$imm),

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZc.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZc.td
@@ -93,7 +93,7 @@ def negstackadj : RISCVOp<OtherVT> {
 let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 class CLoadB_ri<bits<6> funct6, string OpcodeStr>
     : RVInst16CLB<funct6, OPC_C0, (outs GPRC:$rd),
-                  (ins GPRCMem:$rs1, uimm2:$imm),
+                  (ins BasePtrC:$rs1, uimm2:$imm),
                   OpcodeStr, "$rd, ${imm}(${rs1})"> {
   bits<2> imm;
 
@@ -104,7 +104,7 @@ let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 class CLoadH_ri<bits<6> funct6, bit funct1, string OpcodeStr,
                 DAGOperand rty = GPRC>
     : RVInst16CLH<funct6, funct1, OPC_C0, (outs rty:$rd),
-                  (ins GPRCMem:$rs1, uimm2_lsb0:$imm),
+                  (ins BasePtrC:$rs1, uimm2_lsb0:$imm),
                   OpcodeStr, "$rd, ${imm}(${rs1})"> {
   bits<2> imm;
 
@@ -114,7 +114,7 @@ class CLoadH_ri<bits<6> funct6, bit funct1, string OpcodeStr,
 let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 class CStoreB_rri<bits<6> funct6, string OpcodeStr>
     : RVInst16CSB<funct6, OPC_C0, (outs),
-                  (ins GPRC:$rs2, GPRCMem:$rs1, uimm2:$imm),
+                  (ins GPRC:$rs2, BasePtrC:$rs1, uimm2:$imm),
                   OpcodeStr, "$rs2, ${imm}(${rs1})"> {
   bits<2> imm;
 
@@ -125,7 +125,7 @@ let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 class CStoreH_rri<bits<6> funct6, bit funct1, string OpcodeStr,
                   DAGOperand rty = GPRC>
     : RVInst16CSH<funct6, funct1, OPC_C0, (outs),
-                  (ins rty:$rs2, GPRCMem:$rs1, uimm2_lsb0:$imm),
+                  (ins rty:$rs2, BasePtrC:$rs1, uimm2_lsb0:$imm),
                   OpcodeStr, "$rs2, ${imm}(${rs1})"> {
   bits<2> imm;
 
@@ -307,22 +307,22 @@ def : CompressPat<(XORI GPRC:$rs1, GPRC:$rs1, -1),
 }
 
 let Predicates = [HasStdExtZcb] in{
-def : CompressPat<(LBU GPRC:$rd, GPRCMem:$rs1, uimm2:$imm),
-                  (C_LBU GPRC:$rd, GPRCMem:$rs1, uimm2:$imm)>;
-def : CompressPat<(LHU GPRC:$rd, GPRCMem:$rs1, uimm2_lsb0:$imm),
-                  (C_LHU GPRC:$rd, GPRCMem:$rs1, uimm2_lsb0:$imm)>;
-def : CompressPat<(LH GPRC:$rd, GPRCMem:$rs1, uimm2_lsb0:$imm),
-                  (C_LH GPRC:$rd, GPRCMem:$rs1, uimm2_lsb0:$imm)>;
-def : CompressPat<(SB GPRC:$rs2, GPRCMem:$rs1, uimm2:$imm),
-                  (C_SB GPRC:$rs2, GPRCMem:$rs1, uimm2:$imm)>;
-def : CompressPat<(SH GPRC:$rs2, GPRCMem:$rs1, uimm2_lsb0:$imm),
-                  (C_SH GPRC:$rs2, GPRCMem:$rs1, uimm2_lsb0:$imm)>;
+def : CompressPat<(LBU GPRC:$rd, BasePtrC:$rs1, uimm2:$imm),
+                  (C_LBU GPRC:$rd, BasePtrC:$rs1, uimm2:$imm)>;
+def : CompressPat<(LHU GPRC:$rd, BasePtrC:$rs1, uimm2_lsb0:$imm),
+                  (C_LHU GPRC:$rd, BasePtrC:$rs1, uimm2_lsb0:$imm)>;
+def : CompressPat<(LH GPRC:$rd, BasePtrC:$rs1, uimm2_lsb0:$imm),
+                  (C_LH GPRC:$rd, BasePtrC:$rs1, uimm2_lsb0:$imm)>;
+def : CompressPat<(SB GPRC:$rs2, BasePtrC:$rs1, uimm2:$imm),
+                  (C_SB GPRC:$rs2, BasePtrC:$rs1, uimm2:$imm)>;
+def : CompressPat<(SH GPRC:$rs2, BasePtrC:$rs1, uimm2_lsb0:$imm),
+                  (C_SH GPRC:$rs2, BasePtrC:$rs1, uimm2_lsb0:$imm)>;
 
 let isCompressOnly = true in {
-def : CompressPat<(LH_INX GPRF16C:$rd, GPRCMem:$rs1, uimm2_lsb0:$imm),
-                  (C_LH_INX GPRF16C:$rd, GPRCMem:$rs1, uimm2_lsb0:$imm)>;
-def : CompressPat<(SH_INX GPRF16C:$rs2, GPRCMem:$rs1, uimm2_lsb0:$imm),
-                  (C_SH_INX GPRF16C:$rs2, GPRCMem:$rs1, uimm2_lsb0:$imm)>;
+def : CompressPat<(LH_INX GPRF16C:$rd, BasePtrC:$rs1, uimm2_lsb0:$imm),
+                  (C_LH_INX GPRF16C:$rd, BasePtrC:$rs1, uimm2_lsb0:$imm)>;
+def : CompressPat<(SH_INX GPRF16C:$rs2, BasePtrC:$rs1, uimm2_lsb0:$imm),
+                  (C_SH_INX GPRF16C:$rs2, BasePtrC:$rs1, uimm2_lsb0:$imm)>;
 }
 }// Predicates = [HasStdExtZcb]
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZclsd.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZclsd.td
@@ -73,9 +73,9 @@ def C_SD_RV32 : CStore_rri<0b111, "c.sd", GPRPairCRV32, uimm8_lsb000>,
 
 let Predicates = [HasStdExtZclsd, IsRV32] in {
 def : InstAlias<"c.ld $rd, (${rs1})",
-                (C_LD_RV32 GPRPairCRV32:$rd, GPRCMem:$rs1, 0), 0>;
+                (C_LD_RV32 GPRPairCRV32:$rd, BasePtrC:$rs1, 0), 0>;
 def : InstAlias<"c.sd $rs2, (${rs1})",
-                (C_SD_RV32 GPRPairCRV32:$rs2, GPRCMem:$rs1, 0), 0>;
+                (C_SD_RV32 GPRPairCRV32:$rs2, BasePtrC:$rs1, 0), 0>;
 def : InstAlias<"c.ldsp $rd, (${rs1})",
                 (C_LDSP_RV32 GPRPairNoX0RV32:$rd, SPMem:$rs1, 0), 0>;
 def : InstAlias<"c.sdsp $rs2, (${rs1})",
@@ -91,8 +91,8 @@ def : CompressPat<(LD_RV32 GPRPairNoX0RV32:$rd, SPMem:$rs1, uimm9_lsb000:$imm),
                   (C_LDSP_RV32 GPRPairNoX0RV32:$rd, SPMem:$rs1, uimm9_lsb000:$imm)>;
 def : CompressPat<(SD_RV32 GPRPairRV32:$rs2, SPMem:$rs1, uimm9_lsb000:$imm),
                   (C_SDSP_RV32 GPRPairRV32:$rs2, SPMem:$rs1, uimm9_lsb000:$imm)>;
-def : CompressPat<(LD_RV32 GPRPairCRV32:$rd, GPRCMem:$rs1, uimm8_lsb000:$imm),
-                  (C_LD_RV32 GPRPairCRV32:$rd, GPRCMem:$rs1, uimm8_lsb000:$imm)>;
-def : CompressPat<(SD_RV32 GPRPairCRV32:$rs2, GPRCMem:$rs1, uimm8_lsb000:$imm),
-                  (C_SD_RV32 GPRPairCRV32:$rs2, GPRCMem:$rs1, uimm8_lsb000:$imm)>;
+def : CompressPat<(LD_RV32 GPRPairCRV32:$rd, BasePtrC:$rs1, uimm8_lsb000:$imm),
+                  (C_LD_RV32 GPRPairCRV32:$rd, BasePtrC:$rs1, uimm8_lsb000:$imm)>;
+def : CompressPat<(SD_RV32 GPRPairCRV32:$rs2, BasePtrC:$rs1, uimm8_lsb000:$imm),
+                  (C_SD_RV32 GPRPairCRV32:$rs2, BasePtrC:$rs1, uimm8_lsb000:$imm)>;
 } // Predicates = [HasStdExtZclsd, IsRV32]


### PR DESCRIPTION
This is in preparation for https://github.com/llvm/llvm-project/pull/177073
where these operands can refer to either a GPR or YGPR depending on the
current HwMode.
