### PR TITLE
[flang][OpenMP] Emit warning that REVERSE_OFFLOAD is not supported

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -5694,6 +5694,12 @@ void OmpStructureChecker::Enter(const parser::OmpClause::DynamicAllocators &x) {
 
 void OmpStructureChecker::Enter(const parser::OmpClause::ReverseOffload &x) {
   CheckAllowedRequiresClause(llvm::omp::Clause::OMPC_reverse_offload);
+  if (IsAllowedClause(llvm::omp::Clause::OMPC_reverse_offload)) {
+    unsigned version{context_.langOptions().OpenMPVersion};
+    context_.Say(GetContext().clauseSource,
+        "%s clause is not supported and will be ignored"_warn_en_US,
+        GetUpperName(llvm::omp::Clause::OMPC_reverse_offload, version));
+  }
 }
 
 void OmpStructureChecker::Enter(const parser::OmpClause::UnifiedAddress &x) {

--- a/flang/test/Semantics/OpenMP/declarative-directive01.f90
+++ b/flang/test/Semantics/OpenMP/declarative-directive01.f90
@@ -6,6 +6,7 @@
 
 subroutine requires_1(a)
   real(8), intent(inout) :: a
+  !WARNING: REVERSE_OFFLOAD clause is not supported and will be ignored
   !$omp requires reverse_offload, unified_shared_memory, atomic_default_mem_order(relaxed)
   a = a + 0.01
 end subroutine requires_1

--- a/flang/test/Semantics/OpenMP/requires01.f90
+++ b/flang/test/Semantics/OpenMP/requires01.f90
@@ -1,5 +1,6 @@
 ! RUN: %python %S/../test_errors.py %s %flang -fopenmp
 
+!WARNING: REVERSE_OFFLOAD clause is not supported and will be ignored
 !$omp requires reverse_offload unified_shared_memory
 
 !ERROR: NOWAIT clause is not allowed on the REQUIRES directive

--- a/flang/test/Semantics/OpenMP/requires03.f90
+++ b/flang/test/Semantics/OpenMP/requires03.f90
@@ -12,6 +12,7 @@ end subroutine f
 subroutine g
   !ERROR: REQUIRES directive with 'DYNAMIC_ALLOCATORS' clause found lexically after device construct
   !$omp requires dynamic_allocators
+  !WARNING: REVERSE_OFFLOAD clause is not supported and will be ignored
   !ERROR: REQUIRES directive with 'REVERSE_OFFLOAD' clause found lexically after device construct
   !$omp requires reverse_offload
   !ERROR: REQUIRES directive with 'UNIFIED_ADDRESS' clause found lexically after device construct

--- a/flang/test/Semantics/OpenMP/requires04.f90
+++ b/flang/test/Semantics/OpenMP/requires04.f90
@@ -14,6 +14,7 @@ end subroutine f
 subroutine g
   !ERROR: REQUIRES directive with 'DYNAMIC_ALLOCATORS' clause found lexically after device construct
   !$omp requires dynamic_allocators
+  !WARNING: REVERSE_OFFLOAD clause is not supported and will be ignored
   !ERROR: REQUIRES directive with 'REVERSE_OFFLOAD' clause found lexically after device construct
   !$omp requires reverse_offload
   !ERROR: REQUIRES directive with 'UNIFIED_ADDRESS' clause found lexically after device construct

--- a/flang/test/Semantics/OpenMP/requires05.f90
+++ b/flang/test/Semantics/OpenMP/requires05.f90
@@ -13,6 +13,7 @@ end subroutine f
 subroutine g
   !ERROR: REQUIRES directive with 'DYNAMIC_ALLOCATORS' clause found lexically after device construct
   !$omp requires dynamic_allocators
+  !WARNING: REVERSE_OFFLOAD clause is not supported and will be ignored
   !ERROR: REQUIRES directive with 'REVERSE_OFFLOAD' clause found lexically after device construct
   !$omp requires reverse_offload
   !ERROR: REQUIRES directive with 'UNIFIED_ADDRESS' clause found lexically after device construct

--- a/flang/test/Semantics/OpenMP/requires06.f90
+++ b/flang/test/Semantics/OpenMP/requires06.f90
@@ -11,6 +11,7 @@ end subroutine f
 subroutine g
   !ERROR: REQUIRES directive with 'DYNAMIC_ALLOCATORS' clause found lexically after device construct
   !$omp requires dynamic_allocators
+  !WARNING: REVERSE_OFFLOAD clause is not supported and will be ignored
   !ERROR: REQUIRES directive with 'REVERSE_OFFLOAD' clause found lexically after device construct
   !$omp requires reverse_offload
   !ERROR: REQUIRES directive with 'UNIFIED_ADDRESS' clause found lexically after device construct

--- a/flang/test/Semantics/OpenMP/requires07.f90
+++ b/flang/test/Semantics/OpenMP/requires07.f90
@@ -12,6 +12,7 @@ end subroutine f
 subroutine g
   !ERROR: REQUIRES directive with 'DYNAMIC_ALLOCATORS' clause found lexically after device construct
   !$omp requires dynamic_allocators
+  !WARNING: REVERSE_OFFLOAD clause is not supported and will be ignored
   !ERROR: REQUIRES directive with 'REVERSE_OFFLOAD' clause found lexically after device construct
   !$omp requires reverse_offload
   !ERROR: REQUIRES directive with 'UNIFIED_ADDRESS' clause found lexically after device construct

--- a/flang/test/Semantics/OpenMP/requires08.f90
+++ b/flang/test/Semantics/OpenMP/requires08.f90
@@ -14,6 +14,7 @@ end subroutine f
 subroutine g
   !ERROR: REQUIRES directive with 'DYNAMIC_ALLOCATORS' clause found lexically after device construct
   !$omp requires dynamic_allocators
+  !WARNING: REVERSE_OFFLOAD clause is not supported and will be ignored
   !ERROR: REQUIRES directive with 'REVERSE_OFFLOAD' clause found lexically after device construct
   !$omp requires reverse_offload
   !ERROR: REQUIRES directive with 'UNIFIED_ADDRESS' clause found lexically after device construct

--- a/flang/test/Semantics/OpenMP/requires10.f90
+++ b/flang/test/Semantics/OpenMP/requires10.f90
@@ -2,12 +2,14 @@
 
 subroutine f00(x)
   logical :: x
+  !WARNING: REVERSE_OFFLOAD clause is not supported and will be ignored
   !ERROR: An argument to REVERSE_OFFLOAD is an OpenMP v6.0 feature, try -fopenmp-version=60
   !ERROR: Must be a constant value
   !$omp requires reverse_offload(x)
 end
 
 subroutine f01
+  !WARNING: REVERSE_OFFLOAD clause is not supported and will be ignored
   !WARNING: An argument to REVERSE_OFFLOAD is an OpenMP v6.0 feature, try -fopenmp-version=60
   !$omp requires reverse_offload(.true.)
 end

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.td
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.td
@@ -1084,17 +1084,9 @@ def OMP_Requires : Directive<[Spelling<"requires">]> {
     VersionedClause<OMPC_UnifiedAddress>,
     VersionedClause<OMPC_UnifiedSharedMemory>,
     VersionedClause<OMPC_DeviceSafesync, 60>,
-    // OpenMP 5.2 Spec: If an implementation is not supporting a requirement
-    // (reverse offload in this case) then it should give compile-time error
-    // termination.
-    // Seeting supported version for reverse_offload to a distant future version
-    // 9.9 so that its partial support can be tested in the meantime.
-    //
-    // TODO: Correct this supprted version number whenever complete
-    // implementation of reverse_offload is available.
     VersionedClause<OMPC_AtomicDefaultMemOrder>,
     VersionedClause<OMPC_DynamicAllocators>, VersionedClause<OMPC_SelfMaps>,
-    VersionedClause<OMPC_ReverseOffload, 99>,
+    VersionedClause<OMPC_ReverseOffload>,
   ];
   let association = AS_None;
   let category = CA_Informational;


### PR DESCRIPTION
Right now we quietly ignore it, whereas the OpenMP spec mandates a compilation error for requirements that the implementation does not support.
The REVERSE_OFFLOAD was not causing a compilation error to allow testing of incremental implementation improvements, but we should at least warn about not supporting it.