### PR TITLE
Add no-arg constructor and EraseIf method to MultiplexExternalSemaSource

### DIFF
--- a/clang/include/clang/Sema/MultiplexExternalSemaSource.h
+++ b/clang/include/clang/Sema/MultiplexExternalSemaSource.h
@@ -14,6 +14,7 @@
 
 #include "clang/Sema/ExternalSemaSource.h"
 #include "clang/Sema/Weak.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include <utility>
 
@@ -43,6 +44,9 @@ private:
   SmallVector<llvm::IntrusiveRefCntPtr<ExternalSemaSource>, 2> Sources;
 
 public:
+  /// Constructs an empty multiplexing external sema source.
+  MultiplexExternalSemaSource();
+
   /// Constructs a new multiplexing external sema source and appends the
   /// given element to it.
   ///
@@ -57,6 +61,15 @@ public:
   ///\param[in] Source - An ExternalSemaSource.
   ///
   void AddSource(llvm::IntrusiveRefCntPtr<ExternalSemaSource> Source);
+
+  /// Remove all sources for which the predicate returns true.
+  ///
+  /// \param P - A predicate that takes an
+  /// IntrusiveRefCntPtr<ExternalSemaSource> param and returns true if
+  /// the source should be removed, false otherwise.
+  template <typename UnaryPredicate> void EraseIf(UnaryPredicate P) {
+    llvm::erase_if(Sources, P);
+  }
 
   //===--------------------------------------------------------------------===//
   // ExternalASTSource.

--- a/clang/lib/Sema/MultiplexExternalSemaSource.cpp
+++ b/clang/lib/Sema/MultiplexExternalSemaSource.cpp
@@ -16,6 +16,9 @@ using namespace clang;
 
 char MultiplexExternalSemaSource::ID;
 
+/// Constructs an empty multiplexing external sema source.
+MultiplexExternalSemaSource::MultiplexExternalSemaSource() {}
+
 /// Constructs a new multiplexing external sema source and appends the
 /// given element to it.
 ///


### PR DESCRIPTION
The no-arg constructor makes MultiplexExternalSemaSource usable in situations where two child sources are not immediately available, or where conditional logic makes it easier to call AddSource rather than immediately pass child sources to the constructor.

The EraseIf method allows sources to be removed later if they are no longer needed.