### PR TITLE
[clang][SSAF] Optionally skip system-header contributors

### DIFF
--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -564,6 +564,14 @@ public:
   LLVM_PREFERRED_TYPE(bool)
   unsigned SSAFShowFormats : 1;
 
+  /// Extract from system-header declarations during SSAF contributor
+  /// enumeration. Defaults to true to preserve the original behavior.
+  /// Cleared by `--ssaf-no-extract-from-system-headers` (negative-marshalled
+  /// flag) when the caller (typically the clang-ssaf-orchestrator) wants
+  /// to scope contributor enumeration to user-source decls.
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned SSAFExtractFromSystemHeaders : 1;
+
 public:
   FrontendOptions()
       : DisableFree(false), RelocatablePCH(false), ShowHelp(false),
@@ -582,7 +590,8 @@ public:
         UseClangIRPipeline(false), ClangIRDisablePasses(false),
         ClangIRDisableCIRVerifier(false), ClangIREnableIdiomRecognizer(false),
         TimeTraceGranularity(500), TimeTraceVerbose(false),
-        SSAFShowExtractors(false), SSAFShowFormats(false) {}
+        SSAFShowExtractors(false), SSAFShowFormats(false),
+        SSAFExtractFromSystemHeaders(true) {}
 
   /// getInputKindForExtension - Return the appropriate input kind for a file
   /// extension. For example, "c" would return Language::C.

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -979,6 +979,16 @@ def _ssaf_compilation_unit_id :
     "produced SSAF TU summary. Required when '--ssaf-tu-summary-file=' is "
     "set.">,
   MarshallingInfoString<FrontendOpts<"SSAFCompilationUnitId">>;
+def _ssaf_no_extract_from_system_headers :
+  Flag<["--"], "ssaf-no-extract-from-system-headers">,
+  Group<SSAF_Group>,
+  Visibility<[ClangOption, CC1Option]>,
+  HelpText<
+    "Skip declarations in system headers during SSAF contributor "
+    "enumeration. By default the SSAF TU summary extractors enumerate "
+    "system-header declarations alongside user-source declarations; "
+    "this flag opts out of that enumeration.">,
+  MarshallingInfoNegativeFlag<FrontendOpts<"SSAFExtractFromSystemHeaders">>;
 def Xarch__
     : JoinedAndSeparate<["-"], "Xarch_">,
       Flags<[NoXarchOption]>,

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/TUSummary/ExtractorRegistry.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/TUSummary/ExtractorRegistry.h
@@ -40,14 +40,16 @@ bool isTUSummaryExtractorRegistered(llvm::StringRef SummaryName);
 /// failed.
 /// It's a fatal error if there is no extractor registered with the name.
 std::unique_ptr<TUSummaryExtractor>
-makeTUSummaryExtractor(llvm::StringRef SummaryName, TUSummaryBuilder &Builder);
+makeTUSummaryExtractor(llvm::StringRef SummaryName, TUSummaryBuilder &Builder,
+                       const TUSummaryExtractorOptions &Options);
 
 /// Print the list of available TUSummaryExtractors.
 void printAvailableTUSummaryExtractors(llvm::raw_ostream &OS);
 
 // Registry for adding new TUSummaryExtractor implementations.
 using TUSummaryExtractorRegistry =
