### PR TITLE
[NFC] LowerCommentStringPass: remove unused #include

### DIFF
--- a/llvm/lib/Transforms/Utils/LowerCommentStringPass.cpp
+++ b/llvm/lib/Transforms/Utils/LowerCommentStringPass.cpp
@@ -53,7 +53,6 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Type.h"
 #include "llvm/IR/Value.h"
-#include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/TargetParser/Triple.h"


### PR DESCRIPTION
This pass was added in a64928f267f3aeeb3571bfc7de92c432126d74e9 but does not actually use PassBuilder