### PR TITLE
[Coverage] Fix atomic mode for certain types of coverage counter updates

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp
+++ b/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp
@@ -1370,7 +1370,8 @@ void InstrLowerer::lowerMCDCTestVectorBitmapUpdate(
     // If ((Bitmap & Val) != Val), then execute atomic (Bitmap |= Val).
     // Note, just-loaded Bitmap might not be up-to-date. Use it just for
     // early testing.
-    // Use an atomic load to avoid data races.
+    // Use an atomic load to pair with the later atomicrmw, preventing a data
+    // race.
     Bitmap->setOrdering(llvm::AtomicOrdering::Monotonic);
     auto *Masked = Builder.CreateAnd(Bitmap, ShiftedVal);
     auto *ShouldStore = Builder.CreateICmpNE(Masked, ShiftedVal);

--- a/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp
+++ b/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp
@@ -1253,7 +1253,9 @@ void InstrLowerer::lowerCover(InstrProfCoverInst *CoverInstruction) {
   }
 
   // We store zero to represent that this block is covered.
-  Builder.CreateStore(Builder.getInt8(0), Addr);
+  StoreInst *Store = Builder.CreateStore(Builder.getInt8(0), Addr);
+  if (Options.Atomic || AtomicCounterUpdateAll)
+    Store->setOrdering(llvm::AtomicOrdering::Monotonic);
   CoverInstruction->eraseFromParent();
 }
 
@@ -1366,6 +1368,8 @@ void InstrLowerer::lowerMCDCTestVectorBitmapUpdate(
     // If ((Bitmap & Val) != Val), then execute atomic (Bitmap |= Val).
     // Note, just-loaded Bitmap might not be up-to-date. Use it just for
     // early testing.
+    // Use an atomic load to avoid data races.
+    Bitmap->setOrdering(llvm::AtomicOrdering::Monotonic);
     auto *Masked = Builder.CreateAnd(Bitmap, ShiftedVal);
     auto *ShouldStore = Builder.CreateICmpNE(Masked, ShiftedVal);
 

--- a/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp
+++ b/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp
@@ -1245,7 +1245,9 @@ void InstrLowerer::lowerCover(InstrProfCoverInst *CoverInstruction) {
     Instruction *SplitBefore = CoverInstruction->getNextNode();
     auto &Ctx = CoverInstruction->getParent()->getContext();
     auto *Int8Ty = llvm::Type::getInt8Ty(Ctx);
-    Value *Load = Builder.CreateLoad(Int8Ty, Addr, "pgocount");
+    LoadInst *Load = Builder.CreateLoad(Int8Ty, Addr, "pgocount");
+    if (Options.Atomic || AtomicCounterUpdateAll)
+      Load->setOrdering(llvm::AtomicOrdering::Monotonic);
     Value *Cmp = Builder.CreateIsNotNull(Load, "pgocount.ifnonzero");
     Instruction *ThenBranch =
         SplitBlockAndInsertIfThen(Cmp, SplitBefore, false);

--- a/llvm/test/Instrumentation/InstrProfiling/mcdc.ll
+++ b/llvm/test/Instrumentation/InstrProfiling/mcdc.ll
@@ -36,7 +36,9 @@ entry:
   ; CHECK-NEXT: %[[LAB8:[0-9]+]] = and i32 %[[TEMP]], 7
   ; CHECK-NEXT: %[[LAB9:[0-9]+]] = trunc i32 %[[LAB8]] to i8
   ; CHECK-NEXT: %[[LAB10:[0-9]+]] = shl i8 1, %[[LAB9]]
-  ; CHECK-NEXT: %[[BITS:.+]] = load i8, ptr %[[LAB7]], align 1
+  ; BASIC-NEXT: %[[BITS:.+]] = load i8, ptr %[[LAB7]], align 1
+  ; RELOC-NEXT: %[[BITS:.+]] = load i8, ptr %[[LAB7]], align 1
+  ; ATOMIC-NEXT: %[[BITS:.+]] = load atomic i8, ptr %[[LAB7]] monotonic, align 1
   ; ATOMIC-NEXT: %[[MASKED:.+]] = and i8 %[[BITS]], %[[LAB10]]
   ; ATOMIC-NEXT: %[[SHOULDWRITE:.+]] = icmp ne i8 %[[MASKED]], %[[LAB10]]
   ; ATOMIC-NEXT: br i1 %[[SHOULDWRITE]], label %[[WRITE:.+]], label %[[SKIP:.+]], !prof ![[MDPROF:[0-9]+]]

--- a/llvm/test/Instrumentation/InstrProfiling/mcdc.ll
+++ b/llvm/test/Instrumentation/InstrProfiling/mcdc.ll
@@ -21,6 +21,7 @@ entry:
   ; RELOC: %[[PROFC_INTADDR:.+]] = add i64 ptrtoint (ptr @__profc_test to i64), %profc_bias
   ; RELOC: %[[PROFC_ADDR:.+]] = inttoptr i64 %[[PROFC_INTADDR]] to ptr
   ; RELOC: store i8 0, ptr %[[PROFC_ADDR]], align 1
+  ; ATOMIC: store atomic i8 0, ptr @__profc_test monotonic, align 1
 
   call void @llvm.instrprof.mcdc.parameters(ptr @__profn_test, i64 99278, i32 1)
   store i32 0, ptr %mcdc.addr, align 4


### PR DESCRIPTION
In atomic mode, to prevent data races we need to use only atomic stores and loads to access the coverage counters. This is also necessary to suppress TSan diagnostics regarding racy MC/DC counter updates when `-fsanitize=thread` is specified.

According to the C++ Standard, a program containing concurrent access to data, where at least one access is a write and at least one is non-atomic, has a data race, which results in UB. Therefore, it is important to use atomic operations for updating single-byte coverage counters instead of plain load and store operations. Moreover, in most cases this does not result in the generation of slower instructions.