### PR TITLE
[SCEV] Invalidate extractvalue users of non-SCEVable LCSSA PHIs

### DIFF
--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -8883,10 +8883,11 @@ void ScalarEvolution::forgetLcssaPhiWithNewPredecessor(Loop *L, PHINode *V) {
   // If V has a non-SCEV-able type (e.g. {i64, i1} from a with.overflow
   // intrinsic), its users (e.g. extractvalue) may have stale SCEV
   // expressions referencing loop-internal values.
-  if (!isSCEVable(V->getType()))
+  if (!isSCEVable(V->getType()) && any_of(V->incoming_values(), [](Value *Inc) {
+        return isa<WithOverflowInst>(Inc);
+      }))
     for (User *U : V->users())
       InvalidateValue(U);
-
   // Also perform the normal invalidation.
   forgetValue(V);
 }

--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -8844,38 +8844,48 @@ void ScalarEvolution::forgetValue(Value *V) {
 }
 
 void ScalarEvolution::forgetLcssaPhiWithNewPredecessor(Loop *L, PHINode *V) {
-  if (!isSCEVable(V->getType()))
-    return;
-
   // If SCEV looked through a trivial LCSSA phi node, we might have SCEV's
   // directly using a SCEVUnknown/SCEVAddRec defined in the loop. After an
   // extra predecessor is added, this is no longer valid. Find all Unknowns and
   // AddRecs defined in the loop and invalidate any SCEV's making use of them.
-  if (const SCEV *S = getExistingSCEV(V)) {
-    struct InvalidationRootCollector {
-      Loop *L;
-      SmallVector<SCEVUse, 8> Roots;
+  auto InvalidateValue = [&](Value *Val) {
+    if (!isSCEVable(Val->getType()))
+      return;
+    if (const SCEV *S = getExistingSCEV(Val)) {
+      struct InvalidationRootCollector {
+        Loop *L;
+        SmallVector<SCEVUse, 8> Roots;
 
-      InvalidationRootCollector(Loop *L) : L(L) {}
+        InvalidationRootCollector(Loop *L) : L(L) {}
 
-      bool follow(const SCEV *S) {
-        if (auto *SU = dyn_cast<SCEVUnknown>(S)) {
-          if (auto *I = dyn_cast<Instruction>(SU->getValue()))
-            if (L->contains(I))
+        bool follow(const SCEV *S) {
+          if (auto *SU = dyn_cast<SCEVUnknown>(S)) {
+            if (auto *I = dyn_cast<Instruction>(SU->getValue()))
+              if (L->contains(I))
+                Roots.push_back(S);
+          } else if (auto *AddRec = dyn_cast<SCEVAddRecExpr>(S)) {
+            if (L->contains(AddRec->getLoop()))
               Roots.push_back(S);
-        } else if (auto *AddRec = dyn_cast<SCEVAddRecExpr>(S)) {
-          if (L->contains(AddRec->getLoop()))
-            Roots.push_back(S);
+          }
+          return true;
         }
-        return true;
-      }
-      bool isDone() const { return false; }
-    };
+        bool isDone() const { return false; }
+      };
 
-    InvalidationRootCollector C(L);
-    visitAll(S, C);
-    forgetMemoizedResults(C.Roots);
-  }
+      InvalidationRootCollector C(L);
+      visitAll(S, C);
+      forgetMemoizedResults(C.Roots);
+    }
+  };
+
+  InvalidateValue(V);
+
+  // If V has a non-SCEV-able type (e.g. {i64, i1} from a with.overflow
+  // intrinsic), its users (e.g. extractvalue) may have stale SCEV
+  // expressions referencing loop-internal values.
+  if (!isSCEVable(V->getType()))
+    for (User *U : V->users())
+      InvalidateValue(U);
 
   // Also perform the normal invalidation.
   forgetValue(V);

--- a/llvm/test/Transforms/LoopUnroll/peel-loop-scev-invalidate-lcssa.ll
+++ b/llvm/test/Transforms/LoopUnroll/peel-loop-scev-invalidate-lcssa.ll
@@ -1,0 +1,30 @@
+; RUN: opt < %s -S -passes='print<scalar-evolution>,loop-unroll<O3>' 2>/dev/null | FileCheck %s --check-prefix=CHECK-LCSSA
+
+; Test that forgetLcssaPhiWithNewPredecessor correctly handles LCSSA PHIs with
+; non-SCEV-able struct types from with.overflow intrinsics. Previously the
+; function bailed early on struct-typed PHIs without invalidating their
+; extractvalue users, causing a stale SCEV cache entry and assertion failure
+; in getAddRecExpr.
+define void @lcssa_phi_uadd_with_overflow(ptr %p) {
+; CHECK-LCSSA-LABEL: define void @lcssa_phi_uadd_with_overflow
+entry:
+  br label %lbl_entry
+
+lbl_entry:
+  %0 = phi i64 [ 0, %lbl_entry ], [ 1, %entry ]
+  %1 = load i64, ptr %p, align 8
+  %2 = call { i64, i1 } @llvm.uadd.with.overflow.i64(i64 0, i64 %1)
+  br i1 true, label %lbl_entry, label %if.end
+
+if.end:
+  %3 = extractvalue { i64, i1 } %2, 0
+  br label %lbl_br5.peel
+
+lbl_br5.peel:
+  %4 = phi i8 [ 1, %lbl_br5.peel ], [ 0, %if.end ]
+  %ov11.1.peel = phi i64 [ %sub.peel, %lbl_br5.peel ], [ %3, %if.end ]
+  %sub.peel = add i64 %ov11.1.peel, 1
+  br label %lbl_br5.peel
+}
+
+declare { i64, i1 } @llvm.uadd.with.overflow.i64(i64, i64)

--- a/llvm/test/Transforms/LoopUnroll/peel-loop-scev-invalidate-with-overflow-inst.ll
+++ b/llvm/test/Transforms/LoopUnroll/peel-loop-scev-invalidate-with-overflow-inst.ll
@@ -69,3 +69,35 @@ bb7:                                              ; preds = %bb5
 bb9:                                              ; preds = %bb5
   ret void
 }
+
+
+; RUN: opt < %s -S -passes='print<scalar-evolution>,loop-unroll<O3>' 2>/dev/null | FileCheck %s --check-prefix=CHECK-LCSSA
+
+; Test that forgetLcssaPhiWithNewPredecessor correctly handles LCSSA PHIs with
+; non-SCEV-able struct types from with.overflow intrinsics. Previously the
+; function bailed early on struct-typed PHIs without invalidating their
+; extractvalue users, causing a stale SCEV cache entry and assertion failure
+; in getAddRecExpr.
+define void @lcssa_phi_uadd_with_overflow() {
+; CHECK-LCSSA-LABEL: define void @lcssa_phi_uadd_with_overflow
+entry:
+  br label %lbl_entry
+
+lbl_entry:
+  %0 = phi i64 [ 0, %lbl_entry ], [ 1, %entry ]
+  %1 = load i64, ptr null, align 8
+  %2 = call { i64, i1 } @llvm.uadd.with.overflow.i64(i64 0, i64 %1)
+  br i1 true, label %lbl_entry, label %if.end
+
+if.end:
+  %3 = extractvalue { i64, i1 } %2, 0
+  br label %lbl_br5.peel
+
+lbl_br5.peel:
+  %4 = phi i8 [ 1, %lbl_br5.peel ], [ 0, %if.end ]
+  %ov11.1.peel = phi i64 [ %sub.peel, %lbl_br5.peel ], [ %3, %if.end ]
+  %sub.peel = add i64 %ov11.1.peel, 1
+  br label %lbl_br5.peel
+}
+
+declare { i64, i1 } @llvm.uadd.with.overflow.i64(i64, i64)

--- a/llvm/test/Transforms/LoopUnroll/peel-loop-scev-invalidate-with-overflow-inst.ll
+++ b/llvm/test/Transforms/LoopUnroll/peel-loop-scev-invalidate-with-overflow-inst.ll
@@ -69,35 +69,3 @@ bb7:                                              ; preds = %bb5
 bb9:                                              ; preds = %bb5
   ret void
 }
