### PR TITLE
[NVPTX] Don't force the mask() path for widening ptrtoint in aggregate initializers

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -1083,7 +1083,7 @@ void NVPTXAsmPrinter::printModuleLevelGV(const GlobalVariable *GVar,
             const unsigned int ptrSize = MAI.getCodePointerSize();
             if (ElementSize % ptrSize ||
                 !aggBuffer.allSymbolsAligned(ptrSize) ||
-                !aggBuffer.allSymbolsFullPtrSize(ptrSize)) {
+                !aggBuffer.allSymbolsAtLeastPtrSize(ptrSize)) {
               // Print in bytes and use the mask() operator for pointers.
               if (!STI.hasMaskOperator())
                 report_fatal_error(
@@ -1153,6 +1153,7 @@ void NVPTXAsmPrinter::AggBuffer::printSymbol(unsigned nSym, raw_ostream &os) {
 }
 
 void NVPTXAsmPrinter::AggBuffer::printBytes(raw_ostream &os) {
+  unsigned int ptrSize = AP.MAI.getCodePointerSize();
   // Do not emit trailing zero initializers. They will be zero-initialized by
   // ptxas. This saves on both space requirements for the generated PTX and on
   // memory use by ptxas. (See:
@@ -1184,8 +1185,10 @@ void NVPTXAsmPrinter::AggBuffer::printBytes(raw_ostream &os) {
     // A symbol occupies SymbolSizes[nSym] bytes, which is the pointer size for
     // a plain pointer but may be narrower for a ptrtoint to a smaller integer.
     // Emit only that many low bytes; the dropped high bytes are the part the
-    // truncation discards.
-    unsigned symSize = SymbolSizes[nSym];
+    // truncation discards. If the slot is wider than the pointer (a widening
+    // ptrtoint), emit ptrSize mask bytes; the remaining high bytes are
+    // zero-extension and are read from the buffer as ordinary zeros.
+    unsigned symSize = std::min(SymbolSizes[nSym], ptrSize);
     for (unsigned i = 0; i < symSize; ++i) {
       if (i)
         os << ", ";

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.h
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.h
@@ -88,13 +88,15 @@ class LLVM_LIBRARY_VISIBILITY NVPTXAsmPrinter : public AsmPrinter {
                           [=](unsigned pos) { return pos % ptrSize == 0; });
     }
 
-    // True when every symbol occupies a full pointer-sized slot. A narrower
-    // slot (e.g. ptrtoint to an integer smaller than the pointer) must use the
-    // per-byte mask() path, since the word path emits a whole pointer per
-    // symbol and would overrun the following field.
-    bool allSymbolsFullPtrSize(unsigned ptrSize) const {
+    // True when every symbol occupies at least a full pointer-sized slot. A
+    // narrower slot (e.g. ptrtoint to an integer smaller than the pointer) must
+    // use the per-byte mask() path, since the word path emits a whole pointer
+    // per symbol and would overrun the following field. A wider slot (ptrtoint
+    // to a larger integer) is fine on the word path: the symbol fills one word
+    // and the remaining zero-extension bytes come from the buffer.
+    bool allSymbolsAtLeastPtrSize(unsigned ptrSize) const {
       return llvm::all_of(SymbolSizes,
-                          [=](unsigned size) { return size == ptrSize; });
+                          [=](unsigned size) { return size >= ptrSize; });
     }
 
   private:

--- a/llvm/test/CodeGen/NVPTX/global-ordering.ll
+++ b/llvm/test/CodeGen/NVPTX/global-ordering.ll
@@ -26,5 +26,6 @@
 ; global.
 @g = addrspace(1) global i8 0
 
+; PTX32: .visible .global .align 8 .u32 sadd[4] = {(g&4294967295)+4, 0, 7, 0};
 ; PTX64: .visible .global .align 8 .u64 sadd[2] = {g+4, 7};
 @sadd = addrspace(1) global { i64, i64 } { i64 add (i64 ptrtoint (ptr addrspace(1) @g to i64), i64 4), i64 7 }

--- a/llvm/test/CodeGen/NVPTX/packed-aggr.ll
+++ b/llvm/test/CodeGen/NVPTX/packed-aggr.ll
@@ -104,3 +104,12 @@ declare void @func()
 ; CHECK32: .global .align 8 .u32 s6[2] = {g, 305419896};
 ; CHECK64: .global .align 8 .u8 s6[8] = {
 ; CHECK64-SAME: 0xFF(g), 0xFF00(g), 0xFF0000(g), 0xFF000000(g), 120, 86, 52, 18};
+
+;; Test that a ptrtoint to an integer wider than a pointer emits only ptrSize
+;; mask() bytes for the symbol; the remaining high bytes are zero-extension and
+;; come out as plain zeros. On a 64-bit target an i64 is already pointer-sized.
+
+@s7 = addrspace(1) global <{ i8, i64 }> <{ i8 1, i64 ptrtoint (ptr addrspace(1) @p to i64) }>, align 1
+; CHECK32: .global .align 1 .u8 s7[9] = {1, 0xFF(p), 0xFF00(p), 0xFF0000(p), 0xFF000000(p), 0, 0, 0, 0};
+; CHECK64: .global .align 1 .u8 s7[9] = {1, 0xFF(p), 0xFF00(p), 0xFF0000(p), 0xFF000000(p),
+; CHECK64-SAME: 0xFF00000000(p), 0xFF0000000000(p), 0xFF000000000000(p), 0xFF00000000000000(p)};


### PR DESCRIPTION
After #201217, global-ordering.ll crashes on the 32-bit nvptx triple with

    LLVM ERROR: initialized packed aggregate with pointers 'sadd' requires at least PTX ISA version 7.1

for

    @sadd = addrspace(1) global { i64, i64 }
              { i64 add (i64 ptrtoint (ptr addrspace(1) @g to i64), i64 4), i64 7 }

That PR added allSymbolsFullPtrSize, which forces the per-byte mask() path
whenever a symbol's slot size differs from the pointer size.  The intent was
to catch *narrowing* ptrtoint (an i32 slot on a 64-bit target), where emitting
a full pointer word would clobber the next field.  But here the ptrtoint is
*widening* -- an i64 slot on a 32-bit target -- and the word path already
handles that fine: it emits the symbol as one 32-bit word and the remaining
zero-extension bytes come from the buffer as 0 words.

Relax the check to >= so only narrower-than-pointer slots take the byte path.
Also clamp printBytes to emit at most ptrSize mask bytes per symbol, so a
widening ptrtoint that does end up on the byte path (e.g. at an unaligned
offset) emits the high bytes as plain 0 rather than nonsense 0xFF00000000(sym)
masks of a 32-bit value.

https://claude.ai/code/session_016Fxu3Bh9Mx48FA81ukVqMJ