### PR TITLE
[bazel] Guard usage of repo_metadata

### DIFF
--- a/utils/bazel/configure.bzl
+++ b/utils/bazel/configure.bzl
@@ -198,7 +198,8 @@ def _llvm_configure_impl(repository_ctx):
         executable = False,
     )
 
-    return repository_ctx.repo_metadata(reproducible = True)
+    if hasattr(repository_ctx, "repo_metadata"):
+        return repository_ctx.repo_metadata(reproducible = True)
 
 llvm_configure = repository_rule(
     implementation = _llvm_configure_impl,


### PR DESCRIPTION
Older Bazel versions don't have this attribute yet.