### PR TITLE
[webkit.NoUncountedMemberChecker] Improve the warning text

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefMemberChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefMemberChecker.cpp
@@ -40,7 +40,6 @@ public:
   virtual std::optional<bool> isUnsafePtr(QualType,
                                           bool ignoreARC = false) const = 0;
   virtual const char *typeName() const = 0;
-  virtual const char *invariant() const = 0;
 
   void checkASTDecl(const TranslationUnitDecl *TUD, AnalysisManager &MGR,
                     BugReporter &BRArg) const {
@@ -291,8 +290,9 @@ public:
     } else
       Os << "Member variable ";
     printQuotedName(Os, Member);
-    Os << " in ";
+    Os << " (of ";
     printQuotedQualifiedName(Os, ClassCXXRD);
+    Os << ")";
     if (Member->getType().getTypePtrOrNull() == MemberType)
       Os << " is a ";
     else
@@ -303,7 +303,6 @@ public:
       printQuotedQualifiedName(Os, Typedef->getDecl());
     } else
       printQuotedQualifiedName(Os, Pointee);
-    Os << "; " << invariant() << ".";
 
     PathDiagnosticLocation BSLoc(Member->getSourceRange().getBegin(),
                                  BR->getSourceManager());
@@ -332,11 +331,7 @@ public:
     return isUncountedPtr(QT.getCanonicalType());
   }
 
-  const char *typeName() const final { return "ref-countable type"; }
-
-  const char *invariant() const final {
-    return "member variables must be Ref, RefPtr, WeakRef, or WeakPtr";
-  }
+  const char *typeName() const final { return "RefPtr capable type"; }
 };
 
 class NoUncheckedPtrMemberChecker final : public RawPtrRefMemberChecker {
@@ -350,11 +345,6 @@ public:
   }
 
   const char *typeName() const final { return "CheckedPtr capable type"; }
-
-  const char *invariant() const final {
-    return "member variables must be a CheckedPtr, CheckedRef, WeakRef, or "
-           "WeakPtr";
-  }
 };
 
 class NoUnretainedMemberChecker final : public RawPtrRefMemberChecker {
@@ -371,11 +361,7 @@ public:
     return RTC->isUnretained(QT, ignoreARC);
   }
 
-  const char *typeName() const final { return "retainable type"; }
-
-  const char *invariant() const final {
-    return "member variables must be a RetainPtr or OSObjectPtr";
-  }
+  const char *typeName() const final { return "RetainPtr capable type"; }
 
   PrintDeclKind printPointer(llvm::raw_svector_ostream &Os,
                              const Type *T) const final {

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefMemberChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefMemberChecker.cpp
@@ -331,7 +331,7 @@ public:
     return isUncountedPtr(QT.getCanonicalType());
   }
 
-  const char *typeName() const final { return "RefPtr capable type"; }
+  const char *typeName() const final { return "RefPtr-capable type"; }
 };
 
 class NoUncheckedPtrMemberChecker final : public RawPtrRefMemberChecker {
@@ -344,7 +344,7 @@ public:
     return isUncheckedPtr(QT.getCanonicalType());
   }
 
-  const char *typeName() const final { return "CheckedPtr capable type"; }
+  const char *typeName() const final { return "CheckedPtr-capable type"; }
 };
 
 class NoUnretainedMemberChecker final : public RawPtrRefMemberChecker {
@@ -361,7 +361,7 @@ public:
     return RTC->isUnretained(QT, ignoreARC);
   }
 
