### PR TITLE
[lldb] Treat synthetic variables as locals

### DIFF
--- a/lldb/include/lldb/Interpreter/Interfaces/ScriptedFrameInterface.h
+++ b/lldb/include/lldb/Interpreter/Interfaces/ScriptedFrameInterface.h
@@ -53,6 +53,11 @@ public:
 
   virtual lldb::ValueObjectListSP GetVariables() { return nullptr; }
 
+  virtual std::optional<lldb::ValueType>
+  GetValueTypeForVariable(lldb::ValueObjectSP value) {
+    return std::nullopt;
+  }
+
   virtual lldb::ValueObjectSP
   GetValueObjectForVariableExpression(llvm::StringRef expr, uint32_t options,
                                       Status &error) {

--- a/lldb/include/lldb/Utility/ValueType.h
+++ b/lldb/include/lldb/Utility/ValueType.h
@@ -15,17 +15,17 @@ namespace lldb_private {
 /// Get the base value type - for when we don't care if the value is synthetic
 /// or not, or when we've already handled that case.
 constexpr lldb::ValueType GetBaseValueType(lldb::ValueType vt) {
-  return lldb::ValueType(vt & ~lldb::ValueTypeSyntheticMask);
+  return lldb::ValueType(vt & ~lldb::eValueTypeSyntheticFlag);
 }
 
 /// Given a base value type, return a version that carries the synthetic bit.
 constexpr lldb::ValueType GetSyntheticValueType(lldb::ValueType base) {
-  return lldb::ValueType(base | lldb::ValueTypeSyntheticMask);
+  return lldb::ValueType(base | lldb::eValueTypeSyntheticFlag);
 }
 
 /// Return true if vt represents a synthetic value, false if not.
 constexpr bool IsSyntheticValueType(lldb::ValueType vt) {
-  return vt & lldb::ValueTypeSyntheticMask;
+  return vt & lldb::eValueTypeSyntheticFlag;
 }
 } // namespace lldb_private
 

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -390,14 +390,16 @@ enum ValueType : uint32_t {
   /// function pointer in virtual function table
   eValueTypeVTableEntry = 10,
 
-  kLastValueType = eValueTypeVTableEntry
-};
+  kLastValueType = eValueTypeVTableEntry,
 
-/// A mask that we can use to check if the value type is synthetic or not.
-// NOTE: This limits the number of value types to 31, but that's 3x more than
-// what we currently have now. See lldb/Utility/ValueType.h for helpers for
-// working with synthetic value types.
-static constexpr unsigned ValueTypeSyntheticMask = 0x20;
+  /// A flag that indicates if the value type is synthetic or not.
+  // NOTE: This limits the number of value types to 31, but that's 3x more than
+  // what we currently have now. See lldb/Utility/ValueType.h for helpers for
+  // working with synthetic value types.
+  eValueTypeSyntheticFlag = 0x20,
+
+  kValueTypeFlagsMask = eValueTypeSyntheticFlag,
+};
 
 /// Token size/granularities for Input Readers.
 

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -389,6 +389,8 @@ enum ValueType : uint32_t {
   eValueTypeVTable = 9,
   /// function pointer in virtual function table
   eValueTypeVTableEntry = 10,
+
+  kLastValueType = eValueTypeVTableEntry
 };
 
 /// A mask that we can use to check if the value type is synthetic or not.

--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -568,6 +568,8 @@ protected:
       // modifiers above that should apply equally to synthetic and normal
       // variables, any other synthetic variable we should default to showing.
       return is_synthetic;
+    case eValueTypeSyntheticFlag:
+      llvm_unreachable("This flag was unset");
     }
     llvm_unreachable("Unexpected scope value");
   }

