### PR TITLE
[llvm] Remove LLVM_ABI_FOR_TEST in public headers

### DIFF
--- a/llvm/include/llvm/BinaryFormat/DXContainer.h
+++ b/llvm/include/llvm/BinaryFormat/DXContainer.h
@@ -203,7 +203,7 @@ enum class RootParameterType : uint32_t {
 
 LLVM_ABI ArrayRef<EnumEntry<RootParameterType>> getRootParameterTypes();
 
-LLVM_ABI_FOR_TEST bool isValidParameterType(uint32_t V);
+LLVM_ABI bool isValidParameterType(uint32_t V);
 
 LLVM_ABI bool isValidRangeType(uint32_t V);
 

--- a/llvm/include/llvm/CAS/ActionCache.h
+++ b/llvm/include/llvm/CAS/ActionCache.h
@@ -34,7 +34,7 @@ public:
   StringRef getKey() const { return Key; }
 
   LLVM_ABI CacheKey(const CASID &ID);
-  LLVM_ABI_FOR_TEST CacheKey(const ObjectProxy &Proxy);
+  LLVM_ABI CacheKey(const ObjectProxy &Proxy);
   LLVM_ABI CacheKey(const ObjectStore &CAS, const ObjectRef &Ref);
 
 private:

--- a/llvm/include/llvm/CAS/MappedFileRegionArena.h
+++ b/llvm/include/llvm/CAS/MappedFileRegionArena.h
@@ -65,7 +65,7 @@ public:
   /// that information can be stored before the header, like a file magic.
   /// \param NewFileConstructor is for constructing new files. It has exclusive
   /// access to the file. Must call \c initializeBumpPtr.
-  LLVM_ABI_FOR_TEST static Expected<MappedFileRegionArena>
+  LLVM_ABI static Expected<MappedFileRegionArena>
   create(const Twine &Path, uint64_t Capacity, uint64_t HeaderOffset,
          std::shared_ptr<ondisk::OnDiskCASLogger> Logger,
          function_ref<Error(MappedFileRegionArena &)> NewFileConstructor);
@@ -86,7 +86,7 @@ public:
     return data() + *Offset;
   }
   /// Allocate, returning the offset from \a data() instead of a pointer.
-  LLVM_ABI_FOR_TEST Expected<int64_t> allocateOffset(uint64_t AllocSize);
+  LLVM_ABI Expected<int64_t> allocateOffset(uint64_t AllocSize);
 
   char *data() const { return Region.data(); }
   uint64_t size() const { return H->BumpPtr; }
@@ -111,7 +111,7 @@ private:
   // initialize header from offset.
   Error initializeHeader(uint64_t HeaderOffset);
 
