### PR TITLE
[orc-rt] Fix assertion, add fail-to-connect unit test.

### DIFF
--- a/orc-rt/lib/executor/Session.cpp
+++ b/orc-rt/lib/executor/Session.cpp
@@ -83,7 +83,7 @@ void Session::attach(std::shared_ptr<ControllerAccess> CA, BootstrapInfo BI) {
 
   {
     std::scoped_lock<std::mutex> Lock(M);
-    assert(TargetState >= State::Attached);
+    assert(TargetState >= State::Attached || CurrentState >= State::Detached);
 
     // There are three possibilities that we have to deal with here:
     // 1. Connection succeeded and we're done.
@@ -93,8 +93,8 @@ void Session::attach(std::shared_ptr<ControllerAccess> CA, BootstrapInfo BI) {
     //
     // 2. Connect failed.
     //
-    //    In this case connect must have called handleDisconnect, which should
-    //    have initiated the detach. We just need to bail out.
+    //    In this case connect must have called notifyDisconnected, which
+    //    should have initiated the detach. We just need to bail out.
     //
     // 3. Connection succeeded but a detach or shutdown was requested
     //    concurrently. In this case we need to start the detach process.
@@ -108,7 +108,7 @@ void Session::attach(std::shared_ptr<ControllerAccess> CA, BootstrapInfo BI) {
     }
 
     // The target state is Detached or higher. Check the current state. If it's
-    // also Detached or higher then handleDisconnect must already have been
+    // also Detached or higher then notifyDisconnected must already have been
     // called (in turn calling proceedToDetach, which updated the current
     // state). In this case we're in option (2) and we just need to bail out.
     if (CurrentState >= State::Detached)

--- a/orc-rt/unittests/SessionTest.cpp
+++ b/orc-rt/unittests/SessionTest.cpp
@@ -117,7 +117,7 @@ private:
 
 class MockControllerAccess : public Session::ControllerAccess {
 public:
-  using OnConnectFn = move_only_function<void(BootstrapInfo &BI)>;
+  using OnConnectFn = move_only_function<Error(BootstrapInfo &BI)>;
 
   MockControllerAccess(Session &SS) : Session::ControllerAccess(SS), SS(SS) {}
 
@@ -126,8 +126,12 @@ public:
   }
 
   void connect(BootstrapInfo BI) override {
-    if (OnConnect)
-      OnConnect(BI);
+    if (OnConnect) {
+      if (auto Err = OnConnect(BI)) {
+        reportError(std::move(Err));
+        notifyDisconnected();
+      }
+    }
   }
 
   void disconnect() override {
@@ -786,6 +790,23 @@ TEST(ControllerAccessTest, CallFromController) {
   EXPECT_EQ(Result, 42);
 }
 
+TEST(ControllerAccessTest, FailConnect) {
+  // Simulate failure to connect.
+  bool GotError = false;
+  std::string ErrMsg = "failed to connect";
+  Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
+            [&](Error Err) {
+              GotError = true;
+              EXPECT_EQ(toString(std::move(Err)), ErrMsg);
+            });
+  BootstrapInfo BI(S);
+  auto CA = std::make_shared<MockControllerAccess>(S);
+  CA->setOnConnect(
+      [&](BootstrapInfo &BI) { return make_error<StringError>(ErrMsg); });
+  S.attach(std::move(CA), std::move(BI));
+  ASSERT_TRUE(GotError);
+}
+
 TEST(ControllerAccessTest, BootstrapInfoPassedToConnect) {
   Session S(mockExecutorProcessInfo(), std::make_unique<NoDispatcher>(),
             noErrors);
@@ -809,6 +830,7 @@ TEST(ControllerAccessTest, BootstrapInfoPassedToConnect) {
     EXPECT_EQ(BI.symbols().at(SymName), static_cast<const void *>(&Sym));
     EXPECT_EQ(BI.values().at(SecretKey), SecretValue);
     OnConnectRan = true;
+    return Error::success();
   });
   S.attach(CA, std::move(BI));
 


### PR DESCRIPTION
If a ControllerAccess object's connect method calls notifyDisconnected then by the time we return to Connect we may have completed the detach, in which case TargetState will be None, and CurrentState will be >= Detached. This case was not covered by the assert after the return from connect, leading to assertions when connect failed.

This commit relaxes the assertion to include the case above, and adds a unit test to cover it.