### PR TITLE
[DWARFLinker] Fix data race on the global parallel strategy

### DIFF
--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.cpp
@@ -68,7 +68,6 @@ void DWARFLinkerImpl::addObjectFile(DWARFFile &File, ObjFileLoaderTy Loader,
     for (const std::unique_ptr<DWARFUnit> &CU :
          ObjectContexts.back()->InputDWARFFile.Dwarf->compile_units()) {
       DWARFDie CUDie = CU->getUnitDIE();
-      OverallNumberOfCU++;
 
       if (!CUDie)
         continue;
@@ -175,12 +174,16 @@ Error DWARFLinkerImpl::link() {
     });
   }
 
-  // Set parallel options.
-  if (GlobalData.getOptions().Threads == 0)
-    llvm::parallel::strategy = optimal_concurrency(OverallNumberOfCU);
-  else
+  // Set this process-global once. link() runs per architecture and dsymutil
+  // may run those links concurrently, so assigning it from each would be a
+  // data race; the thread count is the same for every architecture, so the
+  // first assignment suffices. Size the executor from that thread count rather
+  // than the per-architecture CU count, which is moot once it is shared.
+  static llvm::once_flag ParallelStrategyFlag;
+  llvm::call_once(ParallelStrategyFlag, [&] {
     llvm::parallel::strategy =
         hardware_concurrency(GlobalData.getOptions().Threads);
+  });
 
   // Link object files.
   if (GlobalData.getOptions().Threads == 1) {

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.h
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.h
@@ -431,9 +431,6 @@ protected:
 
   /// Hanler for output sections.
   SectionHandlerTy SectionHandler = nullptr;
-
-  /// Overall compile units number.
-  uint64_t OverallNumberOfCU = 0;
   /// @}
 };
 

--- a/llvm/test/tools/dsymutil/X86/fat-multiarch-parallel-link.test
+++ b/llvm/test/tools/dsymutil/X86/fat-multiarch-parallel-link.test
@@ -1,0 +1,16 @@
+# Check that the parallel linker handles a universal binary, which exercises
+# linking multiple architectures concurrently. Each slice defines a uniquely
+# named variable, so seeing all three confirms every slice was linked; the
+# classic linker is checked too for parity.
+
+# REQUIRES: object-emission,system-darwin
+
+# RUN: dsymutil --linker parallel -oso-prepend-path %p/.. %p/../Inputs/fat-test.dylib -o %t.parallel.dSYM
+# RUN: llvm-dwarfdump -debug-info %t.parallel.dSYM/Contents/Resources/DWARF/fat-test.dylib | FileCheck %s
+
+# RUN: dsymutil --linker classic -oso-prepend-path %p/.. %p/../Inputs/fat-test.dylib -o %t.classic.dSYM
+# RUN: llvm-dwarfdump -debug-info %t.classic.dSYM/Contents/Resources/DWARF/fat-test.dylib | FileCheck %s
+
+# CHECK-DAG: DW_AT_name{{.*}}"i386_var"
+# CHECK-DAG: DW_AT_name{{.*}}"x86_64_var"
+# CHECK-DAG: DW_AT_name{{.*}}"x86_64h_var"


### PR DESCRIPTION
DWARFLinkerImpl::link() assigned the process-global llvm::parallel::strategy on entry. dsymutil runs link() concurrently, one call per architecture of a universal binary, so those assignments race. An inconsistent strategy can route per-compile-unit cloning onto a thread that is not an llvm::parallel ThreadPoolExecutor worker, where the per-thread allocators call getThreadIndex().

This manifested itself as an assert, but otherwise returns in a out-of-bounds.

```
Assertion failed: ((threadIndex != UINT_MAX) && "getThreadIndex() must be called from a thread created by " "ThreadPoolExecutor"), function getThreadIndex, file Parallel.h, line 51.
```

The assert is non-deterministic and needs more than one architecture to reproduce.

Set the strategy under llvm::call_once so only the first link writes it. Base it on the requested thread count, which is the same for every architecture, rather than the per-architecture compile-unit count the code used before which would race.

rdar://179339642