### PR TITLE
[AMDGPU][InsertWaitCnts] Move TENSOR/ASYNC event detection to separate header

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUHWEvents.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUHWEvents.cpp
@@ -127,8 +127,15 @@ static HWEvents getEventsForImpl(const MachineInstr &Inst,
 
     if (TII.mayAccessLDSThroughFlat(Inst))
       E |= HWEvents::LDS_ACCESS;
+
+    if (SIInstrInfo::usesASYNC_CNT(Inst))
+      E |= HWEvents::ASYNC_ACCESS;
+
     return E;
   }
+
+  if (SIInstrInfo::usesTENSOR_CNT(Inst))
+    return HWEvents::TENSOR_ACCESS;
 
   if (SIInstrInfo::isVMEM(Inst) &&
       (!AMDGPU::getMUBUFIsBufferInv(Inst.getOpcode()) ||

--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -2668,11 +2668,6 @@ void SIInsertWaitcnts::updateEventWaitcntAfter(MachineInstr &Inst,
       // pointers so that both VM and LGKM counters are flushed.
       ScoreBrackets->setPendingFlat();
     }
-    if (SIInstrInfo::usesASYNC_CNT(Inst)) {
-      ScoreBrackets->updateByEvent(HWEvents::ASYNC_ACCESS, Inst);
-    }
-  } else if (SIInstrInfo::usesTENSOR_CNT(Inst)) {
-    ScoreBrackets->updateByEvent(HWEvents::TENSOR_ACCESS, Inst);
   } else if (Inst.isCall()) {
     // Act as a wait on everything, but AsyncCnt and TensorCnt are never
     // included in such blanket waits.


### PR DESCRIPTION
I forgot to move those out of the way as they were not grouped with the other.
Now `getEventsFor` does all the work.