### PR TITLE
[Flang] Match additional CMake Fortran detection probes

### DIFF
--- a/flang/test/Driver/fakeflang.F
+++ b/flang/test/Driver/fakeflang.F
@@ -4,17 +4,25 @@
 ! RUN: mkdir -p %t
 ! RUN: cd %t
 
-! RUN: fakeflang -v -c --target=x86_64-unknown-linux-gnu %s
+! RUN: fakeflang -v -c -cpp -E --target=x86_64-unknown-linux-gnu %s
 ! RUN: FileCheck %s --input-file=a.out --check-prefixes=CHECK,GNU
 ! RUN: rm a.out
 
-! RUN: fakeflang -v -c --target=x86_64-pc-windows-msvc %s
+! RUN: fakeflang -v -c -cpp -E --target=aarch64-linux-gnu %s
+! RUN: FileCheck %s --input-file=a.out --check-prefixes=CHECK,GNU
+! RUN: rm a.out
+
+! RUN: fakeflang -v -c -cpp -E --target=x86_64-pc-windows-msvc %s
 ! RUN: FileCheck %s --input-file=a.out --check-prefixes=CHECK,MSVC --match-full-lines
 ! RUN: rm a.out
 
 
 ! CHECK: CMAKE_Fortran_COMPILER_ID=1
 CMAKE_Fortran_COMPILER_ID=__flang__
+
+! __GNUC__ is not defined
+! CHECK: __GNUC__
+__GNUC__
 
 ! CHECK: CMAKE_Fortran_COMPILER_VERSION={{[0-9]+}} . {{[0-9]+}} . {{[0-9]+}}
 CMAKE_Fortran_COMPILER_VERSION=__flang_major__.__flang_minor__.__flang_patchlevel__

--- a/flang/tools/fakeflang/ensure_flang_exists.cmake
+++ b/flang/tools/fakeflang/ensure_flang_exists.cmake
@@ -7,5 +7,7 @@ if (NOT EXISTS "${OUTPUT_FILE}")
 
   # This could also be the symlink but its small size is not worth the effort
   # handling platform differences.
-  file(COPY_FILE "${INPUT_FILE}" "${OUTPUT_FILE}")
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E copy "${INPUT_FILE}" "${OUTPUT_FILE}"
+  )
 endif ()

--- a/flang/tools/fakeflang/fakeflang.cpp
+++ b/flang/tools/fakeflang/fakeflang.cpp
@@ -84,9 +84,16 @@ int main(int argc, const char **argv) {
   Args.append({ClangExe, "-E", "-P", "-D__flang__=1",
       "-D__flang_major__=" FLANG_VERSION_MAJOR_STRING,
       "-D__flang_minor__=" FLANG_VERSION_MINOR_STRING,
-      "-D__flang_patchlevel__=" FLANG_VERSION_PATCHLEVEL_STRING, "-x", "c"});
-  for (int I = 1; I < argc; ++I)
-    Args.push_back(argv[I]);
+      "-D__flang_patchlevel__=" FLANG_VERSION_PATCHLEVEL_STRING,
+      "-U__GNUC__", "-x", "c"});
+  for (int I = 1; I < argc; ++I) {
+    llvm::StringRef arg = argv[I];
+
+    // Sometime CMake tries to invoke the preprocessor
+    if (arg == "-cpp" || arg == "-E") continue ;
+
+    Args.push_back(arg);
+  }
   if (!hasDashO)
     Args.append({"-o", "a.out"});
 

--- a/flang/tools/fakeflang/fakeflang.cpp
+++ b/flang/tools/fakeflang/fakeflang.cpp
@@ -84,13 +84,14 @@ int main(int argc, const char **argv) {
   Args.append({ClangExe, "-E", "-P", "-D__flang__=1",
       "-D__flang_major__=" FLANG_VERSION_MAJOR_STRING,
       "-D__flang_minor__=" FLANG_VERSION_MINOR_STRING,
-      "-D__flang_patchlevel__=" FLANG_VERSION_PATCHLEVEL_STRING,
-      "-U__GNUC__", "-x", "c"});
+      "-D__flang_patchlevel__=" FLANG_VERSION_PATCHLEVEL_STRING, "-U__GNUC__",
+      "-x", "c"});
   for (int I = 1; I < argc; ++I) {
     llvm::StringRef arg = argv[I];
 
     // Sometime CMake tries to invoke the preprocessor
-    if (arg == "-cpp" || arg == "-E") continue ;
+    if (arg == "-cpp" || arg == "-E")
+      continue;
 
     Args.push_back(arg);
   }

--- a/flang/tools/fakeflang/fakeflang.cpp
+++ b/flang/tools/fakeflang/fakeflang.cpp
@@ -76,6 +76,10 @@ int main(int argc, const char **argv) {
   // `-E`: Invoke the preprocessor
   // `-P`: No #line directives
   // `-D..`: Preprocessor definitions that CMake probes
+  // `-fgnuc-version=0`: Prevent clang from implicitly defining __GNUC__;
+  //                     CMake's CMakeFortranCompilerId.F.in checks
+  //                     __GNUC__before __flang__, so without this flag the
+  //                     compiler is misidentified as GNU.
   // `-x c`: Usually Clang would forward Fortran files to gfortran; Interpret as
   //         C for clang to preprocess the files itself
   // `-o`: -E by default emits to stdout, but CMake expects a new file to appear
@@ -84,8 +88,8 @@ int main(int argc, const char **argv) {
   Args.append({ClangExe, "-E", "-P", "-D__flang__=1",
       "-D__flang_major__=" FLANG_VERSION_MAJOR_STRING,
       "-D__flang_minor__=" FLANG_VERSION_MINOR_STRING,
-      "-D__flang_patchlevel__=" FLANG_VERSION_PATCHLEVEL_STRING, "-U__GNUC__",
-      "-x", "c"});
+      "-D__flang_patchlevel__=" FLANG_VERSION_PATCHLEVEL_STRING,
+      "-fgnuc-version=0", "-x", "c"});
   for (int I = 1; I < argc; ++I) {
     llvm::StringRef arg = argv[I];
 


### PR DESCRIPTION
Support the following additional patterns that CMake may use to introspect the Fortran compiler:
1. `__GNUC__` may be tested before `__flang__` which results in the compiler to be identified as "GNU" instead of "LLVMFlang"
2. Invoke with `-E -cpp` to explicitly use the preprocessor

Fakeflang was added in #203481 to not have to build all of flang just to pass CMake's compiler detection.

Tested with CMake 3.20, 3.28, and 4.4-rc.

Should fix the [flang-aarch64-rel-assert](https://lab.llvm.org/buildbot/#/builders/29) and [flang-aarch64-dylib](https://lab.llvm.org/buildbot/#/builders/50) buildbots.