### PR TITLE
[lldb] Only run libc++ tests when the architecture matches

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -841,7 +841,7 @@ def canRunLibcxxTests():
         )
         try:
             libcxx_arch_list = subprocess.check_output(
-                ["lipo", "-archs", libcxx_dylib_path], encoding="utf-8"
+                ["lipo", "-archs", libcxx_dylib_path], text=True
             ).split()
             if test_architecture not in libcxx_arch_list:
                 return False, f"libc++ dylib missing {test_architecture} slice"

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -842,7 +842,7 @@ def canRunLibcxxTests():
         try:
             libcxx_arch_list = subprocess.check_output(
                 ["lipo", "-archs", libcxx_dylib_path], encoding="utf-8"
-            ).split(" ")
+            ).split()
             if test_architecture not in libcxx_arch_list:
                 return False, f"libc++ dylib missing {test_architecture} slice"
         except subprocess.CalledProcessError:

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -832,6 +832,22 @@ def canRunLibcxxTests():
     if lldbplatformutil.platformIsDarwin():
         if not configuration.libcxx_include_dir or not configuration.libcxx_library_dir:
             return False, "libc++ tests require a locally built libc++"
+
+        # Check that the libc++ architecture matches the test architecture.
+        test_architecture = lldbplatformutil.getArchitecture()
+
+        libcxx_dylib_path = os.path.join(
+            configuration.libcxx_library_dir, "libc++.dylib"
+        )
+        try:
+            libcxx_arch_list = subprocess.check_output(
+                ["lipo", "-archs", libcxx_dylib_path], encoding="utf-8"
+            ).split(" ")
+            if test_architecture not in libcxx_arch_list:
+                return False, f"libc++ dylib missing {test_architecture} slice"
+        except subprocess.CalledProcessError:
+            return False, "libc++ dylib is not present"
+
         return True, "libc++ present"
 
     if platform == "linux":


### PR DESCRIPTION
It does not make sense to run the libc++ tests when the libc++ dylib has an architecture that does not match the test binary.

I ran into this when running the test suite with arm64e test binaries and the locally-built libc++ is built arm64.