### PR TITLE
[Uniformity] Introduce isUniform/DivergentTerminator naming. NFC.

### DIFF
--- a/llvm/include/llvm/ADT/GenericUniformityImpl.h
+++ b/llvm/include/llvm/ADT/GenericUniformityImpl.h
@@ -382,11 +382,9 @@ public:
 
   bool hasDivergentDefs(const InstructionT &I) const;
 
-  bool isDivergent(const InstructionT &I) const {
-    if (I.isTerminator()) {
-      return DivergentTermBlocks.contains(I.getParent());
-    }
-    return hasDivergentDefs(I);
+  bool isDivergentTerminator(const InstructionT &I) const {
+    assert(I.isTerminator() && "Expected a terminator instruction!");
+    return DivergentTermBlocks.contains(I.getParent());
   };
 
   /// \brief Whether \p Val is divergent at its definition.
@@ -1167,7 +1165,7 @@ void GenericUniformityAnalysisImpl<ContextT>::compute() {
     }
 
     // propagate value divergence to users
-    assert(isDivergent(*I) && "Worklist invariant violated!");
+    assert(hasDivergentDefs(*I) && "Worklist invariant violated!");
     pushUsers(*I);
   }
 }
@@ -1297,9 +1295,10 @@ bool GenericUniformityInfo<ContextT>::isDivergentAtDef(ConstValueRefT V) const {
 }
 
 template <typename ContextT>
-bool GenericUniformityInfo<ContextT>::isDivergentAtDef(
+bool GenericUniformityInfo<ContextT>::isDivergentTerminator(
     const InstructionT *I) const {
-  return DA && DA->isDivergent(*I);
+  assert(I->isTerminator() && "Expected a terminator instruction!");
+  return DA && DA->isDivergentTerminator(*I);
 }
 
 template <typename ContextT>

--- a/llvm/include/llvm/ADT/GenericUniformityInfo.h
+++ b/llvm/include/llvm/ADT/GenericUniformityInfo.h
@@ -63,14 +63,18 @@ public:
   /// Whether \p V is uniform/non-divergent at its definition.
   bool isUniformAtDef(ConstValueRefT V) const { return !isDivergentAtDef(V); }
 
-  // Similar queries for InstructionT. These accept a pointer argument so that
+  // Whether the terminator instruction \p I is uniform/divergent, i.e. whether
+  // the controlling condition of a conditional branch or switch is
+  // uniform/divergent.
+  // TODO: The comment below is now out of date:
+  // These accept a pointer argument so that
   // in LLVM IR, they overload the equivalent queries for Value*. For example,
   // if querying whether a CondBrInst is divergent, it should not be treated as
   // a Value in LLVM IR.
-  bool isUniformAtDef(const InstructionT *I) const {
-    return !isDivergentAtDef(I);
+  bool isUniformTerminator(const InstructionT *I) const {
+    return !isDivergentTerminator(I);
   };
-  bool isDivergentAtDef(const InstructionT *I) const;
+  bool isDivergentTerminator(const InstructionT *I) const;
 
   /// \brief Whether \p U is divergent at its use. Uses of a uniform value can
   /// be divergent.

--- a/llvm/lib/Target/AMDGPU/AMDGPUAnnotateUniformValues.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAnnotateUniformValues.cpp
@@ -60,7 +60,7 @@ public:
 } // End anonymous namespace
 
 void AMDGPUAnnotateUniformValues::visitCondBrInst(CondBrInst &I) {
-  if (UA->isUniformAtDef(&I))
+  if (UA->isUniformTerminator(&I))
     setUniformMetadata(&I);
 }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPURewriteUndefForPHI.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURewriteUndefForPHI.cpp
@@ -144,7 +144,7 @@ bool rewritePHIs(Function &F, UniformityInfo &UA, DominatorTree *DT) {
       // TODO: We should still be able to replace undef value if the unique
       // value is a Constant.
       if (!UniqueDefinedIncoming || Undefs.empty() ||
-          UA.isUniformAtDef(DominateBB->getTerminator()))
+          UA.isUniformTerminator(DominateBB->getTerminator()))
         continue;
 
       // We only replace the undef when DominateBB truly dominates all the

--- a/llvm/lib/Target/AMDGPU/AMDGPUUnifyDivergentExitNodes.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUUnifyDivergentExitNodes.cpp
@@ -123,7 +123,7 @@ static bool isUniformlyReached(const UniformityInfo &UA, BasicBlock &BB) {
 
   while (!Stack.empty()) {
     BasicBlock *Top = Stack.pop_back_val();
-    if (UA.isDivergentAtDef(Top->getTerminator()))
+    if (UA.isDivergentTerminator(Top->getTerminator()))
       return false;
 
     for (BasicBlock *Pred : predecessors(Top)) {

--- a/llvm/lib/Target/AMDGPU/SIAnnotateControlFlow.cpp
+++ b/llvm/lib/Target/AMDGPU/SIAnnotateControlFlow.cpp
@@ -128,7 +128,7 @@ void SIAnnotateControlFlow::initialize(const GCNSubtarget &ST) {
 /// Is the branch condition uniform or did the StructurizeCFG pass
 /// consider it as such?
 bool SIAnnotateControlFlow::isUniform(CondBrInst *T) {
-  return UA->isUniformAtDef(T) || T->hasMetadata("structurizecfg.uniform");
+  return UA->isUniformTerminator(T) || T->hasMetadata("structurizecfg.uniform");
 }
 
 /// Is BB the last block saved on the stack ?

--- a/llvm/lib/Transforms/Scalar/StructurizeCFG.cpp
+++ b/llvm/lib/Transforms/Scalar/StructurizeCFG.cpp
@@ -1302,7 +1302,7 @@ static bool hasOnlyUniformBranches(Region *R, unsigned UniformMDKindID,
       if (!Br)
         continue;
 
-      if (UA.isDivergentAtDef(Br))
+      if (UA.isDivergentTerminator(Br))
         return false;
 
       // One of our direct children is conditional.


### PR DESCRIPTION
Rename the overloads of isUniformAtDef/isDivergentAtDef that take an
InstructionT (instead of a ValueT) to
isUniformTerminator/isDivergentTerminator to make it clear that they
should only be used for terminator instructions, and assert this. Call
sites passing in a non-terminator instruction now resolve to the ValueT
overloads instead.