-  LLVM_ABI_FOR_TEST void destroyImpl();
+  LLVM_ABI void destroyImpl();
   void moveImpl(MappedFileRegionArena &RHS) {
     std::swap(Region, RHS.Region);
     std::swap(H, RHS.H);

--- a/llvm/include/llvm/CAS/OnDiskDataAllocator.h
+++ b/llvm/include/llvm/CAS/OnDiskDataAllocator.h
@@ -58,34 +58,33 @@ public:
   /// Get the data of \p Size stored at the given \p Offset. Note the allocator
   /// doesn't keep track of the allocation size, thus \p Size doesn't need to
   /// match the size of allocation but needs to be smaller.
-  LLVM_ABI_FOR_TEST Expected<ArrayRef<char>> get(FileOffset Offset,
-                                                 size_t Size) const;
+  LLVM_ABI Expected<ArrayRef<char>> get(FileOffset Offset, size_t Size) const;
 
   /// Allocate at least \p Size with 8-byte alignment.
-  LLVM_ABI_FOR_TEST Expected<OnDiskPtr> allocate(size_t Size);
+  LLVM_ABI Expected<OnDiskPtr> allocate(size_t Size);
 
   /// \returns the buffer that was allocated at \p create time, with size
   /// \p UserHeaderSize.
   LLVM_ABI MutableArrayRef<uint8_t> getUserHeader() const;
 
-  LLVM_ABI_FOR_TEST size_t size() const;
-  LLVM_ABI_FOR_TEST size_t capacity() const;
+  LLVM_ABI size_t size() const;
+  LLVM_ABI size_t capacity() const;
 
-  LLVM_ABI_FOR_TEST static Expected<OnDiskDataAllocator>
+  LLVM_ABI static Expected<OnDiskDataAllocator>
   create(const Twine &Path, const Twine &TableName, uint64_t MaxFileSize,
          std::optional<uint64_t> NewFileInitialSize,
          uint32_t UserHeaderSize = 0,
          std::shared_ptr<ondisk::OnDiskCASLogger> Logger = nullptr,
          function_ref<void(void *)> UserHeaderInit = nullptr);
 
-  LLVM_ABI_FOR_TEST OnDiskDataAllocator(OnDiskDataAllocator &&RHS);
-  LLVM_ABI_FOR_TEST OnDiskDataAllocator &operator=(OnDiskDataAllocator &&RHS);
+  LLVM_ABI OnDiskDataAllocator(OnDiskDataAllocator &&RHS);
+  LLVM_ABI OnDiskDataAllocator &operator=(OnDiskDataAllocator &&RHS);
 
   // No copy. Just call \a create() again.
   OnDiskDataAllocator(const OnDiskDataAllocator &) = delete;
   OnDiskDataAllocator &operator=(const OnDiskDataAllocator &) = delete;
 
-  LLVM_ABI_FOR_TEST ~OnDiskDataAllocator();
+  LLVM_ABI ~OnDiskDataAllocator();
 
 private:
   struct ImplType;

--- a/llvm/include/llvm/CAS/OnDiskGraphDB.h
+++ b/llvm/include/llvm/CAS/OnDiskGraphDB.h
@@ -261,8 +261,8 @@ public:
   /// already a record for this object the operation is a no-op. \param ID the
   /// object ID to associate the data & references with. \param Refs references
   /// \param Data data buffer.
-  LLVM_ABI_FOR_TEST Error store(ObjectID ID, ArrayRef<ObjectID> Refs,
-                                ArrayRef<char> Data);
+  LLVM_ABI Error store(ObjectID ID, ArrayRef<ObjectID> Refs,
+                       ArrayRef<char> Data);
 
   /// Associates the data of a file with a particular object ID. If there is
   /// already a record for this object the operation is a no-op.
@@ -275,10 +275,10 @@ public:
   ///
   /// \param ID the object ID to associate the data with.
   /// \param FilePath the path of the file data.
-  LLVM_ABI_FOR_TEST Error storeFile(ObjectID ID, StringRef FilePath);
+  LLVM_ABI Error storeFile(ObjectID ID, StringRef FilePath);
 
   /// \returns \p nullopt if the object associated with \p Ref does not exist.
-  LLVM_ABI_FOR_TEST Expected<std::optional<ObjectHandle>> load(ObjectID Ref);
+  LLVM_ABI Expected<std::optional<ObjectHandle>> load(ObjectID Ref);
 
   /// \returns the hash bytes digest for the object reference.
   ArrayRef<uint8_t> getDigest(ObjectID Ref) const {
@@ -288,12 +288,12 @@ public:
 
   /// Form a reference for the provided hash. The reference can be used as part
   /// of a CAS object even if it's not associated with an object yet.
-  LLVM_ABI_FOR_TEST Expected<ObjectID> getReference(ArrayRef<uint8_t> Hash);
+  LLVM_ABI Expected<ObjectID> getReference(ArrayRef<uint8_t> Hash);
 
   /// Get an existing reference to the object \p Digest.
   ///
   /// Returns \p nullopt if the object is not stored in this CAS.
-  LLVM_ABI_FOR_TEST std::optional<ObjectID>
+  LLVM_ABI std::optional<ObjectID>
   getExistingReference(ArrayRef<uint8_t> Digest, bool CheckUpstream = true);
 
   /// Check whether the object associated with \p Ref is stored in the CAS.
@@ -320,7 +320,7 @@ public:
   }
 
   /// \returns the data part of the provided object handle.
-  LLVM_ABI_FOR_TEST ArrayRef<char> getObjectData(ObjectHandle Node) const;
+  LLVM_ABI ArrayRef<char> getObjectData(ObjectHandle Node) const;
 
   /// \returns the object referenced by the provided object handle.
   object_refs_range getObjectRefs(ObjectHandle Node) const {
@@ -358,7 +358,7 @@ public:
   ///
   /// NOTE: There's a possibility that the returned size is not including a
   /// large object if the process crashed right at the point of inserting it.
-  LLVM_ABI_FOR_TEST size_t getStorageSize() const;
+  LLVM_ABI size_t getStorageSize() const;
 
   /// \returns The precentage of space utilization of hard space limits.
   ///
@@ -381,7 +381,7 @@ public:
 
   /// Checks that \p ID exists in the index. It is allowed to not have data
   /// associated with it.
-  LLVM_ABI_FOR_TEST Error validateObjectID(ObjectID ID) const;
+  LLVM_ABI Error validateObjectID(ObjectID ID) const;
 
   /// How to fault-in nodes if an upstream database is used.
   enum class FaultInPolicy {
@@ -407,13 +407,13 @@ public:
   /// \param Policy If \p UpstreamDB is provided, controls how nodes are copied
   /// to primary store. This is recorded at creation time and subsequent opens
   /// need to pass the same policy otherwise the \p open will fail.
-  LLVM_ABI_FOR_TEST static Expected<std::unique_ptr<OnDiskGraphDB>>
+  LLVM_ABI static Expected<std::unique_ptr<OnDiskGraphDB>>
   open(StringRef Path, StringRef HashName, unsigned HashByteSize,
        OnDiskGraphDB *UpstreamDB = nullptr,
        std::shared_ptr<OnDiskCASLogger> Logger = nullptr,
        FaultInPolicy Policy = FaultInPolicy::FullTree);
 
-  LLVM_ABI_FOR_TEST ~OnDiskGraphDB();
+  LLVM_ABI ~OnDiskGraphDB();
 
 private:
   /// Forward declaration for a proxy for an ondisk index record.
@@ -426,8 +426,8 @@ private:
   };
 
   /// Check if object exists and if it is on upstream only.
-  LLVM_ABI_FOR_TEST Expected<ObjectPresence>
-  getObjectPresence(ObjectID Ref, bool CheckUpstream) const;
+  LLVM_ABI Expected<ObjectPresence> getObjectPresence(ObjectID Ref,
+                                                      bool CheckUpstream) const;
 
   /// When \p load is called for a node that doesn't exist, this function tries
   /// to load it from the upstream store and copy it to the primary one.
@@ -468,8 +468,7 @@ private:
 
   static InternalRef makeInternalRef(FileOffset IndexOffset);
 
-  LLVM_ABI_FOR_TEST Expected<ArrayRef<uint8_t>>
-  getDigest(InternalRef Ref) const;
+  LLVM_ABI Expected<ArrayRef<uint8_t>> getDigest(InternalRef Ref) const;
 
   ArrayRef<uint8_t> getDigest(const IndexProxy &I) const;
 
@@ -478,8 +477,7 @@ private:
   IndexProxy
   getIndexProxyFromPointer(OnDiskTrieRawHashMap::ConstOnDiskPtr P) const;
 
-  LLVM_ABI_FOR_TEST InternalRefArrayRef
-  getInternalRefs(ObjectHandle Node) const;
+  LLVM_ABI InternalRefArrayRef getInternalRefs(ObjectHandle Node) const;
   /// \}
 
   /// Get the atomic variable that keeps track of the standalone data storage

--- a/llvm/include/llvm/CAS/OnDiskKeyValueDB.h
+++ b/llvm/include/llvm/CAS/OnDiskKeyValueDB.h
@@ -36,13 +36,12 @@ public:
   ///
   /// \returns the value associated with the \p Key. It may be different than
   /// \p Value if another value is already associated with this key.
-  LLVM_ABI_FOR_TEST Expected<ArrayRef<char>> put(ArrayRef<uint8_t> Key,
-                                                 ArrayRef<char> Value);
+  LLVM_ABI Expected<ArrayRef<char>> put(ArrayRef<uint8_t> Key,
+                                        ArrayRef<char> Value);
 
   /// \returns the value associated with the \p Key, or \p std::nullopt if the
   /// key does not exist.
-  LLVM_ABI_FOR_TEST Expected<std::optional<ArrayRef<char>>>
-  get(ArrayRef<uint8_t> Key);
+  LLVM_ABI Expected<std::optional<ArrayRef<char>>> get(ArrayRef<uint8_t> Key);
 
   /// \returns Total size of stored data.
   size_t getStorageSize() const { return Cache.size(); }
@@ -66,14 +65,14 @@ public:
   /// \param UnifiedCache An optional UnifiedOnDiskCache that manages the size
   /// and lifetime of the CAS instance and it must owns current initializing
   /// KeyValueDB after initialized.
-  LLVM_ABI_FOR_TEST static Expected<std::unique_ptr<OnDiskKeyValueDB>>
+  LLVM_ABI static Expected<std::unique_ptr<OnDiskKeyValueDB>>
   open(StringRef Path, StringRef HashName, unsigned KeySize,
        StringRef ValueName, size_t ValueSize,
        UnifiedOnDiskCache *UnifiedCache = nullptr,
        std::shared_ptr<OnDiskCASLogger> Logger = nullptr);
 
   /// Validate the storage.
-  LLVM_ABI_FOR_TEST Error validate() const;
+  LLVM_ABI Error validate() const;
 
 private:
   OnDiskKeyValueDB(size_t ValueSize, OnDiskTrieRawHashMap Cache,

--- a/llvm/include/llvm/CAS/OnDiskTrieRawHashMap.h
+++ b/llvm/include/llvm/CAS/OnDiskTrieRawHashMap.h
@@ -86,7 +86,7 @@ public:
   /// Validate the trie data structure.
   ///
   /// Callback receives the file offset to the data entry and the data stored.
-  LLVM_ABI_FOR_TEST Error validate(
+  LLVM_ABI Error validate(
       function_ref<Error(FileOffset, ConstValueProxy)> RecordVerifier) const;
 
   /// Check the valid range of file offset for OnDiskTrieRawHashMap.
@@ -164,10 +164,10 @@ public:
   ///
   /// \returns pointer to the value if exists, otherwise returns a non-value
   /// pointer that evaluates to `false` when convert to boolean.
-  LLVM_ABI_FOR_TEST ConstOnDiskPtr find(ArrayRef<uint8_t> Hash) const;
+  LLVM_ABI ConstOnDiskPtr find(ArrayRef<uint8_t> Hash) const;
 
   /// Helper function to recover a pointer into the trie from file offset.
-  LLVM_ABI_FOR_TEST Expected<ConstOnDiskPtr>
+  LLVM_ABI Expected<ConstOnDiskPtr>
   recoverFromFileOffset(FileOffset Offset) const;
 
   using LazyInsertOnConstructCB =
@@ -190,7 +190,7 @@ public:
   /// The in-memory \a TrieRawHashMap uses LazyAtomicPointer to synchronize
   /// simultaneous writes, but that seems dangerous to use in a memory-mapped
   /// file in case a process crashes in the busy state.
-  LLVM_ABI_FOR_TEST Expected<OnDiskPtr>
+  LLVM_ABI Expected<OnDiskPtr>
   insertLazy(ArrayRef<uint8_t> Hash,
              LazyInsertOnConstructCB OnConstruct = nullptr,
              LazyInsertOnLeakCB OnLeak = nullptr);
@@ -203,8 +203,8 @@ public:
     });
   }
 
-  LLVM_ABI_FOR_TEST size_t size() const;
-  LLVM_ABI_FOR_TEST size_t capacity() const;
+  LLVM_ABI size_t size() const;
+  LLVM_ABI size_t capacity() const;
 
   /// Gets or creates a file at \p Path with a hash-mapped trie named \p
   /// TrieName. The hash size is \p NumHashBits (in bits) and the records store
@@ -218,7 +218,7 @@ public:
   /// configure the trie, if it doesn't already exist.
   ///
   /// \pre NumHashBits is a multiple of 8 (byte-aligned).
-  LLVM_ABI_FOR_TEST static Expected<OnDiskTrieRawHashMap>
+  LLVM_ABI static Expected<OnDiskTrieRawHashMap>
   create(const Twine &Path, const Twine &TrieName, size_t NumHashBits,
          uint64_t DataSize, uint64_t MaxFileSize,
          std::optional<uint64_t> NewFileInitialSize,
@@ -226,9 +226,9 @@ public:
          std::optional<size_t> NewTableNumRootBits = std::nullopt,
          std::optional<size_t> NewTableNumSubtrieBits = std::nullopt);
 
-  LLVM_ABI_FOR_TEST OnDiskTrieRawHashMap(OnDiskTrieRawHashMap &&RHS);
-  LLVM_ABI_FOR_TEST OnDiskTrieRawHashMap &operator=(OnDiskTrieRawHashMap &&RHS);
-  LLVM_ABI_FOR_TEST ~OnDiskTrieRawHashMap();
+  LLVM_ABI OnDiskTrieRawHashMap(OnDiskTrieRawHashMap &&RHS);
+  LLVM_ABI OnDiskTrieRawHashMap &operator=(OnDiskTrieRawHashMap &&RHS);
+  LLVM_ABI ~OnDiskTrieRawHashMap();
 
 private:
   struct ImplType;

--- a/llvm/include/llvm/CAS/UnifiedOnDiskCache.h
+++ b/llvm/include/llvm/CAS/UnifiedOnDiskCache.h
@@ -64,7 +64,7 @@ public:
   /// \param FaultInPolicy Controls how nodes are copied to primary store. This
   /// is recorded at creation time and subsequent opens need to pass the same
   /// policy otherwise the \p open will fail.
-  LLVM_ABI_FOR_TEST static Expected<std::unique_ptr<UnifiedOnDiskCache>>
+  LLVM_ABI static Expected<std::unique_ptr<UnifiedOnDiskCache>>
   open(StringRef Path, std::optional<uint64_t> SizeLimit, StringRef HashName,
        unsigned HashByteSize,
        OnDiskGraphDB::FaultInPolicy FaultInPolicy =
@@ -100,7 +100,7 @@ public:
                    std::optional<StringRef> LLVMCasBinary);
 
   /// Validate the action cache only.
-  LLVM_ABI_FOR_TEST Error validateActionCache() const;
+  LLVM_ABI Error validateActionCache() const;
 
   /// This is called implicitly at destruction time, so it is not required for a
   /// client to call this. After calling \p close the only method that is valid
@@ -109,20 +109,20 @@ public:
   /// \param CheckSizeLimit if true it will check whether the primary store has
   /// exceeded its intended size limit. If false the check is skipped even if a
   /// \p SizeLimit was passed to the \p open call.
-  LLVM_ABI_FOR_TEST Error close(bool CheckSizeLimit = true);
+  LLVM_ABI Error close(bool CheckSizeLimit = true);
 
   /// Set the size for limiting growth. This has an effect for when the instance
   /// is closed.
-  LLVM_ABI_FOR_TEST void setSizeLimit(std::optional<uint64_t> SizeLimit);
+  LLVM_ABI void setSizeLimit(std::optional<uint64_t> SizeLimit);
 
   /// \returns the storage size of the cache data.
-  LLVM_ABI_FOR_TEST uint64_t getStorageSize() const;
+  LLVM_ABI uint64_t getStorageSize() const;
 
   /// \returns whether the primary store has exceeded the intended size limit.
   /// This can return false even if the overall size of the opened directory is
   /// over the \p SizeLimit passed to \p open. To know whether garbage
   /// collection needs to be triggered or not, call \p needsGarbaseCollection.
-  LLVM_ABI_FOR_TEST bool hasExceededSizeLimit() const;
+  LLVM_ABI bool hasExceededSizeLimit() const;
 
   /// \returns whether there are unused data that can be deleted using a
   /// \p collectGarbage call.
@@ -137,19 +137,19 @@ public:
   ///
   /// It is recommended that garbage-collection is triggered concurrently in the
   /// background, so that it has minimal effect on the workload of the process.
-  LLVM_ABI_FOR_TEST static Error
+  LLVM_ABI static Error
   collectGarbage(StringRef Path, ondisk::OnDiskCASLogger *Logger = nullptr);
 
   /// Remove unused data from the current UnifiedOnDiskCache.
   LLVM_ABI Error collectGarbage();
 
   /// Helper function to convert the value stored in KeyValueDB and ObjectID.
-  LLVM_ABI_FOR_TEST static ObjectID getObjectIDFromValue(ArrayRef<char> Value);
+  LLVM_ABI static ObjectID getObjectIDFromValue(ArrayRef<char> Value);
 
   using ValueBytes = std::array<char, sizeof(uint64_t)>;
-  LLVM_ABI_FOR_TEST static ValueBytes getValueFromObjectID(ObjectID ID);
+  LLVM_ABI static ValueBytes getValueFromObjectID(ObjectID ID);
 
-  LLVM_ABI_FOR_TEST ~UnifiedOnDiskCache();
+  LLVM_ABI ~UnifiedOnDiskCache();
 
 private:
   friend class OnDiskGraphDB;

--- a/llvm/include/llvm/CGData/StableFunctionMap.h
+++ b/llvm/include/llvm/CGData/StableFunctionMap.h
@@ -105,7 +105,7 @@ struct StableFunctionMap {
   using HashFuncsMapType = std::unordered_map<stable_hash, EntryStorage>;
 
   /// Get the HashToFuncs map for serialization.
-  LLVM_ABI_FOR_TEST const HashFuncsMapType &getFunctionMap() const;
+  LLVM_ABI const HashFuncsMapType &getFunctionMap() const;
 
   /// Get the NameToId vector for serialization.
   ArrayRef<std::string> getNames() const { return IdToName; }

--- a/llvm/include/llvm/CodeGen/MIR2Vec.h
+++ b/llvm/include/llvm/CodeGen/MIR2Vec.h
@@ -211,16 +211,14 @@ class MIRVocabulary {
 
 public:
   /// Static method for extracting base opcode names (public for testing)
-  LLVM_ABI_FOR_TEST static std::string
-  extractBaseOpcodeName(StringRef InstrName);
+  LLVM_ABI static std::string extractBaseOpcodeName(StringRef InstrName);
 
   /// Get indices from opcode or operand names. These are public for testing.
   /// String based lookups are inefficient and should be avoided in general.
-  LLVM_ABI_FOR_TEST unsigned
-  getCanonicalIndexForBaseName(StringRef BaseName) const;
-  LLVM_ABI_FOR_TEST unsigned
+  LLVM_ABI unsigned getCanonicalIndexForBaseName(StringRef BaseName) const;
+  LLVM_ABI unsigned
   getCanonicalIndexForOperandName(StringRef OperandName) const;
-  LLVM_ABI_FOR_TEST unsigned
+  LLVM_ABI unsigned
   getCanonicalIndexForRegisterClass(StringRef RegName,
                                     bool IsPhysical = true) const;
 
@@ -266,7 +264,7 @@ public:
   MIRVocabulary() = delete;
 
   /// Factory method to create MIRVocabulary from vocabulary map
-  LLVM_ABI_FOR_TEST static Expected<MIRVocabulary>
+  LLVM_ABI static Expected<MIRVocabulary>
   create(VocabMap &&OpcMap, VocabMap &&CommonOperandsMap, VocabMap &&PhyRegMap,
          VocabMap &&VirtRegMap, const TargetInstrInfo &TII,
          const TargetRegisterInfo &TRI, const MachineRegisterInfo &MRI);

--- a/llvm/include/llvm/IR/BasicBlock.h
+++ b/llvm/include/llvm/IR/BasicBlock.h
@@ -747,7 +747,7 @@ public:
   /// instructions, so the order should be validated no more than once after
   /// each ordering to ensure that transforms have the same algorithmic
   /// complexity when asserts are enabled as when they are disabled.
-  LLVM_ABI_FOR_TEST void validateInstrOrdering() const;
+  LLVM_ABI void validateInstrOrdering() const;
 };
 
 // Create wrappers for C Binding types (see CBindingWrapping.h).

--- a/llvm/include/llvm/Option/ArgList.h
+++ b/llvm/include/llvm/Option/ArgList.h
@@ -292,7 +292,7 @@ public:
   /// \return The name of the subcommand found. If no subcommand is found,
   /// this returns an empty StringRef. If multiple subcommands are found, the
   /// first one is returned.
-  LLVM_ABI_FOR_TEST StringRef getSubCommand(
+  LLVM_ABI StringRef getSubCommand(
       ArrayRef<OptTable::SubCommand> AllSubCommands,
       std::function<void(ArrayRef<StringRef>)> HandleMultipleSubcommands,
       std::function<void(ArrayRef<StringRef>)> HandleOtherPositionals) const;

--- a/llvm/include/llvm/SandboxIR/Argument.h
+++ b/llvm/include/llvm/SandboxIR/Argument.h
@@ -29,7 +29,7 @@ public:
     assert(isa<llvm::Argument>(Val) && "Expected Argument!");
   }
   void printAsOperand(raw_ostream &OS) const;
-  LLVM_ABI_FOR_TEST void dumpOS(raw_ostream &OS) const final;
+  LLVM_ABI void dumpOS(raw_ostream &OS) const final;
 #endif
 };
 

--- a/llvm/include/llvm/SandboxIR/BasicBlock.h
+++ b/llvm/include/llvm/SandboxIR/BasicBlock.h
@@ -104,7 +104,7 @@ public:
 
 #ifndef NDEBUG
   void verify() const final;
-  LLVM_ABI_FOR_TEST void dumpOS(raw_ostream &OS) const final;
+  LLVM_ABI void dumpOS(raw_ostream &OS) const final;
 #endif
 };
 

