### PR TITLE
[sanitizer_common] [Darwin] Update version mapping for macOS 27-aligned releases

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
@@ -688,9 +688,9 @@ static void MapToMacos(u16 *major, u16 *minor) {
     return;
   }
 #  else
-   // macOS 26 and later have aligned version strings.
-   if (*major >= 26)
-     return;
+  // macOS 26 and later have aligned version strings.
+  if (*major >= 26)
+    return;
 #  endif
 
   // Below are mappings for pre-macOS-25-aligned releases

--- a/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
@@ -613,7 +613,13 @@ static uptr ApproximateOSVersionViaKernelVersion(VersStr vers) {
   u16 os_major = kernel_major - offset;
 
   const char *format = "%d.0";
-  if (TARGET_OS_OSX) {
+  if (kernel_major >= 27) {
+    // with kernel major 27 <=> OSes 27.0, OS versions are aligned with kernel
+    os_major = kernel_major;
+  } else if (kernel_major >= 25) {
+    // with kernel_major 25 <=> OSes 26.0, OS versions are aligned
+    os_major = kernel_major + 1;
+  } else if (TARGET_OS_OSX) {
     if (os_major >= 16) {  // macOS 11+
       os_major -= 5;
     } else {  // macOS 10.15 and below
@@ -670,6 +676,24 @@ static void MapToMacos(u16 *major, u16 *minor) {
   if (TARGET_OS_OSX)
     return;
 
+  // All supported platforms (including DriverKit) have
+  // aligned version numbers in macOS 27+
+  if (*major >= 27)
+    return;
+
+#  if TARGET_OS_DRIVERKIT
+  // Driverkit 25.0+ aligns with macOS 26+
+  if (*major >= 25) {
+    *major += 1;
+    return;
+  }
+#  else
+   // macOS 26 and later have aligned version strings.
+   if (*major >= 26)
+     return;
+#  endif
+
+  // Below are mappings for pre-macOS-25-aligned releases
   if (TARGET_OS_IOS || TARGET_OS_TV)
     *major += 2;
   else if (TARGET_OS_WATCH)


### PR DESCRIPTION
This updates `MapToMacos` et. al. to produce correct results for macOS 26 and macOS 27-aligned releases.

rdar://177997021
rdar://169356606