### PR TITLE
Add a useful command to the python examples & "lldb.utils"

### DIFF
--- a/lldb/bindings/python/CMakeLists.txt
+++ b/lldb/bindings/python/CMakeLists.txt
@@ -103,6 +103,7 @@ function(finish_swig_python swig_target lldb_python_bindings_dir lldb_python_tar
     "utils"
     FILES "${LLDB_SOURCE_DIR}/examples/python/in_call_stack.py"
           "${LLDB_SOURCE_DIR}/examples/python/symbolication.py"
+          "${LLDB_SOURCE_DIR}/examples/python/delayed_enable.py"
   )
 
   create_python_package(

--- a/lldb/examples/python/delayed_enable.py
+++ b/lldb/examples/python/delayed_enable.py
@@ -1,0 +1,60 @@
+import lldb
+from lldb.plugins.parsed_cmd import ParsedCommand
+import time
+
+class EnableThemLater(ParsedCommand):
+    program = "delayed_enable"
+    def __init__(self, debugger : lldb.SBDebugger, internal_dict):
+        super().__init__(debugger, internal_dict)
+
+    def setup_command_definition(self):
+        ov_parser = self.get_parser()
+        ov_parser.add_argument_set([
+            ov_parser.make_argument_element(lldb.eArgTypeUnsignedInteger,
+                                                 repeat = "plain", groups=None)])
+
+    def __call__(self, debugger, args_array, exe_ctx, result):
+        target = exe_ctx.target
+        
+        breakpoints = []
+        for breakpoint in target.breakpoints:
+            if breakpoint.enabled:
+                breakpoints.append(breakpoint)
+                breakpoint.SetEnabled(False)
+                
+        interval = 5
+        process = exe_ctx.process
+        # If the process is running we don't need to do anything, lldb
+        # will auto-pause/continue around disabling the breakpoints,
+        # but if we're stopped we want to continue.
+        if process.IsValid() and process.state == lldb.eStateStopped:
+            old_async = self.debugger.GetAsync()
+            self.debugger.SetAsync(True)
+            process.Continue()
+            self.debugger.SetAsync(old_async)
+
+        # num_args can only be 0 or 1 due to the command definition.
+        num_args = args_array.GetSize()
+        if num_args == 1:
+            interval = args_array.GetItemAtIndex(0).GetUnsignedIntegerValue(5)
+        time.sleep(interval)
+
+        for breakpoint in breakpoints:
+            breakpoint.SetEnabled(True)
+            
+    def get_short_help(self):
+        return "Disable all enabled breakpoints, sleep and re-enable"
+
+    def get_long_help(self):
+        return ("Disable all enabled breakpoints in the target passed to the "
+                "command; sleep for 5 seconds - or the interval passed as the "
+                "argument command; then reenable them.  "
+                "\nThis is useful when you need to set up a situation in a GUI app w/o "
+                "hitting breakpoints, and then start hitting them again w/o disturbing "
+                "the GUI state.  For instance, if you want to hit a breakpoint "
+                "while testing a drag and drop action, you can't interact with "
+                "the debugger once you've started the drag so you need a delayed "
+                "enable.")
+
+def __lldb_init_module(debugger, internal_dict): 
+    ParsedCommand.do_register_cmd(EnableThemLater, debugger, __name__)

--- a/lldb/examples/python/delayed_enable.py
+++ b/lldb/examples/python/delayed_enable.py
@@ -2,26 +2,32 @@ import lldb
 from lldb.plugins.parsed_cmd import ParsedCommand
 import time
 
+
 class EnableThemLater(ParsedCommand):
     program = "delayed_enable"
-    def __init__(self, debugger : lldb.SBDebugger, internal_dict):
+
+    def __init__(self, debugger: lldb.SBDebugger, internal_dict):
         super().__init__(debugger, internal_dict)
 
     def setup_command_definition(self):
         ov_parser = self.get_parser()
-        ov_parser.add_argument_set([
-            ov_parser.make_argument_element(lldb.eArgTypeUnsignedInteger,
-                                                 repeat = "plain", groups=None)])
+        ov_parser.add_argument_set(
+            [
+                ov_parser.make_argument_element(
+                    lldb.eArgTypeUnsignedInteger, repeat="plain", groups=None
+                )
+            ]
+        )
 
     def __call__(self, debugger, args_array, exe_ctx, result):
         target = exe_ctx.target
-        
+
         breakpoints = []
         for breakpoint in target.breakpoints:
             if breakpoint.enabled:
                 breakpoints.append(breakpoint)
                 breakpoint.SetEnabled(False)
-                
+
         interval = 5
         process = exe_ctx.process
         # If the process is running we don't need to do anything, lldb
@@ -41,20 +47,23 @@ class EnableThemLater(ParsedCommand):
 
         for breakpoint in breakpoints:
             breakpoint.SetEnabled(True)
-            
+
     def get_short_help(self):
         return "Disable all enabled breakpoints, sleep and re-enable"
 
     def get_long_help(self):
-        return ("Disable all enabled breakpoints in the target passed to the "
-                "command; sleep for 5 seconds - or the interval passed as the "
-                "argument command; then reenable them.  "
-                "\nThis is useful when you need to set up a situation in a GUI app w/o "
-                "hitting breakpoints, and then start hitting them again w/o disturbing "
-                "the GUI state.  For instance, if you want to hit a breakpoint "
-                "while testing a drag and drop action, you can't interact with "
-                "the debugger once you've started the drag so you need a delayed "
-                "enable.")
+        return (
+            "Disable all enabled breakpoints in the target passed to the "
+            "command; sleep for 5 seconds - or the interval passed as the "
+            "argument command; then reenable them.  "
+            "\nThis is useful when you need to set up a situation in a GUI app w/o "
+            "hitting breakpoints, and then start hitting them again w/o disturbing "
+            "the GUI state.  For instance, if you want to hit a breakpoint "
+            "while testing a drag and drop action, you can't interact with "
+            "the debugger once you've started the drag so you need a delayed "
+            "enable."
+        )
 
-def __lldb_init_module(debugger, internal_dict): 
+
+def __lldb_init_module(debugger, internal_dict):
     ParsedCommand.do_register_cmd(EnableThemLater, debugger, __name__)


### PR DESCRIPTION
When debugging GUI programs where you have a bunch of breakpoints set that you only want to have trigger when in the middle of some UI interaction (a drag and drop for example) but not before, you need a way to have the breakpoints disabled till a certain point, then re-enabled.  But since you are in the middle of the interaction, you can't interact with the debugger to do that.

This little command disables your breakpoints, continues if you were stopped, waits for a prescribed interval, then re-enables them.