--- a/llvm/include/llvm/SandboxIR/Function.h
+++ b/llvm/include/llvm/SandboxIR/Function.h
@@ -73,8 +73,8 @@ public:
   void verify() const final {
     assert(isa<llvm::Function>(Val) && "Expected Function!");
   }
-  LLVM_ABI_FOR_TEST void dumpNameAndArgs(raw_ostream &OS) const;
-  LLVM_ABI_FOR_TEST void dumpOS(raw_ostream &OS) const final;
+  LLVM_ABI void dumpNameAndArgs(raw_ostream &OS) const;
+  LLVM_ABI void dumpOS(raw_ostream &OS) const final;
 #endif
 };
 

--- a/llvm/include/llvm/SandboxIR/Instruction.h
+++ b/llvm/include/llvm/SandboxIR/Instruction.h
@@ -1967,8 +1967,8 @@ public:
   public:
     CaseHandleImpl(Context &Ctx, LLVMCaseItT LLVMCaseIt)
         : Ctx(Ctx), LLVMCaseIt(LLVMCaseIt) {}
-    LLVM_ABI_FOR_TEST ConstT *getCaseValue() const;
-    LLVM_ABI_FOR_TEST BlockT *getCaseSuccessor() const;
+    LLVM_ABI ConstT *getCaseValue() const;
+    LLVM_ABI BlockT *getCaseSuccessor() const;
     unsigned getCaseIndex() const {
       const auto &LLVMCaseHandle = *LLVMCaseIt;
       return LLVMCaseHandle.getCaseIndex();

--- a/llvm/include/llvm/SandboxIR/Pass.h
+++ b/llvm/include/llvm/SandboxIR/Pass.h
@@ -65,7 +65,7 @@ public:
     return OS;
   }
   virtual void print(raw_ostream &OS) const { OS << Name; }
