### PR TITLE
[Dexter] Add additional variable metrics, sanitize lldb-dap function names

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
@@ -438,7 +438,7 @@ class LLDBDAP(DAP):
 
     def _sanitize_function_name(self, name: str):  # pylint: disable=no-self-use
         if name.endswith(" [opt]"):
-            name = name[:-len(" [opt]")]
+            name = name[: -len(" [opt]")]
         return name
 
     def _post_step_hook(self):

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
@@ -437,8 +437,11 @@ class LLDBDAP(DAP):
         ]
 
     def _sanitize_function_name(self, name: str):  # pylint: disable=no-self-use
-        if name.endswith(" [opt]"):
-            name = name[: -len(" [opt]")]
+        # Remove the tags that LLDB may insert at the end of a function name; these appear in a fixed order, and we
+        # strip them in the reverse of that order below.
+        for tag in ["artificial", "inlined", "opt"]:
+            if name.endswith(f" [{tag}]"):
+                name = name[: -len(f" [{tag}]")]
         return name
 
     def _post_step_hook(self):

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
@@ -436,6 +436,11 @@ class LLDBDAP(DAP):
             "_start",
         ]
 
+    def _sanitize_function_name(self, name: str):  # pylint: disable=no-self-use
+        if name.endswith(" [opt]"):
+            name = name[:-len(" [opt]")]
+        return name
+
     def _post_step_hook(self):
         """Hook to be executed after completing a step request."""
         if self._debugger_state.stopped_reason == "step":

--- a/cross-project-tests/debuginfo-tests/dexter/dex/evaluation/Metrics.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/evaluation/Metrics.py
@@ -108,6 +108,7 @@ def get_variable_metrics(
     seen_expected_values = set()
     num_correct_steps = 0
     num_optimized_out_steps = 0
+    num_irretrievable_steps = 0
     num_missing_var_steps = 0
     num_unexpected_value_steps = 0
     partial_step_correctness = 0.0
@@ -121,6 +122,8 @@ def get_variable_metrics(
         elif match.actual_result is None:
             if match.actual and match.actual.is_optimized_away:
                 num_optimized_out_steps += 1
+            elif match.actual and match.actual.is_irretrievable:
+                num_irretrievable_steps += 1
             else:
                 num_missing_var_steps += 1
         else:
@@ -149,6 +152,8 @@ def get_variable_metrics(
         "partial_step_correctness": ScalarMetric(partial_step_correctness),
         # The number of steps where the watched variable/expression was marked "optimized out" in the debugger.
         "optimized_out_steps": ScalarMetric(num_optimized_out_steps, improves_asc=False),
+        # The number of steps where the watched variable/expression had an inaccessible address in the debugger.
+        "irretrievable_steps": ScalarMetric(num_irretrievable_steps, improves_asc=False),
         # The number of steps where the watched variable/expression was not available in the debugger.
         "missing_var_steps": ScalarMetric(num_missing_var_steps, improves_asc=False),
         # The number of steps where the watched variable/expression had a value not in the set of expected values.

--- a/cross-project-tests/debuginfo-tests/dexter/dex/evaluation/Metrics.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/evaluation/Metrics.py
@@ -107,6 +107,7 @@ def get_variable_metrics(
     all_expected_values = get_expected_value_set(expected_values)
     seen_expected_values = set()
     num_correct_steps = 0
+    num_optimized_out_steps = 0
     num_missing_var_steps = 0
     num_unexpected_value_steps = 0
     partial_step_correctness = 0.0
@@ -118,7 +119,10 @@ def get_variable_metrics(
         if match.match_result == MatchResult.TRUE:
             num_correct_steps += 1
         elif match.actual_result is None:
-            num_missing_var_steps += 1
+            if match.actual and match.actual.is_optimized_away:
+                num_optimized_out_steps += 1
+            else:
+                num_missing_var_steps += 1
         else:
             num_unexpected_value_steps += 1
     assert all(
@@ -143,6 +147,8 @@ def get_variable_metrics(
         ),
         # The sum of the 0.0-1.0 "correctness value" of matches across each step.
         "partial_step_correctness": ScalarMetric(partial_step_correctness),
+        # The number of steps where the watched variable/expression was marked "optimized out" in the debugger.
+        "optimized_out_steps": ScalarMetric(num_optimized_out_steps, improves_asc=False),
         # The number of steps where the watched variable/expression was not available in the debugger.
         "missing_var_steps": ScalarMetric(num_missing_var_steps, improves_asc=False),
         # The number of steps where the watched variable/expression had a value not in the set of expected values.

--- a/cross-project-tests/debuginfo-tests/dexter/dex/evaluation/Metrics.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/evaluation/Metrics.py
@@ -151,9 +151,13 @@ def get_variable_metrics(
         # The sum of the 0.0-1.0 "correctness value" of matches across each step.
         "partial_step_correctness": ScalarMetric(partial_step_correctness),
         # The number of steps where the watched variable/expression was marked "optimized out" in the debugger.
-        "optimized_out_steps": ScalarMetric(num_optimized_out_steps, improves_asc=False),
+        "optimized_out_steps": ScalarMetric(
+            num_optimized_out_steps, improves_asc=False
+        ),
         # The number of steps where the watched variable/expression had an inaccessible address in the debugger.
-        "irretrievable_steps": ScalarMetric(num_irretrievable_steps, improves_asc=False),
+        "irretrievable_steps": ScalarMetric(
+            num_irretrievable_steps, improves_asc=False
+        ),
         # The number of steps where the watched variable/expression was not available in the debugger.
         "missing_var_steps": ScalarMetric(num_missing_var_steps, improves_asc=False),
         # The number of steps where the watched variable/expression had a value not in the set of expected values.


### PR DESCRIPTION
This patch makes some required changes prior to switching over to using the script model by default, to keep the tests in `dexter-tests` working and meaningful.

In addition to the existing metrics, we split the "missing_vars" metric into 3 - adding "irretrievable" and "optimized_out", so that we can specifically test those properties in the output.

We also add some function name sanitizing to lldb-dap, to account for the fact that some function names get presented with a suffix " [opt]", which causes the script to fail.