### PR TITLE
[clang][test] Use `FileCheck` in `Rewriter/objc-modern-getclass-proto.mm`

### DIFF
--- a/clang/test/Rewriter/objc-modern-getclass-proto.mm
+++ b/clang/test/Rewriter/objc-modern-getclass-proto.mm
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 -E %s -o %t.mm
-// RUN: %clang_cc1 -x objective-c++ -fblocks -fms-extensions -rewrite-objc -fobjc-runtime=macosx-fragile-10.5 %t.mm -o %t-rw.cpp
+// RUN: %clang_cc1 -x objective-c++ -fblocks -fms-extensions -rewrite-objc -fobjc-runtime=macosx-10.7 %t.mm -o %t-rw.cpp
+// RUN: FileCheck --input-file=%t-rw.cpp %s
 
 @interface I @end
 @implementation I @end


### PR DESCRIPTION
The test had `CHECK` directives that were never executed because no `RUN` line invoked `FileCheck` on the output.

The test also used a fragile runtime, which invoked the fragile rewriter instead of the modern one the test was written for.

Switch to a non-fragile runtime so the modern rewriter runs as the test intended.