### PR TITLE
[libc] Add CPU_CLR(_S) macros

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -1101,6 +1101,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.pthread.pthread_setspecific
 
     # sched.h entrypoints
+    libc.src.sched.__sched_clrcpuset
     libc.src.sched.__sched_cpualloc
     libc.src.sched.__sched_cpufree
     libc.src.sched.__sched_getcpucount

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -1234,6 +1234,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.pthread.pthread_setspecific
 
     # sched.h entrypoints
+    libc.src.sched.__sched_clrcpuset
     libc.src.sched.__sched_cpualloc
     libc.src.sched.__sched_cpufree
     libc.src.sched.__sched_getcpucount

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1296,6 +1296,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.pthread.pthread_setspecific
 
     # sched.h entrypoints
+    libc.src.sched.__sched_clrcpuset
     libc.src.sched.__sched_cpualloc
     libc.src.sched.__sched_cpufree
     libc.src.sched.__sched_getcpucount

--- a/libc/include/llvm-libc-macros/linux/sched-macros.h
+++ b/libc/include/llvm-libc-macros/linux/sched-macros.h
@@ -25,6 +25,8 @@
 
 #define CPU_SETSIZE __CPU_SETSIZE
 #define NCPUBITS __NCPUBITS
+#define CPU_CLR_S(cpu, setsize, set) __sched_clrcpuset(cpu, setsize, set)
+#define CPU_CLR(cpu, set) CPU_CLR_S(cpu, sizeof(cpu_set_t), set)
 #define CPU_COUNT_S(setsize, set) __sched_getcpucount(setsize, set)
 #define CPU_COUNT(set) CPU_COUNT_S(sizeof(cpu_set_t), set)
 #define CPU_ZERO_S(setsize, set) __sched_setcpuzero(setsize, set)

--- a/libc/include/sched.yaml
+++ b/libc/include/sched.yaml
@@ -18,6 +18,14 @@ types:
 enums: []
 objects: []
 functions:
+  - name: __sched_clrcpuset
+    standards:
+      - llvm_libc_ext
+    return_type: void
+    arguments:
+      - type: int
+      - type: size_t
+      - type: cpu_set_t *
   - name: __sched_cpualloc
     standards:
       - llvm_libc_ext

--- a/libc/src/sched/CMakeLists.txt
+++ b/libc/src/sched/CMakeLists.txt
@@ -87,6 +87,13 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  __sched_clrcpuset
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.__sched_clrcpuset
+)
+
+add_entrypoint_object(
   __sched_cpualloc
   ALIAS
   DEPENDS

--- a/libc/src/sched/linux/CMakeLists.txt
+++ b/libc/src/sched/linux/CMakeLists.txt
@@ -169,6 +169,21 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  __sched_clrcpuset
+  SRCS
+    sched_clrcpuset.cpp
+  HDRS
+    ../sched_clrcpuset.h
+  DEPENDS
+    libc.src.__support.common
+    libc.src.__support.macros.config
+    libc.src.__support.macros.null_check
+    libc.hdr.sched_macros
+    libc.hdr.types.cpu_set_t
+    libc.hdr.types.size_t
+)
+
+add_entrypoint_object(
   __sched_cpualloc
   SRCS
     sched_cpualloc.cpp

--- a/libc/src/sched/linux/sched_clrcpuset.cpp
+++ b/libc/src/sched/linux/sched_clrcpuset.cpp
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Linux implementation of __sched_clrcpuset.
+///
+//===----------------------------------------------------------------------===//
+
+#include "src/sched/sched_clrcpuset.h"
+#include "hdr/sched_macros.h" // NCPUBITS
+#include "hdr/types/cpu_set_t.h"
+#include "hdr/types/size_t.h"
+#include "src/__support/common.h"            // LLVM_LIBC_FUNCTION
+#include "src/__support/macros/config.h"     // LIBC_NAMESPACE_DECL
+#include "src/__support/macros/null_check.h" // LIBC_CRASH_ON_NULLPTR
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(void, __sched_clrcpuset,
+                   (int cpu, const size_t cpuset_size, cpu_set_t *set)) {
+  LIBC_CRASH_ON_NULLPTR(set);
+  if (static_cast<size_t>(cpu) / 8 < cpuset_size) {
+    const size_t element_index = static_cast<size_t>(cpu) / NCPUBITS;
+    const size_t bit_position = static_cast<size_t>(cpu) % NCPUBITS;
+
+    const unsigned long mask = 1UL << bit_position;
+    set->__mask[element_index] &= ~mask;
+  }
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/sched/sched_clrcpuset.h
+++ b/libc/src/sched/sched_clrcpuset.h
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for __sched_clrcpuset.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SCHED_SCHED_CLRCPUSET_H
+#define LLVM_LIBC_SRC_SCHED_SCHED_CLRCPUSET_H
+
+#include "hdr/types/cpu_set_t.h"
+#include "hdr/types/size_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// for internal use in the CPU_CLR macro
+void __sched_clrcpuset(int cpu, const size_t cpuset_size, cpu_set_t *set);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_SCHED_SCHED_CLRCPUSET_H

--- a/libc/test/src/sched/CMakeLists.txt
+++ b/libc/test/src/sched/CMakeLists.txt
@@ -137,6 +137,7 @@ add_libc_unittest(
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
     libc.src.sched.sched_getaffinity
+    libc.src.sched.__sched_clrcpuset
     libc.src.sched.__sched_getcpucount
     libc.src.sched.__sched_getcpuisset
     libc.src.sched.__sched_setcpuset

--- a/libc/test/src/sched/cpu_count_test.cpp
+++ b/libc/test/src/sched/cpu_count_test.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/__support/OSUtil/syscall.h"
+#include "src/sched/sched_clrcpuset.h"
 #include "src/sched/sched_getaffinity.h"
 #include "src/sched/sched_getcpucount.h"
 #include "src/sched/sched_getcpuisset.h"
@@ -46,4 +47,12 @@ TEST_F(LlvmLibcSchedCpuCountTest, CpuSetMacros) {
   LIBC_NAMESPACE::CPU_SET(1, &mask);
   ASSERT_EQ(LIBC_NAMESPACE::CPU_ISSET(1, &mask), 1);
   ASSERT_EQ(LIBC_NAMESPACE::CPU_COUNT(&mask), 1);
+
+  LIBC_NAMESPACE::CPU_CLR(1, &mask);
+  ASSERT_EQ(LIBC_NAMESPACE::CPU_ISSET(1, &mask), 0);
+
+  LIBC_NAMESPACE::CPU_SET_S(1, sizeof(cpu_set_t), &mask);
+  ASSERT_EQ(LIBC_NAMESPACE::CPU_ISSET_S(1, sizeof(cpu_set_t), &mask), 1);
+  LIBC_NAMESPACE::CPU_CLR_S(1, sizeof(cpu_set_t), &mask);
+  ASSERT_EQ(LIBC_NAMESPACE::CPU_ISSET_S(1, sizeof(cpu_set_t), &mask), 0);
 }


### PR DESCRIPTION
This patch implements CPU_CLR and CPU_CLR_S macros following the existing CPU_SET pattern. The macro just forwards to an internal entry point.

Assisted by Gemini.