### PR TITLE
[mlir] Handle null region in LoopLikeOpInterface::isDefinedOutsideOfLoop

### DIFF
--- a/mlir/include/mlir/IR/Region.h
+++ b/mlir/include/mlir/IR/Region.h
@@ -199,6 +199,9 @@ public:
   /// Return the parent operation this region is attached to.
   Operation *getParentOp() { return container; }
 
+  /// Return true if this region is attached to an operation.
+  bool isAttached() { return container != nullptr; }
+
   /// Find the first parent operation of the given type, or nullptr if there is
   /// no ancestor operation.
   template <typename ParentT>

--- a/mlir/include/mlir/Interfaces/LoopLikeInterface.td
+++ b/mlir/include/mlir/Interfaces/LoopLikeInterface.td
@@ -62,7 +62,8 @@ def LoopLikeOpInterface : OpInterface<"LoopLikeOpInterface"> {
       /*args=*/(ins "::mlir::Value ":$value),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
-        return !$_op->isAncestor(value.getParentRegion()->getParentOp());
+        ::mlir::Region *region = value.getParentRegion();
+        return !region || !region->isAttached() || !$_op->isAncestor(region->getParentOp());
       }]
     >,
     InterfaceMethod<[{

--- a/mlir/test/Conversion/FuncToLLVM/func-to-llvm.mlir
+++ b/mlir/test/Conversion/FuncToLLVM/func-to-llvm.mlir
@@ -583,3 +583,18 @@ module attributes {transform.with_named_sequence} {
     transform.yield
   }
 }
+
+// During signature conversion with index-bitwidth=32, pattern rollback can
+// unlink blocks/ops from their regions. If loop-like operations are folded
+// in this state, querying `isDefinedOutsideOfLoop` on block arguments
+// of unlinked blocks would previously dereference a null parent region pointer
+// and crash.
+// See: https://github.com/llvm/llvm-project/issues/203860
+// CHECK32-LABEL: llvm.func @affine_for_index_bitwidth_32
+func.func @affine_for_index_bitwidth_32(%arg0: index, %arg1: index, %arg2: index, %arg3: index) {
+  %0 = affine.for %arg4 = 0 to 101 iter_args(%arg5 = %arg1) -> (index) {
+    affine.yield %arg3 : index
+  }
+  return
+}
+


### PR DESCRIPTION
Fixes #203860 

In LoopLikeOpInterface::isDefinedOutsideOfLoop default implementation, value.getParentRegion() can return null during signature conversion rollbacks when blocks/ops are unlinked. Check for null region to avoid a segmentation fault.

Also, add a regression test for convert-func-to-llvm with index-bitwidth=32 on functions with affine.for loops.