-  const char *typeName() const final { return "RetainPtr capable type"; }
+  const char *typeName() const final { return "RetainPtr-capable type"; }
 
   PrintDeclKind printPointer(llvm::raw_svector_ostream &Os,
                              const Type *T) const final {

--- a/clang/test/Analysis/Checkers/WebKit/unchecked-members-objc.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unchecked-members-objc.mm
@@ -14,7 +14,7 @@ void doSomeWork();
 
 @interface SomeObjC : NSObject {
   CheckedObj* _unchecked1;
-// expected-warning@-1{{Instance variable '_unchecked1' in 'SomeObjC' is a raw pointer to CheckedPtr capable type 'CheckedObj'}}  
+// expected-warning@-1{{Instance variable '_unchecked1' (of 'SomeObjC') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}  
   CheckedPtr<CheckedObj> _counted1;
   [[clang::suppress]] CheckedObj* _unchecked2;
 }
@@ -23,7 +23,7 @@ void doSomeWork();
 
 @implementation SomeObjC {
   CheckedObj* _unchecked3;
-// expected-warning@-1{{Instance variable '_unchecked3' in 'SomeObjC' is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+// expected-warning@-1{{Instance variable '_unchecked3' (of 'SomeObjC') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
   CheckedPtr<CheckedObj> _counted2;
   [[clang::suppress]] CheckedObj* _unchecked4;
 }

--- a/clang/test/Analysis/Checkers/WebKit/unchecked-members-objc.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unchecked-members-objc.mm
@@ -14,7 +14,7 @@ void doSomeWork();
 
 @interface SomeObjC : NSObject {
   CheckedObj* _unchecked1;
-// expected-warning@-1{{Instance variable '_unchecked1' (of 'SomeObjC') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}  
+// expected-warning@-1{{Instance variable '_unchecked1' (of 'SomeObjC') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}  
   CheckedPtr<CheckedObj> _counted1;
   [[clang::suppress]] CheckedObj* _unchecked2;
 }
@@ -23,7 +23,7 @@ void doSomeWork();
 
 @implementation SomeObjC {
   CheckedObj* _unchecked3;
-// expected-warning@-1{{Instance variable '_unchecked3' (of 'SomeObjC') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+// expected-warning@-1{{Instance variable '_unchecked3' (of 'SomeObjC') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
   CheckedPtr<CheckedObj> _counted2;
   [[clang::suppress]] CheckedObj* _unchecked4;
 }

--- a/clang/test/Analysis/Checkers/WebKit/unchecked-members.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/unchecked-members.cpp
@@ -7,9 +7,9 @@ namespace members {
   struct Foo {
   private:
     CheckedObj* a = nullptr;
-// expected-warning@-1{{Member variable 'a' in 'members::Foo' is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+// expected-warning@-1{{Member variable 'a' (of 'members::Foo') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
     CheckedObj& b;
-// expected-warning@-1{{Member variable 'b' in 'members::Foo' is a reference to CheckedPtr capable type 'CheckedObj'}}
+// expected-warning@-1{{Member variable 'b' (of 'members::Foo') is a reference to CheckedPtr capable type 'CheckedObj'}}
 
     [[clang::suppress]]
     CheckedObj* a_suppressed = nullptr;
@@ -27,7 +27,7 @@ namespace members {
   template <typename S>
   struct FooTmpl {
     S* e;
-// expected-warning@-1{{Member variable 'e' in 'members::FooTmpl<CheckedObj>' is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+// expected-warning@-1{{Member variable 'e' (of 'members::FooTmpl<CheckedObj>') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
   };
 
   void forceTmplToInstantiate(FooTmpl<CheckedObj>) { }
@@ -38,7 +38,7 @@ namespace unions {
 
   union Foo {
     CheckedObj* a;
-    // expected-warning@-1{{Member variable 'a' in 'unions::Foo' is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Member variable 'a' (of 'unions::Foo') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
     CheckedPtr<CheckedObj> c;
     CheckedRef<CheckedObj> d;
   };
@@ -46,7 +46,7 @@ namespace unions {
   template<class T>
   union FooTmpl {
     T* a;
-    // expected-warning@-1{{Member variable 'a' in 'unions::FooTmpl<CheckedObj>' is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Member variable 'a' (of 'unions::FooTmpl<CheckedObj>') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
   };
 
   void forceTmplToInstantiate(FooTmpl<CheckedObj>) { }
@@ -66,13 +66,13 @@ namespace ptr_to_ptr_to_checked_ptr_capable {
 
   struct List {
     CheckedObj** elements;
-    // expected-warning@-1{{Member variable 'elements' in 'ptr_to_ptr_to_checked_ptr_capable::List' contains a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Member variable 'elements' (of 'ptr_to_ptr_to_checked_ptr_capable::List') contains a raw pointer to CheckedPtr capable type 'CheckedObj'}}
   };
 
   template <typename T>
   struct TemplateList {
     T** elements;
-    // expected-warning@-1{{Member variable 'elements' in 'ptr_to_ptr_to_checked_ptr_capable::TemplateList<CheckedObj>' contains a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Member variable 'elements' (of 'ptr_to_ptr_to_checked_ptr_capable::TemplateList<CheckedObj>') contains a raw pointer to CheckedPtr capable type 'CheckedObj'}}
   };
   TemplateList<CheckedObj> list;
 

--- a/clang/test/Analysis/Checkers/WebKit/unchecked-members.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/unchecked-members.cpp
@@ -7,9 +7,9 @@ namespace members {
   struct Foo {
   private:
     CheckedObj* a = nullptr;
-// expected-warning@-1{{Member variable 'a' (of 'members::Foo') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+// expected-warning@-1{{Member variable 'a' (of 'members::Foo') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
     CheckedObj& b;
-// expected-warning@-1{{Member variable 'b' (of 'members::Foo') is a reference to CheckedPtr capable type 'CheckedObj'}}
+// expected-warning@-1{{Member variable 'b' (of 'members::Foo') is a reference to CheckedPtr-capable type 'CheckedObj'}}
 
     [[clang::suppress]]
     CheckedObj* a_suppressed = nullptr;
@@ -27,7 +27,7 @@ namespace members {
   template <typename S>
   struct FooTmpl {
     S* e;
-// expected-warning@-1{{Member variable 'e' (of 'members::FooTmpl<CheckedObj>') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+// expected-warning@-1{{Member variable 'e' (of 'members::FooTmpl<CheckedObj>') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
   };
 
   void forceTmplToInstantiate(FooTmpl<CheckedObj>) { }
@@ -38,7 +38,7 @@ namespace unions {
 
   union Foo {
     CheckedObj* a;
-    // expected-warning@-1{{Member variable 'a' (of 'unions::Foo') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Member variable 'a' (of 'unions::Foo') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
     CheckedPtr<CheckedObj> c;
     CheckedRef<CheckedObj> d;
   };
@@ -46,7 +46,7 @@ namespace unions {
   template<class T>
   union FooTmpl {
     T* a;
-    // expected-warning@-1{{Member variable 'a' (of 'unions::FooTmpl<CheckedObj>') is a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Member variable 'a' (of 'unions::FooTmpl<CheckedObj>') is a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
   };
 
   void forceTmplToInstantiate(FooTmpl<CheckedObj>) { }
@@ -66,13 +66,13 @@ namespace ptr_to_ptr_to_checked_ptr_capable {
 
   struct List {
     CheckedObj** elements;
-    // expected-warning@-1{{Member variable 'elements' (of 'ptr_to_ptr_to_checked_ptr_capable::List') contains a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Member variable 'elements' (of 'ptr_to_ptr_to_checked_ptr_capable::List') contains a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
   };
 
   template <typename T>
   struct TemplateList {
     T** elements;
-    // expected-warning@-1{{Member variable 'elements' (of 'ptr_to_ptr_to_checked_ptr_capable::TemplateList<CheckedObj>') contains a raw pointer to CheckedPtr capable type 'CheckedObj'}}
+    // expected-warning@-1{{Member variable 'elements' (of 'ptr_to_ptr_to_checked_ptr_capable::TemplateList<CheckedObj>') contains a raw pointer to CheckedPtr-capable type 'CheckedObj'}}
   };
   TemplateList<CheckedObj> list;
 

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-members-objc.mm
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-members-objc.mm
@@ -14,7 +14,7 @@ void doSomeWork();
 
 @interface SomeObjC : NSObject {
   RefCountable* _uncounted1;
-// expected-warning@-1{{Instance variable '_uncounted1' in 'SomeObjC' is a raw pointer to ref-countable type 'RefCountable'}}  
+// expected-warning@-1{{Instance variable '_uncounted1' (of 'SomeObjC') is a raw pointer to RefPtr capable type 'RefCountable'}}  
   RefPtr<RefCountable> _counted1;
   [[clang::suppress]] RefCountable* _uncounted2;
 }
@@ -23,7 +23,7 @@ void doSomeWork();
 
 @implementation SomeObjC {
   RefCountable* _uncounted3;
-// expected-warning@-1{{Instance variable '_uncounted3' in 'SomeObjC' is a raw pointer to ref-countable type 'RefCountable'}}
+// expected-warning@-1{{Instance variable '_uncounted3' (of 'SomeObjC') is a raw pointer to RefPtr capable type 'RefCountable'}}
   RefPtr<RefCountable> _counted2;
   [[clang::suppress]] RefCountable* _uncounted4;
 }

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-members-objc.mm
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-members-objc.mm
@@ -14,7 +14,7 @@ void doSomeWork();
 
 @interface SomeObjC : NSObject {
   RefCountable* _uncounted1;
-// expected-warning@-1{{Instance variable '_uncounted1' (of 'SomeObjC') is a raw pointer to RefPtr capable type 'RefCountable'}}  
+// expected-warning@-1{{Instance variable '_uncounted1' (of 'SomeObjC') is a raw pointer to RefPtr-capable type 'RefCountable'}}  
   RefPtr<RefCountable> _counted1;
   [[clang::suppress]] RefCountable* _uncounted2;
 }
@@ -23,7 +23,7 @@ void doSomeWork();
 
 @implementation SomeObjC {
   RefCountable* _uncounted3;
-// expected-warning@-1{{Instance variable '_uncounted3' (of 'SomeObjC') is a raw pointer to RefPtr capable type 'RefCountable'}}
+// expected-warning@-1{{Instance variable '_uncounted3' (of 'SomeObjC') is a raw pointer to RefPtr-capable type 'RefCountable'}}
   RefPtr<RefCountable> _counted2;
   [[clang::suppress]] RefCountable* _uncounted4;
 }

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-members-ref-deref-on-diff-classes.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-members-ref-deref-on-diff-classes.cpp
@@ -19,5 +19,5 @@ public:
 
 private:
   TreeNode* m_parent;
-// expected-warning@-1{{Member variable 'm_parent' in 'TreeNode' is a raw pointer to ref-countable type 'TreeNode'}}
+// expected-warning@-1{{Member variable 'm_parent' (of 'TreeNode') is a raw pointer to RefPtr capable type 'TreeNode'}}
 };

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-members-ref-deref-on-diff-classes.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-members-ref-deref-on-diff-classes.cpp
@@ -19,5 +19,5 @@ public:
 
 private:
   TreeNode* m_parent;
-// expected-warning@-1{{Member variable 'm_parent' (of 'TreeNode') is a raw pointer to RefPtr capable type 'TreeNode'}}
+// expected-warning@-1{{Member variable 'm_parent' (of 'TreeNode') is a raw pointer to RefPtr-capable type 'TreeNode'}}
 };

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-members.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-members.cpp
@@ -7,7 +7,7 @@ namespace members {
   struct Foo {
   private:
     RefCountable* a = nullptr;
-// expected-warning@-1{{Member variable 'a' in 'members::Foo' is a raw pointer to ref-countable type 'RefCountable'}}
+// expected-warning@-1{{Member variable 'a' (of 'members::Foo') is a raw pointer to RefPtr capable type 'RefCountable'}}
 
     [[clang::suppress]]
     RefCountable* a_suppressed = nullptr;
@@ -18,14 +18,14 @@ namespace members {
   public:
     RefCountable silenceWarningAboutInit;
     RefCountable& c = silenceWarningAboutInit;
-// expected-warning@-1{{Member variable 'c' in 'members::Foo' is a reference to ref-countable type 'RefCountable'}}
+// expected-warning@-1{{Member variable 'c' (of 'members::Foo') is a reference to RefPtr capable type 'RefCountable'}}
     Ref<RefCountable> d;
   };
 
   template<class T>
   struct FooTmpl {
     T* a;
-// expected-warning@-1{{Member variable 'a' in 'members::FooTmpl<RefCountable>' is a raw pointer to ref-countable type 'RefCountable'}}
+// expected-warning@-1{{Member variable 'a' (of 'members::FooTmpl<RefCountable>') is a raw pointer to RefPtr capable type 'RefCountable'}}
   };
 
   void forceTmplToInstantiate(FooTmpl<RefCountable>) {}
@@ -39,7 +39,7 @@ namespace members {
 namespace unions {
   union Foo {
     RefCountable* a;
-    // expected-warning@-1{{Member variable 'a' in 'unions::Foo' is a raw pointer to ref-countable type 'RefCountable'}}
+    // expected-warning@-1{{Member variable 'a' (of 'unions::Foo') is a raw pointer to RefPtr capable type 'RefCountable'}}
     RefPtr<RefCountable> b;
     Ref<RefCountable> c;
   };
@@ -47,7 +47,7 @@ namespace unions {
   template<class T>
   union FooTmpl {
     T* a;
-    // expected-warning@-1{{Member variable 'a' in 'unions::FooTmpl<RefCountable>' is a raw pointer to ref-countable type 'RefCountable'}}
+    // expected-warning@-1{{Member variable 'a' (of 'unions::FooTmpl<RefCountable>') is a raw pointer to RefPtr capable type 'RefCountable'}}
   };
 
   void forceTmplToInstantiate(FooTmpl<RefCountable>) {}
@@ -84,13 +84,13 @@ namespace ptr_to_ptr_to_ref_counted {
 
   struct List {
     RefCountable** elements;
-    // expected-warning@-1{{Member variable 'elements' in 'ptr_to_ptr_to_ref_counted::List' contains a raw pointer to ref-countable type 'RefCountable'}}
+    // expected-warning@-1{{Member variable 'elements' (of 'ptr_to_ptr_to_ref_counted::List') contains a raw pointer to RefPtr capable type 'RefCountable'}}
   };
 
   template <typename T>
   struct TemplateList {
     T** elements;
-    // expected-warning@-1{{Member variable 'elements' in 'ptr_to_ptr_to_ref_counted::TemplateList<RefCountable>' contains a raw pointer to ref-countable type 'RefCountable'}}
+    // expected-warning@-1{{Member variable 'elements' (of 'ptr_to_ptr_to_ref_counted::TemplateList<RefCountable>') contains a raw pointer to RefPtr capable type 'RefCountable'}}
   };
   TemplateList<RefCountable> list;
 

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-members.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-members.cpp
@@ -7,7 +7,7 @@ namespace members {
   struct Foo {
   private:
     RefCountable* a = nullptr;
-// expected-warning@-1{{Member variable 'a' (of 'members::Foo') is a raw pointer to RefPtr capable type 'RefCountable'}}
+// expected-warning@-1{{Member variable 'a' (of 'members::Foo') is a raw pointer to RefPtr-capable type 'RefCountable'}}
 
     [[clang::suppress]]
     RefCountable* a_suppressed = nullptr;
@@ -18,14 +18,14 @@ namespace members {
   public:
     RefCountable silenceWarningAboutInit;
     RefCountable& c = silenceWarningAboutInit;
-// expected-warning@-1{{Member variable 'c' (of 'members::Foo') is a reference to RefPtr capable type 'RefCountable'}}
+// expected-warning@-1{{Member variable 'c' (of 'members::Foo') is a reference to RefPtr-capable type 'RefCountable'}}
     Ref<RefCountable> d;
   };
 
   template<class T>
   struct FooTmpl {
     T* a;
-// expected-warning@-1{{Member variable 'a' (of 'members::FooTmpl<RefCountable>') is a raw pointer to RefPtr capable type 'RefCountable'}}
+// expected-warning@-1{{Member variable 'a' (of 'members::FooTmpl<RefCountable>') is a raw pointer to RefPtr-capable type 'RefCountable'}}
   };
 
   void forceTmplToInstantiate(FooTmpl<RefCountable>) {}
@@ -39,7 +39,7 @@ namespace members {
 namespace unions {
   union Foo {
     RefCountable* a;
-    // expected-warning@-1{{Member variable 'a' (of 'unions::Foo') is a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Member variable 'a' (of 'unions::Foo') is a raw pointer to RefPtr-capable type 'RefCountable'}}
     RefPtr<RefCountable> b;
     Ref<RefCountable> c;
   };
@@ -47,7 +47,7 @@ namespace unions {
   template<class T>
   union FooTmpl {
     T* a;
-    // expected-warning@-1{{Member variable 'a' (of 'unions::FooTmpl<RefCountable>') is a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Member variable 'a' (of 'unions::FooTmpl<RefCountable>') is a raw pointer to RefPtr-capable type 'RefCountable'}}
   };
 
   void forceTmplToInstantiate(FooTmpl<RefCountable>) {}
@@ -84,13 +84,13 @@ namespace ptr_to_ptr_to_ref_counted {
 
   struct List {
     RefCountable** elements;
-    // expected-warning@-1{{Member variable 'elements' (of 'ptr_to_ptr_to_ref_counted::List') contains a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Member variable 'elements' (of 'ptr_to_ptr_to_ref_counted::List') contains a raw pointer to RefPtr-capable type 'RefCountable'}}
   };
 
   template <typename T>
   struct TemplateList {
     T** elements;
-    // expected-warning@-1{{Member variable 'elements' (of 'ptr_to_ptr_to_ref_counted::TemplateList<RefCountable>') contains a raw pointer to RefPtr capable type 'RefCountable'}}
+    // expected-warning@-1{{Member variable 'elements' (of 'ptr_to_ptr_to_ref_counted::TemplateList<RefCountable>') contains a raw pointer to RefPtr-capable type 'RefCountable'}}
   };
   TemplateList<RefCountable> list;
 

--- a/clang/test/Analysis/Checkers/WebKit/unretained-members-arc.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-members-arc.mm
@@ -19,7 +19,7 @@ namespace members {
     RetainPtr<SomeObj> d;
 
     CFMutableArrayRef e = nullptr;
-// expected-warning@-1{{Member variable 'e' in 'members::Foo' is a retainable type 'CFMutableArrayRef'}}
+// expected-warning@-1{{Member variable 'e' (of 'members::Foo') is a RetainPtr capable type 'CFMutableArrayRef'}}
 
     dispatch_queue_t f = nullptr;
   };
@@ -27,7 +27,7 @@ namespace members {
   union FooUnion {
     SomeObj* a;
     CFMutableArrayRef b;
-    // expected-warning@-1{{Member variable 'b' in 'members::FooUnion' is a retainable type 'CFMutableArrayRef'}}
+    // expected-warning@-1{{Member variable 'b' (of 'members::FooUnion') is a RetainPtr capable type 'CFMutableArrayRef'}}
     dispatch_queue_t c;
   };
 
@@ -35,7 +35,7 @@ namespace members {
   struct FooTmpl {
     T* x;
     S y;
-// expected-warning@-1{{Member variable 'y' in 'members::FooTmpl<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>' is a raw pointer to retainable type}}
+// expected-warning@-1{{Member variable 'y' (of 'members::FooTmpl<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') is a raw pointer to RetainPtr capable type}}
     R z;
   };
 
@@ -52,14 +52,14 @@ namespace ptr_to_ptr_to_retained {
 
   struct List {
     CFMutableArrayRef* elements2;
-    // expected-warning@-1{{Member variable 'elements2' in 'ptr_to_ptr_to_retained::List' contains a retainable type 'CFMutableArrayRef'}}
+    // expected-warning@-1{{Member variable 'elements2' (of 'ptr_to_ptr_to_retained::List') contains a RetainPtr capable type 'CFMutableArrayRef'}}
   };
 
   template <typename T, typename S, typename R>
   struct TemplateList {
     T* elements1;
     S* elements2;
-    // expected-warning@-1{{Member variable 'elements2' in 'ptr_to_ptr_to_retained::TemplateList<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>' contains a raw pointer to retainable type '__CFArray'}}
+    // expected-warning@-1{{Member variable 'elements2' (of 'ptr_to_ptr_to_retained::TemplateList<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') contains a raw pointer to RetainPtr capable type '__CFArray'}}
     R* elements3;
   };
   TemplateList<SomeObj, CFMutableArrayRef, dispatch_queue_t> list;
@@ -75,14 +75,14 @@ namespace ptr_to_ptr_to_retained {
 @interface AnotherObject : NSObject {
   NSString *ns_string;
   CFStringRef cf_string;
-  // expected-warning@-1{{Instance variable 'cf_string' in 'AnotherObject' is a retainable type 'CFStringRef'; member variables must be a RetainPtr}}
+  // expected-warning@-1{{Instance variable 'cf_string' (of 'AnotherObject') is a RetainPtr capable type 'CFStringRef'}}
   dispatch_queue_t queue;
 }
 @property(nonatomic, strong) NSString *prop_string1;
 @property(nonatomic, assign) NSString *prop_string2;
-// expected-warning@-1{{Property 'prop_string2' in 'AnotherObject' is a raw pointer to retainable type 'NSString'; member variables must be a RetainPtr}}
+// expected-warning@-1{{Property 'prop_string2' (of 'AnotherObject') is a raw pointer to RetainPtr capable type 'NSString'}}
 @property(nonatomic, unsafe_unretained) NSString *prop_string3;
-// expected-warning@-1{{Property 'prop_string3' in 'AnotherObject' is a raw pointer to retainable type 'NSString'; member variables must be a RetainPtr}}
+// expected-warning@-1{{Property 'prop_string3' (of 'AnotherObject') is a raw pointer to RetainPtr capable type 'NSString'}}
 @property(nonatomic, readonly) NSString *prop_string4;
 @property(nonatomic, readonly) NSString *prop_safe;
 @end
@@ -106,16 +106,16 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 @interface NoSynthObject : NSObject {
   NSString *ns_string;
   CFStringRef cf_string;
-  // expected-warning@-1{{Instance variable 'cf_string' in 'NoSynthObject' is a retainable type 'CFStringRef'; member variables must be a RetainPtr}}
+  // expected-warning@-1{{Instance variable 'cf_string' (of 'NoSynthObject') is a RetainPtr capable type 'CFStringRef'}}
 }
 @property(nonatomic, readonly, strong) NSString *prop_string1;
 @property(nonatomic, readonly, strong) NSString *prop_string2;
 @property(nonatomic, assign) NSString *prop_string3;
-// expected-warning@-1{{Property 'prop_string3' in 'NoSynthObject' is a raw pointer to retainable type 'NSString'; member variables must be a RetainPtr}}
+// expected-warning@-1{{Property 'prop_string3' (of 'NoSynthObject') is a raw pointer to RetainPtr capable type 'NSString'}}
 @property(nonatomic, unsafe_unretained) NSString *prop_string4;
-// expected-warning@-1{{Property 'prop_string4' in 'NoSynthObject' is a raw pointer to retainable type 'NSString'; member variables must be a RetainPtr}}
+// expected-warning@-1{{Property 'prop_string4' (of 'NoSynthObject') is a raw pointer to RetainPtr capable type 'NSString'}}
 @property(nonatomic, unsafe_unretained) dispatch_queue_t prop_string5;
-// expected-warning@-1{{Property 'prop_string5' in 'NoSynthObject' is a retainable type 'dispatch_queue_t'}}
+// expected-warning@-1{{Property 'prop_string5' (of 'NoSynthObject') is a RetainPtr capable type 'dispatch_queue_t'}}
 @end
 
 @implementation NoSynthObject

--- a/clang/test/Analysis/Checkers/WebKit/unretained-members-arc.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-members-arc.mm
@@ -19,7 +19,7 @@ namespace members {
     RetainPtr<SomeObj> d;
 
     CFMutableArrayRef e = nullptr;
-// expected-warning@-1{{Member variable 'e' (of 'members::Foo') is a RetainPtr capable type 'CFMutableArrayRef'}}
+// expected-warning@-1{{Member variable 'e' (of 'members::Foo') is a RetainPtr-capable type 'CFMutableArrayRef'}}
 
     dispatch_queue_t f = nullptr;
   };
@@ -27,7 +27,7 @@ namespace members {
   union FooUnion {
     SomeObj* a;
     CFMutableArrayRef b;
-    // expected-warning@-1{{Member variable 'b' (of 'members::FooUnion') is a RetainPtr capable type 'CFMutableArrayRef'}}
+    // expected-warning@-1{{Member variable 'b' (of 'members::FooUnion') is a RetainPtr-capable type 'CFMutableArrayRef'}}
     dispatch_queue_t c;
   };
 
@@ -35,7 +35,7 @@ namespace members {
   struct FooTmpl {
     T* x;
     S y;
-// expected-warning@-1{{Member variable 'y' (of 'members::FooTmpl<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') is a raw pointer to RetainPtr capable type}}
+// expected-warning@-1{{Member variable 'y' (of 'members::FooTmpl<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') is a raw pointer to RetainPtr-capable type}}
     R z;
   };
 
@@ -52,14 +52,14 @@ namespace ptr_to_ptr_to_retained {
 
   struct List {
     CFMutableArrayRef* elements2;
-    // expected-warning@-1{{Member variable 'elements2' (of 'ptr_to_ptr_to_retained::List') contains a RetainPtr capable type 'CFMutableArrayRef'}}
+    // expected-warning@-1{{Member variable 'elements2' (of 'ptr_to_ptr_to_retained::List') contains a RetainPtr-capable type 'CFMutableArrayRef'}}
   };
 
   template <typename T, typename S, typename R>
   struct TemplateList {
     T* elements1;
     S* elements2;
-    // expected-warning@-1{{Member variable 'elements2' (of 'ptr_to_ptr_to_retained::TemplateList<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') contains a raw pointer to RetainPtr capable type '__CFArray'}}
+    // expected-warning@-1{{Member variable 'elements2' (of 'ptr_to_ptr_to_retained::TemplateList<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') contains a raw pointer to RetainPtr-capable type '__CFArray'}}
     R* elements3;
   };
   TemplateList<SomeObj, CFMutableArrayRef, dispatch_queue_t> list;
@@ -75,14 +75,14 @@ namespace ptr_to_ptr_to_retained {
 @interface AnotherObject : NSObject {
   NSString *ns_string;
   CFStringRef cf_string;
-  // expected-warning@-1{{Instance variable 'cf_string' (of 'AnotherObject') is a RetainPtr capable type 'CFStringRef'}}
+  // expected-warning@-1{{Instance variable 'cf_string' (of 'AnotherObject') is a RetainPtr-capable type 'CFStringRef'}}
   dispatch_queue_t queue;
 }
 @property(nonatomic, strong) NSString *prop_string1;
 @property(nonatomic, assign) NSString *prop_string2;
-// expected-warning@-1{{Property 'prop_string2' (of 'AnotherObject') is a raw pointer to RetainPtr capable type 'NSString'}}
+// expected-warning@-1{{Property 'prop_string2' (of 'AnotherObject') is a raw pointer to RetainPtr-capable type 'NSString'}}
 @property(nonatomic, unsafe_unretained) NSString *prop_string3;
-// expected-warning@-1{{Property 'prop_string3' (of 'AnotherObject') is a raw pointer to RetainPtr capable type 'NSString'}}
+// expected-warning@-1{{Property 'prop_string3' (of 'AnotherObject') is a raw pointer to RetainPtr-capable type 'NSString'}}
 @property(nonatomic, readonly) NSString *prop_string4;
 @property(nonatomic, readonly) NSString *prop_safe;
 @end
@@ -106,16 +106,16 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 @interface NoSynthObject : NSObject {
   NSString *ns_string;
   CFStringRef cf_string;
-  // expected-warning@-1{{Instance variable 'cf_string' (of 'NoSynthObject') is a RetainPtr capable type 'CFStringRef'}}
+  // expected-warning@-1{{Instance variable 'cf_string' (of 'NoSynthObject') is a RetainPtr-capable type 'CFStringRef'}}
 }
 @property(nonatomic, readonly, strong) NSString *prop_string1;
 @property(nonatomic, readonly, strong) NSString *prop_string2;
 @property(nonatomic, assign) NSString *prop_string3;
-// expected-warning@-1{{Property 'prop_string3' (of 'NoSynthObject') is a raw pointer to RetainPtr capable type 'NSString'}}
+// expected-warning@-1{{Property 'prop_string3' (of 'NoSynthObject') is a raw pointer to RetainPtr-capable type 'NSString'}}
 @property(nonatomic, unsafe_unretained) NSString *prop_string4;
-// expected-warning@-1{{Property 'prop_string4' (of 'NoSynthObject') is a raw pointer to RetainPtr capable type 'NSString'}}
+// expected-warning@-1{{Property 'prop_string4' (of 'NoSynthObject') is a raw pointer to RetainPtr-capable type 'NSString'}}
 @property(nonatomic, unsafe_unretained) dispatch_queue_t prop_string5;
-// expected-warning@-1{{Property 'prop_string5' (of 'NoSynthObject') is a RetainPtr capable type 'dispatch_queue_t'}}
+// expected-warning@-1{{Property 'prop_string5' (of 'NoSynthObject') is a RetainPtr-capable type 'dispatch_queue_t'}}
 @end
 
 @implementation NoSynthObject

--- a/clang/test/Analysis/Checkers/WebKit/unretained-members.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-members.mm
@@ -10,9 +10,9 @@ namespace members {
   struct Foo {
   private:
     SomeObj* a = nullptr;
-// expected-warning@-1{{Member variable 'a' in 'members::Foo' is a raw pointer to retainable type}}
+// expected-warning@-1{{Member variable 'a' (of 'members::Foo') is a raw pointer to RetainPtr capable type}}
     dispatch_queue_t a2 = nullptr;
-// expected-warning@-1{{Member variable 'a2' in 'members::Foo' is a retainable type 'dispatch_queue_t'}}
+// expected-warning@-1{{Member variable 'a2' (of 'members::Foo') is a RetainPtr capable type 'dispatch_queue_t'}}
 
     [[clang::suppress]]
     SomeObj* a_suppressed = nullptr;
@@ -26,23 +26,23 @@ namespace members {
 
   public:
     SomeObj* c = nullptr;
-// expected-warning@-1{{Member variable 'c' in 'members::Foo' is a raw pointer to retainable type}}
+// expected-warning@-1{{Member variable 'c' (of 'members::Foo') is a raw pointer to RetainPtr capable type}}
     RetainPtr<SomeObj> d;
     OSObjectPtr<dispatch_queue_t> d2;
 
     CFMutableArrayRef e = nullptr;
-// expected-warning@-1{{Member variable 'e' in 'members::Foo' is a retainable type 'CFMutableArrayRef'}}
+// expected-warning@-1{{Member variable 'e' (of 'members::Foo') is a RetainPtr capable type 'CFMutableArrayRef'}}
 
   };
 
   template<class T, class S, class R>
   struct FooTmpl {
     T* a;
-// expected-warning@-1{{Member variable 'a' in 'members::FooTmpl<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>' is a raw pointer to retainable type}}
+// expected-warning@-1{{Member variable 'a' (of 'members::FooTmpl<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') is a raw pointer to RetainPtr capable type}}
     S b;
-// expected-warning@-1{{Member variable 'b' in 'members::FooTmpl<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>' is a raw pointer to retainable type}}
+// expected-warning@-1{{Member variable 'b' (of 'members::FooTmpl<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') is a raw pointer to RetainPtr capable type}}
     R c;
-// expected-warning@-1{{Member variable 'c' in 'members::FooTmpl<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>' is a raw pointer to retainable type}}
+// expected-warning@-1{{Member variable 'c' (of 'members::FooTmpl<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') is a raw pointer to RetainPtr capable type}}
   };
 
   void forceTmplToInstantiate(FooTmpl<SomeObj, CFMutableArrayRef, dispatch_queue_t>) {}
@@ -58,18 +58,18 @@ namespace members {
 namespace unions {
   union Foo {
     SomeObj* a;
-    // expected-warning@-1{{Member variable 'a' in 'unions::Foo' is a raw pointer to retainable type 'SomeObj'}}
+    // expected-warning@-1{{Member variable 'a' (of 'unions::Foo') is a raw pointer to RetainPtr capable type 'SomeObj'}}
     RetainPtr<SomeObj> b;
     CFMutableArrayRef c;
-    // expected-warning@-1{{Member variable 'c' in 'unions::Foo' is a retainable type 'CFMutableArrayRef'}}
+    // expected-warning@-1{{Member variable 'c' (of 'unions::Foo') is a RetainPtr capable type 'CFMutableArrayRef'}}
     dispatch_queue_t d;
-    // expected-warning@-1{{Member variable 'd' in 'unions::Foo' is a retainable type 'dispatch_queue_t'}}
+    // expected-warning@-1{{Member variable 'd' (of 'unions::Foo') is a RetainPtr capable type 'dispatch_queue_t'}}
   };
 
   template<class T>
   union FooTempl {
     T* a;
-    // expected-warning@-1{{Member variable 'a' in 'unions::FooTempl<SomeObj>' is a raw pointer to retainable type 'SomeObj'}}
+    // expected-warning@-1{{Member variable 'a' (of 'unions::FooTempl<SomeObj>') is a raw pointer to RetainPtr capable type 'SomeObj'}}
   };
 
   void forceTmplToInstantiate(FooTempl<SomeObj>) {}
@@ -79,21 +79,21 @@ namespace ptr_to_ptr_to_retained {
 
   struct List {
     SomeObj** elements1;
-    // expected-warning@-1{{Member variable 'elements1' in 'ptr_to_ptr_to_retained::List' contains a raw pointer to retainable type 'SomeObj'}}
+    // expected-warning@-1{{Member variable 'elements1' (of 'ptr_to_ptr_to_retained::List') contains a raw pointer to RetainPtr capable type 'SomeObj'}}
     CFMutableArrayRef* elements2;
-    // expected-warning@-1{{Member variable 'elements2' in 'ptr_to_ptr_to_retained::List' contains a retainable type 'CFMutableArrayRef'}}
+    // expected-warning@-1{{Member variable 'elements2' (of 'ptr_to_ptr_to_retained::List') contains a RetainPtr capable type 'CFMutableArrayRef'}}
     dispatch_queue_t* elements3;
-    // expected-warning@-1{{Member variable 'elements3' in 'ptr_to_ptr_to_retained::List' contains a retainable type 'dispatch_queue_t'}}
+    // expected-warning@-1{{Member variable 'elements3' (of 'ptr_to_ptr_to_retained::List') contains a RetainPtr capable type 'dispatch_queue_t'}}
   };
 
   template <typename T, typename S, typename R>
   struct TemplateList {
     T** elements1;
-    // expected-warning@-1{{Member variable 'elements1' in 'ptr_to_ptr_to_retained::TemplateList<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>' contains a raw pointer to retainable type 'SomeObj'}}
+    // expected-warning@-1{{Member variable 'elements1' (of 'ptr_to_ptr_to_retained::TemplateList<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') contains a raw pointer to RetainPtr capable type 'SomeObj'}}
     S* elements2;
-    // expected-warning@-1{{Member variable 'elements2' in 'ptr_to_ptr_to_retained::TemplateList<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>' contains a raw pointer to retainable type '__CFArray'}}
+    // expected-warning@-1{{Member variable 'elements2' (of 'ptr_to_ptr_to_retained::TemplateList<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') contains a raw pointer to RetainPtr capable type '__CFArray'}}
     R* elements3;
-    // expected-warning@-1{{Member variable 'elements3' in 'ptr_to_ptr_to_retained::TemplateList<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>' contains a raw pointer to retainable type 'NSObject'}}
+    // expected-warning@-1{{Member variable 'elements3' (of 'ptr_to_ptr_to_retained::TemplateList<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') contains a raw pointer to RetainPtr capable type 'NSObject'}}
   };
   TemplateList<SomeObj, CFMutableArrayRef, dispatch_queue_t> list;
 
@@ -106,11 +106,11 @@ namespace ptr_to_ptr_to_retained {
 
 @interface AnotherObject : NSObject {
   NSString *ns_string;
-  // expected-warning@-1{{Instance variable 'ns_string' in 'AnotherObject' is a raw pointer to retainable type 'NSString'}}
+  // expected-warning@-1{{Instance variable 'ns_string' (of 'AnotherObject') is a raw pointer to RetainPtr capable type 'NSString'}}
   CFStringRef cf_string;
-  // expected-warning@-1{{Instance variable 'cf_string' in 'AnotherObject' is a retainable type 'CFStringRef'}}
+  // expected-warning@-1{{Instance variable 'cf_string' (of 'AnotherObject') is a RetainPtr capable type 'CFStringRef'}}
   dispatch_queue_t dispatch;
-  // expected-warning@-1{{Instance variable 'dispatch' in 'AnotherObject' is a retainable type 'dispatch_queue_t'}}
+  // expected-warning@-1{{Instance variable 'dispatch' (of 'AnotherObject') is a RetainPtr capable type 'dispatch_queue_t'}}
 }
 @property(nonatomic, readonly, strong) NSString *prop_string;
 @property(nonatomic, readonly) NSString *prop_safe;
@@ -124,11 +124,11 @@ namespace ptr_to_ptr_to_retained {
 
 @interface DerivedObject : AnotherObject {
   NSNumber *ns_number;
-  // expected-warning@-1{{Instance variable 'ns_number' in 'DerivedObject' is a raw pointer to retainable type 'NSNumber'}}
+  // expected-warning@-1{{Instance variable 'ns_number' (of 'DerivedObject') is a raw pointer to RetainPtr capable type 'NSNumber'}}
   CGImageRef cg_image;
-  // expected-warning@-1{{Instance variable 'cg_image' in 'DerivedObject' is a retainable type 'CGImageRef'}}
+  // expected-warning@-1{{Instance variable 'cg_image' (of 'DerivedObject') is a RetainPtr capable type 'CGImageRef'}}
   dispatch_queue_t os_dispatch;
-  // expected-warning@-1{{Instance variable 'os_dispatch' in 'DerivedObject' is a retainable type 'dispatch_queue_t'}}
+  // expected-warning@-1{{Instance variable 'os_dispatch' (of 'DerivedObject') is a RetainPtr capable type 'dispatch_queue_t'}}
 }
 @property(nonatomic, strong) NSNumber *prop_number;
 @property(nonatomic, readonly) NSString *prop_string;
@@ -152,13 +152,13 @@ namespace ptr_to_ptr_to_retained {
 @property(nonatomic, strong) NSString *prop_string1;
 @property(nonatomic, assign) NSString *prop_string2;
 @property(nonatomic, unsafe_unretained) NSString *prop_string3;
-// expected-warning@-1{{Property 'prop_string3' in 'DerivedObject2' is a raw pointer to retainable type 'NSString'}}
+// expected-warning@-1{{Property 'prop_string3' (of 'DerivedObject2') is a raw pointer to RetainPtr capable type 'NSString'}}
 @property(nonatomic, readonly) NSString *prop_string4;
 @end
 
 @interface DerivedObject2 : InterfaceOnlyObject2
 @property(nonatomic, readonly) NSString *prop_string5;
-// expected-warning@-1{{Property 'prop_string5' in 'DerivedObject2' is a raw pointer to retainable type 'NSString'}}
+// expected-warning@-1{{Property 'prop_string5' (of 'DerivedObject2') is a raw pointer to RetainPtr capable type 'NSString'}}
 @end
 
 @implementation DerivedObject2
@@ -168,18 +168,18 @@ namespace ptr_to_ptr_to_retained {
 NS_REQUIRES_PROPERTY_DEFINITIONS
 @interface NoSynthObject : NSObject {
   NSString *ns_string;
-  // expected-warning@-1{{Instance variable 'ns_string' in 'NoSynthObject' is a raw pointer to retainable type 'NSString'}}
+  // expected-warning@-1{{Instance variable 'ns_string' (of 'NoSynthObject') is a raw pointer to RetainPtr capable type 'NSString'}}
   CFStringRef cf_string;
-  // expected-warning@-1{{Instance variable 'cf_string' in 'NoSynthObject' is a retainable type 'CFStringRef'}}
+  // expected-warning@-1{{Instance variable 'cf_string' (of 'NoSynthObject') is a RetainPtr capable type 'CFStringRef'}}
   dispatch_queue_t dispatch;
-  // expected-warning@-1{{Instance variable 'dispatch' in 'NoSynthObject' is a retainable type 'dispatch_queue_t'}}
+  // expected-warning@-1{{Instance variable 'dispatch' (of 'NoSynthObject') is a RetainPtr capable type 'dispatch_queue_t'}}
 }
 @property(nonatomic, readonly, strong) NSString *prop_string1;
 @property(nonatomic, readonly, strong) NSString *prop_string2;
 @property(nonatomic, assign) NSString *prop_string3;
-// expected-warning@-1{{Property 'prop_string3' in 'NoSynthObject' is a raw pointer to retainable type 'NSString'; member variables must be a RetainPtr}}
+// expected-warning@-1{{Property 'prop_string3' (of 'NoSynthObject') is a raw pointer to RetainPtr capable type 'NSString'}}
 @property(nonatomic, unsafe_unretained) NSString *prop_string4;
-// expected-warning@-1{{Property 'prop_string4' in 'NoSynthObject' is a raw pointer to retainable type 'NSString'; member variables must be a RetainPtr}}
+// expected-warning@-1{{Property 'prop_string4' (of 'NoSynthObject') is a raw pointer to RetainPtr capable type 'NSString'}}
 @property(nonatomic, copy) NSString *prop_string5;
 @property(nonatomic, readonly, strong) dispatch_queue_t dispatch;
 @end

--- a/clang/test/Analysis/Checkers/WebKit/unretained-members.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-members.mm
@@ -10,9 +10,9 @@ namespace members {
   struct Foo {
   private:
     SomeObj* a = nullptr;
-// expected-warning@-1{{Member variable 'a' (of 'members::Foo') is a raw pointer to RetainPtr capable type}}
+// expected-warning@-1{{Member variable 'a' (of 'members::Foo') is a raw pointer to RetainPtr-capable type}}
     dispatch_queue_t a2 = nullptr;
-// expected-warning@-1{{Member variable 'a2' (of 'members::Foo') is a RetainPtr capable type 'dispatch_queue_t'}}
+// expected-warning@-1{{Member variable 'a2' (of 'members::Foo') is a RetainPtr-capable type 'dispatch_queue_t'}}
 
     [[clang::suppress]]
     SomeObj* a_suppressed = nullptr;
@@ -26,23 +26,23 @@ namespace members {
 
   public:
     SomeObj* c = nullptr;
-// expected-warning@-1{{Member variable 'c' (of 'members::Foo') is a raw pointer to RetainPtr capable type}}
+// expected-warning@-1{{Member variable 'c' (of 'members::Foo') is a raw pointer to RetainPtr-capable type}}
     RetainPtr<SomeObj> d;
     OSObjectPtr<dispatch_queue_t> d2;
 
     CFMutableArrayRef e = nullptr;
-// expected-warning@-1{{Member variable 'e' (of 'members::Foo') is a RetainPtr capable type 'CFMutableArrayRef'}}
+// expected-warning@-1{{Member variable 'e' (of 'members::Foo') is a RetainPtr-capable type 'CFMutableArrayRef'}}
 
   };
 
   template<class T, class S, class R>
   struct FooTmpl {
     T* a;
-// expected-warning@-1{{Member variable 'a' (of 'members::FooTmpl<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') is a raw pointer to RetainPtr capable type}}
+// expected-warning@-1{{Member variable 'a' (of 'members::FooTmpl<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') is a raw pointer to RetainPtr-capable type}}
     S b;
-// expected-warning@-1{{Member variable 'b' (of 'members::FooTmpl<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') is a raw pointer to RetainPtr capable type}}
+// expected-warning@-1{{Member variable 'b' (of 'members::FooTmpl<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') is a raw pointer to RetainPtr-capable type}}
     R c;
-// expected-warning@-1{{Member variable 'c' (of 'members::FooTmpl<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') is a raw pointer to RetainPtr capable type}}
+// expected-warning@-1{{Member variable 'c' (of 'members::FooTmpl<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') is a raw pointer to RetainPtr-capable type}}
   };
 
   void forceTmplToInstantiate(FooTmpl<SomeObj, CFMutableArrayRef, dispatch_queue_t>) {}
@@ -58,18 +58,18 @@ namespace members {
 namespace unions {
   union Foo {
     SomeObj* a;
-    // expected-warning@-1{{Member variable 'a' (of 'unions::Foo') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+    // expected-warning@-1{{Member variable 'a' (of 'unions::Foo') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
     RetainPtr<SomeObj> b;
     CFMutableArrayRef c;
-    // expected-warning@-1{{Member variable 'c' (of 'unions::Foo') is a RetainPtr capable type 'CFMutableArrayRef'}}
+    // expected-warning@-1{{Member variable 'c' (of 'unions::Foo') is a RetainPtr-capable type 'CFMutableArrayRef'}}
     dispatch_queue_t d;
-    // expected-warning@-1{{Member variable 'd' (of 'unions::Foo') is a RetainPtr capable type 'dispatch_queue_t'}}
+    // expected-warning@-1{{Member variable 'd' (of 'unions::Foo') is a RetainPtr-capable type 'dispatch_queue_t'}}
   };
 
   template<class T>
   union FooTempl {
     T* a;
-    // expected-warning@-1{{Member variable 'a' (of 'unions::FooTempl<SomeObj>') is a raw pointer to RetainPtr capable type 'SomeObj'}}
+    // expected-warning@-1{{Member variable 'a' (of 'unions::FooTempl<SomeObj>') is a raw pointer to RetainPtr-capable type 'SomeObj'}}
   };
 
   void forceTmplToInstantiate(FooTempl<SomeObj>) {}
@@ -79,21 +79,21 @@ namespace ptr_to_ptr_to_retained {
 
   struct List {
     SomeObj** elements1;
-    // expected-warning@-1{{Member variable 'elements1' (of 'ptr_to_ptr_to_retained::List') contains a raw pointer to RetainPtr capable type 'SomeObj'}}
+    // expected-warning@-1{{Member variable 'elements1' (of 'ptr_to_ptr_to_retained::List') contains a raw pointer to RetainPtr-capable type 'SomeObj'}}
     CFMutableArrayRef* elements2;
-    // expected-warning@-1{{Member variable 'elements2' (of 'ptr_to_ptr_to_retained::List') contains a RetainPtr capable type 'CFMutableArrayRef'}}
+    // expected-warning@-1{{Member variable 'elements2' (of 'ptr_to_ptr_to_retained::List') contains a RetainPtr-capable type 'CFMutableArrayRef'}}
     dispatch_queue_t* elements3;
-    // expected-warning@-1{{Member variable 'elements3' (of 'ptr_to_ptr_to_retained::List') contains a RetainPtr capable type 'dispatch_queue_t'}}
+    // expected-warning@-1{{Member variable 'elements3' (of 'ptr_to_ptr_to_retained::List') contains a RetainPtr-capable type 'dispatch_queue_t'}}
   };
 
   template <typename T, typename S, typename R>
   struct TemplateList {
     T** elements1;
-    // expected-warning@-1{{Member variable 'elements1' (of 'ptr_to_ptr_to_retained::TemplateList<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') contains a raw pointer to RetainPtr capable type 'SomeObj'}}
+    // expected-warning@-1{{Member variable 'elements1' (of 'ptr_to_ptr_to_retained::TemplateList<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') contains a raw pointer to RetainPtr-capable type 'SomeObj'}}
     S* elements2;
-    // expected-warning@-1{{Member variable 'elements2' (of 'ptr_to_ptr_to_retained::TemplateList<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') contains a raw pointer to RetainPtr capable type '__CFArray'}}
+    // expected-warning@-1{{Member variable 'elements2' (of 'ptr_to_ptr_to_retained::TemplateList<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') contains a raw pointer to RetainPtr-capable type '__CFArray'}}
     R* elements3;
-    // expected-warning@-1{{Member variable 'elements3' (of 'ptr_to_ptr_to_retained::TemplateList<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') contains a raw pointer to RetainPtr capable type 'NSObject'}}
+    // expected-warning@-1{{Member variable 'elements3' (of 'ptr_to_ptr_to_retained::TemplateList<SomeObj, __CFArray *, NSObject<OS_dispatch_queue> *>') contains a raw pointer to RetainPtr-capable type 'NSObject'}}
   };
   TemplateList<SomeObj, CFMutableArrayRef, dispatch_queue_t> list;
 
@@ -106,11 +106,11 @@ namespace ptr_to_ptr_to_retained {
 
 @interface AnotherObject : NSObject {
   NSString *ns_string;
-  // expected-warning@-1{{Instance variable 'ns_string' (of 'AnotherObject') is a raw pointer to RetainPtr capable type 'NSString'}}
+  // expected-warning@-1{{Instance variable 'ns_string' (of 'AnotherObject') is a raw pointer to RetainPtr-capable type 'NSString'}}
   CFStringRef cf_string;
-  // expected-warning@-1{{Instance variable 'cf_string' (of 'AnotherObject') is a RetainPtr capable type 'CFStringRef'}}
+  // expected-warning@-1{{Instance variable 'cf_string' (of 'AnotherObject') is a RetainPtr-capable type 'CFStringRef'}}
   dispatch_queue_t dispatch;
-  // expected-warning@-1{{Instance variable 'dispatch' (of 'AnotherObject') is a RetainPtr capable type 'dispatch_queue_t'}}
+  // expected-warning@-1{{Instance variable 'dispatch' (of 'AnotherObject') is a RetainPtr-capable type 'dispatch_queue_t'}}
 }
 @property(nonatomic, readonly, strong) NSString *prop_string;
 @property(nonatomic, readonly) NSString *prop_safe;
@@ -124,11 +124,11 @@ namespace ptr_to_ptr_to_retained {
 
 @interface DerivedObject : AnotherObject {
   NSNumber *ns_number;
-  // expected-warning@-1{{Instance variable 'ns_number' (of 'DerivedObject') is a raw pointer to RetainPtr capable type 'NSNumber'}}
+  // expected-warning@-1{{Instance variable 'ns_number' (of 'DerivedObject') is a raw pointer to RetainPtr-capable type 'NSNumber'}}
   CGImageRef cg_image;
-  // expected-warning@-1{{Instance variable 'cg_image' (of 'DerivedObject') is a RetainPtr capable type 'CGImageRef'}}
+  // expected-warning@-1{{Instance variable 'cg_image' (of 'DerivedObject') is a RetainPtr-capable type 'CGImageRef'}}
   dispatch_queue_t os_dispatch;
-  // expected-warning@-1{{Instance variable 'os_dispatch' (of 'DerivedObject') is a RetainPtr capable type 'dispatch_queue_t'}}
+  // expected-warning@-1{{Instance variable 'os_dispatch' (of 'DerivedObject') is a RetainPtr-capable type 'dispatch_queue_t'}}
 }
 @property(nonatomic, strong) NSNumber *prop_number;
 @property(nonatomic, readonly) NSString *prop_string;
@@ -152,13 +152,13 @@ namespace ptr_to_ptr_to_retained {
 @property(nonatomic, strong) NSString *prop_string1;
 @property(nonatomic, assign) NSString *prop_string2;
 @property(nonatomic, unsafe_unretained) NSString *prop_string3;
-// expected-warning@-1{{Property 'prop_string3' (of 'DerivedObject2') is a raw pointer to RetainPtr capable type 'NSString'}}
+// expected-warning@-1{{Property 'prop_string3' (of 'DerivedObject2') is a raw pointer to RetainPtr-capable type 'NSString'}}
 @property(nonatomic, readonly) NSString *prop_string4;
 @end
 
 @interface DerivedObject2 : InterfaceOnlyObject2
 @property(nonatomic, readonly) NSString *prop_string5;
-// expected-warning@-1{{Property 'prop_string5' (of 'DerivedObject2') is a raw pointer to RetainPtr capable type 'NSString'}}
+// expected-warning@-1{{Property 'prop_string5' (of 'DerivedObject2') is a raw pointer to RetainPtr-capable type 'NSString'}}
 @end
 
 @implementation DerivedObject2
@@ -168,18 +168,18 @@ namespace ptr_to_ptr_to_retained {
 NS_REQUIRES_PROPERTY_DEFINITIONS
 @interface NoSynthObject : NSObject {
   NSString *ns_string;
-  // expected-warning@-1{{Instance variable 'ns_string' (of 'NoSynthObject') is a raw pointer to RetainPtr capable type 'NSString'}}
+  // expected-warning@-1{{Instance variable 'ns_string' (of 'NoSynthObject') is a raw pointer to RetainPtr-capable type 'NSString'}}
   CFStringRef cf_string;
-  // expected-warning@-1{{Instance variable 'cf_string' (of 'NoSynthObject') is a RetainPtr capable type 'CFStringRef'}}
+  // expected-warning@-1{{Instance variable 'cf_string' (of 'NoSynthObject') is a RetainPtr-capable type 'CFStringRef'}}
   dispatch_queue_t dispatch;
-  // expected-warning@-1{{Instance variable 'dispatch' (of 'NoSynthObject') is a RetainPtr capable type 'dispatch_queue_t'}}
+  // expected-warning@-1{{Instance variable 'dispatch' (of 'NoSynthObject') is a RetainPtr-capable type 'dispatch_queue_t'}}
 }
 @property(nonatomic, readonly, strong) NSString *prop_string1;
 @property(nonatomic, readonly, strong) NSString *prop_string2;
 @property(nonatomic, assign) NSString *prop_string3;
-// expected-warning@-1{{Property 'prop_string3' (of 'NoSynthObject') is a raw pointer to RetainPtr capable type 'NSString'}}
+// expected-warning@-1{{Property 'prop_string3' (of 'NoSynthObject') is a raw pointer to RetainPtr-capable type 'NSString'}}
 @property(nonatomic, unsafe_unretained) NSString *prop_string4;
-// expected-warning@-1{{Property 'prop_string4' (of 'NoSynthObject') is a raw pointer to RetainPtr capable type 'NSString'}}
+// expected-warning@-1{{Property 'prop_string4' (of 'NoSynthObject') is a raw pointer to RetainPtr-capable type 'NSString'}}
 @property(nonatomic, copy) NSString *prop_string5;
 @property(nonatomic, readonly, strong) dispatch_queue_t dispatch;
 @end


### PR DESCRIPTION
This PR aligns NoUncountedMemberChecker and its variant's warning message with the new warning format in https://github.com/llvm/llvm-project/pull/202724.