### PR TITLE
[Flang] Standardize coarray TODO() diagnostic messages

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -6618,7 +6618,9 @@ private:
             !Fortran::semantics::IsAllocatable(sym) &&
             Fortran::semantics::IsSaved(sym)) {
           mlir::Location loc = toLocation();
-          TODO(loc, "non-ALLOCATABLE SAVE Coarray outside the main program.");
+          TODO(
+              loc,
+              "coarray: non-ALLOCATABLE SAVE coarray outside the main program");
         }
       }
       Fortran::lower::defineModuleVariable(*this, var);

--- a/flang/lib/Lower/ConvertVariable.cpp
+++ b/flang/lib/Lower/ConvertVariable.cpp
@@ -703,8 +703,8 @@ static void instantiateGlobal(Fortran::lower::AbstractConverter &converter,
 
   if (Fortran::evaluate::IsCoarray(sym))
     if (hasFinalization(sym) || hasAllocatableDirectComponent(sym))
-      TODO(loc, "Coarray with an allocatable direct component and/or requiring "
-                "finalization.");
+      TODO(loc, "coarray: coarray with an allocatable direct component and/or "
+                "requiring finalization");
 
   if (var.isModuleOrSubmoduleVariable()) {
     // A non-intrinsic module global is defined when lowering the module.
@@ -2337,7 +2337,7 @@ void Fortran::lower::mapSymbolAttributes(
     if (Fortran::evaluate::IsCoarray(sym))
       // Operation in MIF dialect to create an alias of the coarray not
       // yet supported (by using the procedure provided by PRIF).
-      TODO(loc, "coarray dummy argument not yet supported.");
+      TODO(loc, "coarray: dummy argument not yet supported");
 
     mlir::Value dummyArg = symMap.lookupSymbol(sym).getAddr();
     if (lowerToBoxValue(sym, dummyArg, converter)) {
@@ -2638,7 +2638,8 @@ void Fortran::lower::mapSymbolAttributes(
            "must be a non-ALLOCATABLE coarray");
     if (Fortran::semantics::IsSaved(sym) &&
         sym.owner().kind() != Fortran::semantics::Scope::Kind::MainProgram)
-      TODO(loc, "non-ALLOCATABLE SAVE Coarray outside the main program.");
+      TODO(loc,
+           "coarray: non-ALLOCATABLE SAVE coarray outside the main program");
     ;
     Fortran::lower::genAllocateCoarray(converter, loc, sym, addr);
     ::genDeclareSymbol(converter, symMap, sym, addr, len, extents, lbounds,

--- a/flang/lib/Lower/MultiImageFortran.cpp
+++ b/flang/lib/Lower/MultiImageFortran.cpp
@@ -158,7 +158,7 @@ Fortran::lower::genChangeTeamStmt(Fortran::lower::AbstractConverter &converter,
   const std::list<Fortran::parser::CoarrayAssociation> &coarrayAssocList =
       std::get<std::list<Fortran::parser::CoarrayAssociation>>(stmt.t);
   if (coarrayAssocList.size())
-    TODO(loc, "Coarrays provided in the association list.");
+    TODO(loc, "coarray: coarrays provided in the association list");
 
   // Handle TEAM-VALUE
   const auto *teamExpr =
@@ -458,10 +458,10 @@ mlir::Value Fortran::lower::genAllocateCoarray(
 fir::ExtendedValue Fortran::lower::CoarrayExprHelper::genAddr(
     const Fortran::evaluate::CoarrayRef &expr) {
   (void)symMap;
-  TODO(converter.getCurrentLocation(), "co-array address");
+  TODO(converter.getCurrentLocation(), "coarray: coarray address");
 }
 
 fir::ExtendedValue Fortran::lower::CoarrayExprHelper::genValue(
     const Fortran::evaluate::CoarrayRef &expr) {
-  TODO(converter.getCurrentLocation(), "co-array value");
+  TODO(converter.getCurrentLocation(), "coarray: coarray value");
 }

--- a/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
+++ b/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
@@ -8300,7 +8300,7 @@ IntrinsicLibrary::genThisImage(mlir::Type resultType,
   mlir::Value team = fir::getBase(args[args.size() - 1]);
 
   if (!coarrayIsAbsent)
-    TODO(loc, "this_image with coarray argument.");
+    TODO(loc, "coarray: this_image with coarray argument");
   mlir::Value res = mif::ThisImageOp::create(builder, loc, team);
   return builder.createConvert(loc, resultType, res);
 }

--- a/flang/lib/Optimizer/Transforms/MIFOpConversion.cpp
+++ b/flang/lib/Optimizer/Transforms/MIFOpConversion.cpp
@@ -430,7 +430,7 @@ struct MIFThisImageOpConversion
     mlir::Location loc = op.getLoc();
 
     if (op.getCoarray())
-      TODO(loc, "mif.this_image op with coarray argument.");
+      TODO(loc, "coarray: mif.this_image op with coarray argument");
     else {
       mlir::Type i32Ty = builder.getI32Type();
       mlir::Type boxTy = fir::BoxType::get(rewriter.getNoneType());

--- a/flang/test/Lower/MIF/coarray_allocation3.f90
+++ b/flang/test/Lower/MIF/coarray_allocation3.f90
@@ -1,6 +1,6 @@
 ! RUN: not %flang_fc1 -emit-hlfir -fcoarray %s -o - 2>&1 | FileCheck %s
 
-!CHECK: not yet implemented: Coarray with an allocatable direct component and/or requiring finalization.
+!CHECK: not yet implemented: coarray: coarray with an allocatable direct component and/or requiring finalization
 
 module m_test
     implicit none

--- a/flang/test/Lower/MIF/coarray_allocation4.f90
+++ b/flang/test/Lower/MIF/coarray_allocation4.f90
@@ -1,6 +1,6 @@
 ! RUN: not %flang_fc1 -emit-hlfir -fcoarray %s -o - 2>&1 | FileCheck %s
 
-!CHECK: not yet implemented: non-ALLOCATABLE SAVE Coarray outside the main program.
+!CHECK: not yet implemented: coarray: non-ALLOCATABLE SAVE coarray outside the main program
 
 subroutine test_coarray_save()
     implicit none

--- a/flang/test/Lower/MIF/coarray_allocation5.f90
+++ b/flang/test/Lower/MIF/coarray_allocation5.f90
@@ -1,6 +1,6 @@
 ! RUN: not %flang_fc1 -emit-hlfir -fcoarray %s -o - 2>&1 | FileCheck %s
 
-!CHECK: not yet implemented: non-ALLOCATABLE SAVE Coarray outside the main program.
+!CHECK: not yet implemented: coarray: non-ALLOCATABLE SAVE coarray outside the main program
 
 module m_coarray_test
     implicit none


### PR DESCRIPTION
All coarray-related TODO() strings now start with "coarray:" and no longer end with a trailing period, matching the existing convention used elsewhere in lowering and MIF code. Update the matching lit tests.

Assisted-by: AI