### PR TITLE
[clang][bytecode] Diagnose jumps to case labels in StmtExprs

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -4619,6 +4619,8 @@ bool Compiler<Emitter>::VisitStmtExpr(const StmtExpr *E) {
     assert(S == Result);
     if (const Expr *ResultExpr = dyn_cast<Expr>(S))
       return this->delegate(ResultExpr);
+    if (!this->visitStmt(S))
+      return false;
     return this->emitUnsupported(E);
   }
 
@@ -6599,6 +6601,7 @@ bool Compiler<Emitter>::visitSwitchStmt(const SwitchStmt *S) {
 
   PrimType CondT = this->classifyPrim(Cond->getType());
   LocalScope<Emitter> LS(this);
+  llvm::SaveAndRestore StmtExprSAR(this->SwitchInStmtExpr, this->InStmtExpr);
 
   LabelTy EndLabel = this->getLabel();
   UnsignedOrNone DefaultLabel = std::nullopt;
@@ -6705,6 +6708,12 @@ template <class Emitter>
 bool Compiler<Emitter>::visitCaseStmt(const CaseStmt *S) {
   this->fallthrough(CaseLabels[S]);
   this->emitLabel(CaseLabels[S]);
+
+  // We can't jump from an outer switch statement to a case label
+  // that's inside a StmtExpr.
+  if (this->InStmtExpr && !this->SwitchInStmtExpr)
+    return this->emitUnsupported(S);
+
   return this->visitStmt(S->getSubStmt());
 }
 

--- a/clang/lib/AST/ByteCode/Compiler.h
+++ b/clang/lib/AST/ByteCode/Compiler.h
@@ -478,6 +478,7 @@ protected:
   /// Flag indicating if return value is to be discarded.
   bool DiscardResult = false;
 
+  bool SwitchInStmtExpr = false;
   bool InStmtExpr = false;
   bool ToLValue = false;
 

--- a/clang/test/AST/ByteCode/literals.cpp
+++ b/clang/test/AST/ByteCode/literals.cpp
@@ -1336,6 +1336,21 @@ namespace StmtExprs {
            i;
         }) == 300);
   }
+
+  constexpr int f(int k) {
+    switch (k) {
+    case 0:
+      return 0;
+
+      ({  // both-note {{jump enters a statement expression}}
+        case 1:// both-error {{cannot jump from switch statement to this case label}} \
+               // both-note  {{not supported}}
+          return 1;
+      });
+    }
+  }
+  static_assert(f(1) == 1, ""); // both-error {{constant expression}} both-note {{in call}}
+
 }
 #endif
 


### PR DESCRIPTION
We need another bit of state to save if the switch was also in the StmtExpr or not.