### PR TITLE
[dsymutil] Reuse a single thread pool across architectures

### DIFF
--- a/llvm/include/llvm/DWARFLinker/Classic/DWARFLinker.h
+++ b/llvm/include/llvm/DWARFLinker/Classic/DWARFLinker.h
@@ -277,6 +277,9 @@ public:
     Options.Threads = NumThreads;
   }
 
+  /// The classic linker does not use a shared thread pool.
+  void setThreadPool(ThreadPoolInterface *Pool) override {}
+
   /// Add kind of accelerator tables to be generated.
   void addAccelTableKind(AccelTableKind Kind) override {
     assert(!llvm::is_contained(Options.AccelTables, Kind));

--- a/llvm/include/llvm/DWARFLinker/DWARFLinkerBase.h
+++ b/llvm/include/llvm/DWARFLinker/DWARFLinkerBase.h
@@ -21,6 +21,7 @@
 #include <map>
 namespace llvm {
 class DWARFUnit;
+class ThreadPoolInterface;
 
 namespace dwarf_linker {
 
@@ -138,6 +139,8 @@ public:
   virtual void setObjectPrefixMap(ObjectPrefixMapTy *Map) = 0;
   /// Set target DWARF version.
   virtual Error setTargetDWARFVersion(uint16_t TargetDWARFVersion) = 0;
+  /// Set the thread pool used to link the object files.
+  virtual void setThreadPool(ThreadPoolInterface *Pool) = 0;
 };
 } // end namespace dwarf_linker
 } // end namespace llvm

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.cpp
@@ -195,17 +195,16 @@ Error DWARFLinkerImpl::link() {
         GlobalData.error(std::move(Err), Context->InputDWARFFile.FileName);
     }
   } else {
-    DefaultThreadPool Pool(llvm::parallel::strategy);
+    assert(ThreadPool && "setThreadPool() must be called before link()");
+    ThreadPoolTaskGroup Group(*ThreadPool);
     for (std::unique_ptr<LinkContext> &Context : ObjectContexts)
-      Pool.async([&]() {
+      Group.async([&]() {
         // Link object file.
         if (Error Err = Context->link(ArtificialTypeUnit.get()))
           GlobalData.error(std::move(Err), Context->InputDWARFFile.FileName);
         if (Error Err = Context->unloadInput())
           GlobalData.error(std::move(Err), Context->InputDWARFFile.FileName);
       });
-
-    Pool.wait();
   }
 
   // Merge staged parseable Swift interface entries into the shared map. Done

--- a/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.h
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFLinkerImpl.h
@@ -89,6 +89,9 @@ public:
     GlobalData.Options.Threads = NumThreads;
   }
 
+  /// Use the specified thread pool to link the object files.
+  void setThreadPool(ThreadPoolInterface *Pool) override { ThreadPool = Pool; }
+
   /// Add kind of accelerator tables to be generated.
   void addAccelTableKind(AccelTableKind Kind) override {
     assert(!llvm::is_contained(GlobalData.getOptions().AccelTables, Kind));
@@ -431,6 +434,9 @@ protected:
 
   /// Hanler for output sections.
   SectionHandlerTy SectionHandler = nullptr;
+
+  /// Thread pool that links the object files, or null to use a private pool.
+  ThreadPoolInterface *ThreadPool = nullptr;
   /// @}
 };
 

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
@@ -743,6 +743,7 @@ bool DwarfLinkerForBinary::linkImpl(
   GeneralLinker->setNumThreads(Options.Threads);
   GeneralLinker->setPrependPath(Options.PrependPath);
   GeneralLinker->setKeepFunctionForStatic(Options.KeepFunctionForStatic);
+  GeneralLinker->setThreadPool(ThreadPool);
   GeneralLinker->setInputVerificationHandler(
       [&](const DWARFFile &File, llvm::StringRef Output) {
         std::lock_guard<std::mutex> Guard(ErrorHandlerMutex);

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.h
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.h
@@ -21,6 +21,7 @@
 #include <optional>
 
 namespace llvm {
+class ThreadPoolInterface;
 using namespace dwarf_linker;
 
 namespace dsymutil {
@@ -73,9 +74,10 @@ struct ObjectWithRelocMap {
 class DwarfLinkerForBinary {
 public:
   DwarfLinkerForBinary(raw_fd_ostream &OutFile, BinaryHolder &BinHolder,
-                       LinkOptions Options, std::mutex &ErrorHandlerMutex)
+                       LinkOptions Options, std::mutex &ErrorHandlerMutex,
+                       ThreadPoolInterface *ThreadPool = nullptr)
       : OutFile(OutFile), BinHolder(BinHolder), Options(std::move(Options)),
-        ErrorHandlerMutex(ErrorHandlerMutex) {}
+        ErrorHandlerMutex(ErrorHandlerMutex), ThreadPool(ThreadPool) {}
 
   /// Link the contents of the DebugMap.
   bool link(const DebugMap &);
@@ -295,6 +297,7 @@ private:
   BinaryHolder &BinHolder;
   LinkOptions Options;
   std::mutex &ErrorHandlerMutex;
+  ThreadPoolInterface *ThreadPool;
 
   std::vector<std::string> EmptyWarnings;
 

--- a/llvm/tools/dsymutil/dsymutil.cpp
+++ b/llvm/tools/dsymutil/dsymutil.cpp
@@ -869,18 +869,10 @@ int dsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
     }
     Options.LinkOpts.ResourceDir = OutputLocationOrErr->getResourceDir();
 
-    // Statistics only require different architectures to be processed
-    // sequentially, the link itself can still happen in parallel. Change the
-    // thread pool strategy here instead of modifying LinkOpts.Threads.
-    ThreadPoolStrategy S = hardware_concurrency(
-        Options.LinkOpts.Statistics ? 1 : Options.LinkOpts.Threads);
-    if (Options.LinkOpts.Threads == 0) {
-      // If NumThreads is not specified, create one thread for each input, up to
-      // the number of hardware threads.
-      S.ThreadsRequested = DebugMapPtrsOrErr->size();
-      S.Limit = true;
-    }
-    DefaultThreadPool Threads(S);
+    // Use a single thread for --statistics and --verbose (which forces one
+    // thread) so the per-architecture link output is emitted in order.
+    DefaultThreadPool ThreadPool(hardware_concurrency(
+        Options.LinkOpts.Statistics ? 1 : Options.LinkOpts.Threads));
 
     // If there is more than one link to execute, we need to generate
     // temporary files.
@@ -900,11 +892,10 @@ int dsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
 
     const bool Crashed = !CRC.RunSafely([&]() {
       for (auto &Map : *DebugMapPtrsOrErr) {
-        if (Options.LinkOpts.Verbose || Options.DumpDebugMap)
+        if (Options.DumpDebugMap) {
           Map->print(outs());
-
-        if (Options.DumpDebugMap)
           continue;
+        }
 
         if (Map->begin() == Map->end()) {
           if (!Options.LinkOpts.Quiet) {
@@ -950,8 +941,12 @@ int dsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
 
         auto LinkLambda = [&,
                            OutputFile](std::shared_ptr<raw_fd_ostream> Stream) {
+          // Print the debug map here, on the thread that links it, so verbose
+          // output stays interleaved per architecture.
+          if (Options.LinkOpts.Verbose)
+            Map->print(outs());
           DwarfLinkerForBinary Linker(*Stream, BinHolder, Options.LinkOpts,
-                                      ErrorHandlerMutex);
+                                      ErrorHandlerMutex, &ThreadPool);
           AllOK.fetch_and(Linker.link(*Map));
           Stream->flush();
           if (flagIsSet(Options.Verify, DWARFVerify::Output) ||
@@ -963,16 +958,10 @@ int dsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
           }
         };
 
-        // FIXME: The DwarfLinker can have some very deep recursion that can max
-        // out the (significantly smaller) stack when using threads. We don't
-        // want this limitation when we only have a single thread.
-        if (S.ThreadsRequested == 1)
-          LinkLambda(OS);
-        else
-          Threads.async(LinkLambda, OS);
+        ThreadPool.async(LinkLambda, OS);
       }
 
-      Threads.wait();
+      ThreadPool.wait();
     });
 
     if (Crashed)

--- a/llvm/tools/llvm-dwarfutil/DebugInfoLinker.cpp
+++ b/llvm/tools/llvm-dwarfutil/DebugInfoLinker.cpp
@@ -15,7 +15,10 @@
 #include "llvm/DebugInfo/DWARF/DWARFContext.h"
 #include "llvm/DebugInfo/DWARF/LowLevel/DWARFExpression.h"
 #include "llvm/Object/ObjectFile.h"
+#include "llvm/Support/ThreadPool.h"
+#include "llvm/Support/Threading.h"
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace llvm {
@@ -345,6 +348,11 @@ Error linkDebugInfoImpl(object::ObjectFile &File, const Options &Options,
   else
     return StreamerOrErr.takeError();
 
+  // The parallel linker links the object files on this pool; it must outlive
+  // link() below. The classic linker ignores it.
+  DefaultThreadPool ThreadPool(hardware_concurrency(Options.NumThreads));
+  DebugInfoLinker->setThreadPool(&ThreadPool);
+
   if constexpr (std::is_same<Linker,
                              dwarf_linker::parallel::DWARFLinker>::value) {
     DebugInfoLinker->setOutputDWARFHandler(
@@ -354,8 +362,9 @@ Error linkDebugInfoImpl(object::ObjectFile &File, const Options &Options,
           Streamer->emitSectionContents(Section->getContents(),
                                         Section->getKind());
         });
-  } else
+  } else {
     DebugInfoLinker->setOutputDWARFEmitter(Streamer.get());
+  }
 
   DebugInfoLinker->setEstimatedObjfilesAmount(1);
   DebugInfoLinker->setNumThreads(Options.NumThreads);


### PR DESCRIPTION
dsymutil links the architectures of a universal binary on a thread pool, and the parallel linker's DWARFLinkerImpl::link() then created a second pool to link each architecture's object files. With one such inner pool per architecture, dsymutil spun up more worker threads than the machine has cores.

Add DWARFLinkerBase::setThreadPool() so the caller provides the pool. The parallel linker schedules the object files on it as a ThreadPoolTaskGroup. dsymutil hands over the pool it already uses to schedule the architectures, llvm-dwarfutil passes one sized by --num-threads, and the classic linker ignores it and manages its own threads (always 2 for the lockstep algorithm).

The per-compile-unit cloning still runs on the global llvm::parallel executor, whose per-thread allocators are indexed by getThreadIndex(), so it can't move onto this pool.