### PR TITLE
[LifetimeSafety] Add multi-block support to buildOriginFlowChain

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Facts.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Facts.h
@@ -378,6 +378,7 @@ public:
   /// Retrieves all the facts in the block containing Program Point P.
   /// \note This is intended for testing only.
   llvm::ArrayRef<const Fact *> getBlockContaining(ProgramPoint P) const;
+  std::optional<size_t> getBlockID(ProgramPoint P) const;
 
   unsigned getNumFacts() const { return NextFactID.Value; }
 

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/Facts.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/Facts.h
@@ -378,7 +378,7 @@ public:
   /// Retrieves all the facts in the block containing Program Point P.
   /// \note This is intended for testing only.
   llvm::ArrayRef<const Fact *> getBlockContaining(ProgramPoint P) const;
-  std::optional<size_t> getBlockID(ProgramPoint P) const;
+  size_t getBlockID(ProgramPoint P) const;
 
   unsigned getNumFacts() const { return NextFactID.Value; }
 

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LoanPropagation.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LoanPropagation.h
@@ -41,7 +41,7 @@ public:
   /// Builds the chain of origins through which a loan has propagated.
   ///
   /// Starting from the last fact of the block containing StartPoint, this
-  /// function performs a BFS over CFG blocks to explore all reachable blocks.
+  /// function performs a DFS over CFG blocks to explore all reachable blocks.
   /// Within each block, facts are processed in reverse order.
   ///
   /// The traversal follows OriginFlowFacts backwards to reconstruct the

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LoanPropagation.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LoanPropagation.h
@@ -40,8 +40,11 @@ public:
 
   /// Builds the chain of origins through which a loan has propagated.
   ///
-  /// Starting from the last fact of the block containg StartPoint,
-  /// this function traces backwards through OriginFlowFacts to identify the
+  /// Starting from the last fact of the block containing StartPoint, this
+  /// function performs a BFS over CFG blocks to explore all reachable blocks.
+  /// Within each block, facts are processed in reverse order.
+  ///
+  /// The traversal follows OriginFlowFacts backwards to reconstruct the
   /// sequence of origins through which the loan flowed, ending at the origin
   /// where the loan was originally issued.
   llvm::SmallVector<OriginID> buildOriginFlowChain(ProgramPoint StartPoint,

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LoanPropagation.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LoanPropagation.h
@@ -16,7 +16,6 @@
 #define LLVM_CLANG_ANALYSIS_ANALYSES_LIFETIMESAFETY_LOAN_PROPAGATION_H
 
 #include "clang/Analysis/Analyses/LifetimeSafety/Facts.h"
-#include "clang/Analysis/Analyses/PostOrderCFGView.h"
 #include "clang/Analysis/AnalysisDeclContext.h"
 #include "clang/Analysis/CFG.h"
 #include "llvm/ADT/ImmutableMap.h"
@@ -45,14 +44,14 @@ public:
   /// this function traces backwards through OriginFlowFacts to identify the
   /// sequence of origins through which the loan flowed, ending at the origin
   /// where the loan was originally issued.
-  llvm::SmallVector<OriginID>
-  buildOriginFlowChain(ProgramPoint StartPoint, const OriginID StartOID,
-                       const LoanID TargetLoan,
-                       const PostOrderCFGView *POV) const;
+  llvm::SmallVector<OriginID> buildOriginFlowChain(ProgramPoint StartPoint,
+                                                   const OriginID StartOID,
+                                                   const LoanID TargetLoan,
+                                                   const CFG *Cfg) const;
 
-  llvm::SmallVector<OriginID>
-  buildOriginFlowChain(const UseFact *UF, const LoanID TargetLoan,
-                       const PostOrderCFGView *POV) const;
+  llvm::SmallVector<OriginID> buildOriginFlowChain(const UseFact *UF,
+                                                   const LoanID TargetLoan,
+                                                   const CFG *Cfg) const;
 
 private:
   class Impl;

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LoanPropagation.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LoanPropagation.h
@@ -40,7 +40,7 @@ public:
 
   /// Builds the chain of origins through which a loan has propagated.
   ///
-  /// Starting from StartPoint where StartOID currently holds TargetLoan,
+  /// Starting from the last fact of the block containg StartPoint,
   /// this function traces backwards through OriginFlowFacts to identify the
   /// sequence of origins through which the loan flowed, ending at the origin
   /// where the loan was originally issued.

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LoanPropagation.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LoanPropagation.h
@@ -16,6 +16,7 @@
 #define LLVM_CLANG_ANALYSIS_ANALYSES_LIFETIMESAFETY_LOAN_PROPAGATION_H
 
 #include "clang/Analysis/Analyses/LifetimeSafety/Facts.h"
+#include "clang/Analysis/Analyses/PostOrderCFGView.h"
 #include "clang/Analysis/AnalysisDeclContext.h"
 #include "clang/Analysis/CFG.h"
 #include "llvm/ADT/ImmutableMap.h"
@@ -46,10 +47,12 @@ public:
   /// where the loan was originally issued.
   llvm::SmallVector<OriginID>
   buildOriginFlowChain(ProgramPoint StartPoint, const OriginID StartOID,
-                       const LoanID TargetLoan) const;
+                       const LoanID TargetLoan,
+                       const PostOrderCFGView *POV) const;
 
   llvm::SmallVector<OriginID>
-  buildOriginFlowChain(const UseFact *UF, const LoanID TargetLoan) const;
+  buildOriginFlowChain(const UseFact *UF, const LoanID TargetLoan,
+                       const PostOrderCFGView *POV) const;
 
 private:
   class Impl;

--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -67,9 +67,9 @@ private:
   FactManager &FactMgr;
   LifetimeSafetySemaHelper *SemaHelper;
   ASTContext &AST;
+  const CFG *Cfg;
   const Decl *FD;
   const LifetimeSafetyOpts &LSOpts;
-  const PostOrderCFGView *POV;
 
   static SourceLocation
   GetFactLoc(llvm::PointerUnion<const UseFact *, const OriginEscapesFact *> F) {
@@ -93,8 +93,8 @@ public:
                   const LifetimeSafetyOpts &LSOpts)
       : LoanPropagation(LoanPropagation), MovedLoans(MovedLoans),
         LiveOrigins(LiveOrigins), FactMgr(FM), SemaHelper(SemaHelper),
