### PR TITLE
[BPF] Fix erroneous removal of non-jump-table globals

### DIFF
--- a/llvm/lib/Target/BPF/BPFAsmPrinter.cpp
+++ b/llvm/lib/Target/BPF/BPFAsmPrinter.cpp
@@ -82,10 +82,9 @@ bool BPFAsmPrinter::doFinalization(Module &M) {
       if (!CA)
         continue;
 
-      for (unsigned i = 1, e = CA->getNumOperands(); i != e; ++i) {
-        if (!dyn_cast<BlockAddress>(CA->getOperand(i)))
-          continue;
-      }
+      if (!all_of(CA->operands(),
+                  [](const Use &Op) { return isa<BlockAddress>(Op); }))
+        continue;
       Targets.push_back(&Global);
     }
 

--- a/llvm/test/CodeGen/BPF/jump_table_func_ptr_array.ll
+++ b/llvm/test/CodeGen/BPF/jump_table_func_ptr_array.ll
@@ -1,0 +1,41 @@
+; RUN: llc -march=bpf -mcpu=v4 < %s | FileCheck %s
+
+; The real jump table (@__const.foo.jt, all BlockAddress) is converted into a
+; .jumptables entry and its global is removed.
+; CHECK-LABEL: foo:
+; CHECK:       r2 = BPF.JT.0.0 ll
+; CHECK:       gotox r1
+; CHECK:       .section .jumptables
+; CHECK:       BPF.JT.0.0:
+
+; The function-pointer array is preserved and still emitted.
+; CHECK-LABEL: get:
+; CHECK:       r2 = .Lkfuncs ll
+; CHECK:       .Lkfuncs:
+; CHECK:       .size .Lkfuncs, 16
+
+@__const.foo.jt = private unnamed_addr constant [2 x ptr] [ptr blockaddress(@foo, %l1), ptr blockaddress(@foo, %l2)], align 8
+@kfuncs = private unnamed_addr constant [2 x ptr] [ptr @ext1, ptr @ext2], align 8
+
+declare void @ext1()
+declare void @ext2()
+
+define i32 @foo(i32 %a) {
+entry:
+  %rem = and i32 %a, 1
+  %idx = zext nneg i32 %rem to i64
+  %g = getelementptr inbounds nuw [2 x ptr], ptr @__const.foo.jt, i64 0, i64 %idx
+  %t = load ptr, ptr %g, align 8
+  indirectbr ptr %t, [label %l1, label %l2]
+l1:
+  br label %l2
+l2:
+  %ret = phi i32 [ 4, %l1 ], [ 3, %entry ]
+  ret i32 %ret
+}
+
+define ptr @get(i64 %i) {
+  %p = getelementptr inbounds [2 x ptr], ptr @kfuncs, i64 0, i64 %i
+  %v = load ptr, ptr %p, align 8
+  ret ptr %v
+}


### PR DESCRIPTION
Jump tables are supported only for cpu v4. After lowering them into .jumptables entries, BPFAsmPrinter::doFinalization() removes the private constant arrays that backed the jump tables. But the below 'for' loop is actually a no-op.
```
    for (unsigned i = 1, e = CA->getNumOperands(); i != e; ++i) {
      if (!dyn_cast<BlockAddress>(CA->getOperand(i)))
        continue;
    }
    Targets.push_back(&Global);
```
With current implementation, 'Global' will be added to 'Targets' and later in doFinalization(), 'Global' will be removed. But it is possible in 'Global' there exists non BlockAddress which are used in later code. This will cause the problem like:
```
  error: Undefined temporary symbol .L__const.select_fn.fns
```
To fix the problem, For the above 'for' loop, only if all operands are with BlockAddress, 'Global' can be pushed to 'Targets'.

The issue is discovered when running bpf selftest with -O1. The related file is
  tools/testing/selftests/bpf/progs/kprobe_multi_session.c
Before optimization, we have
```
  @__const.session_check.kfuncs = private unnamed_addr constant [8 x ptr]
    [ptr @bpf_fentry_test1, ptr @bpf_fentry_test2, ptr @bpf_fentry_test3,
     ptr @bpf_fentry_test4, ptr @bpf_fentry_test5, ptr @bpf_fentry_test6,
     ptr @bpf_fentry_test7, ptr @bpf_fentry_test8], align 8
```
With -O1, `@__const.session_check.kfuncs` is used in codegen like
```
   ...
   $r2 = LD_imm64 @__const.session_check.kfuncs
   ...
```
which triggered the compilation failure.

With -O2, `@__const.session_check.kfuncs` is inlined in llvm GlobalOptPass and each individual funciton `@bpf_fentry_test1` etc. is directly used in IR, e.g.,
```
   ...
   %9 = icmp eq i64 %8, ptrtoint (ptr @bpf_fentry_test1 to i64), !dbg !95
   ...
```