### PR TITLE
[dsymutil] Use more portable way to compare timestamp (NFC)

### DIFF
--- a/llvm/test/tools/dsymutil/X86/bundle-mtime.test
+++ b/llvm/test/tools/dsymutil/X86/bundle-mtime.test
@@ -20,5 +20,5 @@ RUN: dsymutil -oso-prepend-path=%p/.. %t.dir/basic
 ## It prints the bundle path iff its mtime is newer than the marker.
 ## Without the mtime bump, the directory keeps its 1970 stamp and
 ## nothing is printed.
-RUN: %python -c "import os, sys; sys.exit(0 if os.path.getmtime('%t.dir/basic.dSYM') > os.path.getmtime('%t.dir/marker') else 1)" && echo "basic.dSYM" | FileCheck %s
+RUN: %python -c "import sys ; from pathlib import Path ; sys.exit(0 if Path(r'%t.dir/basic.dSYM').stat().st_mtime > Path(r'%t.dir/marker').stat().st_mtime else 1)" && echo "basic.dSYM" | FileCheck %s
 CHECK: basic.dSYM

--- a/llvm/test/tools/dsymutil/X86/bundle-mtime.test
+++ b/llvm/test/tools/dsymutil/X86/bundle-mtime.test
@@ -17,8 +17,8 @@ RUN: env TZ=GMT touch -t 200001010000 %t.dir/marker
 
 RUN: dsymutil -oso-prepend-path=%p/.. %t.dir/basic
 
-## `find -maxdepth 0 -newer` prints the bundle path iff its mtime is newer
-## than the marker. Without the mtime bump, the directory keeps its 1970
-## stamp and find prints nothing.
-RUN: find %t.dir/basic.dSYM -maxdepth 0 -newer %t.dir/marker | FileCheck %s
+## It prints the bundle path iff its mtime is newer than the marker.
+## Without the mtime bump, the directory keeps its 1970 stamp and
+## nothing is printed.
+RUN: %python -c "import os, sys; sys.exit(0 if os.path.getmtime('%t.dir/basic.dSYM') > os.path.getmtime('%t.dir/marker') else 1)" && echo "basic.dSYM" | FileCheck %s
 CHECK: basic.dSYM


### PR DESCRIPTION
`find` on AIX does not support `-maxpath` option. This patch is
to use python to compare the `mtime` of the file/directory.

Changes in https://github.com/llvm/llvm-project/pull/199257 cause failure on AIX - https://lab.llvm.org/staging/#/builders/231/builds/1502