### PR TITLE
[CI] Restore /build* gitignore pattern to unbreak check_generated_files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@
 /*/CMakeUserPresets.json
 
 # Nested build directory
-/build_*
+/build*
 
 #==============================================================================#
 # Explicit files to ignore (only matches one).


### PR DESCRIPTION
`check_generated_files` is failing on every libc++ pull request.

The job runs `libcxx/utils/ci/run-buildbot check-generated-output`, which builds into the default `build/check-generated-output` and then runs `git ls-files -o --exclude-standard` to catch generator output that was not committed. #203270 changed the root `.gitignore` build pattern from `/build*` to `/build_*` as an edit unrelated to its LifetimeSafety change, so `build/` is no longer ignored. The check then lists the whole build tree as untracked and fails.

This restores `/build*`. The other `.gitignore` additions from #203270 are left untouched, since they do not affect the check.

Assisted-by: Claude (Anthropic)
