### PR TITLE
[lldb][test] Wait on the exit-status future in HostTest

### DIFF
--- a/lldb/unittests/Host/HostTest.cpp
+++ b/lldb/unittests/Host/HostTest.cpp
@@ -127,7 +127,7 @@ TEST(Host, FindProcesses) {
   ASSERT_TRUE(foundPID);
   llvm::scope_exit clean_up([&] {
     Host::Kill(info.GetProcessID(), SIGKILL);
-    exit_status.get_future().get();
+    exit_status.get_future().wait();
   });
 }
 


### PR DESCRIPTION
libc++ marks `std::future::get()` as` `[[nodiscard]]`. The cleanup lambda only needs to block until the child is reaped, not read the status. Use `wait()` to avoid the `-Wunused-result` warning.