### PR TITLE
[lldb][test] Skip wasm-unsupported API tests

### DIFF
--- a/lldb/test/API/functionalities/breakpoint/cpp_exception/TestCPPExceptionBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/cpp_exception/TestCPPExceptionBreakpoint.py
@@ -9,6 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # wasm inferiors are built with -fno-exceptions
 class TestCPPExceptionBreakpoint(TestBase):
     my_var = 10
 

--- a/lldb/test/API/functionalities/exec/TestExec.py
+++ b/lldb/test/API/functionalities/exec/TestExec.py
@@ -8,6 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no exec() on WebAssembly
 class ExecTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/fork/resumes-child/TestForkResumesChild.py
+++ b/lldb/test/API/functionalities/fork/resumes-child/TestForkResumesChild.py
@@ -9,6 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 
 
+@skipIfWasm  # no fork() on WebAssembly
 class TestForkResumesChild(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/functionalities/inferior-changed/TestInferiorChanged.py
+++ b/lldb/test/API/functionalities/inferior-changed/TestInferiorChanged.py
@@ -9,6 +9,7 @@ from lldbsuite.test import configuration
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # wasm has no memory-protection faults/signals
 class ChangedInferiorTestCase(TestBase):
     SHARED_BUILD_TESTCASE = False
 

--- a/lldb/test/API/functionalities/inferior-crashing/TestInferiorCrashing.py
+++ b/lldb/test/API/functionalities/inferior-crashing/TestInferiorCrashing.py
@@ -8,6 +8,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
 
+@skipIfWasm  # wasm has no memory-protection faults/signals
 class CrashingInferiorTestCase(TestBase):
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24778")
     @expectedFailureNetBSD

--- a/lldb/test/API/functionalities/inferior-crashing/TestInferiorCrashingStep.py
+++ b/lldb/test/API/functionalities/inferior-crashing/TestInferiorCrashingStep.py
@@ -8,6 +8,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 
 
+@skipIfWasm  # wasm has no memory-protection faults/signals
 class CrashingInferiorStepTestCase(TestBase):
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24778")
     @expectedFailureNetBSD

--- a/lldb/test/API/functionalities/inferior-crashing/recursive-inferior/TestRecursiveInferior.py
+++ b/lldb/test/API/functionalities/inferior-crashing/recursive-inferior/TestRecursiveInferior.py
@@ -8,6 +8,7 @@ from lldbsuite.test import lldbplatformutil
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # wasm has no memory-protection faults/signals
 class CrashingRecursiveInferiorTestCase(TestBase):
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24778")
     @expectedFailureNetBSD

--- a/lldb/test/API/functionalities/inferior-crashing/recursive-inferior/TestRecursiveInferiorStep.py
+++ b/lldb/test/API/functionalities/inferior-crashing/recursive-inferior/TestRecursiveInferiorStep.py
@@ -8,6 +8,7 @@ from lldbsuite.test import lldbplatformutil
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # wasm has no memory-protection faults/signals
 class CrashingRecursiveInferiorStepTestCase(TestBase):
     def test_recursive_inferior_crashing_step(self):
         """Test that stepping after a crash behaves correctly."""

--- a/lldb/test/API/functionalities/longjmp/TestLongjmp.py
+++ b/lldb/test/API/functionalities/longjmp/TestLongjmp.py
@@ -9,6 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # setjmp/longjmp on wasm requires exception-handling support
 class LongjmpTestCase(TestBase):
     @skipIfDarwin  # llvm.org/pr16769: LLDB on Mac OS X dies in function ReadRegisterBytes in GDBRemoteRegisterContext.cpp
     @skipIfWindows # Test is flaky on Windows

--- a/lldb/test/API/functionalities/process_group/TestChangeProcessGroup.py
+++ b/lldb/test/API/functionalities/process_group/TestChangeProcessGroup.py
@@ -8,6 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # no fork()/setpgid() on WebAssembly
 class ChangeProcessGroupTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/lang/cpp/exceptions/TestCPPExceptionBreakpoints.py
+++ b/lldb/test/API/lang/cpp/exceptions/TestCPPExceptionBreakpoints.py
@@ -9,6 +9,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # wasm inferiors are built with -fno-exceptions
 class CPPBreakpointTestCase(TestBase):
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/lang/cpp/floating-types-specialization/TestCppFloatingTypesSpecialization.py
+++ b/lldb/test/API/lang/cpp/floating-types-specialization/TestCppFloatingTypesSpecialization.py
@@ -5,6 +5,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfWasm  # _Float16/__bf16 are unsupported on the wasm target
 class TestCase(TestBase):
     @skipIf(compiler="clang", compiler_version=["<", "17.0"])
     def test(self):

--- a/lldb/test/API/tools/lldb-dap/exception/cpp/TestDAP_exception_cpp.py
+++ b/lldb/test/API/tools/lldb-dap/exception/cpp/TestDAP_exception_cpp.py
@@ -7,6 +7,7 @@ from lldbsuite.test.lldbtest import *
 import lldbdap_testcase
 
 
+@skipIfWasm  # wasm inferiors are built with -fno-exceptions
 class TestDAP_exception_cpp(lldbdap_testcase.DAPTestCaseBase):
     @skipIfWindows
     def test_stopped_description(self):


### PR DESCRIPTION
WebAssembly inferiors are built with -fno-exceptions and run on a wasip1 runtime with no exec/fork/setpgid, no setjmp/longjmp (needs the exception-handling proposal), no memory-protection faults/signals, and no _Float16/__bf16 support. Mark the corresponding API tests as skipped on wasm so they report unsupported instead of failing to build or run.