### PR TITLE
[llvm] Fix APFloat::exp for 32-bit x86 when dealing with signaling NaNs.

### DIFF
--- a/llvm/lib/Support/APFloat.cpp
+++ b/llvm/lib/Support/APFloat.cpp
@@ -6121,21 +6121,35 @@ std::optional<APFloat> exp(const APFloat &x, RoundingMode rounding_mode,
   if (rounding_mode == APFloatBase::rmNearestTiesToEven) {
     if (APFloat::SemanticsToEnum(x.getSemantics()) ==
         APFloatBase::S_IEEEsingle) {
-      float x_val = x.bitcastToAPInt().bitsToFloat();
+      float x_val = x.convertToFloat();
       int exc =
           LIBC_NAMESPACE::shared::check::exp_exceptions(x_val, FE_TONEAREST);
-      if (status)
+      if (status) {
         *status = getOpStatusFromLibc(exc);
+        if (x.isSignaling()) {
+          // 32-bit x86 will silence sNaN when loading floats, so we explicitly
+          // add the INVALID exception here.
+          *status =
+              static_cast<APFloat::opStatus>(*status | APFloat::opInvalidOp);
+        }
+      }
       float result = LIBC_NAMESPACE::shared::expf(x_val);
       return APFloat(result);
     }
     if (APFloat::SemanticsToEnum(x.getSemantics()) ==
         APFloatBase::S_IEEEdouble) {
-      double x_val = x.bitcastToAPInt().bitsToDouble();
+      double x_val = x.convertToDouble();
       int exc =
           LIBC_NAMESPACE::shared::check::exp_exceptions(x_val, FE_TONEAREST);
-      if (status)
+      if (status) {
         *status = getOpStatusFromLibc(exc);
+        if (x.isSignaling()) {
+          // 32-bit x86 will silence sNaN when loading floats, so we explicitly
+          // add the INVALID exception here.
+          *status =
+              static_cast<APFloat::opStatus>(*status | APFloat::opInvalidOp);
+        }
+      }
       double result = LIBC_NAMESPACE::shared::exp(x_val);
       return APFloat(result);
     }

--- a/llvm/lib/Support/APFloat.cpp
+++ b/llvm/lib/Support/APFloat.cpp
@@ -38,9 +38,7 @@
 /// explicitly.  We also put them in a separate namespace so that the symbols
 /// do not clash with other libc math builds just in case.
 #define LIBC_NAMESPACE __llvm_libc_apfloat
-#define LIBC_MATH                                                              \
-  (LIBC_MATH_NO_ERRNO | LIBC_MATH_NO_EXCEPT |                                  \
-   LIBC_MATH_ASSUME_ROUND_NEAREST_ONLY)
+#define LIBC_MATH (LIBC_MATH_NO_ERRNO | LIBC_MATH_NO_EXCEPT)
 
 #include "shared/math.h"
 #include "shared/math_check_exceptions.h"

--- a/llvm/lib/Support/APFloat.cpp
+++ b/llvm/lib/Support/APFloat.cpp
@@ -38,7 +38,9 @@
 /// explicitly.  We also put them in a separate namespace so that the symbols
 /// do not clash with other libc math builds just in case.
 #define LIBC_NAMESPACE __llvm_libc_apfloat
-#define LIBC_MATH (LIBC_MATH_NO_ERRNO | LIBC_MATH_NO_EXCEPT)
+#define LIBC_MATH                                                              \
+  (LIBC_MATH_NO_ERRNO | LIBC_MATH_NO_EXCEPT |                                  \
+   LIBC_MATH_ASSUME_ROUND_NEAREST_ONLY)
 
 #include "shared/math.h"
 #include "shared/math_check_exceptions.h"
@@ -6121,7 +6123,7 @@ std::optional<APFloat> exp(const APFloat &x, RoundingMode rounding_mode,
   if (rounding_mode == APFloatBase::rmNearestTiesToEven) {
     if (APFloat::SemanticsToEnum(x.getSemantics()) ==
         APFloatBase::S_IEEEsingle) {
-      float x_val = x.convertToFloat();
+      float x_val = x.bitcastToAPInt().bitsToFloat();
       int exc =
           LIBC_NAMESPACE::shared::check::exp_exceptions(x_val, FE_TONEAREST);
       if (status)
@@ -6131,7 +6133,7 @@ std::optional<APFloat> exp(const APFloat &x, RoundingMode rounding_mode,
     }
     if (APFloat::SemanticsToEnum(x.getSemantics()) ==
         APFloatBase::S_IEEEdouble) {
-      double x_val = x.convertToDouble();
+      double x_val = x.bitcastToAPInt().bitsToDouble();
       int exc =
           LIBC_NAMESPACE::shared::check::exp_exceptions(x_val, FE_TONEAREST);
       if (status)


### PR DESCRIPTION
Currently APFloat::exp uses convertToFloat and convertToDouble which
might silence sNaN on 32-bit x86.  Add `APFloat::isSignaling` check explicitly.