### PR TITLE
[GISel] CombinerHelper::matchBinopWithNegInner should only look for not on the LHS of G_SUB.

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
@@ -3290,7 +3290,9 @@ bool CombinerHelper::matchBinopWithNegInner(Register MInner, Register Other,
     return false;
   };
 
-  if (!TryMatch(InnerLHS, InnerRHS) && !TryMatch(InnerRHS, InnerLHS))
+  // For SUB, the not must be the LHS. For ADD, it can be either operand.
+  if (!TryMatch(InnerLHS, InnerRHS) &&
+      !(InnerOpc == TargetOpcode::G_ADD && TryMatch(InnerRHS, InnerLHS)))
     return false;
 
   // Flip add/sub

--- a/llvm/test/CodeGen/AArch64/GlobalISel/combine-binop-neg.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/combine-binop-neg.mir
@@ -279,9 +279,9 @@ body: |
     ; CHECK-NEXT: %b:_(s64) = COPY $x1
     ; CHECK-NEXT: %c:_(s64) = COPY $x2
     ; CHECK-NEXT: %mone:_(s64) = G_CONSTANT i64 -1
-    ; CHECK-NEXT: [[ADD:%[0-9]+]]:_(s64) = G_ADD %b, %c
-    ; CHECK-NEXT: [[XOR:%[0-9]+]]:_(s64) = G_XOR [[ADD]], %mone
-    ; CHECK-NEXT: %dst:_(s64) = G_AND %a, [[XOR]]
+    ; CHECK-NEXT: %neg_y:_(s64) = G_XOR %b, %mone
+    ; CHECK-NEXT: %sub:_(s64) = G_SUB %c, %neg_y
+    ; CHECK-NEXT: %dst:_(s64) = G_AND %a, %sub
     ; CHECK-NEXT: $x0 = COPY %dst(s64)
     ; CHECK-NEXT: RET_ReallyLR implicit $x0
     %a:_(s64) = COPY $x0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/combine-binop-neg.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/combine-binop-neg.mir
@@ -235,3 +235,62 @@ body: |
     $x0 = COPY %and2
     RET_ReallyLR implicit $x0
 ...
+---
+name:            binop_with_neg_sub_and
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $x0, $x1, $x2, $x3
+
+    ; CHECK-LABEL: name: binop_with_neg_sub_and
+    ; CHECK: liveins: $x0, $x1, $x2, $x3
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: %a:_(s64) = COPY $x0
+    ; CHECK-NEXT: %b:_(s64) = COPY $x1
+    ; CHECK-NEXT: %c:_(s64) = COPY $x2
+    ; CHECK-NEXT: %mone:_(s64) = G_CONSTANT i64 -1
+    ; CHECK-NEXT: [[ADD:%[0-9]+]]:_(s64) = G_ADD %b, %c
+    ; CHECK-NEXT: [[XOR:%[0-9]+]]:_(s64) = G_XOR [[ADD]], %mone
+    ; CHECK-NEXT: %dst:_(s64) = G_AND %a, [[XOR]]
+    ; CHECK-NEXT: $x0 = COPY %dst(s64)
+    ; CHECK-NEXT: RET_ReallyLR implicit $x0
+    %a:_(s64) = COPY $x0
+    %b:_(s64) = COPY $x1
+    %c:_(s64) = COPY $x2
+    %mone:_(s64) = G_CONSTANT i64 -1
+    %neg_y:_(s64) = G_XOR %mone, %b
+    %sub:_(s64) = G_SUB %neg_y, %c
+    %dst:_(s64) = G_AND %a, %sub
+    $x0 = COPY %dst
+    RET_ReallyLR implicit $x0
+...
+---
+# This test should not transform
+name:            binop_with_neg_sub_and_commuted
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $x0, $x1, $x2, $x3
+
+    ; CHECK-LABEL: name: binop_with_neg_sub_and_commuted
+    ; CHECK: liveins: $x0, $x1, $x2, $x3
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: %a:_(s64) = COPY $x0
+    ; CHECK-NEXT: %b:_(s64) = COPY $x1
+    ; CHECK-NEXT: %c:_(s64) = COPY $x2
+    ; CHECK-NEXT: %mone:_(s64) = G_CONSTANT i64 -1
+    ; CHECK-NEXT: [[ADD:%[0-9]+]]:_(s64) = G_ADD %b, %c
+    ; CHECK-NEXT: [[XOR:%[0-9]+]]:_(s64) = G_XOR [[ADD]], %mone
+    ; CHECK-NEXT: %dst:_(s64) = G_AND %a, [[XOR]]
+    ; CHECK-NEXT: $x0 = COPY %dst(s64)
+    ; CHECK-NEXT: RET_ReallyLR implicit $x0
+    %a:_(s64) = COPY $x0
+    %b:_(s64) = COPY $x1
+    %c:_(s64) = COPY $x2
+    %mone:_(s64) = G_CONSTANT i64 -1
+    %neg_y:_(s64) = G_XOR %mone, %b
+    %sub:_(s64) = G_SUB %c, %neg_y
+    %dst:_(s64) = G_AND %a, %sub
+    $x0 = COPY %dst
+    RET_ReallyLR implicit $x0
+...


### PR DESCRIPTION
Fixes #204219.