### PR TITLE
[llvm-nm][AIX] Set default to 'any' if OBJECT_MODE is not set

### DIFF
--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -495,7 +495,6 @@ elif platform.system() == "AIX":
 # "OBJECT_MODE" to "any" by default on AIX OS.
 
 if "system-aix" in config.available_features:
-   config.substitutions.append(("llvm-nm", "env OBJECT_MODE=any llvm-nm"))
    config.substitutions.append(("llvm-ar", "env OBJECT_MODE=any llvm-ar"))
    config.substitutions.append(("llvm-ranlib", "env OBJECT_MODE=any llvm-ranlib"))
 

--- a/llvm/docs/CommandGuide/llvm-nm.rst
+++ b/llvm/docs/CommandGuide/llvm-nm.rst
@@ -141,11 +141,10 @@ OPTIONS
    any
          Process all the supported object files.
 
-  On AIX OS, the default is to process 32-bit object files only and to ignore
-  64-bit objects. The can be changed by setting the OBJECT_MODE environment
-  variable. For example, OBJECT_MODE=64 causes :program:`llvm-nm` to process
-  64-bit objects and ignore 32-bit objects. The -X flag overrides the OBJECT_MODE
-  variable.
+  On AIX OS, the default is to process all object files and it can be changed
+  by setting the OBJECT_MODE environment variable. For example, OBJECT_MODE=64
+  causes :program:`llvm-nm` to process 64-bit objects and ignore 32-bit objects.
+  The -X flag overrides the OBJECT_MODE variable.
 
   On other operating systems, the default is to process all object files: the
   OBJECT_MODE environment variable is not supported.

--- a/llvm/test/tools/llvm-nm/option-X-AIX.test
+++ b/llvm/test/tools/llvm-nm/option-X-AIX.test
@@ -8,7 +8,7 @@
 
 ## Test default "-X" option.
 # RUN: env -u OBJECT_MODE llvm-nm --format=just-symbols %t_xcoff32.o %t_xcoff64.o | \
-# RUN:   FileCheck -DFILE32=%t_xcoff32.o --check-prefixes=XCOFF32 %s --implicit-check-not={{.}}
+# RUN:   FileCheck -DFILE32=%t_xcoff32.o -DFILE64=%t_xcoff64.o --check-prefixes=XCOFF32,XCOFF64 %s --implicit-check-not={{.}}
 
 ## Test environment variable "OBJECT_MODE".
 # RUN: env OBJECT_MODE=32 llvm-nm --format=just-symbols %t_xcoff32.o %t_xcoff64.o | \

--- a/llvm/tools/llvm-nm/llvm-nm.cpp
+++ b/llvm/tools/llvm-nm/llvm-nm.cpp
@@ -2487,7 +2487,8 @@ int llvm_nm_main(int argc, char **argv, const llvm::ToolContext &) {
                   .Case("32_64", BitModeTy::Bit32_64)
                   .Case("any", BitModeTy::Any)
                   .Default(BitModeTy::Any);
-  }
+  } else
+    BitMode = BitModeTy::Any;
 
   if (Arg *A = Args.getLastArg(OPT_X)) {
     StringRef Mode = A->getValue();

--- a/llvm/tools/llvm-nm/llvm-nm.cpp
+++ b/llvm/tools/llvm-nm/llvm-nm.cpp
@@ -2480,16 +2480,13 @@ int llvm_nm_main(int argc, char **argv, const llvm::ToolContext &) {
   // Get BitMode from enviornment variable "OBJECT_MODE" for AIX OS, if
   // specified.
   Triple HostTriple(sys::getProcessTriple());
-  BitMode = BitModeTy::Any;
   if (HostTriple.isOSAIX()) {
-    if (char *ObjMode = getenv("OBJECT_MODE")) {
-      BitMode = StringSwitch<BitModeTy>(ObjMode)
-                    .Case("32", BitModeTy::Bit32)
-                    .Case("64", BitModeTy::Bit64)
-                    .Case("32_64", BitModeTy::Bit32_64)
-                    .Case("any", BitModeTy::Any)
-                    .Default(BitModeTy::Any);
-    }
+    BitMode = StringSwitch<BitModeTy>(getenv("OBJECT_MODE"))
+                  .Case("32", BitModeTy::Bit32)
+                  .Case("64", BitModeTy::Bit64)
+                  .Case("32_64", BitModeTy::Bit32_64)
+                  .Case("any", BitModeTy::Any)
+                  .Default(BitModeTy::Any);
   }
 
   if (Arg *A = Args.getLastArg(OPT_X)) {

--- a/llvm/tools/llvm-nm/llvm-nm.cpp
+++ b/llvm/tools/llvm-nm/llvm-nm.cpp
@@ -2480,15 +2480,17 @@ int llvm_nm_main(int argc, char **argv, const llvm::ToolContext &) {
   // Get BitMode from enviornment variable "OBJECT_MODE" for AIX OS, if
   // specified.
   Triple HostTriple(sys::getProcessTriple());
+  BitMode = BitModeTy::Any;
   if (HostTriple.isOSAIX()) {
-    BitMode = StringSwitch<BitModeTy>(getenv("OBJECT_MODE"))
-                  .Case("32", BitModeTy::Bit32)
-                  .Case("64", BitModeTy::Bit64)
-                  .Case("32_64", BitModeTy::Bit32_64)
-                  .Case("any", BitModeTy::Any)
-                  .Default(BitModeTy::Bit32);
-  } else
-    BitMode = BitModeTy::Any;
+    if (char *ObjMode = getenv("OBJECT_MODE")) {
+      BitMode = StringSwitch<BitModeTy>(ObjMode)
+                    .Case("32", BitModeTy::Bit32)
+                    .Case("64", BitModeTy::Bit64)
+                    .Case("32_64", BitModeTy::Bit32_64)
+                    .Case("any", BitModeTy::Any)
+                    .Default(BitModeTy::Any);
+    }
+  }
 
   if (Arg *A = Args.getLastArg(OPT_X)) {
     StringRef Mode = A->getValue();


### PR DESCRIPTION
Currently, the llvm-nm defaults to `32` if OBJECT_MODE is not set. This patch is to change the default to `any` to make the usage more flexible.