### PR TITLE
Add hash-backed print-changed modes

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineFunctionPass.h
+++ b/llvm/include/llvm/CodeGen/MachineFunctionPass.h
@@ -38,6 +38,9 @@ public:
     ClearedProperties = getClearedProperties();
     return false;
   }
+
+  bool doFinalization(Module &) override;
+
 protected:
   explicit MachineFunctionPass(char &ID) : FunctionPass(ID) {}
 

--- a/llvm/include/llvm/CodeGen/MachineStableHash.h
+++ b/llvm/include/llvm/CodeGen/MachineStableHash.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_MACHINESTABLEHASH_H
 #define LLVM_CODEGEN_MACHINESTABLEHASH_H
 
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StableHashing.h"
 #include "llvm/Support/Compiler.h"
 
@@ -23,6 +24,16 @@ class MachineFunction;
 class MachineInstr;
 class MachineOperand;
 
+struct MachineBasicBlockStableHashInfo {
+  const MachineBasicBlock *MBB = nullptr;
+  stable_hash Hash = 0;
+};
+
+struct MachineFunctionStableHashInfo {
+  stable_hash Hash = 0;
+  SmallVector<MachineBasicBlockStableHashInfo, 0> Blocks;
+};
+
 LLVM_ABI stable_hash stableHashValue(const MachineOperand &MO);
 LLVM_ABI stable_hash stableHashValue(const MachineInstr &MI,
                                      bool HashVRegs = false,
@@ -30,6 +41,14 @@ LLVM_ABI stable_hash stableHashValue(const MachineInstr &MI,
                                      bool HashMemOperands = false);
 LLVM_ABI stable_hash stableHashValue(const MachineBasicBlock &MBB);
 LLVM_ABI stable_hash stableHashValue(const MachineFunction &MF);
+
+/// Diagnostic hash for -print-changed; more permissive than stableHashValue().
+LLVM_ABI stable_hash stableHashValueForChangePrinter(const MachineInstr &MI);
+LLVM_ABI stable_hash
+stableHashValueForChangePrinter(const MachineBasicBlock &MBB);
+LLVM_ABI stable_hash stableHashValueForChangePrinter(const MachineFunction &MF);
+LLVM_ABI MachineFunctionStableHashInfo
+stableHashValueWithDetailsForChangePrinter(const MachineFunction &MF);
 
 } // namespace llvm
 

--- a/llvm/include/llvm/IR/FMF.h
+++ b/llvm/include/llvm/IR/FMF.h
@@ -56,6 +56,7 @@ public:
   bool any() const { return Flags != 0; }
   bool none() const { return Flags == 0; }
   bool all() const { return Flags == AllFlagsMask; }
+  unsigned getRawFlags() const { return Flags; }
 
   void clear() { Flags = 0; }
   void set() { Flags = AllFlagsMask; }

