### PR TITLE
[flang][OpenMP][NFC] Hoist variant match-info construction into Semantics

### DIFF
--- a/flang/include/flang/Semantics/openmp-utils.h
+++ b/flang/include/flang/Semantics/openmp-utils.h
@@ -163,6 +163,46 @@ std::optional<bool> GetLogicalArgument(
 std::optional<bool> IsContiguous(
     SemanticsContext &semaCtx, const parser::OmpObject &object);
 
+/// Non-constant user condition expression and source for runtime lowering.
+struct DynamicUserCondition {
+  const parser::ScalarExpr *expr;
+  parser::CharBlock source;
+};
+
+/// A context-selector feature that variant matching accepts syntactically but
+/// cannot yet honour during selection. Callers are expected to diagnose these
+/// (a lowering \c TODO or a semantic error) before calling
+/// \c MakeVariantMatchInfo, which asserts none are present.
+enum class UnsupportedSelectorFeature {
+  None,
+  /// A `target_device={...}` selector set.
+  TargetDevice,
+  /// A clause property (e.g. \c simdlen(8) in \c construct={simd(simdlen(8))})
+  /// or an extension property (e.g. \c foo(bar) in
+  /// \c implementation={my_trait(foo(bar))}).
+  ClauseOrExtensionProperty,
+};
+
+/// Scan a parsed context selector for the first feature that variant matching
+/// cannot yet honour (see \c UnsupportedSelectorFeature). Pure detection: emits
+/// no diagnostics and has no side effects on any match info.
+UnsupportedSelectorFeature FindUnsupportedSelectorFeature(
+    const parser::traits::OmpContextSelectorSpecification &ctxSel,
+    SemanticsContext &semaCtx);
+
+/// Populate \p vmi from a parsed context selector. Score modifiers are
+/// honoured (including on `condition(...)` selectors). Constant user
+/// conditions are folded into user_condition_true/false traits; a non-constant
+/// user condition is recorded as user_condition_unknown and the first such
+/// expression is returned for the caller to lower as a runtime condition.
+///
+/// The caller must first reject unsupported selector features (see
+/// \c FindUnsupportedSelectorFeature); this function asserts none are present.
+std::optional<DynamicUserCondition> MakeVariantMatchInfo(
+    llvm::omp::VariantMatchInfo &vmi,
+    const parser::traits::OmpContextSelectorSpecification &ctxSel,
+    SemanticsContext &semaCtx);
+
 std::vector<SomeExpr> GetTopLevelDesignators(const SomeExpr &expr);
 const SomeExpr *HasStorageOverlap(
     const SomeExpr &base, llvm::ArrayRef<SomeExpr> exprs);

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -4763,18 +4763,18 @@ static void genOMP(lower::AbstractConverter &converter, lower::SymMap &symTable,
 
 namespace {
 struct MetadirectiveCandidate {
-  MetadirectiveCandidate(
-      const parser::OmpDirectiveSpecification *spec,
-      llvm::omp::VariantMatchInfo vmi, bool isExplicit,
-      std::optional<DynamicUserCondition> dynamicCond = std::nullopt,
-      bool conditionShouldBeTrue = true)
+  MetadirectiveCandidate(const parser::OmpDirectiveSpecification *spec,
+                         llvm::omp::VariantMatchInfo vmi, bool isExplicit,
+                         std::optional<semantics::omp::DynamicUserCondition>
+                             dynamicCond = std::nullopt,
+                         bool conditionShouldBeTrue = true)
       : spec(spec), vmi(vmi), isExplicit(isExplicit), dynamicCond(dynamicCond),
         conditionShouldBeTrue(conditionShouldBeTrue) {}
 
   const parser::OmpDirectiveSpecification *spec = nullptr;
   llvm::omp::VariantMatchInfo vmi;
   bool isExplicit = false;
-  std::optional<DynamicUserCondition> dynamicCond;
+  std::optional<semantics::omp::DynamicUserCondition> dynamicCond;
   bool conditionShouldBeTrue = true;
 };
 } // namespace
@@ -4832,9 +4832,25 @@ static void genMetadirective(lower::AbstractConverter &converter,
       const auto &ctxSel = getContextSelector(*whenClause);
       auto [spec, isExplicit] = getDirectiveVariant(*whenClause);
 
+      // METADIRECTIVE cannot yet honour some selector features that are
+      // otherwise accepted; reject them before building the match info.
+      switch (semantics::omp::FindUnsupportedSelectorFeature(ctxSel, semaCtx)) {
+      case semantics::omp::UnsupportedSelectorFeature::TargetDevice:
+        TODO(converter.genLocation(clause.source),
+             "target_device selector in METADIRECTIVE");
+        break;
+      case semantics::omp::UnsupportedSelectorFeature::
+          ClauseOrExtensionProperty:
+        TODO(converter.genLocation(clause.source),
+             "clause or extension trait matching in METADIRECTIVE");
+        break;
+      case semantics::omp::UnsupportedSelectorFeature::None:
+        break;
+      }
+
       llvm::omp::VariantMatchInfo rawVMI;
-      std::optional<DynamicUserCondition> dynamicCond = makeVariantMatchInfo(
-          rawVMI, ctxSel, semaCtx, converter.genLocation(clause.source));
+      std::optional<semantics::omp::DynamicUserCondition> dynamicCond =
+          semantics::omp::MakeVariantMatchInfo(rawVMI, ctxSel, semaCtx);
 
       if (dynamicCond) {
         constexpr llvm::omp::TraitProperty dynamicConditionTrait =

--- a/flang/lib/Lower/OpenMP/Utils.cpp
+++ b/flang/lib/Lower/OpenMP/Utils.cpp
@@ -70,6 +70,7 @@ llvm::cl::opt<bool> treatIndexAsSection(
 namespace Fortran {
 namespace lower {
 namespace omp {
+
 bool requiresImplicitDefaultDeclareMapper(
     const semantics::DerivedTypeSpec &typeSpec) {
   // ISO C interoperable types (e.g., c_ptr, c_funptr) must always have implicit
@@ -1284,117 +1285,6 @@ mlir::Value genIteratorCoordinate(Fortran::lower::AbstractConverter &converter,
                                   /*slice=*/mlir::Value{},
                                   /*indices=*/ivs,
                                   /*typeparams=*/mlir::ValueRange{});
-}
-
-/// Collect trait property names (vendor, kind, arch, isa, etc.) into a VMI.
-static void processTraitProperties(
-    llvm::omp::VariantMatchInfo &vmi, llvm::omp::TraitSet set,
-    llvm::omp::TraitSelector selector,
-    const std::optional<parser::OmpTraitSelector::Properties> &props,
-    llvm::APInt *scorePtr, mlir::Location loc) {
-  if (!props)
-    return;
-
-  for (const auto &prop :
-       std::get<std::list<parser::OmpTraitProperty>>(props->t)) {
-    const auto *name = std::get_if<parser::OmpTraitPropertyName>(&prop.u);
-    // Clause properties and extension properties (e.g. `simdlen(8)` in
-    // `construct={simd(simdlen(8))}`) and `foo(bar)` in
-    // `implementation={my_trait(foo(bar))}` are not matched yet.
-    if (!name)
-      TODO(loc, "clause or extension trait matching in METADIRECTIVE");
-  }
-  semantics::omp::ProcessTraitProperties(vmi, set, selector, props, scorePtr);
-}
-
-/// Process user={condition(...)} trait properties. Constant conditions are
-/// resolved to user_condition_true/false. Non-constant conditions are marked
-/// as user_condition_unknown and returned for later use in fir.if lowering.
-static std::optional<DynamicUserCondition> processUserConditionTrait(
-    llvm::omp::VariantMatchInfo &vmi,
-    const std::optional<parser::OmpTraitSelector::Properties> &props,
-    semantics::SemanticsContext &semaCtx, llvm::APInt *scorePtr) {
-  std::optional<DynamicUserCondition> dynamicCond;
-  if (!props)
-    return dynamicCond;
-
-  for (const auto &prop :
-       std::get<std::list<parser::OmpTraitProperty>>(props->t)) {
-    const auto *scalarExpr = std::get_if<parser::ScalarExpr>(&prop.u);
-    if (!scalarExpr)
-      continue;
-
-    if (auto constValue =
-            semantics::omp::EvaluateUserCondition(semaCtx, *scalarExpr)) {
-      vmi.addTrait(*constValue ? llvm::omp::TraitProperty::user_condition_true
-                               : llvm::omp::TraitProperty::user_condition_false,
-                   "<condition>", scorePtr);
-      continue;
-    }
-
-    dynamicCond = DynamicUserCondition{scalarExpr, prop.source};
-    vmi.addTrait(llvm::omp::TraitProperty::user_condition_unknown,
-                 "<condition>", scorePtr);
-  }
-
-  return dynamicCond;
-}
-
-/// Populate a VariantMatchInfo from context selector.
-/// For user conditions, attempts constant folding. Non-constant conditions
-/// are recorded as user_condition_unknown and returned for later use in
-/// fir.if lowering.
-std::optional<DynamicUserCondition>
-makeVariantMatchInfo(llvm::omp::VariantMatchInfo &vmi,
-                     const parser::modifier::OmpContextSelector &ctxSel,
-                     semantics::SemanticsContext &semaCtx, mlir::Location loc) {
-  std::optional<DynamicUserCondition> dynamicCond;
-
-  for (const auto &traitSet : ctxSel.v) {
-    using TSSName = parser::OmpTraitSetSelectorName;
-    auto setName = std::get<TSSName>(traitSet.t).v;
-    llvm::omp::TraitSet set = semantics::omp::MapTraitSet(setName);
-
-    for (const auto &trait :
-         std::get<std::list<parser::OmpTraitSelector>>(traitSet.t)) {
-      const auto &selectorName =
-          std::get<parser::OmpTraitSelectorName>(trait.t);
-      llvm::omp::TraitSelector selector =
-          semantics::omp::MapTraitSelector(selectorName, set);
-      const auto &props =
-          std::get<std::optional<parser::OmpTraitSelector::Properties>>(
-              trait.t);
-
-      // target_device selectors require runtime target device queries not yet
-      // supported.
-      if (set == llvm::omp::TraitSet::target_device)
-        TODO(loc, "target_device selector in METADIRECTIVE");
-
-      std::optional<llvm::APInt> score;
-      llvm::APInt *scorePtr =
-          semantics::omp::GetTraitScore(props, semaCtx, score);
-
-      if (selector == llvm::omp::TraitSelector::user_condition) {
-        if (std::optional<DynamicUserCondition> userCond =
-                processUserConditionTrait(vmi, props, semaCtx, scorePtr))
-          dynamicCond = userCond;
-        continue;
-      }
-
-      processTraitProperties(vmi, set, selector, props, scorePtr, loc);
-
-      if (props || set != llvm::omp::TraitSet::construct)
-        continue;
-
-      // Construct traits with no properties: the selector is the property.
-      llvm::omp::TraitProperty propKind =
-          llvm::omp::getOpenMPContextTraitPropertyForSelector(selector);
-      if (propKind != llvm::omp::TraitProperty::invalid)
-        vmi.addTrait(set, propKind, selectorName.ToString(), scorePtr);
-    }
-  }
-
-  return dynamicCond;
 }
 
 // ---------------------------------------------------------------------------

--- a/flang/lib/Lower/OpenMP/Utils.cpp
+++ b/flang/lib/Lower/OpenMP/Utils.cpp
@@ -70,7 +70,6 @@ llvm::cl::opt<bool> treatIndexAsSection(
 namespace Fortran {
 namespace lower {
 namespace omp {
-
 bool requiresImplicitDefaultDeclareMapper(
     const semantics::DerivedTypeSpec &typeSpec) {
   // ISO C interoperable types (e.g., c_ptr, c_funptr) must always have implicit

--- a/flang/lib/Lower/OpenMP/Utils.h
+++ b/flang/lib/Lower/OpenMP/Utils.h
@@ -258,26 +258,11 @@ std::optional<llvm::SmallVector<mlir::Value>> getIteratorElementIndices(
 
 /// Walk the already-emitted MLIR parent operations starting from \p op and
 /// collect the implied OpenMP construct traits in outermost-to-innermost
-/// order. Used by metadirective lowering to build the `ConstructTraits` of an
-/// `OMPContext`.
+/// order. Used by metadirective lowering and declare-variant call resolution
+/// to build the `ConstructTraits` of an `OMPContext`.
 void collectEnclosingConstructTraits(
     mlir::Operation *op,
     llvm::SmallVectorImpl<llvm::omp::TraitProperty> &constructTraits);
-
-/// Non-constant user condition expression and source for runtime lowering.
-struct DynamicUserCondition {
-  const parser::ScalarExpr *expr;
-  parser::CharBlock source;
-};
-
-/// Populate \p vmi from a parsed OpenMP context selector. Constant user
-/// conditions are folded into user_condition_true/false traits. A non-constant
-/// user condition is recorded as user_condition_unknown and returned for later
-/// lowering as a runtime condition.
-std::optional<DynamicUserCondition>
-makeVariantMatchInfo(llvm::omp::VariantMatchInfo &vmi,
-                     const parser::modifier::OmpContextSelector &ctxSel,
-                     semantics::SemanticsContext &semaCtx, mlir::Location loc);
 
 /// `OMPContext` flavour used by Flang's OpenMP variant matching. Adds an
 /// ISA-trait override based on the module's target-features attribute.

--- a/flang/lib/Semantics/openmp-utils.cpp
+++ b/flang/lib/Semantics/openmp-utils.cpp
@@ -2236,22 +2236,26 @@ UnsupportedSelectorFeature FindUnsupportedSelectorFeature(
   for (const parser::OmpTraitSetSelector &traitSet : ctxSel.v) {
     using TSSName = parser::OmpTraitSetSelectorName;
     auto setName{std::get<TSSName>(traitSet.t).v};
-    if (MapTraitSet(setName) == llvm::omp::TraitSet::target_device)
+    if (MapTraitSet(setName) == llvm::omp::TraitSet::target_device) {
       return UnsupportedSelectorFeature::TargetDevice;
+    }
 
     for (const parser::OmpTraitSelector &selector :
         std::get<std::list<parser::OmpTraitSelector>>(traitSet.t)) {
       const auto &props{
           std::get<std::optional<parser::OmpTraitSelector::Properties>>(
               selector.t)};
-      if (!props)
+      if (!props) {
         continue;
+      }
       for (const auto &prop :
-          std::get<std::list<parser::OmpTraitProperty>>(props->t))
+          std::get<std::list<parser::OmpTraitProperty>>(props->t)) {
         if (std::holds_alternative<common::Indirection<parser::OmpClause>>(
                 prop.u) ||
-            std::holds_alternative<parser::OmpTraitPropertyExtension>(prop.u))
+            std::holds_alternative<parser::OmpTraitPropertyExtension>(prop.u)) {
           return UnsupportedSelectorFeature::ClauseOrExtensionProperty;
+        }
+      }
     }
   }
   return UnsupportedSelectorFeature::None;
@@ -2274,13 +2278,15 @@ static void AddTraitPropertiesFromSelector(llvm::omp::TraitSet set,
   // first such expression is captured for later runtime lowering.
   llvm::omp::TraitSelector selectorKind{MapTraitSelector(traitName, set)};
   if (selectorKind == llvm::omp::TraitSelector::user_condition) {
-    if (!props)
+    if (!props) {
       return;
+    }
     for (const auto &prop :
         std::get<std::list<parser::OmpTraitProperty>>(props->t)) {
       const auto *scalarExpr{std::get_if<parser::ScalarExpr>(&prop.u)};
-      if (!scalarExpr)
+      if (!scalarExpr) {
         continue;
+      }
       if (auto constValue{EvaluateUserCondition(semaCtx, *scalarExpr)}) {
         vmi.addTrait(set,
             *constValue ? llvm::omp::TraitProperty::user_condition_true
@@ -2288,8 +2294,9 @@ static void AddTraitPropertiesFromSelector(llvm::omp::TraitSet set,
             "<condition>", scorePtr);
         continue;
       }
-      if (!dynamicCond)
+      if (!dynamicCond) {
         dynamicCond = DynamicUserCondition{scalarExpr, prop.source};
+      }
       vmi.addTrait(set, llvm::omp::TraitProperty::user_condition_unknown,
           "<condition>", scorePtr);
     }
@@ -2298,15 +2305,17 @@ static void AddTraitPropertiesFromSelector(llvm::omp::TraitSet set,
 
   ProcessTraitProperties(vmi, set, selectorKind, props, scorePtr);
 
-  if (props || set != llvm::omp::TraitSet::construct)
+  if (props || set != llvm::omp::TraitSet::construct) {
     return;
+  }
 
   // Construct trait selector with no properties (e.g. `construct={simd}`):
   // the selector itself implies the property.
   llvm::omp::TraitProperty propKind{
       llvm::omp::getOpenMPContextTraitPropertyForSelector(selectorKind)};
-  if (propKind != llvm::omp::TraitProperty::invalid)
+  if (propKind != llvm::omp::TraitProperty::invalid) {
     vmi.addTrait(set, propKind, traitName.ToString(), scorePtr);
+  }
 }
 
 std::optional<DynamicUserCondition> MakeVariantMatchInfo(
@@ -2322,8 +2331,9 @@ std::optional<DynamicUserCondition> MakeVariantMatchInfo(
     llvm::omp::TraitSet set{MapTraitSet(setName)};
 
     for (const parser::OmpTraitSelector &selector :
-        std::get<std::list<parser::OmpTraitSelector>>(traitSet.t))
+        std::get<std::list<parser::OmpTraitSelector>>(traitSet.t)) {
       AddTraitPropertiesFromSelector(set, selector, vmi, semaCtx, dynamicCond);
+    }
   }
   return dynamicCond;
 }

--- a/flang/lib/Semantics/openmp-utils.cpp
+++ b/flang/lib/Semantics/openmp-utils.cpp
@@ -2230,4 +2230,101 @@ void ProcessTraitProperties(llvm::omp::VariantMatchInfo &vmi,
   }
 }
 
+UnsupportedSelectorFeature FindUnsupportedSelectorFeature(
+    const parser::traits::OmpContextSelectorSpecification &ctxSel,
+    SemanticsContext &semaCtx) {
+  for (const parser::OmpTraitSetSelector &traitSet : ctxSel.v) {
+    using TSSName = parser::OmpTraitSetSelectorName;
+    auto setName{std::get<TSSName>(traitSet.t).v};
+    if (MapTraitSet(setName) == llvm::omp::TraitSet::target_device)
+      return UnsupportedSelectorFeature::TargetDevice;
+
+    for (const parser::OmpTraitSelector &selector :
+        std::get<std::list<parser::OmpTraitSelector>>(traitSet.t)) {
+      const auto &props{
+          std::get<std::optional<parser::OmpTraitSelector::Properties>>(
+              selector.t)};
+      if (!props)
+        continue;
+      for (const auto &prop :
+          std::get<std::list<parser::OmpTraitProperty>>(props->t))
+        if (std::holds_alternative<common::Indirection<parser::OmpClause>>(
+                prop.u) ||
+            std::holds_alternative<parser::OmpTraitPropertyExtension>(prop.u))
+          return UnsupportedSelectorFeature::ClauseOrExtensionProperty;
+    }
+  }
+  return UnsupportedSelectorFeature::None;
+}
+
+static void AddTraitPropertiesFromSelector(llvm::omp::TraitSet set,
+    const parser::OmpTraitSelector &selector, llvm::omp::VariantMatchInfo &vmi,
+    SemanticsContext &semaCtx,
+    std::optional<DynamicUserCondition> &dynamicCond) {
+  const auto &traitName{std::get<parser::OmpTraitSelectorName>(selector.t)};
+  const auto &props{
+      std::get<std::optional<parser::OmpTraitSelector::Properties>>(
+          selector.t)};
+
+  std::optional<llvm::APInt> scoreStorage;
+  llvm::APInt *scorePtr{GetTraitScore(props, semaCtx, scoreStorage)};
+
+  // user={condition(...)}: constant-fold to user_condition_true/false. A
+  // non-constant expression is recorded as user_condition_unknown and the
+  // first such expression is captured for later runtime lowering.
+  llvm::omp::TraitSelector selectorKind{MapTraitSelector(traitName, set)};
+  if (selectorKind == llvm::omp::TraitSelector::user_condition) {
+    if (!props)
+      return;
+    for (const auto &prop :
+        std::get<std::list<parser::OmpTraitProperty>>(props->t)) {
+      const auto *scalarExpr{std::get_if<parser::ScalarExpr>(&prop.u)};
+      if (!scalarExpr)
+        continue;
+      if (auto constValue{EvaluateUserCondition(semaCtx, *scalarExpr)}) {
+        vmi.addTrait(set,
+            *constValue ? llvm::omp::TraitProperty::user_condition_true
+                        : llvm::omp::TraitProperty::user_condition_false,
+            "<condition>", scorePtr);
+        continue;
+      }
+      if (!dynamicCond)
+        dynamicCond = DynamicUserCondition{scalarExpr, prop.source};
+      vmi.addTrait(set, llvm::omp::TraitProperty::user_condition_unknown,
+          "<condition>", scorePtr);
+    }
+    return;
+  }
+
+  ProcessTraitProperties(vmi, set, selectorKind, props, scorePtr);
+
+  if (props || set != llvm::omp::TraitSet::construct)
+    return;
+
+  // Construct trait selector with no properties (e.g. `construct={simd}`):
+  // the selector itself implies the property.
+  llvm::omp::TraitProperty propKind{
+      llvm::omp::getOpenMPContextTraitPropertyForSelector(selectorKind)};
+  if (propKind != llvm::omp::TraitProperty::invalid)
+    vmi.addTrait(set, propKind, traitName.ToString(), scorePtr);
+}
+
+std::optional<DynamicUserCondition> MakeVariantMatchInfo(
+    llvm::omp::VariantMatchInfo &vmi,
+    const parser::traits::OmpContextSelectorSpecification &ctxSel,
+    SemanticsContext &semaCtx) {
+  CHECK(FindUnsupportedSelectorFeature(ctxSel, semaCtx) ==
+      UnsupportedSelectorFeature::None);
+  std::optional<DynamicUserCondition> dynamicCond;
+  for (const parser::OmpTraitSetSelector &traitSet : ctxSel.v) {
+    using TSSName = parser::OmpTraitSetSelectorName;
+    auto setName{std::get<TSSName>(traitSet.t).v};
+    llvm::omp::TraitSet set{MapTraitSet(setName)};
+
+    for (const parser::OmpTraitSelector &selector :
+        std::get<std::list<parser::OmpTraitSelector>>(traitSet.t))
+      AddTraitPropertiesFromSelector(set, selector, vmi, semaCtx, dynamicCond);
+  }
+  return dynamicCond;
+}
 } // namespace Fortran::semantics::omp


### PR DESCRIPTION
Replace the lowering-only `makeVariantMatchInfo` helper with a single shared `semantics::omp::MakeVariantMatchInfo`. It builds the VariantMatchInfo from a parsed context selector and returns the optional non-constant user condition (as before). Update metadirective lowering to use it and drop the duplicated Lower/OpenMP copy.

Selector features that variant selection cannot yet honour (target_device selectors, and clause/extension trait properties) are not match-info concerns, so they are kept out of `MakeVariantMatchInfo`. Detection lives in a separate, pure helper `FindUnsupportedSelectorFeature`; the caller diagnoses the feature in its own terms (metadirective lowering emits a TODO) before building the match info. `MakeVariantMatchInfo` checks the precondition. NFC for metadirective.

Co-authored-by: Cursor