### PR TITLE
[DirectX] Fix IO sandbox violation in DXContainerPDB pass

### DIFF
--- a/llvm/lib/Target/DirectX/DXContainerPDB.cpp
+++ b/llvm/lib/Target/DirectX/DXContainerPDB.cpp
@@ -17,6 +17,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/MC/MCDXContainerWriter.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/IOSandbox.h"
 
 using namespace llvm;
 
@@ -143,6 +144,8 @@ bool DXContainerPDB::runOnModule(Module &M) {
   write(OS, M.getTargetTriple());
 
   // Write PDB file.
+  // FIXME(sandboxing): Remove this by routing PDB output through the VFS.
+  auto BypassSandbox = sys::sandbox::scopedDisable();
   codeview::GUID IgnoredOutGuid;
   if (Error Err = Builder.commit(DebugFileName, &IgnoredOutGuid))
     reportFatalUsageError(std::move(Err));


### PR DESCRIPTION
`DXContainerPDB::runOnModule` writes a PDB file to disk via `PDBFileBuilder::commit`, which calls through `MSFBuilder::commit`  -> `FileOutputBuffer::create` -> `llvm::sys::fs::status()`. These are raw filesystem APIs that trigger a fatal "IO sandbox violation" when the IO sandbox is enabled.

The sandbox is enabled in `CC1Command::Execute` (Job.cpp) to enforce that all filesystem access goes through the VFS. Since `PDBFileBuilder` doesn't support VFS-based output, bypass the sandbox for the commit call using `scopedDisable()`, matching the established pattern used in `raw_ostream.cpp`, `VirtualFileSystem.cpp`, `BackendUtil.cpp`, and others.

This crash occurs on any clang invocation targeting the DirectX backend with PDB emission enabled, e.g.:

`Target: dxilv1.7-unknown-shadermodel6.7-library`

and was introduced with this commit: https://github.com/llvm/llvm-project/pull/202762, which added the   `Builder.commit(DebugFileName, ...)`  call that writes a PDB file via raw filesystem APIs, which violates the IO sandbox.

Stack trace:
```
reportFatalInternalError("IO sandbox violation")
 llvm::sys::fs::status()
  FileOutputBuffer::create()
   MSFBuilder::commit()
    PDBFileBuilder::commit()
     DXContainerPDB::runOnModule()
```

Assisted by: Github Copilot
Fixes: https://github.com/llvm/llvm-project/issues/204468