### PR TITLE
[compiler-rt] Fix default builtins target _Float16 detection on x86_64/i386

### DIFF
--- a/compiler-rt/cmake/builtin-config-ix.cmake
+++ b/compiler-rt/cmake/builtin-config-ix.cmake
@@ -284,10 +284,16 @@ else()
 
   # COMPILER_RT_HAS_${arch}_* defines that are shared between lib/builtins/ and test/builtins/
   foreach (arch ${BUILTIN_SUPPORTED_ARCH})
+    cmake_push_check_state()
+    list(APPEND CMAKE_REQUIRED_FLAGS
+      ${TARGET_${arch}_CFLAGS})
+    list(JOIN CMAKE_REQUIRED_FLAGS " " CMAKE_REQUIRED_FLAGS)
+
     # NOTE: The corresponding check for if(APPLE) is in CompilerRTDarwinUtils.cmake
     check_c_source_compiles("_Float16 foo(_Float16 x) { return x; }
                               int main(void) { return 0; }"
                             COMPILER_RT_HAS_${arch}_FLOAT16)
+    cmake_pop_check_state()
   endforeach()
 endif()
 


### PR DESCRIPTION
This fixes errors from the following on x86 freebsd:

```
cmake -G 'Ninja' \
      -DCMAKE_BUILD_TYPE=Release \
      ../compiler-rt/lib/builtins
```

```
[2/280] Building C object CMakeFiles/clang_rt.builtins-i386.dir/extendhfsf2.c.o
FAILED: [code=1] CMakeFiles/clang_rt.builtins-i386.dir/extendhfsf2.c.o
/usr/bin/cc -DVISIBILITY_HIDDEN -I/root/llvm-project/compiler-rt/lib/builtins/../../../third-party/siphash/include -O3 -DNDEBUG -std=gnu11 -m32 -fno-lto -nostdinc++ -Wno-c2y-extensions -fPIC -fno-builtin -fvisibility=hidden -fomit-frame-pointer -DCOMPILER_RT_HAS_FLOAT16 -MD -MT CMakeFiles/clang_rt.builtins-i386.dir/extendhfsf2.c.o -MF CMakeFiles/clang_rt.builtins-i386.dir/extendhfsf2.c.o.d -o CMakeFiles/clang_rt.builtins-i386.dir/extendhfsf2.c.o -c /root/llvm-project/compiler-rt/lib/builtins/extendhfsf2.c
In file included from /root/llvm-project/compiler-rt/lib/builtins/extendhfsf2.c:11:
In file included from /root/llvm-project/compiler-rt/lib/builtins/fp_extend_impl.inc:38:
/root/llvm-project/compiler-rt/lib/builtins/fp_extend.h:57:9: error: _Float16 is not supported on this target
   57 | typedef _Float16 src_t;
      |         ^
1 error generated.
```

Caused by #171941.

rdar://178447969