### PR TITLE
[lldb][NFC] Remove const char * from ProcessInfo interface

### DIFF
--- a/lldb/include/lldb/Utility/ProcessInfo.h
+++ b/lldb/include/lldb/Utility/ProcessInfo.h
@@ -36,9 +36,7 @@ public:
 
   void Clear();
 
-  const char *GetName() const;
-
-  llvm::StringRef GetNameAsStringRef() const;
+  llvm::StringRef GetName() const;
 
   FileSpec &GetExecutableFile() { return m_executable; }
 
@@ -329,7 +327,7 @@ public:
   bool ArchitectureMatches(const ArchSpec &arch_spec) const;
 
   /// Return true iff the process name in this object matches process_name.
-  bool NameMatches(const char *process_name) const;
+  bool NameMatches(llvm::StringRef process_name) const;
 
   /// Return true iff the process ID and parent process IDs in this object match
   /// the ones in proc_info.

--- a/lldb/source/Commands/CommandCompletions.cpp
+++ b/lldb/source/Commands/CommandCompletions.cpp
@@ -722,7 +722,7 @@ void CommandCompletions::ProcessIDs(CommandInterpreter &interpreter,
   platform_sp->FindProcesses(match_info, process_infos);
   for (const ProcessInstanceInfo &info : process_infos)
     request.TryCompleteCurrentArg(std::to_string(info.GetProcessID()),
-                                  info.GetNameAsStringRef());
+                                  info.GetName());
 }
 
 void CommandCompletions::ProcessNames(CommandInterpreter &interpreter,
@@ -735,7 +735,7 @@ void CommandCompletions::ProcessNames(CommandInterpreter &interpreter,
   ProcessInstanceInfoMatch match_info;
   platform_sp->FindProcesses(match_info, process_infos);
   for (const ProcessInstanceInfo &info : process_infos)
-    request.TryCompleteCurrentArg(info.GetNameAsStringRef());
+    request.TryCompleteCurrentArg(info.GetName());
 }
 
 void CommandCompletions::TypeLanguages(CommandInterpreter &interpreter,

--- a/lldb/source/Commands/CommandObjectPlatform.cpp
+++ b/lldb/source/Commands/CommandObjectPlatform.cpp
@@ -1248,9 +1248,9 @@ protected:
         const uint32_t matches =
             platform_sp->FindProcesses(m_options.match_info, proc_infos);
         const char *match_desc = nullptr;
-        const char *match_name =
+        llvm::StringRef match_name =
             m_options.match_info.GetProcessInfo().GetName();
-        if (match_name && match_name[0]) {
+        if (!match_name.empty()) {
           switch (m_options.match_info.GetNameMatchType()) {
           case NameMatch::Ignore:
             break;

--- a/lldb/source/Plugins/Process/elf-core/ThreadElfCore.cpp
+++ b/lldb/source/Plugins/Process/elf-core/ThreadElfCore.cpp
@@ -503,7 +503,7 @@ ELFLinuxPrPsInfo::Populate(const lldb_private::ProcessInstanceInfo &info,
 
   constexpr size_t fname_len = std::extent_v<decltype(prpsinfo.pr_fname)>;
   static_assert(fname_len > 0, "This should always be non zero");
-  const llvm::StringRef fname = info.GetNameAsStringRef();
+  const llvm::StringRef fname = info.GetName();
   auto fname_begin = fname.begin();
   std::copy_n(fname_begin, std::min(fname_len, fname.size()),
               prpsinfo.pr_fname);

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -2425,9 +2425,9 @@ uint32_t GDBRemoteCommunicationClient::FindProcesses(
     packet.PutCString("qfProcessInfo");
     if (!match_info.MatchAllProcesses()) {
       packet.PutChar(':');
-      const char *name = match_info.GetProcessInfo().GetName();
+      llvm::StringRef name = match_info.GetProcessInfo().GetName();
       bool has_name_match = false;
-      if (name && name[0]) {
+      if (!name.empty()) {
         has_name_match = true;
         NameMatch name_match_type = match_info.GetNameMatchType();
         switch (name_match_type) {
@@ -2457,7 +2457,7 @@ uint32_t GDBRemoteCommunicationClient::FindProcesses(
         }
         if (has_name_match) {
           packet.PutCString("name:");
-          packet.PutBytesAsRawHex8(name, ::strlen(name));
+          packet.PutBytesAsRawHex8(name.data(), name.size());
           packet.PutChar(';');
         }
       }

--- a/lldb/source/Utility/ProcessInfo.cpp
+++ b/lldb/source/Utility/ProcessInfo.cpp
@@ -42,11 +42,7 @@ void ProcessInfo::Clear() {
   m_scripted_metadata_sp.reset();
 }
 
-const char *ProcessInfo::GetName() const {
-  return m_executable.GetFilename().GetCString();
-}
-
-llvm::StringRef ProcessInfo::GetNameAsStringRef() const {
+llvm::StringRef ProcessInfo::GetName() const {
   return m_executable.GetFilename().GetStringRef();
 }
 
@@ -256,11 +252,11 @@ bool ProcessInstanceInfoMatch::ArchitectureMatches(
          m_match_info.GetArchitecture().IsCompatibleMatch(arch_spec);
 }
 
-bool ProcessInstanceInfoMatch::NameMatches(const char *process_name) const {
+bool ProcessInstanceInfoMatch::NameMatches(llvm::StringRef process_name) const {
   if (m_name_match_type == NameMatch::Ignore)
     return true;
-  const char *match_name = m_match_info.GetName();
-  if (!match_name)
+  llvm::StringRef match_name = m_match_info.GetName();
+  if (match_name.empty())
     return true;
 
   return lldb_private::NameMatches(process_name, m_name_match_type, match_name);

--- a/lldb/unittests/Utility/ProcessInfoTest.cpp
+++ b/lldb/unittests/Utility/ProcessInfoTest.cpp
@@ -13,7 +13,7 @@ using namespace lldb_private;
 
 TEST(ProcessInfoTest, Constructor) {
   ProcessInfo Info("foo", ArchSpec("x86_64-pc-linux"), 47);
-  EXPECT_STREQ("foo", Info.GetName());
+  EXPECT_EQ("foo", Info.GetName());
   EXPECT_EQ(ArchSpec("x86_64-pc-linux"), Info.GetArchitecture());
   EXPECT_EQ(47u, Info.GetProcessID());
 }


### PR DESCRIPTION
My primary reason for doing this is so that I can refactor FileSpec's interface to stop using ConstStrings. But more generally StringRef is sufficient for ProcessInfo's needs. Any spot that actually needs an actual `const char *` can create one from the StringRef.