-
-
-; RUN: opt < %s -S -passes='print<scalar-evolution>,loop-unroll<O3>' 2>/dev/null | FileCheck %s --check-prefix=CHECK-LCSSA
-
-; Test that forgetLcssaPhiWithNewPredecessor correctly handles LCSSA PHIs with
-; non-SCEV-able struct types from with.overflow intrinsics. Previously the
-; function bailed early on struct-typed PHIs without invalidating their
-; extractvalue users, causing a stale SCEV cache entry and assertion failure
-; in getAddRecExpr.
-define void @lcssa_phi_uadd_with_overflow() {
-; CHECK-LCSSA-LABEL: define void @lcssa_phi_uadd_with_overflow
-entry:
-  br label %lbl_entry
-
-lbl_entry:
-  %0 = phi i64 [ 0, %lbl_entry ], [ 1, %entry ]
-  %1 = load i64, ptr null, align 8
-  %2 = call { i64, i1 } @llvm.uadd.with.overflow.i64(i64 0, i64 %1)
-  br i1 true, label %lbl_entry, label %if.end
-
-if.end:
-  %3 = extractvalue { i64, i1 } %2, 0
-  br label %lbl_br5.peel
-
-lbl_br5.peel:
-  %4 = phi i8 [ 1, %lbl_br5.peel ], [ 0, %if.end ]
-  %ov11.1.peel = phi i64 [ %sub.peel, %lbl_br5.peel ], [ %3, %if.end ]
-  %sub.peel = add i64 %ov11.1.peel, 1
-  br label %lbl_br5.peel
-}
-
-declare { i64, i1 } @llvm.uadd.with.overflow.i64(i64, i64)


### PR DESCRIPTION
Fixes : #200858 

forgetLcssaPhiWithNewPredecessor bailed early on struct-typed PHIs (e.g. {i64, i1} from uadd.with.overflow) without invalidating their extractvalue users, leaving stale SCEV cache entries that caused an assertion failure in getAddRecExpr after loop unrolling.

Fix by also visiting direct users of the PHI when its type is not SCEV-able.