### PR TITLE
[bazel] Use --incompatible_default_to_explicit_init_py

### DIFF
--- a/utils/bazel/.bazelrc
+++ b/utils/bazel/.bazelrc
@@ -12,6 +12,9 @@ common --enable_bzlmod --noenable_workspace
 # TODO: Remove lit test reliance on this
 common --legacy_external_runfiles
 
+# Prevent automatic __init__.py generation from confusing some lit tests.
+common --incompatible_default_to_explicit_init_py
+
 # Prevent invalid caching if input files are modified during a build.
 build --guard_against_concurrent_changes
 

--- a/utils/bazel/llvm-project-overlay/llvm/utils/lit/tests/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/utils/lit/tests/BUILD.bazel
@@ -38,11 +38,7 @@ expand_template(
         ["**/*.py"],
         exclude = [
             "Inputs/**",
-            "discovery.py",  # TODO: debug and re-enable
-            "max-time.py",
-            "selecting.py",
-            "shtest-recursive-substitution.py",
-            "use-llvm-tool.py",
+            "use-llvm-tool.py",  # TODO: debug and re-enable
         ],
     )
 ]


### PR DESCRIPTION
After #203998, the `per-test-coverage-by-lit-cfg.py` test is failing in Bazel. It seems to be due to automatic `__init__.py` generation.

With some extra logs:
```
# .---command stdout------------
# | -- Testing: 5 tests, 1 workers --
# | FAIL: per-test-coverage-by-lit-cfg :: name-collision/__init__.py (1 of 5)
# | ******************** TEST 'per-test-coverage-by-lit-cfg :: name-collision/__init__.py' FAILED ********************
...
# | # .---command stderr------------
# | # | error: no check strings found with prefix 'CHECK:'
# | # `----------------------------- 
```

I am not sure exactly the best way to deal with this, but `--incompatible_default_to_explicit_init_py` disables this behavior and makes the test pass. I also found some other excluded tests that now pass, some of which have a similar directory structure, so those may have the same underlying root cause.