### PR TITLE
[offload] Improve report printing for kernel recording

### DIFF
--- a/offload/libomptarget/device.cpp
+++ b/offload/libomptarget/device.cpp
@@ -95,7 +95,8 @@ llvm::Error DeviceTy::init() {
     Int32Envar OMPX_RecordDevice("LIBOMPTARGET_RECORD_DEVICE", 0);
     StringEnvar OMPX_RecordOutputDir("LIBOMPTARGET_RECORD_DIR", "");
     BoolEnvar OMPX_EmitRecordReport("LIBOMPTARGET_RECORD_REPORT", false);
-    StringEnvar OMPX_RecordReportFilename("LIBOMPTARGET_RECORD_REPORT_FILENAME", "");
+    StringEnvar OMPX_RecordReportFilename("LIBOMPTARGET_RECORD_REPORT_FILENAME",
+                                          "");
     if (OMPX_RecordDevice != RTLDeviceID)
       return llvm::Error::success();
 

--- a/offload/libomptarget/device.cpp
+++ b/offload/libomptarget/device.cpp
@@ -95,13 +95,19 @@ llvm::Error DeviceTy::init() {
     Int32Envar OMPX_RecordDevice("LIBOMPTARGET_RECORD_DEVICE", 0);
     StringEnvar OMPX_RecordOutputDir("LIBOMPTARGET_RECORD_DIR", "");
     BoolEnvar OMPX_EmitRecordReport("LIBOMPTARGET_RECORD_REPORT", false);
+    StringEnvar OMPX_RecordReportFile("LIBOMPTARGET_RECORD_REPORT_FILE", "");
     if (OMPX_RecordDevice != RTLDeviceID)
       return llvm::Error::success();
 
+    // Print report if it was enabled explicitly or a report file was indicated.
+    bool EmitReport =
+        OMPX_EmitRecordReport || !OMPX_RecordReportFile.get().empty();
+
     Ret = RTL->initialize_record_replay(
         RTLDeviceID, OMPX_RecordMemSize, nullptr,
-        /*IsRecord=*/true, /*IsNative=*/true, OMPX_RecordOutput,
-        OMPX_EmitRecordReport, OMPX_RecordOutputDir.get().c_str());
+        /*IsRecord=*/true, /*IsNative=*/true, OMPX_RecordOutput, EmitReport,
+        OMPX_RecordReportFile.get().c_str(),
+        OMPX_RecordOutputDir.get().c_str());
     if (Ret != OFFLOAD_SUCCESS)
       return error::createOffloadError(error::ErrorCode::BACKEND_FAILURE,
                                        "failed to initialize RR in device %d\n",

--- a/offload/libomptarget/device.cpp
+++ b/offload/libomptarget/device.cpp
@@ -95,18 +95,18 @@ llvm::Error DeviceTy::init() {
     Int32Envar OMPX_RecordDevice("LIBOMPTARGET_RECORD_DEVICE", 0);
     StringEnvar OMPX_RecordOutputDir("LIBOMPTARGET_RECORD_DIR", "");
     BoolEnvar OMPX_EmitRecordReport("LIBOMPTARGET_RECORD_REPORT", false);
-    StringEnvar OMPX_RecordReportFile("LIBOMPTARGET_RECORD_REPORT_FILE", "");
+    StringEnvar OMPX_RecordReportFilename("LIBOMPTARGET_RECORD_REPORT_FILENAME", "");
     if (OMPX_RecordDevice != RTLDeviceID)
       return llvm::Error::success();
 
     // Print report if it was enabled explicitly or a report file was indicated.
     bool EmitReport =
-        OMPX_EmitRecordReport || !OMPX_RecordReportFile.get().empty();
+        OMPX_EmitRecordReport || !OMPX_RecordReportFilename.get().empty();
 
     Ret = RTL->initialize_record_replay(
         RTLDeviceID, OMPX_RecordMemSize, nullptr,
         /*IsRecord=*/true, /*IsNative=*/true, OMPX_RecordOutput, EmitReport,
-        OMPX_RecordReportFile.get().c_str(),
+        OMPX_RecordReportFilename.get().c_str(),
         OMPX_RecordOutputDir.get().c_str());
     if (Ret != OFFLOAD_SUCCESS)
       return error::createOffloadError(error::ErrorCode::BACKEND_FAILURE,

--- a/offload/libomptarget/omptarget.cpp
+++ b/offload/libomptarget/omptarget.cpp
@@ -2383,7 +2383,7 @@ int target_activate_rr(DeviceTy &Device, uint64_t MemorySize, void *VAddr,
                        const char *OutputDirPath) {
   return Device.RTL->initialize_record_replay(
       Device.DeviceID, MemorySize, VAddr, IsRecord,
-      /*IsNative=*/true, SaveOutput, EmitReport, /*ReportFile=*/"",
+      /*IsNative=*/true, SaveOutput, EmitReport, /*ReportFilename=*/"",
       OutputDirPath);
 }
 

--- a/offload/libomptarget/omptarget.cpp
+++ b/offload/libomptarget/omptarget.cpp
@@ -2383,7 +2383,8 @@ int target_activate_rr(DeviceTy &Device, uint64_t MemorySize, void *VAddr,
                        const char *OutputDirPath) {
   return Device.RTL->initialize_record_replay(
       Device.DeviceID, MemorySize, VAddr, IsRecord,
-      /*IsNative=*/true, SaveOutput, EmitReport, OutputDirPath);
+      /*IsNative=*/true, SaveOutput, EmitReport, /*ReportFile=*/"",
+      OutputDirPath);
 }
 
 /// Executes a kernel using pre-recorded information for loading to

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -1252,7 +1252,7 @@ struct GenericDeviceTy : public DeviceAllocatorTy {
 
   Error initRecordReplay(int64_t Size, void *VAddr, bool IsRecord,
                          bool IsNative, bool SaveOutput, bool EmitReport,
-                         const char *OutputDirPath) {
+                         const char *ReportFile, const char *OutputDirPath) {
     if (RecordReplay)
       return Plugin::error(error::ErrorCode::INVALID_ARGUMENT,
                            "RR already initialized");
@@ -1267,7 +1267,7 @@ struct GenericDeviceTy : public DeviceAllocatorTy {
 
     RecordReplay =
         new NativeRecordReplayTy(Status, OutputDirPath ? OutputDirPath : "",
-                                 SaveOutput, EmitReport, *this);
+                                 SaveOutput, EmitReport, ReportFile, *this);
     return RecordReplay->init(Size, VAddr);
   }
 
@@ -1587,6 +1587,7 @@ public:
   int32_t initialize_record_replay(int32_t DeviceId, int64_t MemorySize,
                                    void *VAddr, bool IsRecord, bool IsNative,
                                    bool SaveOutput, bool EmitReport,
+                                   const char *ReportFile,
                                    const char *OutputDirPath);
 
   /// Loads the associated binary into the plugin and returns a handle to it.

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -1252,7 +1252,8 @@ struct GenericDeviceTy : public DeviceAllocatorTy {
 
   Error initRecordReplay(int64_t Size, void *VAddr, bool IsRecord,
                          bool IsNative, bool SaveOutput, bool EmitReport,
-                         const char *ReportFilename, const char *OutputDirPath) {
+                         const char *ReportFilename,
+                         const char *OutputDirPath) {
     if (RecordReplay)
       return Plugin::error(error::ErrorCode::INVALID_ARGUMENT,
                            "RR already initialized");

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -1252,7 +1252,7 @@ struct GenericDeviceTy : public DeviceAllocatorTy {
 
   Error initRecordReplay(int64_t Size, void *VAddr, bool IsRecord,
                          bool IsNative, bool SaveOutput, bool EmitReport,
-                         const char *ReportFile, const char *OutputDirPath) {
+                         const char *ReportFilename, const char *OutputDirPath) {
     if (RecordReplay)
       return Plugin::error(error::ErrorCode::INVALID_ARGUMENT,
                            "RR already initialized");
@@ -1267,7 +1267,7 @@ struct GenericDeviceTy : public DeviceAllocatorTy {
 
     RecordReplay =
         new NativeRecordReplayTy(Status, OutputDirPath ? OutputDirPath : "",
-                                 SaveOutput, EmitReport, ReportFile, *this);
+                                 SaveOutput, EmitReport, ReportFilename, *this);
     return RecordReplay->init(Size, VAddr);
   }
 
@@ -1587,7 +1587,7 @@ public:
   int32_t initialize_record_replay(int32_t DeviceId, int64_t MemorySize,
                                    void *VAddr, bool IsRecord, bool IsNative,
                                    bool SaveOutput, bool EmitReport,
-                                   const char *ReportFile,
+                                   const char *ReportFilename,
                                    const char *OutputDirPath);
 
   /// Loads the associated binary into the plugin and returns a handle to it.

--- a/offload/plugins-nextgen/common/include/RecordReplay.h
+++ b/offload/plugins-nextgen/common/include/RecordReplay.h
@@ -80,8 +80,11 @@ protected:
   /// Whether a memory snapshot should be recorded a kernel execution.
   bool SaveOutput;
 
-  /// Whether a report should be emitted afther the recording.
+  /// Whether a report should be emitted after the recording.
   bool EmitReport;
+
+  /// The name of the file where to emit the record report.
+  std::string ReportFile;
 
   /// Reference to the corresponding device.
   GenericDeviceTy &Device;
@@ -157,13 +160,14 @@ protected:
 
   /// Tracker of record replay instances.
   std::unordered_set<InstanceTy, InstanceHasher> Instances;
+  SmallVector<const InstanceTy *> OrderedInstances;
   std::mutex InstancesLock;
 
 public:
   RecordReplayTy(StatusTy Status, StringRef OutputDirectoryStr, bool SaveOutput,
-                 bool EmitReport, GenericDeviceTy &Device)
+                 bool EmitReport, StringRef ReportFile, GenericDeviceTy &Device)
       : Status(Status), SaveOutput(SaveOutput), EmitReport(EmitReport),
-        Device(Device) {
+        ReportFile(ReportFile.str()), Device(Device) {
     if (OutputDirectoryStr == "")
       OutputDirectory = std::filesystem::current_path();
     else
@@ -260,10 +264,10 @@ private:
 /// The native kernel record replay support.
 struct NativeRecordReplayTy : public RecordReplayTy {
   NativeRecordReplayTy(StatusTy Status, StringRef OutputDirectoryStr,
-                       bool SaveOutput, bool EmitReport,
+                       bool SaveOutput, bool EmitReport, StringRef ReportFile,
                        GenericDeviceTy &Device)
       : RecordReplayTy(Status, OutputDirectoryStr, SaveOutput, EmitReport,
-                       Device) {}
+                       ReportFile, Device) {}
 
 private:
   Error recordPrologueImpl(const GenericKernelTy &Kernel,

--- a/offload/plugins-nextgen/common/include/RecordReplay.h
+++ b/offload/plugins-nextgen/common/include/RecordReplay.h
@@ -165,7 +165,8 @@ protected:
 
 public:
   RecordReplayTy(StatusTy Status, StringRef OutputDirectoryStr, bool SaveOutput,
-                 bool EmitReport, StringRef ReportFilename, GenericDeviceTy &Device)
+                 bool EmitReport, StringRef ReportFilename,
+                 GenericDeviceTy &Device)
       : Status(Status), SaveOutput(SaveOutput), EmitReport(EmitReport),
         ReportFilename(ReportFilename.str()), Device(Device) {
     if (OutputDirectoryStr == "")
@@ -264,8 +265,8 @@ private:
 /// The native kernel record replay support.
 struct NativeRecordReplayTy : public RecordReplayTy {
   NativeRecordReplayTy(StatusTy Status, StringRef OutputDirectoryStr,
-                       bool SaveOutput, bool EmitReport, StringRef ReportFilename,
-                       GenericDeviceTy &Device)
+                       bool SaveOutput, bool EmitReport,
+                       StringRef ReportFilename, GenericDeviceTy &Device)
       : RecordReplayTy(Status, OutputDirectoryStr, SaveOutput, EmitReport,
                        ReportFilename, Device) {}
 

--- a/offload/plugins-nextgen/common/include/RecordReplay.h
+++ b/offload/plugins-nextgen/common/include/RecordReplay.h
@@ -84,7 +84,7 @@ protected:
   bool EmitReport;
 
   /// The name of the file where to emit the record report.
-  std::string ReportFile;
+  std::string ReportFilename;
 
   /// Reference to the corresponding device.
   GenericDeviceTy &Device;
@@ -165,9 +165,9 @@ protected:
 
 public:
   RecordReplayTy(StatusTy Status, StringRef OutputDirectoryStr, bool SaveOutput,
-                 bool EmitReport, StringRef ReportFile, GenericDeviceTy &Device)
+                 bool EmitReport, StringRef ReportFilename, GenericDeviceTy &Device)
       : Status(Status), SaveOutput(SaveOutput), EmitReport(EmitReport),
-        ReportFile(ReportFile.str()), Device(Device) {
+        ReportFilename(ReportFilename.str()), Device(Device) {
     if (OutputDirectoryStr == "")
       OutputDirectory = std::filesystem::current_path();
     else
@@ -264,10 +264,10 @@ private:
 /// The native kernel record replay support.
 struct NativeRecordReplayTy : public RecordReplayTy {
   NativeRecordReplayTy(StatusTy Status, StringRef OutputDirectoryStr,
-                       bool SaveOutput, bool EmitReport, StringRef ReportFile,
+                       bool SaveOutput, bool EmitReport, StringRef ReportFilename,
                        GenericDeviceTy &Device)
       : RecordReplayTy(Status, OutputDirectoryStr, SaveOutput, EmitReport,
-                       ReportFile, Device) {}
+                       ReportFilename, Device) {}
 
 private:
   Error recordPrologueImpl(const GenericKernelTy &Kernel,

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -1498,12 +1498,12 @@ int32_t GenericPluginTy::is_data_exchangable(int32_t SrcDeviceId,
 
 int32_t GenericPluginTy::initialize_record_replay(
     int32_t DeviceId, int64_t MemorySize, void *VAddr, bool IsRecord,
-    bool IsNative, bool SaveOutput, bool EmitReport, const char *ReportFile,
+    bool IsNative, bool SaveOutput, bool EmitReport, const char *ReportFilename,
     const char *OutputDirPath) {
   GenericDeviceTy &Device = getDevice(DeviceId);
 
   if (auto Err = Device.initRecordReplay(MemorySize, VAddr, IsRecord, IsNative,
-                                         SaveOutput, EmitReport, ReportFile,
+                                         SaveOutput, EmitReport, ReportFilename,
                                          OutputDirPath)) {
     REPORT() << "Failure to initialize RR with " << MemorySize
              << " bytes on device " << DeviceId << ": "

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -1498,13 +1498,13 @@ int32_t GenericPluginTy::is_data_exchangable(int32_t SrcDeviceId,
 
 int32_t GenericPluginTy::initialize_record_replay(
     int32_t DeviceId, int64_t MemorySize, void *VAddr, bool IsRecord,
-    bool IsNative, bool SaveOutput, bool EmitReport,
+    bool IsNative, bool SaveOutput, bool EmitReport, const char *ReportFile,
     const char *OutputDirPath) {
   GenericDeviceTy &Device = getDevice(DeviceId);
 
-  if (auto Err =
-          Device.initRecordReplay(MemorySize, VAddr, IsRecord, IsNative,
-                                  SaveOutput, EmitReport, OutputDirPath)) {
+  if (auto Err = Device.initRecordReplay(MemorySize, VAddr, IsRecord, IsNative,
+                                         SaveOutput, EmitReport, ReportFile,
+                                         OutputDirPath)) {
     REPORT() << "Failure to initialize RR with " << MemorySize
              << " bytes on device " << DeviceId << ": "
              << toString(std::move(Err));

--- a/offload/plugins-nextgen/common/src/RecordReplay.cpp
+++ b/offload/plugins-nextgen/common/src/RecordReplay.cpp
@@ -88,20 +88,34 @@ Error RecordReplayTy::deinit() {
 }
 
 Error RecordReplayTy::emitInstanceReport() {
+  llvm::raw_ostream *OutStream = &llvm::outs();
+  std::unique_ptr<llvm::raw_fd_ostream> FileOut;
+
+  if (!ReportFile.empty()) {
+    // The report file is emitted in the output directory.
+    std::string ReportFilePath =
+        (std::filesystem::absolute(OutputDirectory) / ReportFile).string();
+    std::error_code EC;
+    FileOut = std::make_unique<llvm::raw_fd_ostream>(ReportFilePath, EC);
+    if (EC)
+      return Plugin::error(ErrorCode::HOST_IO, "saving report file");
+    OutStream = FileOut.get();
+  }
+
   std::lock_guard<std::mutex> LG(InstancesLock);
-  llvm::outs() << "=== Kernel Record Report ===\n";
-  llvm::outs() << "Directory: "
-               << std::filesystem::absolute(OutputDirectory).string() << "\n";
-  llvm::outs() << "Total Instances: " << Instances.size() << "\n";
-  llvm::outs() << "JSON Filename, Kernel Name, Time (ns), Occurrences:\n";
+  *OutStream << "=== Kernel Record Report ===\n";
+  *OutStream << "Directory: "
+             << std::filesystem::absolute(OutputDirectory).string() << "\n";
+  *OutStream << "Total Instances: " << OrderedInstances.size() << "\n";
+  *OutStream << "JSON Filename, Kernel Name, Time (ns), Occurrences:\n";
 
   SmallString<128> Filename;
-  for (const auto &Inst : Instances)
-    llvm::outs()
-        << getFilename(Inst, FileTy::Descriptor, /*IncludeDir=*/false).c_str()
-        << ", " << Inst.Kernel.getName() << ", " << Inst.getRecordedTimeNs()
-        << ", " << Inst.Occurrences << "\n";
-  llvm::outs() << "=== End Kernel Record Report ===\n";
+  for (const auto *Inst : OrderedInstances)
+    *OutStream
+        << getFilename(*Inst, FileTy::Descriptor, /*IncludeDir=*/false).c_str()
+        << ", " << Inst->Kernel.getName() << ", " << Inst->getRecordedTimeNs()
+        << ", " << Inst->Occurrences << "\n";
+  *OutStream << "=== End Kernel Record Report ===\n";
 
   return Plugin::success();
 }
@@ -114,18 +128,24 @@ RecordReplayTy::registerInstance(const GenericKernelTy &Kernel,
   std::lock_guard<std::mutex> LG(InstancesLock);
   auto [It, Inserted] = Instances.emplace(Kernel, NumTeams, NumThreads,
                                           SharedMemorySize, ReplayOutcome);
+  // Keep insertion order.
+  if (Inserted)
+    OrderedInstances.push_back(&(*It));
+
   // Increase the number of occurrences.
   It->Occurrences += 1;
-  return {*It, Inserted};
+
+  // Return reference and whether it was registered for the first time. Notice
+  // that registering an unregistered instance counts as a new registration.
+  return {*It, (It->Occurrences == 1)};
 }
 
 Error RecordReplayTy::unregisterInstance(const InstanceTy &Instance) {
   assert(isReplaying() && "Cannot unregister instance when recording.");
 
+  // Do not remove it, it may be reused in the future.
   std::lock_guard<std::mutex> LG(InstancesLock);
-  size_t Erased = Instances.erase(Instance);
-  if (Erased != 1)
-    return Plugin::error(ErrorCode::INVALID_ARGUMENT, "invalid instance");
+  Instance.Occurrences = 0;
   return Plugin::success();
 }
 

--- a/offload/plugins-nextgen/common/src/RecordReplay.cpp
+++ b/offload/plugins-nextgen/common/src/RecordReplay.cpp
@@ -91,12 +91,12 @@ Error RecordReplayTy::emitInstanceReport() {
   llvm::raw_ostream *OutStream = &llvm::outs();
   std::unique_ptr<llvm::raw_fd_ostream> FileOut;
 
-  if (!ReportFile.empty()) {
+  if (!ReportFilename.empty()) {
     // The report file is emitted in the output directory.
-    std::string ReportFilePath =
-        (std::filesystem::absolute(OutputDirectory) / ReportFile).string();
+    std::string ReportFilepath =
+        (std::filesystem::absolute(OutputDirectory) / ReportFilename).string();
     std::error_code EC;
-    FileOut = std::make_unique<llvm::raw_fd_ostream>(ReportFilePath, EC);
+    FileOut = std::make_unique<llvm::raw_fd_ostream>(ReportFilepath, EC);
     if (EC)
       return Plugin::error(ErrorCode::HOST_IO, "saving report file");
     OutStream = FileOut.get();

--- a/openmp/docs/design/Runtimes.rst
+++ b/openmp/docs/design/Runtimes.rst
@@ -1312,8 +1312,8 @@ LIBOMPTARGET_RECORD_REPORT
 This environment variable is used to instruct the runtime to emit a summary of
 the recorded kernel instances and their associated JSON files. When enabled, the
 report is emitted in the standard output. The environment variable
-:ref:`LIBOMPTARGET_RECORD_REPORT_FILE` can be used to indicate a file where to
-emit the report. By default, no report is emitted.
+:ref:`LIBOMPTARGET_RECORD_REPORT_FILE` can be used to indicate the file name of
+the file where to emit the report. By default, no report is emitted.
 
 .. _libomptarget_record_report_file:
 
@@ -1321,9 +1321,10 @@ LIBOMPTARGET_RECORD_REPORT_FILE
 """""""""""""""""""""""""""""""
 
 This environment variable is used to instruct the runtime to emit the recording
-report to a specific output file. The file will be created within the recording
-directory. Note that it is not needed to use :ref:`LIBOMPTARGET_RECORD_REPORT`
-when setting this enviornment variable.
+report to an output file with a specific file name. The file will be created
+within the recording directory (see :ref:`LIBOMPTARGET_RECORD_DIR`). Note that
+it is not needed to use :ref:`LIBOMPTARGET_RECORD_REPORT` when setting this
+environment variable.
 
 LIBOMPTARGET_RECORD_MEMSIZE
 """""""""""""""""""""""""""

--- a/openmp/docs/design/Runtimes.rst
+++ b/openmp/docs/design/Runtimes.rst
@@ -1279,7 +1279,7 @@ is provided below.
 * ``LIBOMPTARGET_RECORD=[TRUE/FALSE] (default FALSE)``
 * ``LIBOMPTARGET_RECORD_DIR=<Filepath>``
 * ``LIBOMPTARGET_RECORD_REPORT=[TRUE/FALSE] (default FALSE)``
-* ``LIBOMPTARGET_RECORD_REPORT_FILE=<Filename>``
+* ``LIBOMPTARGET_RECORD_REPORT_FILENAME=<Filename>``
 * ``LIBOMPTARGET_RECORD_MEMSIZE=<Num> (default 8*1024*1024*1024)``
 * ``LIBOMPTARGET_RECORD_DEVICE=<Num> (default 0)``
 * ``LIBOMPTARGET_RECORD_OUTPUT=[TRUE/FALSE] (default TRUE)``
@@ -1311,20 +1311,19 @@ LIBOMPTARGET_RECORD_REPORT
 
 This environment variable is used to instruct the runtime to emit a summary of
 the recorded kernel instances and their associated JSON files. When enabled, the
-report is emitted in the standard output. The environment variable
-:ref:`LIBOMPTARGET_RECORD_REPORT_FILE` can be used to indicate the file name of
-the file where to emit the report. By default, no report is emitted.
+report is emitted in the standard output. See
+:ref:`LIBOMPTARGET_RECORD_REPORT_FILENAME` to emit the report to a file. By
+default, no report is emitted.
 
-.. _libomptarget_record_report_file:
+.. _libomptarget_record_report_filename:
 
-LIBOMPTARGET_RECORD_REPORT_FILE
-"""""""""""""""""""""""""""""""
+LIBOMPTARGET_RECORD_REPORT_FILENAME
+"""""""""""""""""""""""""""""""""""
 
 This environment variable is used to instruct the runtime to emit the recording
-report to an output file with a specific file name. The file will be created
-within the recording directory (see :ref:`LIBOMPTARGET_RECORD_DIR`). Note that
-it is not needed to use :ref:`LIBOMPTARGET_RECORD_REPORT` when setting this
-environment variable.
+report to a file with a specific file. The file is written in the recording
+directory (see :ref:`LIBOMPTARGET_RECORD_DIR`). Note that it is not needed to
+use :ref:`LIBOMPTARGET_RECORD_REPORT` when setting this environment variable.
 
 LIBOMPTARGET_RECORD_MEMSIZE
 """""""""""""""""""""""""""

--- a/openmp/docs/design/Runtimes.rst
+++ b/openmp/docs/design/Runtimes.rst
@@ -1279,6 +1279,7 @@ is provided below.
 * ``LIBOMPTARGET_RECORD=[TRUE/FALSE] (default FALSE)``
 * ``LIBOMPTARGET_RECORD_DIR=<Filepath>``
 * ``LIBOMPTARGET_RECORD_REPORT=[TRUE/FALSE] (default FALSE)``
+* ``LIBOMPTARGET_RECORD_REPORT_FILE=<Filename>``
 * ``LIBOMPTARGET_RECORD_MEMSIZE=<Num> (default 8*1024*1024*1024)``
 * ``LIBOMPTARGET_RECORD_DEVICE=<Num> (default 0)``
 * ``LIBOMPTARGET_RECORD_OUTPUT=[TRUE/FALSE] (default TRUE)``
@@ -1309,8 +1310,20 @@ LIBOMPTARGET_RECORD_REPORT
 """"""""""""""""""""""""""
 
 This environment variable is used to instruct the runtime to emit a summary of
-the recorded kernel instances and their associated JSON files. By default, no
-report is emitted.
+the recorded kernel instances and their associated JSON files. When enabled, the
+report is emitted in the standard output. The environment variable
+:ref:`LIBOMPTARGET_RECORD_REPORT_FILE` can be used to indicate a file where to
+emit the report. By default, no report is emitted.
+
+.. _libomptarget_record_report_file:
+
+LIBOMPTARGET_RECORD_REPORT_FILE
+"""""""""""""""""""""""""""""""
+
+This environment variable is used to instruct the runtime to emit the recording
+report to a specific output file. The file will be created within the recording
+directory. Note that it is not needed to use :ref:`LIBOMPTARGET_RECORD_REPORT`
+when setting this enviornment variable.
 
 LIBOMPTARGET_RECORD_MEMSIZE
 """""""""""""""""""""""""""


### PR DESCRIPTION
This commit extends the record reporting mechanism:
- `LIBOMPTARGET_RECORD_REPORT_FILENAME` enables the reporting mechanism and allows specifying the name of the output file.
- The report of recorded kernels are ordered in recording order. This is really useful for tests that need to record and replay more than one kernel.