### PR TITLE
[lldb][test] Skip unsupported tests on WebAssembly

### DIFF
--- a/lldb/test/API/commands/target/create-deps/TestTargetCreateDeps.py
+++ b/lldb/test/API/commands/target/create-deps/TestTargetCreateDeps.py
@@ -10,6 +10,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfTargetDoesNotSupportSharedLibraries()
 @skipIfWindows  # Windows deals differently with shared libs.
 class TargetDependentsTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True

--- a/lldb/test/API/functionalities/always-run-threads/TestAlwaysRunThreadNames.py
+++ b/lldb/test/API/functionalities/always-run-threads/TestAlwaysRunThreadNames.py
@@ -4,6 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfTargetDoesNotSupportThreads()
 class AlwaysRunThreadNamesTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/tail_call_frames/cross_dso/TestCrossDSOTailCalls.py
+++ b/lldb/test/API/functionalities/tail_call_frames/cross_dso/TestCrossDSOTailCalls.py
@@ -7,6 +7,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfTargetDoesNotSupportSharedLibraries()
 class TestCrossDSOTailCalls(TestBase):
     @skipIf(compiler="clang", compiler_version=["<", "22.0"])
     @skipIf(dwarf_version=["<", "4"])

--- a/lldb/test/API/lang/c/anonymous/TestAnonymous.py
+++ b/lldb/test/API/lang/c/anonymous/TestAnonymous.py
@@ -74,6 +74,7 @@ class AnonymousTestCase(TestBase):
             substrs=["(type_y) $", "dummy = 2"],
         )
 
+    @skipIfWasm  # no expression evaluation
     def test_expr_null(self):
         self.build()
         self.common_setup(self.line2)

--- a/lldb/test/API/lang/c/blocks/TestBlocks.py
+++ b/lldb/test/API/lang/c/blocks/TestBlocks.py
@@ -7,6 +7,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class BlocksTestCase(TestBase):
     lines = []
 

--- a/lldb/test/API/lang/c/calling-conventions/TestCCallingConventions.py
+++ b/lldb/test/API/lang/c/calling-conventions/TestCCallingConventions.py
@@ -87,6 +87,7 @@ class TestCase(TestBase):
             return
         self.expect_expr("func(1, 2, 3, 4)", result_type="int", result_value="10")
 
+    @skipIfWasm  # no expression evaluation
     def test_sysv_abi(self):
         if not self.build_and_run("sysv_abi.c"):
             return

--- a/lldb/test/API/lang/c/conflicting-symbol/TestConflictingSymbol.py
+++ b/lldb/test/API/lang/c/conflicting-symbol/TestConflictingSymbol.py
@@ -7,6 +7,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfTargetDoesNotSupportSharedLibraries()
 class TestConflictingSymbols(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/lang/c/enum_types/TestEnumTypes.py
+++ b/lldb/test/API/lang/c/enum_types/TestEnumTypes.py
@@ -14,6 +14,7 @@ class EnumTypesTestCase(TestBase):
         # Find the line number to break inside main().
         self.line = line_number("main.c", "// Set break point at this line.")
 
+    @skipIfWasm  # no expression evaluation
     def test_command_line(self):
         """Test 'image lookup -t enum_test_days' and check for correct display and enum value printing."""
         self.build()

--- a/lldb/test/API/lang/c/fpeval/TestFPEval.py
+++ b/lldb/test/API/lang/c/fpeval/TestFPEval.py
@@ -6,6 +6,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class FPEvalTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/lang/c/function_types/TestFunctionTypes.py
+++ b/lldb/test/API/lang/c/function_types/TestFunctionTypes.py
@@ -7,6 +7,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class FunctionTypesTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/lang/c/modules/TestCModules.py
+++ b/lldb/test/API/lang/c/modules/TestCModules.py
@@ -9,6 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class CModulesTestCase(TestBase):
     @expectedFailureAll(
         oslist=["freebsd", "linux"],

--- a/lldb/test/API/lang/c/register_variables/test.c
+++ b/lldb/test/API/lang/c/register_variables/test.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 
-#if defined(__arm__) || defined(__aarch64__) || defined (__mips__) || defined(__powerpc64__) || defined(__wasm__)
+#if defined(__arm__) || defined(__aarch64__) || defined(__mips__) ||           \
+    defined(__powerpc64__) || defined(__wasm__)
 // Clang does not accept regparm attribute on these platforms.
 // Fortunately, the default calling convention passes arguments in registers
 // anyway.

--- a/lldb/test/API/lang/c/register_variables/test.c
+++ b/lldb/test/API/lang/c/register_variables/test.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-#if defined(__arm__) || defined(__aarch64__) || defined (__mips__) || defined(__powerpc64__)
+#if defined(__arm__) || defined(__aarch64__) || defined (__mips__) || defined(__powerpc64__) || defined(__wasm__)
 // Clang does not accept regparm attribute on these platforms.
 // Fortunately, the default calling convention passes arguments in registers
 // anyway.

--- a/lldb/test/API/lang/c/sizeof/TestCSizeof.py
+++ b/lldb/test/API/lang/c/sizeof/TestCSizeof.py
@@ -4,6 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestCase(TestBase):
     def test(self):
         self.build()

--- a/lldb/test/API/lang/c/struct_types/TestStructTypes.py
+++ b/lldb/test/API/lang/c/struct_types/TestStructTypes.py
@@ -1,4 +1,4 @@
 from lldbsuite.test import lldbinline
 from lldbsuite.test import decorators
 
-lldbinline.MakeInlineTest(__file__, globals())
+lldbinline.MakeInlineTest(__file__, globals(), [decorators.skipIfWasm])

--- a/lldb/test/API/python_api/unnamed_symbol_lookup/TestUnnamedSymbolLookup.py
+++ b/lldb/test/API/python_api/unnamed_symbol_lookup/TestUnnamedSymbolLookup.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 # --keep-symbol causes error on Windows: llvm-strip.exe: error: option is not supported for COFF
 @skipIfWindows
+# llvm-strip doesn't support --keep-symbol for the Wasm object format.
+@skipIfWasm
 # Unnamed symbols don't get into the .eh_frame section on ARM, so LLDB can't find them.
 @skipIf(archs=["arm$"])
 class TestUnnamedSymbolLookup(TestBase):

--- a/lldb/test/API/tools/lldb-dap/module/TestDAP_module.py
+++ b/lldb/test/API/tools/lldb-dap/module/TestDAP_module.py
@@ -8,6 +8,7 @@ import lldbdap_testcase
 import re
 
 
+@skipIfTargetDoesNotSupportSharedLibraries()
 class TestDAP_module(lldbdap_testcase.DAPTestCaseBase):
     def run_test(self, symbol_basename, expect_debug_info_size):
         program_basename = "a.out.stripped"


### PR DESCRIPTION
Mark more tests that rely on features unavailable on wasm32-wasip1 (or in LLDB's Wasm support): expression evaluation (skipIfWasm), shared libraries (skipIfTargetDoesNotSupportSharedLibraries), threads (skipIfTargetDoesNotSupportThreads), and llvm-strip --keep-symbol, which the Wasm object format doesn't support. Where a test also has supported, passing cases, the decorator is applied per method.

The "expression" category is already skipped for Wasm, but that only covers commands/expression/*, where the category is set by a "categories" file. The tests in this PR live elsewhere and merely use expression evaluation incidentally, so they aren't in that category and need skipIfWasm directly.