### PR TITLE
[clang-format] Fix short function merging with macro expansion

### DIFF
--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -975,28 +975,54 @@ private:
           return 0;
         }
 
-        // Check that we still have three lines and they fit into the limit.
+        // We need at least three lines to merge: { / body / }.
         if (I + 2 == E || I[2]->Type == LT_Invalid)
           return 0;
-        Limit = limitConsideringMacros(I + 2, E, Limit);
 
-        if (!nextTwoLinesFitInto(I, Limit))
-          return 0;
-
-        // Second, check that the next line does not contain any braces - if it
-        // does, readability declines when putting it into a single line.
-        if (I[1]->Last->is(TT_LineComment))
-          return 0;
-        do {
-          if (Tok->isOneOf(tok::l_brace, tok::r_brace) &&
-              Tok->isNot(BK_BracedInit)) {
-            return 0;
+        // When macro expansion produces additional unwrapped lines, scan
+        // forward past the expanded lines to find the closing `}`.
+        // For example, RETURN_IF_ERROR(x) expands to `if (x) return expr`;
+        // the parser creates separate unwrapped lines for the `if` and the
+        // `return`, so the function body has two lines instead of one.
+        unsigned NumBodyLines = 1;
+        if (I[1]->First->MacroCtx) {
+          while (I + NumBodyLines + 1 != E &&
+                 I[NumBodyLines + 1]->First->MacroCtx &&
+                 I[NumBodyLines + 1]->First->isNot(tok::r_brace)) {
+            ++NumBodyLines;
           }
-          Tok = Tok->Next;
-        } while (Tok);
+          // Ran off the end without finding a closing `}`.
+          if (I + NumBodyLines + 1 == E)
+            return 0;
+        }
 
-        // Last, check that the third line starts with a closing brace.
-        Tok = I[2]->First;
+        if (I[NumBodyLines + 1]->Type == LT_Invalid)
+          return 0;
+
+        // Check that all body lines plus the closing `}` fit.
+        Limit = limitConsideringMacros(I + NumBodyLines + 1, E, Limit);
+        // Range: opening line, NumBodyLines body lines, closing `}`.
+        if (!nextNLinesFitInto(I, I + NumBodyLines + 2, Limit))
+          return 0;
+
+        // Check that none of the body lines end with a line comment or
+        // contain braces; nesting braces on a single line hurts readability.
+        // (For macro-expanded lines this is unlikely since brace-delimited
+        // blocks become child unwrapped lines, but check anyway.)
+        for (unsigned J = 0; J < NumBodyLines; ++J) {
+          const AnnotatedLine *BodyLine = I[J + 1];
+          if (BodyLine->Last->is(TT_LineComment))
+            return 0;
+          for (const FormatToken *T = BodyLine->First; T; T = T->Next) {
+            if (T->isOneOf(tok::l_brace, tok::r_brace) &&
+                T->isNot(BK_BracedInit)) {
+              return 0;
+            }
+          }
+        }
+
+        // Check that the line after the body starts with a closing brace.
+        Tok = I[NumBodyLines + 1]->First;
         if (Tok->isNot(tok::r_brace))
           return 0;
 
@@ -1017,7 +1043,7 @@ private:
           return 0;
         }
 
-        return 2;
+        return NumBodyLines + 1;
       }
     } else if (I[1]->First->is(tok::l_brace)) {
       if (I[1]->Last->is(TT_LineComment))

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -15142,6 +15142,25 @@ TEST_F(FormatTest, PullTrivialFunctionDefinitionsIntoSingleLine) {
                      "}");
 }
 
