### PR TITLE
[AMDGPU] Fix 64->32 bit division corner case

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUCodeGenPrepare.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCodeGenPrepare.cpp
@@ -1362,9 +1362,9 @@ Value *AMDGPUCodeGenPrepareImpl::shrinkDivRem64(IRBuilder<> &Builder,
     Narrowed = expandDivRemToFloatImpl(Builder, I, Num, Den, NumDivBits, IsDiv,
                                        IsSigned);
   } else if (NumDivBits <= (IsSigned ? 31 : 32)) {
-    // Do not use 32-bit division if dividend may be -0x80000000LL.
+    // Do not use 32-bit division if dividend may be -2147483648.
     // Otherwise 32-bit division cannot be used safely.
-    // -0x80000000LL/1 and -0x80000000LL/-1 are not equal,
+    // -2147483648/1 and -2147483648/-1 are not equal,
     // but they produce the same lower 32-bit result.
     Narrowed = expandDivRem32(Builder, I, Num, Den);
   }

--- a/llvm/lib/Target/AMDGPU/AMDGPUCodeGenPrepare.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCodeGenPrepare.cpp
@@ -1361,7 +1361,11 @@ Value *AMDGPUCodeGenPrepareImpl::shrinkDivRem64(IRBuilder<> &Builder,
   if (NumDivBits <= (IsSigned ? 23 : 22)) {
     Narrowed = expandDivRemToFloatImpl(Builder, I, Num, Den, NumDivBits, IsDiv,
                                        IsSigned);
-  } else if (NumDivBits <= 32) {
+  } else if (NumDivBits <= (IsSigned ? 31 : 32)) {
+    // Do not use 32-bit division if dividend may be -0x80000000.
+    // Otherwise 32-bit division cannot be used safely.
+    // -0x80000000/1 and -0x80000000/-1 are not equal,
+    // but they produce the same lower 32-bit result.
     Narrowed = expandDivRem32(Builder, I, Num, Den);
   }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUCodeGenPrepare.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCodeGenPrepare.cpp
@@ -1362,9 +1362,9 @@ Value *AMDGPUCodeGenPrepareImpl::shrinkDivRem64(IRBuilder<> &Builder,
     Narrowed = expandDivRemToFloatImpl(Builder, I, Num, Den, NumDivBits, IsDiv,
                                        IsSigned);
   } else if (NumDivBits <= (IsSigned ? 31 : 32)) {
-    // Do not use 32-bit division if dividend may be -0x80000000.
+    // Do not use 32-bit division if dividend may be -0x80000000LL.
     // Otherwise 32-bit division cannot be used safely.
-    // -0x80000000/1 and -0x80000000/-1 are not equal,
+    // -0x80000000LL/1 and -0x80000000LL/-1 are not equal,
     // but they produce the same lower 32-bit result.
     Narrowed = expandDivRem32(Builder, I, Num, Den);
   }

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -2423,9 +2423,9 @@ SDValue AMDGPUTargetLowering::LowerSDIVREM(SDValue Op,
       return Res;
   }
 
-  // LHS must have > 33 sign-bits to ensure that LHS != -0x80000000
+  // LHS must have > 33 sign-bits to ensure that LHS != -0x80000000LL
   // Otherwise 32-bit division cannot be used safely.
-  // -0x80000000/1 and -0x80000000/-1 are not equal,
+  // -0x80000000LL/1 and -0x80000000LL/-1 are not equal,
   // but they produce the same lower 32-bit result.
   if (VT == MVT::i64 && DAG.ComputeNumSignBits(LHS) > 33 &&
       DAG.ComputeNumSignBits(RHS) > 32) {

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -2423,9 +2423,9 @@ SDValue AMDGPUTargetLowering::LowerSDIVREM(SDValue Op,
       return Res;
   }
 
-  // LHS must have > 33 sign-bits to ensure that LHS != -0x80000000LL
+  // LHS must have > 33 sign-bits to ensure that LHS != -2147483648
   // Otherwise 32-bit division cannot be used safely.
-  // -0x80000000LL/1 and -0x80000000LL/-1 are not equal,
+  // -2147483648/1 and -2147483648/-1 are not equal,
   // but they produce the same lower 32-bit result.
   if (VT == MVT::i64 && DAG.ComputeNumSignBits(LHS) > 33 &&
       DAG.ComputeNumSignBits(RHS) > 32) {

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -2423,8 +2423,11 @@ SDValue AMDGPUTargetLowering::LowerSDIVREM(SDValue Op,
       return Res;
   }
 
-  if (VT == MVT::i64 &&
-      DAG.ComputeNumSignBits(LHS) > 32 &&
+  // LHS must have > 33 sign-bits to ensure that LHS != -0x80000000
+  // Otherwise 32-bit division cannot be used safely.
+  // -0x80000000/1 and -0x80000000/-1 are not equal,
+  // but they produce the same lower 32-bit result.
+  if (VT == MVT::i64 && DAG.ComputeNumSignBits(LHS) > 33 &&
       DAG.ComputeNumSignBits(RHS) > 32) {
     EVT HalfVT = VT.getHalfSizedIntegerVT(*DAG.getContext());
 

--- a/llvm/test/CodeGen/AMDGPU/sdiv64.ll
+++ b/llvm/test/CodeGen/AMDGPU/sdiv64.ll
@@ -702,84 +702,249 @@ define i64 @v_test_sdiv24_64(i64 %x, i64 %y) {
 define amdgpu_kernel void @s_test_sdiv32_64(ptr addrspace(1) %out, i64 %x, i64 %y) {
 ; GCN-LABEL: s_test_sdiv32_64:
 ; GCN:       ; %bb.0:
-; GCN-NEXT:    s_load_dword s8, s[4:5], 0xe
-; GCN-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x9
-; GCN-NEXT:    s_mov_b32 s7, 0xf000
-; GCN-NEXT:    s_mov_b32 s6, -1
+; GCN-NEXT:    s_load_dwordx4 s[8:11], s[4:5], 0x9
+; GCN-NEXT:    s_load_dword s0, s[4:5], 0xe
+; GCN-NEXT:    s_mov_b32 s3, 0xf000
 ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-NEXT:    s_abs_i32 s9, s8
-; GCN-NEXT:    v_cvt_f32_u32_e32 v0, s9
-; GCN-NEXT:    s_sub_i32 s2, 0, s9
-; GCN-NEXT:    s_mov_b32 s4, s0
-; GCN-NEXT:    s_abs_i32 s0, s3
+; GCN-NEXT:    s_ashr_i32 s4, s11, 31
+; GCN-NEXT:    s_ashr_i32 s6, s0, 31
+; GCN-NEXT:    s_add_u32 s0, s0, s6
+; GCN-NEXT:    s_mov_b32 s7, s6
+; GCN-NEXT:    s_addc_u32 s1, s6, s6
+; GCN-NEXT:    s_xor_b64 s[12:13], s[0:1], s[6:7]
+; GCN-NEXT:    v_cvt_f32_u32_e32 v0, s12
+; GCN-NEXT:    v_cvt_f32_u32_e32 v1, s13
+; GCN-NEXT:    s_sub_u32 s0, 0, s12
+; GCN-NEXT:    s_subb_u32 s1, 0, s13
+; GCN-NEXT:    v_madmk_f32 v0, v1, 0x4f800000, v0
 ; GCN-NEXT:    v_rcp_f32_e32 v0, v0
-; GCN-NEXT:    s_mov_b32 s5, s1
-; GCN-NEXT:    s_xor_b32 s1, s3, s8
-; GCN-NEXT:    s_ashr_i32 s1, s1, 31
-; GCN-NEXT:    v_mul_f32_e32 v0, 0x4f7ffffe, v0
+; GCN-NEXT:    v_mul_f32_e32 v0, 0x5f7ffffc, v0
+; GCN-NEXT:    v_mul_f32_e32 v1, 0x2f800000, v0
+; GCN-NEXT:    v_trunc_f32_e32 v1, v1
+; GCN-NEXT:    v_madmk_f32 v0, v1, 0xcf800000, v0
 ; GCN-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GCN-NEXT:    v_mul_lo_u32 v1, s2, v0
-; GCN-NEXT:    v_mul_hi_u32 v1, v0, v1
-; GCN-NEXT:    v_add_i32_e32 v0, vcc, v0, v1
-; GCN-NEXT:    v_mul_hi_u32 v0, s0, v0
+; GCN-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GCN-NEXT:    v_mul_hi_u32 v2, s0, v0
+; GCN-NEXT:    v_readfirstlane_b32 s5, v1
 ; GCN-NEXT:    v_readfirstlane_b32 s2, v0
-; GCN-NEXT:    s_mul_i32 s3, s2, s9
-; GCN-NEXT:    s_sub_i32 s0, s0, s3
-; GCN-NEXT:    s_add_i32 s8, s2, 1
-; GCN-NEXT:    s_sub_i32 s3, s0, s9
-; GCN-NEXT:    s_cmp_ge_u32 s0, s9
-; GCN-NEXT:    s_cselect_b32 s2, s8, s2
-; GCN-NEXT:    s_cselect_b32 s0, s3, s0
-; GCN-NEXT:    s_add_i32 s3, s2, 1
-; GCN-NEXT:    s_cmp_ge_u32 s0, s9
-; GCN-NEXT:    s_cselect_b32 s0, s3, s2
-; GCN-NEXT:    s_xor_b32 s0, s0, s1
-; GCN-NEXT:    s_sub_i32 s0, s0, s1
-; GCN-NEXT:    s_ashr_i32 s1, s0, 31
-; GCN-NEXT:    v_mov_b32_e32 v0, s0
-; GCN-NEXT:    v_mov_b32_e32 v1, s1
-; GCN-NEXT:    buffer_store_dwordx2 v[0:1], off, s[4:7], 0
+; GCN-NEXT:    s_mul_i32 s10, s0, s5
+; GCN-NEXT:    v_readfirstlane_b32 s16, v2
+; GCN-NEXT:    s_mul_i32 s14, s1, s2
+; GCN-NEXT:    s_mul_i32 s15, s0, s2
+; GCN-NEXT:    s_add_i32 s10, s16, s10
+; GCN-NEXT:    v_mul_hi_u32 v3, v0, s15
+; GCN-NEXT:    s_add_i32 s10, s10, s14
+; GCN-NEXT:    v_mul_hi_u32 v0, v0, s10
+; GCN-NEXT:    v_mul_hi_u32 v4, v1, s15
+; GCN-NEXT:    v_readfirstlane_b32 s14, v3
+; GCN-NEXT:    s_mul_i32 s16, s2, s10
+; GCN-NEXT:    v_mul_hi_u32 v1, v1, s10
+; GCN-NEXT:    s_add_u32 s14, s14, s16
+; GCN-NEXT:    v_readfirstlane_b32 s16, v0
+; GCN-NEXT:    s_addc_u32 s16, 0, s16
+; GCN-NEXT:    s_mul_i32 s15, s5, s15
+; GCN-NEXT:    v_readfirstlane_b32 s17, v4
+; GCN-NEXT:    s_add_u32 s14, s14, s15
+; GCN-NEXT:    s_addc_u32 s14, s16, s17
+; GCN-NEXT:    v_readfirstlane_b32 s15, v1
+; GCN-NEXT:    s_addc_u32 s15, s15, 0
+; GCN-NEXT:    s_mul_i32 s10, s5, s10
+; GCN-NEXT:    s_add_u32 s10, s14, s10
+; GCN-NEXT:    s_addc_u32 s14, 0, s15
+; GCN-NEXT:    s_add_u32 s10, s2, s10
+; GCN-NEXT:    v_mov_b32_e32 v0, s10
+; GCN-NEXT:    v_mul_hi_u32 v0, s0, v0
+; GCN-NEXT:    s_addc_u32 s5, s5, s14
+; GCN-NEXT:    s_mul_i32 s14, s0, s5
+; GCN-NEXT:    s_mul_i32 s1, s1, s10
+; GCN-NEXT:    v_readfirstlane_b32 s15, v0
+; GCN-NEXT:    s_add_i32 s14, s15, s14
+; GCN-NEXT:    s_mul_i32 s0, s0, s10
+; GCN-NEXT:    s_add_i32 s1, s14, s1
+; GCN-NEXT:    v_mov_b32_e32 v2, s0
+; GCN-NEXT:    v_mov_b32_e32 v0, s1
+; GCN-NEXT:    v_mul_hi_u32 v3, s5, v2
+; GCN-NEXT:    v_mul_hi_u32 v2, s10, v2
+; GCN-NEXT:    v_mul_hi_u32 v1, s5, v0
+; GCN-NEXT:    v_mul_hi_u32 v0, s10, v0
+; GCN-NEXT:    s_mul_i32 s15, s10, s1
+; GCN-NEXT:    v_readfirstlane_b32 s17, v2
+; GCN-NEXT:    s_add_u32 s15, s17, s15
+; GCN-NEXT:    v_readfirstlane_b32 s16, v0
+; GCN-NEXT:    s_mul_i32 s0, s5, s0
+; GCN-NEXT:    s_addc_u32 s16, 0, s16
+; GCN-NEXT:    v_readfirstlane_b32 s14, v3
+; GCN-NEXT:    s_add_u32 s0, s15, s0
+; GCN-NEXT:    s_addc_u32 s0, s16, s14
+; GCN-NEXT:    v_readfirstlane_b32 s14, v1
+; GCN-NEXT:    s_addc_u32 s14, s14, 0
+; GCN-NEXT:    s_mul_i32 s1, s5, s1
+; GCN-NEXT:    s_add_u32 s0, s0, s1
+; GCN-NEXT:    s_addc_u32 s1, 0, s14
+; GCN-NEXT:    s_add_u32 s14, s10, s0
+; GCN-NEXT:    s_addc_u32 s15, s5, s1
+; GCN-NEXT:    s_add_u32 s0, s11, s4
+; GCN-NEXT:    s_mov_b32 s5, s4
+; GCN-NEXT:    s_addc_u32 s1, s4, s4
+; GCN-NEXT:    s_xor_b64 s[10:11], s[0:1], s[4:5]
+; GCN-NEXT:    v_mov_b32_e32 v0, s15
+; GCN-NEXT:    v_mul_hi_u32 v1, s10, v0
+; GCN-NEXT:    v_mov_b32_e32 v2, s14
+; GCN-NEXT:    v_mul_hi_u32 v3, s10, v2
+; GCN-NEXT:    s_mov_b32 s0, s8
+; GCN-NEXT:    v_readfirstlane_b32 s8, v1
+; GCN-NEXT:    v_mul_hi_u32 v1, s11, v2
+; GCN-NEXT:    s_mul_i32 s1, s10, s15
+; GCN-NEXT:    v_readfirstlane_b32 s16, v3
+; GCN-NEXT:    v_mul_hi_u32 v0, s11, v0
+; GCN-NEXT:    s_add_u32 s1, s16, s1
+; GCN-NEXT:    s_addc_u32 s8, 0, s8
+; GCN-NEXT:    s_mul_i32 s14, s11, s14
+; GCN-NEXT:    v_readfirstlane_b32 s16, v1
+; GCN-NEXT:    s_add_u32 s1, s1, s14
+; GCN-NEXT:    s_addc_u32 s1, s8, s16
+; GCN-NEXT:    v_readfirstlane_b32 s8, v0
+; GCN-NEXT:    s_addc_u32 s8, s8, 0
+; GCN-NEXT:    s_mul_i32 s14, s11, s15
+; GCN-NEXT:    s_add_u32 s14, s1, s14
+; GCN-NEXT:    v_mov_b32_e32 v0, s14
+; GCN-NEXT:    v_mul_hi_u32 v0, s12, v0
+; GCN-NEXT:    s_addc_u32 s15, 0, s8
+; GCN-NEXT:    s_mov_b32 s1, s9
+; GCN-NEXT:    s_mul_i32 s8, s12, s15
+; GCN-NEXT:    v_readfirstlane_b32 s9, v0
+; GCN-NEXT:    s_add_i32 s8, s9, s8
+; GCN-NEXT:    s_mul_i32 s9, s13, s14
+; GCN-NEXT:    s_add_i32 s16, s8, s9
+; GCN-NEXT:    s_sub_i32 s17, s11, s16
+; GCN-NEXT:    s_mul_i32 s8, s12, s14
+; GCN-NEXT:    s_sub_u32 s10, s10, s8
+; GCN-NEXT:    s_cselect_b64 s[8:9], -1, 0
+; GCN-NEXT:    s_subb_u32 s17, s17, s13
+; GCN-NEXT:    s_sub_u32 s18, s10, s12
+; GCN-NEXT:    s_subb_u32 s17, s17, 0
+; GCN-NEXT:    s_cmp_ge_u32 s17, s13
+; GCN-NEXT:    s_cselect_b32 s19, -1, 0
+; GCN-NEXT:    s_cmp_ge_u32 s18, s12
+; GCN-NEXT:    s_cselect_b32 s18, -1, 0
+; GCN-NEXT:    s_cmp_eq_u32 s17, s13
+; GCN-NEXT:    s_cselect_b32 s17, s18, s19
+; GCN-NEXT:    s_add_u32 s18, s14, 1
+; GCN-NEXT:    s_addc_u32 s19, s15, 0
+; GCN-NEXT:    s_add_u32 s20, s14, 2
+; GCN-NEXT:    s_addc_u32 s21, s15, 0
+; GCN-NEXT:    s_cmp_lg_u32 s17, 0
+; GCN-NEXT:    s_cselect_b32 s17, s20, s18
+; GCN-NEXT:    s_cselect_b32 s18, s21, s19
+; GCN-NEXT:    s_or_b32 s8, s8, s9
+; GCN-NEXT:    s_subb_u32 s8, s11, s16
+; GCN-NEXT:    s_cmp_ge_u32 s8, s13
+; GCN-NEXT:    s_cselect_b32 s9, -1, 0
+; GCN-NEXT:    s_cmp_ge_u32 s10, s12
+; GCN-NEXT:    s_cselect_b32 s10, -1, 0
+; GCN-NEXT:    s_cmp_eq_u32 s8, s13
+; GCN-NEXT:    s_cselect_b32 s8, s10, s9
+; GCN-NEXT:    s_cmp_lg_u32 s8, 0
+; GCN-NEXT:    s_cselect_b32 s9, s18, s15
+; GCN-NEXT:    s_cselect_b32 s8, s17, s14
+; GCN-NEXT:    s_xor_b64 s[4:5], s[4:5], s[6:7]
+; GCN-NEXT:    s_xor_b64 s[6:7], s[8:9], s[4:5]
+; GCN-NEXT:    s_sub_u32 s4, s6, s4
+; GCN-NEXT:    s_subb_u32 s5, s7, s5
+; GCN-NEXT:    v_mov_b32_e32 v0, s4
+; GCN-NEXT:    s_mov_b32 s2, -1
+; GCN-NEXT:    v_mov_b32_e32 v1, s5
+; GCN-NEXT:    buffer_store_dwordx2 v[0:1], off, s[0:3], 0
 ; GCN-NEXT:    s_endpgm
 ;
 ; GCN-IR-LABEL: s_test_sdiv32_64:
-; GCN-IR:       ; %bb.0:
-; GCN-IR-NEXT:    s_load_dword s8, s[4:5], 0xe
+; GCN-IR:       ; %bb.0: ; %_udiv-special-cases
 ; GCN-IR-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x9
-; GCN-IR-NEXT:    s_mov_b32 s7, 0xf000
-; GCN-IR-NEXT:    s_mov_b32 s6, -1
+; GCN-IR-NEXT:    s_load_dwordx2 s[4:5], s[4:5], 0xd
+; GCN-IR-NEXT:    s_mov_b32 s15, 0
 ; GCN-IR-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-IR-NEXT:    s_abs_i32 s9, s8
-; GCN-IR-NEXT:    v_cvt_f32_u32_e32 v0, s9
-; GCN-IR-NEXT:    s_sub_i32 s2, 0, s9
-; GCN-IR-NEXT:    s_mov_b32 s4, s0
-; GCN-IR-NEXT:    s_abs_i32 s0, s3
-; GCN-IR-NEXT:    v_rcp_f32_e32 v0, v0
-; GCN-IR-NEXT:    s_mov_b32 s5, s1
-; GCN-IR-NEXT:    s_xor_b32 s1, s3, s8
-; GCN-IR-NEXT:    s_ashr_i32 s1, s1, 31
-; GCN-IR-NEXT:    v_mul_f32_e32 v0, 0x4f7ffffe, v0
-; GCN-IR-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GCN-IR-NEXT:    v_mul_lo_u32 v1, s2, v0
-; GCN-IR-NEXT:    v_mul_hi_u32 v1, v0, v1
-; GCN-IR-NEXT:    v_add_i32_e32 v0, vcc, v0, v1
-; GCN-IR-NEXT:    v_mul_hi_u32 v0, s0, v0
-; GCN-IR-NEXT:    v_readfirstlane_b32 s2, v0
-; GCN-IR-NEXT:    s_mul_i32 s3, s2, s9
-; GCN-IR-NEXT:    s_sub_i32 s0, s0, s3
-; GCN-IR-NEXT:    s_add_i32 s8, s2, 1
-; GCN-IR-NEXT:    s_sub_i32 s3, s0, s9
-; GCN-IR-NEXT:    s_cmp_ge_u32 s0, s9
-; GCN-IR-NEXT:    s_cselect_b32 s2, s8, s2
-; GCN-IR-NEXT:    s_cselect_b32 s0, s3, s0
-; GCN-IR-NEXT:    s_add_i32 s3, s2, 1
-; GCN-IR-NEXT:    s_cmp_ge_u32 s0, s9
-; GCN-IR-NEXT:    s_cselect_b32 s0, s3, s2
-; GCN-IR-NEXT:    s_xor_b32 s0, s0, s1
-; GCN-IR-NEXT:    s_sub_i32 s0, s0, s1
-; GCN-IR-NEXT:    s_ashr_i32 s1, s0, 31
-; GCN-IR-NEXT:    v_mov_b32_e32 v0, s0
-; GCN-IR-NEXT:    v_mov_b32_e32 v1, s1
-; GCN-IR-NEXT:    buffer_store_dwordx2 v[0:1], off, s[4:7], 0
+; GCN-IR-NEXT:    s_ashr_i32 s9, s3, 31
+; GCN-IR-NEXT:    s_mov_b32 s8, s3
+; GCN-IR-NEXT:    s_ashr_i32 s3, s5, 31
+; GCN-IR-NEXT:    s_mov_b32 s2, s5
+; GCN-IR-NEXT:    s_mov_b32 s4, s9
+; GCN-IR-NEXT:    s_mov_b32 s5, s9
+; GCN-IR-NEXT:    s_xor_b64 s[10:11], s[8:9], s[4:5]
+; GCN-IR-NEXT:    s_mov_b32 s6, s3
+; GCN-IR-NEXT:    s_mov_b32 s7, s3
+; GCN-IR-NEXT:    s_sub_u32 s12, s10, s9
+; GCN-IR-NEXT:    s_subb_u32 s13, s11, s9
+; GCN-IR-NEXT:    s_xor_b64 s[8:9], s[2:3], s[6:7]
+; GCN-IR-NEXT:    s_sub_u32 s2, s8, s3
+; GCN-IR-NEXT:    s_subb_u32 s3, s9, s3
+; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[8:9], s[2:3], 0
+; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[10:11], s[12:13], 0
+; GCN-IR-NEXT:    s_flbit_i32_b64 s14, s[2:3]
+; GCN-IR-NEXT:    s_or_b64 s[10:11], s[8:9], s[10:11]
+; GCN-IR-NEXT:    s_flbit_i32_b64 s20, s[12:13]
+; GCN-IR-NEXT:    s_sub_u32 s16, s14, s20
+; GCN-IR-NEXT:    s_subb_u32 s17, 0, 0
+; GCN-IR-NEXT:    v_cmp_gt_u64_e64 s[18:19], s[16:17], 63
+; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[22:23], s[16:17], 63
+; GCN-IR-NEXT:    s_or_b64 s[18:19], s[10:11], s[18:19]
+; GCN-IR-NEXT:    s_and_b64 s[10:11], s[18:19], exec
+; GCN-IR-NEXT:    s_cselect_b32 s11, 0, s13
+; GCN-IR-NEXT:    s_cselect_b32 s10, 0, s12
+; GCN-IR-NEXT:    s_or_b64 s[18:19], s[18:19], s[22:23]
+; GCN-IR-NEXT:    s_mov_b64 s[8:9], 0
+; GCN-IR-NEXT:    s_andn2_b64 vcc, exec, s[18:19]
+; GCN-IR-NEXT:    s_cbranch_vccz .LBB5_5
+; GCN-IR-NEXT:  ; %bb.1: ; %udiv-bb1
+; GCN-IR-NEXT:    s_add_u32 s18, s16, 1
+; GCN-IR-NEXT:    s_addc_u32 s10, s17, 0
+; GCN-IR-NEXT:    s_cselect_b64 s[10:11], -1, 0
+; GCN-IR-NEXT:    s_sub_i32 s16, 63, s16
+; GCN-IR-NEXT:    s_andn2_b64 vcc, exec, s[10:11]
+; GCN-IR-NEXT:    s_lshl_b64 s[10:11], s[12:13], s16
+; GCN-IR-NEXT:    s_cbranch_vccz .LBB5_4
+; GCN-IR-NEXT:  ; %bb.2: ; %udiv-preheader
+; GCN-IR-NEXT:    s_lshr_b64 s[16:17], s[12:13], s18
+; GCN-IR-NEXT:    s_add_u32 s18, s2, -1
+; GCN-IR-NEXT:    s_addc_u32 s19, s3, -1
+; GCN-IR-NEXT:    s_not_b64 s[8:9], s[14:15]
+; GCN-IR-NEXT:    s_add_u32 s14, s8, s20
+; GCN-IR-NEXT:    s_addc_u32 s15, s9, 0
+; GCN-IR-NEXT:    s_mov_b64 s[12:13], 0
+; GCN-IR-NEXT:    s_mov_b32 s9, 0
+; GCN-IR-NEXT:  .LBB5_3: ; %udiv-do-while
+; GCN-IR-NEXT:    ; =>This Inner Loop Header: Depth=1
+; GCN-IR-NEXT:    s_lshl_b64 s[16:17], s[16:17], 1
+; GCN-IR-NEXT:    s_lshr_b32 s8, s11, 31
+; GCN-IR-NEXT:    s_lshl_b64 s[10:11], s[10:11], 1
+; GCN-IR-NEXT:    s_or_b64 s[16:17], s[16:17], s[8:9]
+; GCN-IR-NEXT:    s_or_b64 s[10:11], s[12:13], s[10:11]
+; GCN-IR-NEXT:    s_sub_u32 s8, s18, s16
+; GCN-IR-NEXT:    s_subb_u32 s8, s19, s17
+; GCN-IR-NEXT:    s_ashr_i32 s12, s8, 31
+; GCN-IR-NEXT:    s_mov_b32 s13, s12
+; GCN-IR-NEXT:    s_and_b32 s8, s12, 1
+; GCN-IR-NEXT:    s_and_b64 s[20:21], s[12:13], s[2:3]
+; GCN-IR-NEXT:    s_sub_u32 s16, s16, s20
+; GCN-IR-NEXT:    s_subb_u32 s17, s17, s21
+; GCN-IR-NEXT:    s_add_u32 s14, s14, 1
+; GCN-IR-NEXT:    s_addc_u32 s15, s15, 0
+; GCN-IR-NEXT:    s_cselect_b64 s[20:21], -1, 0
+; GCN-IR-NEXT:    s_mov_b64 s[12:13], s[8:9]
+; GCN-IR-NEXT:    s_and_b64 vcc, exec, s[20:21]
+; GCN-IR-NEXT:    s_cbranch_vccz .LBB5_3
+; GCN-IR-NEXT:  .LBB5_4: ; %Flow7
+; GCN-IR-NEXT:    s_lshl_b64 s[2:3], s[10:11], 1
+; GCN-IR-NEXT:    s_or_b64 s[10:11], s[8:9], s[2:3]
+; GCN-IR-NEXT:  .LBB5_5: ; %udiv-end
+; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[6:7], s[4:5]
+; GCN-IR-NEXT:    s_xor_b64 s[6:7], s[10:11], s[4:5]
+; GCN-IR-NEXT:    s_sub_u32 s4, s6, s4
+; GCN-IR-NEXT:    s_subb_u32 s5, s7, s5
+; GCN-IR-NEXT:    v_mov_b32_e32 v0, s4
+; GCN-IR-NEXT:    s_mov_b32 s3, 0xf000
+; GCN-IR-NEXT:    s_mov_b32 s2, -1
+; GCN-IR-NEXT:    v_mov_b32_e32 v1, s5
+; GCN-IR-NEXT:    buffer_store_dwordx2 v[0:1], off, s[0:3], 0
 ; GCN-IR-NEXT:    s_endpgm
   %1 = ashr i64 %x, 32
   %2 = ashr i64 %y, 32

--- a/llvm/test/CodeGen/AMDGPU/srem64.ll
+++ b/llvm/test/CodeGen/AMDGPU/srem64.ll
@@ -874,80 +874,258 @@ define amdgpu_kernel void @s_test_srem31_64(ptr addrspace(1) %out, i64 %x, i64 %
 define amdgpu_kernel void @s_test_srem32_64(ptr addrspace(1) %out, i64 %x, i64 %y) {
 ; GCN-LABEL: s_test_srem32_64:
 ; GCN:       ; %bb.0:
-; GCN-NEXT:    s_load_dword s0, s[4:5], 0xe
-; GCN-NEXT:    s_mov_b32 s7, 0xf000
-; GCN-NEXT:    s_mov_b32 s6, -1
+; GCN-NEXT:    s_load_dwordx4 s[8:11], s[4:5], 0x9
+; GCN-NEXT:    s_load_dword s2, s[4:5], 0xe
 ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-NEXT:    s_abs_i32 s8, s0
-; GCN-NEXT:    v_cvt_f32_u32_e32 v0, s8
-; GCN-NEXT:    s_sub_i32 s0, 0, s8
+; GCN-NEXT:    s_ashr_i32 s4, s11, 31
+; GCN-NEXT:    s_ashr_i32 s0, s2, 31
+; GCN-NEXT:    s_add_u32 s2, s2, s0
+; GCN-NEXT:    s_mov_b32 s1, s0
+; GCN-NEXT:    s_addc_u32 s3, s0, s0
+; GCN-NEXT:    s_xor_b64 s[6:7], s[2:3], s[0:1]
+; GCN-NEXT:    v_cvt_f32_u32_e32 v0, s6
+; GCN-NEXT:    v_cvt_f32_u32_e32 v1, s7
+; GCN-NEXT:    s_sub_u32 s0, 0, s6
+; GCN-NEXT:    s_subb_u32 s1, 0, s7
+; GCN-NEXT:    s_mov_b32 s3, 0xf000
+; GCN-NEXT:    v_madmk_f32 v0, v1, 0x4f800000, v0
 ; GCN-NEXT:    v_rcp_f32_e32 v0, v0
-; GCN-NEXT:    v_mul_f32_e32 v0, 0x4f7ffffe, v0
+; GCN-NEXT:    v_mul_f32_e32 v0, 0x5f7ffffc, v0
+; GCN-NEXT:    v_mul_f32_e32 v1, 0x2f800000, v0
+; GCN-NEXT:    v_trunc_f32_e32 v1, v1
+; GCN-NEXT:    v_madmk_f32 v0, v1, 0xcf800000, v0
 ; GCN-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GCN-NEXT:    v_mul_lo_u32 v1, s0, v0
-; GCN-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x9
-; GCN-NEXT:    v_mul_hi_u32 v1, v0, v1
-; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-NEXT:    s_abs_i32 s2, s3
-; GCN-NEXT:    s_mov_b32 s5, s1
-; GCN-NEXT:    v_add_i32_e32 v0, vcc, v0, v1
-; GCN-NEXT:    v_mul_hi_u32 v0, s2, v0
-; GCN-NEXT:    s_mov_b32 s4, s0
-; GCN-NEXT:    s_ashr_i32 s0, s3, 31
-; GCN-NEXT:    v_readfirstlane_b32 s1, v0
-; GCN-NEXT:    s_mul_i32 s1, s1, s8
-; GCN-NEXT:    s_sub_i32 s1, s2, s1
-; GCN-NEXT:    s_sub_i32 s2, s1, s8
-; GCN-NEXT:    s_cmp_ge_u32 s1, s8
-; GCN-NEXT:    s_cselect_b32 s1, s2, s1
-; GCN-NEXT:    s_sub_i32 s2, s1, s8
-; GCN-NEXT:    s_cmp_ge_u32 s1, s8
-; GCN-NEXT:    s_cselect_b32 s1, s2, s1
-; GCN-NEXT:    s_xor_b32 s1, s1, s0
-; GCN-NEXT:    s_sub_i32 s0, s1, s0
-; GCN-NEXT:    s_ashr_i32 s1, s0, 31
-; GCN-NEXT:    v_mov_b32_e32 v0, s0
-; GCN-NEXT:    v_mov_b32_e32 v1, s1
-; GCN-NEXT:    buffer_store_dwordx2 v[0:1], off, s[4:7], 0
+; GCN-NEXT:    v_cvt_u32_f32_e32 v1, v1
+; GCN-NEXT:    v_mul_hi_u32 v2, s0, v0
+; GCN-NEXT:    v_readfirstlane_b32 s5, v1
+; GCN-NEXT:    v_readfirstlane_b32 s2, v0
+; GCN-NEXT:    s_mul_i32 s10, s0, s5
+; GCN-NEXT:    v_readfirstlane_b32 s14, v2
+; GCN-NEXT:    s_mul_i32 s12, s1, s2
+; GCN-NEXT:    s_mul_i32 s13, s0, s2
+; GCN-NEXT:    s_add_i32 s10, s14, s10
+; GCN-NEXT:    v_mul_hi_u32 v3, v0, s13
+; GCN-NEXT:    s_add_i32 s10, s10, s12
+; GCN-NEXT:    v_mul_hi_u32 v0, v0, s10
+; GCN-NEXT:    v_mul_hi_u32 v4, v1, s13
+; GCN-NEXT:    v_readfirstlane_b32 s12, v3
+; GCN-NEXT:    s_mul_i32 s14, s2, s10
+; GCN-NEXT:    v_mul_hi_u32 v1, v1, s10
+; GCN-NEXT:    s_add_u32 s12, s12, s14
+; GCN-NEXT:    v_readfirstlane_b32 s14, v0
+; GCN-NEXT:    s_addc_u32 s14, 0, s14
+; GCN-NEXT:    s_mul_i32 s13, s5, s13
+; GCN-NEXT:    v_readfirstlane_b32 s15, v4
+; GCN-NEXT:    s_add_u32 s12, s12, s13
+; GCN-NEXT:    s_addc_u32 s12, s14, s15
+; GCN-NEXT:    v_readfirstlane_b32 s13, v1
+; GCN-NEXT:    s_addc_u32 s13, s13, 0
+; GCN-NEXT:    s_mul_i32 s10, s5, s10
+; GCN-NEXT:    s_add_u32 s10, s12, s10
+; GCN-NEXT:    s_addc_u32 s12, 0, s13
+; GCN-NEXT:    s_add_u32 s10, s2, s10
+; GCN-NEXT:    v_mov_b32_e32 v0, s10
+; GCN-NEXT:    v_mul_hi_u32 v0, s0, v0
+; GCN-NEXT:    s_addc_u32 s5, s5, s12
+; GCN-NEXT:    s_mul_i32 s12, s0, s5
+; GCN-NEXT:    s_mul_i32 s1, s1, s10
+; GCN-NEXT:    v_readfirstlane_b32 s13, v0
+; GCN-NEXT:    s_add_i32 s12, s13, s12
+; GCN-NEXT:    s_mul_i32 s0, s0, s10
+; GCN-NEXT:    s_add_i32 s1, s12, s1
+; GCN-NEXT:    v_mov_b32_e32 v2, s0
+; GCN-NEXT:    v_mov_b32_e32 v0, s1
+; GCN-NEXT:    v_mul_hi_u32 v3, s5, v2
+; GCN-NEXT:    v_mul_hi_u32 v2, s10, v2
+; GCN-NEXT:    v_mul_hi_u32 v1, s5, v0
+; GCN-NEXT:    v_mul_hi_u32 v0, s10, v0
+; GCN-NEXT:    s_mul_i32 s13, s10, s1
+; GCN-NEXT:    v_readfirstlane_b32 s15, v2
+; GCN-NEXT:    s_add_u32 s13, s15, s13
+; GCN-NEXT:    v_readfirstlane_b32 s14, v0
+; GCN-NEXT:    s_mul_i32 s0, s5, s0
+; GCN-NEXT:    s_addc_u32 s14, 0, s14
+; GCN-NEXT:    v_readfirstlane_b32 s12, v3
+; GCN-NEXT:    s_add_u32 s0, s13, s0
+; GCN-NEXT:    s_addc_u32 s0, s14, s12
+; GCN-NEXT:    v_readfirstlane_b32 s12, v1
+; GCN-NEXT:    s_addc_u32 s12, s12, 0
+; GCN-NEXT:    s_mul_i32 s1, s5, s1
+; GCN-NEXT:    s_add_u32 s0, s0, s1
+; GCN-NEXT:    s_addc_u32 s1, 0, s12
+; GCN-NEXT:    s_add_u32 s12, s10, s0
+; GCN-NEXT:    s_addc_u32 s13, s5, s1
+; GCN-NEXT:    s_add_u32 s0, s11, s4
+; GCN-NEXT:    s_mov_b32 s5, s4
+; GCN-NEXT:    s_addc_u32 s1, s4, s4
+; GCN-NEXT:    s_xor_b64 s[10:11], s[0:1], s[4:5]
+; GCN-NEXT:    v_mov_b32_e32 v0, s13
+; GCN-NEXT:    v_mul_hi_u32 v1, s10, v0
+; GCN-NEXT:    v_mov_b32_e32 v2, s12
+; GCN-NEXT:    v_mul_hi_u32 v3, s10, v2
+; GCN-NEXT:    s_mov_b32 s0, s8
+; GCN-NEXT:    v_readfirstlane_b32 s8, v1
+; GCN-NEXT:    v_mul_hi_u32 v1, s11, v2
+; GCN-NEXT:    s_mul_i32 s1, s10, s13
+; GCN-NEXT:    v_readfirstlane_b32 s14, v3
+; GCN-NEXT:    v_mul_hi_u32 v0, s11, v0
+; GCN-NEXT:    s_add_u32 s1, s14, s1
+; GCN-NEXT:    s_addc_u32 s8, 0, s8
+; GCN-NEXT:    s_mul_i32 s12, s11, s12
+; GCN-NEXT:    v_readfirstlane_b32 s14, v1
+; GCN-NEXT:    s_add_u32 s1, s1, s12
+; GCN-NEXT:    s_addc_u32 s1, s8, s14
+; GCN-NEXT:    v_readfirstlane_b32 s8, v0
+; GCN-NEXT:    s_addc_u32 s8, s8, 0
+; GCN-NEXT:    s_mul_i32 s12, s11, s13
+; GCN-NEXT:    s_add_u32 s12, s1, s12
+; GCN-NEXT:    v_mov_b32_e32 v0, s12
+; GCN-NEXT:    v_mul_hi_u32 v0, s6, v0
+; GCN-NEXT:    s_addc_u32 s8, 0, s8
+; GCN-NEXT:    s_mov_b32 s1, s9
+; GCN-NEXT:    s_mul_i32 s8, s6, s8
+; GCN-NEXT:    v_readfirstlane_b32 s9, v0
+; GCN-NEXT:    s_add_i32 s8, s9, s8
+; GCN-NEXT:    s_mul_i32 s9, s7, s12
+; GCN-NEXT:    s_add_i32 s14, s8, s9
+; GCN-NEXT:    s_sub_i32 s13, s11, s14
+; GCN-NEXT:    s_mul_i32 s8, s6, s12
+; GCN-NEXT:    s_sub_u32 s10, s10, s8
+; GCN-NEXT:    s_cselect_b64 s[8:9], -1, 0
+; GCN-NEXT:    s_subb_u32 s15, s13, s7
+; GCN-NEXT:    s_sub_u32 s16, s10, s6
+; GCN-NEXT:    s_cselect_b64 s[12:13], -1, 0
+; GCN-NEXT:    s_subb_u32 s17, s15, 0
+; GCN-NEXT:    s_cmp_ge_u32 s17, s7
+; GCN-NEXT:    s_cselect_b32 s18, -1, 0
+; GCN-NEXT:    s_cmp_ge_u32 s16, s6
+; GCN-NEXT:    s_cselect_b32 s19, -1, 0
+; GCN-NEXT:    s_cmp_eq_u32 s17, s7
+; GCN-NEXT:    s_cselect_b32 s18, s19, s18
+; GCN-NEXT:    s_or_b32 s12, s12, s13
+; GCN-NEXT:    s_subb_u32 s12, s15, s7
+; GCN-NEXT:    s_sub_u32 s13, s16, s6
+; GCN-NEXT:    s_subb_u32 s12, s12, 0
+; GCN-NEXT:    s_cmp_lg_u32 s18, 0
+; GCN-NEXT:    s_cselect_b32 s13, s13, s16
+; GCN-NEXT:    s_cselect_b32 s12, s12, s17
+; GCN-NEXT:    s_or_b32 s8, s8, s9
+; GCN-NEXT:    s_subb_u32 s8, s11, s14
+; GCN-NEXT:    s_cmp_ge_u32 s8, s7
+; GCN-NEXT:    s_cselect_b32 s9, -1, 0
+; GCN-NEXT:    s_cmp_ge_u32 s10, s6
+; GCN-NEXT:    s_cselect_b32 s6, -1, 0
+; GCN-NEXT:    s_cmp_eq_u32 s8, s7
+; GCN-NEXT:    s_cselect_b32 s6, s6, s9
+; GCN-NEXT:    s_cmp_lg_u32 s6, 0
+; GCN-NEXT:    s_cselect_b32 s7, s12, s8
+; GCN-NEXT:    s_cselect_b32 s6, s13, s10
+; GCN-NEXT:    s_xor_b64 s[6:7], s[6:7], s[4:5]
+; GCN-NEXT:    s_sub_u32 s6, s6, s4
+; GCN-NEXT:    s_subb_u32 s7, s7, s4
+; GCN-NEXT:    v_mov_b32_e32 v0, s6
+; GCN-NEXT:    s_mov_b32 s2, -1
+; GCN-NEXT:    v_mov_b32_e32 v1, s7
+; GCN-NEXT:    buffer_store_dwordx2 v[0:1], off, s[0:3], 0
 ; GCN-NEXT:    s_endpgm
 ;
 ; GCN-IR-LABEL: s_test_srem32_64:
-; GCN-IR:       ; %bb.0:
-; GCN-IR-NEXT:    s_load_dword s0, s[4:5], 0xe
-; GCN-IR-NEXT:    s_mov_b32 s7, 0xf000
-; GCN-IR-NEXT:    s_mov_b32 s6, -1
-; GCN-IR-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-IR-NEXT:    s_abs_i32 s8, s0
-; GCN-IR-NEXT:    v_cvt_f32_u32_e32 v0, s8
-; GCN-IR-NEXT:    s_sub_i32 s0, 0, s8
-; GCN-IR-NEXT:    v_rcp_f32_e32 v0, v0
-; GCN-IR-NEXT:    v_mul_f32_e32 v0, 0x4f7ffffe, v0
-; GCN-IR-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GCN-IR-NEXT:    v_mul_lo_u32 v1, s0, v0
+; GCN-IR:       ; %bb.0: ; %_udiv-special-cases
 ; GCN-IR-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x9
-; GCN-IR-NEXT:    v_mul_hi_u32 v1, v0, v1
+; GCN-IR-NEXT:    s_load_dwordx2 s[4:5], s[4:5], 0xd
+; GCN-IR-NEXT:    s_mov_b32 s13, 0
 ; GCN-IR-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-IR-NEXT:    s_abs_i32 s2, s3
-; GCN-IR-NEXT:    s_mov_b32 s5, s1
-; GCN-IR-NEXT:    v_add_i32_e32 v0, vcc, v0, v1
-; GCN-IR-NEXT:    v_mul_hi_u32 v0, s2, v0
-; GCN-IR-NEXT:    s_mov_b32 s4, s0
-; GCN-IR-NEXT:    s_ashr_i32 s0, s3, 31
-; GCN-IR-NEXT:    v_readfirstlane_b32 s1, v0
-; GCN-IR-NEXT:    s_mul_i32 s1, s1, s8
-; GCN-IR-NEXT:    s_sub_i32 s1, s2, s1
-; GCN-IR-NEXT:    s_sub_i32 s2, s1, s8
-; GCN-IR-NEXT:    s_cmp_ge_u32 s1, s8
-; GCN-IR-NEXT:    s_cselect_b32 s1, s2, s1
-; GCN-IR-NEXT:    s_sub_i32 s2, s1, s8
-; GCN-IR-NEXT:    s_cmp_ge_u32 s1, s8
-; GCN-IR-NEXT:    s_cselect_b32 s1, s2, s1
-; GCN-IR-NEXT:    s_xor_b32 s1, s1, s0
-; GCN-IR-NEXT:    s_sub_i32 s0, s1, s0
-; GCN-IR-NEXT:    s_ashr_i32 s1, s0, 31
-; GCN-IR-NEXT:    v_mov_b32_e32 v0, s0
-; GCN-IR-NEXT:    v_mov_b32_e32 v1, s1
-; GCN-IR-NEXT:    buffer_store_dwordx2 v[0:1], off, s[4:7], 0
+; GCN-IR-NEXT:    s_ashr_i32 s7, s3, 31
+; GCN-IR-NEXT:    s_mov_b32 s6, s3
+; GCN-IR-NEXT:    s_ashr_i32 s3, s5, 31
+; GCN-IR-NEXT:    s_mov_b32 s2, s5
+; GCN-IR-NEXT:    s_mov_b32 s4, s7
+; GCN-IR-NEXT:    s_mov_b32 s5, s7
+; GCN-IR-NEXT:    s_xor_b64 s[8:9], s[6:7], s[4:5]
+; GCN-IR-NEXT:    s_sub_u32 s6, s8, s7
+; GCN-IR-NEXT:    s_subb_u32 s7, s9, s7
+; GCN-IR-NEXT:    s_mov_b32 s8, s3
+; GCN-IR-NEXT:    s_mov_b32 s9, s3
+; GCN-IR-NEXT:    s_xor_b64 s[8:9], s[2:3], s[8:9]
+; GCN-IR-NEXT:    s_sub_u32 s8, s8, s3
+; GCN-IR-NEXT:    s_subb_u32 s9, s9, s3
+; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[2:3], s[8:9], 0
+; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[10:11], s[6:7], 0
+; GCN-IR-NEXT:    s_flbit_i32_b64 s12, s[8:9]
+; GCN-IR-NEXT:    s_or_b64 s[10:11], s[2:3], s[10:11]
+; GCN-IR-NEXT:    s_flbit_i32_b64 s18, s[6:7]
+; GCN-IR-NEXT:    s_sub_u32 s14, s12, s18
+; GCN-IR-NEXT:    s_subb_u32 s15, 0, 0
+; GCN-IR-NEXT:    v_cmp_gt_u64_e64 s[16:17], s[14:15], 63
+; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[20:21], s[14:15], 63
+; GCN-IR-NEXT:    s_or_b64 s[16:17], s[10:11], s[16:17]
+; GCN-IR-NEXT:    s_and_b64 s[10:11], s[16:17], exec
+; GCN-IR-NEXT:    s_cselect_b32 s11, 0, s7
+; GCN-IR-NEXT:    s_cselect_b32 s10, 0, s6
+; GCN-IR-NEXT:    s_or_b64 s[16:17], s[16:17], s[20:21]
+; GCN-IR-NEXT:    s_mov_b64 s[2:3], 0
+; GCN-IR-NEXT:    s_andn2_b64 vcc, exec, s[16:17]
+; GCN-IR-NEXT:    s_cbranch_vccz .LBB7_5
+; GCN-IR-NEXT:  ; %bb.1: ; %udiv-bb1
+; GCN-IR-NEXT:    s_add_u32 s16, s14, 1
+; GCN-IR-NEXT:    s_addc_u32 s10, s15, 0
+; GCN-IR-NEXT:    s_cselect_b64 s[10:11], -1, 0
+; GCN-IR-NEXT:    s_sub_i32 s14, 63, s14
+; GCN-IR-NEXT:    s_andn2_b64 vcc, exec, s[10:11]
+; GCN-IR-NEXT:    s_lshl_b64 s[10:11], s[6:7], s14
+; GCN-IR-NEXT:    s_cbranch_vccz .LBB7_4
+; GCN-IR-NEXT:  ; %bb.2: ; %udiv-preheader
+; GCN-IR-NEXT:    s_lshr_b64 s[14:15], s[6:7], s16
+; GCN-IR-NEXT:    s_add_u32 s16, s8, -1
+; GCN-IR-NEXT:    s_addc_u32 s17, s9, -1
+; GCN-IR-NEXT:    s_not_b64 s[2:3], s[12:13]
+; GCN-IR-NEXT:    s_add_u32 s18, s2, s18
+; GCN-IR-NEXT:    s_addc_u32 s19, s3, 0
+; GCN-IR-NEXT:    s_mov_b64 s[12:13], 0
+; GCN-IR-NEXT:    s_mov_b32 s3, 0
+; GCN-IR-NEXT:  .LBB7_3: ; %udiv-do-while
+; GCN-IR-NEXT:    ; =>This Inner Loop Header: Depth=1
+; GCN-IR-NEXT:    s_lshl_b64 s[14:15], s[14:15], 1
+; GCN-IR-NEXT:    s_lshr_b32 s2, s11, 31
+; GCN-IR-NEXT:    s_lshl_b64 s[10:11], s[10:11], 1
+; GCN-IR-NEXT:    s_or_b64 s[14:15], s[14:15], s[2:3]
+; GCN-IR-NEXT:    s_or_b64 s[10:11], s[12:13], s[10:11]
+; GCN-IR-NEXT:    s_sub_u32 s2, s16, s14
+; GCN-IR-NEXT:    s_subb_u32 s2, s17, s15
+; GCN-IR-NEXT:    s_ashr_i32 s12, s2, 31
+; GCN-IR-NEXT:    s_mov_b32 s13, s12
+; GCN-IR-NEXT:    s_and_b32 s2, s12, 1
+; GCN-IR-NEXT:    s_and_b64 s[20:21], s[12:13], s[8:9]
+; GCN-IR-NEXT:    s_sub_u32 s14, s14, s20
+; GCN-IR-NEXT:    s_subb_u32 s15, s15, s21
+; GCN-IR-NEXT:    s_add_u32 s18, s18, 1
+; GCN-IR-NEXT:    s_addc_u32 s19, s19, 0
+; GCN-IR-NEXT:    s_cselect_b64 s[20:21], -1, 0
+; GCN-IR-NEXT:    s_mov_b64 s[12:13], s[2:3]
+; GCN-IR-NEXT:    s_and_b64 vcc, exec, s[20:21]
+; GCN-IR-NEXT:    s_cbranch_vccz .LBB7_3
+; GCN-IR-NEXT:  .LBB7_4: ; %Flow7
+; GCN-IR-NEXT:    s_lshl_b64 s[10:11], s[10:11], 1
+; GCN-IR-NEXT:    s_or_b64 s[10:11], s[2:3], s[10:11]
+; GCN-IR-NEXT:  .LBB7_5: ; %udiv-end
+; GCN-IR-NEXT:    v_mov_b32_e32 v0, s10
+; GCN-IR-NEXT:    v_mul_hi_u32 v0, s8, v0
+; GCN-IR-NEXT:    s_mul_i32 s11, s8, s11
+; GCN-IR-NEXT:    s_mul_i32 s9, s9, s10
+; GCN-IR-NEXT:    s_mul_i32 s8, s8, s10
+; GCN-IR-NEXT:    v_readfirstlane_b32 s12, v0
+; GCN-IR-NEXT:    s_add_i32 s11, s12, s11
+; GCN-IR-NEXT:    s_add_i32 s11, s11, s9
+; GCN-IR-NEXT:    s_sub_u32 s6, s6, s8
+; GCN-IR-NEXT:    s_subb_u32 s7, s7, s11
+; GCN-IR-NEXT:    s_xor_b64 s[6:7], s[6:7], s[4:5]
+; GCN-IR-NEXT:    s_sub_u32 s4, s6, s4
+; GCN-IR-NEXT:    s_subb_u32 s5, s7, s5
+; GCN-IR-NEXT:    v_mov_b32_e32 v0, s4
+; GCN-IR-NEXT:    s_mov_b32 s3, 0xf000
+; GCN-IR-NEXT:    s_mov_b32 s2, -1
+; GCN-IR-NEXT:    v_mov_b32_e32 v1, s5
+; GCN-IR-NEXT:    buffer_store_dwordx2 v[0:1], off, s[0:3], 0
 ; GCN-IR-NEXT:    s_endpgm
   %1 = ashr i64 %x, 32
   %2 = ashr i64 %y, 32


### PR DESCRIPTION
Do not implement 64-bit signed division with 32-bit division if operands are only constrained to a 32-bit signed range.
-2147483648/-1  != -2147483648/1, but their lower 32-bits are identical.  32-bit division cannot generate the correct result for both sets of operands.  Only use 32-bit division if operands are constrained to a 31-bit signed range.

Bug appears in both AMDGPUCodeGenPrepare.cpp and AMDGPUISelLowering.cpp.

Tested in https://github.com/llvm/llvm-test-suite/pull/428.