### PR TITLE
[X86] Fix COFF _fltused early return skipping __morestack_addr emission

### DIFF
--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -1117,7 +1117,6 @@ void X86AsmPrinter::emitEndOfAsmFile(Module &M) {
           (TT.getArch() == Triple::x86) ? "__fltused" : "_fltused";
       MCSymbol *S = MMI->getContext().getOrCreateSymbol(SymbolName);
       OutStreamer->emitSymbolAttribute(S, MCSA_Global);
-      return;
     }
   } else if (TT.isOSBinFormatELF()) {
     FM.serializeToFaultMapSection();

--- a/llvm/test/CodeGen/X86/coff-fltused-morestack-largecode.ll
+++ b/llvm/test/CodeGen/X86/coff-fltused-morestack-largecode.ll
@@ -1,0 +1,27 @@
+; RUN: llc -mtriple=x86_64-pc-windows-msvc -code-model=large < %s | FileCheck %s
+
+;; On a COFF/MSVC target built with the large code model and split stacks, the
+;; prologue calls __morestack indirectly through the __morestack_addr data slot,
+;; whose definition is emitted at the end of the file by
+;; X86AsmPrinter::emitEndOfAsmFile. When the program also uses floating point,
+;; the same routine emits the _fltused marker. emitEndOfAsmFile used to `return`
+;; right after emitting _fltused, which skipped the trailing __morestack_addr
+;; definition -- leaving the indirect call referencing an undefined symbol.
+;;
+;; Both the _fltused marker and the __morestack_addr definition must be emitted.
+
+; CHECK: callq *__morestack_addr(%rip)
+; CHECK: .globl{{.*}}_fltused
+; CHECK: __morestack_addr:
+; CHECK-NEXT: .quad{{.*}}__morestack
+
+declare void @use(ptr)
+
+define double @f(double %a, double %b) #0 {
+  %buf = alloca [4096 x i8]
+  call void @use(ptr %buf)
+  %r = fadd double %a, %b
+  ret double %r
+}
+
+attributes #0 = { "split-stack" }


### PR DESCRIPTION
`X86AsmPrinter::emitEndOfAsmFile` emits a few end-of-file items, including the COFF/MSVC `_fltused` marker (when the program uses floating point) and the `__morestack_addr` data slot (for any x86-64 large-code-model file that used split stacks).

The COFF branch `return`s immediately after emitting `_fltused`. That `return` sits before the shared `__morestack_addr` block at the bottom of the function, so when a target is COFF *and* uses floating point, the function bails out before defining `__morestack_addr`.

On x86_64-windows-msvc with the large code model and split stacks (`"split-stack"`), the prologue emits an indirect call `callq *__morestack_addr(%rip)` and relies on emitEndOfAsmFile to define `__morestack_addr: .quad __morestack`. If the function also uses floating point, the early `return` drops that definition: the emitted assembly references `__morestack_addr` but never defines it, leaving an undefined symbol at link time. Segmented stacks are explicitly supported on Win64 (X86FrameLowering rejects only other platforms), so the trigger is narrow but legal.

The `_fltused` emission is just a marker and is not order-critical, unlike the Mach-O branch's trailing `emitSubsectionsViaSymbols`. Removing the early `return` lets control fall through into the `__morestack_addr` block, so both `_fltused` and the `__morestack_addr` definition are emitted.

Found via @jlebar's X86 LLVM bug-hunt / FuzzX effort:
https://github.com/SemiAnalysisAI/FuzzX/tree/master/x86/bugs/077-asmprinter-coff-fltused-early-return-skips-morestack

cc @jlebar