--- a/llvm/include/llvm/IR/PrintPasses.h
+++ b/llvm/include/llvm/IR/PrintPasses.h
@@ -9,8 +9,10 @@
 #ifndef LLVM_IR_PRINTPASSES_H
 #define LLVM_IR_PRINTPASSES_H
 
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/CommandLine.h"
+#include <system_error>
 #include <vector>
 
 namespace llvm {
@@ -27,7 +29,17 @@ enum class ChangePrinter {
   DotCfgQuiet
 };
 
-extern LLVM_ABI cl::opt<ChangePrinter> PrintChanged;
+enum class ChangePrinterHashMode { None, Function, BasicBlock };
+
+extern LLVM_ABI ChangePrinter PrintChanged;
+
+// Returns true if -print-changed should print only function attribute changes
+// when only function attributes changed.
+LLVM_ABI bool shouldPrintChangedAttributeDiffs();
+
+// Returns true if -print-changed should use hashes for change detection.
+LLVM_ABI bool shouldUsePrintChangedHash();
+LLVM_ABI ChangePrinterHashMode getPrintChangedHashMode();
 
 // Returns true if printing before/after some pass is enabled, whether all
 // passes or a specific pass.

--- a/llvm/include/llvm/IR/StructuralHash.h
+++ b/llvm/include/llvm/IR/StructuralHash.h
@@ -15,6 +15,7 @@
 #define LLVM_IR_STRUCTURALHASH_H
 
 #include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StableHashing.h"
 #include "llvm/IR/Instruction.h"
 #include "llvm/Support/Compiler.h"
@@ -22,8 +23,28 @@
 
 namespace llvm {
 
+class BasicBlock;
 class Function;
 class Module;
+
+struct InstructionStructuralHashInfo {
+  const Instruction *Inst = nullptr;
+  stable_hash InstructionHash = 0;
+};
+
+struct BasicBlockStructuralHashInfo {
+  BasicBlockStructuralHashInfo() = default;
+  BasicBlockStructuralHashInfo(const BasicBlock *BB) : BB(BB) {}
+
+  const BasicBlock *BB = nullptr;
+  stable_hash BlockHash = 0;
+  SmallVector<InstructionStructuralHashInfo, 0> Instructions;
+};
+
+struct FunctionStructuralHashInfo {
+  stable_hash FunctionHash = 0;
+  SmallVector<BasicBlockStructuralHashInfo, 0> Blocks;
+};
 
 /// Returns a hash of the function \p F.
 /// \param F The function to hash.
@@ -32,6 +53,11 @@ class Module;
 /// to true includes instruction and operand type information.
 LLVM_ABI stable_hash StructuralHash(const Function &F,
                                     bool DetailedHash = false);
+
+/// Returns structural hash details for \p F, including the function hash and
+/// the block/instruction hashes computed while building it.
+LLVM_ABI FunctionStructuralHashInfo
+StructuralHashWithDetails(const Function &F, bool DetailedHash = false);
 
 /// Returns a hash of the global variable \p G.
 LLVM_ABI stable_hash StructuralHash(const GlobalVariable &G);

--- a/llvm/include/llvm/IR/StructuralHash.h
+++ b/llvm/include/llvm/IR/StructuralHash.h
@@ -15,6 +15,7 @@
 #define LLVM_IR_STRUCTURALHASH_H
 
 #include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StableHashing.h"
 #include "llvm/IR/Instruction.h"
@@ -27,18 +28,12 @@ class BasicBlock;
 class Function;
 class Module;
 
-struct InstructionStructuralHashInfo {
-  const Instruction *Inst = nullptr;
-  stable_hash InstructionHash = 0;
-};
-
 struct BasicBlockStructuralHashInfo {
   BasicBlockStructuralHashInfo() = default;
   BasicBlockStructuralHashInfo(const BasicBlock *BB) : BB(BB) {}
 
   const BasicBlock *BB = nullptr;
   stable_hash BlockHash = 0;
-  SmallVector<InstructionStructuralHashInfo, 0> Instructions;
 };
 
 struct FunctionStructuralHashInfo {
@@ -54,10 +49,20 @@ struct FunctionStructuralHashInfo {
 LLVM_ABI stable_hash StructuralHash(const Function &F,
                                     bool DetailedHash = false);
 
-/// Returns structural hash details for \p F, including the function hash and
-/// the block/instruction hashes computed while building it.
+/// Returns structural hash details for \p F for users that need to know which
+/// basic blocks changed after the function hash changes. For example,
+/// -print-changed=hash-bb compares these per-block hashes so it can print only
+/// changed blocks instead of dumping the whole function.
 LLVM_ABI FunctionStructuralHashInfo
 StructuralHashWithDetails(const Function &F, bool DetailedHash = false);
+
+/// Like StructuralHashWithDetails(), but only records block details accepted by
+/// \p ShouldCollectBlock. This is used when the interesting IR unit is a subset
+/// of a function, such as a loop pass; the function hash still covers the whole
+/// function.
+LLVM_ABI FunctionStructuralHashInfo StructuralHashWithDetails(
+    const Function &F, bool DetailedHash,
+    function_ref<bool(const BasicBlock &)> ShouldCollectBlock);
 
 /// Returns a hash of the global variable \p G.
 LLVM_ABI stable_hash StructuralHash(const GlobalVariable &G);

--- a/llvm/include/llvm/Passes/StandardInstrumentations.h
+++ b/llvm/include/llvm/Passes/StandardInstrumentations.h
@@ -17,9 +17,12 @@
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StableHashing.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/IR/Attributes.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/DroppedVariableStatsIR.h"
@@ -33,6 +36,7 @@
 
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace llvm {
 
@@ -297,6 +301,90 @@ protected:
   void handleAfter(StringRef PassID, std::string &Name,
                    const std::string &Before, const std::string &After,
                    Any) override;
+};
+
+struct FunctionChangeAttributes {
+  std::string Name;
+  AttributeList Attributes;
+  unsigned ArgCount = 0;
+
+  bool operator==(const FunctionChangeAttributes &That) const {
+    return Name == That.Name && Attributes == That.Attributes &&
+           ArgCount == That.ArgCount;
+  }
+};
+
+struct BasicBlockChangeHash {
+  std::string Key;
+  stable_hash Hash = 0;
+
+  bool operator==(const BasicBlockChangeHash &That) const {
+    return Key == That.Key && Hash == That.Hash;
+  }
+};
+
+struct FunctionChangeHash {
+  std::string Name;
+  stable_hash Hash = 0;
+  SmallVector<BasicBlockChangeHash> Blocks;
+
+  bool operator==(const FunctionChangeHash &That) const {
+    return Name == That.Name && Hash == That.Hash;
+  }
+};
+
+struct IRChangeHash {
+  bool operator==(const IRChangeHash &That) const {
+    if (UseTextComparison || That.UseTextComparison)
+      return Text == That.Text;
+    return Hash == That.Hash && FunctionAttrs == That.FunctionAttrs;
+  }
+
+  bool UseTextComparison = false;
+  stable_hash Hash = 0;
+  SmallVector<FunctionChangeHash> Functions;
+  SmallVector<FunctionChangeAttributes> FunctionAttrs;
+  std::string Text;
+};
+
+class LLVM_ABI IRChangedHashPrinter : public TextChangeReporter<IRChangeHash> {
+public:
+  IRChangedHashPrinter(bool VerboseMode)
+      : TextChangeReporter<IRChangeHash>(VerboseMode) {}
+  ~IRChangedHashPrinter() override;
+  void registerCallbacks(PassInstrumentationCallbacks &PIC);
+
+protected:
+  void generateIRRepresentation(Any IR, StringRef PassID,
+                                IRChangeHash &Output) override;
+  void handleAfter(StringRef PassID, std::string &Name,
+                   const IRChangeHash &Before, const IRChangeHash &After,
+                   Any IR) override;
+
+private:
+  struct StatefulHashFrame {
+    bool IsInteresting = false;
+    bool IsIR = true;
+    bool UseBeforeOverride = false;
+    SmallVector<std::string> FunctionNames;
+    IRChangeHash BeforeOverride;
+  };
+
+  void registerStatefulHashCallbacks(PassInstrumentationCallbacks &PIC);
+  void saveStatefulBeforePass(Any IR, StringRef PassID, StringRef PassName);
+  void handleStatefulAfterPass(Any IR, StringRef PassID, StringRef PassName);
+  void handleStatefulInvalidatedPass(StringRef PassID);
+
+  // Cache the last known hash state for each function so hash-based
+  // print-changed does not need to recompute the full "before" snapshot before
+  // every pass. The after-pass callback recomputes the current hash, compares
+  // it with the cached before state, then updates the cache for the next pass.
+  // Loop passes still take an explicit before snapshot because they only cover
+  // a subset of a function.
+  StringMap<FunctionChangeHash> StatefulFunctionHashes;
+  StringMap<FunctionChangeHash> StatefulMachineFunctionHashes;
+  StringMap<FunctionChangeAttributes> StatefulFunctionAttrs;
+  std::vector<StatefulHashFrame> StatefulHashStack;
 };
 
 class LLVM_ABI IRChangedTester : public IRChangedPrinter {
@@ -605,6 +693,7 @@ class StandardInstrumentations {
   OptPassGateInstrumentation OptPassGate;
   PreservedCFGCheckerInstrumentation PreservedCFGChecker;
   IRChangedPrinter PrintChangedIR;
+  IRChangedHashPrinter PrintChangedHashIR;
   PseudoProbeVerifier PseudoProbeVerification;
   InLineChangePrinter PrintChangedDiff;
   DotCfgChangeReporter WebsiteChangeReporter;

--- a/llvm/lib/CodeGen/MachineFunctionPass.cpp
+++ b/llvm/lib/CodeGen/MachineFunctionPass.cpp
@@ -11,6 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StableHashing.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/Analysis/BasicAliasAnalysis.h"
 #include "llvm/Analysis/BranchProbabilityInfo.h"
 #include "llvm/Analysis/DominanceFrontier.h"
@@ -28,11 +32,16 @@
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/MachineOptimizationRemarkEmitter.h"
+#include "llvm/CodeGen/MachineStableHash.h"
 #include "llvm/CodeGen/Passes.h"
 #include "llvm/IR/Dominators.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IR/ModuleSlotTracker.h"
+#include "llvm/IR/PrintPasses.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/FormatVariadic.h"
+#include <optional>
 
 using namespace llvm;
 using namespace ore;
@@ -41,6 +50,223 @@ static cl::opt<bool> DroppedVarStatsMIR(
     "dropped-variable-stats-mir", cl::Hidden,
     cl::desc("Dump dropped debug variables stats for MIR passes"),
     cl::init(false));
+
+static bool isDiffChangePrinter(ChangePrinter Printer) {
+  return Printer == ChangePrinter::DiffQuiet ||
+         Printer == ChangePrinter::DiffVerbose ||
+         Printer == ChangePrinter::ColourDiffQuiet ||
+         Printer == ChangePrinter::ColourDiffVerbose;
+}
+
+namespace {
+
+struct MachineBasicBlockChangeHash {
+  std::string Key;
+  stable_hash Hash = 0;
+
+  bool operator==(const MachineBasicBlockChangeHash &That) const {
+    return Key == That.Key && Hash == That.Hash;
+  }
+};
+
+struct MachineFunctionChangeHash {
+  stable_hash Hash = 0;
+  SmallVector<MachineBasicBlockChangeHash> Blocks;
+
+  bool operator==(const MachineFunctionChangeHash &That) const {
+    return Hash == That.Hash;
+  }
+};
+
+// Legacy MachineFunctionPass handles -print-changed outside the new pass
+// instrumentation callbacks. Keep its stateful hash cache here, keyed by live
+// MachineFunction objects from the current module, and clear it when the module
+// changes to avoid stale pointer reuse.
+DenseMap<const MachineFunction *, MachineFunctionChangeHash>
+    StatefulMachineFunctionHashes;
+const Module *StatefulMachineFunctionHashModule = nullptr;
+
+void setStatefulMachineFunctionHashModule(const Module *M) {
+  if (StatefulMachineFunctionHashModule == M)
+    return;
+  StatefulMachineFunctionHashes.clear();
+  StatefulMachineFunctionHashModule = M;
+}
+
+// MachineBasicBlock pointers in MachineFunctionStableHashInfo are only valid
+// for the current snapshot. Across passes, hash-bb matches blocks by a derived
+// key: the block name when present, otherwise the block's ordinal position in
+// the function. This does not suppress transformed or duplicated blocks;
+// changed and newly-created blocks are still printed. The limitation is
+// association: passes that delete/recreate, duplicate, or reorder unnamed
+// blocks can appear as added/deleted or position-matched block changes instead
+// of being matched to a previous logical block. TODO: add a more stable block
+// tracking key.
+std::string getMachineBasicBlockChangeKey(
+    const MachineBasicBlock &MBB,
+    const DenseMap<const MachineBasicBlock *, unsigned> *Numbers = nullptr) {
+  if (MBB.hasName())
+    return MBB.getName().str();
+  if (Numbers)
+    return formatv("{0}", Numbers->lookup(&MBB)).str();
+  return formatv("{0}", MBB.getNumber()).str();
+}
+
+MachineFunctionChangeHash
+collectMachineFunctionChangeHash(const MachineFunction &MF) {
+  ChangePrinterHashMode HashMode = getPrintChangedHashMode();
+  MachineFunctionChangeHash FunctionHash;
+
+  if (HashMode == ChangePrinterHashMode::Function ||
+      (HashMode == ChangePrinterHashMode::BasicBlock && MF.size() <= 1)) {
+    FunctionHash.Hash = stableHashValueForChangePrinter(MF);
+    return FunctionHash;
+  }
+
+  MachineFunctionStableHashInfo Details =
+      stableHashValueWithDetailsForChangePrinter(MF);
+  FunctionHash.Hash = Details.Hash;
+  DenseMap<const MachineBasicBlock *, unsigned> BlockNumbers;
+  unsigned BlockNumber = 0;
+  for (const MachineBasicBlock &MBB : MF)
+    BlockNumbers.try_emplace(&MBB, BlockNumber++);
+  for (const MachineBasicBlockStableHashInfo &BlockInfo : Details.Blocks) {
+    MachineBasicBlockChangeHash BlockHash;
+    BlockHash.Key =
+        getMachineBasicBlockChangeKey(*BlockInfo.MBB, &BlockNumbers);
+    BlockHash.Hash = BlockInfo.Hash;
+    FunctionHash.Blocks.push_back(std::move(BlockHash));
+  }
+
+  return FunctionHash;
+}
+
+StringMap<const MachineBasicBlock *>
+collectMachineBasicBlockMap(const MachineFunction &MF) {
+  StringMap<const MachineBasicBlock *> Blocks;
+  DenseMap<const MachineBasicBlock *, unsigned> BlockNumbers;
+  unsigned BlockNumber = 0;
+  for (const MachineBasicBlock &MBB : MF)
+    BlockNumbers.try_emplace(&MBB, BlockNumber++);
+  for (const MachineBasicBlock &MBB : MF)
+    Blocks[getMachineBasicBlockChangeKey(MBB, &BlockNumbers)] = &MBB;
+  return Blocks;
+}
+
+class MachineChangePrinterPrintContext {
+  const MachineFunction &MF;
+  std::optional<ModuleSlotTracker> MST;
+
+  ModuleSlotTracker &getModuleSlotTracker() {
+    if (!MST) {
+      MST.emplace(MF.getFunction().getParent());
+      MST->incorporateFunction(MF.getFunction());
+    }
+    return *MST;
+  }
+
+public:
+  explicit MachineChangePrinterPrintContext(const MachineFunction &MF)
+      : MF(MF) {}
+
+  void printBasicBlock(raw_ostream &OS, const MachineBasicBlock &MBB) {
+    MBB.print(OS, getModuleSlotTracker(), /*Indexes=*/nullptr,
+              /*IsStandalone=*/true);
+  }
+};
+
+void printMachineBasicBlockChangeHeader(raw_ostream &OS,
+                                        const MachineFunction &MF,
+                                        StringRef BlockKey, StringRef Change,
+                                        const MachineBasicBlock *MBB) {
+  OS << "*** BasicBlock " << MF.getName() << ":";
+  if (MBB && MBB->hasName())
+    OS << MBB->getName();
+  else
+    OS << BlockKey;
+  OS << " " << Change << " ***\n";
+}
+
+bool printMachineBasicBlockHashChanges(
+    raw_ostream &OS, const MachineFunction &MF,
+    const MachineFunctionChangeHash &Before,
+    const MachineFunctionChangeHash &After,
+    MachineChangePrinterPrintContext &PrintCtx) {
+  bool Printed = false;
+  StringMap<const MachineBasicBlock *> CurrentBlocks =
+      collectMachineBasicBlockMap(MF);
+  DenseMap<StringRef, const MachineBasicBlockChangeHash *> BeforeBlocks;
+  DenseMap<StringRef, const MachineBasicBlockChangeHash *> AfterBlocks;
+  for (const MachineBasicBlockChangeHash &BeforeBlock : Before.Blocks)
+    BeforeBlocks.try_emplace(BeforeBlock.Key, &BeforeBlock);
+  for (const MachineBasicBlockChangeHash &AfterBlock : After.Blocks)
+    AfterBlocks.try_emplace(AfterBlock.Key, &AfterBlock);
+
+  unsigned ChangedBlockCount = 0;
+  for (const MachineBasicBlockChangeHash &AfterBlock : After.Blocks) {
+    const MachineBasicBlockChangeHash *BeforeBlock =
+        BeforeBlocks.lookup(AfterBlock.Key);
+    if (!BeforeBlock || BeforeBlock->Hash != AfterBlock.Hash)
+      ++ChangedBlockCount;
+  }
+  for (const MachineBasicBlockChangeHash &BeforeBlock : Before.Blocks)
+    if (!AfterBlocks.contains(BeforeBlock.Key))
+      ++ChangedBlockCount;
+  if (ChangedBlockCount == 0)
+    return false;
+
+  unsigned UnchangedBlockCount = 0;
+  for (const MachineBasicBlockChangeHash &AfterBlock : After.Blocks) {
+    const MachineBasicBlockChangeHash *BeforeBlock =
+        BeforeBlocks.lookup(AfterBlock.Key);
+    if (BeforeBlock && BeforeBlock->Hash == AfterBlock.Hash) {
+      ++UnchangedBlockCount;
+      continue;
+    }
+    const MachineBasicBlock *MBB = CurrentBlocks.lookup(AfterBlock.Key);
+    printMachineBasicBlockChangeHeader(OS, MF, AfterBlock.Key, "changed", MBB);
+    if (MBB)
+      PrintCtx.printBasicBlock(OS, *MBB);
+    Printed = true;
+  }
+  if (UnchangedBlockCount != 0)
+    OS << "; " << UnchangedBlockCount << " unchanged basic blocks omitted\n";
+  for (const MachineBasicBlockChangeHash &BeforeBlock : Before.Blocks) {
+    if (AfterBlocks.contains(BeforeBlock.Key))
+      continue;
+    printMachineBasicBlockChangeHeader(OS, MF, BeforeBlock.Key, "deleted",
+                                       /*MBB=*/nullptr);
+    Printed = true;
+  }
+  return Printed;
+}
+
+void printMachineFunctionHashChanges(raw_ostream &OS, const MachineFunction &MF,
+                                     const MachineFunctionChangeHash &Before,
+                                     const MachineFunctionChangeHash &After) {
+  bool Printed = false;
+  MachineChangePrinterPrintContext PrintCtx(MF);
+  switch (getPrintChangedHashMode()) {
+  case ChangePrinterHashMode::Function:
+    MF.print(OS);
+    return;
+  case ChangePrinterHashMode::BasicBlock:
+    if (Before.Blocks.empty() || After.Blocks.empty()) {
+      MF.print(OS);
+      return;
+    }
+    Printed =
+        printMachineBasicBlockHashChanges(OS, MF, Before, After, PrintCtx);
+    break;
+  case ChangePrinterHashMode::None:
+    llvm_unreachable("expected hash mode");
+  }
+
+  if (!Printed && Before.Hash != After.Hash)
+    MF.print(OS);
+}
+
+} // namespace
 
 Pass *MachineFunctionPass::createPrinterPass(raw_ostream &O,
                                              const std::string &Banner) const {
@@ -82,6 +308,39 @@ bool MachineFunctionPass::runOnFunction(Function &F) {
   if (ShouldEmitSizeRemarks)
     CountBefore = MF.getInstructionCount();
 
+  // Hash-based --print-changed is handled here so the legacy pass manager does
+  // not need to materialize full MIR text before and after every machine pass.
+  // Text and diff modes are handled by FunctionPass::printIRUnit().
+  MachineFunctionChangeHash BeforeHash, AfterHash;
+  StringRef PassID;
+  if (PrintChanged != ChangePrinter::None) {
+    if (const PassInfo *PI = Pass::lookupPassInfo(getPassID()))
+      PassID = PI->getPassArgument();
+  }
+  const bool IsInterestingPass = isPassInPrintList(PassID);
+  const bool UseHashComparison =
+      shouldUsePrintChangedHash() && !isDiffChangePrinter(PrintChanged);
+  const bool UseStatefulHash = UseHashComparison && isFilterPassesEmpty();
+  const bool ShouldTrackChangedHash =
+      UseStatefulHash && isFunctionInPrintList(MF.getName());
+  const bool ShouldPrintChangedHash = UseHashComparison && IsInterestingPass &&
+                                      isFunctionInPrintList(MF.getName());
+  if (UseStatefulHash)
+    setStatefulMachineFunctionHashModule(F.getParent());
+  if (ShouldPrintChangedHash || ShouldTrackChangedHash) {
+    if (UseStatefulHash) {
+      auto It = StatefulMachineFunctionHashes.find(&MF);
+      if (It == StatefulMachineFunctionHashes.end()) {
+        BeforeHash = collectMachineFunctionChangeHash(MF);
+        MachineFunctionChangeHash CachedHash = BeforeHash;
+        StatefulMachineFunctionHashes[&MF] = std::move(CachedHash);
+      } else {
+        BeforeHash = It->second;
+      }
+    } else {
+      BeforeHash = collectMachineFunctionChangeHash(MF);
+    }
+  }
   MFProps.reset(ClearedProperties);
 
   bool RV;
@@ -120,16 +379,75 @@ bool MachineFunctionPass::runOnFunction(Function &F) {
 
   MFProps.set(SetProperties);
 
+  // For --print-changed, print if the MF has changed. Modes other than
+  // quiet/verbose are unimplemented and treated the same as 'quiet'.
+  if (UseHashComparison && (ShouldPrintChangedHash || !IsInterestingPass ||
+                            ShouldTrackChangedHash)) {
+    if (ShouldPrintChangedHash || ShouldTrackChangedHash) {
+      AfterHash = collectMachineFunctionChangeHash(MF);
+    }
+    if (ShouldPrintChangedHash && !(BeforeHash == AfterHash)) {
+      errs() << ("*** IR Dump After " + getPassName() + " (" + PassID +
+                 ") on " + MF.getName() + " ***\n");
+      switch (PrintChanged) {
+      case ChangePrinter::None:
+        llvm_unreachable("");
+      case ChangePrinter::Quiet:
+      case ChangePrinter::Verbose:
+      case ChangePrinter::DotCfgQuiet:   // unimplemented
+      case ChangePrinter::DotCfgVerbose: // unimplemented
+        if (getPrintChangedHashMode() != ChangePrinterHashMode::Function)
+          printMachineFunctionHashChanges(errs(), MF, BeforeHash, AfterHash);
+        else
+          MF.print(errs());
+        break;
+      case ChangePrinter::DiffQuiet:
+      case ChangePrinter::DiffVerbose:
+      case ChangePrinter::ColourDiffQuiet:
+      case ChangePrinter::ColourDiffVerbose:
+        llvm_unreachable("hash mode is not supported with diff output");
+        break;
+      }
+    } else if (llvm::is_contained({ChangePrinter::Verbose,
+                                   ChangePrinter::DiffVerbose,
+                                   ChangePrinter::ColourDiffVerbose},
+                                  PrintChanged)) {
+      const char *Reason =
+          IsInterestingPass ? " omitted because no change" : " filtered out";
+      errs() << "*** IR Dump After " << getPassName();
+      if (!PassID.empty())
+        errs() << " (" << PassID << ")";
+      errs() << " on " << MF.getName() + Reason + " ***\n";
+    }
+    if (ShouldTrackChangedHash && IsInterestingPass) {
+      MachineFunctionChangeHash CachedHash = AfterHash;
+      StatefulMachineFunctionHashes[&MF] = std::move(CachedHash);
+    } else if (ShouldTrackChangedHash) {
+      StatefulMachineFunctionHashes.erase(&MF);
+    }
+  }
   return RV;
 }
 
 bool MachineFunctionPass::printIRUnit(raw_ostream &OS, Function &F) {
+  // Hash mode is handled in runOnFunction() to avoid full before/after MIR
+  // printing in the legacy pass manager.
+  if (shouldUsePrintChangedHash())
+    return false;
+
   // available_externally functions are not codegen'd (see runOnFunction).
   if (F.hasAvailableExternallyLinkage())
     return false;
   MachineModuleInfo &MMI = getAnalysis<MachineModuleInfoWrapperPass>().getMMI();
   MMI.getOrCreateMachineFunction(F).print(OS);
   return true;
+}
+
+bool MachineFunctionPass::doFinalization(Module &M) {
+  StatefulMachineFunctionHashes.clear();
+  if (StatefulMachineFunctionHashModule == &M)
+    StatefulMachineFunctionHashModule = nullptr;
+  return false;
 }
 
 void MachineFunctionPass::getAnalysisUsage(AnalysisUsage &AU) const {

--- a/llvm/lib/CodeGen/MachineStableHash.cpp
+++ b/llvm/lib/CodeGen/MachineStableHash.cpp
@@ -26,6 +26,7 @@
 #include "llvm/CodeGen/MachineRegisterInfo.h"
 #include "llvm/CodeGen/Register.h"
 #include "llvm/Config/llvm-config.h"
+#include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/StructuralHash.h"
@@ -243,4 +244,211 @@ stable_hash llvm::stableHashValue(const MachineFunction &MF) {
   for (const auto &MBB : MF)
     HashComponents.push_back(stableHashValue(MBB));
   return stable_hash_combine(HashComponents);
+}
+
+// The generic stableHashValue() API is conservative: it can return 0 when an
+// operand cannot be hashed with the stability needed by compiler analyses. The
+// print-changed hash is diagnostic-only, so it is more permissive and hashes
+// those operands using the best local identity available. This keeps
+// -print-changed=hash-func/hash-bb useful for change detection without changing
+// the contract of the generic stable hash APIs.
+// TODO: Prefer stable symbolic identities over local numbering where available
+// to reduce false positives from renumbering.
+static stable_hash
+hashMachineOperandForChangePrinter(const MachineOperand &MO) {
+  stable_hash H = stable_hash_combine(
+      MO.getType(), static_cast<unsigned>(MO.getTargetFlags()));
+
+  switch (MO.getType()) {
+  case MachineOperand::MO_Register: {
+    H = stable_hash_combine(
+        H, stable_hash_combine(MO.getReg().id(), MO.isDef(), MO.isImplicit()),
+        stable_hash_combine(MO.isDead(), MO.isKill()));
+    if (MO.getSubReg())
+      H = stable_hash_combine(H, MO.getSubReg());
+    return H;
+  }
+  case MachineOperand::MO_Immediate:
+    return stable_hash_combine(H, MO.getImm());
+  case MachineOperand::MO_CImmediate: {
+    APInt Val = MO.getCImm()->getValue();
+    return stable_hash_combine(H, static_cast<stable_hash>(hash_value(Val)));
+  }
+  case MachineOperand::MO_FPImmediate: {
+    APInt Val = MO.getFPImm()->getValueAPF().bitcastToAPInt();
+    return stable_hash_combine(H, static_cast<stable_hash>(hash_value(Val)));
+  }
+  case MachineOperand::MO_MachineBasicBlock:
+    return stable_hash_combine(H, MO.getMBB()->getNumber());
+  case MachineOperand::MO_FrameIndex:
+    return stable_hash_combine(H, MO.getIndex());
+  case MachineOperand::MO_ConstantPoolIndex:
+    return stable_hash_combine(H, MO.getIndex(), MO.getOffset());
+  case MachineOperand::MO_TargetIndex:
+    return stable_hash_combine(H, MO.getIndex(), MO.getOffset());
+  case MachineOperand::MO_JumpTableIndex:
+    return stable_hash_combine(H, MO.getIndex());
+  case MachineOperand::MO_ExternalSymbol:
+    return stable_hash_combine(
+        H, MO.getOffset(),
+        static_cast<stable_hash>(hash_value(StringRef(MO.getSymbolName()))));
+  case MachineOperand::MO_GlobalAddress:
+    return stable_hash_combine(
+        H, static_cast<stable_hash>(hash_value(MO.getGlobal()->getName())),
+        MO.getOffset());
+  case MachineOperand::MO_BlockAddress:
+    return stable_hash_combine(
+        H,
+        static_cast<stable_hash>(
+            hash_value(MO.getBlockAddress()->getFunction()->getName())),
+        MO.getBlockAddress()->getBasicBlock()->hasName()
+            ? static_cast<stable_hash>(
+                  hash_value(MO.getBlockAddress()->getBasicBlock()->getName()))
+            : static_cast<stable_hash>(
+                  hash_value(MO.getBlockAddress()->getBasicBlock())),
+        MO.getOffset());
+  case MachineOperand::MO_Metadata:
+    return stable_hash_combine(H, hash_value(MO.getMetadata()));
+  case MachineOperand::MO_MCSymbol:
+    return stable_hash_combine(
+        H, static_cast<stable_hash>(hash_value(MO.getMCSymbol()->getName())));
+  case MachineOperand::MO_RegisterMask:
+  case MachineOperand::MO_RegisterLiveOut: {
+    const MachineInstr *MI = MO.getParent();
+    const MachineBasicBlock *MBB = MI ? MI->getParent() : nullptr;
+    const MachineFunction *MF = MBB ? MBB->getParent() : nullptr;
+    const TargetRegisterInfo *TRI =
+        MF ? MF->getSubtarget().getRegisterInfo() : nullptr;
+    if (!TRI)
+      return H;
+    unsigned RegMaskSize = MachineOperand::getRegMaskSize(TRI->getNumRegs());
+    const uint32_t *RegMask =
+        MO.isRegMask() ? MO.getRegMask() : MO.getRegLiveOut();
+    SmallVector<stable_hash, 32> RegMaskHashes(RegMask, RegMask + RegMaskSize);
+    return stable_hash_combine(H, stable_hash_combine(RegMaskHashes));
+  }
+  case MachineOperand::MO_CFIIndex:
+    return stable_hash_combine(H, MO.getCFIIndex());
+  case MachineOperand::MO_IntrinsicID:
+    return stable_hash_combine(H, MO.getIntrinsicID());
+  case MachineOperand::MO_Predicate:
+    return stable_hash_combine(H, MO.getPredicate());
+  case MachineOperand::MO_ShuffleMask: {
+    SmallVector<stable_hash, 8> ShuffleMaskHashes;
+    llvm::transform(MO.getShuffleMask(), std::back_inserter(ShuffleMaskHashes),
+                    [](int S) { return stable_hash(S); });
+    return stable_hash_combine(H, stable_hash_combine(ShuffleMaskHashes));
+  }
+  case MachineOperand::MO_DbgInstrRef:
+    return stable_hash_combine(H, MO.getInstrRefInstrIndex(),
+                               MO.getInstrRefOpIndex());
+  case MachineOperand::MO_LaneMask:
+    return stable_hash_combine(H, MO.getLaneMask().getAsInteger());
+  }
+  llvm_unreachable("Invalid machine operand type");
+}
+
+static stable_hash hashLocationSizeForChangePrinter(LocationSize Size) {
+  if (!Size.hasValue())
+    return 0;
+
+  TypeSize TySize = Size.getValue();
+  return stable_hash_combine(/*HasValue=*/true, TySize.getKnownMinValue(),
+                             TySize.isScalable());
+}
+
+static stable_hash
+hashMachineMemOperandForChangePrinter(const MachineMemOperand &MMO) {
+  AAMDNodes AAInfo = MMO.getAAInfo();
+  SmallVector<stable_hash, 16> HashComponents;
+  HashComponents.push_back(static_cast<unsigned>(MMO.getFlags()));
+  HashComponents.push_back(hashLocationSizeForChangePrinter(MMO.getSize()));
+  HashComponents.push_back(MMO.getOffset());
+  HashComponents.push_back(MMO.getAddrSpace());
+  HashComponents.push_back(MMO.getBaseAlign().value());
+  HashComponents.push_back(static_cast<unsigned>(MMO.getSyncScopeID()));
+  HashComponents.push_back(static_cast<unsigned>(MMO.getSuccessOrdering()));
+  HashComponents.push_back(static_cast<unsigned>(MMO.getFailureOrdering()));
+  HashComponents.push_back(MMO.getMemoryType().isValid()
+                               ? MMO.getMemoryType().getUniqueRAWLLTData()
+                               : uint64_t(0));
+  HashComponents.push_back(
+      static_cast<stable_hash>(hash_value(MMO.getOpaqueValue())));
+  HashComponents.push_back(static_cast<stable_hash>(hash_value(AAInfo.TBAA)));
+  HashComponents.push_back(
+      static_cast<stable_hash>(hash_value(AAInfo.TBAAStruct)));
+  HashComponents.push_back(static_cast<stable_hash>(hash_value(AAInfo.Scope)));
+  HashComponents.push_back(
+      static_cast<stable_hash>(hash_value(AAInfo.NoAlias)));
+  HashComponents.push_back(
+      static_cast<stable_hash>(hash_value(AAInfo.NoAliasAddrSpace)));
+  HashComponents.push_back(
+      static_cast<stable_hash>(hash_value(MMO.getRanges())));
+  return stable_hash_combine(HashComponents);
+}
+
+stable_hash llvm::stableHashValueForChangePrinter(const MachineInstr &MI) {
+  stable_hash H =
+      stable_hash_combine(MI.getOpcode(), MI.getFlags(), MI.getNumOperands(),
+                          MI.getNumMemOperands());
+  for (const MachineOperand &MO : MI.operands())
+    H = stable_hash_combine(H, hashMachineOperandForChangePrinter(MO));
+  for (const MachineMemOperand *MMO : MI.memoperands())
+    H = stable_hash_combine(H, hashMachineMemOperandForChangePrinter(*MMO));
+  return H;
+}
+
+static stable_hash stableHashMachineBasicBlockForChangePrinter(
+    const MachineBasicBlock &MBB,
+    MachineBasicBlockStableHashInfo *Details = nullptr) {
+  if (Details)
+    Details->MBB = &MBB;
+
+  stable_hash MBBHash = 0;
+  for (const MachineInstr &MI : MBB) {
+    stable_hash MIHash = stableHashValueForChangePrinter(MI);
+    MBBHash = stable_hash_combine(MBBHash, MIHash);
+  }
+
+  if (Details)
+    Details->Hash = MBBHash;
+  return MBBHash;
+}
+
+static stable_hash hashMachineFunctionForChangePrinter(
+    const MachineFunction &MF,
+    MachineFunctionStableHashInfo *Details = nullptr) {
+  if (Details)
+    Details->Blocks.reserve(MF.size());
+
+  stable_hash MFHash = 0;
+  for (const MachineBasicBlock &MBB : MF) {
+    MachineBasicBlockStableHashInfo *BlockDetails = nullptr;
+    if (Details) {
+      Details->Blocks.emplace_back();
+      BlockDetails = &Details->Blocks.back();
+    }
+    MFHash = stable_hash_combine(
+        MFHash, stableHashMachineBasicBlockForChangePrinter(MBB, BlockDetails));
+  }
+
+  if (Details)
+    Details->Hash = MFHash;
+  return MFHash;
+}
+
+stable_hash
+llvm::stableHashValueForChangePrinter(const MachineBasicBlock &MBB) {
+  return stableHashMachineBasicBlockForChangePrinter(MBB);
+}
+
+stable_hash llvm::stableHashValueForChangePrinter(const MachineFunction &MF) {
+  return hashMachineFunctionForChangePrinter(MF);
+}
+
+MachineFunctionStableHashInfo
+llvm::stableHashValueWithDetailsForChangePrinter(const MachineFunction &MF) {
+  MachineFunctionStableHashInfo Details;
+  hashMachineFunctionForChangePrinter(MF, &Details);
+  return Details;
 }

--- a/llvm/lib/IR/PrintPasses.cpp
+++ b/llvm/lib/IR/PrintPasses.cpp
@@ -8,6 +8,7 @@
 
 #include "llvm/IR/PrintPasses.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/CommandLine.h"
@@ -18,6 +19,7 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Program.h"
 #include "llvm/Support/raw_ostream.h"
+#include <optional>
 
 using namespace llvm;
 
@@ -54,33 +56,149 @@ static cl::opt<bool> PrintAfterAll("print-after-all",
 // with the rest being reported as filtered out.  The -print-before-changed
 // option will print the IR as it was before each pass that changed it. The
 // optional value of quiet will only report when the IR changes, suppressing all
-// other messages, including the initial IR. The values "diff" and "diff-quiet"
+// other messages, including the initial IR. The optional values are separated
+// by commas. The value "attrs-only" will only print function attribute changes
+// when only function attributes changed. Without "attrs-only", attribute-only
+// changes keep the historical behavior: -print-changed reports the change by
+// printing the changed IR. With "attrs-only", passes that only change function
+// attributes print a compact before/after attribute report instead. Other IR
+// changes still use the normal print-changed output.
+// The hash modes use structural hashes to avoid printing and comparing the full
+// IR after every pass. This is faster, but it reports changes according to what
+// the hash encodes. The default text mode remains the reference mode for
+// faithfully detecting changes in the printed IR. The "hash-func" mode reports
+// changed functions, while "hash-bb" can narrow reports to changed basic
+// blocks when block hashes are available. This avoids printing unchanged basic
+// blocks, which has been effective in empirical measurements when most blocks
+// are unchanged.
+// The values "diff" and "diff-quiet"
 // will present the changes in a form similar to a patch, in either verbose or
 // quiet mode, respectively. The lines that are removed and added are prefixed
 // with '-' and '+', respectively. The -filter-print-funcs and -filter-passes
-// can be used to filter the output.  This reporter relies on the linux diff
+// can be used to filter the output. This reporter relies on the linux diff
 // utility to do comparisons and insert the prefixes. For systems that do not
 // have the necessary facilities, the error message will be shown in place of
 // the expected output.
-cl::opt<ChangePrinter> llvm::PrintChanged(
-    "print-changed", cl::desc("Print changed IRs"), cl::Hidden,
-    cl::ValueOptional, cl::init(ChangePrinter::None),
-    cl::values(
-        clEnumValN(ChangePrinter::Quiet, "quiet", "Run in quiet mode"),
-        clEnumValN(ChangePrinter::DiffVerbose, "diff",
-                   "Display patch-like changes"),
-        clEnumValN(ChangePrinter::DiffQuiet, "diff-quiet",
-                   "Display patch-like changes in quiet mode"),
-        clEnumValN(ChangePrinter::ColourDiffVerbose, "cdiff",
-                   "Display patch-like changes with color"),
-        clEnumValN(ChangePrinter::ColourDiffQuiet, "cdiff-quiet",
-                   "Display patch-like changes in quiet mode with color"),
-        clEnumValN(ChangePrinter::DotCfgVerbose, "dot-cfg",
-                   "Create a website with graphical changes"),
-        clEnumValN(ChangePrinter::DotCfgQuiet, "dot-cfg-quiet",
-                   "Create a website with graphical changes in quiet mode"),
-        // Sentinel value for unspecified option.
-        clEnumValN(ChangePrinter::Verbose, "", "")));
+ChangePrinter llvm::PrintChanged = ChangePrinter::None;
+static bool PrintChangedAttributeDiffs = false;
+static ChangePrinterHashMode PrintChangedHashMode = ChangePrinterHashMode::None;
+
+namespace {
+enum class ChangePrinterFormat { Text, Diff, ColourDiff, DotCfg };
+
+struct PrintChangedOption {
+  void reportError(StringRef Value) const {
+    reportFatalUsageError(
+        Twine("invalid argument '") + Value +
+        "' to -print-changed=; expected a comma-separated list of quiet, "
+        "hash, hash-func, hash-bb, attrs-only, diff, diff-quiet, cdiff, "
+        "cdiff-quiet, dot-cfg, or dot-cfg-quiet");
+  }
+
+  void operator=(const std::string &Value) const {
+    PrintChanged = ChangePrinter::Verbose;
+    PrintChangedAttributeDiffs = false;
+    PrintChangedHashMode = ChangePrinterHashMode::None;
+
+    bool Quiet = false;
+    std::optional<ChangePrinterFormat> Format;
+    std::optional<std::string> HashModeValue;
+
+    SmallVector<StringRef> Values;
+    StringRef(Value).split(Values, ',', -1, false);
+    if (Values.empty())
+      Values.push_back("");
+
+    auto SetFormat = [&](StringRef V, ChangePrinterFormat F) {
+      if (Format && *Format != F)
+        reportError(V);
+      Format = F;
+    };
+    auto SetHashMode = [&](StringRef V, ChangePrinterHashMode H) {
+      if (PrintChangedHashMode != ChangePrinterHashMode::None &&
+          PrintChangedHashMode != H)
+        reportError(V);
+      PrintChangedHashMode = H;
+      if (!HashModeValue)
+        HashModeValue = V.str();
+    };
+
+    for (StringRef V : Values) {
+      if (V.empty())
+        continue;
+      if (V == "quiet") {
+        Quiet = true;
+      } else if (V == "hash" || V == "hash-func") {
+        SetHashMode(V, ChangePrinterHashMode::Function);
+      } else if (V == "hash-bb") {
+        SetHashMode(V, ChangePrinterHashMode::BasicBlock);
+      } else if (V == "attrs-only") {
+        PrintChangedAttributeDiffs = true;
+      } else if (V == "diff") {
+        SetFormat(V, ChangePrinterFormat::Diff);
+      } else if (V == "diff-quiet") {
+        SetFormat(V, ChangePrinterFormat::Diff);
+        Quiet = true;
+      } else if (V == "cdiff") {
+        SetFormat(V, ChangePrinterFormat::ColourDiff);
+      } else if (V == "cdiff-quiet") {
+        SetFormat(V, ChangePrinterFormat::ColourDiff);
+        Quiet = true;
+      } else if (V == "dot-cfg") {
+        SetFormat(V, ChangePrinterFormat::DotCfg);
+      } else if (V == "dot-cfg-quiet") {
+        SetFormat(V, ChangePrinterFormat::DotCfg);
+        Quiet = true;
+      } else {
+        reportError(V);
+      }
+    }
+
+    switch (Format.value_or(ChangePrinterFormat::Text)) {
+    case ChangePrinterFormat::Text:
+      PrintChanged = Quiet ? ChangePrinter::Quiet : ChangePrinter::Verbose;
+      break;
+    case ChangePrinterFormat::Diff:
+      PrintChanged =
+          Quiet ? ChangePrinter::DiffQuiet : ChangePrinter::DiffVerbose;
+      break;
+    case ChangePrinterFormat::ColourDiff:
+      PrintChanged = Quiet ? ChangePrinter::ColourDiffQuiet
+                           : ChangePrinter::ColourDiffVerbose;
+      break;
+    case ChangePrinterFormat::DotCfg:
+      PrintChanged =
+          Quiet ? ChangePrinter::DotCfgQuiet : ChangePrinter::DotCfgVerbose;
+      break;
+    }
+
+    if (PrintChangedAttributeDiffs && Format &&
+        *Format != ChangePrinterFormat::Text)
+      reportError("attrs-only");
+    if (PrintChangedHashMode != ChangePrinterHashMode::None && Format &&
+        *Format != ChangePrinterFormat::Text)
+      reportError(*HashModeValue);
+  }
+};
+} // namespace
+
+static PrintChangedOption PrintChangedOptionLoc;
+
+static cl::opt<PrintChangedOption, true, cl::parser<std::string>>
+    PrintChangedOpt("print-changed", cl::desc("Print changed IRs"), cl::Hidden,
+                    cl::ValueOptional, cl::location(PrintChangedOptionLoc));
+
+bool llvm::shouldPrintChangedAttributeDiffs() {
+  return PrintChangedAttributeDiffs;
+}
+
+bool llvm::shouldUsePrintChangedHash() {
+  return PrintChangedHashMode != ChangePrinterHashMode::None;
+}
+
+ChangePrinterHashMode llvm::getPrintChangedHashMode() {
+  return PrintChangedHashMode;
+}
 
 // An option for specifying the diff used by print-changed=[diff | diff-quiet]
 static cl::opt<std::string>
@@ -281,7 +399,7 @@ void llvm::reportChangedIR(StringRef Before, StringRef After,
     case ChangePrinter::ColourDiffVerbose: {
       bool Color = llvm::is_contained(
           {ChangePrinter::ColourDiffQuiet, ChangePrinter::ColourDiffVerbose},
-          PrintChanged.getValue());
+          PrintChanged);
       StringRef Removed = Color ? "\033[31m-%l\033[0m\n" : "-%l\n";
       StringRef Added = Color ? "\033[32m+%l\033[0m\n" : "+%l\n";
       StringRef NoChange = " %l\n";
@@ -292,7 +410,7 @@ void llvm::reportChangedIR(StringRef Before, StringRef After,
   } else if (llvm::is_contained({ChangePrinter::Verbose,
                                  ChangePrinter::DiffVerbose,
                                  ChangePrinter::ColourDiffVerbose},
-                                PrintChanged.getValue())) {
+                                PrintChanged)) {
     const char *Reason =
         IsInteresting ? " omitted because no change" : " filtered out";
     errs() << "*** IR Dump After " << PassName;

--- a/llvm/lib/IR/StructuralHash.cpp
+++ b/llvm/lib/IR/StructuralHash.cpp
@@ -13,6 +13,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IR/Operator.h"
 
 using namespace llvm;
 
@@ -219,6 +220,9 @@ public:
       return stable_hash_combine(Hashes);
 
     Hashes.emplace_back(hashType(Inst.getType()));
+    Hashes.emplace_back(Inst.getRawSubclassOptionalData());
+    if (const auto *FPO = dyn_cast<FPMathOperator>(&Inst))
+      Hashes.emplace_back(FPO->getFastMathFlags().getRawFlags());
 
     // Handle additional properties of specific instructions that cause
     // semantic differences in the IR.

--- a/llvm/lib/IR/StructuralHash.cpp
+++ b/llvm/lib/IR/StructuralHash.cpp
@@ -26,6 +26,7 @@ class StructuralHashImpl {
   stable_hash Hash = 4;
 
   bool DetailedHash;
+  bool CollectDetails;
 
   // This random value acts as a block header, as otherwise the partition of
   // opcodes into BBs wouldn't affect the hash, only the order of the opcodes.
@@ -42,6 +43,7 @@ class StructuralHashImpl {
   /// A mapping from pairs of instruction indices and operand indices
   /// to the hashes of the operands.
   std::unique_ptr<IndexOperandHashMapType> IndexOperandHashMap = nullptr;
+  FunctionStructuralHashInfo Details;
 
   /// Assign a unique ID to each Value in the order they are first seen.
   DenseMap<const Value *, int> ValueToId;
@@ -57,8 +59,10 @@ class StructuralHashImpl {
 public:
   StructuralHashImpl() = delete;
   explicit StructuralHashImpl(bool DetailedHash,
-                              IgnoreOperandFunc IgnoreOp = nullptr)
-      : DetailedHash(DetailedHash), IgnoreOp(IgnoreOp) {
+                              IgnoreOperandFunc IgnoreOp = nullptr,
+                              bool CollectDetails = false)
+      : DetailedHash(DetailedHash), CollectDetails(CollectDetails),
+        IgnoreOp(IgnoreOp) {
     if (IgnoreOp) {
       IndexInstruction = std::make_unique<IndexInstrMap>();
       IndexOperandHashMap = std::make_unique<IndexOperandHashMapType>();
@@ -257,8 +261,11 @@ public:
   // selectively.
   void update(const Function &F) {
     // Declarations don't affect analyses.
-    if (F.isDeclaration())
+    if (F.isDeclaration()) {
+      if (CollectDetails)
+        Details.FunctionHash = Hash;
       return;
+    }
 
     SmallVector<stable_hash> Hashes;
     Hashes.emplace_back(Hash);
@@ -279,8 +286,24 @@ public:
       const BasicBlock *BB = BBs.pop_back_val();
 
       Hashes.emplace_back(BlockHeaderHash);
-      for (auto &Inst : *BB)
-        Hashes.emplace_back(hashInstruction(Inst));
+      SmallVector<stable_hash> BlockHashes;
+      BasicBlockStructuralHashInfo *BlockDetails = nullptr;
+      if (CollectDetails) {
+        BlockHashes.emplace_back(BlockHeaderHash);
+        Details.Blocks.emplace_back(BB);
+        BlockDetails = &Details.Blocks.back();
+      }
+
+      for (auto &Inst : *BB) {
+        stable_hash InstHash = hashInstruction(Inst);
+        Hashes.emplace_back(InstHash);
+        if (CollectDetails) {
+          BlockHashes.emplace_back(InstHash);
+          BlockDetails->Instructions.push_back({&Inst, InstHash});
+        }
+      }
+      if (CollectDetails)
+        BlockDetails->BlockHash = stable_hash_combine(BlockHashes);
 
       for (const BasicBlock *Succ : successors(BB))
         if (VisitedBBs.insert(Succ).second)
@@ -289,6 +312,8 @@ public:
 
     // Update the combined hash in place.
     Hash = stable_hash_combine(Hashes);
+    if (CollectDetails)
+      Details.FunctionHash = Hash;
   }
 
   void update(const GlobalVariable &GV) {
@@ -315,6 +340,8 @@ public:
 
   uint64_t getHash() const { return Hash; }
 
+  FunctionStructuralHashInfo getDetails() { return std::move(Details); }
+
   std::unique_ptr<IndexInstrMap> getIndexInstrMap() {
     return std::move(IndexInstruction);
   }
@@ -330,6 +357,14 @@ stable_hash llvm::StructuralHash(const Function &F, bool DetailedHash) {
   StructuralHashImpl H(DetailedHash);
   H.update(F);
   return H.getHash();
+}
+
+FunctionStructuralHashInfo llvm::StructuralHashWithDetails(const Function &F,
+                                                           bool DetailedHash) {
+  StructuralHashImpl H(DetailedHash, /*IgnoreOp=*/nullptr,
+                       /*CollectDetails=*/true);
+  H.update(F);
+  return H.getDetails();
 }
 
 stable_hash llvm::StructuralHash(const GlobalVariable &GVar) {

--- a/llvm/lib/IR/StructuralHash.cpp
+++ b/llvm/lib/IR/StructuralHash.cpp
@@ -19,6 +19,8 @@ using namespace llvm;
 
 namespace {
 
+static bool shouldCollectAllBlocks(const BasicBlock &) { return true; }
+
 // Basic hashing mechanism to detect structural change to the IR, used to verify
 // pass return status consistency with actual change. In addition to being used
 // by the MergeFunctions pass.
@@ -50,7 +52,7 @@ class StructuralHashImpl {
   DenseMap<const Value *, int> ValueToId;
 
   static stable_hash hashType(Type *ValueType) {
-    SmallVector<stable_hash> Hashes;
+    SmallVector<stable_hash, 4> Hashes;
     Hashes.emplace_back(ValueType->getTypeID());
     if (ValueType->isIntegerTy())
       Hashes.emplace_back(ValueType->getIntegerBitWidth());
@@ -71,7 +73,7 @@ public:
   }
 
   static stable_hash hashAPInt(const APInt &I) {
-    SmallVector<stable_hash> Hashes;
+    SmallVector<stable_hash, 8> Hashes;
     Hashes.emplace_back(I.getBitWidth());
     auto RawVals = ArrayRef<uint64_t>(I.getRawData(), I.getNumWords());
     Hashes.append(RawVals.begin(), RawVals.end());
@@ -121,7 +123,7 @@ public:
   // we're interested in computing a hash rather than comparing two Constants.
   // Some of the logic is simplified, e.g, we don't expand GEPOperator.
   static stable_hash hashConstant(const Constant *C) {
-    SmallVector<stable_hash> Hashes;
+    SmallVector<stable_hash, 2> Hashes;
 
     Type *Ty = C->getType();
     Hashes.emplace_back(hashType(Ty));
@@ -194,7 +196,7 @@ public:
       return hashConstant(C);
 
     // Hash argument number.
-    SmallVector<stable_hash> Hashes;
+    SmallVector<stable_hash, 2> Hashes;
     if (Argument *Arg = dyn_cast<Argument>(V))
       Hashes.emplace_back(Arg->getArgNo());
 
@@ -206,14 +208,14 @@ public:
   }
 
   stable_hash hashOperand(Value *Operand) {
-    SmallVector<stable_hash> Hashes;
+    SmallVector<stable_hash, 8> Hashes;
     Hashes.emplace_back(hashType(Operand->getType()));
     Hashes.emplace_back(hashValue(Operand));
     return stable_hash_combine(Hashes);
   }
 
   stable_hash hashInstruction(const Instruction &Inst) {
-    SmallVector<stable_hash> Hashes;
+    SmallVector<stable_hash, 16> Hashes;
     Hashes.emplace_back(Inst.getOpcode());
 
     if (!DetailedHash)
@@ -263,7 +265,10 @@ public:
   // expensive checks for pass modification status). When modifying this
   // function, most changes should be gated behind an option and enabled
   // selectively.
-  void update(const Function &F) {
+  void update(const Function &F) { update(F, shouldCollectAllBlocks); }
+
+  void update(const Function &F,
+              function_ref<bool(const BasicBlock &)> ShouldCollectBlock) {
     // Declarations don't affect analyses.
     if (F.isDeclaration()) {
       if (CollectDetails)
@@ -271,7 +276,7 @@ public:
       return;
     }
 
-    SmallVector<stable_hash> Hashes;
+    SmallVector<stable_hash, 128> Hashes;
     Hashes.emplace_back(Hash);
     Hashes.emplace_back(FunctionHeaderHash);
 
@@ -280,6 +285,8 @@ public:
 
     SmallVector<const BasicBlock *, 8> BBs;
     SmallPtrSet<const BasicBlock *, 16> VisitedBBs;
+    if (CollectDetails)
+      Details.Blocks.reserve(F.size());
 
     // Walk the blocks in the same order as
     // FunctionComparator::cmpBasicBlocks(), accumulating the hash of the
@@ -289,11 +296,11 @@ public:
     while (!BBs.empty()) {
       const BasicBlock *BB = BBs.pop_back_val();
 
+      size_t BlockHashStart = Hashes.size();
       Hashes.emplace_back(BlockHeaderHash);
-      SmallVector<stable_hash> BlockHashes;
       BasicBlockStructuralHashInfo *BlockDetails = nullptr;
-      if (CollectDetails) {
-        BlockHashes.emplace_back(BlockHeaderHash);
+      bool CollectBlockDetails = CollectDetails && ShouldCollectBlock(*BB);
+      if (CollectBlockDetails) {
         Details.Blocks.emplace_back(BB);
         BlockDetails = &Details.Blocks.back();
       }
@@ -301,13 +308,10 @@ public:
       for (auto &Inst : *BB) {
         stable_hash InstHash = hashInstruction(Inst);
         Hashes.emplace_back(InstHash);
-        if (CollectDetails) {
-          BlockHashes.emplace_back(InstHash);
-          BlockDetails->Instructions.push_back({&Inst, InstHash});
-        }
       }
-      if (CollectDetails)
-        BlockDetails->BlockHash = stable_hash_combine(BlockHashes);
+      if (CollectBlockDetails)
+        BlockDetails->BlockHash =
+            stable_hash_combine(ArrayRef(Hashes).drop_front(BlockHashStart));
 
       for (const BasicBlock *Succ : successors(BB))
         if (VisitedBBs.insert(Succ).second)
@@ -326,7 +330,7 @@ public:
     // we ignore anything with the `.llvm` prefix
     if (GV.isDeclaration() || GV.getName().starts_with("llvm."))
       return;
-    SmallVector<stable_hash> Hashes;
+    SmallVector<stable_hash, 8> Hashes;
     Hashes.emplace_back(Hash);
     Hashes.emplace_back(GlobalHeaderHash);
     Hashes.emplace_back(GV.getValueType()->getTypeID());
@@ -365,9 +369,15 @@ stable_hash llvm::StructuralHash(const Function &F, bool DetailedHash) {
 
 FunctionStructuralHashInfo llvm::StructuralHashWithDetails(const Function &F,
                                                            bool DetailedHash) {
+  return StructuralHashWithDetails(F, DetailedHash, shouldCollectAllBlocks);
+}
+
+FunctionStructuralHashInfo llvm::StructuralHashWithDetails(
+    const Function &F, bool DetailedHash,
+    function_ref<bool(const BasicBlock &)> ShouldCollectBlock) {
   StructuralHashImpl H(DetailedHash, /*IgnoreOp=*/nullptr,
                        /*CollectDetails=*/true);
-  H.update(F);
+  H.update(F, ShouldCollectBlock);
   return H.getDetails();
 }
 

--- a/llvm/lib/Passes/StandardInstrumentations.cpp
+++ b/llvm/lib/Passes/StandardInstrumentations.cpp
@@ -15,17 +15,22 @@
 #include "llvm/Passes/StandardInstrumentations.h"
 #include "llvm/ADT/Any.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Analysis/LazyCallGraph.h"
 #include "llvm/Analysis/LoopInfo.h"
 #include "llvm/CodeGen/MIRPrinter.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
+#include "llvm/CodeGen/MachineStableHash.h"
 #include "llvm/CodeGen/MachineVerifier.h"
 #include "llvm/IR/Constants.h"
+#include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IR/ModuleSlotTracker.h"
 #include "llvm/IR/PassInstrumentation.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/IR/PrintPasses.h"
@@ -42,6 +47,7 @@
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/xxhash.h"
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -291,6 +297,283 @@ bool shouldPrintIR(Any IR) {
   llvm_unreachable("Unknown wrapped IR type");
 }
 
+static stable_hash hashFunctionForChangePrinter(const Function &F) {
+  SmallVector<stable_hash> Hashes = {stable_hash_name(F.getName()),
+                                     F.isDeclaration()};
+  if (!F.isDeclaration())
+    Hashes.push_back(StructuralHash(F, /*DetailedHash=*/true));
+  return stable_hash_combine(Hashes);
+}
+
+static void saveFunctionAttributesForChangePrinter(
+    const Function &F, SmallVectorImpl<FunctionChangeAttributes> &Attrs) {
+  Attrs.push_back({F.getName().str(), F.getAttributes(),
+                   static_cast<unsigned>(F.arg_size())});
+}
+
+static std::string getBasicBlockChangeKey(
+    const BasicBlock &BB,
+    const DenseMap<const BasicBlock *, unsigned> *Numbers = nullptr) {
+  if (BB.hasName())
+    return BB.getName().str();
+  if (Numbers)
+    return formatv("{0}", Numbers->lookup(&BB)).str();
+
+  unsigned Index = 0;
+  for (const BasicBlock &FuncBB : *BB.getParent()) {
+    if (&FuncBB == &BB)
+      return formatv("{0}", Index).str();
+    ++Index;
+  }
+  llvm_unreachable("basic block must be in its parent function");
+}
+
+static std::string getMachineBasicBlockChangeKey(
+    const MachineBasicBlock &MBB,
+    const DenseMap<const MachineBasicBlock *, unsigned> *Numbers = nullptr) {
+  if (MBB.hasName())
+    return MBB.getName().str();
+  if (Numbers)
+    return formatv("{0}", Numbers->lookup(&MBB)).str();
+  return formatv("{0}", MBB.getNumber()).str();
+}
+
+static void appendFunctionChangeHash(IRChangeHash &Output,
+                                     FunctionChangeHash &&FunctionHash) {
+  Output.Hash = stable_hash_combine(
+      Output.Hash, stable_hash_name(FunctionHash.Name), FunctionHash.Hash);
+  Output.Functions.push_back(std::move(FunctionHash));
+}
+
+static bool shouldCollectAllBasicBlocks(const BasicBlock &) { return true; }
+
+// BasicBlock pointers in StructuralHashWithDetails are only valid for the
+// current snapshot. Across passes, hash-bb matches blocks by a derived key:
+// the block name when present, otherwise the block's ordinal position in the
+// function. This does not suppress transformed or duplicated blocks; changed
+// and newly-created blocks are still printed. The limitation is association:
+// passes that delete/recreate, duplicate, or reorder unnamed blocks can appear
+// as added/deleted or position-matched block changes instead of being matched
+// to a previous logical block. TODO: add a more stable block tracking key.
+static void collectFunctionChangeHash(
+    const Function &F, IRChangeHash &Output, bool MatchAllFunctions = false,
+    function_ref<bool(const BasicBlock &)> ShouldCollectBlock =
+        shouldCollectAllBasicBlocks) {
+  if (!MatchAllFunctions && !isFunctionInPrintList(F.getName()))
+    return;
+
+  ChangePrinterHashMode HashMode = getPrintChangedHashMode();
+  FunctionChangeHash FunctionHash;
+  FunctionHash.Name = F.getName().str();
+  saveFunctionAttributesForChangePrinter(F, Output.FunctionAttrs);
+
+  if (F.isDeclaration() || HashMode == ChangePrinterHashMode::Function ||
+      (HashMode == ChangePrinterHashMode::BasicBlock && F.size() <= 1)) {
+    FunctionHash.Hash = hashFunctionForChangePrinter(F);
+  } else {
+    FunctionStructuralHashInfo Details =
+        StructuralHashWithDetails(F, /*DetailedHash=*/true, ShouldCollectBlock);
+    FunctionHash.Hash = stable_hash_combine(
+        stable_hash_name(F.getName()), F.isDeclaration(), Details.FunctionHash);
+    DenseMap<const BasicBlock *, unsigned> BlockNumbers;
+    unsigned BlockNumber = 0;
+    for (const BasicBlock &BB : F)
+      BlockNumbers.try_emplace(&BB, BlockNumber++);
+    for (const BasicBlockStructuralHashInfo &BlockInfo : Details.Blocks) {
+      BasicBlockChangeHash BlockHash;
+      BlockHash.Key = getBasicBlockChangeKey(*BlockInfo.BB, &BlockNumbers);
+      BlockHash.Hash = BlockInfo.BlockHash;
+      FunctionHash.Blocks.push_back(std::move(BlockHash));
+    }
+  }
+
+  appendFunctionChangeHash(Output, std::move(FunctionHash));
+}
+
+static void collectMachineFunctionChangeHash(const MachineFunction &MF,
+                                             IRChangeHash &Output) {
+  if (!isFunctionInPrintList(MF.getName()))
+    return;
+
+  ChangePrinterHashMode HashMode = getPrintChangedHashMode();
+  FunctionChangeHash FunctionHash;
+  FunctionHash.Name = MF.getName().str();
+
+  if (HashMode == ChangePrinterHashMode::Function ||
+      (HashMode == ChangePrinterHashMode::BasicBlock && MF.size() <= 1)) {
+    FunctionHash.Hash = stableHashValueForChangePrinter(MF);
+    appendFunctionChangeHash(Output, std::move(FunctionHash));
+    return;
+  }
+
+  MachineFunctionStableHashInfo Details =
+      stableHashValueWithDetailsForChangePrinter(MF);
+  FunctionHash.Hash = Details.Hash;
+  DenseMap<const MachineBasicBlock *, unsigned> BlockNumbers;
+  unsigned BlockNumber = 0;
+  for (const MachineBasicBlock &MBB : MF)
+    BlockNumbers.try_emplace(&MBB, BlockNumber++);
+  for (const MachineBasicBlockStableHashInfo &BlockInfo : Details.Blocks) {
+    BasicBlockChangeHash BlockHash;
+    BlockHash.Key =
+        getMachineBasicBlockChangeKey(*BlockInfo.MBB, &BlockNumbers);
+    BlockHash.Hash = BlockInfo.Hash;
+    FunctionHash.Blocks.push_back(std::move(BlockHash));
+  }
+
+  appendFunctionChangeHash(Output, std::move(FunctionHash));
+}
+
+static constexpr stable_hash PrintedFunctionsHashSalt = 0x8a2d3c4f;
+
+static void hashIRForChangePrinter(Any IR, IRChangeHash &Output) {
+  Output.Hash = PrintedFunctionsHashSalt;
+
+  if (const auto *M = unwrapIR<Module>(IR)) {
+    bool MatchAllFunctions = isFunctionInPrintList("*") || forcePrintModuleIR();
+    if (MatchAllFunctions)
+      Output.Hash = stable_hash_combine(
+          Output.Hash, StructuralHash(*M, /*DetailedHash=*/true));
+    for (const Function &F : *M)
+      collectFunctionChangeHash(F, Output, MatchAllFunctions);
+    return;
+  }
+
+  if (const auto *F = unwrapIR<Function>(IR)) {
+    collectFunctionChangeHash(*F, Output);
+    return;
+  }
+
+  if (const auto *C = unwrapIR<LazyCallGraph::SCC>(IR)) {
+    for (const LazyCallGraph::Node &N : *C)
+      collectFunctionChangeHash(N.getFunction(), Output);
+    return;
+  }
+
+  if (const auto *L = unwrapIR<Loop>(IR)) {
+    SmallPtrSet<const BasicBlock *, 8> LoopBlocks;
+    for (const BasicBlock *BB : L->blocks())
+      LoopBlocks.insert(BB);
+    collectFunctionChangeHash(*L->getHeader()->getParent(), Output,
+                              /*MatchAllFunctions=*/false,
+                              [&LoopBlocks](const BasicBlock &BB) {
+                                return LoopBlocks.contains(&BB);
+                              });
+    return;
+  }
+
+  llvm_unreachable("Unknown wrapped IR type");
+}
+
+static bool
+collectFunctionNamesForChangePrinter(Any IR,
+                                     SmallVectorImpl<std::string> &Names) {
+  if (const auto *M = unwrapIR<Module>(IR)) {
+    bool MatchAllFunctions = isFunctionInPrintList("*") || forcePrintModuleIR();
+    for (const Function &F : *M)
+      if (MatchAllFunctions || isFunctionInPrintList(F.getName()))
+        Names.push_back(F.getName().str());
+    return true;
+  }
+
+  if (const auto *F = unwrapIR<Function>(IR)) {
+    if (isFunctionInPrintList(F->getName()))
+      Names.push_back(F->getName().str());
+    return true;
+  }
+
+  if (const auto *C = unwrapIR<LazyCallGraph::SCC>(IR)) {
+    for (const LazyCallGraph::Node &N : *C)
+      if (isFunctionInPrintList(N.getFunction().getName()))
+        Names.push_back(N.getFunction().getName().str());
+    return true;
+  }
+
+  if (const auto *L = unwrapIR<Loop>(IR)) {
+    const Function *F = L->getHeader()->getParent();
+    if (isFunctionInPrintList(F->getName()))
+      Names.push_back(F->getName().str());
+    return true;
+  }
+
+  if (const auto *MF = unwrapIR<MachineFunction>(IR)) {
+    if (isFunctionInPrintList(MF->getName()))
+      Names.push_back(MF->getName().str());
+    return false;
+  }
+
+  llvm_unreachable("Unknown wrapped IR type");
+}
+
+static void hashWholeIRForStatefulChangePrinter(Any IR, IRChangeHash &Output) {
+  if (const auto *MF = unwrapIR<MachineFunction>(IR)) {
+    Output.Hash = PrintedFunctionsHashSalt;
+    collectMachineFunctionChangeHash(*MF, Output);
+    return;
+  }
+
+  if (const auto *L = unwrapIR<Loop>(IR)) {
+    Output.Hash = PrintedFunctionsHashSalt;
+    collectFunctionChangeHash(*L->getHeader()->getParent(), Output);
+    return;
+  }
+
+  hashIRForChangePrinter(IR, Output);
+}
+
+static void updateStatefulHashCache(
+    const IRChangeHash &Hash, ArrayRef<std::string> BeforeNames,
+    StringMap<FunctionChangeHash> &FunctionCache,
+    StringMap<FunctionChangeAttributes> *AttrCache = nullptr) {
+  DenseSet<StringRef> AfterNames;
+  for (const FunctionChangeHash &Func : Hash.Functions) {
+    AfterNames.insert(Func.Name);
+    FunctionCache[Func.Name] = Func;
+  }
+
+  if (AttrCache)
+    for (const FunctionChangeAttributes &Attrs : Hash.FunctionAttrs)
+      (*AttrCache)[Attrs.Name] = Attrs;
+
+  for (StringRef Name : BeforeNames) {
+    if (AfterNames.contains(Name))
+      continue;
+    FunctionCache.erase(Name);
+    if (AttrCache)
+      AttrCache->erase(Name);
+  }
+}
+
+static void
+buildStatefulBeforeHash(ArrayRef<std::string> FunctionNames,
+                        const StringMap<FunctionChangeHash> &FunctionCache,
+                        const StringMap<FunctionChangeAttributes> *AttrCache,
+                        IRChangeHash &Before) {
+  Before.Hash = PrintedFunctionsHashSalt;
+  for (StringRef Name : FunctionNames) {
+    auto FuncIt = FunctionCache.find(Name);
+    if (FuncIt == FunctionCache.end())
+      continue;
+    FunctionChangeHash Func = FuncIt->second;
+    appendFunctionChangeHash(Before, std::move(Func));
+
+    if (AttrCache) {
+      auto AttrIt = AttrCache->find(Name);
+      if (AttrIt != AttrCache->end())
+        Before.FunctionAttrs.push_back(AttrIt->second);
+    }
+  }
+}
+
+static bool
+hasMissingStatefulHash(ArrayRef<std::string> FunctionNames,
+                       const StringMap<FunctionChangeHash> &FunctionCache) {
+  for (StringRef Name : FunctionNames)
+    if (!FunctionCache.contains(Name))
+      return true;
+  return false;
+}
+
 /// Generic IR-printing helper that unpacks a pointer to IRUnit wrapped into
 /// Any and does actual print job.
 void unwrapAndPrint(raw_ostream &OS, Any IR) {
@@ -507,9 +790,30 @@ void TextChangeReporter<T>::handleIgnored(StringRef PassID, std::string &Name) {
 
 IRChangedPrinter::~IRChangedPrinter() = default;
 
+static bool isTextualChangePrinter() {
+  return PrintChanged == ChangePrinter::Verbose ||
+         PrintChanged == ChangePrinter::Quiet;
+}
+
+static bool isHashChangePrinter() {
+  return isTextualChangePrinter() && shouldUsePrintChangedHash();
+}
+
+static bool isAttributeChangePrinter() {
+  return isTextualChangePrinter() && shouldPrintChangedAttributeDiffs();
+}
+
+static bool isHashOrAttributeChangePrinter() {
+  return isHashChangePrinter() || isAttributeChangePrinter();
+}
+
+static bool shouldUseStatefulHashChangePrinter() {
+  return isHashChangePrinter() && !PrintChangedBefore && isFilterPassesEmpty();
+}
+
 void IRChangedPrinter::registerCallbacks(PassInstrumentationCallbacks &PIC) {
-  if (PrintChanged == ChangePrinter::Verbose ||
-      PrintChanged == ChangePrinter::Quiet)
+  if (isTextualChangePrinter() && !shouldUsePrintChangedHash() &&
+      !shouldPrintChangedAttributeDiffs())
     TextChangeReporter<std::string>::registerRequiredCallbacks(PIC);
 }
 
@@ -536,6 +840,676 @@ void IRChangedPrinter::handleAfter(StringRef PassID, std::string &Name,
   }
 
   Out << "*** IR Dump After " << PassID << " on " << Name << " ***\n" << After;
+}
+
+IRChangedHashPrinter::~IRChangedHashPrinter() = default;
+
+void IRChangedHashPrinter::registerCallbacks(
+    PassInstrumentationCallbacks &PIC) {
+  if (!isHashOrAttributeChangePrinter())
+    return;
+  if (shouldUseStatefulHashChangePrinter()) {
+    registerStatefulHashCallbacks(PIC);
+    return;
+  }
+  TextChangeReporter<IRChangeHash>::registerRequiredCallbacks(PIC);
+}
+
+void IRChangedHashPrinter::registerStatefulHashCallbacks(
+    PassInstrumentationCallbacks &PIC) {
+  PIC.registerBeforeNonSkippedPassCallback([&PIC, this](StringRef P, Any IR) {
+    saveStatefulBeforePass(IR, P, PIC.getPassNameForClassName(P));
+  });
+
+  PIC.registerAfterPassCallback(
+      [&PIC, this](StringRef P, Any IR, const PreservedAnalyses &) {
+        handleStatefulAfterPass(IR, P, PIC.getPassNameForClassName(P));
+      });
+  PIC.registerAfterPassInvalidatedCallback(
+      [this](StringRef P, const PreservedAnalyses &) {
+        handleStatefulInvalidatedPass(P);
+      });
+}
+
+void IRChangedHashPrinter::saveStatefulBeforePass(Any IR, StringRef PassID,
+                                                  StringRef PassName) {
+  assert(isFilterPassesEmpty() &&
+         "stateful hash change printer is disabled with -filter-passes");
+  if (InitialIR) {
+    InitialIR = false;
+    if (VerboseMode)
+      handleInitialIR(IR);
+  }
+
+  StatefulHashFrame Frame;
+  StatefulHashStack.push_back(std::move(Frame));
+
+  if (!isInteresting(IR, PassID, PassName))
+    return;
+
+  StatefulHashFrame &CurrentFrame = StatefulHashStack.back();
+  CurrentFrame.IsInteresting = true;
+  CurrentFrame.IsIR =
+      collectFunctionNamesForChangePrinter(IR, CurrentFrame.FunctionNames);
+  if (CurrentFrame.FunctionNames.empty())
+    return;
+
+  StringMap<FunctionChangeHash> &FunctionCache =
+      CurrentFrame.IsIR ? StatefulFunctionHashes
+                        : StatefulMachineFunctionHashes;
+
+  if (unwrapIR<Loop>(IR)) {
+    CurrentFrame.UseBeforeOverride = true;
+    hashIRForChangePrinter(IR, CurrentFrame.BeforeOverride);
+  }
+
+  if (!hasMissingStatefulHash(CurrentFrame.FunctionNames, FunctionCache))
+    return;
+
+  IRChangeHash Current;
+  hashWholeIRForStatefulChangePrinter(IR, Current);
+  updateStatefulHashCache(Current, ArrayRef<std::string>(), FunctionCache,
+                          CurrentFrame.IsIR ? &StatefulFunctionAttrs : nullptr);
+}
+
+void IRChangedHashPrinter::handleStatefulInvalidatedPass(StringRef PassID) {
+  assert(!StatefulHashStack.empty() && "Unexpected empty stack encountered.");
+  if (VerboseMode)
+    handleInvalidated(PassID);
+  StatefulHashStack.pop_back();
+}
+
+void IRChangedHashPrinter::generateIRRepresentation(Any IR, StringRef PassID,
+                                                    IRChangeHash &Output) {
+  if (!shouldUsePrintChangedHash()) {
+    Output.UseTextComparison = true;
+    if (!unwrapIR<MachineFunction>(IR))
+      hashIRForChangePrinter(IR, Output);
+    raw_string_ostream OS(Output.Text);
+    unwrapAndPrint(OS, IR);
+    OS.str();
+    return;
+  }
+
+  if (const auto *MF = unwrapIR<MachineFunction>(IR)) {
+    Output.Hash = PrintedFunctionsHashSalt;
+    collectMachineFunctionChangeHash(*MF, Output);
+    if (PrintChangedBefore) {
+      raw_string_ostream OS(Output.Text);
+      unwrapAndPrint(OS, IR);
+      OS.str();
+    }
+    return;
+  }
+
+  hashIRForChangePrinter(IR, Output);
+  if (PrintChangedBefore) {
+    raw_string_ostream OS(Output.Text);
+    unwrapAndPrint(OS, IR);
+    OS.str();
+  }
+}
+
+static bool hasOnlyFunctionAttributeChanges(const IRChangeHash &Before,
+                                            const IRChangeHash &After) {
+  if (Before.Hash != After.Hash ||
+      Before.FunctionAttrs.size() != After.FunctionAttrs.size())
+    return false;
+
+  bool HasAttributeChange = false;
+  for (auto [BeforeAttrs, AfterAttrs] :
+       zip_equal(Before.FunctionAttrs, After.FunctionAttrs)) {
+    if (BeforeAttrs.Name != AfterAttrs.Name ||
+        BeforeAttrs.ArgCount != AfterAttrs.ArgCount)
+      return false;
+    HasAttributeChange |= BeforeAttrs.Attributes != AfterAttrs.Attributes;
+  }
+
+  return HasAttributeChange;
+}
+
+static void printAttributeSetChange(raw_ostream &Out, StringRef Label,
+                                    AttributeList BeforeAttrs,
+                                    AttributeList AfterAttrs, unsigned Index) {
+  if (BeforeAttrs.getAttributes(Index) == AfterAttrs.getAttributes(Index))
+    return;
+
+  std::string Before = BeforeAttrs.getAsString(Index);
+  std::string After = AfterAttrs.getAsString(Index);
+  Out << "  " << Label << " before: " << (Before.empty() ? "(none)" : Before)
+      << '\n';
+  Out << "  " << Label << " after:  " << (After.empty() ? "(none)" : After)
+      << '\n';
+}
+
+static void
+printFunctionAttributeChange(raw_ostream &Out,
+                             const FunctionChangeAttributes &Before,
+                             const FunctionChangeAttributes &After) {
+  if (Before.Attributes == After.Attributes)
+    return;
+
+  Out << "Function: " << After.Name << '\n';
+  printAttributeSetChange(Out, "function", Before.Attributes, After.Attributes,
+                          AttributeList::FunctionIndex);
+  printAttributeSetChange(Out, "return", Before.Attributes, After.Attributes,
+                          AttributeList::ReturnIndex);
+  for (unsigned ArgNo = 0; ArgNo != After.ArgCount; ++ArgNo) {
+    std::string Label = "arg " + std::to_string(ArgNo);
+    printAttributeSetChange(Out, Label, Before.Attributes, After.Attributes,
+                            AttributeList::FirstArgIndex + ArgNo);
+  }
+}
+
+static void printFunctionAttributeChanges(raw_ostream &Out, StringRef PassID,
+                                          StringRef Name,
+                                          const IRChangeHash &Before,
+                                          const IRChangeHash &After) {
+  Out << "*** IR Attribute Changes After " << PassID << " on " << Name
+      << " ***\n";
+  for (auto [BeforeAttrs, AfterAttrs] :
+       zip_equal(Before.FunctionAttrs, After.FunctionAttrs))
+    printFunctionAttributeChange(Out, BeforeAttrs, AfterAttrs);
+}
+
+static DenseMap<StringRef, const FunctionChangeHash *>
+collectFunctionChangeHashMap(ArrayRef<FunctionChangeHash> Hashes) {
+  DenseMap<StringRef, const FunctionChangeHash *> Map;
+  for (const FunctionChangeHash &Hash : Hashes)
+    Map.try_emplace(Hash.Name, &Hash);
+  return Map;
+}
+
+static const Function *findFunctionInIR(Any IR, StringRef Name) {
+  if (const auto *M = unwrapIR<Module>(IR))
+    return M->getFunction(Name);
+
+  if (const auto *F = unwrapIR<Function>(IR))
+    return F->getName() == Name ? F : nullptr;
+
+  if (const auto *C = unwrapIR<LazyCallGraph::SCC>(IR)) {
+    for (const LazyCallGraph::Node &N : *C)
+      if (N.getName() == Name)
+        return &N.getFunction();
+    return nullptr;
+  }
+
+  if (const auto *L = unwrapIR<Loop>(IR)) {
+    const Function *F = L->getHeader()->getParent();
+    return F->getName() == Name ? F : nullptr;
+  }
+
+  return nullptr;
+}
+
+static const MachineFunction *findMachineFunctionInIR(Any IR, StringRef Name) {
+  if (const auto *MF = unwrapIR<MachineFunction>(IR))
+    return MF->getName() == Name ? MF : nullptr;
+  return nullptr;
+}
+
+static const BasicBlock *findBasicBlockByKey(const Function &F, StringRef Key) {
+  for (const BasicBlock &BB : F)
+    if (BB.hasName() && BB.getName() == Key)
+      return &BB;
+
+  unsigned Index;
+  if (Key.getAsInteger(10, Index))
+    return nullptr;
+  unsigned CurrentIndex = 0;
+  for (const BasicBlock &BB : F) {
+    if (CurrentIndex == Index)
+      return &BB;
+    ++CurrentIndex;
+  }
+  return nullptr;
+}
+
+static const MachineBasicBlock *
+findMachineBasicBlockByKey(const MachineFunction &MF, StringRef Key) {
+  for (const MachineBasicBlock &MBB : MF)
+    if (MBB.hasName() && MBB.getName() == Key)
+      return &MBB;
+
+  unsigned Number;
+  if (Key.getAsInteger(10, Number))
+    return nullptr;
+  unsigned CurrentIndex = 0;
+  for (const MachineBasicBlock &MBB : MF)
+    if (CurrentIndex++ == Number)
+      return &MBB;
+  return nullptr;
+}
+
+static StringMap<const BasicBlock *> collectBasicBlockMap(const Function &F) {
+  StringMap<const BasicBlock *> Blocks;
+  DenseMap<const BasicBlock *, unsigned> BlockNumbers;
+  unsigned BlockNumber = 0;
+  for (const BasicBlock &BB : F)
+    BlockNumbers.try_emplace(&BB, BlockNumber++);
+  for (const BasicBlock &BB : F)
+    Blocks[getBasicBlockChangeKey(BB, &BlockNumbers)] = &BB;
+  return Blocks;
+}
+
+static StringMap<const MachineBasicBlock *>
+collectMachineBasicBlockMap(const MachineFunction &MF) {
+  StringMap<const MachineBasicBlock *> Blocks;
+  DenseMap<const MachineBasicBlock *, unsigned> BlockNumbers;
+  unsigned BlockNumber = 0;
+  for (const MachineBasicBlock &MBB : MF)
+    BlockNumbers.try_emplace(&MBB, BlockNumber++);
+  for (const MachineBasicBlock &MBB : MF)
+    Blocks[getMachineBasicBlockChangeKey(MBB, &BlockNumbers)] = &MBB;
+  return Blocks;
+}
+
+static const Module *getModuleForChangePrinting(Any IR) {
+  if (const auto *M = unwrapIR<Module>(IR))
+    return M;
+
+  if (const auto *F = unwrapIR<Function>(IR))
+    return F->getParent();
+
+  if (const auto *C = unwrapIR<LazyCallGraph::SCC>(IR)) {
+    for (const LazyCallGraph::Node &N : *C)
+      return N.getFunction().getParent();
+    return nullptr;
+  }
+
+  if (const auto *L = unwrapIR<Loop>(IR))
+    return L->getHeader()->getParent()->getParent();
+
+  if (const auto *MF = unwrapIR<MachineFunction>(IR))
+    return MF->getFunction().getParent();
+
+  return nullptr;
+}
+
+class ChangePrinterPrintContext {
+  Any IR;
+  std::optional<ModuleSlotTracker> MST;
+  bool TriedToCreateMST = false;
+
+  ModuleSlotTracker *getModuleSlotTracker() {
+    if (!TriedToCreateMST) {
+      TriedToCreateMST = true;
+      if (const Module *M = getModuleForChangePrinting(IR))
+        MST.emplace(M, /*ShouldInitializeAllMetadata=*/false);
+    }
+    return MST ? &*MST : nullptr;
+  }
+
+public:
+  explicit ChangePrinterPrintContext(Any IR) : IR(IR) {}
+
+  void printFunction(raw_ostream &Out, const Function &F) {
+    if (ModuleSlotTracker *MST = getModuleSlotTracker()) {
+      static_cast<const Value &>(F).print(Out, *MST);
+      return;
+    }
+    F.print(Out);
+  }
+
+  void printBasicBlock(raw_ostream &Out, const BasicBlock &BB) {
+    if (ModuleSlotTracker *MST = getModuleSlotTracker()) {
+      static_cast<const Value &>(BB).print(Out, *MST, /*IsForDebug=*/true);
+      return;
+    }
+    BB.print(Out, nullptr, /*ShouldPreserveUseListOrder=*/true,
+             /*IsForDebug=*/true);
+  }
+};
+
+static void printFunctionForChange(raw_ostream &Out, Any IR,
+                                   StringRef FunctionName,
+                                   ChangePrinterPrintContext &PrintCtx) {
+  if (const Function *F = findFunctionInIR(IR, FunctionName)) {
+    PrintCtx.printFunction(Out, *F);
+    return;
+  }
+  if (const MachineFunction *MF = findMachineFunctionInIR(IR, FunctionName)) {
+    MF->print(Out);
+    return;
+  }
+  Out << "*** Function " << FunctionName << " deleted ***\n";
+}
+
+static void printBasicBlockForChange(raw_ostream &Out, Any IR,
+                                     StringRef FunctionName, StringRef BlockKey,
+                                     ChangePrinterPrintContext &PrintCtx) {
+  if (const Function *F = findFunctionInIR(IR, FunctionName)) {
+    if (const BasicBlock *BB = findBasicBlockByKey(*F, BlockKey)) {
+      PrintCtx.printBasicBlock(Out, *BB);
+      return;
+    }
+  }
+  if (const MachineFunction *MF = findMachineFunctionInIR(IR, FunctionName)) {
+    if (const MachineBasicBlock *MBB =
+            findMachineBasicBlockByKey(*MF, BlockKey)) {
+      MBB->print(Out);
+      return;
+    }
+  }
+  Out << "*** BasicBlock " << FunctionName << ":" << BlockKey
+      << " deleted ***\n";
+}
+
+static void
+printBasicBlockChangeHeader(raw_ostream &Out, StringRef FunctionName,
+                            StringRef BlockKey, StringRef Change,
+                            const BasicBlock *BB = nullptr,
+                            const MachineBasicBlock *MBB = nullptr) {
+  Out << "*** BasicBlock " << FunctionName << ":";
+  if (BB && BB->hasName())
+    Out << BB->getName();
+  else if (MBB && MBB->hasName())
+    Out << MBB->getName();
+  else
+    Out << BlockKey;
+  Out << " " << Change << " ***\n";
+}
+
+static bool printFunctionHashChanges(raw_ostream &Out, StringRef PassID,
+                                     StringRef Name, const IRChangeHash &Before,
+                                     const IRChangeHash &After, Any IR,
+                                     ChangePrinterPrintContext &PrintCtx) {
+  bool Printed = false;
+  auto EnsureHeader = [&]() {
+    if (Printed)
+      return;
+    Out << "*** IR Function Changes After " << PassID << " on " << Name
+        << " ***\n";
+    Printed = true;
+  };
+  DenseMap<StringRef, const FunctionChangeHash *> BeforeFuncs =
+      collectFunctionChangeHashMap(Before.Functions);
+  DenseMap<StringRef, const FunctionChangeHash *> AfterFuncs =
+      collectFunctionChangeHashMap(After.Functions);
+  for (const FunctionChangeHash &AfterFunc : After.Functions) {
+    const FunctionChangeHash *BeforeFunc = BeforeFuncs.lookup(AfterFunc.Name);
+    if (BeforeFunc && BeforeFunc->Hash == AfterFunc.Hash)
+      continue;
+    EnsureHeader();
+    Out << "*** Function " << AfterFunc.Name << " changed ***\n";
+    printFunctionForChange(Out, IR, AfterFunc.Name, PrintCtx);
+  }
+  for (const FunctionChangeHash &BeforeFunc : Before.Functions) {
+    if (AfterFuncs.contains(BeforeFunc.Name))
+      continue;
+    EnsureHeader();
+    Out << "*** Function " << BeforeFunc.Name << " deleted ***\n";
+  }
+  return Printed;
+}
+
+static bool printBasicBlockHashChanges(raw_ostream &Out, StringRef PassID,
+                                       StringRef Name,
+                                       const IRChangeHash &Before,
+                                       const IRChangeHash &After, Any IR,
+                                       ChangePrinterPrintContext &PrintCtx) {
+  bool Printed = false;
+  auto EnsureHeader = [&]() {
+    if (Printed)
+      return;
+    Out << "*** IR BasicBlock Changes After " << PassID << " on " << Name
+        << " ***\n";
+    Printed = true;
+  };
+  DenseMap<StringRef, const FunctionChangeHash *> BeforeFuncs =
+      collectFunctionChangeHashMap(Before.Functions);
+  DenseMap<StringRef, const FunctionChangeHash *> AfterFuncs =
+      collectFunctionChangeHashMap(After.Functions);
+  for (const FunctionChangeHash &AfterFunc : After.Functions) {
+    const FunctionChangeHash *BeforeFunc = BeforeFuncs.lookup(AfterFunc.Name);
+    if (!BeforeFunc) {
+      EnsureHeader();
+      Out << "*** Function " << AfterFunc.Name << " added ***\n";
+      if (AfterFunc.Blocks.empty()) {
+        printFunctionForChange(Out, IR, AfterFunc.Name, PrintCtx);
+        continue;
+      }
+      const Function *F = findFunctionInIR(IR, AfterFunc.Name);
+      StringMap<const BasicBlock *> CurrentBlocks =
+          F ? collectBasicBlockMap(*F) : StringMap<const BasicBlock *>();
+      const MachineFunction *MF = findMachineFunctionInIR(IR, AfterFunc.Name);
+      StringMap<const MachineBasicBlock *> CurrentMachineBlocks =
+          MF ? collectMachineBasicBlockMap(*MF)
+             : StringMap<const MachineBasicBlock *>();
+      for (const BasicBlockChangeHash &AfterBlock : AfterFunc.Blocks) {
+        const BasicBlock *BB = CurrentBlocks.lookup(AfterBlock.Key);
+        const MachineBasicBlock *MBB =
+            CurrentMachineBlocks.lookup(AfterBlock.Key);
+        printBasicBlockChangeHeader(Out, AfterFunc.Name, AfterBlock.Key,
+                                    "added", BB, MBB);
+        if (BB)
+          PrintCtx.printBasicBlock(Out, *BB);
+        else if (MBB)
+          MBB->print(Out);
+        else
+          printBasicBlockForChange(Out, IR, AfterFunc.Name, AfterBlock.Key,
+                                   PrintCtx);
+      }
+      continue;
+    }
+    if (BeforeFunc->Hash == AfterFunc.Hash)
+      continue;
+
+    if (BeforeFunc->Blocks.empty() || AfterFunc.Blocks.empty()) {
+      EnsureHeader();
+      Out << "*** Function " << AfterFunc.Name << " changed ***\n";
+      printFunctionForChange(Out, IR, AfterFunc.Name, PrintCtx);
+      continue;
+    }
+
+    DenseMap<StringRef, const BasicBlockChangeHash *> BeforeBlocks;
+    DenseMap<StringRef, const BasicBlockChangeHash *> AfterBlocks;
+    for (const BasicBlockChangeHash &BeforeBlock : BeforeFunc->Blocks)
+      BeforeBlocks.try_emplace(BeforeBlock.Key, &BeforeBlock);
+    for (const BasicBlockChangeHash &AfterBlock : AfterFunc.Blocks)
+      AfterBlocks.try_emplace(AfterBlock.Key, &AfterBlock);
+
+    unsigned ChangedBlockCount = 0;
+    for (const BasicBlockChangeHash &AfterBlock : AfterFunc.Blocks) {
+      const BasicBlockChangeHash *BeforeBlock =
+          BeforeBlocks.lookup(AfterBlock.Key);
+      if (!BeforeBlock || BeforeBlock->Hash != AfterBlock.Hash)
+        ++ChangedBlockCount;
+    }
+    for (const BasicBlockChangeHash &BeforeBlock : BeforeFunc->Blocks)
+      if (!AfterBlocks.contains(BeforeBlock.Key))
+        ++ChangedBlockCount;
+    if (ChangedBlockCount == 0)
+      continue;
+
+    EnsureHeader();
+    Out << "*** Function " << AfterFunc.Name << " changed ***\n";
+
+    const Function *F = findFunctionInIR(IR, AfterFunc.Name);
+    StringMap<const BasicBlock *> CurrentBlocks =
+        F ? collectBasicBlockMap(*F) : StringMap<const BasicBlock *>();
+    const MachineFunction *MF = findMachineFunctionInIR(IR, AfterFunc.Name);
+    StringMap<const MachineBasicBlock *> CurrentMachineBlocks =
+        MF ? collectMachineBasicBlockMap(*MF)
+           : StringMap<const MachineBasicBlock *>();
+
+    unsigned UnchangedBlockCount = 0;
+    for (const BasicBlockChangeHash &AfterBlock : AfterFunc.Blocks) {
+      const BasicBlockChangeHash *BeforeBlock =
+          BeforeBlocks.lookup(AfterBlock.Key);
+      if (BeforeBlock && BeforeBlock->Hash == AfterBlock.Hash) {
+        ++UnchangedBlockCount;
+        continue;
+      }
+      const BasicBlock *BB = CurrentBlocks.lookup(AfterBlock.Key);
+      const MachineBasicBlock *MBB =
+          CurrentMachineBlocks.lookup(AfterBlock.Key);
+      printBasicBlockChangeHeader(Out, AfterFunc.Name, AfterBlock.Key,
+                                  "changed", BB, MBB);
+      if (BB)
+        PrintCtx.printBasicBlock(Out, *BB);
+      else if (MBB)
+        MBB->print(Out);
+      else
+        printBasicBlockForChange(Out, IR, AfterFunc.Name, AfterBlock.Key,
+                                 PrintCtx);
+    }
+    if (UnchangedBlockCount != 0)
+      Out << "; " << UnchangedBlockCount << " unchanged basic blocks omitted\n";
+    for (const BasicBlockChangeHash &BeforeBlock : BeforeFunc->Blocks) {
+      if (AfterBlocks.contains(BeforeBlock.Key))
+        continue;
+      printBasicBlockChangeHeader(Out, AfterFunc.Name, BeforeBlock.Key,
+                                  "deleted");
+    }
+  }
+  for (const FunctionChangeHash &BeforeFunc : Before.Functions) {
+    if (AfterFuncs.contains(BeforeFunc.Name))
+      continue;
+    EnsureHeader();
+    Out << "*** Function " << BeforeFunc.Name << " deleted ***\n";
+  }
+  return Printed;
+}
+
+void IRChangedHashPrinter::handleStatefulAfterPass(Any IR, StringRef PassID,
+                                                   StringRef /*PassName*/) {
+  assert(!StatefulHashStack.empty() && "Unexpected empty stack encountered.");
+  StatefulHashFrame Frame = std::move(StatefulHashStack.back());
+  StatefulHashStack.pop_back();
+
+  std::string Name = getIRName(IR);
+  if (isIgnored(PassID)) {
+    if (VerboseMode)
+      handleIgnored(PassID, Name);
+    return;
+  }
+  if (!Frame.IsInteresting) {
+    if (VerboseMode)
+      handleFiltered(PassID, Name);
+    return;
+  }
+
+  StringMap<FunctionChangeHash> &FunctionCache =
+      Frame.IsIR ? StatefulFunctionHashes : StatefulMachineFunctionHashes;
+
+  IRChangeHash Before;
+  if (Frame.UseBeforeOverride) {
+    Before = std::move(Frame.BeforeOverride);
+  } else {
+    buildStatefulBeforeHash(Frame.FunctionNames, FunctionCache,
+                            Frame.IsIR ? &StatefulFunctionAttrs : nullptr,
+                            Before);
+  }
+
+  IRChangeHash After;
+  if (Frame.UseBeforeOverride) {
+    if (Frame.IsIR)
+      hashIRForChangePrinter(IR, After);
+    else
+      hashWholeIRForStatefulChangePrinter(IR, After);
+  } else {
+    hashWholeIRForStatefulChangePrinter(IR, After);
+  }
+
+  auto UpdateCache = [&]() {
+    if (Frame.UseBeforeOverride) {
+      IRChangeHash WholeAfter;
+      hashWholeIRForStatefulChangePrinter(IR, WholeAfter);
+      updateStatefulHashCache(WholeAfter, Frame.FunctionNames, FunctionCache,
+                              Frame.IsIR ? &StatefulFunctionAttrs : nullptr);
+      return;
+    }
+    updateStatefulHashCache(After, Frame.FunctionNames, FunctionCache,
+                            Frame.IsIR ? &StatefulFunctionAttrs : nullptr);
+  };
+
+  if (shouldPrintChangedAttributeDiffs() &&
+      hasOnlyFunctionAttributeChanges(Before, After)) {
+    printFunctionAttributeChanges(Out, PassID, Name, Before, After);
+    UpdateCache();
+    return;
+  }
+
+  ChangePrinterPrintContext PrintCtx(IR);
+  bool Printed = false;
+  switch (getPrintChangedHashMode()) {
+  case ChangePrinterHashMode::Function:
+    Printed = printFunctionHashChanges(Out, PassID, Name, Before, After, IR,
+                                       PrintCtx);
+    break;
+  case ChangePrinterHashMode::BasicBlock:
+    Printed = printBasicBlockHashChanges(Out, PassID, Name, Before, After, IR,
+                                         PrintCtx);
+    break;
+  case ChangePrinterHashMode::None:
+    llvm_unreachable("expected hash mode");
+  }
+  if (!Printed) {
+    if (Before == After) {
+      if (VerboseMode)
+        omitAfter(PassID, Name);
+    } else {
+      std::string AfterText;
+      raw_string_ostream OS(AfterText);
+      unwrapAndPrint(OS, IR);
+      OS.str();
+      if (AfterText.empty())
+        Out << "*** IR Deleted After " << PassID << " on " << Name << " ***\n";
+      else
+        Out << "*** IR Dump After " << PassID << " on " << Name << " ***\n"
+            << AfterText;
+    }
+  }
+
+  UpdateCache();
+}
+
+void IRChangedHashPrinter::handleAfter(StringRef PassID, std::string &Name,
+                                       const IRChangeHash &Before,
+                                       const IRChangeHash &After, Any IR) {
+  if (shouldPrintChangedAttributeDiffs() &&
+      hasOnlyFunctionAttributeChanges(Before, After)) {
+    printFunctionAttributeChanges(Out, PassID, Name, Before, After);
+    return;
+  }
+
+  if (PrintChangedBefore)
+    Out << "*** IR Dump Before " << PassID << " on " << Name << " ***\n"
+        << Before.Text;
+
+  ChangePrinterPrintContext PrintCtx(IR);
+  switch (getPrintChangedHashMode()) {
+  case ChangePrinterHashMode::Function:
+    if (printFunctionHashChanges(Out, PassID, Name, Before, After, IR,
+                                 PrintCtx))
+      return;
+    break;
+  case ChangePrinterHashMode::BasicBlock:
+    if (printBasicBlockHashChanges(Out, PassID, Name, Before, After, IR,
+                                   PrintCtx))
+      return;
+    break;
+  case ChangePrinterHashMode::None:
+    break;
+  }
+
+  std::string AfterText;
+  if (After.UseTextComparison) {
+    AfterText = After.Text;
+  } else {
+    raw_string_ostream OS(AfterText);
+    unwrapAndPrint(OS, IR);
+    OS.str();
+  }
+
+  if (AfterText.empty()) {
+    Out << "*** IR Deleted After " << PassID << " on " << Name << " ***\n";
+    return;
+  }
+
+  Out << "*** IR Dump After " << PassID << " on " << Name << " ***\n"
+      << AfterText;
 }
 
 IRChangedTester::~IRChangedTester() = default;
@@ -2441,6 +3415,7 @@ StandardInstrumentations::StandardInstrumentations(
     : PrintPass(DebugLogging, PrintPassOpts), OptNone(DebugLogging),
       OptPassGate(Context),
       PrintChangedIR(PrintChanged == ChangePrinter::Verbose),
+      PrintChangedHashIR(PrintChanged == ChangePrinter::Verbose),
       PrintChangedDiff(PrintChanged == ChangePrinter::DiffVerbose ||
                            PrintChanged == ChangePrinter::ColourDiffVerbose,
                        PrintChanged == ChangePrinter::ColourDiffVerbose ||
@@ -2518,6 +3493,7 @@ void StandardInstrumentations::registerCallbacks(
   PseudoProbeVerification.registerCallbacks(PIC);
   if (VerifyEach)
     Verify.registerCallbacks(PIC, MAM);
+  PrintChangedHashIR.registerCallbacks(PIC);
   PrintChangedDiff.registerCallbacks(PIC);
   WebsiteChangeReporter.registerCallbacks(PIC);
   ChangeTester.registerCallbacks(PIC);

--- a/llvm/test/Other/ChangePrinters/print-changed-diff.ll
+++ b/llvm/test/Other/ChangePrinters/print-changed-diff.ll
@@ -36,6 +36,7 @@
 ;
 ; Simple functionality check.
 ; RUN: opt -S -print-changed=diff-quiet -passes=instsimplify 2>&1 -o /dev/null < %s | FileCheck %s --check-prefix=CHECK-DIFF-QUIET-SIMPLE --allow-empty
+; RUN: opt -S -print-changed=diff,quiet -passes=instsimplify 2>&1 -o /dev/null < %s | FileCheck %s --check-prefix=CHECK-DIFF-QUIET-SIMPLE --allow-empty
 ;
 ; Check that only the passes that change the IR are printed and that the
 ; others (including g) are filtered out.

--- a/llvm/test/Other/print-changed-function-attrs.ll
+++ b/llvm/test/Other/print-changed-function-attrs.ll
@@ -1,0 +1,32 @@
+; RUN: opt -S -print-changed=quiet -passes=function-attrs 2>&1 \
+; RUN:   -o /dev/null < %s | FileCheck %s --check-prefix=FULL
+; RUN: opt -S -print-changed=quiet,hash -passes=function-attrs 2>&1 \
+; RUN:   -o /dev/null < %s | FileCheck %s --check-prefix=FULL
+; RUN: opt -S -print-changed=attrs-only -passes=function-attrs 2>&1 \
+; RUN:   -o /dev/null < %s | FileCheck %s --check-prefix=ATTRS
+; RUN: opt -S -print-changed=quiet,attrs-only -passes=function-attrs 2>&1 \
+; RUN:   -o /dev/null < %s | FileCheck %s --check-prefix=ATTRS
+; RUN: opt -S -print-changed=attrs-only -passes=instsimplify 2>&1 \
+; RUN:   -o /dev/null < %s | FileCheck %s --check-prefix=TEXT
+
+define i32 @f() {
+entry:
+  %sum = add i32 2, 3
+  ret i32 %sum
+}
+
+; FULL: *** IR Dump After {{.*}}FunctionAttrsPass on (f) ***
+; FULL: Function Attrs: {{.*}}memory(none)
+; FULL: define {{.*}}i32 @f()
+; FULL: ret i32 %sum
+
+; ATTRS: *** IR Attribute Changes After {{.*}}FunctionAttrsPass on (f) ***
+; ATTRS-NEXT: Function: f
+; ATTRS-NEXT:   function before: (none)
+; ATTRS-NEXT:   function after:  {{.*}}memory(none)
+; ATTRS-NEXT:   return before: (none)
+; ATTRS-NEXT:   return after:  noundef
+; ATTRS-NOT: ret i32
+
+; TEXT: *** IR Dump After InstSimplifyPass on f ***
+; TEXT: ret i32 5

--- a/llvm/test/Other/print-changed-hash-levels.ll
+++ b/llvm/test/Other/print-changed-hash-levels.ll
@@ -1,0 +1,62 @@
+; RUN: opt -S -passes=instsimplify -print-changed=quiet,hash \
+; RUN:   -disable-output < %s 2>&1 | FileCheck %s --check-prefix=FUNC
+; RUN: opt -S -passes=instsimplify -print-changed=quiet,hash-func \
+; RUN:   -disable-output < %s 2>&1 | FileCheck %s --check-prefix=FUNC
+; RUN: opt -S -passes=instsimplify -print-changed=quiet,hash-bb \
+; RUN:   -disable-output < %s 2>&1 | FileCheck %s --check-prefix=BB
+; RUN: opt -S -passes=simplifycfg -print-changed=quiet,hash-bb \
+; RUN:   -disable-output < %s 2>&1 | FileCheck %s --check-prefix=SINGLE
+; RUN: opt -S -passes="no-op-function,instsimplify,no-op-function" \
+; RUN:   -filter-passes="no-op-function" -print-changed=hash \
+; RUN:   -disable-output < %s 2>&1 | FileCheck %s --check-prefix=FILTER
+; RUN: not opt -S -passes=instsimplify \
+; RUN:   -print-changed=hash-func,hash-bb -disable-output < %s 2>&1 \
+; RUN:   | FileCheck %s --check-prefix=BAD-HASH-MODE
+; RUN: not opt -S -passes=instsimplify \
+; RUN:   -print-changed=hash,diff -disable-output < %s 2>&1 \
+; RUN:   | FileCheck %s --check-prefix=BAD-HASH-DIFF
+
+define i32 @f(i1 %c, i32 %x) {
+entry:
+  br i1 %c, label %then, label %else
+
+then:
+  %a = add i32 %x, 0
+  ret i32 %a
+
+else:
+  ret i32 %x
+}
+
+define i32 @collapse() {
+entry:
+  br label %exit
+
+exit:
+  ret i32 0
+}
+
+; FUNC: *** IR Function Changes After InstSimplifyPass on f ***
+; FUNC-NEXT: *** Function f changed ***
+; FUNC-NEXT: define i32 @f(i1 %c, i32 %x) {
+; FUNC: ret i32 %x
+
+; BB: *** IR BasicBlock Changes After InstSimplifyPass on f ***
+; BB-NEXT: *** Function f changed ***
+; BB-NEXT: *** BasicBlock f:then changed ***
+; BB: then:
+; BB: ret i32 %x
+; BB: ; 2 unchanged basic blocks omitted
+
+; SINGLE: *** IR BasicBlock Changes After SimplifyCFGPass on collapse ***
+; SINGLE-NEXT: *** Function collapse changed ***
+; SINGLE-NEXT: define i32 @collapse() {
+; SINGLE: ret i32 0
+
+; FILTER: *** IR Dump After NoOpFunctionPass on f omitted because no change ***
+; FILTER: *** IR Dump After InstSimplifyPass on f filtered out ***
+; FILTER-NOT: *** IR Function Changes After NoOpFunctionPass on f ***
+; FILTER: *** IR Dump After NoOpFunctionPass on f omitted because no change ***
+
+; BAD-HASH-MODE: LLVM ERROR: invalid argument 'hash-bb' to -print-changed=;
+; BAD-HASH-DIFF: LLVM ERROR: invalid argument 'hash' to -print-changed=;

--- a/llvm/test/Other/print-changed-machine-hash.ll
+++ b/llvm/test/Other/print-changed-machine-hash.ll
@@ -1,0 +1,14 @@
+; REQUIRES: x86-registered-target
+; RUN: llc -mtriple=x86_64-unknown-linux-gnu -filetype=null -O0 \
+; RUN:   -print-changed=quiet,hash-bb 2>&1 < %s | FileCheck %s \
+; RUN:   --check-prefix=BB
+
+define i32 @f(i32 %x) {
+entry:
+  %a = add i32 %x, 1
+  ret i32 %a
+}
+
+; BB: *** IR Dump After X86 DAG->DAG Instruction Selection (x86-isel) on f ***
+; BB: bb.0.entry:
+; BB: ADD32ri

--- a/llvm/unittests/IR/StructuralHashTest.cpp
+++ b/llvm/unittests/IR/StructuralHashTest.cpp
@@ -70,6 +70,33 @@ TEST(StructuralHashTest, BasicFunction) {
             StructuralHash(*M->getFunction("h")));
 }
 
+TEST(StructuralHashTest, FunctionHashDetails) {
+  LLVMContext Ctx;
+  std::unique_ptr<Module> M = parseIR(Ctx, "define i32 @f(i32 %x) {\n"
+                                           "entry:\n"
+                                           "  %a = add i32 %x, 1\n"
+                                           "  ret i32 %a\n"
+                                           "}\n");
+  Function &F = *M->getFunction("f");
+
+  FunctionStructuralHashInfo Info =
+      StructuralHashWithDetails(F, /*DetailedHash=*/true);
+  EXPECT_EQ(StructuralHash(F, /*DetailedHash=*/true), Info.FunctionHash);
+  ASSERT_THAT(Info.Blocks, SizeIs(1));
+  EXPECT_EQ(&F.getEntryBlock(), Info.Blocks[0].BB);
+  EXPECT_NE(0u, Info.Blocks[0].BlockHash);
+}
+
+TEST(StructuralHashTest, FunctionHashDetailsForDeclaration) {
+  LLVMContext Ctx;
+  std::unique_ptr<Module> M = parseIR(Ctx, "declare void @f()\n");
+  Function &F = *M->getFunction("f");
+
+  FunctionStructuralHashInfo Info = StructuralHashWithDetails(F);
+  EXPECT_EQ(StructuralHash(F), Info.FunctionHash);
+  EXPECT_THAT(Info.Blocks, SizeIs(0));
+}
+
 TEST(StructuralHashTest, Declaration) {
   LLVMContext Ctx;
   std::unique_ptr<Module> M0 = parseIR(Ctx, "");

--- a/llvm/unittests/IR/StructuralHashTest.cpp
+++ b/llvm/unittests/IR/StructuralHashTest.cpp
@@ -203,6 +203,48 @@ TEST(StructuralHashTest, ComparisonInstructionPredicate) {
   EXPECT_NE(StructuralHash(*M1, true), StructuralHash(*M2, true));
 }
 
+TEST(StructuralHashTest, InstructionFlags) {
+  LLVMContext Ctx;
+
+  auto FunctionHash = [&](const char *IR) {
+    return StructuralHash(*parseIR(Ctx, IR)->getFunction("f"),
+                          /*DetailedHash=*/true);
+  };
+
+  EXPECT_NE(FunctionHash("define i32 @f(i32 %a, i32 %b) {\n"
+                         "  %r = add i32 %a, %b\n"
+                         "  ret i32 %r\n"
+                         "}\n"),
+            FunctionHash("define i32 @f(i32 %a, i32 %b) {\n"
+                         "  %r = add nsw i32 %a, %b\n"
+                         "  ret i32 %r\n"
+                         "}\n"));
+  EXPECT_NE(FunctionHash("define i32 @f(i32 %a, i32 %b) {\n"
+                         "  %r = udiv i32 %a, %b\n"
+                         "  ret i32 %r\n"
+                         "}\n"),
+            FunctionHash("define i32 @f(i32 %a, i32 %b) {\n"
+                         "  %r = udiv exact i32 %a, %b\n"
+                         "  ret i32 %r\n"
+                         "}\n"));
+  EXPECT_NE(FunctionHash("define i1 @f(i32 %a, i32 %b) {\n"
+                         "  %r = icmp slt i32 %a, %b\n"
+                         "  ret i1 %r\n"
+                         "}\n"),
+            FunctionHash("define i1 @f(i32 %a, i32 %b) {\n"
+                         "  %r = icmp samesign slt i32 %a, %b\n"
+                         "  ret i1 %r\n"
+                         "}\n"));
+  EXPECT_NE(FunctionHash("define float @f(float %a, float %b) {\n"
+                         "  %r = fadd float %a, %b\n"
+                         "  ret float %r\n"
+                         "}\n"),
+            FunctionHash("define float @f(float %a, float %b) {\n"
+                         "  %r = fadd fast float %a, %b\n"
+                         "  ret float %r\n"
+                         "}\n"));
+}
+
 TEST(StructuralHashTest, IntrinsicInstruction) {
   LLVMContext Ctx;
   std::unique_ptr<Module> M1 =


### PR DESCRIPTION
-print-changed reports pass effects by comparing the printed IR or MIR before
and after each pass. For function assembly output this text-based comparison is
accurate, but it can be time consuming because every pass needs to materialize
and compare the full textual form. On medium-sized IR, this printing and
comparison cost can dominate the time spent collecting change reports.

Add hash-func and hash-bb modes as faster alternatives. hash-func compares
detailed structural hashes at function granularity and provides a significant
speedup over the old text-based print-changed mode. hash-bb also records
per-basic-block hashes so unchanged blocks can be skipped when reporting a
changed function, which provides a further speedup over hash-func when most
blocks are unchanged.

The hash-bb mode keeps transformed, duplicated, and newly created blocks
visible. Its current limitation is that name/order-based block keys may not
associate a recreated, duplicated, or reordered unnamed block with its previous
logical block.

Extend -print-changed option parsing to accept the new hash and attrs-only
values, including comma combinations such as quiet,hash-bb, while preserving
the existing option spellings and behavior. Add attrs-only as an opt-in compact
report for passes that only change function attributes; without attrs-only,
attribute-only changes keep the historical behavior of printing the changed IR.

Hash mode caches the last known per-function hash state so the before snapshot
does not need to be recomputed before every pass. The after-pass callback
recomputes the current hash, compares it with the cached state, and updates the
cache for the next pass. Hash mode reports changes according to what the hash
encodes; the existing text-based mode remains the reference path for faithfully
detecting changes in the printed IR/MIR output.

This depends on #200480, which exposes structural hash details, and #200488,
which includes semantic instruction flags in detailed structural hashes.