-        AST(ADC.getASTContext()), FD(ADC.getDecl()), LSOpts(LSOpts),
-        POV(ADC.getAnalysis<PostOrderCFGView>()) {
+        AST(ADC.getASTContext()), Cfg(ADC.getCFG()), FD(ADC.getDecl()),
+        LSOpts(LSOpts) {
     for (const CFGBlock *B : *ADC.getAnalysis<PostOrderCFGView>())
       for (const Fact *F : FactMgr.getFacts(B))
         if (const auto *EF = F->getAs<ExpireFact>())
@@ -274,7 +274,7 @@ public:
           // Scope-based expiry (use-after-scope).
           SemaHelper->reportUseAfterScope(
               IssueExpr, UF->getUseExpr(), MovedExpr, ExpiryLoc,
-              getExprChain(LoanPropagation.buildOriginFlowChain(UF, LID, POV)));
+              getExprChain(LoanPropagation.buildOriginFlowChain(UF, LID, Cfg)));
 
       } else if (const auto *OEF =
                      CausingFact.dyn_cast<const OriginEscapesFact *>()) {

--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -69,6 +69,7 @@ private:
   ASTContext &AST;
   const Decl *FD;
   const LifetimeSafetyOpts &LSOpts;
+  const PostOrderCFGView *POV;
 
   static SourceLocation
   GetFactLoc(llvm::PointerUnion<const UseFact *, const OriginEscapesFact *> F) {
@@ -92,7 +93,8 @@ public:
                   const LifetimeSafetyOpts &LSOpts)
       : LoanPropagation(LoanPropagation), MovedLoans(MovedLoans),
         LiveOrigins(LiveOrigins), FactMgr(FM), SemaHelper(SemaHelper),
-        AST(ADC.getASTContext()), FD(ADC.getDecl()), LSOpts(LSOpts) {
+        AST(ADC.getASTContext()), FD(ADC.getDecl()), LSOpts(LSOpts),
+        POV(ADC.getAnalysis<PostOrderCFGView>()) {
     for (const CFGBlock *B : *ADC.getAnalysis<PostOrderCFGView>())
       for (const Fact *F : FactMgr.getFacts(B))
         if (const auto *EF = F->getAs<ExpireFact>())
@@ -272,7 +274,7 @@ public:
           // Scope-based expiry (use-after-scope).
           SemaHelper->reportUseAfterScope(
               IssueExpr, UF->getUseExpr(), MovedExpr, ExpiryLoc,
-              getExprChain(LoanPropagation.buildOriginFlowChain(UF, LID)));
+              getExprChain(LoanPropagation.buildOriginFlowChain(UF, LID, POV)));
 
       } else if (const auto *OEF =
                      CausingFact.dyn_cast<const OriginEscapesFact *>()) {

--- a/clang/lib/Analysis/LifetimeSafety/Facts.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Facts.cpp
@@ -145,17 +145,14 @@ void FactManager::dump(const CFG &Cfg, AnalysisDeclContext &AC) const {
 
 llvm::ArrayRef<const Fact *>
 FactManager::getBlockContaining(ProgramPoint P) const {
-  std::optional<size_t> BlockIndex = getBlockID(P);
-  if (BlockIndex)
-    return BlockToFacts[BlockIndex.value()];
-  return {};
+  return BlockToFacts[getBlockID(P)];
 }
 
-std::optional<size_t> FactManager::getBlockID(ProgramPoint P) const {
+size_t FactManager::getBlockID(ProgramPoint P) const {
   for (size_t i = 0; i < BlockToFacts.size(); ++i)
     for (const Fact *F : BlockToFacts[i])
       if (F == P)
         return i;
-  return std::nullopt;
+  llvm_unreachable("Failed to find BlockID for given ProgramPoint");
 }
 } // namespace clang::lifetimes::internal

--- a/clang/lib/Analysis/LifetimeSafety/Facts.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Facts.cpp
@@ -145,12 +145,17 @@ void FactManager::dump(const CFG &Cfg, AnalysisDeclContext &AC) const {
 
 llvm::ArrayRef<const Fact *>
 FactManager::getBlockContaining(ProgramPoint P) const {
-  for (const auto &BlockToFactsVec : BlockToFacts) {
-    for (const Fact *F : BlockToFactsVec)
-      if (F == P)
-        return BlockToFactsVec;
-  }
+  std::optional<size_t> BlockIndex = getBlockID(P);
+  if (BlockIndex)
+    return BlockToFacts[BlockIndex.value()];
   return {};
 }
 
+std::optional<size_t> FactManager::getBlockID(ProgramPoint P) const {
+  for (size_t i = 0; i < BlockToFacts.size(); ++i)
+    for (const Fact *F : BlockToFacts[i])
+      if (F == P)
+        return i;
+  return std::nullopt;
+}
 } // namespace clang::lifetimes::internal

--- a/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
@@ -210,14 +210,21 @@ public:
     assert(getLoans(StartOID, StartPoint).contains(TargetLoan) &&
            "TargetLoan must be present in the StartOID at the StartPoint");
 
-    DEBUG_WITH_TYPE("LifetimeBuildOriginFlow",
-                    llvm::dbgs()
-                        << "==========================================\n"
-                        << "    Lifetime Analysis buildOriginFlow\n"
-                        << "==========================================\n"
-                        << "StartOriginID: " << StartOID
-                        << ", TargetLoanID: " << TargetLoan << "\n\n");
+    const auto ShouldTrack = [&](const CFGBlock *Block, OriginID StartOID) {
+      for (const Fact *F : llvm::reverse(FactMgr.getFacts(Block))) {
+        const auto *OFF = llvm::dyn_cast<OriginFlowFact>(F);
+        if (!OFF)
+          continue;
+        if (OFF->getDestOriginID() == StartOID) {
+          if (getLoans(StartOID, OFF).contains(TargetLoan))
+            return true;
+          return false;
+        }
+      }
+      return true;
+    };
 
+    // Locate the CFG block containing the StartPoint
     const CFGBlock *EndBlock = nullptr;
     size_t BlockID = FactMgr.getBlockID(StartPoint);
     for (const CFGBlock *Block : *Cfg)
@@ -226,6 +233,9 @@ public:
         break;
       }
 
+    // Set up DFS traversal state
+    // SearchState tracks which block we're in and which origin we're tracing
+    // Each DFSNode maintains its own OriginFlowChain.
     using SearchState = std::pair<const CFGBlock *, OriginID>;
     struct DFSNode {
       SearchState CurrState;
@@ -236,6 +246,7 @@ public:
     llvm::SmallSet<SearchState, 16> VistedStates;
     PendingStates.push_back({{EndBlock, StartOID}, {}});
 
+    // DFS loop to trace loan backwards through CFG
     while (!PendingStates.empty()) {
       DFSNode CurrNode = PendingStates.pop_back_val();
       auto [CurrBlock, CurrOID] = CurrNode.CurrState;
@@ -244,6 +255,7 @@ public:
                       llvm::dbgs() << "CurrBlockID: " << CurrBlock->getBlockID()
                                    << ", StartOriginID: " << CurrOID << "\n");
 
+      // Trace origins within the current block
       const auto [BuildResult, Complete] =
           buildOriginFlowChain(CurrBlock, CurrOID, TargetLoan);
       if (!BuildResult.empty()) {
@@ -251,6 +263,7 @@ public:
         CurrOID = BuildResult.back();
       }
 
+      // If we found the IssueFact, we're done
       if (Complete)
         return CurrNode.OriginFlowChain;
 
@@ -259,7 +272,8 @@ public:
 
       for (const CFGBlock *PredBlock : CurrBlock->preds()) {
         SearchState NextState = {PredBlock, CurrOID};
-        if (VistedStates.insert(NextState).second)
+        if (ShouldTrack(PredBlock, CurrOID) &&
+            VistedStates.insert(NextState).second)
           PendingStates.push_back({NextState, CurrNode.OriginFlowChain});
       }
     }
@@ -322,18 +336,13 @@ private:
           return {OriginFlowChain, true};
 
       const auto *OFF = F->getAs<OriginFlowFact>();
-      if (!OFF)
-        continue;
-      if (OFF->getDestOriginID() != CurrOID)
+      if (!OFF || OFF->getDestOriginID() != CurrOID)
         continue;
 
       const OriginID SrcOriginID = OFF->getSrcOriginID();
       if (!getLoans(SrcOriginID, OFF).contains(TargetLoan))
         continue;
 
-      DEBUG_WITH_TYPE("LifetimeBuildOriginFlow",
-                      llvm::dbgs()
-                          << "\tFind OriginID: " << SrcOriginID << "\n");
       OriginFlowChain.push_back(SrcOriginID);
       CurrOID = SrcOriginID;
     }

--- a/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
@@ -210,6 +210,18 @@ public:
     assert(getLoans(StartOID, StartPoint).contains(TargetLoan) &&
            "TargetLoan must be present in the StartOID at the StartPoint");
 
+    DEBUG_WITH_TYPE("LifetimeBuildOriginFlow",
+                    llvm::dbgs()
+                        << "==========================================\n");
+    DEBUG_WITH_TYPE("LifetimeBuildOriginFlow",
+                    llvm::dbgs() << "    Lifetime Analysis buildOriginFlow\n");
+    DEBUG_WITH_TYPE("LifetimeBuildOriginFlow",
+                    llvm::dbgs()
+                        << "==========================================\n");
+    DEBUG_WITH_TYPE("LifetimeBuildOriginFlow",
+                    llvm::dbgs() << "StartOriginID: " << StartOID
+                                 << ", TargetLoanID: " << TargetLoan << "\n\n");
+
     std::optional<OriginID> FinalOID;
     llvm::DenseMap<OriginID, OriginID> VistedOriginIDs;
 
@@ -256,6 +268,10 @@ public:
       auto [CurrBlock, CurrOID] = PendingContext.front();
       PendingContext.pop();
 
+      DEBUG_WITH_TYPE("LifetimeBuildOriginFlow",
+                      llvm::dbgs() << "CurrBlockID: " << CurrBlock->getBlockID()
+                                   << ", StartOriginID: " << CurrOID << "\n");
+
       const auto [BuildResult, Complete] =
           buildOriginFlowChain(CurrBlock, CurrOID, TargetLoan);
       if (!BuildResult.empty())
@@ -263,6 +279,9 @@ public:
 
       if (Complete)
         return OriginFlowChainFilter(*FinalOID);
+
+      DEBUG_WITH_TYPE("LifetimeBuildOriginFlow",
+                      llvm::dbgs() << "EndOriginID: " << CurrOID << "\n");
 
       for (const CFGBlock *Block : CurrBlock->preds()) {
         SearchContext Context = {Block, CurrOID};
@@ -329,6 +348,10 @@ private:
       const OriginID SrcOriginID = OFF->getSrcOriginID();
       if (!getLoans(SrcOriginID, OFF).contains(TargetLoan))
         continue;
+
+      DEBUG_WITH_TYPE("LifetimeBuildOriginFlow",
+                      llvm::dbgs()
+                          << "\tFind OriginID: " << SrcOriginID << "\n");
       OriginFlowChain.push_back(SrcOriginID);
       CurrOID = SrcOriginID;
     }

--- a/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
@@ -231,12 +231,12 @@ public:
 
     OriginID CurrOID = StartOID;
     llvm::SmallVector<OriginID> OriginFlowChain;
-    std::queue<const CFGBlock *> PendingState;
-    PendingState.push(EndBlock);
+    std::queue<const CFGBlock *> PendingBlocks;
+    PendingBlocks.push(EndBlock);
 
-    while (!PendingState.empty()) {
-      const CFGBlock *CurrBlock = PendingState.front();
-      PendingState.pop();
+    while (!PendingBlocks.empty()) {
+      const CFGBlock *CurrBlock = PendingBlocks.front();
+      PendingBlocks.pop();
 
       DEBUG_WITH_TYPE("LifetimeBuildOriginFlow",
                       llvm::dbgs() << "CurrBlockID: " << CurrBlock->getBlockID()
@@ -256,7 +256,7 @@ public:
                       llvm::dbgs() << "EndOriginID: " << CurrOID << "\n");
 
       for (const CFGBlock *Block : CurrBlock->preds())
-        PendingState.push(Block);
+        PendingBlocks.push(Block);
     }
 
     llvm_unreachable(

--- a/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
@@ -18,7 +18,6 @@
 #include "clang/Analysis/CFG.h"
 #include "clang/Basic/LLVM.h"
 #include "llvm/ADT/BitVector.h"
-#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/TimeProfiler.h"
 #include "llvm/Support/raw_ostream.h"

--- a/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
@@ -212,9 +212,10 @@ public:
     llvm::SmallVector<OriginID> OriginFlowChain;
     std::optional<size_t> BlockID = FactMgr.getBlockID(StartPoint);
     assert(BlockID.has_value());
-    const auto EndBlockIt = llvm::find_if(*POV, [&BlockID](const CFGBlock *Block) {
-      return Block->getBlockID() == BlockID;
-    });
+    const auto EndBlockIt =
+        llvm::find_if(*POV, [&BlockID](const CFGBlock *Block) {
+          return Block->getBlockID() == BlockID;
+        });
 
     OriginID CurrOID = StartOID;
     for (const CFGBlock *B :

--- a/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
@@ -214,35 +214,7 @@ public:
     assert(getLoans(StartOID, StartPoint).contains(TargetLoan) &&
            "TargetLoan must be present in the StartOID at the StartPoint");
 
-    std::optional<OriginID> FinalOID;
-    llvm::DenseMap<OriginID, OriginID> VistedOriginIDs;
-
-    const auto OriginFlowChainFilter = [&VistedOriginIDs](OriginID FinalOID) {
-      llvm::SmallVector<OriginID> OriginFlowChain;
-      while (true) {
-        OriginFlowChain.push_back(FinalOID);
-        const auto NextOriginID = VistedOriginIDs.find(FinalOID);
-        if (NextOriginID == VistedOriginIDs.end())
-          break;
-        FinalOID = NextOriginID->second;
-      }
-      return OriginFlowChain;
-    };
-
-    const auto InsertVistedOriginIDs =
-        [&VistedOriginIDs, &FinalOID](llvm::ArrayRef<OriginID> OriginFlowChain,
-                                      OriginID &StartOID) {
-          if (!VistedOriginIDs.empty())
-            VistedOriginIDs.insert({OriginFlowChain[0], StartOID});
-
-          for (size_t i = 0; i < OriginFlowChain.size() - 1; ++i)
-            VistedOriginIDs.insert(
-                {OriginFlowChain[i + 1], OriginFlowChain[i]});
-
-          StartOID = OriginFlowChain.back();
-          FinalOID = StartOID;
-        };
-
+    llvm::SmallVector<OriginID> OriginFlowChain;
     std::optional<size_t> BlockID = FactMgr.getBlockID(StartPoint);
     assert(BlockID.has_value());
     const auto StartIt = llvm::find_if(*POV, [&BlockID](const CFGBlock *Block) {
@@ -252,45 +224,20 @@ public:
     OriginID CurrOID = StartOID;
     for (const CFGBlock *B :
          llvm::reverse(llvm::make_range(POV->begin(), StartIt + 1))) {
-      BuildOriginFlowChainResult BuildResult =
-          buildOriginFlowChain(B, CurrOID, TargetLoan);
-      if (!BuildResult.OriginFlowChain.empty())
-        InsertVistedOriginIDs(BuildResult.OriginFlowChain, CurrOID);
-      if (BuildResult.Complete)
-        return OriginFlowChainFilter(*FinalOID);
+      auto [OFChain, Complete] = buildOriginFlowChain(B, CurrOID, TargetLoan);
+
+      if (!OFChain.empty()) {
+        OriginFlowChain.append(OFChain.begin(), OFChain.end());
+        CurrOID = OFChain.back();
+      }
+
+      if (Complete)
+        return OriginFlowChain;
     }
 
     llvm_unreachable(
         "buildOriginFlowChain should return at BuildResult.Complete");
-  }
-
-  BuildOriginFlowChainResult
-  buildOriginFlowChain(const CFGBlock *Block, const OriginID StartOID,
-                       const LoanID TargetLoan) const {
-    OriginID CurrOID = StartOID;
-    llvm::SmallVector<OriginID> OriginFlowChain;
-
-    for (const Fact *F : llvm::reverse(FactMgr.getFacts(Block))) {
-      if (const auto *IF = F->getAs<IssueFact>())
-        if (IF->getLoanID() == TargetLoan) {
-          assert(IF->getOriginID() == CurrOID);
-          return {OriginFlowChain, true};
-        }
-
-      const auto *OFF = F->getAs<OriginFlowFact>();
-      if (!OFF)
-        continue;
-      if (OFF->getDestOriginID() != CurrOID)
-        continue;
-
-      const OriginID SrcOriginID = OFF->getSrcOriginID();
-      if (!getLoans(SrcOriginID, OFF).contains(TargetLoan))
-        continue;
-      OriginFlowChain.push_back(SrcOriginID);
-      CurrOID = SrcOriginID;
-    }
-
-    return {OriginFlowChain, false};
+    return OriginFlowChain;
   }
 
   llvm::SmallVector<OriginID>
@@ -325,6 +272,35 @@ private:
     if (auto *Loans = Map->lookup(OID))
       return *Loans;
     return LoanSetFactory.getEmptySet();
+  }
+
+  BuildOriginFlowChainResult
+  buildOriginFlowChain(const CFGBlock *Block, const OriginID StartOID,
+                       const LoanID TargetLoan) const {
+    OriginID CurrOID = StartOID;
+    llvm::SmallVector<OriginID> OriginFlowChain;
+
+    for (const Fact *F : llvm::reverse(FactMgr.getFacts(Block))) {
+      if (const auto *IF = F->getAs<IssueFact>())
+        if (IF->getLoanID() == TargetLoan) {
+          assert(IF->getOriginID() == CurrOID);
+          return {OriginFlowChain, true};
+        }
+
+      const auto *OFF = F->getAs<OriginFlowFact>();
+      if (!OFF)
+        continue;
+      if (OFF->getDestOriginID() != CurrOID)
+        continue;
+
+      const OriginID SrcOriginID = OFF->getSrcOriginID();
+      if (!getLoans(SrcOriginID, OFF).contains(TargetLoan))
+        continue;
+      OriginFlowChain.push_back(SrcOriginID);
+      CurrOID = SrcOriginID;
+    }
+
+    return {OriginFlowChain, false};
   }
 
   OriginLoanMap::Factory &OriginLoanMapFactory;

--- a/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
@@ -222,35 +222,6 @@ public:
                     llvm::dbgs() << "StartOriginID: " << StartOID
                                  << ", TargetLoanID: " << TargetLoan << "\n\n");
 
-    std::optional<OriginID> FinalOID;
-    llvm::DenseMap<OriginID, OriginID> VistedOriginIDs;
-
-    const auto OriginFlowChainFilter = [&VistedOriginIDs](OriginID FinalOID) {
-      llvm::SmallVector<OriginID> OriginFlowChain;
-      while (true) {
-        OriginFlowChain.push_back(FinalOID);
-        const auto NextOriginID = VistedOriginIDs.find(FinalOID);
-        if (NextOriginID == VistedOriginIDs.end())
-          break;
-        FinalOID = NextOriginID->second;
-      }
-      return OriginFlowChain;
-    };
-
-    const auto InsertVistedOriginIDs =
-        [&VistedOriginIDs, &FinalOID](llvm::ArrayRef<OriginID> OriginFlowChain,
-                                      OriginID &StartOID) {
-          if (!VistedOriginIDs.empty())
-            VistedOriginIDs.insert({OriginFlowChain[0], StartOID});
-
-          for (size_t i = 0; i < OriginFlowChain.size() - 1; ++i)
-            VistedOriginIDs.insert(
-                {OriginFlowChain[i + 1], OriginFlowChain[i]});
-
-          StartOID = OriginFlowChain.back();
-          FinalOID = StartOID;
-        };
-
     const CFGBlock *EndBlock = nullptr;
     size_t BlockID = FactMgr.getBlockID(StartPoint);
     for (const CFGBlock *Block : *Cfg)
@@ -259,14 +230,14 @@ public:
         break;
       }
 
-    using SearchContext = std::pair<const CFGBlock *, OriginID>;
-    std::queue<SearchContext> PendingContext;
-    llvm::SmallSet<SearchContext, 32> VistedContext;
-    PendingContext.push({EndBlock, StartOID});
+    OriginID CurrOID = StartOID;
+    llvm::SmallVector<OriginID> OriginFlowChain;
+    std::queue<const CFGBlock *> PendingState;
+    PendingState.push(EndBlock);
 
-    while (!PendingContext.empty()) {
-      auto [CurrBlock, CurrOID] = PendingContext.front();
-      PendingContext.pop();
+    while (!PendingState.empty()) {
+      const CFGBlock *CurrBlock = PendingState.front();
+      PendingState.pop();
 
       DEBUG_WITH_TYPE("LifetimeBuildOriginFlow",
                       llvm::dbgs() << "CurrBlockID: " << CurrBlock->getBlockID()
@@ -274,20 +245,19 @@ public:
 
       const auto [BuildResult, Complete] =
           buildOriginFlowChain(CurrBlock, CurrOID, TargetLoan);
-      if (!BuildResult.empty())
-        InsertVistedOriginIDs(BuildResult, CurrOID);
+      if (!BuildResult.empty()) {
+        OriginFlowChain.append(BuildResult);
+        CurrOID = BuildResult.back();
+      }
 
       if (Complete)
-        return OriginFlowChainFilter(*FinalOID);
+        return OriginFlowChain;
 
       DEBUG_WITH_TYPE("LifetimeBuildOriginFlow",
                       llvm::dbgs() << "EndOriginID: " << CurrOID << "\n");
 
-      for (const CFGBlock *Block : CurrBlock->preds()) {
-        SearchContext Context = {Block, CurrOID};
-        if (Block && VistedContext.insert(Context).second)
-          PendingContext.push(Context);
-      }
+      for (const CFGBlock *Block : CurrBlock->preds())
+        PendingState.push(Block);
     }
 
     llvm_unreachable(

--- a/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
@@ -226,16 +226,19 @@ public:
         break;
       }
 
-    llvm::SmallVector<OriginID> OriginFlowChain;
-
     using SearchState = std::pair<const CFGBlock *, OriginID>;
-    std::queue<SearchState> PendingStates;
+    struct DFSNode {
+      SearchState CurrState;
+      llvm::SmallVector<OriginID> OriginFlowChain;
+    };
+
+    llvm::SmallVector<DFSNode> PendingStates;
     llvm::SmallSet<SearchState, 16> VistedStates;
-    PendingStates.push({EndBlock, StartOID});
+    PendingStates.push_back({{EndBlock, StartOID}, {}});
 
     while (!PendingStates.empty()) {
-      auto [CurrBlock, CurrOID] = PendingStates.front();
-      PendingStates.pop();
+      DFSNode CurrNode = PendingStates.pop_back_val();
+      auto [CurrBlock, CurrOID] = CurrNode.CurrState;
 
       DEBUG_WITH_TYPE("LifetimeBuildOriginFlow",
                       llvm::dbgs() << "CurrBlockID: " << CurrBlock->getBlockID()
@@ -244,20 +247,20 @@ public:
       const auto [BuildResult, Complete] =
           buildOriginFlowChain(CurrBlock, CurrOID, TargetLoan);
       if (!BuildResult.empty()) {
-        OriginFlowChain.append(BuildResult);
+        CurrNode.OriginFlowChain.append(BuildResult);
         CurrOID = BuildResult.back();
       }
 
       if (Complete)
-        return OriginFlowChain;
+        return CurrNode.OriginFlowChain;
 
       DEBUG_WITH_TYPE("LifetimeBuildOriginFlow",
                       llvm::dbgs() << "EndOriginID: " << CurrOID << "\n");
 
-      for (const CFGBlock *Block : CurrBlock->preds()) {
-        SearchState NextState = {Block, CurrOID};
+      for (const CFGBlock *PredBlock : CurrBlock->preds()) {
+        SearchState NextState = {PredBlock, CurrOID};
         if (VistedStates.insert(NextState).second)
-          PendingStates.push(NextState);
+          PendingStates.push_back({NextState, CurrNode.OriginFlowChain});
       }
     }
 

--- a/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
@@ -211,15 +211,11 @@ public:
 
     DEBUG_WITH_TYPE("LifetimeBuildOriginFlow",
                     llvm::dbgs()
-                        << "==========================================\n");
-    DEBUG_WITH_TYPE("LifetimeBuildOriginFlow",
-                    llvm::dbgs() << "    Lifetime Analysis buildOriginFlow\n");
-    DEBUG_WITH_TYPE("LifetimeBuildOriginFlow",
-                    llvm::dbgs()
-                        << "==========================================\n");
-    DEBUG_WITH_TYPE("LifetimeBuildOriginFlow",
-                    llvm::dbgs() << "StartOriginID: " << StartOID
-                                 << ", TargetLoanID: " << TargetLoan << "\n\n");
+                        << "==========================================\n"
+                        << "    Lifetime Analysis buildOriginFlow\n"
+                        << "==========================================\n"
+                        << "StartOriginID: " << StartOID
+                        << ", TargetLoanID: " << TargetLoan << "\n\n");
 
     const CFGBlock *EndBlock = nullptr;
     size_t BlockID = FactMgr.getBlockID(StartPoint);

--- a/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
@@ -18,6 +18,7 @@
 #include "clang/Analysis/CFG.h"
 #include "clang/Basic/LLVM.h"
 #include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/TimeProfiler.h"
 #include "llvm/Support/raw_ostream.h"
@@ -202,46 +203,86 @@ public:
     return getLoans(getState(P), OID);
   }
 
-  llvm::SmallVector<OriginID>
-  buildOriginFlowChain(ProgramPoint StartPoint, const OriginID StartOID,
-                       const LoanID TargetLoan,
-                       const PostOrderCFGView *POV) const {
+  llvm::SmallVector<OriginID> buildOriginFlowChain(ProgramPoint StartPoint,
+                                                   const OriginID StartOID,
+                                                   const LoanID TargetLoan,
+                                                   const CFG *Cfg) const {
     assert(getLoans(StartOID, StartPoint).contains(TargetLoan) &&
            "TargetLoan must be present in the StartOID at the StartPoint");
 
-    llvm::SmallVector<OriginID> OriginFlowChain;
+    std::optional<OriginID> FinalOID;
+    llvm::DenseMap<OriginID, OriginID> VistedOriginIDs;
+
+    const auto OriginFlowChainFilter = [&VistedOriginIDs](OriginID FinalOID) {
+      llvm::SmallVector<OriginID> OriginFlowChain;
+      while (true) {
+        OriginFlowChain.push_back(FinalOID);
+        const auto NextOriginID = VistedOriginIDs.find(FinalOID);
+        if (NextOriginID == VistedOriginIDs.end())
+          break;
+        FinalOID = NextOriginID->second;
+      }
+      return OriginFlowChain;
+    };
+
+    const auto InsertVistedOriginIDs =
+        [&VistedOriginIDs, &FinalOID](llvm::ArrayRef<OriginID> OriginFlowChain,
+                                      OriginID &StartOID) {
+          if (!VistedOriginIDs.empty())
+            VistedOriginIDs.insert({OriginFlowChain[0], StartOID});
+
+          for (size_t i = 0; i < OriginFlowChain.size() - 1; ++i)
+            VistedOriginIDs.insert(
+                {OriginFlowChain[i + 1], OriginFlowChain[i]});
+
+          StartOID = OriginFlowChain.back();
+          FinalOID = StartOID;
+        };
+
+    const CFGBlock *EndBlock = nullptr;
     size_t BlockID = FactMgr.getBlockID(StartPoint);
-    const auto EndBlockIt =
-        llvm::find_if(*POV, [&BlockID](const CFGBlock *Block) {
-          return Block->getBlockID() == BlockID;
-        });
-
-    OriginID CurrOID = StartOID;
-    for (const CFGBlock *B :
-         llvm::reverse(llvm::make_range(POV->begin(), EndBlockIt + 1))) {
-      auto [OFChain, Complete] = buildOriginFlowChain(B, CurrOID, TargetLoan);
-
-      if (!OFChain.empty()) {
-        OriginFlowChain.append(OFChain.begin(), OFChain.end());
-        CurrOID = OFChain.back();
+    for (const CFGBlock *Block : *Cfg)
+      if (Block->getBlockID() == BlockID) {
+        EndBlock = Block;
+        break;
       }
 
+    using SearchContext = std::pair<const CFGBlock *, OriginID>;
+    std::queue<SearchContext> PendingContext;
+    llvm::SmallSet<SearchContext, 32> VistedContext;
+    PendingContext.push({EndBlock, StartOID});
+
+    while (!PendingContext.empty()) {
+      auto [CurrBlock, CurrOID] = PendingContext.front();
+      PendingContext.pop();
+
+      const auto [BuildResult, Complete] =
+          buildOriginFlowChain(CurrBlock, CurrOID, TargetLoan);
+      if (!BuildResult.empty())
+        InsertVistedOriginIDs(BuildResult, CurrOID);
+
       if (Complete)
-        return OriginFlowChain;
+        return OriginFlowChainFilter(*FinalOID);
+
+      for (const CFGBlock *Block : CurrBlock->preds()) {
+        SearchContext Context = {Block, CurrOID};
+        if (Block && VistedContext.insert(Context).second)
+          PendingContext.push(Context);
+      }
     }
 
     llvm_unreachable(
         "buildOriginFlowChain did not reach IssueFact for TargetLoan");
   }
 
-  llvm::SmallVector<OriginID>
-  buildOriginFlowChain(const UseFact *UF, const LoanID TargetLoan,
-                       const PostOrderCFGView *POV) const {
+  llvm::SmallVector<OriginID> buildOriginFlowChain(const UseFact *UF,
+                                                   const LoanID TargetLoan,
+                                                   const CFG *Cfg) const {
     for (const OriginList *Cur = UF->getUsedOrigins(); Cur;
          Cur = Cur->peelOuterOrigin())
       if (getLoans(Cur->getOuterOriginID(), UF).contains(TargetLoan))
         return buildOriginFlowChain(UF, Cur->getOuterOriginID(), TargetLoan,
-                                    POV);
+                                    Cfg);
 
     return {};
   }
@@ -276,10 +317,8 @@ private:
 
     for (const Fact *F : llvm::reverse(FactMgr.getFacts(Block))) {
       if (const auto *IF = F->getAs<IssueFact>())
-        if (IF->getLoanID() == TargetLoan) {
-          assert(IF->getOriginID() == CurrOID);
+        if (IF->getLoanID() == TargetLoan && IF->getOriginID() == CurrOID)
           return {OriginFlowChain, true};
-        }
 
       const auto *OFF = F->getAs<OriginFlowFact>();
       if (!OFF)
@@ -327,13 +366,12 @@ LoanSet LoanPropagationAnalysis::getLoans(OriginID OID, ProgramPoint P) const {
 
 llvm::SmallVector<OriginID> LoanPropagationAnalysis::buildOriginFlowChain(
     ProgramPoint StartPoint, const OriginID StartOID, const LoanID TargetLoan,
-    const PostOrderCFGView *POV) const {
-  return PImpl->buildOriginFlowChain(StartPoint, StartOID, TargetLoan, POV);
+    const CFG *Cfg) const {
+  return PImpl->buildOriginFlowChain(StartPoint, StartOID, TargetLoan, Cfg);
 }
 
 llvm::SmallVector<OriginID> LoanPropagationAnalysis::buildOriginFlowChain(
-    const UseFact *UF, const LoanID TargetLoan,
-    const PostOrderCFGView *POV) const {
-  return PImpl->buildOriginFlowChain(UF, TargetLoan, POV);
+    const UseFact *UF, const LoanID TargetLoan, const CFG *Cfg) const {
+  return PImpl->buildOriginFlowChain(UF, TargetLoan, Cfg);
 }
 } // namespace clang::lifetimes::internal

--- a/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
@@ -130,6 +130,11 @@ struct Lattice {
   }
 };
 
+struct BuildOriginFlowChainResult {
+  const llvm::SmallVector<OriginID> OriginFlowChain;
+  const bool Complete;
+};
+
 class AnalysisImpl
     : public DataflowAnalysis<AnalysisImpl, Lattice, Direction::Forward> {
 public:
@@ -204,22 +209,72 @@ public:
 
   llvm::SmallVector<OriginID>
   buildOriginFlowChain(ProgramPoint StartPoint, const OriginID StartOID,
-                       const LoanID TargetLoan) const {
+                       const LoanID TargetLoan,
+                       const PostOrderCFGView *POV) const {
     assert(getLoans(StartOID, StartPoint).contains(TargetLoan) &&
            "TargetLoan must be present in the StartOID at the StartPoint");
 
+    std::optional<OriginID> FinalOID;
+    llvm::DenseMap<OriginID, OriginID> VistedOriginIDs;
+
+    const auto OriginFlowChainFilter = [&VistedOriginIDs](OriginID FinalOID) {
+      llvm::SmallVector<OriginID> OriginFlowChain;
+      while (true) {
+        OriginFlowChain.push_back(FinalOID);
+        const auto NextOriginID = VistedOriginIDs.find(FinalOID);
+        if (NextOriginID == VistedOriginIDs.end())
+          break;
+        FinalOID = NextOriginID->second;
+      }
+      return OriginFlowChain;
+    };
+
+    const auto InsertVistedOriginIDs =
+        [&VistedOriginIDs, &FinalOID](llvm::ArrayRef<OriginID> OriginFlowChain,
+                                      OriginID &StartOID) {
+          if (!VistedOriginIDs.empty())
+            VistedOriginIDs.insert({OriginFlowChain[0], StartOID});
+
+          for (size_t i = 0; i < OriginFlowChain.size() - 1; ++i)
+            VistedOriginIDs.insert(
+                {OriginFlowChain[i + 1], OriginFlowChain[i]});
+
+          StartOID = OriginFlowChain.back();
+          FinalOID = StartOID;
+        };
+
+    std::optional<size_t> BlockID = FactMgr.getBlockID(StartPoint);
+    assert(BlockID.has_value());
+    const auto StartIt = llvm::find_if(*POV, [&BlockID](const CFGBlock *Block) {
+      return Block->getBlockID() == BlockID;
+    });
+
+    OriginID CurrOID = StartOID;
+    for (const CFGBlock *B :
+         llvm::reverse(llvm::make_range(POV->begin(), StartIt + 1))) {
+      BuildOriginFlowChainResult BuildResult =
+          buildOriginFlowChain(B, CurrOID, TargetLoan);
+      if (!BuildResult.OriginFlowChain.empty())
+        InsertVistedOriginIDs(BuildResult.OriginFlowChain, CurrOID);
+      if (BuildResult.Complete)
+        return OriginFlowChainFilter(*FinalOID);
+    }
+
+    llvm_unreachable(
+        "buildOriginFlowChain should return at BuildResult.Complete");
+  }
+
+  BuildOriginFlowChainResult
+  buildOriginFlowChain(const CFGBlock *Block, const OriginID StartOID,
+                       const LoanID TargetLoan) const {
     OriginID CurrOID = StartOID;
     llvm::SmallVector<OriginID> OriginFlowChain;
-    llvm::ArrayRef<const Fact *> Facts = FactMgr.getBlockContaining(StartPoint);
-    const auto *StartIt = llvm::find(Facts, StartPoint);
-    assert(StartIt != Facts.end());
 
-    for (const Fact *F :
-         llvm::reverse(llvm::make_range(Facts.begin(), StartIt))) {
+    for (const Fact *F : llvm::reverse(FactMgr.getFacts(Block))) {
       if (const auto *IF = F->getAs<IssueFact>())
         if (IF->getLoanID() == TargetLoan) {
           assert(IF->getOriginID() == CurrOID);
-          return OriginFlowChain;
+          return {OriginFlowChain, true};
         }
 
       const auto *OFF = F->getAs<OriginFlowFact>();
@@ -235,20 +290,17 @@ public:
       CurrOID = SrcOriginID;
     }
 
-    // FIXME: Ideally, this return is unreachable and should be an assert
-    // because we expect to always finish at an IssueFact. But since current
-    // traversal is limited to a single CFG block, multi-block OriginFlowChain
-    // construction might miss the IssueFact. We should add llvm_unreachable
-    // here once multi-block support is implemented.
-    return {};
+    return {OriginFlowChain, false};
   }
 
   llvm::SmallVector<OriginID>
-  buildOriginFlowChain(const UseFact *UF, const LoanID TargetLoan) const {
+  buildOriginFlowChain(const UseFact *UF, const LoanID TargetLoan,
+                       const PostOrderCFGView *POV) const {
     for (const OriginList *Cur = UF->getUsedOrigins(); Cur;
          Cur = Cur->peelOuterOrigin())
       if (getLoans(Cur->getOuterOriginID(), UF).contains(TargetLoan))
-        return buildOriginFlowChain(UF, Cur->getOuterOriginID(), TargetLoan);
+        return buildOriginFlowChain(UF, Cur->getOuterOriginID(), TargetLoan,
+                                    POV);
 
     return {};
   }
@@ -303,16 +355,15 @@ LoanSet LoanPropagationAnalysis::getLoans(OriginID OID, ProgramPoint P) const {
   return PImpl->getLoans(OID, P);
 }
 
-llvm::SmallVector<OriginID>
-LoanPropagationAnalysis::buildOriginFlowChain(ProgramPoint StartPoint,
-                                              const OriginID StartOID,
-                                              const LoanID TargetLoan) const {
-  return PImpl->buildOriginFlowChain(StartPoint, StartOID, TargetLoan);
+llvm::SmallVector<OriginID> LoanPropagationAnalysis::buildOriginFlowChain(
+    ProgramPoint StartPoint, const OriginID StartOID, const LoanID TargetLoan,
+    const PostOrderCFGView *POV) const {
+  return PImpl->buildOriginFlowChain(StartPoint, StartOID, TargetLoan, POV);
 }
 
-llvm::SmallVector<OriginID>
-LoanPropagationAnalysis::buildOriginFlowChain(const UseFact *UF,
-                                              const LoanID TargetLoan) const {
-  return PImpl->buildOriginFlowChain(UF, TargetLoan);
+llvm::SmallVector<OriginID> LoanPropagationAnalysis::buildOriginFlowChain(
+    const UseFact *UF, const LoanID TargetLoan,
+    const PostOrderCFGView *POV) const {
+  return PImpl->buildOriginFlowChain(UF, TargetLoan, POV);
 }
 } // namespace clang::lifetimes::internal

--- a/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
@@ -293,6 +293,14 @@ private:
     return LoanSetFactory.getEmptySet();
   }
 
+  /// Builds the chain of origins through which a loan has propagated.
+  ///
+  /// This procedure operates strictly within a single Block. Starting from the
+  /// last fact of the Block, it traces backwards through OriginFlowFacts to
+  /// identify the sequence of origins through which the loan flowed.
+  ///
+  /// Returns (chain, true) if the target loan origin is found during the
+  /// traversal, otherwise returns (chain, false).
   std::pair<llvm::SmallVector<OriginID>, bool>
   buildOriginFlowChain(const CFGBlock *Block, const OriginID StartOID,
                        const LoanID TargetLoan) const {

--- a/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
@@ -212,13 +212,13 @@ public:
     llvm::SmallVector<OriginID> OriginFlowChain;
     std::optional<size_t> BlockID = FactMgr.getBlockID(StartPoint);
     assert(BlockID.has_value());
-    const auto StartIt = llvm::find_if(*POV, [&BlockID](const CFGBlock *Block) {
+    const auto EndBlockIt = llvm::find_if(*POV, [&BlockID](const CFGBlock *Block) {
       return Block->getBlockID() == BlockID;
     });
 
     OriginID CurrOID = StartOID;
     for (const CFGBlock *B :
-         llvm::reverse(llvm::make_range(POV->begin(), StartIt + 1))) {
+         llvm::reverse(llvm::make_range(POV->begin(), EndBlockIt + 1))) {
       auto [OFChain, Complete] = buildOriginFlowChain(B, CurrOID, TargetLoan);
 
       if (!OFChain.empty()) {

--- a/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
@@ -210,8 +210,7 @@ public:
            "TargetLoan must be present in the StartOID at the StartPoint");
 
     llvm::SmallVector<OriginID> OriginFlowChain;
-    std::optional<size_t> BlockID = FactMgr.getBlockID(StartPoint);
-    assert(BlockID.has_value());
+    size_t BlockID = FactMgr.getBlockID(StartPoint);
     const auto EndBlockIt =
         llvm::find_if(*POV, [&BlockID](const CFGBlock *Block) {
           return Block->getBlockID() == BlockID;
@@ -232,8 +231,7 @@ public:
     }
 
     llvm_unreachable(
-        "buildOriginFlowChain should return at BuildResult.Complete");
-    return {};
+        "buildOriginFlowChain did not reach IssueFact for TargetLoan");
   }
 
   llvm::SmallVector<OriginID>

--- a/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
@@ -130,11 +130,6 @@ struct Lattice {
   }
 };
 
-struct BuildOriginFlowChainResult {
-  const llvm::SmallVector<OriginID> OriginFlowChain;
-  const bool Complete;
-};
-
 class AnalysisImpl
     : public DataflowAnalysis<AnalysisImpl, Lattice, Direction::Forward> {
 public:
@@ -237,7 +232,7 @@ public:
 
     llvm_unreachable(
         "buildOriginFlowChain should return at BuildResult.Complete");
-    return OriginFlowChain;
+    return {};
   }
 
   llvm::SmallVector<OriginID>
@@ -274,7 +269,7 @@ private:
     return LoanSetFactory.getEmptySet();
   }
 
-  BuildOriginFlowChainResult
+  std::pair<llvm::SmallVector<OriginID>, bool>
   buildOriginFlowChain(const CFGBlock *Block, const OriginID StartOID,
                        const LoanID TargetLoan) const {
     OriginID CurrOID = StartOID;

--- a/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
@@ -18,6 +18,7 @@
 #include "clang/Analysis/CFG.h"
 #include "clang/Basic/LLVM.h"
 #include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/TimeProfiler.h"
 #include "llvm/Support/raw_ostream.h"
@@ -225,14 +226,16 @@ public:
         break;
       }
 
-    OriginID CurrOID = StartOID;
     llvm::SmallVector<OriginID> OriginFlowChain;
-    std::queue<const CFGBlock *> PendingBlocks;
-    PendingBlocks.push(EndBlock);
 
-    while (!PendingBlocks.empty()) {
-      const CFGBlock *CurrBlock = PendingBlocks.front();
-      PendingBlocks.pop();
+    using SearchState = std::pair<const CFGBlock *, OriginID>;
+    std::queue<SearchState> PendingStates;
+    llvm::SmallSet<SearchState, 16> VistedStates;
+    PendingStates.push({EndBlock, StartOID});
+
+    while (!PendingStates.empty()) {
+      auto [CurrBlock, CurrOID] = PendingStates.front();
+      PendingStates.pop();
 
       DEBUG_WITH_TYPE("LifetimeBuildOriginFlow",
                       llvm::dbgs() << "CurrBlockID: " << CurrBlock->getBlockID()
@@ -251,8 +254,11 @@ public:
       DEBUG_WITH_TYPE("LifetimeBuildOriginFlow",
                       llvm::dbgs() << "EndOriginID: " << CurrOID << "\n");
 
-      for (const CFGBlock *Block : CurrBlock->preds())
-        PendingBlocks.push(Block);
+      for (const CFGBlock *Block : CurrBlock->preds()) {
+        SearchState NextState = {Block, CurrOID};
+        if (VistedStates.insert(NextState).second)
+          PendingStates.push(NextState);
+      }
     }
 
     llvm_unreachable(

--- a/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
@@ -210,20 +210,6 @@ public:
     assert(getLoans(StartOID, StartPoint).contains(TargetLoan) &&
            "TargetLoan must be present in the StartOID at the StartPoint");
 
-    const auto ShouldTrack = [&](const CFGBlock *Block, OriginID StartOID) {
-      for (const Fact *F : llvm::reverse(FactMgr.getFacts(Block))) {
-        const auto *OFF = llvm::dyn_cast<OriginFlowFact>(F);
-        if (!OFF)
-          continue;
-        if (OFF->getDestOriginID() == StartOID) {
-          if (getLoans(StartOID, OFF).contains(TargetLoan))
-            return true;
-          return false;
-        }
-      }
-      return true;
-    };
-
     // Locate the CFG block containing the StartPoint
     const CFGBlock *EndBlock = nullptr;
     size_t BlockID = FactMgr.getBlockID(StartPoint);
@@ -251,10 +237,6 @@ public:
       DFSNode CurrNode = PendingStates.pop_back_val();
       auto [CurrBlock, CurrOID] = CurrNode.CurrState;
 
-      DEBUG_WITH_TYPE("LifetimeBuildOriginFlow",
-                      llvm::dbgs() << "CurrBlockID: " << CurrBlock->getBlockID()
-                                   << ", StartOriginID: " << CurrOID << "\n");
-
       // Trace origins within the current block
       const auto [BuildResult, Complete] =
           buildOriginFlowChain(CurrBlock, CurrOID, TargetLoan);
@@ -267,12 +249,9 @@ public:
       if (Complete)
         return CurrNode.OriginFlowChain;
 
-      DEBUG_WITH_TYPE("LifetimeBuildOriginFlow",
-                      llvm::dbgs() << "EndOriginID: " << CurrOID << "\n");
-
       for (const CFGBlock *PredBlock : CurrBlock->preds()) {
         SearchState NextState = {PredBlock, CurrOID};
-        if (ShouldTrack(PredBlock, CurrOID) &&
+        if (getLoans(getOutState(PredBlock), CurrOID).contains(TargetLoan) &&
             VistedStates.insert(NextState).second)
           PendingStates.push_back({NextState, CurrNode.OriginFlowChain});
       }

--- a/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LoanPropagation.cpp
@@ -249,6 +249,8 @@ public:
       if (Complete)
         return CurrNode.OriginFlowChain;
 
+      // Only explore predecessor blocks where the target loan is present in the
+      // current origin.
       for (const CFGBlock *PredBlock : CurrBlock->preds()) {
         SearchState NextState = {PredBlock, CurrOID};
         if (getLoans(getOutState(PredBlock), CurrOID).contains(TargetLoan) &&

--- a/clang/lib/Sema/SemaLifetimeSafety.h
+++ b/clang/lib/Sema/SemaLifetimeSafety.h
@@ -671,7 +671,7 @@ private:
     const Expr *LastExpr = OriginExprChain.back();
     std::string IssueStr = getDiagSubjectDescription(LastExpr);
 
-    for (const Expr *CurrExpr : llvm::reverse(OriginExprChain.drop_back())) {
+    for (const Expr *CurrExpr : reverse(OriginExprChain.drop_back())) {
       if (!shouldShowInAliasChain(CurrExpr, LastExpr))
         continue;
       S.Diag(CurrExpr->getBeginLoc(),

--- a/clang/lib/Sema/SemaLifetimeSafety.h
+++ b/clang/lib/Sema/SemaLifetimeSafety.h
@@ -668,10 +668,10 @@ private:
     if (OriginExprChain.empty())
       return;
 
-    const Expr *LastExpr = OriginExprChain.back();
+    const Expr *LastExpr = OriginExprChain.front();
     std::string IssueStr = getDiagSubjectDescription(LastExpr);
 
-    for (const Expr *CurrExpr : reverse(OriginExprChain.drop_back())) {
+    for (const Expr *CurrExpr : OriginExprChain.drop_front()) {
       if (!shouldShowInAliasChain(CurrExpr, LastExpr))
         continue;
       S.Diag(CurrExpr->getBeginLoc(),

--- a/clang/lib/Sema/SemaLifetimeSafety.h
+++ b/clang/lib/Sema/SemaLifetimeSafety.h
@@ -654,22 +654,22 @@ private:
 
   bool isInValidExpr(const Expr *E) {
     if (const auto *DRE = dyn_cast<DeclRefExpr>(E)) {
-      return !DRE->getDecl()->isImplicit();
+      return DRE->getDecl()->isImplicit();
     }
 
     if (const auto *CE = dyn_cast<CallExpr>(E)) {
       if (const auto *FE = CE->getDirectCallee())
-        return !FE->isImplicit();
+        return FE->isImplicit();
     }
 
-    return false;
+    return true;
   }
 
   bool shouldShowInAliasChain(const Expr *CurrExpr, const Expr *LastExpr) {
     CurrExpr = CurrExpr->IgnoreImpCasts();
     LastExpr = LastExpr->IgnoreImpCasts();
 
-    if (!isInValidExpr(CurrExpr))
+    if (isInValidExpr(CurrExpr))
       return false;
     // Source ranges can be used to filter out many implicit expressions,
     // because operations between class objects often involve numerous implicit

--- a/clang/lib/Sema/SemaLifetimeSafety.h
+++ b/clang/lib/Sema/SemaLifetimeSafety.h
@@ -681,10 +681,10 @@ private:
     if (OriginExprChain.empty())
       return;
 
-    const Expr *LastExpr = OriginExprChain.back();
+    const Expr *LastExpr = OriginExprChain.front();
     std::string IssueStr = getDiagSubjectDescription(LastExpr);
 
-    for (const Expr *CurrExpr : reverse(OriginExprChain.drop_back())) {
+    for (const Expr *CurrExpr : OriginExprChain.drop_front()) {
       if (!shouldShowInAliasChain(CurrExpr, LastExpr))
         continue;
       S.Diag(CurrExpr->getBeginLoc(),

--- a/clang/lib/Sema/SemaLifetimeSafety.h
+++ b/clang/lib/Sema/SemaLifetimeSafety.h
@@ -660,6 +660,7 @@ private:
     if (const auto *CE = dyn_cast<CallExpr>(E)) {
       if (const auto *FE = CE->getDirectCallee())
         return FE->isImplicit();
+      return false;
     }
 
     return true;

--- a/clang/lib/Sema/SemaLifetimeSafety.h
+++ b/clang/lib/Sema/SemaLifetimeSafety.h
@@ -652,11 +652,24 @@ private:
     return "expression";
   }
 
+  bool isInValidExpr(const Expr *E) {
+    if (const auto *DRE = dyn_cast<DeclRefExpr>(E)) {
+      return !DRE->getDecl()->isImplicit();
+    }
+
+    if (const auto *CE = dyn_cast<CallExpr>(E)) {
+      if (const auto *FE = CE->getDirectCallee())
+        return !FE->isImplicit();
+    }
+
+    return false;
+  }
+
   bool shouldShowInAliasChain(const Expr *CurrExpr, const Expr *LastExpr) {
     CurrExpr = CurrExpr->IgnoreImpCasts();
     LastExpr = LastExpr->IgnoreImpCasts();
 
-    if (!isa<CallExpr, DeclRefExpr>(CurrExpr))
+    if (!isInValidExpr(CurrExpr))
       return false;
     // Source ranges can be used to filter out many implicit expressions,
     // because operations between class objects often involve numerous implicit

--- a/clang/lib/Sema/SemaLifetimeSafety.h
+++ b/clang/lib/Sema/SemaLifetimeSafety.h
@@ -668,10 +668,10 @@ private:
     if (OriginExprChain.empty())
       return;
 
-    const Expr *LastExpr = OriginExprChain.front();
+    const Expr *LastExpr = OriginExprChain.back();
     std::string IssueStr = getDiagSubjectDescription(LastExpr);
 
-    for (const Expr *CurrExpr : OriginExprChain.drop_front()) {
+    for (const Expr *CurrExpr : llvm::reverse(OriginExprChain.drop_back())) {
       if (!shouldShowInAliasChain(CurrExpr, LastExpr))
         continue;
       S.Diag(CurrExpr->getBeginLoc(),

--- a/clang/lib/Sema/SemaLifetimeSafety.h
+++ b/clang/lib/Sema/SemaLifetimeSafety.h
@@ -682,10 +682,10 @@ private:
     if (OriginExprChain.empty())
       return;
 
-    const Expr *LastExpr = OriginExprChain.front();
+    const Expr *LastExpr = OriginExprChain.back();
     std::string IssueStr = getDiagSubjectDescription(LastExpr);
 
-    for (const Expr *CurrExpr : OriginExprChain.drop_front()) {
+    for (const Expr *CurrExpr : reverse(OriginExprChain.drop_back())) {
       if (!shouldShowInAliasChain(CurrExpr, LastExpr))
         continue;
       S.Diag(CurrExpr->getBeginLoc(),

--- a/clang/lib/Sema/SemaLifetimeSafety.h
+++ b/clang/lib/Sema/SemaLifetimeSafety.h
@@ -652,7 +652,7 @@ private:
     return "expression";
   }
 
-  bool isInValidExpr(const Expr *E) {
+  bool isInvalidExpr(const Expr *E) {
     if (const auto *DRE = dyn_cast<DeclRefExpr>(E)) {
       return DRE->getDecl()->isImplicit();
     }
@@ -669,7 +669,7 @@ private:
     CurrExpr = CurrExpr->IgnoreImpCasts();
     LastExpr = LastExpr->IgnoreImpCasts();
 
-    if (isInValidExpr(CurrExpr))
+    if (isInvalidExpr(CurrExpr))
       return false;
     // Source ranges can be used to filter out many implicit expressions,
     // because operations between class objects often involve numerous implicit

--- a/clang/lib/Sema/SemaLifetimeSafety.h
+++ b/clang/lib/Sema/SemaLifetimeSafety.h
@@ -652,25 +652,11 @@ private:
     return "expression";
   }
 
-  bool isInvalidExpr(const Expr *E) {
-    if (const auto *DRE = dyn_cast<DeclRefExpr>(E)) {
-      return DRE->getDecl()->isImplicit();
-    }
-
-    if (const auto *CE = dyn_cast<CallExpr>(E)) {
-      if (const auto *FE = CE->getDirectCallee())
-        return FE->isImplicit();
-      return false;
-    }
-
-    return true;
-  }
-
   bool shouldShowInAliasChain(const Expr *CurrExpr, const Expr *LastExpr) {
     CurrExpr = CurrExpr->IgnoreImpCasts();
     LastExpr = LastExpr->IgnoreImpCasts();
 
-    if (isInvalidExpr(CurrExpr))
+    if (!isa<CallExpr, DeclRefExpr>(CurrExpr))
       return false;
     // Source ranges can be used to filter out many implicit expressions,
     // because operations between class objects often involve numerous implicit

--- a/clang/test/Sema/LifetimeSafety/safety-c.c
+++ b/clang/test/Sema/LifetimeSafety/safety-c.c
@@ -93,7 +93,9 @@ void conditional_operator_lifetimebound(int cond) {
   int *p;
   {
     int a, b;
-    p = identity(cond ? &a    // expected-warning {{local variable 'a' does not live long enough}}
+    p = identity(cond ? &a    // expected-warning {{local variable 'a' does not live long enough}} \
+                              // expected-note {{result of call to 'identity' aliases the storage of local variable 'a'}} \
+                              // expected-note {{result of call to 'identity' aliases the storage of local variable 'b'}}
                       : &b);  // expected-warning {{local variable 'b' does not live long enough}}
   }                           // expected-note {{local variable 'a' is destroyed here}} \
                               // expected-note {{local variable 'b' is destroyed here}}

--- a/clang/test/Sema/LifetimeSafety/safety.cpp
+++ b/clang/test/Sema/LifetimeSafety/safety.cpp
@@ -4114,33 +4114,6 @@ void test_loop_cond_bind(bool cond) {
 // buildOriginFlowChain
 //===----------------------------------------------------------------------===//
 
-#define BRANCH(con) \
-  if (con) {} else {}
-
-#define BRANCH10(con) \
-  BRANCH(con); \
-  BRANCH(con); \
-  BRANCH(con); \
-  BRANCH(con); \
-  BRANCH(con); \
-  BRANCH(con); \
-  BRANCH(con); \
-  BRANCH(con); \
-  BRANCH(con); \
-  BRANCH(con)
-
-#define BRANCH100(con) \
-  BRANCH10(con); \
-  BRANCH10(con); \
-  BRANCH10(con); \
-  BRANCH10(con); \
-  BRANCH10(con); \
-  BRANCH10(con); \
-  BRANCH10(con); \
-  BRANCH10(con); \
-  BRANCH10(con); \
-  BRANCH10(con)
-
 void used_variable_reassigned() {
   View p, q, r;
   {
@@ -4178,6 +4151,33 @@ void multi_reassigned(bool condition) {
 
   p1.use();  // expected-note {{later used here}}
 }
+
+#define BRANCH(con) \
+  if (con) {} else {}
+
+#define BRANCH10(con) \
+  BRANCH(con); \
+  BRANCH(con); \
+  BRANCH(con); \
+  BRANCH(con); \
+  BRANCH(con); \
+  BRANCH(con); \
+  BRANCH(con); \
+  BRANCH(con); \
+  BRANCH(con); \
+  BRANCH(con)
+
+#define BRANCH100(con) \
+  BRANCH10(con); \
+  BRANCH10(con); \
+  BRANCH10(con); \
+  BRANCH10(con); \
+  BRANCH10(con); \
+  BRANCH10(con); \
+  BRANCH10(con); \
+  BRANCH10(con); \
+  BRANCH10(con); \
+  BRANCH10(con)
 
 void test_exponential_paths(bool c) {
   View v;

--- a/clang/test/Sema/LifetimeSafety/safety.cpp
+++ b/clang/test/Sema/LifetimeSafety/safety.cpp
@@ -236,7 +236,7 @@ void overrides_potential(bool cond) {
   {
     MyObj s;
     q = &s;       // expected-warning {{does not live long enough}}
-    p = q;
+    p = q;        // expected-note {{local variable 'q' aliases the storage of local variable 's'}}
   }               // expected-note {{local variable 's' is destroyed here}}
 
   if (cond) {
@@ -1236,8 +1236,11 @@ void conditional_operator_lifetimebound_nested(bool cond) {
   MyObj* p;
   {
     MyObj a, b;
-    p = Identity(cond ? Identity(&a)    // expected-warning {{local variable 'a' does not live long enough}}
-                      : Identity(&b));  // expected-warning {{local variable 'b' does not live long enough}}
+    p = Identity(cond ? Identity(&a)    // expected-warning {{local variable 'a' does not live long enough}} \
+                                        // expected-note 2 {{result of call to 'Identity' aliases the storage of local variable 'a'}} \
+                                        // expected-note {{result of call to 'Identity' aliases the storage of local variable 'b'}}
+                      : Identity(&b));  // expected-warning {{local variable 'b' does not live long enough}} \
+                                        // expected-note {{result of call to 'Identity' aliases the storage of local variable 'b'}}
   }  // expected-note {{local variable 'b' is destroyed here}} expected-note {{local variable 'a' is destroyed here}}
   (void)*p;  // expected-note 2 {{later used here}}
 }
@@ -2735,8 +2738,7 @@ void chained_defaulted_assignment_propagation() {
     std::string str{"abc"};
     S a = getS(str); // expected-warning {{local variable 'str' does not live long enough}} \
                      // expected-note {{result of call to 'getS' aliases the storage of local variable 'str'}}
-    c = b = a;       // expected-note {{local variable 'a' aliases the storage of local variable 'str'}}\
-                     // expected-note {{expression aliases the storage of local variable 'str'}}
+    c = b = a;       // expected-note {{local variable 'a' aliases the storage of local variable 'str'}}
   }                  // expected-note {{local variable 'str' is destroyed here}}
   use(c);            // expected-note {{later used here}}
 }

--- a/clang/test/Sema/LifetimeSafety/safety.cpp
+++ b/clang/test/Sema/LifetimeSafety/safety.cpp
@@ -4094,9 +4094,52 @@ View suggestion_disabled_test(View a) {
   return a;
 }
 
+// Test case for false positive involving conditional operator in a loop.
+struct LoopCondBindS {
+  int* get() const [[clang::lifetimebound]];
+};
+void consume_loop_cond_bind(int*);
+void test_loop_cond_bind(bool cond) {
+  for (int i = 0; i < 2; i++) {
+    LoopCondBindS s;
+    consume_loop_cond_bind(cond ? s.get() : nullptr); // no-warning
+  }
+  for (int i = 0; i < 2; i++) {
+    int x, y;
+    consume_loop_cond_bind(cond ? &x : &y); // no-warning
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // buildOriginFlowChain
 //===----------------------------------------------------------------------===//
+
+#define BRANCH(con) \
+  if (con) {} else {}
+
+#define BRANCH10(con) \
+  BRANCH(con); \
+  BRANCH(con); \
+  BRANCH(con); \
+  BRANCH(con); \
+  BRANCH(con); \
+  BRANCH(con); \
+  BRANCH(con); \
+  BRANCH(con); \
+  BRANCH(con); \
+  BRANCH(con)
+
+#define BRANCH100(con) \
+  BRANCH10(con); \
+  BRANCH10(con); \
+  BRANCH10(con); \
+  BRANCH10(con); \
+  BRANCH10(con); \
+  BRANCH10(con); \
+  BRANCH10(con); \
+  BRANCH10(con); \
+  BRANCH10(con); \
+  BRANCH10(con)
 
 void used_variable_reassigned() {
   View p, q, r;
@@ -4136,18 +4179,46 @@ void multi_reassigned(bool condition) {
   p1.use();  // expected-note {{later used here}}
 }
 
-// Test case for false positive involving conditional operator in a loop.
-struct LoopCondBindS {
-  int* get() const [[clang::lifetimebound]];
-};
-void consume_loop_cond_bind(int*);
-void test_loop_cond_bind(bool cond) {
-  for (int i = 0; i < 2; i++) {
-    LoopCondBindS s;
-    consume_loop_cond_bind(cond ? s.get() : nullptr); // no-warning
-  }
-  for (int i = 0; i < 2; i++) {
-    int x, y;
-    consume_loop_cond_bind(cond ? &x : &y); // no-warning
-  }
+void test_exponential_paths(bool c) {
+  View v;
+  {
+    MyObj a;
+    View p = a;  // expected-warning{{local variable 'a' does not live long enough}}
+    BRANCH100(c);
+    v = p;  // expected-note {{local variable 'p' aliases the storage of local variable 'a'}}
+  }         // expected-note {{local variable 'a' is destroyed here}}
+  v.use();  // expected-note {{later used here}}
+}
+
+void test_multiple_paths(bool cond) {
+  View v;
+  {
+    MyObj a;
+    View p1, p2, p3;
+    p1 = a;     // expected-warning {{local variable 'a' does not live long enough}}
+    p2 = p1;
+    if (cond) {
+      p3 = p1;  // expected-note {{local variable 'p1' aliases the storage of local variable 'a'}}
+    } else {
+      p3 = p2;
+    }
+
+    v = p3; // expected-note {{local variable 'p3' aliases the storage of local variable 'a'}}
+  }         // expected-note {{local variable 'a' is destroyed here}}
+  v.use();  // expected-note {{later used here}}
+}
+
+void test_cyclic_cfg(int n) {
+  View v;
+  {
+    MyObj a;
+    View p;
+    p = a;  // expected-warning {{local variable 'a' does not live long enough}}
+    while (n > 0) {
+      p = p;
+      n--;
+    }
+    v = p;  // expected-note {{local variable 'p' aliases the storage of local variable 'a'}}
+  }         // expected-note {{local variable 'a' is destroyed here}}
+  v.use();  // expected-note {{later used here}}
 }

--- a/clang/test/Sema/LifetimeSafety/safety.cpp
+++ b/clang/test/Sema/LifetimeSafety/safety.cpp
@@ -1549,7 +1549,7 @@ void range_based_for_use_after_scope() {
   {
     MyObjStorage s;
     for (const MyObj &o : s) { // expected-warning {{local variable 's' does not live long enough}} \
-                               // expected-note {{local variable '__range2' aliases the storage of local variable 's'}}
+                               // expected-note {{result of call to 'begin' aliases the storage of local variable 's'}}
       v = o;
     }
   } // expected-note {{local variable 's' is destroyed here}}

--- a/clang/test/Sema/LifetimeSafety/safety.cpp
+++ b/clang/test/Sema/LifetimeSafety/safety.cpp
@@ -4092,6 +4092,7 @@ void discarded_body_local() {
 // Since it is off, we expect NO warnings or notes here.
 View suggestion_disabled_test(View a) {
   return a;
+}
 
 //===----------------------------------------------------------------------===//
 // buildOriginFlowChain

--- a/clang/test/Sema/LifetimeSafety/safety.cpp
+++ b/clang/test/Sema/LifetimeSafety/safety.cpp
@@ -855,6 +855,18 @@ void lifetimebound_multiple_args_potential(bool cond) {
   v.use();                         // expected-note 2 {{later used here}}
 }
 
+// FIXME: Detect this.
+void func_pointer() {
+  View p;
+  View (*func_ptr)(View v [[clang::lifetimebound]]);
+  {
+   MyObj s;
+   View a = Identity(s);
+   p = func_ptr(a);
+  }
+  p.use();
+}
+
 View SelectFirst(View a [[clang::lifetimebound]], View b);
 void lifetimebound_mixed_args() {
   View v;

--- a/clang/test/Sema/LifetimeSafety/safety.cpp
+++ b/clang/test/Sema/LifetimeSafety/safety.cpp
@@ -448,7 +448,7 @@ void loan_from_previous_iteration(MyObj safe, bool condition) {
     p = &x;     // expected-warning {{does not live long enough}}
 
     if (condition)
-      q = p;
+      q = p;    // expected-note {{local variable 'p' aliases the storage of local variable 'x'}}
     (void)*p;
     (void)*q;   // expected-note {{later used here}}
   }             // expected-note {{local variable 'x' is destroyed here}}
@@ -846,7 +846,8 @@ void lifetimebound_multiple_args_potential(bool cond) {
     MyObj obj1;
     if (cond) {
       MyObj obj2;
-      v = Choose(true,
+      v = Choose(true,             // expected-note {{result of call to 'Choose' aliases the storage of local variable 'obj1'}} \
+                                   // expected-note {{result of call to 'Choose' aliases the storage of local variable 'obj2'}}
                  obj1,             // expected-warning {{local variable 'obj1' does not live long enough}}
                  obj2);            // expected-warning {{local variable 'obj2' does not live long enough}}
     }                              // expected-note {{local variable 'obj2' is destroyed here}}
@@ -940,7 +941,7 @@ void lifetimebound_partial_safety(bool cond) {
   
   if (cond) {
     MyObj temp_obj;
-    v = Choose(true, 
+    v = Choose(true,      // expected-note {{result of call to 'Choose' aliases the storage of local variable 'temp_obj'}}
                safe_obj,
                temp_obj); // expected-warning {{local variable 'temp_obj' does not live long enough}}
   }                       // expected-note {{local variable 'temp_obj' is destroyed here}}
@@ -1223,7 +1224,9 @@ void conditional_operator_lifetimebound(bool cond) {
   MyObj* p;
   {
     MyObj a, b;
-    p = Identity(cond ? &a    // expected-warning {{local variable 'a' does not live long enough}}
+    p = Identity(cond ? &a    // expected-warning {{local variable 'a' does not live long enough}} \
+                              // expected-note {{result of call to 'Identity' aliases the storage of local variable 'a'}} \
+                              // expected-note {{result of call to 'Identity' aliases the storage of local variable 'b'}}
                       : &b);  // expected-warning {{local variable 'b' does not live long enough}}
   }  // expected-note {{local variable 'b' is destroyed here}} expected-note {{local variable 'a' is destroyed here}}
   (void)*p;  // expected-note 2 {{later used here}}
@@ -1243,9 +1246,15 @@ void conditional_operator_lifetimebound_nested_deep(bool cond) {
   MyObj* p;
   {
     MyObj a, b, c, d;
-    p = Identity(cond ? Identity(cond ? &a     // expected-warning {{local variable 'a' does not live long enough}}
+    p = Identity(cond ? Identity(cond ? &a     // expected-warning {{local variable 'a' does not live long enough}} \
+                                               // expected-note 2 {{result of call to 'Identity' aliases the storage of local variable 'a'}} \
+                                               // expected-note 2 {{result of call to 'Identity' aliases the storage of local variable 'b'}} \
+                                               // expected-note {{result of call to 'Identity' aliases the storage of local variable 'c'}} \
+                                               // expected-note {{result of call to 'Identity' aliases the storage of local variable 'd'}}
                                       : &b)    // expected-warning {{local variable 'b' does not live long enough}}
-                      : Identity(cond ? &c     // expected-warning {{local variable 'c' does not live long enough}}
+                      : Identity(cond ? &c     // expected-warning {{local variable 'c' does not live long enough}} \
+                                               // expected-note {{result of call to 'Identity' aliases the storage of local variable 'c'}} \
+                                               // expected-note {{result of call to 'Identity' aliases the storage of local variable 'd'}}
                                       : &d));  // expected-warning {{local variable 'd' does not live long enough}}
   }  // expected-note {{local variable 'a' is destroyed here}} expected-note {{local variable 'd' is destroyed here}} expected-note {{local variable 'b' is destroyed here}} expected-note {{local variable 'c' is destroyed here}}
   (void)*p;  // expected-note 4 {{later used here}}
@@ -1539,7 +1548,8 @@ void range_based_for_use_after_scope() {
   View v;
   {
     MyObjStorage s;
-    for (const MyObj &o : s) { // expected-warning {{local variable 's' does not live long enough}}
+    for (const MyObj &o : s) { // expected-warning {{local variable 's' does not live long enough}} \
+                               // expected-note {{local variable '__range2' aliases the storage of local variable 's'}}
       v = o;
     }
   } // expected-note {{local variable 's' is destroyed here}}

--- a/clang/test/Sema/LifetimeSafety/safety.cpp
+++ b/clang/test/Sema/LifetimeSafety/safety.cpp
@@ -4078,6 +4078,47 @@ void discarded_body_local() {
 // Since it is off, we expect NO warnings or notes here.
 View suggestion_disabled_test(View a) {
   return a;
+
+//===----------------------------------------------------------------------===//
+// buildOriginFlowChain
+//===----------------------------------------------------------------------===//
+
+void used_variable_reassigned() {
+  View p, q, r;
+  {
+    MyObj a;
+    p = a; // expected-warning {{local variable 'a' does not live long enough}}
+    q = p; // expected-note {{local variable 'p' aliases the storage of local variable 'a'}}
+    r = q; // expected-note {{local variable 'q' aliases the storage of local variable 'a'}}
+  }        // expected-note {{destroyed here}}
+  r.use(); // expected-note {{later used here}}
+
+  MyObj b;
+  r = b;
+  r.use();
+}
+
+void multi_reassigned(bool condition) {
+  MyObj v1, v2, v3;
+  View p1, p2, p3, p4;
+  {
+    MyObj v4;
+
+    p1 = v1;
+    p2 = v2;
+    p3 = v3;
+    p4 = v4;    // expected-warning {{local variable 'v4' does not live long enough}}
+
+    while (condition) {
+      View temp = p1;
+      p1 = p2;  // expected-note {{local variable 'p2' aliases the storage of local variable 'v4'}}
+      p2 = p3;  // expected-note {{local variable 'p3' aliases the storage of local variable 'v4'}}
+      p3 = p4;  // expected-note {{local variable 'p4' aliases the storage of local variable 'v4'}}
+      p4 = temp;
+    }
+  }  // expected-note {{destroyed here}}
+
+  p1.use();  // expected-note {{later used here}}
 }
 
 // Test case for false positive involving conditional operator in a loop.

--- a/clang/test/Sema/LifetimeSafety/safety.cpp
+++ b/clang/test/Sema/LifetimeSafety/safety.cpp
@@ -1564,7 +1564,7 @@ void range_based_for_use_after_scope() {
   {
     MyObjStorage s;
     for (const MyObj &o : s) { // expected-warning {{local variable 's' does not live long enough}} \
-                               // expected-note {{result of call to 'begin' aliases the storage of local variable 's'}}
+                               // expected-note {{local variable '__range2' aliases the storage of local variable 's'}}
       v = o;
     }
   } // expected-note {{local variable 's' is destroyed here}}
@@ -2750,7 +2750,8 @@ void chained_defaulted_assignment_propagation() {
     std::string str{"abc"};
     S a = getS(str); // expected-warning {{local variable 'str' does not live long enough}} \
                      // expected-note {{result of call to 'getS' aliases the storage of local variable 'str'}}
-    c = b = a;       // expected-note {{local variable 'a' aliases the storage of local variable 'str'}}
+    c = b = a;       // expected-note {{local variable 'a' aliases the storage of local variable 'str'}} \
+                     // expected-note {{expression aliases the storage of local variable 'str'}}
   }                  // expected-note {{local variable 'str' is destroyed here}}
   use(c);            // expected-note {{later used here}}
 }

--- a/clang/unittests/Analysis/LifetimeSafetyTest.cpp
+++ b/clang/unittests/Analysis/LifetimeSafetyTest.cpp
@@ -2078,5 +2078,49 @@ TEST_F(LifetimeAnalysisTest, BuildOriginFlowChainWithLifetimeBound) {
   EXPECT_THAT(ChainForTgtB, Contains(*Helper->getOriginForDecl("result")));
   EXPECT_THAT(ChainForTgtB, Not(Contains(*Helper->getOriginForDecl("a"))));
 }
+
+TEST_F(LifetimeAnalysisTest, BuildOriginFlowChainInMultiBlock) {
+  SetupTest(R"(
+    void target(bool c1, bool c2) {
+      int *s;
+      int *a, *b, *c;
+
+      {
+        int tgta, tgtb, tgtc;
+        a = &tgta;
+        b = &tgtb;
+        c = &tgtc;
+      }
+
+      if (c1) {
+        s = c2 ? a : b;
+      } else {
+        s = c;
+      }
+
+      POINT(after_nested_merge);
+      (void)*s;
+    }
+  )");
+
+  llvm::SmallVector<OriginID> ChainForTgtA =
+      Helper->buildOriginFlowChainInOneBlock("s", "tgta", "after_nested_merge");
+  llvm::SmallVector<OriginID> ChainForTgtB =
+      Helper->buildOriginFlowChainInOneBlock("s", "tgtb", "after_nested_merge");
+  llvm::SmallVector<OriginID> ChainForTgtC =
+      Helper->buildOriginFlowChainInOneBlock("s", "tgtc", "after_nested_merge");
+
+  EXPECT_THAT(ChainForTgtA, Contains(*Helper->getOriginForDecl("a")));
+  EXPECT_THAT(ChainForTgtA, Not(Contains(*Helper->getOriginForDecl("b"))));
+  EXPECT_THAT(ChainForTgtA, Not(Contains(*Helper->getOriginForDecl("c"))));
+
+  EXPECT_THAT(ChainForTgtB, Contains(*Helper->getOriginForDecl("b")));
+  EXPECT_THAT(ChainForTgtB, Not(Contains(*Helper->getOriginForDecl("a"))));
+  EXPECT_THAT(ChainForTgtB, Not(Contains(*Helper->getOriginForDecl("c"))));
+
+  EXPECT_THAT(ChainForTgtC, Contains(*Helper->getOriginForDecl("c")));
+  EXPECT_THAT(ChainForTgtC, Not(Contains(*Helper->getOriginForDecl("b"))));
+  EXPECT_THAT(ChainForTgtC, Not(Contains(*Helper->getOriginForDecl("a"))));
+}
 } // anonymous namespace
 } // namespace clang::lifetimes::internal

--- a/clang/unittests/Analysis/LifetimeSafetyTest.cpp
+++ b/clang/unittests/Analysis/LifetimeSafetyTest.cpp
@@ -1996,6 +1996,8 @@ TEST_F(LifetimeAnalysisTest, BuildOriginFlowChain) {
 
       POINT(after_nested_merge);
       (void)*s;
+      int reset;
+      s = &reset;
     }
   )");
 

--- a/clang/unittests/Analysis/LifetimeSafetyTest.cpp
+++ b/clang/unittests/Analysis/LifetimeSafetyTest.cpp
@@ -206,9 +206,8 @@ public:
   }
 
   llvm::SmallVector<OriginID>
-  buildOriginFlowChainInOneBlock(llvm::StringRef StartOriginVar,
-                                 llvm::StringRef EndLoanVar,
-                                 llvm::StringRef Annotation) {
+  buildOriginFlowChain(llvm::StringRef StartOriginVar,
+                       llvm::StringRef EndLoanVar, llvm::StringRef Annotation) {
     std::optional<OriginID> StartOriginID = getOriginForDecl(StartOriginVar);
     std::vector<LoanID> EndLoanIDs = getLoansForVar(EndLoanVar);
 
@@ -216,7 +215,7 @@ public:
       llvm::SmallVector<OriginID> OriginFlowChain =
           Runner.getAnalysis().getLoanPropagation().buildOriginFlowChain(
               getProgramPoint(Annotation), *StartOriginID, LID,
-              Runner.getAnalysisContext().getAnalysis<PostOrderCFGView>());
+              Runner.getAnalysisContext().getCFG());
       if (!OriginFlowChain.empty())
         return OriginFlowChain;
     }
@@ -1976,110 +1975,7 @@ TEST_F(LifetimeAnalysisTest, LambdaInitCaptureViewByValue) {
 //                    Tests for buildOriginFlowChain
 // ========================================================================= //
 
-TEST_F(LifetimeAnalysisTest, BuildOriginFlowChainWithErrorTargetLoan) {
-  SetupTest(R"(
-    void target() {
-      int tgt = 2;
-      int *a = &tgt;
-      int *s = a;
-      POINT(after_use);
-    }
-  )");
-
-#if !defined(NDEBUG) && GTEST_HAS_DEATH_TEST
-  EXPECT_DEATH(Helper->buildOriginFlowChainInOneBlock("s", "a", "after_use"),
-               "TargetLoan must be present in the StartOID at the StartPoint");
-#endif
-}
-
-TEST_F(LifetimeAnalysisTest, BuildOriginFlowChainWithSelfAssignment) {
-  SetupTest(R"(
-    void target() {
-      int tgt = 2;
-      int *a = &tgt;
-      int *b = a;
-      a = b;
-      a = a;
-      int *s = a;
-      POINT(after_use);
-    }
-  )");
-
-  const llvm::SmallVector<OriginID> OriginFlowChain =
-      Helper->buildOriginFlowChainInOneBlock("s", "tgt", "after_use");
-
-  EXPECT_THAT(OriginFlowChain, Contains(*Helper->getOriginForDecl("a")));
-}
-
-TEST_F(LifetimeAnalysisTest, BuildOriginFlowChainWithMultiAssignInSameStmt) {
-  SetupTest(R"(
-    void target() {
-      int tgt = 2;
-      int *a, *b, *c;
-      a = b = c = &tgt;
-      int *s = a;
-      POINT(after_use);
-    }
-  )");
-
-  const llvm::SmallVector<OriginID> OriginFlowChain =
-      Helper->buildOriginFlowChainInOneBlock("s", "tgt", "after_use");
-
-  EXPECT_THAT(OriginFlowChain, Contains(*Helper->getOriginForDecl("a")));
-  EXPECT_THAT(OriginFlowChain, Contains(*Helper->getOriginForDecl("b")));
-  EXPECT_THAT(OriginFlowChain, Contains(*Helper->getOriginForDecl("c")));
-}
-
-TEST_F(LifetimeAnalysisTest, BuildOriginFlowChainWithOverwritingAssignments) {
-  SetupTest(R"(
-    void target() {
-      int tgt1 = 1, tgt2 = 2;
-      int *a = &tgt1;
-      int *b = a;
-      int *c = b;
-      b = &tgt2;
-      int *s = c;
-      POINT(after_use);
-    }
-  )");
-
-  const llvm::SmallVector<OriginID> OriginFlowChain =
-      Helper->buildOriginFlowChainInOneBlock("s", "tgt1", "after_use");
-
-  EXPECT_THAT(OriginFlowChain, Contains(*Helper->getOriginForDecl("a")));
-  EXPECT_THAT(OriginFlowChain, Contains(*Helper->getOriginForDecl("b")));
-  EXPECT_THAT(OriginFlowChain, Contains(*Helper->getOriginForDecl("c")));
-}
-
-TEST_F(LifetimeAnalysisTest, BuildOriginFlowChainWithLifetimeBound) {
-  SetupTest(R"(
-    int* choose(int* a [[clang::lifetimebound]], int* b  [[clang::lifetimebound]]);
-    void target() {
-      int tgta = 1, tgtb = 2;
-      int *a = &tgta;
-      int *b = &tgtb;
-      int *result = choose(a, b);
-      result = choose(result , result);
-      int *s = result;
-      POINT(after_use);
-    }
-  )");
-
-  llvm::SmallVector<OriginID> ChainForTgtA =
-      Helper->buildOriginFlowChainInOneBlock("s", "tgta", "after_use");
-  llvm::SmallVector<OriginID> ChainForTgtB =
-      Helper->buildOriginFlowChainInOneBlock("s", "tgtb", "after_use");
-
-  EXPECT_THAT(ChainForTgtA, Contains(*Helper->getOriginForDecl("a")));
-  EXPECT_THAT(ChainForTgtA, Contains(*Helper->getOriginForDecl("result")));
-  EXPECT_THAT(ChainForTgtA, Not(Contains(*Helper->getOriginForDecl("b"))));
-
-  EXPECT_THAT(ChainForTgtB, Contains(*Helper->getOriginForDecl("b")));
-  EXPECT_THAT(ChainForTgtB, Contains(*Helper->getOriginForDecl("result")));
-  EXPECT_THAT(ChainForTgtB, Not(Contains(*Helper->getOriginForDecl("a"))));
-}
-
-TEST_F(LifetimeAnalysisTest, BuildOriginFlowChainInMultiBlock) {
+TEST_F(LifetimeAnalysisTest, BuildOriginFlowChain) {
   SetupTest(R"(
     void target(bool c1, bool c2) {
       int *s;
@@ -2104,23 +2000,126 @@ TEST_F(LifetimeAnalysisTest, BuildOriginFlowChainInMultiBlock) {
   )");
 
   llvm::SmallVector<OriginID> ChainForTgtA =
-      Helper->buildOriginFlowChainInOneBlock("s", "tgta", "after_nested_merge");
+      Helper->buildOriginFlowChain("s", "tgta", "after_nested_merge");
   llvm::SmallVector<OriginID> ChainForTgtB =
-      Helper->buildOriginFlowChainInOneBlock("s", "tgtb", "after_nested_merge");
+      Helper->buildOriginFlowChain("s", "tgtb", "after_nested_merge");
   llvm::SmallVector<OriginID> ChainForTgtC =
-      Helper->buildOriginFlowChainInOneBlock("s", "tgtc", "after_nested_merge");
+      Helper->buildOriginFlowChain("s", "tgtc", "after_nested_merge");
 
   EXPECT_THAT(ChainForTgtA, Contains(*Helper->getOriginForDecl("a")));
   EXPECT_THAT(ChainForTgtA, Not(Contains(*Helper->getOriginForDecl("b"))));
   EXPECT_THAT(ChainForTgtA, Not(Contains(*Helper->getOriginForDecl("c"))));
 
-  EXPECT_THAT(ChainForTgtB, Contains(*Helper->getOriginForDecl("b")));
   EXPECT_THAT(ChainForTgtB, Not(Contains(*Helper->getOriginForDecl("a"))));
+  EXPECT_THAT(ChainForTgtB, Contains(*Helper->getOriginForDecl("b")));
   EXPECT_THAT(ChainForTgtB, Not(Contains(*Helper->getOriginForDecl("c"))));
 
-  EXPECT_THAT(ChainForTgtC, Contains(*Helper->getOriginForDecl("c")));
-  EXPECT_THAT(ChainForTgtC, Not(Contains(*Helper->getOriginForDecl("b"))));
   EXPECT_THAT(ChainForTgtC, Not(Contains(*Helper->getOriginForDecl("a"))));
+  EXPECT_THAT(ChainForTgtC, Not(Contains(*Helper->getOriginForDecl("b"))));
+  EXPECT_THAT(ChainForTgtC, Contains(*Helper->getOriginForDecl("c")));
+}
+
+TEST_F(LifetimeAnalysisTest, BuildOriginFlowChainWithErrorTargetLoan) {
+  SetupTest(R"(
+    void target() {
+      int tgt = 2;
+      int *a = &tgt;
+      int *s = a;
+      POINT(after_use);
+    }
+  )");
+
+#if !defined(NDEBUG) && GTEST_HAS_DEATH_TEST
+  EXPECT_DEATH(Helper->buildOriginFlowChain("s", "a", "after_use"),
+               "TargetLoan must be present in the StartOID at the StartPoint");
+#endif
+}
+
+TEST_F(LifetimeAnalysisTest, BuildOriginFlowChainWithSelfAssignment) {
+  SetupTest(R"(
+    void target() {
+      int tgt = 2;
+      int *a = &tgt;
+      int *b = a;
+      a = b;
+      a = a;
+      int *s = a;
+      POINT(after_use);
+    }
+  )");
+
+  const llvm::SmallVector<OriginID> OriginFlowChain =
+      Helper->buildOriginFlowChain("s", "tgt", "after_use");
+
+  EXPECT_THAT(OriginFlowChain, Contains(*Helper->getOriginForDecl("a")));
+}
+
+TEST_F(LifetimeAnalysisTest, BuildOriginFlowChainWithMultiAssignInSameStmt) {
+  SetupTest(R"(
+    void target() {
+      int tgt = 2;
+      int *a, *b, *c;
+      a = b = c = &tgt;
+      int *s = a;
+      POINT(after_use);
+    }
+  )");
+
+  const llvm::SmallVector<OriginID> OriginFlowChain =
+      Helper->buildOriginFlowChain("s", "tgt", "after_use");
+
+  EXPECT_THAT(OriginFlowChain, Contains(*Helper->getOriginForDecl("a")));
+  EXPECT_THAT(OriginFlowChain, Contains(*Helper->getOriginForDecl("b")));
+  EXPECT_THAT(OriginFlowChain, Contains(*Helper->getOriginForDecl("c")));
+}
+
+TEST_F(LifetimeAnalysisTest, BuildOriginFlowChainWithOverwritingAssignments) {
+  SetupTest(R"(
+    void target() {
+      int tgt1 = 1, tgt2 = 2;
+      int *a = &tgt1;
+      int *b = a;
+      int *c = b;
+      b = &tgt2;
+      int *s = c;
+      POINT(after_use);
+    }
+  )");
+
+  const llvm::SmallVector<OriginID> OriginFlowChain =
+      Helper->buildOriginFlowChain("s", "tgt1", "after_use");
+
+  EXPECT_THAT(OriginFlowChain, Contains(*Helper->getOriginForDecl("a")));
+  EXPECT_THAT(OriginFlowChain, Contains(*Helper->getOriginForDecl("b")));
+  EXPECT_THAT(OriginFlowChain, Contains(*Helper->getOriginForDecl("c")));
+}
+
+TEST_F(LifetimeAnalysisTest, BuildOriginFlowChainWithLifetimeBound) {
+  SetupTest(R"(
+    int* choose(int* a [[clang::lifetimebound]], int* b  [[clang::lifetimebound]]);
+    void target() {
+      int tgta = 1, tgtb = 2;
+      int *a = &tgta;
+      int *b = &tgtb;
+      int *result = choose(a, b);
+      result = choose(result , result);
+      int *s = result;
+      POINT(after_use);
+    }
+  )");
+
+  llvm::SmallVector<OriginID> ChainForTgtA =
+      Helper->buildOriginFlowChain("s", "tgta", "after_use");
+  llvm::SmallVector<OriginID> ChainForTgtB =
+      Helper->buildOriginFlowChain("s", "tgtb", "after_use");
+
+  EXPECT_THAT(ChainForTgtA, Contains(*Helper->getOriginForDecl("a")));
+  EXPECT_THAT(ChainForTgtA, Contains(*Helper->getOriginForDecl("result")));
+  EXPECT_THAT(ChainForTgtA, Not(Contains(*Helper->getOriginForDecl("b"))));
+
+  EXPECT_THAT(ChainForTgtB, Contains(*Helper->getOriginForDecl("b")));
+  EXPECT_THAT(ChainForTgtB, Contains(*Helper->getOriginForDecl("result")));
+  EXPECT_THAT(ChainForTgtB, Not(Contains(*Helper->getOriginForDecl("a"))));
 }
 } // anonymous namespace
 } // namespace clang::lifetimes::internal

--- a/clang/unittests/Analysis/LifetimeSafetyTest.cpp
+++ b/clang/unittests/Analysis/LifetimeSafetyTest.cpp
@@ -215,7 +215,8 @@ public:
     for (LoanID LID : EndLoanIDs) {
       llvm::SmallVector<OriginID> OriginFlowChain =
           Runner.getAnalysis().getLoanPropagation().buildOriginFlowChain(
-              getProgramPoint(Annotation), *StartOriginID, LID);
+              getProgramPoint(Annotation), *StartOriginID, LID,
+              Runner.getAnalysisContext().getAnalysis<PostOrderCFGView>());
       if (!OriginFlowChain.empty())
         return OriginFlowChain;
     }


### PR DESCRIPTION
After introducing `buildOriginFlowChain` to use-after-scope diagnostics, it should support multi-block analysis. This also allows it to be reused by other diagnostics.

In some loops, `UseFact` may appear before `OriginFlowFact`:

```cpp
void for_loop_use_before_loop_body(MyObj safe) {
  MyObj* p = &safe;
  for (int i = 0; i < 1; ++i) {
    (void)*p;
    MyObj s;
    p = &s;
  }
  (void)*p;
}
```

So I no longer use `StartPoint` as the initial search starting point; it is only used to locate the corresponding block.

