### PR TITLE
[Hexagon] Emit PS_aligna in the prologue with the final stack alignment

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonFrameLowering.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonFrameLowering.cpp
@@ -373,60 +373,65 @@ static Register getMaxCalleeSavedReg(ArrayRef<CalleeSavedInfo> CSI,
 /// frame to be already in place.
 static bool needsStackFrame(const MachineBasicBlock &MBB, const BitVector &CSR,
                             const HexagonRegisterInfo &HRI) {
-    for (const MachineInstr &MI : MBB) {
-      if (MI.isCall())
+  const MachineFunction *MF = MBB.getParent();
+  if (&MBB == &MF->front() && MF->getInfo<HexagonMachineFunctionInfo>()
+                                  ->getStackAlignBaseReg()
+                                  .isValid())
+    return true;
+
+  for (const MachineInstr &MI : MBB) {
+    if (MI.isCall())
+      return true;
+    unsigned Opc = MI.getOpcode();
+    switch (Opc) {
+    case Hexagon::PS_alloca:
+      return true;
+    default:
+      break;
+    }
+    // Check individual operands.
+    for (const MachineOperand &MO : MI.operands()) {
+      // While the presence of a frame index does not prove that a stack
+      // frame will be required, all frame indexes should be within alloc-
+      // frame/deallocframe. Otherwise, the code that translates a frame
+      // index into an offset would have to be aware of the placement of
+      // the frame creation/destruction instructions.
+      if (MO.isFI())
         return true;
-      unsigned Opc = MI.getOpcode();
-      switch (Opc) {
-        case Hexagon::PS_alloca:
-        case Hexagon::PS_aligna:
-          return true;
-        default:
-          break;
-      }
-      // Check individual operands.
-      for (const MachineOperand &MO : MI.operands()) {
-        // While the presence of a frame index does not prove that a stack
-        // frame will be required, all frame indexes should be within alloc-
-        // frame/deallocframe. Otherwise, the code that translates a frame
-        // index into an offset would have to be aware of the placement of
-        // the frame creation/destruction instructions.
-        if (MO.isFI())
-          return true;
-        if (MO.isReg()) {
-          Register R = MO.getReg();
-          // Debug instructions may refer to $noreg.
-          if (!R)
-            continue;
-          // Virtual registers will need scavenging, which then may require
-          // a stack slot.
-          if (R.isVirtual())
-            return true;
-          for (MCPhysReg S : HRI.subregs_inclusive(R))
-            if (CSR[S])
-              return true;
+      if (MO.isReg()) {
+        Register R = MO.getReg();
+        // Debug instructions may refer to $noreg.
+        if (!R)
           continue;
-        }
-        if (MO.isRegMask()) {
-          // A regmask would normally have all callee-saved registers marked
-          // as preserved, so this check would not be needed, but in case of
-          // ever having other regmasks (for other calling conventions),
-          // make sure they would be processed correctly.
-          const uint32_t *BM = MO.getRegMask();
-          for (int x = CSR.find_first(); x >= 0; x = CSR.find_next(x)) {
-            unsigned R = x;
-            // If this regmask does not preserve a CSR, a frame will be needed.
-            if (!(BM[R/32] & (1u << (R%32))))
-              return true;
-          }
+        // Virtual registers will need scavenging, which then may require
+        // a stack slot.
+        if (R.isVirtual())
+          return true;
+        for (MCPhysReg S : HRI.subregs_inclusive(R))
+          if (CSR[S])
+            return true;
+        continue;
+      }
+      if (MO.isRegMask()) {
+        // A regmask would normally have all callee-saved registers marked
+        // as preserved, so this check would not be needed, but in case of
+        // ever having other regmasks (for other calling conventions),
+        // make sure they would be processed correctly.
+        const uint32_t *BM = MO.getRegMask();
+        for (int x = CSR.find_first(); x >= 0; x = CSR.find_next(x)) {
+          unsigned R = x;
+          // If this regmask does not preserve a CSR, a frame will be needed.
+          if (!(BM[R / 32] & (1u << (R % 32))))
+            return true;
         }
       }
     }
-    return false;
+  }
+  return false;
 }
 
-  /// Returns true if MBB has a machine instructions that indicates a tail call
-  /// in the block.
+/// Returns true if MBB has a machine instructions that indicates a tail call
+/// in the block.
 static bool hasTailCall(const MachineBasicBlock &MBB) {
     MachineBasicBlock::const_iterator I = MBB.getLastNonDebugInstr();
     if (I == MBB.end())
@@ -608,7 +613,14 @@ void HexagonFrameLowering::emitPrologue(MachineFunction &MF,
     findShrunkPrologEpilog(MF, PrologB, EpilogB);
 
   bool PrologueStubs = false;
-  insertCSRSpillsInBlock(*PrologB, CSI, HRI, PrologueStubs);
+  MachineBasicBlock::iterator AfterCSR =
+      insertCSRSpillsInBlock(*PrologB, CSI, HRI, PrologueStubs);
+  // Insert PS_aligna after all CSR spills.
+  // PS_aligna initializes the AP register with an aligned
+  // value derived from FP. Since AP is a callee-saved register, its original
+  // value must be saved before it is overwritten, and it must be defined
+  // before any AP-relative stack accesses.
+  insertAlignaInBlock(*PrologB, AfterCSR);
   insertPrologueInBlock(*PrologB, PrologueStubs);
   // Insert the SCS prologue after all FrameSetup instructions so that it
   // follows allocframe and any CSR spills in the instruction stream.  The
@@ -1196,6 +1208,23 @@ void HexagonFrameLowering::inlineStackProbe(
   }
 }
 
+void HexagonFrameLowering::insertAlignaInBlock(
+    MachineBasicBlock &MBB, MachineBasicBlock::iterator InsertPt) const {
+  MachineFunction &MF = *MBB.getParent();
+  Register AP =
+      MF.getInfo<HexagonMachineFunctionInfo>()->getStackAlignBaseReg();
+  if (!AP.isValid())
+    return;
+
+  assert(needsAligna(MF) && "Unexpected stack align base register");
+
+  auto &HII = *MF.getSubtarget<HexagonSubtarget>().getInstrInfo();
+  Align MaxAlign = std::max(MF.getFrameInfo().getMaxAlign(), getStackAlign());
+  DebugLoc DL = MBB.findDebugLoc(InsertPt);
+  BuildMI(MBB, InsertPt, DL, HII.get(Hexagon::PS_aligna), AP)
+      .addImm(MaxAlign.value());
+}
+
 void HexagonFrameLowering::updateEntryPaths(MachineFunction &MF,
       MachineBasicBlock &SaveB) const {
   SetVector<unsigned> Worklist;
@@ -1627,13 +1656,13 @@ HexagonFrameLowering::getFrameIndexReference(const MachineFunction &MF, int FI,
   return StackOffset::getFixed(RealOffset);
 }
 
-bool HexagonFrameLowering::insertCSRSpillsInBlock(MachineBasicBlock &MBB,
-      const CSIVect &CSI, const HexagonRegisterInfo &HRI,
-      bool &PrologueStubs) const {
-  if (CSI.empty())
-    return true;
-
+MachineBasicBlock::iterator HexagonFrameLowering::insertCSRSpillsInBlock(
+    MachineBasicBlock &MBB, const CSIVect &CSI, const HexagonRegisterInfo &HRI,
+    bool &PrologueStubs) const {
   MachineBasicBlock::iterator MI = MBB.begin();
+  if (CSI.empty())
+    return MI;
+
   PrologueStubs = false;
   MachineFunction &MF = *MBB.getParent();
   auto &HST = MF.getSubtarget<HexagonSubtarget>();
@@ -1692,25 +1721,7 @@ bool HexagonFrameLowering::insertCSRSpillsInBlock(MachineBasicBlock &MBB,
     }
   }
 
-  // Move PS_aligna to after all CSR spills (both inline and spill-function
-  // paths). PS_aligna initializes the AP register (e.g. R16) with an aligned
-  // value derived from FP. Since AP is a callee-saved register, its original
-  // value must be saved before it is overwritten, and it must be defined
-  // before any AP-relative stack accesses.
-  // MI points to the first non-spill instruction; all spills are before it.
-  auto &HFI = *MF.getSubtarget<HexagonSubtarget>().getFrameLowering();
-  if (const MachineInstr *AlignaI = HFI.getAlignaInstr(MF)) {
-    MachineInstr *AI = const_cast<MachineInstr *>(AlignaI);
-    // PS_aligna is always created in EntryBB during ISEL. Since PS_aligna
-    // causes needsStackFrame() to return true, EntryBB will be included in
-    // the set of blocks needing a frame. Because EntryBB dominates all blocks,
-    // shrink-wrapping will always place PrologB at EntryBB when PS_aligna
-    // exists. Therefore, this assertion should always hold.
-    assert(AI->getParent() == &MBB && "PS_aligna not in prologue block");
-    MBB.splice(MI, AI->getParent(), AI->getIterator());
-  }
-
-  return true;
+  return MI;
 }
 
 bool HexagonFrameLowering::insertCSRRestoresInBlock(MachineBasicBlock &MBB,
@@ -1788,28 +1799,6 @@ MachineBasicBlock::iterator HexagonFrameLowering::eliminateCallFramePseudoInstr(
   return MBB.erase(I);
 }
 
-void HexagonFrameLowering::processFunctionBeforeFrameFinalized(
-    MachineFunction &MF, RegScavenger *RS) const {
-  // If this function has uses aligned stack and also has variable sized stack
-  // objects, then we need to map all spill slots to fixed positions, so that
-  // they can be accessed through FP. Otherwise they would have to be accessed
-  // via AP, which may not be available at the particular place in the program.
-  MachineFrameInfo &MFI = MF.getFrameInfo();
-  bool HasAlloca = MFI.hasVarSizedObjects();
-  bool NeedsAlign = (MFI.getMaxAlign() > getStackAlign());
-
-  if (!HasAlloca || !NeedsAlign)
-    return;
-
-  // Set the physical aligned-stack base address register.
-  MCRegister AP;
-  if (const MachineInstr *AI = getAlignaInstr(MF))
-    AP = AI->getOperand(0).getReg();
-  auto &HMFI = *MF.getInfo<HexagonMachineFunctionInfo>();
-  assert(!AP.isValid() || AP.isPhysical());
-  HMFI.setStackAlignBaseReg(AP);
-}
-
 /// Returns true if there are no caller-saved registers available in class RC.
 static bool needToReserveScavengingSpillSlots(MachineFunction &MF,
       const HexagonRegisterInfo &HRI, const TargetRegisterClass *RC) {
@@ -1873,6 +1862,8 @@ bool HexagonFrameLowering::assignCalleeSavedSpillSlots(MachineFunction &MF,
   // only, it still needs to be saved/restored.
   Register AP =
       MF.getInfo<HexagonMachineFunctionInfo>()->getStackAlignBaseReg();
+  assert((!needsAligna(MF) || AP.isValid()) &&
+         "AP must be assigned before register allocation");
   if (AP.isValid()) {
     Reserved[AP] = false;
     // Unreserve super-regs if no other subregisters are reserved.
@@ -2371,6 +2362,16 @@ void HexagonFrameLowering::determineCalleeSaves(MachineFunction &MF,
   if (MF.getInfo<HexagonMachineFunctionInfo>()->hasEHReturn())
     for (const MCPhysReg *R = HRI.getCalleeSavedRegs(&MF); *R; ++R)
       SavedRegs.set(*R);
+
+  // If the function needs dynamic stack realignment, AP is a callee-saved
+  // register that gets overwritten by the PS_aligna emitted in the prologue
+  // but PS_aligna is created during emitPrologue, which runs after this hook.
+  if (needsAligna(MF)) {
+    Register AP =
+        MF.getInfo<HexagonMachineFunctionInfo>()->getStackAlignBaseReg();
+    assert(AP.isValid() && "AP must be assigned before register allocation");
+    SavedRegs.set(AP);
+  }
 
   // Replace predicate register pseudo spill code.
   SmallVector<Register,8> NewRegs;
@@ -2941,15 +2942,6 @@ bool HexagonFrameLowering::needsAligna(const MachineFunction &MF) const {
   // may not be complete yet. Assume that we will need PS_aligna if there
   // are variable-sized objects.
   return true;
-}
-
-const MachineInstr *HexagonFrameLowering::getAlignaInstr(
-      const MachineFunction &MF) const {
-  for (auto &B : MF)
-    for (auto &I : B)
-      if (I.getOpcode() == Hexagon::PS_aligna)
-        return &I;
-  return nullptr;
 }
 
 /// Adds all callee-saved registers as implicit uses or defs to the

--- a/llvm/lib/Target/Hexagon/HexagonFrameLowering.h
+++ b/llvm/lib/Target/Hexagon/HexagonFrameLowering.h
@@ -79,8 +79,6 @@ public:
   MachineBasicBlock::iterator
   eliminateCallFramePseudoInstr(MachineFunction &MF, MachineBasicBlock &MBB,
                                 MachineBasicBlock::iterator I) const override;
-  void processFunctionBeforeFrameFinalized(MachineFunction &MF,
-      RegScavenger *RS = nullptr) const override;
   void determineCalleeSaves(MachineFunction &MF, BitVector &SavedRegs,
       RegScavenger *RS) const override;
 
@@ -110,7 +108,6 @@ public:
       const override;
 
   bool needsAligna(const MachineFunction &MF) const;
-  const MachineInstr *getAlignaInstr(const MachineFunction &MF) const;
 
   void insertCFIInstructions(MachineFunction &MF) const;
 
@@ -127,11 +124,15 @@ private:
                     const HexagonInstrInfo &TII, Register SP,
                     unsigned CF) const;
   void insertPrologueInBlock(MachineBasicBlock &MBB, bool PrologueStubs) const;
+  void insertAlignaInBlock(MachineBasicBlock &MBB,
+                           MachineBasicBlock::iterator InsertPt) const;
   void insertEpilogueInBlock(MachineBasicBlock &MBB) const;
   void insertAllocframe(MachineBasicBlock &MBB,
       MachineBasicBlock::iterator InsertPt, unsigned NumBytes) const;
-  bool insertCSRSpillsInBlock(MachineBasicBlock &MBB, const CSIVect &CSI,
-      const HexagonRegisterInfo &HRI, bool &PrologueStubs) const;
+  MachineBasicBlock::iterator
+  insertCSRSpillsInBlock(MachineBasicBlock &MBB, const CSIVect &CSI,
+                         const HexagonRegisterInfo &HRI,
+                         bool &PrologueStubs) const;
   bool insertCSRRestoresInBlock(MachineBasicBlock &MBB, const CSIVect &CSI,
       const HexagonRegisterInfo &HRI) const;
   void updateEntryPaths(MachineFunction &MF, MachineBasicBlock &SaveB) const;

--- a/llvm/lib/Target/Hexagon/HexagonISelDAGToDAG.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelDAGToDAG.cpp
@@ -794,6 +794,7 @@ void HexagonDAGToDAGISel::SelectFrameIndex(SDNode *N) {
   } else {
     auto &HMFI = *MF->getInfo<HexagonMachineFunctionInfo>();
     Register AR = HMFI.getStackAlignBaseReg();
+    assert(AR.isValid() && "Missing stack align base register");
     SDValue CH = CurDAG->getEntryNode();
     SDValue Ops[] = { CurDAG->getCopyFromReg(CH, DL, AR, MVT::i32), FI, Zero };
     R = CurDAG->getMachineNode(Hexagon::PS_fia, DL, MVT::i32, Ops);
@@ -1433,35 +1434,10 @@ void HexagonDAGToDAGISel::emitFunctionEntryCode() {
   if (!HFI.needsAligna(*MF))
     return;
 
-  MachineFrameInfo &MFI = MF->getFrameInfo();
-  MachineBasicBlock *EntryBB = &MF->front();
-  Align EntryMaxA = MFI.getMaxAlign();
-
-  // Reserve the first non-volatile register.
-  Register AP = 0;
   auto &HRI = *HST.getRegisterInfo();
-  BitVector Reserved = HRI.getReservedRegs(*MF);
-  for (const MCPhysReg *R = HRI.getCalleeSavedRegs(MF); *R; ++R) {
-    if (Reserved[*R])
-      continue;
-    AP = *R;
-    break;
-  }
+  Register AP = HRI.computeStackAlignBaseRegister(*MF);
   assert(AP.isValid() && "Couldn't reserve stack align register");
-  BuildMI(EntryBB, DebugLoc(), HII->get(Hexagon::PS_aligna), AP)
-      .addImm(EntryMaxA.value());
   MF->getInfo<HexagonMachineFunctionInfo>()->setStackAlignBaseReg(AP);
-}
-
-void HexagonDAGToDAGISel::updateAligna() {
-  auto &HFI = *MF->getSubtarget<HexagonSubtarget>().getFrameLowering();
-  if (!HFI.needsAligna(*MF))
-    return;
-  auto *AlignaI = const_cast<MachineInstr*>(HFI.getAlignaInstr(*MF));
-  assert(AlignaI != nullptr);
-  unsigned MaxA = MF->getFrameInfo().getMaxAlign().value();
-  if (AlignaI->getOperand(1).getImm() < MaxA)
-    AlignaI->getOperand(1).setImm(MaxA);
 }
 
 // Match a frame index that can be used in an addressing mode.

--- a/llvm/lib/Target/Hexagon/HexagonISelDAGToDAG.h
+++ b/llvm/lib/Target/Hexagon/HexagonISelDAGToDAG.h
@@ -44,7 +44,6 @@ public:
     HII = HST->getInstrInfo();
     HRI = HST->getRegisterInfo();
     SelectionDAGISel::runOnMachineFunction(MF);
-    updateAligna();
     return true;
   }
 
@@ -149,9 +148,6 @@ private:
   void SelectHvxShuffle(SDNode *N);
   void SelectHvxRor(SDNode *N);
   void SelectHvxVAlign(SDNode *N);
-
-  // Function postprocessing.
-  void updateAligna();
 
   SmallDenseMap<SDNode *,int> RootWeights;
   SmallDenseMap<SDNode *,int> RootHeights;

--- a/llvm/lib/Target/Hexagon/HexagonRegisterInfo.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonRegisterInfo.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "HexagonRegisterInfo.h"
+#include "HexagonFrameLowering.h"
 #include "HexagonMachineFunctionInfo.h"
 #include "HexagonSubtarget.h"
 #include "llvm/ADT/BitVector.h"
@@ -157,9 +158,41 @@ const uint32_t *HexagonRegisterInfo::getCallPreservedMask(
   return HexagonCSR_RegMask;
 }
 
+BitVector
+HexagonRegisterInfo::getReservedRegs(const MachineFunction &MF) const {
+  BitVector Reserved = getBaseReservedRegs(MF);
+  if (Register AP = computeStackAlignBaseRegister(MF, Reserved)) {
+    Reserved.set(AP);
+    markSuperRegs(Reserved, AP);
+  }
+  return Reserved;
+}
 
-BitVector HexagonRegisterInfo::getReservedRegs(const MachineFunction &MF)
-      const {
+Register HexagonRegisterInfo::computeStackAlignBaseRegister(
+    const MachineFunction &MF) const {
+  return computeStackAlignBaseRegister(MF, getBaseReservedRegs(MF));
+}
+
+Register HexagonRegisterInfo::computeStackAlignBaseRegister(
+    const MachineFunction &MF, const BitVector &BaseReservedRegs) const {
+  auto &HFI = *MF.getSubtarget<HexagonSubtarget>().getFrameLowering();
+  if (!HFI.needsAligna(MF))
+    return Register();
+
+  // Reserve the first non-volatile register.
+  Register AP;
+  for (const MCPhysReg *R = getCalleeSavedRegs(&MF); *R; ++R) {
+    if (BaseReservedRegs[*R])
+      continue;
+    AP = *R;
+    break;
+  }
+  assert(AP.isValid() && "Couldn't reserve stack align register");
+  return AP;
+}
+
+BitVector
+HexagonRegisterInfo::getBaseReservedRegs(const MachineFunction &MF) const {
   BitVector Reserved(getNumRegs());
   Reserved.set(Hexagon::R29);
   Reserved.set(Hexagon::R30);
@@ -214,11 +247,6 @@ BitVector HexagonRegisterInfo::getReservedRegs(const MachineFunction &MF)
   for (MCPhysReg Reg : RRegs)
     if (MF.getSubtarget().isRegisterReservedByUser(Reg))
       Reserved.set(Reg);
-
-  Register AP =
-      MF.getInfo<HexagonMachineFunctionInfo>()->getStackAlignBaseReg();
-  if (AP.isValid())
-    Reserved.set(AP);
 
   for (int x = Reserved.find_first(); x >= 0; x = Reserved.find_next(x))
     markSuperRegs(Reserved, x);

--- a/llvm/lib/Target/Hexagon/HexagonRegisterInfo.h
+++ b/llvm/lib/Target/Hexagon/HexagonRegisterInfo.h
@@ -38,6 +38,11 @@ public:
 
   BitVector getReservedRegs(const MachineFunction &MF) const override;
 
+  /// Compute the first available callee-saved register to use as the
+  /// aligned-stack base register when this function needs dynamic stack
+  /// realignment. This does not update the machine function info.
+  Register computeStackAlignBaseRegister(const MachineFunction &MF) const;
+
   bool eliminateFrameIndex(MachineBasicBlock::iterator II, int SPAdj,
         unsigned FIOperandNum, RegScavenger *RS = nullptr) const override;
 
@@ -85,6 +90,12 @@ public:
   bool isFakeReg(MCPhysReg Reg) const;
 
   bool isEHReturnCalleeSaveReg(Register Reg) const;
+
+private:
+  BitVector getBaseReservedRegs(const MachineFunction &MF) const;
+  Register
+  computeStackAlignBaseRegister(const MachineFunction &MF,
+                                const BitVector &BaseReservedRegs) const;
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/Hexagon/HexagonVExtract.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonVExtract.cpp
@@ -125,7 +125,6 @@ bool HexagonVExtract::runOnMachineFunction(MachineFunction &MF) {
     return AddrR;
   };
 
-  MaybeAlign MaxAlign;
   for (auto &P : VExtractMap) {
     unsigned VecR = P.first;
     if (P.second.size() <= VExtractThreshold)
@@ -133,7 +132,6 @@ bool HexagonVExtract::runOnMachineFunction(MachineFunction &MF) {
 
     const auto &VecRC = *MRI.getRegClass(VecR);
     Align Alignment = HRI.getSpillAlign(VecRC);
-    MaxAlign = std::max(MaxAlign.valueOrOne(), Alignment);
     // Make sure this is not a spill slot: spill slots cannot be aligned
     // if there are variable-sized objects on the stack. They must be
     // accessible via FP (which is not aligned), because SP is unknown,
@@ -170,15 +168,6 @@ bool HexagonVExtract::runOnMachineFunction(MachineFunction &MF) {
       ExtB.erase(ExtI);
       Changed = true;
     }
-  }
-
-  if (AR && MaxAlign) {
-    // Update the required stack alignment.
-    MachineInstr *AlignaI = MRI.getVRegDef(AR);
-    assert(AlignaI->getOpcode() == Hexagon::PS_aligna);
-    MachineOperand &Op = AlignaI->getOperand(1);
-    if (*MaxAlign > Op.getImm())
-      Op.setImm(MaxAlign->value());
   }
 
   return Changed;

--- a/llvm/test/CodeGen/Hexagon/aligna-prologue-expansion.mir
+++ b/llvm/test/CodeGen/Hexagon/aligna-prologue-expansion.mir
@@ -57,7 +57,6 @@ body:             |
     renamable $r20 = COPY killed $r3
     renamable $r21 = COPY killed $r2
     renamable $r22 = COPY killed $r1
-    $r16 = PS_aligna 128, implicit killed $r30
     renamable $r25 = A2_tfrsi 0
     renamable $r2 = A2_tfrsi 0
     renamable $r23 = PS_alloca killed renamable $r6, 128, implicit-def dead $r29

--- a/llvm/test/CodeGen/Hexagon/aligna-save-base-reg.ll
+++ b/llvm/test/CodeGen/Hexagon/aligna-save-base-reg.ll
@@ -1,0 +1,26 @@
+; RUN: llc -mtriple=hexagon -mattr=+hvxv68,+hvx-length128b < %s | FileCheck %s
+
+; When a function needs dynamic stack realignment, AP (here r16) is
+; initialized by PS_aligna in the prologue. AP is a callee-saved register, so it
+; must be saved before PS_aligna clobbers it and restored on the way out.
+; PS_aligna is created during prologue emission (after callee-saved registers
+; are determined), so HexagonFrameLowering::determineCalleeSaves must explicitly
+; add AP to the save set; otherwise the caller's r16 is corrupted.
+
+; CHECK-LABEL: f:
+; CHECK: r16 = and(r30,#-128)
+; CHECK: memd(r30+#-8) = r17:16
+; CHECK: r17:16 = memd(r30+#-8)
+; CHECK: dealloc_return
+
+declare void @use(ptr, ptr)
+
+define void @f(i32 %n) {
+entry:
+  ; Variable-sized alloca -> hasVarSizedObjects -> needsAligna.
+  %vla = alloca i32, i32 %n, align 4
+  ; Over-aligned local -> MaxAlign > stack alignment -> real realignment.
+  %buf = alloca [16 x i32], align 128
+  call void @use(ptr %vla, ptr %buf)
+  ret void
+}

--- a/llvm/test/CodeGen/Hexagon/spill-vector-alignment.mir
+++ b/llvm/test/CodeGen/Hexagon/spill-vector-alignment.mir
@@ -1,17 +1,29 @@
 # RUN: llc -mtriple=hexagon -run-pass prolog-epilog %s -o - | FileCheck %s
 
+# Check that the aligned-stack base register $r16 is
+# saved before it is clobbered by PS_aligna in the prologue.
+# CHECK: S2_storerd_io $r30, -8, killed $d8
+
+# Check that PS_aligna is emitted with the final stack alignment after late HVX
+# spill slots increase the required stack alignment.
+# CHECK: $r16 = PS_aligna 128
+
 # Check that the spill of $q0 no longer uses unaligned store instruction.
 # CHECK: V6_vS32b_ai $r16, -256, killed $v0
+
+# Check that the aligned-stack base register is restored on the way out.
+# CHECK: $d8 = L2_loadrd_io $r30, -8
 
 ---
 name:            test
 tracksRegLiveness: true
+machineFunctionInfo:
+  stackAlignBaseReg: '$r16'
 stack:
   - { id: 0, type: variable-sized, offset: 0, alignment: 1 }
   - { id: 1, type: spill-slot, size: 128, alignment: 128 }
 body: |
   bb.0:
     liveins: $q0
-    $r16 = PS_aligna 128, implicit $r30
     PS_vstorerq_ai %stack.1, 0, $q0
 ...


### PR DESCRIPTION
Hexagon uses PS_aligna to set up the aligned stack base register when a function has variable-sized stack objects. That pseudo is created during instruction selection using the maximum stack alignment known at that point.

Register allocation can later introduce HVX spill slots with stricter alignment, for example 128-byte alignment in HVX 128-byte mode. If PS_aligna keeps the older immediate, the aligned base register can be under-aligned, and aligned HVX spill stores may address stack slots with insufficient alignment.

In order to address this bug, insert PS_aligna during prologue emission once its final value is known instead of manually updating it throughout the backend multiple times.