### PR TITLE
[BOLT][AArch64] Align tentative layout bases using per-section alignment

### DIFF
--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -45,6 +45,7 @@
 #include "llvm/Support/RWMutex.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Triple.h"
+#include <atomic>
 #include <functional>
 #include <list>
 #include <map>
@@ -809,6 +810,29 @@ public:
   /// sets this prior to running BOLT passes, so layout passes are aware of the
   /// final addresses functions will have.
   uint64_t LayoutStartAddress{0};
+
+  /// Maximum alignment of objects emitted into the main (hot) and cold code
+  /// sections, populated by the parallel AlignerPass (updateMaxCodeAlignment).
+  std::atomic<uint16_t> MaxMainCodeAlignment{1};
+  std::atomic<uint16_t> MaxColdCodeAlignment{1};
+
+  /// Fold \p Alignment into the running max for the main code section (when
+  /// \p InMainSection) and/or the cold code section (when \p InColdSection),
+  /// reflecting which output section(s) the object is emitted into. Safe to
+  /// call concurrently.
+  void updateMaxCodeAlignment(uint16_t Alignment, bool InMainSection,
+                              bool InColdSection) {
+    auto AtomicMax = [](std::atomic<uint16_t> &Max, uint16_t Value) {
+      uint16_t Cur = Max.load(std::memory_order_relaxed);
+      while (Value > Cur &&
+             !Max.compare_exchange_weak(Cur, Value, std::memory_order_relaxed))
+        ;
+    };
+    if (InMainSection)
+      AtomicMax(MaxMainCodeAlignment, Alignment);
+    if (InColdSection)
+      AtomicMax(MaxColdCodeAlignment, Alignment);
+  }
 
   /// Old .text info.
   uint64_t OldTextSectionAddress{0};

--- a/bolt/lib/Passes/Aligner.cpp
+++ b/bolt/lib/Passes/Aligner.cpp
@@ -165,6 +165,26 @@ Error AlignerPass::runOnFunctions(BinaryContext &BC) {
     else
       alignMaxBytes(BF);
 
+    // Record the function's effective code alignment so layout passes can align
+    // the tentative section base to the eventual section alignment without
+    // re-scanning all functions. AssignSections (run just before this pass) has
+    // assigned the output sections, so route the alignment to whichever of
+    // .text / .text.cold the function actually emits into: a whole cold
+    // function (and its constant island) lands entirely in .text.cold, while a
+    // split function contributes its (duplicated) island and code to both.
+    const uint16_t Align = std::max<uint16_t>(
+        BF.getAlignment(),
+        BF.hasIslandsInfo() ? BF.getConstantIslandAlignment() : uint16_t(0));
+    const SmallString<32> MainSectionName = BF.getCodeSectionName();
+    const bool InMainSection =
+        StringRef(MainSectionName) == BC.getMainCodeSectionName();
+    bool InColdSection =
+        StringRef(MainSectionName) == BC.getColdCodeSectionName();
+    if (!InColdSection && BF.isSplit())
+      InColdSection = StringRef(BF.getCodeSectionName(FragmentNum::cold())) ==
+                      BC.getColdCodeSectionName();
+    BC.updateMaxCodeAlignment(Align, InMainSection, InColdSection);
+
     if (opts::AlignBlocks && !opts::PreserveBlocksAlignment)
       alignBlocks(BF, Emitter.MCE.get());
   };

--- a/bolt/lib/Passes/LongJmp.cpp
+++ b/bolt/lib/Passes/LongJmp.cpp
@@ -317,7 +317,9 @@ void LongJmpPass::tentativeBBLayout(const BinaryFunction &Func) {
 uint64_t LongJmpPass::tentativeLayoutRelocColdPart(
     const BinaryContext &BC, BinaryFunctionListType &SortedFunctions,
     uint64_t DotAddress) {
-  DotAddress = alignTo(DotAddress, llvm::Align(opts::AlignFunctions));
+  DotAddress =
+      alignTo(DotAddress, std::max<uint64_t>(opts::AlignFunctions,
+                                             BC.MaxColdCodeAlignment.load()));
   for (BinaryFunction *Func : SortedFunctions) {
     if (!Func->isSplit())
       continue;
@@ -448,8 +450,12 @@ void LongJmpPass::tentativeLayout(const BinaryContext &BC,
     }
   }
 
-  if (!EstimatedTextSize || EstimatedTextSize > BC.OldTextSectionSize)
-    DotAddress = alignTo(BC.LayoutStartAddress, opts::AlignText);
+  if (!EstimatedTextSize || EstimatedTextSize > BC.OldTextSectionSize) {
+    uint64_t TextAlign =
+        std::max<uint64_t>(opts::AlignText, opts::AlignFunctions);
+    TextAlign = std::max<uint64_t>(TextAlign, BC.MaxMainCodeAlignment.load());
+    DotAddress = alignTo(BC.LayoutStartAddress, TextAlign);
+  }
 
   tentativeLayoutRelocMode(BC, SortedFunctions, DotAddress);
 }

--- a/bolt/lib/Passes/LongJmp.cpp
+++ b/bolt/lib/Passes/LongJmp.cpp
@@ -452,8 +452,7 @@ void LongJmpPass::tentativeLayout(const BinaryContext &BC,
 
   if (!EstimatedTextSize || EstimatedTextSize > BC.OldTextSectionSize) {
     uint64_t TextAlign =
-        std::max<uint64_t>(opts::AlignText, opts::AlignFunctions);
-    TextAlign = std::max<uint64_t>(TextAlign, BC.MaxMainCodeAlignment.load());
+        std::max<uint64_t>(opts::AlignText, BC.MaxMainCodeAlignment.load());
     DotAddress = alignTo(BC.LayoutStartAddress, TextAlign);
   }
 

--- a/bolt/lib/Rewrite/BinaryPassManager.cpp
+++ b/bolt/lib/Rewrite/BinaryPassManager.cpp
@@ -518,6 +518,11 @@ Error BinaryFunctionPassManager::runAllPasses(BinaryContext &BC) {
 
   Manager.registerPass(std::make_unique<Peepholes>(PrintPeepholes));
 
+  // Assign each function an output section before AlignerPass and LongJmpPass,
+  // so those passes can attribute per-section code alignment and tentative
+  // layout to the final .text / .text.cold sections.
+  Manager.registerPass(std::make_unique<AssignSections>());
+
   Manager.registerPass(std::make_unique<AlignerPass>());
 
   // Perform reordering on data contained in one or more sections using
@@ -554,9 +559,6 @@ Error BinaryFunctionPassManager::runAllPasses(BinaryContext &BC) {
 
   Manager.registerPass(
       std::make_unique<RetpolineInsertion>(PrintRetpolineInsertion));
-
-  // Assign each function an output section.
-  Manager.registerPass(std::make_unique<AssignSections>());
 
   // This pass turns tail calls into jumps which makes them invisible to
   // function reordering. It's unsafe to use any CFG or instruction analysis


### PR DESCRIPTION
Move `AssignSections` pass before `AlignerPass` so it can record the max code alignment per output section, then align the tentative hot/cold section bases using the recorded alignment, which makes tentative layout better match actually emitted.