### PR TITLE
[mlir][tosa] Preserve raw const data in signless conversion

### DIFF
--- a/mlir/lib/Dialect/Tosa/Transforms/TosaConvertIntegerTypeToSignless.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaConvertIntegerTypeToSignless.cpp
@@ -119,7 +119,8 @@ class ConvertTosaConstWithIntegerTensorType
 
     ElementsAttr newAttr = oldAttr;
     if (auto denseAttr = llvm::dyn_cast<DenseElementsAttr>(oldAttr)) {
-      newAttr = DenseElementsAttr::get(newTy, denseAttr.getRawData());
+      newAttr =
+          DenseElementsAttr::getFromRawBuffer(newTy, denseAttr.getRawData());
     } else {
       return rewriter.notifyMatchFailure(op, "unknown elements attribute type");
     }

--- a/mlir/test/Dialect/Tosa/tosa-convert-integer-type-to-signless.mlir
+++ b/mlir/test/Dialect/Tosa/tosa-convert-integer-type-to-signless.mlir
@@ -65,6 +65,33 @@ func.func @test_unsigned_const_data() -> tensor<5xui8> {
 
 // -----
 
+// CHECK-LABEL: test_unsigned_const_data_i16
+// CHECK: "tosa.const"() <{values = dense<[-1, -2, 0, 1, -32768]> : tensor<5xi16>}> : () -> tensor<5xi16>
+func.func @test_unsigned_const_data_i16() -> tensor<5xui16> {
+  %0 = "tosa.const"() <{values = dense<[65535, 65534, 0, 1, 32768]> : tensor<5xui16>}> : () -> tensor<5xui16>
+  return %0 : tensor<5xui16>
+}
+
+// -----
+
+// CHECK-LABEL: test_unsigned_const_data_i32
+// CHECK: "tosa.const"() <{values = dense<[-1, -2, 0, 1, -2147483648]> : tensor<5xi32>}> : () -> tensor<5xi32>
+func.func @test_unsigned_const_data_i32() -> tensor<5xui32> {
+  %0 = "tosa.const"() <{values = dense<[4294967295, 4294967294, 0, 1, 2147483648]> : tensor<5xui32>}> : () -> tensor<5xui32>
+  return %0 : tensor<5xui32>
+}
+
+// -----
+
+// CHECK-LABEL: test_unsigned_const_data_i48
+// CHECK: "tosa.const"() <{values = dense<[-1, -2, 0, 1, -140737488355328]> : tensor<5xi48>}> : () -> tensor<5xi48>
+func.func @test_unsigned_const_data_i48() -> tensor<5xui48> {
+  %0 = "tosa.const"() <{values = dense<[281474976710655, 281474976710654, 0, 1, 140737488355328]> : tensor<5xui48>}> : () -> tensor<5xui48>
+  return %0 : tensor<5xui48>
+}
+
+// -----
+
 // CHECK-LABEL: test_no_change
 // CHECK: %arg0: tensor<13x21x3xi8>
 func.func @test_no_change(%arg0: tensor<13x21x3xi8>) -> tensor<13x21x3xi8> {


### PR DESCRIPTION
Use DenseElementsAttr::getFromRawBuffer when rebuilding tosa.const attributes in TosaConvertIntegerTypeToSignless. The previous DenseElementsAttr::get(type, ArrayRef<char>) call interpreted raw bytes as i8 elements, which asserted for integer constants wider than 8 bits.

Add regression coverage for ui16, ui32, and ui48 constants.