### PR TITLE
[libc++] Restore release note dropped during rebase of #196495

### DIFF
--- a/libcxx/docs/ReleaseNotes/23.rst
+++ b/libcxx/docs/ReleaseNotes/23.rst
@@ -61,6 +61,7 @@ Improvements and New Features
   for ``std::deque<int>`` iterators.
 - ``std::copy(CharT*, CharT*, ostreambuf_iterator<CharT>)`` has been optimized, resulting in performance improvements
   of up to 25x.
+- A lot of transitive includes have been removed, resulting in significant compile time improvements.
 - ``std::bad_variant_access::what()`` now returns a message identifying the cause of the failure:
   ``"std::visit: variant is valueless"``, ``"std::get: variant is valueless"``, or
   ``"std::get: wrong alternative for variant"``. The standard only requires ``what()`` to return an


### PR DESCRIPTION
A release note about transitive include removals was inadvertently
dropped during a rebase of #196495 before merge. This restores it.