### PR TITLE
[lldb] Fix LLDB_BUILD_FRAMEWORK with the dynamic script interpreters

### DIFF
--- a/lldb/cmake/modules/AddLLDB.cmake
+++ b/lldb/cmake/modules/AddLLDB.cmake
@@ -492,6 +492,31 @@ function(lldb_add_to_buildtree_lldb_framework name subdir)
     ${name}-cleanup)
 endfunction()
 
+# PluginManager discovers dynamic script interpreter plugins at runtime by
+# scanning the directory that holds liblldb, so a plugin is loaded only when it
+# sits beside it. A framework build moves liblldb into the bundle, so the plugin
+# must move with it and carry an rpath that reaches liblldb from its new
+# location.
+function(lldb_add_scriptinterpreter_plugin_to_framework name)
+  if(NOT LLDB_BUILD_FRAMEWORK)
+    return()
+  endif()
+  set_property(TARGET ${name} APPEND PROPERTY
+    INSTALL_RPATH "@loader_path/../../..")
+  # Copy under the unversioned name: PluginManager derives a plugin's
+  # initializer symbol from it. A versioned copy would load but never
+  # initialize.
+  set(plugin_in_framework
+    "${LLDB_FRAMEWORK_ABSOLUTE_BUILD_DIR}/LLDB.framework/Versions/${LLDB_FRAMEWORK_VERSION}/$<TARGET_LINKER_FILE_NAME:${name}>")
+  add_custom_command(TARGET ${name} POST_BUILD VERBATIM
+    COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:${name}>" "${plugin_in_framework}"
+    COMMENT "Copy ${name} into LLDB.framework")
+  add_custom_target(${name}-framework-cleanup
+    COMMAND ${CMAKE_COMMAND} -E remove "${plugin_in_framework}"
+    COMMENT "Removing ${name} from LLDB.framework")
+  add_dependencies(lldb-framework-cleanup ${name}-framework-cleanup)
+endfunction()
+
 # Add extra install steps for dSYM creation and stripping for the given target.
 function(lldb_add_post_install_steps_darwin name install_prefix)
   if(NOT APPLE)

--- a/lldb/source/Plugins/ScriptInterpreter/Lua/CMakeLists.txt
+++ b/lldb/source/Plugins/ScriptInterpreter/Lua/CMakeLists.txt
@@ -19,6 +19,8 @@ if (LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS)
       lldbPluginScriptInterpreterLua)
   endif()
 
+  lldb_add_scriptinterpreter_plugin_to_framework(lldbPluginScriptInterpreterLua)
+
   # Static variant linked directly by unit tests. Separate compilation is
   # required so llvm::Error RTTI (ErrorInfoBase::ID) has a single address
   # shared between the test binary and the plugin code.

--- a/lldb/source/Plugins/ScriptInterpreter/Python/CMakeLists.txt
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/CMakeLists.txt
@@ -77,6 +77,8 @@ if (LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS)
       lldbPluginScriptInterpreterPython)
   endif()
 
+  lldb_add_scriptinterpreter_plugin_to_framework(lldbPluginScriptInterpreterPython)
+
   # Static variant linked directly by unit tests. Separate compilation is
   # required so llvm::Error RTTI (ErrorInfoBase::ID) has a single address
   # shared between the test binary and the plugin code.


### PR DESCRIPTION
When using LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS (the default on Darwin as of #204015), the PluginManager loads at runtime by scanning the directory that holds liblldb. A framework build moves liblldb into LLDB.framework, but the plugins were only emitted into lib/ and never copied into the bundle, so they were never found.

Add lldb_add_scriptinterpreter_plugin_to_framework(), called from the Python and Lua plugin CMakeLists, which copies the plugin next to the framework binary and appends an rpath so it can resolve liblldb from inside the bundle. The copy uses the plugin's unversioned name because PluginManager derives the initializer symbol from it (a versioned copy would load but never register). Non-framework builds are unaffected.