### PR TITLE
[clang][test] Use #marker in enable_if tests

### DIFF
--- a/clang/test/Sema/enable_if.c
+++ b/clang/test/Sema/enable_if.c
@@ -112,29 +112,50 @@ void f(int n) __attribute__((enable_if()));  // expected-error{{'enable_if' attr
 void f(int n) __attribute__((enable_if(unresolvedid, "chosen when 'unresolvedid' is non-zero")));  // expected-error{{use of undeclared identifier 'unresolvedid'}}
 
 int global;
-void f(int n) __attribute__((enable_if(global == 0, "chosen when 'global' is zero")));  // expected-error{{'enable_if' attribute expression never produces a constant expression}}  // expected-note{{subexpression not valid in a constant expression}}
+void f(int n) __attribute__((enable_if(global == 0, "chosen when 'global' is zero")));  // expected-error{{'enable_if' attribute expression never produces a constant expression}} \
+                                                                                        // expected-note{{subexpression not valid in a constant expression}}
 
 enum { cst = 7 };
 void return_cst(void) __attribute__((overloadable)) __attribute__((enable_if(cst == 7, "chosen when 'cst' is 7")));
 void test_return_cst(void) { return_cst(); }
 
-void f2(void) __attribute__((overloadable)) __attribute__((enable_if(1, "always chosen")));
-void f2(void) __attribute__((overloadable)) __attribute__((enable_if(0, "never chosen")));
-void f2(void) __attribute__((overloadable)) __attribute__((enable_if(TRUE, "always chosen #2")));
+void f2(void) __attribute__((overloadable)) __attribute__((enable_if(1, "always chosen")));       // #f2_1
+void f2(void) __attribute__((overloadable)) __attribute__((enable_if(0, "never chosen")));        // #f2_2
+void f2(void) __attribute__((overloadable)) __attribute__((enable_if(TRUE, "always chosen #2"))); // #f2_3
 void test6(void) {
-  void (*p1)(void) = &f2; // expected-error{{initializing 'void (*)(void)' with an expression of incompatible type '<overloaded function type>'}} expected-note@121{{candidate function}} expected-note@122{{candidate function made ineligible by enable_if}} expected-note@123{{candidate function}}
-  void (*p2)(void) = f2; // expected-error{{initializing 'void (*)(void)' with an expression of incompatible type '<overloaded function type>'}} expected-note@121{{candidate function}} expected-note@122{{candidate function made ineligible by enable_if}} expected-note@123{{candidate function}}
-  void *p3 = (void*)&f2; // expected-error{{address of overloaded function 'f2' is ambiguous}} expected-note@121{{candidate function}} expected-note@122{{candidate function made ineligible by enable_if}} expected-note@123{{candidate function}}
-  void *p4 = (void*)f2; // expected-error{{address of overloaded function 'f2' is ambiguous}} expected-note@121{{candidate function}} expected-note@122{{candidate function made ineligible by enable_if}} expected-note@123{{candidate function}}
+  void (*p1)(void) = &f2; // expected-error {{initializing 'void (*)(void)' with an expression of incompatible type '<overloaded function type>'}} \
+                          // expected-note@#f2_1 {{candidate function}} \
+                          // expected-note@#f2_2 {{candidate function made ineligible by enable_if}} \
+                          // expected-note@#f2_3 {{candidate function}}
+  void (*p2)(void) = f2; // expected-error {{initializing 'void (*)(void)' with an expression of incompatible type '<overloaded function type>'}} \
+                         // expected-note@#f2_1 {{candidate function}} \
+                         // expected-note@#f2_2 {{candidate function made ineligible by enable_if}} \
+                         // expected-note@#f2_3 {{candidate function}}
+  void *p3 = (void*)&f2; // expected-error {{address of overloaded function 'f2' is ambiguous}} \
+                         // expected-note@#f2_1 {{candidate function}} \
+                         // expected-note@#f2_2 {{candidate function made ineligible by enable_if}} \
+                         // expected-note@#f2_3 {{candidate function}}
+  void *p4 = (void*)f2; // expected-error {{address of overloaded function 'f2' is ambiguous}} \
+                        // expected-note@#f2_1 {{candidate function}} \
+                        // expected-note@#f2_2 {{candidate function made ineligible by enable_if}} \
+                        // expected-note@#f2_3 {{candidate function}}
 }
 
