### PR TITLE
[CHERI] Fix incorrect MAX_E for RV64Y capabilities.

### DIFF
--- a/llvm/include/llvm/Support/CHERICapabilityFormat.h
+++ b/llvm/include/llvm/Support/CHERICapabilityFormat.h
@@ -41,7 +41,7 @@ struct RVYCapabilityFormat
 };
 
 using RV32YCapabilityFormat = RVYCapabilityFormat<uint32_t, 10, 24>;
-using RV64YCapabilityFormat = RVYCapabilityFormat<uint64_t, 14, 24>;
+using RV64YCapabilityFormat = RVYCapabilityFormat<uint64_t, 14, 52>;
 
 struct CHERIoTCapabilityFormat
     : public CHERICapabilityFormatBase<CHERIoTCapabilityFormat, uint32_t> {

--- a/llvm/lib/Support/CHERICapabilityFormat.cpp
+++ b/llvm/lib/Support/CHERICapabilityFormat.cpp
@@ -52,10 +52,10 @@ RVYCapabilityFormat<AddressType, MW, MAX_E>::getAlignmentMask(uint64_t Length) {
 
 template struct CHERICapabilityFormatBase<RVYCapabilityFormat<uint32_t, 10, 24>,
                                           uint32_t>;
-template struct CHERICapabilityFormatBase<RVYCapabilityFormat<uint64_t, 14, 24>,
+template struct CHERICapabilityFormatBase<RVYCapabilityFormat<uint64_t, 14, 52>,
                                           uint64_t>;
 template struct RVYCapabilityFormat<uint32_t, 10, 24>;
-template struct RVYCapabilityFormat<uint64_t, 14, 24>;
+template struct RVYCapabilityFormat<uint64_t, 14, 52>;
 
 uint32_t CHERIoTCapabilityFormat::getAlignmentMask(uint32_t Length) {
   // Per section 7.13.4 and table 7.4 in the v1.0 CHERIoT specification.

--- a/llvm/unittests/Support/CHERICapabilityFormatTest.cpp
+++ b/llvm/unittests/Support/CHERICapabilityFormatTest.cpp
@@ -30,6 +30,10 @@ TEST(CHERICapabilityFormat, RV32Y) {
     EXPECT_EQ(RV32Y::getRequiredAlignment(Len), 16);
     EXPECT_EQ(RV32Y::getAlignmentMask(Len), 0xFFFFFFF0);
   }
+
+  EXPECT_EQ(RV32Y::getRepresentableLength(0xFFFFFFF0), 0ULL);
+  EXPECT_EQ(RV32Y::getRequiredAlignment(0xFFFFFFF0), 67108864);
+  EXPECT_EQ(RV32Y::getAlignmentMask(0xFFFFFFF0), 0xFC000000);
 }
 
 TEST(CHERICapabilityFormat, RV64Y) {
@@ -59,6 +63,11 @@ TEST(CHERICapabilityFormat, RV64Y) {
     EXPECT_EQ(RV64Y::getRequiredAlignment(Len), 16);
     EXPECT_EQ(RV64Y::getAlignmentMask(Len), 0xFFFFFFFFFFFFFFF0);
   }
+
+  EXPECT_EQ(RV64Y::getRepresentableLength(0xFFFFFFFFFFFFFFF0), 0ULL);
+  EXPECT_EQ(RV64Y::getRequiredAlignment(0xFFFFFFFFFFFFFFF0),
+            18014398509481984ULL);
+  EXPECT_EQ(RV64Y::getAlignmentMask(0xFFFFFFFFFFFFFFF0), 0xFFC0000000000000);
 }
 
 TEST(CHERICapabilityFormat, CHERIoT) {
@@ -86,6 +95,10 @@ TEST(CHERICapabilityFormat, CHERIoT) {
     assert(CHERIoT::getRequiredAlignment(Len) == 4);
     EXPECT_EQ(CHERIoT::getAlignmentMask(Len), 0xFFFFFFFC);
   }
+
+  EXPECT_EQ(CHERIoT::getRepresentableLength(0xFFFFFFF0), 0ULL);
+  EXPECT_EQ(CHERIoT::getRequiredAlignment(0xFFFFFFF0), 16777216ULL);
+  EXPECT_EQ(CHERIoT::getAlignmentMask(0xFFFFFFF0), 0xFF000000);
 }
 
 } // namespace


### PR DESCRIPTION
Add tests for all capability formats at the upper end of their ranges, which would have caught this oversight.
