### PR TITLE
[OpenMP] Limit HSA core dumps for OpenMP test suite

### DIFF
--- a/offload/test/lit.cfg
+++ b/offload/test/lit.cfg
@@ -234,6 +234,7 @@ if config.libomptarget_current_target.startswith('nvptx'):
 if config.libomptarget_current_target.startswith('amdgcn'):
     config.available_features.add('gpu')
     config.available_features.add('amdgpu')
+    config.environment['HSA_DISABLE_COREDUMP_ON_EXCEPTION'] = '1'
 if config.libomptarget_current_target.startswith('spirv64-intel'):
     config.available_features.add('gpu')
     config.available_features.add('intelgpu')


### PR DESCRIPTION
Summary:
These will print extra information, which makes it difficult to match on
the `libomptarget` output in exceptional cases like in the sanitizer
checks.
