### PR TITLE
Revert `[NVPTX] Properly emit narrow ptrtoint in aggregate initializers. (#201217)`

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -1690,7 +1690,7 @@ void NVPTXAsmPrinter::bufferLEByte(const Constant *CPV, int Bytes,
       // ptrtoint, e.g. add(ptrtoint(@g), C). It can't fold to a ConstantInt
       // because it references a symbol; emit it through lowerConstantForGV, the
       // same path scalar symbol-relative integer globals use.
-      AggBuffer->addSymbol(Cexpr, Cexpr, AllocSize);
+      AggBuffer->addSymbol(Cexpr, Cexpr);
       AggBuffer->addZeros(AllocSize);
       break;
     }

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -1082,8 +1082,7 @@ void NVPTXAsmPrinter::printModuleLevelGV(const GlobalVariable *GVar,
           if (aggBuffer.numSymbols()) {
             const unsigned int ptrSize = MAI.getCodePointerSize();
             if (ElementSize % ptrSize ||
-                !aggBuffer.allSymbolsAligned(ptrSize) ||
-                !aggBuffer.allSymbolsFullPtrSize(ptrSize)) {
+                !aggBuffer.allSymbolsAligned(ptrSize)) {
               // Print in bytes and use the mask() operator for pointers.
               if (!STI.hasMaskOperator())
                 report_fatal_error(
@@ -1153,6 +1152,7 @@ void NVPTXAsmPrinter::AggBuffer::printSymbol(unsigned nSym, raw_ostream &os) {
 }
 
 void NVPTXAsmPrinter::AggBuffer::printBytes(raw_ostream &os) {
+  unsigned int ptrSize = AP.MAI.getCodePointerSize();
   // Do not emit trailing zero initializers. They will be zero-initialized by
   // ptxas. This saves on both space requirements for the generated PTX and on
   // memory use by ptxas. (See:
@@ -1181,18 +1181,13 @@ void NVPTXAsmPrinter::AggBuffer::printBytes(raw_ostream &os) {
     std::string symText;
     llvm::raw_string_ostream oss(symText);
     printSymbol(nSym, oss);
-    // A symbol occupies SymbolSizes[nSym] bytes, which is the pointer size for
-    // a plain pointer but may be narrower for a ptrtoint to a smaller integer.
-    // Emit only that many low bytes; the dropped high bytes are the part the
-    // truncation discards.
-    unsigned symSize = SymbolSizes[nSym];
-    for (unsigned i = 0; i < symSize; ++i) {
+    for (unsigned i = 0; i < ptrSize; ++i) {
       if (i)
         os << ", ";
       llvm::write_hex(os, 0xFFULL << i * 8, HexPrintStyle::PrefixUpper);
       os << "(" << symText << ")";
     }
-    pos += symSize;
+    pos += ptrSize;
     nextSymbolPos = symbolPosInBuffer[++nSym];
     assert(nextSymbolPos >= pos);
   }
@@ -1682,7 +1677,7 @@ void NVPTXAsmPrinter::bufferLEByte(const Constant *CPV, int Bytes,
       }
       if (Cexpr->getOpcode() == Instruction::PtrToInt) {
         Value *V = Cexpr->getOperand(0)->stripPointerCasts();
-        AggBuffer->addSymbol(V, Cexpr->getOperand(0), AllocSize);
+        AggBuffer->addSymbol(V, Cexpr->getOperand(0));
         AggBuffer->addZeros(AllocSize);
         break;
       }
@@ -1706,10 +1701,10 @@ void NVPTXAsmPrinter::bufferLEByte(const Constant *CPV, int Bytes,
 
   case Type::PointerTyID: {
     if (const GlobalValue *GVar = dyn_cast<GlobalValue>(CPV)) {
-      AggBuffer->addSymbol(GVar, GVar, AllocSize);
+      AggBuffer->addSymbol(GVar, GVar);
     } else if (const ConstantExpr *Cexpr = dyn_cast<ConstantExpr>(CPV)) {
       const Value *v = Cexpr->stripPointerCasts();
-      AggBuffer->addSymbol(v, Cexpr, AllocSize);
+      AggBuffer->addSymbol(v, Cexpr);
     }
     AggBuffer->addZeros(AllocSize);
     break;

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.h
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.h
@@ -88,21 +88,10 @@ class LLVM_LIBRARY_VISIBILITY NVPTXAsmPrinter : public AsmPrinter {
                           [=](unsigned pos) { return pos % ptrSize == 0; });
     }
 
-    // True when every symbol occupies a full pointer-sized slot. A narrower
-    // slot (e.g. ptrtoint to an integer smaller than the pointer) must use the
-    // per-byte mask() path, since the word path emits a whole pointer per
-    // symbol and would overrun the following field.
-    bool allSymbolsFullPtrSize(unsigned ptrSize) const {
-      return llvm::all_of(SymbolSizes,
-                          [=](unsigned size) { return size == ptrSize; });
-    }
-
   private:
     const unsigned Size;               // size of the buffer in bytes
     std::vector<unsigned char> buffer; // the buffer
     SmallVector<unsigned, 4> symbolPosInBuffer;
-    // SymbolSizes[i] is the number of bytes Symbols[i] occupies in 'buffer'.
-    SmallVector<unsigned, 4> SymbolSizes;
     SmallVector<const Value *, 4> Symbols;
     // SymbolsBeforeStripping[i] is the original form of Symbols[i] before
     // stripping pointer casts, i.e.,
@@ -147,12 +136,10 @@ class LLVM_LIBRARY_VISIBILITY NVPTXAsmPrinter : public AsmPrinter {
       }
     }
 
-    void addSymbol(const Value *GVar, const Value *GVarBeforeStripping,
-                   unsigned SymbolSize) {
+    void addSymbol(const Value *GVar, const Value *GVarBeforeStripping) {
       symbolPosInBuffer.push_back(curpos);
       Symbols.push_back(GVar);
       SymbolsBeforeStripping.push_back(GVarBeforeStripping);
-      SymbolSizes.push_back(SymbolSize);
     }
 
     void printBytes(raw_ostream &os);

--- a/llvm/test/CodeGen/NVPTX/packed-aggr.ll
+++ b/llvm/test/CodeGen/NVPTX/packed-aggr.ll
@@ -93,14 +93,3 @@ declare void @func()
 ; CHECK64-SAME: 0xFF(func), 0xFF00(func), 0xFF0000(func), 0xFF000000(func),
 ; CHECK64-SAME: 0xFF00000000(func), 0xFF0000000000(func), 0xFF000000000000(func), 0xFF00000000000000(func),
 ; CHECK64-SAME: 9, 0};
-
-;; Test that a ptrtoint to an integer narrower than a pointer emits only the
-;; symbol's low bytes via mask(), rather than a full pointer that would overrun
-;; and drop the following field. On a 32-bit target an i32 is already pointer-
-;; sized, so the aligned word path is used instead.
-
-@g = addrspace(1) global i32 0
-@s6 = addrspace(1) global { i32, i32 } { i32 ptrtoint (ptr addrspace(1) @g to i32), i32 305419896 }
-; CHECK32: .global .align 8 .u32 s6[2] = {g, 305419896};
-; CHECK64: .global .align 8 .u8 s6[8] = {
-; CHECK64-SAME: 0xFF(g), 0xFF00(g), 0xFF0000(g), 0xFF000000(g), 120, 86, 52, 18};


### PR DESCRIPTION
Revert c625725b06987f05e8742df291da082a964dab03 (#201217) along with build fix d84819d39e3103f92ad9b375cea7864280f3325c (#204380) due to test failures in global-ordering.ll mentioned here: https://github.com/llvm/llvm-project/pull/201217#issuecomment-4734212548