### PR TITLE
[bazel][CI] Skip enormous/manual tests

### DIFF
--- a/utils/bazel/.bazelrc
+++ b/utils/bazel/.bazelrc
@@ -238,9 +238,15 @@ build:ci --sandbox_base=/dev/shm
 build:ci --@llvm-project//libc:mpfr=system
 build:ci --@llvm-project//llvm:pfm=system
 
-# Don't build/test targets tagged with "nobuildkite".
-build:ci --build_tag_filters=-nobuildkite
-build:ci --test_tag_filters=-nobuildkite
+# Tags to skip when building/testing:
+# * "nobuildkite" - something incompatible with buildkite CI
+# * "manual" - normally skipped when running `bazel test //...`, but buildkite
+#   runs `bazel query //... | xargs bazel test` which will include those.
+build:ci --build_tag_filters=-nobuildkite,-manual
+build:ci --test_tag_filters=-nobuildkite,-manual
+
+# Don't run tests that take too long.
+test:ci --test_size_filters=-enormous
 
 # Show as many errors as possible.
 build:ci --keep_going


### PR DESCRIPTION
Buildkite CI often gets stalled on this slow test:

```
[65,544 / 65,545] 3600 / 3601 tests, 5 failed;  1 action; last test: @llvm-project//clang/unittests:analysis_flow_sensitive_tests
    Testing @@+_repo_rules+llvm-project//flang/unittests:DecimalThoroughTest; 2975s remote-cache, processwrapper-sandbox
```

Use `--test_size_filters=-enormous` to skip it.

It's also tagged `"manual"`, but because buildkite is configured to use `bazel query //... | xargs bazel test` instead of `bazel test //...`, we still run manual targets. I'm not sure why we shouldn't just change buildkite to not do that, but it also doesn't seem to hurt to have manual targets excluded like this.