--- a/lldb/source/Plugins/Process/scripted/ScriptedFrame.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedFrame.cpp
@@ -307,10 +307,11 @@ void ScriptedFrame::PopulateVariableListFromInterface(
 
     VariableSP var = v->GetVariable();
     if (!var && include_synthetic_vars) {
-      // Construct the value type as an synthetic verison of what the value type
+      // Construct the value type as an synthetic version of what the value type
       // is. That'll allow the user to tell the scope and the 'synthetic-ness'
       // of the variable.
-      lldb::ValueType vt = GetSyntheticValueType(v->GetValueType());
+      // Any variable we create here will be treated as a local variable.
+      lldb::ValueType vt = GetSyntheticValueType(eValueTypeVariableLocal);
 
       // Just make up a variable - the frame variable dumper just passes it
       // back in to GetValueObjectForFrameVariable, so we really just need to

--- a/lldb/source/Plugins/Process/scripted/ScriptedFrame.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedFrame.cpp
@@ -307,17 +307,9 @@ void ScriptedFrame::PopulateVariableListFromInterface(
       continue;
 
     // Ask the interface about the value type of this variable. If it doesn't
-    // specify any, use the original value type. If we encounter a variable, use
-    // a non-synthetic type unless it's overwritten.
-    std::optional<lldb::ValueType> desired_vt =
-        GetInterface()->GetValueTypeForVariable(v);
-    lldb::ValueType vt = [&] {
-      if (desired_vt)
-        return GetSyntheticValueType(*desired_vt);
-      if (v->GetVariable())
-        return v->GetValueType();
-      return GetSyntheticValueType(v->GetValueType());
-    }();
+    // specify any, use the original value type.
+    lldb::ValueType vt = GetInterface()->GetValueTypeForVariable(v).value_or(
+        GetSyntheticValueType(v->GetValueType()));
 
     if (IsSyntheticValueType(vt) && !include_synthetic_vars)
       continue;

--- a/lldb/source/Plugins/Process/scripted/ScriptedFrame.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedFrame.cpp
@@ -300,35 +300,39 @@ void ScriptedFrame::PopulateVariableListFromInterface(
 
   // Convert what we can into a variable.
   m_variable_list_sp = std::make_shared<VariableList>();
+
   for (uint32_t i = 0, e = value_list_sp->GetSize(); i < e; ++i) {
     ValueObjectSP v = value_list_sp->GetValueObjectAtIndex(i);
     if (!v)
       continue;
 
-    VariableSP var = v->GetVariable();
-    if (!var && include_synthetic_vars) {
-      // Construct the value type as an synthetic version of what the value type
-      // is. That'll allow the user to tell the scope and the 'synthetic-ness'
-      // of the variable.
-      // Any variable we create here will be treated as a local variable.
-      lldb::ValueType vt = GetSyntheticValueType(eValueTypeVariableLocal);
+    // Ask the interface about the value type of this variable. If it doesn't
+    // specify any, use the original value type. If we encounter a variable, use
+    // a non-synthetic type unless it's overwritten.
+    std::optional<lldb::ValueType> desired_vt =
+        GetInterface()->GetValueTypeForVariable(v);
+    lldb::ValueType vt = [&] {
+      if (desired_vt)
+        return GetSyntheticValueType(*desired_vt);
+      if (v->GetVariable())
+        return v->GetValueType();
+      return GetSyntheticValueType(v->GetValueType());
+    }();
 
-      // Just make up a variable - the frame variable dumper just passes it
-      // back in to GetValueObjectForFrameVariable, so we really just need to
-      // make sure the name and type are correct. We create IDs based on
-      // value_list_sp in order to make sure they're unique.
-      var = std::make_shared<lldb_private::Variable>(
-          (lldb::user_id_t)value_list_sp->GetSize() + i,
-          v->GetName().GetCString(), v->GetName().GetCString(), nullptr, vt,
-          /*owner_scope=*/nullptr,
-          /*scope_range=*/Variable::RangeList{},
-          /*decl=*/nullptr, DWARFExpressionList{}, /*external=*/false,
-          /*artificial=*/true, /*location_is_constant_data=*/false);
-    }
+    if (IsSyntheticValueType(vt) && !include_synthetic_vars)
+      continue;
 
-    // Only append the variable if we have one (had already, or just created).
-    if (var)
-      m_variable_list_sp->AddVariable(var);
+    // Just make up a variable - the frame variable dumper just passes it
+    // back in to GetValueObjectForFrameVariable, so we really just need to
+    // make sure the name and type are correct. We create IDs based on
+    // value_list_sp in order to make sure they're unique.
+    m_variable_list_sp->AddVariable(std::make_shared<lldb_private::Variable>(
+        (lldb::user_id_t)value_list_sp->GetSize() + i,
+        v->GetName().GetCString(), v->GetName().GetCString(), nullptr, vt,
+        /*owner_scope=*/nullptr,
+        /*scope_range=*/Variable::RangeList{},
+        /*decl=*/nullptr, DWARFExpressionList{}, /*external=*/false,
+        /*artificial=*/true, /*location_is_constant_data=*/false));
   }
 }
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedFramePythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedFramePythonInterface.cpp
@@ -11,6 +11,7 @@
 #include "lldb/Host/Config.h"
 #include "lldb/Target/ExecutionContext.h"
 #include "lldb/Utility/Log.h"
+#include "lldb/ValueObject/ValueObject.h"
 #include "lldb/lldb-enumerations.h"
 
 #include "../SWIGPythonBridge.h"
@@ -161,6 +162,21 @@ lldb::ValueObjectListSP ScriptedFramePythonInterface::GetVariables() {
   }
 
   return vals;
+}
+
+std::optional<lldb::ValueType>
+ScriptedFramePythonInterface::GetValueTypeForVariable(
+    lldb::ValueObjectSP value) {
+  Status error;
+  auto val = Dispatch<std::optional<lldb::ValueType>>(
+      "get_value_type_for_variable", error, std::move(value));
+
+  if (error.Fail()) {
+    return ErrorWithMessage<std::optional<lldb::ValueType>>(
+        LLVM_PRETTY_FUNCTION, error.AsCString(), error);
+  }
+
+  return val;
 }
 
 lldb::ValueObjectSP

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedFramePythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedFramePythonInterface.h
@@ -51,6 +51,9 @@ public:
 
   lldb::ValueObjectListSP GetVariables() override;
 
+  std::optional<lldb::ValueType>
+  GetValueTypeForVariable(lldb::ValueObjectSP value) override;
+
   lldb::ValueObjectSP
   GetValueObjectForVariableExpression(llvm::StringRef expr, uint32_t options,
                                       Status &status) override;

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.cpp
@@ -335,9 +335,9 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<
     error = Status::FromError(val.takeError());
     return std::nullopt;
   }
-  if (*val > std::numeric_limits<std::underlying_type_t<ValueType>>::max()) {
-    error =
-        Status::FromErrorStringWithFormatv("value too large (got {0})", *val);
+  if (*val == eValueTypeInvalid || *val > kLastValueType) {
+    error = Status::FromErrorStringWithFormatv(
+        "value type invalid or too large (got {0})", *val);
     return std::nullopt;
   }
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.cpp
@@ -322,3 +322,24 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<lldb::ValueObjectListSP>(
 
   return out;
 }
+
+template <>
+std::optional<lldb::ValueType>
+ScriptedPythonInterface::ExtractValueFromPythonObject<
+    std::optional<lldb::ValueType>>(python::PythonObject &p, Status &error) {
+  if (p.IsNone())
+    return std::nullopt;
+
+  llvm::Expected<unsigned long long> val = p.AsUnsignedLongLong();
+  if (!val) {
+    error = Status::FromError(val.takeError());
+    return std::nullopt;
+  }
+  if (*val > std::numeric_limits<std::underlying_type_t<ValueType>>::max()) {
+    error =
+        Status::FromErrorStringWithFormatv("value too large (got {0})", *val);
+    return std::nullopt;
+  }
+
+  return static_cast<ValueType>(*val);
+}

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.cpp
@@ -335,11 +335,13 @@ ScriptedPythonInterface::ExtractValueFromPythonObject<
     error = Status::FromError(val.takeError());
     return std::nullopt;
   }
-  if (*val == eValueTypeInvalid || *val > kLastValueType) {
+  unsigned long long unmasked = *val & ~kValueTypeFlagsMask;
+  unsigned long long flags = *val & kValueTypeFlagsMask;
+  if (unmasked == eValueTypeInvalid || unmasked > kLastValueType) {
     error = Status::FromErrorStringWithFormatv(
-        "value type invalid or too large (got {0})", *val);
+        "value type invalid or too large (got {0} | {1:x})", unmasked, flags);
     return std::nullopt;
   }
 
-  return static_cast<ValueType>(*val);
+  return static_cast<ValueType>(unmasked | flags);
 }

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
@@ -836,6 +836,11 @@ lldb::ValueObjectListSP
 ScriptedPythonInterface::ExtractValueFromPythonObject<lldb::ValueObjectListSP>(
     python::PythonObject &p, Status &error);
 
