### PR TITLE
[Dexter] Switch to using script-mode by default

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter-tests/aggregate-indirect-arg.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/aggregate-indirect-arg.cpp
@@ -2,7 +2,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %clang++ -std=gnu++11 -O0 -g %s -o %t
-// RUN: %dexter -w --use-script \
+// RUN: %dexter -w \
 // RUN:     --binary %t %dexter_lldb_args -- %s | FileCheck %s
 // Radar 8945514
 

--- a/cross-project-tests/debuginfo-tests/dexter-tests/asan-deque.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/asan-deque.cpp
@@ -10,8 +10,7 @@
 
 // RUN: %clang++ -std=gnu++11 -O1 -glldb -fsanitize=address -arch x86_64 %s \
 // RUN:   -o %t
-// RUN: %dexter -w --use-script \
-// RUN:     --binary %t %dexter_lldb_args -- %s | FileCheck %s
+// RUN: %dexter -w --binary %t %dexter_lldb_args -- %s | FileCheck %s
 #include <deque>
 
 struct A {

--- a/cross-project-tests/debuginfo-tests/dexter-tests/asan.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/asan.c
@@ -5,7 +5,7 @@
 //
 // RUN: %clang -std=gnu11 --driver-mode=gcc -O0 -glldb -fblocks -arch x86_64 \
 // RUN:     -fsanitize=address %s -o %t
-// RUN: %dexter -w --use-script \
+// RUN: %dexter -w \
 // RUN:     --binary %t %dexter_lldb_args -- %s | FileCheck %s
 
 struct S {

--- a/cross-project-tests/debuginfo-tests/dexter-tests/ctor.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/ctor.cpp
@@ -2,7 +2,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %clang++ -std=gnu++11 -O0 -glldb %s -o %t
-// RUN: %dexter -w --use-script \
+// RUN: %dexter -w \
 // RUN:     --binary %t %dexter_lldb_args -- %s | FileCheck %s
 
 class A {

--- a/cross-project-tests/debuginfo-tests/dexter-tests/dbg-arg.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/dbg-arg.c
@@ -3,7 +3,7 @@
 //
 // This test case checks debug info during register moves for an argument.
 // RUN: %clang -std=gnu11 -m64 -mllvm -fast-isel=false -g %s -o %t
-// RUN: %dexter -w --use-script \
+// RUN: %dexter -w \
 // RUN:     --binary %t %dexter_lldb_args -- %s | FileCheck %s
 //
 // Radar 8412415

--- a/cross-project-tests/debuginfo-tests/dexter-tests/deferred_globals.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/deferred_globals.cpp
@@ -5,7 +5,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang++ -std=gnu++11 -O0 -g %s -o %t
-// RUN: %dexter -w --use-script \
+// RUN: %dexter -w \
 // RUN:     --binary  %t %dexter_lldb_args -v -- %s | FileCheck %s
 
 const int d = 100;

--- a/cross-project-tests/debuginfo-tests/dexter-tests/global-constant.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/global-constant.cpp
@@ -1,7 +1,8 @@
 // REQUIRES: system-windows
 //
 // RUN: %clang_cl /Z7 /Zi %s -o %t
-// RUN: %dexter --use-heuristic --use-heuristic --fail-lt 1.0 -w --binary %t --debugger 'dbgeng' -- %s
+// RUN: %dexter --use-heuristic --fail-lt 1.0 -w --binary %t \
+// RUN:   --debugger 'dbgeng' -- %s
 
 // Check that global constants have debug info.
 

--- a/cross-project-tests/debuginfo-tests/dexter-tests/global-constant.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/global-constant.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: system-windows
 //
 // RUN: %clang_cl /Z7 /Zi %s -o %t
-// RUN: %dexter --fail-lt 1.0 -w --binary %t --debugger 'dbgeng' -- %s
+// RUN: %dexter --use-heuristic --use-heuristic --fail-lt 1.0 -w --binary %t --debugger 'dbgeng' -- %s
 
 // Check that global constants have debug info.
 

--- a/cross-project-tests/debuginfo-tests/dexter-tests/hello.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/hello.c
@@ -1,7 +1,7 @@
 // REQUIRES: system-windows
 //
 // RUN: %clang_cl /Z7 /Zi %s -o %t
-// RUN: %dexter --fail-lt 1.0 -w --binary %t --debugger 'dbgeng' -- %s
+// RUN: %dexter --use-heuristic --fail-lt 1.0 -w --binary %t --debugger 'dbgeng' -- %s
 
 #include <stdio.h>
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter-tests/inline-line-gap.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/inline-line-gap.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: system-windows
 //
 // RUN: %clang_cl /Od /Z7 /Zi %s -o %t
-// RUN: %dexter --fail-lt 1.0 -w --binary %t --debugger 'dbgeng' -- %s
+// RUN: %dexter --use-heuristic --fail-lt 1.0 -w --binary %t --debugger 'dbgeng' -- %s
 //
 // RUN: %clang_cl /O2 /Z7 /Zi %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w --binary %t \

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/bitcast.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/bitcast.c
@@ -4,8 +4,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O3 -glldb %s -o %t
-// RUN: %dexter --use-script -w --use-script %dexter_lldb_args --binary %t \
-// RUN:   -- %s | FileCheck %s
+// RUN: %dexter -w %dexter_lldb_args --binary %t -- %s | FileCheck %s
 
 //// Adapted from https://bugs.llvm.org/show_bug.cgi?id=34136#c1
 //// LowerDbgDeclare has since been updated to look through bitcasts. We still

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/const-branch.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/const-branch.c
@@ -4,8 +4,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O3 -glldb %s -o %t
-// RUN: %dexter -w --use-script %dexter_lldb_args --binary %t -- %s \
-// RUN:   | FileCheck %s
+// RUN: %dexter -w %dexter_lldb_args --binary %t -- %s | FileCheck %s
 
 //// Adapted from https://bugs.llvm.org/show_bug.cgi?id=34136#c4
 

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/ctrl-flow.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/ctrl-flow.c
@@ -1,8 +1,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O2 -glldb %s -o %t
-// RUN: %dexter -w --use-script %dexter_lldb_args --binary %t -- %s \
-// RUN:   | FileCheck %s
+// RUN: %dexter -w %dexter_lldb_args --binary %t -- %s | FileCheck %s
 
 //// Check that we give good locations to a variable ('local') which is escaped
 //// down some control paths and not others. This example is handled well currently.

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/implicit-ptr.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/implicit-ptr.c
@@ -4,8 +4,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O3 -glldb %s -o %t
-// RUN: %dexter -w --use-script %dexter_lldb_args --binary %t -- %s \
-// RUN:   | FileCheck %s
+// RUN: %dexter -w %dexter_lldb_args --binary %t -- %s | FileCheck %s
 
 //// Check that 'param' in 'fun' can be read throughout, and that 'pa' and 'pb'
 //// can be dereferenced in the debugger even if we can't provide the pointer

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/inline-escaping-function.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/inline-escaping-function.c
@@ -4,8 +4,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O3 -glldb %s -o %t
-// RUN: %dexter -w --use-script %dexter_lldb_args --binary %t -- %s \
-// RUN:   | FileCheck %s
+// RUN: %dexter -w %dexter_lldb_args --binary %t -- %s | FileCheck %s
 
 // 1. param is escaped by inlineme(&param) so it is not promoted by
 //    SROA/mem2reg.

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/inlining-dse.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/inlining-dse.c
@@ -4,8 +4,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O2 -glldb %s -o %t
-// RUN: %dexter -w --use-script %dexter_lldb_args --binary %t -- %s \
-// RUN:   | FileCheck %s
+// RUN: %dexter -w %dexter_lldb_args --binary %t -- %s | FileCheck %s
 //
 //// Check that once-escaped variable 'param' can still be read after we
 //// perform inlining + mem2reg, and that we see the DSE'd value 255.

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/inlining.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/inlining.c
@@ -1,8 +1,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O2 -glldb %s -o %t
-// RUN: %dexter -w --use-script %dexter_lldb_args --binary %t -- %s \
-// RUN:   | FileCheck %s
+// RUN: %dexter -w %dexter_lldb_args --binary %t -- %s | FileCheck %s
 //
 //// Check that the once-escaped variable 'param' can still be read after
 //// we perform inlining + mem2reg. See D89810 and D85555.

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/loop.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/loop.c
@@ -4,8 +4,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O3 -glldb %s -o %t
-// RUN: %dexter -w --use-script %dexter_lldb_args --binary %t -- %s \
-// RUN:   | FileCheck %s
+// RUN: %dexter -w %dexter_lldb_args --binary %t -- %s | FileCheck %s
 
 //// Check that escaped local 'param' in function 'fun' has sensible debug info
 //// after the escaping function 'use' gets arg promotion (int* -> int). Currently

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/merged-store.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/merged-store.c
@@ -4,8 +4,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O3 -glldb %s -o %t
-// RUN: %dexter -w --use-script %dexter_lldb_args --binary %t -- %s \
-// RUN:   | FileCheck %s
+// RUN: %dexter -w %dexter_lldb_args --binary %t -- %s | FileCheck %s
 
 // 1. parama is escaped by esc(&parama) so it is not promoted by
 //    SROA/mem2reg.

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/ptr-to.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/ptr-to.c
@@ -5,8 +5,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O2 -glldb %s -o %t
-// RUN: %dexter -w --use-script %dexter_lldb_args --binary %t -- %s \
-// RUN:   | FileCheck %s
+// RUN: %dexter -w %dexter_lldb_args --binary %t -- %s | FileCheck %s
 //
 //// Check that a pointer to a variable living on the stack dereferences to the
 //// variable value.

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/struct-dse.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/struct-dse.c
@@ -5,8 +5,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O2 -glldb %s -o %t
-// RUN: %dexter -w --use-script %dexter_lldb_args --binary %t -- %s \
-// RUN:   | FileCheck %s
+// RUN: %dexter -w %dexter_lldb_args --binary %t -- %s | FileCheck %s
 //
 //// Check debug-info for the escaped struct variable num is reasonable.
 

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/unused-merged-value.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/unused-merged-value.c
@@ -6,8 +6,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O3 -glldb %s -o %t
-// RUN: %dexter -w --use-script %dexter_lldb_args --binary %t -- %s \
-// RUN:   | FileCheck %s
+// RUN: %dexter -w %dexter_lldb_args --binary %t -- %s | FileCheck %s
 // See NOTE at end for more info about the RUN command.
 
 // 1. SROA/mem2reg fully promotes parama.

--- a/cross-project-tests/debuginfo-tests/dexter-tests/namespace.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/namespace.cpp
@@ -6,7 +6,7 @@
 // UNSUPPORTED: system-windows
 
 // RUN: %clang++ -g -O0 %s -o %t
-// RUN: %dexter -w --use-script \
+// RUN: %dexter -w \
 // RUN:     --binary %t %dexter_lldb_args -v -- %s | FileCheck %s
 
 #include <stdio.h>

--- a/cross-project-tests/debuginfo-tests/dexter-tests/nrvo-string.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/nrvo-string.cpp
@@ -8,11 +8,11 @@
 //           compiler-rt. Only run this test on non-asanified configurations.
 //
 // RUN: %clang++ -std=gnu++11 -O0 -glldb -fno-exceptions %s -o %t
-// RUN: %dexter -w --use-script \
+// RUN: %dexter -w \
 // RUN:     --binary %t %dexter_lldb_args -- %s | FileCheck %s
 //
 // RUN: %clang++ -std=gnu++11 -O1 -glldb -fno-exceptions %s -o %t
-// RUN: %dexter -w --use-script \
+// RUN: %dexter -w \
 // RUN:     --binary %t %dexter_lldb_args -- %s | FileCheck %s
 //
 // PR34513

--- a/cross-project-tests/debuginfo-tests/dexter-tests/nrvo.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/nrvo.cpp
@@ -4,7 +4,7 @@
 // REQUIRES: system-windows, dbgeng-10-19041
 //
 // RUN: %clang_cl /Z7 /Zi %s -o %t
-// RUN: %dexter --fail-lt 1.0 -w --binary %t --debugger 'dbgeng' -- %s
+// RUN: %dexter --use-heuristic --fail-lt 1.0 -w --binary %t --debugger 'dbgeng' -- %s
 
 struct string {
   string() {}

--- a/cross-project-tests/debuginfo-tests/dexter-tests/optnone-fastmath.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/optnone-fastmath.cpp
@@ -1,8 +1,8 @@
 // RUN: %clang++ -std=gnu++11 -O2 -ffast-math -g %s -o %t
-// RUN: %dexter -w --use-script \
+// RUN: %dexter -w \
 // RUN:     --binary %t %dexter_lldb_args -- %s | FileCheck %s
 // RUN: %clang++ -std=gnu++11 -O0 -ffast-math -g %s -o %t
-// RUN: %dexter -w --use-script \
+// RUN: %dexter -w \
 // RUN:     --binary %t %dexter_lldb_args -- %s | FileCheck %s
 
 // REQUIRES: lldb

--- a/cross-project-tests/debuginfo-tests/dexter-tests/optnone-loops.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/optnone-loops.cpp
@@ -6,7 +6,7 @@
 // UNSUPPORTED: system-darwin
 
 // RUN: %clang++ -std=gnu++11 -O2 -g %s -o %t
-// RUN: %dexter -w --use-script \
+// RUN: %dexter -w \
 // RUN:     --binary %t %dexter_lldb_args -- %s | FileCheck %s
 
 // A simple loop of assignments.

--- a/cross-project-tests/debuginfo-tests/dexter-tests/optnone-simple-functions.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/optnone-simple-functions.cpp
@@ -1,8 +1,8 @@
 // RUN: %clang++ -std=gnu++11 -O2 -g %s -o %t
-// RUN: %dexter -w --use-script \
+// RUN: %dexter -w \
 // RUN:     --binary %t %dexter_lldb_args -- %s | FileCheck %s
 // RUN: %clang++ -std=gnu++11 -O0 -g %s -o %t
-// RUN: %dexter -w --use-script \
+// RUN: %dexter -w \
 // RUN:     --binary %t %dexter_lldb_args -- %s | FileCheck %s
 
 // REQUIRES: lldb, D136396

--- a/cross-project-tests/debuginfo-tests/dexter-tests/optnone-struct-and-methods.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/optnone-struct-and-methods.cpp
@@ -1,8 +1,8 @@
 // RUN: %clang++ -std=gnu++11 -O2 -g %s -o %t
-// RUN: %dexter -w --use-script \
+// RUN: %dexter -w \
 // RUN:     --binary %t %dexter_lldb_args -v -- %s | FileCheck %s
 // RUN: %clang++ -std=gnu++11 -O0 -g %s -o %t
-// RUN: %dexter -w --use-script \
+// RUN: %dexter -w \
 // RUN:     --binary %t %dexter_lldb_args -- %s | FileCheck %s
 
 // REQUIRES: lldb

--- a/cross-project-tests/debuginfo-tests/dexter-tests/optnone-vectors-and-functions.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/optnone-vectors-and-functions.cpp
@@ -1,8 +1,8 @@
 // RUN: %clang++ -std=gnu++11 -O2 -g %s -o %t
-// RUN: %dexter -w --use-script \
+// RUN: %dexter -w \
 // RUN:     --binary %t %dexter_lldb_args -v -- %s | FileCheck %s
 // RUN: %clang++ -std=gnu++11 -O0 -g %s -o %t
-// RUN: %dexter -w --use-script \
+// RUN: %dexter -w \
 // RUN:     --binary %t %dexter_lldb_args -- %s | FileCheck %s
 
 // REQUIRES: lldb

--- a/cross-project-tests/debuginfo-tests/dexter-tests/realigned-frame.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/realigned-frame.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: system-windows
 //
 // RUN: %clang_cl /Z7 /Zi %s -o %t
-// RUN: %dexter --fail-lt 1.0 -w --binary %t --debugger 'dbgeng' -- %s
+// RUN: %dexter --use-heuristic --fail-lt 1.0 -w --binary %t --debugger 'dbgeng' -- %s
 
 // From https://llvm.org/pr38857, where we had issues with stack realignment.
 

--- a/cross-project-tests/debuginfo-tests/dexter-tests/stack-var.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/stack-var.c
@@ -2,8 +2,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %clang -std=gnu11 -O -glldb %s -o %t
-// RUN: %dexter -w --use-script --binary %t %dexter_lldb_args -- %s \
-// RUN:  | FileCheck %s
+// RUN: %dexter -w --binary %t %dexter_lldb_args -- %s | FileCheck %s
 
 void __attribute__((noinline, optnone)) bar(int *test) {}
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter-tests/vla.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/vla.c
@@ -3,8 +3,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %clang -std=gnu11 -O0 -glldb %s -o %t
-// RUN: %dexter -w --use-script --binary %t %dexter_lldb_args -- %s \
-// RUN:  | FileCheck %s
+// RUN: %dexter -w --binary %t %dexter_lldb_args -- %s | FileCheck %s
 
 void init_vla(int size) {
   int i;

--- a/cross-project-tests/debuginfo-tests/dexter/Heuristic.md
+++ b/cross-project-tests/debuginfo-tests/dexter/Heuristic.md
@@ -1,5 +1,7 @@
 # Dexter Heuristic Testing
 
+Dexter's heuristic mode can be accessed by using the `--use-heuristic` flag.
+
 The old test model for Dexter is based on a debug experience "heuristic", combining a variety of different measures produced by "commands" into a single score, ranging from 0.0 (the lowest score) to 1.0 (a perfect score). The contribution from each command and each kind of failure towards this overall score is determine by a set of weights, which are assigned default values but can be given explicit overrides via command line. The set of commands and their behaviour are documented in [Commands.md](./Commands.md).
 
 ## Running a test case

--- a/cross-project-tests/debuginfo-tests/dexter/Script.md
+++ b/cross-project-tests/debuginfo-tests/dexter/Script.md
@@ -1,7 +1,5 @@
 # Dexter Script Testing
 
-Dexter's script mode can be accessed by using the `--use-script` flag.
-
 Dexter scripts are represented by YAML documents, which contain various "nodes" instructing Dexter how to step through the debuggee program, what information to collect and store from the debugger, and how to evaluate the result. A simple Dexter script looks something like this:
 
 ```yaml

--- a/cross-project-tests/debuginfo-tests/dexter/Script.md
+++ b/cross-project-tests/debuginfo-tests/dexter/Script.md
@@ -1,5 +1,7 @@
 # Dexter Script Testing
 
+Dexter's script mode is the default mode of operation; the heuristic mode can be used instead by using the `--use-heuristic` flag (see the main Dexter [Readme](./README.md)).
+
 Dexter scripts are represented by YAML documents, which contain various "nodes" instructing Dexter how to step through the debuggee program, what information to collect and store from the debugger, and how to evaluate the result. A simple Dexter script looks something like this:
 
 ```yaml

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/dbgeng/dbgeng.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/dbgeng/dbgeng.py
@@ -169,12 +169,12 @@ class DbgEng(DebuggerBase):
         )
 
     def get_stack_frames(self, step_index: int) -> StepIR:
-        raise NotImplementedError("--use-script debugging not supported in dbgeng yet.")
+        raise NotImplementedError("--use-heuristic required for dbgeng.")
 
     def collect_watches(
         self, step: StepIR, frame_idx: int, watches: List[str], scope_watches: List[str]
     ):
-        raise NotImplementedError("--use-script debugging not supported in dbgeng yet.")
+        raise NotImplementedError("--use-heuristic required for dbgeng.")
 
     @property
     def is_running(self):

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
@@ -320,12 +320,12 @@ class LLDB(DebuggerBase):
         )
 
     def get_stack_frames(self, step_index: int) -> StepIR:
-        raise NotImplementedError("--use-script debugging not supported in lldb yet.")
+        raise NotImplementedError("--use-heuristic required for dbgeng.")
 
     def collect_watches(
         self, step: StepIR, frame_idx: int, watches: List[str], scope_watches: List[str]
     ):
-        raise NotImplementedError("--use-script debugging not supported in lldb yet.")
+        raise NotImplementedError("--use-heuristic required for dbgeng.")
 
     @property
     def is_running(self):

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/visualstudio/VisualStudio.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/visualstudio/VisualStudio.py
@@ -394,16 +394,12 @@ class VisualStudio(
         )
 
     def get_stack_frames(self, step_index: int) -> StepIR:
-        raise NotImplementedError(
-            "--use-script debugging not supported in visual studio yet."
-        )
+        raise NotImplementedError("--use-heuristic required for visual studio.")
 
     def collect_watches(
         self, step: StepIR, frame_idx: int, watches: List[str], scope_watches: List[str]
     ):
-        raise NotImplementedError(
-            "--use-script debugging not supported in visual studio yet."
-        )
+        raise NotImplementedError("--use-heuristic required for visual studio.")
 
     @property
     def is_running(self):

--- a/cross-project-tests/debuginfo-tests/dexter/dex/tools/TestToolBase.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/tools/TestToolBase.py
@@ -66,10 +66,10 @@ class TestToolBase(ToolBase):
             help="if passed, result names will include relative path from this directory",
         )
         parser.add_argument(
-            "--use-script",
+            "--use-heuristic",
             action="store_true",
             default=False,
-            help="if passed, Dexter will look for a structured YAML script instead of dexter commands",
+            help="if passed, Dexter will use heuristic-mode instead of script-mode (the default)",
         )
 
     def handle_options(self, defaults):

--- a/cross-project-tests/debuginfo-tests/dexter/dex/tools/test/Tool.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/tools/test/Tool.py
@@ -147,7 +147,7 @@ class Tool(TestToolBase):
             dexter_version=self.context.version,
         )
 
-        if self.context.options.use_script:
+        if not self.context.options.use_heuristic:
             step_collection.script, new_source_files = get_dexter_script(
                 self.context,
                 self.context.options.test_files[0],
@@ -160,7 +160,7 @@ class Tool(TestToolBase):
 
         self.context.options.source_files.extend(list(new_source_files))
 
-        if self.context.options.use_script:
+        if not self.context.options.use_heuristic:
             debugger_controller = ScriptDebuggerController(
                 self.context, step_collection
             )
@@ -324,7 +324,7 @@ class Tool(TestToolBase):
                     print("\n".join(step.detailed_print()))
                 return
             self._record_steps(test_name, steps)
-            if self.context.options.use_script:
+            if not self.context.options.use_heuristic:
                 # Before evaluating, the script may contain "unknown" expects; if they should be rewritten, then do so
                 # first, and then use the rewritten script to evaluate.
                 script_writer = ScriptExpectRewriter(self.context, steps)

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/control/dex-continue.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/control/dex-continue.cpp
@@ -9,7 +9,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run -v --binary %t -- %s 2>&1 | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic -v --binary %t -- %s 2>&1 | FileCheck %s
 
 int g = 0;
 int c(int) {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/control/dex_step_function.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/control/dex_step_function.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run -v --binary %t -- %s 2>&1 | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic -v --binary %t -- %s 2>&1 | FileCheck %s
 
 int g = 0;
 int c(int) {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/dex_declare_file.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/dex_declare_file.cpp
@@ -6,7 +6,7 @@
 //
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: dex_declare_file.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_program_state.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_program_state.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: expect_program_state.cpp:
 
 int GCD(int lhs, int rhs)

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_step_kinds.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_step_kinds.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: expect_step_kinds.cpp:
 
 int abs(int i){

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_step_order.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_step_order.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: expect_step_order.cpp:
 
 int main()

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_watch_type.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_watch_type.cpp
@@ -10,7 +10,7 @@
 // expected behaviour.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: expect_watch_type.cpp:
 
 template<class T>

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_watch_value.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_watch_value.cpp
@@ -6,7 +6,7 @@
 //
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: expect_watch_value.cpp:
 
 int main()

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/float_range_out_range.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/float_range_out_range.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: float_range_out_range.cpp:
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/float_range_zero_nonmatch.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/float_range_zero_nonmatch.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: float_range_zero_nonmatch.cpp:
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/missing_dex_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/missing_dex_address.cpp
@@ -6,7 +6,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: missing_dex_address.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/unreachable.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/unreachable.cpp
@@ -6,7 +6,7 @@
 //
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: unreachable.cpp:
 
 int

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/unreachable_line_range.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/unreachable_line_range.cpp
@@ -6,7 +6,7 @@
 //
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: unreachable_line_range.cpp:
 
 int

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/unreachable_on_line.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/unreachable_on_line.cpp
@@ -6,7 +6,7 @@
 //
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: unreachable_on_line.cpp:
 
 int

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/command_line.c
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/command_line.c
@@ -2,7 +2,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %dexter_regression_test_c_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: command_line.c:
 
 int main(int argc, const char **argv) {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/address_after_ref.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/address_after_ref.cpp
@@ -3,7 +3,7 @@
 //      the first reference to that value.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: address_after_ref.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/address_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/address_hit_count.cpp
@@ -5,7 +5,7 @@
 //      times.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: address_hit_count.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/expression_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/expression_address.cpp
@@ -3,7 +3,7 @@
 //      addresses of two local variables that refer to the same address.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: expression_address.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/identical_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/identical_address.cpp
@@ -3,7 +3,7 @@
 //      pointer variables.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: identical_address.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/multiple_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/multiple_address.cpp
@@ -3,7 +3,7 @@
 //      addresses can be used within a single \DexExpectWatchValue.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: multiple_address.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/offset_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/offset_address.cpp
@@ -3,7 +3,7 @@
 //      variables that have a fixed offset between them.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: offset_address.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/self_comparison.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/self_comparison.cpp
@@ -3,7 +3,7 @@
 //      value of a variable over time, relative to its initial value.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: self_comparison.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_file/dex_and_source/test.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_file/dex_and_source/test.cpp
@@ -7,7 +7,7 @@
 //
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: dex_and_source
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_conditional.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_conditional.cpp
@@ -7,7 +7,7 @@
 //      Tests using the default controller (no \DexLimitSteps).
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: default_conditional.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_conditional_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_conditional_hit_count.cpp
@@ -8,7 +8,7 @@
 //      Tests using the default controller (no \DexLimitSteps).
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: default_conditional_hit_count.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_hit_count.cpp
@@ -5,7 +5,7 @@
 //      Tests using the default controller (no \DexLimitSteps).
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: default_hit_count.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_simple.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_simple.cpp
@@ -5,7 +5,7 @@
 //      Tests using the default controller (no \DexLimitSteps).
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: default_simple.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_conditional.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_conditional.cpp
@@ -8,7 +8,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: limit_steps_conditional.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_conditional_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_conditional_hit_count.cpp
@@ -9,7 +9,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: limit_steps_conditional_hit_count.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_hit_count.cpp
@@ -8,7 +8,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: limit_steps_hit_count.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_simple.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_simple.cpp
@@ -8,7 +8,7 @@
 // UNSUPPORTED: system-windows, system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: limit_steps_simple.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_program_state.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_program_state.cpp
@@ -6,7 +6,7 @@
 //
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: expect_program_state.cpp:
 
 int GCD(int lhs, int rhs)

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/direction.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/direction.cpp
@@ -14,7 +14,7 @@
 // UNSUPPORTED: system-linux
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: direction.cpp:
 
 int func(int i) {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/func.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/func.cpp
@@ -6,7 +6,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: func.cpp:
 
 int func(int i) {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/func_external.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/func_external.cpp
@@ -9,7 +9,7 @@
 // why.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: func_external.cpp:
 
 #include <cstdlib>

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/recursive.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/recursive.cpp
@@ -6,7 +6,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: recursive.cpp:
 
 int func(int i) {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/small_loop.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/small_loop.cpp
@@ -6,7 +6,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: small_loop.cpp:
 
 int func(int i){

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_order.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_order.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: expect_step_order.cpp:
 
 int main() // DexLabel('main')

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_watch_type.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_watch_type.cpp
@@ -9,7 +9,7 @@
 // XFAIL: system-windows
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: expect_watch_type.cpp:
 
 template<class T>

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_watch_value.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_watch_value.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: expect_watch_value.cpp:
 
 unsigned long Factorial(int n) {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_multiple.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_multiple.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: float_range_multiple.cpp:
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_no_arg.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_no_arg.cpp
@@ -8,7 +8,7 @@
 // UNSUPPORTED: system-darwin, system-windows
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: float_range_no_arg.cpp:
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_small.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_small.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: float_range_small.cpp:
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_zero_match.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_zero_match.cpp
@@ -4,7 +4,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: float_range_zero_match.cpp:
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/hit_count.cpp
@@ -3,7 +3,7 @@
 //      the number of times the command can trigger.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: hit_count.cpp
 
 int a;

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_check_json_step_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_check_json_step_count.cpp
@@ -2,7 +2,7 @@
 //      Check number of step lines are correctly reported in json output.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t --verbose -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t --verbose -- %s | FileCheck %s
 // CHECK: limit_steps_check_json_step_count.cpp
 // CHECK: ## BEGIN ##
 // CHECK-COUNT-3: json_step_count.cpp",

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_expect_loop.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_expect_loop.cpp
@@ -3,7 +3,7 @@
 //      for loop.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: limit_steps_expect_loop.cpp:
 
 int main(const int argc, const char * argv[]) {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_expect_value.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_expect_value.cpp
@@ -2,7 +2,7 @@
 //      Ensure that limited stepping breaks for all expected values.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: limit_steps_expect_value.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_line_mismatch.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_line_mismatch.cpp
@@ -4,7 +4,7 @@
 //      empty line.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: limit_steps_line_mismatch.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_overlapping_ranges.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_overlapping_ranges.cpp
@@ -2,7 +2,7 @@
 //      Ensure that multiple overlapping \DexLimitSteps ranges do not interfere.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: limit_steps_overlapping_ranges.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_same_line_conditional.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_same_line_conditional.cpp
@@ -2,7 +2,7 @@
 //      Test that LimitStep commands can exist on the same from line.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: limit_steps_same_line_conditional.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/unconditional.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/unconditional.cpp
@@ -3,7 +3,7 @@
 //      breakpoint range is set any time from_line is stepped on).
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: unconditional.cpp
 
 int glob;

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/unreachable.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/unreachable.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: unreachable.cpp:
 
 int main()

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/unreachable_not_cmd_lineno.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/unreachable_not_cmd_lineno.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: unreachable_not_cmd_lineno.cpp:
 
 int main(int argc, char **argv)

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/unreachable_on_line.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/unreachable_on_line.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: unreachable_on_line.cpp:
 
 int main()

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/conditions.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/conditions.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --binary %t -- %s \
+// RUN: %dexter_regression_test_run --binary %t -- %s \
 // RUN:   | FileCheck %s
 
 /// Test that we correctly interpret nested !where+!and nodes during debugging

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/debug_aggregates.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/debug_aggregates.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --skip-evaluate --binary %t \
+// RUN: %dexter_regression_test_run --skip-evaluate --binary %t \
 // RUN:   -- %s | FileCheck %s
 
 /// Check that the debugger is able to fetch the components of aggregate values.

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/simple_where_function.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/simple_where_function.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --skip-evaluate --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --skip-evaluate --binary %t -- %s | FileCheck %s
 
 void assign(int *Target, int Value) {
     // A comment.

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/simple_where_line.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/simple_where_line.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --skip-evaluate --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --skip-evaluate --binary %t -- %s | FileCheck %s
 
 /// Test that we can perform a simple non-nested line-based !where.
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/then_after_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/then_after_hit_count.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --skip-evaluate --binary %t \
+// RUN: %dexter_regression_test_run --skip-evaluate --binary %t \
 // RUN:   -- %s | FileCheck %s
 
 /// Test !then finish with !and{after_hit_count}.

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/then_at_frame.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/then_at_frame.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --skip-evaluate --binary %t \
+// RUN: %dexter_regression_test_run --skip-evaluate --binary %t \
 // RUN:   -- %s | FileCheck %s --implicit-check-not="(int) -5"
 
 // NB: Test CHECKs use line numbers, update them accordingly if adding/removing

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/then_finish.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/then_finish.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --skip-evaluate --binary %t \
+// RUN: %dexter_regression_test_run --skip-evaluate --binary %t \
 // RUN:   -- %s | FileCheck %s
 
 /// Test that when we use !then finish, we finish the entire test immediately,

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/then_step_out.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/then_step_out.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --skip-evaluate --binary %t \
+// RUN: %dexter_regression_test_run --skip-evaluate --binary %t \
 // RUN:   -- %s | FileCheck %s
 
 /// Test that when we use !then step_out, we jump out of the current frame, but

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/watch_scope.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/watch_scope.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --skip-evaluate --binary %t \
+// RUN: %dexter_regression_test_run --skip-evaluate --binary %t \
 // RUN:   -- %s | FileCheck %s
 
 char There[] = "Here";

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/where_file_paths.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/where_file_paths.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --skip-evaluate --binary %t -- %s | FileCheck %s --implicit-check-not="header.h(9"
+// RUN: %dexter_regression_test_run --skip-evaluate --binary %t -- %s | FileCheck %s --implicit-check-not="header.h(9"
 
 /// Test that we can use file paths as part of a !where node, and that we can
 /// use a trailing subset of the file path, including just the base filename, to

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/where_fn_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/where_fn_hit_count.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --skip-evaluate --binary %t \
+// RUN: %dexter_regression_test_run --skip-evaluate --binary %t \
 // RUN:   -- %s | FileCheck %s
 
 /// Test that we record hit counts for !where{function} nodes, even when there

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/where_for_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/where_for_hit_count.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --skip-evaluate --binary %t \
+// RUN: %dexter_regression_test_run --skip-evaluate --binary %t \
 // RUN:   -- %s | FileCheck %s
 
 /// Test !where nodes work with for_hit_count.

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/where_hit_count_early_exit.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/where_hit_count_early_exit.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --skip-evaluate --binary %t \
+// RUN: %dexter_regression_test_run --skip-evaluate --binary %t \
 // RUN:   -- %s 2>&1 | FileCheck %s
 
 /// Test that when all root !where nodes have expired, we exit without waiting

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/evaluation/basic_evaluate.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/evaluation/basic_evaluate.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 
 // Test evaluation of a simple Dexter test.
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/evaluation/eval_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/evaluation/eval_address.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --binary %t -- %s \
+// RUN: %dexter_regression_test_run --binary %t -- %s \
 // RUN:   | FileCheck %s
 
 // Test evaluation of !address nodes in Dexter.

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/evaluation/eval_aggregates.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/evaluation/eval_aggregates.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --binary %t -- %s \
+// RUN: %dexter_regression_test_run --binary %t -- %s \
 // RUN:   | FileCheck %s
 
 /// Check that the debugger is able to evaluate the components of aggregate

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/evaluation/eval_at_frame.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/evaluation/eval_at_frame.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --binary %t -- %s \
+// RUN: %dexter_regression_test_run --binary %t -- %s \
 // RUN:   | FileCheck %s
 
 // Test evaluation of !and{at_frame_idx} nodes in Dexter.

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/evaluation/eval_list_aggregates.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/evaluation/eval_list_aggregates.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --binary %t -- %s \
+// RUN: %dexter_regression_test_run --binary %t -- %s \
 // RUN:   | FileCheck %s
 
 /// Check that the debugger is able to correctly evaluate a list of expected

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/evaluation/eval_steps_penalties.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/evaluation/eval_steps_penalties.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --binary %t -- %s \
+// RUN: %dexter_regression_test_run --binary %t -- %s \
 // RUN:   | FileCheck %s
 
 // Test evaluation of !step nodes in Dexter.

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/evaluation/eval_steps_perfect.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/evaluation/eval_steps_perfect.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --binary %t -- %s \
+// RUN: %dexter_regression_test_run --binary %t -- %s \
 // RUN:   | FileCheck %s
 
 // Test evaluation of !step nodes in Dexter.

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/evaluation/eval_sublist_aggregates.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/evaluation/eval_sublist_aggregates.cpp
@@ -1,8 +1,8 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --binary %t -- %s \
+// RUN: %dexter_regression_test_run --binary %t -- %s \
 // RUN:   | FileCheck %s --check-prefixes=CHECK,CHECK-FORWARD
 // RUN: %dexter_regression_test_cxx_build %s -o %t -DREVERSE_TEST
-// RUN: %dexter_regression_test_run --use-script --binary %t -- %s \
+// RUN: %dexter_regression_test_run --binary %t -- %s \
 // RUN:   | FileCheck %s --check-prefixes=CHECK,CHECK-REVERSE
 
 /// Check that the debugger is able to correctly evaluate lists of values for

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/evaluation/eval_sublist_aggregates_addresses.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/evaluation/eval_sublist_aggregates_addresses.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --binary %t -- %s \
+// RUN: %dexter_regression_test_run --binary %t -- %s \
 // RUN:   | FileCheck %s
 
 /// Tests that expected value lists for aggregate members work as expected with

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/evaluation/eval_types.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/evaluation/eval_types.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --binary %t -- %s \
+// RUN: %dexter_regression_test_run --binary %t -- %s \
 // RUN:   | FileCheck %s
 
 // Test evaluation of !type nodes in Dexter.

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/evaluation/evaluate_nothing.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/evaluation/evaluate_nothing.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 
 // Test evaluation of a Dexter test with no expects.
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/floats.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/floats.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --binary %t -- %s \
+// RUN: %dexter_regression_test_run --binary %t -- %s \
 // RUN:   | FileCheck %s
 
 /// Test that we correctly match float values against Float nodes, and also

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/labels/invalid_label.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/labels/invalid_label.cpp
@@ -1,6 +1,6 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_regression_test_run --source-root-dir %S/Inputs \
-// RUN:   --use-script --binary %t -- %s 2>&1 | FileCheck %s
+// RUN:   --binary %t -- %s 2>&1 | FileCheck %s
 
 int main() {
   int a = 4;

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/labels/offset.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/labels/offset.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --binary %t -- %s \
+// RUN: %dexter_regression_test_run --binary %t -- %s \
 // RUN:   | FileCheck %s
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/labels/simple_labels.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/labels/simple_labels.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --binary %t -- %s \
+// RUN: %dexter_regression_test_run --binary %t -- %s \
 // RUN:   | FileCheck %s
 
 #include "Inputs/header.h"

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/labels/source_root_dir.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/labels/source_root_dir.cpp
@@ -1,6 +1,6 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --source-root-dir %S/Inputs \
-// RUN:   --use-script --binary %t -- %s | FileCheck %s
+// RUN:   --binary %t -- %s | FileCheck %s
 
 // Check that when --source-root-dir is provided, labels will be checked
 // relative to that directory.

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/nested_wheres.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/nested_wheres.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --binary %t -- %s \
+// RUN: %dexter_regression_test_run --binary %t -- %s \
 // RUN:   | FileCheck %s
 
 /// Test that we correctly interpret nested !where+!and nodes during debugging

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/parser/bad-where-attr.test
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/parser/bad-where-attr.test
@@ -1,4 +1,4 @@
-RUN: not %dexter_regression_test_run --binary %s --use-script -- %s 2>&1 | FileCheck %s
+RUN: not %dexter_regression_test_run --binary %s -- %s 2>&1 | FileCheck %s
 
 This is a test that when the script document starts part-way through a file, any syntax errors are reported with the
 correct line number.

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/parser/error-locations.test
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/parser/error-locations.test
@@ -1,4 +1,4 @@
-RUN: not %dexter_regression_test_run --binary %s --use-script -- %s 2>&1 | FileCheck %s
+RUN: not %dexter_regression_test_run --binary %s -- %s 2>&1 | FileCheck %s
 
 This is a test that when the script document starts part-way through a file, any syntax errors are reported with the
 correct line number.

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/parser/expect-all-with-value.test
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/parser/expect-all-with-value.test
@@ -1,4 +1,4 @@
-RUN: not %dexter_regression_test_run --binary %s --use-script --skip-run -- %s 2>&1 | FileCheck %s
+RUN: not %dexter_regression_test_run --binary %s --skip-run -- %s 2>&1 | FileCheck %s
 
 Tests that we reject !expect/all nodes with expected values.
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/parser/invalid-address.test
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/parser/invalid-address.test
@@ -1,4 +1,4 @@
-RUN: not %dexter_regression_test_run --binary %s --use-script --skip-run -- %s 2>&1 | FileCheck %s
+RUN: not %dexter_regression_test_run --binary %s --skip-run -- %s 2>&1 | FileCheck %s
 
 Tests that we reject ill-formed addresses.
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/parser/invalid-script-nodes.test
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/parser/invalid-script-nodes.test
@@ -1,4 +1,4 @@
-RUN: not %dexter_regression_test_run --binary %s --use-script -- %s 2>&1 | FileCheck %s
+RUN: not %dexter_regression_test_run --binary %s -- %s 2>&1 | FileCheck %s
 
 This is a test that Dexter validates that nodes appear in the correct place in scripts.
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/parser/parse-address.test
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/parser/parse-address.test
@@ -1,4 +1,4 @@
-RUN: %dexter_regression_test_run --binary %s --use-script --skip-run -- %s 2>&1 | FileCheck %s
+RUN: %dexter_regression_test_run --binary %s --skip-run -- %s 2>&1 | FileCheck %s
 
 Tests that we can correctly parse+print !address nodes.
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/parser/reject-bad-at_frame_idx.test
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/parser/reject-bad-at_frame_idx.test
@@ -1,4 +1,4 @@
-RUN: not %dexter_regression_test_run --binary %s --use-script --skip-run -- %s 2>&1 | FileCheck %s
+RUN: not %dexter_regression_test_run --binary %s --skip-run -- %s 2>&1 | FileCheck %s
 
 Tests that we reject invalid at_frame_idx uses.
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/parser/step-node-expected-values.test
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/parser/step-node-expected-values.test
@@ -1,4 +1,4 @@
-RUN: not %dexter_regression_test_run --binary %s --use-script --skip-run -- %s 2>&1 | FileCheck %s
+RUN: not %dexter_regression_test_run --binary %s --skip-run -- %s 2>&1 | FileCheck %s
 
 Tests that !step expected values must not be anything other than a list of integers.
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/parser/valid-parse.test
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/parser/valid-parse.test
@@ -1,4 +1,4 @@
-RUN: %dexter_regression_test_run --binary %s --use-script --skip-run -- %s 2>&1 | FileCheck %s
+RUN: %dexter_regression_test_run --binary %s --skip-run -- %s 2>&1 | FileCheck %s
 
 Provides a valid test case and checks that we can parse it successfully and print the script back out correctly.
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/Inputs/rewrite_aggregates_expected.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/Inputs/rewrite_aggregates_expected.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: %dexter_regression_test_cxx_build %s -o %t/test
-// RUN: %dexter_regression_test_run --use-script --binary %t/test \
+// RUN: %dexter_regression_test_run --binary %t/test \
 // RUN:   --results-directory %t/results -- %s 2>&1 | FileCheck %s
 // RUN: diff %t/results/%{s:basename} %S/Inputs/rewrite_aggregates_expected.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/Inputs/rewrite_at_frame_expected.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/Inputs/rewrite_at_frame_expected.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: %dexter_regression_test_cxx_build %s -o %t/test
-// RUN: %dexter_regression_test_run --use-script --binary %t/test \
+// RUN: %dexter_regression_test_run --binary %t/test \
 // RUN:   --results-directory %t/results -- %s 2>&1 | FileCheck %s
 // RUN: diff %t/results/%{s:basename} \
 // RUN:   %S/Inputs/rewrite_at_frame_expected.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/Inputs/rewrite_expect_list_expected.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/Inputs/rewrite_expect_list_expected.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: %dexter_regression_test_cxx_build %s -o %t/test
-// RUN: %dexter_regression_test_run --use-script --binary %t/test \
+// RUN: %dexter_regression_test_run --binary %t/test \
 // RUN:   --results-directory %t/results -- %s 2>&1 | FileCheck %s
 // RUN: diff %t/results/%{s:basename} %S/Inputs/rewrite_expect_list_expected.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/Inputs/rewrite_expects_expected.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/Inputs/rewrite_expects_expected.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: %dexter_regression_test_cxx_build %s -o %t/test
-// RUN: %dexter_regression_test_run --use-script --binary %t/test \
+// RUN: %dexter_regression_test_run --binary %t/test \
 // RUN:   --results-directory %t/results -- %s 2>&1 | FileCheck %s
 // RUN: diff %t/results/%{s:basename} %S/Inputs/rewrite_expects_expected.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/Inputs/rewrite_list_aggregates_expected.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/Inputs/rewrite_list_aggregates_expected.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: %dexter_regression_test_cxx_build %s -o %t/test
-// RUN: %dexter_regression_test_run --use-script --binary %t/test \
+// RUN: %dexter_regression_test_run --binary %t/test \
 // RUN:   --results-directory %t/results -- %s 2>&1 | FileCheck %s
 // RUN: diff %t/results/%{s:basename} \
 // RUN:   %S/Inputs/rewrite_list_aggregates_expected.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/Inputs/rewrite_multiple_scripts_expected.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/Inputs/rewrite_multiple_scripts_expected.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: %dexter_regression_test_cxx_build %s -o %t/test
-// RUN: %dexter_regression_test_run --use-script --binary %t/test \
+// RUN: %dexter_regression_test_run --binary %t/test \
 // RUN:   --results-directory %t/results -- %s 2>&1 | FileCheck %s
 // RUN: diff %t/results/%{s:basename} \
 // RUN:   %S/Inputs/rewrite_multiple_scripts_expected.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/Inputs/rewrite_scopes_expected.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/Inputs/rewrite_scopes_expected.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: %dexter_regression_test_cxx_build %s -o %t/test
-// RUN: %dexter_regression_test_run --use-script --binary %t/test \
+// RUN: %dexter_regression_test_run --binary %t/test \
 // RUN:   --results-directory %t/results -- %s 2>&1 | FileCheck %s
 // RUN: diff %t/results/%{s:basename} \
 // RUN:   %S/Inputs/rewrite_scopes_expected.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/Inputs/rewrite_scopes_list_expected.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/Inputs/rewrite_scopes_list_expected.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: %dexter_regression_test_cxx_build %s -o %t/test
-// RUN: %dexter_regression_test_run --use-script --binary %t/test \
+// RUN: %dexter_regression_test_run --binary %t/test \
 // RUN:   --results-directory %t/results -- %s 2>&1 | FileCheck %s
 // RUN: diff %t/results/%{s:basename} \
 // RUN:   %S/Inputs/rewrite_scopes_list_expected.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/Inputs/rewrite_types_expected.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/Inputs/rewrite_types_expected.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: %dexter_regression_test_cxx_build %s -o %t/test
-// RUN: %dexter_regression_test_run --use-script --binary %t/test \
+// RUN: %dexter_regression_test_run --binary %t/test \
 // RUN:   --results-directory %t/results -- %s 2>&1 | FileCheck %s
 // RUN: diff %t/results/%{s:basename} %S/Inputs/rewrite_types_expected.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_aggregates.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_aggregates.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: %dexter_regression_test_cxx_build %s -o %t/test
-// RUN: %dexter_regression_test_run --use-script --binary %t/test \
+// RUN: %dexter_regression_test_run --binary %t/test \
 // RUN:   --results-directory %t/results -- %s 2>&1 | FileCheck %s
 // RUN: diff %t/results/%{s:basename} %S/Inputs/rewrite_aggregates_expected.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_at_frame.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_at_frame.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: %dexter_regression_test_cxx_build %s -o %t/test
-// RUN: %dexter_regression_test_run --use-script --binary %t/test \
+// RUN: %dexter_regression_test_run --binary %t/test \
 // RUN:   --results-directory %t/results -- %s 2>&1 | FileCheck %s
 // RUN: diff %t/results/%{s:basename} \
 // RUN:   %S/Inputs/rewrite_at_frame_expected.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_expect_list.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_expect_list.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: %dexter_regression_test_cxx_build %s -o %t/test
-// RUN: %dexter_regression_test_run --use-script --binary %t/test \
+// RUN: %dexter_regression_test_run --binary %t/test \
 // RUN:   --results-directory %t/results -- %s 2>&1 | FileCheck %s
 // RUN: diff %t/results/%{s:basename} %S/Inputs/rewrite_expect_list_expected.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_expects.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_expects.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: %dexter_regression_test_cxx_build %s -o %t/test
-// RUN: %dexter_regression_test_run --use-script --binary %t/test \
+// RUN: %dexter_regression_test_run --binary %t/test \
 // RUN:   --results-directory %t/results -- %s 2>&1 | FileCheck %s
 // RUN: diff %t/results/%{s:basename} %S/Inputs/rewrite_expects_expected.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_list_aggregates.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_list_aggregates.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: %dexter_regression_test_cxx_build %s -o %t/test
-// RUN: %dexter_regression_test_run --use-script --binary %t/test \
+// RUN: %dexter_regression_test_run --binary %t/test \
 // RUN:   --results-directory %t/results -- %s 2>&1 | FileCheck %s
 // RUN: diff %t/results/%{s:basename} \
 // RUN:   %S/Inputs/rewrite_list_aggregates_expected.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_multiple_scripts.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_multiple_scripts.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: %dexter_regression_test_cxx_build %s -o %t/test
-// RUN: %dexter_regression_test_run --use-script --binary %t/test \
+// RUN: %dexter_regression_test_run --binary %t/test \
 // RUN:   --results-directory %t/results -- %s 2>&1 | FileCheck %s
 // RUN: diff %t/results/%{s:basename} \
 // RUN:   %S/Inputs/rewrite_multiple_scripts_expected.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_scopes.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_scopes.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: %dexter_regression_test_cxx_build %s -o %t/test
-// RUN: %dexter_regression_test_run --use-script --binary %t/test \
+// RUN: %dexter_regression_test_run --binary %t/test \
 // RUN:   --results-directory %t/results -- %s 2>&1 | FileCheck %s
 // RUN: diff %t/results/%{s:basename} \
 // RUN:   %S/Inputs/rewrite_scopes_expected.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_scopes_list.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_scopes_list.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: %dexter_regression_test_cxx_build %s -o %t/test
-// RUN: %dexter_regression_test_run --use-script --binary %t/test \
+// RUN: %dexter_regression_test_run --binary %t/test \
 // RUN:   --results-directory %t/results -- %s 2>&1 | FileCheck %s
 // RUN: diff %t/results/%{s:basename} \
 // RUN:   %S/Inputs/rewrite_scopes_list_expected.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_step_lines.test
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_step_lines.test
@@ -2,7 +2,7 @@ RUN: rm -rf %t
 RUN: mkdir %t
 RUN: %dexter_regression_test_cxx_build %S/Inputs/rewrite_step_lines.cpp \
 RUN:   -o %t/test
-RUN: %dexter_regression_test_run --use-script --binary %t/test \
+RUN: %dexter_regression_test_run --binary %t/test \
 RUN:   --results-directory %t/results -- %S/Inputs/rewrite_step_lines.cpp 2>&1 \
 RUN:   | FileCheck %s
 RUN: diff %t/results/rewrite_step_lines.cpp \

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_types.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/rewrite_types.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: %dexter_regression_test_cxx_build %s -o %t/test
-// RUN: %dexter_regression_test_run --use-script --binary %t/test \
+// RUN: %dexter_regression_test_run --binary %t/test \
 // RUN:   --results-directory %t/results -- %s 2>&1 | FileCheck %s
 // RUN: diff %t/results/%{s:basename} %S/Inputs/rewrite_types_expected.cpp
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/whole_file.test
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/rewriting/whole_file.test
@@ -1,7 +1,7 @@
 RUN: rm -rf %t
 RUN: mkdir %t
 RUN: %dexter_regression_test_cxx_build %S/Inputs/simple_prog.cpp -o %t/test
-RUN: %dexter_regression_test_run --use-script --binary %t/test \
+RUN: %dexter_regression_test_run --binary %t/test \
 RUN:   --results-directory %t/results --source-root-dir %S/Inputs -- \
 RUN:   %S/Inputs/whole_file_test.dex 2>&1 | FileCheck %s
 RUN: diff %t/results/whole_file_test.dex %S/Inputs/whole_file_test_expected.dex

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/where_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/where_hit_count.cpp
@@ -1,5 +1,5 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --use-script --binary %t -- %s \
+// RUN: %dexter_regression_test_run --binary %t -- %s \
 // RUN:   | FileCheck %s
 
 /// Test that Dexter respects for and after hit_counts.

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/address_printing.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/address_printing.cpp
@@ -12,7 +12,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -v -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --use-heuristic --binary %t -v -- %s | FileCheck %s
 
 // CHECK: Resolved Addresses:
 // CHECK-NEXT: 'x_2': 0x[[X2_VAL:[0-9a-f]+]]

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_bad_label_ref.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_bad_label_ref.cpp
@@ -2,7 +2,7 @@
 //      Check that referencing an undefined label gives a useful error message.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -v -- %s | FileCheck %s --match-full-lines
+// RUN: not %dexter_regression_test_run --use-heuristic --binary %t -v -- %s | FileCheck %s --match-full-lines
 //
 // CHECK: parser error:{{.*}}err_bad_label_ref.cpp(15): Unresolved label: 'label_does_not_exist'
 // CHECK-NEXT: {{Dex}}ExpectWatchValue('result', '0', on_line=ref('label_does_not_exist'))

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_duplicate_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_duplicate_address.cpp
@@ -2,7 +2,7 @@
 //      Check that declaring duplicate addresses gives a useful error message.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -v -- %s | FileCheck %s --match-full-lines
+// RUN: not %dexter_regression_test_run --use-heuristic --binary %t -v -- %s | FileCheck %s --match-full-lines
 
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_duplicate_label.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_duplicate_label.cpp
@@ -2,7 +2,7 @@
 //      Check that defining duplicate labels gives a useful error message.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -v -- %s | FileCheck %s --match-full-lines
+// RUN: not %dexter_regression_test_run --use-heuristic --binary %t -v -- %s | FileCheck %s --match-full-lines
 //
 // CHECK: parser error:{{.*}}err_duplicate_label.cpp(12): Found duplicate line label: 'oops'
 // CHECK-NEXT: {{Dex}}Label('oops')

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_label_kwarg.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_label_kwarg.cpp
@@ -2,7 +2,7 @@
 //    Check that bad keyword args in \DexLabel are reported.
 //    Use --binary switch to trick dexter into skipping the build step.
 //
-// RUN: not %dexter_base test --binary %s %dexter_regression_test_debugger_args -- %s | FileCheck %s
+// RUN: not %dexter_base test --use-heuristic --binary %s %dexter_regression_test_debugger_args -- %s | FileCheck %s
 // CHECK: parser error:{{.*}}err_label_kwarg.cpp(8): unexpected named args: bad_arg
 
 // DexLabel('test', bad_arg=0)

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_limit_steps_no_values.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_limit_steps_no_values.cpp
@@ -3,7 +3,7 @@
 //    in a \DexLimitSteps command results in a useful error message.
 //    Use --binary switch to trick dexter into skipping the build step.
 //
-// RUN: not %dexter_base test --binary %s %dexter_regression_test_debugger_args -- %s | FileCheck %s
+// RUN: not %dexter_base test --use-heuristic --binary %s %dexter_regression_test_debugger_args -- %s | FileCheck %s
 // CHECK: parser error:{{.*}}err_limit_steps_no_values.cpp(9): expected 0 or at least 2 positional arguments
 
 // DexLimitSteps('test')

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren.cpp
@@ -5,7 +5,7 @@
 //      commands.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
+// RUN: not %dexter_base test --use-heuristic --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //
 // CHECK:parser error:{{.*}}err_paren.cpp(19): Unbalanced parenthesis starting here

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren_mline.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren_mline.cpp
@@ -5,7 +5,7 @@
 //      commands.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
+// RUN: not %dexter_base test --use-heuristic --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //
 // CHECK:parser error:{{.*}}err_paren_mline.cpp(20): Unbalanced parenthesis starting here

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax.cpp
@@ -5,7 +5,7 @@
 //      commands.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
+// RUN: not %dexter_base test --use-heuristic --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //
 // CHECK:parser error:{{.*}}err_syntax.cpp(18): invalid syntax

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax_dexdeclarefile.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax_dexdeclarefile.cpp
@@ -3,7 +3,7 @@
 //      they appeared in rather than the current declared file.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args -v -- %s \
+// RUN: not %dexter_base test --use-heuristic --binary %t %dexter_regression_test_debugger_args -v -- %s \
 // RUN:     | FileCheck %s --implicit-check-not=FAIL-FILENAME-MATCH
 
 // CHECK: err_syntax_dexdeclarefile.cpp(14): Undeclared address: 'not_been_declared'

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax_mline.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax_mline.cpp
@@ -5,7 +5,7 @@
 //      commands.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
+// RUN: not %dexter_base test --use-heuristic --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //
 // CHECK:parser error:{{.*}}err_syntax_mline.cpp(21): invalid syntax

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type.cpp
@@ -5,7 +5,7 @@
 //      commands.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
+// RUN: not %dexter_base test --use-heuristic --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //
 // CHECK:parser error:{{.*}}err_type.cpp(18): expected at least two args

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type_mline.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type_mline.cpp
@@ -5,7 +5,7 @@
 //      commands.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
+// RUN: not %dexter_base test --use-heuristic --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //
 // CHECK:parser error:{{.*}}err_type_mline.cpp(19): expected at least two args

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_undeclared_addr.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_undeclared_addr.cpp
@@ -2,7 +2,7 @@
 //      Check that using an undeclared address gives a useful error message.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -v -- %s | FileCheck %s --match-full-lines
+// RUN: not %dexter_regression_test_run --use-heuristic --binary %t -v -- %s | FileCheck %s --match-full-lines
 
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/label_another_line.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/label_another_line.cpp
@@ -3,7 +3,7 @@
 //    that line instead of the line the command is found on.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -- %s | FileCheck %s
 // CHECK: label_another_line.cpp: (1.0000)
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/label_offset.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/label_offset.cpp
@@ -2,7 +2,7 @@
 //      Check that we can use label-relative line numbers.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -v -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t -v -- %s | FileCheck %s
 //
 // CHECK: label_offset.cpp: (1.0000)
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/source-root-dir.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/source-root-dir.cpp
@@ -2,7 +2,7 @@
 // XFAIL:*
 // RUN: %dexter_regression_test_cxx_build \
 // RUN:     -fdebug-prefix-map=%S=/changed %s -o %t
-// RUN: %dexter_regression_test_run \
+// RUN: %dexter_regression_test_run --use-heuristic \
 // RUN:     --binary %t --source-root-dir=%S --debugger-use-relative-paths -- %s
 
 #include <stdio.h>

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/target_run_args.c
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/target_run_args.c
@@ -2,7 +2,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %dexter_regression_test_c_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t --target-run-args "a b 'c d'" -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t --target-run-args "a b 'c d'" -- %s | FileCheck %s
 // CHECK: target_run_args.c:
 
 int main(int argc, const char **argv) {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/target_run_args_with_command.c
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/target_run_args_with_command.c
@@ -2,7 +2,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %dexter_regression_test_c_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t --target-run-args "a b 'c d'" -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t --target-run-args "a b 'c d'" -- %s | FileCheck %s
 // CHECK: target_run_args_with_command.c:
 
 int main(int argc, const char **argv) {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/view.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/view.cpp
@@ -1,15 +1,14 @@
 // Purpose:
 //      Check the `view` subtool works with typical inputs.
 //
+// RUN: rm -rf %t
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t --results %t.results -- %s
+// RUN: %dexter_regression_test_run --use-heuristic --binary %t \
+// RUN:   --results %t.results -- %s
 //
 // RUN: %dexter_base view %t.results/view.cpp.dextIR | FileCheck %s
 // CHECK: ## BEGIN
 // CHECK: ## END
-//
-// # [TODO] This doesn't run if FileCheck fails!
-// RUN: rm -rf %t
 
 int main() {
     int a = 0;


### PR DESCRIPTION
This patch changes the default mode of Dexter from heuristic-mode to
script-mode. The --use-script argument is replaced with --use-heuristic,
some comments/docs/error messages are updated accordingly, and tests have
their flags switched accordingly.