### PR TITLE
[clang][modules] Add BuiltinsAVR.def as textual header in module.modulemap

### DIFF
--- a/clang/include/module.modulemap
+++ b/clang/include/module.modulemap
@@ -42,6 +42,7 @@ module Clang_Basic {
   textual header "clang/Basic/BuiltinsAArch64NeonSVEBridge.def"
   textual header "clang/Basic/BuiltinsAArch64NeonSVEBridge_cg.def"
   textual header "clang/Basic/BuiltinsARM.def"
+  textual header "clang/Basic/BuiltinsAVR.def"
   textual header "clang/Basic/BuiltinsHexagonMapCustomDep.def"
   textual header "clang/Basic/BuiltinsLoongArchBase.def"
   textual header "clang/Basic/BuiltinsLoongArchLASX.def"


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/203214 added BuiltinsAVR.def but omitted its textual header entry in module.modulemap. Building the Clang_Basic module then tried to import the .def as a submodule from inside namespace clang::AVR, which is illegal, breaking the module build. Add the missing entry.