### PR TITLE
[UBSan][AMDGPU] Report minimal-runtime diagnostics with symbolization

### DIFF
--- a/compiler-rt/include/sanitizer/gpu_sanitizer.h
+++ b/compiler-rt/include/sanitizer/gpu_sanitizer.h
@@ -1,0 +1,42 @@
+//===-- sanitizer/gpu_sanitizer.h -------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Shared ABI contract for GPU sanitizer reports shipped to the host over RPC.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SANITIZER_GPU_SANITIZER_H
+#define SANITIZER_GPU_SANITIZER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SANITIZER_GPU_OPCODE(n) (('s' << 24) | (n))
+
+#define UBSAN_GPU_REPORT_OPCODE SANITIZER_GPU_OPCODE(0)
+
+/// Longest minimal handler kind ("function-type-mismatch") plus a NUL, sized so
+/// the report is one 64-byte RPC packet.
+#define UBSAN_GPU_KIND_MAX 24
+
+/// A single minimal-runtime UBSan diagnostic, shared verbatim across the
+/// device/host RPC boundary. 'pc' is a raw device address resolved on the host.
+typedef struct __ubsan_gpu_report {
+  unsigned long long pc;         ///< Device PC of the faulting check (caller).
+  unsigned block[3];             ///< Block / workgroup id.
+  unsigned thread[3];            ///< Thread / work-item id within the block.
+  unsigned lane;                 ///< Lane id within the wave.
+  char kind[UBSAN_GPU_KIND_MAX]; ///< Null-terminated check name.
+} __ubsan_gpu_report;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // SANITIZER_GPU_SANITIZER_H

