### PR TITLE
[LFI][AArch64] Add guard elimination optimization

### DIFF
--- a/llvm/docs/LFI.rst
+++ b/llvm/docs/LFI.rst
@@ -365,8 +365,6 @@ Optimizations
 Basic guard elimination
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-**Note**: not yet implemented.
-
 If a register is guarded multiple times in the same basic block without any
 modifications to it during the intervening instructions, then subsequent guards
 can be removed.

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
@@ -27,9 +27,9 @@
 using namespace llvm;
 
 static cl::opt<bool>
-    NoLFIGuardElim("aarch64-lfi-no-guard-elim", cl::Hidden,
-                   cl::desc("Disable the LFI guard elimination optimization"),
-                   cl::init(false));
+    LFIGuardElim("aarch64-lfi-guard-elim", cl::Hidden,
+                 cl::desc("Enable the LFI guard elimination optimization"),
+                 cl::init(true));
 
 namespace llvm::AArch64 {
 struct LFIVariantEntry {
@@ -277,7 +277,7 @@ void AArch64MCLFIRewriter::emitAddMask(MCRegister Dest, MCRegister Src,
                                        const MCSubtargetInfo &STI) {
   // If x28 already holds the guarded value of Src, this guard is redundant and
   // can be skipped.
-  if (!NoLFIGuardElim && Dest == LFIAddrReg && ActiveGuard &&
+  if (LFIGuardElim && Dest == LFIAddrReg && ActiveGuard &&
       ActiveGuardReg == Src)
     return;
 

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
@@ -253,20 +253,20 @@ MCRegister AArch64MCLFIRewriter::mayModifyReserved(const MCInst &Inst) const {
 
 void AArch64MCLFIRewriter::onLabel(const MCSymbol *) {
   // Invalidate guard state since the label is a potential branch target.
-  ActiveGuard = false;
+  ActiveGuardReg = std::nullopt;
 }
 
 void AArch64MCLFIRewriter::emitInst(const MCInst &Inst, MCStreamer &Out,
                                     const MCSubtargetInfo &STI) {
   // Invalidate the active guard if this instruction modifies the guarded
   // register, modifies x28 itself, or may affect control flow.
-  if (ActiveGuard) {
+  if (ActiveGuardReg) {
     const MCInstrDesc &Desc = InstInfo->get(Inst.getOpcode());
     if (Desc.mayAffectControlFlow(Inst, *RegInfo) ||
-        mayModifyRegister(Inst, ActiveGuardReg) ||
-        mayModifyRegister(Inst, getWRegFromXReg(ActiveGuardReg)) ||
+        mayModifyRegister(Inst, *ActiveGuardReg) ||
+        mayModifyRegister(Inst, getWRegFromXReg(*ActiveGuardReg)) ||
         mayModifyRegister(Inst, LFIAddrReg))
-      ActiveGuard = false;
+      ActiveGuardReg = std::nullopt;
   }
 
   Out.emitInstruction(Inst, STI);
@@ -277,8 +277,7 @@ void AArch64MCLFIRewriter::emitAddMask(MCRegister Dest, MCRegister Src,
                                        const MCSubtargetInfo &STI) {
   // If x28 already holds the guarded value of Src, this guard is redundant and
   // can be skipped.
-  if (LFIGuardElim && Dest == LFIAddrReg && ActiveGuard &&
-      ActiveGuardReg == Src)
+  if (LFIGuardElim && Dest == LFIAddrReg && ActiveGuardReg == Src)
     return;
 
   // add Dest, LFIBaseReg, W(Src), uxtw
@@ -292,10 +291,8 @@ void AArch64MCLFIRewriter::emitAddMask(MCRegister Dest, MCRegister Src,
   emitInst(Inst, Out, STI);
 
   // Record Src as the new active guard.
-  if (Dest == LFIAddrReg) {
-    ActiveGuard = true;
+  if (Dest == LFIAddrReg)
     ActiveGuardReg = Src;
-  }
 }
 
 void AArch64MCLFIRewriter::emitBranch(unsigned Opcode, MCRegister Target,
@@ -854,7 +851,7 @@ bool AArch64MCLFIRewriter::rewriteInst(const MCInst &Inst, MCStreamer &Out,
                                        const MCSubtargetInfo &STI) {
   // Invalidate guard state if the rewriter was manually disabled.
   if (!Enabled)
-    ActiveGuard = false;
+    ActiveGuardReg = std::nullopt;
 
   // This recursion guard prevents rewrite-recursion when we emit instructions
   // from inside the rewriter (such instructions should not be rewritten).

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.cpp
@@ -22,8 +22,14 @@
 #include "llvm/MC/MCInstrInfo.h"
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSubtargetInfo.h"
+#include "llvm/Support/CommandLine.h"
 
 using namespace llvm;
+
+static cl::opt<bool>
+    NoLFIGuardElim("aarch64-lfi-no-guard-elim", cl::Hidden,
+                   cl::desc("Disable the LFI guard elimination optimization"),
+                   cl::init(false));
 
 namespace llvm::AArch64 {
 struct LFIVariantEntry {
@@ -245,14 +251,36 @@ MCRegister AArch64MCLFIRewriter::mayModifyReserved(const MCInst &Inst) const {
   return {};
 }
 
+void AArch64MCLFIRewriter::onLabel(const MCSymbol *) {
+  // Invalidate guard state since the label is a potential branch target.
+  ActiveGuard = false;
+}
+
 void AArch64MCLFIRewriter::emitInst(const MCInst &Inst, MCStreamer &Out,
                                     const MCSubtargetInfo &STI) {
+  // Invalidate the active guard if this instruction modifies the guarded
+  // register, modifies x28 itself, or may affect control flow.
+  if (ActiveGuard) {
+    const MCInstrDesc &Desc = InstInfo->get(Inst.getOpcode());
+    if (Desc.mayAffectControlFlow(Inst, *RegInfo) ||
+        mayModifyRegister(Inst, ActiveGuardReg) ||
+        mayModifyRegister(Inst, getWRegFromXReg(ActiveGuardReg)) ||
+        mayModifyRegister(Inst, LFIAddrReg))
+      ActiveGuard = false;
+  }
+
   Out.emitInstruction(Inst, STI);
 }
 
 void AArch64MCLFIRewriter::emitAddMask(MCRegister Dest, MCRegister Src,
                                        MCStreamer &Out,
                                        const MCSubtargetInfo &STI) {
+  // If x28 already holds the guarded value of Src, this guard is redundant and
+  // can be skipped.
+  if (!NoLFIGuardElim && Dest == LFIAddrReg && ActiveGuard &&
+      ActiveGuardReg == Src)
+    return;
+
   // add Dest, LFIBaseReg, W(Src), uxtw
   MCInst Inst;
   Inst.setOpcode(AArch64::ADDXrx);
@@ -262,6 +290,12 @@ void AArch64MCLFIRewriter::emitAddMask(MCRegister Dest, MCRegister Src,
   Inst.addOperand(
       MCOperand::createImm(AArch64_AM::getArithExtendImm(AArch64_AM::UXTW, 0)));
   emitInst(Inst, Out, STI);
+
+  // Record Src as the new active guard.
+  if (Dest == LFIAddrReg) {
+    ActiveGuard = true;
+    ActiveGuardReg = Src;
+  }
 }
 
 void AArch64MCLFIRewriter::emitBranch(unsigned Opcode, MCRegister Target,
@@ -818,8 +852,12 @@ bool llvm::isLFIPrePostMemAccess(unsigned Opcode) {
 
 bool AArch64MCLFIRewriter::rewriteInst(const MCInst &Inst, MCStreamer &Out,
                                        const MCSubtargetInfo &STI) {
-  // The guard prevents rewrite-recursion when we emit instructions from inside
-  // the rewriter (such instructions should not be rewritten).
+  // Invalidate guard state if the rewriter was manually disabled.
+  if (!Enabled)
+    ActiveGuard = false;
+
+  // This recursion guard prevents rewrite-recursion when we emit instructions
+  // from inside the rewriter (such instructions should not be rewritten).
   if (!Enabled || Guard)
     return false;
   Guard = true;

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.h
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.h
@@ -19,6 +19,8 @@
 #include "llvm/MC/MCRegister.h"
 #include "llvm/MC/MCRegisterInfo.h"
 
+#include <optional>
+
 namespace llvm {
 class MCContext;
 class MCExpr;
@@ -63,9 +65,9 @@ private:
   const MCExpr *PendingTLSDescCall = nullptr;
 
   /// Rewriter state for implementing the guard-elimination optimization, which
-  /// allows redundant add masks to be skipped.
-  bool ActiveGuard = false;
-  MCRegister ActiveGuardReg;
+  /// allows redundant add masks to be skipped. When it holds a value, x28 is
+  /// known to already hold the guarded value of that register.
+  std::optional<MCRegister> ActiveGuardReg;
 
   // Instruction classification. Returns the reserved register that may be
   // modified, or an invalid register if no reserved register is touched.

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.h
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCLFIRewriter.h
@@ -26,6 +26,7 @@ class MCInst;
 class MCOperand;
 class MCStreamer;
 class MCSubtargetInfo;
+class MCSymbol;
 
 /// Rewrites AArch64 instructions for LFI sandboxing.
 ///
@@ -49,6 +50,8 @@ public:
   bool rewriteInst(const MCInst &Inst, MCStreamer &Out,
                    const MCSubtargetInfo &STI) override;
 
+  void onLabel(const MCSymbol *Symbol) override;
+
 private:
   /// Recursion guard to prevent infinite loops when emitting instructions.
   bool Guard = false;
@@ -58,6 +61,11 @@ private:
   /// a guard before that BLR, the marker is deferred and re-emitted between
   /// the guard and the branch so the relocation stays on the BLR.
   const MCExpr *PendingTLSDescCall = nullptr;
+
+  /// Rewriter state for implementing the guard-elimination optimization, which
+  /// allows redundant add masks to be skipped.
+  bool ActiveGuard = false;
+  MCRegister ActiveGuardReg;
 
   // Instruction classification. Returns the reserved register that may be
   // modified, or an invalid register if no reserved register is touched.

--- a/llvm/test/MC/AArch64/LFI/exclusive.s
+++ b/llvm/test/MC/AArch64/LFI/exclusive.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
+// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-no-guard-elim %s | FileCheck %s
 
 // Load exclusive
 ldxr x0, [x1]

--- a/llvm/test/MC/AArch64/LFI/exclusive.s
+++ b/llvm/test/MC/AArch64/LFI/exclusive.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-no-guard-elim %s | FileCheck %s
+// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-guard-elim=false %s | FileCheck %s
 
 // Load exclusive
 ldxr x0, [x1]

--- a/llvm/test/MC/AArch64/LFI/fp.s
+++ b/llvm/test/MC/AArch64/LFI/fp.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
+// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-no-guard-elim %s | FileCheck %s
 
 // FP/SIMD scalar loads (zero offset -> RoW)
 ldr b0, [x1]

--- a/llvm/test/MC/AArch64/LFI/fp.s
+++ b/llvm/test/MC/AArch64/LFI/fp.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-no-guard-elim %s | FileCheck %s
+// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-guard-elim=false %s | FileCheck %s
 
 // FP/SIMD scalar loads (zero offset -> RoW)
 ldr b0, [x1]

--- a/llvm/test/MC/AArch64/LFI/guard-elim.s
+++ b/llvm/test/MC/AArch64/LFI/guard-elim.s
@@ -1,0 +1,176 @@
+// RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
+
+// Consecutive loads from the same register share a guard.
+ldr x0, [x1, #8]
+ldr x2, [x1, #16]
+// CHECK:      add x28, x27, w1, uxtw
+// CHECK-NEXT: ldr x0, [x28, #8]
+// CHECK-NEXT: ldr x2, [x28, #16]
+
+// Modifying the base register invalidates the guard.
+ldr x4, [x3, #8]
+add x3, x3, #24
+ldr x5, [x3, #8]
+// CHECK:      add x28, x27, w3, uxtw
+// CHECK-NEXT: ldr x4, [x28, #8]
+// CHECK-NEXT: add x3, x3, #24
+// CHECK-NEXT: add x28, x27, w3, uxtw
+// CHECK-NEXT: ldr x5, [x28, #8]
+
+// A different base register requires a new guard.
+ldr x6, [x4, #8]
+ldr x7, [x5, #8]
+// CHECK:      add x28, x27, w4, uxtw
+// CHECK-NEXT: ldr x6, [x28, #8]
+// CHECK-NEXT: add x28, x27, w5, uxtw
+// CHECK-NEXT: ldr x7, [x28, #8]
+
+// Labels invalidate the guard.
+label_boundary_test:
+ldr x8, [x6, #8]
+label1:
+ldr x9, [x6, #16]
+// CHECK-LABEL: label_boundary_test:
+// CHECK-NEXT: add x28, x27, w6, uxtw
+// CHECK-NEXT: ldr x8, [x28, #8]
+// CHECK-NEXT: label1:
+// CHECK-NEXT: add x28, x27, w6, uxtw
+// CHECK-NEXT: ldr x9, [x28, #16]
+
+// Branches invalidate the guard.
+control_flow_test:
+ldr x10, [x7, #8]
+b label2
+ldr x11, [x7, #16]
+label2:
+// CHECK-LABEL: control_flow_test:
+// CHECK-NEXT: add x28, x27, w7, uxtw
+// CHECK-NEXT: ldr x10, [x28, #8]
+// CHECK-NEXT: b label2
+// CHECK-NEXT: add x28, x27, w7, uxtw
+// CHECK-NEXT: ldr x11, [x28, #16]
+// CHECK-NEXT: label2:
+
+// Modifying the W subregister invalidates the X guard.
+w_reg_modification:
+ldr x12, [x8, #8]
+mov w8, #0
+ldr x13, [x8, #16]
+// CHECK-LABEL: w_reg_modification:
+// CHECK-NEXT: add x28, x27, w8, uxtw
+// CHECK-NEXT: ldr x12, [x28, #8]
+// CHECK-NEXT: mov w8, #0
+// CHECK-NEXT: add x28, x27, w8, uxtw
+// CHECK-NEXT: ldr x13, [x28, #16]
+
+// Multiple consecutive accesses share a single guard.
+multiple_accesses:
+ldr x14, [x9, #8]
+ldr x15, [x9, #16]
+ldr x16, [x9, #24]
+str x17, [x9, #32]
+// CHECK-LABEL: multiple_accesses:
+// CHECK-NEXT: add x28, x27, w9, uxtw
+// CHECK-NEXT: ldr x14, [x28, #8]
+// CHECK-NEXT: ldr x15, [x28, #16]
+// CHECK-NEXT: ldr x16, [x28, #24]
+// CHECK-NEXT: str x17, [x28, #32]
+
+// Mixed loads and stores share a guard.
+mixed_load_store:
+str x18, [x10, #8]
+ldr x19, [x10, #16]
+str x20, [x10, #24]
+// CHECK-LABEL: mixed_load_store:
+// CHECK-NEXT: add x28, x27, w10, uxtw
+// CHECK-NEXT: str x18, [x28, #8]
+// CHECK-NEXT: ldr x19, [x28, #16]
+// CHECK-NEXT: str x20, [x28, #24]
+
+// Instructions that don't touch x28 or the guarded register keep the guard.
+non_modifying_between:
+ldr x21, [x11, #8]
+mov x0, x1
+add x2, x3, x4
+ldr x22, [x11, #16]
+// CHECK-LABEL: non_modifying_between:
+// CHECK-NEXT: add x28, x27, w11, uxtw
+// CHECK-NEXT: ldr x21, [x28, #8]
+// CHECK-NEXT: mov x0, x1
+// CHECK-NEXT: add x2, x3, x4
+// CHECK-NEXT: ldr x22, [x28, #16]
+
+// Post-index pair writeback invalidates the guard.
+prepost_ldp:
+    ldp x0, x1, [x2]
+    ldp x3, x4, [x2], #16
+    ldp x5, x6, [x2]
+// CHECK-LABEL: prepost_ldp:
+// CHECK-NEXT: add x28, x27, w2, uxtw
+// CHECK-NEXT: ldp x0, x1, [x28]
+// CHECK-NEXT: ldp x3, x4, [x28]
+// CHECK-NEXT: add x2, x2, #16
+// CHECK-NEXT: add x28, x27, w2, uxtw
+// CHECK-NEXT: ldp x5, x6, [x28]
+
+prepost_stp:
+    stp x0, x1, [x2]
+    stp x3, x4, [x2], #16
+    stp x5, x6, [x2]
+// CHECK-LABEL: prepost_stp:
+// CHECK-NEXT: add x28, x27, w2, uxtw
+// CHECK-NEXT: stp x0, x1, [x28]
+// CHECK-NEXT: stp x3, x4, [x28]
+// CHECK-NEXT: add x2, x2, #16
+// CHECK-NEXT: add x28, x27, w2, uxtw
+// CHECK-NEXT: stp x5, x6, [x28]
+
+// Pre-index pair writeback invalidates the guard.
+prepost_ldp_pre:
+    ldp x0, x1, [x2]
+    ldp x3, x4, [x2, #16]!
+    ldp x5, x6, [x2]
+// CHECK-LABEL: prepost_ldp_pre:
+// CHECK-NEXT: add x28, x27, w2, uxtw
+// CHECK-NEXT: ldp x0, x1, [x28]
+// CHECK-NEXT: ldp x3, x4, [x28, #16]
+// CHECK-NEXT: add x2, x2, #16
+// CHECK-NEXT: add x28, x27, w2, uxtw
+// CHECK-NEXT: ldp x5, x6, [x28]
+
+// A load into the base register invalidates the guard.
+load_into_base:
+ldr x1, [x1, #8]
+ldr x2, [x1, #16]
+// CHECK-LABEL: load_into_base:
+// CHECK-NEXT: add x28, x27, w1, uxtw
+// CHECK-NEXT: ldr x1, [x28, #8]
+// CHECK-NEXT: add x28, x27, w1, uxtw
+// CHECK-NEXT: ldr x2, [x28, #16]
+
+// The guard for x28 carries across an LR mask, since the mask touches only x30.
+lr_mask_between:
+ldr x0, [x12, #8]
+ldr x30, [x12, #16]
+ldr x1, [x12, #24]
+// CHECK-LABEL: lr_mask_between:
+// CHECK-NEXT: add x28, x27, w12, uxtw
+// CHECK-NEXT: ldr x0, [x28, #8]
+// CHECK-NEXT: ldr x30, [x28, #16]
+// CHECK-NEXT: add x30, x27, w30, uxtw
+// CHECK-NEXT: ldr x1, [x28, #24]
+
+// A .lfi_rewrite_disable region invalidates the guard, since the instructions
+// inside it bypass the rewriter and may modify the base register or x28.
+rewrite_disable_boundary:
+ldr x0, [x14, #8]
+.lfi_rewrite_disable
+mov x14, x15
+.lfi_rewrite_enable
+ldr x1, [x14, #16]
+// CHECK-LABEL: rewrite_disable_boundary:
+// CHECK-NEXT: add x28, x27, w14, uxtw
+// CHECK-NEXT: ldr x0, [x28, #8]
+// CHECK-NEXT: mov x14, x15
+// CHECK-NEXT: add x28, x27, w14, uxtw
+// CHECK-NEXT: ldr x1, [x28, #16]

--- a/llvm/test/MC/AArch64/LFI/guard-elim.s
+++ b/llvm/test/MC/AArch64/LFI/guard-elim.s
@@ -102,9 +102,9 @@ ldr x22, [x11, #16]
 
 // Post-index pair writeback invalidates the guard.
 prepost_ldp:
-    ldp x0, x1, [x2]
-    ldp x3, x4, [x2], #16
-    ldp x5, x6, [x2]
+ldp x0, x1, [x2]
+ldp x3, x4, [x2], #16
+ldp x5, x6, [x2]
 // CHECK-LABEL: prepost_ldp:
 // CHECK-NEXT: add x28, x27, w2, uxtw
 // CHECK-NEXT: ldp x0, x1, [x28]
@@ -114,9 +114,9 @@ prepost_ldp:
 // CHECK-NEXT: ldp x5, x6, [x28]
 
 prepost_stp:
-    stp x0, x1, [x2]
-    stp x3, x4, [x2], #16
-    stp x5, x6, [x2]
+stp x0, x1, [x2]
+stp x3, x4, [x2], #16
+stp x5, x6, [x2]
 // CHECK-LABEL: prepost_stp:
 // CHECK-NEXT: add x28, x27, w2, uxtw
 // CHECK-NEXT: stp x0, x1, [x28]
@@ -127,9 +127,9 @@ prepost_stp:
 
 // Pre-index pair writeback invalidates the guard.
 prepost_ldp_pre:
-    ldp x0, x1, [x2]
-    ldp x3, x4, [x2, #16]!
-    ldp x5, x6, [x2]
+ldp x0, x1, [x2]
+ldp x3, x4, [x2, #16]!
+ldp x5, x6, [x2]
 // CHECK-LABEL: prepost_ldp_pre:
 // CHECK-NEXT: add x28, x27, w2, uxtw
 // CHECK-NEXT: ldp x0, x1, [x28]

--- a/llvm/test/MC/AArch64/LFI/lse.s
+++ b/llvm/test/MC/AArch64/LFI/lse.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-no-guard-elim %s | FileCheck %s
-// RUN: llvm-mc -triple aarch64_lfi -mattr=+no-lfi-loads --aarch64-lfi-no-guard-elim %s | FileCheck %s
+// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-guard-elim=false %s | FileCheck %s
+// RUN: llvm-mc -triple aarch64_lfi -mattr=+no-lfi-loads --aarch64-lfi-guard-elim=false %s | FileCheck %s
 
 .arch_extension lse
 

--- a/llvm/test/MC/AArch64/LFI/lse.s
+++ b/llvm/test/MC/AArch64/LFI/lse.s
@@ -1,5 +1,5 @@
-// RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
-// RUN: llvm-mc -triple aarch64_lfi -mattr=+no-lfi-loads %s | FileCheck %s
+// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-no-guard-elim %s | FileCheck %s
+// RUN: llvm-mc -triple aarch64_lfi -mattr=+no-lfi-loads --aarch64-lfi-no-guard-elim %s | FileCheck %s
 
 .arch_extension lse
 

--- a/llvm/test/MC/AArch64/LFI/mem-lr.s
+++ b/llvm/test/MC/AArch64/LFI/mem-lr.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-no-guard-elim %s | FileCheck %s
+// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-guard-elim=false %s | FileCheck %s
 
 // Memory accesses that define LR (x30) must sandbox the base register
 // in addition to masking LR after the access.

--- a/llvm/test/MC/AArch64/LFI/mem-lr.s
+++ b/llvm/test/MC/AArch64/LFI/mem-lr.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
+// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-no-guard-elim %s | FileCheck %s
 
 // Memory accesses that define LR (x30) must sandbox the base register
 // in addition to masking LR after the access.

--- a/llvm/test/MC/AArch64/LFI/mem.s
+++ b/llvm/test/MC/AArch64/LFI/mem.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
+// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-no-guard-elim %s | FileCheck %s
 
 // SP-relative loads/stores (no sandboxing needed)
 ldr x0, [sp]

--- a/llvm/test/MC/AArch64/LFI/mem.s
+++ b/llvm/test/MC/AArch64/LFI/mem.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-no-guard-elim %s | FileCheck %s
+// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-guard-elim=false %s | FileCheck %s
 
 // SP-relative loads/stores (no sandboxing needed)
 ldr x0, [sp]

--- a/llvm/test/MC/AArch64/LFI/prefetch.s
+++ b/llvm/test/MC/AArch64/LFI/prefetch.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-no-guard-elim %s | FileCheck %s
+// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-guard-elim=false %s | FileCheck %s
 
 prfm pldl1keep, [x0]
 // CHECK: prfm pldl1keep, [x27, w0, uxtw]

--- a/llvm/test/MC/AArch64/LFI/prefetch.s
+++ b/llvm/test/MC/AArch64/LFI/prefetch.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
+// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-no-guard-elim %s | FileCheck %s
 
 prfm pldl1keep, [x0]
 // CHECK: prfm pldl1keep, [x27, w0, uxtw]

--- a/llvm/test/MC/AArch64/LFI/rcpc.s
+++ b/llvm/test/MC/AArch64/LFI/rcpc.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-no-guard-elim %s | FileCheck %s
+// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-guard-elim=false %s | FileCheck %s
 
 .arch_extension rcpc
 

--- a/llvm/test/MC/AArch64/LFI/rcpc.s
+++ b/llvm/test/MC/AArch64/LFI/rcpc.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
+// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-no-guard-elim %s | FileCheck %s
 
 .arch_extension rcpc
 

--- a/llvm/test/MC/AArch64/LFI/simd.s
+++ b/llvm/test/MC/AArch64/LFI/simd.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple aarch64_lfi %s | FileCheck %s
+// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-no-guard-elim %s | FileCheck %s
 
 // LD1/ST1 single structure (no post-index)
 

--- a/llvm/test/MC/AArch64/LFI/simd.s
+++ b/llvm/test/MC/AArch64/LFI/simd.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-no-guard-elim %s | FileCheck %s
+// RUN: llvm-mc -triple aarch64_lfi --aarch64-lfi-guard-elim=false %s | FileCheck %s
 
 // LD1/ST1 single structure (no post-index)
 


### PR DESCRIPTION
This adds support for the guard elimination optimization to the AArch64 LFI rewriter. Redundant guards (`add x28, x27, wN, uxtw` instructions) will be skipped when possible. See the LFI.rst documentation for an example of the optimization.