### PR TITLE
[LoopCacheAnalysis] Support handling partially perfect loop nests

### DIFF
--- a/llvm/include/llvm/Analysis/LoopCacheAnalysis.h
+++ b/llvm/include/llvm/Analysis/LoopCacheAnalysis.h
@@ -185,10 +185,20 @@ using ReferenceGroupsTy = SmallVector<ReferenceGroupTy, 8>;
 ///    other subscripts is zero (e.g. RefCost = TripCount/(CLS/RefStride))
 ///  - equal to the innermost loop trip count if the reference stride is greater
 ///    or equal to the cache line size CLS.
+///
+/// A nest need not be perfectly nested. \c CacheCost decomposes the nest into
+/// disjoint linear chains of loops and costs each chain independently down to
+/// its unique innermost loop. The result is a list of per-chain rankings, with
+/// the costs only meaningful for comparison within the same chain. A loop that
+/// forks the nest, or that encloses a fork, is not a reorder candidate and does
+/// not appear in any chain. A perfectly nested loop is a specific case of this.
 class CacheCost {
   friend LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const CacheCost &CC);
   using LoopTripCountTy = std::pair<const Loop *, unsigned>;
   using LoopCacheCostTy = std::pair<const Loop *, CacheCostTy>;
+  /// The cache-cost ranking of a single linear chain of loops, sorted by
+  /// decreasing cost. Costs are only comparable within a chain.
+  using LoopCacheCostsTy = SmallVector<LoopCacheCostTy, 3>;
 
 public:
   /// Construct a CacheCost object for the loop nest described by \p Loops.
@@ -208,31 +218,41 @@ public:
   getCacheCost(Loop &Root, LoopStandardAnalysisResults &AR, DependenceInfo &DI,
                std::optional<unsigned> TRT = std::nullopt);
 
-  /// Return the estimated cost of loop \p L if the given loop is part of the
-  /// loop nest associated with this object. Return -1 otherwise.
+  /// Return the estimated cost of loop \p L if the given loop is a rankable
+  /// candidate in the loop nest associated with this object. Return -1
+  /// otherwise.
   CacheCostTy getLoopCost(const Loop &L) const {
-    auto IT = llvm::find_if(LoopCosts, [&L](const LoopCacheCostTy &LCC) {
-      return LCC.first == &L;
-    });
-    return (IT != LoopCosts.end()) ? (*IT).second : -1;
+    for (const LoopCacheCostsTy &Chain : ChainCosts) {
+      auto IT = llvm::find_if(
+          Chain, [&L](const LoopCacheCostTy &LCC) { return LCC.first == &L; });
+      if (IT != Chain.end())
+        return IT->second;
+    }
+    return -1;
   }
 
-  /// Return the estimated ordered loop costs.
-  ArrayRef<LoopCacheCostTy> getLoopCosts() const { return LoopCosts; }
+  /// Return the estimated ordered loop costs, grouped by linear chain. Each
+  /// inner range is one chain's ranking, sorted by decreasing cost. Costs are
+  /// only meaningful for comparison within a single chain. Fork loops (and
+  /// loops above a fork) are not rankable candidates and do not appear.
+  ArrayRef<LoopCacheCostsTy> getLoopCosts() const { return ChainCosts; }
 
 private:
   /// Calculate the cache footprint of each loop in the nest (when it is
-  /// considered to be in the innermost position).
+  /// considered to be in the innermost position). The nest is decomposed into
+  /// disjoint linear chains and each chain is costed independently.
   void calculateCacheFootprint();
 
-  /// Partition store/load instructions in the loop nest into reference groups.
-  /// Two or more memory accesses belong in the same reference group if they
-  /// share the same cache line.
-  bool populateReferenceGroups(ReferenceGroupsTy &RefGroups) const;
+  /// Partition the store/load instructions in the innermost loop \p Leaf of a
+  /// chain into reference groups. Two or more memory accesses belong in the
+  /// same reference group if they share the same cache line.
+  bool populateReferenceGroups(const Loop &Leaf,
+                               ReferenceGroupsTy &RefGroups) const;
 
   /// Calculate the cost of the given loop \p L assuming it is the innermost
