### PR TITLE
[X86] Fix stale kill flag when folding VPMOV*2M + KMOV to VMOVMSK

### DIFF
--- a/llvm/lib/Target/X86/X86CompressEVEX.cpp
+++ b/llvm/lib/Target/X86/X86CompressEVEX.cpp
@@ -310,7 +310,11 @@ static bool tryCompressVPMOVPattern(MachineInstr &MI, MachineBasicBlock &MBB,
 
   // Apply the transformation
   KMovMI->setDesc(TII->get(MovMskOpc));
-  KMovMI->getOperand(1).setReg(SrcVecReg);
+  MachineOperand &NewSrc = KMovMI->getOperand(1);
+  NewSrc.setReg(SrcVecReg);
+  // setReg() keeps the mask operand's kill flag; take the source's kill
+  // state from the VPMOV instead.
+  NewSrc.setIsKill(MI.getOperand(1).isKill());
   KMovMI->setAsmPrinterFlag(X86::AC_EVEX_2_VEX);
 
   ToErase.push_back(&MI);

--- a/llvm/test/CodeGen/X86/compress-evex-vpmov-kill.mir
+++ b/llvm/test/CodeGen/X86/compress-evex-vpmov-kill.mir
@@ -1,0 +1,37 @@
+# RUN: llc %s -mtriple=x86_64-unknown -mattr=+avx512vl,+avx512dq \
+# RUN:   -run-pass=x86-compress-evex -o - | FileCheck %s
+#
+# tryCompressVPMOVPattern folds VPMOV*2M + KMOV into VMOVMSK. The kill flag on
+# the XMM source must be derived from the VPMOV. Otherwise it inherits the kill
+# flag from the KMOV's mask operand, which can mark a still-live XMM register as
+# killed and produce incorrect liveness.
+
+---
+name:            live_xmm
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $xmm0
+    ; $xmm0 is used after the fold, so it must not be killed.
+    ; CHECK-LABEL: name: live_xmm
+    ; CHECK:     $eax = VMOVMSKPSrr $xmm0
+    ; CHECK-NOT: killed $xmm0
+    $k0 = VPMOVD2MZ128kr $xmm0
+    $eax = KMOVDrk killed $k0
+    $xmm1 = VMOVAPSrr $xmm0
+    RET64 $eax, implicit $xmm1
+...
+
+---
+name:            dead_xmm
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $xmm0
+    ; $xmm0 is dead after the fold, so the kill is preserved.
+    ; CHECK-LABEL: name: dead_xmm
+    ; CHECK: $eax = VMOVMSKPSrr killed $xmm0
+    $k0 = VPMOVD2MZ128kr killed $xmm0
+    $eax = KMOVDrk killed $k0
+    RET64 $eax
+...


### PR DESCRIPTION
tryCompressVPMOVPattern folds VPMOV*2M + KMOV into a single VMOVMSK in place: it changes the KMOV's opcode and repoints its source operand from the mask k-register to the XMM source via MachineOperand::setReg().

setReg() only changes the register number and keeps the operand's other flags, so the kill flag computed for the mask ("killed $k0") is reused for the XMM source. When the source is still live this marks it killed, which the machine verifier reports as a use of an undefined register.

We should instead use the kill flag from the VPMOV's source operand. The forward scan already guarantees the source is not redefined between the VPMOV and the KMOV, so the VPMOV's flag is correct at the relocated read.

Found via @jlebar's X86 LLVM bug-hunt / FuzzX effort:
https://github.com/SemiAnalysisAI/FuzzX/tree/master/x86/bugs/043-compress-evex-vpmov-srcvec-clobber-kmov

cc @jlebar