### PR TITLE
[AMDGPU] Remove TransCoexecutionHazard feature from gfx13

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPU.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.td
@@ -2326,8 +2326,7 @@ def FeatureISAVersion13 : FeatureSet<
    FeatureCvtNormInsts,
    FeatureCvtPkNormVOP2Insts,
    FeatureCvtPkNormVOP3Insts,
-   FeatureSmemPrefetchInsts,
-   FeatureTransCoexecutionHazard
+   FeatureSmemPrefetchInsts
 ]>;
 
 //===----------------------------------------------------------------------===//

--- a/llvm/test/CodeGen/AMDGPU/carryout-selection.ll
+++ b/llvm/test/CodeGen/AMDGPU/carryout-selection.ll
@@ -3855,9 +3855,8 @@ define amdgpu_kernel void @sudiv64(ptr addrspace(1) %out, i64 %x, i64 %y) {
 ; GFX13-NEXT:    v_cvt_f32_u32_e32 v0, s4
 ; GFX13-NEXT:    s_sub_co_i32 s5, 0, s4
 ; GFX13-NEXT:    s_mov_b32 s9, 0
-; GFX13-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
+; GFX13-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(TRANS32_DEP_1)
 ; GFX13-NEXT:    v_rcp_iflag_f32_e32 v0, v0
-; GFX13-NEXT:    v_nop
 ; GFX13-NEXT:    v_mul_f32_e32 v0, 0x4f7ffffe, v0
 ; GFX13-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX13-NEXT:    v_cvt_u32_f32_e32 v0, v0

--- a/llvm/test/CodeGen/AMDGPU/trans-coexecution-hazard.mir
+++ b/llvm/test/CodeGen/AMDGPU/trans-coexecution-hazard.mir
@@ -16,7 +16,6 @@ body:            |
     ;
     ; GFX1310-LABEL: name: trans_writes_valu_reads_hazard
     ; GFX1310: $vgpr1 = V_SQRT_F32_e32 $vgpr0, implicit $mode, implicit $exec
-    ; GFX1310-NEXT: V_NOP_e32 implicit $exec
     ; GFX1310-NEXT: $vgpr3 = V_ADD_F32_e32 $vgpr1, $vgpr2, implicit $mode, implicit $exec
     ;
     ; GFX1200-LABEL: name: trans_writes_valu_reads_hazard
@@ -52,7 +51,6 @@ body:            |
     ; GFX1310-LABEL: name: trans_writes_salu_valu_reads_hazard
     ; GFX1310: $vgpr1 = V_SQRT_F32_e32 $vgpr0, implicit $mode, implicit $exec
     ; GFX1310-NEXT: $sgpr2 = S_ADD_U32 $sgpr0, $sgpr1, implicit-def $scc
-    ; GFX1310-NEXT: V_NOP_e32 implicit $exec
     ; GFX1310-NEXT: $vgpr4 = V_ADD_F32_e32 $vgpr1, $vgpr2, implicit $mode, implicit $exec
     ;
     ; GFX1200-LABEL: name: trans_writes_salu_valu_reads_hazard
@@ -86,7 +84,6 @@ body:            |
     ;
     ; GFX1310-LABEL: name: trans_reads_valu_writes_hazard
     ; GFX1310: $vgpr1 = V_COS_F32_e32 $vgpr0, implicit $mode, implicit $exec
-    ; GFX1310-NEXT: V_NOP_e32 implicit $exec
     ; GFX1310-NEXT: $vgpr0 = V_ADD_F32_e32 $vgpr2, $vgpr3, implicit $mode, implicit $exec
     ;
     ; GFX1200-LABEL: name: trans_reads_valu_writes_hazard
@@ -122,7 +119,6 @@ body:            |
     ; GFX1310-LABEL: name: trans_reads__salu_valu_writes_hazard
     ; GFX1310: $vgpr1 = V_COS_F32_e32 $vgpr0, implicit $mode, implicit $exec
     ; GFX1310-NEXT: $sgpr2 = S_ADD_U32 $sgpr0, $sgpr1, implicit-def $scc
-    ; GFX1310-NEXT: V_NOP_e32 implicit $exec
     ; GFX1310-NEXT: $vgpr0 = V_ADD_F32_e32 $vgpr4, $vgpr2, implicit $mode, implicit $exec
     ;
     ; GFX1200-LABEL: name: trans_reads__salu_valu_writes_hazard


### PR DESCRIPTION
  No TRANS coexecution hazard on gfx13 based on the latest SPG.