### PR TITLE
[BOLT] Increase BufSize in runtime/common.h

### DIFF
--- a/bolt/runtime/common.h
+++ b/bolt/runtime/common.h
@@ -162,7 +162,7 @@ struct timespec {
 #error "For AArch64/ARM64,X86_64 AND RISCV64 only."
 #endif
 
-constexpr uint32_t BufSize = 10240;
+constexpr uint32_t BufSize = 32768U;
 
 // Helper functions for writing strings to the .fdata file. We intentionally
 // avoid using libc names to make it clear it is our impl.


### PR DESCRIPTION
During my work towards bolring the flang binary, I've encountered a frequently occuring problem with running out of the buffer space.

The problem affects C++ programs with a decent number of very long symbol names, which is inevitable when using template metaprogramming. As one can clearly see, flang is one of such programs.

The proposed BufSize value is an effect of the trial-and-error process aiming at finiding the smallest reasonable increase.