### PR TITLE
[LLVM] Fix a bug in auto upgrading lifetime start/end intrinsics

### DIFF
--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -1556,8 +1556,10 @@ static bool upgradeIntrinsicFunction1(Function *F, Function *&NewFn,
                               ? Intrinsic::lifetime_start
                               : Intrinsic::lifetime_end;
       rename(F);
+      // Old 2 argument form of these intrinsics have [Size, Ptr] as arguments.
+      // Use the Ptr argument to create new declaration.
       NewFn = Intrinsic::getOrInsertDeclaration(F->getParent(), IID,
-                                                F->getArg(0)->getType());
+                                                F->getArg(1)->getType());
       return true;
     }
     break;

--- a/llvm/test/Assembler/autoupgrade-lifetime-intrinsics-invalid-decl.ll
+++ b/llvm/test/Assembler/autoupgrade-lifetime-intrinsics-invalid-decl.ll
@@ -1,0 +1,17 @@
+; Test to verify that autoupgrade does not end up creating an invalid
+; declaration.
+; RUN: llvm-as < %s | llvm-dis | FileCheck %s
+
+; CHECK-NOT: declare void @llvm.lifetime.start.i64(i64)
+; CHECK-NOT: declare void @llvm.lifetime.end.i64(i64)
+
+define void @tests.lifetime.start.end() {
+  %a = alloca i8
+  call void @llvm.lifetime.start(i64 1, ptr %a)
+  store i8 0, ptr %a
+  call void @llvm.lifetime.end(i64 1, ptr %a)
+  ret void
+}
+
+declare void @llvm.lifetime.start.p0(i64, ptr)
+declare void @llvm.lifetime.end.p0(i64, ptr)


### PR DESCRIPTION
When creating the new intrinsic declaration, use the correct pointer argument (arg #1) from the existing call. Currently, we use arg #0 (size) and end up creating an invalid intrinsic declaration. However, later on we do not use this declaration directly and instead call `CreateLifetimeStart` or `CreateLifetimeEnd` IRBuilder functions that end up creating valid intrinsic declarations. The net result is that we are left with a stray unused invalid declaration.

Fix this issue by creating the intrinsic with the right pointer argument type.