-  LLVM_ABI_FOR_TEST LLVM_DUMP_METHOD virtual void dump() const;
+  LLVM_ABI LLVM_DUMP_METHOD virtual void dump() const;
 #endif
   /// Similar to print() but adds a newline. Used for testing.
   virtual void printPipeline(raw_ostream &OS) const { OS << Name << "\n"; }

--- a/llvm/include/llvm/SandboxIR/Region.h
+++ b/llvm/include/llvm/SandboxIR/Region.h
@@ -189,10 +189,10 @@ public:
 
 #ifndef NDEBUG
   /// This is an expensive check, meant for testing.
-  LLVM_ABI_FOR_TEST bool operator==(const Region &Other) const;
+  LLVM_ABI bool operator==(const Region &Other) const;
   bool operator!=(const Region &other) const { return !(*this == other); }
 
-  LLVM_ABI_FOR_TEST void dump(raw_ostream &OS) const;
+  LLVM_ABI void dump(raw_ostream &OS) const;
   void dump() const;
   friend raw_ostream &operator<<(raw_ostream &OS, const Region &Rgn) {
     Rgn.dump(OS);

--- a/llvm/include/llvm/SandboxIR/Tracker.h
+++ b/llvm/include/llvm/SandboxIR/Tracker.h
@@ -115,10 +115,10 @@ public:
 
   /// Saves a snapshot of the current state. If there was any previous snapshot,
   /// it will be replaced with the new one.
-  LLVM_ABI_FOR_TEST void save();
+  LLVM_ABI void save();
 
   /// Checks current state against saved state, crashes if different.
-  LLVM_ABI_FOR_TEST void expectNoDiff();
+  LLVM_ABI void expectNoDiff();
 };
 
 #endif // NDEBUG

