### PR TITLE
[BOLT][AArch64] Only reserve constant-island space when an island exists

### DIFF
--- a/bolt/lib/Passes/LongJmp.cpp
+++ b/bolt/lib/Passes/LongJmp.cpp
@@ -330,8 +330,10 @@ uint64_t LongJmpPass::tentativeLayoutRelocColdPart(
     LLVM_DEBUG(dbgs() << Func->getPrintName() << " cold tentative: "
                       << Twine::utohexstr(DotAddress) << "\n");
     DotAddress += Func->estimateColdSize();
-    DotAddress = alignTo(DotAddress, Func->getConstantIslandAlignment());
-    DotAddress += Func->estimateConstantIslandSize();
+    if (uint64_t IslandSize = Func->estimateConstantIslandSize()) {
+      DotAddress = alignTo(DotAddress, Func->getConstantIslandAlignment());
+      DotAddress += IslandSize;
+    }
   }
   return DotAddress;
 }
@@ -399,8 +401,10 @@ LongJmpPass::tentativeLayoutRelocMode(const BinaryContext &BC,
     else
       DotAddress += Func->estimateHotSize();
 
-    DotAddress = alignTo(DotAddress, Func->getConstantIslandAlignment());
-    DotAddress += Func->estimateConstantIslandSize();
+    if (uint64_t IslandSize = Func->estimateConstantIslandSize()) {
+      DotAddress = alignTo(DotAddress, Func->getConstantIslandAlignment());
+      DotAddress += IslandSize;
+    }
     ++CurrentIndex;
   }
 


### PR DESCRIPTION
`tentativeLayout()` aligns every function's tail to its constant island alignment even when the function has no constant island. This over-padded nearly every function, drifting tentative layout from emitted layout non trivially, while the emitter only pads when emitting a real constant island. Guard with `estimateConstantIslandSize() > 0` so tentative better matches emitted.