+template <>
+std::optional<lldb::ValueType>
+ScriptedPythonInterface::ExtractValueFromPythonObject<
+    std::optional<lldb::ValueType>>(python::PythonObject &p, Status &error);
+
 } // namespace lldb_private
 
 #endif // LLDB_SOURCE_PLUGINS_SCRIPTINTERPRETER_PYTHON_INTERFACES_SCRIPTEDPYTHONINTERFACE_H

--- a/lldb/test/API/functionalities/scripted_frame_provider/TestScriptedFrameProvider.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/TestScriptedFrameProvider.py
@@ -824,24 +824,41 @@ class ScriptedFrameProviderTestCase(TestBase):
         options = lldb.SBVariablesOptions()
         options.SetIncludeSynthetic(True)
         variables = frame0.GetVariables(options)
+        self.assertFalse(variables.IsValid())
+        self.assertEqual(variables.GetSize(), 0)
+
+        options.SetIncludeLocals(True)
+        variables = frame0.GetVariables(options)
         self.assertTrue(variables.IsValid())
-        self.assertTrue(variables.GetValueAtIndex(0).name == "_handler_one")
+        self.assertEqual(variables.GetSize(), 2)
+        self.assertEqual(variables.GetValueAtIndex(0).name, "variable_in_main")
+        self.assertEqual(variables.GetValueAtIndex(1).name, "_handler_one")
 
         # Ensure that we get synthetic variables in the other overloads.
         # (arguments, locals, statics, in_scope_only)
         variables = frame0.GetVariables(False, False, False, False)
