### PR TITLE
[InstCombine] Register manually created assumes in the AssumptionCache.

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -5962,6 +5962,10 @@ bool InstCombinerImpl::run() {
 
         Result->insertInto(InstParent, InsertPos);
 
+        // Register newly created assumptions.
+        if (auto *Assume = dyn_cast<AssumeInst>(Result))
+          AC.registerAssumption(Assume);
+
         // Push the new instruction and any users onto the worklist.
         Worklist.pushUsersToWorkList(*Result);
         Worklist.push(Result);

--- a/llvm/test/Transforms/InstCombine/assume-cache-update.ll
+++ b/llvm/test/Transforms/InstCombine/assume-cache-update.ll
@@ -5,7 +5,7 @@ declare void @llvm.assume(i1)
 ; CHECK: Cached assumptions for function: drop_dead_bundle
 ; CHECK-NEXT: i1 true
 ; CHECK: Cached assumptions for function: drop_dead_bundle
-; CHECK-NOT: i1 true
+; CHECK-NEXT: i1 true
 define i8 @drop_dead_bundle(ptr %p, ptr %q) {
   %v = load i8, ptr %p
   call void @llvm.assume(i1 true) [ "ignore"(ptr %q), "align"(ptr %p, i64 8) ]

--- a/llvm/test/Transforms/InstCombine/assume-cache-update.ll
+++ b/llvm/test/Transforms/InstCombine/assume-cache-update.ll
@@ -1,0 +1,13 @@
+; RUN: opt -passes='print<assumptions>,instcombine,print<assumptions>' -disable-output %s 2>&1 | FileCheck %s
+
+declare void @llvm.assume(i1)
+
+; CHECK: Cached assumptions for function: drop_dead_bundle
+; CHECK-NEXT: i1 true
+; CHECK: Cached assumptions for function: drop_dead_bundle
+; CHECK-NOT: i1 true
+define i8 @drop_dead_bundle(ptr %p, ptr %q) {
+  %v = load i8, ptr %p
+  call void @llvm.assume(i1 true) [ "ignore"(ptr %q), "align"(ptr %p, i64 8) ]
+  ret i8 %v
+}


### PR DESCRIPTION
Instructions inserted via Result->insertInto() bypassing the IRBuilder
inserter that would otherwise register new @llvm.assume calls in the
AssumptionCache.

Register the assume when inserting such a Result, mirroring what the
IRBuilder inserter does.