### PR TITLE
[Clang] Don't suppress vtable emission for classes with -fmodules-debuginfo

### DIFF
--- a/clang/include/clang/AST/DeclBase.h
+++ b/clang/include/clang/AST/DeclBase.h
@@ -687,6 +687,10 @@ public:
 
   /// Whether the definition of the declaration should be emitted in external
   /// sources.
+  /// FIXME: This conflates two questions: if the entity should be emitted into
+  ///   other object files (because there's no primary), and if the debug info
+  ///   should be emitted into other object files. This matters for
+  //    `-fmodules-debuginfo`, `-fmodules-codgen`, and `isInNamedModule()`.
   bool shouldEmitInExternalSource() const;
 
   /// Whether this declaration comes from explicit global module.

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -19296,7 +19296,12 @@ bool Sema::DefineUsedVTables() {
     DefinedAnything = true;
     MarkVirtualMembersReferenced(Loc, Class);
     CXXRecordDecl *Canonical = Class->getCanonicalDecl();
-    if (VTablesUsed[Canonical] && !Class->shouldEmitInExternalSource())
+    // The vtable is assumed to be emitted in an external source only for
+    // classes attached to a named module, which is guaranteed to have an object
+    // file. This isn't true for -fmodules-debuginfo, which still has
+    // shouldEmitInExternalSource as true so that debug info gets supressed.
+    if (VTablesUsed[Canonical] &&
+        !(Class->isInNamedModule() && Class->shouldEmitInExternalSource()))
       Consumer.HandleVTable(Class);
 
     // Warn if we're emitting a weak vtable. The vtable will be weak if there is

--- a/clang/test/PCH/pch-debuginfo-vtable.cpp
+++ b/clang/test/PCH/pch-debuginfo-vtable.cpp
@@ -1,0 +1,28 @@
+// Check that a key function defined in a TU that includes a -fpch-debuginfo
+// PCH still emits the vtable. The PCH object only carries debug info, not the
+// vtable definition, so the importing TU must emit it itself.
+
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+
+// RUN: %clang_cc1 -std=c++20 -triple %itanium_abi_triple -fmodules-debuginfo \
+// RUN:     -building-pch-with-obj -x c++-header -emit-pch %t/b.h -o %t/b.pch
+
+// RUN: %clang_cc1 -std=c++20 -triple %itanium_abi_triple -include-pch %t/b.pch \
+// RUN:     -emit-llvm -o - %t/b.cpp | FileCheck %s
+
+// CHECK: @_ZTV1B = {{.*}}constant
+
+//--- b.h
+#pragma once
+struct B {
+    B() = default;
+    virtual ~B();
+    virtual void f();
+};
+
+//--- b.cpp
+#include "b.h"
+B::~B() { }
+void B::f() { }


### PR DESCRIPTION
847f9cb0e868 made `Sema::DefineUsedVTables` skip
`Consumer.HandleVTable()` when `Class->shouldEmitInExternalSource()` is true. This works for named C++20 modules as they have an object file, but does not hold for -fmodules-debuginfo / -fpch-debuginfo.

This patch additionally gates that on `Class->isInNamedModule()`. This is the same pattern used by the rest of codegen for this situation.

Needing to check this everywhere is a bit unfortunate. It would be good to eventually refactor this class of checks to have clearer semantics around named modules, debug info, and -fmodules-codgen.

Fixes https://github.com/llvm/llvm-project/issues/198587

Assisted-by: Claude Code: opus-4-8