+// Function bodies containing braces (other than braced init) should not merge,
+// because `void f() { if (x) { return y; } }` is hard to read on one line.
+TEST_F(FormatTest, BracesInBodyPreventMerging) {
+  FormatStyle Style = getLLVMStyle();
+  verifyFormat("void f() {\n"
+               "  if (x) {\n"
+               "    return y;\n"
+               "  }\n"
+               "}",
+               Style);
+}
+
+// Braced init lists are excluded from the brace check -- they should still
+// allow short function merging.
+TEST_F(FormatTest, BracedInitDoesNotPreventMerging) {
+  FormatStyle Style = getLLVMStyle();
+  verifyFormat("void f() { S s = {1}; }", Style);
+}
+
 TEST_F(FormatTest, PullEmptyFunctionDefinitionsIntoSingleLine) {
   FormatStyle MergeEmptyOnly = getLLVMStyle();
   MergeEmptyOnly.AllowShortFunctionsOnASingleLine =

--- a/clang/unittests/Format/FormatTestMacroExpansion.cpp
+++ b/clang/unittests/Format/FormatTestMacroExpansion.cpp
@@ -338,25 +338,6 @@ TEST_F(FormatTestMacroExpansion, LongBodyWithMacroDoesNotMerge) {
                Style);
 }
 
-// Function bodies containing braces (other than braced init) should not merge,
-// because `void f() { if (x) { return y; } }` is hard to read on one line.
-TEST_F(FormatTestMacroExpansion, BracesInBodyPreventMerging) {
-  FormatStyle Style = getLLVMStyle();
-  verifyFormat("void f() {\n"
-               "  if (x) {\n"
-               "    return y;\n"
-               "  }\n"
-               "}",
-               Style);
-}
-
-// Braced init lists are excluded from the brace check -- they should still
-// allow short function merging.
-TEST_F(FormatTestMacroExpansion, BracedInitDoesNotPreventMerging) {
-  FormatStyle Style = getLLVMStyle();
-  verifyFormat("void f() { S s = {1}; }", Style);
-}
-
 } // namespace
 } // namespace test
 } // namespace format

--- a/clang/unittests/Format/FormatTestMacroExpansion.cpp
+++ b/clang/unittests/Format/FormatTestMacroExpansion.cpp
@@ -308,29 +308,23 @@ TEST_F(FormatTestMacroExpansion, ShortFunctionMergingSimpleMacro) {
   verifyFormat("void f() { EXPR(x); }", Style);
 }
 
-// When the macro expansion contains control flow, short function merging
-// breaks: the opening brace stays on the function line, but the closing brace
-// gets its own line, producing the inconsistent `{ code\n}` layout.
-//
-// FIXME: The correct output is `void f() { IF_ERROR_RETURN(x); }`.
+// Short function merging works when the macro expansion contains control flow.
 TEST_F(FormatTestMacroExpansion, ShortFunctionMergingControlFlowMacro) {
   FormatStyle Style = getLLVMStyle();
   Style.Macros.push_back("IF_ERROR_RETURN(x)=if (x) return x");
-  verifyFormat("void f() { IF_ERROR_RETURN(x);\n}", Style);
+  verifyFormat("void f() { IF_ERROR_RETURN(x); }", Style);
 }
 
-// Same bug with a multi-statement macro containing control flow.
-//
-// FIXME: The correct output is:
-//   `void f() { ASSIGN_OR_RETURN(v, F(), R()); }`.
+// Short function merging works with multi-statement macros containing
+// control flow.
 TEST_F(FormatTestMacroExpansion, ShortFunctionMergingMultiStmtMacro) {
   FormatStyle Style = getLLVMStyle();
   Style.Macros.push_back("ASSIGN_OR_RETURN(a, b)=a = (b)");
   Style.Macros.push_back("ASSIGN_OR_RETURN(a, b, c)=a = (b); if (x) return c");
-  // 2-arg version has no control flow -- merges fine.
+  // 2-arg version has no control flow.
   verifyFormat("void f() { ASSIGN_OR_RETURN(v, F()); }", Style);
-  // 3-arg version has control flow -- broken.
-  verifyFormat("void f() { ASSIGN_OR_RETURN(v, F(), R());\n}", Style);
+  // 3-arg version has control flow.
+  verifyFormat("void f() { ASSIGN_OR_RETURN(v, F(), R()); }", Style);
 }
 
 // When the function body is too long to fit on one line, the macro should

