### PR TITLE
[lldb][test] Skip even more unsupported tests on WebAssembly

### DIFF
--- a/lldb/test/API/commands/platform/process/list/TestProcessList.py
+++ b/lldb/test/API/commands/platform/process/list/TestProcessList.py
@@ -11,6 +11,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # attaching requires launching the inferior as a host process
 class ProcessListTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/commands/process/attach/TestProcessAttach.py
+++ b/lldb/test/API/commands/process/attach/TestProcessAttach.py
@@ -13,6 +13,7 @@ from lldbsuite.test import lldbutil
 exe_name = "ProcessAttach"  # Must match Makefile
 
 
+@skipIfWasm  # attaching requires launching the inferior as a host process
 class ProcessAttachTestCase(TestBase):
     SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True

--- a/lldb/test/API/commands/register/register_command/TestRegisters.py
+++ b/lldb/test/API/commands/register/register_command/TestRegisters.py
@@ -702,6 +702,7 @@ class RegisterCommandsTestCase(TestBase):
             "fs_base does not equal to pthread_self() value.",
         )
 
+    @skipIfWasm  # attaching requires launching the inferior as a host process
     def test_process_must_be_stopped(self):
         """Check that all register commands error when the process is not stopped."""
         self.build()

--- a/lldb/test/API/functionalities/deleted-executable/TestDeletedExecutable.py
+++ b/lldb/test/API/functionalities/deleted-executable/TestDeletedExecutable.py
@@ -10,6 +10,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # attaching requires launching the inferior as a host process
 class TestDeletedExecutable(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/gdb_remote_client/TestPlatformKill.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestPlatformKill.py
@@ -6,6 +6,7 @@ from lldbsuite.test.gdbclientutils import *
 from lldbsuite.test.lldbgdbclient import GDBRemoteTestBase
 
 
+@skipIfWasm  # attaching requires launching the inferior as a host process
 class TestPlatformKill(GDBRemoteTestBase):
     SHARED_BUILD_TESTCASE = False
 

--- a/lldb/test/API/functionalities/rerun_and_expr/TestRerunAndExpr.py
+++ b/lldb/test/API/functionalities/rerun_and_expr/TestRerunAndExpr.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 from lldbsuite.test.decorators import *
 
 
+@skipIfWasm  # no expression evaluation
 class TestRerunExpr(TestBase):
     SHARED_BUILD_TESTCASE = False
 

--- a/lldb/test/API/functionalities/rerun_and_expr_dylib/TestRerunAndExprDylib.py
+++ b/lldb/test/API/functionalities/rerun_and_expr_dylib/TestRerunAndExprDylib.py
@@ -25,6 +25,7 @@ def isUbuntu18_04():
     return None
 
 
+@skipIfWasm  # no expression evaluation
 class TestRerunExprDylib(TestBase):
     SHARED_BUILD_TESTCASE = False
 

--- a/lldb/test/API/lang/c/libc_calls/TestLibcCalls.py
+++ b/lldb/test/API/lang/c/libc_calls/TestLibcCalls.py
@@ -54,6 +54,7 @@ class LibcCallsTestCase(TestBase):
                     resolved_module_name, "dyld", f"Called dyld version of {symbol}"
                 )
 
+    @skipIfWasm  # no expression evaluation
     def test_libc_calls_succeed(self):
         """Calling memset/memcpy/memmove/memcmp from expressions must
         execute without trapping."""

--- a/lldb/test/API/lang/cpp/abi_tag_structors/TestAbiTagStructors.py
+++ b/lldb/test/API/lang/cpp/abi_tag_structors/TestAbiTagStructors.py
@@ -18,6 +18,7 @@ class AbiTagStructorsTestCase(TestBase):
         bugnumber="Required Clang flag not supported",
     )
     @expectedFailureAll(oslist=["windows"])
+    @skipIfWasm  # no expression evaluation
     def test_with_structor_linkage_names(self):
         self.build(dictionary={"CXXFLAGS_EXTRAS": "-gstructor-decl-linkage-names"})
 
@@ -123,11 +124,13 @@ class AbiTagStructorsTestCase(TestBase):
 
     @skipIf(compiler="clang", compiler_version=["<", "22"])
     @expectedFailureAll(oslist=["windows"])
+    @skipIfWasm  # no expression evaluation
     def test_nested_with_structor_linkage_names(self):
         self.build(dictionary={"CXXFLAGS_EXTRAS": "-gstructor-decl-linkage-names"})
         self.do_nested_structor_test()
 
     @expectedFailureAll(oslist=["windows"])
+    @skipIfWasm  # no expression evaluation
     def test_nested_no_structor_linkage_names(self):
         # In older versions of Clang the -gno-structor-decl-linkage-names
         # behaviour was the default.

--- a/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
+++ b/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
     SHARED_BUILD_TESTCASE = False
 
+    @skipIfWasm  # no expression evaluation
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/cpp/decl-from-submodule/TestDeclFromSubmodule.py
+++ b/lldb/test/API/lang/cpp/decl-from-submodule/TestDeclFromSubmodule.py
@@ -8,6 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class DeclFromSubmoduleTestCase(TestBase):
     # Requires DWARF debug info which is not retained when linking with link.exe.
     @skipIfWindows