-void f3(int m) __attribute__((overloadable)) __attribute__((enable_if(m >= 0, "positive")));
-void f3(int m) __attribute__((overloadable)) __attribute__((enable_if(m < 0, "negative")));
+void f3(int m) __attribute__((overloadable)) __attribute__((enable_if(m >= 0, "positive"))); // #f3_1
+void f3(int m) __attribute__((overloadable)) __attribute__((enable_if(m < 0, "negative")));  // #f3_2
 void test7(void) {
-  void (*p1)(int) = &f3; // expected-error{{initializing 'void (*)(int)' with an expression of incompatible type '<overloaded function type>'}} expected-note@131{{candidate function made ineligible by enable_if}} expected-note@132{{candidate function made ineligible by enable_if}}
-  void (*p2)(int) = f3; // expected-error{{initializing 'void (*)(int)' with an expression of incompatible type '<overloaded function type>'}} expected-note@131{{candidate function made ineligible by enable_if}} expected-note@132{{candidate function made ineligible by enable_if}}
-  void *p3 = (void*)&f3; // expected-error{{address of overloaded function 'f3' does not match required type 'void'}} expected-note@131{{candidate function made ineligible by enable_if}} expected-note@132{{candidate function made ineligible by enable_if}}
-  void *p4 = (void*)f3; // expected-error{{address of overloaded function 'f3' does not match required type 'void'}} expected-note@131{{candidate function made ineligible by enable_if}} expected-note@132{{candidate function made ineligible by enable_if}}
+  void (*p1)(int) = &f3; // expected-error {{initializing 'void (*)(int)' with an expression of incompatible type '<overloaded function type>'}} \
+                         // expected-note@#f3_1 {{candidate function made ineligible by enable_if}} \
+                         // expected-note@#f3_2 {{candidate function made ineligible by enable_if}}
+  void (*p2)(int) = f3; // expected-error {{initializing 'void (*)(int)' with an expression of incompatible type '<overloaded function type>'}} \
+                        // expected-note@#f3_1 {{candidate function made ineligible by enable_if}} \
+                        // expected-note@#f3_2 {{candidate function made ineligible by enable_if}}
+  void *p3 = (void*)&f3; // expected-error {{address of overloaded function 'f3' does not match required type 'void'}} \
+                         // expected-note@#f3_1 {{candidate function made ineligible by enable_if}} \
+                         // expected-note@#f3_2 {{candidate function made ineligible by enable_if}}
+  void *p4 = (void*)f3; // expected-error {{address of overloaded function 'f3' does not match required type 'void'}} \
+                        // expected-note@#f3_1 {{candidate function made ineligible by enable_if}} \
+                        // expected-note@#f3_2 {{candidate function made ineligible by enable_if}}
 }
 
 void f4(int m) __attribute__((enable_if(0, "")));

--- a/clang/test/SemaCXX/enable_if.cpp
+++ b/clang/test/SemaCXX/enable_if.cpp
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 -std=c++11 -verify %s
 // RUN: %clang_cc1 -std=c++2a -verify %s
+
 typedef int (*fp)(int);
 int surrogate(int);
 struct Incomplete;  // expected-note{{forward declaration of 'Incomplete'}} \
