### PR TITLE
[AMDGPU] Promote uniform i16 ABS to i32

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -1041,6 +1041,18 @@ bool AMDGPUTargetLowering::isZExtFree(EVT Src, EVT Dest) const {
 bool AMDGPUTargetLowering::isNarrowingProfitable(SDNode *N, EVT SrcVT,
                                                  EVT DestVT) const {
   switch (N->getOpcode()) {
+  case ISD::ABS: {
+    // Narrowing to types smaller than 32 bit is never profitable for uniform
+    // operations. The only native instruction is s_abs for i32, so narrowing to
+    // smaller types requires less efficient expansions.
+    if (!N->isDivergent() && DestVT.getSizeInBits() < 32)
+      return false;
+    // For all other cases, i.e., divergent or types larger than 32 bit, fall
+    // through. They will either profit from narrowing to i32 or will be
+    // expanded to a combination of SUB and SMAX, so follow their profitability
+    // logic.
+    LLVM_FALLTHROUGH;
+  }
   case ISD::ADD:
   case ISD::SUB:
   case ISD::SHL:

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -1041,18 +1041,7 @@ bool AMDGPUTargetLowering::isZExtFree(EVT Src, EVT Dest) const {
 bool AMDGPUTargetLowering::isNarrowingProfitable(SDNode *N, EVT SrcVT,
                                                  EVT DestVT) const {
   switch (N->getOpcode()) {
-  case ISD::ABS: {
-    // Narrowing to types smaller than 32 bit is never profitable for uniform
-    // operations. The only native instruction is s_abs for i32, so narrowing to
-    // smaller types requires less efficient expansions.
-    if (!N->isDivergent() && DestVT.getSizeInBits() < 32)
-      return false;
-    // For all other cases, i.e., divergent or types larger than 32 bit, fall
-    // through. They will either profit from narrowing to i32 or will be
-    // expanded to a combination of SUB and SMAX, so follow their profitability
-    // logic.
-    LLVM_FALLTHROUGH;
-  }
+  case ISD::ABS:
   case ISD::ADD:
   case ISD::SUB:
   case ISD::SHL:

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -8826,10 +8826,9 @@ static unsigned getExtOpcodeForPromotedOp(SDValue Op) {
   }
 }
 
-SDValue SITargetLowering::promoteUniformABSToI32(SDValue Op,
-                                                 DAGCombinerInfo &DCI) const {
-  assert(Op.getOpcode() == ISD::ABS);
-
+SDValue
+SITargetLowering::promoteUniformUnaryOpToI32(SDValue Op,
+                                             DAGCombinerInfo &DCI) const {
   EVT OpTy = Op.getValueType();
   auto &DAG = DCI.DAG;
   EVT ExtTy = OpTy.changeElementType(*DAG.getContext(), MVT::i32);
@@ -8842,9 +8841,9 @@ SDValue SITargetLowering::promoteUniformABSToI32(SDValue Op,
   const unsigned ExtOp = getExtOpcodeForPromotedOp(Op);
   Input = DAG.getNode(ExtOp, DL, ExtTy, Input);
 
-  SDValue NewVal = DAG.getNode(ISD::ABS, DL, ExtTy, Input);
+  SDValue NewVal = DAG.getNode(Op.getOpcode(), DL, ExtTy, Input);
 
-  return DAG.getZExtOrTrunc(NewVal, DL, OpTy);
+  return DAG.getNode(ISD::TRUNCATE, DL, OpTy, NewVal);
 }
 
 SDValue SITargetLowering::promoteUniformOpToI32(SDValue Op,
@@ -18594,7 +18593,7 @@ SDValue SITargetLowering::PerformDAGCombine(SDNode *N,
                                             DAGCombinerInfo &DCI) const {
   switch (N->getOpcode()) {
   case ISD::ABS:
-    if (auto Res = promoteUniformABSToI32(SDValue(N, 0), DCI))
+    if (auto Res = promoteUniformUnaryOpToI32(SDValue(N, 0), DCI))
       return Res;
     break;
   case ISD::ADD:

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -595,6 +595,9 @@ SITargetLowering::SITargetLowering(const TargetMachine &TM,
                         ISD::CTPOP},
                        MVT::i16, Promote);
 
+    setOperationAction(ISD::ABS, MVT::i16, Custom);
+    setOperationAction(ISD::ABS_MIN_POISON, MVT::i16, Custom);
+
     setOperationAction(ISD::LOAD, MVT::i16, Custom);
 
     setTruncStoreAction(MVT::i64, MVT::i16, Expand);
@@ -7492,6 +7495,36 @@ SDValue SITargetLowering::lowerROTR(SDValue Op, SelectionDAG &DAG) const {
   return DAG.UnrollVectorOp(Op.getNode());
 }
 
+SDValue SITargetLowering::lowerABS(SDValue Op, SelectionDAG &DAG) const {
+  assert(Subtarget->has16BitInsts() && "Requires 16-bit operations.");
+  [[maybe_unused]] EVT VT = Op.getValueType();
+
+  assert(VT == MVT::i16 && "Unexpected ValueType.");
+
+  // There is no integer v_abs instruction on AMDGPU, so divergent ABS needs to
+  // be expanded differently.
+  if (Op->isDivergent())
+    return SDValue();
+
+  SDLoc SL(Op);
+  // Expand plain abs by sign-extending to i32 and using the native s_abs
+  // instruction.
+  if (Op->getOpcode() == ISD::ABS) {
+    SDValue Ext = DAG.getNode(ISD::SIGN_EXTEND, SL, MVT::i32, Op.getOperand(0));
+    SDValue Abs = DAG.getNode(ISD::ABS, SL, MVT::i32, Ext);
+    return DAG.getNode(ISD::TRUNCATE, SL, MVT::i16, Abs);
+  }
+  assert(Op->getOpcode() == ISD::ABS_MIN_POISON);
+  // We also need to handle ABS_MIN_POISON here. This is the same expansion as
+  // in TargetLowering::expandABS, but since we marked ABS custom,
+  // TargetLowering::expandABS would expand ABS_MIN_POISON to ABS and lose the
+  // poison semantics. This instead expands abs(x) to max(x, 0 - x).
+  SDValue Zero = DAG.getConstant(0, SL, VT);
+  SDValue Frozen = DAG.getFreeze(Op.getOperand(0));
+  SDValue Sub = DAG.getNode(ISD::SUB, SL, VT, Zero, Frozen);
+  return DAG.getNode(ISD::SMAX, SL, VT, Frozen, Sub);
+}
+
 // Work around LegalizeDAG doing the wrong thing and fully scalarizing if the
 // wider vector type is legal.
 SDValue SITargetLowering::splitBinaryVectorOp(SDValue Op,
@@ -7618,7 +7651,13 @@ SDValue SITargetLowering::LowerOperation(SDValue Op, SelectionDAG &DAG) const {
     return lowerTRAP(Op, DAG);
   case ISD::DEBUGTRAP:
     return lowerDEBUGTRAP(Op, DAG);
-  case ISD::ABS:
+  case ISD::ABS: {
+    if (Op.getValueType() == MVT::i16)
+      return lowerABS(Op, DAG);
+    return splitUnaryVectorOp(Op, DAG);
+  }
+  case ISD::ABS_MIN_POISON:
+    return lowerABS(Op, DAG);
   case ISD::FABS:
   case ISD::FNEG:
   case ISD::FCANONICALIZE:

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -1053,6 +1053,7 @@ SITargetLowering::SITargetLowering(const TargetMachine &TM,
                        ISD::FMINIMUMNUM,
                        ISD::FMAXIMUMNUM,
                        ISD::FMA,
+                       ISD::ABS,
                        ISD::SMIN,
                        ISD::SMAX,
                        ISD::UMIN,
@@ -8796,6 +8797,7 @@ SDValue SITargetLowering::lowerFLDEXP(SDValue Op, SelectionDAG &DAG) const {
 
 static unsigned getExtOpcodeForPromotedOp(SDValue Op) {
   switch (Op->getOpcode()) {
+  case ISD::ABS:
   case ISD::SRA:
   case ISD::SMIN:
   case ISD::SMAX:
@@ -8822,6 +8824,27 @@ static unsigned getExtOpcodeForPromotedOp(SDValue Op) {
   default:
     llvm_unreachable("unexpected opcode!");
   }
+}
+
+SDValue SITargetLowering::promoteUniformABSToI32(SDValue Op,
+                                                 DAGCombinerInfo &DCI) const {
+  assert(Op.getOpcode() == ISD::ABS);
+
+  EVT OpTy = Op.getValueType();
+  auto &DAG = DCI.DAG;
+  EVT ExtTy = OpTy.changeElementType(*DAG.getContext(), MVT::i32);
+
+  if (Op->isDivergent() || isNarrowingProfitable(Op.getNode(), ExtTy, OpTy))
+    return SDValue();
+
+  SDLoc DL(Op);
+  SDValue Input = Op.getOperand(0);
+  const unsigned ExtOp = getExtOpcodeForPromotedOp(Op);
+  Input = DAG.getNode(ExtOp, DL, ExtTy, Input);
+
+  SDValue NewVal = DAG.getNode(ISD::ABS, DL, ExtTy, Input);
+
+  return DAG.getZExtOrTrunc(NewVal, DL, OpTy);
 }
 
 SDValue SITargetLowering::promoteUniformOpToI32(SDValue Op,
@@ -18570,6 +18593,10 @@ SDValue SITargetLowering::performSelectCombine(SDNode *N,
 SDValue SITargetLowering::PerformDAGCombine(SDNode *N,
                                             DAGCombinerInfo &DCI) const {
   switch (N->getOpcode()) {
+  case ISD::ABS:
+    if (auto Res = promoteUniformABSToI32(SDValue(N, 0), DCI))
+      return Res;
+    break;
   case ISD::ADD:
   case ISD::SUB:
   case ISD::SHL:

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -8834,7 +8834,7 @@ SDValue SITargetLowering::promoteUniformABSToI32(SDValue Op,
   auto &DAG = DCI.DAG;
   EVT ExtTy = OpTy.changeElementType(*DAG.getContext(), MVT::i32);
 
-  if (Op->isDivergent() || isNarrowingProfitable(Op.getNode(), ExtTy, OpTy))
+  if (isNarrowingProfitable(Op.getNode(), ExtTy, OpTy))
     return SDValue();
 
   SDLoc DL(Op);

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -595,9 +595,6 @@ SITargetLowering::SITargetLowering(const TargetMachine &TM,
                         ISD::CTPOP},
                        MVT::i16, Promote);
 
-    setOperationAction(ISD::ABS, MVT::i16, Custom);
-    setOperationAction(ISD::ABS_MIN_POISON, MVT::i16, Custom);
-
     setOperationAction(ISD::LOAD, MVT::i16, Custom);
 
     setTruncStoreAction(MVT::i64, MVT::i16, Expand);
@@ -7495,36 +7492,6 @@ SDValue SITargetLowering::lowerROTR(SDValue Op, SelectionDAG &DAG) const {
   return DAG.UnrollVectorOp(Op.getNode());
 }
 
-SDValue SITargetLowering::lowerABS(SDValue Op, SelectionDAG &DAG) const {
-  assert(Subtarget->has16BitInsts() && "Requires 16-bit operations.");
-  [[maybe_unused]] EVT VT = Op.getValueType();
-
-  assert(VT == MVT::i16 && "Unexpected ValueType.");
-
-  // There is no integer v_abs instruction on AMDGPU, so divergent ABS needs to
-  // be expanded differently.
-  if (Op->isDivergent())
-    return SDValue();
-
-  SDLoc SL(Op);
-  // Expand plain abs by sign-extending to i32 and using the native s_abs
-  // instruction.
-  if (Op->getOpcode() == ISD::ABS) {
-    SDValue Ext = DAG.getNode(ISD::SIGN_EXTEND, SL, MVT::i32, Op.getOperand(0));
-    SDValue Abs = DAG.getNode(ISD::ABS, SL, MVT::i32, Ext);
-    return DAG.getNode(ISD::TRUNCATE, SL, MVT::i16, Abs);
-  }
-  assert(Op->getOpcode() == ISD::ABS_MIN_POISON);
-  // We also need to handle ABS_MIN_POISON here. This is the same expansion as
-  // in TargetLowering::expandABS, but since we marked ABS custom,
-  // TargetLowering::expandABS would expand ABS_MIN_POISON to ABS and lose the
-  // poison semantics. This instead expands abs(x) to max(x, 0 - x).
-  SDValue Zero = DAG.getConstant(0, SL, VT);
-  SDValue Frozen = DAG.getFreeze(Op.getOperand(0));
-  SDValue Sub = DAG.getNode(ISD::SUB, SL, VT, Zero, Frozen);
-  return DAG.getNode(ISD::SMAX, SL, VT, Frozen, Sub);
-}
-
 // Work around LegalizeDAG doing the wrong thing and fully scalarizing if the
 // wider vector type is legal.
 SDValue SITargetLowering::splitBinaryVectorOp(SDValue Op,
@@ -7651,13 +7618,7 @@ SDValue SITargetLowering::LowerOperation(SDValue Op, SelectionDAG &DAG) const {
     return lowerTRAP(Op, DAG);
   case ISD::DEBUGTRAP:
     return lowerDEBUGTRAP(Op, DAG);
-  case ISD::ABS: {
-    if (Op.getValueType() == MVT::i16)
-      return lowerABS(Op, DAG);
-    return splitUnaryVectorOp(Op, DAG);
-  }
-  case ISD::ABS_MIN_POISON:
-    return lowerABS(Op, DAG);
+  case ISD::ABS:
   case ISD::FABS:
   case ISD::FNEG:
   case ISD::FCANONICALIZE:

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -8830,7 +8830,7 @@ SDValue
 SITargetLowering::promoteUniformUnaryOpToI32(SDValue Op,
                                              DAGCombinerInfo &DCI) const {
   EVT OpTy = Op.getValueType();
-  auto &DAG = DCI.DAG;
+  SelectionDAG &DAG = DCI.DAG;
   EVT ExtTy = OpTy.changeElementType(*DAG.getContext(), MVT::i32);
 
   if (isNarrowingProfitable(Op.getNode(), ExtTy, OpTy))
@@ -18593,7 +18593,7 @@ SDValue SITargetLowering::PerformDAGCombine(SDNode *N,
                                             DAGCombinerInfo &DCI) const {
   switch (N->getOpcode()) {
   case ISD::ABS:
-    if (auto Res = promoteUniformUnaryOpToI32(SDValue(N, 0), DCI))
+    if (SDValue Res = promoteUniformUnaryOpToI32(SDValue(N, 0), DCI))
       return Res;
     break;
   case ISD::ADD:

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.h
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.h
@@ -472,7 +472,6 @@ public:
   SDValue lowerGET_FPENV(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerSET_FPENV(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerROTR(SDValue Op, SelectionDAG &DAG) const;
-  SDValue lowerABS(SDValue Op, SelectionDAG &DAG) const;
 
   Register getRegisterByName(const char* RegName, LLT VT,
                              const MachineFunction &MF) const override;

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.h
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.h
@@ -168,7 +168,7 @@ private:
   SDValue lowerFMINIMUM_FMAXIMUM(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerFLDEXP(SDValue Op, SelectionDAG &DAG) const;
   SDValue promoteUniformOpToI32(SDValue Op, DAGCombinerInfo &DCI) const;
-  SDValue promoteUniformABSToI32(SDValue Op, DAGCombinerInfo &DCI) const;
+  SDValue promoteUniformUnaryOpToI32(SDValue Op, DAGCombinerInfo &DCI) const;
   SDValue lowerFCOPYSIGN(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerMUL(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerXMULO(SDValue Op, SelectionDAG &DAG) const;

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.h
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.h
@@ -168,6 +168,7 @@ private:
   SDValue lowerFMINIMUM_FMAXIMUM(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerFLDEXP(SDValue Op, SelectionDAG &DAG) const;
   SDValue promoteUniformOpToI32(SDValue Op, DAGCombinerInfo &DCI) const;
+  SDValue promoteUniformABSToI32(SDValue Op, DAGCombinerInfo &DCI) const;
   SDValue lowerFCOPYSIGN(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerMUL(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerXMULO(SDValue Op, SelectionDAG &DAG) const;

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.h
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.h
@@ -472,6 +472,7 @@ public:
   SDValue lowerGET_FPENV(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerSET_FPENV(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerROTR(SDValue Op, SelectionDAG &DAG) const;
+  SDValue lowerABS(SDValue Op, SelectionDAG &DAG) const;
 
   Register getRegisterByName(const char* RegName, LLT VT,
                              const MachineFunction &MF) const override;

--- a/llvm/test/CodeGen/AMDGPU/absdiff.ll
+++ b/llvm/test/CodeGen/AMDGPU/absdiff.ll
@@ -43,10 +43,8 @@ define amdgpu_ps i16 @absdiff_i16_false(i16 inreg %arg0, i16 inreg %arg1) {
 ; CHECK-LABEL: absdiff_i16_false:
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    s_sub_i32 s0, s0, s1
-; CHECK-NEXT:    s_sext_i32_i16 s1, s0
-; CHECK-NEXT:    s_sub_i32 s0, 0, s0
 ; CHECK-NEXT:    s_sext_i32_i16 s0, s0
-; CHECK-NEXT:    s_max_i32 s0, s1, s0
+; CHECK-NEXT:    s_abs_i32 s0, s0
 ; CHECK-NEXT:    ; return to shader part epilog
   %diff = sub i16 %arg0, %arg1
   %res = call i16 @llvm.abs.i16(i16 %diff, i1 false) ; INT_MIN input returns INT_MIN

--- a/llvm/test/CodeGen/AMDGPU/absdiff.ll
+++ b/llvm/test/CodeGen/AMDGPU/absdiff.ll
@@ -43,8 +43,10 @@ define amdgpu_ps i16 @absdiff_i16_false(i16 inreg %arg0, i16 inreg %arg1) {
 ; CHECK-LABEL: absdiff_i16_false:
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    s_sub_i32 s0, s0, s1
+; CHECK-NEXT:    s_sext_i32_i16 s1, s0
+; CHECK-NEXT:    s_sub_i32 s0, 0, s0
 ; CHECK-NEXT:    s_sext_i32_i16 s0, s0
-; CHECK-NEXT:    s_abs_i32 s0, s0
+; CHECK-NEXT:    s_max_i32 s0, s1, s0
 ; CHECK-NEXT:    ; return to shader part epilog
   %diff = sub i16 %arg0, %arg1
   %res = call i16 @llvm.abs.i16(i16 %diff, i1 false) ; INT_MIN input returns INT_MIN


### PR DESCRIPTION
GlobalISel already expands uniform `i16` `G_ABS` to sign-extend to i32 and the native `s_abs` instruction.

This adds a similar expansion as DAGCombiner pattern, promoting uniform `i16` `ABS` to `i32` that can use `s_abs`.