### PR TITLE
[BOLT] Instrument static PIEs through entry point

### DIFF
--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -38,6 +38,7 @@
 #include "bolt/Utils/Utils.h"
 #include "llvm/ADT/AddressRanges.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/BinaryFormat/ELF.h"
 #include "llvm/DebugInfo/DWARF/DWARFContext.h"
 #include "llvm/DebugInfo/DWARF/DWARFDebugFrame.h"
 #include "llvm/MC/MCAsmBackend.h"
@@ -2415,7 +2416,7 @@ void RewriteInstance::adjustCommandLineOptions() {
   }
 
   if (opts::Instrument && opts::RuntimeLibInitHook == opts::RLIH_ENTRY_POINT &&
-      !BC->HasInterpHeader) {
+      !BC->HasInterpHeader && !BC->IsStaticExecutable) {
     BC->errs()
         << "BOLT-WARNING: adjusted runtime-lib-init-hook to 'init' due to "
            "absence of INTERP header\n";
@@ -6070,7 +6071,6 @@ Error RewriteInstance::readELFDynamic(ELFObjectFile<ELFT> *File) {
 
   if (!DynamicPhdr) {
     BC->outs() << "BOLT-INFO: static input executable detected\n";
-    // TODO: static PIE executable might have dynamic header
     BC->IsStaticExecutable = true;
     return Error::success();
   }
@@ -6087,6 +6087,14 @@ Error RewriteInstance::readELFDynamic(ELFObjectFile<ELFT> *File) {
 
   for (const Elf_Dyn &Dyn : DynamicEntries) {
     switch (Dyn.d_tag) {
+    case ELF::DT_FLAGS_1: {
+      auto Flags = Dyn.getVal();
+      if (Flags & ELF::DF_1_PIE && !BC->HasInterpHeader) {
+        BC->outs() << "BOLT-INFO: static pie executable detected\n";
+        BC->IsStaticExecutable = true;
+      }
+      break;
+    }
     case ELF::DT_INIT:
       BC->InitAddress = Dyn.getPtr();
       break;

--- a/bolt/test/AArch64/instrument-no-fini.s
+++ b/bolt/test/AArch64/instrument-no-fini.s
@@ -3,10 +3,12 @@
 # REQUIRES: system-linux,bolt-runtime,target=aarch64{{.*}}
 
 # RUN: llvm-mc -triple aarch64 -filetype=obj %s -o %t.o
-# RUN: ld.lld -q -pie -o %t.exe %t.o
+# RUN: %clang -nostartfiles -nostdlib -Wl,-q -Wl,-pie -o %t.exe %t.o
 # RUN: llvm-readelf -d %t.exe | FileCheck --check-prefix=CHECK-NO-FINI %s
-# RUN: not llvm-bolt --instrument -o %t.out %t.exe 2>&1 | FileCheck %s --check-prefix=CHECK-BOLT-FAIL
-# RUN: llvm-bolt --instrument --instrumentation-sleep-time=1 -o %t.out %t.exe 2>&1 | FileCheck %s --check-prefix=CHECK-BOLT-PASS
+# RUN: not llvm-bolt --instrument --runtime-lib-init-hook=init -o %t.out %t.exe 2>&1 \
+# RUN:   | FileCheck %s --check-prefix=CHECK-BOLT-FAIL
+# RUN: llvm-bolt --instrument --runtime-lib-init-hook=init --instrumentation-sleep-time=1 -o %t.out %t.exe 2>&1 \
+# RUN:   | FileCheck %s --check-prefix=CHECK-BOLT-PASS
 
 # CHECK-NO-FINI: INIT
 # CHECK-NO-FINI-NOT: FINI

--- a/bolt/test/X86/instrument-no-fini.s
+++ b/bolt/test/X86/instrument-no-fini.s
@@ -3,10 +3,12 @@
 # REQUIRES: system-linux,bolt-runtime,target=x86_64-{{.*}}
 
 # RUN: llvm-mc -triple x86_64 -filetype=obj %s -o %t.o
-# RUN: ld.lld -q -pie -o %t.exe %t.o
+# RUN: %clang -nostartfiles -nostdlib -Wl,-q -Wl,-pie -o %t.exe %t.o
 # RUN: llvm-readelf -d %t.exe | FileCheck --check-prefix=CHECK-NO-FINI %s
-# RUN: not llvm-bolt --instrument -o %t.out %t.exe 2>&1 | FileCheck %s --check-prefix=CHECK-BOLT-FAIL
-# RUN: llvm-bolt --instrument --instrumentation-sleep-time=1 -o %t.out %t.exe 2>&1 | FileCheck %s --check-prefix=CHECK-BOLT-PASS
+# RUN: not llvm-bolt --instrument --runtime-lib-init-hook=init -o %t.out %t.exe 2>&1 \
+# RUN:   | FileCheck %s --check-prefix=CHECK-BOLT-FAIL
+# RUN: llvm-bolt --instrument --runtime-lib-init-hook=init --instrumentation-sleep-time=1 -o %t.out %t.exe 2>&1 \
+# RUN:   | FileCheck %s --check-prefix=CHECK-BOLT-PASS
 
 # CHECK-NO-FINI: INIT
 # CHECK-NO-FINI-NOT: FINI

--- a/bolt/test/X86/instrument-static-pie.s
+++ b/bolt/test/X86/instrument-static-pie.s
@@ -1,0 +1,34 @@
+# Test that BOLT will instrument a statically linked PIE using entry point
+# patching.
+
+# REQUIRES: system-linux,bolt-runtime,target=x86_64-{{.*}}
+
+# RUN: llvm-mc -triple x86_64 -filetype=obj %s -o %t.o
+# Using lld directly and not specifying and interpreter effectlively generates a static pie.
+# RUN: ld.lld -q -pie -o %t.exe %t.o
+# RUN: llvm-bolt --instrument --instrumentation-sleep-time=1 \
+# RUN:   -o %t.out %t.exe 2>&1 | FileCheck %s
+
+# CHECK: static pie executable detected
+# CHECK: runtime library initialization was hooked via ELF Header Entry Point
+
+    .text
+    .globl _start
+    .type _start, %function
+_start:
+    # BOLT errs when instrumenting without relocations; create a dummy one.
+    .reloc 0, R_X86_64_NONE
+    retq
+    .size _start, .-_start
+
+    .globl _init
+    .type _init, %function
+_init:
+    ret
+    .size _init, .-_init
+
+    .globl _fini
+    .type _fini, %function
+_fini:
+    ret
+    .size _fini, .-_fini

--- a/bolt/test/runtime/X86/instrument-wrong-target.s
+++ b/bolt/test/runtime/X86/instrument-wrong-target.s
@@ -6,7 +6,7 @@
 
 # RUN: llvm-mc -triple aarch64 -filetype=obj %s -o %t.o
 # RUN: ld.lld -q -pie -o %t.exe %t.o
-# RUN: not llvm-bolt --instrument -o %t.out %t.exe 2>&1 | FileCheck %s
+# RUN: not llvm-bolt --instrument --instrumentation-sleep-time=1 -o %t.out %t.exe 2>&1 | FileCheck %s
 
 # CHECK: BOLT-ERROR: linking object with arch x86_64 into context with arch aarch64
 
@@ -18,17 +18,3 @@ _start:
     .reloc 0, R_AARCH64_NONE
     ret
     .size _start, .-_start
-
-    .globl _init
-    .type _init, %function
-    # Force DT_INIT to be created (needed for instrumentation).
-_init:
-    ret
-    .size _init, .-_init
-
-    .globl _fini
-    .type _fini, %function
-    # Force DT_FINI to be created (needed for instrumentation).
-_fini:
-    ret
-    .size _fini, .-_fini


### PR DESCRIPTION
Static PIEs contain DT_INIT and DT_FINI. However, statically linked libc does not read the dynamic entries, so patching those entries has no effect. Check DT_FLAGS_1 to detect input static PIEs and rely on entry point patching accordingly.

Fixes #201371.