@@ -118,7 +119,8 @@ template <typename T> class C {
 
 int fn3(bool b) __attribute__((enable_if(b, ""))); // FIXME: This test should net 0 error messages.
 template <class T> void test3() {
-  fn3(sizeof(T) == 1); // expected-error{{no matching function for call to 'fn3'}} expected-note@-2{{candidate disabled}}
+  fn3(sizeof(T) == 1); // expected-error{{no matching function for call to 'fn3'}} \
+                       // expected-note@-2{{candidate disabled}}
 }
 
 template <typename T>
@@ -138,7 +140,8 @@ void test4() {
 void h(int);
 template <typename T> void outer() {
   void local_function() __attribute__((enable_if(::h(T()), "")));
-  local_function(); // expected-error{{no matching function for call to 'local_function'}} expected-note@-1{{candidate disabled}}
+  local_function(); // expected-error{{no matching function for call to 'local_function'}} \
+                    // expected-note@-1{{candidate disabled}}
 };
 
 namespace PR20988 {
@@ -160,7 +163,8 @@ namespace PR20988 {
 
   int fn3(bool b) __attribute__((enable_if(b, ""))); // FIXME: This test should net 0 error messages.
   template <class T> void test3() {
-    fn3(sizeof(T) == 1); // expected-error{{no matching function for call to 'fn3'}} expected-note@-2{{candidate disabled}}
+    fn3(sizeof(T) == 1); // expected-error {{no matching function for call to 'fn3'}} \
+                         // expected-note@-2 {{candidate disabled}}
   }
 }
 
@@ -188,14 +192,22 @@ namespace FnPtrs {
     a = &ovlBar;
   }
 
-  int ovlConflict(int m) __attribute__((enable_if(true, "")));
-  int ovlConflict(int m) __attribute__((enable_if(1, "")));
+  int ovlConflict(int m) __attribute__((enable_if(true, ""))); // #ovl_1
+  int ovlConflict(int m) __attribute__((enable_if(1, "")));    // #ovl_2
   void test3() {
-    int (*p)(int) = ovlConflict; // expected-error{{address of overloaded function 'ovlConflict' is ambiguous}} expected-note@191{{candidate function}} expected-note@192{{candidate function}}
-    int (*p2)(int) = &ovlConflict; // expected-error{{address of overloaded function 'ovlConflict' is ambiguous}} expected-note@191{{candidate function}} expected-note@192{{candidate function}}
+    int (*p)(int) = ovlConflict; // expected-error {{address of overloaded function 'ovlConflict' is ambiguous}} \
+                                 // expected-note@#ovl_1 {{candidate function}} \
+                                 // expected-note@#ovl_2 {{candidate function}}
+    int (*p2)(int) = &ovlConflict; // expected-error {{address of overloaded function 'ovlConflict' is ambiguous}} \
+                                   // expected-note@#ovl_1 {{candidate function}} \
+                                   // expected-note@#ovl_2 {{candidate function}}
     int (*a)(int);
-    a = ovlConflict; // expected-error{{assigning to 'int (*)(int)' from incompatible type '<overloaded function type>'}} expected-note@191{{candidate function}} expected-note@192{{candidate function}}
-    a = &ovlConflict; // expected-error{{assigning to 'int (*)(int)' from incompatible type '<overloaded function type>'}} expected-note@191{{candidate function}} expected-note@192{{candidate function}}
+    a = ovlConflict; // expected-error {{assigning to 'int (*)(int)' from incompatible type '<overloaded function type>'}} \
+                     // expected-note@#ovl_1 {{candidate function}} \
+                     // expected-note@#ovl_2 {{candidate function}}
+    a = &ovlConflict; // expected-error {{assigning to 'int (*)(int)' from incompatible type '<overloaded function type>'}} \
+                      // expected-note@#ovl_1 {{candidate function}} \
+                      // expected-note@#ovl_2 {{candidate function}}
   }
 
   template <typename T>
@@ -211,37 +223,59 @@ namespace FnPtrs {
   }
 
   template <typename T>
-  T templatedBar(T m) __attribute__((enable_if(m > 0, ""))) { return T(); }
+  T templatedBar(T m) __attribute__((enable_if(m > 0, ""))) { return T(); } // #tbar
   void test5() {
-    int (*p)(int) = templatedBar<int>; // expected-error{{address of overloaded function 'templatedBar' does not match required type 'int (int)'}} expected-note@214{{candidate function made ineligible by enable_if}}
-    int (*p2)(int) = &templatedBar<int>; // expected-error{{address of overloaded function 'templatedBar' does not match required type 'int (int)'}} expected-note@214{{candidate function made ineligible by enable_if}}
+    int (*p)(int) = templatedBar<int>; // expected-error {{address of overloaded function 'templatedBar' does not match required type 'int (int)'}} \
+                                       // expected-note@#tbar {{candidate function made ineligible by enable_if}}
+    int (*p2)(int) = &templatedBar<int>; // expected-error {{address of overloaded function 'templatedBar' does not match required type 'int (int)'}} \
+                                         // expected-note@#tbar {{candidate function made ineligible by enable_if}}
     int (*a)(int);
-    a = templatedBar<int>; // expected-error{{assigning to 'int (*)(int)' from incompatible type '<overloaded function type>'}} expected-note@214{{candidate function made ineligible by enable_if}}
-    a = &templatedBar<int>; // expected-error{{assigning to 'int (*)(int)' from incompatible type '<overloaded function type>'}} expected-note@214{{candidate function made ineligible by enable_if}}
+    a = templatedBar<int>; // expected-error {{assigning to 'int (*)(int)' from incompatible type '<overloaded function type>'}} \
+                           // expected-note@#tbar {{candidate function made ineligible by enable_if}}
+    a = &templatedBar<int>; // expected-error {{assigning to 'int (*)(int)' from incompatible type '<overloaded function type>'}} \
+                            // expected-note@#tbar {{candidate function made ineligible by enable_if}}
   }
 
   template <typename T>
-  T templatedConflict(T m) __attribute__((enable_if(false, ""))) { return T(); }
+  T templatedConflict(T m) __attribute__((enable_if(false, ""))) { return T(); } // #conflict1
   template <typename T>
-  T templatedConflict(T m) __attribute__((enable_if(true, ""))) { return T(); }
+  T templatedConflict(T m) __attribute__((enable_if(true, ""))) { return T(); } // #conflict2
   template <typename T>
-  T templatedConflict(T m) __attribute__((enable_if(1, ""))) { return T(); }
+  T templatedConflict(T m) __attribute__((enable_if(1, ""))) { return T(); }    // #conflict3
   void test6() {
-    int (*p)(int) = templatedConflict<int>; // expected-error{{address of overloaded function 'templatedConflict' is ambiguous}} expected-note@224{{candidate function made ineligible by enable_if}} expected-note@226{{candidate function}} expected-note@228{{candidate function}}
-    int (*p0)(int) = &templatedConflict<int>; // expected-error{{address of overloaded function 'templatedConflict' is ambiguous}} expected-note@224{{candidate function made ineligible by enable_if}} expected-note@226{{candidate function}} expected-note@228{{candidate function}}
+    int (*p)(int) = templatedConflict<int>; // expected-error {{address of overloaded function 'templatedConflict' is ambiguous}} \
+                                            // expected-note@#conflict1 {{candidate function made ineligible by enable_if}} \
+                                            // expected-note@#conflict2 {{candidate function}} \
+                                            // expected-note@#conflict3 {{candidate function}}
+    int (*p0)(int) = &templatedConflict<int>; // expected-error {{address of overloaded function 'templatedConflict' is ambiguous}} \
+                                              // expected-note@#conflict1 {{candidate function made ineligible by enable_if}} \
+                                              // expected-note@#conflict2 {{candidate function}} \
+                                              // expected-note@#conflict3 {{candidate function}}
     int (*a)(int);
-    a = templatedConflict<int>; // expected-error{{assigning to 'int (*)(int)' from incompatible type '<overloaded function type>'}} expected-note@226{{candidate function}} expected-note@228{{candidate function}}
-    a = &templatedConflict<int>; // expected-error{{assigning to 'int (*)(int)' from incompatible type '<overloaded function type>'}} expected-note@226{{candidate function}} expected-note@228{{candidate function}}
+    a = templatedConflict<int>; // expected-error {{assigning to 'int (*)(int)' from incompatible type '<overloaded function type>'}} \
+                                // expected-note@#conflict2 {{candidate function}} \
+                                // expected-note@#conflict3 {{candidate function}}
+    a = &templatedConflict<int>; // expected-error {{assigning to 'int (*)(int)' from incompatible type '<overloaded function type>'}} \
+                                 // expected-note@#conflict2 {{candidate function}} \
+                                 // expected-note@#conflict3 {{candidate function}}
   }
 
-  int ovlNoCandidate(int m) __attribute__((enable_if(false, "")));
-  int ovlNoCandidate(int m) __attribute__((enable_if(0, "")));
+  int ovlNoCandidate(int m) __attribute__((enable_if(false, ""))); // #ovlno1
+  int ovlNoCandidate(int m) __attribute__((enable_if(0, "")));     // #ovlno2
   void test7() {
-    int (*p)(int) = ovlNoCandidate; // expected-error{{address of overloaded function 'ovlNoCandidate' does not match required type}} expected-note@237{{made ineligible by enable_if}} expected-note@238{{made ineligible by enable_if}}
-    int (*p2)(int) = &ovlNoCandidate; // expected-error{{address of overloaded function 'ovlNoCandidate' does not match required type}} expected-note@237{{made ineligible by enable_if}} expected-note@238{{made ineligible by enable_if}}
+    int (*p)(int) = ovlNoCandidate; // expected-error {{address of overloaded function 'ovlNoCandidate' does not match required type}} \
+                                    // expected-note@#ovlno1 {{made ineligible by enable_if}} \
+                                    // expected-note@#ovlno2 {{made ineligible by enable_if}}
+    int (*p2)(int) = &ovlNoCandidate; // expected-error {{address of overloaded function 'ovlNoCandidate' does not match required type}} \
+                                      // expected-note@#ovlno1 {{made ineligible by enable_if}} \
+                                      // expected-note@#ovlno2 {{made ineligible by enable_if}}
     int (*a)(int);
-    a = ovlNoCandidate; // expected-error{{assigning to 'int (*)(int)' from incompatible type '<overloaded function type>'}} expected-note@237{{made ineligible by enable_if}} expected-note@238{{made ineligible by enable_if}}
-    a = &ovlNoCandidate; // expected-error{{assigning to 'int (*)(int)' from incompatible type '<overloaded function type>'}} expected-note@237{{made ineligible by enable_if}} expected-note@238{{made ineligible by enable_if}}
+    a = ovlNoCandidate; // expected-error {{assigning to 'int (*)(int)' from incompatible type '<overloaded function type>'}} \
+                        // expected-note@#ovlno1 {{made ineligible by enable_if}} \
+                        // expected-note@#ovlno2 {{made ineligible by enable_if}}
+    a = &ovlNoCandidate; // expected-error {{assigning to 'int (*)(int)' from incompatible type '<overloaded function type>'}} \
+                         // expected-note@#ovlno1 {{made ineligible by enable_if}} \
+                         // expected-note@#ovlno2 {{made ineligible by enable_if}}
   }
 
   int noOvlNoCandidate(int m) __attribute__((enable_if(false, "")));


### PR DESCRIPTION
I just wasted way too long trying to figure out why my newly added RUN lines were randomly broken or not.

Stop using absolute line numbers.