### PR TITLE
[Fuzzer] Bump rss_limit again

### DIFF
--- a/compiler-rt/test/fuzzer/fork.test
+++ b/compiler-rt/test/fuzzer/fork.test
@@ -22,4 +22,4 @@ RUN: FileCheck %s --check-prefix=CRASH --input-file=%t-ShallowOOMDeepCrash.log
 
 MAX_TOTAL_TIME: INFO: fuzzed for {{.*}} seconds, wrapping up soon
 MAX_TOTAL_TIME: INFO: exiting: {{.*}} time:
-RUN: not %run %t-ShallowOOMDeepCrash -fork=1 -rss_limit_mb=256 -ignore_crashes=1 -max_total_time=30 2>&1 | FileCheck %s  --check-prefix=MAX_TOTAL_TIME
+RUN: not %run %t-ShallowOOMDeepCrash -fork=1 -rss_limit_mb=512 -ignore_crashes=1 -max_total_time=30 2>&1 | FileCheck %s  --check-prefix=MAX_TOTAL_TIME

--- a/compiler-rt/test/fuzzer/fork_corpus_groups.test
+++ b/compiler-rt/test/fuzzer/fork_corpus_groups.test
@@ -22,4 +22,4 @@ RUN: FileCheck %s --check-prefix=CRASH --input-file=%t-ShallowOOMDeepCrash.log
 
 MAX_TOTAL_TIME: INFO: fuzzed for {{.*}} seconds, wrapping up soon
 MAX_TOTAL_TIME: INFO: exiting: {{.*}} time:
-RUN: not %run %t-ShallowOOMDeepCrash -fork=1 -fork_corpus_groups=1 -rss_limit_mb=256 -ignore_crashes=1 -max_total_time=30 2>&1 | FileCheck %s  --check-prefix=MAX_TOTAL_TIME
+RUN: not %run %t-ShallowOOMDeepCrash -fork=1 -fork_corpus_groups=1 -rss_limit_mb=512 -ignore_crashes=1 -max_total_time=30 2>&1 | FileCheck %s  --check-prefix=MAX_TOTAL_TIME


### PR DESCRIPTION
These tests are still somewhat flaky, even after
3e11b3be3b86d4e72e73e610fb15fe431169f16e, so bump the limit again.

See
https://github.com/llvm/llvm-project/pull/203450#issuecomment-4737237866 for info on failures.