### PR TITLE
[libc] Include linux headers to get ioctl macros

### DIFF
--- a/libc/include/llvm-libc-macros/linux/sys-ioctl-macros.h
+++ b/libc/include/llvm-libc-macros/linux/sys-ioctl-macros.h
@@ -9,13 +9,7 @@
 #ifndef LLVM_LIBC_MACROS_LINUX_SYS_IOCTL_MACROS_H
 #define LLVM_LIBC_MACROS_LINUX_SYS_IOCTL_MACROS_H
 
-// TODO (michaelrj): Finish defining these macros.
-// Just defining this macro for the moment since it's all that we need right
-// now. The other macros are mostly just constants, but there's some complexity
-// around the definitions of macros like _IO, _IOR, _IOW, and _IOWR that I don't
-// think is worth digging into right now.
-#define TIOCGETD 0x5424
-#define FIONREAD 0x541B
-#define TIOCGWINSZ 0x5413
+#include <asm/ioctls.h>
+#include <linux/sockios.h>
 
 #endif // LLVM_LIBC_MACROS_LINUX_SYS_IOCTL_MACROS_H


### PR DESCRIPTION
Linux has many existing ioctls and keeps adding them, so a hand-maintained list would always be out of date. Additionally, some ioctls have architecture specific numbers (some in a very subtle way -- by having the number depend on the size of a structure).

asm/ioctls.h and linux/sockios.h are pretty clean, and are already included by glibc, so we can just do the same to get the latest definitions.