### PR TITLE
[lit] Make RecursionError less likely in internal shell

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -702,8 +702,8 @@ def executeScriptInternal(
         else:
             assert len(cmds) > 1, "didn't expect an empty sequence"
             split = len(cmds) // 2
-            return ShUtil.Seq(
-                make_tree(cmds[:split]), "&&", make_tree(cmds[split:]))
+            return ShUtil.Seq(make_tree(cmds[:split]), "&&", make_tree(cmds[split:]))
+
     cmd = make_tree(cmds)
 
     results = []

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -691,9 +691,20 @@ def executeScriptInternal(
                 f"shell parser error on {dbg}: {command.lstrip()}\n"
             ) from None
 
-    cmd = cmds[0]
-    for c in cmds[1:]:
-        cmd = ShUtil.Seq(cmd, "&&", c)
+    # Link all of `cmds` into a single command, consisting of the original
+    # commands chained together with &&. To avoid RecursionError in large tests
+    # (e.g. with 1000 RUN: lines), we do this by subdividing the list in half
+    # each time, so that we make a balanced tree structure with depth
+    # proportional to only the log of the list length.
+    def make_tree(cmds):
+        if len(cmds) == 1:
+            return cmds[0]
+        else:
+            assert len(cmds) > 1, "didn't expect an empty sequence"
+            split = len(cmds) // 2
+            return ShUtil.Seq(
+                make_tree(cmds[:split]), "&&", make_tree(cmds[split:]))
+    cmd = make_tree(cmds)
 
     results = []
     timeoutInfo = None


### PR DESCRIPTION
The lit internal shell chains together the contents of multiple RUN: lines by connecting them with implicit && nodes, forming a binary tree structure which is then executed recursively by `_executeShCommand`. However the tree structure is constructed in a very simple way which makes it effectively just a linked list, so `_executeShCommand` must recurse to a depth equal to the number of commands.

If a test file contains more than 1000 RUN: lines (e.g. running the clang driver only, with lots of different options), then this causes a RecursionError exception, which did not happen using the external shell. Failures of this kind can be avoided by instead connecting the commands together in a _balanced_ binary tree, which has equivalent behaviour, since the && shell operator is associative.