--- a/llvm/include/llvm/SandboxIR/Use.h
+++ b/llvm/include/llvm/SandboxIR/Use.h
@@ -76,7 +76,7 @@ public:
   }
   bool operator!=(const Use &Other) const { return !(*this == Other); }
 #ifndef NDEBUG
-  LLVM_ABI_FOR_TEST void dumpOS(raw_ostream &OS) const;
+  LLVM_ABI void dumpOS(raw_ostream &OS) const;
   void dump() const;
 #endif // NDEBUG
 };

--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -171,10 +171,12 @@
 /// for both functions and classes. On windows its turned in to dllimport for
 /// library consumers, for other platforms its a default visibility attribute.
 ///
-/// LLVM_ABI_FOR_TEST is for annotating symbols that are only exported because
-/// they are imported from a test. These symbols are not technically part of the
-/// LLVM public interface and could be conditionally excluded when not building
-/// tests in the future.
+/// LLVM_ABI_FOR_TEST is for annotating symbols that are exported from a
+/// library-internal header solely so that unit tests can link against them.
+/// Symbols in LLVM's public headers are part of the LLVM public interface and
+/// should use LLVM_ABI. LLVM_ABI_FOR_TEST is reserved for internal headers,
+/// whose symbols could be conditionally excluded when not building tests in the
+/// future.
 ///
 #ifndef LLVM_ABI_GENERATING_ANNOTATIONS
 // Marker to add to classes or functions in public headers that should not have

--- a/llvm/include/llvm/Support/GlobPattern.h
+++ b/llvm/include/llvm/Support/GlobPattern.h
@@ -82,7 +82,7 @@ public:
   StringRef suffix() const { return Pattern.take_back(SuffixSize); }
   // Returns the longest plain substring of the pattern between prefix and
   // suffix.
-  LLVM_ABI_FOR_TEST StringRef longest_substr() const;
+  LLVM_ABI StringRef longest_substr() const;
 
 private:
   StringRef Pattern;

--- a/llvm/include/llvm/Support/LSP/Logging.h
+++ b/llvm/include/llvm/Support/LSP/Logging.h
@@ -24,7 +24,7 @@ public:
   enum class Level { Debug, Info, Error };
 
   /// Set the severity level of the logger.
-  LLVM_ABI_FOR_TEST static void setLogLevel(Level LogLevel);
+  LLVM_ABI static void setLogLevel(Level LogLevel);
 
   /// Initiate a log message at various severity levels. These should be called
   /// after a call to `initialize`.
@@ -45,8 +45,8 @@ private:
   static Logger &get();
 
   /// Start a log message with the given severity level.
