### PR TITLE
[Offload] Fix pessimistic max block count sizing on AMDGPU

### DIFF
--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -2573,6 +2573,16 @@ struct AMDGPUDeviceTy : public GenericDeviceTy, AMDGenericDeviceTy {
   /// See GenericDeviceTy::getComputeUnitKind().
   std::string getComputeUnitKind() const override { return ComputeUnitKind; }
 
+  /// See GenericDeviceTy::getBlockLimit(uint32_t).
+  uint32_t getBlockLimit(uint32_t NumThreads) const override {
+    if (NumThreads == 0)
+      return GridValues.GV_Max_Teams;
+    uint64_t MaxGridItems =
+        uint64_t(GridValues.GV_Max_Teams) * getThreadLimit();
+    uint64_t MaxBlocks = MaxGridItems / NumThreads;
+    return std::min<uint64_t>(MaxBlocks, UINT32_MAX);
+  }
+
   /// Returns the clock frequency for the given AMDGPU device.
   uint64_t getClockFrequency() const override { return ClockFrequency; }
 

--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -2573,7 +2573,9 @@ struct AMDGPUDeviceTy : public GenericDeviceTy, AMDGenericDeviceTy {
   /// See GenericDeviceTy::getComputeUnitKind().
   std::string getComputeUnitKind() const override { return ComputeUnitKind; }
 
-  /// See GenericDeviceTy::getBlockLimit(uint32_t).
+  /// See GenericDeviceTy::getBlockLimit(uint32_t). The HSA launch configuration
+  /// is an int32_t grid representing blocks * threads. This means the block
+  /// limit depends on the user's requested thread count.
   uint32_t getBlockLimit(uint32_t NumThreads) const override {
     if (NumThreads == 0)
       return GridValues.GV_Max_Teams;

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -1110,7 +1110,9 @@ struct GenericDeviceTy : public DeviceAllocatorTy {
   /// Get the number of lanes used for the RPC interface.
   virtual uint32_t getRPCNumLanes() const { return getWarpSize(); }
   uint32_t getThreadLimit() const { return GridValues.GV_Max_WG_Size; }
-  uint32_t getBlockLimit() const { return GridValues.GV_Max_Teams; }
+  virtual uint32_t getBlockLimit(uint32_t NumThreads) const {
+    return GridValues.GV_Max_Teams;
+  }
   uint32_t getDefaultNumThreads() const {
     return GridValues.GV_Default_WG_Size;
   }

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -1110,6 +1110,8 @@ struct GenericDeviceTy : public DeviceAllocatorTy {
   /// Get the number of lanes used for the RPC interface.
   virtual uint32_t getRPCNumLanes() const { return getWarpSize(); }
   uint32_t getThreadLimit() const { return GridValues.GV_Max_WG_Size; }
+  /// Get the maximum number of blocks that can be launched. The \p NumThreads
+  /// argument is the per-block thread count the kernel will be launched with.
   virtual uint32_t getBlockLimit(uint32_t NumThreads) const {
     return GridValues.GV_Max_Teams;
   }

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -392,12 +392,9 @@ uint32_t GenericKernelTy::getEffectiveNumBlocks(
     bool IsNumThreadsFromUser) const {
   assert(!isBareMode() && "bare kernel should not call this function");
 
-  if (UserNumBlocks > 0) {
-    // TODO: We need to honor any value and consequently allow more than the
-    // block limit. For this we might need to start multiple kernels or let the
-    // blocks start again until the requested number has been started.
-    return std::min(UserNumBlocks, GenericDevice.getBlockLimit());
-  }
+  if (UserNumBlocks > 0)
+    return std::min(UserNumBlocks,
+                    GenericDevice.getBlockLimit(EffectiveNumThreads));
 
   // Return the number of blocks required to cover the loop iterations.
   if (isNoLoopMode())
@@ -474,7 +471,8 @@ uint32_t GenericKernelTy::getEffectiveNumBlocks(
   // If the loops are long running we rather reuse blocks than spawn too many.
   if (GenericDevice.getReuseBlocksForHighTripCount())
     PreferredNumBlocks = std::min(TripCountNumBlocks, DefaultNumBlocks);
-  return std::min(PreferredNumBlocks, GenericDevice.getBlockLimit());
+  return std::min(PreferredNumBlocks,
+                  GenericDevice.getBlockLimit(EffectiveNumThreads));
 }
 
 GenericDeviceTy::GenericDeviceTy(GenericPluginTy &Plugin, int32_t DeviceId,

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -392,6 +392,9 @@ uint32_t GenericKernelTy::getEffectiveNumBlocks(
     bool IsNumThreadsFromUser) const {
   assert(!isBareMode() && "bare kernel should not call this function");
 
+  // TODO: We need to honor any value and consequently allow more than the
+  // block limit. For this we might need to start multiple kernels or let the
+  // blocks start again until the requested number has been started.
   if (UserNumBlocks > 0)
     return std::min(UserNumBlocks,
                     GenericDevice.getBlockLimit(EffectiveNumThreads));

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -392,9 +392,10 @@ uint32_t GenericKernelTy::getEffectiveNumBlocks(
     bool IsNumThreadsFromUser) const {
   assert(!isBareMode() && "bare kernel should not call this function");
 
-  // TODO: We need to honor any value and consequently allow more than the
-  // block limit. For this we might need to start multiple kernels or let the
-  // blocks start again until the requested number has been started.
+  // NOTE: This clamps the user-requested number of blocks to the device limit
+  // rather than honoring it exactly, which is non-standard behavior. Truly
+  // honoring an arbitrary value would require launching multiple kernels or
+  // reusing blocks until the requested count has been served.
   if (UserNumBlocks > 0)
     return std::min(UserNumBlocks,
                     GenericDevice.getBlockLimit(EffectiveNumThreads));

--- a/offload/test/lit.cfg
+++ b/offload/test/lit.cfg
@@ -234,6 +234,7 @@ if config.libomptarget_current_target.startswith('nvptx'):
 if config.libomptarget_current_target.startswith('amdgcn'):
     config.available_features.add('gpu')
     config.available_features.add('amdgpu')
+    config.environment['HSA_DISABLE_COREDUMP_ON_EXCEPTION'] = '1'
 if config.libomptarget_current_target.startswith('spirv64-intel'):
     config.available_features.add('gpu')
     config.available_features.add('intelgpu')

--- a/offload/test/lit.cfg
+++ b/offload/test/lit.cfg
@@ -234,7 +234,6 @@ if config.libomptarget_current_target.startswith('nvptx'):
 if config.libomptarget_current_target.startswith('amdgcn'):
     config.available_features.add('gpu')
     config.available_features.add('amdgpu')
-    config.environment['HSA_DISABLE_COREDUMP_ON_EXCEPTION'] = '1'
 if config.libomptarget_current_target.startswith('spirv64-intel'):
     config.available_features.add('gpu')
     config.available_features.add('intelgpu')


### PR DESCRIPTION
Summary:
For whatever reason, HSA copied the questionable choices that OpenCL
made and represents its launch parameters in a threads * blocks grid.
The problem is that you then combine this with an `int32_t` interface,
so you have 31 bits to represent your launch. We were then
pessimistically stating that your launch always had 1024 threads, which
left us with 2^21. This is only about two million which people do all
the time, and this caused us to perform weird clamping in OpenMP. The
effect was that tests like ompx_saxpy_mixed.c was hitting that clamp and
returning wrong results.

Also fix the sanitizer tests failing because of HSA core dumps.
