### PR TITLE
[ELF][AArch64] Relax zero TLSLE add to nop

### DIFF
--- a/lld/ELF/Arch/AArch64.cpp
+++ b/lld/ELF/Arch/AArch64.cpp
@@ -787,6 +787,14 @@ void AArch64::relocate(uint8_t *loc, const Relocation &rel,
     break;
   case R_AARCH64_TLSLE_ADD_TPREL_HI12:
     checkUInt(ctx, loc, val, 24, rel);
+    if (ctx.arg.relax && (val >> 12) == 0) {
+      uint32_t inst = read32le(loc);
+      // The W-form zero-extends Xd, so only the X-form is a nop.
+      if ((inst & (1u << 31)) && (inst & 0x1f) == ((inst >> 5) & 0x1f)) {
+        write32le(loc, 0xd503201f); // nop
+        break;
+      }
+    }
     write32Imm12(loc, val >> 12);
     break;
   case R_AARCH64_TLSLE_ADD_TPREL_LO12_NC:

--- a/lld/test/ELF/aarch64-tls-le.s
+++ b/lld/test/ELF/aarch64-tls-le.s
@@ -1,7 +1,9 @@
 # REQUIRES: aarch64
 # RUN: llvm-mc -filetype=obj -triple=aarch64 %s -o %t.o
 # RUN: ld.lld %t.o -o %t
-# RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn %t | FileCheck %s
+# RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn %t | FileCheck %s --check-prefixes=CHECK,RELAX
+# RUN: ld.lld --no-relax %t.o -o %t.norelax
+# RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn %t.norelax | FileCheck %s --check-prefixes=CHECK,NORELAX
 # RUN: llvm-readobj -S -r %t | FileCheck -check-prefix=RELOC %s
 
 #Local-Dynamic to Local-Exec relax creates no
@@ -15,6 +17,9 @@
 # ERR: error: relocation R_AARCH64_TLSLE_ADD_TPREL_LO12_NC against v1 cannot be used with -shared
 # ERR: error: relocation R_AARCH64_TLSLE_ADD_TPREL_HI12 against v2 cannot be used with -shared
 # ERR: error: relocation R_AARCH64_TLSLE_ADD_TPREL_LO12_NC against v2 cannot be used with -shared
+# ERR: error: relocation R_AARCH64_TLSLE_ADD_TPREL_HI12 against v1 cannot be used with -shared
+# ERR: error: relocation R_AARCH64_TLSLE_ADD_TPREL_HI12 against v1 cannot be used with -shared
+# ERR: error: relocation R_AARCH64_TLSLE_ADD_TPREL_HI12 against v1 cannot be used with -shared
 
 .globl _start
 _start:
@@ -24,16 +29,24 @@ _start:
  mrs x0, TPIDR_EL0
  add x0, x0, :tprel_hi12:v2
  add x0, x0, :tprel_lo12_nc:v2
+ add x2, x1, :tprel_hi12:v1
+ add w3, w3, :tprel_hi12:v1
+ add sp, sp, :tprel_hi12:v1
 
 # TCB size = 0x16 and foo is first element from TLS register.
 #CHECK: Disassembly of section .text:
 #CHECK:      <_start>:
 #CHECK-NEXT:   mrs     x0, TPIDR_EL0
-#CHECK-NEXT:   add     x0, x0, #0, lsl #12
+#RELAX-NEXT:   nop
+#NORELAX-NEXT:   add     x0, x0, #0, lsl #12
 #CHECK-NEXT:   add     x0, x0, #16
 #CHECK-NEXT:   mrs     x0, TPIDR_EL0
 #CHECK-NEXT:   add     x0, x0, #4095, lsl #12
 #CHECK-NEXT:   add     x0, x0, #4088
+#CHECK-NEXT:   add     x2, x1, #0, lsl #12
+#CHECK-NEXT:   add     w3, w3, #0, lsl #12
+#RELAX-NEXT:   nop
+#NORELAX-NEXT:   add     sp, sp, #0, lsl #12
 
 .section        .tbss,"awT",@nobits
 

--- a/lld/test/ELF/aarch64-tlsld-ldst.s
+++ b/lld/test/ELF/aarch64-tlsld-ldst.s
@@ -27,7 +27,7 @@ _start:  mrs x8, TPIDR_EL0
 // CHECK: <_start>:
 // CHECK-NEXT:    210158:       mrs     x8, TPIDR_EL0
 // 0x0 + c10 = 0xc10       = tcb (16-bytes) + var0
-// CHECK-NEXT:    21015c:       add     x8, x8, #0, lsl #12
+// CHECK-NEXT:    21015c:       nop
 // CHECK-NEXT:    210160:       ldr     q20, [x8, #3088]
 // 0x1000 + 0x820 = 0x1820 = tcb + var1
 // CHECK-NEXT:    210164:       add     x8, x8, #1, lsl #12


### PR DESCRIPTION
Optimize AArch64 local-exec TLS relocation handling by replacing a
self-add R_AARCH64_TLSLE_ADD_TPREL_HI12 instruction with nop when the
high 12 bits are zero.

The optimization is disabled by --no-relax and avoids non-equivalent
forms such as non-self-adds and 32-bit destination registers.