-  LLVM_ABI_FOR_TEST static void log(Level LogLevel, const char *Fmt,
-                                    const llvm::formatv_object_base &Message);
+  LLVM_ABI static void log(Level LogLevel, const char *Fmt,
+                           const llvm::formatv_object_base &Message);
 
   /// The minimum logging level. Messages with lower level are ignored.
   Level LogLevel = Level::Error;

--- a/llvm/include/llvm/Support/LSP/Protocol.h
+++ b/llvm/include/llvm/Support/LSP/Protocol.h
@@ -81,7 +81,7 @@ class LSPError : public llvm::ErrorInfo<LSPError> {
 public:
   std::string message;
   ErrorCode code;
-  LLVM_ABI_FOR_TEST static char ID;
+  LLVM_ABI static char ID;
 
   LSPError(std::string message, ErrorCode code)
       : message(std::move(message)), code(code) {}
@@ -146,9 +146,9 @@ private:
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const URIForFile &value);
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                URIForFile &result, llvm::json::Path path);
+LLVM_ABI llvm::json::Value toJSON(const URIForFile &value);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value, URIForFile &result,
+                       llvm::json::Path path);
 LLVM_ABI raw_ostream &operator<<(raw_ostream &os, const URIForFile &value);
 
 //===----------------------------------------------------------------------===//
@@ -172,9 +172,8 @@ struct ClientCapabilities {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                ClientCapabilities &result,
-                                llvm::json::Path path);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value,
+                       ClientCapabilities &result, llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // ClientInfo
@@ -189,8 +188,8 @@ struct ClientInfo {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                ClientInfo &result, llvm::json::Path path);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value, ClientInfo &result,
+                       llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // InitializeParams
@@ -203,8 +202,8 @@ enum class TraceLevel {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                TraceLevel &result, llvm::json::Path path);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value, TraceLevel &result,
+                       llvm::json::Path path);
 
 struct InitializeParams {
   /// The capabilities provided by the client (editor or tool).
@@ -225,9 +224,8 @@ struct InitializeParams {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                InitializeParams &result,
-                                llvm::json::Path path);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value, InitializeParams &result,
+                       llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // InitializedParams
@@ -258,9 +256,8 @@ struct TextDocumentItem {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                TextDocumentItem &result,
-                                llvm::json::Path path);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value, TextDocumentItem &result,
+                       llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // TextDocumentIdentifier
@@ -272,10 +269,9 @@ struct TextDocumentIdentifier {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const TextDocumentIdentifier &value);
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                TextDocumentIdentifier &result,
-                                llvm::json::Path path);
+LLVM_ABI llvm::json::Value toJSON(const TextDocumentIdentifier &value);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value,
+                       TextDocumentIdentifier &result, llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // VersionedTextDocumentIdentifier
@@ -289,11 +285,10 @@ struct VersionedTextDocumentIdentifier {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST llvm::json::Value
-toJSON(const VersionedTextDocumentIdentifier &value);
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                VersionedTextDocumentIdentifier &result,
-                                llvm::json::Path path);
+LLVM_ABI llvm::json::Value toJSON(const VersionedTextDocumentIdentifier &value);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value,
+                       VersionedTextDocumentIdentifier &result,
+                       llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // Position
@@ -341,9 +336,9 @@ struct Position {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                Position &result, llvm::json::Path path);
-LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const Position &value);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value, Position &result,
+                       llvm::json::Path path);
+LLVM_ABI llvm::json::Value toJSON(const Position &value);
 LLVM_ABI raw_ostream &operator<<(raw_ostream &os, const Position &value);
 
 //===----------------------------------------------------------------------===//
@@ -394,9 +389,9 @@ struct Range {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value, Range &result,
-                                llvm::json::Path path);
-LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const Range &value);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value, Range &result,
+                       llvm::json::Path path);
+LLVM_ABI llvm::json::Value toJSON(const Range &value);
 LLVM_ABI raw_ostream &operator<<(raw_ostream &os, const Range &value);
 
 //===----------------------------------------------------------------------===//
@@ -429,9 +424,9 @@ struct Location {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                Location &result, llvm::json::Path path);
-LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const Location &value);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value, Location &result,
+                       llvm::json::Path path);
+LLVM_ABI llvm::json::Value toJSON(const Location &value);
 LLVM_ABI raw_ostream &operator<<(raw_ostream &os, const Location &value);
 
 //===----------------------------------------------------------------------===//
@@ -447,9 +442,9 @@ struct TextDocumentPositionParams {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                TextDocumentPositionParams &result,
-                                llvm::json::Path path);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value,
+                       TextDocumentPositionParams &result,
+                       llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // ReferenceParams
@@ -461,17 +456,16 @@ struct ReferenceContext {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                ReferenceContext &result,
-                                llvm::json::Path path);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value, ReferenceContext &result,
+                       llvm::json::Path path);
 
 struct ReferenceParams : TextDocumentPositionParams {
   ReferenceContext context;
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                ReferenceParams &result, llvm::json::Path path);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value, ReferenceParams &result,
+                       llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // DidOpenTextDocumentParams
@@ -483,9 +477,9 @@ struct DidOpenTextDocumentParams {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                DidOpenTextDocumentParams &result,
-                                llvm::json::Path path);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value,
+                       DidOpenTextDocumentParams &result,
+                       llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // DidCloseTextDocumentParams
@@ -497,9 +491,9 @@ struct DidCloseTextDocumentParams {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                DidCloseTextDocumentParams &result,
-                                llvm::json::Path path);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value,
+                       DidCloseTextDocumentParams &result,
+                       llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // DidSaveTextDocumentParams
@@ -510,8 +504,8 @@ struct DidSaveTextDocumentParams {
   TextDocumentIdentifier textDocument;
 };
 
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &,
-                                DidSaveTextDocumentParams &, llvm::json::Path);
+LLVM_ABI bool fromJSON(const llvm::json::Value &, DidSaveTextDocumentParams &,
+                       llvm::json::Path);
 
 //===----------------------------------------------------------------------===//
 // DidChangeTextDocumentParams
