### PR TITLE
[lldb][test] Avoid a 3-argument main in test inferiors

### DIFF
--- a/lldb/test/API/commands/frame/diagnose/inheritance/main.cpp
+++ b/lldb/test/API/commands/frame/diagnose/inheritance/main.cpp
@@ -60,10 +60,8 @@ public:
 protected:
     int m_d;
 };
-int main (int argc, char const *argv[], char const *envp[])
-{
-    D *good_d = new D(1, 2, 3, 4);
-    D *d = nullptr;
-    return d->get();
+int main(int argc, char const *argv[]) {
+  D *good_d = new D(1, 2, 3, 4);
+  D *d = nullptr;
+  return d->get();
 }
-

--- a/lldb/test/API/functionalities/plugins/python_os_plugin/TestPythonOSPlugin.py
+++ b/lldb/test/API/functionalities/plugins/python_os_plugin/TestPythonOSPlugin.py
@@ -168,6 +168,7 @@ class PluginPythonOSPlugin(TestBase):
         # Set breakpoints inside and outside methods that take pointers to the
         # containing struct.
         lldbutil.run_break_set_by_source_regexp(self, "// Set breakpoint here")
+        stop_line = line_number("main.c", "// Set breakpoint here")
 
         # Register our shared libraries for remote targets so they get
         # automatically uploaded
@@ -219,10 +220,12 @@ class PluginPythonOSPlugin(TestBase):
         self.assertEqual(
             line_entry.GetFileSpec().GetFilename(),
             "main.c",
-            "Make sure we stopped on line 5 in main.c",
+            "Make sure we stopped on the breakpoint line in main.c",
         )
         self.assertEqual(
-            line_entry.GetLine(), 5, "Make sure we stopped on line 5 in main.c"
+            line_entry.GetLine(),
+            stop_line,
+            "Make sure we stopped on the breakpoint line in main.c",
         )
 
         # Now single step thread 0x111111111 and make sure it does what we need
@@ -243,12 +246,12 @@ class PluginPythonOSPlugin(TestBase):
         self.assertEqual(
             line_entry.GetFileSpec().GetFilename(),
             "main.c",
-            "Make sure we stepped from line 5 to line 6 in main.c",
+            "Make sure we stepped to the next line in main.c",
         )
         self.assertEqual(
             line_entry.GetLine(),
-            6,
-            "Make sure we stepped from line 5 to line 6 in main.c",
+            stop_line + 1,
+            "Make sure we stepped to the next line in main.c",
         )
 
         thread_bp_number = lldbutil.run_break_set_by_source_regexp(

--- a/lldb/test/API/functionalities/plugins/python_os_plugin/main.c
+++ b/lldb/test/API/functionalities/plugins/python_os_plugin/main.c
@@ -1,9 +1,8 @@
 #include <stdio.h>
 
-int main (int argc, char const *argv[], char const *envp[])
-{
-    puts("stop here"); // Set breakpoint here
-    puts("hello");
-    puts("Set tid-specific breakpoint here");
-    return 0;
+int main(int argc, char const *argv[]) {
+  puts("stop here"); // Set breakpoint here
+  puts("hello");
+  puts("Set tid-specific breakpoint here");
+  return 0;
 }

--- a/lldb/test/API/lang/cpp/extern_c/main.cpp
+++ b/lldb/test/API/lang/cpp/extern_c/main.cpp
@@ -14,9 +14,7 @@ int foo()
   return 2;
 }
 
-int main (int argc, char const *argv[], char const *envp[])
-{          
-    foo();
-    return 0; //% self.expect("expression -- foo()", substrs = ['2'])
+int main(int argc, char const *argv[]) {
+  foo();
+  return 0; //% self.expect("expression -- foo()", substrs = ['2'])
 }
-

--- a/lldb/test/API/lang/cpp/unique-types/main.cpp
+++ b/lldb/test/API/lang/cpp/unique-types/main.cpp
@@ -3,14 +3,13 @@
 #include <stdio.h>
 #include <stdint.h>
 
-int main (int argc, char const *argv[], char const *envp[])
-{
-    std::vector<long> longs;
-    std::vector<short> shorts;  
-    for (int i=0; i<12; i++)
-    {
-        longs.push_back(i);
-        shorts.push_back(i);
-    }
-    return 0; // Set breakpoint here to verify that std::vector 'longs' and 'shorts' have unique types.
+int main(int argc, char const *argv[]) {
+  std::vector<long> longs;
+  std::vector<short> shorts;
+  for (int i = 0; i < 12; i++) {
+    longs.push_back(i);
+    shorts.push_back(i);
+  }
+  return 0; // Set breakpoint here to verify that std::vector 'longs' and
+            // 'shorts' have unique types.
 }

--- a/lldb/test/API/python_api/sbvalue_const_addrof/main.cpp
+++ b/lldb/test/API/python_api/sbvalue_const_addrof/main.cpp
@@ -19,14 +19,13 @@ struct ThreadInfo {
   RegisterContext regs;
   ThreadInfo *next;
 };
-int main (int argc, char const *argv[], char const *envp[]);
+int main(int argc, char const *argv[]);
 
 ThreadInfo g_thread2 = { 0x2222, "thread2", { 0x2000, 0x2001, 0x2002, 0x2003, 0x2004, (uintptr_t)&main, 0x2006, 0x2007 }, NULL       };
 ThreadInfo g_thread1 = { 0x1111, "thread1", { 0x1000, 0x1001, 0x1002, 0x1003, 0x1004, (uintptr_t)&main, 0x1006, 0x1007 }, &g_thread2 };
 ThreadInfo *g_thread_list_ptr = &g_thread1;
 
-int main (int argc, char const *argv[], char const *envp[])
-{
+int main(int argc, char const *argv[]) {
   // clang-format off
   printf ("g_thread_list is %p\n", g_thread_list_ptr);
   return 0; //% v = self.dbg.GetSelectedTarget().FindFirstGlobalVariable('g_thread_list_ptr')

--- a/lldb/test/API/python_api/sbvalue_unsigned_enum_bitfield_value/main.cpp
+++ b/lldb/test/API/python_api/sbvalue_unsigned_enum_bitfield_value/main.cpp
@@ -6,7 +6,7 @@ struct Foo {
   EnumVals b : 4;
 };
 
-int main(int argc, char const *argv[], char const *envp[]) {
+int main(int argc, char const *argv[]) {
   Foo f{.b = static_cast<EnumVals>(8)};
   return 0; //% b = self.frame().FindVariable("f").GetChildMemberWithName("b")
             //% val = b.GetValueAsUnsigned()

--- a/lldb/test/API/python_api/target/main.c
+++ b/lldb/test/API/python_api/target/main.c
@@ -1,4 +1,10 @@
 #include <stdio.h>
+#include <stdlib.h>
+#ifdef _WIN32
+#define environ _environ
+#else
+extern char **environ;
+#endif
 
 // This simple program is to test the lldb Python API SBTarget.
 //
@@ -36,24 +42,23 @@ int c(int val)
     return val + 3;
 }
 
-int main (int argc, char const *argv[], char** env)
-{
-    // Set a break at entry to main.
-    int A1 = a(1);  // a(1) -> b(1) -> c(1)
-    printf("a(1) returns %d\n", A1);
+int main(int argc, char const *argv[]) {
+  // Set a break at entry to main.
+  int A1 = a(1); // a(1) -> b(1) -> c(1)
+  printf("a(1) returns %d\n", A1);
 
-    int B2 = b(2);  // b(2) -> c(2)
-    printf("b(2) returns %d\n", B2);
+  int B2 = b(2); // b(2) -> c(2)
+  printf("b(2) returns %d\n", B2);
 
-    int A3 = a(3);  // a(3) -> c(3)
-    printf("a(3) returns %d\n", A3);
+  int A3 = a(3); // a(3) -> c(3)
+  printf("a(3) returns %d\n", A3);
 
-    for (int i = 1; i < argc; i++) {
-      printf("arg: %s\n", argv[i]);
-    }
+  for (int i = 1; i < argc; i++) {
+    printf("arg: %s\n", argv[i]);
+  }
 
-    while (*env)
-      printf("env: %s\n", *env++);
+  for (char **e = environ; *e; ++e)
+    printf("env: %s\n", *e);
 
-    return 0;
+  return 0;
 }

--- a/lldb/test/API/tools/lldb-dap/launch/main.c
+++ b/lldb/test/API/tools/lldb-dap/launch/main.c
@@ -2,15 +2,20 @@
 #include <stdlib.h>
 #ifdef _WIN32
 #include <direct.h>
+#define environ _environ
 #else
 #include <unistd.h>
+extern char **environ;
 #endif
 
-int main(int argc, char const *argv[], char const *envp[]) {
+// Read the environment from `environ` rather than a third main parameter: not
+// every target wires a 3-argument main to the entry point (wasi wires up only
+// the 0- and 2-argument forms).
+int main(int argc, char const *argv[]) {
   for (int i = 0; i < argc; ++i)
     printf("arg[%i] = \"%s\"\n", i, argv[i]);
-  for (int i = 0; envp[i]; ++i)
-    printf("env[%i] = \"%s\"\n", i, envp[i]);
+  for (int i = 0; environ[i]; ++i)
+    printf("env[%i] = \"%s\"\n", i, environ[i]);
   char *cwd = getcwd(NULL, 0);
   printf("cwd = \"%s\"\n", cwd); // breakpoint 1
   free(cwd);

--- a/lldb/test/API/tools/lldb-dap/restart/main.c
+++ b/lldb/test/API/tools/lldb-dap/restart/main.c
@@ -1,4 +1,4 @@
-int main(int argc, char const *argv[], char const *envp[]) {
+int main(int argc, char const *argv[]) {
   int i = 0;
   (void)i; // breakpoint A
   i = 1234;


### PR DESCRIPTION
On WebAssembly clang only wires a 0- or 2-argument main to the program entry point: EmitMainVoidAlias emits the __main_void alias for a no-argument main, and the 2-argument form is mangled to __main_argc_argv.

A 3-argument main(argc, argv, envp) matches neither, so main is never connected to the entry point and is left as an undefined-weak stub whose body is `unreachable`. The affected inferiors trap with "Exception: unreachable" before reaching main (even when run outside the debugger) so any test using them fails on wasm.

Drop the unused third parameter, and where the environment is actually iterated read it from `environ` instead. The inferiors now run on WebAssembly and behave identically on other platforms.