### PR TITLE
[InstCombine] Drop assumption-cache update in freezeOtherUses

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -5400,12 +5400,6 @@ bool InstCombinerImpl::freezeOtherUses(FreezeInst &FI) {
     auto *UI = cast<Instruction>(U);
     Worklist.pushUsersToWorkList(*UI);
     Worklist.push(UI);
-
-    for (auto &AssumeVH : AC.assumptionsFor(U)) {
-      if (!AssumeVH)
-        continue;
-      AC.updateAffectedValues(cast<AssumeInst>(AssumeVH));
-    }
   }
 
   return Changed;


### PR DESCRIPTION
Redundant now that freezeOtherUses re-queues the rewritten users (#202306), which re-processes them in the same iteration. Added in #192935 to avoid a fixpoint-verifier failure.