### PR TITLE
[libc++][byte] Applied `[[nodiscard]]` to `std::byte`

### DIFF
--- a/libcxx/include/__cstddef/byte.h
+++ b/libcxx/include/__cstddef/byte.h
@@ -23,7 +23,7 @@ _LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
 
 enum class byte : unsigned char {};
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr byte operator|(byte __lhs, byte __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr byte operator|(byte __lhs, byte __rhs) noexcept {
   return static_cast<byte>(
       static_cast<unsigned char>(static_cast<unsigned int>(__lhs) | static_cast<unsigned int>(__rhs)));
 }
@@ -32,7 +32,7 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr byte& operator|=(byte& __lhs, byte __rhs)
   return __lhs = __lhs | __rhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr byte operator&(byte __lhs, byte __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr byte operator&(byte __lhs, byte __rhs) noexcept {
   return static_cast<byte>(
       static_cast<unsigned char>(static_cast<unsigned int>(__lhs) & static_cast<unsigned int>(__rhs)));
 }
@@ -41,7 +41,7 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr byte& operator&=(byte& __lhs, byte __rhs)
   return __lhs = __lhs & __rhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr byte operator^(byte __lhs, byte __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr byte operator^(byte __lhs, byte __rhs) noexcept {
   return static_cast<byte>(
       static_cast<unsigned char>(static_cast<unsigned int>(__lhs) ^ static_cast<unsigned int>(__rhs)));
 }
@@ -50,7 +50,7 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr byte& operator^=(byte& __lhs, byte __rhs)
   return __lhs = __lhs ^ __rhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr byte operator~(byte __b) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr byte operator~(byte __b) noexcept {
   return static_cast<byte>(static_cast<unsigned char>(~static_cast<unsigned int>(__b)));
 }
 
@@ -60,7 +60,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr byte& operator<<=(byte& __lhs, _Integer __shift)
 }
 
 template <class _Integer, __enable_if_t<is_integral<_Integer>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI constexpr byte operator<<(byte __lhs, _Integer __shift) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr byte operator<<(byte __lhs, _Integer __shift) noexcept {
   return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(__lhs) << __shift));
 }
 
@@ -70,7 +70,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr byte& operator>>=(byte& __lhs, _Integer __shift)
 }
 
 template <class _Integer, __enable_if_t<is_integral<_Integer>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI constexpr byte operator>>(byte __lhs, _Integer __shift) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr byte operator>>(byte __lhs, _Integer __shift) noexcept {
   return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(__lhs) >> __shift));
 }
 

--- a/libcxx/test/libcxx/language.support/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/language.support/nodiscard.verify.cpp
@@ -14,6 +14,7 @@
 
 #include <compare>
 #include <coroutine>
+#include <cstddef>
 #include <exception>
 #include <initializer_list>
 #include <new>
@@ -83,6 +84,29 @@ void test() {
       // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
       std::noop_coroutine();
     }
+  }
+#endif
+
+#if TEST_STD_VER >= 17
+  { // <cstddef>
+    std::byte b{0};
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    b | b;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    b & b;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    b ^ b;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ~b;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    b << 1;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    b >> 1;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::to_integer<int>(b);
   }
 #endif
 


### PR DESCRIPTION
https://libcxx.llvm.org/CodingGuidelines.html#apply-nodiscard-where-relevant

Towards: #172124