### PR TITLE
[lldb] Prefer main obj file's symtab if exists

### DIFF
--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -3232,8 +3232,26 @@ void ObjectFileELF::ParseSymtab(Symtab &lldb_symtab) {
   // smaller version of the symtab that only contains global symbols. The
   // information found in the dynsym is therefore also found in the symtab,
   // while the reverse is not necessarily true.
-  Section *symtab =
-      section_list->FindSectionByType(eSectionTypeELFSymbolTable, true).get();
+  //
+  // Prefer the symbol table from this (the main) object file. When a separate
+  // debug file is attached to the module -- for example via the platform
+  // locate-module callback supplying both a binary and a DWARF-only
+  // ".debuginfo" whose ".symtab" has been stripped to SHT_NOBITS (zero file
+  // size) -- the module's unified section list can surface that empty ".symtab"
+  // ahead of the populated ".symtab" in this object file. Parsing the empty one
+  // yields no symbols and forces a fallback to eh_frame-synthesized
+  // "___lldb_unnamed_symbol" names. If our own object file carries a populated
+  // symbol table, use it; otherwise fall back to the module's unified list,
+  // which legitimately provides the symbol table from a separate debug file for
+  // a stripped binary.
+  Section *symtab = nullptr;
+  if (SectionList *obj_section_list = GetSectionList())
+    symtab =
+        obj_section_list->FindSectionByType(eSectionTypeELFSymbolTable, true)
+            .get();
+  if (!symtab || symtab->GetFileSize() == 0)
+    symtab =
+        section_list->FindSectionByType(eSectionTypeELFSymbolTable, true).get();
   if (symtab) {
     auto [num_symbols, address_class_map] =
         ParseSymbolTable(&lldb_symtab, symbol_id, symtab);


### PR DESCRIPTION
**NOTE: This PR is still in prototype/discussion phase. I am in process of running/fixing tests.**

Sometimes, the main object file isn't stripped of symbols, while the debug file is. Currently, lldb prefers the debug file's symbol table, which cause the said case to result in no symbols.

Change this to prefer symbols from the main object file if exists. If the main object file is stripped, it still fallbacks to the debug file's symbol table.

Before the change:
```
devvm24317 ~/tmp $ lldb -o "target create -c core.5457.1781100845.openr-ThriftCtr --symfile openr.debuginfo openr" -o "bt" -o "image list"
(lldb) target create -c core.5457.1781100845.openr-ThriftCtr --symfile openr.debuginfo openr
warning: (x86_64) /home/royshi/tmp/openr unable to locate separate debug file (dwo, dwp). Debugging will be degraded. (troubleshoot with https://fburl.com/missing_dwo)
Core file '/home/royshi/tmp/core.5457.1781100845.openr-ThriftCtr' (x86_64) was loaded.
(lldb) bt
* thread #1, name = 'openr', stop reason = SIGABRT: sent by tkill system call (sender pid=5457, uid=0)
   * frame #0: 0x00007fb08ed41993 libc.so.6`
     frame #1: 0x00007fb08ece94ad libc.so.6`
     frame #2: 0x000000000123533a openr`___lldb_unnamed_symbol_12348e0 at SignalHandler.cpp:213
     frame #3: 0x00007fb08ece9560 libc.so.6`
     frame #4: 0x00007fb08ece94ad libc.so.6`
     frame #5: 0x00007fb08ecd1433 libc.so.6`
     frame #6: 0x00000000012a2ab1 openr`___lldb_unnamed_symbol_12a2970 at LogCategory.cpp:73
     frame #7: 0x00000000012a17d0 openr`___lldb_unnamed_symbol_12a1750 at LogStreamProcessor.cpp:190
     frame #8: 0x00000000012a1b9d openr`___lldb_unnamed_symbol_12a1b90 at LogStreamProcessor.cpp:223
     frame #9: 0x0000000003bf4764 openr`___lldb_unnamed_symbol_3bf3be0 at ThriftServer.cpp:1792
     frame #10: 0x0000000003bdcde5 openr`___lldb_unnamed_symbol_3bdcc30 at ThriftServer.cpp:1687
     frame #11: 0x0000000003c19431 openr`___lldb_unnamed_symbol_3c19330 at ThriftServer.cpp:1596
     frame #12: 0x0000000003bdca4d openr`___lldb_unnamed_symbol_3bdc990 at ThriftServer.cpp:1576
     frame #13: 0x00000000011b3a68 openr`___lldb_unnamed_symbol_11b3a00 at Main.cpp:526
     frame #14: 0x00007fb08ea0c5b5 libstdc++.so.6`read_bom<char const, true, 3>(bom=<unavailable>, from=<unavailable>) at codecvt.cc:190:11 [inlined]
     frame #15: 0x00007fb08ea0c5aa libstdc++.so.6`read_utf8_bom<char>(mode=<unavailable>, from=<unavailable>) at codecvt.cc:227:15 [inlined]
     frame #16: 0x00007fb08ea0c5aa libstdc++.so.6`ucs4_span<char>(mode=<unavailable>, maxcode=<unavailable>, max=<unavailable>, end=<unavailable>, begin=<unavailable>) at codecvt.cc:721:18
     frame #17: 0x00007fb08ea0c5a0 libstdc++.so.6`std::__codecvt_utf8_base<char32_t>::do_length(this=<unavailable>, (null)=<unavailable>, __from=<unavailable>, __end=<unavailable>, __max=<unavailable>) const at codecvt.cc:1172:20
(lldb) image list
[  0] 8E943D96-0368-AB8D-C234-59D4B982932A-5D151CCC 0x0000000000200000 /home/royshi/tmp/openr
      /home/royshi/tmp/openr.debuginfo
```

After the change:
```
devvm24317 ~/tmp $ lluu -o "target create -c core.5457.1781100845.openr-ThriftCtr --symfile openr.debuginfo openr" -o "bt" -o "image list"
(lldb) target create -c core.5457.1781100845.openr-ThriftCtr --symfile openr.debuginfo openr
warning: (x86_64) /home/royshi/tmp/openr unable to locate separate debug file (dwo, dwp). Debugging will be degraded
Core file '/home/royshi/tmp/core.5457.1781100845.openr-ThriftCtr' (x86_64) was loaded.
Core was generated by 'openr --config=/etc/openr_config --logging=DBG1;default:async=true --v=1 '.
(lldb) bt
* thread #1, name = 'openr', stop reason = SIGABRT: sent by tkill system call (sender pid=5457, uid=0)
   * frame #0: 0x00007fb08ed41993 libc.so.6`
     frame #1: 0x00007fb08ece94ad libc.so.6`
     frame #2: 0x000000000123533a openr`folly::symbolizer::(anonymous namespace)::signalHandler(int, siginfo_t*, void*) at SignalHandler.cpp:213
     frame #3: 0x00007fb08ece9560 libc.so.6`
     frame #4: 0x00007fb08ece94ad libc.so.6`
     frame #5: 0x00007fb08ecd1433 libc.so.6`
     frame #6: 0x00000000012a2ab1 openr`folly::LogCategory::admitMessage(folly::LogMessage const&, bool) const at LogCategory.cpp:73
     frame #7: 0x00000000012a17d0 openr`folly::LogStreamProcessor::logNow() at LogStreamProcessor.cpp:190
     frame #8: 0x00000000012a1b9d openr`folly::LogStreamVoidify<true>::operator&(std::ostream&) at LogStreamProcessor.cpp:223
     frame #9: 0x0000000003bf4764 openr`apache::thrift::ThriftServer::stopAcceptingAndJoinOutstandingRequests() at ThriftServer.cpp:1792
     frame #10: 0x0000000003bdcde5 openr`apache::thrift::ThriftServer::stopListening() at ThriftServer.cpp:1687
     frame #11: 0x0000000003c19431 openr`apache::thrift::ThriftServer::cleanUp() at ThriftServer.cpp:1596
     frame #12: 0x0000000003bdca4d openr`apache::thrift::ThriftServer::serve() at ThriftServer.cpp:1576
     frame #13: 0x00000000011b3a68 openr`std::thread::_State_impl<std::thread::_Invoker<std::tuple<main::$_2>>>::_M_run() at Main.cpp:526
     frame #14: 0x00007fb08ea0c5b5 libstdc++.so.6`read_bom<char const, true, 3>(bom=<unavailable>, from=<unavailable>) at codecvt.cc:190:11 [inlined]
     frame #15: 0x00007fb08ea0c5aa libstdc++.so.6`read_utf8_bom<char>(mode=<unavailable>, from=<unavailable>) at codecvt.cc:227:15 [inlined]
     frame #16: 0x00007fb08ea0c5aa libstdc++.so.6`ucs4_span<char>(mode=<unavailable>, maxcode=<unavailable>, max=<unavailable>, end=<unavailable>, begin=<unavailable>) at codecvt.cc:721:18
     frame #17: 0x00007fb08ea0c5a0 libstdc++.so.6`std::__codecvt_utf8_base<char32_t>::do_length(this=<unavailable>, (null)=<unavailable>, __from=<unavailable>, __end=<unavailable>, __max=<unavailable>) const at codecvt.cc:1172:20
(lldb) image list
[  0] 8E943D96-0368-AB8D-C234-59D4B982932A-5D151CCC 0x0000000000200000 /home/royshi/tmp/openr
      /home/royshi/tmp/openr.debuginfo
```