### PR TITLE
[NFC][llvm] simplify convertWideToUTF8 overloads

### DIFF
--- a/llvm/include/llvm/Support/ConvertUTF.h
+++ b/llvm/include/llvm/Support/ConvertUTF.h
@@ -246,16 +246,10 @@ LLVM_ABI bool ConvertUTF8toWide(llvm::StringRef Source, std::wstring &Result);
 LLVM_ABI bool ConvertUTF8toWide(const char *Source, std::wstring &Result);
 
 /**
- * Converts an ArrayRef<wchar_t> to a UTF-8 encoded std::string.
+ * Converts a wide string view to a UTF-8 encoded std::string.
  * \return true on success.
  */
-LLVM_ABI bool convertWideToUTF8(ArrayRef<wchar_t> Source, std::string &Result);
-
-/**
- * Converts a wide C-string to a UTF-8 encoded std::string.
- * \return true on success.
- */
-LLVM_ABI bool convertWideToUTF8(const wchar_t *Source, std::string &Result);
+LLVM_ABI bool convertWideToUTF8(std::wstring_view Source, std::string &Result);
 
 /**
  * Convert an Unicode code point to UTF8 sequence.

--- a/llvm/lib/Support/ConvertUTFWrapper.cpp
+++ b/llvm/lib/Support/ConvertUTFWrapper.cpp
@@ -268,7 +268,7 @@ bool ConvertUTF8toWide(const char *Source, std::wstring &Result) {
   return ConvertUTF8toWide(llvm::StringRef(Source), Result);
 }
 
-bool convertWideToUTF8(ArrayRef<wchar_t> Source, std::string &Result) {
+bool convertWideToUTF8(std::wstring_view Source, std::string &Result) {
   if (sizeof(wchar_t) == 1) {
     const UTF8 *Start = reinterpret_cast<const UTF8 *>(Source.data());
     const UTF8 *End =
@@ -302,10 +302,6 @@ bool convertWideToUTF8(ArrayRef<wchar_t> Source, std::string &Result) {
     llvm_unreachable(
         "Control should never reach this point; see static_assert further up");
   }
-}
-
-bool convertWideToUTF8(const wchar_t *Source, std::string &Result) {
-  return convertWideToUTF8(std::wstring_view(Source), Result);
 }
 
 bool IsSingleCodeUnitUTF8Codepoint(unsigned V) { return V <= 0x7F; }


### PR DESCRIPTION
Remove the C-String overload of `convertWideToUTF8` and convert the `ArrayRef` one to use `std::wstring_view` in order to simplify the API.