### PR TITLE
[NFC][analyzer] Remove the NodeBuilder from VisitArrayInitLoopExpr

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3193,17 +3193,16 @@ void ExprEngine::VisitCommonDeclRefExpr(const Expr *Ex, const NamedDecl *D,
 void ExprEngine::VisitArrayInitLoopExpr(const ArrayInitLoopExpr *Ex,
                                         ExplodedNode *Pred,
                                         ExplodedNodeSet &Dst) {
+  const Expr *Arr = Ex->getCommonExpr()->getSourceExpr();
+
   ExplodedNodeSet CheckerPreStmt;
   getCheckerManager().runCheckersForPreStmt(CheckerPreStmt, Pred, Ex, *this);
 
   ExplodedNodeSet EvalSet;
-  NodeBuilder Bldr(CheckerPreStmt, EvalSet, *currBldrCtx);
-
-  const Expr *Arr = Ex->getCommonExpr()->getSourceExpr();
-
   if (isa<CXXConstructExpr>(Ex->getSubExpr())) {
     // The constructor visitior has already taken care of everything, so let's
     // skip forward to the PostStmt handling after the 'for' loop.
+    EvalSet.insert(CheckerPreStmt);
     CheckerPreStmt.clear();
   }
 
@@ -3282,7 +3281,7 @@ void ExprEngine::VisitArrayInitLoopExpr(const ArrayInitLoopExpr *Ex,
     else
       Base = UnknownVal();
 
-    Bldr.generateNode(Ex, Node, state->BindExpr(Ex, SF, Base));
+    EvalSet.insert(Engine.makeNodeWithBinding(Node, Ex, Base));
   }
 
   getCheckerManager().runCheckersForPostStmt(Dst, EvalSet, Ex, *this);

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3200,8 +3200,8 @@ void ExprEngine::VisitArrayInitLoopExpr(const ArrayInitLoopExpr *Ex,
 
   ExplodedNodeSet EvalSet;
   if (isa<CXXConstructExpr>(Ex->getSubExpr())) {
-    // The constructor visitior has already taken care of everything, so let's
-    // skip forward to the PostStmt handling after the 'for' loop.
+    // The constructor visitor has already handled everything, so let's skip
+    // forward to PostStmt handling by clearing the range of the 'for' loop.
     EvalSet.insert(CheckerPreStmt);
     CheckerPreStmt.clear();
   }

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3201,12 +3201,13 @@ void ExprEngine::VisitArrayInitLoopExpr(const ArrayInitLoopExpr *Ex,
 
   const Expr *Arr = Ex->getCommonExpr()->getSourceExpr();
 
+  if (isa<CXXConstructExpr>(Ex->getSubExpr())) {
+    // The constructor visitior has already taken care of everything, so let's
+    // skip forward to the PostStmt handling after the 'for' loop.
+    CheckerPreStmt.clear();
+  }
+
   for (auto *Node : CheckerPreStmt) {
-
-    // The constructor visitior has already taken care of everything.
-    if (isa<CXXConstructExpr>(Ex->getSubExpr()))
-      break;
-
     const StackFrame *SF = Node->getStackFrame();
     ProgramStateRef state = Node->getState();
 


### PR DESCRIPTION
Part of my commit series to eliminate the class `NodeBuilder`.