@@ -536,9 +530,9 @@ struct TextDocumentContentChangeEvent {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                TextDocumentContentChangeEvent &result,
-                                llvm::json::Path path);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value,
+                       TextDocumentContentChangeEvent &result,
+                       llvm::json::Path path);
 
 struct DidChangeTextDocumentParams {
   /// The document that changed.
@@ -549,9 +543,9 @@ struct DidChangeTextDocumentParams {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                DidChangeTextDocumentParams &result,
-                                llvm::json::Path path);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value,
+                       DidChangeTextDocumentParams &result,
+                       llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // MarkupContent
@@ -571,7 +565,7 @@ struct MarkupContent {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const MarkupContent &mc);
+LLVM_ABI llvm::json::Value toJSON(const MarkupContent &mc);
 
 //===----------------------------------------------------------------------===//
 // Hover
@@ -590,7 +584,7 @@ struct Hover {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const Hover &hover);
+LLVM_ABI llvm::json::Value toJSON(const Hover &hover);
 
 //===----------------------------------------------------------------------===//
 // SymbolKind
@@ -665,7 +659,7 @@ struct DocumentSymbol {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const DocumentSymbol &symbol);
+LLVM_ABI llvm::json::Value toJSON(const DocumentSymbol &symbol);
 
 //===----------------------------------------------------------------------===//
 // DocumentSymbolParams
@@ -677,9 +671,8 @@ struct DocumentSymbolParams {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                DocumentSymbolParams &result,
-                                llvm::json::Path path);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value,
+                       DocumentSymbolParams &result, llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // DiagnosticRelatedInformation
@@ -700,11 +693,10 @@ struct DiagnosticRelatedInformation {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                DiagnosticRelatedInformation &result,
-                                llvm::json::Path path);
-LLVM_ABI_FOR_TEST llvm::json::Value
-toJSON(const DiagnosticRelatedInformation &info);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value,
+                       DiagnosticRelatedInformation &result,
+                       llvm::json::Path path);
+LLVM_ABI llvm::json::Value toJSON(const DiagnosticRelatedInformation &info);
 
 //===----------------------------------------------------------------------===//
 // Diagnostic
@@ -726,9 +718,9 @@ enum class DiagnosticTag {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST llvm::json::Value toJSON(DiagnosticTag tag);
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                DiagnosticTag &result, llvm::json::Path path);
+LLVM_ABI llvm::json::Value toJSON(DiagnosticTag tag);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value, DiagnosticTag &result,
+                       llvm::json::Path path);
 
 struct Diagnostic {
   /// The source range where the message applies.
@@ -760,9 +752,9 @@ struct Diagnostic {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const Diagnostic &diag);
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                Diagnostic &result, llvm::json::Path path);
+LLVM_ABI llvm::json::Value toJSON(const Diagnostic &diag);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value, Diagnostic &result,
+                       llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // PublishDiagnosticsParams
@@ -781,8 +773,7 @@ struct PublishDiagnosticsParams {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST llvm::json::Value
-toJSON(const PublishDiagnosticsParams &params);
+LLVM_ABI llvm::json::Value toJSON(const PublishDiagnosticsParams &params);
 
 //===----------------------------------------------------------------------===//
 // TextEdit
@@ -802,9 +793,9 @@ inline bool operator==(const TextEdit &lhs, const TextEdit &rhs) {
   return std::tie(lhs.newText, lhs.range) == std::tie(rhs.newText, rhs.range);
 }
 
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                TextEdit &result, llvm::json::Path path);
-LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const TextEdit &value);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value, TextEdit &result,
+                       llvm::json::Path path);
+LLVM_ABI llvm::json::Value toJSON(const TextEdit &value);
 LLVM_ABI raw_ostream &operator<<(raw_ostream &os, const TextEdit &value);
 
 //===----------------------------------------------------------------------===//
@@ -840,18 +831,16 @@ enum class CompletionItemKind {
   Operator = 24,
   TypeParameter = 25,
 };
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                CompletionItemKind &result,
-                                llvm::json::Path path);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value,
+                       CompletionItemKind &result, llvm::json::Path path);
 
 constexpr auto kCompletionItemKindMin =
     static_cast<size_t>(CompletionItemKind::Text);
 constexpr auto kCompletionItemKindMax =
     static_cast<size_t>(CompletionItemKind::TypeParameter);
 using CompletionItemKindBitset = std::bitset<kCompletionItemKindMax + 1>;
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                CompletionItemKindBitset &result,
-                                llvm::json::Path path);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value,
+                       CompletionItemKindBitset &result, llvm::json::Path path);
 
 LLVM_ABI CompletionItemKind
 adjustKindToCapability(CompletionItemKind kind,
@@ -934,7 +923,7 @@ struct CompletionItem {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const CompletionItem &value);
+LLVM_ABI llvm::json::Value toJSON(const CompletionItem &value);
 LLVM_ABI raw_ostream &operator<<(raw_ostream &os, const CompletionItem &value);
 LLVM_ABI bool operator<(const CompletionItem &lhs, const CompletionItem &rhs);
 
@@ -953,7 +942,7 @@ struct CompletionList {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const CompletionList &value);
+LLVM_ABI llvm::json::Value toJSON(const CompletionList &value);
 
 //===----------------------------------------------------------------------===//
 // CompletionContext
@@ -982,9 +971,8 @@ struct CompletionContext {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                CompletionContext &result,
-                                llvm::json::Path path);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value,
+                       CompletionContext &result, llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // CompletionParams
@@ -995,9 +983,8 @@ struct CompletionParams : TextDocumentPositionParams {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                CompletionParams &result,
-                                llvm::json::Path path);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value, CompletionParams &result,
+                       llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // ParameterInformation
@@ -1017,7 +1004,7 @@ struct ParameterInformation {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const ParameterInformation &value);
+LLVM_ABI llvm::json::Value toJSON(const ParameterInformation &value);
 
 //===----------------------------------------------------------------------===//
 // SignatureInformation
@@ -1036,7 +1023,7 @@ struct SignatureInformation {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const SignatureInformation &value);
+LLVM_ABI llvm::json::Value toJSON(const SignatureInformation &value);
 LLVM_ABI raw_ostream &operator<<(raw_ostream &os,
                                  const SignatureInformation &value);
 
@@ -1057,7 +1044,7 @@ struct SignatureHelp {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const SignatureHelp &value);
+LLVM_ABI llvm::json::Value toJSON(const SignatureHelp &value);
 
 //===----------------------------------------------------------------------===//
 // DocumentLinkParams
@@ -1070,9 +1057,8 @@ struct DocumentLinkParams {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                DocumentLinkParams &result,
-                                llvm::json::Path path);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value,
+                       DocumentLinkParams &result, llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // DocumentLink
@@ -1108,7 +1094,7 @@ struct DocumentLink {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const DocumentLink &value);
+LLVM_ABI llvm::json::Value toJSON(const DocumentLink &value);
 
 //===----------------------------------------------------------------------===//
 // InlayHintsParams
@@ -1124,9 +1110,8 @@ struct InlayHintsParams {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                InlayHintsParams &result,
-                                llvm::json::Path path);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value, InlayHintsParams &result,
+                       llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // InlayHintKind
@@ -1186,7 +1171,7 @@ struct InlayHint {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const InlayHint &);
+LLVM_ABI llvm::json::Value toJSON(const InlayHint &);
 LLVM_ABI bool operator==(const InlayHint &lhs, const InlayHint &rhs);
 LLVM_ABI bool operator<(const InlayHint &lhs, const InlayHint &rhs);
 LLVM_ABI llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
@@ -1213,9 +1198,8 @@ struct CodeActionContext {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                CodeActionContext &result,
-                                llvm::json::Path path);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value,
+                       CodeActionContext &result, llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // CodeActionParams
@@ -1233,9 +1217,8 @@ struct CodeActionParams {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                CodeActionParams &result,
-                                llvm::json::Path path);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value, CodeActionParams &result,
+                       llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // WorkspaceEdit
@@ -1250,9 +1233,9 @@ struct WorkspaceEdit {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
-                                WorkspaceEdit &result, llvm::json::Path path);
-LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const WorkspaceEdit &value);
+LLVM_ABI bool fromJSON(const llvm::json::Value &value, WorkspaceEdit &result,
+                       llvm::json::Path path);
+LLVM_ABI llvm::json::Value toJSON(const WorkspaceEdit &value);
 
 //===----------------------------------------------------------------------===//
 // CodeAction
