### PR TITLE
[clang][AST] Attributed Type Deduplication Logic Cleanup

### DIFF
--- a/clang/lib/AST/AttrImpl.cpp
+++ b/clang/lib/AST/AttrImpl.cpp
@@ -391,7 +391,9 @@ namespace {
 
 template <class T>
 typename std::enable_if_t<!USE_DEFAULT_PROFILE>
-profileAttrArg(llvm::FoldingSetNodeID &, const ASTContext &, T) {}
+profileAttrArg(llvm::FoldingSetNodeID &, const ASTContext &, T) {
+  llvm_unreachable("profile not implemented for this type");
+}
 
 template <class T>
 typename std::enable_if_t<USE_DEFAULT_PROFILE>

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -14,7 +14,6 @@
 #include "Linkage.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
-#include "clang/AST/Attrs.inc"
 #include "clang/AST/CharUnits.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclBase.h"

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -3275,8 +3275,8 @@ static void emitAttributes(const RecordKeeper &Records, raw_ostream &OS,
       OS << "}\n\n";
     }
 
-    std::string ProfileSig = "Profile(llvm::FoldingSetNodeID &ID, "
-                             "const ASTContext &Ctx) const";
+    StringRef ProfileSig = "Profile(llvm::FoldingSetNodeID &ID, "
+                           "const ASTContext &Ctx) const";
     if (Header) {
       OS << "  void " << ProfileSig << ";\n";
     } else {


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/200961 implemented `AttributedType` deduplication using the attributes' arguments. This PR addresses the post-commit feedback. 

The reason to have `llvm_unreachable("profile not implemented for this type");` in the body of `profileAttrArg` for non-supported attribute types is that none of the attributes that currently instantiate this method are type attributes. The methods that are instantiated and not supported are all for decl attributes. Leaving the body out will lead to compilation failures, but the method's body should never be executed. If an unsupported attribute type happens to execute this code path, the failure should be loud and clear. 