### PR TITLE
[WebAssembly] Default to 0 shadow offset for wasm64 ASan

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -599,6 +599,8 @@ static ShadowMapping getShadowMapping(const Triple &TargetTriple, int LongSize,
                         (kSmallX86_64ShadowOffsetAlignMask << Mapping.Scale));
     else if (IsBPF)
       Mapping.Offset = kDynamicShadowSentinel;
+    else if (IsWasm)
+      Mapping.Offset = kWebAssemblyShadowOffset;
     else
       Mapping.Offset = kDefaultShadowOffset64;
   }

--- a/llvm/test/Instrumentation/AddressSanitizer/wasm.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/wasm.ll
@@ -1,0 +1,23 @@
+; Check ASan shadow mapping on WebAssembly (both wasm32 and wasm64 should use offset 0).
+; RUN: opt -passes=asan -S -mtriple=wasm32-unknown-emscripten < %s | FileCheck %s --check-prefixes=WASM32
+; RUN: opt -passes=asan -S -mtriple=wasm64-unknown-emscripten < %s | FileCheck %s --check-prefixes=WASM64
+
+define i32 @test_load(ptr %a) sanitize_address {
+; WASM32-LABEL: @test_load
+; WASM32:   %[[LOAD_ADDR:[^ ]*]] = ptrtoint ptr %a to i32
+; WASM32:   %[[SHIFT:[^ ]*]] = lshr i32 %[[LOAD_ADDR]], 3
+; WASM32-NOT: or i32 %[[SHIFT]]
+; WASM32-NOT: add i32 %[[SHIFT]]
+; WASM32:   inttoptr i32 %[[SHIFT]] to ptr
+
+; WASM64-LABEL: @test_load
+; WASM64:   %[[LOAD_ADDR:[^ ]*]] = ptrtoint ptr %a to i64
+; WASM64:   %[[SHIFT:[^ ]*]] = lshr i64 %[[LOAD_ADDR]], 3
+; WASM64-NOT: or i64 %[[SHIFT]]
+; WASM64-NOT: add i64 %[[SHIFT]]
+; WASM64:   inttoptr i64 %[[SHIFT]] to ptr
+
+entry:
+  %x = load i32, ptr %a, align 4
+  ret i32 %x
+}


### PR DESCRIPTION
For Wasm64, ASan instrumentation was defaulting to a 16TB shadow offset, while the runtime configures it to 0. Align them by defaulting to 0 for all WebAssembly targets.