+        self.assertFalse(variables.IsValid())
+        self.assertEqual(variables.GetSize(), 0)
+        variables = frame0.GetVariables(False, True, False, False)
         self.assertTrue(variables.IsValid())
-        self.assertTrue(variables.GetValueAtIndex(0).name == "_handler_one")
+        self.assertEqual(variables.GetSize(), 2)
+        self.assertEqual(variables.GetValueAtIndex(0).name, "variable_in_main")
+        self.assertEqual(variables.GetValueAtIndex(1).name, "_handler_one")
 
         # (arguments, locals, statics, in_scope_only, use_dynamic)
         variables = frame0.GetVariables(
-            False, False, False, False, lldb.eNoDynamicValues
+            False, True, False, False, lldb.eNoDynamicValues
         )
         self.assertTrue(variables.IsValid())
-        self.assertTrue(variables.GetValueAtIndex(0).name == "_handler_one")
+        self.assertEqual(variables.GetSize(), 2)
+        self.assertEqual(variables.GetValueAtIndex(0).name, "variable_in_main")
+        self.assertEqual(variables.GetValueAtIndex(1).name, "_handler_one")
 
         # FIXME: Synthetic variables are never in scope.
         variables = frame0.GetVariables(False, False, False, True)
+        self.assertFalse(variables.IsValid())
+        self.assertEqual(variables.GetSize(), 0)
+        variables = frame0.GetVariables(False, True, False, True)
         self.assertFalse(variables.IsValid())
         self.assertEqual(variables.GetSize(), 0)
 

--- a/lldb/test/API/functionalities/scripted_frame_provider/test_frame_providers.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/test_frame_providers.py
@@ -554,11 +554,11 @@ class ValueProvidingFrame(ScriptedFrame):
     def get_register_context(self):
         """No register context."""
         return None
-    
+
     def get_value_type_for_variable(self, var):
         if var.GetName() == "_handler_one":
             return lldb.eValueTypeVariableLocal
-        return None # Inherit the value type for others.
+        return None  # Inherit the value type for others.
 
     def get_variables(self):
         """"""

--- a/lldb/test/API/functionalities/scripted_frame_provider/test_frame_providers.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/test_frame_providers.py
@@ -556,9 +556,12 @@ class ValueProvidingFrame(ScriptedFrame):
         return None
 
     def get_value_type_for_variable(self, var):
-        if var.GetName() == "_handler_one":
+        name = var.GetName()
+        if name == "_handler_one":
+            return lldb.eValueTypeVariableLocal | lldb.eValueTypeSyntheticFlag
+        if name == "variable_in_main":
             return lldb.eValueTypeVariableLocal
-        return None  # Inherit the value type for others.
+        return None
 
     def get_variables(self):
         """"""

--- a/lldb/test/API/functionalities/scripted_frame_provider/test_frame_providers.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/test_frame_providers.py
@@ -554,6 +554,11 @@ class ValueProvidingFrame(ScriptedFrame):
     def get_register_context(self):
         """No register context."""
         return None
+    
+    def get_value_type_for_variable(self, var):
+        if var.GetName() == "_handler_one":
+            return lldb.eValueTypeVariableLocal
+        return None # Inherit the value type for others.
 
     def get_variables(self):
         """"""


### PR DESCRIPTION
From the discussion in #204177: Synthetic variables were, if they weren't variables already, created with their original type plus a flag that they're synthetic (`ValueTypeSyntheticMask`). This could lead to unexpected results. For example, when a synthetic frame would return a value derived from a global variable in `GetVariables`, the created variable would be treated as a synthetic global variable. 

With this PR, synthetic frames can overwrite the value type of the variables they return.