### PR TITLE
[clang-format] Reset `Line->IsModuleOrImportDecl` in `addUnwrappedLine`

### DIFF
--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -108,7 +108,6 @@ public:
     Parser.Line->PPLevel = PreBlockLine->PPLevel;
     Parser.Line->InPPDirective = PreBlockLine->InPPDirective;
     Parser.Line->InMacroBody = PreBlockLine->InMacroBody;
-    Parser.Line->IsModuleOrImportDecl = PreBlockLine->IsModuleOrImportDecl;
     Parser.Line->UnbracedBodyLevel = PreBlockLine->UnbracedBodyLevel;
   }
 

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -4718,6 +4718,7 @@ void UnwrappedLineParser::addUnwrappedLine(LineLevel AdjustLevel) {
   Line->FirstStartColumn = 0;
   Line->IsContinuation = false;
   Line->SeenDecltypeAuto = false;
+  Line->IsModuleOrImportDecl = false;
 
   if (ClosesWhitesmithsBlock && AdjustLevel == LineLevel::Remove)
     --Line->Level;

--- a/clang/lib/Format/UnwrappedLineParser.h
+++ b/clang/lib/Format/UnwrappedLineParser.h
@@ -48,8 +48,6 @@ struct UnwrappedLine {
   bool InPragmaDirective = false;
   /// Whether it is part of a macro body.
   bool InMacroBody = false;
-  /// Whether it is a C++20 module/import declaration.
-  bool IsModuleOrImportDecl = false;
 
   /// Nesting level of unbraced body of a control statement.
   unsigned UnbracedBodyLevel = 0;
@@ -62,6 +60,9 @@ struct UnwrappedLine {
   /// \c True if this line should be indented by ContinuationIndent in
   /// addition to the normal indention level.
   bool IsContinuation = false;
+
+  /// Whether it is a C++20 module/import declaration.
+  bool IsModuleOrImportDecl = false;
 
   /// If this \c UnwrappedLine closes a block in a sequence of lines,
   /// \c MatchingOpeningBlockLineIndex stores the index of the corresponding

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -24906,6 +24906,15 @@ TEST_F(FormatTest, Cpp20ModulesSupport) {
   verifyFormat("import <Foo/Bar> /* comment */;", Style);
   verifyFormat("import <Foo/Bar>; // Trailing comment", Style);
 
+  Style.BreakStringLiterals = true;
+  Style.ColumnLimit = 20;
+  verifyFormat("export module foobar;\n"
+               "char *s = \"s1\"\n"
+               "          \"s2\";",
+               "export module foobar;\n"
+               "char *s = \"s1\" \"s2\";",
+               Style);
+
   // Somewhat gracefully handle import in pre-C++20 code.
   verifyFormat("import /* not keyword */ = val ? 2 : 1;");
   verifyFormat("_world->import<engine_module>();");


### PR DESCRIPTION
The `IsModuleOrImportDecl` flag was not reset in `addUnwrappedLine`. Since the parser recycles the `Line` object, this flag remained `true` for all subsequent lines in the file, which disabled wrapping (`CanBreakBefore` in `TokenAnnotator.cpp`) for expression-level constructs after any C++20 module or import statement, causing some formatting rules to not be applied in places. This patch fixes the issue by resetting the flag to `false`.