### PR TITLE
[CommandLine] Make cl::boolOrDefault a scoped enum

### DIFF
--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -2284,15 +2284,16 @@ Error RewriteInstance::readSpecialSections() {
     BC->printSections(BC->outs());
   }
 
-  if (opts::RelocationMode == cl::BOU_TRUE && !HasTextRelocations) {
+  if (opts::RelocationMode == cl::boolOrDefault::BOU_TRUE &&
+      !HasTextRelocations) {
     BC->errs()
         << "BOLT-ERROR: relocations against code are missing from the input "
            "file. Cannot proceed in relocations mode (-relocs).\n";
     exit(1);
   }
 
-  BC->HasRelocations =
-      HasTextRelocations && (opts::RelocationMode != cl::BOU_FALSE);
+  BC->HasRelocations = HasTextRelocations &&
+                       (opts::RelocationMode != cl::boolOrDefault::BOU_FALSE);
 
   if (BC->IsLinuxKernel && BC->HasRelocations) {
     BC->outs() << "BOLT-INFO: disabling relocation mode for Linux kernel\n";

--- a/llvm/include/llvm/Passes/CodeGenPassBuilder.h
+++ b/llvm/include/llvm/Passes/CodeGenPassBuilder.h
@@ -194,9 +194,10 @@ public:
     if (Opt.EnableGlobalISelAbort)
       TM.Options.GlobalISelAbort = *Opt.EnableGlobalISelAbort;
 
-    if (Opt.OptimizeRegAlloc == cl::BOU_UNSET)
-      Opt.OptimizeRegAlloc =
-          getOptLevel() != CodeGenOptLevel::None ? cl::BOU_TRUE : cl::BOU_FALSE;
+    if (Opt.OptimizeRegAlloc == cl::boolOrDefault::BOU_UNSET)
+      Opt.OptimizeRegAlloc = getOptLevel() != CodeGenOptLevel::None
+                                 ? cl::boolOrDefault::BOU_TRUE
+                                 : cl::boolOrDefault::BOU_FALSE;
   }
 
   Error buildPipeline(ModulePassManager &MPM, ModuleAnalysisManager &MAM,
@@ -876,17 +877,18 @@ template <typename Derived, typename TargetMachineT>
 Error CodeGenPassBuilder<Derived, TargetMachineT>::addCoreISelPasses(
     PassManagerWrapper &PMW) const {
   // Enable FastISel with -fast-isel, but allow that to be overridden.
-  TM.setO0WantsFastISel(Opt.EnableFastISelOption != cl::BOU_FALSE);
+  TM.setO0WantsFastISel(Opt.EnableFastISelOption !=
+                        cl::boolOrDefault::BOU_FALSE);
 
   // Determine an instruction selector.
   enum class SelectorType { SelectionDAG, FastISel, GlobalISel };
   SelectorType Selector;
 
-  if (Opt.EnableFastISelOption == cl::BOU_TRUE)
+  if (Opt.EnableFastISelOption == cl::boolOrDefault::BOU_TRUE)
     Selector = SelectorType::FastISel;
-  else if (Opt.EnableGlobalISelOption == cl::BOU_TRUE ||
+  else if (Opt.EnableGlobalISelOption == cl::boolOrDefault::BOU_TRUE ||
            (TM.Options.EnableGlobalISel &&
-            Opt.EnableGlobalISelOption != cl::BOU_FALSE))
+            Opt.EnableGlobalISelOption != cl::boolOrDefault::BOU_FALSE))
     Selector = SelectorType::GlobalISel;
   else if (TM.getOptLevel() == CodeGenOptLevel::None && TM.getO0WantsFastISel())
     Selector = SelectorType::FastISel;
@@ -988,7 +990,7 @@ Error CodeGenPassBuilder<Derived, TargetMachineT>::addMachinePasses(
 
   // Run register allocation and passes that are tightly coupled with it,
   // including phi elimination and scheduling.
-  if (auto Err = Opt.OptimizeRegAlloc == cl::BOU_TRUE
+  if (auto Err = Opt.OptimizeRegAlloc == cl::boolOrDefault::BOU_TRUE
                      ? derived().addOptimizedRegAlloc(PMW)
                      : derived().addFastRegAlloc(PMW))
     return std::move(Err);

--- a/llvm/include/llvm/Support/CommandLine.h
+++ b/llvm/include/llvm/Support/CommandLine.h
@@ -630,7 +630,7 @@ struct OptionValue final
 };
 
 // Other safe-to-copy-by-value common option types.
-enum boolOrDefault { BOU_UNSET, BOU_TRUE, BOU_FALSE };
+enum class boolOrDefault { BOU_UNSET, BOU_TRUE, BOU_FALSE };
 template <>
 struct LLVM_ABI OptionValue<cl::boolOrDefault> final
     : OptionValueCopy<cl::boolOrDefault> {

--- a/llvm/include/llvm/Target/CGPassBuilderOption.h
+++ b/llvm/include/llvm/Target/CGPassBuilderOption.h
@@ -48,7 +48,7 @@ public:
 // Not one-on-one but mostly corresponding to commandline options in
 // TargetPassConfig.cpp.
 struct CGPassBuilderOption {
-  cl::boolOrDefault OptimizeRegAlloc = cl::BOU_UNSET;
+  cl::boolOrDefault OptimizeRegAlloc = cl::boolOrDefault::BOU_UNSET;
   std::optional<bool> EnableIPRA;
   bool DebugPM = false;
   bool DisableVerify = false;
@@ -84,11 +84,11 @@ struct CGPassBuilderOption {
   std::string FSProfileFile;
   std::string FSRemappingFile;
 
-  cl::boolOrDefault VerifyMachineCode = cl::BOU_UNSET;
-  cl::boolOrDefault EnableFastISelOption = cl::BOU_UNSET;
-  cl::boolOrDefault EnableGlobalISelOption = cl::BOU_UNSET;
-  cl::boolOrDefault DebugifyAndStripAll = cl::BOU_UNSET;
-  cl::boolOrDefault DebugifyCheckAndStripAll = cl::BOU_UNSET;
+  cl::boolOrDefault VerifyMachineCode = cl::boolOrDefault::BOU_UNSET;
+  cl::boolOrDefault EnableFastISelOption = cl::boolOrDefault::BOU_UNSET;
+  cl::boolOrDefault EnableGlobalISelOption = cl::boolOrDefault::BOU_UNSET;
+  cl::boolOrDefault DebugifyAndStripAll = cl::boolOrDefault::BOU_UNSET;
+  cl::boolOrDefault DebugifyCheckAndStripAll = cl::boolOrDefault::BOU_UNSET;
 };
 
 LLVM_ABI CGPassBuilderOption getCGPassBuilderOption();

--- a/llvm/lib/CodeGen/BranchFolding.cpp
+++ b/llvm/lib/CodeGen/BranchFolding.cpp
@@ -74,8 +74,9 @@ STATISTIC(NumTailMerge , "Number of block tails merged");
 STATISTIC(NumHoist     , "Number of times common instructions are hoisted");
 STATISTIC(NumTailCalls,  "Number of tail calls optimized");
 
-static cl::opt<cl::boolOrDefault> FlagEnableTailMerge("enable-tail-merge",
-                              cl::init(cl::BOU_UNSET), cl::Hidden);
+static cl::opt<cl::boolOrDefault>
+    FlagEnableTailMerge("enable-tail-merge",
+                        cl::init(cl::boolOrDefault::BOU_UNSET), cl::Hidden);
 
 // Throttle for huge numbers of predecessors (compile speed problems)
 static cl::opt<unsigned>
@@ -173,11 +174,15 @@ BranchFolder::BranchFolder(bool DefaultEnableTailMerge, bool CommonHoist,
     : EnableHoistCommonCode(CommonHoist), MinCommonTailLength(MinTailLength),
       MBBFreqInfo(FreqInfo), MBPI(ProbInfo), PSI(PSI) {
   switch (FlagEnableTailMerge) {
-  case cl::BOU_UNSET:
+  case cl::boolOrDefault::BOU_UNSET:
     EnableTailMerge = DefaultEnableTailMerge;
     break;
-  case cl::BOU_TRUE: EnableTailMerge = true; break;
-  case cl::BOU_FALSE: EnableTailMerge = false; break;
+  case cl::boolOrDefault::BOU_TRUE:
+    EnableTailMerge = true;
+    break;
+  case cl::boolOrDefault::BOU_FALSE:
+    EnableTailMerge = false;
+    break;
   }
 }
 

--- a/llvm/lib/CodeGen/GlobalMerge.cpp
+++ b/llvm/lib/CodeGen/GlobalMerge.cpp
@@ -773,8 +773,10 @@ Pass *llvm::createGlobalMergePass(const TargetMachine *TM, unsigned Offset,
                                   bool MergeExternalByDefault,
                                   bool MergeConstantByDefault,
                                   bool MergeConstAggressiveByDefault) {
-  bool MergeExternal = (EnableGlobalMergeOnExternal == cl::BOU_UNSET) ?
-    MergeExternalByDefault : (EnableGlobalMergeOnExternal == cl::BOU_TRUE);
+  bool MergeExternal =
+      (EnableGlobalMergeOnExternal == cl::boolOrDefault::BOU_UNSET)
+          ? MergeExternalByDefault
+          : (EnableGlobalMergeOnExternal == cl::boolOrDefault::BOU_TRUE);
   bool MergeConstant = EnableGlobalMergeOnConst || MergeConstantByDefault;
   bool MergeConstAggressive = GlobalMergeAllConst.getNumOccurrences() > 0
                                   ? GlobalMergeAllConst

--- a/llvm/lib/CodeGen/MachineCopyPropagation.cpp
+++ b/llvm/lib/CodeGen/MachineCopyPropagation.cpp
@@ -1619,14 +1619,14 @@ MachineCopyPropagationPass::run(MachineFunction &MF,
 bool MachineCopyPropagation::run(MachineFunction &MF) {
   bool IsSpillageCopyElimEnabled = false;
   switch (EnableSpillageCopyElimination) {
-  case cl::BOU_UNSET:
+  case cl::boolOrDefault::BOU_UNSET:
     IsSpillageCopyElimEnabled =
         MF.getSubtarget().enableSpillageCopyElimination();
     break;
-  case cl::BOU_TRUE:
+  case cl::boolOrDefault::BOU_TRUE:
     IsSpillageCopyElimEnabled = true;
     break;
-  case cl::BOU_FALSE:
+  case cl::boolOrDefault::BOU_FALSE:
     IsSpillageCopyElimEnabled = false;
     break;
   }

--- a/llvm/lib/CodeGen/RegisterCoalescer.cpp
+++ b/llvm/lib/CodeGen/RegisterCoalescer.cpp
@@ -92,7 +92,7 @@ static cl::opt<bool> EnableJoinSplits(
 static cl::opt<cl::boolOrDefault> EnableGlobalCopies(
     "join-globalcopies",
     cl::desc("Coalesce copies that span blocks (default=subtarget)"),
-    cl::init(cl::BOU_UNSET), cl::Hidden);
+    cl::init(cl::boolOrDefault::BOU_UNSET), cl::Hidden);
 
 static cl::opt<bool> VerifyCoalescing(
     "verify-coalescing",
@@ -4317,10 +4317,10 @@ bool RegisterCoalescer::run(MachineFunction &fn) {
   const TargetSubtargetInfo &STI = fn.getSubtarget();
   TRI = STI.getRegisterInfo();
   TII = STI.getInstrInfo();
-  if (EnableGlobalCopies == cl::BOU_UNSET)
+  if (EnableGlobalCopies == cl::boolOrDefault::BOU_UNSET)
     JoinGlobalCopies = STI.enableJoinGlobalCopies();
   else
-    JoinGlobalCopies = (EnableGlobalCopies == cl::BOU_TRUE);
+    JoinGlobalCopies = (EnableGlobalCopies == cl::boolOrDefault::BOU_TRUE);
 
   // If there are PHIs tracked by debug-info, they will need updating during
   // coalescing. Build an index of those PHIs to ease updating.

--- a/llvm/lib/CodeGen/ShrinkWrap.cpp
+++ b/llvm/lib/CodeGen/ShrinkWrap.cpp
@@ -1034,7 +1034,7 @@ bool ShrinkWrapImpl::isShrinkWrapEnabled(const MachineFunction &MF) {
   const TargetFrameLowering *TFI = MF.getSubtarget().getFrameLowering();
 
   switch (EnableShrinkWrapOpt) {
-  case cl::BOU_UNSET:
+  case cl::boolOrDefault::BOU_UNSET:
     return TFI->enableShrinkWrapping(MF) &&
            // Windows with CFI has some limitations that make it impossible
            // to use shrink-wrapping.
@@ -1051,9 +1051,9 @@ bool ShrinkWrapImpl::isShrinkWrapEnabled(const MachineFunction &MF) {
   // If EnableShrinkWrap is set, it takes precedence on whatever the
   // target sets. The rational is that we assume we want to test
   // something related to shrink-wrapping.
-  case cl::BOU_TRUE:
+  case cl::boolOrDefault::BOU_TRUE:
     return true;
-  case cl::BOU_FALSE:
+  case cl::boolOrDefault::BOU_FALSE:
     return false;
   }
   llvm_unreachable("Invalid shrink-wrapping state");

--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -802,9 +802,9 @@ void TargetPassConfig::addPrintPass(const std::string &Banner) {
 }
 
 void TargetPassConfig::addVerifyPass(const std::string &Banner) {
-  bool Verify = VerifyMachineCode == cl::BOU_TRUE;
+  bool Verify = VerifyMachineCode == cl::boolOrDefault::BOU_TRUE;
 #ifdef EXPENSIVE_CHECKS
-  if (VerifyMachineCode == cl::BOU_UNSET)
+  if (VerifyMachineCode == cl::boolOrDefault::BOU_UNSET)
     Verify = TM->isMachineVerifierClean();
 #endif
   if (Verify)
@@ -825,17 +825,17 @@ void TargetPassConfig::addCheckDebugPass() {
 
 void TargetPassConfig::addMachinePrePasses(bool AllowDebugify) {
   if (AllowDebugify && DebugifyIsSafe &&
-      (DebugifyAndStripAll == cl::BOU_TRUE ||
-       DebugifyCheckAndStripAll == cl::BOU_TRUE))
+      (DebugifyAndStripAll == cl::boolOrDefault::BOU_TRUE ||
+       DebugifyCheckAndStripAll == cl::boolOrDefault::BOU_TRUE))
     addDebugifyPass();
 }
 
 void TargetPassConfig::addMachinePostPasses(const std::string &Banner) {
   if (DebugifyIsSafe) {
-    if (DebugifyCheckAndStripAll == cl::BOU_TRUE) {
+    if (DebugifyCheckAndStripAll == cl::boolOrDefault::BOU_TRUE) {
       addCheckDebugPass();
       addStripDebugPass();
-    } else if (DebugifyAndStripAll == cl::BOU_TRUE)
+    } else if (DebugifyAndStripAll == cl::boolOrDefault::BOU_TRUE)
       addStripDebugPass();
   }
   addVerifyPass(Banner);
@@ -994,17 +994,17 @@ void TargetPassConfig::addISelPrepare() {
 
 bool TargetPassConfig::addCoreISelPasses() {
   // Enable FastISel with -fast-isel, but allow that to be overridden.
-  TM->setO0WantsFastISel(EnableFastISelOption != cl::BOU_FALSE);
+  TM->setO0WantsFastISel(EnableFastISelOption != cl::boolOrDefault::BOU_FALSE);
 
   // Determine an instruction selector.
   enum class SelectorType { SelectionDAG, FastISel, GlobalISel };
   SelectorType Selector;
 
-  if (EnableFastISelOption == cl::BOU_TRUE)
+  if (EnableFastISelOption == cl::boolOrDefault::BOU_TRUE)
     Selector = SelectorType::FastISel;
-  else if (EnableGlobalISelOption == cl::BOU_TRUE ||
+  else if (EnableGlobalISelOption == cl::boolOrDefault::BOU_TRUE ||
            (TM->Options.EnableGlobalISel &&
-            EnableGlobalISelOption != cl::BOU_FALSE))
+            EnableGlobalISelOption != cl::boolOrDefault::BOU_FALSE))
     Selector = SelectorType::GlobalISel;
   else if (TM->getOptLevel() == CodeGenOptLevel::None &&
            TM->getO0WantsFastISel())
@@ -1368,10 +1368,12 @@ void TargetPassConfig::addMachineSSAOptimization() {
 
 bool TargetPassConfig::getOptimizeRegAlloc() const {
   switch (OptimizeRegAlloc) {
-  case cl::BOU_UNSET:
+  case cl::boolOrDefault::BOU_UNSET:
     return getOptLevel() != CodeGenOptLevel::None;
-  case cl::BOU_TRUE:  return true;
-  case cl::BOU_FALSE: return false;
+  case cl::boolOrDefault::BOU_TRUE:
+    return true;
+  case cl::boolOrDefault::BOU_FALSE:
+    return false;
   }
   llvm_unreachable("Invalid optimize-regalloc state");
 }

--- a/llvm/lib/MC/MCAsmInfo.cpp
+++ b/llvm/lib/MC/MCAsmInfo.cpp
@@ -38,14 +38,14 @@ cl::opt<cl::boolOrDefault> UseLEB128Directives(
     "use-leb128-directives", cl::Hidden,
     cl::desc(
         "Disable the usage of LEB128 directives, and generate .byte instead."),
-    cl::init(cl::BOU_UNSET));
+    cl::init(cl::boolOrDefault::BOU_UNSET));
 }
 
 MCAsmInfo::MCAsmInfo(const MCTargetOptions &Options) : TargetOptions(Options) {
   if (DwarfExtendedLoc != Default)
     SupportsExtendedDwarfLocDirective = DwarfExtendedLoc == Enable;
-  if (UseLEB128Directives != cl::BOU_UNSET)
-    HasLEB128Directives = UseLEB128Directives == cl::BOU_TRUE;
+  if (UseLEB128Directives != cl::boolOrDefault::BOU_UNSET)
+    HasLEB128Directives = UseLEB128Directives == cl::boolOrDefault::BOU_TRUE;
 }
 
 MCAsmInfo::~MCAsmInfo() = default;

--- a/llvm/lib/MC/MCAsmInfoXCOFF.cpp
+++ b/llvm/lib/MC/MCAsmInfoXCOFF.cpp
@@ -27,7 +27,7 @@ MCAsmInfoXCOFF::MCAsmInfoXCOFF(const MCTargetOptions &Options)
 
   InternalSymbolPrefix = "L..";
   SupportsQuotedNames = false;
-  if (UseLEB128Directives == cl::BOU_UNSET)
+  if (UseLEB128Directives == cl::boolOrDefault::BOU_UNSET)
     HasLEB128Directives = false;
   ZeroDirective = "\t.space\t";
   AsciiDirective = nullptr; // not supported

--- a/llvm/lib/Remarks/RemarkStreamer.cpp
+++ b/llvm/lib/Remarks/RemarkStreamer.cpp
@@ -23,7 +23,7 @@ static cl::opt<cl::boolOrDefault> EnableRemarksSection(
     cl::desc(
         "Emit a section containing remark diagnostics metadata. By default, "
         "this is enabled for the following formats: bitstream."),
-    cl::init(cl::BOU_UNSET), cl::Hidden);
+    cl::init(cl::boolOrDefault::BOU_UNSET), cl::Hidden);
 
 RemarkStreamer::RemarkStreamer(
     std::unique_ptr<remarks::RemarkSerializer> RemarkSerializer,
@@ -58,11 +58,11 @@ bool RemarkStreamer::matchesFilter(StringRef Str) {
 }
 
 bool RemarkStreamer::needsSection() const {
-  return EnableRemarksSection == cl::BOU_TRUE;
+  return EnableRemarksSection == cl::boolOrDefault::BOU_TRUE;
 }
 
 bool RemarkStreamer::wantsSection() const {
-  if (EnableRemarksSection == cl::BOU_FALSE)
+  if (EnableRemarksSection == cl::boolOrDefault::BOU_FALSE)
     return false;
   // Enable remark sections by default for bitstream remarks (so dsymutil can
   // find all remarks for a linked binary)

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -2011,7 +2011,8 @@ bool parser<bool>::parse(Option &O, StringRef ArgName, StringRef Arg,
 //
 bool parser<boolOrDefault>::parse(Option &O, StringRef ArgName, StringRef Arg,
                                   boolOrDefault &Value) {
-  return parseBool<boolOrDefault, BOU_TRUE, BOU_FALSE>(O, ArgName, Arg, Value);
+  return parseBool<boolOrDefault, boolOrDefault::BOU_TRUE,
+                   boolOrDefault::BOU_FALSE>(O, ArgName, Arg, Value);
 }
 
 // parser<int> implementation
@@ -2229,6 +2230,14 @@ void generic_parser_base::printGenericOptionDiff(
 
 // printOptionDiff - Specializations for printing basic value types.
 //
+namespace llvm {
+namespace cl {
+static raw_ostream &operator<<(raw_ostream &OS, boolOrDefault V) {
+  return OS << static_cast<int>(V);
+}
+} // namespace cl
+} // namespace llvm
+
 #define PRINT_OPT_DIFF(T)                                                      \
   void parser<T>::printOptionDiff(const Option &O, T V, OptionValue<T> D,      \
                                   size_t GlobalWidth) const {                  \

--- a/llvm/lib/Support/WithColor.cpp
+++ b/llvm/lib/Support/WithColor.cpp
@@ -26,7 +26,7 @@ struct CreateUseColor {
     return new cl::opt<cl::boolOrDefault>(
         "color", cl::cat(getColorCategory()),
         cl::desc("Use colors in output (default=autodetect)"),
-        cl::init(cl::BOU_UNSET));
+        cl::init(cl::boolOrDefault::BOU_UNSET));
   }
 };
 } // namespace
@@ -34,8 +34,9 @@ static ManagedStatic<cl::opt<cl::boolOrDefault>, CreateUseColor> UseColor;
 void llvm::initWithColorOptions() { *UseColor; }
 
 static bool DefaultAutoDetectFunction(const raw_ostream &OS) {
-  return *UseColor == cl::BOU_UNSET ? OS.has_colors()
-                                    : *UseColor == cl::BOU_TRUE;
+  return *UseColor == cl::boolOrDefault::BOU_UNSET
+             ? OS.has_colors()
+             : *UseColor == cl::boolOrDefault::BOU_TRUE;
 }
 
 WithColor::AutoDetectFunctionType WithColor::AutoDetectFunction =

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -291,8 +291,8 @@ LLVMInitializeAArch64Target() {
 }
 
 bool AArch64TargetMachine::isGlobalISelOptNone() const {
-  const bool GlobalISelFlag =
-      getCGPassBuilderOption().EnableGlobalISelOption == cl::BOU_TRUE;
+  const bool GlobalISelFlag = getCGPassBuilderOption().EnableGlobalISelOption ==
+                              cl::boolOrDefault::BOU_TRUE;
 
   return getOptLevel() == CodeGenOptLevel::None ||
          (static_cast<unsigned>(getOptLevel()) >
@@ -404,8 +404,8 @@ AArch64TargetMachine::AArch64TargetMachine(const Target &T, const Triple &TT,
       TT.getEnvironment() != Triple::GNUILP32 &&
       !(getCodeModel() == CodeModel::Large && TT.isOSBinFormatMachO());
 
-  const bool GlobalISelFlag =
-      getCGPassBuilderOption().EnableGlobalISelOption == cl::BOU_TRUE;
+  const bool GlobalISelFlag = getCGPassBuilderOption().EnableGlobalISelOption ==
+                              cl::boolOrDefault::BOU_TRUE;
 
   // Enable GlobalISel at or below EnableGlobalISelAt0, unless this is
   // MachO/CodeModel::Large, which GlobalISel does not support.
@@ -724,11 +724,11 @@ bool AArch64PassConfig::addPreISel() {
   // Basically, the addressable offsets are up to 4095 * Ty.getSizeInBytes().
   // and the offset has to be a multiple of the related size in bytes.
   if ((TM->getOptLevel() != CodeGenOptLevel::None &&
-       EnableGlobalMerge == cl::BOU_UNSET) ||
-      EnableGlobalMerge == cl::BOU_TRUE) {
+       EnableGlobalMerge == cl::boolOrDefault::BOU_UNSET) ||
+      EnableGlobalMerge == cl::boolOrDefault::BOU_TRUE) {
     bool OnlyOptimizeForSize =
         (TM->getOptLevel() < CodeGenOptLevel::Aggressive) &&
-        (EnableGlobalMerge == cl::BOU_UNSET);
+        (EnableGlobalMerge == cl::boolOrDefault::BOU_UNSET);
 
     // Merging of extern globals is enabled by default on non-Mach-O as we
     // expect it to be generally either beneficial or harmless. On Mach-O it

--- a/llvm/lib/Target/AArch64/GISel/AArch64CallLowering.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64CallLowering.cpp
@@ -601,7 +601,8 @@ bool AArch64CallLowering::fallBackToDAGISel(const MachineFunction &MF) const {
 
   auto OptLevel = MF.getTarget().getOptLevel();
   bool IsGlobalISelPreferred =
-      getCGPassBuilderOption().EnableGlobalISelOption == cl::BOU_TRUE ||
+      getCGPassBuilderOption().EnableGlobalISelOption ==
+          cl::boolOrDefault::BOU_TRUE ||
       static_cast<unsigned>(OptLevel) <= TM.getEnableGlobalISelAtO() ||
       F.hasOptNone();
   return !IsGlobalISelPreferred;

--- a/llvm/lib/Target/AMDGPU/AMDGPUCodeGenPrepare.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUCodeGenPrepare.cpp
@@ -1900,8 +1900,8 @@ bool AMDGPUCodeGenPrepareImpl::visitPHINode(PHINode &I) {
   // operations with most elements being "undef". This inhibits a lot of
   // optimization opportunities and can result in unreasonably high register
   // pressure and the inevitable stack spilling.
-  if (!BreakLargePHIs ||
-      getCGPassBuilderOption().EnableGlobalISelOption == cl::BOU_TRUE)
+  if (!BreakLargePHIs || getCGPassBuilderOption().EnableGlobalISelOption ==
+                             cl::boolOrDefault::BOU_TRUE)
     return false;
 
   FixedVectorType *FVT = dyn_cast<FixedVectorType>(I.getType());

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -1626,7 +1626,8 @@ bool GCNPassConfig::addPreISel() {
 
   // SDAG requires LCSSA, GlobalISel does not. Disable LCSSA for -global-isel
   // with -new-reg-bank-select and without any of the fallback options.
-  if (getCGPassBuilderOption().EnableGlobalISelOption != cl::BOU_TRUE ||
+  if (getCGPassBuilderOption().EnableGlobalISelOption !=
+          cl::boolOrDefault::BOU_TRUE ||
       !isGlobalISelAbortEnabled() || !NewRegBankSelect)
     addPass(createLCSSAPass());
 
@@ -2390,7 +2391,8 @@ void AMDGPUCodeGenPassBuilder::addPreISel(PassManagerWrapper &PMW) const {
   // control flow modifications.
   addFunctionPass(AMDGPURewriteUndefForPHIPass(), PMW);
 
-  if (getCGPassBuilderOption().EnableGlobalISelOption != cl::BOU_TRUE ||
+  if (getCGPassBuilderOption().EnableGlobalISelOption !=
+          cl::boolOrDefault::BOU_TRUE ||
       !isGlobalISelAbortEnabled() || !NewRegBankSelect)
     addFunctionPass(LCSSAPass(), PMW);
 

--- a/llvm/lib/Target/ARM/ARMTargetMachine.cpp
+++ b/llvm/lib/Target/ARM/ARMTargetMachine.cpp
@@ -400,8 +400,8 @@ void ARMPassConfig::addCodeGenPrepare() {
 
 bool ARMPassConfig::addPreISel() {
   if ((TM->getOptLevel() != CodeGenOptLevel::None &&
-       EnableGlobalMerge == cl::BOU_UNSET) ||
-      EnableGlobalMerge == cl::BOU_TRUE) {
+       EnableGlobalMerge == cl::boolOrDefault::BOU_UNSET) ||
+      EnableGlobalMerge == cl::boolOrDefault::BOU_TRUE) {
     // FIXME: This is using the thumb1 only constant value for
     // maximal global offset for merging globals. We may want
     // to look into using the old value for non-thumb1 code of
@@ -409,7 +409,7 @@ bool ARMPassConfig::addPreISel() {
     // tricky when doing code gen per function.
     bool OnlyOptimizeForSize =
         (TM->getOptLevel() < CodeGenOptLevel::Aggressive) &&
-        (EnableGlobalMerge == cl::BOU_UNSET);
+        (EnableGlobalMerge == cl::boolOrDefault::BOU_UNSET);
     // Merging of extern globals is enabled by default on non-Mach-O as we
     // expect it to be generally either beneficial or harmless. On Mach-O it
     // is disabled as we emit the .subsections_via_symbols directive which

--- a/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
@@ -504,8 +504,8 @@ bool RISCVPassConfig::addPreISel() {
   }
 
   if ((TM->getOptLevel() != CodeGenOptLevel::None &&
-       EnableGlobalMerge == cl::BOU_UNSET) ||
-      EnableGlobalMerge == cl::BOU_TRUE) {
+       EnableGlobalMerge == cl::boolOrDefault::BOU_UNSET) ||
+      EnableGlobalMerge == cl::boolOrDefault::BOU_TRUE) {
     // FIXME: Like AArch64, we disable extern global merging by default due to
     // concerns it might regress some workloads. Unlike AArch64, we don't
     // currently support enabling the pass in an "OnlyOptimizeForSize" mode.

--- a/llvm/lib/Transforms/ObjCARC/ObjCARCContract.cpp
+++ b/llvm/lib/Transforms/ObjCARC/ObjCARCContract.cpp
@@ -529,8 +529,8 @@ bool ObjCARCContract::tryToPeepholeInstruction(
 /// Should we use objc_claimAutoreleasedReturnValue?
 static bool useClaimRuntimeCall(Module &M) {
   // Let the flag override our OS-based default.
-  if (UseObjCClaimRV != cl::BOU_UNSET)
-    return UseObjCClaimRV == cl::BOU_TRUE;
+  if (UseObjCClaimRV != cl::boolOrDefault::BOU_UNSET)
+    return UseObjCClaimRV == cl::boolOrDefault::BOU_TRUE;
 
   Triple TT(M.getTargetTriple());
 

--- a/llvm/lib/Transforms/Scalar/LoopStrengthReduce.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopStrengthReduce.cpp
@@ -5666,11 +5666,11 @@ void LSRInstance::Solve(SmallVectorImpl<const Formula *> &Solution) const {
 
   const bool EnableDropUnprofitableSolution = [&] {
     switch (AllowDropSolutionIfLessProfitable) {
-    case cl::BOU_TRUE:
+    case cl::boolOrDefault::BOU_TRUE:
       return true;
-    case cl::BOU_FALSE:
+    case cl::boolOrDefault::BOU_FALSE:
       return false;
-    case cl::BOU_UNSET:
+    case cl::boolOrDefault::BOU_UNSET:
       return TTI.shouldDropLSRSolutionIfLessProfitable();
     }
     llvm_unreachable("Unhandled cl::boolOrDefault enum");

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -999,11 +999,11 @@ public:
   bool isDivRemScalarWithPredication(InstructionCost ScalarCost,
                                      InstructionCost MaskedCost) const {
     switch (ForceMaskedDivRem) {
-    case cl::BOU_UNSET:
+    case cl::boolOrDefault::BOU_UNSET:
       return ScalarCost < MaskedCost;
-    case cl::BOU_TRUE:
+    case cl::boolOrDefault::BOU_TRUE:
       return false;
-    case cl::BOU_FALSE:
+    case cl::boolOrDefault::BOU_FALSE:
       return true;
     }
     llvm_unreachable("impossible case value");

--- a/llvm/tools/llvm-cov/CodeCoverage.cpp
+++ b/llvm/tools/llvm-cov/CodeCoverage.cpp
@@ -766,7 +766,7 @@ int CodeCoverageTool::run(Command Cmd, int argc, const char **argv) {
 
   cl::opt<cl::boolOrDefault> UseColor(
       "use-color", cl::desc("Emit colored output (default=autodetect)"),
-      cl::init(cl::BOU_UNSET));
+      cl::init(cl::boolOrDefault::BOU_UNSET));
 
   cl::list<std::string> DemanglerOpts(
       "Xdemangler", cl::desc("<demangler-path>|<demangler-option>"));
@@ -849,17 +849,17 @@ int CodeCoverageTool::run(Command Cmd, int argc, const char **argv) {
     ViewOpts.Format = Format;
     switch (ViewOpts.Format) {
     case CoverageViewOptions::OutputFormat::Text:
-      ViewOpts.Colors = UseColor == cl::BOU_UNSET
+      ViewOpts.Colors = UseColor == cl::boolOrDefault::BOU_UNSET
                             ? sys::Process::StandardOutHasColors()
-                            : UseColor == cl::BOU_TRUE;
+                            : UseColor == cl::boolOrDefault::BOU_TRUE;
       break;
     case CoverageViewOptions::OutputFormat::HTML:
-      if (UseColor == cl::BOU_FALSE)
+      if (UseColor == cl::boolOrDefault::BOU_FALSE)
         errs() << "Color output cannot be disabled when generating html.\n";
       ViewOpts.Colors = true;
       break;
     case CoverageViewOptions::OutputFormat::Lcov:
-      if (UseColor == cl::BOU_TRUE)
+      if (UseColor == cl::boolOrDefault::BOU_TRUE)
         errs() << "Color output cannot be enabled when generating lcov.\n";
       ViewOpts.Colors = false;
       break;

--- a/llvm/tools/llvm-pdbutil/llvm-pdbutil.cpp
+++ b/llvm/tools/llvm-pdbutil/llvm-pdbutil.cpp
@@ -1171,9 +1171,10 @@ static void dumpPretty(StringRef Path) {
     Session->setLoadAddress(opts::pretty::LoadAddress);
 
   auto &Stream = outs();
-  const bool UseColor = opts::pretty::ColorOutput == cl::BOU_UNSET
-                            ? Stream.has_colors()
-                            : opts::pretty::ColorOutput == cl::BOU_TRUE;
+  const bool UseColor =
+      opts::pretty::ColorOutput == cl::boolOrDefault::BOU_UNSET
+          ? Stream.has_colors()
+          : opts::pretty::ColorOutput == cl::boolOrDefault::BOU_TRUE;
   LinePrinter Printer(2, UseColor, Stream, opts::Filters);
 
   auto GlobalScope(Session->getGlobalScope());

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -4779,7 +4779,8 @@ static bool checkPTDynamic(const typename ELFT::Phdr &Phdr,
 template <class ELFT>
 void GNUELFDumper<ELFT>::printProgramHeaders(
     bool PrintProgramHeaders, cl::boolOrDefault PrintSectionMapping) {
-  const bool ShouldPrintSectionMapping = (PrintSectionMapping != cl::BOU_FALSE);
+  const bool ShouldPrintSectionMapping =
+      (PrintSectionMapping != cl::boolOrDefault::BOU_FALSE);
   // Exit early if no program header or section mapping details were requested.
   if (!PrintProgramHeaders && !ShouldPrintSectionMapping)
     return;
@@ -7991,7 +7992,7 @@ void LLVMELFDumper<ELFT>::printProgramHeaders(
     bool PrintProgramHeaders, cl::boolOrDefault PrintSectionMapping) {
   if (PrintProgramHeaders)
     printProgramHeaders();
-  if (PrintSectionMapping == cl::BOU_TRUE)
+  if (PrintSectionMapping == cl::boolOrDefault::BOU_TRUE)
     printSectionMapping();
 }
 

--- a/llvm/tools/llvm-readobj/ObjDumper.h
+++ b/llvm/tools/llvm-readobj/ObjDumper.h
@@ -98,7 +98,7 @@ public:
                                    cl::boolOrDefault PrintSectionMapping) {
     if (PrintProgramHeaders)
       printProgramHeaders();
-    if (PrintSectionMapping == cl::BOU_TRUE)
+    if (PrintSectionMapping == cl::boolOrDefault::BOU_TRUE)
       printSectionMapping();
   }
 

--- a/llvm/tools/llvm-readobj/llvm-readobj.cpp
+++ b/llvm/tools/llvm-readobj/llvm-readobj.cpp
@@ -243,11 +243,11 @@ static void parseOptions(const opt::InputArgList &Args) {
   opts::SectionRelocations = Args.hasArg(OPT_section_relocations);
   opts::SectionSymbols = Args.hasArg(OPT_section_symbols);
   if (Args.hasArg(OPT_section_mapping))
-    opts::SectionMapping = cl::BOU_TRUE;
+    opts::SectionMapping = cl::boolOrDefault::BOU_TRUE;
   else if (Args.hasArg(OPT_section_mapping_EQ_false))
-    opts::SectionMapping = cl::BOU_FALSE;
+    opts::SectionMapping = cl::boolOrDefault::BOU_FALSE;
   else
-    opts::SectionMapping = cl::BOU_UNSET;
+    opts::SectionMapping = cl::boolOrDefault::BOU_UNSET;
   opts::PrintStackSizes = Args.hasArg(OPT_stack_sizes);
   opts::PrintStackMap = Args.hasArg(OPT_stackmap);
   opts::StringDump = Args.getAllArgValues(OPT_string_dump_EQ);
@@ -440,7 +440,8 @@ static void dumpObject(ObjectFile &Obj, ScopedPrinter &Writer,
 
   if (opts::HashSymbols)
     Dumper->printHashSymbols();
-  if (opts::ProgramHeaders || opts::SectionMapping == cl::BOU_TRUE)
+  if (opts::ProgramHeaders ||
+      opts::SectionMapping == cl::boolOrDefault::BOU_TRUE)
     Dumper->printProgramHeaders(opts::ProgramHeaders, opts::SectionMapping);
   if (opts::DynamicTable)
     Dumper->printDynamicTable();

--- a/llvm/utils/yaml-bench/YAMLBench.cpp
+++ b/llvm/utils/yaml-bench/YAMLBench.cpp
@@ -54,7 +54,7 @@ static cl::opt<unsigned>
 
 static cl::opt<cl::boolOrDefault>
     UseColor("use-color", cl::desc("Emit colored output (default=autodetect)"),
-             cl::init(cl::BOU_UNSET));
+             cl::init(cl::boolOrDefault::BOU_UNSET));
 
 /// Pretty print a tag by replacing tag:yaml.org,2002: with !!.
 static std::string prettyTag(yaml::Node *N) {
@@ -182,9 +182,9 @@ static std::string createJSONText(size_t MemoryMB, unsigned ValueSize) {
 
 int main(int argc, char **argv) {
   llvm::cl::ParseCommandLineOptions(argc, argv);
-  bool ShowColors = UseColor == cl::BOU_UNSET
+  bool ShowColors = UseColor == cl::boolOrDefault::BOU_UNSET
                         ? sys::Process::StandardOutHasColors()
-                        : UseColor == cl::BOU_TRUE;
+                        : UseColor == cl::boolOrDefault::BOU_TRUE;
   if (Input.getNumOccurrences()) {
     ErrorOr<std::unique_ptr<MemoryBuffer>> BufOrErr =
         MemoryBuffer::getFileOrSTDIN(Input);


### PR DESCRIPTION
Prevents implicit conversion to bool/int, where BOU_FALSE wrongly
evaluated as true. All uses qualified as cl::boolOrDefault::BOU_*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>