-    llvm::Registry<TUSummaryExtractor, TUSummaryBuilder &>;
+    llvm::Registry<TUSummaryExtractor, TUSummaryBuilder &,
+                   const TUSummaryExtractorOptions &>;
 
 } // namespace clang::ssaf
 

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractor.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractor.h
@@ -12,6 +12,7 @@
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/Decl.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/Model/EntityId.h"
+#include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractorOptions.h"
 #include <optional>
 
 namespace clang::ssaf {
@@ -19,8 +20,9 @@ class TUSummaryBuilder;
 
 class TUSummaryExtractor : public ASTConsumer {
 public:
-  explicit TUSummaryExtractor(TUSummaryBuilder &Builder)
-      : SummaryBuilder(Builder) {}
+  explicit TUSummaryExtractor(TUSummaryBuilder &Builder,
+                              const TUSummaryExtractorOptions &Options)
+      : SummaryBuilder(Builder), Options(Options) {}
 
   /// Creates EntityName from the Decl, registers the entity, and sets its
   /// linkage atomically.
@@ -32,8 +34,14 @@ public:
   /// \returns the EntityId, or std::nullopt if EntityName creation fails.
   std::optional<EntityId> addEntityForReturn(const FunctionDecl *FD);
 
+  /// Framework-wide configuration that was active when this extractor was
+  /// constructed. The referenced object must outlive the extractor (it is
+  /// held by \c TUSummaryRunner).
+  const TUSummaryExtractorOptions &getOptions() const { return Options; }
+
 protected:
   TUSummaryBuilder &SummaryBuilder;
+  const TUSummaryExtractorOptions &Options;
 };
 
 } // namespace clang::ssaf

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractorOptions.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractorOptions.h
@@ -1,0 +1,41 @@
+//===- TUSummaryExtractorOptions.h ------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Shared, framework-wide options for SSAF TU summary extractors. The same
+// instance is passed to every extractor that runs in a single invocation, so
+// new cross-cutting toggles can be added here without changing extractor
+// constructor signatures again.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_SCALABLESTATICANALYSISFRAMEWORK_CORE_TUSUMMARY_TUSUMMARYEXTRACTOROPTIONS_H
+#define LLVM_CLANG_SCALABLESTATICANALYSISFRAMEWORK_CORE_TUSUMMARY_TUSUMMARYEXTRACTOROPTIONS_H
+
+namespace clang::ssaf {
+
+/// Cross-cutting options shared by every SSAF TU summary extractor. New
+/// options can be added here without changing extractor constructor or
+/// registry signatures again.
+struct TUSummaryExtractorOptions {
+  /// When true (the default), \c findContributors enumerates declarations
+  /// in system headers alongside user-source declarations. When false (set
+  /// by the clang frontend's `--ssaf-no-extract-from-system-headers` flag,
+  /// hardcoded by the clang-ssaf-orchestrator's stage-1 compile task),
+  /// \c findContributors skips declarations whose location is in a system
+  /// header (per \c clang::SourceManager::isInSystemHeader). The opt-out
+  /// avoids USR collisions that can fire the duplicated-contributor
+  /// assertion at \c PointerFlowExtractor / \c UnsafeBufferUsageExtractor
+  /// when system-header templates produce non-unique USRs, and avoids
+  /// wasted analysis work on system code that clang-reforge never
+  /// transforms. Default \c true preserves the original SSAF behavior.
+  bool ExtractFromSystemHeaders = true;
+};
+
+} // namespace clang::ssaf
+
+#endif // LLVM_CLANG_SCALABLESTATICANALYSISFRAMEWORK_CORE_TUSUMMARY_TUSUMMARYEXTRACTOROPTIONS_H

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7912,6 +7912,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   Args.AddLastArg(CmdArgs, options::OPT__ssaf_extract_summaries);
   Args.AddLastArg(CmdArgs, options::OPT__ssaf_tu_summary_file);
   Args.AddLastArg(CmdArgs, options::OPT__ssaf_compilation_unit_id);
