### PR TITLE
[Offload] Flush pending RPC ports when tearing down a device

### DIFF
--- a/offload/plugins-nextgen/common/src/RPC.cpp
+++ b/offload/plugins-nextgen/common/src/RPC.cpp
@@ -114,6 +114,17 @@ runServer(plugin::GenericDeviceTy &Device, void *Buffer,
   return Status;
 }
 
+static void flushServer(
+    plugin::GenericDeviceTy &Device, void *Buffer,
+    llvm::SmallSetVector<RPCServerTy::RPCServerCallbackTy, 0> Callbacks) {
+  bool Pending = true;
+  while (Pending) {
+    Pending = false;
+    if (runServer(Device, Buffer, Callbacks, Pending) != rpc::RPC_SUCCESS)
+      FAILURE_MESSAGE("Unhandled or invalid RPC opcode!\n");
+  }
+}
+
 void RPCServerTy::ServerThread::startThread() {
   if (!Running.fetch_or(true, std::memory_order_acquire))
     Worker = std::thread([this]() { run(); });
@@ -240,6 +251,9 @@ Error RPCServerTy::initDevice(plugin::GenericDeviceTy &Device,
 
 Error RPCServerTy::deinitDevice(plugin::GenericDeviceTy &Device) {
   std::lock_guard<decltype(BufferMutex)> Lock(BufferMutex);
+  // Flush any requests the device may have pushed before being deinitialized.
+  if (void *Buffer = Buffers[Device.getDeviceId()])
+    flushServer(Device, Buffer, Callbacks);
   if (auto Err = Device.free(Buffers[Device.getDeviceId()], TARGET_ALLOC_HOST))
     return Err;
   Buffers[Device.getDeviceId()] = nullptr;


### PR DESCRIPTION
The RPC client can push asynchronous work and then quit. These can be
lost if the kernel returns and is torn down before the RPC server gets
to run to check it. To handle this, we just manually flush the interface
once when we tear the device down. The interface is lock-free so this
should be safe even if the other thread is working through it as well.
