### PR TITLE
[SimplifyCFG]divergent undef predecessor removal

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -8905,9 +8905,12 @@ static bool passingValueIsAlwaysUndefined(Value *V, Instruction *I, bool PtrValu
         if (isa<ConstantPointerNull>(C) &&
             CB->paramHasNonNullAttr(ArgIdx, /*AllowUndefOrPoison=*/false))
           return !PtrValueMayBeModified;
-        // Passing undef to a noundef argument is undefined.
+        // Passing poison/undef to a noundef argument is undefined in the
+        // single-lane IR model, unless the call is convergent: at a join
+        // point, convergent operations bind SIMT semantics and poison on one
+        // PHI incoming edge does not imply that predecessor is unreachable.
         if (isa<UndefValue>(C) && CB->isPassingUndefUB(ArgIdx))
-          return true;
+          return !CB->isConvergent();
       }
     }
     // Div/Rem by zero is immediate UB

--- a/llvm/test/Transforms/SimplifyCFG/divergent-poison-phi.ll
+++ b/llvm/test/Transforms/SimplifyCFG/divergent-poison-phi.ll
@@ -1,0 +1,64 @@
+; REQUIRES: amdgpu-registered-target && x86-registered-target
+; RUN: opt < %s -mtriple=amdgcn -passes=simplifycfg -S | FileCheck %s -check-prefix=DIVERGENT
+; RUN: opt < %s -mtriple=x86_64 -passes=simplifycfg -S | FileCheck %s -check-prefix=UNIFORM
+
+; When poison on a PHI incoming edge flows to a convergent noundef call at a
+; join point, do not treat that edge as unreachable. Scalar folding remains
+; valid for the same pattern with a non-convergent callee.
+
+declare i32 @llvm.amdgcn.workitem.id.x() #0
+
+declare i32 @shuffle(i32 noundef, i32 noundef) convergent
+
+declare i32 @use_val(i32 noundef)
+
+define amdgpu_kernel void @k_convergent(ptr addrspace(1) nocapture %counter, ptr addrspace(1) nocapture %out) #1 {
+; DIVERGENT-LABEL: @k_convergent(
+entry:
+  %tid = tail call i32 @llvm.amdgcn.workitem.id.x()
+  %cmp = icmp eq i32 %tid, 0
+  br i1 %cmp, label %if.then, label %if.end
+
+if.then:
+  %old = atomicrmw add ptr addrspace(1) %counter, i32 1 monotonic, align 4
+  br label %if.end
+
+if.end:
+  %val = phi i32 [ %old, %if.then ], [ poison, %entry ]
+  %shfl = tail call i32 @shuffle(i32 noundef %val, i32 noundef %tid) #2
+  %idx = zext i32 %tid to i64
+  %ptr = getelementptr i32, ptr addrspace(1) %out, i64 %idx
+  store i32 %shfl, ptr addrspace(1) %ptr, align 4
+  ret void
+}
+
+define void @k_scalar(i32 %tid, ptr nocapture %counter, ptr nocapture %out) {
+; UNIFORM-LABEL: @k_scalar(
+entry:
+  %cmp = icmp eq i32 %tid, 0
+  br i1 %cmp, label %if.then, label %if.end
+
+if.then:
+  %old = atomicrmw add ptr %counter, i32 1 monotonic, align 4
+  br label %if.end
+
+if.end:
+  %val = phi i32 [ %old, %if.then ], [ poison, %entry ]
+  %use = call i32 @use_val(i32 noundef %val)
+  %idx = zext i32 %tid to i64
+  %ptr = getelementptr i32, ptr %out, i64 %idx
+  store i32 %use, ptr %ptr, align 4
+  ret void
+}
+
+; DIVERGENT-NOT: call void @llvm.assume
+; DIVERGENT: br i1 {{%.*}}, label %if.then, label %if.end
+; DIVERGENT: atomicrmw add
+; DIVERGENT: phi i32
+
+; UNIFORM: call void @llvm.assume
+; UNIFORM-NOT: br i1 {{%.*}}, label %if.then, label %if.end
+
+attributes #0 = { nounwind readnone }
+attributes #1 = { convergent "amdgpu-flat-work-group-size"="1,256" }
+attributes #2 = { convergent }


### PR DESCRIPTION
Fixes incorrect control-flow folding in SimplifyCFG::removeUndefIntroducingPredecessor() on SIMT targets.

On divergent GPU control flow, a PHI incoming undef from one lane does not mean that predecessor edge is unreachable—other lanes may still take that path concurrently. The pass was treating such undef values (especially when flowing into a noundef convergent call argument) as immediate UB, inserting llvm.assume, and folding away the branch.