--- a/compiler-rt/lib/ubsan_minimal/CMakeLists.txt
+++ b/compiler-rt/lib/ubsan_minimal/CMakeLists.txt
@@ -6,6 +6,16 @@ set(UBSAN_MINIMAL_SOURCES
 
 include_directories(..)
 
+# The GPU runtime reports to the host over the RPC channel for host-side
+# symbolization, so it needs the shared sanitizer header and the RPC headers.
+if(COMPILER_RT_GPU_BUILD)
+  include_directories(${COMPILER_RT_SOURCE_DIR}/include)
+  include(FindLibcCommonUtils)
+  get_target_property(LIBC_COMMON_UTILS_INCLUDE
+    llvm-libc-common-utilities INTERFACE_INCLUDE_DIRECTORIES)
+  include_directories(${LIBC_COMMON_UTILS_INCLUDE})
+endif()
+
 set(UBSAN_CFLAGS
   ${SANITIZER_COMMON_CFLAGS}
   -DSANITIZER_COMMON_NO_REDEFINE_BUILTINS)

--- a/compiler-rt/lib/ubsan_minimal/ubsan_minimal_handlers.cpp
+++ b/compiler-rt/lib/ubsan_minimal/ubsan_minimal_handlers.cpp
@@ -24,6 +24,18 @@ static void message(const char *msg, Args &&...args) {
 static void message(const char *msg) { (void)write(2, msg, strlen(msg)); }
 #endif
 
+// The SPIR-V target cannot currently use the GPU libc / RPC.
+#if SANITIZER_AMDGPU || SANITIZER_NVPTX
+#include <gpuintrin.h>
+
+#include "sanitizer/gpu_sanitizer.h"
+#include "shared/rpc.h"
+
+// The libc RPC client used to ship results to the host for symbolization.
+[[gnu::visibility("protected"),
+  gnu::weak]] rpc::Client __ubsan_rpc_client asm("__llvm_rpc_client");
+#endif
+
 // If for some reason we cannot build the runtime with preserve_all, don't
 // emit any symbol. Programs that need them will fail to link, but that is
 // better than randomly corrupted registers.
@@ -40,11 +52,13 @@ static void message(const char *msg) { (void)write(2, msg, strlen(msg)); }
 #define PRESERVE_HANDLERS false
 #endif
 
+#if !(SANITIZER_AMDGPU || SANITIZER_NVPTX)
 static const int kMaxCallerPcs = 20;
 static __sanitizer::atomic_uintptr_t caller_pcs[kMaxCallerPcs];
 // Number of elements in caller_pcs. A special value of kMaxCallerPcs + 1 means
 // that "too many errors" has already been reported.
 static __sanitizer::atomic_uint32_t caller_pcs_sz;
+#endif
 
 static char *append_str(const char *s, char *buf, const char *end) {
   for (const char *p = s; (buf < end) && (*p != '\0'); ++p, ++buf)
@@ -75,7 +89,28 @@ static void format_msg(const char *kind, uintptr_t caller, char *buf,
 }
 
 static void format(const char *kind, uintptr_t caller) {
-#if SANITIZER_AMDGPU || SANITIZER_NVPTX || SANITIZER_SPIRV
+#if SANITIZER_AMDGPU || SANITIZER_NVPTX
+  (void)format_msg;
+  // Ship a structured report to the host, which rebases and symbolizes the pc;
+  // the block/thread/lane triple pins the offending work-item. The report fits
+  // one packet, so it is sent fire-and-forget in a single send.
+  __ubsan_gpu_report rep = {};
+  rep.pc = static_cast<unsigned long long>(caller);
+  rep.block[0] = __gpu_block_id(__GPU_X_DIM);
+  rep.block[1] = __gpu_block_id(__GPU_Y_DIM);
+  rep.block[2] = __gpu_block_id(__GPU_Z_DIM);
+  rep.thread[0] = __gpu_thread_id(__GPU_X_DIM);
+  rep.thread[1] = __gpu_thread_id(__GPU_Y_DIM);
+  rep.thread[2] = __gpu_thread_id(__GPU_Z_DIM);
+  rep.lane = __gpu_lane_id();
+  for (unsigned i = 0; i < UBSAN_GPU_KIND_MAX - 1 && kind[i]; ++i)
+    rep.kind[i] = kind[i];
+
+  rpc::Client::Port Port = __ubsan_rpc_client.open<UBSAN_GPU_REPORT_OPCODE>();
+  Port.send([&](rpc::Buffer *buf, uint32_t) {
+    __builtin_memcpy(buf->data, &rep, sizeof(rep));
+  });
+#elif SANITIZER_SPIRV
   (void)format_msg;
   message("ubsan: %s by %p\n", kind, reinterpret_cast<void *>(caller));
 #else
@@ -88,6 +123,11 @@ static void format(const char *kind, uintptr_t caller) {
 [[gnu::cold]] static void report_error(const char *kind, uintptr_t caller) {
   if (caller == 0)
     return;
+#if SANITIZER_AMDGPU || SANITIZER_NVPTX
+  // The host process coalesces duplicate reports.
+  format(kind, caller);
+  return;
+#else
   while (true) {
     unsigned sz = __sanitizer::atomic_load_relaxed(&caller_pcs_sz);
     if (sz > kMaxCallerPcs)
@@ -119,6 +159,7 @@ static void format(const char *kind, uintptr_t caller) {
 
     format(kind, caller);
   }
+#endif
 }
 
 SANITIZER_INTERFACE_WEAK_DEF(void, __ubsan_report_error, const char *kind,

--- a/compiler-rt/test/ubsan_minimal/TestCases/recover-dedup-limit.cpp
+++ b/compiler-rt/test/ubsan_minimal/TestCases/recover-dedup-limit.cpp
@@ -1,4 +1,5 @@
 // RUN: %clangxx_min_runtime -fsanitize=signed-integer-overflow -fsanitize-recover=all %s -o %t && %run %t 2>&1 | FileCheck %s
+// UNSUPPORTED: gpu
 
 #include <stdint.h>
 

--- a/compiler-rt/test/ubsan_minimal/lit.common.cfg.py
+++ b/compiler-rt/test/ubsan_minimal/lit.common.cfg.py
@@ -52,6 +52,9 @@ if config.target_os not in [
 if config.test_cfi:
     config.available_features.add("cfi")
 
+if config.target_arch in ("amdgcn", "nvptx", "spirv"):
+    config.available_features.add("gpu")
+
 # Don't target x86_64h if the test machine can't execute x86_64h binaries.
 if "-arch x86_64h" in target_cflags and "x86_64h" not in config.available_features:
     config.unsupported = True

--- a/offload/plugins-nextgen/CMakeLists.txt
+++ b/offload/plugins-nextgen/CMakeLists.txt
@@ -12,7 +12,7 @@ function(add_target_library target_name lib_name)
       AggressiveInstCombine Analysis BinaryFormat BitReader BitWriter CodeGen
       Core Extensions FrontendOffloading InstCombine Instrumentation IPO IRReader
       Linker MC Object Passes ProfileData Remarks ScalarOpts Support Target
-      TargetParser TransformUtils Vectorize)
+      TargetParser TransformUtils Vectorize DebugInfoDWARF Object)
   endif()
   llvm_update_compile_flags(${target_name})
   target_include_directories(${target_name} PUBLIC ${common_dir}/include

--- a/offload/plugins-nextgen/common/CMakeLists.txt
+++ b/offload/plugins-nextgen/common/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(PluginCommon OBJECT
   src/JIT.cpp
   src/RecordReplay.cpp
   src/RPC.cpp
+  src/Sanitizer.cpp
   src/OffloadError.cpp
   src/Utils/ELF.cpp
 )
@@ -52,6 +53,8 @@ target_include_directories(PluginCommon PUBLIC
   ${LIBOMPTARGET_LLVM_INCLUDE_DIRS}
   ${LIBOMPTARGET_BINARY_INCLUDE_DIR}
   ${LIBOMPTARGET_INCLUDE_DIR}
+  # For the shared GPU sanitizer report ABI header.
+  ${OFFLOAD_SOURCE_DIR}/../compiler-rt/include
 )
 
 set_target_properties(PluginCommon PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -41,6 +41,7 @@
 #include "omp-tools.h"
 #endif
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/Hashing.h"

--- a/offload/plugins-nextgen/common/include/RPC.h
+++ b/offload/plugins-nextgen/common/include/RPC.h
@@ -24,6 +24,7 @@
 #include <condition_variable>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <thread>
 
@@ -35,6 +36,10 @@ class GenericGlobalHandlerTy;
 class DeviceImageTy;
 } // namespace plugin
 
+/// Deduplication tables for GPU sanitizer diagnostics; defined in 'Sanitizer.h'
+/// and held by pointer so this header stays free of the sanitizer ABI include.
+struct SanitizerTables;
+
 /// A generic class implementing the interface between the RPC server provided
 /// by the 'libc' project and 'libomptarget'. If the RPC server is not available
 /// these routines will perform no action.
@@ -44,6 +49,9 @@ public:
 
   /// Initializes the handles to the number of devices we may need to service.
   RPCServerTy(plugin::GenericPluginTy &Plugin);
+
+  /// Defined out of line for the sanitizer tables.
+  ~RPCServerTy();
 
   /// Deinitialize the associated memory and resources.
   llvm::Error shutDown(plugin::GenericPluginTy &Plugin);
@@ -76,7 +84,13 @@ public:
   void setSleepFunction(std::function<void()> Sleep,
                         std::function<void()> Wake);
 
+  /// Sanitizer deduplication state with the same lifetime as the RPC interface.
+  SanitizerTables &getSanitizerTables() { return *Sanitizers; }
+
 private:
+  /// Deduplication tables for any sanitizer diagnostics this server services.
+  std::unique_ptr<SanitizerTables> Sanitizers;
+
   /// Array from this device's identifier to its attached devices.
   std::unique_ptr<void *[]> Buffers;
 

--- a/offload/plugins-nextgen/common/include/Sanitizer.h
+++ b/offload/plugins-nextgen/common/include/Sanitizer.h
@@ -1,0 +1,44 @@
+//===-- Sanitizer.h - Host-side GPU sanitizer reporting ---------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef OFFLOAD_PLUGINS_NEXTGEN_COMMON_SANITIZER_H
+#define OFFLOAD_PLUGINS_NEXTGEN_COMMON_SANITIZER_H
+
+#include "sanitizer/gpu_sanitizer.h"
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSet.h"
+
+#include <cstdint>
+#include <mutex>
+
+namespace llvm::omp::target {
+namespace plugin {
+struct GenericDeviceTy;
+} // namespace plugin
+
+/// Deduplication tables for GPU sanitizer diagnostics.
+struct SanitizerTables {
+  /// Records a minimal-runtime (UBSan) diagnostic, returning true the first
+  /// time this program counter and kind are seen.
+  bool isNewReport(uint64_t PC, StringRef Kind);
+
+private:
+  std::mutex Mtx;
+  StringSet<> Reports;
+};
+
+/// Symbolize and print one GPU UndefinedBehaviorSanitizer diagnostic against
+/// \p Device's loaded images, in a format reminiscent of the host sanitizers.
+/// \p Tables deduplicates repeated diagnostics.
+void reportGPUUBSan(plugin::GenericDeviceTy &Device, SanitizerTables &Tables,
+                    const __ubsan_gpu_report &Report);
+
+} // namespace llvm::omp::target
+
+#endif // OFFLOAD_PLUGINS_NEXTGEN_COMMON_SANITIZER_H

--- a/offload/plugins-nextgen/common/include/Utils/ELF.h
+++ b/offload/plugins-nextgen/common/include/Utils/ELF.h
@@ -13,8 +13,17 @@
 #ifndef LLVM_OPENMP_LIBOMPTARGET_PLUGINS_ELF_UTILS_H
 #define LLVM_OPENMP_LIBOMPTARGET_PLUGINS_ELF_UTILS_H
 
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Object/ELF.h"
 #include "llvm/Object/ELFObjectFile.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace llvm {
+class DWARFContext;
+} // namespace llvm
 
 namespace utils {
 namespace elf {
@@ -38,6 +47,30 @@ getSymbolAddress(const llvm::object::ELFSymbolRef &Symbol);
 /// executable file without a hash table.
 llvm::Expected<std::optional<llvm::object::ELFSymbolRef>>
 getSymbol(const llvm::object::ObjectFile &ELFObj, llvm::StringRef Name);
+
+/// A resolved source location for a single DWARF frame.
+struct SourceLocation {
+  std::string FunctionName;
+  std::string FileName;
+  uint32_t Line = 0;
+  uint32_t Column = 0;
+};
+
+/// Resolves the code address \p Addr against \p DICtx into its source frames.
+/// Returns an empty vector if no symbols are present.
+llvm::SmallVector<SourceLocation> symbolize(llvm::DWARFContext &DICtx,
+                                            uint64_t Addr);
+
+/// Returns the data symbol covering \p Addr in the ELF object, or an empty
+/// string if none is found.
+llvm::StringRef findDataSymbol(const llvm::object::ObjectFile &ELFObj,
+                               uint64_t Addr);
+
+/// Returns the function symbol covering \p Addr in the ELF object, or an empty
+/// string if none is found. Unlike DWARF this only needs the symbol table, so
+/// it still resolves when the image lacks line tables.
+llvm::StringRef findFunctionSymbol(const llvm::object::ObjectFile &ELFObj,
+                                   uint64_t Addr);
 
 } // namespace elf
 } // namespace utils

--- a/offload/plugins-nextgen/common/src/RPC.cpp
+++ b/offload/plugins-nextgen/common/src/RPC.cpp
@@ -12,6 +12,9 @@
 #include "Shared/RPCOpcodes.h"
 
 #include "PluginInterface.h"
+#include "Sanitizer.h"
+
+#include "sanitizer/gpu_sanitizer.h"
 
 #include "shared/rpc.h"
 #include "shared/rpc_opcodes.h"
@@ -60,6 +63,15 @@ rpc::RPCStatus handleOffloadOpcodes(plugin::GenericDeviceTy &Device,
     Port.send([&](rpc::Buffer *Buffer, uint32_t ID) {
       Buffer->data[0] = static_cast<uint64_t>(Results[ID]);
       delete[] reinterpret_cast<char *>(Args[ID]);
+    });
+    break;
+  }
+  case UBSAN_GPU_REPORT_OPCODE: {
+    static_assert(sizeof(__ubsan_gpu_report) <= sizeof(rpc::Buffer),
+                  "Report does not fit in a single packet");
+    Port.recv([&](rpc::Buffer *Buffer, uint32_t) {
+      reportGPUUBSan(Device, Device.getRPCServer()->getSanitizerTables(),
+                     *reinterpret_cast<__ubsan_gpu_report *>(Buffer->data));
     });
     break;
   }
@@ -180,12 +192,15 @@ void RPCServerTy::ServerThread::run() {
 }
 
 RPCServerTy::RPCServerTy(plugin::GenericPluginTy &Plugin)
-    : Buffers(std::make_unique<void *[]>(Plugin.getNumDevices())),
+    : Sanitizers(std::make_unique<SanitizerTables>()),
+      Buffers(std::make_unique<void *[]>(Plugin.getNumDevices())),
       Devices(std::make_unique<plugin::GenericDeviceTy *[]>(
           Plugin.getNumDevices())),
       Thread(new ServerThread(Buffers.get(), Devices.get(),
                               Plugin.getNumDevices(), BufferMutex, Callbacks)) {
 }
+
+RPCServerTy::~RPCServerTy() = default;
 
 llvm::Error RPCServerTy::startThread() {
   Thread->startThread();

--- a/offload/plugins-nextgen/common/src/Sanitizer.cpp
+++ b/offload/plugins-nextgen/common/src/Sanitizer.cpp
@@ -1,0 +1,183 @@
+//===-- Sanitizer.cpp - Host-side GPU sanitizer reporting -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Sanitizer.h"
+
+#include "PluginInterface.h"
+#include "Utils/ELF.h"
+
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/DebugInfo/DWARF/DWARFContext.h"
+#include "llvm/Object/ObjectFile.h"
+
+#include <cinttypes>
+#include <cstdio>
+#include <cstring>
+#include <mutex>
+#include <optional>
+#include <string>
+
+using namespace llvm;
+using namespace omp;
+using namespace target;
+
+namespace {
+
+/// We calculate the program counter relative to the RPC client symbol.
+constexpr StringRef RPCClientSymbol = "__llvm_rpc_client";
+
+/// Link-time ELF value of \p Name in \p Obj, if the image defines it.
+std::optional<uint64_t> getSymbolValue(const object::ObjectFile &Obj,
+                                       StringRef Name) {
+  Expected<std::optional<object::ELFSymbolRef>> SymOrErr =
+      utils::elf::getSymbol(Obj, Name);
+  if (!SymOrErr) {
+    consumeError(SymOrErr.takeError());
+    return std::nullopt;
+  }
+  if (!*SymOrErr)
+    return std::nullopt;
+  Expected<uint64_t> ValueOrErr = (*SymOrErr)->getValue();
+  if (!ValueOrErr) {
+    consumeError(ValueOrErr.takeError());
+    return std::nullopt;
+  }
+  return *ValueOrErr;
+}
+
+/// A loaded image selected to symbolize a report against, holding the data
+/// needed to rebase raw device addresses into image VAs.
+struct ResolvedImage {
+  std::unique_ptr<object::ObjectFile> Obj;
+  std::unique_ptr<DWARFContext> DICtx;
+  uint64_t ClientValue = 0;
+  uint64_t ClientDeviceAddr = 0;
+
+  explicit operator bool() const { return static_cast<bool>(Obj); }
+
+  /// Map a raw device address to its address inside the resolved image.
+  uint64_t rebase(uint64_t DeviceAddr) const {
+    return DeviceAddr - ClientDeviceAddr + ClientValue;
+  }
+};
+
+/// Find the loaded image that contains this program counter, using the RPC
+/// client symbol as a reference point. The relative offset of the symbol from
+/// the device and the original ELF image lets us identify the program counter.
+ResolvedImage selectImage(plugin::GenericDeviceTy &Device, uint64_t PC) {
+  plugin::GenericGlobalHandlerTy &Handler = Device.Plugin.getGlobalHandler();
+  ResolvedImage Result;
+  for (plugin::DeviceImageTy *Image : Device.LoadedImages) {
+    if (!Image)
+      continue;
+    Expected<std::unique_ptr<object::ObjectFile>> ObjOrErr =
+        object::ObjectFile::createELFObjectFile(Image->getMemoryBuffer());
+    if (!ObjOrErr) {
+      consumeError(ObjOrErr.takeError());
+      continue;
+    }
+    std::optional<uint64_t> CV = getSymbolValue(**ObjOrErr, RPCClientSymbol);
+    if (!CV)
+      continue;
+
+    plugin::GlobalTy ClientGlobal(RPCClientSymbol.str());
+    if (auto Err =
+            Handler.getGlobalMetadataFromDevice(Device, *Image, ClientGlobal)) {
+      consumeError(std::move(Err));
+      continue;
+    }
+    uint64_t Base = reinterpret_cast<uintptr_t>(ClientGlobal.getPtr());
+    uint64_t ImagePC = PC - Base + *CV;
+    // '__builtin_return_address' yields the return PC, step back into the call.
+    bool PCResolved = !utils::elf::findFunctionSymbol(
+                           **ObjOrErr, ImagePC ? ImagePC - 1 : ImagePC)
+                           .empty();
+    if (!Result.Obj || PCResolved) {
+      Result.ClientValue = *CV;
+      Result.ClientDeviceAddr = Base;
+      Result.DICtx = DWARFContext::create(**ObjOrErr);
+      Result.Obj = std::move(*ObjOrErr);
+    }
+    if (PCResolved)
+      break;
+  }
+  return Result;
+}
+
+} // namespace
+
+// Deduplicates reports on the same program counter and kind, so a whole grid
+// tripping one check yields a single diagnostic.
+bool llvm::omp::target::SanitizerTables::isNewReport(uint64_t PC,
+                                                     StringRef Kind) {
+  SmallString<64> Key(Kind);
+  Key += ':' + utohexstr(PC);
+  std::lock_guard<std::mutex> Guard(Mtx);
+  return Reports.insert(Key).second;
+}
+
+void llvm::omp::target::reportGPUUBSan(plugin::GenericDeviceTy &Device,
+                                       SanitizerTables &Tables,
+                                       const __ubsan_gpu_report &R) {
+  // The device sends a fixed-width, null-terminated kind.
+  size_t KindLen = strnlen(R.kind, UBSAN_GPU_KIND_MAX);
+  StringRef Kind(R.kind, KindLen);
+  if (Kind.empty())
+    return;
+
+  // Drop duplicates before the expensive ELF/DWARF parsing below.
+  if (!Tables.isNewReport(R.pc, Kind))
+    return;
+
+  ResolvedImage Image = selectImage(Device, R.pc);
+
+  uint64_t ImagePC = Image ? Image.rebase(R.pc) : R.pc;
+  uint64_t LookupPC = ImagePC ? ImagePC - 1 : ImagePC;
+
+  SmallVector<utils::elf::SourceLocation> Frames;
+  if (Image)
+    Frames = utils::elf::symbolize(*Image.DICtx, LookupPC);
+
+  // Without debug info there is nothing to symbolize, so fall back to the same
+  // minimal line the device runtime prints on the host.
+  if (Frames.empty()) {
+    fprintf(stderr, "ubsan: %s by 0x%" PRIx64 "\n", Kind.str().c_str(),
+            ImagePC);
+    return;
+  }
+
+  const utils::elf::SourceLocation &Top = Frames.front();
+  StringRef TopFunc = Top.FunctionName;
+  std::string Loc;
+  if (!Top.FileName.empty())
+    Loc =
+        (Top.FileName + ":" + Twine(Top.Line) + ":" + Twine(Top.Column)).str();
+
+  if (!Loc.empty())
+    fprintf(stderr, "%s: runtime error: %s\n", Loc.c_str(), Kind.str().c_str());
+  else
+    fprintf(stderr, "runtime error: %s\n", Kind.str().c_str());
+  fprintf(stderr,
+          "    on GPU thread: block (%u,%u,%u) thread (%u,%u,%u) lane %u\n",
+          R.block[0], R.block[1], R.block[2], R.thread[0], R.thread[1],
+          R.thread[2], R.lane);
+
+  for (uint32_t I = 0, N = static_cast<uint32_t>(Frames.size()); I < N; ++I) {
+    const utils::elf::SourceLocation &F = Frames[I];
+    fprintf(stderr, "    #%u 0x%" PRIx64 " in %s %s:%u:%u\n", I, ImagePC,
+            F.FunctionName.empty() ? "??" : F.FunctionName.c_str(),
+            F.FileName.empty() ? "??" : F.FileName.c_str(), F.Line, F.Column);
+  }
+
+  fprintf(stderr, "SUMMARY: UndefinedBehaviorSanitizer: %s%s%s%s%s\n",
+          Kind.str().c_str(), Loc.empty() ? "" : " ", Loc.c_str(),
+          TopFunc.empty() ? "" : " in ",
+          TopFunc.empty() ? "" : TopFunc.str().c_str());
+}

--- a/offload/plugins-nextgen/common/src/Utils/ELF.cpp
+++ b/offload/plugins-nextgen/common/src/Utils/ELF.cpp
@@ -13,6 +13,8 @@
 #include "Utils/ELF.h"
 
 #include "llvm/BinaryFormat/Magic.h"
+#include "llvm/DebugInfo/DIContext.h"
+#include "llvm/DebugInfo/DWARF/DWARFContext.h"
 #include "llvm/Object/Binary.h"
 #include "llvm/Object/ELFObjectFile.h"
 #include "llvm/Object/ELFTypes.h"
@@ -363,4 +365,56 @@ utils::elf::getSymbolAddress(const ELFSymbolRef &SymRef) {
   if (const ELF64BEObjectFile *ELFObj = dyn_cast<ELF64BEObjectFile>(Obj))
     return getSymbolAddressImpl(*ELFObj, SymRef);
   return createError("Only 64-bit ELF files are supported");
+}
+
+SmallVector<utils::elf::SourceLocation>
+utils::elf::symbolize(DWARFContext &DICtx, uint64_t Addr) {
+  SmallVector<SourceLocation> Locations;
+  DILineInfoSpecifier Spec(DILineInfoSpecifier::FileLineInfoKind::RawValue,
+                           DILineInfoSpecifier::FunctionNameKind::ShortName);
+  DIInliningInfo Info =
+      DICtx.getInliningInfoForAddress(object::SectionedAddress{Addr}, Spec);
+  Locations.reserve(Info.getNumberOfFrames());
+  for (uint32_t I = 0, N = Info.getNumberOfFrames(); I < N; ++I) {
+    const DILineInfo &Frame = Info.getFrame(I);
+    Locations.push_back({Frame.FunctionName, Frame.FileName,
+                         static_cast<uint32_t>(Frame.Line),
+                         static_cast<uint32_t>(Frame.Column)});
+  }
+  return Locations;
+}
+
+// Returns the name of the symbol of type \p Type whose [value, value + size)
+// range covers \p Addr, or an empty string if none is found.
+static StringRef findSymbolByAddress(const ObjectFile &ELFObj, uint64_t Addr,
+                                     uint8_t Type) {
+  for (const SymbolRef &Sym : ELFObj.symbols()) {
+    ELFSymbolRef ESym(Sym);
+    if (ESym.getELFType() != Type || ESym.getSize() == 0)
+      continue;
+    Expected<uint64_t> ValueOrErr = Sym.getValue();
+    if (!ValueOrErr) {
+      consumeError(ValueOrErr.takeError());
+      continue;
+    }
+    if (Addr < *ValueOrErr || Addr >= *ValueOrErr + ESym.getSize())
+      continue;
+    Expected<StringRef> NameOrErr = Sym.getName();
+    if (!NameOrErr) {
+      consumeError(NameOrErr.takeError());
+      continue;
+    }
+    if (!NameOrErr->empty())
+      return *NameOrErr;
+  }
+  return StringRef();
+}
+
+StringRef utils::elf::findDataSymbol(const ObjectFile &ELFObj, uint64_t Addr) {
+  return findSymbolByAddress(ELFObj, Addr, ELF::STT_OBJECT);
+}
+
+StringRef utils::elf::findFunctionSymbol(const ObjectFile &ELFObj,
+                                         uint64_t Addr) {
+  return findSymbolByAddress(ELFObj, Addr, ELF::STT_FUNC);
 }

--- a/offload/test/sanitizer/ubsan_shift.c
+++ b/offload/test/sanitizer/ubsan_shift.c
@@ -1,0 +1,24 @@
+// clang-format off
+// RUN: %libomptarget-compile-generic -g -Xarch_device -fsanitize=undefined -Xarch_device -fsanitize-minimal-runtime
+// RUN: %libomptarget-run-generic 2>&1 | %fcheck-generic --check-prefix=CHECK
+
+// REQUIRES: libc
+// REQUIRES: gpu
+
+#include <omp.h>
+
+int main(void) {
+#pragma omp target teams num_teams(1) thread_limit(2)
+#pragma omp parallel num_threads(2)
+  {
+    volatile int shift = 33;
+    volatile int x = 1;
+    x <<= shift; // shift exponent >= width: undefined behavior
+    (void)x;
+  }
+}
+
+// CHECK: {{.*}}ubsan_shift.c:[[#@LINE-9]]:{{[0-9]+}}: runtime error: shift-out-of-bounds
+// CHECK-NEXT: on GPU thread: block (0,0,0) thread ({{[0-9]+}},0,0) lane {{[0-9]+}}
+// CHECK-NEXT: #0 0x{{[0-9a-f]+}} in {{.*}}ubsan_shift.c:[[#@LINE-11]]:
+// CHECK: SUMMARY: UndefinedBehaviorSanitizer: shift-out-of-bounds {{.*}}ubsan_shift.c:[[#@LINE-12]]:


### PR DESCRIPTION
Summary:
Currently, the GPU uses the same reporting the minimal runtime uses. The
minimal runtime is the correct place for these to live, however the GPU
should be able to get more informative error messages. This PR pulls in
the full RPC interface to send a custom sanitizer message. We ship this
over the wire to then be symbolized by the host runtime.

The symbilization here is intended to be generic and can be re-used for
other planned sanitizers in the runtime. The main change here is
including a compiler-rt include directory, but this should be legal as
we do not support partial checkouts for offload builds.

This lets us get more precise information about where the incident
occurred. In the future we may look into optinoally providing the values
like in full UBSan.

The output looks like this now, and it uses many fewer registers without
the device-side deduplication.
```c
int shift(int x, int val) { return x << val; }                 

int main(void) {
#pragma omp target teams num_teams(1) thread_limit(1) ompx_bare
  {
    volatile int val = 33;
    volatile int x = 1;
    x = shift(x, val);
    (void)x;
  }
}

```
```console
clang -fopenmp  ubsan_test.c --offload-arch=gfx1030 -Xarch_device -fsanitize=undefined -Xarch_device -fsanitize-minimal-runtime -O3  -gline-tables-only && ./a.out 
ubsan_test.c:15:0: Function Name: __omp_offloading_10302_bc60012_main_l15
ubsan_test.c:15:0:     TotalSGPRs: 35
ubsan_test.c:15:0:     VGPRs: 34
    on GPU thread: block (0,0,0) thread (0,0,0) lane 0
    #0 0x54a4 in shift ubsan_test.c:1:38
    #1 0x54a4 in __omp_offloading_10302_bc60e24_main_l4_omp_outlined ubsan_test.c:8:9
    #2 0x54a4 in __omp_offloading_10302_bc60e24_main_l4 ubsan_test.c:4:1
SUMMARY: UndefinedBehaviorSanitizer: shift-out-of-bounds ubsan_test.c:1:38 in shift
```