-  /// loop in nest.
-  CacheCostTy computeLoopCacheCost(const Loop &L,
+  /// loop of the chain whose innermost loop is \p Leaf, using \p RefGroups
+  /// collected from \p Leaf.
+  CacheCostTy computeLoopCacheCost(const Loop &L, const Loop &Leaf,
                                    const ReferenceGroupsTy &RefGroups) const;
 
   /// Compute the cost of a representative reference in reference group \p RG
@@ -248,23 +268,26 @@ private:
   CacheCostTy computeRefGroupCacheCost(const ReferenceGroupTy &RG,
                                        const Loop &L) const;
 
-  /// Sort the LoopCosts vector by decreasing cache cost.
-  void sortLoopCosts() {
-    stable_sort(LoopCosts,
-                [](const LoopCacheCostTy &A, const LoopCacheCostTy &B) {
-                  return A.second > B.second;
-                });
+  /// Sort the given chain's costs by decreasing cache cost.
+  static void sortLoopCosts(LoopCacheCostsTy &Costs) {
+    stable_sort(Costs, [](const LoopCacheCostTy &A, const LoopCacheCostTy &B) {
+      return A.second > B.second;
+    });
   }
 
 private:
   /// Loops in the loop nest associated with this object.
   LoopVectorTy Loops;
 
+  /// The disjoint linear chains the nest decomposes into.
+  SmallVector<LoopVectorTy, 4> Chains;
+
   /// Trip counts for the loops in the loop nest associated with this object.
   SmallVector<LoopTripCountTy, 3> TripCounts;
 
-  /// Cache costs for the loops in the loop nest associated with this object.
-  SmallVector<LoopCacheCostTy, 3> LoopCosts;
+  /// Cache costs grouped by linear chain. Each chain is sorted by decreasing
+  /// cost and is only meaningful for comparison within itself.
+  SmallVector<LoopCacheCostsTy, 4> ChainCosts;
 
   /// The max. distance between array elements accessed in a loop so that the
   /// elements are classified to have temporal reuse.

--- a/llvm/lib/Analysis/LoopCacheAnalysis.cpp
+++ b/llvm/lib/Analysis/LoopCacheAnalysis.cpp
@@ -57,10 +57,9 @@ static cl::opt<unsigned> TemporalReuseThreshold(
              "accessed in a loop so that the elements are classified to have "
              "temporal reuse"));
 
-/// Decompose the loop nest rooted at \p Root into disjoint linear chains of
-/// loops. A chain is built from a leaf by including a parent only while that
-/// parent has exactly one sub-loop. A loop that forks the nest or encloses a
-/// fork is not in any chain.
+/// Collect the maximal single-child chain above each leaf. A chain is built
+/// from a leaf by including a parent only while that parent has exactly one
+/// sub-loop. A loop that forks the nest or encloses fork is not in any chain.
 static SmallVector<LoopVectorTy, 4> collectLinearChains(Loop &Root) {
   SmallVector<LoopVectorTy, 4> Chains;
 
@@ -72,8 +71,7 @@ static SmallVector<LoopVectorTy, 4> collectLinearChains(Loop &Root) {
     LoopVectorTy Chain;
     Chain.push_back(L);
     for (Loop *P = L->getParentLoop();
-         P != nullptr && Root.contains(P) && P->getSubLoops().size() == 1;
-         P = P->getParentLoop())
+         P != nullptr && P->getSubLoops().size() == 1; P = P->getParentLoop())
       Chain.push_back(P);
 
     // The chain was built inner->outer; reverse to outer->inner.
@@ -542,8 +540,8 @@ bool IndexedReference::isAliased(const IndexedReference &Other,
 // CacheCost implementation
 //
 raw_ostream &llvm::operator<<(raw_ostream &OS, const CacheCost &CC) {
-  for (const auto &Chain : CC.ChainCosts)
-    for (const auto &LC : Chain) {
+  for (const CacheCost::LoopCacheCostsTy &Chain : CC.ChainCosts)
+    for (const CacheCost::LoopCacheCostTy &LC : Chain) {
       const Loop *L = LC.first;
       OS << "Loop '" << L->getName() << "' has cost = " << LC.second << "\n";
     }

--- a/llvm/lib/Analysis/LoopCacheAnalysis.cpp
+++ b/llvm/lib/Analysis/LoopCacheAnalysis.cpp
@@ -27,6 +27,7 @@
 
 #include "llvm/Analysis/LoopCacheAnalysis.h"
 #include "llvm/ADT/BreadthFirstIterator.h"
+#include "llvm/ADT/DepthFirstIterator.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Analysis/AliasAnalysis.h"
@@ -37,6 +38,7 @@
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
+#include <algorithm>
 
 using namespace llvm;
 
@@ -55,27 +57,31 @@ static cl::opt<unsigned> TemporalReuseThreshold(
              "accessed in a loop so that the elements are classified to have "
              "temporal reuse"));
 
-/// Retrieve the innermost loop in the given loop nest \p Loops. It returns a
-/// nullptr if any loops in the loop vector supplied has more than one sibling.
-/// The loop vector is expected to contain loops collected in breadth-first
-/// order.
-static Loop *getInnerMostLoop(const LoopVectorTy &Loops) {
-  assert(!Loops.empty() && "Expecting a non-empy loop vector");
+/// Decompose the loop nest rooted at \p Root into disjoint linear chains of
+/// loops. A chain is built from a leaf by including a parent only while that
+/// parent has exactly one sub-loop. A loop that forks the nest or encloses a
+/// fork is not in any chain.
+static SmallVector<LoopVectorTy, 4> collectLinearChains(Loop &Root) {
+  SmallVector<LoopVectorTy, 4> Chains;
 
-  Loop *LastLoop = Loops.back();
-  Loop *ParentLoop = LastLoop->getParentLoop();
+  for (Loop *L : depth_first(&Root)) {
+    // Start a chain at each leaf (innermost) loop.
+    if (!L->isInnermost())
+      continue;
 
-  if (ParentLoop == nullptr) {
-    assert(Loops.size() == 1 && "Expecting a single loop");
-    return LastLoop;
+    LoopVectorTy Chain;
+    Chain.push_back(L);
+    for (Loop *P = L->getParentLoop();
+         P != nullptr && Root.contains(P) && P->getSubLoops().size() == 1;
+         P = P->getParentLoop())
+      Chain.push_back(P);
+
+    // The chain was built inner->outer; reverse to outer->inner.
+    std::reverse(Chain.begin(), Chain.end());
+    Chains.push_back(std::move(Chain));
   }
 
-  return (llvm::is_sorted(Loops,
-                          [](const Loop *L1, const Loop *L2) {
-                            return L1->getLoopDepth() < L2->getLoopDepth();
-                          }))
-             ? LastLoop
-             : nullptr;
+  return Chains;
 }
 
 static bool isOneDimensionalArray(const SCEV &AccessFn, const SCEV &ElemSize,
@@ -536,10 +542,11 @@ bool IndexedReference::isAliased(const IndexedReference &Other,
 // CacheCost implementation
 //
 raw_ostream &llvm::operator<<(raw_ostream &OS, const CacheCost &CC) {
-  for (const auto &LC : CC.LoopCosts) {
-    const Loop *L = LC.first;
-    OS << "Loop '" << L->getName() << "' has cost = " << LC.second << "\n";
-  }
+  for (const auto &Chain : CC.ChainCosts)
+    for (const auto &LC : Chain) {
+      const Loop *L = LC.first;
+      OS << "Loop '" << L->getName() << "' has cost = " << LC.second << "\n";
+    }
   return OS;
 }
 
@@ -557,6 +564,8 @@ CacheCost::CacheCost(const LoopVectorTy &Loops, const LoopInfo &LI,
     TripCounts.push_back({L, TripCount});
   }
 
+  Chains = collectLinearChains(*Loops.front());
+
   calculateCacheFootprint();
 }
 
@@ -571,43 +580,49 @@ CacheCost::getCacheCost(Loop &Root, LoopStandardAnalysisResults &AR,
   LoopVectorTy Loops;
   append_range(Loops, breadth_first(&Root));
 
-  if (!getInnerMostLoop(Loops)) {
-    LLVM_DEBUG(dbgs() << "Cannot compute cache cost of loop nest with more "
-                         "than one innermost loop\n");
-    return nullptr;
-  }
-
   return std::make_unique<CacheCost>(Loops, AR.LI, AR.SE, AR.TTI, AR.AA, DI, TRT);
 }
 
 void CacheCost::calculateCacheFootprint() {
-  LLVM_DEBUG(dbgs() << "POPULATING REFERENCE GROUPS\n");
-  ReferenceGroupsTy RefGroups;
-  if (!populateReferenceGroups(RefGroups))
-    return;
+  // Cost each linear chain independently: reference groups are collected from
+  // the chain's own innermost loop, and each loop in the chain is costed
+  // against them.
+  for (const LoopVectorTy &Chain : Chains) {
+    assert(!Chain.empty() && "Expecting a non-empty chain");
+    const Loop &Leaf = *Chain.back();
 
-  LLVM_DEBUG(dbgs() << "COMPUTING LOOP CACHE COSTS\n");
-  for (const Loop *L : Loops) {
-    assert(llvm::none_of(
-               LoopCosts,
-               [L](const LoopCacheCostTy &LCC) { return LCC.first == L; }) &&
-           "Should not add duplicate element");
-    CacheCostTy LoopCost = computeLoopCacheCost(*L, RefGroups);
-    LoopCosts.push_back(std::make_pair(L, LoopCost));
+    LLVM_DEBUG(dbgs() << "POPULATING REFERENCE GROUPS for innermost loop '"
+                      << Leaf.getName() << "'\n");
+    ReferenceGroupsTy RefGroups;
+    // If a chain's innermost loop has no analyzable references, skip the whole
+    // chain: its loops will not appear in the results and getLoopCost()
+    // returns -1 for them.
+    if (!populateReferenceGroups(Leaf, RefGroups))
+      continue;
+
+    LLVM_DEBUG(dbgs() << "COMPUTING LOOP CACHE COSTS\n");
+    LoopCacheCostsTy Costs;
+    for (const Loop *L : Chain) {
+      assert(llvm::none_of(
+                 Costs,
+                 [L](const LoopCacheCostTy &LCC) { return LCC.first == L; }) &&
+             "Should not add duplicate element");
+      CacheCostTy LoopCost = computeLoopCacheCost(*L, Leaf, RefGroups);
+      Costs.push_back(std::make_pair(L, LoopCost));
+    }
+
+    sortLoopCosts(Costs);
+    ChainCosts.push_back(std::move(Costs));
   }
-
-  sortLoopCosts();
-  RefGroups.clear();
 }
 
-bool CacheCost::populateReferenceGroups(ReferenceGroupsTy &RefGroups) const {
+bool CacheCost::populateReferenceGroups(const Loop &Leaf,
+                                        ReferenceGroupsTy &RefGroups) const {
   assert(RefGroups.empty() && "Reference groups should be empty");
 
   unsigned CLS = TTI.getCacheLineSize();
-  Loop *InnerMostLoop = getInnerMostLoop(Loops);
-  assert(InnerMostLoop != nullptr && "Expecting a valid innermost loop");
 
-  for (BasicBlock *BB : InnerMostLoop->getBlocks()) {
+  for (BasicBlock *BB : Leaf.getBlocks()) {
     for (Instruction &I : *BB) {
       if (!isa<StoreInst>(I) && !isa<LoadInst>(I))
         continue;
@@ -638,7 +653,7 @@ bool CacheCost::populateReferenceGroups(ReferenceGroupsTy &RefGroups) const {
        // should have a cost closer to 2x the second due to the two cache
        // access per iteration from opposite ends of the array
         std::optional<bool> HasTemporalReuse =
-            R->hasTemporalReuse(Representative, *TRT, *InnerMostLoop, DI, AA);
+            R->hasTemporalReuse(Representative, *TRT, Leaf, DI, AA);
         std::optional<bool> HasSpacialReuse =
             R->hasSpacialReuse(Representative, CLS, AA);
 
@@ -677,7 +692,7 @@ bool CacheCost::populateReferenceGroups(ReferenceGroupsTy &RefGroups) const {
 }
 
 CacheCostTy
-CacheCost::computeLoopCacheCost(const Loop &L,
+CacheCost::computeLoopCacheCost(const Loop &L, const Loop &Leaf,
                                 const ReferenceGroupsTy &RefGroups) const {
   if (!L.isLoopSimplifyForm())
     return CacheCostTy::getInvalid();
@@ -685,10 +700,13 @@ CacheCost::computeLoopCacheCost(const Loop &L,
   LLVM_DEBUG(dbgs() << "Considering loop '" << L.getName()
                     << "' as innermost loop.\n");
 
-  // Compute the product of the trip counts of each other loop in the nest.
+  // Compute the product of the trip counts of each other loop that encloses the
+  // references being costed, i.e. the loops on the chain's leaf's root-to-leaf
+  // path, excluding L itself. Loops in disjoint sibling sub-nests do not
+  // enclose these references and must not contribute to the product.
   CacheCostTy TripCountsProduct = 1;
   for (const auto &TC : TripCounts) {
-    if (TC.first == &L)
+    if (TC.first == &L || !TC.first->contains(&Leaf))
       continue;
     TripCountsProduct *= TC.second;
   }

--- a/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
@@ -1670,17 +1670,19 @@ void CacheCostManager::computeIfUnitinialized() {
 
   LLVM_DEBUG(dbgs() << "Compute CacheCost.\n");
   CC = CacheCost::getCacheCost(*OutermostLoop, *AR, *DI);
-  // Obtain the loop vector returned from loop cache analysis beforehand,
-  // and put each <Loop, index> pair into a map for constant time query
-  // later. Indices in loop vector reprsent the optimal order of the
-  // corresponding loop, e.g., given a loopnest with depth N, index 0
-  // indicates the loop should be placed as the outermost loop and index N
-  // indicates the loop should be placed as the innermost loop.
+  // Obtain the loop costs returned from loop cache analysis, which are grouped
+  // by linear chain (the nest may be partially perfect / forked). Within each
+  // chain the costs are ordered, and the index represents the optimal position
+  // of the corresponding loop in that chain, e.g. index 0 indicates the loop
+  // should be placed as the outermost loop of its chain and the last index
+  // indicates it should be the innermost. Put each <Loop, index> pair into a
+  // map for constant time query later.
   //
   // For the old pass manager CacheCost would be null.
   if (*CC != nullptr)
-    for (const auto &[Idx, Cost] : enumerate((*CC)->getLoopCosts()))
-      CostMap[Cost.first] = Idx;
+    for (const auto &Chain : (*CC)->getLoopCosts())
+      for (const auto &[Idx, Cost] : enumerate(Chain))
+        CostMap[Cost.first] = Idx;
 }
 
 CacheCost *CacheCostManager::getCacheCost() {

--- a/llvm/test/Analysis/LoopCacheAnalysis/partially-perfect-nest.ll
+++ b/llvm/test/Analysis/LoopCacheAnalysis/partially-perfect-nest.ll
@@ -1,0 +1,229 @@
+; RUN: opt < %s -cache-line-size=64 -passes='print<loop-cache-cost>' -disable-output 2>&1 | FileCheck %s
+
+;; A partially perfect nest is decomposed into disjoint linear chains, each
+;; costed against its own innermost loop. A loop that forks the nest, or that
+;; encloses a fork, is not a reorder candidate and is omitted.
+
+;; for (i) {
+;;   for (j)
+;;     for (jj) A[jj][j] = 1;
+;;   for (k)
+;;     for (kk) B[k][kk] = 1;
+;; }
+;; 'i' forks, so it is omitted. Chains {j,jj} (A[jj][j]) and {k,kk} (B[k][kk])
+;; are costed independently.
+
+; CHECK-DAG: Loop 'a.jj' has cost = 1000000
+; CHECK-DAG: Loop 'a.j' has cost = 130000
+; CHECK-DAG: Loop 'a.k' has cost = 1000000
+; CHECK-DAG: Loop 'a.kk' has cost = 130000
+; CHECK-NOT: Loop 'a.i'
+
+define void @fork_at_top(ptr %A, ptr %B) {
+entry:
+  br label %a.i
+a.i:
+  %iv = phi i64 [ 0, %entry ], [ %iv.n, %a.i.inc ]
+  br label %a.j
+a.j:
+  %jv = phi i64 [ 0, %a.i ], [ %jv.n, %a.j.inc ]
+  br label %a.jj
+a.jj:
+  %jjv = phi i64 [ 0, %a.j ], [ %jjv.n, %a.jj ]
+  %ga = getelementptr inbounds [100 x [100 x double]], ptr %A, i64 0, i64 %jjv, i64 %jv
+  store double 1.0, ptr %ga
+  %jjv.n = add nsw i64 %jjv, 1
+  %jj.e = icmp eq i64 %jjv.n, 100
+  br i1 %jj.e, label %a.j.inc, label %a.jj
+a.j.inc:
+  %jv.n = add nsw i64 %jv, 1
+  %j.e = icmp eq i64 %jv.n, 100
+  br i1 %j.e, label %a.k, label %a.j
+a.k:
+  %kv = phi i64 [ 0, %a.j.inc ], [ %kv.n, %a.k.inc ]
+  br label %a.kk
+a.kk:
+  %kkv = phi i64 [ 0, %a.k ], [ %kkv.n, %a.kk ]
+  %gb = getelementptr inbounds [100 x [100 x double]], ptr %B, i64 0, i64 %kv, i64 %kkv
+  store double 1.0, ptr %gb
+  %kkv.n = add nsw i64 %kkv, 1
+  %kk.e = icmp eq i64 %kkv.n, 100
+  br i1 %kk.e, label %a.k.inc, label %a.kk
+a.k.inc:
+  %kv.n = add nsw i64 %kv, 1
+  %k.e = icmp eq i64 %kv.n, 100
+  br i1 %k.e, label %a.i.inc, label %a.k
+a.i.inc:
+  %iv.n = add nsw i64 %iv, 1
+  %i.e = icmp eq i64 %iv.n, 100
+  br i1 %i.e, label %exit, label %a.i
+exit:
+  ret void
+}
+
+;; for (i)
+;;   for (j) {
+;;     for (k) C[k] = 1;
+;;     for (l) D[l] = 1;
+;;   }
+;; 'j' forks, so both 'i' and 'j' are omitted. The singleton chains {k} (C[k])
+;; and {l} (D[l]) are costed independently.
+
+; CHECK-DAG: Loop 'b.k' has cost = 130000
+; CHECK-DAG: Loop 'b.l' has cost = 130000
+; CHECK-NOT: Loop 'b.i'
+; CHECK-NOT: Loop 'b.j'
+
+define void @fork_in_middle(ptr %C, ptr %D) {
+entry:
+  br label %b.i
+b.i:
+  %iv = phi i64 [ 0, %entry ], [ %iv.n, %b.i.inc ]
+  br label %b.j
+b.j:
+  %jv = phi i64 [ 0, %b.i ], [ %jv.n, %b.j.inc ]
+  br label %b.k
+b.k:
+  %kv = phi i64 [ 0, %b.j ], [ %kv.n, %b.k ]
+  %gc = getelementptr inbounds double, ptr %C, i64 %kv
+  store double 1.0, ptr %gc
+  %kv.n = add nsw i64 %kv, 1
+  %k.e = icmp eq i64 %kv.n, 100
+  br i1 %k.e, label %b.l, label %b.k
+b.l:
+  %lv = phi i64 [ 0, %b.k ], [ %lv.n, %b.l ]
+  %gd = getelementptr inbounds double, ptr %D, i64 %lv
+  store double 1.0, ptr %gd
+  %lv.n = add nsw i64 %lv, 1
+  %l.e = icmp eq i64 %lv.n, 100
+  br i1 %l.e, label %b.j.inc, label %b.l
+b.j.inc:
+  %jv.n = add nsw i64 %jv, 1
+  %j.e = icmp eq i64 %jv.n, 100
+  br i1 %j.e, label %b.i.inc, label %b.j
+b.i.inc:
+  %iv.n = add nsw i64 %iv, 1
+  %i.e = icmp eq i64 %iv.n, 100
+  br i1 %i.e, label %exit, label %b.i
+exit:
+  ret void
+}
+
+;; for (i) {
+;;   for (j)  for (jj) A[jj][j] = 1;
+;;   for (k)  for (kk) B[k][kk] = 1;
+;;   for (l)  for (ll) C[ll][l] = 1;
+;; }
+;; Three-way fork at the outermost loop: confirms more than two chains are
+;; produced, costed independently. 'c.i' is omitted.
+
+; CHECK-DAG: Loop 'c.jj' has cost = 1000000
+; CHECK-DAG: Loop 'c.j' has cost = 130000
+; CHECK-DAG: Loop 'c.k' has cost = 1000000
+; CHECK-DAG: Loop 'c.kk' has cost = 130000
+; CHECK-DAG: Loop 'c.ll' has cost = 1000000
+; CHECK-DAG: Loop 'c.l' has cost = 130000
+; CHECK-NOT: Loop 'c.i'
+
+define void @fork_three_way(ptr %A, ptr %B, ptr %C) {
+entry:
+  br label %c.i
+c.i:
+  %iv = phi i64 [ 0, %entry ], [ %iv.n, %c.i.inc ]
+  br label %c.j
+c.j:
+  %jv = phi i64 [ 0, %c.i ], [ %jv.n, %c.j.inc ]
+  br label %c.jj
+c.jj:
+  %jjv = phi i64 [ 0, %c.j ], [ %jjv.n, %c.jj ]
+  %ga = getelementptr inbounds [100 x [100 x double]], ptr %A, i64 0, i64 %jjv, i64 %jv
+  store double 1.0, ptr %ga
+  %jjv.n = add nsw i64 %jjv, 1
+  %jj.e = icmp eq i64 %jjv.n, 100
+  br i1 %jj.e, label %c.j.inc, label %c.jj
+c.j.inc:
+  %jv.n = add nsw i64 %jv, 1
+  %j.e = icmp eq i64 %jv.n, 100
+  br i1 %j.e, label %c.k, label %c.j
+c.k:
+  %kv = phi i64 [ 0, %c.j.inc ], [ %kv.n, %c.k.inc ]
+  br label %c.kk
+c.kk:
+  %kkv = phi i64 [ 0, %c.k ], [ %kkv.n, %c.kk ]
+  %gb = getelementptr inbounds [100 x [100 x double]], ptr %B, i64 0, i64 %kv, i64 %kkv
+  store double 1.0, ptr %gb
+  %kkv.n = add nsw i64 %kkv, 1
+  %kk.e = icmp eq i64 %kkv.n, 100
+  br i1 %kk.e, label %c.k.inc, label %c.kk
+c.k.inc:
+  %kv.n = add nsw i64 %kv, 1
+  %k.e = icmp eq i64 %kv.n, 100
+  br i1 %k.e, label %c.l, label %c.k
+c.l:
+  %lv = phi i64 [ 0, %c.k.inc ], [ %lv.n, %c.l.inc ]
+  br label %c.ll
+c.ll:
+  %llv = phi i64 [ 0, %c.l ], [ %llv.n, %c.ll ]
+  %gc = getelementptr inbounds [100 x [100 x double]], ptr %C, i64 0, i64 %llv, i64 %lv
+  store double 1.0, ptr %gc
+  %llv.n = add nsw i64 %llv, 1
+  %ll.e = icmp eq i64 %llv.n, 100
+  br i1 %ll.e, label %c.l.inc, label %c.ll
+c.l.inc:
+  %lv.n = add nsw i64 %lv, 1
+  %l.e = icmp eq i64 %lv.n, 100
+  br i1 %l.e, label %c.i.inc, label %c.l
+c.i.inc:
+  %iv.n = add nsw i64 %iv, 1
+  %i.e = icmp eq i64 %iv.n, 100
+  br i1 %i.e, label %exit, label %c.i
+exit:
+  ret void
+}
+
+;; for (i) {
+;;   for (j)  for (jj) A[jj][j] = 1;
+;;   for (k)            D[k] = 1;
+;; }
+;; Asymmetric depths under a fork: chains of different sizes ({j,jj} and {k})
+;; produced from the same fork. 'd.i' is omitted.
+
+; CHECK-DAG: Loop 'd.jj' has cost = 1000000
+; CHECK-DAG: Loop 'd.j' has cost = 130000
+; CHECK-DAG: Loop 'd.k' has cost = 1300
+; CHECK-NOT: Loop 'd.i'
+
+define void @fork_asymmetric_depths(ptr %A, ptr %D) {
+entry:
+  br label %d.i
+d.i:
+  %iv = phi i64 [ 0, %entry ], [ %iv.n, %d.i.inc ]
+  br label %d.j
+d.j:
+  %jv = phi i64 [ 0, %d.i ], [ %jv.n, %d.j.inc ]
+  br label %d.jj
+d.jj:
+  %jjv = phi i64 [ 0, %d.j ], [ %jjv.n, %d.jj ]
+  %ga = getelementptr inbounds [100 x [100 x double]], ptr %A, i64 0, i64 %jjv, i64 %jv
+  store double 1.0, ptr %ga
+  %jjv.n = add nsw i64 %jjv, 1
+  %jj.e = icmp eq i64 %jjv.n, 100
+  br i1 %jj.e, label %d.j.inc, label %d.jj
+d.j.inc:
+  %jv.n = add nsw i64 %jv, 1
+  %j.e = icmp eq i64 %jv.n, 100
+  br i1 %j.e, label %d.k, label %d.j
+d.k:
+  %kv = phi i64 [ 0, %d.j.inc ], [ %kv.n, %d.k ]
+  %gd = getelementptr inbounds double, ptr %D, i64 %kv
+  store double 1.0, ptr %gd
+  %kv.n = add nsw i64 %kv, 1
+  %k.e = icmp eq i64 %kv.n, 100
+  br i1 %k.e, label %d.i.inc, label %d.k
+d.i.inc:
+  %iv.n = add nsw i64 %iv, 1
+  %i.e = icmp eq i64 %iv.n, 100
+  br i1 %i.e, label %exit, label %d.i
+exit:
+  ret void
+}


### PR DESCRIPTION
Previously the analysis bailed out on partially perfect (forked) loop nests: getInnerMostLoop() picked a single wrong innermost loop and the resulting costs were meaningless.

This patch removes the buggy code and adds support to handle partially perfect as follows:
Replace getInnerMostLoop() with collectLinearChains() which decomposes the nest into disjoint linear chains by walking up from each leaf loop through single-child parents and stopping at any fork. A loop that forks the nest or encloses a fork belongs to no chain. Each chain is then costed independently against its own innermost loop, and computeLoopCacheCost() restricts the trip-count product to loops that enclose the chain's leaf. For a perfectly nested loop this is a single chain and behavior is unchanged.

CacheCost::getLoopCosts() now returns ArrayRef<LoopCacheCostsTy>, one ranking per chain, with costs only meaningful for comparison within a chain.

Fixes #198694