### PR TITLE
[RDF] Replace unordered_map with DenseMap. NFC

### DIFF
--- a/llvm/include/llvm/CodeGen/RDFGraph.h
+++ b/llvm/include/llvm/CodeGen/RDFGraph.h
@@ -226,6 +226,7 @@
 
 #include "RDFRegisters.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/MC/LaneBitmask.h"
 #include "llvm/Support/Allocator.h"
@@ -236,7 +237,6 @@
 #include <map>
 #include <memory>
 #include <set>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -770,9 +770,8 @@ struct DataFlowGraph {
     StorageType Stack;
   };
 
-  // Make this std::unordered_map for speed of accessing elements.
   // Map: Register (physical or virtual) -> DefStack
-  using DefStackMap = std::unordered_map<RegisterId, DefStack>;
+  using DefStackMap = DenseMap<RegisterId, DefStack>;
 
   LLVM_ABI void build(const Config &config);
   void build() { build(Config()); }

--- a/llvm/include/llvm/CodeGen/RDFLiveness.h
+++ b/llvm/include/llvm/CodeGen/RDFLiveness.h
@@ -18,7 +18,6 @@
 #include "llvm/MC/LaneBitmask.h"
 #include <map>
 #include <set>
-#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 
@@ -57,7 +56,7 @@ public:
   using LiveMapType = RegisterAggrMap<MachineBasicBlock *>;
   using NodeRef = detail::NodeRef;
   using NodeRefSet = std::unordered_set<NodeRef>;
-  using RefMap = std::unordered_map<RegisterId, NodeRefSet>;
+  using RefMap = DenseMap<RegisterId, NodeRefSet>;
 
   Liveness(MachineRegisterInfo &mri, const DataFlowGraph &g)
       : DFG(g), TRI(g.getTRI()), PRI(g.getPRI()), MDT(g.getDT()),

--- a/llvm/lib/CodeGen/RDFGraph.cpp
+++ b/llvm/lib/CodeGen/RDFGraph.cpp
@@ -1016,12 +1016,7 @@ void DataFlowGraph::releaseBlock(NodeId B, DefStackMap &DefM) {
     P.second.clear_block(B);
 
   // Finally, remove empty stacks from the map.
-  for (auto I = DefM.begin(), E = DefM.end(), NextI = I; I != E; I = NextI) {
-    NextI = std::next(I);
-    // This preserves the validity of iterators other than I.
-    if (I->second.empty())
-      DefM.erase(I);
-  }
+  DefM.remove_if([](const auto &P) { return P.second.empty(); });
 }
 
 // Push all definitions from the instruction node IA to an appropriate

--- a/llvm/lib/CodeGen/RDFLiveness.cpp
+++ b/llvm/lib/CodeGen/RDFLiveness.cpp
@@ -471,8 +471,7 @@ void Liveness::computePhiInfo() {
   // phi use -> (map: reaching phi -> set of registers defined in between)
   std::map<NodeId, std::map<NodeId, RegisterAggr>> PhiUp;
   std::vector<NodeId> PhiUQ; // Work list of phis for upward propagation.
-  std::unordered_map<NodeId, RegisterAggr>
-      PhiDRs; // Phi -> registers defined by it.
+  DenseMap<NodeId, RegisterAggr> PhiDRs; // Phi -> registers defined by it.
 
   // Go over all phis.
   for (NodeAddr<PhiNode *> PhiA : Phis) {
@@ -574,8 +573,10 @@ void Liveness::computePhiInfo() {
           UI->second.insert({I.first, S.Mask});
         }
       }
-      UI = UI->second.empty() ? RealUses.erase(UI) : std::next(UI);
+      ++UI;
     }
+    // Drop the entries whose use sets ended up empty.
+    emptify(RealUses);
 
     // If this phi reaches some "real" uses, add it to the queue for upward
     // propagation.
@@ -697,7 +698,7 @@ void Liveness::computePhiInfo() {
         //     if MidDefs does not cover (R,U)
         //       then add (R-MidDefs,U) to RealUseMap[P]
         //
-        for (const std::pair<const RegisterId, NodeRefSet> &T : RUM) {
+        for (const auto &T : RUM) {
           RegisterRef R(T.first);
           // The current phi (PA) could be a phi for a regmask. It could
           // reach a whole variety of uses that are not related to the
@@ -830,7 +831,7 @@ void Liveness::computeLiveIns() {
         auto PrA = DFG.addr<BlockNode *>(PUA.Addr->getPredecessor());
         RefMap &LOX = PhiLOX[PrA.Addr->getCode()];
 
-        for (const std::pair<const RegisterId, NodeRefSet> &RS : RUs) {
+        for (const auto &RS : RUs) {
           // We need to visit each individual use.
           for (std::pair<NodeId, LaneBitmask> P : RS.second) {
             // Create a register ref corresponding to the use, and find
@@ -1048,7 +1049,7 @@ void Liveness::traverse(MachineBasicBlock *B, RefMap &LiveIn) {
   RefMap LiveInCopy = LiveIn;
   LiveIn.clear();
 
-  for (const std::pair<const RegisterId, NodeRefSet> &LE : LiveInCopy) {
+  for (const auto &LE : LiveInCopy) {
     RegisterRef LRef(LE.first);
     NodeRefSet &NewDefs = LiveIn[LRef.Id]; // To be filled.
     const NodeRefSet &OldDefs = LE.second;
@@ -1162,7 +1163,7 @@ void Liveness::traverse(MachineBasicBlock *B, RefMap &LiveIn) {
 
   for (auto *C : IIDF[B]) {
     RegisterAggr &LiveC = LiveMap[C];
-    for (const std::pair<const RegisterId, NodeRefSet> &S : LiveIn)
+    for (const auto &S : LiveIn)
       for (auto R : S.second)
         if (MDT.properlyDominates(getBlockWithRef(R.first), C))
           LiveC.insert(RegisterRef(S.first, R.second));
@@ -1170,8 +1171,7 @@ void Liveness::traverse(MachineBasicBlock *B, RefMap &LiveIn) {
 }
 
 void Liveness::emptify(RefMap &M) {
-  for (auto I = M.begin(), E = M.end(); I != E;)
-    I = I->second.empty() ? M.erase(I) : std::next(I);
+  M.remove_if([](const auto &P) { return P.second.empty(); });
 }
 
 } // namespace llvm::rdf


### PR DESCRIPTION
std::unordered_map is slow. Switch DefStackMap and RefMap to DenseMap.
erase-while-iterating loops become DenseMap::remove_if.