--- a/clang/unittests/Format/FormatTestMacroExpansion.cpp
+++ b/clang/unittests/Format/FormatTestMacroExpansion.cpp
@@ -301,6 +301,68 @@ TEST_F(FormatTestMacroExpansion, IndentChildrenWithinMacroCall) {
                Style);
 }
 
+// Short function merging works when the macro expansion is a simple expression.
+TEST_F(FormatTestMacroExpansion, ShortFunctionMergingSimpleMacro) {
+  FormatStyle Style = getLLVMStyle();
+  Style.Macros.push_back("EXPR(x)=x");
+  verifyFormat("void f() { EXPR(x); }", Style);
+}
+
+// When the macro expansion contains control flow, short function merging
+// breaks: the opening brace stays on the function line, but the closing brace
+// gets its own line, producing the inconsistent `{ code\n}` layout.
+//
+// FIXME: The correct output is `void f() { IF_ERROR_RETURN(x); }`.
+TEST_F(FormatTestMacroExpansion, ShortFunctionMergingControlFlowMacro) {
+  FormatStyle Style = getLLVMStyle();
+  Style.Macros.push_back("IF_ERROR_RETURN(x)=if (x) return x");
+  verifyFormat("void f() { IF_ERROR_RETURN(x);\n}", Style);
+}
+
+// Same bug with a multi-statement macro containing control flow.
+//
+// FIXME: The correct output is:
+//   `void f() { ASSIGN_OR_RETURN(v, F(), R()); }`.
+TEST_F(FormatTestMacroExpansion, ShortFunctionMergingMultiStmtMacro) {
+  FormatStyle Style = getLLVMStyle();
+  Style.Macros.push_back("ASSIGN_OR_RETURN(a, b)=a = (b)");
+  Style.Macros.push_back("ASSIGN_OR_RETURN(a, b, c)=a = (b); if (x) return c");
+  // 2-arg version has no control flow -- merges fine.
+  verifyFormat("void f() { ASSIGN_OR_RETURN(v, F()); }", Style);
+  // 3-arg version has control flow -- broken.
+  verifyFormat("void f() { ASSIGN_OR_RETURN(v, F(), R());\n}", Style);
+}
+
+// When the function body is too long to fit on one line, the macro should
+// expand to a properly indented multi-line body (not the `{ code\n}` layout).
+TEST_F(FormatTestMacroExpansion, LongBodyWithMacroDoesNotMerge) {
+  FormatStyle Style = getLLVMStyleWithColumns(40);
+  Style.Macros.push_back("IF_ERROR_RETURN(x)=if (x) return x");
+  verifyFormat("void f() {\n"
+               "  IF_ERROR_RETURN(long_function());\n"
+               "}",
+               Style);
+}
+
+// Function bodies containing braces (other than braced init) should not merge,
+// because `void f() { if (x) { return y; } }` is hard to read on one line.
+TEST_F(FormatTestMacroExpansion, BracesInBodyPreventMerging) {
+  FormatStyle Style = getLLVMStyle();
+  verifyFormat("void f() {\n"
+               "  if (x) {\n"
+               "    return y;\n"
+               "  }\n"
+               "}",
+               Style);
+}
+
+// Braced init lists are excluded from the brace check -- they should still
+// allow short function merging.
+TEST_F(FormatTestMacroExpansion, BracedInitDoesNotPreventMerging) {
+  FormatStyle Style = getLLVMStyle();
+  verifyFormat("void f() { S s = {1}; }", Style);
+}
+
 } // namespace
 } // namespace test
 } // namespace format


### PR DESCRIPTION
When a configured macro expands to multiple unwrapped lines (e.g.,
RETURN_IF_ERROR(x) expands to `if (x) return x`, producing separate
lines for `if` and `return`), tryMergeSimpleBlock failed to merge the
function body because it expected exactly three lines: { / body / }.

Scan forward past macro-expanded body lines (identified by MacroCtx on
their first token) to find the closing `}`, then check that all lines
fit within the column limit. This produces `void f() { MACRO(); }`
instead of the broken `void f() { MACRO();\n}` layout.

Assisted-by: Gemini