### PR TITLE
[lldb] Don't enable Objective-C in expressions on unsupported formats

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -652,6 +652,12 @@ static void SetupLangOpts(CompilerInstance &compiler,
     break;
   }
 
+  // The cases above enable Objective-C speculatively; undo that for targets
+  // whose object file format can't support it.
+  if (!ObjCLanguageRuntime::IsSupportedForArchitecture(
+          ArchSpec(compiler.getTargetOpts().Triple)))
+    lang_opts.ObjC = false;
+
   diagnostic_manager.AddDiagnostic(
       llvm::formatv("{0}Ran expression as '{1}'.", language_fallback_reason,
                     lldb_private::Language::GetDisplayNameForLanguageType(

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.cpp
@@ -19,6 +19,7 @@
 #include "lldb/Symbol/Variable.h"
 #include "lldb/Target/ABI.h"
 #include "lldb/Target/Target.h"
+#include "lldb/Utility/ArchSpec.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/Timer.h"
@@ -35,6 +36,19 @@ char ObjCLanguageRuntime::ID = 0;
 
 // Destructor
 ObjCLanguageRuntime::~ObjCLanguageRuntime() = default;
+
+bool ObjCLanguageRuntime::IsSupportedForArchitecture(const ArchSpec &arch) {
+  // These are the only object file formats clang can emit Objective-C
+  // metadata for; it aborts on any other.
+  switch (arch.GetTriple().getObjectFormat()) {
+  case llvm::Triple::MachO:
+  case llvm::Triple::ELF:
+  case llvm::Triple::COFF:
+    return true;
+  default:
+    return false;
+  }
+}
 
 ObjCLanguageRuntime::ObjCLanguageRuntime(Process *process)
     : LanguageRuntime(process), m_impl_cache(), m_impl_str_cache(),

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
@@ -226,6 +226,11 @@ public:
         process.GetLanguageRuntime(lldb::eLanguageTypeObjC));
   }
 
+  /// Returns whether the architecture's object file format supports
+  /// Objective-C code generation. Generating Objective-C for a format that
+  /// does not aborts the compiler.
+  static bool IsSupportedForArchitecture(const ArchSpec &arch);
+
   virtual TaggedPointerVendor *GetTaggedPointerVendor() { return nullptr; }
 
   typedef std::shared_ptr<EncodingToType> EncodingToTypeSP;

--- a/lldb/test/Shell/Expr/wasm-no-objc-codegen.test
+++ b/lldb/test/Shell/Expr/wasm-no-objc-codegen.test
@@ -1,0 +1,18 @@
+# Evaluating an expression for a target whose object file format has no
+# Objective-C code generation used to abort the compiler, because LLDB enables
+# Objective-C speculatively. It should fall back to C/C++ instead.
+
+# RUN: yaml2obj %s -o %t
+# RUN: %lldb %t -b -o "expr 1 + 1" 2>&1 | FileCheck %s
+
+# CHECK: (int) $0 = 2
+
+--- !WASM
+FileHeader:
+  Version: 0x00000001
+Sections:
+  - Type: CODE
+    Functions:
+      - Index:  0
+        Locals: []
+        Body:   0B


### PR DESCRIPTION
Evaluating any expression against a WebAssembly target aborted LLDB:

```
(lldb) expr (int)sizeof(Point)
LLVM ERROR: Objective-C support is unimplemented for object file format
```

WebAssembly can't JIT expressions (RuntimeDyld doesn't support the Wasm object format, so ProcessWasm sets CanJIT to false), but it can handle simple expressions that can be IR interpreted.

When setting up the expression's language options, LLDB speculatively enables Objective-C, which trips up the fatal error as Objective-C code generation only supports Mach-O, ELF, and COFF.

Add ObjCLanguageRuntime::IsSupportedForArchitecture and disable Objective-C in the expression's language options when the target's object file format can't support it, parsing as C/C++ instead. The IR interpreter can then evaluate what it supports, and the rest fails cleanly instead of crashing.