### PR TITLE
[z/OS][Clang] Add wrapper headers to avoid macro name conflicts

### DIFF
--- a/clang/lib/Headers/CMakeLists.txt
+++ b/clang/lib/Headers/CMakeLists.txt
@@ -407,6 +407,14 @@ set(llvm_libc_wrapper_files
 
 set(zos_wrapper_files
   zos_wrappers/builtins.h
+  zos_wrappers/grp.h
+  zos_wrappers/locale.h
+  zos_wrappers/math.h
+  zos_wrappers/poll.h
+  zos_wrappers/stdlib.h
+  zos_wrappers/string.h
+  zos_wrappers/time.h
+  zos_wrappers/variant.h
 )
 
 include(GetClangResourceDir)

--- a/clang/lib/Headers/zos_wrappers/grp.h
+++ b/clang/lib/Headers/zos_wrappers/grp.h
@@ -1,0 +1,19 @@
+/*===----------------------------- grp.h ----------------------------------===
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *===-----------------------------------------------------------------------===
+ */
+
+#ifndef __ZOS_WRAPPERS_GRP_H
+#define __ZOS_WRAPPERS_GRP_H
+#if defined(__MVS__)
+#include_next <grp.h>
+#ifdef __grp
+#undef __grp
+#define __grp __grp
+#endif
+#endif /* defined(__MVS__) */
+#endif /* __ZOS_WRAPPERS_GRP_H */

--- a/clang/lib/Headers/zos_wrappers/grp.h
+++ b/clang/lib/Headers/zos_wrappers/grp.h
@@ -9,11 +9,11 @@
 
 #ifndef __ZOS_WRAPPERS_GRP_H
 #define __ZOS_WRAPPERS_GRP_H
-#if defined(__MVS__)
+#if __has_include_next(<grp.h>)
 #include_next <grp.h>
 #ifdef __grp
 #undef __grp
 #define __grp __grp
 #endif
-#endif /* defined(__MVS__) */
+#endif /* __has_include_next(<grp.h>) */
 #endif /* __ZOS_WRAPPERS_GRP_H */

--- a/clang/lib/Headers/zos_wrappers/locale.h
+++ b/clang/lib/Headers/zos_wrappers/locale.h
@@ -1,0 +1,19 @@
+/*===----------------------------- locale.h ---------------------------------===
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *===-----------------------------------------------------------------------===
+ */
+
+#ifndef __ZOS_WRAPPERS_LOCALE_H
+#define __ZOS_WRAPPERS_LOCALE_H
+#if defined(__MVS__)
+#include_next <locale.h>
+#ifdef __locale
+#undef __locale
+#define __locale __locale
+#endif
+#endif /* defined(__MVS__) */
+#endif /* __ZOS_WRAPPERS_LOCALE_H */

--- a/clang/lib/Headers/zos_wrappers/locale.h
+++ b/clang/lib/Headers/zos_wrappers/locale.h
@@ -9,11 +9,11 @@
 
 #ifndef __ZOS_WRAPPERS_LOCALE_H
 #define __ZOS_WRAPPERS_LOCALE_H
-#if defined(__MVS__)
+#if __has_include_next(<locale.h>)
 #include_next <locale.h>
 #ifdef __locale
 #undef __locale
 #define __locale __locale
 #endif
-#endif /* defined(__MVS__) */
+#endif /* __has_include_next(<locale.h>) */
 #endif /* __ZOS_WRAPPERS_LOCALE_H */

--- a/clang/lib/Headers/zos_wrappers/math.h
+++ b/clang/lib/Headers/zos_wrappers/math.h
@@ -9,7 +9,7 @@
 
 #ifndef __ZOS_WRAPPERS_MATH_H
 #define __ZOS_WRAPPERS_MATH_H
-#if defined(__MVS__)
+#if __has_include_next(<math.h>)
 #include_next <math.h>
 #ifdef __math
 #undef __math
@@ -27,5 +27,5 @@ extern "C"
 #pragma map(tgamma, "\174\174TGMAH9")
 #endif
 #endif
-#endif /* defined(__MVS__) */
+#endif /* __has_include_next(<math.h>) */
 #endif /* __ZOS_WRAPPERS_MATH_H */

--- a/clang/lib/Headers/zos_wrappers/math.h
+++ b/clang/lib/Headers/zos_wrappers/math.h
@@ -1,0 +1,31 @@
+/*===----------------------------- math.h ----------------------------------===
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *===-----------------------------------------------------------------------===
+ */
+
+#ifndef __ZOS_WRAPPERS_MATH_H
+#define __ZOS_WRAPPERS_MATH_H
+#if defined(__MVS__)
+#include_next <math.h>
+#ifdef __math
+#undef __math
+#define __math __math
+#endif
+#ifndef __BFP__
+#ifdef __cplusplus
+extern "C"
+#endif
+    double fabs(double x) __THROW;
+#endif
+#if !defined(__LP64__) && !defined(__BFP__)
+#ifdef __C99
+#pragma map(tgammaf, "\174\174TGMFH9")
+#pragma map(tgamma, "\174\174TGMAH9")
+#endif
+#endif
+#endif /* defined(__MVS__) */
+#endif /* __ZOS_WRAPPERS_MATH_H */

--- a/clang/lib/Headers/zos_wrappers/poll.h
+++ b/clang/lib/Headers/zos_wrappers/poll.h
@@ -9,11 +9,11 @@
 
 #ifndef __ZOS_WRAPPERS_POLL_H
 #define __ZOS_WRAPPERS_POLL_H
-#if defined(__MVS__)
+#if __has_include_next(<poll.h>)
 #include_next <poll.h>
 #ifdef __poll
 #undef __poll
 #define __poll __poll
 #endif
-#endif /* defined(__MVS__) */
+#endif /* __has_include_next(<poll.h>) */
 #endif /* __ZOS_WRAPPERS_POLL_H */

--- a/clang/lib/Headers/zos_wrappers/poll.h
+++ b/clang/lib/Headers/zos_wrappers/poll.h
@@ -1,0 +1,19 @@
+/*===----------------------------- poll.h ----------------------------------===
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *===-----------------------------------------------------------------------===
+ */
+
+#ifndef __ZOS_WRAPPERS_POLL_H
+#define __ZOS_WRAPPERS_POLL_H
+#if defined(__MVS__)
+#include_next <poll.h>
+#ifdef __poll
+#undef __poll
+#define __poll __poll
+#endif
+#endif /* defined(__MVS__) */
+#endif /* __ZOS_WRAPPERS_POLL_H */

--- a/clang/lib/Headers/zos_wrappers/stdlib.h
+++ b/clang/lib/Headers/zos_wrappers/stdlib.h
@@ -9,12 +9,12 @@
 
 #ifndef __ZOS_WRAPPERS_STDLIB_H
 #define __ZOS_WRAPPERS_STDLIB_H
-#if defined(__MVS__)
+#if __has_include_next(<stdlib.h>)
 #include_next <stdlib.h>
 #ifdef _EXT
 #ifndef __CS1
 #undef __cs
 #endif
 #endif /* _EXT */
-#endif /* defined(__MVS__) */
+#endif /* __has_include_next(<stdlib.h>) */
 #endif /* __ZOS_WRAPPERS_STDLIB_H */

--- a/clang/lib/Headers/zos_wrappers/stdlib.h
+++ b/clang/lib/Headers/zos_wrappers/stdlib.h
@@ -1,0 +1,20 @@
+/*===----------------------------- stdlib.h --------------------------------===
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *===-----------------------------------------------------------------------===
+ */
+
+#ifndef __ZOS_WRAPPERS_STDLIB_H
+#define __ZOS_WRAPPERS_STDLIB_H
+#if defined(__MVS__)
+#include_next <stdlib.h>
+#ifdef _EXT
+#ifndef __CS1
+#undef __cs
+#endif
+#endif /* _EXT */
+#endif /* defined(__MVS__) */
+#endif /* __ZOS_WRAPPERS_STDLIB_H */

--- a/clang/lib/Headers/zos_wrappers/string.h
+++ b/clang/lib/Headers/zos_wrappers/string.h
@@ -9,11 +9,11 @@
 
 #ifndef __ZOS_WRAPPERS_STRING_H
 #define __ZOS_WRAPPERS_STRING_H
-#if defined(__MVS__)
+#if __has_include_next(<string.h>)
 #include_next <string.h>
 #ifdef __string
 #undef __string
 #define __string __string
 #endif
-#endif /* defined(__MVS__) */
+#endif /* __has_include_next(<string.h>) */
 #endif /* __ZOS_WRAPPERS_STRING_H */

--- a/clang/lib/Headers/zos_wrappers/string.h
+++ b/clang/lib/Headers/zos_wrappers/string.h
@@ -1,0 +1,19 @@
+/*===--------------------------- string.h ----------------------------------===
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *===-----------------------------------------------------------------------===
+ */
+
+#ifndef __ZOS_WRAPPERS_STRING_H
+#define __ZOS_WRAPPERS_STRING_H
+#if defined(__MVS__)
+#include_next <string.h>
+#ifdef __string
+#undef __string
+#define __string __string
+#endif
+#endif /* defined(__MVS__) */
+#endif /* __ZOS_WRAPPERS_STRING_H */

--- a/clang/lib/Headers/zos_wrappers/time.h
+++ b/clang/lib/Headers/zos_wrappers/time.h
@@ -9,11 +9,11 @@
 
 #ifndef __ZOS_WRAPPERS_TIME_H
 #define __ZOS_WRAPPERS_TIME_H
-#if defined(__MVS__)
+#if __has_include_next(<time.h>)
 #include_next <time.h>
 #ifdef __time
 #undef __time
 #define __time __time
 #endif
-#endif /* defined(__MVS__) */
+#endif /* __has_include_next(<time.h>) */
 #endif /* __ZOS_WRAPPERS_TIME_H */

--- a/clang/lib/Headers/zos_wrappers/time.h
+++ b/clang/lib/Headers/zos_wrappers/time.h
@@ -1,0 +1,19 @@
+/*===----------------------------- time.h ----------------------------------===
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *===-----------------------------------------------------------------------===
+ */
+
+#ifndef __ZOS_WRAPPERS_TIME_H
+#define __ZOS_WRAPPERS_TIME_H
+#if defined(__MVS__)
+#include_next <time.h>
+#ifdef __time
+#undef __time
+#define __time __time
+#endif
+#endif /* defined(__MVS__) */
+#endif /* __ZOS_WRAPPERS_TIME_H */

--- a/clang/lib/Headers/zos_wrappers/variant.h
+++ b/clang/lib/Headers/zos_wrappers/variant.h
@@ -1,0 +1,19 @@
+/*===-------------------------- variant.h ----------------------------------===
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *===-----------------------------------------------------------------------===
+ */
+
+#ifndef __ZOS_WRAPPERS_VARIANT_H
+#define __ZOS_WRAPPERS_VARIANT_H
+#if defined(__MVS__)
+#include_next <variant.h>
+#ifdef __variant
+#undef __variant
+#define __variant __variant
+#endif
+#endif /* defined(__MVS__) */
+#endif /* __ZOS_WRAPPERS_VARIANT_H */

--- a/clang/lib/Headers/zos_wrappers/variant.h
+++ b/clang/lib/Headers/zos_wrappers/variant.h
@@ -9,11 +9,11 @@
 
 #ifndef __ZOS_WRAPPERS_VARIANT_H
 #define __ZOS_WRAPPERS_VARIANT_H
-#if defined(__MVS__)
+#if __has_include_next(<variant.h>)
 #include_next <variant.h>
 #ifdef __variant
 #undef __variant
 #define __variant __variant
 #endif
-#endif /* defined(__MVS__) */
+#endif /* __has_include_next(<variant.h>) */
 #endif /* __ZOS_WRAPPERS_VARIANT_H */

--- a/clang/test/Headers/Inputs/zos/usr/include/grp.h
+++ b/clang/test/Headers/Inputs/zos/usr/include/grp.h
@@ -1,0 +1,1 @@
+#define __grp 1

--- a/clang/test/Headers/Inputs/zos/usr/include/locale.h
+++ b/clang/test/Headers/Inputs/zos/usr/include/locale.h
@@ -1,0 +1,1 @@
+#define __locale 1

--- a/clang/test/Headers/Inputs/zos/usr/include/math.h
+++ b/clang/test/Headers/Inputs/zos/usr/include/math.h
@@ -1,0 +1,2 @@
+#define __math 1
+#define __THROW

--- a/clang/test/Headers/Inputs/zos/usr/include/poll.h
+++ b/clang/test/Headers/Inputs/zos/usr/include/poll.h
@@ -1,0 +1,1 @@
+#define __poll 1

--- a/clang/test/Headers/Inputs/zos/usr/include/stdlib.h
+++ b/clang/test/Headers/Inputs/zos/usr/include/stdlib.h
@@ -1,0 +1,1 @@
+#define __cs 1

--- a/clang/test/Headers/Inputs/zos/usr/include/string.h
+++ b/clang/test/Headers/Inputs/zos/usr/include/string.h
@@ -1,0 +1,1 @@
+#define __string 1

--- a/clang/test/Headers/Inputs/zos/usr/include/time.h
+++ b/clang/test/Headers/Inputs/zos/usr/include/time.h
@@ -1,0 +1,1 @@
+#define __time 1

--- a/clang/test/Headers/Inputs/zos/usr/include/variant.h
+++ b/clang/test/Headers/Inputs/zos/usr/include/variant.h
@@ -1,0 +1,1 @@
+#define __variant 1

--- a/clang/test/Headers/zos-guard.c
+++ b/clang/test/Headers/zos-guard.c
@@ -1,0 +1,19 @@
+//RUN: %clang -c  --target=s390x-ibm-zos %s -mzos-sys-include=%S/Inputs/zos/usr/include -Xclang -verify
+
+// expected-no-diagnostics
+
+#include <grp.h>
+#include <locale.h>
+#include <math.h>
+#include <poll.h>
+#include <string.h>
+#include <time.h>
+#include <variant.h>
+
+int __grp;
+int __locale;
+int __math;
+int __poll;
+int __string;
+int __time;
+int __variant;


### PR DESCRIPTION
Some z/OS system headers define macros (e.g. __time, __math) that conflict with
user identifiers and break compilation. These wrappers include the system headers
and neutralize the problematic macros.