### PR TITLE
[clang][bytecode][NFC] Mark results as non-empty when taking a value

### DIFF
--- a/clang/lib/AST/ByteCode/EvaluationResult.h
+++ b/clang/lib/AST/ByteCode/EvaluationResult.h
@@ -51,6 +51,8 @@ private:
   void takeValue(APValue &&V) {
     assert(empty());
     Value = std::move(V);
+    Kind = Valid;
+    assert(!empty());
   }
   void setInvalid() {
     // We are NOT asserting empty() here, since setting it to invalid
@@ -72,13 +74,7 @@ public:
   bool empty() const { return Kind == Empty; }
   bool isInvalid() const { return Kind == Invalid; }
 
-  /// Returns an APValue for the evaluation result.
-  APValue toAPValue() const {
-    assert(!empty());
-    assert(!isInvalid());
-    return Value;
-  }
-
+  /// Moves the APValue containing the evaluation result to the caller.
   APValue stealAPValue() { return std::move(Value); }
 
   /// Check that all subobjects of the given pointer have been initialized.


### PR DESCRIPTION
This was missing and all the EvaluationResults always ended up being empty even though their APValue was set. Since the assert(!empty()) was missing from `takeAPValue()`, nobody noticed though.