--- a/lldb/test/API/lang/cpp/llvm-style/TestLLVMStyle.py
+++ b/lldb/test/API/lang/cpp/llvm-style/TestLLVMStyle.py
@@ -1,4 +1,4 @@
 from lldbsuite.test import lldbinline
 from lldbsuite.test import decorators
 
-lldbinline.MakeInlineTest(__file__, globals())
+lldbinline.MakeInlineTest(__file__, globals(), [decorators.skipIfWasm])

--- a/lldb/test/API/lang/cpp/namespace/TestNamespace.py
+++ b/lldb/test/API/lang/cpp/namespace/TestNamespace.py
@@ -133,6 +133,7 @@ class NamespaceTestCase(TestBase):
 
     # rdar://problem/8668674
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24764")
+    @skipIfWasm  # no expression evaluation
     def test_with_run_command(self):
         """Test that anonymous and named namespace variables display correctly."""
         self.build()

--- a/lldb/test/API/lang/cpp/namespace/TestNamespaceLookup.py
+++ b/lldb/test/API/lang/cpp/namespace/TestNamespaceLookup.py
@@ -100,6 +100,7 @@ class NamespaceLookupTestCase(TestBase):
         self.expect_expr("::func()", result_type="int", result_value="1")
 
     @skipIfWindows  # This is flakey on Windows: llvm.org/pr38373
+    @skipIfWasm  # no expression evaluation
     def test_scope_lookup_with_run_command(self):
         """Test scope lookup of functions in lldb."""
         self.build()
@@ -258,6 +259,7 @@ class NamespaceLookupTestCase(TestBase):
     # NOTE: this test may fail on older systems that don't emit import
     # entries in DWARF - may need to add checks for compiler versions here.
     @skipIf(compiler="gcc", oslist=["linux"], debug_info=["dwo"])  # Skip to avoid crash
+    @skipIfWasm  # no expression evaluation
     def test_scope_after_using_directive_lookup_with_run_command(self):
         """Test scope lookup after using directive in lldb."""
         self.build()
@@ -321,6 +323,7 @@ class NamespaceLookupTestCase(TestBase):
         # the same type.
         self.expect("expr -- func()", startstr="error")
 
+    @skipIfWasm  # no expression evaluation
     def test_scope_lookup_shadowed_by_using_with_run_command(self):
         """Test scope lookup shadowed by using in lldb."""
         self.build()

--- a/lldb/test/API/lang/cpp/namespace_conflicts/TestNamespaceConflicts.py
+++ b/lldb/test/API/lang/cpp/namespace_conflicts/TestNamespaceConflicts.py
@@ -1,4 +1,4 @@
 from lldbsuite.test import lldbinline
 from lldbsuite.test import decorators
 
-lldbinline.MakeInlineTest(__file__, globals())
+lldbinline.MakeInlineTest(__file__, globals(), [decorators.skipIfWasm])

--- a/lldb/test/API/lang/cpp/operators/TestCppOperators.py
+++ b/lldb/test/API/lang/cpp/operators/TestCppOperators.py
@@ -4,5 +4,6 @@ from lldbsuite.test import decorators
 lldbinline.MakeInlineTest(
     __file__,
     globals(),
-    [decorators.expectedFailureAll(bugnumber="llvm.org/pr50814", compiler="gcc")],
+    [
+        decorators.skipIfWasm,decorators.expectedFailureAll(bugnumber="llvm.org/pr50814", compiler="gcc")],
 )

--- a/lldb/test/API/lang/cpp/operators/TestCppOperators.py
+++ b/lldb/test/API/lang/cpp/operators/TestCppOperators.py
@@ -5,5 +5,7 @@ lldbinline.MakeInlineTest(
     __file__,
     globals(),
     [
-        decorators.skipIfWasm,decorators.expectedFailureAll(bugnumber="llvm.org/pr50814", compiler="gcc")],
+        decorators.skipIfWasm,
+        decorators.expectedFailureAll(bugnumber="llvm.org/pr50814", compiler="gcc"),
+    ],
 )

--- a/lldb/test/API/lang/cpp/printf/TestPrintf.py
+++ b/lldb/test/API/lang/cpp/printf/TestPrintf.py
@@ -4,5 +4,6 @@ from lldbsuite.test import decorators
 lldbinline.MakeInlineTest(
     __file__,
     globals(),
-    [decorators.expectedFailureAll(bugnumber="llvm.org/PR36715", oslist=["windows"])],
+    [
+        decorators.skipIfWasm,decorators.expectedFailureAll(bugnumber="llvm.org/PR36715", oslist=["windows"])],
 )

--- a/lldb/test/API/lang/cpp/printf/TestPrintf.py
+++ b/lldb/test/API/lang/cpp/printf/TestPrintf.py
@@ -5,5 +5,7 @@ lldbinline.MakeInlineTest(
     __file__,
     globals(),
     [
-        decorators.skipIfWasm,decorators.expectedFailureAll(bugnumber="llvm.org/PR36715", oslist=["windows"])],
+        decorators.skipIfWasm,
+        decorators.expectedFailureAll(bugnumber="llvm.org/PR36715", oslist=["windows"]),
+    ],
 )

