### PR TITLE
[clang-cl][test] Use /Zs to avoid writing unnecessary output files

### DIFF
--- a/clang/test/Preprocessor/init-datetime-macros.c
+++ b/clang/test/Preprocessor/init-datetime-macros.c
@@ -27,7 +27,7 @@
 //  /d1nodatetime - undefines __DATE__, __TIME__ and __TIMESTAMP__
 //  /Brepro - sets __DATE__, __TIME__ and __TIMESTAMP__ to "1"
 
-// RUN: %clang_cl -Xclang -verify /d1nodatetime /DDATETIME_UNDEFINED /c -- %s
+// RUN: %clang_cl -Xclang -verify /d1nodatetime /DDATETIME_UNDEFINED /Zs -- %s
 
 // RUN: %clang_cl -E /Brepro /DDATETIME_LITERALONE -- %s | FileCheck %s --check-prefix CHECK-INIT-DATETIME-LITERALONE
 


### PR DESCRIPTION
#194779 adds a test clang/test/Preprocessor/init-datetime-macros.c which verifies some diagnostics. However, it does so with `/c`, which will unnecessarily generate an output, and when run on a build system that does not run tests in a writeable dir by default, will cause the test to fail.

Since we don't care about the resulting object file, use `/Zs` (equivalent of `-fsyntax-only`) to check the diagnostics but not produce any output files.