### PR TITLE
AMDGPU: Add TargetParser to disassembler dependencies

### DIFF
--- a/llvm/lib/Target/AMDGPU/Disassembler/CMakeLists.txt
+++ b/llvm/lib/Target/AMDGPU/Disassembler/CMakeLists.txt
@@ -10,6 +10,7 @@ add_llvm_component_library(LLVMAMDGPUDisassembler
   CodeGenTypes
   MC
   MCDisassembler
+  TargetParser
   Support
 
   ADD_TO_COMPONENT


### PR DESCRIPTION
Should fix build failure after #203979, but should be reverted
in #204150