### PR TITLE
[clang][driver] Fix flang frontend resolution for symlinked clang driver

### DIFF
--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -1328,10 +1328,11 @@ void Flang::ConstructJob(Compilation &C, const JobAction &JA,
 
   // Handle "clang --driver-mode=flang" case
   bool isClangDriverWithFlangMode = false;
-  if (D.Name.find("clang") != std::string_view::npos)
-    if (const Arg *A = Args.getLastArg(options::OPT_driver_mode))
-      if (StringRef(A->getValue()) == "flang")
-        isClangDriverWithFlangMode = true;
+  std::string DriverName = D.Name;
+  if (const char *PA = D.getPrependArg())
+    DriverName = PA;
+  if (DriverName.find("clang") != std::string::npos && D.IsFlangMode())
+    isClangDriverWithFlangMode = true;
 
   const char *Exec = isClangDriverWithFlangMode
                          ? Args.MakeArgString(D.GetProgramPath("flang", TC))


### PR DESCRIPTION
When clang is built as a symlink to the llvm multicall binary, the driver resolves the executable path to 'llvm', making D.Name 'llvm' instead of 'clang'.
This broke the detection of 'clang --driver-mode=flang' in Flang.cpp, causing the driver to try to run 'llvm -fc1' instead of looking up 'flang', after change in #200438 was landed.

Fix this by checking D.getPrependArg() in addition to D.Name to identify if we are acting as clang. Also use D.IsFlangMode() for simpler and more robust detection of the driver mode.