### PR TITLE
[NFC][LLVM] Tighten overload types for `@llvm.get.active.lane.mask`

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -2632,8 +2632,8 @@ def int_loop_dependence_war_mask:
             [IntrNoMem, IntrNoSync, IntrWillReturn, ImmArg<ArgIndex<2>>]>;
 
 def int_get_active_lane_mask:
-  DefaultAttrsIntrinsic<[llvm_anyvector_ty],
-            [llvm_anyint_ty, LLVMMatchType<1>],
+  DefaultAttrsIntrinsic<[llvm_any_vector_int_ty],
+            [llvm_any_scalar_int_ty, LLVMMatchType<1>],
             [IntrNoMem, IntrSpeculatable]>;
 
 def int_experimental_get_vector_length:

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -6746,15 +6746,9 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
     break;
   }
   case Intrinsic::get_active_lane_mask: {
-    Check(Call.getType()->isVectorTy(),
-          "get_active_lane_mask: must return a "
-          "vector",
-          Call);
-    auto *ElemTy = Call.getType()->getScalarType();
+    Type *ElemTy = Call.getType()->getScalarType();
     Check(ElemTy->isIntegerTy(1),
-          "get_active_lane_mask: element type is not "
-          "i1",
-          Call);
+          "get_active_lane_mask: element type is not i1", Call);
     break;
   }
   case Intrinsic::experimental_get_vector_length: {

--- a/llvm/test/Verifier/get-active-lane-mask.ll
+++ b/llvm/test/Verifier/get-active-lane-mask.ll
@@ -13,9 +13,19 @@ define <4 x i32> @t1(i32 %IV, i32 %TC) {
 declare i32 @llvm.get.active.lane.mask.i32.i32(i32, i32)
 
 define i32 @t2(i32 %IV, i32 %TC) {
-; CHECK:      intrinsic return type (overload type 0) expected any vector type, but got i32
+; CHECK:      intrinsic return type (overload type 0) expected any integer vector, but got i32
 ; CHECK-NEXT: ptr @llvm.get.active.lane.mask.i32.i32
 
   %res = call i32 @llvm.get.active.lane.mask.i32.i32(i32 %IV, i32 %TC)
   ret i32 %res
+}
+
+declare <4 x i1> @llvm.get.active.lane.mask.v4i1.v4i32(<4 x i32>, <4 x i32>)
+
+define <4 x i1> @t3(<4 x i32> %x) {
+; CHECK:      intrinsic argument 0 type (overload type 1) expected any integer type, but got <4 x i32>
+; CHECK-NEXT: ptr @llvm.get.active.lane.mask.v4i1.v4i32
+
+  %res = call <4 x i1> @llvm.get.active.lane.mask.v4i1.v4i32(<4 x i32> %x, <4 x i32> %x)
+  ret <4 x i1> %res
 }


### PR DESCRIPTION
Change return type to `llvm_any_vector_int_ty` and the 2 argument types to `llvm_any_scalar_int_ty`.