### PR TITLE
[ADT] Add StringRef::nonEmptyOr

### DIFF
--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -577,6 +577,7 @@ public:
 
   /// Returns this StringRef or a default value if this StringRef is empty.
   [[nodiscard]] StringRef nonEmptyOr(llvm::StringRef Str) const {
+    assert(Str.empty());
     return empty() ? Str : *this;
   }
 

--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -576,7 +576,7 @@ public:
   [[nodiscard]] LLVM_ABI std::string upper() const;
 
   /// Returns this StringRef or a default value if this StringRef is empty.
-  [[nodiscard]] StringRef value_if_empty(llvm::StringRef default_value) const {
+  [[nodiscard]] StringRef nonemptyOr(llvm::StringRef default_value) const {
     return empty() ? default_value : *this;
   }
 

--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -576,7 +576,7 @@ public:
   [[nodiscard]] LLVM_ABI std::string upper() const;
 
   /// Returns this StringRef or a default value if this StringRef is empty.
-  [[nodiscard]] StringRef nonemptyOr(llvm::StringRef default_value) const {
+  [[nodiscard]] StringRef nonEmptyOr(llvm::StringRef default_value) const {
     return empty() ? default_value : *this;
   }
 

--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -575,6 +575,11 @@ public:
   /// Convert the given ASCII string to uppercase.
   [[nodiscard]] LLVM_ABI std::string upper() const;
 
+  /// Returns this StringRef or a default value if this StringRef is empty.
+  [[nodiscard]] StringRef value_if_empty(llvm::StringRef default_value) const {
+    return empty() ? default_value : *this;
+  }
+
   /// @}
   /// @name Substring Operations
   /// @{

--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -576,7 +576,7 @@ public:
   [[nodiscard]] LLVM_ABI std::string upper() const;
 
   /// Returns this StringRef or a default value if this StringRef is empty.
-  [[nodiscard]] StringRef nonEmptyOr(llvm::StringRef Str) const {
+  [[nodiscard]] constexpr StringRef nonEmptyOr(llvm::StringRef Str) const {
     assert(!Str.empty() && "nonEmptyOr should not have an empty default!");
     return empty() ? Str : *this;
   }

--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -576,8 +576,8 @@ public:
   [[nodiscard]] LLVM_ABI std::string upper() const;
 
   /// Returns this StringRef or a default value if this StringRef is empty.
-  [[nodiscard]] StringRef nonEmptyOr(llvm::StringRef default_value) const {
-    return empty() ? default_value : *this;
+  [[nodiscard]] StringRef nonEmptyOr(llvm::StringRef Str) const {
+    return empty() ? Str : *this;
   }
 
   /// @}

--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -577,7 +577,7 @@ public:
 
   /// Returns this StringRef or a default value if this StringRef is empty.
   [[nodiscard]] StringRef nonEmptyOr(llvm::StringRef Str) const {
-    assert(Str.empty());
+    assert(!Str.empty() && "nonEmptyOr should not have an empty default!");
     return empty() ? Str : *this;
   }
 

--- a/llvm/unittests/ADT/StringRefTest.cpp
+++ b/llvm/unittests/ADT/StringRefTest.cpp
@@ -1213,7 +1213,6 @@ TEST(StringRefTest, NonEmptyOr) {
   constexpr StringRef populated("yay!");
   EXPECT_EQ(populated, empty.nonEmptyOr("yay!"));
   EXPECT_EQ(populated, populated.nonEmptyOr("boo!"));
-  EXPECT_EQ(empty, empty.nonEmptyOr(empty));
 }
 
 static_assert(std::is_trivially_copyable_v<StringRef>, "trivially copyable");

--- a/llvm/unittests/ADT/StringRefTest.cpp
+++ b/llvm/unittests/ADT/StringRefTest.cpp
@@ -1209,8 +1209,8 @@ TEST(StringRefTest, LFCRLineEnding) {
 }
 
 TEST(StringRefTest, NonEmptyOr) {
-  constexpr StringRef empty;
-  constexpr StringRef populated("yay!");
+  constexpr StringLiteral empty("");
+  constexpr StringLiteral populated("yay!");
   EXPECT_EQ(populated, empty.nonEmptyOr("yay!"));
   EXPECT_EQ(populated, populated.nonEmptyOr("boo!"));
 }

--- a/llvm/unittests/ADT/StringRefTest.cpp
+++ b/llvm/unittests/ADT/StringRefTest.cpp
@@ -1208,12 +1208,12 @@ TEST(StringRefTest, LFCRLineEnding) {
   EXPECT_EQ(StringRef("\n\r"), Cases[2].detectEOL());
 }
 
-TEST(StringRefTest, ValueIfEmpty) {
+TEST(StringRefTest, NonemptyOr) {
   constexpr StringRef empty;
   constexpr StringRef populated("yay!");
-  EXPECT_EQ(populated, empty.value_if_empty("yay!"));
-  EXPECT_EQ(populated, populated.value_if_empty("boo!"));
-  EXPECT_EQ(empty, empty.value_if_empty(empty));
+  EXPECT_EQ(populated, empty.nonemptyOr("yay!"));
+  EXPECT_EQ(populated, populated.nonemptyOr("boo!"));
+  EXPECT_EQ(empty, empty.nonemptyOr(empty));
 }
 
 static_assert(std::is_trivially_copyable_v<StringRef>, "trivially copyable");

--- a/llvm/unittests/ADT/StringRefTest.cpp
+++ b/llvm/unittests/ADT/StringRefTest.cpp
@@ -1208,6 +1208,14 @@ TEST(StringRefTest, LFCRLineEnding) {
   EXPECT_EQ(StringRef("\n\r"), Cases[2].detectEOL());
 }
 
+TEST(StringRefTest, ValueIfEmpty) {
+  constexpr StringRef empty;
+  constexpr StringRef populated("yay!");
+  EXPECT_EQ(populated, empty.value_if_empty("yay!"));
+  EXPECT_EQ(populated, populated.value_if_empty("boo!"));
+  EXPECT_EQ(empty, empty.value_if_empty(empty));
+}
+
 static_assert(std::is_trivially_copyable_v<StringRef>, "trivially copyable");
 
 } // end anonymous namespace

--- a/llvm/unittests/ADT/StringRefTest.cpp
+++ b/llvm/unittests/ADT/StringRefTest.cpp
@@ -1208,12 +1208,12 @@ TEST(StringRefTest, LFCRLineEnding) {
   EXPECT_EQ(StringRef("\n\r"), Cases[2].detectEOL());
 }
 
-TEST(StringRefTest, NonemptyOr) {
+TEST(StringRefTest, NonEmptyOr) {
   constexpr StringRef empty;
   constexpr StringRef populated("yay!");
-  EXPECT_EQ(populated, empty.nonemptyOr("yay!"));
-  EXPECT_EQ(populated, populated.nonemptyOr("boo!"));
-  EXPECT_EQ(empty, empty.nonemptyOr(empty));
+  EXPECT_EQ(populated, empty.nonEmptyOr("yay!"));
+  EXPECT_EQ(populated, populated.nonEmptyOr("boo!"));
+  EXPECT_EQ(empty, empty.nonEmptyOr(empty));
 }
 
 static_assert(std::is_trivially_copyable_v<StringRef>, "trivially copyable");


### PR DESCRIPTION
This adds a new method to StringRef. The intended use case is for situations when a non-empty StringRef is needed but some operation returns an empty StringRef because of missing data or some other exception.

This is primarily for ergonomics. I'm mainly motivated to avoid creating a temporary StringRef in situations where a StringRef is obtained through a long call chain. e.g.

`doAThing(my_obj.getFoo().getBar().getBaz().getStringRef().nonEmptyOr("unknown"))`