### PR TITLE
[lldb] Report a generic wasm32 architecture for Wasm object files

### DIFF
--- a/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
+++ b/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
@@ -281,7 +281,7 @@ ObjectFileWasm::GetModuleSpecifications(const FileSpec &file,
     return {};
 
   ModuleSpecList specs;
-  specs.Append(ModuleSpec(file, ArchSpec("wasm32-unknown-unknown-wasm")));
+  specs.Append(ModuleSpec(file, ArchSpec("wasm32")));
   return specs;
 }
 
@@ -290,7 +290,7 @@ ObjectFileWasm::ObjectFileWasm(const ModuleSP &module_sp,
                                offset_t data_offset, const FileSpec *file,
                                offset_t offset, offset_t length)
     : ObjectFile(module_sp, file, offset, length, extractor_sp, data_offset),
-      m_arch("wasm32-unknown-unknown-wasm") {
+      m_arch("wasm32") {
   m_data_nsp->SetAddressByteSize(4);
 }
 
@@ -300,7 +300,7 @@ ObjectFileWasm::ObjectFileWasm(const lldb::ModuleSP &module_sp,
                                lldb::addr_t header_addr)
     : ObjectFile(module_sp, process_sp, header_addr,
                  std::make_shared<DataExtractor>(header_data_sp)),
-      m_arch("wasm32-unknown-unknown-wasm") {}
+      m_arch("wasm32") {}
 
 bool ObjectFileWasm::ParseHeader() {
   // We already parsed the header during initialization.

--- a/lldb/source/Plugins/Platform/WebAssembly/PlatformWasm.cpp
+++ b/lldb/source/Plugins/Platform/WebAssembly/PlatformWasm.cpp
@@ -126,8 +126,7 @@ llvm::Expected<uint16_t> PlatformWasm::FindFreeTCPPort() {
 
 std::vector<ArchSpec>
 PlatformWasm::GetSupportedArchitectures(const ArchSpec &process_host_arch) {
-  return {ArchSpec("wasm32-unknown-unknown-wasm"),
-          ArchSpec("wasm64-unknown-unknown-wasm")};
+  return {ArchSpec("wasm32"), ArchSpec("wasm64")};
 }
 
 lldb::ProcessSP PlatformWasm::Attach(ProcessAttachInfo &attach_info,

--- a/lldb/test/Shell/ObjectFile/wasm/basic.yaml
+++ b/lldb/test/Shell/ObjectFile/wasm/basic.yaml
@@ -2,7 +2,7 @@
 # RUN: lldb-test object-file %t | FileCheck %s
 
 # CHECK: Plugin name: wasm
-# CHECK: Architecture: wasm32-unknown-unknown-wasm
+# CHECK: Architecture: wasm32
 # CHECK: UUID: 
 # CHECK: Executable: false
 # CHECK: Stripped: false

--- a/lldb/test/Shell/ObjectFile/wasm/embedded-debug-sections.yaml
+++ b/lldb/test/Shell/ObjectFile/wasm/embedded-debug-sections.yaml
@@ -2,7 +2,7 @@
 # RUN: lldb-test object-file %t | FileCheck %s
 
 # CHECK: Plugin name: wasm
-# CHECK: Architecture: wasm32-unknown-unknown-wasm
+# CHECK: Architecture: wasm32
 # CHECK: UUID: 
 # CHECK: Executable: false
 # CHECK: Stripped: false

--- a/lldb/test/Shell/ObjectFile/wasm/stripped-debug-sections.yaml
+++ b/lldb/test/Shell/ObjectFile/wasm/stripped-debug-sections.yaml
@@ -2,7 +2,7 @@
 # RUN: lldb-test object-file %t | FileCheck %s
 
 # CHECK: Plugin name: wasm
-# CHECK: Architecture: wasm32-unknown-unknown-wasm
+# CHECK: Architecture: wasm32
 # CHECK: UUID: 
 # CHECK: Executable: false
 # CHECK: Stripped: false

--- a/lldb/test/Shell/ObjectFile/wasm/unified-debug-sections.yaml
+++ b/lldb/test/Shell/ObjectFile/wasm/unified-debug-sections.yaml
@@ -11,7 +11,7 @@
 # relative path of the debug module.
 
 # CHECK: Plugin name: wasm
-# CHECK: Architecture: wasm32-unknown-unknown-wasm
+# CHECK: Architecture: wasm32
 # CHECK: UUID: 
 # CHECK: Executable: false
 # CHECK: Stripped: true


### PR DESCRIPTION
ObjectFileWasm hardcoded the architecture of every Wasm module as "wasm32-unknown-unknown-wasm". A Wasm binary does not actually encode a vendor or OS, those are properties of the runtime executing it.

When debugging via a runtime whose gdb stub reports a more specific triple (e.g. WAMR reports "wasm32-wamr-wasi-wasm"), lldb adopts that triple and clears the module list. The dynamic loader then tries to reload the main executable, but GetOrCreateModule rejects the on-disk file because the triples are incompatible. This causes lldb to back to reading from memory.

Fix all this by reporting a bare "wasm32"/"wasm64" architecture instead.