### PR TITLE
[AMDGPU][VOPD] Optimise VOPD pairing hazard checks

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNVOPDUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNVOPDUtils.cpp
@@ -266,7 +266,7 @@ static bool shouldScheduleVOPDAdjacent(const TargetInstrInfo &TII,
 
 /// Collect all load (dependents if \p Forward else dependencies) that connect
 /// to the \p Head SU.
-static void collectLoads(SmallVector<SUnit *> &Loads, BitVector &Visited,
+static void collectLoads(SmallPtrSet<SUnit *, 8> &Loads, BitVector &Visited,
                          SUnit &Head, bool Forward) {
   if (Head.isBoundaryNode() || Visited.test(Head.NodeNum))
     return;
@@ -277,50 +277,28 @@ static void collectLoads(SmallVector<SUnit *> &Loads, BitVector &Visited,
     SUnit *SU = Stack.pop_back_val();
     const SmallVector<SDep, 4> &Deps = Forward ? SU->Succs : SU->Preds;
     for (const SDep &Edge : Deps) {
-      if (Edge.getKind() != SDep::Data)
-        continue;
       SUnit *Dep = Edge.getSUnit();
       if (Dep->isBoundaryNode() || Visited.test(Dep->NodeNum))
         continue;
       if (Dep->isInstr() && Dep->getInstr()->mayLoad())
-        Loads.push_back(Dep);
-      else
-        Stack.push_back(Dep);
+        Loads.insert(Dep);
 
+      Stack.push_back(Dep);
       Visited.set(Dep->NodeNum);
     }
   }
 }
 
-/// Checks whether fusing SU \p I with SU \p J would force the loads preceding
-/// \p J to complete before loads depending on \p I.
-static bool loadsMayOverlap(ScheduleDAGInstrs *DAG, [[maybe_unused]] SUnit &I,
-                            const BitVector &IVisited,
-                            const SmallVector<SUnit *> &ILoadSuccs,
-                            [[maybe_unused]] SUnit &J,
-                            const BitVector &JVisited,
-                            const SmallVector<SUnit *> &JLoadPreds) {
-  if (JLoadPreds.empty())
-    return false;
-
-  for (SUnit *Succ : ILoadSuccs)
-    for (SUnit *Pred : JLoadPreds)
-      if (!DAG->IsReachable(Succ, Pred)) {
-        LLVM_DEBUG({
-          dbgs() << "Will not pair SU(" << I.NodeNum << ") with SU("
-                 << J.NodeNum << ")\n";
-          if (Pred == Succ)
-            dbgs() << "  Fusion would introduce a cyclic dependency "
-                      "with SU("
-                   << Pred->NodeNum << ")\n";
-          else
-            dbgs() << "  Fusion may force SU(" << Pred->NodeNum
-                   << ") to complete its load before dispatching SU("
-                   << Succ->NodeNum << ")\n";
-        });
-        return true;
-      }
-  return false;
+/// Returns some SUnit that lives in both \p A and \p B or nullptr if there are
+/// none.
+static SUnit *findCommonSUnit(const SmallPtrSet<SUnit *, 8> &A,
+                              const SmallPtrSet<SUnit *, 8> &B) {
+  if (B.empty())
+    return nullptr;
+  for (SUnit *SU : A)
+    if (B.contains(SU))
+      return SU;
+  return nullptr;
 }
 
 namespace {
@@ -356,11 +334,11 @@ struct VOPDPairingMutation : ScheduleDAGMutation {
 
     IIdx = 0;
     BitVector IVisited(DAG->SUnits.size());
-    SmallVector<SUnit *> ILoadSuccs;
+    SmallPtrSet<SUnit *, 8> ILoadSuccs;
 
     BitVector JVisited(DAG->SUnits.size());
     BitVector JLoadPredsComputed(DAG->SUnits.size());
-    SmallVector<SmallVector<SUnit *>> JLoadPredsCache(DAG->SUnits.size());
+    SmallVector<SmallPtrSet<SUnit *, 8>> JLoadPredsCache(DAG->SUnits.size());
     for (auto ISUI = DAG->SUnits.begin(), E = DAG->SUnits.end(); ISUI != E;
          ++ISUI, ++IIdx) {
       if (!VOPDCapable[IIdx])
@@ -381,15 +359,21 @@ struct VOPDPairingMutation : ScheduleDAGMutation {
           continue;
 
         if (!ILoadSuccs.empty()) {
-          SmallVector<SUnit *> &JLoadPreds = JLoadPredsCache[JIdx];
+          SmallPtrSet<SUnit *, 8> &JLoadPreds = JLoadPredsCache[JIdx];
           if (!JLoadPredsComputed.test(JIdx)) {
             JVisited.reset();
             collectLoads(JLoadPreds, JVisited, *JSUI, /*Forward=*/false);
             JLoadPredsComputed.set(JIdx);
           }
-          if (loadsMayOverlap(DAG, *ISUI, IVisited, ILoadSuccs, *JSUI, JVisited,
-                              JLoadPreds))
+          if ([[maybe_unused]] SUnit *OverlappingLoad =
+                  findCommonSUnit(ILoadSuccs, JLoadPreds)) {
+            LLVM_DEBUG(dbgs() << "Will not pair SU(" << ISUI->NodeNum
+                              << ") with SU(" << JSUI->NodeNum << ")\n"
+                              << "  Fusion would introduce a cyclic dependency "
+                                 "with SU("
+                              << OverlappingLoad->NodeNum << ")\n");
             continue;
+          }
         }
 
         if (fuseInstructionPair(*DAG, *ISUI, *JSUI)) {

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/insertelement.i8.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/insertelement.i8.ll
@@ -503,10 +503,11 @@ define amdgpu_ps void @insertelement_s_v2i8_s_v(ptr addrspace(4) inreg %ptr, i8 
 ; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_4)
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v1, 0xff, v1
 ; GFX11-FAKE16-NEXT:    v_cndmask_b32_e64 v0, v2, s4, vcc_lo
-; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v3, 8, v1
-; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v1, 0 :: v_dual_and_b32 v2, 0xff, v0
+; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_4)
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v2, 0xff, v0
 ; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-FAKE16-NEXT:    v_lshlrev_b16 v3, 8, v1
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX11-FAKE16-NEXT:    v_or_b32_e32 v2, v2, v3
 ; GFX11-FAKE16-NEXT:    global_store_b16 v[0:1], v2, off
@@ -617,13 +618,13 @@ define amdgpu_ps void @insertelement_s_v2i8_v_v(ptr addrspace(4) inreg %ptr, i8 
 ; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v2, s1, v0, vcc_lo
 ; GFX11-TRUE16-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 0, v1
 ; GFX11-TRUE16-NEXT:    v_cndmask_b32_e32 v1, s0, v0, vcc_lo
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_3)
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_2)
+; GFX11-TRUE16-NEXT:    v_and_b16 v0.h, 0xff, v1.l
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX11-TRUE16-NEXT:    v_and_b16 v0.l, 0xff, v2.l
 ; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v2, 0
-; GFX11-TRUE16-NEXT:    v_and_b16 v0.h, 0xff, v1.l
-; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX11-TRUE16-NEXT:    v_lshlrev_b16 v0.l, 8, v0.l
-; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-TRUE16-NEXT:    v_or_b16 v0.l, v0.h, v0.l
 ; GFX11-TRUE16-NEXT:    global_store_b16 v[1:2], v0, off
 ; GFX11-TRUE16-NEXT:    s_endpgm

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/llvm.amdgcn.intersect_ray.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/llvm.amdgcn.intersect_ray.ll
@@ -767,31 +767,32 @@ define amdgpu_kernel void @image_bvh_intersect_ray_nsa_reassign(ptr %p_node_ptr,
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_load_b256 s[0:7], s[4:5], 0x24
 ; GFX11-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
-; GFX11-NEXT:    s_mov_b32 s10, 0x40a00000
-; GFX11-NEXT:    s_mov_b32 s9, 4.0
-; GFX11-NEXT:    s_mov_b32 s8, 0x40400000
-; GFX11-NEXT:    s_mov_b32 s12, 0x40c00000
-; GFX11-NEXT:    v_lshlrev_b32_e32 v4, 2, v0
 ; GFX11-NEXT:    s_mov_b32 s14, 0x41000000
 ; GFX11-NEXT:    s_mov_b32 s13, 0x40e00000
+; GFX11-NEXT:    s_mov_b32 s12, 0x40c00000
+; GFX11-NEXT:    s_mov_b32 s8, 0x40400000
+; GFX11-NEXT:    v_lshlrev_b32_e32 v4, 2, v0
 ; GFX11-NEXT:    v_mov_b32_e32 v6, s12
+; GFX11-NEXT:    s_mov_b32 s10, 0x40a00000
+; GFX11-NEXT:    s_mov_b32 s9, 4.0
 ; GFX11-NEXT:    v_dual_mov_b32 v8, s14 :: v_dual_mov_b32 v7, s13
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    s_mov_b32 s2, 2.0
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX11-NEXT:    s_mov_b32 s0, 0
-; GFX11-NEXT:    s_mov_b32 s1, 1.0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v4
 ; GFX11-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-NEXT:    v_add_co_u32 v2, vcc_lo, v2, v4
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-NEXT:    v_add_co_ci_u32_e64 v3, null, 0, v3, vcc_lo
 ; GFX11-NEXT:    flat_load_b32 v9, v[0:1]
 ; GFX11-NEXT:    flat_load_b32 v10, v[2:3]
-; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v3, s8
-; GFX11-NEXT:    v_dual_mov_b32 v1, s1 :: v_dual_mov_b32 v2, s2
+; GFX11-NEXT:    s_mov_b32 s2, 2.0
+; GFX11-NEXT:    s_mov_b32 s1, 1.0
+; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s8
 ; GFX11-NEXT:    v_dual_mov_b32 v4, s9 :: v_dual_mov_b32 v5, s10
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    image_bvh_intersect_ray v[0:3], [v9, v10, v[0:2], v[3:5], v[6:8]], s[4:7]
@@ -879,24 +880,24 @@ define amdgpu_kernel void @image_bvh_intersect_ray_a16_nsa_reassign(ptr %p_node_
 ; GFX11-NEXT:    s_mov_b32 s8, 0x42004600
 ; GFX11-NEXT:    s_mov_b32 s9, 0x44004700
 ; GFX11-NEXT:    s_mov_b32 s10, 0x45004800
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_4) | instid1(VALU_DEP_2)
 ; GFX11-NEXT:    v_lshlrev_b32_e32 v4, 2, v0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    s_mov_b32 s2, 2.0
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX11-NEXT:    s_mov_b32 s0, 0
-; GFX11-NEXT:    s_mov_b32 s1, 1.0
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v4
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX11-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
 ; GFX11-NEXT:    v_add_co_u32 v2, vcc_lo, v2, v4
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_4) | instid1(SALU_CYCLE_1)
 ; GFX11-NEXT:    v_add_co_ci_u32_e64 v3, null, 0, v3, vcc_lo
 ; GFX11-NEXT:    flat_load_b32 v6, v[0:1]
 ; GFX11-NEXT:    flat_load_b32 v7, v[2:3]
-; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v3, s8
-; GFX11-NEXT:    v_dual_mov_b32 v1, s1 :: v_dual_mov_b32 v2, s2
+; GFX11-NEXT:    s_mov_b32 s2, 2.0
+; GFX11-NEXT:    s_mov_b32 s1, 1.0
+; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s8
 ; GFX11-NEXT:    v_dual_mov_b32 v4, s9 :: v_dual_mov_b32 v5, s10
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    image_bvh_intersect_ray v[0:3], [v6, v7, v[0:2], v[3:5]], s[4:7] a16
@@ -987,14 +988,14 @@ define amdgpu_kernel void @image_bvh64_intersect_ray_nsa_reassign(ptr %p_ray, <4
 ; GFX11-NEXT:    s_load_b64 s[6:7], s[4:5], 0x24
 ; GFX11-NEXT:    s_load_b128 s[0:3], s[4:5], 0x34
 ; GFX11-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
-; GFX11-NEXT:    s_mov_b32 s5, 1.0
-; GFX11-NEXT:    s_mov_b32 s4, 0
-; GFX11-NEXT:    v_mov_b32_e32 v9, 0xb36211c7
-; GFX11-NEXT:    s_mov_b32 s8, 0x40400000
-; GFX11-NEXT:    v_lshlrev_b32_e32 v2, 2, v0
-; GFX11-NEXT:    s_mov_b32 s12, 0x40c00000
 ; GFX11-NEXT:    s_mov_b32 s10, 0x40a00000
 ; GFX11-NEXT:    s_mov_b32 s9, 4.0
+; GFX11-NEXT:    s_mov_b32 s8, 0x40400000
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-NEXT:    v_dual_mov_b32 v9, 0xb36211c7 :: v_dual_lshlrev_b32 v2, 2, v0
+; GFX11-NEXT:    s_mov_b32 s4, 0
+; GFX11-NEXT:    s_mov_b32 s12, 0x40c00000
+; GFX11-NEXT:    s_mov_b32 s5, 1.0
 ; GFX11-NEXT:    s_mov_b32 s14, 0x41000000
 ; GFX11-NEXT:    s_mov_b32 s13, 0x40e00000
 ; GFX11-NEXT:    v_mov_b32_e32 v6, s12
@@ -1092,19 +1093,19 @@ define amdgpu_kernel void @image_bvh64_intersect_ray_a16_nsa_reassign(ptr %p_ray
 ; GFX11-NEXT:    s_load_b64 s[6:7], s[4:5], 0x24
 ; GFX11-NEXT:    s_load_b128 s[0:3], s[4:5], 0x34
 ; GFX11-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
-; GFX11-NEXT:    s_mov_b32 s5, 1.0
-; GFX11-NEXT:    s_mov_b32 s4, 0
 ; GFX11-NEXT:    s_mov_b32 s8, 0x42004600
 ; GFX11-NEXT:    s_mov_b32 s9, 0x44004700
-; GFX11-NEXT:    v_lshlrev_b32_e32 v2, 2, v0
 ; GFX11-NEXT:    s_mov_b32 s10, 0x45004800
-; GFX11-NEXT:    v_mov_b32_e32 v6, 0xb36211c6
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-NEXT:    v_dual_mov_b32 v3, s8 :: v_dual_lshlrev_b32 v2, 2, v0
+; GFX11-NEXT:    s_mov_b32 s4, 0
+; GFX11-NEXT:    s_mov_b32 s5, 1.0
 ; GFX11-NEXT:    v_bfrev_b32_e32 v7, 4.0
-; GFX11-NEXT:    v_dual_mov_b32 v3, s8 :: v_dual_mov_b32 v4, s9
+; GFX11-NEXT:    v_dual_mov_b32 v4, s9 :: v_dual_mov_b32 v5, s10
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    v_dual_mov_b32 v5, s10 :: v_dual_mov_b32 v0, s6
-; GFX11-NEXT:    v_mov_b32_e32 v1, s7
+; GFX11-NEXT:    v_dual_mov_b32 v0, s6 :: v_dual_mov_b32 v1, s7
 ; GFX11-NEXT:    s_mov_b32 s6, 2.0
+; GFX11-NEXT:    v_mov_b32_e32 v6, 0xb36211c6
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
 ; GFX11-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo

--- a/llvm/test/CodeGen/AMDGPU/asyncmark-gfx12plus.ll
+++ b/llvm/test/CodeGen/AMDGPU/asyncmark-gfx12plus.ll
@@ -471,15 +471,13 @@ define amdgpu_kernel void @test_pipelined_loop_with_global(ptr addrspace(1) %foo
 ; GISEL-NEXT:    s_lshl_b32 s1, s0, 2
 ; GISEL-NEXT:    s_add_co_i32 s4, s18, s8
 ; GISEL-NEXT:    s_add_co_u32 s1, s10, s1
-; GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_4) | instid1(SALU_CYCLE_1)
 ; GISEL-NEXT:    v_mov_b32_e32 v0, s1
 ; GISEL-NEXT:    ds_load_b32 v1, v0
 ; GISEL-NEXT:    s_wait_dscnt 0x0
 ; GISEL-NEXT:    v_readfirstlane_b32 s1, v1
-; GISEL-NEXT:    v_mov_b32_e32 v1, s0
 ; GISEL-NEXT:    s_add_co_i32 s1, s4, s1
-; GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GISEL-NEXT:    v_mov_b32_e32 v2, s1
+; GISEL-NEXT:    v_dual_mov_b32 v1, s0 :: v_dual_mov_b32 v2, s1
 ; GISEL-NEXT:    s_add_co_i32 s1, s9, s19
 ; GISEL-NEXT:    global_store_b32 v1, v2, s[2:3] scale_offset
 ; GISEL-NEXT:    ; wait_asyncmark(0)

--- a/llvm/test/CodeGen/AMDGPU/consecutive-loads-in-branch.ll
+++ b/llvm/test/CodeGen/AMDGPU/consecutive-loads-in-branch.ll
@@ -30,18 +30,23 @@ define amdgpu_kernel void @straightline_kernel(ptr addrspace(1) noalias %in, ptr
 ; GFX12-NEXT:    s_mov_b32 s7, 0
 ; GFX12-NEXT:  .LBB0_3: ; %main
 ; GFX12-NEXT:    v_mov_b32_e32 v1, 0
-; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(VALU_DEP_4)
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(VALU_DEP_2)
+; GFX12-NEXT:    v_lshlrev_b64_e32 v[8:9], 4, v[0:1]
 ; GFX12-NEXT:    v_mov_b32_e32 v3, v1
 ; GFX12-NEXT:    v_mov_b32_e32 v5, v1
-; GFX12-NEXT:    v_lshlrev_b64_e32 v[8:9], 4, v[0:1]
-; GFX12-NEXT:    v_mov_b32_e32 v7, v1
 ; GFX12-NEXT:    v_lshlrev_b64_e32 v[10:11], 4, v[2:3]
-; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_4)
-; GFX12-NEXT:    v_lshlrev_b64_e32 v[12:13], 4, v[4:5]
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX12-NEXT:    v_add_co_u32 v8, vcc_lo, s0, v8
-; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GFX12-NEXT:    v_lshlrev_b64_e32 v[14:15], 4, v[6:7]
 ; GFX12-NEXT:    v_add_co_ci_u32_e64 v9, null, s1, v9, vcc_lo
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX12-NEXT:    v_lshlrev_b64_e32 v[12:13], 4, v[4:5]
+; GFX12-NEXT:    global_load_b128 v[2:5], v[8:9], off
+; GFX12-NEXT:    s_wait_loadcnt 0x0
+; GFX12-NEXT:    s_wait_kmcnt 0x0
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    v_dual_mov_b32 v7, v1 :: v_dual_add_nc_u32 v4, s6, v4
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12-NEXT:    v_lshlrev_b64_e32 v[14:15], 4, v[6:7]
 ; GFX12-NEXT:    v_add_co_u32 v6, vcc_lo, s0, v10
 ; GFX12-NEXT:    s_wait_alu depctr_va_vcc(0)
 ; GFX12-NEXT:    v_add_co_ci_u32_e64 v7, null, s1, v11, vcc_lo
@@ -51,16 +56,11 @@ define amdgpu_kernel void @straightline_kernel(ptr addrspace(1) noalias %in, ptr
 ; GFX12-NEXT:    v_add_co_u32 v14, vcc_lo, s0, v14
 ; GFX12-NEXT:    s_wait_alu depctr_va_vcc(0)
 ; GFX12-NEXT:    v_add_co_ci_u32_e64 v15, null, s1, v15, vcc_lo
-; GFX12-NEXT:    s_clause 0x3
-; GFX12-NEXT:    global_load_b128 v[2:5], v[8:9], off
+; GFX12-NEXT:    s_clause 0x2
 ; GFX12-NEXT:    global_load_b128 v[6:9], v[6:7], off
 ; GFX12-NEXT:    global_load_b128 v[10:13], v[10:11], off
 ; GFX12-NEXT:    global_load_b128 v[14:17], v[14:15], off
-; GFX12-NEXT:    s_wait_loadcnt 0x3
-; GFX12-NEXT:    s_wait_kmcnt 0x0
-; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-NEXT:    v_add_nc_u32_e32 v5, s7, v5
-; GFX12-NEXT:    v_add_nc_u32_e32 v4, s6, v4
 ; GFX12-NEXT:    v_add_nc_u32_e32 v3, s5, v3
 ; GFX12-NEXT:    v_add_nc_u32_e32 v2, s4, v2
 ; GFX12-NEXT:    s_wait_loadcnt 0x2

--- a/llvm/test/CodeGen/AMDGPU/idot4u.ll
+++ b/llvm/test/CodeGen/AMDGPU/idot4u.ll
@@ -1682,30 +1682,30 @@ define amdgpu_kernel void @notdot4_mixedtypes(ptr addrspace(1) %src1,
 ; GFX11-DL-FAKE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
 ; GFX11-DL-FAKE16-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX11-DL-FAKE16-NEXT:    s_load_b64 s[4:5], s[4:5], 0x34
-; GFX11-DL-FAKE16-NEXT:    v_mov_b32_e32 v2, 0
-; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-DL-FAKE16-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX11-DL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-DL-FAKE16-NEXT:    s_clause 0x1
 ; GFX11-DL-FAKE16-NEXT:    global_load_b32 v1, v0, s[0:1]
 ; GFX11-DL-FAKE16-NEXT:    global_load_b32 v0, v0, s[2:3]
-; GFX11-DL-FAKE16-NEXT:    global_load_u16 v3, v2, s[4:5]
-; GFX11-DL-FAKE16-NEXT:    s_waitcnt vmcnt(2)
-; GFX11-DL-FAKE16-NEXT:    v_lshrrev_b32_e32 v4, 8, v1
 ; GFX11-DL-FAKE16-NEXT:    s_waitcnt vmcnt(1)
+; GFX11-DL-FAKE16-NEXT:    v_lshrrev_b32_e32 v4, 8, v1
+; GFX11-DL-FAKE16-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-DL-FAKE16-NEXT:    v_lshrrev_b32_e32 v5, 8, v0
+; GFX11-DL-FAKE16-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX11-DL-FAKE16-NEXT:    v_bfe_i32 v6, v1, 0, 8
 ; GFX11-DL-FAKE16-NEXT:    v_bfe_i32 v7, v0, 0, 8
-; GFX11-DL-FAKE16-NEXT:    v_perm_b32 v0, v0, v0, 0xc0c0302
 ; GFX11-DL-FAKE16-NEXT:    v_and_b32_e32 v4, 0xff, v4
 ; GFX11-DL-FAKE16-NEXT:    v_and_b32_e32 v5, 0xff, v5
+; GFX11-DL-FAKE16-NEXT:    global_load_u16 v3, v2, s[4:5]
+; GFX11-DL-FAKE16-NEXT:    v_perm_b32 v0, v0, v0, 0xc0c0302
 ; GFX11-DL-FAKE16-NEXT:    v_perm_b32 v1, v1, v1, 0xc0c0302
 ; GFX11-DL-FAKE16-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-DL-FAKE16-NEXT:    v_mad_u16 v3, v4, v5, v3
-; GFX11-DL-FAKE16-NEXT:    v_mad_u16 v3, v6, v7, v3
 ; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-DL-FAKE16-NEXT:    v_mad_u16 v3, v6, v7, v3
 ; GFX11-DL-FAKE16-NEXT:    v_and_b32_e32 v3, 0xffff, v3
+; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-DL-FAKE16-NEXT:    v_dot4_u32_u8 v0, v1, v0, v3
 ; GFX11-DL-FAKE16-NEXT:    global_store_b16 v2, v0, s[4:5]
 ; GFX11-DL-FAKE16-NEXT:    s_endpgm
@@ -1977,35 +1977,35 @@ define amdgpu_kernel void @notdot4_mixedtypes2(ptr addrspace(1) %src1,
 ; GFX11-DL-FAKE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
 ; GFX11-DL-FAKE16-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX11-DL-FAKE16-NEXT:    s_load_b64 s[4:5], s[4:5], 0x34
-; GFX11-DL-FAKE16-NEXT:    v_mov_b32_e32 v2, 0
-; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-DL-FAKE16-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX11-DL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-DL-FAKE16-NEXT:    s_clause 0x1
 ; GFX11-DL-FAKE16-NEXT:    global_load_b32 v1, v0, s[0:1]
 ; GFX11-DL-FAKE16-NEXT:    global_load_b32 v0, v0, s[2:3]
-; GFX11-DL-FAKE16-NEXT:    global_load_u16 v3, v2, s[4:5]
-; GFX11-DL-FAKE16-NEXT:    s_waitcnt vmcnt(2)
-; GFX11-DL-FAKE16-NEXT:    v_lshrrev_b32_e32 v4, 8, v1
+; GFX11-DL-FAKE16-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX11-DL-FAKE16-NEXT:    s_waitcnt vmcnt(1)
+; GFX11-DL-FAKE16-NEXT:    v_lshrrev_b32_e32 v4, 8, v1
+; GFX11-DL-FAKE16-NEXT:    s_waitcnt vmcnt(0)
+; GFX11-DL-FAKE16-NEXT:    v_and_b32_e32 v9, 0xff, v0
+; GFX11-DL-FAKE16-NEXT:    global_load_u16 v3, v2, s[4:5]
 ; GFX11-DL-FAKE16-NEXT:    v_lshrrev_b32_e32 v5, 8, v0
 ; GFX11-DL-FAKE16-NEXT:    v_lshrrev_b32_e32 v6, 16, v1
+; GFX11-DL-FAKE16-NEXT:    v_and_b32_e32 v4, 0xff, v4
 ; GFX11-DL-FAKE16-NEXT:    v_lshrrev_b32_e32 v7, 16, v0
 ; GFX11-DL-FAKE16-NEXT:    v_bfe_i32 v8, v1, 0, 8
-; GFX11-DL-FAKE16-NEXT:    v_and_b32_e32 v4, 0xff, v4
 ; GFX11-DL-FAKE16-NEXT:    v_bfe_i32 v5, v5, 0, 8
-; GFX11-DL-FAKE16-NEXT:    v_and_b32_e32 v9, 0xff, v0
 ; GFX11-DL-FAKE16-NEXT:    v_lshrrev_b32_e32 v0, 24, v0
 ; GFX11-DL-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 24, v1
+; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_4) | instid1(VALU_DEP_3)
+; GFX11-DL-FAKE16-NEXT:    v_bfe_i32 v0, v0, 0, 8
 ; GFX11-DL-FAKE16-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-DL-FAKE16-NEXT:    v_mad_u16 v3, v4, v5, v3
 ; GFX11-DL-FAKE16-NEXT:    v_bfe_i32 v4, v6, 0, 8
 ; GFX11-DL-FAKE16-NEXT:    v_and_b32_e32 v5, 0xff, v7
-; GFX11-DL-FAKE16-NEXT:    v_bfe_i32 v0, v0, 0, 8
-; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-DL-FAKE16-NEXT:    v_mad_u16 v3, v8, v9, v3
+; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-DL-FAKE16-NEXT:    v_mad_u16 v3, v4, v5, v3
-; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-DL-FAKE16-NEXT:    v_mad_u16 v0, v1, v0, v3
 ; GFX11-DL-FAKE16-NEXT:    global_store_b16 v2, v0, s[4:5]
 ; GFX11-DL-FAKE16-NEXT:    s_endpgm
@@ -2451,25 +2451,24 @@ define amdgpu_kernel void @udot4_acc16_vecMul(ptr addrspace(1) %src1,
 ; GFX11-DL-FAKE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
 ; GFX11-DL-FAKE16-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX11-DL-FAKE16-NEXT:    s_load_b64 s[4:5], s[4:5], 0x34
-; GFX11-DL-FAKE16-NEXT:    v_mov_b32_e32 v2, 0
-; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-DL-FAKE16-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX11-DL-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-DL-FAKE16-NEXT:    s_clause 0x1
 ; GFX11-DL-FAKE16-NEXT:    global_load_b32 v1, v0, s[0:1]
 ; GFX11-DL-FAKE16-NEXT:    global_load_b32 v0, v0, s[2:3]
+; GFX11-DL-FAKE16-NEXT:    s_waitcnt vmcnt(1)
+; GFX11-DL-FAKE16-NEXT:    v_dual_mov_b32 v2, 0 :: v_dual_and_b32 v7, 0xff, v1
 ; GFX11-DL-FAKE16-NEXT:    global_load_u16 v3, v2, s[4:5]
-; GFX11-DL-FAKE16-NEXT:    s_waitcnt vmcnt(2)
 ; GFX11-DL-FAKE16-NEXT:    v_lshrrev_b16 v4, 8, v1
 ; GFX11-DL-FAKE16-NEXT:    s_waitcnt vmcnt(1)
 ; GFX11-DL-FAKE16-NEXT:    v_lshrrev_b16 v5, 8, v0
 ; GFX11-DL-FAKE16-NEXT:    v_and_b32_e32 v6, 0xff, v0
-; GFX11-DL-FAKE16-NEXT:    v_and_b32_e32 v7, 0xff, v1
 ; GFX11-DL-FAKE16-NEXT:    v_lshrrev_b32_e32 v8, 16, v1
 ; GFX11-DL-FAKE16-NEXT:    v_lshrrev_b32_e32 v9, 16, v0
+; GFX11-DL-FAKE16-NEXT:    v_perm_b32 v4, v4, v7, 0x5040100
 ; GFX11-DL-FAKE16-NEXT:    v_lshrrev_b32_e32 v1, 24, v1
 ; GFX11-DL-FAKE16-NEXT:    v_perm_b32 v5, v5, v6, 0x5040100
-; GFX11-DL-FAKE16-NEXT:    v_perm_b32 v4, v4, v7, 0x5040100
 ; GFX11-DL-FAKE16-NEXT:    v_lshrrev_b32_e32 v0, 24, v0
 ; GFX11-DL-FAKE16-NEXT:    v_and_b32_e32 v6, 0xff, v9
 ; GFX11-DL-FAKE16-NEXT:    v_and_b32_e32 v7, 0xff, v8
@@ -2479,12 +2478,12 @@ define amdgpu_kernel void @udot4_acc16_vecMul(ptr addrspace(1) %src1,
 ; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX11-DL-FAKE16-NEXT:    v_perm_b32 v1, v1, v7, 0x5040100
 ; GFX11-DL-FAKE16-NEXT:    v_lshrrev_b32_e32 v5, 16, v4
+; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_1)
+; GFX11-DL-FAKE16-NEXT:    v_pk_mul_lo_u16 v0, v1, v0
 ; GFX11-DL-FAKE16-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-DL-FAKE16-NEXT:    v_add_nc_u16 v3, v4, v3
-; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-DL-FAKE16-NEXT:    v_pk_mul_lo_u16 v0, v1, v0
 ; GFX11-DL-FAKE16-NEXT:    v_add_nc_u16 v1, v3, v5
-; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX11-DL-FAKE16-NEXT:    v_lshrrev_b32_e32 v3, 16, v0
 ; GFX11-DL-FAKE16-NEXT:    v_add_nc_u16 v0, v1, v0
 ; GFX11-DL-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.av.store.b128.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.av.store.b128.ll
@@ -1241,13 +1241,12 @@ define amdgpu_kernel void @global_store_saddr_uniform_ptr_in_vgprs(i32 %voffset,
 ; GFX1250-SDAG-LABEL: global_store_saddr_uniform_ptr_in_vgprs:
 ; GFX1250-SDAG:       ; %bb.0:
 ; GFX1250-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-SDAG-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX1250-SDAG-NEXT:    s_clause 0x1
 ; GFX1250-SDAG-NEXT:    s_load_b32 s6, s[4:5], 0x24 nv
 ; GFX1250-SDAG-NEXT:    s_load_b128 s[0:3], s[4:5], 0x34 nv
-; GFX1250-SDAG-NEXT:    ds_load_b64 v[4:5], v0
 ; GFX1250-SDAG-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-SDAG-NEXT:    v_mov_b32_e32 v6, s6
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v6, s6
+; GFX1250-SDAG-NEXT:    ds_load_b64 v[4:5], v0
 ; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[0:1], s[0:1]
 ; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[2:3], s[2:3]
 ; GFX1250-SDAG-NEXT:    s_wait_dscnt 0x0
@@ -1419,13 +1418,12 @@ define amdgpu_kernel void @global_store_saddr_uniform_ptr_in_vgprs_immoffset(i32
 ; GFX1250-SDAG-LABEL: global_store_saddr_uniform_ptr_in_vgprs_immoffset:
 ; GFX1250-SDAG:       ; %bb.0:
 ; GFX1250-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-SDAG-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX1250-SDAG-NEXT:    s_clause 0x1
 ; GFX1250-SDAG-NEXT:    s_load_b32 s6, s[4:5], 0x24 nv
 ; GFX1250-SDAG-NEXT:    s_load_b128 s[0:3], s[4:5], 0x34 nv
-; GFX1250-SDAG-NEXT:    ds_load_b64 v[4:5], v0
 ; GFX1250-SDAG-NEXT:    s_wait_kmcnt 0x0
-; GFX1250-SDAG-NEXT:    v_mov_b32_e32 v6, s6
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v6, s6
+; GFX1250-SDAG-NEXT:    ds_load_b64 v[4:5], v0
 ; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[0:1], s[0:1]
 ; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[2:3], s[2:3]
 ; GFX1250-SDAG-NEXT:    s_wait_dscnt 0x0

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.intersect_ray.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.intersect_ray.ll
@@ -751,11 +751,11 @@ define amdgpu_kernel void @image_bvh_intersect_ray_nsa_reassign(ptr %p_node_ptr,
 ; GFX11-SDAG:       ; %bb.0: ; %main_body
 ; GFX11-SDAG-NEXT:    s_load_b256 s[0:7], s[4:5], 0x24
 ; GFX11-SDAG-NEXT:    v_dual_mov_b32 v7, 1.0 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX11-SDAG-NEXT:    v_dual_mov_b32 v5, 0x40a00000 :: v_dual_mov_b32 v6, 0
-; GFX11-SDAG-NEXT:    v_mov_b32_e32 v8, 2.0
+; GFX11-SDAG-NEXT:    v_dual_mov_b32 v8, 2.0 :: v_dual_mov_b32 v5, 0x40a00000
+; GFX11-SDAG-NEXT:    v_mov_b32_e32 v4, 4.0
 ; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_2) | instid1(VALU_DEP_2)
 ; GFX11-SDAG-NEXT:    v_lshlrev_b32_e32 v2, 2, v0
-; GFX11-SDAG-NEXT:    v_mov_b32_e32 v4, 4.0
+; GFX11-SDAG-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX11-SDAG-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-SDAG-NEXT:    v_add_co_u32 v0, s0, s0, v2
 ; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
@@ -778,31 +778,32 @@ define amdgpu_kernel void @image_bvh_intersect_ray_nsa_reassign(ptr %p_node_ptr,
 ; GFX11-GISEL:       ; %bb.0: ; %main_body
 ; GFX11-GISEL-NEXT:    s_load_b256 s[0:7], s[4:5], 0x24
 ; GFX11-GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
-; GFX11-GISEL-NEXT:    s_mov_b32 s10, 0x40a00000
-; GFX11-GISEL-NEXT:    s_mov_b32 s9, 4.0
-; GFX11-GISEL-NEXT:    s_mov_b32 s8, 0x40400000
-; GFX11-GISEL-NEXT:    s_mov_b32 s12, 0x40c00000
-; GFX11-GISEL-NEXT:    v_lshlrev_b32_e32 v4, 2, v0
 ; GFX11-GISEL-NEXT:    s_mov_b32 s14, 0x41000000
 ; GFX11-GISEL-NEXT:    s_mov_b32 s13, 0x40e00000
+; GFX11-GISEL-NEXT:    s_mov_b32 s12, 0x40c00000
+; GFX11-GISEL-NEXT:    s_mov_b32 s8, 0x40400000
+; GFX11-GISEL-NEXT:    v_lshlrev_b32_e32 v4, 2, v0
 ; GFX11-GISEL-NEXT:    v_mov_b32_e32 v6, s12
+; GFX11-GISEL-NEXT:    s_mov_b32 s10, 0x40a00000
+; GFX11-GISEL-NEXT:    s_mov_b32 s9, 4.0
 ; GFX11-GISEL-NEXT:    v_dual_mov_b32 v8, s14 :: v_dual_mov_b32 v7, s13
 ; GFX11-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-GISEL-NEXT:    s_mov_b32 s2, 2.0
 ; GFX11-GISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX11-GISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX11-GISEL-NEXT:    s_mov_b32 s0, 0
-; GFX11-GISEL-NEXT:    s_mov_b32 s1, 1.0
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-GISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v4
 ; GFX11-GISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-GISEL-NEXT:    v_add_co_u32 v2, vcc_lo, v2, v4
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-GISEL-NEXT:    v_add_co_ci_u32_e64 v3, null, 0, v3, vcc_lo
 ; GFX11-GISEL-NEXT:    flat_load_b32 v9, v[0:1]
 ; GFX11-GISEL-NEXT:    flat_load_b32 v10, v[2:3]
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v3, s8
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v1, s1 :: v_dual_mov_b32 v2, s2
+; GFX11-GISEL-NEXT:    s_mov_b32 s2, 2.0
+; GFX11-GISEL-NEXT:    s_mov_b32 s1, 1.0
+; GFX11-GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX11-GISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX11-GISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s8
 ; GFX11-GISEL-NEXT:    v_dual_mov_b32 v4, s9 :: v_dual_mov_b32 v5, s10
 ; GFX11-GISEL-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX11-GISEL-NEXT:    image_bvh_intersect_ray v[0:3], [v9, v10, v[0:2], v[3:5], v[6:8]], s[4:7]
@@ -814,11 +815,11 @@ define amdgpu_kernel void @image_bvh_intersect_ray_nsa_reassign(ptr %p_node_ptr,
 ; GFX12-SDAG:       ; %bb.0: ; %main_body
 ; GFX12-SDAG-NEXT:    s_load_b256 s[0:7], s[4:5], 0x24
 ; GFX12-SDAG-NEXT:    v_dual_mov_b32 v7, 1.0 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX12-SDAG-NEXT:    v_dual_mov_b32 v5, 0x40a00000 :: v_dual_mov_b32 v6, 0
-; GFX12-SDAG-NEXT:    v_mov_b32_e32 v8, 2.0
+; GFX12-SDAG-NEXT:    v_dual_mov_b32 v8, 2.0 :: v_dual_mov_b32 v5, 0x40a00000
+; GFX12-SDAG-NEXT:    v_mov_b32_e32 v4, 4.0
 ; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_2) | instid1(VALU_DEP_2)
 ; GFX12-SDAG-NEXT:    v_lshlrev_b32_e32 v2, 2, v0
-; GFX12-SDAG-NEXT:    v_mov_b32_e32 v4, 4.0
+; GFX12-SDAG-NEXT:    v_mov_b32_e32 v6, 0
 ; GFX12-SDAG-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-SDAG-NEXT:    v_add_co_u32 v0, s0, s0, v2
 ; GFX12-SDAG-NEXT:    s_wait_alu depctr_va_sdst(0)
@@ -842,32 +843,33 @@ define amdgpu_kernel void @image_bvh_intersect_ray_nsa_reassign(ptr %p_node_ptr,
 ; GFX12-GISEL:       ; %bb.0: ; %main_body
 ; GFX12-GISEL-NEXT:    s_load_b256 s[0:7], s[4:5], 0x24
 ; GFX12-GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
-; GFX12-GISEL-NEXT:    s_mov_b32 s10, 0x40a00000
-; GFX12-GISEL-NEXT:    s_mov_b32 s9, 4.0
-; GFX12-GISEL-NEXT:    s_mov_b32 s8, 0x40400000
-; GFX12-GISEL-NEXT:    s_mov_b32 s12, 0x40c00000
-; GFX12-GISEL-NEXT:    v_lshlrev_b32_e32 v4, 2, v0
 ; GFX12-GISEL-NEXT:    s_mov_b32 s14, 0x41000000
 ; GFX12-GISEL-NEXT:    s_mov_b32 s13, 0x40e00000
+; GFX12-GISEL-NEXT:    s_mov_b32 s12, 0x40c00000
+; GFX12-GISEL-NEXT:    s_mov_b32 s8, 0x40400000
+; GFX12-GISEL-NEXT:    v_lshlrev_b32_e32 v4, 2, v0
 ; GFX12-GISEL-NEXT:    v_mov_b32_e32 v6, s12
+; GFX12-GISEL-NEXT:    s_mov_b32 s10, 0x40a00000
+; GFX12-GISEL-NEXT:    s_mov_b32 s9, 4.0
 ; GFX12-GISEL-NEXT:    v_dual_mov_b32 v8, s14 :: v_dual_mov_b32 v7, s13
 ; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX12-GISEL-NEXT:    s_mov_b32 s2, 2.0
 ; GFX12-GISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-GISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX12-GISEL-NEXT:    s_mov_b32 s0, 0
-; GFX12-GISEL-NEXT:    s_mov_b32 s1, 1.0
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX12-GISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v4
 ; GFX12-GISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
+; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_3)
 ; GFX12-GISEL-NEXT:    v_add_co_u32 v2, vcc_lo, v2, v4
 ; GFX12-GISEL-NEXT:    s_wait_alu depctr_va_vcc(0)
 ; GFX12-GISEL-NEXT:    v_add_co_ci_u32_e64 v3, null, 0, v3, vcc_lo
 ; GFX12-GISEL-NEXT:    flat_load_b32 v9, v[0:1]
 ; GFX12-GISEL-NEXT:    flat_load_b32 v10, v[2:3]
+; GFX12-GISEL-NEXT:    s_mov_b32 s2, 2.0
+; GFX12-GISEL-NEXT:    s_mov_b32 s1, 1.0
 ; GFX12-GISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v3, s8
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v1, s1 :: v_dual_mov_b32 v2, s2
+; GFX12-GISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-GISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s8
 ; GFX12-GISEL-NEXT:    v_dual_mov_b32 v4, s9 :: v_dual_mov_b32 v5, s10
 ; GFX12-GISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX12-GISEL-NEXT:    image_bvh_intersect_ray v[0:3], [v9, v10, v[0:2], v[3:5], v[6:8]], s[4:7]
@@ -998,8 +1000,8 @@ define amdgpu_kernel void @image_bvh_intersect_ray_a16_nsa_reassign(ptr %p_node_
 ; GFX11-SDAG-LABEL: image_bvh_intersect_ray_a16_nsa_reassign:
 ; GFX11-SDAG:       ; %bb.0: ; %main_body
 ; GFX11-SDAG-NEXT:    s_load_b256 s[0:7], s[4:5], 0x24
-; GFX11-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
-; GFX11-SDAG-NEXT:    v_dual_mov_b32 v4, 1.0 :: v_dual_mov_b32 v5, 2.0
+; GFX11-SDAG-NEXT:    v_dual_mov_b32 v5, 2.0 :: v_dual_and_b32 v0, 0x3ff, v0
+; GFX11-SDAG-NEXT:    v_mov_b32_e32 v4, 1.0
 ; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_1)
 ; GFX11-SDAG-NEXT:    v_lshlrev_b32_e32 v2, 2, v0
 ; GFX11-SDAG-NEXT:    s_waitcnt lgkmcnt(0)
@@ -1010,9 +1012,9 @@ define amdgpu_kernel void @image_bvh_intersect_ray_a16_nsa_reassign(ptr %p_node_
 ; GFX11-SDAG-NEXT:    v_add_co_ci_u32_e64 v3, null, s3, 0, s0
 ; GFX11-SDAG-NEXT:    flat_load_b32 v6, v[0:1]
 ; GFX11-SDAG-NEXT:    flat_load_b32 v7, v[2:3]
-; GFX11-SDAG-NEXT:    v_mov_b32_e32 v0, 0x46004200
+; GFX11-SDAG-NEXT:    v_dual_mov_b32 v0, 0x46004200 :: v_dual_mov_b32 v3, 0
 ; GFX11-SDAG-NEXT:    v_mov_b32_e32 v1, 0x47004400
-; GFX11-SDAG-NEXT:    v_dual_mov_b32 v2, 0x48004500 :: v_dual_mov_b32 v3, 0
+; GFX11-SDAG-NEXT:    v_mov_b32_e32 v2, 0x48004500
 ; GFX11-SDAG-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX11-SDAG-NEXT:    image_bvh_intersect_ray v[0:3], [v6, v7, v[3:5], v[0:2]], s[4:7] a16
 ; GFX11-SDAG-NEXT:    s_waitcnt vmcnt(0)
@@ -1026,24 +1028,24 @@ define amdgpu_kernel void @image_bvh_intersect_ray_a16_nsa_reassign(ptr %p_node_
 ; GFX11-GISEL-NEXT:    s_mov_b32 s8, 0x42004600
 ; GFX11-GISEL-NEXT:    s_mov_b32 s9, 0x44004700
 ; GFX11-GISEL-NEXT:    s_mov_b32 s10, 0x45004800
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_4) | instid1(VALU_DEP_2)
 ; GFX11-GISEL-NEXT:    v_lshlrev_b32_e32 v4, 2, v0
 ; GFX11-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-GISEL-NEXT:    s_mov_b32 s2, 2.0
 ; GFX11-GISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX11-GISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX11-GISEL-NEXT:    s_mov_b32 s0, 0
-; GFX11-GISEL-NEXT:    s_mov_b32 s1, 1.0
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-GISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v4
+; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX11-GISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
 ; GFX11-GISEL-NEXT:    v_add_co_u32 v2, vcc_lo, v2, v4
-; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_4) | instid1(SALU_CYCLE_1)
 ; GFX11-GISEL-NEXT:    v_add_co_ci_u32_e64 v3, null, 0, v3, vcc_lo
 ; GFX11-GISEL-NEXT:    flat_load_b32 v6, v[0:1]
 ; GFX11-GISEL-NEXT:    flat_load_b32 v7, v[2:3]
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v3, s8
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v1, s1 :: v_dual_mov_b32 v2, s2
+; GFX11-GISEL-NEXT:    s_mov_b32 s2, 2.0
+; GFX11-GISEL-NEXT:    s_mov_b32 s1, 1.0
+; GFX11-GISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX11-GISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s8
 ; GFX11-GISEL-NEXT:    v_dual_mov_b32 v4, s9 :: v_dual_mov_b32 v5, s10
 ; GFX11-GISEL-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX11-GISEL-NEXT:    image_bvh_intersect_ray v[0:3], [v6, v7, v[0:2], v[3:5]], s[4:7] a16
@@ -1054,8 +1056,8 @@ define amdgpu_kernel void @image_bvh_intersect_ray_a16_nsa_reassign(ptr %p_node_
 ; GFX12-SDAG-LABEL: image_bvh_intersect_ray_a16_nsa_reassign:
 ; GFX12-SDAG:       ; %bb.0: ; %main_body
 ; GFX12-SDAG-NEXT:    s_load_b256 s[0:7], s[4:5], 0x24
-; GFX12-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
-; GFX12-SDAG-NEXT:    v_dual_mov_b32 v4, 1.0 :: v_dual_mov_b32 v5, 2.0
+; GFX12-SDAG-NEXT:    v_dual_mov_b32 v5, 2.0 :: v_dual_and_b32 v0, 0x3ff, v0
+; GFX12-SDAG-NEXT:    v_mov_b32_e32 v4, 1.0
 ; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_1)
 ; GFX12-SDAG-NEXT:    v_lshlrev_b32_e32 v2, 2, v0
 ; GFX12-SDAG-NEXT:    s_wait_kmcnt 0x0
@@ -1067,9 +1069,9 @@ define amdgpu_kernel void @image_bvh_intersect_ray_a16_nsa_reassign(ptr %p_node_
 ; GFX12-SDAG-NEXT:    v_add_co_ci_u32_e64 v3, null, s3, 0, s0
 ; GFX12-SDAG-NEXT:    flat_load_b32 v6, v[0:1]
 ; GFX12-SDAG-NEXT:    flat_load_b32 v7, v[2:3]
-; GFX12-SDAG-NEXT:    v_mov_b32_e32 v0, 0x46004200
+; GFX12-SDAG-NEXT:    v_dual_mov_b32 v0, 0x46004200 :: v_dual_mov_b32 v3, 0
 ; GFX12-SDAG-NEXT:    v_mov_b32_e32 v1, 0x47004400
-; GFX12-SDAG-NEXT:    v_dual_mov_b32 v2, 0x48004500 :: v_dual_mov_b32 v3, 0
+; GFX12-SDAG-NEXT:    v_mov_b32_e32 v2, 0x48004500
 ; GFX12-SDAG-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX12-SDAG-NEXT:    image_bvh_intersect_ray v[0:3], [v6, v7, v[3:5], v[0:2]], s[4:7] a16
 ; GFX12-SDAG-NEXT:    s_wait_bvhcnt 0x0
@@ -1083,25 +1085,25 @@ define amdgpu_kernel void @image_bvh_intersect_ray_a16_nsa_reassign(ptr %p_node_
 ; GFX12-GISEL-NEXT:    s_mov_b32 s8, 0x42004600
 ; GFX12-GISEL-NEXT:    s_mov_b32 s9, 0x44004700
 ; GFX12-GISEL-NEXT:    s_mov_b32 s10, 0x45004800
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_4) | instid1(VALU_DEP_2)
 ; GFX12-GISEL-NEXT:    v_lshlrev_b32_e32 v4, 2, v0
 ; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX12-GISEL-NEXT:    s_mov_b32 s2, 2.0
 ; GFX12-GISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-GISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX12-GISEL-NEXT:    s_mov_b32 s0, 0
-; GFX12-GISEL-NEXT:    s_mov_b32 s1, 1.0
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX12-GISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v4
+; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX12-GISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
 ; GFX12-GISEL-NEXT:    v_add_co_u32 v2, vcc_lo, v2, v4
 ; GFX12-GISEL-NEXT:    s_wait_alu depctr_va_vcc(0)
 ; GFX12-GISEL-NEXT:    v_add_co_ci_u32_e64 v3, null, 0, v3, vcc_lo
 ; GFX12-GISEL-NEXT:    flat_load_b32 v6, v[0:1]
 ; GFX12-GISEL-NEXT:    flat_load_b32 v7, v[2:3]
+; GFX12-GISEL-NEXT:    s_mov_b32 s2, 2.0
+; GFX12-GISEL-NEXT:    s_mov_b32 s1, 1.0
 ; GFX12-GISEL-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v3, s8
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v1, s1 :: v_dual_mov_b32 v2, s2
+; GFX12-GISEL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
+; GFX12-GISEL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s8
 ; GFX12-GISEL-NEXT:    v_dual_mov_b32 v4, s9 :: v_dual_mov_b32 v5, s10
 ; GFX12-GISEL-NEXT:    s_wait_loadcnt_dscnt 0x0
 ; GFX12-GISEL-NEXT:    image_bvh_intersect_ray v[0:3], [v6, v7, v[0:2], v[3:5]], s[4:7] a16
@@ -1248,12 +1250,13 @@ define amdgpu_kernel void @image_bvh64_intersect_ray_nsa_reassign(ptr %p_ray, <4
 ; GFX11-SDAG-NEXT:    s_load_b128 s[0:3], s[4:5], 0x34
 ; GFX11-SDAG-NEXT:    v_dual_mov_b32 v7, 1.0 :: v_dual_and_b32 v0, 0x3ff, v0
 ; GFX11-SDAG-NEXT:    v_mov_b32_e32 v2, 0x41000000
-; GFX11-SDAG-NEXT:    v_dual_mov_b32 v3, 0x40400000 :: v_dual_mov_b32 v4, 4.0
-; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3)
-; GFX11-SDAG-NEXT:    v_dual_mov_b32 v5, 0x40a00000 :: v_dual_lshlrev_b32 v0, 2, v0
-; GFX11-SDAG-NEXT:    v_mov_b32_e32 v6, 0
+; GFX11-SDAG-NEXT:    v_mov_b32_e32 v3, 0x40400000
+; GFX11-SDAG-NEXT:    v_dual_mov_b32 v5, 0x40a00000 :: v_dual_mov_b32 v6, 0
+; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11-SDAG-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX11-SDAG-NEXT:    v_dual_mov_b32 v8, 2.0 :: v_dual_mov_b32 v9, 0xb36211c7
 ; GFX11-SDAG-NEXT:    v_bfrev_b32_e32 v10, 4.0
+; GFX11-SDAG-NEXT:    v_mov_b32_e32 v4, 4.0
 ; GFX11-SDAG-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-SDAG-NEXT:    v_add_co_u32 v0, s4, s6, v0
 ; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
@@ -1273,14 +1276,14 @@ define amdgpu_kernel void @image_bvh64_intersect_ray_nsa_reassign(ptr %p_ray, <4
 ; GFX11-GISEL-NEXT:    s_load_b64 s[6:7], s[4:5], 0x24
 ; GFX11-GISEL-NEXT:    s_load_b128 s[0:3], s[4:5], 0x34
 ; GFX11-GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
-; GFX11-GISEL-NEXT:    s_mov_b32 s5, 1.0
-; GFX11-GISEL-NEXT:    s_mov_b32 s4, 0
-; GFX11-GISEL-NEXT:    v_mov_b32_e32 v9, 0xb36211c7
-; GFX11-GISEL-NEXT:    s_mov_b32 s8, 0x40400000
-; GFX11-GISEL-NEXT:    v_lshlrev_b32_e32 v2, 2, v0
-; GFX11-GISEL-NEXT:    s_mov_b32 s12, 0x40c00000
 ; GFX11-GISEL-NEXT:    s_mov_b32 s10, 0x40a00000
 ; GFX11-GISEL-NEXT:    s_mov_b32 s9, 4.0
+; GFX11-GISEL-NEXT:    s_mov_b32 s8, 0x40400000
+; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-GISEL-NEXT:    v_dual_mov_b32 v9, 0xb36211c7 :: v_dual_lshlrev_b32 v2, 2, v0
+; GFX11-GISEL-NEXT:    s_mov_b32 s4, 0
+; GFX11-GISEL-NEXT:    s_mov_b32 s12, 0x40c00000
+; GFX11-GISEL-NEXT:    s_mov_b32 s5, 1.0
 ; GFX11-GISEL-NEXT:    s_mov_b32 s14, 0x41000000
 ; GFX11-GISEL-NEXT:    s_mov_b32 s13, 0x40e00000
 ; GFX11-GISEL-NEXT:    v_mov_b32_e32 v6, s12
@@ -1310,12 +1313,13 @@ define amdgpu_kernel void @image_bvh64_intersect_ray_nsa_reassign(ptr %p_ray, <4
 ; GFX12-SDAG-NEXT:    s_load_b128 s[0:3], s[4:5], 0x34
 ; GFX12-SDAG-NEXT:    v_dual_mov_b32 v7, 1.0 :: v_dual_and_b32 v0, 0x3ff, v0
 ; GFX12-SDAG-NEXT:    v_mov_b32_e32 v2, 0x41000000
-; GFX12-SDAG-NEXT:    v_dual_mov_b32 v3, 0x40400000 :: v_dual_mov_b32 v4, 4.0
-; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3)
-; GFX12-SDAG-NEXT:    v_dual_mov_b32 v5, 0x40a00000 :: v_dual_lshlrev_b32 v0, 2, v0
-; GFX12-SDAG-NEXT:    v_mov_b32_e32 v6, 0
+; GFX12-SDAG-NEXT:    v_mov_b32_e32 v3, 0x40400000
+; GFX12-SDAG-NEXT:    v_dual_mov_b32 v5, 0x40a00000 :: v_dual_mov_b32 v6, 0
+; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX12-SDAG-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX12-SDAG-NEXT:    v_dual_mov_b32 v8, 2.0 :: v_dual_mov_b32 v9, 0xb36211c7
 ; GFX12-SDAG-NEXT:    v_bfrev_b32_e32 v10, 4.0
+; GFX12-SDAG-NEXT:    v_mov_b32_e32 v4, 4.0
 ; GFX12-SDAG-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-SDAG-NEXT:    v_add_co_u32 v0, s4, s6, v0
 ; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
@@ -1335,14 +1339,14 @@ define amdgpu_kernel void @image_bvh64_intersect_ray_nsa_reassign(ptr %p_ray, <4
 ; GFX12-GISEL-NEXT:    s_load_b64 s[6:7], s[4:5], 0x24
 ; GFX12-GISEL-NEXT:    s_load_b128 s[0:3], s[4:5], 0x34
 ; GFX12-GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
-; GFX12-GISEL-NEXT:    s_mov_b32 s5, 1.0
-; GFX12-GISEL-NEXT:    s_mov_b32 s4, 0
-; GFX12-GISEL-NEXT:    v_mov_b32_e32 v9, 0xb36211c7
-; GFX12-GISEL-NEXT:    s_mov_b32 s8, 0x40400000
-; GFX12-GISEL-NEXT:    v_lshlrev_b32_e32 v2, 2, v0
-; GFX12-GISEL-NEXT:    s_mov_b32 s12, 0x40c00000
 ; GFX12-GISEL-NEXT:    s_mov_b32 s10, 0x40a00000
 ; GFX12-GISEL-NEXT:    s_mov_b32 s9, 4.0
+; GFX12-GISEL-NEXT:    s_mov_b32 s8, 0x40400000
+; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12-GISEL-NEXT:    v_dual_mov_b32 v9, 0xb36211c7 :: v_dual_lshlrev_b32 v2, 2, v0
+; GFX12-GISEL-NEXT:    s_mov_b32 s4, 0
+; GFX12-GISEL-NEXT:    s_mov_b32 s12, 0x40c00000
+; GFX12-GISEL-NEXT:    s_mov_b32 s5, 1.0
 ; GFX12-GISEL-NEXT:    s_mov_b32 s14, 0x41000000
 ; GFX12-GISEL-NEXT:    s_mov_b32 s13, 0x40e00000
 ; GFX12-GISEL-NEXT:    v_mov_b32_e32 v6, s12
@@ -1490,13 +1494,12 @@ define amdgpu_kernel void @image_bvh64_intersect_ray_a16_nsa_reassign(ptr %p_ray
 ; GFX11-SDAG-NEXT:    s_load_b64 s[6:7], s[4:5], 0x24
 ; GFX11-SDAG-NEXT:    s_load_b128 s[0:3], s[4:5], 0x34
 ; GFX11-SDAG-NEXT:    v_dual_mov_b32 v3, 0 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX11-SDAG-NEXT:    v_mov_b32_e32 v2, 0x48004500
-; GFX11-SDAG-NEXT:    v_mov_b32_e32 v4, 1.0
+; GFX11-SDAG-NEXT:    v_dual_mov_b32 v2, 0x48004500 :: v_dual_mov_b32 v5, 2.0
 ; GFX11-SDAG-NEXT:    v_mov_b32_e32 v6, 0xb36211c6
-; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_3) | instid1(VALU_DEP_3)
+; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_3) | instid1(VALU_DEP_3)
 ; GFX11-SDAG-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX11-SDAG-NEXT:    v_bfrev_b32_e32 v7, 4.0
-; GFX11-SDAG-NEXT:    v_mov_b32_e32 v5, 2.0
+; GFX11-SDAG-NEXT:    v_mov_b32_e32 v4, 1.0
 ; GFX11-SDAG-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-SDAG-NEXT:    v_add_co_u32 v0, s4, s6, v0
 ; GFX11-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
@@ -1516,19 +1519,19 @@ define amdgpu_kernel void @image_bvh64_intersect_ray_a16_nsa_reassign(ptr %p_ray
 ; GFX11-GISEL-NEXT:    s_load_b64 s[6:7], s[4:5], 0x24
 ; GFX11-GISEL-NEXT:    s_load_b128 s[0:3], s[4:5], 0x34
 ; GFX11-GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
-; GFX11-GISEL-NEXT:    s_mov_b32 s5, 1.0
-; GFX11-GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX11-GISEL-NEXT:    s_mov_b32 s8, 0x42004600
 ; GFX11-GISEL-NEXT:    s_mov_b32 s9, 0x44004700
-; GFX11-GISEL-NEXT:    v_lshlrev_b32_e32 v2, 2, v0
 ; GFX11-GISEL-NEXT:    s_mov_b32 s10, 0x45004800
-; GFX11-GISEL-NEXT:    v_mov_b32_e32 v6, 0xb36211c6
+; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-GISEL-NEXT:    v_dual_mov_b32 v3, s8 :: v_dual_lshlrev_b32 v2, 2, v0
+; GFX11-GISEL-NEXT:    s_mov_b32 s4, 0
+; GFX11-GISEL-NEXT:    s_mov_b32 s5, 1.0
 ; GFX11-GISEL-NEXT:    v_bfrev_b32_e32 v7, 4.0
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v3, s8 :: v_dual_mov_b32 v4, s9
+; GFX11-GISEL-NEXT:    v_dual_mov_b32 v4, s9 :: v_dual_mov_b32 v5, s10
 ; GFX11-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-NEXT:    v_dual_mov_b32 v5, s10 :: v_dual_mov_b32 v0, s6
-; GFX11-GISEL-NEXT:    v_mov_b32_e32 v1, s7
+; GFX11-GISEL-NEXT:    v_dual_mov_b32 v0, s6 :: v_dual_mov_b32 v1, s7
 ; GFX11-GISEL-NEXT:    s_mov_b32 s6, 2.0
+; GFX11-GISEL-NEXT:    v_mov_b32_e32 v6, 0xb36211c6
 ; GFX11-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX11-GISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
 ; GFX11-GISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo
@@ -1547,13 +1550,12 @@ define amdgpu_kernel void @image_bvh64_intersect_ray_a16_nsa_reassign(ptr %p_ray
 ; GFX12-SDAG-NEXT:    s_load_b64 s[6:7], s[4:5], 0x24
 ; GFX12-SDAG-NEXT:    s_load_b128 s[0:3], s[4:5], 0x34
 ; GFX12-SDAG-NEXT:    v_dual_mov_b32 v3, 0 :: v_dual_and_b32 v0, 0x3ff, v0
-; GFX12-SDAG-NEXT:    v_mov_b32_e32 v2, 0x48004500
-; GFX12-SDAG-NEXT:    v_mov_b32_e32 v4, 1.0
+; GFX12-SDAG-NEXT:    v_dual_mov_b32 v2, 0x48004500 :: v_dual_mov_b32 v5, 2.0
 ; GFX12-SDAG-NEXT:    v_mov_b32_e32 v6, 0xb36211c6
-; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_3) | instid1(VALU_DEP_3)
+; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_3) | instid1(VALU_DEP_3)
 ; GFX12-SDAG-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX12-SDAG-NEXT:    v_bfrev_b32_e32 v7, 4.0
-; GFX12-SDAG-NEXT:    v_mov_b32_e32 v5, 2.0
+; GFX12-SDAG-NEXT:    v_mov_b32_e32 v4, 1.0
 ; GFX12-SDAG-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-SDAG-NEXT:    v_add_co_u32 v0, s4, s6, v0
 ; GFX12-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
@@ -1573,19 +1575,19 @@ define amdgpu_kernel void @image_bvh64_intersect_ray_a16_nsa_reassign(ptr %p_ray
 ; GFX12-GISEL-NEXT:    s_load_b64 s[6:7], s[4:5], 0x24
 ; GFX12-GISEL-NEXT:    s_load_b128 s[0:3], s[4:5], 0x34
 ; GFX12-GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
-; GFX12-GISEL-NEXT:    s_mov_b32 s5, 1.0
-; GFX12-GISEL-NEXT:    s_mov_b32 s4, 0
 ; GFX12-GISEL-NEXT:    s_mov_b32 s8, 0x42004600
 ; GFX12-GISEL-NEXT:    s_mov_b32 s9, 0x44004700
-; GFX12-GISEL-NEXT:    v_lshlrev_b32_e32 v2, 2, v0
 ; GFX12-GISEL-NEXT:    s_mov_b32 s10, 0x45004800
-; GFX12-GISEL-NEXT:    v_mov_b32_e32 v6, 0xb36211c6
+; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12-GISEL-NEXT:    v_dual_mov_b32 v3, s8 :: v_dual_lshlrev_b32 v2, 2, v0
+; GFX12-GISEL-NEXT:    s_mov_b32 s4, 0
+; GFX12-GISEL-NEXT:    s_mov_b32 s5, 1.0
 ; GFX12-GISEL-NEXT:    v_bfrev_b32_e32 v7, 4.0
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v3, s8 :: v_dual_mov_b32 v4, s9
+; GFX12-GISEL-NEXT:    v_dual_mov_b32 v4, s9 :: v_dual_mov_b32 v5, s10
 ; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GISEL-NEXT:    v_dual_mov_b32 v5, s10 :: v_dual_mov_b32 v0, s6
-; GFX12-GISEL-NEXT:    v_mov_b32_e32 v1, s7
+; GFX12-GISEL-NEXT:    v_dual_mov_b32 v0, s6 :: v_dual_mov_b32 v1, s7
 ; GFX12-GISEL-NEXT:    s_mov_b32 s6, 2.0
+; GFX12-GISEL-NEXT:    v_mov_b32_e32 v6, 0xb36211c6
 ; GFX12-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
 ; GFX12-GISEL-NEXT:    v_add_co_u32 v0, vcc_lo, v0, v2
 ; GFX12-GISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, vcc_lo

--- a/llvm/test/CodeGen/AMDGPU/packed-fp32.ll
+++ b/llvm/test/CodeGen/AMDGPU/packed-fp32.ll
@@ -348,14 +348,14 @@ define amdgpu_kernel void @fadd_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; GFX1250-SDAG-LABEL: fadd_v32_vs:
 ; GFX1250-SDAG:       ; %bb.0:
 ; GFX1250-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-SDAG-NEXT:    s_clause 0x2
 ; GFX1250-SDAG-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
-; GFX1250-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
-; GFX1250-SDAG-NEXT:    s_clause 0x1
 ; GFX1250-SDAG-NEXT:    s_load_b512 s[36:51], s[4:5], 0xa4 nv
 ; GFX1250-SDAG-NEXT:    s_load_b512 s[8:23], s[4:5], 0xe4 nv
-; GFX1250-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1250-SDAG-NEXT:    v_lshlrev_b32_e32 v56, 7, v0
+; GFX1250-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX1250-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1250-SDAG-NEXT:    v_dual_lshlrev_b32 v56, 7, v0 :: v_dual_mov_b32 v32, s40
 ; GFX1250-SDAG-NEXT:    s_clause 0x7
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v56, s[0:1] offset:16
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[4:7], v56, s[0:1] offset:48
@@ -365,18 +365,18 @@ define amdgpu_kernel void @fadd_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[20:23], v56, s[0:1] offset:96
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[24:27], v56, s[0:1] offset:64
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[28:31], v56, s[0:1] offset:112
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v32, s40 :: v_dual_mov_b32 v33, s41
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v34, s42 :: v_dual_mov_b32 v35, s43
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v40, s50 :: v_dual_mov_b32 v41, s51
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v38, s48 :: v_dual_mov_b32 v39, s49
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v33, s41 :: v_dual_mov_b32 v34, s42
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v35, s43 :: v_dual_mov_b32 v36, s38
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v39, s49 :: v_dual_mov_b32 v40, s50
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v41, s51 :: v_dual_mov_b32 v42, s44
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v37, s39 :: v_dual_mov_b32 v38, s48
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v55, s23 :: v_dual_mov_b32 v51, s11
 ; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v52, s20 :: v_dual_mov_b32 v53, s21
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v54, s22 :: v_dual_mov_b32 v55, s23
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v50, s10 :: v_dual_mov_b32 v51, s11
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v54, s22 :: v_dual_mov_b32 v49, s15
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v50, s10 :: v_dual_mov_b32 v45, s47
 ; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v46, s12 :: v_dual_mov_b32 v47, s13
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v48, s14 :: v_dual_mov_b32 v49, s15
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v42, s44 :: v_dual_mov_b32 v43, s45
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v44, s46 :: v_dual_mov_b32 v45, s47
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v36, s38 :: v_dual_mov_b32 v37, s39
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v48, s14 :: v_dual_mov_b32 v43, s45
+; GFX1250-SDAG-NEXT:    v_mov_b32_e32 v44, s46
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x7
 ; GFX1250-SDAG-NEXT:    v_pk_add_f32 v[0:1], v[0:1], v[32:33]
 ; GFX1250-SDAG-NEXT:    v_pk_add_f32 v[2:3], v[2:3], v[34:35]
@@ -1712,14 +1712,14 @@ define amdgpu_kernel void @fmul_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; GFX1250-SDAG-LABEL: fmul_v32_vs:
 ; GFX1250-SDAG:       ; %bb.0:
 ; GFX1250-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1250-SDAG-NEXT:    s_clause 0x2
 ; GFX1250-SDAG-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
-; GFX1250-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
-; GFX1250-SDAG-NEXT:    s_clause 0x1
 ; GFX1250-SDAG-NEXT:    s_load_b512 s[36:51], s[4:5], 0xa4 nv
 ; GFX1250-SDAG-NEXT:    s_load_b512 s[8:23], s[4:5], 0xe4 nv
-; GFX1250-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1250-SDAG-NEXT:    v_lshlrev_b32_e32 v56, 7, v0
+; GFX1250-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX1250-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1250-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1250-SDAG-NEXT:    v_dual_lshlrev_b32 v56, 7, v0 :: v_dual_mov_b32 v32, s40
 ; GFX1250-SDAG-NEXT:    s_clause 0x7
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v56, s[0:1] offset:16
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[4:7], v56, s[0:1] offset:48
@@ -1729,18 +1729,18 @@ define amdgpu_kernel void @fmul_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[20:23], v56, s[0:1] offset:96
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[24:27], v56, s[0:1] offset:64
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[28:31], v56, s[0:1] offset:112
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v32, s40 :: v_dual_mov_b32 v33, s41
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v34, s42 :: v_dual_mov_b32 v35, s43
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v40, s50 :: v_dual_mov_b32 v41, s51
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v38, s48 :: v_dual_mov_b32 v39, s49
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v33, s41 :: v_dual_mov_b32 v34, s42
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v35, s43 :: v_dual_mov_b32 v36, s38
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v39, s49 :: v_dual_mov_b32 v40, s50
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v41, s51 :: v_dual_mov_b32 v42, s44
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v37, s39 :: v_dual_mov_b32 v38, s48
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v55, s23 :: v_dual_mov_b32 v51, s11
 ; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v52, s20 :: v_dual_mov_b32 v53, s21
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v54, s22 :: v_dual_mov_b32 v55, s23
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v50, s10 :: v_dual_mov_b32 v51, s11
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v54, s22 :: v_dual_mov_b32 v49, s15
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v50, s10 :: v_dual_mov_b32 v45, s47
 ; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v46, s12 :: v_dual_mov_b32 v47, s13
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v48, s14 :: v_dual_mov_b32 v49, s15
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v42, s44 :: v_dual_mov_b32 v43, s45
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v44, s46 :: v_dual_mov_b32 v45, s47
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v36, s38 :: v_dual_mov_b32 v37, s39
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v48, s14 :: v_dual_mov_b32 v43, s45
+; GFX1250-SDAG-NEXT:    v_mov_b32_e32 v44, s46
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x7
 ; GFX1250-SDAG-NEXT:    v_pk_mul_f32 v[0:1], v[0:1], v[32:33]
 ; GFX1250-SDAG-NEXT:    v_pk_mul_f32 v[2:3], v[2:3], v[34:35]

--- a/llvm/test/CodeGen/AMDGPU/packed-fp64.ll
+++ b/llvm/test/CodeGen/AMDGPU/packed-fp64.ll
@@ -98,21 +98,22 @@ define amdgpu_kernel void @fadd_v4_vs(ptr addrspace(1) %a, <4 x double> %x) {
 ; GFX1251-SDAG-LABEL: fadd_v4_vs:
 ; GFX1251-SDAG:       ; %bb.0:
 ; GFX1251-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1251-SDAG-NEXT:    s_clause 0x1
 ; GFX1251-SDAG-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
-; GFX1251-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX1251-SDAG-NEXT:    s_load_b256 s[8:15], s[4:5], 0x44 nv
-; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1251-SDAG-NEXT:    v_lshlrev_b32_e32 v16, 5, v0
+; GFX1251-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX1251-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1251-SDAG-NEXT:    v_dual_lshlrev_b32 v16, 5, v0 :: v_dual_mov_b32 v8, s12
 ; GFX1251-SDAG-NEXT:    s_clause 0x1
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[0:3], v16, s[0:1]
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[4:7], v16, s[0:1] offset:16
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v10, s14 :: v_dual_mov_b32 v12, s8
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v13, s9 :: v_dual_mov_b32 v14, s10
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v15, s11 :: v_dual_mov_b32 v11, s15
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v8, s12 :: v_dual_mov_b32 v9, s13
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v12, s8 :: v_dual_mov_b32 v13, s9
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v14, s10 :: v_dual_mov_b32 v15, s11
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v9, s13 :: v_dual_mov_b32 v10, s14
+; GFX1251-SDAG-NEXT:    v_mov_b32_e32 v11, s15
 ; GFX1251-SDAG-NEXT:    s_wait_loadcnt 0x1
-; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX1251-SDAG-NEXT:    v_pk_add_f64 v[0:3], v[0:3], v[12:15]
 ; GFX1251-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1251-SDAG-NEXT:    v_pk_add_f64 v[4:7], v[4:7], v[8:11]
@@ -158,15 +159,17 @@ define amdgpu_kernel void @fadd_v32_vs(ptr addrspace(1) %a, <32 x double> %x) {
 ; GFX1251-SDAG-LABEL: fadd_v32_vs:
 ; GFX1251-SDAG:       ; %bb.0:
 ; GFX1251-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1251-SDAG-NEXT:    s_clause 0x4
 ; GFX1251-SDAG-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
-; GFX1251-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
-; GFX1251-SDAG-NEXT:    s_clause 0x3
 ; GFX1251-SDAG-NEXT:    s_load_b512 s[68:83], s[4:5], 0x1a4 nv
 ; GFX1251-SDAG-NEXT:    s_load_b512 s[52:67], s[4:5], 0x1e4 nv
 ; GFX1251-SDAG-NEXT:    s_load_b512 s[8:23], s[4:5], 0x124 nv
 ; GFX1251-SDAG-NEXT:    s_load_b512 s[36:51], s[4:5], 0x164 nv
-; GFX1251-SDAG-NEXT:    v_lshlrev_b32_e32 v44, 8, v0
+; GFX1251-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX1251-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1251-SDAG-NEXT:    v_dual_lshlrev_b32 v44, 8, v0 :: v_dual_mov_b32 v66, s72
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v67, s73 :: v_dual_mov_b32 v68, s74
 ; GFX1251-SDAG-NEXT:    s_clause 0xf
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[40:43], v44, s[0:1] offset:144
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[36:39], v44, s[0:1] offset:128
@@ -184,10 +187,9 @@ define amdgpu_kernel void @fadd_v32_vs(ptr addrspace(1) %a, <32 x double> %x) {
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[54:57], v44, s[0:1] offset:96
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[58:61], v44, s[0:1] offset:32
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[62:65], v44, s[0:1] offset:48
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v66, s72 :: v_dual_mov_b32 v67, s73
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v68, s74 :: v_dual_mov_b32 v69, s75
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v70, s68 :: v_dual_mov_b32 v71, s69
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v72, s70 :: v_dual_mov_b32 v73, s71
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v69, s75 :: v_dual_mov_b32 v70, s68
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v71, s69 :: v_dual_mov_b32 v72, s70
+; GFX1251-SDAG-NEXT:    v_mov_b32_e32 v73, s71
 ; GFX1251-SDAG-NEXT:    s_wait_loadcnt 0xf
 ; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3)
 ; GFX1251-SDAG-NEXT:    v_pk_add_f64 v[40:43], v[40:43], v[66:69]
@@ -980,21 +982,22 @@ define amdgpu_kernel void @fmul_v4_vs(ptr addrspace(1) %a, <4 x double> %x) {
 ; GFX1251-SDAG-LABEL: fmul_v4_vs:
 ; GFX1251-SDAG:       ; %bb.0:
 ; GFX1251-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1251-SDAG-NEXT:    s_clause 0x1
 ; GFX1251-SDAG-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
-; GFX1251-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX1251-SDAG-NEXT:    s_load_b256 s[8:15], s[4:5], 0x44 nv
-; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1251-SDAG-NEXT:    v_lshlrev_b32_e32 v16, 5, v0
+; GFX1251-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX1251-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1251-SDAG-NEXT:    v_dual_lshlrev_b32 v16, 5, v0 :: v_dual_mov_b32 v8, s12
 ; GFX1251-SDAG-NEXT:    s_clause 0x1
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[0:3], v16, s[0:1]
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[4:7], v16, s[0:1] offset:16
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v10, s14 :: v_dual_mov_b32 v12, s8
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v13, s9 :: v_dual_mov_b32 v14, s10
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v15, s11 :: v_dual_mov_b32 v11, s15
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v8, s12 :: v_dual_mov_b32 v9, s13
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v12, s8 :: v_dual_mov_b32 v13, s9
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v14, s10 :: v_dual_mov_b32 v15, s11
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v9, s13 :: v_dual_mov_b32 v10, s14
+; GFX1251-SDAG-NEXT:    v_mov_b32_e32 v11, s15
 ; GFX1251-SDAG-NEXT:    s_wait_loadcnt 0x1
-; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX1251-SDAG-NEXT:    v_pk_mul_f64 v[0:3], v[0:3], v[12:15]
 ; GFX1251-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1251-SDAG-NEXT:    v_pk_mul_f64 v[4:7], v[4:7], v[8:11]
@@ -1040,15 +1043,17 @@ define amdgpu_kernel void @fmul_v32_vs(ptr addrspace(1) %a, <32 x double> %x) {
 ; GFX1251-SDAG-LABEL: fmul_v32_vs:
 ; GFX1251-SDAG:       ; %bb.0:
 ; GFX1251-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1251-SDAG-NEXT:    s_clause 0x4
 ; GFX1251-SDAG-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
-; GFX1251-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
-; GFX1251-SDAG-NEXT:    s_clause 0x3
 ; GFX1251-SDAG-NEXT:    s_load_b512 s[68:83], s[4:5], 0x1a4 nv
 ; GFX1251-SDAG-NEXT:    s_load_b512 s[52:67], s[4:5], 0x1e4 nv
 ; GFX1251-SDAG-NEXT:    s_load_b512 s[8:23], s[4:5], 0x124 nv
 ; GFX1251-SDAG-NEXT:    s_load_b512 s[36:51], s[4:5], 0x164 nv
-; GFX1251-SDAG-NEXT:    v_lshlrev_b32_e32 v44, 8, v0
+; GFX1251-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX1251-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1251-SDAG-NEXT:    v_dual_lshlrev_b32 v44, 8, v0 :: v_dual_mov_b32 v66, s72
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v67, s73 :: v_dual_mov_b32 v68, s74
 ; GFX1251-SDAG-NEXT:    s_clause 0xf
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[40:43], v44, s[0:1] offset:144
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[36:39], v44, s[0:1] offset:128
@@ -1066,10 +1071,9 @@ define amdgpu_kernel void @fmul_v32_vs(ptr addrspace(1) %a, <32 x double> %x) {
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[54:57], v44, s[0:1] offset:96
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[58:61], v44, s[0:1] offset:32
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[62:65], v44, s[0:1] offset:48
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v66, s72 :: v_dual_mov_b32 v67, s73
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v68, s74 :: v_dual_mov_b32 v69, s75
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v70, s68 :: v_dual_mov_b32 v71, s69
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v72, s70 :: v_dual_mov_b32 v73, s71
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v69, s75 :: v_dual_mov_b32 v70, s68
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v71, s69 :: v_dual_mov_b32 v72, s70
+; GFX1251-SDAG-NEXT:    v_mov_b32_e32 v73, s71
 ; GFX1251-SDAG-NEXT:    s_wait_loadcnt 0xf
 ; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3)
 ; GFX1251-SDAG-NEXT:    v_pk_mul_f64 v[40:43], v[40:43], v[66:69]

--- a/llvm/test/CodeGen/AMDGPU/packed-u64.ll
+++ b/llvm/test/CodeGen/AMDGPU/packed-u64.ll
@@ -90,21 +90,22 @@ define amdgpu_kernel void @add_v4_vs(ptr addrspace(1) %a, <4 x i64> %x) {
 ; GFX1251-SDAG-LABEL: add_v4_vs:
 ; GFX1251-SDAG:       ; %bb.0:
 ; GFX1251-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1251-SDAG-NEXT:    s_clause 0x1
 ; GFX1251-SDAG-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
-; GFX1251-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX1251-SDAG-NEXT:    s_load_b256 s[8:15], s[4:5], 0x44 nv
-; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1251-SDAG-NEXT:    v_lshlrev_b32_e32 v16, 5, v0
+; GFX1251-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX1251-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1251-SDAG-NEXT:    v_dual_lshlrev_b32 v16, 5, v0 :: v_dual_mov_b32 v8, s12
 ; GFX1251-SDAG-NEXT:    s_clause 0x1
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[0:3], v16, s[0:1]
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[4:7], v16, s[0:1] offset:16
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v10, s14 :: v_dual_mov_b32 v12, s8
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v13, s9 :: v_dual_mov_b32 v14, s10
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v15, s11 :: v_dual_mov_b32 v11, s15
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v8, s12 :: v_dual_mov_b32 v9, s13
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v12, s8 :: v_dual_mov_b32 v13, s9
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v14, s10 :: v_dual_mov_b32 v15, s11
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v9, s13 :: v_dual_mov_b32 v10, s14
+; GFX1251-SDAG-NEXT:    v_mov_b32_e32 v11, s15
 ; GFX1251-SDAG-NEXT:    s_wait_loadcnt 0x1
-; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX1251-SDAG-NEXT:    v_pk_add_nc_u64 v[0:3], v[0:3], v[12:15]
 ; GFX1251-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1251-SDAG-NEXT:    v_pk_add_nc_u64 v[4:7], v[4:7], v[8:11]
@@ -150,15 +151,17 @@ define amdgpu_kernel void @add_v32_vs(ptr addrspace(1) %a, <32 x i64> %x) {
 ; GFX1251-SDAG-LABEL: add_v32_vs:
 ; GFX1251-SDAG:       ; %bb.0:
 ; GFX1251-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1251-SDAG-NEXT:    s_clause 0x4
 ; GFX1251-SDAG-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
-; GFX1251-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
-; GFX1251-SDAG-NEXT:    s_clause 0x3
 ; GFX1251-SDAG-NEXT:    s_load_b512 s[68:83], s[4:5], 0x1a4 nv
 ; GFX1251-SDAG-NEXT:    s_load_b512 s[52:67], s[4:5], 0x1e4 nv
 ; GFX1251-SDAG-NEXT:    s_load_b512 s[8:23], s[4:5], 0x124 nv
 ; GFX1251-SDAG-NEXT:    s_load_b512 s[36:51], s[4:5], 0x164 nv
-; GFX1251-SDAG-NEXT:    v_lshlrev_b32_e32 v44, 8, v0
+; GFX1251-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX1251-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1251-SDAG-NEXT:    v_dual_lshlrev_b32 v44, 8, v0 :: v_dual_mov_b32 v66, s72
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v67, s73 :: v_dual_mov_b32 v68, s74
 ; GFX1251-SDAG-NEXT:    s_clause 0xf
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[40:43], v44, s[0:1] offset:144
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[36:39], v44, s[0:1] offset:128
@@ -176,10 +179,9 @@ define amdgpu_kernel void @add_v32_vs(ptr addrspace(1) %a, <32 x i64> %x) {
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[54:57], v44, s[0:1] offset:96
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[58:61], v44, s[0:1] offset:80
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[62:65], v44, s[0:1] offset:32
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v66, s72 :: v_dual_mov_b32 v67, s73
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v68, s74 :: v_dual_mov_b32 v69, s75
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v70, s68 :: v_dual_mov_b32 v71, s69
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v72, s70 :: v_dual_mov_b32 v73, s71
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v69, s75 :: v_dual_mov_b32 v70, s68
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v71, s69 :: v_dual_mov_b32 v72, s70
+; GFX1251-SDAG-NEXT:    v_mov_b32_e32 v73, s71
 ; GFX1251-SDAG-NEXT:    s_wait_loadcnt 0xf
 ; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3)
 ; GFX1251-SDAG-NEXT:    v_pk_add_nc_u64 v[40:43], v[40:43], v[66:69]
@@ -725,21 +727,22 @@ define amdgpu_kernel void @sub_v4_vs(ptr addrspace(1) %a, <4 x i64> %x) {
 ; GFX1251-SDAG-LABEL: sub_v4_vs:
 ; GFX1251-SDAG:       ; %bb.0:
 ; GFX1251-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1251-SDAG-NEXT:    s_clause 0x1
 ; GFX1251-SDAG-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
-; GFX1251-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX1251-SDAG-NEXT:    s_load_b256 s[8:15], s[4:5], 0x44 nv
-; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1251-SDAG-NEXT:    v_lshlrev_b32_e32 v16, 5, v0
+; GFX1251-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX1251-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1251-SDAG-NEXT:    v_dual_lshlrev_b32 v16, 5, v0 :: v_dual_mov_b32 v8, s12
 ; GFX1251-SDAG-NEXT:    s_clause 0x1
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[0:3], v16, s[0:1]
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[4:7], v16, s[0:1] offset:16
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v10, s14 :: v_dual_mov_b32 v12, s8
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v13, s9 :: v_dual_mov_b32 v14, s10
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v15, s11 :: v_dual_mov_b32 v11, s15
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v8, s12 :: v_dual_mov_b32 v9, s13
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v12, s8 :: v_dual_mov_b32 v13, s9
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v14, s10 :: v_dual_mov_b32 v15, s11
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v9, s13 :: v_dual_mov_b32 v10, s14
+; GFX1251-SDAG-NEXT:    v_mov_b32_e32 v11, s15
 ; GFX1251-SDAG-NEXT:    s_wait_loadcnt 0x1
-; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_2)
+; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(SKIP_1) | instid1(VALU_DEP_2)
 ; GFX1251-SDAG-NEXT:    v_pk_sub_nc_u64 v[0:3], v[0:3], v[12:15]
 ; GFX1251-SDAG-NEXT:    s_wait_loadcnt 0x0
 ; GFX1251-SDAG-NEXT:    v_pk_sub_nc_u64 v[4:7], v[4:7], v[8:11]
@@ -785,15 +788,17 @@ define amdgpu_kernel void @sub_v32_vs(ptr addrspace(1) %a, <32 x i64> %x) {
 ; GFX1251-SDAG-LABEL: sub_v32_vs:
 ; GFX1251-SDAG:       ; %bb.0:
 ; GFX1251-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GFX1251-SDAG-NEXT:    s_clause 0x4
 ; GFX1251-SDAG-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
-; GFX1251-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
-; GFX1251-SDAG-NEXT:    s_clause 0x3
 ; GFX1251-SDAG-NEXT:    s_load_b512 s[68:83], s[4:5], 0x1a4 nv
 ; GFX1251-SDAG-NEXT:    s_load_b512 s[52:67], s[4:5], 0x1e4 nv
 ; GFX1251-SDAG-NEXT:    s_load_b512 s[8:23], s[4:5], 0x124 nv
 ; GFX1251-SDAG-NEXT:    s_load_b512 s[36:51], s[4:5], 0x164 nv
-; GFX1251-SDAG-NEXT:    v_lshlrev_b32_e32 v44, 8, v0
+; GFX1251-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX1251-SDAG-NEXT:    s_wait_kmcnt 0x0
+; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1251-SDAG-NEXT:    v_dual_lshlrev_b32 v44, 8, v0 :: v_dual_mov_b32 v66, s72
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v67, s73 :: v_dual_mov_b32 v68, s74
 ; GFX1251-SDAG-NEXT:    s_clause 0xf
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[40:43], v44, s[0:1] offset:144
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[36:39], v44, s[0:1] offset:128
@@ -811,10 +816,9 @@ define amdgpu_kernel void @sub_v32_vs(ptr addrspace(1) %a, <32 x i64> %x) {
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[54:57], v44, s[0:1] offset:96
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[58:61], v44, s[0:1] offset:80
 ; GFX1251-SDAG-NEXT:    global_load_b128 v[62:65], v44, s[0:1] offset:32
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v66, s72 :: v_dual_mov_b32 v67, s73
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v68, s74 :: v_dual_mov_b32 v69, s75
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v70, s68 :: v_dual_mov_b32 v71, s69
-; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v72, s70 :: v_dual_mov_b32 v73, s71
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v69, s75 :: v_dual_mov_b32 v70, s68
+; GFX1251-SDAG-NEXT:    v_dual_mov_b32 v71, s69 :: v_dual_mov_b32 v72, s70
+; GFX1251-SDAG-NEXT:    v_mov_b32_e32 v73, s71
 ; GFX1251-SDAG-NEXT:    s_wait_loadcnt 0xf
 ; GFX1251-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_3)
 ; GFX1251-SDAG-NEXT:    v_pk_sub_nc_u64 v[40:43], v[40:43], v[66:69]

--- a/llvm/test/CodeGen/AMDGPU/scratch-simple.ll
+++ b/llvm/test/CodeGen/AMDGPU/scratch-simple.ll
@@ -950,31 +950,30 @@ define amdgpu_ps float @ps_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v21, 0xbf5f2ee3
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v1, 0xbf20e7f4 :: v_dual_lshlrev_b32 v0, 2, v0
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v28, 0x3f3d349e
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v7, 0x3eae29d8
-; GFX11-FLATSCR-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v23, v21
+; GFX11-FLATSCR-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v24, 0xbf523be3 :: v_dual_mov_b32 v23, v21
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v27, 0x3f523be1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[1:4], off offset:320
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v2, v28
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v26, 0x3f5f2ee2
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v19, 0xbefcd89f :: v_dual_mov_b32 v30, v27
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v17, 0xbeae29dc :: v_dual_mov_b32 v16, v24
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v3, v27
 ; GFX11-FLATSCR-NEXT:    s_delay_alu instid0(VALU_DEP_3)
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v25, 0x3f638e37 :: v_dual_mov_b32 v4, v26
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v24, 0xbf523be3
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v17, 0xbeae29dc
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v12, 0xbf20e7f5
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v11, 0xbf3d349e
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v6, 0x3eae29dc
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v7, 0x3eae29d8
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v8, 0x3e319356
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v9, 0x3e31934f
 ; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[25:28], off offset:304
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[1:4], off offset:288
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v12, 0xbf20e7f5
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v13, 0x3efcd89f :: v_dual_mov_b32 v16, v24
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v13, 0x3efcd89f
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v3, 0xbe319356
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v14, 0x3efcd89c
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v18, v17 :: v_dual_and_b32 v33, 0x1fc, v0
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v19, 0xbefcd89f :: v_dual_mov_b32 v30, v27
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v20, 0xbefcd8a3 :: v_dual_mov_b32 v15, v11
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v1, 0xb7043519 :: v_dual_mov_b32 v10, v13
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v2, 0xbe31934f :: v_dual_mov_b32 v31, v11
@@ -989,24 +988,23 @@ define amdgpu_ps float @ps_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[0:3], off offset:256
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[21:24], off offset:208
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[13:16], off offset:192
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v4, 0x3f20e7f4
-; GFX11-FLATSCR-NEXT:    scratch_load_b32 v0, v33, off
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v23, v25 :: v_dual_mov_b32 v4, 0x3f20e7f4
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v29, 0xbf523be1
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v32, 0x3f3d349c
+; GFX11-FLATSCR-NEXT:    scratch_load_b32 v0, v33, off
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v24, v21
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[4:7], off offset:832
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v7, 0x3703c499 :: v_dual_mov_b32 v16, v28
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v7, 0x3703c499
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[29:32], off offset:784
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v31, 0xbf5f2ee2 :: v_dual_mov_b32 v32, v26
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v23, v25
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v25, v26 :: v_dual_mov_b32 v18, v12
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v16, v28 :: v_dual_mov_b32 v25, v26
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v18, v12
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v20, v17 :: v_dual_mov_b32 v21, v3
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v4, v7 :: v_dual_mov_b32 v5, v8
 ; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[29:32], off offset:752
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[13:16], off offset:736
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v5, v8 :: v_dual_mov_b32 v14, v17
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v4, v7
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v13, v19
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v13, v19 :: v_dual_mov_b32 v14, v17
 ; GFX11-FLATSCR-NEXT:    s_clause 0x4
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[7:10], off offset:816
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[18:21], off offset:800
@@ -1954,31 +1952,30 @@ define amdgpu_vs float @vs_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v21, 0xbf5f2ee3
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v1, 0xbf20e7f4 :: v_dual_lshlrev_b32 v0, 2, v0
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v28, 0x3f3d349e
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v7, 0x3eae29d8
-; GFX11-FLATSCR-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v23, v21
+; GFX11-FLATSCR-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v24, 0xbf523be3 :: v_dual_mov_b32 v23, v21
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v27, 0x3f523be1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[1:4], off offset:320
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v2, v28
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v26, 0x3f5f2ee2
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v19, 0xbefcd89f :: v_dual_mov_b32 v30, v27
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v17, 0xbeae29dc :: v_dual_mov_b32 v16, v24
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v3, v27
 ; GFX11-FLATSCR-NEXT:    s_delay_alu instid0(VALU_DEP_3)
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v25, 0x3f638e37 :: v_dual_mov_b32 v4, v26
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v24, 0xbf523be3
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v17, 0xbeae29dc
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v12, 0xbf20e7f5
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v11, 0xbf3d349e
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v6, 0x3eae29dc
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v7, 0x3eae29d8
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v8, 0x3e319356
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v9, 0x3e31934f
 ; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[25:28], off offset:304
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[1:4], off offset:288
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v12, 0xbf20e7f5
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v13, 0x3efcd89f :: v_dual_mov_b32 v16, v24
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v13, 0x3efcd89f
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v3, 0xbe319356
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v14, 0x3efcd89c
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v18, v17 :: v_dual_and_b32 v33, 0x1fc, v0
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v19, 0xbefcd89f :: v_dual_mov_b32 v30, v27
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v20, 0xbefcd8a3 :: v_dual_mov_b32 v15, v11
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v1, 0xb7043519 :: v_dual_mov_b32 v10, v13
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v2, 0xbe31934f :: v_dual_mov_b32 v31, v11
@@ -1993,24 +1990,23 @@ define amdgpu_vs float @vs_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[0:3], off offset:256
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[21:24], off offset:208
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[13:16], off offset:192
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v4, 0x3f20e7f4
-; GFX11-FLATSCR-NEXT:    scratch_load_b32 v0, v33, off
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v23, v25 :: v_dual_mov_b32 v4, 0x3f20e7f4
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v29, 0xbf523be1
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v32, 0x3f3d349c
+; GFX11-FLATSCR-NEXT:    scratch_load_b32 v0, v33, off
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v24, v21
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[4:7], off offset:832
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v7, 0x3703c499 :: v_dual_mov_b32 v16, v28
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v7, 0x3703c499
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[29:32], off offset:784
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v31, 0xbf5f2ee2 :: v_dual_mov_b32 v32, v26
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v23, v25
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v25, v26 :: v_dual_mov_b32 v18, v12
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v16, v28 :: v_dual_mov_b32 v25, v26
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v18, v12
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v20, v17 :: v_dual_mov_b32 v21, v3
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v4, v7 :: v_dual_mov_b32 v5, v8
 ; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[29:32], off offset:752
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[13:16], off offset:736
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v5, v8 :: v_dual_mov_b32 v14, v17
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v4, v7
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v13, v19
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v13, v19 :: v_dual_mov_b32 v14, v17
 ; GFX11-FLATSCR-NEXT:    s_clause 0x4
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[7:10], off offset:816
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[18:21], off offset:800
@@ -2958,31 +2954,30 @@ define amdgpu_cs float @cs_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v21, 0xbf5f2ee3
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v1, 0xbf20e7f4 :: v_dual_lshlrev_b32 v0, 2, v0
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v28, 0x3f3d349e
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v7, 0x3eae29d8
-; GFX11-FLATSCR-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v23, v21
+; GFX11-FLATSCR-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v24, 0xbf523be3 :: v_dual_mov_b32 v23, v21
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v27, 0x3f523be1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[1:4], off offset:320
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v2, v28
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v26, 0x3f5f2ee2
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v19, 0xbefcd89f :: v_dual_mov_b32 v30, v27
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v17, 0xbeae29dc :: v_dual_mov_b32 v16, v24
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v3, v27
 ; GFX11-FLATSCR-NEXT:    s_delay_alu instid0(VALU_DEP_3)
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v25, 0x3f638e37 :: v_dual_mov_b32 v4, v26
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v24, 0xbf523be3
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v17, 0xbeae29dc
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v12, 0xbf20e7f5
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v11, 0xbf3d349e
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v6, 0x3eae29dc
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v7, 0x3eae29d8
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v8, 0x3e319356
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v9, 0x3e31934f
 ; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[25:28], off offset:304
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[1:4], off offset:288
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v12, 0xbf20e7f5
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v13, 0x3efcd89f :: v_dual_mov_b32 v16, v24
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v13, 0x3efcd89f
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v3, 0xbe319356
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v14, 0x3efcd89c
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v18, v17 :: v_dual_and_b32 v33, 0x1fc, v0
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v19, 0xbefcd89f :: v_dual_mov_b32 v30, v27
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v20, 0xbefcd8a3 :: v_dual_mov_b32 v15, v11
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v1, 0xb7043519 :: v_dual_mov_b32 v10, v13
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v2, 0xbe31934f :: v_dual_mov_b32 v31, v11
@@ -2997,24 +2992,23 @@ define amdgpu_cs float @cs_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[0:3], off offset:256
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[21:24], off offset:208
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[13:16], off offset:192
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v4, 0x3f20e7f4
-; GFX11-FLATSCR-NEXT:    scratch_load_b32 v0, v33, off
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v23, v25 :: v_dual_mov_b32 v4, 0x3f20e7f4
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v29, 0xbf523be1
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v32, 0x3f3d349c
+; GFX11-FLATSCR-NEXT:    scratch_load_b32 v0, v33, off
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v24, v21
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[4:7], off offset:832
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v7, 0x3703c499 :: v_dual_mov_b32 v16, v28
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v7, 0x3703c499
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[29:32], off offset:784
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v31, 0xbf5f2ee2 :: v_dual_mov_b32 v32, v26
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v23, v25
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v25, v26 :: v_dual_mov_b32 v18, v12
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v16, v28 :: v_dual_mov_b32 v25, v26
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v18, v12
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v20, v17 :: v_dual_mov_b32 v21, v3
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v4, v7 :: v_dual_mov_b32 v5, v8
 ; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[29:32], off offset:752
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[13:16], off offset:736
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v5, v8 :: v_dual_mov_b32 v14, v17
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v4, v7
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v13, v19
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v13, v19 :: v_dual_mov_b32 v14, v17
 ; GFX11-FLATSCR-NEXT:    s_clause 0x4
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[7:10], off offset:816
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[18:21], off offset:800
@@ -3959,31 +3953,30 @@ define amdgpu_hs float @hs_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v21, 0xbf5f2ee3
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v1, 0xbf20e7f4 :: v_dual_lshlrev_b32 v0, 2, v0
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v28, 0x3f3d349e
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v7, 0x3eae29d8
-; GFX11-FLATSCR-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v23, v21
+; GFX11-FLATSCR-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v24, 0xbf523be3 :: v_dual_mov_b32 v23, v21
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v27, 0x3f523be1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[1:4], off offset:320
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v2, v28
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v26, 0x3f5f2ee2
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v19, 0xbefcd89f :: v_dual_mov_b32 v30, v27
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v17, 0xbeae29dc :: v_dual_mov_b32 v16, v24
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v3, v27
 ; GFX11-FLATSCR-NEXT:    s_delay_alu instid0(VALU_DEP_3)
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v25, 0x3f638e37 :: v_dual_mov_b32 v4, v26
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v24, 0xbf523be3
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v17, 0xbeae29dc
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v12, 0xbf20e7f5
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v11, 0xbf3d349e
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v6, 0x3eae29dc
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v7, 0x3eae29d8
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v8, 0x3e319356
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v9, 0x3e31934f
 ; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[25:28], off offset:304
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[1:4], off offset:288
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v12, 0xbf20e7f5
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v13, 0x3efcd89f :: v_dual_mov_b32 v16, v24
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v13, 0x3efcd89f
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v3, 0xbe319356
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v14, 0x3efcd89c
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v18, v17 :: v_dual_and_b32 v33, 0x1fc, v0
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v19, 0xbefcd89f :: v_dual_mov_b32 v30, v27
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v20, 0xbefcd8a3 :: v_dual_mov_b32 v15, v11
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v1, 0xb7043519 :: v_dual_mov_b32 v10, v13
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v2, 0xbe31934f :: v_dual_mov_b32 v31, v11
@@ -3998,24 +3991,23 @@ define amdgpu_hs float @hs_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[0:3], off offset:256
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[21:24], off offset:208
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[13:16], off offset:192
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v4, 0x3f20e7f4
-; GFX11-FLATSCR-NEXT:    scratch_load_b32 v0, v33, off
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v23, v25 :: v_dual_mov_b32 v4, 0x3f20e7f4
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v29, 0xbf523be1
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v32, 0x3f3d349c
+; GFX11-FLATSCR-NEXT:    scratch_load_b32 v0, v33, off
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v24, v21
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[4:7], off offset:832
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v7, 0x3703c499 :: v_dual_mov_b32 v16, v28
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v7, 0x3703c499
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[29:32], off offset:784
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v31, 0xbf5f2ee2 :: v_dual_mov_b32 v32, v26
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v23, v25
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v25, v26 :: v_dual_mov_b32 v18, v12
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v16, v28 :: v_dual_mov_b32 v25, v26
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v18, v12
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v20, v17 :: v_dual_mov_b32 v21, v3
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v4, v7 :: v_dual_mov_b32 v5, v8
 ; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[29:32], off offset:752
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[13:16], off offset:736
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v5, v8 :: v_dual_mov_b32 v14, v17
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v4, v7
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v13, v19
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v13, v19 :: v_dual_mov_b32 v14, v17
 ; GFX11-FLATSCR-NEXT:    s_clause 0x4
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[7:10], off offset:816
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[18:21], off offset:800
@@ -4960,31 +4952,30 @@ define amdgpu_gs float @gs_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v21, 0xbf5f2ee3
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v1, 0xbf20e7f4 :: v_dual_lshlrev_b32 v0, 2, v0
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v28, 0x3f3d349e
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v7, 0x3eae29d8
-; GFX11-FLATSCR-NEXT:    s_delay_alu instid0(VALU_DEP_4)
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v23, v21
+; GFX11-FLATSCR-NEXT:    s_delay_alu instid0(VALU_DEP_3)
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v24, 0xbf523be3 :: v_dual_mov_b32 v23, v21
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v27, 0x3f523be1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[1:4], off offset:320
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v2, v28
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v26, 0x3f5f2ee2
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v19, 0xbefcd89f :: v_dual_mov_b32 v30, v27
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v17, 0xbeae29dc :: v_dual_mov_b32 v16, v24
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v3, v27
 ; GFX11-FLATSCR-NEXT:    s_delay_alu instid0(VALU_DEP_3)
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v25, 0x3f638e37 :: v_dual_mov_b32 v4, v26
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v24, 0xbf523be3
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v17, 0xbeae29dc
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v12, 0xbf20e7f5
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v11, 0xbf3d349e
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v6, 0x3eae29dc
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v7, 0x3eae29d8
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v8, 0x3e319356
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v9, 0x3e31934f
 ; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[25:28], off offset:304
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[1:4], off offset:288
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v12, 0xbf20e7f5
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v13, 0x3efcd89f :: v_dual_mov_b32 v16, v24
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v13, 0x3efcd89f
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v3, 0xbe319356
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v14, 0x3efcd89c
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v18, v17 :: v_dual_and_b32 v33, 0x1fc, v0
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v19, 0xbefcd89f :: v_dual_mov_b32 v30, v27
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v20, 0xbefcd8a3 :: v_dual_mov_b32 v15, v11
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v1, 0xb7043519 :: v_dual_mov_b32 v10, v13
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v2, 0xbe31934f :: v_dual_mov_b32 v31, v11
@@ -4999,24 +4990,23 @@ define amdgpu_gs float @gs_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[0:3], off offset:256
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[21:24], off offset:208
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[13:16], off offset:192
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v4, 0x3f20e7f4
-; GFX11-FLATSCR-NEXT:    scratch_load_b32 v0, v33, off
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v23, v25 :: v_dual_mov_b32 v4, 0x3f20e7f4
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v29, 0xbf523be1
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v32, 0x3f3d349c
+; GFX11-FLATSCR-NEXT:    scratch_load_b32 v0, v33, off
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v24, v21
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[4:7], off offset:832
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v7, 0x3703c499 :: v_dual_mov_b32 v16, v28
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v7, 0x3703c499
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[29:32], off offset:784
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v31, 0xbf5f2ee2 :: v_dual_mov_b32 v32, v26
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v23, v25
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v25, v26 :: v_dual_mov_b32 v18, v12
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v16, v28 :: v_dual_mov_b32 v25, v26
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v18, v12
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v20, v17 :: v_dual_mov_b32 v21, v3
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v4, v7 :: v_dual_mov_b32 v5, v8
 ; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[29:32], off offset:752
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[13:16], off offset:736
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v5, v8 :: v_dual_mov_b32 v14, v17
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v4, v7
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v13, v19
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v13, v19 :: v_dual_mov_b32 v14, v17
 ; GFX11-FLATSCR-NEXT:    s_clause 0x4
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[7:10], off offset:816
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[18:21], off offset:800
@@ -5971,19 +5961,19 @@ define amdgpu_hs <{i32, i32, i32, float}> @hs_ir_uses_scratch_offset(i32 inreg, 
 ;
 ; GFX11-FLATSCR-LABEL: hs_ir_uses_scratch_offset:
 ; GFX11-FLATSCR:       ; %bb.0:
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v21, 0xbf5f2ee3
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v1, 0xbf20e7f4 :: v_dual_lshlrev_b32 v0, 2, v0
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v28, 0x3f3d349e
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v27, 0x3f523be1
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v21, 0xbf5f2ee3
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v26, 0x3f5f2ee2
+; GFX11-FLATSCR-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v26, 0x3f5f2ee2 :: v_dual_mov_b32 v23, v21
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v25, 0x3f638e37
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v24, 0xbf523be3
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[1:4], off offset:320
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v2, v28 :: v_dual_mov_b32 v19, 0xbefcd89f
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v30, v27
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v24, 0xbf523be3 :: v_dual_mov_b32 v23, v21
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v25, 0x3f638e37 :: v_dual_mov_b32 v4, v26
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v3, v27
-; GFX11-FLATSCR-NEXT:    s_delay_alu instid0(VALU_DEP_3)
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v17, 0xbeae29dc :: v_dual_mov_b32 v16, v24
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v2, v28 :: v_dual_mov_b32 v3, v27
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v4, v26 :: v_dual_mov_b32 v17, 0xbeae29dc
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v16, v24
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v12, 0xbf20e7f5
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v11, 0xbf3d349e
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v6, 0x3eae29dc
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v7, 0x3eae29d8
@@ -5992,11 +5982,11 @@ define amdgpu_hs <{i32, i32, i32, float}> @hs_ir_uses_scratch_offset(i32 inreg, 
 ; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[25:28], off offset:304
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[1:4], off offset:288
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v12, 0xbf20e7f5
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v13, 0x3efcd89f
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v3, 0xbe319356
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v14, 0x3efcd89c
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v18, v17 :: v_dual_and_b32 v33, 0x1fc, v0
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v19, 0xbefcd89f :: v_dual_mov_b32 v30, v27
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v20, 0xbefcd8a3 :: v_dual_mov_b32 v15, v11
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v1, 0xb7043519 :: v_dual_mov_b32 v10, v13
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v2, 0xbe31934f :: v_dual_mov_b32 v31, v11
@@ -6011,24 +6001,23 @@ define amdgpu_hs <{i32, i32, i32, float}> @hs_ir_uses_scratch_offset(i32 inreg, 
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[0:3], off offset:256
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[21:24], off offset:208
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[13:16], off offset:192
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v4, 0x3f20e7f4
-; GFX11-FLATSCR-NEXT:    scratch_load_b32 v0, v33, off
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v23, v25 :: v_dual_mov_b32 v4, 0x3f20e7f4
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v29, 0xbf523be1
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v32, 0x3f3d349c
+; GFX11-FLATSCR-NEXT:    scratch_load_b32 v0, v33, off
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v24, v21
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[4:7], off offset:832
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v7, 0x3703c499 :: v_dual_mov_b32 v16, v28
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v7, 0x3703c499
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[29:32], off offset:784
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v31, 0xbf5f2ee2 :: v_dual_mov_b32 v32, v26
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v23, v25
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v25, v26 :: v_dual_mov_b32 v18, v12
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v16, v28 :: v_dual_mov_b32 v25, v26
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v18, v12
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v20, v17 :: v_dual_mov_b32 v21, v3
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v4, v7 :: v_dual_mov_b32 v5, v8
 ; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[29:32], off offset:752
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[13:16], off offset:736
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v5, v8 :: v_dual_mov_b32 v14, v17
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v4, v7
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v13, v19
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v13, v19 :: v_dual_mov_b32 v14, v17
 ; GFX11-FLATSCR-NEXT:    s_clause 0x4
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[7:10], off offset:816
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[18:21], off offset:800
@@ -6982,19 +6971,19 @@ define amdgpu_gs <{i32, i32, i32, float}> @gs_ir_uses_scratch_offset(i32 inreg, 
 ;
 ; GFX11-FLATSCR-LABEL: gs_ir_uses_scratch_offset:
 ; GFX11-FLATSCR:       ; %bb.0:
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v21, 0xbf5f2ee3
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v1, 0xbf20e7f4 :: v_dual_lshlrev_b32 v0, 2, v0
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v28, 0x3f3d349e
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v27, 0x3f523be1
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v21, 0xbf5f2ee3
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v26, 0x3f5f2ee2
+; GFX11-FLATSCR-NEXT:    s_delay_alu instid0(VALU_DEP_4)
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v26, 0x3f5f2ee2 :: v_dual_mov_b32 v23, v21
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v25, 0x3f638e37
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v24, 0xbf523be3
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[1:4], off offset:320
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v2, v28 :: v_dual_mov_b32 v19, 0xbefcd89f
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v30, v27
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v24, 0xbf523be3 :: v_dual_mov_b32 v23, v21
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v25, 0x3f638e37 :: v_dual_mov_b32 v4, v26
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v3, v27
-; GFX11-FLATSCR-NEXT:    s_delay_alu instid0(VALU_DEP_3)
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v17, 0xbeae29dc :: v_dual_mov_b32 v16, v24
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v2, v28 :: v_dual_mov_b32 v3, v27
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v4, v26 :: v_dual_mov_b32 v17, 0xbeae29dc
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v16, v24
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v12, 0xbf20e7f5
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v11, 0xbf3d349e
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v6, 0x3eae29dc
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v7, 0x3eae29d8
@@ -7003,11 +6992,11 @@ define amdgpu_gs <{i32, i32, i32, float}> @gs_ir_uses_scratch_offset(i32 inreg, 
 ; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[25:28], off offset:304
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[1:4], off offset:288
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v12, 0xbf20e7f5
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v13, 0x3efcd89f
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v3, 0xbe319356
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v14, 0x3efcd89c
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v18, v17 :: v_dual_and_b32 v33, 0x1fc, v0
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v19, 0xbefcd89f :: v_dual_mov_b32 v30, v27
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v20, 0xbefcd8a3 :: v_dual_mov_b32 v15, v11
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v1, 0xb7043519 :: v_dual_mov_b32 v10, v13
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v2, 0xbe31934f :: v_dual_mov_b32 v31, v11
@@ -7022,24 +7011,23 @@ define amdgpu_gs <{i32, i32, i32, float}> @gs_ir_uses_scratch_offset(i32 inreg, 
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[0:3], off offset:256
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[21:24], off offset:208
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[13:16], off offset:192
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v4, 0x3f20e7f4
-; GFX11-FLATSCR-NEXT:    scratch_load_b32 v0, v33, off
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v23, v25 :: v_dual_mov_b32 v4, 0x3f20e7f4
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v29, 0xbf523be1
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v32, 0x3f3d349c
+; GFX11-FLATSCR-NEXT:    scratch_load_b32 v0, v33, off
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v24, v21
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[4:7], off offset:832
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v7, 0x3703c499 :: v_dual_mov_b32 v16, v28
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v7, 0x3703c499
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[29:32], off offset:784
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v31, 0xbf5f2ee2 :: v_dual_mov_b32 v32, v26
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v23, v25
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v25, v26 :: v_dual_mov_b32 v18, v12
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v16, v28 :: v_dual_mov_b32 v25, v26
+; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v18, v12
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v20, v17 :: v_dual_mov_b32 v21, v3
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v4, v7 :: v_dual_mov_b32 v5, v8
 ; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[29:32], off offset:752
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[13:16], off offset:736
-; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v5, v8 :: v_dual_mov_b32 v14, v17
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v4, v7
-; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v13, v19
+; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v13, v19 :: v_dual_mov_b32 v14, v17
 ; GFX11-FLATSCR-NEXT:    s_clause 0x4
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[7:10], off offset:816
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[18:21], off offset:800

--- a/llvm/test/CodeGen/AMDGPU/store-weird-sizes.ll
+++ b/llvm/test/CodeGen/AMDGPU/store-weird-sizes.ll
@@ -142,15 +142,16 @@ define amdgpu_kernel void @local_store_i55(ptr addrspace(3) %ptr, i55 %arg) #0 {
 ;
 ; GFX11-TRUE16-LABEL: local_store_i55:
 ; GFX11-TRUE16:       ; %bb.0:
-; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v0, 0
-; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 0
 ; GFX11-TRUE16-NEXT:    s_clause 0x1
 ; GFX11-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x8
 ; GFX11-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x0
-; GFX11-TRUE16-NEXT:    global_load_d16_hi_u8 v1, v0, s[4:5] offset:14
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v0, 0
+; GFX11-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 0
 ; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v3, s0
+; GFX11-TRUE16-NEXT:    global_load_d16_hi_u8 v1, v0, s[4:5] offset:14
 ; GFX11-TRUE16-NEXT:    s_and_b32 s3, s1, 0xffff
-; GFX11-TRUE16-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s0
+; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v2, s1
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-TRUE16-NEXT:    v_or_b32_e32 v0, s3, v1
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
@@ -162,18 +163,19 @@ define amdgpu_kernel void @local_store_i55(ptr addrspace(3) %ptr, i55 %arg) #0 {
 ;
 ; GFX11-FAKE16-LABEL: local_store_i55:
 ; GFX11-FAKE16:       ; %bb.0:
-; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX11-FAKE16-NEXT:    s_clause 0x1
 ; GFX11-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x8
 ; GFX11-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x0
-; GFX11-FAKE16-NEXT:    global_load_d16_hi_u8 v0, v0, s[4:5] offset:14
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-FAKE16-NEXT:    s_and_b32 s3, s1, 0xffff
+; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v1, s2
+; GFX11-FAKE16-NEXT:    global_load_d16_hi_u8 v0, v0, s[4:5] offset:14
 ; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s0
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-FAKE16-NEXT:    v_or_b32_e32 v0, s3, v0
 ; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-FAKE16-NEXT:    v_dual_mov_b32 v1, s2 :: v_dual_and_b32 v0, 0x7fffff, v0
+; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0x7fffff, v0
 ; GFX11-FAKE16-NEXT:    ds_store_b8_d16_hi v1, v0 offset:6
 ; GFX11-FAKE16-NEXT:    ds_store_b16 v1, v2 offset:4
 ; GFX11-FAKE16-NEXT:    ds_store_b32 v1, v3


### PR DESCRIPTION
#201930 causes significant compilation time regression when building ROCm mathlibs. 

This patch avoids the need to query `DAG->IsReachable` on every pair of possibly hazardous loads by instead collecting *all* transitive load dependencies (or dependents), even those reachable through other loads. This allows only checking that the transitive load dependents of one pair candidate overlap with the transitive load dependencies of the other pair candidate.

Because `DAG->IsReachable` checks reach through all edges (not just `SDep::Data` edges), this patch also modifies `collectLoads` to do the same.