### PR TITLE
[NVPTX] Fix build break from #201217

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -1690,7 +1690,7 @@ void NVPTXAsmPrinter::bufferLEByte(const Constant *CPV, int Bytes,
       // ptrtoint, e.g. add(ptrtoint(@g), C). It can't fold to a ConstantInt
       // because it references a symbol; emit it through lowerConstantForGV, the
       // same path scalar symbol-relative integer globals use.
-      AggBuffer->addSymbol(Cexpr, Cexpr);
+      AggBuffer->addSymbol(Cexpr, Cexpr, AllocSize);
       AggBuffer->addZeros(AllocSize);
       break;
     }


### PR DESCRIPTION
#201217 added a third `SymbolSize` argument to `AggBuffer::addSymbol()` but missed one call site, which was added by 98160521cb72 after the PR branch was cut.  Pass `AllocSize` like the sibling calls do.