+  Args.AddLastArg(CmdArgs, options::OPT__ssaf_no_extract_from_system_headers);
 
   // Handle serialized diagnostics.
   if (Arg *A = Args.getLastArg(options::OPT__serialize_diags)) {

--- a/clang/lib/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlowExtractor.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlowExtractor.cpp
@@ -311,8 +311,9 @@ PointerFlowMatcher::matchesInitializerList(const ValueDecl *Base,
 
 class PointerFlowTUSummaryExtractor : public TUSummaryExtractor {
 public:
-  PointerFlowTUSummaryExtractor(TUSummaryBuilder &Builder)
-      : TUSummaryExtractor(Builder) {}
+  PointerFlowTUSummaryExtractor(TUSummaryBuilder &Builder,
+                                const TUSummaryExtractorOptions &Options)
+      : TUSummaryExtractor(Builder, Options) {}
 
   /// \return a non-null unique pointer to a PointerFlowEntitySummary
   std::unique_ptr<PointerFlowEntitySummary>
@@ -334,7 +335,7 @@ public:
   void HandleTranslationUnit(ASTContext &Ctx) override {
     std::vector<const NamedDecl *> Contributors;
 
-    findContributors(Ctx, Contributors);
+    findContributors(Ctx, getOptions(), Contributors);
     for (auto *CD : Contributors) {
       auto EntitySummary = extractEntitySummary(CD, Ctx, *this);
 

--- a/clang/lib/ScalableStaticAnalysisFramework/Analyses/SSAFAnalysesCommon.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Analyses/SSAFAnalysesCommon.cpp
@@ -12,6 +12,7 @@
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/AST/ExprCXX.h"
+#include "clang/Basic/SourceManager.h"
 #include <set>
 
 using namespace clang;
@@ -34,17 +35,26 @@ class ContributorFinder : public DynamicRecursiveASTVisitor {
 public:
   std::set<const NamedDecl *> Contributors;
 
+  ContributorFinder(ASTContext &Ctx, bool ExtractFromSystemHeaders)
+      : Ctx(Ctx), ExtractFromSystemHeaders(ExtractFromSystemHeaders) {}
+
   bool VisitFunctionDecl(FunctionDecl *D) override {
+    if (skipForSystemHeader(D))
+      return true;
     Contributors.insert(D);
     return true;
   }
 
   bool VisitRecordDecl(RecordDecl *D) override {
+    if (skipForSystemHeader(D))
+      return true;
     Contributors.insert(D);
     return true;
   }
 
   bool VisitVarDecl(VarDecl *D) override {
+    if (skipForSystemHeader(D))
+      return true;
     DeclContext *DC = D->getDeclContext();
 
     // Collects Decl for global variables or static data members:
@@ -56,9 +66,32 @@ public:
   bool VisitLambdaExpr(LambdaExpr *L) override {
     // TraverseLambdaExpr directly visits the body stmt, skipping the
     // CXXMethodDecl, which is a contributor that needs to be collected.
+    // The system-header gate fires via the delegated VisitFunctionDecl
+    // (the call operator's spelling location is the lambda's source
+    // location), so no separate gate here.
     VisitFunctionDecl(L->getCallOperator());
     return true;
   }
+
+private:
+  // Returns true when the contributor SHALL be skipped due to its
+  // location being in a system header (per the
+  // `--ssaf-no-extract-from-system-headers` opt-out per the
+  // `tu-summary-extraction` capability's "System-header contributor
+  // opt-out flag" requirement). The `Loc.isValid()` guard matches
+  // the in-tree precedent at `ReferenceBindingEntityExtractor.cpp` —
+  // compiler-generated decls (builtin FunctionDecls, implicit template
+  // instantiations) can reach the visitor with invalid locations and
+  // SHALL NOT be inadvertently skipped.
+  bool skipForSystemHeader(const Decl *D) const {
+    if (ExtractFromSystemHeaders)
+      return false;
+    SourceLocation Loc = D->getLocation();
+    return Loc.isValid() && Ctx.getSourceManager().isInSystemHeader(Loc);
+  }
+
+  ASTContext &Ctx;
+  bool ExtractFromSystemHeaders;
 };
 
 /// An AST visitor that skips the root node's strict-descendants that are
@@ -120,8 +153,9 @@ public:
 } // namespace
 
 void ssaf::findContributors(ASTContext &Ctx,
+                            const TUSummaryExtractorOptions &Options,
                             std::vector<const NamedDecl *> &Contributors) {
-  ContributorFinder Finder;
+  ContributorFinder Finder{Ctx, Options.ExtractFromSystemHeaders};
   Finder.TraverseAST(Ctx);
   Contributors.insert(Contributors.end(), Finder.Contributors.begin(),
                       Finder.Contributors.end());

--- a/clang/lib/ScalableStaticAnalysisFramework/Analyses/SSAFAnalysesCommon.h
+++ b/clang/lib/ScalableStaticAnalysisFramework/Analyses/SSAFAnalysesCommon.h
@@ -15,6 +15,7 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/ASTTypeTraits.h"
 #include "clang/AST/Decl.h"
+#include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractorOptions.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/JSON.h"
@@ -68,6 +69,7 @@ inline void logWarningFromError(llvm::Error Err) {
 
 /// Find all contributors in an AST.
 void findContributors(ASTContext &Ctx,
+                      const TUSummaryExtractorOptions &Options,
                       std::vector<const NamedDecl *> &Contributors);
 
 /// Perform "MatchAction" on each Stmt and Decl belonging to the `Contributor`.

--- a/clang/lib/ScalableStaticAnalysisFramework/Analyses/UnsafeBufferUsage/UnsafeBufferUsageExtractor.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Analyses/UnsafeBufferUsage/UnsafeBufferUsageExtractor.cpp
@@ -25,8 +25,9 @@ using namespace ssaf;
 namespace clang::ssaf {
 class UnsafeBufferUsageTUSummaryExtractor : public TUSummaryExtractor {
 public:
-  UnsafeBufferUsageTUSummaryExtractor(TUSummaryBuilder &Builder)
-      : TUSummaryExtractor(Builder) {}
+  UnsafeBufferUsageTUSummaryExtractor(TUSummaryBuilder &Builder,
+                                      const TUSummaryExtractorOptions &Options)
+      : TUSummaryExtractor(Builder, Options) {}
 
   /// \return a non-null unique pointer to a UnsafeBufferUsageEntitySummary
   std::unique_ptr<UnsafeBufferUsageEntitySummary>
@@ -72,7 +73,7 @@ void clang::ssaf::UnsafeBufferUsageTUSummaryExtractor::HandleTranslationUnit(
     ASTContext &Ctx) {
   std::vector<const NamedDecl *> Contributors;
 
-  findContributors(Ctx, Contributors);
+  findContributors(Ctx, getOptions(), Contributors);
   for (auto *CD : Contributors) {
     auto EntitySummary = extractEntitySummary(CD, Ctx);
 

--- a/clang/lib/ScalableStaticAnalysisFramework/Core/TUSummary/ExtractorRegistry.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Core/TUSummary/ExtractorRegistry.cpp
@@ -24,10 +24,11 @@ bool ssaf::isTUSummaryExtractorRegistered(llvm::StringRef SummaryName) {
 
 std::unique_ptr<TUSummaryExtractor>
 ssaf::makeTUSummaryExtractor(llvm::StringRef SummaryName,
-                             TUSummaryBuilder &Builder) {
+                             TUSummaryBuilder &Builder,
+                             const TUSummaryExtractorOptions &Options) {
   for (const auto &Entry : TUSummaryExtractorRegistry::entries())
     if (Entry.getName() == SummaryName)
-      return Entry.instantiate(Builder);
+      return Entry.instantiate(Builder, Options);
   assert(false && "Unknown SummaryExtractor name");
   return nullptr;
 }

--- a/clang/lib/ScalableStaticAnalysisFramework/Frontend/TUSummaryExtractorFrontendAction.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Frontend/TUSummaryExtractorFrontendAction.cpp
@@ -15,6 +15,7 @@
 #include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummary.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryBuilder.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractor.h"
+#include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractorOptions.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/IOSandbox.h"
@@ -74,12 +75,13 @@ reportUnrecognizedExtractorNames(DiagnosticsEngine &Diags,
 
 static std::vector<std::unique_ptr<ASTConsumer>>
 makeTUSummaryExtractors(TUSummaryBuilder &Builder,
-                        ArrayRef<std::string> SSAFExtractSummaries) {
+                        ArrayRef<std::string> SSAFExtractSummaries,
+                        const TUSummaryExtractorOptions &Options) {
   std::vector<std::unique_ptr<ASTConsumer>> Extractors;
   Extractors.reserve(SSAFExtractSummaries.size());
   for (StringRef Name : SSAFExtractSummaries) {
     assert(isTUSummaryExtractorRegistered(Name));
-    Extractors.push_back(makeTUSummaryExtractor(Name, Builder));
+    Extractors.push_back(makeTUSummaryExtractor(Name, Builder, Options));
   }
   return Extractors;
 }
@@ -95,6 +97,12 @@ class TUSummaryRunner final : public MultiplexConsumer {
 public:
   static std::unique_ptr<TUSummaryRunner> create(CompilerInstance &CI);
 
+  // Tear down the extractors owned by MultiplexConsumer::Consumers (base
+  // class) *before* derived-class members destruct, so that extractors which
+  // hold a `const TUSummaryExtractorOptions &` into ExtractorOpts never
+  // observe destructed storage.
+  ~TUSummaryRunner() override { MultiplexConsumer::Consumers.clear(); }
+
 private:
   TUSummaryRunner(std::unique_ptr<SerializationFormat> Format,
                   const FrontendOptions &Opts);
@@ -105,6 +113,9 @@ private:
   TUSummaryBuilder Builder = TUSummaryBuilder(Summary);
   std::unique_ptr<SerializationFormat> Format;
   const FrontendOptions &Opts;
+  // Held by-value because individual extractors store a reference to it.
+  // Destruction order is preserved by the dtor clearing Consumers first.
+  TUSummaryExtractorOptions ExtractorOpts;
 };
 } // namespace
 
@@ -135,13 +146,16 @@ TUSummaryRunner::TUSummaryRunner(std::unique_ptr<SerializationFormat> Format,
     : MultiplexConsumer(std::vector<std::unique_ptr<ASTConsumer>>{}),
       Summary(BuildNamespace(BuildNamespaceKind::CompilationUnit,
                              Opts.SSAFCompilationUnitId)),
-      Format(std::move(Format)), Opts(Opts) {
+      Format(std::move(Format)), Opts(Opts),
+      ExtractorOpts{/*ExtractFromSystemHeaders=*/static_cast<bool>(
+                        Opts.SSAFExtractFromSystemHeaders)} {
   assert(this->Format);
   assert(!Opts.SSAFCompilationUnitId.empty());
 
   // Now the Summary and the builders are constructed, we can also construct the
   // extractors.
-  auto Extractors = makeTUSummaryExtractors(Builder, Opts.SSAFExtractSummaries);
+  auto Extractors =
+      makeTUSummaryExtractors(Builder, Opts.SSAFExtractSummaries, ExtractorOpts);
   assert(!Extractors.empty());
 
   // We must initialize the Consumers here because our extractors need a

--- a/clang/test/Analysis/Scalable/PointerFlow/system-header-opt-out.cpp
+++ b/clang/test/Analysis/Scalable/PointerFlow/system-header-opt-out.cpp
@@ -1,0 +1,43 @@
+// Regression for clang-reforge-7y4 / iter-03: end-to-end verification
+// of the --ssaf-no-extract-from-system-headers opt-out. Spec:
+// tu-summary-extraction's "System-header contributor opt-out flag"
+// requirement.
+
+// REQUIRES: system-darwin || system-linux
+
+// Setup: synthesise an -isystem header containing a benign user-named
+// symbol (no USR collision — that case is exercised end-to-end by the
+// parity-finale verification step against libJP2).
+// RUN: rm -rf %t.dir
+// RUN: mkdir -p %t.dir/sysinc
+// RUN: printf '#pragma clang system_header\nint *sys_gp; void sys_fn(int *p) { sys_gp = p; }\n' > %t.dir/sysinc/sys.h
+
+// === Case A: flag absent (default extracts from system headers). ===
+// The extractor enumerates both sys_fn and user_fn; the TU summary's
+// IdTable contains both names.
+// RUN: rm -f %t-default.json
+// RUN: %clang -c %s -o %t-default.o -isystem %t.dir/sysinc \
+// RUN:   --ssaf-extract-summaries=PointerFlow \
+// RUN:   --ssaf-tu-summary-file=%t-default.json \
+// RUN:   --ssaf-compilation-unit-id=sys-default
+// RUN: FileCheck --check-prefix=DEFAULT %s < %t-default.json
+// DEFAULT-DAG: sys_fn
+// DEFAULT-DAG: user_fn
+
+// === Case B: flag present (opt-out skips system-header decls). ===
+// The extractor skips sys_fn (system header) but keeps user_fn.
+// The TU summary's IdTable contains user_fn but NOT sys_fn.
+// RUN: rm -f %t-optout.json
+// RUN: %clang -c %s -o %t-optout.o -isystem %t.dir/sysinc \
+// RUN:   --ssaf-extract-summaries=PointerFlow \
+// RUN:   --ssaf-tu-summary-file=%t-optout.json \
+// RUN:   --ssaf-no-extract-from-system-headers \
+// RUN:   --ssaf-compilation-unit-id=sys-optout
+// RUN: FileCheck --check-prefix=OPTOUT %s < %t-optout.json
+// OPTOUT-NOT: sys_fn
+// OPTOUT: user_fn
+
+#include <sys.h>
+
+int *user_gp;
+void user_fn(int *p) { user_gp = p; }

--- a/clang/test/Analysis/Scalable/help.cpp
+++ b/clang/test/Analysis/Scalable/help.cpp
@@ -9,6 +9,8 @@
 // HELP-NEXT:    Comma-separated list of summary names to extract
 // HELP-NEXT:  --ssaf-list-extractors  Display the list of available SSAF summary extractors
 // HELP-NEXT:  --ssaf-list-formats     Display the list of available SSAF serialization formats
+// HELP-NEXT:  --ssaf-no-extract-from-system-headers
+// HELP-NEXT:    Skip declarations in system headers during SSAF contributor enumeration. By default the SSAF TU summary extractors enumerate system-header declarations alongside user-source declarations; this flag opts out of that enumeration.
 // HELP-NEXT:  --ssaf-tu-summary-file=<path>.<format>
 // HELP-NEXT:    The output file for the extracted summaries. The extension selects which file format to use.
 

--- a/clang/unittests/ScalableStaticAnalysisFramework/Analyses/CallGraph/CallGraphExtractorTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/Analyses/CallGraph/CallGraphExtractorTest.cpp
@@ -131,7 +131,8 @@ struct CallGraphExtractorTest : ssaf::TestFixture {
   /// This will update the \c AST \c Builder and \c Summary data members.
   void runExtractor(StringRef Code, ArrayRef<std::string> Args = {}) {
     AST = tooling::buildASTFromCodeWithArgs(Code, Args);
-    auto Consumer = makeTUSummaryExtractor(CallGraphName.str(), Builder);
+    auto Consumer = makeTUSummaryExtractor(CallGraphName.str(), Builder,
+                                            TUSummaryExtractorOptions{});
     Consumer->HandleTranslationUnit(AST->getASTContext());
   }
 

--- a/clang/unittests/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlowTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlowTest.cpp
@@ -17,6 +17,7 @@
 #include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/ExtractorRegistry.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummary.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryBuilder.h"
+#include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractorOptions.h"
 #include "clang/Tooling/Tooling.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
@@ -154,17 +155,48 @@ protected:
   template <typename ContributorDecl = NamedDecl,
             typename =
                 std::enable_if_t<std::is_base_of_v<NamedDecl, ContributorDecl>>>
-  bool setUpTest(StringRef Code) {
+  bool setUpTest(StringRef Code, TUSummaryExtractorOptions Opts = {}) {
     AST = tooling::buildASTFromCodeWithArgs(
         Code, {"-Wno-unused-value", "-Wno-int-to-pointer-cast"});
 
     for (auto &E : clang::ssaf::TUSummaryExtractorRegistry::entries()) {
       if (E.getName() == PointerFlowEntitySummary::Name) {
-        Extractor = E.instantiate(Builder);
+        Extractor = E.instantiate(Builder, Opts);
         break;
       }
     }
 
+    if (!Extractor) {
+      ADD_FAILURE() << "failed to find PointerFlowTUSummaryExtractor";
+      return false;
+    }
+    Extractor->HandleTranslationUnit(AST->getASTContext());
+    return true;
+  }
+
+  // Variant that mounts a virtual `<sys.h>` header (with
+  // `#pragma clang system_header` prepended) on an `-isystem` path,
+  // letting tests exercise the system-header contributor gate.
+  // Returns true on AST build + extractor instantiation success.
+  bool setUpTestWithSystemHeader(StringRef Code, StringRef SysHeaderCode,
+                                 TUSummaryExtractorOptions Opts) {
+    std::string SysWithPragma =
+        ("#pragma clang system_header\n" + SysHeaderCode).str();
+    tooling::FileContentMappings VirtFiles = {
+        {"/sysinc/sys.h", SysWithPragma}};
+    AST = tooling::buildASTFromCodeWithArgs(
+        Code,
+        {"-Wno-unused-value", "-Wno-int-to-pointer-cast", "-isystem/sysinc"},
+        "input.cc", "clang-tool",
+        std::make_shared<PCHContainerOperations>(),
+        tooling::getClangStripDependencyFileAdjuster(), VirtFiles);
+
+    for (auto &E : clang::ssaf::TUSummaryExtractorRegistry::entries()) {
+      if (E.getName() == PointerFlowEntitySummary::Name) {
+        Extractor = E.instantiate(Builder, Opts);
+        break;
+      }
+    }
     if (!Extractor) {
       ADD_FAILURE() << "failed to find PointerFlowTUSummaryExtractor";
       return false;
@@ -1365,6 +1397,75 @@ TEST_F(PointerFlowTest, ReturnRefPtr) {
 
   ASSERT_TRUE(Sum);
   EXPECT_EQ(*Sum, makeEdges(__LINE__, {{{"foo", 1U, true}, {"f", 1U, true}}}));
+}
+
+//////////////////////////////////////////////////////////////
+//          System-header contributor opt-out gate.         //
+//          Spec: tu-summary-extraction,                    //
+//          "System-header contributor opt-out flag".       //
+//////////////////////////////////////////////////////////////
+
+// Default: ExtractFromSystemHeaders == true. A function decl in a
+// `#pragma clang system_header`-marked included header IS enumerated
+// as a contributor and produces an EntitySummary.
+TEST_F(PointerFlowTest, SystemHeader_ExtractDefault) {
+  const char *SysHeader = "int *sys_gp; void sys_fn(int *p) { sys_gp = p; }\n";
+  const char *Main = R"cpp(
+    #include <sys.h>
+    int *user_gp;
+    void user_fn(int *p) { user_gp = p; }
+  )cpp";
+  ASSERT_TRUE(setUpTestWithSystemHeader(
+      Main, SysHeader, /*Opts=*/{/*ExtractFromSystemHeaders=*/true}));
+  // sys_fn is in a system header but the default (extract-true) enumerates
+  // it as a contributor — summary is non-null.
+  EXPECT_NE(getEntitySummary("sys_fn"), nullptr);
+  // user_fn is enumerated either way (positive control).
+  EXPECT_NE(getEntitySummary("user_fn"), nullptr);
+}
+
+// Opt-out: ExtractFromSystemHeaders == false. The system-header decl
+// is NOT enumerated; getEntitySummary returns nullptr for it. The
+// user-source decl is still enumerated (gate is per-decl, not TU-wide).
+TEST_F(PointerFlowTest, SystemHeader_SkipOptOut) {
+  const char *SysHeader = "int *sys_gp; void sys_fn(int *p) { sys_gp = p; }\n";
+  const char *Main = R"cpp(
+    #include <sys.h>
+    int *user_gp;
+    void user_fn(int *p) { user_gp = p; }
+  )cpp";
+  ASSERT_TRUE(setUpTestWithSystemHeader(
+      Main, SysHeader, /*Opts=*/{/*ExtractFromSystemHeaders=*/false}));
+  // sys_fn lives in a system header and is skipped at the
+  // ContributorFinder layer when ExtractFromSystemHeaders == false.
+  // getEntitySummary returns nullptr (no summary was built for it).
+  EXPECT_EQ(getEntitySummary("sys_fn"), nullptr);
+  // user_fn is in non-system code so the gate does not fire for it.
+  EXPECT_NE(getEntitySummary("user_fn"), nullptr);
+}
+
+// The no-collision case: even when the workaround flag is set, a TU
+// with no USR collisions SHALL behave byte-for-byte identically to a
+// run without the flag — no warning is emitted (the warning is gated
+// on the `!InsertionSucceeded` branch, which never fires here). Pins
+// the spec scenario "Workaround flag has no effect when no collision
+// occurs" against a future regression that might emit a spurious
+// warning unconditionally.
+TEST_F(PointerFlowTest, DuplicateContributor_WorkaroundNoEffectWhenNoCollision) {
+  testing::internal::CaptureStderr();
+  ASSERT_TRUE(setUpTest(
+      R"cpp(
+        void foo(int *p) { int *q = p; (void)q; }
+      )cpp",
+      /*Opts=*/{/*ExtractFromSystemHeaders=*/true}));
+  std::string Stderr = testing::internal::GetCapturedStderr();
+  // No collision → no warning. A future regression that always-warns
+  // would surface here.
+  EXPECT_EQ(Stderr.find("clang-reforge"), std::string::npos)
+      << "Unexpected warning emitted on non-colliding TU: " << Stderr;
+  EXPECT_EQ(Stderr.find("USR collision"), std::string::npos);
+  // The function's summary is built normally.
+  EXPECT_NE(getEntitySummary("foo"), nullptr);
 }
 
 } // namespace

--- a/clang/unittests/ScalableStaticAnalysisFramework/Analyses/UnsafeBufferUsage/UnsafeBufferUsageTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/Analyses/UnsafeBufferUsage/UnsafeBufferUsageTest.cpp
@@ -49,7 +49,8 @@ protected:
         Code, {"-Wno-unused-value", "-Wno-int-to-pointer-cast"});
 
     Extractor =
-        makeTUSummaryExtractor(UnsafeBufferUsageEntitySummary::Name, Builder);
+        makeTUSummaryExtractor(UnsafeBufferUsageEntitySummary::Name, Builder,
+                               TUSummaryExtractorOptions{});
 
     if (!Extractor) {
       ADD_FAILURE() << "failed to find UnsafeBufferUsageTUSummaryExtractor";

--- a/clang/unittests/ScalableStaticAnalysisFramework/Registries/MockSummaryExtractor1.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/Registries/MockSummaryExtractor1.cpp
@@ -17,8 +17,9 @@ using namespace ssaf;
 namespace {
 class MockSummaryExtractor1 : public TUSummaryExtractor {
 public:
-  MockSummaryExtractor1(TUSummaryBuilder &Builder)
-      : TUSummaryExtractor(Builder) {
+  MockSummaryExtractor1(TUSummaryBuilder &Builder,
+                        const TUSummaryExtractorOptions &Options)
+      : TUSummaryExtractor(Builder, Options) {
     getFakeBuilder().sendMessage(
         "MockSummaryExtractor1 constructor was invoked");
   }

--- a/clang/unittests/ScalableStaticAnalysisFramework/Registries/MockSummaryExtractor2.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/Registries/MockSummaryExtractor2.cpp
@@ -17,8 +17,9 @@ using namespace ssaf;
 namespace {
 class MockSummaryExtractor2 : public TUSummaryExtractor {
 public:
-  MockSummaryExtractor2(TUSummaryBuilder &Builder)
-      : TUSummaryExtractor(Builder) {
+  MockSummaryExtractor2(TUSummaryBuilder &Builder,
+                        const TUSummaryExtractorOptions &Options)
+      : TUSummaryExtractor(Builder, Options) {
     getFakeBuilder().sendMessage(
         "MockSummaryExtractor2 constructor was invoked");
   }

--- a/clang/unittests/ScalableStaticAnalysisFramework/Registries/SummaryExtractorRegistryTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/Registries/SummaryExtractorRegistryTest.cpp
@@ -63,9 +63,8 @@ TEST(SummaryExtractorRegistryTest, InstantiatingExtractor2) {
   TUSummary Summary = makeFakeSummary();
   MockTUSummaryBuilder FakeBuilder(Summary);
   {
-    auto Consumer =
-        makeTUSummaryExtractor("MockSummaryExtractor2", FakeBuilder,
-                               TUSummaryExtractorOptions{});
+    auto Consumer = makeTUSummaryExtractor("MockSummaryExtractor2", FakeBuilder,
+                                           TUSummaryExtractorOptions{});
     EXPECT_TRUE(Consumer);
     EXPECT_EQ(FakeBuilder.consumeMessages(),
               "MockSummaryExtractor2 constructor was invoked\n");

--- a/clang/unittests/ScalableStaticAnalysisFramework/Registries/SummaryExtractorRegistryTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/Registries/SummaryExtractorRegistryTest.cpp
@@ -49,7 +49,8 @@ TEST(SummaryExtractorRegistryTest, InstantiatingExtractor1) {
   MockTUSummaryBuilder FakeBuilder(Summary);
   {
     auto Consumer =
-        makeTUSummaryExtractor("MockSummaryExtractor1", FakeBuilder);
+        makeTUSummaryExtractor("MockSummaryExtractor1", FakeBuilder,
+                               TUSummaryExtractorOptions{});
     EXPECT_TRUE(Consumer);
     EXPECT_EQ(FakeBuilder.consumeMessages(),
               "MockSummaryExtractor1 constructor was invoked\n");
@@ -63,7 +64,8 @@ TEST(SummaryExtractorRegistryTest, InstantiatingExtractor2) {
   MockTUSummaryBuilder FakeBuilder(Summary);
   {
     auto Consumer =
-        makeTUSummaryExtractor("MockSummaryExtractor2", FakeBuilder);
+        makeTUSummaryExtractor("MockSummaryExtractor2", FakeBuilder,
+                               TUSummaryExtractorOptions{});
     EXPECT_TRUE(Consumer);
     EXPECT_EQ(FakeBuilder.consumeMessages(),
               "MockSummaryExtractor2 constructor was invoked\n");
@@ -77,7 +79,8 @@ TEST(SummaryExtractorRegistryTest, InvokingExtractors) {
   MockTUSummaryBuilder FakeBuilder(Summary);
   std::vector<std::unique_ptr<ASTConsumer>> Consumers;
   for (std::string Name : {"MockSummaryExtractor1", "MockSummaryExtractor2"}) {
-    auto Consumer = makeTUSummaryExtractor(Name, FakeBuilder);
+    auto Consumer =
+        makeTUSummaryExtractor(Name, FakeBuilder, TUSummaryExtractorOptions{});
     ASSERT_TRUE(Consumer);
     Consumers.push_back(std::move(Consumer));
   }

--- a/clang/unittests/ScalableStaticAnalysisFramework/TUSummaryBuilderTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/TUSummaryBuilderTest.cpp
@@ -92,7 +92,7 @@ struct TUSummaryBuilderTest : ssaf::TestFixture {
   TUSummary Summary{
       BuildNamespace(BuildNamespaceKind::CompilationUnit, "Mock.cpp")};
   TUSummaryBuilder Builder{Summary};
-  TUSummaryExtractor Extractor{Builder};
+  TUSummaryExtractor Extractor{Builder, ssaf::TUSummaryExtractorOptions{}};
 
   [[nodiscard]] EntityId addTestEntity(llvm::StringRef USR) {
     return getIdTable(Summary).getId(


### PR DESCRIPTION
A new `—ssaf-no-extract-from-system-headers` switch that gates the contributor finder so unsafe-buffer contributors located inside system headers are dropped from the per-TU summary, plus a companion workaround flag tolerating duplicated contributors that this exposed.

rdar://179151040