@@ -1289,7 +1272,7 @@ struct CodeAction {
 };
 
 /// Add support for JSON serialization.
-LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const CodeAction &);
+LLVM_ABI llvm::json::Value toJSON(const CodeAction &);
 
 //===----------------------------------------------------------------------===//
 //  ShowMessageParams

--- a/llvm/include/llvm/Support/LSP/Transport.h
+++ b/llvm/include/llvm/Support/LSP/Transport.h
@@ -104,14 +104,14 @@ public:
         PrettyOutput(PrettyOutput) {}
 
   /// The following methods are used to send a message to the LSP client.
-  LLVM_ABI_FOR_TEST void notify(StringRef Method, llvm::json::Value Params);
-  LLVM_ABI_FOR_TEST void call(StringRef Method, llvm::json::Value Params,
-                              llvm::json::Value Id);
-  LLVM_ABI_FOR_TEST void reply(llvm::json::Value Id,
-                               llvm::Expected<llvm::json::Value> Result);
+  LLVM_ABI void notify(StringRef Method, llvm::json::Value Params);
+  LLVM_ABI void call(StringRef Method, llvm::json::Value Params,
+                     llvm::json::Value Id);
+  LLVM_ABI void reply(llvm::json::Value Id,
+                      llvm::Expected<llvm::json::Value> Result);
 
   /// Start executing the JSON-RPC transport.
-  LLVM_ABI_FOR_TEST llvm::Error run(MessageHandler &Handler);
+  LLVM_ABI llvm::Error run(MessageHandler &Handler);
 
 private:
   /// Dispatches the given incoming json message to the message handler.

--- a/llvm/include/llvm/Support/VirtualOutputConfig.h
+++ b/llvm/include/llvm/Support/VirtualOutputConfig.h
@@ -36,7 +36,7 @@ struct EmptyBaseClass {};
 /// configuration flag is either \c true or \c false.
 struct OutputConfig : detail::EmptyBaseClass {
 public:
-  LLVM_ABI_FOR_TEST void print(raw_ostream &OS) const;
+  LLVM_ABI void print(raw_ostream &OS) const;
   LLVM_ABI void dump() const;
 
 #define HANDLE_OUTPUT_CONFIG_FLAG(NAME, DEFAULT)                               \
@@ -61,7 +61,7 @@ public:
   /// Updates Text and CRLF flags based on \a sys::fs::OF_Text and \a
   /// sys::fs::OF_CRLF in \p Flags. Rejects CRLF without Text (calling
   /// \a setBinary()).
-  LLVM_ABI_FOR_TEST OutputConfig &setOpenFlags(const sys::fs::OpenFlags &Flags);
+  LLVM_ABI OutputConfig &setOpenFlags(const sys::fs::OpenFlags &Flags);
 
   constexpr OutputConfig()
       : EmptyBaseClass()
@@ -86,8 +86,7 @@ private:
 
 } // namespace vfs
 
-LLVM_ABI_FOR_TEST raw_ostream &operator<<(raw_ostream &OS,
-                                          vfs::OutputConfig Config);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, vfs::OutputConfig Config);
 
 } // namespace llvm
 

--- a/llvm/include/llvm/Transforms/Utils/DebugSSAUpdater.h
+++ b/llvm/include/llvm/Transforms/Utils/DebugSSAUpdater.h
@@ -343,7 +343,7 @@ class DbgValueRangeTable {
   DenseMap<DebugVariableAggregate, DbgValueDef> OrigSingleLocVariableValueTable;
 
 public:
-  LLVM_ABI_FOR_TEST void addVariable(Function *F, DebugVariableAggregate DVA);
+  LLVM_ABI void addVariable(Function *F, DebugVariableAggregate DVA);
   bool hasVariableEntry(DebugVariableAggregate DVA) const {
     return OrigVariableValueRangeTable.contains(DVA) ||
            OrigSingleLocVariableValueTable.contains(DVA);

--- a/llvm/include/llvm/Transforms/Utils/SSAUpdaterBulk.h
+++ b/llvm/include/llvm/Transforms/Utils/SSAUpdaterBulk.h
@@ -81,10 +81,10 @@ public:
 
   /// Rewrite all uses and simplify the inserted PHI nodes.
   /// Use this method to preserve behavior when replacing SSAUpdater.
-  LLVM_ABI_FOR_TEST void RewriteAndOptimizeAllUses(DominatorTree &DT);
+  LLVM_ABI void RewriteAndOptimizeAllUses(DominatorTree &DT);
 };
 
-LLVM_ABI_FOR_TEST bool
+LLVM_ABI bool
 EliminateNewDuplicatePHINodes(BasicBlock *BB,
                               BasicBlock::phi_iterator FirstExistingPN);
 


### PR DESCRIPTION
These annotations were mistakenly set up as LLVM_ABI_FOR_TEST. Since these are public headers, they should be using LLVM_ABI.

The effort to build LLVM as a dylib is tracked in #109483.