### PR TITLE
Add SPV_INTEL_bfloat16_arithmetic for Opencl extended instructions with bfloat16 type

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -1660,8 +1660,39 @@ void addInstrRequirements(const MachineInstr &MI,
       addPrintfRequirements(MI, Reqs, ST);
       break;
     }
-    // TODO: handle bfloat16 extended instructions when
-    // SPV_INTEL_bfloat16_arithmetic is enabled.
+    if (MI.getOperand(2).getImm() ==
+        static_cast<int64_t>(SPIRV::InstructionSet::OpenCL_std)) {
+      MachineFunction *MF = const_cast<MachineFunction *>(MI.getMF());
+      const MachineRegisterInfo &MRI = MF->getRegInfo();
+      SPIRVGlobalRegistry *GR = ST.getSPIRVGlobalRegistry();
+
+      auto IsBFloat16 = [&](SPIRVTypeInst TypeDef) {
+        if (TypeDef && TypeDef->getOpcode() == SPIRV::OpTypeVector)
+          TypeDef = MRI.getVRegDef(TypeDef->getOperand(1).getReg());
+        return isBFloat16Type(TypeDef);
+      };
+
+      // Result type is operand 1; arguments start at operand 4.
+      bool UsesBFloat16 = IsBFloat16(MRI.getVRegDef(MI.getOperand(1).getReg()));
+      for (unsigned I = 4, E = MI.getNumOperands(); I < E && !UsesBFloat16;
+           ++I) {
+        const MachineOperand &MO = MI.getOperand(I);
+        if (MO.isReg())
+          UsesBFloat16 = IsBFloat16(GR->getResultType(MO.getReg(), MF));
+      }
+
+      // The OpenCL extended instruction set operates on IEEE-754 encoding only,
+      // but can be allowed with SPV_INTEL_bfloat16_arithmetic
+      if (UsesBFloat16) {
+        if (!ST.canUseExtension(
+                SPIRV::Extension::SPV_INTEL_bfloat16_arithmetic))
+          report_fatal_error(
+              "Extended instructions with bfloat16 arguments require the "
+              "following SPIR-V extension: SPV_INTEL_bfloat16_arithmetic",
+              false);
+        Reqs.addExtension(SPIRV::Extension::SPV_INTEL_bfloat16_arithmetic);
+      }
+    }
     break;
   }
   case SPIRV::OpAliasDomainDeclINTEL:

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_bfloat16_arithmetic/bfloat16-ocl-ext.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_bfloat16_arithmetic/bfloat16-ocl-ext.ll
@@ -1,0 +1,53 @@
+; Without SPV_INTEL_bfloat16_arithmetic: report error.
+; RUN: not llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_KHR_bfloat16 %s -o %t.spvt 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
+; CHECK-ERROR: LLVM ERROR: Extended instructions with bfloat16 arguments require the following SPIR-V extension: SPV_INTEL_bfloat16_arithmetic
+
+; With the extension: emit OpExtInst with OpExtension
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %s -o - | FileCheck %s --check-prefixes=COMMON,CHECK-FABS
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %s -o - | FileCheck %s --check-prefixes=COMMON,CHECK-FABSV
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_bfloat16_arithmetic,+SPV_KHR_bfloat16 %s -o - | FileCheck %s --check-prefix=COMMON
+
+; COMMON-NOT: OpCapability BFloat16ArithmeticINTEL
+; COMMON-DAG: OpCapability BFloat16TypeKHR
+; COMMON-DAG: OpExtension "SPV_KHR_bfloat16"
+; COMMON-DAG: OpExtension "SPV_INTEL_bfloat16_arithmetic"
+; COMMON-DAG: [[EXTSET:%.*]] = OpExtInstImport "OpenCL.std"
+; COMMON-DAG: [[BFLOAT:%.*]] = OpTypeFloat 16 0
+
+; Scalar bfloat16 result and argument.
+; CHECK-FABS: OpFunction [[BFLOAT]]
+; CHECK-FABS: [[X:%.*]] = OpFunctionParameter [[BFLOAT]]
+; CHECK-FABS: OpExtInst [[BFLOAT]] [[EXTSET]] fabs [[X]]
+define spir_func bfloat @test_fabs(bfloat %x) {
+entry:
+  %r = call bfloat @llvm.fabs.bf16(bfloat %x)
+  ret bfloat %r
+}
+
+declare bfloat @llvm.fabs.bf16(bfloat)
+
+; Vector bfloat16 result and argument.
+; CHECK-FABSV-DAG: [[BFLOATV:%.*]] = OpTypeVector [[BFLOAT]] 4
+; CHECK-FABSV: OpFunction [[BFLOATV]]
+; CHECK-FABSV: [[XV:%.*]] = OpFunctionParameter [[BFLOATV]]
+; CHECK-FABSV: OpExtInst [[BFLOATV]] [[EXTSET]] fabs [[XV]]
+define spir_func <4 x bfloat> @test_fabsv(<4 x bfloat> %x) {
+entry:
+  %r = call <4 x bfloat> @llvm.fabs.v4bf16(<4 x bfloat> %x)
+  ret <4 x bfloat> %r
+}
+
+declare <4 x bfloat> @llvm.fabs.v4bf16(<4 x bfloat>)
+
+; A non-bfloat16 (i32) result with a bfloat16 argument.
+; CHECK-DAG: [[INT:%.*]] = OpTypeInt 32 0
+; CHECK: OpFunction [[INT]]
+; CHECK: [[XI:%.*]] = OpFunctionParameter [[BFLOAT]]
+; CHECK: OpExtInst [[INT]] [[EXTSET]] ilogb [[XI]]
+define spir_func i32 @test_ilogb(bfloat %x) {
+entry:
+  %r = call i32 @_Z5ilogbDh(bfloat %x)
+  ret i32 %r
+}
+
+declare i32 @_Z5ilogbDh(bfloat)


### PR DESCRIPTION
For `OpExtInst`: check for `bfloat16` type when it's an OpenCL.std extended instruction, and add requirements for `SPV_INTEL_bfloat16_arithmetic` if so.

Add such check and extension requirement since OpenCL.std extended instruction set can operate on IEEE-754 FP types only, as per the revision from [OpenCL.std spec](https://registry.khronos.org/SPIR-V/specs/unified1/OpenCL.ExtendedInstructionSet.100.html#_changes_from_version_1_0_revision_8)