### PR TITLE
[RISCV] Remove unused CHECK prefixes in `rvp-simd-32.ll`

### DIFF
--- a/llvm/test/CodeGen/RISCV/rvp-simd-32.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-simd-32.ll
@@ -961,23 +961,7 @@ define <4 x i8> @test_psll_bs_mask(<4 x i8> %a, i8 %shamt) {
 
 ; Test logical shift left(vector shamt)
 define <2 x i16> @test_psll_hs_vec_shamt(<2 x i16> %a, <2 x i16> %b) {
-; CHECK-RV32-LABEL: test_psll_hs_vec_shamt:
-; CHECK-RV32:       # %bb.0:
-; CHECK-RV32-NEXT:    srli a2, a1, 16
-; CHECK-RV32-NEXT:    srli a3, a0, 16
-; CHECK-RV32-NEXT:    sll a0, a0, a1
-; CHECK-RV32-NEXT:    sll a1, a3, a2
-; CHECK-RV32-NEXT:    pack a0, a0, a1
-; CHECK-RV32-NEXT:    ret
 ;
-; CHECK-RV64-LABEL: test_psll_hs_vec_shamt:
-; CHECK-RV64:       # %bb.0:
-; CHECK-RV64-NEXT:    srli a2, a1, 16
-; CHECK-RV64-NEXT:    srli a3, a0, 16
-; CHECK-RV64-NEXT:    sll a0, a0, a1
-; CHECK-RV64-NEXT:    sll a1, a3, a2
-; CHECK-RV64-NEXT:    ppaire.h a0, a0, a1
-; CHECK-RV64-NEXT:    ret
 ; RV32-LABEL: test_psll_hs_vec_shamt:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    srli a2, a1, 16
@@ -1000,38 +984,7 @@ define <2 x i16> @test_psll_hs_vec_shamt(<2 x i16> %a, <2 x i16> %b) {
 }
 
 define <4 x i8> @test_psll_bs_vec_shamt(<4 x i8> %a, <4 x i8> %b) {
-; CHECK-RV32-LABEL: test_psll_bs_vec_shamt:
-; CHECK-RV32:       # %bb.0:
-; CHECK-RV32-NEXT:    srli a2, a1, 24
-; CHECK-RV32-NEXT:    srli a3, a0, 24
-; CHECK-RV32-NEXT:    srli a4, a1, 8
-; CHECK-RV32-NEXT:    sll a3, a3, a2
-; CHECK-RV32-NEXT:    srli a2, a0, 8
-; CHECK-RV32-NEXT:    sll a6, a0, a1
-; CHECK-RV32-NEXT:    srli a1, a1, 16
-; CHECK-RV32-NEXT:    srli a0, a0, 16
-; CHECK-RV32-NEXT:    sll a2, a2, a4
-; CHECK-RV32-NEXT:    sll a7, a0, a1
-; CHECK-RV32-NEXT:    ppaire.db a0, a6, a2
-; CHECK-RV32-NEXT:    pack a0, a0, a1
-; CHECK-RV32-NEXT:    ret
 ;
-; CHECK-RV64-LABEL: test_psll_bs_vec_shamt:
-; CHECK-RV64:       # %bb.0:
-; CHECK-RV64-NEXT:    srli a2, a1, 24
-; CHECK-RV64-NEXT:    srli a3, a0, 24
-; CHECK-RV64-NEXT:    srli a4, a1, 16
-; CHECK-RV64-NEXT:    srli a5, a0, 16
-; CHECK-RV64-NEXT:    sll a2, a3, a2
-; CHECK-RV64-NEXT:    sll a3, a5, a4
-; CHECK-RV64-NEXT:    srli a4, a1, 8
-; CHECK-RV64-NEXT:    srli a5, a0, 8
-; CHECK-RV64-NEXT:    sll a0, a0, a1
-; CHECK-RV64-NEXT:    sll a1, a5, a4
-; CHECK-RV64-NEXT:    ppaire.b a2, a3, a2
-; CHECK-RV64-NEXT:    ppaire.b a0, a0, a1
-; CHECK-RV64-NEXT:    ppaire.h a0, a0, a2
-; CHECK-RV64-NEXT:    ret
 ; RV32-LABEL: test_psll_bs_vec_shamt:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    srli a2, a1, 24
@@ -1188,44 +1141,7 @@ define <2 x i16> @test_psrl_hs_vec_shamt(<2 x i16> %a, <2 x i16> %b) {
 }
 
 define <4 x i8> @test_psrl_bs_vec_shamt(<4 x i8> %a, <4 x i8> %b) {
-; CHECK-RV32-LABEL: test_psrl_bs_vec_shamt:
-; CHECK-RV32:       # %bb.0:
-; CHECK-RV32-NEXT:    srli a2, a1, 24
-; CHECK-RV32-NEXT:    srli a3, a0, 24
-; CHECK-RV32-NEXT:    srli a4, a1, 8
-; CHECK-RV32-NEXT:    srl a3, a3, a2
-; CHECK-RV32-NEXT:    slli a2, a0, 16
-; CHECK-RV32-NEXT:    srli a2, a2, 24
-; CHECK-RV32-NEXT:    zext.b a5, a0
-; CHECK-RV32-NEXT:    srl a6, a5, a1
-; CHECK-RV32-NEXT:    slli a0, a0, 8
-; CHECK-RV32-NEXT:    srli a1, a1, 16
-; CHECK-RV32-NEXT:    srli a0, a0, 24
-; CHECK-RV32-NEXT:    srl a2, a2, a4
-; CHECK-RV32-NEXT:    srl a7, a0, a1
-; CHECK-RV32-NEXT:    ppaire.db a0, a6, a2
-; CHECK-RV32-NEXT:    pack a0, a0, a1
-; CHECK-RV32-NEXT:    ret
 ;
-; CHECK-RV64-LABEL: test_psrl_bs_vec_shamt:
-; CHECK-RV64:       # %bb.0:
-; CHECK-RV64-NEXT:    srli a2, a1, 24
-; CHECK-RV64-NEXT:    srliw a3, a0, 24
-; CHECK-RV64-NEXT:    slli a4, a0, 40
-; CHECK-RV64-NEXT:    srli a5, a1, 16
-; CHECK-RV64-NEXT:    srli a4, a4, 56
-; CHECK-RV64-NEXT:    srl a2, a3, a2
-; CHECK-RV64-NEXT:    srl a3, a4, a5
-; CHECK-RV64-NEXT:    zext.b a4, a0
-; CHECK-RV64-NEXT:    slli a0, a0, 48
-; CHECK-RV64-NEXT:    srli a5, a1, 8
-; CHECK-RV64-NEXT:    srli a0, a0, 56
-; CHECK-RV64-NEXT:    srl a1, a4, a1
-; CHECK-RV64-NEXT:    srl a0, a0, a5
-; CHECK-RV64-NEXT:    ppaire.b a2, a3, a2
-; CHECK-RV64-NEXT:    ppaire.b a0, a1, a0
-; CHECK-RV64-NEXT:    ppaire.h a0, a0, a2
-; CHECK-RV64-NEXT:    ret
 ; RV32-LABEL: test_psrl_bs_vec_shamt:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    srli a2, a1, 24
@@ -1290,60 +1206,12 @@ define <2 x i16> @test_psra_hs_vec_shamt(<2 x i16> %a, <2 x i16> %b) {
 ; RV64-NEXT:    sra a0, a0, a3
 ; RV64-NEXT:    ppaire.h a0, a1, a0
 ; RV64-NEXT:    ret
-; CHECK-RV64-LABEL: test_psra_hs_vec_shamt:
-; CHECK-RV64:       # %bb.0:
-; CHECK-RV64-NEXT:    sext.h a2, a0
-; CHECK-RV64-NEXT:    srli a0, a0, 16
-; CHECK-RV64-NEXT:    srli a3, a1, 16
-; CHECK-RV64-NEXT:    sext.h a0, a0
-; CHECK-RV64-NEXT:    sra a1, a2, a1
-; CHECK-RV64-NEXT:    sra a0, a0, a3
-; CHECK-RV64-NEXT:    ppaire.h a0, a1, a0
-; CHECK-RV64-NEXT:    ret
   %res = ashr <2 x i16> %a, %b
   ret <2 x i16> %res
 }
 
 define <4 x i8> @test_psra_bs_vec_shamt(<4 x i8> %a, <4 x i8> %b) {
-; CHECK-RV32-LABEL: test_psra_bs_vec_shamt:
-; CHECK-RV32:       # %bb.0:
-; CHECK-RV32-NEXT:    srli a2, a1, 24
-; CHECK-RV32-NEXT:    srai a3, a0, 24
-; CHECK-RV32-NEXT:    srli a4, a1, 8
-; CHECK-RV32-NEXT:    sra a3, a3, a2
-; CHECK-RV32-NEXT:    srli a2, a0, 8
-; CHECK-RV32-NEXT:    sext.b a2, a2
-; CHECK-RV32-NEXT:    sext.b a5, a0
-; CHECK-RV32-NEXT:    sra a6, a5, a1
-; CHECK-RV32-NEXT:    srli a0, a0, 16
-; CHECK-RV32-NEXT:    srli a1, a1, 16
-; CHECK-RV32-NEXT:    sext.b a0, a0
-; CHECK-RV32-NEXT:    sra a2, a2, a4
-; CHECK-RV32-NEXT:    sra a7, a0, a1
-; CHECK-RV32-NEXT:    ppaire.db a0, a6, a2
-; CHECK-RV32-NEXT:    pack a0, a0, a1
-; CHECK-RV32-NEXT:    ret
 ;
-; CHECK-RV64-LABEL: test_psra_bs_vec_shamt:
-; CHECK-RV64:       # %bb.0:
-; CHECK-RV64-NEXT:    srli a2, a1, 24
-; CHECK-RV64-NEXT:    srli a3, a0, 24
-; CHECK-RV64-NEXT:    srli a4, a0, 16
-; CHECK-RV64-NEXT:    sext.b a3, a3
-; CHECK-RV64-NEXT:    srli a5, a1, 16
-; CHECK-RV64-NEXT:    sext.b a4, a4
-; CHECK-RV64-NEXT:    sra a2, a3, a2
-; CHECK-RV64-NEXT:    sra a3, a4, a5
-; CHECK-RV64-NEXT:    sext.b a4, a0
-; CHECK-RV64-NEXT:    srli a0, a0, 8
-; CHECK-RV64-NEXT:    srli a5, a1, 8
-; CHECK-RV64-NEXT:    sext.b a0, a0
-; CHECK-RV64-NEXT:    sra a1, a4, a1
-; CHECK-RV64-NEXT:    sra a0, a0, a5
-; CHECK-RV64-NEXT:    ppaire.b a2, a3, a2
-; CHECK-RV64-NEXT:    ppaire.b a0, a1, a0
-; CHECK-RV64-NEXT:    ppaire.h a0, a0, a2
-; CHECK-RV64-NEXT:    ret
 ; RV32-LABEL: test_psra_bs_vec_shamt:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    srli a2, a1, 24
@@ -1658,29 +1526,6 @@ define <4 x i8> @test_pmul_b(<4 x i8> %a, <4 x i8> %b) {
 
 ; Division and remainder tests
 define <2 x i16> @test_psdiv_h(<2 x i16> %a, <2 x i16> %b) {
-; CHECK-RV32-LABEL: test_psdiv_h:
-; CHECK-RV32:       # %bb.0:
-; CHECK-RV32-NEXT:    srai a2, a1, 16
-; CHECK-RV32-NEXT:    srai a3, a0, 16
-; CHECK-RV32-NEXT:    div a2, a3, a2
-; CHECK-RV32-NEXT:    sext.h a1, a1
-; CHECK-RV32-NEXT:    sext.h a0, a0
-; CHECK-RV32-NEXT:    div a0, a0, a1
-; CHECK-RV32-NEXT:    pack a0, a0, a2
-; CHECK-RV32-NEXT:    ret
-;
-; CHECK-RV64-LABEL: test_psdiv_h:
-; CHECK-RV64:       # %bb.0:
-; CHECK-RV64-NEXT:    sext.h a2, a1
-; CHECK-RV64-NEXT:    sext.h a3, a0
-; CHECK-RV64-NEXT:    divw a2, a3, a2
-; CHECK-RV64-NEXT:    srli a1, a1, 16
-; CHECK-RV64-NEXT:    srli a0, a0, 16
-; CHECK-RV64-NEXT:    sext.h a1, a1
-; CHECK-RV64-NEXT:    sext.h a0, a0
-; CHECK-RV64-NEXT:    divw a0, a0, a1
-; CHECK-RV64-NEXT:    ppaire.h a0, a2, a0
-; CHECK-RV64-NEXT:    ret
 ; RV32-LABEL: test_psdiv_h:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    srai a2, a1, 16
@@ -1724,52 +1569,6 @@ define <2 x i16> @test_psdiv_mulhsu_h(<2 x i16> %a) {
 }
 
 define <4 x i8> @test_psdiv_b(<4 x i8> %a, <4 x i8> %b) {
-; CHECK-RV32-LABEL: test_psdiv_b:
-; CHECK-RV32:       # %bb.0:
-; CHECK-RV32-NEXT:    srai a2, a1, 24
-; CHECK-RV32-NEXT:    srai a3, a0, 24
-; CHECK-RV32-NEXT:    div a3, a3, a2
-; CHECK-RV32-NEXT:    srli a2, a1, 8
-; CHECK-RV32-NEXT:    srli a4, a0, 8
-; CHECK-RV32-NEXT:    sext.b a2, a2
-; CHECK-RV32-NEXT:    sext.b a4, a4
-; CHECK-RV32-NEXT:    div a2, a4, a2
-; CHECK-RV32-NEXT:    sext.b a4, a1
-; CHECK-RV32-NEXT:    sext.b a5, a0
-; CHECK-RV32-NEXT:    div a4, a5, a4
-; CHECK-RV32-NEXT:    srli a1, a1, 16
-; CHECK-RV32-NEXT:    srli a0, a0, 16
-; CHECK-RV32-NEXT:    sext.b a1, a1
-; CHECK-RV32-NEXT:    sext.b a0, a0
-; CHECK-RV32-NEXT:    div a5, a0, a1
-; CHECK-RV32-NEXT:    ppaire.db a0, a4, a2
-; CHECK-RV32-NEXT:    pack a0, a0, a1
-; CHECK-RV32-NEXT:    ret
-;
-; CHECK-RV64-LABEL: test_psdiv_b:
-; CHECK-RV64:       # %bb.0:
-; CHECK-RV64-NEXT:    srli a2, a1, 24
-; CHECK-RV64-NEXT:    srli a3, a0, 24
-; CHECK-RV64-NEXT:    sext.b a2, a2
-; CHECK-RV64-NEXT:    sext.b a3, a3
-; CHECK-RV64-NEXT:    divw a2, a3, a2
-; CHECK-RV64-NEXT:    srli a3, a1, 16
-; CHECK-RV64-NEXT:    srli a4, a0, 16
-; CHECK-RV64-NEXT:    sext.b a3, a3
-; CHECK-RV64-NEXT:    sext.b a4, a4
-; CHECK-RV64-NEXT:    divw a3, a4, a3
-; CHECK-RV64-NEXT:    sext.b a4, a1
-; CHECK-RV64-NEXT:    sext.b a5, a0
-; CHECK-RV64-NEXT:    divw a4, a5, a4
-; CHECK-RV64-NEXT:    srli a1, a1, 8
-; CHECK-RV64-NEXT:    srli a0, a0, 8
-; CHECK-RV64-NEXT:    sext.b a1, a1
-; CHECK-RV64-NEXT:    sext.b a0, a0
-; CHECK-RV64-NEXT:    divw a0, a0, a1
-; CHECK-RV64-NEXT:    ppaire.b a1, a3, a2
-; CHECK-RV64-NEXT:    ppaire.b a0, a4, a0
-; CHECK-RV64-NEXT:    ppaire.h a0, a0, a1
-; CHECK-RV64-NEXT:    ret
 ; RV32-LABEL: test_psdiv_b:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    srai a2, a1, 24
@@ -1821,27 +1620,6 @@ define <4 x i8> @test_psdiv_b(<4 x i8> %a, <4 x i8> %b) {
 }
 
 define <2 x i16> @test_pudiv_h(<2 x i16> %a, <2 x i16> %b) {
-; CHECK-RV32-LABEL: test_pudiv_h:
-; CHECK-RV32:       # %bb.0:
-; CHECK-RV32-NEXT:    srli a2, a1, 16
-; CHECK-RV32-NEXT:    srli a3, a0, 16
-; CHECK-RV32-NEXT:    divu a2, a3, a2
-; CHECK-RV32-NEXT:    zext.h a1, a1
-; CHECK-RV32-NEXT:    zext.h a0, a0
-; CHECK-RV32-NEXT:    divu a0, a0, a1
-; CHECK-RV32-NEXT:    pack a0, a0, a2
-; CHECK-RV32-NEXT:    ret
-;
-; CHECK-RV64-LABEL: test_pudiv_h:
-; CHECK-RV64:       # %bb.0:
-; CHECK-RV64-NEXT:    srliw a2, a1, 16
-; CHECK-RV64-NEXT:    srliw a3, a0, 16
-; CHECK-RV64-NEXT:    divuw a2, a3, a2
-; CHECK-RV64-NEXT:    zext.h a1, a1
-; CHECK-RV64-NEXT:    zext.h a0, a0
-; CHECK-RV64-NEXT:    divuw a0, a0, a1
-; CHECK-RV64-NEXT:    ppaire.h a0, a0, a2
-; CHECK-RV64-NEXT:    ret
 ; RV32-LABEL: test_pudiv_h:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    srli a2, a1, 16
@@ -1893,50 +1671,6 @@ define <4 x i8> @test_psdiv_mulhsu_b(<4 x i8> %a) {
 }
 
 define <4 x i8> @test_pudiv_b(<4 x i8> %a, <4 x i8> %b) {
-; CHECK-RV32-LABEL: test_pudiv_b:
-; CHECK-RV32:       # %bb.0:
-; CHECK-RV32-NEXT:    srli a2, a1, 24
-; CHECK-RV32-NEXT:    srli a3, a0, 24
-; CHECK-RV32-NEXT:    divu a3, a3, a2
-; CHECK-RV32-NEXT:    slli a2, a1, 16
-; CHECK-RV32-NEXT:    slli a4, a0, 16
-; CHECK-RV32-NEXT:    srli a2, a2, 24
-; CHECK-RV32-NEXT:    srli a4, a4, 24
-; CHECK-RV32-NEXT:    divu a2, a4, a2
-; CHECK-RV32-NEXT:    zext.b a4, a1
-; CHECK-RV32-NEXT:    zext.b a5, a0
-; CHECK-RV32-NEXT:    divu a4, a5, a4
-; CHECK-RV32-NEXT:    slli a1, a1, 8
-; CHECK-RV32-NEXT:    slli a0, a0, 8
-; CHECK-RV32-NEXT:    srli a1, a1, 24
-; CHECK-RV32-NEXT:    srli a0, a0, 24
-; CHECK-RV32-NEXT:    divu a5, a0, a1
-; CHECK-RV32-NEXT:    ppaire.db a0, a4, a2
-; CHECK-RV32-NEXT:    pack a0, a0, a1
-; CHECK-RV32-NEXT:    ret
-;
-; CHECK-RV64-LABEL: test_pudiv_b:
-; CHECK-RV64:       # %bb.0:
-; CHECK-RV64-NEXT:    srliw a2, a1, 24
-; CHECK-RV64-NEXT:    srliw a3, a0, 24
-; CHECK-RV64-NEXT:    divuw a2, a3, a2
-; CHECK-RV64-NEXT:    slli a3, a1, 40
-; CHECK-RV64-NEXT:    slli a4, a0, 40
-; CHECK-RV64-NEXT:    srli a3, a3, 56
-; CHECK-RV64-NEXT:    srli a4, a4, 56
-; CHECK-RV64-NEXT:    divuw a3, a4, a3
-; CHECK-RV64-NEXT:    zext.b a4, a1
-; CHECK-RV64-NEXT:    zext.b a5, a0
-; CHECK-RV64-NEXT:    divuw a4, a5, a4
-; CHECK-RV64-NEXT:    slli a1, a1, 48
-; CHECK-RV64-NEXT:    slli a0, a0, 48
-; CHECK-RV64-NEXT:    srli a1, a1, 56
-; CHECK-RV64-NEXT:    srli a0, a0, 56
-; CHECK-RV64-NEXT:    divuw a0, a0, a1
-; CHECK-RV64-NEXT:    ppaire.b a1, a3, a2
-; CHECK-RV64-NEXT:    ppaire.b a0, a4, a0
-; CHECK-RV64-NEXT:    ppaire.h a0, a0, a1
-; CHECK-RV64-NEXT:    ret
 ; RV32-LABEL: test_pudiv_b:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    srli a2, a1, 24
@@ -1986,29 +1720,6 @@ define <4 x i8> @test_pudiv_b(<4 x i8> %a, <4 x i8> %b) {
 }
 
 define <2 x i16> @test_psrem_h(<2 x i16> %a, <2 x i16> %b) {
-; CHECK-RV32-LABEL: test_psrem_h:
-; CHECK-RV32:       # %bb.0:
-; CHECK-RV32-NEXT:    srai a2, a1, 16
-; CHECK-RV32-NEXT:    srai a3, a0, 16
-; CHECK-RV32-NEXT:    rem a2, a3, a2
-; CHECK-RV32-NEXT:    sext.h a1, a1
-; CHECK-RV32-NEXT:    sext.h a0, a0
-; CHECK-RV32-NEXT:    rem a0, a0, a1
-; CHECK-RV32-NEXT:    pack a0, a0, a2
-; CHECK-RV32-NEXT:    ret
-;
-; CHECK-RV64-LABEL: test_psrem_h:
-; CHECK-RV64:       # %bb.0:
-; CHECK-RV64-NEXT:    sext.h a2, a1
-; CHECK-RV64-NEXT:    sext.h a3, a0
-; CHECK-RV64-NEXT:    remw a2, a3, a2
-; CHECK-RV64-NEXT:    srli a1, a1, 16
-; CHECK-RV64-NEXT:    srli a0, a0, 16
-; CHECK-RV64-NEXT:    sext.h a1, a1
-; CHECK-RV64-NEXT:    sext.h a0, a0
-; CHECK-RV64-NEXT:    remw a0, a0, a1
-; CHECK-RV64-NEXT:    ppaire.h a0, a2, a0
-; CHECK-RV64-NEXT:    ret
 ; RV32-LABEL: test_psrem_h:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    srai a2, a1, 16
@@ -2037,52 +1748,6 @@ define <2 x i16> @test_psrem_h(<2 x i16> %a, <2 x i16> %b) {
 }
 
 define <4 x i8> @test_psrem_b(<4 x i8> %a, <4 x i8> %b) {
-; CHECK-RV32-LABEL: test_psrem_b:
-; CHECK-RV32:       # %bb.0:
-; CHECK-RV32-NEXT:    srai a2, a1, 24
-; CHECK-RV32-NEXT:    srai a3, a0, 24
-; CHECK-RV32-NEXT:    rem a3, a3, a2
-; CHECK-RV32-NEXT:    srli a2, a1, 8
-; CHECK-RV32-NEXT:    srli a4, a0, 8
-; CHECK-RV32-NEXT:    sext.b a2, a2
-; CHECK-RV32-NEXT:    sext.b a4, a4
-; CHECK-RV32-NEXT:    rem a2, a4, a2
-; CHECK-RV32-NEXT:    sext.b a4, a1
-; CHECK-RV32-NEXT:    sext.b a5, a0
-; CHECK-RV32-NEXT:    rem a4, a5, a4
-; CHECK-RV32-NEXT:    srli a1, a1, 16
-; CHECK-RV32-NEXT:    srli a0, a0, 16
-; CHECK-RV32-NEXT:    sext.b a1, a1
-; CHECK-RV32-NEXT:    sext.b a0, a0
-; CHECK-RV32-NEXT:    rem a5, a0, a1
-; CHECK-RV32-NEXT:    ppaire.db a0, a4, a2
-; CHECK-RV32-NEXT:    pack a0, a0, a1
-; CHECK-RV32-NEXT:    ret
-;
-; CHECK-RV64-LABEL: test_psrem_b:
-; CHECK-RV64:       # %bb.0:
-; CHECK-RV64-NEXT:    srli a2, a1, 24
-; CHECK-RV64-NEXT:    srli a3, a0, 24
-; CHECK-RV64-NEXT:    sext.b a2, a2
-; CHECK-RV64-NEXT:    sext.b a3, a3
-; CHECK-RV64-NEXT:    remw a2, a3, a2
-; CHECK-RV64-NEXT:    srli a3, a1, 16
-; CHECK-RV64-NEXT:    srli a4, a0, 16
-; CHECK-RV64-NEXT:    sext.b a3, a3
-; CHECK-RV64-NEXT:    sext.b a4, a4
-; CHECK-RV64-NEXT:    remw a3, a4, a3
-; CHECK-RV64-NEXT:    sext.b a4, a1
-; CHECK-RV64-NEXT:    sext.b a5, a0
-; CHECK-RV64-NEXT:    remw a4, a5, a4
-; CHECK-RV64-NEXT:    srli a1, a1, 8
-; CHECK-RV64-NEXT:    srli a0, a0, 8
-; CHECK-RV64-NEXT:    sext.b a1, a1
-; CHECK-RV64-NEXT:    sext.b a0, a0
-; CHECK-RV64-NEXT:    remw a0, a0, a1
-; CHECK-RV64-NEXT:    ppaire.b a1, a3, a2
-; CHECK-RV64-NEXT:    ppaire.b a0, a4, a0
-; CHECK-RV64-NEXT:    ppaire.h a0, a0, a1
-; CHECK-RV64-NEXT:    ret
 ; RV32-LABEL: test_psrem_b:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    srai a2, a1, 24
@@ -2134,27 +1799,6 @@ define <4 x i8> @test_psrem_b(<4 x i8> %a, <4 x i8> %b) {
 }
 
 define <2 x i16> @test_purem_h(<2 x i16> %a, <2 x i16> %b) {
-; CHECK-RV32-LABEL: test_purem_h:
-; CHECK-RV32:       # %bb.0:
-; CHECK-RV32-NEXT:    srli a2, a1, 16
-; CHECK-RV32-NEXT:    srli a3, a0, 16
-; CHECK-RV32-NEXT:    remu a2, a3, a2
-; CHECK-RV32-NEXT:    zext.h a1, a1
-; CHECK-RV32-NEXT:    zext.h a0, a0
-; CHECK-RV32-NEXT:    remu a0, a0, a1
-; CHECK-RV32-NEXT:    pack a0, a0, a2
-; CHECK-RV32-NEXT:    ret
-;
-; CHECK-RV64-LABEL: test_purem_h:
-; CHECK-RV64:       # %bb.0:
-; CHECK-RV64-NEXT:    srliw a2, a1, 16
-; CHECK-RV64-NEXT:    srliw a3, a0, 16
-; CHECK-RV64-NEXT:    remuw a2, a3, a2
-; CHECK-RV64-NEXT:    zext.h a1, a1
-; CHECK-RV64-NEXT:    zext.h a0, a0
-; CHECK-RV64-NEXT:    remuw a0, a0, a1
-; CHECK-RV64-NEXT:    ppaire.h a0, a0, a2
-; CHECK-RV64-NEXT:    ret
 ; RV32-LABEL: test_purem_h:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    srli a2, a1, 16
@@ -2181,50 +1825,6 @@ define <2 x i16> @test_purem_h(<2 x i16> %a, <2 x i16> %b) {
 }
 
 define <4 x i8> @test_purem_b(<4 x i8> %a, <4 x i8> %b) {
-; CHECK-RV32-LABEL: test_purem_b:
-; CHECK-RV32:       # %bb.0:
-; CHECK-RV32-NEXT:    srli a2, a1, 24
-; CHECK-RV32-NEXT:    srli a3, a0, 24
-; CHECK-RV32-NEXT:    remu a3, a3, a2
-; CHECK-RV32-NEXT:    slli a2, a1, 16
-; CHECK-RV32-NEXT:    slli a4, a0, 16
-; CHECK-RV32-NEXT:    srli a2, a2, 24
-; CHECK-RV32-NEXT:    srli a4, a4, 24
-; CHECK-RV32-NEXT:    remu a2, a4, a2
-; CHECK-RV32-NEXT:    zext.b a4, a1
-; CHECK-RV32-NEXT:    zext.b a5, a0
-; CHECK-RV32-NEXT:    remu a4, a5, a4
-; CHECK-RV32-NEXT:    slli a1, a1, 8
-; CHECK-RV32-NEXT:    slli a0, a0, 8
-; CHECK-RV32-NEXT:    srli a1, a1, 24
-; CHECK-RV32-NEXT:    srli a0, a0, 24
-; CHECK-RV32-NEXT:    remu a5, a0, a1
-; CHECK-RV32-NEXT:    ppaire.db a0, a4, a2
-; CHECK-RV32-NEXT:    pack a0, a0, a1
-; CHECK-RV32-NEXT:    ret
-;
-; CHECK-RV64-LABEL: test_purem_b:
-; CHECK-RV64:       # %bb.0:
-; CHECK-RV64-NEXT:    srliw a2, a1, 24
-; CHECK-RV64-NEXT:    srliw a3, a0, 24
-; CHECK-RV64-NEXT:    remuw a2, a3, a2
-; CHECK-RV64-NEXT:    slli a3, a1, 40
-; CHECK-RV64-NEXT:    slli a4, a0, 40
-; CHECK-RV64-NEXT:    srli a3, a3, 56
-; CHECK-RV64-NEXT:    srli a4, a4, 56
-; CHECK-RV64-NEXT:    remuw a3, a4, a3
-; CHECK-RV64-NEXT:    zext.b a4, a1
-; CHECK-RV64-NEXT:    zext.b a5, a0
-; CHECK-RV64-NEXT:    remuw a4, a5, a4
-; CHECK-RV64-NEXT:    slli a1, a1, 48
-; CHECK-RV64-NEXT:    slli a0, a0, 48
-; CHECK-RV64-NEXT:    srli a1, a1, 56
-; CHECK-RV64-NEXT:    srli a0, a0, 56
-; CHECK-RV64-NEXT:    remuw a0, a0, a1
-; CHECK-RV64-NEXT:    ppaire.b a1, a3, a2
-; CHECK-RV64-NEXT:    ppaire.b a0, a4, a0
-; CHECK-RV64-NEXT:    ppaire.h a0, a0, a1
-; CHECK-RV64-NEXT:    ret
 ; RV32-LABEL: test_purem_b:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    srli a2, a1, 24

--- a/llvm/test/CodeGen/RISCV/rvp-simd-32.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-simd-32.ll
@@ -961,7 +961,6 @@ define <4 x i8> @test_psll_bs_mask(<4 x i8> %a, i8 %shamt) {
 
 ; Test logical shift left(vector shamt)
 define <2 x i16> @test_psll_hs_vec_shamt(<2 x i16> %a, <2 x i16> %b) {
-;
 ; RV32-LABEL: test_psll_hs_vec_shamt:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    srli a2, a1, 16

--- a/llvm/test/CodeGen/RISCV/rvp-simd-32.ll
+++ b/llvm/test/CodeGen/RISCV/rvp-simd-32.ll
@@ -983,7 +983,6 @@ define <2 x i16> @test_psll_hs_vec_shamt(<2 x i16> %a, <2 x i16> %b) {
 }
 
 define <4 x i8> @test_psll_bs_vec_shamt(<4 x i8> %a, <4 x i8> %b) {
-;
 ; RV32-LABEL: test_psll_bs_vec_shamt:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    srli a2, a1, 24
@@ -1140,7 +1139,6 @@ define <2 x i16> @test_psrl_hs_vec_shamt(<2 x i16> %a, <2 x i16> %b) {
 }
 
 define <4 x i8> @test_psrl_bs_vec_shamt(<4 x i8> %a, <4 x i8> %b) {
-;
 ; RV32-LABEL: test_psrl_bs_vec_shamt:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    srli a2, a1, 24
@@ -1210,7 +1208,6 @@ define <2 x i16> @test_psra_hs_vec_shamt(<2 x i16> %a, <2 x i16> %b) {
 }
 
 define <4 x i8> @test_psra_bs_vec_shamt(<4 x i8> %a, <4 x i8> %b) {
-;
 ; RV32-LABEL: test_psra_bs_vec_shamt:
 ; RV32:       # %bb.0:
 ; RV32-NEXT:    srli a2, a1, 24


### PR DESCRIPTION
They were probably introduced by merge conflicts + UTC script changes.