### PR TITLE
[CodeGen] Check for isReg is redundant, just add the DebugOp (NFC)

### DIFF
--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -2415,10 +2415,7 @@ MachineInstrBuilder llvm::BuildMI(MachineFunction &MF, const DebugLoc &DL,
   auto MIB = BuildMI(MF, DL, MCID);
   MIB.addMetadata(Variable).addMetadata(Expr);
   for (const MachineOperand &DebugOp : DebugOps)
-    if (DebugOp.isReg())
-      MIB.addReg(DebugOp.getReg());
-    else
-      MIB.add(DebugOp);
+    MIB.add(DebugOp);
   return MIB;
 }
 


### PR DESCRIPTION
add will do the rest for us without issue.