### PR TITLE
[clang][ssaf][NFC] Make SSAFOptions available in Builders and Extractors

### DIFF
--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryBuilder.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryBuilder.h
@@ -18,11 +18,13 @@
 namespace clang::ssaf {
 
 class EntityName;
+class SSAFOptions;
 class TUSummary;
 
 class TUSummaryBuilder {
 public:
-  explicit TUSummaryBuilder(TUSummary &Summary) : Summary(Summary) {}
+  TUSummaryBuilder(TUSummary &Summary, const SSAFOptions &Options)
+      : Summary(Summary), Options(Options) {}
 
   EntityId addEntity(const EntityName &EN, EntityLinkageType Linkage);
 
@@ -35,8 +37,12 @@ public:
   std::pair<EntitySummary *, bool>
   addSummary(EntityId Entity, std::unique_ptr<ConcreteEntitySummary> &&Data);
 
+  /// \returns the \c SSAFOptions of this builder.
+  const SSAFOptions &getOptions() const { return Options; }
+
 private:
   TUSummary &Summary;
+  const SSAFOptions &Options;
 
   std::pair<EntitySummary *, bool>
   addSummaryImpl(EntityId Entity, std::unique_ptr<EntitySummary> &&Data);

--- a/clang/include/clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractor.h
+++ b/clang/include/clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractor.h
@@ -15,6 +15,7 @@
 #include <optional>
 
 namespace clang::ssaf {
+class SSAFOptions;
 class TUSummaryBuilder;
 
 class TUSummaryExtractor : public ASTConsumer {
@@ -31,6 +32,9 @@ public:
   /// and sets its linkage atomically.
   /// \returns the EntityId, or std::nullopt if EntityName creation fails.
   std::optional<EntityId> addEntityForReturn(const FunctionDecl *FD);
+
+  /// \returns the \c SSAFOptions of the builder.
+  const SSAFOptions &getOptions() const;
 
 protected:
   TUSummaryBuilder &SummaryBuilder;

--- a/clang/lib/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlowExtractor.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlowExtractor.cpp
@@ -311,8 +311,7 @@ PointerFlowMatcher::matchesInitializerList(const ValueDecl *Base,
 
 class PointerFlowTUSummaryExtractor : public TUSummaryExtractor {
 public:
-  PointerFlowTUSummaryExtractor(TUSummaryBuilder &Builder)
-      : TUSummaryExtractor(Builder) {}
+  using TUSummaryExtractor::TUSummaryExtractor;
 
   /// \return a non-null unique pointer to a PointerFlowEntitySummary
   std::unique_ptr<PointerFlowEntitySummary>

--- a/clang/lib/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractor.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryExtractor.cpp
@@ -74,3 +74,7 @@ TUSummaryExtractor::addEntityForReturn(const FunctionDecl *FD) {
     return std::nullopt;
   return SummaryBuilder.addEntity(*Name, getLinkageForDecl(FD));
 }
+
+const SSAFOptions &TUSummaryExtractor::getOptions() const {
+  return SummaryBuilder.getOptions();
+}

--- a/clang/lib/ScalableStaticAnalysisFramework/Frontend/TUSummaryExtractorFrontendAction.cpp
+++ b/clang/lib/ScalableStaticAnalysisFramework/Frontend/TUSummaryExtractorFrontendAction.cpp
@@ -106,9 +106,12 @@ private:
   void HandleTranslationUnit(ASTContext &Ctx) override;
 
   TUSummary Summary;
-  TUSummaryBuilder Builder = TUSummaryBuilder(Summary);
-  std::unique_ptr<SerializationFormat> Format;
+
+  /// Owned by the \c CompilerInstance.
   const SSAFOptions &Opts;
+
+  TUSummaryBuilder Builder = TUSummaryBuilder(Summary, Opts);
+  std::unique_ptr<SerializationFormat> Format;
 };
 } // namespace
 
@@ -141,7 +144,7 @@ TUSummaryRunner::TUSummaryRunner(llvm::Triple TargetTriple,
       Summary(std::move(TargetTriple),
               BuildNamespace(BuildNamespaceKind::CompilationUnit,
                              Opts.CompilationUnitId)),
-      Format(std::move(Format)), Opts(Opts) {
+      Opts(Opts), Format(std::move(Format)) {
   assert(this->Format);
   assert(!Opts.CompilationUnitId.empty());
 

--- a/clang/unittests/ScalableStaticAnalysisFramework/Analyses/CallGraph/CallGraphExtractorTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/Analyses/CallGraph/CallGraphExtractorTest.cpp
@@ -11,6 +11,7 @@
 #include "clang/AST/Decl.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
+#include "clang/Frontend/SSAFOptions.h"
 #include "clang/ScalableStaticAnalysisFramework/Analyses/CallGraph/CallGraphSummary.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/ASTEntityMapping.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/ExtractorRegistry.h"
@@ -123,10 +124,11 @@ template <typename... Matchers> auto hasSummaryThat(const Matchers &...Ms) {
 static const SummaryName CallGraphName{CallGraphSummary::Name.str()};
 
 struct CallGraphExtractorTest : ssaf::TestFixture {
+  SSAFOptions Opts;
   TUSummary Summary{
       llvm::Triple("arm64-apple-macosx"),
       BuildNamespace(BuildNamespaceKind::CompilationUnit, "Mock.cpp")};
-  TUSummaryBuilder Builder = TUSummaryBuilder(Summary);
+  TUSummaryBuilder Builder = TUSummaryBuilder(Summary, Opts);
 
   /// Creates the AST and extractor, then extracts the summaries from the AST.
   /// This will update the \c AST \c Builder and \c Summary data members.

--- a/clang/unittests/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlowTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/Analyses/PointerFlow/PointerFlowTest.cpp
@@ -13,6 +13,7 @@
 #include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/Frontend/ASTUnit.h"
+#include "clang/Frontend/SSAFOptions.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/Model/EntityId.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/ExtractorRegistry.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummary.h"
@@ -146,6 +147,7 @@ struct EPLPair {
 
 class PointerFlowTest : public TestFixture {
 protected:
+  SSAFOptions Opts;
   TUSummary TUSum;
   TUSummaryBuilder Builder;
   std::unique_ptr<TUSummaryExtractor> Extractor;
@@ -154,7 +156,7 @@ protected:
   PointerFlowTest()
       : TUSum(llvm::Triple("arm64-apple-macosx"),
               BuildNamespace(BuildNamespaceKind::CompilationUnit, "Mock.cpp")),
-        Builder(TUSum), Extractor(nullptr) {}
+        Builder(TUSum, Opts), Extractor(nullptr) {}
 
   template <typename ContributorDecl = NamedDecl,
             typename =

--- a/clang/unittests/ScalableStaticAnalysisFramework/Analyses/UnsafeBufferUsage/UnsafeBufferUsageTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/Analyses/UnsafeBufferUsage/UnsafeBufferUsageTest.cpp
@@ -10,6 +10,7 @@
 #include "FindDecl.h"
 #include "TestFixture.h"
 #include "clang/Frontend/ASTUnit.h"
+#include "clang/Frontend/SSAFOptions.h"
 #include "clang/ScalableStaticAnalysisFramework/Analyses/EntityPointerLevel/EntityPointerLevel.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/Model/EntityId.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/Model/EntityIdTable.h"
@@ -35,6 +36,7 @@ using testing::UnorderedElementsAre;
 namespace {
 class UnsafeBufferUsageTest : public TestFixture {
 protected:
+  SSAFOptions Opts;
   TUSummary TUSum;
   TUSummaryBuilder Builder;
   std::unique_ptr<TUSummaryExtractor> Extractor;
@@ -43,7 +45,7 @@ protected:
   UnsafeBufferUsageTest()
       : TUSum(llvm::Triple("arm64-apple-macosx"),
               BuildNamespace(BuildNamespaceKind::CompilationUnit, "Mock.cpp")),
-        Builder(TUSum) {}
+        Builder(TUSum, Opts) {}
 
   bool setUpTest(StringRef Code) {
     AST = tooling::buildASTFromCodeWithArgs(

--- a/clang/unittests/ScalableStaticAnalysisFramework/Registries/SummaryExtractorRegistryTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/Registries/SummaryExtractorRegistryTest.cpp
@@ -8,6 +8,7 @@
 
 #include "MockTUSummaryBuilder.h"
 #include "clang/Frontend/MultiplexConsumer.h"
+#include "clang/Frontend/SSAFOptions.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/ExtractorRegistry.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummary.h"
 #include "clang/Tooling/Tooling.h"
@@ -46,8 +47,9 @@ TEST(SummaryExtractorRegistryTest, EnumeratingRegistryEntries) {
 }
 
 TEST(SummaryExtractorRegistryTest, InstantiatingExtractor1) {
+  SSAFOptions Opts;
   TUSummary Summary = makeFakeSummary();
-  MockTUSummaryBuilder FakeBuilder(Summary);
+  MockTUSummaryBuilder FakeBuilder(Summary, Opts);
   {
     auto Consumer =
         makeTUSummaryExtractor("MockSummaryExtractor1", FakeBuilder);
@@ -60,8 +62,9 @@ TEST(SummaryExtractorRegistryTest, InstantiatingExtractor1) {
 }
 
 TEST(SummaryExtractorRegistryTest, InstantiatingExtractor2) {
+  SSAFOptions Opts;
   TUSummary Summary = makeFakeSummary();
-  MockTUSummaryBuilder FakeBuilder(Summary);
+  MockTUSummaryBuilder FakeBuilder(Summary, Opts);
   {
     auto Consumer =
         makeTUSummaryExtractor("MockSummaryExtractor2", FakeBuilder);
@@ -74,8 +77,9 @@ TEST(SummaryExtractorRegistryTest, InstantiatingExtractor2) {
 }
 
 TEST(SummaryExtractorRegistryTest, InvokingExtractors) {
+  SSAFOptions Opts;
   TUSummary Summary = makeFakeSummary();
-  MockTUSummaryBuilder FakeBuilder(Summary);
+  MockTUSummaryBuilder FakeBuilder(Summary, Opts);
   std::vector<std::unique_ptr<ASTConsumer>> Consumers;
   for (std::string Name : {"MockSummaryExtractor1", "MockSummaryExtractor2"}) {
     auto Consumer = makeTUSummaryExtractor(Name, FakeBuilder);

--- a/clang/unittests/ScalableStaticAnalysisFramework/TUSummaryBuilderTest.cpp
+++ b/clang/unittests/ScalableStaticAnalysisFramework/TUSummaryBuilderTest.cpp
@@ -9,6 +9,7 @@
 #include "clang/ScalableStaticAnalysisFramework/Core/TUSummary/TUSummaryBuilder.h"
 #include "FindDecl.h"
 #include "TestFixture.h"
+#include "clang/Frontend/SSAFOptions.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/Model/BuildNamespace.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/Model/EntityId.h"
 #include "clang/ScalableStaticAnalysisFramework/Core/Model/EntityLinkage.h"
@@ -89,10 +90,11 @@ void PrintTo(const MockSummaryData3 &S, std::ostream *OS) {
 }
 
 struct TUSummaryBuilderTest : ssaf::TestFixture {
+  SSAFOptions Opts;
   TUSummary Summary{
       llvm::Triple("arm64-apple-macosx"),
       BuildNamespace(BuildNamespaceKind::CompilationUnit, "Mock.cpp")};
-  TUSummaryBuilder Builder{Summary};
+  TUSummaryBuilder Builder{Summary, Opts};
   TUSummaryExtractor Extractor{Builder};
 
   [[nodiscard]] EntityId addTestEntity(llvm::StringRef USR) {


### PR DESCRIPTION
Now that we have SSAFOptions, it would make it a lot more ergonomic if it was accessible from builders and extractors.
This PR does exactly that.

Part of rdar://179151023