--- a/lldb/test/API/lang/cpp/static_members/TestCPPStaticMembers.py
+++ b/lldb/test/API/lang/cpp/static_members/TestCPPStaticMembers.py
@@ -12,6 +12,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
     # We fail to lookup static members on Windows.
     @expectedFailureAll(oslist=["windows"])
+    @skipIfWasm  # no expression evaluation
     def test_access_from_main(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -24,6 +25,7 @@ class TestCase(TestBase):
 
     # We fail to lookup static members on Windows.
     @expectedFailureAll(oslist=["windows"])
+    @skipIfWasm  # no expression evaluation
     def test_access_from_member_function(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/cpp/symbols/TestSymbols.py
+++ b/lldb/test/API/lang/cpp/symbols/TestSymbols.py
@@ -5,5 +5,7 @@ lldbinline.MakeInlineTest(
     __file__,
     globals(),
     [
-        decorators.skipIfWasm,decorators.expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24764")],
+        decorators.skipIfWasm,
+        decorators.expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24764"),
+    ],
 )

--- a/lldb/test/API/lang/cpp/symbols/TestSymbols.py
+++ b/lldb/test/API/lang/cpp/symbols/TestSymbols.py
@@ -4,5 +4,6 @@ from lldbsuite.test import decorators
 lldbinline.MakeInlineTest(
     __file__,
     globals(),
-    [decorators.expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24764")],
+    [
+        decorators.skipIfWasm,decorators.expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24764")],
 )

--- a/lldb/test/API/lang/cpp/template-diagnostic-hint/TestTemplateDiagnosticHint.py
+++ b/lldb/test/API/lang/cpp/template-diagnostic-hint/TestTemplateDiagnosticHint.py
@@ -4,6 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class TestCase(TestBase):
     @expectedFailureWindows
     def test(self):

--- a/lldb/test/API/lang/cpp/template-function/TestTemplateFunctions.py
+++ b/lldb/test/API/lang/cpp/template-function/TestTemplateFunctions.py
@@ -56,6 +56,7 @@ class TemplateFunctionsTestCase(TestBase):
             self.expect_expr("d1 == d2", result_type="bool", result_value="true")
 
     @skipIfWindows
+    @skipIfWasm  # no expression evaluation
     def test_template_function_with_cast(self):
         self.do_test_template_function(True)
 

--- a/lldb/test/API/lang/cpp/this/TestCPPThis.py
+++ b/lldb/test/API/lang/cpp/this/TestCPPThis.py
@@ -8,6 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no expression evaluation
 class CPPThisTestCase(TestBase):
     # rdar://problem/9962849
     @expectedFailureAll(

--- a/lldb/test/API/lang/cpp/unique-types4/TestUniqueTypes4.py
+++ b/lldb/test/API/lang/cpp/unique-types4/TestUniqueTypes4.py
@@ -8,6 +8,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
 
+@skipIfWasm  # no expression evaluation
 class UniqueTypesTestCase4(TestBase):
     SHARED_BUILD_TESTCASE = False
 

--- a/lldb/test/API/python_api/hello_world/TestHelloWorld.py
+++ b/lldb/test/API/python_api/hello_world/TestHelloWorld.py
@@ -72,6 +72,7 @@ class HelloWorldTestCase(TestBase):
 
     @expectedFailureAll(oslist=["windows"], archs=["aarch64"])
     @skipIfiOSSimulator
+    @skipIfWasm  # attaching requires launching the inferior as a host process
     def test_with_attach_to_process_with_id_api(self):
         """Create target, spawn a process, and attach to it with process id."""
         exe = "%s_%d" % (self.testMethodName, os.getpid())
@@ -104,6 +105,7 @@ class HelloWorldTestCase(TestBase):
     @expectedFailureAll(oslist=["windows"], archs=["aarch64"])
     @skipIfiOSSimulator
     @skipIfAsan  # FIXME: Hangs indefinitely.
+    @skipIfWasm  # attaching requires launching the inferior as a host process
     def test_with_attach_to_process_with_name_api(self):
         """Create target, spawn a process, and attach to it with process name."""
         exe = "%s_%d" % (self.testMethodName, os.getpid())


### PR DESCRIPTION
A second pass over the full API suite for tests that depend on features unavailable on wasm32-wasip1 or in LLDB's Wasm support:

- Expression evaluation (skipIfWasm) for the C++ tests that the "expression" category doesn't cover, since that category only applies to commands/expression/*.

- Attaching to a running process (skipIfWasm). These tests have the harness spawn the inferior as a host process and then attach, but a .wasm module isn't a native executable, so exec'ing it fails with ENOEXEC ("Exec format error"). The wasm module only runs inside the runtime (e.g. iwasm) that LLDB launches, so there is no host process to attach to.

Where a test also has supported, passing cases, the decorator is applied per method.