### PR TITLE
[BOLT][AArch64] reproducible output with constant islands

### DIFF
--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -37,6 +37,7 @@
 #include "bolt/Utils/NameResolver.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator.h"
@@ -193,7 +194,9 @@ public:
     /// Keeps track of other functions we depend on because there is a reference
     /// to the constant islands in them.
     IslandProxiesType Proxies, ColdProxies;
-    SmallPtrSet<BinaryFunction *, 1> Dependency; // The other way around
+    SetVector<BinaryFunction *, SmallVector<BinaryFunction *, 1>,
+              SmallPtrSet<BinaryFunction *, 1>>
+        Dependency; // The other way around
 
     mutable MCSymbol *FunctionConstantIslandLabel{nullptr};
     mutable MCSymbol *FunctionColdConstantIslandLabel{nullptr};

--- a/bolt/test/AArch64/constant-island-reproducible.s
+++ b/bolt/test/AArch64/constant-island-reproducible.s
@@ -1,0 +1,56 @@
+# This test checks that the sequence of generated constant islands is the same across
+# every llvm-bolt run.
+# The 1 KB alignment is used to place the main and dummy0 functions far enough apart.
+# If the functions are close, the original constant islands are used instead of
+# the generated ones (no binary difference in this case).
+
+# REQUIRES: system-linux
+
+# RUN: %clang %s %cflags -no-pie -o %t.exe -Wl,-q
+# RUN: llvm-bolt %t.exe -o %t.bolt --lite=0
+# RUN: llvm-objdump --disassemble-symbols=main %t.bolt | FileCheck %s
+
+# CHECK: 00000010 udf #0x10
+# CHECK: 00000020 udf #0x20
+# CHECK: 00000030 udf #0x30
+# CHECK: 00000040 udf #0x40
+
+  .text
+  .align 10
+  .global main
+  .type main, %function
+main:
+  adr x0, CI0
+  ldr x0, [x0]
+  adr x0, CI1
+  ldr x0, [x0]
+  adr x0, CI2
+  ldr x0, [x0]
+  adr x0, CI3
+  ldr x0, [x0]
+  ret
+  .size main, .-main
+
+  .align 10
+  .global dummy0
+  .type dummy0, %function
+dummy0:
+  mov x0, #0
+  ret
+  .size dummy0, .-dummy0
+CI0:
+  .xword 0x10
+CI1:
+  .xword 0x20
+
+  .align 4
+  .global dummy1
+  .type dummy1, %function
+dummy1:
+  mov x0, #0
+  ret
+  .size dummy1, .-dummy1
+CI2:
+  .xword 0x30
+CI3:
+  .xword 0x40


### PR DESCRIPTION
Optimized binaries from subsequent llvm-bolt runs may sometimes differ due to the unordered set (SmallPtrSet), even if the input binary and parameters are the same. Usage of SetVector guarantees a deterministic sequence of binary functions while keeping each function as a single instance.

Below you can see two different main functions before the fix after two llvm-bolt runs (same input binaries, same arguments).

```
0000000000210400 <main>:
  210400: 10000140      adr     x0, 0x210428 <main+0x28>
  210404: f9400000      ldr     x0, [x0]
  210408: 10000140      adr     x0, 0x210430 <main+0x30>
  21040c: f9400000      ldr     x0, [x0]
  210410: 10000180      adr     x0, 0x210440 <main+0x40>
  210414: f9400000      ldr     x0, [x0]
  210418: 10000180      adr     x0, 0x210448 <main+0x48>
  21041c: f9400000      ldr     x0, [x0]
  210420: d65f03c0      ret
  210424: d503201f      nop
  210428: 00000010      udf     #0x10
  21042c: 00000000      udf     #0x0
  210430: 00000020      udf     #0x20
  210434: 00000000      udf     #0x0
  210438: d503201f      nop
  21043c: d503201f      nop
  210440: 00000030      udf     #0x30
  210444: 00000000      udf     #0x0
  210448: 00000040      udf     #0x40
  21044c: 00000000      udf     #0x0
  210450: d503201f      nop
  210454: d503201f      nop

0000000000210400 <main>:
  210400: 100001c0      adr     x0, 0x210438 <main+0x38>
  210404: f9400000      ldr     x0, [x0]
  210408: 100001c0      adr     x0, 0x210440 <main+0x40>
  21040c: f9400000      ldr     x0, [x0]
  210410: 100000c0      adr     x0, 0x210428 <main+0x28>
  210414: f9400000      ldr     x0, [x0]
  210418: 100000c0      adr     x0, 0x210430 <main+0x30>
  21041c: f9400000      ldr     x0, [x0]
  210420: d65f03c0      ret
  210424: d503201f      nop
  210428: 00000030      udf     #0x30
  21042c: 00000000      udf     #0x0
  210430: 00000040      udf     #0x40
  210434: 00000000      udf     #0x0
  210438: 00000010      udf     #0x10
  21043c: 00000000      udf     #0x0
  210440: 00000020      udf     #0x20
  210444: 00000000      udf     #0x0
  210448: d503201f      nop
  21044c: d503201f      nop
```