### PR TITLE
[lldb][test] Don't export all symbols when building Wasm test inferiors

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/WASI.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/WASI.rules
@@ -9,6 +9,4 @@ ARCH_CXXFLAGS += \
 
 ARCH_LDFLAGS += \
 	$(if $(RESOURCE_DIR),-resource-dir $(RESOURCE_DIR)) \
-	-Wl,--export-all \
-	-Wl,--no-entry \
 	-Wl,--allow-undefined


### PR DESCRIPTION
WASI.rules linked test inferiors with -Wl,--export-all and the reactor-style -Wl,--no-entry. I cargo-culted them and neither flag is needed as our test inferiors all have a main and crt1 provided _start.

The --export-all flag was also harmful: for a no-argument main(), wasi-libc renames the user's main to __original_main and emits a small `main` trampoline. The --export-all flag caused that trampoline to an exported `main` symbol, so `break main` resolved to two locations.

Drop both flags but keep --allow-undefined for inferiors that reference runtime-provided symbols.